### PR TITLE
fix(sdk): correct npm package name in SDK install instructions

### DIFF
--- a/packages/sdk-typescript/README.md
+++ b/packages/sdk-typescript/README.md
@@ -496,7 +496,7 @@ Version 0.1.0 requires [Qwen Code](https://github.com/QwenLM/qwen-code) **>= 0.4
 
 ```bash
 # Install Qwen Code globally
-npm install -g qwen-code@^0.4.0
+npm install -g @qwen-code/qwen-code@latest
 ```
 
 **Note**: From version **0.1.1** onwards, the CLI is bundled with the SDK, so no separate Qwen Code installation is needed.


### PR DESCRIPTION
## What this PR does

Fixes the npm install command in `packages/sdk-typescript/README.md` from the unscoped `qwen-code` to the correct scoped `@qwen-code/qwen-code@latest`.

## Why it's needed

The unscoped `qwen-code` package on npm is a copycat/squatted package published by an unofficial maintainer (`liangshuai`, version 0.0.5). Users following the SDK README install instructions would install this wrong package instead of the official `@qwen-code/qwen-code` (latest 0.17.1).

The `qwen-code` copycat even mirrors the official README with badges pointing to `@qwen-code/qwen-code`, making it highly deceptive.

## Reviewer Test Plan

### How to verify

**1. Verify the diff is correct:**

```bash
git diff origin/main -- packages/sdk-typescript/README.md
```

Expected output:

```diff
-npm install -g qwen-code@^0.4.0
+npm install -g @qwen-code/qwen-code@latest
```

**2. Verify the copycat package exists on npm:**

```bash
# The unscoped package is a copycat (v0.0.5, by "liangshuai")
npm view qwen-code name version maintainers

# The official scoped package is the real one (v0.17.1)
npm view @qwen-code/qwen-code name version
```

**3. Confirm this PR changes only the README:**

```bash
git diff origin/main --stat
# Should show only: packages/sdk-typescript/README.md | 2 +-
```

### Evidence (Before & After)

| Before | After |
|--------|-------|
| `npm install -g qwen-code@^0.4.0` | `npm install -g @qwen-code/qwen-code@latest` |

| Package | Name | Version | Publisher |
|---------|------|---------|-----------|
| Copycat | `qwen-code` | 0.0.5 | `liangshuai` (unofficial) |
| Official | `@qwen-code/qwen-code` | 0.17.1 | `@qwen-code` (Qwen team) |

### Tested on

|     OS     | Status  |
| :--------: | :-----: |
|  🍏 macOS  | N/A     |
| 🪟 Windows | N/A     |
|  🐧 Linux  | N/A     |

## Risk & Scope

- Main risk or tradeoff: None — documentation-only change.
- Not validated / out of scope: N/A
- Breaking changes / migration notes: None

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复 `packages/sdk-typescript/README.md` 中的 npm 安装命令，将不带 scope 的 `qwen-code` 改为正确的带 scope 的 `@qwen-code/qwen-code@latest`。

## 为什么需要

npm 上不带 scope 的 `qwen-code` 是一个山寨/抢注包，由非官方维护者（`liangshuai`，版本 0.0.5）发布。用户按照 SDK README 的安装说明操作会安装到这个错误版本，而非官方 `@qwen-code/qwen-code`（最新 0.17.1）。

山寨 `qwen-code` 甚至复刻了官方 README，badge 也指向 `@qwen-code/qwen-code`，极具迷惑性。

## 审查验证计划

### 如何验证

**1. 验证 diff 正确性：**

```bash
git diff origin/main -- packages/sdk-typescript/README.md
```

期望输出：

```diff
-npm install -g qwen-code@^0.4.0
+npm install -g @qwen-code/qwen-code@latest
```

**2. 验证山寨包确实存在：**

```bash
npm view qwen-code name version maintainers    # 山寨包
npm view @qwen-code/qwen-code name version     # 官方正版
```

**3. 确认本次只改了 README：**

```bash
git diff origin/main --stat
# 应只显示: packages/sdk-typescript/README.md | 2 +-
```

### 修改前后对比

| 修改前 | 修改后 |
|--------|--------|
| `npm install -g qwen-code@^0.4.0` | `npm install -g @qwen-code/qwen-code@latest` |

| 包 | 名称 | 版本 | 发布者 |
|----|------|------|--------|
| 山寨 | `qwen-code` | 0.0.5 | `liangshuai`（非官方） |
| 官方 | `@qwen-code/qwen-code` | 0.17.1 | `@qwen-code`（Qwen 团队） |

### 测试平台

|     系统    | 状态 |
| :---------: | :--: |
|  🍏 macOS  | N/A  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

## 风险与范围

- 主要风险：无 — 仅文档变更。
- 未验证/不包含：N/A
- 破坏性变更/迁移说明：无

</details>