### PR TITLE
fix(core): don't kill a failed-spawn sleep inhibitor child (sandbox abort on tool use)

### DIFF
--- a/packages/core/src/services/sleepInhibitor.test.ts
+++ b/packages/core/src/services/sleepInhibitor.test.ts
@@ -17,7 +17,8 @@ function createChild(pid: number | undefined = 4242): ChildProcess {
   });
   // A real successful spawn has a numeric pid synchronously; a failed spawn
   // (e.g. ENOENT) leaves it undefined. Tests pass `undefined` to model that.
-  child.pid = pid;
+  // `pid` is readonly on ChildProcess, so define it rather than assign.
+  Object.defineProperty(child, 'pid', { value: pid });
   child.kill = vi.fn(() => {
     killed = true;
     return true;
@@ -229,7 +230,7 @@ describe('SleepInhibitor', () => {
     const spawn = vi.fn(() => {
       const child = new EventEmitter() as ChildProcess;
       Object.defineProperty(child, 'killed', { get: () => false });
-      child.pid = 4242;
+      Object.defineProperty(child, 'pid', { value: 4242 });
       child.kill = vi.fn(() => {
         throw new Error('ESRCH');
       });
@@ -259,7 +260,7 @@ describe('SleepInhibitor', () => {
       // Pidless child: spawn returned but the process never started (ENOENT).
       const child = new EventEmitter() as ChildProcess;
       Object.defineProperty(child, 'killed', { get: () => false });
-      child.pid = undefined;
+      Object.defineProperty(child, 'pid', { value: undefined });
       child.kill = vi.fn(() => true);
       children.push(child);
       return child;

--- a/packages/core/src/services/sleepInhibitor.test.ts
+++ b/packages/core/src/services/sleepInhibitor.test.ts
@@ -9,12 +9,15 @@ import type { ChildProcess, SpawnOptions } from 'node:child_process';
 import { describe, expect, it, vi } from 'vitest';
 import { acquireSleepInhibitor, SleepInhibitor } from './sleepInhibitor.js';
 
-function createChild(): ChildProcess {
+function createChild(pid: number | undefined = 4242): ChildProcess {
   const child = new EventEmitter() as ChildProcess;
   let killed = false;
   Object.defineProperty(child, 'killed', {
     get: () => killed,
   });
+  // A real successful spawn has a numeric pid synchronously; a failed spawn
+  // (e.g. ENOENT) leaves it undefined. Tests pass `undefined` to model that.
+  child.pid = pid;
   child.kill = vi.fn(() => {
     killed = true;
     return true;
@@ -226,6 +229,7 @@ describe('SleepInhibitor', () => {
     const spawn = vi.fn(() => {
       const child = new EventEmitter() as ChildProcess;
       Object.defineProperty(child, 'killed', { get: () => false });
+      child.pid = 4242;
       child.kill = vi.fn(() => {
         throw new Error('ESRCH');
       });
@@ -241,6 +245,36 @@ describe('SleepInhibitor', () => {
       'Failed to stop sleep inhibitor: ESRCH',
     );
     expect(inhibitor.getActiveCount()).toBe(0);
+  });
+
+  it('does not kill a child whose spawn failed (no pid)', () => {
+    // Mimics the container sandbox: `systemd-inhibit` is absent, so the spawn
+    // rejects with ENOENT on the next tick and the child never gets a pid. If
+    // `stop()` (here via the synchronous release before the error event fires)
+    // called `kill()` on this pidless child, the kill would target the
+    // caller's own process group and deliver SIGTERM to this process, aborting
+    // the run. Releasing must therefore be a no-op for a pidless child.
+    const children: ChildProcess[] = [];
+    const spawn = vi.fn(() => {
+      // Pidless child: spawn returned but the process never started (ENOENT).
+      const child = new EventEmitter() as ChildProcess;
+      Object.defineProperty(child, 'killed', { get: () => false });
+      child.pid = undefined;
+      child.kill = vi.fn(() => true);
+      children.push(child);
+      return child;
+    });
+    const logger = { debug: vi.fn(), warn: vi.fn() };
+    const inhibitor = new SleepInhibitor({ platform: 'linux', spawn, logger });
+
+    const handle = inhibitor.acquire('executing tool');
+    expect(spawn).toHaveBeenCalledTimes(1);
+
+    handle.release();
+
+    expect(children[0]!.kill).not.toHaveBeenCalled();
+    expect(inhibitor.getActiveCount()).toBe(0);
+    expect(inhibitor.isRunning()).toBe(false);
   });
 
   it('ignores a late error event from an already-replaced child', () => {

--- a/packages/core/src/services/sleepInhibitor.ts
+++ b/packages/core/src/services/sleepInhibitor.ts
@@ -207,7 +207,13 @@ export class SleepInhibitor {
   private stop(): void {
     const child = this.child;
     this.child = undefined;
-    if (!child || child.killed) {
+    // `child.pid` is undefined when the spawn failed (e.g. `systemd-inhibit`
+    // is absent, as in the container sandbox, which rejects with ENOENT on the
+    // next tick). Calling `kill()` on such a pidless child does not kill the
+    // intended process — it signals the caller's own process group, which
+    // inside a container delivers SIGTERM to this process and aborts the run.
+    // Only kill a child that actually started.
+    if (!child || child.killed || child.pid == null) {
       return;
     }
 


### PR DESCRIPTION
## What this PR does

Stops a sandboxed session from aborting with `Operation cancelled.` (exit 130) the moment the model invokes a tool. The keep-system-awake feature (on by default) was mishandling the teardown of its helper process when that helper failed to start, which ended up delivering a termination signal to the CLI itself.

## Why it's needed

While the model is streaming or a tool is executing, the keep-awake feature spawns an OS helper to inhibit system sleep. Inside a container sandbox that helper binary is not present, so the spawn fails and the child never receives a process id. On release the teardown still tried to terminate that never-started child. Terminating a child handle that has no process id does not target the intended process — it signals the caller's own process group, and inside a container that delivers SIGTERM to the CLI itself. The CLI's signal handler treats this as a user cancellation and exits 130.

The net effect: with default settings, a sandboxed (`docker`/`podman`) run aborts as soon as the model calls a fast, in-process tool. It is masked on the host (where the helper binary exists) and in non-sandbox CI, which is why it went unnoticed. It surfaced as failing Docker integration tests in the cron and tool-search suites, and it would hit real users running in a sandbox.

The fix is to only terminate a helper that actually started (i.e. has a process id); a failed spawn is left alone, exactly as intended.

## Reviewer Test Plan

### How to verify

Run the cron-tools and tool-search integration tests under the Docker sandbox (`QWEN_SANDBOX=docker`). Before this change, every test that triggers a tool call aborts with `Process exited with code 130: ... Operation cancelled.`; after it, they run to completion. The keep-awake service's unit tests also cover the regression directly: a helper whose spawn failed (no process id) must not be killed on release.

### Evidence (Before & After)

Before: the cron and tool-search Docker integration tests abort with `Operation cancelled.` / exit 130 the instant the model calls a tool. After: zero exit-130 occurrences in the same runs; the cron create/list/delete and one-shot tool-execution tests pass. Verified by rebuilding the sandbox image with this change and re-running those suites locally. Non-UI change, so no screenshots.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Local Docker sandbox (rebuilt image) plus package unit tests.

## Risk & Scope

- Main risk or tradeoff: very low — the change only skips terminating a child that never started; a successfully started helper is still terminated exactly as before.
- Not validated / out of scope: the keep-awake helper remains a no-op inside containers (the underlying inhibitor binary is absent there); restoring actual sleep inhibition in sandboxes is out of scope.
- Breaking changes / migration notes: none.

## Linked Issues

References #4434, which introduced the keep-system-awake feature. Note: the repository build is currently red on `main` because of an unrelated test syntax error (being fixed in #4863); this PR's build/typecheck will go green once that lands.
