### PR TITLE
feat(web-shell): collapse thinking output to a 5-line window

### DIFF
--- a/packages/acp-bridge/src/status.ts
+++ b/packages/acp-bridge/src/status.ts
@@ -674,7 +674,9 @@ export type ServeHookMatcherKind =
   | 'trigger'
   | 'sessionTrigger'
   | 'error'
-  | 'notificationType';
+  | 'notificationType'
+  | 'commandName'
+  | 'filePath';
 
 export interface ServeHookEventMeta {
   description: string;
@@ -792,6 +794,10 @@ export const IDLE_HOOK_EVENTS: Record<HookEventName, ServeHookEventMeta> = {
     matcherKind: 'notificationType',
   },
   UserPromptSubmit: { description: 'When the user submits a prompt' },
+  UserPromptExpansion: {
+    description: 'When a slash command expands into a prompt',
+    matcherKind: 'commandName',
+  },
   SessionStart: {
     description: 'When a new session is started',
     matcherKind: 'sessionTrigger',
@@ -831,6 +837,10 @@ export const IDLE_HOOK_EVENTS: Record<HookEventName, ServeHookEventMeta> = {
   },
   TodoCreated: { description: 'When a new todo item is created' },
   TodoCompleted: { description: 'When a todo item is marked as completed' },
+  InstructionsLoaded: {
+    description: 'When an instruction or context file is loaded',
+    matcherKind: 'filePath',
+  },
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -1274,16 +1274,34 @@ describe('refreshSessionContext', () => {
 
   it('should update session context when telemetry is initialized', () => {
     initializeTelemetry(mockConfig);
-    vi.clearAllMocks();
 
     refreshSessionContext('new-session-id');
 
-    expect(setSessionContext).toHaveBeenCalledWith(undefined, 'new-session-id');
+    expect(createSessionRootContext).toHaveBeenCalledWith('new-session-id');
+    expect(setSessionContext).toHaveBeenCalledWith(
+      { __sessionId: 'new-session-id' },
+      'new-session-id',
+    );
   });
 
   it('should be a no-op when telemetry is not initialized', () => {
+    // Do NOT call initializeTelemetry — telemetryInitialized remains false
     refreshSessionContext('some-session');
 
+    expect(createSessionRootContext).not.toHaveBeenCalled();
+    expect(setSessionContext).not.toHaveBeenCalled();
+  });
+
+  it('should not throw when refreshing session context fails', () => {
+    initializeTelemetry(mockConfig);
+    vi.clearAllMocks();
+    vi.mocked(createSessionRootContext).mockImplementationOnce(() => {
+      throw new Error('session context failed');
+    });
+
+    expect(() => refreshSessionContext('bad-session')).not.toThrow();
+
+    expect(createSessionRootContext).toHaveBeenCalledWith('bad-session');
     expect(setSessionContext).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -584,7 +584,11 @@ export function initializeTelemetry(config: TelemetryRuntimeConfig): void {
  */
 export function refreshSessionContext(sessionId: string): void {
   if (!telemetryInitialized) return;
-  setSessionContext(undefined, sessionId);
+  try {
+    setSessionContext(createSessionRootContext(sessionId), sessionId);
+  } catch (error) {
+    createDebugLogger('OTEL').warn('Failed to refresh session context:', error);
+  }
 }
 
 export async function shutdownTelemetry(): Promise<void> {

--- a/packages/sdk-typescript/src/daemon/types.ts
+++ b/packages/sdk-typescript/src/daemon/types.ts
@@ -1405,6 +1405,7 @@ export type DaemonHookEventName =
   | 'PostToolBatch'
   | 'Notification'
   | 'UserPromptSubmit'
+  | 'UserPromptExpansion'
   | 'SessionStart'
   | 'Stop'
   | 'SubagentStart'
@@ -1417,6 +1418,7 @@ export type DaemonHookEventName =
   | 'StopFailure'
   | 'TodoCreated'
   | 'TodoCompleted'
+  | 'InstructionsLoaded'
   | (string & {});
 
 export type DaemonHookMatcherKind =
@@ -1425,7 +1427,9 @@ export type DaemonHookMatcherKind =
   | 'trigger'
   | 'sessionTrigger'
   | 'error'
-  | 'notificationType';
+  | 'notificationType'
+  | 'commandName'
+  | 'filePath';
 
 export interface DaemonHookEventMeta {
   description: string;

--- a/packages/web-shell/client/components/MessageItem.tsx
+++ b/packages/web-shell/client/components/MessageItem.tsx
@@ -43,6 +43,7 @@ export const MessageItem = memo(function MessageItem({
         <AssistantMessage
           content={message.content}
           thinking={message.thinking}
+          isStreaming={message.isStreaming}
         />
       );
     case 'tool_group':

--- a/packages/web-shell/client/components/messages/AssistantMessage.module.css
+++ b/packages/web-shell/client/components/messages/AssistantMessage.module.css
@@ -70,6 +70,15 @@
   word-break: break-word;
 }
 
+/* Streaming variant: same 5-line window, but scrolled to the tail via JS
+   so the newest thinking stays in view while it streams. */
+.thinkingPreviewTail {
+  max-height: calc(5 * 1.5em);
+  overflow: hidden;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .expandToggle {
   display: block;
   background: none;

--- a/packages/web-shell/client/components/messages/AssistantMessage.tsx
+++ b/packages/web-shell/client/components/messages/AssistantMessage.tsx
@@ -14,37 +14,53 @@ import styles from './AssistantMessage.module.css';
 interface AssistantMessageProps {
   content: string;
   thinking?: string;
+  isStreaming?: boolean;
 }
 
 export const AssistantMessage = memo(function AssistantMessage({
   content,
   thinking,
+  isStreaming,
 }: AssistantMessageProps) {
   const compactMode = useContext(CompactModeContext);
   const { compactThinking } = useWebShellCustomization();
   const [thinkingExpanded, setThinkingExpanded] = useState(false);
   const [overflowing, setOverflowing] = useState(false);
   const previewRef = useRef<HTMLDivElement>(null);
-  const thinkingExpandedRef = useRef(thinkingExpanded);
 
   const collapsed = compactThinking && !thinkingExpanded;
-  thinkingExpandedRef.current = thinkingExpanded;
+  // While thinking is still streaming (no content yet), the collapsed
+  // preview follows the tail so the latest thought stays visible.
+  const streamingTail = collapsed && !!isStreaming && !content;
+
+  // Re-check on content growth: the clamped box stops resizing once it
+  // hits 5 lines, so a ResizeObserver alone misses later overflow.
+  useEffect(() => {
+    const el = previewRef.current;
+    if (!el || !collapsed) return;
+    setOverflowing(el.scrollHeight > el.clientHeight);
+  }, [collapsed, thinking]);
 
   useEffect(() => {
     const el = previewRef.current;
-    if (!el || !compactThinking) return;
+    if (!el || !collapsed) return;
 
     const check = () => {
-      if (thinkingExpandedRef.current) return;
       setOverflowing(el.scrollHeight > el.clientHeight);
     };
-
-    check();
 
     const observer = new ResizeObserver(check);
     observer.observe(el);
     return () => observer.disconnect();
-  }, [compactThinking, thinkingExpanded]);
+  }, [collapsed]);
+
+  useEffect(() => {
+    const el = previewRef.current;
+    if (!el || !collapsed) return;
+    // Tail mode pins the newest line into view; when streaming ends the
+    // same element switches back to line-clamp, which needs scrollTop 0.
+    el.scrollTop = streamingTail ? el.scrollHeight : 0;
+  }, [collapsed, streamingTail, thinking]);
 
   const handleToggle = useCallback(() => {
     setThinkingExpanded((v) => !v);
@@ -58,10 +74,17 @@ export const AssistantMessage = memo(function AssistantMessage({
           <div className={styles.thinkingBody}>
             {collapsed ? (
               <div className={styles.thinkingPreviewWrap}>
-                <div ref={previewRef} className={styles.thinkingPreview}>
+                <div
+                  ref={previewRef}
+                  className={
+                    streamingTail
+                      ? styles.thinkingPreviewTail
+                      : styles.thinkingPreview
+                  }
+                >
                   {thinking}
                 </div>
-                {compactThinking && overflowing && (
+                {overflowing && (
                   <button
                     className={styles.expandToggle}
                     onClick={handleToggle}

--- a/packages/web-shell/client/components/messages/tools/SubAgentPanel.module.css
+++ b/packages/web-shell/client/components/messages/tools/SubAgentPanel.module.css
@@ -78,6 +78,27 @@
   overflow-y: auto;
 }
 
+/* Compact live stream: 5-line window pinned to the tail via JS. */
+.streamCollapsed {
+  max-height: calc(5 * 1.6em);
+  overflow: hidden;
+}
+
+.streamToggle {
+  display: block;
+  margin: 2px 0 0 auto;
+  background: none;
+  border: none;
+  color: color-mix(in srgb, var(--text-dimmed) 60%, transparent);
+  font-size: 12px;
+  cursor: pointer;
+  padding: 0 4px;
+}
+
+.streamToggle:hover {
+  color: var(--text-dimmed);
+}
+
 .tabBar {
   display: flex;
   gap: 0;

--- a/packages/web-shell/client/components/messages/tools/SubAgentPanel.tsx
+++ b/packages/web-shell/client/components/messages/tools/SubAgentPanel.tsx
@@ -1,5 +1,6 @@
-import { memo, useState, useMemo } from 'react';
+import { memo, useEffect, useRef, useState, useMemo } from 'react';
 import type { ACPToolCall } from '../../../adapters/types';
+import { useWebShellCustomization } from '../../../customization';
 import { Markdown } from '../Markdown';
 import {
   formatDurationMs,
@@ -173,6 +174,60 @@ function getAgentResultText(tool: ACPToolCall): string {
 
 type SubAgentTab = 'result' | 'tools';
 
+/**
+ * Live sub-agent stream (thinking + output) shown while the agent runs.
+ * With compactThinking enabled it collapses to a 5-line window pinned to
+ * the newest content, with a toggle to the full scrollable view.
+ */
+function SubAgentStream({ text }: { text: string }) {
+  const { compactThinking } = useWebShellCustomization();
+  const [streamExpanded, setStreamExpanded] = useState(false);
+  const [overflowing, setOverflowing] = useState(false);
+  const streamRef = useRef<HTMLPreElement>(null);
+
+  const collapsed = compactThinking && !streamExpanded;
+
+  useEffect(() => {
+    const el = streamRef.current;
+    if (!el || !collapsed) return;
+    setOverflowing(el.scrollHeight > el.clientHeight);
+    // Pin the newest line into view while the stream grows.
+    el.scrollTop = el.scrollHeight;
+  }, [collapsed, text]);
+
+  useEffect(() => {
+    const el = streamRef.current;
+    if (!el || !collapsed) return;
+    const check = () => setOverflowing(el.scrollHeight > el.clientHeight);
+    const observer = new ResizeObserver(check);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [collapsed]);
+
+  return (
+    <div>
+      <pre
+        ref={streamRef}
+        className={
+          collapsed ? `${styles.stream} ${styles.streamCollapsed}` : styles.stream
+        }
+      >
+        {text}
+      </pre>
+      {compactThinking && (overflowing || streamExpanded) && (
+        <button
+          className={styles.streamToggle}
+          onClick={() => setStreamExpanded((v) => !v)}
+          aria-expanded={streamExpanded}
+          aria-label="Toggle agent stream details"
+        >
+          {streamExpanded ? '▲' : '▼'}
+        </button>
+      )}
+    </div>
+  );
+}
+
 export function SubAgentPanel({
   tool,
   defaultExpanded,
@@ -256,9 +311,7 @@ export function SubAgentPanel({
               {isComplete ? (
                 <Markdown content={tool.subContent || resultText} />
               ) : (
-                tool.subContent && (
-                  <pre className={styles.stream}>{tool.subContent}</pre>
-                )
+                tool.subContent && <SubAgentStream text={tool.subContent} />
               )}
             </div>
           )}

--- a/packages/web-shell/client/main.tsx
+++ b/packages/web-shell/client/main.tsx
@@ -110,6 +110,7 @@ function StandaloneApp() {
           onThemeChange={handleThemeChange}
           language={language}
           onLanguageChange={handleLanguageChange}
+          compactThinking
         />
       </DaemonSessionProvider>
     </DaemonWorkspaceProvider>


### PR DESCRIPTION
## What this PR does

Collapses thinking output in the Web Shell to a bounded 5-line window. While thinking is streaming, the window follows the newest lines (tail mode); once the stream finishes it shows the first five lines with a ▼/▲ toggle to expand or re-collapse. The same treatment now covers live sub-agent streams in the agent panel (both the single-agent and parallel-agents render paths), which previously rendered as a tall scroll area pinned to the oldest content. The standalone daemon-served shell enables collapse by default; the embedder API keeps `compactThinking` opt-in, so npm consumers see no behavior change. A separate commit completes the half-applied 0610 origin/main merge that had broken the workspace build (and therefore `npm run dev:daemon`).

## Why it's needed

Long thinking output flooded the screen and made sessions unreadable. The collapse machinery has existed since #4867 but was never enabled for the standalone shell, and sub-agent thought streams had no collapse at all — measured on a live `/review` session, ~88% of thought chunks (5203 of 5945) came from sub-agents, so fixing only the main-agent path would not have solved the user-visible problem. Separately, `npm run dev:daemon` failed to boot: the 0610 merge (44b936b73) brought in main's test mock and import of `createSessionRootContext` while keeping the old `refreshSessionContext` implementation and assertions, leaving a dead import that fails `tsc` under `noUnusedLocals`; the same merge also missed the branch-only `IDLE_HOOK_EVENTS` table when main added `UserPromptExpansion` / `InstructionsLoaded` to `HookEventName`. With the workspace build broken, the stale `acp-bridge` dist (missing `BranchWhilePromptActiveError`) could not be rebuilt, so the daemon crashed at module load.

## Reviewer Test Plan

### How to verify

1. Build fix: `npm install && npm run dev:daemon`. Before this PR the daemon crashed at boot with `SyntaxError: The requested module '@qwen-code/acp-bridge/bridgeErrors' does not provide an export named 'BranchWhilePromptActiveError'`, and `npm run build` failed in `packages/core` (TS6133 unused import in `telemetry/sdk.test.ts`) and `packages/acp-bridge` (TS2739 missing keys in `IDLE_HOOK_EVENTS`). After: full `npm run build` is green and the daemon boots and serves the shell.
2. Main-agent collapse: in the opened web shell (http://localhost:5173), send a prompt that produces long thinking. Expected: while streaming, the thinking block stays 5 lines tall and follows the newest lines; after completion it shows the first 5 lines with a ▼ button at the bottom right; clicking expands the full Markdown and ▲ re-collapses.
3. Sub-agent collapse: run a skill that spawns sub-agents (e.g. `/review <pr-url>`), click an agent row to open its panel while it is running. Expected: the live stream is a 5-line window following the newest output with a ▼ toggle to the previous full scroll view; completed-agent details keep the existing click-to-open behavior.
4. Embedder regression: render `WebShellWithProviders` without `compactThinking` — thinking renders fully expanded with no toggle (unchanged default).
5. Suites: `npm test --workspace=packages/web-shell` (198/198 incl. build-artifact boundary tests), core `telemetry/sdk.test.ts` (59/59), acp-bridge (416/416), cli hooks-related `acpAgent` tests, eslint clean on touched files.

### Evidence (Before & After)

Before: thinking rendered unbounded — hundreds of lines during long reasoning streams — and opening a running agent panel showed a 400px `overflow-y: auto` stream that stayed at the oldest content. After: both render as a 5-line window pinned to the newest line, with an explicit ▼/▲ control to reach the full content. No screenshots attached (browser UI); reproduce with steps 2–3 above. Verified live against a running dev server: the served `main.tsx` module contains `compactThinking: true`, and the SSE replay of a real `/review` session confirmed the 5203 sub-agent / 742 main-agent thought-chunk split that motivated covering both render paths.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npm run dev:daemon` (tsx-driven daemon on :4170 + vite dev server on :5173), Node v22.22.2, macOS.

## Risk & Scope

- Main risk or tradeoff: the standalone shell changes its default — thinking is collapsed instead of fully rendered. Mitigated by the per-block expand toggle; embedders are unaffected because the `compactThinking` prop still defaults to `false`.
- Not validated / out of scope: Windows/Linux manual runs (CI covers builds/tests); expanded-state persistence across virtual-list recycling (pre-existing behavior since #4867 — scrolling far away and back resets a block to collapsed); webui chat components (`ThinkingMessage`) are a separate surface and untouched.
- Breaking changes / migration notes: none. The serve/SDK type additions (`commandName` / `filePath` matcher kinds, two hook event names) are additive, and `DaemonHookEventName` already had a `(string & {})` forward-compat arm.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 Web Shell 中的思考过程输出折叠为固定 5 行的窗口。思考流式输出期间，窗口跟随最新内容（尾随模式）；输出结束后显示前 5 行，并提供 ▼/▲ 按钮展开或重新折叠。子代理面板中的实时输出流（单代理和并行代理两条渲染路径）也采用同样的处理——此前它是一个停留在最旧内容、不跟随尾部的高滚动区域。daemon 直接服务的独立 Web Shell 默认启用折叠；嵌入方 API 的 `compactThinking` 保持可选（默认关闭），npm 使用方行为不变。另有一个独立 commit 补完了 0610 合并 origin/main 时留下的半截合并，该问题导致 workspace 构建失败（进而导致 `npm run dev:daemon` 无法启动）。

## 为什么需要

思考内容太长会刷满屏幕，会话无法阅读。折叠机制自 #4867 起就存在，但从未对独立 Shell 启用；子代理的思考流则完全没有折叠——在一个真实的 `/review` 会话上实测，约 88% 的思考块（5945 个中的 5203 个）来自子代理，因此只修主代理路径无法解决用户可见的问题。另外，`npm run dev:daemon` 无法启动：0610 的合并（44b936b73）把 main 测试文件中的 mock 和 `createSessionRootContext` import 带了进来，却保留了旧版 `refreshSessionContext` 实现和断言，留下的死 import 在 `noUnusedLocals` 下使 `tsc` 失败；同一次合并还遗漏了本分支特有的 `IDLE_HOOK_EVENTS` 表——main 已向 `HookEventName` 新增 `UserPromptExpansion` / `InstructionsLoaded` 两个事件。由于 workspace 构建已坏，过期的 `acp-bridge` 产物（缺少 `BranchWhilePromptActiveError` 导出）无法重新构建，daemon 在模块加载时直接崩溃。

## Reviewer 测试计划

### 如何验证

1. 构建修复：`npm install && npm run dev:daemon`。本 PR 之前 daemon 启动即崩溃，报 `SyntaxError: The requested module '@qwen-code/acp-bridge/bridgeErrors' does not provide an export named 'BranchWhilePromptActiveError'`，且 `npm run build` 在 `packages/core`（`telemetry/sdk.test.ts` 的 TS6133 未使用 import）和 `packages/acp-bridge`（`IDLE_HOOK_EVENTS` 缺键的 TS2739）处失败。修复后：完整 `npm run build` 通过，daemon 正常启动并服务 Shell。
2. 主代理折叠：在打开的 Web Shell（http://localhost:5173）中发送一个会产生长思考的提示词。预期：流式期间思考块保持 5 行高并跟随最新内容；完成后显示前 5 行，右下角出现 ▼ 按钮；点击展开完整 Markdown，▲ 重新折叠。
3. 子代理折叠：运行会派生子代理的技能（如 `/review <pr-url>`），在运行期间点击某个代理行打开其面板。预期：实时流是一个跟随最新输出的 5 行窗口，▼ 可切换到原先的完整滚动视图；已完成代理的详情保持原有的点击展开行为。
4. 嵌入方回归：不传 `compactThinking` 渲染 `WebShellWithProviders`——思考完整展开且无切换按钮（默认行为不变）。
5. 测试套件：`npm test --workspace=packages/web-shell`（198/198，含构建产物边界测试）、core `telemetry/sdk.test.ts`（59/59）、acp-bridge（416/416）、cli 中 hooks 相关的 `acpAgent` 测试，改动文件 eslint 全部干净。

### 证据（Before & After）

Before：思考无上限渲染——长推理流式期间达数百行；打开运行中的代理面板是一个停留在最旧内容的 400px `overflow-y: auto` 滚动区。After：两者都渲染为钉住最新行的 5 行窗口，并有明确的 ▼/▲ 控件可查看完整内容。未附截图（浏览器 UI），可按上述步骤 2–3 复现。已对运行中的 dev server 实测验证：vite 服务的 `main.tsx` 模块包含 `compactThinking: true`；对真实 `/review` 会话的 SSE 回放统计确认了 5203（子代理）/ 742（主代理）的思考块分布，这正是需要覆盖两条渲染路径的依据。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

`npm run dev:daemon`（tsx 驱动的 daemon 跑在 :4170 + vite dev server 跑在 :5173），Node v22.22.2，macOS。

## 风险与范围

- 主要风险或权衡：独立 Shell 的默认行为改变——思考默认折叠而非完整渲染。每个块都有展开按钮兜底；嵌入方不受影响（`compactThinking` prop 默认仍为 `false`）。
- 未验证 / 范围之外：Windows/Linux 手工运行（构建/测试由 CI 覆盖）；虚拟列表回收导致的展开状态不持久（#4867 起的既有行为——滚远再滚回，块会重置为折叠态）；webui 聊天组件（`ThinkingMessage`）属于另一套界面，本次未改动。
- 破坏性变更 / 迁移说明：无。serve/SDK 的类型新增（`commandName` / `filePath` 两种 matcher、两个 hook 事件名）均为增量；`DaemonHookEventName` 本就有 `(string & {})` 前向兼容分支。

## 关联 Issue

无。

</details>

<img width="2992" height="312" alt="image" src="https://github.com/user-attachments/assets/34e1663f-796e-463b-90e4-0f5f366b3d93" />


<img width="3000" height="668" alt="image" src="https://github.com/user-attachments/assets/4b945fed-112a-4979-8ef9-3610a82c0934" />
