### PR TITLE
feat(web-shell): make context usage mouse-reachable and survive reloads

### DIFF
--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -1116,6 +1116,36 @@ export function App({
     handleSetMode(next);
   }, [currentMode, handleSetMode]);
 
+  // Shared by the /context slash command and the status-bar context
+  // indicator. Echoes the command as a local user message first — that also
+  // makes the transcript follow the tail (MessageList Rule 4), so the panel
+  // is revealed even when the click comes while scrolled up.
+  const showContextUsage = useCallback(
+    (commandText: string, detail: boolean) => {
+      store.appendLocalUserMessage(commandText);
+      sessionActions
+        .getContextUsage({ detail })
+        .then((result) => {
+          store.dispatch([
+            {
+              type: 'status',
+              text: serializeContextUsageMessage(result),
+            },
+          ]);
+        })
+        .catch((error: unknown) => {
+          reportError(error, 'Failed to load context usage');
+        });
+    },
+    [store, sessionActions, reportError],
+  );
+
+  // Stable reference: this travels through the memoized MessageList →
+  // MessageItem chain, so an inline closure would defeat their memo.
+  const handleShowContextDetail = useCallback(() => {
+    showContextUsage('/context detail', true);
+  }, [showContextUsage]);
+
   const handleSubmit = useCallback(
     (text: string, images?: PromptImage[]) => {
       const promptBlocked = streamingStateRef.current !== 'idle';
@@ -1415,22 +1445,10 @@ export function App({
               contextArg === 'detail' ||
               contextArg === '-d'
             ) {
-              store.appendLocalUserMessage(text);
-              sessionActions
-                .getContextUsage({
-                  detail: contextArg === 'detail' || contextArg === '-d',
-                })
-                .then((result) => {
-                  store.dispatch([
-                    {
-                      type: 'status',
-                      text: serializeContextUsageMessage(result),
-                    },
-                  ]);
-                })
-                .catch((error: unknown) => {
-                  reportError(error, 'Failed to load context usage');
-                });
+              showContextUsage(
+                text,
+                contextArg === 'detail' || contextArg === '-d',
+              );
               return true;
             }
           }
@@ -1718,6 +1736,7 @@ export function App({
       runVisibleRecap,
       runVisibleBtw,
       selectedLanguage,
+      showContextUsage,
       t,
       workspaceActions,
     ],
@@ -2082,6 +2101,7 @@ export function App({
                   messages={displayMessages}
                   pendingApproval={pendingApproval}
                   onConfirm={handleConfirm}
+                  onShowContextDetail={handleShowContextDetail}
                   catchingUp={connection.catchingUp}
                   workspaceCwd={connection.workspaceCwd || ''}
                   welcomeHeader={welcomeHeader}
@@ -2234,6 +2254,7 @@ export function App({
                   onSelectModel={() =>
                     setModelInlineMode((v) => (v ? null : 'main'))
                   }
+                  onShowContext={() => showContextUsage('/context', false)}
                 />
               ))}
 

--- a/packages/web-shell/client/components/MessageItem.tsx
+++ b/packages/web-shell/client/components/MessageItem.tsx
@@ -23,6 +23,8 @@ interface MessageItemProps {
     selectedOption: string,
     answers?: Record<string, string>,
   ) => void;
+  /** Run /context detail, exactly like typing it (context-usage panels). */
+  onShowContextDetail?: () => void;
   workspaceCwd?: string;
 }
 
@@ -30,6 +32,7 @@ export const MessageItem = memo(function MessageItem({
   message,
   pendingApproval,
   onConfirm,
+  onShowContextDetail,
   workspaceCwd,
 }: MessageItemProps) {
   switch (message.role) {
@@ -55,7 +58,11 @@ export const MessageItem = memo(function MessageItem({
       return <PlanMessage todos={message.todos} />;
     case 'system':
       return (
-        <SystemMessage content={message.content} variant={message.variant} />
+        <SystemMessage
+          content={message.content}
+          variant={message.variant}
+          onShowContextDetail={onShowContextDetail}
+        />
       );
     case 'user_shell':
       return (
@@ -98,6 +105,7 @@ function areMessageItemPropsEqual(
 ): boolean {
   if (prev.pendingApproval?.id !== next.pendingApproval?.id) return false;
   if (prev.onConfirm !== next.onConfirm) return false;
+  if (prev.onShowContextDetail !== next.onShowContextDetail) return false;
   if (prev.workspaceCwd !== next.workspaceCwd) return false;
   return areMessagesEqual(prev.message, next.message);
 }

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -28,6 +28,8 @@ interface MessageListProps {
     selectedOption: string,
     answers?: Record<string, string>,
   ) => void;
+  /** Run /context detail, exactly like typing it (context-usage panels). */
+  onShowContextDetail?: () => void;
   catchingUp?: boolean;
   welcomeHeader?: ReactNode;
   workspaceCwd?: string;
@@ -205,6 +207,7 @@ export function MessageList({
   messages,
   pendingApproval,
   onConfirm,
+  onShowContextDetail,
   catchingUp,
   welcomeHeader,
   workspaceCwd,
@@ -481,6 +484,7 @@ export function MessageList({
           message={item.message}
           pendingApproval={pendingApproval}
           onConfirm={onConfirm}
+          onShowContextDetail={onShowContextDetail}
           workspaceCwd={workspaceCwd}
         />
       );
@@ -495,6 +499,7 @@ export function MessageList({
       tailApprovalIndex,
       pendingApproval,
       onConfirm,
+      onShowContextDetail,
       headerOffset,
       displayItems,
       workspaceCwd,

--- a/packages/web-shell/client/components/StatusBar.module.css
+++ b/packages/web-shell/client/components/StatusBar.module.css
@@ -99,6 +99,24 @@
   color: var(--error-color);
 }
 
+.contextButton {
+  display: inline-flex;
+  align-items: center;
+  padding: 0;
+  margin: 0;
+  border: none;
+  background: none;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+.contextButton:hover .context,
+.contextButton:focus-visible .context {
+  color: var(--text-primary);
+  text-decoration: underline;
+}
+
 .context {
   font-size: 11px;
   color: var(--text-dimmed);

--- a/packages/web-shell/client/components/StatusBar.tsx
+++ b/packages/web-shell/client/components/StatusBar.tsx
@@ -29,12 +29,15 @@ interface StatusBarProps {
   onSelectMode: () => void;
   /** Open the model picker so the model can be chosen with the mouse. */
   onSelectModel: () => void;
+  /** Show the context-usage breakdown, exactly like typing /context. */
+  onShowContext: () => void;
 }
 
 export function StatusBar({
   escapeHint,
   onSelectMode,
   onSelectModel,
+  onShowContext,
 }: StatusBarProps) {
   const connection = useConnection();
   const connected = connection.status === 'connected';
@@ -102,9 +105,21 @@ export function StatusBar({
           </button>
         )}
         {contextWindow > 0 && tokenCount > 0 && (
-          <span className={styles.context}>
-            {t('status.contextUsed', { pct: pctDisplay })}
-          </span>
+          // Clicking the percentage runs the same flow as typing /context:
+          // it echoes the command and appends the usage breakdown to the
+          // transcript. No stopPropagation here — unlike the mode/model
+          // buttons this opens no picker, and if one is open the press
+          // should dismiss it like any other outside press.
+          <button
+            type="button"
+            className={styles.contextButton}
+            onClick={onShowContext}
+            title={t('contextUsage.title')}
+          >
+            <span className={styles.context}>
+              {t('status.contextUsed', { pct: pctDisplay })}
+            </span>
+          </button>
         )}
       </div>
     </div>

--- a/packages/web-shell/client/components/messages/ContextUsageMessage.module.css
+++ b/packages/web-shell/client/components/messages/ContextUsageMessage.module.css
@@ -108,6 +108,21 @@
   font-style: italic;
 }
 
+.detailCommand {
+  padding: 0;
+  margin: 0;
+  border: none;
+  background: none;
+  font: inherit;
+  color: var(--accent-color);
+  cursor: pointer;
+}
+
+.detailCommand:hover,
+.detailCommand:focus-visible {
+  text-decoration: underline;
+}
+
 .estimateHint {
   margin-bottom: 8px;
   color: var(--warning-color);

--- a/packages/web-shell/client/components/messages/ContextUsageMessage.tsx
+++ b/packages/web-shell/client/components/messages/ContextUsageMessage.tsx
@@ -118,6 +118,35 @@ function CategoryRow({
   );
 }
 
+const DETAIL_COMMAND = '/context detail';
+
+function DetailHint({
+  hint,
+  onShowDetail,
+}: {
+  hint: string;
+  onShowDetail?: () => void;
+}) {
+  // The clickable part is located by the literal command inside the
+  // translated hint, so a translation that drops it (or a missing
+  // callback) degrades to the plain text line.
+  const idx = onShowDetail ? hint.indexOf(DETAIL_COMMAND) : -1;
+  if (idx < 0) return <div className={styles.hint}>{hint}</div>;
+  return (
+    <div className={styles.hint}>
+      {hint.slice(0, idx)}
+      <button
+        type="button"
+        className={styles.detailCommand}
+        onClick={onShowDetail}
+      >
+        {DETAIL_COMMAND}
+      </button>
+      {hint.slice(idx + DETAIL_COMMAND.length)}
+    </div>
+  );
+}
+
 function DetailRow({
   name,
   tokens,
@@ -222,8 +251,11 @@ function SkillsSection({
 
 export function ContextUsageMessage({
   status,
+  onShowDetail,
 }: {
   status: DaemonSessionContextUsageStatus;
+  /** Run /context detail, exactly like typing it. */
+  onShowDetail?: () => void;
 }) {
   const { t } = useI18n();
   const { usage } = status;
@@ -387,7 +419,10 @@ export function ContextUsageMessage({
           />
         </>
       ) : (
-        <div className={styles.hint}>{t('contextUsage.detailHint')}</div>
+        <DetailHint
+          hint={t('contextUsage.detailHint')}
+          onShowDetail={onShowDetail}
+        />
       )}
     </div>
   );

--- a/packages/web-shell/client/components/messages/SystemMessage.tsx
+++ b/packages/web-shell/client/components/messages/SystemMessage.tsx
@@ -12,18 +12,24 @@ import styles from './SystemMessage.module.css';
 interface SystemMessageProps {
   content: string;
   variant: 'info' | 'error' | 'warning';
+  /** Run /context detail, exactly like typing it (context-usage panels). */
+  onShowContextDetail?: () => void;
 }
 
 export const SystemMessage = memo(function SystemMessage({
   content,
   variant,
+  onShowContextDetail,
 }: SystemMessageProps) {
   const contextUsage =
     variant === 'info' ? parseContextUsageMessage(content) : null;
   if (contextUsage) {
     return (
       <div className={styles.flushMessage}>
-        <ContextUsageMessage status={contextUsage} />
+        <ContextUsageMessage
+          status={contextUsage}
+          onShowDetail={onShowContextDetail}
+        />
       </div>
     );
   }

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -1559,6 +1559,118 @@ describe('DaemonSessionProvider', () => {
     expect(connection?.tokenCount).toBe(23_000);
   });
 
+  it('keeps the in-memory tokenCount across SSE re-subscribe when replay has no usage', async () => {
+    const events = vi.fn(async function* usageThenReusableEvents(
+      opts: { signal?: AbortSignal } = {},
+    ) {
+      if (events.mock.calls.length === 1) {
+        const event: DaemonEvent = {
+          id: 5,
+          v: 1,
+          type: 'session_update',
+          data: {
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: 'counted' },
+              _meta: { usage: { inputTokens: 7_000, totalTokens: 7_500 } },
+            },
+          },
+        };
+        yield event;
+        return;
+      }
+      await new Promise<void>((resolve) => {
+        if (opts.signal?.aborted) {
+          resolve();
+          return;
+        }
+        opts.signal?.addEventListener('abort', () => resolve(), {
+          once: true,
+        });
+      });
+      yield* [];
+    });
+    const session = createMockSession({ events });
+    sdkMocks.sessions.push(session);
+    let connection: DaemonConnectionState | undefined;
+
+    function Harness() {
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      reconnectDelayMs: 1,
+      maxReconnectDelayMs: 1,
+    });
+    await act(async () => {
+      await wait(5);
+      await flushPromises();
+    });
+
+    // The stream ended once and the provider re-subscribed on the same
+    // session object; its (empty) original replay snapshot must not reset
+    // the live count.
+    expect(events).toHaveBeenCalledTimes(2);
+    expect(connection?.tokenCount).toBe(7_000);
+  });
+
+  it('resets tokenCount when reconnect attaches a different session without replay usage', async () => {
+    const firstEvents = createClosableEvents();
+    const firstSession = createMockSession({
+      sessionId: 'session-usage-a',
+      events: async function* usageThenGoneEvents() {
+        const event: DaemonEvent = {
+          id: 5,
+          v: 1,
+          type: 'session_update',
+          data: {
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: 'counted' },
+              _meta: { usage: { inputTokens: 7_000, totalTokens: 7_500 } },
+            },
+          },
+        };
+        yield event;
+        await firstEvents.closed.promise;
+        yield* [];
+        throw Object.assign(new Error('missing session'), { status: 404 });
+      },
+    });
+    const secondSession = createMockSession({
+      sessionId: 'session-usage-b',
+      events: createIdleEvents(),
+    });
+    sdkMocks.sessions.push(firstSession, secondSession);
+    let connection: DaemonConnectionState | undefined;
+
+    function Harness() {
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      reconnectDelayMs: 1,
+      maxReconnectDelayMs: 1,
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+    expect(connection?.tokenCount).toBe(7_000);
+
+    firstEvents.close();
+    await act(async () => {
+      await wait(20);
+      await flushPromises();
+    });
+
+    expect(connection).toMatchObject({ sessionId: 'session-usage-b' });
+    expect(connection?.tokenCount).toBe(0);
+  });
+
   it('bumps workspace event signals from replay snapshot events', async () => {
     const session = createMockSession({
       replaySnapshot: {

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -1495,6 +1495,70 @@ describe('DaemonSessionProvider', () => {
     ]);
   });
 
+  it('seeds tokenCount from the latest replay usage on attach', async () => {
+    const session = createMockSession({
+      replaySnapshot: {
+        compactedReplay: [
+          {
+            id: 1,
+            v: 1,
+            type: 'session_update',
+            data: {
+              update: {
+                sessionUpdate: 'agent_message_chunk',
+                content: { type: 'text', text: 'old answer' },
+                _meta: { usage: { inputTokens: 11_000, totalTokens: 12_000 } },
+              },
+            },
+          },
+          {
+            id: 2,
+            v: 1,
+            type: 'turn_complete',
+            data: { stopReason: 'end_turn' },
+          },
+          {
+            id: 3,
+            v: 1,
+            type: 'session_update',
+            data: {
+              update: {
+                sessionUpdate: 'agent_message_chunk',
+                content: { type: 'text', text: 'latest answer' },
+                _meta: { usage: { inputTokens: 23_000, totalTokens: 25_000 } },
+              },
+            },
+          },
+          {
+            id: 4,
+            v: 1,
+            type: 'turn_complete',
+            data: { stopReason: 'end_turn' },
+          },
+        ],
+        liveJournal: [],
+      },
+    });
+    sdkMocks.sessions.push(session);
+    let connection: DaemonConnectionState | undefined;
+
+    function Harness() {
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      reconnectDelayMs: 1,
+      maxReconnectDelayMs: 1,
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(connection?.tokenCount).toBe(23_000);
+  });
+
   it('bumps workspace event signals from replay snapshot events', async () => {
     const session = createMockSession({
       replaySnapshot: {

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -35,6 +35,7 @@ import { detachDaemonClient, getStableClientId } from './clientLifecycle.js';
 import { useOptionalDaemonWorkspace } from '../workspace/DaemonWorkspaceProvider.js';
 import {
   getCurrentMode,
+  getReplayTokenCount,
   mapProviderStatus,
   mapSupportedCommands,
   updateConnectionFromDaemonEvent,
@@ -228,6 +229,10 @@ export function DaemonSessionProvider({
         try {
           let isSameSessionReconnect = false;
           let shouldInjectReplaySnapshot = false;
+          // Only populated when this attempt (re)loads the session: a reused
+          // session object carries the snapshot from its original load, whose
+          // usage may be older than the in-memory count.
+          let replayTokenCount: number | undefined;
           if (!session) {
             setConnection((current) => ({
               ...current,
@@ -318,6 +323,10 @@ export function DaemonSessionProvider({
             shouldInjectReplaySnapshot =
               nextSession.replaySnapshot.compactedReplay.length > 0 ||
               nextSession.replaySnapshot.liveJournal.length > 0;
+            replayTokenCount = getReplayTokenCount([
+              ...nextSession.replaySnapshot.compactedReplay,
+              ...nextSession.replaySnapshot.liveJournal,
+            ]);
             session = nextSession;
             reconnectSessionId = session.sessionId;
             shouldCreateFreshSession = false;
@@ -370,9 +379,15 @@ export function DaemonSessionProvider({
             currentModel,
             currentMode,
             tokenCount:
-              current.sessionId === activeSession.sessionId
-                ? (current.tokenCount ?? 0)
-                : 0,
+              // A freshly loaded snapshot covers everything up to the SSE
+              // resume point, so its usage supersedes the in-memory count;
+              // without one (or with a usage-less replay) keep the
+              // same-session value and start anything else at 0.
+              replayTokenCount !== undefined
+                ? replayTokenCount
+                : current.sessionId === activeSession.sessionId
+                  ? (current.tokenCount ?? 0)
+                  : 0,
             contextWindow,
             providers,
             supportedCommands,

--- a/packages/webui/src/daemon/session/mappers.test.ts
+++ b/packages/webui/src/daemon/session/mappers.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { DaemonEvent } from '@qwen-code/sdk/daemon';
+import { getReplayTokenCount } from './mappers.js';
+
+function usageEvent(
+  id: number,
+  usage: Record<string, unknown>,
+  text = '',
+): DaemonEvent {
+  return {
+    id,
+    v: 1,
+    type: 'session_update',
+    data: {
+      update: {
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text },
+        _meta: { usage },
+      },
+    },
+  };
+}
+
+const turnComplete: DaemonEvent = {
+  id: 99,
+  v: 1,
+  type: 'turn_complete',
+  data: { stopReason: 'end_turn' },
+};
+
+describe('getReplayTokenCount', () => {
+  it('returns undefined for an empty array', () => {
+    expect(getReplayTokenCount([])).toBeUndefined();
+  });
+
+  it('returns undefined when no event carries usage', () => {
+    const plainChunk: DaemonEvent = {
+      id: 1,
+      v: 1,
+      type: 'session_update',
+      data: {
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'no usage here' },
+        },
+      },
+    };
+    expect(getReplayTokenCount([plainChunk, turnComplete])).toBeUndefined();
+  });
+
+  it('returns the latest usage, not the first', () => {
+    expect(
+      getReplayTokenCount([
+        usageEvent(1, { inputTokens: 11_000 }),
+        turnComplete,
+        usageEvent(3, { inputTokens: 23_000 }),
+        turnComplete,
+      ]),
+    ).toBe(23_000);
+  });
+
+  it('prefers inputTokens over totalTokens and falls back to totalTokens', () => {
+    expect(
+      getReplayTokenCount([
+        usageEvent(1, { inputTokens: 7_000, totalTokens: 7_500 }),
+      ]),
+    ).toBe(7_000);
+    expect(getReplayTokenCount([usageEvent(1, { totalTokens: 7_500 })])).toBe(
+      7_500,
+    );
+  });
+
+  it('ignores non-positive and non-numeric usage values', () => {
+    expect(
+      getReplayTokenCount([
+        usageEvent(1, { inputTokens: 5_000 }),
+        usageEvent(2, { inputTokens: 0 }),
+        usageEvent(3, { inputTokens: 'NaN-ish' }),
+      ]),
+    ).toBe(5_000);
+  });
+
+  it('skips events with non-record payloads and keeps scanning', () => {
+    const nullData = {
+      id: 2,
+      v: 1,
+      type: 'session_update',
+      data: null,
+    } as unknown as DaemonEvent;
+    expect(
+      getReplayTokenCount([usageEvent(1, { inputTokens: 500 }), nullData]),
+    ).toBe(500);
+  });
+
+  it('skips events whose payload getter throws and keeps scanning', () => {
+    const throwing = {
+      id: 2,
+      v: 1,
+      type: 'session_update',
+    } as DaemonEvent;
+    Object.defineProperty(throwing, 'data', {
+      get() {
+        throw new Error('bad replay payload');
+      },
+    });
+    expect(
+      getReplayTokenCount([usageEvent(1, { inputTokens: 500 }), throwing]),
+    ).toBe(500);
+  });
+});

--- a/packages/webui/src/daemon/session/mappers.ts
+++ b/packages/webui/src/daemon/session/mappers.ts
@@ -173,6 +173,31 @@ export function getCurrentMode(
   return getString(modes, 'currentModeId') ?? getString(modes, 'currentMode');
 }
 
+/**
+ * Latest usage token count carried in a replay snapshot, or undefined if
+ * no replayed event has one. Token usage is not part of the attach-time
+ * status fetches — it only arrives on streaming `session_update` events —
+ * so on session load the last usage-bearing replay event is the freshest
+ * count available.
+ */
+export function getReplayTokenCount(
+  events: readonly DaemonEvent[],
+): number | undefined {
+  for (let i = events.length - 1; i >= 0; i--) {
+    try {
+      const event = events[i];
+      if (event.type !== 'session_update') continue;
+      const update = getRecord(getRecord(event.data)?.['update']);
+      const tokenCount = getUsageTokenCount(update);
+      if (tokenCount !== undefined) return tokenCount;
+    } catch {
+      // Malformed replay events are skipped, mirroring the replay
+      // injection loop — a usage scan must not fail the whole attach.
+    }
+  }
+  return undefined;
+}
+
 function getUsageTokenCount(
   update: Record<string, unknown> | undefined,
 ): number | undefined {


### PR DESCRIPTION
## What this PR does

Makes context usage in the web shell explorable with the mouse, and keeps the status-bar indicator alive across page reloads. The bottom-right "x.x% context used" label becomes a button that runs the same flow as typing `/context` (echoes the command, appends the usage panel, and the transcript follows the tail so the panel is revealed even when scrolled up). Inside the `/context` panel, the literal `/context detail` in the hint line becomes a button that runs `/context detail`; the clickable part is located by literal match in the translated hint, so a translation without it (or a missing callback) degrades to the plain text line. On the SDK side, the connection's `tokenCount` is now seeded from the freshly loaded replay snapshot on session attach, scanning backwards for the latest usage-bearing `session_update` (turn compaction keeps each merged slot's last `_meta`, so usage survives compaction).

## Why it's needed

Follow-up to #4887 (mouse-selectable model indicator): the context percentage and the detail hint were the remaining context-usage surfaces only reachable by typing slash commands. While wiring the button we also surfaced a pre-existing gap: `tokenCount` was only populated from streaming usage updates and reset to 0 on attach, so the indicator vanished on every page reload until the next model response — which made the new button disappear too. Clicked and typed behavior share one code path (`App.showContextUsage()`), so they cannot drift.

## Reviewer Test Plan

### How to verify

1. `npm run dev:daemon`, open the web shell, send any prompt and wait for the response — the bottom-right shows "x.x% context used".
2. Click the percentage: a `/context` user message is echoed and the usage panel appears, identical to typing `/context`. Hovering shows the underline affordance; if the mode/model picker is open, the press dismisses it like any outside press.
3. In the panel's last line ("Run /context detail for per-item breakdown."), click the accent-colored `/context detail`: a `/context detail` echo plus the per-item breakdown panel appear, identical to typing it.
4. Reload the page (F5) while the session has history: the percentage indicator is back immediately after reattach (previously it stayed hidden until the next model response).
5. Unit suites: `webui` 116 passed (includes new `seeds tokenCount from the latest replay usage on attach`, asserting the newest usage wins and `inputTokens` takes precedence over `totalTokens`), `web-shell` 198 passed; `tsc` and `eslint` clean on both packages.

### Evidence (Before & After)

Before: the percentage was a static `<span>`; the detail hint was plain text; after any page reload the indicator disappeared until the next response. After: percentage and `/context detail` are real buttons with hover/focus affordances that echo and run the exact slash-command flow; after reload the indicator shows the last known usage immediately. (Behavior verified live via `npm run dev:daemon` with Vite HMR.)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npm run dev:daemon` (daemon from source via tsx + Vite dev server with webui/web-shell source aliases), plus `vitest` in `packages/webui` and `packages/web-shell`.

## Risk & Scope

- Main risk or tradeoff: the replay seeding takes the latest usage-bearing event as-is (no max), which is correct for non-monotonic counts (e.g. after compaction); sessions whose replay carries no usage at all keep the old behavior (0 until the next response). The detail-hint callback travels App → MessageList → MessageItem → SystemMessage → ContextUsageMessage as a stable `useCallback` with memo comparators updated, so the virtualized list's memoization stays intact; no new `createContext` (the build-artifact boundary test caps those at 3).
- Not validated / out of scope: native CLI footer is untouched; subagent usage semantics intentionally mirror the existing live-update path (no filtering change); Windows/Linux only covered by CI.
- Breaking changes / migration notes: none. `getReplayTokenCount` is a new additive export in webui's daemon SDK; replay seeding only happens when the connect attempt actually (re)loads the session — a reused session object (normal SSE re-subscribe) keeps the in-memory count, and malformed replay events are skipped per-event, mirroring the replay injection loop's tolerance.

## Linked Issues

Related: #4887 (mouse-selectable model indicator), #4874 (mouse-selectable approval mode).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 Web Shell 中的上下文用量可以用鼠标探索,并让状态栏指示器在页面刷新后不再消失。右下角"上下文已用 x.x%"标签变为按钮,点击后执行与输入 `/context` 完全相同的流程(回显命令、追加用量面板,且对话跟随到底部,即使向上翻页也能看到面板)。在 `/context` 面板内,提示行中的 `/context detail` 字面量变为按钮,点击即执行 `/context detail`;可点击部分通过在翻译文案中按字面量定位,若某个翻译不含该字面量(或回调未传入),则优雅降级为纯文本行。SDK 侧,会话 attach 时从新加载的 replay 快照中回填连接的 `tokenCount`:倒序扫描最近一条携带 usage 的 `session_update`(turn 压缩保留每个合并槽最后的 `_meta`,因此 usage 在压缩后仍然存活)。

## 为什么需要

承接 #4887(模型指示器鼠标可选):上下文百分比和明细提示是仅剩的只能通过输入斜杠命令触达的上下文用量入口。在接线按钮的过程中还暴露了一个先前就存在的缺口:`tokenCount` 只从流式 usage 更新中填充,attach 时重置为 0,因此每次页面刷新后指示器都会消失,直到下一条模型回复——新按钮也会跟着消失。点击与手敲共享同一条代码路径(`App.showContextUsage()`),二者行为不会漂移。

## 审阅测试计划

### 如何验证

1. `npm run dev:daemon`,打开 Web Shell,发送任意消息并等待回复——右下角显示"上下文已用 x.x%"。
2. 点击百分比:回显一条 `/context` 用户消息并出现用量面板,与手敲 `/context` 完全一致。悬停有下划线提示;若模式/模型选择器开着,该次按下会像任何外部点击一样将其关闭。
3. 在面板最后一行("运行 /context detail 查看逐项明细。")点击强调色的 `/context detail`:回显 `/context detail` 并出现逐项明细面板,与手敲一致。
4. 在会话有历史时刷新页面(F5):重新 attach 后百分比指示器立即恢复(此前会一直隐藏,直到下一条模型回复)。
5. 单测:`webui` 116 个通过(含新增的 `seeds tokenCount from the latest replay usage on attach`,断言取最新 usage 且 `inputTokens` 优先于 `totalTokens`),`web-shell` 198 个通过;两个包的 `tsc` 与 `eslint` 干净。

### 证据(前后对比)

之前:百分比是静态 `<span>`;明细提示是纯文本;任何页面刷新后指示器消失,直到下一条回复。之后:百分比与 `/context detail` 是带悬停/聚焦提示的真实按钮,回显并执行与斜杠命令完全相同的流程;刷新后指示器立即显示最近一次已知用量。(行为已通过 `npm run dev:daemon` + Vite HMR 实测。)

### 测试系统

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境(可选)

`npm run dev:daemon`(daemon 经 tsx 从源码运行 + Vite dev server 以源码别名加载 webui/web-shell),以及在 `packages/webui` 与 `packages/web-shell` 中运行 `vitest`。

## 风险与范围

- 主要风险或权衡:replay 回填直接采用最近一条带 usage 的事件(不取 max),这对非单调计数(如压缩后变小)是正确的;若某会话的 replay 完全不含 usage,则保持旧行为(0,直到下一条回复)。明细提示回调以稳定的 `useCallback` 经 App → MessageList → MessageItem → SystemMessage → ContextUsageMessage 传递,memo 比较函数已同步更新,虚拟化列表的渲染缓存不受影响;未新增 `createContext`(构建产物边界测试将其上限定为 3)。
- 未验证/范围外:原生 CLI 底栏不受影响;subagent 的 usage 语义有意沿用现有实时更新路径(未改变过滤行为);Windows/Linux 仅由 CI 覆盖。
- 破坏性变更/迁移说明:无。`getReplayTokenCount` 是 webui daemon SDK 的纯增量新导出;replay 回填仅在本次连接尝试真正(重新)加载会话时生效——复用的 session 对象(SSE 正常重订阅)保留内存中的计数,畸形 replay 事件逐条跳过,与 replay 注入循环的容错一致。

## 关联 Issue

相关:#4887(模型指示器鼠标可选)、#4874(审批模式鼠标可选)。

</details>

<img width="3002" height="764" alt="image" src="https://github.com/user-attachments/assets/f5afbeff-4ffc-4801-8155-bf685728343f" />

<img width="1662" height="1074" alt="image" src="https://github.com/user-attachments/assets/1b9fd8c4-709e-4685-af5b-2eb2b855495e" />

<img width="1512" height="1188" alt="image" src="https://github.com/user-attachments/assets/5288b3e1-86d4-4ac5-8fc9-777d64a19c15" />
