### PR TITLE
feat(extension): add description field to ExtensionConfig

### DIFF
--- a/packages/cli/src/commands/extensions/consent.test.ts
+++ b/packages/cli/src/commands/extensions/consent.test.ts
@@ -43,6 +43,31 @@ describe('extensionConsentString', () => {
     expect(result).toContain('Installing extension "test-extension".');
   });
 
+  it('should include description when present', () => {
+    const config: ExtensionConfig = {
+      name: 'test-extension',
+      version: '1.0.0',
+      description: 'A helpful test extension',
+    };
+
+    const result = extensionConsentString(config);
+
+    expect(result).toContain('A helpful test extension');
+  });
+
+  it('should not include description when absent', () => {
+    const config: ExtensionConfig = {
+      name: 'test-extension',
+      version: '1.0.0',
+    };
+
+    const result = extensionConsentString(config);
+
+    const lines = result.split('\n');
+    expect(lines[0]).toContain('Installing extension "test-extension".');
+    expect(lines[1]).toContain('Extensions may introduce unexpected behavior');
+  });
+
   it('should include warning message', () => {
     const config: ExtensionConfig = {
       name: 'test-extension',

--- a/packages/cli/src/commands/extensions/consent.test.ts
+++ b/packages/cli/src/commands/extensions/consent.test.ts
@@ -55,6 +55,31 @@ describe('extensionConsentString', () => {
     expect(result).toContain('A helpful test extension');
   });
 
+  it('should strip ANSI escape codes from description', () => {
+    const config: ExtensionConfig = {
+      name: 'test-extension',
+      version: '1.0.0',
+      description: '\x1b[31mMalicious\x1b[0m description',
+    };
+
+    const result = extensionConsentString(config);
+
+    expect(result).toContain('Malicious description');
+    expect(result).not.toContain('\x1b[31m');
+  });
+
+  it('should handle non-string description gracefully', () => {
+    const config = {
+      name: 'test-extension',
+      version: '1.0.0',
+      description: 123,
+    } as unknown as ExtensionConfig;
+
+    const result = extensionConsentString(config);
+
+    expect(result).not.toContain('123');
+  });
+
   it('should not include description when absent', () => {
     const config: ExtensionConfig = {
       name: 'test-extension',

--- a/packages/cli/src/commands/extensions/consent.ts
+++ b/packages/cli/src/commands/extensions/consent.ts
@@ -8,6 +8,7 @@ import type {
 import type { ConfirmationRequest } from '../../ui/types.js';
 import chalk from 'chalk';
 import prompts from 'prompts';
+import stripAnsi from 'strip-ansi';
 import { t } from '../../i18n/index.js';
 import { writeStdoutLine } from '../../utils/stdioHelpers.js';
 
@@ -165,7 +166,7 @@ export function extensionConsentString(
     t('Installing extension "{{name}}".', { name: extensionConfig.name }),
   );
   if (extensionConfig.description) {
-    output.push(extensionConfig.description);
+    output.push(stripAnsi(extensionConfig.description));
   }
   output.push(
     t(

--- a/packages/cli/src/commands/extensions/consent.ts
+++ b/packages/cli/src/commands/extensions/consent.ts
@@ -165,7 +165,7 @@ export function extensionConsentString(
   output.push(
     t('Installing extension "{{name}}".', { name: extensionConfig.name }),
   );
-  if (extensionConfig.description) {
+  if (typeof extensionConfig.description === 'string' && extensionConfig.description) {
     output.push(stripAnsi(extensionConfig.description));
   }
   output.push(

--- a/packages/cli/src/commands/extensions/consent.ts
+++ b/packages/cli/src/commands/extensions/consent.ts
@@ -164,6 +164,9 @@ export function extensionConsentString(
   output.push(
     t('Installing extension "{{name}}".', { name: extensionConfig.name }),
   );
+  if (extensionConfig.description) {
+    output.push(extensionConfig.description);
+  }
   output.push(
     t(
       '**Extensions may introduce unexpected behavior. Ensure you have investigated the extension source and trust the author.**',

--- a/packages/cli/src/commands/extensions/examples/agent/qwen-extension.json
+++ b/packages/cli/src/commands/extensions/examples/agent/qwen-extension.json
@@ -1,4 +1,5 @@
 {
   "name": "agent-example",
+  "description": "Example extension that provides a custom subagent",
   "version": "1.0.0"
 }

--- a/packages/cli/src/commands/extensions/examples/commands/qwen-extension.json
+++ b/packages/cli/src/commands/extensions/examples/commands/qwen-extension.json
@@ -1,4 +1,5 @@
 {
   "name": "commands-example",
+  "description": "Example extension that provides custom slash commands",
   "version": "1.0.0"
 }

--- a/packages/cli/src/commands/extensions/examples/context/qwen-extension.json
+++ b/packages/cli/src/commands/extensions/examples/context/qwen-extension.json
@@ -1,4 +1,5 @@
 {
   "name": "context-example",
+  "description": "Example extension that provides additional context via QWEN.md",
   "version": "1.0.0"
 }

--- a/packages/cli/src/commands/extensions/examples/mcp-server/qwen-extension.json
+++ b/packages/cli/src/commands/extensions/examples/mcp-server/qwen-extension.json
@@ -1,5 +1,6 @@
 {
   "name": "mcp-server-example",
+  "description": "Example extension that provides an MCP server",
   "version": "1.0.0",
   "mcpServers": {
     "nodeServer": {

--- a/packages/cli/src/commands/extensions/examples/skills/qwen-extension.json
+++ b/packages/cli/src/commands/extensions/examples/skills/qwen-extension.json
@@ -1,4 +1,5 @@
 {
   "name": "skills-example",
+  "description": "Example extension that provides custom skills",
   "version": "1.0.0"
 }

--- a/packages/cli/src/commands/extensions/new.ts
+++ b/packages/cli/src/commands/extensions/new.ts
@@ -64,7 +64,6 @@ async function handleNew(args: NewArgs) {
       const extensionName = basename(args.path);
       const manifest = {
         name: extensionName,
-        description: '',
         version: '1.0.0',
       };
       await writeFile(

--- a/packages/cli/src/commands/extensions/new.ts
+++ b/packages/cli/src/commands/extensions/new.ts
@@ -64,6 +64,7 @@ async function handleNew(args: NewArgs) {
       const extensionName = basename(args.path);
       const manifest = {
         name: extensionName,
+        description: '',
         version: '1.0.0',
       };
       await writeFile(

--- a/packages/cli/src/commands/extensions/utils.test.ts
+++ b/packages/cli/src/commands/extensions/utils.test.ts
@@ -156,6 +156,41 @@ describe('extensionToOutputString', () => {
     expect(result).toContain('A helpful test extension');
   });
 
+  it('should strip ANSI escape codes from description', () => {
+    const extension = createMockExtension({
+      config: {
+        name: 'test-extension',
+        version: '1.0.0',
+        description: '\x1b[31mMalicious\x1b[0m description',
+      },
+    });
+    const result = extensionToOutputString(
+      extension,
+      mockExtensionManager,
+      '/workspace',
+    );
+
+    expect(result).toContain('Malicious description');
+    expect(result).not.toContain('\x1b[31m');
+  });
+
+  it('should handle non-string description gracefully', () => {
+    const extension = createMockExtension({
+      config: {
+        name: 'test-extension',
+        version: '1.0.0',
+        description: 42,
+      },
+    });
+    const result = extensionToOutputString(
+      extension,
+      mockExtensionManager,
+      '/workspace',
+    );
+
+    expect(result).not.toContain('Description:');
+  });
+
   it('should not include description line when absent', () => {
     const extension = createMockExtension();
     const result = extensionToOutputString(

--- a/packages/cli/src/commands/extensions/utils.test.ts
+++ b/packages/cli/src/commands/extensions/utils.test.ts
@@ -138,6 +138,35 @@ describe('extensionToOutputString', () => {
     expect(resultWithoutInline).toEqual(resultWithInlineFalse);
   });
 
+  it('should include description when present', () => {
+    const extension = createMockExtension({
+      config: {
+        name: 'test-extension',
+        version: '1.0.0',
+        description: 'A helpful test extension',
+      },
+    });
+    const result = extensionToOutputString(
+      extension,
+      mockExtensionManager,
+      '/workspace',
+    );
+
+    expect(result).toContain('Description:');
+    expect(result).toContain('A helpful test extension');
+  });
+
+  it('should not include description line when absent', () => {
+    const extension = createMockExtension();
+    const result = extensionToOutputString(
+      extension,
+      mockExtensionManager,
+      '/workspace',
+    );
+
+    expect(result).not.toContain('Description:');
+  });
+
   it('should redact URL credentials in install source output', () => {
     const extension = createMockExtension({
       installMetadata: {

--- a/packages/cli/src/commands/extensions/utils.ts
+++ b/packages/cli/src/commands/extensions/utils.ts
@@ -53,6 +53,9 @@ export function extensionToOutputString(
 
   const status = workspaceEnabled ? chalk.green('✓') : chalk.red('✗');
   let output = `${inline ? '' : status} ${extension.config.name} (${extension.config.version})`;
+  if (extension.config.description) {
+    output += `\n ${t('Description:')} ${extension.config.description}`;
+  }
   output += `\n ${t('Path:')} ${extension.path}`;
   if (extension.installMetadata) {
     output += `\n ${t('Source:')} ${redactUrlCredentials(extension.installMetadata.source)} (${t('Type:')} ${extension.installMetadata.type})`;

--- a/packages/cli/src/commands/extensions/utils.ts
+++ b/packages/cli/src/commands/extensions/utils.ts
@@ -54,7 +54,7 @@ export function extensionToOutputString(
 
   const status = workspaceEnabled ? chalk.green('✓') : chalk.red('✗');
   let output = `${inline ? '' : status} ${extension.config.name} (${extension.config.version})`;
-  if (extension.config.description) {
+  if (typeof extension.config.description === 'string' && extension.config.description) {
     output += `\n ${t('Description:')} ${stripAnsi(extension.config.description)}`;
   }
   output += `\n ${t('Path:')} ${extension.path}`;

--- a/packages/cli/src/commands/extensions/utils.ts
+++ b/packages/cli/src/commands/extensions/utils.ts
@@ -18,6 +18,7 @@ import {
 import { isWorkspaceTrusted } from '../../config/trustedFolders.js';
 import * as os from 'node:os';
 import chalk from 'chalk';
+import stripAnsi from 'strip-ansi';
 import { t } from '../../i18n/index.js';
 
 export async function getExtensionManager(): Promise<ExtensionManager> {
@@ -54,7 +55,7 @@ export function extensionToOutputString(
   const status = workspaceEnabled ? chalk.green('✓') : chalk.red('✗');
   let output = `${inline ? '' : status} ${extension.config.name} (${extension.config.version})`;
   if (extension.config.description) {
-    output += `\n ${t('Description:')} ${extension.config.description}`;
+    output += `\n ${t('Description:')} ${stripAnsi(extension.config.description)}`;
   }
   output += `\n ${t('Path:')} ${extension.path}`;
   if (extension.installMetadata) {

--- a/packages/core/src/extension/claude-converter.test.ts
+++ b/packages/core/src/extension/claude-converter.test.ts
@@ -71,6 +71,29 @@ describe('convertClaudeToQwenConfig', () => {
     expect(result.lspServers).toEqual(claudeConfig.lspServers);
   });
 
+  it('should preserve description field', () => {
+    const claudeConfig: ClaudePluginConfig = {
+      name: 'desc-plugin',
+      version: '1.0.0',
+      description: 'A plugin with a description',
+    };
+
+    const result = convertClaudeToQwenConfig(claudeConfig);
+
+    expect(result.description).toBe('A plugin with a description');
+  });
+
+  it('should leave description undefined when not provided', () => {
+    const claudeConfig: ClaudePluginConfig = {
+      name: 'no-desc-plugin',
+      version: '1.0.0',
+    };
+
+    const result = convertClaudeToQwenConfig(claudeConfig);
+
+    expect(result.description).toBeUndefined();
+  });
+
   it('should throw error for missing name', () => {
     const invalidConfig = {
       version: '1.0.0',

--- a/packages/core/src/extension/claude-converter.ts
+++ b/packages/core/src/extension/claude-converter.ts
@@ -347,6 +347,7 @@ export function convertClaudeToQwenConfig(
   return {
     name: claudeConfig.name,
     version: claudeConfig.version,
+    description: claudeConfig.description,
     mcpServers,
     lspServers: claudeConfig.lspServers,
     hooks, // Assign the properly typed hooks variable

--- a/packages/core/src/extension/extensionManager.ts
+++ b/packages/core/src/extension/extensionManager.ts
@@ -125,6 +125,7 @@ export interface Extension {
 export interface ExtensionConfig {
   name: string;
   version: string;
+  description?: string;
   mcpServers?: Record<string, MCPServerConfig>;
   lspServers?: string | Record<string, unknown>;
   contextFileName?: string | string[];


### PR DESCRIPTION
## What this PR does

Adds an optional `description` field to `ExtensionConfig`, so extension authors can provide a brief summary of what their extension does. The description is displayed in `qwen extensions list` output (below the name/version line) and in the install consent prompt (between the extension name and the security warning). The Claude plugin converter now preserves the `description` field during format conversion instead of silently dropping it. The `qwen extensions new` scaffold and all five bundled example templates include the field by default.

## Why it's needed

Extensions currently only expose `name` and `version` — there is no way for users to quickly understand what an installed extension does without reading its source or context files. Claude Code's plugin format already supports a top-level `description` (used by `plugin validate`), but the converter was discarding it. This small addition improves discoverability and the install experience.

## Reviewer Test Plan

### How to verify

1. Create a test extension with `qwen extensions new /tmp/test-ext` — confirm the generated `qwen-extension.json` includes a `"description": ""` field.
2. Edit the description to something non-empty, install via `qwen extensions link /tmp/test-ext`, then run `qwen extensions list` — confirm the description line appears.
3. Install any extension that has a `description` in its manifest — confirm the install consent prompt shows the description text between the extension name and the security warning.
4. Run `npx vitest run packages/core/src/extension/claude-converter.test.ts` — 21 tests should pass (2 new).
5. Run `npx vitest run packages/cli/src/commands/extensions/consent.test.ts` — new description tests pass.
6. Run `npx vitest run packages/cli/src/commands/extensions/utils.test.ts` — new description tests pass.

### Evidence (Before & After)

N/A — non-UI change, verified via unit tests and CLI output.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A — unit tests only.

## Risk & Scope

- Main risk or tradeoff: None — purely additive optional field, fully backward-compatible.
- Not validated / out of scope: Gemini extension format does not have a `description` field; no converter change needed there.
- Breaking changes / migration notes: None. Existing extensions without `description` are unaffected.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

为 `ExtensionConfig` 添加可选的 `description` 字段，允许扩展作者提供简短的用途说明。该描述会在 `qwen extensions list` 输出中（名称/版本行下方）和安装确认提示中（扩展名称与安全警告之间）显示。Claude 插件转换器现在会在格式转换时保留 `description` 字段，而不是静默丢弃。`qwen extensions new` 脚手架和所有五个内置示例模板默认包含该字段。

## 为什么需要

扩展目前只暴露 `name` 和 `version`——用户无法快速了解已安装扩展的用途，除非阅读源码或上下文文件。Claude Code 的插件格式已支持顶层 `description`（用于 `plugin validate`），但转换器之前会丢弃它。这个小改进提升了扩展的可发现性和安装体验。

## 审查测试计划

### 如何验证

1. 用 `qwen extensions new /tmp/test-ext` 创建测试扩展——确认生成的 `qwen-extension.json` 包含 `"description": ""` 字段。
2. 编辑描述为非空值，通过 `qwen extensions link /tmp/test-ext` 安装，然后运行 `qwen extensions list`——确认描述行出现。
3. 安装任何在 manifest 中有 `description` 的扩展——确认安装确认提示在扩展名称和安全警告之间显示描述文本。
4. 运行 `npx vitest run packages/core/src/extension/claude-converter.test.ts`——21 个测试应全部通过（新增 2 个）。
5. 运行 `npx vitest run packages/cli/src/commands/extensions/consent.test.ts`——新增的 description 测试通过。
6. 运行 `npx vitest run packages/cli/src/commands/extensions/utils.test.ts`——新增的 description 测试通过。

### 证据（前后对比）

N/A——非 UI 变更，通过单元测试和 CLI 输出验证。

### 测试环境

|   操作系统   | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

N/A——仅单元测试。

## 风险与范围

- 主要风险或权衡：无——纯新增的可选字段，完全向后兼容。
- 未验证/超出范围：Gemini 扩展格式没有 `description` 字段，无需修改转换器。
- 破坏性变更/迁移说明：无。没有 `description` 的现有扩展不受影响。

## 关联 Issue

无。

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)