### PR TITLE
feat(extensions): support archive install sources

### DIFF
--- a/docs/users/extension/introduction.md
+++ b/docs/users/extension/introduction.md
@@ -12,11 +12,11 @@ We offer a suite of extension management tools using both `qwen extensions` CLI 
 
 You can manage extensions at runtime within the interactive CLI using `/extensions` slash commands. These commands support hot-reloading, meaning changes take effect immediately without restarting the application.
 
-| Command                               | Description                                                                  |
-| ------------------------------------- | ---------------------------------------------------------------------------- |
-| `/extensions` or `/extensions manage` | Manage all installed extensions                                              |
-| `/extensions install <source>`        | Install an extension from a git URL, local path, npm package, or marketplace |
-| `/extensions explore [source]`        | Open extensions source page(Gemini or ClaudeCode) in your browser            |
+| Command                               | Description                                                                                          |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `/extensions` or `/extensions manage` | Manage all installed extensions                                                                      |
+| `/extensions install <source>`        | Install an extension from a git URL, local path or archive, archive URL, npm package, or marketplace |
+| `/extensions explore [source]`        | Open extensions source page(Gemini or ClaudeCode) in your browser                                    |
 
 #### The interactive extension manager
 
@@ -141,7 +141,25 @@ This will install the github mcp server extension.
 qwen extensions install /path/to/your/extension
 ```
 
+Local `.zip` and `.tar.gz` archives are also supported:
+
+```bash
+qwen extensions install /path/to/your/extension.zip
+qwen extensions install /path/to/your/extension.tar.gz
+```
+
+The archive must contain a complete extension at its root, or a single top-level directory containing the extension.
+
 Note that we create a copy of the installed extension, so you will need to run `qwen extensions update` to pull in changes from both locally-defined extensions and those on GitHub.
+
+#### From Archive URL
+
+```bash
+qwen extensions install https://example.com/your/extension.zip
+qwen extensions install https://example.com/your/extension.tar.gz
+```
+
+Archive URLs can be updated later as long as the URL continues to point at a newer archive for the same extension.
 
 #### Choosing an install scope
 
@@ -193,7 +211,7 @@ This is useful if you have an extension disabled at the top-level and only enabl
 
 ### Updating an extension
 
-For extensions installed from a local path, a git repository, or an npm registry, you can explicitly update to the latest version with `qwen extensions update extension-name`. For npm extensions installed without a version pin (e.g. `@scope/pkg`), updates check the `latest` dist-tag. For those installed with a specific dist-tag (e.g. `@scope/pkg@beta`), updates track that tag. Extensions pinned to an exact version (e.g. `@scope/pkg@1.2.0`) are always considered up-to-date.
+For extensions installed from a local path or archive, an archive URL, a git repository, or an npm registry, you can explicitly update to the latest version with `qwen extensions update extension-name`. For npm extensions installed without a version pin (e.g. `@scope/pkg`), updates check the `latest` dist-tag. For those installed with a specific dist-tag (e.g. `@scope/pkg@beta`), updates track that tag. Extensions pinned to an exact version (e.g. `@scope/pkg@1.2.0`) are always considered up-to-date.
 
 You can update all extensions with:
 

--- a/packages/acp-bridge/src/status.ts
+++ b/packages/acp-bridge/src/status.ts
@@ -859,7 +859,8 @@ export type ServeExtensionInstallType =
   | 'local'
   | 'link'
   | 'github-release'
-  | 'npm';
+  | 'npm'
+  | 'archive-url';
 
 export type ServeExtensionOriginSource = 'QwenCode' | 'Claude' | 'Gemini';
 

--- a/packages/cli/src/commands/extensions/install.test.ts
+++ b/packages/cli/src/commands/extensions/install.test.ts
@@ -215,6 +215,61 @@ describe('handleInstall', () => {
     processSpy.mockRestore();
   });
 
+  it('should install an extension from an archive URL', async () => {
+    const processSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+
+    mockParseInstallSource.mockResolvedValue({
+      type: 'archive-url',
+      source: 'https://example.com/extension.zip',
+    });
+    mockInstallExtension.mockResolvedValue({ name: 'archive-extension' });
+
+    await handleInstall({
+      source: 'https://example.com/extension.zip',
+      autoUpdate: true,
+    });
+
+    expect(mockInstallExtension).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'https://example.com/extension.zip',
+        type: 'archive-url',
+        autoUpdate: true,
+      }),
+      expect.any(Function),
+    );
+    expect(mockWriteStdoutLine).toHaveBeenCalledWith(
+      'Extension "archive-extension" installed successfully and enabled.',
+    );
+
+    processSpy.mockRestore();
+  });
+
+  it('should reject --ref for archive URL extensions', async () => {
+    const processSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+
+    mockParseInstallSource.mockResolvedValue({
+      type: 'archive-url',
+      source: 'https://example.com/extension.zip',
+    });
+
+    await handleInstall({
+      source: 'https://example.com/extension.zip',
+      ref: 'v1.0.0',
+    });
+
+    expect(mockWriteStderrLine).toHaveBeenCalledWith(
+      '--ref is not applicable for archive URL extensions.',
+    );
+    expect(mockInstallExtension).not.toHaveBeenCalled();
+    expect(processSpy).toHaveBeenCalledWith(1);
+
+    processSpy.mockRestore();
+  });
+
   it('should throw an error if install extension fails', async () => {
     const processSpy = vi
       .spyOn(process, 'exit')
@@ -365,5 +420,30 @@ describe('handleInstall', () => {
     expect(mockWriteStdoutLine).toHaveBeenCalledWith(
       'Extension "user-extension" installed successfully and enabled.',
     );
+  });
+
+  it('should print archive validation errors from the extension manager', async () => {
+    const processSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+
+    mockParseInstallSource.mockResolvedValue({
+      type: 'git',
+      source: 'owner/repo',
+    });
+    mockInstallExtension.mockRejectedValue(
+      new Error(
+        'Extension archive is missing a supported extension manifest. Expected qwen-extension.json, gemini-extension.json, .claude-plugin/marketplace.json, or .claude-plugin/plugin.json at the archive root, or inside a single top-level extension directory.',
+      ),
+    );
+
+    await handleInstall({ source: 'owner/repo' });
+
+    expect(mockWriteStderrLine).toHaveBeenCalledWith(
+      'Extension archive is missing a supported extension manifest. Expected qwen-extension.json, gemini-extension.json, .claude-plugin/marketplace.json, or .claude-plugin/plugin.json at the archive root, or inside a single top-level extension directory.',
+    );
+    expect(processSpy).toHaveBeenCalledWith(1);
+
+    processSpy.mockRestore();
   });
 });

--- a/packages/cli/src/commands/extensions/install.ts
+++ b/packages/cli/src/commands/extensions/install.ts
@@ -44,7 +44,8 @@ export async function handleInstall(args: InstallArgs) {
     if (
       installMetadata.type !== 'git' &&
       installMetadata.type !== 'github-release' &&
-      installMetadata.type !== 'npm'
+      installMetadata.type !== 'npm' &&
+      installMetadata.type !== 'archive-url'
     ) {
       if (args.ref || args.autoUpdate) {
         throw new Error(
@@ -55,10 +56,16 @@ export async function handleInstall(args: InstallArgs) {
       }
     }
 
-    if (installMetadata.type === 'npm' && args.ref) {
+    if (
+      (installMetadata.type === 'npm' ||
+        installMetadata.type === 'archive-url') &&
+      args.ref
+    ) {
       throw new Error(
         t(
-          '--ref is not applicable for npm extensions. Use @version suffix instead (e.g. @scope/package@1.2.0).',
+          installMetadata.type === 'npm'
+            ? '--ref is not applicable for npm extensions. Use @version suffix instead (e.g. @scope/package@1.2.0).'
+            : '--ref is not applicable for archive URL extensions.',
         ),
       );
     }
@@ -153,13 +160,13 @@ export async function handleInstall(args: InstallArgs) {
 export const installCommand: CommandModule = {
   command: 'install <source>',
   describe: t(
-    'Installs an extension from a git repository URL, local path, scoped npm package (@scope/name), or claude marketplace (marketplace-url:plugin-name).',
+    'Installs an extension from a git repository URL, local path or archive, archive URL, scoped npm package (@scope/name), or claude marketplace (marketplace-url:plugin-name).',
   ),
   builder: (yargs) =>
     yargs
       .positional('source', {
         describe: t(
-          'The github URL, local path, or marketplace source (marketplace-url:plugin-name) of the extension to install.',
+          'The github URL, local path or archive, archive URL, or marketplace source (marketplace-url:plugin-name) of the extension to install.',
         ),
         type: 'string',
         demandOption: true,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -539,7 +539,7 @@ export type ExtensionOriginSource = 'QwenCode' | 'Claude' | 'Gemini';
 
 export interface ExtensionInstallMetadata {
   source: string;
-  type: 'git' | 'local' | 'link' | 'github-release' | 'npm';
+  type: 'git' | 'local' | 'link' | 'github-release' | 'npm' | 'archive-url';
   originSource?: ExtensionOriginSource;
   releaseTag?: string; // Only present for github-release and npm installs.
   registryUrl?: string; // Only present for npm installs.

--- a/packages/core/src/extension/extension-converter.ts
+++ b/packages/core/src/extension/extension-converter.ts
@@ -17,13 +17,23 @@ import {
 } from './claude-converter.js';
 import type { ExtensionOriginSource } from '../config/config.js';
 
+export const SUPPORTED_EXTENSION_MANIFESTS = [
+  EXTENSIONS_CONFIG_FILENAME,
+  'gemini-extension.json',
+  '.claude-plugin/marketplace.json',
+  '.claude-plugin/plugin.json',
+] as const;
+
 export async function convertGeminiOrClaudeExtension(
   extensionDir: string,
   pluginName?: string,
 ): Promise<{ extensionDir: string; originSource: ExtensionOriginSource }> {
   let newExtensionDir = extensionDir;
   let originSource: ExtensionOriginSource = 'QwenCode';
-  const configFilePath = path.join(extensionDir, EXTENSIONS_CONFIG_FILENAME);
+  const configFilePath = path.join(
+    extensionDir,
+    SUPPORTED_EXTENSION_MANIFESTS[0],
+  );
   if (fs.existsSync(configFilePath)) {
     newExtensionDir = extensionDir;
   } else if (isGeminiExtensionConfig(extensionDir)) {
@@ -36,7 +46,7 @@ export async function convertGeminiOrClaudeExtension(
     ).convertedDir;
     originSource = 'Claude';
   } else if (
-    fs.existsSync(path.join(extensionDir, '.claude-plugin', 'plugin.json'))
+    fs.existsSync(path.join(extensionDir, SUPPORTED_EXTENSION_MANIFESTS[3]))
   ) {
     newExtensionDir = (await convertClaudePluginStandalone(extensionDir))
       .convertedDir;

--- a/packages/core/src/extension/extension-converter.ts
+++ b/packages/core/src/extension/extension-converter.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { EXTENSIONS_CONFIG_FILENAME } from './variables.js';
+import {
+  convertGeminiExtensionPackage,
+  isGeminiExtensionConfig,
+} from './gemini-converter.js';
+import {
+  convertClaudePluginPackage,
+  convertClaudePluginStandalone,
+} from './claude-converter.js';
+import type { ExtensionOriginSource } from '../config/config.js';
+
+export async function convertGeminiOrClaudeExtension(
+  extensionDir: string,
+  pluginName?: string,
+): Promise<{ extensionDir: string; originSource: ExtensionOriginSource }> {
+  let newExtensionDir = extensionDir;
+  let originSource: ExtensionOriginSource = 'QwenCode';
+  const configFilePath = path.join(extensionDir, EXTENSIONS_CONFIG_FILENAME);
+  if (fs.existsSync(configFilePath)) {
+    newExtensionDir = extensionDir;
+  } else if (isGeminiExtensionConfig(extensionDir)) {
+    newExtensionDir = (await convertGeminiExtensionPackage(extensionDir))
+      .convertedDir;
+    originSource = 'Gemini';
+  } else if (pluginName) {
+    newExtensionDir = (
+      await convertClaudePluginPackage(extensionDir, pluginName)
+    ).convertedDir;
+    originSource = 'Claude';
+  } else if (
+    fs.existsSync(path.join(extensionDir, '.claude-plugin', 'plugin.json'))
+  ) {
+    newExtensionDir = (await convertClaudePluginStandalone(extensionDir))
+      .convertedDir;
+    originSource = 'Claude';
+  }
+  return { extensionDir: newExtensionDir, originSource };
+}

--- a/packages/core/src/extension/extensionManager.test.ts
+++ b/packages/core/src/extension/extensionManager.test.ts
@@ -12,6 +12,7 @@ import {
   INSTALL_METADATA_FILENAME,
   EXTENSIONS_CONFIG_FILENAME,
 } from './variables.js';
+import { ExtensionStorage } from './storage.js';
 import { QWEN_DIR } from '../config/storage.js';
 import {
   ExtensionManager,
@@ -195,6 +196,58 @@ describe('extension tests', () => {
         source: archivePath,
         type: 'local',
       });
+    });
+
+    it('should clean up converted temp dir for local archive installs', async () => {
+      const archivePath = path.join(tempWorkspaceDir, 'gemini-extension.zip');
+      fs.writeFileSync(archivePath, 'not used by mocked extractor');
+      const tempDirs: string[] = [];
+      vi.spyOn(ExtensionStorage, 'createTmpDir').mockImplementation(
+        async () => {
+          const tempDir = fs.mkdtempSync(
+            path.join(tempHomeDir, 'tracked-extension-'),
+          );
+          tempDirs.push(tempDir);
+          return tempDir;
+        },
+      );
+      mockExtractArchiveFile.mockImplementation(
+        async (_source: string, destination: string) => {
+          fs.mkdirSync(destination, { recursive: true });
+          fs.writeFileSync(
+            path.join(destination, 'gemini-extension.json'),
+            JSON.stringify({
+              name: 'gemini-archive-extension',
+              version: '1.0.0',
+            }),
+          );
+        },
+      );
+
+      const manager = createExtensionManager();
+      await manager.refreshCache();
+
+      const extension = await manager.installExtension(
+        {
+          source: archivePath,
+          type: 'local',
+        },
+        async () => {},
+      );
+
+      expect(extension.name).toBe('gemini-archive-extension');
+      expect(tempDirs).toHaveLength(2);
+      expect(fs.existsSync(tempDirs[0])).toBe(false);
+      expect(fs.existsSync(tempDirs[1])).toBe(false);
+      expect(
+        fs.existsSync(
+          path.join(
+            userExtensionsDir,
+            'gemini-archive-extension',
+            EXTENSIONS_CONFIG_FILENAME,
+          ),
+        ),
+      ).toBe(true);
     });
 
     it('should install an extension from an archive URL', async () => {

--- a/packages/core/src/extension/extensionManager.test.ts
+++ b/packages/core/src/extension/extensionManager.test.ts
@@ -33,6 +33,8 @@ const mockGit = {
   revparse: vi.fn(),
   path: vi.fn(),
 };
+const mockDownloadFromArchiveUrl = vi.hoisted(() => vi.fn());
+const mockExtractArchiveFile = vi.hoisted(() => vi.fn());
 
 vi.mock('simple-git', () => ({
   simpleGit: vi.fn((path: string) => {
@@ -45,9 +47,11 @@ vi.mock('./github.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./github.js')>();
   return {
     ...actual,
+    downloadFromArchiveUrl: mockDownloadFromArchiveUrl,
     downloadFromGitHubRelease: vi
       .fn()
       .mockRejectedValue(new Error('Mocked GitHub release download failure')),
+    extractArchiveFile: mockExtractArchiveFile,
   };
 });
 
@@ -134,6 +138,8 @@ describe('extension tests', () => {
     mockHomedir.mockReturnValue(tempHomeDir);
     vi.spyOn(process, 'cwd').mockReturnValue(tempWorkspaceDir);
     Object.values(mockGit).forEach((fn) => fn.mockReset());
+    mockDownloadFromArchiveUrl.mockReset();
+    mockExtractArchiveFile.mockReset();
   });
 
   afterEach(() => {
@@ -150,6 +156,133 @@ describe('extension tests', () => {
       ...options,
     });
   }
+
+  describe('installExtension', () => {
+    function writeExtractedExtension(destination: string, name: string) {
+      fs.mkdirSync(destination, { recursive: true });
+      fs.writeFileSync(
+        path.join(destination, EXTENSIONS_CONFIG_FILENAME),
+        JSON.stringify({ name, version: '1.0.0' }),
+      );
+    }
+
+    it('should install an extension from a local archive', async () => {
+      const archivePath = path.join(tempWorkspaceDir, 'local-extension.zip');
+      fs.writeFileSync(archivePath, 'not used by mocked extractor');
+      mockExtractArchiveFile.mockImplementation(
+        async (_source: string, destination: string) => {
+          writeExtractedExtension(destination, 'local-archive-extension');
+        },
+      );
+
+      const manager = createExtensionManager();
+      await manager.refreshCache();
+
+      const extension = await manager.installExtension(
+        {
+          source: archivePath,
+          type: 'local',
+        },
+        async () => {},
+      );
+
+      expect(mockExtractArchiveFile).toHaveBeenCalledWith(
+        archivePath,
+        expect.any(String),
+      );
+      expect(extension.name).toBe('local-archive-extension');
+      expect(extension.installMetadata).toMatchObject({
+        source: archivePath,
+        type: 'local',
+      });
+    });
+
+    it('should install an extension from an archive URL', async () => {
+      mockDownloadFromArchiveUrl.mockImplementation(
+        async (_metadata: ExtensionInstallMetadata, destination: string) => {
+          writeExtractedExtension(destination, 'archive-url-extension');
+        },
+      );
+
+      const manager = createExtensionManager();
+      await manager.refreshCache();
+
+      const extension = await manager.installExtension(
+        {
+          source: 'https://example.com/archive-extension.zip',
+          type: 'archive-url',
+        },
+        async () => {},
+      );
+
+      expect(mockDownloadFromArchiveUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: 'https://example.com/archive-extension.zip',
+          type: 'archive-url',
+        }),
+        expect.any(String),
+      );
+      expect(extension.name).toBe('archive-url-extension');
+      expect(extension.installMetadata).toMatchObject({
+        source: 'https://example.com/archive-extension.zip',
+        type: 'archive-url',
+      });
+    });
+
+    it('should clean up the temp dir when archive URL download fails', async () => {
+      let tempDir: string | undefined;
+      mockDownloadFromArchiveUrl.mockImplementation(
+        async (_metadata: ExtensionInstallMetadata, destination: string) => {
+          tempDir = destination;
+          throw new Error('download failed');
+        },
+      );
+
+      const manager = createExtensionManager();
+      await manager.refreshCache();
+
+      await expect(
+        manager.installExtension(
+          {
+            source: 'https://example.com/archive-extension.zip',
+            type: 'archive-url',
+          },
+          async () => {},
+        ),
+      ).rejects.toThrow('download failed');
+
+      expect(tempDir).toBeDefined();
+      expect(fs.existsSync(tempDir!)).toBe(false);
+    });
+
+    it('should clean up the temp dir when local archive extraction fails', async () => {
+      const archivePath = path.join(tempWorkspaceDir, 'local-extension.zip');
+      fs.writeFileSync(archivePath, 'not used by mocked extractor');
+      let tempDir: string | undefined;
+      mockExtractArchiveFile.mockImplementation(
+        async (_source: string, destination: string) => {
+          tempDir = destination;
+          throw new Error('extract failed');
+        },
+      );
+
+      const manager = createExtensionManager();
+      await manager.refreshCache();
+
+      await expect(
+        manager.installExtension(
+          {
+            source: archivePath,
+            type: 'local',
+          },
+          async () => {},
+        ),
+      ).rejects.toThrow('extract failed');
+
+      expect(tempDir).toBeDefined();
+      expect(fs.existsSync(tempDir!)).toBe(false);
+    });
+  });
 
   describe('loadExtension', () => {
     it('should include extension path in loaded extension', async () => {

--- a/packages/core/src/extension/extensionManager.ts
+++ b/packages/core/src/extension/extensionManager.ts
@@ -40,7 +40,10 @@ import { resolveEnvVarsInObject } from '../utils/envVarResolver.js';
 import {
   checkForExtensionUpdate,
   cloneFromGit,
+  downloadFromArchiveUrl,
   downloadFromGitHubRelease,
+  extractArchiveFile,
+  isSupportedArchivePath,
   parseGitHubRepoForReleases,
 } from './github.js';
 import { downloadFromNpmRegistry } from './npm.js';
@@ -62,14 +65,7 @@ import {
   loadMarketplaceConfigFromSource,
   parseInstallSource,
 } from './marketplace.js';
-import {
-  isGeminiExtensionConfig,
-  convertGeminiExtensionPackage,
-} from './gemini-converter.js';
-import {
-  convertClaudePluginPackage,
-  convertClaudePluginStandalone,
-} from './claude-converter.js';
+import { convertGeminiOrClaudeExtension } from './extension-converter.js';
 import { glob } from 'glob';
 import { createHash } from 'node:crypto';
 import { ExtensionStorage } from './storage.js';
@@ -297,36 +293,6 @@ async function loadCommandsFromDir(dir: string): Promise<string[]> {
     }
     return [];
   }
-}
-
-async function convertGeminiOrClaudeExtension(
-  extensionDir: string,
-  pluginName?: string,
-): Promise<{ extensionDir: string; originSource: ExtensionOriginSource }> {
-  let newExtensionDir = extensionDir;
-  let originSource: ExtensionOriginSource = 'QwenCode';
-  const configFilePath = path.join(extensionDir, EXTENSIONS_CONFIG_FILENAME);
-  if (fs.existsSync(configFilePath)) {
-    newExtensionDir = extensionDir;
-  } else if (isGeminiExtensionConfig(extensionDir)) {
-    newExtensionDir = (await convertGeminiExtensionPackage(extensionDir))
-      .convertedDir;
-    originSource = 'Gemini';
-  } else if (pluginName) {
-    newExtensionDir = (
-      await convertClaudePluginPackage(extensionDir, pluginName)
-    ).convertedDir;
-    originSource = 'Claude';
-  } else if (
-    fs.existsSync(path.join(extensionDir, '.claude-plugin', 'plugin.json'))
-  ) {
-    // A standalone Claude plugin installed directly from a git URL: its root
-    // holds `.claude-plugin/plugin.json` with no marketplace.json.
-    newExtensionDir = (await convertClaudePluginStandalone(extensionDir))
-      .convertedDir;
-    originSource = 'Claude';
-  }
-  return { extensionDir: newExtensionDir, originSource };
 }
 
 // ============================================================================
@@ -1064,6 +1030,7 @@ export class ExtensionManager {
     const isUpdate = !!previousExtensionConfig;
     let newExtensionConfig: ExtensionConfig | null = null;
     let localSourcePath: string | undefined;
+    let tempDir: string | undefined;
 
     try {
       if (!this.isWorkspaceTrusted) {
@@ -1084,8 +1051,6 @@ export class ExtensionManager {
           installMetadata.source,
         );
       }
-
-      let tempDir: string | undefined;
 
       if (
         installMetadata.originSource === 'Claude' &&
@@ -1122,10 +1087,21 @@ export class ExtensionManager {
           }
         }
         localSourcePath = tempDir;
+      } else if (installMetadata.type === 'archive-url') {
+        tempDir = await ExtensionStorage.createTmpDir();
+        await downloadFromArchiveUrl(installMetadata, tempDir);
+        localSourcePath = tempDir;
       } else if (installMetadata.type === 'npm') {
         tempDir = await ExtensionStorage.createTmpDir();
         const result = await downloadFromNpmRegistry(installMetadata, tempDir);
         installMetadata.releaseTag = result.version;
+        localSourcePath = tempDir;
+      } else if (
+        installMetadata.type === 'local' &&
+        isSupportedArchivePath(installMetadata.source)
+      ) {
+        tempDir = await ExtensionStorage.createTmpDir();
+        await extractArchiveFile(installMetadata.source, tempDir);
         localSourcePath = tempDir;
       } else if (
         installMetadata.type === 'local' ||
@@ -1348,6 +1324,9 @@ export class ExtensionManager {
         } catch {
           // Ignore error
         }
+      }
+      if (tempDir) {
+        await fs.promises.rm(tempDir, { recursive: true, force: true });
       }
       const config = newExtensionConfig ?? previousExtensionConfig;
       const extensionId = config

--- a/packages/core/src/extension/extensionManager.ts
+++ b/packages/core/src/extension/extensionManager.ts
@@ -1031,6 +1031,7 @@ export class ExtensionManager {
     let newExtensionConfig: ExtensionConfig | null = null;
     let localSourcePath: string | undefined;
     let tempDir: string | undefined;
+    let convertedSourcePath: string | undefined;
 
     try {
       if (!this.isWorkspaceTrusted) {
@@ -1113,12 +1114,16 @@ export class ExtensionManager {
       }
 
       try {
+        const sourceBeforeConversion = localSourcePath;
         const { extensionDir, originSource } =
           await convertGeminiOrClaudeExtension(
-            localSourcePath,
+            sourceBeforeConversion,
             installMetadata.pluginName,
           );
 
+        if (extensionDir !== sourceBeforeConversion) {
+          convertedSourcePath = extensionDir;
+        }
         localSourcePath = extensionDir;
         installMetadata.originSource = originSource;
 
@@ -1302,8 +1307,16 @@ export class ExtensionManager {
         if (tempDir) {
           await fs.promises.rm(tempDir, { recursive: true, force: true });
         }
+        if (convertedSourcePath && convertedSourcePath !== tempDir) {
+          await fs.promises.rm(convertedSourcePath, {
+            recursive: true,
+            force: true,
+          });
+        }
         if (
+          localSourcePath &&
           localSourcePath !== tempDir &&
+          localSourcePath !== convertedSourcePath &&
           installMetadata.type !== 'link' &&
           installMetadata.type !== 'local'
         ) {
@@ -1327,6 +1340,12 @@ export class ExtensionManager {
       }
       if (tempDir) {
         await fs.promises.rm(tempDir, { recursive: true, force: true });
+      }
+      if (convertedSourcePath && convertedSourcePath !== tempDir) {
+        await fs.promises.rm(convertedSourcePath, {
+          recursive: true,
+          force: true,
+        });
       }
       const config = newExtensionConfig ?? previousExtensionConfig;
       const extensionId = config

--- a/packages/core/src/extension/github.test.ts
+++ b/packages/core/src/extension/github.test.ts
@@ -8,15 +8,23 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   checkForExtensionUpdate,
   cloneFromGit,
+  downloadFromArchiveUrl,
+  downloadFromGitHubRelease,
+  extractArchiveFile,
   extractFile,
   findReleaseAsset,
+  isSupportedArchivePath,
+  isSupportedArchiveUrl,
   parseGitHubRepoForReleases,
 } from './github.js';
 import { simpleGit, type SimpleGit } from 'simple-git';
 import * as os from 'node:os';
+import type * as https from 'node:https';
+import type { IncomingMessage } from 'node:http';
 import * as fs from 'node:fs/promises';
 import * as fsSync from 'node:fs';
 import * as path from 'node:path';
+import { Readable } from 'node:stream';
 import * as tar from 'tar';
 import * as archiver from 'archiver';
 import {
@@ -25,9 +33,11 @@ import {
   type ExtensionManager,
 } from './extensionManager.js';
 import { getErrorMessage } from '../utils/errors.js';
+import { EXTENSIONS_CONFIG_FILENAME } from './variables.js';
 
 const mockPlatform = vi.hoisted(() => vi.fn());
 const mockArch = vi.hoisted(() => vi.fn());
+const mockHttpsGet = vi.hoisted(() => vi.fn());
 vi.mock('node:os', async (importOriginal) => {
   const actual = await importOriginal<typeof os>();
   return {
@@ -36,13 +46,96 @@ vi.mock('node:os', async (importOriginal) => {
     arch: mockArch,
   };
 });
-
+vi.mock('node:https', async (importOriginal) => {
+  const actual = await importOriginal<typeof https>();
+  return {
+    ...actual,
+    get: mockHttpsGet,
+  };
+});
 vi.mock('simple-git');
 
 describe('git extension helpers', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    mockHttpsGet.mockReset();
   });
+
+  function createResponse(
+    responseBody: string | Buffer | undefined,
+    statusCode = 200,
+    headers: IncomingMessage['headers'] = {},
+  ): IncomingMessage {
+    const response = Readable.from([
+      typeof responseBody === 'string'
+        ? Buffer.from(responseBody)
+        : (responseBody ?? Buffer.alloc(0)),
+    ]) as IncomingMessage;
+    Object.assign(response, {
+      statusCode,
+      headers,
+    });
+    return response;
+  }
+
+  function callResponseCallback(
+    _options:
+      | https.RequestOptions
+      | ((res: IncomingMessage) => void)
+      | undefined,
+    callback: ((res: IncomingMessage) => void) | undefined,
+    response: IncomingMessage,
+  ): void {
+    if (typeof _options === 'function') {
+      _options(response);
+    } else {
+      callback?.(response);
+    }
+  }
+
+  function createRequestMock(): ReturnType<typeof https.get> {
+    return {
+      on: vi.fn().mockReturnThis(),
+      setTimeout: vi.fn().mockReturnThis(),
+      destroy: vi.fn().mockReturnThis(),
+    } as unknown as ReturnType<typeof https.get>;
+  }
+
+  function mockHttpsResponses(...responses: Array<string | Buffer>): void {
+    mockHttpsGet.mockImplementation(((
+      _url: string | URL | https.RequestOptions,
+      _options:
+        | https.RequestOptions
+        | ((res: IncomingMessage) => void)
+        | undefined,
+      callback?: (res: IncomingMessage) => void,
+    ) => {
+      const response = createResponse(responses.shift());
+      callResponseCallback(_options, callback, response);
+      return createRequestMock();
+    }) as typeof https.get);
+  }
+
+  async function createZipBuffer(
+    tempDir: string,
+    entries: Array<{ name: string; content: string }>,
+  ): Promise<Buffer> {
+    const archivePath = path.join(tempDir, `archive-${Date.now()}.zip`);
+    const output = fsSync.createWriteStream(archivePath);
+    const archive = archiver.create('zip');
+    const streamFinished = new Promise((resolve, reject) => {
+      output.on('close', () => resolve(null));
+      archive.on('error', reject);
+    });
+
+    archive.pipe(output);
+    for (const entry of entries) {
+      archive.append(entry.content, { name: entry.name });
+    }
+    await archive.finalize();
+    await streamFinished;
+    return fs.readFile(archivePath);
+  }
 
   describe('cloneFromGit', () => {
     const mockGit = {
@@ -422,6 +515,832 @@ describe('git extension helpers', () => {
       const result = await checkForExtensionUpdate(extension, mockManager);
       expect(result).toBe(ExtensionUpdateState.NOT_UPDATABLE);
     });
+
+    it('should convert a local Gemini archive before checking for updates', async () => {
+      const tempDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'local-archive-update-test-'),
+      );
+      try {
+        const archivePath = path.join(tempDir, 'gemini-extension.zip');
+        const archive = await createZipBuffer(tempDir, [
+          {
+            name: 'gemini-extension.json',
+            content: JSON.stringify({
+              name: 'gemini-archive-extension',
+              version: '2.0.0',
+            }),
+          },
+        ]);
+        await fs.writeFile(archivePath, archive);
+        const extension = createExtension({
+          version: '1.0.0',
+          installMetadata: {
+            type: 'local',
+            source: archivePath,
+          },
+        });
+        const mockManager = {
+          loadExtensionConfig: vi.fn(
+            ({ extensionDir }: { extensionDir: string }) => {
+              expect(
+                fsSync.existsSync(
+                  path.join(extensionDir, EXTENSIONS_CONFIG_FILENAME),
+                ),
+              ).toBe(true);
+              return JSON.parse(
+                fsSync.readFileSync(
+                  path.join(extensionDir, EXTENSIONS_CONFIG_FILENAME),
+                  'utf-8',
+                ),
+              );
+            },
+          ),
+        } as unknown as ExtensionManager;
+
+        const result = await checkForExtensionUpdate(extension, mockManager);
+
+        expect(result).toBe(ExtensionUpdateState.UPDATE_AVAILABLE);
+      } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should return UPDATE_AVAILABLE for local archive extension with different version', async () => {
+      const tempDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'local-archive-update-test-'),
+      );
+      try {
+        const archivePath = path.join(tempDir, 'qwen-extension.zip');
+        const archive = await createZipBuffer(tempDir, [
+          {
+            name: EXTENSIONS_CONFIG_FILENAME,
+            content: JSON.stringify({
+              name: 'local-archive-extension',
+              version: '2.0.0',
+            }),
+          },
+        ]);
+        await fs.writeFile(archivePath, archive);
+        const extension = createExtension({
+          version: '1.0.0',
+          installMetadata: {
+            type: 'local',
+            source: archivePath,
+          },
+        });
+        const mockManager = {
+          loadExtensionConfig: vi.fn().mockReturnValue({
+            name: 'local-archive-extension',
+            version: '2.0.0',
+          }),
+        } as unknown as ExtensionManager;
+
+        const result = await checkForExtensionUpdate(extension, mockManager);
+
+        expect(result).toBe(ExtensionUpdateState.UPDATE_AVAILABLE);
+        expect(mockManager.loadExtensionConfig).toHaveBeenCalledWith({
+          extensionDir: expect.stringContaining('extension-archive-update-'),
+        });
+      } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should return UPDATE_AVAILABLE for archive URL extension with different version', async () => {
+      const tempDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'archive-url-update-test-'),
+      );
+      try {
+        const archive = await createZipBuffer(tempDir, [
+          {
+            name: EXTENSIONS_CONFIG_FILENAME,
+            content: JSON.stringify({
+              name: 'archive-url-extension',
+              version: '2.0.0',
+            }),
+          },
+        ]);
+        mockHttpsResponses(archive);
+        const extension = createExtension({
+          version: '1.0.0',
+          installMetadata: {
+            type: 'archive-url',
+            source: 'https://example.com/extension.zip',
+          },
+        });
+        const mockManager = {
+          loadExtensionConfig: vi.fn().mockReturnValue({
+            name: 'archive-url-extension',
+            version: '2.0.0',
+          }),
+        } as unknown as ExtensionManager;
+
+        const result = await checkForExtensionUpdate(extension, mockManager);
+
+        expect(result).toBe(ExtensionUpdateState.UPDATE_AVAILABLE);
+        expect(mockManager.loadExtensionConfig).toHaveBeenCalledWith({
+          extensionDir: expect.stringContaining('extension-archive-update-'),
+        });
+      } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should convert an archive URL Gemini archive before checking for updates', async () => {
+      const tempDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'archive-url-update-test-'),
+      );
+      try {
+        const archive = await createZipBuffer(tempDir, [
+          {
+            name: 'gemini-extension.json',
+            content: JSON.stringify({
+              name: 'gemini-archive-url-extension',
+              version: '2.0.0',
+            }),
+          },
+        ]);
+        mockHttpsResponses(archive);
+        const extension = createExtension({
+          version: '1.0.0',
+          installMetadata: {
+            type: 'archive-url',
+            source: 'https://example.com/gemini-extension.zip',
+          },
+        });
+        const mockManager = {
+          loadExtensionConfig: vi.fn(
+            ({ extensionDir }: { extensionDir: string }) => {
+              expect(
+                fsSync.existsSync(
+                  path.join(extensionDir, EXTENSIONS_CONFIG_FILENAME),
+                ),
+              ).toBe(true);
+              return JSON.parse(
+                fsSync.readFileSync(
+                  path.join(extensionDir, EXTENSIONS_CONFIG_FILENAME),
+                  'utf-8',
+                ),
+              );
+            },
+          ),
+        } as unknown as ExtensionManager;
+
+        const result = await checkForExtensionUpdate(extension, mockManager);
+
+        expect(result).toBe(ExtensionUpdateState.UPDATE_AVAILABLE);
+      } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should return UP_TO_DATE for archive URL extension with same version', async () => {
+      const tempDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'archive-url-update-test-'),
+      );
+      try {
+        const archive = await createZipBuffer(tempDir, [
+          {
+            name: EXTENSIONS_CONFIG_FILENAME,
+            content: JSON.stringify({
+              name: 'archive-url-extension',
+              version: '1.0.0',
+            }),
+          },
+        ]);
+        mockHttpsResponses(archive);
+        const extension = createExtension({
+          version: '1.0.0',
+          installMetadata: {
+            type: 'archive-url',
+            source: 'https://example.com/extension.zip',
+          },
+        });
+        const mockManager = {
+          loadExtensionConfig: vi.fn().mockReturnValue({
+            name: 'archive-url-extension',
+            version: '1.0.0',
+          }),
+        } as unknown as ExtensionManager;
+
+        const result = await checkForExtensionUpdate(extension, mockManager);
+
+        expect(result).toBe(ExtensionUpdateState.UP_TO_DATE);
+      } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('downloadFromGitHubRelease', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'github-release-archive-test-'),
+      );
+    });
+
+    afterEach(async () => {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    });
+
+    it('should explain when a release archive is missing an extension manifest', async () => {
+      const invalidArchive = await createZipBuffer(tempDir, [
+        { name: 'README.md', content: 'not an extension' },
+      ]);
+      mockHttpsResponses(
+        JSON.stringify({
+          assets: [
+            {
+              name: 'extension.zip',
+              browser_download_url: 'https://example.com/extension.zip',
+            },
+          ],
+          tag_name: 'v1.0.0',
+        }),
+        invalidArchive,
+      );
+
+      await expect(
+        downloadFromGitHubRelease(
+          {
+            source: 'owner/repo',
+            type: 'git',
+          },
+          tempDir,
+        ),
+      ).rejects.toThrow(
+        'Extension archive is missing a supported extension manifest.',
+      );
+    });
+
+    it('should download and extract an archive URL', async () => {
+      const archive = await createZipBuffer(tempDir, [
+        {
+          name: `${EXTENSIONS_CONFIG_FILENAME}`,
+          content: JSON.stringify({
+            name: 'archive-extension',
+            version: '1.0.0',
+          }),
+        },
+      ]);
+      mockHttpsResponses(archive);
+
+      await downloadFromArchiveUrl(
+        {
+          source: 'https://example.com/extension.zip',
+          type: 'archive-url',
+        },
+        tempDir,
+      );
+
+      await expect(
+        fs.readFile(path.join(tempDir, EXTENSIONS_CONFIG_FILENAME), 'utf-8'),
+      ).resolves.toContain('archive-extension');
+    });
+
+    it.each([307, 308])(
+      'should follow %i redirects with relative locations',
+      async (statusCode) => {
+        const archive = await createZipBuffer(tempDir, [
+          {
+            name: EXTENSIONS_CONFIG_FILENAME,
+            content: JSON.stringify({
+              name: 'redirected-archive-extension',
+              version: '1.0.0',
+            }),
+          },
+        ]);
+        mockHttpsGet
+          .mockImplementationOnce(((
+            _url: string | URL | https.RequestOptions,
+            _options:
+              | https.RequestOptions
+              | ((res: IncomingMessage) => void)
+              | undefined,
+            callback?: (res: IncomingMessage) => void,
+          ) => {
+            const response = createResponse(undefined, statusCode, {
+              location: '../download/extension.zip',
+            });
+            callResponseCallback(_options, callback, response);
+            return createRequestMock();
+          }) as typeof https.get)
+          .mockImplementationOnce(((
+            _url: string | URL | https.RequestOptions,
+            _options:
+              | https.RequestOptions
+              | ((res: IncomingMessage) => void)
+              | undefined,
+            callback?: (res: IncomingMessage) => void,
+          ) => {
+            const response = createResponse(archive);
+            callResponseCallback(_options, callback, response);
+            return createRequestMock();
+          }) as typeof https.get);
+
+        await downloadFromArchiveUrl(
+          {
+            source: 'https://example.com/releases/extension.zip',
+            type: 'archive-url',
+          },
+          tempDir,
+        );
+
+        expect(mockHttpsGet).toHaveBeenCalledTimes(2);
+        expect(mockHttpsGet.mock.calls[1][0].toString()).toBe(
+          'https://example.com/download/extension.zip',
+        );
+      },
+    );
+
+    it('should reject malformed redirect locations without throwing', async () => {
+      const response = createResponse(undefined, 302, {
+        location: 'https://[::1',
+      });
+      const resumeSpy = vi.spyOn(response, 'resume');
+      mockHttpsGet.mockImplementationOnce(((
+        _url: string | URL | https.RequestOptions,
+        _options:
+          | https.RequestOptions
+          | ((res: IncomingMessage) => void)
+          | undefined,
+        callback?: (res: IncomingMessage) => void,
+      ) => {
+        callResponseCallback(_options, callback, response);
+        return createRequestMock();
+      }) as typeof https.get);
+
+      await expect(
+        downloadFromArchiveUrl(
+          {
+            source: 'https://example.com/releases/extension.zip',
+            type: 'archive-url',
+          },
+          tempDir,
+        ),
+      ).rejects.toThrow('Invalid redirect URL:');
+      expect(resumeSpy).toHaveBeenCalled();
+    });
+
+    it('should drain non-200 archive URL responses before rejecting', async () => {
+      const response = createResponse('missing', 404);
+      const resumeSpy = vi.spyOn(response, 'resume');
+      mockHttpsGet.mockImplementationOnce(((
+        _url: string | URL | https.RequestOptions,
+        _options:
+          | https.RequestOptions
+          | ((res: IncomingMessage) => void)
+          | undefined,
+        callback?: (res: IncomingMessage) => void,
+      ) => {
+        callResponseCallback(_options, callback, response);
+        return createRequestMock();
+      }) as typeof https.get);
+
+      await expect(
+        downloadFromArchiveUrl(
+          {
+            source: 'https://example.com/releases/extension.zip',
+            type: 'archive-url',
+          },
+          tempDir,
+        ),
+      ).rejects.toThrow('Request failed with status code 404');
+      expect(resumeSpy).toHaveBeenCalled();
+    });
+
+    it('should time out archive URL downloads', async () => {
+      let timeoutCallback: (() => void) | undefined;
+      const request = {
+        on: vi.fn().mockReturnThis(),
+        setTimeout: vi.fn((_ms: number, callback?: () => void) => {
+          timeoutCallback = callback;
+          return request;
+        }),
+        destroy: vi.fn().mockReturnThis(),
+      } as unknown as ReturnType<typeof https.get>;
+      mockHttpsGet.mockImplementationOnce(() => request);
+
+      const download = downloadFromArchiveUrl(
+        {
+          source: 'https://example.com/releases/extension.zip',
+          type: 'archive-url',
+        },
+        tempDir,
+      );
+      timeoutCallback?.();
+
+      await expect(download).rejects.toThrow(
+        'Timed out downloading extension archive',
+      );
+      expect(request.destroy).toHaveBeenCalled();
+    });
+
+    it('should reject oversized archive URL downloads', async () => {
+      let dataHandler: ((chunk: Buffer) => void) | undefined;
+      const response = {
+        statusCode: 200,
+        headers: {},
+        on: vi.fn((event: string, handler: (chunk: Buffer) => void) => {
+          if (event === 'data') {
+            dataHandler = handler;
+          }
+          return response;
+        }),
+        pipe: vi.fn(),
+        resume: vi.fn(),
+        destroy: vi.fn(),
+      } as unknown as IncomingMessage;
+      mockHttpsGet.mockImplementationOnce(((
+        _url: string | URL | https.RequestOptions,
+        _options:
+          | https.RequestOptions
+          | ((res: IncomingMessage) => void)
+          | undefined,
+        callback?: (res: IncomingMessage) => void,
+      ) => {
+        callResponseCallback(_options, callback, response);
+        return createRequestMock();
+      }) as typeof https.get);
+
+      const download = downloadFromArchiveUrl(
+        {
+          source: 'https://example.com/releases/extension.zip',
+          type: 'archive-url',
+        },
+        tempDir,
+      );
+      dataHandler?.({ length: 101 * 1024 * 1024 } as Buffer);
+
+      await expect(download).rejects.toThrow(
+        'Extension archive download exceeded maximum size',
+      );
+      expect(response.destroy).toHaveBeenCalled();
+    });
+
+    it('should not include the GitHub token for archive URL downloads', async () => {
+      const originalToken = process.env['GITHUB_TOKEN'];
+      process.env['GITHUB_TOKEN'] = 'secret-token';
+      const archive = await createZipBuffer(tempDir, [
+        {
+          name: EXTENSIONS_CONFIG_FILENAME,
+          content: JSON.stringify({
+            name: 'public-archive-extension',
+            version: '1.0.0',
+          }),
+        },
+      ]);
+      mockHttpsResponses(archive);
+
+      try {
+        await downloadFromArchiveUrl(
+          {
+            source: 'https://example.com/extension.zip',
+            type: 'archive-url',
+          },
+          tempDir,
+        );
+      } finally {
+        if (originalToken === undefined) {
+          delete process.env['GITHUB_TOKEN'];
+        } else {
+          process.env['GITHUB_TOKEN'] = originalToken;
+        }
+      }
+
+      const requestOptions = mockHttpsGet.mock.calls[0][1] as
+        | https.RequestOptions
+        | undefined;
+      expect(requestOptions?.headers).toEqual({
+        'User-agent': 'gemini-cli',
+      });
+    });
+
+    it('should not forward the GitHub token to cross-host redirects', async () => {
+      const originalToken = process.env['GITHUB_TOKEN'];
+      process.env['GITHUB_TOKEN'] = 'secret-token';
+      const archive = await createZipBuffer(tempDir, [
+        {
+          name: EXTENSIONS_CONFIG_FILENAME,
+          content: JSON.stringify({
+            name: 'redirected-release-extension',
+            version: '1.0.0',
+          }),
+        },
+      ]);
+      mockHttpsGet
+        .mockImplementationOnce(((
+          _url: string | URL | https.RequestOptions,
+          _options:
+            | https.RequestOptions
+            | ((res: IncomingMessage) => void)
+            | undefined,
+          callback?: (res: IncomingMessage) => void,
+        ) => {
+          const response = createResponse(
+            JSON.stringify({
+              assets: [
+                {
+                  name: 'extension.zip',
+                  browser_download_url:
+                    'https://github.com/owner/repo/releases/download/v1.0.0/extension.zip',
+                },
+              ],
+              tag_name: 'v1.0.0',
+            }),
+          );
+          callResponseCallback(_options, callback, response);
+          return createRequestMock();
+        }) as typeof https.get)
+        .mockImplementationOnce(((
+          _url: string | URL | https.RequestOptions,
+          _options:
+            | https.RequestOptions
+            | ((res: IncomingMessage) => void)
+            | undefined,
+          callback?: (res: IncomingMessage) => void,
+        ) => {
+          const response = createResponse(undefined, 302, {
+            location: 'https://objects.githubusercontent.com/extension.zip',
+          });
+          callResponseCallback(_options, callback, response);
+          return createRequestMock();
+        }) as typeof https.get)
+        .mockImplementationOnce(((
+          _url: string | URL | https.RequestOptions,
+          _options:
+            | https.RequestOptions
+            | ((res: IncomingMessage) => void)
+            | undefined,
+          callback?: (res: IncomingMessage) => void,
+        ) => {
+          const response = createResponse(archive);
+          callResponseCallback(_options, callback, response);
+          return createRequestMock();
+        }) as typeof https.get);
+
+      try {
+        await downloadFromGitHubRelease(
+          {
+            source: 'owner/repo',
+            type: 'git',
+          },
+          tempDir,
+        );
+      } finally {
+        if (originalToken === undefined) {
+          delete process.env['GITHUB_TOKEN'];
+        } else {
+          process.env['GITHUB_TOKEN'] = originalToken;
+        }
+      }
+
+      const originalDownloadOptions = mockHttpsGet.mock.calls[1][1] as
+        | https.RequestOptions
+        | undefined;
+      const redirectedDownloadOptions = mockHttpsGet.mock.calls[2][1] as
+        | https.RequestOptions
+        | undefined;
+      expect(originalDownloadOptions?.headers).toMatchObject({
+        Authorization: 'token secret-token',
+      });
+      expect(redirectedDownloadOptions?.headers).toEqual({
+        'User-agent': 'gemini-cli',
+      });
+    });
+
+    it('should stop following redirect loops', async () => {
+      mockHttpsGet.mockImplementation(((
+        _url: string | URL | https.RequestOptions,
+        _options:
+          | https.RequestOptions
+          | ((res: IncomingMessage) => void)
+          | undefined,
+        callback?: (res: IncomingMessage) => void,
+      ) => {
+        const response = createResponse(undefined, 302, {
+          location: 'https://example.com/extension.zip',
+        });
+        callResponseCallback(_options, callback, response);
+        return createRequestMock();
+      }) as typeof https.get);
+
+      await expect(
+        downloadFromArchiveUrl(
+          {
+            source: 'https://example.com/extension.zip',
+            type: 'archive-url',
+          },
+          tempDir,
+        ),
+      ).rejects.toThrow(
+        'Too many redirects while downloading extension archive',
+      );
+    });
+
+    it('should reject when an archive URL response stream errors', async () => {
+      mockHttpsGet.mockImplementationOnce(((
+        _url: string | URL | https.RequestOptions,
+        _options:
+          | https.RequestOptions
+          | ((res: IncomingMessage) => void)
+          | undefined,
+        callback?: (res: IncomingMessage) => void,
+      ) => {
+        const response = new Readable({
+          read() {
+            this.destroy(new Error('connection lost'));
+          },
+        }) as IncomingMessage;
+        Object.assign(response, {
+          statusCode: 200,
+          headers: {},
+        });
+        callResponseCallback(_options, callback, response);
+        return createRequestMock();
+      }) as typeof https.get);
+
+      await expect(
+        downloadFromArchiveUrl(
+          {
+            source: 'https://example.com/extension.zip',
+            type: 'archive-url',
+          },
+          tempDir,
+        ),
+      ).rejects.toThrow(
+        'Failed to download archive from https://example.com/extension.zip: connection lost',
+      );
+    });
+
+    it('should explain when an archive URL cannot be extracted', async () => {
+      mockHttpsResponses(Buffer.from('not a zip'));
+
+      await expect(
+        downloadFromArchiveUrl(
+          {
+            source: 'https://example.com/extension.zip',
+            type: 'archive-url',
+          },
+          tempDir,
+        ),
+      ).rejects.toThrow(
+        'Extension archive could not be extracted. Make sure it is a valid .zip or .tar.gz file.',
+      );
+    });
+
+    it('should explain when a local archive is missing an extension manifest', async () => {
+      const invalidArchivePath = path.join(tempDir, 'invalid.zip');
+      const invalidArchive = await createZipBuffer(tempDir, [
+        { name: 'README.md', content: 'not an extension' },
+      ]);
+      await fs.writeFile(invalidArchivePath, invalidArchive);
+
+      await expect(
+        extractArchiveFile(invalidArchivePath, tempDir),
+      ).rejects.toThrow(
+        'Extension archive is missing a supported extension manifest.',
+      );
+    });
+
+    it('should extract and flatten a tar.gz archive with a wrapped extension directory', async () => {
+      const archivePath = path.join(tempDir, 'wrapped-extension.tar.gz');
+      const sourceRoot = path.join(tempDir, 'tar-source');
+      const wrappedDir = path.join(sourceRoot, 'wrapped-extension');
+      await fs.mkdir(wrappedDir, { recursive: true });
+      await fs.writeFile(
+        path.join(wrappedDir, EXTENSIONS_CONFIG_FILENAME),
+        JSON.stringify({
+          name: 'tar-wrapped-extension',
+          version: '1.0.0',
+        }),
+      );
+      await tar.c(
+        {
+          cwd: sourceRoot,
+          file: archivePath,
+          gzip: true,
+        },
+        ['wrapped-extension'],
+      );
+      await fs.rm(sourceRoot, { recursive: true, force: true });
+
+      await extractArchiveFile(archivePath, tempDir);
+
+      await expect(
+        fs.readFile(path.join(tempDir, EXTENSIONS_CONFIG_FILENAME), 'utf-8'),
+      ).resolves.toContain('tar-wrapped-extension');
+    });
+
+    it('should flatten wrapped archives when the archive file is in the destination', async () => {
+      const archivePath = path.join(tempDir, 'downloaded-extension.zip');
+      const archiveBuildDir = path.join(tempDir, 'archive-build');
+      await fs.mkdir(archiveBuildDir);
+      const archive = await createZipBuffer(archiveBuildDir, [
+        {
+          name: `wrapped/${EXTENSIONS_CONFIG_FILENAME}`,
+          content: JSON.stringify({
+            name: 'wrapped-with-readme-extension',
+            version: '1.0.0',
+          }),
+        },
+        { name: 'README.md', content: 'readme' },
+      ]);
+      await fs.rm(archiveBuildDir, { recursive: true, force: true });
+      await fs.writeFile(archivePath, archive);
+
+      await extractArchiveFile(archivePath, tempDir);
+
+      await expect(
+        fs.readFile(path.join(tempDir, EXTENSIONS_CONFIG_FILENAME), 'utf-8'),
+      ).resolves.toContain('wrapped-with-readme-extension');
+      await expect(
+        fs.readFile(path.join(tempDir, 'README.md'), 'utf-8'),
+      ).resolves.toBe('readme');
+      await expect(fs.stat(archivePath)).resolves.toBeDefined();
+    });
+
+    it('should not flatten archives with multiple top-level entries', async () => {
+      const archivePath = path.join(tempDir, 'multiple-entries.zip');
+      const archive = await createZipBuffer(tempDir, [
+        {
+          name: `wrapped/${EXTENSIONS_CONFIG_FILENAME}`,
+          content: JSON.stringify({
+            name: 'wrapped-extension',
+            version: '1.0.0',
+          }),
+        },
+        { name: 'README.md', content: 'readme' },
+        { name: 'LICENSE', content: 'license' },
+      ]);
+      await fs.writeFile(archivePath, archive);
+
+      await expect(extractArchiveFile(archivePath, tempDir)).rejects.toThrow(
+        'Extension archive is missing a supported extension manifest.',
+      );
+      await expect(
+        fs.readFile(
+          path.join(tempDir, 'wrapped', EXTENSIONS_CONFIG_FILENAME),
+          'utf-8',
+        ),
+      ).resolves.toContain('wrapped-extension');
+    });
+
+    it('should not flatten archives without a top-level directory', async () => {
+      const archivePath = path.join(tempDir, 'files-only.zip');
+      const archive = await createZipBuffer(tempDir, [
+        {
+          name: EXTENSIONS_CONFIG_FILENAME,
+          content: JSON.stringify({
+            name: 'files-only-extension',
+            version: '1.0.0',
+          }),
+        },
+        { name: 'README.md', content: 'readme' },
+      ]);
+      await fs.writeFile(archivePath, archive);
+
+      await extractArchiveFile(archivePath, tempDir);
+
+      await expect(
+        fs.readFile(path.join(tempDir, EXTENSIONS_CONFIG_FILENAME), 'utf-8'),
+      ).resolves.toContain('files-only-extension');
+    });
+
+    it('should not flatten a top-level directory without a supported manifest', async () => {
+      const archivePath = path.join(tempDir, 'unsupported-wrapper.zip');
+      const archive = await createZipBuffer(tempDir, [
+        { name: 'wrapped/README.md', content: 'not an extension' },
+      ]);
+      await fs.writeFile(archivePath, archive);
+
+      await expect(extractArchiveFile(archivePath, tempDir)).rejects.toThrow(
+        'Extension archive is missing a supported extension manifest.',
+      );
+      await expect(
+        fs.readFile(path.join(tempDir, 'wrapped', 'README.md'), 'utf-8'),
+      ).resolves.toBe('not an extension');
+    });
+
+    it('should identify supported archive paths and URLs', () => {
+      expect(isSupportedArchivePath('/tmp/extension.zip')).toBe(true);
+      expect(isSupportedArchivePath('/tmp/extension.tar.gz')).toBe(true);
+      expect(isSupportedArchivePath('/tmp/extension.tgz')).toBe(false);
+      expect(isSupportedArchiveUrl('https://example.com/extension.zip')).toBe(
+        true,
+      );
+      expect(isSupportedArchiveUrl('http://example.com/extension.zip')).toBe(
+        false,
+      );
+      expect(
+        isSupportedArchiveUrl('https://example.com/extension.tar.gz'),
+      ).toBe(true);
+      expect(isSupportedArchiveUrl('git@github.com:owner/repo.git')).toBe(
+        false,
+      );
+    });
   });
 
   describe('findReleaseAsset', () => {
@@ -588,6 +1507,35 @@ describe('git extension helpers', () => {
       expect(content).toBe('hello tar');
     });
 
+    it.skipIf(process.platform === 'win32')(
+      'should skip symlink entries in tar archives',
+      async () => {
+        const archivePath = path.join(tempDir, 'symlink.tar.gz');
+        const extractionDest = path.join(tempDir, 'extracted');
+        const sourceDir = path.join(tempDir, 'source');
+        const outsideDir = path.join(tempDir, 'outside');
+        await fs.mkdir(extractionDest);
+        await fs.mkdir(sourceDir);
+        await fs.mkdir(outsideDir);
+        await fs.symlink(outsideDir, path.join(sourceDir, 'escape-link'));
+
+        await tar.c(
+          {
+            gzip: true,
+            file: archivePath,
+            cwd: sourceDir,
+          },
+          ['escape-link'],
+        );
+
+        await extractFile(archivePath, extractionDest);
+
+        await expect(
+          fs.lstat(path.join(extractionDest, 'escape-link')),
+        ).rejects.toThrow();
+      },
+    );
+
     it('should extract a .zip file', async () => {
       const archivePath = path.join(tempDir, 'test.zip');
       const extractionDest = path.join(tempDir, 'extracted');
@@ -616,6 +1564,32 @@ describe('git extension helpers', () => {
       const extractedFilePath = path.join(extractionDest, 'test.txt');
       const content = await fs.readFile(extractedFilePath, 'utf-8');
       expect(content).toBe('hello zip');
+    });
+
+    it('should reject symlink entries in zip archives', async () => {
+      const archivePath = path.join(tempDir, 'symlink.zip');
+      const extractionDest = path.join(tempDir, 'extracted');
+      await fs.mkdir(extractionDest);
+
+      const output = fsSync.createWriteStream(archivePath);
+      const archive = archiver.create('zip');
+
+      const streamFinished = new Promise((resolve, reject) => {
+        output.on('close', () => resolve(null));
+        archive.on('error', reject);
+      });
+
+      archive.pipe(output);
+      archive.symlink('escape-link', '/tmp/outside-target');
+      await archive.finalize();
+      await streamFinished;
+
+      await expect(extractFile(archivePath, extractionDest)).rejects.toThrow(
+        'Zip archive contains unsupported symbolic link entry: escape-link',
+      );
+      await expect(
+        fs.lstat(path.join(extractionDest, 'escape-link')),
+      ).rejects.toThrow();
     });
 
     it('should throw an error for unsupported file types', async () => {

--- a/packages/core/src/extension/github.test.ts
+++ b/packages/core/src/extension/github.test.ts
@@ -1140,6 +1140,39 @@ describe('git extension helpers', () => {
       );
     });
 
+    it('should reject redirects without a location and clear the timeout', async () => {
+      vi.useFakeTimers();
+      const response = createResponse(undefined, 302);
+      const resumeSpy = vi.spyOn(response, 'resume');
+      mockHttpsGet.mockImplementationOnce(((
+        _url: string | URL | https.RequestOptions,
+        _options:
+          | https.RequestOptions
+          | ((res: IncomingMessage) => void)
+          | undefined,
+        callback?: (res: IncomingMessage) => void,
+      ) => {
+        callResponseCallback(_options, callback, response);
+        return createRequestMock();
+      }) as typeof https.get);
+
+      try {
+        await expect(
+          downloadFromArchiveUrl(
+            {
+              source: 'https://example.com/extension.zip',
+              type: 'archive-url',
+            },
+            tempDir,
+          ),
+        ).rejects.toThrow('Redirect response missing location header');
+        expect(resumeSpy).toHaveBeenCalled();
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('should reject when an archive URL response stream errors', async () => {
       mockHttpsGet.mockImplementationOnce(((
         _url: string | URL | https.RequestOptions,
@@ -1260,6 +1293,71 @@ describe('git extension helpers', () => {
         fs.readFile(path.join(tempDir, 'README.md'), 'utf-8'),
       ).resolves.toBe('readme');
       await expect(fs.stat(archivePath)).resolves.toBeDefined();
+    });
+
+    it('should not flatten when the archive root already has a manifest', async () => {
+      const archivePath = path.join(tempDir, 'root-and-wrapper.zip');
+      const archive = await createZipBuffer(tempDir, [
+        {
+          name: EXTENSIONS_CONFIG_FILENAME,
+          content: JSON.stringify({
+            name: 'root-extension',
+            version: '1.0.0',
+          }),
+        },
+        {
+          name: `wrapped/${EXTENSIONS_CONFIG_FILENAME}`,
+          content: JSON.stringify({
+            name: 'wrapped-extension',
+            version: '1.0.0',
+          }),
+        },
+      ]);
+      await fs.writeFile(archivePath, archive);
+
+      await extractArchiveFile(archivePath, tempDir);
+
+      await expect(
+        fs.readFile(path.join(tempDir, EXTENSIONS_CONFIG_FILENAME), 'utf-8'),
+      ).resolves.toContain('root-extension');
+      await expect(
+        fs.readFile(
+          path.join(tempDir, 'wrapped', EXTENSIONS_CONFIG_FILENAME),
+          'utf-8',
+        ),
+      ).resolves.toContain('wrapped-extension');
+    });
+
+    it('should reject flattening when wrapper contents collide with root files', async () => {
+      const archivePath = path.join(tempDir, 'colliding-wrapper.zip');
+      const archiveBuildDir = path.join(tempDir, 'collision-build');
+      await fs.mkdir(archiveBuildDir);
+      const archive = await createZipBuffer(archiveBuildDir, [
+        {
+          name: `wrapped/${EXTENSIONS_CONFIG_FILENAME}`,
+          content: JSON.stringify({
+            name: 'wrapped-extension',
+            version: '1.0.0',
+          }),
+        },
+        { name: 'wrapped/README.md', content: 'wrapped readme' },
+        { name: 'README.md', content: 'root readme' },
+      ]);
+      await fs.rm(archiveBuildDir, { recursive: true, force: true });
+      await fs.writeFile(archivePath, archive);
+
+      await expect(extractArchiveFile(archivePath, tempDir)).rejects.toThrow(
+        'Extension archive cannot be flattened because "README.md" exists at both the archive root and inside "wrapped".',
+      );
+      await expect(
+        fs.readFile(path.join(tempDir, 'README.md'), 'utf-8'),
+      ).resolves.toBe('root readme');
+      await expect(
+        fs.readFile(
+          path.join(tempDir, 'wrapped', EXTENSIONS_CONFIG_FILENAME),
+          'utf-8',
+        ),
+      ).resolves.toContain('wrapped-extension');
     });
 
     it('should not flatten archives with multiple top-level entries', async () => {
@@ -1508,7 +1606,7 @@ describe('git extension helpers', () => {
     });
 
     it.skipIf(process.platform === 'win32')(
-      'should skip symlink entries in tar archives',
+      'should reject symlink entries in tar archives',
       async () => {
         const archivePath = path.join(tempDir, 'symlink.tar.gz');
         const extractionDest = path.join(tempDir, 'extracted');
@@ -1528,7 +1626,9 @@ describe('git extension helpers', () => {
           ['escape-link'],
         );
 
-        await extractFile(archivePath, extractionDest);
+        await expect(extractFile(archivePath, extractionDest)).rejects.toThrow(
+          'Tar archive contains unsupported link entry: escape-link',
+        );
 
         await expect(
           fs.lstat(path.join(extractionDest, 'escape-link')),

--- a/packages/core/src/extension/github.ts
+++ b/packages/core/src/extension/github.ts
@@ -23,8 +23,14 @@ import {
 import type { ExtensionInstallMetadata } from '../config/config.js';
 import { checkNpmUpdate } from './npm.js';
 import { redactUrlCredentials } from './redaction.js';
+import { convertGeminiOrClaudeExtension } from './extension-converter.js';
 
 const debugLogger = createDebugLogger('EXT_GITHUB');
+const SUPPORTED_ARCHIVE_EXTENSIONS = ['.tar.gz', '.zip'] as const;
+const ZIP_FILE_TYPE_MASK = 0xf000;
+const ZIP_SYMBOLIC_LINK_TYPE = 0xa000;
+const ARCHIVE_DOWNLOAD_TIMEOUT_MS = 120_000;
+const ARCHIVE_DOWNLOAD_MAX_BYTES = 100 * 1024 * 1024;
 
 interface GithubReleaseData {
   assets: Asset[];
@@ -41,6 +47,43 @@ interface Asset {
 export interface GitHubDownloadResult {
   tagName: string;
   type: 'git' | 'github-release';
+}
+
+function getSupportedArchiveExtensionFromPathname(
+  pathname: string,
+): string | undefined {
+  const normalizedPathname = pathname.toLowerCase();
+  return SUPPORTED_ARCHIVE_EXTENSIONS.find((extension) =>
+    normalizedPathname.endsWith(extension),
+  );
+}
+
+function getSupportedArchiveExtension(url: string): string | undefined {
+  let pathname: string;
+  try {
+    pathname = new URL(url).pathname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+  return getSupportedArchiveExtensionFromPathname(pathname);
+}
+
+export function isSupportedArchivePath(source: string): boolean {
+  return getSupportedArchiveExtensionFromPathname(source) !== undefined;
+}
+
+export function isSupportedArchiveUrl(source: string): boolean {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(source);
+  } catch {
+    return false;
+  }
+
+  return (
+    parsedUrl.protocol === 'https:' &&
+    getSupportedArchiveExtension(source) !== undefined
+  );
 }
 
 function createRedactedErrorCause(error: unknown, message: string): Error {
@@ -166,15 +209,39 @@ export async function checkForExtensionUpdate(
   const installMetadata = extension.installMetadata;
   if (installMetadata?.type === 'local') {
     let latestConfig: ExtensionConfig | undefined;
+    let tempDir: string | undefined;
+    let convertedDir: string | undefined;
     try {
+      let extensionDir = installMetadata.source;
+      if (isSupportedArchivePath(installMetadata.source)) {
+        tempDir = await fs.promises.mkdtemp(
+          path.join(os.tmpdir(), 'extension-archive-update-'),
+        );
+        await extractArchiveFile(installMetadata.source, tempDir);
+        const converted = await convertGeminiOrClaudeExtension(
+          tempDir,
+          installMetadata.pluginName,
+        );
+        extensionDir = converted.extensionDir;
+        if (extensionDir !== tempDir) {
+          convertedDir = extensionDir;
+        }
+      }
       latestConfig = extensionManager.loadExtensionConfig({
-        extensionDir: installMetadata.source,
+        extensionDir,
       });
     } catch (e) {
       debugLogger.error(
         `Failed to check for update for local extension "${extension.name}". Could not load extension from source path: ${redactUrlCredentials(installMetadata.source)}. Error: ${redactUrlCredentials(getErrorMessage(e))}`,
       );
       return ExtensionUpdateState.NOT_UPDATABLE;
+    } finally {
+      if (tempDir) {
+        await fs.promises.rm(tempDir, { recursive: true, force: true });
+      }
+      if (convertedDir) {
+        await fs.promises.rm(convertedDir, { recursive: true, force: true });
+      }
     }
 
     if (!latestConfig) {
@@ -190,6 +257,49 @@ export async function checkForExtensionUpdate(
   }
   if (installMetadata?.type === 'npm') {
     return checkNpmUpdate(installMetadata);
+  }
+  if (installMetadata?.type === 'archive-url') {
+    let tempDir: string | undefined;
+    let convertedDir: string | undefined;
+    try {
+      tempDir = await fs.promises.mkdtemp(
+        path.join(os.tmpdir(), 'extension-archive-update-'),
+      );
+      await downloadFromArchiveUrl(installMetadata, tempDir);
+      const converted = await convertGeminiOrClaudeExtension(
+        tempDir,
+        installMetadata.pluginName,
+      );
+      const extensionDir = converted.extensionDir;
+      if (extensionDir !== tempDir) {
+        convertedDir = extensionDir;
+      }
+      const latestConfig = extensionManager.loadExtensionConfig({
+        extensionDir,
+      });
+      if (!latestConfig) {
+        debugLogger.error(
+          `Failed to check for update for archive URL extension "${extension.name}". Could not load extension from source URL: ${redactUrlCredentials(installMetadata.source)}`,
+        );
+        return ExtensionUpdateState.ERROR;
+      }
+      if (latestConfig.version !== extension.version) {
+        return ExtensionUpdateState.UPDATE_AVAILABLE;
+      }
+      return ExtensionUpdateState.UP_TO_DATE;
+    } catch (error) {
+      debugLogger.error(
+        `Failed to check for update for archive URL extension "${extension.name}" from ${redactUrlCredentials(installMetadata.source)}: ${redactUrlCredentials(getErrorMessage(error))}`,
+      );
+      return ExtensionUpdateState.ERROR;
+    } finally {
+      if (tempDir) {
+        await fs.promises.rm(tempDir, { recursive: true, force: true });
+      }
+      if (convertedDir) {
+        await fs.promises.rm(convertedDir, { recursive: true, force: true });
+      }
+    }
   }
   if (
     !installMetadata ||
@@ -270,105 +380,109 @@ export async function downloadFromGitHubRelease(
   const { source, ref } = installMetadata;
   const { owner, repo } = parseGitHubRepoForReleases(source);
 
-  try {
-    const releaseData = await fetchReleaseFromGithub(owner, repo, ref);
-    if (!releaseData) {
-      throw new Error(
-        `No release data found for ${owner}/${repo} at tag ${ref}`,
-      );
-    }
+  const releaseData = await fetchReleaseFromGithub(owner, repo, ref);
+  if (!releaseData) {
+    throw new Error(`No release data found for ${owner}/${repo} at tag ${ref}`);
+  }
 
-    const asset = findReleaseAsset(releaseData.assets);
-    let archiveUrl: string | undefined;
-    let isTar = false;
-    let isZip = false;
-    if (asset) {
-      archiveUrl = asset.browser_download_url;
-    } else {
-      if (releaseData.tarball_url) {
-        archiveUrl = releaseData.tarball_url;
-        isTar = true;
-      } else if (releaseData.zipball_url) {
-        archiveUrl = releaseData.zipball_url;
-        isZip = true;
-      }
+  const asset = findReleaseAsset(releaseData.assets);
+  let archiveUrl: string | undefined;
+  let isTar = false;
+  let isZip = false;
+  if (asset) {
+    archiveUrl = asset.browser_download_url;
+  } else {
+    if (releaseData.tarball_url) {
+      archiveUrl = releaseData.tarball_url;
+      isTar = true;
+    } else if (releaseData.zipball_url) {
+      archiveUrl = releaseData.zipball_url;
+      isZip = true;
     }
-    if (!archiveUrl) {
-      throw new Error(
-        `No assets found for release with tag ${releaseData.tag_name}`,
-      );
-    }
-    let downloadedAssetPath = path.join(
-      destination,
-      path.basename(new URL(archiveUrl).pathname),
+  }
+  if (!archiveUrl) {
+    throw new Error(
+      `No assets found for release with tag ${releaseData.tag_name}`,
     );
-    if (isTar && !downloadedAssetPath.endsWith('.tar.gz')) {
-      downloadedAssetPath += '.tar.gz';
-    } else if (isZip && !downloadedAssetPath.endsWith('.zip')) {
-      downloadedAssetPath += '.zip';
-    }
+  }
+  let downloadedAssetPath = path.join(
+    destination,
+    path.basename(new URL(archiveUrl).pathname),
+  );
+  if (isTar && !downloadedAssetPath.endsWith('.tar.gz')) {
+    downloadedAssetPath += '.tar.gz';
+  } else if (isZip && !downloadedAssetPath.endsWith('.zip')) {
+    downloadedAssetPath += '.zip';
+  }
 
-    await downloadFile(archiveUrl, downloadedAssetPath);
-
-    await extractFile(downloadedAssetPath, destination);
-
-    // For regular github releases, the repository is put inside of a top level
-    // directory. In this case we should see exactly two file in the destination
-    // dir, the archive and the directory. If we see that, validate that the
-    // dir has a qwen extension configuration file (or gemini-extension.json
-    // which will be converted later) and then move all files from the directory
-    // up one level into the destination directory.
-    const entries = await fs.promises.readdir(destination, {
-      withFileTypes: true,
+  try {
+    await downloadFile(archiveUrl, downloadedAssetPath, {
+      includeGitHubToken: true,
     });
-    if (entries.length === 2) {
-      const lonelyDir = entries.find((entry) => entry.isDirectory());
-      if (lonelyDir) {
-        const hasQwenConfig = fs.existsSync(
-          path.join(destination, lonelyDir.name, EXTENSIONS_CONFIG_FILENAME),
-        );
-        const hasGeminiConfig = fs.existsSync(
-          path.join(destination, lonelyDir.name, 'gemini-extension.json'),
-        );
-        const hasMarketplaceConfig = fs.existsSync(
-          path.join(
-            destination,
-            lonelyDir.name,
-            '.claude-plugin/marketplace.json',
-          ),
-        );
-        const hasClaudePluginConfig = fs.existsSync(
-          path.join(destination, lonelyDir.name, '.claude-plugin/plugin.json'),
-        );
-        if (
-          hasQwenConfig ||
-          hasGeminiConfig ||
-          hasMarketplaceConfig ||
-          hasClaudePluginConfig
-        ) {
-          const dirPathToExtract = path.join(destination, lonelyDir.name);
-          const extractedDirFiles = await fs.promises.readdir(dirPathToExtract);
-          for (const file of extractedDirFiles) {
-            await fs.promises.rename(
-              path.join(dirPathToExtract, file),
-              path.join(destination, file),
-            );
-          }
-          await fs.promises.rmdir(dirPathToExtract);
-        }
-      }
-    }
-
-    await fs.promises.unlink(downloadedAssetPath);
-    return {
-      tagName: releaseData.tag_name,
-      type: 'github-release',
-    };
   } catch (error) {
     throw new Error(
       `Failed to download release from ${redactUrlCredentials(installMetadata.source)}: ${redactUrlCredentials(getErrorMessage(error))}`,
     );
   }
+
+  await extractArchiveFile(downloadedAssetPath, destination);
+
+  await fs.promises.unlink(downloadedAssetPath);
+  return {
+    tagName: releaseData.tag_name,
+    type: 'github-release',
+  };
+}
+
+export async function downloadFromArchiveUrl(
+  installMetadata: ExtensionInstallMetadata,
+  destination: string,
+): Promise<void> {
+  const archiveExtension = getSupportedArchiveExtension(installMetadata.source);
+  if (!archiveExtension) {
+    throw new Error(
+      `Unsupported archive URL for extension install: ${redactUrlCredentials(installMetadata.source)}`,
+    );
+  }
+
+  const archiveName =
+    path.basename(new URL(installMetadata.source).pathname) ||
+    `extension${archiveExtension}`;
+  const downloadedAssetPath = path.join(destination, archiveName);
+
+  try {
+    await downloadFile(installMetadata.source, downloadedAssetPath, {
+      includeGitHubToken: false,
+    });
+  } catch (error) {
+    throw new Error(
+      `Failed to download archive from ${redactUrlCredentials(installMetadata.source)}: ${redactUrlCredentials(getErrorMessage(error))}`,
+    );
+  }
+
+  await extractArchiveFile(downloadedAssetPath, destination);
+  await fs.promises.unlink(downloadedAssetPath);
+}
+
+export async function extractArchiveFile(
+  archivePath: string,
+  destination: string,
+): Promise<void> {
+  if (!isSupportedArchivePath(archivePath)) {
+    throw new Error(
+      `Unsupported archive file for extension install: ${redactUrlCredentials(archivePath)}`,
+    );
+  }
+  try {
+    await extractFile(archivePath, destination);
+  } catch (error) {
+    throw new Error(
+      'Extension archive could not be extracted. Make sure it is a valid ' +
+        `.zip or .tar.gz file. ${getErrorMessage(error)}`,
+    );
+  }
+  await flattenSingleExtensionDirectory(destination, archivePath);
+  assertExtractedArchiveContainsExtensionSource(destination);
 }
 
 export function findReleaseAsset(assets: Asset[]): Asset | undefined {
@@ -435,31 +549,123 @@ async function fetchJson<T>(url: string): Promise<T> {
   });
 }
 
-async function downloadFile(url: string, dest: string): Promise<void> {
+async function downloadFile(
+  url: string,
+  dest: string,
+  options: { includeGitHubToken?: boolean } = { includeGitHubToken: false },
+  redirectCount = 0,
+): Promise<void> {
+  if (redirectCount > 10) {
+    throw new Error('Too many redirects while downloading extension archive');
+  }
   const headers: { 'User-agent': string; Authorization?: string } = {
     'User-agent': 'gemini-cli',
   };
   const token = getGitHubToken();
-  if (token) {
+  if (options.includeGitHubToken === true && token) {
     headers.Authorization = `token ${token}`;
   }
+  const parsedUrl = new URL(url);
+  if (parsedUrl.protocol !== 'https:') {
+    throw new Error(`Unsupported download URL protocol: ${parsedUrl.protocol}`);
+  }
   return new Promise((resolve, reject) => {
-    https
-      .get(url, { headers }, (res) => {
-        if (res.statusCode === 302 || res.statusCode === 301) {
-          downloadFile(res.headers.location!, dest).then(resolve).catch(reject);
+    let settled = false;
+    let hardDeadline: NodeJS.Timeout | undefined;
+    const cleanup = () => {
+      if (hardDeadline) {
+        clearTimeout(hardDeadline);
+        hardDeadline = undefined;
+      }
+    };
+    const finish = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve();
+    };
+    const fail = (error: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const req = https
+      .get(parsedUrl, { headers }, (res) => {
+        if (
+          res.statusCode === 301 ||
+          res.statusCode === 302 ||
+          res.statusCode === 307 ||
+          res.statusCode === 308
+        ) {
+          if (!res.headers.location) {
+            reject(new Error('Redirect response missing location header'));
+            return;
+          }
+          res.resume();
+          let redirectUrl: URL;
+          try {
+            redirectUrl = new URL(res.headers.location, url);
+          } catch (error) {
+            fail(new Error(`Invalid redirect URL: ${getErrorMessage(error)}`));
+            return;
+          }
+          const redirectHost = redirectUrl.host;
+          const redirectOptions =
+            redirectHost === parsedUrl.host
+              ? options
+              : { ...options, includeGitHubToken: false };
+          cleanup();
+          downloadFile(
+            redirectUrl.toString(),
+            dest,
+            redirectOptions,
+            redirectCount + 1,
+          )
+            .then(finish)
+            .catch(fail);
           return;
         }
         if (res.statusCode !== 200) {
-          return reject(
+          res.resume();
+          return fail(
             new Error(`Request failed with status code ${res.statusCode}`),
           );
         }
         const file = fs.createWriteStream(dest);
+        let bytesWritten = 0;
+        res.on('data', (chunk: Buffer) => {
+          bytesWritten += chunk.length;
+          if (bytesWritten > ARCHIVE_DOWNLOAD_MAX_BYTES) {
+            res.destroy();
+            file.destroy();
+            fail(
+              new Error(
+                `Extension archive download exceeded maximum size of ${ARCHIVE_DOWNLOAD_MAX_BYTES} bytes`,
+              ),
+            );
+          }
+        });
+        res.on('error', fail);
+        file.on('error', fail);
         res.pipe(file);
-        file.on('finish', () => file.close(resolve as () => void));
+        file.on('finish', () => file.close(finish));
       })
-      .on('error', reject);
+      .on('error', fail);
+    if (!settled) {
+      hardDeadline = setTimeout(() => {
+        req.destroy();
+        fail(new Error('Timed out downloading extension archive'));
+      }, ARCHIVE_DOWNLOAD_TIMEOUT_MS);
+      req.setTimeout(ARCHIVE_DOWNLOAD_TIMEOUT_MS, () => {
+        req.destroy();
+        fail(new Error('Timed out downloading extension archive'));
+      });
+    }
   });
 }
 
@@ -468,10 +674,99 @@ export async function extractFile(file: string, dest: string): Promise<void> {
     await tar.x({
       file,
       cwd: dest,
+      filter: (_path, entry) =>
+        !('type' in entry) ||
+        (entry.type !== 'SymbolicLink' && entry.type !== 'Link'),
     });
   } else if (file.endsWith('.zip')) {
-    await extract(file, { dir: dest });
+    await extract(file, {
+      dir: dest,
+      onEntry: (entry) => {
+        if (isZipSymlinkEntry(entry.externalFileAttributes)) {
+          throw new Error(
+            `Zip archive contains unsupported symbolic link entry: ${entry.fileName}`,
+          );
+        }
+      },
+    });
   } else {
     throw new Error(`Unsupported file extension for extraction: ${file}`);
   }
+}
+
+function isZipSymlinkEntry(externalFileAttributes: number): boolean {
+  const mode = externalFileAttributes >>> 16;
+  return (mode & ZIP_FILE_TYPE_MASK) === ZIP_SYMBOLIC_LINK_TYPE;
+}
+
+async function flattenSingleExtensionDirectory(
+  destination: string,
+  archivePath: string,
+) {
+  // GitHub source archives and many uploaded archives wrap content in a single
+  // top-level directory. Flatten only when that directory looks like a valid
+  // extension root or a compatible source that can be converted later.
+  const archiveNameToIgnore = getContainedArchiveName(destination, archivePath);
+  const entries = (
+    await fs.promises.readdir(destination, {
+      withFileTypes: true,
+    })
+  ).filter((entry) => entry.name !== archiveNameToIgnore);
+  if (entries.length > 2) {
+    return;
+  }
+
+  const lonelyDir = entries.find((entry) => entry.isDirectory());
+  if (!lonelyDir) {
+    return;
+  }
+
+  const rootPath = path.join(destination, lonelyDir.name);
+  if (!hasSupportedExtensionSourceManifest(rootPath)) {
+    return;
+  }
+
+  const extractedDirFiles = await fs.promises.readdir(rootPath);
+  for (const file of extractedDirFiles) {
+    await fs.promises.rename(
+      path.join(rootPath, file),
+      path.join(destination, file),
+    );
+  }
+  await fs.promises.rmdir(rootPath);
+}
+
+function assertExtractedArchiveContainsExtensionSource(
+  destination: string,
+): void {
+  if (hasSupportedExtensionSourceManifest(destination)) {
+    return;
+  }
+
+  throw new Error(
+    'Extension archive is missing a supported extension manifest. ' +
+      `Expected ${EXTENSIONS_CONFIG_FILENAME}, gemini-extension.json, ` +
+      '.claude-plugin/marketplace.json, or .claude-plugin/plugin.json at the archive root, or inside a single top-level extension directory.',
+  );
+}
+
+function getContainedArchiveName(
+  destination: string,
+  archivePath: string,
+): string | undefined {
+  const resolvedDestination = path.resolve(destination);
+  const resolvedArchivePath = path.resolve(archivePath);
+  if (path.dirname(resolvedArchivePath) === resolvedDestination) {
+    return path.basename(resolvedArchivePath);
+  }
+  return undefined;
+}
+
+function hasSupportedExtensionSourceManifest(rootPath: string): boolean {
+  return (
+    fs.existsSync(path.join(rootPath, EXTENSIONS_CONFIG_FILENAME)) ||
+    fs.existsSync(path.join(rootPath, 'gemini-extension.json')) ||
+    fs.existsSync(path.join(rootPath, '.claude-plugin/marketplace.json')) ||
+    fs.existsSync(path.join(rootPath, '.claude-plugin/plugin.json'))
+  );
 }

--- a/packages/core/src/extension/github.ts
+++ b/packages/core/src/extension/github.ts
@@ -10,7 +10,6 @@ import * as os from 'node:os';
 import * as https from 'node:https';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { EXTENSIONS_CONFIG_FILENAME } from './variables.js';
 import * as tar from 'tar';
 import extract from 'extract-zip';
 import { createDebugLogger } from '../utils/debugLogger.js';
@@ -23,7 +22,10 @@ import {
 import type { ExtensionInstallMetadata } from '../config/config.js';
 import { checkNpmUpdate } from './npm.js';
 import { redactUrlCredentials } from './redaction.js';
-import { convertGeminiOrClaudeExtension } from './extension-converter.js';
+import {
+  convertGeminiOrClaudeExtension,
+  SUPPORTED_EXTENSION_MANIFESTS,
+} from './extension-converter.js';
 
 const debugLogger = createDebugLogger('EXT_GITHUB');
 const SUPPORTED_ARCHIVE_EXTENSIONS = ['.tar.gz', '.zip'] as const;
@@ -603,7 +605,8 @@ async function downloadFile(
           res.statusCode === 308
         ) {
           if (!res.headers.location) {
-            reject(new Error('Redirect response missing location header'));
+            res.resume();
+            fail(new Error('Redirect response missing location header'));
             return;
           }
           res.resume();
@@ -650,8 +653,14 @@ async function downloadFile(
             );
           }
         });
-        res.on('error', fail);
-        file.on('error', fail);
+        res.on('error', (error) => {
+          file.destroy();
+          fail(error);
+        });
+        file.on('error', (error) => {
+          res.destroy();
+          fail(error);
+        });
         res.pipe(file);
         file.on('finish', () => file.close(finish));
       })
@@ -671,12 +680,10 @@ async function downloadFile(
 
 export async function extractFile(file: string, dest: string): Promise<void> {
   if (file.endsWith('.tar.gz')) {
+    await assertTarArchiveHasNoLinks(file);
     await tar.x({
       file,
       cwd: dest,
-      filter: (_path, entry) =>
-        !('type' in entry) ||
-        (entry.type !== 'SymbolicLink' && entry.type !== 'Link'),
     });
   } else if (file.endsWith('.zip')) {
     await extract(file, {
@@ -691,6 +698,26 @@ export async function extractFile(file: string, dest: string): Promise<void> {
     });
   } else {
     throw new Error(`Unsupported file extension for extraction: ${file}`);
+  }
+}
+
+async function assertTarArchiveHasNoLinks(file: string): Promise<void> {
+  let unsupportedLinkPath: string | undefined;
+  await tar.t({
+    file,
+    onReadEntry: (entry) => {
+      if (
+        !unsupportedLinkPath &&
+        (entry.type === 'SymbolicLink' || entry.type === 'Link')
+      ) {
+        unsupportedLinkPath = entry.path;
+      }
+    },
+  });
+  if (unsupportedLinkPath) {
+    throw new Error(
+      `Tar archive contains unsupported link entry: ${unsupportedLinkPath}`,
+    );
   }
 }
 
@@ -712,6 +739,9 @@ async function flattenSingleExtensionDirectory(
       withFileTypes: true,
     })
   ).filter((entry) => entry.name !== archiveNameToIgnore);
+  if (hasSupportedExtensionSourceManifest(destination)) {
+    return;
+  }
   if (entries.length > 2) {
     return;
   }
@@ -728,12 +758,28 @@ async function flattenSingleExtensionDirectory(
 
   const extractedDirFiles = await fs.promises.readdir(rootPath);
   for (const file of extractedDirFiles) {
-    await fs.promises.rename(
-      path.join(rootPath, file),
-      path.join(destination, file),
-    );
+    const destinationPath = path.join(destination, file);
+    if (fs.existsSync(destinationPath)) {
+      throw new Error(
+        `Extension archive cannot be flattened because "${file}" exists at both the archive root and inside "${lonelyDir.name}".`,
+      );
+    }
+  }
+  for (const file of extractedDirFiles) {
+    const destinationPath = path.join(destination, file);
+    await fs.promises.rename(path.join(rootPath, file), destinationPath);
   }
   await fs.promises.rmdir(rootPath);
+}
+
+function getSupportedManifestList(): string {
+  return SUPPORTED_EXTENSION_MANIFESTS.join(', ');
+}
+
+function hasSupportedExtensionSourceManifest(rootPath: string): boolean {
+  return SUPPORTED_EXTENSION_MANIFESTS.some((manifestPath) =>
+    fs.existsSync(path.join(rootPath, manifestPath)),
+  );
 }
 
 function assertExtractedArchiveContainsExtensionSource(
@@ -745,8 +791,8 @@ function assertExtractedArchiveContainsExtensionSource(
 
   throw new Error(
     'Extension archive is missing a supported extension manifest. ' +
-      `Expected ${EXTENSIONS_CONFIG_FILENAME}, gemini-extension.json, ` +
-      '.claude-plugin/marketplace.json, or .claude-plugin/plugin.json at the archive root, or inside a single top-level extension directory.',
+      `Expected one of: ${getSupportedManifestList()} at the archive root, ` +
+      'or inside a single top-level extension directory.',
   );
 }
 
@@ -760,13 +806,4 @@ function getContainedArchiveName(
     return path.basename(resolvedArchivePath);
   }
   return undefined;
-}
-
-function hasSupportedExtensionSourceManifest(rootPath: string): boolean {
-  return (
-    fs.existsSync(path.join(rootPath, EXTENSIONS_CONFIG_FILENAME)) ||
-    fs.existsSync(path.join(rootPath, 'gemini-extension.json')) ||
-    fs.existsSync(path.join(rootPath, '.claude-plugin/marketplace.json')) ||
-    fs.existsSync(path.join(rootPath, '.claude-plugin/plugin.json'))
-  );
 }

--- a/packages/core/src/extension/marketplace.test.ts
+++ b/packages/core/src/extension/marketplace.test.ts
@@ -28,6 +28,18 @@ vi.mock('node:https', () => ({
 }));
 
 vi.mock('./github.js', () => ({
+  isSupportedArchiveUrl: vi.fn((url: string) => {
+    try {
+      const parsedUrl = new URL(url);
+      const pathname = parsedUrl.pathname.toLowerCase();
+      return (
+        parsedUrl.protocol === 'https:' &&
+        (pathname.endsWith('.zip') || pathname.endsWith('.tar.gz'))
+      );
+    } catch {
+      return false;
+    }
+  }),
   parseGitHubRepoForReleases: vi.fn((url: string) => {
     const match = url.match(/github\.com\/([^/]+)\/([^/]+)/);
     if (match) {
@@ -138,6 +150,32 @@ describe('parseInstallSource', () => {
       // scheme is not mistaken for a pluginName separator.
       expect(result.source).toBe('HTTPS://github.com/owner/repo');
       expect(result.type).toBe('git');
+      expect(result.pluginName).toBe('my-plugin');
+    });
+
+    it('should parse supported archive URLs as archive-url installs', async () => {
+      vi.mocked(fs.stat).mockRejectedValueOnce(new Error('ENOENT'));
+
+      const result = await parseInstallSource(
+        'https://example.com/releases/extension.tar.gz',
+      );
+
+      expect(result.source).toBe(
+        'https://example.com/releases/extension.tar.gz',
+      );
+      expect(result.type).toBe('archive-url');
+      expect(result.pluginName).toBeUndefined();
+    });
+
+    it('should parse supported archive URLs with plugin name', async () => {
+      vi.mocked(fs.stat).mockRejectedValueOnce(new Error('ENOENT'));
+
+      const result = await parseInstallSource(
+        'https://example.com/releases/extension.zip:my-plugin',
+      );
+
+      expect(result.source).toBe('https://example.com/releases/extension.zip');
+      expect(result.type).toBe('archive-url');
       expect(result.pluginName).toBe('my-plugin');
     });
   });

--- a/packages/core/src/extension/marketplace.ts
+++ b/packages/core/src/extension/marketplace.ts
@@ -11,7 +11,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as https from 'node:https';
 import { stat } from 'node:fs/promises';
-import { parseGitHubRepoForReleases } from './github.js';
+import { isSupportedArchiveUrl, parseGitHubRepoForReleases } from './github.js';
 import { isScopedNpmPackage } from './npm.js';
 import { redactUrlCredentials } from './redaction.js';
 
@@ -361,6 +361,12 @@ export async function parseInstallSource(
 
     // Try to read marketplace config from local path
     marketplaceConfig = await readLocalMarketplaceConfig(repo);
+  } else if (isSupportedArchiveUrl(repo)) {
+    installMetadata = {
+      source: repoSource,
+      type: 'archive-url',
+      pluginName,
+    };
   } else if (isGitUrl(repo)) {
     // Priority 2: Git URL (http://, https://, git@, sso://)
     installMetadata = {

--- a/scripts/tests/dev.test.js
+++ b/scripts/tests/dev.test.js
@@ -12,8 +12,6 @@ const { spawnMock, platformMock, existsSyncMock } = vi.hoisted(() => ({
   existsSyncMock: vi.fn(() => false),
 }));
 
-const normalizePath = (filePath) => String(filePath).replaceAll('\\', '/');
-
 vi.mock('node:child_process', () => ({
   spawn: spawnMock,
 }));
@@ -35,6 +33,8 @@ vi.mock('node:fs', () => ({
   symlinkSync: vi.fn(),
   mkdirSync: vi.fn(),
 }));
+
+const normalizePath = (path) => String(path).replaceAll('\\', '/');
 
 describe('scripts/dev.js launcher', () => {
   const originalArgv = process.argv;


### PR DESCRIPTION
## What this PR does

Adds support for installing extensions from local `.zip` and `.tar.gz` archives, plus remote archive URLs that end in `.zip` or `.tar.gz`. Archive installs reuse the existing extension extraction, validation, conversion, consent, copy, metadata, and update paths. Local archives stay as `local` install metadata, while remote archives use a new `archive-url` install metadata type so updates can replay the stored URL.

This also makes the existing Windows-only dev launcher test path assertions accept Windows path separators, which unblocked the Windows CI job.

## Why it is needed

Some extension authors distribute self-contained archives instead of git repositories or npm packages. Letting the install command consume those archives directly makes the CLI install path more flexible while keeping the extension structure and validation requirements the same.

## Reviewer Test Plan

### How to verify

Install a local `.zip` or `.tar.gz` archive that contains `qwen-extension.json` at the archive root, or inside a single top-level directory, and confirm it installs and writes local install metadata. Install a remote archive URL ending in `.zip` or `.tar.gz` and confirm it installs through the same consent and copy flow, stores `archive-url` metadata, and can be checked for updates by replaying that URL. Try a corrupt archive or an archive without a supported extension manifest and confirm the CLI reports a specific archive extraction or missing-manifest error.

### Evidence (Before & After)

Before: `qwen extensions install` treated HTTP(S) archive URLs as git sources, and local archive files were copied as files instead of being extracted as extension packages.

After: supported local archives and archive URLs are extracted, flattened when they contain a single top-level extension directory, validated for a compatible extension manifest, and installed through the normal extension manager flow.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ CI only |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Node.js >=22 with focused unit tests.

Commands run:

```sh
npx vitest run scripts/tests/dev.test.js
cd packages/core && npx vitest run src/extension/github.test.ts src/extension/marketplace.test.ts src/extension/extensionManager.test.ts
cd packages/cli && npx vitest run src/commands/extensions/install.test.ts
cd packages/core && npm run typecheck
cd packages/core && npm run build
```

## Risk & Scope

- Main risk or tradeoff: Archive URLs are recognized before generic HTTP(S) git sources when the URL path ends in `.zip` or `.tar.gz`.
- Not validated / out of scope: Full `npm run preflight` was not run; package-level CLI typecheck still fails on existing serve/channel/acp/web-template workspace errors outside this change.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #4910

<details>
<summary>中文说明</summary>

## What this PR does

支持从本地 `.zip` / `.tar.gz` 归档安装扩展，也支持从以 `.zip` 或 `.tar.gz` 结尾的远程归档 URL 安装扩展。归档安装复用现有扩展解压、校验、转换、授权确认、复制、metadata 写入和更新路径。本地归档仍保存为 `local` 安装 metadata；远程归档使用新的 `archive-url` 安装 metadata 类型，这样更新时可以重放保存的 URL。

同时让现有 Windows-only dev launcher 测试里的路径断言兼容 Windows 路径分隔符，用来解除 Windows CI job 的阻塞。

## Why it is needed

有些扩展作者会发布自包含归档，而不是 git 仓库或 npm 包。让 install 命令直接消费这些归档，可以让 CLI 安装路径更灵活，同时保持扩展结构和校验要求不变。

## Reviewer Test Plan

### How to verify

安装一个本地 `.zip` 或 `.tar.gz` 归档，归档根目录或单个顶层目录中包含 `qwen-extension.json`，确认它能安装并写入 local 安装 metadata。安装一个以 `.zip` 或 `.tar.gz` 结尾的远程归档 URL，确认它经过同一套确认和复制流程，保存 `archive-url` metadata，并能通过重放该 URL 检查更新。尝试损坏归档或缺少兼容 manifest 的归档，确认 CLI 输出明确的解压失败或缺少 manifest 错误。

### Evidence (Before & After)

Before：`qwen extensions install` 会把 HTTP(S) 归档 URL 当作 git source，本地归档文件也会作为普通文件复制，而不是作为扩展包解压。

After：支持的本地归档和归档 URL 会被解压；如果包含单个顶层扩展目录会自动展平；随后校验兼容扩展 manifest，并通过正常 extension manager 流程安装。

### Tested on

macOS 已本地测试；Windows 依赖 CI；Linux 未在本地测试。

### Environment (optional)

Node.js >=22，运行了聚焦单元测试。

## Risk & Scope

主要风险或权衡：当 URL path 以 `.zip` 或 `.tar.gz` 结尾时，archive URL 会优先于普通 HTTP(S) git source 被识别。

未验证或范围外：没有运行完整 `npm run preflight`；package-level CLI typecheck 仍会因为本次改动外已有的 serve/channel/acp/web-template workspace 错误失败。

破坏性变更或迁移说明：无。

## Linked Issues

Fixes #4910

</details>