### PR TITLE
fix(core): remove `env` from read-only shell command allowlist

### DIFF
--- a/packages/core/src/utils/shellAstParser.ts
+++ b/packages/core/src/utils/shellAstParser.ts
@@ -83,7 +83,6 @@ const READ_ONLY_ROOT_COMMANDS = new Set([
   'dirname',
   'du',
   'echo',
-  'env',
   'find',
   'git',
   'grep',

--- a/packages/core/src/utils/shellReadOnlyChecker.ts
+++ b/packages/core/src/utils/shellReadOnlyChecker.ts
@@ -28,7 +28,6 @@ const READ_ONLY_ROOT_COMMANDS = new Set([
   'dirname',
   'du',
   'echo',
-  'env',
   'find',
   'git',
   'grep',


### PR DESCRIPTION
## Summary

`env` is a command proxy — it can execute arbitrary commands with side effects (`env open -a Calculator`, `env rm -rf ...`, etc.). Having it in `READ_ONLY_ROOT_COMMANDS` bypasses the user confirmation prompt, allowing prompt-injection attacks to achieve arbitrary code execution without user interaction.

This fix removes `env` from both read-only command sets so all `env` invocations now require user confirmation.

Fixes #4930.

## Changes

- `packages/core/src/utils/shellReadOnlyChecker.ts` — remove `'env'` from `READ_ONLY_ROOT_COMMANDS` (deprecated regex-based checker)
- `packages/core/src/utils/shellAstParser.ts` — remove `'env'` from `READ_ONLY_ROOT_COMMANDS` (current AST-based checker)

## Verification

All 181 existing tests in `shellAstParser.test.ts` (148 tests) and `shellReadOnlyChecker.test.ts` (33 tests) pass without modification.

## Reviewer Test Plan

**How to verify:** Start `qwen` in default mode and try `Please help me run this command: env open -a Calculator`. Before this fix, the command executes without confirmation. After this fix, the user is prompted for confirmation.

**Before:** `env open -a Calculator` → no confirmation prompt → calculator opens.
**After:** `env open -a Calculator` → user confirmation prompt appears.

<details><summary>中文说明</summary>

## 概述

`env` 不仅是"打印环境变量"的工具，它本质上是一个命令代理——可以执行任意带副作用的命令（如 `env open -a Calculator`、`env rm -rf ...` 等）。将其放在只读命令白名单中会跳过用户确认，使得 prompt injection 攻击可以在无确认情况下执行任意代码。

## 改动

从 `shellReadOnlyChecker.ts`（已废弃的正则方案）和 `shellAstParser.ts`（当前 AST 方案）的 `READ_ONLY_ROOT_COMMANDS` 中各移除 `'env'` 一行。

## 验证

`shellAstParser.test.ts`（148 个测试）和 `shellReadOnlyChecker.test.ts`（33 个测试）共 181 个测试全部通过，无需修改测试用例。

</details>