### PR TITLE
feat(daemon): Support image upload and echo in WebShell

### DIFF
--- a/packages/sdk-typescript/src/daemon/ui/normalizer.ts
+++ b/packages/sdk-typescript/src/daemon/ui/normalizer.ts
@@ -23,6 +23,7 @@ import {
   getOutputText,
   getString,
   getTextContent,
+  extractContentPart,
   isRecord,
   redactSensitiveFields,
   stringifyJson,
@@ -419,7 +420,36 @@ function normalizeSessionUpdate(
       ) {
         return [];
       }
-      const text = getTextContent(update['content']);
+      const content = update['content'];
+      const part = extractContentPart(content);
+      if (part) {
+        if (part.kind === 'image') {
+          const data = part.source.data;
+          let mimeType = part.mediaType || 'image/*';
+          if (mimeType === 'image/*' && data) {
+            // Strip data: URI prefix if present before magic-byte sniffing
+            const rawData = data.startsWith('data:')
+              ? (data.split(',')[1] ?? '')
+              : data;
+            const prefix = rawData.slice(0, 10);
+            if (prefix.startsWith('iVBORw0KGg')) mimeType = 'image/png';
+            else if (prefix.startsWith('/9j/')) mimeType = 'image/jpeg';
+            else if (prefix.startsWith('R0lGOD')) mimeType = 'image/gif';
+            else if (prefix.startsWith('UklGR')) mimeType = 'image/webp';
+          }
+          if (data) {
+            return [{ ...base, type: 'user.image.delta', data, mimeType }];
+          }
+          return [];
+        }
+        if (part.kind === 'text') {
+          return part.text
+            ? [{ ...base, type: 'user.text.delta', text: part.text }]
+            : [];
+        }
+        return [];
+      }
+      const text = getTextContent(content);
       return text ? [{ ...base, type: 'user.text.delta', text }] : [];
     }
     case 'agent_message_chunk': {

--- a/packages/sdk-typescript/src/daemon/ui/store.ts
+++ b/packages/sdk-typescript/src/daemon/ui/store.ts
@@ -57,8 +57,11 @@ export function createDaemonTranscriptStore(
       state = reduceDaemonTranscriptEvents(state, events);
       scheduleNotify();
     },
-    appendLocalUserMessage(text: string) {
-      state = appendLocalUserTranscriptMessage(state, text);
+    appendLocalUserMessage(
+      text: string,
+      images?: Array<{ data: string; mimeType: string }>,
+    ) {
+      state = appendLocalUserTranscriptMessage(state, text, { images });
       scheduleNotify();
     },
     reset(nextSeed: Partial<DaemonTranscriptState> = {}) {

--- a/packages/sdk-typescript/src/daemon/ui/terminal.ts
+++ b/packages/sdk-typescript/src/daemon/ui/terminal.ts
@@ -173,6 +173,8 @@ export function daemonUiEventToTerminalText(event: DaemonUiEvent): string {
       );
     case 'user.shell.command':
       return '';
+    case 'user.image.delta':
+      return `[image: ${event.mimeType}]`;
     default:
       return assertNever(event);
   }

--- a/packages/sdk-typescript/src/daemon/ui/terminal.ts
+++ b/packages/sdk-typescript/src/daemon/ui/terminal.ts
@@ -174,7 +174,7 @@ export function daemonUiEventToTerminalText(event: DaemonUiEvent): string {
     case 'user.shell.command':
       return '';
     case 'user.image.delta':
-      return `[image: ${event.mimeType}]`;
+      return `[image: ${sanitizeTerminalText(event.mimeType)}]`;
     default:
       return assertNever(event);
   }

--- a/packages/sdk-typescript/src/daemon/ui/transcript.ts
+++ b/packages/sdk-typescript/src/daemon/ui/transcript.ts
@@ -93,11 +93,16 @@ const RESYNC_PASSTHROUGH_TYPES: ReadonlySet<string> = new Set([
 export function appendLocalUserTranscriptMessage(
   state: DaemonTranscriptState,
   text: string,
-  opts: DaemonTranscriptReducerOptions = {},
+  opts: DaemonTranscriptReducerOptions & {
+    images?: Array<{ data: string; mimeType: string }>;
+  } = {},
 ): DaemonTranscriptState {
   const next = cloneTranscriptState(state, opts);
   finishAssistant(next);
   const block = createTextBlock(next, 'user', text);
+  if (opts.images && opts.images.length > 0) {
+    (block as DaemonTextTranscriptBlock).images = [...opts.images];
+  }
   appendBlock(next, block);
   next.activeUserBlockId = block.id;
   return trimTranscriptState(next);
@@ -180,6 +185,30 @@ function applyDaemonTranscriptEvent(
       }
       appendTextDelta(next, 'user', 'activeUserBlockId', event.text, event);
       break;
+    case 'user.image.delta': {
+      if (!next.activeUserBlockId) {
+        const block = createTextBlock(
+          next,
+          'user',
+          '',
+        ) as DaemonTextTranscriptBlock;
+        block.images = [{ data: event.data, mimeType: event.mimeType }];
+        appendBlock(next, block);
+        next.activeUserBlockId = block.id;
+      } else {
+        // Use getWritableBlockById to ensure COW safety when mutating block.images
+        const block = getWritableBlockById(next, next.activeUserBlockId) as
+          | DaemonTextTranscriptBlock
+          | undefined;
+        if (block && block.kind === 'user') {
+          if (!block.images) {
+            block.images = [];
+          }
+          block.images.push({ data: event.data, mimeType: event.mimeType });
+        }
+      }
+      break;
+    }
     case 'assistant.text.delta':
       appendTextDelta(
         next,

--- a/packages/sdk-typescript/src/daemon/ui/transcript.ts
+++ b/packages/sdk-typescript/src/daemon/ui/transcript.ts
@@ -201,10 +201,11 @@ function applyDaemonTranscriptEvent(
           | DaemonTextTranscriptBlock
           | undefined;
         if (block && block.kind === 'user') {
-          if (!block.images) {
-            block.images = [];
-          }
-          block.images.push({ data: event.data, mimeType: event.mimeType });
+          // Use immutable update to avoid mutating a shared array reference
+          block.images = [
+            ...(block.images ?? []),
+            { data: event.data, mimeType: event.mimeType },
+          ];
         }
       }
       break;

--- a/packages/sdk-typescript/src/daemon/ui/types.ts
+++ b/packages/sdk-typescript/src/daemon/ui/types.ts
@@ -17,6 +17,7 @@ export const DAEMON_PLAN_TOOL_CALL_ID = 'daemon-plan';
 export type DaemonUiEventType =
   // Chat-stream events (Stage 1)
   | 'user.text.delta'
+  | 'user.image.delta'
   | 'user.shell.command'
   | 'assistant.text.delta'
   | 'assistant.done'
@@ -84,6 +85,12 @@ export interface DaemonUiTextEvent extends DaemonUiEventBase {
   type: 'user.text.delta' | 'assistant.text.delta' | 'thought.text.delta';
   text: string;
   parentToolCallId?: string;
+}
+
+export interface DaemonUiUserImageEvent extends DaemonUiEventBase {
+  type: 'user.image.delta';
+  data: string;
+  mimeType: string;
 }
 
 export interface DaemonUiUserShellCommandEvent extends DaemonUiEventBase {
@@ -439,6 +446,7 @@ export type DaemonUiAuthDeviceFlowEvent =
 export type DaemonUiEvent =
   // Chat-stream events
   | DaemonUiTextEvent
+  | DaemonUiUserImageEvent
   | DaemonUiUserShellCommandEvent
   | DaemonUiAssistantDoneEvent
   | DaemonUiToolUpdateEvent
@@ -656,6 +664,8 @@ export interface DaemonTranscriptBlockBase {
 export interface DaemonTextTranscriptBlock extends DaemonTranscriptBlockBase {
   kind: 'user' | 'assistant' | 'thought';
   text: string;
+  /** Images attached to this user message (base64 data URIs). */
+  images?: Array<{ data: string; mimeType: string }>;
   streaming?: boolean;
   collapsed?: boolean;
   /** Used by the reducer for per-subAgent block routing; renderers may use it for nesting. */
@@ -826,7 +836,10 @@ export interface DaemonTranscriptStore {
   getSnapshot(): DaemonTranscriptState;
   subscribe(listener: () => void): () => void;
   dispatch(event: DaemonUiEvent | DaemonUiEvent[]): void;
-  appendLocalUserMessage(text: string): void;
+  appendLocalUserMessage(
+    text: string,
+    images?: Array<{ data: string; mimeType: string }>,
+  ): void;
   reset(seed?: Partial<DaemonTranscriptState>): void;
   /**
    * Clear the `awaitingResync` latch that gets set when the daemon emits

--- a/packages/sdk-typescript/src/daemon/ui/utils.ts
+++ b/packages/sdk-typescript/src/daemon/ui/utils.ts
@@ -141,23 +141,47 @@ export function extractContentPart(
     return undefined;
   }
   if (type === 'image') {
+    // Support both formats:
+    // 1. { type: 'image', source: { data/url, mediaType } } (SDK format)
+    // 2. { type: 'image', data, mimeType } (daemon echo / web-shell format)
+    // 3. { type: 'image', data, media_type } (legacy format)
     const source = isRecord(value['source']) ? value['source'] : undefined;
-    if (!source) return undefined;
+    let url: string | undefined;
+    let data: string | undefined;
+    if (source) {
+      url =
+        typeof source['url'] === 'string'
+          ? (source['url'] as string)
+          : undefined;
+      data =
+        typeof source['data'] === 'string'
+          ? (source['data'] as string)
+          : undefined;
+    }
+    // Fallback: check root-level data (daemon echo format)
+    if (!url && !data) {
+      data =
+        typeof value['data'] === 'string'
+          ? (value['data'] as string)
+          : undefined;
+      url =
+        typeof value['url'] === 'string' ? (value['url'] as string) : undefined;
+    }
+    if (!url && !data) return undefined;
     const mediaType =
       (typeof value['mediaType'] === 'string'
         ? (value['mediaType'] as string)
         : undefined) ??
-      (typeof source['mediaType'] === 'string'
+      (typeof value['mimeType'] === 'string'
+        ? (value['mimeType'] as string)
+        : undefined) ??
+      (typeof value['media_type'] === 'string'
+        ? (value['media_type'] as string)
+        : undefined) ??
+      (source && typeof source['mediaType'] === 'string'
         ? (source['mediaType'] as string)
         : undefined) ??
       'image/*';
-    const url =
-      typeof source['url'] === 'string' ? (source['url'] as string) : undefined;
-    const data =
-      typeof source['data'] === 'string'
-        ? (source['data'] as string)
-        : undefined;
-    if (!url && !data) return undefined;
     return {
       kind: 'image',
       mediaType,

--- a/packages/web-shell/client/adapters/messageTypes.ts
+++ b/packages/web-shell/client/adapters/messageTypes.ts
@@ -64,6 +64,7 @@ export interface DaemonUserMessage {
   id: string;
   role: 'user';
   content: string;
+  images?: Array<{ data: string; mimeType: string }>;
 }
 
 export interface DaemonAssistantMessage {

--- a/packages/web-shell/client/adapters/transcriptToMessages.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.ts
@@ -18,6 +18,7 @@ import type {
   DaemonMessageToolCallStatus,
   DaemonMessageToolKind,
   DaemonMessageTodoItem,
+  DaemonUserMessage,
 } from './messageTypes.js';
 
 interface PermissionToolInfo {
@@ -75,15 +76,25 @@ export function transcriptBlocksToDaemonMessages(
     const block = blocks[i];
 
     switch (block.kind) {
-      case 'user':
+      case 'user': {
         currentAssistantIdx = null;
         needsNewContentMessage = false;
-        messages.push({
+        const textBlock = block as DaemonTextTranscriptBlock;
+        const msg: DaemonUserMessage = {
           id: block.id,
           role: 'user',
-          content: (block as DaemonTextTranscriptBlock).text,
-        });
+          content: textBlock.text,
+        };
+        // Attach images if present
+        if (textBlock.images && textBlock.images.length > 0) {
+          msg.images = textBlock.images.map((img) => ({
+            data: img.data,
+            mimeType: img.mimeType || 'image/*',
+          }));
+        }
+        messages.push(msg);
         break;
+      }
 
       case 'assistant': {
         const textBlock = block as DaemonTextTranscriptBlock;

--- a/packages/web-shell/client/components/MessageItem.tsx
+++ b/packages/web-shell/client/components/MessageItem.tsx
@@ -33,13 +33,8 @@ export const MessageItem = memo(function MessageItem({
   workspaceCwd,
 }: MessageItemProps) {
   switch (message.role) {
-    case 'user': {
-      const userMsg = message as {
-        role: 'user';
-        images?: Array<{ data: string; mimeType: string }>;
-      };
-      return <UserMessage content={message.content} images={userMsg.images} />;
-    }
+    case 'user':
+      return <UserMessage content={message.content} images={message.images} />;
     case 'assistant':
       return (
         <AssistantMessage
@@ -111,21 +106,11 @@ function areMessagesEqual(prev: Message, next: Message): boolean {
   if (prev === next) return true;
   if (prev.id !== next.id || prev.role !== next.role) return false;
   switch (prev.role) {
-    case 'user': {
-      const prevUser = prev as {
-        role: 'user';
-        images?: Array<{ data: string; mimeType: string }>;
-      };
-      const nextUser = next as {
-        role: 'user';
-        images?: Array<{ data: string; mimeType: string }>;
-      };
+    case 'user':
       return (
-        next.role === 'user' &&
         prev.content === next.content &&
-        stableImagesEqual(prevUser.images, nextUser.images)
+        stableImagesEqual(prev.images, next.images)
       );
-    }
     case 'assistant':
       return (
         next.role === 'assistant' &&

--- a/packages/web-shell/client/components/MessageItem.tsx
+++ b/packages/web-shell/client/components/MessageItem.tsx
@@ -108,6 +108,7 @@ function areMessagesEqual(prev: Message, next: Message): boolean {
   switch (prev.role) {
     case 'user':
       return (
+        next.role === 'user' &&
         prev.content === next.content &&
         stableImagesEqual(prev.images, next.images)
       );

--- a/packages/web-shell/client/components/MessageItem.tsx
+++ b/packages/web-shell/client/components/MessageItem.tsx
@@ -33,8 +33,13 @@ export const MessageItem = memo(function MessageItem({
   workspaceCwd,
 }: MessageItemProps) {
   switch (message.role) {
-    case 'user':
-      return <UserMessage content={message.content} />;
+    case 'user': {
+      const userMsg = message as {
+        role: 'user';
+        images?: Array<{ data: string; mimeType: string }>;
+      };
+      return <UserMessage content={message.content} images={userMsg.images} />;
+    }
     case 'assistant':
       return (
         <AssistantMessage
@@ -106,8 +111,21 @@ function areMessagesEqual(prev: Message, next: Message): boolean {
   if (prev === next) return true;
   if (prev.id !== next.id || prev.role !== next.role) return false;
   switch (prev.role) {
-    case 'user':
-      return next.role === 'user' && prev.content === next.content;
+    case 'user': {
+      const prevUser = prev as {
+        role: 'user';
+        images?: Array<{ data: string; mimeType: string }>;
+      };
+      const nextUser = next as {
+        role: 'user';
+        images?: Array<{ data: string; mimeType: string }>;
+      };
+      return (
+        next.role === 'user' &&
+        prev.content === next.content &&
+        stableImagesEqual(prevUser.images, nextUser.images)
+      );
+    }
     case 'assistant':
       return (
         next.role === 'assistant' &&
@@ -209,6 +227,17 @@ function areToolListsEqual(
 }
 
 const jsonCache = new WeakMap<object, string>();
+
+function stableImagesEqual(
+  a: Array<{ data: string; mimeType: string }> | undefined,
+  b: Array<{ data: string; mimeType: string }> | undefined,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b || a.length !== b.length) return false;
+  return a.every(
+    (img, i) => img.data === b[i].data && img.mimeType === b[i].mimeType,
+  );
+}
 
 function stableJson(value: unknown): string {
   if (value === undefined) return '';

--- a/packages/web-shell/client/components/messages/UserMessage.module.css
+++ b/packages/web-shell/client/components/messages/UserMessage.module.css
@@ -16,3 +16,18 @@
   white-space: pre-wrap;
   word-break: break-word;
 }
+
+.images {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.imageThumb {
+  max-width: 200px;
+  max-height: 200px;
+  border-radius: 8px;
+  object-fit: contain;
+  border: 1px solid var(--border-color, #e5e7eb);
+}

--- a/packages/web-shell/client/components/messages/UserMessage.tsx
+++ b/packages/web-shell/client/components/messages/UserMessage.tsx
@@ -22,7 +22,7 @@ export const UserMessage = memo(function UserMessage({
       <span className={styles.prefix}>
         <PromptChevron />
       </span>
-      <span className={styles.body}>
+      <div className={styles.body}>
         {images && images.length > 0 && (
           <div className={styles.images}>
             {images.map((img, index) => {
@@ -42,7 +42,7 @@ export const UserMessage = memo(function UserMessage({
           </div>
         )}
         {content}
-      </span>
+      </div>
     </div>
   );
 });

--- a/packages/web-shell/client/components/messages/UserMessage.tsx
+++ b/packages/web-shell/client/components/messages/UserMessage.tsx
@@ -1,20 +1,48 @@
 import { memo } from 'react';
 import { PromptChevron } from '../PromptChevron';
+import { isSafeImageSrc } from './Markdown';
 import styles from './UserMessage.module.css';
+
+interface UserMessageImage {
+  data: string;
+  mimeType: string;
+}
 
 interface UserMessageProps {
   content: string;
+  images?: UserMessageImage[];
 }
 
 export const UserMessage = memo(function UserMessage({
   content,
+  images,
 }: UserMessageProps) {
   return (
     <div className={styles.message}>
       <span className={styles.prefix}>
         <PromptChevron />
       </span>
-      <span className={styles.body}>{content}</span>
+      <span className={styles.body}>
+        {images && images.length > 0 && (
+          <div className={styles.images}>
+            {images.map((img, index) => {
+              const src = img.data.startsWith('data:')
+                ? img.data
+                : `data:${img.mimeType};base64,${img.data}`;
+              if (!isSafeImageSrc(src)) return null;
+              return (
+                <img
+                  key={index}
+                  src={src}
+                  alt={`User uploaded image ${index + 1}`}
+                  className={styles.imageThumb}
+                />
+              );
+            })}
+          </div>
+        )}
+        {content}
+      </span>
     </div>
   );
 });

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -125,7 +125,15 @@ export function createDaemonSessionActions({
       activePromptsRef.current.set(sessionId, { controller: ctrl });
       try {
         if (options?.optimisticUserMessage !== false) {
-          store.appendLocalUserMessage(text);
+          // Convert images from {data, media_type} to {data, mimeType} format
+          const normalizedImages: Array<{ data: string; mimeType: string }> = (
+            options?.images ?? []
+          ).map((img) => ({
+            data: img.data,
+            mimeType:
+              img.mimeType || img.mediaType || img.media_type || 'image/*',
+          }));
+          store.appendLocalUserMessage(text, normalizedImages);
         }
         const result = await session.prompt(
           {

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -124,20 +124,20 @@ export function createDaemonSessionActions({
       const ctrl = new AbortController();
       activePromptsRef.current.set(sessionId, { controller: ctrl });
       try {
+        // Normalize images once and pass the same array to both calls
+        const normalizedImages: Array<{ data: string; mimeType: string }> = (
+          options?.images ?? []
+        ).map((img) => ({
+          data: img.data,
+          mimeType:
+            img.mimeType || img.mediaType || img.media_type || 'image/*',
+        }));
         if (options?.optimisticUserMessage !== false) {
-          // Convert images from {data, media_type} to {data, mimeType} format
-          const normalizedImages: Array<{ data: string; mimeType: string }> = (
-            options?.images ?? []
-          ).map((img) => ({
-            data: img.data,
-            mimeType:
-              img.mimeType || img.mediaType || img.media_type || 'image/*',
-          }));
           store.appendLocalUserMessage(text, normalizedImages);
         }
         const result = await session.prompt(
           {
-            prompt: toDaemonPromptContent(text, options?.images),
+            prompt: toDaemonPromptContent(text, normalizedImages),
           },
           ctrl.signal,
         );

--- a/packages/webui/src/daemon/session/promptContent.ts
+++ b/packages/webui/src/daemon/session/promptContent.ts
@@ -15,11 +15,20 @@ export function toDaemonPromptContent(
 
   for (const image of images) {
     const mimeType = image.mimeType ?? image.mediaType ?? image.media_type;
-    prompt.push({
-      type: 'image',
-      data: image.data,
-      ...(mimeType ? { mimeType } : {}),
-    });
+    // Omit 'image/*' (unknown type) to preserve legacy behavior where
+    // untyped images are sent without mimeType to the daemon.
+    if (mimeType && mimeType !== 'image/*') {
+      prompt.push({
+        type: 'image',
+        data: image.data,
+        mimeType,
+      });
+    } else {
+      prompt.push({
+        type: 'image',
+        data: image.data,
+      });
+    }
   }
 
   return prompt;


### PR DESCRIPTION
## What this PR does

Adds web-shell support for multimodal image upload and echo display. When users paste or upload an image in the chat input, the image is now correctly echoed back and displayed as a thumbnail in the conversation. The changes span three layers:

- **SDK Layer**: Extended `extractContentPart()` to handle the flat image format from daemon echo; added `user.image.delta` event type for transcript rendering; implemented image extraction and base64 prefix mimeType inference in `user_message_chunk` handler.
- **WebUI Layer**: Converted `{data, media_type}` to `{data, mimeType}` format during optimistic local rendering.
- **WebShell Layer**: Added `images` field to `DaemonUserMessage`; `UserMessage` component now renders image thumbnails; `MessageItem` includes image equality comparison to prevent redundant re-renders.

## Why it's needed

Previously, while WebShell supported image pasting/uploading, images were not echoed back after sending. This caused users to be unable to confirm whether the image was successfully transmitted, degrading the multimodal interaction experience. Users had to rely on pure text replies or switch to terminal mode to verify. Integrating image echo into WebShell allows users to fully utilize the image upload feature directly in the browser.

## Reviewer Test Plan

### How to verify

1. Start the daemon and web-shell against this branch.
2. In the chat input box, **paste an image** (Ctrl+V / Cmd+V) or upload one.
3. Add some text and **send the message**.
4. Verify that the image is displayed as a thumbnail in the user message, positioned above the text content.
5. **Send multiple messages with images** to confirm no crashes or redundant rendering.

### Evidence (Before & After)

- **Before**: Images were not echoed back after sending. Users couldn't visually confirm the image was part of the message, leading to a disjointed experience.
- **After**: Images are correctly echoed and displayed as thumbnails in the user message. Supports PNG/JPEG/GIF/WebP formats with secure URI validation.

## Tested on

| OS | Status |
| :--- | :--- |
| 🍏 macOS | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
| 🐧 Linux | ⚠️ not tested |

## Environment (optional)

Verified locally on `daemon_mode_b_main` branch using `npm run build` and tested via Vite dev server.

## Risk & Scope

- **Main risk**: Image echo touches SDK normalizer, transcript reducer, and UI rendering. Regressions could appear in event parsing or message equality checks. Mitigated by removing `as any` type assertions and adding `stableImagesEqual` comparison logic.
- **Not validated / out of scope**: Full cross-platform manual UI validation not performed. Performance impact of very large images (>10MB) not specifically tested.
- **Breaking changes / migration notes**: None. The `images` field is optional and does not affect existing text-only messages.

## Linked Issues

N/A

<img width="1724" height="852" alt="image" src="https://github.com/user-attachments/assets/bcdb9ad9-8715-4c5e-a02f-3ac632d2c700" />
