### PR TITLE
fix(core): add qwen3.7-plus to Coding Plan model list

### DIFF
--- a/packages/core/src/providers/presets/alibaba-coding-plan.ts
+++ b/packages/core/src/providers/presets/alibaba-coding-plan.ts
@@ -32,6 +32,7 @@ const MODELSTUDIO_MODELS: ModelSpec[] = [
     enableThinking: true,
     modalities: { image: true, video: true },
   },
+  { id: 'qwen3.7-plus', contextWindowSize: 1000000, enableThinking: true },
   { id: 'glm-5', contextWindowSize: 202752, enableThinking: true },
   {
     id: 'kimi-k2.5',

--- a/packages/vscode-ide-companion/src/services/subscriptionPlanDefinitions.ts
+++ b/packages/vscode-ide-companion/src/services/subscriptionPlanDefinitions.ts
@@ -93,6 +93,7 @@ const ALIBABA_SUBSCRIPTION_MODELS = [
     contextWindowSize: 1000000,
     enableThinking: true,
   },
+  { id: 'qwen3.7-plus', contextWindowSize: 1000000, enableThinking: true },
   { id: 'glm-5', contextWindowSize: 202752, enableThinking: true },
   { id: 'kimi-k2.5', contextWindowSize: 262144, enableThinking: true },
   { id: 'MiniMax-M2.5', contextWindowSize: 196608, enableThinking: true },


### PR DESCRIPTION
## Problem

The `qwen3.7-plus` model is missing from the Coding Plan provider model list. Users get this error when trying to switch:

```
Model 'qwen3.7-plus' is not available for auth type 'openai'.
Available models for 'openai': qwen3.5-plus, qwen3.6-plus, glm-5, kimi-k2.5, ...
```

## Root Cause

Two preset files define the Coding Plan model list but are missing `qwen3.7-plus`:

- `packages/core/src/providers/presets/alibaba-coding-plan.ts` — `MODELSTUDIO_MODELS`
- `packages/vscode-ide-companion/src/services/subscriptionPlanDefinitions.ts` — `ALIBABA_SUBSCRIPTION_MODELS`

The code comment says "keep in sync" between these files, but they have drifted out of sync. The Standard API Key provider (`alibaba-standard.ts`) already has `qwen3.7-plus`, confirming backend support.

## Fix

Add `{ id: 'qwen3.7-plus', contextWindowSize: 1000000, enableThinking: true }` to both preset arrays.

## Verification

- Build passes
- Typecheck passes
- Verified on official website that Coding Plan supports qwen3.7-plus

Fixes #4904
