### PR TITLE
fix(cli): enable VP scroll at idle prompt and fix viewport height

### DIFF
--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -148,18 +148,18 @@ export const defaultKeyBindings: KeyBindingConfig = {
   // History navigation
   [Command.HISTORY_UP]: [{ key: 'p', ctrl: true }],
   [Command.HISTORY_DOWN]: [{ key: 'n', ctrl: true }],
-  [Command.NAVIGATION_UP]: [{ key: 'up' }],
-  [Command.NAVIGATION_DOWN]: [{ key: 'down' }],
+  [Command.NAVIGATION_UP]: [{ key: 'up', shift: false }],
+  [Command.NAVIGATION_DOWN]: [{ key: 'down', shift: false }],
 
   // Selection-list nav: arrows + k/j + Ctrl+P/Ctrl+N
   // ctrl: false on bare k/j skips Ctrl+K and Ctrl+J
   [Command.SELECTION_UP]: [
-    { key: 'up' },
+    { key: 'up', shift: false },
     { key: 'k', ctrl: false },
     { key: 'p', ctrl: true },
   ],
   [Command.SELECTION_DOWN]: [
-    { key: 'down' },
+    { key: 'down', shift: false },
     { key: 'j', ctrl: false },
     { key: 'n', ctrl: true },
   ],
@@ -167,8 +167,8 @@ export const defaultKeyBindings: KeyBindingConfig = {
   // Auto-completion
   [Command.ACCEPT_SUGGESTION]: [{ key: 'tab' }, { key: 'return', ctrl: false }],
   // Completion navigation uses only arrow keys
-  [Command.COMPLETION_UP]: [{ key: 'up' }],
-  [Command.COMPLETION_DOWN]: [{ key: 'down' }],
+  [Command.COMPLETION_UP]: [{ key: 'up', shift: false }],
+  [Command.COMPLETION_DOWN]: [{ key: 'down', shift: false }],
 
   // Text input
   // Must also exclude shift to allow shift+enter for newline

--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -562,7 +562,7 @@ export const MainContent = () => {
         </Box>
         <OverflowProvider>
           <ScrollableList
-            hasFocus={!uiState.isEditorDialogOpen && !uiState.dialogsVisible}
+            hasFocus={!uiState.dialogsVisible}
             data={allVirtualItems}
             renderItem={renderVirtualItem}
             estimatedItemHeight={virtualEstimatedItemHeight}

--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Box, Static } from 'ink';
+import { Box, Static, type DOMElement, useBoxMetrics } from 'ink';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { HistoryItem, HistoryItemWithoutId } from '../types.js';
 import { HistoryItemDisplay } from './HistoryItemDisplay.js';
@@ -544,24 +544,32 @@ export const MainContent = () => {
     ],
   );
 
+  const vpHeaderRef = useRef<DOMElement>(null);
+  const { height: vpHeaderHeight } = useBoxMetrics(vpHeaderRef);
+
   if (useVirtualScroll) {
+    const scrollContainerHeight = Math.max(
+      0,
+      (uiState.availableTerminalHeight ?? 0) - vpHeaderHeight,
+    );
+
     return (
       <>
-        <Box flexDirection="column" flexShrink={0}>
+        <Box ref={vpHeaderRef} flexDirection="column" flexShrink={0}>
           <AppHeader version={version} />
           <DebugModeNotification />
           <Notifications />
         </Box>
         <OverflowProvider>
           <ScrollableList
-            hasFocus={!uiState.isInputActive && !uiState.isEditorDialogOpen}
+            hasFocus={!uiState.isEditorDialogOpen && !uiState.dialogsVisible}
             data={allVirtualItems}
             renderItem={renderVirtualItem}
             estimatedItemHeight={virtualEstimatedItemHeight}
             keyExtractor={virtualKeyExtractor}
             initialScrollIndex={SCROLL_TO_ITEM_END}
             isStaticItem={virtualIsStaticItem}
-            containerHeight={uiState.availableTerminalHeight}
+            containerHeight={scrollContainerHeight}
           />
           <ShowMoreLines constrainHeight={uiState.constrainHeight} />
         </OverflowProvider>

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -165,10 +165,7 @@ export function KeypressProvider({
   );
 
   useEffect(() => {
-    const wasRaw = stdin.isRaw;
-    if (wasRaw === false) {
-      setRawMode(true);
-    }
+    setRawMode(true);
 
     // Use pre-drained captured input passed from outside React.
     // Draining happens before render() so StrictMode's mount/cleanup/remount
@@ -196,6 +193,7 @@ export function KeypressProvider({
     let waitingForEnterAfterBackslash = false;
     let rawDataBuffer = Buffer.alloc(0);
     let rawFlushTimeout: NodeJS.Timeout | null = null;
+    let swallowingSgrMouse = false;
 
     const updateKittyBuffer = (value: string) => {
       kittySequenceBufferRef.current = value;
@@ -678,6 +676,23 @@ export function KeypressProvider({
         return;
       }
 
+      // SGR mouse sequences (\x1b[<...M or \x1b[<...m) are handled by
+      // useMouseEvents via ink's useInput pipeline. readline's CSI parser
+      // treats the `<` parameter byte as a final byte, splitting the
+      // sequence into a CSI event (\x1b[<) followed by individual character
+      // events (digits, semicolons, M/m). Without this filter, those
+      // trailing characters would appear as typed text in the input box.
+      if (swallowingSgrMouse) {
+        if (key.name === 'm' || key.sequence === 'M') {
+          swallowingSgrMouse = false;
+        }
+        return;
+      }
+      if (key.sequence === `${ESC}[<`) {
+        swallowingSgrMouse = true;
+        return;
+      }
+
       // Ctrl+C is an always-available escape hatch. It MUST be processed
       // before the `isPaste` branch below, otherwise a stuck paste mode
       // (paste-start without paste-end) silently buffers every key —
@@ -1148,10 +1163,7 @@ export function KeypressProvider({
 
       rl.close();
 
-      // Restore the terminal to its original state.
-      if (wasRaw === false) {
-        setRawMode(false);
-      }
+      setRawMode(false);
 
       if (backslashTimeout) {
         clearTimeout(backslashTimeout);

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -194,6 +194,7 @@ export function KeypressProvider({
     let rawDataBuffer = Buffer.alloc(0);
     let rawFlushTimeout: NodeJS.Timeout | null = null;
     let swallowingSgrMouse = false;
+    let sgrMouseTimeout: NodeJS.Timeout | null = null;
 
     const updateKittyBuffer = (value: string) => {
       kittySequenceBufferRef.current = value;
@@ -683,13 +684,32 @@ export function KeypressProvider({
       // events (digits, semicolons, M/m). Without this filter, those
       // trailing characters would appear as typed text in the input box.
       if (swallowingSgrMouse) {
-        if (key.name === 'm' || key.sequence === 'M') {
+        if (key.ctrl && key.name === 'c') {
           swallowingSgrMouse = false;
+          if (sgrMouseTimeout) {
+            clearTimeout(sgrMouseTimeout);
+            sgrMouseTimeout = null;
+          }
+        } else {
+          if (key.name === 'm' || key.sequence === 'M') {
+            swallowingSgrMouse = false;
+            if (sgrMouseTimeout) {
+              clearTimeout(sgrMouseTimeout);
+              sgrMouseTimeout = null;
+            }
+          }
+          return;
         }
-        return;
       }
       if (key.sequence === `${ESC}[<`) {
         swallowingSgrMouse = true;
+        if (sgrMouseTimeout) {
+          clearTimeout(sgrMouseTimeout);
+        }
+        sgrMouseTimeout = setTimeout(() => {
+          swallowingSgrMouse = false;
+          sgrMouseTimeout = null;
+        }, KITTY_SEQUENCE_TIMEOUT_MS);
         return;
       }
 
@@ -1172,6 +1192,12 @@ export function KeypressProvider({
 
       clearKittyBufferAndTimeout();
       clearPasteIdleTimeout();
+
+      if (sgrMouseTimeout) {
+        clearTimeout(sgrMouseTimeout);
+        sgrMouseTimeout = null;
+      }
+      swallowingSgrMouse = false;
 
       if (rawFlushTimeout) {
         clearTimeout(rawFlushTimeout);

--- a/packages/cli/src/ui/hooks/useFocus.test.ts
+++ b/packages/cli/src/ui/hooks/useFocus.test.ts
@@ -37,7 +37,11 @@ describe('useFocus', () => {
     stdin.resume = vi.fn();
     stdin.pause = vi.fn();
     stdout = { write: vi.fn() };
-    mockedUseStdin.mockReturnValue({ stdin } as ReturnType<typeof useStdin>);
+    mockedUseStdin.mockReturnValue({
+      stdin,
+      setRawMode: vi.fn(),
+      isRawModeSupported: true,
+    } as unknown as ReturnType<typeof useStdin>);
     mockedUseStdout.mockReturnValue({ stdout } as unknown as ReturnType<
       typeof useStdout
     >);

--- a/packages/cli/src/ui/keyMatchers.test.ts
+++ b/packages/cli/src/ui/keyMatchers.test.ts
@@ -36,14 +36,14 @@ describe('keyMatchers', () => {
     [Command.CLEAR_SCREEN]: (key: Key) => key.ctrl && key.name === 'l',
     [Command.HISTORY_UP]: (key: Key) => key.ctrl && key.name === 'p',
     [Command.HISTORY_DOWN]: (key: Key) => key.ctrl && key.name === 'n',
-    [Command.NAVIGATION_UP]: (key: Key) => key.name === 'up',
-    [Command.NAVIGATION_DOWN]: (key: Key) => key.name === 'down',
+    [Command.NAVIGATION_UP]: (key: Key) => key.name === 'up' && !key.shift,
+    [Command.NAVIGATION_DOWN]: (key: Key) => key.name === 'down' && !key.shift,
     [Command.ACCEPT_SUGGESTION]: (key: Key) =>
       key.name === 'tab' || (key.name === 'return' && !key.ctrl),
     // Completion navigation only uses arrow keys (not Ctrl+P/N)
     // to allow Ctrl+P/N to always navigate history
-    [Command.COMPLETION_UP]: (key: Key) => key.name === 'up',
-    [Command.COMPLETION_DOWN]: (key: Key) => key.name === 'down',
+    [Command.COMPLETION_UP]: (key: Key) => key.name === 'up' && !key.shift,
+    [Command.COMPLETION_DOWN]: (key: Key) => key.name === 'down' && !key.shift,
     [Command.ESCAPE]: (key: Key) => key.name === 'escape',
     [Command.SUBMIT]: (key: Key) =>
       key.name === 'return' && !key.ctrl && !key.meta && !key.paste,
@@ -76,11 +76,11 @@ describe('keyMatchers', () => {
     [Command.COLLAPSE_SUGGESTION]: (key: Key) => key.name === 'left',
     // Selection list navigation: up/k (ctrl=false)/Ctrl+P move up; down/j (ctrl=false)/Ctrl+N move down
     [Command.SELECTION_UP]: (key: Key) =>
-      key.name === 'up' ||
+      (key.name === 'up' && !key.shift) ||
       (key.name === 'k' && !key.ctrl) ||
       (key.ctrl && key.name === 'p'),
     [Command.SELECTION_DOWN]: (key: Key) =>
-      key.name === 'down' ||
+      (key.name === 'down' && !key.shift) ||
       (key.name === 'j' && !key.ctrl) ||
       (key.ctrl && key.name === 'n'),
     [Command.SCROLL_UP]: (key: Key) => key.shift && key.name === 'up',
@@ -175,12 +175,22 @@ describe('keyMatchers', () => {
     {
       command: Command.NAVIGATION_UP,
       positive: [createKey('up'), createKey('up', { ctrl: true })],
-      negative: [createKey('p'), createKey('u')],
+      negative: [
+        createKey('p'),
+        createKey('u'),
+        // shift: false — Shift+Up must NOT match (reserved for SCROLL_UP)
+        createKey('up', { shift: true }),
+      ],
     },
     {
       command: Command.NAVIGATION_DOWN,
       positive: [createKey('down'), createKey('down', { ctrl: true })],
-      negative: [createKey('n'), createKey('d')],
+      negative: [
+        createKey('n'),
+        createKey('d'),
+        // shift: false — Shift+Down must NOT match (reserved for SCROLL_DOWN)
+        createKey('down', { shift: true }),
+      ],
     },
 
     // Auto-completion
@@ -198,6 +208,7 @@ describe('keyMatchers', () => {
         createKey('p'),
         createKey('down'),
         createKey('p', { ctrl: true }),
+        createKey('up', { shift: true }),
       ],
     },
     {
@@ -209,6 +220,7 @@ describe('keyMatchers', () => {
         createKey('n'),
         createKey('up'),
         createKey('n', { ctrl: true }),
+        createKey('down', { shift: true }),
       ],
     },
 
@@ -302,6 +314,8 @@ describe('keyMatchers', () => {
         createKey('u'),
         // ctrl: false on k — Ctrl+K must NOT match (would conflict with KILL_LINE_RIGHT)
         createKey('k', { ctrl: true }),
+        // shift: false on up — Shift+Up must NOT match (reserved for SCROLL_UP)
+        createKey('up', { shift: true }),
       ],
     },
     {
@@ -317,6 +331,8 @@ describe('keyMatchers', () => {
         createKey('d'),
         // ctrl: false on j — Ctrl+J must NOT match (preserves Ctrl+J = newline in some terminals)
         createKey('j', { ctrl: true }),
+        // shift: false on down — Shift+Down must NOT match (reserved for SCROLL_DOWN)
+        createKey('down', { shift: true }),
       ],
     },
 

--- a/packages/cli/src/ui/keyMatchers.ts
+++ b/packages/cli/src/ui/keyMatchers.ts
@@ -29,28 +29,32 @@ function matchKeyBinding(keyBinding: KeyBinding, key: Key): boolean {
     return false;
   }
 
-  // Check modifiers - follow original logic:
-  // undefined = ignore this modifier (original behavior)
-  // true = modifier must be pressed
-  // false = modifier must NOT be pressed
+  // Check modifiers:
+  // binding undefined = ignore this modifier
+  // binding true  = modifier must be pressed (key value must be truthy)
+  // binding false = modifier must NOT be pressed (key value falsy or undefined)
+  //
+  // Using !!key.X normalizes undefined → false so that a binding requiring
+  // shift: false matches keys where shift is either false or omitted (common
+  // in test mocks that construct partial Key objects).
 
-  if (keyBinding.ctrl !== undefined && key.ctrl !== keyBinding.ctrl) {
+  if (keyBinding.ctrl !== undefined && !!key.ctrl !== keyBinding.ctrl) {
     return false;
   }
 
-  if (keyBinding.shift !== undefined && key.shift !== keyBinding.shift) {
+  if (keyBinding.shift !== undefined && !!key.shift !== keyBinding.shift) {
     return false;
   }
 
-  if (keyBinding.command !== undefined && key.meta !== keyBinding.command) {
+  if (keyBinding.command !== undefined && !!key.meta !== keyBinding.command) {
     return false;
   }
 
-  if (keyBinding.paste !== undefined && key.paste !== keyBinding.paste) {
+  if (keyBinding.paste !== undefined && !!key.paste !== keyBinding.paste) {
     return false;
   }
 
-  if (keyBinding.meta !== undefined && key.meta !== keyBinding.meta) {
+  if (keyBinding.meta !== undefined && !!key.meta !== keyBinding.meta) {
     return false;
   }
 


### PR DESCRIPTION
## What this PR does

Fixes five issues that block flipping `ui.useTerminalBuffer` (Virtual Viewport) to default-on:

1. **Key binding disambiguation** — adds `shift: false` to `NAVIGATION_UP/DOWN`, `SELECTION_UP/DOWN`, and `COMPLETION_UP/DOWN` so Shift+Up/Down only triggers `SCROLL_UP/DOWN`, never input history navigation or dialog selection.
2. **Scroll/input coexistence** — changes `ScrollableList`'s `hasFocus` from `!isInputActive && !isEditorDialogOpen` to `!dialogsVisible`, so VP scroll keys and mouse wheel work at the idle prompt while dialogs (Help, Settings, etc.) still own their own PgUp/PgDn handlers.
3. **Viewport height overflow** — measures the VP header block (AppHeader + DebugModeNotification + Notifications) with `useBoxMetrics` and subtracts it from `containerHeight`, eliminating the ~5 extra rows that caused blank lines and a native terminal scrollbar.
4. **Key matcher normalization** — uses `!!key.X` to normalize `undefined` → `false` in modifier comparison, so `shift: false` constraints work correctly with partial Key objects in tests.
5. **Raw-mode refcount** (#4973) — removes the `wasRaw` guard in KeypressContext so it always holds its own ink refcount. Previously, when the last ink `useInput` deactivated (e.g. opening a dialog), the refcount hit 0 and stdin dropped to cooked mode — all input dead until Enter.
6. **SGR mouse text leak** (#4974) — filters SGR mouse sequences (`\x1b[<...M/m`) in handleKeypress before they reach readline. readline's CSI parser treated `<` as a final byte, emitting trailing `64;50;15M` as typed text in the input box.

## Why it's needed

VP mode (`ui.useTerminalBuffer`) was merged in #4146 as opt-in. Multiple bugs block flipping it to default-on:
- #4942: scroll keys and mouse wheel are completely unresponsive at the idle prompt (the most common state)
- #4921: viewport height is ~5 rows taller than the physical terminal, producing blank lines and a native scrollbar
- #4973: opening any dialog (Help, Settings, etc.) freezes all input — KeypressContext's raw-mode refcount drops to 0
- #4974: mouse wheel scrolling types `64;50;15M` into the input box — readline misparses SGR mouse CSI sequences

\#4973 and #4974 are pre-existing latent bugs in KeypressContext, not VP-specific. They are exposed by this PR's `hasFocus` change which enables SGR mouse mode at the idle prompt (previously it was only active during tool processing, when the user wasn't typing).

## Design alternatives considered

<details>
<summary>Evaluated 5 approaches for scroll/input coexistence — click to expand</summary>

### Approach A: `useBoxMetrics` measurement + `dialogsVisible` gating (chosen)

Measure VP header height dynamically with `useBoxMetrics(vpHeaderRef)`, subtract from `containerHeight`. Gate scroll activation on `!dialogsVisible` instead of `!isInputActive`.

| Pros | Cons |
|------|------|
| Minimal change (~60 lines, 4 files) | First frame `vpHeaderHeight=0` (useBoxMetrics returns 0 before layout) |
| Accurate — adapts to DebugMode/Notifications appearing | SGR mouse mode stays enabled at idle prompt (Shift/Option needed for text selection) |
| Key binding disambiguation is pure data change | |
| No event routing architecture changes | |

First-frame zero-height is handled by VirtualizedList's `isReady` guard (`containerHeight > 0`). SGR mouse mode at idle is documented in `keyboard-shortcuts.md`.

### Approach B: `flexGrow` layout — ❌ not viable

Use `<Box flexGrow={1}>` on the ScrollableList wrapper so it automatically claims remaining vertical space after the VP header.

**Why it fails**: `DefaultAppLayout`'s root `<Box>` only sets `width={terminalWidth}` with no `height` constraint. Without a known total height, yoga's `flexGrow` cannot compute vertical space allocation. Adding `height={terminalHeight}` breaks ink's `useInput` focus chain — Composer stops receiving Enter and other keys correctly. Additionally, `MainContent` returns a React Fragment (`<>`), not a `Box`, so `flexGrow` cannot be applied without restructuring the component tree.

Attempted and reported as broken by the #4942 author.

### Approach C: VP-specific `availableTerminalHeight` in AppContainer

Compute a separate height in `AppContainer` based on `useTerminalBuffer` state, using a different `staticExtraHeight` value for VP mode.

| Pros | Cons |
|------|------|
| No first-frame measurement delay | AppContainer doesn't know VP header's actual height (varies with notifications) |
| | Requires new UIState field and AppContainer changes (~3800 line file, higher risk) |
| | Couples AppContainer to MainContent's VP layout details |

Feasible but less clean than localized measurement in MainContent.

### Approach D: Event consumption in KeypressContext

Add `return true` support to the `broadcast()` loop in `KeypressContext` so handlers can consume events and stop propagation. This would let ScrollableList consume Shift+Up without needing key binding disambiguation.

| Pros | Cons |
|------|------|
| Architecturally cleanest — solves the root cause | Changes event model for ALL 30+ `useKeypress` call sites |
| No key binding changes needed | Introduces handler priority/ordering questions |
| | Far exceeds the scope of #4942 |

Correct long-term direction, but too heavy as a fix for these specific issues.

### Approach E: Hardcoded header height subtraction

Subtract a fixed value (e.g. 6 rows for AppHeader) from `containerHeight` instead of measuring.

| Pros | Cons |
|------|------|
| No first-frame delay | Breaks when DebugModeNotification or Notifications appear (adds 3+ rows) |
| Simplest code | AppHeader height varies with terminal width (narrow terminals cause wrapping) |

Too fragile for a dynamic UI.

### Decision

**Approach A** — minimal, accurate, localized. The `useBoxMetrics` first-frame edge case is already handled by VirtualizedList's existing `isReady` guard. The key binding disambiguation is a safe data-only change that also fixes a latent bug (Shift+arrow matching non-scroll commands).

</details>

## Reviewer Test Plan

### How to verify

1. Enable VP mode: Settings → UI → Virtualized History (or `jq '.ui.useTerminalBuffer = true' ~/.qwen/settings.json > /tmp/s.json && mv /tmp/s.json ~/.qwen/settings.json`)
2. Start a conversation with at least 2-3 turns so there's scroll history
3. At the idle prompt (cursor blinking in input box):
   - Press `Shift+Up` / `Shift+Down` → should scroll history by 1 line
   - Press `PgUp` / `PgDn` → should scroll by one page
   - Scroll mouse wheel → should scroll history (no `64;50;15M` in input box)
   - Press bare `↑` / `↓` → should navigate input history (not scroll)
4. Open `/help` dialog → `PgUp`/`PgDn` should scroll the help list, not the conversation behind it. All keys should work (no cooked-mode freeze).
5. Close `/help` → input should immediately work (no dead keys until Enter)
6. Open `/settings` dialog → `↑`/`↓` should navigate settings, not scroll conversation
7. Check that no blank lines or native terminal scrollbar appear at the bottom

### Evidence (Before & After)

**Before** (main): At idle prompt, Shift+Up/Down, PgUp/PgDn, and mouse wheel do nothing. Bottom of VP has ~5 rows of blank space with a native scrollbar.

**After** (this PR): All scroll inputs work at idle. Viewport height matches physical terminal exactly. Opening/closing dialogs does not freeze input.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

## Risk & Scope

- Main risk or tradeoff: the `shift: false` constraint changes behavior for existing arrow-key bindings. All 6 affected commands (NAVIGATION, SELECTION, COMPLETION) were verified to never need `Shift+Arrow` — their consumers use bare arrows only.
- The `wasRaw` guard removal makes KeypressContext always hold a raw-mode refcount. This is safe because ink's `setRawMode` is refcounted — double-acquire increments the count, cleanup decrements it. The only behavioral change: KeypressContext now owns its refcount for its entire lifetime instead of depending on child `useInput` consumers to keep raw mode alive.
- The SGR mouse filter uses a simple state machine (`swallowingSgrMouse` flag). Edge case: if a malformed sequence arrives (e.g. `\x1b[<` followed by non-digit, non-M/m), the flag stays true until the next `M`/`m`. This is acceptable because malformed SGR sequences only occur from terminal bugs, and the worst case is silently swallowing a few characters.
- Not validated / out of scope: scrollbar drag (#4942 sub-problem), smooth scroll animation, scrollback preservation on VP exit.
- Breaking changes / migration notes: none.

## Linked Issues

Closes #4942
Closes #4921
Fixes #4973
Fixes #4974

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修复了五个阻塞虚拟滚动（`ui.useTerminalBuffer`）默认开启的问题：

1. **按键绑定消歧** — 给 `NAVIGATION_UP/DOWN`、`SELECTION_UP/DOWN`、`COMPLETION_UP/DOWN` 添加 `shift: false` 约束，使 Shift+Up/Down 只触发 `SCROLL_UP/DOWN`。
2. **滚动/输入共存** — 将 `ScrollableList` 的 `hasFocus` 改为 `!dialogsVisible`，使空闲时滚动可用。
3. **视口高度溢出** — 使用 `useBoxMetrics` 动态测量 VP 头部区域高度并扣除。
4. **按键匹配器归一化** — 使用 `!!key.X` 归一化修饰键比较。
5. **Raw mode refcount** (#4973) — 去掉 KeypressContext 的 `wasRaw` 守卫，始终持有自己的 ink refcount。之前打开 dialog 时最后一个 `useInput` 失活会导致 stdin 退回 cooked mode，所有输入冻结。
6. **SGR 鼠标文本泄漏** (#4974) — 在 handleKeypress 中过滤 SGR 鼠标序列。readline 的 CSI 解析器把 `<` 当终止符，将后续的 `64;50;15M` 当成普通文本输入到输入框。

\#4973 和 #4974 是 KeypressContext 的预存缺陷，不是 VP 特有的。它们被本 PR 的 `hasFocus` 变更暴露（之前 SGR 鼠标模式在用户可输入时从未启用过）。

## 设计方案对比

评估了 5 种方案（详见英文 Design alternatives），最终采用方案 A：`useBoxMetrics` 动态测量 + `dialogsVisible` 门控 — 最小改动，准确，局部化。

## 风险与范围

- `shift: false` 约束：已验证所有受影响命令都不需要 Shift+方向键
- `wasRaw` 去除：ink 的 `setRawMode` 是引用计数的，重复获取安全
- SGR 过滤器：简单状态机，畸形序列最坏只是多吞几个字符
- 超出范围：滚动条拖拽、平滑滚动、scrollback 保留
- 破坏性变更：无

</details>