### PR TITLE
feat(serve): deliver A2UI surfaces over MCP — bridge extraction and action endpoint

### DIFF
--- a/packages/acp-bridge/src/a2uiExtraction.test.ts
+++ b/packages/acp-bridge/src/a2uiExtraction.test.ts
@@ -179,15 +179,29 @@ describe('extractA2uiToolUpdate', () => {
     );
   });
 
-  it('returns null when no command carries a surfaceId or text is not a2ui', () => {
-    expect(
-      extractA2uiToolUpdate(
-        toolUpdate({
-          serverId: 'a2ui-ui',
-          text: '[{"version":"v0.9","noop":{}}]',
-        }),
-      ),
-    ).toBeNull();
+  it('sanitizes detected a2ui output even when no command carries a surfaceId', () => {
+    const text = '[{"version":"v0.9","noop":{}}]\nfallback summary';
+    const result = extractA2uiToolUpdate(
+      toolUpdate({
+        serverId: 'a2ui-ui',
+        text,
+        rawOutput: text,
+      }),
+    );
+    expect(result).not.toBeNull();
+    expect(result!.surfaces).toEqual([]);
+    const sanitized = result!.sanitizedParams as unknown as {
+      update: {
+        content: Array<{ content: { text: string } }>;
+        rawOutput: string;
+      };
+    };
+    expect(sanitized.update.content[0].content.text).toBe('fallback summary');
+    expect(sanitized.update.rawOutput).toBe('fallback summary');
+    expect(sanitized.update.content[0].content.text).not.toContain('noop');
+  });
+
+  it('returns null when text is not a2ui', () => {
     expect(
       extractA2uiToolUpdate(
         toolUpdate({ serverId: 'a2ui-ui', text: 'plain text result' }),

--- a/packages/acp-bridge/src/a2uiExtraction.test.ts
+++ b/packages/acp-bridge/src/a2uiExtraction.test.ts
@@ -1,0 +1,197 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  splitA2uiText,
+  isA2uiToolMeta,
+  extractA2uiToolUpdate,
+} from './bridgeClient.js';
+
+type Params = Parameters<typeof extractA2uiToolUpdate>[0];
+
+function toolUpdate(opts: {
+  toolName?: string;
+  serverId?: string;
+  text?: string;
+  rawOutput?: string;
+  sessionUpdate?: string;
+}): Params {
+  return {
+    sessionId: 'sess-1',
+    update: {
+      sessionUpdate: opts.sessionUpdate ?? 'tool_call_update',
+      toolCallId: 'call-1',
+      _meta: { toolName: opts.toolName, serverId: opts.serverId },
+      ...(opts.text !== undefined
+        ? {
+            content: [
+              { type: 'content', content: { type: 'text', text: opts.text } },
+            ],
+          }
+        : {}),
+      ...(opts.rawOutput !== undefined ? { rawOutput: opts.rawOutput } : {}),
+    },
+  } as unknown as Params;
+}
+
+const CMD = (surfaceId: string, kind = 'updateComponents') =>
+  `{"version":"v0.9","${kind}":{"surfaceId":"${surfaceId}","components":[]}}`;
+
+describe('splitA2uiText', () => {
+  it('extracts a leading array and returns the remaining fallback text', () => {
+    const out = splitA2uiText(`[${CMD('s1')}]\nrendered a card`);
+    expect(out).not.toBeNull();
+    const [commands, fallback] = out!;
+    expect(commands).toHaveLength(1);
+    expect(fallback).toBe('rendered a card');
+  });
+
+  it('tolerates leading whitespace and empty fallback', () => {
+    const out = splitA2uiText(`  \n[${CMD('s1')}]`);
+    expect(out).not.toBeNull();
+    expect(out![1]).toBe('');
+  });
+
+  it('handles nested arrays and escaped quotes inside strings', () => {
+    const text =
+      '[{"version":"v0.9","updateDataModel":{"surfaceId":"s1","path":"/","value":{"rows":[[1,2],[3,4]],"note":"a \\"quoted\\" ] bracket"}}}] tail';
+    const out = splitA2uiText(text);
+    expect(out).not.toBeNull();
+    const [commands, fallback] = out!;
+    expect(commands).toHaveLength(1);
+    expect(fallback).toBe('tail');
+  });
+
+  it('returns null for text not starting with an array', () => {
+    expect(splitA2uiText('hello [1,2]')).toBeNull();
+    expect(splitA2uiText('{"a":1}')).toBeNull();
+  });
+
+  it('returns null for unbalanced brackets', () => {
+    expect(splitA2uiText('[{"a":[1,2}')).toBeNull();
+  });
+
+  it('returns null for an empty array or invalid JSON', () => {
+    expect(splitA2uiText('[] tail')).toBeNull();
+    expect(splitA2uiText('[{"a":}] tail')).toBeNull();
+  });
+});
+
+describe('isA2uiToolMeta', () => {
+  it('matches when serverId contains "a2ui" regardless of tool name', () => {
+    expect(isA2uiToolMeta({ serverId: 'a2ui-ui', toolName: 'anything' })).toBe(
+      true,
+    );
+    expect(
+      isA2uiToolMeta({
+        serverId: 'dq-A2UI',
+        toolName: 'present_quality_report',
+      }),
+    ).toBe(true);
+  });
+
+  it('falls back to known tool names when serverId is absent', () => {
+    expect(isA2uiToolMeta({ toolName: 'mcp__legacy__present_ui' })).toBe(true);
+    expect(isA2uiToolMeta({ toolName: 'present_choices' })).toBe(true);
+  });
+
+  it('rejects unrelated tools and missing meta', () => {
+    expect(
+      isA2uiToolMeta({ serverId: 'github', toolName: 'create_issue' }),
+    ).toBe(false);
+    expect(isA2uiToolMeta(undefined)).toBe(false);
+  });
+});
+
+describe('extractA2uiToolUpdate', () => {
+  it('ignores non tool_call_update notifications and non-a2ui tools', () => {
+    expect(
+      extractA2uiToolUpdate(
+        toolUpdate({
+          toolName: 'present_ui',
+          serverId: 'a2ui-ui',
+          text: `[${CMD('s1')}]`,
+          sessionUpdate: 'tool_call',
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      extractA2uiToolUpdate(
+        toolUpdate({ toolName: 'run_shell_command', text: `[${CMD('s1')}]` }),
+      ),
+    ).toBeNull();
+  });
+
+  it('extracts commands, groups by surface, and sanitizes the original frame', () => {
+    const text = `[${CMD('s1', 'createSurface')},${CMD('s1')},${CMD('s2')}]\nfallback summary`;
+    const result = extractA2uiToolUpdate(
+      toolUpdate({
+        serverId: 'a2ui-ui',
+        toolName: 'mcp__a2ui-ui__present_ui',
+        text,
+        rawOutput: text,
+      }),
+    );
+    expect(result).not.toBeNull();
+    expect(result!.callId).toBe('call-1');
+    expect(result!.surfaces.map((s) => s.surfaceId)).toEqual(['s1', 's2']);
+    expect(result!.surfaces[0].commands).toHaveLength(2);
+    expect(result!.surfaces[1].commands).toHaveLength(1);
+    const sanitized = result!.sanitizedParams as unknown as {
+      update: {
+        content: Array<{ content: { text: string } }>;
+        rawOutput: string;
+      };
+    };
+    expect(sanitized.update.content[0].content.text).toBe('fallback summary');
+    expect(sanitized.update.rawOutput).toBe('fallback summary');
+    expect(sanitized.update.content[0].content.text).not.toContain(
+      'createSurface',
+    );
+  });
+
+  it('accepts updateDataModel-only results and uses the placeholder when fallback is empty', () => {
+    const text = `[{"version":"v0.9","updateDataModel":{"surfaceId":"s9","path":"/x","value":1}}]`;
+    const result = extractA2uiToolUpdate(
+      toolUpdate({ serverId: 'a2ui-ui', text }),
+    );
+    expect(result).not.toBeNull();
+    expect(result!.surfaces).toEqual([
+      {
+        surfaceId: 's9',
+        commands: [
+          {
+            version: 'v0.9',
+            updateDataModel: { surfaceId: 's9', path: '/x', value: 1 },
+          },
+        ],
+      },
+    ]);
+    const sanitized = result!.sanitizedParams as unknown as {
+      update: { content: Array<{ content: { text: string } }> };
+    };
+    expect(sanitized.update.content[0].content.text).toBe(
+      '[A2UI surface rendered]',
+    );
+  });
+
+  it('returns null when no command carries a surfaceId or text is not a2ui', () => {
+    expect(
+      extractA2uiToolUpdate(
+        toolUpdate({
+          serverId: 'a2ui-ui',
+          text: '[{"version":"v0.9","noop":{}}]',
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      extractA2uiToolUpdate(
+        toolUpdate({ serverId: 'a2ui-ui', text: 'plain text result' }),
+      ),
+    ).toBeNull();
+  });
+});

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -5589,6 +5589,106 @@ describe('createAcpSessionBridge', () => {
       await bridge.shutdown();
     });
 
+    it('splits a2ui tool updates and publishes a sanitized original frame', async () => {
+      let capturedConn: AgentSideConnection | undefined;
+      const factory: ChannelFactory = async () => {
+        const { clientStream, agentStream } = createInMemoryChannel();
+        const fakeAgent = new FakeAgent();
+        capturedConn = new AgentSideConnection(() => fakeAgent, agentStream);
+        return {
+          stream: clientStream,
+          exited: new Promise<
+            | { exitCode: number | null; signalCode: NodeJS.Signals | null }
+            | undefined
+          >(() => {}),
+          kill: async () => {},
+          killSync: () => {},
+        };
+      };
+      const bridge = makeBridge({ channelFactory: factory });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+
+      const abort = new AbortController();
+      const iter = bridge.subscribeEvents(session.sessionId, {
+        signal: abort.signal,
+      });
+      const text =
+        '[{"version":"v0.9","createSurface":{"surfaceId":"s1","components":[]}},{"version":"v0.9","updateComponents":{"surfaceId":"s2","components":[]}}]\nfallback summary';
+
+      void capturedConn!.sessionUpdate({
+        sessionId: session.sessionId,
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'call-1',
+          _meta: {
+            serverId: 'a2ui-ui',
+            toolName: 'mcp__a2ui-ui__present_ui',
+          },
+          content: [{ type: 'content', content: { type: 'text', text } }],
+          rawOutput: text,
+        },
+      });
+
+      const collected: Array<{ type: string; data: unknown }> = [];
+      for await (const e of iter) {
+        collected.push({ type: e.type, data: e.data });
+        if (collected.length === 3) break;
+      }
+      expect(collected.map((e) => e.type)).toEqual([
+        'session_update',
+        'session_update',
+        'session_update',
+      ]);
+      expect(collected[0]?.data).toMatchObject({
+        sessionId: session.sessionId,
+        update: {
+          sessionUpdate: 'a2ui',
+          a2ui: {
+            surfaceId: 's1',
+            callId: 'call-1',
+            commands: [
+              {
+                version: 'v0.9',
+                createSurface: { surfaceId: 's1', components: [] },
+              },
+            ],
+          },
+          _meta: { source: 'a2ui-bridge' },
+        },
+      });
+      expect(collected[1]?.data).toMatchObject({
+        update: {
+          sessionUpdate: 'a2ui',
+          a2ui: {
+            surfaceId: 's2',
+            callId: 'call-1',
+            commands: [
+              {
+                version: 'v0.9',
+                updateComponents: { surfaceId: 's2', components: [] },
+              },
+            ],
+          },
+          _meta: { source: 'a2ui-bridge' },
+        },
+      });
+      expect(collected[2]?.data).toMatchObject({
+        update: {
+          sessionUpdate: 'tool_call_update',
+          content: [
+            {
+              type: 'content',
+              content: { type: 'text', text: 'fallback summary' },
+            },
+          ],
+          rawOutput: 'fallback summary',
+        },
+      });
+
+      abort.abort();
+      await bridge.shutdown();
+    });
+
     it('shutdown closes live event subscriptions', async () => {
       const factory: ChannelFactory = async () => makeChannel().channel;
       const bridge = makeBridge({ channelFactory: factory });

--- a/packages/acp-bridge/src/bridgeClient.test.ts
+++ b/packages/acp-bridge/src/bridgeClient.test.ts
@@ -384,6 +384,98 @@ describe('BridgeClient — BridgeFileSystem injection seam (F1 step 5)', () => {
   });
 });
 
+describe('BridgeClient — A2UI session update publishing', () => {
+  it('publishes per-surface a2ui frames before the sanitized original frame', async () => {
+    const publish = vi.fn().mockReturnValue(true);
+    const fakeEntry = {
+      sessionId: 'sess:a2ui',
+      activePromptOriginatorClientId: 'client-1',
+      events: { publish },
+    };
+    const noPermissionFlow = () => {
+      throw new Error('test: permission flow should not run');
+    };
+    const client = new BridgeClient(
+      ((sid: string) => (sid === 'sess:a2ui' ? fakeEntry : undefined)) as never,
+      noPermissionFlow as never,
+      { request: noPermissionFlow } as never,
+      0,
+      Infinity,
+    );
+    const rawText =
+      '[{"version":"v0.9","createSurface":{"surfaceId":"s1","components":[]}},' +
+      '{"version":"v0.9","updateComponents":{"surfaceId":"s1","components":[]}},' +
+      '{"version":"v0.9","updateDataModel":{"surfaceId":"s2","path":"/","value":1}}]\n' +
+      'rendered fallback';
+
+    await client.sessionUpdate({
+      sessionId: 'sess:a2ui',
+      update: {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'call-1',
+        _meta: { serverId: 'a2ui-ui', toolName: 'present_choices' },
+        content: [
+          { type: 'content', content: { type: 'text', text: rawText } },
+        ],
+        rawOutput: rawText,
+      },
+    } as Parameters<BridgeClient['sessionUpdate']>[0]);
+
+    type PublishedFrame = {
+      type: string;
+      originatorClientId?: string;
+      data: {
+        sessionId: string;
+        update: {
+          sessionUpdate: string;
+          a2ui?: {
+            surfaceId: string;
+            callId?: string;
+            commands: unknown[];
+          };
+          content?: Array<{ content: { text: string } }>;
+          rawOutput?: string;
+          _meta?: { source?: string };
+        };
+      };
+    };
+    const published = publish.mock.calls.map(
+      ([frame]) => frame as PublishedFrame,
+    );
+
+    expect(published).toHaveLength(3);
+    expect(published[0]).toMatchObject({
+      type: 'session_update',
+      originatorClientId: 'client-1',
+      data: {
+        sessionId: 'sess:a2ui',
+        update: {
+          sessionUpdate: 'a2ui',
+          a2ui: {
+            surfaceId: 's1',
+            callId: 'call-1',
+          },
+          _meta: { source: 'a2ui-bridge' },
+        },
+      },
+    });
+    expect(published[0].data.update.a2ui?.commands).toHaveLength(2);
+    expect(published[1].data.update.a2ui).toMatchObject({
+      surfaceId: 's2',
+      callId: 'call-1',
+    });
+    expect(published[1].data.update.a2ui?.commands).toHaveLength(1);
+    expect(published[2].originatorClientId).toBe('client-1');
+    expect(published[2].data.update.content?.[0].content.text).toBe(
+      'rendered fallback',
+    );
+    expect(published[2].data.update.rawOutput).toBe('rendered fallback');
+    expect(JSON.stringify(published[2].data.update)).not.toContain(
+      'createSurface',
+    );
+  });
+});
+
 /**
  * Wenshao review #4335 / 3271978365 — `requestPermission`'s pre-publish
  * `CancelSentinelCollisionError` guard prevents an orphan SSE

--- a/packages/acp-bridge/src/bridgeClient.ts
+++ b/packages/acp-bridge/src/bridgeClient.ts
@@ -1289,14 +1289,22 @@ export function extractA2uiToolUpdate(
   const grouped = new Map<string, unknown[]>();
   for (const c of commands) {
     const sid = surfaceIdOf(c);
-    if (!sid) continue;
+    if (!sid) {
+      const shape =
+        c && typeof c === 'object'
+          ? Object.keys(c).join(',') || 'empty object'
+          : typeof c;
+      writeStderrLine(
+        `a2ui: dropping command with unrecognized shape (${shape})`,
+      );
+      continue;
+    }
     if (!grouped.has(sid)) {
       grouped.set(sid, []);
       order.push(sid);
     }
     grouped.get(sid)!.push(c);
   }
-  if (order.length === 0) return null;
   const surfaces = order.map((sid) => ({
     surfaceId: sid,
     commands: grouped.get(sid)!,

--- a/packages/acp-bridge/src/bridgeClient.ts
+++ b/packages/acp-bridge/src/bridgeClient.ts
@@ -409,22 +409,26 @@ export class BridgeClient implements Client {
     // original tool frame so raw command JSON never reaches transcripts/SSE.
     const a2ui = extractA2uiToolUpdate(params);
     if (a2ui) {
-      events.publish({
-        type: 'session_update',
-        data: {
-          sessionId: params.sessionId,
-          update: {
-            sessionUpdate: 'a2ui',
-            a2ui: {
-              surfaceId: a2ui.surfaceId,
-              callId: a2ui.callId,
-              commands: a2ui.commands,
+      // One frame per surface: tool results carrying commands for multiple
+      // surfaces are split so every consumer sees a single-surface frame.
+      for (const surface of a2ui.surfaces) {
+        events.publish({
+          type: 'session_update',
+          data: {
+            sessionId: params.sessionId,
+            update: {
+              sessionUpdate: 'a2ui',
+              a2ui: {
+                surfaceId: surface.surfaceId,
+                callId: a2ui.callId,
+                commands: surface.commands,
+              },
+              _meta: { serverTimestamp: Date.now(), source: 'a2ui-bridge' },
             },
-            _meta: { serverTimestamp: Date.now(), source: 'a2ui-bridge' },
           },
-        },
-        ...originator,
-      });
+          ...originator,
+        });
+      }
       params = a2ui.sanitizedParams;
     }
     events.publish({
@@ -1159,9 +1163,11 @@ export class BridgeClient implements Client {
  * "a2ui" is treated as a UI server, so new tools added to that server need no
  * change here); tool-name matching is the fallback for legacy frames/replays
  * where serverId is absent.
+ *
+ * Exported for unit testing.
  */
 const A2UI_TOOL_RE = /(^|__)(present_ui|present_choices|a2ui_action)$/;
-function isA2uiToolMeta(meta?: {
+export function isA2uiToolMeta(meta?: {
   toolName?: string;
   serverId?: string;
 }): boolean {
@@ -1177,8 +1183,10 @@ function isA2uiToolMeta(meta?: {
 /**
  * Extract the balanced JSON array at the start of the text; returns
  * [command array, remaining fallback text], or null when no array parses.
+ *
+ * Exported for unit testing.
  */
-function splitA2uiText(raw: string): [unknown[], string] | null {
+export function splitA2uiText(raw: string): [unknown[], string] | null {
   const s = raw.replace(/^\s+/, '');
   if (s[0] !== '[') return null;
   let depth = 0;
@@ -1213,20 +1221,39 @@ function splitA2uiText(raw: string): [unknown[], string] | null {
   }
 }
 
-interface A2uiExtraction {
-  surfaceId: string;
+/** Read the surfaceId off any of the four A2UI command kinds. */
+function surfaceIdOf(c: unknown): string | undefined {
+  const cmd = c as {
+    createSurface?: { surfaceId?: string };
+    updateComponents?: { surfaceId?: string };
+    updateDataModel?: { surfaceId?: string };
+    deleteSurface?: { surfaceId?: string };
+  };
+  return (
+    cmd?.createSurface?.surfaceId ??
+    cmd?.updateComponents?.surfaceId ??
+    cmd?.updateDataModel?.surfaceId ??
+    cmd?.deleteSurface?.surfaceId
+  );
+}
+
+export interface A2uiExtraction {
+  /** Commands grouped per surface, in first-appearance order. */
+  surfaces: Array<{ surfaceId: string; commands: unknown[] }>;
   callId: string | undefined;
-  commands: unknown[];
   /** Sanitized copy of the notification: the A2UI JSON in the tool-result text is replaced with the fallback text. */
   sanitizedParams: SessionNotification;
 }
 
 /**
  * If the notification is a `tool_call_update` from an A2UI tool whose result
- * carries an A2UI command array, extract the commands and produce a sanitized
- * notification; otherwise return null (the notification is forwarded as-is).
+ * carries an A2UI command array, extract the commands (grouped per surface)
+ * and produce a sanitized notification; otherwise return null (the
+ * notification is forwarded as-is).
+ *
+ * Exported for unit testing.
  */
-function extractA2uiToolUpdate(
+export function extractA2uiToolUpdate(
   params: SessionNotification,
 ): A2uiExtraction | null {
   const update = (params as { update?: Record<string, unknown> }).update;
@@ -1255,24 +1282,25 @@ function extractA2uiToolUpdate(
   if (!split) return null;
   const [commands, fallback] = split;
 
-  // surfaceId may arrive on any of the four command kinds (updateDataModel-only
-  // / deleteSurface-only tool results are legal too).
-  let surfaceId: string | undefined;
+  // Group commands per surface (updateDataModel-only / deleteSurface-only
+  // tool results are legal too). Commands without a surfaceId are dropped —
+  // every A2UI server->client command carries one per the spec.
+  const order: string[] = [];
+  const grouped = new Map<string, unknown[]>();
   for (const c of commands) {
-    const cmd = c as {
-      createSurface?: { surfaceId?: string };
-      updateComponents?: { surfaceId?: string };
-      updateDataModel?: { surfaceId?: string };
-      deleteSurface?: { surfaceId?: string };
-    };
-    surfaceId =
-      cmd?.createSurface?.surfaceId ??
-      cmd?.updateComponents?.surfaceId ??
-      cmd?.updateDataModel?.surfaceId ??
-      cmd?.deleteSurface?.surfaceId;
-    if (surfaceId) break;
+    const sid = surfaceIdOf(c);
+    if (!sid) continue;
+    if (!grouped.has(sid)) {
+      grouped.set(sid, []);
+      order.push(sid);
+    }
+    grouped.get(sid)!.push(c);
   }
-  if (!surfaceId) return null;
+  if (order.length === 0) return null;
+  const surfaces = order.map((sid) => ({
+    surfaceId: sid,
+    commands: grouped.get(sid)!,
+  }));
 
   // Sanitize: JSON -> fallback text. The model already received the raw text
   // inside the ACP child; what is being cleaned here is the SSE/transcript copy.
@@ -1296,12 +1324,11 @@ function extractA2uiToolUpdate(
     sanitizedUpdate['rawOutput'] = sanitizedText;
   }
   return {
-    surfaceId,
+    surfaces,
     callId:
       typeof update['toolCallId'] === 'string'
         ? update['toolCallId']
         : undefined,
-    commands,
     sanitizedParams: {
       ...(params as Record<string, unknown>),
       update: sanitizedUpdate,

--- a/packages/acp-bridge/src/bridgeClient.ts
+++ b/packages/acp-bridge/src/bridgeClient.ts
@@ -398,12 +398,39 @@ export class BridgeClient implements Client {
     const events =
       entry?.events ?? this.resolvePendingRestoreEvents(params.sessionId);
     if (!events) return;
+    const originator = entry?.activePromptOriginatorClientId
+      ? { originatorClientId: entry.activePromptOriginatorClientId }
+      : {};
+    // A2UI-over-MCP: tool_call_update results from an A2UI UI server carry
+    // the A2UI command JSON flattened by core (EmbeddedResource -> text, the
+    // application/a2ui+json mime is dropped, so detection keys off the
+    // server/tool identity). Extract the commands, publish them as a separate
+    // `sessionUpdate:'a2ui'` frame for renderer clients, and sanitize the
+    // original tool frame so raw command JSON never reaches transcripts/SSE.
+    const a2ui = extractA2uiToolUpdate(params);
+    if (a2ui) {
+      events.publish({
+        type: 'session_update',
+        data: {
+          sessionId: params.sessionId,
+          update: {
+            sessionUpdate: 'a2ui',
+            a2ui: {
+              surfaceId: a2ui.surfaceId,
+              callId: a2ui.callId,
+              commands: a2ui.commands,
+            },
+            _meta: { serverTimestamp: Date.now(), source: 'a2ui-bridge' },
+          },
+        },
+        ...originator,
+      });
+      params = a2ui.sanitizedParams;
+    }
     events.publish({
       type: 'session_update',
       data: params,
-      ...(entry?.activePromptOriginatorClientId
-        ? { originatorClientId: entry.activePromptOriginatorClientId }
-        : {}),
+      ...originator,
     });
   }
 
@@ -1116,4 +1143,168 @@ export class BridgeClient implements Client {
     }
     return { content };
   }
+}
+
+// ---------------------------------------------------------------------------
+// A2UI-over-MCP extraction.
+// Detection has to key off the server/tool identity rather than mime type:
+// core's transformResourceBlock flattens EmbeddedResource blocks to `{text}`
+// and drops the application/a2ui+json mimeType, so by the time the result
+// reaches the bridge it is plain text of the form
+// `<A2UI command JSON array>\n<fallback text>`.
+// ---------------------------------------------------------------------------
+
+/**
+ * A2UI tool detection: prefer `_meta.serverId` (a server whose name contains
+ * "a2ui" is treated as a UI server, so new tools added to that server need no
+ * change here); tool-name matching is the fallback for legacy frames/replays
+ * where serverId is absent.
+ */
+const A2UI_TOOL_RE = /(^|__)(present_ui|present_choices|a2ui_action)$/;
+function isA2uiToolMeta(meta?: {
+  toolName?: string;
+  serverId?: string;
+}): boolean {
+  if (!meta) return false;
+  if (
+    typeof meta.serverId === 'string' &&
+    meta.serverId.toLowerCase().includes('a2ui')
+  )
+    return true;
+  return typeof meta.toolName === 'string' && A2UI_TOOL_RE.test(meta.toolName);
+}
+
+/**
+ * Extract the balanced JSON array at the start of the text; returns
+ * [command array, remaining fallback text], or null when no array parses.
+ */
+function splitA2uiText(raw: string): [unknown[], string] | null {
+  const s = raw.replace(/^\s+/, '');
+  if (s[0] !== '[') return null;
+  let depth = 0;
+  let inStr = false;
+  let esc = false;
+  let end = -1;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (c === '\\') esc = true;
+      else if (c === '"') inStr = false;
+      continue;
+    }
+    if (c === '"') inStr = true;
+    else if (c === '[') depth++;
+    else if (c === ']') {
+      depth--;
+      if (depth === 0) {
+        end = i + 1;
+        break;
+      }
+    }
+  }
+  if (end < 0) return null;
+  try {
+    const arr = JSON.parse(s.slice(0, end));
+    if (!Array.isArray(arr) || arr.length === 0) return null;
+    return [arr, s.slice(end).trim()];
+  } catch {
+    return null;
+  }
+}
+
+interface A2uiExtraction {
+  surfaceId: string;
+  callId: string | undefined;
+  commands: unknown[];
+  /** Sanitized copy of the notification: the A2UI JSON in the tool-result text is replaced with the fallback text. */
+  sanitizedParams: SessionNotification;
+}
+
+/**
+ * If the notification is a `tool_call_update` from an A2UI tool whose result
+ * carries an A2UI command array, extract the commands and produce a sanitized
+ * notification; otherwise return null (the notification is forwarded as-is).
+ */
+function extractA2uiToolUpdate(
+  params: SessionNotification,
+): A2uiExtraction | null {
+  const update = (params as { update?: Record<string, unknown> }).update;
+  if (!update || update['sessionUpdate'] !== 'tool_call_update') return null;
+  const meta = update['_meta'] as
+    | { toolName?: string; serverId?: string }
+    | undefined;
+  if (!isA2uiToolMeta(meta)) return null;
+
+  // The result text lives at content[].content.text (ACP ToolCallContent
+  // wraps one level); rawOutput mirrors the same text.
+  const content = update['content'];
+  if (!Array.isArray(content)) return null;
+  let split: [unknown[], string] | null = null;
+  let hitIndex = -1;
+  for (let i = 0; i < content.length; i++) {
+    const inner = (content[i] as { content?: { text?: unknown } })?.content;
+    if (typeof inner?.text === 'string') {
+      split = splitA2uiText(inner.text);
+      if (split) {
+        hitIndex = i;
+        break;
+      }
+    }
+  }
+  if (!split) return null;
+  const [commands, fallback] = split;
+
+  // surfaceId may arrive on any of the four command kinds (updateDataModel-only
+  // / deleteSurface-only tool results are legal too).
+  let surfaceId: string | undefined;
+  for (const c of commands) {
+    const cmd = c as {
+      createSurface?: { surfaceId?: string };
+      updateComponents?: { surfaceId?: string };
+      updateDataModel?: { surfaceId?: string };
+      deleteSurface?: { surfaceId?: string };
+    };
+    surfaceId =
+      cmd?.createSurface?.surfaceId ??
+      cmd?.updateComponents?.surfaceId ??
+      cmd?.updateDataModel?.surfaceId ??
+      cmd?.deleteSurface?.surfaceId;
+    if (surfaceId) break;
+  }
+  if (!surfaceId) return null;
+
+  // Sanitize: JSON -> fallback text. The model already received the raw text
+  // inside the ACP child; what is being cleaned here is the SSE/transcript copy.
+  const sanitizedText = fallback || '[A2UI surface rendered]';
+  const sanitizedContent = content.map((block, i) =>
+    i === hitIndex
+      ? {
+          ...(block as Record<string, unknown>),
+          content: {
+            ...((block as { content?: Record<string, unknown> }).content ?? {}),
+            text: sanitizedText,
+          },
+        }
+      : block,
+  );
+  const sanitizedUpdate: Record<string, unknown> = {
+    ...update,
+    content: sanitizedContent,
+  };
+  if (typeof update['rawOutput'] === 'string') {
+    sanitizedUpdate['rawOutput'] = sanitizedText;
+  }
+  return {
+    surfaceId,
+    callId:
+      typeof update['toolCallId'] === 'string'
+        ? update['toolCallId']
+        : undefined,
+    commands,
+    sanitizedParams: {
+      ...(params as Record<string, unknown>),
+      update: sanitizedUpdate,
+    } as SessionNotification,
+  };
 }

--- a/packages/cli/src/serve/routes/a2uiAction.test.ts
+++ b/packages/cli/src/serve/routes/a2uiAction.test.ts
@@ -1,0 +1,184 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import * as fsp from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  registerA2uiActionRoutes,
+  findFromSettingsFile,
+  usableServerConfig,
+  type A2uiActionArgs,
+  type A2uiActionResult,
+  type McpServerCell,
+  type McpServerConfigLike,
+} from './a2uiAction.js';
+
+function makeApp(opts: {
+  servers?: McpServerCell[];
+  serversError?: boolean;
+  callAction?: (
+    cfg: McpServerConfigLike,
+    args: A2uiActionArgs,
+  ) => Promise<A2uiActionResult>;
+  workspace?: string;
+}) {
+  const app = express();
+  app.use(express.json());
+  const calls: A2uiActionArgs[] = [];
+  const configs: McpServerConfigLike[] = [];
+  registerA2uiActionRoutes(app, {
+    boundWorkspace: opts.workspace ?? '/nonexistent-workspace',
+    mutate: () => (_req, _res, next) => next(),
+    safeBody: (req) =>
+      req.body && typeof req.body === 'object' ? req.body : {},
+    getMcpServers: async () => {
+      if (opts.serversError) throw new Error('status unavailable');
+      return opts.servers ?? [];
+    },
+    callAction:
+      opts.callAction ??
+      (async (cfg, args) => {
+        configs.push(cfg);
+        calls.push(args);
+        return { commands: [{ version: 'v0.9' }], fallback: 'ok' };
+      }),
+  });
+  return { app, calls, configs };
+}
+
+const STDIO_SERVER: McpServerCell = {
+  name: 'a2ui-ui',
+  mcpStatus: 'connected',
+  config: { command: 'node', args: ['server.mjs'] },
+};
+
+describe('POST /session/:id/a2ui-action', () => {
+  it('rejects a missing or empty name with 400', async () => {
+    const { app } = makeApp({ servers: [STDIO_SERVER] });
+    await request(app).post('/session/s1/a2ui-action').send({}).expect(400);
+    await request(app)
+      .post('/session/s1/a2ui-action')
+      .send({ name: '  ' })
+      .expect(400);
+  });
+
+  it('returns 503 when no a2ui server is discoverable anywhere', async () => {
+    const { app } = makeApp({
+      servers: [{ name: 'github', config: { command: 'x' } }],
+    });
+    const res = await request(app)
+      .post('/session/s1/a2ui-action')
+      .send({ name: 'go' })
+      .expect(503);
+    expect(res.body.error).toMatch(/no a2ui MCP server/);
+  });
+
+  it('proxies to the action tool and returns its continuation', async () => {
+    const { app, calls } = makeApp({ servers: [STDIO_SERVER] });
+    const res = await request(app)
+      .post('/session/s1/a2ui-action')
+      .send({ name: ' submit ', surfaceId: 'ui_1', context: { a: 1 } })
+      .expect(200);
+    expect(res.body).toEqual({
+      commands: [{ version: 'v0.9' }],
+      fallback: 'ok',
+    });
+    expect(calls).toEqual([
+      { name: 'submit', surfaceId: 'ui_1', context: { a: 1 } },
+    ]);
+  });
+
+  it('strips a non-object/array context instead of forwarding it', async () => {
+    const { app, calls } = makeApp({ servers: [STDIO_SERVER] });
+    await request(app)
+      .post('/session/s1/a2ui-action')
+      .send({ name: 'go', context: [1, 2, 3] })
+      .expect(200);
+    expect(calls[0].context).toBeUndefined();
+  });
+
+  it('prefers a connected server over a merely-listed one', async () => {
+    const disconnected: McpServerCell = {
+      name: 'a2ui-old',
+      mcpStatus: 'disconnected',
+      config: { command: 'old' },
+    };
+    const { app, configs } = makeApp({ servers: [disconnected, STDIO_SERVER] });
+    await request(app)
+      .post('/session/s1/a2ui-action')
+      .send({ name: 'go' })
+      .expect(200);
+    expect(configs[0]).toEqual(STDIO_SERVER.config);
+  });
+
+  it('falls back to workspace settings when daemon status is unavailable', async () => {
+    const ws = await fsp.mkdtemp(path.join(os.tmpdir(), 'a2ui-action-test-'));
+    await fsp.mkdir(path.join(ws, '.qwen'), { recursive: true });
+    await fsp.writeFile(
+      path.join(ws, '.qwen', 'settings.json'),
+      JSON.stringify({
+        mcpServers: { 'my-a2ui': { command: 'node', args: ['x.mjs'] } },
+      }),
+    );
+    try {
+      const { app, configs } = makeApp({ serversError: true, workspace: ws });
+      await request(app)
+        .post('/session/s1/a2ui-action')
+        .send({ name: 'go' })
+        .expect(200);
+      expect(configs[0]).toEqual({ command: 'node', args: ['x.mjs'] });
+    } finally {
+      await fsp.rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  it('maps proxy failures to a generic 502 without leaking details', async () => {
+    const errSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    const { app } = makeApp({
+      servers: [STDIO_SERVER],
+      callAction: async () => {
+        throw new Error('spawn /secret/path failed');
+      },
+    });
+    const res = await request(app)
+      .post('/session/s1/a2ui-action')
+      .send({ name: 'go' })
+      .expect(502);
+    expect(res.body).toEqual({ error: 'a2ui action call failed' });
+    expect(JSON.stringify(res.body)).not.toContain('/secret/path');
+    errSpy.mockRestore();
+  });
+});
+
+describe('helpers', () => {
+  beforeEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it('usableServerConfig accepts stdio or streamable-http shapes only', () => {
+    expect(usableServerConfig({ command: 'node' })).toBe(true);
+    expect(usableServerConfig({ httpUrl: 'https://x/mcp' })).toBe(true);
+    expect(usableServerConfig({})).toBe(false);
+    expect(usableServerConfig(undefined)).toBe(false);
+  });
+
+  it('findFromSettingsFile returns null for a missing or unparseable file', async () => {
+    expect(await findFromSettingsFile('/definitely-missing-dir')).toBeNull();
+    const ws = await fsp.mkdtemp(path.join(os.tmpdir(), 'a2ui-action-test-'));
+    await fsp.mkdir(path.join(ws, '.qwen'), { recursive: true });
+    await fsp.writeFile(path.join(ws, '.qwen', 'settings.json'), '{not json');
+    try {
+      expect(await findFromSettingsFile(ws)).toBeNull();
+    } finally {
+      await fsp.rm(ws, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/src/serve/routes/a2uiAction.test.ts
+++ b/packages/cli/src/serve/routes/a2uiAction.test.ts
@@ -12,6 +12,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import {
   registerA2uiActionRoutes,
+  extractA2uiActionResult,
   findFromSettingsFile,
   usableServerConfig,
   type A2uiActionArgs,
@@ -162,6 +163,97 @@ describe('POST /session/:id/a2ui-action', () => {
 describe('helpers', () => {
   beforeEach(() => vi.restoreAllMocks());
   afterEach(() => vi.restoreAllMocks());
+
+  it('extracts the first A2UI resource and accumulates text fallback', () => {
+    const result = extractA2uiActionResult({
+      content: [
+        { type: 'text', text: 'before ' },
+        {
+          type: 'resource',
+          resource: {
+            mimeType: 'application/a2ui+json',
+            text: JSON.stringify([
+              {
+                command: 'update',
+                payload: { items: [['nested']], label: 'say "hi"' },
+              },
+            ]),
+          },
+        },
+        {
+          type: 'resource',
+          resource: {
+            mimeType: 'application/a2ui+json',
+            text: JSON.stringify([{ command: 'ignored' }]),
+          },
+        },
+        { type: 'text', text: 'after' },
+      ],
+    });
+
+    expect(result).toEqual({
+      commands: [
+        {
+          command: 'update',
+          payload: { items: [['nested']], label: 'say "hi"' },
+        },
+      ],
+      fallback: 'before after',
+    });
+  });
+
+  it('keeps empty arrays and ignores invalid or non-array resources', () => {
+    expect(
+      extractA2uiActionResult({
+        content: [
+          {
+            type: 'resource',
+            resource: {
+              mimeType: 'application/a2ui+json',
+              text: '[',
+            },
+          },
+          {
+            type: 'resource',
+            resource: {
+              mimeType: 'application/a2ui+json',
+              text: '{"command":"not-array"}',
+            },
+          },
+        ],
+      }),
+    ).toEqual({ commands: null, fallback: '' });
+
+    expect(
+      extractA2uiActionResult({
+        content: [
+          {
+            type: 'resource',
+            resource: {
+              mimeType: 'application/a2ui+json',
+              text: '[]',
+            },
+          },
+        ],
+      }),
+    ).toEqual({ commands: [], fallback: '' });
+  });
+
+  it('throws MCP tool errors with text details when present', () => {
+    expect(() =>
+      extractA2uiActionResult({
+        isError: true,
+        content: [
+          { type: 'text', text: 'bad ' },
+          { type: 'text', text: 'input' },
+        ],
+      }),
+    ).toThrow('a2ui action tool returned error: bad input');
+
+    expect(() => extractA2uiActionResult({ isError: true })).toThrow(
+      'a2ui action tool returned error: unknown error',
+    );
+  });
 
   it('usableServerConfig accepts stdio or streamable-http shapes only', () => {
     expect(usableServerConfig({ command: 'node' })).toBe(true);

--- a/packages/cli/src/serve/routes/a2uiAction.test.ts
+++ b/packages/cli/src/serve/routes/a2uiAction.test.ts
@@ -10,8 +10,66 @@ import request from 'supertest';
 import * as fsp from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
+
+const sdkMocks = vi.hoisted(() => {
+  const state = {
+    stdioTransports: [] as unknown[],
+    httpTransports: [] as unknown[],
+    clients: [] as unknown[],
+    connectError: undefined as Error | undefined,
+    toolResult: { content: [{ type: 'text', text: 'ok' }] } as unknown,
+  };
+
+  class MockStdioClientTransport {
+    close = vi.fn(async () => {});
+
+    constructor(public options: unknown) {
+      state.stdioTransports.push(this);
+    }
+  }
+
+  class MockStreamableHTTPClientTransport {
+    close = vi.fn(async () => {});
+
+    constructor(public url: URL) {
+      state.httpTransports.push(this);
+    }
+  }
+
+  class MockClient {
+    connect = vi.fn(async () => {
+      if (state.connectError) throw state.connectError;
+    });
+    callTool = vi.fn(async () => state.toolResult);
+    close = vi.fn(async () => {});
+
+    constructor(public clientInfo: unknown) {
+      state.clients.push(this);
+    }
+  }
+
+  return {
+    state,
+    MockClient,
+    MockStdioClientTransport,
+    MockStreamableHTTPClientTransport,
+  };
+});
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: sdkMocks.MockClient,
+}));
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: sdkMocks.MockStdioClientTransport,
+}));
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: sdkMocks.MockStreamableHTTPClientTransport,
+}));
+
 import {
   registerA2uiActionRoutes,
+  buildTransport,
+  callA2uiAction,
   extractA2uiActionResult,
   findFromSettingsFile,
   usableServerConfig,
@@ -161,7 +219,14 @@ describe('POST /session/:id/a2ui-action', () => {
 });
 
 describe('helpers', () => {
-  beforeEach(() => vi.restoreAllMocks());
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    sdkMocks.state.stdioTransports.length = 0;
+    sdkMocks.state.httpTransports.length = 0;
+    sdkMocks.state.clients.length = 0;
+    sdkMocks.state.connectError = undefined;
+    sdkMocks.state.toolResult = { content: [{ type: 'text', text: 'ok' }] };
+  });
   afterEach(() => vi.restoreAllMocks());
 
   it('extracts the first A2UI resource and accumulates text fallback', () => {
@@ -260,6 +325,83 @@ describe('helpers', () => {
     expect(usableServerConfig({ httpUrl: 'https://x/mcp' })).toBe(true);
     expect(usableServerConfig({})).toBe(false);
     expect(usableServerConfig(undefined)).toBe(false);
+  });
+
+  it('buildTransport creates streamable HTTP transports', () => {
+    buildTransport({ httpUrl: 'https://example.com/mcp' });
+
+    const transport = sdkMocks.state.httpTransports[0] as { url: URL };
+    expect(transport.url.href).toBe('https://example.com/mcp');
+    expect(sdkMocks.state.stdioTransports).toHaveLength(0);
+  });
+
+  it('buildTransport merges stdio env only when provided', () => {
+    buildTransport({
+      command: 'node',
+      args: ['server.mjs'],
+      env: { A2UI_TOKEN: 'secret' },
+      cwd: '/workspace',
+    });
+    buildTransport({ command: 'node' });
+
+    const withEnv = sdkMocks.state.stdioTransports[0] as {
+      options: {
+        command: string;
+        args: string[];
+        env?: Record<string, string | undefined>;
+        cwd?: string;
+      };
+    };
+    const withoutEnv = sdkMocks.state.stdioTransports[1] as {
+      options: { env?: Record<string, string | undefined> };
+    };
+    expect(withEnv.options).toMatchObject({
+      command: 'node',
+      args: ['server.mjs'],
+      cwd: '/workspace',
+    });
+    expect(withEnv.options.env?.['A2UI_TOKEN']).toBe('secret');
+    expect(withEnv.options.env?.['PATH']).toBe(process.env['PATH']);
+    expect(withoutEnv.options).not.toHaveProperty('env');
+  });
+
+  it('callA2uiAction connects, calls the action tool, and closes resources', async () => {
+    const result = await callA2uiAction({ command: 'node' }, { name: 'tap' });
+
+    const transport = sdkMocks.state.stdioTransports[0];
+    const client = sdkMocks.state.clients[0] as {
+      connect: unknown;
+      callTool: unknown;
+      close: unknown;
+    };
+    expect(result).toEqual({ commands: null, fallback: 'ok' });
+    expect(client.connect).toHaveBeenCalledWith(transport, {
+      timeout: 15_000,
+    });
+    expect(client.callTool).toHaveBeenCalledWith(
+      { name: 'action', arguments: { name: 'tap' } },
+      undefined,
+      { timeout: 15_000 },
+    );
+    expect((transport as { close: unknown }).close).toHaveBeenCalledTimes(1);
+    expect(client.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('callA2uiAction closes resources when connect fails', async () => {
+    sdkMocks.state.connectError = new Error('connect failed');
+
+    await expect(
+      callA2uiAction({ command: 'node' }, { name: 'tap' }),
+    ).rejects.toThrow('connect failed');
+
+    const transport = sdkMocks.state.stdioTransports[0] as { close: unknown };
+    const client = sdkMocks.state.clients[0] as {
+      callTool: unknown;
+      close: unknown;
+    };
+    expect(client.callTool).not.toHaveBeenCalled();
+    expect(transport.close).toHaveBeenCalledTimes(1);
+    expect(client.close).toHaveBeenCalledTimes(1);
   });
 
   it('findFromSettingsFile returns null for a missing or unparseable file', async () => {

--- a/packages/cli/src/serve/routes/a2uiAction.ts
+++ b/packages/cli/src/serve/routes/a2uiAction.ts
@@ -1,0 +1,209 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * A2UI action inbound endpoint (the upstream half of A2UI-over-MCP).
+ *
+ * `POST /session/:id/a2ui-action`: web clients post user interactions on an
+ * A2UI surface (`{name, surfaceId, context}`) to the daemon, which proxies
+ * them to the UI MCP server's standard `action` tool (clients never talk to
+ * MCP directly). Continuation A2UI commands returned by the tool
+ * (EmbeddedResource, mimeType=application/a2ui+json) are sent back
+ * synchronously in the HTTP response as `{commands, fallback}`.
+ *
+ * UI-server discovery order:
+ *  1. the daemon's workspace MCP status (injected via getMcpServers) — this
+ *     covers servers registered at runtime via POST /workspace/mcp/servers;
+ *     any server whose name contains "a2ui" is a candidate, connected first;
+ *  2. fallback: `mcpServers` in the workspace `.qwen/settings.json` (when the
+ *     daemon status is unavailable).
+ * Transports: stdio (command/args) and streamable HTTP (httpUrl).
+ * Each action spawns a one-shot client (the tool is stateless; a direct
+ * per-call connection is the most robust option).
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { Application, Request, RequestHandler, Response } from 'express';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+
+const A2UI_MIME = 'application/a2ui+json';
+// Standard action-tool name from the official A2UI-over-MCP guide
+// (a2ui.org/guides/a2ui_over_mcp).
+const ACTION_TOOL = 'action';
+const CALL_TIMEOUT_MS = 15_000;
+
+interface McpServerConfigLike {
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  httpUrl?: string;
+  url?: string;
+  cwd?: string;
+}
+
+interface McpServerCell {
+  name: string;
+  mcpStatus?: string;
+  config?: McpServerConfigLike;
+}
+
+interface RegisterA2uiActionRoutesOptions {
+  boundWorkspace: string;
+  mutate: () => RequestHandler;
+  safeBody: (req: Request) => Record<string, unknown>;
+  /** Workspace MCP status from the daemon (includes runtime-registered servers). */
+  getMcpServers: (req: Request) => Promise<McpServerCell[]>;
+}
+
+function usable(cfg?: McpServerConfigLike): boolean {
+  return (
+    !!cfg &&
+    (typeof cfg.command === 'string' || typeof cfg.httpUrl === 'string')
+  );
+}
+
+/** Fallback: read the workspace settings file directly (when the daemon status is unavailable). */
+function findFromSettingsFile(
+  workspaceCwd: string,
+): McpServerConfigLike | null {
+  try {
+    const raw = fs.readFileSync(
+      path.join(workspaceCwd, '.qwen', 'settings.json'),
+      'utf8',
+    );
+    const settings = JSON.parse(raw) as {
+      mcpServers?: Record<string, McpServerConfigLike>;
+    };
+    for (const [name, cfg] of Object.entries(settings.mcpServers ?? {})) {
+      if (name.toLowerCase().includes('a2ui') && usable(cfg)) return cfg;
+    }
+  } catch {
+    /* Missing/unparseable settings file -> treated as not configured. */
+  }
+  return null;
+}
+
+/** Build a one-shot transport from the config shape: stdio (command) or streamable HTTP (httpUrl). */
+function buildTransport(cfg: McpServerConfigLike): Transport {
+  if (typeof cfg.httpUrl === 'string') {
+    return new StreamableHTTPClientTransport(new URL(cfg.httpUrl));
+  }
+  return new StdioClientTransport({
+    command: cfg.command!,
+    args: cfg.args ?? [],
+    env: cfg.env,
+    cwd: cfg.cwd,
+  });
+}
+
+/** Call the UI MCP server's action tool directly and extract the A2UI continuation commands plus fallback text. */
+async function callA2uiAction(
+  cfg: McpServerConfigLike,
+  args: { name: string; surfaceId?: string; context?: Record<string, unknown> },
+): Promise<{ commands: unknown[] | null; fallback: string }> {
+  const transport = buildTransport(cfg);
+  const client = new Client({ name: 'qwen-serve-a2ui', version: '0.0.1' });
+  try {
+    await client.connect(transport);
+    const result = (await client.callTool(
+      { name: ACTION_TOOL, arguments: args },
+      undefined,
+      { timeout: CALL_TIMEOUT_MS },
+    )) as {
+      content?: Array<{
+        type: string;
+        text?: string;
+        resource?: { mimeType?: string; text?: string };
+      }>;
+    };
+    let commands: unknown[] | null = null;
+    let fallback = '';
+    for (const block of result.content ?? []) {
+      if (
+        block.type === 'resource' &&
+        block.resource?.mimeType === A2UI_MIME &&
+        typeof block.resource.text === 'string'
+      ) {
+        try {
+          const parsed = JSON.parse(block.resource.text);
+          if (Array.isArray(parsed)) commands = parsed;
+        } catch {
+          /* Invalid JSON -> treated as no continuation frame. */
+        }
+      } else if (block.type === 'text' && typeof block.text === 'string') {
+        fallback += block.text;
+      }
+    }
+    return { commands, fallback };
+  } finally {
+    await client.close().catch(() => {});
+  }
+}
+
+export function registerA2uiActionRoutes(
+  app: Application,
+  opts: RegisterA2uiActionRoutesOptions,
+): void {
+  const { boundWorkspace, mutate, safeBody, getMcpServers } = opts;
+
+  app.post(
+    '/session/:id/a2ui-action',
+    mutate(),
+    async (req: Request, res: Response) => {
+      const body = safeBody(req);
+      const name = body['name'];
+      if (typeof name !== 'string' || name.trim().length === 0) {
+        res.status(400).json({ error: '`name` is required' });
+        return;
+      }
+      const surfaceId =
+        typeof body['surfaceId'] === 'string' ? body['surfaceId'] : undefined;
+      const context =
+        body['context'] && typeof body['context'] === 'object'
+          ? (body['context'] as Record<string, unknown>)
+          : undefined;
+
+      // Discover the UI server: daemon status first (covers runtime
+      // registration), settings file as fallback.
+      let cfg: McpServerConfigLike | null = null;
+      try {
+        const servers = (await getMcpServers(req)).filter(
+          (s) => s.name.toLowerCase().includes('a2ui') && usable(s.config),
+        );
+        const live = servers.find((s) => s.mcpStatus === 'connected');
+        cfg = (live ?? servers[0])?.config ?? null;
+      } catch {
+        /* Status unavailable -> fall through to the settings fallback. */
+      }
+      if (!cfg) cfg = findFromSettingsFile(boundWorkspace);
+      if (!cfg) {
+        res.status(503).json({
+          error:
+            'no a2ui MCP server found (neither runtime-registered nor in workspace settings mcpServers)',
+        });
+        return;
+      }
+      try {
+        const { commands, fallback } = await callA2uiAction(cfg, {
+          name: name.trim(),
+          surfaceId,
+          context,
+        });
+        res.status(200).json({ commands, fallback });
+      } catch (err) {
+        res.status(502).json({
+          error: `a2ui action call failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        });
+      }
+    },
+  );
+}

--- a/packages/cli/src/serve/routes/a2uiAction.ts
+++ b/packages/cli/src/serve/routes/a2uiAction.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Qwen
+ * Copyright 2025 Qwen Team
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -20,18 +20,20 @@
  *     any server whose name contains "a2ui" is a candidate, connected first;
  *  2. fallback: `mcpServers` in the workspace `.qwen/settings.json` (when the
  *     daemon status is unavailable).
- * Transports: stdio (command/args) and streamable HTTP (httpUrl).
+ * Transports: stdio (command/args) and streamable HTTP (httpUrl). Legacy SSE
+ * (`url`) is intentionally unsupported.
  * Each action spawns a one-shot client (the tool is stateless; a direct
  * per-call connection is the most robust option).
  */
 
-import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 import type { Application, Request, RequestHandler, Response } from 'express';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { writeStderrLine } from '../../utils/stdioHelpers.js';
 
 const A2UI_MIME = 'application/a2ui+json';
 // Standard action-tool name from the official A2UI-over-MCP guide
@@ -39,19 +41,29 @@ const A2UI_MIME = 'application/a2ui+json';
 const ACTION_TOOL = 'action';
 const CALL_TIMEOUT_MS = 15_000;
 
-interface McpServerConfigLike {
+export interface McpServerConfigLike {
   command?: string;
   args?: string[];
   env?: Record<string, string>;
   httpUrl?: string;
-  url?: string;
   cwd?: string;
 }
 
-interface McpServerCell {
+export interface McpServerCell {
   name: string;
   mcpStatus?: string;
   config?: McpServerConfigLike;
+}
+
+export interface A2uiActionArgs {
+  name: string;
+  surfaceId?: string;
+  context?: Record<string, unknown>;
+}
+
+export interface A2uiActionResult {
+  commands: unknown[] | null;
+  fallback: string;
 }
 
 interface RegisterA2uiActionRoutesOptions {
@@ -60,21 +72,30 @@ interface RegisterA2uiActionRoutesOptions {
   safeBody: (req: Request) => Record<string, unknown>;
   /** Workspace MCP status from the daemon (includes runtime-registered servers). */
   getMcpServers: (req: Request) => Promise<McpServerCell[]>;
+  /** Injectable for unit tests; defaults to the real one-shot MCP call. */
+  callAction?: (
+    cfg: McpServerConfigLike,
+    args: A2uiActionArgs,
+  ) => Promise<A2uiActionResult>;
 }
 
-function usable(cfg?: McpServerConfigLike): boolean {
+/** Exported for unit testing. */
+export function usableServerConfig(cfg?: McpServerConfigLike): boolean {
   return (
     !!cfg &&
     (typeof cfg.command === 'string' || typeof cfg.httpUrl === 'string')
   );
 }
 
-/** Fallback: read the workspace settings file directly (when the daemon status is unavailable). */
-function findFromSettingsFile(
+/**
+ * Fallback: read the workspace settings file directly (when the daemon
+ * status is unavailable). Exported for unit testing.
+ */
+export async function findFromSettingsFile(
   workspaceCwd: string,
-): McpServerConfigLike | null {
+): Promise<McpServerConfigLike | null> {
   try {
-    const raw = fs.readFileSync(
+    const raw = await fsp.readFile(
       path.join(workspaceCwd, '.qwen', 'settings.json'),
       'utf8',
     );
@@ -82,7 +103,9 @@ function findFromSettingsFile(
       mcpServers?: Record<string, McpServerConfigLike>;
     };
     for (const [name, cfg] of Object.entries(settings.mcpServers ?? {})) {
-      if (name.toLowerCase().includes('a2ui') && usable(cfg)) return cfg;
+      if (name.toLowerCase().includes('a2ui') && usableServerConfig(cfg)) {
+        return cfg;
+      }
     }
   } catch {
     /* Missing/unparseable settings file -> treated as not configured. */
@@ -98,7 +121,13 @@ function buildTransport(cfg: McpServerConfigLike): Transport {
   return new StdioClientTransport({
     command: cfg.command!,
     args: cfg.args ?? [],
-    env: cfg.env,
+    // spawn() treats `env` as a complete replacement, not a merge — a partial
+    // env (e.g. {API_KEY}) would strip PATH/HOME and break the child. Merge
+    // over process.env like packages/core/src/tools/mcp-client.ts does; when
+    // unset, let the SDK apply its safe default environment.
+    ...(cfg.env
+      ? { env: { ...process.env, ...cfg.env } as Record<string, string> }
+      : {}),
     cwd: cfg.cwd,
   });
 }
@@ -106,31 +135,47 @@ function buildTransport(cfg: McpServerConfigLike): Transport {
 /** Call the UI MCP server's action tool directly and extract the A2UI continuation commands plus fallback text. */
 async function callA2uiAction(
   cfg: McpServerConfigLike,
-  args: { name: string; surfaceId?: string; context?: Record<string, unknown> },
-): Promise<{ commands: unknown[] | null; fallback: string }> {
+  args: A2uiActionArgs,
+): Promise<A2uiActionResult> {
   const transport = buildTransport(cfg);
   const client = new Client({ name: 'qwen-serve-a2ui', version: '0.0.1' });
   try {
-    await client.connect(transport);
+    await client.connect(transport, { timeout: CALL_TIMEOUT_MS });
     const result = (await client.callTool(
-      { name: ACTION_TOOL, arguments: args },
+      { name: ACTION_TOOL, arguments: { ...args } },
       undefined,
       { timeout: CALL_TIMEOUT_MS },
     )) as {
+      isError?: boolean;
       content?: Array<{
         type: string;
         text?: string;
         resource?: { mimeType?: string; text?: string };
       }>;
     };
+    if (result.isError) {
+      const errMsg = (result.content ?? [])
+        .filter(
+          (b): b is { type: string; text: string } =>
+            b.type === 'text' && typeof b.text === 'string',
+        )
+        .map((b) => b.text)
+        .join('');
+      throw new Error(
+        `a2ui action tool returned error: ${errMsg || 'unknown error'}`,
+      );
+    }
     let commands: unknown[] | null = null;
     let fallback = '';
     for (const block of result.content ?? []) {
       if (
+        commands === null &&
         block.type === 'resource' &&
         block.resource?.mimeType === A2UI_MIME &&
         typeof block.resource.text === 'string'
       ) {
+        // Single-block semantics: the first a2ui+json resource wins; further
+        // resource blocks are ignored while text blocks keep accumulating.
         try {
           const parsed = JSON.parse(block.resource.text);
           if (Array.isArray(parsed)) commands = parsed;
@@ -143,6 +188,9 @@ async function callA2uiAction(
     }
     return { commands, fallback };
   } finally {
+    // Close the transport explicitly as well: client.close() alone may not
+    // reap a spawned stdio child when connect() failed mid-handshake.
+    await transport.close().catch(() => {});
     await client.close().catch(() => {});
   }
 }
@@ -152,6 +200,7 @@ export function registerA2uiActionRoutes(
   opts: RegisterA2uiActionRoutesOptions,
 ): void {
   const { boundWorkspace, mutate, safeBody, getMcpServers } = opts;
+  const callAction = opts.callAction ?? callA2uiAction;
 
   app.post(
     '/session/:id/a2ui-action',
@@ -166,7 +215,9 @@ export function registerA2uiActionRoutes(
       const surfaceId =
         typeof body['surfaceId'] === 'string' ? body['surfaceId'] : undefined;
       const context =
-        body['context'] && typeof body['context'] === 'object'
+        body['context'] &&
+        typeof body['context'] === 'object' &&
+        !Array.isArray(body['context'])
           ? (body['context'] as Record<string, unknown>)
           : undefined;
 
@@ -175,14 +226,16 @@ export function registerA2uiActionRoutes(
       let cfg: McpServerConfigLike | null = null;
       try {
         const servers = (await getMcpServers(req)).filter(
-          (s) => s.name.toLowerCase().includes('a2ui') && usable(s.config),
+          (s) =>
+            s.name.toLowerCase().includes('a2ui') &&
+            usableServerConfig(s.config),
         );
         const live = servers.find((s) => s.mcpStatus === 'connected');
         cfg = (live ?? servers[0])?.config ?? null;
       } catch {
         /* Status unavailable -> fall through to the settings fallback. */
       }
-      if (!cfg) cfg = findFromSettingsFile(boundWorkspace);
+      if (!cfg) cfg = await findFromSettingsFile(boundWorkspace);
       if (!cfg) {
         res.status(503).json({
           error:
@@ -191,18 +244,19 @@ export function registerA2uiActionRoutes(
         return;
       }
       try {
-        const { commands, fallback } = await callA2uiAction(cfg, {
+        const { commands, fallback } = await callAction(cfg, {
           name: name.trim(),
           surfaceId,
           context,
         });
         res.status(200).json({ commands, fallback });
       } catch (err) {
-        res.status(502).json({
-          error: `a2ui action call failed: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-        });
+        // Log the detail server-side; keep the client-facing message generic
+        // so internal paths/commands/URLs never leak.
+        writeStderrLine(
+          `a2ui-action proxy failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        res.status(502).json({ error: 'a2ui action call failed' });
       }
     },
   );

--- a/packages/cli/src/serve/routes/a2uiAction.ts
+++ b/packages/cli/src/serve/routes/a2uiAction.ts
@@ -123,7 +123,7 @@ export async function findFromSettingsFile(
 }
 
 /** Build a one-shot transport from the config shape: stdio (command) or streamable HTTP (httpUrl). */
-function buildTransport(cfg: McpServerConfigLike): Transport {
+export function buildTransport(cfg: McpServerConfigLike): Transport {
   if (typeof cfg.httpUrl === 'string') {
     return new StreamableHTTPClientTransport(new URL(cfg.httpUrl));
   }
@@ -183,7 +183,7 @@ export function extractA2uiActionResult(
 }
 
 /** Call the UI MCP server's action tool directly and extract the A2UI continuation commands plus fallback text. */
-async function callA2uiAction(
+export async function callA2uiAction(
   cfg: McpServerConfigLike,
   args: A2uiActionArgs,
 ): Promise<A2uiActionResult> {

--- a/packages/cli/src/serve/routes/a2uiAction.ts
+++ b/packages/cli/src/serve/routes/a2uiAction.ts
@@ -66,6 +66,15 @@ export interface A2uiActionResult {
   fallback: string;
 }
 
+export interface A2uiToolResult {
+  isError?: boolean;
+  content?: Array<{
+    type: string;
+    text?: string;
+    resource?: { mimeType?: string; text?: string };
+  }>;
+}
+
 interface RegisterA2uiActionRoutesOptions {
   boundWorkspace: string;
   mutate: () => RequestHandler;
@@ -132,6 +141,47 @@ function buildTransport(cfg: McpServerConfigLike): Transport {
   });
 }
 
+/** Exported for unit testing the MCP content normalization rules. */
+export function extractA2uiActionResult(
+  result: A2uiToolResult,
+): A2uiActionResult {
+  if (result.isError) {
+    const errMsg = (result.content ?? [])
+      .filter(
+        (b): b is { type: string; text: string } =>
+          b.type === 'text' && typeof b.text === 'string',
+      )
+      .map((b) => b.text)
+      .join('');
+    throw new Error(
+      `a2ui action tool returned error: ${errMsg || 'unknown error'}`,
+    );
+  }
+
+  let commands: unknown[] | null = null;
+  let fallback = '';
+  for (const block of result.content ?? []) {
+    if (
+      commands === null &&
+      block.type === 'resource' &&
+      block.resource?.mimeType === A2UI_MIME &&
+      typeof block.resource.text === 'string'
+    ) {
+      // Single-block semantics: the first a2ui+json resource wins; further
+      // resource blocks are ignored while text blocks keep accumulating.
+      try {
+        const parsed = JSON.parse(block.resource.text);
+        if (Array.isArray(parsed)) commands = parsed;
+      } catch {
+        /* Invalid JSON -> treated as no continuation frame. */
+      }
+    } else if (block.type === 'text' && typeof block.text === 'string') {
+      fallback += block.text;
+    }
+  }
+  return { commands, fallback };
+}
+
 /** Call the UI MCP server's action tool directly and extract the A2UI continuation commands plus fallback text. */
 async function callA2uiAction(
   cfg: McpServerConfigLike,
@@ -145,48 +195,8 @@ async function callA2uiAction(
       { name: ACTION_TOOL, arguments: { ...args } },
       undefined,
       { timeout: CALL_TIMEOUT_MS },
-    )) as {
-      isError?: boolean;
-      content?: Array<{
-        type: string;
-        text?: string;
-        resource?: { mimeType?: string; text?: string };
-      }>;
-    };
-    if (result.isError) {
-      const errMsg = (result.content ?? [])
-        .filter(
-          (b): b is { type: string; text: string } =>
-            b.type === 'text' && typeof b.text === 'string',
-        )
-        .map((b) => b.text)
-        .join('');
-      throw new Error(
-        `a2ui action tool returned error: ${errMsg || 'unknown error'}`,
-      );
-    }
-    let commands: unknown[] | null = null;
-    let fallback = '';
-    for (const block of result.content ?? []) {
-      if (
-        commands === null &&
-        block.type === 'resource' &&
-        block.resource?.mimeType === A2UI_MIME &&
-        typeof block.resource.text === 'string'
-      ) {
-        // Single-block semantics: the first a2ui+json resource wins; further
-        // resource blocks are ignored while text blocks keep accumulating.
-        try {
-          const parsed = JSON.parse(block.resource.text);
-          if (Array.isArray(parsed)) commands = parsed;
-        } catch {
-          /* Invalid JSON -> treated as no continuation frame. */
-        }
-      } else if (block.type === 'text' && typeof block.text === 'string') {
-        fallback += block.text;
-      }
-    }
-    return { commands, fallback };
+    )) as A2uiToolResult;
+    return extractA2uiActionResult(result);
   } finally {
     // Close the transport explicitly as well: client.close() alone may not
     // reap a spawned stdio child when connect() failed mid-handshake.

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -110,6 +110,7 @@ import {
   type WorkspaceRequestContext,
 } from './workspace-service/index.js';
 import { registerWorkspaceSettingsRoutes } from './routes/workspaceSettings.js';
+import { registerA2uiActionRoutes } from './routes/a2uiAction.js';
 import {
   createRateLimiter,
   setRateLimiter,
@@ -672,7 +673,7 @@ function resolveDaemonTelemetryRoute(
     return { route: 'POST /sessions/delete' };
   }
   const sessionAction = path.match(
-    /^\/session\/([^/]+)\/(load|resume|prompt|cancel|recap|btw|model|shell|detach|rewind|approval-mode|language)$/,
+    /^\/session\/([^/]+)\/(load|resume|prompt|cancel|recap|btw|model|shell|detach|rewind|approval-mode|language|a2ui-action)$/,
   );
   const sessionActionId = sessionAction?.[1];
   const sessionActionName = sessionAction?.[2];
@@ -1531,6 +1532,26 @@ export function createServeApp(
         parseAndValidateWorkspaceClientId(req, res, bridge),
     });
   }
+
+  // A2UI action inbound (the upstream half of A2UI-over-MCP): user
+  // interactions from web clients are proxied to the UI MCP server's
+  // standard `action` tool.
+  registerA2uiActionRoutes(app, {
+    boundWorkspace,
+    mutate,
+    safeBody,
+    // UI-server discovery uses the daemon's workspace MCP status, which
+    // includes servers registered at runtime.
+    getMcpServers: async (req) => {
+      const ctx = buildWorkspaceCtx(req, 'POST /session/:id/a2ui-action');
+      const status = await workspace.getWorkspaceMcpStatus(ctx);
+      return (status.servers ?? []) as Array<{
+        name: string;
+        mcpStatus?: string;
+        config?: Record<string, unknown>;
+      }>;
+    },
+  });
 
   // -- auth device-flow routes ---------------------------------------------
 

--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -65,6 +65,7 @@ vi.mock('./tracer.js', () => ({
 import { LogToSpanProcessor } from './log-to-span-processor.js';
 import { setSessionContext } from './session-context.js';
 import { setShellTracePropagation } from './trace-context.js';
+import { createSessionRootContext } from './tracer.js';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici';
 

--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -65,7 +65,6 @@ vi.mock('./tracer.js', () => ({
 import { LogToSpanProcessor } from './log-to-span-processor.js';
 import { setSessionContext } from './session-context.js';
 import { setShellTracePropagation } from './trace-context.js';
-import { createSessionRootContext } from './tracer.js';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici';
 


### PR DESCRIPTION
## What this PR does

Lets web clients of `qwen serve` render interactive [A2UI](https://a2ui.org/) surfaces produced by MCP tools, following the official [A2UI-over-MCP guide](https://a2ui.org/guides/a2ui_over_mcp/). Two additions, both confined to the daemon layer (zero changes to core, the ACP schema, or the tool registry):

**Downstream (acp-bridge):** `BridgeClient.sessionUpdate` — the single funnel where all ACP child notifications reach the event bus — now detects tool results coming from an A2UI UI server (`_meta.serverId` containing `a2ui`, tool-name regex as fallback for legacy frames), extracts the leading A2UI command array from the result text, publishes it as a separate `sessionUpdate: 'a2ui'` frame (`{surfaceId, callId, commands}`) onto the session event bus, and sanitizes the original `tool_call_update` so raw command JSON never reaches transcripts. Publishing through the event bus means SSE delivery, journaling, and history replay all work unchanged. Commands are passed through opaquely — the bridge never interprets A2UI itself, so protocol upgrades (v0.9 → v1.0) require no daemon change.

**Upstream (serve route):** `POST /session/:id/a2ui-action` proxies user interactions on a surface back to the UI MCP server's standard `action` tool (`{name, surfaceId, context}`), per the official guide. UI-server discovery prefers the live workspace MCP status (which covers runtime-registered servers via `POST /workspace/mcp/servers`) and falls back to workspace settings; both stdio and streamable-HTTP transports are supported. Continuation frames returned by the tool are sent back synchronously as `{commands, fallback}`.

## Why it's needed

The official A2UI-over-MCP pattern assumes the MCP host and the renderer live in the same process, where client middleware can route `application/a2ui+json` tool results to a renderer. In `qwen serve` the host is the ACP child and the renderer is a browser on the other side of the SSE stream, so without this bridge a UI-producing MCP tool degrades to raw JSON in the transcript and user interactions have no path back to the server. A2UI is explicitly transport-agnostic, so relaying the payload over the daemon's existing SSE channel stays within the spec. Note the extraction keys off the server/tool identity rather than mime type because `transformResourceBlock` in core flattens `EmbeddedResource` blocks to plain text and drops `mimeType` — the bridge compensates without touching core.

## Reviewer Test Plan

### How to verify

1. Register any A2UI-over-MCP server (tools return `EmbeddedResource` with `mimeType: application/a2ui+json` whose text is a stringified A2UI v0.9 command array, plus a fallback `TextContent`) in workspace settings under a name containing `a2ui`, e.g. `{"mcpServers": {"a2ui-ui": {"command": "node", "args": ["/abs/path/server.mjs"]}}}`.
2. Start the daemon (`qwen serve --workspace <ws> --port 4170`), create a session, subscribe to `GET /session/:id/events`, and send a prompt that makes the model call the UI tool.
3. Expected on the SSE stream: a `session_update` frame with `data.update.sessionUpdate === 'a2ui'` carrying `{surfaceId, callId, commands}` (`_meta.source: 'a2ui-bridge'`), followed by the original `tool_call_update` whose `content`/`rawOutput` now contain only the fallback text — no raw command JSON.
4. Action round-trip: `curl -X POST .../session/<id>/a2ui-action -H 'X-Qwen-Client-Id: <cid>' -d '{"name":"<action>","surfaceId":"<sid>","context":{...}}'` → responds `{commands, fallback}` from the server's `action` tool. Also verified with workspace settings containing no `mcpServers` at all and the UI server registered purely at runtime via `POST /workspace/mcp/servers` — discovery picks it up from the live MCP status.
5. Regression: text-only prompts, tool calls from non-a2ui servers, session replay/restore, and the web-shell are unaffected (the new frame kind is additive; unknown kinds were already ignored by consumers).

### Evidence (Before & After)

Before: the UI tool's result rendered as a wall of raw JSON inside the tool output block, and there was no route for user actions.

After (live SSE capture, abridged):

```
event: session_update
data: {"update":{"sessionUpdate":"a2ui","a2ui":{"surfaceId":"ui_mq7z22zg_0","callId":"call_fe1357…","commands":[{"version":"v0.9","createSurface":{…}},{"version":"v0.9","updateComponents":{…}}]},"_meta":{"source":"a2ui-bridge"}}}

event: session_update
data: {"update":{"sessionUpdate":"tool_call_update","content":[{"content":{"text":"已生成选择卡「验证」，选项：甲 / 乙 / 丙。…","type":"text"}}],…}}
```

Tested on: macOS (darwin arm64), Node 24 — full chain verified against a live model session (tool call → a2ui frame → sanitized tool frame → action round-trip → continuation frame).

🤖 Generated with [Claude Code](https://claude.com/claude-code)