### PR TITLE
fix(ci): normalize dev launcher path assertions on Windows

### DIFF
--- a/scripts/tests/dev.test.js
+++ b/scripts/tests/dev.test.js
@@ -12,6 +12,8 @@ const { spawnMock, platformMock, existsSyncMock } = vi.hoisted(() => ({
   existsSyncMock: vi.fn(() => false),
 }));
 
+const normalizePath = (filePath) => String(filePath).replaceAll('\\', '/');
+
 vi.mock('node:child_process', () => ({
   spawn: spawnMock,
 }));
@@ -57,7 +59,7 @@ describe('scripts/dev.js launcher', () => {
   it('spawns Node without a shell on Windows when local tsx cli.mjs exists', async () => {
     platformMock.mockReturnValue('win32');
     existsSyncMock.mockImplementation((filePath) =>
-      String(filePath).endsWith('node_modules/tsx/dist/cli.mjs'),
+      normalizePath(filePath).endsWith('node_modules/tsx/dist/cli.mjs'),
     );
     Object.defineProperty(process, 'execPath', {
       configurable: true,
@@ -67,29 +69,29 @@ describe('scripts/dev.js launcher', () => {
 
     await import('../dev.js?direct-node');
 
-    expect(spawnMock).toHaveBeenCalledWith(
-      'C:\\Program Files\\nodejs\\node.exe',
-      [
-        expect.stringContaining('node_modules/tsx/dist/cli.mjs'),
-        expect.stringContaining('packages/cli/index.ts'),
-        '--help',
-      ],
-      expect.objectContaining({ shell: false }),
-    );
+    const [command, args, options] = spawnMock.mock.calls[0];
+    expect(command).toBe('C:\\Program Files\\nodejs\\node.exe');
+    expect(args.map(normalizePath)).toEqual([
+      expect.stringContaining('node_modules/tsx/dist/cli.mjs'),
+      expect.stringContaining('packages/cli/index.ts'),
+      '--help',
+    ]);
+    expect(options).toEqual(expect.objectContaining({ shell: false }));
   });
 
   it('keeps shell fallback for Windows tsx.cmd resolution', async () => {
     platformMock.mockReturnValue('win32');
     existsSyncMock.mockImplementation((filePath) =>
-      String(filePath).endsWith('node_modules/.bin/tsx.cmd'),
+      normalizePath(filePath).endsWith('node_modules/.bin/tsx.cmd'),
     );
 
     await import('../dev.js?cmd-fallback');
 
-    expect(spawnMock).toHaveBeenCalledWith(
-      expect.stringContaining('tsx.cmd'),
-      [expect.stringContaining('packages/cli/index.ts')],
-      expect.objectContaining({ shell: true }),
-    );
+    const [command, args, options] = spawnMock.mock.calls[0];
+    expect(normalizePath(command)).toContain('tsx.cmd');
+    expect(args.map(normalizePath)).toEqual([
+      expect.stringContaining('packages/cli/index.ts'),
+    ]);
+    expect(options).toEqual(expect.objectContaining({ shell: true }));
   });
 });


### PR DESCRIPTION
## What this PR does

Makes the two Windows-targeted `scripts/dev.js` launcher tests path-separator agnostic, so they pass on real `windows-latest` runners and main's Windows CI recovers.

## Why it's needed

Main's `Test (windows-latest, Node 22.x)` job has been red on every push since `423cac110` (#4728) — last green main commit `9e4c87a7e`, with `fb1432cf5`, `9533aface`, `1190ef316` all failing on the same two tests (e.g. run [27235517277](https://github.com/QwenLM/qwen-code/actions/runs/27235517277)). This also turns the Windows check red on every open PR that includes current main (seen on #4519).

Root cause: the tests (added in #4728) mock `existsSync` with forward-slash suffix matching (`endsWith('node_modules/tsx/dist/cli.mjs')`) and assert spawn args with forward-slash `stringContaining('packages/cli/index.ts')`. They mock `platform()` to `win32`, but `dev.js` builds paths with the real `path.join` — backslashes on a real Windows host. The `existsSync` mock therefore never matches, `dev.js` falls into the bare `tsx.cmd` shell fallback, and both assertions fail. On macOS/Linux the real joins use `/`, so the tests only fail on actual Windows — the platform they were written to cover.

Fix: normalize separators (`normalizePath`) in both the `existsSync` mocks and the received spawn arguments before asserting.

Note: this is the same content as the fix bundled into #4840's merge commit `0e104e179` (credit @qqqys, co-authored). Extracted into a standalone test-only PR so main's CI recovers without coupling to a core-behavior PR's merge timing — the file contents are identical, so #4840 and this PR merge cleanly in either order.

## Reviewer Test Plan

### How to verify

```bash
npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/dev.test.js
npx prettier --check scripts/tests/dev.test.js
npx eslint scripts/tests/dev.test.js
```

Expected: 2/2 pass on macOS/Linux, and — the actual point — the `Test (windows-latest, Node 22.x)` check on this PR goes green, while it is red on current main.

### Evidence (Before & After)

Mechanism-level A/B, reproduced on Linux by mocking `node:path` with `path.win32` so `dev.js` builds backslash paths exactly as on a real Windows runner:

- Pre-fix matchers under win32 path semantics: **2/2 fail** with the same symptom as CI (`existsSync` mock misses → spawn called with bare `'tsx.cmd'` + `shell: true` instead of `node.exe` + `cli.mjs` + `shell: false`; received args are backslash paths that forward-slash `stringContaining` rejects).
- Fixed matchers under the same simulation: **2/2 pass**.
- Fixed file on plain Linux: **2/2 pass** (no regression).

Real-runner proof is this PR's own Windows CI job (main is red on the same job at the merge-base).

### Tested on

|   OS    | Status |
| :-----: | :----: |
|  macOS  |   CI   |
| Windows |   CI   |
|  Linux  | tested locally + CI |

## Risk & Scope

- Test-only change; `scripts/dev.js` behavior is untouched.
- Main risk: none beyond the test file itself. Content is byte-identical to the version already reviewed inside #4840, so no divergence between the two.

## Linked Issues

Unbreaks Windows CI broken by #4728; unblocks the Windows check on open PRs (e.g. #4519).
