### PR TITLE
fix(daemon): stamp serverTimestamp at EventBus and fix streaming state finalization

### DIFF
--- a/packages/acp-bridge/src/compactionEngine.test.ts
+++ b/packages/acp-bridge/src/compactionEngine.test.ts
@@ -249,17 +249,22 @@ describe('TurnBoundaryCompactionEngine', () => {
     it('folds tool_call + tool_call_updates into single final-state event', () => {
       const engine = new TurnBoundaryCompactionEngine();
       engine.ingest(makeTextChunk(1, 'Let me check'));
-      engine.ingest(makeToolCall(2, 'tc1', 'running', { title: 'Read file' }));
-      engine.ingest(
-        makeToolCallUpdate(3, 'tc1', 'running', {
+      engine.ingest({
+        ...makeToolCall(2, 'tc1', 'running', { title: 'Read file' }),
+        _meta: { serverTimestamp: 100, source: 'initial' },
+      });
+      engine.ingest({
+        ...makeToolCallUpdate(3, 'tc1', 'running', {
           content: 'reading...',
         }),
-      );
-      engine.ingest(
-        makeToolCallUpdate(4, 'tc1', 'done', {
+        _meta: { serverTimestamp: 150 },
+      });
+      engine.ingest({
+        ...makeToolCallUpdate(4, 'tc1', 'done', {
           rawOutput: 'file contents',
         }),
-      );
+        _meta: { serverTimestamp: 200 },
+      });
       engine.ingest(makeTextChunk(5, 'Done'));
       engine.ingest(makeTurnComplete(6));
 
@@ -281,6 +286,10 @@ describe('TurnBoundaryCompactionEngine', () => {
       expect(data.update.title).toBe('Read file');
       expect(data.update.rawOutput).toBe('file contents');
       expect(toolEvent.id).toBe(4); // last update's id
+      expect(toolEvent._meta).toEqual({
+        serverTimestamp: 200,
+        source: 'initial',
+      });
     });
 
     it('preserves tool call order when multiple tools run', () => {

--- a/packages/acp-bridge/src/compactionEngine.test.ts
+++ b/packages/acp-bridge/src/compactionEngine.test.ts
@@ -686,6 +686,9 @@ describe('EventBus + CompactionEngine integration', () => {
       update: { content: { text: string } };
     };
     expect(mergedText.update.content.text).toBe('Hi there');
+    expect(snapshot!.compactedTurns[1]!._meta?.['serverTimestamp']).toEqual(
+      expect.any(Number),
+    );
   });
 
   it('snapshotReplay returns undefined when no engine is configured', () => {

--- a/packages/acp-bridge/src/compactionEngine.ts
+++ b/packages/acp-bridge/src/compactionEngine.ts
@@ -44,6 +44,7 @@ type CompactedSlot =
       chunks: string[];
       lastEventId: number;
       lastMeta: unknown;
+      lastEnvelopeMeta?: Record<string, unknown>;
     }
   | { kind: 'tool'; toolCallId: string; event: BridgeEvent }
   | { kind: 'misc'; event: BridgeEvent }
@@ -220,6 +221,7 @@ export class TurnBoundaryCompactionEngine implements CompactionEngine {
         slot.chunks.push(text);
         if (event.id !== undefined) slot.lastEventId = event.id;
         slot.lastMeta = meta ?? slot.lastMeta;
+        slot.lastEnvelopeMeta = event._meta ?? slot.lastEnvelopeMeta;
       } else {
         this.textSlotIndex.set(slotKey, this.slots.length);
         this.slots.push({
@@ -228,6 +230,7 @@ export class TurnBoundaryCompactionEngine implements CompactionEngine {
           chunks: [text],
           lastEventId: event.id ?? 0,
           lastMeta: meta,
+          lastEnvelopeMeta: event._meta,
         });
       }
     } else {
@@ -243,6 +246,7 @@ export class TurnBoundaryCompactionEngine implements CompactionEngine {
         lastSlot.chunks.push(text);
         if (event.id !== undefined) lastSlot.lastEventId = event.id;
         lastSlot.lastMeta = meta ?? lastSlot.lastMeta;
+        lastSlot.lastEnvelopeMeta = event._meta ?? lastSlot.lastEnvelopeMeta;
       } else {
         this.slots.push({
           kind,
@@ -250,6 +254,7 @@ export class TurnBoundaryCompactionEngine implements CompactionEngine {
           chunks: [text],
           lastEventId: event.id ?? 0,
           lastMeta: meta,
+          lastEnvelopeMeta: event._meta,
         });
       }
     }
@@ -270,6 +275,7 @@ export class TurnBoundaryCompactionEngine implements CompactionEngine {
               slot.chunks.join(''),
               slot.lastEventId,
               slot.lastMeta,
+              slot.lastEnvelopeMeta,
             ),
           );
           break;
@@ -297,11 +303,13 @@ function makeMergedSessionUpdateEvent(
   text: string,
   eventId: number,
   meta: unknown,
+  envelopeMeta: Record<string, unknown> | undefined,
 ): BridgeEvent {
   return {
     id: eventId || undefined,
     v: EVENT_SCHEMA_VERSION,
     type: 'session_update',
+    ...(envelopeMeta !== undefined ? { _meta: envelopeMeta } : {}),
     data: {
       update: {
         sessionUpdate,
@@ -326,9 +334,7 @@ function normalizeToolCallType(event: BridgeEvent): BridgeEvent {
   return event;
 }
 
-function extractParentToolCallIdFromMeta(
-  meta: unknown,
-): string | undefined {
+function extractParentToolCallIdFromMeta(meta: unknown): string | undefined {
   if (typeof meta === 'object' && meta !== null) {
     const val = (meta as Record<string, unknown>)['parentToolCallId'];
     return typeof val === 'string' && val.length > 0 ? val : undefined;

--- a/packages/acp-bridge/src/compactionEngine.ts
+++ b/packages/acp-bridge/src/compactionEngine.ts
@@ -359,11 +359,16 @@ function mergeToolCallEvent(
   }
   // Always use 'tool_call' as the compacted type
   merged['sessionUpdate'] = 'tool_call';
+  const mergedMeta =
+    existing._meta || incoming._meta
+      ? { ...(existing._meta ?? {}), ...(incoming._meta ?? {}) }
+      : undefined;
 
   return {
     id: incoming.id ?? existing.id,
     v: EVENT_SCHEMA_VERSION,
     type: 'session_update',
+    ...(mergedMeta ? { _meta: mergedMeta } : {}),
     data: {
       ...existingData,
       ...incomingData,

--- a/packages/acp-bridge/src/eventBus.test.ts
+++ b/packages/acp-bridge/src/eventBus.test.ts
@@ -34,6 +34,32 @@ describe('EventBus', () => {
     expect(bus.lastEventId).toBe(2);
   });
 
+  it('stamps published events with serverTimestamp metadata', () => {
+    const bus = new EventBus();
+    const before = Date.now();
+    const event = bus.publish({
+      type: 'foo',
+      data: 1,
+      _meta: { source: 'test' },
+    });
+    const after = Date.now();
+
+    expect(event?._meta?.['source']).toBe('test');
+    expect(event?._meta?.['serverTimestamp']).toBeGreaterThanOrEqual(before);
+    expect(event?._meta?.['serverTimestamp']).toBeLessThanOrEqual(after);
+  });
+
+  it('preserves an existing serverTimestamp when publishing', () => {
+    const bus = new EventBus();
+    const event = bus.publish({
+      type: 'foo',
+      data: 1,
+      _meta: { serverTimestamp: 123 },
+    });
+
+    expect(event?._meta?.['serverTimestamp']).toBe(123);
+  });
+
   it('delivers live publishes to a subscriber', async () => {
     const bus = new EventBus();
     const abort = new AbortController();

--- a/packages/acp-bridge/src/eventBus.ts
+++ b/packages/acp-bridge/src/eventBus.ts
@@ -50,6 +50,10 @@ export interface BridgeEvent {
   /** Frame payload — opaque JSON. */
   data: unknown;
   /**
+   * Envelope metadata shared by SSE and load/replay responses.
+   */
+  _meta?: Record<string, unknown>;
+  /**
    * Identifier of the client that triggered the event, when known. Used by
    * fan-out consumers to suppress echoes of their own actions.
    */
@@ -107,6 +111,13 @@ const WARN_RESET_RATIO = 0.375;
  * configured at the listener level — see `runQwenServe.ts`.
  */
 const DEFAULT_MAX_SUBSCRIBERS = 64;
+
+function getServerTimestamp(meta: Record<string, unknown> | undefined): number {
+  const existing = meta?.['serverTimestamp'];
+  return typeof existing === 'number' && Number.isFinite(existing)
+    ? existing
+    : Date.now();
+}
 
 interface InternalSub {
   queue: BoundedAsyncQueue<BridgeEvent>;
@@ -222,10 +233,15 @@ export class EventBus {
     // straightforward; nobody can observe a frame nobody can subscribe
     // to anyway.
     if (this.closed) return undefined;
+    const existingMeta = input._meta;
     const event: BridgeEvent = {
       id: this.nextId++,
       v: EVENT_SCHEMA_VERSION,
       ...input,
+      _meta: {
+        ...(existingMeta ?? {}),
+        serverTimestamp: getServerTimestamp(existingMeta),
+      },
     };
     this.ring.push(event);
     try {

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -6272,10 +6272,10 @@ describe('GET /session/:id/events (SSE)', () => {
   });
 
   it('stamps _meta.serverTimestamp on every SSE frame (#4175 F4 prereq, chiga0 #19 P0)', async () => {
-    // The daemon stamps `_meta.serverTimestamp` at the SSE write
-    // boundary so multi-client UIs use the server clock for transcript
-    // ordering / "X minutes ago" instead of each client's drifting
-    // local clock. The chiga0 SDK PR #4353 reads this via a 3-
+    // The daemon stamps `_meta.serverTimestamp` so multi-client UIs
+    // use the server clock for transcript ordering / "X minutes ago"
+    // instead of each client's drifting local clock. The chiga0 SDK
+    // PR #4353 reads this via a 3-
     // location probe (`event.serverTimestamp` / `event._meta.
     // serverTimestamp` / `event.data._meta.serverTimestamp`); we
     // pick `_meta.serverTimestamp` (Anthropic convention) so the
@@ -6343,6 +6343,32 @@ describe('GET /session/:id/events (SSE)', () => {
     expect(parsed._meta.toolName).toBe('Read');
     expect(parsed._meta.timestamp).toBe(1234567890);
     expect(typeof parsed._meta.serverTimestamp).toBe('number');
+  });
+
+  it('preserves pre-existing _meta.serverTimestamp on SSE frames', async () => {
+    const bridge = fakeBridge({
+      async *subscribeImpl(_sessionId, _opts) {
+        yield {
+          id: 1,
+          v: 1,
+          type: 'session_update',
+          data: { foo: 'bar' },
+          _meta: { serverTimestamp: 1234567890 },
+        };
+        await new Promise(() => {});
+      },
+    });
+    handle = await runQwenServe(
+      { hostname: '127.0.0.1', port: 0, mode: 'http-bridge' },
+      { bridge },
+    );
+    const port = (handle.server.address() as { port: number }).port;
+
+    const res = await fetch(`http://127.0.0.1:${port}/session/sess-A/events`);
+    const frames = await readSseFrames(res.body!, 1);
+
+    const parsed = JSON.parse(frames[0]!.data!);
+    expect(parsed._meta.serverTimestamp).toBe(1234567890);
   });
 
   it('forwards Last-Event-ID to the bridge', async () => {

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -3536,16 +3536,19 @@ function formatSseFrame(event: BridgeEvent | OmitId<BridgeEvent>): string {
   // multi-line variant on the receive side — input/output asymmetry is
   // intentional.
   //
-  // `_meta.serverTimestamp`: stamp the daemon's wall-clock at SSE write
-  // time so multi-client transcript ordering uses the server's clock.
-  // Stamped at the wire boundary (NOT at EventBus.publish) so the
-  // in-memory `BridgeEvent` type stays unchanged. The top-level merge
-  // with `event._meta` is a forward-compat escape hatch for future
-  // envelope-level metadata; today `existingMeta` is always `undefined`.
+  // `_meta.serverTimestamp`: EventBus stamps normal session frames when they
+  // are published so SSE and load/replay share the same event time. Keep this
+  // fallback for synthetic frames that do not pass through EventBus.
   const existingMeta = (event as { _meta?: Record<string, unknown> })._meta;
+  const existingServerTimestamp = existingMeta?.['serverTimestamp'];
+  const serverTimestamp =
+    typeof existingServerTimestamp === 'number' &&
+    Number.isFinite(existingServerTimestamp)
+      ? existingServerTimestamp
+      : Date.now();
   const stamped = {
     ...event,
-    _meta: { ...(existingMeta ?? {}), serverTimestamp: Date.now() },
+    _meta: { ...(existingMeta ?? {}), serverTimestamp },
   };
   const dataJson = JSON.stringify(stamped);
   const idLine =

--- a/packages/sdk-typescript/src/daemon/types.ts
+++ b/packages/sdk-typescript/src/daemon/types.ts
@@ -1325,6 +1325,8 @@ export interface DaemonEvent {
   type: string;
   /** Frame payload — opaque JSON. */
   data: unknown;
+  /** Envelope metadata, including daemon-emitted timestamps when available. */
+  _meta?: Record<string, unknown>;
   originatorClientId?: string;
 }
 

--- a/packages/sdk-typescript/src/daemon/ui/normalizer.ts
+++ b/packages/sdk-typescript/src/daemon/ui/normalizer.ts
@@ -351,12 +351,13 @@ function createBase(
 }
 
 /**
- * Extract daemon-authoritative timestamp from envelope. Looks at three
+ * Extract daemon-authoritative timestamp from envelope. Looks at known
  * candidate locations in order:
  *
  *   1. `event.serverTimestamp` — top-level, preferred when daemon adds it
  *   2. `event._meta.serverTimestamp` — Anthropic-style metadata convention
  *   3. `event.data._meta.serverTimestamp` — sessionUpdate nested location
+ *   4. `event.data.update._meta.serverTimestamp|timestamp` — ACP update meta
  *
  * Returns undefined when none of them are present or all are non-finite.
  * Forward-compat: SDK reads whichever location the daemon eventually emits
@@ -375,6 +376,18 @@ function extractServerTimestamp(event: DaemonEvent): number | undefined {
     if (isRecord(dataMeta)) {
       const ts = dataMeta['serverTimestamp'];
       if (typeof ts === 'number' && Number.isFinite(ts)) return ts;
+    }
+    const update = (event.data as Record<string, unknown>)['update'];
+    if (isRecord(update)) {
+      const updateMeta = update['_meta'];
+      if (isRecord(updateMeta)) {
+        const serverTs = updateMeta['serverTimestamp'];
+        if (typeof serverTs === 'number' && Number.isFinite(serverTs)) {
+          return serverTs;
+        }
+        const ts = updateMeta['timestamp'];
+        if (typeof ts === 'number' && Number.isFinite(ts)) return ts;
+      }
     }
   }
   return undefined;

--- a/packages/sdk-typescript/src/daemon/ui/transcript.ts
+++ b/packages/sdk-typescript/src/daemon/ui/transcript.ts
@@ -96,13 +96,10 @@ export function appendLocalUserTranscriptMessage(
   opts: DaemonTranscriptReducerOptions = {},
 ): DaemonTranscriptState {
   const next = cloneTranscriptState(state, opts);
+  finishAssistant(next);
   const block = createTextBlock(next, 'user', text);
   appendBlock(next, block);
   next.activeUserBlockId = block.id;
-  next.activeAssistantBlockId = undefined;
-  next.activeThoughtBlockId = undefined;
-  next.activeAssistantBlockByParent = {};
-  next.activeThoughtBlockByParent = {};
   return trimTranscriptState(next);
 }
 
@@ -370,10 +367,52 @@ export function selectPendingPermissionBlocks(
   );
 }
 
-// Keyed (parentToolCallId) and scalar (activeAssistantBlockId) paths are
-// fully independent. Neither clears nor finalizes the other's blocks.
-// Only finishAssistant() or clearActiveText() with matching parentToolCallId
-// can finalize keyed-path blocks.
+function finalizeStreamingTextBlock(
+  state: DaemonTranscriptState,
+  blockId: string | undefined,
+): void {
+  const block = getWritableBlockById(state, blockId);
+  if (block?.kind === 'assistant' || block?.kind === 'thought') {
+    block.streaming = false;
+    block.updatedAt = state.now;
+  }
+}
+
+function clearActiveAssistant(state: DaemonTranscriptState): void {
+  finalizeStreamingTextBlock(state, state.activeAssistantBlockId);
+  state.activeAssistantBlockId = undefined;
+}
+
+function clearActiveThought(state: DaemonTranscriptState): void {
+  finalizeStreamingTextBlock(state, state.activeThoughtBlockId);
+  state.activeThoughtBlockId = undefined;
+}
+
+function clearActiveAssistantForParent(
+  state: DaemonTranscriptState,
+  parentToolCallId: string,
+): void {
+  finalizeStreamingTextBlock(
+    state,
+    state.activeAssistantBlockByParent[parentToolCallId],
+  );
+  delete state.activeAssistantBlockByParent[parentToolCallId];
+}
+
+function clearActiveThoughtForParent(
+  state: DaemonTranscriptState,
+  parentToolCallId: string,
+): void {
+  finalizeStreamingTextBlock(
+    state,
+    state.activeThoughtBlockByParent[parentToolCallId],
+  );
+  delete state.activeThoughtBlockByParent[parentToolCallId];
+}
+
+// Keyed (parentToolCallId) and scalar paths are independent, but replacing an
+// active assistant/thought with another text kind must finalize the old block
+// before clearing its active pointer.
 function appendTextDelta(
   state: DaemonTranscriptState,
   kind: 'user' | 'assistant' | 'thought',
@@ -406,7 +445,10 @@ function appendTextDelta(
     existing.text = appendBoundedText(existing.text, text);
     existing.updatedAt = state.now;
     if (event.eventId !== undefined) existing.eventId = event.eventId;
-    if (kind === 'assistant') existing.streaming = true;
+    if (event.serverTimestamp !== undefined) {
+      existing.serverTimestamp = event.serverTimestamp;
+    }
+    if (kind === 'assistant' || kind === 'thought') existing.streaming = true;
     return;
   }
 
@@ -417,7 +459,7 @@ function appendTextDelta(
     event.eventId,
     event.serverTimestamp,
   );
-  if (kind === 'assistant') block.streaming = true;
+  if (kind === 'assistant' || kind === 'thought') block.streaming = true;
   if (kind === 'thought') block.collapsed = true;
   if (parentId != null) {
     (block as DaemonTextTranscriptBlock).parentToolCallId = parentId;
@@ -432,56 +474,28 @@ function appendTextDelta(
 
   if (parentId != null) {
     if (kind === 'assistant') {
-      delete state.activeThoughtBlockByParent[parentId];
+      clearActiveThoughtForParent(state, parentId);
     }
     if (kind === 'thought') {
-      const evictedAssistId = state.activeAssistantBlockByParent[parentId];
-      if (evictedAssistId) {
-        const evicted = getWritableBlockById(state, evictedAssistId);
-        if (evicted?.kind === 'assistant') {
-          evicted.streaming = false;
-          evicted.updatedAt = state.now;
-        }
-      }
-      delete state.activeAssistantBlockByParent[parentId];
+      clearActiveAssistantForParent(state, parentId);
     }
   } else {
     if (kind !== 'user') state.activeUserBlockId = undefined;
-    if (kind !== 'assistant') state.activeAssistantBlockId = undefined;
-    if (kind !== 'thought') state.activeThoughtBlockId = undefined;
+    if (kind !== 'assistant') clearActiveAssistant(state);
+    if (kind !== 'thought') clearActiveThought(state);
   }
 }
 
 function finishAssistant(state: DaemonTranscriptState): void {
-  const existing = getWritableBlockById(state, state.activeAssistantBlockId);
-  if (existing?.kind === 'assistant') {
-    existing.streaming = false;
-    existing.updatedAt = state.now;
-  }
-  state.activeAssistantBlockId = undefined;
+  clearActiveAssistant(state);
 
-  for (const blockId of Object.values(state.activeAssistantBlockByParent)) {
-    const block = getWritableBlockById(state, blockId);
-    if (block?.kind === 'assistant') {
-      block.streaming = false;
-      block.updatedAt = state.now;
-    }
+  for (const parentId of Object.keys(state.activeAssistantBlockByParent)) {
+    clearActiveAssistantForParent(state, parentId);
   }
-  state.activeAssistantBlockByParent = {};
-  for (const blockId of Object.values(state.activeThoughtBlockByParent)) {
-    const block = getWritableBlockById(state, blockId);
-    if (block?.kind === 'thought') {
-      block.streaming = false;
-      block.updatedAt = state.now;
-    }
+  for (const parentId of Object.keys(state.activeThoughtBlockByParent)) {
+    clearActiveThoughtForParent(state, parentId);
   }
-  state.activeThoughtBlockByParent = {};
-  const scalarThought = getWritableBlockById(state, state.activeThoughtBlockId);
-  if (scalarThought?.kind === 'thought') {
-    scalarThought.streaming = false;
-    scalarThought.updatedAt = state.now;
-  }
-  state.activeThoughtBlockId = undefined;
+  clearActiveThought(state);
 }
 
 function upsertToolBlock(
@@ -1118,20 +1132,11 @@ function clearActiveText(
   parentToolCallId?: string,
 ): void {
   if (parentToolCallId) {
-    const assistId = state.activeAssistantBlockByParent[parentToolCallId];
-    if (assistId) {
-      const block = getWritableBlockById(state, assistId);
-      if (block?.kind === 'assistant') {
-        block.streaming = false;
-        block.updatedAt = state.now;
-      }
-      delete state.activeAssistantBlockByParent[parentToolCallId];
-    }
-    delete state.activeThoughtBlockByParent[parentToolCallId];
+    clearActiveAssistantForParent(state, parentToolCallId);
+    clearActiveThoughtForParent(state, parentToolCallId);
   } else {
     finishAssistant(state);
     state.activeUserBlockId = undefined;
-    state.activeThoughtBlockId = undefined;
   }
 }
 

--- a/packages/sdk-typescript/test/unit/daemonUi.test.ts
+++ b/packages/sdk-typescript/test/unit/daemonUi.test.ts
@@ -133,9 +133,8 @@ describe('daemon UI normalizer and transcript reducer', () => {
     );
 
     expect(streaming.blocks).toMatchObject([
-      { kind: 'thought', text: 'thinking' },
+      { kind: 'thought', text: 'thinking', streaming: true },
     ]);
-    expect(streaming.blocks[0]).not.toHaveProperty('streaming', false);
 
     const finished = reduceDaemonTranscriptEvents(
       streaming,
@@ -2066,6 +2065,66 @@ describe('daemon UI time schema (PR-B)', () => {
     expect(events[0]).toMatchObject({
       type: 'user.text.delta',
       serverTimestamp: 1_888_888_888_888,
+    });
+  });
+
+  it('extracts serverTimestamp from ACP update _meta timestamp', () => {
+    const events = normalizeDaemonEvent({
+      id: 2,
+      v: 1,
+      type: 'session_update',
+      data: {
+        update: {
+          _meta: { timestamp: 1_780_905_333_596 },
+          sessionUpdate: 'user_message_chunk',
+          content: { type: 'text', text: 'hello' },
+        },
+      },
+    });
+    expect(events[0]).toMatchObject({
+      type: 'user.text.delta',
+      serverTimestamp: 1_780_905_333_596,
+    });
+  });
+
+  it('backfills serverTimestamp onto an existing text block', () => {
+    let state = createDaemonTranscriptState({ now: 1 });
+    state = reduceDaemonTranscriptEvents(
+      state,
+      normalizeDaemonEvent({
+        id: 1,
+        v: 1,
+        type: 'session_update',
+        data: {
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'hel' },
+          },
+        },
+      }),
+    );
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      normalizeDaemonEvent({
+        id: 2,
+        v: 1,
+        type: 'session_update',
+        data: {
+          update: {
+            _meta: { timestamp: 1_780_910_319_876 },
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'lo' },
+          },
+        },
+      }),
+    );
+
+    expect(state.blocks[0]).toMatchObject({
+      kind: 'assistant',
+      text: 'hello',
+      eventId: 2,
+      serverTimestamp: 1_780_910_319_876,
     });
   });
 
@@ -5883,8 +5942,8 @@ describe('parallel subAgent text interleaving fix', () => {
     const before = state.blocks.filter((b) => b.kind === 'thought') as Array<{
       streaming?: boolean;
     }>;
-    expect(before[0]!.streaming).toBeUndefined();
-    expect(before[1]!.streaming).toBeUndefined();
+    expect(before[0]!.streaming).toBe(true);
+    expect(before[1]!.streaming).toBe(true);
 
     state = reduceDaemonTranscriptEvents(
       state,
@@ -6010,6 +6069,12 @@ describe('parallel subAgent text interleaving fix', () => {
 
     expect(state.activeAssistantBlockByParent).toEqual({});
     expect(state.activeThoughtBlockByParent).toEqual({});
+    expect(
+      state.blocks.find(
+        (block) =>
+          block.kind === 'assistant' && block.parentToolCallId === 'task-Y',
+      ),
+    ).toMatchObject({ streaming: false, updatedAt: 3 });
   });
 
   it('T8: thought evicts assistant block and finalizes streaming for same parent', () => {
@@ -6186,6 +6251,81 @@ describe('parallel subAgent text interleaving fix', () => {
 
     expect(state.activeThoughtBlockByParent['task-E']).toBeUndefined();
     expect(state.activeAssistantBlockByParent['task-E']).toBeDefined();
+    expect(
+      state.blocks.find((block) => block.kind === 'thought'),
+    ).toMatchObject({ streaming: false, updatedAt: 3 });
+  });
+
+  it('T12b: scalar assistant finalizes previous scalar thought block', () => {
+    let state = createDaemonTranscriptState({ now: 1 });
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [{ type: 'thought.text.delta', text: 'thinking first' }],
+      { now: 2 },
+    );
+
+    expect(state.activeThoughtBlockId).toBeDefined();
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [{ type: 'assistant.text.delta', text: 'now responding' }],
+      { now: 3 },
+    );
+
+    expect(state.activeThoughtBlockId).toBeUndefined();
+    expect(state.activeAssistantBlockId).toBeDefined();
+    expect(
+      state.blocks.find((block) => block.kind === 'thought'),
+    ).toMatchObject({ streaming: false, updatedAt: 3 });
+  });
+
+  it('T12c: scalar thought finalizes previous scalar assistant block', () => {
+    let state = createDaemonTranscriptState({ now: 1 });
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [{ type: 'assistant.text.delta', text: 'answer first' }],
+      { now: 2 },
+    );
+
+    expect(state.activeAssistantBlockId).toBeDefined();
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [{ type: 'thought.text.delta', text: 'thinking next' }],
+      { now: 3 },
+    );
+
+    expect(state.activeAssistantBlockId).toBeUndefined();
+    expect(state.activeThoughtBlockId).toBeDefined();
+    expect(
+      state.blocks.find((block) => block.kind === 'assistant'),
+    ).toMatchObject({ streaming: false, updatedAt: 3 });
+  });
+
+  it('T12d: scalar user text finalizes previous scalar assistant block', () => {
+    let state = createDaemonTranscriptState({ now: 1 });
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [{ type: 'assistant.text.delta', text: 'answer first' }],
+      { now: 2 },
+    );
+
+    expect(state.activeAssistantBlockId).toBeDefined();
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [{ type: 'user.text.delta', text: 'new question' }],
+      { now: 3 },
+    );
+
+    expect(state.activeAssistantBlockId).toBeUndefined();
+    expect(state.activeUserBlockId).toBeDefined();
+    expect(
+      state.blocks.find((block) => block.kind === 'assistant'),
+    ).toMatchObject({ streaming: false, updatedAt: 3 });
   });
 
   it('T13: scoped clearActiveText sets streaming=false on cleared block', () => {
@@ -6228,6 +6368,56 @@ describe('parallel subAgent text interleaving fix', () => {
         (b as { parentToolCallId?: string }).parentToolCallId === 'task-B',
     ) as Array<{ streaming?: boolean }>;
     expect(bBlocks[0]!.streaming).toBe(true);
+  });
+
+  it('T13b: scoped clearActiveText finalizes assistant and thought for the same parent', () => {
+    let state = createDaemonTranscriptState({ now: 1 });
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [
+        {
+          type: 'assistant.text.delta',
+          text: 'assistant streaming',
+          parentToolCallId: 'task-A',
+        },
+        {
+          type: 'thought.text.delta',
+          text: 'thought streaming',
+          parentToolCallId: 'task-B',
+        },
+        {
+          type: 'tool.update',
+          toolCallId: 'child-tool-A',
+          title: 'Bash',
+          status: 'running',
+          parentToolCallId: 'task-A',
+        } as DaemonUiEvent,
+        {
+          type: 'tool.update',
+          toolCallId: 'child-tool-B',
+          title: 'Bash',
+          status: 'running',
+          parentToolCallId: 'task-B',
+        } as DaemonUiEvent,
+      ],
+      { now: 2 },
+    );
+
+    expect(
+      state.blocks.find(
+        (block) =>
+          block.kind === 'assistant' && block.parentToolCallId === 'task-A',
+      ),
+    ).toMatchObject({ streaming: false });
+    expect(
+      state.blocks.find(
+        (block) =>
+          block.kind === 'thought' && block.parentToolCallId === 'task-B',
+      ),
+    ).toMatchObject({ streaming: false });
+    expect(state.activeAssistantBlockByParent['task-A']).toBeUndefined();
+    expect(state.activeThoughtBlockByParent['task-B']).toBeUndefined();
   });
 
   it('T14: scoped clearActiveText preserves scalar activeAssistantBlockId', () => {

--- a/packages/web-shell/client/adapters/transcriptToMessages.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.ts
@@ -542,7 +542,7 @@ function daemonToolBlockToToolCall(
     rawOutput,
     args: block.rawInput as Record<string, unknown> | undefined,
     parentToolCallId: block.parentToolCallId,
-    startTime: block.createdAt,
+    startTime: blockStartTime(block),
     endTime: isComplete && !isBackgroundAgent ? block.updatedAt : undefined,
   };
 }
@@ -579,10 +579,14 @@ function permissionBlockToToolCall(
     status: 'pending',
     kind: inferToolKind(toolName, kind),
     args: rawInput,
-    startTime: block.createdAt,
+    startTime: blockStartTime(block),
   };
 
   return syntheticTool;
+}
+
+function blockStartTime(block: DaemonTranscriptBlock): number {
+  return block.serverTimestamp ?? block.clientReceivedAt;
 }
 
 function rememberPermissionToolInfo(

--- a/packages/web-shell/client/adapters/transcriptToMessages.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.ts
@@ -542,7 +542,7 @@ function daemonToolBlockToToolCall(
     rawOutput,
     args: block.rawInput as Record<string, unknown> | undefined,
     parentToolCallId: block.parentToolCallId,
-    startTime: blockStartTime(block),
+    startTime: block.createdAt,
     endTime: isComplete && !isBackgroundAgent ? block.updatedAt : undefined,
   };
 }
@@ -579,14 +579,10 @@ function permissionBlockToToolCall(
     status: 'pending',
     kind: inferToolKind(toolName, kind),
     args: rawInput,
-    startTime: blockStartTime(block),
+    startTime: block.createdAt,
   };
 
   return syntheticTool;
-}
-
-function blockStartTime(block: DaemonTranscriptBlock): number {
-  return block.serverTimestamp ?? block.clientReceivedAt;
 }
 
 function rememberPermissionToolInfo(

--- a/packages/web-shell/vite.config.ts
+++ b/packages/web-shell/vite.config.ts
@@ -41,9 +41,17 @@ export default defineConfig(({ command }) => ({
               '../webui/src/daemon-react-sdk.ts',
             ),
             '@qwen-code/webui': resolve(__dirname, '../webui/src/index.ts'),
+            '@qwen-code/sdk/daemon': resolve(
+              __dirname,
+              '../sdk-typescript/src/daemon/index.ts',
+            ),
+            '@qwen-code/sdk': resolve(
+              __dirname,
+              '../sdk-typescript/src/index.ts',
+            ),
           }
         : {},
-    dedupe: ['react', 'react-dom', '@qwen-code/webui'],
+    dedupe: ['react', 'react-dom', '@qwen-code/webui', '@qwen-code/sdk'],
   },
   build: {
     outDir: '../dist',

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -1321,6 +1321,84 @@ describe('DaemonSessionProvider', () => {
     ]);
   });
 
+  it('finishes each completed turn in replay snapshots', async () => {
+    const session = createMockSession({
+      replaySnapshot: {
+        compactedReplay: [
+          {
+            id: 1,
+            v: 1,
+            type: 'session_update',
+            data: {
+              update: {
+                sessionUpdate: 'agent_message_chunk',
+                content: { type: 'text', text: 'first done' },
+              },
+            },
+          },
+          {
+            id: 2,
+            v: 1,
+            type: 'turn_complete',
+            data: { stopReason: 'end_turn' },
+          },
+          {
+            id: 3,
+            v: 1,
+            type: 'session_update',
+            data: {
+              update: {
+                sessionUpdate: 'agent_message_chunk',
+                content: { type: 'text', text: 'second done' },
+              },
+            },
+          },
+          {
+            id: 4,
+            v: 1,
+            type: 'turn_complete',
+            data: { stopReason: 'end_turn' },
+          },
+        ],
+        liveJournal: [
+          {
+            id: 5,
+            v: 1,
+            type: 'session_update',
+            data: {
+              update: {
+                sessionUpdate: 'agent_message_chunk',
+                content: { type: 'text', text: 'still running' },
+              },
+            },
+          },
+        ],
+      },
+    });
+    sdkMocks.sessions.push(session);
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+
+    function Harness() {
+      blocks = useDaemonTranscriptBlocks();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      reconnectDelayMs: 1,
+      maxReconnectDelayMs: 1,
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(blocks.filter((block) => block.kind === 'assistant')).toMatchObject([
+      { text: 'first done', streaming: false },
+      { text: 'second done', streaming: false },
+      { text: 'still running', streaming: true },
+    ]);
+  });
+
   it('does not let replay state events overwrite fresh connection status', async () => {
     const session = createMockSession({
       context: vi.fn(async () => ({

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -425,6 +425,17 @@ export function DaemonSessionProvider({
                     { updateConnection: false },
                   ),
                 );
+                if (replayEvent.type === 'turn_complete') {
+                  const stopReason =
+                    (replayEvent.data as DaemonTurnCompleteData | undefined)
+                      ?.stopReason ?? 'end_turn';
+                  allUiEvents.push({
+                    type: 'assistant.done',
+                    reason: stopReason,
+                  });
+                } else if (replayEvent.type === 'turn_error') {
+                  allUiEvents.push({ type: 'assistant.done', reason: 'error' });
+                }
               } catch (error) {
                 const message =
                   error instanceof Error ? error.message : String(error);

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -450,31 +450,16 @@ export function DaemonSessionProvider({
               store.dispatch(allUiEvents);
               bumpWorkspaceEventSignals(allUiEvents, setWorkspaceEventSignals);
             }
-            let activePromptSettled = false;
             for (const replayEvent of replayEvents) {
-              activePromptSettled =
-                settleActivePromptFromTurnEvent(
-                  activePromptsRef.current,
-                  activeSession.sessionId,
-                  replayEvent,
-                  store,
-                  setPromptStatus,
-                  passiveAssistantDoneTimerRef,
-                  { requireBoundPromptId: true },
-                ) || activePromptSettled;
-            }
-            const lastReplayEvent = replayEvents[replayEvents.length - 1];
-            if (
-              !activePromptSettled &&
-              lastReplayEvent &&
-              (lastReplayEvent.type === 'turn_complete' ||
-                lastReplayEvent.type === 'turn_error') &&
-              !activePromptsRef.current.has(activeSession.sessionId)
-            ) {
-              store.dispatch({
-                type: 'assistant.done',
-                reason: 'replay_complete',
-              });
+              settleActivePromptFromTurnEvent(
+                activePromptsRef.current,
+                activeSession.sessionId,
+                replayEvent,
+                store,
+                setPromptStatus,
+                passiveAssistantDoneTimerRef,
+                { requireBoundPromptId: true },
+              );
             }
             setConnection((c) => ({ ...c, catchingUp: undefined }));
           }


### PR DESCRIPTION
## What this PR does

This PR fixes two daemon replay correctness issues. First, daemon events are stamped with a server-side timestamp when they enter the event bus so both SSE delivery and load/replay snapshots share the same authoritative event time. Second, replayed transcript blocks now finalize streaming state consistently when turns complete, including assistant and thought blocks that are cleared through parent-scoped or scalar active pointers.

It also keeps compacted tool-call events on the same timestamp path as text and thought events, so reconnecting to a compacted snapshot does not mix daemon time for text with client receive time for tools.

## Why it's needed

The web-shell transcript can be rebuilt from historical load/replay data after refresh or reconnect. Before this fix, replayed events could miss `serverTimestamp`, which made UI ordering and elapsed-time display fall back to each browser client's local clock. Separately, some historical assistant or thought blocks could remain `streaming: true` after the task had already ended because replay did not consistently deliver turn-completion finalization to every active block.

## Reviewer Test Plan

### How to verify

Refresh or reconnect a web-shell session with completed historical turns and an active live turn. Completed historical assistant/thought blocks should no longer remain `streaming: true`, while the current unfinished turn can still show `streaming: true`. Inspect replayed transcript blocks and tool calls after compaction: text, thought, and tool blocks should all carry daemon-derived `serverTimestamp` when the daemon emitted it.

### Evidence (Before & After)

Before: replayed historical blocks could remain stuck in streaming state after their turn completed, and compacted tool events could lose `_meta.serverTimestamp` while text/thought events kept it. After: every replayed turn boundary finalizes the active assistant/thought blocks for that turn, and compacted tool events preserve merged envelope metadata.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local targeted verification:

`cd packages/acp-bridge && npx vitest run src/compactionEngine.test.ts`

`cd packages/webui && npx vitest run src/daemon/session/DaemonSessionProvider.test.tsx`

Earlier local verification on this branch also covered:

`cd packages/sdk-typescript && npx vitest run test/unit/daemonUi.test.ts`

`cd packages/sdk-typescript && npm run typecheck`

`cd packages/web-shell && npm run build`

## Risk & Scope

- Main risk or tradeoff: The timestamp source now lives earlier in the daemon event pipeline, so event metadata preservation matters across compaction paths.
- Not validated / out of scope: Full CLI server test file currently has unrelated upstream baseline failures around capability registry expectations; this PR was verified with targeted tests for the touched replay and compaction paths.
- Breaking changes / migration notes: None expected.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 修复两个 daemon replay 正确性问题。第一，daemon 事件进入 event bus 时就打上服务端时间戳，让 SSE 推送和 load/replay 快照共享同一个权威事件时间。第二，replay transcript 时会在 turn 完成后稳定地结束 streaming 状态，包括通过 parent-scoped 或 scalar active 指针清理的 assistant/thought block。

它也让 compacted tool-call 事件和 text/thought 事件走同一套时间戳路径，避免 reconnect 到 compacted snapshot 后 text 使用 daemon 时间、tool 却回退到 client receive time。

## Why it's needed

web-shell 在刷新或重连后会用历史 load/replay 数据重建 transcript。修复前，replay 事件可能缺少 `serverTimestamp`，导致 UI 排序和 elapsed-time 展示回退到每个浏览器客户端的本地时钟。另外，一些历史 assistant 或 thought block 在任务已经结束后仍可能残留 `streaming: true`，因为 replay 没有把 turn-completion finalization 稳定应用到每个 active block。

## Reviewer Test Plan

### How to verify

刷新或重连一个包含已完成历史 turn 和当前 live turn 的 web-shell session。已完成历史 assistant/thought block 不应再残留 `streaming: true`；当前尚未结束的 turn 仍可以显示 `streaming: true`。检查 compaction 后 replay 出来的 transcript blocks 和 tool calls：daemon 发出时间戳时，text、thought 和 tool block 都应带 daemon-derived `serverTimestamp`。

### Evidence (Before & After)

Before：历史 replay block 可能在 turn 完成后仍卡在 streaming 状态；compacted tool event 可能丢失 `_meta.serverTimestamp`，而 text/thought event 保留它。After：每个 replayed turn boundary 都会 finalize 当前 turn 的 active assistant/thought blocks，compacted tool event 也会保留合并后的 envelope metadata。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地定向验证：

`cd packages/acp-bridge && npx vitest run src/compactionEngine.test.ts`

`cd packages/webui && npx vitest run src/daemon/session/DaemonSessionProvider.test.tsx`

该分支此前也做过以下本地验证：

`cd packages/sdk-typescript && npx vitest run test/unit/daemonUi.test.ts`

`cd packages/sdk-typescript && npm run typecheck`

`cd packages/web-shell && npm run build`

## Risk & Scope

- Main risk or tradeoff：时间戳来源前移到了 daemon event pipeline 更早的位置，因此 compaction 路径需要正确保留 event metadata。
- Not validated / out of scope：完整 CLI server 测试文件目前有与本 PR 无关的上游 capability registry 期望漂移失败；本 PR 使用 touched replay 和 compaction 路径的定向测试验证。
- Breaking changes / migration notes：预期没有。

## Linked Issues

N/A

</details>
