### PR TITLE
feat(serve): add per-tier HTTP rate limiting for daemon (issue #4514 T3.4)

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -303,10 +303,11 @@ export const serveCommand: CommandModule<unknown, ServeArgs> = {
     }
 
     // Rate limit resolution + validation (only when enabled).
-    const rateLimit =
-      argv['rate-limit'] ||
-      process.env['QWEN_SERVE_RATE_LIMIT'] === '1' ||
-      process.env['QWEN_SERVE_RATE_LIMIT'] === 'true';
+    // CLI flag takes precedence; env var is fallback only when CLI is default (false).
+    const rateLimit = argv['rate-limit']
+      ? true
+      : process.env['QWEN_SERVE_RATE_LIMIT'] === '1' ||
+        process.env['QWEN_SERVE_RATE_LIMIT'] === 'true';
     let rateLimitPrompt: number | undefined;
     let rateLimitMutation: number | undefined;
     let rateLimitRead: number | undefined;

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -49,6 +49,11 @@ interface ServeArgs {
   'prompt-deadline-ms'?: number;
   'writer-idle-timeout-ms'?: number;
   'channel-idle-timeout-ms'?: number;
+  'rate-limit': boolean;
+  'rate-limit-prompt'?: number;
+  'rate-limit-mutation'?: number;
+  'rate-limit-read'?: number;
+  'rate-limit-window-ms'?: number;
 }
 
 export const serveCommand: CommandModule<unknown, ServeArgs> = {
@@ -175,6 +180,38 @@ export const serveCommand: CommandModule<unknown, ServeArgs> = {
         description:
           'Milliseconds to keep ACP child alive after last session closes. ' +
           '0 or unset = immediate kill (default).',
+      })
+      .option('rate-limit', {
+        type: 'boolean',
+        default: false,
+        description:
+          'Enable per-tier HTTP rate limiting. Tiers: prompt (10/min), ' +
+          'mutation (30/min), read (120/min). Health, heartbeat, SSE, ' +
+          'and /acp are exempt.',
+      })
+      .option('rate-limit-prompt', {
+        type: 'number',
+        description:
+          'Max prompt requests per window per client (default 10). ' +
+          'Requires --rate-limit.',
+      })
+      .option('rate-limit-mutation', {
+        type: 'number',
+        description:
+          'Max mutation requests per window per client (default 30). ' +
+          'Requires --rate-limit.',
+      })
+      .option('rate-limit-read', {
+        type: 'number',
+        description:
+          'Max read requests per window per client (default 120). ' +
+          'Requires --rate-limit.',
+      })
+      .option('rate-limit-window-ms', {
+        type: 'number',
+        description:
+          'Rate limit window duration in ms (default 60000). ' +
+          'Requires --rate-limit.',
       }) as unknown as Argv<ServeArgs>,
   handler: async (argv) => {
     if (!argv['http-bridge']) {
@@ -265,6 +302,56 @@ export const serveCommand: CommandModule<unknown, ServeArgs> = {
       // path will report the same error to the user via Session.
     }
 
+    // Rate limit resolution + validation (only when enabled).
+    const rateLimit =
+      argv['rate-limit'] ||
+      process.env['QWEN_SERVE_RATE_LIMIT'] === '1' ||
+      process.env['QWEN_SERVE_RATE_LIMIT'] === 'true';
+    let rateLimitPrompt: number | undefined;
+    let rateLimitMutation: number | undefined;
+    let rateLimitRead: number | undefined;
+    let rateLimitWindowMs: number | undefined;
+    if (rateLimit) {
+      const envInt = (key: string): number | undefined => {
+        const v = process.env[key];
+        return v ? Number(v) : undefined;
+      };
+      rateLimitPrompt =
+        argv['rate-limit-prompt'] ?? envInt('QWEN_SERVE_RATE_LIMIT_PROMPT');
+      rateLimitMutation =
+        argv['rate-limit-mutation'] ?? envInt('QWEN_SERVE_RATE_LIMIT_MUTATION');
+      rateLimitRead =
+        argv['rate-limit-read'] ?? envInt('QWEN_SERVE_RATE_LIMIT_READ');
+      rateLimitWindowMs =
+        argv['rate-limit-window-ms'] ??
+        envInt('QWEN_SERVE_RATE_LIMIT_WINDOW_MS');
+
+      for (const [name, value] of [
+        ['--rate-limit-prompt', rateLimitPrompt],
+        ['--rate-limit-mutation', rateLimitMutation],
+        ['--rate-limit-read', rateLimitRead],
+      ] as const) {
+        if (
+          value !== undefined &&
+          (!Number.isFinite(value) || !Number.isInteger(value) || value <= 0)
+        ) {
+          writeStderrLine(`qwen serve: ${name} must be a positive integer.`);
+          process.exit(1);
+        }
+      }
+      if (
+        rateLimitWindowMs !== undefined &&
+        (!Number.isFinite(rateLimitWindowMs) ||
+          !Number.isInteger(rateLimitWindowMs) ||
+          rateLimitWindowMs < 1000)
+      ) {
+        writeStderrLine(
+          'qwen serve: --rate-limit-window-ms must be an integer >= 1000.',
+        );
+        process.exit(1);
+      }
+    }
+
     // Lazy-load the serve module so non-serve invocations don't pay for
     // express + body-parser + qs in their startup path.
     const { runQwenServe } = await import('../serve/index.js');
@@ -293,6 +380,11 @@ export const serveCommand: CommandModule<unknown, ServeArgs> = {
         ...(argv['channel-idle-timeout-ms'] !== undefined
           ? { channelIdleTimeoutMs: argv['channel-idle-timeout-ms'] }
           : {}),
+        ...(rateLimit ? { rateLimit: true } : {}),
+        ...(rateLimitPrompt !== undefined ? { rateLimitPrompt } : {}),
+        ...(rateLimitMutation !== undefined ? { rateLimitMutation } : {}),
+        ...(rateLimitRead !== undefined ? { rateLimitRead } : {}),
+        ...(rateLimitWindowMs !== undefined ? { rateLimitWindowMs } : {}),
       });
     } catch (err) {
       writeStderrLine(

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -49,7 +49,7 @@ interface ServeArgs {
   'prompt-deadline-ms'?: number;
   'writer-idle-timeout-ms'?: number;
   'channel-idle-timeout-ms'?: number;
-  'rate-limit': boolean;
+  'rate-limit'?: boolean;
   'rate-limit-prompt'?: number;
   'rate-limit-mutation'?: number;
   'rate-limit-read'?: number;
@@ -183,7 +183,6 @@ export const serveCommand: CommandModule<unknown, ServeArgs> = {
       })
       .option('rate-limit', {
         type: 'boolean',
-        default: false,
         description:
           'Enable per-tier HTTP rate limiting. Tiers: prompt (10/min), ' +
           'mutation (30/min), read (120/min). Health, heartbeat, SSE, ' +
@@ -302,12 +301,12 @@ export const serveCommand: CommandModule<unknown, ServeArgs> = {
       // path will report the same error to the user via Session.
     }
 
-    // Rate limit resolution + validation (only when enabled).
-    // CLI flag takes precedence; env var is fallback only when CLI is default (false).
-    const rateLimit = argv['rate-limit']
-      ? true
-      : process.env['QWEN_SERVE_RATE_LIMIT'] === '1' ||
-        process.env['QWEN_SERVE_RATE_LIMIT'] === 'true';
+    // Rate limit resolution: --rate-limit / --no-rate-limit override env var.
+    // With no default, argv['rate-limit'] is undefined when neither flag is passed.
+    const rateLimit =
+      argv['rate-limit'] ??
+      (process.env['QWEN_SERVE_RATE_LIMIT'] === '1' ||
+        process.env['QWEN_SERVE_RATE_LIMIT'] === 'true');
     let rateLimitPrompt: number | undefined;
     let rateLimitMutation: number | undefined;
     let rateLimitRead: number | undefined;

--- a/packages/cli/src/serve/capabilities.ts
+++ b/packages/cli/src/serve/capabilities.ts
@@ -220,6 +220,7 @@ export const SERVE_CAPABILITY_REGISTRY = {
   session_hooks: { since: 'v1' },
   workspace_extensions: { since: 'v1' },
   session_branch: { since: 'v1' },
+  rate_limit: { since: 'v1' },
 } as const satisfies Record<string, ServeCapabilityDescriptor>;
 
 export type ServeFeature = keyof typeof SERVE_CAPABILITY_REGISTRY;
@@ -236,6 +237,7 @@ export interface AdvertiseFeatureToggles {
   promptDeadlineMs?: number;
   writerIdleTimeoutMs?: number;
   persistSettingAvailable?: boolean;
+  rateLimit?: boolean;
 }
 
 /**
@@ -291,6 +293,7 @@ export const CONDITIONAL_SERVE_FEATURES: ReadonlyMap<
       toggles.writerIdleTimeoutMs > 0,
   ],
   ['workspace_settings', (toggles) => toggles.persistSettingAvailable === true],
+  ['rate_limit', (toggles) => toggles.rateLimit === true],
 ]);
 
 export const SERVE_FEATURES = Object.freeze(

--- a/packages/cli/src/serve/rateLimit.test.ts
+++ b/packages/cli/src/serve/rateLimit.test.ts
@@ -1,0 +1,523 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRateLimiter, createKeyExtractor } from './rateLimit.js';
+import type { Request, Response } from 'express';
+
+function mockReq(overrides: Record<string, unknown> = {}): Request {
+  return {
+    method: 'POST',
+    path: '/session/abc/prompt',
+    get: vi.fn().mockReturnValue(undefined),
+    socket: { remoteAddress: '192.168.1.1' },
+    ...overrides,
+  } as unknown as Request;
+}
+
+function mockRes(): Response & { statusCode: number; body: unknown } {
+  const res = {
+    statusCode: 0,
+    body: undefined as unknown,
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    json(body: unknown) {
+      res.body = body;
+      return res;
+    },
+    setHeader: vi.fn(),
+  } as unknown as Response & { statusCode: number; body: unknown };
+  return res;
+}
+
+describe('rateLimit', () => {
+  describe('token bucket - continuous drip', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('allows requests up to max', () => {
+      const limiter = createRateLimiter({
+        tiers: {
+          prompt: { windowMs: 60_000, max: 3 },
+          mutation: { windowMs: 60_000, max: 30 },
+          read: { windowMs: 60_000, max: 120 },
+        },
+        hostname: '127.0.0.1',
+      });
+
+      const next = vi.fn();
+      for (let i = 0; i < 3; i++) {
+        const res = mockRes();
+        limiter.middleware(mockReq(), res, next);
+      }
+      expect(next).toHaveBeenCalledTimes(3);
+
+      // 4th request should be rate limited
+      const res = mockRes();
+      limiter.middleware(mockReq(), res, vi.fn());
+      expect(res.statusCode).toBe(429);
+      expect(res.body).toMatchObject({
+        code: 'rate_limit_exceeded',
+        tier: 'prompt',
+      });
+      limiter.dispose();
+    });
+
+    it('refills tokens continuously over time', () => {
+      const limiter = createRateLimiter({
+        tiers: {
+          prompt: { windowMs: 60_000, max: 2 },
+          mutation: { windowMs: 60_000, max: 30 },
+          read: { windowMs: 60_000, max: 120 },
+        },
+        hostname: '127.0.0.1',
+      });
+
+      const next = vi.fn();
+      // Exhaust tokens
+      limiter.middleware(mockReq(), mockRes(), next);
+      limiter.middleware(mockReq(), mockRes(), next);
+      expect(next).toHaveBeenCalledTimes(2);
+
+      // Immediately: rate limited
+      const res1 = mockRes();
+      limiter.middleware(mockReq(), res1, vi.fn());
+      expect(res1.statusCode).toBe(429);
+
+      // Advance 30s (half window): should have ~1 token
+      vi.advanceTimersByTime(30_000);
+      const next2 = vi.fn();
+      limiter.middleware(mockReq(), mockRes(), next2);
+      expect(next2).toHaveBeenCalledTimes(1);
+
+      limiter.dispose();
+    });
+
+    it('includes Retry-After header on 429', () => {
+      const limiter = createRateLimiter({
+        tiers: {
+          prompt: { windowMs: 60_000, max: 1 },
+          mutation: { windowMs: 60_000, max: 30 },
+          read: { windowMs: 60_000, max: 120 },
+        },
+        hostname: '127.0.0.1',
+      });
+
+      limiter.middleware(mockReq(), mockRes(), vi.fn());
+      const res = mockRes();
+      limiter.middleware(mockReq(), res, vi.fn());
+      expect(res.statusCode).toBe(429);
+      expect(res.setHeader).toHaveBeenCalledWith(
+        'Retry-After',
+        expect.any(String),
+      );
+      expect(
+        Number(
+          (res.setHeader as ReturnType<typeof vi.fn>).mock.calls.find(
+            (c: string[]) => c[0] === 'Retry-After',
+          )?.[1],
+        ),
+      ).toBeGreaterThan(0);
+      limiter.dispose();
+    });
+
+    it('handles clock skew (negative elapsed) via Math.max(0, elapsed)', () => {
+      // The implementation uses Math.max(0, now - lastRefill) to guard
+      // against clock regression. We verify the code doesn't crash or
+      // subtract tokens when elapsed is negative by testing the algorithm
+      // directly: two rapid requests within the same ms should both work
+      // (elapsed=0 means no refill, but initial tokens cover it).
+      const limiter = createRateLimiter({
+        tiers: {
+          prompt: { windowMs: 60_000, max: 5 },
+          mutation: { windowMs: 60_000, max: 30 },
+          read: { windowMs: 60_000, max: 120 },
+        },
+        hostname: '127.0.0.1',
+      });
+
+      const next = vi.fn();
+      // Two requests at exactly the same timestamp (elapsed=0)
+      limiter.middleware(mockReq(), mockRes(), next);
+      limiter.middleware(mockReq(), mockRes(), next);
+      expect(next).toHaveBeenCalledTimes(2);
+      limiter.dispose();
+    });
+  });
+
+  describe('tier resolution', () => {
+    let limiter: ReturnType<typeof createRateLimiter>;
+
+    beforeEach(() => {
+      limiter = createRateLimiter({
+        tiers: {
+          prompt: { windowMs: 60_000, max: 1 },
+          mutation: { windowMs: 60_000, max: 1 },
+          read: { windowMs: 60_000, max: 1 },
+        },
+        hostname: '127.0.0.1',
+      });
+    });
+    afterEach(() => {
+      limiter.dispose();
+    });
+
+    it('classifies POST .../prompt as prompt tier', () => {
+      const next = vi.fn();
+      limiter.middleware(
+        mockReq({ path: '/session/x/prompt' }),
+        mockRes(),
+        next,
+      );
+      expect(next).toHaveBeenCalled();
+      // Second should be rate limited in prompt tier
+      const res = mockRes();
+      limiter.middleware(mockReq({ path: '/session/x/prompt' }), res, vi.fn());
+      expect(res.body).toMatchObject({ tier: 'prompt' });
+    });
+
+    it('classifies POST /session as mutation tier', () => {
+      const next = vi.fn();
+      limiter.middleware(
+        mockReq({ method: 'POST', path: '/session' }),
+        mockRes(),
+        next,
+      );
+      expect(next).toHaveBeenCalled();
+      const res = mockRes();
+      limiter.middleware(
+        mockReq({ method: 'POST', path: '/session' }),
+        res,
+        vi.fn(),
+      );
+      expect(res.body).toMatchObject({ tier: 'mutation' });
+    });
+
+    it('classifies GET as read tier', () => {
+      const next = vi.fn();
+      limiter.middleware(
+        mockReq({ method: 'GET', path: '/workspace/mcp' }),
+        mockRes(),
+        next,
+      );
+      expect(next).toHaveBeenCalled();
+      const res = mockRes();
+      limiter.middleware(
+        mockReq({ method: 'GET', path: '/workspace/mcp' }),
+        res,
+        vi.fn(),
+      );
+      expect(res.body).toMatchObject({ tier: 'read' });
+    });
+
+    it('exempts GET /health', () => {
+      const next = vi.fn();
+      for (let i = 0; i < 5; i++) {
+        limiter.middleware(
+          mockReq({ method: 'GET', path: '/health' }),
+          mockRes(),
+          next,
+        );
+      }
+      expect(next).toHaveBeenCalledTimes(5);
+    });
+
+    it('exempts GET /demo', () => {
+      const next = vi.fn();
+      for (let i = 0; i < 5; i++) {
+        limiter.middleware(
+          mockReq({ method: 'GET', path: '/demo' }),
+          mockRes(),
+          next,
+        );
+      }
+      expect(next).toHaveBeenCalledTimes(5);
+    });
+
+    it('exempts POST .../heartbeat', () => {
+      const next = vi.fn();
+      for (let i = 0; i < 5; i++) {
+        limiter.middleware(
+          mockReq({ method: 'POST', path: '/session/x/heartbeat' }),
+          mockRes(),
+          next,
+        );
+      }
+      expect(next).toHaveBeenCalledTimes(5);
+    });
+
+    it('exempts GET .../events (SSE)', () => {
+      const next = vi.fn();
+      for (let i = 0; i < 5; i++) {
+        limiter.middleware(
+          mockReq({ method: 'GET', path: '/session/x/events' }),
+          mockRes(),
+          next,
+        );
+      }
+      expect(next).toHaveBeenCalledTimes(5);
+    });
+
+    it('exempts /acp routes', () => {
+      const next = vi.fn();
+      for (let i = 0; i < 5; i++) {
+        limiter.middleware(
+          mockReq({ method: 'POST', path: '/acp' }),
+          mockRes(),
+          next,
+        );
+      }
+      expect(next).toHaveBeenCalledTimes(5);
+    });
+
+    it('exempts OPTIONS requests', () => {
+      const next = vi.fn();
+      for (let i = 0; i < 5; i++) {
+        limiter.middleware(
+          mockReq({ method: 'OPTIONS', path: '/session/x/prompt' }),
+          mockRes(),
+          next,
+        );
+      }
+      expect(next).toHaveBeenCalledTimes(5);
+    });
+
+    it('handles trailing slash', () => {
+      const next = vi.fn();
+      limiter.middleware(
+        mockReq({ path: '/session/x/prompt/' }),
+        mockRes(),
+        next,
+      );
+      expect(next).toHaveBeenCalled();
+      const res = mockRes();
+      limiter.middleware(mockReq({ path: '/session/x/prompt/' }), res, vi.fn());
+      expect(res.body).toMatchObject({ tier: 'prompt' });
+    });
+  });
+
+  describe('key extraction', () => {
+    it('uses client-id on loopback', () => {
+      const extractor = createKeyExtractor('127.0.0.1');
+      const req = mockReq({
+        get: vi
+          .fn()
+          .mockImplementation((h: string) =>
+            h === 'x-qwen-client-id' ? 'my-client' : undefined,
+          ),
+      });
+      expect(extractor(req)).toBe('cid:my-client');
+    });
+
+    it('falls back to anonymous on loopback without client-id', () => {
+      const extractor = createKeyExtractor('127.0.0.1');
+      const req = mockReq();
+      expect(extractor(req)).toBe('anonymous');
+    });
+
+    it('uses IP on non-loopback', () => {
+      const extractor = createKeyExtractor('0.0.0.0');
+      const req = mockReq({
+        get: vi.fn().mockReturnValue(undefined),
+        socket: { remoteAddress: '10.0.0.5' },
+      });
+      expect(extractor(req as unknown as Request)).toBe('10.0.0.5');
+    });
+
+    it('normalizes IPv6-mapped IPv4', () => {
+      const extractor = createKeyExtractor('0.0.0.0');
+      const req = mockReq({
+        get: vi.fn().mockReturnValue(undefined),
+        socket: { remoteAddress: '::ffff:10.0.0.5' },
+      });
+      expect(extractor(req as unknown as Request)).toBe('10.0.0.5');
+    });
+
+    it('combines IP and client-id on non-loopback', () => {
+      const extractor = createKeyExtractor('0.0.0.0');
+      const req = mockReq({
+        get: vi
+          .fn()
+          .mockImplementation((h: string) =>
+            h === 'x-qwen-client-id' ? 'web-1' : undefined,
+          ),
+        socket: { remoteAddress: '10.0.0.5' },
+      });
+      expect(extractor(req as unknown as Request)).toBe('10.0.0.5:web-1');
+    });
+
+    it('rejects invalid client-id', () => {
+      const extractor = createKeyExtractor('127.0.0.1');
+      const req = mockReq({
+        get: vi
+          .fn()
+          .mockImplementation((h: string) =>
+            h === 'x-qwen-client-id' ? 'bad id with spaces' : undefined,
+          ),
+      });
+      expect(extractor(req)).toBe('anonymous');
+    });
+  });
+
+  describe('fail-open', () => {
+    it('passes through when bucket map is at capacity', () => {
+      const limiter = createRateLimiter({
+        tiers: {
+          prompt: { windowMs: 60_000, max: 1 },
+          mutation: { windowMs: 60_000, max: 1 },
+          read: { windowMs: 60_000, max: 1 },
+        },
+        hostname: '0.0.0.0',
+      });
+
+      // Fill with 10000 unique keys by consuming their tokens
+      for (let i = 0; i < 10_001; i++) {
+        const req = mockReq({
+          method: 'GET',
+          path: '/workspace/mcp',
+          get: vi.fn().mockReturnValue(undefined),
+          socket: {
+            remoteAddress: `10.${Math.floor(i / 256) % 256}.${i % 256}.1`,
+          },
+        });
+        limiter.middleware(req as unknown as Request, mockRes(), vi.fn());
+      }
+
+      // New unique key should fail-open (pass through)
+      const next = vi.fn();
+      const req = mockReq({
+        method: 'GET',
+        path: '/workspace/mcp',
+        get: vi.fn().mockReturnValue(undefined),
+        socket: { remoteAddress: '99.99.99.99' },
+      });
+      limiter.middleware(req as unknown as Request, mockRes(), next);
+      expect(next).toHaveBeenCalled();
+      limiter.dispose();
+    });
+  });
+
+  describe('draining', () => {
+    it('passes all requests through when draining', () => {
+      const limiter = createRateLimiter({
+        tiers: {
+          prompt: { windowMs: 60_000, max: 1 },
+          mutation: { windowMs: 60_000, max: 1 },
+          read: { windowMs: 60_000, max: 1 },
+        },
+        hostname: '127.0.0.1',
+      });
+
+      // Exhaust prompt bucket
+      limiter.middleware(mockReq(), mockRes(), vi.fn());
+      const res1 = mockRes();
+      limiter.middleware(mockReq(), res1, vi.fn());
+      expect(res1.statusCode).toBe(429);
+
+      // Enable draining
+      limiter.setDraining(true);
+
+      // Should pass through now
+      const next = vi.fn();
+      limiter.middleware(mockReq(), mockRes(), next);
+      expect(next).toHaveBeenCalled();
+
+      limiter.dispose();
+    });
+  });
+
+  describe('reset', () => {
+    it('clears all buckets and hit counts', () => {
+      const limiter = createRateLimiter({
+        tiers: {
+          prompt: { windowMs: 60_000, max: 1 },
+          mutation: { windowMs: 60_000, max: 1 },
+          read: { windowMs: 60_000, max: 1 },
+        },
+        hostname: '127.0.0.1',
+      });
+
+      // Exhaust and trigger a hit
+      limiter.middleware(mockReq(), mockRes(), vi.fn());
+      limiter.middleware(mockReq(), mockRes(), vi.fn());
+      expect(limiter.getHitCounts().prompt).toBe(1);
+
+      // Reset
+      limiter.reset();
+      expect(limiter.getHitCounts().prompt).toBe(0);
+
+      // Should allow again
+      const next = vi.fn();
+      limiter.middleware(mockReq(), mockRes(), next);
+      expect(next).toHaveBeenCalled();
+
+      limiter.dispose();
+    });
+  });
+
+  describe('onLimitReached callback', () => {
+    it('fires on first rejection', () => {
+      const cb = vi.fn();
+      const limiter = createRateLimiter({
+        tiers: {
+          prompt: { windowMs: 60_000, max: 1 },
+          mutation: { windowMs: 60_000, max: 30 },
+          read: { windowMs: 60_000, max: 120 },
+        },
+        hostname: '127.0.0.1',
+        onLimitReached: cb,
+      });
+
+      limiter.middleware(mockReq(), mockRes(), vi.fn());
+      limiter.middleware(mockReq(), mockRes(), vi.fn());
+
+      expect(cb).toHaveBeenCalledWith('prompt', 'anonymous', 0);
+      limiter.dispose();
+    });
+  });
+
+  describe('getHitCounts', () => {
+    it('tracks hits per tier', () => {
+      const limiter = createRateLimiter({
+        tiers: {
+          prompt: { windowMs: 60_000, max: 1 },
+          mutation: { windowMs: 60_000, max: 1 },
+          read: { windowMs: 60_000, max: 1 },
+        },
+        hostname: '127.0.0.1',
+      });
+
+      // Trigger prompt hit
+      limiter.middleware(mockReq(), mockRes(), vi.fn());
+      limiter.middleware(mockReq(), mockRes(), vi.fn());
+
+      // Trigger read hit
+      limiter.middleware(
+        mockReq({ method: 'GET', path: '/capabilities' }),
+        mockRes(),
+        vi.fn(),
+      );
+      limiter.middleware(
+        mockReq({ method: 'GET', path: '/capabilities' }),
+        mockRes(),
+        vi.fn(),
+      );
+
+      const hits = limiter.getHitCounts();
+      expect(hits.prompt).toBe(1);
+      expect(hits.read).toBe(1);
+      expect(hits.mutation).toBe(0);
+
+      limiter.dispose();
+    });
+  });
+});

--- a/packages/cli/src/serve/rateLimit.ts
+++ b/packages/cli/src/serve/rateLimit.ts
@@ -26,6 +26,7 @@ export interface RateLimitConfig {
     key: string,
     suppressed: number,
   ) => void;
+  onError?: (err: unknown, path: string) => void;
 }
 
 export interface RateLimiterInstance {
@@ -206,7 +207,7 @@ export function createRateLimiter(
     ? createSampledLogger(config.onLimitReached)
     : undefined;
 
-  // GC: sweep stale buckets and logger state
+  // GC: sweep stale buckets
   function sweep(): void {
     const now = Date.now();
     for (const [key, tierMap] of buckets) {
@@ -221,7 +222,6 @@ export function createRateLimiter(
         buckets.delete(key);
       }
     }
-    sampledLog?.clear();
   }
 
   const gcTimer = setInterval(sweep, GC_TIMER_INTERVAL_MS);
@@ -260,6 +260,10 @@ export function createRateLimiter(
       let tierMap = buckets.get(key);
       if (!tierMap) {
         if (buckets.size >= MAX_BUCKETS) {
+          config.onError?.(
+            new Error(`rate limit bucket overflow: ${buckets.size} keys`),
+            req.path,
+          );
           next();
           return;
         }
@@ -305,8 +309,8 @@ export function createRateLimiter(
           retryAfterMs,
         });
       }
-    } catch {
-      // Fail-open: internal error should not block requests
+    } catch (err) {
+      config.onError?.(err, req.path);
       next();
     }
   };
@@ -327,9 +331,25 @@ export function createRateLimiter(
     dispose() {
       clearInterval(gcTimer);
       buckets.clear();
+      sampledLog?.clear();
     },
     getHitCounts() {
       return { ...hitCounts };
     },
   };
+}
+
+const RATE_LIMITER_KEY = '_rateLimiter';
+
+export function setRateLimiter(
+  app: { locals: Record<string, unknown> },
+  limiter: RateLimiterInstance,
+): void {
+  app.locals[RATE_LIMITER_KEY] = limiter;
+}
+
+export function getRateLimiter(app: {
+  locals: Record<string, unknown>;
+}): RateLimiterInstance | undefined {
+  return app.locals[RATE_LIMITER_KEY] as RateLimiterInstance | undefined;
 }

--- a/packages/cli/src/serve/rateLimit.ts
+++ b/packages/cli/src/serve/rateLimit.ts
@@ -1,0 +1,335 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+import { isLoopbackBind } from './loopbackBinds.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type RateLimitTier = 'prompt' | 'mutation' | 'read';
+
+export interface RateLimitTierConfig {
+  windowMs: number;
+  max: number;
+}
+
+export interface RateLimitConfig {
+  tiers: Record<RateLimitTier, RateLimitTierConfig>;
+  hostname: string;
+  onLimitReached?: (
+    tier: RateLimitTier,
+    key: string,
+    suppressed: number,
+  ) => void;
+}
+
+export interface RateLimiterInstance {
+  middleware: RequestHandler;
+  reset(): void;
+  setDraining(v: boolean): void;
+  dispose(): void;
+  getHitCounts(): Record<RateLimitTier, number>;
+}
+
+// ---------------------------------------------------------------------------
+// Token Bucket
+// ---------------------------------------------------------------------------
+
+interface TokenBucket {
+  tokens: number;
+  lastRefill: number;
+}
+
+const MAX_BUCKETS = 10_000;
+const GC_REQUEST_INTERVAL = 1000;
+const GC_TIMER_INTERVAL_MS = 5 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Tier Resolution
+// ---------------------------------------------------------------------------
+
+function resolveTier(method: string, path: string): RateLimitTier | null {
+  // Strip trailing slash for consistent matching
+  const p = path.endsWith('/') && path.length > 1 ? path.slice(0, -1) : path;
+
+  // Exempt: OPTIONS, health, demo, heartbeat, SSE events, ACP transport
+  if (method === 'OPTIONS') return null;
+  if (
+    (method === 'GET' || method === 'HEAD') &&
+    (p === '/health' || p === '/demo')
+  )
+    return null;
+  if (
+    method === 'POST' &&
+    p.startsWith('/session/') &&
+    p.endsWith('/heartbeat')
+  )
+    return null;
+  if (method === 'GET' && p.startsWith('/session/') && p.endsWith('/events'))
+    return null;
+  if (p === '/acp' || p.startsWith('/acp/')) return null;
+
+  // Prompt tier
+  if (method === 'POST' && p.startsWith('/session/') && p.endsWith('/prompt'))
+    return 'prompt';
+
+  // Mutation tier: all remaining non-GET/HEAD
+  if (method !== 'GET' && method !== 'HEAD') return 'mutation';
+
+  // Read tier: all remaining GET/HEAD
+  return 'read';
+}
+
+// ---------------------------------------------------------------------------
+// Key Extraction
+// ---------------------------------------------------------------------------
+
+// Keep in sync with server.ts CLIENT_ID_RE / MAX_CLIENT_ID_LENGTH.
+const MAX_CLIENT_ID_LENGTH = 128;
+const CLIENT_ID_RE = /^[A-Za-z0-9._:-]+$/;
+
+function normalizeIp(raw: string): string {
+  // Normalize IPv6-mapped IPv4 (::ffff:127.0.0.1 -> 127.0.0.1)
+  if (raw.startsWith('::ffff:')) {
+    return raw.slice(7);
+  }
+  return raw;
+}
+
+export function createKeyExtractor(hostname: string): (req: Request) => string {
+  const loopback = isLoopbackBind(hostname);
+  return (req: Request): string => {
+    const raw = req.get('x-qwen-client-id');
+    const clientId =
+      raw && raw.length <= MAX_CLIENT_ID_LENGTH && CLIENT_ID_RE.test(raw)
+        ? raw
+        : undefined;
+
+    if (loopback) {
+      return clientId ? `cid:${clientId}` : 'anonymous';
+    }
+
+    const ip = normalizeIp(req.socket?.remoteAddress ?? 'unknown');
+    return clientId ? `${ip}:${clientId}` : ip;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sampled Logger
+// ---------------------------------------------------------------------------
+
+interface SampledLogState {
+  count: number;
+  suppressed: number;
+}
+
+const LOG_SAMPLE_INTERVAL = 100;
+
+interface SampledLogger {
+  log(tier: RateLimitTier, key: string): void;
+  clear(): void;
+}
+
+function createSampledLogger(
+  onLog: (tier: RateLimitTier, key: string, suppressed: number) => void,
+): SampledLogger {
+  const state = new Map<string, SampledLogState>();
+
+  return {
+    log(tier: RateLimitTier, key: string) {
+      const logKey = `${tier}:${key}`;
+      let entry = state.get(logKey);
+      if (!entry) {
+        entry = { count: 0, suppressed: 0 };
+        state.set(logKey, entry);
+      }
+      entry.count++;
+
+      if (entry.count === 1 || entry.count % LOG_SAMPLE_INTERVAL === 0) {
+        onLog(tier, key, entry.suppressed);
+        entry.suppressed = 0;
+      } else {
+        entry.suppressed++;
+      }
+    },
+    clear() {
+      state.clear();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createRateLimiter(
+  config: RateLimitConfig,
+): RateLimiterInstance {
+  // Defense-in-depth: reject invalid config even if CLI validation ran first.
+  for (const [tier, cfg] of Object.entries(config.tiers) as Array<
+    [RateLimitTier, RateLimitTierConfig]
+  >) {
+    if (!Number.isFinite(cfg.max) || cfg.max <= 0) {
+      throw new Error(
+        `rate limit: ${tier}.max must be a positive number, got ${cfg.max}`,
+      );
+    }
+    if (!Number.isFinite(cfg.windowMs) || cfg.windowMs <= 0) {
+      throw new Error(
+        `rate limit: ${tier}.windowMs must be a positive number, got ${cfg.windowMs}`,
+      );
+    }
+  }
+
+  const buckets = new Map<string, Map<RateLimitTier, TokenBucket>>();
+  const keyExtractor = createKeyExtractor(config.hostname);
+  const hitCounts: Record<RateLimitTier, number> = {
+    prompt: 0,
+    mutation: 0,
+    read: 0,
+  };
+  const rates: Record<RateLimitTier, number> = {
+    prompt: config.tiers.prompt.max / config.tiers.prompt.windowMs,
+    mutation: config.tiers.mutation.max / config.tiers.mutation.windowMs,
+    read: config.tiers.read.max / config.tiers.read.windowMs,
+  };
+
+  let draining = false;
+  let requestCount = 0;
+
+  const sampledLog = config.onLimitReached
+    ? createSampledLogger(config.onLimitReached)
+    : undefined;
+
+  // GC: sweep stale buckets and logger state
+  function sweep(): void {
+    const now = Date.now();
+    for (const [key, tierMap] of buckets) {
+      let allStale = true;
+      for (const [tier, bucket] of tierMap) {
+        if (now - bucket.lastRefill < config.tiers[tier].windowMs * 2) {
+          allStale = false;
+          break;
+        }
+      }
+      if (allStale) {
+        buckets.delete(key);
+      }
+    }
+    sampledLog?.clear();
+  }
+
+  const gcTimer = setInterval(sweep, GC_TIMER_INTERVAL_MS);
+  gcTimer.unref();
+
+  // Middleware
+  const middleware: RequestHandler = (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): void => {
+    try {
+      if (draining) {
+        next();
+        return;
+      }
+
+      const tier = resolveTier(req.method, req.path);
+      if (tier === null) {
+        next();
+        return;
+      }
+
+      // GC sweep on request count
+      requestCount++;
+      if (requestCount % GC_REQUEST_INTERVAL === 0) {
+        sweep();
+      }
+
+      const key = keyExtractor(req);
+      const tierConfig = config.tiers[tier];
+      const rate = rates[tier];
+      const now = Date.now();
+
+      // Fail-open if bucket map is at capacity
+      let tierMap = buckets.get(key);
+      if (!tierMap) {
+        if (buckets.size >= MAX_BUCKETS) {
+          next();
+          return;
+        }
+        tierMap = new Map();
+        buckets.set(key, tierMap);
+      }
+
+      let bucket = tierMap.get(tier);
+      if (!bucket) {
+        bucket = { tokens: tierConfig.max, lastRefill: now };
+        tierMap.set(tier, bucket);
+      }
+
+      // Continuous drip refill
+      const elapsed = Math.max(0, now - bucket.lastRefill);
+      bucket.tokens = Math.min(tierConfig.max, bucket.tokens + elapsed * rate);
+      bucket.lastRefill = now;
+
+      if (bucket.tokens >= 1) {
+        bucket.tokens -= 1;
+        next();
+      } else {
+        // Rate limited
+        hitCounts[tier]++;
+        const retryAfterMs = Math.ceil((1 - bucket.tokens) / rate);
+        const retryAfterSec = Math.ceil(retryAfterMs / 1000);
+
+        if (sampledLog) {
+          sampledLog.log(tier, key);
+        }
+
+        res.setHeader('Retry-After', String(retryAfterSec));
+        res.setHeader('X-RateLimit-Limit', String(tierConfig.max));
+        res.setHeader('X-RateLimit-Remaining', '0');
+        res.setHeader(
+          'X-RateLimit-Reset',
+          String(Math.ceil((now + retryAfterMs) / 1000)),
+        );
+        res.status(429).json({
+          error: 'Rate limit exceeded',
+          code: 'rate_limit_exceeded',
+          tier,
+          retryAfterMs,
+        });
+      }
+    } catch {
+      // Fail-open: internal error should not block requests
+      next();
+    }
+  };
+
+  return {
+    middleware,
+    reset() {
+      buckets.clear();
+      hitCounts.prompt = 0;
+      hitCounts.mutation = 0;
+      hitCounts.read = 0;
+      requestCount = 0;
+      sampledLog?.clear();
+    },
+    setDraining(v: boolean) {
+      draining = v;
+    },
+    dispose() {
+      clearInterval(gcTimer);
+      buckets.clear();
+    },
+    getHitCounts() {
+      return { ...hitCounts };
+    },
+  };
+}

--- a/packages/cli/src/serve/runQwenServe.ts
+++ b/packages/cli/src/serve/runQwenServe.ts
@@ -1132,6 +1132,14 @@ export async function runQwenServe(
                 );
               }
             }
+            // Dispose rate limiter (clear GC timer + buckets).
+            const rl = app.locals['_rateLimiter'] as
+              | { dispose(): void; setDraining(v: boolean): void }
+              | undefined;
+            if (rl) {
+              rl.setDraining(true);
+              rl.dispose();
+            }
             forceFlushMetrics()
               .catch((flushErr) => {
                 daemonLog.warn(

--- a/packages/cli/src/serve/runQwenServe.ts
+++ b/packages/cli/src/serve/runQwenServe.ts
@@ -57,6 +57,7 @@ import type { ServeOptions } from './types.js';
 import type { WorkspaceFileSystemFactory } from './fs/index.js';
 import type { PermissionPolicy } from '@qwen-code/acp-bridge';
 import { getCliVersion } from '../utils/version.js';
+import { getRateLimiter } from './rateLimit.js';
 
 const QWEN_SERVER_TOKEN_ENV = 'QWEN_SERVER_TOKEN';
 const QWEN_SERVE_PROMPT_DEADLINE_MS_ENV = 'QWEN_SERVE_PROMPT_DEADLINE_MS';
@@ -1133,9 +1134,7 @@ export async function runQwenServe(
               }
             }
             // Dispose rate limiter (clear GC timer + buckets).
-            const rl = app.locals['_rateLimiter'] as
-              | { dispose(): void; setDraining(v: boolean): void }
-              | undefined;
+            const rl = getRateLimiter(app);
             if (rl) {
               rl.setDraining(true);
               rl.dispose();

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -211,7 +211,8 @@ const EXPECTED_REGISTERED_FEATURES = [
       f !== 'workspace_hooks' &&
       f !== 'session_hooks' &&
       f !== 'workspace_extensions' &&
-      f !== 'session_branch',
+      f !== 'session_branch' &&
+      f !== 'rate_limit',
   ),
   'workspace_settings',
   'workspace_init',
@@ -232,6 +233,7 @@ const EXPECTED_REGISTERED_FEATURES = [
   'session_hooks',
   'workspace_extensions',
   'session_branch',
+  'rate_limit',
 ] as const;
 
 interface FakeBridgeOpts {
@@ -1323,6 +1325,18 @@ describe('createServeApp', () => {
             getAdvertisedServeFeatures(undefined, {
               persistSettingAvailable: true,
             }),
+          ).toContain(feature);
+          expect(getAdvertisedServeFeatures(undefined, {})).not.toContain(
+            feature,
+          );
+          continue;
+        }
+        if (feature === 'rate_limit') {
+          expect(predicate({ rateLimit: true })).toBe(true);
+          expect(predicate({ rateLimit: false })).toBe(false);
+          expect(predicate({})).toBe(false);
+          expect(
+            getAdvertisedServeFeatures(undefined, { rateLimit: true }),
           ).toContain(feature);
           expect(getAdvertisedServeFeatures(undefined, {})).not.toContain(
             feature,

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -102,6 +102,7 @@ import {
   type WorkspaceRequestContext,
 } from './workspace-service/index.js';
 import { registerWorkspaceSettingsRoutes } from './routes/workspaceSettings.js';
+import { createRateLimiter, type RateLimiterInstance } from './rateLimit.js';
 
 let activeSseCount = 0;
 export function getActiveSseCount(): number {
@@ -809,6 +810,7 @@ export function createServeApp(
         status: 'ok',
         sessions: bridge.sessionCount,
         pendingPermissions: bridge.pendingPermissionCount,
+        ...(rateLimiter ? { rateLimitHits: rateLimiter.getHitCounts() } : {}),
       });
     } catch (err) {
       writeStderrLine(
@@ -882,6 +884,30 @@ export function createServeApp(
 
   app.use(bearerAuth(opts.token));
 
+  // Rate limiter: after auth (only count authenticated requests),
+  // before body parser (reject early without burning JSON.parse CPU).
+  let rateLimiter: RateLimiterInstance | undefined;
+  if (opts.rateLimit) {
+    const windowMs = opts.rateLimitWindowMs ?? 60_000;
+    rateLimiter = createRateLimiter({
+      tiers: {
+        prompt: { windowMs, max: opts.rateLimitPrompt ?? 10 },
+        mutation: { windowMs, max: opts.rateLimitMutation ?? 30 },
+        read: { windowMs, max: opts.rateLimitRead ?? 120 },
+      },
+      hostname: opts.hostname,
+      onLimitReached: daemonLog
+        ? (tier, key, suppressed) => {
+            daemonLog.warn(
+              `rate limit hit${suppressed > 0 ? ` (${suppressed} suppressed)` : ''}`,
+              { tier, key: key.slice(0, 64) },
+            );
+          }
+        : undefined,
+    });
+    app.use(rateLimiter.middleware);
+  }
+
   app.use(express.json({ limit: '10mb' }));
   app.use(
     (
@@ -946,6 +972,7 @@ export function createServeApp(
           ? { writerIdleTimeoutMs: opts.writerIdleTimeoutMs }
           : {}),
         persistSettingAvailable: deps.persistSetting !== undefined,
+        rateLimit: opts.rateLimit === true,
       }),
       modelServices: [],
       // Surface the bound workspace so clients can detect mismatch
@@ -2988,6 +3015,10 @@ export function createServeApp(
       }
     },
   );
+
+  if (rateLimiter) {
+    app.locals['_rateLimiter'] = rateLimiter;
+  }
 
   return app;
 }

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -102,7 +102,11 @@ import {
   type WorkspaceRequestContext,
 } from './workspace-service/index.js';
 import { registerWorkspaceSettingsRoutes } from './routes/workspaceSettings.js';
-import { createRateLimiter, type RateLimiterInstance } from './rateLimit.js';
+import {
+  createRateLimiter,
+  setRateLimiter,
+  type RateLimiterInstance,
+} from './rateLimit.js';
 
 let activeSseCount = 0;
 export function getActiveSseCount(): number {
@@ -901,6 +905,14 @@ export function createServeApp(
             daemonLog.warn(
               `rate limit hit${suppressed > 0 ? ` (${suppressed} suppressed)` : ''}`,
               { tier, key: key.slice(0, 64) },
+            );
+          }
+        : undefined,
+      onError: daemonLog
+        ? (err, path) => {
+            daemonLog.warn(
+              `rate limiter error (fail-open): ${err instanceof Error ? err.message : String(err)}`,
+              { path },
             );
           }
         : undefined,
@@ -3017,7 +3029,7 @@ export function createServeApp(
   );
 
   if (rateLimiter) {
-    app.locals['_rateLimiter'] = rateLimiter;
+    setRateLimiter(app, rateLimiter);
   }
 
   return app;

--- a/packages/cli/src/serve/types.ts
+++ b/packages/cli/src/serve/types.ts
@@ -156,6 +156,19 @@ export interface ServeOptions {
   writerIdleTimeoutMs?: number;
   /** Non-negative ms to keep ACP child alive after last session closes. 0 = immediate kill (default). */
   channelIdleTimeoutMs?: number;
+  /**
+   * Enable per-tier HTTP rate limiting. Off by default. When enabled,
+   * requests exceeding per-tier limits receive 429 + Retry-After.
+   */
+  rateLimit?: boolean;
+  /** Max prompt requests per window per key (default 10). Requires --rate-limit. */
+  rateLimitPrompt?: number;
+  /** Max mutation requests per window per key (default 30). Requires --rate-limit. */
+  rateLimitMutation?: number;
+  /** Max read requests per window per key (default 120). Requires --rate-limit. */
+  rateLimitRead?: number;
+  /** Rate limit window duration in ms (default 60000). Requires --rate-limit. */
+  rateLimitWindowMs?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds opt-in per-tier HTTP rate limiting to `qwen serve` via `--rate-limit` flag
- Token bucket with continuous drip refill, default off to preserve backward compatibility
- Three tiers: prompt (10/min), mutation (30/min), read (120/min) per client key
- Health, heartbeat, SSE, and `/acp` endpoints exempt
- Fail-open on bucket map capacity (10k keys) and internal errors
- Graceful shutdown: `setDraining(true)` + `dispose()` in shutdown path

## Details

| File | Change |
|------|--------|
| `rateLimit.ts` | NEW — core middleware: token bucket, key extractor (loopback=client-id, non-loopback=IP+client-id), tier resolver, sampled logging, GC (timer + request-count), config validation |
| `rateLimit.test.ts` | NEW — 25 unit tests: bucket mechanics, continuous drip refill, tier assignment, key extraction (IPv6 normalization), exempt routes, fail-open, draining, reset, callbacks |
| `types.ts` | 5 new `ServeOptions` fields |
| `capabilities.ts` | `rate_limit` conditional feature tag (3 coordinated changes) |
| `server.ts` | Middleware wiring between `bearerAuth` and `express.json`, capabilities toggle, deep health hit counts, `app.locals` lifecycle exposure |
| `runQwenServe.ts` | Shutdown `setDraining` + `dispose` |
| `serve.ts` | CLI flags (`--rate-limit`, `--rate-limit-prompt/mutation/read/window-ms`), env var fallbacks, boot validation |
| `server.test.ts` | Capability fixture update for `rate_limit` conditional tag |

## CLI Flags

| Flag | Default | Env Var |
|------|---------|---------|
| `--rate-limit` | false | `QWEN_SERVE_RATE_LIMIT` |
| `--rate-limit-prompt` | 10 | `QWEN_SERVE_RATE_LIMIT_PROMPT` |
| `--rate-limit-mutation` | 30 | `QWEN_SERVE_RATE_LIMIT_MUTATION` |
| `--rate-limit-read` | 120 | `QWEN_SERVE_RATE_LIMIT_READ` |
| `--rate-limit-window-ms` | 60000 | `QWEN_SERVE_RATE_LIMIT_WINDOW_MS` |

## Known Limitations (documented)

- Reverse proxy: `req.socket.remoteAddress` is the proxy IP; all clients share one bucket
- `0.0.0.0` bind: local clients all appear as `127.0.0.1`
- Client-ID bypass: loopback clients can rotate client-id for fresh buckets (bounded by 10k cap → fail-open)
- Boot-time only: limits require daemon restart to change

## Test plan

- [x] 25 unit tests pass (bucket, tier, key, exempt, fail-open, draining, reset, callbacks)
- [x] TypeScript typecheck passes (no rate-limit related errors)
- [x] ESLint + prettier pass (pre-commit hook)
- [x] Capability test fixture updated for `rate_limit` conditional tag
- [ ] Manual: `qwen serve --rate-limit --rate-limit-prompt 2` → 3rd prompt returns 429

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)