### PR TITLE
fix(core): parse comma-separated tools/disallowedTools in agent frontmatter

### DIFF
--- a/packages/core/src/subagents/subagent-manager.test.ts
+++ b/packages/core/src/subagents/subagent-manager.test.ts
@@ -126,15 +126,18 @@ describe('SubagentManager', () => {
     mockParseYaml.mockImplementation((yamlString: string) => {
       // Handle different test cases based on YAML content
       // Check disallowedTools before tools to avoid substring match
-      if (yamlString.includes('disallowedTools: write_file')) {
-        // Scalar form
-        return {
-          name: 'test-agent',
-          description: 'A test subagent',
-          disallowedTools: 'write_file',
-        };
-      }
       if (yamlString.includes('disallowedTools:')) {
+        const dtLine = yamlString
+          .split('\n')
+          .find((l: string) => l.startsWith('disallowedTools:'));
+        const dtInline = dtLine?.replace('disallowedTools:', '').trim();
+        if (dtInline && dtInline !== '') {
+          return {
+            name: 'test-agent',
+            description: 'A test subagent',
+            disallowedTools: dtInline,
+          };
+        }
         return {
           name: 'test-agent',
           description: 'A test subagent',
@@ -142,6 +145,21 @@ describe('SubagentManager', () => {
         };
       }
       if (yamlString.includes('tools:')) {
+        const toolsLine = yamlString
+          .split('\n')
+          .find((l: string) => l.startsWith('tools:'));
+        const inlineValue = toolsLine?.replace('tools:', '').trim();
+        if (
+          inlineValue &&
+          !inlineValue.startsWith('\n') &&
+          inlineValue !== ''
+        ) {
+          return {
+            name: 'test-agent',
+            description: 'A test subagent',
+            tools: inlineValue,
+          };
+        }
         return {
           name: 'test-agent',
           description: 'A test subagent',
@@ -297,6 +315,52 @@ You are a helpful assistant.
       expect(config.tools).toEqual(['read_file', 'write_file']);
     });
 
+    it('should parse comma-separated tools string into array', () => {
+      const markdownWithCSV = `---
+name: test-agent
+description: A test subagent
+tools: Read, Bash, Grep, Glob, WebSearch, WebFetch, mcp__context7__*
+---
+
+You are a helpful assistant.
+`;
+
+      const config = manager.parseSubagentContent(
+        markdownWithCSV,
+        validConfig.filePath!,
+        'project',
+      );
+
+      expect(config.tools).toEqual([
+        'Read',
+        'Bash',
+        'Grep',
+        'Glob',
+        'WebSearch',
+        'WebFetch',
+        'mcp__context7__*',
+      ]);
+    });
+
+    it('should parse single tool string into array', () => {
+      const markdownWithSingle = `---
+name: test-agent
+description: A test subagent
+tools: Read
+---
+
+You are a helpful assistant.
+`;
+
+      const config = manager.parseSubagentContent(
+        markdownWithSingle,
+        validConfig.filePath!,
+        'project',
+      );
+
+      expect(config.tools).toEqual(['Read']);
+    });
+
     it('should parse content with disallowedTools array', () => {
       const markdownWithDisallowed = `---
 name: test-agent
@@ -335,6 +399,29 @@ You are a helpful assistant.
       );
 
       expect(config.disallowedTools).toEqual(['write_file']);
+    });
+
+    it('should parse comma-separated disallowedTools string into array', () => {
+      const markdownWithCSV = `---
+name: test-agent
+description: A test subagent
+disallowedTools: write_file, mcp__slack, Bash
+---
+
+You are a helpful assistant.
+`;
+
+      const config = manager.parseSubagentContent(
+        markdownWithCSV,
+        validConfig.filePath!,
+        'project',
+      );
+
+      expect(config.disallowedTools).toEqual([
+        'write_file',
+        'mcp__slack',
+        'Bash',
+      ]);
     });
 
     it('should parse content with model selector', () => {

--- a/packages/core/src/subagents/subagent-manager.ts
+++ b/packages/core/src/subagents/subagent-manager.ts
@@ -1116,7 +1116,15 @@ function parseSubagentContent(
     const description = String(descriptionRaw);
 
     // Extract optional fields
-    const tools = frontmatter['tools'] as string[] | undefined;
+    const toolsRaw = frontmatter['tools'];
+    const tools: string[] | undefined = Array.isArray(toolsRaw)
+      ? toolsRaw.filter((item): item is string => typeof item === 'string')
+      : typeof toolsRaw === 'string'
+        ? toolsRaw
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
+        : undefined;
     const disallowedToolsRaw = frontmatter['disallowedTools'];
     const disallowedTools: string[] | undefined = Array.isArray(
       disallowedToolsRaw,
@@ -1125,7 +1133,10 @@ function parseSubagentContent(
           (item): item is string => typeof item === 'string',
         )
       : typeof disallowedToolsRaw === 'string'
-        ? [disallowedToolsRaw]
+        ? disallowedToolsRaw
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
         : undefined;
     const modelRaw = frontmatter['model'];
     const legacyModelConfig = frontmatter['modelConfig'] as


### PR DESCRIPTION
## What this PR does

Fixes subagent loading for extensions (e.g. gsd-core) that declare `tools` as a comma-separated string in YAML frontmatter.

## Why it's needed

Many Gemini extensions use inline YAML syntax for tools:

```yaml
tools: Read, Bash, Grep, Glob, WebSearch, WebFetch
```

YAML parses this as a single string `"Read, Bash, Grep, Glob, WebSearch, WebFetch"`, not an array. `SubagentValidator.validateTools` then rejects it with "Tools must be an array of strings", causing the agent to be silently skipped.

This is the root cause behind gsd-core loading only 2 of 33 agents — the 2 that passed used YAML array syntax (`- Read`), while the other 31 used comma-separated strings.

## How it works

In `parseSubagentContent`, when `tools` or `disallowedTools` is a string, split by comma and trim each entry. This is consistent with the existing scalar-to-array normalization already applied to `disallowedTools`.

## Reviewer Test Plan

### How to verify
1. `npx vitest run src/subagents/` — all 138 tests pass
2. Install gsd-core and confirm all 33 agents load:
   ```
   qwen extensions install 'https://github.com/open-gsd/gsd-core'
   ```

### Evidence
- Before: 2 / 33 subagents loaded (only `gsd-nyquist-auditor` and `gsd-security-auditor`)
- After: 33 / 33 subagents loaded

### Tested on
| Platform | Node | Result |
|----------|------|--------|
| macOS (darwin arm64) | 22.x | Pass |

## Risk & Scope

**Low risk.** Only changes parsing normalization — arrays pass through unchanged, strings get split. No behavioral change for extensions already using array syntax.

- 2 files changed: `subagent-manager.ts` (parsing logic) + `subagent-manager.test.ts` (3 new tests)
- No new dependencies

## Linked Issues

Supersedes #4859 — that PR misidentified the root cause as missing auto-detection in the Gemini converter. The actual issue is in the subagent parser's tools format handling.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复了使用逗号分隔字符串声明 `tools` 的扩展（如 gsd-core）的 subagent 加载失败问题。

## 为什么需要

很多 Gemini 扩展使用 YAML 行内语法声明工具：`tools: Read, Bash, Grep`。YAML 将其解析为单个字符串而非数组，`SubagentValidator` 校验失败后静默跳过该 agent。

这是 gsd-core 只加载 2/33 个 agent 的根因——通过的 2 个用了 YAML 数组语法（`- Read`），被拒的 31 个用了逗号分隔字符串。

## 修复方式

在 `parseSubagentContent` 中，当 `tools` 或 `disallowedTools` 是字符串时，按逗号分隔拆成数组。与已有的 `disallowedTools` 标量归一化逻辑保持一致。

## 风险

低风险。仅改变解析归一化——数组原样通过，字符串被拆分。对已使用数组语法的扩展无行为变化。

</details>