### PR TITLE
fix(skills): use full YAML parser for frontmatter to support block scalars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17286,7 +17286,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -17840,7 +17839,8 @@
         "undici": "^6.22.0",
         "uuid": "^9.0.1",
         "web-tree-sitter": "^0.24.7",
-        "ws": "^8.18.0"
+        "ws": "^8.18.0",
+        "yaml": "^2.8.1"
       },
       "devDependencies": {
         "@types/diff": "^7.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -72,7 +72,8 @@
     "undici": "^6.22.0",
     "uuid": "^9.0.1",
     "web-tree-sitter": "^0.24.7",
-    "ws": "^8.18.0"
+    "ws": "^8.18.0",
+    "yaml": "^2.8.1"
   },
   "optionalDependencies": {
     "@lydell/node-pty": "1.2.0-beta.10",

--- a/packages/core/src/skills/skill-load.real-parser.test.ts
+++ b/packages/core/src/skills/skill-load.real-parser.test.ts
@@ -104,13 +104,17 @@ Body content here.
   });
 
   it('falls back gracefully for malformed YAML', () => {
+    // Unclosed flow mapping triggers a yaml.parse error; the simple
+    // parser ignores it and still extracts name + description.
     const markdown = `---
 name: test-skill
-description: value with unmatched "quote
+description: a test skill
+extra: {key: [nested unclosed
 ---
 Body.
 `;
     const config = parseSkillContent(markdown, testPath);
     expect(config.name).toBe('test-skill');
+    expect(config.description).toBe('a test skill');
   });
 });

--- a/packages/core/src/skills/skill-load.real-parser.test.ts
+++ b/packages/core/src/skills/skill-load.real-parser.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseSkillContent } from './skill-load.js';
+
+describe('parseSkillContent with real YAML parser', () => {
+  const testPath = '/test/extension/skills/test-skill/SKILL.md';
+
+  it('parses folded block scalar descriptions (>)', () => {
+    const markdown = `---
+name: test-skill
+description: >
+  This is a folded
+  multiline description.
+---
+
+Body.
+`;
+    const config = parseSkillContent(markdown, testPath);
+    expect(config.name).toBe('test-skill');
+    expect(config.description).toBe(
+      'This is a folded multiline description.\n',
+    );
+  });
+
+  it('parses literal block scalar descriptions (|)', () => {
+    const markdown = `---
+name: test-skill
+description: |
+  Line one.
+  Line two.
+---
+Body.
+`;
+    const config = parseSkillContent(markdown, testPath);
+    expect(config.description).toBe('Line one.\nLine two.\n');
+  });
+
+  it('parses strip-chomped folded block scalar (>-)', () => {
+    const markdown = `---
+name: test-skill
+description: >-
+  No trailing newline.
+---
+Body.
+`;
+    const config = parseSkillContent(markdown, testPath);
+    expect(config.description).toBe('No trailing newline.');
+  });
+
+  it('does not coerce date-like values to Date objects', () => {
+    const markdown = `---
+name: test-skill
+description: A skill created on 2024-01-01
+---
+Body.
+`;
+    const config = parseSkillContent(markdown, testPath);
+    expect(typeof config.description).toBe('string');
+  });
+
+  it('handles allowedTools array correctly', () => {
+    const markdown = `---
+name: test-skill
+description: A test skill
+allowedTools:
+  - read_file
+  - write_file
+---
+Body.
+`;
+    const config = parseSkillContent(markdown, testPath);
+    expect(config.allowedTools).toEqual(['read_file', 'write_file']);
+  });
+
+  it('handles complex frontmatter with mixed field types', () => {
+    const markdown = `---
+name: test-skill
+description: >
+  Manage the full lifecycle of
+  cloud resources.
+allowedTools:
+  - read_file
+  - write_file
+model: qwen-max
+argument-hint: "[resource-type]"
+priority: 10
+disable-model-invocation: true
+---
+Body content here.
+`;
+    const config = parseSkillContent(markdown, testPath);
+    expect(config.name).toBe('test-skill');
+    expect(config.description).toContain('Manage the full lifecycle');
+    expect(config.allowedTools).toEqual(['read_file', 'write_file']);
+    expect(config.model).toBe('qwen-max');
+    expect(config.argumentHint).toBe('[resource-type]');
+    expect(config.priority).toBe(10);
+    expect(config.disableModelInvocation).toBe(true);
+  });
+
+  it('falls back gracefully for malformed YAML', () => {
+    const markdown = `---
+name: test-skill
+description: value with unmatched "quote
+---
+Body.
+`;
+    const config = parseSkillContent(markdown, testPath);
+    expect(config.name).toBe('test-skill');
+  });
+});

--- a/packages/core/src/skills/skill-load.test.ts
+++ b/packages/core/src/skills/skill-load.test.ts
@@ -238,25 +238,6 @@ Body.
       expect(config.priority).toBeUndefined();
     });
 
-    it('should parse YAML folded block scalar description (>)', () => {
-      const markdown =
-        '---\nname: test-skill\ndescription: >\n  This is a folded\n  multiline description.\n---\nBody';
-      const config = parseSkillContent(markdown, testFilePath);
-      expect(config.name).toBe('test-skill');
-      expect(config.description).toBe(
-        'This is a folded multiline description.\n',
-      );
-    });
-
-    it('should parse YAML literal block scalar description (|)', () => {
-      const markdown =
-        '---\nname: test-skill\ndescription: |\n  Line one.\n  Line two.\n---\nBody';
-      const config = parseSkillContent(markdown, testFilePath);
-      expect(config.name).toBe('test-skill');
-      expect(config.description).toContain('Line one.');
-      expect(config.description).toContain('Line two.');
-    });
-
     it('should throw error for invalid format without frontmatter', () => {
       const invalidMarkdown = `# Just a heading
 Some content without frontmatter.

--- a/packages/core/src/skills/skill-load.test.ts
+++ b/packages/core/src/skills/skill-load.test.ts
@@ -238,6 +238,25 @@ Body.
       expect(config.priority).toBeUndefined();
     });
 
+    it('should parse YAML folded block scalar description (>)', () => {
+      const markdown =
+        '---\nname: test-skill\ndescription: >\n  This is a folded\n  multiline description.\n---\nBody';
+      const config = parseSkillContent(markdown, testFilePath);
+      expect(config.name).toBe('test-skill');
+      expect(config.description).toBe(
+        'This is a folded multiline description.\n',
+      );
+    });
+
+    it('should parse YAML literal block scalar description (|)', () => {
+      const markdown =
+        '---\nname: test-skill\ndescription: |\n  Line one.\n  Line two.\n---\nBody';
+      const config = parseSkillContent(markdown, testFilePath);
+      expect(config.name).toBe('test-skill');
+      expect(config.description).toContain('Line one.');
+      expect(config.description).toContain('Line two.');
+    });
+
     it('should throw error for invalid format without frontmatter', () => {
       const invalidMarkdown = `# Just a heading
 Some content without frontmatter.

--- a/packages/core/src/skills/skill-load.ts
+++ b/packages/core/src/skills/skill-load.ts
@@ -8,23 +8,9 @@ import {
 import { validateSymlinkTarget } from './symlinkScope.js';
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { parse as parseYamlSimple } from '../utils/yaml-parser.js';
-import * as yaml from 'yaml';
+import { parse as parseYaml } from '../utils/yaml-parser.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { normalizeContent } from '../utils/textUtils.js';
-
-/**
- * Parses a YAML string with full spec support (block scalars, nested
- * structures, etc.), falling back to the simple parser on failure so
- * that slightly malformed frontmatter still loads where possible.
- */
-function parseYaml(input: string): Record<string, unknown> {
-  try {
-    return yaml.parse(input) as Record<string, unknown>;
-  } catch {
-    return parseYamlSimple(input);
-  }
-}
 
 const debugLogger = createDebugLogger('SKILL_LOAD');
 

--- a/packages/core/src/skills/skill-load.ts
+++ b/packages/core/src/skills/skill-load.ts
@@ -135,7 +135,7 @@ export function parseSkillContent(
   const allowedToolsRaw = frontmatter['allowedTools'] as unknown[] | undefined;
   let allowedTools: string[] | undefined;
 
-  if (allowedToolsRaw != null) {
+  if (allowedToolsRaw !== undefined) {
     if (Array.isArray(allowedToolsRaw)) {
       allowedTools = allowedToolsRaw.map(String);
     } else {

--- a/packages/core/src/skills/skill-load.ts
+++ b/packages/core/src/skills/skill-load.ts
@@ -1,6 +1,7 @@
 import {
   type SkillConfig,
   type SkillValidationResult,
+  parseAllowedToolsField,
   parseModelField,
   parsePathsField,
   validateSkillName,
@@ -132,16 +133,7 @@ export function parseSkillContent(
   const description = String(descriptionRaw);
 
   // Extract optional fields
-  const allowedToolsRaw = frontmatter['allowedTools'] as unknown[] | undefined;
-  let allowedTools: string[] | undefined;
-
-  if (allowedToolsRaw !== undefined) {
-    if (Array.isArray(allowedToolsRaw)) {
-      allowedTools = allowedToolsRaw.map(String);
-    } else {
-      throw new Error('"allowedTools" must be an array');
-    }
-  }
+  const allowedTools = parseAllowedToolsField(frontmatter);
 
   // Extract optional model field
   const model = parseModelField(frontmatter);

--- a/packages/core/src/skills/skill-load.ts
+++ b/packages/core/src/skills/skill-load.ts
@@ -135,7 +135,7 @@ export function parseSkillContent(
   const allowedToolsRaw = frontmatter['allowedTools'] as unknown[] | undefined;
   let allowedTools: string[] | undefined;
 
-  if (allowedToolsRaw !== undefined) {
+  if (allowedToolsRaw != null) {
     if (Array.isArray(allowedToolsRaw)) {
       allowedTools = allowedToolsRaw.map(String);
     } else {

--- a/packages/core/src/skills/skill-load.ts
+++ b/packages/core/src/skills/skill-load.ts
@@ -8,9 +8,23 @@ import {
 import { validateSymlinkTarget } from './symlinkScope.js';
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { parse as parseYaml } from '../utils/yaml-parser.js';
+import { parse as parseYamlSimple } from '../utils/yaml-parser.js';
+import * as yaml from 'yaml';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { normalizeContent } from '../utils/textUtils.js';
+
+/**
+ * Parses a YAML string with full spec support (block scalars, nested
+ * structures, etc.), falling back to the simple parser on failure so
+ * that slightly malformed frontmatter still loads where possible.
+ */
+function parseYaml(input: string): Record<string, unknown> {
+  try {
+    return yaml.parse(input) as Record<string, unknown>;
+  } catch {
+    return parseYamlSimple(input);
+  }
+}
 
 const debugLogger = createDebugLogger('SKILL_LOAD');
 

--- a/packages/core/src/skills/skill-manager.ts
+++ b/packages/core/src/skills/skill-manager.ts
@@ -21,6 +21,7 @@ import type {
 import {
   SkillError,
   SkillErrorCode,
+  parseAllowedToolsField,
   parseModelField,
   parsePathsField,
   validateSkillName,
@@ -687,26 +688,18 @@ export class SkillManager {
       const description = String(descriptionRaw);
 
       // Extract optional fields
-      const allowedToolsRaw = frontmatter['allowedTools'] as
-        | unknown[]
-        | undefined;
-      let allowedTools: string[] | undefined;
-
-      if (allowedToolsRaw !== undefined) {
-        if (Array.isArray(allowedToolsRaw)) {
-          allowedTools = allowedToolsRaw.map(String);
-        } else {
-          throw new Error('"allowedTools" must be an array');
-        }
-      }
+      const allowedTools = parseAllowedToolsField(frontmatter);
 
       // Extract hooks configuration
       let hooks: SkillHooksSettings | undefined;
-      const hooksRaw = frontmatter['hooks'] as
-        | Record<string, unknown>
-        | undefined;
-      if (hooksRaw !== undefined) {
-        hooks = this.parseHooksConfig(hooksRaw);
+      const hooksRaw = frontmatter['hooks'];
+      if (
+        hooksRaw !== undefined &&
+        typeof hooksRaw === 'object' &&
+        hooksRaw !== null &&
+        !Array.isArray(hooksRaw)
+      ) {
+        hooks = this.parseHooksConfig(hooksRaw as Record<string, unknown>);
       }
 
       // Set skillRoot to the directory containing SKILL.md

--- a/packages/core/src/skills/skill-manager.ts
+++ b/packages/core/src/skills/skill-manager.ts
@@ -692,7 +692,7 @@ export class SkillManager {
         | undefined;
       let allowedTools: string[] | undefined;
 
-      if (allowedToolsRaw !== undefined) {
+      if (allowedToolsRaw != null) {
         if (Array.isArray(allowedToolsRaw)) {
           allowedTools = allowedToolsRaw.map(String);
         } else {
@@ -705,7 +705,7 @@ export class SkillManager {
       const hooksRaw = frontmatter['hooks'] as
         | Record<string, unknown>
         | undefined;
-      if (hooksRaw !== undefined) {
+      if (hooksRaw != null) {
         hooks = this.parseHooksConfig(hooksRaw);
       }
 

--- a/packages/core/src/skills/skill-manager.ts
+++ b/packages/core/src/skills/skill-manager.ts
@@ -692,7 +692,7 @@ export class SkillManager {
         | undefined;
       let allowedTools: string[] | undefined;
 
-      if (allowedToolsRaw != null) {
+      if (allowedToolsRaw !== undefined) {
         if (Array.isArray(allowedToolsRaw)) {
           allowedTools = allowedToolsRaw.map(String);
         } else {
@@ -705,7 +705,7 @@ export class SkillManager {
       const hooksRaw = frontmatter['hooks'] as
         | Record<string, unknown>
         | undefined;
-      if (hooksRaw != null) {
+      if (hooksRaw !== undefined) {
         hooks = this.parseHooksConfig(hooksRaw);
       }
 

--- a/packages/core/src/skills/skill-manager.ts
+++ b/packages/core/src/skills/skill-manager.ts
@@ -10,21 +10,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { watch as watchFs, type FSWatcher } from 'chokidar';
 import { resolveBundleDir } from '../utils/bundlePaths.js';
-import { parse as parseYamlSimple } from '../utils/yaml-parser.js';
-import * as yaml from 'yaml';
-
-/**
- * Parses a YAML string with full spec support (block scalars, nested
- * structures, etc.), falling back to the simple parser on failure so
- * that slightly malformed frontmatter still loads where possible.
- */
-function parseYaml(input: string): Record<string, unknown> {
-  try {
-    return yaml.parse(input) as Record<string, unknown>;
-  } catch {
-    return parseYamlSimple(input);
-  }
-}
+import { parse as parseYaml } from '../utils/yaml-parser.js';
 import type {
   SkillConfig,
   SkillLevel,

--- a/packages/core/src/skills/skill-manager.ts
+++ b/packages/core/src/skills/skill-manager.ts
@@ -10,8 +10,21 @@ import * as path from 'path';
 import * as os from 'os';
 import { watch as watchFs, type FSWatcher } from 'chokidar';
 import { resolveBundleDir } from '../utils/bundlePaths.js';
-import { parse as parseYaml } from '../utils/yaml-parser.js';
+import { parse as parseYamlSimple } from '../utils/yaml-parser.js';
 import * as yaml from 'yaml';
+
+/**
+ * Parses a YAML string with full spec support (block scalars, nested
+ * structures, etc.), falling back to the simple parser on failure so
+ * that slightly malformed frontmatter still loads where possible.
+ */
+function parseYaml(input: string): Record<string, unknown> {
+  try {
+    return yaml.parse(input) as Record<string, unknown>;
+  } catch {
+    return parseYamlSimple(input);
+  }
+}
 import type {
   SkillConfig,
   SkillLevel,
@@ -702,20 +715,12 @@ export class SkillManager {
       }
 
       // Extract hooks configuration
-      // Use full YAML parser for hooks as they have nested structures
       let hooks: SkillHooksSettings | undefined;
-      if (frontmatterYaml.includes('hooks:')) {
-        // Re-parse with full YAML parser to get nested hooks structure
-        const fullFrontmatter = yaml.parse(frontmatterYaml) as Record<
-          string,
-          unknown
-        >;
-        const hooksRaw = fullFrontmatter['hooks'] as
-          | Record<string, unknown>
-          | undefined;
-        if (hooksRaw !== undefined) {
-          hooks = this.parseHooksConfig(hooksRaw);
-        }
+      const hooksRaw = frontmatter['hooks'] as
+        | Record<string, unknown>
+        | undefined;
+      if (hooksRaw !== undefined) {
+        hooks = this.parseHooksConfig(hooksRaw);
       }
 
       // Set skillRoot to the directory containing SKILL.md

--- a/packages/core/src/skills/types.ts
+++ b/packages/core/src/skills/types.ts
@@ -233,6 +233,24 @@ export function parsePathsField(
 export const SKILL_NAME_PATTERN = /^[\p{L}\p{N}_:.-]+$/u;
 
 /**
+ * Parse the `allowedTools` field from skill frontmatter.
+ * Returns `undefined` when the field is omitted. Throws when the field is
+ * present but not an array.
+ */
+export function parseAllowedToolsField(
+  frontmatter: Record<string, unknown>,
+): string[] | undefined {
+  const raw = frontmatter['allowedTools'];
+  if (raw == null) {
+    return undefined;
+  }
+  if (!Array.isArray(raw)) {
+    throw new Error('"allowedTools" must be an array');
+  }
+  return raw.map(String);
+}
+
+/**
  * Validate that a skill `name` is safe to embed into prompts and reminders
  * verbatim. Throws with a descriptive message if not — the surrounding
  * parser converts this into a `parseErrors` entry and skips the skill,

--- a/packages/core/src/subagents/subagent-manager.ts
+++ b/packages/core/src/subagents/subagent-manager.ts
@@ -7,8 +7,6 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
-// Note: yaml package would need to be added as a dependency
-// For now, we'll use a simple YAML parser implementation
 import {
   parse as parseYaml,
   stringify as stringifyYaml,

--- a/packages/core/src/utils/yaml-parser.test.ts
+++ b/packages/core/src/utils/yaml-parser.test.ts
@@ -62,6 +62,50 @@ describe('yaml-parser', () => {
       expect(result['name']).toBe('test-skill');
       expect(result['description']).toBe('Folded without trailing newline.');
     });
+
+    it('should not coerce date-like strings into Date objects', () => {
+      const input = 'name: test\ncreated: 2024-01-01';
+      const result = parse(input);
+      expect(typeof result['created']).toBe('string');
+      expect(result['created']).toBe('2024-01-01');
+    });
+
+    it('should return null for bare keys with no value', () => {
+      const input = 'name: test\nhooks:';
+      const result = parse(input);
+      expect(result['name']).toBe('test');
+      expect(result['hooks']).toBeNull();
+    });
+
+    it('should return null for explicit null and tilde values', () => {
+      const input = 'a: null\nb: ~';
+      const result = parse(input);
+      expect(result['a']).toBeNull();
+      expect(result['b']).toBeNull();
+    });
+
+    it('should treat yes/no as strings in YAML 1.2 core schema', () => {
+      const input = 'answer: yes\nother: no';
+      const result = parse(input);
+      expect(result['answer']).toBe('yes');
+      expect(result['other']).toBe('no');
+    });
+
+    it('should fall back to simple parser on invalid YAML', () => {
+      const input = 'name: test\ndescription: value with unmatched "quote';
+      const result = parse(input);
+      expect(result['name']).toBe('test');
+    });
+
+    it('should handle empty input gracefully', () => {
+      const result = parse('');
+      expect(result).toEqual({});
+    });
+
+    it('should handle comment-only input gracefully', () => {
+      const result = parse('# just a comment');
+      expect(result).toEqual({});
+    });
   });
 
   describe('stringify', () => {

--- a/packages/core/src/utils/yaml-parser.test.ts
+++ b/packages/core/src/utils/yaml-parser.test.ts
@@ -36,6 +36,32 @@ describe('yaml-parser', () => {
         },
       });
     });
+
+    it('should parse YAML folded block scalar (>)', () => {
+      const input =
+        'name: test-skill\ndescription: >\n  This is a folded\n  multiline description.';
+      const result = parse(input);
+      expect(result['name']).toBe('test-skill');
+      expect(result['description']).toBe(
+        'This is a folded multiline description.\n',
+      );
+    });
+
+    it('should parse YAML literal block scalar (|)', () => {
+      const input =
+        'name: test-skill\ndescription: |\n  Line one.\n  Line two.';
+      const result = parse(input);
+      expect(result['name']).toBe('test-skill');
+      expect(result['description']).toBe('Line one.\nLine two.\n');
+    });
+
+    it('should parse YAML block scalar with strip chomping (>-)', () => {
+      const input =
+        'name: test-skill\ndescription: >-\n  Folded without trailing newline.';
+      const result = parse(input);
+      expect(result['name']).toBe('test-skill');
+      expect(result['description']).toBe('Folded without trailing newline.');
+    });
   });
 
   describe('stringify', () => {

--- a/packages/core/src/utils/yaml-parser.test.ts
+++ b/packages/core/src/utils/yaml-parser.test.ts
@@ -92,9 +92,22 @@ describe('yaml-parser', () => {
     });
 
     it('should fall back to simple parser on invalid YAML', () => {
-      const input = 'name: test\ndescription: value with unmatched "quote';
+      // Unclosed flow sequence triggers a yaml.parse error
+      const input = 'name: test\nallowedTools: [unclosed';
       const result = parse(input);
       expect(result['name']).toBe('test');
+    });
+
+    it('should not allow prototype pollution via simple parser fallback', () => {
+      // Crafted to fail yaml.parse (unclosed flow) and trigger parseSimple,
+      // where __proto__ as a nested-object key could pollute the prototype.
+      const input =
+        '__proto__:\n  polluted: true\nname: test\nbroken: [unclosed';
+      const result = parse(input);
+      expect(result['name']).toBe('test');
+      const clean: Record<string, unknown> = {};
+      expect(clean['polluted']).toBeUndefined();
+      expect(Object.getPrototypeOf(result)).toBeNull();
     });
 
     it('should handle empty input gracefully', () => {
@@ -105,6 +118,31 @@ describe('yaml-parser', () => {
     it('should handle comment-only input gracefully', () => {
       const result = parse('# just a comment');
       expect(result).toEqual({});
+    });
+
+    it('should not allow prototype pollution via __proto__ key', () => {
+      const input = 'name: legit\n__proto__:\n  polluted: true';
+      const result = parse(input);
+      expect(result['name']).toBe('legit');
+      // result uses null prototype — __proto__ is a plain own property
+      expect(Object.getPrototypeOf(result)).toBeNull();
+      expect(Object.hasOwn(result, '__proto__')).toBe(true);
+    });
+
+    it('should not resolve !!timestamp explicit tags', () => {
+      const input = 'name: test\ncreated: !!timestamp 2024-01-01';
+      const result = parse(input);
+      expect(typeof result['created']).toBe('string');
+    });
+
+    it('should sanitize nested objects recursively', () => {
+      const input =
+        'name: test\nmetadata:\n  created: !!timestamp 2024-01-01\n  note: hello';
+      const result = parse(input);
+      const metadata = result['metadata'] as Record<string, unknown>;
+      expect(typeof metadata['created']).toBe('string');
+      expect(metadata['note']).toBe('hello');
+      expect(Object.getPrototypeOf(metadata)).toBeNull();
     });
   });
 

--- a/packages/core/src/utils/yaml-parser.test.ts
+++ b/packages/core/src/utils/yaml-parser.test.ts
@@ -98,6 +98,16 @@ describe('yaml-parser', () => {
       expect(result['name']).toBe('test');
     });
 
+    it('should strip null values in fallback path same as main path', () => {
+      // Unclosed flow forces fallback to parseSimple; explicit null
+      // must be stripped so callers can use `!== undefined` consistently.
+      const input = 'name: test\noptional: null\nbroken: [unclosed';
+      const result = parse(input);
+      expect(result['name']).toBe('test');
+      expect(result['optional']).toBeUndefined();
+      expect('optional' in result).toBe(false);
+    });
+
     it('should not allow prototype pollution via simple parser fallback', () => {
       // Crafted to fail yaml.parse (unclosed flow) and trigger parseSimple,
       // where __proto__ as a nested-object key could pollute the prototype.

--- a/packages/core/src/utils/yaml-parser.test.ts
+++ b/packages/core/src/utils/yaml-parser.test.ts
@@ -70,18 +70,18 @@ describe('yaml-parser', () => {
       expect(result['created']).toBe('2024-01-01');
     });
 
-    it('should return null for bare keys with no value', () => {
+    it('should strip bare keys with no value', () => {
       const input = 'name: test\nhooks:';
       const result = parse(input);
       expect(result['name']).toBe('test');
-      expect(result['hooks']).toBeNull();
+      expect(result['hooks']).toBeUndefined();
     });
 
-    it('should return null for explicit null and tilde values', () => {
+    it('should strip explicit null and tilde values', () => {
       const input = 'a: null\nb: ~';
       const result = parse(input);
-      expect(result['a']).toBeNull();
-      expect(result['b']).toBeNull();
+      expect(result['a']).toBeUndefined();
+      expect(result['b']).toBeUndefined();
     });
 
     it('should treat yes/no as strings in YAML 1.2 core schema', () => {

--- a/packages/core/src/utils/yaml-parser.ts
+++ b/packages/core/src/utils/yaml-parser.ts
@@ -39,7 +39,7 @@ export function parse(yamlString: string): Record<string, unknown> {
  * @param yamlString - YAML string to parse
  * @returns Parsed object
  */
-export function parseSimple(yamlString: string): Record<string, unknown> {
+function parseSimple(yamlString: string): Record<string, unknown> {
   const lines = yamlString
     .split('\n')
     .filter((line) => line.trim() && !line.trim().startsWith('#'));

--- a/packages/core/src/utils/yaml-parser.ts
+++ b/packages/core/src/utils/yaml-parser.ts
@@ -4,20 +4,42 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * Simple YAML parser for subagent frontmatter.
- * This is a minimal implementation that handles the basic YAML structures
- * needed for subagent configuration files.
- */
+import * as yaml from 'yaml';
+import { createDebugLogger } from './debugLogger.js';
+
+const debugLogger = createDebugLogger('YAML_PARSER');
 
 /**
- * Parses a simple YAML string into a JavaScript object.
- * Supports basic key-value pairs, arrays, and nested objects.
+ * Parses a YAML string with full spec support (block scalars, nested
+ * structures, etc.), falling back to the simple parser on failure so
+ * that slightly malformed frontmatter still loads where possible.
  *
  * @param yamlString - YAML string to parse
  * @returns Parsed object
  */
 export function parse(yamlString: string): Record<string, unknown> {
+  try {
+    const result = yaml.parse(yamlString);
+    if (result && typeof result === 'object' && !Array.isArray(result)) {
+      return result as Record<string, unknown>;
+    }
+  } catch (error) {
+    debugLogger.debug(
+      `Full YAML parser failed, falling back to simple parser: ${error}`,
+    );
+  }
+  return parseSimple(yamlString);
+}
+
+/**
+ * Simple YAML parser for subagent frontmatter.
+ * This is a minimal implementation that handles the basic YAML structures
+ * needed for subagent configuration files.
+ *
+ * @param yamlString - YAML string to parse
+ * @returns Parsed object
+ */
+export function parseSimple(yamlString: string): Record<string, unknown> {
   const lines = yamlString
     .split('\n')
     .filter((line) => line.trim() && !line.trim().startsWith('#'));

--- a/packages/core/src/utils/yaml-parser.ts
+++ b/packages/core/src/utils/yaml-parser.ts
@@ -47,7 +47,7 @@ export function parse(yamlString: string): Record<string, unknown> {
       `Full YAML parser failed, falling back to simple parser: ${error}`,
     );
   }
-  return parseSimple(yamlString);
+  return stripNullValues(parseSimple(yamlString));
 }
 
 /**

--- a/packages/core/src/utils/yaml-parser.ts
+++ b/packages/core/src/utils/yaml-parser.ts
@@ -21,7 +21,7 @@ export function parse(yamlString: string): Record<string, unknown> {
   try {
     const result = yaml.parse(yamlString, { schema: 'core' });
     if (result && typeof result === 'object' && !Array.isArray(result)) {
-      return result as Record<string, unknown>;
+      return stripNullValues(result as Record<string, unknown>);
     }
   } catch (error) {
     debugLogger.debug(
@@ -29,6 +29,24 @@ export function parse(yamlString: string): Record<string, unknown> {
     );
   }
   return parseSimple(yamlString);
+}
+
+/**
+ * Strips top-level null values so callers can keep using `!== undefined`.
+ * yaml.parse returns null for bare keys (e.g. `hooks:`) and explicit
+ * nulls (`key: null`, `key: ~`), while the old simple parser omitted
+ * them entirely — normalizing here keeps the contract consistent.
+ */
+function stripNullValues(
+  obj: Record<string, unknown>,
+): Record<string, unknown> {
+  const cleaned: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (value !== null) {
+      cleaned[key] = value;
+    }
+  }
+  return cleaned;
 }
 
 /**

--- a/packages/core/src/utils/yaml-parser.ts
+++ b/packages/core/src/utils/yaml-parser.ts
@@ -19,7 +19,7 @@ const debugLogger = createDebugLogger('YAML_PARSER');
  */
 export function parse(yamlString: string): Record<string, unknown> {
   try {
-    const result = yaml.parse(yamlString);
+    const result = yaml.parse(yamlString, { schema: 'core' });
     if (result && typeof result === 'object' && !Array.isArray(result)) {
       return result as Record<string, unknown>;
     }

--- a/packages/core/src/utils/yaml-parser.ts
+++ b/packages/core/src/utils/yaml-parser.ts
@@ -19,12 +19,31 @@ const debugLogger = createDebugLogger('YAML_PARSER');
  */
 export function parse(yamlString: string): Record<string, unknown> {
   try {
-    const result = yaml.parse(yamlString, { schema: 'core' });
+    const result = yaml.parse(yamlString, {
+      schema: 'core',
+      // Belt-and-suspenders: filter timestamp/binary from schema tags.
+      // The core schema doesn't include them, so this is a no-op in
+      // practice — the real defense is in sanitizeValue() which catches
+      // Date/Uint8Array from explicit !!tags that bypass schema filtering.
+      customTags: (tags) =>
+        tags.filter((tag) => {
+          const uri = typeof tag === 'string' ? tag : tag.tag;
+          return (
+            uri !== 'tag:yaml.org,2002:timestamp' &&
+            uri !== 'tag:yaml.org,2002:binary' &&
+            uri !== 'timestamp' &&
+            uri !== 'binary'
+          );
+        }),
+    });
     if (result && typeof result === 'object' && !Array.isArray(result)) {
       return stripNullValues(result as Record<string, unknown>);
     }
+    debugLogger.warn(
+      `Full YAML parser returned non-object (${typeof result}), falling back to simple parser`,
+    );
   } catch (error) {
-    debugLogger.debug(
+    debugLogger.warn(
       `Full YAML parser failed, falling back to simple parser: ${error}`,
     );
   }
@@ -32,18 +51,47 @@ export function parse(yamlString: string): Record<string, unknown> {
 }
 
 /**
- * Strips top-level null values so callers can keep using `!== undefined`.
- * yaml.parse returns null for bare keys (e.g. `hooks:`) and explicit
- * nulls (`key: null`, `key: ~`), while the old simple parser omitted
- * them entirely — normalizing here keeps the contract consistent.
+ * Recursively sanitizes parsed YAML values:
+ * - Strips null values so callers can use `!== undefined` consistently
+ * - Converts Date / Uint8Array (from explicit !!tags) back to strings
+ * - Wraps nested objects in null-prototype containers to prevent
+ *   prototype pollution via `__proto__` keys
  */
+function sanitizeValue(value: unknown): unknown {
+  if (value === null) {
+    return undefined;
+  }
+  // Explicit YAML tags (!!timestamp, !!binary) bypass schema filtering
+  // and produce Date / Uint8Array objects. Coerce them back to strings
+  // so downstream code that expects plain JSON-style values stays safe.
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (value instanceof Uint8Array) {
+    return new TextDecoder().decode(value);
+  }
+  // Recurse into nested plain objects so __proto__ / Date / Uint8Array
+  // values inside hooks or metadata are also sanitized.
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return stripNullValues(value as Record<string, unknown>);
+  }
+  if (Array.isArray(value)) {
+    return value.map(sanitizeValue).filter((v) => v !== undefined);
+  }
+  return value;
+}
+
 function stripNullValues(
   obj: Record<string, unknown>,
 ): Record<string, unknown> {
-  const cleaned: Record<string, unknown> = {};
+  // Object.create(null) prevents prototype pollution: a YAML key of
+  // "__proto__" becomes a plain own property instead of triggering the
+  // __proto__ setter that would replace the object's prototype.
+  const cleaned = Object.create(null) as Record<string, unknown>;
   for (const [key, value] of Object.entries(obj)) {
-    if (value !== null) {
-      cleaned[key] = value;
+    const sanitized = sanitizeValue(value);
+    if (sanitized !== undefined) {
+      cleaned[key] = sanitized;
     }
   }
   return cleaned;
@@ -61,12 +109,12 @@ function parseSimple(yamlString: string): Record<string, unknown> {
   const lines = yamlString
     .split('\n')
     .filter((line) => line.trim() && !line.trim().startsWith('#'));
-  const result: Record<string, unknown> = {};
+  const result = Object.create(null) as Record<string, unknown>;
 
   let currentKey = '';
   let currentArray: unknown[] = [];
   let inArray = false;
-  let currentObject: Record<string, unknown> = {};
+  let currentObject = Object.create(null) as Record<string, unknown>;
   let inObject = false;
   let objectKey = '';
 
@@ -104,7 +152,7 @@ function parseSimple(yamlString: string): Record<string, unknown> {
     if (inObject && !line.startsWith('  ')) {
       result[objectKey] = currentObject;
       inObject = false;
-      currentObject = {};
+      currentObject = Object.create(null) as Record<string, unknown>;
       objectKey = '';
     }
 
@@ -127,7 +175,7 @@ function parseSimple(yamlString: string): Record<string, unknown> {
             // Next line is indented, so this is an object
             inObject = true;
             objectKey = currentKey;
-            currentObject = {};
+            currentObject = Object.create(null) as Record<string, unknown>;
             currentKey = '';
             continue;
           }


### PR DESCRIPTION
## What this PR does

Switches the YAML frontmatter parser for SKILL.md files from a hand-rolled minimal parser (`yaml-parser.ts`) to the full `yaml` npm package (v2.8.1, already installed) as the primary parser, with an automatic fallback to the old simple parser when the full parser rejects malformed input. This makes skill descriptions written with YAML block scalar syntax (`>` folded, `|` literal) parse correctly instead of showing the raw `>` or `|` character.

## Why it's needed

The custom `yaml-parser.ts` (193 lines) only handles flat `key: value` pairs, single-level arrays, and one-level nested objects. It has no support for YAML block scalar indicators (`>`, `>-`, `|`, `|-`). When a SKILL.md uses standard YAML multiline syntax like `description: >`, only the `>` character is captured as the description — the continuation lines are silently dropped. Claude Code handles the same SKILL.md files correctly because it uses a full YAML parser.

## Reviewer Test Plan

### How to verify

1. Create a skill with block scalar description:
   ```yaml
   ---
   name: test-multiline
   description: >
     This is a multiline
     description that should be folded into one line.
   ---
   # Test skill body
   ```
2. Load the skill in Qwen Code (CLI or VS Code extension)
3. Run `/test-multiline` or check the skill picker — the full description should display instead of `>`
4. Verify existing skills with single-line descriptions still work unchanged
5. Run `npx vitest run packages/core/src/utils/yaml-parser.test.ts packages/core/src/skills/skill-load.test.ts packages/core/src/skills/skill-load.real-parser.test.ts` — all 98 tests pass

### Evidence (Before & After)

before:
qc: 
<img width="1028" height="366" alt="image" src="https://github.com/user-attachments/assets/761bdcda-cd26-4677-8751-def59e3d6127" />
cc:
<img width="2028" height="240" alt="image" src="https://github.com/user-attachments/assets/a9a7f9db-3014-47f4-9870-86a2e808de36" />


### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  ⚠️   |
|  🐧 Linux  |  ⚠️   |

### Environment (optional)

Local runtime: `npx vitest run` for unit/integration tests. CI covers all three platforms.

## Risk & Scope

- Main risk or tradeoff: `yaml.parse()` may return different types than the old simple parser for edge cases. Mitigated by using `schema: 'core'` (prevents date-like strings from becoming Date objects) and adding `!= null` guards (handles bare keys returning null instead of empty string).
- Blast radius beyond skills: `parse()` in `yaml-parser.ts` is a shared utility, so `subagent-manager`, `claude-converter`, and `rulesDiscovery` also switch to the full parser. I checked each call site — they all read fields via bracket access with `Array.isArray` / `|| ''` defaults, so the null-stripping and null-prototype objects introduced here are compatible. Net effect for those callers is they gain the same block scalar support.
- Not validated / out of scope: The `stringify` function was not upgraded — it remains the simple implementation. This is safe today since all current stringify call sites build objects from scratch, but a future parse→modify→stringify roundtrip with deeply nested YAML would need `yaml.stringify()`.
- Breaking changes / migration notes: None. All existing SKILL.md files continue to work. The only behavioral change is that block scalar descriptions now parse correctly.

## Linked Issues

Closes #4869

<details>
<summary>中文说明</summary>

将 SKILL.md 的 YAML frontmatter 解析器从手写的极简 parser 切换到完整的 `yaml` npm 包作为主解析器，解析失败时自动回退到旧的简单 parser。这样使用 YAML block scalar 语法（`>` 折叠、`|` 保留换行）编写的 skill 描述能够正确解析，而不是只显示 `>` 或 `|` 字符。

**根因**：自研的 `yaml-parser.ts`（193行）只支持平铺的 `key: value` 对、单层数组和一层嵌套对象，完全没有处理 YAML block scalar 语法。当 SKILL.md 使用 `description: >` 时，只有 `>` 字符被捕获为描述内容，后续的缩进行被静默丢弃。Claude Code 使用完整的 YAML 解析器处理相同的 SKILL.md 文件，所以能正常显示。

**主要改动**：
- `yaml-parser.ts`：新的 `parse()` 函数优先使用 `yaml.parse(input, { schema: 'core' })` 解析，失败时回退到旧的 `parseSimple()`
- `skill-manager.ts`：移除冗余的 hooks 二次解析，统一使用新的 parser；`!== undefined` 改为 `!= null` 防止空值穿透
- `skill-load.ts`：同样修复 `allowedToolsRaw` 的 null guard
- `package.json`：将 `yaml` 添加为显式依赖
- 影响面说明：`parse()` 是共享工具函数，`subagent-manager`、`claude-converter`、`rulesDiscovery` 等调用方也同步切换到完整解析器。已逐一确认这些调用点的用法（方括号取值 + `Array.isArray` / `|| ''` 兜底）与 null 剥离、null-prototype 对象兼容，它们同时获得 block scalar 支持
- 新增 17 个测试覆盖 block scalar、Date 非转换、null/tilde、malformed fallback 等边界情况

</details>

