### PR TITLE
docs(desktop): use main for brand builder skill

### DIFF
--- a/packages/desktop/.agents/skills/desktop-brand-builder/SKILL.md
+++ b/packages/desktop/.agents/skills/desktop-brand-builder/SKILL.md
@@ -65,22 +65,22 @@ Use explicit user-provided override values as-is after basic validation.
 ## Build Workflow
 
 Use an isolated build directory under the current working directory so user
-changes in the current worktree are not mutated. Default to the qwen-code desktop branch; do not clone from
-`craft-agents-oss`, OpenWork, or another local checkout unless the user
-explicitly asks for that source:
+changes in the current worktree are not mutated. Default to the qwen-code main
+branch; do not clone from `craft-agents-oss`, OpenWork, or another local
+checkout unless the user explicitly asks for that source:
 
 ```bash
 BUILD_ROOT="$PWD/brand-builds/<brandId>-<timestamp>"
 mkdir -p "$BUILD_ROOT"
-git clone --branch dragon/feat-unstable-desktop-app --single-branch \
+git clone --branch main --single-branch \
   https://github.com/QwenLM/qwen-code.git \
   "$BUILD_ROOT/qwen-code"
 cd "$BUILD_ROOT/qwen-code"
-git checkout -B dragon/brand-<brandId> origin/dragon/feat-unstable-desktop-app
+git checkout -B brand-<brandId> origin/main
 ```
 
 If the branch fetch or checkout fails, stop and report the failure. Do not
-continue as if `dragon/brand-<brandId>` was created.
+continue as if `brand-<brandId>` was created.
 
 Create a temporary `brand.json` in the build directory:
 


### PR DESCRIPTION
## What this PR does

Updates the desktop brand builder skill to clone qwen-code from `main` and create neutral brand branches from `origin/main`.

## Why it's needed

The desktop package has landed on `main`, so the brand builder no longer needs to reference the old unstable desktop branch. It also removes the maintainer-specific branch prefix from generated brand branch examples so the skill is reusable.

## Reviewer Test Plan

### How to verify

Review the desktop brand builder workflow and confirm it uses `git clone --branch main --single-branch` and `git checkout -B brand-<brandId> origin/main`. Confirm the skill no longer references the old unstable desktop branch or a maintainer-specific brand branch prefix.

### Evidence (Before & After)

Before: the skill cloned `dragon/feat-unstable-desktop-app` and created `dragon/brand-<brandId>`. After: the skill clones `main` and creates `brand-<brandId>` from `origin/main`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

N/A, docs-only change.

## Risk & Scope

- Main risk or tradeoff: Existing users following the old branch-specific instructions will now use `main`, which is intended now that desktop has landed there.
- Not validated / out of scope: A full branded desktop package build was not run because this only updates the reusable skill instructions.
- Breaking changes / migration notes: N/A.

## Linked Issues

N/A.

<details>
<summary>中文说明</summary>

## What this PR does

更新 desktop brand builder skill，让它从 `main` 克隆 qwen-code，并基于 `origin/main` 创建中性的品牌分支。

## Why it's needed

desktop 包已经合入 `main`，所以 brand builder 不再需要引用旧的 unstable desktop 分支。同时移除了生成品牌分支示例里的维护者个人分支前缀，让这个 skill 更适合作为可复用流程。

## Reviewer Test Plan

### How to verify

检查 desktop brand builder 的构建流程，确认它使用 `git clone --branch main --single-branch` 和 `git checkout -B brand-<brandId> origin/main`。确认这个 skill 不再引用旧的 unstable desktop 分支，也不再带维护者个人品牌分支前缀。

### Evidence (Before & After)

Before：skill 克隆 `dragon/feat-unstable-desktop-app`，并创建 `dragon/brand-<brandId>`。After：skill 克隆 `main`，并基于 `origin/main` 创建 `brand-<brandId>`。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

N/A，仅文档变更。

## Risk & Scope

- Main risk or tradeoff：原来照旧分支说明执行的用户现在会改用 `main`；desktop 已经合入 `main`，这是预期行为。
- Not validated / out of scope：没有跑完整品牌桌面包构建，因为这次只更新可复用 skill 指令。
- Breaking changes / migration notes：N/A。

## Linked Issues

N/A。

</details>