### PR TITLE
feat(cli): add optional [HH:MM:SS] timestamp before each assistant turn

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -570,6 +570,16 @@ const SETTINGS_SCHEMA = {
           { value: 'json', label: 'JSON' },
         ],
       },
+      showTimestamps: {
+        type: 'boolean',
+        label: 'Show Timestamps',
+        category: 'General',
+        requiresRestart: false,
+        default: false,
+        description:
+          'Show [HH:MM:SS] timestamp before each assistant response.',
+        showInDialog: true,
+      },
     },
   },
 

--- a/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
@@ -15,6 +15,7 @@ import type {
 } from '@qwen-code/qwen-code-core';
 import { ToolGroupMessage } from './messages/ToolGroupMessage.js';
 import { renderWithProviders } from '../../test-utils/render.js';
+import { LoadedSettings } from '../../config/settings.js';
 import { ConfigContext } from '../contexts/ConfigContext.js';
 import { CompactModeProvider } from '../contexts/CompactModeContext.js';
 
@@ -405,5 +406,80 @@ describe('<HistoryItemDisplay />', () => {
     );
 
     expect(lastFrame()).not.toContain('Continuing the reasoning');
+  });
+
+  describe('showTimestamps', () => {
+    const timestampItem: HistoryItem = {
+      ...baseItem,
+      type: 'gemini',
+      text: 'Hello from assistant',
+      timestamp: new Date('2026-01-15T14:30:45').getTime(),
+    };
+
+    const makeTimestampSettings = () =>
+      new LoadedSettings(
+        { path: '', settings: {}, originalSettings: {} },
+        { path: '', settings: {}, originalSettings: {} },
+        {
+          path: '',
+          settings: { output: { showTimestamps: true } },
+          originalSettings: {},
+        },
+        { path: '', settings: {}, originalSettings: {} },
+        true,
+        new Set(),
+      );
+
+    it('does not render timestamp when showTimestamps is disabled', () => {
+      const { lastFrame } = renderWithProviders(
+        <HistoryItemDisplay
+          {...baseItem}
+          item={timestampItem}
+          isPending={false}
+        />,
+      );
+      expect(lastFrame()).not.toMatch(/\[\d{2}:\d{2}:\d{2}\]/);
+    });
+
+    it('renders [HH:MM:SS] timestamp when showTimestamps is enabled', () => {
+      const { lastFrame } = renderWithProviders(
+        <HistoryItemDisplay
+          {...baseItem}
+          item={timestampItem}
+          isPending={false}
+        />,
+        { settings: makeTimestampSettings() },
+      );
+      expect(lastFrame()).toMatch(/\[\d{2}:\d{2}:\d{2}\]/);
+    });
+
+    it('renders timestamp even when isPending is true (streaming)', () => {
+      const { lastFrame } = renderWithProviders(
+        <HistoryItemDisplay
+          {...baseItem}
+          item={timestampItem}
+          isPending={true}
+        />,
+        { settings: makeTimestampSettings() },
+      );
+      expect(lastFrame()).toMatch(/\[\d{2}:\d{2}:\d{2}\]/);
+    });
+
+    it('does not render timestamp when timestamp field is missing', () => {
+      const noTimestampItem: HistoryItem = {
+        id: 1,
+        type: 'gemini',
+        text: 'Hello',
+      };
+      const { lastFrame } = renderWithProviders(
+        <HistoryItemDisplay
+          {...baseItem}
+          item={noTimestampItem}
+          isPending={false}
+        />,
+        { settings: makeTimestampSettings() },
+      );
+      expect(lastFrame()).not.toMatch(/\[\d{2}:\d{2}:\d{2}\]/);
+    });
   });
 });

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -57,6 +57,7 @@ import { MemorySavedMessage } from './messages/MemorySavedMessage.js';
 import { DiffStatsDisplay } from './messages/DiffStatsDisplay.js';
 import { GoalStatusMessage } from './messages/GoalStatusMessage.js';
 import { useCompactMode } from '../contexts/CompactModeContext.js';
+import { useSettings } from '../contexts/SettingsContext.js';
 
 interface HistoryItemDisplayProps {
   item: HistoryItem;
@@ -137,6 +138,9 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
   const marginTop = getHistoryItemMarginTop(item);
 
   const { compactMode } = useCompactMode();
+  const settings = useSettings();
+  const showTimestamps = settings.merged.output?.showTimestamps === true;
+
   const itemForDisplay = useMemo(() => escapeAnsiCtrlCodes(item), [item]);
   const contentWidth = terminalWidth - 4;
   const boxWidth = mainAreaWidth || contentWidth;
@@ -160,15 +164,26 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
         <UserShellMessage text={itemForDisplay.text} />
       )}
       {itemForDisplay.type === 'gemini' && (
-        <AssistantMessage
-          text={itemForDisplay.text}
-          isPending={isPending}
-          availableTerminalHeight={
-            availableTerminalHeightGemini ?? availableTerminalHeight
-          }
-          contentWidth={contentWidth}
-          sourceCopyIndexOffsets={sourceCopyIndexOffsets}
-        />
+        <>
+          {showTimestamps && itemForDisplay.timestamp != null && (
+            <Text dimColor>
+              [
+              {new Date(itemForDisplay.timestamp).toLocaleTimeString('en-US', {
+                hour12: false,
+              })}
+              ]
+            </Text>
+          )}
+          <AssistantMessage
+            text={itemForDisplay.text}
+            isPending={isPending}
+            availableTerminalHeight={
+              availableTerminalHeightGemini ?? availableTerminalHeight
+            }
+            contentWidth={contentWidth}
+            sourceCopyIndexOffsets={sourceCopyIndexOffsets}
+          />
+        </>
       )}
       {itemForDisplay.type === 'gemini_content' && (
         <AssistantMessageContent

--- a/packages/cli/src/ui/components/SessionPreview.test.tsx
+++ b/packages/cli/src/ui/components/SessionPreview.test.tsx
@@ -3,9 +3,8 @@
  * Copyright 2025 Qwen Code
  * SPDX-License-Identifier: Apache-2.0
  */
-import { render } from 'ink-testing-library';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { KeypressProvider } from '../contexts/KeypressContext.js';
+import { renderWithProviders } from '../../test-utils/render.js';
 import { SessionPreview } from './SessionPreview.js';
 
 beforeEach(() => {
@@ -83,32 +82,28 @@ function fakeResumedData(
 describe('SessionPreview', () => {
   it('shows loading state before data arrives', () => {
     const svc = mockService(new Promise(() => {})); // never resolves
-    const { lastFrame } = render(
-      <KeypressProvider kittyProtocolEnabled={false}>
-        <SessionPreview
-          sessionService={svc}
-          sessionId="s1"
-          sessionTitle="My session"
-          onExit={vi.fn()}
-          onResume={vi.fn()}
-        />
-      </KeypressProvider>,
+    const { lastFrame } = renderWithProviders(
+      <SessionPreview
+        sessionService={svc}
+        sessionId="s1"
+        sessionTitle="My session"
+        onExit={vi.fn()}
+        onResume={vi.fn()}
+      />,
     );
     expect(lastFrame()).toContain('Loading session preview');
   });
 
   it('renders all messages after load', async () => {
     const svc = mockService(fakeResumedData());
-    const { lastFrame } = render(
-      <KeypressProvider kittyProtocolEnabled={false}>
-        <SessionPreview
-          sessionService={svc}
-          sessionId="s1"
-          sessionTitle="My session"
-          onExit={vi.fn()}
-          onResume={vi.fn()}
-        />
-      </KeypressProvider>,
+    const { lastFrame } = renderWithProviders(
+      <SessionPreview
+        sessionService={svc}
+        sessionId="s1"
+        sessionTitle="My session"
+        onExit={vi.fn()}
+        onResume={vi.fn()}
+      />,
     );
     await wait(100);
     const frame = lastFrame() ?? '';
@@ -127,16 +122,14 @@ describe('SessionPreview', () => {
         { text: 'FINAL-ANSWER-MARKER' },
       ]),
     );
-    const { lastFrame } = render(
-      <KeypressProvider kittyProtocolEnabled={false}>
-        <SessionPreview
-          sessionService={svc}
-          sessionId="s1"
-          sessionTitle="My session"
-          onExit={vi.fn()}
-          onResume={vi.fn()}
-        />
-      </KeypressProvider>,
+    const { lastFrame } = renderWithProviders(
+      <SessionPreview
+        sessionService={svc}
+        sessionId="s1"
+        sessionTitle="My session"
+        onExit={vi.fn()}
+        onResume={vi.fn()}
+      />,
     );
     await wait(100);
     const frame = lastFrame() ?? '';
@@ -151,19 +144,17 @@ describe('SessionPreview', () => {
 
   it('renders footer metadata (messageCount · time · branch)', async () => {
     const svc = mockService(fakeResumedData());
-    const { lastFrame } = render(
-      <KeypressProvider kittyProtocolEnabled={false}>
-        <SessionPreview
-          sessionService={svc}
-          sessionId="s1"
-          sessionTitle="My session"
-          messageCount={42}
-          mtime={Date.now() - 60_000}
-          gitBranch="feat/preview"
-          onExit={vi.fn()}
-          onResume={vi.fn()}
-        />
-      </KeypressProvider>,
+    const { lastFrame } = renderWithProviders(
+      <SessionPreview
+        sessionService={svc}
+        sessionId="s1"
+        sessionTitle="My session"
+        messageCount={42}
+        mtime={Date.now() - 60_000}
+        gitBranch="feat/preview"
+        onExit={vi.fn()}
+        onResume={vi.fn()}
+      />,
     );
     await wait(100);
     const frame = lastFrame() ?? '';
@@ -176,16 +167,14 @@ describe('SessionPreview', () => {
     // through to SessionPreview. The footer must still show a count, derived
     // from the loaded ResumedSessionData using unique user/assistant UUIDs.
     const svc = mockService(fakeResumedData());
-    const { lastFrame } = render(
-      <KeypressProvider kittyProtocolEnabled={false}>
-        <SessionPreview
-          sessionService={svc}
-          sessionId="s1"
-          sessionTitle="My session"
-          onExit={vi.fn()}
-          onResume={vi.fn()}
-        />
-      </KeypressProvider>,
+    const { lastFrame } = renderWithProviders(
+      <SessionPreview
+        sessionService={svc}
+        sessionId="s1"
+        sessionTitle="My session"
+        onExit={vi.fn()}
+        onResume={vi.fn()}
+      />,
     );
     await wait(100);
     const frame = lastFrame() ?? '';
@@ -196,16 +185,14 @@ describe('SessionPreview', () => {
   it('calls onExit when Escape is pressed', async () => {
     const onExit = vi.fn();
     const svc = mockService(fakeResumedData());
-    const { stdin } = render(
-      <KeypressProvider kittyProtocolEnabled={false}>
-        <SessionPreview
-          sessionService={svc}
-          sessionId="s1"
-          sessionTitle="My session"
-          onExit={onExit}
-          onResume={vi.fn()}
-        />
-      </KeypressProvider>,
+    const { stdin } = renderWithProviders(
+      <SessionPreview
+        sessionService={svc}
+        sessionId="s1"
+        sessionTitle="My session"
+        onExit={onExit}
+        onResume={vi.fn()}
+      />,
     );
     await wait(100);
     stdin.write('\u001B'); // ESC
@@ -216,16 +203,14 @@ describe('SessionPreview', () => {
   it('calls onResume(sessionId) when Enter is pressed', async () => {
     const onResume = vi.fn();
     const svc = mockService(fakeResumedData());
-    const { stdin } = render(
-      <KeypressProvider kittyProtocolEnabled={false}>
-        <SessionPreview
-          sessionService={svc}
-          sessionId="s1"
-          sessionTitle="My session"
-          onExit={vi.fn()}
-          onResume={onResume}
-        />
-      </KeypressProvider>,
+    const { stdin } = renderWithProviders(
+      <SessionPreview
+        sessionService={svc}
+        sessionId="s1"
+        sessionTitle="My session"
+        onExit={vi.fn()}
+        onResume={onResume}
+      />,
     );
     await wait(100);
     stdin.write('\r'); // Enter

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -3759,10 +3759,10 @@ describe('useGeminiStream', () => {
       });
 
       expect(mockAddItem).toHaveBeenCalledWith(
-        {
+        expect.objectContaining({
           type: 'gemini',
           text: 'Initial',
-        },
+        }),
         expect.any(Number),
       );
 
@@ -6695,10 +6695,10 @@ describe('useGeminiStream', () => {
         });
 
         expect(mockAddItem).toHaveBeenCalledWith(
-          {
+          expect.objectContaining({
             type: 'gemini',
             text: 'First call content',
-          },
+          }),
           expect.any(Number),
         );
         expect(mainAbortSignal?.aborted).toBe(true);

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -64,6 +64,7 @@ import type {
   HistoryItemGoalStatus,
   HistoryItemWithoutId,
   HistoryItemToolGroup,
+  HistoryItemGemini,
   SlashCommandProcessorResult,
 } from '../types.js';
 import { StreamingState, MessageType, ToolCallStatus } from '../types.js';
@@ -399,6 +400,20 @@ export const useGeminiStream = (
   // alongside lastTurnUserItemRef.
   const turnSawContentEventRef = useRef(false);
   const lastPromptErroredRef = useRef(false);
+
+  // Wrapper around addItem that attaches timestamp to gemini items for display.
+  // Only 'gemini' (new assistant turn) gets a timestamp; 'gemini_content'
+  // (same turn, performance-split continuation) does not.
+  const commitItem = useCallback(
+    (item: HistoryItemWithoutId, userMessageTimestamp: number): number => {
+      if (item.type === 'gemini' && !(item as HistoryItemGemini).timestamp) {
+        (item as HistoryItemGemini).timestamp = Date.now();
+      }
+      return addItem(item, userMessageTimestamp);
+    },
+    [addItem],
+  );
+
   const dualOutput = useDualOutput();
   const [isResponding, setIsResponding] = useState<boolean>(false);
   // React state can lag by one render; this tracks the actual stream lifetime.
@@ -691,7 +706,7 @@ export const useGeminiStream = (
     // events that arrived inside the throttle window
     // (STREAM_UPDATE_THROTTLE_MS), making AppContainer's auto-restore
     // wrongly conclude the model produced nothing — and the subsequent
-    // addItem(pendingHistoryItemRef.current) below would commit content
+    // commitItem(pendingHistoryItemRef.current) below would commit content
     // that auto-restore then truncates away.
     for (const flushBufferedStreamEvents of flushBufferedStreamEventsRef.current) {
       flushBufferedStreamEvents();
@@ -728,7 +743,7 @@ export const useGeminiStream = (
     logApiCancel(config, cancellationEvent);
 
     if (pendingHistoryItemRef.current) {
-      addItem(pendingHistoryItemRef.current, Date.now());
+      commitItem(pendingHistoryItemRef.current, Date.now());
     }
     addItem(
       {
@@ -766,6 +781,7 @@ export const useGeminiStream = (
   }, [
     streamingState,
     addItem,
+    commitItem,
     setPendingHistoryItem,
     onCancelSubmit,
     pendingHistoryItemRef,
@@ -975,9 +991,13 @@ export const useGeminiStream = (
           return newGeminiMessageBuffer;
         }
         if (pendingHistoryItemRef.current) {
-          addItem(pendingHistoryItemRef.current, userMessageTimestamp);
+          commitItem(pendingHistoryItemRef.current, userMessageTimestamp);
         }
-        setPendingHistoryItem({ type: 'gemini', text: '' });
+        setPendingHistoryItem({
+          type: 'gemini',
+          text: '',
+          timestamp: Date.now(),
+        });
         newGeminiMessageBuffer = stripLeadingBlankLines(newGeminiMessageBuffer);
       }
       // Split large messages for better rendering performance. Ideally,
@@ -1005,7 +1025,7 @@ export const useGeminiStream = (
         // broken up so that there are more "statically" rendered.
         const beforeText = newGeminiMessageBuffer.substring(0, safeSplitPoint);
         const afterText = newGeminiMessageBuffer.substring(safeSplitPoint);
-        addItem(
+        commitItem(
           {
             type: nextPendingType,
             text: beforeText,
@@ -1016,13 +1036,21 @@ export const useGeminiStream = (
         newGeminiMessageBuffer = afterText;
       }
       // Update the existing message with accumulated content.
-      setPendingHistoryItem({
-        type: nextPendingType,
-        text: newGeminiMessageBuffer,
+      setPendingHistoryItem((item) => {
+        const base: HistoryItemWithoutId = {
+          type: nextPendingType,
+          text: newGeminiMessageBuffer,
+        };
+        if (item && 'timestamp' in item) {
+          (base as HistoryItemGemini).timestamp = (
+            item as HistoryItemGemini
+          ).timestamp;
+        }
+        return base;
       });
       return newGeminiMessageBuffer;
     },
-    [addItem, pendingHistoryItemRef, setPendingHistoryItem],
+    [commitItem, pendingHistoryItemRef, setPendingHistoryItem],
   );
 
   const mergeThought = useCallback(
@@ -1200,7 +1228,7 @@ export const useGeminiStream = (
           };
           addItem(pendingItem, userMessageTimestamp);
         } else {
-          addItem(pendingHistoryItemRef.current, userMessageTimestamp);
+          commitItem(pendingHistoryItemRef.current, userMessageTimestamp);
         }
         setPendingHistoryItem(null);
       }
@@ -1215,6 +1243,7 @@ export const useGeminiStream = (
     [
       addItem,
       commitPendingThought,
+      commitItem,
       pendingHistoryItemRef,
       setPendingHistoryItem,
       setThought,
@@ -1228,7 +1257,7 @@ export const useGeminiStream = (
       // Persist any streamed reasoning (collapsed) above the error.
       commitPendingThought(userMessageTimestamp);
       if (pendingHistoryItemRef.current) {
-        addItem(pendingHistoryItemRef.current, userMessageTimestamp);
+        commitItem(pendingHistoryItemRef.current, userMessageTimestamp);
         setPendingHistoryItem(null);
       }
       // Only show Ctrl+Y hint if not already showing an auto-retry countdown
@@ -1268,8 +1297,8 @@ export const useGeminiStream = (
         });
     },
     [
-      addItem,
       commitPendingThought,
+      commitItem,
       pendingHistoryItemRef,
       setPendingHistoryItem,
       setPendingRetryErrorItem,
@@ -1286,12 +1315,18 @@ export const useGeminiStream = (
       }
 
       if (pendingHistoryItemRef.current) {
-        addItem(pendingHistoryItemRef.current, userMessageTimestamp);
+        commitItem(pendingHistoryItemRef.current, userMessageTimestamp);
         setPendingHistoryItem(null);
       }
       addItem({ type: MessageType.INFO, text }, userMessageTimestamp);
     },
-    [addItem, pendingHistoryItemRef, setPendingHistoryItem, settings],
+    [
+      addItem,
+      commitItem,
+      pendingHistoryItemRef,
+      setPendingHistoryItem,
+      settings,
+    ],
   );
 
   const handleFinishedEvent = useCallback(
@@ -1354,7 +1389,7 @@ export const useGeminiStream = (
       userMessageTimestamp: number,
     ) => {
       if (pendingHistoryItemRef.current) {
-        addItem(pendingHistoryItemRef.current, userMessageTimestamp);
+        commitItem(pendingHistoryItemRef.current, userMessageTimestamp);
         setPendingHistoryItem(null);
       }
       const reasonClause =
@@ -1373,7 +1408,7 @@ export const useGeminiStream = (
         Date.now(),
       );
     },
-    [addItem, config, pendingHistoryItemRef, setPendingHistoryItem],
+    [addItem, commitItem, config, pendingHistoryItemRef, setPendingHistoryItem],
   );
 
   const handleMaxSessionTurnsEvent = useCallback(
@@ -1446,7 +1481,7 @@ export const useGeminiStream = (
       userMessageTimestamp: number,
     ) => {
       if (pendingHistoryItemRef.current) {
-        addItem(pendingHistoryItemRef.current, userMessageTimestamp);
+        commitItem(pendingHistoryItemRef.current, userMessageTimestamp);
         setPendingHistoryItem(null);
       }
       addItem(
@@ -1458,7 +1493,7 @@ export const useGeminiStream = (
         userMessageTimestamp,
       );
     },
-    [addItem, pendingHistoryItemRef, setPendingHistoryItem],
+    [addItem, commitItem, pendingHistoryItemRef, setPendingHistoryItem],
   );
 
   const handleStopHookLoopEvent = useCallback(
@@ -1471,7 +1506,7 @@ export const useGeminiStream = (
       userMessageTimestamp: number,
     ) => {
       if (pendingHistoryItemRef.current) {
-        addItem(pendingHistoryItemRef.current, userMessageTimestamp);
+        commitItem(pendingHistoryItemRef.current, userMessageTimestamp);
         setPendingHistoryItem(null);
       }
       // When the active loop is driven by `/goal`, replace the generic
@@ -1502,7 +1537,7 @@ export const useGeminiStream = (
         userMessageTimestamp,
       );
     },
-    [addItem, config, pendingHistoryItemRef, setPendingHistoryItem],
+    [addItem, commitItem, config, pendingHistoryItemRef, setPendingHistoryItem],
   );
 
   const handleActiveGoalEvent = useCallback(
@@ -1712,7 +1747,7 @@ export const useGeminiStream = (
               // as "t" → "te" → "tes" cumulative rendering even though each
               // turn is persisted as a clean, separate assistant message.
               if (pendingHistoryItemRef.current) {
-                addItem(pendingHistoryItemRef.current, userMessageTimestamp);
+                commitItem(pendingHistoryItemRef.current, userMessageTimestamp);
                 setPendingHistoryItem(null);
               }
               geminiMessageBuffer = '';
@@ -1768,7 +1803,7 @@ export const useGeminiStream = (
               // Display system message from Stop hooks with "Stop says:" prefix
               // First commit any pending AI response to ensure correct ordering
               if (pendingHistoryItemRef.current) {
-                addItem(pendingHistoryItemRef.current, userMessageTimestamp);
+                commitItem(pendingHistoryItemRef.current, userMessageTimestamp);
                 setPendingHistoryItem(null);
               }
               addItem(
@@ -1887,6 +1922,7 @@ export const useGeminiStream = (
       handleStopHookLoopEvent,
       handleActiveGoalEvent,
       addItem,
+      commitItem,
       dualOutput,
     ],
   );
@@ -2112,7 +2148,7 @@ export const useGeminiStream = (
           }
 
           if (pendingHistoryItemRef.current) {
-            addItem(pendingHistoryItemRef.current, userMessageTimestamp);
+            commitItem(pendingHistoryItemRef.current, userMessageTimestamp);
             setPendingHistoryItem(null);
           }
 
@@ -2204,6 +2240,7 @@ export const useGeminiStream = (
       processGeminiStreamEvents,
       pendingHistoryItemRef,
       addItem,
+      commitItem,
       setPendingHistoryItem,
       setInitError,
       geminiClient,

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -126,6 +126,7 @@ export type HistoryItemUser = HistoryItemBase & {
 export type HistoryItemGemini = HistoryItemBase & {
   type: 'gemini';
   text: string;
+  timestamp?: number;
 };
 
 export type HistoryItemGeminiContent = HistoryItemBase & {

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -158,6 +158,11 @@
             "json"
           ],
           "default": "text"
+        },
+        "showTimestamps": {
+          "description": "Show [HH:MM:SS] timestamp before each assistant response.",
+          "type": "boolean",
+          "default": false
         }
       }
     },


### PR DESCRIPTION
## What this PR does

Adds an optional `output.showTimestamps` setting that renders a `[HH:MM:SS]` timestamp before each assistant response in the CLI. The timestamp appears immediately when the model starts outputting, not after the response completes. The implementation uses a `commitItem` wrapper around `addItem` in `useGeminiStream` to attach `Date.now()` to `gemini` type items, including the split-code path that previously bypassed timestamp assignment. Only the first item of each assistant turn gets a timestamp; `gemini_content` items (performance-split continuations) do not, preventing duplicate timestamps within the same turn.

## Why it's needed

Users requested the ability to see when each assistant response was generated, similar to Claude Code's turn duration display. This helps with debugging, logging, and understanding the temporal flow of conversations. The feature is opt-in (default off) to avoid cluttering the UI for users who don't need it.

## Reviewer Test Plan

### How to verify

1. Run `npm run dev`
2. Open settings: `/settings`
3. Navigate to `output` → `showTimestamps` and enable it
4. Ask a simple question — should see `[HH:MM:SS]` appear immediately when the model starts responding
5. Ask a question that triggers tool calls — should see one timestamp per assistant turn
6. Disable `showTimestamps` in settings — next response should not have timestamp, no restart needed

### Evidence (Before & After)

Will provide video recording.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Tested with `npm run dev` on macOS 14.5, Node.js v22.

## Risk & Scope

- **Main risk or tradeoff:** Adds a new UI element that may clutter the display for users who enable it. The `commitItem` wrapper adds minimal overhead (~1 function call per item commit).
- **Not validated / out of scope:** Windows and Linux testing. Subagent responses (they use a different rendering path). Non-interactive output modes.
- **Breaking changes / migration notes:** None. The setting defaults to `false`, so existing users see no change. Settings are automatically persisted to `~/.qwen/settings.json`.

## Linked Issues

Refs #4899

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

添加了一个可选的 `output.showTimestamps` 设置，在 CLI 的每个助手回复前渲染一个 `[HH:MM:SS]` 时间戳。时间戳在模型开始输出时立即显示，而不是在响应完成后才显示。实现在 `useGeminiStream` 中使用 `commitItem` 包装器来包装 `addItem`，将 `Date.now()` 附加到 `gemini` 类型的 item 上，包括之前会绕过时间戳分配的 split 代码路径。只有每个助手 turn 的第一个 item 会获得时间戳；`gemini_content` items（性能分割的延续）不会，防止同一个 turn 内出现重复的时间戳。

## 为什么需要它

用户希望看到每个助手响应的生成时间，类似于 Claude Code 的 turn duration 显示。这有助于调试、记录日志和理解对话的时间流动。该功能是可选的（默认关闭），避免给不需要的用户造成 UI 混乱。

## 审阅者测试计划

### 如何验证

1. 打开设置：`/settings`
2. 导航到 `output` → `showTimestamps` 并启用它
3. 问一个简单的问题 — 应该看到 `[HH:MM:SS]` 在模型开始响应时立即出现
4. 问一个会触发工具调用的问题 — 应该看到每个助手 turn 一个时间戳
5. 在设置中禁用 `showTimestamps` — 下次回复时间戳应该消失，无需重启

### 证据（前后对比）

见视频

### 已测试平台

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

在 macOS 14.5, Node.js v22 测试。

## 风险与范围

- **主要风险或权衡：** 添加了一个新的 UI 元素，可能会给启用它的用户造成显示混乱。`commitItem` 包装器增加了最小的开销（每个 item 提交约 1 次函数调用）。
- **未验证 / 超出范围：** Windows 和 Linux 测试。子代理响应（它们使用不同的渲染路径）。非交互式输出模式。
- **破坏性更改 / 迁移说明：** 无。设置默认为 `false`，所以现有用户看不到任何变化。设置会自动持久化到 `~/.qwen/settings.json`。

## 关联的 Issues

Refs #4899

</details>