### PR TITLE
test: cover rewind selector fallback states

### DIFF
--- a/packages/cli/src/ui/components/RewindSelector.test.tsx
+++ b/packages/cli/src/ui/components/RewindSelector.test.tsx
@@ -154,4 +154,88 @@ describe('RewindSelector', () => {
     expect(lastFrame()).toContain('› #2 second prompt');
     expect(lastFrame()).not.toContain('Restore conversation only');
   });
+
+  it('falls back to conversation-only options when diff stats fail', async () => {
+    vi.spyOn(fileHistoryService, 'getDiffStats').mockRejectedValue(
+      new Error('diff unavailable'),
+    );
+
+    const { lastFrame } = render(
+      <RewindSelector
+        history={[
+          userTurn(1, 'first prompt', 'prompt-1'),
+          userTurn(2, 'second prompt', 'prompt-2'),
+        ]}
+        onRewind={vi.fn()}
+        onCancel={vi.fn()}
+        fileCheckpointingEnabled={true}
+        fileHistoryService={fileHistoryService}
+      />,
+    );
+
+    pressKey({ name: 'return' });
+    await flush();
+
+    expect(fileHistoryService.getDiffStats).toHaveBeenCalledWith('prompt-2');
+    expect(lastFrame()).toContain('Restore conversation only');
+    expect(lastFrame()).toContain('Never mind');
+    expect(lastFrame()).toContain('File restore is unavailable for this turn');
+    expect(lastFrame()).not.toContain('Restore code and conversation');
+    expect(lastFrame()).not.toContain('Restore code only');
+  });
+
+  it('does not request diff stats when the selected turn has no prompt id', async () => {
+    vi.spyOn(fileHistoryService, 'getDiffStats').mockResolvedValue({
+      filesChanged: ['src/foo.ts'],
+      insertions: 2,
+      deletions: 0,
+    });
+
+    const { lastFrame } = render(
+      <RewindSelector
+        history={[userTurn(1, 'first prompt'), userTurn(2, 'second prompt')]}
+        onRewind={vi.fn()}
+        onCancel={vi.fn()}
+        fileCheckpointingEnabled={true}
+        fileHistoryService={fileHistoryService}
+      />,
+    );
+
+    pressKey({ name: 'return' });
+    await flush();
+
+    expect(fileHistoryService.getDiffStats).not.toHaveBeenCalled();
+    expect(lastFrame()).toContain('Restore conversation only');
+    expect(lastFrame()).toContain('Never mind');
+    expect(lastFrame()).toContain('File restore is unavailable for this turn');
+    expect(lastFrame()).not.toContain('Restore code and conversation');
+    expect(lastFrame()).not.toContain('Restore code only');
+  });
+
+  it('confirms a conversation-only rewind when checkpointing is disabled', () => {
+    const onRewind = vi.fn();
+
+    const { lastFrame } = render(
+      <RewindSelector
+        history={[userTurn(1, 'first prompt'), userTurn(2, 'second prompt')]}
+        onRewind={onRewind}
+        onCancel={vi.fn()}
+        fileCheckpointingEnabled={false}
+        fileHistoryService={fileHistoryService}
+      />,
+    );
+
+    pressKey({ name: 'return' });
+
+    expect(lastFrame()).toContain(
+      'This will remove all conversation after this turn.',
+    );
+
+    pressKey({ sequence: 'y' });
+
+    expect(onRewind).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 2 }),
+      'conversation',
+    );
+  });
 });


### PR DESCRIPTION
## What this PR does

Adds focused regression coverage for additional RewindSelector fallback states in the rewind flow. This covers cases where file restore is unavailable because diff stats cannot be loaded, the selected turn has no prompt id, or file checkpointing is disabled and the selector uses the legacy confirmation path.

## Why it's needed

This continues the test coverage work tracked in #4187. The previous PR covered restore-options rendering when file diff stats are available; this PR covers fallback paths that should still keep rewind usable and predictable when checkpoint metadata is missing or unavailable.

## Reviewer Test Plan

### How to verify

Run the focused CLI component test from `packages/cli` and confirm all RewindSelector tests pass. I verified this locally with `vitest run src/ui/components/RewindSelector.test.tsx --config vitest.config.ts`; the suite passed with 6 tests.

### Evidence (Before & After)

N/A. This PR only adds regression tests and does not change user-visible runtime behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Tested locally on Windows with Node.js v24.14.0. Command run from `packages/cli`: `vitest run src/ui/components/RewindSelector.test.tsx --config vitest.config.ts`.

## Risk & Scope

- Main risk or tradeoff: Low risk; this PR only adds tests for existing RewindSelector behavior.
- Not validated / out of scope: This does not cover the broader handleRewindConfirm orchestration scenarios from #4187.
- Breaking changes / migration notes: None.

## Linked Issues

Part of #4187.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 为 rewind 流程中的 RewindSelector 额外 fallback 状态添加了聚焦的回归测试。新增测试覆盖了文件恢复不可用的几种情况：diff stats 无法加载、选中的历史 turn 没有 prompt id，以及关闭 file checkpointing 时使用 legacy confirmation 路径。

## Why it's needed

这个 PR 继续推进 #4187 中追踪的测试覆盖工作。上一个 PR 覆盖了存在文件 diff stats 时 restore-options 的渲染；这个 PR 覆盖 checkpoint 元数据缺失或不可用时的 fallback 路径，确保 rewind 在这些情况下仍然保持可用和行为可预期。

## Reviewer Test Plan

### How to verify

从 `packages/cli` 目录运行聚焦的 CLI 组件测试，并确认所有 RewindSelector 测试通过。我已在本地使用 `vitest run src/ui/components/RewindSelector.test.tsx --config vitest.config.ts` 验证，该测试套件通过，共 6 个测试。

### Evidence (Before & After)

N/A。这个 PR 只新增回归测试，不改变用户可见的运行时行为。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地在 Windows 上使用 Node.js v24.14.0 测试。从 `packages/cli` 目录运行的命令是：`vitest run src/ui/components/RewindSelector.test.tsx --config vitest.config.ts`。

## Risk & Scope

- Main risk or tradeoff: 风险较低；这个 PR 只为已有的 RewindSelector 行为添加测试。
- Not validated / out of scope: 这个 PR 不覆盖 #4187 中更完整的 handleRewindConfirm orchestration 场景。
- Breaking changes / migration notes: 无。

## Linked Issues

Part of #4187.

</details>
