### PR TITLE
fix(auth): time out Qwen OAuth refresh

### DIFF
--- a/packages/core/src/qwen/qwenOAuth2.test.ts
+++ b/packages/core/src/qwen/qwenOAuth2.test.ts
@@ -759,9 +759,21 @@ describe('QwenOAuth2Client', () => {
                 reject(new Error('missing abort signal'));
                 return;
               }
-              signal.addEventListener('abort', () => reject(signal.reason), {
-                once: true,
-              });
+              signal.addEventListener(
+                'abort',
+                () => {
+                  reject(
+                    Object.assign(
+                      new DOMException(
+                        'The operation was aborted',
+                        'AbortError',
+                      ),
+                      { cause: signal.reason },
+                    ),
+                  );
+                },
+                { once: true },
+              );
             }),
         );
 
@@ -774,11 +786,64 @@ describe('QwenOAuth2Client', () => {
         const error = await refreshError;
         expect(error).toBeInstanceOf(Error);
         expect((error as Error).message).toContain(
-          'Token refresh failed: Operation timed out',
+          'Token refresh timeout: The operation was aborted (cause: Operation timed out)',
         );
+        expect((error as Error).cause).toBeInstanceOf(DOMException);
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    it('should keep the refresh timeout active while reading the response body', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.mocked(global.fetch).mockImplementation(async (_url, init) => {
+          const signal = (init as RequestInit).signal;
+          if (!signal) {
+            throw new Error('missing abort signal');
+          }
+          return {
+            ok: true,
+            text: () =>
+              new Promise<string>((_, reject) => {
+                signal.addEventListener('abort', () => reject(signal.reason), {
+                  once: true,
+                });
+              }),
+          } as Response;
+        });
+
+        const refreshError = client
+          .refreshAccessToken()
+          .catch((error: unknown) => error);
+
+        await vi.advanceTimersByTimeAsync(30_000);
+
+        const error = await refreshError;
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toContain('Token refresh timeout:');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should preserve non-timeout network errors and show the token endpoint', async () => {
+      const cause = Object.assign(new Error('connect ECONNREFUSED'), {
+        code: 'ECONNREFUSED',
+      });
+      const networkError = new TypeError('fetch failed', { cause });
+      vi.mocked(global.fetch).mockRejectedValue(networkError);
+
+      const error = await client
+        .refreshAccessToken()
+        .catch((refreshError: unknown) => refreshError);
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).cause).toBe(networkError);
+      expect((error as Error).message).toContain('Token refresh failed:');
+      expect((error as Error).message).toContain(
+        'https://chat.qwen.ai/api/v1/oauth2/token',
+      );
     });
 
     it('should NOT clear credentials on malformed 200 response (e.g. proxy HTML)', async () => {

--- a/packages/core/src/qwen/qwenOAuth2.test.ts
+++ b/packages/core/src/qwen/qwenOAuth2.test.ts
@@ -748,6 +748,39 @@ describe('QwenOAuth2Client', () => {
       );
     });
 
+    it('should time out hung refresh token requests', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.mocked(global.fetch).mockImplementation(
+          (_url, init) =>
+            new Promise<Response>((_, reject) => {
+              const signal = (init as RequestInit).signal;
+              if (!signal) {
+                reject(new Error('missing abort signal'));
+                return;
+              }
+              signal.addEventListener('abort', () => reject(signal.reason), {
+                once: true,
+              });
+            }),
+        );
+
+        const refreshError = client
+          .refreshAccessToken()
+          .catch((error: unknown) => error);
+
+        await vi.advanceTimersByTimeAsync(30_000);
+
+        const error = await refreshError;
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toContain(
+          'Token refresh failed: Operation timed out',
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('should NOT clear credentials on malformed 200 response (e.g. proxy HTML)', async () => {
       const { CredentialsClearRequiredError } = await import('./qwenOAuth2.js');
 

--- a/packages/core/src/qwen/qwenOAuth2.ts
+++ b/packages/core/src/qwen/qwenOAuth2.ts
@@ -88,6 +88,19 @@ function objectToUrlEncoded(data: Record<string, string>): string {
     .join('&');
 }
 
+function createTokenRefreshNetworkError(
+  error: unknown,
+  timedOut: boolean,
+): Error {
+  const prefix = timedOut ? 'Token refresh timeout' : 'Token refresh failed';
+  return new Error(
+    `${prefix}: ${formatFetchErrorForUser(error, {
+      url: QWEN_OAUTH_TOKEN_ENDPOINT,
+    })}`,
+    { cause: error },
+  );
+}
+
 /**
  * Standard error response data
  */
@@ -499,83 +512,89 @@ export class QwenOAuth2Client implements IQwenOAuth2Client {
     const { signal, cleanup } = combineAbortSignals([], {
       timeoutMs: QWEN_OAUTH_REFRESH_TIMEOUT_MS,
     });
-    let response: Response;
+    debugLogger.debug('Refreshing access token...');
+
     try {
-      response = await fetch(QWEN_OAUTH_TOKEN_ENDPOINT, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          Accept: 'application/json',
-        },
-        body: objectToUrlEncoded(bodyData),
-        signal,
-      });
-    } catch (error) {
-      throw new Error(
-        `Token refresh failed: ${formatFetchErrorForUser(error, {
-          url: QWEN_OAUTH_BASE_URL,
-        })}`,
-      );
+      let response: Response;
+      try {
+        response = await fetch(QWEN_OAUTH_TOKEN_ENDPOINT, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Accept: 'application/json',
+          },
+          body: objectToUrlEncoded(bodyData),
+          signal,
+        });
+      } catch (error) {
+        throw createTokenRefreshNetworkError(error, signal.aborted);
+      }
+
+      if (!response.ok) {
+        let errorData: string;
+        try {
+          errorData = await response.text();
+        } catch (error) {
+          throw createTokenRefreshNetworkError(error, signal.aborted);
+        }
+        // Handle 400/401 errors which indicate refresh token expiry or invalidity
+        if (response.status === 400 || response.status === 401) {
+          await clearQwenCredentials();
+          throw new CredentialsClearRequiredError(
+            "Refresh token expired or invalid. Please use '/auth' to re-authenticate.",
+            { status: response.status, response: errorData },
+          );
+        }
+        throw new Error(
+          `Token refresh failed: ${response.status} ${response.statusText}. Response: ${errorData}`,
+        );
+      }
+
+      let responseText: string;
+      try {
+        responseText = await response.text();
+      } catch (error) {
+        throw createTokenRefreshNetworkError(error, signal.aborted);
+      }
+
+      let responseData: TokenRefreshResponse;
+      try {
+        responseData = JSON.parse(responseText) as TokenRefreshResponse;
+      } catch {
+        throw new Error(
+          `Qwen OAuth refresh returned invalid JSON: ${responseText || '(empty response body)'}`,
+        );
+      }
+
+      // Check if the response indicates success
+      if (isErrorResponse(responseData)) {
+        const errorData = responseData as ErrorData;
+        throw new Error(
+          `Token refresh failed: ${errorData?.error || 'Unknown error'} - ${errorData?.error_description || 'No details provided'}`,
+        );
+      }
+
+      // Handle successful response
+      const tokenData = responseData as TokenRefreshData;
+      const tokens: QwenCredentials = {
+        access_token: tokenData.access_token,
+        token_type: tokenData.token_type,
+        // Use new refresh token if provided, otherwise preserve existing one
+        refresh_token:
+          tokenData.refresh_token || this.credentials.refresh_token,
+        resource_url: tokenData.resource_url, // Include resource_url if provided
+        expiry_date: Date.now() + tokenData.expires_in * 1000,
+      };
+
+      this.setCredentials(tokens);
+
+      // Note: File caching is now handled by SharedTokenManager
+      // to prevent cross-session token invalidation issues
+
+      return responseData;
     } finally {
       cleanup();
     }
-
-    if (!response.ok) {
-      const errorData = await response.text();
-      // Handle 400/401 errors which indicate refresh token expiry or invalidity
-      if (response.status === 400 || response.status === 401) {
-        await clearQwenCredentials();
-        throw new CredentialsClearRequiredError(
-          "Refresh token expired or invalid. Please use '/auth' to re-authenticate.",
-          { status: response.status, response: errorData },
-        );
-      }
-      throw new Error(
-        `Token refresh failed: ${response.status} ${response.statusText}. Response: ${errorData}`,
-      );
-    }
-
-    let responseText: string;
-    try {
-      responseText = await response.text();
-    } catch {
-      responseText = '';
-    }
-
-    let responseData: TokenRefreshResponse;
-    try {
-      responseData = JSON.parse(responseText) as TokenRefreshResponse;
-    } catch {
-      throw new Error(
-        `Qwen OAuth refresh returned invalid JSON: ${responseText || '(empty response body)'}`,
-      );
-    }
-
-    // Check if the response indicates success
-    if (isErrorResponse(responseData)) {
-      const errorData = responseData as ErrorData;
-      throw new Error(
-        `Token refresh failed: ${errorData?.error || 'Unknown error'} - ${errorData?.error_description || 'No details provided'}`,
-      );
-    }
-
-    // Handle successful response
-    const tokenData = responseData as TokenRefreshData;
-    const tokens: QwenCredentials = {
-      access_token: tokenData.access_token,
-      token_type: tokenData.token_type,
-      // Use new refresh token if provided, otherwise preserve existing one
-      refresh_token: tokenData.refresh_token || this.credentials.refresh_token,
-      resource_url: tokenData.resource_url, // Include resource_url if provided
-      expiry_date: Date.now() + tokenData.expires_in * 1000,
-    };
-
-    this.setCredentials(tokens);
-
-    // Note: File caching is now handled by SharedTokenManager
-    // to prevent cross-session token invalidation issues
-
-    return responseData;
   }
 }
 

--- a/packages/core/src/qwen/qwenOAuth2.ts
+++ b/packages/core/src/qwen/qwenOAuth2.ts
@@ -14,6 +14,7 @@ import type { Config } from '../config/config.js';
 import { randomUUID } from 'node:crypto';
 import { formatFetchErrorForUser } from '../utils/fetch.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import { combineAbortSignals } from '../utils/abortController.js';
 import {
   SharedTokenManager,
   TokenManagerError,
@@ -34,6 +35,7 @@ const QWEN_OAUTH_CLIENT_ID = 'f0304373b74a44d2b584a3fb70ca9e56';
 
 const QWEN_OAUTH_SCOPE = 'openid profile email model.completion';
 const QWEN_OAUTH_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code';
+const QWEN_OAUTH_REFRESH_TIMEOUT_MS = 30_000;
 
 // File System Configuration
 const QWEN_CREDENTIAL_FILENAME = 'oauth_creds.json';
@@ -494,14 +496,29 @@ export class QwenOAuth2Client implements IQwenOAuth2Client {
       client_id: QWEN_OAUTH_CLIENT_ID,
     };
 
-    const response = await fetch(QWEN_OAUTH_TOKEN_ENDPOINT, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-        Accept: 'application/json',
-      },
-      body: objectToUrlEncoded(bodyData),
+    const { signal, cleanup } = combineAbortSignals([], {
+      timeoutMs: QWEN_OAUTH_REFRESH_TIMEOUT_MS,
     });
+    let response: Response;
+    try {
+      response = await fetch(QWEN_OAUTH_TOKEN_ENDPOINT, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Accept: 'application/json',
+        },
+        body: objectToUrlEncoded(bodyData),
+        signal,
+      });
+    } catch (error) {
+      throw new Error(
+        `Token refresh failed: ${formatFetchErrorForUser(error, {
+          url: QWEN_OAUTH_BASE_URL,
+        })}`,
+      );
+    } finally {
+      cleanup();
+    }
 
     if (!response.ok) {
       const errorData = await response.text();

--- a/packages/core/src/qwen/sharedTokenManager.ts
+++ b/packages/core/src/qwen/sharedTokenManager.ts
@@ -28,7 +28,8 @@ const QWEN_LOCK_FILENAME = 'oauth_creds.lock';
 
 // Token and Cache Configuration
 const TOKEN_REFRESH_BUFFER_MS = 30 * 1000; // 30 seconds
-const LOCK_TIMEOUT_MS = 10000; // 10 seconds lock timeout
+// Must exceed QWEN_OAUTH_REFRESH_TIMEOUT_MS so an in-flight refresh keeps its lock.
+const LOCK_TIMEOUT_MS = 35_000;
 const CACHE_CHECK_INTERVAL_MS = 5000; // 5 seconds cache check interval (increased from 1 second)
 
 // Lock acquisition configuration (can be overridden for testing)


### PR DESCRIPTION
## What this PR does

This adds a timeout to the Qwen OAuth refresh-token request. If the refresh endpoint accepts the connection but never returns, the request now aborts instead of leaving CLI startup stuck behind an unbounded fetch. The existing HTTP response handling is unchanged once a response is received.

## Why it's needed

The Qwen OAuth refresh path currently calls fetch without an abort signal. A stale OAuth credential, a blocked network path, or an internal/offline environment can therefore make startup wait indefinitely before the CLI can recover. This PR only covers the Qwen OAuth refresh-token path; it does not claim to fix API-key/OpenAI-provider startup hangs.

## Reviewer Test Plan

### How to verify

Run the focused unit test and the normal TypeScript checks for the touched core package:

```bash
npm run test --workspace @qwen-code/qwen-code-core -- qwenOAuth2.test.ts
npx eslint packages/core/src/qwen/qwenOAuth2.ts packages/core/src/qwen/qwenOAuth2.test.ts --ext .ts
npm run typecheck --workspace @qwen-code/qwen-code-core
```

The regression test keeps the mocked refresh fetch unresolved and verifies that the refresh path rejects on timeout instead of waiting forever.

### Evidence (Before & After)

Before: a pending refresh-token fetch had no abort signal, so the refresh path could wait forever.

After: the refresh-token fetch gets a timeout signal and rejects once the timeout expires; ordinary HTTP response handling still follows the existing code path.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node/npm workspace test environment for `@qwen-code/qwen-code-core`.

## Risk & Scope

- Main risk or tradeoff: the timeout value must be long enough for slow but healthy networks. This uses the same defensive shape as other bounded network operations rather than changing auth routing.
- Not validated / out of scope: this does not fix API-key/OpenAI-provider startup hangs, because those do not reach Qwen OAuth refresh.
- Breaking changes / migration notes: none.

## Linked Issues

References #4550 for the broader startup-hang discussion, but this PR does not close it because the reported API-key path is separate from Qwen OAuth refresh.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 给 Qwen OAuth refresh-token 请求加了超时。如果 refresh endpoint 建立连接后一直不返回，CLI 启动不会再卡在一个没有边界的 fetch 上。只要服务端正常返回响应，原有 HTTP response 处理逻辑保持不变。

## 为什么需要

当前 Qwen OAuth refresh 路径调用 fetch 时没有 abort signal。过期 OAuth 凭据、被阻断的网络路径或内网/离线环境，都可能让启动流程无限等待。这个 PR 只覆盖 Qwen OAuth refresh-token 路径，不声称修复 API key / OpenAI provider 的启动卡住问题。

## Reviewer Test Plan

### 如何验证

运行针对改动的单测和 core package 的常规 TypeScript 检查：

```bash
npm run test --workspace @qwen-code/qwen-code-core -- qwenOAuth2.test.ts
npx eslint packages/core/src/qwen/qwenOAuth2.ts packages/core/src/qwen/qwenOAuth2.test.ts --ext .ts
npm run typecheck --workspace @qwen-code/qwen-code-core
```

新增回归测试会让 mocked refresh fetch 一直 pending，并验证 refresh 路径会因为 timeout reject，而不是无限等待。

### Before / After 证据

Before：refresh-token fetch 没有 abort signal，所以 refresh 路径可能永远等下去。

After：refresh-token fetch 带有 timeout signal，到时间会 reject；普通 HTTP response 仍走原逻辑。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### 环境

`@qwen-code/qwen-code-core` 的 Node/npm workspace test 环境。

## 风险与范围

- 主要风险或取舍：timeout 要足够长，避免误伤慢但正常的网络。这里采用的是给网络操作加边界的防御性修复，不改变 auth routing。
- 未验证 / 范围外：不修 API key / OpenAI provider 的启动卡住，因为那条路径不会走 Qwen OAuth refresh。
- 破坏性变更 / 迁移说明：无。

## 关联 issue

参考 #4550 的启动卡住讨论，但本 PR 不关闭该 issue，因为报告里的 API-key 路径和 Qwen OAuth refresh 是两条路径。

</details>