### PR TITLE
ci(desktop): mac code-signing + App Store Connect API-key notarization

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -428,7 +428,9 @@ jobs:
                   echo "::error::Published macOS desktop releases require APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID for notarization."
                   exit 1
                 fi
-                append_env "NOTARIZE" "true"
+                # electron-builder (>=24) auto-notarizes via notarytool when
+                # APPLE_ID/APPLE_APP_SPECIFIC_PASSWORD/APPLE_TEAM_ID are present
+                # in the env (appended below); no explicit flag is required.
               fi
 
               append_env "CSC_LINK" "$mac_csc_link"

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -377,8 +377,9 @@ jobs:
         shell: 'bash'
         env:
           IS_DRY_RUN: '${{ inputs.dry_run }}'
-          APPLE_APP_SPECIFIC_PASSWORD_SECRET: '${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}'
-          APPLE_ID_SECRET: '${{ secrets.APPLE_ID }}'
+          APPLE_NOTARY_API_KEY_P8_BASE64_SECRET: '${{ secrets.APPLE_NOTARY_API_KEY_P8_BASE64 }}'
+          APPLE_NOTARY_KEY_ID_SECRET: '${{ secrets.APPLE_NOTARY_KEY_ID }}'
+          APPLE_NOTARY_ISSUER_ID_SECRET: '${{ secrets.APPLE_NOTARY_ISSUER_ID }}'
           APPLE_TEAM_ID_SECRET: '${{ secrets.APPLE_TEAM_ID }}'
           MAC_CSC_KEY_PASSWORD_SECRET: '${{ secrets.MAC_CSC_KEY_PASSWORD }}'
           MAC_CSC_LINK_SECRET: '${{ secrets.MAC_CSC_LINK }}'
@@ -424,19 +425,25 @@ jobs:
               fi
 
               if [ "$IS_DRY_RUN" = "false" ]; then
-                if [ -z "$APPLE_ID_SECRET" ] || [ -z "$APPLE_APP_SPECIFIC_PASSWORD_SECRET" ] || [ -z "$APPLE_TEAM_ID_SECRET" ]; then
-                  echo "::error::Published macOS desktop releases require APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID for notarization."
+                if [ -z "$APPLE_NOTARY_API_KEY_P8_BASE64_SECRET" ] || [ -z "$APPLE_NOTARY_KEY_ID_SECRET" ] || [ -z "$APPLE_NOTARY_ISSUER_ID_SECRET" ] || [ -z "$APPLE_TEAM_ID_SECRET" ]; then
+                  echo "::error::Published macOS desktop releases require APPLE_NOTARY_API_KEY_P8_BASE64, APPLE_NOTARY_KEY_ID, APPLE_NOTARY_ISSUER_ID, and APPLE_TEAM_ID for notarization."
                   exit 1
                 fi
-                # electron-builder (>=24) auto-notarizes via notarytool when
-                # APPLE_ID/APPLE_APP_SPECIFIC_PASSWORD/APPLE_TEAM_ID are present
-                # in the env (appended below); no explicit flag is required.
+              fi
+
+              # Materialize the App Store Connect API key (.p8) so electron-builder
+              # (>=24) notarizes via notarytool. It reads APPLE_API_KEY (a path to
+              # the .p8 file), APPLE_API_KEY_ID, and APPLE_API_ISSUER from the env.
+              if [ -n "$APPLE_NOTARY_API_KEY_P8_BASE64_SECRET" ] && [ -n "$APPLE_NOTARY_KEY_ID_SECRET" ] && [ -n "$APPLE_NOTARY_ISSUER_ID_SECRET" ]; then
+                api_key_path="${RUNNER_TEMP}/apple-notary-key.p8"
+                printf '%s' "$APPLE_NOTARY_API_KEY_P8_BASE64_SECRET" | base64 --decode > "$api_key_path"
+                append_env "APPLE_API_KEY" "$api_key_path"
+                append_env "APPLE_API_KEY_ID" "$APPLE_NOTARY_KEY_ID_SECRET"
+                append_env "APPLE_API_ISSUER" "$APPLE_NOTARY_ISSUER_ID_SECRET"
               fi
 
               append_env "CSC_LINK" "$mac_csc_link"
               append_env "CSC_KEY_PASSWORD" "$mac_csc_key_password"
-              append_env "APPLE_ID" "$APPLE_ID_SECRET"
-              append_env "APPLE_APP_SPECIFIC_PASSWORD" "$APPLE_APP_SPECIFIC_PASSWORD_SECRET"
               append_env "APPLE_TEAM_ID" "$APPLE_TEAM_ID_SECRET"
               echo "CSC_IDENTITY_AUTO_DISCOVERY=true" >> "$GITHUB_ENV"
             else

--- a/packages/desktop/apps/electron/scripts/build-dmg.sh
+++ b/packages/desktop/apps/electron/scripts/build-dmg.sh
@@ -150,17 +150,15 @@ if [ -n "$APPLE_SIGNING_IDENTITY" ]; then
     export CSC_NAME="$CSC_NAME_CLEAN"
 fi
 
-# Add notarization if all credentials are available
+# Add notarization if all credentials are available.
+# electron-builder (>=24) auto-notarizes via notarytool whenever APPLE_ID,
+# APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID are present in the env.
+# No `notarize:` config block or NOTARIZE flag is required (or read).
 if [ -n "$APPLE_ID" ] && [ -n "$APPLE_TEAM_ID" ] && [ -n "$APPLE_APP_SPECIFIC_PASSWORD" ]; then
     echo "Notarization enabled"
     export APPLE_ID="$APPLE_ID"
     export APPLE_TEAM_ID="$APPLE_TEAM_ID"
     export APPLE_APP_SPECIFIC_PASSWORD="$APPLE_APP_SPECIFIC_PASSWORD"
-
-    # Enable notarization in electron-builder by setting env vars
-    # The electron-builder.yml has notarize section commented out,
-    # but we can enable it via environment
-    export NOTARIZE=true
 fi
 
 # Run electron-builder

--- a/packages/desktop/scripts/build/darwin.ts
+++ b/packages/desktop/scripts/build/darwin.ts
@@ -32,14 +32,16 @@ export async function packageDarwin(config: BuildConfig): Promise<string> {
     process.env.CSC_NAME = cscName;
   }
 
-  // Add notarization if all credentials are available
+  // Add notarization if all credentials are available.
+  // electron-builder auto-notarizes via notarytool when APPLE_ID,
+  // APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID are present in the env;
+  // no `notarize:` config block or NOTARIZE flag is required (or read).
   if (
     process.env.APPLE_ID &&
     process.env.APPLE_TEAM_ID &&
     process.env.APPLE_APP_SPECIFIC_PASSWORD
   ) {
     console.log('  Notarization enabled');
-    process.env.NOTARIZE = 'true';
   }
 
   // Run electron-builder


### PR DESCRIPTION
## What this PR does

Wires up macOS desktop release code-signing and notarization for the desktop app's first signed release, and switches the notarization auth method to the App Store Connect API key. The release workflow now reads `APPLE_NOTARY_API_KEY_P8_BASE64`, `APPLE_NOTARY_KEY_ID`, and `APPLE_NOTARY_ISSUER_ID`, decodes the `.p8` to a temp file, and exports `APPLE_API_KEY` / `APPLE_API_KEY_ID` / `APPLE_API_ISSUER`, which electron-builder (≥24) consumes to notarize via `notarytool`. It also drops the dead `NOTARIZE` env flag that was set in three places but never read by electron-builder, and corrects the misleading `build-dmg.sh` comment that claimed it enabled notarization.

## Why it's needed

The desktop app is preparing its first publicly distributed macOS build. Without a Developer ID signature and Apple notarization, Gatekeeper blocks the app and the in-app auto-updater refuses to run (it requires a non-ad-hoc Developer ID signature — see `apps/electron/src/main/auto-update-signature.ts`). The App Store Connect API key method is more robust than Apple ID + app-specific password (no 2FA prompts, no password expiry) and is what electron-builder ≥24 natively consumes; it also reuses the notary key already provisioned for the org's Apple Developer account (team `NF4574S59H`).

## Reviewer Test Plan

### How to verify

Run the **Desktop Release** workflow with `dry_run=true` on this branch (builds installers without creating a release). On macOS the build must code-sign with the org's Developer ID Application certificate and notarize via notarytool. The required secrets (`MAC_CSC_LINK`, `MAC_CSC_KEY_PASSWORD`, `APPLE_TEAM_ID`, `APPLE_NOTARY_API_KEY_P8_BASE64`, `APPLE_NOTARY_KEY_ID`, `APPLE_NOTARY_ISSUER_ID`) are configured in the repo.

### Evidence (Before & After)

Dry-run on this branch — run [27393073161](https://github.com/QwenLM/qwen-code/actions/runs/27393073161) — all platforms green. macOS `Build desktop installer` step signed and notarized both arches:

```
• signing  file=release/mac-arm64/Qwen Code Desktop.app  type=distribution  identityName=Developer ID Application: Alibaba Cloud (Singapore) Private Limited (…)  identityHash=C285973BA4A24F8647A4687E7630EA8732C0735B
• notarization successful
• building target=macOS zip arch=arm64 file=release/Qwen-Code-Desktop-arm64.zip
• building target=DMG arch=arm64 file=release/Qwen-Code-Desktop-arm64.dmg
• signing  file=release/mac/Qwen Code Desktop.app  type=distribution  identityName=Developer ID Application: Alibaba Cloud (Singapore) Private Limited (…)
• notarization successful
• building target=macOS zip arch=x64 file=release/Qwen-Code-Desktop-x64.zip
• building target=DMG arch=x64 file=release/Qwen-Code-Desktop-x64.dmg
```

Both arm64 and x64 `.app` bundles were signed with the Developer ID Application identity and notarized (`notarization successful`), then packaged into `.dmg` + `.zip`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   ✅   |

All three built green in the CI dry-run above; macOS additionally verified signed + notarized.

### Environment (optional)

GitHub Actions `macos-latest` / `windows-latest` / `ubuntu-22.04`, `dry_run=true`. Signing/notarization requires CI credentials, so it is verified via the dry-run rather than locally.

## Risk & Scope

- Main risk or tradeoff: changes the macOS notarization auth method; mitigated by the green dry-run proving sign + notarize end-to-end.
- Not validated / out of scope: the local-only build helper `build-dmg.sh` and the orphaned `scripts/build/darwin.ts` keep their existing local Apple ID code paths (neither runs in CI — CI invokes electron-builder directly via `dist:mac:no-publish`); a full publish (`dry_run=false`) is not exercised here.
- Breaking changes / migration notes: published macOS releases now require the `APPLE_NOTARY_*` secrets instead of `APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD`. These are already configured in the repo.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

为桌面应用首个签名版接通 macOS 发布的代码签名与公证,并把公证认证方式切换为 App Store Connect API key。发布 workflow 现在读取 `APPLE_NOTARY_API_KEY_P8_BASE64`、`APPLE_NOTARY_KEY_ID`、`APPLE_NOTARY_ISSUER_ID`,把 `.p8` 解码到临时文件,并导出 `APPLE_API_KEY` / `APPLE_API_KEY_ID` / `APPLE_API_ISSUER`,由 electron-builder(≥24)通过 `notarytool` 完成公证。同时移除了在三处设置却从未被 electron-builder 读取的死 `NOTARIZE` 标志,并修正了 `build-dmg.sh` 中声称它能启用公证的误导性注释。

## 为什么需要

桌面应用正在准备首个对外分发的 macOS 构建。没有 Developer ID 签名和 Apple 公证,Gatekeeper 会拦截该应用,应用内自动更新也会拒绝运行(它要求非 ad-hoc 的 Developer ID 签名,见 `apps/electron/src/main/auto-update-signature.ts`)。App Store Connect API key 方式比 Apple ID + 应用专用密码更稳健(无 2FA 提示、无密码过期),也是 electron-builder ≥24 原生支持的方式;并且复用了组织 Apple 开发者账号(team `NF4574S59H`)已配置的公证 key。

## Reviewer Test Plan

### 如何验证

在本分支以 `dry_run=true` 运行 **Desktop Release** workflow(只构建安装包,不创建 release)。macOS 上构建必须用组织的 Developer ID Application 证书签名并经 notarytool 公证。所需 secrets(`MAC_CSC_LINK`、`MAC_CSC_KEY_PASSWORD`、`APPLE_TEAM_ID`、`APPLE_NOTARY_API_KEY_P8_BASE64`、`APPLE_NOTARY_KEY_ID`、`APPLE_NOTARY_ISSUER_ID`)已在仓库配置。

### 证据(Before & After)

本分支 dry-run —— run [27393073161](https://github.com/QwenLM/qwen-code/actions/runs/27393073161) —— 三平台全绿。macOS `Build desktop installer` 步骤对两个架构均完成签名+公证(日志见上方英文部分):arm64 与 x64 的 `.app` 都用 Developer ID Application 身份签名并 `notarization successful`,随后打包为 `.dmg` + `.zip`。

### Tested on

见上表:macOS / Windows / Linux 在上述 CI dry-run 中均构建成功;macOS 额外验证了签名 + 公证。

### Environment(可选)

GitHub Actions `macos-latest` / `windows-latest` / `ubuntu-22.04`,`dry_run=true`。签名/公证需要 CI 凭证,故通过 dry-run 而非本地验证。

## Risk & Scope

- 主要风险/取舍:更改了 macOS 公证认证方式;已由全绿 dry-run 端到端证明签名+公证可用来缓解。
- 未验证/范围外:本地构建辅助脚本 `build-dmg.sh` 和孤儿脚本 `scripts/build/darwin.ts` 保留各自的本地 Apple ID 代码路径(两者都不在 CI 运行——CI 通过 `dist:mac:no-publish` 直接调用 electron-builder);未执行完整发布(`dry_run=false`)。
- 破坏性变更/迁移说明:已发布的 macOS release 现在需要 `APPLE_NOTARY_*` secrets,而非 `APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD`。这些已在仓库配置。

## Linked Issues

无。

</details>
