### PR TITLE
feat(daemon): gate direct session shell behind explicit opt-in

### DIFF
--- a/.qwen/design/2026-06-12-session-shell-permission-policy.md
+++ b/.qwen/design/2026-06-12-session-shell-permission-policy.md
@@ -1,0 +1,101 @@
+---
+title: 'Session Shell Permission Policy'
+date: '2026-06-12'
+status: 'implemented'
+---
+
+# Session Shell Permission Policy
+
+## Problem
+
+`POST /session/:id/shell` executes a shell command directly through the daemon,
+without an LLM tool call or the normal agent permission mediation flow. Before
+this change, the endpoint was a non-strict mutation and could be reached with a
+daemon token plus a session id, or on the tokenless loopback developer default.
+
+That is too much authority for a direct shell surface. A caller should not be
+able to execute shell commands unless the daemon operator explicitly enables
+the surface and the caller proves it is attached to the target session.
+
+## Goals
+
+- Disable direct session shell by default.
+- Require explicit operator opt-in with `qwen serve --enable-session-shell`.
+- Require bearer-token configuration before the opt-in becomes effective.
+- Require a client id that is registered on the addressed session.
+- Apply the same policy at the REST route, ACP HTTP dispatcher, and bridge
+  execution sink.
+- Keep normal agent shell tool approvals and permission mediation unchanged.
+
+## Non-Goals
+
+- Do not route direct shell through `PermissionMediator`.
+- Do not change prompt submission, prompt queueing, or SDK pending prompt
+  behavior.
+- Do not add a shell-specific rate limiter.
+- Do not add an environment-variable alias for the opt-in flag.
+
+## Design
+
+`runQwenServe` resolves and trims the bearer token once. After that it computes
+one effective boolean:
+
+```ts
+sessionShellCommandEnabled =
+  opts.enableSessionShell === true && token !== undefined;
+```
+
+That value is threaded into the bridge, REST app, and ACP dispatcher. Embedded
+callers that invoke `createServeApp` directly compute token presence using a
+non-empty string check so `token: ''` behaves like no token for both strict
+mutation gating and shell capability advertisement.
+
+The REST route uses `mutate({ strict: true })`. On a tokenless loopback daemon,
+the strict gate returns `401 token_required` before the handler runs. When a
+token is configured, the handler rejects disabled shell with
+`session_shell_disabled`, then requires `X-Qwen-Client-Id`, then validates the
+command body, and finally delegates to the bridge.
+
+The ACP dispatcher keeps `_qwen/session/shell` dispatchable for old clients, but
+does not advertise it in the initialize `_qwen.methods` list unless the
+effective policy is enabled. Disabled ACP calls return a stable
+`session_shell_disabled` JSON-RPC error without logging the command or calling
+the bridge. Enabled calls still require the connection to own the session and
+must use the bridge-stamped session binding client id.
+
+The bridge enforces the final defense-in-depth check at
+`executeShellCommand()`: disabled, missing client id, unknown session, then
+unbound client id. Only after those checks pass does it publish shell events,
+execute the command, or write shell history.
+
+## Error Contract
+
+REST:
+
+- no token: `401`, `code: token_required`
+- disabled: `403`, `code/errorKind: session_shell_disabled`
+- missing client id: `403`, `code/errorKind: client_id_required`
+- malformed or unbound client id: existing `400 invalid_client_id`
+- unknown session: existing `404 SessionNotFoundError` mapping
+
+ACP:
+
+- disabled: `RPC.INVALID_REQUEST`, `data.errorKind: session_shell_disabled`
+- missing session binding client id: `RPC.INVALID_REQUEST`,
+  `data.errorKind: client_id_required`
+- unowned session and invalid client id keep existing JSON-RPC mappings
+
+## Compatibility
+
+`DaemonSessionClient.shellCommand()` continues to work when the daemon is
+explicitly enabled and authenticated because the session client carries the
+session-bound client id. Bare `DaemonClient.shellCommand(sessionId, command)`
+must pass `opts.clientId`, otherwise it receives `client_id_required`.
+
+## Test Coverage
+
+The implementation is covered by focused bridge, REST, ACP transport, serve
+boot, and command-parser tests. The highest-value checks are default-disabled
+behavior, tokenless strict gating, capability advertisement, ACP initialize
+method filtering, bridge sink enforcement, and propagation of the session-bound
+client id.

--- a/.qwen/e2e-tests/session-shell-permission-policy.md
+++ b/.qwen/e2e-tests/session-shell-permission-policy.md
@@ -1,0 +1,60 @@
+# Session Shell Permission Policy E2E
+
+## Problem
+
+Direct session shell is a user-visible daemon capability. It must stay disabled
+by default and only become visible and callable when the operator enables it on
+an authenticated daemon.
+
+## Scenarios
+
+1. Start `qwen serve` on loopback without `--token` or
+   `QWEN_SERVER_TOKEN`.
+   - `/capabilities.features` must not include `session_shell_command`.
+   - ACP initialize `_meta.qwen.methods` must not include
+     `_qwen/session/shell`.
+   - `POST /session/:id/shell` must return `401 token_required`.
+
+2. Start `qwen serve --token <token>` without `--enable-session-shell`.
+   - `/capabilities.features` must not include `session_shell_command`.
+   - ACP initialize must not advertise `_qwen/session/shell`.
+   - Authenticated REST shell calls must return
+     `session_shell_disabled`.
+
+3. Start `qwen serve --token <token> --enable-session-shell`.
+   - `/capabilities.features` must include `session_shell_command`.
+   - ACP initialize must advertise `_qwen/session/shell`.
+   - REST shell without `X-Qwen-Client-Id` must return
+     `client_id_required`.
+   - REST shell with the session-bound client id must execute and stream
+     shell output through the session events.
+
+## Commands
+
+Focused automated checks:
+
+```bash
+cd packages/acp-bridge && npx vitest run src/bridge.test.ts
+cd packages/cli && npx vitest run src/serve/server.test.ts src/serve/acpHttp/transport.test.ts src/commands/serve.test.ts
+```
+
+Final verification:
+
+```bash
+npm run build
+npm run typecheck
+```
+
+## What This Proves
+
+- The default daemon does not expose direct session shell.
+- Operator opt-in without bearer auth is ineffective.
+- Authenticated opt-in advertises the capability consistently across REST and
+  ACP.
+- Calls still need a client id bound to the target session.
+
+## What This Does Not Prove
+
+- It does not validate prompt queue backpressure.
+- It does not validate normal agent-originated shell tool approval behavior.
+- It does not add or validate shell-specific rate limiting.

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -31,6 +31,8 @@ import {
   InvalidSessionScopeError,
   NOT_CURRENTLY_GENERATING_CANCEL_MESSAGE,
   RestoreInProgressError,
+  SessionShellClientRequiredError,
+  SessionShellDisabledError,
   SessionNotFoundError,
   WorkspaceMismatchError,
 } from './bridgeErrors.js';
@@ -40,7 +42,7 @@ import type { ChannelFactory } from './channel.js';
 import type { BridgeTelemetry } from './bridgeOptions.js';
 import { createInMemoryChannel } from './inMemoryChannel.js';
 import type { BridgeEvent } from './eventBus.js';
-import { ApprovalMode } from '@qwen-code/qwen-code-core';
+import { ApprovalMode, ShellExecutionService } from '@qwen-code/qwen-code-core';
 import {
   FakeAgent,
   type ChannelHandle,
@@ -4764,6 +4766,117 @@ describe('createAcpSessionBridge', () => {
           modelId: 'qwen3-coder',
         }),
       ).rejects.toBeInstanceOf(SessionNotFoundError);
+    });
+  });
+
+  describe('executeShellCommand permission policy', () => {
+    function mockShellExecute(output = 'ok') {
+      return vi.spyOn(ShellExecutionService, 'execute').mockResolvedValue({
+        pid: 123,
+        result: Promise.resolve({
+          rawOutput: Buffer.from(output),
+          output,
+          exitCode: 0,
+          signal: null,
+          error: null,
+          aborted: false,
+          pid: 123,
+          executionMethod: 'none',
+        }),
+      });
+    }
+
+    async function setupShellSession() {
+      const handle = makeChannel();
+      const bridge = makeBridge({
+        sessionShellCommandEnabled: true,
+        channelFactory: async () => handle.channel,
+      });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      return { bridge, session, handle };
+    }
+
+    it('rejects direct shell by default before executing the command', async () => {
+      const shellSpy = mockShellExecute();
+      const { bridge, session } = await setupShellSession();
+      const disabledBridge = makeBridge({
+        channelFactory: async () => {
+          throw new Error('disabled shell should not spawn a channel');
+        },
+      });
+
+      await expect(
+        disabledBridge.executeShellCommand(session.sessionId, 'echo hi'),
+      ).rejects.toBeInstanceOf(SessionShellDisabledError);
+      expect(shellSpy).not.toHaveBeenCalled();
+
+      await bridge.shutdown();
+      await disabledBridge.shutdown();
+      shellSpy.mockRestore();
+    });
+
+    it('requires a client id before checking whether the session exists', async () => {
+      const shellSpy = mockShellExecute();
+      const bridge = makeBridge({
+        sessionShellCommandEnabled: true,
+        channelFactory: async () => {
+          throw new Error('missing client id should not spawn a channel');
+        },
+      });
+
+      await expect(
+        bridge.executeShellCommand('unknown-session', 'echo hi'),
+      ).rejects.toBeInstanceOf(SessionShellClientRequiredError);
+      expect(shellSpy).not.toHaveBeenCalled();
+
+      await bridge.shutdown();
+      shellSpy.mockRestore();
+    });
+
+    it('rejects unregistered client ids when direct shell is enabled', async () => {
+      const shellSpy = mockShellExecute();
+      const { bridge, session } = await setupShellSession();
+
+      await expect(
+        bridge.executeShellCommand(session.sessionId, 'echo hi', undefined, {
+          clientId: 'client-not-issued',
+        }),
+      ).rejects.toBeInstanceOf(InvalidClientIdError);
+      expect(shellSpy).not.toHaveBeenCalled();
+
+      await bridge.shutdown();
+      shellSpy.mockRestore();
+    });
+
+    it('executes and stamps events when the client id belongs to the session', async () => {
+      const shellSpy = mockShellExecute('hello\n');
+      const { bridge, session } = await setupShellSession();
+      const abort = new AbortController();
+      const events = bridge.subscribeEvents(session.sessionId, {
+        signal: abort.signal,
+      });
+
+      const result = await bridge.executeShellCommand(
+        session.sessionId,
+        'echo hello',
+        undefined,
+        { clientId: session.clientId },
+      );
+
+      expect(result).toEqual({
+        exitCode: 0,
+        output: 'hello\n',
+        aborted: false,
+      });
+      expect(shellSpy).toHaveBeenCalledTimes(1);
+      const it = events[Symbol.asyncIterator]();
+      const first = await it.next();
+      expect(first.value?.type).toBe('user_shell_command');
+      expect(first.value?.originatorClientId).toBe(session.clientId);
+
+      abort.abort();
+      await bridge.shutdown();
+      shellSpy.mockRestore();
     });
   });
 

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -53,6 +53,8 @@ import {
   SessionLimitExceededError,
   WorkspaceMismatchError,
   InvalidClientIdError,
+  SessionShellClientRequiredError,
+  SessionShellDisabledError,
   // Mediator's `vote()` validates `optionId in allowedOptionIds`,
   // but the bridge ALSO throws `InvalidPermissionOptionError`
   // pre-mediator when a wire client tries to inject the cancel
@@ -4005,11 +4007,17 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         `qwen serve: bridge executeShellCommand for session=${sessionId}`,
         'info',
       );
+      if (opts.sessionShellCommandEnabled !== true) {
+        throw new SessionShellDisabledError();
+      }
+      if (context?.clientId === undefined) {
+        throw new SessionShellClientRequiredError();
+      }
       const entry = byId.get(sessionId);
       if (!entry) throw new SessionNotFoundError(sessionId);
       const originatorClientId = resolveTrustedClientId(
         entry,
-        context?.clientId,
+        context.clientId,
       );
 
       if (signal?.aborted) {

--- a/packages/acp-bridge/src/bridgeErrors.ts
+++ b/packages/acp-bridge/src/bridgeErrors.ts
@@ -173,6 +173,29 @@ export class InvalidClientIdError extends Error {
 }
 
 /**
+ * Thrown when a direct daemon shell command is attempted without the operator
+ * explicitly enabling the high-risk session shell surface.
+ */
+export class SessionShellDisabledError extends Error {
+  constructor() {
+    super('Direct session shell is disabled for this daemon');
+    this.name = 'SessionShellDisabledError';
+  }
+}
+
+/**
+ * Thrown when a direct daemon shell command has no client id bound to the
+ * addressed session. The bearer token authenticates the caller to the daemon;
+ * this error means the caller has not proven ownership of the session.
+ */
+export class SessionShellClientRequiredError extends Error {
+  constructor() {
+    super('Direct session shell requires a session-bound client id');
+    this.name = 'SessionShellClientRequiredError';
+  }
+}
+
+/**
  * Thrown by `bridge.respondToPermission` when the voter's
  * `optionId` isn't in the set of options the agent originally
  * offered. Server route catches this and returns 400 (distinct from
@@ -449,9 +472,7 @@ export class InvalidRewindTargetError extends Error {
 export class BranchWhilePromptActiveError extends Error {
   readonly sessionId: string;
   constructor(sessionId: string) {
-    super(
-      `Cannot branch session ${sessionId}: a prompt is currently active`,
-    );
+    super(`Cannot branch session ${sessionId}: a prompt is currently active`);
     this.name = 'BranchWhilePromptActiveError';
     this.sessionId = sessionId;
   }

--- a/packages/acp-bridge/src/bridgeOptions.ts
+++ b/packages/acp-bridge/src/bridgeOptions.ts
@@ -173,6 +173,12 @@ export interface BridgeOptions {
    */
   permissionResponseTimeoutMs?: number;
   /**
+   * Enables direct daemon shell execution through session shell APIs.
+   * Defaults to false. Callers should turn this on only after the daemon has
+   * bearer auth configured and route layers require a session-bound client id.
+   */
+  sessionShellCommandEnabled?: boolean;
+  /**
    * Per-session cap on pending permissions in flight. New
    * `requestPermission` calls past this cap resolve as cancelled with
    * a stderr warning. Defaults to 64. `0` / `Infinity` disable the

--- a/packages/acp-bridge/src/bridgeTypes.ts
+++ b/packages/acp-bridge/src/bridgeTypes.ts
@@ -482,7 +482,10 @@ export interface AcpSessionBridge {
    * Execute a shell command directly on the daemon (no LLM involvement).
    * Streams output through the session's SSE bus and injects the
    * command+result into the LLM's chat history via extMethod.
-   * Throws `SessionNotFoundError` for unknown ids.
+   * Throws `SessionShellDisabledError` when direct shell is not enabled,
+   * `SessionShellClientRequiredError` when no session-bound client id is
+   * provided, `InvalidClientIdError` when the client id is not bound to the
+   * session, and `SessionNotFoundError` for unknown ids.
    */
   executeShellCommand(
     sessionId: string,

--- a/packages/cli/src/commands/serve.test.ts
+++ b/packages/cli/src/commands/serve.test.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import yargs, { type Argv } from 'yargs';
+import { serveCommand } from './serve.js';
+
+function buildParser(): Argv {
+  return (serveCommand.builder as (argv: Argv) => Argv)(
+    yargs([]).exitProcess(false).fail(false).locale('en'),
+  );
+}
+
+describe('serve command args', () => {
+  it('parses --enable-session-shell', () => {
+    const parsed = buildParser().parseSync('--enable-session-shell');
+    expect(parsed['enable-session-shell']).toBe(true);
+  });
+
+  it('defaults direct session shell to disabled', () => {
+    const parsed = buildParser().parseSync('');
+    expect(parsed['enable-session-shell']).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -39,6 +39,7 @@ interface ServeArgs {
   'event-ring-size': number;
   workspace?: string;
   'require-auth': boolean;
+  'enable-session-shell': boolean;
   // Read from the kebab-case key only — the camelCase mirror that yargs
   // synthesizes is convenient for handlers but type-confusing here. The
   // handler reads `argv['http-bridge']` directly.
@@ -116,6 +117,12 @@ export const serveCommand: CommandModule<unknown, ServeArgs> = {
           '127.0.0.1. Requires --token or QWEN_SERVER_TOKEN. /health also ' +
           'requires Authorization when enabled (no loopback exemption — ' +
           'k8s/Compose probes must pass the bearer too).',
+      })
+      .option('enable-session-shell', {
+        type: 'boolean',
+        default: false,
+        description:
+          'Enable direct POST /session/:id/shell execution. Requires a bearer token and a session-bound client id on each call.',
       })
       .option('event-ring-size', {
         type: 'number',
@@ -387,6 +394,7 @@ export const serveCommand: CommandModule<unknown, ServeArgs> = {
         eventRingSize: argv['event-ring-size'],
         workspace: argv.workspace,
         requireAuth: argv['require-auth'],
+        enableSessionShell: argv['enable-session-shell'],
         allowPrivateAuthBaseUrl: argv['allow-private-auth-base-url'],
         mcpClientBudget,
         mcpBudgetMode: resolvedMcpMode,

--- a/packages/cli/src/serve/acpHttp/dispatch.ts
+++ b/packages/cli/src/serve/acpHttp/dispatch.ts
@@ -25,6 +25,10 @@ import {
 } from '../auth/deviceFlow.js';
 import type { HttpAcpBridge } from '@qwen-code/acp-bridge/bridgeTypes';
 import type { BridgeEvent } from '@qwen-code/acp-bridge/eventBus';
+import {
+  SessionShellClientRequiredError,
+  SessionShellDisabledError,
+} from '@qwen-code/acp-bridge/bridgeErrors';
 import { writeStderrLine } from '../../utils/stdioHelpers.js';
 import { MAX_WORKSPACE_PATH_LENGTH } from '../fs/paths.js';
 import type { WorkspaceFileSystemFactory } from '../fs/index.js';
@@ -67,7 +71,9 @@ function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-const QWEN_VENDOR_METHODS: readonly string[] = [
+const SESSION_SHELL_METHOD = `${QWEN_METHOD_NS}session/shell`;
+
+const ALL_QWEN_VENDOR_METHODS: readonly string[] = [
   `${QWEN_METHOD_NS}session/heartbeat`,
   `${QWEN_METHOD_NS}session/context`,
   `${QWEN_METHOD_NS}session/supported_commands`,
@@ -83,7 +89,7 @@ const QWEN_VENDOR_METHODS: readonly string[] = [
   // Wave 1: session extensions
   `${QWEN_METHOD_NS}session/recap`,
   `${QWEN_METHOD_NS}session/btw`,
-  `${QWEN_METHOD_NS}session/shell`,
+  SESSION_SHELL_METHOD,
   `${QWEN_METHOD_NS}session/detach`,
   `${QWEN_METHOD_NS}session/context_usage`,
   `${QWEN_METHOD_NS}session/tasks`,
@@ -117,6 +123,14 @@ const QWEN_VENDOR_METHODS: readonly string[] = [
   `${QWEN_METHOD_NS}workspace/agents/delete`,
 ];
 
+function advertisedQwenVendorMethods(
+  sessionShellCommandEnabled: boolean,
+): string[] {
+  return ALL_QWEN_VENDOR_METHODS.filter(
+    (method) => sessionShellCommandEnabled || method !== SESSION_SHELL_METHOD,
+  );
+}
+
 /**
  * Method names whose responses ride the CONNECTION-scoped stream (the
  * session stream may not exist yet / ownership not granted on failure).
@@ -129,7 +143,7 @@ const CONN_ROUTED_METHODS = new Set<string>([
   'session/resume',
   'session/list',
   'session/close',
-  ...QWEN_VENDOR_METHODS,
+  ...ALL_QWEN_VENDOR_METHODS,
 ]);
 
 // SYNC: server.ts MAX_TOOL_NAME_LENGTH / MAX_SERVER_NAME_LENGTH (both 256).
@@ -252,6 +266,18 @@ function toRpcError(err: unknown): {
   }
   const name = err instanceof Error ? err.name : '';
   switch (name) {
+    case 'SessionShellDisabledError':
+      return {
+        code: RPC.INVALID_REQUEST,
+        message: errMsg(err),
+        data: { errorKind: 'session_shell_disabled' },
+      };
+    case 'SessionShellClientRequiredError':
+      return {
+        code: RPC.INVALID_REQUEST,
+        message: errMsg(err),
+        data: { errorKind: 'client_id_required' },
+      };
     case 'SessionNotFoundError':
     case 'InvalidSessionScopeError':
     case 'WorkspaceMismatchError':
@@ -288,6 +314,7 @@ export class AcpDispatcher {
     private readonly workspace: DaemonWorkspaceService,
     private readonly fsFactory?: WorkspaceFileSystemFactory,
     private readonly deviceFlowRegistry?: DeviceFlowRegistry,
+    private readonly sessionShellCommandEnabled: boolean = false,
   ) {
     this.agentManager = createDaemonSubagentManager(boundWorkspace);
   }
@@ -434,7 +461,9 @@ export class AcpDispatcher {
           [QWEN_META_KEY]: {
             connectionId,
             workspaceCwd: this.boundWorkspace,
-            methods: [...QWEN_VENDOR_METHODS],
+            methods: advertisedQwenVendorMethods(
+              this.sessionShellCommandEnabled,
+            ),
           },
         },
       },
@@ -1067,7 +1096,14 @@ export class AcpDispatcher {
 
         case `${QWEN_METHOD_NS}session/shell`: {
           const sessionId = String(params['sessionId'] ?? '');
+          if (!this.sessionShellCommandEnabled) {
+            throw new SessionShellDisabledError();
+          }
           if (!this.requireOwned(conn, sessionId, id)) return;
+          const clientId = conn.sessions.get(sessionId)?.clientId;
+          if (!clientId) {
+            throw new SessionShellClientRequiredError();
+          }
           const rawCmd = params['command'];
           if (typeof rawCmd !== 'string' || rawCmd.trim().length === 0) {
             if (id !== undefined)
@@ -1091,7 +1127,7 @@ export class AcpDispatcher {
             sessionId,
             rawCmd,
             undefined,
-            this.sessionCtx(conn, sessionId, loopback),
+            { clientId, fromLoopback: loopback },
           );
           this.replyConn(conn, id, result as unknown);
           return;

--- a/packages/cli/src/serve/acpHttp/dispatch.ts
+++ b/packages/cli/src/serve/acpHttp/dispatch.ts
@@ -264,20 +264,22 @@ function toRpcError(err: unknown): {
       data: { errorKind: 'upstream_error' },
     };
   }
+  if (err instanceof SessionShellDisabledError) {
+    return {
+      code: RPC.INVALID_PARAMS,
+      message: errMsg(err),
+      data: { errorKind: 'session_shell_disabled' },
+    };
+  }
+  if (err instanceof SessionShellClientRequiredError) {
+    return {
+      code: RPC.INVALID_PARAMS,
+      message: errMsg(err),
+      data: { errorKind: 'client_id_required' },
+    };
+  }
   const name = err instanceof Error ? err.name : '';
   switch (name) {
-    case 'SessionShellDisabledError':
-      return {
-        code: RPC.INVALID_PARAMS,
-        message: errMsg(err),
-        data: { errorKind: 'session_shell_disabled' },
-      };
-    case 'SessionShellClientRequiredError':
-      return {
-        code: RPC.INVALID_PARAMS,
-        message: errMsg(err),
-        data: { errorKind: 'client_id_required' },
-      };
     case 'SessionNotFoundError':
     case 'InvalidSessionScopeError':
     case 'WorkspaceMismatchError':
@@ -292,6 +294,11 @@ function toRpcError(err: unknown): {
         data: { errorKind: 'internal' },
       };
   }
+}
+
+function rpcErrorFrame(id: JsonRpcId, err: unknown) {
+  const { code, message, data } = toRpcError(err);
+  return error(id, code, message, data);
 }
 
 /**
@@ -1097,13 +1104,21 @@ export class AcpDispatcher {
         case `${QWEN_METHOD_NS}session/shell`: {
           const sessionId = String(params['sessionId'] ?? '');
           if (!this.sessionShellCommandEnabled) {
-            throw new SessionShellDisabledError();
+            if (id !== undefined) {
+              conn.sendConn(rpcErrorFrame(id, new SessionShellDisabledError()));
+            }
+            return;
           }
           if (!this.requireOwned(conn, sessionId, id)) return;
           const binding = conn.sessions.get(sessionId);
           const clientId = binding?.clientId;
           if (!clientId) {
-            throw new SessionShellClientRequiredError();
+            if (id !== undefined) {
+              conn.sendConn(
+                rpcErrorFrame(id, new SessionShellClientRequiredError()),
+              );
+            }
+            return;
           }
           const rawCmd = params['command'];
           if (typeof rawCmd !== 'string' || rawCmd.trim().length === 0) {
@@ -1128,7 +1143,7 @@ export class AcpDispatcher {
             sessionId,
             rawCmd,
             binding.abort.signal,
-            { clientId, fromLoopback: loopback },
+            this.sessionCtx(conn, sessionId, loopback),
           );
           this.replyConn(conn, id, result as unknown);
           return;

--- a/packages/cli/src/serve/acpHttp/dispatch.ts
+++ b/packages/cli/src/serve/acpHttp/dispatch.ts
@@ -268,13 +268,13 @@ function toRpcError(err: unknown): {
   switch (name) {
     case 'SessionShellDisabledError':
       return {
-        code: RPC.INVALID_REQUEST,
+        code: RPC.INVALID_PARAMS,
         message: errMsg(err),
         data: { errorKind: 'session_shell_disabled' },
       };
     case 'SessionShellClientRequiredError':
       return {
-        code: RPC.INVALID_REQUEST,
+        code: RPC.INVALID_PARAMS,
         message: errMsg(err),
         data: { errorKind: 'client_id_required' },
       };
@@ -1100,7 +1100,8 @@ export class AcpDispatcher {
             throw new SessionShellDisabledError();
           }
           if (!this.requireOwned(conn, sessionId, id)) return;
-          const clientId = conn.sessions.get(sessionId)?.clientId;
+          const binding = conn.sessions.get(sessionId);
+          const clientId = binding?.clientId;
           if (!clientId) {
             throw new SessionShellClientRequiredError();
           }
@@ -1126,7 +1127,7 @@ export class AcpDispatcher {
           const result = await this.bridge.executeShellCommand(
             sessionId,
             rawCmd,
-            undefined,
+            binding.abort.signal,
             { clientId, fromLoopback: loopback },
           );
           this.replyConn(conn, id, result as unknown);

--- a/packages/cli/src/serve/acpHttp/index.ts
+++ b/packages/cli/src/serve/acpHttp/index.ts
@@ -75,6 +75,8 @@ export interface MountAcpHttpOptions {
   maxConnections?: number;
   /** Bearer token for WS auth (WS bypasses Express middleware). */
   token?: string;
+  /** Effective direct session shell policy for ACP initialize/dispatch. */
+  sessionShellCommandEnabled?: boolean;
   /** Rate limit checker for WS messages (WS bypasses Express middleware). */
   checkRate?: (key: string, tier: RateLimitTier) => boolean;
 }
@@ -113,6 +115,7 @@ export function mountAcpHttp(
     opts.workspace,
     opts.fsFactory,
     opts.deviceFlowRegistry,
+    opts.sessionShellCommandEnabled === true,
   );
   // When a session/connection tears down with a permission still pending,
   // cancel it on the bridge so the agent's prompt isn't left blocked.

--- a/packages/cli/src/serve/acpHttp/transport.test.ts
+++ b/packages/cli/src/serve/acpHttp/transport.test.ts
@@ -1788,6 +1788,11 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
           line.includes('/acp session/shell session='),
         ),
       ).toBe(false);
+      expect(
+        stdioMocks.writeStderrLine.mock.calls.some(([line]) =>
+          line.includes('/acp dispatch error'),
+        ),
+      ).toBe(false);
     });
 
     it('_qwen/session/shell rejects unowned session when enabled', async () => {
@@ -1983,6 +1988,36 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
       });
       const frames = await takeFrames(await streamRes, 2);
       expect(frames[1]).toMatchObject({ error: { code: -32602 } });
+    });
+
+    it('_qwen/session/shell does not map arbitrary error names as shell policy errors', async () => {
+      await restartServer({ sessionShellCommandEnabled: true });
+      bridge.shellError = Object.assign(new Error('fake policy'), {
+        name: 'SessionShellDisabledError',
+      });
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 99,
+        method: 'session/new',
+        params: {},
+      });
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 61,
+        method: '_qwen/session/shell',
+        params: { sessionId: 'sess-1', command: 'pwd' },
+      });
+      const frames = await takeFrames(await streamRes, 2);
+      expect(frames[1]).toMatchObject({
+        error: {
+          code: -32603,
+          data: { errorKind: 'internal' },
+        },
+      });
     });
 
     it('_qwen/session/detach succeeds', async () => {

--- a/packages/cli/src/serve/acpHttp/transport.test.ts
+++ b/packages/cli/src/serve/acpHttp/transport.test.ts
@@ -11,6 +11,11 @@ import type { AddressInfo } from 'node:net';
 import WebSocket from 'ws';
 import type { HttpAcpBridge } from '@qwen-code/acp-bridge/bridgeTypes';
 import type { BridgeEvent } from '@qwen-code/acp-bridge/eventBus';
+import {
+  InvalidClientIdError,
+  SessionShellClientRequiredError,
+  SessionShellDisabledError,
+} from '@qwen-code/acp-bridge/bridgeErrors';
 import type { DaemonWorkspaceService } from '../workspace-service/types.js';
 import { mountAcpHttp } from './index.js';
 
@@ -91,6 +96,7 @@ class FakeBridge {
   gate: Promise<void> | undefined;
   /** `attached` value loadSession returns (false = spawned-from-disk). */
   loadAttached = true;
+  spawnClientId: string | undefined = 'client-1';
 
   closedSessions: string[] = [];
 
@@ -101,7 +107,7 @@ class FakeBridge {
       sessionId: 'sess-1',
       workspaceCwd: '/ws',
       attached: false,
-      clientId: 'client-1',
+      clientId: this.spawnClientId,
     };
   }
   async killSession(sessionId: string) {
@@ -221,7 +227,24 @@ class FakeBridge {
   async generateSessionBtw(sessionId: string, question: string) {
     return { sessionId, answer: `re: ${question}` };
   }
-  async executeShellCommand(sessionId: string, command: string) {
+  shellCalls: Array<{
+    sessionId: string;
+    command: string;
+    context?: unknown;
+  }> = [];
+  shellError: unknown;
+  async executeShellCommand(
+    sessionId: string,
+    command: string,
+    _signal?: AbortSignal,
+    context?: unknown,
+  ) {
+    this.shellCalls.push({
+      sessionId,
+      command,
+      ...(context !== undefined ? { context } : {}),
+    });
+    if (this.shellError !== undefined) throw this.shellError;
     return { exitCode: 0, output: `$ ${command}`, aborted: false };
   }
   async getSessionContextUsageStatus(sessionId: string) {
@@ -410,7 +433,32 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
     await new Promise<void>((r) => server.close(() => r()));
   });
 
-  async function initialize(): Promise<string> {
+  async function restartServer(opts: {
+    sessionShellCommandEnabled?: boolean;
+    nextBridge?: FakeBridge;
+  }): Promise<void> {
+    server.closeAllConnections?.();
+    await new Promise<void>((r) => server.close(() => r()));
+    bridge = opts.nextBridge ?? new FakeBridge();
+    const app = express();
+    app.use(express.json());
+    mountAcpHttp(app, bridge as unknown as HttpAcpBridge, {
+      boundWorkspace: '/ws',
+      workspace: fakeWorkspace,
+      enabled: true,
+      sessionShellCommandEnabled: opts.sessionShellCommandEnabled,
+    });
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, '127.0.0.1', () => resolve());
+    });
+    const addr = server.address() as AddressInfo;
+    base = `http://127.0.0.1:${addr.port}`;
+  }
+
+  async function initializeRaw(): Promise<{
+    connId: string;
+    body: Record<string, unknown>;
+  }> {
     const res = await fetch(`${base}/acp`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -419,9 +467,15 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
     expect(res.status).toBe(200);
     const connId = res.headers.get('acp-connection-id');
     expect(connId).toBeTruthy();
-    const body = (await res.json()) as { result: { protocolVersion: number } };
-    expect(body.result.protocolVersion).toBe(1);
-    return connId!;
+    const body = (await res.json()) as Record<string, unknown>;
+    return { connId: connId!, body };
+  }
+
+  async function initialize(): Promise<string> {
+    const { connId, body } = await initializeRaw();
+    const result = body['result'] as { protocolVersion: number };
+    expect(result.protocolVersion).toBe(1);
+    return connId;
   }
 
   function post(connId: string, msg: unknown) {
@@ -464,6 +518,31 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
       method: 'session/new',
     });
     expect(bad.status).toBe(404);
+  });
+
+  it('initialize omits _qwen/session/shell by default', async () => {
+    const { body } = await initializeRaw();
+    const result = body['result'] as {
+      agentCapabilities: {
+        _meta: { qwen: { methods: string[] } };
+      };
+    };
+    expect(result.agentCapabilities._meta.qwen.methods).not.toContain(
+      '_qwen/session/shell',
+    );
+  });
+
+  it('initialize advertises _qwen/session/shell when enabled', async () => {
+    await restartServer({ sessionShellCommandEnabled: true });
+    const { body } = await initializeRaw();
+    const result = body['result'] as {
+      agentCapabilities: {
+        _meta: { qwen: { methods: string[] } };
+      };
+    };
+    expect(result.agentCapabilities._meta.qwen.methods).toContain(
+      '_qwen/session/shell',
+    );
   });
 
   it('session/new reply rides the connection-scoped stream', async () => {
@@ -1684,7 +1763,59 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
       });
     });
 
-    it('_qwen/session/shell rejects empty command', async () => {
+    it('_qwen/session/shell returns stable disabled error by default', async () => {
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 53,
+        method: '_qwen/session/shell',
+        params: { sessionId: 'sess-1', command: '' },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({
+        error: {
+          code: -32600,
+          data: { errorKind: 'session_shell_disabled' },
+        },
+      });
+      expect(bridge.shellCalls).toHaveLength(0);
+      expect(
+        stdioMocks.writeStderrLine.mock.calls.some(([line]) =>
+          line.includes('/acp session/shell session='),
+        ),
+      ).toBe(false);
+    });
+
+    it('_qwen/session/shell rejects unowned session when enabled', async () => {
+      await restartServer({ sessionShellCommandEnabled: true });
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 54,
+        method: '_qwen/session/shell',
+        params: { sessionId: 'sess-1', command: 'pwd' },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({ error: { code: -32602 } });
+      expect(bridge.shellCalls).toHaveLength(0);
+      expect(
+        stdioMocks.writeStderrLine.mock.calls.some(([line]) =>
+          line.includes('/acp session/shell session='),
+        ),
+      ).toBe(false);
+    });
+
+    it('_qwen/session/shell requires an owned bridge-stamped clientId when enabled', async () => {
+      const nextBridge = new FakeBridge();
+      nextBridge.spawnClientId = undefined;
+      await restartServer({
+        sessionShellCommandEnabled: true,
+        nextBridge,
+      });
       const connId = await initialize();
       const streamRes = openStream(connId);
       await new Promise((r) => setTimeout(r, 30));
@@ -1697,15 +1828,45 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
       await new Promise((r) => setTimeout(r, 30));
       await post(connId, {
         jsonrpc: '2.0',
-        id: 53,
+        id: 55,
+        method: '_qwen/session/shell',
+        params: { sessionId: 'sess-1', command: 'pwd' },
+      });
+      const frames = await takeFrames(await streamRes, 2);
+      expect(frames[1]).toMatchObject({
+        error: {
+          code: -32600,
+          data: { errorKind: 'client_id_required' },
+        },
+      });
+      expect(bridge.shellCalls).toHaveLength(0);
+    });
+
+    it('_qwen/session/shell rejects empty command when enabled', async () => {
+      await restartServer({ sessionShellCommandEnabled: true });
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 99,
+        method: 'session/new',
+        params: {},
+      });
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 56,
         method: '_qwen/session/shell',
         params: { sessionId: 'sess-1', command: '' },
       });
       const frames = await takeFrames(await streamRes, 2);
       expect(frames[1]).toMatchObject({ error: { code: -32602 } });
+      expect(bridge.shellCalls).toHaveLength(0);
     });
 
     it('_qwen/session/shell returns result', async () => {
+      await restartServer({ sessionShellCommandEnabled: true });
       const connId = await initialize();
       const streamRes = openStream(connId);
       const command = 'ls\nFAKE\r\x1b[31m';
@@ -1719,7 +1880,7 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
       await new Promise((r) => setTimeout(r, 30));
       await post(connId, {
         jsonrpc: '2.0',
-        id: 54,
+        id: 57,
         method: '_qwen/session/shell',
         params: { sessionId: 'sess-1', command },
       });
@@ -1734,6 +1895,90 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
       expect(shellLog).not.toContain('\n');
       expect(shellLog).not.toContain('\r');
       expect(shellLog).not.toContain('\x1b');
+      expect(bridge.shellCalls).toEqual([
+        {
+          sessionId: 'sess-1',
+          command,
+          context: { clientId: 'client-1', fromLoopback: true },
+        },
+      ]);
+    });
+
+    it('_qwen/session/shell maps bridge shell policy errors to RPC errorKind', async () => {
+      await restartServer({ sessionShellCommandEnabled: true });
+      bridge.shellError = new SessionShellDisabledError();
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 99,
+        method: 'session/new',
+        params: {},
+      });
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 58,
+        method: '_qwen/session/shell',
+        params: { sessionId: 'sess-1', command: 'pwd' },
+      });
+      const disabledFrames = await takeFrames(await streamRes, 2);
+      expect(disabledFrames[1]).toMatchObject({
+        error: {
+          code: -32600,
+          data: { errorKind: 'session_shell_disabled' },
+        },
+      });
+
+      await restartServer({ sessionShellCommandEnabled: true });
+      bridge.shellError = new SessionShellClientRequiredError();
+      const connId2 = await initialize();
+      const streamRes2 = openStream(connId2);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId2, {
+        jsonrpc: '2.0',
+        id: 99,
+        method: 'session/new',
+        params: {},
+      });
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId2, {
+        jsonrpc: '2.0',
+        id: 59,
+        method: '_qwen/session/shell',
+        params: { sessionId: 'sess-1', command: 'pwd' },
+      });
+      const clientRequiredFrames = await takeFrames(await streamRes2, 2);
+      expect(clientRequiredFrames[1]).toMatchObject({
+        error: {
+          code: -32600,
+          data: { errorKind: 'client_id_required' },
+        },
+      });
+    });
+
+    it('_qwen/session/shell preserves InvalidClientIdError invalid params mapping', async () => {
+      await restartServer({ sessionShellCommandEnabled: true });
+      bridge.shellError = new InvalidClientIdError('sess-1', 'client-2');
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 99,
+        method: 'session/new',
+        params: {},
+      });
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 60,
+        method: '_qwen/session/shell',
+        params: { sessionId: 'sess-1', command: 'pwd' },
+      });
+      const frames = await takeFrames(await streamRes, 2);
+      expect(frames[1]).toMatchObject({ error: { code: -32602 } });
     });
 
     it('_qwen/session/detach succeeds', async () => {

--- a/packages/cli/src/serve/acpHttp/transport.test.ts
+++ b/packages/cli/src/serve/acpHttp/transport.test.ts
@@ -230,18 +230,20 @@ class FakeBridge {
   shellCalls: Array<{
     sessionId: string;
     command: string;
+    signal?: AbortSignal;
     context?: unknown;
   }> = [];
   shellError: unknown;
   async executeShellCommand(
     sessionId: string,
     command: string,
-    _signal?: AbortSignal,
+    signal?: AbortSignal,
     context?: unknown,
   ) {
     this.shellCalls.push({
       sessionId,
       command,
+      ...(signal !== undefined ? { signal } : {}),
       ...(context !== undefined ? { context } : {}),
     });
     if (this.shellError !== undefined) throw this.shellError;
@@ -1776,7 +1778,7 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
       const frames = await takeFrames(await streamRes, 1);
       expect(frames[0]).toMatchObject({
         error: {
-          code: -32600,
+          code: -32602,
           data: { errorKind: 'session_shell_disabled' },
         },
       });
@@ -1835,7 +1837,7 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
       const frames = await takeFrames(await streamRes, 2);
       expect(frames[1]).toMatchObject({
         error: {
-          code: -32600,
+          code: -32602,
           data: { errorKind: 'client_id_required' },
         },
       });
@@ -1899,9 +1901,11 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
         {
           sessionId: 'sess-1',
           command,
+          signal: expect.any(AbortSignal),
           context: { clientId: 'client-1', fromLoopback: true },
         },
       ]);
+      expect(bridge.shellCalls[0]?.signal?.aborted).toBe(false);
     });
 
     it('_qwen/session/shell maps bridge shell policy errors to RPC errorKind', async () => {
@@ -1926,7 +1930,7 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
       const disabledFrames = await takeFrames(await streamRes, 2);
       expect(disabledFrames[1]).toMatchObject({
         error: {
-          code: -32600,
+          code: -32602,
           data: { errorKind: 'session_shell_disabled' },
         },
       });
@@ -1952,7 +1956,7 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
       const clientRequiredFrames = await takeFrames(await streamRes2, 2);
       expect(clientRequiredFrames[1]).toMatchObject({
         error: {
-          code: -32600,
+          code: -32602,
           data: { errorKind: 'client_id_required' },
         },
       });

--- a/packages/cli/src/serve/acpSessionBridge.ts
+++ b/packages/cli/src/serve/acpSessionBridge.ts
@@ -99,6 +99,8 @@ export {
   CancelSentinelCollisionError,
   PermissionForbiddenError,
   PermissionPolicyNotImplementedError,
+  SessionShellClientRequiredError,
+  SessionShellDisabledError,
 } from '@qwen-code/acp-bridge/bridgeErrors';
 
 export {

--- a/packages/cli/src/serve/capabilities.ts
+++ b/packages/cli/src/serve/capabilities.ts
@@ -160,6 +160,11 @@ export const SERVE_CAPABILITY_REGISTRY = {
   // Side question (/btw) against the session's conversation context.
   // Single-turn, tool-free LLM call via runForkedAgent (cache path).
   session_btw: { since: 'v1' },
+  // Direct daemon-side shell execution for an existing session.
+  // Advertised CONDITIONALLY: operators must explicitly enable it and
+  // configure bearer auth. Clients must still send a session-bound
+  // X-Qwen-Client-Id when calling the route.
+  session_shell_command: { since: 'v1' },
   // Daemon hosts a workspace-shared MCP transport
   // pool (`QwenAgent.mcpPool`); `GET /workspace/mcp` reflects pool-level
   // accounting (`entryCount`, `entrySummary` on each per-server cell).
@@ -240,6 +245,7 @@ export interface AdvertiseFeatureToggles {
   promptDeadlineMs?: number;
   writerIdleTimeoutMs?: number;
   persistSettingAvailable?: boolean;
+  sessionShellCommandEnabled?: boolean;
   rateLimit?: boolean;
   reloadAvailable?: boolean;
 }
@@ -297,6 +303,10 @@ export const CONDITIONAL_SERVE_FEATURES: ReadonlyMap<
       toggles.writerIdleTimeoutMs > 0,
   ],
   ['workspace_settings', (toggles) => toggles.persistSettingAvailable === true],
+  [
+    'session_shell_command',
+    (toggles) => toggles.sessionShellCommandEnabled === true,
+  ],
   ['rate_limit', (toggles) => toggles.rateLimit === true],
   ['workspace_reload', (toggles) => toggles.reloadAvailable === true],
 ]);

--- a/packages/cli/src/serve/index.ts
+++ b/packages/cli/src/serve/index.ts
@@ -120,6 +120,8 @@ export {
   McpServerNotFoundError,
   McpServerRestartFailedError,
   SessionNotFoundError,
+  SessionShellClientRequiredError,
+  SessionShellDisabledError,
   WorkspaceInitConflictError,
   WorkspaceInitPathEscapeError,
   WorkspaceInitSymlinkError,

--- a/packages/cli/src/serve/runQwenServe.ts
+++ b/packages/cli/src/serve/runQwenServe.ts
@@ -440,6 +440,8 @@ export async function runQwenServe(
     typeof rawToken === 'string' && rawToken.trim().length > 0
       ? rawToken.trim()
       : undefined;
+  const sessionShellCommandEnabled =
+    optsIn.enableSessionShell === true && token !== undefined;
   // Env-var fallback for the deadline options. Explicit option
   // beats the env beats unset (= unlimited). `parseDeadlineEnv` throws
   // on malformed values so an `export QWEN_SERVE_PROMPT_DEADLINE_MS=abc`
@@ -852,6 +854,7 @@ export async function runQwenServe(
         ? { sessionIdleTimeoutMs: opts.sessionIdleTimeoutMs }
         : {}),
       boundWorkspace,
+      sessionShellCommandEnabled,
       childEnvOverrides,
       channelFactory,
       onDiagnosticLine: diagnosticSink,

--- a/packages/cli/src/serve/runQwenServe.ts
+++ b/packages/cli/src/serve/runQwenServe.ts
@@ -442,6 +442,13 @@ export async function runQwenServe(
       : undefined;
   const sessionShellCommandEnabled =
     optsIn.enableSessionShell === true && token !== undefined;
+  if (optsIn.enableSessionShell === true && token === undefined) {
+    writeStderrLine(
+      `qwen serve: --enable-session-shell ignored because no bearer token ` +
+        `is configured. Set ${QWEN_SERVER_TOKEN_ENV} or pass --token to ` +
+        `enable direct session shell.`,
+    );
+  }
   // Env-var fallback for the deadline options. Explicit option
   // beats the env beats unset (= unlimited). `parseDeadlineEnv` throws
   // on malformed values so an `export QWEN_SERVE_PROMPT_DEADLINE_MS=abc`

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -6254,13 +6254,26 @@ describe('runQwenServe', () => {
     );
   });
 
-  it('does not advertise session shell when flag is set but no token is configured', async () => {
-    handle = await runQwenServe({
-      hostname: '127.0.0.1',
-      port: 0,
-      mode: 'http-bridge',
-      enableSessionShell: true,
-    });
+  it('warns and does not advertise session shell when flag is set without a token', async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation((() => true) as typeof process.stderr.write);
+    try {
+      handle = await runQwenServe({
+        hostname: '127.0.0.1',
+        port: 0,
+        mode: 'http-bridge',
+        enableSessionShell: true,
+      });
+      expect(
+        stderrSpy.mock.calls.some(([chunk]) =>
+          String(chunk).includes('--enable-session-shell ignored'),
+        ),
+      ).toBe(true);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+
     const port = (handle.server.address() as { port: number }).port;
     const capsRes = await fetch(`http://127.0.0.1:${port}/capabilities`);
     expect(capsRes.status).toBe(200);

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -52,6 +52,8 @@ import {
   PermissionForbiddenError,
   PermissionPolicyNotImplementedError,
   RestoreInProgressError,
+  SessionShellClientRequiredError,
+  SessionShellDisabledError,
   SessionLimitExceededError,
   SessionNotFoundError,
   WorkspaceMismatchError,
@@ -209,6 +211,7 @@ const EXPECTED_REGISTERED_FEATURES = [
       f !== 'workspace_mcp_restart' &&
       f !== 'session_recap' &&
       f !== 'session_btw' &&
+      f !== 'session_shell_command' &&
       f !== 'auth_device_flow' &&
       f !== 'permission_mediation' &&
       f !== 'non_blocking_prompt' &&
@@ -226,6 +229,7 @@ const EXPECTED_REGISTERED_FEATURES = [
   'workspace_mcp_restart',
   'session_recap',
   'session_btw',
+  'session_shell_command',
   'mcp_workspace_pool',
   'mcp_pool_restart',
   'require_auth',
@@ -411,6 +415,12 @@ interface FakeBridgeOpts {
     context?: BridgeClientRequestContext,
   ) => BridgeHeartbeatResult;
   heartbeatStateImpl?: (sessionId: string) => BridgeHeartbeatState | undefined;
+  shellImpl?: (
+    sessionId: string,
+    command: string,
+    signal?: AbortSignal,
+    context?: BridgeClientRequestContext,
+  ) => Promise<{ exitCode: number | null; output: string; aborted: boolean }>;
 }
 
 interface FakeBridge extends AcpSessionBridge {
@@ -479,6 +489,12 @@ interface FakeBridge extends AcpSessionBridge {
     sessionId: string;
     mode: ApprovalMode;
     opts: { persist: boolean };
+    context?: BridgeClientRequestContext;
+  }>;
+  shellCalls: Array<{
+    sessionId: string;
+    command: string;
+    signal?: AbortSignal;
     context?: BridgeClientRequestContext;
   }>;
   generateSessionRecapCalls: Array<{
@@ -750,6 +766,7 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
       refreshed: params.syncOutputLanguage,
     }));
   const setApprovalModeCalls: FakeBridge['setApprovalModeCalls'] = [];
+  const shellCalls: FakeBridge['shellCalls'] = [];
   const setApprovalModeImpl =
     opts.setApprovalModeImpl ??
     (async (
@@ -837,6 +854,13 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
       sessionLastSeenAt: 1_700_000_000_000,
       clientLastSeenAt: new Map<string, number>(),
     }));
+  const shellImpl =
+    opts.shellImpl ??
+    (async (_sessionId: string, command: string) => ({
+      exitCode: 0,
+      output: `$ ${command}`,
+      aborted: false,
+    }));
   return {
     // F3 Commit 6 — `AcpSessionBridge.permissionPolicy` is required so
     // `/capabilities` can expose `policy.permission`. Tests don't
@@ -864,6 +888,7 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
     setModelCalls,
     setLanguageCalls,
     setApprovalModeCalls,
+    shellCalls,
     generateSessionRecapCalls,
     setToolEnabledCalls,
     initWorkspaceCalls,
@@ -1070,6 +1095,15 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
     },
     async generateSessionBtw(sessionId, _question, _signal, _context) {
       return { sessionId, answer: 'mock btw answer' };
+    },
+    async executeShellCommand(sessionId, command, signal, context) {
+      shellCalls.push({
+        sessionId,
+        command,
+        ...(signal ? { signal } : {}),
+        ...(context ? { context } : {}),
+      });
+      return shellImpl(sessionId, command, signal, context);
     },
     async setWorkspaceToolEnabled(
       toolName: string,
@@ -1416,6 +1450,20 @@ describe('createServeApp', () => {
           );
           continue;
         }
+        if (feature === 'session_shell_command') {
+          expect(predicate({ sessionShellCommandEnabled: true })).toBe(true);
+          expect(predicate({ sessionShellCommandEnabled: false })).toBe(false);
+          expect(predicate({})).toBe(false);
+          expect(
+            getAdvertisedServeFeatures(undefined, {
+              sessionShellCommandEnabled: true,
+            }),
+          ).toContain(feature);
+          expect(getAdvertisedServeFeatures(undefined, {})).not.toContain(
+            feature,
+          );
+          continue;
+        }
         if (feature === 'workspace_reload') {
           expect(predicate({ reloadAvailable: true })).toBe(true);
           expect(predicate({ reloadAvailable: false })).toBe(false);
@@ -1601,6 +1649,54 @@ describe('createServeApp', () => {
         .set('Authorization', 'Bearer secret');
       expect(res.status).toBe(200);
       expect(res.body.features).toContain('require_auth');
+    });
+
+    it('omits `session_shell_command` by default', async () => {
+      const app = createServeApp(baseOpts);
+      const res = await request(app)
+        .get('/capabilities')
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+      expect(res.status).toBe(200);
+      expect(res.body.features).not.toContain('session_shell_command');
+    });
+
+    it('omits `session_shell_command` when enabled without a token', async () => {
+      const app = createServeApp({
+        ...baseOpts,
+        enableSessionShell: true,
+      });
+      const res = await request(app)
+        .get('/capabilities')
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+      expect(res.status).toBe(200);
+      expect(res.body.features).not.toContain('session_shell_command');
+    });
+
+    it('advertises `session_shell_command` only when enabled with a token', async () => {
+      const app = createServeApp({
+        ...baseOpts,
+        token: 'secret',
+        enableSessionShell: true,
+      });
+      const res = await request(app)
+        .get('/capabilities')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .set('Authorization', 'Bearer secret');
+      expect(res.status).toBe(200);
+      expect(res.body.features).toContain('session_shell_command');
+    });
+
+    it('treats an empty token string as no token for session shell capability', async () => {
+      const app = createServeApp({
+        ...baseOpts,
+        token: '',
+        enableSessionShell: true,
+      });
+      const res = await request(app)
+        .get('/capabilities')
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+      expect(res.status).toBe(200);
+      expect(res.body.features).not.toContain('session_shell_command');
     });
   });
 
@@ -3477,9 +3573,7 @@ describe('createServeApp', () => {
         { bridge, boundWorkspace: WS_BOUND },
       );
       const res = await request(app)
-        .get(
-          `/workspace/${encodeURIComponent(WS_BOUND)}/sessions?size=0`,
-        )
+        .get(`/workspace/${encodeURIComponent(WS_BOUND)}/sessions?size=0`)
         .set('Host', `127.0.0.1:${baseOpts.port}`);
       expect(res.status).toBe(200);
       expect(res.body.sessions).toHaveLength(1);
@@ -3493,9 +3587,7 @@ describe('createServeApp', () => {
         { bridge, boundWorkspace: WS_BOUND },
       );
       const res = await request(app)
-        .get(
-          `/workspace/${encodeURIComponent(WS_BOUND)}/sessions?size=200`,
-        )
+        .get(`/workspace/${encodeURIComponent(WS_BOUND)}/sessions?size=200`)
         .set('Host', `127.0.0.1:${baseOpts.port}`);
       expect(res.status).toBe(200);
     });
@@ -3701,6 +3793,179 @@ describe('createServeApp', () => {
         .set('Host', `127.0.0.1:${baseOpts.port}`)
         .send();
       expect(res.status).toBe(200);
+    });
+  });
+
+  describe('POST /session/:id/shell', () => {
+    const tokenOpts: ServeOptions = {
+      ...baseOpts,
+      token: 'secret',
+      enableSessionShell: true,
+    };
+    const auth = (req: request.Test): request.Test =>
+      req
+        .set('Host', `127.0.0.1:${tokenOpts.port}`)
+        .set('Authorization', 'Bearer secret');
+
+    it('401 token_required on a no-token daemon before bridge dispatch', async () => {
+      const bridge = fakeBridge();
+      const app = createServeApp(
+        { ...baseOpts, enableSessionShell: true },
+        undefined,
+        { bridge },
+      );
+      const res = await request(app)
+        .post('/session/session-A/shell')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .send({ command: 'pwd' });
+      expect(res.status).toBe(401);
+      expect(res.body.code).toBe('token_required');
+      expect(bridge.shellCalls).toHaveLength(0);
+    });
+
+    it('403 session_shell_disabled when token auth is present but flag is off', async () => {
+      const bridge = fakeBridge();
+      const app = createServeApp({ ...baseOpts, token: 'secret' }, undefined, {
+        bridge,
+      });
+      const res = await request(app)
+        .post('/session/session-A/shell')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .set('Authorization', 'Bearer secret')
+        .send({ command: 'pwd' });
+      expect(res.status).toBe(403);
+      expect(res.body).toMatchObject({
+        code: 'session_shell_disabled',
+        errorKind: 'session_shell_disabled',
+      });
+      expect(bridge.shellCalls).toHaveLength(0);
+    });
+
+    it('403 client_id_required before command validation when enabled without X-Qwen-Client-Id', async () => {
+      const bridge = fakeBridge();
+      const app = createServeApp(tokenOpts, undefined, { bridge });
+      const res = await auth(
+        request(app).post('/session/session-A/shell'),
+      ).send({ command: '' });
+      expect(res.status).toBe(403);
+      expect(res.body).toMatchObject({
+        code: 'client_id_required',
+        errorKind: 'client_id_required',
+      });
+      expect(bridge.shellCalls).toHaveLength(0);
+    });
+
+    it('400 invalid_client_id for malformed X-Qwen-Client-Id before bridge dispatch', async () => {
+      const bridge = fakeBridge();
+      const app = createServeApp(tokenOpts, undefined, { bridge });
+      const res = await auth(request(app).post('/session/session-A/shell'))
+        .set('X-Qwen-Client-Id', 'bad client id')
+        .send({ command: 'pwd' });
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('invalid_client_id');
+      expect(bridge.shellCalls).toHaveLength(0);
+    });
+
+    it('400 for empty command after a valid client id is present', async () => {
+      const bridge = fakeBridge();
+      const app = createServeApp(tokenOpts, undefined, { bridge });
+      const res = await auth(request(app).post('/session/session-A/shell'))
+        .set('X-Qwen-Client-Id', 'client-1')
+        .send({ command: '   ' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('`command` is required');
+      expect(bridge.shellCalls).toHaveLength(0);
+    });
+
+    it('calls the bridge with a session-bound client context on success', async () => {
+      const bridge = fakeBridge();
+      const app = createServeApp(tokenOpts, undefined, { bridge });
+      const res = await auth(request(app).post('/session/session-A/shell'))
+        .set('X-Qwen-Client-Id', 'client-1')
+        .send({ command: 'pwd' });
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        exitCode: 0,
+        output: '$ pwd',
+        aborted: false,
+      });
+      expect(bridge.shellCalls).toEqual([
+        {
+          sessionId: 'session-A',
+          command: 'pwd',
+          signal: expect.any(AbortSignal),
+          context: { clientId: 'client-1' },
+        },
+      ]);
+    });
+
+    it('maps bridge InvalidClientIdError to the existing invalid_client_id response', async () => {
+      const bridge = fakeBridge({
+        shellImpl: async () => {
+          throw new InvalidClientIdError('session-A', 'client-2');
+        },
+      });
+      const app = createServeApp(tokenOpts, undefined, { bridge });
+      const res = await auth(request(app).post('/session/session-A/shell'))
+        .set('X-Qwen-Client-Id', 'client-2')
+        .send({ command: 'pwd' });
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        code: 'invalid_client_id',
+        sessionId: 'session-A',
+        clientId: 'client-2',
+      });
+    });
+
+    it('treats an empty token string as no token on the strict shell route', async () => {
+      const bridge = fakeBridge();
+      const app = createServeApp(
+        { ...baseOpts, token: '', enableSessionShell: true },
+        undefined,
+        { bridge },
+      );
+      const res = await request(app)
+        .post('/session/session-A/shell')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .set('X-Qwen-Client-Id', 'client-1')
+        .send({ command: 'pwd' });
+      expect(res.status).toBe(401);
+      expect(res.body.code).toBe('token_required');
+      expect(bridge.shellCalls).toHaveLength(0);
+    });
+
+    it('maps bridge shell policy errors to stable REST error kinds', async () => {
+      const disabledBridge = fakeBridge({
+        shellImpl: async () => {
+          throw new SessionShellDisabledError();
+        },
+      });
+      const disabledApp = createServeApp(tokenOpts, undefined, {
+        bridge: disabledBridge,
+      });
+      const disabled = await auth(
+        request(disabledApp).post('/session/session-A/shell'),
+      )
+        .set('X-Qwen-Client-Id', 'client-1')
+        .send({ command: 'pwd' });
+      expect(disabled.status).toBe(403);
+      expect(disabled.body.errorKind).toBe('session_shell_disabled');
+
+      const clientRequiredBridge = fakeBridge({
+        shellImpl: async () => {
+          throw new SessionShellClientRequiredError();
+        },
+      });
+      const clientRequiredApp = createServeApp(tokenOpts, undefined, {
+        bridge: clientRequiredBridge,
+      });
+      const clientRequired = await auth(
+        request(clientRequiredApp).post('/session/session-A/shell'),
+      )
+        .set('X-Qwen-Client-Id', 'client-1')
+        .send({ command: 'pwd' });
+      expect(clientRequired.status).toBe(403);
+      expect(clientRequired.body.errorKind).toBe('client_id_required');
     });
   });
 
@@ -5950,6 +6215,74 @@ describe('runQwenServe', () => {
     );
     expect(res.headers.get('access-control-expose-headers')).toBe(
       'Retry-After',
+    );
+  });
+
+  it('uses normalized token for session shell capability across REST and ACP initialize', async () => {
+    handle = await runQwenServe({
+      hostname: '127.0.0.1',
+      port: 0,
+      mode: 'http-bridge',
+      token: '  secret  ',
+      enableSessionShell: true,
+    });
+    const port = (handle.server.address() as { port: number }).port;
+    const capsRes = await fetch(`http://127.0.0.1:${port}/capabilities`, {
+      headers: { Authorization: 'Bearer secret' },
+    });
+    expect(capsRes.status).toBe(200);
+    const caps = (await capsRes.json()) as { features: string[] };
+    expect(caps.features).toContain('session_shell_command');
+
+    const initRes = await fetch(`http://127.0.0.1:${port}/acp`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        Authorization: 'Bearer secret',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+      }),
+    });
+    expect(initRes.status).toBe(200);
+    const init = (await initRes.json()) as {
+      result: { agentCapabilities: { _meta: { qwen: { methods: string[] } } } };
+    };
+    expect(init.result.agentCapabilities._meta.qwen.methods).toContain(
+      '_qwen/session/shell',
+    );
+  });
+
+  it('does not advertise session shell when flag is set but no token is configured', async () => {
+    handle = await runQwenServe({
+      hostname: '127.0.0.1',
+      port: 0,
+      mode: 'http-bridge',
+      enableSessionShell: true,
+    });
+    const port = (handle.server.address() as { port: number }).port;
+    const capsRes = await fetch(`http://127.0.0.1:${port}/capabilities`);
+    expect(capsRes.status).toBe(200);
+    const caps = (await capsRes.json()) as { features: string[] };
+    expect(caps.features).not.toContain('session_shell_command');
+
+    const initRes = await fetch(`http://127.0.0.1:${port}/acp`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+      }),
+    });
+    expect(initRes.status).toBe(200);
+    const init = (await initRes.json()) as {
+      result: { agentCapabilities: { _meta: { qwen: { methods: string[] } } } };
+    };
+    expect(init.result.agentCapabilities._meta.qwen.methods).not.toContain(
+      '_qwen/session/shell',
     );
   });
 

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -211,7 +211,6 @@ const EXPECTED_REGISTERED_FEATURES = [
       f !== 'workspace_mcp_restart' &&
       f !== 'session_recap' &&
       f !== 'session_btw' &&
-      f !== 'session_shell_command' &&
       f !== 'auth_device_flow' &&
       f !== 'permission_mediation' &&
       f !== 'non_blocking_prompt' &&

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -73,6 +73,8 @@ import {
   InvalidRewindTargetError,
   SessionLimitExceededError,
   SessionNotFoundError,
+  SessionShellClientRequiredError,
+  SessionShellDisabledError,
   WorkspaceInitConflictError,
   WorkspaceInitPathEscapeError,
   WorkspaceInitSymlinkError,
@@ -276,9 +278,7 @@ export async function listWorkspaceSessionsForResponse(
   });
 
   const nextCursor =
-    persisted.nextCursor != null
-      ? String(persisted.nextCursor)
-      : undefined;
+    persisted.nextCursor != null ? String(persisted.nextCursor) : undefined;
 
   return { sessions, nextCursor };
 }
@@ -943,12 +943,17 @@ export function createServeApp(
     injected: deps.fsFactory,
     trusted: false,
   });
+  const tokenConfigured =
+    typeof opts.token === 'string' && opts.token.length > 0;
+  const sessionShellCommandEnabled =
+    opts.enableSessionShell === true && tokenConfigured;
   const bridge =
     deps.bridge ??
     createAcpSessionBridge({
       maxSessions: opts.maxSessions,
       eventRingSize: opts.eventRingSize,
       boundWorkspace,
+      sessionShellCommandEnabled,
       // Wire the production status provider so direct embeds / tests
       // that don't inject `deps.bridge` get daemon env + preflight cells.
       statusProvider: createDaemonStatusProvider(),
@@ -1327,7 +1332,7 @@ export function createServeApp(
   // Mutation-route gate factory. Non-strict mode is passthrough;
   // `{ strict: true }` requires a token even on loopback defaults.
   const mutate = createMutationGate({
-    tokenConfigured: opts.token !== undefined,
+    tokenConfigured,
     requireAuth: opts.requireAuth === true,
   });
 
@@ -1367,6 +1372,7 @@ export function createServeApp(
           ? { writerIdleTimeoutMs: opts.writerIdleTimeoutMs }
           : {}),
         persistSettingAvailable: deps.persistSetting !== undefined,
+        sessionShellCommandEnabled,
         rateLimit: opts.rateLimit === true,
         reloadAvailable: deps.workspace !== undefined,
       }),
@@ -2626,8 +2632,26 @@ export function createServeApp(
     }
   });
 
-  app.post('/session/:id/shell', mutate(), async (req, res) => {
+  app.post('/session/:id/shell', mutate({ strict: true }), async (req, res) => {
     const sessionId = req.params['id'];
+    if (!sessionShellCommandEnabled) {
+      sendBridgeError(res, new SessionShellDisabledError(), {
+        route: 'POST /session/:id/shell',
+        sessionId,
+      });
+      return;
+    }
+    const clientId = parseClientIdHeader(req, res);
+    if (clientId === null) {
+      return;
+    }
+    if (clientId === undefined) {
+      sendBridgeError(res, new SessionShellClientRequiredError(), {
+        route: 'POST /session/:id/shell',
+        sessionId,
+      });
+      return;
+    }
     const body = safeBody(req);
     const command = body['command'];
     if (typeof command !== 'string' || command.trim().length === 0) {
@@ -2641,17 +2665,12 @@ export function createServeApp(
       if (!res.writableEnded) abort.abort();
     };
     res.once('close', onResClose);
-    const clientId = parseClientIdHeader(req, res);
-    if (clientId === null) {
-      res.off('close', onResClose);
-      return;
-    }
     try {
       const result = await bridge.executeShellCommand(
         sessionId,
         command.trim(),
         abort.signal,
-        clientId !== undefined ? { clientId } : undefined,
+        { clientId },
       );
       if (daemonLog) {
         daemonLog.info('shell command completed', {
@@ -3595,6 +3614,7 @@ export function createServeApp(
     fsFactory,
     deviceFlowRegistry,
     token: opts.token,
+    sessionShellCommandEnabled,
     checkRate: rateLimiter?.checkRate,
   });
   if (acpHandle) {
@@ -4330,6 +4350,22 @@ function sendBridgeErrorImpl(
       code: 'invalid_client_id',
       sessionId: err.sessionId,
       clientId: err.clientId,
+    });
+    return;
+  }
+  if (err instanceof SessionShellDisabledError) {
+    res.status(403).json({
+      error: err.message,
+      code: 'session_shell_disabled',
+      errorKind: 'session_shell_disabled',
+    });
+    return;
+  }
+  if (err instanceof SessionShellClientRequiredError) {
+    res.status(403).json({
+      error: err.message,
+      code: 'client_id_required',
+      errorKind: 'client_id_required',
     });
     return;
   }

--- a/packages/cli/src/serve/types.ts
+++ b/packages/cli/src/serve/types.ts
@@ -113,6 +113,11 @@ export interface ServeOptions {
    */
   requireAuth?: boolean;
   /**
+   * Opt in to direct session shell execution. The effective policy also
+   * requires a configured bearer token and a session-bound client id.
+   */
+  enableSessionShell?: boolean;
+  /**
    * Cap on live MCP clients spawned inside the
    * ACP child for the bound workspace. When set, the daemon
    * forwards `QWEN_SERVE_MCP_CLIENT_BUDGET` to the child's env so

--- a/packages/sdk-typescript/src/daemon/DaemonClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonClient.ts
@@ -1373,6 +1373,13 @@ export class DaemonClient {
     return (await res.json()) as DaemonSessionBtwResult;
   }
 
+  /**
+   * Execute a direct daemon-side shell command for a session. The daemon must
+   * be started with direct session shell enabled and bearer auth configured;
+   * callers must also provide a client id already bound to this session.
+   * Prefer `DaemonSessionClient.shellCommand()` when available because it
+   * forwards the session-bound client id automatically.
+   */
   async shellCommand(
     sessionId: string,
     command: string,

--- a/packages/sdk-typescript/src/daemon/DaemonSessionClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonSessionClient.ts
@@ -329,6 +329,12 @@ export class DaemonSessionClient {
     });
   }
 
+  /**
+   * Execute a direct daemon-side shell command for this session. Requires the
+   * daemon to opt in to direct session shell and bearer auth; this wrapper
+   * automatically forwards the client id bound when the session was created
+   * or attached.
+   */
   async shellCommand(
     command: string,
     signal?: AbortSignal,


### PR DESCRIPTION
## What this PR does

This PR turns direct session shell execution into an explicit daemon opt-in. `qwen serve --enable-session-shell` is now required, and the effective policy is only enabled when a bearer token is configured. REST, ACP `_qwen/session/shell`, and the bridge execution sink all enforce the same policy.

It also requires direct shell callers to provide a client id already bound to the target session. ACP calls use the bridge-stamped client id from the owned session binding, and SDK docs now call out the opt-in, bearer auth, and session-bound client id requirements.

For direct `createServeApp()` embedders, `token: ''` is treated as tokenless rather than configured. Strict mutation routes return `token_required`, and the session shell capability stays hidden until a non-empty token is supplied.

Passing `--enable-session-shell` without a token now emits a boot warning and leaves direct session shell disabled.

## Why it's needed

`POST /session/:id/shell` bypasses the normal agent tool approval flow and executes directly through the daemon. Leaving that surface reachable by default, or reachable with only a daemon token plus a session id, gives too much authority to a high-risk endpoint. This PR makes the capability disabled by default and adds a session ownership proof before any command can execute.

## Reviewer Test Plan

### How to verify

Start a default loopback daemon without a bearer token and confirm `/capabilities.features` does not include `session_shell_command`, ACP initialize does not advertise `_qwen/session/shell`, and REST shell returns `401 token_required`.

Start an authenticated daemon without `--enable-session-shell` and confirm authenticated direct shell calls return `session_shell_disabled` without reaching the bridge.

Start an authenticated daemon with `--enable-session-shell` and confirm shell calls without `X-Qwen-Client-Id` return `client_id_required`, while calls with a client id bound to the session reach the bridge and execute normally.

For direct embedders, call `createServeApp({ token: '' })` and confirm it behaves as tokenless: strict shell mutation returns `token_required`, and `session_shell_command` is not advertised.

### Evidence (Before & After)

N/A for UI. Local automated verification covered the REST, ACP, bridge, CLI argument, build, and typecheck paths.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Local Node/npm workspace in the repository worktree.

## Risk & Scope

- Main risk or tradeoff: this is a behavior change for direct daemon shell clients; callers must explicitly enable the daemon capability and provide a session-bound client id.
- Not validated / out of scope: no shell-specific rate limiter, no PermissionMediator synthetic approval flow, no changes to normal agent shell tool approvals or prompt queue behavior.
- Breaking changes / migration notes: bare `DaemonClient.shellCommand(sessionId, command)` calls must pass `opts.clientId` when the daemon has direct session shell enabled; `DaemonSessionClient.shellCommand()` continues to forward the session-bound client id automatically. Direct embedders that pass an empty string token should pass a non-empty bearer token or omit `token`; an empty string is not treated as a configured token.

## Linked Issues

References #4490.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 把 direct session shell 执行改成 daemon 显式 opt-in 能力。现在必须传 `qwen serve --enable-session-shell`，并且只有配置了 bearer token 时 effective policy 才会开启。REST、ACP `_qwen/session/shell` 和 bridge 执行入口都会执行同一套策略。

它还要求 direct shell 调用方提供已经绑定到目标 session 的 client id。ACP 调用会使用 owned session binding 里由 bridge stamp 的 client id，SDK 注释也补充了 opt-in、bearer auth 和 session-bound client id 的要求。

对直接使用 `createServeApp()` 的 embedder，`token: ''` 会被视为没有配置 token。strict mutation route 会返回 `token_required`，并且只有提供非空 token 后才会暴露 `session_shell_command` capability。

传了 `--enable-session-shell` 但没有配置 token 时，现在启动阶段会打印 warning，并保持 direct session shell disabled。

## Why it's needed

`POST /session/:id/shell` 会绕过普通 agent tool approval flow，直接通过 daemon 执行命令。默认可达，或者只凭 daemon token 加 session id 可达，对高风险入口来说权限过大。这个 PR 默认禁用该能力，并在执行任何命令前增加 session ownership proof。

## Reviewer Test Plan

### How to verify

启动一个没有 bearer token 的默认 loopback daemon，确认 `/capabilities.features` 不包含 `session_shell_command`，ACP initialize 不广告 `_qwen/session/shell`，REST shell 返回 `401 token_required`。

启动一个带认证但没有 `--enable-session-shell` 的 daemon，确认认证后的 direct shell 调用返回 `session_shell_disabled`，并且不会进入 bridge。

启动一个带认证且开启 `--enable-session-shell` 的 daemon，确认缺少 `X-Qwen-Client-Id` 的 shell 调用返回 `client_id_required`，而携带绑定到该 session 的 client id 时会进入 bridge 并正常执行。

对直接 embed 的路径，调用 `createServeApp({ token: '' })`，确认它按未配置 token 处理：strict shell mutation 返回 `token_required`，且不广告 `session_shell_command`。

### Evidence (Before & After)

非 UI 变更，本地自动化验证覆盖了 REST、ACP、bridge、CLI 参数、build 和 typecheck 路径。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

本地 Node/npm 仓库 worktree。

## Risk & Scope

- Main risk or tradeoff: 这是 direct daemon shell client 的行为变更；调用方必须显式开启 daemon 能力，并提供 session-bound client id。
- Not validated / out of scope: 不新增 shell-specific rate limiter，不接入 PermissionMediator synthetic approval flow，不改变普通 agent shell tool approval 或 prompt queue 行为。
- Breaking changes / migration notes: 裸 `DaemonClient.shellCommand(sessionId, command)` 在 daemon 开启 direct session shell 后必须传 `opts.clientId`；`DaemonSessionClient.shellCommand()` 会继续自动转发 session-bound client id。直接 embedder 如果传了空字符串 token，应改为传非空 bearer token 或省略 `token`；空字符串不会被视为已配置 token。

## Linked Issues

参考 #4490。

</details>
