### PR TITLE
feat(web-shell): add conversation rewind

### DIFF
--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -626,6 +626,68 @@ describe('createAcpSessionBridge', () => {
     await bridge.shutdown();
   });
 
+  it('loads trimmed replay after rewinding an attached session', async () => {
+    const bridge = makeBridge({
+      channelFactory: async () =>
+        makeChannel({
+          extMethodImpl: (method, params) => {
+            if (method === 'qwen/control/session/rewind') {
+              return {
+                targetTurnIndex: params['targetTurnIndex'],
+                filesChanged: [],
+                filesFailed: [],
+              };
+            }
+            return {};
+          },
+        }).channel,
+    });
+    const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+
+    await bridge.sendPrompt(session.sessionId, {
+      sessionId: session.sessionId,
+      prompt: [{ type: 'text', text: 'first' }],
+    });
+    await bridge.sendPrompt(session.sessionId, {
+      sessionId: session.sessionId,
+      prompt: [{ type: 'text', text: 'second' }],
+    });
+
+    const before = await bridge.loadSession({
+      sessionId: session.sessionId,
+      workspaceCwd: WS_A,
+    });
+    const beforeReplayText = [
+      ...(before.compactedReplay ?? []),
+      ...(before.liveJournal ?? []),
+    ]
+      .map((event) => JSON.stringify(event.data))
+      .join('\n');
+    expect(beforeReplayText).toContain('first');
+    expect(beforeReplayText).toContain('second');
+
+    await bridge.rewindSession(session.sessionId, { targetTurnIndex: 0 });
+    const loaded = await bridge.loadSession({
+      sessionId: session.sessionId,
+      workspaceCwd: WS_A,
+    });
+
+    const replayText = [
+      ...(loaded.compactedReplay ?? []),
+      ...(loaded.liveJournal ?? []),
+    ]
+      .map((event) => JSON.stringify(event.data))
+      .join('\n');
+    expect(loaded.attached).toBe(true);
+    expect(replayText).not.toContain('first');
+    expect(replayText).not.toContain('second');
+    expect(loaded.liveJournal?.map((event) => event.type)).toEqual([
+      'session_rewound',
+    ]);
+
+    await bridge.shutdown();
+  });
+
   it('buffers load replay events until the restored session is registered', async () => {
     let capturedConn: AgentSideConnection | undefined;
     const factory: ChannelFactory = async () => {

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -4149,7 +4149,14 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
           withTimeout(
             entry.connection.extMethod(
               SERVE_CONTROL_EXT_METHODS.sessionRewind,
-              { sessionId, promptId: req.promptId, rewindFiles: true },
+              {
+                sessionId,
+                ...(req.promptId ? { promptId: req.promptId } : {}),
+                ...(Number.isInteger(req.targetTurnIndex)
+                  ? { targetTurnIndex: req.targetTurnIndex }
+                  : {}),
+                rewindFiles: req.promptId !== undefined,
+              },
             ),
             initTimeoutMs,
             SERVE_CONTROL_EXT_METHODS.sessionRewind,
@@ -4174,6 +4181,8 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       const targetTurnIndex = (response['targetTurnIndex'] as number) ?? 0;
       const filesChanged = (response['filesChanged'] as string[]) ?? [];
       const filesFailed = (response['filesFailed'] as string[]) ?? [];
+
+      entry.events.rewindReplay(targetTurnIndex);
 
       try {
         entry.events.publish({

--- a/packages/acp-bridge/src/bridgeTypes.ts
+++ b/packages/acp-bridge/src/bridgeTypes.ts
@@ -31,14 +31,15 @@ import type {
 } from './status.js';
 
 export interface RewindSnapshotInfo {
-  promptId: string;
+  promptId?: string;
   turnIndex: number;
   timestamp: string;
   diffStats: { filesChanged: number; insertions: number; deletions: number };
 }
 
 export interface RewindRequest {
-  promptId: string;
+  promptId?: string;
+  targetTurnIndex?: number;
 }
 
 export interface RewindResponse {

--- a/packages/acp-bridge/src/compactionEngine.test.ts
+++ b/packages/acp-bridge/src/compactionEngine.test.ts
@@ -461,6 +461,26 @@ describe('TurnBoundaryCompactionEngine', () => {
       expect(texts).toContain('Bye');
       expect(texts).toContain('Goodbye');
     });
+
+    it('rewinds compacted replay to the requested user turn', () => {
+      const engine = new TurnBoundaryCompactionEngine();
+      engine.ingest(makeUserMessage(1, 'Hello'));
+      engine.ingest(makeTextChunk(2, 'Hi'));
+      engine.ingest(makeTurnComplete(3));
+      engine.ingest(makeUserMessage(4, 'Again'));
+      engine.ingest(makeTextChunk(5, 'Second'));
+      engine.ingest(makeTurnComplete(6));
+
+      engine.rewindToTurn(1);
+
+      const snap = engine.snapshot();
+      const texts = extractTexts(snap.compactedTurns);
+      expect(texts).toContain('Hello');
+      expect(texts).toContain('Hi');
+      expect(texts).not.toContain('Again');
+      expect(texts).not.toContain('Second');
+      expect(snap.liveJournal).toHaveLength(0);
+    });
   });
 
   describe('turn_error compaction', () => {
@@ -733,6 +753,37 @@ describe('EventBus + CompactionEngine integration', () => {
     expect(snapshot.compactedTurns).toHaveLength(0);
     expect(snapshot.liveJournal).toHaveLength(2);
     expect(snapshot.lastEventId).toBe(2);
+  });
+
+  it('session_rewound trims active replay cache and stale live journal', () => {
+    const engine = new TurnBoundaryCompactionEngine();
+    const bus = new EventBus(100, undefined, engine);
+
+    bus.publish(makeUserMessage(0, 'first'));
+    bus.publish(makeTextChunk(0, 'first reply'));
+    bus.publish({ type: 'turn_complete', data: { stopReason: 'end_turn' } });
+    bus.publish(makeUserMessage(0, 'second'));
+    bus.publish(makeTextChunk(0, 'second reply'));
+    bus.publish({ type: 'turn_complete', data: { stopReason: 'end_turn' } });
+    bus.publish({
+      type: 'followup_suggestion',
+      data: { suggestion: 'stale followup' },
+    });
+    bus.publish({
+      type: 'session_rewound',
+      data: {
+        sessionId: 'session-1',
+        targetTurnIndex: 0,
+        filesChanged: [],
+        filesFailed: [],
+      },
+    });
+
+    const snapshot = bus.snapshotReplay()!;
+    expect(extractTexts(snapshot.compactedTurns)).toEqual([]);
+    expect(snapshot.liveJournal).toHaveLength(1);
+    expect(snapshot.liveJournal[0]?.type).toBe('session_rewound');
+    expect(snapshot.lastEventId).toBe(8);
   });
 
   it('compaction engine is closed when bus closes', () => {

--- a/packages/acp-bridge/src/compactionEngine.ts
+++ b/packages/acp-bridge/src/compactionEngine.ts
@@ -79,6 +79,18 @@ export class TurnBoundaryCompactionEngine implements CompactionEngine {
 
     if (TRANSIENT_TYPES.has(event.type)) return;
 
+    if (event.type === 'session_rewound') {
+      const targetTurnIndex = getRewindTargetTurnIndex(event);
+      if (targetTurnIndex !== undefined) {
+        this.rewindToTurn(targetTurnIndex);
+        if (event.id !== undefined) {
+          this.lastEventId = event.id;
+        }
+      }
+      this.liveJournal.push(event);
+      return;
+    }
+
     this.liveJournal.push(event);
 
     if (TURN_BOUNDARY_TYPES.has(event.type)) {
@@ -110,6 +122,41 @@ export class TurnBoundaryCompactionEngine implements CompactionEngine {
     this.slots = [];
     this.toolSlotIndex.clear();
     this.textSlotIndex.clear();
+  }
+
+  rewindToTurn(targetTurnIndex: number): void {
+    if (this.closed) return;
+    if (!Number.isInteger(targetTurnIndex) || targetTurnIndex < 0) return;
+
+    let completedUserTurns = 0;
+    let activeUserTurn = false;
+    let truncateIndex = -1;
+
+    for (let i = 0; i < this.compactedTurns.length; i++) {
+      const event = this.compactedTurns[i]!;
+      if (isUserMessageEvent(event) && !activeUserTurn) {
+        if (completedUserTurns >= targetTurnIndex) {
+          truncateIndex = i;
+          break;
+        }
+        activeUserTurn = true;
+      }
+      if (TURN_BOUNDARY_TYPES.has(event.type) && activeUserTurn) {
+        completedUserTurns += 1;
+        activeUserTurn = false;
+      }
+    }
+
+    if (truncateIndex >= 0) {
+      this.compactedTurns = this.compactedTurns.slice(0, truncateIndex);
+    }
+    this.liveJournal = [];
+    this.slots = [];
+    this.toolSlotIndex.clear();
+    this.textSlotIndex.clear();
+    const lastKeptId = this.compactedTurns.at(-1)?.id;
+    this.lastEventId =
+      typeof lastKeptId === 'number' ? lastKeptId : this.lastEventId;
   }
 
   close(): void {
@@ -296,6 +343,19 @@ export class TurnBoundaryCompactionEngine implements CompactionEngine {
     this.toolSlotIndex.clear();
     this.textSlotIndex.clear();
   }
+}
+
+function isUserMessageEvent(event: BridgeEvent): boolean {
+  const data = event.data as SessionUpdateData | undefined;
+  return data?.update?.sessionUpdate === 'user_message_chunk';
+}
+
+function getRewindTargetTurnIndex(event: BridgeEvent): number | undefined {
+  const data = event.data as { targetTurnIndex?: unknown } | undefined;
+  const targetTurnIndex = data?.targetTurnIndex;
+  return Number.isInteger(targetTurnIndex) && (targetTurnIndex as number) >= 0
+    ? (targetTurnIndex as number)
+    : undefined;
 }
 
 function makeMergedSessionUpdateEvent(

--- a/packages/acp-bridge/src/eventBus.ts
+++ b/packages/acp-bridge/src/eventBus.ts
@@ -28,6 +28,7 @@ export interface SessionReplaySnapshot {
 export interface CompactionEngine {
   ingest(event: BridgeEvent): void;
   snapshot(): SessionReplaySnapshot;
+  rewindToTurn(targetTurnIndex: number): void;
   close(): void;
 }
 
@@ -194,6 +195,10 @@ export class EventBus {
 
   snapshotReplay(): SessionReplaySnapshot | undefined {
     return this.compactionEngine?.snapshot();
+  }
+
+  rewindReplay(targetTurnIndex: number): void {
+    this.compactionEngine?.rewindToTurn(targetTurnIndex);
   }
 
   /** Most recent id ever assigned by `publish`. 0 if no events published. */

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -1015,6 +1015,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
   let lastSessionMock:
     | {
         captureHistorySnapshot: ReturnType<typeof vi.fn>;
+        getRewindableTurns: ReturnType<typeof vi.fn>;
         restoreHistory: ReturnType<typeof vi.fn>;
         rewindToTurn: ReturnType<typeof vi.fn>;
       }
@@ -1205,6 +1206,9 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
   });
 
   function makeInnerConfig() {
+    const chatRecordingService = {
+      flush: vi.fn().mockResolvedValue(undefined),
+    };
     return {
       initialize: vi.fn().mockResolvedValue(undefined),
       waitForMcpReady: vi.fn().mockResolvedValue(undefined),
@@ -1230,9 +1234,18 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       }),
       getFileSystemService: vi.fn().mockReturnValue(undefined),
       setFileSystemService: vi.fn(),
+      getFileHistoryService: vi.fn().mockReturnValue({
+        getSnapshots: vi.fn().mockReturnValue([]),
+        getDiffStats: vi.fn().mockResolvedValue(undefined),
+        rewind: vi.fn().mockResolvedValue({
+          filesChanged: [],
+          filesFailed: [],
+        }),
+      }),
       getHookSystem: vi.fn().mockReturnValue(undefined),
       getDisableAllHooks: vi.fn().mockReturnValue(true),
       hasHooksForEvent: vi.fn().mockReturnValue(false),
+      getChatRecordingService: vi.fn().mockReturnValue(chatRecordingService),
     };
   }
 
@@ -1319,6 +1332,9 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         captureHistorySnapshot: vi
           .fn()
           .mockReturnValue([{ role: 'user', parts: [{ text: 'before' }] }]),
+        getRewindableTurns: vi
+          .fn()
+          .mockReturnValue([{ turnIndex: 0, text: 'before' }]),
         restoreHistory: vi.fn(),
         rewindToTurn: vi
           .fn()
@@ -4231,7 +4247,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
 
   it('rewindSession extension method rewinds the active session', async () => {
     const sessionId = '11111111-1111-1111-1111-111111111111';
-    await setupSessionMocks(sessionId);
+    const innerConfig = await setupSessionMocks(sessionId);
 
     const agentPromise = runAcpAgent(
       mockConfig,
@@ -4254,6 +4270,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     });
 
     expect(lastSessionMock?.rewindToTurn).toHaveBeenCalledWith(1);
+    expect(innerConfig.getChatRecordingService().flush).toHaveBeenCalledOnce();
     expect(response).toEqual({
       success: true,
       historyBeforeRewind: [{ role: 'user', parts: [{ text: 'before' }] }],
@@ -4261,6 +4278,47 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       apiTruncateIndex: 2,
       filesChanged: [],
       filesFailed: [],
+    });
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('rewind snapshots are based on conversation turns when file snapshots are empty', async () => {
+    const sessionId = '11111111-1111-1111-1111-111111111111';
+    await setupSessionMocks(sessionId);
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    vi.mocked(lastSessionMock!.getRewindableTurns).mockReturnValue([
+      { turnIndex: 0, text: 'first' },
+      { turnIndex: 1, text: 'second' },
+    ]);
+
+    const response = await agent.extMethod(
+      SERVE_STATUS_EXT_METHODS.sessionRewindSnapshots,
+      {
+        sessionId,
+      },
+    );
+
+    expect(response).toMatchObject({
+      snapshots: [
+        { turnIndex: 0, diffStats: { filesChanged: 0 } },
+        { turnIndex: 1, diffStats: { filesChanged: 0 } },
+      ],
     });
 
     mockConnectionState.resolve();

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -5027,7 +5027,7 @@ class QwenAgent implements Agent {
         const fhs = session.getConfig().getFileHistoryService();
         const snapshots = fhs.getSnapshots();
         const prefix = (sessionId as string) + '########';
-        const results = await Promise.all(
+        const fileSnapshotsByTurn = new Map(
           snapshots
             .map((s, idx) => ({ s, idx }))
             .filter(
@@ -5035,19 +5035,25 @@ class QwenAgent implements Agent {
                 s.promptId.startsWith(prefix) &&
                 /^\d+$/.test(s.promptId.slice(prefix.length)),
             )
-            .map(async ({ s, idx }) => {
-              const stats = await fhs.getDiffStats(s.promptId);
-              return {
-                promptId: s.promptId,
-                turnIndex: idx,
-                timestamp: s.timestamp.toISOString(),
-                diffStats: {
-                  filesChanged: stats?.filesChanged?.length ?? 0,
-                  insertions: stats?.insertions ?? 0,
-                  deletions: stats?.deletions ?? 0,
-                },
-              };
-            }),
+            .map(({ s, idx }) => [idx, s] as const),
+        );
+        const results = await Promise.all(
+          session.getRewindableTurns().map(async ({ turnIndex }) => {
+            const snapshot = fileSnapshotsByTurn.get(turnIndex);
+            const stats = snapshot
+              ? await fhs.getDiffStats(snapshot.promptId)
+              : undefined;
+            return {
+              ...(snapshot ? { promptId: snapshot.promptId } : {}),
+              turnIndex,
+              timestamp: (snapshot?.timestamp ?? new Date()).toISOString(),
+              diffStats: {
+                filesChanged: stats?.filesChanged?.length ?? 0,
+                insertions: stats?.insertions ?? 0,
+                deletions: stats?.deletions ?? 0,
+              },
+            };
+          }),
         );
         return { snapshots: results } as unknown as Record<string, unknown>;
       }
@@ -6074,6 +6080,7 @@ class QwenAgent implements Agent {
         let rewindResult;
         try {
           rewindResult = session.rewindToTurn(turnIndex as number);
+          await session.getConfig().getChatRecordingService()?.flush();
         } catch (err) {
           if (err instanceof RequestError) {
             const msg = err.message;

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -194,6 +194,11 @@ interface BackgroundNotificationQueueItem {
 
 const MAX_NOTIFICATION_QUEUE = 20;
 
+export interface RewindableTurn {
+  turnIndex: number;
+  text: string;
+}
+
 export function computeInitialTurnFromHistory(
   records: ChatRecord[],
   sessionId: string,
@@ -636,6 +641,21 @@ export class Session implements SessionContext {
     return this.config.getGeminiClient()!.getChat().getHistoryShallow();
   }
 
+  getRewindableTurns(): RewindableTurn[] {
+    const apiHistory = this.captureHistorySnapshot();
+    const startIndex = getStartupContextLength(apiHistory);
+    const turns: RewindableTurn[] = [];
+    for (let i = startIndex; i < apiHistory.length; i++) {
+      if (this.#isUserTextContent(apiHistory[i]!)) {
+        const text = this.#getUserText(apiHistory[i]!);
+        if (text.trim()) {
+          turns.push({ turnIndex: turns.length, text });
+        }
+      }
+    }
+    return turns;
+  }
+
   restoreHistory(history: Content[]): void {
     if (
       this.pendingPrompt ||
@@ -700,6 +720,15 @@ export class Session implements SessionContext {
     if (isSystemReminderContent(content)) return false;
 
     return content.parts.some((part) => 'text' in part && part.text);
+  }
+
+  #getUserText(content: Content): string {
+    if (!content.parts) return '';
+    return content.parts
+      .filter((part): part is Part & { text: string } => 'text' in part)
+      .map((part) => part.text)
+      .join(' ')
+      .trim();
   }
 
   async cancelPendingPrompt(): Promise<void> {

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -276,9 +276,7 @@ export async function listWorkspaceSessionsForResponse(
   });
 
   const nextCursor =
-    persisted.nextCursor != null
-      ? String(persisted.nextCursor)
-      : undefined;
+    persisted.nextCursor != null ? String(persisted.nextCursor) : undefined;
 
   return { sessions, nextCursor };
 }
@@ -2703,10 +2701,17 @@ export function createServeApp(
       const sessionId = req.params['id'];
       const body = safeBody(req);
       const promptId = body['promptId'];
-      if (typeof promptId !== 'string' || promptId.length === 0) {
+      const targetTurnIndex = body['targetTurnIndex'];
+      const hasPromptId = typeof promptId === 'string' && promptId.length > 0;
+      const hasTargetTurnIndex =
+        typeof targetTurnIndex === 'number' &&
+        Number.isInteger(targetTurnIndex) &&
+        targetTurnIndex >= 0;
+      if (!hasPromptId && !hasTargetTurnIndex) {
         res.status(400).json({
-          error: '`promptId` is required and must be a non-empty string',
-          code: 'missing_prompt_id',
+          error:
+            '`promptId` or `targetTurnIndex` is required for session rewind',
+          code: 'missing_rewind_target',
         });
         return;
       }
@@ -2715,7 +2720,10 @@ export function createServeApp(
       try {
         const response = await bridge.rewindSession(
           sessionId,
-          { promptId },
+          {
+            ...(hasPromptId ? { promptId } : {}),
+            ...(hasTargetTurnIndex ? { targetTurnIndex } : {}),
+          },
           clientId !== undefined ? { clientId } : undefined,
         );
         res.status(200).json(response);

--- a/packages/sdk-typescript/src/daemon/DaemonClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonClient.ts
@@ -1284,9 +1284,15 @@ export class DaemonClient {
 
   async rewindSession(
     sessionId: string,
-    promptId: string,
+    req:
+      | string
+      | {
+          promptId?: string;
+          targetTurnIndex?: number;
+        },
     opts?: { clientId?: string },
   ): Promise<DaemonRewindResult> {
+    const body = typeof req === 'string' ? { promptId: req } : req;
     return await this.fetchWithTimeout(
       `${this.baseUrl}/session/${encodeURIComponent(sessionId)}/rewind`,
       {
@@ -1295,7 +1301,7 @@ export class DaemonClient {
           { 'Content-Type': 'application/json' },
           opts?.clientId,
         ),
-        body: JSON.stringify({ promptId }),
+        body: JSON.stringify(body),
       },
       async (res) => {
         if (!res.ok) {

--- a/packages/sdk-typescript/src/daemon/DaemonSessionClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonSessionClient.ts
@@ -296,8 +296,10 @@ export class DaemonSessionClient {
     return await this.client.getRewindSnapshots(this.sessionId);
   }
 
-  async rewind(promptId: string): Promise<DaemonRewindResult> {
-    return await this.client.rewindSession(this.sessionId, promptId, {
+  async rewind(
+    target: string | { targetTurnIndex: number; promptId?: string },
+  ): Promise<DaemonRewindResult> {
+    return await this.client.rewindSession(this.sessionId, target, {
       clientId: this.clientId,
     });
   }

--- a/packages/sdk-typescript/src/daemon/events.ts
+++ b/packages/sdk-typescript/src/daemon/events.ts
@@ -127,8 +127,10 @@ const MAX_PENDING_PER_SESSION = 64;
 export type DaemonKnownEventType =
   (typeof DAEMON_KNOWN_EVENT_TYPE_VALUES)[number];
 
-export interface DaemonEventEnvelope<TType extends string, TData>
-  extends Omit<DaemonEvent, 'type' | 'data'> {
+export interface DaemonEventEnvelope<TType extends string, TData> extends Omit<
+  DaemonEvent,
+  'type' | 'data'
+> {
   type: TType;
   data: TData;
 }
@@ -635,7 +637,7 @@ export interface DaemonTurnErrorData {
 
 export interface DaemonSessionRewoundData {
   sessionId: string;
-  promptId: string;
+  promptId?: string;
   targetTurnIndex: number;
   filesChanged: string[];
   filesFailed: string[];
@@ -1445,7 +1447,7 @@ function isSessionRewoundData(
   return (
     isRecord(value) &&
     isNonEmptyString(value['sessionId']) &&
-    isNonEmptyString(value['promptId']) &&
+    (value['promptId'] === undefined || isNonEmptyString(value['promptId'])) &&
     isFiniteNumber(value['targetTurnIndex']) &&
     Array.isArray(value['filesChanged']) &&
     Array.isArray(value['filesFailed'])

--- a/packages/sdk-typescript/src/daemon/types.ts
+++ b/packages/sdk-typescript/src/daemon/types.ts
@@ -615,8 +615,7 @@ export interface DaemonWorkspaceAgentSummary {
   filePath?: string;
 }
 
-export interface DaemonWorkspaceAgentDetail
-  extends DaemonWorkspaceAgentSummary {
+export interface DaemonWorkspaceAgentDetail extends DaemonWorkspaceAgentSummary {
   systemPrompt: string;
   tools?: string[];
   disallowedTools?: string[];
@@ -1469,7 +1468,7 @@ export interface PermissionResponse {
 }
 
 export interface DaemonRewindSnapshotInfo {
-  promptId: string;
+  promptId?: string;
   turnIndex: number;
   timestamp: string;
   diffStats: { filesChanged: number; insertions: number; deletions: number };

--- a/packages/sdk-typescript/src/daemon/ui/index.ts
+++ b/packages/sdk-typescript/src/daemon/ui/index.ts
@@ -95,6 +95,7 @@ export type {
   DaemonUiSessionAvailableCommandsEvent,
   DaemonUiStateResyncRequiredEvent,
   DaemonUiReplayCompleteEvent,
+  DaemonUiSessionRewoundEvent,
   DaemonUiPromptCancelledEvent,
   // Daemon assist push (server-side ghost-text suggestion)
   DaemonUiFollowupSuggestionEvent,

--- a/packages/sdk-typescript/src/daemon/ui/normalizer.ts
+++ b/packages/sdk-typescript/src/daemon/ui/normalizer.ts
@@ -282,6 +282,9 @@ export function normalizeDaemonEvent(
     case 'auth_device_flow_cancelled':
       return normalizeAuthDeviceFlowCancelled(event, base);
 
+    case 'session_rewound':
+      return normalizeSessionRewound(event, base);
+
     default:
       // Emit a single `debug` block instead
       // of `status + debug`. In long sessions where the daemon adds
@@ -347,6 +350,34 @@ function normalizeFollowupSuggestion(
       sessionId,
       suggestion,
       promptId,
+    },
+  ];
+}
+
+function normalizeSessionRewound(
+  event: DaemonEvent,
+  base: NormalizedEventBase,
+): DaemonUiEvent[] {
+  const sessionId = getString(event.data, 'sessionId');
+  const targetTurnIndex = numberField(event.data, 'targetTurnIndex');
+  const filesChanged = stringArrayField(event.data, 'filesChanged');
+  const filesFailed = stringArrayField(event.data, 'filesFailed');
+  if (
+    !sessionId ||
+    targetTurnIndex === undefined ||
+    !filesChanged ||
+    !filesFailed
+  ) {
+    return fallbackDebug(event, base, 'malformed session_rewound payload');
+  }
+  return [
+    {
+      ...base,
+      type: 'session.rewound',
+      sessionId,
+      targetTurnIndex,
+      filesChanged,
+      filesFailed,
     },
   ];
 }
@@ -1378,4 +1409,12 @@ function stringField(value: unknown, key: string): string | undefined {
   if (!isRecord(value)) return undefined;
   const v = value[key];
   return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+function stringArrayField(value: unknown, key: string): string[] | undefined {
+  if (!isRecord(value)) return undefined;
+  const v = value[key];
+  return Array.isArray(v) && v.every((item) => typeof item === 'string')
+    ? v
+    : undefined;
 }

--- a/packages/sdk-typescript/src/daemon/ui/terminal.ts
+++ b/packages/sdk-typescript/src/daemon/ui/terminal.ts
@@ -77,6 +77,12 @@ export function daemonUiEventToTerminalText(event: DaemonUiEvent): string {
         `caught up (${event.replayedCount} replayed)`,
         '2',
       );
+    case 'session.rewound':
+      return terminalLine(
+        'rewound',
+        `session rewound to turn ${event.targetTurnIndex}`,
+        '33',
+      );
     case 'prompt.cancelled':
       return terminalLine('cancelled', 'prompt cancelled', '33');
     case 'followup.suggestion':

--- a/packages/sdk-typescript/src/daemon/ui/transcript.ts
+++ b/packages/sdk-typescript/src/daemon/ui/transcript.ts
@@ -925,8 +925,8 @@ function appendStatusBlock(
     ...(event?.type === 'error' && event.promptId
       ? { promptId: event.promptId }
       : {}),
-    ...(event?.type === 'error' && event.source
-      ? { source: event.source }
+    ...(event && 'source' in event && event.source
+      ? { source: event.source as DaemonStatusTranscriptBlock['source'] }
       : {}),
   };
   appendBlock(state, block);

--- a/packages/sdk-typescript/src/daemon/ui/types.ts
+++ b/packages/sdk-typescript/src/daemon/ui/types.ts
@@ -37,6 +37,7 @@ export type DaemonUiEventType =
   | 'session.available_commands'
   | 'session.state_resync_required'
   | 'session.replay_complete'
+  | 'session.rewound'
   // Prompt lifecycle (cross-client)
   | 'prompt.cancelled'
   // Daemon assist push (server-side ghost-text suggestion)
@@ -211,6 +212,7 @@ export interface DaemonUiModelChangedEvent extends DaemonUiEventBase {
 export interface DaemonUiStatusEvent extends DaemonUiEventBase {
   type: 'status' | 'debug';
   text: string;
+  source?: 'conversation_rewind';
 }
 
 export interface DaemonUiErrorEvent extends DaemonUiEventBase {
@@ -239,8 +241,7 @@ export interface DaemonUiSessionMetadataChangedEvent extends DaemonUiEventBase {
   displayName?: string;
 }
 
-export interface DaemonUiSessionApprovalModeChangedEvent
-  extends DaemonUiEventBase {
+export interface DaemonUiSessionApprovalModeChangedEvent extends DaemonUiEventBase {
   type: 'session.approval_mode.changed';
   sessionId: string;
   previous: string;
@@ -254,8 +255,7 @@ export interface DaemonUiSessionApprovalModeChangedEvent
  * to refresh command completion menus (TUI / web command palette / IDE
  * quick pick).
  */
-export interface DaemonUiSessionAvailableCommandsEvent
-  extends DaemonUiEventBase {
+export interface DaemonUiSessionAvailableCommandsEvent extends DaemonUiEventBase {
   type: 'session.available_commands';
   /** Total count exposed by the daemon; convenience for renderers. */
   count: number;
@@ -326,6 +326,14 @@ export interface DaemonUiReplayCompleteEvent extends DaemonUiEventBase {
   lastReplayedEventId?: number;
 }
 
+export interface DaemonUiSessionRewoundEvent extends DaemonUiEventBase {
+  type: 'session.rewound';
+  sessionId: string;
+  targetTurnIndex: number;
+  filesChanged: string[];
+  filesFailed: string[];
+}
+
 /* ──────────────────────────────────────────────────────────────────────────
  * Workspace events (Wave 3-4)
  * ──────────────────────────────────────────────────────────────────────── */
@@ -351,8 +359,7 @@ export interface DaemonUiWorkspaceToolToggledEvent extends DaemonUiEventBase {
   enabled: boolean;
 }
 
-export interface DaemonUiWorkspaceSettingsChangedEvent
-  extends DaemonUiEventBase {
+export interface DaemonUiWorkspaceSettingsChangedEvent extends DaemonUiEventBase {
   type: 'workspace.settings.changed';
   key: string;
   scope: string;
@@ -392,8 +399,7 @@ export interface DaemonUiMcpServerRestartedEvent extends DaemonUiEventBase {
   durationMs: number;
 }
 
-export interface DaemonUiMcpServerRestartRefusedEvent
-  extends DaemonUiEventBase {
+export interface DaemonUiMcpServerRestartRefusedEvent extends DaemonUiEventBase {
   type: 'workspace.mcp.server_restart_refused';
   serverName: string;
   reason: 'in_flight' | 'disabled' | 'budget_would_exceed';
@@ -410,15 +416,13 @@ export interface DaemonUiAuthDeviceFlowStartedEvent extends DaemonUiEventBase {
   expiresAt: number;
 }
 
-export interface DaemonUiAuthDeviceFlowThrottledEvent
-  extends DaemonUiEventBase {
+export interface DaemonUiAuthDeviceFlowThrottledEvent extends DaemonUiEventBase {
   type: 'auth.device_flow.throttled';
   deviceFlowId: string;
   intervalMs: number;
 }
 
-export interface DaemonUiAuthDeviceFlowAuthorizedEvent
-  extends DaemonUiEventBase {
+export interface DaemonUiAuthDeviceFlowAuthorizedEvent extends DaemonUiEventBase {
   type: 'auth.device_flow.authorized';
   deviceFlowId: string;
   providerId: DaemonAuthProviderId;
@@ -433,8 +437,7 @@ export interface DaemonUiAuthDeviceFlowFailedEvent extends DaemonUiEventBase {
   hint?: string;
 }
 
-export interface DaemonUiAuthDeviceFlowCancelledEvent
-  extends DaemonUiEventBase {
+export interface DaemonUiAuthDeviceFlowCancelledEvent extends DaemonUiEventBase {
   type: 'auth.device_flow.cancelled';
   deviceFlowId: string;
 }
@@ -466,6 +469,7 @@ export type DaemonUiEvent =
   | DaemonUiSessionAvailableCommandsEvent
   | DaemonUiStateResyncRequiredEvent
   | DaemonUiReplayCompleteEvent
+  | DaemonUiSessionRewoundEvent
   // Prompt lifecycle (cross-client)
   | DaemonUiPromptCancelledEvent
   // Daemon assist push (server-side ghost-text suggestion)
@@ -718,8 +722,7 @@ export interface DaemonShellTranscriptBlock extends DaemonTranscriptBlockBase {
   stream?: 'stdout' | 'stderr';
 }
 
-export interface DaemonUserShellTranscriptBlock
-  extends DaemonTranscriptBlockBase {
+export interface DaemonUserShellTranscriptBlock extends DaemonTranscriptBlockBase {
   kind: 'user_shell';
   text: string;
   command: string;
@@ -727,8 +730,7 @@ export interface DaemonUserShellTranscriptBlock
   stream?: 'stdout' | 'stderr';
 }
 
-export interface DaemonPermissionTranscriptBlock
-  extends DaemonTranscriptBlockBase {
+export interface DaemonPermissionTranscriptBlock extends DaemonTranscriptBlockBase {
   kind: 'permission';
   requestId: string;
   sessionId?: string;
@@ -744,11 +746,10 @@ export interface DaemonStatusTranscriptBlock extends DaemonTranscriptBlockBase {
   text: string;
   code?: string;
   promptId?: string;
-  source?: 'turn_error';
+  source?: 'turn_error' | 'conversation_rewind';
 }
 
-export interface DaemonPromptCancelledTranscriptBlock
-  extends DaemonTranscriptBlockBase {
+export interface DaemonPromptCancelledTranscriptBlock extends DaemonTranscriptBlockBase {
   kind: 'prompt_cancelled';
   reason?: string;
 }
@@ -815,8 +816,7 @@ export interface DaemonTranscriptSidechannelState {
   };
 }
 
-export interface DaemonTranscriptState
-  extends DaemonTranscriptSidechannelState {
+export interface DaemonTranscriptState extends DaemonTranscriptSidechannelState {
   // wenshao R5 (deepseek-v4-pro): `blocks` is frozen at the dispatch
   // boundary in `reduceDaemonTranscriptEvents` (defense against
   // consumer in-place mutation poisoning the shared snapshot under

--- a/packages/sdk-typescript/test/unit/daemonUi.test.ts
+++ b/packages/sdk-typescript/test/unit/daemonUi.test.ts
@@ -64,6 +64,27 @@ describe('daemon UI normalizer and transcript reducer', () => {
     ]);
   });
 
+  it('preserves status source in transcript blocks', () => {
+    const state = reduceDaemonTranscriptEvents(
+      createDaemonTranscriptState({ now: 100 }),
+      [
+        {
+          type: 'status',
+          text: 'Conversation rewound.',
+          source: 'conversation_rewind',
+        },
+      ],
+    );
+
+    expect(state.blocks).toEqual([
+      expect.objectContaining({
+        kind: 'status',
+        text: 'Conversation rewound.',
+        source: 'conversation_rewind',
+      }),
+    ]);
+  });
+
   it('keeps optimistic local user blocks before daemon replies when sorting', () => {
     let state = createDaemonTranscriptState({ now: 1 });
     state = appendLocalUserTranscriptMessage(state, 'hello', { now: 10 });
@@ -2158,9 +2179,8 @@ describe('daemon UI time schema (PR-B)', () => {
   });
 
   it('selectTranscriptBlocksOrderedByEventId sorts by eventId, ignoring out-of-order arrival', async () => {
-    const { selectTranscriptBlocksOrderedByEventId } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { selectTranscriptBlocksOrderedByEventId } =
+      await import('../../src/daemon/ui/index.js');
     let state = createDaemonTranscriptState({ now: 1 });
     // Push 3 blocks; insert ids in mixed arrival order (replay scenario)
     state = reduceDaemonTranscriptEvents(
@@ -2226,9 +2246,8 @@ describe('daemon UI time schema (PR-B)', () => {
   });
 
   it('formatBlockTimestamp prefers serverTimestamp over clientReceivedAt', async () => {
-    const { formatBlockTimestamp } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { formatBlockTimestamp } =
+      await import('../../src/daemon/ui/index.js');
     const events = normalizeDaemonEvent({
       id: 1,
       v: 1,
@@ -2847,9 +2866,8 @@ describe('daemon UI content extraction (PR-C)', () => {
 
 describe('daemon UI render contract (PR-D)', () => {
   it('daemonBlockToMarkdown renders user/assistant/tool/shell/permission/error', async () => {
-    const { daemonBlockToMarkdown } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonBlockToMarkdown } =
+      await import('../../src/daemon/ui/index.js');
     let state = createDaemonTranscriptState({ now: 1 });
     state = appendLocalUserTranscriptMessage(state, 'hello', { now: 2 });
     state = reduceDaemonTranscriptEvents(
@@ -2877,9 +2895,8 @@ describe('daemon UI render contract (PR-D)', () => {
   });
 
   it('daemonBlockToMarkdown renders file_diff preview as unified diff', async () => {
-    const { daemonBlockToMarkdown } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonBlockToMarkdown } =
+      await import('../../src/daemon/ui/index.js');
     let state = createDaemonTranscriptState({ now: 1 });
     state = reduceDaemonTranscriptEvents(
       state,
@@ -2911,9 +2928,8 @@ describe('daemon UI render contract (PR-D)', () => {
   });
 
   it('daemonBlockToMarkdown uses longer fences for embedded backticks', async () => {
-    const { daemonToolPreviewToMarkdown } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonToolPreviewToMarkdown } =
+      await import('../../src/daemon/ui/index.js');
     const md = daemonToolPreviewToMarkdown({
       kind: 'command',
       command: 'printf "```\\n"',
@@ -2925,9 +2941,8 @@ describe('daemon UI render contract (PR-D)', () => {
   });
 
   it('daemonBlockToMarkdown renders mcp_invocation preview with server::tool', async () => {
-    const { daemonBlockToMarkdown } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonBlockToMarkdown } =
+      await import('../../src/daemon/ui/index.js');
     let state = createDaemonTranscriptState({ now: 1 });
     state = reduceDaemonTranscriptEvents(
       state,
@@ -2995,9 +3010,8 @@ describe('daemon UI render contract (PR-D)', () => {
   });
 
   it('daemonBlockToPlainText drops markdown / html, suitable for copy-paste', async () => {
-    const { daemonBlockToPlainText } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonBlockToPlainText } =
+      await import('../../src/daemon/ui/index.js');
     let state = createDaemonTranscriptState({ now: 1 });
     state = reduceDaemonTranscriptEvents(
       state,
@@ -3010,9 +3024,8 @@ describe('daemon UI render contract (PR-D)', () => {
   });
 
   it('maxFieldLength truncates with ellipsis', async () => {
-    const { daemonBlockToMarkdown } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonBlockToMarkdown } =
+      await import('../../src/daemon/ui/index.js');
     let state = createDaemonTranscriptState({ now: 1 });
     state = appendLocalUserTranscriptMessage(state, 'X'.repeat(200), {
       now: 2,
@@ -3025,9 +3038,8 @@ describe('daemon UI render contract (PR-D)', () => {
   });
 
   it('sanitizeUrls strips token query params in web_fetch preview', async () => {
-    const { daemonToolPreviewToMarkdown } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonToolPreviewToMarkdown } =
+      await import('../../src/daemon/ui/index.js');
     const md = daemonToolPreviewToMarkdown(
       {
         kind: 'web_fetch',
@@ -3040,9 +3052,8 @@ describe('daemon UI render contract (PR-D)', () => {
   });
 
   it('sanitizeUrls rejects unsafe protocols and parse failures', async () => {
-    const { daemonToolPreviewToMarkdown } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonToolPreviewToMarkdown } =
+      await import('../../src/daemon/ui/index.js');
     expect(
       daemonToolPreviewToMarkdown(
         { kind: 'web_fetch', url: 'javascript:alert(1)' },
@@ -3058,9 +3069,8 @@ describe('daemon UI render contract (PR-D)', () => {
   });
 
   it('sanitizeUrls strips common auth query params', async () => {
-    const { daemonToolPreviewToMarkdown } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonToolPreviewToMarkdown } =
+      await import('../../src/daemon/ui/index.js');
     const md = daemonToolPreviewToMarkdown(
       {
         kind: 'web_fetch',
@@ -3075,9 +3085,8 @@ describe('daemon UI render contract (PR-D)', () => {
   });
 
   it('daemonBlockToMarkdown strips ANSI and bidi controls', async () => {
-    const { daemonBlockToMarkdown } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonBlockToMarkdown } =
+      await import('../../src/daemon/ui/index.js');
     let state = createDaemonTranscriptState({ now: 1 });
     state = appendLocalUserTranscriptMessage(
       state,
@@ -3091,9 +3100,8 @@ describe('daemon UI render contract (PR-D)', () => {
   });
 
   it('daemonToolPreviewToMarkdown escapes inline metadata delimiters', async () => {
-    const { daemonToolPreviewToMarkdown } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonToolPreviewToMarkdown } =
+      await import('../../src/daemon/ui/index.js');
     const md = daemonToolPreviewToMarkdown({
       kind: 'file_read',
       path: '` <img src=x onerror=alert(1)> `',
@@ -3280,9 +3288,8 @@ describe('daemon UI tool preview taxonomy — long-tail kinds (PR-F)', () => {
   });
 
   it('search preview renders to GFM markdown with bullet list', async () => {
-    const { daemonToolPreviewToMarkdown } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonToolPreviewToMarkdown } =
+      await import('../../src/daemon/ui/index.js');
     const md = daemonToolPreviewToMarkdown({
       kind: 'search',
       query: 'TODO',
@@ -3296,9 +3303,8 @@ describe('daemon UI tool preview taxonomy — long-tail kinds (PR-F)', () => {
   });
 
   it('tabular preview renders to GFM markdown table', async () => {
-    const { daemonToolPreviewToMarkdown } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonToolPreviewToMarkdown } =
+      await import('../../src/daemon/ui/index.js');
     const md = daemonToolPreviewToMarkdown({
       kind: 'tabular',
       columns: ['name', 'age'],
@@ -3313,9 +3319,8 @@ describe('daemon UI tool preview taxonomy — long-tail kinds (PR-F)', () => {
   });
 
   it('tabular preview escapes pipes in headers and cells', async () => {
-    const { daemonToolPreviewToMarkdown } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonToolPreviewToMarkdown } =
+      await import('../../src/daemon/ui/index.js');
     const md = daemonToolPreviewToMarkdown({
       kind: 'tabular',
       columns: ['Name | ID', 'value'],
@@ -3326,9 +3331,8 @@ describe('daemon UI tool preview taxonomy — long-tail kinds (PR-F)', () => {
   });
 
   it('image_generation renders with embedded markdown image', async () => {
-    const { daemonToolPreviewToMarkdown } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonToolPreviewToMarkdown } =
+      await import('../../src/daemon/ui/index.js');
     const md = daemonToolPreviewToMarkdown({
       kind: 'image_generation',
       prompt: 'A sunset',
@@ -3339,9 +3343,8 @@ describe('daemon UI tool preview taxonomy — long-tail kinds (PR-F)', () => {
   });
 
   it('subagent_delegation renders with delegate header + task quote', async () => {
-    const { daemonToolPreviewToMarkdown } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonToolPreviewToMarkdown } =
+      await import('../../src/daemon/ui/index.js');
     const md = daemonToolPreviewToMarkdown({
       kind: 'subagent_delegation',
       agentName: 'reviewer',
@@ -3404,9 +3407,8 @@ describe('daemon UI adapter conformance framework (PR-G)', () => {
   });
 
   it('detects redaction violations (leaked phrases in malformed-payload fixture)', async () => {
-    const { runAdapterConformanceSuite } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { runAdapterConformanceSuite } =
+      await import('../../src/daemon/ui/index.js');
     // Buggy adapter that dumps raw event data including secrets.
     const result = runAdapterConformanceSuite(
       {
@@ -3427,9 +3429,8 @@ describe('daemon UI adapter conformance framework (PR-G)', () => {
   });
 
   it('respects only / skip filter options', async () => {
-    const { runAdapterConformanceSuite } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { runAdapterConformanceSuite } =
+      await import('../../src/daemon/ui/index.js');
     const result = runAdapterConformanceSuite(
       {
         reduce() {
@@ -3539,9 +3540,8 @@ describe('daemon UI subagent nesting (PR-K, post-rebase)', () => {
   });
 
   it('reducer correlates parentBlockId at create time when parent already in state', async () => {
-    const { selectSubagentChildBlocks } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { selectSubagentChildBlocks } =
+      await import('../../src/daemon/ui/index.js');
     let state = createDaemonTranscriptState({ now: 1 });
     // Parent Task tool call first.
     state = reduceDaemonTranscriptEvents(
@@ -3676,9 +3676,8 @@ describe('daemon UI subagent nesting (PR-K, post-rebase)', () => {
   });
 
   it('isSubagentChildBlock discriminates tool blocks by parentToolCallId', async () => {
-    const { isSubagentChildBlock } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { isSubagentChildBlock } =
+      await import('../../src/daemon/ui/index.js');
     let state = createDaemonTranscriptState({ now: 1 });
     state = reduceDaemonTranscriptEvents(
       state,
@@ -3751,9 +3750,8 @@ describe('daemon UI subagent nesting — review hardening (R1-R4)', () => {
   });
 
   it('back-fills parentBlockId when parent appears AFTER child (out-of-order)', async () => {
-    const { selectSubagentChildBlocks } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { selectSubagentChildBlocks } =
+      await import('../../src/daemon/ui/index.js');
     let state = createDaemonTranscriptState({ now: 1 });
     // Child first, with parent stamp pointing to a parent not yet in state.
     state = reduceDaemonTranscriptEvents(
@@ -3950,7 +3948,9 @@ describe('daemon UI subagent nesting — review hardening (R1-R4)', () => {
     );
     if (child) {
       // parentToolCallId stays (selector-friendly), parentBlockId is nulled.
+      // eslint-disable-next-line vitest/no-conditional-expect
       expect(child.parentToolCallId).toBe('pT');
+      // eslint-disable-next-line vitest/no-conditional-expect
       expect(child.parentBlockId).toBeUndefined();
     }
   });
@@ -4111,9 +4111,8 @@ describe('transcriptBlockToTerminalText (wenshao review — coverage)', () => {
   };
 
   it('renders user block with qwen label', async () => {
-    const { transcriptBlockToTerminalText } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { transcriptBlockToTerminalText } =
+      await import('../../src/daemon/ui/index.js');
     const out = transcriptBlockToTerminalText({
       ...baseFields,
       kind: 'user',
@@ -4124,9 +4123,8 @@ describe('transcriptBlockToTerminalText (wenshao review — coverage)', () => {
   });
 
   it('renders assistant block as sanitized text (no label prefix)', async () => {
-    const { transcriptBlockToTerminalText } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { transcriptBlockToTerminalText } =
+      await import('../../src/daemon/ui/index.js');
     const out = transcriptBlockToTerminalText({
       ...baseFields,
       kind: 'assistant',
@@ -4137,9 +4135,8 @@ describe('transcriptBlockToTerminalText (wenshao review — coverage)', () => {
   });
 
   it('renders thought block dimly', async () => {
-    const { transcriptBlockToTerminalText } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { transcriptBlockToTerminalText } =
+      await import('../../src/daemon/ui/index.js');
     const out = transcriptBlockToTerminalText({
       ...baseFields,
       kind: 'thought',
@@ -4150,9 +4147,8 @@ describe('transcriptBlockToTerminalText (wenshao review — coverage)', () => {
   });
 
   it('renders tool block with status and title', async () => {
-    const { transcriptBlockToTerminalText } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { transcriptBlockToTerminalText } =
+      await import('../../src/daemon/ui/index.js');
     const out = transcriptBlockToTerminalText({
       ...baseFields,
       kind: 'tool',
@@ -4166,9 +4162,8 @@ describe('transcriptBlockToTerminalText (wenshao review — coverage)', () => {
   });
 
   it('renders shell block (stdout)', async () => {
-    const { transcriptBlockToTerminalText } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { transcriptBlockToTerminalText } =
+      await import('../../src/daemon/ui/index.js');
     const out = transcriptBlockToTerminalText({
       ...baseFields,
       kind: 'shell',
@@ -4180,9 +4175,8 @@ describe('transcriptBlockToTerminalText (wenshao review — coverage)', () => {
   });
 
   it('renders shell block (stderr)', async () => {
-    const { transcriptBlockToTerminalText } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { transcriptBlockToTerminalText } =
+      await import('../../src/daemon/ui/index.js');
     const out = transcriptBlockToTerminalText({
       ...baseFields,
       kind: 'shell',
@@ -4193,9 +4187,8 @@ describe('transcriptBlockToTerminalText (wenshao review — coverage)', () => {
   });
 
   it('renders unresolved permission block with options', async () => {
-    const { transcriptBlockToTerminalText } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { transcriptBlockToTerminalText } =
+      await import('../../src/daemon/ui/index.js');
     const out = transcriptBlockToTerminalText({
       ...baseFields,
       kind: 'permission',
@@ -4214,9 +4207,8 @@ describe('transcriptBlockToTerminalText (wenshao review — coverage)', () => {
   });
 
   it('renders resolved permission block with resolved suffix', async () => {
-    const { transcriptBlockToTerminalText } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { transcriptBlockToTerminalText } =
+      await import('../../src/daemon/ui/index.js');
     const out = transcriptBlockToTerminalText({
       ...baseFields,
       kind: 'permission',
@@ -4230,9 +4222,8 @@ describe('transcriptBlockToTerminalText (wenshao review — coverage)', () => {
   });
 
   it('renders status block', async () => {
-    const { transcriptBlockToTerminalText } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { transcriptBlockToTerminalText } =
+      await import('../../src/daemon/ui/index.js');
     const out = transcriptBlockToTerminalText({
       ...baseFields,
       kind: 'status',
@@ -4243,9 +4234,8 @@ describe('transcriptBlockToTerminalText (wenshao review — coverage)', () => {
   });
 
   it('renders debug block', async () => {
-    const { transcriptBlockToTerminalText } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { transcriptBlockToTerminalText } =
+      await import('../../src/daemon/ui/index.js');
     const out = transcriptBlockToTerminalText({
       ...baseFields,
       kind: 'debug',
@@ -4256,9 +4246,8 @@ describe('transcriptBlockToTerminalText (wenshao review — coverage)', () => {
   });
 
   it('renders error block', async () => {
-    const { transcriptBlockToTerminalText } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { transcriptBlockToTerminalText } =
+      await import('../../src/daemon/ui/index.js');
     const out = transcriptBlockToTerminalText({
       ...baseFields,
       kind: 'error',
@@ -4269,9 +4258,8 @@ describe('transcriptBlockToTerminalText (wenshao review — coverage)', () => {
   });
 
   it('degrades gracefully on unknown block kind (returns error line, does NOT throw)', async () => {
-    const { transcriptBlockToTerminalText } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { transcriptBlockToTerminalText } =
+      await import('../../src/daemon/ui/index.js');
     const fauxBlock = {
       ...baseFields,
       kind: 'experimental_kind_from_future_daemon' as never,
@@ -4291,9 +4279,8 @@ describe('daemon UI WeakMap memo hits (wenshao glm-5.1 review)', () => {
   // preserve `state.blocks` reference, so the WeakMap caches actually hit
   // across renders. Verify by checking reference identity.
   it('selectTranscriptBlocksOrderedByEventId returns the same array reference for sidechannel-only events', async () => {
-    const { selectTranscriptBlocksOrderedByEventId } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { selectTranscriptBlocksOrderedByEventId } =
+      await import('../../src/daemon/ui/index.js');
     let state = createDaemonTranscriptState({ now: 1 });
     // Dispatch a tool_call event to populate blocks.
     state = reduceDaemonTranscriptEvents(
@@ -4337,9 +4324,8 @@ describe('daemon UI WeakMap memo hits (wenshao glm-5.1 review)', () => {
   });
 
   it('selectSubagentChildBlocks returns same memoized array across sidechannel dispatches', async () => {
-    const { selectSubagentChildBlocks } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { selectSubagentChildBlocks } =
+      await import('../../src/daemon/ui/index.js');
     let state = createDaemonTranscriptState({ now: 1 });
     state = reduceDaemonTranscriptEvents(
       state,
@@ -4404,9 +4390,8 @@ describe('daemon UI WeakMap memo hits (wenshao glm-5.1 review)', () => {
   });
 
   it('selectSubagentChildBlocks returns a frozen list (caller mutation throws, cache safe)', async () => {
-    const { selectSubagentChildBlocks } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { selectSubagentChildBlocks } =
+      await import('../../src/daemon/ui/index.js');
     let state = createDaemonTranscriptState({ now: 1 });
     state = reduceDaemonTranscriptEvents(
       state,
@@ -4466,9 +4451,8 @@ describe('KNOWN_DEVICE_FLOW_ERROR_KINDS stays in sync with public type', async (
   // wenshao 5-23 13:03 (glm-5.1) suggestion: ensure the known-set
   // documentation export doesn't go stale.
   it('only contains canonical device-flow error kinds (compile-time assertion)', async () => {
-    const { KNOWN_DEVICE_FLOW_ERROR_KINDS } = await import(
-      '../../src/daemon/ui/normalizer.js'
-    );
+    const { KNOWN_DEVICE_FLOW_ERROR_KINDS } =
+      await import('../../src/daemon/ui/normalizer.js');
     // The `as const satisfies readonly DaemonAuthDeviceFlowSdkErrorKind[]`
     // at the declaration site already enforces type-level membership.
     // This runtime test guards against the array being silently emptied
@@ -4486,9 +4470,8 @@ describe('KNOWN_DEVICE_FLOW_ERROR_KINDS stays in sync with public type', async (
 
 describe('daemonBlockToPlainText forwards opts (wenshao review 4350741340)', () => {
   it('sanitizes URL on tool preview when opts.sanitizeUrls is set', async () => {
-    const { daemonBlockToPlainText, createDaemonToolPreview } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonBlockToPlainText, createDaemonToolPreview } =
+      await import('../../src/daemon/ui/index.js');
     const block = {
       id: 'b',
       kind: 'tool' as const,
@@ -4518,9 +4501,8 @@ describe('daemonBlockToHtml — additional coverage (wenshao R3 qwen3.7-max)', (
   } as const;
 
   it('strips token query param + Basic Auth from web_fetch URL when sanitizeUrls:true', async () => {
-    const { daemonBlockToHtml, createDaemonToolPreview } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonBlockToHtml, createDaemonToolPreview } =
+      await import('../../src/daemon/ui/index.js');
     const block = {
       ...baseFields,
       kind: 'tool' as const,
@@ -4542,9 +4524,8 @@ describe('daemonBlockToHtml — additional coverage (wenshao R3 qwen3.7-max)', (
   });
 
   it('protocol-validates thumbnailUrl even when sanitizeUrls:false', async () => {
-    const { daemonBlockToMarkdown, createDaemonToolPreview } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonBlockToMarkdown, createDaemonToolPreview } =
+      await import('../../src/daemon/ui/index.js');
     const block = {
       ...baseFields,
       kind: 'tool' as const,
@@ -4747,9 +4728,8 @@ describe('Late permission.resolved after sentinel pruned (wenshao R3 qwen3.7-max
 
 describe('ensureSafeImageUrl tightened to data:image/* (audit follow-up)', () => {
   it('allows http/https/data:image/* but rejects data:text/html', async () => {
-    const { daemonBlockToMarkdown, createDaemonToolPreview } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonBlockToMarkdown, createDaemonToolPreview } =
+      await import('../../src/daemon/ui/index.js');
     const mkBlock = (thumbnailUrl: string) => ({
       id: 'b',
       kind: 'tool' as const,
@@ -4815,9 +4795,8 @@ describe('R5 review batch — coverage additions', () => {
   });
 
   it('sanitizeUrl clears OAuth implicit-grant access_token in #fragment', async () => {
-    const { daemonBlockToMarkdown, createDaemonToolPreview } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonBlockToMarkdown, createDaemonToolPreview } =
+      await import('../../src/daemon/ui/index.js');
     const block = {
       id: 'b',
       kind: 'tool' as const,
@@ -4841,9 +4820,8 @@ describe('R5 review batch — coverage additions', () => {
   });
 
   it('sanitizeUrl strips AWS / GCP / Azure SAS credential params', async () => {
-    const { daemonBlockToMarkdown, createDaemonToolPreview } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonBlockToMarkdown, createDaemonToolPreview } =
+      await import('../../src/daemon/ui/index.js');
     const mkBlock = (url: string) => ({
       id: 'b',
       kind: 'tool' as const,
@@ -4887,18 +4865,16 @@ describe('R5 review batch — coverage additions', () => {
   });
 
   it('formatMissedRange handles no-gap / single-event / multi-event', async () => {
-    const { formatMissedRange } = await import(
-      '../../src/daemon/ui/transcript.js'
-    );
+    const { formatMissedRange } =
+      await import('../../src/daemon/ui/transcript.js');
     expect(formatMissedRange(5, 6)).toContain('no events lost');
     expect(formatMissedRange(5, 7)).toContain('1 daemon event');
     expect(formatMissedRange(5, 10)).toContain('6-9');
   });
 
   it('detectFileDiff content alias rejected for non-write tools', async () => {
-    const { createDaemonToolPreview } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { createDaemonToolPreview } =
+      await import('../../src/daemon/ui/index.js');
     // `{ path, content }` with READ-like tool name → NOT file_diff
     const read = createDaemonToolPreview(
       { path: '/x', content: 'expected text' },
@@ -4914,9 +4890,8 @@ describe('R5 review batch — coverage additions', () => {
   });
 
   it('writeIntent regex word-boundary: prewrite_check does NOT match write', async () => {
-    const { createDaemonToolPreview } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { createDaemonToolPreview } =
+      await import('../../src/daemon/ui/index.js');
     const preview = createDaemonToolPreview(
       { path: '/x', content: 'data' },
       { toolName: 'prewrite_check' },
@@ -4925,9 +4900,8 @@ describe('R5 review batch — coverage additions', () => {
   });
 
   it('conformance suite captures adapter throw as fixture failure (does not abort)', async () => {
-    const { runAdapterConformanceSuite } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { runAdapterConformanceSuite } =
+      await import('../../src/daemon/ui/index.js');
     const result = runAdapterConformanceSuite(
       {
         reduce: () => {
@@ -4954,10 +4928,32 @@ describe('R5 review batch — coverage additions', () => {
     expect(events[0]?.type).toBe('debug');
   });
 
+  it('normalizes session_rewound as a typed event', () => {
+    const events = normalizeDaemonEvent({
+      id: 1,
+      v: 1,
+      type: 'session_rewound',
+      data: {
+        sessionId: 'session-1',
+        targetTurnIndex: 1,
+        filesChanged: [],
+        filesFailed: [],
+      },
+    });
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: 'session.rewound',
+        sessionId: 'session-1',
+        targetTurnIndex: 1,
+        filesChanged: [],
+        filesFailed: [],
+      }),
+    ]);
+  });
+
   it('store.clearAwaitingResync clears latch', async () => {
-    const { createDaemonTranscriptStore } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { createDaemonTranscriptStore } =
+      await import('../../src/daemon/ui/index.js');
     const store = createDaemonTranscriptStore();
     store.dispatch({
       type: 'session.state_resync_required',
@@ -5001,9 +4997,8 @@ describe('R6 review batch — recovery flow + pending pointer', () => {
   });
 
   it('clearAwaitingResync FIRST then dispatch new events: events flow', async () => {
-    const { createDaemonTranscriptStore } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { createDaemonTranscriptStore } =
+      await import('../../src/daemon/ui/index.js');
     const store = createDaemonTranscriptStore();
     // Set the latch.
     store.dispatch({
@@ -5043,9 +5038,8 @@ describe('R6 review batch — recovery flow + pending pointer', () => {
     // This test pins the correct flow as documented: latch drops everything
     // until cleared. If a consumer dispatches events FIRST then clears, the
     // events are lost.
-    const { createDaemonTranscriptStore } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { createDaemonTranscriptStore } =
+      await import('../../src/daemon/ui/index.js');
     const store = createDaemonTranscriptStore();
     store.dispatch({
       type: 'session.state_resync_required',
@@ -5081,9 +5075,8 @@ describe('R6 review batch — recovery flow + pending pointer', () => {
 
 describe('R7 review batch — markdown escape + details sanitization', () => {
   it('escapeMarkdownText escapes < in metadata fields (titles/kinds) for HTML-backed pipelines', async () => {
-    const { daemonBlockToMarkdown, createDaemonToolPreview } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonBlockToMarkdown, createDaemonToolPreview } =
+      await import('../../src/daemon/ui/index.js');
     // `escapeMarkdownText` is applied to METADATA fields (title /
     // toolKind / status) — those are reviewer-untrusted and should
     // escape `<` to prevent raw HTML pass-through when consumers run
@@ -5117,9 +5110,8 @@ describe('R7 review batch — markdown escape + details sanitization', () => {
   });
 
   it('markdown tool block details strips URL credentials when sanitizeUrls:true', async () => {
-    const { daemonBlockToMarkdown, createDaemonToolPreview } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonBlockToMarkdown, createDaemonToolPreview } =
+      await import('../../src/daemon/ui/index.js');
     const block = {
       id: 'b',
       kind: 'tool' as const,
@@ -5146,9 +5138,8 @@ describe('R7 review batch — markdown escape + details sanitization', () => {
   });
 
   it('markdown tool block details preserves URLs verbatim when sanitizeUrls:false (back-compat)', async () => {
-    const { daemonBlockToMarkdown, createDaemonToolPreview } = await import(
-      '../../src/daemon/ui/index.js'
-    );
+    const { daemonBlockToMarkdown, createDaemonToolPreview } =
+      await import('../../src/daemon/ui/index.js');
     const block = {
       id: 'b',
       kind: 'tool' as const,

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -15,10 +15,12 @@ import {
   useTranscriptBlocks,
   useTranscriptStore,
   useWorkspaceActions,
+  isDaemonTurnError,
   type DaemonSessionNotice,
+  type DaemonTranscriptBlock,
   type DaemonStreamingState,
+  type DaemonRewindSnapshotInfo,
 } from '@qwen-code/webui/daemon-react-sdk';
-import { isDaemonTurnError } from '@qwen-code/sdk/daemon';
 import { extractPendingPermission } from './adapters/transcriptAdapter';
 import { MessageList } from './components/MessageList';
 import { Editor, type EditorHandle } from './components/Editor';
@@ -39,6 +41,11 @@ import {
   ApprovalModeMessage,
 } from './components/messages/ApprovalModeMessage';
 import { ResumeDialog } from './components/dialogs/ResumeDialog';
+import {
+  RewindDialog,
+  type RewindRestoreOption,
+  type RewindTarget,
+} from './components/dialogs/RewindDialog';
 import {
   AGENTS_ACTIVE_EVENT,
   AgentsMessage,
@@ -145,6 +152,33 @@ const MAX_DISPLAYED_QUEUED_PROMPTS = 3;
 const MAX_QUEUED_PROMPT_PREVIEW_CHARS = 240;
 const MAX_TOASTS = 4;
 const COMPACT_MODE_STORAGE_KEY = 'web-shell:compact-mode';
+const SLASH_PATH_SEPARATOR_RE = /[/\\]/;
+
+function isSlashCommandPrompt(text: string): boolean {
+  if (!text.startsWith('/')) return false;
+  if (text.startsWith('//') || text.startsWith('/*')) return false;
+  const firstToken = text.slice(1).trimStart().split(/\s+/u)[0] ?? '';
+  return !SLASH_PATH_SEPARATOR_RE.test(firstToken);
+}
+
+function buildRewindTargets(
+  snapshots: readonly DaemonRewindSnapshotInfo[],
+  blocks: readonly DaemonTranscriptBlock[],
+): RewindTarget[] {
+  const userBlocks = blocks.filter(
+    (block): block is Extract<DaemonTranscriptBlock, { kind: 'user' }> =>
+      block.kind === 'user' &&
+      block.text.trim().length > 0 &&
+      !isSlashCommandPrompt(block.text) &&
+      !block.text.startsWith('?'),
+  );
+  return [...snapshots]
+    .sort((a, b) => a.turnIndex - b.turnIndex)
+    .flatMap((snapshot) => {
+      const text = userBlocks[snapshot.turnIndex]?.text.trim();
+      return text ? [{ ...snapshot, text }] : [];
+    });
+}
 
 function loadCompactMode(): boolean {
   try {
@@ -790,6 +824,12 @@ export function App({
     useState<ModelInlineMode | null>(null);
   const [approvalModeInlineOpen, setApprovalModeInlineOpen] = useState(false);
   const [showResumeDialog, setShowResumeDialog] = useState(false);
+  const [showRewindDialog, setShowRewindDialog] = useState(false);
+  const [rewindSnapshots, setRewindSnapshots] = useState<
+    DaemonRewindSnapshotInfo[]
+  >([]);
+  const [rewindLoading, setRewindLoading] = useState(false);
+  const [rewindError, setRewindError] = useState<string | undefined>();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showReleaseDialog, setShowReleaseDialog] = useState(false);
   const [showHelpDialog, setShowHelpDialog] = useState(false);
@@ -807,6 +847,10 @@ export function App({
     useState<AgentsInitialMode | null>(null);
   const [memoryPortalHost, setMemoryPortalHost] =
     useState<HTMLDivElement | null>(null);
+  const rewindTargets = useMemo(
+    () => buildRewindTargets(rewindSnapshots, messageBlocks),
+    [rewindSnapshots, messageBlocks],
+  );
   const [showShortcuts, setShowShortcuts] = useState(false);
   const [escapeHintVisible, setEscapeHintVisible] = useState(false);
   const escPressCountRef = useRef(0);
@@ -836,6 +880,7 @@ export function App({
   const drainingQueueRef = useRef(false);
   const dialogOpen =
     showResumeDialog ||
+    showRewindDialog ||
     showDeleteDialog ||
     showReleaseDialog ||
     showHelpDialog ||
@@ -1432,6 +1477,41 @@ export function App({
     ],
   );
 
+  const openRewindDialog = useCallback(() => {
+    setShowRewindDialog(true);
+    setRewindLoading(true);
+    setRewindError(undefined);
+    sessionActions
+      .getRewindSnapshots()
+      .then(({ snapshots }) => {
+        setRewindSnapshots(snapshots);
+      })
+      .catch((error: unknown) => {
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Failed to load rewind turns';
+        setRewindError(message);
+      })
+      .finally(() => {
+        setRewindLoading(false);
+      });
+  }, [sessionActions]);
+
+  const handleRewind = useCallback(
+    (target: RewindTarget, option: RewindRestoreOption) =>
+      sessionActions
+        .rewind(
+          target.turnIndex,
+          option === 'both' ? target.promptId : undefined,
+        )
+        .catch((error: unknown) => {
+          reportError(error, 'Failed to rewind session');
+          throw error;
+        }),
+    [reportError, sessionActions],
+  );
+
   const handleSubmit = useCallback(
     (text: string, images?: PromptImage[]) => {
       const promptBlocked = streamingStateRef.current !== 'idle';
@@ -1839,6 +1919,14 @@ export function App({
             }
             return true;
           }
+          if (cmd === 'rewind') {
+            if (promptBlocked) {
+              store.dispatch([{ type: 'error', text: t('rewind.blocked') }]);
+              return true;
+            }
+            openRewindDialog();
+            return true;
+          }
           if (cmd === 'recap') {
             runVisibleRecap();
             return true;
@@ -2014,6 +2102,7 @@ export function App({
       handleGoalSlashCommand,
       handleThemeChange,
       handleSetMode,
+      openRewindDialog,
       onLanguageChange,
       pushToast,
       reportError,
@@ -2315,6 +2404,15 @@ export function App({
                       });
                   }}
                   onClose={() => setShowResumeDialog(false)}
+                />
+              )}
+              {showRewindDialog && (
+                <RewindDialog
+                  targets={rewindTargets}
+                  loading={rewindLoading}
+                  error={rewindError}
+                  onRewind={handleRewind}
+                  onClose={() => setShowRewindDialog(false)}
                 />
               )}
               {showDeleteDialog && (

--- a/packages/web-shell/client/adapters/transcriptToMessages.test.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.test.ts
@@ -6,7 +6,7 @@ import type {
   DaemonToolTranscriptBlock,
   DaemonTranscriptBlock,
   DaemonUserShellTranscriptBlock,
-} from '@qwen-code/sdk/daemon';
+} from '@qwen-code/webui/daemon-react-sdk';
 import { transcriptBlocksToDaemonMessages } from './transcriptToMessages.js';
 
 function textBlock(

--- a/packages/web-shell/client/adapters/transcriptToMessages.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.ts
@@ -11,7 +11,7 @@ import type {
   DaemonShellTranscriptBlock,
   DaemonStatusTranscriptBlock,
   DaemonUserShellTranscriptBlock,
-} from '@qwen-code/sdk/daemon';
+} from '@qwen-code/webui/daemon-react-sdk';
 import type {
   DaemonMessage,
   DaemonMessageToolCall,

--- a/packages/web-shell/client/components/dialogs/DialogPrimitives.module.css
+++ b/packages/web-shell/client/components/dialogs/DialogPrimitives.module.css
@@ -10,6 +10,11 @@
   overflow: hidden;
 }
 
+.resume-picker-compact {
+  height: auto;
+  max-height: calc(100% - 48px);
+}
+
 .resume-picker-header {
   display: flex;
   align-items: center;
@@ -91,7 +96,32 @@
   padding: 4px 0;
 }
 
+.resume-picker-list-compact {
+  flex: 0 0 auto;
+  overflow-y: visible;
+}
+
 .resume-picker-empty {
+  padding: 16px 12px;
+  color: var(--text-dimmed);
+  font-size: 13px;
+}
+
+.resume-picker-target {
+  padding: 16px 12px;
+  font-size: 13px;
+}
+
+.resume-picker-target-label {
+  color: var(--text-primary);
+}
+
+.resume-picker-target-text {
+  color: var(--accent-color);
+  font-weight: 700;
+}
+
+.resume-picker-description {
   padding: 16px 12px;
   color: var(--text-dimmed);
   font-size: 13px;

--- a/packages/web-shell/client/components/dialogs/RewindDialog.tsx
+++ b/packages/web-shell/client/components/dialogs/RewindDialog.tsx
@@ -1,0 +1,313 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { DaemonRewindSnapshotInfo } from '@qwen-code/webui/daemon-react-sdk';
+import { dp } from './dialogStyles';
+import { useDelayedGlobalKeyDown } from '../../hooks/useDelayedGlobalKeyDown';
+import { useI18n } from '../../i18n';
+
+export interface RewindTarget extends DaemonRewindSnapshotInfo {
+  text: string;
+}
+
+export type RewindRestoreOption = 'both' | 'conversation';
+
+type RestoreChoice =
+  | { key: RewindRestoreOption; label: string; detail?: string }
+  | { key: 'cancel'; label: string; detail?: string };
+
+interface RewindDialogProps {
+  targets: readonly RewindTarget[];
+  loading: boolean;
+  error?: string;
+  onRewind: (
+    target: RewindTarget,
+    option: RewindRestoreOption,
+  ) => Promise<void>;
+  onClose: () => void;
+}
+
+function previewText(text: string): string {
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  if (!normalized) return '(empty)';
+  return normalized.length > 120
+    ? `${normalized.slice(0, 120)}...`
+    : normalized;
+}
+
+function getRestoreOptions(
+  target: RewindTarget,
+  t: ReturnType<typeof useI18n>['t'],
+): RestoreChoice[] {
+  const hasChanges = target.diffStats.filesChanged > 0;
+  const options: RestoreChoice[] = [];
+  if (hasChanges) {
+    options.push({
+      key: 'both',
+      label: t('rewind.option.both'),
+      detail: t('rewind.option.fileDetail', {
+        files: target.diffStats.filesChanged,
+        insertions: target.diffStats.insertions,
+        deletions: target.diffStats.deletions,
+      }),
+    });
+  }
+  options.push({ key: 'conversation', label: t('rewind.option.conversation') });
+  options.push({ key: 'cancel', label: t('rewind.option.cancel') });
+  return options;
+}
+
+export function RewindDialog({
+  targets,
+  loading,
+  error,
+  onRewind,
+  onClose,
+}: RewindDialogProps) {
+  const { t } = useI18n();
+  const [selectedIdx, setSelectedIdx] = useState(() =>
+    Math.max(0, targets.length - 1),
+  );
+  const [confirmTarget, setConfirmTarget] = useState<RewindTarget | null>(null);
+  const [restoreOptionIdx, setRestoreOptionIdx] = useState(0);
+  const [restoring, setRestoring] = useState(false);
+  const listRef = useRef<HTMLDivElement>(null);
+  const restoreOptions = confirmTarget
+    ? getRestoreOptions(confirmTarget, t)
+    : [];
+  const canRestoreFiles = restoreOptions.some(
+    (option) => option.key === 'both',
+  );
+
+  useEffect(() => {
+    setSelectedIdx(Math.max(0, targets.length - 1));
+  }, [targets.length]);
+
+  useEffect(() => {
+    const el = listRef.current?.children[selectedIdx] as
+      | HTMLElement
+      | undefined;
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [selectedIdx]);
+
+  const handleConfirm = useCallback(() => {
+    if (!confirmTarget || restoring) return;
+    const options = getRestoreOptions(confirmTarget, t);
+    const option = options[restoreOptionIdx];
+    if (!option) return;
+    if (option.key === 'cancel') {
+      setConfirmTarget(null);
+      setRestoreOptionIdx(0);
+      return;
+    }
+    setRestoring(true);
+    onRewind(confirmTarget, option.key)
+      .then(onClose)
+      .catch(() => {
+        setRestoring(false);
+      });
+  }, [confirmTarget, onClose, onRewind, restoreOptionIdx, restoring, t]);
+
+  useDelayedGlobalKeyDown(
+    (e: KeyboardEvent) => {
+      if (restoring) return;
+
+      if (confirmTarget) {
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          setConfirmTarget(null);
+          setRestoreOptionIdx(0);
+          return;
+        }
+        const options = getRestoreOptions(confirmTarget, t);
+        if (e.key === 'ArrowDown' || e.key === 'j') {
+          e.preventDefault();
+          setRestoreOptionIdx((idx) => Math.min(idx + 1, options.length - 1));
+          return;
+        }
+        if (e.key === 'ArrowUp' || e.key === 'k') {
+          e.preventDefault();
+          setRestoreOptionIdx((idx) => Math.max(idx - 1, 0));
+          return;
+        }
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          handleConfirm();
+          return;
+        }
+        return;
+      }
+
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (loading || error || targets.length === 0) return;
+      if (e.key === 'ArrowDown' || e.key === 'j') {
+        e.preventDefault();
+        setSelectedIdx((idx) => Math.min(idx + 1, targets.length - 1));
+        return;
+      }
+      if (e.key === 'ArrowUp' || e.key === 'k') {
+        e.preventDefault();
+        setSelectedIdx((idx) => Math.max(idx - 1, 0));
+        return;
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        const target = targets[selectedIdx];
+        if (target) {
+          setConfirmTarget(target);
+          setRestoreOptionIdx(0);
+        }
+      }
+    },
+    [
+      confirmTarget,
+      error,
+      handleConfirm,
+      loading,
+      onClose,
+      restoring,
+      selectedIdx,
+      targets,
+      t,
+    ],
+  );
+
+  return (
+    <div
+      className={dp(
+        'resume-picker',
+        confirmTarget ? 'resume-picker-compact' : undefined,
+        'resume-picker-keyboard-only',
+      )}
+    >
+      <div className={dp('resume-picker-header')}>
+        <span className={dp('resume-picker-title')}>
+          {confirmTarget
+            ? t('rewind.title')
+            : t('rewind.titleWithCount', { count: targets.length })}
+        </span>
+        <button
+          className={dp('resume-picker-close')}
+          onClick={onClose}
+          title="Close"
+        >
+          ESC
+        </button>
+      </div>
+
+      <div className={dp('resume-picker-sep')} />
+
+      {confirmTarget ? (
+        <div className={dp('resume-picker-list', 'resume-picker-list-compact')}>
+          <div className={dp('resume-picker-target')}>
+            <span className={dp('resume-picker-target-label')}>
+              {t('rewind.to')}
+            </span>{' '}
+            <span className={dp('resume-picker-target-text')}>
+              {previewText(confirmTarget.text)}
+            </span>
+          </div>
+          {restoreOptions.map((option, idx) => (
+            <div
+              key={option.key}
+              className={dp(
+                'resume-picker-item',
+                idx === restoreOptionIdx ? 'selected' : undefined,
+              )}
+              onClick={() => {
+                setRestoreOptionIdx(idx);
+                if (option.key === 'cancel') {
+                  setConfirmTarget(null);
+                  setRestoreOptionIdx(0);
+                  return;
+                }
+                setRestoring(true);
+                onRewind(confirmTarget, option.key)
+                  .then(onClose)
+                  .catch(() => setRestoring(false));
+              }}
+            >
+              <div className={dp('resume-picker-item-row')}>
+                <span className={dp('resume-picker-item-prefix')}>
+                  {idx === restoreOptionIdx ? '›' : ' '}
+                </span>
+                <span className={dp('resume-picker-item-title')}>
+                  {option.label}
+                </span>
+                {option.detail && (
+                  <span className={dp('resume-picker-item-detail')}>
+                    {option.detail}
+                  </span>
+                )}
+              </div>
+            </div>
+          ))}
+          {!restoring && !canRestoreFiles && (
+            <div className={dp('resume-picker-description')}>
+              {t('rewind.filesUnavailable')}
+            </div>
+          )}
+          {!restoring && canRestoreFiles && (
+            <div className={dp('resume-picker-description')}>
+              {t('rewind.filesNote')}
+            </div>
+          )}
+          {restoring && (
+            <div className={dp('resume-picker-description')}>
+              {t('rewind.restoring')}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className={dp('resume-picker-list')} ref={listRef}>
+          {loading && (
+            <div className={dp('resume-picker-empty')}>
+              {t('common.loading')}
+            </div>
+          )}
+          {!loading && error && (
+            <div className={dp('resume-picker-empty')}>{error}</div>
+          )}
+          {!loading && !error && targets.length === 0 && (
+            <div className={dp('resume-picker-empty')}>{t('rewind.none')}</div>
+          )}
+          {!loading &&
+            !error &&
+            targets.map((target, idx) => {
+              return (
+                <div
+                  key={target.promptId ?? target.turnIndex}
+                  className={dp(
+                    'resume-picker-item',
+                    idx === selectedIdx ? 'selected' : undefined,
+                  )}
+                  onClick={() => {
+                    setConfirmTarget(target);
+                    setRestoreOptionIdx(0);
+                  }}
+                >
+                  <div className={dp('resume-picker-item-row')}>
+                    <span className={dp('resume-picker-item-prefix')}>
+                      {idx === selectedIdx ? '›' : ' '}
+                    </span>
+                    <span className={dp('resume-picker-item-title')}>
+                      #{idx + 1} {previewText(target.text)}
+                    </span>
+                  </div>
+                </div>
+              );
+            })}
+        </div>
+      )}
+
+      <div className={dp('resume-picker-sep')} />
+      <div className={dp('resume-picker-footer')}>
+        {confirmTarget
+          ? t('dialog.footer.navSelectBack')
+          : t('dialog.footer.navSelectCancel')}
+      </div>
+    </div>
+  );
+}

--- a/packages/web-shell/client/constants/localCommands.ts
+++ b/packages/web-shell/client/constants/localCommands.ts
@@ -96,6 +96,10 @@ export function getLocalCommands(t: Translate): CommandInfo[] {
       description: t('local.resume'),
       argumentHint: '<session-id>',
     },
+    {
+      name: 'rewind',
+      description: t('local.rewind'),
+    },
     { name: 'settings', description: t('local.settings') },
   ];
   return commands.map((command) => ({

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -288,6 +288,8 @@ const EN: Messages = {
     '↑↓ to navigate · / to search · c for custom · Enter to set fast model · Esc to cancel',
   'dialog.footer.navSelectCancel':
     '↑↓ to navigate · Enter to select · Esc to cancel',
+  'dialog.footer.navSelectBack':
+    '↑↓ to navigate · Enter to select · Esc to go back',
   'dialog.footer.navSelectClose':
     '↑↓ to navigate · Enter to select · Esc to close',
   'dialog.footer.navSelectMenu':
@@ -440,6 +442,28 @@ const EN: Messages = {
   'rename.success': (v) => `Session renamed to ${v?.name ?? ''}`,
   'local.reset': 'Reset current conversation',
   'local.resume': 'Resume a previous session',
+  'local.rewind': 'Rewind conversation to a previous turn',
+  'rewind.blocked': 'Cannot rewind while streaming. Cancel first (Esc).',
+  'rewind.title': 'Rewind Conversation',
+  'rewind.titleWithCount': (v) =>
+    `Rewind Conversation (${v?.count ?? 0} turns)`,
+  'rewind.none': 'No user turns to rewind to.',
+  'rewind.to': 'Rewind to:',
+  'rewind.restoreBoth': 'Restore conversation and captured file changes.',
+  'rewind.option.both': 'Restore code and conversation',
+  'rewind.option.conversation': 'Restore conversation only',
+  'rewind.option.cancel': 'Never mind',
+  'rewind.option.fileDetail': (v) =>
+    `(+${v?.insertions ?? 0} -${v?.deletions ?? 0} in ${v?.files ?? 0} file(s))`,
+  'rewind.filesUnavailable':
+    'File restore is unavailable for this turn (no captured file changes, or this turn predates the current session).',
+  'rewind.filesNote':
+    'Rewinding does not affect files edited manually or via shell commands.',
+  'rewind.restoring': 'Restoring...',
+  'rewind.turn': (v) => `Turn ${v?.turn ?? ''}`,
+  'rewind.files': (v) =>
+    `${v?.files ?? 0} file(s), +${v?.insertions ?? 0} -${v?.deletions ?? 0}`,
+  'rewind.footer.confirm': 'Enter/Y confirm · N/Esc cancel',
   'local.skills': 'View available skills',
   'local.stats': 'Show session statistics',
   'local.tasks': 'View background tasks',
@@ -1094,6 +1118,7 @@ const ZH: Messages = {
   'dialog.footer.modelFast':
     '↑↓ 导航 · / 搜索 · c 自定义 · Enter 设置 fast model · Esc 取消',
   'dialog.footer.navSelectCancel': '↑↓ 导航 · Enter 选择 · Esc 取消',
+  'dialog.footer.navSelectBack': '↑↓ 导航 · Enter 选择 · Esc 返回',
   'dialog.footer.navSelectClose': '↑↓ 导航 · Enter 选择 · Esc 关闭',
   'dialog.footer.navSelectMenu': '↑↓ 导航 · Enter 选择 · Esc 返回菜单',
   'dialog.footer.navOpenClose': '↑↓ 导航 · Enter 打开 · Esc 关闭',
@@ -1237,6 +1262,26 @@ const ZH: Messages = {
   'rename.success': (v) => `会话已重命名为 ${v?.name ?? ''}`,
   'local.reset': '重置当前对话',
   'local.resume': '恢复历史会话',
+  'local.rewind': '将对话回退到之前的轮次',
+  'rewind.blocked': '流式输出中无法 rewind，请先按 Esc 取消。',
+  'rewind.title': '回退对话',
+  'rewind.titleWithCount': (v) => `回退对话 (${v?.count ?? 0} turns)`,
+  'rewind.none': '没有可回退的用户对话轮次。',
+  'rewind.to': '回退到：',
+  'rewind.restoreBoth': '恢复对话和已捕获的文件变更。',
+  'rewind.option.both': '恢复代码和对话',
+  'rewind.option.conversation': '仅恢复对话',
+  'rewind.option.cancel': '算了',
+  'rewind.option.fileDetail': (v) =>
+    `(+${v?.insertions ?? 0} -${v?.deletions ?? 0}，${v?.files ?? 0} 个文件)`,
+  'rewind.filesUnavailable':
+    '该轮次无法恢复文件（没有捕获到文件变更，或该轮次属于本次会话之前）。',
+  'rewind.filesNote': '回退不会影响手动编辑或通过 shell 命令修改的文件。',
+  'rewind.restoring': '正在恢复...',
+  'rewind.turn': (v) => `第 ${v?.turn ?? ''} 轮`,
+  'rewind.files': (v) =>
+    `${v?.files ?? 0} 个文件，+${v?.insertions ?? 0} -${v?.deletions ?? 0}`,
+  'rewind.footer.confirm': 'Enter/Y 确认 · N/Esc 取消',
   'local.skills': '查看可用 skills',
   'local.stats': '查看会话统计',
   'local.tasks': '查看后台任务',

--- a/packages/webui/src/daemon-react-sdk.ts
+++ b/packages/webui/src/daemon-react-sdk.ts
@@ -182,6 +182,8 @@ export type {
   DaemonAuthProviderModel,
   DaemonContextCategoryBreakdown,
   DaemonContextMemoryDetail,
+  DaemonRewindResult,
+  DaemonRewindSnapshotInfo,
   DaemonContextSkillDetail,
   DaemonContextToolDetail,
   DaemonSessionContextUsage,
@@ -274,11 +276,15 @@ export type {
   DaemonSettingUpdateResult,
 } from './daemon/index.js';
 
+export { isDaemonTurnError } from './daemon/index.js';
+
 // ── Types: SDK Transcript Blocks (low-level) ─────────────────────
 
 export type {
   /** Shell output block: stdout/stderr text stream. */
   DaemonShellTranscriptBlock,
+  /** User-entered shell command block. */
+  DaemonUserShellTranscriptBlock,
   /** Status/error/debug informational block. */
   DaemonStatusTranscriptBlock,
   /** User, assistant, or thought text block (may be streaming). */
@@ -287,7 +293,7 @@ export type {
   DaemonToolTranscriptBlock,
   /** Discriminated union of all transcript block types. */
   DaemonTranscriptBlock,
-  /** Block kind tag: `'user' | 'assistant' | 'thought' | 'tool' | 'shell' | 'permission' | 'status' | 'error' | 'debug'`. */
+  /** Block kind tag: `'user' | 'assistant' | 'thought' | 'tool' | 'shell' | 'user_shell' | 'permission' | 'status' | 'error' | 'debug'`. */
   DaemonTranscriptBlockKind,
   /** Interactive question block (ask_user_question tool preview). */
   DaemonTranscriptQuestion,

--- a/packages/webui/src/daemon/index.ts
+++ b/packages/webui/src/daemon/index.ts
@@ -97,7 +97,10 @@ export {
 // ── Re-exported SDK types/constants for UI consumers ──────────────
 // These allow web-shell and other UI packages to depend only on
 // @qwen-code/webui without importing @qwen-code/sdk/daemon directly.
-export { DAEMON_APPROVAL_MODES } from '@qwen-code/sdk/daemon';
+export {
+  DAEMON_APPROVAL_MODES,
+  isDaemonTurnError,
+} from '@qwen-code/sdk/daemon';
 export type {
   DaemonApprovalMode,
   DaemonAuthProviderBaseUrlOption,
@@ -111,6 +114,8 @@ export type {
   DaemonContextMemoryDetail,
   DaemonContextSkillDetail,
   DaemonContextToolDetail,
+  DaemonRewindResult,
+  DaemonRewindSnapshotInfo,
   DaemonSessionContextUsage,
   DaemonSessionContextUsageStatus,
   DaemonSessionStatsModelMetrics,

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -50,6 +50,24 @@ interface MockSession {
   setModel: (modelId: string) => Promise<{ modelId: string }>;
   heartbeat: () => Promise<{ ok: boolean }>;
   shellCommand: (command: string, signal?: AbortSignal) => Promise<unknown>;
+  getRewindSnapshots: () => Promise<{
+    snapshots: Array<{
+      promptId?: string;
+      turnIndex: number;
+      timestamp: string;
+      diffStats: {
+        filesChanged: number;
+        insertions: number;
+        deletions: number;
+      };
+    }>;
+  }>;
+  rewind: (req: { targetTurnIndex: number; promptId?: string }) => Promise<{
+    rewound: boolean;
+    targetTurnIndex: number;
+    filesChanged: string[];
+    filesFailed: string[];
+  }>;
   context: () => Promise<{
     v: 1;
     sessionId: string;
@@ -179,7 +197,7 @@ const sdkMocks = vi.hoisted(() => {
       });
       workspaceProviders.mockReset();
       workspaceProviders.mockResolvedValue({
-        v: 1,
+        v: 1 as const,
         workspaceCwd: '/mock-workspace',
         initialized: true,
         providers: [],
@@ -663,6 +681,86 @@ describe('DaemonSessionProvider', () => {
       },
       expect.any(AbortSignal),
     );
+  });
+
+  it('loads rewind snapshots and reloads the session after rewind', async () => {
+    const getRewindSnapshots = vi.fn(async () => ({
+      snapshots: [
+        {
+          promptId: 'prompt-1',
+          turnIndex: 3,
+          timestamp: '2026-06-11T00:00:00.000Z',
+          diffStats: { filesChanged: 1, insertions: 2, deletions: 3 },
+        },
+      ],
+    }));
+    const rewind = vi.fn(async () => ({
+      rewound: true,
+      targetTurnIndex: 3,
+      filesChanged: ['README.md'],
+      filesFailed: [],
+    }));
+    const session = createMockSession({
+      sessionId: 'session-rewind',
+      getRewindSnapshots,
+      rewind,
+      events: createIdleEvents(),
+    });
+    const reloadedSession = createMockSession({
+      sessionId: 'session-rewind',
+      events: createIdleEvents(),
+    });
+    sdkMocks.sessions.push(session, reloadedSession);
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    const providerActions = actions;
+    if (!providerActions) throw new Error('actions were not initialized');
+
+    await act(async () => {
+      await expect(providerActions.getRewindSnapshots()).resolves.toEqual({
+        snapshots: [
+          expect.objectContaining({
+            promptId: 'prompt-1',
+            turnIndex: 3,
+          }),
+        ],
+      });
+    });
+    let rewindPromise: ReturnType<DaemonSessionActions['rewind']> | undefined;
+    act(() => {
+      rewindPromise = providerActions.rewind(3, 'prompt-1');
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+    await expect(rewindPromise).resolves.toMatchObject({
+      rewound: true,
+      targetTurnIndex: 3,
+    });
+
+    expect(getRewindSnapshots).toHaveBeenCalledTimes(1);
+    expect(rewind).toHaveBeenCalledWith({
+      targetTurnIndex: 3,
+      promptId: 'prompt-1',
+    });
+    expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledWith(
+      expect.anything(),
+      'session-rewind',
+      { workspaceCwd: '/mock-workspace' },
+      expect.any(String),
+    );
+    expect(connection).toMatchObject({
+      status: 'connected',
+      sessionId: 'session-rewind',
+    });
   });
 
   it('submits permission selections with optional answers', async () => {
@@ -2989,20 +3087,9 @@ describe('DaemonSessionProvider', () => {
         ],
         liveJournal: [],
       },
-      events: async function* reloadedIdleEvents(
-        opts: { signal?: AbortSignal } = {},
-      ) {
+      events: function reloadedIdleEvents(opts: { signal?: AbortSignal } = {}) {
         reloaded.resolve();
-        await new Promise<void>((resolve) => {
-          if (opts.signal?.aborted) {
-            resolve();
-            return;
-          }
-          opts.signal?.addEventListener('abort', () => resolve(), {
-            once: true,
-          });
-        });
-        yield* [];
+        return createIdleEvents()(opts);
       },
     });
     sdkMocks.sessions.push(firstSession, reloadedSession);
@@ -3045,6 +3132,95 @@ describe('DaemonSessionProvider', () => {
         expect.objectContaining({
           kind: 'error',
           text: expect.stringContaining('State resync required'),
+        }),
+      ]),
+    );
+  });
+
+  it('reloads the session snapshot after a conversation-only rewind event', async () => {
+    const reloaded = createDeferred<void>();
+    const firstSession = createMockSession({
+      sessionId: 'session-rewound',
+      lastEventId: 20,
+      events: async function* rewindEvents() {
+        yield {
+          id: 21,
+          v: 1,
+          type: 'session_rewound',
+          data: {
+            sessionId: 'session-rewound',
+            targetTurnIndex: 1,
+            filesChanged: [],
+            filesFailed: [],
+          },
+        };
+      },
+    });
+    const reloadedSession = createMockSession({
+      sessionId: 'session-rewound',
+      replaySnapshot: {
+        compactedReplay: [
+          {
+            id: 22,
+            v: 1,
+            type: 'session_update',
+            data: {
+              update: {
+                sessionUpdate: 'agent_message_chunk',
+                content: { type: 'text', text: 'rewound history' },
+              },
+            },
+          },
+        ],
+        liveJournal: [],
+      },
+      events: function reloadedIdleEvents(opts: { signal?: AbortSignal } = {}) {
+        reloaded.resolve();
+        return createIdleEvents()(opts);
+      },
+    });
+    sdkMocks.sessions.push(firstSession, reloadedSession);
+
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+    function Harness() {
+      blocks = useDaemonTranscriptBlocks();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      reconnectDelayMs: 1,
+      maxReconnectDelayMs: 1,
+    });
+    await act(async () => {
+      await reloaded.promise;
+      await flushPromises();
+    });
+
+    expect(sdkMocks.MockDaemonSessionClient.load).toHaveBeenCalledWith(
+      expect.anything(),
+      'session-rewound',
+      { workspaceCwd: '/mock-workspace' },
+      expect.any(String),
+    );
+    expect(blocks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'assistant',
+          text: 'rewound history',
+        }),
+        expect.objectContaining({
+          kind: 'status',
+          text: 'Conversation rewound.',
+          source: 'conversation_rewind',
+        }),
+      ]),
+    );
+    expect(blocks).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'error',
+          text: expect.stringContaining('session_rewound'),
         }),
       ]),
     );
@@ -3776,7 +3952,7 @@ describe('DaemonSessionProvider', () => {
     ) {
       callCount += 1;
       if (callCount === 1) {
-        yield {
+        const event: DaemonEvent = {
           id: 5,
           v: 1 as const,
           type: 'session_update' as const,
@@ -3787,10 +3963,11 @@ describe('DaemonSessionProvider', () => {
             },
           },
         };
+        yield event;
         throw new Error('network timeout');
       }
       // Second call: delta resume succeeds with new content
-      yield {
+      const event: DaemonEvent = {
         id: 6,
         v: 1 as const,
         type: 'session_update' as const,
@@ -3801,6 +3978,7 @@ describe('DaemonSessionProvider', () => {
           },
         },
       };
+      yield event;
       await new Promise<void>((resolve) => {
         if (opts.signal?.aborted) {
           resolve();
@@ -4118,6 +4296,19 @@ function createMockSession(opts: Partial<MockSession> = {}): MockSession {
       })),
     heartbeat: opts.heartbeat ?? vi.fn(async () => ({ ok: true })),
     shellCommand: opts.shellCommand ?? vi.fn(async () => undefined),
+    getRewindSnapshots:
+      opts.getRewindSnapshots ??
+      vi.fn(async () => ({
+        snapshots: [],
+      })),
+    rewind:
+      opts.rewind ??
+      vi.fn(async () => ({
+        rewound: true,
+        targetTurnIndex: 1,
+        filesChanged: [],
+        filesFailed: [],
+      })),
     context:
       opts.context ??
       vi.fn(async () => ({

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -153,6 +153,7 @@ const INITIAL_WORKSPACE_EVENT_SIGNALS: DaemonWorkspaceEventSignals = {
  * those are recoverable by creating a fresh session.
  */
 const AUTH_FAILURE_HTTP_STATUSES = new Set([401, 403]);
+const REWIND_STATUS_TEXT = 'Conversation rewound.';
 
 export function DaemonSessionProvider({
   baseUrl,
@@ -198,6 +199,7 @@ export function DaemonSessionProvider({
     undefined,
   );
   const pendingSessionLoadIdRef = useRef(0);
+  const pendingRewindNoticeRef = useRef(false);
   const passiveAssistantDoneTimerRef = useRef<
     ReturnType<typeof setTimeout> | undefined
   >(undefined);
@@ -613,6 +615,14 @@ export function DaemonSessionProvider({
             }
             setConnection((c) => ({ ...c, catchingUp: undefined }));
           }
+          if (pendingRewindNoticeRef.current) {
+            pendingRewindNoticeRef.current = false;
+            store.dispatch({
+              type: 'status',
+              text: REWIND_STATUS_TEXT,
+              source: 'conversation_rewind',
+            });
+          }
           if (pendingLoadToResolve) {
             pendingSessionLoadRef.current = undefined;
             clearTimeout(pendingLoadToResolve.timeout);
@@ -662,6 +672,19 @@ export function DaemonSessionProvider({
                   epochReplaySourceEvents = [];
                   continue;
                 }
+              }
+              if (event.type === 'session_rewound') {
+                store.reset();
+                pendingRewindNoticeRef.current = true;
+                resyncRequested = true;
+                session = undefined;
+                sessionRef.current = undefined;
+                setConnection((current) => ({
+                  ...current,
+                  status: 'connecting',
+                  error: undefined,
+                }));
+                break;
               }
               if (epochReplayUiEvents) {
                 epochReplaySourceEvents.push(event);

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -545,6 +545,56 @@ export function createDaemonSessionActions({
       }
     },
 
+    async getRewindSnapshots() {
+      const session = requireSessionForAction(
+        addNotice,
+        sessionRef.current,
+        'Load rewind snapshots failed',
+        'load_rewind_snapshots',
+      );
+      try {
+        return await withActionTimeout(
+          session.getRewindSnapshots(),
+          'Load rewind snapshots timed out',
+        );
+      } catch (error) {
+        throw dispatchActionError(
+          addNotice,
+          'Load rewind snapshots failed',
+          error,
+          'load_rewind_snapshots',
+        );
+      }
+    },
+
+    async rewind(targetTurnIndex, promptId) {
+      const session = requireSessionForAction(
+        addNotice,
+        sessionRef.current,
+        'Rewind failed',
+        'rewind_session',
+      );
+      const sessionId = session.sessionId;
+      try {
+        const result = await withActionTimeout(
+          session.rewind({
+            targetTurnIndex,
+            ...(promptId ? { promptId } : {}),
+          }),
+          'Rewind timed out',
+        );
+        void startSessionSwitch(sessionId, 'load').catch(() => {});
+        return result;
+      } catch (error) {
+        throw dispatchActionError(
+          addNotice,
+          'Rewind failed',
+          error,
+          'rewind_session',
+        );
+      }
+    },
+
     async recapSession(): Promise<DaemonSessionRecapResult> {
       const session = requireSessionForAction(
         addNotice,

--- a/packages/webui/src/daemon/session/types.ts
+++ b/packages/webui/src/daemon/session/types.ts
@@ -15,6 +15,8 @@ import type {
   DaemonSessionContextStatus,
   DaemonSessionContextUsageStatus,
   DaemonSessionRecapResult,
+  DaemonRewindResult,
+  DaemonRewindSnapshotInfo,
   DaemonSessionSummary,
   DaemonSessionSupportedCommandsStatus,
   DaemonSessionTaskStatus,
@@ -113,6 +115,8 @@ export type DaemonNoticeOperation =
   | 'list_sessions'
   | 'load_context'
   | 'load_context_usage'
+  | 'load_rewind_snapshots'
+  | 'rewind_session'
   | 'load_tasks'
   | 'cancel_task'
   | 'clear_goal'
@@ -237,6 +241,11 @@ export interface DaemonSessionActions {
     detail?: boolean;
   }): Promise<DaemonSessionContextUsageStatus>;
   renameSession(displayName: string): Promise<SessionMetadataResult>;
+  getRewindSnapshots(): Promise<{ snapshots: DaemonRewindSnapshotInfo[] }>;
+  rewind(
+    targetTurnIndex: number,
+    promptId?: string,
+  ): Promise<DaemonRewindResult>;
   recapSession(): Promise<DaemonSessionRecapResult>;
   btwSession(
     question: string,

--- a/scripts/daemon-dev.js
+++ b/scripts/daemon-dev.js
@@ -6,13 +6,23 @@
 
 import { spawn } from 'node:child_process';
 import crypto from 'node:crypto';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import http from 'node:http';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import { platform } from 'node:os';
+import { platform, tmpdir } from 'node:os';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, '..');
+const acpBridgeLoaderDir = mkdtempSync(join(tmpdir(), 'qwen-daemon-dev-'));
+const acpBridgeLoaderPath = join(acpBridgeLoaderDir, 'acp-bridge-loader.mjs');
+const acpBridgeRegisterPath = join(
+  acpBridgeLoaderDir,
+  'acp-bridge-register.mjs',
+);
+const acpBridgeSourceRootUrl = pathToFileURL(
+  join(root, 'packages', 'acp-bridge', 'src'),
+).href;
 const args = process.argv.slice(2);
 const isWin = platform() === 'win32';
 const serveOptionNames = new Set([
@@ -179,12 +189,21 @@ function shutdown(code) {
     pending += 1;
     child.on('close', () => {
       pending -= 1;
-      if (pending <= 0) process.exit(code);
+      if (pending <= 0) exit(code);
     });
     killChild(child);
   }
-  if (pending === 0) process.exit(code);
-  setTimeout(() => process.exit(code), 5_000).unref();
+  if (pending === 0) exit(code);
+  setTimeout(() => exit(code), 5_000).unref();
+}
+
+function exit(code) {
+  try {
+    rmSync(acpBridgeLoaderDir, { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup errors.
+  }
+  process.exit(code);
 }
 
 const children = [];
@@ -196,7 +215,7 @@ try {
   console.error(
     `[daemon-dev] ${err instanceof Error ? err.message : String(err)}`,
   );
-  process.exit(1);
+  exit(1);
 }
 
 const port = readOption('--port') || '4170';
@@ -204,7 +223,7 @@ if (port === '0') {
   console.error(
     'daemon-dev: --port 0 is not supported; the launcher needs a fixed port to poll for health.',
   );
-  process.exit(1);
+  exit(1);
 }
 
 const hostname = readOption('--hostname') || '127.0.0.1';
@@ -220,7 +239,48 @@ if (!hasOption('--workspace')) serveArgs.push('--workspace', workspace);
 const tsxLoaderUrl = pathToFileURL(
   join(root, 'node_modules', 'tsx', 'dist', 'esm', 'index.mjs'),
 ).href;
-const nodeOptions = [process.env.NODE_OPTIONS, `--import ${tsxLoaderUrl}`]
+writeFileSync(
+  acpBridgeLoaderPath,
+  `
+const acpBridgeSourceRootUrl = '${acpBridgeSourceRootUrl}';
+
+export function resolve(specifier, context, nextResolve) {
+  if (specifier === '@qwen-code/acp-bridge') {
+    return {
+      shortCircuit: true,
+      url: acpBridgeSourceRootUrl + '/index.ts',
+      format: 'module',
+    };
+  }
+  if (specifier.startsWith('@qwen-code/acp-bridge/')) {
+    return {
+      shortCircuit: true,
+      url:
+        acpBridgeSourceRootUrl +
+        '/' +
+        specifier.slice('@qwen-code/acp-bridge/'.length) +
+        '.ts',
+      format: 'module',
+    };
+  }
+  return nextResolve(specifier, context);
+}
+`,
+);
+writeFileSync(
+  acpBridgeRegisterPath,
+  `
+import { register } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+register('${pathToFileURL(acpBridgeLoaderPath).href}', pathToFileURL('./'));
+`,
+);
+const nodeOptions = [
+  process.env.NODE_OPTIONS,
+  `--import ${tsxLoaderUrl}`,
+  `--import ${pathToFileURL(acpBridgeRegisterPath).href}`,
+]
   .filter(Boolean)
   .join(' ');
 


### PR DESCRIPTION

## What this PR does

Adds conversation rewind support for daemon-backed web-shell sessions. The web-shell exposes a rewind command and dialog, asks the daemon for rewindable turns, sends the selected rewind request, reloads the active session snapshot, and shows a local `Conversation rewound.` status block tagged with `source: conversation_rewind`.

The daemon bridge now supports rewinding an active session replay cache when a rewind succeeds, so subsequent session loads reflect the rewound conversation instead of stale live events. The SDK and web UI clients expose the rewind API and typed rewind event needed by the UI.

## Why it is needed

Users need a way to return a web-shell conversation to an earlier turn without restarting the daemon or relying on persisted history reloads. Active sessions previously could keep stale replay data after a rewind, which made `/load` show old conversation turns until the daemon restarted.

## Reviewer Test Plan

### How to verify

Run web-shell against a daemon session, send several prompts, run the rewind command, choose an earlier turn, and confirm the visible transcript reloads to the selected point. Confirm the transcript includes a `Conversation rewound.` status block and that `useTranscriptBlocks()` marks that block with `source: conversation_rewind`. Confirm loading the same active session after rewind does not include turns after the rewind point.

Focused local checks run:

```bash
cd packages/acp-bridge && npx vitest run src/compactionEngine.test.ts -t "session_rewound trims active replay cache"
cd packages/sdk-typescript && npx vitest run test/unit/daemonUi.test.ts -t "normalizes session_rewound as a typed event"
cd packages/sdk-typescript && npx vitest run test/unit/daemonUi.test.ts -t "preserves status source"
cd packages/webui && npx vitest run src/daemon/session/DaemonSessionProvider.test.tsx -t "reloads the session snapshot after a conversation-only rewind event"
cd packages/web-shell && npx vitest run client/adapters/transcriptToMessages.test.ts -t "renders daemon plan status blocks as plan messages"
node --check scripts/daemon-dev.js
git diff --check
```

### Evidence (Before & After)

Before: web-shell had no conversation rewind flow, and an active daemon session load could still include stale post-rewind turns in replay data. After: web-shell can rewind to a prior turn, reloads the session snapshot, shows `Conversation rewound.`, and active replay snapshots are trimmed when the daemon publishes the rewind event.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Local development workspace with targeted Vitest, ESLint through the pre-commit hook, and `npm run dev:daemon` source-loading adjustments for daemon development.

## Risk & Scope

- Main risk or tradeoff: rewind reloads the session snapshot and injects a local status block, so UI state around the active session is reset as part of the operation.
- Not validated / out of scope: full cross-platform manual browser testing and full repository test suite.
- Breaking changes / migration notes: none expected; the rewind API is additive.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

为 daemon 驱动的 web-shell 会话增加对话回退能力。web-shell 现在提供回退命令和弹窗，可以从 daemon 获取可回退的轮次，提交选中的回退请求，重新加载当前会话快照，并显示带有 `source: conversation_rewind` 的本地状态块 `Conversation rewound.`。

daemon bridge 现在会在回退成功后同步裁剪活跃会话的 replay 缓存，因此后续加载会话时会反映回退后的对话，而不是继续带着旧的 live events。SDK 和 web UI client 也暴露了 UI 所需的 rewind API 和类型化 rewind event。

## Why it is needed

用户需要在 web-shell 中把对话回到更早轮次，而不必重启 daemon 或依赖持久化历史重新加载。此前活跃会话在回退后仍可能保留 stale replay 数据，导致 `/load` 在 daemon 重启前仍显示旧的后续对话轮次。

## Reviewer Test Plan

### How to verify

使用 web-shell 连接 daemon 会话，发送多轮 prompt，运行 rewind 命令，选择更早的轮次，并确认可见 transcript 重新加载到选中的位置。确认 transcript 中出现 `Conversation rewound.` 状态块，并且 `useTranscriptBlocks()` 返回的该状态块带有 `source: conversation_rewind`。确认回退后再次加载同一个活跃会话时，不再包含回退点之后的对话轮次。

本地已运行的聚焦检查：

```bash
cd packages/acp-bridge && npx vitest run src/compactionEngine.test.ts -t "session_rewound trims active replay cache"
cd packages/sdk-typescript && npx vitest run test/unit/daemonUi.test.ts -t "normalizes session_rewound as a typed event"
cd packages/sdk-typescript && npx vitest run test/unit/daemonUi.test.ts -t "preserves status source"
cd packages/webui && npx vitest run src/daemon/session/DaemonSessionProvider.test.tsx -t "reloads the session snapshot after a conversation-only rewind event"
cd packages/web-shell && npx vitest run client/adapters/transcriptToMessages.test.ts -t "renders daemon plan status blocks as plan messages"
node --check scripts/daemon-dev.js
git diff --check
```

### Evidence (Before & After)

Before：web-shell 没有对话回退流程，活跃 daemon 会话的 load 仍可能在 replay 数据中包含回退后的旧轮次。After：web-shell 可以回退到先前轮次，重新加载会话快照，显示 `Conversation rewound.`，并且 daemon 发布回退事件时会裁剪活跃 replay 快照。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

本地开发工作区，运行了聚焦 Vitest、pre-commit hook 中的 ESLint，以及用于 daemon 开发的 `npm run dev:daemon` 源码加载调整。

## Risk & Scope

- Main risk or tradeoff: rewind 会重新加载会话快照并注入一个本地状态块，因此当前会话相关 UI 状态会随操作被重置。
- Not validated / out of scope: 完整跨平台浏览器手动测试和完整仓库测试套件。
- Breaking changes / migration notes: 预计没有；rewind API 是增量新增。

## Linked Issues

N/A

</details>
