### PR TITLE
fix(daemon): enable auto-title generation for ACP sessions

### DIFF
--- a/packages/core/src/services/chatRecordingService.autoTitle.test.ts
+++ b/packages/core/src/services/chatRecordingService.autoTitle.test.ts
@@ -99,6 +99,7 @@ describe('ChatRecordingService - auto-title trigger', () => {
       getModel: vi.fn().mockReturnValue('qwen-plus'),
       getFastModel: vi.fn(() => fastModelValue),
       isInteractive: vi.fn().mockReturnValue(true),
+      getExperimentalZedIntegration: vi.fn().mockReturnValue(false),
       getDebugMode: vi.fn().mockReturnValue(false),
       getToolRegistry: vi.fn().mockReturnValue({
         getTool: vi.fn().mockReturnValue({
@@ -290,6 +291,38 @@ describe('ChatRecordingService - auto-title trigger', () => {
 
     expect(tryGenerateSessionTitleMock).not.toHaveBeenCalled();
     expect(findCustomTitleRecord()).toBeUndefined();
+  });
+
+  it('triggers in ACP (daemon) mode even though isInteractive is false', async () => {
+    vi.mocked(mockConfig.isInteractive).mockReturnValue(false);
+    vi.mocked(mockConfig.getExperimentalZedIntegration).mockReturnValue(true);
+    mockOk('Fix login button');
+
+    chatRecordingService.recordAssistantTurn({
+      model: 'qwen-plus',
+      message: [{ text: 'reply' }],
+    });
+    await flushMicrotasks();
+
+    expect(tryGenerateSessionTitleMock).toHaveBeenCalled();
+    const record = findCustomTitleRecord();
+    expect(record).toBeDefined();
+    expect((record!.systemPayload as { customTitle: string }).customTitle).toBe(
+      'Fix login button',
+    );
+  });
+
+  it('does not trigger in headless CLI mode (non-interactive, non-ACP)', async () => {
+    vi.mocked(mockConfig.isInteractive).mockReturnValue(false);
+    vi.mocked(mockConfig.getExperimentalZedIntegration).mockReturnValue(false);
+
+    chatRecordingService.recordAssistantTurn({
+      model: 'qwen-plus',
+      message: [{ text: 'reply' }],
+    });
+    await flushMicrotasks();
+
+    expect(tryGenerateSessionTitleMock).not.toHaveBeenCalled();
   });
 
   it('prevents concurrent in-flight generations across rapid turns', async () => {

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -955,9 +955,15 @@ export class ChatRecordingService {
     // Headless/one-shot CLI flows (`qwen -p "…"`, cron, CI scripts) run a
     // single prompt and throw the session away. Spending fast-model tokens
     // on a title no one will ever resume is pure waste; skip entirely.
-    // Checked before `getFastModel()` because it's strictly cheaper (a bool
-    // field read vs. a method that looks up available models).
-    if (!this.config.isInteractive()) return;
+    // Daemon (ACP) sessions are long-lived and user-resumable, so they
+    // DO need auto-titles even though `isInteractive()` returns false
+    // (the ACP child is spawned with pipe stdio, not a TTY).
+    if (
+      !this.config.isInteractive() &&
+      !this.config.getExperimentalZedIntegration()
+    ) {
+      return;
+    }
     const fastModel = this.config.getFastModel();
     if (!fastModel) return;
 


### PR DESCRIPTION
## What this PR does

Allow ACP (daemon) sessions to auto-generate session titles after the first assistant reply, matching the existing behavior of interactive TUI sessions. The fix relaxes a single guard in `maybeTriggerAutoTitle()` from `if (!isInteractive()) return` to `if (!isInteractive() && !getExperimentalZedIntegration()) return`, so daemon sessions are no longer treated as headless one-shot CLI runs.

## Why it's needed

The `isInteractive()` guard was originally added to prevent headless CLI runs (`qwen -p "..."`) from wasting fast-model tokens on a session title nobody would see. However, the ACP child process is spawned with pipe stdio (`process.stdin.isTTY === false`), which causes `isInteractive()` to return `false` for ALL daemon sessions — not just headless ones. As a result, every daemon session (Web Chat, IDE extension, Channel) shows truncated raw prompt text in the session list instead of a semantically meaningful title.

| Mode | `isInteractive()` | `getExperimentalZedIntegration()` | Auto-title before | After |
|------|-------------------|-----------------------------------|--------------------|-------|
| TUI (terminal) | `true` | `false` | works | works |
| Daemon (ACP) | `false` | `true` | **broken** | **fixed** |
| Headless CLI | `false` | `false` | blocked | blocked |

## Reviewer Test Plan

### How to verify

1. Confirm guard logic: in `chatRecordingService.ts:955-965`, verify the condition `!isInteractive() && !getExperimentalZedIntegration()` correctly skips only headless CLI mode.
2. Run `npx vitest run packages/core/src/services/chatRecordingService.autoTitle.test.ts` — all 17 tests pass (15 existing + 2 new).
3. The two new tests cover: (a) ACP mode triggers auto-title despite `isInteractive() === false`; (b) headless CLI mode (non-interactive + non-ACP) still blocks.

### Evidence (Before & After)

Non-UI change — unit tests only.

Before: `maybeTriggerAutoTitle` returns early for any non-interactive config, including ACP.
After: `maybeTriggerAutoTitle` proceeds for ACP sessions (`getExperimentalZedIntegration() === true`).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

## Risk & Scope

- Main risk or tradeoff: ACP sessions now consume one fast-model call (~130 tokens) per new session for title generation. This matches TUI behavior and is bounded by `AUTO_TITLE_ATTEMPT_CAP = 3`.
- Not validated / out of scope: The generated title is written to JSONL only — no SSE push to connected clients. Session list refresh is needed to see the new title (same as TUI).
- Breaking changes / migration notes: None.

## Linked Issues

None — discovered during daemon session lifecycle analysis.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

允许 ACP（daemon）会话在第一个 assistant 回复后自动生成会话标题，与交互式 TUI 会话的现有行为一致。修复方式是将 `maybeTriggerAutoTitle()` 中的守卫条件从 `if (!isInteractive()) return` 放宽为 `if (!isInteractive() && !getExperimentalZedIntegration()) return`，使 daemon 会话不再被当作一次性无头 CLI 运行。

## 为什么需要

`isInteractive()` 守卫最初是为了防止无头 CLI 运行（`qwen -p "..."`）在不会被看到的会话标题上浪费 fast model token。但 ACP 子进程通过 pipe stdio 启动（`process.stdin.isTTY === false`），导致所有 daemon 会话的 `isInteractive()` 返回 `false`——不仅仅是无头运行。结果是所有 daemon 会话（Web Chat、IDE 扩展、Channel）在会话列表中显示截断的原始 prompt 文本，而非语义化的标题。

## 风险与范围

- 主要风险：ACP 会话现在每个新会话消耗一次 fast model 调用（~130 tokens）。与 TUI 行为一致，受 `AUTO_TITLE_ATTEMPT_CAP = 3` 限制。
- 未验证/超出范围：生成的标题仅写入 JSONL，不通过 SSE 推送到已连接的客户端。需要刷新会话列表才能看到新标题（与 TUI 相同）。
- 无破坏性变更。

</details>

🤖 Generated with [Qwen Code](https://qwen.ai/qwencode)