### PR TITLE
ci: extend qwen PR review timeout to 90min and queue delay to 30min

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -31,7 +31,7 @@ on:
       timeout_minutes:
         description: 'Review timeout in minutes'
         required: false
-        default: '60'
+        default: '90'
         type: 'number'
 
 concurrency:
@@ -138,7 +138,7 @@ jobs:
        github.event.pull_request.author_association == 'MEMBER' ||
        github.event.pull_request.author_association == 'COLLABORATOR')
     runs-on: 'ubuntu-latest'
-    # Configured in repo settings with a 10-minute wait timer.
+    # Configured in repo settings with a 30-minute wait timer.
     environment:
       name: 'qwen-pr-review-delay'
       deployment: false
@@ -256,7 +256,7 @@ jobs:
         (github.event.review.author_association == 'OWNER' ||
          github.event.review.author_association == 'MEMBER' ||
          github.event.review.author_association == 'COLLABORATOR')))
-    timeout-minutes: 60
+    timeout-minutes: 90
     runs-on: ['self-hosted', 'linux', 'x64', 'ecs-qwen']
     permissions:
       contents: 'read'
@@ -303,7 +303,7 @@ jobs:
             exit 1
           fi
 
-          TIMEOUT_MINUTES="${{ github.event.inputs.timeout_minutes || '60' }}"
+          TIMEOUT_MINUTES="${{ github.event.inputs.timeout_minutes || '90' }}"
 
           {
             echo "should_run=true"
@@ -361,8 +361,8 @@ jobs:
           if [ "$TIMEOUT_MINUTES" -le 5 ]; then
             fail "timeout_minutes must be greater than 5"
           fi
-          if [ "$TIMEOUT_MINUTES" -gt 60 ]; then
-            fail "timeout_minutes must not exceed the 60 minute job timeout"
+          if [ "$TIMEOUT_MINUTES" -gt 90 ]; then
+            fail "timeout_minutes must not exceed the 90 minute job timeout"
           fi
 
           if ! PR_STATE="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state --jq '.state')"; then


### PR DESCRIPTION
## What this PR does

Extends two time limits in the automated PR review workflow: the review run timeout goes from 60 to 90 minutes (dispatch input default, job `timeout-minutes`, fallback value, and the validation cap), and the documented auto-review queue delay goes to 30 minutes.

The queue delay itself lives in the `qwen-pr-review-delay` environment's wait timer (repo settings), so this PR only updates the stale comment — the actual timer is adjusted in settings alongside this change.

## Why it's needed

Larger PRs have been hitting the 60-minute ceiling before the review completes. Extracted from #4866 so the timeout bump can land independently of the pipeline refactor.

## Reviewer Test Plan

### How to verify

Config-only change — all four `60 → 90` sites move together (input default, job timeout, fallback, validation cap), so an explicit `timeout_minutes=90` dispatch passes validation and stays under the job timeout. YAML parses; actionlint reports only the pre-existing warnings (custom `ecs-qwen` label, `deployment` key).

### Evidence (Before & After)

N/A (CI config).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

## Risk & Scope

- Main risk or tradeoff: a hung review now occupies the self-hosted runner for up to 90 minutes instead of 60.
- Not validated / out of scope: the pipeline refactor in #4866; the environment wait-timer value itself (repo settings, not in YAML).
- Breaking changes / migration notes: none.

## Linked Issues

Extracted from #4866.

<details>
<summary>中文说明</summary>

把自动 PR review workflow 的两个时间上限放宽：review 运行超时从 60 分钟扩到 90 分钟（dispatch 输入默认值、job `timeout-minutes`、回退值、校验上限四处同步），自动 review 的排队等待时间注释更新为 30 分钟。

排队等待实际由 `qwen-pr-review-delay` environment 的 wait timer（仓库设置）控制，本 PR 只修正过期注释，真实计时器随本改动在设置中调整。

**为什么：** 较大的 PR 在 review 完成前就撞到 60 分钟上限。从 #4866 拆出，让超时调整先于流水线重构独立合入。

**风险：** 卡死的 review 会占用自建 runner 最多 90 分钟（原 60）。范围外：#4866 的流水线重构、wait timer 数值本身。无破坏性变更。

</details>
