### PR TITLE
fix(core): prevent cron scheduler from firing on creation minute

### DIFF
--- a/packages/core/src/services/cronScheduler.test.ts
+++ b/packages/core/src/services/cronScheduler.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { CronScheduler, type CronJob } from './cronScheduler.js';
 
 describe('CronScheduler', () => {
@@ -97,6 +97,28 @@ describe('CronScheduler', () => {
 
       expect(fired).toHaveLength(1);
       expect(fired[0]!.prompt).toBe('match');
+    });
+
+    it('does not fire on the same minute the job was created', () => {
+      vi.useFakeTimers();
+      const localScheduler = new CronScheduler();
+      try {
+        vi.setSystemTime(new Date(2025, 0, 15, 10, 30, 15));
+        const fired: CronJob[] = [];
+        localScheduler.start((job) => fired.push(job));
+
+        localScheduler.create('*/1 * * * *', 'should not fire yet', true);
+
+        localScheduler.tick(new Date(2025, 0, 15, 10, 30, 59));
+        expect(fired).toHaveLength(0);
+
+        localScheduler.tick(new Date(2025, 0, 15, 10, 31, 59));
+        expect(fired).toHaveLength(1);
+        expect(fired[0]!.prompt).toBe('should not fire yet');
+      } finally {
+        localScheduler.destroy();
+        vi.useRealTimers();
+      }
     });
 
     it('does not fire when no match', () => {

--- a/packages/core/src/services/cronScheduler.ts
+++ b/packages/core/src/services/cronScheduler.ts
@@ -115,6 +115,8 @@ export class CronScheduler {
       recurring,
       createdAt: now,
       expiresAt: recurring ? now + THREE_DAYS_MS : Infinity,
+      // Prevent the scheduler from firing during the creation minute
+      lastFiredAt: now - (now % 60_000),
       jitterMs,
     };
 


### PR DESCRIPTION
## What this PR does

Initializes `lastFiredAt` to the creation minute-start when a cron job is created, so the scheduler's double-fire guard treats the creation minute as "already fired" and waits for the next matching cron window.

## Why it's needed

When `/loop` schedules a cron job, the SKILL.md instructs the agent to execute the prompt immediately (step 3, by design). However, the `CronScheduler.tick()` could also fire the same job within the same minute — `lastFiredAt` was `undefined` on creation, so the guard check (`lastFiredAt === matchedMinuteMs`) was bypassed whenever the current minute happened to match the cron expression. This caused duplicate execution of the prompt: once by the agent (intentional) and once by the scheduler (bug).

For example, `/loop 2m check the build` would write the file immediately, then the scheduler would fire `● Cron: check the build` seconds later and write it again.

The fix seeds `lastFiredAt` to the floor of the creation minute so the existing double-fire guard handles it naturally.

## Reviewer Test Plan

### How to verify

1. Build and bundle: `npm run build && npm run bundle`
2. Start a session with cron enabled: `QWEN_CODE_ENABLE_CRON=1 node dist/cli.js --approval-mode yolo`
3. Run `/loop 2m write the word TEST to /tmp/looptest.txt`
4. **Before this fix**: two WriteFile calls appear — the intentional one and then a `● Cron:` triggered duplicate
5. **After this fix**: only the intentional WriteFile from SKILL.md step 3; no scheduler-triggered duplicate until the next matching cron minute

### Evidence (Before & After)

**Before** — scheduler fires immediately after the agent's execution:
```
✦ Done — LOOPTEST written to /tmp/crontest/output.txt. It will be rewritten every 2 minutes.

● Cron: write the word LOOPTEST to /tmp/crontest       ← SCHEDULER DOUBLE-FIRE
  ✓  WriteFile Writing to /tmp/crontest/output.txt
     No changes detected.
```

**After** — only the intentional execution, prompt returns to idle:
```
✦ Done — wrote LOOPTEST to /tmp/crontest/output.txt. It will be rewritten every 2 minutes until the job expires or is cancelled.

────────────────────────────────────────────
*   Type your message or @path/to/file       ← NO DOUBLE-FIRE
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

E2E verified via tmux interactive session with `QWEN_CODE_ENABLE_CRON=1 node dist/cli.js --approval-mode yolo`. Unit tests via `npx vitest run`.

## Risk & Scope

- Main risk or tradeoff: Minimal — `lastFiredAt` was previously unused at creation time; the change piggybacks on the existing double-fire guard.
- Not validated / out of scope: One-shot cron jobs created directly via CronCreate (not through `/loop`) also benefit — they no longer fire on the creation minute either.
- Breaking changes / migration notes: None. Jobs are in-memory only (session-scoped), so no migration needed.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在创建 cron 任务时，将 `lastFiredAt` 初始化为创建时间所在分钟的起始时间戳，使调度器的防重复触发机制将创建分钟视为"已触发"，从而等待下一个匹配的 cron 窗口。

## 为什么需要这个改动

使用 `/loop` 调度 cron 任务时，SKILL.md 指示 agent 立即执行提示词（步骤 3，设计如此）。但 `CronScheduler.tick()` 也会在同一分钟内触发同一任务——因为创建时 `lastFiredAt` 为 `undefined`，防重复触发检查（`lastFiredAt === matchedMinuteMs`）被绕过。这导致提示词被重复执行：agent 执行一次（预期行为），调度器又执行一次（bug）。

## 风险与范围

- 主要风险：极小——`lastFiredAt` 在创建时此前未使用；此改动利用了现有的防重复触发机制。
- 未验证/超出范围：通过 CronCreate 直接创建的一次性 cron 任务（非通过 `/loop`）也受益——不再在创建分钟触发。
- 破坏性变更/迁移说明：无。任务仅存在于内存中（会话级别），无需迁移。

</details>
