### PR TITLE
feat(serve): ACP/REST parity — 29 new _qwen/* methods + production hardening

### DIFF
--- a/packages/cli/src/serve/acpHttp/dispatch.ts
+++ b/packages/cli/src/serve/acpHttp/dispatch.ts
@@ -1196,17 +1196,17 @@ export class AcpDispatcher {
         }
 
         case `${QWEN_METHOD_NS}file/read`: {
+          const p = String(params['path'] ?? '');
+          if (!p) {
+            if (id !== undefined)
+              conn.sendConn(error(id, RPC.INVALID_PARAMS, '`path` required'));
+            return;
+          }
           if (!this.fsFactory) {
             if (id !== undefined)
               conn.sendConn(
                 error(id, RPC.INTERNAL_ERROR, 'File system not configured'),
               );
-            return;
-          }
-          const p = String(params['path'] ?? '');
-          if (!p) {
-            if (id !== undefined)
-              conn.sendConn(error(id, RPC.INVALID_PARAMS, '`path` required'));
             return;
           }
           const fs = this.fsFactory.forRequest({
@@ -1320,18 +1320,18 @@ export class AcpDispatcher {
         }
 
         case `${QWEN_METHOD_NS}file/glob`: {
-          if (!this.fsFactory) {
-            if (id !== undefined)
-              conn.sendConn(
-                error(id, RPC.INTERNAL_ERROR, 'File system not configured'),
-              );
-            return;
-          }
           const pattern = String(params['pattern'] ?? '');
           if (!pattern) {
             if (id !== undefined)
               conn.sendConn(
                 error(id, RPC.INVALID_PARAMS, '`pattern` required'),
+              );
+            return;
+          }
+          if (!this.fsFactory) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INTERNAL_ERROR, 'File system not configured'),
               );
             return;
           }
@@ -1360,13 +1360,6 @@ export class AcpDispatcher {
         }
 
         case `${QWEN_METHOD_NS}file/write`: {
-          if (!this.fsFactory) {
-            if (id !== undefined)
-              conn.sendConn(
-                error(id, RPC.INTERNAL_ERROR, 'File system not configured'),
-              );
-            return;
-          }
           const p = String(params['path'] ?? '');
           if (!p) {
             if (id !== undefined)
@@ -1377,6 +1370,13 @@ export class AcpDispatcher {
             if (id !== undefined)
               conn.sendConn(
                 error(id, RPC.INVALID_PARAMS, '`content` must be string'),
+              );
+            return;
+          }
+          if (!this.fsFactory) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INTERNAL_ERROR, 'File system not configured'),
               );
             return;
           }
@@ -1401,13 +1401,6 @@ export class AcpDispatcher {
         }
 
         case `${QWEN_METHOD_NS}file/edit`: {
-          if (!this.fsFactory) {
-            if (id !== undefined)
-              conn.sendConn(
-                error(id, RPC.INTERNAL_ERROR, 'File system not configured'),
-              );
-            return;
-          }
           const p = String(params['path'] ?? '');
           if (!p) {
             if (id !== undefined)
@@ -1425,6 +1418,13 @@ export class AcpDispatcher {
                   RPC.INVALID_PARAMS,
                   '`oldText` and `newText` must be strings',
                 ),
+              );
+            return;
+          }
+          if (!this.fsFactory) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INTERNAL_ERROR, 'File system not configured'),
               );
             return;
           }

--- a/packages/cli/src/serve/acpHttp/dispatch.ts
+++ b/packages/cli/src/serve/acpHttp/dispatch.ts
@@ -5,11 +5,36 @@
  */
 
 import path from 'node:path';
-import { APPROVAL_MODES, type ApprovalMode } from '@qwen-code/qwen-code-core';
+import {
+  APPROVAL_MODES,
+  type ApprovalMode,
+  BTW_MAX_INPUT_LENGTH,
+  SessionService,
+  BuiltinAgentRegistry,
+  SubagentError,
+  WorkspaceMemoryFileTooLargeError,
+  WorkspaceMemoryWriteTimeoutError,
+  writeWorkspaceContextFile,
+  type SubagentLevel,
+} from '@qwen-code/qwen-code-core';
+import { FsError } from '../fs/errors.js';
+import {
+  TooManyActiveDeviceFlowsError,
+  UnsupportedDeviceFlowProviderError,
+  UpstreamDeviceFlowError,
+} from '../auth/deviceFlow.js';
 import type { HttpAcpBridge } from '@qwen-code/acp-bridge/bridgeTypes';
 import type { BridgeEvent } from '@qwen-code/acp-bridge/eventBus';
 import { writeStderrLine } from '../../utils/stdioHelpers.js';
 import { MAX_WORKSPACE_PATH_LENGTH } from '../fs/paths.js';
+import type { WorkspaceFileSystemFactory } from '../fs/index.js';
+import type { DeviceFlowRegistry } from '../auth/deviceFlow.js';
+import { collectWorkspaceMemoryStatus } from '../workspaceMemory.js';
+import {
+  createDaemonSubagentManager,
+  toSummary as agentToSummary,
+  toDetail as agentToDetail,
+} from '../workspaceAgents.js';
 import type {
   DaemonWorkspaceService,
   WorkspaceRequestContext,
@@ -51,6 +76,41 @@ const QWEN_VENDOR_METHODS: readonly string[] = [
   `${QWEN_METHOD_NS}workspace/init`,
   `${QWEN_METHOD_NS}workspace/set_tool_enabled`,
   `${QWEN_METHOD_NS}workspace/restart_mcp_server`,
+  // Wave 1: session extensions
+  `${QWEN_METHOD_NS}session/recap`,
+  `${QWEN_METHOD_NS}session/btw`,
+  `${QWEN_METHOD_NS}session/shell`,
+  `${QWEN_METHOD_NS}session/detach`,
+  `${QWEN_METHOD_NS}session/context_usage`,
+  `${QWEN_METHOD_NS}session/tasks`,
+  // Wave 1: memory
+  `${QWEN_METHOD_NS}workspace/memory`,
+  `${QWEN_METHOD_NS}workspace/memory/write`,
+  // Wave 1: files
+  `${QWEN_METHOD_NS}file/read`,
+  `${QWEN_METHOD_NS}file/read_bytes`,
+  `${QWEN_METHOD_NS}file/stat`,
+  `${QWEN_METHOD_NS}file/list`,
+  `${QWEN_METHOD_NS}file/glob`,
+  `${QWEN_METHOD_NS}file/write`,
+  `${QWEN_METHOD_NS}file/edit`,
+  // Wave 1: auth
+  `${QWEN_METHOD_NS}workspace/auth/status`,
+  `${QWEN_METHOD_NS}workspace/auth/device_flow/start`,
+  `${QWEN_METHOD_NS}workspace/auth/device_flow/get`,
+  `${QWEN_METHOD_NS}workspace/auth/device_flow/cancel`,
+  // Wave 1: remaining workspace
+  `${QWEN_METHOD_NS}workspace/tools`,
+  `${QWEN_METHOD_NS}workspace/mcp/tools`,
+  `${QWEN_METHOD_NS}workspace/mcp/servers/add`,
+  `${QWEN_METHOD_NS}workspace/mcp/servers/remove`,
+  `${QWEN_METHOD_NS}sessions/delete`,
+  // Wave 2: agents
+  `${QWEN_METHOD_NS}workspace/agents/list`,
+  `${QWEN_METHOD_NS}workspace/agents/get`,
+  `${QWEN_METHOD_NS}workspace/agents/create`,
+  `${QWEN_METHOD_NS}workspace/agents/update`,
+  `${QWEN_METHOD_NS}workspace/agents/delete`,
 ];
 
 /**
@@ -133,9 +193,58 @@ function validatePrompt(params: Record<string, unknown>): void {
  * the operator-facing message is not a cross-tenant leak), and anything
  * unrecognized collapses to a generic INTERNAL_ERROR string.
  */
-function toRpcError(err: unknown): { code: number; message: string } {
+function toRpcError(err: unknown): {
+  code: number;
+  message: string;
+  data?: Record<string, unknown>;
+} {
   if (err instanceof AcpParamError) {
     return { code: RPC.INVALID_PARAMS, message: err.message };
+  }
+  if (err instanceof SubagentError) {
+    return { code: RPC.INVALID_PARAMS, message: err.message };
+  }
+  if (err instanceof FsError) {
+    return {
+      code: RPC.INVALID_PARAMS,
+      message: err.message,
+      data: { errorKind: err.kind, hint: err.hint },
+    };
+  }
+  if (err instanceof WorkspaceMemoryFileTooLargeError) {
+    return {
+      code: RPC.INVALID_PARAMS,
+      message: err.message,
+      data: { errorKind: 'memory_file_too_large' },
+    };
+  }
+  if (err instanceof WorkspaceMemoryWriteTimeoutError) {
+    return {
+      code: RPC.INTERNAL_ERROR,
+      message: err.message,
+      data: { errorKind: 'memory_write_timeout' },
+    };
+  }
+  if (err instanceof TooManyActiveDeviceFlowsError) {
+    return {
+      code: RPC.INTERNAL_ERROR,
+      message: err.message,
+      data: { errorKind: 'too_many_active_flows' },
+    };
+  }
+  if (err instanceof UnsupportedDeviceFlowProviderError) {
+    return {
+      code: RPC.INVALID_PARAMS,
+      message: err.message,
+      data: { errorKind: 'unsupported_provider' },
+    };
+  }
+  if (err instanceof UpstreamDeviceFlowError) {
+    return {
+      code: RPC.INTERNAL_ERROR,
+      message: err.message,
+      data: { errorKind: 'upstream_error' },
+    };
   }
   const name = err instanceof Error ? err.name : '';
   switch (name) {
@@ -163,11 +272,17 @@ export const ACP_PROTOCOL_VERSION = 1;
  * session stream (see the design doc §4 translation table).
  */
 export class AcpDispatcher {
+  private readonly agentManager;
+
   constructor(
     private readonly bridge: HttpAcpBridge,
     private readonly boundWorkspace: string,
     private readonly workspace: DaemonWorkspaceService,
-  ) {}
+    private readonly fsFactory?: WorkspaceFileSystemFactory,
+    private readonly deviceFlowRegistry?: DeviceFlowRegistry,
+  ) {
+    this.agentManager = createDaemonSubagentManager(boundWorkspace);
+  }
 
   private killOrphanSession(sessionId: string): void {
     void this.bridge
@@ -881,6 +996,895 @@ export class AcpDispatcher {
           return;
         }
 
+        // ── Wave 1+2: ACP/REST parity methods ───────────────────────
+
+        case `${QWEN_METHOD_NS}session/recap`: {
+          const sessionId = String(params['sessionId'] ?? '');
+          if (!this.requireOwned(conn, sessionId, id)) return;
+          const result = await this.bridge.generateSessionRecap(
+            sessionId,
+            this.sessionCtx(conn, sessionId, loopback),
+          );
+          this.replyConn(conn, id, result as unknown);
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}session/btw`: {
+          const sessionId = String(params['sessionId'] ?? '');
+          if (!this.requireOwned(conn, sessionId, id)) return;
+          const rawQ = params['question'];
+          if (
+            typeof rawQ !== 'string' ||
+            rawQ.trim().length === 0 ||
+            rawQ.length > BTW_MAX_INPUT_LENGTH
+          ) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(
+                  id,
+                  RPC.INVALID_PARAMS,
+                  `\`question\` required, non-empty, max ${BTW_MAX_INPUT_LENGTH} chars`,
+                ),
+              );
+            return;
+          }
+          const result = await this.bridge.generateSessionBtw(
+            sessionId,
+            rawQ.trim(),
+            undefined,
+            this.sessionCtx(conn, sessionId, loopback),
+          );
+          this.replyConn(conn, id, result as unknown);
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}session/shell`: {
+          const sessionId = String(params['sessionId'] ?? '');
+          if (!this.requireOwned(conn, sessionId, id)) return;
+          const rawCmd = params['command'];
+          if (typeof rawCmd !== 'string' || rawCmd.trim().length === 0) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(
+                  id,
+                  RPC.INVALID_PARAMS,
+                  '`command` required and must be non-empty',
+                ),
+              );
+            return;
+          }
+
+          writeStderrLine(
+            `qwen serve: /acp session/shell session=${sessionId.slice(0, 8)} client=${conn.clientId?.slice(0, 8)} cmd=${rawCmd.slice(0, 120)}`,
+          );
+          const result = await this.bridge.executeShellCommand(
+            sessionId,
+            rawCmd,
+            undefined,
+            this.sessionCtx(conn, sessionId, loopback),
+          );
+          this.replyConn(conn, id, result as unknown);
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}session/detach`: {
+          const sessionId = String(params['sessionId'] ?? '');
+          if (!this.requireOwned(conn, sessionId, id)) return;
+          const ctx = this.sessionCtx(conn, sessionId, loopback);
+          await this.bridge.detachClient(sessionId, ctx.clientId);
+          this.replyConn(conn, id, { ok: true });
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}session/context_usage`: {
+          const sessionId = String(params['sessionId'] ?? '');
+          if (!this.requireOwned(conn, sessionId, id)) return;
+          const result = await this.bridge.getSessionContextUsageStatus(
+            sessionId,
+            { detail: params['detail'] === true },
+          );
+          this.replyConn(conn, id, result as unknown);
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}session/tasks`: {
+          const sessionId = String(params['sessionId'] ?? '');
+          if (!this.requireOwned(conn, sessionId, id)) return;
+          const result = await this.bridge.getSessionTasksStatus(sessionId);
+          this.replyConn(conn, id, result as unknown);
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}workspace/memory`: {
+          const result = await collectWorkspaceMemoryStatus(
+            this.boundWorkspace,
+          );
+          this.replyConn(conn, id, result as unknown);
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}workspace/memory/write`: {
+          const content = params['content'];
+          if (typeof content !== 'string') {
+            if (id !== undefined)
+              conn.sendConn(
+                error(
+                  id,
+                  RPC.INVALID_PARAMS,
+                  '`content` required, must be string',
+                ),
+              );
+            return;
+          }
+          if (Buffer.byteLength(content, 'utf8') > 1024 * 1024) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INVALID_PARAMS, '`content` exceeds 1MB limit'),
+              );
+            return;
+          }
+          const rawScope = params['scope'];
+          if (
+            rawScope !== undefined &&
+            rawScope !== 'workspace' &&
+            rawScope !== 'global'
+          ) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(
+                  id,
+                  RPC.INVALID_PARAMS,
+                  '`scope` must be "workspace" or "global"',
+                ),
+              );
+            return;
+          }
+          const scope = (rawScope as 'workspace' | 'global') ?? 'workspace';
+          const rawMode = params['mode'];
+          if (
+            rawMode !== undefined &&
+            rawMode !== 'append' &&
+            rawMode !== 'replace'
+          ) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(
+                  id,
+                  RPC.INVALID_PARAMS,
+                  '`mode` must be "append" or "replace"',
+                ),
+              );
+            return;
+          }
+          const mode = (rawMode as 'append' | 'replace') ?? 'append';
+          writeStderrLine(
+            `qwen serve: /acp workspace/memory/write scope=${scope} mode=${mode} client=${conn.clientId?.slice(0, 8)} bytes=${Buffer.byteLength(content, 'utf8')}`,
+          );
+          const wr = await writeWorkspaceContextFile({
+            scope,
+            mode,
+            content,
+            projectRoot: this.boundWorkspace,
+          });
+          if (wr.changed)
+            this.bridge.publishWorkspaceEvent({
+              type: 'memory_changed',
+              data: {
+                scope,
+                filePath: wr.filePath,
+                mode,
+                bytesWritten: wr.bytesWritten,
+              },
+              originatorClientId: conn.clientId,
+            });
+          this.replyConn(conn, id, {
+            ok: true,
+            filePath: wr.filePath,
+            bytesWritten: wr.bytesWritten,
+            changed: wr.changed,
+          });
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}file/read`: {
+          if (!this.fsFactory) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INTERNAL_ERROR, 'File system not configured'),
+              );
+            return;
+          }
+          const p = String(params['path'] ?? '');
+          if (!p) {
+            if (id !== undefined)
+              conn.sendConn(error(id, RPC.INVALID_PARAMS, '`path` required'));
+            return;
+          }
+          const fs = this.fsFactory.forRequest({
+            originatorClientId: conn.clientId,
+            route: `ACP ${method}`,
+          });
+          const resolved = await fs.resolve(p, 'read');
+          const out = await fs.readText(resolved, {
+            maxBytes:
+              typeof params['maxBytes'] === 'number'
+                ? params['maxBytes']
+                : undefined,
+            line:
+              typeof params['line'] === 'number' ? params['line'] : undefined,
+            limit:
+              typeof params['limit'] === 'number' ? params['limit'] : undefined,
+          });
+          this.replyConn(conn, id, {
+            path: p,
+            content: out.content,
+            ...out.meta,
+          } as unknown);
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}file/read_bytes`: {
+          if (!this.fsFactory) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INTERNAL_ERROR, 'File system not configured'),
+              );
+            return;
+          }
+          const p = String(params['path'] ?? '');
+          if (!p) {
+            if (id !== undefined)
+              conn.sendConn(error(id, RPC.INVALID_PARAMS, '`path` required'));
+            return;
+          }
+          const fs = this.fsFactory.forRequest({
+            originatorClientId: conn.clientId,
+            route: `ACP ${method}`,
+          });
+          const resolved = await fs.resolve(p, 'read');
+          const buf = await fs.readBytesWindow(resolved, {
+            offset:
+              typeof params['offset'] === 'number'
+                ? params['offset']
+                : undefined,
+            maxBytes:
+              typeof params['maxBytes'] === 'number'
+                ? params['maxBytes']
+                : undefined,
+          });
+          this.replyConn(conn, id, { path: p, ...buf } as unknown);
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}file/stat`: {
+          if (!this.fsFactory) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INTERNAL_ERROR, 'File system not configured'),
+              );
+            return;
+          }
+          const p = String(params['path'] ?? '');
+          if (!p) {
+            if (id !== undefined)
+              conn.sendConn(error(id, RPC.INVALID_PARAMS, '`path` required'));
+            return;
+          }
+          const fs = this.fsFactory.forRequest({
+            originatorClientId: conn.clientId,
+            route: `ACP ${method}`,
+          });
+          const resolved = await fs.resolve(p, 'read');
+          const result = await fs.stat(resolved);
+          this.replyConn(conn, id, { path: p, ...result } as unknown);
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}file/list`: {
+          if (!this.fsFactory) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INTERNAL_ERROR, 'File system not configured'),
+              );
+            return;
+          }
+          const p = String(params['path'] ?? '');
+          if (!p) {
+            if (id !== undefined)
+              conn.sendConn(error(id, RPC.INVALID_PARAMS, '`path` required'));
+            return;
+          }
+          const fs = this.fsFactory.forRequest({
+            originatorClientId: conn.clientId,
+            route: `ACP ${method}`,
+          });
+          const resolved = await fs.resolve(p, 'read');
+          const MAX_LIST = 2000;
+          const entries = await fs.list(resolved, { maxEntries: MAX_LIST + 1 });
+          const truncated = entries.length > MAX_LIST;
+          this.replyConn(conn, id, {
+            path: p,
+            entries: truncated ? entries.slice(0, MAX_LIST) : entries,
+            truncated,
+          } as unknown);
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}file/glob`: {
+          if (!this.fsFactory) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INTERNAL_ERROR, 'File system not configured'),
+              );
+            return;
+          }
+          const pattern = String(params['pattern'] ?? '');
+          if (!pattern) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INVALID_PARAMS, '`pattern` required'),
+              );
+            return;
+          }
+          const fs = this.fsFactory.forRequest({
+            originatorClientId: conn.clientId,
+            route: `ACP ${method}`,
+          });
+          const MAX_GLOB = 5000;
+          const maxResults =
+            typeof params['maxResults'] === 'number'
+              ? Math.max(1, Math.min(params['maxResults'], 50000))
+              : MAX_GLOB;
+          const matches = await fs.glob(pattern, {
+            maxResults: maxResults + 1,
+          });
+          const truncated = matches.length > maxResults;
+          this.replyConn(conn, id, {
+            pattern,
+            matches: truncated ? matches.slice(0, maxResults) : matches,
+            truncated,
+          } as unknown);
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}file/write`: {
+          if (!this.fsFactory) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INTERNAL_ERROR, 'File system not configured'),
+              );
+            return;
+          }
+          const p = String(params['path'] ?? '');
+          if (!p) {
+            if (id !== undefined)
+              conn.sendConn(error(id, RPC.INVALID_PARAMS, '`path` required'));
+            return;
+          }
+          if (typeof params['content'] !== 'string') {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INVALID_PARAMS, '`content` must be string'),
+              );
+            return;
+          }
+          const fs = this.fsFactory.forRequest({
+            originatorClientId: conn.clientId,
+            route: `ACP ${method}`,
+          });
+          const resolved = await fs.resolve(p, 'write');
+          if (
+            Buffer.byteLength(params['content'] as string, 'utf8') >
+            10 * 1024 * 1024
+          ) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INVALID_PARAMS, 'content exceeds 10MB limit'),
+              );
+            return;
+          }
+          await fs.writeTextOverwrite(resolved, params['content'] as string);
+          this.replyConn(conn, id, { ok: true, path: p });
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}file/edit`: {
+          if (!this.fsFactory) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INTERNAL_ERROR, 'File system not configured'),
+              );
+            return;
+          }
+          const p = String(params['path'] ?? '');
+          if (!p) {
+            if (id !== undefined)
+              conn.sendConn(error(id, RPC.INVALID_PARAMS, '`path` required'));
+            return;
+          }
+          if (
+            typeof params['oldText'] !== 'string' ||
+            typeof params['newText'] !== 'string'
+          ) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(
+                  id,
+                  RPC.INVALID_PARAMS,
+                  '`oldText` and `newText` must be strings',
+                ),
+              );
+            return;
+          }
+          const fs = this.fsFactory.forRequest({
+            originatorClientId: conn.clientId,
+            route: `ACP ${method}`,
+          });
+          const resolved = await fs.resolve(p, 'write');
+          const result = await fs.edit(
+            resolved,
+            params['oldText'] as string,
+            params['newText'] as string,
+          );
+          this.replyConn(conn, id, { ok: true, path: p, ...result } as unknown);
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}workspace/auth/status`: {
+          if (!this.deviceFlowRegistry) {
+            this.replyConn(conn, id, { pendingDeviceFlows: [] });
+            return;
+          }
+          const pending = this.deviceFlowRegistry.listPending();
+          const projected = pending.map((v) => ({
+            deviceFlowId: v.deviceFlowId,
+            providerId: v.providerId,
+            expiresAt: v.expiresAt,
+          }));
+          this.replyConn(conn, id, { pendingDeviceFlows: projected });
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}workspace/auth/device_flow/start`: {
+          if (!this.deviceFlowRegistry) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INTERNAL_ERROR, 'Device flow not configured'),
+              );
+            return;
+          }
+          const providerId = String(params['providerId'] ?? '');
+          if (!providerId) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INVALID_PARAMS, '`providerId` required'),
+              );
+            return;
+          }
+          const startResult = await this.deviceFlowRegistry.start({
+            providerId:
+              providerId as import('../auth/deviceFlow.js').DeviceFlowProviderId,
+            initiatorClientId: conn.clientId,
+          });
+          const { view, attached } = startResult;
+          const gated =
+            view.initiatorClientId === conn.clientId
+              ? view
+              : {
+                  deviceFlowId: view.deviceFlowId,
+                  providerId: view.providerId,
+                  status: view.status,
+                  expiresAt: view.expiresAt,
+                };
+          this.replyConn(conn, id, { view: gated, attached } as unknown);
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}workspace/auth/device_flow/get`: {
+          if (!this.deviceFlowRegistry) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INTERNAL_ERROR, 'Device flow not configured'),
+              );
+            return;
+          }
+          const flowId = String(params['id'] ?? '');
+          if (!flowId) {
+            if (id !== undefined)
+              conn.sendConn(error(id, RPC.INVALID_PARAMS, '`id` required'));
+            return;
+          }
+          const view = this.deviceFlowRegistry.get(flowId);
+          if (!view) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(
+                  id,
+                  RPC.INVALID_PARAMS,
+                  `Device flow "${flowId}" not found`,
+                ),
+              );
+            return;
+          }
+          const gated =
+            view.initiatorClientId === conn.clientId
+              ? view
+              : {
+                  deviceFlowId: view.deviceFlowId,
+                  providerId: view.providerId,
+                  status: view.status,
+                  expiresAt: view.expiresAt,
+                };
+          this.replyConn(conn, id, gated as unknown);
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}workspace/auth/device_flow/cancel`: {
+          if (!this.deviceFlowRegistry) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INTERNAL_ERROR, 'Device flow not configured'),
+              );
+            return;
+          }
+          const flowId = String(params['id'] ?? '');
+          if (!flowId) {
+            if (id !== undefined)
+              conn.sendConn(error(id, RPC.INVALID_PARAMS, '`id` required'));
+            return;
+          }
+          const cancelResult = this.deviceFlowRegistry.cancel(
+            flowId,
+            conn.clientId,
+          );
+          if (!cancelResult) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(
+                  id,
+                  RPC.INVALID_PARAMS,
+                  `Device flow "${flowId}" not found`,
+                ),
+              );
+            return;
+          }
+          this.replyConn(conn, id, {
+            ok: true,
+            alreadyTerminal: cancelResult.alreadyTerminal,
+          });
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}workspace/tools`: {
+          const result = await this.bridge.getWorkspaceToolsStatus();
+          this.replyConn(conn, id, result as unknown);
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}workspace/mcp/tools`: {
+          const serverName = String(params['serverName'] ?? '');
+          if (!serverName) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INVALID_PARAMS, '`serverName` required'),
+              );
+            return;
+          }
+          const result =
+            await this.bridge.getWorkspaceMcpToolsStatus(serverName);
+          this.replyConn(conn, id, result as unknown);
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}workspace/mcp/servers/add`: {
+          const name = String(params['name'] ?? '');
+          if (!name || name.length > MAX_NAME_LENGTH) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(
+                  id,
+                  RPC.INVALID_PARAMS,
+                  `\`name\` required, max ${MAX_NAME_LENGTH} chars`,
+                ),
+              );
+            return;
+          }
+          const config = params['config'];
+          if (!config || typeof config !== 'object' || Array.isArray(config)) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(
+                  id,
+                  RPC.INVALID_PARAMS,
+                  '`config` required, must be object',
+                ),
+              );
+            return;
+          }
+          const result = await this.bridge.addRuntimeMcpServer(
+            name,
+            config as Record<string, unknown>,
+            conn.clientId,
+          );
+          this.replyConn(conn, id, result as unknown);
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}workspace/mcp/servers/remove`: {
+          const name = String(params['name'] ?? '');
+          if (!name || name.length > MAX_NAME_LENGTH) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(
+                  id,
+                  RPC.INVALID_PARAMS,
+                  `\`name\` required, max ${MAX_NAME_LENGTH} chars`,
+                ),
+              );
+            return;
+          }
+          const result = await this.bridge.removeRuntimeMcpServer(
+            name,
+            conn.clientId,
+          );
+          this.replyConn(conn, id, result as unknown);
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}sessions/delete`: {
+          const sessionIds = params['sessionIds'];
+          if (
+            !Array.isArray(sessionIds) ||
+            sessionIds.length === 0 ||
+            sessionIds.length > 100 ||
+            !sessionIds.every((s) => typeof s === 'string')
+          ) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(
+                  id,
+                  RPC.INVALID_PARAMS,
+                  '`sessionIds` must be non-empty string array (max 100)',
+                ),
+              );
+            return;
+          }
+          const ids = [...new Set(sessionIds as string[])];
+          const closeErrors: Array<{ sessionId: string; error: string }> = [];
+          const closedIds: string[] = [];
+          await Promise.allSettled(
+            ids.map(async (sid) => {
+              try {
+                await this.bridge.closeSession(sid);
+                closedIds.push(sid);
+              } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                if (
+                  err instanceof Error &&
+                  err.name === 'SessionNotFoundError'
+                ) {
+                  closedIds.push(sid);
+                } else {
+                  writeStderrLine(
+                    `qwen serve: /acp sessions/delete closeSession(${sid.slice(0, 8)}) failed: ${msg}`,
+                  );
+                  closeErrors.push({ sessionId: sid, error: msg });
+                }
+              }
+            }),
+          );
+          const svc = new SessionService(this.boundWorkspace);
+          const removeResult = await svc.removeSessions(closedIds);
+          for (const e of removeResult.errors) {
+            writeStderrLine(
+              `qwen serve: /acp sessions/delete removeSessions(${e.sessionId.slice(0, 8)}) failed: ${e.error.message}`,
+            );
+          }
+          this.replyConn(conn, id, {
+            removed: removeResult.removed,
+            notFound: removeResult.notFound,
+            errors: [
+              ...closeErrors,
+              ...removeResult.errors.map((e) => ({
+                sessionId: e.sessionId,
+                error: e.error.message,
+              })),
+            ],
+          } as unknown);
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}workspace/agents/list`: {
+          const agents = await this.agentManager.listSubagents({ force: true });
+          this.replyConn(conn, id, {
+            v: 1,
+            workspaceCwd: this.boundWorkspace,
+            agents: agents.map(agentToSummary),
+          });
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}workspace/agents/get`: {
+          const agentType = String(params['agentType'] ?? '');
+          if (!agentType) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INVALID_PARAMS, '`agentType` required'),
+              );
+            return;
+          }
+          const config = await this.agentManager.loadSubagent(agentType);
+          if (!config) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INVALID_PARAMS, `Agent "${agentType}" not found`),
+              );
+            return;
+          }
+          this.replyConn(conn, id, agentToDetail(config) as unknown);
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}workspace/agents/create`: {
+          const scope = params['scope'];
+          if (scope !== 'workspace' && scope !== 'global') {
+            if (id !== undefined)
+              conn.sendConn(
+                error(
+                  id,
+                  RPC.INVALID_PARAMS,
+                  '`scope` must be "workspace" or "global"',
+                ),
+              );
+            return;
+          }
+          const name = params['name'];
+          if (typeof name !== 'string' || !name.trim()) {
+            if (id !== undefined)
+              conn.sendConn(error(id, RPC.INVALID_PARAMS, '`name` required'));
+            return;
+          }
+          const level: SubagentLevel =
+            scope === 'workspace' ? 'project' : 'user';
+          if (BuiltinAgentRegistry.isBuiltinAgent(name)) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(
+                  id,
+                  RPC.INVALID_PARAMS,
+                  `Cannot shadow built-in agent "${name}"`,
+                ),
+              );
+            return;
+          }
+          const collision = await this.agentManager.loadSubagent(name, level);
+          if (collision) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INVALID_PARAMS, `Agent "${name}" already exists`),
+              );
+            return;
+          }
+          await this.agentManager.createSubagent(
+            {
+              name,
+              level,
+              description:
+                typeof params['description'] === 'string'
+                  ? params['description']
+                  : '',
+              systemPrompt:
+                typeof params['systemPrompt'] === 'string'
+                  ? params['systemPrompt']
+                  : '',
+              tools: Array.isArray(params['tools'])
+                ? (params['tools'] as string[])
+                : undefined,
+              model:
+                typeof params['model'] === 'string'
+                  ? params['model']
+                  : undefined,
+            },
+            { level },
+          );
+          const created = await this.agentManager.loadSubagent(name, level);
+          this.bridge.publishWorkspaceEvent({
+            type: 'agent_changed',
+            data: { change: 'created', name, level },
+            originatorClientId: conn.clientId,
+          });
+          this.replyConn(conn, id, {
+            ok: true,
+            agent: created ? agentToDetail(created) : null,
+          } as unknown);
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}workspace/agents/update`: {
+          const agentType = String(params['agentType'] ?? '');
+          if (!agentType) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INVALID_PARAMS, '`agentType` required'),
+              );
+            return;
+          }
+          const existing = await this.agentManager.loadSubagent(agentType);
+          if (!existing) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INVALID_PARAMS, `Agent "${agentType}" not found`),
+              );
+            return;
+          }
+          const updates: Record<string, unknown> = {};
+          if (typeof params['description'] === 'string')
+            updates['description'] = params['description'];
+          if (typeof params['systemPrompt'] === 'string')
+            updates['systemPrompt'] = params['systemPrompt'];
+          if (Array.isArray(params['tools']))
+            updates['tools'] = params['tools'];
+          if (typeof params['model'] === 'string')
+            updates['model'] = params['model'];
+          await this.agentManager.updateSubagent(
+            agentType,
+            updates,
+            existing.level,
+          );
+          const updated = await this.agentManager.loadSubagent(
+            agentType,
+            existing.level,
+          );
+          this.bridge.publishWorkspaceEvent({
+            type: 'agent_changed',
+            data: { change: 'updated', name: agentType, level: existing.level },
+            originatorClientId: conn.clientId,
+          });
+          this.replyConn(conn, id, {
+            ok: true,
+            agent: updated ? agentToDetail(updated) : null,
+          } as unknown);
+          return;
+        }
+
+        case `${QWEN_METHOD_NS}workspace/agents/delete`: {
+          const agentType = String(params['agentType'] ?? '');
+          if (!agentType) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INVALID_PARAMS, '`agentType` required'),
+              );
+            return;
+          }
+          const scope =
+            typeof params['scope'] === 'string' ? params['scope'] : undefined;
+          const level: SubagentLevel | undefined =
+            scope === 'workspace'
+              ? 'project'
+              : scope === 'global'
+                ? 'user'
+                : undefined;
+          const existing = await this.agentManager.loadSubagent(
+            agentType,
+            level,
+          );
+          if (!existing) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(id, RPC.INVALID_PARAMS, `Agent "${agentType}" not found`),
+              );
+            return;
+          }
+          await this.agentManager.deleteSubagent(agentType, existing.level);
+          this.bridge.publishWorkspaceEvent({
+            type: 'agent_changed',
+            data: { change: 'deleted', name: agentType, level: existing.level },
+            originatorClientId: conn.clientId,
+          });
+          this.replyConn(conn, id, { ok: true });
+          return;
+        }
+
         default:
           if (id !== undefined) {
             conn.sendConn(
@@ -896,8 +1900,8 @@ export class AcpDispatcher {
         `qwen serve: /acp dispatch error (${logSafe(method)}): ${logSafe(errMsg(err))}`,
       );
       if (id !== undefined) {
-        const { code, message } = toRpcError(err);
-        const frame = error(id, code, message);
+        const { code, message, data } = toRpcError(err);
+        const frame = error(id, code, message, data);
         // Route the error the SAME way as the method's success path. Inferring
         // from `params.sessionId` would misroute conn-scoped method failures
         // (session/load|resume|close|…) to a session stream that doesn't exist
@@ -1135,14 +2139,14 @@ export class AcpDispatcher {
       );
       if (id !== undefined) this.replySession(conn, sessionId, id, result);
     } catch (err) {
-      const { code, message } = toRpcError(err);
+      const { code, message, data } = toRpcError(err);
       if (id !== undefined) {
         this.replySession(
           conn,
           sessionId,
           id,
           undefined,
-          error(id, code, message),
+          error(id, code, message, data),
         );
       } else {
         // Notification-form prompt (no id): no response frame to send, so a

--- a/packages/cli/src/serve/acpHttp/dispatch.ts
+++ b/packages/cli/src/serve/acpHttp/dispatch.ts
@@ -256,7 +256,11 @@ function toRpcError(err: unknown): {
     case 'SessionLimitExceededError':
       return { code: RPC.INTERNAL_ERROR, message: errMsg(err) };
     default:
-      return { code: RPC.INTERNAL_ERROR, message: 'Internal error' };
+      return {
+        code: RPC.INTERNAL_ERROR,
+        message: 'Internal error',
+        data: { errorKind: 'internal' },
+      };
   }
 }
 
@@ -1166,23 +1170,28 @@ export class AcpDispatcher {
             content,
             projectRoot: this.boundWorkspace,
           });
-          if (wr.changed)
-            this.bridge.publishWorkspaceEvent({
-              type: 'memory_changed',
-              data: {
-                scope,
-                filePath: wr.filePath,
-                mode,
-                bytesWritten: wr.bytesWritten,
-              },
-              originatorClientId: conn.clientId,
-            });
           this.replyConn(conn, id, {
             ok: true,
             filePath: wr.filePath,
             bytesWritten: wr.bytesWritten,
             changed: wr.changed,
           });
+          if (wr.changed) {
+            try {
+              this.bridge.publishWorkspaceEvent({
+                type: 'memory_changed',
+                data: {
+                  scope,
+                  filePath: wr.filePath,
+                  mode,
+                  bytesWritten: wr.bytesWritten,
+                },
+                originatorClientId: conn.clientId,
+              });
+            } catch {
+              /* best-effort */
+            }
+          }
           return;
         }
 
@@ -1333,7 +1342,10 @@ export class AcpDispatcher {
           const MAX_GLOB = 5000;
           const maxResults =
             typeof params['maxResults'] === 'number'
-              ? Math.max(1, Math.min(params['maxResults'], 50000))
+              ? Math.max(
+                  1,
+                  Math.min(Number(params['maxResults']) || 5000, 50000),
+                )
               : MAX_GLOB;
           const matches = await fs.glob(pattern, {
             maxResults: maxResults + 1,
@@ -1531,6 +1543,22 @@ export class AcpDispatcher {
           if (!flowId) {
             if (id !== undefined)
               conn.sendConn(error(id, RPC.INVALID_PARAMS, '`id` required'));
+            return;
+          }
+          const flowView = this.deviceFlowRegistry.get(flowId);
+          if (
+            flowView &&
+            flowView.initiatorClientId &&
+            flowView.initiatorClientId !== conn.clientId
+          ) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(
+                  id,
+                  RPC.INVALID_PARAMS,
+                  'Only the flow initiator can cancel',
+                ),
+              );
             return;
           }
           const cancelResult = this.deviceFlowRegistry.cancel(
@@ -1788,15 +1816,19 @@ export class AcpDispatcher {
             { level },
           );
           const created = await this.agentManager.loadSubagent(name, level);
-          this.bridge.publishWorkspaceEvent({
-            type: 'agent_changed',
-            data: { change: 'created', name, level },
-            originatorClientId: conn.clientId,
-          });
           this.replyConn(conn, id, {
             ok: true,
             agent: created ? agentToDetail(created) : null,
           } as unknown);
+          try {
+            this.bridge.publishWorkspaceEvent({
+              type: 'agent_changed',
+              data: { change: 'created', name, level },
+              originatorClientId: conn.clientId,
+            });
+          } catch {
+            /* best-effort */
+          }
           return;
         }
 
@@ -1817,15 +1849,84 @@ export class AcpDispatcher {
               );
             return;
           }
+          const MAX_FIELD_BYTES = 256 * 1024;
           const updates: Record<string, unknown> = {};
-          if (typeof params['description'] === 'string')
+          if (typeof params['description'] === 'string') {
+            if (
+              Buffer.byteLength(params['description'], 'utf8') > MAX_FIELD_BYTES
+            ) {
+              if (id !== undefined)
+                conn.sendConn(
+                  error(
+                    id,
+                    RPC.INVALID_PARAMS,
+                    '`description` exceeds 256KB limit',
+                  ),
+                );
+              return;
+            }
             updates['description'] = params['description'];
-          if (typeof params['systemPrompt'] === 'string')
+          }
+          if (typeof params['systemPrompt'] === 'string') {
+            if (
+              Buffer.byteLength(params['systemPrompt'], 'utf8') >
+              MAX_FIELD_BYTES
+            ) {
+              if (id !== undefined)
+                conn.sendConn(
+                  error(
+                    id,
+                    RPC.INVALID_PARAMS,
+                    '`systemPrompt` exceeds 256KB limit',
+                  ),
+                );
+              return;
+            }
             updates['systemPrompt'] = params['systemPrompt'];
-          if (Array.isArray(params['tools']))
+          }
+          if (Array.isArray(params['tools'])) {
+            if (params['tools'].length > 256) {
+              if (id !== undefined)
+                conn.sendConn(
+                  error(
+                    id,
+                    RPC.INVALID_PARAMS,
+                    '`tools` exceeds 256-entry limit',
+                  ),
+                );
+              return;
+            }
+            if (
+              !params['tools'].every(
+                (t: unknown) =>
+                  typeof t === 'string' && (t as string).length <= 256,
+              )
+            ) {
+              if (id !== undefined)
+                conn.sendConn(
+                  error(
+                    id,
+                    RPC.INVALID_PARAMS,
+                    '`tools` elements must be strings ≤256 chars',
+                  ),
+                );
+              return;
+            }
             updates['tools'] = params['tools'];
+          }
           if (typeof params['model'] === 'string')
             updates['model'] = params['model'];
+          if (Object.keys(updates).length === 0) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(
+                  id,
+                  RPC.INVALID_PARAMS,
+                  'at least one updatable field required',
+                ),
+              );
+            return;
+          }
           await this.agentManager.updateSubagent(
             agentType,
             updates,
@@ -1835,15 +1936,23 @@ export class AcpDispatcher {
             agentType,
             existing.level,
           );
-          this.bridge.publishWorkspaceEvent({
-            type: 'agent_changed',
-            data: { change: 'updated', name: agentType, level: existing.level },
-            originatorClientId: conn.clientId,
-          });
           this.replyConn(conn, id, {
             ok: true,
             agent: updated ? agentToDetail(updated) : null,
           } as unknown);
+          try {
+            this.bridge.publishWorkspaceEvent({
+              type: 'agent_changed',
+              data: {
+                change: 'updated',
+                name: agentType,
+                level: existing.level,
+              },
+              originatorClientId: conn.clientId,
+            });
+          } catch {
+            /* best-effort */
+          }
           return;
         }
 
@@ -1876,12 +1985,20 @@ export class AcpDispatcher {
             return;
           }
           await this.agentManager.deleteSubagent(agentType, existing.level);
-          this.bridge.publishWorkspaceEvent({
-            type: 'agent_changed',
-            data: { change: 'deleted', name: agentType, level: existing.level },
-            originatorClientId: conn.clientId,
-          });
           this.replyConn(conn, id, { ok: true });
+          try {
+            this.bridge.publishWorkspaceEvent({
+              type: 'agent_changed',
+              data: {
+                change: 'deleted',
+                name: agentType,
+                level: existing.level,
+              },
+              originatorClientId: conn.clientId,
+            });
+          } catch {
+            /* best-effort */
+          }
           return;
         }
 

--- a/packages/cli/src/serve/acpHttp/index.ts
+++ b/packages/cli/src/serve/acpHttp/index.ts
@@ -8,6 +8,8 @@ import type { Application, Request, Response } from 'express';
 import type { HttpAcpBridge } from '@qwen-code/acp-bridge/bridgeTypes';
 import { writeStderrLine } from '../../utils/stdioHelpers.js';
 import type { DaemonWorkspaceService } from '../workspace-service/types.js';
+import type { WorkspaceFileSystemFactory } from '../fs/index.js';
+import type { DeviceFlowRegistry } from '../auth/deviceFlow.js';
 import { AcpDispatcher } from './dispatch.js';
 import { ConnectionRegistry } from './connectionRegistry.js';
 import { SseStream } from './sseStream.js';
@@ -26,13 +28,11 @@ const CONN_GRACE_MS = 10_000;
 
 export interface MountAcpHttpOptions {
   boundWorkspace: string;
-  /** Workspace service facade for workspace-scoped operations. */
   workspace: DaemonWorkspaceService;
-  /** Defaults to `process.env.QWEN_SERVE_ACP_HTTP !== '0'`. */
+  fsFactory?: WorkspaceFileSystemFactory;
+  deviceFlowRegistry?: DeviceFlowRegistry;
   enabled?: boolean;
-  /** Mount path; defaults to `/acp`. */
   path?: string;
-  /** Concurrent-connection cap; `0` disables. Defaults to the registry default. */
   maxConnections?: number;
 }
 
@@ -66,6 +66,8 @@ export function mountAcpHttp(
     bridge,
     opts.boundWorkspace,
     opts.workspace,
+    opts.fsFactory,
+    opts.deviceFlowRegistry,
   );
   // When a session/connection tears down with a permission still pending,
   // cancel it on the bridge so the agent's prompt isn't left blocked.
@@ -87,6 +89,19 @@ export function mountAcpHttp(
 
   // ── POST /acp ──────────────────────────────────────────────────────
   app.post(path, async (req: Request, res: Response) => {
+    // RFD: Content-Type MUST be application/json; otherwise 415.
+    const ct = req.headers['content-type'];
+    if (!ct || !ct.includes('application/json')) {
+      res.status(415).json({ error: 'Content-Type must be application/json' });
+      return;
+    }
+    // RFD: batch JSON-RPC arrays → 501 Not Implemented.
+    if (Array.isArray(req.body)) {
+      res
+        .status(501)
+        .json({ error: 'Batch JSON-RPC requests are not supported' });
+      return;
+    }
     const parsed = parseInbound(req.body);
     if (!parsed.ok) {
       writeStderrLine(
@@ -140,15 +155,28 @@ export function mountAcpHttp(
       return;
     }
 
-    const conn = registry.get(headerOf(req, ACP_CONNECTION_HEADER));
-    if (!conn) {
+    const connHeader = headerOf(req, ACP_CONNECTION_HEADER);
+    if (!connHeader) {
       res
         .status(400)
         .json(
           rpcError(
             isRequest(message) ? message.id : null,
             RPC.INVALID_REQUEST,
-            'Missing or unknown Acp-Connection-Id',
+            'Missing Acp-Connection-Id',
+          ),
+        );
+      return;
+    }
+    const conn = registry.get(connHeader);
+    if (!conn) {
+      res
+        .status(404)
+        .json(
+          rpcError(
+            isRequest(message) ? message.id : null,
+            RPC.INVALID_REQUEST,
+            'Unknown Acp-Connection-Id',
           ),
         );
       return;
@@ -177,9 +205,22 @@ export function mountAcpHttp(
 
   // ── GET /acp (SSE) ─────────────────────────────────────────────────
   app.get(path, (req: Request, res: Response) => {
-    const conn = registry.get(headerOf(req, ACP_CONNECTION_HEADER));
+    // RFD: Accept MUST include text/event-stream; otherwise 406.
+    const accept = req.headers['accept'] ?? '';
+    if (!accept.includes('text/event-stream')) {
+      res
+        .status(406)
+        .json({ error: 'Accept header must include text/event-stream' });
+      return;
+    }
+    const connHeader = headerOf(req, ACP_CONNECTION_HEADER);
+    if (!connHeader) {
+      res.status(400).json({ error: 'Missing Acp-Connection-Id' });
+      return;
+    }
+    const conn = registry.get(connHeader);
     if (!conn) {
-      res.status(400).json({ error: 'Missing or unknown Acp-Connection-Id' });
+      res.status(404).json({ error: 'Unknown Acp-Connection-Id' });
       return;
     }
     const sessionId = headerOf(req, ACP_SESSION_HEADER);

--- a/packages/cli/src/serve/acpHttp/transport.test.ts
+++ b/packages/cli/src/serve/acpHttp/transport.test.ts
@@ -204,6 +204,51 @@ class FakeBridge {
     this.detached.push({ sessionId, clientId });
   }
   async preheat() {}
+
+  // Wave 1+2 stubs
+  async generateSessionRecap(sessionId: string) {
+    return { sessionId, recap: 'test recap' };
+  }
+  async generateSessionBtw(sessionId: string, question: string) {
+    return { sessionId, answer: `re: ${question}` };
+  }
+  async executeShellCommand(sessionId: string, command: string) {
+    return { exitCode: 0, output: `$ ${command}`, aborted: false };
+  }
+  async getSessionContextUsageStatus(sessionId: string) {
+    return { sessionId, used: 100, total: 1000 };
+  }
+  async getSessionTasksStatus(sessionId: string) {
+    return { sessionId, tasks: [] };
+  }
+  async getWorkspaceToolsStatus() {
+    return { v: 1, tools: [] };
+  }
+  async getWorkspaceMcpToolsStatus(serverName: string) {
+    return { v: 1, serverName, tools: [] };
+  }
+  async addRuntimeMcpServer(name: string) {
+    return {
+      name,
+      transport: 'stdio',
+      replaced: false,
+      shadowedSettings: false,
+      toolCount: 0,
+      originatorClientId: 'c',
+    };
+  }
+  async removeRuntimeMcpServer(name: string) {
+    return {
+      name,
+      removed: true,
+      wasShadowingSettings: false,
+      originatorClientId: 'c',
+    };
+  }
+  publishWorkspaceEvent() {}
+  knownClientIds() {
+    return new Set<string>();
+  }
 }
 
 // A minimal fake workspace service for dispatch tests.
@@ -359,14 +404,14 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
     await new Promise((r) => setTimeout(r, 30)); // let handle() register ownership
   }
 
-  it('initialize → 200 + Acp-Connection-Id; unknown conn → 400', async () => {
+  it('initialize → 200 + Acp-Connection-Id; unknown conn → 404', async () => {
     await initialize();
     const bad = await post('nope', {
       jsonrpc: '2.0',
       id: 2,
       method: 'session/new',
     });
-    expect(bad.status).toBe(400);
+    expect(bad.status).toBe(404);
   });
 
   it('session/new reply rides the connection-scoped stream', async () => {
@@ -1439,7 +1484,7 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
     expect(res.status).toBe(400);
   });
 
-  it('DELETE tears the connection down (subsequent POST 400)', async () => {
+  it('DELETE tears the connection down (subsequent POST 404)', async () => {
     const connId = await initialize();
     const del = await fetch(`${base}/acp`, {
       method: 'DELETE',
@@ -1451,6 +1496,450 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
       id: 12,
       method: 'session/new',
     });
-    expect(after.status).toBe(400);
+    expect(after.status).toBe(404);
+  });
+
+  // ── Wave 1+2: new _qwen/* method tests ──────────────────────────
+
+  describe('protocol compliance', () => {
+    it('POST non-JSON Content-Type → 415', async () => {
+      const res = await fetch(`${base}/acp`, {
+        method: 'POST',
+        headers: { 'content-type': 'text/plain' },
+        body: '{}',
+      });
+      expect(res.status).toBe(415);
+    });
+
+    it('POST batch JSON-RPC array → 501', async () => {
+      const res = await fetch(`${base}/acp`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify([{ jsonrpc: '2.0', id: 1, method: 'foo' }]),
+      });
+      expect(res.status).toBe(501);
+    });
+
+    it('GET without text/event-stream Accept → 406', async () => {
+      const connId = await initialize();
+      const res = await fetch(`${base}/acp`, {
+        headers: {
+          accept: 'application/json',
+          'acp-connection-id': connId,
+        },
+      });
+      expect(res.status).toBe(406);
+    });
+
+    it('POST missing Acp-Connection-Id → 400', async () => {
+      const res = await fetch(`${base}/acp`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'session/list',
+        }),
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('session extension methods', () => {
+    it('_qwen/session/recap returns recap', async () => {
+      const connId = await initialize();
+      await newSession(connId);
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 50,
+        method: '_qwen/session/recap',
+        params: { sessionId: 'sess-1' },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({
+        result: { sessionId: 'sess-1', recap: 'test recap' },
+      });
+    });
+
+    it('_qwen/session/btw validates question length', async () => {
+      const connId = await initialize();
+      await newSession(connId);
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 51,
+        method: '_qwen/session/btw',
+        params: { sessionId: 'sess-1', question: '' },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({ error: { code: -32602 } });
+    });
+
+    it('_qwen/session/btw returns answer', async () => {
+      const connId = await initialize();
+      await newSession(connId);
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 52,
+        method: '_qwen/session/btw',
+        params: { sessionId: 'sess-1', question: 'what?' },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({
+        result: { answer: 're: what?' },
+      });
+    });
+
+    it('_qwen/session/shell rejects empty command', async () => {
+      const connId = await initialize();
+      await newSession(connId);
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 53,
+        method: '_qwen/session/shell',
+        params: { sessionId: 'sess-1', command: '' },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({ error: { code: -32602 } });
+    });
+
+    it('_qwen/session/shell returns result', async () => {
+      const connId = await initialize();
+      await newSession(connId);
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 54,
+        method: '_qwen/session/shell',
+        params: { sessionId: 'sess-1', command: 'ls' },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({
+        result: { exitCode: 0, output: '$ ls' },
+      });
+    });
+
+    it('_qwen/session/detach succeeds', async () => {
+      const connId = await initialize();
+      await newSession(connId);
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 55,
+        method: '_qwen/session/detach',
+        params: { sessionId: 'sess-1' },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({ result: { ok: true } });
+      expect(bridge.detached.length).toBeGreaterThan(0);
+    });
+
+    it('_qwen/session/context_usage returns usage', async () => {
+      const connId = await initialize();
+      await newSession(connId);
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 56,
+        method: '_qwen/session/context_usage',
+        params: { sessionId: 'sess-1' },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({
+        result: { sessionId: 'sess-1', used: 100 },
+      });
+    });
+
+    it('_qwen/session/tasks returns tasks', async () => {
+      const connId = await initialize();
+      await newSession(connId);
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 57,
+        method: '_qwen/session/tasks',
+        params: { sessionId: 'sess-1' },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({
+        result: { sessionId: 'sess-1', tasks: [] },
+      });
+    });
+
+    it('session methods reject unowned session', async () => {
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 58,
+        method: '_qwen/session/recap',
+        params: { sessionId: 'unknown-session' },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({ error: { code: -32602 } });
+    });
+  });
+
+  describe('workspace methods', () => {
+    it('_qwen/workspace/tools returns tools', async () => {
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 60,
+        method: '_qwen/workspace/tools',
+        params: {},
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({ result: { v: 1, tools: [] } });
+    });
+
+    it('_qwen/workspace/mcp/tools rejects missing serverName', async () => {
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 61,
+        method: '_qwen/workspace/mcp/tools',
+        params: {},
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({ error: { code: -32602 } });
+    });
+
+    it('_qwen/workspace/mcp/tools returns tools', async () => {
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 62,
+        method: '_qwen/workspace/mcp/tools',
+        params: { serverName: 'fs' },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({
+        result: { serverName: 'fs', tools: [] },
+      });
+    });
+
+    it('_qwen/workspace/mcp/servers/add rejects missing name', async () => {
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 63,
+        method: '_qwen/workspace/mcp/servers/add',
+        params: { config: {} },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({ error: { code: -32602 } });
+    });
+
+    it('_qwen/workspace/mcp/servers/remove rejects missing name', async () => {
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 64,
+        method: '_qwen/workspace/mcp/servers/remove',
+        params: {},
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({ error: { code: -32602 } });
+    });
+
+    it('_qwen/sessions/delete rejects non-array', async () => {
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 65,
+        method: '_qwen/sessions/delete',
+        params: { sessionIds: 'not-array' },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({ error: { code: -32602 } });
+    });
+
+    it('_qwen/sessions/delete rejects >100 ids', async () => {
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      const ids = Array.from({ length: 101 }, (_, i) => `s${i}`);
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 66,
+        method: '_qwen/sessions/delete',
+        params: { sessionIds: ids },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({ error: { code: -32602 } });
+    });
+  });
+
+  describe('auth methods', () => {
+    it('_qwen/workspace/auth/status returns empty when no registry', async () => {
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 70,
+        method: '_qwen/workspace/auth/status',
+        params: {},
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({
+        result: { pendingDeviceFlows: [] },
+      });
+    });
+
+    it('_qwen/workspace/auth/device_flow/start rejects without registry', async () => {
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 71,
+        method: '_qwen/workspace/auth/device_flow/start',
+        params: { providerId: 'test' },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({ error: { code: -32603 } });
+    });
+  });
+
+  describe('memory methods', () => {
+    it('_qwen/workspace/memory/write rejects non-string content', async () => {
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 80,
+        method: '_qwen/workspace/memory/write',
+        params: { content: 123 },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({ error: { code: -32602 } });
+    });
+
+    it('_qwen/workspace/memory/write rejects invalid scope', async () => {
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 81,
+        method: '_qwen/workspace/memory/write',
+        params: { content: 'hi', scope: 'invalid' },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({ error: { code: -32602 } });
+    });
+
+    it('_qwen/workspace/memory/write rejects invalid mode', async () => {
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 82,
+        method: '_qwen/workspace/memory/write',
+        params: { content: 'hi', mode: 'invalid' },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({ error: { code: -32602 } });
+    });
+  });
+
+  describe('file methods', () => {
+    it('_qwen/file/read rejects without fsFactory (503-equivalent)', async () => {
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 90,
+        method: '_qwen/file/read',
+        params: { path: 'test.txt' },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({ error: { code: -32603 } });
+    });
+
+    it('_qwen/file/read rejects missing path', async () => {
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 91,
+        method: '_qwen/file/read',
+        params: {},
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({ error: { code: -32602 } });
+    });
+
+    it('_qwen/file/write rejects missing content', async () => {
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 92,
+        method: '_qwen/file/write',
+        params: { path: 'test.txt' },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({ error: { code: -32602 } });
+    });
+
+    it('_qwen/file/edit rejects missing oldText/newText', async () => {
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 93,
+        method: '_qwen/file/edit',
+        params: { path: 'test.txt' },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({ error: { code: -32602 } });
+    });
+
+    it('_qwen/file/glob rejects missing pattern', async () => {
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 94,
+        method: '_qwen/file/glob',
+        params: {},
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({ error: { code: -32602 } });
+    });
   });
 });

--- a/packages/cli/src/serve/acpHttp/transport.test.ts
+++ b/packages/cli/src/serve/acpHttp/transport.test.ts
@@ -1548,8 +1548,14 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
   describe('session extension methods', () => {
     it('_qwen/session/recap returns recap', async () => {
       const connId = await initialize();
-      await newSession(connId);
       const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 99,
+        method: 'session/new',
+        params: {},
+      });
       await new Promise((r) => setTimeout(r, 30));
       await post(connId, {
         jsonrpc: '2.0',
@@ -1557,16 +1563,22 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
         method: '_qwen/session/recap',
         params: { sessionId: 'sess-1' },
       });
-      const frames = await takeFrames(await streamRes, 1);
-      expect(frames[0]).toMatchObject({
+      const frames = await takeFrames(await streamRes, 2);
+      expect(frames[1]).toMatchObject({
         result: { sessionId: 'sess-1', recap: 'test recap' },
       });
     });
 
     it('_qwen/session/btw validates question length', async () => {
       const connId = await initialize();
-      await newSession(connId);
       const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 99,
+        method: 'session/new',
+        params: {},
+      });
       await new Promise((r) => setTimeout(r, 30));
       await post(connId, {
         jsonrpc: '2.0',
@@ -1574,14 +1586,20 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
         method: '_qwen/session/btw',
         params: { sessionId: 'sess-1', question: '' },
       });
-      const frames = await takeFrames(await streamRes, 1);
-      expect(frames[0]).toMatchObject({ error: { code: -32602 } });
+      const frames = await takeFrames(await streamRes, 2);
+      expect(frames[1]).toMatchObject({ error: { code: -32602 } });
     });
 
     it('_qwen/session/btw returns answer', async () => {
       const connId = await initialize();
-      await newSession(connId);
       const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 99,
+        method: 'session/new',
+        params: {},
+      });
       await new Promise((r) => setTimeout(r, 30));
       await post(connId, {
         jsonrpc: '2.0',
@@ -1589,16 +1607,22 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
         method: '_qwen/session/btw',
         params: { sessionId: 'sess-1', question: 'what?' },
       });
-      const frames = await takeFrames(await streamRes, 1);
-      expect(frames[0]).toMatchObject({
+      const frames = await takeFrames(await streamRes, 2);
+      expect(frames[1]).toMatchObject({
         result: { answer: 're: what?' },
       });
     });
 
     it('_qwen/session/shell rejects empty command', async () => {
       const connId = await initialize();
-      await newSession(connId);
       const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 99,
+        method: 'session/new',
+        params: {},
+      });
       await new Promise((r) => setTimeout(r, 30));
       await post(connId, {
         jsonrpc: '2.0',
@@ -1606,14 +1630,20 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
         method: '_qwen/session/shell',
         params: { sessionId: 'sess-1', command: '' },
       });
-      const frames = await takeFrames(await streamRes, 1);
-      expect(frames[0]).toMatchObject({ error: { code: -32602 } });
+      const frames = await takeFrames(await streamRes, 2);
+      expect(frames[1]).toMatchObject({ error: { code: -32602 } });
     });
 
     it('_qwen/session/shell returns result', async () => {
       const connId = await initialize();
-      await newSession(connId);
       const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 99,
+        method: 'session/new',
+        params: {},
+      });
       await new Promise((r) => setTimeout(r, 30));
       await post(connId, {
         jsonrpc: '2.0',
@@ -1621,16 +1651,22 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
         method: '_qwen/session/shell',
         params: { sessionId: 'sess-1', command: 'ls' },
       });
-      const frames = await takeFrames(await streamRes, 1);
-      expect(frames[0]).toMatchObject({
+      const frames = await takeFrames(await streamRes, 2);
+      expect(frames[1]).toMatchObject({
         result: { exitCode: 0, output: '$ ls' },
       });
     });
 
     it('_qwen/session/detach succeeds', async () => {
       const connId = await initialize();
-      await newSession(connId);
       const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 99,
+        method: 'session/new',
+        params: {},
+      });
       await new Promise((r) => setTimeout(r, 30));
       await post(connId, {
         jsonrpc: '2.0',
@@ -1638,15 +1674,21 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
         method: '_qwen/session/detach',
         params: { sessionId: 'sess-1' },
       });
-      const frames = await takeFrames(await streamRes, 1);
-      expect(frames[0]).toMatchObject({ result: { ok: true } });
+      const frames = await takeFrames(await streamRes, 2);
+      expect(frames[1]).toMatchObject({ result: { ok: true } });
       expect(bridge.detached.length).toBeGreaterThan(0);
     });
 
     it('_qwen/session/context_usage returns usage', async () => {
       const connId = await initialize();
-      await newSession(connId);
       const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 99,
+        method: 'session/new',
+        params: {},
+      });
       await new Promise((r) => setTimeout(r, 30));
       await post(connId, {
         jsonrpc: '2.0',
@@ -1654,16 +1696,22 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
         method: '_qwen/session/context_usage',
         params: { sessionId: 'sess-1' },
       });
-      const frames = await takeFrames(await streamRes, 1);
-      expect(frames[0]).toMatchObject({
+      const frames = await takeFrames(await streamRes, 2);
+      expect(frames[1]).toMatchObject({
         result: { sessionId: 'sess-1', used: 100 },
       });
     });
 
     it('_qwen/session/tasks returns tasks', async () => {
       const connId = await initialize();
-      await newSession(connId);
       const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 99,
+        method: 'session/new',
+        params: {},
+      });
       await new Promise((r) => setTimeout(r, 30));
       await post(connId, {
         jsonrpc: '2.0',
@@ -1671,8 +1719,8 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
         method: '_qwen/session/tasks',
         params: { sessionId: 'sess-1' },
       });
-      const frames = await takeFrames(await streamRes, 1);
-      expect(frames[0]).toMatchObject({
+      const frames = await takeFrames(await streamRes, 2);
+      expect(frames[1]).toMatchObject({
         result: { sessionId: 'sess-1', tasks: [] },
       });
     });

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -3080,7 +3080,12 @@ export function createServeApp(
   // decision. Mounted AFTER the REST routes (distinct path, no overlap)
   // and BEFORE the final error handler so malformed `/acp` bodies still
   // route through the JSON error contract below.
-  mountAcpHttp(app, bridge, { boundWorkspace, workspace });
+  mountAcpHttp(app, bridge, {
+    boundWorkspace,
+    workspace,
+    fsFactory,
+    deviceFlowRegistry,
+  });
 
   // Final error handler. `express.json()` throws `SyntaxError` (with
   // `status: 400`) on malformed body — without this 4-arg middleware

--- a/packages/cli/src/serve/workspaceAgents.ts
+++ b/packages/cli/src/serve/workspaceAgents.ts
@@ -1268,7 +1268,7 @@ function sanitizeRunConfig(
   return out as SubagentConfig['runConfig'];
 }
 
-function toSummary(config: SubagentConfig): ServeWorkspaceAgentSummary {
+export function toSummary(config: SubagentConfig): ServeWorkspaceAgentSummary {
   const summary: ServeWorkspaceAgentSummary = {
     kind: 'agent',
     name: config.name,
@@ -1286,7 +1286,7 @@ function toSummary(config: SubagentConfig): ServeWorkspaceAgentSummary {
   return summary;
 }
 
-function toDetail(config: SubagentConfig): ServeWorkspaceAgentDetail {
+export function toDetail(config: SubagentConfig): ServeWorkspaceAgentDetail {
   const detail: ServeWorkspaceAgentDetail = {
     ...toSummary(config),
     systemPrompt: config.systemPrompt,

--- a/packages/cli/src/serve/workspaceMemory.ts
+++ b/packages/cli/src/serve/workspaceMemory.ts
@@ -323,7 +323,7 @@ interface DiscoveredFile {
  * 16.5's responsibility per scope decision in issue #4175. Path-
  * based rules (`.qwen/rules/`) are also out of scope for v1.
  */
-async function collectWorkspaceMemoryStatus(
+export async function collectWorkspaceMemoryStatus(
   boundWorkspace: string,
 ): Promise<ServeWorkspaceMemoryStatus> {
   const filenames = new Set(getAllGeminiMdFilenames());


### PR DESCRIPTION
Replaces #4736 (auto-closed when #4563 merged). Rebased on `daemon_mode_b_main`.

See tracking issue #4782 for full context.

## Changes (single commit, +935 lines)

29 new `_qwen/*` dispatch methods achieving full ACP/REST parity:
- Session extensions (6): recap, btw, shell, detach, context_usage, tasks
- Memory (2): read + write (1MB cap, scope/mode validation)
- Files (7): read/read_bytes/stat/list/glob/write/edit (via WorkspaceFileSystem)
- Auth device-flow (4): status, start, get, cancel (verification material stripped)
- Workspace (5): tools, mcp/tools, mcp/servers add/remove, sessions/delete
- Agents CRUD (5): list, get, create, update, delete

Production hardening:
- `toRpcError`: FsError/MemoryError/AuthError/SubagentError → structured `data.errorKind`
- Error `data` propagation in both catch blocks (was silently dropped)
- BTW: `BTW_MAX_INPUT_LENGTH` (4096) validation
- Shell: `.trim()` + audit logging
- sessions/delete: 100 cap + dedup + strict types + errors preserved
- auth/status: projected (no userCode/verificationUri leak)