### PR TITLE
fix(cli): make extensions new work when bundled examples are missing

### DIFF
--- a/packages/cli/src/commands/extensions/examples/starter/QWEN.md
+++ b/packages/cli/src/commands/extensions/examples/starter/QWEN.md
@@ -1,0 +1,30 @@
+# Writing Companion
+
+This extension turns Qwen Code into a thoughtful writing companion. Keep the
+following guidance in mind whenever this extension is active.
+
+## Voice
+
+- Be warm, clear, and concise. Prefer plain language over jargon.
+- Preserve the user's own voice and intent — improve their words, don't replace
+  them with your own style.
+- Offer choices rather than dictating a single "correct" rewrite.
+
+## Available capabilities
+
+- **`/writing:polish <text>`** — proofread and tighten a passage while keeping
+  its meaning and tone.
+- **The `synonyms` skill** — suggest alternative words and phrasings with notes
+  on nuance and formality.
+- **The `diary-writer` subagent** — expand brief notes into a full journal
+  entry. Reach for it when the user wants reflective, longer-form writing.
+- **The `count_words` MCP tool** — count the words and characters in a passage
+  when the user asks about length or wants to hit a target.
+
+## Guidelines
+
+- When asked to "make it shorter", cut filler and redundancy first; flag any
+  meaning you would lose.
+- When suggesting synonyms or rewrites, briefly explain _why_ one option fits
+  better than another.
+- Treat the user's drafts as private and confidential.

--- a/packages/cli/src/commands/extensions/examples/starter/README.md
+++ b/packages/cli/src/commands/extensions/examples/starter/README.md
@@ -1,0 +1,59 @@
+# Starter Extension Example
+
+A complete, end-to-end Qwen Code extension that demonstrates **every** building
+block in a single package, themed around a small "writing companion". Use it as
+a starting point when you want a relatively complete scaffold instead of an
+empty extension.
+
+```
+starter/
+├── qwen-extension.json        # Manifest: name, version, context file, MCP servers
+├── QWEN.md                    # Context: persistent instructions for the model
+├── agents/
+│   └── diary.md               # Subagent: a focused diary-writing assistant
+├── commands/
+│   └── writing/
+│       └── polish.md          # Custom command: /writing:polish
+├── skills/
+│   └── synonyms/
+│       └── SKILL.md           # Skill: generate synonyms on demand
+├── example.ts                 # MCP server source (tools + prompts)
+├── package.json               # Build config for the MCP server
+└── tsconfig.json
+```
+
+## What each piece does
+
+| Capability | Where               | How it shows up                                          |
+| ---------- | ------------------- | -------------------------------------------------------- |
+| Context    | `QWEN.md`           | Persistent instructions injected into every session.     |
+| Subagent   | `agents/diary.md`   | Available via `/agents manage`.                          |
+| Command    | `commands/writing/` | Invoked as `/writing:polish <text>`.                     |
+| Skill      | `skills/synonyms/`  | Auto-activated via `/skills` when relevant.              |
+| MCP server | `example.ts`        | Exposes a `count_words` tool and a `poem-writer` prompt. |
+
+## Building the MCP server
+
+The MCP server is written in TypeScript and must be compiled before it can run.
+From the extension directory:
+
+```bash
+npm install
+npm run build   # emits dist/example.js, which qwen-extension.json points at
+```
+
+The other capabilities (context, agents, commands, skills) work without any
+build step.
+
+## Trying it out
+
+```bash
+qwen extensions link /path/to/starter   # link this directory for local testing
+```
+
+Then restart Qwen Code. The context loads automatically, `/writing:polish` and
+`/skills` become available, the `diary-writer` subagent appears under
+`/agents manage`, and (once built) the MCP `count_words` tool is callable.
+
+See the [Getting Started with Extensions](https://github.com/QwenLM/qwen-code/blob/main/docs/users/extension/getting-started-extensions.md)
+guide for a deeper walkthrough.

--- a/packages/cli/src/commands/extensions/examples/starter/agents/diary.md
+++ b/packages/cli/src/commands/extensions/examples/starter/agents/diary.md
@@ -1,0 +1,86 @@
+---
+name: diary-writer
+description: generate a diary for user
+color: yellow
+tools:
+  - Glob
+  - Grep
+  - ListFiles
+  - ReadFile
+  - ReadManyFiles
+  - NotebookRead
+  - WebFetch
+  - TodoWrite
+modelConfig:
+  model: qwen3-coder-plus
+---
+
+You are a personal diary writing assistant who helps users capture their daily experiences, thoughts, and reflections in meaningful journal entries.
+
+## Core Mission
+
+Help users create thoughtful, well-structured diary entries that preserve their memories, emotions, and personal growth moments.
+
+## Writing Style
+
+**Tone & Voice**
+
+- Warm, personal, and authentic
+- Reflective and introspective
+- Supportive without being overly sentimental
+- Adapt to user's preferred style (casual, formal, poetic, etc.)
+
+**Structure Options**
+
+- Free-form narrative
+- Bullet-point highlights
+- Gratitude-focused entries
+- Goal and achievement tracking
+- Emotional processing format
+
+## Capabilities
+
+**1. Daily Entry Creation**
+
+- Transform user's brief notes into full diary entries
+- Expand on key moments with descriptive details
+- Add context about weather, mood, or setting when relevant
+- Include meaningful quotes or observations
+
+**2. Reflection Prompts**
+
+- Ask thoughtful questions to deepen entries
+- Suggest areas worth exploring further
+- Help identify patterns in thoughts and behaviors
+- Encourage gratitude and positive reflection
+
+**3. Memory Enhancement**
+
+- Help recall specific details from the day
+- Connect current events to past experiences
+- Highlight personal growth and progress
+- Preserve important conversations or interactions
+
+**4. Organization**
+
+- Suggest tags or themes for entries
+- Create summaries for weekly/monthly reviews
+- Track recurring topics or goals
+- Maintain consistency in formatting
+
+## Guidelines
+
+- **Privacy First**: Treat all content as deeply personal and confidential
+- **User's Voice**: Write in a way that sounds like the user, not generic
+- **No Judgment**: Accept all emotions and experiences without criticism
+- **Encourage Honesty**: Create a safe space for authentic expression
+- **Balance**: Mix facts with feelings, events with reflections
+
+## Output Format
+
+When creating a diary entry, include:
+
+1. **Date & Title** (optional creative title)
+2. **Main Content** - The narrative or bullet points
+3. **Reflection** - A brief closing thought or takeaway
+4. **Tags** (optional) - For organization and future reference

--- a/packages/cli/src/commands/extensions/examples/starter/commands/writing/polish.md
+++ b/packages/cli/src/commands/extensions/examples/starter/commands/writing/polish.md
@@ -1,0 +1,13 @@
+---
+description: Proofread and tighten a passage while keeping its meaning and tone.
+argument-hint: <text to polish>
+---
+
+Polish the following passage. Fix grammar, spelling, and awkward phrasing, and
+tighten any wordiness — but preserve the author's meaning, voice, and tone.
+
+Then give a short bullet list of the most important changes you made and why.
+
+Passage:
+
+{{args}}

--- a/packages/cli/src/commands/extensions/examples/starter/example.ts
+++ b/packages/cli/src/commands/extensions/examples/starter/example.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+
+const server = new McpServer({
+  name: 'writing-companion-server',
+  version: '1.0.0',
+});
+
+// A self-contained tool (no network access needed) that counts the words and
+// characters in a passage. Useful for hitting a length target.
+server.registerTool(
+  'count_words',
+  {
+    description: 'Count the words and characters in a passage of text.',
+    inputSchema: z.object({
+      text: z.string().describe('The text to measure.'),
+    }).shape,
+  },
+  async ({ text }) => {
+    const words = text.trim() === '' ? 0 : text.trim().split(/\s+/).length;
+    const characters = text.length;
+    const charactersNoSpaces = text.replace(/\s/g, '').length;
+    const response = { words, characters, charactersNoSpaces };
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(response),
+        },
+      ],
+    };
+  },
+);
+
+// A reusable prompt template surfaced to the user via the MCP server.
+server.registerPrompt(
+  'poem-writer',
+  {
+    title: 'Poem Writer',
+    description: 'Write a nice haiku',
+    argsSchema: { title: z.string(), mood: z.string().optional() },
+  },
+  ({ title, mood }) => ({
+    messages: [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text: `Write a haiku${mood ? ` with the mood ${mood}` : ''} called ${title}. Note that a haiku is 5 syllables followed by 7 syllables followed by 5 syllables `,
+        },
+      },
+    ],
+  }),
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/cli/src/commands/extensions/examples/starter/package.json
+++ b/packages/cli/src/commands/extensions/examples/starter/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "starter-example",
+  "version": "1.0.0",
+  "description": "Complete example Qwen Code extension (context, agent, command, skill, and MCP server)",
+  "type": "module",
+  "main": "example.js",
+  "scripts": {
+    "build": "tsc"
+  },
+  "devDependencies": {
+    "typescript": "~5.4.5",
+    "@types/node": "^20.11.25"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.11.0",
+    "zod": "^3.22.4"
+  }
+}

--- a/packages/cli/src/commands/extensions/examples/starter/qwen-extension.json
+++ b/packages/cli/src/commands/extensions/examples/starter/qwen-extension.json
@@ -1,0 +1,12 @@
+{
+  "name": "starter-example",
+  "version": "1.0.0",
+  "contextFileName": "QWEN.md",
+  "mcpServers": {
+    "nodeServer": {
+      "command": "node",
+      "args": ["${extensionPath}${/}dist${/}example.js"],
+      "cwd": "${extensionPath}"
+    }
+  }
+}

--- a/packages/cli/src/commands/extensions/examples/starter/skills/synonyms/SKILL.md
+++ b/packages/cli/src/commands/extensions/examples/starter/skills/synonyms/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: synonyms
+description: Generate synonyms for words or phrases. Use this skill when the user needs alternative words with similar meanings, wants to expand vocabulary, or seeks varied expressions for writing.
+license: Complete terms in LICENSE.txt
+---
+
+This skill helps generate synonyms and alternative expressions for given words or phrases. It provides contextually appropriate alternatives to enhance vocabulary and improve writing variety.
+
+The user provides a word, phrase, or sentence where they need synonym suggestions. They may specify the context, tone, or formality level desired.
+
+## Synonym Generation Guidelines
+
+When generating synonyms, consider:
+
+- **Context**: The specific domain or situation where the word will be used
+- **Tone**: Formal, informal, neutral, academic, conversational, etc.
+- **Nuance**: Subtle differences in meaning between similar words
+- **Register**: Appropriate level of formality for the intended audience
+
+## Output Format
+
+For each input word or phrase, provide:
+
+1. **Direct Synonyms**: Words with nearly identical meanings
+2. **Related Alternatives**: Words with similar but slightly different connotations
+3. **Context Examples**: Brief usage examples when helpful
+
+## Best Practices
+
+- Prioritize commonly used synonyms over obscure alternatives
+- Note any subtle differences in meaning or usage
+- Consider regional variations when relevant
+- Indicate formality levels (formal/informal/neutral)
+- Provide multiple options to give users choices
+
+## Example
+
+**Input**: "happy"
+
+**Synonyms**:
+
+- **Direct**: joyful, cheerful, delighted, pleased, content
+- **Informal**: thrilled, stoked, over the moon
+- **Formal**: elated, gratified, blissful
+- **Subtle variations**:
+  - _content_ - peaceful satisfaction
+  - _ecstatic_ - intense, overwhelming happiness
+  - _cheerful_ - outwardly expressing happiness

--- a/packages/cli/src/commands/extensions/examples/starter/tsconfig.json
+++ b/packages/cli/src/commands/extensions/examples/starter/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist"
+  },
+  "include": ["example.ts"]
+}

--- a/packages/cli/src/commands/extensions/new.test.ts
+++ b/packages/cli/src/commands/extensions/new.test.ts
@@ -10,7 +10,16 @@ import yargs from 'yargs';
 import * as fsPromises from 'node:fs/promises';
 import path from 'node:path';
 
+const mockWriteStdoutLine = vi.hoisted(() => vi.fn());
+const mockWriteStderrLine = vi.hoisted(() => vi.fn());
+
 vi.mock('node:fs/promises');
+
+vi.mock('../../utils/stdioHelpers.js', () => ({
+  writeStdoutLine: mockWriteStdoutLine,
+  writeStderrLine: mockWriteStderrLine,
+  clearScreen: vi.fn(),
+}));
 
 const mockedFs = vi.mocked(fsPromises);
 
@@ -74,6 +83,109 @@ describe('extensions new command', () => {
       expect.stringContaining(path.normalize('context/mcp-server')),
       path.normalize('/some/path/mcp-server'),
       { recursive: true },
+    );
+  });
+
+  it('should still create an extension when the examples directory is missing', async () => {
+    mockedFs.readdir.mockRejectedValue(
+      Object.assign(new Error('ENOENT: no such file or directory'), {
+        code: 'ENOENT',
+      }),
+    );
+    mockedFs.access.mockRejectedValue(new Error('ENOENT'));
+    mockedFs.mkdir.mockResolvedValue(undefined);
+
+    const parser = yargs([]).command(newCommand).fail(false);
+
+    await parser.parseAsync('new /some/path');
+
+    expect(mockedFs.mkdir).toHaveBeenCalledWith('/some/path', {
+      recursive: true,
+    });
+    expect(mockedFs.cp).not.toHaveBeenCalled();
+    // A plainly missing directory is the expected degraded state, not an
+    // install problem worth warning about.
+    expect(mockWriteStderrLine).not.toHaveBeenCalled();
+  });
+
+  it('should reject a template argument with a clear error when the examples directory is missing', async () => {
+    mockedFs.readdir.mockRejectedValue(
+      Object.assign(new Error('ENOENT: no such file or directory'), {
+        code: 'ENOENT',
+      }),
+    );
+    mockedFs.access.mockRejectedValue(new Error('ENOENT'));
+    mockedFs.mkdir.mockResolvedValue(undefined);
+
+    const parser = yargs([]).command(newCommand).fail(false);
+
+    await expect(parser.parseAsync('new /some/path context')).rejects.toThrow(
+      'No boilerplate templates are available in this installation.',
+    );
+
+    expect(mockedFs.mkdir).not.toHaveBeenCalled();
+    expect(mockedFs.cp).not.toHaveBeenCalled();
+  });
+
+  it('should reject a template that is not in the available list', async () => {
+    mockedFs.access.mockRejectedValue(new Error('ENOENT'));
+    mockedFs.mkdir.mockResolvedValue(undefined);
+
+    const parser = yargs([]).command(newCommand).fail(false).locale('en');
+
+    await expect(parser.parseAsync('new /some/path bogus')).rejects.toThrow(
+      /Invalid values/,
+    );
+
+    expect(mockedFs.mkdir).not.toHaveBeenCalled();
+    expect(mockedFs.cp).not.toHaveBeenCalled();
+  });
+
+  it('should still create an extension when reading templates fails with a non-ENOENT error', async () => {
+    mockedFs.readdir.mockRejectedValue(
+      Object.assign(new Error('EACCES: permission denied'), {
+        code: 'EACCES',
+      }),
+    );
+    mockedFs.access.mockRejectedValue(new Error('ENOENT'));
+    mockedFs.mkdir.mockResolvedValue(undefined);
+
+    const parser = yargs([]).command(newCommand).fail(false);
+
+    await parser.parseAsync('new /some/path');
+
+    expect(mockedFs.mkdir).toHaveBeenCalledWith('/some/path', {
+      recursive: true,
+    });
+    expect(mockedFs.cp).not.toHaveBeenCalled();
+    // Unexpected errors must be surfaced, not silently treated as
+    // "no templates installed".
+    expect(mockWriteStderrLine).toHaveBeenCalledTimes(1);
+    expect(mockWriteStderrLine).toHaveBeenCalledWith(
+      expect.stringContaining('Warning: failed to read extension templates'),
+    );
+  });
+
+  it('should warn and reject a template argument when reading templates fails with a non-ENOENT error', async () => {
+    mockedFs.readdir.mockRejectedValue(
+      Object.assign(new Error('EACCES: permission denied'), {
+        code: 'EACCES',
+      }),
+    );
+    mockedFs.access.mockRejectedValue(new Error('ENOENT'));
+    mockedFs.mkdir.mockResolvedValue(undefined);
+
+    const parser = yargs([]).command(newCommand).fail(false);
+
+    await expect(parser.parseAsync('new /some/path context')).rejects.toThrow(
+      'Extension templates could not be read in this installation.',
+    );
+
+    expect(mockedFs.mkdir).not.toHaveBeenCalled();
+    expect(mockedFs.cp).not.toHaveBeenCalled();
+    expect(mockWriteStderrLine).toHaveBeenCalledTimes(1);
+    expect(mockWriteStderrLine).toHaveBeenCalledWith(
+      expect.stringContaining('Warning: failed to read extension templates'),
     );
   });
 

--- a/packages/cli/src/commands/extensions/new.ts
+++ b/packages/cli/src/commands/extensions/new.ts
@@ -7,7 +7,7 @@
 import { access, cp, mkdir, readdir, writeFile } from 'node:fs/promises';
 import { join, basename } from 'node:path';
 import type { CommandModule } from 'yargs';
-import { resolveBundleDir } from '@qwen-code/qwen-code-core';
+import { isNodeError, resolveBundleDir } from '@qwen-code/qwen-code-core';
 import { getErrorMessage } from '../../utils/errors.js';
 import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
 
@@ -81,18 +81,39 @@ async function handleNew(args: NewArgs) {
   }
 }
 
-async function getBoilerplateChoices() {
-  const entries = await readdir(EXAMPLES_PATH, { withFileTypes: true });
-  return entries
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => entry.name);
+async function getBoilerplateChoices(): Promise<{
+  choices: string[];
+  readFailed: boolean;
+}> {
+  // The examples directory may be absent from a given install (e.g. a package
+  // built without bundled assets). Degrade to "no templates" so the
+  // template-less `new <path>` form keeps working — but warn on unexpected
+  // errors (EACCES, EMFILE, ...) so a broken install doesn't silently
+  // masquerade as a template-less one.
+  try {
+    const entries = await readdir(EXAMPLES_PATH, { withFileTypes: true });
+    return {
+      choices: entries
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name),
+      readFailed: false,
+    };
+  } catch (e) {
+    const isMissing = isNodeError(e) && e.code === 'ENOENT';
+    if (!isMissing) {
+      writeStderrLine(
+        `Warning: failed to read extension templates: ${getErrorMessage(e)}`,
+      );
+    }
+    return { choices: [], readFailed: !isMissing };
+  }
 }
 
 export const newCommand: CommandModule = {
   command: 'new <path> [template]',
   describe: 'Create a new extension from a boilerplate example.',
   builder: async (yargs) => {
-    const choices = await getBoilerplateChoices();
+    const { choices, readFailed } = await getBoilerplateChoices();
     return yargs
       .positional('path', {
         describe: 'The path to create the extension in.',
@@ -101,7 +122,24 @@ export const newCommand: CommandModule = {
       .positional('template', {
         describe: 'The boilerplate template to use.',
         type: 'string',
-        choices,
+        // An empty choices list would reject every value with a blank
+        // "Choices:" hint; yargs treats undefined as "no constraint".
+        choices: choices.length > 0 ? choices : undefined,
+      })
+      .check((argv) => {
+        // With no templates available the positional is unconstrained, so an
+        // arbitrary value would otherwise reach the copy step — creating the
+        // destination directory before failing on a raw ENOENT (or escaping
+        // EXAMPLES_PATH via a ".."-laden value). When templates exist, the
+        // `choices` constraint above already validates membership.
+        if (argv['template'] && choices.length === 0) {
+          throw new Error(
+            readFailed
+              ? 'Extension templates could not be read in this installation.'
+              : 'No boilerplate templates are available in this installation.',
+          );
+        }
+        return true;
       });
   },
   handler: async (args) => {


### PR DESCRIPTION
## What this PR does

This PR makes `qwen extensions new` tolerate installs where the bundled extension examples directory is missing or unreadable, and adds `starter` as an explicit full-featured boilerplate template available via `qwen extensions new <path> starter`.

Concretely, `getBoilerplateChoices()` now degrades to an empty template list when the examples directory is missing (`ENOENT`) instead of letting a raw filesystem error escape from the yargs builder, while still surfacing unexpected read errors (`EACCES`, `EMFILE`, etc.) as warnings. When no templates are available, the `template` positional drops its `choices` constraint and a builder-level `check` rejects any provided template argument with a clear message before the command handler runs. The default `qwen extensions new <path>` path still creates the minimal manifest scaffold; the new `starter` template is opt-in.

Since #4719 is already on `main`, the normal packaged/bundled path should include `dist/examples`. The missing-template behavior here is a defensive fallback for broken, partial, or otherwise unusual installs rather than the primary packaging fix.

## Why it's needed

Installs without readable bundled examples should not make `qwen extensions new <path>` crash with a raw `ENOENT` before the user has even requested a template. In that degraded state, creating a minimal extension without a template can still succeed, while requesting a named template should fail early with a clear explanation. Separately, the new `starter` template gives users an explicit, working example that bundles every extension capability — context, subagent, custom command, skill, and an MCP server — in one package.

## Reviewer Test Plan

### How to verify

Unit tests cover both the degraded-install paths and the existing happy paths: run `npx vitest run packages/cli/src/commands/extensions/new.test.ts` and confirm 9/9 pass. The added cases assert that (1) a missing examples directory still lets `new <path>` create the minimal extension without a warning, (2) a non-ENOENT read error still creates the minimal extension but emits a warning, (3) passing a template when no templates are available is rejected with the correct message for missing vs unreadable examples, and (4) an unknown template is still rejected through the normal `choices` path when templates exist.

To reproduce the degraded-install behavior by hand: temporarily remove or rename the bundled `dist/examples` directory of a built CLI and run `qwen extensions new /tmp/my-ext`. Before this change it crashes with a raw `ENOENT`; after this change it creates the minimal extension. Running `qwen extensions new /tmp/my-ext context` on that same degraded install now prints "No boilerplate templates are available in this installation." and creates nothing.

### Evidence (Before & After)

Not a TUI change. On an install with no bundled examples, `qwen extensions new <path>` previously failed in the yargs builder with a raw `ENOENT: no such file or directory, scandir '.../examples'` before the command handler ran. After this change, `new <path>` creates the minimal extension normally, and `new <path> <template>` is rejected up front with "No boilerplate templates are available in this installation." (or "Extension templates could not be read in this installation." when the read failed for a non-ENOENT reason).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only (`vitest`) plus `tsc --noEmit` on `packages/cli`. No runtime sandbox needed.

## Risk & Scope

- Main risk or tradeoff: Low. The change is confined to `extensions new` argument parsing plus the additive `starter` example. Normal installs should continue to get the existing template choices, now with one additional explicit `starter` option.
- Not validated / out of scope: Windows and Linux were not exercised locally (covered by CI). Bundling examples into the published tarball is out of scope here because #4719 is already on `main`.
- Breaking changes / migration notes: None.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

本 PR 让 `qwen extensions new` 能容忍捆绑扩展示例目录缺失或不可读的安装环境，并新增了一个显式的完整功能模板 `starter`，可通过 `qwen extensions new <path> starter` 使用。

具体来说，`getBoilerplateChoices()` 现在会在示例目录缺失（`ENOENT`）时降级为空模板列表，而不是让原始文件系统错误从 yargs builder 抛出；同时对于非预期读取错误（`EACCES`、`EMFILE` 等）仍会以警告形式暴露出来。当没有可用模板时，`template` 位置参数会去掉 `choices` 约束，并由 builder 层的 `check` 在命令 handler 运行前用清晰提示拒绝传入的模板参数。默认的 `qwen extensions new <path>` 路径仍然创建最小 manifest 脚手架；新的 `starter` 模板是显式选择使用的。

由于 #4719 已经在 `main` 上，正常的打包/捆绑路径应该已经包含 `dist/examples`。这里的缺失模板处理是针对损坏、不完整或其他非典型安装环境的防御性兜底，而不是主要的打包修复。

## 为什么需要它

当安装环境中没有可读的捆绑 examples 时，`qwen extensions new <path>` 不应该在用户没有请求任何模板的情况下就因为原始 `ENOENT` 崩溃。在这种降级状态下，不指定模板创建最小扩展仍然可以成功；如果用户请求了具名模板，则应该提前用清晰提示失败。另一方面，新增的 `starter` 模板为用户提供了一个显式、可运行的完整示例，把上下文、子代理、自定义命令、技能以及 MCP server 都放在同一个包里。

## 审查者测试计划

### 如何验证

单元测试同时覆盖了降级安装路径和原有正常路径：运行 `npx vitest run packages/cli/src/commands/extensions/new.test.ts`，确认 9/9 通过。新增用例验证：(1) 示例目录缺失时 `new <path>` 仍能创建最小扩展且不产生警告；(2) 非 ENOENT 的读取错误下仍能创建最小扩展，但会发出警告；(3) 在没有可用模板时传入模板会被拒绝，并且对“缺失”和“不可读”两种情况给出正确提示；(4) 当模板存在时，未知模板仍会通过正常的 `choices` 路径被拒绝。

手动复现降级安装行为：临时删除或重命名已构建 CLI 的捆绑 `dist/examples` 目录，然后运行 `qwen extensions new /tmp/my-ext`。改动前会以原始 `ENOENT` 崩溃；改动后会正常创建最小扩展。在同一降级安装上运行 `qwen extensions new /tmp/my-ext context` 现在会打印 "No boilerplate templates are available in this installation." 并且什么都不创建。

### 证据（前后对比）

不是 TUI 改动。在没有捆绑 examples 的安装上，`qwen extensions new <path>` 以前会在 yargs builder 中以原始 `ENOENT: no such file or directory, scandir '.../examples'` 失败，命令 handler 还没有开始执行。改动后，`new <path>` 会正常创建最小扩展；`new <path> <template>` 会被提前以 "No boilerplate templates are available in this installation."（当读取因非 ENOENT 原因失败时则为 "Extension templates could not be read in this installation."）拒绝。

### 测试环境

仅单元测试（`vitest`）外加对 `packages/cli` 执行 `tsc --noEmit`。无需运行时沙箱。

## 风险与范围

- 主要风险或权衡：低。改动局限于 `extensions new` 的参数解析以及新增（纯增量）的 `starter` 示例。正常安装应继续得到既有模板选项，只是额外多了一个显式的 `starter` 选项。
- 未验证 / 不在范围内：Windows 和 Linux 未在本地验证（由 CI 覆盖）。把 examples 打进发布产物不在本 PR 范围内，因为 #4719 已经在 `main` 上。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
