### PR TITLE
fix(cli): debounce resize repaint and clear stale scrollback on settle

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -515,7 +515,47 @@ describe('AppContainer State Management', () => {
       expect(mockStdout.write).toHaveBeenCalledWith(ansiEscapes.clearTerminal);
     });
 
-    it('does not clear the terminal just because width changed', () => {
+    it('refreshStatic skips the physical clear in VP mode (#4891)', () => {
+      const vpSettings = {
+        merged: {
+          hideTips: false,
+          theme: 'default',
+          ui: {
+            showStatusInTitle: false,
+            hideWindowTitle: false,
+            useTerminalBuffer: true,
+          },
+        },
+        setValue: vi.fn(),
+      } as unknown as LoadedSettings;
+
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={vpSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+      mockStdout.write.mockClear();
+
+      capturedUIActions.refreshStatic();
+
+      // VP mode owns the viewport via the React tree, so refreshStatic must not
+      // emit a physical clear — the resize-settle path (#4891) strands nothing.
+      expect(mockStdout.write).not.toHaveBeenCalledWith(
+        ansiEscapes.clearTerminal,
+      );
+    });
+
+    // #4891 changed the resize contract: width changes now trigger ONE full
+    // clearTerminal after RESIZE_REPAINT_SETTLE_MS (trailing-edge debounce),
+    // instead of never (#3967) or per-event (pre-#3967). This test pins the
+    // synchronous half: no immediate clear during the burst. The settle-time
+    // half is not observable here — ink-testing-library's rerender does not
+    // flush update-time passive effects — and is covered by
+    // useResizeSettleRepaint.test.ts.
+    it('does not clear the terminal synchronously on width change', () => {
       vi.spyOn(mockConfig, 'initialize').mockResolvedValue(undefined);
       mockedUseTerminalSize.mockReturnValue({ columns: 80, rows: 24 });
       const { rerender } = render(

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -103,6 +103,7 @@ const MCP_BATCH_FLUSH_MS = 16;
 const STARTUP_PROFILE_FINALIZE_CAP_MS = 35_000;
 import { useHistory } from './hooks/useHistoryManager.js';
 import { useMemoryMonitor } from './hooks/useMemoryMonitor.js';
+import { useResizeSettleRepaint } from './hooks/useResizeSettleRepaint.js';
 import { useThemeCommand } from './hooks/useThemeCommand.js';
 import { useFeedbackDialog } from './hooks/useFeedbackDialog.js';
 import { useAuthCommand } from './auth/useAuth.js';
@@ -865,26 +866,6 @@ export const AppContainer = (props: AppContainerProps) => {
     }
     remountStaticHistory();
   }, [useTerminalBuffer, remountStaticHistory, stdout]);
-
-  // Targeted repaint for resize events: move cursor to top-left and erase
-  // downward instead of a full clearTerminal, avoiding the full-screen
-  // flash. Ink's <Static> region is append-only, so when terminal width
-  // changes (tmux split, fullscreen toggle, font size change) we must
-  // explicitly re-emit the static history at the new width — otherwise
-  // header content stays at the old width and visibly tears.
-  // VP mode handles resize via ink's reflow + its own overflow clipping, so
-  // the physical write is unnecessary there too.
-  const repaintStaticViewport = useCallback(() => {
-    if (!useTerminalBuffer) {
-      stdout.write(`${ansiEscapes.cursorTo(0, 0)}${ansiEscapes.eraseDown}`);
-    }
-    remountStaticHistory();
-  }, [useTerminalBuffer, remountStaticHistory, stdout]);
-
-  // Track previous terminal width across renders so we only repaint when
-  // the width actually changes. Initialized to the current width to avoid
-  // a spurious repaint on first mount.
-  const previousTerminalWidthRef = useRef(terminalWidth);
 
   // Keep the static header in sync with model changes without polling.
   // Ink's <Static> output is append-only, so model changes must explicitly
@@ -2419,18 +2400,8 @@ export const AppContainer = (props: AppContainerProps) => {
     }
   }, [terminalWidth, availableTerminalHeight, activePtyId]);
 
-  // Repaint static header on terminal resize. Without this, tmux pane
-  // resizes and fullscreen toggles leave the static region rendered at the
-  // old width — header content visibly tears until the next refreshStatic
-  // (e.g. /model). Cheap repaint (cursor-to + erase-down) rather than a
-  // full clearTerminal to avoid the full-screen flash.
-  useEffect(() => {
-    if (previousTerminalWidthRef.current === terminalWidth) {
-      return;
-    }
-    previousTerminalWidthRef.current = terminalWidth;
-    repaintStaticViewport();
-  }, [terminalWidth, repaintStaticViewport]);
+  // Repaint static history on the trailing edge of a resize burst (#4891).
+  useResizeSettleRepaint(terminalWidth, refreshStatic);
 
   useEffect(() => {
     if (ideNeedsRestart) {

--- a/packages/cli/src/ui/hooks/useResizeSettleRepaint.test.ts
+++ b/packages/cli/src/ui/hooks/useResizeSettleRepaint.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  RESIZE_REPAINT_SETTLE_MS,
+  useResizeSettleRepaint,
+} from './useResizeSettleRepaint.js';
+
+describe('useResizeSettleRepaint (#4891)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const setup = (initialWidth: number) => {
+    const refreshStatic = vi.fn();
+    const view = renderHook(
+      ({ width }: { width: number }) =>
+        useResizeSettleRepaint(width, refreshStatic),
+      { initialProps: { width: initialWidth } },
+    );
+    return { refreshStatic, view };
+  };
+
+  it('does not repaint on first mount', () => {
+    const { refreshStatic } = setup(80);
+
+    act(() => {
+      vi.advanceTimersByTime(RESIZE_REPAINT_SETTLE_MS + 50);
+    });
+
+    expect(refreshStatic).not.toHaveBeenCalled();
+  });
+
+  it('coalesces a burst of width changes into one repaint after settle', () => {
+    const { refreshStatic, view } = setup(80);
+
+    // Three rapid width changes, each well within the settle window.
+    act(() => view.rerender({ width: 90 }));
+    act(() => vi.advanceTimersByTime(100));
+    act(() => view.rerender({ width: 100 }));
+    act(() => vi.advanceTimersByTime(100));
+    act(() => view.rerender({ width: 110 }));
+
+    // Burst not yet settled (measured from the last change): nothing fired.
+    act(() => vi.advanceTimersByTime(RESIZE_REPAINT_SETTLE_MS - 1));
+    expect(refreshStatic).not.toHaveBeenCalled();
+
+    // Settle window elapses → exactly one repaint for the whole burst.
+    act(() => vi.advanceTimersByTime(1));
+    expect(refreshStatic).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not repaint when a drag returns to the original width', () => {
+    const { refreshStatic, view } = setup(80);
+
+    act(() => view.rerender({ width: 100 }));
+    act(() => vi.advanceTimersByTime(RESIZE_REPAINT_SETTLE_MS - 1)); // pending
+    act(() => view.rerender({ width: 80 })); // back to start before it fires
+
+    act(() => vi.advanceTimersByTime(RESIZE_REPAINT_SETTLE_MS + 50));
+    expect(refreshStatic).not.toHaveBeenCalled();
+  });
+
+  it('repaints exactly once after a single settled width change', () => {
+    const { refreshStatic, view } = setup(80);
+
+    act(() => view.rerender({ width: 100 }));
+    act(() => vi.advanceTimersByTime(RESIZE_REPAINT_SETTLE_MS));
+
+    expect(refreshStatic).toHaveBeenCalledTimes(1);
+  });
+
+  it('schedules nothing when a re-render leaves the width unchanged', () => {
+    // A height-only resize re-renders with the same width: no repaint.
+    const { refreshStatic, view } = setup(80);
+
+    act(() => view.rerender({ width: 80 }));
+    act(() => vi.advanceTimersByTime(RESIZE_REPAINT_SETTLE_MS + 50));
+
+    expect(refreshStatic).not.toHaveBeenCalled();
+  });
+
+  it('cancels a pending repaint when unmounted mid-settle', () => {
+    const { refreshStatic, view } = setup(80);
+
+    act(() => view.rerender({ width: 100 }));
+    act(() => vi.advanceTimersByTime(RESIZE_REPAINT_SETTLE_MS - 1)); // pending
+    view.unmount();
+
+    act(() => vi.advanceTimersByTime(RESIZE_REPAINT_SETTLE_MS + 50));
+    expect(refreshStatic).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/ui/hooks/useResizeSettleRepaint.ts
+++ b/packages/cli/src/ui/hooks/useResizeSettleRepaint.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect, useRef } from 'react';
+
+// Trailing-edge debounce for resize-triggered static repaints (#4891).
+export const RESIZE_REPAINT_SETTLE_MS = 200;
+
+/**
+ * Repaint the static history once the terminal width settles (#4891).
+ *
+ * A window drag fires dozens of `resize` events. Per-event repainting restarted
+ * the progressive <Static> replay (#3899) mid-flight, and the viewport-only
+ * cursorTo+eraseDown erase introduced by #3967 (4bab7a1a) cannot reach output
+ * that has already scrolled into the scrollback, so each event stranded a
+ * fragment at that instant's width. Debouncing to the trailing edge and issuing
+ * one full `refreshStatic` (clearTerminal incl. ESC[3J + remount) wipes the
+ * fragments and re-emits the history once at the final width. The cleanup
+ * cancels the pending timer on the next width change or unmount, so a drag
+ * returning to the start width is a no-op.
+ *
+ * Trade-off: the full-screen flash #3967 removed returns, but at most once per
+ * resize gesture; the settle-time ESC[3J clears pre-session scrollback — the
+ * same as the pre-#3967 per-event behavior and today's /clear.
+ *
+ * `refreshStatic` must be referentially stable (e.g. `useCallback`) so an
+ * unrelated re-render does not cancel an in-flight settle.
+ */
+export function useResizeSettleRepaint(
+  terminalWidth: number,
+  refreshStatic: () => void,
+): void {
+  // Width at the last settled repaint; starts at mount width (first mount is a
+  // no-op) and only advances when a repaint actually fires.
+  const settledTerminalWidthRef = useRef(terminalWidth);
+
+  useEffect(() => {
+    if (settledTerminalWidthRef.current === terminalWidth) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      settledTerminalWidthRef.current = terminalWidth;
+      refreshStatic();
+    }, RESIZE_REPAINT_SETTLE_MS);
+    return () => clearTimeout(timer);
+  }, [terminalWidth, refreshStatic]);
+}


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">What this PR does</h2>
<p class="font-claude-response-body break-words whitespace-normal">Replaces the per-event repaint on terminal width change (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">cursorTo(0,0)+eraseDown</code> + <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">&lt;Static&gt;</code> remount, from #3967) with a 200 ms trailing-edge debounce: when the width settles, perform one full <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">refreshStatic()</code> (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">clearTerminal</code> incl. <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">ESC[3J</code>) + remount. A window-drag's resize burst now yields a single repaint at the final width; a drag that returns to the starting width yields none. The debounce lives in a new hook, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">useResizeSettleRepaint</code>, extracted for testability (see below).</p>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Why it's needed</h2>
<p class="font-claude-response-body break-words whitespace-normal">Fixes #4891. Root cause is the interaction of three things on the default rendering path (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">ui.useTerminalBuffer=false</code>):</p>
<ol class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-decimal flex flex-col gap-1 pl-8 mb-3">
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">useTerminalSize</code> does not debounce — a window drag fires dozens of <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">resize</code> events at intermediate widths.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">#3967 (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">4bab7a1a</code>) replaced the full <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">clearTerminal</code> (whose <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">ESC[3J</code> cleared scrollback) with <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">cursorTo(0,0)+eraseDown</code>, which only erases the visible viewport.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">Each width change remounts <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">&lt;Static&gt;</code>, restarting the #3899 progressive replay.</li>
</ol>
<p class="font-claude-response-body break-words whitespace-normal">When the next resize lands mid-replay, chunks that already scrolled above the viewport are unreachable by <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">eraseDown</code> and stay in scrollback at that instant's width — one stranded fragment per event, i.e. the reported alternating narrow/wide segments. (tmux likely doesn't reproduce because pane resizes lack the high-frequency burst and don't reflow scrollback.)</p>
<p class="font-claude-response-body break-words whitespace-normal"><strong>Why a new hook:</strong> ink-testing-library's <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">rerender</code> doesn't flush update-time passive effects, so the <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">rerender → effect → setTimeout</code> chain can't be observed in <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">AppContainer.test.tsx</code>; <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">renderHook</code> is this repo's idiomatic pattern for timer hooks.</p>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Reviewer Test Plan</h2>
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold">Automated</h3>
<div role="group" aria-label="bash code" tabindex="0" class="relative group/copy bg-bg-000/50 border-0.5 border-border-400 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-100"><div class="sticky opacity-0 group-hover/copy:opacity-100 group-focus-within/copy:opacity-100 top-2 py-2 h-12 w-0 float-right"><div class="absolute right-0 h-8 px-2 items-center inline-flex z-10"><button class="inline-flex
  items-center
  justify-center
  relative
  isolate
  shrink-0
  can-focus
  select-none
  disabled:pointer-events-none
  disabled:opacity-50
  disabled:shadow-none
  disabled:drop-shadow-none border-transparent
          transition
          font-base
          duration-300
          ease-[cubic-bezier(0.165,0.85,0.45,1)] h-8 w-8 rounded-md backdrop-blur-md _fill_10ocf_9 _ghost_10ocf_96" type="button" aria-label="Copy to clipboard" data-state="closed"><div class="relative"><div class="transition-all opacity-100 scale-100" style="width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="transition-all opacity-100 scale-100" aria-hidden="true" style="flex-shrink: 0;"><path d="M12.5 3A1.5 1.5 0 0 1 14 4.5V6h1.5A1.5 1.5 0 0 1 17 7.5v8a1.5 1.5 0 0 1-1.5 1.5h-8A1.5 1.5 0 0 1 6 15.5V14H4.5A1.5 1.5 0 0 1 3 12.5v-8A1.5 1.5 0 0 1 4.5 3zm1.5 9.5a1.5 1.5 0 0 1-1.5 1.5H7v1.5a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5v-8a.5.5 0 0 0-.5-.5H14zM4.5 4a.5.5 0 0 0-.5.5v8a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5v-8a.5.5 0 0 0-.5-.5z"></path></svg></div><div class="absolute inset-0 flex items-center justify-center"><div class="transition-all opacity-0 scale-50" style="width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="transition-all opacity-0 scale-50" aria-hidden="true" style="flex-shrink: 0;"><path d="M15.188 5.11a.5.5 0 0 1 .752.626l-.056.084-7.5 9a.5.5 0 0 1-.738.033l-3.5-3.5-.064-.078a.501.501 0 0 1 .693-.693l.078.064 3.113 3.113 7.15-8.58z"></path></svg></div></div></div></button></div></div><div class="text-text-500 font-small p-3.5 pb-0">bash</div><div class="overflow-x-auto"><pre class="code-block__code !my-0 !rounded-lg !text-sm !leading-relaxed p-3.5" style="color: rgb(234, 236, 240); background: transparent; font-family: var(--font-mono);"><code class="language-bash" style="color: rgb(234, 236, 240); background: transparent; font-family: var(--font-mono); white-space: pre;"><span><span class="token token" style="color: rgb(112, 184, 255);">npm</span><span> run typecheck --workspace</span><span class="token token" style="color: rgb(234, 236, 240);">=</span><span>@qwen-code/qwen-code
</span></span><span>npx vitest run packages/cli/src/ui/hooks/useResizeSettleRepaint.test.ts
</span><span>npx vitest run packages/cli/src/ui/AppContainer.test.tsx packages/cli/src/ui/components/MainContent.test.tsx</span></code></pre></div></div>
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold">Manual (macOS — requires a real window drag)</h3>
<ol class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-decimal flex flex-col gap-1 pl-8 mb-3">
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">qwen --approval-mode yolo</code> in Terminal.app or iTerm2</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">Send a prompt that triggers several tool calls</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">While they stream, drag the window edge 3–5 times (narrow → wide → narrow)</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">Scroll to the top after completion</li>
</ol>
<p class="font-claude-response-body break-words whitespace-normal">Expected: all content at the final width — one brief clear+redraw ~200 ms after the drag settles, no mixed-width fragments.</p>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Evidence (Before &amp; After)</h2>
<p class="font-claude-response-body break-words whitespace-normal">Before: the issue's mixed-width scrollback segments. After: single-width history once the resize settles — we have no macOS machine to record this. @tanzhenxin, could you verify with the steps above?</p>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Tested on</h2>
<div class="overflow-x-auto w-full px-2 mb-6">
OS | Status
-- | --
🍏 macOS | ⚠️ needs a real window drag — requesting reporter verification
🪟 Windows | ✅ full automated verification (see Environment)
🐧 Linux | ⚠️ via CI

</div>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Environment (optional)</h2>
<p class="font-claude-response-body break-words whitespace-normal">Windows 10, Node v22.22.1, npm 10.5.2. Typecheck clean on both workspaces; prettier + eslint clean on changed files. Full <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">@qwen-code/qwen-code</code> Vitest suite: 7521/7563 tests passed (40 skipped); the 2 failing files are unrelated — <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/i18n/mustTranslateKeys.test.ts</code> fails identically on clean <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">origin/main</code>, and <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/ui/components/InputPrompt.test.tsx</code> (#4171) passes in isolation on both branches (flaked only under the full parallel run). Touched suites all pass: AppContainer (79), MainContent (13, unmodified), useResizeSettleRepaint (6). Full <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">npm run preflight</code> is delegated to PR CI.</p>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Risk &amp; Scope</h2>
<p class="font-claude-response-body break-words whitespace-normal"><strong>Main risk or tradeoff:</strong> the full-screen flash #3967 removed returns, but at most once per resize gesture (vs. every event before #3967, vs. never-but-incorrect after); the settle-time <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">ESC[3J</code> clears pre-session scrollback — same as the pre-#3967 per-event behavior and today's <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">/clear</code>; during the ~200 ms settle window the static region is briefly stale while ink reflows the dynamic region live.</p>
<p class="font-claude-response-body break-words whitespace-normal"><strong>Not validated / out of scope:</strong> VP mode (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">ui.useTerminalBuffer=true</code>) unchanged — <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">refreshStatic</code> already guards the physical write there, and a new test pins it; no changes to <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">useTerminalSize</code> or the #3899 replay machinery; macOS visual verification pending.</p>
<p class="font-claude-response-body break-words whitespace-normal"><strong>Breaking changes / migration notes:</strong> none. One existing test renamed (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">…just because width changed</code> → <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">…synchronously on width change</code>) — assertions unchanged; it pins the synchronous half of the new contract, with the settle-time half covered by <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">useResizeSettleRepaint.test.ts</code>.</p>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Linked Issues</h2>
<p class="font-claude-response-body break-words whitespace-normal">Fixes #4891. Possibly related (not claimed as duplicates): #3213, #3824.</p>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">中文说明</h2>
<p class="font-claude-response-body break-words whitespace-normal"><strong>做了什么:</strong> 把宽度变化时的逐事件重绘(#3967 的 <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">cursorTo+eraseDown</code>)替换为 200ms 尾沿防抖,settle 后只做一次完整 <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">clearTerminal</code>(含 <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">ESC[3J</code>)+ remount;防抖抽成 <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">useResizeSettleRepaint</code> hook 以便确定性单测。</p>
<p class="font-claude-response-body break-words whitespace-normal"><strong>为什么:</strong> 修复 #4891。无防抖的 resize 事件风暴 × #3967 只擦可视区的重绘 × #3899 渐进重放被反复打断 → 已滚出可视区的内容以旧宽度永久滞留 scrollback,每个事件滞留一层,即 issue 中的宽窄交替碎片。</p>
<p class="font-claude-response-body break-words whitespace-normal"><strong>风险与范围:</strong> 全屏闪烁回归,但每次拖拽手势最多一次;settle 时的 <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">ESC[3J</code> 会清除会话前 scrollback(与 #3967 之前每个事件的行为、当前 <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">/clear</code> 一致)。不修改 VP 模式、<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">useTerminalSize</code>、#3899 重放机制;macOS 视觉验证待 reporter 协助。无破坏性变更;一个既有测试改名,断言不变。</p>
<p class="font-claude-response-body break-words whitespace-normal"><strong>关联:</strong> Fixes #4891;可能相关(非重复):#3213、#3824。</p><!--EndFragment-->
</body>
</html>