### PR TITLE
fix(daemon): language switch writes to wrong output-language.md path

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -121,6 +121,7 @@ import {
 import {
   resolveOutputLanguage,
   updateOutputLanguageFile,
+  getOutputLanguageFilePath,
   isAutoLanguage,
   OUTPUT_LANGUAGE_AUTO,
 } from '../utils/languageUtils.js';
@@ -2897,7 +2898,7 @@ class QwenAgent implements Agent {
           );
         }
 
-        this.sessionOrThrow(sessionId);
+        const session = this.sessionOrThrow(sessionId);
 
         try {
           await setLanguageAsync(language);
@@ -2930,9 +2931,16 @@ class QwenAgent implements Agent {
             ? OUTPUT_LANGUAGE_AUTO
             : resolved;
 
+          const targetPath = session.getConfig().getOutputLanguageFilePath();
+
           let fileWriteOk = false;
           try {
-            updateOutputLanguageFile(settingValue);
+            updateOutputLanguageFile(settingValue, targetPath);
+            if (!targetPath) {
+              session
+                .getConfig()
+                .setOutputLanguageFilePath(getOutputLanguageFilePath());
+            }
             fileWriteOk = true;
           } catch (err) {
             debugLogger.warn('Failed to write output-language.md:', err);
@@ -2951,10 +2959,20 @@ class QwenAgent implements Agent {
                 err,
               );
             }
+            const writtenPath = targetPath ?? getOutputLanguageFilePath();
             const allSessions = [...this.sessions.values()];
             const results = await Promise.allSettled(
               allSessions.map(async (s) => {
                 const cfg = s.getConfig();
+                const sessionPath = cfg.getOutputLanguageFilePath();
+                if (sessionPath && sessionPath !== writtenPath) {
+                  updateOutputLanguageFile(settingValue, sessionPath);
+                }
+                if (!sessionPath) {
+                  const fallback = getOutputLanguageFilePath();
+                  updateOutputLanguageFile(settingValue, fallback);
+                  cfg.setOutputLanguageFilePath(fallback);
+                }
                 await cfg.refreshHierarchicalMemory();
                 await cfg.getGeminiClient()?.refreshSystemInstruction();
               }),

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -965,6 +965,8 @@ export function createServeApp(
     };
   }
 
+  const LANGUAGE_CODES = [...SUPPORTED_LANGUAGES.map((l) => l.code), 'auto'];
+
   app.get('/capabilities', (_req, res) => {
     const envelope: CapabilitiesEnvelope = {
       v: CAPABILITIES_SCHEMA_VERSION,
@@ -993,6 +995,7 @@ export function createServeApp(
       workspaceCwd: boundWorkspace,
       // Active mediation policy under the `policy` namespace.
       policy: { permission: bridge.permissionPolicy },
+      supportedLanguages: LANGUAGE_CODES,
     };
     res.status(200).json(envelope);
   });
@@ -2255,8 +2258,6 @@ export function createServeApp(
       }
     },
   );
-
-  const LANGUAGE_CODES = [...SUPPORTED_LANGUAGES.map((l) => l.code), 'auto'];
 
   app.post('/session/:id/language', mutate(), async (req, res) => {
     const sessionId = req.params['id'];

--- a/packages/cli/src/ui/commands/languageCommand.ts
+++ b/packages/cli/src/ui/commands/languageCommand.ts
@@ -28,6 +28,7 @@ import {
   isAutoLanguage,
   resolveOutputLanguage,
   updateOutputLanguageFile,
+  getOutputLanguageFilePath,
 } from '../../utils/languageUtils.js';
 import { createDebugLogger } from '@qwen-code/qwen-code-core';
 
@@ -125,7 +126,13 @@ async function setOutputLanguage(
     // Save 'auto' as-is to settings, or normalize other values
     const settingValue = isAuto ? OUTPUT_LANGUAGE_AUTO : resolved;
 
-    updateOutputLanguageFile(settingValue);
+    const targetPath = context.services.config?.getOutputLanguageFilePath?.();
+    updateOutputLanguageFile(settingValue, targetPath);
+    if (!targetPath) {
+      context.services.config?.setOutputLanguageFilePath?.(
+        getOutputLanguageFilePath(),
+      );
+    }
 
     if (context.services.settings?.setValue) {
       try {

--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -380,7 +380,7 @@ export function SettingsDialog({
 
       // Update output language rule file immediately (no restart needed for LLM effect)
       if (key === 'general.outputLanguage' && typeof parsed === 'string') {
-        updateOutputLanguageFile(parsed);
+        updateOutputLanguageFile(parsed, config?.getOutputLanguageFilePath?.());
       }
 
       // Mark as needing restart and show prompt

--- a/packages/cli/src/utils/languageUtils.ts
+++ b/packages/cli/src/utils/languageUtils.ts
@@ -63,7 +63,7 @@ export function resolveOutputLanguage(
 /**
  * Returns the path to the LLM output language rule file (~/.qwen/output-language.md).
  */
-function getOutputLanguageFilePath(): string {
+export function getOutputLanguageFilePath(): string {
   return path.join(
     Storage.getGlobalQwenDir(),
     LLM_OUTPUT_LANGUAGE_RULE_FILENAME,
@@ -151,9 +151,16 @@ function readOutputLanguageFromFile(): string | null {
 
 /**
  * Writes the output language rule file with the given language.
+ *
+ * @param targetPath - When provided, write to this path instead of the
+ *   global default.  Callers should pass `config.getOutputLanguageFilePath()`
+ *   so the file that the session actually reads is the one being updated.
  */
-export function writeOutputLanguageFile(language: string): void {
-  const filePath = getOutputLanguageFilePath();
+export function writeOutputLanguageFile(
+  language: string,
+  targetPath?: string,
+): void {
+  const filePath = targetPath ?? getOutputLanguageFilePath();
   const content = generateOutputLanguageFileContent(language);
   const dir = path.dirname(filePath);
   fs.mkdirSync(dir, { recursive: true });
@@ -163,10 +170,15 @@ export function writeOutputLanguageFile(language: string): void {
 /**
  * Updates the LLM output language rule file based on the setting value.
  * Resolves 'auto' to the detected system language before writing.
+ *
+ * @param targetPath - Forwarded to {@link writeOutputLanguageFile}.
  */
-export function updateOutputLanguageFile(settingValue: string): void {
+export function updateOutputLanguageFile(
+  settingValue: string,
+  targetPath?: string,
+): void {
   const resolved = resolveOutputLanguage(settingValue);
-  writeOutputLanguageFile(resolved);
+  writeOutputLanguageFile(resolved, targetPath);
 }
 
 /**

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1080,7 +1080,7 @@ export class Config {
   private readonly cwd: string;
   private readonly explicitIncludeDirectories: string[];
   private readonly bugCommand: BugCommandSettings | undefined;
-  private readonly outputLanguageFilePath?: string;
+  private outputLanguageFilePath?: string;
   private readonly noBrowser: boolean;
   private readonly folderTrustFeature: boolean;
   private readonly folderTrust: boolean;
@@ -2906,6 +2906,10 @@ export class Config {
 
   getOutputLanguageFilePath(): string | undefined {
     return this.outputLanguageFilePath;
+  }
+
+  setOutputLanguageFilePath(filePath: string): void {
+    this.outputLanguageFilePath = filePath;
   }
 
   setUserMemory(newUserMemory: string): void {

--- a/packages/sdk-typescript/src/daemon/DaemonClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonClient.ts
@@ -54,6 +54,7 @@ import type {
   PromptContentBlock,
   PromptResult,
   SetModelResult,
+  SetSessionLanguageResult,
   SessionMetadataResult,
   DaemonApprovalMode,
   DaemonApprovalModeResult,
@@ -1029,10 +1030,7 @@ export class DaemonClient {
       `${this.baseUrl}/session/${encodeURIComponent(sessionId)}/branch`,
       {
         method: 'POST',
-        headers: this.headers(
-          { 'Content-Type': 'application/json' },
-          clientId,
-        ),
+        headers: this.headers({ 'Content-Type': 'application/json' }, clientId),
         body: JSON.stringify({ name: req.name }),
       },
       async (res) => {
@@ -1613,6 +1611,33 @@ export class DaemonClient {
           throw await this.failOnError(res, 'POST /session/:id/model');
         }
         return (await res.json()) as SetModelResult;
+      },
+    );
+  }
+
+  async setSessionLanguage(
+    sessionId: string,
+    language: string,
+    opts?: { syncOutputLanguage?: boolean; clientId?: string },
+  ): Promise<SetSessionLanguageResult> {
+    return await this.fetchWithTimeout(
+      `${this.baseUrl}/session/${encodeURIComponent(sessionId)}/language`,
+      {
+        method: 'POST',
+        headers: this.headers(
+          { 'Content-Type': 'application/json' },
+          opts?.clientId,
+        ),
+        body: JSON.stringify({
+          language,
+          syncOutputLanguage: opts?.syncOutputLanguage ?? false,
+        }),
+      },
+      async (res) => {
+        if (!res.ok) {
+          throw await this.failOnError(res, 'POST /session/:id/language');
+        }
+        return (await res.json()) as SetSessionLanguageResult;
       },
     );
   }

--- a/packages/sdk-typescript/src/daemon/index.ts
+++ b/packages/sdk-typescript/src/daemon/index.ts
@@ -386,5 +386,6 @@ export type {
   PromptResult,
   PromptTextContent,
   SetModelResult,
+  SetSessionLanguageResult,
   SessionMetadataResult,
 } from './types.js';

--- a/packages/sdk-typescript/src/daemon/types.ts
+++ b/packages/sdk-typescript/src/daemon/types.ts
@@ -962,6 +962,13 @@ export interface SetModelResult {
   [key: string]: unknown;
 }
 
+/** Returned from `POST /session/:id/language`. */
+export interface SetSessionLanguageResult {
+  language: string;
+  outputLanguage: string | null;
+  refreshed: boolean;
+}
+
 /**
  * Closed enumeration of session approval modes the
  * daemon exposes via `POST /session/:id/approval-mode`. Mirrors core's


### PR DESCRIPTION
## Summary

Fixes a bug in `POST /session/:id/language` (introduced in #4705) where the language switch silently fails because the output-language file is written to the wrong path.

**Root cause**: `updateOutputLanguageFile()` always writes to the global `~/.qwen/output-language.md`, but `Config.outputLanguageFilePath` may point to a project-level `<cwd>/.qwen/output-language.md` (when it existed at daemon startup). Since `refreshHierarchicalMemory` reads from the Config-bound path, the written file is never read back — the language switch has no effect.

**Additional issue**: On a fresh environment where no `output-language.md` exists, the first language switch creates the file at the global path, but `Config.outputLanguageFilePath` remains `undefined` (was `readonly`), so `refreshHierarchicalMemory` never discovers the newly created file.

## Changes

### Bug fixes
- **`Config.outputLanguageFilePath`**: remove `readonly`, add `setOutputLanguageFilePath()` setter so the path can be registered after first-time file creation
- **`languageUtils.ts`**: add optional `targetPath` parameter to `writeOutputLanguageFile()` and `updateOutputLanguageFile()`, export `getOutputLanguageFilePath()` for callers that need the global default
- **`acpAgent.ts`**: write to the session Config's actual path; on first-time creation register the path on Config; on multi-session refresh also update each session's own file if its path differs
- **`languageCommand.ts`** and **`SettingsDialog.tsx`**: same Config-bound path fix for the CLI `/language` command and settings dialog

### Enhancements
- **`server.ts`**: expose `supportedLanguages` array in `GET /capabilities` response so clients can discover valid language codes before calling the endpoint
- **SDK**: add `DaemonClient.setSessionLanguage()` method and `SetSessionLanguageResult` type

## How it ensures read/write consistency

| Scenario | Write path | Read path | Consistent |
|----------|-----------|-----------|:---:|
| Project-level file exists | `config.getOutputLanguageFilePath()` = project path | Same field | ✅ |
| Only global file exists | `config.getOutputLanguageFilePath()` = global path | Same field | ✅ |
| First-time creation | Fallback writes global → `setOutputLanguageFilePath()` registers it | Registered field | ✅ |

## Test plan

- [x] `npx vitest run packages/cli/src/ui/commands/languageCommand.test.ts` — 48 tests pass
- [x] `npx vitest run packages/cli/src/serve/server.test.ts -t "language"` — 7 language route tests pass
- [x] Local daemon startup verification: `GET /capabilities` returns `supportedLanguages`, `POST /session/:id/language` validates against the list
- [ ] Deploy to environment with project-level `.qwen/output-language.md` and verify language switch takes effect

## Related

- Follow-up to #4705 (feat: add POST /session/:id/language for runtime language switching)

🤖 Generated with [Qwen Code](https://qwen.ai/qwencode)