### PR TITLE
test(integration): drop tight 30s timeout in sleep-interception e2e tests

### DIFF
--- a/integration-tests/cli/sleep-interception.test.ts
+++ b/integration-tests/cli/sleep-interception.test.ts
@@ -34,7 +34,7 @@ describe('sleep-interception', () => {
 
     // The model's output should mention it was blocked
     expect(result.toLowerCase()).toContain('blocked');
-  }, 30000);
+  });
 
   it('should allow sleep < 2s', async () => {
     rig = new TestRig();
@@ -51,7 +51,7 @@ describe('sleep-interception', () => {
 
     // Should not be blocked — model should complete successfully
     expect(result.toLowerCase()).not.toContain('blocked');
-  }, 30000);
+  });
 
   it('should allow retrying blocked sleep with an intentional sleep comment', async () => {
     rig = new TestRig();
@@ -70,7 +70,7 @@ describe('sleep-interception', () => {
     expect(foundShell).toBeTruthy();
 
     expect(result.toLowerCase()).toContain('done');
-  }, 30000);
+  });
 
   it('should block sleep >= 2s even when followed by a trailing comment', async () => {
     // The `trimTrailingShellComment` state machine strips trailing `#...`
@@ -93,5 +93,5 @@ describe('sleep-interception', () => {
 
     // Model must report it was blocked despite the trailing comment.
     expect(result.toLowerCase()).toContain('blocked');
-  }, 30000);
+  });
 });


### PR DESCRIPTION
## What this PR does

Removes the hardcoded 30-second per-test timeout from the four sleep-interception integration tests so they use the suite's default timeout (the same as the rest of the integration tests).

## Why it's needed

These tests drive a real model and execute a shell command inside the Docker sandbox. They hardcoded a 30s timeout — which is actually shorter than the test rig's own per-operation timeout in CI (60s), and each test performs more than one such operation. Under Docker-sandbox load with the CI model they intermittently exceed 30s and fail the release pipeline's Docker integration job. The most recent failure timed out on "should allow sleep < 2s" across all retries: https://github.com/QwenLM/qwen-code/actions/runs/27178705912/job/80233278943

The interception behavior these tests cover is environment-independent and already passes in the non-sandbox job; the failures are purely a too-tight timeout budget, not a real defect. Dropping the override lets them use the same generous default as every other integration test, which removes the flakiness without losing any coverage.

## Reviewer Test Plan

### How to verify

Run the sleep-interception integration tests under the Docker sandbox. They complete in roughly 12–20s normally and no longer fail spuriously when the runner or model is slow. Behavior and assertions are unchanged — only the timeout budget.

### Evidence (Before & After)

Before: the release Docker integration job failed with "Test timed out in 30000ms" on the sleep-interception suite (linked above). After: the tests use the default timeout and complete normally. Reproduced locally in the Docker sandbox passing 3/3 — twice in isolation and once under induced parallel contention — at ~12s each. Non-UI change, so no screenshots.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Local Docker sandbox.

## Risk & Scope

- Main risk or tradeoff: negligible — test-only change that relaxes a timeout; no production or test-logic change.
- Not validated / out of scope: N/A.
- Breaking changes / migration notes: none.

## Linked Issues

Failed CI run that motivated this: https://github.com/QwenLM/qwen-code/actions/runs/27178705912/job/80233278943
