### PR TITLE
test(integration): harden flaky sleep-interception e2e against skipped tool calls

### DIFF
--- a/integration-tests/cli/sleep-interception.test.ts
+++ b/integration-tests/cli/sleep-interception.test.ts
@@ -5,7 +5,11 @@
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
-import { TestRig, validateModelOutput } from '../test-helper.js';
+import {
+  TestRig,
+  printDebugInfo,
+  validateModelOutput,
+} from '../test-helper.js';
 
 describe('sleep-interception', () => {
   let rig: TestRig;
@@ -16,24 +20,80 @@ describe('sleep-interception', () => {
     }
   });
 
+  type ShellCall = {
+    args: string;
+    success: boolean;
+    error?: string;
+  };
+
+  /**
+   * Poll telemetry for a run_shell_command call matching the predicate.
+   * The model's narration is unreliable (it may retry, paraphrase, or skip
+   * the scripted reply), so assertions key off the recorded tool calls —
+   * blocked calls are logged too, with success: false and the block
+   * message in the error attribute.
+   */
+  const waitForShellCall = (predicate: (call: ShellCall) => boolean) =>
+    rig.poll(
+      () =>
+        rig
+          .readToolLogs()
+          .some(
+            (log) =>
+              log.toolRequest.name === 'run_shell_command' &&
+              predicate(log.toolRequest),
+          ),
+      rig.getDefaultTimeout(),
+      100,
+    );
+
+  const shellCalls = (): ShellCall[] =>
+    rig
+      .readToolLogs()
+      .filter((log) => log.toolRequest.name === 'run_shell_command')
+      .map((log) => log.toolRequest);
+
   it('should block sleep >= 2s and mention Monitor in guidance', async () => {
     rig = new TestRig();
     await rig.setup('sleep-blocked');
 
     const result = await rig.run(
-      'Run this exact shell command: sleep 5. ' +
-        'If the command is blocked, say "BLOCKED" and explain why. ' +
-        'If it succeeds, say "SUCCESS".',
+      'Use the run_shell_command tool to run this exact command in the ' +
+        'foreground: sleep 5. You must actually call run_shell_command — ' +
+        'do not predict the outcome without calling the tool, do not set ' +
+        'is_background, and do not modify the command. If the tool reports ' +
+        'the command was blocked, say "BLOCKED". If it executed ' +
+        'successfully, say "SUCCESS".',
     );
 
-    validateModelOutput(result, null, 'sleep blocked');
+    const foundBlockedCall = await waitForShellCall(
+      (call) => call.args.includes('sleep 5') && !call.success,
+    );
 
-    // The model should report being blocked, since sleep 5 triggers interception
-    const foundShell = await rig.waitForToolCall('run_shell_command');
-    expect(foundShell).toBeTruthy();
+    if (!foundBlockedCall) {
+      printDebugInfo(rig, result, {
+        'Shell calls': JSON.stringify(shellCalls()),
+      });
+    }
 
-    // The model's output should mention it was blocked
-    expect(result.toLowerCase()).toContain('blocked');
+    expect(
+      foundBlockedCall,
+      'Expected a blocked (success: false) run_shell_command call for sleep 5',
+    ).toBeTruthy();
+
+    // The block guidance must point the model at the Monitor tool. The
+    // error attribute is only available from file-based telemetry; the
+    // podman stdout fallback leaves it undefined.
+    const blockedCall = shellCalls().find(
+      (call) => call.args.includes('sleep 5') && !call.success,
+    );
+    if (blockedCall?.error !== undefined) {
+      expect(blockedCall.error).toContain('Monitor');
+    }
+
+    // Narration is best-effort: warns instead of failing if the model
+    // phrases the block differently.
+    validateModelOutput(result, 'blocked', 'sleep blocked');
   });
 
   it('should allow sleep < 2s', async () => {
@@ -41,16 +101,27 @@ describe('sleep-interception', () => {
     await rig.setup('sleep-allowed');
 
     const result = await rig.run(
-      'Run this exact shell command: sleep 1. Then say "DONE".',
+      'Use the run_shell_command tool to run this exact command: sleep 1. ' +
+        'You must actually call run_shell_command with that command — do ' +
+        'not skip it. After it completes, say "DONE".',
     );
 
-    validateModelOutput(result, null, 'sleep allowed');
+    const foundSuccessfulCall = await waitForShellCall(
+      (call) => call.args.includes('sleep 1') && call.success,
+    );
 
-    const foundShell = await rig.waitForToolCall('run_shell_command');
-    expect(foundShell).toBeTruthy();
+    if (!foundSuccessfulCall) {
+      printDebugInfo(rig, result, {
+        'Shell calls': JSON.stringify(shellCalls()),
+      });
+    }
 
-    // Should not be blocked — model should complete successfully
-    expect(result.toLowerCase()).not.toContain('blocked');
+    expect(
+      foundSuccessfulCall,
+      'Expected a successful run_shell_command call for sleep 1',
+    ).toBeTruthy();
+
+    validateModelOutput(result, 'done', 'sleep allowed');
   });
 
   it('should allow retrying blocked sleep with an intentional sleep comment', async () => {
@@ -58,18 +129,32 @@ describe('sleep-interception', () => {
     await rig.setup('sleep-intentional-retry');
 
     const result = await rig.run(
-      'Run this exact shell command first: sleep 5. ' +
-        'If the command is blocked, retry with this exact shell command: ' +
-        'sleep 2 # intentional-sleep: wait for MCP rate limit reset. ' +
-        'Then say "DONE".',
+      'Use the run_shell_command tool to run this exact command in the ' +
+        'foreground: sleep 5. You must actually call run_shell_command — ' +
+        'do not predict the outcome without calling the tool. When that ' +
+        'call is blocked, call run_shell_command again with this exact ' +
+        'command: sleep 2 # intentional-sleep: wait for MCP rate limit ' +
+        'reset. Then say "DONE".',
     );
 
-    validateModelOutput(result, null, 'sleep intentional retry');
+    // The escape hatch worked iff a call carrying the intentional-sleep
+    // comment completed successfully.
+    const foundIntentionalCall = await waitForShellCall(
+      (call) => call.args.includes('intentional-sleep') && call.success,
+    );
 
-    const foundShell = await rig.waitForToolCall('run_shell_command');
-    expect(foundShell).toBeTruthy();
+    if (!foundIntentionalCall) {
+      printDebugInfo(rig, result, {
+        'Shell calls': JSON.stringify(shellCalls()),
+      });
+    }
 
-    expect(result.toLowerCase()).toContain('done');
+    expect(
+      foundIntentionalCall,
+      'Expected a successful run_shell_command call with an intentional-sleep comment',
+    ).toBeTruthy();
+
+    validateModelOutput(result, 'done', 'sleep intentional retry');
   });
 
   it('should block sleep >= 2s even when followed by a trailing comment', async () => {
@@ -81,17 +166,33 @@ describe('sleep-interception', () => {
     await rig.setup('sleep-blocked-trailing-comment');
 
     const result = await rig.run(
-      'Run this exact shell command: sleep 5 # wait for db. ' +
-        'If the command is blocked, say "BLOCKED" and explain why. ' +
-        'If it succeeds, say "SUCCESS".',
+      'Use the run_shell_command tool to run this exact command in the ' +
+        'foreground: sleep 5 # wait for db. You must actually call ' +
+        'run_shell_command — do not predict the outcome without calling ' +
+        'the tool, do not set is_background, and do not modify the ' +
+        'command. If the tool reports the command was blocked, say ' +
+        '"BLOCKED". If it executed successfully, say "SUCCESS".',
     );
 
-    validateModelOutput(result, null, 'sleep blocked with trailing comment');
+    const foundBlockedCall = await waitForShellCall(
+      (call) => call.args.includes('sleep 5') && !call.success,
+    );
 
-    const foundShell = await rig.waitForToolCall('run_shell_command');
-    expect(foundShell).toBeTruthy();
+    if (!foundBlockedCall) {
+      printDebugInfo(rig, result, {
+        'Shell calls': JSON.stringify(shellCalls()),
+      });
+    }
 
-    // Model must report it was blocked despite the trailing comment.
-    expect(result.toLowerCase()).toContain('blocked');
+    expect(
+      foundBlockedCall,
+      'Expected a blocked (success: false) run_shell_command call for sleep 5 with trailing comment',
+    ).toBeTruthy();
+
+    validateModelOutput(
+      result,
+      'blocked',
+      'sleep blocked with trailing comment',
+    );
   });
 });

--- a/integration-tests/test-helper.ts
+++ b/integration-tests/test-helper.ts
@@ -129,6 +129,8 @@ interface ParsedLog {
     function_args?: string;
     success?: boolean;
     duration_ms?: number;
+    status?: string;
+    'error.message'?: string;
   };
   scopeMetrics?: {
     metrics: {
@@ -569,6 +571,8 @@ export class TestRig {
         args: string;
         success: boolean;
         duration_ms: number;
+        status?: string;
+        error?: string;
       };
     }[] = [];
 
@@ -760,6 +764,8 @@ export class TestRig {
         args: string;
         success: boolean;
         duration_ms: number;
+        status?: string;
+        error?: string;
       };
     }[] = [];
 
@@ -776,6 +782,8 @@ export class TestRig {
             args: logData.attributes.function_args,
             success: logData.attributes.success,
             duration_ms: logData.attributes.duration_ms,
+            status: logData.attributes.status,
+            error: logData.attributes['error.message'],
           },
         });
       }


### PR DESCRIPTION

## What this PR does

- Rewrites the sleep-interception e2e prompts to explicitly name the shell tool and require an actual tool call, instead of leaving the model room to answer from prediction ("if blocked, say BLOCKED" could be satisfied without running anything).
- Moves the core assertions from model narration to recorded telemetry: blocked runs must show a failed foreground `sleep` tool call, allowed and intentional-sleep runs must show a successful one.
- Verifies for the first time that the block guidance actually mentions the Monitor tool — the test name always promised this, but nothing checked it.
- Downgrades phrasing checks ("BLOCKED" / "DONE") to warn-only, and prints debug info (model output plus the tool calls actually made) when an assertion is about to fail, so future flakes are self-diagnosing in CI logs.
- The test rig now exposes each tool call's status and error message from telemetry (additive; existing tests are unaffected).

## Why it's needed

- This suite is flaky in CI and has failed unrelated runs at least twice recently (run 27256480970 on 2026-06-10, and the e2e run on commit 9e4c87a7e on 2026-06-09), after #4878 already addressed a different flake source in the same file.
- The remaining failure mode is the model answering without ever calling the shell tool, so waiting for the tool call times out. Each failed attempt burns ~77s (model run + a full 60s futile telemetry poll), about 230s per CI run with retries — and the log gives no clue what the model did instead.
- The old narration assertions had latent flake paths of their own: a model saying "the command was **not** blocked" would fail the allow test, and a model retrying the blocked sleep in the background would flip the blocked test's expected reply.

## Reviewer Test Plan

### How to verify

From `integration-tests/`, run the suite against a real model:

```bash
QWEN_SANDBOX=false OPENAI_API_KEY=... \
  OPENAI_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1 \
  OPENAI_MODEL=deepseek-v4-flash \
  npx vitest run cli/sleep-interception.test.ts
```

Expected: all 4 tests pass. The blocked cases require telemetry to record a failed foreground `sleep 5` call whose error message mentions the Monitor tool; the allow and intentional-sleep cases require a successful call. A regression would have looked like the old flake: a 60s hang waiting for a tool call that never happened, with no diagnostics.

### Evidence (Before & After)

Three consecutive local runs against a real model (deepseek-v4-flash via DashScope, throwaway QWEN_HOME):

| Run | Tests | Result | Duration |
| :-: | :---: | :----: | :------: |
|  1  |  4/4  |   ✅   |  54.8s   |
|  2  |  4/4  |   ✅   |  54.0s   |
|  3  |  4/4  |   ✅   |  53.2s   |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`node dist/cli.js` (fresh build + bundle), no sandbox, DashScope OpenAI-compatible endpoint.

## Risk & Scope

- Main risk or tradeoff: prompts reduce but cannot eliminate model nondeterminism; if a flake recurs, the failure now self-diagnoses via the printed model output and tool-call log.
- Not validated / out of scope: the podman stdout telemetry fallback does not carry the error message, so the Monitor-guidance check degrades gracefully (skipped) there; runtime sleep-interception behavior itself is unchanged.
- Breaking changes / migration notes: none — test-only change.

## Linked Issues

Follow-up to #4878 (same test file, different flake source).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

- 重写 sleep-interception e2e 测试的提示词：明确点名 shell 工具并要求模型真正发起工具调用，不再给模型留下"凭预测直接回答"的空间（旧提示词"如果被拦截就说 BLOCKED"无需运行任何命令即可完成）。
- 将核心断言从模型的自然语言回复迁移到遥测记录的工具调用上：拦截场景必须记录到一次失败的前台 `sleep` 调用，放行和 intentional-sleep 场景必须记录到一次成功调用。
- 首次真正校验拦截提示信息中确实提到了 Monitor 工具——测试名称一直承诺这一点，但此前没有任何断言检查它。
- 将措辞检查（"BLOCKED" / "DONE"）降级为仅告警，并在断言即将失败时打印调试信息（模型输出和实际发生的工具调用），让未来的偶发失败能在 CI 日志中自行定位。
- 测试框架现在从遥测中暴露每个工具调用的状态和错误信息（纯增量字段，现有测试不受影响）。

## 为什么需要

- 该套件在 CI 中不稳定，最近至少两次导致无关的运行失败（2026-06-10 的 run 27256480970，以及 2026-06-09 提交 9e4c87a7e 上的 e2e 运行），此前 #4878 已经修过同一文件中的另一个不稳定来源。
- 剩余的失败模式是模型根本没有调用 shell 工具，导致等待工具调用超时。每次失败的尝试浪费约 77 秒（模型运行 + 整整 60 秒无效的遥测轮询），算上重试每次 CI 运行约浪费 230 秒——而且日志完全看不出模型究竟做了什么。
- 旧的措辞断言本身也有潜在的不稳定路径：模型回复"the command was **not** blocked"会让放行测试误判失败；模型在被拦截后改用后台方式重试会改变拦截测试的预期回复。

## 评审验证方案

### 如何验证

在 `integration-tests/` 目录下，用真实模型运行该套件（命令见上文英文部分）。

预期：4 个测试全部通过。拦截场景要求遥测记录到一次失败的前台 `sleep 5` 调用且错误信息提到 Monitor 工具；放行和 intentional-sleep 场景要求记录到成功调用。回归的表现会和旧的偶发失败一样：等待一次从未发生的工具调用而挂起 60 秒，且没有任何诊断信息。

### 证据（前后对比）

连续三次本地真实模型运行（DashScope 的 deepseek-v4-flash，一次性 QWEN_HOME），结果见上文表格：3 次运行均 4/4 通过。

### 已测试平台

macOS ✅，Windows ⚠️，Linux ⚠️（CI 覆盖三平台）。

## 风险与范围

- 主要风险/权衡：提示词只能降低、无法消除模型的非确定性；若再次出现偶发失败，现在会通过打印的模型输出和工具调用日志自行定位。
- 未验证/超出范围：podman 的 stdout 遥测回退路径不携带错误信息，Monitor 提示检查在该路径下会优雅降级（跳过）；运行时的 sleep 拦截行为本身没有改动。
- 破坏性变更/迁移说明：无——仅测试改动。

## 关联 Issue

#4878 的后续（同一测试文件，不同的不稳定来源）。

</details>
