### PR TITLE
fix(core): fix qc-helper skill docs index and config categories

### DIFF
--- a/packages/core/src/skills/bundled/qc-helper/SKILL.md
+++ b/packages/core/src/skills/bundled/qc-helper/SKILL.md
@@ -121,7 +121,7 @@ When the user asks about configuration, the primary reference is `docs/configura
 | Permissions   | `permissions.allow/ask/deny`                                         | `docs/configuration/settings.md`, `docs/features/approval-mode.md`                               |
 | MCP Servers   | `mcpServers.*`, `mcp.*`                                              | `docs/configuration/settings.md`, `docs/features/mcp.md`                                         |
 | Tool Approval | `tools.approvalMode`                                                 | `docs/configuration/settings.md`, `docs/features/approval-mode.md`, `docs/features/auto-mode.md` |
-| Hooks         | `hooks.*`                                                            | `docs/features/hooks.md`                                                                         |
+| Hooks         | `hooks.*`                                                            | `docs/configuration/settings.md`, `docs/features/hooks.md`                                        |
 | Model         | `model.name`, `modelProviders`                                       | `docs/configuration/settings.md`, `docs/configuration/model-providers.md`                        |
 | General/UI    | `general.*`, `ui.*`, `ide.*`, `output.*`                             | `docs/configuration/settings.md`                                                                 |
 | Context       | `context.*`                                                          | `docs/configuration/settings.md`                                                                 |

--- a/packages/core/src/skills/bundled/qc-helper/SKILL.md
+++ b/packages/core/src/skills/bundled/qc-helper/SKILL.md
@@ -43,25 +43,30 @@ Use this index to locate the right document for the user's question. Load only t
 | Model providers (OpenAI-compatible, etc.) | `docs/configuration/model-providers.md` |
 | .qwenignore file                          | `docs/configuration/qwen-ignore.md`     |
 | Themes                                    | `docs/configuration/themes.md`          |
-| Memory                                    | `docs/configuration/memory.md`          |
 | Trusted folders                           | `docs/configuration/trusted-folders.md` |
 
 ### Features
 
-| Topic                                       | Doc Path                         |
-| ------------------------------------------- | -------------------------------- |
-| Approval mode (plan/default/auto_edit/yolo) | `docs/features/approval-mode.md` |
-| MCP (Model Context Protocol)                | `docs/features/mcp.md`           |
-| Skills system                               | `docs/features/skills.md`        |
-| Sub-agents                                  | `docs/features/sub-agents.md`    |
-| Sandbox / security                          | `docs/features/sandbox.md`       |
-| Slash commands                              | `docs/features/commands.md`      |
-| Headless / non-interactive mode             | `docs/features/headless.md`      |
-| LSP integration                             | `docs/features/lsp.md`           |
-| Checkpointing                               | `docs/features/checkpointing.md` |
-| Token caching                               | `docs/features/token-caching.md` |
-| Language / i18n                             | `docs/features/language.md`      |
-| Arena mode                                  | `docs/features/arena.md`         |
+| Topic                                       | Doc Path                           |
+| ------------------------------------------- | ---------------------------------- |
+| Approval mode (plan/default/auto_edit/yolo) | `docs/features/approval-mode.md`   |
+| Auto mode (AI-driven approval)              | `docs/features/auto-mode.md`       |
+| Hooks (lifecycle hooks)                     | `docs/features/hooks.md`           |
+| MCP (Model Context Protocol)                | `docs/features/mcp.md`             |
+| Memory                                      | `docs/features/memory.md`          |
+| Skills system                               | `docs/features/skills.md`          |
+| Sub-agents                                  | `docs/features/sub-agents.md`      |
+| Sandbox / security                          | `docs/features/sandbox.md`         |
+| Slash commands                              | `docs/features/commands.md`        |
+| Headless / non-interactive mode             | `docs/features/headless.md`        |
+| LSP integration                             | `docs/features/lsp.md`             |
+| Checkpointing                               | `docs/features/checkpointing.md`   |
+| Token caching                               | `docs/features/token-caching.md`   |
+| Language / i18n                             | `docs/features/language.md`        |
+| Arena mode                                  | `docs/features/arena.md`           |
+| Status line                                 | `docs/features/status-line.md`     |
+| Scheduled tasks (cron/loop)                 | `docs/features/scheduled-tasks.md` |
+| Worktree                                    | `docs/features/worktree.md`        |
 
 ### IDE Integration
 
@@ -111,15 +116,16 @@ When the user asks about configuration, the primary reference is `docs/configura
 
 ### Common Config Categories
 
-| Category      | Key Config Keys                                                               | Reference                                                                 |
-| ------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| Permissions   | `permissions.allow/ask/deny`                                                  | `docs/configuration/settings.md`, `docs/features/approval-mode.md`        |
-| MCP Servers   | `mcpServers.*`, `mcp.*`                                                       | `docs/configuration/settings.md`, `docs/features/mcp.md`                  |
-| Tool Approval | `tools.approvalMode`                                                          | `docs/configuration/settings.md`, `docs/features/approval-mode.md`        |
-| Model         | `model.name`, `modelProviders`                                                | `docs/configuration/settings.md`, `docs/configuration/model-providers.md` |
-| General/UI    | `general.*`, `ui.*`, `ide.*`, `output.*`                                      | `docs/configuration/settings.md`                                          |
-| Context       | `context.*`                                                                   | `docs/configuration/settings.md`                                          |
-| Advanced      | `hooks`, `env`, `webSearch`, `security`, `privacy`, `telemetry`, `advanced.*` | `docs/configuration/settings.md`                                          |
+| Category      | Key Config Keys                                                      | Reference                                                                                        |
+| ------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Permissions   | `permissions.allow/ask/deny`                                         | `docs/configuration/settings.md`, `docs/features/approval-mode.md`                               |
+| MCP Servers   | `mcpServers.*`, `mcp.*`                                              | `docs/configuration/settings.md`, `docs/features/mcp.md`                                         |
+| Tool Approval | `tools.approvalMode`                                                 | `docs/configuration/settings.md`, `docs/features/approval-mode.md`, `docs/features/auto-mode.md` |
+| Hooks         | `hooks.*`                                                            | `docs/features/hooks.md`                                                                         |
+| Model         | `model.name`, `modelProviders`                                       | `docs/configuration/settings.md`, `docs/configuration/model-providers.md`                        |
+| General/UI    | `general.*`, `ui.*`, `ide.*`, `output.*`                             | `docs/configuration/settings.md`                                                                 |
+| Context       | `context.*`                                                          | `docs/configuration/settings.md`                                                                 |
+| Advanced      | `env`, `webSearch`, `security`, `privacy`, `telemetry`, `advanced.*` | `docs/configuration/settings.md`                                                                 |
 
 ---
 


### PR DESCRIPTION
## What this PR does

The `qc-helper` bundled skill maintains a documentation index (tables mapping topics to doc file paths) that it uses to locate and load the correct user docs when answering configuration questions. This index had several stale and missing entries, causing the skill to either fail to find relevant docs or silently skip them.

Three fixes in one file (`packages/core/src/skills/bundled/qc-helper/SKILL.md`):

1. **Broken path removed**: `docs/configuration/memory.md` did not exist — the file lives at `docs/features/memory.md`. Moved it to the Features table at the correct path.
2. **Missing doc entries added** to the Features table: `hooks.md`, `auto-mode.md`, `status-line.md`, `scheduled-tasks.md`, `worktree.md`. These are all real files under `docs/users/features/` that the skill previously had no pointer to.
3. **Hooks promoted to a first-class config category** in the "Common Config Categories" table — extracted from the catch-all "Advanced" bucket and given its own row pointing at `docs/features/hooks.md` (a 1300-line comprehensive reference). Also added `auto-mode.md` reference to the Tool Approval row.

## Why it's needed

Users invoke `/qc-helper` to ask questions like "how do I set up a PostToolUse hook?" or "what's the difference between allow and deny permissions?". The skill uses the index to decide which doc to `read_file`. With hooks missing from the index entirely, the skill had no way to discover the hooks documentation — it would fall back to the generic `settings.md` which only has a brief mention. Similarly, memory was pointed at a nonexistent path, so any memory-related question would silently miss the dedicated doc.

This is a docs-only change to a bundled skill's SKILL.md. No runtime code, no type changes, no tests affected.

## Reviewer Test Plan

### How to verify

1. Build: `npm run build` — should pass (no TS/code changes).
2. Invoke `/qc-helper how do I configure a hook to run prettier after file writes?` — the skill should read `docs/features/hooks.md` (check debug logs or observe the tool calls). Before this PR it would fall back to `settings.md` and give a shallow answer.
3. Invoke `/qc-helper how does memory work?` — should find `docs/features/memory.md`. Before this PR the path was wrong (`docs/configuration/memory.md` doesn't exist).
4. Confirm all newly-indexed doc paths exist: `ls docs/users/features/{hooks,auto-mode,status-line,scheduled-tasks,worktree,memory}.md`.

### Evidence (Before & After)

N/A — non-user-visible change (bundled skill prompt text only). The behavior difference is observable via `/qc-helper` invocations as described above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A — Markdown-only change.

## Risk & Scope

- Main risk or tradeoff: None. Markdown change in a bundled skill's SKILL.md; no runtime code, no schema, no tests.
- Not validated / out of scope: Did not audit every other bundled skill's doc references — only `qc-helper` was scoped here.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

---

## 中文说明

### 这个 PR 做了什么

`qc-helper` 这个 bundled skill 内部维护了一份文档索引（topic 到文档路径的映射表），用于在回答用户配置问题时定位并加载正确的用户文档。这份索引存在多个过期和缺失的条目，导致 skill 要么找不到相关文档，要么静默跳过。

在一个文件中修复了三类问题（`packages/core/src/skills/bundled/qc-helper/SKILL.md`）：

1. **修复错误路径**：`docs/configuration/memory.md` 实际不存在——文件位于 `docs/features/memory.md`。已将其移动到 Features 表的正确路径。
2. **补充缺失的文档条目**：在 Features 表中新增 `hooks.md`、`auto-mode.md`、`status-line.md`、`scheduled-tasks.md`、`worktree.md`。这些都是 `docs/users/features/` 下真实存在但 skill 之前没有指向的文件。
3. **Hooks 提升为独立的配置类别**：在 "Common Config Categories" 表中，将 Hooks 从"Advanced"兜底分类中提取出来，单独成行并指向 `docs/features/hooks.md`（一份 1300 行的完整参考文档）。同时为 Tool Approval 行补充了 `auto-mode.md` 引用。

### 为什么需要这个改动

用户通过 `/qc-helper` 提出诸如"如何配置一个在文件写入后运行 prettier 的 hook？"或"allow 和 deny 权限有什么区别？"这类问题。skill 依赖索引来决定 `read_file` 读取哪个文档。在 Hooks 完全缺失于索引的情况下，skill 无法发现 hooks 文档——只能退而求其次使用泛化的 `settings.md`，给出浅显的回答。同样，memory 指向了一个不存在的路径，所有关于 memory 的问题都会静默错过专用文档。

这是一个仅涉及 bundled skill SKILL.md 的文档变更。没有运行时代码、没有类型变更、不影响测试。

### 风险与范围

- 主要风险或权衡：无。bundled skill SKILL.md 的 Markdown 变更；无运行时代码、无 schema、无测试。
- 未验证 / 超出范围：未审计其他 bundled skill 的文档引用——本次仅针对 `qc-helper`。
- 破坏性变更 / 迁移说明：无。

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)
