### PR TITLE
fix(core): ensure hard threshold always exceeds auto threshold

### DIFF
--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -1883,12 +1883,21 @@ describe('ChatCompressionService.compress cheap-gate uses estimated tokens', () 
 });
 
 describe('computeThresholds', () => {
-  it('32K window — proportional fallback for all tiers, hard degrades to auto', () => {
+  it('32K window — proportional fallback for all tiers, hard = auto + HARD_BUFFER', () => {
     const t = computeThresholds(32_000);
     expect(t.warn).toBe(19_200); // 0.6 * 32K
     expect(t.auto).toBe(22_400); // 0.7 * 32K
-    expect(t.hard).toBe(22_400); // max(window-23K=9K, auto=22.4K) = auto
+    expect(t.hard).toBe(25_400); // auto + HARD_BUFFER = 22.4K + 3K
     expect(t.effectiveWindow).toBe(12_000);
+  });
+
+  it('60K window — hard no longer equals auto (issue #4945)', () => {
+    const t = computeThresholds(60_000);
+    expect(t.warn).toBe(36_000); // 0.6 * 60K
+    expect(t.auto).toBe(42_000); // 0.7 * 60K (pct wins: 42K vs ew-13K=27K)
+    expect(t.hard).toBe(45_000); // auto + HARD_BUFFER = 42K + 3K
+    expect(t.hard).toBeGreaterThan(t.auto);
+    expect(t.effectiveWindow).toBe(40_000);
   });
 
   it('128K window — mixed (warn=pct, auto/hard=abs)', () => {
@@ -1933,11 +1942,13 @@ describe('computeThresholds', () => {
     expect(t.hard).toBe(0);
   });
 
-  it('thresholds always satisfy warn <= auto <= hard', () => {
-    for (const w of [32_000, 64_000, 128_000, 200_000, 256_000, 1_000_000]) {
+  it('thresholds always satisfy warn <= auto < hard for non-zero windows', () => {
+    for (const w of [
+      10_000, 32_000, 60_000, 64_000, 128_000, 200_000, 256_000, 1_000_000,
+    ]) {
       const t = computeThresholds(w);
       expect(t.warn).toBeLessThanOrEqual(t.auto);
-      expect(t.auto).toBeLessThanOrEqual(t.hard);
+      expect(t.auto).toBeLessThan(t.hard);
     }
   });
 });

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -120,7 +120,7 @@ export interface CompactionThresholds {
  * Each tier is `max(proportional, absolute)`:
  *   auto = max(DEFAULT_PCT * window,                       effectiveWindow - AUTOCOMPACT_BUFFER)
  *   warn = max((DEFAULT_PCT - WARN_PCT_OFFSET) * window,   auto - WARN_BUFFER)
- *   hard = max(effectiveWindow - HARD_BUFFER,              auto)   // hard degrades to auto for tiny windows
+ *   hard = min(window, max(effectiveWindow - HARD_BUFFER,  auto + HARD_BUFFER))
  *
  * Small windows (where the absolute branch goes negative) automatically
  * fall back to the proportional branch. Large windows are dominated by
@@ -144,7 +144,10 @@ export function computeThresholds(window: number): CompactionThresholds {
   const warn = Math.max((DEFAULT_PCT - WARN_PCT_OFFSET) * window, absWarn);
 
   const rawHard = effectiveWindow - HARD_BUFFER;
-  const hard = Math.max(rawHard, auto);
+  // Guarantee hard > auto so compaction doesn't wait until the last moment.
+  // For tiny/zero windows where auto is already at the proportional floor,
+  // clamp hard to the window itself so it never exceeds the actual limit.
+  const hard = Math.min(window, Math.max(rawHard, auto + HARD_BUFFER));
 
   return { warn, auto, hard, effectiveWindow };
 }


### PR DESCRIPTION
## What this PR does

Ensures the hard compaction threshold is always strictly greater than the auto threshold. Previously, on medium-sized context windows (roughly below 110K tokens), hard degraded to equal auto, leaving no gap between the two tiers. The fix changes the hard calculation from `max(rawHard, auto)` to `min(window, max(rawHard, auto + HARD_BUFFER))`, guaranteeing at least a 3,000-token gap.

## Why it's needed

When hard equals auto, the hard-tier rescue path — which force-triggers compaction to prevent context window saturation — never fires independently. Compaction only triggers at the very last moment with no safety margin. For a 60K context window, both auto and hard were 42,000 tokens; now auto stays at 42,000 and hard moves to 45,000, giving the rescue path room to act.

## Reviewer Test Plan

### How to verify

1. Set `contextWindowSize: 60000` in `~/.qwen/settings.json` under your model provider entry.
2. Start the CLI (`npm run dev`), send any message, then run `/context`.
3. Confirm that Hard threshold (45,000) is strictly greater than Auto threshold (42,000).
4. Repeat with the default large window (e.g. 200K) and confirm thresholds are unchanged (auto=167K, hard=177K).

### Evidence (Before & After)
**Before:**
<img width="786" height="455" alt="截屏2026-06-10 16 41 37" src="https://github.com/user-attachments/assets/fceae500-167a-41dc-86ec-c73683197eba" />


**After:**
<img width="778" height="467" alt="截屏2026-06-10 16 41 09" src="https://github.com/user-attachments/assets/6b9a5d6d-99af-4d6c-a40a-d7f44016dd77" />


### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  ⚠️   |
|  🐧 Linux  |  ⚠️   |

### Environment (optional)

Unit tests via `npx vitest run` in `packages/core` and `packages/cli`. Manual verification via `npm run dev` + `/context`.

## Risk & Scope

- Main risk or tradeoff: Hard threshold now exceeds the effective window on very small windows (e.g. 10K), clamped to `window` itself — acceptable since hard is a last-resort trigger.
- Not validated / out of scope: No integration test changes; compaction behavior itself is not modified, only the trigger threshold.
- Breaking changes / migration notes: None.

## Linked Issues

Closes #4945

<details>
<summary>中文说明</summary>

## 做了什么

确保 hard 压缩阈值始终严格大于 auto 阈值。此前在中等大小的上下文窗口（大约 110K 以下）上，hard 会退化为与 auto 相同的值，两个层级之间没有间距。修复将 hard 的计算从 `max(rawHard, auto)` 改为 `min(window, max(rawHard, auto + HARD_BUFFER))`，保证至少有 3,000 token 的间距。

## 为什么需要

当 hard 等于 auto 时，hard 层级的救援路径（强制触发压缩以防止上下文窗口饱和）永远不会独立触发。压缩只在最后一刻才触发，没有安全余量。对于 60K 上下文窗口，之前 auto 和 hard 都是 42,000 token；现在 auto 保持 42,000，hard 变为 45,000，给救援路径留出了空间。

## 审查测试计划

1. 在 `~/.qwen/settings.json` 的 model provider 配置中设置 `contextWindowSize: 60000`。
2. 启动 CLI（`npm run dev`），发送任意消息，然后执行 `/context`。
3. 确认 Hard threshold（45,000）严格大于 Auto threshold（42,000）。
4. 使用默认大窗口（如 200K）重复测试，确认阈值不变（auto=167K，hard=177K）。

## 风险与范围

- 主要风险：极小窗口（如 10K）hard 阈值会超过 effective window，被 clamp 到 window 本身——可接受，因为 hard 是最后手段。
- 未验证/不在范围内：无集成测试变更；压缩行为本身未修改，只调整了触发阈值。
- 破坏性变更：无。

## 关联 Issue

Closes #4945

</details>