### PR TITLE
fix: enable fork subagents by default

### DIFF
--- a/packages/cli/src/i18n/locales/ca.js
+++ b/packages/cli/src/i18n/locales/ca.js
@@ -847,8 +847,6 @@ export default {
     "No es pot crear una bifurcació mentre hi ha una resposta o una crida a una eina en curs. Espereu que acabi o resolgueu la crida a l'eina pendent.",
   'Cannot fork before the first conversation turn.':
     'No es pot crear una bifurcació abans del primer torn de conversa.',
-  'The /fork command requires the fork feature gate. Set QWEN_CODE_ENABLE_FORK_SUBAGENT=1 to enable it.':
-    'L’ordre /fork requereix el feature gate de fork. Definiu QWEN_CODE_ENABLE_FORK_SUBAGENT=1 per activar-lo.',
   'The agent tool is unavailable; cannot fork.':
     "L'eina d'agent no està disponible; no es pot crear una bifurcació.",
   'Failed to launch fork: {{error}}':

--- a/packages/cli/src/i18n/locales/de.js
+++ b/packages/cli/src/i18n/locales/de.js
@@ -804,8 +804,6 @@ export default {
     'Während eine Antwort oder ein Tool-Aufruf läuft, kann kein Hintergrund-Fork erstellt werden. Warten Sie, bis der Vorgang abgeschlossen ist, oder bearbeiten Sie den ausstehenden Tool-Aufruf.',
   'Cannot fork before the first conversation turn.':
     'Vor der ersten Gesprächsrunde kann kein Fork erstellt werden.',
-  'The /fork command requires the fork feature gate. Set QWEN_CODE_ENABLE_FORK_SUBAGENT=1 to enable it.':
-    'Der Befehl /fork erfordert das Fork-Feature-Gate. Setzen Sie QWEN_CODE_ENABLE_FORK_SUBAGENT=1, um es zu aktivieren.',
   'The agent tool is unavailable; cannot fork.':
     'Das Agent-Tool ist nicht verfügbar; Fork kann nicht gestartet werden.',
   'Failed to launch fork: {{error}}':

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -890,8 +890,6 @@ export default {
     'Cannot fork while a response or tool call is in progress. Wait for it to finish or resolve the pending tool call.',
   'Cannot fork before the first conversation turn.':
     'Cannot fork before the first conversation turn.',
-  'The /fork command requires the fork feature gate. Set QWEN_CODE_ENABLE_FORK_SUBAGENT=1 to enable it.':
-    'The /fork command requires the fork feature gate. Set QWEN_CODE_ENABLE_FORK_SUBAGENT=1 to enable it.',
   'The agent tool is unavailable; cannot fork.':
     'The agent tool is unavailable; cannot fork.',
   'Failed to launch fork: {{error}}': 'Failed to launch fork: {{error}}',

--- a/packages/cli/src/i18n/locales/fr.js
+++ b/packages/cli/src/i18n/locales/fr.js
@@ -868,8 +868,6 @@ export default {
     "Impossible de créer un fork pendant qu'une réponse ou un appel d'outil est en cours. Attendez la fin ou traitez l'appel d'outil en attente.",
   'Cannot fork before the first conversation turn.':
     'Impossible de créer un fork avant le premier tour de conversation.',
-  'The /fork command requires the fork feature gate. Set QWEN_CODE_ENABLE_FORK_SUBAGENT=1 to enable it.':
-    'La commande /fork nécessite le feature gate fork. Définissez QWEN_CODE_ENABLE_FORK_SUBAGENT=1 pour l’activer.',
   'The agent tool is unavailable; cannot fork.':
     "L'outil agent est indisponible ; impossible de créer un fork.",
   'Failed to launch fork: {{error}}': 'Échec du lancement du fork : {{error}}',

--- a/packages/cli/src/i18n/locales/ja.js
+++ b/packages/cli/src/i18n/locales/ja.js
@@ -591,8 +591,6 @@ export default {
     '応答またはツール呼び出しの処理中はフォークできません。完了するか、保留中のツール呼び出しを解決してください。',
   'Cannot fork before the first conversation turn.':
     '最初の会話ターンの前にはフォークできません。',
-  'The /fork command requires the fork feature gate. Set QWEN_CODE_ENABLE_FORK_SUBAGENT=1 to enable it.':
-    '/fork コマンドには fork フィーチャーゲートが必要です。有効にするには QWEN_CODE_ENABLE_FORK_SUBAGENT=1 を設定してください。',
   'The agent tool is unavailable; cannot fork.':
     'エージェントツールを利用できないため、フォークできません。',
   'Failed to launch fork: {{error}}': 'フォークの起動に失敗しました: {{error}}',

--- a/packages/cli/src/i18n/locales/pt.js
+++ b/packages/cli/src/i18n/locales/pt.js
@@ -809,8 +809,6 @@ export default {
     'Não é possível criar um fork enquanto uma resposta ou chamada de ferramenta está em andamento. Aguarde a conclusão ou resolva a chamada de ferramenta pendente.',
   'Cannot fork before the first conversation turn.':
     'Não é possível criar um fork antes da primeira rodada da conversa.',
-  'The /fork command requires the fork feature gate. Set QWEN_CODE_ENABLE_FORK_SUBAGENT=1 to enable it.':
-    'O comando /fork requer o feature gate de fork. Defina QWEN_CODE_ENABLE_FORK_SUBAGENT=1 para ativá-lo.',
   'The agent tool is unavailable; cannot fork.':
     'A ferramenta de agente está indisponível; não é possível criar um fork.',
   'Failed to launch fork: {{error}}': 'Falha ao iniciar o fork: {{error}}',

--- a/packages/cli/src/i18n/locales/ru.js
+++ b/packages/cli/src/i18n/locales/ru.js
@@ -816,8 +816,6 @@ export default {
     'Нельзя создать fork, пока выполняется ответ или вызов инструмента. Дождитесь завершения или обработайте ожидающий вызов инструмента.',
   'Cannot fork before the first conversation turn.':
     'Нельзя создать fork до первого сообщения в разговоре.',
-  'The /fork command requires the fork feature gate. Set QWEN_CODE_ENABLE_FORK_SUBAGENT=1 to enable it.':
-    'Команде /fork требуется feature gate fork. Установите QWEN_CODE_ENABLE_FORK_SUBAGENT=1, чтобы включить его.',
   'The agent tool is unavailable; cannot fork.':
     'Инструмент агента недоступен; fork создать нельзя.',
   'Failed to launch fork: {{error}}': 'Не удалось запустить fork: {{error}}',

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -762,8 +762,6 @@ export default {
   'Cannot fork while a response or tool call is in progress. Wait for it to finish or resolve the pending tool call.':
     '回應或工具呼叫正在進行時無法分支。請等待其完成或處理待確認的工具呼叫。',
   'Cannot fork before the first conversation turn.': '首次對話輪次前無法分支。',
-  'The /fork command requires the fork feature gate. Set QWEN_CODE_ENABLE_FORK_SUBAGENT=1 to enable it.':
-    '/fork 命令需要啟用 fork 功能開關。設定 QWEN_CODE_ENABLE_FORK_SUBAGENT=1 以啟用。',
   'The agent tool is unavailable; cannot fork.': 'Agent 工具不可用；無法分支。',
   'Failed to launch fork: {{error}}': '啟動分支失敗：{{error}}',
   'the background agent could not be started.': '背景智能體無法啟動。',

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -843,8 +843,6 @@ export default {
   'Cannot fork while a response or tool call is in progress. Wait for it to finish or resolve the pending tool call.':
     '响应或工具调用正在进行时无法分支。请等待其完成或处理待确认的工具调用。',
   'Cannot fork before the first conversation turn.': '首次对话轮次前无法分支。',
-  'The /fork command requires the fork feature gate. Set QWEN_CODE_ENABLE_FORK_SUBAGENT=1 to enable it.':
-    '/fork 命令需要启用 fork 功能开关。设置 QWEN_CODE_ENABLE_FORK_SUBAGENT=1 以启用。',
   'The agent tool is unavailable; cannot fork.': 'Agent 工具不可用；无法分支。',
   'Failed to launch fork: {{error}}': '启动分支失败：{{error}}',
   'the background agent could not be started.': '后台智能体无法启动。',

--- a/packages/cli/src/i18n/mustTranslateKeys.test.ts
+++ b/packages/cli/src/i18n/mustTranslateKeys.test.ts
@@ -28,7 +28,6 @@ const FORK_COMMAND_REQUIRED_KEYS = [
   'Please provide a directive. Usage: /fork <directive>',
   'Cannot fork while a response or tool call is in progress. Wait for it to finish or resolve the pending tool call.',
   'Cannot fork before the first conversation turn.',
-  'The /fork command requires the fork feature gate. Set QWEN_CODE_ENABLE_FORK_SUBAGENT=1 to enable it.',
   'The agent tool is unavailable; cannot fork.',
   'Failed to launch fork: {{error}}',
   'User launched a background fork via /fork: {{directive}}',

--- a/packages/cli/src/i18n/mustTranslateKeys.ts
+++ b/packages/cli/src/i18n/mustTranslateKeys.ts
@@ -23,7 +23,6 @@ export const MUST_TRANSLATE_KEYS = [
   'Please provide a directive. Usage: /fork <directive>',
   'Cannot fork while a response or tool call is in progress. Wait for it to finish or resolve the pending tool call.',
   'Cannot fork before the first conversation turn.',
-  'The /fork command requires the fork feature gate. Set QWEN_CODE_ENABLE_FORK_SUBAGENT=1 to enable it.',
   'The agent tool is unavailable; cannot fork.',
   'Failed to launch fork: {{error}}',
   'User launched a background fork via /fork: {{directive}}',

--- a/packages/cli/src/ui/commands/forkCommand.test.ts
+++ b/packages/cli/src/ui/commands/forkCommand.test.ts
@@ -45,7 +45,6 @@ describe('forkCommand', () => {
       getHistoryShallow: () => historyWithTurn,
     }),
     getModel: () => 'test-model',
-    isForkSubagentEnabled: () => true,
     getToolRegistry: () => ({ getTool: mockGetTool }),
     ...overrides,
   });

--- a/packages/cli/src/ui/commands/forkCommand.test.ts
+++ b/packages/cli/src/ui/commands/forkCommand.test.ts
@@ -153,23 +153,6 @@ describe('forkCommand', () => {
     expect(mockBuild).not.toHaveBeenCalled();
   });
 
-  it('refuses to fork when the fork feature gate is disabled', async () => {
-    const disabled = createMockCommandContext({
-      services: {
-        config: createConfig({
-          isForkSubagentEnabled: () => false,
-        }),
-      },
-    });
-    const result = await forkCommand.action!(disabled, 'do something');
-    expect(result).toMatchObject({
-      messageType: 'error',
-      content:
-        'The /fork command requires the fork feature gate. Set QWEN_CODE_ENABLE_FORK_SUBAGENT=1 to enable it.',
-    });
-    expect(mockBuild).not.toHaveBeenCalled();
-  });
-
   it('errors when the agent tool is unavailable', async () => {
     mockGetTool.mockReturnValue(undefined);
     const result = await forkCommand.action!(mockContext, 'do something');

--- a/packages/cli/src/ui/commands/forkCommand.ts
+++ b/packages/cli/src/ui/commands/forkCommand.ts
@@ -102,16 +102,6 @@ export const forkCommand: SlashCommand = {
       };
     }
 
-    if (!config.isForkSubagentEnabled?.()) {
-      return {
-        type: 'message',
-        messageType: 'error',
-        content: t(
-          'The /fork command requires the fork feature gate. Set QWEN_CODE_ENABLE_FORK_SUBAGENT=1 to enable it.',
-        ),
-      };
-    }
-
     // Route through the Agent tool's background path (omitting subagent_type
     // selects the implicit FORK_AGENT). This reuses the full background
     // machinery: registration in the BackgroundTaskRegistry, live activity

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -764,7 +764,6 @@ export interface ConfigParameters {
   experimentalZedIntegration?: boolean;
   cronEnabled?: boolean;
   agentTeamEnabled?: boolean;
-  forkSubagentEnabled?: boolean;
   workflowsEnabled?: boolean;
   computerUseEnabled?: boolean;
   emitToolUseSummaries?: boolean;
@@ -1176,7 +1175,6 @@ export class Config {
   private readonly experimentalZedIntegration: boolean = false;
   private readonly cronEnabled: boolean = true;
   private readonly agentTeamEnabled: boolean = false;
-  private readonly forkSubagentEnabled: boolean = false;
   private workflowsEnabled = false;
   private readonly computerUseEnabled: boolean = true;
   private readonly emitToolUseSummaries: boolean = true;
@@ -1367,7 +1365,6 @@ export class Config {
       params.experimentalZedIntegration ?? false;
     this.cronEnabled = params.cronEnabled ?? true;
     this.agentTeamEnabled = params.agentTeamEnabled ?? false;
-    this.forkSubagentEnabled = params.forkSubagentEnabled ?? false;
     this.workflowsEnabled = params.workflowsEnabled ?? false;
     this.computerUseEnabled = params.computerUseEnabled ?? true;
     this.emitToolUseSummaries = params.emitToolUseSummaries ?? true;
@@ -3524,11 +3521,6 @@ export class Config {
     // Agent team is experimental and opt-in: enabled via settings or env var
     if (process.env['QWEN_CODE_ENABLE_AGENT_TEAM'] === '1') return true;
     return this.agentTeamEnabled;
-  }
-
-  isForkSubagentEnabled(): boolean {
-    if (process.env['QWEN_CODE_ENABLE_FORK_SUBAGENT'] === '1') return true;
-    return this.forkSubagentEnabled;
   }
 
   isWorkflowsEnabled(): boolean {

--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -306,7 +306,7 @@ describe('AgentTool', () => {
       );
     });
 
-    it('omits fork discipline when interactive but fork flag is off', async () => {
+    it('includes fork discipline when interactive even if the legacy flag is off', async () => {
       (config as unknown as Record<string, unknown>)['isInteractive'] = vi
         .fn()
         .mockReturnValue(true);
@@ -316,10 +316,10 @@ describe('AgentTool', () => {
       const tool = new AgentTool(config);
       await vi.runAllTimersAsync();
 
-      expect(tool.description).not.toContain('When to fork');
-      expect(tool.description).toContain(
-        'If omitted, the general-purpose agent is used',
-      );
+      expect(tool.description).toContain('When to fork');
+      expect(tool.description).toContain("Don't peek");
+      expect(tool.description).toContain("Don't race");
+      expect(tool.description).toContain('Writing a fork prompt');
     });
   });
 
@@ -1131,9 +1131,10 @@ describe('AgentTool', () => {
         }),
       } as unknown as ReturnType<Config['getGeminiClient']>);
 
+      vi.mocked(AgentHeadless.create).mockClear();
       vi.mocked(AgentHeadless.create).mockResolvedValue(mockAgent);
 
-      // Fork requires interactive mode + feature flag — gate from isForkSubagentEnabled().
+      // Fork only requires interactive mode.
       (config as unknown as Record<string, unknown>)['isInteractive'] = vi
         .fn()
         .mockReturnValue(true);
@@ -1141,8 +1142,7 @@ describe('AgentTool', () => {
         vi.fn().mockReturnValue(true);
     });
 
-    it('falls back to general-purpose when fork flag is off', async () => {
-      // Fork flag off — even though interactive
+    it('forks in interactive mode even if the legacy flag method returns false', async () => {
       vi.mocked(
         config.isForkSubagentEnabled as ReturnType<typeof vi.fn>,
       ).mockReturnValue(false);
@@ -1168,19 +1168,17 @@ describe('AgentTool', () => {
       ).createInvocation(params);
       await invocation.execute();
 
-      // Should load general-purpose, not fork
-      expect(mockSubagentManager.loadSubagent).toHaveBeenCalledWith(
+      expect(mockSubagentManager.loadSubagent).not.toHaveBeenCalledWith(
         'general-purpose',
       );
-      expect(AgentHeadless.create).not.toHaveBeenCalled();
+      expect(AgentHeadless.create).toHaveBeenCalledTimes(1);
     });
 
-    it('falls back to general-purpose when non-interactive (even with fork flag on)', async () => {
+    it('falls back to general-purpose when non-interactive', async () => {
       vi.mocked(
         config.isInteractive as ReturnType<typeof vi.fn>,
       ).mockReturnValue(false);
-      // Fork flag is on, but non-interactive → isForkSubagentEnabled() returns false
-      // because it requires both flag + interactive.
+      // Non-interactive sessions cannot service fork progress or prompts.
 
       const mockLoadedSubagent: SubagentConfig = {
         name: 'general-purpose',
@@ -1228,6 +1226,7 @@ describe('AgentTool', () => {
 
       const createArgs = vi.mocked(AgentHeadless.create).mock.calls[0];
       expect(createArgs[0]).toBe('fork'); // name
+      expect(createArgs[1].getApprovalMode()).toBe(ApprovalMode.DEFAULT);
       // First-turn fork (no cache params): systemPrompt path, no
       // renderedSystemPrompt. initialMessages is undefined (empty history).
       const promptConfig = createArgs[2];
@@ -2960,7 +2959,7 @@ describe('AgentTool', () => {
     });
 
     it('persists fork capability snapshots in the bootstrap transcript', async () => {
-      // Fork requires opt-in + interactive
+      // Fork requires interactive mode
       (config as unknown as Record<string, unknown>)['isForkSubagentEnabled'] =
         vi.fn().mockReturnValue(true);
       (config as unknown as Record<string, unknown>)['isInteractive'] = vi

--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -171,7 +171,6 @@ describe('AgentTool', () => {
       getApprovalMode: vi.fn().mockReturnValue('default'),
       isTrustedFolder: vi.fn().mockReturnValue(true),
       isInteractive: vi.fn().mockReturnValue(false),
-      isForkSubagentEnabled: vi.fn().mockReturnValue(false),
       getBackgroundTaskRegistry: vi.fn().mockReturnValue(stubRegistry),
       getMonitorRegistry: vi.fn().mockReturnValue(stubMonitorRegistry),
       getToolRegistry: vi.fn().mockReturnValue(stubToolRegistry),
@@ -269,8 +268,6 @@ describe('AgentTool', () => {
       (config as unknown as Record<string, unknown>)['isInteractive'] = vi
         .fn()
         .mockReturnValue(true);
-      (config as unknown as Record<string, unknown>)['isForkSubagentEnabled'] =
-        vi.fn().mockReturnValue(true);
 
       const interactiveTool = new AgentTool(config);
       await vi.runAllTimersAsync();
@@ -285,8 +282,6 @@ describe('AgentTool', () => {
       (config as unknown as Record<string, unknown>)['isInteractive'] = vi
         .fn()
         .mockReturnValue(false);
-      (config as unknown as Record<string, unknown>)['isForkSubagentEnabled'] =
-        vi.fn().mockReturnValue(false);
 
       const nonInteractiveTool = new AgentTool(config);
       await vi.runAllTimersAsync();
@@ -306,12 +301,10 @@ describe('AgentTool', () => {
       );
     });
 
-    it('includes fork discipline when interactive even if the legacy flag is off', async () => {
+    it('includes fork discipline when interactive', async () => {
       (config as unknown as Record<string, unknown>)['isInteractive'] = vi
         .fn()
         .mockReturnValue(true);
-      (config as unknown as Record<string, unknown>)['isForkSubagentEnabled'] =
-        vi.fn().mockReturnValue(false);
 
       const tool = new AgentTool(config);
       await vi.runAllTimersAsync();
@@ -1134,19 +1127,12 @@ describe('AgentTool', () => {
       vi.mocked(AgentHeadless.create).mockClear();
       vi.mocked(AgentHeadless.create).mockResolvedValue(mockAgent);
 
-      // Fork only requires interactive mode.
       (config as unknown as Record<string, unknown>)['isInteractive'] = vi
         .fn()
         .mockReturnValue(true);
-      (config as unknown as Record<string, unknown>)['isForkSubagentEnabled'] =
-        vi.fn().mockReturnValue(true);
     });
 
-    it('forks in interactive mode even if the legacy flag method returns false', async () => {
-      vi.mocked(
-        config.isForkSubagentEnabled as ReturnType<typeof vi.fn>,
-      ).mockReturnValue(false);
-
+    it('forks in interactive mode', async () => {
       const mockLoadedSubagent: SubagentConfig = {
         name: 'general-purpose',
         description: 'General-purpose agent',
@@ -2959,9 +2945,6 @@ describe('AgentTool', () => {
     });
 
     it('persists fork capability snapshots in the bootstrap transcript', async () => {
-      // Fork requires interactive mode
-      (config as unknown as Record<string, unknown>)['isForkSubagentEnabled'] =
-        vi.fn().mockReturnValue(true);
       (config as unknown as Record<string, unknown>)['isInteractive'] = vi
         .fn()
         .mockReturnValue(true);

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -1721,8 +1721,8 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
     let restoreParentPM: () => void = () => {};
 
     try {
-      // When subagent_type is omitted and fork is enabled (opt-in +
-      // interactive), use fork. Otherwise fall back to general-purpose.
+      // When subagent_type is omitted and fork is available in an interactive
+      // session, use fork. Otherwise fall back to general-purpose.
       const isFork =
         !this.params.subagent_type && isForkSubagentEnabled(this.config);
       const effectiveSubagentType =

--- a/packages/core/src/tools/agent/fork-subagent.ts
+++ b/packages/core/src/tools/agent/fork-subagent.ts
@@ -1,11 +1,23 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Content } from '@google/genai';
 import type { Config } from '../../config/config.js';
+import type { SubagentConfig } from '../../subagents/types.js';
 
 export const FORK_SUBAGENT_TYPE = 'fork';
 
+/**
+ * Fork subagent availability gate.
+ *
+ * Fork is available by default in interactive sessions. Non-interactive
+ * sessions (e.g. `qwen -p`, SDK headless, CI/CD) lack a terminal UI for fork
+ * progress display and permission prompts, which can cause hangs or silent
+ * failures.
+ *
+ * When fork is unavailable, omitting `subagent_type` falls back to a
+ * general-purpose subagent instead of forking.
+ */
 export function isForkSubagentEnabled(config: Config): boolean {
-  return config.isForkSubagentEnabled() && config.isInteractive();
+  return config.isInteractive();
 }
 
 export const FORK_BOILERPLATE_TAG = 'fork-boilerplate';
@@ -18,8 +30,9 @@ export const FORK_AGENT = {
   tools: ['*'],
   systemPrompt:
     'You are a forked worker process. Follow the directive in the conversation history. Execute tasks directly using available tools. Do not spawn sub-agents.',
+  approvalMode: 'default',
   level: 'session' as const,
-};
+} satisfies SubagentConfig;
 
 // Recursive-fork guard. A fork child keeps the `agent` tool in its declarations
 // for byte-identical cache parity with the parent, so tool-availability


### PR DESCRIPTION
Fixes #4956.

## Summary
- make fork subagents available by default in interactive sessions
- keep non-interactive sessions on the existing general-purpose fallback path
- set the implicit fork agent's approval mode to `default`, so trusted folders do not silently promote fork workers to auto-edit
- remove the now-dead `/fork` feature-gate error string from required i18n keys and locale files

Current main does not define a separate `bubble` approval mode; `default` is the existing mode that routes tool calls through the normal permission prompt path.

## To verify
- `npm run generate`
- `npm run build --workspace=@qwen-code/web-templates`
- `npm run build --workspace=@qwen-code/channel-base`
- `npm run build --workspace=@qwen-code/channel-telegram`
- `npm run build --workspace=@qwen-code/channel-weixin`
- `npm run build --workspace=@qwen-code/channel-dingtalk`
- `npm run build --workspace=@qwen-code/channel-feishu`
- `npm run build --workspace=@qwen-code/channel-plugin-example`
- `npm run build --workspace=@qwen-code/acp-bridge`
- `npm test -- src/tools/agent/agent.test.ts` from `packages/core`
- `npm test -- src/ui/commands/forkCommand.test.ts src/i18n/mustTranslateKeys.test.ts` from `packages/cli`
- `npm run check-i18n` from `packages/cli`
- `npm run typecheck --workspace=@qwen-code/qwen-code-core`
- `npm run typecheck --workspace=@qwen-code/qwen-code`
- targeted `npx eslint` on the changed core/CLI/i18n files
- `git diff --check`