### PR TITLE
fix(core): coerce numeric string params in SchemaValidator for MCP tools

### DIFF
--- a/packages/core/src/utils/schemaValidator.test.ts
+++ b/packages/core/src/utils/schemaValidator.test.ts
@@ -517,6 +517,46 @@ describe('SchemaValidator', () => {
       expect(SchemaValidator.validate(schema, params)).toBeNull();
       expect(params.time).toBe(5);
     });
+
+    it('should not coerce decimal string for integer-only schema', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          count: { type: 'integer' },
+        },
+        required: ['count'],
+      };
+      const params = { count: '5.5' };
+      // Should NOT coerce — let validation fail so LLM self-corrects
+      expect(SchemaValidator.validate(schema, params)).not.toBeNull();
+      expect(params.count).toBe('5.5');
+    });
+
+    it('should coerce decimal string when number is accepted via anyOf', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          value: { anyOf: [{ type: 'integer' }, { type: 'number' }] },
+        },
+        required: ['value'],
+      };
+      const params = { value: '5.5' };
+      expect(SchemaValidator.validate(schema, params)).toBeNull();
+      expect(params.value).toBe(5.5);
+    });
+
+    it('should coerce numeric strings inside arrays of integers', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          ports: { type: 'array', items: { type: 'integer' } },
+        },
+        required: ['ports'],
+      };
+      const params = { ports: ['8080', '3000'] };
+      expect(SchemaValidator.validate(schema, params)).toBeNull();
+      expect(params.ports).toEqual([8080, 3000]);
+    });
   });
 
   describe('JSON Schema version support', () => {

--- a/packages/core/src/utils/schemaValidator.test.ts
+++ b/packages/core/src/utils/schemaValidator.test.ts
@@ -391,6 +391,134 @@ describe('SchemaValidator', () => {
     });
   });
 
+  describe('numeric string coercion', () => {
+    it('should coerce string "3" to integer 3', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          depth: { type: 'integer' },
+        },
+        required: ['depth'],
+      };
+      const params = { depth: '3' };
+      expect(SchemaValidator.validate(schema, params)).toBeNull();
+      expect(params.depth).toBe(3);
+    });
+
+    it('should coerce string "5.5" to number 5.5', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          timeout: { type: 'number' },
+        },
+        required: ['timeout'],
+      };
+      const params = { timeout: '5.5' };
+      expect(SchemaValidator.validate(schema, params)).toBeNull();
+      expect(params.timeout).toBe(5.5);
+    });
+
+    it('should coerce negative numeric strings', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          offset: { type: 'integer' },
+        },
+        required: ['offset'],
+      };
+      const params = { offset: '-10' };
+      expect(SchemaValidator.validate(schema, params)).toBeNull();
+      expect(params.offset).toBe(-10);
+    });
+
+    it('should not coerce non-numeric strings', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          count: { type: 'integer' },
+        },
+        required: ['count'],
+      };
+      const params = { count: 'abc' };
+      expect(SchemaValidator.validate(schema, params)).not.toBeNull();
+    });
+
+    it('should not coerce when schema also accepts string', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          value: { anyOf: [{ type: 'string' }, { type: 'integer' }] },
+        },
+        required: ['value'],
+      };
+      const params = { value: '42' };
+      expect(SchemaValidator.validate(schema, params)).toBeNull();
+      // Should remain a string since string is accepted
+      expect(params.value).toBe('42');
+    });
+
+    it('should coerce numeric strings in nested objects', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          options: {
+            type: 'object',
+            properties: {
+              retries: { type: 'integer' },
+            },
+          },
+        },
+      };
+      const params = { options: { retries: '3' } };
+      expect(SchemaValidator.validate(schema, params)).toBeNull();
+      expect((params.options as unknown as { retries: number }).retries).toBe(
+        3,
+      );
+    });
+
+    it('should not affect actual number values', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          depth: { type: 'integer' },
+        },
+        required: ['depth'],
+      };
+      const params = { depth: 3 };
+      expect(SchemaValidator.validate(schema, params)).toBeNull();
+      expect(params.depth).toBe(3);
+    });
+
+    it('should not corrupt string fields with numeric-looking values', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          count: { type: 'integer' },
+        },
+        required: ['name', 'count'],
+      };
+      const params = { name: '42', count: '7' };
+      expect(SchemaValidator.validate(schema, params)).toBeNull();
+      expect(params.name).toBe('42');
+      expect(params.count).toBe(7);
+    });
+
+    it('should work with draft-2020-12 schema (MCP servers)', () => {
+      const schema = {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        type: 'object',
+        properties: {
+          time: { type: 'number' },
+        },
+        required: ['time'],
+      };
+      const params = { time: '5' };
+      expect(SchemaValidator.validate(schema, params)).toBeNull();
+      expect(params.time).toBe(5);
+    });
+  });
+
   describe('JSON Schema version support', () => {
     it('should support JSON Schema draft-2020-12', () => {
       const schema = {

--- a/packages/core/src/utils/schemaValidator.test.ts
+++ b/packages/core/src/utils/schemaValidator.test.ts
@@ -545,6 +545,20 @@ describe('SchemaValidator', () => {
       expect(params.value).toBe(5.5);
     });
 
+    it('should coerce whole-number decimal string to integer (e.g. "3.0")', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          depth: { type: 'integer' },
+        },
+        required: ['depth'],
+      };
+      const params = { depth: '3.0' };
+      // "3.0" represents an integer — coerce it rather than rejecting.
+      expect(SchemaValidator.validate(schema, params)).toBeNull();
+      expect(params.depth).toBe(3);
+    });
+
     it('should coerce numeric strings inside arrays of integers', () => {
       const schema = {
         type: 'object',

--- a/packages/core/src/utils/schemaValidator.ts
+++ b/packages/core/src/utils/schemaValidator.ts
@@ -170,6 +170,13 @@ export class SchemaValidator {
         data as Record<string, unknown>,
         anySchema as Record<string, unknown>,
       );
+      // Coerce numeric strings ("3", "5.0") to actual numbers when the schema
+      // expects integer/number. LLMs frequently emit numeric parameters as
+      // strings which strict MCP servers (e.g. Playwright) reject.
+      fixNumericValues(
+        data as Record<string, unknown>,
+        anySchema as Record<string, unknown>,
+      );
 
       valid = validate(data);
       if (!valid && validate.errors) {
@@ -271,6 +278,53 @@ function fixStringifiedJsonValues(
       } catch {
         // Not valid JSON — leave the value unchanged
       }
+    }
+  }
+}
+
+/**
+ * Coerces string numeric values to actual numbers.
+ * LLMs frequently emit numeric parameters as strings (e.g. `{"depth": "3"}`)
+ * which strict MCP servers (e.g. Playwright) reject with schema validation
+ * errors like "params/depth must be number".
+ *
+ * Only coerces when:
+ * 1. The value is a string that looks like a clean number
+ * 2. The schema accepts integer/number but NOT string
+ */
+function fixNumericValues(
+  data: Record<string, unknown>,
+  schema: Record<string, unknown>,
+) {
+  const properties = schema['properties'] as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+  const items = schema['items'] as Record<string, unknown> | undefined;
+
+  for (const key of Object.keys(data)) {
+    if (!(key in data)) continue;
+    const value = data[key];
+    const childSchema = Array.isArray(data) ? items : properties?.[key];
+
+    if (typeof value === 'object' && value !== null) {
+      fixNumericValues(value as Record<string, unknown>, childSchema ?? {});
+      continue;
+    }
+
+    if (typeof value !== 'string') continue;
+
+    const accepted = childSchema ? getAcceptedTypes(childSchema) : null;
+    if (!accepted || accepted.has('string')) continue;
+    const wantsInteger = accepted.has('integer');
+    const wantsNumber = accepted.has('number');
+    if (!wantsInteger && !wantsNumber) continue;
+
+    const trimmed = value.trim();
+    if (!/^-?\d+(\.\d+)?$/.test(trimmed)) continue;
+
+    const parsed = wantsInteger ? parseInt(trimmed, 10) : parseFloat(trimmed);
+    if (Number.isFinite(parsed)) {
+      data[key] = parsed;
     }
   }
 }

--- a/packages/core/src/utils/schemaValidator.ts
+++ b/packages/core/src/utils/schemaValidator.ts
@@ -322,10 +322,12 @@ function fixNumericValues(
     const trimmed = value.trim();
     if (!/^-?\d+(\.\d+)?$/.test(trimmed)) continue;
 
-    const hasDecimal = trimmed.includes('.');
-    if (wantsInteger && !wantsNumber && hasDecimal) continue;
+    const num = parseFloat(trimmed);
+    // Reject non-integer values (e.g. "5.5") for integer-only schemas so the
+    // LLM self-corrects. Whole-number decimals (e.g. "3.0") still coerce.
+    if (wantsInteger && !wantsNumber && num % 1 !== 0) continue;
 
-    const parsed = wantsNumber ? parseFloat(trimmed) : parseInt(trimmed, 10);
+    const parsed = wantsNumber ? num : parseInt(trimmed, 10);
     if (Number.isFinite(parsed)) {
       data[key] = parsed;
     }

--- a/packages/core/src/utils/schemaValidator.ts
+++ b/packages/core/src/utils/schemaValidator.ts
@@ -322,7 +322,10 @@ function fixNumericValues(
     const trimmed = value.trim();
     if (!/^-?\d+(\.\d+)?$/.test(trimmed)) continue;
 
-    const parsed = wantsInteger ? parseInt(trimmed, 10) : parseFloat(trimmed);
+    const hasDecimal = trimmed.includes('.');
+    if (wantsInteger && !wantsNumber && hasDecimal) continue;
+
+    const parsed = wantsNumber ? parseFloat(trimmed) : parseInt(trimmed, 10);
     if (Number.isFinite(parsed)) {
       data[key] = parsed;
     }


### PR DESCRIPTION
## What this PR does

Adds numeric string coercion (`"3"` → `3`) to `SchemaValidator.validate()`, filling a gap alongside the existing boolean and stringified-JSON coercions. When the schema expects `integer`/`number` but does **not** accept `string`, clean numeric strings are parsed in-place before re-validation. The new `fixNumericValues()` helper recurses into nested objects and respects `anyOf`/`oneOf` union types, matching the style of `fixBooleanValues()`.

## Why it's needed

LLMs frequently emit numeric parameters as strings (e.g. `{"depth": "3"}` instead of `{"depth": 3}`). Strict MCP servers like Playwright validate JSON Schema types and reject these calls outright. The SchemaValidator already coerced booleans and JSON arrays/objects but was missing the numeric case.

### Real-world session evidence (session `65c4f5fe`)

In a real user session using Playwright MCP with qwen3.7-max, **4 out of ~20 Playwright tool calls failed** due to numeric type mismatches, forcing the model into retry loops and significantly degrading UX:

| Tool | LLM sent | MCP server error |
|------|----------|-----------------|
| `browser_snapshot` | `{"depth": "3"}` | `params/depth must be number` |
| `browser_wait_for` | `{"time": "5"}` | `params/time must be number` |
| `browser_wait_for` | `{"time": "5"}` | `params/time must be number` |
| `browser_evaluate` | `{"expression": "..."}` (missing `function`) | `params must have required property 'function'` |

The first three are type-mismatch errors that this PR fixes. The fourth (`browser_evaluate` wrong parameter name) is a separate issue not addressed here.

Additionally, the session also hit other Playwright errors (browser lock contention, file access sandbox restrictions, CSS selector parse failures) — those are unrelated to parameter coercion.

## Reviewer Test Plan

### How to verify

1. Run `npx vitest run packages/core/src/utils/schemaValidator.test.ts` — all 52 tests should pass (9 new tests for numeric coercion).
2. Confirm the new tests cover: integer coercion, float coercion, negative numbers, garbage-string rejection, union-type safety (no coercion when `string` is accepted), nested objects, draft-2020-12 schemas.
3. Optionally, configure a Playwright MCP server and invoke a tool with a numeric parameter — the model's string-typed numbers should now pass through without error.

### Evidence (Before & After)

N/A — non-UI change, covered by unit tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

N/A — unit tests only.

## Risk & Scope

- Main risk or tradeoff: Coercion could convert a legitimately string-typed `"42"` to a number — mitigated by only coercing when the schema does NOT accept `string`.
- Not validated / out of scope: The `browser_evaluate` error (`params must have required property 'function'`) seen in the same session is a different issue (wrong parameter name, not a type mismatch).
- Breaking changes / migration notes: None.

## Linked Issues

Closes #4966

<details>
<summary>中文说明</summary>

## 做了什么

在 `SchemaValidator.validate()` 中新增数字字符串强转（`"3"` → `3`），补齐已有的布尔值和 JSON 字符串强转逻辑。当 schema 期望 `integer`/`number` 且不接受 `string` 时，将合法的数字字符串原地解析后重新校验。新增的 `fixNumericValues()` 支持递归嵌套对象，并正确处理 `anyOf`/`oneOf` 联合类型，与 `fixBooleanValues()` 风格一致。

## 为什么需要

LLM 经常把数字参数以字符串形式发出（如 `{"depth": "3"}` 而非 `{"depth": 3}`）。严格的 MCP 服务端（如 Playwright）按 JSON Schema 类型校验后直接拒绝。SchemaValidator 已有布尔值和 JSON 数组/对象的强转，唯独缺少数字类型。

### 真实会话证据（session `65c4f5fe`）

在一个使用 Playwright MCP + qwen3.7-max 的真实用户会话中，约 20 次 Playwright 工具调用中有 **4 次因数字类型不匹配而失败**，导致模型反复重试，严重影响体验：

| 工具 | LLM 发送 | MCP 服务端报错 |
|------|----------|---------------|
| `browser_snapshot` | `{"depth": "3"}` | `params/depth must be number` |
| `browser_wait_for` | `{"time": "5"}` | `params/time must be number` |
| `browser_wait_for` | `{"time": "5"}` | `params/time must be number` |
| `browser_evaluate` | `{"expression": "..."}` (缺少 `function`) | `params must have required property 'function'` |

前三个是本 PR 修复的类型不匹配错误。第四个（`browser_evaluate` 参数名错误）是另一个问题，不在本 PR 范围内。

此外，该会话还遇到了其他 Playwright 错误（浏览器锁竞争、文件访问沙箱限制、CSS 选择器解析失败）——这些与参数强转无关。

## 验证方式

1. 执行 `npx vitest run packages/core/src/utils/schemaValidator.test.ts` — 52 个测试全部通过（含 9 个新增的数字强转测试）。
2. 新测试覆盖：整数强转、浮点强转、负数、非法字符串拒绝、联合类型安全（schema 接受 string 时不强转）、嵌套对象、draft-2020-12 schema。

## 风险与范围

- 主要风险：强转可能误将合法的字符串 `"42"` 转为数字 — 通过仅在 schema 不接受 `string` 时才强转来规避。
- 未验证/不在范围内：同一会话中 `browser_evaluate` 的 `params must have required property 'function'` 错误是另一个问题（参数名错误，非类型不匹配）。
- 无破坏性变更。

</details>