### PR TITLE
fix(desktop): allow unsigned Windows auto-updates

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -464,12 +464,11 @@ jobs:
               append_env "WIN_CSC_LINK" "$WIN_CSC_LINK_SECRET"
               append_env "WIN_CSC_KEY_PASSWORD" "$WIN_CSC_KEY_PASSWORD_SECRET"
             else
-              if ! allow_unsigned_artifacts; then
-                echo "::error::Published Windows desktop releases require WIN_CSC_LINK and WIN_CSC_KEY_PASSWORD."
-                exit 1
+              if [ "$IS_DRY_RUN" = "true" ]; then
+                echo "Windows signing certificate is not configured; Windows dry-run artifacts will be unsigned."
+              else
+                echo "::warning::Windows signing certificate is not configured; published Windows desktop releases will be unsigned."
               fi
-
-              echo "Windows signing certificate is not configured; Windows dry-run artifacts will be unsigned."
             fi
           else
             if [ "$RUNNER_OS" != "Linux" ] && [ -n "$CSC_LINK_SECRET" ]; then

--- a/packages/desktop/apps/electron/electron-builder.yml
+++ b/packages/desktop/apps/electron/electron-builder.yml
@@ -124,6 +124,9 @@ dmg:
 
 win:
   icon: resources/brands/qwen-code/icon.ico
+  # Windows releases are currently unsigned, so keep this update channel unsigned
+  # from the first release. Re-enable only with a planned signed-channel migration.
+  verifyUpdateCodeSignature: false
   target:
     - target: nsis
       arch:


### PR DESCRIPTION
## What this PR does

Allows Windows desktop releases to remain unsigned while still participating in the desktop auto-update channel. Windows update signature verification is disabled for this channel from the first release, and the release workflow now warns instead of failing when Windows signing credentials are absent.

## Why it's needed

Windows code signing is not currently available, but the desktop app still needs an automatic update path before any Windows version has shipped. Starting the channel as unsigned avoids the signed-to-unsigned migration failure where older signed builds would reject an unsigned update before installation.

## Reviewer Test Plan

### How to verify

Confirm the generated desktop builder configuration keeps Windows update signature verification disabled while still pointing at the Qwen Code GitHub release feed. Confirm a non-dry-run Windows release without Windows signing secrets reaches the build step with a warning instead of failing during signing-secret configuration.

### Evidence (Before & After)

N/A; this is release configuration behavior rather than a TUI change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | N/A |

### Environment (optional)

Validated locally with `git diff --check`, `CRAFT_BRAND=qwen-code bun run electron:builder-config`, YAML parsing for the release workflow, and an assertion that the generated builder config has Windows update signature verification disabled while keeping the Qwen Code publish target.

## Risk & Scope

- Main risk or tradeoff: unsigned Windows installers will trigger weaker platform trust signals such as SmartScreen warnings, and the update chain relies on the release feed and artifact hash rather than publisher code signing.
- Not validated / out of scope: a full Windows installer auto-update run was not performed locally; local `node scripts/lint.js --yamllint .github/workflows/desktop-release.yml` could not run because `yamllint` is not installed in this environment.
- Breaking changes / migration notes: this should be used before the first Windows desktop release; moving from this unsigned channel to a signed channel later should be handled as a planned migration.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

允许 Windows 桌面版在未签名的情况下继续使用桌面自动更新通道。这个 PR 从首个版本开始关闭 Windows 更新签名校验，并让发布 workflow 在没有 Windows 签名凭据时给出 warning 而不是直接失败。

## Why it's needed

目前 Windows 代码签名不可用，但桌面 app 在发布任何 Windows 版本前仍然需要一条自动更新路径。从一开始就使用 unsigned channel，可以避免以后从已签名旧版本更新到未签名新版本时，旧 updater 在安装前拒绝更新的问题。

## Reviewer Test Plan

### How to verify

确认生成的桌面 builder 配置会关闭 Windows 更新签名校验，同时仍然指向 Qwen Code 的 GitHub release feed。确认没有 Windows 签名 secret 的非 dry-run Windows release 会在签名配置阶段输出 warning 并继续进入 build step，而不是直接失败。

### Evidence (Before & After)

N/A；这是发布配置行为，不是 TUI 改动。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | N/A |

### Environment (optional)

本地验证包括 `git diff --check`、`CRAFT_BRAND=qwen-code bun run electron:builder-config`、release workflow 的 YAML 解析，以及断言生成后的 builder config 已关闭 Windows 更新签名校验并保留 Qwen Code publish target。

## Risk & Scope

- Main risk or tradeoff: 未签名 Windows installer 会带来更弱的平台信任信号，例如 SmartScreen 警告；更新链路依赖 release feed 和 artifact hash，而不是发布者代码签名。
- Not validated / out of scope: 本地没有执行完整 Windows installer 自动更新；`node scripts/lint.js --yamllint .github/workflows/desktop-release.yml` 因当前环境没有安装 `yamllint` 无法运行。
- Breaking changes / migration notes: 这个方案应在首个 Windows 桌面版本发布前使用；以后如果要迁移到签名通道，需要单独规划迁移流程。

## Linked Issues

N/A

</details>
