### PR TITLE
fix: include extension examples in bundle assets

### DIFF
--- a/scripts/copy_bundle_assets.js
+++ b/scripts/copy_bundle_assets.js
@@ -18,85 +18,106 @@
 // limitations under the License.
 
 import { copyFileSync, existsSync, mkdirSync, statSync } from 'node:fs';
-import { dirname, join, basename } from 'node:path';
+import { dirname, join, basename, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { glob } from 'glob';
 import fs from 'node:fs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const root = join(__dirname, '..');
-const distDir = join(root, 'dist');
-const coreVendorDir = join(root, 'packages', 'core', 'vendor');
 
-// Create the dist directory if it doesn't exist
-if (!existsSync(distDir)) {
-  mkdirSync(distDir);
-}
+export function copyBundleAssets(root = join(__dirname, '..')) {
+  const distDir = join(root, 'dist');
+  const coreVendorDir = join(root, 'packages', 'core', 'vendor');
 
-// Find and copy all .sb files from packages to the root of the dist directory
-const sbFiles = glob.sync('packages/**/*.sb', { cwd: root });
-for (const file of sbFiles) {
-  copyFileSync(join(root, file), join(distDir, basename(file)));
-}
+  // Create the dist directory if it doesn't exist
+  if (!existsSync(distDir)) {
+    mkdirSync(distDir);
+  }
 
-console.log('Copied sandbox profiles to dist/');
+  // Find and copy all .sb files from packages to the root of the dist directory
+  const sbFiles = glob.sync('packages/**/*.sb', { cwd: root });
+  for (const file of sbFiles) {
+    copyFileSync(join(root, file), join(distDir, basename(file)));
+  }
 
-// Copy vendor directory (contains ripgrep binaries)
-console.log('Copying vendor directory...');
-if (existsSync(coreVendorDir)) {
-  const destVendorDir = join(distDir, 'vendor');
-  copyRecursiveSync(coreVendorDir, destVendorDir);
-  console.log('Copied vendor directory to dist/');
-} else {
-  console.warn(`Warning: Vendor directory not found at ${coreVendorDir}`);
-}
+  console.log('Copied sandbox profiles to dist/');
 
-// Copy bundled skills (e.g. /review) so they are available at runtime.
-// In the esbuild bundle, import.meta.url resolves to dist/cli.js, so
-// SkillManager looks for bundled skills at dist/bundled/.
-const bundledSkillsDir = join(
-  root,
-  'packages',
-  'core',
-  'src',
-  'skills',
-  'bundled',
-);
-if (existsSync(bundledSkillsDir)) {
-  const destBundledDir = join(distDir, 'bundled');
-  copyRecursiveSync(bundledSkillsDir, destBundledDir);
-  console.log('Copied bundled skills to dist/bundled/');
-} else {
-  console.warn(
-    `Warning: Bundled skills directory not found at ${bundledSkillsDir}`,
+  // Copy vendor directory (contains ripgrep binaries)
+  console.log('Copying vendor directory...');
+  if (existsSync(coreVendorDir)) {
+    const destVendorDir = join(distDir, 'vendor');
+    copyRecursiveSync(coreVendorDir, destVendorDir);
+    console.log('Copied vendor directory to dist/');
+  } else {
+    console.warn(`Warning: Vendor directory not found at ${coreVendorDir}`);
+  }
+
+  // Copy bundled skills (e.g. /review) so they are available at runtime.
+  // In the esbuild bundle, import.meta.url resolves to dist/cli.js, so
+  // SkillManager looks for bundled skills at dist/bundled/.
+  const bundledSkillsDir = join(
+    root,
+    'packages',
+    'core',
+    'src',
+    'skills',
+    'bundled',
   );
-}
+  if (existsSync(bundledSkillsDir)) {
+    const destBundledDir = join(distDir, 'bundled');
+    copyRecursiveSync(bundledSkillsDir, destBundledDir);
+    console.log('Copied bundled skills to dist/bundled/');
+  } else {
+    console.warn(
+      `Warning: Bundled skills directory not found at ${bundledSkillsDir}`,
+    );
+  }
 
-// Copy user docs into qc-helper bundled skill so it can reference them at runtime.
-// The qc-helper skill reads docs from a `docs/` subdirectory relative to its own
-// directory. In the esbuild bundle this becomes dist/bundled/qc-helper/docs/.
-const userDocsDir = join(root, 'docs', 'users');
-if (existsSync(userDocsDir)) {
-  const destDocsDir = join(distDir, 'bundled', 'qc-helper', 'docs');
-  copyRecursiveSync(userDocsDir, destDocsDir);
-  console.log('Copied docs/users/ to dist/bundled/qc-helper/docs/');
-} else {
-  console.warn(`Warning: User docs directory not found at ${userDocsDir}`);
-}
+  // Copy user docs into qc-helper bundled skill so it can reference them at runtime.
+  // The qc-helper skill reads docs from a `docs/` subdirectory relative to its own
+  // directory. In the esbuild bundle this becomes dist/bundled/qc-helper/docs/.
+  const userDocsDir = join(root, 'docs', 'users');
+  if (existsSync(userDocsDir)) {
+    const destDocsDir = join(distDir, 'bundled', 'qc-helper', 'docs');
+    copyRecursiveSync(userDocsDir, destDocsDir);
+    console.log('Copied docs/users/ to dist/bundled/qc-helper/docs/');
+  } else {
+    console.warn(`Warning: User docs directory not found at ${userDocsDir}`);
+  }
 
-// Copy builtin locales so bundled dist/cli.js can load UI translations at runtime.
-// Published packages already include these via prepare-package.js; bundle output
-// should mirror that behavior for local `node dist/cli.js` runs.
-const localesDir = join(root, 'packages', 'cli', 'src', 'i18n', 'locales');
-if (existsSync(localesDir)) {
-  const destLocalesDir = join(distDir, 'locales');
-  copyRecursiveSync(localesDir, destLocalesDir);
-  console.log('Copied builtin locales to dist/locales/');
-} else {
-  console.warn(`Warning: Locales directory not found at ${localesDir}`);
-}
+  // Copy builtin locales so bundled dist/cli.js can load UI translations at runtime.
+  // Published packages already include these via prepare-package.js; bundle output
+  // should mirror that behavior for local `node dist/cli.js` runs.
+  const localesDir = join(root, 'packages', 'cli', 'src', 'i18n', 'locales');
+  if (existsSync(localesDir)) {
+    const destLocalesDir = join(distDir, 'locales');
+    copyRecursiveSync(localesDir, destLocalesDir);
+    console.log('Copied builtin locales to dist/locales/');
+  } else {
+    console.warn(`Warning: Locales directory not found at ${localesDir}`);
+  }
 
-console.log('\n✅ All bundle assets copied to dist/');
+  const extensionExamplesDir = join(
+    root,
+    'packages',
+    'cli',
+    'src',
+    'commands',
+    'extensions',
+    'examples',
+  );
+  if (existsSync(extensionExamplesDir)) {
+    const destExamplesDir = join(distDir, 'examples');
+    copyRecursiveSync(extensionExamplesDir, destExamplesDir);
+    console.log('Copied extension examples to dist/examples/');
+  } else {
+    console.warn(
+      `Warning: Extension examples directory not found at ${extensionExamplesDir}`,
+    );
+  }
+
+  console.log('\n✅ All bundle assets copied to dist/');
+}
 
 /**
  * Recursively copy directory
@@ -132,4 +153,8 @@ function copyRecursiveSync(src, dest) {
       fs.chmodSync(dest, srcStats.mode);
     }
   }
+}
+
+if (resolve(process.argv[1] ?? '') === fileURLToPath(import.meta.url)) {
+  copyBundleAssets();
 }

--- a/scripts/tests/copy-bundle-assets.test.js
+++ b/scripts/tests/copy-bundle-assets.test.js
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdtemp, mkdir, readFile, writeFile, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { copyBundleAssets } from '../copy_bundle_assets.js';
+
+const tempRoots = [];
+
+describe('copyBundleAssets', () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempRoots
+        .splice(0)
+        .map((root) => rm(root, { recursive: true, force: true })),
+    );
+  });
+
+  it('copies extension boilerplate examples into dist', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'qwen-bundle-assets-'));
+    tempRoots.push(root);
+
+    await mkdir(join(root, 'packages'), { recursive: true });
+    await writeFile(join(root, 'packages', 'sandbox.sb'), 'sandbox');
+    await mkdir(join(root, 'packages', 'core', 'vendor', 'rg'), {
+      recursive: true,
+    });
+    await writeFile(
+      join(root, 'packages', 'core', 'vendor', 'rg', 'README'),
+      'rg',
+    );
+    await mkdir(
+      join(root, 'packages', 'core', 'src', 'skills', 'bundled', 'review'),
+      { recursive: true },
+    );
+    await writeFile(
+      join(
+        root,
+        'packages',
+        'core',
+        'src',
+        'skills',
+        'bundled',
+        'review',
+        'SKILL.md',
+      ),
+      'review',
+    );
+    await mkdir(join(root, 'docs', 'users'), { recursive: true });
+    await writeFile(join(root, 'docs', 'users', 'commands.md'), 'commands');
+    await mkdir(join(root, 'packages', 'cli', 'src', 'i18n', 'locales'), {
+      recursive: true,
+    });
+    await writeFile(
+      join(root, 'packages', 'cli', 'src', 'i18n', 'locales', 'en.json'),
+      '{}',
+    );
+    await mkdir(
+      join(
+        root,
+        'packages',
+        'cli',
+        'src',
+        'commands',
+        'extensions',
+        'examples',
+        'mcp-server',
+      ),
+      { recursive: true },
+    );
+    await writeFile(
+      join(
+        root,
+        'packages',
+        'cli',
+        'src',
+        'commands',
+        'extensions',
+        'examples',
+        'mcp-server',
+        'qwen-extension.json',
+      ),
+      '{"name":"mcp-server"}',
+    );
+
+    copyBundleAssets(root);
+
+    expect(existsSync(join(root, 'dist', 'sandbox.sb'))).toBe(true);
+    expect(existsSync(join(root, 'dist', 'examples', 'mcp-server'))).toBe(true);
+    await expect(
+      readFile(
+        join(root, 'dist', 'examples', 'mcp-server', 'qwen-extension.json'),
+        'utf-8',
+      ),
+    ).resolves.toContain('mcp-server');
+  });
+});


### PR DESCRIPTION
## What this PR does

This moves extension-example copying into the shared bundle asset step. `qwen extensions new` reads boilerplates from `dist/examples`, but the regular `npm run bundle` path only invoked `scripts/copy_bundle_assets.js`; extension examples were copied separately by `prepare-package.js`. With this change, local bundle output and package preparation use the same asset-copy path.

The patch also adds focused script coverage using a temporary repo layout, so the regression does not depend on the developer's real workspace state.

## Why it's needed

Issue #4718 reports that generated extension boilerplates are missing from the bundled output. That makes `qwen extensions new` fail in installed or packaged builds even though the source tree has the examples. Keeping the examples in the shared bundle asset step makes the packaged CLI behavior match the source-tree behavior.

## Reviewer Test Plan

### How to verify

```bash
npm exec -- vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/copy-bundle-assets.test.js
npm exec -- prettier --check scripts/copy_bundle_assets.js scripts/tests/copy-bundle-assets.test.js
npm exec -- eslint scripts/copy_bundle_assets.js scripts/tests/copy-bundle-assets.test.js --max-warnings 0
git diff --check
node scripts/copy_bundle_assets.js
```

I also ran a secret scan on the touched script/test files and `git fsck --no-progress`.

### Evidence (Before & After)

Before: `npm run bundle` could finish without creating `dist/examples`, while `prepare-package.js` copied those examples through a separate path. A bundled CLI could therefore miss the extension boilerplates that `qwen extensions new` expects.

After: `scripts/copy_bundle_assets.js` copies `examples/extensions` into `dist/examples`, and the new temp-layout test asserts the generated files are present in the bundle output.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Windows PowerShell with the existing repository Node/npm workspace. I also tried `npm run bundle`; it failed before reaching `copy_bundle_assets.js` because the reused local `node_modules` is incomplete and esbuild could not resolve packages such as `undici`, `fdir`, `ajv/dist/2020.js`, and several workspace channel package `dist/*.js` entrypoints. The standalone asset script smoke test above validates the changed packaging step once dependencies are present.

## Risk & Scope

- Main risk or tradeoff: the copy step now includes extension examples whenever bundle assets are copied. This is intentional so package and local bundle output stay aligned.
- Not validated / out of scope: this does not rebuild the whole package in the current Windows worktree because local dependencies are incomplete.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #4718.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 把 extension 示例复制逻辑移动到统一的 bundle asset 步骤里。`qwen extensions new` 会从 `dist/examples` 读取模板，但普通 `npm run bundle` 只运行 `scripts/copy_bundle_assets.js`；extension 示例之前只在 `prepare-package.js` 里单独复制。改完后，本地 bundle 输出和 package 准备流程会走同一条 asset-copy 路径。

同时新增了一个基于临时 repo layout 的脚本测试，避免测试依赖开发者真实工作区状态。

## 为什么需要

#4718 报告了 bundled output 缺少 extension boilerplates 的问题。源码树里有示例，但安装或打包后的 CLI 可能缺少这些文件，导致 `qwen extensions new` 找不到模板。把 examples 放进统一 bundle asset 步骤后，打包版 CLI 行为和源码树保持一致。

## Reviewer Test Plan

### 如何验证

```bash
npm exec -- vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/copy-bundle-assets.test.js
npm exec -- prettier --check scripts/copy_bundle_assets.js scripts/tests/copy-bundle-assets.test.js
npm exec -- eslint scripts/copy_bundle_assets.js scripts/tests/copy-bundle-assets.test.js --max-warnings 0
git diff --check
node scripts/copy_bundle_assets.js
```

我还对改动的脚本和测试文件做了 secret scan，并运行了 `git fsck --no-progress`。

### Before / After 证据

Before：`npm run bundle` 可能不会生成 `dist/examples`，而 `prepare-package.js` 通过另一条路径复制 examples；因此 bundled CLI 可能缺少 `qwen extensions new` 需要的模板。

After：`scripts/copy_bundle_assets.js` 会把 `examples/extensions` 复制到 `dist/examples`，新增测试也断言 bundle 输出里存在这些文件。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### 环境

Windows PowerShell，使用当前仓库已有 Node/npm workspace。我也尝试了 `npm run bundle`；它在执行到 `copy_bundle_assets.js` 前失败，因为本地复用的 `node_modules` 不完整，esbuild 无法解析 `undici`、`fdir`、`ajv/dist/2020.js` 和若干 workspace channel package 的 `dist/*.js` 入口。上面的 standalone asset script smoke 已验证依赖齐全时的改动路径。

## 风险与范围

- 主要风险或取舍：bundle asset 复制时会同时带上 extension examples。这是预期行为，用来保证 package 和本地 bundle 输出一致。
- 未验证 / 范围外：当前 Windows worktree 依赖不完整，因此没有完成整包 `npm run bundle`。
- 破坏性变更 / 迁移说明：无。

## 关联 issue

Fixes #4718.

</details>
