### PR TITLE
feat(core): persist file history snapshots for cross-session /rewind (T2.1)

### DIFF
--- a/integration-tests/cli/qwen-serve-routes.test.ts
+++ b/integration-tests/cli/qwen-serve-routes.test.ts
@@ -193,6 +193,7 @@ describe('qwen serve — capabilities envelope', () => {
       'session_create',
       'session_scope_override',
       'session_load',
+      'session_resume',
       'unstable_session_resume',
       'session_list',
       'session_prompt',

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -6763,6 +6763,12 @@ class QwenAgent implements Agent {
       // <available_skills> at cold start.
       buildDisabledSkillNamesProvider(this.settings),
     );
+    // ACP sessions run with piped stdio (non-TTY), so the default
+    // interactive-based gating disables file checkpointing. Enable it
+    // explicitly so /rewind works across daemon session resume.
+    if (typeof config.enableFileCheckpointing === 'function') {
+      config.enableFileCheckpointing();
+    }
     // Inject the workspace-shared MCP transport pool BEFORE
     // `config.initialize()` so the ToolRegistry picks it up.
     if (

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -308,7 +308,9 @@ describe('Session', () => {
         .mockReturnValue(mockBackgroundShellRegistry),
       getMonitorRegistry: vi.fn().mockReturnValue(mockMonitorRegistry),
       getFileHistoryService: vi.fn().mockReturnValue({
+        makeSnapshot: vi.fn().mockResolvedValue(undefined),
         getSnapshots: vi.fn().mockReturnValue([]),
+        rewind: vi.fn(),
       }),
     } as unknown as Config;
 

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -307,6 +307,9 @@ describe('Session', () => {
         .fn()
         .mockReturnValue(mockBackgroundShellRegistry),
       getMonitorRegistry: vi.fn().mockReturnValue(mockMonitorRegistry),
+      getFileHistoryService: vi.fn().mockReturnValue({
+        getSnapshots: vi.fn().mockReturnValue([]),
+      }),
     } as unknown as Config;
 
     mockClient = {

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -310,6 +310,7 @@ describe('Session', () => {
       getFileHistoryService: vi.fn().mockReturnValue({
         makeSnapshot: vi.fn().mockResolvedValue(undefined),
         getSnapshots: vi.fn().mockReturnValue([]),
+        restoreFromSnapshots: vi.fn(),
         rewind: vi.fn(),
       }),
     } as unknown as Config;

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -449,9 +449,11 @@ describe('Session', () => {
       expect(result).toEqual({ targetTurnIndex: 1, apiTruncateIndex: 2 });
       expect(mockChat.truncateHistory).toHaveBeenCalledWith(2);
       expect(mockChat.stripThoughtsFromHistory).toHaveBeenCalled();
-      expect(mockChatRecordingService.rewindRecording).toHaveBeenCalledWith(1, {
-        truncatedCount: 2,
-      });
+      expect(mockChatRecordingService.rewindRecording).toHaveBeenCalledWith(
+        1,
+        { truncatedCount: 2 },
+        [],
+      );
     });
 
     it('preserves startup context when rewinding to the first user turn', () => {

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -944,6 +944,27 @@ export class Session implements SessionContext {
         this.turn += 1;
 
         const promptId = this.config.getSessionId() + '########' + this.turn;
+
+        // Snapshot file state before this turn (mirrors client.ts:1488).
+        try {
+          await this.config.getFileHistoryService().makeSnapshot(promptId);
+          try {
+            const latestSnapshot = this.config
+              .getFileHistoryService()
+              .getSnapshots()
+              .at(-1);
+            if (latestSnapshot) {
+              this.config
+                .getChatRecordingService()
+                ?.recordFileHistorySnapshot(latestSnapshot);
+            }
+          } catch {
+            // Recording is best-effort
+          }
+        } catch {
+          // Snapshot is best-effort
+        }
+
         const parentContext = extractDaemonTraceContext(params);
 
         return await withInteractionSpan(

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -1059,10 +1059,10 @@ export class Session implements SessionContext {
               }
             }
 
-            // Snapshot file state before this turn (mirrors client.ts:1488).
-            // Placed after slash-command and hook early-returns so locally
-            // handled commands (e.g. /help) don't create phantom snapshots
-            // that would desync the snapshot index from the real turn count.
+            // Snapshot file state before this turn (mirrors the makeSnapshot
+            // block in GeminiClient.sendMessageStream). Placed after
+            // slash-command and hook early-returns so locally handled commands
+            // don't create phantom snapshots that desync the snapshot index.
             try {
               const fileHistoryService = this.config.getFileHistoryService();
               await fileHistoryService.makeSnapshot(promptId);

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -614,13 +614,14 @@ export class Session implements SessionContext {
     chat.truncateHistory(apiTruncateIndex);
     chat.stripThoughtsFromHistory();
 
-    this.config
-      .getChatRecordingService()
-      ?.rewindRecording(
-        targetTurnIndex,
-        { truncatedCount: Math.max(0, apiHistory.length - apiTruncateIndex) },
-        this.config.getFileHistoryService().getSnapshots(),
-      );
+    this.config.getChatRecordingService()?.rewindRecording(
+      targetTurnIndex,
+      { truncatedCount: Math.max(0, apiHistory.length - apiTruncateIndex) },
+      this.config
+        .getFileHistoryService()
+        .getSnapshots()
+        .slice(0, targetTurnIndex + 1),
+    );
 
     return { targetTurnIndex, apiTruncateIndex };
   }

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -944,27 +944,6 @@ export class Session implements SessionContext {
         this.turn += 1;
 
         const promptId = this.config.getSessionId() + '########' + this.turn;
-
-        // Snapshot file state before this turn (mirrors client.ts:1488).
-        try {
-          await this.config.getFileHistoryService().makeSnapshot(promptId);
-          try {
-            const latestSnapshot = this.config
-              .getFileHistoryService()
-              .getSnapshots()
-              .at(-1);
-            if (latestSnapshot) {
-              this.config
-                .getChatRecordingService()
-                ?.recordFileHistorySnapshot(latestSnapshot);
-            }
-          } catch (e) {
-            debugLogger.error(`FileHistory: recordSnapshot failed: ${e}`);
-          }
-        } catch (e) {
-          debugLogger.error(`FileHistory: makeSnapshot failed: ${e}`);
-        }
-
         const parentContext = extractDaemonTraceContext(params);
 
         return await withInteractionSpan(
@@ -1078,6 +1057,27 @@ export class Session implements SessionContext {
               if (additionalContext) {
                 parts = [...parts, { text: additionalContext }];
               }
+            }
+
+            // Snapshot file state before this turn (mirrors client.ts:1488).
+            // Placed after slash-command and hook early-returns so locally
+            // handled commands (e.g. /help) don't create phantom snapshots
+            // that would desync the snapshot index from the real turn count.
+            try {
+              const fileHistoryService = this.config.getFileHistoryService();
+              await fileHistoryService.makeSnapshot(promptId);
+              try {
+                const latestSnapshot = fileHistoryService.getSnapshots().at(-1);
+                if (latestSnapshot) {
+                  this.config
+                    .getChatRecordingService()
+                    ?.recordFileHistorySnapshot(latestSnapshot);
+                }
+              } catch (e) {
+                debugLogger.error(`FileHistory: recordSnapshot failed: ${e}`);
+              }
+            } catch (e) {
+              debugLogger.error(`FileHistory: makeSnapshot failed: ${e}`);
             }
 
             // Prepend session-level system reminders (plan mode / subagent /

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -614,9 +614,13 @@ export class Session implements SessionContext {
     chat.truncateHistory(apiTruncateIndex);
     chat.stripThoughtsFromHistory();
 
-    this.config.getChatRecordingService()?.rewindRecording(targetTurnIndex, {
-      truncatedCount: Math.max(0, apiHistory.length - apiTruncateIndex),
-    });
+    this.config
+      .getChatRecordingService()
+      ?.rewindRecording(
+        targetTurnIndex,
+        { truncatedCount: Math.max(0, apiHistory.length - apiTruncateIndex) },
+        this.config.getFileHistoryService().getSnapshots(),
+      );
 
     return { targetTurnIndex, apiTruncateIndex };
   }

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -958,11 +958,11 @@ export class Session implements SessionContext {
                 .getChatRecordingService()
                 ?.recordFileHistorySnapshot(latestSnapshot);
             }
-          } catch {
-            // Recording is best-effort
+          } catch (e) {
+            debugLogger.error(`FileHistory: recordSnapshot failed: ${e}`);
           }
-        } catch {
-          // Snapshot is best-effort
+        } catch (e) {
+          debugLogger.error(`FileHistory: makeSnapshot failed: ${e}`);
         }
 
         const parentContext = extractDaemonTraceContext(params);

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -614,14 +614,20 @@ export class Session implements SessionContext {
     chat.truncateHistory(apiTruncateIndex);
     chat.stripThoughtsFromHistory();
 
-    this.config.getChatRecordingService()?.rewindRecording(
-      targetTurnIndex,
-      { truncatedCount: Math.max(0, apiHistory.length - apiTruncateIndex) },
-      this.config
-        .getFileHistoryService()
-        .getSnapshots()
-        .slice(0, targetTurnIndex + 1),
-    );
+    const fileHistoryService = this.config.getFileHistoryService();
+    const survivingSnapshots = fileHistoryService
+      .getSnapshots()
+      .slice(0, targetTurnIndex + 1);
+
+    fileHistoryService.restoreFromSnapshots(survivingSnapshots);
+
+    this.config
+      .getChatRecordingService()
+      ?.rewindRecording(
+        targetTurnIndex,
+        { truncatedCount: Math.max(0, apiHistory.length - apiTruncateIndex) },
+        survivingSnapshots,
+      );
 
     return { targetTurnIndex, apiTruncateIndex };
   }

--- a/packages/cli/src/serve/capabilities.ts
+++ b/packages/cli/src/serve/capabilities.ts
@@ -35,9 +35,9 @@ export const SERVE_CAPABILITY_REGISTRY = {
   session_create: { since: 'v1' },
   session_scope_override: { since: 'v1' },
   session_load: { since: 'v1' },
-  // ACP backs this with `connection.unstable_resumeSession`. Surface
-  // the unstable prefix so clients don't pin against a `v1` shape that
-  // the underlying ACP method may still change.
+  session_resume: { since: 'v1' },
+  // Deprecated alias — kept until @agentclientprotocol/sdk graduates
+  // the underlying ACP method from unstable_resumeSession to resumeSession.
   unstable_session_resume: { since: 'v1' },
   session_list: { since: 'v1' },
   session_prompt: { since: 'v1' },

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -107,6 +107,7 @@ const EXPECTED_STAGE1_FEATURES = [
   'session_create',
   'session_scope_override',
   'session_load',
+  'session_resume',
   'unstable_session_resume',
   'session_list',
   'session_prompt',

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -441,7 +441,11 @@ export const AppContainer = (props: AppContainerProps) => {
   );
 
   // Additional hooks moved from App.tsx
-  const { stats: sessionStats, startNewSession } = useSessionStats();
+  const {
+    stats: sessionStats,
+    startNewSession,
+    seedPromptCount,
+  } = useSessionStats();
   const logger = useLogger(config.storage, sessionStats.sessionId);
   const branchName = useGitBranchName(config.getTargetDir());
   const worktreeSession = useWorktreeSession(config);
@@ -548,6 +552,15 @@ export const AppContainer = (props: AppContainerProps) => {
           config,
         );
         historyManager.loadHistory(historyItems);
+
+        // Seed the prompt counter from the resumed conversation so new
+        // promptIds don't collide with restored file history snapshots.
+        const userTurnCount = resumedSessionData.conversation.messages.filter(
+          (m) => m.type === 'user' && m.subtype !== 'mid_turn_user_message',
+        ).length;
+        if (userTurnCount > 0) {
+          seedPromptCount(userTurnCount);
+        }
 
         // Re-arm any `/goal` that was active when the prior session ended.
         try {

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -2627,7 +2627,9 @@ export const AppContainer = (props: AppContainerProps) => {
             ?.rewindRecording(
               targetTurnIndex,
               { truncatedCount: originalLength - truncatedUi.length },
-              config.getFileHistoryService().getSnapshots(),
+              !hasRestoreFailure
+                ? config.getFileHistoryService().getSnapshots()
+                : undefined,
             );
         }
 

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -2622,9 +2622,13 @@ export const AppContainer = (props: AppContainerProps) => {
             Date.now(),
           );
 
-          config.getChatRecordingService()?.rewindRecording(targetTurnIndex, {
-            truncatedCount: originalLength - truncatedUi.length,
-          });
+          config
+            .getChatRecordingService()
+            ?.rewindRecording(
+              targetTurnIndex,
+              { truncatedCount: originalLength - truncatedUi.length },
+              config.getFileHistoryService().getSnapshots(),
+            );
         }
 
         // Show file restore result after conversation truncation so the

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -2622,15 +2622,16 @@ export const AppContainer = (props: AppContainerProps) => {
             Date.now(),
           );
 
-          config
-            .getChatRecordingService()
-            ?.rewindRecording(
-              targetTurnIndex,
-              { truncatedCount: originalLength - truncatedUi.length },
-              !hasRestoreFailure
-                ? config.getFileHistoryService().getSnapshots()
-                : undefined,
-            );
+          config.getChatRecordingService()?.rewindRecording(
+            targetTurnIndex,
+            { truncatedCount: originalLength - truncatedUi.length },
+            !hasRestoreFailure
+              ? config
+                  .getFileHistoryService()
+                  .getSnapshots()
+                  .slice(0, targetTurnIndex + 1)
+              : undefined,
+          );
         }
 
         // Show file restore result after conversation truncation so the

--- a/packages/cli/src/ui/contexts/SessionContext.tsx
+++ b/packages/cli/src/ui/contexts/SessionContext.tsx
@@ -191,6 +191,7 @@ interface SessionStatsContextValue {
   startNewSession: (sessionId: string) => void;
   startNewPrompt: () => void;
   getPromptCount: () => number;
+  seedPromptCount: (count: number) => void;
 }
 
 // --- Context Definition ---
@@ -271,14 +272,22 @@ export const SessionStatsProvider: React.FC<{
     [stats.promptCount],
   );
 
+  const seedPromptCount = useCallback((count: number) => {
+    setStats((prevState) => ({
+      ...prevState,
+      promptCount: Math.max(prevState.promptCount, count),
+    }));
+  }, []);
+
   const value = useMemo(
     () => ({
       stats,
       startNewSession,
       startNewPrompt,
       getPromptCount,
+      seedPromptCount,
     }),
-    [stats, startNewSession, startNewPrompt, getPromptCount],
+    [stats, startNewSession, startNewPrompt, getPromptCount, seedPromptCount],
   );
 
   return (

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -3606,6 +3606,7 @@ export class Config {
 
   enableFileCheckpointing(): void {
     this.fileCheckpointingEnabled = true;
+    this.fileHistoryService = undefined;
   }
 
   getFileHistoryService(): FileHistoryService {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1151,7 +1151,7 @@ export class Config {
   private fileDiscoveryService: FileDiscoveryService | null = null;
   private sessionService: SessionService | undefined = undefined;
   private chatRecordingService: ChatRecordingService | undefined = undefined;
-  private readonly fileCheckpointingEnabled: boolean;
+  private fileCheckpointingEnabled: boolean;
   private fileHistoryService: FileHistoryService | undefined;
   private readonly proxy: string | undefined;
   private readonly cwd: string;
@@ -3602,6 +3602,10 @@ export class Config {
 
   getFileCheckpointingEnabled(): boolean {
     return this.fileCheckpointingEnabled;
+  }
+
+  enableFileCheckpointing(): void {
+    this.fileCheckpointingEnabled = true;
   }
 
   getFileHistoryService(): FileHistoryService {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -3612,7 +3612,7 @@ export class Config {
         this.cwd,
       );
       const snapshots = this.sessionData?.fileHistorySnapshots;
-      if (snapshots?.length) {
+      if (snapshots?.length && this.fileHistoryService.isEnabled()) {
         this.fileHistoryService.restoreFromSnapshots(snapshots);
         void this.fileHistoryService.validateRestoredSnapshots().catch((e) => {
           this.debugLogger.error(

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -3611,6 +3611,15 @@ export class Config {
         this.fileCheckpointingEnabled,
         this.cwd,
       );
+      const snapshots = this.sessionData?.fileHistorySnapshots;
+      if (snapshots?.length) {
+        this.fileHistoryService.restoreFromSnapshots(snapshots);
+        void this.fileHistoryService.validateRestoredSnapshots().catch((e) => {
+          this.debugLogger.error(
+            `FileHistory: validateRestoredSnapshots failed: ${e}`,
+          );
+        });
+      }
     }
     return this.fileHistoryService;
   }

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -1661,6 +1661,19 @@ export class GeminiClient {
         if (messageType === SendMessageType.UserQuery) {
           try {
             await this.config.getFileHistoryService().makeSnapshot(prompt_id);
+            try {
+              const latestSnapshot = this.config
+                .getFileHistoryService()
+                .getSnapshots()
+                .at(-1);
+              if (latestSnapshot) {
+                this.config
+                  .getChatRecordingService()
+                  ?.recordFileHistorySnapshot(latestSnapshot);
+              }
+            } catch (e) {
+              debugLogger.error(`FileHistory: recordSnapshot failed: ${e}`);
+            }
           } catch (e) {
             debugLogger.error(`FileHistory: makeSnapshot failed: ${e}`);
           }

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -1373,17 +1373,7 @@ export class ChatRecordingService {
   }
 
   recordFileHistorySnapshot(snapshot: FileHistorySnapshot): void {
-    try {
-      const record: ChatRecord = {
-        ...this.createBaseRecord('system'),
-        type: 'system',
-        subtype: 'file_history_snapshot',
-        systemPayload: { snapshots: [serializeSnapshot(snapshot)] },
-      };
-      this.appendRecord(record);
-    } catch (error) {
-      debugLogger.error('Error saving file history snapshot:', error);
-    }
+    this.recordFileHistorySnapshotBatch([snapshot]);
   }
 
   recordFileHistorySnapshotBatch(snapshots: FileHistorySnapshot[]): void {

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -28,6 +28,11 @@ import type {
 import type { Status } from '../core/coreToolScheduler.js';
 import type { AgentResultDisplay, FileDiff } from '../tools/tools.js';
 import type { UiEvent } from '../telemetry/uiTelemetry.js';
+import type {
+  FileHistorySnapshot,
+  SerializedFileHistorySnapshot,
+} from './fileHistoryService.js';
+import { serializeSnapshot } from './fileHistoryService.js';
 
 const debugLogger = createDebugLogger('CHAT_RECORDING');
 
@@ -235,7 +240,8 @@ export interface ChatRecord {
     | 'custom_title'
     | 'rewind'
     | 'agent_bootstrap'
-    | 'agent_launch_prompt';
+    | 'agent_launch_prompt'
+    | 'file_history_snapshot';
   /** Working directory at time of message */
   cwd: string;
   /** CLI version for compatibility tracking */
@@ -281,7 +287,8 @@ export interface ChatRecord {
     | CustomTitleRecordPayload
     | NotificationRecordPayload
     | RewindRecordPayload
-    | AgentBootstrapRecordPayload;
+    | AgentBootstrapRecordPayload
+    | FileHistorySnapshotRecordPayload;
 
   /** Background subagent that produced this record (e.g. "explore-7f3c"). */
   agentId?: string;
@@ -426,6 +433,14 @@ export interface AttributionSnapshotPayload {
 export interface RewindRecordPayload {
   /** Number of UI history items truncated. */
   truncatedCount: number;
+}
+
+/**
+ * Stored payload for file history snapshot persistence.
+ * Each entry records one or more snapshots for session resume.
+ */
+export interface FileHistorySnapshotRecordPayload {
+  snapshots: SerializedFileHistorySnapshot[];
 }
 
 /**
@@ -1140,7 +1155,11 @@ export class ChatRecordingService {
    *   nothing before it), 1 means keep the first user turn, etc.
    * @param payload Additional metadata to persist with the rewind record.
    */
-  rewindRecording(targetTurnIndex: number, payload: RewindRecordPayload): void {
+  rewindRecording(
+    targetTurnIndex: number,
+    payload: RewindRecordPayload,
+    survivingFileHistorySnapshots?: FileHistorySnapshot[],
+  ): void {
     try {
       // Re-root: point back to the record just before the target user turn.
       this.lastRecordUuid = this.turnParentUuids[targetTurnIndex] ?? null;
@@ -1161,6 +1180,12 @@ export class ChatRecordingService {
       };
 
       this.appendRecord(record);
+
+      // Re-record surviving file history snapshots on the active branch so
+      // they are visible to reconstructHistory on resume.
+      if (survivingFileHistorySnapshots?.length) {
+        this.recordFileHistorySnapshotBatch(survivingFileHistorySnapshots);
+      }
     } catch (error) {
       debugLogger.error('Error saving rewind record:', error);
     }
@@ -1344,6 +1369,35 @@ export class ChatRecordingService {
         this.lastAttributionSnapshotJson = undefined;
       }
       debugLogger.error('Error saving attribution snapshot:', error);
+    }
+  }
+
+  recordFileHistorySnapshot(snapshot: FileHistorySnapshot): void {
+    try {
+      const record: ChatRecord = {
+        ...this.createBaseRecord('system'),
+        type: 'system',
+        subtype: 'file_history_snapshot',
+        systemPayload: { snapshots: [serializeSnapshot(snapshot)] },
+      };
+      this.appendRecord(record);
+    } catch (error) {
+      debugLogger.error('Error saving file history snapshot:', error);
+    }
+  }
+
+  recordFileHistorySnapshotBatch(snapshots: FileHistorySnapshot[]): void {
+    if (snapshots.length === 0) return;
+    try {
+      const record: ChatRecord = {
+        ...this.createBaseRecord('system'),
+        type: 'system',
+        subtype: 'file_history_snapshot',
+        systemPayload: { snapshots: snapshots.map(serializeSnapshot) },
+      };
+      this.appendRecord(record);
+    } catch (error) {
+      debugLogger.error('Error saving file history snapshot batch:', error);
     }
   }
 }

--- a/packages/core/src/services/fileHistoryService.ts
+++ b/packages/core/src/services/fileHistoryService.ts
@@ -98,8 +98,70 @@ export interface TurnDiff {
   };
 }
 
-const MAX_SNAPSHOTS = 100;
+export const MAX_SNAPSHOTS = 100;
 export const FILE_HISTORY_DIR = 'file-history';
+
+// ---------------------------------------------------------------------------
+// Serialization types for JSONL persistence
+// ---------------------------------------------------------------------------
+
+export interface SerializedFileHistorySnapshot {
+  promptId: string;
+  trackedFileBackups: Record<string, SerializedFileHistoryBackup>;
+  timestamp: string;
+}
+
+export interface SerializedFileHistoryBackup {
+  backupFileName: string | null;
+  version: number;
+  backupTime: string;
+  failed?: boolean;
+}
+
+export function serializeSnapshot(
+  s: FileHistorySnapshot,
+): SerializedFileHistorySnapshot {
+  return {
+    promptId: s.promptId,
+    timestamp: s.timestamp.toISOString(),
+    trackedFileBackups: Object.fromEntries(
+      Object.entries(s.trackedFileBackups).map(([path, backup]) => [
+        path,
+        {
+          backupFileName: backup.backupFileName,
+          version: backup.version,
+          backupTime: backup.backupTime.toISOString(),
+          failed: backup.failed || undefined,
+        },
+      ]),
+    ),
+  };
+}
+
+function safeParseDate(iso: string): Date {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? new Date(0) : d;
+}
+
+export function deserializeSnapshots(
+  arr: SerializedFileHistorySnapshot[],
+): FileHistorySnapshot[] {
+  return arr.map((s) => ({
+    promptId: s.promptId,
+    timestamp: safeParseDate(s.timestamp),
+    trackedFileBackups: Object.fromEntries(
+      Object.entries(s.trackedFileBackups).map(([path, backup]) => [
+        path,
+        {
+          backupFileName: backup.backupFileName,
+          version: backup.version,
+          backupTime: safeParseDate(backup.backupTime),
+          failed: backup.failed,
+        },
+      ]),
+    ),
+  }));
+}
 /** Per-turn read-fanout cap. Each candidate file may read up to two backups,
  *  so 500 files ≈ 1000 concurrent opens — safely under the typical 4096 fd
  *  ceiling and well below `ulimit -n` defaults on Linux/macOS. */
@@ -519,6 +581,52 @@ export class FileHistoryService {
       snapshots: migrated,
       trackedFiles,
     };
+  }
+
+  async validateRestoredSnapshots(): Promise<void> {
+    // Collect unique backup file names to stat (dedup: many snapshots share
+    // the same backup file via the inheritance optimization in makeSnapshot).
+    const uniqueNames = new Set<string>();
+    for (const snapshot of this.state.snapshots) {
+      for (const backup of Object.values(snapshot.trackedFileBackups)) {
+        if (backup.backupFileName !== null && !backup.failed) {
+          uniqueNames.add(backup.backupFileName);
+        }
+      }
+    }
+    if (uniqueNames.size === 0) return;
+
+    // Parallel stat with bounded concurrency to avoid fd exhaustion.
+    const BATCH_SIZE = 200;
+    const missing = new Set<string>();
+    const names = [...uniqueNames];
+    for (let i = 0; i < names.length; i += BATCH_SIZE) {
+      const batch = names.slice(i, i + BATCH_SIZE);
+      const results = await Promise.all(
+        batch.map((name) =>
+          pathExists(resolveBackupPath(name, this.sessionId)),
+        ),
+      );
+      for (let j = 0; j < batch.length; j++) {
+        if (!results[j]) missing.add(batch[j]);
+      }
+    }
+
+    if (missing.size === 0) return;
+
+    // Single synchronous pass to mark failures — minimizes the mutation
+    // window so concurrent makeSnapshot/trackEdit see a consistent state.
+    for (const snapshot of this.state.snapshots) {
+      for (const backup of Object.values(snapshot.trackedFileBackups)) {
+        if (backup.backupFileName && missing.has(backup.backupFileName)) {
+          backup.failed = true;
+        }
+      }
+    }
+
+    debugLogger.warn(
+      `FileHistory: ${missing.size} restored backup file(s) missing on disk`,
+    );
   }
 
   async trackEdit(filePath: string): Promise<void> {

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -787,7 +787,10 @@ export class SessionService {
         let deserialized: FileHistorySnapshot[];
         try {
           deserialized = deserializeSnapshots(payload.snapshots);
-        } catch {
+        } catch (e) {
+          debugLogger.warn(
+            `loadSession: skipping malformed file_history_snapshot: ${e}`,
+          );
           continue;
         }
         for (const s of deserialized) {

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -166,18 +166,6 @@ const MAX_PROMPT_SCAN_LINES = 10;
  */
 const TAIL_READ_SIZE = 64 * 1024;
 
-/**
- * Service for managing chat sessions.
- *
- * This service handles:
- * - Listing sessions with pagination (ordered by mtime)
- * - Loading full session data for resumption
- * - Removing sessions
- *
- * Sessions are stored as JSONL files, one per session.
- * File location: ~/.qwen/tmp/<project_id>/chats/
- */
-
 async function copyFileHistoryBackups(
   sourceSessionId: string,
   targetSessionId: string,
@@ -229,6 +217,17 @@ async function copyFileHistoryBackups(
   );
 }
 
+/**
+ * Service for managing chat sessions.
+ *
+ * This service handles:
+ * - Listing sessions with pagination (ordered by mtime)
+ * - Loading full session data for resumption
+ * - Removing sessions
+ *
+ * Sessions are stored as JSONL files, one per session.
+ * File location: ~/.qwen/tmp/<project_id>/chats/
+ */
 export class SessionService {
   private readonly storage: Storage;
   private readonly projectHash: string;

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -204,7 +204,12 @@ async function copyFileHistoryBackups(
   }
   if (entries.length === 0) return;
 
-  await fsPromises.mkdir(targetDir, { recursive: true });
+  try {
+    await fsPromises.mkdir(targetDir, { recursive: true });
+  } catch (e) {
+    debugLogger.warn(`copyFileHistoryBackups: mkdir failed: ${e}`);
+    return;
+  }
   await Promise.all(
     entries.map(async (name) => {
       const src = path.join(sourceDir, name);
@@ -781,8 +786,7 @@ export class SessionService {
         msg.subtype === 'file_history_snapshot' &&
         msg.systemPayload
       ) {
-        const payload =
-          msg.systemPayload as unknown as FileHistorySnapshotRecordPayload;
+        const payload = msg.systemPayload as FileHistorySnapshotRecordPayload;
         if (!Array.isArray(payload?.snapshots)) continue;
         let deserialized: FileHistorySnapshot[];
         try {

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -15,9 +15,16 @@ import * as jsonl from '../utils/jsonl-utils.js';
 import type {
   ChatCompressionRecordPayload,
   ChatRecord,
+  FileHistorySnapshotRecordPayload,
   TitleSource,
   UiTelemetryRecordPayload,
 } from './chatRecordingService.js';
+import type { FileHistorySnapshot } from './fileHistoryService.js';
+import {
+  deserializeSnapshots,
+  FILE_HISTORY_DIR,
+  MAX_SNAPSHOTS,
+} from './fileHistoryService.js';
 import { uiTelemetryService } from '../telemetry/uiTelemetry.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import {
@@ -129,6 +136,8 @@ export interface ResumedSessionData {
   filePath: string;
   /** UUID of the last completed message - new messages should use this as parentUuid */
   lastCompletedUuid: string | null;
+  /** Deserialized file history snapshots for resume (enables /rewind across sessions) */
+  fileHistorySnapshots?: FileHistorySnapshot[];
 }
 
 /**
@@ -168,6 +177,53 @@ const TAIL_READ_SIZE = 64 * 1024;
  * Sessions are stored as JSONL files, one per session.
  * File location: ~/.qwen/tmp/<project_id>/chats/
  */
+
+async function copyFileHistoryBackups(
+  sourceSessionId: string,
+  targetSessionId: string,
+): Promise<void> {
+  const fsPromises = await import('node:fs/promises');
+  const sourceDir = path.join(
+    Storage.getGlobalQwenDir(),
+    FILE_HISTORY_DIR,
+    sourceSessionId,
+  );
+  const targetDir = path.join(
+    Storage.getGlobalQwenDir(),
+    FILE_HISTORY_DIR,
+    targetSessionId,
+  );
+
+  let entries: string[];
+  try {
+    entries = await fsPromises.readdir(sourceDir);
+  } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') return;
+    debugLogger.warn(`copyFileHistoryBackups: readdir failed: ${e}`);
+    return;
+  }
+  if (entries.length === 0) return;
+
+  await fsPromises.mkdir(targetDir, { recursive: true });
+  await Promise.all(
+    entries.map(async (name) => {
+      const src = path.join(sourceDir, name);
+      const dst = path.join(targetDir, name);
+      try {
+        await fsPromises.link(src, dst);
+      } catch {
+        try {
+          await fsPromises.copyFile(src, dst);
+        } catch (copyErr) {
+          debugLogger.warn(
+            `copyFileHistoryBackups: failed to copy ${name}: ${copyErr}`,
+          );
+        }
+      }
+    }),
+  );
+}
+
 export class SessionService {
   private readonly storage: Storage;
   private readonly projectHash: string;
@@ -716,10 +772,43 @@ export class SessionService {
       messages,
     };
 
+    // Extract file history snapshots for /rewind across resume
+    const fileHistorySnapshots: FileHistorySnapshot[] = [];
+    const seenPromptIds = new Set<string>();
+    for (const msg of messages) {
+      if (
+        msg.type === 'system' &&
+        msg.subtype === 'file_history_snapshot' &&
+        msg.systemPayload
+      ) {
+        const payload =
+          msg.systemPayload as unknown as FileHistorySnapshotRecordPayload;
+        if (!Array.isArray(payload?.snapshots)) continue;
+        let deserialized: FileHistorySnapshot[];
+        try {
+          deserialized = deserializeSnapshots(payload.snapshots);
+        } catch {
+          continue;
+        }
+        for (const s of deserialized) {
+          if (!seenPromptIds.has(s.promptId)) {
+            seenPromptIds.add(s.promptId);
+            fileHistorySnapshots.push(s);
+          }
+        }
+      }
+    }
+    const cappedSnapshots =
+      fileHistorySnapshots.length > MAX_SNAPSHOTS
+        ? fileHistorySnapshots.slice(-MAX_SNAPSHOTS)
+        : fileHistorySnapshots;
+
     return {
       conversation,
       filePath,
       lastCompletedUuid: lastMessage.uuid,
+      fileHistorySnapshots:
+        cappedSnapshots.length > 0 ? cappedSnapshots : undefined,
     };
   }
 
@@ -947,6 +1036,8 @@ export class SessionService {
     } finally {
       fs.closeSync(fd);
     }
+
+    await copyFileHistoryBackups(sourceSessionId, newSessionId);
 
     return { filePath: targetPath, copiedCount: forked.length };
   }

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -774,7 +774,7 @@ export class SessionService {
 
     // Extract file history snapshots for /rewind across resume
     const fileHistorySnapshots: FileHistorySnapshot[] = [];
-    const seenPromptIds = new Set<string>();
+    const seenPromptIds = new Map<string, number>();
     for (const msg of messages) {
       if (
         msg.type === 'system' &&
@@ -791,8 +791,11 @@ export class SessionService {
           continue;
         }
         for (const s of deserialized) {
-          if (!seenPromptIds.has(s.promptId)) {
-            seenPromptIds.add(s.promptId);
+          const existingIdx = seenPromptIds.get(s.promptId);
+          if (existingIdx !== undefined) {
+            fileHistorySnapshots[existingIdx] = s;
+          } else {
+            seenPromptIds.set(s.promptId, fileHistorySnapshots.length);
             fileHistorySnapshots.push(s);
           }
         }


### PR DESCRIPTION
## What this PR does

Persists `FileHistorySnapshot` to JSONL as `file_history_snapshot` system records, enabling `/rewind` to work across session resume. Previously, file history snapshots were purely in-memory and lost on process exit.

## Why it's needed

T2.1 (`loadSession`/`resume` graduation from `unstable_`) is blocked because `/rewind` doesn't work after session resume — the snapshot chain is empty. This PR closes that gap, making the resume feature reliable enough to drop the `unstable_` prefix.

Replaces the stalled PR #4253 with a fresh implementation.

## Key changes

- Serialize/deserialize `FileHistorySnapshot` to/from JSONL system records
- Record each snapshot after `makeSnapshot` succeeds (incremental per turn)
- Re-record surviving snapshots after rewind (full batch on active branch)
- Parse `file_history_snapshot` records in `sessionService.loadSession()`
- Restore snapshot chain in `config.getFileHistoryService()` on resume
- Copy backup files on session fork (hard link with copy fallback)
- Add `session_resume` capability tag (stable alias for `unstable_session_resume`)
- `validateRestoredSnapshots` with dedup + batched parallel stat
- `enableFileCheckpointing()` in Config — daemon/ACP sessions run with piped stdin (non-TTY), so `fileCheckpointingEnabled` defaulted to `false`; explicitly enabled via `acpAgent.newSessionConfig`
- `seedPromptCount()` in SessionContext — on TUI `--continue` resume, the prompt counter restarted at 0, causing promptId collisions with pre-resume turns; now seeded from resumed conversation user turn count
- ACP `Session.prompt` now calls `makeSnapshot` + `recordFileHistorySnapshot` — daemon-created sessions previously never produced file history snapshots

## Risk & Scope

**Main risk**: Last turn's snapshot may be incomplete (serialized before `trackEdit` mutates it). Self-healing for all but the very last turn before exit.

**Out of scope** (follow-up):
1. Turn-end recording hook (last-turn completeness — move recording from turn-start to turn-end)
2. Fork `promptId` rewriting (forked snapshots carry source session's promptId prefix)

**Breaking changes**: None. Old sessions without `file_history_snapshot` records resume normally (graceful degradation).

## Linked Issues

- Closes the file-history persistence gap in issue #4514 T2.1
- Replaces stalled PR #4253

## Reviewer Test Plan

### How to verify

```bash
# 1. Type-check
npx tsc --noEmit --project packages/core/tsconfig.json

# 2. Unit tests
npx vitest run packages/core/src/services/fileHistoryService.test.ts
npx vitest run packages/core/src/services/sessionService.test.ts

# 3. Capability tag test
npx vitest run packages/cli/src/serve/server.test.ts

# 4. Integration test
npx vitest run integration-tests/cli/qwen-serve-routes.test.ts

# 5. Manual E2E (daemon path):
#    a. Start daemon: qwen serve
#    b. Create session, edit a file via prompt
#    c. Exit daemon
#    d. Resume same session
#    e. /rewind to pre-resume turn → verify file restored

# 6. Manual E2E (TUI --continue path):
#    a. qwen — edit a file, exit
#    b. qwen --continue — verify /rewind works for pre-resume turns
#    c. Verify promptId counter doesn't collide (no duplicate snapshot promptIds in JSONL)
```

### Tested on

| OS | Version | Status |
|----|---------|--------|
| macOS | 15.4 (Darwin 25.4.0) | tsc pass, pre-commit pass |

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

将 `FileHistorySnapshot` 持久化到 JSONL 的 `file_history_snapshot` 系统记录中，使 `/rewind` 能跨 session resume 工作。此前快照完全在内存中，进程退出即丢失。

## 为什么需要

T2.1（`loadSession`/`resume` 从 `unstable_` 毕业）被阻塞，因为 resume 后 `/rewind` 不工作——快照链为空。本 PR 修复了这个核心差距。

替代已停滞 3 周的 PR #4253。

## 主要变更

- 快照序列化/反序列化到 JSONL 系统记录
- `makeSnapshot` 成功后录制快照（增量写入）
- rewind 后重新录制存活快照（全量写入活跃分支）
- `loadSession` 解析 `file_history_snapshot` 记录并恢复快照链
- Fork 时硬链接复制备份文件
- 新增 `session_resume` 稳定 capability tag
- `validateRestoredSnapshots` 去重 + 批量并行 stat
- `enableFileCheckpointing()` — 修复 daemon/ACP 会话因 piped stdin 导致文件检查点被禁用的问题
- `seedPromptCount()` — 修复 TUI `--continue` 恢复后 promptId 计数器归零导致的冲突
- ACP `Session.prompt` 新增 `makeSnapshot` 调用 — 修复 daemon 创建的会话从不产生快照的问题

## 已知限制（后续 PR）

1. 最后一个 turn 的快照可能不完整（录制在 turn 开始而非结束时）
2. Fork 时 snapshot 的 `promptId` 包含源 session ID，可能导致不匹配

</details>

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)