### PR TITLE
fix(web-shell): merge adjacent tool calls into one tool_group like native CLI

### DIFF
--- a/packages/web-shell/client/adapters/transcriptToMessages.test.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.test.ts
@@ -900,6 +900,73 @@ describe('transcriptBlocksToDaemonMessages', () => {
     });
   });
 
+  it('attaches shell output to the running execute tool in a merged group', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      toolBlock('t1', 'tc-bash', 'running', 1, {
+        toolName: 'bash',
+        toolKind: 'execute',
+      }),
+      toolBlock('t2', 'tc-read', 'completed', 2, { toolName: 'Read' }),
+      shellBlock('sh1', 'bash output', 3),
+    ]);
+
+    expect(messages).toHaveLength(1);
+    const tools =
+      messages[0].role === 'tool_group' ? messages[0].tools : undefined;
+    expect(tools?.[0]).toMatchObject({
+      callId: 'tc-bash',
+      rawOutput: 'bash output',
+    });
+    expect(tools?.[1]?.rawOutput).toBeUndefined();
+  });
+
+  it('attaches shell output to the most recent running execute tool', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      toolBlock('t1', 'tc-bash-1', 'completed', 1, {
+        toolName: 'bash',
+        toolKind: 'execute',
+        rawOutput: 'first output',
+      }),
+      toolBlock('t2', 'tc-bash-2', 'running', 2, {
+        toolName: 'bash',
+        toolKind: 'execute',
+      }),
+      shellBlock('sh1', 'second output', 3),
+    ]);
+
+    expect(messages).toHaveLength(1);
+    const tools =
+      messages[0].role === 'tool_group' ? messages[0].tools : undefined;
+    expect(tools?.[0]).toMatchObject({
+      callId: 'tc-bash-1',
+      rawOutput: 'first output',
+    });
+    expect(tools?.[1]).toMatchObject({
+      callId: 'tc-bash-2',
+      rawOutput: 'second output',
+    });
+  });
+
+  it('falls back to the last execute tool when every status is terminal', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      toolBlock('t1', 'tc-bash', 'completed', 1, {
+        toolName: 'bash',
+        toolKind: 'execute',
+      }),
+      toolBlock('t2', 'tc-read', 'completed', 2, { toolName: 'Read' }),
+      shellBlock('sh1', 'replayed output', 3),
+    ]);
+
+    expect(messages).toHaveLength(1);
+    const tools =
+      messages[0].role === 'tool_group' ? messages[0].tools : undefined;
+    expect(tools?.[0]).toMatchObject({
+      callId: 'tc-bash',
+      rawOutput: 'replayed output',
+    });
+    expect(tools?.[1]?.rawOutput).toBeUndefined();
+  });
+
   it('merges thought across interleaved tool blocks but splits content after tools', () => {
     const messages = transcriptBlocksToDaemonMessages([
       textBlock('t1', 'thought', 'thinking part 1', 1),

--- a/packages/web-shell/client/adapters/transcriptToMessages.test.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.test.ts
@@ -181,7 +181,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
     ]);
   });
 
-  it('keeps TodoWrite blocks as tool messages and does not aggregate tools', () => {
+  it('keeps each TodoWrite call as a distinct tool entry with its own todos', () => {
     const messages = transcriptBlocksToDaemonMessages([
       toolBlock('todo-1', 'todo-call-1', 'completed', 1, {
         title: 'Update Todos',
@@ -211,6 +211,8 @@ describe('transcriptBlocksToDaemonMessages', () => {
       }),
     ]);
 
+    // Adjacent tool blocks share one tool_group (Native CLI batch parity),
+    // but each TodoWrite call keeps its own tool entry and todo payload.
     expect(messages).toEqual([
       {
         id: 'tg-todo-1',
@@ -220,18 +222,107 @@ describe('transcriptBlocksToDaemonMessages', () => {
             callId: 'todo-call-1',
             toolName: 'TodoWrite',
           }),
-        ],
-      },
-      {
-        id: 'tg-todo-2',
-        role: 'tool_group',
-        tools: [
           expect.objectContaining({
             callId: 'todo-call-2',
             toolName: 'TodoWrite',
           }),
         ],
       },
+    ]);
+  });
+
+  it('merges adjacent top-level tool blocks into one tool_group', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      toolBlock('t1', 'tc1', 'completed', 1, { toolName: 'Read' }),
+      toolBlock('t2', 'tc2', 'completed', 2, { toolName: 'Grep' }),
+    ]);
+
+    expect(messages).toEqual([
+      {
+        id: 'tg-t1',
+        role: 'tool_group',
+        tools: [
+          expect.objectContaining({ callId: 'tc1', toolName: 'Read' }),
+          expect.objectContaining({ callId: 'tc2', toolName: 'Grep' }),
+        ],
+      },
+    ]);
+  });
+
+  it('starts a new tool_group after intervening assistant text', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      toolBlock('t1', 'tc1', 'completed', 1, { toolName: 'Read' }),
+      textBlock('a1', 'assistant', 'found it, editing now', 2),
+      toolBlock('t2', 'tc2', 'completed', 3, { toolName: 'Edit' }),
+    ]);
+
+    expect(messages).toMatchObject([
+      { role: 'tool_group', tools: [{ callId: 'tc1' }] },
+      { role: 'assistant', content: 'found it, editing now' },
+      { role: 'tool_group', tools: [{ callId: 'tc2' }] },
+    ]);
+  });
+
+  it('starts a new tool_group after an intervening thought block', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      toolBlock('t1', 'tc1', 'completed', 1, { toolName: 'Read' }),
+      textBlock('th1', 'thought', 'next I should grep', 2),
+      toolBlock('t2', 'tc2', 'completed', 3, { toolName: 'Grep' }),
+    ]);
+
+    expect(messages).toMatchObject([
+      { role: 'tool_group', tools: [{ callId: 'tc1' }] },
+      { role: 'assistant', thinking: 'next I should grep' },
+      { role: 'tool_group', tools: [{ callId: 'tc2' }] },
+    ]);
+  });
+
+  it('keeps merged groups intact when a member tool completes later', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      toolBlock('t1', 'tc1', 'in_progress', 1, { toolName: 'Read' }),
+      toolBlock('t2', 'tc2', 'in_progress', 2, { toolName: 'Grep' }),
+      toolBlock('t1-done', 'tc1', 'completed', 3, {
+        toolName: 'Read',
+        updatedAt: 4,
+      }),
+    ]);
+
+    expect(messages).toHaveLength(1);
+    const tools =
+      messages[0].role === 'tool_group' ? messages[0].tools : undefined;
+    expect(tools).toHaveLength(2);
+    expect(tools?.[0]).toMatchObject({ callId: 'tc1', status: 'completed' });
+    expect(tools?.[1]).toMatchObject({ callId: 'tc2', status: 'in_progress' });
+  });
+
+  it('never merges subagent calls into or after a regular tool_group', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      toolBlock('t1', 'tc1', 'completed', 1, { toolName: 'Read' }),
+      toolBlock('agent-1', 'agent-call-1', 'in_progress', 2, {
+        toolName: 'agent',
+        rawInput: { subagent_type: 'general-purpose' },
+      }),
+      toolBlock('t2', 'tc2', 'completed', 3, { toolName: 'Grep' }),
+    ]);
+
+    expect(messages).toMatchObject([
+      { role: 'tool_group', tools: [{ callId: 'tc1' }] },
+      { role: 'tool_group', tools: [{ callId: 'agent-call-1' }] },
+      { role: 'tool_group', tools: [{ callId: 'tc2' }] },
+    ]);
+  });
+
+  it('does not merge real tool calls into synthetic raw-shell groups', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      textBlock('u1', 'user', 'run it', 1),
+      shellBlock('sh1', 'raw shell output\n', 2),
+      toolBlock('t1', 'tc1', 'completed', 3, { toolName: 'Read' }),
+    ]);
+
+    expect(messages).toMatchObject([
+      { role: 'user', content: 'run it' },
+      { id: 'sh1', role: 'tool_group', tools: [{ toolName: 'shell' }] },
+      { id: 'tg-t1', role: 'tool_group', tools: [{ callId: 'tc1' }] },
     ]);
   });
 
@@ -1936,15 +2027,12 @@ describe('transcriptBlocksToDaemonMessages', () => {
       toolBlock('t3', 'tc3', 'completed', 3, { toolName: 'mygrep' }),
     ]);
 
-    const tool1 =
-      messages[0].role === 'tool_group' ? messages[0].tools[0] : undefined;
-    const tool2 =
-      messages[1].role === 'tool_group' ? messages[1].tools[0] : undefined;
-    const tool3 =
-      messages[2].role === 'tool_group' ? messages[2].tools[0] : undefined;
-    expect(tool1?.kind).toBe('search');
-    expect(tool2?.kind).toBe('search');
-    expect(tool3?.kind).toBeUndefined();
+    expect(messages).toHaveLength(1);
+    const tools =
+      messages[0].role === 'tool_group' ? messages[0].tools : undefined;
+    expect(tools?.[0]?.kind).toBe('search');
+    expect(tools?.[1]?.kind).toBe('search');
+    expect(tools?.[2]?.kind).toBeUndefined();
   });
 
   it('getToolRawOutput fallback returns rawOutput ?? details for non-cancelled', () => {
@@ -2138,17 +2226,16 @@ describe('transcriptBlocksToDaemonMessages', () => {
       }),
     ]);
 
-    const tool1 =
-      messages[0].role === 'tool_group' ? messages[0].tools[0] : undefined;
-    const tool2 =
-      messages[1].role === 'tool_group' ? messages[1].tools[0] : undefined;
-    const tool3 =
-      messages[2].role === 'tool_group' ? messages[2].tools[0] : undefined;
+    // tc1-tc3 are adjacent regular tools and share one group; the trailing
+    // subagent call stays in its own single-tool group.
+    expect(messages).toHaveLength(2);
+    const tools =
+      messages[0].role === 'tool_group' ? messages[0].tools : undefined;
     const tool4 =
-      messages[3].role === 'tool_group' ? messages[3].tools[0] : undefined;
-    expect(tool1?.status).toBe('in_progress');
-    expect(tool2?.status).toBe('pending');
-    expect(tool3?.status).toBe('failed');
+      messages[1].role === 'tool_group' ? messages[1].tools[0] : undefined;
+    expect(tools?.[0]?.status).toBe('in_progress');
+    expect(tools?.[1]?.status).toBe('pending');
+    expect(tools?.[2]?.status).toBe('failed');
     expect(tool4?.status).toBe('completed');
     expect(tool4?.endTime).toBe(5);
   });

--- a/packages/web-shell/client/adapters/transcriptToMessages.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.ts
@@ -242,20 +242,27 @@ export function transcriptBlocksToDaemonMessages(
         const shellBlock = block as DaemonShellTranscriptBlock;
         const lastMsg = messages[messages.length - 1];
         if (lastMsg && lastMsg.role === 'tool_group') {
-          const lastTool = lastMsg.tools[lastMsg.tools.length - 1];
-          if (lastTool) {
+          const targetIdx = findShellOutputTargetIndex(lastMsg.tools);
+          const targetTool = lastMsg.tools[targetIdx];
+          if (targetTool) {
             const previousOutput =
-              typeof lastTool.rawOutput === 'string' ? lastTool.rawOutput : '';
+              typeof targetTool.rawOutput === 'string'
+                ? targetTool.rawOutput
+                : '';
             const nextTool = {
-              ...lastTool,
+              ...targetTool,
               rawOutput: previousOutput + shellBlock.text,
             };
             messages[messages.length - 1] = {
               ...lastMsg,
-              tools: [...lastMsg.tools.slice(0, -1), nextTool],
+              tools: [
+                ...lastMsg.tools.slice(0, targetIdx),
+                nextTool,
+                ...lastMsg.tools.slice(targetIdx + 1),
+              ],
             };
-            if (toolsByCallId.get(lastTool.callId) === lastTool) {
-              toolsByCallId.set(lastTool.callId, nextTool);
+            if (toolsByCallId.get(targetTool.callId) === targetTool) {
+              toolsByCallId.set(targetTool.callId, nextTool);
             }
           }
         } else {
@@ -444,6 +451,34 @@ function appendToolCallMessage(
     role: 'tool_group',
     tools: [toolCall],
   });
+}
+
+/**
+ * Pick which tool in a group should receive a raw shell output chunk.
+ *
+ * Shell transcript blocks carry no toolCallId, so attachment is heuristic.
+ * Single-tool groups (the only shape before adjacent-merge) keep the old
+ * "last tool" behavior. In merged groups, prefer the most recent `execute`
+ * tool that is still running — the scheduler executes one tool at a time, so
+ * that is the tool producing output. On replay every status is already
+ * terminal; fall back to the most recent `execute` tool, then to the last
+ * tool so groups without kind metadata behave exactly as before.
+ */
+function findShellOutputTargetIndex(
+  tools: readonly DaemonMessageToolCall[],
+): number {
+  for (let i = tools.length - 1; i >= 0; i--) {
+    const tool = tools[i];
+    if (tool.kind === 'execute' && tool.status === 'in_progress') {
+      return i;
+    }
+  }
+  for (let i = tools.length - 1; i >= 0; i--) {
+    if (tools[i].kind === 'execute') {
+      return i;
+    }
+  }
+  return tools.length - 1;
 }
 
 function mergeToolCall(

--- a/packages/web-shell/client/adapters/transcriptToMessages.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.ts
@@ -416,6 +416,29 @@ function appendToolCallMessage(
   blockId: string,
   toolCall: DaemonMessageToolCall,
 ): void {
+  // Native CLI groups every tool call of one scheduler batch into a single
+  // bordered tool_group (mapToDisplay in useReactToolScheduler). The daemon
+  // transcript carries no batch marker, so the replay-stable equivalent is
+  // adjacency: a tool block arriving while a tool_group is still the latest
+  // visible message joins that group instead of opening a new box.
+  //
+  // Sub-agent calls stay in their own single-tool groups — MessageList's
+  // groupParallelAgents relies on that shape to render consecutive agent
+  // launches as ParallelAgentsGroup.
+  //
+  // Synthetic raw-shell groups (pushed by the `shell` block fallback) use the
+  // bare block id without the `tg-` prefix and never absorb real tool calls.
+  const last = messages[messages.length - 1];
+  if (
+    last &&
+    last.role === 'tool_group' &&
+    last.id.startsWith('tg-') &&
+    !isSubAgentToolCall(toolCall) &&
+    !last.tools.some(isSubAgentToolCall)
+  ) {
+    last.tools.push(toolCall);
+    return;
+  }
   messages.push({
     id: `tg-${blockId}`,
     role: 'tool_group',


### PR DESCRIPTION
## What this PR does

When the model issues several tool calls with nothing visible between them, the web shell now renders them inside a single tool_group card instead of one card per call, matching the native CLI's batch rendering. A daemon tool block joins the trailing tool_group while that group is still the latest visible message; any intervening visible message (assistant text, thinking, status, user input) starts a new group. Two shapes are deliberately excluded from merging: sub-agent calls keep their own single-tool groups so `groupParallelAgents` can still detect consecutive agent launches and render the ParallelAgentsGroup panel, and synthetic raw-shell groups (bare block id without the `tg-` prefix) never absorb real tool calls.

## Why it's needed

The native CLI batches every tool call of one scheduler turn into a single bordered tool_group (`mapToDisplay` in `useReactToolScheduler`), so parallel tool calls render as one box even in the default non-compact mode. The web-shell adapter instead created a separate single-tool `tool_group` message per daemon tool block, and the existing merge in `MessageList` only runs in compact mode (off by default) — so the same conversation rendered as N separate cards in the web shell. The daemon transcript carries no batch marker, so adjacency is the replay-stable equivalent of the CLI's batch boundary.

## Reviewer Test Plan

### How to verify

1. `npx vitest run --root packages/web-shell` — 207 tests pass; 9 new tests cover adjacent-merge, split on assistant text, split on thought, late completion of a merged member, sub-agent exclusion, the raw-shell synthetic-group guard, and shell-output routing to the running execute tool inside merged groups.
2. Manual: start the daemon, open the web shell, and send a prompt that triggers multiple tool calls in one turn (e.g. ask it to read two files). The calls should render as one card with one row per tool, same as the native CLI; when text/thinking appears between calls, separate cards should still appear.
3. Launch several sub-agents in parallel and confirm they still render as the ParallelAgentsGroup panel rather than merging into one generic card.
4. Trigger a tool that needs approval alongside an auto-approved one; the approval form should render inline at its own row inside the merged card.

### Evidence (Before & After)

Schematic of the same two-call turn (web shell cards):

Before — one card per tool call:

```
[ ● Read package.json   ]
[ ● Grep "tool_group"   ]   ← two separate cards
```

After — one card per adjacent run, matching native CLI:

```
[ ● Read package.json
  ● Grep "tool_group"   ]   ← one card, two rows
```

All 207 web-shell tests pass and the vite build succeeds.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests (`vitest`) and `npm run build --workspace=@qwen-code/web-shell` on macOS; no end-to-end daemon run.

## Risk & Scope

- Main risk or tradeoff: cross-turn tool calls with literally nothing visible between them (textless agentic chains from non-thinking models) now share one card, whereas native CLI non-compact shows one card per turn — the transcript has no batch marker to tell these apart, and the merged rendering matches the existing compact-mode semantics.
- Not validated / out of scope: `packages/webui` (different architecture, no per-tool group pattern), native CLI rendering, adding a turn/batch marker to the daemon protocol.
- Breaking changes / migration notes: none — display-level change only; a merged group reuses the first member's message id, so virtualizer keys stay stable across streaming rebuilds.

## Linked Issues

N/A — reported directly while comparing web shell and native CLI rendering; no tracking issue.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当模型连续发起多个工具调用、且中间没有任何可见内容时，Web Shell 现在会把它们渲染在同一个 tool_group 卡片中，而不是每个调用一张卡片，与 Native CLI 的批次渲染保持一致。当消息列表尾部仍是 tool_group 时，新的 daemon tool block 会加入该组；中间出现任何可见消息（assistant 文本、thinking、status、用户输入）都会开启新组。有两类形态被刻意排除在合并之外：子代理调用保持各自的单 tool 组，使 `groupParallelAgents` 仍能识别连续的代理启动并渲染 ParallelAgentsGroup 面板；raw-shell 合成组（裸 block id，无 `tg-` 前缀）永远不吸收真实工具调用。

## 为什么需要

Native CLI 在 `mapToDisplay`（`useReactToolScheduler`）中把调度器同一轮次的所有工具调用打包成一个带边框的 tool_group，因此即使在默认的非 compact 模式下，并行工具调用也渲染为一个框。而 Web Shell 的 adapter 对每个 daemon tool block 单独创建一条单 tool 的 `tool_group` 消息，`MessageList` 中已有的合并逻辑只在 compact 模式（默认关闭）下生效——同样的对话在 Web Shell 中渲染为 N 张独立卡片。daemon transcript 不携带批次标记，相邻性是 CLI 批次边界在重放下稳定的等价物。

## 审阅者测试计划

### 如何验证

1. `npx vitest run --root packages/web-shell` —— 207 个测试通过；9 个新测试覆盖相邻合并、assistant 文本切断、thought 切断、已合并成员的延迟完成、子代理排除、raw-shell 合成组守卫，以及合并组内 shell 输出路由到正在执行的 execute 工具。
2. 手动验证：启动 daemon，打开 Web Shell，发送一个会在一轮中触发多个工具调用的提示（例如让它读两个文件）。这些调用应渲染为一张卡片、每个工具一行，与 Native CLI 一致；当调用之间出现文本/思考时，仍应显示为独立卡片。
3. 并行启动多个子代理，确认它们仍渲染为 ParallelAgentsGroup 面板，而不是合并成一张普通卡片。
4. 触发一个需要审批的工具与一个自动通过的工具同批执行；审批表单应在合并卡片内对应行内联渲染。

### 证据（修改前后）

同一轮两个调用的示意图（Web Shell 卡片）：

修改前——每个工具调用一张卡片：

```
[ ● Read package.json   ]
[ ● Grep "tool_group"   ]   ← 两张独立卡片
```

修改后——每段相邻调用一张卡片，与 Native CLI 一致：

```
[ ● Read package.json
  ● Grep "tool_group"   ]   ← 一张卡片，两行
```

Web Shell 全部 207 个测试通过，vite 构建通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

在 macOS 上运行单元测试（`vitest`）与 `npm run build --workspace=@qwen-code/web-shell`；未做端到端 daemon 运行。

## 风险与范围

- 主要风险或取舍：跨轮次但中间完全没有可见内容的连续工具调用（非思考模型的无文本 agentic 连击）现在会共享一张卡片，而 Native CLI 非 compact 模式下是每轮一张卡片——transcript 层没有批次标记无法区分这两种情况，且合并后的渲染与现有 compact 模式语义一致。
- 未验证 / 范围之外：`packages/webui`（架构不同，无逐工具建组模式）、Native CLI 渲染、在 daemon 协议中增加轮次/批次标记。
- 破坏性变更 / 迁移说明：无——仅为展示层改动；合并组复用首个成员的消息 id，流式重建过程中 virtualizer key 保持稳定。

## 关联 Issue

N/A —— 在对比 Web Shell 与 Native CLI 渲染时直接发现，无跟踪 issue。

</details>

<img width="3006" height="452" alt="image" src="https://github.com/user-attachments/assets/b2fba82b-10b7-4c29-b0f7-50d5ba325552" />
