### PR TITLE
fix(stats): dedup usage records by sessionId and skip in-progress writes

### DIFF
--- a/packages/cli/src/ui/utils/statsDataService.ts
+++ b/packages/cli/src/ui/utils/statsDataService.ts
@@ -248,7 +248,7 @@ export async function loadStatsData(
   range: TimeRange,
   currentSession?: UsageSummaryRecord,
 ): Promise<StatsData> {
-  const persisted = await loadUsageHistory();
+  const persisted = await loadUsageHistory(currentSession?.sessionId);
   let records = persisted;
   if (currentSession) {
     records = persisted.filter((r) => r.sessionId !== currentSession.sessionId);

--- a/packages/core/src/services/usageHistoryService.test.ts
+++ b/packages/core/src/services/usageHistoryService.test.ts
@@ -515,7 +515,7 @@ describe('loadUsageHistory + persistSessionUsage (issue #4994 regression)', () =
     expect(report.sessionCount).toBe(1);
   });
 
-  it('write-side: rebuildFromSessionJsonl skips the in-progress session when currentSessionId is passed', async () => {
+  it('write-side: rebuildFromSessionJsonl skips the in-progress session when skipSessionInRebuild is passed', async () => {
     const sessionId = 'sess-in-progress';
     plantChatJsonl(sessionId, 1600);
     const usagePath = path.join(

--- a/packages/core/src/services/usageHistoryService.test.ts
+++ b/packages/core/src/services/usageHistoryService.test.ts
@@ -4,8 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
-import { metricsToUsageRecord, aggregateUsage } from './usageHistoryService.js';
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  metricsToUsageRecord,
+  aggregateUsage,
+  loadUsageHistory,
+  persistSessionUsage,
+} from './usageHistoryService.js';
 import { ToolCallDecision } from '../telemetry/tool-call-decision.js';
 import type { SessionMetrics } from '../telemetry/uiTelemetry.js';
 import type { UsageSummaryRecord } from './usageHistoryService.js';
@@ -347,5 +355,224 @@ describe('aggregateUsage', () => {
     expect(report.totalLatencyMs).toBe(0);
     expect(report.totalRequests).toBe(0);
     expect(report.tools.topTools).toEqual([]);
+  });
+});
+
+// Regression coverage for issue #4994: opening /stats during the first-ever
+// turn followed by /clear or process exit used to write the same sessionId
+// twice into usage_record.jsonl, permanently inflating every aggregate 2x.
+describe('loadUsageHistory + persistSessionUsage (issue #4994 regression)', () => {
+  let tmpHome: string;
+  let originalQwenHome: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'qwen-usage-history-'));
+    originalQwenHome = process.env['QWEN_HOME'];
+    process.env['QWEN_HOME'] = path.join(tmpHome, '.qwen');
+    fs.mkdirSync(process.env['QWEN_HOME'], { recursive: true });
+  });
+
+  afterEach(() => {
+    if (originalQwenHome === undefined) delete process.env['QWEN_HOME'];
+    else process.env['QWEN_HOME'] = originalQwenHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  function plantChatJsonl(sessionId: string, tokens: number) {
+    const cwd = '/repro/project';
+    const start = new Date('2026-06-11T00:00:00Z').toISOString();
+    const mid = new Date('2026-06-11T00:01:00Z').toISOString();
+    const end = new Date('2026-06-11T00:02:00Z').toISOString();
+    const projDir = path.join(
+      process.env['QWEN_HOME']!,
+      'projects',
+      'repro-project',
+    );
+    fs.mkdirSync(path.join(projDir, 'chats'), { recursive: true });
+    const records = [
+      {
+        sessionId,
+        cwd,
+        uuid: 'u1',
+        parentUuid: null,
+        timestamp: start,
+        type: 'user',
+        message: { role: 'user', content: 'hi' },
+      },
+      {
+        sessionId,
+        cwd,
+        uuid: 'u2',
+        parentUuid: 'u1',
+        timestamp: mid,
+        type: 'system',
+        subtype: 'ui_telemetry',
+        systemPayload: {
+          uiEvent: {
+            'event.name': 'qwen-code.api_response',
+            'event.timestamp': mid,
+            response_id: 'r1',
+            model: 'qwen-max',
+            duration_ms: 1200,
+            input_token_count: tokens * 0.6,
+            output_token_count: tokens * 0.3,
+            cached_content_token_count: 0,
+            thoughts_token_count: tokens * 0.1,
+            total_token_count: tokens,
+            prompt_id: 'p1',
+          },
+        },
+      },
+      {
+        sessionId,
+        cwd,
+        uuid: 'u3',
+        parentUuid: 'u2',
+        timestamp: end,
+        type: 'assistant',
+        message: { role: 'assistant', content: 'ok' },
+      },
+    ];
+    fs.writeFileSync(
+      path.join(projDir, 'chats', `${sessionId}.jsonl`),
+      records.map((r) => JSON.stringify(r)).join('\n') + '\n',
+    );
+  }
+
+  function makeLiveMetrics(tokens: number): SessionMetrics {
+    return {
+      models: {
+        'qwen-max': {
+          api: { totalRequests: 1, totalErrors: 0, totalLatencyMs: 1200 },
+          tokens: {
+            prompt: tokens * 0.6,
+            candidates: tokens * 0.3,
+            total: tokens,
+            cached: 0,
+            thoughts: tokens * 0.1,
+          },
+          bySource: {},
+        },
+      },
+      tools: {
+        totalCalls: 0,
+        totalSuccess: 0,
+        totalFail: 0,
+        totalDurationMs: 0,
+        totalDecisions: {
+          [ToolCallDecision.ACCEPT]: 0,
+          [ToolCallDecision.REJECT]: 0,
+          [ToolCallDecision.MODIFY]: 0,
+          [ToolCallDecision.AUTO_ACCEPT]: 0,
+        },
+        byName: {},
+      },
+      files: { totalLinesAdded: 0, totalLinesRemoved: 0 },
+    };
+  }
+
+  it('read-side: dedups duplicate sessionId records already on disk (last-wins)', async () => {
+    // Simulate a usage_record.jsonl already corrupted by the pre-fix bug:
+    // two records with the same sessionId.
+    const sessionId = 'sess-dup-1';
+    const usagePath = path.join(
+      process.env['QWEN_HOME']!,
+      'usage_record.jsonl',
+    );
+    const rec = (totalTokens: number) => ({
+      version: 1 as const,
+      sessionId,
+      timestamp: Date.now(),
+      startTime: Date.now() - 60000,
+      project: '/p',
+      durationMs: 60000,
+      totalLatencyMs: 1200,
+      models: {
+        'qwen-max': {
+          requests: 1,
+          inputTokens: totalTokens * 0.6,
+          outputTokens: totalTokens * 0.3,
+          cachedTokens: 0,
+          thoughtsTokens: totalTokens * 0.1,
+          totalTokens,
+        },
+      },
+      tools: { totalCalls: 0, totalSuccess: 0, totalFail: 0, byName: {} },
+      files: { linesAdded: 0, linesRemoved: 0 },
+    });
+    fs.writeFileSync(
+      usagePath,
+      JSON.stringify(rec(1000)) + '\n' + JSON.stringify(rec(1600)) + '\n',
+    );
+
+    const records = await loadUsageHistory();
+
+    expect(records).toHaveLength(1);
+    // Last-wins: the second record (1600 tokens) survives.
+    expect(records[0]!.models['qwen-max']!.totalTokens).toBe(1600);
+
+    const report = aggregateUsage(records, 'all');
+    expect(report.sessionCount).toBe(1);
+  });
+
+  it('write-side: rebuildFromSessionJsonl skips the in-progress session when currentSessionId is passed', async () => {
+    const sessionId = 'sess-in-progress';
+    plantChatJsonl(sessionId, 1600);
+    const usagePath = path.join(
+      process.env['QWEN_HOME']!,
+      'usage_record.jsonl',
+    );
+
+    // First /stats open during the live session.
+    const first = await loadUsageHistory(sessionId);
+    expect(first).toHaveLength(1);
+    // Critically: the file must NOT contain the in-progress session.
+    expect(fs.existsSync(usagePath)).toBe(false);
+
+    // /clear or process exit writes the authoritative record exactly once.
+    persistSessionUsage({
+      sessionId,
+      startTime: new Date('2026-06-11T00:00:00Z'),
+      endTime: new Date('2026-06-11T00:02:00Z'),
+      project: '/repro/project',
+      metrics: makeLiveMetrics(1600),
+    });
+    const lines = fs.readFileSync(usagePath, 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+
+    // Subsequent /stats open after session end aggregates exactly one record.
+    const second = await loadUsageHistory();
+    expect(second).toHaveLength(1);
+    const report = aggregateUsage(second, 'all');
+    expect(report.sessionCount).toBe(1);
+    let totalTokens = 0;
+    for (const m of Object.values(report.models)) totalTokens += m.totalTokens;
+    expect(totalTokens).toBe(1600);
+  });
+
+  it('end-to-end: /stats during first turn + /clear must not 2x the session', async () => {
+    const sessionId = 'sess-e2e';
+    plantChatJsonl(sessionId, 1600);
+
+    // Step 1: open /stats (first time) during the live session.
+    await loadUsageHistory(sessionId);
+
+    // Step 2: /clear or exit.
+    persistSessionUsage({
+      sessionId,
+      startTime: new Date('2026-06-11T00:00:00Z'),
+      endTime: new Date('2026-06-11T00:02:00Z'),
+      project: '/repro/project',
+      metrics: makeLiveMetrics(1600),
+    });
+
+    // Step 3: re-open /stats.
+    const records = await loadUsageHistory();
+    const report = aggregateUsage(records, 'all');
+
+    expect(report.sessionCount).toBe(1);
+    let totalTokens = 0;
+    for (const m of Object.values(report.models)) totalTokens += m.totalTokens;
+    expect(totalTokens).toBe(1600);
   });
 });

--- a/packages/core/src/services/usageHistoryService.ts
+++ b/packages/core/src/services/usageHistoryService.ts
@@ -173,7 +173,9 @@ export function metricsToUsageRecord(
   };
 }
 
-async function rebuildFromSessionJsonl(): Promise<UsageSummaryRecord[]> {
+async function rebuildFromSessionJsonl(
+  currentSessionId?: string,
+): Promise<UsageSummaryRecord[]> {
   const projectsDir = path.join(Storage.getGlobalQwenDir(), 'projects');
   try {
     if (!fs.existsSync(projectsDir)) return [];
@@ -261,6 +263,10 @@ async function rebuildFromSessionJsonl(): Promise<UsageSummaryRecord[]> {
   if (results.length > 0) {
     const usagePath = getUsageHistoryPath();
     for (const record of results) {
+      // Skip the in-progress current session: persistSessionUsage() will write
+      // its authoritative record on /clear or exit. Writing here would create
+      // a permanent duplicate in usage_record.jsonl (issue #4994).
+      if (currentSessionId && record.sessionId === currentSessionId) continue;
       jsonl.writeLineSync(usagePath, record);
     }
   }
@@ -268,16 +274,27 @@ async function rebuildFromSessionJsonl(): Promise<UsageSummaryRecord[]> {
   return results;
 }
 
-export async function loadUsageHistory(): Promise<UsageSummaryRecord[]> {
+function dedupBySessionId(records: UsageSummaryRecord[]): UsageSummaryRecord[] {
+  // Last-wins by sessionId. Protects existing users whose usage_record.jsonl
+  // already contains duplicates produced by the bug fixed in this change
+  // (issue #4994) — without this, every aggregate stays inflated forever.
+  const map = new Map<string, UsageSummaryRecord>();
+  for (const r of records) map.set(r.sessionId, r);
+  return [...map.values()];
+}
+
+export async function loadUsageHistory(
+  currentSessionId?: string,
+): Promise<UsageSummaryRecord[]> {
   try {
     const records = await jsonl.read<UsageSummaryRecord>(getUsageHistoryPath());
     const filtered = records.filter((r) => r.version === 1);
-    if (filtered.length > 0) return filtered;
+    if (filtered.length > 0) return dedupBySessionId(filtered);
   } catch (e) {
     debugLogger.debug(`loadUsageHistory: failed to read usage file: ${e}`);
   }
 
-  return rebuildFromSessionJsonl();
+  return dedupBySessionId(await rebuildFromSessionJsonl(currentSessionId));
 }
 
 export function getTimeRangeBounds(range: TimeRange): {

--- a/packages/core/src/services/usageHistoryService.ts
+++ b/packages/core/src/services/usageHistoryService.ts
@@ -174,7 +174,7 @@ export function metricsToUsageRecord(
 }
 
 async function rebuildFromSessionJsonl(
-  currentSessionId?: string,
+  skipSessionInRebuild?: string,
 ): Promise<UsageSummaryRecord[]> {
   const projectsDir = path.join(Storage.getGlobalQwenDir(), 'projects');
   try {
@@ -266,7 +266,8 @@ async function rebuildFromSessionJsonl(
       // Skip the in-progress current session: persistSessionUsage() will write
       // its authoritative record on /clear or exit. Writing here would create
       // a permanent duplicate in usage_record.jsonl (issue #4994).
-      if (currentSessionId && record.sessionId === currentSessionId) continue;
+      if (skipSessionInRebuild && record.sessionId === skipSessionInRebuild)
+        continue;
       jsonl.writeLineSync(usagePath, record);
     }
   }
@@ -280,11 +281,16 @@ function dedupBySessionId(records: UsageSummaryRecord[]): UsageSummaryRecord[] {
   // (issue #4994) — without this, every aggregate stays inflated forever.
   const map = new Map<string, UsageSummaryRecord>();
   for (const r of records) map.set(r.sessionId, r);
+  if (map.size < records.length) {
+    debugLogger.debug(
+      `dedupBySessionId: removed ${records.length - map.size} duplicate record(s)`,
+    );
+  }
   return [...map.values()];
 }
 
 export async function loadUsageHistory(
-  currentSessionId?: string,
+  skipSessionInRebuild?: string,
 ): Promise<UsageSummaryRecord[]> {
   try {
     const records = await jsonl.read<UsageSummaryRecord>(getUsageHistoryPath());
@@ -294,7 +300,7 @@ export async function loadUsageHistory(
     debugLogger.debug(`loadUsageHistory: failed to read usage file: ${e}`);
   }
 
-  return dedupBySessionId(await rebuildFromSessionJsonl(currentSessionId));
+  return dedupBySessionId(await rebuildFromSessionJsonl(skipSessionInRebuild));
 }
 
 export function getTimeRangeBounds(range: TimeRange): {


### PR DESCRIPTION
## Summary

Closes #4994.

Opening `/stats` during the first-ever turn followed by `/clear` (or process exit) used to write the same `sessionId` **twice** into `~/.qwen/usage_record.jsonl`, permanently inflating every `/stats` aggregate (sessions / tokens / durations / tool counts / heatmap / projects) **2×** for that session. The mechanism, deterministic repro, and code-level walkthrough are in #4994 (the bug is real on `main` @ `ac040d0a6` — repro script in that issue).

This is also the same `aggregateUsage`-dedup Critical raised by @wenshao in the review of #4779.

## Fix — defense in depth

1. **Read side** (`usageHistoryService.ts` — `loadUsageHistory`): records are deduped by `sessionId` with **last-wins** before being returned. Users whose `usage_record.jsonl` already contains duplicates from this bug stop seeing inflated aggregates immediately, without any file rewrite.
2. **Write side** (`usageHistoryService.ts` — `rebuildFromSessionJsonl(currentSessionId?)`): when called with the in-progress session's id, that session is skipped during the file write. `persistSessionUsage()` will write its authoritative record at `/clear` / exit, so the in-progress snapshot would only ever be a transient duplicate. `statsDataService.ts` threads `currentSession?.sessionId` through.

Both fixes are needed: read-side alone leaves the file growing duplicates forever; write-side alone doesn't help users whose files are already corrupted by the bug.

## Test plan

- [x] `packages/core` — new regression tests in `usageHistoryService.test.ts` (3 cases):
  - read-side dedup of pre-existing duplicates (last-wins)
  - write-side skip when `currentSessionId` is passed — `usage_record.jsonl` stays empty until `persistSessionUsage`
  - end-to-end repro of issue #4994 (`/stats` during first turn → `/clear` → `/stats`) asserts `sessionCount === 1`, `totalTokens === 1600`
- [x] `usageHistoryService.test.ts` — 13/13 pass (10 pre-existing + 3 new)
- [x] `statsDataService.test.ts` — 17/17 pass
- [x] `statsCommand.test.ts` — 13/13 pass
- [x] `clearCommand.test.ts` — 15/15 pass
- [x] `tsc --noEmit` core + cli pass
- [x] `prettier --write` + `eslint` on changed files clean
- [x] Standalone repro from #4994 now prints `✅ no double count` (was `🐛 BUG CONFIRMED: sessions=2, tokens=3200`)

## Notes

- `loadUsageHistory()` is now `loadUsageHistory(currentSessionId?: string)`. The parameter is optional and defaults to undefined, so the only behavior change for callers that don't pass it is the dedup pass (which is what we want).
- The read-side dedup also covers the `aggregateUsage` Critical raised on #4779 by @wenshao without requiring any change to `aggregateUsage` itself.

<details>
<summary>中文小结</summary>

**修复**：PR #4779 引入的 `/stats` 会话双计 bug（issue #4994）。在首次 turn 期间打开过一次 `/stats` 再 `/clear`/退出，该会话会被永久双计。

**两侧防御**：
1. **读侧** —— `loadUsageHistory` 按 `sessionId` 做 last-wins 去重，立即修复磁盘已脏的存量用户。
2. **写侧** —— `rebuildFromSessionJsonl(currentSessionId?)` 跳过进行中的会话，避免新增重复；`statsDataService` 把当前 sessionId 透传过来。

**覆盖**：新增 3 个回归测试还原 issue #4994 复现路径，全部相关测试 45/45 通过，typecheck/lint/format 均干净，standalone repro 脚本验证从 `🐛 sessions=2, tokens=3200` 变为 `✅ no double count`。

</details>