### PR TITLE
feat(serve): add cursor-based pagination for session list

### DIFF
--- a/packages/cli/src/serve/acpHttp/dispatch.ts
+++ b/packages/cli/src/serve/acpHttp/dispatch.ts
@@ -676,10 +676,15 @@ export class AcpDispatcher {
         case 'session/list': {
           const cursor =
             typeof params['cursor'] === 'string' ? params['cursor'] : undefined;
+          const meta = isObject(params['_meta']) ? params['_meta'] : undefined;
+          const metaSize =
+            typeof meta?.['size'] === 'number'
+              ? (meta['size'] as number)
+              : undefined;
           const result = await listWorkspaceSessionsForResponse(
             this.bridge,
             this.boundWorkspace,
-            { cursor },
+            { cursor, size: metaSize },
           );
           this.replyConn(conn, id, {
             sessions: result.sessions.map((s) => ({

--- a/packages/cli/src/serve/acpHttp/dispatch.ts
+++ b/packages/cli/src/serve/acpHttp/dispatch.ts
@@ -202,7 +202,7 @@ function toRpcError(err: unknown): {
   message: string;
   data?: Record<string, unknown>;
 } {
-  if (err instanceof AcpParamError) {
+  if (err instanceof AcpParamError || err instanceof InvalidCursorError) {
     return { code: RPC.INVALID_PARAMS, message: err.message };
   }
   if (err instanceof SubagentError) {

--- a/packages/cli/src/serve/acpHttp/dispatch.ts
+++ b/packages/cli/src/serve/acpHttp/dispatch.ts
@@ -688,7 +688,9 @@ export class AcpDispatcher {
               title: s.title,
               updatedAt: s.updatedAt,
             })),
-            ...(result.nextCursor ? { nextCursor: result.nextCursor } : {}),
+            ...(result.nextCursor != null
+              ? { nextCursor: result.nextCursor }
+              : {}),
           });
           return;
         }

--- a/packages/cli/src/serve/acpHttp/dispatch.ts
+++ b/packages/cli/src/serve/acpHttp/dispatch.ts
@@ -35,6 +35,10 @@ import {
   toSummary as agentToSummary,
   toDetail as agentToDetail,
 } from '../workspaceAgents.js';
+import {
+  InvalidCursorError,
+  listWorkspaceSessionsForResponse,
+} from '../server.js';
 import type {
   DaemonWorkspaceService,
   WorkspaceRequestContext,
@@ -670,10 +674,22 @@ export class AcpDispatcher {
         }
 
         case 'session/list': {
-          const sessions = this.bridge.listWorkspaceSessions(
+          const cursor =
+            typeof params['cursor'] === 'string' ? params['cursor'] : undefined;
+          const result = await listWorkspaceSessionsForResponse(
+            this.bridge,
             this.boundWorkspace,
+            { cursor },
           );
-          this.replyConn(conn, id, { sessions });
+          this.replyConn(conn, id, {
+            sessions: result.sessions.map((s) => ({
+              sessionId: s.sessionId,
+              cwd: s.workspaceCwd,
+              title: s.title,
+              updatedAt: s.updatedAt,
+            })),
+            ...(result.nextCursor ? { nextCursor: result.nextCursor } : {}),
+          });
           return;
         }
 

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -2980,7 +2980,7 @@ describe('createServeApp', () => {
           },
         ]),
       );
-      expect(bridge.listCalls).toEqual([WS_BOUND]);
+      expect(bridge.listCalls).toEqual([WS_BOUND, WS_BOUND]);
     });
 
     it('includes persisted sessions from the CLI session store', async () => {
@@ -3044,7 +3044,7 @@ describe('createServeApp', () => {
           }),
         ]),
       );
-      expect(bridge.listCalls).toEqual([WS_BOUND]);
+      expect(bridge.listCalls).toEqual([WS_BOUND, WS_BOUND]);
     });
 
     it('preserves persisted createdAt when a live entry exists', async () => {
@@ -3224,6 +3224,76 @@ describe('createServeApp', () => {
         (s: { sessionId: string }) => s.sessionId,
       );
       expect(cursoredIds).not.toContain('live-only');
+    });
+
+    it('400 invalid_cursor when cursor is not a valid number', async () => {
+      const bridge = fakeBridge();
+      const app = createServeApp(
+        { ...baseOpts, workspace: WS_BOUND },
+        undefined,
+        { bridge, boundWorkspace: WS_BOUND },
+      );
+      const res = await request(app)
+        .get(`/workspace/${encodeURIComponent(WS_BOUND)}/sessions?cursor=abc`)
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('invalid_cursor');
+    });
+
+    it('excludes live sessions from subsequent pages to prevent cross-page duplicates', async () => {
+      const liveId = '550e8400-e29b-41d4-a716-446655440099';
+      for (let i = 0; i < 5; i++) {
+        const id =
+          i === 2
+            ? liveId
+            : `550e8400-e29b-41d4-a716-44665544${String(i).padStart(4, '0')}`;
+        await writeStoredSession({
+          sessionId: id,
+          cwd: WS_BOUND,
+          timestamp: `2026-05-17T12:0${i}:00.000Z`,
+          prompt: `prompt ${i}`,
+          mtime: new Date(`2026-05-17T12:1${i}:00.000Z`),
+        });
+      }
+      const bridge = fakeBridge({
+        listImpl: () => [
+          {
+            sessionId: liveId,
+            workspaceCwd: WS_BOUND,
+            createdAt: '2026-05-17T12:02:00.000Z',
+            updatedAt: '2026-05-17T12:50:00.000Z',
+            clientCount: 1,
+            hasActivePrompt: false,
+          },
+        ],
+      });
+      const app = createServeApp(
+        { ...baseOpts, workspace: WS_BOUND },
+        undefined,
+        { bridge, boundWorkspace: WS_BOUND },
+      );
+
+      const page1 = await request(app)
+        .get(`/workspace/${encodeURIComponent(WS_BOUND)}/sessions?size=3`)
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+      expect(page1.status).toBe(200);
+      const page1Ids = page1.body.sessions.map(
+        (s: { sessionId: string }) => s.sessionId,
+      );
+
+      const page2 = await request(app)
+        .get(
+          `/workspace/${encodeURIComponent(WS_BOUND)}/sessions?size=3&cursor=${page1.body.nextCursor}`,
+        )
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+      expect(page2.status).toBe(200);
+      const page2Ids = page2.body.sessions.map(
+        (s: { sessionId: string }) => s.sessionId,
+      );
+
+      const allIds = [...page1Ids, ...page2Ids];
+      const uniqueIds = new Set(allIds);
+      expect(uniqueIds.size).toBe(allIds.length);
     });
 
     it('400 workspace_mismatch when querying a cross-workspace path (#3803 §02)', async () => {

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -2980,7 +2980,7 @@ describe('createServeApp', () => {
           },
         ]),
       );
-      expect(bridge.listCalls).toEqual([WS_BOUND, WS_BOUND]);
+      expect(bridge.listCalls).toEqual([WS_BOUND]);
     });
 
     it('includes persisted sessions from the CLI session store', async () => {
@@ -3044,7 +3044,7 @@ describe('createServeApp', () => {
           }),
         ]),
       );
-      expect(bridge.listCalls).toEqual([WS_BOUND, WS_BOUND]);
+      expect(bridge.listCalls).toEqual([WS_BOUND]);
     });
 
     it('preserves persisted createdAt when a live entry exists', async () => {

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -3101,7 +3101,131 @@ describe('createServeApp', () => {
         .get(`/workspace/${encodeURIComponent(WS_BOUND)}/sessions`)
         .set('Host', `127.0.0.1:${baseOpts.port}`);
       expect(res.status).toBe(200);
-      expect(res.body).toEqual({ sessions: [] });
+      expect(res.body).toEqual({ sessions: [], hasMore: false });
+    });
+
+    it('returns nextCursor and hasMore when more persisted sessions exist', async () => {
+      const pageSize = 3;
+      const total = 5;
+      for (let i = 0; i < total; i++) {
+        const id = `550e8400-e29b-41d4-a716-44665544${String(i).padStart(4, '0')}`;
+        await writeStoredSession({
+          sessionId: id,
+          cwd: WS_BOUND,
+          timestamp: `2026-05-17T12:0${i}:00.000Z`,
+          prompt: `prompt ${i}`,
+          mtime: new Date(`2026-05-17T12:1${i}:00.000Z`),
+        });
+      }
+      const bridge = fakeBridge();
+      const app = createServeApp(
+        { ...baseOpts, workspace: WS_BOUND },
+        undefined,
+        { bridge, boundWorkspace: WS_BOUND },
+      );
+
+      const res = await request(app)
+        .get(
+          `/workspace/${encodeURIComponent(WS_BOUND)}/sessions?size=${pageSize}`,
+        )
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+      expect(res.status).toBe(200);
+      expect(res.body.sessions).toHaveLength(pageSize);
+      expect(res.body.hasMore).toBe(true);
+      expect(res.body.nextCursor).toBeDefined();
+    });
+
+    it('paginates with cursor query param', async () => {
+      const total = 5;
+      for (let i = 0; i < total; i++) {
+        const id = `550e8400-e29b-41d4-a716-44665544${String(i).padStart(4, '0')}`;
+        await writeStoredSession({
+          sessionId: id,
+          cwd: WS_BOUND,
+          timestamp: `2026-05-17T12:0${i}:00.000Z`,
+          prompt: `prompt ${i}`,
+          mtime: new Date(`2026-05-17T12:1${i}:00.000Z`),
+        });
+      }
+      const bridge = fakeBridge();
+      const app = createServeApp(
+        { ...baseOpts, workspace: WS_BOUND },
+        undefined,
+        { bridge, boundWorkspace: WS_BOUND },
+      );
+
+      const page1 = await request(app)
+        .get(`/workspace/${encodeURIComponent(WS_BOUND)}/sessions?size=3`)
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+      expect(page1.status).toBe(200);
+      expect(page1.body.sessions).toHaveLength(3);
+      expect(page1.body.hasMore).toBe(true);
+
+      const page2 = await request(app)
+        .get(
+          `/workspace/${encodeURIComponent(WS_BOUND)}/sessions?size=3&cursor=${page1.body.nextCursor}`,
+        )
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+      expect(page2.status).toBe(200);
+      expect(page2.body.sessions).toHaveLength(2);
+      expect(page2.body.hasMore).toBe(false);
+      expect(page2.body.nextCursor).toBeUndefined();
+
+      const page1Ids = page1.body.sessions.map(
+        (s: { sessionId: string }) => s.sessionId,
+      );
+      const page2Ids = page2.body.sessions.map(
+        (s: { sessionId: string }) => s.sessionId,
+      );
+      const overlap = page1Ids.filter((id: string) => page2Ids.includes(id));
+      expect(overlap).toHaveLength(0);
+    });
+
+    it('merges live sessions only on first page (no cursor)', async () => {
+      const storedId = '550e8400-e29b-41d4-a716-446655440000';
+      await writeStoredSession({
+        sessionId: storedId,
+        cwd: WS_BOUND,
+        timestamp: '2026-05-17T12:00:00.000Z',
+        prompt: 'stored prompt',
+        mtime: new Date('2026-05-17T12:10:00.000Z'),
+      });
+      const bridge = fakeBridge({
+        listImpl: () => [
+          {
+            sessionId: 'live-only',
+            workspaceCwd: WS_BOUND,
+            createdAt: '2026-05-17T12:30:00.000Z',
+            clientCount: 1,
+            hasActivePrompt: true,
+          },
+        ],
+      });
+      const app = createServeApp(
+        { ...baseOpts, workspace: WS_BOUND },
+        undefined,
+        { bridge, boundWorkspace: WS_BOUND },
+      );
+
+      const firstPage = await request(app)
+        .get(`/workspace/${encodeURIComponent(WS_BOUND)}/sessions`)
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+      expect(firstPage.status).toBe(200);
+      const ids = firstPage.body.sessions.map(
+        (s: { sessionId: string }) => s.sessionId,
+      );
+      expect(ids).toContain('live-only');
+
+      const cursoredPage = await request(app)
+        .get(
+          `/workspace/${encodeURIComponent(WS_BOUND)}/sessions?cursor=${String(Date.now() + 100000)}`,
+        )
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+      expect(cursoredPage.status).toBe(200);
+      const cursoredIds = cursoredPage.body.sessions.map(
+        (s: { sessionId: string }) => s.sessionId,
+      );
+      expect(cursoredIds).not.toContain('live-only');
     });
 
     it('400 workspace_mismatch when querying a cross-workspace path (#3803 §02)', async () => {

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -3101,10 +3101,10 @@ describe('createServeApp', () => {
         .get(`/workspace/${encodeURIComponent(WS_BOUND)}/sessions`)
         .set('Host', `127.0.0.1:${baseOpts.port}`);
       expect(res.status).toBe(200);
-      expect(res.body).toEqual({ sessions: [], hasMore: false });
+      expect(res.body).toEqual({ sessions: [] });
     });
 
-    it('returns nextCursor and hasMore when more persisted sessions exist', async () => {
+    it('returns nextCursor when more persisted sessions exist', async () => {
       const pageSize = 3;
       const total = 5;
       for (let i = 0; i < total; i++) {
@@ -3131,7 +3131,6 @@ describe('createServeApp', () => {
         .set('Host', `127.0.0.1:${baseOpts.port}`);
       expect(res.status).toBe(200);
       expect(res.body.sessions).toHaveLength(pageSize);
-      expect(res.body.hasMore).toBe(true);
       expect(res.body.nextCursor).toBeDefined();
     });
 
@@ -3159,7 +3158,7 @@ describe('createServeApp', () => {
         .set('Host', `127.0.0.1:${baseOpts.port}`);
       expect(page1.status).toBe(200);
       expect(page1.body.sessions).toHaveLength(3);
-      expect(page1.body.hasMore).toBe(true);
+      expect(page1.body.nextCursor).toBeDefined();
 
       const page2 = await request(app)
         .get(
@@ -3168,7 +3167,6 @@ describe('createServeApp', () => {
         .set('Host', `127.0.0.1:${baseOpts.port}`);
       expect(page2.status).toBe(200);
       expect(page2.body.sessions).toHaveLength(2);
-      expect(page2.body.hasMore).toBe(false);
       expect(page2.body.nextCursor).toBeUndefined();
 
       const page1Ids = page1.body.sessions.map(

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -3296,6 +3296,45 @@ describe('createServeApp', () => {
       expect(uniqueIds.size).toBe(allIds.length);
     });
 
+    it('clamps size=0 to 1', async () => {
+      const id = '550e8400-e29b-41d4-a716-446655440000';
+      await writeStoredSession({
+        sessionId: id,
+        cwd: WS_BOUND,
+        timestamp: '2026-05-17T12:00:00.000Z',
+        prompt: 'prompt',
+        mtime: new Date('2026-05-17T12:10:00.000Z'),
+      });
+      const bridge = fakeBridge();
+      const app = createServeApp(
+        { ...baseOpts, workspace: WS_BOUND },
+        undefined,
+        { bridge, boundWorkspace: WS_BOUND },
+      );
+      const res = await request(app)
+        .get(
+          `/workspace/${encodeURIComponent(WS_BOUND)}/sessions?size=0`,
+        )
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+      expect(res.status).toBe(200);
+      expect(res.body.sessions).toHaveLength(1);
+    });
+
+    it('clamps size=200 to max page size', async () => {
+      const bridge = fakeBridge();
+      const app = createServeApp(
+        { ...baseOpts, workspace: WS_BOUND },
+        undefined,
+        { bridge, boundWorkspace: WS_BOUND },
+      );
+      const res = await request(app)
+        .get(
+          `/workspace/${encodeURIComponent(WS_BOUND)}/sessions?size=200`,
+        )
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+      expect(res.status).toBe(200);
+    });
+
     it('400 workspace_mismatch when querying a cross-workspace path (#3803 §02)', async () => {
       // Pin the §02 cross-workspace rejection: querying any path
       // that doesn't canonicalize to the bound workspace gets a 400

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -199,7 +199,11 @@ export async function listWorkspaceSessionsForResponse(
     Math.max(options?.size ?? DEFAULT_SESSION_PAGE_SIZE, 1),
     MAX_SESSION_PAGE_SIZE,
   );
-  const numericCursor = options?.cursor ? Number(options.cursor) : undefined;
+  const rawCursor = options?.cursor ? Number(options.cursor) : undefined;
+  const numericCursor =
+    rawCursor !== undefined && Number.isFinite(rawCursor)
+      ? rawCursor
+      : undefined;
 
   const persisted = await new SessionService(workspaceCwd).listSessions({
     cursor: numericCursor,
@@ -242,7 +246,8 @@ export async function listWorkspaceSessionsForResponse(
 
   return {
     sessions,
-    nextCursor: persisted.nextCursor ? String(persisted.nextCursor) : undefined,
+    nextCursor:
+      persisted.nextCursor != null ? String(persisted.nextCursor) : undefined,
   };
 }
 

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -188,7 +188,13 @@ export interface ListWorkspaceSessionsOptions {
 export interface ListWorkspaceSessionsResult {
   sessions: BridgeSessionSummary[];
   nextCursor?: string;
-  liveMergedIds?: Set<string>;
+}
+
+export class InvalidCursorError extends Error {
+  constructor(cursor: string) {
+    super(`Invalid cursor: "${cursor}" is not a valid numeric cursor`);
+    this.name = 'InvalidCursorError';
+  }
 }
 
 export async function listWorkspaceSessionsForResponse(
@@ -200,11 +206,15 @@ export async function listWorkspaceSessionsForResponse(
     Math.max(options?.size ?? DEFAULT_SESSION_PAGE_SIZE, 1),
     MAX_SESSION_PAGE_SIZE,
   );
-  const rawCursor = options?.cursor ? Number(options.cursor) : undefined;
-  const numericCursor =
-    rawCursor !== undefined && Number.isFinite(rawCursor)
-      ? rawCursor
-      : undefined;
+
+  let numericCursor: number | undefined;
+  if (options?.cursor) {
+    const parsed = Number(options.cursor);
+    if (!Number.isFinite(parsed)) {
+      throw new InvalidCursorError(options.cursor);
+    }
+    numericCursor = parsed;
+  }
   const isFirstPage = numericCursor === undefined;
 
   const persisted = await new SessionService(workspaceCwd).listSessions({
@@ -213,7 +223,12 @@ export async function listWorkspaceSessionsForResponse(
   });
   const bySessionId = new Map<string, BridgeSessionSummary>();
 
+  const liveSessionIds = new Set(
+    bridge.listWorkspaceSessions(workspaceCwd).map((s) => s.sessionId),
+  );
+
   for (const item of persisted.items) {
+    if (!isFirstPage && liveSessionIds.has(item.sessionId)) continue;
     bySessionId.set(item.sessionId, {
       sessionId: item.sessionId,
       workspaceCwd: item.cwd,
@@ -225,11 +240,9 @@ export async function listWorkspaceSessionsForResponse(
     });
   }
 
-  const liveMergedIds = new Set<string>();
   if (isFirstPage) {
     for (const live of bridge.listWorkspaceSessions(workspaceCwd)) {
       const existing = bySessionId.get(live.sessionId);
-      if (!existing) liveMergedIds.add(live.sessionId);
       bySessionId.set(live.sessionId, {
         ...existing,
         ...live,
@@ -258,11 +271,7 @@ export async function listWorkspaceSessionsForResponse(
     nextCursor = String(persisted.nextCursor);
   }
 
-  return {
-    sessions,
-    nextCursor,
-    liveMergedIds: liveMergedIds.size > 0 ? liveMergedIds : undefined,
-  };
+  return { sessions, nextCursor };
 }
 
 export interface ServeAppDeps {
@@ -2046,6 +2055,13 @@ export function createServeApp(
         ...(result.nextCursor != null ? { nextCursor: result.nextCursor } : {}),
       });
     } catch (err) {
+      if (err instanceof InvalidCursorError) {
+        res.status(400).json({
+          error: err.message,
+          code: 'invalid_cursor',
+        });
+        return;
+      }
       writeStderrLine(
         `qwen serve: failed to list sessions for workspace ${safeLogValue(
           key,

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -177,14 +177,34 @@ export function resolveBridgeFsFactory(input: {
   });
 }
 
-const WORKSPACE_SESSION_LIST_SIZE = 100;
+const DEFAULT_SESSION_PAGE_SIZE = 20;
+const MAX_SESSION_PAGE_SIZE = 100;
 
-async function listWorkspaceSessionsForResponse(
+export interface ListWorkspaceSessionsOptions {
+  cursor?: string;
+  size?: number;
+}
+
+export interface ListWorkspaceSessionsResult {
+  sessions: BridgeSessionSummary[];
+  nextCursor?: string;
+  hasMore: boolean;
+}
+
+export async function listWorkspaceSessionsForResponse(
   bridge: AcpSessionBridge,
   workspaceCwd: string,
-): Promise<BridgeSessionSummary[]> {
+  options?: ListWorkspaceSessionsOptions,
+): Promise<ListWorkspaceSessionsResult> {
+  const pageSize = Math.min(
+    Math.max(options?.size ?? DEFAULT_SESSION_PAGE_SIZE, 1),
+    MAX_SESSION_PAGE_SIZE,
+  );
+  const numericCursor = options?.cursor ? Number(options.cursor) : undefined;
+
   const persisted = await new SessionService(workspaceCwd).listSessions({
-    size: WORKSPACE_SESSION_LIST_SIZE,
+    cursor: numericCursor,
+    size: pageSize,
   });
   const bySessionId = new Map<string, BridgeSessionSummary>();
 
@@ -200,24 +220,32 @@ async function listWorkspaceSessionsForResponse(
     });
   }
 
-  for (const live of bridge.listWorkspaceSessions(workspaceCwd)) {
-    const existing = bySessionId.get(live.sessionId);
-    bySessionId.set(live.sessionId, {
-      ...existing,
-      ...live,
-      createdAt: existing?.createdAt ?? live.createdAt,
-      title: live.title ?? existing?.title,
-      updatedAt: live.updatedAt ?? existing?.updatedAt,
-      clientCount: live.clientCount,
-      hasActivePrompt: live.hasActivePrompt,
-    });
+  if (!options?.cursor) {
+    for (const live of bridge.listWorkspaceSessions(workspaceCwd)) {
+      const existing = bySessionId.get(live.sessionId);
+      bySessionId.set(live.sessionId, {
+        ...existing,
+        ...live,
+        createdAt: existing?.createdAt ?? live.createdAt,
+        title: live.title ?? existing?.title,
+        updatedAt: live.updatedAt ?? existing?.updatedAt,
+        clientCount: live.clientCount,
+        hasActivePrompt: live.hasActivePrompt,
+      });
+    }
   }
 
-  return [...bySessionId.values()].sort((a, b) => {
+  const sessions = [...bySessionId.values()].sort((a, b) => {
     const aTime = Date.parse(a.updatedAt ?? a.createdAt);
     const bTime = Date.parse(b.updatedAt ?? b.createdAt);
     return bTime - aTime;
   });
+
+  return {
+    sessions,
+    nextCursor: persisted.nextCursor ? String(persisted.nextCursor) : undefined,
+    hasMore: persisted.hasMore,
+  };
 }
 
 export interface ServeAppDeps {
@@ -1985,8 +2013,18 @@ export function createServeApp(
       return;
     }
     try {
-      const sessions = await listWorkspaceSessionsForResponse(bridge, key);
-      res.status(200).json({ sessions });
+      const cursor =
+        typeof req.query['cursor'] === 'string'
+          ? req.query['cursor']
+          : undefined;
+      const sizeParam = req.query['size'];
+      const size =
+        typeof sizeParam === 'string' ? parseInt(sizeParam, 10) : undefined;
+      const result = await listWorkspaceSessionsForResponse(bridge, key, {
+        cursor,
+        size: Number.isFinite(size) ? size : undefined,
+      });
+      res.status(200).json(result);
     } catch (err) {
       writeStderrLine(
         `qwen serve: failed to list sessions for workspace ${safeLogValue(

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -223,12 +223,7 @@ export async function listWorkspaceSessionsForResponse(
   });
   const bySessionId = new Map<string, BridgeSessionSummary>();
 
-  const liveSessionIds = new Set(
-    bridge.listWorkspaceSessions(workspaceCwd).map((s) => s.sessionId),
-  );
-
   for (const item of persisted.items) {
-    if (!isFirstPage && liveSessionIds.has(item.sessionId)) continue;
     bySessionId.set(item.sessionId, {
       sessionId: item.sessionId,
       workspaceCwd: item.cwd,
@@ -240,19 +235,19 @@ export async function listWorkspaceSessionsForResponse(
     });
   }
 
-  if (isFirstPage) {
-    for (const live of bridge.listWorkspaceSessions(workspaceCwd)) {
-      const existing = bySessionId.get(live.sessionId);
-      bySessionId.set(live.sessionId, {
-        ...existing,
-        ...live,
-        createdAt: existing?.createdAt ?? live.createdAt,
-        title: live.title ?? existing?.title,
-        updatedAt: live.updatedAt ?? existing?.updatedAt,
-        clientCount: live.clientCount,
-        hasActivePrompt: live.hasActivePrompt,
-      });
-    }
+  const liveSessions = bridge.listWorkspaceSessions(workspaceCwd);
+  for (const live of liveSessions) {
+    const existing = bySessionId.get(live.sessionId);
+    if (!existing && !isFirstPage) continue;
+    bySessionId.set(live.sessionId, {
+      ...existing,
+      ...live,
+      createdAt: existing?.createdAt ?? live.createdAt,
+      title: live.title ?? existing?.title,
+      updatedAt: live.updatedAt ?? existing?.updatedAt,
+      clientCount: live.clientCount,
+      hasActivePrompt: live.hasActivePrompt,
+    });
   }
 
   const sorted = [...bySessionId.values()].sort((a, b) => {

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -217,7 +217,8 @@ export async function listWorkspaceSessionsForResponse(
   }
   const isFirstPage = numericCursor === undefined;
 
-  const persisted = await new SessionService(workspaceCwd).listSessions({
+  const sessionService = new SessionService(workspaceCwd);
+  const persisted = await sessionService.listSessions({
     cursor: numericCursor,
     size: pageSize,
   });
@@ -238,33 +239,39 @@ export async function listWorkspaceSessionsForResponse(
   const liveSessions = bridge.listWorkspaceSessions(workspaceCwd);
   for (const live of liveSessions) {
     const existing = bySessionId.get(live.sessionId);
-    if (!existing && !isFirstPage) continue;
-    bySessionId.set(live.sessionId, {
-      ...existing,
-      ...live,
-      createdAt: existing?.createdAt ?? live.createdAt,
-      title: live.title ?? existing?.title,
-      updatedAt: live.updatedAt ?? existing?.updatedAt,
-      clientCount: live.clientCount,
-      hasActivePrompt: live.hasActivePrompt,
-    });
+    if (existing) {
+      bySessionId.set(live.sessionId, {
+        ...existing,
+        ...live,
+        createdAt: existing.createdAt,
+        title: live.title ?? existing.title,
+        updatedAt: live.updatedAt ?? existing.updatedAt,
+        clientCount: live.clientCount,
+        hasActivePrompt: live.hasActivePrompt,
+      });
+    } else if (
+      isFirstPage &&
+      !(await sessionService.sessionExists(live.sessionId))
+    ) {
+      bySessionId.set(live.sessionId, {
+        ...live,
+        createdAt: live.createdAt,
+        clientCount: live.clientCount,
+        hasActivePrompt: live.hasActivePrompt,
+      });
+    }
   }
 
-  const sorted = [...bySessionId.values()].sort((a, b) => {
+  const sessions = [...bySessionId.values()].sort((a, b) => {
     const aTime = Date.parse(a.updatedAt ?? a.createdAt);
     const bTime = Date.parse(b.updatedAt ?? b.createdAt);
     return bTime - aTime;
   });
-  const sessions = sorted.slice(0, pageSize);
-  const hasExcess = sorted.length > pageSize;
 
-  let nextCursor: string | undefined;
-  if (hasExcess) {
-    const last = sessions[sessions.length - 1];
-    nextCursor = String(Date.parse(last?.updatedAt ?? last?.createdAt));
-  } else if (persisted.nextCursor != null) {
-    nextCursor = String(persisted.nextCursor);
-  }
+  const nextCursor =
+    persisted.nextCursor != null
+      ? String(persisted.nextCursor)
+      : undefined;
 
   return { sessions, nextCursor };
 }

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -188,6 +188,7 @@ export interface ListWorkspaceSessionsOptions {
 export interface ListWorkspaceSessionsResult {
   sessions: BridgeSessionSummary[];
   nextCursor?: string;
+  liveMergedIds?: Set<string>;
 }
 
 export async function listWorkspaceSessionsForResponse(
@@ -204,6 +205,7 @@ export async function listWorkspaceSessionsForResponse(
     rawCursor !== undefined && Number.isFinite(rawCursor)
       ? rawCursor
       : undefined;
+  const isFirstPage = numericCursor === undefined;
 
   const persisted = await new SessionService(workspaceCwd).listSessions({
     cursor: numericCursor,
@@ -223,9 +225,11 @@ export async function listWorkspaceSessionsForResponse(
     });
   }
 
-  if (!options?.cursor) {
+  const liveMergedIds = new Set<string>();
+  if (isFirstPage) {
     for (const live of bridge.listWorkspaceSessions(workspaceCwd)) {
       const existing = bySessionId.get(live.sessionId);
+      if (!existing) liveMergedIds.add(live.sessionId);
       bySessionId.set(live.sessionId, {
         ...existing,
         ...live,
@@ -238,16 +242,26 @@ export async function listWorkspaceSessionsForResponse(
     }
   }
 
-  const sessions = [...bySessionId.values()].sort((a, b) => {
+  const sorted = [...bySessionId.values()].sort((a, b) => {
     const aTime = Date.parse(a.updatedAt ?? a.createdAt);
     const bTime = Date.parse(b.updatedAt ?? b.createdAt);
     return bTime - aTime;
   });
+  const sessions = sorted.slice(0, pageSize);
+  const hasExcess = sorted.length > pageSize;
+
+  let nextCursor: string | undefined;
+  if (hasExcess) {
+    const last = sessions[sessions.length - 1];
+    nextCursor = String(Date.parse(last?.updatedAt ?? last?.createdAt));
+  } else if (persisted.nextCursor != null) {
+    nextCursor = String(persisted.nextCursor);
+  }
 
   return {
     sessions,
-    nextCursor:
-      persisted.nextCursor != null ? String(persisted.nextCursor) : undefined,
+    nextCursor,
+    liveMergedIds: liveMergedIds.size > 0 ? liveMergedIds : undefined,
   };
 }
 
@@ -2027,7 +2041,10 @@ export function createServeApp(
         cursor,
         size: Number.isFinite(size) ? size : undefined,
       });
-      res.status(200).json(result);
+      res.status(200).json({
+        sessions: result.sessions,
+        ...(result.nextCursor != null ? { nextCursor: result.nextCursor } : {}),
+      });
     } catch (err) {
       writeStderrLine(
         `qwen serve: failed to list sessions for workspace ${safeLogValue(

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -188,7 +188,6 @@ export interface ListWorkspaceSessionsOptions {
 export interface ListWorkspaceSessionsResult {
   sessions: BridgeSessionSummary[];
   nextCursor?: string;
-  hasMore: boolean;
 }
 
 export async function listWorkspaceSessionsForResponse(
@@ -244,7 +243,6 @@ export async function listWorkspaceSessionsForResponse(
   return {
     sessions,
     nextCursor: persisted.nextCursor ? String(persisted.nextCursor) : undefined,
-    hasMore: persisted.hasMore,
   };
 }
 


### PR DESCRIPTION
## What this PR does

Wire cursor-based pagination through REST and ACP HTTP transport layers for session listing. REST `GET /workspace/:id/sessions` now accepts `?cursor=<mtime>&size=<n>` query params. ACP HTTP dispatch `session/list` now reads `params.cursor` and returns `nextCursor` per ACP protocol spec. Live (in-memory) sessions are merged only on the first page (no cursor), since they are always the most recent. Default page size is 20, max 100. Response uses `nextCursor` only (no `hasMore`), aligned with ACP `ListSessionsResponse` standard.

## Why it's needed

The ACP protocol defines cursor/nextCursor on `ListSessionsRequest`/`ListSessionsResponse`, and the internal `SessionService.listSessions` already supports cursor-based pagination. However neither the REST endpoint nor the ACP HTTP dispatch previously exposed pagination to clients — REST hardcoded a cap of 100 and the ACP dispatch only returned live in-memory sessions. As sessions accumulate, returning all results in a single response becomes a scalability issue and blocks UI virtual-scrolling / lazy-load patterns.

## Reviewer Test Plan

### How to verify

1. Start the daemon, create several sessions in a workspace
2. `curl /workspace/<encoded-cwd>/sessions?size=2` — verify response contains at most 2 sessions and a `nextCursor` field
3. `curl /workspace/<encoded-cwd>/sessions?cursor=<nextCursor>&size=2` — verify second page returns remaining sessions with no `nextCursor`
4. Confirm no overlap between pages
5. Run `npx vitest run packages/cli/src/serve/server.test.ts -t "GET /workspace"` — all 18 tests pass

### Evidence (Before & After)

N/A — non-UI change (REST/ACP API surface). Unit tests cover pagination behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Local `npx vitest run` for unit tests.

## Risk & Scope

- Main risk or tradeoff: REST response shape changes from `{ sessions }` to `{ sessions, nextCursor? }` — additive, backward compatible. Clients that ignore `nextCursor` still work but only see the first page (default 20 items).
- Not validated / out of scope: Web Shell UI integration with pagination (follow-up). ACP dispatch test coverage (transport.test.ts tests are pre-existing skipped).
- Breaking changes / migration notes: None. The `nextCursor` field is optional and additive.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

为 session 列表的 REST 和 ACP HTTP 传输层接入游标分页。REST `GET /workspace/:id/sessions` 现在接受 `?cursor=<mtime>&size=<n>` 查询参数。ACP HTTP dispatch 的 `session/list` 现在读取 `params.cursor` 并按 ACP 协议规范返回 `nextCursor`。活跃（内存中）session 仅在首页（无 cursor）时合并，因为它们总是最新的。默认每页 20 条，最大 100 条。响应仅使用 `nextCursor`（无 `hasMore`），与 ACP `ListSessionsResponse` 标准对齐。

## 为什么需要

ACP 协议在 `ListSessionsRequest`/`ListSessionsResponse` 上定义了 cursor/nextCursor，内部的 `SessionService.listSessions` 已经支持游标分页。但之前 REST 端点和 ACP HTTP dispatch 都未向客户端暴露分页 — REST 硬编码上限 100，ACP dispatch 只返回内存中的活跃 session。随着 session 数量增长，单次全量返回会成为可扩展性问题，也阻碍了 UI 虚拟滚动/懒加载模式。

## 审核测试计划

1. 启动 daemon，在一个 workspace 中创建多个 session
2. `curl /workspace/<encoded-cwd>/sessions?size=2` — 验证响应最多包含 2 个 session 和 `nextCursor` 字段
3. `curl /workspace/<encoded-cwd>/sessions?cursor=<nextCursor>&size=2` — 验证第二页返回剩余 session 且无 `nextCursor`
4. 确认页面之间无重叠
5. 运行 `npx vitest run packages/cli/src/serve/server.test.ts -t "GET /workspace"` — 18 个测试全部通过

## 风险与范围

- 主要风险：REST 响应格式从 `{ sessions }` 变为 `{ sessions, nextCursor? }` — 增量变更，向后兼容
- 未验证/不在范围内：Web Shell UI 与分页的集成（后续跟进）
- 破坏性变更：无

</details>