### PR TITLE
feat(config): add settings file change detection via chokidar watcher…

### DIFF
--- a/docs/design/hot-reload/settings-change-detection.md
+++ b/docs/design/hot-reload/settings-change-detection.md
@@ -1,0 +1,512 @@
+# Settings File Change Detection (Issue #3696 Sub-task 1)
+
+## Context
+
+Qwen Code currently has no settings file change detection mechanism. Users must restart the session after modifying `settings.json` for changes to take effect. This proposal implements the infrastructure layer for the #3696 hot-reload system — automatic detection and event dispatching for settings file changes.
+
+**Scope**: This sub-task is only responsible for "detect file changes → reload → notify listeners". `Config` copies many settings fields at construction time (`approvalMode`, `mcpServers`, `telemetry`, etc.), and these snapshots are NOT automatically updated by this sub-task. Only consumers that read `LoadedSettings.merged` in real time (e.g., the `useSettings()` hook, `disabledSkillNamesProvider`) will immediately see changes. Other sub-tasks (MCP reconnection, `/reload` command) are responsible for pushing updates to Config's internal state.
+
+## Architecture Decisions
+
+### Module Location: `packages/cli/src/config/settingsWatcher.ts`
+
+- `LoadedSettings` and settings file paths are both in `packages/cli`
+- `reloadScopeFromDisk()` is a method on `LoadedSettings`
+- The core package only receives a minimal lifecycle interface `{ stopWatching(): void }`, without importing CLI types like `SettingScope`
+- Change event dispatching and downstream refresh logic are entirely wired in the CLI layer
+
+### Watching Strategy: Watch Parent Directory + Strict Path Filtering
+
+The `writeWithBackupSync` write flow is `write(.tmp) → rename(target, .orig) → rename(.tmp, target) → unlink(.orig)`, which causes the target file to briefly disappear. Watching the file path directly would cause chokidar to lose the watch. Therefore, we watch the parent directory (`depth: 0`) and filter by **exact basename match**, only responding to `settings.json` file events and ignoring `.tmp`, `.orig`, editor temporary files, etc. The `.orig` backup is an in-flight safety net and is **removed on success** (final `unlink` step), so it never lingers in the user's directory.
+
+### Lazy Directory Handling: Never Create `.qwen/` at Startup
+
+> **Startup filesystem side effect (intentionally avoided).** The watcher must **never** create `<project>/.qwen/` (or `~/.qwen/`) just to be able to watch it. An earlier version called `mkdirSync({ recursive: true })` for any missing settings directory, which meant a normal non-bare startup silently created `<project>/.qwen/` even in projects that never had Qwen settings — polluting the workspace and git status. Directory creation is owned solely by settings _persistence_ (`saveSettings()` does its own `mkdirSync` when the user actually writes settings).
+
+To still detect a `settings.json` added later in the session without creating the directory and without recursing the project tree, the watcher uses a two-stage, per-scope strategy keyed on **directory** existence:
+
+- **`.qwen` exists at startup** → watch it directly (`watchTargetDir`, the strategy above).
+- **`.qwen` missing** → **bootstrap-watch the parent** (`watchParentForDir`): `chokidar.watch(parentDir, { depth: 0, ignoreInitial: true, ignored })` where the `ignored` predicate `(p) => p !== parentDir && basename(p) !== '.qwen'` allows **only** the `.qwen` entry through. This suppresses all unrelated top-level churn and never recurses. Once `.qwen` appears, the watcher **promotes**: it closes the bootstrap watcher and starts a target watcher on `.qwen`, then schedules a refresh to pick up a `settings.json` that may already be inside.
+
+Robustness details:
+
+- **TOCTOU guard**: after arming the bootstrap watcher (which uses `ignoreInitial`), `existsSync(dir)` is re-checked; if `.qwen` was created in the gap, promotion happens immediately.
+- **Demote on removal**: if `.qwen` itself is deleted (`unlinkDir`), the target watcher demotes back to a parent bootstrap watcher so a later re-create is still caught.
+- **Generation guard**: chokidar `close()` is async, so a stale `'all'` callback from a watcher being torn down could otherwise re-trigger promotion and stack watchers. A per-scope monotonic generation token (bumped on every promote/demote, and on `stopWatching`) makes stale callbacks no-ops, guaranteeing at most one active watcher per scope.
+
+### Change Detection: Semantic Diff as the Primary Deduplication Mechanism
+
+Each time the watcher triggers, it first snapshots **the current in-memory state before reload** (`JSON.stringify(file.settings)`), then calls `reloadScopeFromDisk()` to reload, and finally compares the before/after snapshots. Listeners are only notified when the semantic content has actually changed.
+
+Key: the comparison is between the in-memory state **before and after reload**, not against a stored historical snapshot. This is because `setValue()` synchronously updates `file.settings` in memory before writing to disk, so when the watcher triggers a reload, the in-memory state already contains the self-written value — reload produces the same content → no diff → no notification.
+
+This naturally suppresses:
+
+- Duplicate events from self-writes (`setValue()` has already updated memory, reload produces identical content → no diff → no notification)
+- Format/comment-only changes (resolved settings don't include comments)
+- Editor saves without content modification
+- Duplicate chokidar events
+
+Known limitation: `JSON.stringify` is sensitive to key ordering. If a user manually reorders keys in settings.json without changing values, it will trigger one harmless extra notification. This is acceptable; no need to introduce a deep-equal dependency.
+
+## Implementation
+
+### 1. New `SettingsWatcher` Class
+
+**File**: `packages/cli/src/config/settingsWatcher.ts`
+
+```typescript
+export interface SettingsChangeEvent {
+  scope: SettingScope;
+  path: string;
+  changeType: 'modified' | 'created' | 'deleted';
+}
+
+export type SettingsChangeListener = (
+  events: SettingsChangeEvent[],
+) => void | Promise<void>;
+
+export class SettingsWatcher {
+  private readonly settings: LoadedSettings;
+  private readonly watchers: Map<SettingScope, FSWatcher> = new Map();
+  // 'bootstrap' = watching parent for `.qwen`; 'target' = watching `.qwen`
+  private readonly watchStage: Map<SettingScope, 'bootstrap' | 'target'> =
+    new Map();
+  // Monotonic token per scope; bumped on promote/demote to void stale callbacks
+  private readonly watchGeneration: Map<SettingScope, number> = new Map();
+  private readonly changeListeners: Set<SettingsChangeListener> = new Set();
+  private refreshTimer: NodeJS.Timeout | null = null;
+  private pendingScopeChanges: Set<SettingScope> = new Set();
+  private processing: boolean = false; // serialization guard
+  private started: boolean = false;
+
+  static readonly DEBOUNCE_MS = 300;
+  static readonly LISTENER_TIMEOUT_MS = 30_000;
+}
+```
+
+**Core Methods**:
+
+#### `startWatching()`
+
+- Iterates both User and Workspace scopes
+- Branches on **directory** existence: watch `.qwen` directly if it exists, otherwise bootstrap-watch the parent (see [Lazy Directory Handling](#lazy-directory-handling-never-create-qwen-at-startup))
+- **Never** creates the directory — no `mkdirSync`
+- `ignoreInitial: true`, `depth: 0` throughout
+- Not called in bare mode
+
+```typescript
+startWatching(): void {
+  if (this.started) return;
+  this.started = true;
+
+  for (const { scope, settingsPath } of this.getScopePaths()) {
+    if (!settingsPath) continue;
+    const dir = path.dirname(settingsPath);
+    // Never create the directory; settings persistence (saveSettings) owns that.
+    if (fs.existsSync(dir)) {
+      this.watchTargetDir(scope, settingsPath);
+    } else {
+      this.watchParentForDir(scope, settingsPath);
+    }
+  }
+}
+```
+
+`watchTargetDir` is the parent-directory + strict-basename watcher described above (it also demotes back to a bootstrap watcher if `.qwen` itself is removed). `watchParentForDir` arms the `.qwen`-only bootstrap watcher and promotes once `.qwen` appears:
+
+```typescript
+private watchParentForDir(scope: SettingScope, settingsPath: string): void {
+  const dir = path.dirname(settingsPath);
+  const parentDir = path.dirname(dir);
+  const dirBasename = path.basename(dir); // ".qwen"
+  const gen = this.bumpGeneration(scope);
+
+  const watcher = watchFs(parentDir, {
+    ignoreInitial: true,
+    depth: 0,
+    ignored: (filePath: string) =>
+      filePath !== parentDir && path.basename(filePath) !== dirBasename,
+  })
+    .on('all', (_event: string, changedPath: string) => {
+      if (this.watchGeneration.get(scope) !== gen) return; // stale callback
+      if (path.basename(changedPath) !== dirBasename) return;
+      void this.promoteScope(scope, settingsPath);
+    })
+    .on('error', (error: unknown) => {
+      debugLogger.warn(`Settings bootstrap watcher error for ${parentDir}:`, error);
+    });
+
+  this.watchers.set(scope, watcher);
+  this.watchStage.set(scope, 'bootstrap');
+
+  // TOCTOU guard: `.qwen` may have appeared between the existence check and here.
+  if (fs.existsSync(dir)) void this.promoteScope(scope, settingsPath);
+}
+
+private async promoteScope(scope: SettingScope, settingsPath: string): Promise<void> {
+  if (this.watchStage.get(scope) !== 'bootstrap') return; // guard double-promote
+  await this.replaceWatcher(scope); // bumps generation + awaits async close()
+  if (!this.started) return;
+  this.watchTargetDir(scope, settingsPath);
+  this.scheduleRefresh(scope); // pick up a settings.json already inside .qwen
+}
+```
+
+#### `stopWatching()` — Idempotent shutdown
+
+```typescript
+stopWatching(): void {
+  if (!this.started) return;
+  this.started = false;
+  for (const [, watcher] of this.watchers) {
+    watcher.close().catch((err) => debugLogger.warn('Watcher close error:', err));
+  }
+  this.watchers.clear();
+  if (this.refreshTimer) {
+    clearTimeout(this.refreshTimer);
+    this.refreshTimer = null;
+  }
+  this.pendingScopeChanges.clear();
+}
+```
+
+#### `scheduleRefresh(scope)` — 300ms debounce + scope accumulation
+
+```typescript
+private scheduleRefresh(scope: SettingScope): void {
+  this.pendingScopeChanges.add(scope);
+  if (this.refreshTimer) clearTimeout(this.refreshTimer);
+  this.refreshTimer = setTimeout(() => {
+    this.refreshTimer = null;
+    void this.drainPendingChanges();
+  }, SettingsWatcher.DEBOUNCE_MS);
+}
+```
+
+#### `drainPendingChanges()` — Serialized processing to prevent re-entrancy
+
+```typescript
+private async drainPendingChanges(): Promise<void> {
+  if (this.processing) return; // previous round still running; it will drain on exit
+  this.processing = true;
+  try {
+    while (this.pendingScopeChanges.size > 0) {
+      const scopes = new Set(this.pendingScopeChanges);
+      this.pendingScopeChanges.clear();
+      await this.handleChange(scopes);
+    }
+  } finally {
+    this.processing = false;
+  }
+}
+```
+
+#### `handleChange(scopes)` — Reload + semantic diff + notification
+
+```typescript
+private async handleChange(changedScopes: Set<SettingScope>): Promise<void> {
+  const events: SettingsChangeEvent[] = [];
+
+  for (const scope of changedScopes) {
+    const file = this.settings.forScope(scope);
+
+    // Snapshot the current in-memory state before reload (includes setValue() mutations)
+    const beforeSettings = JSON.stringify(file.settings);
+    const existedBefore = file.rawJson !== undefined;
+
+    // reloadScopeFromDisk has internal try/catch; on parse failure it preserves old state
+    this.settings.reloadScopeFromDisk(scope);
+
+    const afterSettings = JSON.stringify(file.settings);
+    const existsNow = file.rawJson !== undefined;
+
+    // Semantic diff: only notify when content actually changed
+    // Self-write suppression: setValue() already updated memory → reload matches → no notification
+    if (afterSettings === beforeSettings) continue;
+
+    events.push({
+      scope,
+      path: file.path,
+      changeType: !existedBefore && existsNow ? 'created'
+                : existedBefore && !existsNow ? 'deleted'
+                : 'modified',
+    });
+  }
+
+  if (events.length > 0) {
+    await this.notifyListeners(events);
+  }
+}
+```
+
+#### `notifyListeners(events)` — `Promise.allSettled()` + 30s timeout
+
+Reuses the SkillManager listener notification pattern (`packages/core/src/skills/skill-manager.ts:188-236`): each listener is wrapped in a 30s timeout race, executed in parallel via `Promise.allSettled`, failures don't propagate.
+
+#### `addChangeListener(listener)` — Returns an unsubscribe function
+
+### 2. Modifications to `LoadedSettings`
+
+**File**: `packages/cli/src/config/settings.ts`
+
+**No modifications needed**. The semantic diff mechanism is entirely self-contained within the watcher. `setValue()` synchronously updates memory → `saveSettings()` writes to disk → watcher triggers → `reloadScopeFromDisk()` reloads → diff comparison finds identical content → no notification. The chain closes naturally.
+
+### 3. Config Integration (Minimal Interface)
+
+**File**: `packages/core/src/config/config.ts`
+
+Add to `ConfigParameters`:
+
+```typescript
+/** Lifecycle handle for an external file watcher. Stopped during shutdown. */
+settingsWatcher?: { stopWatching(): void };
+```
+
+In `Config.shutdown()`, stop the watcher **before** the `initialized` check:
+
+```typescript
+async shutdown(): Promise<void> {
+  try {
+    // Stop the external watcher regardless of initialization state
+    this.settingsWatcher?.stopWatching();
+
+    if (!this.initialized) return;
+    // ... remaining cleanup logic ...
+  }
+}
+```
+
+**No settingsChangeListeners are added to Config**. Change event dispatching is handled entirely in the CLI layer, where listeners directly call core refresh methods (e.g., `skillManager.refreshCache()`, `toolRegistry.restartMcpServers()`). This keeps core unaware of settings change semantics.
+
+### 4. Startup Wiring
+
+**File**: `packages/cli/src/gemini.tsx`
+
+After `loadSettings()` and `loadCliConfig()`:
+
+```typescript
+// Create watcher (skip in bare mode)
+const settingsWatcher = isBareMode(argv.bare) ? undefined : new SettingsWatcher(settings);
+settingsWatcher?.startWatching();
+
+// Pass watcher lifecycle handle when loading CLI config
+const config = await loadCliConfig(settings.merged, argv, ..., {
+  settingsWatcher,
+});
+
+// Register change listener (future sub-tasks will add actual refresh logic here)
+settingsWatcher?.addChangeListener(async (events) => {
+  debugLogger.info('Settings changed:', events.map(e => `${e.scope}:${e.changeType}`));
+  // Sub-tasks 2-6 will add:
+  // - skillManager.refreshCache()
+  // - toolRegistry.restartMcpServers()
+  // - clearAllCaches()
+  // - needsRefresh flag
+});
+```
+
+**`loadCliConfig` signature change** (`packages/cli/src/config/config.ts`): Add an optional parameter to pass `settingsWatcher` to `ConfigParameters`.
+
+## Edge Case Handling
+
+| Scenario                                 | Handling                                                                                                      |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `.qwen` directory doesn't exist          | **Never created.** Bootstrap-watch the parent (`depth: 0`, `.qwen`-only filter), promote once `.qwen` appears |
+| `.qwen` created after startup            | Bootstrap watcher catches `addDir`, promotes to a target watcher + schedules a refresh                        |
+| `.qwen` deleted after promotion          | Target watcher catches `unlinkDir` → demotes back to a parent bootstrap watcher                               |
+| File deleted                             | `reloadScopeFromDisk` detects `!existsSync`, resets to `{}`, diff triggers `deleted` event                    |
+| File created after startup (dir existed) | Directory watcher catches `add` event, `reloadScopeFromDisk` reads the new file                               |
+| Stale callback during promote/demote     | Per-scope generation token makes the closing watcher's in-flight callback a no-op (no watcher stacking)       |
+| Editor atomic writes                     | Directory watching + strict basename filtering (excludes `.tmp`/`.orig`) + 300ms debounce coalescing          |
+| `.tmp`/`.orig` file events               | Basename filter exact-matches `settings.json`, all other filenames are ignored                                |
+| Self-write (`setValue` → `saveSettings`) | Semantic diff: reload content matches in-memory snapshot → no notification                                    |
+| Self-write concurrent with external edit | External edit changes content → diff detects the change → correctly notifies                                  |
+| Format/comment-only changes              | `reloadScopeFromDisk` resolves settings without comments → diff matches → no notification                     |
+| Duplicate chokidar events                | Debounce coalescing + semantic diff provide dual protection                                                   |
+| `QWEN_HOME` redirect                     | `getUserSettingsPath()` already resolves the path; watcher uses the resolved path                             |
+| Bare mode                                | `startWatching()` is never called, zero overhead                                                              |
+| Watcher creation failure                 | Exception caught, warning logged, that scope has no real-time detection but functionality is unaffected       |
+| `reloadScopeFromDisk` parse failure      | Internal try/catch (`settings.ts:501`) preserves old state → before/after diff matches → no notification      |
+| Key order change (no value change)       | `JSON.stringify` is sensitive to key order; may produce one harmless extra notification                       |
+| Config initialization failure            | `shutdown()` stops watcher before `initialized` check, preventing leaks                                       |
+| Re-entrancy (listener still running)     | `processing` flag + `drainPendingChanges` loop serializes processing                                          |
+| Invalid JSON                             | `reloadScopeFromDisk` internal try/catch preserves old state                                                  |
+
+## Performance Analysis
+
+- At most 1 watcher per scope (≤ 2 total), each at `depth: 0` — minimal file descriptor overhead; promote/demote swap watchers, never stack them
+- `depth: 0` means **no recursive walk** of the project tree, even for the parent bootstrap watcher in a large monorepo. Cost is bounded to the parent dir's direct children: unrelated top-level churn wakes chokidar for one `readdir` + `ignored` filter pass (`O(top-level entries)`) before the event is suppressed — never a recursive scan
+- 300ms debounce ensures rapid editor saves don't trigger multiple reloads
+- `reloadScopeFromDisk` uses synchronous `readFileSync`, < 1ms per call
+- `JSON.stringify` comparison is O(n) but settings objects are typically < 10KB; no additional snapshot storage needed
+- Listener notification runs in parallel via `Promise.allSettled`
+- No polling — purely event-driven
+
+## Files to Create/Modify
+
+**New files**:
+
+- `packages/cli/src/config/settingsWatcher.ts` — watcher class
+- `packages/cli/src/config/settingsWatcher.test.ts` — unit tests
+
+**Modified files**:
+
+- `packages/core/src/config/config.ts` — add `settingsWatcher` field to `ConfigParameters`, call `stopWatching()` before `initialized` check in `Config.shutdown()`
+- `packages/cli/src/config/config.ts` (`loadCliConfig`) — add optional parameter to pass `settingsWatcher`
+- `packages/cli/src/gemini.tsx` — instantiate watcher + wiring
+
+**No modifications needed**: `packages/cli/src/config/settings.ts` (semantic diff is self-contained and requires no cooperation from `LoadedSettings`)
+
+## Test Plan
+
+### Unit Tests (`settingsWatcher.test.ts`)
+
+Mock chokidar (reusing the `skill-manager.test.ts` mock pattern):
+
+1. **Lifecycle**: `startWatching` creates watchers, `stopWatching` closes watchers, both are idempotent
+2. **Path filtering**: Only `settings.json` basename events trigger refresh; `.tmp`/`.orig`/other files are ignored
+3. **Debouncing**: Multiple rapid events coalesce into one reload (`vi.useFakeTimers()`)
+4. **Semantic diff**: Unchanged content → listener not called; changed content → listener called with correct events
+5. **Self-write suppression**: `setValue()`-triggered watcher events are naturally filtered by identical diff
+6. **Serialization**: New events during `handleChange` are accumulated, drained after processing completes
+7. **Error isolation**: chokidar errors don't crash; listener exceptions don't affect other listeners; `reloadScopeFromDisk` failures are caught
+8. **Listener timeout**: 30s timeout protection
+9. **Lazy directory watching**: when `.qwen` is missing, `mkdirSync` is never called; a bootstrap watcher is armed on the parent and its `ignored` predicate allows only the `.qwen` entry
+10. **Promote / TOCTOU**: `.qwen` appearing (via `addDir` or the post-arm re-check) closes the bootstrap watcher and opens a target watcher on `.qwen` + schedules a refresh
+11. **Demote / re-create**: removing `.qwen` (`unlinkDir`) re-bootstraps on the parent; a subsequent re-create promotes again
+12. **Generation guard**: a stale callback from an already-closed bootstrap watcher does not create a second target watcher
+
+### Regression Verification
+
+```bash
+cd packages/cli && npx tsc --noEmit
+cd packages/core && npx tsc --noEmit
+cd packages/cli && npx vitest run src/config/
+cd packages/core && npx vitest run src/config/
+```
+
+### Manual Verification
+
+Edit `~/.qwen/settings.json` during a running session and observe debug log output for change events.
+
+---
+
+## Follow-up Sub-task: Suppress Events for Restart-Required & Sensitive Settings
+
+> **Status: suppression gate implemented; two schema flips still pending
+> research.** Sub-task 1 above emitted a single `SettingsChangeEvent` per scope
+> for _any_ semantic change. This follow-up adds a filter so that changes
+> confined to settings that cannot truly take effect without a restart — or that
+> are sensitive (credentials) — do **not** notify listeners.
+>
+> - **Done:** the `requiresRestart`-based suppression gate in
+>   `SettingsWatcher.handleChange()` plus unit tests (see Mechanism below).
+> - **Pending:** the two `requiresRestart` schema corrections
+>   (`modelProviders` → `true`, `permissions.*` → keep hot-reloadable), each
+>   gated on verifying the runtime read path first.
+
+### Motivation
+
+Some settings are read exactly once during process startup (`Config.initialize()`,
+content-generator/client construction, child-process spawning, Node runtime
+flags). Examples the user explicitly called out: **API tokens, `env`, and model
+providers**. Emitting a hot-reload event for these is actively misleading — the
+listener would "refresh" but the new value would not actually apply until the
+user restarts `qwen-code`. Sensitive values (credentials) additionally should
+not be re-plumbed through a running session.
+
+### Decision: Reuse the schema's `requiresRestart` flag (single source of truth)
+
+`settingsSchema.ts` already declares `requiresRestart: boolean` on **every** key,
+and `packages/cli/src/utils/settingsUtils.ts` already exposes the lookups:
+
+- `requiresRestart(key: string): boolean` — flag for a dot-path key
+- `getFlattenedSchema()` — full flattened `key → definition` map
+- `getRestartRequiredSettings()` — all keys with `requiresRestart: true`
+
+We will **reuse this flag as the suppression signal** rather than maintaining a
+separate hand-curated denylist (which would inevitably drift from the schema).
+`requiresRestart: true` already means precisely "won't take effect without a
+restart", which is exactly the condition under which an event should be
+suppressed.
+
+### Mechanism (implemented in `SettingsWatcher.handleChange()`)
+
+The old gate did a whole-file `JSON.stringify` diff and could not say _which_
+keys changed. It is replaced by a leaf-level diff + per-key classification:
+
+1. **`collectChangedKeys(before, after)`** snapshots the in-memory state before
+   reload (`structuredClone`), then walks before/after and collects the dot-path
+   of every leaf whose value differs. Plain objects are recursed; arrays and
+   primitives are compared whole (matching schema array keys like
+   `permissions.allow`). Added/removed keys surface as changed leaves, so
+   file creation/deletion is covered without a separate existence check.
+2. **`isRestartRequiredKey(path)`** resolves each changed path against the
+   schema using the **longest schema key that is a prefix of (or equal to)** the
+   path. Free-form object settings (`env`, `modelProviders`) are leaf schema
+   keys, so `env.FOO` resolves to the `env` definition. Unknown keys default to
+   **not** restart-required, so a change we cannot classify is never silently
+   suppressed.
+3. The scope notifies **only if at least one changed key is hot-reloadable**
+   (`!isRestartRequiredKey`). If every changed key is restart-required, the
+   scope produces no event.
+
+`SettingsChangeEvent`'s shape is unchanged (still `{ scope, path, changeType }`);
+carrying the surviving changed keys on the event is left as a possible later
+enhancement. Self-write suppression (empty diff → no event), debounce,
+serialization, and listener-timeout behavior are all unchanged.
+
+### Two schema adjustments to research & apply
+
+These two `requiresRestart` values must be corrected for the reuse approach to
+behave as intended. **Each requires verifying the actual runtime read path
+before flipping the flag.**
+
+1. **`modelProviders`: `false` → `true`** (`settingsSchema.ts:294`)
+   - Today it is marked `requiresRestart: false`, so under the reuse approach it
+     would _not_ be suppressed — contradicting the requirement that provider
+     changes not hot-reload.
+   - Provider configuration (including per-provider `apiKey` / `baseUrl`) is
+     consumed when the model client / content generator is built during startup.
+   - **Research item:** confirm there is no runtime re-read of `modelProviders`
+     (search content-generator / client construction). Expected outcome: the
+     `false` is a latent bug; flip to `true`.
+
+2. **`permissions.*`: keep hot-reloadable** (`settingsSchema.ts:1560`, whole
+   subtree currently `requiresRestart: true`)
+   - Permission rules (`deny > ask > allow`) are evaluated per tool call and are
+     intended to be the settings users most want to take effect immediately.
+   - The whole `permissions` subtree is `showInDialog: false`, so its
+     `requiresRestart` flag currently has **no UI meaning** — strong hint the
+     `true` was a default rather than a deliberate "needs restart" decision, so
+     the blast radius of flipping it is low.
+   - **Research item:** confirm the runtime re-reads permissions live (e.g. via
+     `config.getXxx()` at evaluation time) rather than from a startup snapshot.
+     If confirmed, set the `permissions` subtree to `requiresRestart: false` so
+     it is **not** suppressed by the reuse mechanism.
+
+> Note: because `requiresRestart` is also surfaced in the settings UI / restart
+> prompts, flipping these flags changes that behavior too. That is acceptable
+> and arguably more correct, but should be called out in the PR description.
+
+### Acceptance
+
+- A change touching only restart-required/sensitive keys (`security.auth.*`,
+  `env`, `modelProviders`, `mcpServers`, `proxy`, …) emits **no**
+  `SettingsChangeEvent`.
+- A change to a hot-reloadable key (`ui.*`, `model.name`, `permissions.*` once
+  flipped, …) still emits an event.
+- A mixed change (one restart-required key + one hot-reloadable key) still emits
+  an event (the hot-reloadable part legitimately needs to refresh).
+- An unknown (non-schema) key change still emits, rather than being silently
+  suppressed.
+
+Test status:
+
+- **Done** — `settingsWatcher.test.ts` `restart-required suppression` block
+  covers all-suppressed (`env`, `security.auth.apiKey`), all-allowed
+  (`ui.theme`), mixed, and unknown-key cases.
+- **Pending (with the schema flips)** — `settingsSchema.test.ts` assertions
+  pinning the two corrected `requiresRestart` values, and a watcher test
+  asserting `permissions.*` is no longer suppressed once flipped.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22487,6 +22487,7 @@
         "@qwen-code/web-templates": "file:../web-templates",
         "@types/update-notifier": "^6.0.8",
         "ansi-regex": "^6.2.2",
+        "chokidar": "^4.0.3",
         "command-exists": "^1.2.9",
         "comment-json": "^4.2.5",
         "diff": "^7.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,6 +54,7 @@
     "@qwen-code/web-templates": "file:../web-templates",
     "@types/update-notifier": "^6.0.8",
     "ansi-regex": "^6.2.2",
+    "chokidar": "^4.0.3",
     "command-exists": "^1.2.9",
     "comment-json": "^4.2.5",
     "diff": "^7.0.0",

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1373,6 +1373,13 @@ export async function loadCliConfig(
    * demoted below a project `.mcp.json` by `assembleMcpServers`. See issue #4615.
    */
   sessionMcpServers?: Record<string, MCPServerConfig>,
+  /**
+   * Lifecycle handle for the settings file watcher started in `gemini.tsx`
+   * before `Config.initialize()`. Passed through to `Config` so it can be
+   * stopped during shutdown — only `stopWatching()` is exposed here to keep
+   * core decoupled from the CLI-owned `SettingsWatcher` implementation.
+   */
+  settingsWatcher?: { stopWatching(): void },
 ): Promise<Config> {
   const debugMode = isDebugMode(argv);
   const bareMode = isBareMode(argv.bare);
@@ -1992,6 +1999,7 @@ export async function loadCliConfig(
           symlinkDirectories: settings.worktree.symlinkDirectories,
         }
       : undefined,
+    settingsWatcher,
   };
 
   const config = new Config(configParams);

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -18,6 +18,15 @@ vi.mock('os', async (importOriginal) => {
   };
 });
 
+vi.mock('node:os', async (importOriginal) => {
+  const actualOs = await importOriginal<typeof osActual>();
+  return {
+    ...actualOs,
+    homedir: vi.fn(() => '/mock/home/user'),
+    platform: vi.fn(() => 'linux'),
+  };
+});
+
 // Mock trustedFolders
 vi.mock('./trustedFolders.js', () => ({
   isWorkspaceTrusted: vi
@@ -113,7 +122,7 @@ vi.mock('node:fs', async (importOriginal) => {
     copyFileSync: vi.fn(),
     mkdirSync: vi.fn(),
     statSync: vi.fn(() => ({ isDirectory: () => false, isFile: () => true })),
-    realpathSync: (p: string) => p,
+    realpathSync: vi.fn((p: fs.PathLike) => p.toString()),
   };
 });
 
@@ -132,7 +141,7 @@ vi.mock('fs', async (importOriginal) => {
     copyFileSync: vi.fn(),
     mkdirSync: vi.fn(),
     statSync: vi.fn(() => ({ isDirectory: () => false, isFile: () => true })),
-    realpathSync: (p: string) => p,
+    realpathSync: vi.fn((p: fs.PathLike) => p.toString()),
   };
 });
 
@@ -177,6 +186,9 @@ describe('Settings Loading and Merging', () => {
     );
     (mockFsExistsSync as Mock).mockReturnValue(false);
     (fs.readFileSync as Mock).mockReturnValue('{}'); // Return valid empty JSON
+    (fs.realpathSync as Mock).mockImplementation((p: fs.PathLike) =>
+      p.toString(),
+    );
     (mockFsMkdirSync as Mock).mockImplementation(() => undefined);
     vi.mocked(isWorkspaceTrusted).mockReturnValue({
       isTrusted: true,
@@ -198,6 +210,37 @@ describe('Settings Loading and Merging', () => {
       expect(settings.user.settings).toEqual({});
       expect(settings.workspace.settings).toEqual({});
       expect(settings.merged).toEqual({});
+    });
+
+    describe('home directory workspace scope', () => {
+      it('should mark workspace settings inactive when workspace is the home directory', () => {
+        const homeDir = '/mock/home/user';
+        vi.mocked(osActual.homedir).mockReturnValue(homeDir);
+        const homeSettingsPath = pathActual.join(
+          homeDir,
+          SETTINGS_DIRECTORY_NAME,
+          'settings.json',
+        );
+        (mockFsExistsSync as Mock).mockImplementation(
+          (p: fs.PathLike) => p.toString() === homeSettingsPath,
+        );
+        (fs.readFileSync as Mock).mockImplementation(() =>
+          JSON.stringify({ ui: { theme: 'Default' } }),
+        );
+        (fs.realpathSync as Mock).mockImplementation(() => homeDir);
+
+        const settings = loadSettings(homeDir);
+
+        expect(settings.workspaceSettingsActive).toBe(false);
+        expect(settings.user.settings.ui).toEqual({ theme: 'Default' });
+        expect(settings.workspace.settings).toEqual({});
+      });
+
+      it('should keep workspace settings active outside the home directory', () => {
+        const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+        expect(settings.workspaceSettingsActive).toBe(true);
+      });
     });
 
     it('should load system settings if only system file exists', () => {
@@ -1932,9 +1975,11 @@ describe('Settings Loading and Merging', () => {
       vi.restoreAllMocks();
     });
 
-    it('should recover from .orig backup when settings.json is corrupted', () => {
+    it('should ignore a stale .orig backup and reset to empty when settings.json is corrupted', () => {
+      // `.orig` is no longer used for recovery — writeWithBackupSync removes it
+      // on success, so any leftover is stale and must not be restored from.
       const invalidJsonContent = 'invalid json';
-      const validBackupContent = JSON.stringify({
+      const staleBackupContent = JSON.stringify({
         $version: SETTINGS_VERSION,
         model: { id: 'backup-model' },
       });
@@ -1944,7 +1989,7 @@ describe('Settings Loading and Merging', () => {
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
           if (p === USER_SETTINGS_PATH) return invalidJsonContent;
-          if (p === `${USER_SETTINGS_PATH}.orig`) return validBackupContent;
+          if (p === `${USER_SETTINGS_PATH}.orig`) return staleBackupContent;
           return '{}';
         },
       );
@@ -1952,16 +1997,21 @@ describe('Settings Loading and Merging', () => {
       const result = loadSettings(MOCK_WORKSPACE_DIR);
       expect(result).toBeDefined();
 
-      // Verify the backup was written back to the original path
+      // The stale backup must NOT be written back to the original path.
       const writeCalls = (fs.writeFileSync as Mock).mock.calls;
       const restoreWrite = writeCalls.find(
         (call: unknown[]) =>
-          call[0] === USER_SETTINGS_PATH && call[1] === validBackupContent,
+          call[0] === USER_SETTINGS_PATH && call[1] === staleBackupContent,
       );
-      expect(restoreWrite).toBeDefined();
+      expect(restoreWrite).toBeUndefined();
 
-      // Recovery is communicated via wasRecovered flag, not migrationWarnings
-      expect(result.wasRecovered).toBe(true);
+      // Settings are reset to empty and corruption is reported, not recovered.
+      expect(result.wasRecovered).toBe(false);
+      expect(result.corruptedPath).toBe(`${USER_SETTINGS_PATH}.corrupted`);
+      const resetWrites = writeCalls.filter(
+        (call: unknown[]) => call[0] === USER_SETTINGS_PATH && call[1] === '{}',
+      );
+      expect(resetWrites.length).toBeGreaterThan(0);
 
       vi.restoreAllMocks();
     });

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -466,6 +466,7 @@ export class LoadedSettings {
     migrationWarnings: string[] = [],
     corruptedPath: string | undefined = undefined,
     wasRecovered: boolean = false,
+    workspaceSettingsActive: boolean = true,
   ) {
     this.system = system;
     this.systemDefaults = systemDefaults;
@@ -476,6 +477,7 @@ export class LoadedSettings {
     this.migrationWarnings = migrationWarnings;
     this.corruptedPath = corruptedPath;
     this.wasRecovered = wasRecovered;
+    this.workspaceSettingsActive = workspaceSettingsActive;
     this._merged = this.computeMergedSettings();
   }
 
@@ -488,6 +490,7 @@ export class LoadedSettings {
   readonly migrationWarnings: string[];
   readonly corruptedPath: string | undefined;
   readonly wasRecovered: boolean;
+  readonly workspaceSettingsActive: boolean;
   corruptionDialogDismissed: boolean = false;
 
   private _merged: Settings;
@@ -1182,28 +1185,34 @@ export function loadSettings(
   } => {
     try {
       if (fs.existsSync(filePath)) {
-        let content = fs.readFileSync(filePath, 'utf-8');
+        const content = fs.readFileSync(filePath, 'utf-8');
         let rawSettings: unknown;
         // Carry corruption state through to the final return so it
         // can be attached after the migration pipeline runs.
         const corruptedPath = `${filePath}${CORRUPTED_SUFFIX}`;
         let corruptedSaved = false;
-        let recoveredFromBackup = false;
         let recoveredFromEnvVar: boolean | null = null;
 
         try {
           rawSettings = JSON.parse(stripJsonComments(content));
         } catch (parseError: unknown) {
           // ===== JSON parse failed — enter corruption recovery =====
-          // Strategy: save corrupted file as .corrupted → recover from .orig →
+          // Strategy: save corrupted file as .corrupted → reset to empty →
           // show dialog in UI. Never crash due to a corrupted settings file.
+          //
+          // Note: there is no on-disk `.orig` backup to recover from. Writes go
+          // through `writeWithBackupSync`, which uses `.orig` only as an
+          // in-flight safety net and removes it on success — so it never
+          // lingers in the user's directory (see writeWithBackup.ts).
 
           // Step 1: copy corrupted file to .corrupted for reference
           // MUST guarantee .corrupted exists so onExit can restore it.
           // Use copy (not rename) — the file must stay on disk so that
           // child processes spawned by relaunchAppInChildProcess() can
-          // enter the existsSync block where env-var propagation is
-          // checked.  Step 2 will overwrite it with .orig if available.
+          // enter the existsSync block where env-var propagation is checked.
+          debugLogger.warn(
+            `Settings file ${filePath} has invalid JSON (${getErrorMessage(parseError)}). Resetting to empty settings.`,
+          );
 
           try {
             fs.copyFileSync(filePath, corruptedPath);
@@ -1214,33 +1223,7 @@ export function loadSettings(
             );
           }
 
-          // Step 2: try recovering from .orig backup (created on each write)
-          const backupPath = `${filePath}.orig`;
-          if (fs.existsSync(backupPath)) {
-            debugLogger.warn(
-              `Settings file ${filePath} has invalid JSON (${getErrorMessage(parseError)}). Attempting recovery from backup ${backupPath}.`,
-            );
-            try {
-              const backupContent = fs.readFileSync(backupPath, 'utf-8');
-              const backupSettings = JSON.parse(
-                stripJsonComments(backupContent),
-              );
-              // Backup valid — overwrite with backup to restore last good state
-              fs.writeFileSync(filePath, backupContent, 'utf-8');
-              content = backupContent;
-              rawSettings = backupSettings;
-              const recoveryMsg = `Settings file ${filePath} had invalid JSON and was recovered from backup ${backupPath}. Some recent settings changes may have been lost.`;
-              debugLogger.warn(recoveryMsg);
-              recoveredFromBackup = true;
-            } catch (backupError) {
-              // Backup also corrupted — give up recovery
-              debugLogger.warn(
-                `Failed to recover from backup ${backupPath}: ${getErrorMessage(backupError)}. Falling back to empty settings.`,
-              );
-            }
-          }
-
-          // Step 3: no backup available — start with empty settings
+          // Step 2: no recoverable content — start with empty settings
           if (!rawSettings) {
             const warningMsg = `Settings file ${filePath} has invalid JSON. Your settings have been reset.`;
             debugLogger.warn(warningMsg);
@@ -1260,8 +1243,6 @@ export function loadSettings(
               wasRecovered: false,
             };
           }
-          // Fall through to migration pipeline — .orig backup may be in
-          // an older schema and needs to go through runMigrations.
         }
 
         // Propagate corruption state from parent process via env vars.
@@ -1364,7 +1345,7 @@ export function loadSettings(
           persistSettingsObject('Error normalizing settings version on disk');
         }
 
-        // Attach corruption state if settings were recovered from backup
+        // Attach corruption state propagated from the parent via env vars.
         const result: ReturnType<typeof loadAndMigrate> = {
           settings: settingsObject as Settings,
           rawJson: content,
@@ -1372,8 +1353,7 @@ export function loadSettings(
         };
         if (corruptedSaved) {
           result.corruptedPath = corruptedPath;
-          result.wasRecovered =
-            recoveredFromBackup || (recoveredFromEnvVar ?? false);
+          result.wasRecovered = recoveredFromEnvVar ?? false;
         }
         return result;
       }
@@ -1401,7 +1381,8 @@ export function loadSettings(
     settings: {} as Settings,
     rawJson: undefined,
   };
-  if (realWorkspaceDir !== realHomeDir) {
+  const workspaceSettingsActive = realWorkspaceDir !== realHomeDir;
+  if (workspaceSettingsActive) {
     workspaceResult = loadAndMigrate(
       workspaceSettingsPath,
       SettingScope.Workspace,
@@ -1522,6 +1503,7 @@ export function loadSettings(
     allMigrationWarnings,
     userResult.corruptedPath,
     userResult.wasRecovered ?? false,
+    workspaceSettingsActive,
   );
 }
 

--- a/packages/cli/src/config/settingsWatcher.test.ts
+++ b/packages/cli/src/config/settingsWatcher.test.ts
@@ -1,0 +1,992 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { SettingsWatcher } from './settingsWatcher.js';
+import {
+  SettingScope,
+  type LoadedSettings,
+  type SettingsFile,
+  type Settings,
+} from './settings.js';
+import type { SettingsChangeEvent } from './settingsWatcher.js';
+
+type EventHandler = (...args: unknown[]) => void;
+
+interface MockWatcherEntry {
+  dir: string;
+  handlers: Record<string, EventHandler>;
+  instance: {
+    on: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+  };
+}
+
+const { mockWatchers, mockExistsSync, mockMkdirSync, mockWatch } = vi.hoisted(
+  () => {
+    const mockWatchers: MockWatcherEntry[] = [];
+    const mockExistsSync = vi.fn().mockReturnValue(true);
+    const mockMkdirSync = vi.fn();
+
+    const mockWatch = vi.fn().mockImplementation((dir: string) => {
+      const handlers: Record<string, EventHandler> = {};
+      const instance = {
+        on: vi
+          .fn()
+          .mockImplementation((event: string, handler: EventHandler) => {
+            handlers[event] = handler;
+            return instance;
+          }),
+        close: vi.fn().mockResolvedValue(undefined),
+      };
+      mockWatchers.push({ dir, handlers, instance });
+      return instance;
+    });
+
+    return { mockWatchers, mockExistsSync, mockMkdirSync, mockWatch };
+  },
+);
+const { mockDebugWarn } = vi.hoisted(() => ({
+  mockDebugWarn: vi.fn(),
+}));
+
+vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@qwen-code/qwen-code-core')>();
+  return {
+    ...actual,
+    createDebugLogger: () => ({
+      isEnabled: () => true,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: mockDebugWarn,
+      error: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('chokidar', () => ({
+  watch: mockWatch,
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    existsSync: mockExistsSync,
+    mkdirSync: mockMkdirSync,
+  };
+});
+
+function s(obj: Record<string, unknown>): Settings {
+  return obj as unknown as Settings;
+}
+
+function makeSettingsFile(overrides: Partial<SettingsFile> = {}): SettingsFile {
+  return {
+    settings: {},
+    originalSettings: {},
+    path: '/home/user/.qwen/settings.json',
+    rawJson: '{}',
+    ...overrides,
+  };
+}
+
+function makeLoadedSettings(
+  overrides: {
+    user?: Partial<SettingsFile>;
+    workspace?: Partial<SettingsFile>;
+    workspaceSettingsActive?: boolean;
+  } = {},
+): LoadedSettings {
+  const user = makeSettingsFile({
+    path: '/home/user/.qwen/settings.json',
+    ...overrides.user,
+  });
+  const workspace = makeSettingsFile({
+    path: '/project/.qwen/settings.json',
+    ...overrides.workspace,
+  });
+  return {
+    user,
+    workspace,
+    forScope: vi.fn((scope: SettingScope) => {
+      if (scope === SettingScope.User) return user;
+      return workspace;
+    }),
+    reloadScopeFromDisk: vi.fn(),
+    merged: {},
+    workspaceSettingsActive: overrides.workspaceSettingsActive ?? true,
+  } as unknown as LoadedSettings;
+}
+
+function fireAllEvent(
+  watcherIndex: number,
+  event: string,
+  changedPath: string,
+) {
+  const entry = mockWatchers[watcherIndex];
+  entry.handlers['all']?.(event, changedPath);
+}
+
+describe('SettingsWatcher', () => {
+  let settings: LoadedSettings;
+  let watcher: SettingsWatcher;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockWatchers.length = 0;
+    mockExistsSync.mockReturnValue(true);
+    mockMkdirSync.mockReset();
+    mockWatch.mockClear();
+    mockDebugWarn.mockClear();
+    settings = makeLoadedSettings();
+    watcher = new SettingsWatcher(settings);
+  });
+
+  afterEach(() => {
+    watcher.stopWatching();
+    vi.useRealTimers();
+  });
+
+  describe('lifecycle', () => {
+    it('should create chokidar watchers for user and workspace directories', () => {
+      watcher.startWatching();
+
+      expect(mockWatch).toHaveBeenCalledTimes(2);
+      expect(mockWatch).toHaveBeenCalledWith(
+        '/home/user/.qwen',
+        expect.objectContaining({ ignoreInitial: true, depth: 0 }),
+      );
+      expect(mockWatch).toHaveBeenCalledWith(
+        '/project/.qwen',
+        expect.objectContaining({ ignoreInitial: true, depth: 0 }),
+      );
+    });
+
+    it('should skip workspace watcher when workspace settings are inactive', () => {
+      const inactiveSettings = makeLoadedSettings({
+        workspaceSettingsActive: false,
+      });
+      const inactiveWatcher = new SettingsWatcher(inactiveSettings);
+
+      inactiveWatcher.startWatching();
+
+      expect(mockWatch).toHaveBeenCalledTimes(1);
+      expect(mockWatch).toHaveBeenCalledWith(
+        '/home/user/.qwen',
+        expect.objectContaining({ ignoreInitial: true, depth: 0 }),
+      );
+
+      inactiveWatcher.stopWatching();
+    });
+
+    it('should watch active workspace even when settings file does not exist', () => {
+      const noWorkspaceFileSettings = makeLoadedSettings({
+        workspace: { rawJson: undefined, settings: {} },
+        workspaceSettingsActive: true,
+      });
+      const noWorkspaceFileWatcher = new SettingsWatcher(
+        noWorkspaceFileSettings,
+      );
+
+      noWorkspaceFileWatcher.startWatching();
+
+      expect(mockWatch).toHaveBeenCalledTimes(2);
+      expect(mockWatch).toHaveBeenCalledWith(
+        '/project/.qwen',
+        expect.objectContaining({ ignoreInitial: true, depth: 0 }),
+      );
+
+      noWorkspaceFileWatcher.stopWatching();
+    });
+
+    it('should be idempotent on double start', () => {
+      watcher.startWatching();
+      watcher.startWatching();
+
+      expect(mockWatch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should close all watchers on stop', () => {
+      watcher.startWatching();
+      watcher.stopWatching();
+
+      expect(mockWatchers[0].instance.close).toHaveBeenCalled();
+      expect(mockWatchers[1].instance.close).toHaveBeenCalled();
+    });
+
+    it('should be idempotent on double stop', () => {
+      watcher.startWatching();
+      watcher.stopWatching();
+      watcher.stopWatching();
+
+      expect(mockWatchers[0].instance.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('should never create missing directories', () => {
+      mockExistsSync.mockReturnValue(false);
+      watcher.startWatching();
+
+      expect(mockMkdirSync).not.toHaveBeenCalled();
+    });
+
+    it('should register error handler on each watcher', () => {
+      watcher.startWatching();
+
+      expect(mockWatchers[0].instance.on).toHaveBeenCalledWith(
+        'error',
+        expect.any(Function),
+      );
+    });
+
+    it('should pass ignored filter that rejects special file types', () => {
+      watcher.startWatching();
+
+      const watchCall = mockWatch.mock.calls[0] as [
+        string,
+        {
+          ignored: (
+            p: string,
+            s?: { isFile(): boolean; isDirectory(): boolean },
+          ) => boolean;
+        },
+      ];
+      const ignoredFn = watchCall[1].ignored;
+
+      expect(
+        ignoredFn('/some/file', {
+          isFile: () => true,
+          isDirectory: () => false,
+        }),
+      ).toBe(false);
+      expect(
+        ignoredFn('/some/socket', {
+          isFile: () => false,
+          isDirectory: () => false,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe('path filtering', () => {
+    it('should trigger refresh only for settings.json basename', async () => {
+      watcher.startWatching();
+      const listener = vi.fn();
+      watcher.addChangeListener(listener);
+
+      vi.mocked(settings.reloadScopeFromDisk).mockImplementation(
+        (scope: SettingScope) => {
+          settings.forScope(scope).settings = s({ ui: { theme: 'dark' } });
+        },
+      );
+
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json');
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+
+      expect(settings.reloadScopeFromDisk).toHaveBeenCalledWith(
+        SettingScope.User,
+      );
+      expect(listener).toHaveBeenCalled();
+    });
+
+    it('should ignore .tmp files', async () => {
+      watcher.startWatching();
+      const listener = vi.fn();
+      watcher.addChangeListener(listener);
+
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json.tmp');
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+
+      expect(settings.reloadScopeFromDisk).not.toHaveBeenCalled();
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('should ignore .orig files', async () => {
+      watcher.startWatching();
+      const listener = vi.fn();
+      watcher.addChangeListener(listener);
+
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json.orig');
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+
+      expect(settings.reloadScopeFromDisk).not.toHaveBeenCalled();
+    });
+
+    it('should ignore unrelated files in the same directory', async () => {
+      watcher.startWatching();
+      const listener = vi.fn();
+      watcher.addChangeListener(listener);
+
+      fireAllEvent(0, 'change', '/home/user/.qwen/other-file.json');
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+
+      expect(settings.reloadScopeFromDisk).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('debouncing', () => {
+    it('should coalesce multiple rapid events into one reload', async () => {
+      watcher.startWatching();
+
+      vi.mocked(settings.reloadScopeFromDisk).mockImplementation(
+        (scope: SettingScope) => {
+          settings.forScope(scope).settings = s({ count: 1 });
+        },
+      );
+
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json');
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json');
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json');
+
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+
+      expect(settings.reloadScopeFromDisk).toHaveBeenCalledTimes(1);
+    });
+
+    it('should batch changes from different scopes in one debounce window', async () => {
+      watcher.startWatching();
+      const listener = vi.fn();
+      watcher.addChangeListener(listener);
+
+      vi.mocked(settings.reloadScopeFromDisk).mockImplementation(
+        (scope: SettingScope) => {
+          settings.forScope(scope).settings = s({
+            scope: scope.toString(),
+          });
+        },
+      );
+
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json');
+      fireAllEvent(1, 'change', '/project/.qwen/settings.json');
+
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+
+      expect(settings.reloadScopeFromDisk).toHaveBeenCalledTimes(2);
+      expect(listener).toHaveBeenCalledTimes(1);
+      const events: SettingsChangeEvent[] = listener.mock.calls[0][0];
+      expect(events).toHaveLength(2);
+    });
+  });
+
+  describe('semantic diff', () => {
+    it('should not notify when content is unchanged', async () => {
+      watcher.startWatching();
+      const listener = vi.fn();
+      watcher.addChangeListener(listener);
+
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json');
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+
+      expect(settings.reloadScopeFromDisk).toHaveBeenCalled();
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('should notify when content changes', async () => {
+      watcher.startWatching();
+      const listener = vi.fn();
+      watcher.addChangeListener(listener);
+
+      vi.mocked(settings.reloadScopeFromDisk).mockImplementation(
+        (scope: SettingScope) => {
+          settings.forScope(scope).settings = s({ newKey: 'newValue' });
+        },
+      );
+
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json');
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      const events: SettingsChangeEvent[] = listener.mock.calls[0][0];
+      expect(events).toHaveLength(1);
+      expect(events[0].scope).toBe(SettingScope.User);
+      expect(events[0].changeType).toBe('modified');
+    });
+
+    it('should suppress self-writes (setValue mutates memory before disk write)', async () => {
+      watcher.startWatching();
+      const listener = vi.fn();
+      watcher.addChangeListener(listener);
+
+      const userFile = settings.forScope(SettingScope.User);
+      userFile.settings = s({ theme: 'dark' });
+
+      vi.mocked(settings.reloadScopeFromDisk).mockImplementation(() => {
+        // no-op: disk matches memory
+      });
+
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json');
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('should not notify on format/comment-only changes (resolved settings identical)', async () => {
+      watcher.startWatching();
+      const listener = vi.fn();
+      watcher.addChangeListener(listener);
+
+      vi.mocked(settings.reloadScopeFromDisk).mockImplementation(() => {
+        // no-op: settings stay the same after stripping comments
+      });
+
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json');
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('self-write with concurrent external edit', () => {
+    it('should notify when external edit changes content beyond the self-write', async () => {
+      watcher.startWatching();
+      const listener = vi.fn();
+      watcher.addChangeListener(listener);
+
+      const userFile = settings.forScope(SettingScope.User);
+      userFile.settings = s({ theme: 'dark' });
+
+      vi.mocked(settings.reloadScopeFromDisk).mockImplementation(() => {
+        userFile.settings = s({ theme: 'light' });
+      });
+
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json');
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      const events: SettingsChangeEvent[] = listener.mock.calls[0][0];
+      expect(events[0].changeType).toBe('modified');
+    });
+  });
+
+  describe('restart-required suppression', () => {
+    it('should suppress when only restart-required keys change (env)', async () => {
+      watcher.startWatching();
+      const listener = vi.fn();
+      watcher.addChangeListener(listener);
+
+      const userFile = settings.forScope(SettingScope.User);
+      userFile.settings = s({ env: { FOO: 'a' } });
+
+      vi.mocked(settings.reloadScopeFromDisk).mockImplementation(() => {
+        userFile.settings = s({ env: { FOO: 'b' } });
+      });
+
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json');
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('should suppress when only credentials change (security.auth.apiKey)', async () => {
+      watcher.startWatching();
+      const listener = vi.fn();
+      watcher.addChangeListener(listener);
+
+      const userFile = settings.forScope(SettingScope.User);
+      userFile.settings = s({ security: { auth: { apiKey: 'old' } } });
+
+      vi.mocked(settings.reloadScopeFromDisk).mockImplementation(() => {
+        userFile.settings = s({ security: { auth: { apiKey: 'new' } } });
+      });
+
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json');
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('should notify when a hot-reloadable key changes (ui.theme)', async () => {
+      watcher.startWatching();
+      const listener = vi.fn();
+      watcher.addChangeListener(listener);
+
+      const userFile = settings.forScope(SettingScope.User);
+      userFile.settings = s({ ui: { theme: 'dark' } });
+
+      vi.mocked(settings.reloadScopeFromDisk).mockImplementation(() => {
+        userFile.settings = s({ ui: { theme: 'light' } });
+      });
+
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json');
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should notify when a hot-reloadable key changes alongside a restart-required one', async () => {
+      watcher.startWatching();
+      const listener = vi.fn();
+      watcher.addChangeListener(listener);
+
+      const userFile = settings.forScope(SettingScope.User);
+      userFile.settings = s({ ui: { theme: 'dark' }, env: { FOO: 'a' } });
+
+      vi.mocked(settings.reloadScopeFromDisk).mockImplementation(() => {
+        userFile.settings = s({ ui: { theme: 'light' }, env: { FOO: 'b' } });
+      });
+
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json');
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should notify on an unknown (non-schema) key change rather than silently suppress', async () => {
+      watcher.startWatching();
+      const listener = vi.fn();
+      watcher.addChangeListener(listener);
+
+      const userFile = settings.forScope(SettingScope.User);
+      userFile.settings = s({ someCustomKey: 1 });
+
+      vi.mocked(settings.reloadScopeFromDisk).mockImplementation(() => {
+        userFile.settings = s({ someCustomKey: 2 });
+      });
+
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json');
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('change type classification', () => {
+    it('should report created when file appears', async () => {
+      const noFileSettings = makeLoadedSettings({
+        user: { rawJson: undefined, settings: {} },
+      });
+      const w = new SettingsWatcher(noFileSettings);
+      w.startWatching();
+      const listener = vi.fn();
+      w.addChangeListener(listener);
+
+      vi.mocked(noFileSettings.reloadScopeFromDisk).mockImplementation(
+        (scope: SettingScope) => {
+          const file = noFileSettings.forScope(scope);
+          file.settings = s({ key: 'value' });
+          file.rawJson = '{"key":"value"}';
+        },
+      );
+
+      const userIdx = mockWatchers.length - 2;
+      fireAllEvent(userIdx, 'add', '/home/user/.qwen/settings.json');
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+
+      const events: SettingsChangeEvent[] = listener.mock.calls[0][0];
+      expect(events[0].changeType).toBe('created');
+
+      w.stopWatching();
+    });
+
+    it('should report deleted when file disappears', async () => {
+      watcher.startWatching();
+      const listener = vi.fn();
+      watcher.addChangeListener(listener);
+
+      // Seed real (hot-reloadable) content so the deletion actually removes a
+      // key — deleting an empty-content file has nothing to hot-reload.
+      const userFile = settings.forScope(SettingScope.User);
+      userFile.settings = s({ ui: { theme: 'dark' } });
+      userFile.rawJson = '{"ui":{"theme":"dark"}}';
+
+      vi.mocked(settings.reloadScopeFromDisk).mockImplementation(
+        (scope: SettingScope) => {
+          const file = settings.forScope(scope);
+          file.settings = {};
+          file.rawJson = undefined;
+        },
+      );
+
+      fireAllEvent(0, 'unlink', '/home/user/.qwen/settings.json');
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+
+      const events: SettingsChangeEvent[] = listener.mock.calls[0][0];
+      expect(events[0].changeType).toBe('deleted');
+    });
+  });
+
+  describe('listener management', () => {
+    it('should support unsubscribe', async () => {
+      watcher.startWatching();
+      const listener = vi.fn();
+      const unsub = watcher.addChangeListener(listener);
+
+      unsub();
+
+      vi.mocked(settings.reloadScopeFromDisk).mockImplementation(
+        (scope: SettingScope) => {
+          settings.forScope(scope).settings = s({ a: 1 });
+        },
+      );
+
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json');
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('should isolate listener errors', async () => {
+      watcher.startWatching();
+      const failingListener = vi.fn().mockRejectedValue(new Error('boom'));
+      const goodListener = vi.fn();
+      watcher.addChangeListener(failingListener);
+      watcher.addChangeListener(goodListener);
+
+      vi.mocked(settings.reloadScopeFromDisk).mockImplementation(
+        (scope: SettingScope) => {
+          settings.forScope(scope).settings = s({ changed: true });
+        },
+      );
+
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json');
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+
+      expect(failingListener).toHaveBeenCalled();
+      expect(goodListener).toHaveBeenCalled();
+    });
+
+    it('should enforce listener timeout', async () => {
+      watcher.startWatching();
+      const slowListener = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            setTimeout(resolve, SettingsWatcher.LISTENER_TIMEOUT_MS + 5000);
+          }),
+      );
+      watcher.addChangeListener(slowListener);
+
+      vi.mocked(settings.reloadScopeFromDisk).mockImplementation(
+        (scope: SettingScope) => {
+          settings.forScope(scope).settings = s({ slow: true });
+        },
+      );
+
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json');
+      await vi.advanceTimersByTimeAsync(
+        SettingsWatcher.DEBOUNCE_MS + SettingsWatcher.LISTENER_TIMEOUT_MS + 100,
+      );
+
+      expect(slowListener).toHaveBeenCalled();
+    });
+  });
+
+  describe('watcher creation failure', () => {
+    it('should continue with remaining scopes when chokidar throws', () => {
+      let callCount = 0;
+      mockWatch.mockImplementation((dir: string) => {
+        callCount++;
+        if (callCount === 1) {
+          throw new Error('EACCES: permission denied');
+        }
+        const handlers: Record<string, EventHandler> = {};
+        const instance = {
+          on: vi
+            .fn()
+            .mockImplementation((event: string, handler: EventHandler) => {
+              handlers[event] = handler;
+              return instance;
+            }),
+          close: vi.fn().mockResolvedValue(undefined),
+        };
+        mockWatchers.push({ dir, handlers, instance });
+        return instance;
+      });
+
+      watcher.startWatching();
+
+      expect(mockWatchers).toHaveLength(1);
+      expect(mockWatchers[0].dir).toBe('/project/.qwen');
+    });
+
+    it('should continue with bootstrap watcher when target dir is missing', () => {
+      mockExistsSync.mockReturnValue(false);
+
+      watcher.startWatching();
+
+      // No directory is ever created on the user's behalf.
+      expect(mockMkdirSync).not.toHaveBeenCalled();
+      // Both scopes bootstrap-watch their parent dirs.
+      expect(mockWatch).toHaveBeenCalledTimes(2);
+      expect(mockWatch).toHaveBeenCalledWith(
+        '/home/user',
+        expect.objectContaining({ ignoreInitial: true, depth: 0 }),
+      );
+      expect(mockWatch).toHaveBeenCalledWith(
+        '/project',
+        expect.objectContaining({ ignoreInitial: true, depth: 0 }),
+      );
+    });
+  });
+
+  describe('lazy directory watching', () => {
+    // promote/demote await chokidar's async close(); flush microtasks/timers.
+    const flush = () => vi.advanceTimersByTimeAsync(0);
+
+    function lastWatchOptions(): {
+      ignored?: (p: string, stats?: unknown) => boolean;
+    } {
+      const calls = mockWatch.mock.calls;
+      return calls[calls.length - 1][1] as {
+        ignored?: (p: string, stats?: unknown) => boolean;
+      };
+    }
+
+    it('should never create the settings directory', () => {
+      mockExistsSync.mockReturnValue(false);
+
+      watcher.startWatching();
+
+      expect(mockMkdirSync).not.toHaveBeenCalled();
+    });
+
+    it('should bootstrap-watch the parent when the dir is missing', () => {
+      const workspaceOnly = makeLoadedSettings({
+        workspaceSettingsActive: false,
+      });
+      const w = new SettingsWatcher(workspaceOnly);
+      mockExistsSync.mockReturnValue(false);
+
+      w.startWatching();
+
+      expect(mockWatch).toHaveBeenCalledTimes(1);
+      expect(mockWatch).toHaveBeenCalledWith(
+        '/home/user',
+        expect.objectContaining({ ignoreInitial: true, depth: 0 }),
+      );
+
+      w.stopWatching();
+    });
+
+    it('bootstrap ignored predicate allows only the .qwen entry', () => {
+      const workspaceOnly = makeLoadedSettings({
+        workspaceSettingsActive: false,
+        user: { path: '/home/user/.qwen/settings.json' },
+      });
+      const w = new SettingsWatcher(workspaceOnly);
+      mockExistsSync.mockReturnValue(false);
+
+      w.startWatching();
+
+      const { ignored } = lastWatchOptions();
+      expect(ignored).toBeTypeOf('function');
+      // Watch root and the target dir are allowed (not ignored).
+      expect(ignored!('/home/user')).toBe(false);
+      expect(ignored!('/home/user/.qwen')).toBe(false);
+      // Unrelated top-level entries are ignored.
+      expect(ignored!('/home/user/Documents')).toBe(true);
+      expect(ignored!('/home/user/.bashrc')).toBe(true);
+
+      w.stopWatching();
+    });
+
+    it('should promote to a target watcher when .qwen appears', async () => {
+      const workspaceOnly = makeLoadedSettings({
+        workspaceSettingsActive: false,
+      });
+      const w = new SettingsWatcher(workspaceOnly);
+      mockExistsSync.mockReturnValue(false);
+      w.startWatching();
+
+      // Bootstrap watcher on the parent.
+      expect(mockWatchers).toHaveLength(1);
+      expect(mockWatchers[0].dir).toBe('/home/user');
+
+      // `.qwen` is created.
+      fireAllEvent(0, 'addDir', '/home/user/.qwen');
+      await flush();
+
+      // Bootstrap closed, target watcher opened on `.qwen`.
+      expect(mockWatchers[0].instance.close).toHaveBeenCalled();
+      expect(mockWatchers).toHaveLength(2);
+      expect(mockWatchers[1].dir).toBe('/home/user/.qwen');
+
+      // A settings.json already inside `.qwen` is picked up via a refresh.
+      vi.mocked(workspaceOnly.reloadScopeFromDisk).mockImplementation(
+        (scope: SettingScope) => {
+          workspaceOnly.forScope(scope).settings = s({ promoted: true });
+        },
+      );
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+      expect(workspaceOnly.reloadScopeFromDisk).toHaveBeenCalledWith(
+        SettingScope.User,
+      );
+
+      w.stopWatching();
+    });
+
+    it('should promote immediately when .qwen appears during the TOCTOU window', async () => {
+      const workspaceOnly = makeLoadedSettings({
+        workspaceSettingsActive: false,
+      });
+      const w = new SettingsWatcher(workspaceOnly);
+      // Branch check: missing; TOCTOU re-check: now present.
+      mockExistsSync.mockReturnValueOnce(false).mockReturnValue(true);
+
+      w.startWatching();
+      await flush();
+
+      // Bootstrap on parent, then immediate promote to `.qwen` without an event.
+      expect(mockWatchers).toHaveLength(2);
+      expect(mockWatchers[0].dir).toBe('/home/user');
+      expect(mockWatchers[1].dir).toBe('/home/user/.qwen');
+
+      w.stopWatching();
+    });
+
+    it('should demote back to bootstrap when .qwen is removed', async () => {
+      const workspaceOnly = makeLoadedSettings({
+        workspaceSettingsActive: false,
+      });
+      const w = new SettingsWatcher(workspaceOnly);
+      // dir exists at startup -> target watcher; gone afterwards so the
+      // post-demote TOCTOU re-check does not immediately re-promote.
+      mockExistsSync.mockReturnValueOnce(true).mockReturnValue(false);
+      w.startWatching();
+
+      expect(mockWatchers).toHaveLength(1);
+      expect(mockWatchers[0].dir).toBe('/home/user/.qwen');
+
+      // `.qwen` directory itself is removed.
+      fireAllEvent(0, 'unlinkDir', '/home/user/.qwen');
+      await flush();
+
+      // Re-bootstrapped on the parent.
+      expect(mockWatchers[0].instance.close).toHaveBeenCalled();
+      expect(mockWatchers).toHaveLength(2);
+      expect(mockWatchers[1].dir).toBe('/home/user');
+
+      // A subsequent re-create promotes again.
+      fireAllEvent(1, 'addDir', '/home/user/.qwen');
+      await flush();
+      expect(mockWatchers).toHaveLength(3);
+      expect(mockWatchers[2].dir).toBe('/home/user/.qwen');
+
+      w.stopWatching();
+    });
+
+    it('should not double-promote from a stale bootstrap callback', async () => {
+      const workspaceOnly = makeLoadedSettings({
+        workspaceSettingsActive: false,
+      });
+      const w = new SettingsWatcher(workspaceOnly);
+      mockExistsSync.mockReturnValue(false);
+      w.startWatching();
+
+      // First promotion.
+      fireAllEvent(0, 'addDir', '/home/user/.qwen');
+      await flush();
+      expect(mockWatchers).toHaveLength(2);
+
+      // A stale event from the already-closed bootstrap watcher must be ignored
+      // by the generation guard — no second target watcher is created.
+      fireAllEvent(0, 'addDir', '/home/user/.qwen');
+      await flush();
+      expect(mockWatchers).toHaveLength(2);
+      const targetWatchers = mockWatchers.filter(
+        (m) => m.dir === '/home/user/.qwen',
+      );
+      expect(targetWatchers).toHaveLength(1);
+
+      w.stopWatching();
+    });
+  });
+
+  describe('reloadScopeFromDisk failure', () => {
+    it('should not notify when reload preserves old state (internal catch)', async () => {
+      watcher.startWatching();
+      const listener = vi.fn();
+      watcher.addChangeListener(listener);
+
+      vi.mocked(settings.reloadScopeFromDisk).mockImplementation(() => {
+        // reloadScopeFromDisk catches internally, settings unchanged
+      });
+
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json');
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('should log rejected refreshes', async () => {
+      watcher.startWatching();
+      const error = new Error('reload failed');
+      vi.mocked(settings.reloadScopeFromDisk).mockImplementation(() => {
+        throw error;
+      });
+
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json');
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+
+      expect(mockDebugWarn).toHaveBeenCalledWith(
+        'Settings watcher refresh error:',
+        error,
+      );
+    });
+  });
+
+  describe('stopWatching clears pending state', () => {
+    it('should cancel pending debounce timer on stop', async () => {
+      watcher.startWatching();
+      const listener = vi.fn();
+      watcher.addChangeListener(listener);
+
+      vi.mocked(settings.reloadScopeFromDisk).mockImplementation(
+        (scope: SettingScope) => {
+          settings.forScope(scope).settings = s({ pending: true });
+        },
+      );
+
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json');
+
+      watcher.stopWatching();
+
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 100);
+
+      expect(settings.reloadScopeFromDisk).not.toHaveBeenCalled();
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('path resolution', () => {
+    it('should use resolved paths from LoadedSettings (supports QWEN_HOME redirect)', () => {
+      const customSettings = makeLoadedSettings({
+        user: { path: '/custom/qwen-home/settings.json' },
+      });
+      const w = new SettingsWatcher(customSettings);
+      w.startWatching();
+
+      expect(mockWatch).toHaveBeenCalledWith(
+        '/custom/qwen-home',
+        expect.any(Object),
+      );
+
+      w.stopWatching();
+    });
+  });
+
+  describe('serialization', () => {
+    it('should not overlap handleChange runs', async () => {
+      watcher.startWatching();
+      let callCount = 0;
+
+      vi.mocked(settings.reloadScopeFromDisk).mockImplementation(
+        (scope: SettingScope) => {
+          callCount++;
+          settings.forScope(scope).settings = s({ call: callCount });
+        },
+      );
+
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json');
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+
+      fireAllEvent(0, 'change', '/home/user/.qwen/settings.json');
+      await vi.advanceTimersByTimeAsync(SettingsWatcher.DEBOUNCE_MS + 10);
+
+      expect(settings.reloadScopeFromDisk).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/cli/src/config/settingsWatcher.ts
+++ b/packages/cli/src/config/settingsWatcher.ts
@@ -1,0 +1,460 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { watch as watchFs, type FSWatcher } from 'chokidar';
+import { createDebugLogger } from '@qwen-code/qwen-code-core';
+import { type LoadedSettings, SettingScope } from './settings.js';
+import { getFlattenedSchema } from '../utils/settingsUtils.js';
+
+const debugLogger = createDebugLogger('SETTINGS_WATCHER');
+
+/**
+ * Collects the dot-path of every leaf whose value differs between two settings
+ * snapshots. Plain objects are recursed into; arrays and primitives are compared
+ * whole (via `JSON.stringify`), matching the granularity of schema array keys
+ * such as `permissions.allow`. Added/removed keys surface as changed leaves too,
+ * so this also covers file creation/deletion.
+ */
+function collectChangedKeys(
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+  prefix = '',
+): string[] {
+  const changed: string[] = [];
+  const keys = new Set([...Object.keys(before), ...Object.keys(after)]);
+  for (const key of keys) {
+    const keyPath = prefix ? `${prefix}.${key}` : key;
+    const beforeValue = before[key];
+    const afterValue = after[key];
+    if (isPlainObject(beforeValue) && isPlainObject(afterValue)) {
+      changed.push(...collectChangedKeys(beforeValue, afterValue, keyPath));
+    } else if (JSON.stringify(beforeValue) !== JSON.stringify(afterValue)) {
+      changed.push(keyPath);
+    }
+  }
+  return changed;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Resolves whether a changed dot-path maps to a restart-required setting, using
+ * the longest schema key that is a prefix of (or equal to) the path. Free-form
+ * object settings (e.g. `env`, `modelProviders`) are leaf schema keys, so a
+ * change to `env.FOO` resolves to the `env` definition. Unknown keys default to
+ * NOT restart-required, so a change we cannot classify is never silently
+ * suppressed.
+ */
+function isRestartRequiredKey(changedPath: string): boolean {
+  const flattened = getFlattenedSchema();
+  const parts = changedPath.split('.');
+  for (let i = parts.length; i > 0; i--) {
+    const candidate = parts.slice(0, i).join('.');
+    const definition = flattened[candidate];
+    if (definition) return definition.requiresRestart === true;
+  }
+  return false;
+}
+
+export interface SettingsChangeEvent {
+  scope: SettingScope;
+  path: string;
+  changeType: 'modified' | 'created' | 'deleted';
+}
+
+export type SettingsChangeListener = (
+  events: SettingsChangeEvent[],
+) => void | Promise<void>;
+
+/**
+ * Watches user and workspace settings.json files for changes and emits
+ * change events when the resolved settings content differs from the
+ * in-memory state.
+ *
+ * Uses chokidar to monitor the `.qwen` directory (depth: 0) with strict
+ * basename filtering. Self-writes from `LoadedSettings.setValue()` are
+ * naturally suppressed via a before/after semantic diff — `setValue()`
+ * mutates memory before writing disk, so `reloadScopeFromDisk()` produces
+ * no diff.
+ *
+ * Restart-required settings are filtered out before notifying: if every
+ * changed key is `requiresRestart` in the schema (credentials, `env`,
+ * providers, MCP servers, …), no event is emitted, since such values are read
+ * once at startup and cannot take effect without a restart.
+ *
+ * The watcher never creates `.qwen` itself. When the directory is missing at
+ * startup it bootstrap-watches the parent (depth: 0, `.qwen`-only filter) and
+ * promotes to watching `.qwen` once it appears — so a `settings.json` added
+ * later in the session is still detected without recursing the project tree.
+ */
+export class SettingsWatcher {
+  private readonly settings: LoadedSettings;
+  private readonly watchers: Map<SettingScope, FSWatcher> = new Map();
+  /**
+   * Per-scope watch stage. `bootstrap` watches the parent directory waiting
+   * for the missing `.qwen` dir to appear; `target` watches `.qwen` itself.
+   */
+  private readonly watchStage: Map<SettingScope, 'bootstrap' | 'target'> =
+    new Map();
+  /**
+   * Per-scope generation token. Bumped on every promote/demote so that a
+   * stale `'all'` callback from a watcher being torn down (chokidar `close()`
+   * is async) becomes a no-op instead of stacking watchers.
+   */
+  private readonly watchGeneration: Map<SettingScope, number> = new Map();
+  private readonly changeListeners: Set<SettingsChangeListener> = new Set();
+  private refreshTimer: NodeJS.Timeout | null = null;
+  private readonly pendingScopeChanges: Set<SettingScope> = new Set();
+  private processing: boolean = false;
+  private started: boolean = false;
+
+  static readonly DEBOUNCE_MS = 300;
+  static readonly LISTENER_TIMEOUT_MS = 30_000;
+
+  constructor(settings: LoadedSettings) {
+    this.settings = settings;
+  }
+
+  startWatching(): void {
+    if (this.started) return;
+    this.started = true;
+
+    for (const { scope, settingsPath } of this.getScopePaths()) {
+      if (!settingsPath) continue;
+      const dir = path.dirname(settingsPath);
+
+      // Watch `.qwen` directly when it already exists; otherwise bootstrap on
+      // the parent and promote once `.qwen` appears. We never create the
+      // directory ourselves — settings persistence (`saveSettings`) does that
+      // when the user actually writes settings.
+      if (fs.existsSync(dir)) {
+        this.watchTargetDir(scope, settingsPath);
+      } else {
+        this.watchParentForDir(scope, settingsPath);
+      }
+    }
+  }
+
+  /**
+   * Watches the resolved `.qwen` directory for changes to `settings.json`.
+   * If `.qwen` itself is removed, demotes back to a parent bootstrap watcher
+   * so a later re-creation is still caught.
+   */
+  private watchTargetDir(scope: SettingScope, settingsPath: string): void {
+    const dir = path.dirname(settingsPath);
+    const targetBasename = path.basename(settingsPath);
+    const gen = this.bumpGeneration(scope);
+
+    try {
+      const watcher = watchFs(dir, {
+        ignoreInitial: true,
+        depth: 0,
+        ignored: (filePath: string, stats?: fs.Stats) => {
+          if (stats && !stats.isFile() && !stats.isDirectory()) return true;
+          return false;
+        },
+      })
+        .on('all', (event: string, changedPath: string) => {
+          if (this.watchGeneration.get(scope) !== gen) return;
+          // The `.qwen` directory itself was removed — demote so we can catch
+          // a later re-create instead of holding a stale watcher.
+          if (event === 'unlinkDir' && changedPath === dir) {
+            void this.demoteScope(scope, settingsPath);
+            return;
+          }
+          if (path.basename(changedPath) !== targetBasename) return;
+          this.scheduleRefresh(scope);
+        })
+        .on('error', (error: unknown) => {
+          debugLogger.warn(`Settings watcher error for ${dir}:`, error);
+        });
+
+      this.watchers.set(scope, watcher);
+      this.watchStage.set(scope, 'target');
+    } catch (error) {
+      debugLogger.warn(
+        `Failed to start settings watcher for ${scope} (${dir}):`,
+        error,
+      );
+    }
+  }
+
+  /**
+   * Bootstrap watcher: monitors the parent directory (depth 0) with a strict
+   * predicate that only allows the `.qwen` entry through, so unrelated
+   * top-level churn is suppressed and the project tree is never recursed.
+   * Promotes to a target watcher once `.qwen` appears.
+   */
+  private watchParentForDir(scope: SettingScope, settingsPath: string): void {
+    const dir = path.dirname(settingsPath);
+    const parentDir = path.dirname(dir);
+    const dirBasename = path.basename(dir);
+    const gen = this.bumpGeneration(scope);
+
+    try {
+      const watcher = watchFs(parentDir, {
+        ignoreInitial: true,
+        depth: 0,
+        ignored: (filePath: string) =>
+          filePath !== parentDir && path.basename(filePath) !== dirBasename,
+      })
+        .on('all', (_event: string, changedPath: string) => {
+          if (this.watchGeneration.get(scope) !== gen) return;
+          if (path.basename(changedPath) !== dirBasename) return;
+          void this.promoteScope(scope, settingsPath);
+        })
+        .on('error', (error: unknown) => {
+          debugLogger.warn(
+            `Settings bootstrap watcher error for ${parentDir}:`,
+            error,
+          );
+        });
+
+      this.watchers.set(scope, watcher);
+      this.watchStage.set(scope, 'bootstrap');
+    } catch (error) {
+      debugLogger.warn(
+        `Failed to start settings bootstrap watcher for ${scope} (${parentDir}):`,
+        error,
+      );
+      return;
+    }
+
+    // Close the TOCTOU gap: `.qwen` may have been created between the
+    // existence check and the watcher arming (bootstrap uses ignoreInitial).
+    if (fs.existsSync(dir)) {
+      void this.promoteScope(scope, settingsPath);
+    }
+  }
+
+  /** Swaps a scope's bootstrap watcher for a target watcher on `.qwen`. */
+  private async promoteScope(
+    scope: SettingScope,
+    settingsPath: string,
+  ): Promise<void> {
+    if (this.watchStage.get(scope) !== 'bootstrap') return;
+    await this.replaceWatcher(scope);
+    if (!this.started) return;
+    this.watchTargetDir(scope, settingsPath);
+    // Pick up a settings.json that already exists inside the new `.qwen`.
+    this.scheduleRefresh(scope);
+  }
+
+  /** Swaps a scope's target watcher back to a parent bootstrap watcher. */
+  private async demoteScope(
+    scope: SettingScope,
+    settingsPath: string,
+  ): Promise<void> {
+    if (this.watchStage.get(scope) !== 'target') return;
+    await this.replaceWatcher(scope);
+    if (!this.started) return;
+    this.watchParentForDir(scope, settingsPath);
+    // Surface the deletion (rawJson goes undefined) to listeners.
+    this.scheduleRefresh(scope);
+  }
+
+  /**
+   * Bumps the scope generation and closes its current watcher, clearing the
+   * map entries before the caller opens the next watcher. Bumping first makes
+   * any in-flight callback from the closing watcher a no-op.
+   */
+  private async replaceWatcher(scope: SettingScope): Promise<void> {
+    this.bumpGeneration(scope);
+    const watcher = this.watchers.get(scope);
+    this.watchers.delete(scope);
+    this.watchStage.delete(scope);
+    if (watcher) {
+      try {
+        await watcher.close();
+      } catch (err) {
+        debugLogger.warn('Settings watcher close error:', err);
+      }
+    }
+  }
+
+  private bumpGeneration(scope: SettingScope): number {
+    const next = (this.watchGeneration.get(scope) ?? 0) + 1;
+    this.watchGeneration.set(scope, next);
+    return next;
+  }
+
+  stopWatching(): void {
+    if (!this.started) return;
+    this.started = false;
+    for (const [, watcher] of this.watchers) {
+      watcher.close().catch((err) => {
+        debugLogger.warn('Settings watcher close error:', err);
+      });
+    }
+    this.watchers.clear();
+    this.watchStage.clear();
+    // Bump every scope so any in-flight promote/demote becomes a no-op.
+    for (const scope of this.watchGeneration.keys()) {
+      this.bumpGeneration(scope);
+    }
+    if (this.refreshTimer) {
+      clearTimeout(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+    this.pendingScopeChanges.clear();
+  }
+
+  addChangeListener(listener: SettingsChangeListener): () => void {
+    this.changeListeners.add(listener);
+    return () => {
+      this.changeListeners.delete(listener);
+    };
+  }
+
+  private getScopePaths(): Array<{
+    scope: SettingScope;
+    settingsPath: string;
+  }> {
+    const paths: Array<{
+      scope: SettingScope;
+      settingsPath: string;
+    }> = [
+      {
+        scope: SettingScope.User,
+        settingsPath: this.settings.user.path,
+      },
+    ];
+
+    if (this.settings.workspaceSettingsActive) {
+      paths.push({
+        scope: SettingScope.Workspace,
+        settingsPath: this.settings.workspace.path,
+      });
+    }
+
+    return paths;
+  }
+
+  private scheduleRefresh(scope: SettingScope): void {
+    this.pendingScopeChanges.add(scope);
+    if (this.refreshTimer) clearTimeout(this.refreshTimer);
+    this.refreshTimer = setTimeout(() => {
+      this.refreshTimer = null;
+      void this.drainPendingChanges().catch((err) => {
+        debugLogger.warn('Settings watcher refresh error:', err);
+      });
+    }, SettingsWatcher.DEBOUNCE_MS);
+  }
+
+  private async drainPendingChanges(): Promise<void> {
+    if (this.processing) return;
+    this.processing = true;
+    try {
+      while (this.pendingScopeChanges.size > 0) {
+        const scopes = new Set(this.pendingScopeChanges);
+        this.pendingScopeChanges.clear();
+        await this.handleChange(scopes);
+      }
+    } finally {
+      this.processing = false;
+    }
+  }
+
+  private async handleChange(changedScopes: Set<SettingScope>): Promise<void> {
+    const events: SettingsChangeEvent[] = [];
+
+    for (const scope of changedScopes) {
+      const file = this.settings.forScope(scope);
+
+      // Snapshot the in-memory state before reload (already includes any
+      // setValue() self-write, so self-writes diff to nothing below).
+      const before = structuredClone(file.settings ?? {}) as Record<
+        string,
+        unknown
+      >;
+      const existedBefore = file.rawJson !== undefined;
+
+      this.settings.reloadScopeFromDisk(scope);
+
+      const after = (file.settings ?? {}) as Record<string, unknown>;
+      const existsNow = file.rawJson !== undefined;
+
+      // Which leaf keys actually changed. Empty => self-write, no-op, or a
+      // parse failure that preserved the old state — nothing to notify.
+      const changedKeys = collectChangedKeys(before, after);
+      if (changedKeys.length === 0) {
+        continue;
+      }
+
+      // Suppress hot-reload when every changed key is restart-required (e.g.
+      // credentials, `env`, providers, MCP servers). These are read once at
+      // startup, so emitting an event would mislead listeners into "refreshing"
+      // a value that cannot actually take effect without a restart. We reuse the
+      // schema's `requiresRestart` flag as the single source of truth — notify
+      // only when at least one changed key is genuinely hot-reloadable.
+      const hasHotReloadableChange = changedKeys.some(
+        (key) => !isRestartRequiredKey(key),
+      );
+      if (!hasHotReloadableChange) {
+        continue;
+      }
+
+      events.push({
+        scope,
+        path: file.path,
+        changeType:
+          !existedBefore && existsNow
+            ? 'created'
+            : existedBefore && !existsNow
+              ? 'deleted'
+              : 'modified',
+      });
+    }
+
+    if (events.length > 0) {
+      await this.notifyListeners(events);
+    }
+  }
+
+  private async notifyListeners(events: SettingsChangeEvent[]): Promise<void> {
+    const TIMEOUT_MS = SettingsWatcher.LISTENER_TIMEOUT_MS;
+    const withTimeout = (p: Promise<unknown>): Promise<unknown> => {
+      let timerId: ReturnType<typeof setTimeout> | undefined;
+      const timeoutPromise = new Promise((_, reject) => {
+        timerId = setTimeout(
+          () =>
+            reject(
+              new Error(
+                `settings change listener timeout after ${TIMEOUT_MS}ms`,
+              ),
+            ),
+          TIMEOUT_MS,
+        );
+        if (
+          typeof timerId === 'object' &&
+          timerId !== null &&
+          'unref' in timerId
+        ) {
+          (timerId as { unref: () => void }).unref();
+        }
+      });
+      return Promise.race([p, timeoutPromise]).finally(() => {
+        if (timerId !== undefined) clearTimeout(timerId);
+      });
+    };
+
+    const results = await Promise.allSettled(
+      Array.from(this.changeListeners).map((listener) =>
+        withTimeout(Promise.resolve().then(() => listener(events))),
+      ),
+    );
+
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        debugLogger.warn('Settings change listener error:', result.reason);
+      }
+    }
+  }
+}

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -116,6 +116,20 @@ vi.mock('./commands/extensions/list.js', () => ({
   handleList: mockHandleListExtensions,
 }));
 
+// Stub the settings watcher: main() constructs one and calls startWatching()
+// in non-bare mode. The real implementation reads settings.user/.workspace
+// paths and arms chokidar file watchers, neither of which these main()-flow
+// tests supply or want as a side effect.
+vi.mock('./config/settingsWatcher.js', () => ({
+  SettingsWatcher: class {
+    startWatching() {}
+    stopWatching() {}
+    addChangeListener() {
+      return () => {};
+    }
+  },
+}));
+
 describe('gemini.tsx main function', () => {
   let originalEnvGeminiSandbox: string | undefined;
   let originalEnvSandbox: string | undefined;
@@ -362,6 +376,9 @@ describe('gemini.tsx main function', () => {
         projectHooks: undefined,
       },
       expect.any(Function),
+      undefined,
+      // settingsWatcher: not started in bare mode
+      undefined,
     );
   });
 

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -42,6 +42,7 @@ import {
   loadSettings,
   preResolveHomeEnvOverrides,
 } from './config/settings.js';
+import { SettingsWatcher } from './config/settingsWatcher.js';
 import {
   initializeApp,
   type InitializationResult,
@@ -777,6 +778,12 @@ export async function main() {
   }
 
   {
+    // Start settings file watcher (skip in bare mode)
+    const settingsWatcher = isBareMode(argv.bare)
+      ? undefined
+      : new SettingsWatcher(settings);
+    settingsWatcher?.startWatching();
+
     const config = await loadCliConfig(
       settings.merged,
       argv,
@@ -788,6 +795,8 @@ export async function main() {
         projectHooks: settings.getProjectHooks(),
       },
       buildDisabledSkillNamesProvider(settings),
+      undefined,
+      settingsWatcher,
     );
     profileCheckpoint('after_load_cli_config');
 

--- a/packages/cli/src/utils/writeWithBackup.test.ts
+++ b/packages/cli/src/utils/writeWithBackup.test.ts
@@ -37,7 +37,7 @@ describe('writeWithBackup', () => {
       expect(fs.readFileSync(targetPath, 'utf-8')).toBe(content);
     });
 
-    it('should backup existing file before writing', () => {
+    it('should not leave a backup file behind after a successful overwrite', () => {
       const targetPath = path.join(tempDir, 'test-file.txt');
       const originalContent = 'Original content';
       const newContent = 'New content';
@@ -45,21 +45,33 @@ describe('writeWithBackup', () => {
       fs.writeFileSync(targetPath, originalContent);
       writeWithBackupSync(targetPath, newContent);
 
+      // Target has the new content; the .orig safety net is cleaned up on
+      // success so it does not pollute the directory.
       expect(fs.readFileSync(targetPath, 'utf-8')).toBe(newContent);
-      expect(fs.existsSync(`${targetPath}.orig`)).toBe(true);
-      expect(fs.readFileSync(`${targetPath}.orig`, 'utf-8')).toBe(
-        originalContent,
-      );
+      expect(fs.existsSync(`${targetPath}.orig`)).toBe(false);
     });
 
-    it('should use custom backup suffix', () => {
+    it('should not accumulate backups across repeated writes', () => {
       const targetPath = path.join(tempDir, 'test-file.txt');
-      const originalContent = 'Original';
 
-      fs.writeFileSync(targetPath, originalContent);
+      fs.writeFileSync(targetPath, 'v0');
+      writeWithBackupSync(targetPath, 'v1');
+      writeWithBackupSync(targetPath, 'v2');
+      writeWithBackupSync(targetPath, 'v3');
+
+      expect(fs.readFileSync(targetPath, 'utf-8')).toBe('v3');
+      // Only the target remains in the directory.
+      expect(fs.readdirSync(tempDir)).toEqual(['test-file.txt']);
+    });
+
+    it('should clean up the backup honoring a custom suffix', () => {
+      const targetPath = path.join(tempDir, 'test-file.txt');
+
+      fs.writeFileSync(targetPath, 'Original');
       writeWithBackupSync(targetPath, 'New', { backupSuffix: '.bak' });
 
-      expect(fs.existsSync(`${targetPath}.bak`)).toBe(true);
+      expect(fs.readFileSync(targetPath, 'utf-8')).toBe('New');
+      expect(fs.existsSync(`${targetPath}.bak`)).toBe(false);
       expect(fs.existsSync(`${targetPath}.orig`)).toBe(false);
     });
 
@@ -97,31 +109,18 @@ describe('writeWithBackup', () => {
       fs.rmdirSync(tempPath);
     });
 
-    it('should restore original file from backup when rename fails', () => {
+    it('should remove the backup once the target is updated', () => {
       const targetPath = path.join(tempDir, 'test-file.txt');
       const backupPath = `${targetPath}.orig`;
       const originalContent = 'Original content';
       const newContent = 'New content';
 
-      // Create original file
       fs.writeFileSync(targetPath, originalContent);
-
-      // Write new content successfully first
       writeWithBackupSync(targetPath, newContent);
 
-      // Verify backup exists with original content
-      expect(fs.existsSync(backupPath)).toBe(true);
-      expect(fs.readFileSync(backupPath, 'utf-8')).toBe(originalContent);
-
-      // Verify target has new content
+      // The backup was only an in-flight safety net; it is gone on success.
+      expect(fs.existsSync(backupPath)).toBe(false);
       expect(fs.readFileSync(targetPath, 'utf-8')).toBe(newContent);
-
-      // Now simulate a failure scenario: delete target and try to restore from backup
-      fs.unlinkSync(targetPath);
-
-      // Restore from backup manually to verify backup integrity
-      fs.copyFileSync(backupPath, targetPath);
-      expect(fs.readFileSync(targetPath, 'utf-8')).toBe(originalContent);
     });
 
     it('should include recovery information in error message', () => {
@@ -205,7 +204,7 @@ describe('writeWithBackup', () => {
       expect(fs.readFileSync(targetPath, 'utf-8')).toBe(content);
     });
 
-    it('should backup existing file before writing', async () => {
+    it('should overwrite without leaving a backup behind', async () => {
       const targetPath = path.join(tempDir, 'test-file.txt');
       const originalContent = 'Original content';
       const newContent = 'New content';
@@ -214,10 +213,7 @@ describe('writeWithBackup', () => {
       await writeWithBackup(targetPath, newContent);
 
       expect(fs.readFileSync(targetPath, 'utf-8')).toBe(newContent);
-      expect(fs.existsSync(`${targetPath}.orig`)).toBe(true);
-      expect(fs.readFileSync(`${targetPath}.orig`, 'utf-8')).toBe(
-        originalContent,
-      );
+      expect(fs.existsSync(`${targetPath}.orig`)).toBe(false);
     });
 
     it('should use custom encoding', async () => {

--- a/packages/cli/src/utils/writeWithBackup.ts
+++ b/packages/cli/src/utils/writeWithBackup.ts
@@ -25,10 +25,13 @@ export interface WriteWithBackupOptions {
  * 3. Renaming the temporary file to the target path
  *
  * If any step fails, an error is thrown and no partial changes are left on disk.
- * The backup file (if created) can be used for manual recovery.
+ * The backup acts as an in-flight safety net: if the final rename fails the
+ * original is restored from it. On success the backup is removed so it does not
+ * linger next to the target file (which would pollute the user's project).
  *
- * Note: This is not 100% atomic but provides good protection. In the worst case,
- * a .orig backup file remains that can be manually restored.
+ * Note: This is not 100% atomic but provides good protection. In the worst case
+ * (a crash between the backup rename and the final rename), a .orig file remains
+ * holding the last good content and can be manually restored.
  *
  * @param targetPath - The path to write to
  * @param content - The content to write
@@ -38,7 +41,7 @@ export interface WriteWithBackupOptions {
  * @example
  * ```typescript
  * await writeWithBackup('/path/to/settings.json', JSON.stringify(settings, null, 2));
- * // If /path/to/settings.json existed, it's now backed up to /path/to/settings.json.orig
+ * // On success only /path/to/settings.json exists; the .orig backup is cleaned up.
  * ```
  */
 export async function writeWithBackup(
@@ -66,6 +69,7 @@ export function writeWithBackupSync(
   const { backupSuffix = '.orig', encoding = 'utf-8' } = options;
   const tempPath = `${targetPath}.tmp`;
   const backupPath = `${targetPath}${backupSuffix}`;
+  let backupCreated = false;
 
   // Clean up any existing temp file from previous failed attempts
   try {
@@ -98,6 +102,7 @@ export function writeWithBackupSync(
 
       try {
         fs.renameSync(targetPath, backupPath);
+        backupCreated = true;
       } catch (backupError) {
         // Clean up temp file before throwing
         try {
@@ -114,6 +119,16 @@ export function writeWithBackupSync(
     // Step 3: Rename temp file to target
     try {
       fs.renameSync(tempPath, targetPath);
+
+      // Step 4: Write succeeded — the backup was only an in-flight safety net,
+      // so remove it instead of leaving a .orig file behind in the user's dir.
+      if (backupCreated) {
+        try {
+          fs.unlinkSync(backupPath);
+        } catch (_e) {
+          // Best-effort cleanup; a stray backup is harmless and non-fatal.
+        }
+      }
     } catch (renameError) {
       let restoreFailedMessage: string | undefined;
       let backupExisted = false;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -965,6 +965,8 @@ export interface ConfigParameters {
     ruleType: 'allow' | 'ask' | 'deny',
     rule: string,
   ) => Promise<void>;
+  /** Lifecycle handle for an external settings file watcher. Stopped during shutdown. */
+  settingsWatcher?: { stopWatching(): void };
 }
 
 function normalizeConfigOutputFormat(
@@ -1325,6 +1327,7 @@ export class Config {
   private messageBus?: MessageBus;
   private readonly memoryManager: MemoryManager;
   private readonly modelChangeListeners = new Set<(model: string) => void>();
+  private readonly settingsWatcher?: { stopWatching(): void };
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId ?? randomUUID();
@@ -1569,6 +1572,7 @@ export class Config {
     this.projectHooks = params.projectHooks;
     // Legacy: fall back to merged hooks if new fields are not provided
     this.hooks = params.hooks;
+    this.settingsWatcher = params.settingsWatcher;
     this.memoryManager = new MemoryManager();
   }
 
@@ -2954,6 +2958,10 @@ export class Config {
    */
   async shutdown(): Promise<void> {
     try {
+      // Stop the settings watcher regardless of initialization state —
+      // it is started before Config.initialize() and would leak otherwise.
+      this.settingsWatcher?.stopWatching();
+
       if (!this.initialized) {
         // Nothing else to clean up if not initialized.
         return;


### PR DESCRIPTION
… (#3696)

<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

<!-- What this PR does. Describe the change in prose, not by file or function names. -->

 Adds a SettingsWatcher class that monitors user-level (`~/.qwen/settings.json`) and workspace-level
  (`<project>/.qwen/settings.json`) settings files for changes at runtime. When a file is modified externally (e.g.
  by an editor), the watcher reloads the affected scope via LoadedSettings.reloadScopeFromDisk(), performs a
  before/after semantic diff using JSON.stringify, and notifies registered listeners only when the resolved
  settings content actually changed. This is the foundational building block (sub-task 1 of 6) for the
  comprehensive hot-reload system tracked in #3696.

  The watcher uses chokidar to monitor the parent directories of each settings file (depth: 0) with strict
  basename filtering, so .tmp, .orig, and editor temp files are ignored. Self-writes from
  LoadedSettings.setValue() are naturally suppressed — setValue() mutates memory before writing to disk, so the
  subsequent reload produces an identical snapshot and no notification fires.

  The core package receives only a minimal lifecycle interface (`{ stopWatching(): void }`) via ConfigParameters,
  keeping the CLI/core boundary clean. Config.shutdown() stops the watcher before the initialized check to prevent
  leaks on initialization failure.

## Why it's needed

<!-- Why it's needed: the motivation, the problem being solved, or the user-facing benefit. -->

  Currently, editing settings.json to add/remove an MCP server, change permissions, or toggle a feature requires a
  full session restart — discarding all conversation context. This change enables downstream sub-tasks (#3696
  sub-tasks 2–6) to subscribe to settings change events and refresh their state at runtime (e.g. MCP server
  reconnection, skill cache invalidation, /reload command).

  Note: this sub-task only emits change events and updates LoadedSettings.merged. Config fields that are copied at
  construction time (e.g. mcpServers, approvalMode) are not automatically refreshed — that is the responsibility
  of later sub-tasks.
  
## Reviewer Test Plan

<!--
How a reviewer can confirm this PR: reproduction steps, expected vs observed behavior, and evidence. CI runs on macOS, Windows, and Linux — Tested on is what you verified locally.

User-visible / TUI: Before/After with tmux-real-user-testing skill, screenshots, or a short recording.
Non–user-visible (refactor, types, docs): commands and output below; write N/A under Before/After.
-->

### How to verify

<!-- How you reproduced it and what a reviewer should confirm — steps if needed, expected vs observed behavior. Focus on outcomes; paste logs or test output when helpful. -->


  1. Unit tests (29 cases): `cd packages/cli && npx vitest run src/config/settingsWatcher.test.ts` — covers
  lifecycle, path filtering, debouncing, semantic diff, self-write suppression, change type classification,
  listener error isolation/timeout, watcher creation failure, missing directories, and serialization.
  2. Regression: `cd packages/cli && npx vitest run src/config/` — all 632 config tests pass. `cd packages/core &&
  npx vitest run src/config/`— all 255 tests pass.
  3. Type check: `cd packages/cli && npx tsc --noEmit` — clean.
  4. Manual: run a session with DEBUG=SETTINGS_WATCHER, edit `~/.qwen/settings.json` in another terminal, observe
  debug log output showing the change event.

### Evidence (Before & After)

<!-- User-visible / TUI changes: paste before-and-after screenshots, tmux logs, or video side by side. Non-UI changes (docs, refactor, types): N/A -->


https://github.com/user-attachments/assets/f1461237-64ca-49c2-a325-2c5cf4a1b797



### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅     |
| 🪟 Windows |    ⚠️     |
|  🐧 Linux  |    ⚠️     |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

<!-- Local runtime: e.g. npm run dev, Docker/Podman sandbox, seatbelt. N/A if only unit tests. -->
 npm run dev + vitest
 
## Risk & Scope

  - Main risk or tradeoff: JSON.stringify is sensitive to key ordering — if a user manually reorders keys without
  changing values, one harmless extra notification fires. Acceptable; no deep-equal dependency needed.
  - Not validated / out of scope: actual runtime refresh of MCP servers, skills, or Config snapshot fields — those
  are sub-tasks 2–6. System-level settings (/Library/Application Support/QwenCode/settings.json) are not watched
  (admin-controlled, rarely changed).
  - Breaking changes / migration notes: none. Purely additive: new settingsWatcher field in ConfigParameters is
  optional.

## Linked Issues

<!--
Closes #N / Fixes #N / Resolves #N to auto-close.
Otherwise reference without a closing keyword.
-->

 Progress on #3696 (sub-task 1 of 6: Settings file change detection).

<details>
<summary>中文说明</summary>

<!--
完整翻译上面的英文正文，逐段对应，不要省略或缩写。PR 标题保持英文。
-->
### 本 PR 做了什么

  新增 SettingsWatcher
  类，在运行时监控用户级（`~/.qwen/settings.json`）和项目级（`<project>/.qwen/settings.json`）settings
  文件的变更。当文件被外部编辑器修改时，watcher 通过 `LoadedSettings.reloadScopeFromDisk()` 重新加载受影响的
  scope，使用 `JSON.stringify` 进行前后语义 diff，仅在 resolved settings 内容确实发生变化时通知已注册的监听器。这是
  #3696 热更新系统的基础设施层（6 个子任务中的第 1 个）。

  Watcher 使用 chokidar 监听每个 settings 文件的父目录（depth: 0），通过严格的 basename 过滤，忽略 .tmp、.orig
  及编辑器临时文件。setValue() 产生的自写事件被自然抑制——setValue() 在写入磁盘前已同步更新内存，因此后续 reload
  产生相同的快照，不会触发通知。

  Core 包仅接收一个极简生命周期接口（`{ stopWatching(): void }`），通过 ConfigParameters 传入，保持 CLI/core
  边界清晰。Config.shutdown() 在 initialized 检查之前停止 watcher，防止初始化失败时泄露。

  ## 为什么需要

  目前修改 settings.json（添加/删除 MCP
  server、更改权限、切换功能开关等）需要完全重启会话，所有对话上下文丢失。本改动使后续子任务（#3696 子任务
  2-6）能够订阅 settings 变更事件，在运行时刷新状态（如 MCP server 重连、skill 缓存失效、/reload 命令）。

  注意：本子任务仅负责发出变更事件并更新 `LoadedSettings.merged`。Config 构造时复制的字段（如
  mcpServers、approvalMode）不会被自动刷新——这是后续子任务的职责。
</details>

