### PR TITLE
chore: sync package-lock.json with packages/cli ws dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17313,6 +17313,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -22512,6 +22513,7 @@
         "undici": "^6.22.0",
         "update-notifier": "^7.3.1",
         "wrap-ansi": "^10.0.0",
+        "ws": "^8.18.0",
         "yargs": "^17.7.2",
         "zod": "^3.23.8"
       },
@@ -22533,6 +22535,7 @@
         "@types/semver": "^7.7.0",
         "@types/shell-quote": "^1.7.5",
         "@types/supertest": "^6.0.3",
+        "@types/ws": "^8.5.0",
         "@types/yargs": "^17.0.32",
         "archiver": "^7.0.1",
         "ink-testing-library": "^4.0.0",


### PR DESCRIPTION
## What this PR does

Commits the regenerated lockfile so it matches the CLI package's declared dependencies (`ws` and `@types/ws`), which were added to the manifest without updating the lockfile.

## Why it's needed

On a clean checkout of main, running `npm install` dirties `package-lock.json` — npm adds the two missing entries (plus a `peer` flag on a transitive darwin-only package) on every install. This makes every contributor's working tree dirty after install and risks the noise leaking into unrelated PRs.

## Reviewer Test Plan

### How to verify

On a clean checkout of this branch, run `npm install` and confirm `git status` shows no changes to `package-lock.json`. On main, the same steps produce a 3-line lockfile diff.

### Evidence (Before & After)

N/A — lockfile-only change; the diff is the three entries `npm install` generates (verified on a clean worktree of latest main).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |