### PR TITLE
fix(core): preserve shared baseUrl on auth refresh

### DIFF
--- a/packages/core/src/models/modelsConfig.test.ts
+++ b/packages/core/src/models/modelsConfig.test.ts
@@ -292,6 +292,59 @@ describe('ModelsConfig', () => {
     expect(gc.maxRetries).toBe(1);
   });
 
+  it.each([
+    { kind: 'cli' as const, detail: '--base-url' },
+    { kind: 'env' as const, envKey: 'OPENAI_BASE_URL' },
+    { kind: 'settings' as const, settingsPath: 'model.baseUrl' },
+  ])(
+    'should preserve $kind baseUrl during same-model auth refresh',
+    (baseUrlSource) => {
+      const modelProvidersConfig: ModelProvidersConfig = {
+        openai: [
+          {
+            id: 'shared-base-model',
+            name: 'Shared Base Model',
+            baseUrl: 'https://provider-default.example.com/v1',
+            envKey: 'SHARED_BASE_URL_KEY',
+            generationConfig: {
+              timeout: 111,
+            },
+          },
+        ],
+      };
+
+      const modelsConfig = new ModelsConfig({
+        initialAuthType: AuthType.USE_OPENAI,
+        modelProvidersConfig,
+        generationConfig: {
+          model: 'shared-base-model',
+          baseUrl: 'https://shared-proxy.example.com/v1',
+          apiKey: 'resolved-key',
+        },
+        generationConfigSources: {
+          model: { kind: 'settings', settingsPath: 'model.name' },
+          baseUrl: baseUrlSource,
+          apiKey: { kind: 'settings', settingsPath: 'model.apiKey' },
+        },
+      });
+
+      modelsConfig.syncAfterAuthRefresh(
+        AuthType.USE_OPENAI,
+        'shared-base-model',
+      );
+
+      const gc = currentGenerationConfig(modelsConfig);
+      expect(gc.model).toBe('shared-base-model');
+      expect(gc.baseUrl).toBe('https://shared-proxy.example.com/v1');
+      expect(gc.apiKey).toBe('resolved-key');
+      expect(gc.timeout).toBe(111);
+
+      const sources = modelsConfig.getGenerationConfigSources();
+      expect(sources['baseUrl']).toEqual(baseUrlSource);
+      expect(sources['timeout']?.kind).toBe('modelProviders');
+    },
+  );
+
   it('should preserve settings generationConfig when modelId does not exist in registry', () => {
     const modelProvidersConfig: ModelProvidersConfig = {
       openai: [

--- a/packages/core/src/models/modelsConfig.ts
+++ b/packages/core/src/models/modelsConfig.ts
@@ -1011,6 +1011,21 @@ export class ModelsConfig {
           ? { ...this.generationConfigSources['apiKey'] }
           : undefined
         : undefined;
+      const baseUrlSource = this.generationConfigSources['baseUrl'];
+      const shouldPreserveResolvedBaseUrl =
+        isUnchanged &&
+        !!this._generationConfig.baseUrl &&
+        (baseUrlSource?.kind === 'cli' ||
+          baseUrlSource?.kind === 'env' ||
+          baseUrlSource?.kind === 'settings');
+      const savedBaseUrl = shouldPreserveResolvedBaseUrl
+        ? this._generationConfig.baseUrl
+        : undefined;
+      const savedBaseUrlSource = shouldPreserveResolvedBaseUrl
+        ? baseUrlSource
+          ? { ...baseUrlSource }
+          : undefined
+        : undefined;
 
       this.applyResolvedModelDefaults(resolved);
 
@@ -1020,6 +1035,12 @@ export class ModelsConfig {
         this._generationConfig.apiKey = savedApiKey;
         if (savedApiKeySource) {
           this.generationConfigSources['apiKey'] = savedApiKeySource;
+        }
+      }
+      if (savedBaseUrl) {
+        this._generationConfig.baseUrl = savedBaseUrl;
+        if (savedBaseUrlSource) {
+          this.generationConfigSources['baseUrl'] = savedBaseUrlSource;
         }
       }
 


### PR DESCRIPTION
## What this PR does

This preserves a same-model `baseUrl` that was resolved from CLI flags, environment variables, or settings during `syncAfterAuthRefresh`. It still keeps provider defaults for other generation settings, but it no longer replaces a user-provided shared endpoint with the model entry's baked-in default during a same-model auth refresh.

## Why it's needed

`syncAfterAuthRefresh()` resolves a configured model from `modelProviders`, then `applyResolvedModelDefaults()` applies that provider entry. For same-model refreshes, that could overwrite a shared `baseUrl` with a model default, making one shared endpoint unusable across multiple `modelProviders` entries unless every model repeated the same URL.

## Reviewer Test Plan

### How to verify

```bash
npm run test --workspace=packages/core -- modelsConfig.test.ts -- --testTimeout=30000
npx prettier --check packages/core/src/models/modelsConfig.ts packages/core/src/models/modelsConfig.test.ts
npx eslint packages/core/src/models/modelsConfig.ts packages/core/src/models/modelsConfig.test.ts --max-warnings 0
git diff --check
```

The regression test covers CLI/env/settings-sourced shared base URLs and confirms a same-model refresh keeps the shared endpoint.

### Evidence (Before & After)

Before: same-model auth refresh could replace the resolved shared `baseUrl` with the model entry's default endpoint.

After: same-model auth refresh keeps the already resolved shared `baseUrl` while still applying the model entry's other defaults.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node/npm workspace test environment for `packages/core`.

## Risk & Scope

- Main risk or tradeoff: low; the change only preserves an explicit already-resolved base URL for the same model.
- Not validated / out of scope: provider-specific network integration tests; this is covered at config-resolution level.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #4813.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 在 `syncAfterAuthRefresh` 期间保留已经从 CLI、环境变量或 settings 解析出的同模型 `baseUrl`。它仍然会保留 provider 默认的其他 generation 设置，但不会在同模型 auth refresh 时把用户提供的共享 endpoint 替换成模型条目里的默认 endpoint。

## 为什么需要

`syncAfterAuthRefresh()` 会从 `modelProviders` 里解析当前模型，然后 `applyResolvedModelDefaults()` 应用对应 provider entry。同模型 refresh 时，这可能把共享 `baseUrl` 覆盖成模型默认值，导致一个共享 endpoint 不能被多个 `modelProviders` 条目复用，除非每个模型都重复配置相同 URL。

## Reviewer Test Plan

### 如何验证

```bash
npm run test --workspace=packages/core -- modelsConfig.test.ts -- --testTimeout=30000
npx prettier --check packages/core/src/models/modelsConfig.ts packages/core/src/models/modelsConfig.test.ts
npx eslint packages/core/src/models/modelsConfig.ts packages/core/src/models/modelsConfig.test.ts --max-warnings 0
git diff --check
```

回归测试覆盖从 CLI/env/settings 解析出的共享 base URL，并确认同模型 refresh 会保留该 endpoint。

### Before / After 证据

Before：同模型 auth refresh 可能把已解析的共享 `baseUrl` 替换成模型 entry 的默认 endpoint。

After：同模型 auth refresh 保留已解析的共享 `baseUrl`，同时继续应用模型 entry 的其他默认值。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### 环境

`packages/core` 的 Node/npm workspace test 环境。

## 风险与范围

- 主要风险或取舍：低；改动只在同模型场景保留明确解析出的 base URL。
- 未验证 / 范围外：provider-specific 网络集成测试；这里用配置解析层单测覆盖。
- 破坏性变更 / 迁移说明：无。

## 关联 issue

Fixes #4813.

</details>