### PR TITLE
feat(telemetry): inject TRACEPARENT env var into shell child processes

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1081,7 +1081,7 @@ const SETTINGS_SCHEMA = {
       properties: {
         propagateTraceContext: {
           description:
-            "Requires `telemetry.enabled: true`. Inject W3C `traceparent` header on outbound `fetch` requests (LLM SDK calls, MCP StreamableHTTP, WebFetch, ...). Default: false — trace context stays internal to the operator's OTLP collector and is NOT written onto third-party request streams. Set true only when you want cross-process trace stitching with an OTel-aware LLM provider (e.g. ARMS+DashScope). Client HTTP spans are still emitted in either case; this flag only governs the wire `traceparent` header.",
+            "Requires `telemetry.enabled: true`. Inject W3C `traceparent` on outbound `fetch` requests (LLM SDK calls, MCP StreamableHTTP, WebFetch, ...) AND as a `TRACEPARENT` environment variable in shell child processes (Bash tool, hooks, monitor). When enabled, any existing `TRACEPARENT` in the parent environment is overwritten with qwen-code's own trace context. Default: false — trace context stays internal to the operator's OTLP collector. Set true when you want cross-process trace stitching with an OTel-aware LLM provider (e.g. ARMS+DashScope) or need shell scripts / CLI tools to participate in distributed tracing.",
           type: 'boolean',
           default: false,
         },

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -182,5 +182,5 @@ export {
   truncateContent,
   clearDetailedSpanState,
 } from './detailed-span-attributes.js';
-export { getTraceContext, formatTraceparent, ZERO_TRACE_ID } from './trace-context.js';
+export { getTraceContext, formatTraceparent } from './trace-context.js';
 export type { TraceContext } from './trace-context.js';

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -182,3 +182,5 @@ export {
   truncateContent,
   clearDetailedSpanState,
 } from './detailed-span-attributes.js';
+export { getTraceContext, formatTraceparent, ZERO_TRACE_ID } from './trace-context.js';
+export type { TraceContext } from './trace-context.js';

--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -57,12 +57,14 @@ vi.mock('@opentelemetry/instrumentation-undici');
 vi.mock('./gcp-exporters.js');
 vi.mock('./log-to-span-processor.js');
 vi.mock('./session-context.js');
+vi.mock('./trace-context.js');
 vi.mock('./tracer.js', () => ({
   createSessionRootContext: vi.fn((id: string) => ({ __sessionId: id })),
 }));
 
 import { LogToSpanProcessor } from './log-to-span-processor.js';
 import { setSessionContext } from './session-context.js';
+import { setShellTracePropagation } from './trace-context.js';
 import { createSessionRootContext } from './tracer.js';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici';
@@ -1301,5 +1303,56 @@ describe('refreshSessionContext', () => {
 
     expect(createSessionRootContext).toHaveBeenCalledWith('bad-session');
     expect(setSessionContext).not.toHaveBeenCalled();
+  });
+});
+
+describe('shell trace propagation wiring', () => {
+  let mockConfig: Config;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConfig = {
+      getTelemetryEnabled: () => true,
+      getTelemetryOtlpEndpoint: () => 'http://localhost:4317',
+      getTelemetryOtlpProtocol: () => 'grpc',
+      getTelemetryOtlpTracesEndpoint: () => undefined,
+      getTelemetryOtlpLogsEndpoint: () => undefined,
+      getTelemetryOtlpMetricsEndpoint: () => undefined,
+      getTelemetryTarget: () => 'local',
+      getTelemetryOutfile: () => undefined,
+      getTelemetryIncludeSensitiveSpanAttributes: () => false,
+      getTelemetryResourceAttributes: () => ({}),
+      getTelemetryMetricsIncludeSessionId: () => false,
+      getTelemetryResourceAttributeWarnings: () => [],
+      getDebugMode: () => false,
+      getSessionId: () => 'test-session',
+      getCliVersion: () => '1.0.0-test',
+      getOutboundCorrelationPropagateTraceContext: () => false,
+      isInteractive: () => false,
+    } as unknown as Config;
+  });
+
+  afterEach(async () => {
+    await shutdownTelemetry();
+  });
+
+  it('sets shell trace propagation on init based on config', () => {
+    const config = {
+      ...mockConfig,
+      getOutboundCorrelationPropagateTraceContext: () => true,
+    } as unknown as Config;
+
+    initializeTelemetry(config);
+
+    expect(setShellTracePropagation).toHaveBeenCalledWith(true);
+  });
+
+  it('resets shell trace propagation on shutdown', async () => {
+    initializeTelemetry(mockConfig);
+    vi.mocked(setShellTracePropagation).mockClear();
+
+    await shutdownTelemetry();
+
+    expect(setShellTracePropagation).toHaveBeenCalledWith(false);
   });
 });

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -37,6 +37,7 @@ import { createDebugLogger } from '../utils/debugLogger.js';
 import { LogToSpanProcessor } from './log-to-span-processor.js';
 import { createSessionRootContext } from './tracer.js';
 import { setSessionContext } from './session-context.js';
+import { setShellTracePropagation } from './trace-context.js';
 import { endInteractionSpan } from './session-tracing.js';
 
 function createTelemetryDiagLogger(): DiagLogger {
@@ -547,6 +548,9 @@ export function initializeTelemetry(config: Config): void {
     telemetryInitialized = true;
     const sessionId = config.getSessionId();
     setSessionContext(createSessionRootContext(sessionId), sessionId);
+    setShellTracePropagation(
+      config.getOutboundCorrelationPropagateTraceContext(),
+    );
     initializeMetrics(config);
   } catch (error) {
     debugLogger.error('Error starting OpenTelemetry SDK:', error);
@@ -623,6 +627,7 @@ export async function shutdownTelemetry(): Promise<void> {
       sdk = undefined;
       telemetryShutdownPromise = undefined;
       setSessionContext(undefined);
+      setShellTracePropagation(false);
     }
   })();
   return telemetryShutdownPromise;

--- a/packages/core/src/telemetry/trace-context.test.ts
+++ b/packages/core/src/telemetry/trace-context.test.ts
@@ -93,6 +93,14 @@ describe('trace-context', () => {
 
       expect(getActiveSpanTraceContext()).toBeNull();
     });
+
+    it('rejects span with valid traceId but zero spanId', () => {
+      vi.mocked(trace.getActiveSpan).mockReturnValue(
+        mockSpan('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', INVALID_SPAN, 1),
+      );
+
+      expect(getActiveSpanTraceContext()).toBeNull();
+    });
   });
 
   describe('getSessionRootTraceContext', () => {
@@ -119,6 +127,14 @@ describe('trace-context', () => {
 
     it('returns null when no session context', () => {
       vi.mocked(getSessionContext).mockReturnValue(undefined);
+      expect(getSessionRootTraceContext()).toBeNull();
+    });
+
+    it('returns null when getSessionContext throws', () => {
+      vi.mocked(getSessionContext).mockImplementation(() => {
+        throw new Error('session unavailable');
+      });
+
       expect(getSessionRootTraceContext()).toBeNull();
     });
 

--- a/packages/core/src/telemetry/trace-context.test.ts
+++ b/packages/core/src/telemetry/trace-context.test.ts
@@ -1,0 +1,229 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { trace } from '@opentelemetry/api';
+import type { Span, Context } from '@opentelemetry/api';
+import { getSessionContext } from './session-context.js';
+import {
+  getActiveSpanTraceContext,
+  getSessionRootTraceContext,
+  getTraceContext,
+  formatTraceparent,
+  setShellTracePropagation,
+  isShellTracePropagationEnabled,
+  ZERO_TRACE_ID,
+} from './trace-context.js';
+
+const { INVALID_TRACE, INVALID_SPAN } = vi.hoisted(() => ({
+  INVALID_TRACE: '0'.repeat(32),
+  INVALID_SPAN: '0'.repeat(16),
+}));
+
+vi.mock('@opentelemetry/api', () => ({
+  trace: {
+    getActiveSpan: vi.fn().mockReturnValue(undefined),
+    getSpan: vi.fn().mockReturnValue(undefined),
+  },
+  INVALID_TRACEID: INVALID_TRACE,
+  isSpanContextValid: vi
+    .fn()
+    .mockImplementation(
+      (ctx: { traceId: string; spanId: string }) =>
+        ctx.traceId !== INVALID_TRACE && ctx.spanId !== INVALID_SPAN,
+    ),
+}));
+
+vi.mock('./session-context.js', () => ({
+  getSessionContext: vi.fn().mockReturnValue(undefined),
+}));
+
+function mockSpan(
+  traceId: string,
+  spanId: string,
+  traceFlags: number,
+): Span {
+  return {
+    spanContext: () => ({ traceId, spanId, traceFlags }),
+  } as unknown as Span;
+}
+
+describe('trace-context', () => {
+  beforeEach(() => {
+    vi.mocked(trace.getActiveSpan).mockReturnValue(undefined);
+    vi.mocked(trace.getSpan).mockReturnValue(undefined);
+    vi.mocked(getSessionContext).mockReturnValue(undefined);
+    setShellTracePropagation(false);
+  });
+
+  describe('getActiveSpanTraceContext', () => {
+    it('returns trace context from active span', () => {
+      vi.mocked(trace.getActiveSpan).mockReturnValue(
+        mockSpan('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbb', 1),
+      );
+
+      const ctx = getActiveSpanTraceContext();
+      expect(ctx).toEqual({
+        traceId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        spanId: 'bbbbbbbbbbbbbbbb',
+        traceFlags: 1,
+      });
+    });
+
+    it('returns null for NOOP span with zero traceId', () => {
+      vi.mocked(trace.getActiveSpan).mockReturnValue(
+        mockSpan(ZERO_TRACE_ID, 'bbbbbbbbbbbbbbbb', 0),
+      );
+
+      expect(getActiveSpanTraceContext()).toBeNull();
+    });
+
+    it('returns null when no active span', () => {
+      vi.mocked(trace.getActiveSpan).mockReturnValue(undefined);
+      expect(getActiveSpanTraceContext()).toBeNull();
+    });
+
+    it('returns null when getActiveSpan throws', () => {
+      vi.mocked(trace.getActiveSpan).mockImplementation(() => {
+        throw new Error('otel unavailable');
+      });
+
+      expect(getActiveSpanTraceContext()).toBeNull();
+    });
+  });
+
+  describe('getSessionRootTraceContext', () => {
+    it('returns trace context from session root span', () => {
+      const sessionCtx = {} as Context;
+      vi.mocked(getSessionContext).mockReturnValue(sessionCtx);
+      vi.mocked(trace.getSpan).mockImplementation((ctx) =>
+        ctx === sessionCtx
+          ? mockSpan(
+              'cccccccccccccccccccccccccccccccc',
+              'dddddddddddddddd',
+              1,
+            )
+          : undefined,
+      );
+
+      const ctx = getSessionRootTraceContext();
+      expect(ctx).toEqual({
+        traceId: 'cccccccccccccccccccccccccccccccc',
+        spanId: 'dddddddddddddddd',
+        traceFlags: 1,
+      });
+    });
+
+    it('returns null when no session context', () => {
+      vi.mocked(getSessionContext).mockReturnValue(undefined);
+      expect(getSessionRootTraceContext()).toBeNull();
+    });
+
+    it('returns null when session span has zero traceId', () => {
+      const sessionCtx = {} as Context;
+      vi.mocked(getSessionContext).mockReturnValue(sessionCtx);
+      vi.mocked(trace.getSpan).mockReturnValue(
+        mockSpan(ZERO_TRACE_ID, 'dddddddddddddddd', 0),
+      );
+
+      expect(getSessionRootTraceContext()).toBeNull();
+    });
+  });
+
+  describe('getTraceContext', () => {
+    it('prefers active span over session root', () => {
+      vi.mocked(trace.getActiveSpan).mockReturnValue(
+        mockSpan('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbb', 1),
+      );
+      const sessionCtx = {} as Context;
+      vi.mocked(getSessionContext).mockReturnValue(sessionCtx);
+      vi.mocked(trace.getSpan).mockReturnValue(
+        mockSpan('cccccccccccccccccccccccccccccccc', 'dddddddddddddddd', 1),
+      );
+
+      const ctx = getTraceContext();
+      expect(ctx?.traceId).toBe('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+    });
+
+    it('falls back to session root when no active span', () => {
+      vi.mocked(trace.getActiveSpan).mockReturnValue(undefined);
+      const sessionCtx = {} as Context;
+      vi.mocked(getSessionContext).mockReturnValue(sessionCtx);
+      vi.mocked(trace.getSpan).mockImplementation((ctx) =>
+        ctx === sessionCtx
+          ? mockSpan(
+              'cccccccccccccccccccccccccccccccc',
+              'dddddddddddddddd',
+              1,
+            )
+          : undefined,
+      );
+
+      const ctx = getTraceContext();
+      expect(ctx?.traceId).toBe('cccccccccccccccccccccccccccccccc');
+    });
+
+    it('returns null when neither source has context', () => {
+      expect(getTraceContext()).toBeNull();
+    });
+  });
+
+  describe('formatTraceparent', () => {
+    it('formats with traceFlags=0', () => {
+      expect(
+        formatTraceparent({
+          traceId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          spanId: 'bbbbbbbbbbbbbbbb',
+          traceFlags: 0,
+        }),
+      ).toBe('00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-00');
+    });
+
+    it('formats with traceFlags=1 (sampled)', () => {
+      expect(
+        formatTraceparent({
+          traceId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          spanId: 'bbbbbbbbbbbbbbbb',
+          traceFlags: 1,
+        }),
+      ).toBe('00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01');
+    });
+
+    it('formats with traceFlags=255', () => {
+      expect(
+        formatTraceparent({
+          traceId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          spanId: 'bbbbbbbbbbbbbbbb',
+          traceFlags: 255,
+        }),
+      ).toBe('00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-ff');
+    });
+
+    it('masks traceFlags to one byte', () => {
+      expect(
+        formatTraceparent({
+          traceId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          spanId: 'bbbbbbbbbbbbbbbb',
+          traceFlags: 0x1ff,
+        }),
+      ).toBe('00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-ff');
+    });
+  });
+
+  describe('shellTracePropagation', () => {
+    it('defaults to false', () => {
+      expect(isShellTracePropagationEnabled()).toBe(false);
+    });
+
+    it('can be enabled and disabled', () => {
+      setShellTracePropagation(true);
+      expect(isShellTracePropagationEnabled()).toBe(true);
+
+      setShellTracePropagation(false);
+      expect(isShellTracePropagationEnabled()).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/telemetry/trace-context.ts
+++ b/packages/core/src/telemetry/trace-context.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  trace,
+  isSpanContextValid,
+  INVALID_TRACEID,
+} from '@opentelemetry/api';
+import type { Span } from '@opentelemetry/api';
+import { getSessionContext } from './session-context.js';
+
+export const ZERO_TRACE_ID = INVALID_TRACEID;
+
+export interface TraceContext {
+  traceId: string;
+  spanId: string;
+  traceFlags: number;
+}
+
+function extractTraceContext(span: Span | undefined): TraceContext | null {
+  const ctx = span?.spanContext();
+  if (ctx && isSpanContextValid(ctx)) {
+    return {
+      traceId: ctx.traceId,
+      spanId: ctx.spanId,
+      traceFlags: ctx.traceFlags,
+    };
+  }
+  return null;
+}
+
+export function getActiveSpanTraceContext(): TraceContext | null {
+  try {
+    return extractTraceContext(trace.getActiveSpan());
+  } catch {
+    return null;
+  }
+}
+
+export function getSessionRootTraceContext(): TraceContext | null {
+  try {
+    const sessionCtx = getSessionContext();
+    return extractTraceContext(
+      sessionCtx ? trace.getSpan(sessionCtx) : undefined,
+    );
+  } catch {
+    return null;
+  }
+}
+
+export function getTraceContext(): TraceContext | null {
+  return getActiveSpanTraceContext() ?? getSessionRootTraceContext();
+}
+
+export function formatTraceparent(ctx: TraceContext): string {
+  const flags = (ctx.traceFlags & 0xff).toString(16).padStart(2, '0');
+  return `00-${ctx.traceId}-${ctx.spanId}-${flags}`;
+}
+
+let shellTracePropagationEnabled = false;
+
+export function setShellTracePropagation(enabled: boolean): void {
+  shellTracePropagationEnabled = enabled;
+}
+
+export function isShellTracePropagationEnabled(): boolean {
+  return shellTracePropagationEnabled;
+}

--- a/packages/core/src/utils/debugLogger.test.ts
+++ b/packages/core/src/utils/debugLogger.test.ts
@@ -15,8 +15,7 @@ import {
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { Storage } from '../config/storage.js';
-import { trace, type Context, type Span } from '@opentelemetry/api';
-import { setSessionContext } from '../telemetry/session-context.js';
+import { getTraceContext } from '../telemetry/trace-context.js';
 
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
@@ -33,11 +32,8 @@ vi.mock('node:fs', async (importOriginal) => {
   };
 });
 
-vi.mock('@opentelemetry/api', () => ({
-  trace: {
-    getActiveSpan: vi.fn().mockReturnValue(undefined),
-    getSpan: vi.fn().mockReturnValue(undefined),
-  },
+vi.mock('../telemetry/trace-context.js', () => ({
+  getTraceContext: vi.fn().mockReturnValue(null),
 }));
 
 describe('debugLogger', () => {
@@ -55,16 +51,12 @@ describe('debugLogger', () => {
     vi.setSystemTime(new Date('2026-01-24T10:30:00.000Z'));
     resetDebugLoggingState();
     setDebugLogSession(mockSession);
-    setSessionContext(undefined);
-    // Default: no active OTel span
-    vi.mocked(trace.getActiveSpan).mockReturnValue(undefined);
-    vi.mocked(trace.getSpan).mockReturnValue(undefined);
+    vi.mocked(getTraceContext).mockReturnValue(null);
   });
 
   afterEach(() => {
     vi.useRealTimers();
     setDebugLogSession(null);
-    setSessionContext(undefined);
     Storage.setRuntimeBaseDir(null);
     if (previousDebugLogFileEnv === undefined) {
       delete process.env['QWEN_DEBUG_LOG_FILE'];
@@ -130,14 +122,12 @@ describe('debugLogger', () => {
       expect(calls[3]?.[1]).toContain('[ERROR]');
     });
 
-    it('uses real OTel span context when an active span exists', async () => {
-      vi.mocked(trace.getActiveSpan).mockReturnValue({
-        spanContext: () => ({
-          traceId: 'realtraceidddddddddddddddddddddd',
-          spanId: 'realspanid111111',
-          traceFlags: 1,
-        }),
-      } as unknown as Span);
+    it('uses trace context when getTraceContext returns a context', async () => {
+      vi.mocked(getTraceContext).mockReturnValue({
+        traceId: 'realtraceidddddddddddddddddddddd',
+        spanId: 'realspanid111111',
+        traceFlags: 1,
+      });
 
       const logger = createDebugLogger();
       logger.debug('with real span');
@@ -153,34 +143,11 @@ describe('debugLogger', () => {
       );
     });
 
-    it('omits trace context when active span is noop and telemetry context is unset', async () => {
-      vi.mocked(trace.getActiveSpan).mockReturnValue({
-        spanContext: () => ({
-          traceId: '00000000000000000000000000000000',
-          spanId: 'deadbeefdeadbeef',
-          traceFlags: 0,
-        }),
-      } as unknown as Span);
+    it('omits trace context when getTraceContext returns null', async () => {
+      vi.mocked(getTraceContext).mockReturnValue(null);
 
       const logger = createDebugLogger();
-      logger.debug('noop span');
-
-      await vi.runAllTimersAsync();
-
-      expect(fs.appendFile).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.not.stringContaining('trace_id='),
-        'utf8',
-      );
-    });
-
-    it('omits trace context when reading the active span throws and telemetry context is unset', async () => {
-      vi.mocked(trace.getActiveSpan).mockImplementationOnce(() => {
-        throw new Error('otel unavailable');
-      });
-
-      const logger = createDebugLogger();
-      logger.debug('otel failure');
+      logger.debug('no trace context');
 
       await vi.runAllTimersAsync();
 
@@ -206,19 +173,11 @@ describe('debugLogger', () => {
     });
 
     it('uses the session root span context for fallback trace context', async () => {
-      const sessionRootContext = { root: true } as unknown as Context;
-      setSessionContext(sessionRootContext, 'test-session');
-      vi.mocked(trace.getSpan).mockImplementation((ctx) =>
-        ctx === sessionRootContext
-          ? ({
-              spanContext: () => ({
-                traceId: 'cccccccccccccccccccccccccccccccc',
-                spanId: 'dddddddddddddddd',
-                traceFlags: 1,
-              }),
-            } as unknown as Span)
-          : undefined,
-      );
+      vi.mocked(getTraceContext).mockReturnValue({
+        traceId: 'cccccccccccccccccccccccccccccccc',
+        spanId: 'dddddddddddddddd',
+        traceFlags: 1,
+      });
 
       const logger = createDebugLogger();
       logger.debug('session root fallback');

--- a/packages/core/src/utils/debugLogger.ts
+++ b/packages/core/src/utils/debugLogger.ts
@@ -8,10 +8,12 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import util from 'node:util';
-import { trace } from '@opentelemetry/api';
 import { Storage } from '../config/storage.js';
 import { updateSymlink } from './symlink.js';
-import { getSessionContext } from '../telemetry/session-context.js';
+import {
+  getTraceContext,
+  type TraceContext,
+} from '../telemetry/trace-context.js';
 
 type LogLevel = 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
 
@@ -32,11 +34,6 @@ let ensuredDebugDirPath: string | null = null;
 let hasWriteFailure = false;
 let globalSession: DebugLogSession | null = null;
 const sessionContext = new AsyncLocalStorage<DebugLogSession>();
-
-interface TraceContext {
-  traceId: string;
-  spanId: string;
-}
 
 function isDebugLogFileEnabled(): boolean {
   const value = process.env['QWEN_DEBUG_LOG_FILE'];
@@ -75,41 +72,6 @@ function formatArgs(args: unknown[]): string {
     })
     .map((arg) => (typeof arg === 'string' ? arg : util.inspect(arg)))
     .join(' ');
-}
-
-const ZERO_TRACE_ID = '00000000000000000000000000000000';
-
-function getActiveSpanTraceContext(): TraceContext | null {
-  try {
-    const activeSpan = trace.getActiveSpan();
-    if (activeSpan) {
-      const ctx = activeSpan.spanContext();
-      if (ctx.traceId !== ZERO_TRACE_ID) {
-        return { traceId: ctx.traceId, spanId: ctx.spanId };
-      }
-    }
-    return null;
-  } catch {
-    return null;
-  }
-}
-
-function getSessionRootTraceContext(): TraceContext | null {
-  try {
-    const sessionContext = getSessionContext();
-    const sessionSpan = sessionContext ? trace.getSpan(sessionContext) : null;
-    const ctx = sessionSpan?.spanContext();
-    if (ctx && ctx.traceId !== ZERO_TRACE_ID) {
-      return { traceId: ctx.traceId, spanId: ctx.spanId };
-    }
-    return null;
-  } catch {
-    return null;
-  }
-}
-
-function getTraceContext(): TraceContext | null {
-  return getActiveSpanTraceContext() ?? getSessionRootTraceContext();
 }
 
 /**

--- a/packages/core/src/utils/shellContextEnv.test.ts
+++ b/packages/core/src/utils/shellContextEnv.test.ts
@@ -113,12 +113,12 @@ describe('getShellContextEnvVars', () => {
       );
     });
 
-    it('does not inject TRACEPARENT when propagation is enabled but no context', () => {
+    it('clears TRACEPARENT when propagation is enabled but no context', () => {
       vi.mocked(isShellTracePropagationEnabled).mockReturnValue(true);
       vi.mocked(getTraceContext).mockReturnValue(null);
 
       const env = getShellContextEnvVars();
-      expect(env['TRACEPARENT']).toBeUndefined();
+      expect(env['TRACEPARENT']).toBe('');
     });
   });
 });

--- a/packages/core/src/utils/shellContextEnv.test.ts
+++ b/packages/core/src/utils/shellContextEnv.test.ts
@@ -113,12 +113,13 @@ describe('getShellContextEnvVars', () => {
       );
     });
 
-    it('clears TRACEPARENT when propagation is enabled but no context', () => {
+    it('clears TRACEPARENT and TRACESTATE when propagation is enabled but no context', () => {
       vi.mocked(isShellTracePropagationEnabled).mockReturnValue(true);
       vi.mocked(getTraceContext).mockReturnValue(null);
 
       const env = getShellContextEnvVars();
       expect(env['TRACEPARENT']).toBe('');
+      expect(env['TRACESTATE']).toBe('');
     });
   });
 });

--- a/packages/core/src/utils/shellContextEnv.test.ts
+++ b/packages/core/src/utils/shellContextEnv.test.ts
@@ -4,10 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { getShellContextEnvVars } from './shellContextEnv.js';
 import { runWithAgentContext } from '../agents/runtime/agent-context.js';
 import { promptIdContext } from './promptIdContext.js';
+import {
+  isShellTracePropagationEnabled,
+  getTraceContext,
+  formatTraceparent,
+} from '../telemetry/trace-context.js';
+
+vi.mock('../telemetry/trace-context.js', () => ({
+  isShellTracePropagationEnabled: vi.fn().mockReturnValue(false),
+  getTraceContext: vi.fn().mockReturnValue(null),
+  formatTraceparent: vi.fn().mockReturnValue('00-aaaa-bbbb-01'),
+}));
 
 describe('getShellContextEnvVars', () => {
   let originalSessionId: string | undefined;
@@ -71,5 +82,43 @@ describe('getShellContextEnvVars', () => {
     expect(env['QWEN_CODE_AGENT_ID']).toBe('');
     expect(env['QWEN_CODE_PROMPT_ID']).toBe('');
     // Empty strings will overwrite any stale inherited values in process.env
+  });
+
+  describe('TRACEPARENT injection', () => {
+    afterEach(() => {
+      vi.mocked(isShellTracePropagationEnabled).mockReturnValue(false);
+      vi.mocked(getTraceContext).mockReturnValue(null);
+    });
+
+    it('does not inject TRACEPARENT when propagation is disabled', () => {
+      vi.mocked(isShellTracePropagationEnabled).mockReturnValue(false);
+      const env = getShellContextEnvVars();
+      expect(env['TRACEPARENT']).toBeUndefined();
+    });
+
+    it('injects TRACEPARENT when propagation is enabled and context exists', () => {
+      vi.mocked(isShellTracePropagationEnabled).mockReturnValue(true);
+      vi.mocked(getTraceContext).mockReturnValue({
+        traceId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        spanId: 'bbbbbbbbbbbbbbbb',
+        traceFlags: 1,
+      });
+      vi.mocked(formatTraceparent).mockReturnValue(
+        '00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01',
+      );
+
+      const env = getShellContextEnvVars();
+      expect(env['TRACEPARENT']).toBe(
+        '00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01',
+      );
+    });
+
+    it('does not inject TRACEPARENT when propagation is enabled but no context', () => {
+      vi.mocked(isShellTracePropagationEnabled).mockReturnValue(true);
+      vi.mocked(getTraceContext).mockReturnValue(null);
+
+      const env = getShellContextEnvVars();
+      expect(env['TRACEPARENT']).toBeUndefined();
+    });
   });
 });

--- a/packages/core/src/utils/shellContextEnv.test.ts
+++ b/packages/core/src/utils/shellContextEnv.test.ts
@@ -111,6 +111,7 @@ describe('getShellContextEnvVars', () => {
       expect(env['TRACEPARENT']).toBe(
         '00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01',
       );
+      expect(env['TRACESTATE']).toBe('');
     });
 
     it('clears TRACEPARENT and TRACESTATE when propagation is enabled but no context', () => {

--- a/packages/core/src/utils/shellContextEnv.ts
+++ b/packages/core/src/utils/shellContextEnv.ts
@@ -48,6 +48,7 @@ export function getShellContextEnvVars(): Record<string, string> {
       env['TRACEPARENT'] = formatTraceparent(ctx);
     } else {
       env['TRACEPARENT'] = '';
+      env['TRACESTATE'] = '';
     }
   }
 

--- a/packages/core/src/utils/shellContextEnv.ts
+++ b/packages/core/src/utils/shellContextEnv.ts
@@ -44,12 +44,8 @@ export function getShellContextEnvVars(): Record<string, string> {
 
   if (isShellTracePropagationEnabled()) {
     const ctx = getTraceContext();
-    if (ctx) {
-      env['TRACEPARENT'] = formatTraceparent(ctx);
-    } else {
-      env['TRACEPARENT'] = '';
-      env['TRACESTATE'] = '';
-    }
+    env['TRACEPARENT'] = ctx ? formatTraceparent(ctx) : '';
+    env['TRACESTATE'] = '';
   }
 
   return env;

--- a/packages/core/src/utils/shellContextEnv.ts
+++ b/packages/core/src/utils/shellContextEnv.ts
@@ -19,6 +19,11 @@
 
 import { getCurrentAgentId } from '../agents/runtime/agent-context.js';
 import { promptIdContext } from './promptIdContext.js';
+import {
+  isShellTracePropagationEnabled,
+  getTraceContext,
+  formatTraceparent,
+} from '../telemetry/trace-context.js';
 
 export function getShellContextEnvVars(): Record<string, string> {
   const env: Record<string, string> = {};
@@ -36,6 +41,13 @@ export function getShellContextEnvVars(): Record<string, string> {
 
   const promptId = promptIdContext.getStore();
   env['QWEN_CODE_PROMPT_ID'] = promptId ?? '';
+
+  if (isShellTracePropagationEnabled()) {
+    const ctx = getTraceContext();
+    if (ctx) {
+      env['TRACEPARENT'] = formatTraceparent(ctx);
+    }
+  }
 
   return env;
 }

--- a/packages/core/src/utils/shellContextEnv.ts
+++ b/packages/core/src/utils/shellContextEnv.ts
@@ -46,6 +46,8 @@ export function getShellContextEnvVars(): Record<string, string> {
     const ctx = getTraceContext();
     if (ctx) {
       env['TRACEPARENT'] = formatTraceparent(ctx);
+    } else {
+      env['TRACEPARENT'] = '';
     }
   }
 

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -453,7 +453,7 @@
       "type": "object",
       "properties": {
         "propagateTraceContext": {
-          "description": "Requires `telemetry.enabled: true`. Inject W3C `traceparent` header on outbound `fetch` requests (LLM SDK calls, MCP StreamableHTTP, WebFetch, ...). Default: false — trace context stays internal to the operator's OTLP collector and is NOT written onto third-party request streams. Set true only when you want cross-process trace stitching with an OTel-aware LLM provider (e.g. ARMS+DashScope). Client HTTP spans are still emitted in either case; this flag only governs the wire `traceparent` header.",
+          "description": "Requires `telemetry.enabled: true`. Inject W3C `traceparent` on outbound `fetch` requests (LLM SDK calls, MCP StreamableHTTP, WebFetch, ...) AND as a `TRACEPARENT` environment variable in shell child processes (Bash tool, hooks, monitor). When enabled, any existing `TRACEPARENT` in the parent environment is overwritten with qwen-code's own trace context. Default: false — trace context stays internal to the operator's OTLP collector. Set true when you want cross-process trace stitching with an OTel-aware LLM provider (e.g. ARMS+DashScope) or need shell scripts / CLI tools to participate in distributed tracing.",
           "type": "boolean",
           "default": false
         }


### PR DESCRIPTION
## What this PR does

When `outboundCorrelation.propagateTraceContext` is enabled, inject a W3C `TRACEPARENT` environment variable into all shell child processes (Bash tool, hooks, monitor) so that CLI tools and Python scripts can participate in distributed tracing. Also extracts a shared `trace-context.ts` module from `debugLogger.ts`'s private trace context helpers, eliminating code duplication and using OTel's `isSpanContextValid` for more correct span validation.

## Why it's needed

Shell child processes (Bash tool commands, hooks, monitor, skill-invoked Python scripts) currently cannot participate in distributed tracing because they receive no trace context. The existing `propagateTraceContext` setting only controls HTTP header injection via `UndiciInstrumentation` for `fetch`-based requests. CLI tools and Python scripts spawned by qwen-code are invisible in trace trees, making it difficult to correlate shell command execution with the parent qwen-code session.

## Reviewer Test Plan

### How to verify

1. Configure `settings.json` with `"outboundCorrelation": {"propagateTraceContext": true}` and a telemetry endpoint
2. Execute a Bash command: `env | grep TRACEPARENT`
3. Verify the output shows a W3C traceparent format: `00-{32hex}-{16hex}-{2hex}`
4. Disable the setting and restart — verify `env | grep TRACEPARENT` produces no output
5. Run unit tests: `npm run test -- packages/core/src/telemetry/trace-context.test.ts packages/core/src/utils/shellContextEnv.test.ts packages/core/src/utils/debugLogger.test.ts`

### 人工验证
<img width="1573" height="921" alt="image" src="https://github.com/user-attachments/assets/2ba0a1fe-bcae-46ea-8247-dead675c8893" />


### Evidence (Before & After)

N/A — non-UI change (telemetry plumbing). Unit tests verify behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

## Risk & Scope

- Main risk or tradeoff: When enabled, overwrites any existing `TRACEPARENT` in the parent environment (e.g., from a CI pipeline's OTel agent). Documented in the settings description.
- Not validated / out of scope: MCP stdio transport intentionally excluded — long-lived processes would get stale TRACEPARENT pointing to ended spans.
- Breaking changes / migration notes: None. Feature is off by default behind existing `propagateTraceContext` toggle.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当 `outboundCorrelation.propagateTraceContext` 开启时，向所有 shell 子进程（Bash 工具、hooks、monitor）注入 W3C `TRACEPARENT` 环境变量，使 CLI 工具和 Python 脚本能够参与分布式追踪。同时从 `debugLogger.ts` 提取共享的 `trace-context.ts` 模块，消除代码重复，并使用 OTel 的 `isSpanContextValid` 进行更准确的 span 校验。

## 为什么需要

Shell 子进程（Bash 工具命令、hooks、monitor、skill 调用的 Python 脚本）当前无法参与分布式追踪，因为它们没有收到 trace context。现有的 `propagateTraceContext` 设置仅控制通过 `UndiciInstrumentation` 对 `fetch` 请求的 HTTP header 注入。qwen-code 启动的 CLI 工具和 Python 脚本在 trace 树中不可见，难以将 shell 命令执行与父 qwen-code session 关联。

## 风险与范围

- 主要风险/权衡：开启后会覆盖父环境中已有的 `TRACEPARENT`（如 CI pipeline 的 OTel agent 注入的值），已在设置描述中说明。
- 未验证/超出范围：MCP stdio transport 有意排除——长生命周期进程会获得指向已结束 span 的过时 TRACEPARENT。
- 破坏性变更/迁移说明：无。功能默认关闭，受现有 `propagateTraceContext` 开关控制。

</details>

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)