### PR TITLE
fix(daemon): bind QWEN_CODE_SESSION_ID to the current session via AsyncLocalStorage

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -90,6 +90,7 @@ import {
   acquireSleepInhibitor,
   clearGoalTerminalObserver,
   setGoalTerminalObserver,
+  sessionIdContext,
 } from '@qwen-code/qwen-code-core';
 import { NOT_CURRENTLY_GENERATING_CANCEL_MESSAGE } from '@qwen-code/acp-bridge/bridgeErrors';
 import { getCommandSubcommandNames } from '../../services/commandMetadata.js';
@@ -892,6 +893,19 @@ export class Session implements SessionContext {
   }
 
   async #executePrompt(
+    params: PromptRequest,
+    pendingSend: AbortController,
+  ): Promise<PromptResponse> {
+    // Bind this turn to the session's ID via AsyncLocalStorage so shell
+    // subprocesses (and hooks) read the CURRENT session's ID instead of
+    // the process-global env slot, which in daemon mode only ever holds
+    // the first session created in this process.
+    return sessionIdContext.run(this.config.getSessionId(), () =>
+      this.#executePromptInner(params, pendingSend),
+    );
+  }
+
+  async #executePromptInner(
     params: PromptRequest,
     pendingSend: AbortController,
   ): Promise<PromptResponse> {
@@ -1836,6 +1850,13 @@ export class Session implements SessionContext {
    * `_meta.source='cron'`, streams the model response, and handles tool calls.
    */
   async #executeCronPrompt(prompt: string): Promise<void> {
+    // Same session-ID binding rationale as #executePrompt.
+    return sessionIdContext.run(this.config.getSessionId(), () =>
+      this.#executeCronPromptInner(prompt),
+    );
+  }
+
+  async #executeCronPromptInner(prompt: string): Promise<void> {
     return Storage.runWithRuntimeBaseDir(
       this.runtimeBaseDir,
       this.config.getWorkingDir(),
@@ -2095,6 +2116,15 @@ export class Session implements SessionContext {
   }
 
   async #executeBackgroundNotificationPrompt(
+    item: BackgroundNotificationQueueItem,
+  ): Promise<void> {
+    // Same session-ID binding rationale as #executePrompt.
+    return sessionIdContext.run(this.config.getSessionId(), () =>
+      this.#executeBackgroundNotificationPromptInner(item),
+    );
+  }
+
+  async #executeBackgroundNotificationPromptInner(
     item: BackgroundNotificationQueueItem,
   ): Promise<void> {
     return Storage.runWithRuntimeBaseDir(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -368,6 +368,7 @@ export {
 } from './utils/runtimeFetchOptions.js';
 export * from './utils/runtimeStatus.js';
 export * from './utils/schemaValidator.js';
+export * from './utils/sessionIdContext.js';
 export * from './utils/shell-utils.js';
 export * from './utils/subagentGenerator.js';
 export * from './utils/symlink.js';

--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -65,6 +65,7 @@ vi.mock('./tracer.js', () => ({
 import { LogToSpanProcessor } from './log-to-span-processor.js';
 import { setSessionContext } from './session-context.js';
 import { setShellTracePropagation } from './trace-context.js';
+import { createSessionRootContext } from './tracer.js';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici';
 

--- a/packages/core/src/utils/sessionIdContext.ts
+++ b/packages/core/src/utils/sessionIdContext.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+/**
+ * Per-async-context session ID, mirroring {@link promptIdContext}.
+ *
+ * `QWEN_CODE_SESSION_ID` historically lived only in `process.env`, which is
+ * a single process-global slot. That is fine for the interactive CLI (one
+ * session per process, switched via `Config.startNewSession()`), but breaks
+ * in daemon mode where one process hosts many concurrent sessions: only the
+ * first `Config` ever claims the env slot (see `sessionEnvClaimed` in
+ * config.ts), so shells spawned by every later session would read a stale
+ * session ID.
+ *
+ * Daemon-style hosts should wrap each session's execution entry points in
+ * `sessionIdContext.run(sessionId, ...)`. `getShellContextEnvVars()` prefers
+ * this context over `process.env`, falling back to the env var so the
+ * single-session CLI behavior is unchanged.
+ */
+export const sessionIdContext = new AsyncLocalStorage<string>();

--- a/packages/core/src/utils/shellContextEnv.test.ts
+++ b/packages/core/src/utils/shellContextEnv.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { getShellContextEnvVars } from './shellContextEnv.js';
 import { runWithAgentContext } from '../agents/runtime/agent-context.js';
 import { promptIdContext } from './promptIdContext.js';
+import { sessionIdContext } from './sessionIdContext.js';
 import {
   isShellTracePropagationEnabled,
   getTraceContext,
@@ -73,6 +74,47 @@ describe('getShellContextEnvVars', () => {
       QWEN_CODE_SESSION_ID: 'sess-uuid',
       QWEN_CODE_AGENT_ID: 'agent-xyz',
       QWEN_CODE_PROMPT_ID: 'prompt-456',
+    });
+  });
+
+  describe('session ID from AsyncLocalStorage (daemon multi-session)', () => {
+    it('prefers sessionIdContext over process.env', () => {
+      // Daemon mode: process.env holds the FIRST session's ID forever
+      // (constructor guard `sessionEnvClaimed` in config.ts), so a later
+      // session must win via its own async context.
+      process.env['QWEN_CODE_SESSION_ID'] = 'stale-first-session';
+      const env = sessionIdContext.run('current-session', () =>
+        getShellContextEnvVars(),
+      );
+      expect(env['QWEN_CODE_SESSION_ID']).toBe('current-session');
+    });
+
+    it('falls back to process.env outside any session context (single-session CLI)', () => {
+      process.env['QWEN_CODE_SESSION_ID'] = 'cli-session';
+      const env = getShellContextEnvVars();
+      expect(env['QWEN_CODE_SESSION_ID']).toBe('cli-session');
+    });
+
+    it('isolates concurrent sessions in the same process', async () => {
+      // Regression: two daemon sessions interleaving must each see their
+      // own ID at spawn time, even though process.env is a single slot.
+      process.env['QWEN_CODE_SESSION_ID'] = 'stale-first-session';
+      let envSeenByA: Record<string, string> = {};
+      let envSeenByB: Record<string, string> = {};
+
+      await Promise.all([
+        sessionIdContext.run('session-A', async () => {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          envSeenByA = getShellContextEnvVars();
+        }),
+        sessionIdContext.run('session-B', async () => {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          envSeenByB = getShellContextEnvVars();
+        }),
+      ]);
+
+      expect(envSeenByA['QWEN_CODE_SESSION_ID']).toBe('session-A');
+      expect(envSeenByB['QWEN_CODE_SESSION_ID']).toBe('session-B');
     });
   });
 

--- a/packages/core/src/utils/shellContextEnv.ts
+++ b/packages/core/src/utils/shellContextEnv.ts
@@ -7,18 +7,25 @@
 /**
  * Returns context environment variables to inject into shell subprocesses.
  *
- * Reads dynamic context (agent ID, prompt ID) from AsyncLocalStorage at
- * call time, and session ID from process.env (set by Config at session
- * start). This enables downstream scripts to identify which session,
- * agent, and prompt triggered their execution — useful for tracing,
- * audit logging, and business context correlation.
+ * Reads dynamic context (session ID, agent ID, prompt ID) from
+ * AsyncLocalStorage at call time, falling back to process.env for the
+ * session ID (set by Config at session start in the single-session CLI).
+ * This enables downstream scripts to identify which session, agent, and
+ * prompt triggered their execution — useful for tracing, audit logging,
+ * and business context correlation.
+ *
+ * The ALS-first lookup matters in daemon mode: one process hosts many
+ * sessions, but only the first Config ever claims the process-global
+ * env slot (`sessionEnvClaimed` in config.ts), so process.env alone
+ * would report a stale session ID for every later session.
  *
  * Must be called at spawn time within the executing async context to
- * capture the correct agent/prompt frame.
+ * capture the correct session/agent/prompt frame.
  */
 
 import { getCurrentAgentId } from '../agents/runtime/agent-context.js';
 import { promptIdContext } from './promptIdContext.js';
+import { sessionIdContext } from './sessionIdContext.js';
 import {
   isShellTracePropagationEnabled,
   getTraceContext,
@@ -28,7 +35,11 @@ import {
 export function getShellContextEnvVars(): Record<string, string> {
   const env: Record<string, string> = {};
 
-  const sessionId = process.env['QWEN_CODE_SESSION_ID'];
+  // Prefer the per-async-context session ID (set by multi-session hosts
+  // like the daemon) over the process-global env slot, which only ever
+  // reflects the first session created in this process.
+  const sessionId =
+    sessionIdContext.getStore() ?? process.env['QWEN_CODE_SESSION_ID'];
   if (sessionId) {
     env['QWEN_CODE_SESSION_ID'] = sessionId;
   }


### PR DESCRIPTION
## What this PR does

Makes `QWEN_CODE_SESSION_ID` in shell subprocess environments always reflect the session that actually spawned the shell. It adds a `sessionIdContext` (AsyncLocalStorage, same pattern as `promptIdContext`), makes `getShellContextEnvVars()` prefer that context over `process.env` (falling back to `process.env` so the single-session CLI is unchanged), and wraps the three ACP session execution entry points (`#executePrompt`, `#executeCronPrompt`, `#executeBackgroundNotificationPrompt`) in `sessionIdContext.run(...)`. A separate test-only commit adds a missing import in `sdk.test.ts` that was breaking `tsc --build` on this branch.

## Why it's needed

In daemon mode one process hosts many sessions, but `process.env['QWEN_CODE_SESSION_ID']` is a single process-global slot that only the FIRST `Config` ever writes (the `sessionEnvClaimed` guard in config.ts), and the ACP path never calls `startNewSession()` — that only exists in the interactive TUI. So every session created or resumed after the first one spawned shells that reported the first session's ID: `/status` showed the right session ID while `echo $QWEN_CODE_SESSION_ID` inside a tool call showed a different one, breaking audit logging and trace correlation for downstream SQL/Python scripts.

## Reviewer Test Plan

### How to verify

1. `cd packages/core && npx vitest run src/utils/shellContextEnv.test.ts` — 12/12, including three new regression cases: ALS takes precedence over a stale env value, env fallback keeps the single-session CLI behavior, and two concurrent sessions in one process each see their own ID.
2. Real-process check (no mocks): construct two real `Config` instances in one Node process, then spawn a real `sh -c 'echo $QWEN_CODE_SESSION_ID'` with `{...process.env, ...getShellContextEnvVars()}` — exactly how `shellExecutionService` injects env. Before the fix the second session's shell prints the first session's ID; after the fix it prints its own.
3. Live daemon check: start the ACP agent (`node dist/cli.js --acp`), create session A, prompt it to run `echo "SID=$QWEN_CODE_SESSION_ID"`, then create session B in the same process and repeat — the SID should follow the active session instead of staying at A.

### Evidence (Before & After)

Output of the real-process check (real `Config` class + real shell subprocess):

```
[1] first session created       : session-A-first
    shell sees                  : session-A-first
[2] second session (resumed)    : session-B-resumed
    env slot (process.env)      : session-A-first   <- stale, guard skipped write
[3] BEFORE fix — shell for B    : session-A-first   <- WRONG (session A id)
[4] AFTER fix  — shell for B    : session-B-resumed <- correct
[5] concurrent — A sees: session-A-first | B sees: session-B-resumed

RESULT: PASS
```

Live daemon run (step 3) — real ACP agent process, two sessions in ONE process, model-driven Shell tool call, auto-approved permissions:

```
[A] session/new -> c7885774-072d-4bb2-bc5a-112414fae5a7
[A] shell saw SID = c7885774-072d-4bb2-bc5a-112414fae5a7
[B] session/new -> 28dbe970-8b67-4615-988d-e2238f2cd464
[B] shell saw SID = 28dbe970-8b67-4615-988d-e2238f2cd464

A: match=true
B: match=true   <- second session in the same process: the bug scenario
LIVE VERIFY: PASS
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests via vitest; real-process check via a standalone Node script against the built `packages/core/dist`. No sandbox.

## Risk & Scope

- Main risk or tradeoff: a daemon code path that spawns shells outside the three wrapped entry points would fall back to `process.env` — i.e. pre-fix behavior, never worse. Audited the branch: no such path exists today.
- Not validated / out of scope: full monorepo test suite not run; the 7 failing `Session.test.ts` cases and 2 failing suites on this branch are pre-existing (verified identical with and without this change — 404 passed both ways).
- Breaking changes / migration notes: none. Single-session CLI behavior is unchanged via the `process.env` fallback.

## Linked Issues

Relates to #4649 (the PR that introduced shell context env injection).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 shell 子进程环境变量里的 `QWEN_CODE_SESSION_ID` 始终反映真正发起这次 spawn 的 session。新增与 `promptIdContext` 同模式的 `sessionIdContext`（AsyncLocalStorage），`getShellContextEnvVars()` 优先从该上下文读 session id、读不到再回退 `process.env`（普通单 session CLI 行为完全不变）；ACP `Session` 的三个执行入口（`#executePrompt`、`#executeCronPrompt`、`#executeBackgroundNotificationPrompt`）都包进 `sessionIdContext.run(...)`。另含一个独立的纯测试 commit：补 `sdk.test.ts` 缺失的 import，修复本分支 `tsc --build` 编译不过的问题。

## 为什么需要

daemon 模式下一个进程承载多个 session，但 `process.env['QWEN_CODE_SESSION_ID']` 是单一进程级槽位，只有进程里第一个 `Config` 会写入（config.ts 的 `sessionEnvClaimed` 守卫）；ACP 路径又从不调用 `startNewSession()`（它只挂在交互式 TUI 上）。结果是第一个 session 之后新建/恢复的任何 session，其 bash/SQL/Python 子进程读到的都是第一个 session 的 id——`/status` 显示的会话 ID 和脚本里 `echo $QWEN_CODE_SESSION_ID` 对不上，下游审计日志和链路追踪全部错位。

## 如何验证

1. `packages/core` 下跑 `npx vitest run src/utils/shellContextEnv.test.ts`——12/12 通过，含 3 条新回归用例：ALS 优先于过期 env 值、无上下文时回退 env、同进程两个并发 session 各自拿到自己的 id。
2. 真实进程验证（无 mock）：一个 Node 进程里构造两个真实 `Config`，再以 `{...process.env, ...getShellContextEnvVars()}` 起真实 shell 读 `$QWEN_CODE_SESSION_ID`（与 `shellExecutionService` 注入方式一致）。修复前第二个 session 的 shell 打出第一个 session 的 id；修复后打出自己的。证据输出见上方英文区。
3. 真机 daemon 验证（已通过）：起 ACP agent，session A 里让模型跑 `echo "SID=$QWEN_CODE_SESSION_ID"`，同进程再建 session B 重复——两个 session 的 shell 各自读到自己的 session id（A/B 均 match=true，`LIVE VERIFY: PASS`，证据见上方英文区）。

## 风险与范围

- 主要风险：三个入口之外若有 spawn shell 的 daemon 路径会回退 `process.env`，即修复前行为，不会更糟（已排查，当前不存在这样的路径）。
- 未验证/范围外：全仓测试套件未跑；本分支 `Session.test.ts` 的 7 个失败用例和 2 个失败套件为预先存在（带/不带本改动对照一致，均为 404 passed）。
- 破坏性变更：无。

## 关联

关联 #4649（引入 shell context env 注入的 PR）。

</details>
