### PR TITLE
feat(web-shell): make /settings mouse-reachable via a status-bar gear icon

### DIFF
--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -2176,12 +2176,14 @@ export function App({
                       ? `inline-${modelInlineMode ?? 'none'}-${agentsInlineMode ?? 'none'}-${memoryInlineOpen ? 'memory' : 'none'}-${approvalModeInlineOpen ? 'approval' : 'none'}-${settingsInlineOpen ? 'settings' : 'none'}`
                       : undefined
                   }
-                  // The approval-mode and model pickers are reachable by mouse
-                  // from the status bar, so they reveal themselves when opened
-                  // while the user is scrolled up; the agents/memory panels
-                  // keep the user's scroll position.
+                  // The approval-mode/model pickers and the settings panel are
+                  // reachable by mouse from the status bar, so they reveal
+                  // themselves when opened while the user is scrolled up; the
+                  // agents/memory panels keep the user's scroll position.
                   autoScrollTailIntoView={
-                    approvalModeInlineOpen || modelInlineMode !== null
+                    approvalModeInlineOpen ||
+                    modelInlineMode !== null ||
+                    settingsInlineOpen
                   }
                 />
 
@@ -2255,6 +2257,7 @@ export function App({
                     setModelInlineMode((v) => (v ? null : 'main'))
                   }
                   onShowContext={() => showContextUsage('/context', false)}
+                  onOpenSettings={() => setSettingsInlineOpen((v) => !v)}
                 />
               ))}
 

--- a/packages/web-shell/client/components/StatusBar.module.css
+++ b/packages/web-shell/client/components/StatusBar.module.css
@@ -19,6 +19,35 @@
   position: relative;
 }
 
+.settingsButton {
+  /* Sits in the bar's 2ch left-padding gutter (plus a few px of the footer
+     margin) so the mode label keeps its input-text alignment — the gear takes
+     no flex space. The gutter alone (~15.6px) is narrower than the button, so
+     the extra -6px buys a visible gap between the icon and the mode label
+     instead of the two touching. font: inherit so the -2ch resolves against
+     the same font as the bar's 2ch padding; the 2px padding is hit area, free
+     since we're out of flow. */
+  position: absolute;
+  left: calc(-2ch - 6px);
+  top: 50%;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  margin: 0;
+  border: none;
+  background: none;
+  font: inherit;
+  color: var(--text-dimmed);
+  cursor: pointer;
+}
+
+.settingsButton:hover,
+.settingsButton:focus-visible {
+  color: var(--text-primary);
+}
+
 .modeButton {
   display: inline-flex;
   align-items: center;

--- a/packages/web-shell/client/components/StatusBar.tsx
+++ b/packages/web-shell/client/components/StatusBar.tsx
@@ -31,6 +31,29 @@ interface StatusBarProps {
   onSelectModel: () => void;
   /** Show the context-usage breakdown, exactly like typing /context. */
   onShowContext: () => void;
+  /** Open the inline settings panel so settings are reachable with the mouse. */
+  onOpenSettings: () => void;
+}
+
+// Feather "settings" gear, stroke-based like PromptChevron so it inherits
+// the button's currentColor.
+function GearIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
+    </svg>
+  );
 }
 
 export function StatusBar({
@@ -38,6 +61,7 @@ export function StatusBar({
   onSelectMode,
   onSelectModel,
   onShowContext,
+  onOpenSettings,
 }: StatusBarProps) {
   const connection = useConnection();
   const connected = connection.status === 'connected';
@@ -53,6 +77,27 @@ export function StatusBar({
   return (
     <div className={styles.bar}>
       <div className={styles.left}>
+        {connected && (
+          // Anchored at the corner, outside the escape-hint swap below, so
+          // the settings entry never moves. Hidden while disconnected like
+          // every other control here — the panel needs the daemon to load
+          // settings. Same stopPropagation contract as the mode button: the
+          // settings panel dismisses on outside mousedown/touchstart, so the
+          // opening press must not reach the window or clicking the gear
+          // again could never toggle the panel closed.
+          <button
+            type="button"
+            className={styles.settingsButton}
+            onClick={onOpenSettings}
+            onMouseDown={(e) => e.stopPropagation()}
+            onTouchStart={(e) => e.stopPropagation()}
+            title={t('settings.title')}
+            aria-label={t('settings.title')}
+            aria-haspopup="dialog"
+          >
+            <GearIcon />
+          </button>
+        )}
         {escapeHint ? (
           <span className={styles.escapeHint}>{t('editor.escClearHint')}</span>
         ) : modeIndicator ? (


### PR DESCRIPTION
## What this PR does

Adds a settings gear icon at the far left of the status bar, to the left of the approval-mode indicator. Clicking it toggles the same inline `/settings` panel that typing `/settings` opens (no separate dialog, no command echo — matching the mode/model picker buttons); clicking the gear again, pressing outside the panel, or Escape closes it. The gear is absolutely positioned into the bar's 2ch left-padding gutter (plus 6px of the footer margin), so it takes no flex space and the approval-mode label keeps its existing alignment with the editor's input text; the icon ends up with a balanced ~6px of whitespace on each side. `settingsInlineOpen` joins `autoScrollTailIntoView`, and the gear is hidden while disconnected like every other status-bar control (the panel needs the daemon to load settings).

## Why it's needed

Follow-up to #4887 (model picker) and #4958 (context usage): `/settings` was the remaining frequently-used panel reachable only by typing a slash command. A bottom-left gear is the established IDE convention (VS Code), so the entry is discoverable without knowing slash commands. Two mechanics are load-bearing:

- The settings panel dismisses on outside `mousedown`/`touchstart`, so the gear uses the same stopPropagation contract as the mode button — without it, clicking the gear to close would dismiss-then-reopen the panel, making it impossible to toggle closed.
- Without the `autoScrollTailIntoView` addition, opening settings from the status bar while scrolled up would open the panel out of view and look like a dead click.

## Reviewer Test Plan

### How to verify

1. `npm run dev:daemon`, open the web shell: a dimmed gear sits at the bottom-left corner, left of the approval-mode indicator; hover brightens it, tooltip shows “Settings” / “设置” (reuses the existing `settings.title` i18n key — no new keys).
2. Click the gear: the inline `/settings` panel appears at the transcript tail, identical to typing `/settings`. Click the gear again: it closes. Outside press and Escape also close it.
3. Scroll up in a long transcript, click the gear: the transcript follows the tail so the panel is revealed.
4. In the panel, open a sub-dialog (e.g. Approval Mode row): settings closes and the picker opens, unchanged from the typed flow.
5. Keyboard: Tab reaches the gear first in the bar; Enter toggles. `aria-label`/`aria-haspopup` are set (icon-only button).
6. Stop the daemon: the gear disappears along with mode/model/context; on reconnect it returns.
7. Suites: `web-shell` 198 passed; `eslint` clean on the touched files; package build (vite + `tsc -p tsconfig.lib.json`) green. `tsc -p tsconfig.json` reports one pre-existing error in `transcriptAdapter.test.ts` that is identical on a clean tree (unrelated to this change).

### Evidence (Before & After)

Before: settings only opened by typing `/settings`. After: the gear toggles the same panel; position was tuned live on the dev server over three iterations (in-flow → gutter-anchored → centered in the edge-to-label corridor) so the icon neither floats 2ch in nor touches the mode label — at 13px mono that is ~6px left whitespace and ~5.6px gap to the label, with the label itself not moving at all.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npm run dev:daemon` (daemon from source + Vite dev server), `vitest` in `packages/web-shell`.

## Risk & Scope

- Main risk or tradeoff: the gear button (18px box) is wider than the 2ch gutter (~15.6px), so it deliberately overhangs 6px into the footer's 10px margin — still 4px clear of the viewport edge, nothing else renders there, and the CSS comment documents the math. `font: inherit` on the button is required for the `-2ch` offset to resolve against the bar's monospace metrics (buttons don't inherit fonts by default).
- Not validated / out of scope: native CLI footer untouched; no component test added — the existing status-bar buttons (mode/model/context, #4887/#4958) ship without component tests and the gear's logic is a one-line toggle into the already-tested `/settings` path; Windows/Linux only via CI.
- Breaking changes / migration notes: none. One new required prop `onOpenSettings` on `StatusBar`, whose only call site is `App.tsx` (wired in the same commit).

<img width="1042" height="396" alt="image" src="https://github.com/user-attachments/assets/37edc5ff-8a8a-41fc-b12e-c8ca0409f6a0" />
