### PR TITLE
feat(daemon): session idle reaper for automatic cleanup

### DIFF
--- a/docs/design/session-idle-reaper/README.md
+++ b/docs/design/session-idle-reaper/README.md
@@ -1,0 +1,419 @@
+# Session Idle Reaper — Design Document
+
+**Status:** Draft  
+**Author:** qinqi  
+**Date:** 2026-06-08  
+**Scope:** `packages/acp-bridge/src/bridge.ts`, `packages/cli/src/serve/server.ts`
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Current behavior
+
+Once created, a bridge session lives in memory (`byId: Map<string, SessionEntry>`)
+indefinitely. It is only destroyed when:
+
+1. A client explicitly calls `DELETE /session/:id` (`closeSession`)
+2. The shared `qwen --acp` child process crashes (`channel.exited` handler)
+3. The daemon process receives `SIGTERM` / `SIGINT` (`shutdown`)
+
+There is **no automatic idle timeout** for sessions. The heartbeat timestamps
+(`sessionLastSeenAt`, `clientLastSeenAt`) are recorded by `recordHeartbeat` but
+never consumed for eviction purposes (the field comment references a future
+"revocation policy (PR 24)" that has not landed).
+
+### 1.2 Impact
+
+| Scenario                                                                        | Symptom                                                                         |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| User opens multiple browser tabs, closes them without calling `DELETE /session` | Sessions accumulate in `byId`, each holding an EventBus ring (~2-4 MB)          |
+| 20 sessions (default `maxSessions`) accumulate                                  | `SessionLimitExceededError` on new `spawnOrAttach` — user locked out            |
+| Long-lived daemon with tab churn                                                | Unbounded memory growth in the EventBus replay rings and ACP-side session state |
+| IDE extension restarts / crashes                                                | Orphaned sessions never cleaned up                                              |
+
+### 1.3 Why now
+
+The daemon is increasingly used as a long-running workspace server (desktop app,
+IDE extensions, web UI). Client crashes and network blips are normal — relying on
+explicit `DELETE` for cleanup is untenable.
+
+---
+
+## 2. Design Goals
+
+1. **Automatically reclaim idle sessions** whose clients are gone and that have
+   no active work in progress.
+2. **Never destroy a session that has an active prompt** — doing so would
+   silently kill user-visible work.
+3. **Preserve persisted session data** — only in-memory bridge state is released;
+   disk transcripts (`SessionService`) are untouched. Users can `session/load` or
+   `session/resume` to restore.
+4. **Observable** — emit a distinct SSE event so clients know WHY the session
+   closed (idle timeout vs. explicit close vs. crash).
+5. **Configurable** — operators and tests can tune timeouts or disable the
+   reaper entirely.
+6. **Zero new dependencies / components** — implement entirely within the
+   existing bridge closure.
+
+### Non-goals
+
+- Cross-workspace session management (that would be a gateway concern).
+- LRU eviction at `maxSessions` boundary (valuable but separate work — tracked
+  as a follow-up).
+- EventBus ring compaction for idle sessions (low priority given the 20-session
+  cap; tracked as a follow-up).
+- RSS-based adaptive pressure (requires `process.memoryUsage()` polling and
+  policy design; tracked as a follow-up).
+
+---
+
+## 3. Architecture
+
+### 3.1 Overview
+
+```
+Bridge closure (createHttpAcpBridge)
+│
+├─ byId: Map<sessionId, SessionEntry>     ← existing
+├─ channelInfo: ChannelInfo               ← existing
+├─ idleTimer (channel-level)              ← existing
+│
+└─ sessionReaper: NodeJS.Timeout          ← NEW
+     │
+     ├─ scans byId every REAP_INTERVAL_MS
+     ├─ skips sessions with active prompt
+     ├─ skips sessions with live SSE subscribers
+     ├─ closes sessions exceeding idle TTL
+     └─ emits session_closed { reason: 'idle_timeout' }
+```
+
+### 3.2 Relationship to existing mechanisms
+
+| Mechanism                                 | Scope                     | What it manages                                                                  |
+| ----------------------------------------- | ------------------------- | -------------------------------------------------------------------------------- |
+| `channelIdleTimeoutMs` + `startIdleTimer` | Channel (child process)   | Kills the `qwen --acp` child when ALL sessions are gone                          |
+| **Session reaper** (this design)          | Session (in-memory entry) | Closes individual sessions when idle                                             |
+| `ConnectionRegistry` sweep                | ACP-over-HTTP connection  | Reaps `/acp` transport-layer connections (different layer)                       |
+| `writerIdleTimeoutMs`                     | SSE subscriber            | Evicts a single stuck SSE subscriber                                             |
+| Disconnect reaper (server.ts)             | Spawn handshake           | Reaps sessions whose spawn-owner disconnected DURING the POST /session handshake |
+
+The session reaper fills the gap between "spawn-handshake reaper" (covers only
+the creation window) and "channel idle timer" (fires only when ALL sessions are
+gone). It covers the common case: a session was created successfully, used for a
+while, and then the client disappeared.
+
+---
+
+## 4. Detailed Design
+
+### 4.1 New configuration options (`BridgeOptions`)
+
+```typescript
+interface BridgeOptions {
+  // ... existing fields ...
+
+  /**
+   * How often the session reaper scans `byId` for idle sessions, in
+   * milliseconds. Default: 60_000 (1 minute). Set to 0 or Infinity to
+   * disable the reaper entirely. The timer is `.unref()`'d.
+   */
+  sessionReapIntervalMs?: number;
+
+  /**
+   * A session with ZERO live SSE subscribers AND ZERO registered clients
+   * that has not received a heartbeat for this many milliseconds is
+   * considered idle and will be reaped.
+   *
+   * Default: 30 * 60_000 (30 minutes).
+   * Set to 0 or Infinity to disable idle reaping.
+   */
+  sessionIdleTimeoutMs?: number;
+}
+```
+
+**CLI surface** (`qwen serve` flags):
+
+```
+--session-reap-interval-ms <ms>   Reaper scan interval (default 60000, 0=disable)
+--session-idle-timeout-ms <ms>    Idle threshold (default 1800000, 0=disable)
+```
+
+### 4.2 Session idle predicate
+
+A session is eligible for reaping when **all** of the following hold:
+
+1. **No active prompt**: `entry.activePromptOriginatorClientId === undefined`
+2. **No live SSE subscribers**: `entry.events.subscriberCount === 0`
+3. **No registered clients**: `entry.clientIds.size === 0`
+4. **Idle duration exceeded**: `now - lastActivity(entry) > sessionIdleTimeoutMs`
+
+Where `lastActivity(entry)` is defined as:
+
+```typescript
+function lastActivity(entry: SessionEntry): number {
+  // `sessionLastSeenAt` is epoch-ms (from Date.now());
+  // `createdAt` is an ISO 8601 string — parse to epoch-ms as fallback.
+  return entry.sessionLastSeenAt ?? Date.parse(entry.createdAt);
+}
+```
+
+Note: `entry.createdAt` is typed as `string` (ISO 8601), not a number.
+`Date.parse` is safe here — the format is always `new Date().toISOString()`
+(see `createSessionEntry`, bridge.ts:1883).
+
+**Rationale for each guard:**
+
+| Guard                 | Why                                                                                                                         |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| No active prompt      | A headless / autonomous prompt (e.g. CLI pipe, cron job) may be running with no SSE subscriber. Reaping it would kill work. |
+| No SSE subscribers    | A connected client is actively listening. Even if it hasn't sent a heartbeat, the SSE connection itself proves liveness.    |
+| No registered clients | A client that registered its `clientId` but hasn't yet opened SSE is still considered "present".                            |
+| Idle duration         | Grace period so briefly-disconnected clients can reconnect without losing their session.                                    |
+
+### 4.3 Reap action
+
+For each session that passes the idle predicate, the reaper calls:
+
+```typescript
+await closeSession(sessionId, { reason: 'idle_timeout' });
+```
+
+This reuses the existing `closeSession` path which:
+
+1. Removes from `byId` / `defaultEntry`
+2. Cancels pending permissions via `permissionMediator.forgetSession`
+3. Publishes `session_closed` event (with `reason: 'idle_timeout'`)
+4. Closes the EventBus
+5. Sends `connection.cancel()` to the ACP child (best-effort)
+6. Triggers `startIdleTimer` on the channel if it was the last session
+
+**Why `closeSession` and not `killSession`?**
+
+`killSession` is the internal force-reap path designed for the spawn-handshake
+disconnect race (`requireZeroAttaches` guard, `spawnOwnerWantedKill` tombstone).
+`closeSession` is the documented client-facing path that publishes
+`session_closed` (not `session_died`) and handles telemetry correctly. The reaper
+is a "graceful close on behalf of an absent client", so `closeSession` is the
+right semantic.
+
+### 4.4 Extending `closeSession` to accept a close reason
+
+Currently `closeSession` hardcodes `reason: 'client_close'` in the
+`session_closed` event. We need to make this parameterizable.
+
+**Approach:** Add a new optional `opts` parameter to `closeSession` rather than
+overloading `BridgeClientRequestContext` (which is a client-request-scoped
+type — adding `reason` to it would be a layer violation since "reason" is a
+server-side decision, not something a client passes in a header).
+
+```typescript
+// bridgeTypes.ts — new type + signature change:
+export interface CloseSessionOpts {
+  /** Override the default 'client_close' reason in the session_closed event. */
+  reason?: string;
+}
+
+closeSession(
+  sessionId: string,
+  context?: BridgeClientRequestContext,
+  opts?: CloseSessionOpts,
+): Promise<void>;
+```
+
+```typescript
+// bridge.ts — implementation change:
+async closeSession(sessionId, context, opts) {
+  // ...
+  const reason = opts?.reason ?? 'client_close';
+  entry.events.publish({
+    type: 'session_closed',
+    data: { sessionId, reason, ... },
+  });
+}
+```
+
+Existing callers (`DELETE /session/:id` route) pass no `opts`, defaulting to
+`'client_close'`. The reaper passes `{ reason: 'idle_timeout' }`.
+
+### 4.5 Reaper lifecycle
+
+```typescript
+// Inside createHttpAcpBridge closure:
+
+const resolvedReapIntervalMs = resolvePositiveMs(
+  opts.sessionReapIntervalMs,
+  60_000,
+);
+const resolvedIdleTimeoutMs = resolvePositiveMs(
+  opts.sessionIdleTimeoutMs,
+  30 * 60_000,
+);
+
+let sessionReaper: ReturnType<typeof setInterval> | undefined;
+
+function startSessionReaper(): void {
+  if (resolvedReapIntervalMs <= 0 || resolvedIdleTimeoutMs <= 0) return;
+  sessionReaper = setInterval(() => {
+    if (shuttingDown) return;
+    const now = Date.now();
+    for (const [id, entry] of byId) {
+      if (entry.activePromptOriginatorClientId !== undefined) continue;
+      if (entry.events.subscriberCount > 0) continue;
+      if (entry.clientIds.size > 0) continue;
+      const lastActive = entry.sessionLastSeenAt ?? Date.parse(entry.createdAt);
+      const idle = now - lastActive;
+      if (idle < resolvedIdleTimeoutMs) continue;
+      writeStderrLine(
+        `qwen serve: reaping idle session ${JSON.stringify(id)} ` +
+          `(idle for ${Math.round(idle / 1000)}s, threshold ${Math.round(resolvedIdleTimeoutMs / 1000)}s)`,
+      );
+      // Pass `undefined` context (no client) and `{ reason }` opts.
+      bridgeImpl
+        .closeSession(id, undefined, { reason: 'idle_timeout' })
+        .catch((err) => {
+          writeStderrLine(
+            `qwen serve: session reaper failed to close ${JSON.stringify(id)}: ${String(err)}`,
+          );
+        });
+    }
+  }, resolvedReapIntervalMs);
+  sessionReaper.unref();
+}
+
+function stopSessionReaper(): void {
+  if (sessionReaper !== undefined) {
+    clearInterval(sessionReaper);
+    sessionReaper = undefined;
+  }
+}
+```
+
+Note: `bridgeImpl` refers to the bridge object returned by `createHttpAcpBridge`
+so `closeSession` has full access to the closure-scoped state. In practice, this
+is implemented as a direct call to the closure-internal `closeSessionImpl`
+function.
+
+**Lifecycle integration:**
+
+- `startSessionReaper()` is called at bridge construction time (after
+  option validation, alongside the existing `channelIdleTimeoutMs` setup).
+- `stopSessionReaper()` is called in both `shutdown()` and `killAllSync()`.
+
+### 4.6 Interaction with existing `closeSession` callers
+
+| Caller                       | Impact                                                             |
+| ---------------------------- | ------------------------------------------------------------------ |
+| `DELETE /session/:id` route  | None — no `opts` passed, defaults to `reason: 'client_close'`      |
+| Session reaper (this design) | Passes `opts: { reason: 'idle_timeout' }`                          |
+| `detachClient` deferred reap | Calls `killSession` (not `closeSession`), unaffected               |
+| `channel.exited` handler     | Publishes `session_died`, unaffected                               |
+| `shutdown()`                 | Publishes `session_died` with reason `daemon_shutdown`, unaffected |
+
+### 4.7 Concurrency safety
+
+The reaper callback runs on the Node.js event loop. Key considerations:
+
+- **`for...of` iteration is synchronous.** The reaper evaluates each entry's
+  idle predicate synchronously, then fires `closeSession(...).catch(...)` for
+  matching entries. No `await` in the loop body — all closes are dispatched
+  in a single microtask boundary, then the loop exits.
+- **`byId.delete` is deferred.** Inside `closeSession`, `byId.delete` runs
+  AFTER the first `await` (`notifyAgentSessionClose`). This means deletions
+  happen in microtasks after the `for...of` loop has completed. Since each
+  `closeSession` operates on a distinct key, there is no aliasing. And `for...of`
+  has already finished iterating, so mid-iteration deletion is not a concern.
+- **Double-close race.** If a client calls `DELETE /session/:id` for the same
+  session between the reaper's predicate check and the async `closeSession`
+  execution, the reaper's `closeSession` will throw `SessionNotFoundError`
+  (caught by `.catch()`). Safe.
+- **Reconnect race.** If a client reconnects to a session (registers clientId /
+  opens SSE) between the reaper's predicate check and `closeSession` execution,
+  `closeSession` will still proceed and close the session. The client receives
+  `session_closed` and must re-load. This window is extremely narrow (one
+  synchronous `setInterval` tick) and the consequence is benign — no data loss,
+  just a re-load prompt. The 30-minute default TTL makes this vanishingly rare.
+- A concurrent `spawnOrAttach` that creates a new session while the reaper
+  is scanning won't be seen (we iterate `byId` entries at the start of each
+  tick). This is safe — new sessions are fresh and won't meet the idle threshold.
+
+### 4.8 Wire-format change
+
+The `session_closed` event's `data.reason` field already exists with value
+`'client_close'`. We add `'idle_timeout'` as a new value. This is
+backward-compatible — existing SDK code that checks `reason === 'client_close'`
+will simply not match the new value, and the generic terminal-frame handler
+(`isTerminalLifecycleEvent`) already handles `session_closed` regardless of
+reason.
+
+---
+
+## 5. Test Plan
+
+### 5.1 Unit tests (`bridge.test.ts`)
+
+| #   | Test                                                   | Description                                                                                                                                                                            |
+| --- | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Idle session is reaped after timeout                   | Create a session, advance time past `sessionIdleTimeoutMs`, trigger reaper tick, verify session removed from `byId` and `session_closed` event published with `reason: 'idle_timeout'` |
+| 2   | Session with active prompt is NOT reaped               | Create a session, start a prompt, advance time, verify session survives reaper tick                                                                                                    |
+| 3   | Session with live SSE subscriber is NOT reaped         | Create a session, subscribe to its EventBus, advance time, verify session survives                                                                                                     |
+| 4   | Session with registered client is NOT reaped           | Create a session, register a clientId, advance time, verify session survives                                                                                                           |
+| 5   | Reaper disabled when interval = 0                      | Pass `sessionReapIntervalMs: 0`, verify no `setInterval` is armed                                                                                                                      |
+| 6   | Reaper disabled when timeout = 0                       | Pass `sessionIdleTimeoutMs: 0`, verify no `setInterval` is armed                                                                                                                       |
+| 7   | Reaper stopped on shutdown                             | Call `shutdown()`, verify `clearInterval` was called                                                                                                                                   |
+| 8   | closeSession reason defaults to 'client_close'         | Call `closeSession` without explicit reason, verify published event has `reason: 'client_close'`                                                                                       |
+| 9   | closeSession with explicit reason                      | Call `closeSession` with `reason: 'idle_timeout'`, verify published event                                                                                                              |
+| 10  | Multiple idle sessions reaped in one tick              | Create 3 idle sessions, advance time, trigger tick, verify all 3 reaped                                                                                                                |
+| 11  | Session with heartbeat within TTL survives             | Create a session, record heartbeat, advance time to just under TTL, verify session survives                                                                                            |
+| 12  | Channel idle timer triggered after last session reaped | Create 1 session (last on channel), reap it, verify `startIdleTimer` is called on the channel                                                                                          |
+
+### 5.2 Integration tests (`server.test.ts`)
+
+| #   | Test                                                                   | Description                                                                             |
+| --- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| 1   | `GET /health?deep=1` reflects reaper-cleaned session count             | Start daemon, create sessions, advance time, verify health endpoint shows reduced count |
+| 2   | SSE subscriber receives `session_closed` with `reason: 'idle_timeout'` | Open SSE, disconnect, reconnect before TTL, then let TTL expire, verify event           |
+
+---
+
+## 6. Configuration Defaults
+
+| Option                  | Default            | Rationale                                                                                                   |
+| ----------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------- |
+| `sessionReapIntervalMs` | 60,000 (1 min)     | Frequent enough to prevent long accumulation, cheap enough (simple Map scan) to run often                   |
+| `sessionIdleTimeoutMs`  | 1,800,000 (30 min) | Generous grace period for reconnection. Matches `ConnectionRegistry.idleTtlMs` for mental model consistency |
+
+---
+
+## 7. Observability
+
+- **stderr log**: `qwen serve: reaping idle session "<id>" (idle for Nms)` on
+  each reap, matching existing `qwen serve:` prefix convention.
+- **Telemetry event**: `session.close` with operation
+  `qwen-code.daemon.bridge.operation: 'session.close'` (reuses existing
+  `closeSession` telemetry path).
+- **Telemetry metric**: `sessionLifecycle('close')` (reuses existing counter).
+- **SSE event**: `session_closed` with `data.reason: 'idle_timeout'`.
+
+---
+
+## 8. Follow-up Work (Out of Scope)
+
+| Item                            | Description                                                                     | Priority |
+| ------------------------------- | ------------------------------------------------------------------------------- | -------- |
+| LRU eviction at `maxSessions`   | Instead of rejecting new sessions, evict the least-recently-active idle session | P1       |
+| EventBus ring compaction        | Shrink the ring for sessions with 0 subscribers to save memory                  | P2       |
+| RSS-based adaptive pressure     | Monitor `process.memoryUsage().rss` and lower the idle TTL when memory is tight | P2       |
+| Heartbeat-based client liveness | Auto-unregister clients that miss N consecutive heartbeat windows               | P2       |
+
+---
+
+## 9. Risks and Mitigations
+
+| Risk                                                                            | Mitigation                                                                                                                                                                        |
+| ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Reaper closes a session that a headless client is about to reconnect to         | 30-minute default TTL is generous; headless clients should send heartbeats. Disk transcript is preserved — `session/load` restores it.                                            |
+| `closeSession` inside reaper throws, poisoning the scan loop                    | Each close is in its own `.catch()` — one failure doesn't block others                                                                                                            |
+| Reaper iteration over `byId` during concurrent `closeSession` from another path | ES2015 Map iteration tolerates deletion of current/previous keys. Double-close is idempotent (`byId.get` returns undefined → `SessionNotFoundError` caught by reaper's `.catch`). |
+| Performance of scanning 20 sessions every 60s                                   | Trivial — 20 Map reads + 4 field checks each. No I/O.                                                                                                                             |
+| Channel idle timer interaction                                                  | When the last session is reaped, `closeSession` already calls `startIdleTimer` on the channel. No additional logic needed.                                                        |

--- a/docs/design/session-idle-reaper/README.md
+++ b/docs/design/session-idle-reaper/README.md
@@ -177,12 +177,11 @@ Note: `entry.createdAt` is typed as `string` (ISO 8601), not a number.
 
 **Rationale for each guard:**
 
-| Guard                 | Why                                                                                                                         |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| No active prompt      | A headless / autonomous prompt (e.g. CLI pipe, cron job) may be running with no SSE subscriber. Reaping it would kill work. |
-| No SSE subscribers    | A connected client is actively listening. Even if it hasn't sent a heartbeat, the SSE connection itself proves liveness.    |
-| No registered clients | A client that registered its `clientId` but hasn't yet opened SSE is still considered "present".                            |
-| Idle duration         | Grace period so briefly-disconnected clients can reconnect without losing their session.                                    |
+| Guard              | Why                                                                                                                         |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| No active prompt   | A headless / autonomous prompt (e.g. CLI pipe, cron job) may be running with no SSE subscriber. Reaping it would kill work. |
+| No SSE subscribers | A connected client is actively listening. Even if it hasn't sent a heartbeat, the SSE connection itself proves liveness.    |
+| Idle duration      | Grace period so briefly-disconnected clients can reconnect without losing their session.                                    |
 
 ### 4.3 Reap action
 

--- a/docs/design/session-idle-reaper/README.md
+++ b/docs/design/session-idle-reaper/README.md
@@ -98,10 +98,19 @@ Bridge closure (createHttpAcpBridge)
 | `writerIdleTimeoutMs`                     | SSE subscriber            | Evicts a single stuck SSE subscriber                                             |
 | Disconnect reaper (server.ts)             | Spawn handshake           | Reaps sessions whose spawn-owner disconnected DURING the POST /session handshake |
 
-The session reaper fills the gap between "spawn-handshake reaper" (covers only
-the creation window) and "channel idle timer" (fires only when ALL sessions are
-gone). It covers the common case: a session was created successfully, used for a
-while, and then the client disappeared.
+Two mechanisms work together to cover session lifecycle cleanup:
+
+1. **Close-on-last-detach** (primary) — when `detachClient` removes the last
+   registered client AND no SSE subscribers remain, the session is closed
+   immediately via `closeSessionImpl`. This handles the normal path: user
+   closes a tab → React cleanup → `POST /session/:id/detach`.
+
+2. **Session idle reaper** (backstop) — periodic scan for sessions with no
+   active prompt and no SSE subscribers that haven't received a heartbeat
+   within the configured TTL. This catches the crash path: browser killed,
+   network dropped, `kill -9` — the detach request was never sent, so
+   `clientIds` still shows registered clients but the session is effectively
+   orphaned.
 
 ---
 

--- a/docs/design/session-idle-reaper/README.md
+++ b/docs/design/session-idle-reaper/README.md
@@ -271,9 +271,8 @@ function startSessionReaper(): void {
     if (shuttingDown) return;
     const now = Date.now();
     for (const [id, entry] of byId) {
-      if (entry.activePromptOriginatorClientId !== undefined) continue;
+      if (entry.promptActive) continue;
       if (entry.events.subscriberCount > 0) continue;
-      if (entry.clientIds.size > 0) continue;
       const lastActive = entry.sessionLastSeenAt ?? Date.parse(entry.createdAt);
       const idle = now - lastActive;
       if (idle < resolvedIdleTimeoutMs) continue;

--- a/docs/design/session-idle-reaper/README.md
+++ b/docs/design/session-idle-reaper/README.md
@@ -152,10 +152,14 @@ interface BridgeOptions {
 
 A session is eligible for reaping when **all** of the following hold:
 
-1. **No active prompt**: `entry.activePromptOriginatorClientId === undefined`
+1. **No active prompt**: `entry.promptActive === false`
 2. **No live SSE subscribers**: `entry.events.subscriberCount === 0`
-3. **No registered clients**: `entry.clientIds.size === 0`
-4. **Idle duration exceeded**: `now - lastActivity(entry) > sessionIdleTimeoutMs`
+3. **Idle duration exceeded**: `now - lastActivity(entry) > sessionIdleTimeoutMs`
+
+Note: the reaper intentionally does NOT check `clientIds.size`. It covers
+the crash path where detach was never sent — `clientIds` still shows
+registered clients but the session is effectively orphaned. The normal
+path (client sends detach) is handled by close-on-last-detach instead.
 
 Where `lastActivity(entry)` is defined as:
 

--- a/docs/design/session-idle-reaper/README.md
+++ b/docs/design/session-idle-reaper/README.md
@@ -349,11 +349,15 @@ The reaper callback runs on the Node.js event loop. Key considerations:
 ### 4.8 Wire-format change
 
 The `session_closed` event's `data.reason` field already exists with value
-`'client_close'`. We add `'idle_timeout'` as a new value. This is
-backward-compatible — existing SDK code that checks `reason === 'client_close'`
-will simply not match the new value, and the generic terminal-frame handler
-(`isTerminalLifecycleEvent`) already handles `session_closed` regardless of
-reason.
+`'client_close'`. We add two new values:
+
+- `'idle_timeout'` — emitted by the idle reaper (backstop for crashed clients)
+- `'last_client_detached'` — emitted by close-on-last-detach (normal tab close)
+
+This is backward-compatible — existing SDK code that checks
+`reason === 'client_close'` will simply not match the new values, and the
+generic terminal-frame handler (`isTerminalLifecycleEvent`) already handles
+`session_closed` regardless of reason.
 
 ---
 

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -545,7 +545,7 @@ describe('createAcpSessionBridge', () => {
       // Attach two clients so detaching one doesn't trigger
       // close-on-last-detach (which would remove the session entirely).
       const s1 = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
-      const _s2 = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      await bridge.spawnOrAttach({ workspaceCwd: WS_A });
       bridge.recordHeartbeat(s1.sessionId, { clientId: s1.clientId });
 
       const before = bridge.getHeartbeatState(s1.sessionId);

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -9149,3 +9149,334 @@ describe('preheat', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Session idle reaper
+// ---------------------------------------------------------------------------
+describe('session idle reaper', () => {
+  it('reaps an idle session after the timeout expires', async () => {
+    vi.useFakeTimers();
+    try {
+      const handle = makeChannel();
+      const bridge = makeBridge({
+        channelFactory: async () => handle.channel,
+        sessionReapIntervalMs: 1_000,
+        sessionIdleTimeoutMs: 5_000,
+      });
+      const session = await bridge.spawnOrAttach({
+        workspaceCwd: WS_A,
+        sessionScope: 'thread',
+      });
+      expect(bridge.sessionCount).toBe(1);
+
+      await bridge.detachClient(session.sessionId, session.clientId);
+
+      await vi.advanceTimersByTimeAsync(6_000);
+      expect(bridge.sessionCount).toBe(0);
+
+      await bridge.shutdown();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does NOT reap a session with an active prompt and client', async () => {
+    vi.useFakeTimers();
+    try {
+      const handle = makeChannel({
+        promptImpl: () => new Promise<never>(() => {}),
+      });
+      const bridge = makeBridge({
+        channelFactory: async () => handle.channel,
+        sessionReapIntervalMs: 1_000,
+        sessionIdleTimeoutMs: 2_000,
+      });
+      const session = await bridge.spawnOrAttach({
+        workspaceCwd: WS_A,
+        sessionScope: 'thread',
+      });
+
+      const promptPromise = bridge
+        .sendPrompt(session.sessionId, {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'hi' }],
+        })
+        .catch(() => {});
+      await vi.waitFor(() => {
+        expect(handle.agent.promptCalls).toHaveLength(1);
+      });
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(bridge.sessionCount).toBe(1);
+
+      await bridge.shutdown();
+      await promptPromise;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does NOT reap a session with a live SSE subscriber', async () => {
+    vi.useFakeTimers();
+    try {
+      const handle = makeChannel();
+      const bridge = makeBridge({
+        channelFactory: async () => handle.channel,
+        sessionReapIntervalMs: 1_000,
+        sessionIdleTimeoutMs: 2_000,
+      });
+      const session = await bridge.spawnOrAttach({
+        workspaceCwd: WS_A,
+        sessionScope: 'thread',
+      });
+      await bridge.detachClient(session.sessionId, session.clientId);
+      const abort = new AbortController();
+      bridge.subscribeEvents(session.sessionId, { signal: abort.signal });
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(bridge.sessionCount).toBe(1);
+
+      abort.abort();
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(bridge.sessionCount).toBe(0);
+
+      await bridge.shutdown();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does NOT reap a session with registered clients', async () => {
+    vi.useFakeTimers();
+    try {
+      const handle = makeChannel();
+      const bridge = makeBridge({
+        channelFactory: async () => handle.channel,
+        sessionReapIntervalMs: 1_000,
+        sessionIdleTimeoutMs: 3_000,
+      });
+      const session = await bridge.spawnOrAttach({
+        workspaceCwd: WS_A,
+        sessionScope: 'thread',
+      });
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(bridge.sessionCount).toBe(1);
+
+      await bridge.detachClient(session.sessionId, session.clientId);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(bridge.sessionCount).toBe(0);
+
+      await bridge.shutdown();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('is disabled when sessionReapIntervalMs is 0', async () => {
+    vi.useFakeTimers();
+    try {
+      const handle = makeChannel();
+      const bridge = makeBridge({
+        channelFactory: async () => handle.channel,
+        sessionReapIntervalMs: 0,
+        sessionIdleTimeoutMs: 1_000,
+      });
+      await bridge.spawnOrAttach({
+        workspaceCwd: WS_A,
+        sessionScope: 'thread',
+      });
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(bridge.sessionCount).toBe(1);
+
+      await bridge.shutdown();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('is disabled when sessionIdleTimeoutMs is 0', async () => {
+    vi.useFakeTimers();
+    try {
+      const handle = makeChannel();
+      const bridge = makeBridge({
+        channelFactory: async () => handle.channel,
+        sessionReapIntervalMs: 1_000,
+        sessionIdleTimeoutMs: 0,
+      });
+      await bridge.spawnOrAttach({
+        workspaceCwd: WS_A,
+        sessionScope: 'thread',
+      });
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(bridge.sessionCount).toBe(1);
+
+      await bridge.shutdown();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('publishes session_closed with reason idle_timeout via closeSession opts', async () => {
+    const handle = makeChannel();
+    const bridge = makeBridge({
+      channelFactory: async () => handle.channel,
+    });
+    const session = await bridge.spawnOrAttach({
+      workspaceCwd: WS_A,
+      sessionScope: 'thread',
+    });
+
+    const events: BridgeEvent[] = [];
+    const abort = new AbortController();
+    const iter = bridge.subscribeEvents(session.sessionId, {
+      signal: abort.signal,
+    });
+    const reading = (async () => {
+      for await (const ev of iter) {
+        events.push(ev);
+        if (ev.type === 'session_closed') {
+          abort.abort();
+          break;
+        }
+      }
+    })();
+
+    await bridge.closeSession(session.sessionId, undefined, {
+      reason: 'idle_timeout',
+    });
+    await reading;
+    const closedEv = events.find((e) => e.type === 'session_closed');
+    expect(closedEv).toBeDefined();
+    expect((closedEv!.data as { reason: string }).reason).toBe('idle_timeout');
+
+    await bridge.shutdown();
+  });
+
+  it('closeSession defaults to reason client_close', async () => {
+    const handle = makeChannel();
+    const bridge = makeBridge({
+      channelFactory: async () => handle.channel,
+    });
+    const session = await bridge.spawnOrAttach({
+      workspaceCwd: WS_A,
+      sessionScope: 'thread',
+    });
+
+    const events: BridgeEvent[] = [];
+    const abort = new AbortController();
+    const iter = bridge.subscribeEvents(session.sessionId, {
+      signal: abort.signal,
+    });
+    const reading = (async () => {
+      for await (const ev of iter) {
+        events.push(ev);
+        if (ev.type === 'session_closed') {
+          abort.abort();
+          break;
+        }
+      }
+    })();
+
+    await bridge.closeSession(session.sessionId);
+    await reading;
+    const closedEv = events.find((e) => e.type === 'session_closed');
+    expect(closedEv).toBeDefined();
+    expect((closedEv!.data as { reason: string }).reason).toBe('client_close');
+
+    await bridge.shutdown();
+  });
+
+  it('reaps multiple idle sessions in one tick', async () => {
+    vi.useFakeTimers();
+    try {
+      const handle = makeChannel();
+      const bridge = makeBridge({
+        channelFactory: async () => handle.channel,
+        sessionReapIntervalMs: 1_000,
+        sessionIdleTimeoutMs: 3_000,
+      });
+      const s1 = await bridge.spawnOrAttach({
+        workspaceCwd: WS_A,
+        sessionScope: 'thread',
+      });
+      const s2 = await bridge.spawnOrAttach({
+        workspaceCwd: WS_A,
+        sessionScope: 'thread',
+      });
+      const s3 = await bridge.spawnOrAttach({
+        workspaceCwd: WS_A,
+        sessionScope: 'thread',
+      });
+      expect(bridge.sessionCount).toBe(3);
+
+      await bridge.detachClient(s1.sessionId, s1.clientId);
+      await bridge.detachClient(s2.sessionId, s2.clientId);
+      await bridge.detachClient(s3.sessionId, s3.clientId);
+
+      await vi.advanceTimersByTimeAsync(4_000);
+      expect(bridge.sessionCount).toBe(0);
+
+      await bridge.shutdown();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('session with recent heartbeat survives reaper', async () => {
+    vi.useFakeTimers();
+    try {
+      const handle = makeChannel();
+      const bridge = makeBridge({
+        channelFactory: async () => handle.channel,
+        sessionReapIntervalMs: 1_000,
+        sessionIdleTimeoutMs: 5_000,
+      });
+      const session = await bridge.spawnOrAttach({
+        workspaceCwd: WS_A,
+        sessionScope: 'thread',
+      });
+
+      await bridge.detachClient(session.sessionId, session.clientId);
+
+      await vi.advanceTimersByTimeAsync(4_000);
+      bridge.recordHeartbeat(session.sessionId);
+      expect(bridge.sessionCount).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(4_000);
+      expect(bridge.sessionCount).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(bridge.sessionCount).toBe(0);
+
+      await bridge.shutdown();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reaper is stopped on shutdown (no post-shutdown errors)', async () => {
+    vi.useFakeTimers();
+    try {
+      const handle = makeChannel();
+      const bridge = makeBridge({
+        channelFactory: async () => handle.channel,
+        sessionReapIntervalMs: 1_000,
+        sessionIdleTimeoutMs: 2_000,
+      });
+      await bridge.spawnOrAttach({
+        workspaceCwd: WS_A,
+        sessionScope: 'thread',
+      });
+
+      await bridge.shutdown();
+
+      await vi.advanceTimersByTimeAsync(10_000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -9479,4 +9479,36 @@ describe('session idle reaper', () => {
       vi.useRealTimers();
     }
   });
+
+  it('triggers channel idle timer after reaping the last session', async () => {
+    vi.useFakeTimers();
+    try {
+      const handle = makeChannel();
+      const bridge = makeBridge({
+        channelFactory: async () => handle.channel,
+        sessionReapIntervalMs: 1_000,
+        sessionIdleTimeoutMs: 3_000,
+        channelIdleTimeoutMs: 2_000,
+      });
+      const session = await bridge.spawnOrAttach({
+        workspaceCwd: WS_A,
+        sessionScope: 'thread',
+      });
+      await bridge.detachClient(session.sessionId, session.clientId);
+
+      // Reaper closes the session after 3s idle
+      await vi.advanceTimersByTimeAsync(4_000);
+      expect(bridge.sessionCount).toBe(0);
+      // Channel should still be alive — idle timer just started
+      expect(handle.killed).toBe(false);
+
+      // Channel idle timer fires after 2s more
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(handle.killed).toBe(true);
+
+      await bridge.shutdown();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -542,20 +542,23 @@ describe('createAcpSessionBridge', () => {
       const bridge = makeBridge({
         channelFactory: async () => makeChannel().channel,
       });
-      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
-      bridge.recordHeartbeat(session.sessionId, { clientId: session.clientId });
+      // Attach two clients so detaching one doesn't trigger
+      // close-on-last-detach (which would remove the session entirely).
+      const s1 = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const _s2 = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      bridge.recordHeartbeat(s1.sessionId, { clientId: s1.clientId });
 
-      const before = bridge.getHeartbeatState(session.sessionId);
-      expect(before?.clientLastSeenAt.get(session.clientId!)).toBeDefined();
+      const before = bridge.getHeartbeatState(s1.sessionId);
+      expect(before?.clientLastSeenAt.get(s1.clientId!)).toBeDefined();
 
-      await bridge.detachClient(session.sessionId, session.clientId);
+      await bridge.detachClient(s1.sessionId, s1.clientId);
 
-      const after = bridge.getHeartbeatState(session.sessionId);
+      const after = bridge.getHeartbeatState(s1.sessionId);
       // session watermark stays — diagnostics still see "this session
-      // was alive at T"; per-client entry is gone since the client
-      // ref-count hit zero.
+      // was alive at T"; per-client entry for s1 is gone since its
+      // ref-count hit zero; s2's clientId is still present.
       expect(after?.sessionLastSeenAt).toBe(before?.sessionLastSeenAt);
-      expect(after?.clientLastSeenAt.size).toBe(0);
+      expect(after?.clientLastSeenAt.has(s1.clientId!)).toBe(false);
 
       await bridge.shutdown();
     });
@@ -9154,7 +9157,7 @@ describe('preheat', () => {
 // Session idle reaper
 // ---------------------------------------------------------------------------
 describe('session idle reaper', () => {
-  it('reaps an idle session after the timeout expires', async () => {
+  it('reaps an orphaned session whose client crashed (no detach sent)', async () => {
     vi.useFakeTimers();
     try {
       const handle = makeChannel();
@@ -9163,14 +9166,15 @@ describe('session idle reaper', () => {
         sessionReapIntervalMs: 1_000,
         sessionIdleTimeoutMs: 5_000,
       });
-      const session = await bridge.spawnOrAttach({
+      await bridge.spawnOrAttach({
         workspaceCwd: WS_A,
         sessionScope: 'thread',
       });
       expect(bridge.sessionCount).toBe(1);
 
-      await bridge.detachClient(session.sessionId, session.clientId);
-
+      // Simulate client crash: client never sends detach, but SSE
+      // dropped and no heartbeat. clientIds still > 0 — only the
+      // reaper can catch this.
       await vi.advanceTimersByTimeAsync(6_000);
       expect(bridge.sessionCount).toBe(0);
 
@@ -9229,13 +9233,18 @@ describe('session idle reaper', () => {
         workspaceCwd: WS_A,
         sessionScope: 'thread',
       });
-      await bridge.detachClient(session.sessionId, session.clientId);
+      // Subscribe BEFORE detach so the subscriber keeps the session alive
       const abort = new AbortController();
       bridge.subscribeEvents(session.sessionId, { signal: abort.signal });
+      // Detach — close-on-last-detach checks subscriberCount > 0 → skips
+      await bridge.detachClient(session.sessionId, session.clientId);
+      expect(bridge.sessionCount).toBe(1);
 
+      // Advance past idle timeout — subscriber still protects from reaper
       await vi.advanceTimersByTimeAsync(5_000);
       expect(bridge.sessionCount).toBe(1);
 
+      // Drop the subscriber — reaper catches it on next tick
       abort.abort();
       await vi.advanceTimersByTimeAsync(2_000);
       expect(bridge.sessionCount).toBe(0);
@@ -9246,29 +9255,37 @@ describe('session idle reaper', () => {
     }
   });
 
-  it('does NOT reap a session with registered clients', async () => {
+  it('does NOT reap a session with an active prompt (no SSE, no heartbeat)', async () => {
     vi.useFakeTimers();
     try {
-      const handle = makeChannel();
+      const handle = makeChannel({
+        promptImpl: () => new Promise<never>(() => {}),
+      });
       const bridge = makeBridge({
         channelFactory: async () => handle.channel,
         sessionReapIntervalMs: 1_000,
-        sessionIdleTimeoutMs: 3_000,
+        sessionIdleTimeoutMs: 2_000,
       });
       const session = await bridge.spawnOrAttach({
         workspaceCwd: WS_A,
         sessionScope: 'thread',
       });
+      const promptPromise = bridge
+        .sendPrompt(session.sessionId, {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'hi' }],
+        })
+        .catch(() => {});
+      await vi.waitFor(() => {
+        expect(handle.agent.promptCalls).toHaveLength(1);
+      });
 
+      // No subscriber, client registered but prompt active → reaper skips
       await vi.advanceTimersByTimeAsync(5_000);
       expect(bridge.sessionCount).toBe(1);
 
-      await bridge.detachClient(session.sessionId, session.clientId);
-
-      await vi.advanceTimersByTimeAsync(1_000);
-      expect(bridge.sessionCount).toBe(0);
-
       await bridge.shutdown();
+      await promptPromise;
     } finally {
       vi.useRealTimers();
     }
@@ -9390,7 +9407,7 @@ describe('session idle reaper', () => {
     await bridge.shutdown();
   });
 
-  it('reaps multiple idle sessions in one tick', async () => {
+  it('reaps multiple orphaned sessions in one tick', async () => {
     vi.useFakeTimers();
     try {
       const handle = makeChannel();
@@ -9399,24 +9416,21 @@ describe('session idle reaper', () => {
         sessionReapIntervalMs: 1_000,
         sessionIdleTimeoutMs: 3_000,
       });
-      const s1 = await bridge.spawnOrAttach({
+      await bridge.spawnOrAttach({
         workspaceCwd: WS_A,
         sessionScope: 'thread',
       });
-      const s2 = await bridge.spawnOrAttach({
+      await bridge.spawnOrAttach({
         workspaceCwd: WS_A,
         sessionScope: 'thread',
       });
-      const s3 = await bridge.spawnOrAttach({
+      await bridge.spawnOrAttach({
         workspaceCwd: WS_A,
         sessionScope: 'thread',
       });
       expect(bridge.sessionCount).toBe(3);
 
-      await bridge.detachClient(s1.sessionId, s1.clientId);
-      await bridge.detachClient(s2.sessionId, s2.clientId);
-      await bridge.detachClient(s3.sessionId, s3.clientId);
-
+      // No detach — simulates client crash. Reaper catches all 3.
       await vi.advanceTimersByTimeAsync(4_000);
       expect(bridge.sessionCount).toBe(0);
 
@@ -9440,8 +9454,8 @@ describe('session idle reaper', () => {
         sessionScope: 'thread',
       });
 
-      await bridge.detachClient(session.sessionId, session.clientId);
-
+      // No detach — simulates a crashed client that still sends heartbeats
+      // (e.g. a headless API client with a keepalive loop).
       await vi.advanceTimersByTimeAsync(4_000);
       bridge.recordHeartbeat(session.sessionId);
       expect(bridge.sessionCount).toBe(1);
@@ -9496,13 +9510,12 @@ describe('session idle reaper', () => {
       });
       await bridge.detachClient(session.sessionId, session.clientId);
 
-      // Reaper closes the session after 3s idle
-      await vi.advanceTimersByTimeAsync(4_000);
+      // Close-on-last-detach fires immediately — session gone
       expect(bridge.sessionCount).toBe(0);
-      // Channel should still be alive — idle timer just started
+      // Channel should still be alive — channelIdleTimeoutMs grace
       expect(handle.killed).toBe(false);
 
-      // Channel idle timer fires after 2s more
+      // Channel idle timer fires after 2s
       await vi.advanceTimersByTimeAsync(2_000);
       expect(handle.killed).toBe(true);
 
@@ -9510,5 +9523,76 @@ describe('session idle reaper', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Close on last client detach
+// ---------------------------------------------------------------------------
+describe('close on last client detach', () => {
+  it('closes the session when the last client detaches', async () => {
+    const handle = makeChannel();
+    const bridge = makeBridge({
+      channelFactory: async () => handle.channel,
+      sessionReapIntervalMs: 0,
+    });
+    const session = await bridge.spawnOrAttach({
+      workspaceCwd: WS_A,
+      sessionScope: 'thread',
+    });
+    expect(bridge.sessionCount).toBe(1);
+
+    await bridge.detachClient(session.sessionId, session.clientId);
+    expect(bridge.sessionCount).toBe(0);
+
+    await bridge.shutdown();
+  });
+
+  it('does NOT close when other clients remain', async () => {
+    const handle = makeChannel();
+    const bridge = makeBridge({
+      channelFactory: async () => handle.channel,
+      sessionReapIntervalMs: 0,
+    });
+    const s1 = await bridge.spawnOrAttach({
+      workspaceCwd: WS_A,
+      sessionScope: 'single',
+    });
+    const s2 = await bridge.spawnOrAttach({
+      workspaceCwd: WS_A,
+      sessionScope: 'single',
+    });
+    expect(s2.attached).toBe(true);
+    expect(bridge.sessionCount).toBe(1);
+
+    await bridge.detachClient(s1.sessionId, s1.clientId);
+    expect(bridge.sessionCount).toBe(1);
+
+    await bridge.detachClient(s2.sessionId, s2.clientId);
+    expect(bridge.sessionCount).toBe(0);
+
+    await bridge.shutdown();
+  });
+
+  it('closes immediately on last detach (session removed from byId)', async () => {
+    const handle = makeChannel();
+    const bridge = makeBridge({
+      channelFactory: async () => handle.channel,
+      sessionReapIntervalMs: 0,
+    });
+    const session = await bridge.spawnOrAttach({
+      workspaceCwd: WS_A,
+      sessionScope: 'thread',
+    });
+    expect(bridge.sessionCount).toBe(1);
+
+    // Last client detaches — session closed immediately, no reaper needed
+    await bridge.detachClient(session.sessionId, session.clientId);
+    expect(bridge.sessionCount).toBe(0);
+
+    // Session is gone from bridge but getHeartbeatState returns undefined
+    expect(bridge.getHeartbeatState(session.sessionId)).toBeUndefined();
+
+    await bridge.shutdown();
   });
 });

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -293,6 +293,9 @@ interface SessionEntry {
    * inline session updates / permission requests can safely inherit this id.
    */
   activePromptOriginatorClientId?: string;
+  /** True while a prompt is executing on the FIFO, regardless of whether
+   *  an originator clientId is known. Used by the session reaper to avoid
+   *  killing sessions mid-prompt. */
   promptActive: boolean;
   /**
    * Per-prompt "already broadcast `prompt_cancelled`" latch. The explicit
@@ -869,9 +872,13 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       if (shuttingDown) return;
       const now = Date.now();
       for (const [id, entry] of byId) {
-        if (entry.activePromptOriginatorClientId !== undefined) continue;
+        if (entry.promptActive) continue;
         if (entry.events.subscriberCount > 0) continue;
-        if (entry.clientIds.size > 0) continue;
+        // Note: clientIds.size is NOT checked here. Close-on-last-detach
+        // handles the normal path (client sends detach → immediate close).
+        // The reaper covers the crash path where detach was never sent —
+        // clientIds still > 0 but no SSE subscriber and no heartbeat for
+        // the configured TTL.
         const lastActive =
           entry.sessionLastSeenAt ?? Date.parse(entry.createdAt);
         const idle = now - lastActive;
@@ -1953,6 +1960,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       connection: ci.connection,
       events,
       promptQueue: Promise.resolve(),
+      promptActive: false,
       modelChangeQueue: Promise.resolve(),
       approvalModeQueue: Promise.resolve(),
       modelPublishGeneration: 0,
@@ -2654,6 +2662,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                 if (signal?.aborted) {
                   throw new DOMException('Prompt aborted', 'AbortError');
                 }
+                entry.promptActive = true;
                 if (originatorClientId === undefined) {
                   delete entry.activePromptOriginatorClientId;
                 } else {
@@ -2689,6 +2698,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                 const promptPromise = entry.connection
                   .prompt(normalized)
                   .finally(() => {
+                    entry.promptActive = false;
                     delete entry.activePromptOriginatorClientId;
                     entry.promptActive = false;
                   });
@@ -4383,11 +4393,14 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       // disconnected. This is the symmetric rollback the server's
       // `!res.writable && session.attached` path calls into.
       //
-      // BkwQP: detachClient ONLY decrements; it does NOT reap on its
-      // own. Reaping is the spawn-owner's responsibility, and the spawn
-      // owner's `killSession({ requireZeroAttaches: true })` sets
-      // `spawnOwnerWantedKill` if they had to bail. Only when that
-      // tombstone is set do we complete the deferred reap from here.
+      // BkwQP: detachClient decrements attachCount and unregisters the
+      // client. Two close paths:
+      // 1. spawnOwnerWantedKill tombstone → killSession (deferred reap
+      //    from the spawn-handshake disconnect race).
+      // 2. clientIds.size === 0 → closeSessionImpl (last registered
+      //    client left; session closed immediately, JSONL preserved).
+      // The idle reaper serves as a backstop for clients that crash
+      // without sending a detach request.
       const entry = byId.get(sessionId);
       if (!entry) return;
       if (entry.attachCount > 0) entry.attachCount--;
@@ -4402,6 +4415,24 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         // already validated all the conditions ourselves.
         await this.killSession(sessionId).catch(() => {
           /* best-effort; channel.exited will eventually reap anyway */
+        });
+      } else if (
+        entry.clientIds.size === 0 &&
+        entry.events.subscriberCount === 0
+      ) {
+        // Last registered client left AND no SSE subscribers remain.
+        // Close the session immediately so it doesn't linger in memory.
+        // The JSONL transcript on disk is preserved — session/load or
+        // session/resume can restore it later. The idle reaper serves
+        // as a backstop for the case where the detach request was never
+        // sent (client crash, kill -9, network failure).
+        await closeSessionImpl(sessionId, undefined, {
+          reason: 'last_client_detached',
+        }).catch((err) => {
+          writeStderrLine(
+            `qwen serve: close-on-last-detach failed for ` +
+              `${JSON.stringify(sessionId)}: ${String(err)}`,
+          );
         });
       }
     },

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -72,6 +72,8 @@ import type {
   BridgeSessionState,
   BridgeRestoredSession,
   BridgeSessionSummary,
+  BridgeClientRequestContext,
+  CloseSessionOpts,
   AcpSessionBridge,
 } from './bridgeTypes.js';
 import type { BridgeOptions, BridgeTelemetry } from './bridgeOptions.js';
@@ -660,6 +662,8 @@ const DEFAULT_PERMISSION_TIMEOUT_MS = 5 * 60 * 1000;
 // the limit being hit. Configurable via
 // `BridgeOptions.maxPendingPermissionsPerSession`.
 const DEFAULT_MAX_PENDING_PER_SESSION = 64;
+const DEFAULT_SESSION_REAP_INTERVAL_MS = 60_000;
+const DEFAULT_SESSION_IDLE_TIMEOUT_MS = 30 * 60_000;
 
 export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
   const defaultSessionScope = opts.sessionScope ?? 'single';
@@ -793,6 +797,24 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
   let channelInfo: ChannelInfo | undefined;
   let idleTimer: ReturnType<typeof setTimeout> | undefined;
 
+  const sessionReapIntervalMs = resolvePositiveFiniteMs(
+    opts.sessionReapIntervalMs,
+    DEFAULT_SESSION_REAP_INTERVAL_MS,
+  );
+  const sessionIdleTimeoutMs = resolvePositiveFiniteMs(
+    opts.sessionIdleTimeoutMs,
+    DEFAULT_SESSION_IDLE_TIMEOUT_MS,
+  );
+  let sessionReaper: ReturnType<typeof setInterval> | undefined;
+
+  function resolvePositiveFiniteMs(
+    raw: number | undefined,
+    fallback: number,
+  ): number {
+    if (raw === undefined) return fallback;
+    return raw > 0 && Number.isFinite(raw) ? raw : 0;
+  }
+
   function cancelIdleTimer(): void {
     if (idleTimer !== undefined) {
       clearTimeout(idleTimer);
@@ -839,6 +861,44 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       }
     }, timeoutMs);
     idleTimer.unref();
+  }
+
+  function startSessionReaper(): void {
+    if (sessionReapIntervalMs <= 0 || sessionIdleTimeoutMs <= 0) return;
+    sessionReaper = setInterval(() => {
+      if (shuttingDown) return;
+      const now = Date.now();
+      for (const [id, entry] of byId) {
+        if (entry.activePromptOriginatorClientId !== undefined) continue;
+        if (entry.events.subscriberCount > 0) continue;
+        if (entry.clientIds.size > 0) continue;
+        const lastActive =
+          entry.sessionLastSeenAt ?? Date.parse(entry.createdAt);
+        const idle = now - lastActive;
+        if (idle < sessionIdleTimeoutMs) continue;
+        writeStderrLine(
+          `qwen serve: reaping idle session ${JSON.stringify(id)} ` +
+            `(idle for ${Math.round(idle / 1000)}s, ` +
+            `threshold ${Math.round(sessionIdleTimeoutMs / 1000)}s)`,
+        );
+        void closeSessionImpl(id, undefined, { reason: 'idle_timeout' }).catch(
+          (err) => {
+            writeStderrLine(
+              `qwen serve: session reaper failed to close ` +
+                `${JSON.stringify(id)}: ${String(err)}`,
+            );
+          },
+        );
+      }
+    }, sessionReapIntervalMs);
+    sessionReaper.unref();
+  }
+
+  function stopSessionReaper(): void {
+    if (sessionReaper !== undefined) {
+      clearInterval(sessionReaper);
+      sessionReaper = undefined;
+    }
   }
 
   // BkUyD: superset of `channelInfo` covering channels
@@ -2266,6 +2326,79 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     }
   }
 
+  async function closeSessionImpl(
+    sessionId: string,
+    context?: BridgeClientRequestContext,
+    closeOpts?: CloseSessionOpts,
+  ): Promise<void> {
+    const entry = byId.get(sessionId);
+    if (!entry) throw new SessionNotFoundError(sessionId);
+    let originatorClientId: string | undefined;
+    if (context?.clientId !== undefined) {
+      originatorClientId = resolveTrustedClientId(entry, context.clientId);
+    }
+    writeStderrLine(
+      `qwen serve: closing session ${JSON.stringify(sessionId)}` +
+        (originatorClientId
+          ? ` by client ${JSON.stringify(originatorClientId)}`
+          : ''),
+    );
+    telemetry.event('session.close', {
+      'qwen-code.daemon.bridge.operation': 'session.close',
+      'session.id': sessionId,
+    });
+    if (defaultEntry === entry) defaultEntry = undefined;
+    const ci = channelInfoForEntry(entry);
+    if (!ci) {
+      writeStderrLine(
+        `qwen serve: closeSession channelInfoForEntry returned undefined ` +
+          `for session ${JSON.stringify(sessionId)} — channel cleanup skipped (entry's channel already torn down)`,
+      );
+    }
+    if (ci && ci.channel === entry.channel) {
+      ci.sessionIds.delete(sessionId);
+    }
+    await notifyAgentSessionClose(entry, ci, 'closeSession');
+    permissionMediator.forgetSession(sessionId);
+    entry.pendingPermissionIds.clear();
+    byId.delete(sessionId);
+    telemetry.metrics?.sessionLifecycle('close');
+    ci?.client.markSessionClosed(sessionId);
+    const reason = closeOpts?.reason ?? 'client_close';
+    try {
+      entry.events.publish({
+        type: 'session_closed',
+        data: {
+          sessionId,
+          reason,
+          ...(originatorClientId ? { closedBy: originatorClientId } : {}),
+        },
+        ...(originatorClientId ? { originatorClientId } : {}),
+      });
+    } catch {
+      /* bus already closed */
+    }
+    entry.events.close();
+    try {
+      await telemetry.withSpan(
+        'session.close.cancel_active_prompt',
+        {
+          'qwen-code.daemon.bridge.operation':
+            'session.close.cancel_active_prompt',
+          'session.id': sessionId,
+        },
+        async () => await entry.connection.cancel({ sessionId }),
+      );
+    } catch {
+      /* no active prompt or session already torn down */
+    }
+    if (ci && ci.sessionIds.size === 0 && ci.pendingRestoreIds.size === 0) {
+      await startIdleTimer(ci, `closeSession "${sessionId}"`);
+    }
+  }
+
+  startSessionReaper();
+
   return {
     get sessionCount() {
       return byId.size;
@@ -3021,96 +3154,8 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       return branchResult;
     },
 
-    async closeSession(sessionId, context) {
-      const entry = byId.get(sessionId);
-      if (!entry) throw new SessionNotFoundError(sessionId);
-      let originatorClientId: string | undefined;
-      if (context?.clientId !== undefined) {
-        originatorClientId = resolveTrustedClientId(entry, context.clientId);
-      }
-      writeStderrLine(
-        `qwen serve: closing session ${JSON.stringify(sessionId)}` +
-          (originatorClientId
-            ? ` by client ${JSON.stringify(originatorClientId)}`
-            : ''),
-      );
-      telemetry.event('session.close', {
-        'qwen-code.daemon.bridge.operation': 'session.close',
-        'session.id': sessionId,
-      });
-      if (defaultEntry === entry) defaultEntry = undefined;
-      // HAZARD: Resolve the channel via `channelInfoForEntry(entry)` (search
-      // `aliveChannels` for the entry's actual channel) instead of the
-      // module-scoped `channelInfo` (the CURRENT attach target). The two
-      // diverge during the channel-overlap window — A dying, B freshly
-      // spawned as `channelInfo` — where capturing `channelInfo` would
-      // (1) skip the `sessionIds.delete()` since `B.channel !==
-      // entry.channel`, and (2) call `markSessionClosed` on B's client
-      // instead of A's. The regression test is single-channel smoke only
-      // and WILL NOT fail if this reverts to module-scoped channelInfo.
-      // Keep `channelInfoForEntry(entry)` until a deterministic overlap
-      // test lands.
-      const ci = channelInfoForEntry(entry);
-      if (!ci) {
-        // When the entry's channel has already been torn down out-of-band,
-        // the cleanup branches below all short-circuit silently. Sibling
-        // methods surface this as `SessionNotFoundError`; `closeSession`
-        // is intentionally idempotent so we just log instead of throwing.
-        writeStderrLine(
-          `qwen serve: closeSession channelInfoForEntry returned undefined ` +
-            `for session ${JSON.stringify(sessionId)} — channel cleanup skipped (entry's channel already torn down)`,
-        );
-      }
-      if (ci && ci.channel === entry.channel) {
-        ci.sessionIds.delete(sessionId);
-      }
-      await notifyAgentSessionClose(entry, ci, 'closeSession');
-      // Mediator-driven cancel cascade. Each pending settles as
-      // cancelled, SSE permission_resolved emits, audit records.
-      permissionMediator.forgetSession(sessionId);
-      entry.pendingPermissionIds.clear();
-      byId.delete(sessionId);
-      telemetry.metrics?.sessionLifecycle('close');
-      // Tombstone the closed sessionId so any late `extNotification`
-      // from the (now-defunct) child can't seed the early-event buffer
-      // and leak into a future load/resume of the same persisted id.
-      ci?.client.markSessionClosed(sessionId);
-      try {
-        entry.events.publish({
-          type: 'session_closed',
-          data: {
-            sessionId,
-            reason: 'client_close',
-            // `data.closedBy` is kept for back-compat with existing
-            // wire consumers; new code should read envelope-level
-            // `originatorClientId` (matches `session_metadata_updated`,
-            // `model_switched`, `approval_mode_changed`, etc.).
-            ...(originatorClientId ? { closedBy: originatorClientId } : {}),
-          },
-          ...(originatorClientId ? { originatorClientId } : {}),
-        });
-      } catch {
-        /* bus already closed */
-      }
-      // `session_closed` is terminal. Close the bus before ACP cancel so any
-      // late cancellation frames from the agent are intentionally dropped.
-      entry.events.close();
-      try {
-        await telemetry.withSpan(
-          'session.close.cancel_active_prompt',
-          {
-            'qwen-code.daemon.bridge.operation':
-              'session.close.cancel_active_prompt',
-            'session.id': sessionId,
-          },
-          async () => await entry.connection.cancel({ sessionId }),
-        );
-      } catch {
-        /* no active prompt or session already torn down */
-      }
-      if (ci && ci.sessionIds.size === 0 && ci.pendingRestoreIds.size === 0) {
-        await startIdleTimer(ci, `closeSession "${sessionId}"`);
-      }
+    async closeSession(sessionId, context, closeOpts) {
+      return closeSessionImpl(sessionId, context, closeOpts);
     },
 
     updateSessionMetadata(sessionId, metadata, context) {
@@ -4372,6 +4417,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       // `channel.exited` hasn't fired yet.
       shuttingDown = true;
       cancelIdleTimer();
+      stopSessionReaper();
       const channels = Array.from(aliveChannels);
       defaultEntry = undefined;
       byId.clear();
@@ -4391,6 +4437,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       // spawning a child this teardown won't see.
       shuttingDown = true;
       cancelIdleTimer();
+      stopSessionReaper();
       const entries = Array.from(byId.values());
       // Snapshot every alive channel (typically 1; up to 2 during a
       // `killSession`-then-`spawnOrAttach` overlap) — entries are

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -1970,7 +1970,6 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       connection: ci.connection,
       events,
       promptQueue: Promise.resolve(),
-      promptActive: false,
       modelChangeQueue: Promise.resolve(),
       approvalModeQueue: Promise.resolve(),
       modelPublishGeneration: 0,
@@ -2390,11 +2389,12 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     if (ci && ci.channel === entry.channel) {
       ci.sessionIds.delete(sessionId);
     }
-    // Synchronous teardown block — mirrors `killSession` ordering.
-    // `byId.delete` runs BEFORE `await notifyAgentSessionClose` so any
-    // concurrent caller (reaper tick, detach-close, explicit DELETE)
-    // that does `byId.get(sessionId)` gets `undefined` and throws
-    // `SessionNotFoundError`, preventing duplicate close cascades.
+    // Synchronous teardown block — intentionally diverges from killSession:
+    // tombstone + event publish + bus close all run BEFORE
+    // notifyAgentSessionClose, so concurrent callers see
+    // byId.get(sessionId) === undefined and throw SessionNotFoundError,
+    // and late agent frames arriving during the RPC are dropped by the
+    // closed bus.
     permissionMediator.forgetSession(sessionId);
     entry.pendingPermissionIds.clear();
     byId.delete(sessionId);
@@ -2704,7 +2704,6 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                 } else {
                   entry.activePromptOriginatorClientId = originatorClientId;
                 }
-                entry.promptActive = true;
                 try {
                   // Echo the user prompt to the session bus so other SSE-subscribed
                   // clients see the input alongside the agent response.
@@ -2736,7 +2735,6 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                   .finally(() => {
                     entry.promptActive = false;
                     delete entry.activePromptOriginatorClientId;
-                    entry.promptActive = false;
                   });
 
                 // Race against channel termination: if the underlying transport
@@ -4454,14 +4452,15 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         });
       } else if (
         entry.clientIds.size === 0 &&
-        entry.events.subscriberCount === 0
+        entry.events.subscriberCount === 0 &&
+        !entry.promptActive
       ) {
-        // Last registered client left AND no SSE subscribers remain.
-        // Close the session immediately so it doesn't linger in memory.
-        // The JSONL transcript on disk is preserved — session/load or
-        // session/resume can restore it later. The idle reaper serves
-        // as a backstop for the case where the detach request was never
-        // sent (client crash, kill -9, network failure).
+        // Last registered client left, no SSE subscribers remain, and
+        // no prompt is in flight. Close the session immediately so it
+        // doesn't linger in memory. The JSONL transcript on disk is
+        // preserved — session/load or session/resume can restore it
+        // later. When a prompt IS active, skip the close and let the
+        // idle reaper handle it after the prompt completes.
         await closeSessionImpl(sessionId, undefined, {
           reason: 'last_client_detached',
         }).catch((err) => {

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -2744,7 +2744,12 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                     ) {
                       void closeSessionImpl(sessionId, undefined, {
                         reason: 'last_client_detached',
-                      }).catch(() => {});
+                      }).catch((err) => {
+                        writeStderrLine(
+                          `qwen serve: deferred close-on-prompt-complete failed for ` +
+                            `${JSON.stringify(sessionId)}: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`,
+                        );
+                      });
                     }
                   });
 

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -2699,6 +2699,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                   throw new DOMException('Prompt aborted', 'AbortError');
                 }
                 entry.promptActive = true;
+                entry.sessionLastSeenAt = Date.now();
                 if (originatorClientId === undefined) {
                   delete entry.activePromptOriginatorClientId;
                 } else {
@@ -2734,7 +2735,17 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                   .prompt(normalized)
                   .finally(() => {
                     entry.promptActive = false;
+                    entry.sessionLastSeenAt = Date.now();
                     delete entry.activePromptOriginatorClientId;
+                    if (
+                      entry.clientIds.size === 0 &&
+                      entry.events.subscriberCount === 0 &&
+                      byId.has(sessionId)
+                    ) {
+                      void closeSessionImpl(sessionId, undefined, {
+                        reason: 'last_client_detached',
+                      }).catch(() => {});
+                    }
                   });
 
                 // Race against channel termination: if the underlying transport

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -2343,9 +2343,11 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
           ? ` by client ${JSON.stringify(originatorClientId)}`
           : ''),
     );
+    const reason = closeOpts?.reason ?? 'client_close';
     telemetry.event('session.close', {
       'qwen-code.daemon.bridge.operation': 'session.close',
       'session.id': sessionId,
+      'session.close.reason': reason,
     });
     if (defaultEntry === entry) defaultEntry = undefined;
     const ci = channelInfoForEntry(entry);
@@ -2364,7 +2366,6 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     byId.delete(sessionId);
     telemetry.metrics?.sessionLifecycle('close');
     ci?.client.markSessionClosed(sessionId);
-    const reason = closeOpts?.reason ?? 'client_close';
     try {
       entry.events.publish({
         type: 'session_closed',

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -815,7 +815,9 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     fallback: number,
   ): number {
     if (raw === undefined) return fallback;
-    return raw > 0 && Number.isFinite(raw) ? raw : 0;
+    // Clamp to 2^31-1: Node.js treats setInterval delays larger than
+    // this as 1ms, which would cause a tight CPU-burning loop.
+    return raw > 0 && Number.isFinite(raw) ? Math.min(raw, 2_147_483_647) : 0;
   }
 
   function cancelIdleTimer(): void {
@@ -867,7 +869,15 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
   }
 
   function startSessionReaper(): void {
-    if (sessionReapIntervalMs <= 0 || sessionIdleTimeoutMs <= 0) return;
+    if (sessionReapIntervalMs <= 0 || sessionIdleTimeoutMs <= 0) {
+      writeStderrLine('qwen serve: session reaper disabled');
+      return;
+    }
+    writeStderrLine(
+      `qwen serve: session reaper started ` +
+        `(interval ${sessionReapIntervalMs}ms, ` +
+        `idle threshold ${sessionIdleTimeoutMs}ms)`,
+    );
     sessionReaper = setInterval(() => {
       if (shuttingDown) return;
       const now = Date.now();
@@ -892,7 +902,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
           (err) => {
             writeStderrLine(
               `qwen serve: session reaper failed to close ` +
-                `${JSON.stringify(id)}: ${String(err)}`,
+                `${JSON.stringify(id)}: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`,
             );
           },
         );
@@ -2345,19 +2355,31 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     if (context?.clientId !== undefined) {
       originatorClientId = resolveTrustedClientId(entry, context.clientId);
     }
+    const reason = closeOpts?.reason ?? 'client_close';
     writeStderrLine(
       `qwen serve: closing session ${JSON.stringify(sessionId)}` +
+        ` (reason: ${reason})` +
         (originatorClientId
           ? ` by client ${JSON.stringify(originatorClientId)}`
           : ''),
     );
-    const reason = closeOpts?.reason ?? 'client_close';
     telemetry.event('session.close', {
       'qwen-code.daemon.bridge.operation': 'session.close',
       'session.id': sessionId,
       'session.close.reason': reason,
     });
     if (defaultEntry === entry) defaultEntry = undefined;
+    // HAZARD: Resolve the channel via `channelInfoForEntry(entry)` (search
+    // `aliveChannels` for the entry's actual channel) instead of the
+    // module-scoped `channelInfo` (the CURRENT attach target). The two
+    // diverge during the channel-overlap window — A dying, B freshly
+    // spawned as `channelInfo` — where capturing `channelInfo` would
+    // (1) skip the `sessionIds.delete()` since `B.channel !==
+    // entry.channel`, and (2) call `markSessionClosed` on B's client
+    // instead of A's. The regression test is single-channel smoke only
+    // and WILL NOT fail if this reverts to module-scoped channelInfo.
+    // Keep `channelInfoForEntry(entry)` until a deterministic overlap
+    // test lands.
     const ci = channelInfoForEntry(entry);
     if (!ci) {
       writeStderrLine(
@@ -2368,11 +2390,18 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     if (ci && ci.channel === entry.channel) {
       ci.sessionIds.delete(sessionId);
     }
-    await notifyAgentSessionClose(entry, ci, 'closeSession');
+    // Synchronous teardown block — mirrors `killSession` ordering.
+    // `byId.delete` runs BEFORE `await notifyAgentSessionClose` so any
+    // concurrent caller (reaper tick, detach-close, explicit DELETE)
+    // that does `byId.get(sessionId)` gets `undefined` and throws
+    // `SessionNotFoundError`, preventing duplicate close cascades.
     permissionMediator.forgetSession(sessionId);
     entry.pendingPermissionIds.clear();
     byId.delete(sessionId);
     telemetry.metrics?.sessionLifecycle('close');
+    // Tombstone the closed sessionId so any late `extNotification`
+    // from the (now-defunct) child can't seed the early-event buffer
+    // and leak into a future load/resume of the same persisted id.
     ci?.client.markSessionClosed(sessionId);
     try {
       entry.events.publish({
@@ -2380,6 +2409,10 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         data: {
           sessionId,
           reason,
+          // `data.closedBy` is kept for back-compat with existing
+          // wire consumers; new code should read envelope-level
+          // `originatorClientId` (matches `session_metadata_updated`,
+          // `model_switched`, `approval_mode_changed`, etc.).
           ...(originatorClientId ? { closedBy: originatorClientId } : {}),
         },
         ...(originatorClientId ? { originatorClientId } : {}),
@@ -2387,7 +2420,10 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     } catch {
       /* bus already closed */
     }
+    // `session_closed` is terminal. Close the bus before ACP cancel so any
+    // late cancellation frames from the agent are intentionally dropped.
     entry.events.close();
+    await notifyAgentSessionClose(entry, ci, 'closeSession');
     try {
       await telemetry.withSpan(
         'session.close.cancel_active_prompt',
@@ -4431,7 +4467,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         }).catch((err) => {
           writeStderrLine(
             `qwen serve: close-on-last-detach failed for ` +
-              `${JSON.stringify(sessionId)}: ${String(err)}`,
+              `${JSON.stringify(sessionId)}: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`,
           );
         });
       }

--- a/packages/acp-bridge/src/bridgeOptions.ts
+++ b/packages/acp-bridge/src/bridgeOptions.ts
@@ -340,4 +340,17 @@ export interface BridgeOptions {
    * so it does not prevent daemon exit.
    */
   channelIdleTimeoutMs?: number;
+  /**
+   * How often the session reaper scans for idle sessions, in
+   * milliseconds. Default: 60_000 (1 minute). `0` or `Infinity`
+   * disables the reaper entirely. The timer is `.unref()`'d.
+   */
+  sessionReapIntervalMs?: number;
+  /**
+   * A session with zero SSE subscribers, zero registered clients, and
+   * no active prompt that has not received a heartbeat for this many
+   * milliseconds is reaped. Default: 1_800_000 (30 minutes). `0` or
+   * `Infinity` disables idle reaping.
+   */
+  sessionIdleTimeoutMs?: number;
 }

--- a/packages/acp-bridge/src/bridgeOptions.ts
+++ b/packages/acp-bridge/src/bridgeOptions.ts
@@ -347,10 +347,11 @@ export interface BridgeOptions {
    */
   sessionReapIntervalMs?: number;
   /**
-   * A session with zero SSE subscribers, zero registered clients, and
-   * no active prompt that has not received a heartbeat for this many
-   * milliseconds is reaped. Default: 1_800_000 (30 minutes). `0` or
-   * `Infinity` disables idle reaping.
+   * A session with zero SSE subscribers and no active prompt that has
+   * not received a heartbeat for this many milliseconds is reaped.
+   * Note: `clientIds.size` is intentionally NOT checked — the reaper
+   * covers the crash path where clients never sent a detach request.
+   * Default: 1_800_000 (30 minutes). `0` or `Infinity` disables.
    */
   sessionIdleTimeoutMs?: number;
 }

--- a/packages/acp-bridge/src/bridgeTypes.ts
+++ b/packages/acp-bridge/src/bridgeTypes.ts
@@ -129,6 +129,11 @@ export interface SessionMetadataUpdate {
   displayName?: string;
 }
 
+export interface CloseSessionOpts {
+  /** Override the default `'client_close'` reason in the `session_closed` event. */
+  reason?: string;
+}
+
 export interface BridgeClientRequestContext {
   /** Daemon-issued client id echoed through the HTTP transport header. */
   clientId?: string;
@@ -259,6 +264,7 @@ export interface AcpSessionBridge {
   closeSession(
     sessionId: string,
     context?: BridgeClientRequestContext,
+    opts?: CloseSessionOpts,
   ): Promise<void>;
 
   /**

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -49,6 +49,8 @@ interface ServeArgs {
   'prompt-deadline-ms'?: number;
   'writer-idle-timeout-ms'?: number;
   'channel-idle-timeout-ms'?: number;
+  'session-reap-interval-ms'?: number;
+  'session-idle-timeout-ms'?: number;
 }
 
 export const serveCommand: CommandModule<unknown, ServeArgs> = {
@@ -175,6 +177,17 @@ export const serveCommand: CommandModule<unknown, ServeArgs> = {
         description:
           'Milliseconds to keep ACP child alive after last session closes. ' +
           '0 or unset = immediate kill (default).',
+      })
+      .option('session-reap-interval-ms', {
+        type: 'number',
+        description:
+          'Session reaper scan interval (ms). 0 = disabled. Default: 60000.',
+      })
+      .option('session-idle-timeout-ms', {
+        type: 'number',
+        description:
+          'Idle timeout before a disconnected session is reaped (ms). ' +
+          '0 = disabled. Default: 1800000 (30 min).',
       }) as unknown as Argv<ServeArgs>,
   handler: async (argv) => {
     if (!argv['http-bridge']) {
@@ -292,6 +305,12 @@ export const serveCommand: CommandModule<unknown, ServeArgs> = {
           : {}),
         ...(argv['channel-idle-timeout-ms'] !== undefined
           ? { channelIdleTimeoutMs: argv['channel-idle-timeout-ms'] }
+          : {}),
+        ...(argv['session-reap-interval-ms'] !== undefined
+          ? { sessionReapIntervalMs: argv['session-reap-interval-ms'] }
+          : {}),
+        ...(argv['session-idle-timeout-ms'] !== undefined
+          ? { sessionIdleTimeoutMs: argv['session-idle-timeout-ms'] }
           : {}),
       });
     } catch (err) {

--- a/packages/cli/src/serve/runQwenServe.ts
+++ b/packages/cli/src/serve/runQwenServe.ts
@@ -780,6 +780,12 @@ export async function runQwenServe(
       ...(opts.channelIdleTimeoutMs !== undefined
         ? { channelIdleTimeoutMs: opts.channelIdleTimeoutMs }
         : {}),
+      ...(opts.sessionReapIntervalMs !== undefined
+        ? { sessionReapIntervalMs: opts.sessionReapIntervalMs }
+        : {}),
+      ...(opts.sessionIdleTimeoutMs !== undefined
+        ? { sessionIdleTimeoutMs: opts.sessionIdleTimeoutMs }
+        : {}),
       boundWorkspace,
       childEnvOverrides,
       channelFactory,

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -489,6 +489,7 @@ interface FakeBridge extends AcpSessionBridge {
   closeCalls: Array<{
     sessionId: string;
     context?: BridgeClientRequestContext;
+    opts?: import('@qwen-code/acp-bridge').CloseSessionOpts;
   }>;
   updateMetadataCalls: Array<{
     sessionId: string;
@@ -1075,8 +1076,12 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
       removeRuntimeMcpServerCalls.push({ name, originatorClientId });
       return removeRuntimeMcpServerImpl(name, originatorClientId);
     },
-    async closeSession(sessionId, context) {
-      closeCalls.push({ sessionId, ...(context ? { context } : {}) });
+    async closeSession(sessionId, context, opts) {
+      closeCalls.push({
+        sessionId,
+        ...(context ? { context } : {}),
+        ...(opts ? { opts } : {}),
+      });
       return closeImpl(sessionId, context);
     },
     updateSessionMetadata(sessionId, metadata, context) {
@@ -5427,6 +5432,36 @@ describe('createServeApp', () => {
         .set('Host', `127.0.0.1:${baseOpts.port}`);
       expect(res.status).toBe(503);
       expect(res.body).toEqual({ status: 'degraded' });
+    });
+  });
+
+  describe('session idle reaper — wire integration', () => {
+    it('deep health reflects reduced sessionCount after closeSession', async () => {
+      let count = 2;
+      const bridge = fakeBridge();
+      Object.defineProperty(bridge, 'sessionCount', { get: () => count });
+      const app = createServeApp(baseOpts, undefined, { bridge });
+
+      const before = await request(app)
+        .get('/health?deep=1')
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+      expect(before.body.sessions).toBe(2);
+
+      count = 0;
+      const after = await request(app)
+        .get('/health?deep=1')
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+      expect(after.body.sessions).toBe(0);
+    });
+
+    it('DELETE /session/:id passes no opts (reason defaults to client_close)', async () => {
+      const bridge = fakeBridge();
+      const app = createServeApp(baseOpts, undefined, { bridge });
+      await request(app)
+        .delete('/session/sess-1')
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+      expect(bridge.closeCalls).toHaveLength(1);
+      expect(bridge.closeCalls[0]?.opts).toBeUndefined();
     });
   });
 

--- a/packages/cli/src/serve/types.ts
+++ b/packages/cli/src/serve/types.ts
@@ -156,6 +156,10 @@ export interface ServeOptions {
   writerIdleTimeoutMs?: number;
   /** Non-negative ms to keep ACP child alive after last session closes. 0 = immediate kill (default). */
   channelIdleTimeoutMs?: number;
+  /** Session reaper scan interval in ms. 0 = disabled. Default: 60000. */
+  sessionReapIntervalMs?: number;
+  /** Session idle timeout in ms. 0 = disabled. Default: 1800000 (30 min). */
+  sessionIdleTimeoutMs?: number;
 }
 
 /**


### PR DESCRIPTION
## What this PR does

Add two-layer session lifecycle cleanup for the daemon bridge:

1. **Close-on-last-detach** (immediate) — when `detachClient` removes the last registered client AND no SSE subscribers remain, the session is closed immediately. Handles the normal path: user closes a tab → React cleanup → `POST /session/:id/detach`.
2. **Session idle reaper** (backstop) — periodic scan for orphaned sessions with no active prompt and no SSE subscribers that haven't received a heartbeat within a configurable TTL (default 30 minutes). Catches the crash path where detach was never sent.

Both paths use `closeSessionImpl` which preserves JSONL on disk — `session/load` or `session/resume` can restore any closed session.

## Why it's needed

When clients close browser tabs, crash, or lose network, sessions accumulate in the bridge's `byId` Map. Each orphaned session holds an EventBus ring (~2-4 MB). Without cleanup, the daemon eventually hits `maxSessions=20` and rejects all new sessions — a hard availability failure requiring restart.

## Reviewer Test Plan

### How to verify

1. Run `npx vitest run packages/acp-bridge/src/bridge.test.ts` — 249 tests pass (includes 15 reaper + 3 detach-close tests)
2. Review the idle predicate: no active prompt (`promptActive`), no SSE subscribers, idle > TTL
3. Review close-on-last-detach: `clientIds.size === 0 && subscriberCount === 0 && !promptActive`

### Evidence (Before & After)

Non-UI change — unit tests only. Design document at `docs/design/session-idle-reaper/README.md`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

## Risk & Scope

- Main risk: A session could be reaped while a headless client plans to reconnect. Mitigated by 30-min default TTL + JSONL preservation (session/load restores it).
- Not validated: server.test.ts integration tests have a pre-existing `undici` dependency issue on `daemon_mode_b_main` — not introduced by this PR.
- Breaking changes: None. New `session_closed` reasons (`idle_timeout`, `last_client_detached`) are additive.

## Linked Issues

None — discovered during daemon architecture analysis.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

为 daemon bridge 添加两层 session 生命周期清理机制：

1. **最后一个客户端 detach 时立即关闭**——当 `detachClient` 移除最后一个注册客户端且无 SSE 订阅者时，立即关闭 session。覆盖正常路径：用户关闭 tab → React cleanup → `POST /session/:id/detach`。
2. **Session 闲置回收器**（兜底）——定期扫描无活跃 prompt、无 SSE 订阅者且超过 TTL（默认 30 分钟）未收到心跳的孤儿 session。覆盖客户端崩溃/网络断开等 detach 请求未发出的场景。

两条路径都使用 `closeSessionImpl`，保留磁盘 JSONL——`session/load` 或 `session/resume` 可以恢复任何已关闭的 session。

## 为什么需要

客户端关闭浏览器 tab、崩溃或断网时，session 在 bridge 的 `byId` Map 中累积。每个孤儿 session 持有一个 EventBus 重放环（~2-4 MB）。如果不清理，daemon 最终会达到 `maxSessions=20` 上限并拒绝所有新 session——需要重启才能恢复的可用性故障。

## 风险与范围

- 主要风险：headless 客户端计划重连时 session 可能被回收。30 分钟默认 TTL + JSONL 保留可缓解（session/load 可恢复）。
- 无破坏性变更。新的 `session_closed` reason（`idle_timeout`、`last_client_detached`）是增量添加的。

</details>

🤖 Generated with [Qwen Code](https://qwen.ai/qwencode)