### PR TITLE
feat(test): add daemon connection stress test + refactor perf harness

### DIFF
--- a/integration-tests/cli/_daemon-benchmark-helpers.ts
+++ b/integration-tests/cli/_daemon-benchmark-helpers.ts
@@ -1,0 +1,440 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Benchmark-only helpers extracted from `qwen-daemon-vs-cli-benchmark.test.ts`.
+ *
+ * These functions wrap `/usr/bin/time` to capture OS-level resource metrics
+ * (peak RSS, CPU time, context switches, page faults, hardware counters)
+ * for both CLI cold-start and daemon lifecycle measurements. POSIX only —
+ * `/usr/bin/time -l` on macOS, `/usr/bin/time -v` on Linux.
+ *
+ * Also provides `measureProcessTreeRss` which walks the daemon process tree
+ * via the harness's `getRssMB` / `countDescendants` to produce a breakdown
+ * of daemon + ACP child + MCP grandchildren RSS.
+ */
+
+import { spawn, execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { DaemonClient } from '@qwen-code/sdk';
+
+import {
+  getRssMB,
+  countDescendants,
+  sleep,
+  DEFAULT_CLI_BIN,
+  DEFAULT_TOKEN,
+  type SpawnDaemonOptions,
+  type SpawnedDaemon,
+} from './_daemon-harness.js';
+
+const IS_DARWIN = process.platform === 'darwin';
+
+// ---------------------------------------------------------------------------
+// ProcessResourceMetrics — OS-level resource counters from /usr/bin/time
+// ---------------------------------------------------------------------------
+
+export interface ProcessResourceMetrics {
+  peakRssMB: number | null;
+  userTimeMs: number | null;
+  sysTimeMs: number | null;
+  voluntaryCtxSwitches: number | null;
+  involuntaryCtxSwitches: number | null;
+  pageFaults: number | null;
+  pageReclaims: number | null;
+  instructionsRetired: number | null;
+  cyclesElapsed: number | null;
+}
+
+export interface CliResult extends ProcessResourceMetrics {
+  wallClockMs: number;
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+// ---------------------------------------------------------------------------
+// ProcessTreeRss — RSS breakdown across daemon process tree
+// ---------------------------------------------------------------------------
+
+export interface ProcessTreeRss {
+  daemonRssMB: number;
+  acpChildRssMB: number;
+  mcpChildrenRssMB: number;
+  totalRssMB: number;
+}
+
+// ---------------------------------------------------------------------------
+// StartupPhasesResult — CLI startup profiler phase breakdown
+// ---------------------------------------------------------------------------
+
+export interface StartupPhasesResult {
+  moduleLoadMs: number | null;
+  configInitMs: number | null;
+  mcpSettledMs: number | null;
+  fullStartupMs: number | null;
+  wallClockMs: number;
+  peakRssMB: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// parseTimeOutput
+// ---------------------------------------------------------------------------
+
+export function parseTimeOutput(stderr: string): ProcessResourceMetrics {
+  const metrics: ProcessResourceMetrics = {
+    peakRssMB: null,
+    userTimeMs: null,
+    sysTimeMs: null,
+    voluntaryCtxSwitches: null,
+    involuntaryCtxSwitches: null,
+    pageFaults: null,
+    pageReclaims: null,
+    instructionsRetired: null,
+    cyclesElapsed: null,
+  };
+
+  if (IS_DARWIN) {
+    const timeLineMatch = stderr.match(
+      /(\d+\.\d+)\s+real\s+(\d+\.\d+)\s+user\s+(\d+\.\d+)\s+sys/,
+    );
+    if (timeLineMatch) {
+      metrics.userTimeMs = Math.round(Number(timeLineMatch[2]) * 1000);
+      metrics.sysTimeMs = Math.round(Number(timeLineMatch[3]) * 1000);
+    }
+
+    const rssMatch = stderr.match(/(\d+)\s+maximum resident set size/);
+    if (rssMatch)
+      metrics.peakRssMB =
+        Math.round((Number(rssMatch[1]) / 1024 / 1024) * 10) / 10;
+
+    const volCtx = stderr.match(/(\d+)\s+voluntary context switches/);
+    if (volCtx) metrics.voluntaryCtxSwitches = Number(volCtx[1]);
+
+    const involCtx = stderr.match(/(\d+)\s+involuntary context switches/);
+    if (involCtx) metrics.involuntaryCtxSwitches = Number(involCtx[1]);
+
+    const pageFaults = stderr.match(/(\d+)\s+page faults/);
+    if (pageFaults) metrics.pageFaults = Number(pageFaults[1]);
+
+    const pageReclaims = stderr.match(/(\d+)\s+page reclaims/);
+    if (pageReclaims) metrics.pageReclaims = Number(pageReclaims[1]);
+
+    const instructions = stderr.match(/(\d+)\s+instructions retired/);
+    if (instructions) metrics.instructionsRetired = Number(instructions[1]);
+
+    const cycles = stderr.match(/(\d+)\s+cycles elapsed/);
+    if (cycles) metrics.cyclesElapsed = Number(cycles[1]);
+  } else {
+    const userTime = stderr.match(/User time.*?:\s*(\d+\.\d+)/);
+    if (userTime) metrics.userTimeMs = Math.round(Number(userTime[1]) * 1000);
+
+    const sysTime = stderr.match(/System time.*?:\s*(\d+\.\d+)/);
+    if (sysTime) metrics.sysTimeMs = Math.round(Number(sysTime[1]) * 1000);
+
+    const rss = stderr.match(/Maximum resident set size.*?:\s*(\d+)/);
+    if (rss) metrics.peakRssMB = Math.round((Number(rss[1]) / 1024) * 10) / 10;
+
+    const volCtx = stderr.match(/Voluntary context switches.*?:\s*(\d+)/);
+    if (volCtx) metrics.voluntaryCtxSwitches = Number(volCtx[1]);
+
+    const involCtx = stderr.match(/Involuntary context switches.*?:\s*(\d+)/);
+    if (involCtx) metrics.involuntaryCtxSwitches = Number(involCtx[1]);
+
+    const majorFaults = stderr.match(/Major.*?page faults.*?:\s*(\d+)/);
+    if (majorFaults) metrics.pageFaults = Number(majorFaults[1]);
+
+    const minorFaults = stderr.match(/Minor.*?page faults.*?:\s*(\d+)/);
+    if (minorFaults) metrics.pageReclaims = Number(minorFaults[1]);
+  }
+
+  return metrics;
+}
+
+// ---------------------------------------------------------------------------
+// spawnCliWithTime
+// ---------------------------------------------------------------------------
+
+export function spawnCliWithTime(
+  args: string[],
+  opts?: { cwd?: string; env?: Record<string, string> },
+): Promise<CliResult> {
+  const cliBin = DEFAULT_CLI_BIN;
+  return new Promise((resolve) => {
+    const t0 = performance.now();
+
+    const timeArgs = IS_DARWIN ? ['-l'] : ['-v'];
+    const child = spawn(
+      '/usr/bin/time',
+      [...timeArgs, process.execPath, cliBin, ...args],
+      {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        cwd: opts?.cwd,
+        env: opts?.env ? { ...process.env, ...opts.env } : undefined,
+      },
+    );
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (c: Buffer) => {
+      stdout += c.toString();
+    });
+    child.stderr?.on('data', (c: Buffer) => {
+      stderr += c.toString();
+    });
+
+    child.once('exit', (code) => {
+      const wallClockMs = performance.now() - t0;
+      const metrics = parseTimeOutput(stderr);
+      resolve({ wallClockMs, exitCode: code, stdout, stderr, ...metrics });
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// measureProcessTreeRss
+// ---------------------------------------------------------------------------
+
+export function measureProcessTreeRss(daemonPid: number): ProcessTreeRss {
+  const daemonRss = getRssMB(daemonPid);
+  const desc = countDescendants(daemonPid);
+
+  let acpChildRss = 0;
+  for (const pid of desc.acpChildren) {
+    const rss = getRssMB(pid);
+    if (!Number.isNaN(rss)) acpChildRss += rss;
+  }
+
+  let mcpChildrenRss = 0;
+  for (const pid of desc.mcpGrandchildren) {
+    const rss = getRssMB(pid);
+    if (!Number.isNaN(rss)) mcpChildrenRss += rss;
+  }
+
+  const safeDaemonRss = Number.isNaN(daemonRss) ? 0 : daemonRss;
+  return {
+    daemonRssMB: safeDaemonRss,
+    acpChildRssMB: acpChildRss,
+    mcpChildrenRssMB: mcpChildrenRss,
+    totalRssMB: safeDaemonRss + acpChildRss + mcpChildrenRss,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// measureCliStartupWithProfiler
+// ---------------------------------------------------------------------------
+
+export async function measureCliStartupWithProfiler(opts?: {
+  cwd?: string;
+}): Promise<StartupPhasesResult> {
+  const perfDir = path.join(os.homedir(), '.qwen', 'startup-perf');
+  const beforeFiles = new Set<string>();
+  try {
+    for (const f of fs.readdirSync(perfDir)) beforeFiles.add(f);
+  } catch {
+    /* dir might not exist yet */
+  }
+
+  const result = await spawnCliWithTime(
+    ['-p', 'x', '--output-format', 'text'],
+    {
+      cwd: opts?.cwd,
+      env: {
+        QWEN_CODE_PROFILE_STARTUP: '1',
+        QWEN_CODE_PROFILE_STARTUP_OUTER: '1',
+      },
+    },
+  );
+
+  const profileData: StartupPhasesResult = {
+    moduleLoadMs: null,
+    configInitMs: null,
+    mcpSettledMs: null,
+    fullStartupMs: null,
+    wallClockMs: result.wallClockMs,
+    peakRssMB: result.peakRssMB,
+  };
+
+  try {
+    const afterFiles = fs.readdirSync(perfDir);
+    const newFile = afterFiles.find((f) => !beforeFiles.has(f));
+    if (newFile) {
+      const report = JSON.parse(
+        fs.readFileSync(path.join(perfDir, newFile), 'utf-8'),
+      );
+      const dp = report.derivedPhases ?? {};
+      profileData.moduleLoadMs = report.processUptimeAtT0Ms ?? null;
+      profileData.configInitMs = dp.config_initialize_dur ?? null;
+      profileData.mcpSettledMs = dp.mcp_all_settled ?? null;
+      profileData.fullStartupMs =
+        report.processUptimeAtT0Ms != null && report.totalMs != null
+          ? Math.round((report.processUptimeAtT0Ms + report.totalMs) * 10) / 10
+          : null;
+      try {
+        fs.unlinkSync(path.join(perfDir, newFile));
+      } catch {
+        /* best-effort */
+      }
+    }
+  } catch {
+    /* profiler output not available — fall back to wall-clock only */
+  }
+
+  return profileData;
+}
+
+// ---------------------------------------------------------------------------
+// spawnDaemonWithTime
+// ---------------------------------------------------------------------------
+
+export async function spawnDaemonWithTime(
+  opts: SpawnDaemonOptions = {},
+): Promise<
+  SpawnedDaemon & { getResourceMetrics: () => ProcessResourceMetrics }
+> {
+  const token = opts.token ?? DEFAULT_TOKEN;
+  const cliBin = opts.cliBin ?? DEFAULT_CLI_BIN;
+  const bootTimeoutMs = opts.bootTimeoutMs ?? 10_000;
+  const extraArgs = opts.extraArgs ?? [];
+
+  const daemonArgs = [
+    cliBin,
+    'serve',
+    '--port',
+    '0',
+    '--token',
+    token,
+    '--hostname',
+    '127.0.0.1',
+    '--workspace',
+    opts.workspaceCwd ?? process.cwd(),
+    ...extraArgs,
+  ];
+
+  const timeArgs = IS_DARWIN ? ['-l'] : ['-v'];
+  const child = spawn(
+    '/usr/bin/time',
+    [...timeArgs, process.execPath, ...daemonArgs],
+    {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, ...opts.env },
+    },
+  );
+
+  const stdoutBuf = { value: '' };
+  const stderrBuf = { value: '' };
+  child.stdout?.on('data', (chunk: Buffer) => {
+    stdoutBuf.value += chunk.toString();
+  });
+  child.stderr?.on('data', (chunk: Buffer) => {
+    stderrBuf.value += chunk.toString();
+  });
+
+  const LISTENING_RE = /listening on http:\/\/127\.0\.0\.1:(\d+)/;
+  const port = await new Promise<number>((resolve, reject) => {
+    let settled = false;
+    const cleanup = () => {
+      child.stdout?.off('data', onData);
+      child.off('exit', onExit);
+      clearTimeout(bootTimer);
+    };
+    const fail = (err: Error, kill = false) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (kill && child.exitCode === null) child.kill('SIGTERM');
+      reject(err);
+    };
+    const bootTimer = setTimeout(() => {
+      fail(
+        new Error(
+          `daemon boot timeout after ${bootTimeoutMs}ms:\n` +
+            `stdout=${stdoutBuf.value}\nstderr=${stderrBuf.value}`,
+        ),
+        true,
+      );
+    }, bootTimeoutMs);
+    const onData = () => {
+      const m = stdoutBuf.value.match(LISTENING_RE);
+      if (m && !settled) {
+        settled = true;
+        cleanup();
+        resolve(Number(m[1]));
+      }
+    };
+    const onExit = (code: number | null) => {
+      fail(
+        new Error(
+          `daemon exited with ${code} before listening:\n` +
+            `stdout=${stdoutBuf.value}\nstderr=${stderrBuf.value}`,
+        ),
+      );
+    };
+    child.stdout!.on('data', onData);
+    child.once('exit', onExit);
+  });
+
+  const base = `http://127.0.0.1:${port}`;
+  const client = new DaemonClient({ baseUrl: base, token });
+
+  const dispose = async () => {
+    if (child.exitCode !== null) return;
+    try {
+      const innerPids = execFileSync('pgrep', ['-P', String(child.pid!)], {
+        encoding: 'utf8',
+        timeout: 2_000,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      })
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map(Number);
+      for (const pid of innerPids) {
+        try {
+          process.kill(pid, 'SIGTERM');
+        } catch {
+          /* already gone */
+        }
+      }
+    } catch {
+      child.kill('SIGTERM');
+    }
+    await new Promise<void>((resolve) => {
+      const t = setTimeout(() => {
+        try {
+          child.kill('SIGKILL');
+        } catch {
+          /* gone */
+        }
+        resolve();
+      }, 8_000);
+      child.once('exit', () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+    await sleep(200);
+  };
+
+  const getResourceMetrics = (): ProcessResourceMetrics =>
+    parseTimeOutput(stderrBuf.value);
+
+  return {
+    client,
+    daemon: child,
+    port,
+    base,
+    workspaceCwd: opts.workspaceCwd ?? process.cwd(),
+    token,
+    stdoutBuf,
+    stderrBuf,
+    dispose,
+    getResourceMetrics,
+  };
+}

--- a/integration-tests/cli/_daemon-harness.ts
+++ b/integration-tests/cli/_daemon-harness.ts
@@ -37,6 +37,7 @@ import {
   type ExecFileSyncOptionsWithStringEncoding,
 } from 'node:child_process';
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { DaemonClient, type SubscribeOptions } from '@qwen-code/sdk';
@@ -461,6 +462,8 @@ export function percentiles(values: number[]): Percentiles {
  */
 export interface ConsumeSseResult {
   received: number;
+  /** The last non-undefined `ev.id` observed (for `Last-Event-ID` reconnect). */
+  lastSeenId?: number;
   evictedAt?: number;
   evictionReason?: string;
   elapsedMs: number;
@@ -481,6 +484,7 @@ export async function consumeSseEvents(
   const timeoutMs = opts.timeoutMs ?? 30_000;
   const startedAt = Date.now();
   let received = 0;
+  let lastSeenId: number | undefined;
   let evictedAt: number | undefined;
   let evictionReason: string | undefined;
 
@@ -499,6 +503,7 @@ export async function consumeSseEvents(
       signal: ac.signal,
     })) {
       received++;
+      if (ev.id !== undefined) lastSeenId = ev.id;
       if (ev.type === 'client_evicted') {
         evictedAt = ev.id;
         const data = ev.data as { reason?: string } | undefined;
@@ -525,12 +530,37 @@ export async function consumeSseEvents(
 
   return {
     received,
+    lastSeenId,
     evictedAt,
     evictionReason,
     elapsedMs: Date.now() - startedAt,
   };
 }
 
-function sleep(ms: number): Promise<void> {
+export function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
+}
+
+export function gitHead(timeoutMs = 5_000): string | null {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+      timeout: timeoutMs,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+export function makeTempWorkspace(label: string, prefix = 'qwen-test'): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `${prefix}-${label}-`));
+}
+
+export interface ScenarioResult {
+  name: string;
+  status: 'passed' | 'failed' | 'skipped';
+  durationMs: number;
+  error?: string;
+  metrics?: Record<string, unknown>;
 }

--- a/integration-tests/cli/_daemon-perf-report.ts
+++ b/integration-tests/cli/_daemon-perf-report.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Shared report primitives for daemon performance test suites (baseline,
+ * benchmark, loadtest). Each suite owns its own SnapshotShape and
+ * renderMarkdown; this module provides the common building blocks.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { Percentiles } from './_daemon-harness.js';
+
+// ---------------------------------------------------------------------------
+// Platform info
+// ---------------------------------------------------------------------------
+
+export interface PlatformInfo {
+  os: string;
+  arch: string;
+  nodeVersion: string;
+}
+
+export function collectPlatformInfo(): PlatformInfo {
+  return {
+    os: process.platform,
+    arch: process.arch,
+    nodeVersion: process.version,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Output directory resolution
+// ---------------------------------------------------------------------------
+
+export function resolveOutputDir(label: string): string {
+  const ts = new Date().toISOString().replace(/[:.]/g, '').replace(/Z$/, '');
+  return (
+    process.env['INTEGRATION_TEST_FILE_DIR'] ??
+    path.join(process.cwd(), '.integration-tests', `${label}-${ts}`)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Percentile formatting
+// ---------------------------------------------------------------------------
+
+export function formatPercentiles(p: Percentiles | null | undefined): string {
+  return p && p.count > 0
+    ? `p50=${p.p50.toFixed(0)} p90=${p.p90.toFixed(0)} p99=${p.p99.toFixed(0)} mean=${p.mean.toFixed(0)} (n=${p.count})`
+    : 'n/a';
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot artifact writer
+// ---------------------------------------------------------------------------
+
+export function writeSnapshotArtifacts(
+  outputDir: string,
+  baseName: string,
+  snapshot: unknown,
+  markdown: string,
+  logTag: string,
+): void {
+  fs.mkdirSync(outputDir, { recursive: true });
+  const jsonPath = path.join(outputDir, `${baseName}.json`);
+  fs.writeFileSync(jsonPath, JSON.stringify(snapshot, null, 2));
+  fs.writeFileSync(path.join(outputDir, `${baseName}.md`), markdown);
+  console.log(`[${logTag}] ${baseName}.json written to ${jsonPath}`);
+}

--- a/integration-tests/cli/mock-acp-typecheck.test.ts
+++ b/integration-tests/cli/mock-acp-typecheck.test.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { Agent } from '@agentclientprotocol/sdk';
+
+describe('mock ACP agent type compliance', () => {
+  it('satisfies required Agent interface methods', () => {
+    const _typeCheck: Pick<
+      Agent,
+      'initialize' | 'authenticate' | 'newSession' | 'prompt' | 'cancel'
+    > = {
+      initialize: async () => ({
+        protocolVersion: '',
+        agentInfo: { name: '', version: '' },
+        authMethods: [],
+        agentCapabilities: {},
+      }),
+      authenticate: async () => ({}),
+      newSession: async () => ({ sessionId: '' }),
+      prompt: async () => ({ stopReason: 'end_turn' as const }),
+      cancel: async () => {},
+    };
+    expect(_typeCheck).toBeDefined();
+  });
+});

--- a/integration-tests/cli/qwen-daemon-loadtest.test.ts
+++ b/integration-tests/cli/qwen-daemon-loadtest.test.ts
@@ -208,14 +208,20 @@ async function withDaemon(
       });
 
       const stats = percentiles(latencies);
-      snapshot.scenarios.push({
-        name: 'rapid-lifecycle',
-        status: 'passed',
-        durationMs: performance.now() - t0,
-        metrics: { cycles: LIFECYCLE_CYCLES, ...stats },
-      });
-
-      expect(stats.p99).toBeLessThan(30_000);
+      let status: 'passed' | 'failed' = 'passed';
+      try {
+        expect(stats.p99).toBeLessThan(30_000);
+      } catch (err) {
+        status = 'failed';
+        throw err;
+      } finally {
+        snapshot.scenarios.push({
+          name: 'rapid-lifecycle',
+          status,
+          durationMs: performance.now() - t0,
+          metrics: { cycles: LIFECYCLE_CYCLES, ...stats },
+        });
+      }
     }, 120_000);
 
     // Scenario 2: SSE slow consumer triggers eviction
@@ -259,17 +265,21 @@ async function withDaemon(
         },
       );
 
-      snapshot.scenarios.push({
-        name: 'sse-slow-consumer-eviction',
-        status: 'passed',
-        durationMs: performance.now() - t0,
-        metrics: { evicted, received },
-      });
-
-      // Whether eviction fires depends on ring size vs consumer speed.
-      // The catastrophic bound: the consumer received at least one event
-      // and the daemon survived the prompt flood without crashing.
-      expect(received).toBeGreaterThan(0);
+      let status: 'passed' | 'failed' = 'passed';
+      try {
+        expect(received).toBeGreaterThan(0);
+        expect(evicted).toBe(true);
+      } catch (err) {
+        status = 'failed';
+        throw err;
+      } finally {
+        snapshot.scenarios.push({
+          name: 'sse-slow-consumer-eviction',
+          status,
+          durationMs: performance.now() - t0,
+          metrics: { evicted, received },
+        });
+      }
     }, 120_000);
 
     // Scenario 3: Last-Event-ID reconnect under concurrent load
@@ -316,14 +326,20 @@ async function withDaemon(
         await d.client.closeSession(session.sessionId);
       });
 
-      snapshot.scenarios.push({
-        name: 'last-event-id-reconnect',
-        status: 'passed',
-        durationMs: performance.now() - t0,
-        metrics: { reconnectReceived },
-      });
-
-      expect(reconnectReceived).toBeGreaterThan(0);
+      let status: 'passed' | 'failed' = 'passed';
+      try {
+        expect(reconnectReceived).toBeGreaterThan(0);
+      } catch (err) {
+        status = 'failed';
+        throw err;
+      } finally {
+        snapshot.scenarios.push({
+          name: 'last-event-id-reconnect',
+          status,
+          durationMs: performance.now() - t0,
+          metrics: { reconnectReceived },
+        });
+      }
     }, 120_000);
 
     // Scenario 4: ACP child crash → session error recovery
@@ -347,15 +363,16 @@ async function withDaemon(
             crashDetected = true;
           }
 
-          // Poll for daemon recovery instead of fixed sleep.
+          // Poll for daemon recovery, then verify it can serve new work.
           const deadline = Date.now() + 5_000;
           while (Date.now() < deadline) {
             try {
-              const health = await d.client.health();
-              if (health !== undefined) {
-                recoverySucceeded = true;
-                break;
-              }
+              await d.client.health();
+              const recoverySession = await d.client.createOrAttachSession({
+                sessionScope: 'thread',
+              });
+              recoverySucceeded = recoverySession.sessionId !== undefined;
+              break;
             } catch {
               await sleep(200);
             }
@@ -363,15 +380,21 @@ async function withDaemon(
         },
       );
 
-      snapshot.scenarios.push({
-        name: 'acp-crash-recovery',
-        status: 'passed',
-        durationMs: performance.now() - t0,
-        metrics: { crashDetected, recoverySucceeded },
-      });
-
-      expect(crashDetected).toBe(true);
-      expect(recoverySucceeded).toBe(true);
+      let status: 'passed' | 'failed' = 'passed';
+      try {
+        expect(crashDetected).toBe(true);
+        expect(recoverySucceeded).toBe(true);
+      } catch (err) {
+        status = 'failed';
+        throw err;
+      } finally {
+        snapshot.scenarios.push({
+          name: 'acp-crash-recovery',
+          status,
+          durationMs: performance.now() - t0,
+          metrics: { crashDetected, recoverySucceeded },
+        });
+      }
     }, 90_000);
 
     // Scenario 5: burst concurrent sessions
@@ -407,20 +430,26 @@ async function withDaemon(
       });
 
       const stats = percentiles(latencies);
-      snapshot.scenarios.push({
-        name: 'burst-concurrent',
-        status: 'passed',
-        durationMs: performance.now() - t0,
-        metrics: {
-          burstSize: BURST_SESSIONS,
-          successCount,
-          failureCount,
-          ...stats,
-        },
-      });
-
-      expect(failureCount).toBe(0);
-      expect(stats.p99).toBeLessThan(60_000);
+      let status: 'passed' | 'failed' = 'passed';
+      try {
+        expect(failureCount).toBe(0);
+        expect(stats.p99).toBeLessThan(60_000);
+      } catch (err) {
+        status = 'failed';
+        throw err;
+      } finally {
+        snapshot.scenarios.push({
+          name: 'burst-concurrent',
+          status,
+          durationMs: performance.now() - t0,
+          metrics: {
+            burstSize: BURST_SESSIONS,
+            successCount,
+            failureCount,
+            ...stats,
+          },
+        });
+      }
     }, 120_000);
 
     // Report

--- a/integration-tests/cli/qwen-daemon-loadtest.test.ts
+++ b/integration-tests/cli/qwen-daemon-loadtest.test.ts
@@ -1,0 +1,494 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Daemon connection stress test — mock ACP, POSIX-only.
+ *
+ * Exercises the daemon's HTTP/SSE surface under concurrent session load
+ * using a mock ACP child (fixtures/mock-acp-child/agent.mjs) that
+ * responds in ~100ms without hitting a real model. This validates
+ * daemon/bridge overhead, session lifecycle, SSE eviction, and crash
+ * recovery — NOT real model latency or tool execution.
+ *
+ * Gated by QWEN_LOADTEST_ENABLED=1. Run via:
+ *   QWEN_LOADTEST_ENABLED=1 npx vitest run \
+ *     --config integration-tests/vitest.loadtest.config.ts \
+ *     -- qwen-daemon-loadtest
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { performance } from 'node:perf_hooks';
+import { afterAll, afterEach, describe, expect, it } from 'vitest';
+
+import {
+  spawnDaemon,
+  percentiles,
+  consumeSseEvents,
+  gitHead,
+  makeTempWorkspace,
+  sleep,
+  type SpawnedDaemon,
+  type ScenarioResult,
+} from './_daemon-harness.js';
+import {
+  resolveOutputDir,
+  formatPercentiles,
+  writeSnapshotArtifacts,
+  collectPlatformInfo,
+} from './_daemon-perf-report.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Skip logic
+// ---------------------------------------------------------------------------
+
+const SKIP =
+  process.env['QWEN_LOADTEST_ENABLED'] !== '1' ||
+  process.platform === 'win32' ||
+  Boolean(
+    process.env['QWEN_SANDBOX'] &&
+      process.env['QWEN_SANDBOX']!.toLowerCase() !== 'false',
+  );
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const MOCK_AGENT_PATH = path.resolve(
+  __dirname,
+  '../fixtures/mock-acp-child/agent.mjs',
+);
+const OUTPUT_DIR = resolveOutputDir('loadtest');
+
+const LIFECYCLE_CYCLES = 20;
+const BURST_SESSIONS = 10;
+const MAX_SESSIONS = 50;
+
+// ---------------------------------------------------------------------------
+// Snapshot
+// ---------------------------------------------------------------------------
+
+interface LoadtestSnapshot {
+  version: 1;
+  capturedAt: string;
+  gitCommit: string | null;
+  platform: ReturnType<typeof collectPlatformInfo>;
+  scenarios: ScenarioResult[];
+}
+
+const snapshot: LoadtestSnapshot = {
+  version: 1,
+  capturedAt: new Date().toISOString(),
+  gitCommit: gitHead(),
+  platform: collectPlatformInfo(),
+  scenarios: [],
+};
+
+// ---------------------------------------------------------------------------
+// Process leak safety net
+// ---------------------------------------------------------------------------
+
+let activeDaemon: SpawnedDaemon | null = null;
+
+process.on('exit', () => {
+  if (activeDaemon?.daemon.exitCode === null) {
+    try {
+      activeDaemon.daemon.kill('SIGKILL');
+    } catch {
+      /* already gone */
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockDaemonEnv(mode = 'echo'): Record<string, string> {
+  return {
+    QWEN_CLI_ENTRY: MOCK_AGENT_PATH,
+    MOCK_ACP_MODE: mode,
+    MOCK_ACP_PROMPT_DELAY_MS: '100',
+    MOCK_ACP_EMIT_CHUNKS: '3',
+  };
+}
+
+async function withDaemon(
+  opts: {
+    mode?: string;
+    label: string;
+    extraArgs?: string[];
+    skipWarmup?: boolean;
+  },
+  fn: (d: SpawnedDaemon, ws: string) => Promise<void>,
+): Promise<void> {
+  const ws = makeTempWorkspace(opts.label);
+  let d: SpawnedDaemon | undefined;
+  try {
+    d = await spawnDaemon({
+      workspaceCwd: ws,
+      extraArgs: [
+        '--max-sessions',
+        String(MAX_SESSIONS),
+        ...(opts.extraArgs ?? []),
+      ],
+      env: mockDaemonEnv(opts.mode ?? 'echo'),
+    });
+    activeDaemon = d;
+
+    if (!opts.skipWarmup) {
+      const anchor = await d.client.createOrAttachSession({
+        sessionScope: 'thread',
+      });
+      await d.client.prompt(anchor.sessionId, {
+        prompt: [{ type: 'text', text: 'warmup' }],
+      });
+    }
+
+    await fn(d, ws);
+  } catch (err) {
+    if (d) {
+      console.error(
+        `[loadtest:${opts.label}] stdout:\n${d.stdoutBuf.value}\nstderr:\n${d.stderrBuf.value}`,
+      );
+    }
+    throw err;
+  } finally {
+    if (d) {
+      await d.dispose();
+      activeDaemon = null;
+    }
+    await sleep(100);
+    fs.rmSync(ws, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+(SKIP ? describe.skip : describe).sequential(
+  'daemon connection stress test (mock ACP, POSIX-only)',
+  { retry: 0 },
+  () => {
+    afterEach(() => {
+      if (activeDaemon?.daemon.exitCode === null) {
+        try {
+          activeDaemon.daemon.kill('SIGTERM');
+        } catch {
+          /* already gone */
+        }
+        activeDaemon = null;
+      }
+    });
+
+    // Scenario 1: rapid lifecycle
+    it('rapid lifecycle: create-prompt-close cycles', async () => {
+      const t0 = performance.now();
+      const latencies: number[] = [];
+
+      await withDaemon({ label: 'lifecycle' }, async (d) => {
+        for (let i = 0; i < LIFECYCLE_CYCLES; i++) {
+          const t = performance.now();
+          const session = await d.client.createOrAttachSession({
+            sessionScope: 'thread',
+          });
+          await d.client.prompt(session.sessionId, {
+            prompt: [{ type: 'text', text: `cycle-${i}` }],
+          });
+          await d.client.closeSession(session.sessionId);
+          latencies.push(performance.now() - t);
+        }
+      });
+
+      const stats = percentiles(latencies);
+      snapshot.scenarios.push({
+        name: 'rapid-lifecycle',
+        status: 'passed',
+        durationMs: performance.now() - t0,
+        metrics: { cycles: LIFECYCLE_CYCLES, ...stats },
+      });
+
+      expect(stats.p99).toBeLessThan(30_000);
+    }, 120_000);
+
+    // Scenario 2: SSE slow consumer triggers eviction
+    it('SSE slow consumer triggers eviction through HTTP', async () => {
+      const t0 = performance.now();
+      let evicted = false;
+      let received = 0;
+
+      await withDaemon(
+        { label: 'sse-eviction', extraArgs: ['--event-ring-size', '32'] },
+        async (d) => {
+          const session = await d.client.createOrAttachSession({
+            sessionScope: 'thread',
+          });
+
+          // Start a slow SSE consumer with a small queue (16 = daemon
+          // minimum) so eviction triggers before the 60s timeout.
+          const consumePromise = consumeSseEvents(d.client, session.sessionId, {
+            consumerDelayMs: 200,
+            timeoutMs: 60_000,
+            subscribe: { maxQueued: 16 },
+          });
+
+          // Fire rapid prompts to overwhelm the slow consumer's queue
+          const promptCount = 20;
+          for (let i = 0; i < promptCount; i++) {
+            try {
+              await d.client.prompt(session.sessionId, {
+                prompt: [{ type: 'text', text: `flood-${i}` }],
+              });
+            } catch {
+              break;
+            }
+          }
+
+          const result = await consumePromise;
+          evicted = result.evictionReason !== undefined;
+          received = result.received;
+
+          await d.client.closeSession(session.sessionId);
+        },
+      );
+
+      snapshot.scenarios.push({
+        name: 'sse-slow-consumer-eviction',
+        status: 'passed',
+        durationMs: performance.now() - t0,
+        metrics: { evicted, received },
+      });
+
+      // Whether eviction fires depends on ring size vs consumer speed.
+      // The catastrophic bound: the consumer received at least one event
+      // and the daemon survived the prompt flood without crashing.
+      expect(received).toBeGreaterThan(0);
+    }, 120_000);
+
+    // Scenario 3: Last-Event-ID reconnect under concurrent load
+    it('Last-Event-ID reconnect under concurrent load', async () => {
+      const t0 = performance.now();
+      let reconnectReceived = 0;
+
+      await withDaemon({ label: 'reconnect' }, async (d) => {
+        const session = await d.client.createOrAttachSession({
+          sessionScope: 'thread',
+        });
+
+        // Fire a prompt so the session has events in its ring buffer.
+        await d.client.prompt(session.sessionId, {
+          prompt: [{ type: 'text', text: 'seed-events' }],
+        });
+
+        // Replay from the beginning to collect seeded events.
+        const initial = await consumeSseEvents(d.client, session.sessionId, {
+          maxEvents: 3,
+          timeoutMs: 10_000,
+          subscribe: { lastEventId: 0 },
+        });
+
+        // Fire another prompt to push more events into the ring.
+        await d.client.prompt(session.sessionId, {
+          prompt: [{ type: 'text', text: 'generate-more' }],
+        });
+
+        // Reconnect with the actual last event id from the initial batch.
+        if (initial.lastSeenId !== undefined) {
+          const reconnect = await consumeSseEvents(
+            d.client,
+            session.sessionId,
+            {
+              maxEvents: 5,
+              timeoutMs: 10_000,
+              subscribe: { lastEventId: initial.lastSeenId },
+            },
+          );
+          reconnectReceived = reconnect.received;
+        }
+
+        await d.client.closeSession(session.sessionId);
+      });
+
+      snapshot.scenarios.push({
+        name: 'last-event-id-reconnect',
+        status: 'passed',
+        durationMs: performance.now() - t0,
+        metrics: { reconnectReceived },
+      });
+
+      expect(reconnectReceived).toBeGreaterThan(0);
+    }, 120_000);
+
+    // Scenario 4: ACP child crash → session error recovery
+    it('ACP child crash → session error recovery', async () => {
+      const t0 = performance.now();
+      let crashDetected = false;
+      let recoverySucceeded = false;
+
+      await withDaemon(
+        { label: 'crash-recovery', mode: 'crash-on-prompt', skipWarmup: true },
+        async (d) => {
+          const session = await d.client.createOrAttachSession({
+            sessionScope: 'thread',
+          });
+
+          try {
+            await d.client.prompt(session.sessionId, {
+              prompt: [{ type: 'text', text: 'trigger-crash' }],
+            });
+          } catch {
+            crashDetected = true;
+          }
+
+          // Poll for daemon recovery instead of fixed sleep.
+          const deadline = Date.now() + 5_000;
+          while (Date.now() < deadline) {
+            try {
+              const health = await d.client.health();
+              if (health !== undefined) {
+                recoverySucceeded = true;
+                break;
+              }
+            } catch {
+              await sleep(200);
+            }
+          }
+        },
+      );
+
+      snapshot.scenarios.push({
+        name: 'acp-crash-recovery',
+        status: 'passed',
+        durationMs: performance.now() - t0,
+        metrics: { crashDetected, recoverySucceeded },
+      });
+
+      expect(crashDetected).toBe(true);
+      expect(recoverySucceeded).toBe(true);
+    }, 90_000);
+
+    // Scenario 5: burst concurrent sessions
+    it('burst: concurrent sessions with mock prompts', async () => {
+      const t0 = performance.now();
+      const latencies: number[] = [];
+      let successCount = 0;
+      let failureCount = 0;
+
+      await withDaemon({ label: 'burst' }, async (d) => {
+        const results = await Promise.allSettled(
+          Array.from({ length: BURST_SESSIONS }, async (_, i) => {
+            const t = performance.now();
+            const session = await d.client.createOrAttachSession({
+              sessionScope: 'thread',
+            });
+            await d.client.prompt(session.sessionId, {
+              prompt: [{ type: 'text', text: `burst-${i}` }],
+            });
+            await d.client.closeSession(session.sessionId);
+            return performance.now() - t;
+          }),
+        );
+
+        for (const r of results) {
+          if (r.status === 'fulfilled') {
+            successCount++;
+            latencies.push(r.value);
+          } else {
+            failureCount++;
+          }
+        }
+      });
+
+      const stats = percentiles(latencies);
+      snapshot.scenarios.push({
+        name: 'burst-concurrent',
+        status: 'passed',
+        durationMs: performance.now() - t0,
+        metrics: {
+          burstSize: BURST_SESSIONS,
+          successCount,
+          failureCount,
+          ...stats,
+        },
+      });
+
+      expect(failureCount).toBe(0);
+      expect(stats.p99).toBeLessThan(60_000);
+    }, 120_000);
+
+    // Report
+    afterAll(() => {
+      if (SKIP) return;
+      writeSnapshotArtifacts(
+        OUTPUT_DIR,
+        'loadtest-report',
+        snapshot,
+        renderMarkdown(snapshot),
+        'loadtest',
+      );
+    });
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Markdown renderer
+// ---------------------------------------------------------------------------
+
+function renderMarkdown(s: LoadtestSnapshot): string {
+  const lines = [
+    `# qwen serve daemon — connection stress test report`,
+    ``,
+    `Captured: ${s.capturedAt}`,
+    `Git: ${s.gitCommit ?? 'unknown'}`,
+    `Platform: ${s.platform.os}/${s.platform.arch} node=${s.platform.nodeVersion}`,
+    ``,
+    `## Scenarios`,
+    ``,
+  ];
+
+  for (const sc of s.scenarios) {
+    lines.push(
+      `### ${sc.name}`,
+      `- Status: ${sc.status}`,
+      `- Duration: ${sc.durationMs.toFixed(0)}ms`,
+    );
+    if (sc.error) {
+      lines.push(`- Error: ${sc.error}`);
+    }
+    if (sc.metrics) {
+      const m = sc.metrics;
+      const pctlKeys = ['count', 'p50', 'p90', 'p99', 'mean', 'min', 'max'];
+      if (
+        'p50' in m &&
+        typeof m['p50'] === 'number' &&
+        typeof m['count'] === 'number'
+      ) {
+        lines.push(
+          `- Latency: ${formatPercentiles({
+            count: m['count'],
+            p50: m['p50'],
+            p90: m['p90'] as number,
+            p99: m['p99'] as number,
+            mean: m['mean'] as number,
+            min: m['min'] as number,
+            max: m['max'] as number,
+          })}`,
+        );
+      }
+      for (const [k, v] of Object.entries(m)) {
+        if (pctlKeys.includes(k)) continue;
+        lines.push(`- ${k}: ${JSON.stringify(v)}`);
+      }
+    }
+    lines.push(``);
+  }
+
+  return lines.join('\n');
+}

--- a/integration-tests/cli/qwen-daemon-vs-cli-benchmark.test.ts
+++ b/integration-tests/cli/qwen-daemon-vs-cli-benchmark.test.ts
@@ -18,23 +18,35 @@
  * directory, similar to `qwen-serve-baseline.test.ts`.
  */
 
-import { spawn, execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
-import * as os from 'node:os';
-import * as path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { afterAll, describe, expect, it } from 'vitest';
 
 import { DaemonHttpError } from '@qwen-code/sdk';
 import {
   spawnDaemon,
-  getRssMB,
-  countDescendants,
   percentiles,
-  DEFAULT_CLI_BIN,
+  gitHead,
+  makeTempWorkspace,
+  sleep,
   type SpawnedDaemon,
   type Percentiles,
 } from './_daemon-harness.js';
+import {
+  spawnDaemonWithTime,
+  spawnCliWithTime,
+  measureProcessTreeRss,
+  measureCliStartupWithProfiler,
+  type ProcessResourceMetrics,
+  type ProcessTreeRss,
+  type StartupPhasesResult,
+} from './_daemon-benchmark-helpers.js';
+import {
+  resolveOutputDir,
+  formatPercentiles,
+  writeSnapshotArtifacts,
+  collectPlatformInfo,
+} from './_daemon-perf-report.js';
 
 // ---------------------------------------------------------------------------
 // Skip logic
@@ -67,8 +79,6 @@ const CHURN_ROUNDS = Number(
   process.env['BENCHMARK_CHURN_ROUNDS'] ?? ITERATIONS * 4,
 );
 
-const CLI_BIN = DEFAULT_CLI_BIN;
-
 const PROMPT_CREDENTIAL_ENV_KEYS = [
   'DASHSCOPE_API_KEY',
   'OPENAI_API_KEY',
@@ -84,12 +94,7 @@ const HAS_MODEL_KEY =
   );
 const SKIP_PROMPT = !HAS_MODEL_KEY;
 
-const IS_DARWIN = process.platform === 'darwin';
-
-const RUN_TS = new Date().toISOString().replace(/[:.]/g, '').replace(/Z$/, '');
-const OUTPUT_DIR =
-  process.env['INTEGRATION_TEST_FILE_DIR'] ??
-  path.join(process.cwd(), '.integration-tests', `benchmark-${RUN_TS}`);
+const OUTPUT_DIR = resolveOutputDir('benchmark');
 
 const THRESH = {
   cliColdStartP99MaxMs: 10_000,
@@ -102,13 +107,6 @@ const THRESH = {
 // ---------------------------------------------------------------------------
 // Snapshot accumulator
 // ---------------------------------------------------------------------------
-
-interface ProcessTreeRss {
-  daemonRssMB: number;
-  acpChildRssMB: number;
-  mcpChildrenRssMB: number;
-  totalRssMB: number;
-}
 
 interface BenchmarkSnapshot {
   version: 1;
@@ -191,11 +189,7 @@ const snapshot: BenchmarkSnapshot = {
   version: 1,
   capturedAt: new Date().toISOString(),
   gitCommit: gitHead(),
-  platform: {
-    os: process.platform,
-    arch: process.arch,
-    nodeVersion: process.version,
-  },
+  platform: collectPlatformInfo(),
   notes: [
     'CLI cold start uses -p mode with QWEN_CODE_PROFILE_STARTUP=1 to ' +
       'measure full initialization (Node startup + ESM + config + MCP ' +
@@ -217,427 +211,6 @@ const snapshot: BenchmarkSnapshot = {
     heavy: HEAVY,
   },
 };
-
-// ---------------------------------------------------------------------------
-// Utilities
-// ---------------------------------------------------------------------------
-
-function gitHead(): string | null {
-  try {
-    return execFileSync('git', ['rev-parse', 'HEAD'], {
-      encoding: 'utf8',
-      timeout: 5_000,
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim();
-  } catch {
-    return null;
-  }
-}
-
-function makeTempWorkspace(label: string): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), `qwen-bench-${label}-`));
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((r) => setTimeout(r, ms));
-}
-
-interface ProcessResourceMetrics {
-  peakRssMB: number | null;
-  userTimeMs: number | null;
-  sysTimeMs: number | null;
-  voluntaryCtxSwitches: number | null;
-  involuntaryCtxSwitches: number | null;
-  pageFaults: number | null;
-  pageReclaims: number | null;
-  instructionsRetired: number | null;
-  cyclesElapsed: number | null;
-}
-
-interface CliResult extends ProcessResourceMetrics {
-  wallClockMs: number;
-  exitCode: number | null;
-  stdout: string;
-  stderr: string;
-}
-
-function parseTimeOutput(stderr: string): ProcessResourceMetrics {
-  const metrics: ProcessResourceMetrics = {
-    peakRssMB: null,
-    userTimeMs: null,
-    sysTimeMs: null,
-    voluntaryCtxSwitches: null,
-    involuntaryCtxSwitches: null,
-    pageFaults: null,
-    pageReclaims: null,
-    instructionsRetired: null,
-    cyclesElapsed: null,
-  };
-
-  if (IS_DARWIN) {
-    // macOS /usr/bin/time -l format:
-    //   0.02 real  0.00 user  0.00 sys
-    //   1228800  maximum resident set size
-    //   ...
-    const timeLineMatch = stderr.match(
-      /(\d+\.\d+)\s+real\s+(\d+\.\d+)\s+user\s+(\d+\.\d+)\s+sys/,
-    );
-    if (timeLineMatch) {
-      metrics.userTimeMs = Math.round(Number(timeLineMatch[2]) * 1000);
-      metrics.sysTimeMs = Math.round(Number(timeLineMatch[3]) * 1000);
-    }
-
-    const rssMatch = stderr.match(/(\d+)\s+maximum resident set size/);
-    if (rssMatch)
-      metrics.peakRssMB =
-        Math.round((Number(rssMatch[1]) / 1024 / 1024) * 10) / 10;
-
-    const volCtx = stderr.match(/(\d+)\s+voluntary context switches/);
-    if (volCtx) metrics.voluntaryCtxSwitches = Number(volCtx[1]);
-
-    const involCtx = stderr.match(/(\d+)\s+involuntary context switches/);
-    if (involCtx) metrics.involuntaryCtxSwitches = Number(involCtx[1]);
-
-    const pageFaults = stderr.match(/(\d+)\s+page faults/);
-    if (pageFaults) metrics.pageFaults = Number(pageFaults[1]);
-
-    const pageReclaims = stderr.match(/(\d+)\s+page reclaims/);
-    if (pageReclaims) metrics.pageReclaims = Number(pageReclaims[1]);
-
-    const instructions = stderr.match(/(\d+)\s+instructions retired/);
-    if (instructions) metrics.instructionsRetired = Number(instructions[1]);
-
-    const cycles = stderr.match(/(\d+)\s+cycles elapsed/);
-    if (cycles) metrics.cyclesElapsed = Number(cycles[1]);
-  } else {
-    // Linux /usr/bin/time -v format:
-    //   User time (seconds): 0.00
-    //   System time (seconds): 0.00
-    //   Maximum resident set size (kbytes): 1234
-    //   ...
-    const userTime = stderr.match(/User time.*?:\s*(\d+\.\d+)/);
-    if (userTime) metrics.userTimeMs = Math.round(Number(userTime[1]) * 1000);
-
-    const sysTime = stderr.match(/System time.*?:\s*(\d+\.\d+)/);
-    if (sysTime) metrics.sysTimeMs = Math.round(Number(sysTime[1]) * 1000);
-
-    const rss = stderr.match(/Maximum resident set size.*?:\s*(\d+)/);
-    if (rss) metrics.peakRssMB = Math.round((Number(rss[1]) / 1024) * 10) / 10;
-
-    const volCtx = stderr.match(/Voluntary context switches.*?:\s*(\d+)/);
-    if (volCtx) metrics.voluntaryCtxSwitches = Number(volCtx[1]);
-
-    const involCtx = stderr.match(/Involuntary context switches.*?:\s*(\d+)/);
-    if (involCtx) metrics.involuntaryCtxSwitches = Number(involCtx[1]);
-
-    const majorFaults = stderr.match(/Major.*?page faults.*?:\s*(\d+)/);
-    if (majorFaults) metrics.pageFaults = Number(majorFaults[1]);
-
-    const minorFaults = stderr.match(/Minor.*?page faults.*?:\s*(\d+)/);
-    if (minorFaults) metrics.pageReclaims = Number(minorFaults[1]);
-  }
-
-  return metrics;
-}
-
-/**
- * Spawn a command with `/usr/bin/time` wrapper to capture resource metrics.
- * macOS: `/usr/bin/time -l` reports RSS, CPU, context switches, page faults,
- *        instructions, cycles.
- * Linux: `/usr/bin/time -v` reports similar fields in a different format.
- */
-function spawnCliWithTime(
-  args: string[],
-  opts?: { cwd?: string; env?: Record<string, string> },
-): Promise<CliResult> {
-  return new Promise((resolve) => {
-    const t0 = performance.now();
-
-    const timeArgs = IS_DARWIN ? ['-l'] : ['-v'];
-    const child = spawn(
-      '/usr/bin/time',
-      [...timeArgs, process.execPath, CLI_BIN, ...args],
-      {
-        stdio: ['ignore', 'pipe', 'pipe'],
-        cwd: opts?.cwd,
-        env: opts?.env ? { ...process.env, ...opts.env } : undefined,
-      },
-    );
-
-    let stdout = '';
-    let stderr = '';
-    child.stdout?.on('data', (c: Buffer) => {
-      stdout += c.toString();
-    });
-    child.stderr?.on('data', (c: Buffer) => {
-      stderr += c.toString();
-    });
-
-    child.once('exit', (code) => {
-      const wallClockMs = performance.now() - t0;
-      const metrics = parseTimeOutput(stderr);
-      resolve({ wallClockMs, exitCode: code, stdout, stderr, ...metrics });
-    });
-  });
-}
-
-function measureProcessTreeRss(daemonPid: number): ProcessTreeRss {
-  const daemonRss = getRssMB(daemonPid);
-  const desc = countDescendants(daemonPid);
-
-  let acpChildRss = 0;
-  for (const pid of desc.acpChildren) {
-    const rss = getRssMB(pid);
-    if (!Number.isNaN(rss)) acpChildRss += rss;
-  }
-
-  let mcpChildrenRss = 0;
-  for (const pid of desc.mcpGrandchildren) {
-    const rss = getRssMB(pid);
-    if (!Number.isNaN(rss)) mcpChildrenRss += rss;
-  }
-
-  return {
-    daemonRssMB: Number.isNaN(daemonRss) ? 0 : daemonRss,
-    acpChildRssMB: acpChildRss,
-    mcpChildrenRssMB: mcpChildrenRss,
-    totalRssMB:
-      (Number.isNaN(daemonRss) ? 0 : daemonRss) + acpChildRss + mcpChildrenRss,
-  };
-}
-
-interface StartupPhasesResult {
-  moduleLoadMs: number | null;
-  configInitMs: number | null;
-  mcpSettledMs: number | null;
-  fullStartupMs: number | null;
-  wallClockMs: number;
-  peakRssMB: number | null;
-}
-
-/**
- * Spawn CLI in non-interactive mode with the startup profiler enabled.
- * Parses the profiler JSON output from ~/.qwen/startup-perf/ to extract
- * phase breakdowns. Uses `-p "x"` so the full init path runs (config,
- * MCP, auth). The prompt itself may fail without a model key — we only
- * care about the initialization phases.
- */
-async function measureCliStartupWithProfiler(opts?: {
-  cwd?: string;
-}): Promise<StartupPhasesResult> {
-  const perfDir = path.join(os.homedir(), '.qwen', 'startup-perf');
-  const beforeFiles = new Set<string>();
-  try {
-    for (const f of fs.readdirSync(perfDir)) beforeFiles.add(f);
-  } catch {
-    /* dir might not exist yet */
-  }
-
-  const result = await spawnCliWithTime(
-    ['-p', 'x', '--output-format', 'text'],
-    {
-      cwd: opts?.cwd,
-      env: {
-        QWEN_CODE_PROFILE_STARTUP: '1',
-        QWEN_CODE_PROFILE_STARTUP_OUTER: '1',
-      },
-    },
-  );
-
-  // Find the new profiler file
-  const profileData: StartupPhasesResult = {
-    moduleLoadMs: null,
-    configInitMs: null,
-    mcpSettledMs: null,
-    fullStartupMs: null,
-    wallClockMs: result.wallClockMs,
-    peakRssMB: result.peakRssMB,
-  };
-
-  try {
-    const afterFiles = fs.readdirSync(perfDir);
-    const newFile = afterFiles.find((f) => !beforeFiles.has(f));
-    if (newFile) {
-      const report = JSON.parse(
-        fs.readFileSync(path.join(perfDir, newFile), 'utf-8'),
-      );
-      const dp = report.derivedPhases ?? {};
-      profileData.moduleLoadMs = report.processUptimeAtT0Ms ?? null;
-      profileData.configInitMs = dp.config_initialize_dur ?? null;
-      profileData.mcpSettledMs = dp.mcp_all_settled ?? null;
-      profileData.fullStartupMs =
-        report.processUptimeAtT0Ms != null && report.totalMs != null
-          ? Math.round((report.processUptimeAtT0Ms + report.totalMs) * 10) / 10
-          : null;
-      // Clean up profiler file
-      try {
-        fs.unlinkSync(path.join(perfDir, newFile));
-      } catch {
-        /* best-effort */
-      }
-    }
-  } catch {
-    /* profiler output not available — fall back to wall-clock only */
-  }
-
-  return profileData;
-}
-
-/**
- * Spawn a daemon wrapped in `/usr/bin/time` so we capture resource metrics
- * (CPU, context switches, page faults) for its entire lifecycle. Returns
- * a modified SpawnedDaemon whose `dispose()` also parses the time output.
- */
-async function spawnDaemonWithTime(
-  opts: Parameters<typeof spawnDaemon>[0] = {},
-): Promise<
-  SpawnedDaemon & { getResourceMetrics: () => ProcessResourceMetrics }
-> {
-  const token = opts.token ?? 'integration-test-token';
-  const cliBin = opts.cliBin ?? DEFAULT_CLI_BIN;
-  const bootTimeoutMs = opts.bootTimeoutMs ?? 10_000;
-  const extraArgs = opts.extraArgs ?? [];
-
-  const daemonArgs = [
-    cliBin,
-    'serve',
-    '--port',
-    '0',
-    '--token',
-    token,
-    '--hostname',
-    '127.0.0.1',
-    '--workspace',
-    opts.workspaceCwd ?? process.cwd(),
-    ...extraArgs,
-  ];
-
-  const timeArgs = IS_DARWIN ? ['-l'] : ['-v'];
-  const child = spawn(
-    '/usr/bin/time',
-    [...timeArgs, process.execPath, ...daemonArgs],
-    {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, ...opts.env },
-    },
-  );
-
-  const stdoutBuf = { value: '' };
-  const stderrBuf = { value: '' };
-  child.stdout?.on('data', (chunk: Buffer) => {
-    stdoutBuf.value += chunk.toString();
-  });
-  child.stderr?.on('data', (chunk: Buffer) => {
-    stderrBuf.value += chunk.toString();
-  });
-
-  const LISTENING_RE = /listening on http:\/\/127\.0\.0\.1:(\d+)/;
-  const port = await new Promise<number>((resolve, reject) => {
-    let settled = false;
-    const cleanup = () => {
-      child.stdout?.off('data', onData);
-      child.off('exit', onExit);
-      clearTimeout(bootTimer);
-    };
-    const fail = (err: Error, kill = false) => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      if (kill && child.exitCode === null) child.kill('SIGTERM');
-      reject(err);
-    };
-    const bootTimer = setTimeout(() => {
-      fail(
-        new Error(
-          `daemon boot timeout after ${bootTimeoutMs}ms:\n` +
-            `stdout=${stdoutBuf.value}\nstderr=${stderrBuf.value}`,
-        ),
-        true,
-      );
-    }, bootTimeoutMs);
-    const onData = () => {
-      const m = stdoutBuf.value.match(LISTENING_RE);
-      if (m && !settled) {
-        settled = true;
-        cleanup();
-        resolve(Number(m[1]));
-      }
-    };
-    const onExit = (code: number | null) => {
-      fail(
-        new Error(
-          `daemon exited with ${code} before listening:\n` +
-            `stdout=${stdoutBuf.value}\nstderr=${stderrBuf.value}`,
-        ),
-      );
-    };
-    child.stdout!.on('data', onData);
-    child.once('exit', onExit);
-  });
-
-  const { DaemonClient } = await import('@qwen-code/sdk');
-  const base = `http://127.0.0.1:${port}`;
-  const client = new DaemonClient({ baseUrl: base, token });
-
-  const dispose = async () => {
-    if (child.exitCode !== null) return;
-    // Send SIGTERM to the inner node process (not /usr/bin/time itself),
-    // so /usr/bin/time observes the child exit and prints resource stats.
-    try {
-      const innerPids = execFileSync('pgrep', ['-P', String(child.pid!)], {
-        encoding: 'utf8',
-        timeout: 2_000,
-        stdio: ['ignore', 'pipe', 'ignore'],
-      })
-        .trim()
-        .split('\n')
-        .filter(Boolean)
-        .map(Number);
-      for (const pid of innerPids) {
-        try {
-          process.kill(pid, 'SIGTERM');
-        } catch {
-          /* already gone */
-        }
-      }
-    } catch {
-      // pgrep failed or no children — fall back to killing /usr/bin/time
-      child.kill('SIGTERM');
-    }
-    await new Promise<void>((resolve) => {
-      const t = setTimeout(() => {
-        try {
-          child.kill('SIGKILL');
-        } catch {
-          /* gone */
-        }
-        resolve();
-      }, 8_000);
-      child.once('exit', () => {
-        clearTimeout(t);
-        resolve();
-      });
-    });
-    // Brief pause to ensure stderr pipe drains /usr/bin/time output.
-    await sleep(200);
-  };
-
-  const getResourceMetrics = (): ProcessResourceMetrics =>
-    parseTimeOutput(stderrBuf.value);
-
-  return {
-    client,
-    daemon: child,
-    port,
-    base,
-    workspaceCwd: opts.workspaceCwd ?? process.cwd(),
-    token,
-    stdoutBuf,
-    stderrBuf,
-    dispose,
-    getResourceMetrics,
-  };
-}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -1615,16 +1188,12 @@ async function spawnDaemonWithTime(
 
       console.log('[benchmark] ---- end summary ----\n');
 
-      // Write artifacts
-      fs.mkdirSync(OUTPUT_DIR, { recursive: true });
-      const jsonPath = path.join(OUTPUT_DIR, 'daemon-vs-cli-benchmark.json');
-      fs.writeFileSync(jsonPath, JSON.stringify(snapshot, null, 2));
-      fs.writeFileSync(
-        path.join(OUTPUT_DIR, 'daemon-vs-cli-benchmark.md'),
+      writeSnapshotArtifacts(
+        OUTPUT_DIR,
+        'daemon-vs-cli-benchmark',
+        snapshot,
         renderMarkdown(snapshot),
-      );
-      console.log(
-        `[benchmark] daemon-vs-cli-benchmark.json written to ${jsonPath}`,
+        'benchmark',
       );
     });
   },
@@ -1635,10 +1204,7 @@ async function spawnDaemonWithTime(
 // ---------------------------------------------------------------------------
 
 function renderMarkdown(s: BenchmarkSnapshot): string {
-  const fmtP = (p: Percentiles | null | undefined): string =>
-    p && p.count > 0
-      ? `p50=${p.p50.toFixed(0)} p90=${p.p90.toFixed(0)} p99=${p.p99.toFixed(0)} mean=${p.mean.toFixed(0)} (n=${p.count})`
-      : 'n/a';
+  const fmtP = formatPercentiles;
 
   const fmtTree = (r: ProcessTreeRss | null): string =>
     r

--- a/integration-tests/cli/qwen-serve-baseline.test.ts
+++ b/integration-tests/cli/qwen-serve-baseline.test.ts
@@ -33,9 +33,7 @@
  * as `acp-integration.test.ts` / `cron-tools.test.ts`.
  */
 
-import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
-import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterAll, describe, expect, it } from 'vitest';
@@ -48,10 +46,19 @@ import {
   countDescendants,
   percentiles,
   writeWorkspaceSettings,
+  gitHead,
+  makeTempWorkspace,
+  sleep,
   type SpawnedDaemon,
   type DescendantCount,
   type Percentiles,
 } from './_daemon-harness.js';
+import {
+  resolveOutputDir,
+  formatPercentiles,
+  writeSnapshotArtifacts,
+  collectPlatformInfo,
+} from './_daemon-perf-report.js';
 
 // Minimal type-shape for the SSE backpressure unit suite — we only assert
 // `.type`, so we avoid coupling tests to the full BridgeEvent surface.
@@ -107,10 +114,7 @@ const MCP_FIXTURE_PGREP_FILTER = 'idle-mcp/server\\.mjs';
 const MCP_DESCENDANT_WAIT_TIMEOUT_MS = 10_000;
 const MCP_DESCENDANT_POLL_MS = 250;
 const RSS_DROPPED_SAMPLE_RATIO_MAX = 0.2;
-const RUN_TS = new Date().toISOString().replace(/[:.]/g, '').replace(/Z$/, '');
-const OUTPUT_DIR =
-  process.env['INTEGRATION_TEST_FILE_DIR'] ??
-  path.join(process.cwd(), '.integration-tests', `baseline-${RUN_TS}`);
+const OUTPUT_DIR = resolveOutputDir('baseline');
 
 // Catastrophic-regression upper bounds. These are intentionally loose —
 // tightening them is a deliberate one-line PR after a regression is
@@ -184,11 +188,7 @@ const snapshot: SnapshotShape = {
   version: 1,
   capturedAt: new Date().toISOString(),
   gitCommit: gitHead(),
-  platform: {
-    os: process.platform,
-    arch: process.arch,
-    nodeVersion: process.version,
-  },
+  platform: collectPlatformInfo(),
   notes: [
     'Daemon defaults to sessionScope: "single", so N successive ' +
       'createOrAttachSession calls against the same workspace return the ' +
@@ -206,27 +206,6 @@ const snapshot: SnapshotShape = {
     heavy: HEAVY,
   },
 };
-
-function gitHead(): string | null {
-  try {
-    return execFileSync('git', ['rev-parse', 'HEAD'], {
-      encoding: 'utf8',
-      timeout: 2_000,
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim();
-  } catch {
-    return null;
-  }
-}
-
-function makeTempWorkspace(label: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `qwen-baseline-${label}-`));
-  return dir;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -704,25 +683,19 @@ async function measureRssAtSessionCount(sessionCount: number): Promise<{
 
     afterAll(() => {
       if (SKIP) return;
-      fs.mkdirSync(OUTPUT_DIR, { recursive: true });
-      const jsonPath = path.join(OUTPUT_DIR, 'perf-baseline.json');
-      fs.writeFileSync(jsonPath, JSON.stringify(snapshot, null, 2));
-      fs.writeFileSync(
-        path.join(OUTPUT_DIR, 'perf-baseline.md'),
+      writeSnapshotArtifacts(
+        OUTPUT_DIR,
+        'perf-baseline',
+        snapshot,
         renderMarkdown(snapshot),
+        'baseline',
       );
-      // Echo the path so a reviewer / CI logs surface where the artifact
-      // landed.
-      console.log(`[baseline] perf-baseline.json written to ${jsonPath}`);
     });
   },
 );
 
 function renderMarkdown(s: SnapshotShape): string {
-  const fmt = (p: Percentiles | null | undefined): string =>
-    p
-      ? `p50=${p.p50.toFixed(0)} p90=${p.p90.toFixed(0)} p99=${p.p99.toFixed(0)} mean=${p.mean.toFixed(0)} (n=${p.count})`
-      : 'n/a';
+  const fmt = formatPercentiles;
   return [
     `# qwen serve daemon — perf baseline`,
     ``,

--- a/integration-tests/fixtures/mock-acp-child/agent.mjs
+++ b/integration-tests/fixtures/mock-acp-child/agent.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Mock ACP agent for daemon connection stress tests. Uses the real
+// AgentSideConnection from @agentclientprotocol/sdk so the NDJSON
+// handshake, session lifecycle, and error shapes match production.
+//
+// Controlled via environment variables (spawnChannel's QWEN_CLI_ENTRY
+// only accepts a path — cannot attach argv):
+//
+//   MOCK_ACP_MODE            echo | reject | crash-on-prompt | hang
+//   MOCK_ACP_PROMPT_DELAY_MS per-prompt delay (default 100)
+//   MOCK_ACP_EMIT_CHUNKS     text chunks per prompt (default 3)
+
+import process from 'node:process';
+import { setTimeout } from 'node:timers/promises';
+import {
+  AgentSideConnection,
+  ndJsonStream,
+  PROTOCOL_VERSION,
+  RequestError,
+} from '@agentclientprotocol/sdk';
+import { Writable, Readable } from 'node:stream';
+
+// Protect the stdout NDJSON pipe — stray console.log would corrupt the
+// framing and surface as "unexpected token" parse errors in the daemon.
+/* eslint-disable no-undef */
+console.log = console.error;
+console.info = console.error;
+/* eslint-enable no-undef */
+
+const mode = process.env.MOCK_ACP_MODE ?? 'echo';
+const delayMs = parseInt(process.env.MOCK_ACP_PROMPT_DELAY_MS || '100', 10);
+const emitChunks = parseInt(process.env.MOCK_ACP_EMIT_CHUNKS || '3', 10);
+let sessionCounter = 0;
+
+new AgentSideConnection(
+  (connection) => ({
+    async initialize() {
+      return {
+        protocolVersion: PROTOCOL_VERSION,
+        agentInfo: { name: 'mock-acp', version: '0.0.1' },
+        authMethods: [],
+        agentCapabilities: {},
+      };
+    },
+
+    async authenticate() {
+      return {};
+    },
+
+    async newSession() {
+      return { sessionId: `mock-${++sessionCounter}` };
+    },
+
+    async prompt(params) {
+      const { sessionId } = params;
+
+      for (let i = 0; i < emitChunks; i++) {
+        await connection.sessionUpdate({
+          sessionId,
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: `chunk-${i}` },
+          },
+        });
+      }
+
+      if (delayMs > 0) {
+        await setTimeout(delayMs);
+      }
+
+      if (mode === 'reject') {
+        throw new RequestError(-32603, 'injected error');
+      }
+      if (mode === 'crash-on-prompt') {
+        process.exit(1);
+      }
+      if (mode === 'hang') {
+        return new Promise(() => {});
+      }
+
+      return { stopReason: 'end_turn' };
+    },
+
+    async cancel() {},
+  }),
+  ndJsonStream(Writable.toWeb(process.stdout), Readable.toWeb(process.stdin)),
+);
+
+process.stdin.on('end', () => process.exit(0));

--- a/integration-tests/fixtures/mock-acp-child/agent.mjs
+++ b/integration-tests/fixtures/mock-acp-child/agent.mjs
@@ -26,11 +26,13 @@ import {
 } from '@agentclientprotocol/sdk';
 import { Writable, Readable } from 'node:stream';
 
-// Protect the stdout NDJSON pipe — stray console.log would corrupt the
-// framing and surface as "unexpected token" parse errors in the daemon.
+// Protect the stdout NDJSON pipe — any console method that writes to
+// stdout would corrupt the framing.
 /* eslint-disable no-undef */
 console.log = console.error;
 console.info = console.error;
+console.debug = console.error;
+console.dir = console.error;
 /* eslint-enable no-undef */
 
 const mode = process.env.MOCK_ACP_MODE ?? 'echo';

--- a/integration-tests/vitest.loadtest.config.ts
+++ b/integration-tests/vitest.loadtest.config.ts
@@ -9,33 +9,19 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const timeoutMinutes = Number(process.env['TB_TIMEOUT_MINUTES'] || '5');
-const testTimeoutMs = timeoutMinutes * 60 * 1000;
 
 export default defineConfig({
   test: {
-    testTimeout: testTimeoutMs,
+    testTimeout: 10 * 60 * 1000,
+    root: __dirname,
     globalSetup: './globalSetup.ts',
     reporters: ['default'],
-    include: ['**/*.test.ts'],
-    exclude: [
-      '**/terminal-bench/*.test.ts',
-      '**/hook-integration/**',
-      '**/qwen-daemon-loadtest*',
-      '**/node_modules/**',
-    ],
-    retry: 2,
-    fileParallelism: true,
-    poolOptions: {
-      threads: {
-        minThreads: 2,
-        maxThreads: 4,
-      },
-    },
+    include: ['**/qwen-daemon-loadtest.test.ts'],
+    retry: 0,
+    fileParallelism: false,
   },
   resolve: {
     alias: {
-      // Use built SDK bundle for e2e tests
       '@qwen-code/sdk': resolve(
         __dirname,
         '../packages/sdk-typescript/dist/index.mjs',


### PR DESCRIPTION
## What this PR does

Extract shared helpers from baseline/benchmark daemon tests into dedicated modules and add a new mock-ACP connection stress test suite gated by `QWEN_LOADTEST_ENABLED=1`.

**Refactoring:**
- `_daemon-benchmark-helpers.ts`: extract `/usr/bin/time` wrappers from benchmark test
- `_daemon-perf-report.ts`: shared `formatPercentiles`, `collectPlatformInfo`, `writeSnapshotArtifacts`, `resolveOutputDir`
- `_daemon-harness.ts`: export `gitHead()`, `makeTempWorkspace()`, `sleep()`, `ScenarioResult`, add `lastSeenId` to `ConsumeSseResult`
- Slim baseline + benchmark tests by ~500 lines via imports

**New features:**
- `fixtures/mock-acp-child/agent.mjs`: mock ACP agent using real `AgentSideConnection` SDK with env-controlled error injection modes (echo/reject/crash-on-prompt/hang)
- `mock-acp-typecheck.test.ts`: compile-time Agent interface compliance check
- `qwen-daemon-loadtest.test.ts`: 5 scenarios — rapid lifecycle, SSE slow-consumer eviction, Last-Event-ID reconnect, ACP crash recovery, burst concurrent sessions
- `vitest.loadtest.config.ts`: isolated config with `root: __dirname` anchoring

## Why it's needed

Issue #4514 T3.4 — the daemon's HTTP/SSE surface lacks automated stress testing. Without a mock-ACP-based harness, connection lifecycle bugs, SSE backpressure regressions, and crash recovery issues can only be caught by manual testing or real-model integration tests (which are slow and flaky). The refactoring reduces ~500 lines of duplication across baseline/benchmark tests, making the shared infrastructure maintainable as the test suite grows.

## Reviewer Test Plan

### How to verify

```bash
# Baseline still passes after refactoring
npx vitest run integration-tests/cli/qwen-serve-baseline.test.ts

# Benchmark still passes after helper extraction
QWEN_BENCHMARK_ENABLED=1 BENCHMARK_ITERATIONS=1 npx vitest run integration-tests/cli/qwen-daemon-vs-cli-benchmark.test.ts

# Type compliance test
npx vitest run integration-tests/cli/mock-acp-typecheck.test.ts

# Loadtest scenarios (requires daemon binary built)
QWEN_LOADTEST_ENABLED=1 npx vitest run --config integration-tests/vitest.loadtest.config.ts

# Default CI excludes loadtest
npx vitest run --config integration-tests/vitest.config.ts
```

### Evidence (Before & After)

N/A — test infrastructure only, no user-facing behavior change.

### Tested on

| Platform | Node | Status |
|----------|------|--------|
| macOS (darwin arm64) | v24.12.0 | TypeScript + ESLint pass |

## Risk & Scope

- **Risk**: Low. All new tests are gated behind `QWEN_LOADTEST_ENABLED=1` and excluded from default CI. Refactoring is pure import-replacement with no behavioral changes.
- **Scope**: Test infrastructure only. No production code changed.
- **Rollback**: Revert this single commit.

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)