### PR TITLE
fix(dual-output): prevent FIFO blocking on startup when no reader connected

### DIFF
--- a/docs/users/features/dual-output.md
+++ b/docs/users/features/dual-output.md
@@ -199,10 +199,10 @@ wrappers that throw away stdout anyway.
 
 ## Quick start
 
-Run Qwen Code with all three channels enabled:
+Run Qwen Code with both channels enabled using regular files:
 
 ```bash
-mkfifo /tmp/qwen-events.jsonl /tmp/qwen-input.jsonl
+touch /tmp/qwen-events.jsonl /tmp/qwen-input.jsonl
 qwen \
   --json-file /tmp/qwen-events.jsonl \
   --input-file /tmp/qwen-input.jsonl
@@ -211,7 +211,7 @@ qwen \
 In a second terminal, tail the event stream:
 
 ```bash
-cat /tmp/qwen-events.jsonl
+tail -f /tmp/qwen-events.jsonl
 ```
 
 In a third terminal, push a prompt into the running TUI:
@@ -222,6 +222,28 @@ echo '{"type":"submit","text":"Explain this repo"}' >> /tmp/qwen-input.jsonl
 
 The prompt appears in the TUI exactly as if the user typed it, and the
 streaming response is mirrored on `/tmp/qwen-events.jsonl`.
+
+### Using FIFOs (named pipes)
+
+FIFOs deliver lower latency than regular files (no disk I/O) and work
+well when both sides are on the same host. The bridge opens FIFOs with
+`O_RDWR | O_NONBLOCK`, so it **does not block** even if no reader is
+connected yet — events are buffered in the kernel pipe buffer until a
+reader attaches.
+
+```bash
+mkfifo /tmp/qwen-events.jsonl /tmp/qwen-input.jsonl
+qwen \
+  --json-file /tmp/qwen-events.jsonl \
+  --input-file /tmp/qwen-input.jsonl
+# TUI starts immediately — no need to start a reader first.
+
+# In a second terminal, connect whenever ready:
+cat /tmp/qwen-events.jsonl
+```
+
+If no reader ever connects, the bridge auto-disables once the internal
+buffer exceeds 1 MB. The TUI continues running normally.
 
 ## Output event schema
 
@@ -325,6 +347,10 @@ polling — events are written synchronously as the TUI emits them.
 - **Consumer disconnect.** If the reader on the other side of the channel
   goes away (`EPIPE`), the bridge silently disables itself and the TUI
   keeps running. No retry.
+- **FIFO buffer overflow.** When writing to a FIFO with no reader
+  attached, the bridge buffers events internally. If the buffer exceeds
+  1 MB (no consumer is draining), the bridge disables itself. The TUI
+  continues running normally.
 - **Adapter exception.** Any exception thrown while emitting an event is
   caught, logged, and disables the bridge. The TUI is never crashed by a
   dual-output failure.

--- a/docs/users/features/dual-output.md
+++ b/docs/users/features/dual-output.md
@@ -223,7 +223,7 @@ echo '{"type":"submit","text":"Explain this repo"}' >> /tmp/qwen-input.jsonl
 The prompt appears in the TUI exactly as if the user typed it, and the
 streaming response is mirrored on `/tmp/qwen-events.jsonl`.
 
-### Using FIFOs (named pipes)
+### Using FIFOs (named pipes) for event output
 
 FIFOs deliver lower latency than regular files (no disk I/O) and work
 well when both sides are on the same host. The bridge opens FIFOs with
@@ -231,8 +231,13 @@ well when both sides are on the same host. The bridge opens FIFOs with
 connected yet — events are buffered in the kernel pipe buffer until a
 reader attaches.
 
+> **Note:** `--input-file` requires a regular file (not a FIFO) because
+> the watcher relies on `stat.size` to detect new data, which is always
+> 0 for FIFOs.
+
 ```bash
-mkfifo /tmp/qwen-events.jsonl /tmp/qwen-input.jsonl
+mkfifo /tmp/qwen-events.jsonl
+touch /tmp/qwen-input.jsonl
 qwen \
   --json-file /tmp/qwen-events.jsonl \
   --input-file /tmp/qwen-input.jsonl
@@ -348,9 +353,12 @@ polling — events are written synchronously as the TUI emits them.
   goes away (`EPIPE`), the bridge silently disables itself and the TUI
   keeps running. No retry.
 - **FIFO buffer overflow.** When writing to a FIFO with no reader
-  attached, the bridge buffers events internally. If the buffer exceeds
-  1 MB (no consumer is draining), the bridge disables itself. The TUI
-  continues running normally.
+  attached, events buffer in the kernel pipe (~64 KB on Linux) and the
+  Node.js WriteStream. Once the pipe is full or the internal buffer
+  exceeds 1 MB, the bridge disables itself and closes the fd. No
+  `session_end` is emitted in this case — consumers should treat a
+  closed stream without `session_end` as an abnormal termination. The
+  TUI continues running normally.
 - **Adapter exception.** Any exception thrown while emitting an event is
   caught, logged, and disables the bridge. The TUI is never crashed by a
   dual-output failure.

--- a/packages/cli/src/dualOutput/DualOutputBridge.test.ts
+++ b/packages/cli/src/dualOutput/DualOutputBridge.test.ts
@@ -201,65 +201,118 @@ describe('DualOutputBridge', () => {
     });
   });
 
-  describe('FIFO (named pipe) support', () => {
-    let fifoPath: string;
-
-    beforeEach(() => {
-      fifoPath = path.join(tmpDir, 'events.fifo');
-      try {
-        execSync(`mkfifo "${fifoPath}"`);
-      } catch {
-        // mkfifo not available (Windows) — skip these tests
-      }
-    });
-
-    it('does not block when opened without a reader connected', () => {
-      if (!fs.existsSync(fifoPath) || !fs.statSync(fifoPath).isFIFO()) {
-        return; // skip on platforms without mkfifo
-      }
-
-      const start = Date.now();
-      bridge = new DualOutputBridge(config, { filePath: fifoPath });
-      const elapsed = Date.now() - start;
-
-      expect(elapsed).toBeLessThan(500);
+  describe('buffer overflow guard', () => {
+    it('disables itself when buffered data exceeds 1 MB', () => {
+      bridge = new DualOutputBridge(config, { filePath: target });
       expect(bridge.isConnected).toBe(true);
+
+      // Simulate a bloated buffer by overriding writableLength
+      Object.defineProperty(bridge['stream'], 'writableLength', {
+        value: 1024 * 1024 + 1,
+      });
+
+      // Any write method should trigger the guard
+      bridge.emitSystemMessage('test', {});
+      expect(bridge.isConnected).toBe(false);
     });
 
-    it('delivers events to a reader that connects after construction', async () => {
-      if (!fs.existsSync(fifoPath) || !fs.statSync(fifoPath).isFIFO()) {
-        return; // skip on platforms without mkfifo
-      }
+    it('destroys the stream on overflow so consumers receive EOF', () => {
+      bridge = new DualOutputBridge(config, { filePath: target });
+      const destroySpy = vi.spyOn(bridge['stream'], 'destroy');
 
-      bridge = new DualOutputBridge(config, { filePath: fifoPath });
-      bridge.emitSystemMessage('test_event', { key: 'value' });
+      Object.defineProperty(bridge['stream'], 'writableLength', {
+        value: 1024 * 1024 + 1,
+      });
 
-      // Connect a reader after writes
-      const received = await new Promise<string>((resolve) => {
-        const chunks: Buffer[] = [];
-        const reader = fs.createReadStream(fifoPath);
-        reader.on('data', (chunk) => chunks.push(chunk as Buffer));
-        // Close the bridge to flush + EOF
-        bridge!.shutdown().then(() => {
+      bridge.emitSystemMessage('test', {});
+      expect(destroySpy).toHaveBeenCalled();
+    });
+
+    it('shutdown resolves immediately after buffer overflow destroys stream', async () => {
+      bridge = new DualOutputBridge(config, { filePath: target });
+
+      Object.defineProperty(bridge['stream'], 'writableLength', {
+        value: 1024 * 1024 + 1,
+      });
+      bridge.emitSystemMessage('test', {});
+      expect(bridge.isConnected).toBe(false);
+
+      await expect(bridge.shutdown()).resolves.toBeUndefined();
+    });
+
+    it('disables on ERR_SYSTEM_ERROR stream error', () => {
+      bridge = new DualOutputBridge(config, { filePath: target });
+      expect(bridge.isConnected).toBe(true);
+
+      bridge['stream'].emit(
+        'error',
+        Object.assign(new Error('EAGAIN'), { code: 'ERR_SYSTEM_ERROR' }),
+      );
+      expect(bridge.isConnected).toBe(false);
+    });
+  });
+
+  describe.skipIf(process.platform === 'win32' || process.getuid?.() === 0)(
+    'FIFO (named pipe) support',
+    () => {
+      let fifoPath: string;
+
+      beforeEach(() => {
+        fifoPath = path.join(tmpDir, 'events.fifo');
+        execSync(`mkfifo "${fifoPath}"`);
+      });
+
+      it('does not block when opened without a reader connected', () => {
+        const start = Date.now();
+        bridge = new DualOutputBridge(config, { filePath: fifoPath });
+        const elapsed = Date.now() - start;
+
+        expect(elapsed).toBeLessThan(500);
+        expect(bridge.isConnected).toBe(true);
+      });
+
+      it('delivers events to a reader that connects after construction', async () => {
+        bridge = new DualOutputBridge(config, { filePath: fifoPath });
+        bridge.emitSystemMessage('test_event', { key: 'value' });
+
+        const received = await new Promise<string>((resolve) => {
+          const chunks: Buffer[] = [];
+          const reader = fs.createReadStream(fifoPath);
+          reader.on('data', (chunk) => chunks.push(chunk as Buffer));
           reader.on('end', () => resolve(Buffer.concat(chunks).toString()));
+          reader.on('open', () => bridge!.shutdown());
+        });
+
+        const lines = received
+          .split('\n')
+          .filter(Boolean)
+          .map((l) => JSON.parse(l));
+        expect(lines[0]).toMatchObject({
+          type: 'system',
+          subtype: 'session_start',
+        });
+        const testEvent = lines.find(
+          (l: Record<string, unknown>) =>
+            l['type'] === 'system' && l['subtype'] === 'test_event',
+        );
+        expect(testEvent).toMatchObject({
+          data: { key: 'value' },
         });
       });
 
-      const lines = received
-        .split('\n')
-        .filter(Boolean)
-        .map((l) => JSON.parse(l));
-      expect(lines[0]).toMatchObject({
-        type: 'system',
-        subtype: 'session_start',
+      it('throws actionable error when FIFO lacks read permission', () => {
+        const noReadFifo = path.join(tmpDir, 'no-read.fifo');
+        // chmod 0200 (write-only): first openSync(O_WRONLY) returns ENXIO
+        // (no reader), retry with O_RDWR fails EACCES (no read permission)
+        execSync(`mkfifo "${noReadFifo}" && chmod 0200 "${noReadFifo}"`);
+        try {
+          expect(
+            () => new DualOutputBridge(config, { filePath: noReadFifo }),
+          ).toThrow(/permission denied opening FIFO for read-write/);
+        } finally {
+          execSync(`chmod 644 "${noReadFifo}"`);
+        }
       });
-      const testEvent = lines.find(
-        (l: Record<string, unknown>) =>
-          l['type'] === 'system' && l['subtype'] === 'test_event',
-      );
-      expect(testEvent).toMatchObject({
-        data: { key: 'value' },
-      });
-    });
-  });
+    },
+  );
 });

--- a/packages/cli/src/dualOutput/DualOutputBridge.test.ts
+++ b/packages/cli/src/dualOutput/DualOutputBridge.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { execSync } from 'node:child_process';
 import type { Config } from '@qwen-code/qwen-code-core';
 import {
   DualOutputBridge,
@@ -197,6 +198,68 @@ describe('DualOutputBridge', () => {
         bridge!.emitPermissionRequest('req', 'tool', 'tu', {}),
       ).not.toThrow();
       expect(() => bridge!.emitControlResponse('req', true)).not.toThrow();
+    });
+  });
+
+  describe('FIFO (named pipe) support', () => {
+    let fifoPath: string;
+
+    beforeEach(() => {
+      fifoPath = path.join(tmpDir, 'events.fifo');
+      try {
+        execSync(`mkfifo "${fifoPath}"`);
+      } catch {
+        // mkfifo not available (Windows) — skip these tests
+      }
+    });
+
+    it('does not block when opened without a reader connected', () => {
+      if (!fs.existsSync(fifoPath) || !fs.statSync(fifoPath).isFIFO()) {
+        return; // skip on platforms without mkfifo
+      }
+
+      const start = Date.now();
+      bridge = new DualOutputBridge(config, { filePath: fifoPath });
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeLessThan(500);
+      expect(bridge.isConnected).toBe(true);
+    });
+
+    it('delivers events to a reader that connects after construction', async () => {
+      if (!fs.existsSync(fifoPath) || !fs.statSync(fifoPath).isFIFO()) {
+        return; // skip on platforms without mkfifo
+      }
+
+      bridge = new DualOutputBridge(config, { filePath: fifoPath });
+      bridge.emitSystemMessage('test_event', { key: 'value' });
+
+      // Connect a reader after writes
+      const received = await new Promise<string>((resolve) => {
+        const chunks: Buffer[] = [];
+        const reader = fs.createReadStream(fifoPath);
+        reader.on('data', (chunk) => chunks.push(chunk as Buffer));
+        // Close the bridge to flush + EOF
+        bridge!.shutdown().then(() => {
+          reader.on('end', () => resolve(Buffer.concat(chunks).toString()));
+        });
+      });
+
+      const lines = received
+        .split('\n')
+        .filter(Boolean)
+        .map((l) => JSON.parse(l));
+      expect(lines[0]).toMatchObject({
+        type: 'system',
+        subtype: 'session_start',
+      });
+      const testEvent = lines.find(
+        (l: Record<string, unknown>) =>
+          l['type'] === 'system' && l['subtype'] === 'test_event',
+      );
+      expect(testEvent).toMatchObject({
+        data: { key: 'value' },
+      });
     });
   });
 });

--- a/packages/cli/src/dualOutput/DualOutputBridge.ts
+++ b/packages/cli/src/dualOutput/DualOutputBridge.ts
@@ -114,8 +114,8 @@ export class DualOutputBridge {
     } else {
       // Open with O_WRONLY|O_NONBLOCK to avoid blocking the event loop on FIFOs.
       // On FIFO, a regular open(O_WRONLY) blocks until a reader connects.
-      // O_NONBLOCK makes it return immediately (ENXIO if no reader yet, which
-      // createWriteStream handles via its internal retry/error mechanism).
+      // O_NONBLOCK makes openSync return immediately; if no reader is
+      // connected yet (ENXIO), the catch block below retries with O_RDWR.
       try {
         const fd = openSync(
           target.filePath,
@@ -130,11 +130,22 @@ export class DualOutputBridge {
           // writer, satisfying the "at least one reader" requirement).
           // Trade-off: EPIPE won't fire on reader disconnect; the bridge
           // self-disables when the pipe buffer fills instead.
-          const fd = openSync(
-            target.filePath,
-            constants.O_RDWR | constants.O_NONBLOCK,
-          );
-          this.stream = createWriteStream('', { fd });
+          try {
+            const fd = openSync(
+              target.filePath,
+              constants.O_RDWR | constants.O_NONBLOCK,
+            );
+            this.stream = createWriteStream('', { fd });
+          } catch (retryErr) {
+            if ((retryErr as NodeJS.ErrnoException).code === 'EACCES') {
+              throw new Error(
+                `--json-file "${target.filePath}": permission denied opening FIFO for read-write. ` +
+                  'Check read/write permissions on the file and its parent directories, ' +
+                  'or start a reader before launching Qwen Code.',
+              );
+            }
+            throw retryErr;
+          }
         } else if (code === 'ENOENT') {
           // Regular file doesn't exist yet — create it.
           this.stream = createWriteStream(target.filePath, { flags: 'w' });
@@ -146,9 +157,13 @@ export class DualOutputBridge {
 
     this.stream.on('error', (err) => {
       const code = (err as NodeJS.ErrnoException).code;
-      // Consumer disconnected — gracefully stop writing, don't crash the TUI
       if (code === 'EPIPE' || code === 'ERR_STREAM_DESTROYED') {
         debugLogger.warn('DualOutput: consumer disconnected, disabling');
+      } else if (code === 'ERR_SYSTEM_ERROR') {
+        debugLogger.warn(
+          'DualOutput: system error on stream, disabling:',
+          (err as NodeJS.ErrnoException).message,
+        );
       } else {
         debugLogger.error('DualOutput stream error:', err);
       }
@@ -182,7 +197,8 @@ export class DualOutputBridge {
 
   processEvent(event: ServerGeminiStreamEvent): void {
     if (!this.active) return;
-    if (this.isBufferOverflowing()) return;
+    this.disableIfBufferOverflowed();
+    if (!this.active) return;
     try {
       this.adapter.processEvent(event);
     } catch (err) {
@@ -192,6 +208,8 @@ export class DualOutputBridge {
   }
 
   startAssistantMessage(): void {
+    if (!this.active) return;
+    this.disableIfBufferOverflowed();
     if (!this.active) return;
     try {
       this.adapter.startAssistantMessage();
@@ -203,6 +221,8 @@ export class DualOutputBridge {
 
   finalizeAssistantMessage(): void {
     if (!this.active) return;
+    this.disableIfBufferOverflowed();
+    if (!this.active) return;
     try {
       this.adapter.finalizeAssistantMessage();
     } catch (err) {
@@ -212,6 +232,8 @@ export class DualOutputBridge {
   }
 
   emitUserMessage(parts: Part[]): void {
+    if (!this.active) return;
+    this.disableIfBufferOverflowed();
     if (!this.active) return;
     try {
       this.adapter.emitUserMessage(parts);
@@ -226,6 +248,8 @@ export class DualOutputBridge {
     response: ToolCallResponseInfo,
   ): void {
     if (!this.active) return;
+    this.disableIfBufferOverflowed();
+    if (!this.active) return;
     try {
       this.adapter.emitToolResult(request, response);
     } catch (err) {
@@ -239,15 +263,14 @@ export class DualOutputBridge {
     return this.active;
   }
 
-  private isBufferOverflowing(): boolean {
+  private disableIfBufferOverflowed(): void {
     if (this.stream.writableLength > MAX_BUFFERED_BYTES) {
       debugLogger.warn(
         'DualOutput: buffered data exceeds limit, disabling (no consumer draining?)',
       );
       this.active = false;
-      return true;
+      this.stream.destroy();
     }
-    return false;
   }
 
   /**
@@ -261,6 +284,8 @@ export class DualOutputBridge {
     input: unknown,
     blockedPath: string | null = null,
   ): void {
+    if (!this.active) return;
+    this.disableIfBufferOverflowed();
     if (!this.active) return;
     try {
       this.adapter.emitPermissionRequest(
@@ -282,6 +307,8 @@ export class DualOutputBridge {
    */
   emitControlResponse(requestId: string, allowed: boolean): void {
     if (!this.active) return;
+    this.disableIfBufferOverflowed();
+    if (!this.active) return;
     try {
       this.adapter.emitControlResponse(requestId, allowed);
     } catch (err) {
@@ -298,6 +325,8 @@ export class DualOutputBridge {
    */
   emitControlError(requestId: string, message: string): void {
     if (!this.active) return;
+    this.disableIfBufferOverflowed();
+    if (!this.active) return;
     try {
       this.adapter.emitControlError(requestId, message);
     } catch (err) {
@@ -308,6 +337,8 @@ export class DualOutputBridge {
 
   /** General-purpose system event escape hatch. */
   emitSystemMessage(subtype: string, data?: unknown): void {
+    if (!this.active) return;
+    this.disableIfBufferOverflowed();
     if (!this.active) return;
     try {
       this.adapter.emitSystemMessage(subtype, data);
@@ -334,7 +365,7 @@ export class DualOutputBridge {
     }
     this.active = false;
     this.shutdownPromise = new Promise((resolve) => {
-      if (this.stream.closed) {
+      if (this.stream.closed || this.stream.destroyed) {
         resolve();
         return;
       }

--- a/packages/cli/src/dualOutput/DualOutputBridge.ts
+++ b/packages/cli/src/dualOutput/DualOutputBridge.ts
@@ -53,6 +53,13 @@ export const SUPPORTED_EVENTS = [
 export const DUAL_OUTPUT_PROTOCOL_VERSION = 1;
 
 /**
+ * Maximum bytes buffered in the Node.js WriteStream before the bridge
+ * self-disables. Guards against unbounded memory growth when the output
+ * target is a FIFO opened with O_RDWR (no EPIPE on reader disconnect).
+ */
+const MAX_BUFFERED_BYTES = 1024 * 1024; // 1 MB
+
+/**
  * Optional metadata wired into the `session_start` capability handshake.
  */
 export interface DualOutputBridgeOptions {
@@ -117,9 +124,19 @@ export class DualOutputBridge {
         this.stream = createWriteStream('', { fd });
       } catch (err) {
         const code = (err as NodeJS.ErrnoException).code;
-        // ENXIO: FIFO has no reader yet — fall back to blocking open.
-        // ENOENT: regular file doesn't exist yet — create it.
-        if (code === 'ENXIO' || code === 'ENOENT') {
+        if (code === 'ENXIO') {
+          // FIFO with no reader connected yet. Use O_RDWR | O_NONBLOCK so
+          // the open returns immediately (POSIX: process is both reader and
+          // writer, satisfying the "at least one reader" requirement).
+          // Trade-off: EPIPE won't fire on reader disconnect; the bridge
+          // self-disables when the pipe buffer fills instead.
+          const fd = openSync(
+            target.filePath,
+            constants.O_RDWR | constants.O_NONBLOCK,
+          );
+          this.stream = createWriteStream('', { fd });
+        } else if (code === 'ENOENT') {
+          // Regular file doesn't exist yet — create it.
           this.stream = createWriteStream(target.filePath, { flags: 'w' });
         } else {
           throw err;
@@ -165,6 +182,7 @@ export class DualOutputBridge {
 
   processEvent(event: ServerGeminiStreamEvent): void {
     if (!this.active) return;
+    if (this.isBufferOverflowing()) return;
     try {
       this.adapter.processEvent(event);
     } catch (err) {
@@ -219,6 +237,17 @@ export class DualOutputBridge {
   /** Whether the underlying stream is still writable. */
   get isConnected(): boolean {
     return this.active;
+  }
+
+  private isBufferOverflowing(): boolean {
+    if (this.stream.writableLength > MAX_BUFFERED_BYTES) {
+      debugLogger.warn(
+        'DualOutput: buffered data exceeds limit, disabling (no consumer draining?)',
+      );
+      this.active = false;
+      return true;
+    }
+    return false;
   }
 
   /**


### PR DESCRIPTION
## What this PR does

Fixes the FIFO (named pipe) startup blocking issue in `DualOutputBridge`. When `--json-file` points to a FIFO with no reader connected, the bridge now opens it with `O_RDWR | O_NONBLOCK` instead of falling back to a blocking `createWriteStream`. Also adds a 1 MB buffer high-water-mark safety net that auto-disables the bridge if no consumer ever drains. Updates dual-output docs to recommend regular files in the Quick Start and document FIFOs as an advanced option.

## Why it's needed

Users launching `qwen --json-file <fifo> --input-file <fifo>` with `mkfifo`-created FIFOs found the TUI hanging indefinitely (#4727). The root cause: `DualOutputBridge`'s ENXIO fallback used `createWriteStream(path, {flags:'w'})` which calls `open(O_WRONLY)` on a FIFO — this blocks in the kernel until a reader connects, freezing the Node.js event loop and preventing the TUI from ever starting.

## Reviewer Test Plan

### How to verify

```bash
# Create a FIFO with no reader, launch qwen — TUI should start immediately
mkfifo /tmp/test-out.jsonl
touch /tmp/test-in.jsonl
qwen --json-file /tmp/test-out.jsonl --input-file /tmp/test-in.jsonl
# Expected: TUI starts in <1s (previously: hangs forever)
# In another terminal: cat /tmp/test-out.jsonl → see session_start event
```

### Evidence (Before & After)

**Before:** `qwen --json-file <fifo>` without a pre-connected reader blocks indefinitely (confirmed via Node.js reproduction — `createWriteStream` on FIFO hangs >3s until killed).

**After:** Constructor completes in ~3ms using `O_RDWR | O_NONBLOCK`. Events buffer in the kernel pipe until a reader attaches.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A (no FIFO support) |
|  🐧 Linux  |  ⚠️ not tested locally (same POSIX semantics as macOS) |

### Environment

Local runtime, manual Node.js scripts simulating `DualOutputBridge` constructor logic.

## Risk & Scope

- Main risk or tradeoff: With `O_RDWR`, EPIPE no longer fires when the reader disconnects (process is its own reader). Bridge self-disables via buffer overflow (1 MB limit) instead — slightly delayed but acceptable since the alternative was a completely broken startup.
- Not validated / out of scope: Performance under sustained high-throughput writes to FIFO without reader (edge case — bridge disables after ~1 MB).
- Breaking changes / migration notes: None. Behavior for regular files and FIFOs with a pre-connected reader is unchanged (first `O_WRONLY | O_NONBLOCK` attempt succeeds as before).

## Linked Issues

Fixes #4727

<details>
<summary>中文说明</summary>

修复 `DualOutputBridge` 在 FIFO（命名管道）上启动阻塞的问题。当 `--json-file` 指向一个没有 reader 连接的 FIFO 时，bridge 现在使用 `O_RDWR | O_NONBLOCK` 打开，而不是 fallback 到阻塞的 `createWriteStream`。

根因：`open(O_WRONLY)` 在 FIFO 上会阻塞直到有 reader 连接，冻结了 Node.js 事件循环，TUI 无法启动。

修复方案使用 POSIX 标准技巧：`O_RDWR` 使进程同时作为 reader 和 writer，内核的 "至少一个 reader" 条件自动满足，open 立即返回。额外增加了 1MB buffer 上限安全网，防止无 consumer 时内存无限增长。

同时更新了 dual-output 文档，Quick Start 改为推荐普通文件，FIFO 作为高级低延迟选项单独说明。

</details>