### PR TITLE
fix(core): remove greeting-responder example from agent tool prompt

### DIFF
--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -602,7 +602,6 @@ Example usage:
 
 <example_agent_descriptions>
 "test-runner": use this agent after you are done writing code to run tests
-"greeting-responder": use this agent to respond to user greetings with a friendly joke
 </example_agent_descriptions>
 
 <example>
@@ -621,14 +620,6 @@ function isPrime(n) {
 Since a significant piece of code was written and the task was completed, now use the test-runner agent to run the tests
 </commentary>
 assistant: Uses the ${ToolNames.AGENT} tool to launch the test-runner agent
-</example>
-
-<example>
-user: "Hello"
-<commentary>
-Since the user is greeting, use the greeting-responder agent to respond with a friendly joke
-</commentary>
-assistant: "I'm going to use the ${ToolNames.AGENT} tool to launch the greeting-responder agent"
 </example>
 `;
 


### PR DESCRIPTION
## What this PR does

Removes the `greeting-responder` example from the agent tool's model-facing prompt. This includes the fake agent description entry (`"greeting-responder": use this agent to respond to user greetings with a friendly joke`) and the accompanying few-shot example that shows the model launching a subagent in response to "Hello".

## Why it's needed

We encountered reports of some models misusing the agent tool for simple greeting messages — launching a subagent instead of responding with plain text. The `greeting-responder` example in the agent tool prompt is the likely culprit: it teaches the model that greetings should be delegated to an agent.

We ran a cross-model headless test (8 models × 5 repeats = 40 runs) sending "hi" and checking for agent tool invocations via both JSON output and raw API request logs. None of the tested models (claude-opus-4-6, gpt-5.5, deepseek-v4-pro, deepseek-v4-flash, qwen3.7-max, qwen3.7-plus, glm-5.1, kimi-k2.6) triggered the agent tool in our tests. However, the example still presents an unnecessary risk — it's the only few-shot that teaches a "delegate to agent" pattern for trivial user input, and models we haven't tested (or future model versions) may be more susceptible.

## Reviewer Test Plan

### How to verify

1. Build locally: `npm run build && npm run bundle`
2. Run `node dist/cli.js "hi" --approval-mode yolo --output-format json 2>/dev/null` — confirm the response is plain text with no agent tool call.
3. Optionally, add `--openai-logging --openai-logging-dir /tmp/api-logs` and inspect the API log to confirm `response.choices[0].message.tool_calls` is empty or absent.

### Evidence (Before & After)

N/A — prompt-level change, no TUI impact. The removed text was part of the model-facing tool description, not user-visible UI.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

## Risk & Scope

- Main risk or tradeoff: The remaining test-runner example still demonstrates the agent tool pattern adequately. Removing the greeting example reduces prompt size by ~9 lines.
- Not validated / out of scope: Interactive mode testing, conversation-with-history scenarios.
- Breaking changes / migration notes: None. No API or config changes.

<details>
<summary>中文说明</summary>

从 agent 工具的模型提示词中移除了 `greeting-responder` 示例。该示例包括一个虚构的 agent 描述条目和一个展示模型在收到 "Hello" 时启动子代理的 few-shot 示例。

部分模型会误用 agent 工具来处理简单的问候消息（启动子代理而非直接回复文本）。虽然我们在 8 个模型 × 5 次重复 = 40 次测试中未能复现此问题，但该示例仍然存在不必要的风险——它是唯一一个教导模型将简单用户输入委托给 agent 的 few-shot 示例。

</details>