### PR TITLE
fix(acp): prevent session/prompt hang when client ignores mid-turn drain requests

### DIFF
--- a/integration-tests/cli/acp-cron.test.ts
+++ b/integration-tests/cli/acp-cron.test.ts
@@ -199,6 +199,19 @@ function setupAcpCronTest(rig: TestRig) {
       } catch (e) {
         sendResponse(msg.id, { message: (e as Error).message });
       }
+      return;
+    }
+
+    // JSON-RPC requires every request to get a response. Reject unknown
+    // agent->client requests (e.g. optional extension methods like
+    // craft/drainMidTurnQueue) with -32601 so the agent fails fast instead
+    // of awaiting a reply that never comes.
+    if (typeof msg.id === 'number' && typeof msg.method === 'string') {
+      send({
+        jsonrpc: '2.0',
+        id: msg.id,
+        error: { code: -32601, message: 'Method not found' },
+      });
     }
   };
 

--- a/integration-tests/cli/acp-integration.test.ts
+++ b/integration-tests/cli/acp-integration.test.ts
@@ -233,6 +233,19 @@ function setupAcpTest(
       } catch (e) {
         sendResponse(msg.id, { message: (e as Error).message });
       }
+      return;
+    }
+
+    // JSON-RPC requires every request to get a response. Reject unknown
+    // agent->client requests (e.g. optional extension methods like
+    // craft/drainMidTurnQueue) with -32601 so the agent fails fast instead
+    // of awaiting a reply that never comes.
+    if (typeof msg.id === 'number' && typeof msg.method === 'string') {
+      send({
+        jsonrpc: '2.0',
+        id: msg.id,
+        error: { code: -32601, message: 'Method not found' },
+      });
     }
   };
 

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -2320,6 +2320,136 @@ describe('Session', () => {
         expect(drainCalls).toHaveLength(1);
       });
 
+      it('latches mid-turn drain off after repeated timeouts when the client never responds', async () => {
+        const tool = {
+          name: 'read_file',
+          kind: core.Kind.Read,
+          build: vi.fn().mockReturnValue({
+            params: { path: '/tmp/test.txt' },
+            getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+            getDescription: vi.fn().mockReturnValue('Read file'),
+            toolLocations: vi.fn().mockReturnValue([]),
+            execute: vi
+              .fn()
+              .mockResolvedValue({ llmContent: 'ok', returnDisplay: 'ok' }),
+          }),
+        };
+        mockToolRegistry.getTool.mockReturnValue(tool);
+        mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.YOLO);
+        // A non-conforming client that silently drops unknown methods: the
+        // drain request never settles. The turn must not hang on it.
+        mockClient.extMethod = vi.fn().mockReturnValue(new Promise(() => {}));
+
+        const toolCallStream = () =>
+          createStreamWithChunks([
+            {
+              type: core.StreamEventType.CHUNK,
+              value: {
+                functionCalls: [
+                  {
+                    id: 'c',
+                    name: 'read_file',
+                    args: { path: '/tmp/test.txt' },
+                  },
+                ],
+              },
+            },
+          ]);
+        // Four prompts, each with one tool batch. The first three time out
+        // (consecutive-strike budget), the fourth must skip the drain.
+        mockChat.sendMessageStream = vi
+          .fn()
+          .mockResolvedValueOnce(toolCallStream())
+          .mockResolvedValueOnce(createEmptyStream())
+          .mockResolvedValueOnce(toolCallStream())
+          .mockResolvedValueOnce(createEmptyStream())
+          .mockResolvedValueOnce(toolCallStream())
+          .mockResolvedValueOnce(createEmptyStream())
+          .mockResolvedValueOnce(toolCallStream())
+          .mockResolvedValueOnce(createEmptyStream());
+
+        const prompt = {
+          sessionId: 'test-session-id',
+          prompt: [{ type: 'text' as const, text: 'read file' }],
+        };
+        await session.prompt(prompt);
+        await session.prompt(prompt);
+        await session.prompt(prompt);
+        await session.prompt(prompt);
+
+        // Three consecutive timeouts trip the latch, so the never-answered
+        // extMethod is attempted on the first three tool batches only.
+        const drainCalls = vi
+          .mocked(mockClient.extMethod)
+          .mock.calls.filter((call) => call[0] === 'craft/drainMidTurnQueue');
+        expect(drainCalls).toHaveLength(3);
+      }, 20_000);
+
+      it('resets the timeout strike count when a drain succeeds', async () => {
+        const tool = {
+          name: 'read_file',
+          kind: core.Kind.Read,
+          build: vi.fn().mockReturnValue({
+            params: { path: '/tmp/test.txt' },
+            getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+            getDescription: vi.fn().mockReturnValue('Read file'),
+            toolLocations: vi.fn().mockReturnValue([]),
+            execute: vi
+              .fn()
+              .mockResolvedValue({ llmContent: 'ok', returnDisplay: 'ok' }),
+          }),
+        };
+        mockToolRegistry.getTool.mockReturnValue(tool);
+        mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.YOLO);
+        // Timeout, success, then timeouts: the success must reset the strike
+        // count, so the latch needs three NEW consecutive timeouts to trip.
+        mockClient.extMethod = vi
+          .fn()
+          .mockReturnValueOnce(new Promise(() => {}))
+          .mockResolvedValueOnce({ messages: [] })
+          .mockReturnValue(new Promise(() => {}));
+
+        const toolCallStream = () =>
+          createStreamWithChunks([
+            {
+              type: core.StreamEventType.CHUNK,
+              value: {
+                functionCalls: [
+                  {
+                    id: 'c',
+                    name: 'read_file',
+                    args: { path: '/tmp/test.txt' },
+                  },
+                ],
+              },
+            },
+          ]);
+        const streamMock = vi.fn();
+        for (let i = 0; i < 5; i++) {
+          streamMock
+            .mockResolvedValueOnce(toolCallStream())
+            .mockResolvedValueOnce(createEmptyStream());
+        }
+        mockChat.sendMessageStream = streamMock;
+
+        const prompt = {
+          sessionId: 'test-session-id',
+          prompt: [{ type: 'text' as const, text: 'read file' }],
+        };
+        for (let i = 0; i < 5; i++) {
+          await session.prompt(prompt);
+        }
+
+        // Strikes: timeout(1), success(reset to 0), timeout(1), timeout(2),
+        // timeout(3 -> latch). All five batches attempt the drain; without
+        // the reset the latch would trip on the fourth batch and the fifth
+        // attempt would be skipped.
+        const drainCalls = vi
+          .mocked(mockClient.extMethod)
+          .mock.calls.filter((call) => call[0] === 'craft/drainMidTurnQueue');
+        expect(drainCalls).toHaveLength(5);
+      }, 30_000);
+
       it('keeps mid-turn drain enabled after a transient error', async () => {
         const tool = {
           name: 'read_file',

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -139,6 +139,24 @@ type AutoCompressionSendResult =
   | { responseStream: null; stopReason: PromptResponse['stopReason'] };
 
 const MID_TURN_QUEUE_DRAIN_METHOD = 'craft/drainMidTurnQueue';
+// The drain is served from an in-memory queue, so a conforming client answers
+// near-instantly (or rejects with -32601). No response within this window
+// means the client silently drops unknown methods; without a deadline the
+// await would wedge the prompt turn forever.
+const MID_TURN_QUEUE_DRAIN_TIMEOUT_MS = 2_000;
+// Latch the drain off only after this many consecutive timeouts: one slow
+// answer must not permanently disable mid-turn messages for a
+// conforming-but-busy client, while a client that never answers stops
+// costing a stall per tool batch after a few batches.
+const MID_TURN_QUEUE_DRAIN_MAX_TIMEOUT_STRIKES = 3;
+
+class MidTurnDrainTimeoutError extends Error {
+  constructor() {
+    super(
+      `mid-turn queue drain got no response within ${MID_TURN_QUEUE_DRAIN_TIMEOUT_MS}ms`,
+    );
+  }
+}
 
 interface BackgroundNotificationQueueItem {
   displayText: string;
@@ -373,6 +391,7 @@ export class Session implements SessionContext {
   private lastPromptTokenCount = 0;
   private lastPromptTokenCountChat: GeminiChat | null = null;
   private midTurnDrainUnavailable = false;
+  private midTurnDrainTimeoutStrikes = 0;
 
   // Background notification drain state. ACP does not have the TUI's idle
   // hook, so the session serializes registry callbacks through this queue.
@@ -1512,13 +1531,25 @@ export class Session implements SessionContext {
   async #drainMidTurnUserMessages(): Promise<Part[]> {
     if (this.midTurnDrainUnavailable) return [];
 
+    let drainPromise: ReturnType<AgentSideConnection['extMethod']> | undefined;
     try {
-      const response = await this.client.extMethod(
-        MID_TURN_QUEUE_DRAIN_METHOD,
-        {
-          sessionId: this.sessionId,
-        },
-      );
+      drainPromise = this.client.extMethod(MID_TURN_QUEUE_DRAIN_METHOD, {
+        sessionId: this.sessionId,
+      });
+      let timeoutHandle: NodeJS.Timeout | undefined;
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(
+          () => reject(new MidTurnDrainTimeoutError()),
+          MID_TURN_QUEUE_DRAIN_TIMEOUT_MS,
+        );
+      });
+      let response: Awaited<typeof drainPromise>;
+      try {
+        response = await Promise.race([drainPromise, timeoutPromise]);
+      } finally {
+        clearTimeout(timeoutHandle);
+      }
+      this.midTurnDrainTimeoutStrikes = 0;
       // A client may legally resolve with `result: null` (passed through
       // unwrapped by the ACP SDK); guard the object access so that doesn't
       // throw a TypeError and get misclassified as a transient drain error.
@@ -1557,8 +1588,24 @@ export class Session implements SessionContext {
         error && typeof error === 'object' && 'code' in error
           ? (error as { code?: unknown }).code
           : undefined;
+      const isTimeout = error instanceof MidTurnDrainTimeoutError;
+      if (isTimeout) {
+        this.midTurnDrainTimeoutStrikes += 1;
+        // The lost race leaves the request pending; if the client settles it
+        // later, a rejection must not surface as an unhandled rejection.
+        drainPromise?.catch(() => {});
+      }
+      // Repeated timeouts are also permanent: a conforming client answers
+      // (or rejects with -32601) immediately, so sustained silence means the
+      // client drops unknown methods and would stall every subsequent tool
+      // batch the same way. A single timeout is treated as transient so one
+      // slow answer doesn't disable the drain for the whole session.
       const isPermanentError =
-        errorCode === -32601 || /method not found/i.test(errorMessage);
+        errorCode === -32601 ||
+        /method not found/i.test(errorMessage) ||
+        (isTimeout &&
+          this.midTurnDrainTimeoutStrikes >=
+            MID_TURN_QUEUE_DRAIN_MAX_TIMEOUT_STRIKES);
 
       if (isPermanentError) {
         this.midTurnDrainUnavailable = true;


### PR DESCRIPTION
## What this PR does

- Gives the ACP agent's mid-turn message drain request — sent to the client after every tool batch since #4728 — a 2-second deadline instead of awaiting the client's reply forever.
- After three consecutive unanswered drains, the agent stops asking for the rest of the session. A proper "method not found" rejection still disables it immediately, and a single slow answer never disables it.
- Makes the integration-test ACP client spec-conforming: it now answers unknown agent→client requests with the standard JSON-RPC `-32601` error instead of silently ignoring them.

## Why it's needed

- An ACP client that silently drops unknown methods never answers the drain request, so **every prompt that runs a tool hangs forever**. Pure-text prompts ("Say hello") are unaffected, which made the failure look mysterious.
- This broke the Release pipeline: the ACP integration tests (whose hand-rolled client ignores unknown methods) timed out on `session/prompt` in three consecutive Release runs ([example](https://github.com/QwenLM/qwen-code/actions/runs/27250503972/job/80473984312)), blocking releases.
- Any third-party client written without the official SDK would hit the same permanent hang in production.

## Reviewer Test Plan

### How to verify

1. Connect an ACP client that does not answer unknown extension methods (e.g. the integration-test harness before this PR).
2. Send a prompt that triggers a tool call, e.g. `Create a quick note`.
3. Before: the prompt never returns — the client-side request times out after 60s (`Request 4 (session/prompt) timed out` in CI). After: the turn completes; the first three tool batches pay at most a one-time 2s wait each, then the agent stops asking.

### Evidence (Before & After)

| Scenario | Before | After |
| --- | --- | --- |
| ACP prompt with a tool call, client ignores unknown methods | hangs 60s, failed all retries in 3 consecutive Release runs | ✅ completes (~21s incl. model) |
| `acp-integration` suite + `acp-cron` test, real model, no sandbox | 3 tests failing | ✅ 12/12 pass, no retries |
| Repeated unanswered drains | n/a (hang) | ✅ retried twice, then disabled for the session; one slow answer alone never disables it |

Full E2E report in a separate comment below.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Real model via OpenAI-compatible endpoint (deepseek-v4-flash on DashScope), `QWEN_SANDBOX=false`, isolated `QWEN_HOME`.

## Risk & Scope

- Main risk or tradeoff: a conforming-but-slow client that takes >2s to answer three tool batches in a row loses mid-turn message injection for that session; this degrades silently (debug log only).
- Not validated / out of scope: the desktop client end-to-end (it answers the drain, so only the unchanged happy path applies to it).
- Breaking changes / migration notes: none.

## Linked Issues

Regression introduced by #4728.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

- 自 #4728 起,ACP agent 在每个工具批次执行后都会向客户端发送一个"拉取轮次中用户消息"的请求,并无限期等待回复。本 PR 为该请求加上 2 秒超时。
- 连续三次超时后,本会话内不再发送该请求。客户端正常返回 "method not found" 错误仍会立即停用该功能;单次响应慢不会停用。
- 让集成测试中的 ACP 客户端符合 JSON-RPC 规范:对未知的 agent→client 请求回复标准 `-32601` 错误,而不是静默忽略。

## 为什么需要

- 静默丢弃未知方法的 ACP 客户端永远不会回复该请求,导致**所有调用工具的 prompt 永久挂起**;纯文本 prompt("Say hello")不受影响,使问题看起来很诡异。
- 这导致 Release 流水线损坏:ACP 集成测试(其手写客户端会忽略未知方法)在连续三次 Release 运行中 `session/prompt` 超时,阻塞发版。
- 任何不使用官方 SDK 编写的第三方客户端在生产环境都会遇到同样的永久挂起。

## 验证方式

1. 连接一个不回复未知扩展方法的 ACP 客户端(本 PR 之前的集成测试 harness 即是)。
2. 发送一个会触发工具调用的 prompt,例如 `Create a quick note`。
3. 修复前:prompt 永不返回,客户端 60 秒后超时。修复后:轮次正常完成,前三个工具批次各最多多等 2 秒,之后不再发送该请求。

## 风险与范围

- 主要风险:响应慢(连续三个批次都超过 2 秒)的合规客户端会在该会话内失去轮次中消息注入功能,且仅有 debug 日志记录。
- 未验证:桌面客户端端到端(它会正常应答该请求,走的是未改动的正常路径)。
- 无破坏性变更。

</details>
