### PR TITLE
fix(cli): join previous line when Ctrl+U pressed at column 0

### DIFF
--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -195,6 +195,23 @@ describe('textBufferReducer', () => {
       expect(state2.cursorRow).toBe(0);
       expect(state2.cursorCol).toBe(5);
     });
+
+    it('should undo a join operation', () => {
+      const stateWithText: TextBufferState = {
+        ...initialState,
+        lines: ['hello', 'world'],
+        cursorRow: 1,
+        cursorCol: 0,
+      };
+      const action: TextBufferAction = { type: 'kill_line_left' };
+      const joined = textBufferReducer(stateWithText, action);
+      expect(joined.lines).toEqual(['helloworld']);
+
+      const undone = textBufferReducer(joined, { type: 'undo' });
+      expect(undone.lines).toEqual(['hello', 'world']);
+      expect(undone.cursorRow).toBe(1);
+      expect(undone.cursorCol).toBe(0);
+    });
   });
 
   describe('undo/redo actions', () => {

--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -126,6 +126,77 @@ describe('textBufferReducer', () => {
     });
   });
 
+  describe('kill_line_left action', () => {
+    it('should clear text to the left of cursor on the same line', () => {
+      const stateWithText: TextBufferState = {
+        ...initialState,
+        lines: ['hello world'],
+        cursorRow: 0,
+        cursorCol: 5,
+      };
+      const action: TextBufferAction = { type: 'kill_line_left' };
+      const state = textBufferReducer(stateWithText, action);
+      expect(state).toHaveOnlyValidCharacters();
+      expect(state.lines).toEqual([' world']);
+      expect(state.cursorCol).toBe(0);
+    });
+
+    it('should join with previous line when cursor is at column 0', () => {
+      const stateWithText: TextBufferState = {
+        ...initialState,
+        lines: ['hello', 'world'],
+        cursorRow: 1,
+        cursorCol: 0,
+      };
+      const action: TextBufferAction = { type: 'kill_line_left' };
+      const state = textBufferReducer(stateWithText, action);
+      expect(state).toHaveOnlyValidCharacters();
+      expect(state.lines).toEqual(['helloworld']);
+      expect(state.cursorRow).toBe(0);
+      expect(state.cursorCol).toBe(5);
+    });
+
+    it('should do nothing when cursor is at the very beginning', () => {
+      const stateWithText: TextBufferState = {
+        ...initialState,
+        lines: ['hello'],
+        cursorRow: 0,
+        cursorCol: 0,
+      };
+      const action: TextBufferAction = { type: 'kill_line_left' };
+      const state = textBufferReducer(stateWithText, action);
+      expect(state).toHaveOnlyValidCharacters();
+      expect(state.lines).toEqual(['hello']);
+      expect(state.cursorRow).toBe(0);
+      expect(state.cursorCol).toBe(0);
+    });
+
+    it('should join multiple lines when pressing kill_line_left repeatedly', () => {
+      const stateWithText: TextBufferState = {
+        ...initialState,
+        lines: ['line1', 'line2', 'line3'],
+        cursorRow: 2,
+        cursorCol: 0,
+      };
+      const action: TextBufferAction = { type: 'kill_line_left' };
+      const state1 = textBufferReducer(stateWithText, action);
+      expect(state1).toHaveOnlyValidCharacters();
+      expect(state1.lines).toEqual(['line1', 'line2line3']);
+      expect(state1.cursorRow).toBe(1);
+      expect(state1.cursorCol).toBe(5);
+
+      const stateAtCol0: TextBufferState = {
+        ...state1,
+        cursorCol: 0,
+      };
+      const state2 = textBufferReducer(stateAtCol0, action);
+      expect(state2).toHaveOnlyValidCharacters();
+      expect(state2.lines).toEqual(['line1line2line3']);
+      expect(state2.cursorRow).toBe(0);
+      expect(state2.cursorCol).toBe(5);
+    });
+  });
+
   describe('undo/redo actions', () => {
     it('should undo and redo a change', () => {
       // 1. Insert text

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -1791,6 +1791,21 @@ function textBufferReducerLogic(
           cursorCol: 0,
           preferredCol: null,
         };
+      } else if (cursorRow > 0) {
+        const nextState = pushUndoLocal(state);
+        const prevLineContent = currentLine(cursorRow - 1);
+        const currentLineContent = currentLine(cursorRow);
+        const newCol = cpLen(prevLineContent);
+        const newLines = [...nextState.lines];
+        newLines[cursorRow - 1] = prevLineContent + currentLineContent;
+        newLines.splice(cursorRow, 1);
+        return {
+          ...nextState,
+          lines: newLines,
+          cursorRow: cursorRow - 1,
+          cursorCol: newCol,
+          preferredCol: null,
+        };
       }
       return state;
     }


### PR DESCRIPTION
## What this PR does

Fixes Ctrl+U (kill_line_left) so that when the cursor is at column 0 (beginning of a line) and not on the first line, it joins the current line with the previous line, moving the cursor to the end of the previous line. Previously, pressing Ctrl+U at column 0 did nothing.

## Why it is needed

Pressing Ctrl+U repeatedly should progressively clear lines upward, matching the behavior of kill_line_right (which joins the next line at end-of-line) and backspace (which joins lines at column 0). This is also consistent with how Claude Code handles the same keybinding. Without this fix, the user must manually press Backspace or move the cursor to join lines after clearing them with Ctrl+U.

## Reviewer Test Plan

### How to verify

1. Type multi-line input in the prompt box (e.g. line1, Enter, line2, Enter, line3)
2. Press Ctrl+U — should clear line3 (text to the left of cursor on current line)
3. Press Ctrl+U again (cursor is now at column 0 of the cleared line) — should join the empty line with line2, resulting in line1, Enter, line2
4. Press Ctrl+U again — should join line2 with line1, resulting in line1line2

Also run the unit tests:

    cd packages/cli && npx vitest run src/ui/components/shared/text-buffer.test.ts

All 157 tests should pass (4 new tests added for kill_line_left).

### Evidence (Before & After)

**Before:** Ctrl+U at column 0 does nothing — the line is not joined with the previous line.

**After:** Ctrl+U at column 0 joins the current line with the previous line, mirroring kill_line_right and backspace behavior.

https://github.com/user-attachments/assets/9d95ba26-c1fe-4e8d-b074-c43d9afce1b5



### Tested on

| OS | Status |
| :--------: | :----: |
| macOS | tested |
| Windows | not tested |
| Linux | not tested |

## Risk & Scope

- Main risk or tradeoff: Minimal — only affects the kill_line_left code path when cursorCol === 0 && cursorRow > 0. Existing behavior (cursorCol > 0 clears to left, cursorRow === 0 && cursorCol === 0 does nothing) is unchanged.
- Not validated / out of scope: No changes to kill_line_right or other keybindings.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #4985

<details>
<summary>中文说明</summary>

## 改动内容

修复了 Ctrl+U (kill_line_left) 的行为：当光标位于行首 (column 0) 且不在第一行时，将当前行与上一行合并，光标移动到上一行末尾。之前按 Ctrl+U 在行首时什么都不做。

## 为什么需要这个改动

连续按 Ctrl+U 应该逐行向上清除，这与 kill_line_right (在行尾合并下一行) 和 backspace (在行首合并上一行) 的行为一致，也与 Claude Code 的行为一致。不修复此问题的话，用户在用 Ctrl+U 清除后还需手动按 Backspace 或移动光标来合并行。

## Reviewer 测试计划

### 如何验证

1. 在输入框中输入多行文本 (如 line1 Enter line2 Enter line3)
2. 按 Ctrl+U — 应清除 line3 (光标左侧的文本)
3. 再按一次 Ctrl+U (光标现在在空行的行首) — 应将空行与 line2 合并，结果为 line1 Enter line2
4. 再按一次 Ctrl+U — 应将 line2 与 line1 合并，结果为 line1line2

也可运行单元测试:

    cd packages/cli && npx vitest run src/ui/components/shared/text-buffer.test.ts

所有 157 个测试应通过 (新增 4 个 kill_line_left 测试)。

### 证据 (修改前 vs 修改后)

**修改前:** 行首按 Ctrl+U 无任何效果 — 当前行不会与上一行合并。

**修改后:** 行首按 Ctrl+U 将当前行与上一行合并，行为与 kill_line_right 和 backspace 一致。

### 测试环境

| OS | 状态 |
| :--------: | :----: |
| macOS | 已测试 |
| Windows | 未测试 |
| Linux | 未测试 |

## 风险与范围

- 主要风险: 极低 — 仅影响 kill_line_left 在 cursorCol === 0 && cursorRow > 0 时的代码路径。原有行为 (cursorCol > 0 清除左侧文本、cursorRow === 0 && cursorCol === 0 不操作) 不受影响。
- 未验证/不涉及: 未修改 kill_line_right 或其他按键绑定。
- 破坏性变更/迁移说明: 无。

## 关联 Issue

Fixes #4985
</details>
