### PR TITLE
perf(desktop): add --cli-only flag to skip non-CLI packages during vendor build

### DIFF
--- a/packages/desktop/scripts/vendor-qwen-code.ts
+++ b/packages/desktop/scripts/vendor-qwen-code.ts
@@ -102,7 +102,7 @@ async function vendorLocalCheckout(repoRoot: string): Promise<void> {
   console.log(`Building Qwen Code CLI from ${repoRoot}...`);
 
   const npm = npmCommand();
-  await run([npm, 'run', 'build'], repoRoot);
+  await run([npm, 'run', 'build', '--', '--cli-only'], repoRoot);
   await run([npm, 'run', 'bundle'], repoRoot);
   await run([npm, 'run', 'prepare:package'], repoRoot);
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -33,6 +33,10 @@ if (!existsSync(join(root, 'node_modules'))) {
 // build all workspaces/packages in dependency order
 execSync('npm run generate', { stdio: 'inherit', cwd: root });
 
+// --cli-only: skip packages not needed by the CLI bundle
+// (webui, sdk, web-shell, vscode-ide-companion are for IDE/web use only)
+const cliOnly = process.argv.includes('--cli-only');
+
 // Build in dependency order:
 // 1. core (foundation package, includes test-utils)
 // 2. web-templates (embeddable web templates - used by cli)
@@ -55,10 +59,14 @@ const buildOrder = [
   'packages/channels/plugin-example',
   'packages/acp-bridge',
   'packages/cli',
-  'packages/webui',
-  'packages/sdk-typescript',
-  'packages/web-shell',
-  'packages/vscode-ide-companion',
+  ...(cliOnly
+    ? []
+    : [
+        'packages/webui',
+        'packages/sdk-typescript',
+        'packages/web-shell',
+        'packages/vscode-ide-companion',
+      ]),
 ];
 
 for (const workspace of buildOrder) {


### PR DESCRIPTION
## Summary

The desktop vendor step (`electron:vendor:qwen`) only needs the CLI bundle, but was building all 14 workspaces including `webui`, `sdk-typescript`, `web-shell`, and `vscode-ide-companion`. These packages are only used by IDE/web scenarios and have no dependency from the desktop app.

This wasted ~30-40% of build time and triggered TypeScript type compatibility errors in `vscode-ide-companion` on newer Node.js versions (e.g. `ReadableStream<Uint8Array>` cast issue on Node 24).

## Changes

- **`scripts/build.js`**: Added `--desktop-only` CLI flag. When present, the build order stops after `packages/cli`, skipping `webui`, `sdk-typescript`, `web-shell`, and `vscode-ide-companion`.
- **`packages/desktop/scripts/vendor-qwen-code.ts`**: Passes `--desktop-only` when building from a local source checkout.

## Impact

| Caller | Path | Affected? |
|--------|------|-----------|
| Local brand build | `electron:dist:mac` → `vendor-qwen-code.ts` | ✅ Auto-benefits |
| CI `desktop-release.yml` (`source_branch`) | `QWEN_CODE_ROOT` → `vendor-qwen-code.ts` | ✅ Auto-benefits |
| CI `desktop-release.yml` (`npm_latest`) | npm tarball, no local build | ❌ No change |
| CI `release.yml`, `e2e.yml` | `npm run build` (full) | ❌ No change |
| Skill `desktop-brand-builder` | `electron:dist:mac` → `vendor-qwen-code.ts` | ✅ Auto-benefits |

## Reviewer Test Plan

**How to verify:**

1. From a local checkout, run `npm run build -- --desktop-only` and confirm it builds only through `packages/cli` (10 workspaces, not 14).
2. Run `npm run build` without the flag and confirm all 14 workspaces still build (full build unchanged).
3. Build a desktop installer with `CRAFT_BRAND=qwen-code bun run electron:dist:mac` from `packages/desktop/` and verify the DMG installs and launches normally.