### PR TITLE
fix(installer): print shell reload hint when new qwen is not picked up

### DIFF
--- a/scripts/installation/install-qwen-standalone.sh
+++ b/scripts/installation/install-qwen-standalone.sh
@@ -560,6 +560,7 @@ maybe_update_shell_path() {
         current_tail=$(tail -n 3 "${rc_file}" 2>/dev/null || true)
         if [[ "${current_tail}" == "${begin_marker}"$'\n'"${export_line}"$'\n'"${end_marker}" ]]; then
             PATH_UPDATE_APPLIED=1
+            PATH_UPDATE_RC_FILE="${rc_file}"
             return 0
         fi
     fi
@@ -576,6 +577,7 @@ maybe_update_shell_path() {
     }
 
     PATH_UPDATE_APPLIED=1
+    PATH_UPDATE_RC_FILE="${rc_file}"
 }
 
 github_base_url_for_version() {
@@ -1479,6 +1481,7 @@ print_final_instructions() {
 
     if [[ -n "${install_bin_dir}" && "${NO_MODIFY_PATH:-0}" != "1" ]]; then
         PATH_UPDATE_APPLIED=0
+        PATH_UPDATE_RC_FILE=""
         maybe_update_shell_path "${install_bin_dir}"
     fi
 
@@ -1489,12 +1492,13 @@ print_final_instructions() {
         installed_version=$(qwen --version 2>/dev/null || echo "unknown")
     fi
 
-    local rc_name=""
-    case "${SHELL:-}" in
-        */zsh)  rc_name="~/.zshrc" ;;
-        */bash) rc_name="~/.bashrc" ;;
-        */fish) rc_name="~/.config/fish/config.fish" ;;
-    esac
+    # Display the rc file maybe_update_shell_path actually wrote to (e.g. bash
+    # may fall back to ~/.bash_profile), so the success message and the reload
+    # hint can never point at a different file than the one that was modified.
+    local rc_name="${PATH_UPDATE_RC_FILE:-}"
+    if [[ -n "${rc_name}" && -n "${HOME:-}" && "${rc_name}" == "${HOME}"/* ]]; then
+        rc_name="~${rc_name#"${HOME}"}"
+    fi
     if [[ "${PATH_UPDATE_APPLIED:-0}" == "1" && -n "${rc_name}" ]]; then
         echo -e "${MUTED}Successfully added${NC} qwen ${MUTED}to \$PATH in${NC} ${rc_name}"
     fi

--- a/scripts/installation/install-qwen-standalone.sh
+++ b/scripts/installation/install-qwen-standalone.sh
@@ -93,6 +93,11 @@ finish_progress() {
 TEMP_DIRS=()
 ACTIVE_DOWNLOAD_PID=""
 PATH_UPDATE_APPLIED=0
+# PATH as inherited from the invoking shell. The script later prepends the
+# install dir to its own PATH, but that never propagates to the parent shell
+# (a piped `curl | bash` runs in a child process), so we keep the original
+# value to decide whether the user must reload their shell rc file.
+ORIGINAL_PATH="${PATH:-}"
 
 cleanup_temp_dirs() {
     local temp_dir
@@ -1494,9 +1499,42 @@ print_final_instructions() {
         echo -e "${MUTED}Successfully added${NC} qwen ${MUTED}to \$PATH in${NC} ${rc_name}"
     fi
 
+    # The invoking shell keeps its original PATH (and possibly an older qwen
+    # resolved from it) until the rc file is reloaded. Detect both cases and
+    # tell the user exactly what to run instead of letting `qwen` silently
+    # launch a stale version.
+    local shell_reload_needed=0
+    if [[ -n "${install_bin_dir}" ]]; then
+        case ":${ORIGINAL_PATH}:" in
+            *":${install_bin_dir}:"*) ;;
+            *) shell_reload_needed=1 ;;
+        esac
+    fi
+    if [[ -n "${other_qwens}" ]]; then
+        shell_reload_needed=1
+        log_warning "Other qwen executables were found and may shadow the new install in this shell:"
+        local shadow_path
+        while IFS= read -r shadow_path; do
+            [[ -z "${shadow_path}" ]] && continue
+            printf '  %s\n' "${shadow_path}"
+        done <<< "${other_qwens}"
+    fi
+
+    local reload_cmd=""
+    if [[ "${shell_reload_needed}" == "1" ]]; then
+        if [[ "${PATH_UPDATE_APPLIED:-0}" == "1" && -n "${rc_name}" ]]; then
+            reload_cmd="source ${rc_name}"
+        elif [[ -n "${install_bin_dir}" ]]; then
+            log_warning "Make sure ${install_bin_dir} comes first on your PATH, then open a new terminal."
+        fi
+    fi
+
     echo ""
     echo -e "${MUTED}Qwen Code ${installed_version} installed successfully, to start:${NC}"
     echo ""
+    if [[ -n "${reload_cmd}" ]]; then
+        echo -e "${reload_cmd}  ${MUTED}# Load new PATH (or open a new terminal)${NC}"
+    fi
     echo -e "cd <project>  ${MUTED}# Open directory${NC}"
     echo -e "qwen          ${MUTED}# Run command${NC}"
     echo ""

--- a/scripts/tests/install-script.test.js
+++ b/scripts/tests/install-script.test.js
@@ -2610,14 +2610,55 @@ describe('Linux/macOS installer end-to-end', { timeout: 15000 }, () => {
           installRoot,
           home,
           'standalone',
-          // Minimal PATH keeps PRE_INSTALL_QWENS empty even when the host
-          // machine has a real qwen installed somewhere.
+          // Minimal PATH keeps the fresh install dir off the invoking
+          // shell's PATH so the reload hint is always printed. The shadow
+          // warning is NOT asserted on either way: PRE_INSTALL_QWENS also
+          // scans well-known absolute paths (/usr/local/bin etc.), so its
+          // output depends on the host machine.
           { SHELL: '/bin/bash', PATH: '/usr/bin:/bin' },
         ).toString();
 
         expect(output).toContain('source ~/.bashrc');
         expect(output).toContain('Load new PATH');
-        expect(output).not.toContain('may shadow the new install');
+      } finally {
+        rmSync(tmpDir, { recursive: true, force: true });
+        restoreMinimalDist(createdDist);
+      }
+    },
+  );
+
+  itOnUnix(
+    'points the reload hint at ~/.bash_profile when it is the rc file written',
+    () => {
+      const createdDist = ensureMinimalDist();
+      const tmpDir = mkdtempSync(path.join(tmpdir(), 'qwen-install-test-'));
+
+      try {
+        const archive = packageFakeStandalone(tmpDir);
+        const installRoot = path.join(tmpDir, 'install');
+        const home = path.join(tmpDir, 'home');
+        const bashProfile = path.join(home, '.bash_profile');
+
+        // Default macOS bash setup: ~/.bash_profile exists, ~/.bashrc does
+        // not, so maybe_update_shell_path falls back to ~/.bash_profile.
+        mkdirSync(home, { recursive: true });
+        writeFileSync(bashProfile, '# existing profile\n');
+
+        const output = runUnixInstaller(
+          archive,
+          installRoot,
+          home,
+          'standalone',
+          { SHELL: '/bin/bash', PATH: '/usr/bin:/bin' },
+        ).toString();
+
+        expect(readFileSync(bashProfile, 'utf8')).toContain(
+          '# Qwen Code PATH block begin',
+        );
+        // An ANSI reset sits between "in" and the rc name, so match the
+        // success message and the reload hint on the rc name alone.
+        expect(output).toContain('source ~/.bash_profile');
+        expect(output).not.toContain('~/.bashrc');
       } finally {
         rmSync(tmpDir, { recursive: true, force: true });
         restoreMinimalDist(createdDist);

--- a/scripts/tests/install-script.test.js
+++ b/scripts/tests/install-script.test.js
@@ -2562,6 +2562,11 @@ describe('Linux/macOS installer end-to-end', { timeout: 15000 }, () => {
         const bashrc = readScript(path.join(home, '.bashrc'));
 
         expect(output).toContain('installed successfully, to start:');
+        expect(output).toContain(
+          'Other qwen executables were found and may shadow the new install',
+        );
+        expect(output).toContain(existingQwen);
+        expect(output).toContain('source ~/.bashrc');
         expect(bashrc).toContain('# Qwen Code PATH block begin');
         expect(bashrc).toContain(
           `export PATH='${path.join(installRoot, 'bin')}':$PATH`,
@@ -2582,6 +2587,37 @@ describe('Linux/macOS installer end-to-end', { timeout: 15000 }, () => {
           .toString()
           .trim();
         expect(resolvedQwen).toBe(installedBin);
+      } finally {
+        rmSync(tmpDir, { recursive: true, force: true });
+        restoreMinimalDist(createdDist);
+      }
+    },
+  );
+
+  itOnUnix(
+    'prints a shell reload hint when the install dir is not on PATH yet',
+    () => {
+      const createdDist = ensureMinimalDist();
+      const tmpDir = mkdtempSync(path.join(tmpdir(), 'qwen-install-test-'));
+
+      try {
+        const archive = packageFakeStandalone(tmpDir);
+        const installRoot = path.join(tmpDir, 'install');
+        const home = path.join(tmpDir, 'home');
+
+        const output = runUnixInstaller(
+          archive,
+          installRoot,
+          home,
+          'standalone',
+          // Minimal PATH keeps PRE_INSTALL_QWENS empty even when the host
+          // machine has a real qwen installed somewhere.
+          { SHELL: '/bin/bash', PATH: '/usr/bin:/bin' },
+        ).toString();
+
+        expect(output).toContain('source ~/.bashrc');
+        expect(output).toContain('Load new PATH');
+        expect(output).not.toContain('may shadow the new install');
       } finally {
         rmSync(tmpDir, { recursive: true, force: true });
         restoreMinimalDist(createdDist);


### PR DESCRIPTION
## What this PR does

Makes the Linux/macOS installer tell the user exactly how to activate the new install in the current shell. After install, when the invoking shell cannot resolve the freshly installed `qwen` yet, the start steps now include a `source ~/.bashrc` (or `~/.zshrc` / fish config, following `$SHELL`) line, and a warning lists any other `qwen` executables that shadow the new install. The script captures the PATH inherited from the invoking shell before mutating its own, so the hint only appears when it is actually needed; when the rc update failed or the shell is unsupported, it falls back to a manual-PATH warning instead of a misleading `source` hint.

## Why it's needed

A piped `curl | bash` runs in a child process and can never update the parent shell's PATH. Right after a successful install, `qwen -v` can still print an older version (e.g. a previous npm global install) directly under the "installed successfully" message, with nothing explaining why. The installer already discovered shadowing executables (`PRE_INSTALL_QWENS`) but the result was computed and never used; this PR turns it into the warning.

## Reviewer Test Plan

### How to verify

1. `npm run test:scripts` — includes a new reload-hint test and extended shadow-warning assertions.
2. Manual: put a fake old `qwen` on PATH, run the installer with `SHELL=/bin/bash` — the warning lists the old path and the start steps include `source ~/.bashrc`.
3. Manual: rerun the installer in a shell where `~/.local/bin` is already on PATH and no other qwen exists — no hint, no warning.

### Evidence (Before & After)

Before:

```
Qwen Code 0.17.1 installed successfully, to start:

cd <project>  # Open directory
qwen          # Run command

$ qwen -v
0.15.10   # old npm install still wins, nothing explains why
```

After:

```
WARNING: Other qwen executables were found and may shadow the new install in this shell:
  /usr/lib/node_modules/@qwen-code/qwen-code/bin/qwen

Qwen Code 0.17.1 installed successfully, to start:

source ~/.bashrc  # Load new PATH (or open a new terminal)
cd <project>  # Open directory
qwen          # Run command
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npx vitest run --config ./scripts/tests/vitest.config.ts` on macOS — 98 passed / 9 skipped (Windows-only cases).

## Risk & Scope

- Main risk or tradeoff: the hint may occasionally print when not strictly necessary (e.g. an old qwen found in a well-known tool dir that is not on the live PATH); harmless, the suggested command is always safe to run.
- Not validated / out of scope: Windows installer (`.ps1` / `.bat`) is untouched. Replacing old npm shims in place was prototyped and deliberately dropped — it desyncs npm's metadata from the running binary and `npm update -g` would silently revert it.
- Breaking changes / migration notes: none.

## Linked Issues

N/A — from a user report: after `curl | bash` install on Linux, `qwen -v` kept showing the old npm version until `source ~/.bashrc`.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 Linux/macOS 安装脚本明确告诉用户如何在当前 shell 激活新版本。安装完成后，如果当前 shell 还拿不到新装的 `qwen`，启动步骤里会多一行 `source ~/.bashrc`（按 `$SHELL` 选择 bash/zsh/fish 的 rc 文件），并用 WARNING 列出会遮挡新版本的其他 `qwen` 可执行文件。脚本在修改自身 PATH 之前先记录从父 shell 继承的原始 PATH，因此提示只在真正需要时出现；rc 写入失败或 shell 不受支持时，降级为手动配置 PATH 的提示，避免给出误导性的 `source` 建议。

## 为什么需要

`curl | bash` 的脚本运行在子进程中，永远无法修改父 shell 的 PATH。安装成功后 `qwen -v` 可能仍然输出旧版本（例如之前 npm 全局安装的），且紧跟在 "installed successfully" 之后，没有任何解释。脚本原本已经检测了遮挡的可执行文件（`PRE_INSTALL_QWENS`），但结果算出来后从未使用；本 PR 让它变成警告输出。

## 验证方式

1. `npm run test:scripts` —— 新增 reload 提示测试，并扩展了 shadow 警告断言。
2. 手动：在 PATH 里放一个假的旧 `qwen`，用 `SHELL=/bin/bash` 跑安装脚本——警告列出旧路径，启动步骤包含 `source ~/.bashrc`。
3. 手动：在 `~/.local/bin` 已在 PATH 且无其他 qwen 的 shell 里重跑——无提示、无警告。

## 风险与范围

- 主要风险：提示偶尔可能在非必要时出现（例如旧 qwen 在已知工具目录但不在生效 PATH 上）；无害，建议的命令任何时候执行都安全。
- 未覆盖：Windows 安装器（`.ps1` / `.bat`）未改动。原地替换旧 npm shim 的方案做过原型但主动放弃——会让 npm 元数据与实际运行的二进制不一致，且 `npm update -g` 会静默回退。
- 破坏性变更：无。

</details>
