### PR TITLE
fix(core): preserve teammate identity when resuming a tool call after approval

### DIFF
--- a/packages/core/src/agents/runtime/agent-core.test.ts
+++ b/packages/core/src/agents/runtime/agent-core.test.ts
@@ -15,6 +15,13 @@ import {
   type RuntimeContentGeneratorView,
 } from './agent-context.js';
 import { subagentNameContext } from '../../utils/subagentNameContext.js';
+import {
+  getAgentName,
+  getTeammateContext,
+  isTeammate,
+  runWithTeammateIdentity,
+} from '../team/identity.js';
+import type { TeammateIdentity } from '../team/types.js';
 import type { Config } from '../../config/config.js';
 import type {
   ModelConfig,
@@ -211,6 +218,48 @@ describe('AgentCore.runInAgentFrames', () => {
     await respondClosure!();
 
     expect(observedAgentId).toBe('agent-123');
+  });
+
+  it('restores the teammate identity for deferred-approval continuations', async () => {
+    // Regression: a teammate's `send_message`/`task_update` that requires
+    // confirmation resumes from the UI's async chain, outside the
+    // teammate identity frame TeamManager established. Before the fix,
+    // `getAgentName()` returned undefined there and send_message fell back
+    // to the leader — forging a `from="leader"` envelope and slipping past
+    // the leader-only `isTeammate()` guard. The respond closure must carry
+    // the identity captured at emit time back into the resumed tool body.
+    const core = makeCore('approval-agent');
+    const teammateIdentity: TeammateIdentity = {
+      agentId: 'scribe@demo',
+      agentName: 'scribe',
+      teamName: 'demo',
+      isTeamLead: false,
+    };
+
+    let respondClosure: (() => Promise<void>) | undefined;
+    let observedAgentName: string | undefined;
+    let observedIsTeammate: boolean | undefined;
+    const onConfirm = async () => {
+      observedAgentName = getAgentName();
+      observedIsTeammate = isTeammate();
+    };
+
+    // Simulate the teammate's loop frame being live at emit time.
+    await runWithTeammateIdentity(teammateIdentity, async () => {
+      const inherited = getTeammateContext();
+      respondClosure = () =>
+        core.runInAgentFrames(onConfirm, undefined, undefined, inherited);
+    });
+
+    // Teammate frame is gone; jump to a fresh microtask chain to be sure.
+    expect(getAgentName()).toBeUndefined();
+    expect(isTeammate()).toBe(false);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    await respondClosure!();
+
+    expect(observedAgentName).toBe('scribe');
+    expect(observedIsTeammate).toBe(true);
   });
 
   it("prefers the agent's own view over inheritedView when both are present", async () => {

--- a/packages/core/src/agents/runtime/agent-core.ts
+++ b/packages/core/src/agents/runtime/agent-core.ts
@@ -76,7 +76,12 @@ import { matchesMcpPattern } from '../../permissions/rule-parser.js';
 import { ToolNames } from '../../tools/tool-names.js';
 import { DEFAULT_QWEN_MODEL } from '../../config/models.js';
 import { type ContextState, templateString } from './agent-headless.js';
-import { isTeammate } from '../team/identity.js';
+import {
+  isTeammate,
+  getTeammateContext,
+  runWithTeammateIdentity,
+} from '../team/identity.js';
+import type { TeammateIdentity } from '../team/types.js';
 
 /**
  * Result of a single reasoning loop invocation.
@@ -572,6 +577,15 @@ export class AgentCore {
    * from the parent UI chain, after the subagent's AsyncLocalStorage frame
    * has unwound.
    *
+   * `inheritedTeammateIdentity` restores the in-process teammate identity
+   * frame (`teammateIdentityStore`). Deferred approval needs it for the
+   * same reason as the others: when a teammate's `send_message` /
+   * `task_update` resumes from the UI chain, `getAgentName()` would
+   * otherwise be undefined and the tool would mis-attribute the message
+   * to the leader (forged `from="leader"` envelope) and slip past the
+   * leader-only `isTeammate()` guard. No-op on the reasoning-loop path,
+   * where TeamManager already establishes this frame.
+   *
    * Exposed (rather than inlined twice) so the contract stays testable in
    * isolation; see `agent-core.test.ts`.
    */
@@ -579,13 +593,18 @@ export class AgentCore {
     fn: () => Promise<T>,
     inheritedView?: RuntimeContentGeneratorView,
     inheritedAgentId?: string,
+    inheritedTeammateIdentity?: TeammateIdentity,
   ): Promise<T> {
-    return subagentNameContext.run(this.name, () => {
-      const runWithView = () => this.withRuntimeView(fn, inheritedView);
-      return inheritedAgentId
-        ? runWithAgentContext(inheritedAgentId, runWithView)
-        : runWithView();
-    });
+    const runInner = () =>
+      subagentNameContext.run(this.name, () => {
+        const runWithView = () => this.withRuntimeView(fn, inheritedView);
+        return inheritedAgentId
+          ? runWithAgentContext(inheritedAgentId, runWithView)
+          : runWithView();
+      });
+    return inheritedTeammateIdentity
+      ? runWithTeammateIdentity(inheritedTeammateIdentity, runInner)
+      : runInner();
   }
 
   /**
@@ -1243,6 +1262,11 @@ export class AgentCore {
             // restore it. See `runInAgentFrames` for the wiring.
             const inheritedView = getRuntimeContentGenerator();
             const inheritedAgentId = getCurrentAgentId();
+            // Capture the teammate identity frame too, while the loop
+            // frame is still live, so the deferred-approval continuation
+            // can restore it. See `runInAgentFrames` for why this matters
+            // (mis-attributed `from="leader"` + leader-guard bypass).
+            const inheritedTeammateIdentity = getTeammateContext();
             this.eventEmitter?.emit(AgentEventType.TOOL_WAITING_APPROVAL, {
               subagentId: this.subagentId,
               round: currentRound,
@@ -1272,6 +1296,7 @@ export class AgentCore {
                   () => waiting.confirmationDetails.onConfirm(outcome, payload),
                   inheritedView,
                   inheritedAgentId ?? undefined,
+                  inheritedTeammateIdentity,
                 );
               },
               timestamp: Date.now(),


### PR DESCRIPTION
## What this PR does

In the default approval mode, when a teammate sends a message to the leader and you approve it at the confirmation prompt, the message is now correctly attributed to that teammate. Previously it was mislabeled as coming from the leader.

## Why it's needed

With a team running in the default approval mode, a teammate's message to the leader pauses for your confirmation. After you approved it, the system lost track of which teammate was acting and treated the message as if the leader had sent it. Two consequences:

- The leader's view announced "leader reported back" instead of the teammate's name, and the model driving the leader was told the message came from the leader — corrupting the conversation it reasons over.
- The same identity loss let a teammate's privileged control message (a shutdown request, which is supposed to be leader-only) pass the leader-only check.

This fired on every approved teammate message in the default approval mode. The `yolo` and headless paths were unaffected, because they don't pause for a confirmation round-trip.

## Reviewer Test Plan

### How to verify

1. Build, then run interactively with the experimental team feature enabled and the default approval mode:
   - `QWEN_CODE_ENABLE_AGENT_TEAM=1 node dist/cli.js --approval-mode default`
2. Ask the leader to create a one-teammate team and give the teammate a task to send the leader a one-line greeting, e.g.:
   > Create a team named demo with one teammate named scribe. Give scribe this task: use send_message to send the leader a one-line greeting, then stop. After scribe reports back, say DONE.
3. Open the teammate's tab and approve its message-to-leader at the confirmation prompt.
4. Switch back to the Main view and read the report line.

- **Expected (this PR):** Main shows `● scribe reported back`.
- **Before (regression):** Main showed `● leader reported back`, and the leader narrated the teammate as "appearing as 'leader' in the message routing".

### Evidence (Before & After)

| Scenario (default approval mode, teammate → leader message) | Before | After |
| --- | --- | --- |
| Main-view report line after approval | `● leader reported back` | `● scribe reported back` |
| Leader's model-facing message attribution | `from="leader"` (forged) | `from="scribe"` |
| Leader-only guard on teammate shutdown request | bypassable | enforced |

Full E2E walkthrough posted as a comment below.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local bundled build (`node dist/cli.js`), interactive tmux session, real model (glm-5.1 via OpenAI-compatible auth). New unit regression test added for the resume path.

## Risk & Scope

- Main risk or tradeoff: the change is on the shared post-approval resume path used by all subagents, not only teammates. The restored context is applied only when a teammate identity was actually captured, so non-team subagents are a no-op.
- Not validated / out of scope: the other deferred hardening items for this feature are tracked separately as their own follow-ups.
- Breaking changes / migration notes: none — the feature is behind the experimental flag.

## Linked Issues

Fast-follow on #4844 (Agent Team). Fixes **Finding B** from @wenshao's maintainer-verification of that PR ([#4844 comment](https://github.com/QwenLM/qwen-code/pull/4844#issuecomment-4674777386)). Companion follow-up: #4981. Full background in the comment below.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在默认审批模式下,当队友给 leader 发消息、而你在确认提示处批准之后,该消息现在能正确归属到这名队友。此前它会被错误地标记为来自 leader。

## 为什么需要

当团队运行在默认审批模式下,队友发给 leader 的消息会暂停等待你确认。在你批准之后,系统丢失了"当前是哪名队友在执行"的上下文,于是把这条消息当作 leader 自己发的。由此带来两个后果:

- leader 的视图会显示 "leader reported back",而不是队友的名字;驱动 leader 的模型也被告知消息来自 leader——污染了它所推理的对话内容。
- 同样的身份丢失,会让队友的特权控制消息(shutdown 请求,本应仅限 leader)绕过"仅 leader"校验。

在默认审批模式下,每一条被批准的队友消息都会触发该问题。`yolo` 和 headless 路径不受影响,因为它们不会经过确认往返。

## 复核测试方案

### 如何验证

1. 构建后,在启用实验性团队特性并使用默认审批模式下交互式运行:
   - `QWEN_CODE_ENABLE_AGENT_TEAM=1 node dist/cli.js --approval-mode default`
2. 让 leader 创建一个只含一名队友的团队,并给队友一个任务:用 send_message 给 leader 发一行问候,然后停止。例如:
   > Create a team named demo with one teammate named scribe. Give scribe this task: use send_message to send the leader a one-line greeting, then stop. After scribe reports back, say DONE.
3. 打开队友的标签页,在确认提示处批准它发给 leader 的消息。
4. 切回 Main 视图,查看汇报行。

- **预期(本 PR):** Main 显示 `● scribe reported back`。
- **修复前(回归):** Main 显示 `● leader reported back`,且 leader 会叙述该队友"在消息路由中表现为 'leader'"。

### 证据(前后对比)

| 场景(默认审批模式,队友→leader 消息) | 修复前 | 修复后 |
| --- | --- | --- |
| 批准后 Main 视图的汇报行 | `● leader reported back` | `● scribe reported back` |
| leader 面向模型的消息归属 | `from="leader"`(伪造) | `from="scribe"` |
| 队友 shutdown 请求的"仅 leader"校验 | 可绕过 | 已强制 |

完整 E2E 走查见下方评论。

### 风险与范围

- 主要风险/权衡:改动位于所有子代理共用的审批后恢复路径,不仅限于队友。仅在确实捕获到队友身份时才恢复上下文,因此对非团队子代理是空操作。
- 未验证/范围之外:该特性其余的加固项作为各自独立的后续 PR 单独跟踪。
- 破坏性变更/迁移说明:无——该特性处于实验性 flag 之后。

</details>
