### PR TITLE
fix(ci): acknowledge queued qwen review requests

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -30,6 +30,48 @@ on:
         type: 'number'
 
 jobs:
+  ack-review-request:
+    if: |-
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        github.event.issue.state == 'open' &&
+        (github.event.comment.body == '@qwen-code /review' ||
+         startsWith(github.event.comment.body, '@qwen-code /review ') ||
+         startsWith(github.event.comment.body, format('@qwen-code /review{0}', '\n'))) &&
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        github.event.pull_request.state == 'open' &&
+        (github.event.comment.body == '@qwen-code /review' ||
+         startsWith(github.event.comment.body, '@qwen-code /review ') ||
+         startsWith(github.event.comment.body, format('@qwen-code /review{0}', '\n'))) &&
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'pull_request_review' &&
+        github.event.pull_request.state == 'open' &&
+        (github.event.review.body == '@qwen-code /review' ||
+         startsWith(github.event.review.body, '@qwen-code /review ') ||
+         startsWith(github.event.review.body, format('@qwen-code /review{0}', '\n'))) &&
+        (github.event.review.author_association == 'OWNER' ||
+         github.event.review.author_association == 'MEMBER' ||
+         github.event.review.author_association == 'COLLABORATOR'))
+    runs-on: 'ubuntu-latest'
+    permissions:
+      pull-requests: 'read'
+      issues: 'write'
+    steps:
+      - name: 'Post queued acknowledgement'
+        env:
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          PR_NUMBER: '${{ github.event.issue.number || github.event.pull_request.number }}'
+          RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+        run: |-
+          gh pr comment "$PR_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --body "_Qwen Code review request accepted. Review is queued in [workflow run](${RUN_URL})._"
+
   review-pr:
     if: |-
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -45,6 +45,7 @@ concurrency:
 
 jobs:
   ack-review-request:
+    # KEEP IN SYNC with review-pr.if (explicit-trigger branches).
     if: |-
       (github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
@@ -68,6 +69,7 @@ jobs:
         (github.event.review.body == '@qwen-code /review' ||
          startsWith(github.event.review.body, '@qwen-code /review ') ||
          startsWith(github.event.review.body, format('@qwen-code /review{0}', '\n'))) &&
+        github.event.review.state == 'commented' &&
         (github.event.review.author_association == 'OWNER' ||
          github.event.review.author_association == 'MEMBER' ||
          github.event.review.author_association == 'COLLABORATOR'))
@@ -75,6 +77,7 @@ jobs:
       group: 'qwen-pr-ack-${{ github.event.issue.number || github.event.pull_request.number }}'
       cancel-in-progress: false
     runs-on: 'ubuntu-latest'
+    timeout-minutes: 5
     permissions:
       pull-requests: 'write'
       issues: 'write'
@@ -86,9 +89,15 @@ jobs:
           RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
         run: |-
           set -euo pipefail
+          PR_STATE="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state --jq '.state')"
+          if [ "$PR_STATE" != "OPEN" ]; then
+            echo "PR #${PR_NUMBER} is ${PR_STATE}; skipping acknowledgement." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
           gh pr comment "$PR_NUMBER" \
             --repo "$GITHUB_REPOSITORY" \
-            --body "_Qwen Code review request accepted. Review is queued in [workflow run](${RUN_URL})._"
+            --body "<!-- qwen-review-ack -->_Qwen Code review request accepted. Review is queued in [workflow run](${RUN_URL})._"
+          echo "Queued acknowledgement posted on PR #${PR_NUMBER}." >> "$GITHUB_STEP_SUMMARY"
 
   review-config:
     if: |-
@@ -191,6 +200,7 @@ jobs:
     # - review_requested uses authorize-review-request and skips delay
     # - opened/synchronize uses delay-automatic-review
     # - reopened/ready_for_review runs immediately for trusted PR authors
+    # KEEP IN SYNC with ack-review-request.if (explicit-trigger branches).
     if: |-
       always() &&
       (github.event_name == 'workflow_dispatch' ||
@@ -229,6 +239,7 @@ jobs:
         (github.event.review.body == '@qwen-code /review' ||
          startsWith(github.event.review.body, '@qwen-code /review ') ||
          startsWith(github.event.review.body, format('@qwen-code /review{0}', '\n'))) &&
+        github.event.review.state == 'commented' &&
         (github.event.review.author_association == 'OWNER' ||
          github.event.review.author_association == 'MEMBER' ||
          github.event.review.author_association == 'COLLABORATOR')))

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -69,7 +69,6 @@ jobs:
         (github.event.review.body == '@qwen-code /review' ||
          startsWith(github.event.review.body, '@qwen-code /review ') ||
          startsWith(github.event.review.body, format('@qwen-code /review{0}', '\n'))) &&
-        github.event.review.state == 'commented' &&
         (github.event.review.author_association == 'OWNER' ||
          github.event.review.author_association == 'MEMBER' ||
          github.event.review.author_association == 'COLLABORATOR'))
@@ -254,7 +253,6 @@ jobs:
         (github.event.review.body == '@qwen-code /review' ||
          startsWith(github.event.review.body, '@qwen-code /review ') ||
          startsWith(github.event.review.body, format('@qwen-code /review{0}', '\n'))) &&
-        github.event.review.state == 'commented' &&
         (github.event.review.author_association == 'OWNER' ||
          github.event.review.author_association == 'MEMBER' ||
          github.event.review.author_association == 'COLLABORATOR')))

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -57,6 +57,9 @@ jobs:
         (github.event.review.author_association == 'OWNER' ||
          github.event.review.author_association == 'MEMBER' ||
          github.event.review.author_association == 'COLLABORATOR'))
+    concurrency:
+      group: 'qwen-pr-ack-${{ github.event.issue.number || github.event.pull_request.number }}'
+      cancel-in-progress: true
     runs-on: 'ubuntu-latest'
     permissions:
       pull-requests: 'read'
@@ -68,6 +71,13 @@ jobs:
           PR_NUMBER: '${{ github.event.issue.number || github.event.pull_request.number }}'
           RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
         run: |-
+          set -euo pipefail
+          IS_FORK="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json isCrossRepository --jq '.isCrossRepository')"
+          if [ "$IS_FORK" = "true" ]; then
+            echo "Skipping ack: PR #${PR_NUMBER} is a fork PR; review-pr skips forks." >&2
+            exit 0
+          fi
+
           gh pr comment "$PR_NUMBER" \
             --repo "$GITHUB_REPOSITORY" \
             --body "_Qwen Code review request accepted. Review is queued in [workflow run](${RUN_URL})._"

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -73,10 +73,10 @@ jobs:
          github.event.review.author_association == 'COLLABORATOR'))
     concurrency:
       group: 'qwen-pr-ack-${{ github.event.issue.number || github.event.pull_request.number }}'
-      cancel-in-progress: true
+      cancel-in-progress: false
     runs-on: 'ubuntu-latest'
     permissions:
-      pull-requests: 'read'
+      pull-requests: 'write'
       issues: 'write'
     steps:
       - name: 'Post queued acknowledgement'
@@ -86,12 +86,6 @@ jobs:
           RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
         run: |-
           set -euo pipefail
-          IS_FORK="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json isCrossRepository --jq '.isCrossRepository')"
-          if [ "$IS_FORK" = "true" ]; then
-            echo "Skipping ack: PR #${PR_NUMBER} is a fork PR; review-pr skips forks." >&2
-            exit 0
-          fi
-
           gh pr comment "$PR_NUMBER" \
             --repo "$GITHUB_REPOSITORY" \
             --body "_Qwen Code review request accepted. Review is queued in [workflow run](${RUN_URL})._"

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -98,8 +98,9 @@ jobs:
           EXISTING_ACK_ID="$(
             gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
               --paginate \
-              --jq 'map(select(.body | contains("<!-- qwen-review-ack -->")))[-1].id // ""'
-          )"
+              -F per_page=100 \
+              | jq -sr '[.[][] | select(.body | contains("<!-- qwen-review-ack -->")) | select(.user.login == "github-actions[bot]")] | last | .id // empty'
+          )" || EXISTING_ACK_ID=""
           if [ -n "$EXISTING_ACK_ID" ]; then
             gh api \
               --method PATCH \

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -94,10 +94,24 @@ jobs:
             echo "PR #${PR_NUMBER} is ${PR_STATE}; skipping acknowledgement." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          gh pr comment "$PR_NUMBER" \
-            --repo "$GITHUB_REPOSITORY" \
-            --body "<!-- qwen-review-ack -->_Qwen Code review request accepted. Review is queued in [workflow run](${RUN_URL})._"
-          echo "Queued acknowledgement posted on PR #${PR_NUMBER}." >> "$GITHUB_STEP_SUMMARY"
+          ACK_BODY="<!-- qwen-review-ack -->_Qwen Code review request accepted. Review is queued in [workflow run](${RUN_URL})._"
+          EXISTING_ACK_ID="$(
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              --paginate \
+              --jq 'map(select(.body | contains("<!-- qwen-review-ack -->")))[-1].id // ""'
+          )"
+          if [ -n "$EXISTING_ACK_ID" ]; then
+            gh api \
+              --method PATCH \
+              "repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING_ACK_ID}" \
+              -f body="$ACK_BODY" > /dev/null
+            echo "Queued acknowledgement updated on PR #${PR_NUMBER}." >> "$GITHUB_STEP_SUMMARY"
+          else
+            gh pr comment "$PR_NUMBER" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body "$ACK_BODY"
+            echo "Queued acknowledgement posted on PR #${PR_NUMBER}." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
   review-config:
     if: |-

--- a/packages/core/src/utils/environmentContext.test.ts
+++ b/packages/core/src/utils/environmentContext.test.ts
@@ -399,6 +399,9 @@ describe('formatDateForContext', () => {
     const result = formatDateForContext();
     expect(typeof result).toBe('string');
     expect(result.length).toBeGreaterThan(0);
+  });
+});
+
 describe('startup reminder builders', () => {
   function registry(overrides: Partial<ToolRegistry>): ToolRegistry {
     return {


### PR DESCRIPTION
## What this PR does

Adds an immediate acknowledgement for explicit Qwen Code PR review requests. When a collaborator comments `@qwen-code /review` in a PR conversation, review comment, or review body, the workflow now posts a short PR comment with a link to the Actions run before the self-hosted review job is picked up.

## Why it's needed

The actual review still depends on the self-hosted `ecs-qwen` runner. When that runner is busy, the review job can remain queued with no visible PR conversation feedback, which makes it look like Qwen Code did not trigger. This gives users a quick accepted/queued signal without changing the review execution environment.

## Reviewer Test Plan

### How to verify

Comment `@qwen-code /review` on an open PR as an owner, member, or collaborator. Confirm that the workflow posts a queued acknowledgement with a run link, then confirm that the existing review job still runs through the self-hosted review path.

### Evidence (Before & After)

Before: an accepted review request could sit queued on the self-hosted runner with no PR conversation feedback. After: the workflow posts `_Qwen Code review request accepted. Review is queued in [workflow run](...)._` before the self-hosted runner picks up the review.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

Validated workflow formatting locally with `npx prettier --check .github/workflows/qwen-code-pr-review.yml`. `actionlint` was not available in this environment, and the GitHub event itself must be verified by the PR workflow.

## Risk & Scope

- Main risk or tradeoff: Explicit review requests now add one short PR comment before the actual review result.
- Not validated / out of scope: End-to-end GitHub event execution before merge; this requires the workflow to run in GitHub Actions.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #4846

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

为显式的 Qwen Code PR review 请求增加即时确认反馈。当 owner、member 或 collaborator 在 PR 对话、review comment 或 review body 中评论 `@qwen-code /review` 时，workflow 会先发布一条带 Actions run 链接的简短 PR 评论，然后再等待 self-hosted review job 被调度。

## 为什么需要

真正的 review 仍然依赖 self-hosted `ecs-qwen` runner。当 runner 繁忙时，review job 可能长时间排队，而且 PR 对话区没有任何反馈，看起来就像 Qwen Code 没有触发。这个改动在不改变 review 执行环境的前提下，让用户能立即看到请求已被接受并进入队列。

## Reviewer Test Plan

### 如何验证

以 owner、member 或 collaborator 身份在一个打开的 PR 上评论 `@qwen-code /review`。确认 workflow 发布了带 run 链接的 queued acknowledgement，然后确认现有 review job 仍然走 self-hosted review 路径。

### 证据（Before & After）

Before：review 请求已被接受时，可能因为 self-hosted runner 排队而在 PR 对话区没有任何反馈。After：workflow 会先发布 `_Qwen Code review request accepted. Review is queued in [workflow run](...)._`，再等待 self-hosted runner 执行 review。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### 环境（可选）

本地通过 `npx prettier --check .github/workflows/qwen-code-pr-review.yml` 验证 workflow 格式。当前环境没有 `actionlint`，GitHub event 级别的端到端验证需要在 GitHub Actions 中完成。

## 风险与范围

- 主要风险或取舍：显式 review 请求现在会在真正 review 结果前多发一条简短 PR 评论。
- 未验证 / 范围外：合并前无法在本地端到端验证 GitHub event 执行，需要依赖 GitHub Actions 实跑。
- Breaking changes / migration notes：无。

## 关联 Issue

Fixes #4846

</details>
