### PR TITLE
Fix release workspace test failures

### DIFF
--- a/packages/cli/src/ui/utils/statsDataService.test.ts
+++ b/packages/cli/src/ui/utils/statsDataService.test.ts
@@ -312,12 +312,13 @@ describe('loadStatsData - new fields', () => {
       now.getMonth(),
       now.getDate(),
     );
+    const todayTimestamp = Math.max(todayStart.getTime(), now.getTime() - 1000);
     const yesterdayMid = todayStart.getTime() - 12 * 60 * 60 * 1000; // yesterday noon
 
     const todayRecord = makeRecord({
       sessionId: 'today-1',
-      timestamp: todayStart.getTime() + 3600000,
-      startTime: todayStart.getTime() + 3600000 - 60000,
+      timestamp: todayTimestamp,
+      startTime: todayTimestamp - 60000,
       durationMs: 60000,
       totalLatencyMs: 1000,
       models: {

--- a/packages/core/src/subagents/index.ts
+++ b/packages/core/src/subagents/index.ts
@@ -42,9 +42,9 @@ export { SubagentValidator } from './validation.js';
 // live in `agent-frontmatter-schema.ts` and are intentionally NOT
 // re-exported here — they are internal to the `SubagentManager` /
 // `claude-converter` parse paths and locking their names in the
-// package's public API would constrain follow-up PRs (e.g. when
-// `js-yaml` lands and the schema shape changes). Re-introduce specific
-// exports here when a cross-package caller actually needs them.
+// package's public API would constrain follow-up schema changes.
+// Re-introduce specific exports here when a cross-package caller actually
+// needs them.
 
 // Main management class
 export { SubagentManager } from './subagent-manager.js';

--- a/packages/core/src/utils/yaml-parser.test.ts
+++ b/packages/core/src/utils/yaml-parser.test.ts
@@ -308,39 +308,22 @@ describe('yaml-parser', () => {
       });
     });
 
-    // The following two tests pin known limitations of this lightweight YAML
-    // parser that surfaced while porting Claude Code's declarative-agent
-    // schema (see docs/declarative-agents-port.md). They will FAIL when the
-    // parser gains real nested-YAML support (e.g. after switching to
-    // `js-yaml`) — that failure is the signal to revisit the
-    // `mcpServers` / `hooks` carve-outs in SubagentManager and the
-    // documentation around them.
-    describe('known limitations — nested YAML (pin until js-yaml lands)', () => {
-      it('garbles array-of-records: deeper keys leak to parent scope', () => {
+    describe('nested YAML', () => {
+      it('parses array-of-records', () => {
         const yaml =
           'mcpServers:\n  - filesystem:\n      type: stdio\n      command: node';
         const result = parse(yaml);
-        // What we'd ideally get: { mcpServers: [{ filesystem: { type: 'stdio', command: 'node' } }] }
-        // What the lightweight parser actually returns: the list item is read
-        // as the bare key string "filesystem:" and the deeper indented keys
-        // become siblings of mcpServers at the top level.
-        expect(result['mcpServers']).toEqual(['filesystem:']);
-        expect(result['type']).toBe('stdio');
-        expect(result['command']).toBe('node');
+        expect(result['mcpServers']).toEqual([
+          { filesystem: { type: 'stdio', command: 'node' } },
+        ]);
       });
 
-      it('garbles record-of-records: deeper keys leak into the record', () => {
+      it('parses record-of-records with arrays', () => {
         const yaml = 'hooks:\n  PreToolUse:\n    - matcher: Read';
         const result = parse(yaml);
-        // Ideal: { hooks: { PreToolUse: [{ matcher: 'Read' }] } }
-        // Actual: nested list-item parsed as a sibling key with the dash
-        // pasted into the key.
-        expect((result['hooks'] as Record<string, unknown>)['PreToolUse']).toBe(
-          '',
-        );
-        expect((result['hooks'] as Record<string, unknown>)['- matcher']).toBe(
-          'Read',
-        );
+        expect(result['hooks']).toEqual({
+          PreToolUse: [{ matcher: 'Read' }],
+        });
       });
     });
   });


### PR DESCRIPTION
## What this PR does

This PR fixes the scheduled Release workflow workspace-test failures by making the stats delta test independent of the time of day and by updating the YAML parser assertions to match the parser behavior currently on `main`.

It also removes a stale internal comment that still described the YAML parser migration as future work.

## Why it's needed

The failed CI run was [Release / Quality Checks #27315318446](https://github.com/QwenLM/qwen-code/actions/runs/27315318446/job/80694783621). It failed in two places: the stats test created a “today” record one hour after midnight, which is a future timestamp when CI runs shortly after midnight, and the YAML parser tests expected nested YAML to be garbled even though the parser now uses the full `yaml` package.

The stats regression came from [#4779](https://github.com/QwenLM/qwen-code/pull/4779). The stale YAML expectations came from [#4842](https://github.com/QwenLM/qwen-code/pull/4842), after [#4870](https://github.com/QwenLM/qwen-code/pull/4870) had already added full YAML parser support.

## Reviewer Test Plan

### How to verify

Confirm the targeted tests pass and that the broader build/typecheck gate still succeeds. The relevant local checks are `cd packages/cli && npx vitest run src/ui/utils/statsDataService.test.ts`, `cd packages/core && npx vitest run src/utils/yaml-parser.test.ts`, and `npm run build && npm run typecheck`.

### Evidence (Before & After)

Before: the scheduled Release run failed with `expected -100 to be close to +0` in the stats delta test and two YAML parser expectation failures for nested `mcpServers` / `hooks` input.

After: the targeted stats and YAML parser test files pass locally, and `npm run build && npm run typecheck` exits successfully.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node v22.18.0, npm 10.9.3.

## Risk & Scope

- Main risk or tradeoff: The change is limited to test expectations and a stale comment; runtime behavior is unchanged.
- Not validated / out of scope: Full workspace tests and cross-platform local runs were not run.
- Breaking changes / migration notes: None.

## Linked Issues

References [#4779](https://github.com/QwenLM/qwen-code/pull/4779), [#4842](https://github.com/QwenLM/qwen-code/pull/4842), and failed CI run [27315318446](https://github.com/QwenLM/qwen-code/actions/runs/27315318446/job/80694783621).

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 修复了定时 Release 工作流中的 workspace 测试失败：一处是让 stats delta 测试不再依赖当天的具体时间，另一处是把 YAML parser 的断言更新为当前 `main` 分支上真实的解析行为。

它还移除了一个过期的内部注释，该注释仍然把 YAML parser 迁移描述成未来工作。

## Why it's needed

失败的 CI 运行是 [Release / Quality Checks #27315318446](https://github.com/QwenLM/qwen-code/actions/runs/27315318446/job/80694783621)。它有两处失败：stats 测试把 “today” 记录放在午夜后一小时，因此当 CI 在午夜后不久运行时这个时间戳仍然属于未来；YAML parser 测试则仍然预期嵌套 YAML 会被错误解析，但当前 parser 已经使用完整的 `yaml` 包。

stats 回归来自 [#4779](https://github.com/QwenLM/qwen-code/pull/4779)。过期的 YAML 断言来自 [#4842](https://github.com/QwenLM/qwen-code/pull/4842)，而 [#4870](https://github.com/QwenLM/qwen-code/pull/4870) 已经在此之前加入了完整 YAML parser 支持。

## Reviewer Test Plan

### How to verify

确认相关的定向测试通过，并确认更广的 build/typecheck 门禁仍然成功。对应的本地检查是 `cd packages/cli && npx vitest run src/ui/utils/statsDataService.test.ts`、`cd packages/core && npx vitest run src/utils/yaml-parser.test.ts` 和 `npm run build && npm run typecheck`。

### Evidence (Before & After)

Before：定时 Release 运行中，stats delta 测试失败为 `expected -100 to be close to +0`，并且嵌套 `mcpServers` / `hooks` 输入的两个 YAML parser 期望失败。

After：本地定向 stats 和 YAML parser 测试文件通过，且 `npm run build && npm run typecheck` 成功退出。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node v22.18.0，npm 10.9.3。

## Risk & Scope

- Main risk or tradeoff: 变更仅限于测试期望和过期注释；运行时行为不变。
- Not validated / out of scope: 没有运行完整 workspace 测试，也没有本地跨平台运行。
- Breaking changes / migration notes: 无。

## Linked Issues

引用 [#4779](https://github.com/QwenLM/qwen-code/pull/4779)、[#4842](https://github.com/QwenLM/qwen-code/pull/4842)，以及失败的 CI 运行 [27315318446](https://github.com/QwenLM/qwen-code/actions/runs/27315318446/job/80694783621)。

</details>