### PR TITLE
feat(cli): add /compress-fast command for no-LLM rule-based context compression

### DIFF
--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -19,6 +19,7 @@ import { bugCommand } from '../ui/commands/bugCommand.js';
 import { clearCommand } from '../ui/commands/clearCommand.js';
 import { deleteCommand } from '../ui/commands/deleteCommand.js';
 import { compressCommand } from '../ui/commands/compressCommand.js';
+import { compressFastCommand } from '../ui/commands/compressFastCommand.js';
 import { contextCommand } from '../ui/commands/contextCommand.js';
 import { copyCommand } from '../ui/commands/copyCommand.js';
 import { docsCommand } from '../ui/commands/docsCommand.js';
@@ -107,6 +108,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       bugCommand,
       clearCommand,
       compressCommand,
+      compressFastCommand,
       contextCommand,
       copyCommand,
       diffCommand,

--- a/packages/cli/src/ui/commands/compressFastCommand.test.ts
+++ b/packages/cli/src/ui/commands/compressFastCommand.test.ts
@@ -53,7 +53,7 @@ describe('compressFastCommand', () => {
     expect(mockTryCompressChatFast).not.toHaveBeenCalled();
   });
 
-  it('should default to tool-calls mode', async () => {
+  it('should call tryCompressChatFast without arguments', async () => {
     mockTryCompressChatFast.mockResolvedValue({
       originalTokenCount: 200,
       newTokenCount: 100,
@@ -62,25 +62,7 @@ describe('compressFastCommand', () => {
 
     await compressFastCommand.action!(context, '');
 
-    expect(mockTryCompressChatFast).toHaveBeenCalledWith('tool-calls');
-  });
-
-  it('should use keep-last mode when --keep-last flag is present', async () => {
-    mockTryCompressChatFast.mockResolvedValue({
-      originalTokenCount: 200,
-      newTokenCount: 50,
-      compressionStatus: CompressionStatus.COMPRESSED,
-    } satisfies ChatCompressionInfo);
-
-    context.invocation = {
-      raw: '/compress-fast --keep-last',
-      name: 'compress-fast',
-      args: '--keep-last',
-    };
-
-    await compressFastCommand.action!(context, '');
-
-    expect(mockTryCompressChatFast).toHaveBeenCalledWith('keep-last');
+    expect(mockTryCompressChatFast).toHaveBeenCalledWith();
   });
 
   it('should display compression result on success (interactive)', async () => {

--- a/packages/cli/src/ui/commands/compressFastCommand.test.ts
+++ b/packages/cli/src/ui/commands/compressFastCommand.test.ts
@@ -1,0 +1,196 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  CompressionStatus,
+  type ChatCompressionInfo,
+  type GeminiClient,
+} from '@qwen-code/qwen-code-core';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { compressFastCommand } from './compressFastCommand.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import { MessageType } from '../types.js';
+
+describe('compressFastCommand', () => {
+  let context: ReturnType<typeof createMockCommandContext>;
+  let mockTryCompressChatFast: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockTryCompressChatFast = vi.fn();
+    context = createMockCommandContext({
+      services: {
+        config: {
+          getGeminiClient: () =>
+            ({
+              tryCompressChatFast: mockTryCompressChatFast,
+            }) as unknown as GeminiClient,
+        },
+      },
+    });
+  });
+
+  it('should do nothing if a compression is already pending', async () => {
+    context.ui.pendingItem = {
+      type: MessageType.COMPRESSION,
+      compression: {
+        isPending: true,
+        originalTokenCount: null,
+        newTokenCount: null,
+        compressionStatus: null,
+      },
+    };
+    await compressFastCommand.action!(context, '');
+    expect(context.ui.addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MessageType.ERROR,
+        text: 'Already compressing, wait for previous request to complete',
+      }),
+      expect.any(Number),
+    );
+    expect(mockTryCompressChatFast).not.toHaveBeenCalled();
+  });
+
+  it('should default to tool-calls mode', async () => {
+    mockTryCompressChatFast.mockResolvedValue({
+      originalTokenCount: 200,
+      newTokenCount: 100,
+      compressionStatus: CompressionStatus.COMPRESSED,
+    } satisfies ChatCompressionInfo);
+
+    await compressFastCommand.action!(context, '');
+
+    expect(mockTryCompressChatFast).toHaveBeenCalledWith('tool-calls');
+  });
+
+  it('should use keep-last mode when --keep-last flag is present', async () => {
+    mockTryCompressChatFast.mockResolvedValue({
+      originalTokenCount: 200,
+      newTokenCount: 50,
+      compressionStatus: CompressionStatus.COMPRESSED,
+    } satisfies ChatCompressionInfo);
+
+    context.invocation = {
+      raw: '/compress-fast --keep-last',
+      name: 'compress-fast',
+      args: '--keep-last',
+    };
+
+    await compressFastCommand.action!(context, '');
+
+    expect(mockTryCompressChatFast).toHaveBeenCalledWith('keep-last');
+  });
+
+  it('should display compression result on success (interactive)', async () => {
+    mockTryCompressChatFast.mockResolvedValue({
+      originalTokenCount: 200,
+      newTokenCount: 100,
+      compressionStatus: CompressionStatus.COMPRESSED,
+    } satisfies ChatCompressionInfo);
+
+    await compressFastCommand.action!(context, '');
+
+    expect(context.ui.addItem).toHaveBeenCalledWith(
+      {
+        type: MessageType.COMPRESSION,
+        compression: {
+          isPending: false,
+          originalTokenCount: 200,
+          newTokenCount: 100,
+          compressionStatus: CompressionStatus.COMPRESSED,
+        },
+      },
+      expect.any(Number),
+    );
+    expect(context.ui.setPendingItem).toHaveBeenLastCalledWith(null);
+  });
+
+  it('should show "No compression needed" when tokens unchanged', async () => {
+    mockTryCompressChatFast.mockResolvedValue({
+      originalTokenCount: 100,
+      newTokenCount: 100,
+      compressionStatus: CompressionStatus.NOOP,
+    } satisfies ChatCompressionInfo);
+
+    await compressFastCommand.action!(context, '');
+
+    expect(context.ui.addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MessageType.INFO,
+        text: 'No compression needed.',
+      }),
+      expect.any(Number),
+    );
+  });
+
+  it('should handle errors gracefully', async () => {
+    const error = new Error('Compression failed');
+    mockTryCompressChatFast.mockRejectedValue(error);
+
+    await compressFastCommand.action!(context, '');
+
+    expect(context.ui.addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MessageType.ERROR,
+        text: `Failed to compress chat history: ${error.message}`,
+      }),
+      expect.any(Number),
+    );
+    expect(context.ui.setPendingItem).toHaveBeenCalledWith(null);
+  });
+
+  it('should return error message in non-interactive mode', async () => {
+    const error = new Error('Compression failed');
+    mockTryCompressChatFast.mockRejectedValue(error);
+
+    const ctx = createMockCommandContext({
+      executionMode: 'non_interactive',
+      services: {
+        config: {
+          getGeminiClient: () =>
+            ({
+              tryCompressChatFast: mockTryCompressChatFast,
+            }) as unknown as GeminiClient,
+        },
+      },
+    });
+
+    const result = await compressFastCommand.action!(ctx, '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: `Failed to compress chat history: ${error.message}`,
+    });
+  });
+
+  it('should return info message in non-interactive mode on success', async () => {
+    mockTryCompressChatFast.mockResolvedValue({
+      originalTokenCount: 200,
+      newTokenCount: 100,
+      compressionStatus: CompressionStatus.COMPRESSED,
+    } satisfies ChatCompressionInfo);
+
+    const ctx = createMockCommandContext({
+      executionMode: 'non_interactive',
+      services: {
+        config: {
+          getGeminiClient: () =>
+            ({
+              tryCompressChatFast: mockTryCompressChatFast,
+            }) as unknown as GeminiClient,
+        },
+      },
+    });
+
+    const result = await compressFastCommand.action!(ctx, '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'Context compressed (200 -> 100).',
+    });
+  });
+});

--- a/packages/cli/src/ui/commands/compressFastCommand.ts
+++ b/packages/cli/src/ui/commands/compressFastCommand.ts
@@ -1,0 +1,184 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { HistoryItemCompression } from '../types.js';
+import { MessageType } from '../types.js';
+import type { SlashCommand } from './types.js';
+import { CommandKind } from './types.js';
+import { t } from '../../i18n/index.js';
+
+export const compressFastCommand: SlashCommand = {
+  name: 'compress-fast',
+  get description() {
+    return t(
+      'Fast context compression (no AI). ' +
+        '--tool-calls: strip tool outputs & thinking. ' +
+        '--keep-last: keep only last reply.',
+    );
+  },
+  kind: CommandKind.BUILT_IN,
+  supportedModes: ['interactive', 'non_interactive', 'acp'] as const,
+  argumentHint: '[--tool-calls|--keep-last]',
+  examples: [
+    '/compress-fast',
+    '/compress-fast --tool-calls',
+    '/compress-fast --keep-last',
+  ],
+  action: async (context) => {
+    const { ui } = context;
+    const executionMode = context.executionMode ?? 'interactive';
+
+    if (executionMode === 'interactive' && ui.pendingItem) {
+      ui.addItem(
+        {
+          type: MessageType.ERROR,
+          text: t('Already compressing, wait for previous request to complete'),
+        },
+        Date.now(),
+      );
+      return;
+    }
+
+    const pendingMessage: HistoryItemCompression = {
+      type: MessageType.COMPRESSION,
+      compression: {
+        isPending: true,
+        originalTokenCount: null,
+        newTokenCount: null,
+        compressionStatus: null,
+      },
+    };
+
+    const config = context.services.config;
+    const geminiClient = config?.getGeminiClient();
+    if (!config || !geminiClient) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: t('Config not loaded.'),
+      };
+    }
+
+    const rawArgs = context.invocation?.args?.trim() ?? '';
+    const mode: 'tool-calls' | 'keep-last' = rawArgs.includes('--keep-last')
+      ? 'keep-last'
+      : 'tool-calls';
+
+    const doCompress = async () => await geminiClient.tryCompressChatFast(mode);
+
+    if (executionMode === 'acp') {
+      const messages = async function* () {
+        try {
+          yield {
+            messageType: 'info' as const,
+            content: `Compressing context (fast, mode: ${mode})...`,
+          };
+          const compressed = await doCompress();
+          if (
+            !compressed ||
+            compressed.originalTokenCount === compressed.newTokenCount
+          ) {
+            yield {
+              messageType: 'info' as const,
+              content: t('No compression needed.'),
+            };
+            return;
+          }
+          yield {
+            messageType: 'info' as const,
+            content: `Context compressed (${compressed.originalTokenCount} -> ${compressed.newTokenCount}).`,
+          };
+        } catch (e) {
+          yield {
+            messageType: 'error' as const,
+            content: t('Failed to compress chat history: {{error}}', {
+              error: e instanceof Error ? e.message : String(e),
+            }),
+          };
+        }
+      };
+
+      return { type: 'stream_messages', messages: messages() };
+    }
+
+    try {
+      if (executionMode === 'interactive') {
+        ui.setPendingItem(pendingMessage);
+      }
+
+      const compressed = await doCompress();
+
+      if (
+        !compressed ||
+        compressed.originalTokenCount === compressed.newTokenCount
+      ) {
+        if (executionMode === 'interactive') {
+          ui.addItem(
+            {
+              type: MessageType.INFO,
+              text: t('No compression needed.'),
+            },
+            Date.now(),
+          );
+          return;
+        }
+
+        return {
+          type: 'message',
+          messageType: 'info',
+          content: t('No compression needed.'),
+        };
+      }
+
+      if (executionMode === 'interactive') {
+        ui.addItem(
+          {
+            type: MessageType.COMPRESSION,
+            compression: {
+              isPending: false,
+              originalTokenCount: compressed.originalTokenCount,
+              newTokenCount: compressed.newTokenCount,
+              compressionStatus: compressed.compressionStatus,
+            },
+          } as HistoryItemCompression,
+          Date.now(),
+        );
+        return;
+      }
+
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: `Context compressed (${compressed.originalTokenCount} -> ${compressed.newTokenCount}).`,
+      };
+    } catch (e) {
+      if (executionMode === 'interactive') {
+        ui.addItem(
+          {
+            type: MessageType.ERROR,
+            text: t('Failed to compress chat history: {{error}}', {
+              error: e instanceof Error ? e.message : String(e),
+            }),
+          },
+          Date.now(),
+        );
+        return;
+      }
+
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: t('Failed to compress chat history: {{error}}', {
+          error: e instanceof Error ? e.message : String(e),
+        }),
+      };
+    } finally {
+      if (executionMode === 'interactive') {
+        ui.setPendingItem(null);
+      }
+    }
+  },
+};

--- a/packages/cli/src/ui/commands/compressFastCommand.ts
+++ b/packages/cli/src/ui/commands/compressFastCommand.ts
@@ -14,19 +14,11 @@ export const compressFastCommand: SlashCommand = {
   name: 'compress-fast',
   get description() {
     return t(
-      'Fast context compression (no AI). ' +
-        '--tool-calls: strip tool outputs & thinking. ' +
-        '--keep-last: keep only last reply.',
+      'Fast context compression without AI. Strips old tool outputs and thinking parts.',
     );
   },
   kind: CommandKind.BUILT_IN,
   supportedModes: ['interactive', 'non_interactive', 'acp'] as const,
-  argumentHint: '[--tool-calls|--keep-last]',
-  examples: [
-    '/compress-fast',
-    '/compress-fast --tool-calls',
-    '/compress-fast --keep-last',
-  ],
   action: async (context) => {
     const { ui } = context;
     const executionMode = context.executionMode ?? 'interactive';
@@ -62,19 +54,14 @@ export const compressFastCommand: SlashCommand = {
       };
     }
 
-    const rawArgs = context.invocation?.args?.trim() ?? '';
-    const mode: 'tool-calls' | 'keep-last' = rawArgs.includes('--keep-last')
-      ? 'keep-last'
-      : 'tool-calls';
-
-    const doCompress = async () => await geminiClient.tryCompressChatFast(mode);
+    const doCompress = async () => await geminiClient.tryCompressChatFast();
 
     if (executionMode === 'acp') {
       const messages = async function* () {
         try {
           yield {
             messageType: 'info' as const,
-            content: `Compressing context (fast, mode: ${mode})...`,
+            content: 'Compressing context (fast)...',
           };
           const compressed = await doCompress();
           if (

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -2364,53 +2364,42 @@ export class GeminiClient {
   /**
    * Fast, rule-based compression without any LLM side-query.
    * Delegates to {@link GeminiChat.compressFast} and handles post-compression
-   * session rebuild / FileReadCache disarming.
+   * FileReadCache disarming.
    */
-  async tryCompressChatFast(
-    mode: 'tool-calls' | 'keep-last',
-  ): Promise<ChatCompressionInfo> {
-    const { info, microcompactMeta } = this.getChat().compressFast(mode);
+  async tryCompressChatFast(): Promise<ChatCompressionInfo> {
+    const { info, microcompactMeta } = this.getChat().compressFast();
 
     if (info.compressionStatus !== CompressionStatus.COMPRESSED) {
       return info;
     }
 
-    if (mode === 'keep-last') {
-      // History drastically shrunk — rebuild session.
-      // Trade-off: previously revealed deferred tools are lost, but
-      // --keep-last is an aggressive trim by design.
-      const compressedHistory = this.getChat().getHistoryShallow();
-      await this.startChat(compressedHistory, SessionStartSource.Compact);
-      this.config.getFileReadCache().clear();
-    } else {
-      // --tool-calls: lightweight, setHistory() already called in compressFast().
-      // Reuse microcompaction's surgical FileReadCache disarm pattern.
-      const m = microcompactMeta;
-      const fileReadCache = this.config.getFileReadCache();
-      if (m && m.unresolvedEvictedReads > 0) {
-        debugLogger.debug(
-          `[FILE_READ_CACHE] clear after compress-fast ` +
-            `(${m.unresolvedEvictedReads} unresolved blanked read(s))`,
-        );
-        fileReadCache.clear();
-      } else if (m && m.evictedReadPaths.length > 0) {
-        const statResults = await Promise.all(
-          m.evictedReadPaths.map((p) =>
-            fsPromises.stat(p).catch(() => undefined),
-          ),
-        );
-        let fullyDisarmed = true;
-        for (const stats of statResults) {
-          if (!stats || !fileReadCache.markReadEvictedFromHistory(stats)) {
-            fullyDisarmed = false;
-          }
-        }
-        if (!fullyDisarmed) {
-          fileReadCache.clear();
+    // Lightweight: setHistory() already called in compressFast().
+    // Reuse microcompaction's surgical FileReadCache disarm pattern.
+    const m = microcompactMeta;
+    const fileReadCache = this.config.getFileReadCache();
+    if (m && m.unresolvedEvictedReads > 0) {
+      debugLogger.debug(
+        `[FILE_READ_CACHE] clear after compress-fast ` +
+          `(${m.unresolvedEvictedReads} unresolved blanked read(s))`,
+      );
+      fileReadCache.clear();
+    } else if (m && m.evictedReadPaths.length > 0) {
+      const statResults = await Promise.all(
+        m.evictedReadPaths.map((p) =>
+          fsPromises.stat(p).catch(() => undefined),
+        ),
+      );
+      let fullyDisarmed = true;
+      for (const stats of statResults) {
+        if (!stats || !fileReadCache.markReadEvictedFromHistory(stats)) {
+          fullyDisarmed = false;
         }
       }
-      this.forceFullIdeContext = true;
+      if (!fullyDisarmed) {
+        fileReadCache.clear();
+      }
     }
+    this.forceFullIdeContext = true;
 
     this.getChat().setLastPromptTokenCount(info.newTokenCount);
     return info;

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -2360,4 +2360,59 @@ export class GeminiClient {
     }
     return info;
   }
+
+  /**
+   * Fast, rule-based compression without any LLM side-query.
+   * Delegates to {@link GeminiChat.compressFast} and handles post-compression
+   * session rebuild / FileReadCache disarming.
+   */
+  async tryCompressChatFast(
+    mode: 'tool-calls' | 'keep-last',
+  ): Promise<ChatCompressionInfo> {
+    const { info, microcompactMeta } = this.getChat().compressFast(mode);
+
+    if (info.compressionStatus !== CompressionStatus.COMPRESSED) {
+      return info;
+    }
+
+    if (mode === 'keep-last') {
+      // History drastically shrunk — rebuild session.
+      // Trade-off: previously revealed deferred tools are lost, but
+      // --keep-last is an aggressive trim by design.
+      const compressedHistory = this.getChat().getHistoryShallow();
+      await this.startChat(compressedHistory, SessionStartSource.Compact);
+      this.config.getFileReadCache().clear();
+    } else {
+      // --tool-calls: lightweight, setHistory() already called in compressFast().
+      // Reuse microcompaction's surgical FileReadCache disarm pattern.
+      const m = microcompactMeta;
+      const fileReadCache = this.config.getFileReadCache();
+      if (m && m.unresolvedEvictedReads > 0) {
+        debugLogger.debug(
+          `[FILE_READ_CACHE] clear after compress-fast ` +
+            `(${m.unresolvedEvictedReads} unresolved blanked read(s))`,
+        );
+        fileReadCache.clear();
+      } else if (m && m.evictedReadPaths.length > 0) {
+        const statResults = await Promise.all(
+          m.evictedReadPaths.map((p) =>
+            fsPromises.stat(p).catch(() => undefined),
+          ),
+        );
+        let fullyDisarmed = true;
+        for (const stats of statResults) {
+          if (!stats || !fileReadCache.markReadEvictedFromHistory(stats)) {
+            fullyDisarmed = false;
+          }
+        }
+        if (!fullyDisarmed) {
+          fileReadCache.clear();
+        }
+      }
+      this.forceFullIdeContext = true;
+    }
+
+    this.getChat().setLastPromptTokenCount(info.newTokenCount);
+    return info;
+  }
 }

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -7517,7 +7517,7 @@ describe('GeminiChat', async () => {
       });
     });
 
-    it('tool-calls: strips thinking from model turns', () => {
+    it('strips thinking from model turns', () => {
       chat.setHistory([
         userMsg('hello'),
         modelMsgWithThinking('response text', 'internal reasoning'),
@@ -7526,7 +7526,7 @@ describe('GeminiChat', async () => {
       ]);
       chat.setLastPromptTokenCount(1000);
 
-      const result = chat.compressFast('tool-calls');
+      const result = chat.compressFast();
 
       expect(result.info.compressionStatus).toBe(CompressionStatus.COMPRESSED);
       // Thinking parts should be stripped from the first model message
@@ -7535,7 +7535,7 @@ describe('GeminiChat', async () => {
       expect(firstModel?.parts).toEqual([{ text: 'response text' }]);
     });
 
-    it('tool-calls: NOOP when no tool calls and no thinking', () => {
+    it('NOOP when no tool calls and no thinking', () => {
       chat.setHistory([
         userMsg('hello'),
         modelMsg('hi'),
@@ -7544,7 +7544,7 @@ describe('GeminiChat', async () => {
       ]);
       chat.setLastPromptTokenCount(10);
 
-      const result = chat.compressFast('tool-calls');
+      const result = chat.compressFast();
 
       // afterTokens >= beforeTokens (both very small) → NOOP
       // or compressionStatus is NOOP since estimated tokens may not shrink
@@ -7554,7 +7554,7 @@ describe('GeminiChat', async () => {
       ).toBe(true);
     });
 
-    it('tool-calls: clears old tool results via microcompaction', () => {
+    it('clears old tool results via microcompaction', () => {
       const history: Content[] = [];
       // Create many tool calls so keepRecent=5 kicks in
       for (let i = 0; i < 8; i++) {
@@ -7568,71 +7568,26 @@ describe('GeminiChat', async () => {
       chat.setHistory(history);
       chat.setLastPromptTokenCount(5000);
 
-      const result = chat.compressFast('tool-calls');
+      const result = chat.compressFast();
 
       expect(result.info.compressionStatus).toBe(CompressionStatus.COMPRESSED);
       expect(result.microcompactMeta).toBeDefined();
       expect(result.microcompactMeta!.toolsCleared).toBeGreaterThan(0);
     });
 
-    it('keep-last: keeps only last user/model pair', () => {
-      chat.setHistory([
-        userMsg('first question'),
-        modelMsg('first answer'),
-        userMsg('second question'),
-        modelMsg('second answer'),
-        userMsg('third question'),
-        modelMsg('third answer'),
-      ]);
-      chat.setLastPromptTokenCount(5000);
-
-      const result = chat.compressFast('keep-last');
-
-      expect(result.info.compressionStatus).toBe(CompressionStatus.COMPRESSED);
-      const history = chat.getHistory();
-      expect(history).toHaveLength(2);
-      expect(history[0]).toEqual(userMsg('third question'));
-      expect(history[1]).toEqual(modelMsg('third answer'));
-    });
-
-    it('keep-last: NOOP when model has only thinking (no text)', () => {
-      chat.setHistory([
-        userMsg('question'),
-        modelMsgWithThinking(null, 'just thinking, no output'),
-      ]);
-      chat.setLastPromptTokenCount(1000);
-
-      const result = chat.compressFast('keep-last');
-
-      expect(result.info.compressionStatus).toBe(CompressionStatus.NOOP);
-    });
-
-    it('keep-last: NOOP on empty history', () => {
-      chat.setHistory([]);
-      chat.setLastPromptTokenCount(0);
-
-      const result = chat.compressFast('keep-last');
-
-      expect(result.info.compressionStatus).toBe(CompressionStatus.NOOP);
-    });
-
-    it('keep-last: NOOP when only model messages exist (no user)', () => {
-      chat.setHistory([modelMsg('orphan response')]);
-      chat.setLastPromptTokenCount(100);
-
-      const result = chat.compressFast('keep-last');
-
-      expect(result.info.compressionStatus).toBe(CompressionStatus.NOOP);
-    });
-
     it('updates lastPromptTokenCount on COMPRESSED', () => {
       chat.setHistory([
-        userMsg('question'),
-        modelMsgWithThinking('answer', 'long internal reasoning process'),
+        userMsg('hello'),
+        modelMsgWithThinking(
+          'response',
+          'very long internal reasoning process',
+        ),
+        userMsg('next'),
+        modelMsg('plain reply'),
       ]);
       chat.setLastPromptTokenCount(5000);
 
-      const result = chat.compressFast('keep-last');
+      const result = chat.compressFast();
 
       if (result.info.compressionStatus === CompressionStatus.COMPRESSED) {
         expect(chat.getLastPromptTokenCount()).toBe(result.info.newTokenCount);

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -7482,4 +7482,161 @@ describe('GeminiChat', async () => {
       expect(compressSpy.mock.calls[3][1].consecutiveFailures).toBe(0);
     });
   });
+
+  describe('compressFast', () => {
+    const userMsg = (text: string): Content => ({
+      role: 'user' as const,
+      parts: [{ text }],
+    });
+    const modelMsg = (text: string): Content => ({
+      role: 'model' as const,
+      parts: [{ text }],
+    });
+    const modelMsgWithThinking = (
+      text: string | null,
+      thinking: string,
+    ): Content => ({
+      role: 'model' as const,
+      parts: [{ thought: true, text: thinking }, ...(text ? [{ text }] : [])],
+    });
+    const toolCall = (name: string): Content => ({
+      role: 'model' as const,
+      parts: [{ functionCall: { name, args: {} } }],
+    });
+    const toolResult = (name: string, output: string): Content => ({
+      role: 'user' as const,
+      parts: [{ functionResponse: { name, response: { output } } }],
+    });
+
+    beforeEach(() => {
+      (mockConfig as unknown as Record<string, unknown>)[
+        'getClearContextOnIdle'
+      ] = vi.fn().mockReturnValue({
+        toolResultsThresholdMinutes: 60,
+        toolResultsNumToKeep: 5,
+      });
+    });
+
+    it('tool-calls: strips thinking from model turns', () => {
+      chat.setHistory([
+        userMsg('hello'),
+        modelMsgWithThinking('response text', 'internal reasoning'),
+        userMsg('next'),
+        modelMsg('plain reply'),
+      ]);
+      chat.setLastPromptTokenCount(1000);
+
+      const result = chat.compressFast('tool-calls');
+
+      expect(result.info.compressionStatus).toBe(CompressionStatus.COMPRESSED);
+      // Thinking parts should be stripped from the first model message
+      const history = chat.getHistory();
+      const firstModel = history.find((c) => c.role === 'model');
+      expect(firstModel?.parts).toEqual([{ text: 'response text' }]);
+    });
+
+    it('tool-calls: NOOP when no tool calls and no thinking', () => {
+      chat.setHistory([
+        userMsg('hello'),
+        modelMsg('hi'),
+        userMsg('how are you'),
+        modelMsg('good'),
+      ]);
+      chat.setLastPromptTokenCount(10);
+
+      const result = chat.compressFast('tool-calls');
+
+      // afterTokens >= beforeTokens (both very small) → NOOP
+      // or compressionStatus is NOOP since estimated tokens may not shrink
+      expect(
+        result.info.compressionStatus === CompressionStatus.NOOP ||
+          result.info.compressionStatus === CompressionStatus.COMPRESSED,
+      ).toBe(true);
+    });
+
+    it('tool-calls: clears old tool results via microcompaction', () => {
+      const history: Content[] = [];
+      // Create many tool calls so keepRecent=5 kicks in
+      for (let i = 0; i < 8; i++) {
+        history.push(toolCall('read_file'));
+        history.push(
+          toolResult('read_file', `content for file ${i} `.repeat(50)),
+        );
+      }
+      history.push(userMsg('final'));
+      history.push(modelMsg('done'));
+      chat.setHistory(history);
+      chat.setLastPromptTokenCount(5000);
+
+      const result = chat.compressFast('tool-calls');
+
+      expect(result.info.compressionStatus).toBe(CompressionStatus.COMPRESSED);
+      expect(result.microcompactMeta).toBeDefined();
+      expect(result.microcompactMeta!.toolsCleared).toBeGreaterThan(0);
+    });
+
+    it('keep-last: keeps only last user/model pair', () => {
+      chat.setHistory([
+        userMsg('first question'),
+        modelMsg('first answer'),
+        userMsg('second question'),
+        modelMsg('second answer'),
+        userMsg('third question'),
+        modelMsg('third answer'),
+      ]);
+      chat.setLastPromptTokenCount(5000);
+
+      const result = chat.compressFast('keep-last');
+
+      expect(result.info.compressionStatus).toBe(CompressionStatus.COMPRESSED);
+      const history = chat.getHistory();
+      expect(history).toHaveLength(2);
+      expect(history[0]).toEqual(userMsg('third question'));
+      expect(history[1]).toEqual(modelMsg('third answer'));
+    });
+
+    it('keep-last: NOOP when model has only thinking (no text)', () => {
+      chat.setHistory([
+        userMsg('question'),
+        modelMsgWithThinking(null, 'just thinking, no output'),
+      ]);
+      chat.setLastPromptTokenCount(1000);
+
+      const result = chat.compressFast('keep-last');
+
+      expect(result.info.compressionStatus).toBe(CompressionStatus.NOOP);
+    });
+
+    it('keep-last: NOOP on empty history', () => {
+      chat.setHistory([]);
+      chat.setLastPromptTokenCount(0);
+
+      const result = chat.compressFast('keep-last');
+
+      expect(result.info.compressionStatus).toBe(CompressionStatus.NOOP);
+    });
+
+    it('keep-last: NOOP when only model messages exist (no user)', () => {
+      chat.setHistory([modelMsg('orphan response')]);
+      chat.setLastPromptTokenCount(100);
+
+      const result = chat.compressFast('keep-last');
+
+      expect(result.info.compressionStatus).toBe(CompressionStatus.NOOP);
+    });
+
+    it('updates lastPromptTokenCount on COMPRESSED', () => {
+      chat.setHistory([
+        userMsg('question'),
+        modelMsgWithThinking('answer', 'long internal reasoning process'),
+      ]);
+      chat.setLastPromptTokenCount(5000);
+
+      const result = chat.compressFast('keep-last');
+
+      if (result.info.compressionStatus === CompressionStatus.COMPRESSED) {
+        expect(chat.getLastPromptTokenCount()).toBe(result.info.newTokenCount);
+      }
+    });
+  });
 });

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -53,7 +53,14 @@ import {
 } from '../services/chatCompressionService.js';
 import { acquireSleepInhibitor } from '../services/sleepInhibitor.js';
 import { resolveSlimmingConfig } from '../services/compactionInputSlimming.js';
-import { estimatePromptTokens } from '../services/tokenEstimation.js';
+import {
+  estimateContentTokens,
+  estimatePromptTokens,
+} from '../services/tokenEstimation.js';
+import {
+  microcompactHistory,
+  type MicrocompactMeta,
+} from '../services/microcompaction/microcompact.js';
 import {
   ContentRetryEvent,
   ContentRetryFailureEvent,
@@ -915,7 +922,7 @@ function copyContentContainer(content: Content): Content {
   };
 }
 
-function stripThoughtPartsFromContent(content: Content): Content | null {
+export function stripThoughtPartsFromContent(content: Content): Content | null {
   if (!content.parts) {
     return content;
   }
@@ -1487,6 +1494,110 @@ export class GeminiChat {
     }
 
     return info;
+  }
+
+  /**
+   * Fast, rule-based compression without any LLM side-query.
+   *
+   * - `tool-calls`: force-run microcompaction (clear old tool results + media,
+   *   keep recent N) then strip thinking parts from all model turns.
+   * - `keep-last`: keep only the last user message and the last model reply.
+   */
+  compressFast(mode: 'tool-calls' | 'keep-last'): {
+    info: ChatCompressionInfo;
+    microcompactMeta?: MicrocompactMeta;
+  } {
+    const beforeTokens = this.lastPromptTokenCount;
+    let newHistory: Content[];
+    let mcMeta: MicrocompactMeta | undefined;
+
+    if (mode === 'tool-calls') {
+      // Step 1: force microcompaction (clear old tool results + media)
+      const mcResult = microcompactHistory(
+        this.history,
+        null,
+        this.config.getClearContextOnIdle(),
+        { force: true },
+      );
+      mcMeta = mcResult.meta;
+
+      // Step 2: strip thinking parts from model turns
+      newHistory = mcResult.history
+        .map((c) => (c.role === 'model' ? stripThoughtPartsFromContent(c) : c))
+        .filter((c): c is Content => c !== null);
+    } else {
+      // --keep-last: find last user/model pair
+      let lastModelIdx = -1;
+      let lastUserIdx = -1;
+      for (let i = this.history.length - 1; i >= 0; i--) {
+        const role = this.history[i]!.role;
+        if (lastModelIdx < 0 && role === 'model') lastModelIdx = i;
+        if (lastUserIdx < 0 && role === 'user') lastUserIdx = i;
+        if (lastModelIdx >= 0 && lastUserIdx >= 0) break;
+      }
+
+      // Guard: missing user/model or user after model → NOOP
+      if (lastModelIdx < 0 || lastUserIdx < 0 || lastUserIdx >= lastModelIdx) {
+        return {
+          info: {
+            originalTokenCount: beforeTokens,
+            newTokenCount: beforeTokens,
+            compressionStatus: CompressionStatus.NOOP,
+          },
+        };
+      }
+
+      const strippedModel = stripThoughtPartsFromContent(
+        this.history[lastModelIdx]!,
+      );
+      // Guard: model had only thinking, no text → NOOP
+      if (
+        !strippedModel ||
+        !strippedModel.parts ||
+        strippedModel.parts.length === 0
+      ) {
+        return {
+          info: {
+            originalTokenCount: beforeTokens,
+            newTokenCount: beforeTokens,
+            compressionStatus: CompressionStatus.NOOP,
+          },
+        };
+      }
+
+      newHistory = [this.history[lastUserIdx]!, strippedModel];
+    }
+
+    const afterTokens = estimateContentTokens(newHistory);
+
+    if (afterTokens >= beforeTokens) {
+      return {
+        info: {
+          originalTokenCount: beforeTokens,
+          newTokenCount: beforeTokens,
+          compressionStatus: CompressionStatus.NOOP,
+        },
+      };
+    }
+
+    const info: ChatCompressionInfo = {
+      originalTokenCount: beforeTokens,
+      newTokenCount: afterTokens,
+      compressionStatus: CompressionStatus.COMPRESSED,
+      triggerReason: 'manual',
+    };
+
+    this.chatRecordingService?.recordChatCompression({
+      info,
+      compressedHistory: newHistory,
+    });
+    this.setHistory(newHistory);
+    clearDetailedSpanState();
+    this.lastPromptTokenCount = afterTokens;
+    this.telemetryService?.setLastPromptTokenCount(afterTokens);
+    this.consecutiveFailures = 0;
+
+    return { info, microcompactMeta: mcMeta };
   }
 
   setSystemInstruction(sysInstr: string) {

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -922,7 +922,7 @@ function copyContentContainer(content: Content): Content {
   };
 }
 
-export function stripThoughtPartsFromContent(content: Content): Content | null {
+function stripThoughtPartsFromContent(content: Content): Content | null {
   if (!content.parts) {
     return content;
   }
@@ -1499,74 +1499,28 @@ export class GeminiChat {
   /**
    * Fast, rule-based compression without any LLM side-query.
    *
-   * - `tool-calls`: force-run microcompaction (clear old tool results + media,
-   *   keep recent N) then strip thinking parts from all model turns.
-   * - `keep-last`: keep only the last user message and the last model reply.
+   * Force-runs microcompaction (clear old tool results + media, keep recent N)
+   * then strips thinking parts from all model turns.
    */
-  compressFast(mode: 'tool-calls' | 'keep-last'): {
+  compressFast(): {
     info: ChatCompressionInfo;
     microcompactMeta?: MicrocompactMeta;
   } {
     const beforeTokens = this.lastPromptTokenCount;
-    let newHistory: Content[];
-    let mcMeta: MicrocompactMeta | undefined;
 
-    if (mode === 'tool-calls') {
-      // Step 1: force microcompaction (clear old tool results + media)
-      const mcResult = microcompactHistory(
-        this.history,
-        null,
-        this.config.getClearContextOnIdle(),
-        { force: true },
-      );
-      mcMeta = mcResult.meta;
+    // Step 1: force microcompaction (clear old tool results + media)
+    const mcResult = microcompactHistory(
+      this.history,
+      null,
+      this.config.getClearContextOnIdle(),
+      { force: true },
+    );
+    const mcMeta = mcResult.meta;
 
-      // Step 2: strip thinking parts from model turns
-      newHistory = mcResult.history
-        .map((c) => (c.role === 'model' ? stripThoughtPartsFromContent(c) : c))
-        .filter((c): c is Content => c !== null);
-    } else {
-      // --keep-last: find last user/model pair
-      let lastModelIdx = -1;
-      let lastUserIdx = -1;
-      for (let i = this.history.length - 1; i >= 0; i--) {
-        const role = this.history[i]!.role;
-        if (lastModelIdx < 0 && role === 'model') lastModelIdx = i;
-        if (lastUserIdx < 0 && role === 'user') lastUserIdx = i;
-        if (lastModelIdx >= 0 && lastUserIdx >= 0) break;
-      }
-
-      // Guard: missing user/model or user after model → NOOP
-      if (lastModelIdx < 0 || lastUserIdx < 0 || lastUserIdx >= lastModelIdx) {
-        return {
-          info: {
-            originalTokenCount: beforeTokens,
-            newTokenCount: beforeTokens,
-            compressionStatus: CompressionStatus.NOOP,
-          },
-        };
-      }
-
-      const strippedModel = stripThoughtPartsFromContent(
-        this.history[lastModelIdx]!,
-      );
-      // Guard: model had only thinking, no text → NOOP
-      if (
-        !strippedModel ||
-        !strippedModel.parts ||
-        strippedModel.parts.length === 0
-      ) {
-        return {
-          info: {
-            originalTokenCount: beforeTokens,
-            newTokenCount: beforeTokens,
-            compressionStatus: CompressionStatus.NOOP,
-          },
-        };
-      }
-
-      newHistory = [this.history[lastUserIdx]!, strippedModel];
-    }
+    // Step 2: strip thinking parts from model turns
+    const newHistory = mcResult.history
+      .map((c) => (c.role === 'model' ? stripThoughtPartsFromContent(c) : c))
+      .filter((c): c is Content => c !== null);
 
     const afterTokens = estimateContentTokens(newHistory);
 

--- a/packages/core/src/services/microcompaction/microcompact.test.ts
+++ b/packages/core/src/services/microcompaction/microcompact.test.ts
@@ -833,3 +833,72 @@ describe('microcompactHistory evictedReadPaths (issue #4239)', () => {
     expect(result.meta).toBeUndefined();
   });
 });
+
+describe('microcompactHistory — force option', () => {
+  afterEach(clearEnv);
+
+  it('force: true skips time-based trigger (fires even with recent timestamp)', () => {
+    const history: Content[] = [
+      makeToolCall('read_file'),
+      makeToolResult('read_file', 'old content that is very long'),
+      makeToolCall('read_file'),
+      makeToolResult('read_file', 'recent content'),
+    ];
+
+    // Date.now() would normally prevent the trigger from firing,
+    // but force: true bypasses the check entirely.
+    const result = microcompactHistory(history, Date.now(), DEFAULT_SETTINGS, {
+      force: true,
+    });
+
+    expect(result.meta).toBeDefined();
+    expect(result.meta!.toolsCleared).toBeGreaterThanOrEqual(1);
+  });
+
+  it('force: false behaves the same as not passing opts', () => {
+    const history: Content[] = [
+      makeToolCall('read_file'),
+      makeToolResult('read_file', 'content'),
+    ];
+
+    const result = microcompactHistory(history, Date.now(), DEFAULT_SETTINGS, {
+      force: false,
+    });
+
+    expect(result.meta).toBeUndefined();
+  });
+
+  it('force: true works even when threshold is disabled (-1)', () => {
+    const history: Content[] = [
+      makeToolCall('read_file'),
+      makeToolResult('read_file', 'old content that is very long'),
+      makeToolCall('read_file'),
+      makeToolResult('read_file', 'recent content'),
+    ];
+
+    const result = microcompactHistory(
+      history,
+      null,
+      { toolResultsThresholdMinutes: -1, toolResultsNumToKeep: 1 },
+      { force: true },
+    );
+
+    expect(result.meta).toBeDefined();
+    expect(result.meta!.toolsCleared).toBeGreaterThanOrEqual(1);
+  });
+
+  it('force: true returns history unchanged when nothing to clear', () => {
+    const history: Content[] = [
+      makeUserMessage('hello'),
+      makeModelMessage('hi'),
+    ];
+
+    const result = microcompactHistory(history, null, DEFAULT_SETTINGS, {
+      force: true,
+    });
+
+    // No compactable tools → no meta
+    expect(result.meta).toBeUndefined();
+    expect(result.history).toEqual(history);
+  });
+});

--- a/packages/core/src/services/microcompaction/microcompact.ts
+++ b/packages/core/src/services/microcompaction/microcompact.ts
@@ -266,6 +266,9 @@ export interface MicrocompactMeta {
  * Microcompact history: clear old compactable tool results when the
  * time-based trigger fires.
  *
+ * Pass `opts.force: true` to skip the time-based trigger check and
+ * always run the clearing logic (used by `/compress-fast`).
+ *
  * Returns the (potentially modified) history and optional metadata
  * about what was cleared (for logging by the caller).
  */
@@ -273,11 +276,11 @@ export function microcompactHistory(
   history: Content[],
   lastApiCompletionTimestamp: number | null,
   settings: ClearContextOnIdleSettings,
+  opts?: { force?: boolean },
 ): { history: Content[]; meta?: MicrocompactMeta } {
-  const trigger = evaluateTimeBasedTrigger(
-    lastApiCompletionTimestamp,
-    settings,
-  );
+  const trigger = opts?.force
+    ? { gapMs: 0 }
+    : evaluateTimeBasedTrigger(lastApiCompletionTimestamp, settings);
   if (!trigger) {
     return { history };
   }


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

Adds `/compress-fast`, a new slash command that compresses conversation context without any LLM side-query. It combines two rule-based steps: (1) force microcompaction to clear old tool results and media parts while keeping the most recent N, and (2) stripping `thought` parts from all model turns. The result is a significantly smaller history — typically freeing thousands of tokens — at zero API latency.

A `chat_compression` checkpoint is written to JSONL so `--resume` works exactly as it does after `/compress`.

## Why it's needed

`/compress` relies on an LLM side-query (~2-5s, ~30K tokens) to summarise history. For local model deployments and users who just want quick space reclamation, this is too slow. `/compress-fast` runs entirely rules-based: no API call, no token cost, instant feedback. It complements `/compress` — use `/compress-fast` when you need space right now, and `/compress` when you want semantic summary quality.

Resolves #4264.

## Reviewer Test Plan

### How to verify

```bash
# Unit tests
npx vitest run \
  packages/core/src/services/microcompaction/microcompact.test.ts \
  packages/core/src/core/geminiChat.test.ts \
  packages/cli/src/ui/commands/compressFastCommand.test.ts \
  packages/cli/src/services/BuiltinCommandLoader.test.ts
```

Manual smoke test in interactive mode:

```bash
npm run build && npm run start
# 1. Ask the model to read files and use tools:
> 帮我看看 package.json 和 tsconfig.json
# 2. Run the fast compress:
/compress-fast
#    → COMPRESSION card shows before/after token counts
# 3. Run again immediately:
/compress-fast
#    → "No compression needed" (nothing left to clean)
# 4. Verify model still works:
> 刚才我们读了哪些文件？
#    → Model responds normally, no tool_use_id errors
# 5. Verify context preserved:
> 这句话之前我们聊了什么？
#    → Model remembers conversation structure (dialogue skeleton intact)
# 6. Verify existing /compress still works:
/compress
#    → LLM compression runs as before
# 7. Verify resume:
qwen-code --resume
#    → Session restores and model responds to follow-ups
```

### Evidence (Before & After)

TUI change: a new `COMPRESSION` history item appears after running `/compress-fast`, showing the token reduction (e.g. `15,432 → 8,210`). This is identical UX to `/compress`.

Non-UI artifacts: the JSONL transcript gains a `chat_compression` record with `compressionStatus: COMPRESSED` and `triggerReason: manual`, matching the `/compress` checkpoint format.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local: `npm run dev` on macOS, Node 22.

## Risk & Scope

- Main risk or tradeoff: Stripping thinking blocks discards the model's internal reasoning. For very long tool-use chains where the model refers back to its own earlier reasoning, this could degrade answer quality. In practice text parts and tool results carry enough visible state; the original `/compress` is available if deeper summarization is needed.
- Not validated / out of scope: Performance on extremely large histories (>100K tokens) — the token estimation is fast but `estimateContentTokens` may have edge cases. The command intentionally does NOT rebuild the session via `startChat()` — deferred tools survive, unlike a `/clear`. This is both a feature (fast, preserves state) and a limitation (does not reclaim system prompt tokens).
- Breaking changes / migration notes: None. All changes are additive. `microcompactHistory()` gains an optional `{ force: true }` parameter that existing callers don't pass. `stripThoughtPartsFromContent` remains module-private.

## Linked Issues

Closes #4264

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

新增 `/compress-fast` 斜杠命令，在不发起任何 LLM 侧边查询的情况下压缩对话上下文。它组合了两个基于规则的步骤：(1) 强制 microcompaction 清理旧的工具结果和媒体内容，保留最近 N 个；(2) 剥离所有模型回复中的 `thought` 部分。结果是在零 API 延迟下显著缩减 history token 数。

会写入 `chat_compression` checkpoint 到 JSONL，`--resume` 的行为与 `/compress` 完全一致。

## 为什么需要

`/compress` 依赖 LLM 侧边查询来生成摘要（约 2-5 秒，消耗约 30K token）。对于本地模型部署或只想快速释放空间的用户来说太慢了。`/compress-fast` 纯规则驱动：无 API 调用、无 token 开销、即时响应。它与 `/compress` 互补——需要立即释放空间时用 `/compress-fast`，需要语义摘要质量时用 `/compress`。

解决 #4264。

## Reviewer Test Plan

（测试步骤同上，此处省略以保持可读性。）

## 风险与范围

- 主要风险与权衡：剥离 thinking 会丢弃模型的内部推理过程。对于非常长的工具调用链，模型可能忘记调用某个工具的原因进而影响回答质量。实践中文本内容和工具结果已携带足够的可见状态；如需更深层的摘要可使用 `/compress`。
- 未验证/超出范围：极大 history（>100K tokens）下的性能——token 估算速度很快但 `estimateContentTokens` 可能存在边界情况。命令有意不使用 `startChat()` 重建 session——deferred tools 会保留，不像 `/clear`。这既是优点（快、保留状态）也是局限（无法回收 system prompt token）。
- Breaking changes / 迁移说明：无。所有修改都是增量式的。`microcompactHistory()` 新增可选的 `{ force: true }` 参数，现有调用方不传此参数。`stripThoughtPartsFromContent` 保持模块私有。

## 关联 Issues

Closes #4264

</details>
