### PR TITLE
[codex] Clean permission policy schema copy

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1882,7 +1882,7 @@ const SETTINGS_SCHEMA = {
           '`designated` = only the prompt originator decides; falls back to ' +
           'first-responder if originator is anonymous. ' +
           'NOTE: client identity comes from self-declared X-Qwen-Client-Id ' +
-          'with no proof-of-possession (pair-token mechanism is a future PR), ' +
+          'with no proof-of-possession (pair-token identity is not implemented yet), ' +
           'so any client observing originatorClientId on SSE frames can ' +
           'register with the same id and impersonate the originator. ' +
           '`consensus` = N-of-M voters must agree. Default N=floor(M/2)+1, ' +

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -864,7 +864,7 @@
       "type": "object",
       "properties": {
         "permissionStrategy": {
-          "description": "How permission requests resolve when multiple clients are attached. `first-responder` (default) = any client decides, first wins. `designated` = only the prompt originator decides; falls back to first-responder if originator is anonymous. NOTE: client identity comes from self-declared X-Qwen-Client-Id with no proof-of-possession (pair-token mechanism is a future PR), so any client observing originatorClientId on SSE frames can register with the same id and impersonate the originator. `consensus` = N-of-M voters must agree. Default N=floor(M/2)+1, which means UNANIMITY for M=2 (quorum=2, both must agree) and supermajority for larger even M (M=4 → quorum=3; M=6 → quorum=4). For M=2 specifically, split votes resolve only via permissionTimeoutMs. `local-only` = only loopback clients can RESOLVE; remote clients can still ABORT a pending permission via the cancel sentinel ({outcome:\"cancelled\"}) — F3 v1 keeps cancel cross-policy for consistency. Strict-cancel-too deployments need a dedicated loopback-bound daemon. Requires daemon restart — F3 v1 reads this once at boot. Options: first-responder, designated, consensus, local-only",
+          "description": "How permission requests resolve when multiple clients are attached. `first-responder` (default) = any client decides, first wins. `designated` = only the prompt originator decides; falls back to first-responder if originator is anonymous. NOTE: client identity comes from self-declared X-Qwen-Client-Id with no proof-of-possession (pair-token identity is not implemented yet), so any client observing originatorClientId on SSE frames can register with the same id and impersonate the originator. `consensus` = N-of-M voters must agree. Default N=floor(M/2)+1, which means UNANIMITY for M=2 (quorum=2, both must agree) and supermajority for larger even M (M=4 → quorum=3; M=6 → quorum=4). For M=2 specifically, split votes resolve only via permissionTimeoutMs. `local-only` = only loopback clients can RESOLVE; remote clients can still ABORT a pending permission via the cancel sentinel ({outcome:\"cancelled\"}) — cancel stays cross-policy for consistency. Strict-cancel-too deployments need a dedicated loopback-bound daemon. Requires daemon restart — read once at boot. Options: first-responder, designated, consensus, local-only",
           "enum": [
             "first-responder",
             "designated",
@@ -876,7 +876,7 @@
         "consensusQuorum": {
           "type": "integer",
           "minimum": 1,
-          "description": "Optional fixed quorum size for consensus policy. Capped at M (count of registered voters at request issue time) to prevent unreachable quorum. Unset = floor(M/2)+1. Requires daemon restart — F3 v1 reads this once at boot."
+          "description": "Optional fixed quorum size for consensus policy. Capped at M (count of registered voters at request issue time) to prevent unreachable quorum. Unset = floor(M/2)+1. Requires daemon restart — read once at boot."
         }
       }
     },


### PR DESCRIPTION
## What this PR does

Cleans up the permission mediation settings copy so user-facing schema text describes the behavior directly instead of exposing internal rollout labels or PR-planning language. The generated VS Code settings schema is refreshed from the source schema so editor IntelliSense matches the current wording.

## Why it's needed

The generated schema still contained stale text such as “F3 v1 keeps…” and “F3 v1 reads…”, while the source schema had already moved to clearer wording. A related source description also referred to a “future PR”, which leaks implementation planning language into user-visible settings documentation.

## Reviewer Test Plan

### How to verify

Inspect the permission mediation policy descriptions in the settings schema and confirm they no longer mention internal F3 rollout labels or future PR planning. Confirm the generated schema mirrors the source schema wording.

### Evidence (Before & After)

Before: the generated settings schema described local-only cancellation as “F3 v1 keeps cancel cross-policy for consistency” and restart behavior as “F3 v1 reads this once at boot”. After: the text now says cancellation “stays cross-policy for consistency” and settings are “read once at boot”; pair-token identity is described as not implemented yet rather than as a future PR.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Local repository validation on macOS.

## Risk & Scope

- Main risk or tradeoff: Low; this is wording-only schema documentation cleanup.
- Not validated / out of scope: Full build and typecheck were not run because no executable behavior changed.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

清理权限协调相关 settings schema 文案，让用户可见的 schema 直接描述行为本身，而不是暴露内部 rollout 标签或 PR 规划用语。同时重新生成 VS Code settings schema，保证编辑器 IntelliSense 和源 schema 文案一致。

## 为什么需要

生成后的 schema 仍然残留 “F3 v1 keeps…” 和 “F3 v1 reads…” 这类旧文案，而源 schema 已经改成更清晰的描述。源 schema 里还存在 “future PR” 这样的规划用语，会泄漏到用户可见的 settings 文档里。

## Reviewer Test Plan

### How to verify

检查权限协调策略的 settings schema 描述，确认不再出现内部 F3 rollout 标签或 future PR 规划用语。确认生成 schema 和源 schema 文案一致。

### Evidence (Before & After)

Before：生成 schema 用 “F3 v1 keeps cancel cross-policy for consistency” 描述 local-only cancellation，并用 “F3 v1 reads this once at boot” 描述重启生效行为。After：文案改为 cancellation “stays cross-policy for consistency”，设置 “read once at boot”；pair-token identity 也改为描述尚未实现，而不是 future PR。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

macOS 本地仓库验证。

## Risk & Scope

- Main risk or tradeoff: 风险低，仅清理 schema 文案。
- Not validated / out of scope: 未跑完整 build 和 typecheck，因为没有执行行为变化。
- Breaking changes / migration notes: 无。

## Linked Issues

N/A

</details>