### PR TITLE
docs(channels): add screenshots to Feishu setup guide

### DIFF
--- a/docs/users/features/channels/feishu.md
+++ b/docs/users/features/channels/feishu.md
@@ -11,10 +11,24 @@ This guide covers setting up a Qwen Code channel on Feishu (飞书) / Lark.
 
 1. Go to the [Feishu Open Platform](https://open.feishu.cn)
 2. Create a new application (or use an existing one)
+
+![](https://gw.alicdn.com/imgextra/i4/O1CN01ORb10i1JM0MQfhnsV_!!6000000001013-2-tps-2219-931.png)
+
 3. Under the application, enable the **Bot** capability (添加应用能力 → 机器人)
+
+![](https://gw.alicdn.com/imgextra/i4/O1CN01bClpxu1FZxyH4kNjJ_!!6000000000502-2-tps-2219-931.png)
+
 4. In **Event Subscriptions** (事件与回调), select **Long Connection** (使用长连接接收事件)
+
+![](https://gw.alicdn.com/imgextra/i1/O1CN01uIwzbl1ph8Kwq7hTI_!!6000000005391-2-tps-2219-1166.png)
+
 5. Add the event `im.message.receive_v1` (接收消息)
+
+![](https://gw.alicdn.com/imgextra/i2/O1CN01n7sZmV28s6WX0aDhw_!!6000000007987-2-tps-2219-1090.png)
+
 6. Note the **App ID** (Client ID) and **App Secret** (Client Secret) from the application credentials page
+
+![](https://gw.alicdn.com/imgextra/i2/O1CN01ag1yBh1DxfEUb4xmE_!!6000000000283-2-tps-2219-1166.png)
 
 ### Required Permissions
 
@@ -27,6 +41,8 @@ Enable the following permissions under **Permissions & Scopes** (权限管理):
 ### Publish the Application
 
 After configuring permissions and events, create a version and publish it. The bot won't work until the application is published and approved.
+
+![](https://gw.alicdn.com/imgextra/i1/O1CN01GbNRcj1lVuACnkV6M_!!6000000004825-2-tps-2219-1090.png)
 
 ## Configuration
 


### PR DESCRIPTION
为飞书频道设置指南添加截图，帮助用户更直观地完成配置步骤。

截图覆盖了以下步骤：
- 创建应用
- 启用 Bot 能力
- 事件订阅（长连接）
- 添加接收消息事件
- 获取 App ID 和 App Secret
- 发布应用

## preview

<img width="637" height="654" alt="image" src="https://github.com/user-attachments/assets/79fc4423-2d50-411c-a1b2-de0dc7b2e336" />
<img width="637" height="699" alt="image" src="https://github.com/user-attachments/assets/fa1d72ae-e63a-4941-9ce9-7b70d5ffce4d" />
<img width="637" height="699" alt="image" src="https://github.com/user-attachments/assets/7a1bc951-1fd3-490d-945a-2c1fb320f02a" />
<img width="637" height="699" alt="image" src="https://github.com/user-attachments/assets/0dbed54d-2e52-4d8c-aa92-cd6de456dd2f" />

🤖 Generated with Qwen Code