### PR TITLE
fix(core): stabilize truncated tool retry keys

### DIFF
--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -8558,14 +8558,16 @@ describe('CoreToolScheduler validation retry loop detection', () => {
     callId: string,
     name: string,
     args: Record<string, unknown>,
+    wasOutputTruncated = false,
   ) {
-    return {
+    const request = {
       callId,
       name,
       args,
       isClientInitiated: false,
       prompt_id: `prompt-${callId}`,
     };
+    return wasOutputTruncated ? { ...request, wasOutputTruncated } : request;
   }
 
   function getLastErrorMessage(onToolCallsUpdate: Mock): string | undefined {
@@ -8615,6 +8617,35 @@ describe('CoreToolScheduler validation retry loop detection', () => {
       new AbortController().signal,
     );
     msg = getLastErrorMessage(onToolCallsUpdate);
+    expect(msg).toContain(RETRY_LOOP_STOP_DIRECTIVE);
+  });
+
+  it('should keep retry counts stable when truncation guidance is toggled', async () => {
+    const tool = new StrictStringTool();
+    const { scheduler, onToolCallsUpdate } = createSchedulerWithTool(tool);
+
+    await scheduler.schedule(
+      [makeRequest('c1', 'strictStringTool', { value: 123 }, true)],
+      new AbortController().signal,
+    );
+    let msg = getLastErrorMessage(onToolCallsUpdate);
+    expect(msg).toContain('previous response was truncated');
+    expect(msg).not.toContain(RETRY_LOOP_STOP_DIRECTIVE);
+
+    await scheduler.schedule(
+      [makeRequest('c2', 'strictStringTool', { value: 123 })],
+      new AbortController().signal,
+    );
+    msg = getLastErrorMessage(onToolCallsUpdate);
+    expect(msg).not.toContain('previous response was truncated');
+    expect(msg).not.toContain(RETRY_LOOP_STOP_DIRECTIVE);
+
+    await scheduler.schedule(
+      [makeRequest('c3', 'strictStringTool', { value: 123 }, true)],
+      new AbortController().signal,
+    );
+    msg = getLastErrorMessage(onToolCallsUpdate);
+    expect(msg).not.toContain('previous response was truncated');
     expect(msg).toContain(RETRY_LOOP_STOP_DIRECTIVE);
   });
 

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -1712,7 +1712,7 @@ export class CoreToolScheduler {
           reqInfo.prompt_id,
         );
         if (invocationOrError instanceof Error) {
-          const baseError = reqInfo.wasOutputTruncated
+          const displayError = reqInfo.wasOutputTruncated
             ? new Error(
                 `${invocationOrError.message} ${TRUNCATION_PARAM_GUIDANCE}`,
               )
@@ -1721,7 +1721,7 @@ export class CoreToolScheduler {
           // Track validation retry for loop detection. Counts accumulate per
           // (tool, error message) pair so a different validation mistake on
           // the same tool starts fresh rather than tripping the threshold.
-          const errorKey = `${reqInfo.name}:${baseError.message}`;
+          const errorKey = `${reqInfo.name}:${invocationOrError.message}`;
           const count = (this.validationRetryCounts.get(errorKey) ?? 0) + 1;
           for (const key of this.validationRetryCounts.keys()) {
             if (key.startsWith(`${reqInfo.name}:`) && key !== errorKey) {
@@ -1732,8 +1732,10 @@ export class CoreToolScheduler {
 
           const finalError =
             count >= VALIDATION_RETRY_LOOP_THRESHOLD
-              ? new Error(`${baseError.message}${RETRY_LOOP_STOP_DIRECTIVE}`)
-              : baseError;
+              ? new Error(
+                  `${invocationOrError.message}${RETRY_LOOP_STOP_DIRECTIVE}`,
+                )
+              : displayError;
 
           newToolCalls.push({
             status: 'error',


### PR DESCRIPTION
## What this PR does

This makes validation retry tracking ignore the extra truncation guidance that is appended to the user-facing error message. The model still receives the truncation-specific guidance when a tool call was cut off, but the scheduler counts the underlying schema error as the same failure whether the latest attempt was marked truncated or not.

## Why it's needed

In the max-tokens truncation recovery path, the same invalid MCP/tool call can alternate between an error with truncation guidance and the same base validation error without that guidance. Because the retry-loop key included the full displayed message, that alternation reset the counter and delayed or prevented the retry-loop stop directive. This is one of the failure modes called out in #4964.

## Reviewer Test Plan

### How to verify

Run the core scheduler test file and confirm the validation retry loop tests pass. The new case sends the same invalid tool parameters three times while toggling the truncation marker on and off; the third failure should still include the retry-loop stop directive, while the user-facing truncation guidance should still appear on truncated attempts only.

### Evidence (Before & After)

N/A. This is scheduler retry-state behavior covered by unit tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Windows 11, Node.js v24.15.0, npm 11.12.1.

Local checks run:

- `npm ci`
- `npx vitest run src/core/coreToolScheduler.test.ts -t "validation retry loop detection"`
- `npx vitest run src/core/coreToolScheduler.test.ts`
- `npm run typecheck` from `packages/core`
- `npx prettier --check src/core/coreToolScheduler.ts src/core/coreToolScheduler.test.ts`
- `npx eslint src/core/coreToolScheduler.ts src/core/coreToolScheduler.test.ts`
- `git diff --check`

## Risk & Scope

- Main risk or tradeoff: low; this only changes how validation retry attempts are grouped, not the message shown to the model or tool execution semantics.
- Not validated / out of scope: this does not move max-token escalation to the agent loop and does not attempt to fully solve every recovery path described in #4964.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #4964.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 让工具参数校验失败的重试计数不再受“截断提示文本”影响。模型在截断场景下仍然会看到截断相关的指导，但调度器会把同一个 schema 参数错误视为同一种失败，而不是因为提示文本有无变化就拆成两个重试计数。

## 为什么需要

在 max_tokens 截断恢复路径里，同一个无效 MCP/工具调用可能一轮带截断提示、一轮不带截断提示。旧逻辑把完整展示错误作为 retry-loop key，因此这个 true/false 状态切换会重置计数，导致 retry-loop stop directive 延迟出现甚至无法触发。这正是 #4964 里列出的一个失败模式。

## Reviewer Test Plan

### 如何验证

运行 core scheduler 测试文件，确认 validation retry loop 相关测试通过。新增测试会用同一组无效工具参数连续失败三次，并在截断标记 true/false 之间切换；第三次仍应触发 retry-loop stop directive，同时截断指导只应出现在被标记为截断的尝试里。

### 前后证据

N/A。这是调度器 retry-state 行为，由单元测试覆盖。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### 环境

Windows 11，Node.js v24.15.0，npm 11.12.1。

本地运行过：

- `npm ci`
- `npx vitest run src/core/coreToolScheduler.test.ts -t "validation retry loop detection"`
- `npx vitest run src/core/coreToolScheduler.test.ts`
- `npm run typecheck` from `packages/core`
- `npx prettier --check src/core/coreToolScheduler.ts src/core/coreToolScheduler.test.ts`
- `npx eslint src/core/coreToolScheduler.ts src/core/coreToolScheduler.test.ts`
- `git diff --check`

## 风险与范围

- 主要风险或取舍：低；这里只改变参数校验失败的重试归类方式，不改变展示给模型的错误信息，也不改变工具执行语义。
- 未验证 / 不在范围内：本 PR 不把 max-token 升级移动到 agent loop，也不试图一次性解决 #4964 描述的所有恢复路径。
- breaking change / 迁移说明：无。

## 关联 issue

Refs #4964.

</details>
