### PR TITLE
fix(cli): drop tool calls after cancellation

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -4915,6 +4915,77 @@ describe('useGeminiStream', () => {
       expect(result.current.streamingState).toBe(StreamingState.Idle);
     });
 
+    it('should drop queued tool calls when user cancels the turn', async () => {
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.ToolCallRequest,
+            value: {
+              callId: 'call_cancelled',
+              name: 'write_file',
+              args: { path: 'cancelled.txt' },
+            },
+          };
+          yield { type: ServerGeminiEventType.UserCancelled };
+        })(),
+      );
+
+      const { result } = renderTestHook();
+
+      await act(async () => {
+        await result.current.submitQuery('cancel before tool dispatch');
+      });
+
+      expect(mockScheduleToolCalls).not.toHaveBeenCalled();
+    });
+
+    it('should not dispatch queued tool calls after the request is aborted', async () => {
+      let resolveStream!: () => void;
+      let toolCallQueued!: () => void;
+
+      const streamCanFinish = new Promise<void>((resolve) => {
+        resolveStream = resolve;
+      });
+      const toolCallWasQueued = new Promise<void>((resolve) => {
+        toolCallQueued = resolve;
+      });
+
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.ToolCallRequest,
+            value: {
+              callId: 'call_aborted',
+              name: 'write_file',
+              args: { path: 'aborted.txt' },
+            },
+          };
+          toolCallQueued();
+          await streamCanFinish;
+        })(),
+      );
+
+      const { result } = renderTestHook();
+
+      let submitPromise!: Promise<void>;
+      await act(async () => {
+        submitPromise = result.current.submitQuery(
+          'abort before tool dispatch',
+        );
+      });
+
+      await toolCallWasQueued;
+
+      act(() => {
+        result.current.cancelOngoingRequest();
+      });
+
+      resolveStream();
+      await submitPromise;
+
+      expect(mockScheduleToolCalls).not.toHaveBeenCalled();
+    });
+
     it('should reset thought to null when there is an error', async () => {
       // Mock a stream that yields a thought then encounters an error
       mockSendMessageStream.mockReturnValue(

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1535,6 +1535,7 @@ export const useGeminiStream = (
               break;
             case ServerGeminiEventType.UserCancelled:
               flushBufferedStreamEvents();
+              toolCallRequests.length = 0;
               handleUserCancelledEvent(userMessageTimestamp);
               break;
             case ServerGeminiEventType.Error:
@@ -1663,7 +1664,7 @@ export const useGeminiStream = (
         flushBufferedStreamEventsRef.current.delete(flushBufferedStreamEvents);
       }
       dualOutput?.finalizeAssistantMessage();
-      if (toolCallRequests.length > 0) {
+      if (toolCallRequests.length > 0 && !signal.aborted) {
         scheduleToolCalls(toolCallRequests, signal);
       }
       return StreamProcessingStatus.Completed;


### PR DESCRIPTION
## What this PR does

When an interactive turn is cancelled after the stream has already yielded a tool-call request, the pending tool calls are now discarded before the turn returns to idle. The final scheduling step also skips dispatch if the stream signal has been aborted.

## Why it's needed

This fixes #5016. Previously, a cancellation could stop the visible response while still leaving a collected tool call to be scheduled after the stream finished. That made a cancelled turn capable of running tool work from the interrupted response.

## Reviewer Test Plan

### How to verify

Start an interactive turn that receives a tool call and cancel the turn before the tool dispatches. The cancellation message should be shown, the UI should return to idle, and the tool call from that cancelled response should not run. The added regression test exercises the same ordering by yielding a tool-call request followed by a cancellation event and asserting that no tool scheduling occurs.

### Evidence (Before & After)

Before: a tool-call request collected before cancellation could still be passed to the tool scheduler when stream processing finished. After: cancellation clears queued tool calls, and aborted stream processing does not schedule remaining tool calls.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Windows PowerShell, Node/npm from the repository development environment.

## Risk & Scope

- Main risk or tradeoff: this intentionally drops tool calls that were produced by a response the user cancelled before dispatch.
- Not validated / out of scope: macOS/Linux manual TUI verification; CI should cover the cross-platform test matrix.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5016

<details>
<summary>中文说明</summary>

## What this PR does

交互式回合在 stream 已经产出 tool call request 之后被用户取消时，现在会先丢弃尚未调度的 tool call，再回到 idle。最终调度阶段也会在 stream signal 已经 abort 时跳过 tool dispatch。

## Why it's needed

修复 #5016。之前取消操作可能停止可见回复，但已经收集到的 tool call 仍然会在 stream 结束后被调度，导致一个已经取消的回合继续执行被中断响应里的工具操作。

## Reviewer Test Plan

### How to verify

启动一个会收到 tool call 的交互式回合，并在工具调度前取消。界面应该显示取消信息、回到 idle，并且不执行这个已取消响应里的 tool call。新增回归测试用同样的事件顺序模拟：先 yield tool-call request，再 yield cancellation event，并断言没有发生 tool scheduling。

### Evidence (Before & After)

Before：取消前已经收集到的 tool-call request 仍可能在 stream 处理结束时传给 tool scheduler。After：取消会清空待调度 tool call，并且 abort 后的 stream 处理不会继续调度剩余 tool call。

### Tested on

Windows 本地已验证；macOS / Linux 留给 CI 矩阵覆盖。

### Environment (optional)

Windows PowerShell，使用仓库开发环境中的 Node/npm。

## Risk & Scope

- 主要风险或取舍：这里会主动丢弃用户取消前由同一响应产出的、尚未调度的 tool call。
- 未验证 / 非本次范围：macOS/Linux 手动 TUI 验证；跨平台测试由 CI 覆盖。
- 破坏性变更 / 迁移说明：无。

## Linked Issues

Fixes #5016

</details>
