### PR TITLE
fix(core): give complete intentional-sleep guidance on first rejection for sleep chains

### DIFF
--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -195,16 +195,15 @@ describe('ShellTool', () => {
       expect(error).toBeNull();
     });
 
-    it('should not suggest the intentional sleep comment for sleep chains', async () => {
+    it('should guide model to split and use intentional-sleep for sleep chains', async () => {
       const error = shellTool.validateToolParams({
         command: 'sleep 5 && echo ok',
         is_background: false,
       });
 
-      expect(error).toContain(
-        'intentional-sleep escape hatch only applies to standalone sleep commands',
-      );
-      expect(error).not.toContain('# intentional-sleep:');
+      expect(error).toContain('Split into two calls');
+      expect(error).toContain('intentional-sleep:');
+      expect(error).toContain('reason');
     });
 
     it('should throw an error for a relative directory path', async () => {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -4361,16 +4361,14 @@ export class ShellTool extends BaseDeclarativeTool<
     // `-c` script. This matches every other sensitive check in this file
     // (directory, read-only, command-root extraction, etc.).
     if (!params.is_background) {
-      const sleepPattern = detectBlockedSleepPatternDetails(
-        stripShellWrapper(params.command),
-      );
+      const sleepPattern = detectBlockedSleepPatternDetails(strippedCommand);
       if (sleepPattern !== null) {
         const intentionalSleepGuidance =
           sleepPattern.intentionalSleepRejection ??
           (sleepPattern.isStandalone
             ? 'If you genuinely need a standalone delay (rate limiting, deliberate pacing), ' +
               'add a trailing comment like `# intentional-sleep: wait for MCP rate limit reset` (up to 10 minutes).'
-            : 'The intentional-sleep escape hatch only applies to standalone sleep commands; split follow-up commands into a separate invocation.');
+            : 'Split into two calls: first `sleep N # intentional-sleep: <reason>` (standalone), then the follow-up command.');
         return (
           `Blocked: ${sleepPattern.description}. ` +
           'Run blocking commands in the background with is_background: true. ' +


### PR DESCRIPTION
## What this PR does

When the shell tool blocks a sleep chain like `sleep 5 && curl http://localhost`, the error message now tells the model the full solution in a single rejection — split into two calls and use `# intentional-sleep: <reason>` — instead of revealing the escape hatch only after a second failure.

Also reuses the already-computed `strippedCommand` variable instead of calling `stripShellWrapper` a second time in the same validation method.

## Why it's needed

The old error message for `sleep N && cmd` said "split follow-up commands into a separate invocation" but omitted the `# intentional-sleep:` syntax. The model would split, try standalone `sleep 5`, get blocked again, and only then learn it needs the comment. This wasted two tool calls before the model could succeed.

E2E testing confirmed the model consistently fails twice before succeeding with the old message, and only once with the new message.

## Reviewer Test Plan

### How to verify

Build and bundle, then run a headless prompt that triggers the sleep chain path. **Before:** two `is_error: true` tool results before the model succeeds. **After:** only one.

### Evidence (Before & After)

**Before (2 failures):**
```
1. ❌ "sleep 5 followed by: curl …" → "split follow-up commands into a separate invocation"
2. ❌ "standalone sleep 5" → "add a trailing comment like # intentional-sleep: …"
3. ✅ sleep 5 # intentional-sleep: wait for server startup
```

**After (1 failure):**
```
1. ❌ "sleep 5 followed by: curl …" → "Split into two calls: first sleep N # intentional-sleep: <reason> …"
2. ✅ sleep 5 # intentional-sleep: waiting for server on port 8080 to be ready
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Headless CLI (`node dist/cli.js --yolo --output-format stream-json`), unit tests (`npx vitest run`).

## Risk & Scope

- Main risk or tradeoff: Message wording change — models adapt to the new guidance on first rejection in practice.
- Not validated / out of scope: The standalone sleep path (`sleep 5` alone) is unchanged.
- Breaking changes / migration notes: None.

<details>
<summary>中文说明</summary>

当 shell 工具拦截 `sleep 5 && curl http://localhost` 这样的 sleep 链式命令时，错误信息现在会在第一次拒绝时就告诉模型完整的解决方案——拆分为两个调用并使用 `# intentional-sleep: <reason>` 注释——而不是让模型在第二次失败后才发现这个转义机制。同时复用了已经计算好的 `strippedCommand` 变量，避免重复调用 `stripShellWrapper`。

E2E 测试确认模型在旧消息下一致失败两次，新消息下只失败一次。

</details>
