### PR TITLE
feat(skills): enforce auto-skill- directory prefix for auto-generated skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,11 @@ CLAUDE.md
 !.qwen/commands/**
 !.qwen/skills/
 !.qwen/skills/**
+# Re-ignore auto-generated skills (created by the managed-skill-extractor
+# agent with the mandatory `auto-skill-` directory prefix). Git's last-rule-
+# wins semantics keep hand-authored project skills tracked while excluding
+# these transient, session-specific directories.
+.qwen/skills/auto-skill-*/
 !.qwen/agents/
 !.qwen/agents/**
 

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,9 @@ CLAUDE.md
 # Re-ignore auto-generated skills (created by the managed-skill-extractor
 # agent with the mandatory `auto-skill-` directory prefix). Git's last-rule-
 # wins semantics keep hand-authored project skills tracked while excluding
-# these transient, session-specific directories.
+# these transient, session-specific directories. The `auto-skill-` prefix is
+# reserved for auto-generated skills — do not hand-author a project skill with
+# this prefix, or its directory will be ignored here.
 .qwen/skills/auto-skill-*/
 !.qwen/agents/
 !.qwen/agents/**

--- a/packages/core/src/memory/skillReviewAgentPlanner.test.ts
+++ b/packages/core/src/memory/skillReviewAgentPlanner.test.ts
@@ -23,6 +23,7 @@ import {
   buildTaskPrompt,
   createSkillScopedAgentConfig,
   listExistingSkillDirNames,
+  SKILL_REVIEW_SYSTEM_PROMPT,
 } from './skillReviewAgentPlanner.js';
 import { ToolNames } from '../tools/tool-names.js';
 
@@ -361,5 +362,19 @@ describe('buildTaskPrompt', () => {
     expect(prompt).toContain(AUTO_SKILL_DIR_PREFIX);
     expect(prompt).toContain(`.qwen/skills/${AUTO_SKILL_DIR_PREFIX}<name>/`);
     expect(prompt).toMatch(/mandatory/i);
+  });
+});
+
+describe('SKILL_REVIEW_SYSTEM_PROMPT', () => {
+  it('requires the auto-skill- directory prefix for new skills (#4837)', () => {
+    // The system prompt and buildTaskPrompt carry the prefix instruction on
+    // two independent string arrays. buildTaskPrompt is asserted above; this
+    // guards the parallel system-prompt line so an edit to one can't silently
+    // drop the prefix mandate from the other.
+    expect(SKILL_REVIEW_SYSTEM_PROMPT).toContain(AUTO_SKILL_DIR_PREFIX);
+    expect(SKILL_REVIEW_SYSTEM_PROMPT).toContain(
+      `.qwen/skills/${AUTO_SKILL_DIR_PREFIX}<name>/`,
+    );
+    expect(SKILL_REVIEW_SYSTEM_PROMPT).toMatch(/MUST use/i);
   });
 });

--- a/packages/core/src/memory/skillReviewAgentPlanner.test.ts
+++ b/packages/core/src/memory/skillReviewAgentPlanner.test.ts
@@ -19,6 +19,7 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { Config } from '../config/config.js';
 import {
+  AUTO_SKILL_DIR_PREFIX,
   buildTaskPrompt,
   createSkillScopedAgentConfig,
   listExistingSkillDirNames,
@@ -349,5 +350,16 @@ describe('buildTaskPrompt', () => {
     const prompt = await buildTaskPrompt(projectRoot);
     expect(prompt).toContain(path.join(projectRoot, '.qwen', 'skills'));
     expect(prompt).toContain('real');
+  });
+
+  it('instructs the agent to use the auto-skill- directory prefix (#4837)', async () => {
+    // The `.gitignore` re-ignores `.qwen/skills/auto-skill-*/`, so new
+    // auto-generated skills must land under an `auto-skill-`-prefixed
+    // directory to stay out of version control. The prompt is the soft
+    // guard that steers the agent there.
+    const prompt = await buildTaskPrompt(projectRoot);
+    expect(prompt).toContain(AUTO_SKILL_DIR_PREFIX);
+    expect(prompt).toContain(`.qwen/skills/${AUTO_SKILL_DIR_PREFIX}<name>/`);
+    expect(prompt).toMatch(/mandatory/i);
   });
 });

--- a/packages/core/src/memory/skillReviewAgentPlanner.ts
+++ b/packages/core/src/memory/skillReviewAgentPlanner.ts
@@ -27,6 +27,17 @@ export const SKILL_REVIEW_AGENT_NAME = 'managed-skill-extractor' as const;
 export const DEFAULT_AUTO_SKILL_MAX_TURNS = 8;
 export const DEFAULT_AUTO_SKILL_TIMEOUT_MS = 120_000;
 
+/**
+ * Mandatory directory-name prefix for skills created by the review agent.
+ * The project `.gitignore` re-ignores directories matching
+ * `.qwen/skills/auto-skill-<glob>` so these transient, session-specific
+ * skills stay out of version control while hand-authored project skills
+ * remain tracked. This is a prompt-level convention only — skill discovery
+ * (`SkillManager`) is prefix-agnostic, and the `source: auto-skill`
+ * frontmatter marker remains the file-level signal for edit protection.
+ */
+export const AUTO_SKILL_DIR_PREFIX = 'auto-skill-' as const;
+
 export interface SkillReviewExecutionResult {
   touchedSkillFiles: string[];
   systemMessage?: string;
@@ -239,6 +250,7 @@ const SKILL_REVIEW_SYSTEM_PROMPT = [
   "- You may ONLY modify skill files that contain 'source: auto-skill' in their YAML frontmatter. Always read a skill file before editing it.",
   '- Do NOT touch skills that lack this marker — they were created by the user.',
   "- When creating a new skill, you MUST include 'source: auto-skill' in the frontmatter so future review agents can safely update it.",
+  `- When creating a new skill, its directory MUST use the \`${AUTO_SKILL_DIR_PREFIX}\` prefix (e.g. \`.qwen/skills/${AUTO_SKILL_DIR_PREFIX}<name>/SKILL.md\`) so the project's .gitignore keeps auto-generated skills out of version control. Keep the frontmatter \`name:\` as the natural \`<name>\` without the prefix.`,
   '- Do NOT delete any skill. Only create or update.',
   '',
   "If nothing is worth saving, just say 'Nothing to save.' and stop.",
@@ -328,7 +340,7 @@ export async function buildTaskPrompt(projectRoot: string): Promise<string> {
     '',
     'Use `ls` and `read_file` to inspect existing skills before writing.',
     'Use `write_file` to create a new skill, `edit` to update an existing auto-skill.',
-    "Each skill lives at .qwen/skills/<name>/SKILL.md. Skills you create MUST include 'source: auto-skill' in the frontmatter:",
+    `New skills you create MUST live at \`.qwen/skills/${AUTO_SKILL_DIR_PREFIX}<name>/SKILL.md\` — the \`${AUTO_SKILL_DIR_PREFIX}\` directory prefix is mandatory so the project's .gitignore keeps auto-generated skills out of version control. Keep the frontmatter \`name:\` as the natural \`<name>\` (no prefix). The frontmatter MUST include 'source: auto-skill':`,
     '',
     '---',
     'name: <skill-name>',

--- a/packages/core/src/memory/skillReviewAgentPlanner.ts
+++ b/packages/core/src/memory/skillReviewAgentPlanner.ts
@@ -239,7 +239,9 @@ export function createSkillScopedAgentConfig(
   return scopedConfig;
 }
 
-const SKILL_REVIEW_SYSTEM_PROMPT = [
+// Exported for tests so the `auto-skill-` prefix instruction stays asserted
+// at the system-prompt layer too, not just in `buildTaskPrompt`.
+export const SKILL_REVIEW_SYSTEM_PROMPT = [
   'You are reviewing this conversation to extract reusable skills.',
   '',
   'Review the conversation above and consider saving or updating a skill if appropriate.',


### PR DESCRIPTION
## What this PR does

Auto-generated skills — the ones the `managed-skill-extractor` forked agent writes under `.qwen/skills/` — now use a mandatory `auto-skill-` directory prefix, and the project `.gitignore` re-ignores `.qwen/skills/auto-skill-*/`. Hand-authored project skills (e.g. `bugfix`, `triage`) keep their natural directory names and stay tracked; only auto-generated directories are excluded from version control. The change is two parts: a `.gitignore` rule, and a prompt-layer instruction that steers the review agent to create new skill directories with the prefix. The skill's frontmatter `name:` stays the natural name, so a skill created at `.qwen/skills/auto-skill-foo/` is still invoked as `/foo`.

## Why it's needed

When auto-skill generation creates skills under `.qwen/skills/`, they show up as untracked files in `git status` because the current `.gitignore` explicitly unignores the entire `.qwen/skills/` directory. This is noise for developers and risks accidentally committing transient, session-specific skills. A directory-name prefix solves it cleanly: git's last-rule-wins semantics re-ignore only `auto-skill-`-prefixed directories while keeping hand-authored skills tracked. The existing `source: auto-skill` frontmatter marker only helps at file-read time — it can't drive `.gitignore` or a directory listing, which is what a name prefix does.

## Reviewer Test Plan

### How to verify

1. `.gitignore` semantics (last-rule-wins) — in a scratch repo with the updated rules:

   ```
   mkdir -p .qwen/skills/{bugfix,auto-skill-foo,qwen-code-session-data-extraction}
   touch .qwen/skills/*/SKILL.md
   git check-ignore -v .qwen/skills/auto-skill-foo/SKILL.md   # ignored by `.qwen/skills/auto-skill-*/`
   git check-ignore -v .qwen/skills/bugfix/SKILL.md           # NOT ignored (re-included by `!.qwen/skills/**`)
   git check-ignore -v .qwen/skills/qwen-code-session-data-extraction/SKILL.md  # NOT ignored — legacy skills stay tracked
   ```

   Expected: only the `auto-skill-`-prefixed directory is ignored; hand-authored and pre-existing auto-skills remain tracked.

2. Prompt-layer instruction — unit test:

   ```
   npx vitest run packages/core/src/memory/skillReviewAgentPlanner.test.ts
   ```

   Expected: 18 passed, including `instructs the agent to use the auto-skill- directory prefix (#4837)`, which asserts `buildTaskPrompt()` emits `.qwen/skills/auto-skill-<name>/` and the `mandatory` wording.

### Evidence (Before & After)

N/A — non-user-visible (`.gitignore` rule + prompt text). The behavioral change is the agent's chosen directory name and git's ignore status, both covered by the verification steps above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only (`npx vitest run`); `.gitignore` semantics verified with `git check-ignore` in a scratch repo.

## Risk & Scope

- Main risk or tradeoff: The prefix is enforced at the prompt layer only, not in the permission layer (`evaluateScopedDecision`). If the agent ignores the instruction, the sole consequence is that the new skill appears in `git status` — the pre-existing behavior — so there is no security or correctness boundary at stake. Keeping it prompt-only matches the issue scope.
- Not validated / out of scope: No changes to `SkillManager` discovery (it is prefix-agnostic by design) and no renaming of existing auto-generated skills (`qwen-code-session-data-extraction`, `qwen-code-token-bridge-server`).
- Breaking changes / migration notes: None. Existing skills are untouched; only newly created auto-skills get the prefix going forward.

## Linked Issues

Closes #4837

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

自动生成的 skill（由 `managed-skill-extractor` forked agent 写入 `.qwen/skills/` 的那些）现在强制使用 `auto-skill-` 目录前缀，项目 `.gitignore` 重新忽略 `.qwen/skills/auto-skill-*/`。手写的项目 skill（如 `bugfix`、`triage`）保持自然目录名并继续被 git 跟踪，只有自动生成的目录被排除出版本控制。改动分两部分：一条 `.gitignore` 规则，以及一条 prompt 层指令，引导 review agent 用带前缀的目录名创建新 skill。skill 的 frontmatter `name:` 保持自然名，所以创建在 `.qwen/skills/auto-skill-foo/` 的 skill 仍然用 `/foo` 调用。

## 为什么需要

auto-skill 在 `.qwen/skills/` 下创建后，由于当前 `.gitignore` 显式 unignore 了整个目录，它们会出现在 `git status` 的 untracked files 中，造成噪音并有误提交风险。目录前缀干净解决：git 的"后规则优先"语义只重新忽略带 `auto-skill-` 前缀的目录，手写 skill 保持跟踪。已有的 `source: auto-skill` frontmatter 标记只在读文件时有效，无法驱动 `.gitignore` 或目录列表——而前缀可以。

## Reviewer 测试计划

### 如何验证

1. `.gitignore` 语义（后规则优先）——在 scratch 仓库用更新后的规则：`git check-ignore -v` 验证 `auto-skill-foo/SKILL.md` 被忽略，而 `bugfix/SKILL.md` 和 legacy 的 `qwen-code-session-data-extraction/SKILL.md` 不被忽略。
2. prompt 层指令——单元测试：`npx vitest run packages/core/src/memory/skillReviewAgentPlanner.test.ts`，预期 18 passed，含新测试 `instructs the agent to use the auto-skill- directory prefix (#4837)`。

### 证据（Before & After）

N/A——非用户可见改动（`.gitignore` 规则 + prompt 文本）。

### 测试平台

仅 macOS 本地验证；Windows / Linux 由 CI 覆盖。

## 风险与范围

- 主要风险/取舍：前缀只在 prompt 层强制，不在权限层（`evaluateScopedDecision`）。即使 agent 忽略指令，唯一后果是新 skill 出现在 `git status`（即当前已有行为），无安全或正确性边界风险。只做 prompt 层符合 issue scope。
- 未验证/范围外：不改动 `SkillManager` discovery（设计上就 prefix-agnostic），不重命名已有自动生成 skill。
- 破坏性变更：无。已有 skill 不受影响，仅新建 auto-skill 起效。

## 关联 Issue

Closes #4837

</details>
