### PR TITLE
fix(cli): route down-arrow straight to the live agent panel (#4907)

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -110,7 +110,6 @@ vi.mock('./contexts/AgentViewContext.js', () => ({
     agents: new Map(),
   })),
   useAgentViewActions: vi.fn(() => ({
-    switchToMain: vi.fn(),
     switchToAgent: vi.fn(),
     switchToNext: vi.fn(),
     switchToPrevious: vi.fn(),

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -214,6 +214,8 @@ describe('InputPrompt', () => {
       dialogMode: 'closed',
       dialogOpen: false,
       pillFocused: false,
+      livePanelFocused: false,
+      livePanelSelectedIndex: 0,
     });
     mockedUseBackgroundTaskViewActions.mockReturnValue({
       setPillFocused: mockViewActions.setBgPillFocused,
@@ -4396,6 +4398,41 @@ describe('InputPrompt', () => {
 
       expect(mockViewActions.setLivePanelFocused).toHaveBeenCalledWith(false);
       expect(mockViewActions.setAgentTabBarFocused).toHaveBeenCalledWith(true);
+      unmount();
+    });
+
+    it('Down at the bottom of the live agent panel returns to the composer when no tab bar exists', async () => {
+      // bg sub-agents without an Arena session: there is no tab bar below the
+      // panel, so Down at the last row releases focus back to the composer
+      // instead of silently consuming the key.
+      mockedUseAgentViewState.mockReturnValue({
+        activeView: 'main',
+        agents: new Map(),
+        agentShellFocused: false,
+        agentInputBufferText: '',
+        agentTabBarFocused: false,
+        agentApprovalModes: new Map(),
+      } as unknown as ReturnType<typeof useAgentViewState>);
+      mockedUseBackgroundTaskViewState.mockReturnValue({
+        entries: [{ kind: 'agent', agentId: 'bg-agent' }],
+        selectedIndex: 0,
+        dialogMode: 'closed',
+        dialogOpen: false,
+        pillFocused: false,
+        livePanelFocused: true,
+        livePanelSelectedIndex: 1, // bottom row: 0 = main, 1 = the only bg agent
+      } as unknown as ReturnType<typeof useBackgroundTaskViewState>);
+
+      const { stdin, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+
+      stdin.write('\u001B[B'); // Down arrow
+      await wait();
+
+      expect(mockViewActions.setLivePanelFocused).toHaveBeenCalledWith(false);
+      expect(mockViewActions.setAgentTabBarFocused).not.toHaveBeenCalled();
       unmount();
     });
 

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -41,6 +41,8 @@ import {
 const mockViewActions = vi.hoisted(() => ({
   setAgentTabBarFocused: vi.fn(),
   setBgPillFocused: vi.fn(),
+  setLivePanelFocused: vi.fn(),
+  setLivePanelSelectedIndex: vi.fn(),
 }));
 
 vi.mock('../hooks/useShellHistory.js');
@@ -81,6 +83,8 @@ vi.mock('../contexts/BackgroundTaskViewContext.js', () => ({
   })),
   useBackgroundTaskViewActions: vi.fn(() => ({
     setPillFocused: mockViewActions.setBgPillFocused,
+    setLivePanelFocused: mockViewActions.setLivePanelFocused,
+    setLivePanelSelectedIndex: mockViewActions.setLivePanelSelectedIndex,
   })),
 }));
 
@@ -180,6 +184,8 @@ describe('InputPrompt', () => {
     vi.resetAllMocks();
     mockViewActions.setAgentTabBarFocused.mockReset();
     mockViewActions.setBgPillFocused.mockReset();
+    mockViewActions.setLivePanelFocused.mockReset();
+    mockViewActions.setLivePanelSelectedIndex.mockReset();
 
     mockedUseUIState.mockReturnValue({
       isFeedbackDialogOpen: false,
@@ -211,6 +217,8 @@ describe('InputPrompt', () => {
     });
     mockedUseBackgroundTaskViewActions.mockReturnValue({
       setPillFocused: mockViewActions.setBgPillFocused,
+      setLivePanelFocused: mockViewActions.setLivePanelFocused,
+      setLivePanelSelectedIndex: mockViewActions.setLivePanelSelectedIndex,
     } as unknown as ReturnType<typeof useBackgroundTaskViewActions>);
 
     mockCommandContext = createMockCommandContext();
@@ -4277,6 +4285,116 @@ describe('InputPrompt', () => {
       await wait();
 
       expect(mockInputHistory.navigateDown).toHaveBeenCalled();
+      expect(mockViewActions.setAgentTabBarFocused).toHaveBeenCalledWith(true);
+      unmount();
+    });
+
+    it('arrow Down jumps straight to the live agent panel when a bg sub-agent is running (#4907)', async () => {
+      // Core regression for #4907: with both an Arena session (tab bar) and a
+      // running background sub-agent (live panel), Down must reach the panel in
+      // ONE press — not stop at the tab bar first.
+      (mockInputHistory.navigateDown as Mock).mockReturnValue(false);
+      mockedUseAgentViewState.mockReturnValue({
+        activeView: 'main',
+        agents: new Map([['agent-1', {}]]),
+        agentShellFocused: false,
+        agentInputBufferText: '',
+        agentTabBarFocused: false,
+        agentApprovalModes: new Map(),
+      } as unknown as ReturnType<typeof useAgentViewState>);
+      mockedUseBackgroundTaskViewState.mockReturnValue({
+        entries: [{ kind: 'agent', agentId: 'bg-agent' }],
+        selectedIndex: 0,
+        dialogMode: 'closed',
+        dialogOpen: false,
+        pillFocused: false,
+        livePanelFocused: false,
+        livePanelSelectedIndex: 0,
+      } as unknown as ReturnType<typeof useBackgroundTaskViewState>);
+      mockBuffer.setText('draft');
+      mockBuffer.visualCursor = [0, 'draft'.length];
+
+      const { stdin, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+
+      stdin.write('\u001B[B'); // Down arrow
+      await wait();
+
+      expect(mockViewActions.setLivePanelFocused).toHaveBeenCalledWith(true);
+      expect(mockViewActions.setAgentTabBarFocused).not.toHaveBeenCalled();
+      unmount();
+    });
+
+    it('arrow Down still falls through to the tab bar when the only bg entry is a non-agent (shell) task', async () => {
+      // bgAgentCount (not bgEntries.length) gates the panel jump: a lone shell
+      // task does not render the live panel, so Down must reach the tab bar
+      // instead of focusing a panel that would immediately auto-unfocus.
+      (mockInputHistory.navigateDown as Mock).mockReturnValue(false);
+      mockedUseAgentViewState.mockReturnValue({
+        activeView: 'main',
+        agents: new Map([['agent-1', {}]]),
+        agentShellFocused: false,
+        agentInputBufferText: '',
+        agentTabBarFocused: false,
+        agentApprovalModes: new Map(),
+      } as unknown as ReturnType<typeof useAgentViewState>);
+      mockedUseBackgroundTaskViewState.mockReturnValue({
+        entries: [{ kind: 'shell', shellId: 'bg-shell' }],
+        selectedIndex: 0,
+        dialogMode: 'closed',
+        dialogOpen: false,
+        pillFocused: false,
+        livePanelFocused: false,
+        livePanelSelectedIndex: 0,
+      } as unknown as ReturnType<typeof useBackgroundTaskViewState>);
+      mockBuffer.setText('draft');
+      mockBuffer.visualCursor = [0, 'draft'.length];
+
+      const { stdin, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+
+      stdin.write('\u001B[B'); // Down arrow
+      await wait();
+
+      expect(mockViewActions.setAgentTabBarFocused).toHaveBeenCalledWith(true);
+      expect(mockViewActions.setLivePanelFocused).not.toHaveBeenCalled();
+      unmount();
+    });
+
+    it('Down at the bottom of the live agent panel descends to the agent tab bar', async () => {
+      // Restores tab-bar reachability after the priority swap: from the panel's
+      // last row, Down hands focus to the tab bar (the surface below it).
+      mockedUseAgentViewState.mockReturnValue({
+        activeView: 'main',
+        agents: new Map([['agent-1', {}]]),
+        agentShellFocused: false,
+        agentInputBufferText: '',
+        agentTabBarFocused: false,
+        agentApprovalModes: new Map(),
+      } as unknown as ReturnType<typeof useAgentViewState>);
+      mockedUseBackgroundTaskViewState.mockReturnValue({
+        entries: [{ kind: 'agent', agentId: 'bg-agent' }],
+        selectedIndex: 0,
+        dialogMode: 'closed',
+        dialogOpen: false,
+        pillFocused: false,
+        livePanelFocused: true,
+        livePanelSelectedIndex: 1, // bottom row: 0 = main, 1 = the only bg agent
+      } as unknown as ReturnType<typeof useBackgroundTaskViewState>);
+
+      const { stdin, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+
+      stdin.write('\u001B[B'); // Down arrow
+      await wait();
+
+      expect(mockViewActions.setLivePanelFocused).toHaveBeenCalledWith(false);
       expect(mockViewActions.setAgentTabBarFocused).toHaveBeenCalledWith(true);
       unmount();
     });

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -164,9 +164,8 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     setSelectedIndex: setBgSelectedIndex,
   } = useBackgroundTaskViewActions();
   const hasAgents = agents.size > 0;
-  // Includes terminal entries — the pill stays open so users can reopen
-  // the dialog to inspect final state after the last agent finishes.
-  const hasBgAgents = bgEntries.length > 0;
+  // Live-panel roster: count only `kind === 'agent'` entries — exactly what the
+  // LiveAgentPanel renders, so it's the right gate for focusing the panel.
   const bgAgentCount = useMemo(
     () => bgEntries.filter((e) => e.kind === 'agent').length,
     [bgEntries],
@@ -531,6 +530,11 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           const maxIdx = bgAgentCount; // 0=main, 1..N=agents
           if (livePanelSelectedIndex < maxIdx) {
             setLivePanelSelectedIndex(livePanelSelectedIndex + 1);
+          } else if (hasAgents) {
+            // Bottom of the panel → descend to the tab bar below it
+            // (only rendered when Arena agents exist; else stay put).
+            setLivePanelFocused(false);
+            setAgentTabBarFocused(true);
           }
           return true;
         }
@@ -1146,12 +1150,14 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           if (inputHistory.navigateDown()) {
             return true;
           }
-          if (hasAgents) {
-            setAgentTabBarFocused(true);
+          // Down from an empty composer, in visual top→bottom order:
+          // live agent panel (if bg sub-agents) → tab bar (if Arena) → stay.
+          if (bgAgentCount > 0) {
+            setLivePanelFocused(true);
             return true;
           }
-          if (hasBgAgents) {
-            setLivePanelFocused(true);
+          if (hasAgents) {
+            setAgentTabBarFocused(true);
             return true;
           }
           return true;
@@ -1187,15 +1193,14 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           if (inputHistory.navigateDown()) {
             return true;
           }
-          // Focus order on Down from an empty composer:
-          // team tab bar (if any Arena agents) → Background tasks
-          // dialog (if any bg agents) → otherwise stay put.
-          if (hasAgents) {
-            setAgentTabBarFocused(true);
+          // Down from an empty composer, in visual top→bottom order:
+          // live agent panel (if bg sub-agents) → tab bar (if Arena) → stay.
+          if (bgAgentCount > 0) {
+            setLivePanelFocused(true);
             return true;
           }
-          if (hasBgAgents) {
-            setLivePanelFocused(true);
+          if (hasAgents) {
+            setAgentTabBarFocused(true);
             return true;
           }
           return true;
@@ -1389,7 +1394,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       bgDialogOpen,
       bgPillFocused,
       hasAgents,
-      hasBgAgents,
       hasActiveToolConfirmation,
       setAgentTabBarFocused,
       setLivePanelFocused,

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -515,6 +515,18 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     });
   }, []);
 
+  // Down from an empty composer (bottom edge, history exhausted), in visual
+  // top→bottom order: live agent panel (if bg sub-agents) → tab bar (if
+  // Arena) → stay put. Always consumes the key.
+  const descendFromComposer = useCallback((): boolean => {
+    if (bgAgentCount > 0) {
+      setLivePanelFocused(true);
+    } else if (hasAgents) {
+      setAgentTabBarFocused(true);
+    }
+    return true;
+  }, [bgAgentCount, hasAgents, setLivePanelFocused, setAgentTabBarFocused]);
+
   const handleInput = useCallback(
     (key: Key): boolean => {
       // When the Arena tab bar or background pill has focus, block
@@ -532,9 +544,13 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
             setLivePanelSelectedIndex(livePanelSelectedIndex + 1);
           } else if (hasAgents) {
             // Bottom of the panel → descend to the tab bar below it
-            // (only rendered when Arena agents exist; else stay put).
+            // (only rendered when Arena agents exist).
             setLivePanelFocused(false);
             setAgentTabBarFocused(true);
+          } else {
+            // No tab bar below → release focus back to the composer instead
+            // of silently consuming the key.
+            setLivePanelFocused(false);
           }
           return true;
         }
@@ -1150,17 +1166,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           if (inputHistory.navigateDown()) {
             return true;
           }
-          // Down from an empty composer, in visual top→bottom order:
-          // live agent panel (if bg sub-agents) → tab bar (if Arena) → stay.
-          if (bgAgentCount > 0) {
-            setLivePanelFocused(true);
-            return true;
-          }
-          if (hasAgents) {
-            setAgentTabBarFocused(true);
-            return true;
-          }
-          return true;
+          return descendFromComposer();
         }
         // Handle arrow-up/down for history on single-line or at edges
         if (
@@ -1193,17 +1199,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           if (inputHistory.navigateDown()) {
             return true;
           }
-          // Down from an empty composer, in visual top→bottom order:
-          // live agent panel (if bg sub-agents) → tab bar (if Arena) → stay.
-          if (bgAgentCount > 0) {
-            setLivePanelFocused(true);
-            return true;
-          }
-          if (hasAgents) {
-            setAgentTabBarFocused(true);
-            return true;
-          }
-          return true;
+          return descendFromComposer();
         }
       } else {
         // Shell History Navigation
@@ -1401,6 +1397,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       livePanelFocused,
       livePanelSelectedIndex,
       bgAgentCount,
+      descendFromComposer,
       enterBgDetailFromPanel,
       setBgSelectedIndex,
       followup,

--- a/packages/cli/src/ui/components/agent-view/AgentTabBar.test.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentTabBar.test.tsx
@@ -45,21 +45,13 @@ const pressKey = (overrides: Partial<Key>) => {
 };
 
 describe('AgentTabBar', () => {
-  const switchToMain = vi.fn();
   const setAgentTabBarFocused = vi.fn();
   const setLivePanelFocused = vi.fn();
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-    activeKeypressHandler = null;
-
-    vi.mocked(useKeypress).mockImplementation((handler, { isActive }) => {
-      if (isActive) {
-        activeKeypressHandler = handler;
-      }
-    });
+  // Point the mocked view state at a given tab; tab bar starts focused.
+  const setActiveView = (activeView: string) =>
     vi.mocked(useAgentViewState).mockReturnValue({
-      activeView: 'agent-1',
+      activeView,
       agents: new Map([
         [
           'agent-1',
@@ -76,10 +68,20 @@ describe('AgentTabBar', () => {
       agentShellFocused: false,
       agentTabBarFocused: true,
     } as never);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    activeKeypressHandler = null;
+
+    vi.mocked(useKeypress).mockImplementation((handler, { isActive }) => {
+      if (isActive) {
+        activeKeypressHandler = handler;
+      }
+    });
+    setActiveView('agent-1');
     vi.mocked(useAgentViewActions).mockReturnValue({
       switchToNext: vi.fn(),
       switchToPrevious: vi.fn(),
-      switchToMain,
       setAgentTabBarFocused,
     } as never);
     vi.mocked(useBackgroundTaskViewState).mockReturnValue({
@@ -93,14 +95,64 @@ describe('AgentTabBar', () => {
     } as never);
   });
 
-  it('uses Ctrl+P/N for focus-chain navigation', () => {
+  it('Up on the Main view ascends to the live agent panel when a bg agent roster exists', () => {
+    setActiveView('main');
     render(<AgentTabBar />);
 
-    pressKey({ name: 'p', sequence: '\u0010', ctrl: true });
+    // Arrow Up: release tab-bar focus and focus the panel (rendered on Main).
+    pressKey({ name: 'up', sequence: '[A' });
     expect(setAgentTabBarFocused).toHaveBeenCalledWith(false);
-
-    pressKey({ name: 'n', sequence: '\u000E', ctrl: true });
-    expect(switchToMain).toHaveBeenCalledTimes(1);
     expect(setLivePanelFocused).toHaveBeenCalledWith(true);
+
+    // Ctrl+P is the alias for Up and must behave identically.
+    pressKey({ name: 'p', ctrl: true });
+    expect(setLivePanelFocused).toHaveBeenCalledTimes(2);
+  });
+
+  it('Up on an agent tab returns to the composer (no panel jump), keeping AgentComposer round-trip symmetric', () => {
+    // Default view is the agent tab 'agent-1'; the live panel is not rendered
+    // there, so ↑ must simply release focus back to the AgentComposer.
+    render(<AgentTabBar />);
+
+    pressKey({ name: 'up', sequence: '[A' });
+    expect(setAgentTabBarFocused).toHaveBeenCalledWith(false);
+    expect(setLivePanelFocused).not.toHaveBeenCalled();
+  });
+
+  it('Up returns focus to the input when there is no bg agent roster', () => {
+    setActiveView('main');
+    vi.mocked(useBackgroundTaskViewState).mockReturnValue({
+      entries: [],
+    } as never);
+    render(<AgentTabBar />);
+
+    pressKey({ name: 'up', sequence: '[A' });
+    expect(setAgentTabBarFocused).toHaveBeenCalledWith(false);
+    expect(setLivePanelFocused).not.toHaveBeenCalled();
+  });
+
+  it('Up ignores non-agent bg entries (e.g. background shell) on the Main view', () => {
+    // The panel only renders kind === 'agent' entries, so a lone shell task
+    // must not make ↑ jump to a panel that has nothing to show.
+    setActiveView('main');
+    vi.mocked(useBackgroundTaskViewState).mockReturnValue({
+      entries: [{ kind: 'shell', shellId: 'bg-shell' }],
+    } as never);
+    render(<AgentTabBar />);
+
+    pressKey({ name: 'up', sequence: '[A' });
+    expect(setAgentTabBarFocused).toHaveBeenCalledWith(false);
+    expect(setLivePanelFocused).not.toHaveBeenCalled();
+  });
+
+  it('Down (↓ / Ctrl+N) is a no-op — the tab bar is the bottom of the focus chain', () => {
+    // Default mock has a bg agent roster present; Down must still do nothing
+    // (the panel is reached via ↑, not by hopping down off the bottom).
+    render(<AgentTabBar />);
+
+    pressKey({ name: 'down', sequence: '[B' });
+    pressKey({ name: 'n', ctrl: true });
+    expect(setLivePanelFocused).not.toHaveBeenCalled();
+    expect(setAgentTabBarFocused).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/ui/components/agent-view/AgentTabBar.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentTabBar.tsx
@@ -13,7 +13,9 @@
  * On agent tabs, the tab bar uses an exclusive-focus model:
  *   - Down arrow at the input's bottom edge focuses the tab bar
  *   - Left/Right switch tabs only when the tab bar is focused
- *   - Up arrow or typing returns focus to the input
+ *   - Up arrow: on Main with bg sub-agents → live agent panel; otherwise
+ *     (agent tab, or no roster) → input. Typing also returns focus to input.
+ *   - Down arrow is a no-op — the tab bar is the bottom of the focus chain
  *
  * Tab indicators:  running,  idle/completed,  failed,  cancelled
  */
@@ -63,16 +65,14 @@ function statusIndicator(agent: RegisteredAgent): {
 export const AgentTabBar: React.FC = () => {
   const { activeView, agents, agentShellFocused, agentTabBarFocused } =
     useAgentViewState();
-  const {
-    switchToNext,
-    switchToPrevious,
-    switchToMain,
-    setAgentTabBarFocused,
-  } = useAgentViewActions();
+  const { switchToNext, switchToPrevious, setAgentTabBarFocused } =
+    useAgentViewActions();
   const { entries: bgEntries } = useBackgroundTaskViewState();
   const { setLivePanelFocused } = useBackgroundTaskViewActions();
   const { embeddedShellFocused } = useUIState();
-  const hasBgAgents = bgEntries.length > 0;
+  // Gate panel focus on the panel's own render condition (`kind === 'agent'`),
+  // not `bgEntries.length` (which also counts shell/monitor/dream tasks).
+  const hasBgAgentRoster = bgEntries.some((e) => e.kind === 'agent');
 
   useKeypress(
     (key) => {
@@ -85,12 +85,15 @@ export const AgentTabBar: React.FC = () => {
         switchToNext();
       } else if (key.name === 'up' || (key.ctrl && key.name === 'p')) {
         setAgentTabBarFocused(false);
-      } else if (key.name === 'down' || (key.ctrl && key.name === 'n')) {
-        if (hasBgAgents) {
-          setAgentTabBarFocused(false);
-          switchToMain();
+        // On Main, ascend to the live agent panel above the tab bar. On agent
+        // tabs the panel isn't rendered, so ↑ just returns to the composer
+        // (keeping AgentComposer's ↓/↑ round-trip symmetric).
+        if (activeView === 'main' && hasBgAgentRoster) {
           setLivePanelFocused(true);
         }
+      } else if (key.name === 'down' || (key.ctrl && key.name === 'n')) {
+        // No-op: the tab bar is the bottom of the chain
+        // (input → panel → tab bar); the panel is reached via ↑.
       } else if (
         key.sequence &&
         key.sequence.length === 1 &&

--- a/packages/cli/src/ui/contexts/AgentViewContext.tsx
+++ b/packages/cli/src/ui/contexts/AgentViewContext.tsx
@@ -56,7 +56,6 @@ export interface AgentViewState {
 }
 
 export interface AgentViewActions {
-  switchToMain(): void;
   switchToAgent(agentId: string): void;
   switchToNext(): void;
   switchToPrevious(): void;
@@ -94,7 +93,6 @@ const DEFAULT_STATE: AgentViewState = {
 const noop = () => {};
 
 const DEFAULT_ACTIONS: AgentViewActions = {
-  switchToMain: noop,
   switchToAgent: noop,
   switchToNext: noop,
   switchToPrevious: noop,
@@ -142,11 +140,6 @@ export function AgentViewProvider({
   >(() => new Map());
 
   // ── Navigation ──
-
-  const switchToMain = useCallback(() => {
-    setActiveView('main');
-    setAgentTabBarFocused(false);
-  }, []);
 
   const switchToAgent = useCallback(
     (agentId: string) => {
@@ -265,7 +258,6 @@ export function AgentViewProvider({
 
   const actions: AgentViewActions = useMemo(
     () => ({
-      switchToMain,
       switchToAgent,
       switchToNext,
       switchToPrevious,
@@ -278,7 +270,6 @@ export function AgentViewProvider({
       setAgentApprovalMode,
     }),
     [
-      switchToMain,
       switchToAgent,
       switchToNext,
       switchToPrevious,


### PR DESCRIPTION
## What this PR does

Reorders the TUI keyboard focus chain so that Down from an empty input reaches a running background sub-agent in **one** press instead of two. The chain now follows the visual top-to-bottom layout — input, live agent panel, tab bar:

| From | Key | To |
|---|---|---|
| Input (bottom edge, history exhausted) | ↓ | Live agent panel (if bg sub-agents) → else tab bar (if Arena) → else stay |
| Live agent panel (bottom row) | ↓ | Tab bar (if Arena agents) → else stay |
| Live agent panel (top row) | ↑ | Input |
| Tab bar (on Main, with bg sub-agents) | ↑ | Live agent panel |
| Tab bar (otherwise) | ↑ | Input / composer |
| Tab bar | ↓ | No-op (bottom of the chain) |

Panel-focusing jumps are gated on the agent roster (`kind === 'agent'`, the panel's actual render condition), so a lone background shell/monitor task never produces a dead press into a panel that isn't rendered. The tab bar's old Down-to-panel hop — the second press of the old path — is removed; the panel is now reached from the tab bar via ↑, which also makes the `switchToMain()` side effect unnecessary.

## Why it's needed

Fixes #4907: with an Arena session and a running background sub-agent, the first ↓ from the input stopped at the tab bar — the bottom-most surface — while the panel sits directly under the input, so the extra press was also spatially incoherent. The double-press requires an Arena session and a background sub-agent active at the same time (repro details in the issue thread).

## Reviewer Test Plan

### How to verify

1. With an Arena session and a background sub-agent visible: input empty, press ↓ once — focus lands directly on the live agent panel (was: tab bar first, panel on the second press).
2. ↓ to the panel's last row, then ↓ once more — tab bar focused; ↑ — back to the panel; ↑ from the panel's top — input. Every surface reachable in both directions.
3. With only a non-agent background task (e.g. a background shell), ↓ goes straight to the tab bar. On an agent tab, composer ↓ → tab bar and ↑ → composer, unchanged.

Unit coverage: `npx vitest run packages/cli/src/ui/components/InputPrompt.test.tsx packages/cli/src/ui/components/agent-view/AgentTabBar.test.tsx` — three new InputPrompt cases and a rewritten five-case AgentTabBar suite (arrow keys plus Ctrl+P/N aliases).

### Evidence (Before & After)

**Before:** ↓ from the input focused the tab bar ("Main" highlighted); a second ↓ was needed to reach the running sub-agent.

**After:** ↓ reaches the panel directly; the tab bar sits at the end of the chain — ↓ from the panel's bottom row descends to it, ↑ ascends back.

<!-- 强烈建议在这里补一段 10 秒左右的录屏或 tmux 记录（模板对 TUI 改动点名要求；仓库自带 tmux-real-user-testing skill）。Arena 会话 + 一个 Agent tool 子代理即可复现。 -->

### Tested on

<!-- 把 ✅ 移到你实际本地跑过测试的系统行，其余保持 ⚠️ -->

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Unit tests only — the affected vitest suites plus `eslint`, `prettier --check`, and `tsc --noEmit` on the changed packages. <!-- 若你本地用 npm run dev 起过交互验证，在这里写明 -->

## Risk & Scope

- Main risk or tradeoff: with sub-agents present, reaching the tab bar from the input now costs ↓ through the panel rows instead of a single press — accepted since the panel is the more frequent target and the order now matches the layout. The simpler alternative of skipping the tab bar whenever background entries exist was rejected: finished entries linger and ←/→ only work once the bar is focused, so it would leave the tab bar permanently unreachable by keyboard.
- Not validated / out of scope: full `npm run preflight` not run (targeted suites + lint + format + typecheck only); a full interactive repro requires a live session that spawns a sub-agent, covered here by handler-level unit tests. The agent-tab composer is intentionally unchanged — the panel doesn't render on agent tabs.
- Breaking changes / migration notes: none — keyboard navigation only.

## Linked Issues

Fixes #4907

<details>
<summary>中文说明</summary>

## What this PR does

重排 TUI 键盘焦点链：后台 subagent 运行时，从空输入框按 **↓** 一次即可到达，不再需要两次。焦点链与视觉上下顺序一致——输入框、live agent panel、tab bar：

| 起点 | 按键 | 终点 |
|---|---|---|
| 输入框（底部边缘、历史已到底） | ↓ | live agent panel（有后台子代理）→ 否则 tab bar（有 Arena）→ 否则原地 |
| live agent panel（最后一行） | ↓ | tab bar（有 Arena agents）→ 否则原地 |
| live agent panel（第一行） | ↑ | 输入框 |
| tab bar（Main 视图且有后台子代理） | ↑ | live agent panel |
| tab bar（其他情况） | ↑ | 输入框 / composer |
| tab bar | ↓ | 无操作（链的最底端） |

聚焦面板的跳转以 agent roster（`kind === 'agent'`，面板真实的渲染条件）为门控，单独的后台 shell/monitor 任务不会造成按进未渲染面板的空按。移除 tab bar 旧的 ↓→面板跳转——它本来就是旧路径的第二跳——面板改由 tab bar 的 ↑ 到达，`switchToMain()` 副作用随之删除。

## Why it's needed

修复 #4907：Arena 会话与后台 subagent 并存时，输入框的第一次 ↓ 停在 tab bar——视觉最底部的 surface——而面板就在输入框正下方，多出的这一按在空间上也不合理。双按场景需要 Arena 会话与后台子代理同时存在（复现细节见 issue 讨论）。

## Reviewer Test Plan

### How to verify

1. Arena 会话 + 后台子代理同时可见：输入框为空按一次 ↓——焦点直接落在 live agent panel（旧行为：先 tab bar，第二次才到面板）。
2. ↓ 到面板最后一行再按一次——tab bar 聚焦；↑——回到面板；面板第一行再 ↑——回输入框。所有 surface 双向可达。
3. 后台只有非 agent 任务（如后台 shell）时，↓ 直达 tab bar。agent tab 下 composer ↓→tab bar、↑→composer，行为不变。

单测覆盖：`npx vitest run packages/cli/src/ui/components/InputPrompt.test.tsx packages/cli/src/ui/components/agent-view/AgentTabBar.test.tsx`——InputPrompt 新增 3 个用例，AgentTabBar 重写为 5 个用例（箭头键及 Ctrl+P/N 别名）。

### Evidence (Before & After)

**Before：**输入框 ↓ 聚焦 tab bar（高亮 "Main"）；需第二次 ↓ 才到达运行中的子代理。

**After：**↓ 直达面板；tab bar 位于链末端——面板最后一行 ↓ 下行到达，↑ 上行返回。

### Tested on

macOS 本地运行了受影响的单测套件；Windows / Linux 依赖 CI（平台无关的键盘焦点逻辑）。

### Environment (optional)

仅单元测试——受影响的 vitest 套件，及变更包上的 `eslint`、`prettier --check`、`tsc --noEmit`。

## Risk & Scope

- 主要风险或权衡：子代理存在时，从输入框到达 tab bar 需 ↓ 穿过面板各行而非一次——接受该代价：面板是更高频的目标，且顺序与布局一致。更简单的"只要有后台条目就跳过 tab bar"被否决：已结束条目会常驻，而 ←/→ 仅在 tab bar 已聚焦时生效，该方案会使其永久键盘不可达。
- 未验证 / 范围外：未跑完整 `npm run preflight`（仅定向套件 + lint + format + typecheck）；完整交互复现需要真实会话拉起子代理，此处由 handler 级单测覆盖。agent tab 的 composer 刻意不改——面板不在 agent tab 渲染。
- 破坏性变更 / 迁移说明：无——仅键盘导航。

## Linked Issues

Fixes #4907

</details>
