### PR TITLE
fix(cli): reduce retained interactive tool output memory

### DIFF
--- a/packages/cli/src/ui/hooks/shellCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.test.ts
@@ -191,7 +191,7 @@ describe('useShellCommandProcessor', () => {
     expect(setShellInputFocusedMock).toHaveBeenCalledWith(false);
   });
 
-  it('compacts large shell output before storing UI and model history', async () => {
+  it('compacts large shell output for UI history without changing model history behavior', async () => {
     const largeOutput = `head-${'x'.repeat(100_000)}-tail`;
     const { result } = renderProcessorHook();
 
@@ -222,10 +222,11 @@ describe('useShellCommandProcessor', () => {
         text: string;
       }
     ).text;
-    expect(modelHistoryText.length).toBeLessThan(2600);
+    expect(modelHistoryText.length).toBeGreaterThan(10_000);
+    expect(modelHistoryText.length).toBeLessThan(10_500);
     expect(modelHistoryText).toContain('head-');
-    expect(modelHistoryText).toContain('-tail');
-    expect(modelHistoryText).toContain('truncated from');
+    expect(modelHistoryText).not.toContain('-tail');
+    expect(modelHistoryText).toContain('... (truncated)');
   });
 
   it('should handle command failure and display error status', async () => {

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.test.ts
@@ -229,6 +229,32 @@ describe('useShellCommandProcessor', () => {
     expect(modelHistoryText).toContain('... (truncated)');
   });
 
+  it('preserves unmatched surrogate code units in truncated shell model history', async () => {
+    const longOutput = `head-\uD800-${'x'.repeat(11_000)}`;
+    const { result } = renderProcessorHook();
+
+    act(() => {
+      result.current.handleShellCommand(
+        'surrogate-output',
+        new AbortController().signal,
+      );
+    });
+    const execPromise = onExecMock.mock.calls[0][0];
+
+    act(() => {
+      resolveExecutionPromise(createMockServiceResult({ output: longOutput }));
+    });
+    await act(async () => await execPromise);
+
+    const modelHistoryText = (
+      vi.mocked(mockGeminiClient.addHistory).mock.calls[0]![0].parts![0]! as {
+        text: string;
+      }
+    ).text;
+    expect(modelHistoryText).toContain('\uD800');
+    expect(modelHistoryText).not.toContain('\uFFFD');
+  });
+
   it('should handle command failure and display error status', async () => {
     const { result } = renderProcessorHook();
 

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.test.ts
@@ -36,6 +36,7 @@ import {
   OUTPUT_UPDATE_INTERVAL_MS,
 } from './shellCommandProcessor.js';
 import {
+  MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
   type Config,
   type GeminiClient,
   type ShellExecutionResult,
@@ -188,6 +189,43 @@ describe('useShellCommandProcessor', () => {
     );
     expect(mockGeminiClient.addHistory).toHaveBeenCalled();
     expect(setShellInputFocusedMock).toHaveBeenCalledWith(false);
+  });
+
+  it('compacts large shell output before storing UI and model history', async () => {
+    const largeOutput = `head-${'x'.repeat(100_000)}-tail`;
+    const { result } = renderProcessorHook();
+
+    act(() => {
+      result.current.handleShellCommand(
+        'generate-large-output',
+        new AbortController().signal,
+      );
+    });
+    const execPromise = onExecMock.mock.calls[0][0];
+
+    act(() => {
+      resolveExecutionPromise(createMockServiceResult({ output: largeOutput }));
+    });
+    await act(async () => await execPromise);
+
+    const finalHistoryItem = addItemToHistoryMock.mock.calls[1][0];
+    const finalDisplay = finalHistoryItem.tools[0].resultDisplay as string;
+    expect(finalDisplay.length).toBeLessThanOrEqual(
+      MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+    );
+    expect(finalDisplay).toContain('head-');
+    expect(finalDisplay).toContain('-tail');
+    expect(finalDisplay).toContain('truncated from');
+
+    const modelHistoryText = (
+      vi.mocked(mockGeminiClient.addHistory).mock.calls[0]![0].parts![0]! as {
+        text: string;
+      }
+    ).text;
+    expect(modelHistoryText.length).toBeLessThan(2600);
+    expect(modelHistoryText).toContain('head-');
+    expect(modelHistoryText).toContain('-tail');
+    expect(modelHistoryText).toContain('truncated from');
   });
 
   it('should handle command failure and display error status', async () => {

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.ts
@@ -27,6 +27,7 @@ import type { UseHistoryManagerReturn } from './useHistoryManager.js';
 import { SHELL_COMMAND_NAME } from '../constants.js';
 import { formatMemoryUsage } from '../utils/formatters.js';
 import crypto from 'node:crypto';
+import { Buffer } from 'node:buffer';
 import path from 'node:path';
 import os from 'node:os';
 import fs from 'node:fs';
@@ -36,6 +37,10 @@ export const OUTPUT_UPDATE_INTERVAL_MS = 1000;
 const MAX_OUTPUT_LENGTH = 10000;
 const debugLogger = createDebugLogger('SHELL_COMMAND_PROCESSOR');
 
+function copyString(value: string): string {
+  return Buffer.from(value).toString('utf8');
+}
+
 function addShellCommandToGeminiHistory(
   geminiClient: GeminiClient,
   rawQuery: string,
@@ -43,7 +48,8 @@ function addShellCommandToGeminiHistory(
 ) {
   const modelContent =
     resultText.length > MAX_OUTPUT_LENGTH
-      ? resultText.substring(0, MAX_OUTPUT_LENGTH) + '\n... (truncated)'
+      ? copyString(resultText.substring(0, MAX_OUTPUT_LENGTH)) +
+        '\n... (truncated)'
       : resultText;
 
   geminiClient.addHistory({

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.ts
@@ -17,6 +17,8 @@ import type {
   ShellExecutionResult,
 } from '@qwen-code/qwen-code-core';
 import {
+  compactStringForHistory,
+  compactToolResultDisplayForHistory,
   createDebugLogger,
   isBinary,
   ShellExecutionService,
@@ -32,7 +34,7 @@ import fs from 'node:fs';
 import { themeManager } from '../../ui/themes/theme-manager.js';
 
 export const OUTPUT_UPDATE_INTERVAL_MS = 1000;
-const MAX_OUTPUT_LENGTH = 10000;
+const MAX_MODEL_HISTORY_OUTPUT_LENGTH = 2000;
 const debugLogger = createDebugLogger('SHELL_COMMAND_PROCESSOR');
 
 function addShellCommandToGeminiHistory(
@@ -40,10 +42,10 @@ function addShellCommandToGeminiHistory(
   rawQuery: string,
   resultText: string,
 ) {
-  const modelContent =
-    resultText.length > MAX_OUTPUT_LENGTH
-      ? resultText.substring(0, MAX_OUTPUT_LENGTH) + '\n... (truncated)'
-      : resultText;
+  const modelContent = compactStringForHistory(
+    resultText,
+    MAX_MODEL_HISTORY_OUTPUT_LENGTH,
+  );
 
   geminiClient.addHistory({
     role: 'user',
@@ -220,8 +222,12 @@ export const useShellCommandProcessor = (
                               ...tool,
                               resultDisplay:
                                 typeof currentDisplayOutput === 'string'
-                                  ? currentDisplayOutput
-                                  : { ansiOutput: currentDisplayOutput },
+                                  ? compactToolResultDisplayForHistory(
+                                      currentDisplayOutput,
+                                    )
+                                  : compactToolResultDisplayForHistory({
+                                      ansiOutput: currentDisplayOutput,
+                                    }),
                             }
                           : tool,
                       ),
@@ -297,10 +303,10 @@ export const useShellCommandProcessor = (
               const finalToolDisplay: IndividualToolCallDisplay = {
                 ...initialToolDisplay,
                 status: finalStatus,
-                resultDisplay: finalOutput,
+                resultDisplay: compactToolResultDisplayForHistory(finalOutput),
               };
 
-              // Add the complete, contextual result to the local UI history.
+              // Add the compacted, contextual result to the local UI history.
               addItemToHistory(
                 {
                   type: 'tool_group',
@@ -310,7 +316,7 @@ export const useShellCommandProcessor = (
                 userMessageTimestamp,
               );
 
-              // Add the same complete, contextual result to the LLM's history.
+              // Add a smaller contextual summary to the LLM's history.
               addShellCommandToGeminiHistory(
                 geminiClient,
                 rawQuery,

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.ts
@@ -17,7 +17,6 @@ import type {
   ShellExecutionResult,
 } from '@qwen-code/qwen-code-core';
 import {
-  compactStringForHistory,
   compactToolResultDisplayForHistory,
   createDebugLogger,
   isBinary,
@@ -34,7 +33,7 @@ import fs from 'node:fs';
 import { themeManager } from '../../ui/themes/theme-manager.js';
 
 export const OUTPUT_UPDATE_INTERVAL_MS = 1000;
-const MAX_MODEL_HISTORY_OUTPUT_LENGTH = 2000;
+const MAX_OUTPUT_LENGTH = 10000;
 const debugLogger = createDebugLogger('SHELL_COMMAND_PROCESSOR');
 
 function addShellCommandToGeminiHistory(
@@ -42,10 +41,10 @@ function addShellCommandToGeminiHistory(
   rawQuery: string,
   resultText: string,
 ) {
-  const modelContent = compactStringForHistory(
-    resultText,
-    MAX_MODEL_HISTORY_OUTPUT_LENGTH,
-  );
+  const modelContent =
+    resultText.length > MAX_OUTPUT_LENGTH
+      ? resultText.substring(0, MAX_OUTPUT_LENGTH) + '\n... (truncated)'
+      : resultText;
 
   geminiClient.addHistory({
     role: 'user',
@@ -316,7 +315,7 @@ export const useShellCommandProcessor = (
                 userMessageTimestamp,
               );
 
-              // Add a smaller contextual summary to the LLM's history.
+              // Keep the existing LLM history behavior unchanged.
               addShellCommandToGeminiHistory(
                 geminiClient,
                 rawQuery,

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.ts
@@ -27,7 +27,6 @@ import type { UseHistoryManagerReturn } from './useHistoryManager.js';
 import { SHELL_COMMAND_NAME } from '../constants.js';
 import { formatMemoryUsage } from '../utils/formatters.js';
 import crypto from 'node:crypto';
-import { Buffer } from 'node:buffer';
 import path from 'node:path';
 import os from 'node:os';
 import fs from 'node:fs';
@@ -38,7 +37,7 @@ const MAX_OUTPUT_LENGTH = 10000;
 const debugLogger = createDebugLogger('SHELL_COMMAND_PROCESSOR');
 
 function copyString(value: string): string {
-  return Buffer.from(value).toString('utf8');
+  return value.split('').join('');
 }
 
 function addShellCommandToGeminiHistory(

--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -358,12 +358,12 @@ export function mapToDisplay(
             confirmationDetails: trackedCall.confirmationDetails,
           };
         case 'executing':
+          // React stores compacted live output when handling raw update chunks.
           return {
             ...baseDisplayProperties,
             status: mapCoreStatusToDisplayStatus(trackedCall.status),
-            resultDisplay: compactToolResultDisplayForHistory(
+            resultDisplay:
               (trackedCall as TrackedExecutingToolCall).liveOutput ?? undefined,
-            ),
             confirmationDetails: undefined,
             ptyId: (trackedCall as TrackedExecutingToolCall).pid,
             executionStartTime: (trackedCall as TrackedExecutingToolCall)

--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -112,11 +112,12 @@ export function useReactToolScheduler(
 
   const outputUpdateHandler: OutputUpdateHandler = useCallback(
     (toolCallId, outputChunk) => {
+      const compactOutput = compactToolResultDisplayForHistory(outputChunk);
       setToolCallsForDisplay((prevCalls) =>
         prevCalls.map((tc) => {
           if (tc.request.callId === toolCallId && tc.status === 'executing') {
             const executingTc = tc as TrackedExecutingToolCall;
-            return { ...executingTc, liveOutput: outputChunk };
+            return { ...executingTc, liveOutput: compactOutput };
           }
           return tc;
         }),

--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -22,6 +22,7 @@ import type {
 } from '@qwen-code/qwen-code-core';
 import {
   CoreToolScheduler,
+  compactToolResultDisplayForHistory,
   createDebugLogger,
   isAnyAutoMemPath,
 } from '@qwen-code/qwen-code-core';
@@ -325,21 +326,27 @@ export function mapToDisplay(
           return {
             ...baseDisplayProperties,
             status: mapCoreStatusToDisplayStatus(trackedCall.status),
-            resultDisplay: trackedCall.response.resultDisplay,
+            resultDisplay: compactToolResultDisplayForHistory(
+              trackedCall.response.resultDisplay,
+            ),
             confirmationDetails: undefined,
           };
         case 'error':
           return {
             ...baseDisplayProperties,
             status: mapCoreStatusToDisplayStatus(trackedCall.status),
-            resultDisplay: trackedCall.response.resultDisplay,
+            resultDisplay: compactToolResultDisplayForHistory(
+              trackedCall.response.resultDisplay,
+            ),
             confirmationDetails: undefined,
           };
         case 'cancelled':
           return {
             ...baseDisplayProperties,
             status: mapCoreStatusToDisplayStatus(trackedCall.status),
-            resultDisplay: trackedCall.response.resultDisplay,
+            resultDisplay: compactToolResultDisplayForHistory(
+              trackedCall.response.resultDisplay,
+            ),
             confirmationDetails: undefined,
           };
         case 'awaiting_approval':
@@ -353,8 +360,9 @@ export function mapToDisplay(
           return {
             ...baseDisplayProperties,
             status: mapCoreStatusToDisplayStatus(trackedCall.status),
-            resultDisplay:
+            resultDisplay: compactToolResultDisplayForHistory(
               (trackedCall as TrackedExecutingToolCall).liveOutput ?? undefined,
+            ),
             confirmationDetails: undefined,
             ptyId: (trackedCall as TrackedExecutingToolCall).pid,
             executionStartTime: (trackedCall as TrackedExecutingToolCall)

--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -7,7 +7,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Mock } from 'vitest';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import {
   useReactToolScheduler,
   mapToDisplay,
@@ -509,6 +509,66 @@ describe('useReactToolScheduler', () => {
       }),
     });
     expect(result.current[0]).toEqual([]);
+  });
+
+  it('compacts live output before storing it in React state', async () => {
+    vi.useRealTimers();
+    const longOutput = `head-${'x'.repeat(
+      MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+    )}-tail`;
+    let resolveExecution!: (result: ToolResult) => void;
+    const streamingTool = new MockTool({
+      name: 'streamTool',
+      displayName: 'Stream Tool',
+      canUpdateOutput: true,
+      execute: vi.fn((_params, _signal, updateOutput) => {
+        updateOutput?.(longOutput);
+        return new Promise<ToolResult>((resolve) => {
+          resolveExecution = resolve;
+        });
+      }),
+    });
+
+    mockToolRegistry.getTool.mockReturnValue(streamingTool);
+
+    const { result } = renderScheduler();
+    const request: ToolCallRequestInfo = {
+      callId: 'stream-call',
+      name: 'streamTool',
+      args: { param: 'value' },
+    } as any;
+
+    act(() => {
+      result.current[1](request, new AbortController().signal);
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current[0].some((call) => call.status === 'executing'),
+      ).toBe(true);
+    });
+
+    const executingCall = result.current[0].find(
+      (call) => call.status === 'executing',
+    ) as { liveOutput?: string } | undefined;
+    expect(executingCall?.liveOutput).not.toBe(longOutput);
+    expect(executingCall?.liveOutput?.length).toBeLessThanOrEqual(
+      MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+    );
+    expect(executingCall?.liveOutput).toContain('head-');
+    expect(executingCall?.liveOutput).toContain('-tail');
+    expect(executingCall?.liveOutput).toContain('truncated from');
+
+    await act(async () => {
+      resolveExecution({
+        llmContent: 'done',
+        returnDisplay: 'done',
+      } as ToolResult);
+    });
+
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalled();
+    });
   });
 });
 

--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -28,6 +28,7 @@ import type {
 import {
   DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
   DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
+  MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
   ApprovalMode,
   MockTool,
 } from '@qwen-code/qwen-code-core';
@@ -778,5 +779,33 @@ describe('mapToDisplay', () => {
     expect(display.tools[1].renderOutputAsMarkdown).toBe(true);
     expect(display.tools[1].executionStartTime).toBe(1234567890);
     expect(display.tools[0].executionStartTime).toBeUndefined();
+  });
+
+  it('compacts large resultDisplay values before storing display history', () => {
+    const longDisplay = `head-${'x'.repeat(
+      MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+    )}-tail`;
+    const toolCall: ToolCall = {
+      request: { ...baseRequest, callId: 'large-output-call' },
+      status: 'success',
+      tool: baseTool,
+      invocation: baseTool.build(baseRequest.args),
+      response: {
+        ...baseResponse,
+        callId: 'large-output-call',
+        resultDisplay: longDisplay,
+      },
+    } as ToolCall;
+
+    const display = mapToDisplay(toolCall);
+    const resultDisplay = display.tools[0].resultDisplay;
+
+    expect(typeof resultDisplay).toBe('string');
+    expect((resultDisplay as string).length).toBeLessThanOrEqual(
+      MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+    );
+    expect(resultDisplay).toContain('head-');
+    expect(resultDisplay).toContain('-tail');
+    expect(resultDisplay).toContain('truncated from');
   });
 });

--- a/packages/cli/src/utils/nonInteractiveHelpers.test.ts
+++ b/packages/cli/src/utils/nonInteractiveHelpers.test.ts
@@ -733,6 +733,64 @@ describe('createAgentToolProgressHandler', () => {
     );
   });
 
+  it('forwards subagent tool args and response parts for JSON output', () => {
+    const { handler } = createAgentToolProgressHandler(
+      mockConfig,
+      'parent-tool-id',
+      mockAdapter,
+    );
+    const responseParts: Part[] = [
+      {
+        functionResponse: {
+          name: 'test_tool',
+          id: 'tool-1',
+          response: { output: 'Success from responseParts' },
+        },
+      },
+    ];
+
+    const taskDisplay: AgentResultDisplay = {
+      type: 'task_execution',
+      subagentName: 'test-agent',
+      taskDescription: 'Test task',
+      taskPrompt: 'Test prompt',
+      status: 'running',
+      toolCalls: [
+        {
+          callId: 'tool-1',
+          name: 'test_tool',
+          args: { arg1: 'value1' },
+          status: 'success',
+          responseParts,
+        },
+      ],
+    };
+
+    handler('task-call-id', taskDisplay);
+
+    expect(mockAdapter.processSubagentToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callId: 'tool-1',
+        name: 'test_tool',
+        args: { arg1: 'value1' },
+        status: 'executing',
+      }),
+      'parent-tool-id',
+    );
+    expect(mockAdapter.emitToolResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callId: 'tool-1',
+        name: 'test_tool',
+        args: { arg1: 'value1' },
+      }),
+      expect.objectContaining({
+        callId: 'tool-1',
+        responseParts,
+      }),
+      'parent-tool-id',
+    );
+  });
+
   it('should not duplicate tool_use emissions', () => {
     const { handler } = createAgentToolProgressHandler(
       mockConfig,

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -3781,6 +3781,8 @@ describe('CoreToolScheduler YOLO mode', () => {
         terminalWidth: 90,
         terminalHeight: 30,
       }),
+      getTruncateToolOutputThreshold: () => 100_000,
+      getTruncateToolOutputLines: () => 10_000,
       getUseModelRouter: () => false,
       getGeminiClient: () => null,
       isInteractive: () => isInteractive,

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -3733,10 +3733,10 @@ describe('CoreToolScheduler edit cancellation', () => {
 });
 
 describe('CoreToolScheduler YOLO mode', () => {
-  it('compacts completed resultDisplay before retaining scheduler state', async () => {
-    const longDisplay = `head-${'x'.repeat(
-      MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
-    )}-tail`;
+  const runLongDisplayTool = async (
+    longDisplay: string,
+    isInteractive: boolean,
+  ) => {
     const executeFn = vi.fn().mockResolvedValue({
       llmContent: 'Tool executed',
       returnDisplay: longDisplay,
@@ -3783,7 +3783,7 @@ describe('CoreToolScheduler YOLO mode', () => {
       }),
       getUseModelRouter: () => false,
       getGeminiClient: () => null,
-      isInteractive: () => true,
+      isInteractive: () => isInteractive,
       getIdeMode: () => false,
       getExperimentalZedIntegration: () => false,
       getChatRecordingService: () => undefined,
@@ -3817,14 +3817,34 @@ describe('CoreToolScheduler YOLO mode', () => {
     const completedCall = completedCalls[0];
     expect(completedCall.status).toBe('success');
     if (completedCall.status === 'success') {
-      const retainedDisplay = completedCall.response.resultDisplay as string;
-      expect(retainedDisplay.length).toBeLessThanOrEqual(
-        MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
-      );
-      expect(retainedDisplay).toContain('head-');
-      expect(retainedDisplay).toContain('-tail');
-      expect(retainedDisplay).toContain('truncated from');
+      return completedCall.response.resultDisplay as string;
     }
+    return undefined;
+  };
+
+  it('compacts completed resultDisplay before retaining interactive scheduler state', async () => {
+    const longDisplay = `head-${'x'.repeat(
+      MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+    )}-tail`;
+
+    const retainedDisplay = await runLongDisplayTool(longDisplay, true);
+
+    expect(retainedDisplay?.length).toBeLessThanOrEqual(
+      MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+    );
+    expect(retainedDisplay).toContain('head-');
+    expect(retainedDisplay).toContain('-tail');
+    expect(retainedDisplay).toContain('truncated from');
+  });
+
+  it('preserves completed resultDisplay in non-interactive scheduler responses', async () => {
+    const longDisplay = `head-${'x'.repeat(
+      MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+    )}-tail`;
+
+    await expect(runLongDisplayTool(longDisplay, false)).resolves.toBe(
+      longDisplay,
+    );
   });
 
   it('should execute tool requiring confirmation directly without waiting', async () => {
@@ -4028,6 +4048,7 @@ describe('CoreToolScheduler cancellation during executing with live output', () 
         terminalWidth: 90,
         terminalHeight: 30,
       }),
+      isInteractive: () => true,
       getChatRecordingService: () => undefined,
       getMessageBus: vi.fn().mockReturnValue(undefined),
       getDisableAllHooks: vi.fn().mockReturnValue(true),
@@ -4181,6 +4202,7 @@ describe('CoreToolScheduler cancellation during executing with live output', () 
         terminalWidth: 90,
         terminalHeight: 30,
       }),
+      isInteractive: () => true,
       getChatRecordingService: () => undefined,
       getMessageBus: vi.fn().mockReturnValue(undefined),
       getDisableAllHooks: vi.fn().mockReturnValue(true),

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -4094,7 +4094,7 @@ describe('CoreToolScheduler cancellation during executing with live output', () 
     expect(execSpanRecord?.endMetadata?.cancelled).toBe(true);
   });
 
-  it('compacts live output before retaining it in scheduler state', async () => {
+  it('compacts live output only before retaining it in scheduler state', async () => {
     const longOutput = `head-${'x'.repeat(
       MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
     )}-tail`;
@@ -4213,13 +4213,7 @@ describe('CoreToolScheduler cancellation during executing with live output', () 
       expect(outputUpdateHandler).toHaveBeenCalled();
     });
 
-    const compactOutput = outputUpdateHandler.mock.calls[0][1] as string;
-    expect(compactOutput.length).toBeLessThanOrEqual(
-      MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
-    );
-    expect(compactOutput).toContain('head-');
-    expect(compactOutput).toContain('-tail');
-    expect(compactOutput).toContain('truncated from');
+    expect(outputUpdateHandler.mock.calls[0][1]).toBe(longOutput);
 
     const liveOutputUpdate = onToolCallsUpdate.mock.calls
       .map((call) => call[0][0] as ToolCall)
@@ -4227,7 +4221,13 @@ describe('CoreToolScheduler cancellation during executing with live output', () 
         (call): call is ExecutingToolCall =>
           call.status === 'executing' && call.liveOutput !== undefined,
       );
-    expect(liveOutputUpdate?.liveOutput).toBe(compactOutput);
+    const retainedOutput = liveOutputUpdate?.liveOutput as string;
+    expect(retainedOutput.length).toBeLessThanOrEqual(
+      MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+    );
+    expect(retainedOutput).toContain('head-');
+    expect(retainedOutput).toContain('-tail');
+    expect(retainedOutput).toContain('truncated from');
 
     abortController.abort();
     await schedulePromise;

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -26,6 +26,7 @@ import {
   ToolConfirmationOutcome,
   DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
   DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
+  MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
   ToolErrorType,
 } from '../index.js';
 import * as path from 'node:path';
@@ -33,7 +34,11 @@ import { pathToFileURL } from 'node:url';
 import { SkillTool } from '../tools/skill.js';
 import { StructuredToolError } from '../tools/priorReadEnforcement.js';
 import { ToolNames, ToolNamesMigration } from '../tools/tool-names.js';
-import type { ToolCall, WaitingToolCall } from './coreToolScheduler.js';
+import type {
+  ExecutingToolCall,
+  ToolCall,
+  WaitingToolCall,
+} from './coreToolScheduler.js';
 import {
   CoreToolScheduler,
   convertToFunctionResponse,
@@ -3728,6 +3733,100 @@ describe('CoreToolScheduler edit cancellation', () => {
 });
 
 describe('CoreToolScheduler YOLO mode', () => {
+  it('compacts completed resultDisplay before retaining scheduler state', async () => {
+    const longDisplay = `head-${'x'.repeat(
+      MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+    )}-tail`;
+    const executeFn = vi.fn().mockResolvedValue({
+      llmContent: 'Tool executed',
+      returnDisplay: longDisplay,
+    });
+    const mockTool = new MockTool({
+      name: 'mockTool',
+      execute: executeFn,
+      getDefaultPermission: MOCK_TOOL_GET_DEFAULT_PERMISSION,
+      getConfirmationDetails: MOCK_TOOL_GET_CONFIRMATION_DETAILS,
+    });
+    const declarativeTool = mockTool;
+
+    const mockToolRegistry = {
+      getTool: () => declarativeTool,
+      ensureTool: async () => declarativeTool,
+      getToolByName: () => declarativeTool,
+      getFunctionDeclarations: () => [],
+      tools: new Map(),
+      discovery: {},
+      registerTool: () => {},
+      getToolByDisplayName: () => declarativeTool,
+      getTools: () => [],
+      discoverTools: async () => {},
+      getAllTools: () => [],
+      getToolsByServer: () => [],
+    } as unknown as ToolRegistry;
+
+    const onAllToolCallsComplete = vi.fn();
+    const onToolCallsUpdate = vi.fn();
+    const mockConfig = {
+      getSessionId: () => 'test-session-id',
+      getUsageStatisticsEnabled: () => true,
+      getDebugMode: () => false,
+      getApprovalMode: () => ApprovalMode.YOLO,
+      getPermissionsAllow: () => [],
+      getContentGeneratorConfig: () => ({
+        model: 'test-model',
+        authType: 'gemini',
+      }),
+      getToolRegistry: () => mockToolRegistry,
+      getShellExecutionConfig: () => ({
+        terminalWidth: 90,
+        terminalHeight: 30,
+      }),
+      getUseModelRouter: () => false,
+      getGeminiClient: () => null,
+      isInteractive: () => true,
+      getIdeMode: () => false,
+      getExperimentalZedIntegration: () => false,
+      getChatRecordingService: () => undefined,
+      getMessageBus: vi.fn().mockReturnValue(undefined),
+      getDisableAllHooks: vi.fn().mockReturnValue(true),
+    } as unknown as Config;
+
+    const scheduler = new CoreToolScheduler({
+      config: mockConfig,
+      onAllToolCallsComplete,
+      onToolCallsUpdate,
+      getPreferredEditor: () => 'vscode',
+      onEditorClose: vi.fn(),
+    });
+
+    await scheduler.schedule(
+      [
+        {
+          callId: '1',
+          name: 'mockTool',
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'prompt-id-1',
+        },
+      ],
+      new AbortController().signal,
+    );
+
+    const completedCalls = onAllToolCallsComplete.mock
+      .calls[0][0] as ToolCall[];
+    const completedCall = completedCalls[0];
+    expect(completedCall.status).toBe('success');
+    if (completedCall.status === 'success') {
+      const retainedDisplay = completedCall.response.resultDisplay as string;
+      expect(retainedDisplay.length).toBeLessThanOrEqual(
+        MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+      );
+      expect(retainedDisplay).toContain('head-');
+      expect(retainedDisplay).toContain('-tail');
+      expect(retainedDisplay).toContain('truncated from');
+    }
+  });
+
   it('should execute tool requiring confirmation directly without waiting', async () => {
     // Arrange
     const executeFn = vi.fn().mockResolvedValue({
@@ -3993,6 +4092,145 @@ describe('CoreToolScheduler cancellation during executing with live output', () 
     // #4302 review: cancelled: true so the exec sub-span ends UNSET (not
     // ERROR) — matches setToolSpanCancelled on the parent tool span.
     expect(execSpanRecord?.endMetadata?.cancelled).toBe(true);
+  });
+
+  it('compacts live output before retaining it in scheduler state', async () => {
+    const longOutput = `head-${'x'.repeat(
+      MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+    )}-tail`;
+
+    class StreamingInvocation extends BaseToolInvocation<
+      { id: string },
+      ToolResult
+    > {
+      getDescription(): string {
+        return `Streaming tool ${this.params.id}`;
+      }
+
+      async execute(
+        signal: AbortSignal,
+        updateOutput?: (output: ToolResultDisplay) => void,
+      ): Promise<ToolResult> {
+        updateOutput?.(longOutput);
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) return resolve();
+          const onAbort = () => {
+            signal.removeEventListener('abort', onAbort);
+            resolve();
+          };
+          signal.addEventListener('abort', onAbort, { once: true });
+        });
+        return { llmContent: 'done', returnDisplay: 'done' };
+      }
+    }
+
+    class StreamingTool extends BaseDeclarativeTool<
+      { id: string },
+      ToolResult
+    > {
+      constructor() {
+        super(
+          'stream-tool',
+          'Stream Tool',
+          'Emits live output and waits for abort',
+          Kind.Other,
+          {
+            type: 'object',
+            properties: { id: { type: 'string' } },
+            required: ['id'],
+          },
+          true,
+          true,
+        );
+      }
+      protected createInvocation(params: { id: string }) {
+        return new StreamingInvocation(params);
+      }
+    }
+
+    const tool = new StreamingTool();
+    const mockToolRegistry = {
+      getTool: () => tool,
+      ensureTool: async () => tool,
+      getFunctionDeclarations: () => [],
+      tools: new Map(),
+      discovery: {},
+      registerTool: () => {},
+      getToolByName: () => tool,
+      getToolByDisplayName: () => tool,
+      getTools: () => [],
+      discoverTools: async () => {},
+      getAllTools: () => [],
+      getToolsByServer: () => [],
+    } as unknown as ToolRegistry;
+
+    const onAllToolCallsComplete = vi.fn();
+    const onToolCallsUpdate = vi.fn();
+    const outputUpdateHandler = vi.fn();
+    const mockConfig = {
+      getSessionId: () => 'test-session-id',
+      getUsageStatisticsEnabled: () => true,
+      getDebugMode: () => false,
+      getApprovalMode: () => ApprovalMode.DEFAULT,
+      getContentGeneratorConfig: () => ({
+        model: 'test-model',
+        authType: 'gemini',
+      }),
+      getToolRegistry: () => mockToolRegistry,
+      getShellExecutionConfig: () => ({
+        terminalWidth: 90,
+        terminalHeight: 30,
+      }),
+      getChatRecordingService: () => undefined,
+      getMessageBus: vi.fn().mockReturnValue(undefined),
+      getDisableAllHooks: vi.fn().mockReturnValue(true),
+    } as unknown as Config;
+
+    const scheduler = new CoreToolScheduler({
+      config: mockConfig,
+      outputUpdateHandler,
+      onAllToolCallsComplete,
+      onToolCallsUpdate,
+      getPreferredEditor: () => 'vscode',
+      onEditorClose: vi.fn(),
+    });
+
+    const abortController = new AbortController();
+    const schedulePromise = scheduler.schedule(
+      [
+        {
+          callId: '1',
+          name: 'stream-tool',
+          args: { id: 'x' },
+          isClientInitiated: true,
+          prompt_id: 'prompt-stream',
+        },
+      ],
+      abortController.signal,
+    );
+
+    await vi.waitFor(() => {
+      expect(outputUpdateHandler).toHaveBeenCalled();
+    });
+
+    const compactOutput = outputUpdateHandler.mock.calls[0][1] as string;
+    expect(compactOutput.length).toBeLessThanOrEqual(
+      MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+    );
+    expect(compactOutput).toContain('head-');
+    expect(compactOutput).toContain('-tail');
+    expect(compactOutput).toContain('truncated from');
+
+    const liveOutputUpdate = onToolCallsUpdate.mock.calls
+      .map((call) => call[0][0] as ToolCall)
+      .find(
+        (call): call is ExecutingToolCall =>
+          call.status === 'executing' && call.liveOutput !== undefined,
+      );
+    expect(liveOutputUpdate?.liveOutput).toBe(compactOutput);
+
+    abortController.abort();
+    await schedulePromise;
   });
 });
 

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -19,6 +19,7 @@ import type {
   ChatRecordingService,
 } from '../index.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import { compactToolResultDisplayForHistory } from '../utils/toolResultDisplayCompaction.js';
 import {
   generateToolUseId,
   firePreToolUseHook,
@@ -798,7 +799,7 @@ const createErrorResponse = (
       },
     },
   ],
-  resultDisplay: error.message,
+  resultDisplay: compactToolResultDisplayForHistory(error.message),
   errorType,
   contentLength: error.message.length,
 });
@@ -1254,7 +1255,7 @@ export class CoreToolScheduler {
                   },
                 },
               ],
-              resultDisplay,
+              resultDisplay: compactToolResultDisplayForHistory(resultDisplay),
               error: undefined,
               errorType: undefined,
               contentLength: errorMessage.length,
@@ -3050,12 +3051,13 @@ export class CoreToolScheduler {
 
     const liveOutputCallback = scheduledCall.tool.canUpdateOutput
       ? (outputChunk: ToolResultDisplay) => {
+          const compactOutput = compactToolResultDisplayForHistory(outputChunk);
           if (this.outputUpdateHandler) {
-            this.outputUpdateHandler(callId, outputChunk);
+            this.outputUpdateHandler(callId, compactOutput);
           }
           this.toolCalls = this.toolCalls.map((tc) =>
             tc.request.callId === callId && tc.status === 'executing'
-              ? { ...tc, liveOutput: outputChunk }
+              ? { ...tc, liveOutput: compactOutput }
               : tc,
           );
           this.notifyToolCallsUpdate();
@@ -3499,7 +3501,9 @@ export class CoreToolScheduler {
         const successResponse: ToolCallResponseInfo = {
           callId,
           responseParts: response,
-          resultDisplay: toolResult.returnDisplay,
+          resultDisplay: compactToolResultDisplayForHistory(
+            toolResult.returnDisplay,
+          ),
           error: undefined,
           errorType: undefined,
           contentLength,

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -3053,7 +3053,7 @@ export class CoreToolScheduler {
       ? (outputChunk: ToolResultDisplay) => {
           const compactOutput = compactToolResultDisplayForHistory(outputChunk);
           if (this.outputUpdateHandler) {
-            this.outputUpdateHandler(callId, compactOutput);
+            this.outputUpdateHandler(callId, outputChunk);
           }
           this.toolCalls = this.toolCalls.map((tc) =>
             tc.request.callId === callId && tc.status === 'executing'

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -799,7 +799,7 @@ const createErrorResponse = (
       },
     },
   ],
-  resultDisplay: compactToolResultDisplayForHistory(error.message),
+  resultDisplay: error.message,
   errorType,
   contentLength: error.message.length,
 });
@@ -1106,6 +1106,15 @@ export class CoreToolScheduler {
     return this.config.getMemoryPressureMonitor?.();
   }
 
+  private compactResultDisplayForInteractiveHistory<
+    T extends ToolResultDisplay | undefined,
+  >(resultDisplay: T): T {
+    return typeof this.config.isInteractive === 'function' &&
+      this.config.isInteractive()
+      ? compactToolResultDisplayForHistory(resultDisplay)
+      : resultDisplay;
+  }
+
   private setStatusInternal(
     targetCallId: string,
     status: 'success',
@@ -1255,7 +1264,8 @@ export class CoreToolScheduler {
                   },
                 },
               ],
-              resultDisplay: compactToolResultDisplayForHistory(resultDisplay),
+              resultDisplay:
+                this.compactResultDisplayForInteractiveHistory(resultDisplay),
               error: undefined,
               errorType: undefined,
               contentLength: errorMessage.length,
@@ -3051,7 +3061,8 @@ export class CoreToolScheduler {
 
     const liveOutputCallback = scheduledCall.tool.canUpdateOutput
       ? (outputChunk: ToolResultDisplay) => {
-          const compactOutput = compactToolResultDisplayForHistory(outputChunk);
+          const compactOutput =
+            this.compactResultDisplayForInteractiveHistory(outputChunk);
           if (this.outputUpdateHandler) {
             this.outputUpdateHandler(callId, outputChunk);
           }
@@ -3501,7 +3512,7 @@ export class CoreToolScheduler {
         const successResponse: ToolCallResponseInfo = {
           callId,
           responseParts: response,
-          resultDisplay: compactToolResultDisplayForHistory(
+          resultDisplay: this.compactResultDisplayForInteractiveHistory(
             toolResult.returnDisplay,
           ),
           error: undefined,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -199,6 +199,7 @@ export * from './services/backgroundShellRegistry.js';
 export * from './services/toolUseSummary.js';
 export * from './services/usageHistoryService.js';
 export * from './utils/bareMode.js';
+export * from './utils/toolResultDisplayCompaction.js';
 
 // ============================================================================
 // Managed Auto-Memory

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -15,6 +15,7 @@ import {
   type ChatRecord,
   type AtCommandRecordPayload,
 } from './chatRecordingService.js';
+import { MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS } from '../utils/toolResultDisplayCompaction.js';
 import * as jsonl from '../utils/jsonl-utils.js';
 import type { Part } from '@google/genai';
 import type { FileDiff } from '../tools/tools.js';
@@ -566,6 +567,87 @@ describe('ChatRecordingService', () => {
     });
 
     it('should keep small file diff resultDisplay unchanged', async () => {
+      const toolResultParts: Part[] = [
+        {
+          functionResponse: {
+            id: 'call-1',
+            name: 'edit',
+            response: { output: 'ok' },
+          },
+        },
+      ];
+      const resultDisplay: FileDiff = {
+        fileName: 'file.txt',
+        fileDiff: '--- file.txt\n+++ file.txt\n@@ -1 +1 @@\n-old\n+new',
+        originalContent: 'old',
+        newContent: 'new',
+        diffStat: {
+          model_added_lines: 1,
+          model_removed_lines: 1,
+          model_added_chars: 3,
+          model_removed_chars: 3,
+          user_added_lines: 0,
+          user_removed_lines: 0,
+          user_added_chars: 0,
+          user_removed_chars: 0,
+        },
+      };
+      const metadata = {
+        callId: 'call-1',
+        status: 'success' as const,
+        responseParts: toolResultParts,
+        resultDisplay,
+        error: undefined,
+        errorType: undefined,
+      };
+
+      chatRecordingService.recordToolResult(toolResultParts, metadata);
+      await chatRecordingService.flush();
+
+      const record = vi.mocked(jsonl.writeLine).mock.calls[0][1] as ChatRecord;
+
+      expect(record.toolCallResult?.resultDisplay).toBe(resultDisplay);
+      expect(
+        (record.toolCallResult?.resultDisplay as FileDiff).truncatedForSession,
+      ).toBeUndefined();
+    });
+
+    it('compacts large resultDisplay metadata before recording', async () => {
+      const toolResultParts: Part[] = [
+        {
+          functionResponse: {
+            id: 'call-1',
+            name: 'shell',
+            response: { output: 'result' },
+          },
+        },
+      ];
+      const metadata = {
+        callId: 'call-1',
+        status: 'success',
+        responseParts: toolResultParts,
+        resultDisplay: `head-${'x'.repeat(
+          MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+        )}-tail`,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+
+      chatRecordingService.recordToolResult(toolResultParts, metadata);
+      await chatRecordingService.flush();
+
+      const record = vi.mocked(jsonl.writeLine).mock.calls[0][1] as ChatRecord;
+      const resultDisplay = record.toolCallResult?.resultDisplay;
+
+      expect(typeof resultDisplay).toBe('string');
+      expect((resultDisplay as string).length).toBeLessThanOrEqual(
+        MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+      );
+      expect(resultDisplay).toContain('head-');
+      expect(resultDisplay).toContain('-tail');
+      expect(resultDisplay).toContain('truncated from');
+    });
+
+    it('records promptId on tool results when provided', async () => {
       const toolResultParts: Part[] = [
         {
           functionResponse: {

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -644,7 +644,8 @@ describe('ChatRecordingService', () => {
       );
       expect(resultDisplay).toContain('head-');
       expect(resultDisplay).toContain('-tail');
-      expect(resultDisplay).toContain('truncated from');
+      expect(resultDisplay).toContain('truncated for saved session preview');
+      expect(resultDisplay).not.toContain('CLI history display');
     });
 
     it('records promptId on tool results when provided', async () => {

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -19,7 +19,7 @@ import {
 import * as jsonl from '../utils/jsonl-utils.js';
 import { getGitBranch } from '../utils/gitUtils.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
-import { compactToolResultDisplayForHistory } from '../utils/toolResultDisplayCompaction.js';
+import { compactToolResultDisplayForRecording } from '../utils/toolResultDisplayCompaction.js';
 import type { AttributionSnapshot } from './commitAttribution.js';
 import { tryGenerateSessionTitle } from './sessionTitle.js';
 import type {
@@ -179,7 +179,7 @@ export function sanitizeToolCallResultForRecording<
   }
 
   const sanitizedResultDisplay =
-    compactToolResultDisplayForHistory(resultDisplay);
+    compactToolResultDisplayForRecording(resultDisplay);
   if (sanitizedResultDisplay === resultDisplay) {
     return toolCallResult;
   }

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -19,6 +19,7 @@ import {
 import * as jsonl from '../utils/jsonl-utils.js';
 import { getGitBranch } from '../utils/gitUtils.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import { compactToolResultDisplayForHistory } from '../utils/toolResultDisplayCompaction.js';
 import type { AttributionSnapshot } from './commitAttribution.js';
 import { tryGenerateSessionTitle } from './sessionTitle.js';
 import type {
@@ -165,11 +166,20 @@ export function sanitizeToolCallResultForRecording<
   T extends Partial<ToolCallResponseInfo>,
 >(toolCallResult: T): T {
   const resultDisplay = toolCallResult.resultDisplay;
-  if (!isFileDiffDisplay(resultDisplay)) {
-    return toolCallResult;
+  if (isFileDiffDisplay(resultDisplay)) {
+    const sanitizedResultDisplay = sanitizeFileDiffForRecording(resultDisplay);
+    if (sanitizedResultDisplay === resultDisplay) {
+      return toolCallResult;
+    }
+
+    return {
+      ...toolCallResult,
+      resultDisplay: sanitizedResultDisplay,
+    } as T;
   }
 
-  const sanitizedResultDisplay = sanitizeFileDiffForRecording(resultDisplay);
+  const sanitizedResultDisplay =
+    compactToolResultDisplayForHistory(resultDisplay);
   if (sanitizedResultDisplay === resultDisplay) {
     return toolCallResult;
   }

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -313,6 +313,32 @@ describe('ShellExecutionService', () => {
       });
     });
 
+    it('disposes PTY terminal resources on natural exit', async () => {
+      const terminalDisposeSpy = vi.spyOn(Terminal.prototype, 'dispose');
+      const removeListenerSpy = vi.spyOn(mockPtyProcess, 'removeListener');
+
+      const { result } = await simulateExecution('ls -l', (pty) => {
+        pty.onData.mock.calls[0][0]('file1.txt\n');
+        pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+      });
+
+      expect(result.exitCode).toBe(0);
+      const dataDisposableStub = mockPtyProcess.onData.mock.results[0]
+        .value as { dispose: Mock };
+      const exitDisposableStub = mockPtyProcess.onExit.mock.results[0]
+        .value as { dispose: Mock };
+      expect(dataDisposableStub.dispose).toHaveBeenCalled();
+      expect(exitDisposableStub.dispose).toHaveBeenCalled();
+      expect(removeListenerSpy).toHaveBeenCalledWith(
+        'error',
+        expect.any(Function),
+      );
+      // One terminal is used for live PTY rendering, another for final replay.
+      expect(terminalDisposeSpy).toHaveBeenCalledTimes(2);
+
+      terminalDisposeSpy.mockRestore();
+    });
+
     it('should strip ANSI codes from output', async () => {
       const { result } = await simulateExecution('ls --color=auto', (pty) => {
         pty.onData.mock.calls[0][0]('a\u001b[31mred\u001b[0mword');

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -730,6 +730,7 @@ describe('ShellExecutionService', () => {
     });
 
     it('signal.reason = { kind: "background" } skips kill and resolves with promoted: true (and aborted: false per design question 7)', async () => {
+      const terminalDisposeSpy = vi.spyOn(Terminal.prototype, 'dispose');
       // Critical: do NOT fire onExit — the child is still alive after the
       // background-promote abort. The result Promise must resolve via the
       // abort handler's own immediate resolve, not via the exit handler.
@@ -764,6 +765,34 @@ describe('ShellExecutionService', () => {
         -mockPtyProcess.pid,
         'SIGKILL',
       );
+      expect(terminalDisposeSpy).toHaveBeenCalled();
+
+      terminalDisposeSpy.mockRestore();
+    });
+
+    it('background-promote replay failure falls back to full decoded raw output', async () => {
+      mockSerializeTerminalToText.mockImplementationOnce(() => {
+        throw new Error('replay failed');
+      });
+      const output = Array.from(
+        { length: 250 },
+        (_, index) => `line-${index}`,
+      ).join('\n');
+
+      const { result } = await simulateExecution(
+        'long-running-output',
+        (pty, ac) => {
+          pty.onData.mock.calls[0][0](output);
+          ac.abort({
+            kind: 'background',
+            shellId: 'bg_replay_fallback',
+          } satisfies ShellAbortReason);
+        },
+      );
+
+      expect(result.promoted).toBe(true);
+      expect(result.output).toContain('line-0');
+      expect(result.output).toContain('line-249');
     });
 
     it('post-promotion: PTY data is no longer routed to onOutputEvent (handoff boundary)', async () => {

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -339,6 +339,37 @@ describe('ShellExecutionService', () => {
       terminalDisposeSpy.mockRestore();
     });
 
+    it('disposes PTY resources and resolves when final render throws', async () => {
+      const terminalDisposeSpy = vi.spyOn(Terminal.prototype, 'dispose');
+      mockSerializeTerminalToText.mockImplementationOnce(() => {
+        throw new Error('final render failed');
+      });
+
+      const { result } = await simulateExecution(
+        'render-fails-on-exit',
+        (pty) => {
+          pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+        },
+        {
+          ...shellExecutionConfig,
+          disableDynamicLineTrimming: false,
+        },
+      );
+
+      const dataDisposableStub = mockPtyProcess.onData.mock.results[0]
+        .value as { dispose: Mock };
+      const exitDisposableStub = mockPtyProcess.onExit.mock.results[0]
+        .value as { dispose: Mock };
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toBe('');
+      expect(dataDisposableStub.dispose).toHaveBeenCalled();
+      expect(exitDisposableStub.dispose).toHaveBeenCalled();
+      // One terminal is used for live PTY rendering, another for final replay.
+      expect(terminalDisposeSpy).toHaveBeenCalledTimes(2);
+
+      terminalDisposeSpy.mockRestore();
+    });
+
     it('should strip ANSI codes from output', async () => {
       const { result } = await simulateExecution('ls --color=auto', (pty) => {
         pty.onData.mock.calls[0][0]('a\u001b[31mred\u001b[0mword');
@@ -771,6 +802,7 @@ describe('ShellExecutionService', () => {
     });
 
     it('background-promote replay failure falls back to full decoded raw output', async () => {
+      const terminalDisposeSpy = vi.spyOn(Terminal.prototype, 'dispose');
       mockSerializeTerminalToText.mockImplementationOnce(() => {
         throw new Error('replay failed');
       });
@@ -793,6 +825,10 @@ describe('ShellExecutionService', () => {
       expect(result.promoted).toBe(true);
       expect(result.output).toContain('line-0');
       expect(result.output).toContain('line-249');
+      // One terminal is used for replay, another for the promoted snapshot.
+      expect(terminalDisposeSpy).toHaveBeenCalledTimes(2);
+
+      terminalDisposeSpy.mockRestore();
     });
 
     it('post-promotion: PTY data is no longer routed to onOutputEvent (handoff boundary)', async () => {

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -31,6 +31,9 @@ const debugLogger = createDebugLogger('SHELL_EXECUTION');
 const DEFAULT_MAX_BUFFERED_OUTPUT_BYTES = 64 * 1024 * 1024;
 const MAX_BUFFERED_OUTPUT_BYTES_CEILING = 256 * 1024 * 1024;
 const SIGKILL_TIMEOUT_MS = 200;
+// Live PTY rendering only needs a short scrollback for interactive tailing.
+// The full transcript is preserved separately in raw output and final replay.
+const MAX_LIVE_TERMINAL_SCROLLBACK_LINES = 200;
 /**
  * Bound on how long the background-promote drain waits for in-flight
  * processingChain callbacks to finish writing into the headless terminal
@@ -359,11 +362,14 @@ const replayTerminalOutput = async (
     convertEol: true,
   });
 
-  await new Promise<void>((resolve) => {
-    replayTerminal.write(output, () => resolve());
-  });
-
-  return serializeTerminalToText(replayTerminal);
+  try {
+    await new Promise<void>((resolve) => {
+      replayTerminal.write(output, () => resolve());
+    });
+    return serializeTerminalToText(replayTerminal);
+  } finally {
+    replayTerminal.dispose();
+  }
 };
 
 const getLastNonEmptyAnsiLineIndex = (output: AnsiOutput): number => {
@@ -507,6 +513,11 @@ export class ShellExecutionService {
     for (const [pid, pty] of this.activePtys) {
       try {
         strategy.killPty(pid, pty);
+      } catch {
+        // ignore
+      }
+      try {
+        pty.headlessTerminal.dispose();
       } catch {
         // ignore
       }
@@ -1281,6 +1292,7 @@ export class ShellExecutionService {
           allowProposedApi: true,
           cols,
           rows,
+          scrollback: MAX_LIVE_TERMINAL_SCROLLBACK_LINES,
         });
         headlessTerminal.scrollToTop();
 
@@ -1539,11 +1551,47 @@ export class ShellExecutionService {
         };
         ptyProcess.on('error', ptyErrorHandler);
 
+        const disposeForegroundPtyResources = () => {
+          listenersDetached = true;
+          if (renderTimeout) {
+            clearTimeout(renderTimeout);
+            renderTimeout = null;
+          }
+          try {
+            dataDisposable.dispose();
+          } catch (e) {
+            debugLogger.warn(
+              `dataDisposable.dispose() threw during PTY cleanup: ${e instanceof Error ? e.message : String(e)}`,
+            );
+          }
+          try {
+            exitDisposable.dispose();
+          } catch (e) {
+            debugLogger.warn(
+              `exitDisposable.dispose() threw during PTY cleanup: ${e instanceof Error ? e.message : String(e)}`,
+            );
+          }
+          try {
+            ptyProcess.removeListener('error', ptyErrorHandler);
+          } catch (e) {
+            debugLogger.warn(
+              `ptyProcess.removeListener('error') threw during PTY cleanup: ${e instanceof Error ? e.message : String(e)}`,
+            );
+          }
+          try {
+            headlessTerminal.dispose();
+          } catch (e) {
+            debugLogger.warn(
+              `headlessTerminal.dispose() threw during PTY cleanup: ${e instanceof Error ? e.message : String(e)}`,
+            );
+          }
+          this.activePtys.delete(ptyProcess.pid);
+        };
+
         const exitDisposable = ptyProcess.onExit(
           ({ exitCode, signal }: { exitCode: number; signal?: number }) => {
             exited = true;
             abortSignal.removeEventListener('abort', abortHandler);
-            this.activePtys.delete(ptyProcess.pid);
 
             const finalize = async () => {
               render(true);
@@ -1582,18 +1630,22 @@ export class ShellExecutionService {
                 maxBufferedOutputBytes,
               );
 
-              resolve({
-                rawOutput: finalBuffer,
-                output: fullOutput,
-                exitCode,
-                signal: signal ?? null,
-                error,
-                aborted: abortSignal.aborted,
-                pid: ptyProcess.pid,
-                executionMethod:
-                  (ptyInfo?.name as 'node-pty' | 'lydell-node-pty') ??
-                  'node-pty',
-              });
+              try {
+                resolve({
+                  rawOutput: finalBuffer,
+                  output: fullOutput,
+                  exitCode,
+                  signal: signal ?? null,
+                  error,
+                  aborted: abortSignal.aborted,
+                  pid: ptyProcess.pid,
+                  executionMethod:
+                    (ptyInfo?.name as 'node-pty' | 'lydell-node-pty') ??
+                    'node-pty',
+                });
+              } finally {
+                disposeForegroundPtyResources();
+              }
             };
 
             // Give any last onData callbacks a chance to run before finalizing.
@@ -1925,21 +1977,31 @@ export class ShellExecutionService {
             totalBytesReceived,
             maxBufferedOutputBytes,
           );
-          resolve({
-            rawOutput: finalBuffer,
-            output: snapshot,
-            exitCode: null,
-            signal: null,
-            error,
-            // See childProcessFallback for the full rationale — promoted
-            // results are NOT user-cancellations, so callers' `if
-            // (result.aborted)` branches must NOT trigger.
-            aborted: false,
-            promoted: true,
-            pid: ptyProcess.pid,
-            executionMethod:
-              (ptyInfo?.name as 'node-pty' | 'lydell-node-pty') ?? 'node-pty',
-          });
+          try {
+            resolve({
+              rawOutput: finalBuffer,
+              output: snapshot,
+              exitCode: null,
+              signal: null,
+              error,
+              // See childProcessFallback for the full rationale — promoted
+              // results are NOT user-cancellations, so callers' `if
+              // (result.aborted)` branches must NOT trigger.
+              aborted: false,
+              promoted: true,
+              pid: ptyProcess.pid,
+              executionMethod:
+                (ptyInfo?.name as 'node-pty' | 'lydell-node-pty') ?? 'node-pty',
+            });
+          } finally {
+            try {
+              headlessTerminal.dispose();
+            } catch (e) {
+              debugLogger.warn(
+                `headlessTerminal.dispose() threw during background-promote cleanup: ${e instanceof Error ? e.message : String(e)}`,
+              );
+            }
+          }
         };
 
         const performCancelKill = async (): Promise<void> => {

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -1594,43 +1594,51 @@ export class ShellExecutionService {
             abortSignal.removeEventListener('abort', abortHandler);
 
             const finalize = async () => {
-              render(true);
               const finalBuffer = Buffer.concat(outputChunks);
               let fullOutput = '';
 
               try {
-                if (isStreamingRawContent) {
-                  // Re-decode the captured buffer with proper encoding detection.
-                  // The streaming decoder used the first-chunk heuristic which
-                  // can misdetect when early output is ASCII-only but later
-                  // output is in a different encoding (e.g. GBK).
-                  const finalEncoding = getCachedEncodingForBuffer(finalBuffer);
-                  const decodedOutput = new TextDecoder(finalEncoding).decode(
-                    finalBuffer,
-                  );
-                  fullOutput = await replayTerminalOutput(
-                    decodedOutput,
-                    cols,
-                    rows,
-                  );
-                } else {
-                  fullOutput = serializeTerminalToText(headlessTerminal);
-                }
-              } catch {
                 try {
-                  fullOutput = decodeBufferedOutput(finalBuffer);
-                } catch {
-                  // Ignore fallback rendering errors and resolve with empty text.
+                  render(true);
+                } catch (e) {
+                  debugLogger.warn(
+                    `Final PTY render threw during cleanup: ${e instanceof Error ? e.message : String(e)}`,
+                  );
                 }
-              }
-              fullOutput = appendOutputCaptureLimitNotice(
-                fullOutput,
-                outputCaptureLimitExceeded,
-                totalBytesReceived,
-                maxBufferedOutputBytes,
-              );
 
-              try {
+                try {
+                  if (isStreamingRawContent) {
+                    // Re-decode the captured buffer with proper encoding detection.
+                    // The streaming decoder used the first-chunk heuristic which
+                    // can misdetect when early output is ASCII-only but later
+                    // output is in a different encoding (e.g. GBK).
+                    const finalEncoding =
+                      getCachedEncodingForBuffer(finalBuffer);
+                    const decodedOutput = new TextDecoder(finalEncoding).decode(
+                      finalBuffer,
+                    );
+                    fullOutput = await replayTerminalOutput(
+                      decodedOutput,
+                      cols,
+                      rows,
+                    );
+                  } else {
+                    fullOutput = serializeTerminalToText(headlessTerminal);
+                  }
+                } catch {
+                  try {
+                    fullOutput = decodeBufferedOutput(finalBuffer);
+                  } catch {
+                    // Ignore fallback rendering errors and resolve with empty text.
+                  }
+                }
+                fullOutput = appendOutputCaptureLimitNotice(
+                  fullOutput,
+                  outputCaptureLimitExceeded,
+                  totalBytesReceived,
+                  maxBufferedOutputBytes,
+                );
+
                 resolve({
                   rawOutput: finalBuffer,
                   output: fullOutput,

--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -10,7 +10,7 @@ import {
   type AgentParams,
   resolveSubagentApprovalMode,
 } from './agent.js';
-import type { PartListUnion } from '@google/genai';
+import type { Part, PartListUnion } from '@google/genai';
 import type { ToolResultDisplay, AgentResultDisplay } from '../tools.js';
 import { ToolConfirmationOutcome } from '../tools.js';
 import { ToolNames } from '../tool-names.js';
@@ -1994,6 +1994,97 @@ describe('AgentTool', () => {
 
       return capturedInvocation;
     }
+
+    it('preserves subagent tool protocol payloads in non-interactive mode', async () => {
+      vi.mocked(config.isInteractive).mockReturnValue(false);
+      const responseParts: Part[] = [{ text: 'raw protocol result' }];
+      const snapshots: AgentResultDisplay[] = [];
+
+      const invocation = createInvocationWithEventDrivenAgent((emitter) => {
+        emitter.emit(AgentEventType.TOOL_CALL, {
+          subagentId: 'sub-1',
+          round: 1,
+          callId: 'call-read-1',
+          name: 'read_file',
+          args: { path: '/test.ts' },
+          description: 'Reading test.ts',
+          timestamp: Date.now(),
+        } satisfies AgentToolCallEvent);
+
+        emitter.emit(AgentEventType.TOOL_RESULT, {
+          subagentId: 'sub-1',
+          round: 1,
+          callId: 'call-read-1',
+          name: 'read_file',
+          success: true,
+          responseParts,
+          timestamp: Date.now(),
+        } satisfies AgentToolResultEvent);
+      });
+
+      await invocation.execute(undefined, (output) => {
+        snapshots.push(output as AgentResultDisplay);
+      });
+
+      const resultSnapshot = snapshots.find((snapshot) =>
+        snapshot.toolCalls?.some(
+          (toolCall) =>
+            toolCall.callId === 'call-read-1' && toolCall.status === 'success',
+        ),
+      );
+      const toolCall = resultSnapshot?.toolCalls?.find(
+        (entry) => entry.callId === 'call-read-1',
+      );
+      expect(toolCall?.args).toEqual({ path: '/test.ts' });
+      expect(toolCall?.responseParts).toBe(responseParts);
+    });
+
+    it('omits subagent protocol payloads from interactive display state', async () => {
+      vi.mocked(config.isInteractive).mockReturnValue(true);
+      const responseParts: Part[] = [{ text: 'raw protocol result' }];
+      const snapshots: AgentResultDisplay[] = [];
+
+      const invocation = createInvocationWithEventDrivenAgent((emitter) => {
+        emitter.emit(AgentEventType.TOOL_CALL, {
+          subagentId: 'sub-1',
+          round: 1,
+          callId: 'call-read-1',
+          name: 'read_file',
+          args: { path: '/test.ts' },
+          description: 'Reading test.ts',
+          timestamp: Date.now(),
+        } satisfies AgentToolCallEvent);
+
+        emitter.emit(AgentEventType.TOOL_RESULT, {
+          subagentId: 'sub-1',
+          round: 1,
+          callId: 'call-read-1',
+          name: 'read_file',
+          success: true,
+          responseParts,
+          resultDisplay: 'Rendered result',
+          timestamp: Date.now(),
+        } satisfies AgentToolResultEvent);
+      });
+
+      await invocation.execute(undefined, (output) => {
+        snapshots.push(output as AgentResultDisplay);
+      });
+
+      const resultSnapshot = snapshots.find((snapshot) =>
+        snapshot.toolCalls?.some(
+          (toolCall) =>
+            toolCall.callId === 'call-read-1' && toolCall.status === 'success',
+        ),
+      );
+      const toolCall = resultSnapshot?.toolCalls?.find(
+        (entry) => entry.callId === 'call-read-1',
+      );
+      expect(toolCall?.description).toBe('Reading test.ts');
+      expect(toolCall?.resultDisplay).toBe('Rendered result');
+      expect(toolCall).not.toHaveProperty('args');
+      expect(toolCall).not.toHaveProperty('responseParts');
+    });
 
     it('should clear pendingConfirmation when TOOL_RESULT arrives for the pending tool (IDE accept path)', async () => {
       // Track whether pendingConfirmation was set then cleared, using

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -960,6 +960,7 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
     updateOutput?: (output: ToolResultDisplay) => void,
   ): void {
     let pendingConfirmationCallId: string | undefined;
+    const preserveProtocolPayloads = !this.config.isInteractive();
 
     this.eventEmitter.on(AgentEventType.START, () => {
       this.updateDisplay({ status: 'running' }, updateOutput);
@@ -971,6 +972,7 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
         callId: event.callId,
         name: event.name,
         status: 'executing' as const,
+        ...(preserveProtocolPayloads ? { args: event.args } : {}),
         description: event.description,
       };
       this.currentToolCalls!.push(newToolCall);
@@ -993,6 +995,9 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
           ...this.currentToolCalls![toolCallIndex],
           status: event.success ? 'success' : 'failed',
           error: event.error,
+          ...(preserveProtocolPayloads && event.responseParts !== undefined
+            ? { responseParts: event.responseParts }
+            : {}),
           ...(typeof event.resultDisplay === 'string'
             ? { resultDisplay: event.resultDisplay }
             : {}),

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -971,7 +971,6 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
         callId: event.callId,
         name: event.name,
         status: 'executing' as const,
-        args: event.args,
         description: event.description,
       };
       this.currentToolCalls!.push(newToolCall);
@@ -994,7 +993,9 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
           ...this.currentToolCalls![toolCallIndex],
           status: event.success ? 'success' : 'failed',
           error: event.error,
-          responseParts: event.responseParts,
+          ...(typeof event.resultDisplay === 'string'
+            ? { resultDisplay: event.resultDisplay }
+            : {}),
         };
 
         // When a tool result arrives for the tool that had a pending

--- a/packages/core/src/utils/toolResultDisplayCompaction.test.ts
+++ b/packages/core/src/utils/toolResultDisplayCompaction.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { AgentResultDisplay } from '../tools/tools.js';
+import {
+  compactStringForHistory,
+  compactToolResultDisplayForHistory,
+  MAX_RETAINED_AGENT_FIELD_CHARS,
+  MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+} from './toolResultDisplayCompaction.js';
+
+describe('toolResultDisplayCompaction', () => {
+  it('keeps short strings unchanged', () => {
+    const value = 'short output';
+
+    expect(compactStringForHistory(value)).toBe(value);
+  });
+
+  it('keeps head and tail when compacting long strings', () => {
+    const value = `start-${'x'.repeat(
+      MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+    )}-end`;
+
+    const compacted = compactStringForHistory(value);
+
+    expect(compacted.length).toBeLessThanOrEqual(
+      MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+    );
+    expect(compacted).toContain('start-');
+    expect(compacted).toContain('-end');
+    expect(compacted).toContain('truncated from');
+  });
+
+  it('drops subagent display fields that are not rendered in CLI history', () => {
+    const nestedDisplay = `nested-${'x'.repeat(
+      MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+    )}-done`;
+    const display: AgentResultDisplay = {
+      type: 'task_execution',
+      subagentName: 'researcher',
+      taskDescription: 'research',
+      taskPrompt: 'p'.repeat(MAX_RETAINED_AGENT_FIELD_CHARS + 100),
+      status: 'completed',
+      toolCalls: [
+        {
+          callId: 'call-1',
+          name: 'read_file',
+          status: 'success',
+          args: { content: 'x'.repeat(100_000) },
+          responseParts: [{ text: 'x'.repeat(100_000) }],
+          result: 'x'.repeat(100_000),
+        },
+        {
+          callId: 'call-2',
+          name: 'agent',
+          status: 'success',
+          resultDisplay: nestedDisplay,
+        },
+      ],
+    };
+
+    const compacted = compactToolResultDisplayForHistory(display);
+
+    expect(compacted.taskPrompt.length).toBeLessThanOrEqual(
+      MAX_RETAINED_AGENT_FIELD_CHARS,
+    );
+    expect(compacted.toolCalls?.[0]).not.toHaveProperty('args');
+    expect(compacted.toolCalls?.[0]).not.toHaveProperty('responseParts');
+    expect(compacted.toolCalls?.[0]).not.toHaveProperty('result');
+    expect(compacted.toolCalls?.[1].resultDisplay).toContain('nested-');
+    expect(compacted.toolCalls?.[1].resultDisplay).toContain('-done');
+    expect(compacted.toolCalls?.[1].resultDisplay).toContain('truncated from');
+  });
+});

--- a/packages/core/src/utils/toolResultDisplayCompaction.test.ts
+++ b/packages/core/src/utils/toolResultDisplayCompaction.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest';
 import type {
   AgentResultDisplay,
   AnsiOutputDisplay,
+  FileDiff,
   McpToolProgressData,
   PlanResultDisplay,
   TaskListResultDisplay,
@@ -21,8 +22,26 @@ import {
   compactToolResultDisplayForRecording,
   MAX_RETAINED_AGENT_FIELD_CHARS,
   MAX_RETAINED_ANSI_OUTPUT_LINES,
+  MAX_RETAINED_FILE_CONTENT_CHARS,
+  MAX_RETAINED_FILE_DIFF_CHARS,
   MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
 } from './toolResultDisplayCompaction.js';
+
+function hasUnpairedSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) {
+        return true;
+      }
+      index++;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
 
 describe('toolResultDisplayCompaction', () => {
   it('keeps short strings unchanged', () => {
@@ -69,6 +88,20 @@ describe('toolResultDisplayCompaction', () => {
     expect(compacted).not.toContain('\uFFFD');
   });
 
+  it('does not split surrogate pairs at compaction boundaries', () => {
+    const limit = 80;
+    const emoji = '😀';
+    // With this length and limit, the raw head/tail cuts land inside each emoji.
+    const value = `${'h'.repeat(8)}${emoji}${'m'.repeat(
+      183,
+    )}${emoji}${'t'.repeat(5)}`;
+
+    const compacted = compactStringForHistory(value, limit);
+
+    expect(compacted.length).toBeLessThanOrEqual(limit);
+    expect(hasUnpairedSurrogate(compacted)).toBe(false);
+  });
+
   it('drops subagent display fields that are not rendered in CLI history', () => {
     const nestedDisplay = `nested-${'x'.repeat(
       MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
@@ -108,6 +141,76 @@ describe('toolResultDisplayCompaction', () => {
     expect(compacted.toolCalls?.[1].resultDisplay).toContain('nested-');
     expect(compacted.toolCalls?.[1].resultDisplay).toContain('-done');
     expect(compacted.toolCalls?.[1].resultDisplay).toContain('truncated from');
+  });
+
+  it('compacts file diffs through the history display path', () => {
+    const display: FileDiff = {
+      fileName: 'large.txt',
+      fileDiff: `diff-${'d'.repeat(MAX_RETAINED_FILE_DIFF_CHARS)}-done`,
+      originalContent: `old-${'o'.repeat(
+        MAX_RETAINED_FILE_CONTENT_CHARS,
+      )}-done`,
+      newContent: `new-${'n'.repeat(MAX_RETAINED_FILE_CONTENT_CHARS)}-done`,
+      diffStat: {
+        model_added_lines: 1,
+        model_removed_lines: 1,
+        model_added_chars: 1,
+        model_removed_chars: 1,
+        user_added_lines: 0,
+        user_removed_lines: 0,
+        user_added_chars: 0,
+        user_removed_chars: 0,
+      },
+    };
+
+    const compacted = compactToolResultDisplayForHistory(display);
+
+    expect(compacted).not.toBe(display);
+    expect(compacted.fileDiff.length).toBeLessThanOrEqual(
+      MAX_RETAINED_FILE_DIFF_CHARS,
+    );
+    expect(compacted.originalContent?.length).toBeLessThanOrEqual(
+      MAX_RETAINED_FILE_CONTENT_CHARS,
+    );
+    expect(compacted.newContent.length).toBeLessThanOrEqual(
+      MAX_RETAINED_FILE_CONTENT_CHARS,
+    );
+    expect(compacted.truncatedForSession).toBe(true);
+    expect(compacted.fileDiffLength).toBe(display.fileDiff.length);
+    expect(compacted.originalContentLength).toBe(
+      display.originalContent?.length,
+    );
+    expect(compacted.newContentLength).toBe(display.newContent.length);
+    expect(compacted.fileDiffTruncated).toBe(true);
+    expect(compacted.originalContentTruncated).toBe(true);
+    expect(compacted.newContentTruncated).toBe(true);
+    expect(display.truncatedForSession).toBeUndefined();
+  });
+
+  it('preserves null original content when compacting file diffs', () => {
+    const display: FileDiff = {
+      fileName: 'new.txt',
+      fileDiff: 'new file',
+      originalContent: null,
+      newContent: `new-${'n'.repeat(MAX_RETAINED_FILE_CONTENT_CHARS)}-done`,
+      diffStat: {
+        model_added_lines: 1,
+        model_removed_lines: 0,
+        model_added_chars: 1,
+        model_removed_chars: 0,
+        user_added_lines: 0,
+        user_removed_lines: 0,
+        user_added_chars: 0,
+        user_removed_chars: 0,
+      },
+    };
+
+    const compacted = compactToolResultDisplayForHistory(display);
+
+    expect(compacted.originalContent).toBeNull();
+    expect(compacted.originalContentLength).toBe(0);
+    expect(compacted.originalContentTruncated).toBe(false);
+    expect(compacted.newContentTruncated).toBe(true);
   });
 
   it('compacts ansi output tokens under the retained line limit', () => {

--- a/packages/core/src/utils/toolResultDisplayCompaction.test.ts
+++ b/packages/core/src/utils/toolResultDisplayCompaction.test.ts
@@ -16,7 +16,9 @@ import type {
 } from '../tools/tools.js';
 import {
   compactStringForHistory,
+  compactStringForRecording,
   compactToolResultDisplayForHistory,
+  compactToolResultDisplayForRecording,
   MAX_RETAINED_AGENT_FIELD_CHARS,
   MAX_RETAINED_ANSI_OUTPUT_LINES,
   MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
@@ -42,6 +44,18 @@ describe('toolResultDisplayCompaction', () => {
     expect(compacted).toContain('start-');
     expect(compacted).toContain('-end');
     expect(compacted).toContain('truncated from');
+  });
+
+  it('uses saved session wording when compacting recording strings', () => {
+    const value = `start-${'x'.repeat(
+      MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+    )}-end`;
+
+    const compacted = compactStringForRecording(value);
+
+    expect(compacted).toContain('truncated for saved session preview');
+    expect(compacted).toContain(`original length: ${value.length} characters`);
+    expect(compacted).not.toContain('CLI history display');
   });
 
   it('preserves unmatched surrogate code units when compacting', () => {
@@ -126,6 +140,28 @@ describe('toolResultDisplayCompaction', () => {
     expect(compacted.ansiOutput[0][0].text).toContain('truncated from');
   });
 
+  it('keeps unchanged ansi output displays by reference', () => {
+    const display: AnsiOutputDisplay = {
+      totalLines: 1,
+      ansiOutput: [
+        [
+          {
+            text: 'short',
+            bold: false,
+            italic: false,
+            underline: false,
+            dim: false,
+            inverse: false,
+            fg: '',
+            bg: '',
+          },
+        ],
+      ],
+    };
+
+    expect(compactToolResultDisplayForRecording(display)).toBe(display);
+  });
+
   it('bounds long ansi output and keeps the tail lines', () => {
     const display: AnsiOutputDisplay = {
       ansiOutput: Array.from(
@@ -151,6 +187,35 @@ describe('toolResultDisplayCompaction', () => {
     expect(compacted.ansiOutput[0][0].text).toContain('terminal lines omitted');
     expect(compacted.ansiOutput.at(-1)?.[0].text).toBe(
       `line-${MAX_RETAINED_ANSI_OUTPUT_LINES + 4}`,
+    );
+  });
+
+  it('uses saved session wording when compacting recording ansi output', () => {
+    const display: AnsiOutputDisplay = {
+      ansiOutput: Array.from(
+        { length: MAX_RETAINED_ANSI_OUTPUT_LINES + 5 },
+        (_, index) => [
+          {
+            text: `line-${index}`,
+            bold: false,
+            italic: false,
+            underline: false,
+            dim: false,
+            inverse: false,
+            fg: '',
+            bg: '',
+          },
+        ],
+      ),
+    };
+
+    const compacted = compactToolResultDisplayForRecording(display);
+
+    expect(compacted.ansiOutput[0][0].text).toContain(
+      'terminal lines omitted from saved session preview',
+    );
+    expect(compacted.ansiOutput[0][0].text).not.toContain(
+      'CLI history display',
     );
   });
 

--- a/packages/core/src/utils/toolResultDisplayCompaction.test.ts
+++ b/packages/core/src/utils/toolResultDisplayCompaction.test.ts
@@ -5,11 +5,20 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import type { AgentResultDisplay } from '../tools/tools.js';
+import type {
+  AgentResultDisplay,
+  AnsiOutputDisplay,
+  McpToolProgressData,
+  PlanResultDisplay,
+  TaskListResultDisplay,
+  TeamResultDisplay,
+  TodoResultDisplay,
+} from '../tools/tools.js';
 import {
   compactStringForHistory,
   compactToolResultDisplayForHistory,
   MAX_RETAINED_AGENT_FIELD_CHARS,
+  MAX_RETAINED_ANSI_OUTPUT_LINES,
   MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
 } from './toolResultDisplayCompaction.js';
 
@@ -85,5 +94,122 @@ describe('toolResultDisplayCompaction', () => {
     expect(compacted.toolCalls?.[1].resultDisplay).toContain('nested-');
     expect(compacted.toolCalls?.[1].resultDisplay).toContain('-done');
     expect(compacted.toolCalls?.[1].resultDisplay).toContain('truncated from');
+  });
+
+  it('compacts ansi output tokens under the retained line limit', () => {
+    const display: AnsiOutputDisplay = {
+      totalLines: 1,
+      ansiOutput: [
+        [
+          {
+            text: `line-${'x'.repeat(
+              MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+            )}-done`,
+            bold: false,
+            italic: false,
+            underline: false,
+            dim: false,
+            inverse: false,
+            fg: '',
+            bg: '',
+          },
+        ],
+      ],
+    };
+
+    const compacted = compactToolResultDisplayForHistory(display);
+
+    expect(compacted.ansiOutput).toHaveLength(1);
+    expect(compacted.totalLines).toBe(1);
+    expect(compacted.ansiOutput[0][0].text).toContain('line-');
+    expect(compacted.ansiOutput[0][0].text).toContain('-done');
+    expect(compacted.ansiOutput[0][0].text).toContain('truncated from');
+  });
+
+  it('bounds long ansi output and keeps the tail lines', () => {
+    const display: AnsiOutputDisplay = {
+      ansiOutput: Array.from(
+        { length: MAX_RETAINED_ANSI_OUTPUT_LINES + 5 },
+        (_, index) => [
+          {
+            text: `line-${index}`,
+            bold: false,
+            italic: false,
+            underline: false,
+            dim: false,
+            inverse: false,
+            fg: '',
+            bg: '',
+          },
+        ],
+      ),
+    };
+
+    const compacted = compactToolResultDisplayForHistory(display);
+
+    expect(compacted.ansiOutput).toHaveLength(MAX_RETAINED_ANSI_OUTPUT_LINES);
+    expect(compacted.ansiOutput[0][0].text).toContain('terminal lines omitted');
+    expect(compacted.ansiOutput.at(-1)?.[0].text).toBe(
+      `line-${MAX_RETAINED_ANSI_OUTPUT_LINES + 4}`,
+    );
+  });
+
+  it('compacts todo, plan, and MCP progress displays', () => {
+    const todoDisplay: TodoResultDisplay = {
+      type: 'todo_list',
+      todos: [
+        {
+          id: '1',
+          status: 'pending',
+          content: `todo-${'x'.repeat(MAX_RETAINED_AGENT_FIELD_CHARS)}-done`,
+        },
+      ],
+    };
+    const planDisplay: PlanResultDisplay = {
+      type: 'plan_summary',
+      message: `message-${'x'.repeat(MAX_RETAINED_AGENT_FIELD_CHARS)}-done`,
+      plan: `plan-${'x'.repeat(MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS)}-done`,
+    };
+    const progressDisplay: McpToolProgressData = {
+      type: 'mcp_tool_progress',
+      progress: 1,
+      message: `progress-${'x'.repeat(MAX_RETAINED_AGENT_FIELD_CHARS)}-done`,
+    };
+
+    const compactedTodo = compactToolResultDisplayForHistory(todoDisplay);
+    const compactedPlan = compactToolResultDisplayForHistory(planDisplay);
+    const compactedProgress =
+      compactToolResultDisplayForHistory(progressDisplay);
+
+    expect(compactedTodo.todos[0].content).toContain('truncated from');
+    expect(compactedPlan.message).toContain('truncated from');
+    expect(compactedPlan.plan).toContain('truncated from');
+    expect(compactedProgress.message).toContain('truncated from');
+  });
+
+  it('compacts task list and team result displays', () => {
+    const taskDisplay: TaskListResultDisplay = {
+      type: 'task_list',
+      tasks: [
+        {
+          id: '1',
+          status: 'pending',
+          subject: `task-${'x'.repeat(MAX_RETAINED_AGENT_FIELD_CHARS)}-done`,
+          owner: `owner-${'x'.repeat(MAX_RETAINED_AGENT_FIELD_CHARS)}-done`,
+        },
+      ],
+    };
+    const teamDisplay: TeamResultDisplay = {
+      type: 'team_result',
+      action: 'created',
+      teamName: `team-${'x'.repeat(MAX_RETAINED_AGENT_FIELD_CHARS)}-done`,
+    };
+
+    const compactedTask = compactToolResultDisplayForHistory(taskDisplay);
+    const compactedTeam = compactToolResultDisplayForHistory(teamDisplay);
+
+    expect(compactedTask.tasks[0].subject).toContain('truncated from');
+    expect(compactedTask.tasks[0].owner).toContain('truncated from');
+    expect(compactedTeam.teamName).toContain('truncated from');
   });
 });

--- a/packages/core/src/utils/toolResultDisplayCompaction.test.ts
+++ b/packages/core/src/utils/toolResultDisplayCompaction.test.ts
@@ -35,6 +35,17 @@ describe('toolResultDisplayCompaction', () => {
     expect(compacted).toContain('truncated from');
   });
 
+  it('preserves unmatched surrogate code units when compacting', () => {
+    const value = `start-\uD800-${'x'.repeat(
+      MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+    )}-end`;
+
+    const compacted = compactStringForHistory(value);
+
+    expect(compacted).toContain('\uD800');
+    expect(compacted).not.toContain('\uFFFD');
+  });
+
   it('drops subagent display fields that are not rendered in CLI history', () => {
     const nestedDisplay = `nested-${'x'.repeat(
       MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,

--- a/packages/core/src/utils/toolResultDisplayCompaction.ts
+++ b/packages/core/src/utils/toolResultDisplayCompaction.ts
@@ -29,6 +29,31 @@ function copyString(value: string): string {
   return value.split('').join('');
 }
 
+function isHighSurrogate(code: number): boolean {
+  return code >= 0xd800 && code <= 0xdbff;
+}
+
+function isLowSurrogate(code: number): boolean {
+  return code >= 0xdc00 && code <= 0xdfff;
+}
+
+function splitSurrogatePairAt(value: string, index: number): boolean {
+  return (
+    index > 0 &&
+    index < value.length &&
+    isHighSurrogate(value.charCodeAt(index - 1)) &&
+    isLowSurrogate(value.charCodeAt(index))
+  );
+}
+
+function safeHeadEnd(value: string, index: number): number {
+  return splitSurrogatePairAt(value, index) ? index - 1 : index;
+}
+
+function safeTailStart(value: string, index: number): number {
+  return splitSurrogatePairAt(value, index) ? index + 1 : index;
+}
+
 function buildStringCompactionMarker(
   value: string,
   purpose: CompactionPurpose,
@@ -62,9 +87,10 @@ function compactString(
   const contentBudget = Math.max(0, limit - marker.length);
   const headLength = Math.ceil(contentBudget * 0.6);
   const tailLength = contentBudget - headLength;
-  const head = copyString(value.slice(0, headLength));
-  const tail =
-    tailLength > 0 ? copyString(value.slice(value.length - tailLength)) : '';
+  const headEnd = safeHeadEnd(value, headLength);
+  const tailStart = safeTailStart(value, value.length - tailLength);
+  const head = copyString(value.slice(0, headEnd));
+  const tail = tailLength > 0 ? copyString(value.slice(tailStart)) : '';
 
   return head + marker + tail;
 }

--- a/packages/core/src/utils/toolResultDisplayCompaction.ts
+++ b/packages/core/src/utils/toolResultDisplayCompaction.ts
@@ -10,6 +10,8 @@ import type {
   FileDiff,
   McpToolProgressData,
   PlanResultDisplay,
+  TaskListResultDisplay,
+  TeamResultDisplay,
   TodoResultDisplay,
   ToolResultDisplay,
 } from '../tools/tools.js';
@@ -314,6 +316,61 @@ function compactMcpToolProgressData(
   };
 }
 
+function isTeamResultDisplay(
+  resultDisplay: unknown,
+): resultDisplay is TeamResultDisplay {
+  return (
+    typeof resultDisplay === 'object' &&
+    resultDisplay !== null &&
+    'type' in resultDisplay &&
+    resultDisplay.type === 'team_result'
+  );
+}
+
+function compactTeamResultDisplay(
+  display: TeamResultDisplay,
+): TeamResultDisplay {
+  return {
+    ...display,
+    teamName: compactStringForHistory(
+      display.teamName,
+      MAX_RETAINED_AGENT_FIELD_CHARS,
+    ),
+  };
+}
+
+function isTaskListResultDisplay(
+  resultDisplay: unknown,
+): resultDisplay is TaskListResultDisplay {
+  return (
+    typeof resultDisplay === 'object' &&
+    resultDisplay !== null &&
+    'type' in resultDisplay &&
+    resultDisplay.type === 'task_list'
+  );
+}
+
+function compactTaskListResultDisplay(
+  display: TaskListResultDisplay,
+): TaskListResultDisplay {
+  return {
+    ...display,
+    tasks: display.tasks.map((task) => ({
+      ...task,
+      subject: compactStringForHistory(
+        task.subject,
+        MAX_RETAINED_AGENT_FIELD_CHARS,
+      ),
+      ...(task.owner !== undefined && {
+        owner: compactStringForHistory(
+          task.owner,
+          MAX_RETAINED_AGENT_FIELD_CHARS,
+        ),
+      }),
+    })),
+  };
+}
+
 export function compactToolResultDisplayForHistory<
   T extends ToolResultDisplay | undefined,
 >(resultDisplay: T): T {
@@ -347,6 +404,14 @@ export function compactToolResultDisplayForHistory<
 
   if (isMcpToolProgressData(resultDisplay)) {
     return compactMcpToolProgressData(resultDisplay) as T;
+  }
+
+  if (isTeamResultDisplay(resultDisplay)) {
+    return compactTeamResultDisplay(resultDisplay) as T;
+  }
+
+  if (isTaskListResultDisplay(resultDisplay)) {
+    return compactTaskListResultDisplay(resultDisplay) as T;
   }
 
   return resultDisplay;

--- a/packages/core/src/utils/toolResultDisplayCompaction.ts
+++ b/packages/core/src/utils/toolResultDisplayCompaction.ts
@@ -23,19 +23,42 @@ export const MAX_RETAINED_FILE_DIFF_CHARS = 50_000;
 export const MAX_RETAINED_FILE_CONTENT_CHARS = 16_000;
 export const MAX_RETAINED_ANSI_OUTPUT_LINES = 200;
 
+type CompactionPurpose = 'history' | 'recording';
+
 function copyString(value: string): string {
   return value.split('').join('');
 }
 
-export function compactStringForHistory(
+function buildStringCompactionMarker(
   value: string,
+  purpose: CompactionPurpose,
+): string {
+  if (purpose === 'recording') {
+    return `\n[... truncated for saved session preview; original length: ${value.length} characters ...]\n`;
+  }
+
+  return `\n[... truncated from ${value.length} characters for CLI history display ...]\n`;
+}
+
+function buildAnsiOutputCompactionMarker(
+  omitted: number,
+  purpose: CompactionPurpose,
+): string {
+  const target =
+    purpose === 'recording' ? 'saved session preview' : 'CLI history display';
+  return `[... ${omitted} terminal lines omitted from ${target} ...]`;
+}
+
+function compactString(
+  value: string,
+  purpose: CompactionPurpose,
   limit = MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
 ): string {
   if (value.length <= limit) {
     return value;
   }
 
-  const marker = `\n[... truncated from ${value.length} characters for CLI history display ...]\n`;
+  const marker = buildStringCompactionMarker(value, purpose);
   const contentBudget = Math.max(0, limit - marker.length);
   const headLength = Math.ceil(contentBudget * 0.6);
   const tailLength = contentBudget - headLength;
@@ -44,6 +67,20 @@ export function compactStringForHistory(
     tailLength > 0 ? copyString(value.slice(value.length - tailLength)) : '';
 
   return head + marker + tail;
+}
+
+export function compactStringForHistory(
+  value: string,
+  limit = MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+): string {
+  return compactString(value, 'history', limit);
+}
+
+export function compactStringForRecording(
+  value: string,
+  limit = MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+): string {
+  return compactString(value, 'recording', limit);
 }
 
 function isFileDiffDisplay(resultDisplay: unknown): resultDisplay is FileDiff {
@@ -68,7 +105,10 @@ function isFileDiffDisplay(resultDisplay: unknown): resultDisplay is FileDiff {
   );
 }
 
-function compactFileDiffForHistory(display: FileDiff): FileDiff {
+function compactFileDiff(
+  display: FileDiff,
+  purpose: CompactionPurpose,
+): FileDiff {
   const fileDiffLength = display.fileDiff.length;
   const originalContentLength =
     typeof display.originalContent === 'string'
@@ -87,19 +127,22 @@ function compactFileDiffForHistory(display: FileDiff): FileDiff {
 
   return {
     ...display,
-    fileDiff: compactStringForHistory(
+    fileDiff: compactString(
       display.fileDiff,
+      purpose,
       MAX_RETAINED_FILE_DIFF_CHARS,
     ),
     originalContent:
       typeof display.originalContent === 'string'
-        ? compactStringForHistory(
+        ? compactString(
             display.originalContent,
+            purpose,
             MAX_RETAINED_FILE_CONTENT_CHARS,
           )
         : display.originalContent,
-    newContent: compactStringForHistory(
+    newContent: compactString(
       display.newContent,
+      purpose,
       MAX_RETAINED_FILE_CONTENT_CHARS,
     ),
     truncatedForSession: true,
@@ -138,33 +181,60 @@ function markerAnsiLine(text: string): AnsiLine {
   ];
 }
 
-function compactAnsiLine(line: AnsiLine): AnsiLine {
-  return line.map((token) => ({
-    ...token,
-    text: compactStringForHistory(token.text),
-  }));
+function compactAnsiLine(line: AnsiLine, purpose: CompactionPurpose): AnsiLine {
+  let changed = false;
+  const compactedLine = line.map((token) => {
+    const compactedText = compactString(token.text, purpose);
+    if (compactedText !== token.text) {
+      changed = true;
+      return {
+        ...token,
+        text: compactedText,
+      };
+    }
+
+    return token;
+  });
+  return changed ? compactedLine : line;
 }
 
-function compactAnsiOutput(output: AnsiOutput): AnsiOutput {
+function compactAnsiOutput(
+  output: AnsiOutput,
+  purpose: CompactionPurpose,
+): AnsiOutput {
   if (output.length <= MAX_RETAINED_ANSI_OUTPUT_LINES) {
-    return output.map(compactAnsiLine);
+    let changed = false;
+    const compactedOutput = output.map((line) => {
+      const compactedLine = compactAnsiLine(line, purpose);
+      if (compactedLine !== line) {
+        changed = true;
+      }
+      return compactedLine;
+    });
+    return changed ? compactedOutput : output;
   }
 
   const omitted = output.length - MAX_RETAINED_ANSI_OUTPUT_LINES + 1;
   return [
-    markerAnsiLine(
-      `[... ${omitted} terminal lines omitted from CLI history display ...]`,
-    ),
-    ...output.slice(-(MAX_RETAINED_ANSI_OUTPUT_LINES - 1)).map(compactAnsiLine),
+    markerAnsiLine(buildAnsiOutputCompactionMarker(omitted, purpose)),
+    ...output
+      .slice(-(MAX_RETAINED_ANSI_OUTPUT_LINES - 1))
+      .map((line) => compactAnsiLine(line, purpose)),
   ];
 }
 
 function compactAnsiOutputDisplay(
   display: AnsiOutputDisplay,
+  purpose: CompactionPurpose,
 ): AnsiOutputDisplay {
+  const ansiOutput = compactAnsiOutput(display.ansiOutput, purpose);
+  if (ansiOutput === display.ansiOutput) {
+    return display;
+  }
+
   return {
     ...display,
-    ansiOutput: compactAnsiOutput(display.ansiOutput),
+    ansiOutput,
   };
 }
 
@@ -179,28 +249,33 @@ function isAgentResultDisplay(
   );
 }
 
-function compactAgentResultDisplayForHistory(
+function compactAgentResultDisplay(
   display: AgentResultDisplay,
+  purpose: CompactionPurpose,
 ): AgentResultDisplay {
   return {
     ...display,
-    taskDescription: compactStringForHistory(
+    taskDescription: compactString(
       display.taskDescription,
+      purpose,
       MAX_RETAINED_AGENT_FIELD_CHARS,
     ),
-    taskPrompt: compactStringForHistory(
+    taskPrompt: compactString(
       display.taskPrompt,
+      purpose,
       MAX_RETAINED_AGENT_FIELD_CHARS,
     ),
     ...(display.terminateReason !== undefined && {
-      terminateReason: compactStringForHistory(
+      terminateReason: compactString(
         display.terminateReason,
+        purpose,
         MAX_RETAINED_AGENT_FIELD_CHARS,
       ),
     }),
     ...(display.result !== undefined && {
-      result: compactStringForHistory(
+      result: compactString(
         display.result,
+        purpose,
         MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
       ),
     }),
@@ -218,19 +293,21 @@ function compactAgentResultDisplayForHistory(
         return {
           ...rest,
           ...(description !== undefined && {
-            description: compactStringForHistory(
+            description: compactString(
               description,
+              purpose,
               MAX_RETAINED_AGENT_FIELD_CHARS,
             ),
           }),
           ...(error !== undefined && {
-            error: compactStringForHistory(
+            error: compactString(
               error,
+              purpose,
               MAX_RETAINED_AGENT_FIELD_CHARS,
             ),
           }),
           ...(resultDisplay !== undefined && {
-            resultDisplay: compactStringForHistory(resultDisplay),
+            resultDisplay: compactString(resultDisplay, purpose),
           }),
         };
       }),
@@ -251,13 +328,15 @@ function isTodoResultDisplay(
 
 function compactTodoResultDisplay(
   display: TodoResultDisplay,
+  purpose: CompactionPurpose,
 ): TodoResultDisplay {
   return {
     ...display,
     todos: display.todos.map((todo) => ({
       ...todo,
-      content: compactStringForHistory(
+      content: compactString(
         todo.content,
+        purpose,
         MAX_RETAINED_AGENT_FIELD_CHARS,
       ),
     })),
@@ -277,15 +356,18 @@ function isPlanResultDisplay(
 
 function compactPlanResultDisplay(
   display: PlanResultDisplay,
+  purpose: CompactionPurpose,
 ): PlanResultDisplay {
   return {
     ...display,
-    message: compactStringForHistory(
+    message: compactString(
       display.message,
+      purpose,
       MAX_RETAINED_AGENT_FIELD_CHARS,
     ),
-    plan: compactStringForHistory(
+    plan: compactString(
       display.plan,
+      purpose,
       MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
     ),
   };
@@ -304,12 +386,14 @@ function isMcpToolProgressData(
 
 function compactMcpToolProgressData(
   display: McpToolProgressData,
+  purpose: CompactionPurpose,
 ): McpToolProgressData {
   return {
     ...display,
     ...(display.message !== undefined && {
-      message: compactStringForHistory(
+      message: compactString(
         display.message,
+        purpose,
         MAX_RETAINED_AGENT_FIELD_CHARS,
       ),
     }),
@@ -329,11 +413,13 @@ function isTeamResultDisplay(
 
 function compactTeamResultDisplay(
   display: TeamResultDisplay,
+  purpose: CompactionPurpose,
 ): TeamResultDisplay {
   return {
     ...display,
-    teamName: compactStringForHistory(
+    teamName: compactString(
       display.teamName,
+      purpose,
       MAX_RETAINED_AGENT_FIELD_CHARS,
     ),
   };
@@ -352,18 +438,21 @@ function isTaskListResultDisplay(
 
 function compactTaskListResultDisplay(
   display: TaskListResultDisplay,
+  purpose: CompactionPurpose,
 ): TaskListResultDisplay {
   return {
     ...display,
     tasks: display.tasks.map((task) => ({
       ...task,
-      subject: compactStringForHistory(
+      subject: compactString(
         task.subject,
+        purpose,
         MAX_RETAINED_AGENT_FIELD_CHARS,
       ),
       ...(task.owner !== undefined && {
-        owner: compactStringForHistory(
+        owner: compactString(
           task.owner,
+          purpose,
           MAX_RETAINED_AGENT_FIELD_CHARS,
         ),
       }),
@@ -371,11 +460,12 @@ function compactTaskListResultDisplay(
   };
 }
 
-export function compactToolResultDisplayForHistory<
-  T extends ToolResultDisplay | undefined,
->(resultDisplay: T): T {
+function compactToolResultDisplay<T extends ToolResultDisplay | undefined>(
+  resultDisplay: T,
+  purpose: CompactionPurpose,
+): T {
   if (typeof resultDisplay === 'string') {
-    return compactStringForHistory(resultDisplay) as T;
+    return compactString(resultDisplay, purpose) as T;
   }
 
   if (resultDisplay === undefined) {
@@ -383,36 +473,48 @@ export function compactToolResultDisplayForHistory<
   }
 
   if (isFileDiffDisplay(resultDisplay)) {
-    return compactFileDiffForHistory(resultDisplay) as T;
+    return compactFileDiff(resultDisplay, purpose) as T;
   }
 
   if (isAgentResultDisplay(resultDisplay)) {
-    return compactAgentResultDisplayForHistory(resultDisplay) as T;
+    return compactAgentResultDisplay(resultDisplay, purpose) as T;
   }
 
   if (isAnsiOutputDisplay(resultDisplay)) {
-    return compactAnsiOutputDisplay(resultDisplay) as T;
+    return compactAnsiOutputDisplay(resultDisplay, purpose) as T;
   }
 
   if (isTodoResultDisplay(resultDisplay)) {
-    return compactTodoResultDisplay(resultDisplay) as T;
+    return compactTodoResultDisplay(resultDisplay, purpose) as T;
   }
 
   if (isPlanResultDisplay(resultDisplay)) {
-    return compactPlanResultDisplay(resultDisplay) as T;
+    return compactPlanResultDisplay(resultDisplay, purpose) as T;
   }
 
   if (isMcpToolProgressData(resultDisplay)) {
-    return compactMcpToolProgressData(resultDisplay) as T;
+    return compactMcpToolProgressData(resultDisplay, purpose) as T;
   }
 
   if (isTeamResultDisplay(resultDisplay)) {
-    return compactTeamResultDisplay(resultDisplay) as T;
+    return compactTeamResultDisplay(resultDisplay, purpose) as T;
   }
 
   if (isTaskListResultDisplay(resultDisplay)) {
-    return compactTaskListResultDisplay(resultDisplay) as T;
+    return compactTaskListResultDisplay(resultDisplay, purpose) as T;
   }
 
   return resultDisplay;
+}
+
+export function compactToolResultDisplayForHistory<
+  T extends ToolResultDisplay | undefined,
+>(resultDisplay: T): T {
+  return compactToolResultDisplay(resultDisplay, 'history');
+}
+
+export function compactToolResultDisplayForRecording<
+  T extends ToolResultDisplay | undefined,
+>(resultDisplay: T): T {
+  return compactToolResultDisplay(resultDisplay, 'recording');
 }

--- a/packages/core/src/utils/toolResultDisplayCompaction.ts
+++ b/packages/core/src/utils/toolResultDisplayCompaction.ts
@@ -1,0 +1,354 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Buffer } from 'node:buffer';
+import type {
+  AgentResultDisplay,
+  AnsiOutputDisplay,
+  FileDiff,
+  McpToolProgressData,
+  PlanResultDisplay,
+  TodoResultDisplay,
+  ToolResultDisplay,
+} from '../tools/tools.js';
+import type { AnsiLine, AnsiOutput } from './terminalSerializer.js';
+
+export const MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS = 32_000;
+export const MAX_RETAINED_AGENT_FIELD_CHARS = 8_000;
+export const MAX_RETAINED_FILE_DIFF_CHARS = 50_000;
+export const MAX_RETAINED_FILE_CONTENT_CHARS = 16_000;
+export const MAX_RETAINED_ANSI_OUTPUT_LINES = 200;
+
+function copyString(value: string): string {
+  return Buffer.from(value).toString('utf8');
+}
+
+export function compactStringForHistory(
+  value: string,
+  limit = MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+): string {
+  if (value.length <= limit) {
+    return value;
+  }
+
+  const marker = `\n[... truncated from ${value.length} characters for CLI history display ...]\n`;
+  const contentBudget = Math.max(0, limit - marker.length);
+  const headLength = Math.ceil(contentBudget * 0.6);
+  const tailLength = contentBudget - headLength;
+  const head = copyString(value.slice(0, headLength));
+  const tail =
+    tailLength > 0 ? copyString(value.slice(value.length - tailLength)) : '';
+
+  return head + marker + tail;
+}
+
+function isFileDiffDisplay(resultDisplay: unknown): resultDisplay is FileDiff {
+  if (
+    typeof resultDisplay !== 'object' ||
+    resultDisplay === null ||
+    !('fileDiff' in resultDisplay) ||
+    !('fileName' in resultDisplay) ||
+    !('originalContent' in resultDisplay) ||
+    !('newContent' in resultDisplay)
+  ) {
+    return false;
+  }
+
+  const display = resultDisplay as Record<string, unknown>;
+  const originalContent = display['originalContent'];
+  return (
+    typeof display['fileDiff'] === 'string' &&
+    typeof display['fileName'] === 'string' &&
+    typeof display['newContent'] === 'string' &&
+    (originalContent === null || typeof originalContent === 'string')
+  );
+}
+
+function compactFileDiffForHistory(display: FileDiff): FileDiff {
+  const fileDiffLength = display.fileDiff.length;
+  const originalContentLength =
+    typeof display.originalContent === 'string'
+      ? display.originalContent.length
+      : 0;
+  const newContentLength = display.newContent.length;
+  const fileDiffTruncated = fileDiffLength > MAX_RETAINED_FILE_DIFF_CHARS;
+  const originalContentTruncated =
+    originalContentLength > MAX_RETAINED_FILE_CONTENT_CHARS;
+  const newContentTruncated =
+    newContentLength > MAX_RETAINED_FILE_CONTENT_CHARS;
+
+  if (!fileDiffTruncated && !originalContentTruncated && !newContentTruncated) {
+    return display;
+  }
+
+  return {
+    ...display,
+    fileDiff: compactStringForHistory(
+      display.fileDiff,
+      MAX_RETAINED_FILE_DIFF_CHARS,
+    ),
+    originalContent:
+      typeof display.originalContent === 'string'
+        ? compactStringForHistory(
+            display.originalContent,
+            MAX_RETAINED_FILE_CONTENT_CHARS,
+          )
+        : display.originalContent,
+    newContent: compactStringForHistory(
+      display.newContent,
+      MAX_RETAINED_FILE_CONTENT_CHARS,
+    ),
+    truncatedForSession: true,
+    fileDiffLength,
+    originalContentLength,
+    newContentLength,
+    fileDiffTruncated,
+    originalContentTruncated,
+    newContentTruncated,
+  };
+}
+
+function isAnsiOutputDisplay(
+  resultDisplay: unknown,
+): resultDisplay is AnsiOutputDisplay {
+  return (
+    typeof resultDisplay === 'object' &&
+    resultDisplay !== null &&
+    'ansiOutput' in resultDisplay &&
+    Array.isArray((resultDisplay as { ansiOutput?: unknown }).ansiOutput)
+  );
+}
+
+function markerAnsiLine(text: string): AnsiLine {
+  return [
+    {
+      text,
+      bold: false,
+      italic: false,
+      underline: false,
+      dim: true,
+      inverse: false,
+      fg: '',
+      bg: '',
+    },
+  ];
+}
+
+function compactAnsiLine(line: AnsiLine): AnsiLine {
+  return line.map((token) => ({
+    ...token,
+    text: compactStringForHistory(token.text),
+  }));
+}
+
+function compactAnsiOutput(output: AnsiOutput): AnsiOutput {
+  if (output.length <= MAX_RETAINED_ANSI_OUTPUT_LINES) {
+    return output.map(compactAnsiLine);
+  }
+
+  const omitted = output.length - MAX_RETAINED_ANSI_OUTPUT_LINES + 1;
+  return [
+    markerAnsiLine(
+      `[... ${omitted} terminal lines omitted from CLI history display ...]`,
+    ),
+    ...output.slice(-(MAX_RETAINED_ANSI_OUTPUT_LINES - 1)).map(compactAnsiLine),
+  ];
+}
+
+function compactAnsiOutputDisplay(
+  display: AnsiOutputDisplay,
+): AnsiOutputDisplay {
+  return {
+    ...display,
+    ansiOutput: compactAnsiOutput(display.ansiOutput),
+  };
+}
+
+function isAgentResultDisplay(
+  resultDisplay: unknown,
+): resultDisplay is AgentResultDisplay {
+  return (
+    typeof resultDisplay === 'object' &&
+    resultDisplay !== null &&
+    'type' in resultDisplay &&
+    resultDisplay.type === 'task_execution'
+  );
+}
+
+function compactAgentResultDisplayForHistory(
+  display: AgentResultDisplay,
+): AgentResultDisplay {
+  return {
+    ...display,
+    taskDescription: compactStringForHistory(
+      display.taskDescription,
+      MAX_RETAINED_AGENT_FIELD_CHARS,
+    ),
+    taskPrompt: compactStringForHistory(
+      display.taskPrompt,
+      MAX_RETAINED_AGENT_FIELD_CHARS,
+    ),
+    ...(display.terminateReason !== undefined && {
+      terminateReason: compactStringForHistory(
+        display.terminateReason,
+        MAX_RETAINED_AGENT_FIELD_CHARS,
+      ),
+    }),
+    ...(display.result !== undefined && {
+      result: compactStringForHistory(
+        display.result,
+        MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+      ),
+    }),
+    ...(display.toolCalls !== undefined && {
+      toolCalls: display.toolCalls.map((toolCall) => {
+        const {
+          args: _args,
+          responseParts: _responseParts,
+          result: _result,
+          resultDisplay,
+          error,
+          description,
+          ...rest
+        } = toolCall;
+        return {
+          ...rest,
+          ...(description !== undefined && {
+            description: compactStringForHistory(
+              description,
+              MAX_RETAINED_AGENT_FIELD_CHARS,
+            ),
+          }),
+          ...(error !== undefined && {
+            error: compactStringForHistory(
+              error,
+              MAX_RETAINED_AGENT_FIELD_CHARS,
+            ),
+          }),
+          ...(resultDisplay !== undefined && {
+            resultDisplay: compactStringForHistory(resultDisplay),
+          }),
+        };
+      }),
+    }),
+  };
+}
+
+function isTodoResultDisplay(
+  resultDisplay: unknown,
+): resultDisplay is TodoResultDisplay {
+  return (
+    typeof resultDisplay === 'object' &&
+    resultDisplay !== null &&
+    'type' in resultDisplay &&
+    resultDisplay.type === 'todo_list'
+  );
+}
+
+function compactTodoResultDisplay(
+  display: TodoResultDisplay,
+): TodoResultDisplay {
+  return {
+    ...display,
+    todos: display.todos.map((todo) => ({
+      ...todo,
+      content: compactStringForHistory(
+        todo.content,
+        MAX_RETAINED_AGENT_FIELD_CHARS,
+      ),
+    })),
+  };
+}
+
+function isPlanResultDisplay(
+  resultDisplay: unknown,
+): resultDisplay is PlanResultDisplay {
+  return (
+    typeof resultDisplay === 'object' &&
+    resultDisplay !== null &&
+    'type' in resultDisplay &&
+    resultDisplay.type === 'plan_summary'
+  );
+}
+
+function compactPlanResultDisplay(
+  display: PlanResultDisplay,
+): PlanResultDisplay {
+  return {
+    ...display,
+    message: compactStringForHistory(
+      display.message,
+      MAX_RETAINED_AGENT_FIELD_CHARS,
+    ),
+    plan: compactStringForHistory(
+      display.plan,
+      MAX_RETAINED_TOOL_RESULT_DISPLAY_CHARS,
+    ),
+  };
+}
+
+function isMcpToolProgressData(
+  resultDisplay: unknown,
+): resultDisplay is McpToolProgressData {
+  return (
+    typeof resultDisplay === 'object' &&
+    resultDisplay !== null &&
+    'type' in resultDisplay &&
+    resultDisplay.type === 'mcp_tool_progress'
+  );
+}
+
+function compactMcpToolProgressData(
+  display: McpToolProgressData,
+): McpToolProgressData {
+  return {
+    ...display,
+    ...(display.message !== undefined && {
+      message: compactStringForHistory(
+        display.message,
+        MAX_RETAINED_AGENT_FIELD_CHARS,
+      ),
+    }),
+  };
+}
+
+export function compactToolResultDisplayForHistory<
+  T extends ToolResultDisplay | undefined,
+>(resultDisplay: T): T {
+  if (typeof resultDisplay === 'string') {
+    return compactStringForHistory(resultDisplay) as T;
+  }
+
+  if (resultDisplay === undefined) {
+    return resultDisplay;
+  }
+
+  if (isFileDiffDisplay(resultDisplay)) {
+    return compactFileDiffForHistory(resultDisplay) as T;
+  }
+
+  if (isAgentResultDisplay(resultDisplay)) {
+    return compactAgentResultDisplayForHistory(resultDisplay) as T;
+  }
+
+  if (isAnsiOutputDisplay(resultDisplay)) {
+    return compactAnsiOutputDisplay(resultDisplay) as T;
+  }
+
+  if (isTodoResultDisplay(resultDisplay)) {
+    return compactTodoResultDisplay(resultDisplay) as T;
+  }
+
+  if (isPlanResultDisplay(resultDisplay)) {
+    return compactPlanResultDisplay(resultDisplay) as T;
+  }
+
+  if (isMcpToolProgressData(resultDisplay)) {
+    return compactMcpToolProgressData(resultDisplay) as T;
+  }
+
+  return resultDisplay;
+}

--- a/packages/core/src/utils/toolResultDisplayCompaction.ts
+++ b/packages/core/src/utils/toolResultDisplayCompaction.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Buffer } from 'node:buffer';
 import type {
   AgentResultDisplay,
   AnsiOutputDisplay,
@@ -23,7 +22,7 @@ export const MAX_RETAINED_FILE_CONTENT_CHARS = 16_000;
 export const MAX_RETAINED_ANSI_OUTPUT_LINES = 200;
 
 function copyString(value: string): string {
-  return Buffer.from(value).toString('utf8');
+  return value.split('').join('');
 }
 
 export function compactStringForHistory(


### PR DESCRIPTION
## What this PR does

Reduces how much large tool-output display data the interactive CLI retains after rendering. Oversized display metadata is compacted before it is stored in scheduler state, live UI history, chat recording metadata, and subagent display summaries. Foreground PTY terminal resources are also disposed on natural shell exit, and retained terminal scrollback for display snapshots is bounded.

## Why it's needed

Long interactive sessions can accumulate large display-only copies of tool output even after the model-facing tool result has already moved on. Heavy research tasks that run large shell commands, file diffs, MCP output, or nested agents can therefore grow process memory far beyond what the active conversation needs. Bounding these retained UI/history copies keeps the session usable without changing model-facing tool results or normal-sized display output.

## Reviewer Test Plan

### How to verify

Run the focused unit suites for retained tool display metadata and PTY cleanup: `cd packages/core && npx vitest run src/services/shellExecutionService.test.ts src/core/coreToolScheduler.test.ts src/utils/toolResultDisplayCompaction.test.ts src/services/chatRecordingService.test.ts`, and `cd packages/cli && npx vitest run src/ui/hooks/useToolScheduler.test.ts`. Then run package checks from the checkout: `npm run build`, `cd packages/core && npm run typecheck`, `cd packages/cli && npm run typecheck`, and touched-file lint with `npx eslint` for the files changed in this PR. Reviewers can also reproduce manually by running a long interactive session with large shell output, large file diffs, and nested agent/tool output, then confirming the CLI keeps rendered previews while retained history metadata is bounded.

### Evidence (Before & After)

Non-visual memory-retention change. Before: UI/history paths could retain full oversized `resultDisplay` strings, nested agent tool-call payload fields, large file diff metadata, long ANSI terminal snapshots, and foreground PTY terminal resources after natural shell exit. After: unit tests assert generic display strings are compacted to a bounded head/tail preview, nested agent summaries drop non-rendered `args`, `responseParts`, and `result` payloads, saved chat metadata compacts large display data without mutating the original input, live output stored by the scheduler is compacted, CLI display history receives compacted metadata, and natural-exit PTY resources are disposed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS with Node.js v22.22.2 and npm 10.9.7. `npm run build` completed locally. `packages/core` and `packages/cli` typecheck passed after the workspace build generated local package declarations. Full `npm run preflight` was not run because this checkout currently has unrelated full-repo lint warnings outside the touched files; the touched files were linted directly and passed.

## Risk & Scope

- Main risk or tradeoff: very large display-only history entries now keep a compact head/tail preview instead of retaining the entire rendered payload in memory. Normal-sized output is unchanged, and model-facing tool results are not truncated by this PR.
- Not validated / out of scope: local Windows/Linux validation and full preflight. This PR does not implement model-context tool-output truncation or disk offload; that is separate from retained interactive display metadata and is related to #4880.
- Breaking changes / migration notes: no intended breaking changes.

## Linked Issues

Related to #4179 and #4182. Also related to, but separate from, #4880 because this PR bounds retained interactive display metadata rather than model-facing tool output.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

减少交互式 CLI 在渲染之后继续保留的大型工具输出展示数据。超大的展示元数据会在进入 scheduler state、实时 UI 历史、聊天录制元数据和 subagent 展示摘要之前被压缩。前台 PTY 在 shell 自然退出时也会释放 terminal 资源，并且用于展示快照的 terminal scrollback 会被限制在固定范围内。

## 为什么需要

长时间交互会话可能会积累大量仅用于展示的工具输出副本，即使面向模型的工具结果已经继续向前推进。执行大型 shell 命令、大型文件 diff、MCP 输出或嵌套 agent/tool 输出的重型研究任务，可能因此让进程内存增长到远超当前对话实际需要的规模。限制这些 UI/history 保留副本，可以让会话保持可用，同时不改变面向模型的工具结果，也不改变普通大小输出的展示。

## Reviewer 测试计划

### 如何验证

运行 retained tool display metadata 和 PTY cleanup 的聚焦单测：`cd packages/core && npx vitest run src/services/shellExecutionService.test.ts src/core/coreToolScheduler.test.ts src/utils/toolResultDisplayCompaction.test.ts src/services/chatRecordingService.test.ts`，以及 `cd packages/cli && npx vitest run src/ui/hooks/useToolScheduler.test.ts`。然后在 checkout 中运行包检查：`npm run build`、`cd packages/core && npm run typecheck`、`cd packages/cli && npm run typecheck`，并对本 PR 修改的文件直接运行 `npx eslint`。Reviewer 也可以通过一个长时间交互会话手动复现：运行大型 shell 输出、大型文件 diff、嵌套 agent/tool 输出，并确认 CLI 仍展示预览，同时保留在 history metadata 里的内容有上限。

### 证据（Before & After）

这是非视觉类的内存保留优化。Before：UI/history 路径可能保留完整的超大 `resultDisplay` 字符串、嵌套 agent tool-call payload 字段、大型 file diff 元数据、很长的 ANSI terminal 快照，以及 shell 自然退出后的前台 PTY terminal 资源。After：单测断言通用展示字符串会被压缩成有上限的 head/tail preview，嵌套 agent 摘要会丢弃不参与渲染的 `args`、`responseParts` 和 `result` payload，保存的聊天元数据会在不修改原始输入的情况下压缩大型展示数据，scheduler 存储的 live output 会被压缩，CLI 展示历史接收到的是压缩后的元数据，并且自然退出的 PTY 资源会被释放。

### 测试平台

见上方 OS 表（🍏 macOS 已测；🪟 Windows / 🐧 Linux 未在本地测试，交由 CI）。

### 运行环境（可选）

macOS，Node.js v22.22.2，npm 10.9.7。`npm run build` 已在本地完成。workspace build 生成本地包声明后，`packages/core` 和 `packages/cli` 的 typecheck 都通过。没有运行完整 `npm run preflight`，因为这个 checkout 当前在未触碰文件中有与本 PR 无关的全仓 lint warning；本 PR 修改的文件已直接 lint 并通过。

## 风险与范围

- 主要风险或权衡：特别大的 display-only 历史条目现在会保留紧凑的 head/tail preview，而不是在内存中保留完整渲染 payload。普通大小输出不变，并且这个 PR 不会截断面向模型的工具结果。
- 未验证 / 范围外：本地 Windows/Linux 验证和完整 preflight。这个 PR 不实现模型上下文中的工具输出截断或落盘 offload；那与 retained interactive display metadata 是不同问题，并且与 #4880 相关。
- 破坏性改动 / 迁移说明：没有预期的破坏性改动。

## 关联 Issues

Related to #4179 and #4182. Also related to, but separate from, #4880 because this PR bounds retained interactive display metadata rather than model-facing tool output.

</details>


Refs #2128