### PR TITLE
test(i18n): raise timeout for slow must-translate locale suites on Windows CI

### DIFF
--- a/packages/cli/src/i18n/mustTranslateKeys.test.ts
+++ b/packages/cli/src/i18n/mustTranslateKeys.test.ts
@@ -81,6 +81,12 @@ function flattenCommandDescriptions(
   return flattened;
 }
 
+// Switching locales and loading built-in commands triggers dynamic locale
+// imports plus full command-tree construction, which is slow on cold Windows
+// CI runners — the default 5s per-test budget intermittently times out there.
+// Sibling i18n suites (index.test.ts) already use this same generous timeout.
+const SLOW_LOCALE_TEST_TIMEOUT_MS = 20000;
+
 describe('must-translate locale coverage', () => {
   afterEach(async () => {
     await setLanguageAsync('en');
@@ -110,6 +116,7 @@ describe('must-translate locale coverage', () => {
 
       expect(untranslated).toEqual([]);
     },
+    SLOW_LOCALE_TEST_TIMEOUT_MS,
   );
 
   it.each(NON_ENGLISH_LANGUAGES)(
@@ -156,6 +163,7 @@ describe('must-translate locale coverage', () => {
         "Set up Qwen Code's status line UI",
       );
     },
+    SLOW_LOCALE_TEST_TIMEOUT_MS,
   );
 
   it.each(STRICT_PARITY_NON_ENGLISH_LANGUAGES)(
@@ -182,5 +190,6 @@ describe('must-translate locale coverage', () => {
 
       expect(fallbackDescriptions).toEqual([]);
     },
+    SLOW_LOCALE_TEST_TIMEOUT_MS,
   );
 });


### PR DESCRIPTION
## Summary

- What changed: Raised the per-test budget to `20000ms` for all three locale-iterating must-translate checks in the affected i18n suite. This is test-only; assertions and runtime behavior are unchanged.
- Why it changed: These checks switch languages and, for the command coverage/parity cases, rebuild the built-in command tree. Cold Windows CI runners intermittently exceeded Vitest's default `5000ms` per-test budget, while the same work passed on ubuntu and macOS. A shared timeout matches the convention already used by the sibling i18n suite.
- Reviewer focus: Whether applying the timeout to all three locale loops, and using the existing `20000ms` budget, is the right scope. Passing runs are not delayed; the higher ceiling only matters for slow or hung locale cases.

## Validation

- Commands run:
  ```bash
  cd packages/cli
  npx vitest run src/i18n/mustTranslateKeys.test.ts
  ```
- Prompts / inputs used: N/A.
- Expected result: the affected suite passes; locale cases complete well under the new budget on normal runners, while cold Windows runners no longer fail at the old 5s ceiling.
- Observed result (macOS author run):
  ```text
  ✓ src/i18n/mustTranslateKeys.test.ts (19 tests) 288ms
  Test Files  1 passed (1)
        Tests  19 passed (19)
  ```
- Quickest reviewer verification path: check this PR's Qwen Code CI `Test (windows-latest, Node 22.x)` job. The flaky failure is Windows-specific, so that job is the authoritative validation for the original timeout symptom.
- Evidence from the failure this fixes, from an unrelated PR's CI run [27338565067](https://github.com/QwenLM/qwen-code/actions/runs/27338565067/job/80769797161):
  ```text
  FAIL  src/i18n/mustTranslateKeys.test.ts > ... strict-parity locale { code: 'zh-TW' ... }
  FAIL  src/i18n/mustTranslateKeys.test.ts > ... strict-parity locale { code: 'zh' ... }
  Error: Test timed out in 5000ms.
   ❯ src/i18n/mustTranslateKeys.test.ts:161:46
  ```
  The same run's ubuntu and macOS test jobs passed; only `Test (windows-latest)` failed.

## Scope / Risk

- Main risk or tradeoff: a genuinely hung locale test can now take up to 20s to fail instead of 5s. This is acceptable for this suite because the change only raises the ceiling and does not slow down passing runs.
- Not covered / not validated: the Windows timeout was not reproduced locally; it only appears on cold or slow Windows runners. This PR relies on CI for that platform-specific validation.
- Breaking changes / migration notes: none. Test-only.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | N/A | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- 🍏 ran the affected suite with package-local `npx vitest` and it passed.
- 🪟 / 🐧 were not run locally; use this PR's Qwen Code CI jobs as the source of truth.
- Docker, Podman, and Seatbelt are N/A because this is a test-timeout-only change with no runtime, packaging, or sandbox behavior impact.

## Linked Issues / Bugs

Pre-existing CI flakiness; the affected suite landed earlier with Vitest's default timeout, so this is not a regression from a single PR. No closing keyword.

- Surfaced on CI run [27338565067](https://github.com/QwenLM/qwen-code/actions/runs/27338565067/job/80769797161) as a Windows-only timeout.
