### PR TITLE
feat(web-shell): add Option+Enter and Cmd+Enter newline shortcuts

### DIFF
--- a/packages/web-shell/client/components/Editor.keymap.test.ts
+++ b/packages/web-shell/client/components/Editor.keymap.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+//
+// Regression test for the Editor submit/newline keymap. Mounts a real
+// CodeMirror EditorView with the same bindings as Editor.tsx and dispatches
+// real keydown events, asserting that:
+//   - Enter submits (does not insert a newline)
+//   - Shift+Enter / Ctrl+J / Mod(Cmd/Ctrl)+Enter / Alt(Option)+Enter insert '\n'
+// This locks the resolution of the 'Alt-Enter' and 'Mod-Enter' key strings so
+// Option/Cmd+Enter newline input cannot silently regress.
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { EditorView, keymap } from '@codemirror/view';
+import { EditorState, Prec } from '@codemirror/state';
+
+function mountEditor() {
+  let submitted = false;
+  const insertNewline = (view: EditorView) => {
+    view.dispatch(view.state.replaceSelection('\n'));
+    return true;
+  };
+  const submitKeymap = keymap.of([
+    {
+      key: 'Enter',
+      run: () => {
+        submitted = true;
+        return true;
+      },
+    },
+    { key: 'Shift-Enter', run: insertNewline },
+    { key: 'Ctrl-j', run: insertNewline },
+    { key: 'Mod-Enter', run: insertNewline },
+    { key: 'Alt-Enter', run: insertNewline },
+  ]);
+  const parent = document.createElement('div');
+  document.body.appendChild(parent);
+  const view = new EditorView({
+    state: EditorState.create({ extensions: [Prec.highest(submitKeymap)] }),
+    parent,
+  });
+  return {
+    view,
+    getSubmitted: () => submitted,
+    resetSubmitted: () => {
+      submitted = false;
+    },
+    cleanup: () => {
+      view.destroy();
+      parent.remove();
+    },
+  };
+}
+
+function press(
+  view: EditorView,
+  init: { key: string; code: string } & KeyboardEventInit,
+) {
+  view.contentDOM.dispatchEvent(
+    new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init }),
+  );
+}
+
+describe('Editor newline keymap (runtime)', () => {
+  let h: ReturnType<typeof mountEditor>;
+  beforeEach(() => {
+    h = mountEditor();
+  });
+  afterEach(() => {
+    h.cleanup();
+  });
+
+  it('Enter submits without inserting a newline', () => {
+    press(h.view, { key: 'Enter', code: 'Enter' });
+    expect(h.getSubmitted()).toBe(true);
+    expect(h.view.state.doc.toString()).toBe('');
+  });
+
+  it('Shift+Enter inserts a newline and does not submit', () => {
+    press(h.view, { key: 'Enter', code: 'Enter', shiftKey: true });
+    expect(h.getSubmitted()).toBe(false);
+    expect(h.view.state.doc.toString()).toBe('\n');
+  });
+
+  it('Ctrl+J inserts a newline and does not submit', () => {
+    press(h.view, { key: 'j', code: 'KeyJ', ctrlKey: true });
+    expect(h.getSubmitted()).toBe(false);
+    expect(h.view.state.doc.toString()).toBe('\n');
+  });
+
+  it('Alt/Option+Enter inserts a newline and does not submit', () => {
+    press(h.view, { key: 'Enter', code: 'Enter', altKey: true });
+    expect(h.getSubmitted()).toBe(false);
+    expect(h.view.state.doc.toString()).toBe('\n');
+  });
+
+  it('Mod+Enter (Cmd on mac / Ctrl elsewhere) inserts a newline', () => {
+    // Cover both modifier mappings so the test is platform-agnostic.
+    press(h.view, { key: 'Enter', code: 'Enter', metaKey: true });
+    press(h.view, { key: 'Enter', code: 'Enter', ctrlKey: true });
+    expect(h.getSubmitted()).toBe(false);
+    expect(h.view.state.doc.toString().length).toBeGreaterThan(0);
+    expect(h.view.state.doc.toString()).toMatch(/^\n+$/);
+  });
+});

--- a/packages/web-shell/client/components/Editor.keymap.test.ts
+++ b/packages/web-shell/client/components/Editor.keymap.test.ts
@@ -92,11 +92,17 @@ describe('Editor newline keymap (runtime)', () => {
   });
 
   it('Mod+Enter (Cmd on mac / Ctrl elsewhere) inserts a newline', () => {
-    // Cover both modifier mappings so the test is platform-agnostic.
-    press(h.view, { key: 'Enter', code: 'Enter', metaKey: true });
-    press(h.view, { key: 'Enter', code: 'Enter', ctrlKey: true });
+    // CodeMirror's `Mod-` prefix resolves to exactly one modifier per platform
+    // (Meta on mac, Ctrl elsewhere). Dispatch the platform-correct one so the
+    // assertion fails if Ctrl+Enter is ever broken on non-mac (and vice versa).
+    const isMac = /Mac/i.test(navigator.platform ?? '');
+    press(h.view, {
+      key: 'Enter',
+      code: 'Enter',
+      metaKey: isMac,
+      ctrlKey: !isMac,
+    });
     expect(h.getSubmitted()).toBe(false);
-    expect(h.view.state.doc.toString().length).toBeGreaterThan(0);
-    expect(h.view.state.doc.toString()).toMatch(/^\n+$/);
+    expect(h.view.state.doc.toString()).toBe('\n');
   });
 });

--- a/packages/web-shell/client/components/Editor.tsx
+++ b/packages/web-shell/client/components/Editor.tsx
@@ -314,6 +314,13 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
       ),
     ];
 
+    // Shared newline handler for all multi-line input shortcuts. Inserts a
+    // literal '\n' at the cursor instead of submitting.
+    const insertNewline = (view: EditorView) => {
+      view.dispatch(view.state.replaceSelection('\n'));
+      return true;
+    };
+
     const submitKeymap = keymap.of([
       {
         key: 'Enter',
@@ -331,19 +338,24 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
           return submitText(view);
         },
       },
+      // Newline shortcuts, mirroring the CLI TUI's NEWLINE bindings:
+      // Shift+Enter, Ctrl+J, Ctrl+Enter / Cmd+Enter (Mod-Enter), and
+      // Option/Alt+Enter for terminal muscle memory.
       {
         key: 'Shift-Enter',
-        run: (view) => {
-          view.dispatch(view.state.replaceSelection('\n'));
-          return true;
-        },
+        run: insertNewline,
       },
       {
         key: 'Ctrl-j',
-        run: (view) => {
-          view.dispatch(view.state.replaceSelection('\n'));
-          return true;
-        },
+        run: insertNewline,
+      },
+      {
+        key: 'Mod-Enter',
+        run: insertNewline,
+      },
+      {
+        key: 'Alt-Enter',
+        run: insertNewline,
       },
       {
         key: 'Escape',

--- a/packages/web-shell/client/components/ShortcutsPanel.tsx
+++ b/packages/web-shell/client/components/ShortcutsPanel.tsx
@@ -25,8 +25,8 @@ function getNewlineShortcut(): string {
   // Alt+Enter is labeled Option (⌥) on macOS; Mod+Enter resolves to
   // Cmd+Enter on macOS and Ctrl+Enter elsewhere.
   return isMacPlatform()
-    ? 'shift+enter / ctrl+j / opt+enter'
-    : 'shift+enter / ctrl+j / alt+enter';
+    ? 'shift+enter / ctrl+j / opt+enter / cmd+enter'
+    : 'shift+enter / ctrl+j / alt+enter / ctrl+enter';
 }
 
 const SHORTCUTS: Shortcut[] = [

--- a/packages/web-shell/client/components/ShortcutsPanel.tsx
+++ b/packages/web-shell/client/components/ShortcutsPanel.tsx
@@ -21,12 +21,20 @@ function getPasteImagesShortcut(): string {
   return isMacPlatform() ? 'cmd+v' : 'ctrl+v';
 }
 
+function getNewlineShortcut(): string {
+  // Alt+Enter is labeled Option (⌥) on macOS; Mod+Enter resolves to
+  // Cmd+Enter on macOS and Ctrl+Enter elsewhere.
+  return isMacPlatform()
+    ? 'shift+enter / ctrl+j / opt+enter'
+    : 'shift+enter / ctrl+j / alt+enter';
+}
+
 const SHORTCUTS: Shortcut[] = [
   { key: '/', descriptionKey: 'help.shortcut.commandMenu' },
   { key: '@', descriptionKey: 'help.shortcut.addContext' },
   { key: 'shift+tab', descriptionKey: 'help.shortcut.approvals' },
   { key: 'esc', descriptionKey: 'help.shortcut.cancel' },
-  { key: 'shift+enter / ctrl+j', descriptionKey: 'help.shortcut.newline' },
+  { key: getNewlineShortcut(), descriptionKey: 'help.shortcut.newline' },
   { key: 'ctrl+l', descriptionKey: 'help.shortcut.clear' },
   { key: 'ctrl+y', descriptionKey: 'help.shortcut.retry' },
   { key: 'ctrl+o', descriptionKey: 'help.shortcut.compact' },


### PR DESCRIPTION
## What this PR does

Adds Option+Enter and Cmd/Ctrl+Enter as newline shortcuts in the web terminal input. Previously the editor only inserted a newline on Shift+Enter and Ctrl+J; Option+Enter — which already works in the CLI TUI and matches Claude Code / Codex muscle memory — did nothing, and there was no Cmd/Ctrl+Enter path. This binds `Alt-Enter` (the browser delivers the Option key as `altKey`, so this is Option+Enter, cross-platform) and `Mod-Enter` (Cmd+Enter on macOS, Ctrl+Enter elsewhere), refactors the duplicated newline handler into a shared `insertNewline`, and makes the shortcuts-panel label platform-aware (`opt+enter` on macOS, `alt+enter` otherwise). Submit on Enter, and the existing Shift+Enter / Ctrl+J, are unchanged.

## Why it's needed

It brings the web shell in line with the TUI's newline behavior. The TUI's `NEWLINE` command (`packages/cli/src/config/keyBindings.ts`) binds `{ key: 'return', command: true }` and `{ key: 'return', ctrl: true }`. In a terminal the Option key acts as Meta: pressing Option+Enter sends the `ESC\r` sequence, which `KeypressContext` detects and turns into `key.meta = true` (`packages/cli/src/ui/contexts/KeypressContext.tsx`), so the `command` (meta) binding fires and inserts a newline. The web shell was missing that, so users with terminal muscle memory pressed Option+Enter and got nothing. In the browser, Option+Enter maps to `altKey` (`Alt-Enter`) and Cmd/Ctrl+Enter map to `Mod-Enter`, restoring parity.

## Reviewer Test Plan

### How to verify

Open the web shell, focus the prompt input, type some text, then press each newline shortcut and confirm it inserts a line break instead of submitting: Option+Enter, Cmd+Enter (macOS), Ctrl+Enter (Windows/Linux), plus the existing Shift+Enter and Ctrl+J. Confirm a plain Enter still submits. Open the shortcuts panel (`?`) and confirm the newline row reads `shift+enter / ctrl+j / opt+enter` on macOS and `... / alt+enter` elsewhere. Automated check: `npx vitest run client/components/` in `packages/web-shell` — the suite includes `Editor.keymap.test.ts`, which mounts a real CodeMirror `EditorView` and dispatches real keydown events to assert Enter submits while Shift/Ctrl+J/Mod/Alt+Enter insert `\n`.

### Evidence (Before & After)

Before: Option+Enter and Cmd+Enter were unbound in the editor keymap (no newline). After: both insert a newline without submitting. Verified two ways: (1) a jsdom test driving a real CodeMirror `EditorView` with real keydown events (`Editor.keymap.test.ts`, 5/5); (2) a real-browser run in Chromium (`navigator.platform = MacIntel`) via Playwright, mounting the actual `Editor` component and pressing keys — 7/7 checks pass: Option+Enter (`Alt+Enter`) → `hello\nworld` with 0 submits, Cmd+Enter (`Meta+Enter`) → `foo\nbar` with 0 submits, Shift+Enter → `a\nb`, plain Enter → submits `"submit me"` and clears the input. The full web-shell component suite also passes (96/96).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- macOS: build, ESLint, the jsdom keymap/component suites, and a real-Chromium Playwright run against the live Editor component all pass locally. Windows/Linux not run locally; behavior is platform-agnostic via CodeMirror and covered by CI. -->

### Environment (optional)

`npm run dev` (Vite dev server, port 5173); `npx vitest run` in `packages/web-shell`; Playwright (Chromium) against a throwaway Editor harness page.

## Risk & Scope

- Main risk or tradeoff: Low. Additive keymap entries only; no existing binding changes. Scope is limited to the web-shell CodeMirror editor — CLI / TUI / daemon / backend untouched. The new `Alt-Enter` / `Mod-Enter` combos had no prior binding in the submit keymap, so there is no conflict.
- Not validated / out of scope: Windows and Linux were not exercised locally (CodeMirror makes the bindings platform-agnostic; CI covers those OSes).
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 web 终端输入框里新增 Option+Enter 和 Cmd/Ctrl+Enter 两种换行快捷键。此前编辑器只有 Shift+Enter 和 Ctrl+J 能换行;Option+Enter——它在 CLI TUI 里本来就能换行,也符合 Claude Code / Codex 的肌肉记忆——在 web 端却毫无反应,而且没有 Cmd/Ctrl+Enter 这条路径。本次绑定了 `Alt-Enter`(浏览器把 Option 键作为 `altKey` 传入,所以这就是 Option+Enter,各平台通用)和 `Mod-Enter`(macOS 上是 Cmd+Enter,其他平台是 Ctrl+Enter),把重复的换行逻辑抽成共享的 `insertNewline`,并让快捷键面板的提示文字平台感知(macOS 显示 `opt+enter`,其他平台 `alt+enter`)。Enter 提交,以及原有的 Shift+Enter / Ctrl+J,均保持不变。

## 为什么需要

它让 web shell 与 TUI 的换行行为对齐。TUI 的 `NEWLINE` 命令(`packages/cli/src/config/keyBindings.ts`)绑定了 `{ key: 'return', command: true }` 和 `{ key: 'return', ctrl: true }`。在终端里 Option 键扮演 Meta:按 Option+Enter 会发出 `ESC\r` 序列,`KeypressContext` 识别后把它置为 `key.meta = true`(`packages/cli/src/ui/contexts/KeypressContext.tsx`),于是 `command`(meta)绑定命中并换行。web shell 此前缺这条,所以有终端肌肉记忆的用户按 Option+Enter 没反应。在浏览器里,Option+Enter 对应 `altKey`(`Alt-Enter`),Cmd/Ctrl+Enter 对应 `Mod-Enter`,从而恢复一致性。

## 审阅者测试计划

### 如何验证

打开 web shell,聚焦输入框,输入一些文字,然后分别按各换行快捷键,确认是插入换行而不是提交:Option+Enter、Cmd+Enter(macOS)、Ctrl+Enter(Windows/Linux),以及原有的 Shift+Enter 和 Ctrl+J。确认普通 Enter 仍然提交。打开快捷键面板(`?`),确认换行那一行在 macOS 显示 `shift+enter / ctrl+j / opt+enter`、其他平台显示 `... / alt+enter`。自动化检查:在 `packages/web-shell` 下运行 `npx vitest run client/components/`——测试集包含 `Editor.keymap.test.ts`,它挂载真实的 CodeMirror `EditorView` 并派发真实 keydown 事件,断言 Enter 提交、而 Shift/Ctrl+J/Mod/Alt+Enter 插入 `\n`。

### 证据(前后对比)

前:Option+Enter 和 Cmd+Enter 在编辑器 keymap 中未绑定(不换行)。后:两者都能换行且不提交。通过两种方式验证:(1) jsdom 用真实 CodeMirror `EditorView` + 真实 keydown 事件驱动(`Editor.keymap.test.ts`,5/5);(2) 用 Playwright 在真实 Chromium(`navigator.platform = MacIntel`)里挂载真正的 `Editor` 组件并按键——7/7 通过:Option+Enter(`Alt+Enter`)→ `hello\nworld` 且 0 次提交,Cmd+Enter(`Meta+Enter`)→ `foo\nbar` 且 0 次提交,Shift+Enter → `a\nb`,普通 Enter → 提交 `"submit me"` 并清空输入。整个 web-shell 组件测试集也通过(96/96)。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS:build、ESLint、jsdom 的 keymap/组件测试集,以及针对真实 Editor 组件的真实 Chromium Playwright 运行,均在本地通过。Windows/Linux 未在本地运行;行为通过 CodeMirror 与平台无关,且由 CI 覆盖。

### 环境(可选)

`npm run dev`(Vite 开发服务器,端口 5173);`packages/web-shell` 下的 `npx vitest run`;Playwright(Chromium)针对一个一次性的 Editor harness 页面。

## 风险与范围

- 主要风险或权衡:低。仅新增 keymap 条目,不改任何已有绑定。范围仅限 web-shell 的 CodeMirror 编辑器——不触碰 CLI / TUI / daemon / 后端。新增的 `Alt-Enter` / `Mod-Enter` 组合此前在提交 keymap 中没有绑定,因此无冲突。
- 未验证 / 范围之外:Windows 和 Linux 未在本地实测(CodeMirror 使绑定与平台无关;CI 覆盖这些系统)。
- 破坏性变更 / 迁移说明:无。

## 关联 Issue

N/A

</details>
