### PR TITLE
fix(serve): isolate per-session stats in daemon mode

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -549,6 +549,7 @@ class QwenAgent implements Agent {
     }
 
     this.mcpPool?.releaseSession(sessionId);
+    uiTelemetryService.removeSession(sessionId);
     this.sessions.delete(sessionId);
   }
 
@@ -2001,8 +2002,7 @@ class QwenAgent implements Agent {
   private buildSessionStatsStatus(sessionId: string): ServeSessionStatsStatus {
     const session = this.sessionOrThrow(sessionId);
     const config = session.getConfig();
-    // TODO: uiTelemetryService is process-wide; multi-session stats are cumulative
-    const metrics = uiTelemetryService.getMetrics();
+    const metrics = uiTelemetryService.getMetricsForSession(sessionId);
     const now = Date.now();
     const createdAt = session.getCreatedAt();
 

--- a/packages/cli/src/nonInteractiveCliCommands.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.ts
@@ -319,7 +319,7 @@ export const handleSlashCommand = async (
   const sessionStats: SessionStatsState = {
     sessionId: config?.getSessionId(),
     sessionStartTime: new Date(),
-    metrics: uiTelemetryService.getMetrics(),
+    metrics: config ? uiTelemetryService.getMetricsForSession(config.getSessionId()) : uiTelemetryService.getMetrics(),
     lastPromptTokenCount: 0,
     promptCount: 1,
   };

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -184,6 +184,7 @@ const mockUiTelemetryService = vi.hoisted(() => ({
   setLastPromptTokenCount: vi.fn(),
   getLastPromptTokenCount: vi.fn(),
   reset: vi.fn(),
+  resetSession: vi.fn(),
   addEvent: vi.fn(),
 }));
 vi.mock('../telemetry/tracer.js', () => ({

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -183,6 +183,7 @@ vi.mock('../utils/generateContentResponseUtilities', () => ({
 const mockUiTelemetryService = vi.hoisted(() => ({
   setLastPromptTokenCount: vi.fn(),
   getLastPromptTokenCount: vi.fn(),
+  setLastCachedContentTokenCount: vi.fn(),
   reset: vi.fn(),
   resetSession: vi.fn(),
   addEvent: vi.fn(),

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -223,7 +223,7 @@ export class GeminiClient {
     // Check if we're resuming from a previous session
     const resumedSessionData = this.config.getResumedSessionData();
     if (resumedSessionData) {
-      replayUiTelemetryFromConversation(resumedSessionData.conversation);
+      replayUiTelemetryFromConversation(resumedSessionData.conversation, this.config.getSessionId());
       // Convert resumed session to API history format
       // Each ChatRecord's message field is already a Content object
       const resumedHistory = buildApiHistoryFromConversation(

--- a/packages/core/src/followup/suggestionGenerator.ts
+++ b/packages/core/src/followup/suggestionGenerator.ts
@@ -168,6 +168,7 @@ async function generateViaForkedQuery(
   // Report usage to session stats
   if (result.usage) {
     reportSuggestionUsage(
+      config,
       model,
       {
         promptTokenCount: result.usage.inputTokens,
@@ -226,7 +227,7 @@ async function generateViaBaseLlm(
 
   // Report usage to session stats so /stats tracks suggestion model tokens
   if (result.usage) {
-    reportSuggestionUsage(model, result.usage, durationMs);
+    reportSuggestionUsage(config, model, result.usage, durationMs);
   }
 
   const text = result.text;
@@ -351,6 +352,7 @@ export function shouldFilterSuggestion(suggestion: string): boolean {
  * Report suggestion API usage to the UI telemetry service so it appears in /stats.
  */
 function reportSuggestionUsage(
+  config: Config,
   model: string,
   usage: {
     promptTokenCount?: number;
@@ -375,9 +377,8 @@ function reportSuggestionUsage(
       thoughtsTokenCount: usage.thoughtsTokenCount ?? 0,
     },
   );
-  // Override event.name to match UiEvent type (UiTelemetryService switch)
   const uiEvent = Object.assign(event, {
     'event.name': EVENT_API_RESPONSE as typeof EVENT_API_RESPONSE,
   });
-  uiTelemetryService.addEvent(uiEvent);
+  uiTelemetryService.addEvent(uiEvent, config.getSessionId());
 }

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -1307,8 +1307,13 @@ export function buildApiHistoryFromConversation(
  */
 export function replayUiTelemetryFromConversation(
   conversation: ConversationRecord,
+  sessionId?: string,
 ): void {
-  uiTelemetryService.reset();
+  if (sessionId) {
+    uiTelemetryService.resetSession(sessionId);
+  } else {
+    uiTelemetryService.reset();
+  }
 
   for (const record of conversation.messages) {
     if (record.type !== 'system' || record.subtype !== 'ui_telemetry') {
@@ -1319,7 +1324,7 @@ export function replayUiTelemetryFromConversation(
       | undefined;
     const uiEvent = payload?.uiEvent;
     if (uiEvent) {
-      uiTelemetryService.addEvent(uiEvent);
+      uiTelemetryService.addEvent(uiEvent, sessionId);
     }
   }
 

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -1311,6 +1311,8 @@ export function replayUiTelemetryFromConversation(
 ): void {
   if (sessionId) {
     uiTelemetryService.resetSession(sessionId);
+    uiTelemetryService.setLastPromptTokenCount(0);
+    uiTelemetryService.setLastCachedContentTokenCount(0);
   } else {
     uiTelemetryService.reset();
   }
@@ -1374,7 +1376,9 @@ export async function computeUniqueBranchTitle(
   sessionService: SessionService,
 ): Promise<string> {
   const maxSuffixLen = ' (Branch 1234567890123)'.length;
-  const trimmed = baseName.trim().slice(0, SESSION_TITLE_MAX_LENGTH - maxSuffixLen);
+  const trimmed = baseName
+    .trim()
+    .slice(0, SESSION_TITLE_MAX_LENGTH - maxSuffixLen);
   const taken = new Set(
     (await sessionService.findSessionTitlesByPrefix(`${trimmed} (Branch`)).map(
       (t) => t.toLowerCase().trim(),

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -1311,8 +1311,6 @@ export function replayUiTelemetryFromConversation(
 ): void {
   if (sessionId) {
     uiTelemetryService.resetSession(sessionId);
-    uiTelemetryService.setLastPromptTokenCount(0);
-    uiTelemetryService.setLastCachedContentTokenCount(0);
   } else {
     uiTelemetryService.reset();
   }

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -358,7 +358,7 @@ describe('loggers', () => {
         ...event,
         'event.name': EVENT_API_RESPONSE,
         'event.timestamp': '2025-01-01T00:00:00.000Z',
-      });
+      }, 'test-session-id');
     });
   });
 
@@ -782,7 +782,7 @@ describe('loggers', () => {
         ...event,
         'event.name': EVENT_TOOL_CALL,
         'event.timestamp': '2025-01-01T00:00:00.000Z',
-      });
+      }, 'test-session-id');
     });
     it('should log a tool call with a reject decision', () => {
       const call: ErroredToolCall = {
@@ -855,7 +855,7 @@ describe('loggers', () => {
         ...event,
         'event.name': EVENT_TOOL_CALL,
         'event.timestamp': '2025-01-01T00:00:00.000Z',
-      });
+      }, 'test-session-id');
     });
 
     it('should log a tool call with a modify decision', () => {
@@ -931,7 +931,7 @@ describe('loggers', () => {
         ...event,
         'event.name': EVENT_TOOL_CALL,
         'event.timestamp': '2025-01-01T00:00:00.000Z',
-      });
+      }, 'test-session-id');
     });
 
     it('should log a tool call without a decision', () => {
@@ -1006,7 +1006,7 @@ describe('loggers', () => {
         ...event,
         'event.name': EVENT_TOOL_CALL,
         'event.timestamp': '2025-01-01T00:00:00.000Z',
-      });
+      }, 'test-session-id');
     });
 
     it('should log a failed tool call with an error', () => {
@@ -1082,7 +1082,7 @@ describe('loggers', () => {
         ...event,
         'event.name': EVENT_TOOL_CALL,
         'event.timestamp': '2025-01-01T00:00:00.000Z',
-      });
+      }, 'test-session-id');
     });
 
     it('should log a tool call with mcp_server_name for MCP tools', () => {

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -223,7 +223,7 @@ export function logToolCall(config: Config, event: ToolCallEvent): void {
     'event.name': EVENT_TOOL_CALL,
     'event.timestamp': new Date().toISOString(),
   } as UiEvent;
-  uiTelemetryService.addEvent(uiEvent);
+  uiTelemetryService.addEvent(uiEvent, config.getSessionId());
   if (!isInternalPromptId(event.prompt_id)) {
     config.getChatRecordingService()?.recordUiTelemetryEvent(uiEvent);
   }
@@ -393,7 +393,7 @@ export function logApiError(config: Config, event: ApiErrorEvent): void {
     'event.name': EVENT_API_ERROR,
     'event.timestamp': new Date().toISOString(),
   } as UiEvent;
-  uiTelemetryService.addEvent(uiEvent);
+  uiTelemetryService.addEvent(uiEvent, config.getSessionId());
   if (!isInternalPromptId(event.prompt_id)) {
     config.getChatRecordingService()?.recordUiTelemetryEvent(uiEvent);
   }
@@ -436,7 +436,7 @@ export function logApiCancel(config: Config, event: ApiCancelEvent): void {
     'event.name': EVENT_API_CANCEL,
     'event.timestamp': new Date().toISOString(),
   } as UiEvent;
-  uiTelemetryService.addEvent(uiEvent);
+  uiTelemetryService.addEvent(uiEvent, config.getSessionId());
   QwenLogger.getInstance(config)?.logApiCancelEvent(event);
   if (!isTelemetrySdkInitialized()) return;
 
@@ -462,7 +462,7 @@ export function logApiResponse(config: Config, event: ApiResponseEvent): void {
     'event.name': EVENT_API_RESPONSE,
     'event.timestamp': new Date().toISOString(),
   } as UiEvent;
-  uiTelemetryService.addEvent(uiEvent);
+  uiTelemetryService.addEvent(uiEvent, config.getSessionId());
   if (!isInternalPromptId(event.prompt_id)) {
     config.getChatRecordingService()?.recordUiTelemetryEvent(uiEvent);
   }
@@ -983,7 +983,7 @@ export function logUserFeedback(
     'event.name': EVENT_USER_FEEDBACK,
     'event.timestamp': new Date().toISOString(),
   } as UiEvent;
-  uiTelemetryService.addEvent(uiEvent);
+  uiTelemetryService.addEvent(uiEvent, config.getSessionId());
   config.getChatRecordingService()?.recordUiTelemetryEvent(uiEvent);
   QwenLogger.getInstance(config)?.logUserFeedbackEvent(event);
   if (!isTelemetrySdkInitialized()) return;

--- a/packages/core/src/telemetry/uiTelemetry.test.ts
+++ b/packages/core/src/telemetry/uiTelemetry.test.ts
@@ -971,4 +971,131 @@ describe('UiTelemetryService', () => {
       expect(metrics.files.totalLinesRemoved).toBe(0);
     });
   });
+
+  describe('Per-Session Metrics Isolation', () => {
+    const SESSION_A = 'session-aaa';
+    const SESSION_B = 'session-bbb';
+
+    const makeApiEvent = (model: string, inputTokens: number) =>
+      ({
+        'event.name': EVENT_API_RESPONSE,
+        model,
+        duration_ms: 100,
+        input_token_count: inputTokens,
+        output_token_count: 10,
+        total_token_count: inputTokens + 10,
+        cached_content_token_count: 0,
+        thoughts_token_count: 0,
+      }) as ApiResponseEvent & { 'event.name': typeof EVENT_API_RESPONSE };
+
+    const makeToolEvent = (name: string) =>
+      ({
+        'event.name': EVENT_TOOL_CALL,
+        function_name: name,
+        duration_ms: 50,
+        success: true,
+        decision: ToolCallDecision.AUTO_ACCEPT,
+        prompt_id: 'p1',
+      }) as ToolCallEvent & { 'event.name': typeof EVENT_TOOL_CALL };
+
+    it('should isolate metrics by sessionId', () => {
+      service.addEvent(makeApiEvent('model-a', 100), SESSION_A);
+      service.addEvent(makeApiEvent('model-b', 200), SESSION_B);
+
+      const metricsA = service.getMetricsForSession(SESSION_A);
+      const metricsB = service.getMetricsForSession(SESSION_B);
+
+      expect(metricsA.models['model-a']?.tokens.prompt).toBe(100);
+      expect(metricsA.models['model-b']).toBeUndefined();
+
+      expect(metricsB.models['model-b']?.tokens.prompt).toBe(200);
+      expect(metricsB.models['model-a']).toBeUndefined();
+    });
+
+    it('should still accumulate to global metrics', () => {
+      service.addEvent(makeApiEvent('model-x', 100), SESSION_A);
+      service.addEvent(makeApiEvent('model-x', 200), SESSION_B);
+
+      const global = service.getMetrics();
+      expect(global.models['model-x']?.tokens.prompt).toBe(300);
+    });
+
+    it('should return empty metrics for unknown session', () => {
+      const metrics = service.getMetricsForSession('unknown');
+      expect(metrics.models).toEqual({});
+      expect(metrics.tools.totalCalls).toBe(0);
+    });
+
+    it('should handle events without sessionId (global only)', () => {
+      service.addEvent(makeApiEvent('model-z', 50));
+
+      const global = service.getMetrics();
+      expect(global.models['model-z']?.tokens.prompt).toBe(50);
+
+      const sessionMetrics = service.getMetricsForSession('any-session');
+      expect(sessionMetrics.models).toEqual({});
+    });
+
+    it('resetSession should clear only that session', () => {
+      service.addEvent(makeApiEvent('m', 100), SESSION_A);
+      service.addEvent(makeApiEvent('m', 200), SESSION_B);
+
+      service.resetSession(SESSION_A);
+
+      const metricsA = service.getMetricsForSession(SESSION_A);
+      const metricsB = service.getMetricsForSession(SESSION_B);
+
+      expect(metricsA.models).toEqual({});
+      expect(metricsB.models['m']?.tokens.prompt).toBe(200);
+
+      // Global should not be affected
+      const global = service.getMetrics();
+      expect(global.models['m']?.tokens.prompt).toBe(300);
+    });
+
+    it('removeSession should prevent late events from recreating bucket', () => {
+      service.addEvent(makeApiEvent('m', 100), SESSION_A);
+      service.removeSession(SESSION_A);
+
+      // Late event after removal
+      service.addEvent(makeApiEvent('m', 50), SESSION_A);
+
+      // Session bucket should not be recreated
+      const metricsA = service.getMetricsForSession(SESSION_A);
+      expect(metricsA.models).toEqual({});
+
+      // But global should still accumulate
+      const global = service.getMetrics();
+      expect(global.models['m']?.tokens.prompt).toBe(150);
+    });
+
+    it('resetSession should re-enable a closed session', () => {
+      service.addEvent(makeApiEvent('m', 100), SESSION_A);
+      service.removeSession(SESSION_A);
+
+      // Re-open the session
+      service.resetSession(SESSION_A);
+      service.addEvent(makeApiEvent('m', 50), SESSION_A);
+
+      const metricsA = service.getMetricsForSession(SESSION_A);
+      expect(metricsA.models['m']?.tokens.prompt).toBe(50);
+    });
+
+    it('should isolate tool call metrics by session', () => {
+      service.addEvent(makeToolEvent('Read'), SESSION_A);
+      service.addEvent(makeToolEvent('Write'), SESSION_B);
+      service.addEvent(makeToolEvent('Read'), SESSION_B);
+
+      const metricsA = service.getMetricsForSession(SESSION_A);
+      const metricsB = service.getMetricsForSession(SESSION_B);
+
+      expect(metricsA.tools.totalCalls).toBe(1);
+      expect(metricsA.tools.byName['Read']?.count).toBe(1);
+      expect(metricsA.tools.byName['Write']).toBeUndefined();
+
+      expect(metricsB.tools.totalCalls).toBe(2);
+      expect(metricsB.tools.byName['Write']?.count).toBe(1);
+      expect(metricsB.tools.byName['Read']?.count).toBe(1);
+    });
+  });
 });

--- a/packages/core/src/telemetry/uiTelemetry.test.ts
+++ b/packages/core/src/telemetry/uiTelemetry.test.ts
@@ -1097,5 +1097,50 @@ describe('UiTelemetryService', () => {
       expect(metricsB.tools.byName['Write']?.count).toBe(1);
       expect(metricsB.tools.byName['Read']?.count).toBe(1);
     });
+
+    it('resetSession should not clear global metrics (replay scenario)', () => {
+      // Simulate: session A active, session B being resumed
+      service.addEvent(makeApiEvent('m', 100), SESSION_A);
+      service.addEvent(makeApiEvent('m', 200), SESSION_B);
+
+      // Resume session B: resetSession only clears B's bucket
+      service.resetSession(SESSION_B);
+
+      // Session A untouched
+      const metricsA = service.getMetricsForSession(SESSION_A);
+      expect(metricsA.models['m']?.tokens.prompt).toBe(100);
+
+      // Session B cleared
+      const metricsB = service.getMetricsForSession(SESSION_B);
+      expect(metricsB.models).toEqual({});
+
+      // Global NOT cleared (still has both sessions' original data)
+      const global = service.getMetrics();
+      expect(global.models['m']?.tokens.prompt).toBe(300);
+
+      // Replay events into session B
+      service.addEvent(makeApiEvent('m', 50), SESSION_B);
+
+      // Session B has only replayed data
+      const metricsB2 = service.getMetricsForSession(SESSION_B);
+      expect(metricsB2.models['m']?.tokens.prompt).toBe(50);
+
+      // Global accumulated the replay too
+      const global2 = service.getMetrics();
+      expect(global2.models['m']?.tokens.prompt).toBe(350);
+    });
+
+    it('#closedSessions should be bounded', () => {
+      // Add more than MAX_CLOSED_SESSIONS
+      for (let i = 0; i < 1005; i++) {
+        service.addEvent(makeApiEvent('m', 1), `session-${i}`);
+        service.removeSession(`session-${i}`);
+      }
+      // Late event to oldest session should now create a new bucket
+      // (oldest was evicted from closedSessions)
+      service.addEvent(makeApiEvent('m', 99), 'session-0');
+      const metrics = service.getMetricsForSession('session-0');
+      expect(metrics.models['m']?.tokens.prompt).toBe(99);
+    });
   });
 });

--- a/packages/core/src/telemetry/uiTelemetry.ts
+++ b/packages/core/src/telemetry/uiTelemetry.ts
@@ -144,23 +144,19 @@ const createInitialMetrics = (): SessionMetrics => ({
 
 export class UiTelemetryService extends EventEmitter {
   #metrics: SessionMetrics = createInitialMetrics();
+  #sessionMetrics: Map<string, SessionMetrics> = new Map();
+  #closedSessions: Set<string> = new Set();
   #lastPromptTokenCount = 0;
   #lastCachedContentTokenCount = 0;
 
-  addEvent(event: UiEvent) {
-    switch (event['event.name']) {
-      case EVENT_API_RESPONSE:
-        this.processApiResponse(event);
-        break;
-      case EVENT_API_ERROR:
-        this.processApiError(event);
-        break;
-      case EVENT_TOOL_CALL:
-        this.processToolCall(event);
-        break;
-      default:
-        // We should not emit update for any other event metric.
-        return;
+  addEvent(event: UiEvent, sessionId?: string) {
+    if (!this.#accumulateEvent(this.#metrics, event)) return;
+
+    if (sessionId && !this.#closedSessions.has(sessionId)) {
+      if (!this.#sessionMetrics.has(sessionId)) {
+        this.#sessionMetrics.set(sessionId, createInitialMetrics());
+      }
+      this.#accumulateEvent(this.#sessionMetrics.get(sessionId)!, event);
     }
 
     this.emit('update', {
@@ -171,6 +167,10 @@ export class UiTelemetryService extends EventEmitter {
 
   getMetrics(): SessionMetrics {
     return this.#metrics;
+  }
+
+  getMetricsForSession(sessionId: string): SessionMetrics {
+    return this.#sessionMetrics.get(sessionId) ?? createInitialMetrics();
   }
 
   getLastPromptTokenCount(): number {
@@ -206,26 +206,41 @@ export class UiTelemetryService extends EventEmitter {
     });
   }
 
-  private getOrCreateModelMetrics(modelName: string): ModelMetrics {
-    if (!this.#metrics.models[modelName]) {
-      this.#metrics.models[modelName] = createInitialModelMetrics();
-    }
-    return this.#metrics.models[modelName];
+  resetSession(sessionId: string): void {
+    this.#sessionMetrics.set(sessionId, createInitialMetrics());
+    this.#closedSessions.delete(sessionId);
   }
 
-  private getOrCreateSourceMetrics(
-    modelMetrics: ModelMetrics,
-    source: string,
-  ): ModelMetricsCore {
-    if (!modelMetrics.bySource[source]) {
-      modelMetrics.bySource[source] = createInitialModelMetricsCore();
-    }
-    return modelMetrics.bySource[source];
+  removeSession(sessionId: string): void {
+    this.#sessionMetrics.delete(sessionId);
+    this.#closedSessions.add(sessionId);
   }
 
-  private processApiResponse(event: ApiResponseEvent) {
-    const modelMetrics = this.getOrCreateModelMetrics(event.model);
-    const sourceMetrics = this.getOrCreateSourceMetrics(
+  #accumulateEvent(metrics: SessionMetrics, event: UiEvent): boolean {
+    switch (event['event.name']) {
+      case EVENT_API_RESPONSE:
+        this.#accumulateApiResponse(metrics, event);
+        return true;
+      case EVENT_API_ERROR:
+        this.#accumulateApiError(metrics, event);
+        return true;
+      case EVENT_TOOL_CALL:
+        this.#accumulateToolCall(metrics, event);
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  #accumulateApiResponse(
+    metrics: SessionMetrics,
+    event: ApiResponseEvent,
+  ): void {
+    const modelMetrics = this.#getOrCreateModelMetrics(
+      metrics,
+      event.model,
+    );
+    const sourceMetrics = this.#getOrCreateSourceMetrics(
       modelMetrics,
       event.subagent_name ?? MAIN_SOURCE,
     );
@@ -242,9 +257,15 @@ export class UiTelemetryService extends EventEmitter {
     }
   }
 
-  private processApiError(event: ApiErrorEvent) {
-    const modelMetrics = this.getOrCreateModelMetrics(event.model);
-    const sourceMetrics = this.getOrCreateSourceMetrics(
+  #accumulateApiError(
+    metrics: SessionMetrics,
+    event: ApiErrorEvent,
+  ): void {
+    const modelMetrics = this.#getOrCreateModelMetrics(
+      metrics,
+      event.model,
+    );
+    const sourceMetrics = this.#getOrCreateSourceMetrics(
       modelMetrics,
       event.subagent_name ?? MAIN_SOURCE,
     );
@@ -256,8 +277,11 @@ export class UiTelemetryService extends EventEmitter {
     }
   }
 
-  private processToolCall(event: ToolCallEvent) {
-    const { tools, files } = this.#metrics;
+  #accumulateToolCall(
+    metrics: SessionMetrics,
+    event: ToolCallEvent,
+  ): void {
+    const { tools, files } = metrics;
     tools.totalCalls++;
     tools.totalDurationMs += event.duration_ms;
 
@@ -296,7 +320,6 @@ export class UiTelemetryService extends EventEmitter {
       toolStats.decisions[event.decision]++;
     }
 
-    // Aggregate line count data from metadata
     if (event.metadata) {
       if (event.metadata['model_added_lines'] !== undefined) {
         files.totalLinesAdded += event.metadata['model_added_lines'];
@@ -305,6 +328,26 @@ export class UiTelemetryService extends EventEmitter {
         files.totalLinesRemoved += event.metadata['model_removed_lines'];
       }
     }
+  }
+
+  #getOrCreateModelMetrics(
+    metrics: SessionMetrics,
+    modelName: string,
+  ): ModelMetrics {
+    if (!metrics.models[modelName]) {
+      metrics.models[modelName] = createInitialModelMetrics();
+    }
+    return metrics.models[modelName];
+  }
+
+  #getOrCreateSourceMetrics(
+    modelMetrics: ModelMetrics,
+    source: string,
+  ): ModelMetricsCore {
+    if (!modelMetrics.bySource[source]) {
+      modelMetrics.bySource[source] = createInitialModelMetricsCore();
+    }
+    return modelMetrics.bySource[source];
   }
 }
 

--- a/packages/core/src/telemetry/uiTelemetry.ts
+++ b/packages/core/src/telemetry/uiTelemetry.ts
@@ -199,6 +199,8 @@ export class UiTelemetryService extends EventEmitter {
    */
   reset(): void {
     this.#metrics = createInitialMetrics();
+    this.#sessionMetrics.clear();
+    this.#closedSessions.clear();
     this.#lastPromptTokenCount = 0;
     this.#lastCachedContentTokenCount = 0;
     this.emit('update', {
@@ -241,10 +243,7 @@ export class UiTelemetryService extends EventEmitter {
     metrics: SessionMetrics,
     event: ApiResponseEvent,
   ): void {
-    const modelMetrics = this.#getOrCreateModelMetrics(
-      metrics,
-      event.model,
-    );
+    const modelMetrics = this.#getOrCreateModelMetrics(metrics, event.model);
     const sourceMetrics = this.#getOrCreateSourceMetrics(
       modelMetrics,
       event.subagent_name ?? MAIN_SOURCE,
@@ -262,14 +261,8 @@ export class UiTelemetryService extends EventEmitter {
     }
   }
 
-  #accumulateApiError(
-    metrics: SessionMetrics,
-    event: ApiErrorEvent,
-  ): void {
-    const modelMetrics = this.#getOrCreateModelMetrics(
-      metrics,
-      event.model,
-    );
+  #accumulateApiError(metrics: SessionMetrics, event: ApiErrorEvent): void {
+    const modelMetrics = this.#getOrCreateModelMetrics(metrics, event.model);
     const sourceMetrics = this.#getOrCreateSourceMetrics(
       modelMetrics,
       event.subagent_name ?? MAIN_SOURCE,
@@ -282,10 +275,7 @@ export class UiTelemetryService extends EventEmitter {
     }
   }
 
-  #accumulateToolCall(
-    metrics: SessionMetrics,
-    event: ToolCallEvent,
-  ): void {
+  #accumulateToolCall(metrics: SessionMetrics, event: ToolCallEvent): void {
     const { tools, files } = metrics;
     tools.totalCalls++;
     tools.totalDurationMs += event.duration_ms;

--- a/packages/core/src/telemetry/uiTelemetry.ts
+++ b/packages/core/src/telemetry/uiTelemetry.ts
@@ -143,6 +143,7 @@ const createInitialMetrics = (): SessionMetrics => ({
 });
 
 export class UiTelemetryService extends EventEmitter {
+  static readonly #MAX_CLOSED_SESSIONS = 1000;
   #metrics: SessionMetrics = createInitialMetrics();
   #sessionMetrics: Map<string, SessionMetrics> = new Map();
   #closedSessions: Set<string> = new Set();
@@ -214,6 +215,10 @@ export class UiTelemetryService extends EventEmitter {
   removeSession(sessionId: string): void {
     this.#sessionMetrics.delete(sessionId);
     this.#closedSessions.add(sessionId);
+    if (this.#closedSessions.size > UiTelemetryService.#MAX_CLOSED_SESSIONS) {
+      const oldest = this.#closedSessions.values().next().value;
+      if (oldest) this.#closedSessions.delete(oldest);
+    }
   }
 
   #accumulateEvent(metrics: SessionMetrics, event: UiEvent): boolean {


### PR DESCRIPTION
## What this PR does

Fix `GET /session/:id/stats` to return per-session metrics instead of process-wide cumulative data in daemon mode. Adds a `Map<sessionId, SessionMetrics>` dual-write pattern inside `UiTelemetryService` so each session's API calls, tool calls, and file metrics are tracked independently.

## Why it's needed

In daemon mode, multiple sessions share the same process and the same `uiTelemetryService` singleton. `buildSessionStatsStatus()` was calling `uiTelemetryService.getMetrics()` which returns the global cumulative metrics — meaning session A's stats included session B's token counts. The code had an explicit TODO acknowledging this bug.

## Reviewer Test Plan

### How to verify

1. Start daemon: `qwen serve --port 7779`
2. Create two sessions:
   ```bash
   SESSION1=$(curl -s -X POST localhost:7779/session -H 'Content-Type: application/json' -d '{"cwd":"'$(pwd)'"}' | jq -r .sessionId)
   SESSION2=$(curl -s -X POST localhost:7779/session -H 'Content-Type: application/json' -d '{"cwd":"'$(pwd)'"}' | jq -r .sessionId)
   ```
3. Send a prompt to session 1 only:
   ```bash
   curl -X POST localhost:7779/session/$SESSION1/prompt -H 'Content-Type: application/json' -d '{"prompt":[{"type":"text","text":"hello"}]}'
   ```
4. Query stats for both sessions:
   ```bash
   curl localhost:7779/session/$SESSION1/stats | jq .models
   curl localhost:7779/session/$SESSION2/stats | jq .models
   ```
5. **Expected**: Session 1 shows token usage, Session 2 shows empty `models: {}`
6. **Before this fix**: Both sessions would show the same cumulative token counts

### Evidence (Before & After)

N/A — behavioral fix, no UI changes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

## Risk & Scope

- **Low risk**: Dual-write pattern preserves existing global metrics for CLI consumers. All existing `getMetrics()` callers continue to work unchanged.
- **Backward compatible**: `addEvent(event)` without sessionId still updates only the global metrics (CLI single-session mode).
- **Not in scope**: `lastPromptTokenCount` per-session (separate concern — chat instances already track their own), `/clear` sessionId divergence (independent bug), `emit('update')` per-session (no daemon listeners).
- **Memory**: `#closedSessions` Set grows unbounded but each entry is a UUID (~130 bytes); daemon restarts clear it. Negligible for typical daemon lifetimes.

## Linked Issues

Fixes the TODO at `acpAgent.ts:2004`: "uiTelemetryService is process-wide; multi-session stats are cumulative"

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)