### PR TITLE
feat(core): Workflow P3 — agent({schema, agentType, model, isolation:'worktree'}) (#4721)

### DIFF
--- a/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
@@ -1062,4 +1062,247 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
     await dispatch('extract', { schema: { type: 'object' } });
     expect(calls[0].eventEmitterAttached).toBe(true);
   });
+
+  // R1 self-review (P3-T6 gap): the schema-mode state machine in
+  // createSchemaEventEmitter has a `state.result === null` guard that
+  // allows the model to RECOVER from earlier failed attempts. Only the
+  // 0-failure and 3+-failure boundaries were tested; the 1-failure and
+  // 2-failure recovery transitions had no coverage. A regression
+  // inverting the guard, or one where pendingArgs cleanup discards the
+  // recovered args, would slip past the previous tests.
+  it('schema-mode: success on 2nd attempt (1 nudge then valid) captures round-2 args', async () => {
+    const { config } = fakeConfigWithMgr({
+      onCreate: async () => ({
+        finalText: '',
+        terminateMode: 'CANCELLED',
+        runWithEmitter: (emitter) => {
+          // Round 1: invalid args, validation fails.
+          emitter.emit('tool_call', {
+            subagentId: 'sub',
+            round: 1,
+            callId: 'c1',
+            name: 'structured_output',
+            args: { bad: 'shape' },
+            description: '',
+            isOutputMarkdown: false,
+            timestamp: 1,
+          });
+          emitter.emit('tool_result', {
+            subagentId: 'sub',
+            round: 1,
+            callId: 'c1',
+            name: 'structured_output',
+            success: false,
+            error: 'validation failed',
+            responseParts: [],
+            resultDisplay: '',
+            durationMs: 1,
+            timestamp: 1,
+          });
+          // Round 2: corrected args, validation passes. Must be captured
+          // as the result, not the round-1 args.
+          emitter.emit('tool_call', {
+            subagentId: 'sub',
+            round: 2,
+            callId: 'c2',
+            name: 'structured_output',
+            args: { ok: true, attempt: 2 },
+            description: '',
+            isOutputMarkdown: false,
+            timestamp: 2,
+          });
+          emitter.emit('tool_result', {
+            subagentId: 'sub',
+            round: 2,
+            callId: 'c2',
+            name: 'structured_output',
+            success: true,
+            responseParts: [],
+            resultDisplay: '',
+            durationMs: 1,
+            timestamp: 2,
+          });
+        },
+      }),
+    });
+    const dispatch = createProductionDispatch(config);
+    const result = await dispatch('extract', {
+      schema: { type: 'object' },
+    });
+    expect(result).toEqual({ ok: true, attempt: 2 });
+  });
+
+  it('schema-mode: success on 3rd attempt (2 nudges then valid) captures round-3 args', async () => {
+    const { config } = fakeConfigWithMgr({
+      onCreate: async () => ({
+        finalText: '',
+        terminateMode: 'CANCELLED',
+        runWithEmitter: (emitter) => {
+          for (let r = 1; r <= 2; r++) {
+            emitter.emit('tool_call', {
+              subagentId: 'sub',
+              round: r,
+              callId: `c${r}`,
+              name: 'structured_output',
+              args: { bad: r },
+              description: '',
+              isOutputMarkdown: false,
+              timestamp: r,
+            });
+            emitter.emit('tool_result', {
+              subagentId: 'sub',
+              round: r,
+              callId: `c${r}`,
+              name: 'structured_output',
+              success: false,
+              error: 'validation failed',
+              responseParts: [],
+              resultDisplay: '',
+              durationMs: 1,
+              timestamp: r,
+            });
+          }
+          emitter.emit('tool_call', {
+            subagentId: 'sub',
+            round: 3,
+            callId: 'c3',
+            name: 'structured_output',
+            args: { ok: true, attempt: 3 },
+            description: '',
+            isOutputMarkdown: false,
+            timestamp: 3,
+          });
+          emitter.emit('tool_result', {
+            subagentId: 'sub',
+            round: 3,
+            callId: 'c3',
+            name: 'structured_output',
+            success: true,
+            responseParts: [],
+            resultDisplay: '',
+            durationMs: 1,
+            timestamp: 3,
+          });
+        },
+      }),
+    });
+    const dispatch = createProductionDispatch(config);
+    const result = await dispatch('extract', {
+      schema: { type: 'object' },
+    });
+    expect(result).toEqual({ ok: true, attempt: 3 });
+  });
+
+  // R1 self-review (P3-T6 gap): the disallowed-tool floor invariant
+  // declares "ALWAYS applies regardless of agentType". The
+  // single-option tests above exercise floor+agentType and schema
+  // separately, but not their composition. A regression making the
+  // floor conditional on schema being unset (e.g. mistakenly moving
+  // the union inside an `if (opts.schema === undefined)` branch)
+  // would pass the existing tests.
+  it('schema-mode + agentType: floor disallowedTools still unioned', async () => {
+    const { config, calls } = fakeConfigWithMgr({
+      findSubagentByName: async () => ({
+        name: 'Permissive',
+        description: 'allows SendMessage explicitly',
+        systemPrompt: 'permissive',
+        level: 'project',
+        disallowedTools: ['Foo'],
+      }),
+      onCreate: async (_call, _ee) => ({
+        finalText: '',
+        terminateMode: 'CANCELLED',
+        runWithEmitter: (emitter) => {
+          emitter.emit('tool_call', {
+            subagentId: 'sub',
+            round: 1,
+            callId: 'c1',
+            name: 'structured_output',
+            args: { ok: true },
+            description: '',
+            isOutputMarkdown: false,
+            timestamp: 1,
+          });
+          emitter.emit('tool_result', {
+            subagentId: 'sub',
+            round: 1,
+            callId: 'c1',
+            name: 'structured_output',
+            success: true,
+            responseParts: [],
+            resultDisplay: '',
+            durationMs: 1,
+            timestamp: 1,
+          });
+        },
+      }),
+    });
+    const dispatch = createProductionDispatch(config);
+    await dispatch('extract', {
+      agentType: 'Permissive',
+      schema: { type: 'object' },
+    });
+    const disallowed = calls[0].config.disallowedTools ?? [];
+    expect(disallowed).toEqual(
+      expect.arrayContaining(['Foo', 'send_message', 'exit_plan_mode']),
+    );
+  });
+
+  // R1 self-review (P3-T6 gap): caller-abort taking priority over
+  // "completed without StructuredOutput" is a contract boundary the
+  // dispatch enforces at the explicit `if (signal?.aborted)` check.
+  // Without this test, a refactor removing the check would silently
+  // convert user-cancelled schema runs into schema-failure errors.
+  it('schema-mode: caller abort takes priority over terminal "no structured_output" error', async () => {
+    const externalAbort = new AbortController();
+    const { config } = fakeConfigWithMgr({
+      onCreate: async () => ({
+        finalText: '',
+        terminateMode: 'CANCELLED',
+        runWithEmitter: (_emitter) => {
+          // Caller-side abort fires while the subagent is in flight but
+          // before any structured_output call. After execute() returns,
+          // signal.aborted is true AND state.result is still null — the
+          // dispatch must throw AbortError, not the StructuredOutput
+          // terminal error.
+          externalAbort.abort();
+        },
+      }),
+    });
+    const dispatch = createProductionDispatch(config, externalAbort.signal);
+    await expect(
+      dispatch('extract', { schema: { type: 'object' } }),
+    ).rejects.toThrow(/aborted/i);
+  });
+
+  // R1 self-review (P3-T6 gap): the override path's dispose() must run
+  // in a finally so per-agent MCP processes / hooks don't leak past the
+  // dispatch — including on the exception path. The test harness has a
+  // `disposed` counter that no test asserts on; this closes that gap on
+  // both the success and the thrown-from-execute paths.
+  it('override path always calls dispose() on the success path', async () => {
+    // Use model-only override (no agentType) so we don't go through the
+    // SubagentManager resolution path. The ephemeral-default branch
+    // still routes through createAgentHeadless and therefore dispose().
+    const helper = fakeConfigWithMgr({
+      onCreate: async () => ({ finalText: 'done', terminateMode: 'GOAL' }),
+    });
+    const dispatch = createProductionDispatch(helper.config);
+    await dispatch('hi', { model: 'qwen3-max' });
+    expect(helper.disposed).toBeGreaterThanOrEqual(1);
+  });
+
+  it('override path always calls dispose() even when terminateMode is non-GOAL', async () => {
+    const helper = fakeConfigWithMgr({
+      onCreate: async () => ({
+        finalText: '',
+        terminateMode: 'ERROR', // non-GOAL → dispatch throws after execute
+      }),
+    });
+    const dispatch = createProductionDispatch(helper.config);
+    await expect(dispatch('hi', { model: 'qwen3-max' })).rejects.toThrow(
+      /terminate mode: ERROR/,
+    );
+    expect(helper.disposed).toBeGreaterThanOrEqual(1);
+  });
 });

--- a/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
@@ -1085,7 +1085,13 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
     );
   });
 
-  it('schema-mode: subagent never calls structured_output → same terminal error', async () => {
+  // R3 review (wenshao T6 [M2]): when the subagent terminates without
+  // ever calling structured_output (model answered in plain text;
+  // attempts counter never incremented), the dispatch throws the
+  // accurate "no validation attempt" message — NOT the upstream-
+  // verbatim "after 2 in-conversation nudges" wording (which describes
+  // a different failure mode: 3 validation failures in a row).
+  it('schema-mode: subagent never calls structured_output → "no validation attempt" terminal', async () => {
     const { config } = fakeConfigWithMgr({
       onCreate: async () => ({
         finalText: 'plain-text answer the script will discard',
@@ -1096,7 +1102,7 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
     await expect(
       dispatch('extract', { schema: { type: 'object' } }),
     ).rejects.toThrow(
-      /subagent completed without calling StructuredOutput \(after 2 in-conversation nudges\)\./,
+      /subagent completed without calling structured_output \(no validation attempt — model produced plain-text content\)\./,
     );
   });
 
@@ -1678,5 +1684,293 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
     // to debugLogger instead. See runOverridePath's "schema-mode... payload
     // is returned verbatim" comment.
     expect(result).toEqual({ ok: true, in_worktree: true });
+  });
+
+  // ─── R3 review (wenshao Round 2) ────────────────────────────────
+
+  // T0 [Critical]: when isolation:worktree is provisioned and then a
+  // later setup step throws (here, createSchemaConfigOverride via a
+  // broken fakeRegistry.copyDiscoveredToolsFrom), the outer try/finally
+  // MUST still fire the fallback worktree cleanup. Before the fix, the
+  // outer try opened AFTER schema setup, so this exact path orphaned
+  // the worktree on disk.
+  it("isolation:'worktree' + schema setup throws → worktree is still cleaned up", async () => {
+    const removeCalls: string[] = [];
+    const { GitWorktreeService } = await import(
+      '../../services/gitWorktreeService.js'
+    );
+    vi.mocked(GitWorktreeService).mockImplementation(() => {
+      const stub = worktreeStubs.makeStub();
+      // Track removeUserWorktree calls — the fallback finally must call it.
+      stub.removeUserWorktree = vi.fn(async (slug: string) => {
+        removeCalls.push(slug);
+        return { success: true };
+      });
+      worktreeStubs.instances.push(stub);
+      return stub as unknown as InstanceType<typeof GitWorktreeService>;
+    });
+    // fakeConfigWithMgr's getToolRegistry returns fakeRegistry which has a
+    // no-op copyDiscoveredToolsFrom. Patch the worktree-override path so
+    // createSchemaConfigOverride's rebuildToolRegistryOnOverride throws.
+    const { config } = fakeConfigWithMgr({
+      onCreate: async () => ({
+        finalText: 'unused',
+        terminateMode: 'GOAL',
+      }),
+    });
+    (
+      config as unknown as { createToolRegistry: () => Promise<unknown> }
+    ).createToolRegistry = async () => {
+      throw new Error('simulated registry rebuild failure');
+    };
+    const dispatch = createProductionDispatch(config);
+    await expect(
+      dispatch('hi', {
+        isolation: 'worktree',
+        schema: { type: 'object' },
+      }),
+    ).rejects.toThrow(/simulated registry rebuild failure/);
+    // Cleanup must have called removeUserWorktree even though setup threw.
+    expect(removeCalls).toContain('agent-deadbe1');
+  });
+
+  // T1 + T4 [Critical/H1]: when agentType resolves with a restricted
+  // tools allowlist (no '*'), the schema-mode dispatch MUST add
+  // structured_output to the allowlist so prepareTools doesn't filter
+  // it out of the subagent's tool surface. Without this fix the
+  // SyntheticOutputTool was present in the per-call registry but
+  // invisible to the model, producing the silent "after 2 nudges" dead-end.
+  it('schema-mode + agentType restricted tools: structured_output appended to allowlist', async () => {
+    const { config, calls } = fakeConfigWithMgr({
+      findSubagentByName: async () => ({
+        name: 'Explore',
+        description: 'fast read-only',
+        systemPrompt: 'You are Explore. Read-only. Be fast.',
+        level: 'builtin',
+        tools: ['Read', 'Grep', 'Glob'],
+        disallowedTools: [],
+      }),
+      onCreate: async (_call, _ee) => ({
+        finalText: '',
+        terminateMode: 'CANCELLED',
+        runWithEmitter: (emitter) => {
+          emitter.emit('tool_call', {
+            subagentId: 'sub',
+            round: 1,
+            callId: 'c1',
+            name: 'structured_output',
+            args: { ok: true },
+            description: '',
+            isOutputMarkdown: false,
+            timestamp: 1,
+          });
+          emitter.emit('tool_result', {
+            subagentId: 'sub',
+            round: 1,
+            callId: 'c1',
+            name: 'structured_output',
+            success: true,
+            responseParts: [],
+            resultDisplay: '',
+            durationMs: 1,
+            timestamp: 1,
+          });
+        },
+      }),
+    });
+    const dispatch = createProductionDispatch(config);
+    await dispatch('extract', {
+      agentType: 'Explore',
+      schema: { type: 'object' },
+    });
+    const tools = (calls[0].config as { tools?: string[] }).tools ?? [];
+    expect(tools).toContain('structured_output');
+    // The original agentType tools survive — not replaced.
+    expect(tools).toEqual(
+      expect.arrayContaining(['Read', 'Grep', 'Glob', 'structured_output']),
+    );
+  });
+
+  // T1 + T4 [Critical/H1] companion: the resolved agentType's
+  // systemPrompt MUST be preserved — schema-mode appends the StructuredOutput
+  // instruction block instead of replacing the persona outright.
+  it('schema-mode + agentType: systemPrompt appends schema instructions (persona preserved)', async () => {
+    const personaPrompt = 'You are Explore. Read-only. Be fast.';
+    const { config, calls } = fakeConfigWithMgr({
+      findSubagentByName: async () => ({
+        name: 'Explore',
+        description: 'fast read-only',
+        systemPrompt: personaPrompt,
+        level: 'builtin',
+      }),
+      onCreate: async () => ({
+        finalText: '',
+        terminateMode: 'CANCELLED',
+        runWithEmitter: (emitter) => {
+          emitter.emit('tool_call', {
+            subagentId: 'sub',
+            round: 1,
+            callId: 'c1',
+            name: 'structured_output',
+            args: { ok: true },
+            description: '',
+            isOutputMarkdown: false,
+            timestamp: 1,
+          });
+          emitter.emit('tool_result', {
+            subagentId: 'sub',
+            round: 1,
+            callId: 'c1',
+            name: 'structured_output',
+            success: true,
+            responseParts: [],
+            resultDisplay: '',
+            durationMs: 1,
+            timestamp: 1,
+          });
+        },
+      }),
+    });
+    const dispatch = createProductionDispatch(config);
+    await dispatch('extract', {
+      agentType: 'Explore',
+      schema: { type: 'object' },
+    });
+    const sp =
+      (calls[0].config as { systemPrompt?: string }).systemPrompt ?? '';
+    expect(sp).toContain(personaPrompt);
+    expect(sp).toContain('structured_output');
+  });
+
+  // T2 + T5 [M1]: schema-mode dispatch MUST NOT accumulate listeners on
+  // the parent (run-level) AbortSignal across N calls. Before the fix
+  // `{ once: true }` only removed on actual parent abort, so a workflow
+  // with N schema calls and no abort accumulated N listeners + N child
+  // AbortController closures. The fix removes the named listener in the
+  // outer finally regardless of how the dispatch ended.
+  it('schema-mode: parent-abort listener is removed after each call (no accumulation)', async () => {
+    const sharedSignal = new AbortController().signal;
+    let liveListeners = 0;
+    const origAdd = sharedSignal.addEventListener.bind(sharedSignal);
+    const origRemove = sharedSignal.removeEventListener.bind(sharedSignal);
+    sharedSignal.addEventListener = ((type: string, ...rest: unknown[]) => {
+      if (type === 'abort') liveListeners += 1;
+      return (origAdd as unknown as (t: string, ...r: unknown[]) => void)(
+        type,
+        ...rest,
+      );
+    }) as typeof sharedSignal.addEventListener;
+    sharedSignal.removeEventListener = ((type: string, ...rest: unknown[]) => {
+      if (type === 'abort') liveListeners -= 1;
+      return (origRemove as unknown as (t: string, ...r: unknown[]) => void)(
+        type,
+        ...rest,
+      );
+    }) as typeof sharedSignal.removeEventListener;
+
+    const { config } = fakeConfigWithMgr({
+      onCreate: async (_call, _ee) => ({
+        finalText: '',
+        terminateMode: 'CANCELLED',
+        runWithEmitter: (emitter) => {
+          emitter.emit('tool_call', {
+            subagentId: 'sub',
+            round: 1,
+            callId: 'c1',
+            name: 'structured_output',
+            args: { ok: true },
+            description: '',
+            isOutputMarkdown: false,
+            timestamp: 1,
+          });
+          emitter.emit('tool_result', {
+            subagentId: 'sub',
+            round: 1,
+            callId: 'c1',
+            name: 'structured_output',
+            success: true,
+            responseParts: [],
+            resultDisplay: '',
+            durationMs: 1,
+            timestamp: 1,
+          });
+        },
+      }),
+    });
+    const dispatch = createProductionDispatch(config, sharedSignal);
+    // Run 5 schema-mode dispatches against the same parent signal.
+    for (let i = 0; i < 5; i++) {
+      await dispatch('extract', { schema: { type: 'object' } });
+    }
+    expect(liveListeners).toBe(0);
+  });
+
+  // T6 [M2]: a schema-mode dispatch whose subagent terminates via
+  // TIMEOUT (10 min cap), MAX_TURNS (50 cap), or ERROR without a
+  // structured_output call MUST throw the terminate-mode error, not the
+  // "after 2 in-conversation nudges" terminal. The previous path
+  // misdiagnosed every non-result outcome as a content failure.
+  it.each(['TIMEOUT', 'MAX_TURNS', 'ERROR'])(
+    'schema-mode + terminateMode=%s → "did not complete" terminal, not "after 2 nudges"',
+    async (mode) => {
+      const { config } = fakeConfigWithMgr({
+        onCreate: async () => ({
+          finalText: '',
+          terminateMode: mode,
+        }),
+      });
+      const dispatch = createProductionDispatch(config);
+      await expect(
+        dispatch('extract', { schema: { type: 'object' } }),
+      ).rejects.toThrow(
+        new RegExp(`did not complete \\(terminate mode: ${mode}\\)\\.`),
+      );
+    },
+  );
+
+  // T6 [M2] companion: when the schema-mode dispatch DID see 3 failed
+  // validation attempts (the real "after 2 in-conversation nudges"
+  // path), the upstream-verbatim wording is preserved. This is the
+  // existing 3-failure test, retained here with explicit terminateMode
+  // pinning to make the contract unambiguous.
+  it('schema-mode: 3 failed structured_output calls → upstream-verbatim "after 2 nudges"', async () => {
+    const { config } = fakeConfigWithMgr({
+      onCreate: async (_call, _ee) => ({
+        finalText: '',
+        terminateMode: 'CANCELLED', // dispatch aborts on 3rd failure
+        runWithEmitter: (emitter) => {
+          for (let i = 1; i <= 3; i++) {
+            emitter.emit('tool_call', {
+              subagentId: 'sub',
+              round: i,
+              callId: `c${i}`,
+              name: 'structured_output',
+              args: { bad: i },
+              description: '',
+              isOutputMarkdown: false,
+              timestamp: i,
+            });
+            emitter.emit('tool_result', {
+              subagentId: 'sub',
+              round: i,
+              callId: `c${i}`,
+              name: 'structured_output',
+              success: false,
+              error: 'validation failed',
+              responseParts: [],
+              resultDisplay: '',
+              durationMs: 1,
+              timestamp: i,
+            });
+          }
+        },
+      }),
+    });
+    const dispatch = createProductionDispatch(config);
+    await expect(
+      dispatch('extract', { schema: { type: 'object' } }),
+    ).rejects.toThrow(
+      /subagent completed without calling StructuredOutput \(after 2 in-conversation nudges\)\./,
+    );
   });
 });

--- a/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
@@ -41,6 +41,57 @@ const { created, nextTerminateMode } = vi.hoisted(() => ({
   nextTerminateMode: { value: 'GOAL' as string },
 }));
 
+// P3 R2 self-review (P3-T6 gap, batch): tests below for
+// agent({isolation:'worktree'}) need to drive GitWorktreeService's
+// provision/cleanup branches deterministically. Module-level mock with
+// per-test stub overrides via vi.mocked(...).mockImplementation.
+//
+// Default behaviour = "everything succeeds and the worktree is clean
+// post-spawn" so the cleanup branch removes the worktree. Tests that
+// need a specific error path override the relevant method.
+const worktreeStubs = vi.hoisted(() => {
+  const makeStub = () => ({
+    checkGitAvailable: vi.fn(async () => ({ available: true })),
+    isGitRepository: vi.fn(async () => true),
+    getRepoTopLevel: vi.fn(async () => '/fake/repo'),
+    getCurrentBranch: vi.fn(async () => 'main'),
+    hasWorktreeChanges: vi.fn(async () => false),
+    hasUnmergedWorktreeCommits: vi.fn(async () => false),
+    createUserWorktree: vi.fn(
+      async (
+        slug: string,
+        _base?: string,
+        _options?: { symlinkDirectories?: readonly string[] },
+      ) => ({
+        success: true,
+        worktree: {
+          path: `/fake/repo/.qwen/worktrees/${slug}`,
+          branch: `worktree-${slug}`,
+        },
+      }),
+    ),
+    removeUserWorktree: vi.fn(async () => ({ success: true })),
+  });
+  return { makeStub, instances: [] as Array<ReturnType<typeof makeStub>> };
+});
+
+vi.mock('../../services/gitWorktreeService.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('../../services/gitWorktreeService.js')
+    >();
+  return {
+    ...actual,
+    generateAgentWorktreeSlug: () => 'agent-deadbe1',
+    writeWorktreeSessionMarker: vi.fn(async () => {}),
+    GitWorktreeService: vi.fn().mockImplementation(() => {
+      const stub = worktreeStubs.makeStub();
+      worktreeStubs.instances.push(stub);
+      return stub;
+    }),
+  };
+});
+
 vi.mock('./agent-headless.js', () => ({
   AgentHeadless: {
     create: async (
@@ -732,6 +783,21 @@ describe('WorkflowOrchestrator P2 — parallel() / pipeline() / caps', () => {
 // stub matching just enough surface (findSubagentByName +
 // createAgentHeadless) for the path under test.
 describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', () => {
+  // Reset GitWorktreeService stub state between tests so an override set
+  // by one test does not bleed into the next (mockImplementation is
+  // persistent; the per-test overrides below rely on a clean baseline).
+  beforeEach(async () => {
+    const { GitWorktreeService } = await import(
+      '../../services/gitWorktreeService.js'
+    );
+    worktreeStubs.instances.length = 0;
+    vi.mocked(GitWorktreeService).mockImplementation(() => {
+      const stub = worktreeStubs.makeStub();
+      worktreeStubs.instances.push(stub);
+      return stub as unknown as InstanceType<typeof GitWorktreeService>;
+    });
+  });
+
   type StubSubagentCall = {
     config: { name?: string; model?: string; disallowedTools?: string[] };
     runtimeContextSame: boolean;
@@ -785,6 +851,12 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
     const cfg = {
       createToolRegistry: async () => fakeRegistry,
       getToolRegistry: () => fakeRegistry,
+      // P3 R2 self-review: isolation:'worktree' provisioning reads
+      // these methods. Provide deterministic returns so the tests can
+      // drive GitWorktreeService stubs without re-deriving cwd.
+      getTargetDir: () => '/fake/repo',
+      getSessionId: () => 'sess_fake_test_id',
+      getWorktreeSymlinkDirectories: () => [],
       getSubagentManager: () => ({
         findSubagentByName: opts.findSubagentByName ?? (async () => null),
         createAgentHeadless: async (
@@ -1304,5 +1376,307 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
       /terminate mode: ERROR/,
     );
     expect(helper.disposed).toBeGreaterThanOrEqual(1);
+  });
+
+  // R2 self-review (sec-2): sanitize control characters in user-controlled
+  // strings before interpolating into error messages so a model-authored
+  // agentType cannot fragment a single-line error across log records.
+  it('agentType not found: control chars in name are scrubbed from the error message', async () => {
+    const { config } = fakeConfigWithMgr({
+      findSubagentByName: async () => null,
+      onCreate: async () => ({ finalText: '', terminateMode: 'GOAL' }),
+    });
+    const dispatch = createProductionDispatch(config);
+    // newline + nul + del — all control codes < 0x20 or == 0x7f.
+    const evil = 'Explore\n\rEvil\x00\x7f';
+    await expect(dispatch('hi', { agentType: evil })).rejects.toThrow();
+    // The thrown message must NOT contain raw newlines / NULs.
+    try {
+      await dispatch('hi', { agentType: evil });
+    } catch (err) {
+      const msg = (err as Error).message;
+      // eslint-disable-next-line no-control-regex
+      expect(msg).not.toMatch(/[\n\r\u0000\u007f]/);
+      expect(msg).toContain('not found');
+    }
+  });
+
+  // R2 self-review (test-5): dispose() MUST still run even when
+  // subagent.execute throws synchronously from inside the in-flight
+  // event-emitter callback (schema-mode failure path). The R1 dispose
+  // tests covered terminate-mode-non-GOAL; this covers the thrown-from-
+  // execute branch.
+  it('override path: dispose() still runs in finally when execute throws', async () => {
+    const helper = fakeConfigWithMgr({
+      onCreate: async () => ({
+        finalText: '',
+        terminateMode: 'GOAL', // not reached
+        runWithEmitter: (_emitter) => {
+          throw new Error('simulated subagent failure');
+        },
+      }),
+    });
+    const dispatch = createProductionDispatch(helper.config);
+    await expect(
+      dispatch('extract', { schema: { type: 'object' } }),
+    ).rejects.toThrow(/simulated subagent failure/);
+    expect(helper.disposed).toBeGreaterThanOrEqual(1);
+  });
+
+  // ─── isolation:'worktree' provision error branches ──────────────
+  // R2 self-review (test-1, [critical]): each provisionWorkflowWorktree
+  // error branch had no unit test. Coverage came only from the real-
+  // LLM E2E S7 happy path. Adversarial review noted the parent-dirty
+  // refuse, nested-worktree refuse, and git-not-available paths can
+  // change behavior with no regression signal. Each test below stubs
+  // the GitWorktreeService method that controls the branch.
+
+  it("isolation:'worktree' refuses when parent cwd is already inside a worktree", async () => {
+    const { config } = fakeConfigWithMgr({
+      onCreate: async () => ({ finalText: 'unused', terminateMode: 'GOAL' }),
+    });
+    // Override getTargetDir to look nested-worktree-ish.
+    (config as unknown as { getTargetDir: () => string }).getTargetDir = () =>
+      '/some/repo/.qwen/worktrees/agent-existing/inner';
+    const dispatch = createProductionDispatch(config);
+    await expect(dispatch('hi', { isolation: 'worktree' })).rejects.toThrow(
+      /already inside a worktree/,
+    );
+  });
+
+  it("isolation:'worktree' refuses when git is not available", async () => {
+    worktreeStubs.instances.length = 0; // reset
+    const { GitWorktreeService } = await import(
+      '../../services/gitWorktreeService.js'
+    );
+    vi.mocked(GitWorktreeService).mockImplementation(
+      () =>
+        ({
+          ...worktreeStubs.makeStub(),
+          checkGitAvailable: vi.fn(async () => ({
+            available: false,
+            error: 'git binary missing',
+          })),
+        }) as unknown as InstanceType<typeof GitWorktreeService>,
+    );
+    const { config } = fakeConfigWithMgr({
+      onCreate: async () => ({ finalText: 'unused', terminateMode: 'GOAL' }),
+    });
+    const dispatch = createProductionDispatch(config);
+    await expect(dispatch('hi', { isolation: 'worktree' })).rejects.toThrow(
+      /git binary missing/,
+    );
+  });
+
+  it("isolation:'worktree' refuses when cwd is not a git repository", async () => {
+    const { GitWorktreeService } = await import(
+      '../../services/gitWorktreeService.js'
+    );
+    vi.mocked(GitWorktreeService).mockImplementation(
+      () =>
+        ({
+          ...worktreeStubs.makeStub(),
+          isGitRepository: vi.fn(async () => false),
+        }) as unknown as InstanceType<typeof GitWorktreeService>,
+    );
+    const { config } = fakeConfigWithMgr({
+      onCreate: async () => ({ finalText: 'unused', terminateMode: 'GOAL' }),
+    });
+    const dispatch = createProductionDispatch(config);
+    await expect(dispatch('hi', { isolation: 'worktree' })).rejects.toThrow(
+      /not a git repository/,
+    );
+  });
+
+  it("isolation:'worktree' refuses when parent working tree is dirty", async () => {
+    const { GitWorktreeService } = await import(
+      '../../services/gitWorktreeService.js'
+    );
+    vi.mocked(GitWorktreeService).mockImplementation(
+      () =>
+        ({
+          ...worktreeStubs.makeStub(),
+          hasWorktreeChanges: vi.fn(async () => true),
+        }) as unknown as InstanceType<typeof GitWorktreeService>,
+    );
+    const { config } = fakeConfigWithMgr({
+      onCreate: async () => ({ finalText: 'unused', terminateMode: 'GOAL' }),
+    });
+    const dispatch = createProductionDispatch(config);
+    await expect(dispatch('hi', { isolation: 'worktree' })).rejects.toThrow(
+      /uncommitted changes/,
+    );
+  });
+
+  it("isolation:'worktree' surfaces createUserWorktree failure", async () => {
+    const { GitWorktreeService } = await import(
+      '../../services/gitWorktreeService.js'
+    );
+    vi.mocked(GitWorktreeService).mockImplementation(
+      () =>
+        ({
+          ...worktreeStubs.makeStub(),
+          createUserWorktree: vi.fn(async () => ({
+            success: false,
+            error: 'simulated worktree create failure',
+          })),
+        }) as unknown as InstanceType<typeof GitWorktreeService>,
+    );
+    const { config } = fakeConfigWithMgr({
+      onCreate: async () => ({ finalText: 'unused', terminateMode: 'GOAL' }),
+    });
+    const dispatch = createProductionDispatch(config);
+    await expect(dispatch('hi', { isolation: 'worktree' })).rejects.toThrow(
+      /simulated worktree create failure/,
+    );
+  });
+
+  // ─── isolation:'worktree' cleanup error branches ────────────────
+  // R2 self-review (test-2, [major]): cleanupWorkflowWorktree has 3
+  // notable error/branch transitions: removeUserWorktree returns
+  // {success:false}, returns {success:true, branchPreserved:true}, or
+  // throws synchronously. Each path produces a different preserved
+  // suffix and was previously untested.
+
+  it("isolation:'worktree' cleanup: removeUserWorktree failure preserves path+branch", async () => {
+    const { GitWorktreeService } = await import(
+      '../../services/gitWorktreeService.js'
+    );
+    vi.mocked(GitWorktreeService).mockImplementation(
+      () =>
+        ({
+          ...worktreeStubs.makeStub(),
+          // Subagent left the worktree clean.
+          hasWorktreeChanges: vi
+            .fn(async () => false)
+            // ... but the subsequent cleanup-side hasWorktreeChanges
+            // (called from inside cleanupWorkflowWorktree) also reports
+            // clean. Cleanup proceeds to removeUserWorktree which fails.
+            .mockImplementation(async () => false),
+          removeUserWorktree: vi.fn(async () => ({
+            success: false,
+            error: 'simulated remove failure',
+          })),
+        }) as unknown as InstanceType<typeof GitWorktreeService>,
+    );
+    const { config } = fakeConfigWithMgr({
+      onCreate: async () => ({ finalText: 'done', terminateMode: 'GOAL' }),
+    });
+    const dispatch = createProductionDispatch(config);
+    const result = await dispatch('hi', { isolation: 'worktree' });
+    // Suffix should appear because removeUserWorktree failed → preserve.
+    expect(String(result)).toMatch(
+      /\[worktree preserved:.*\(branch worktree-agent-deadbe1\)\]/,
+    );
+  });
+
+  it("isolation:'worktree' cleanup: branchPreserved race yields branch-only suffix", async () => {
+    const { GitWorktreeService } = await import(
+      '../../services/gitWorktreeService.js'
+    );
+    vi.mocked(GitWorktreeService).mockImplementation(
+      () =>
+        ({
+          ...worktreeStubs.makeStub(),
+          removeUserWorktree: vi.fn(async () => ({
+            success: true,
+            branchPreserved: true, // race: commits landed between checks and delete
+          })),
+        }) as unknown as InstanceType<typeof GitWorktreeService>,
+    );
+    const { config } = fakeConfigWithMgr({
+      onCreate: async () => ({ finalText: 'done', terminateMode: 'GOAL' }),
+    });
+    const dispatch = createProductionDispatch(config);
+    const result = await dispatch('hi', { isolation: 'worktree' });
+    // Directory-removed-but-branch-preserved suffix matches AgentTool
+    // verbatim and includes the recover hint.
+    expect(String(result)).toMatch(/worktree directory removed/);
+    expect(String(result)).toMatch(/git worktree add/);
+  });
+
+  it("isolation:'worktree' cleanup: thrown removeUserWorktree preserves path+branch", async () => {
+    const { GitWorktreeService } = await import(
+      '../../services/gitWorktreeService.js'
+    );
+    vi.mocked(GitWorktreeService).mockImplementation(
+      () =>
+        ({
+          ...worktreeStubs.makeStub(),
+          removeUserWorktree: vi.fn(async () => {
+            throw new Error('simulated git crash during remove');
+          }),
+        }) as unknown as InstanceType<typeof GitWorktreeService>,
+    );
+    const { config } = fakeConfigWithMgr({
+      onCreate: async () => ({ finalText: 'done', terminateMode: 'GOAL' }),
+    });
+    const dispatch = createProductionDispatch(config);
+    const result = await dispatch('hi', { isolation: 'worktree' });
+    expect(String(result)).toMatch(
+      /\[worktree preserved:.*\(branch worktree-agent-deadbe1\)\]/,
+    );
+  });
+
+  // ─── isolation:'worktree' option combinations ───────────────────
+  // R2 self-review (test-3/4): single-option tests don't catch
+  // interactions. These verify model+worktree and schema+worktree
+  // each compose correctly.
+
+  it("model + isolation:'worktree': model threaded through AND worktree provisioned", async () => {
+    const { config, calls } = fakeConfigWithMgr({
+      onCreate: async () => ({ finalText: 'done', terminateMode: 'GOAL' }),
+    });
+    const dispatch = createProductionDispatch(config);
+    const result = await dispatch('hi', {
+      model: 'qwen3-max',
+      isolation: 'worktree',
+    });
+    expect(calls[0].config.model).toBe('qwen3-max');
+    // Default-clean stub auto-removes; no suffix expected.
+    expect(String(result)).not.toMatch(/worktree preserved/);
+  });
+
+  it("schema + isolation:'worktree': structured payload returned, worktree info logged", async () => {
+    const { config } = fakeConfigWithMgr({
+      onCreate: async (_call, _ee) => ({
+        finalText: '',
+        terminateMode: 'CANCELLED',
+        runWithEmitter: (emitter) => {
+          emitter.emit('tool_call', {
+            subagentId: 'sub',
+            round: 1,
+            callId: 'c1',
+            name: 'structured_output',
+            args: { ok: true, in_worktree: true },
+            description: '',
+            isOutputMarkdown: false,
+            timestamp: 1,
+          });
+          emitter.emit('tool_result', {
+            subagentId: 'sub',
+            round: 1,
+            callId: 'c1',
+            name: 'structured_output',
+            success: true,
+            responseParts: [],
+            resultDisplay: '',
+            durationMs: 1,
+            timestamp: 1,
+          });
+        },
+      }),
+    });
+    const dispatch = createProductionDispatch(config);
+    const result = await dispatch('extract from worktree', {
+      schema: { type: 'object' },
+      isolation: 'worktree',
+    });
+    // Schema-mode returns the structured object verbatim, not the
+    // string-with-suffix shape. The preserved-suffix mechanism intentionally
+    // does NOT mutate the structured payload — operator-visible info goes
+    // to debugLogger instead. See runOverridePath's "schema-mode... payload
+    // is returned verbatim" comment.
+    expect(result).toEqual({ ok: true, in_worktree: true });
   });
 });

--- a/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
@@ -721,3 +721,345 @@ describe('WorkflowOrchestrator P2 — parallel() / pipeline() / caps', () => {
     });
   });
 });
+
+// ─── P3 (PR #5xxx): agentType + model + isolation + schema ──────────
+//
+// These tests exercise `createProductionDispatch`'s override path. The
+// fast path (no agentType / model / isolation / schema) is covered by the
+// existing tests above and the vi.mock('./agent-headless.js') used there;
+// the override path goes through SubagentManager.createAgentHeadless, so
+// each test wires a fake Config whose `getSubagentManager()` returns a
+// stub matching just enough surface (findSubagentByName +
+// createAgentHeadless) for the path under test.
+describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', () => {
+  type StubSubagentCall = {
+    config: { name?: string; model?: string; disallowedTools?: string[] };
+    runtimeContextSame: boolean;
+    options?: { runConfigOverrides?: unknown };
+    eventEmitterAttached: boolean;
+  };
+
+  function fakeConfigWithMgr(opts: {
+    findSubagentByName?: (name: string) => Promise<{
+      name: string;
+      description: string;
+      systemPrompt: string;
+      level: string;
+      tools?: string[];
+      disallowedTools?: string[];
+      model?: string;
+    } | null>;
+    onCreate?: (
+      call: StubSubagentCall,
+      ee?: {
+        on(event: string, cb: (payload: unknown) => void): void;
+      },
+    ) => Promise<{
+      // The mock subagent's contract is the minimal surface
+      // createProductionDispatch reads after createAgentHeadless returns.
+      finalText: string;
+      terminateMode: string;
+      // Hook for schema-mode tests: the override path attaches an
+      // AgentEventEmitter that the dispatch listens to for `structured_output`
+      // calls. The test can drive that emitter to simulate model behavior.
+      runWithEmitter?: (emitter: {
+        emit(event: string, payload: unknown): void;
+      }) => void;
+    }>;
+  }): {
+    config: Config;
+    calls: StubSubagentCall[];
+    disposed: number;
+  } {
+    const calls: StubSubagentCall[] = [];
+    let disposed = 0;
+    // Schema mode goes through createSchemaConfigOverride → rebuildToolRegistryOnOverride,
+    // which calls ov.createToolRegistry() and then copies tools from base.getToolRegistry().
+    // The override carries the result. We don't care about the registry contents in unit
+    // tests — only that the override flow doesn't crash on the missing methods — so the
+    // stub registry just answers the API surface those helpers call.
+    const fakeRegistry = {
+      copyDiscoveredToolsFrom: () => {},
+      registerTool: () => {},
+    };
+    const cfg = {
+      createToolRegistry: async () => fakeRegistry,
+      getToolRegistry: () => fakeRegistry,
+      getSubagentManager: () => ({
+        findSubagentByName: opts.findSubagentByName ?? (async () => null),
+        createAgentHeadless: async (
+          subagentConfig: {
+            name?: string;
+            model?: string;
+            disallowedTools?: string[];
+          },
+          runtimeContext: Config,
+          options?: { eventEmitter?: unknown; runConfigOverrides?: unknown },
+        ) => {
+          const call: StubSubagentCall = {
+            config: subagentConfig,
+            runtimeContextSame: runtimeContext === cfg,
+            options: { runConfigOverrides: options?.runConfigOverrides },
+            eventEmitterAttached: options?.eventEmitter !== undefined,
+          };
+          calls.push(call);
+          const outcome = await opts.onCreate!(
+            call,
+            options?.eventEmitter as
+              | { on(event: string, cb: (payload: unknown) => void): void }
+              | undefined,
+          );
+          const finalText = outcome.finalText;
+          const terminateMode = outcome.terminateMode;
+          return {
+            subagent: {
+              execute: async (
+                _ctx: unknown,
+                signal?: AbortSignal,
+              ): Promise<void> => {
+                if (outcome.runWithEmitter && options?.eventEmitter) {
+                  outcome.runWithEmitter(
+                    options.eventEmitter as {
+                      emit(event: string, payload: unknown): void;
+                    },
+                  );
+                }
+                // Honor signal abort if it fires.
+                if (signal?.aborted) return;
+              },
+              getFinalText: () => finalText,
+              getTerminateMode: () => terminateMode,
+            },
+            dispose: async () => {
+              disposed += 1;
+            },
+          };
+        },
+      }),
+    } as unknown as Config;
+    return {
+      config: cfg,
+      calls,
+      get disposed() {
+        return disposed;
+      },
+    } as {
+      config: Config;
+      calls: StubSubagentCall[];
+      disposed: number;
+    };
+  }
+
+  it('agentType resolves SubagentConfig and routes through createAgentHeadless', async () => {
+    const { config, calls } = fakeConfigWithMgr({
+      findSubagentByName: async () => ({
+        name: 'Explore',
+        description: 'fast read-only',
+        systemPrompt: 'You are Explore.',
+        level: 'builtin',
+        tools: ['Read', 'Grep'],
+        disallowedTools: [],
+      }),
+      onCreate: async () => ({
+        finalText: 'explore-output',
+        terminateMode: 'GOAL',
+      }),
+    });
+    const dispatch = createProductionDispatch(config);
+    const result = await dispatch('find foo', { agentType: 'Explore' });
+    expect(result).toBe('explore-output');
+    expect(calls).toHaveLength(1);
+    expect(calls[0].config.name).toBe('Explore');
+    // Workflow floor [SendMessage, ExitPlanMode] must be unioned in.
+    expect(calls[0].config.disallowedTools).toEqual(
+      expect.arrayContaining(['send_message', 'exit_plan_mode']),
+    );
+  });
+
+  it('agentType not found throws upstream-aligned error', async () => {
+    const { config } = fakeConfigWithMgr({
+      findSubagentByName: async () => null,
+      onCreate: async () => ({ finalText: '', terminateMode: 'GOAL' }),
+    });
+    const dispatch = createProductionDispatch(config);
+    await expect(
+      dispatch('whatever', { agentType: 'NotARealAgent' }),
+    ).rejects.toThrow(
+      /^agent\(\{agentType\}\): agent type 'NotARealAgent' not found\.$/,
+    );
+  });
+
+  it('opts.model is threaded into SubagentConfig.model for provider routing', async () => {
+    const { config, calls } = fakeConfigWithMgr({
+      onCreate: async () => ({ finalText: 'done', terminateMode: 'GOAL' }),
+    });
+    const dispatch = createProductionDispatch(config);
+    await dispatch('hi', { model: 'qwen3-max' });
+    // No agentType → ephemeral default config built, then opts.model applied.
+    expect(calls[0].config.model).toBe('qwen3-max');
+  });
+
+  it("isolation:'remote' throws upstream-aligned 'not available' error", async () => {
+    const { config } = fakeConfigWithMgr({
+      onCreate: async () => ({ finalText: '', terminateMode: 'GOAL' }),
+    });
+    const dispatch = createProductionDispatch(config);
+    await expect(dispatch('hi', { isolation: 'remote' })).rejects.toThrow(
+      /agent\(\{isolation:'remote'\}\) is not available in this build\./,
+    );
+  });
+
+  it('floor disallowedTools always unioned (agentType cannot re-enable them)', async () => {
+    const { config, calls } = fakeConfigWithMgr({
+      findSubagentByName: async () => ({
+        name: 'Permissive',
+        description: 'tries to override floor',
+        systemPrompt: 'permissive prompt',
+        level: 'project',
+        // A user-defined agentType that EXPLICITLY allows the very tools
+        // workflow forbids. The floor must still apply.
+        disallowedTools: ['Foo'],
+      }),
+      onCreate: async () => ({ finalText: 'ok', terminateMode: 'GOAL' }),
+    });
+    const dispatch = createProductionDispatch(config);
+    await dispatch('hi', { agentType: 'Permissive' });
+    const disallowed = calls[0].config.disallowedTools ?? [];
+    // Union: Foo (from agentType) + send_message + exit_plan_mode (floor).
+    expect(disallowed).toEqual(
+      expect.arrayContaining(['Foo', 'send_message', 'exit_plan_mode']),
+    );
+  });
+
+  it('schema-mode: subagent calls structured_output successfully → returns validated args', async () => {
+    const { config } = fakeConfigWithMgr({
+      onCreate: async (_call, _ee) => ({
+        finalText: '',
+        terminateMode: 'CANCELLED', // schema dispatch aborts after capture
+        runWithEmitter: (emitter) => {
+          // Simulate the subagent calling structured_output with valid args.
+          emitter.emit('tool_call', {
+            subagentId: 'sub',
+            round: 1,
+            callId: 'c1',
+            name: 'structured_output',
+            args: { ok: true, value: 42 },
+            description: '',
+            isOutputMarkdown: false,
+            timestamp: 1,
+          });
+          emitter.emit('tool_result', {
+            subagentId: 'sub',
+            round: 1,
+            callId: 'c1',
+            name: 'structured_output',
+            success: true,
+            responseParts: [],
+            resultDisplay: '',
+            durationMs: 1,
+            timestamp: 2,
+          });
+        },
+      }),
+    });
+    const dispatch = createProductionDispatch(config);
+    const result = await dispatch('extract', {
+      schema: { type: 'object', properties: { ok: { type: 'boolean' } } },
+    });
+    expect(result).toEqual({ ok: true, value: 42 });
+  });
+
+  it('schema-mode: 3 failed structured_output calls → upstream-aligned terminal error', async () => {
+    const { config } = fakeConfigWithMgr({
+      onCreate: async (_call, _ee) => ({
+        finalText: '',
+        terminateMode: 'CANCELLED',
+        runWithEmitter: (emitter) => {
+          // 3 failed structured_output calls = original attempt + 2 nudges.
+          for (let i = 1; i <= 3; i++) {
+            emitter.emit('tool_call', {
+              subagentId: 'sub',
+              round: i,
+              callId: `c${i}`,
+              name: 'structured_output',
+              args: { bad: 'shape' },
+              description: '',
+              isOutputMarkdown: false,
+              timestamp: i,
+            });
+            emitter.emit('tool_result', {
+              subagentId: 'sub',
+              round: i,
+              callId: `c${i}`,
+              name: 'structured_output',
+              success: false,
+              error: 'validation failed',
+              responseParts: [],
+              resultDisplay: '',
+              durationMs: 1,
+              timestamp: i,
+            });
+          }
+        },
+      }),
+    });
+    const dispatch = createProductionDispatch(config);
+    await expect(
+      dispatch('extract', {
+        schema: { type: 'object' },
+      }),
+    ).rejects.toThrow(
+      /subagent completed without calling StructuredOutput \(after 2 in-conversation nudges\)\./,
+    );
+  });
+
+  it('schema-mode: subagent never calls structured_output → same terminal error', async () => {
+    const { config } = fakeConfigWithMgr({
+      onCreate: async () => ({
+        finalText: 'plain-text answer the script will discard',
+        terminateMode: 'GOAL',
+      }),
+    });
+    const dispatch = createProductionDispatch(config);
+    await expect(
+      dispatch('extract', { schema: { type: 'object' } }),
+    ).rejects.toThrow(
+      /subagent completed without calling StructuredOutput \(after 2 in-conversation nudges\)\./,
+    );
+  });
+
+  it('schema-mode attaches an event emitter to the subagent', async () => {
+    const { config, calls } = fakeConfigWithMgr({
+      onCreate: async (_call, _ee) => ({
+        finalText: '',
+        terminateMode: 'CANCELLED',
+        runWithEmitter: (emitter) => {
+          emitter.emit('tool_call', {
+            subagentId: 'sub',
+            round: 1,
+            callId: 'c1',
+            name: 'structured_output',
+            args: { ok: true },
+            description: '',
+            isOutputMarkdown: false,
+            timestamp: 1,
+          });
+          emitter.emit('tool_result', {
+            subagentId: 'sub',
+            round: 1,
+            callId: 'c1',
+            name: 'structured_output',
+            success: true,
+            responseParts: [],
+            resultDisplay: '',
+            durationMs: 1,
+            timestamp: 2,
+          });
+        },
+      }),
+    });
+    const dispatch = createProductionDispatch(config);
+    await dispatch('extract', { schema: { type: 'object' } });
+    expect(calls[0].eventEmitterAttached).toBe(true);
+  });
+});

--- a/packages/core/src/agents/runtime/workflow-orchestrator.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.ts
@@ -211,6 +211,19 @@ function generateRunId(): string {
 }
 
 /**
+ * Sanitize a user-controlled string for safe interpolation into an error
+ * message. Control characters (CR / LF / NUL / etc.) are replaced with a
+ * single space so a model-authored agentType cannot fragment a single-line
+ * error across log records / OTLP fields / display payloads. P3 R2
+ * self-review surfaced this; the corresponding throw site is in
+ * `runOverridePath` for `opts.agentType`.
+ */
+function sanitizeForErrorMessage(value: string): string {
+  // eslint-disable-next-line no-control-regex
+  return value.replace(/[\u0000-\u001f\u007f]+/g, ' ');
+}
+
+/**
  * Build the production agent-dispatch function.
  *
  * Wraps AgentHeadless.create + execute + getFinalText into the
@@ -352,8 +365,15 @@ async function runOverridePath(
       // "agent({agentType}): agent type '{name}' not found". Match for
       // user-visible parity so scripts authored against either runtime see
       // the same error text.
+      //
+      // SECURITY (P3 R2 self-review): sanitize opts.agentType before
+      // interpolation. The string is model-authored; an attacker model
+      // could embed CRLF / control characters that fragment the error
+      // message in logs / display / OTLP traces. Replace control chars
+      // with a single space so the error stays single-line.
+      const safeAgentType = sanitizeForErrorMessage(opts.agentType);
       throw new Error(
-        `agent({agentType}): agent type '${opts.agentType}' not found.`,
+        `agent({agentType}): agent type '${safeAgentType}' not found.`,
       );
     }
     baseConfig = resolved;
@@ -556,6 +576,25 @@ interface WorktreePreservedInfo {
   branch: string;
 }
 
+/**
+ * In-flight handle for one `agent({isolation:'worktree'})` provision —
+ * passed from `provisionWorkflowWorktree` to `cleanupWorkflowWorktree`
+ * (plus the outer-finally fallback) so cleanup can address the right
+ * worktree without re-discovering it from the filesystem.
+ *
+ *  - `slug` — the ephemeral `agent-<7hex>` name; used as the
+ *    `removeUserWorktree` argument AND as the input to
+ *    `hasUnmergedWorktreeCommits` (which resolves the slug to its
+ *    branch name internally).
+ *  - `path` — absolute worktree directory under
+ *    `<projectRoot>/.qwen/worktrees/`; the subagent's rebound cwd.
+ *  - `branch` — the branch created for this worktree
+ *    (`worktree-<slug>`); appears verbatim in the user-facing preserved
+ *    suffix.
+ *  - `repoRoot` — the parent project root; the cleanup helper builds a
+ *    fresh `GitWorktreeService` anchored here so the worktree-side
+ *    git invocations target the right repo.
+ */
 interface WorkflowWorktreeIsolation {
   slug: string;
   path: string;

--- a/packages/core/src/agents/runtime/workflow-orchestrator.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.ts
@@ -764,11 +764,21 @@ function appendWorktreePreservedSuffix(
   finalText: string,
   preserved: WorktreePreservedInfo,
 ): string {
+  // Wording mirrors AgentTool's formatWorktreeSuffix (agent.ts:1700-1719)
+  // verbatim so a user who has seen both tools' worktree-preserved messages
+  // sees one consistent shape. AgentTool's version includes the
+  // `git worktree add <path> <branch>` recovery hint for the
+  // directory-removed-but-branch-preserved race; the Workflow path hits the
+  // same race (cleanupWorkflowWorktree's result.branchPreserved branch) so
+  // it gets the same hint.
   const sep = finalText.endsWith('\n') ? '\n' : '\n\n';
   if (preserved.path) {
-    return `${finalText}${sep}[worktree preserved at ${preserved.path} on branch ${preserved.branch}]`;
+    return `${finalText}${sep}[worktree preserved: ${preserved.path} (branch ${preserved.branch})]`;
   }
-  return `${finalText}${sep}[worktree branch preserved: ${preserved.branch} (directory already removed)]`;
+  return (
+    `${finalText}${sep}[worktree directory removed; branch ${preserved.branch} ` +
+    `preserved — recover with \`git worktree add <path> ${preserved.branch}\`]`
+  );
 }
 
 /**

--- a/packages/core/src/agents/runtime/workflow-orchestrator.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.ts
@@ -391,17 +391,52 @@ async function runOverridePath(
     };
   }
 
+  // R3 review (wenshao T1 [Critical] + H1): schema mode used to (a)
+  // inherit the resolved agentType's `tools` allowlist verbatim — so
+  // `structured_output` was present in the per-call ToolRegistry but
+  // filtered OUT by prepareTools when the agentType allowlist didn't
+  // include it, producing the silent "after 2 nudges" dead-end with no
+  // hint that the tool was invisible; and (b) replace the resolved
+  // agentType's systemPrompt outright with WORKFLOW_SUBAGENT_SYSTEM_PROMPT_WITH_SCHEMA,
+  // silently dropping the agentType's persona (e.g. Explore's
+  // read-only / be-fast instructions). Upstream's contract is to APPEND
+  // the StructuredOutput instruction block to the resolved persona, so
+  // `agent('review X', {agentType:'code-reviewer', schema:S})` keeps the
+  // code-reviewer persona AND knows to call structured_output. Replace
+  // only on the ephemeral-default no-agentType path, where the persona
+  // IS WORKFLOW_SUBAGENT_SYSTEM_PROMPT and the schema variant is its
+  // strict superset (avoids two near-identical prompt blocks).
+  let schemaSystemPrompt: string | undefined;
+  if (opts.schema !== undefined) {
+    schemaSystemPrompt =
+      opts.agentType !== undefined && baseConfig.systemPrompt
+        ? `${baseConfig.systemPrompt}\n\n${WORKFLOW_SUBAGENT_SYSTEM_PROMPT_WITH_SCHEMA}`
+        : WORKFLOW_SUBAGENT_SYSTEM_PROMPT_WITH_SCHEMA;
+  }
+  // Tools allowlist: when schema mode runs over an agentType with a
+  // restricted allowlist (no '*'), ensure structured_output is part of
+  // the allowed set so prepareTools doesn't filter it out. The case
+  // where baseConfig.tools is undefined / empty is already covered by
+  // convertToRuntimeConfig defaulting to ['*'], which lets every
+  // registered tool through (including the per-call structured_output).
+  let schemaTools: string[] | undefined;
+  if (
+    opts.schema !== undefined &&
+    baseConfig.tools &&
+    baseConfig.tools.length > 0 &&
+    !baseConfig.tools.includes('*') &&
+    !baseConfig.tools.includes(ToolNames.STRUCTURED_OUTPUT)
+  ) {
+    schemaTools = [...baseConfig.tools, ToolNames.STRUCTURED_OUTPUT];
+  }
+
   const augmented: SubagentConfig = {
     ...baseConfig,
     ...(opts.model !== undefined ? { model: opts.model } : {}),
-    // Schema-mode replaces the subagent's systemPrompt with the variant
-    // that explicitly requires a `structured_output` call as the only path
-    // to a final answer. Without this, an `agentType` whose stock prompt
-    // says "answer in plain text" would compete with the schema contract
-    // and produce sustained 2-nudge thrash.
-    ...(opts.schema !== undefined
-      ? { systemPrompt: WORKFLOW_SUBAGENT_SYSTEM_PROMPT_WITH_SCHEMA }
+    ...(schemaSystemPrompt !== undefined
+      ? { systemPrompt: schemaSystemPrompt }
       : {}),
+    ...(schemaTools !== undefined ? { tools: schemaTools } : {}),
     disallowedTools: Array.from(
       new Set([
         ...(baseConfig.disallowedTools ?? []),
@@ -423,45 +458,61 @@ async function runOverridePath(
     );
   }
 
-  // Schema mode: build a per-call Config override with a fresh ToolRegistry
-  // containing a fresh SyntheticOutputTool whose params schema IS the
-  // user-supplied schema. Each agent({schema}) call gets its own override
-  // and its own registry, so concurrent calls under parallel()/pipeline()
-  // do not share state.
-  let schemaState: SchemaModeState | null = null;
-  if (opts.schema !== undefined) {
-    effectiveContext = await createSchemaConfigOverride(
-      effectiveContext,
-      opts.schema as Record<string, unknown>,
-    );
-    schemaState = createSchemaModeState();
-  }
+  // R3 review (wenshao T2/T5 [M1]): named parent-abort listener so the
+  // outer finally can remove it. Declared outside the try so it survives
+  // into the cleanup block. The previous `{ once: true }` registration
+  // only auto-removed when the parent actually aborted; the happy-path
+  // schema dispatch — success capture / 3-failure abort fires the CHILD
+  // controller, not the parent — left the listener attached. With N
+  // schema-mode calls in one workflow the registration accumulated on the
+  // per-run signal.
+  let onParentAbort: (() => void) | undefined;
 
-  // Schema mode chains a child AbortController so the dispatch can stop
-  // the subagent after 2 nudges (or as soon as a valid `structured_output`
-  // call is captured). Outside the schema path, the caller's signal is
-  // passed through unchanged.
-  let dispatchSignal: AbortSignal | undefined = signal;
-  if (schemaState) {
-    const child = new AbortController();
-    if (signal) {
-      if (signal.aborted) {
-        child.abort(signal.reason);
-      } else {
-        signal.addEventListener('abort', () => child.abort(signal.reason), {
-          once: true,
-        });
-      }
-    }
-    schemaState.abortController = child;
-    dispatchSignal = child.signal;
-  }
-
-  const eventEmitter = schemaState
-    ? createSchemaEventEmitter(schemaState)
-    : undefined;
-
+  // R3 review (wenshao T0 [Critical]): the outer try MUST start
+  // immediately after worktree provision. The earlier layout opened it
+  // only after createSchemaConfigOverride / createSchemaModeState /
+  // addEventListener — so any throw in those three (e.g. a broken MCP
+  // server during the schema override's tool-registry rebuild) orphaned
+  // the just-provisioned worktree on disk under .qwen/worktrees/. Move
+  // schema setup + signal chaining + emitter creation inside.
   try {
+    // Schema mode: build a per-call Config override with a fresh ToolRegistry
+    // containing a fresh SyntheticOutputTool whose params schema IS the
+    // user-supplied schema. Each agent({schema}) call gets its own override
+    // and its own registry, so concurrent calls under parallel()/pipeline()
+    // do not share state.
+    let schemaState: SchemaModeState | null = null;
+    if (opts.schema !== undefined) {
+      effectiveContext = await createSchemaConfigOverride(
+        effectiveContext,
+        opts.schema as Record<string, unknown>,
+      );
+      schemaState = createSchemaModeState();
+    }
+
+    // Schema mode chains a child AbortController so the dispatch can stop
+    // the subagent after the 3rd validation failure (or as soon as a valid
+    // `structured_output` call is captured). Outside the schema path, the
+    // caller's signal is passed through unchanged.
+    let dispatchSignal: AbortSignal | undefined = signal;
+    if (schemaState) {
+      const child = new AbortController();
+      if (signal) {
+        if (signal.aborted) {
+          child.abort(signal.reason);
+        } else {
+          onParentAbort = () => child.abort(signal.reason);
+          signal.addEventListener('abort', onParentAbort);
+        }
+      }
+      schemaState.abortController = child;
+      dispatchSignal = child.signal;
+    }
+
+    const eventEmitter = schemaState
+      ? createSchemaEventEmitter(schemaState)
+      : undefined;
+
     const { subagent, dispose } = await subagentMgr.createAgentHeadless(
       augmented,
       effectiveContext,
@@ -509,9 +560,39 @@ async function runOverridePath(
         if (signal?.aborted) {
           throw new DOMException('Workflow aborted.', 'AbortError');
         }
-        // Error message verbatim from upstream Claude Code 2.1.168 strings.
+        // R3 review (wenshao M2): the schema path used to throw the
+        // "after 2 in-conversation nudges" terminal for EVERY non-result
+        // outcome — including TIMEOUT (10 min cap), MAX_TURNS (50 cap),
+        // and ERROR (model client crash). Those aren't content failures
+        // and aren't nudge exhaustion; they're the same terminate-mode
+        // outcomes the non-schema branch below already distinguishes.
+        // Match that shape here BEFORE attributing the failure to schema.
+        const mode = subagent.getTerminateMode();
+        if (
+          mode !== AgentTerminateMode.GOAL &&
+          mode !== AgentTerminateMode.CANCELLED
+        ) {
+          throw new Error(
+            `Workflow subagent did not complete (terminate mode: ${mode}).`,
+          );
+        }
+        // The dispatch aborts via schemaState.abortController on the
+        // 3rd validation failure (attempts > 2) AND on success capture.
+        // The success path returns above, so reaching here means either
+        // (a) the model never called structured_output at all — answered
+        // in plain text — or (b) the 3-failure abort fired. Distinguish
+        // the messages so an operator sees what actually happened:
+        // upstream's verbatim "after 2 in-conversation nudges" wording is
+        // factually correct only for (b).
+        if (schemaState.attempts > 2) {
+          // Error message verbatim from upstream Claude Code 2.1.168 strings.
+          throw new Error(
+            'subagent completed without calling StructuredOutput (after 2 in-conversation nudges).',
+          );
+        }
         throw new Error(
-          'subagent completed without calling StructuredOutput (after 2 in-conversation nudges).',
+          'subagent completed without calling structured_output ' +
+            '(no validation attempt — model produced plain-text content).',
         );
       }
 
@@ -544,9 +625,20 @@ async function runOverridePath(
       await dispose();
     }
   } finally {
+    // R3 review (wenshao T2/T5 [M1]): always remove the parent-abort
+    // listener if we registered one. Happens regardless of how the
+    // dispatch ended — success capture, 3-failure abort, exception in
+    // schema setup, exception in execute — so a workflow with many
+    // schema-mode calls does not accumulate per-call listeners (and
+    // per-call AbortController closures) on the long-lived per-run
+    // parent signal.
+    if (onParentAbort && signal) {
+      signal.removeEventListener('abort', onParentAbort);
+    }
     // Outer fallback cleanup: fires only when worktree was provisioned
     // but the success-path cleanup didn't run (createAgentHeadless threw,
-    // or execute threw, or the terminateMode check threw). Swallow errors
+    // or execute threw, or the terminateMode check threw, or — after the
+    // R3 T0 fix — schema setup / signal chaining threw). Swallow errors
     // here — the original exception (already in flight) is more important
     // than a cleanup failure, but we still log so operators can find the
     // orphaned worktree.

--- a/packages/core/src/agents/runtime/workflow-orchestrator.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.ts
@@ -12,10 +12,29 @@ import type {
   WorkflowAgentOpts,
   WorkflowAgentResult,
 } from './workflow-sandbox.js';
-import { WORKFLOW_SUBAGENT_SYSTEM_PROMPT } from './workflow-prompts.js';
+import {
+  WORKFLOW_SUBAGENT_SYSTEM_PROMPT,
+  WORKFLOW_SUBAGENT_SYSTEM_PROMPT_WITH_SCHEMA,
+} from './workflow-prompts.js';
 import { AgentTerminateMode } from './agent-types.js';
+import type { ContextState } from './agent-headless.js';
+import { AgentEventEmitter, AgentEventType } from './agent-events.js';
+import type {
+  AgentToolCallEvent,
+  AgentToolResultEvent,
+} from './agent-events.js';
 import { ToolNames } from '../../tools/tool-names.js';
 import { createConcurrencyLimiter } from '../../utils/concurrencyLimiter.js';
+import type { SubagentConfig } from '../../subagents/types.js';
+import {
+  GitWorktreeService,
+  generateAgentWorktreeSlug,
+  writeWorktreeSessionMarker,
+} from '../../services/gitWorktreeService.js';
+import { FileDiscoveryService } from '../../services/fileDiscoveryService.js';
+import { WorkspaceContext } from '../../utils/workspaceContext.js';
+import { SyntheticOutputTool } from '../../tools/syntheticOutput.js';
+import { rebuildToolRegistryOnOverride } from '../../tools/agent/agent.js';
 
 /**
  * Default ceiling on total `agent()` calls per workflow run (matches upstream
@@ -203,6 +222,20 @@ function generateRunId(): string {
  * FIX-6 (ARCH-C1): accepts an optional AbortSignal and threads it into
  * subagent.execute() so cancellation from the caller propagates correctly.
  * When signal is undefined, subagent.execute() runs without external abort.
+ *
+ * P3 dispatch routing — two paths:
+ *
+ *  - **Fast path** (no `agentType` and no `model`): direct
+ *    `AgentHeadless.create` with the default workflow subagent prompt and
+ *    the hardcoded resource bounds + disallowed-tool floor. P1/P2 behaviour
+ *    unchanged — zero added overhead, no SubagentManager touch.
+ *
+ *  - **Override path** (`agentType` and/or `model` set): route through
+ *    `SubagentManager.createAgentHeadless` so per-call model overrides go
+ *    through `buildRuntimeContentGeneratorView` (provider routing) and
+ *    per-agent MCP servers / hooks get their own ToolRegistry + lifecycle.
+ *    `dispose()` runs in a `finally` block so the rebuilt registry never
+ *    leaks past a dispatch — even on a thrown subagent.execute().
  */
 export function createProductionDispatch(
   config: Config,
@@ -213,41 +246,648 @@ export function createProductionDispatch(
     const ctx = new ContextState();
     ctx.set('task_prompt', prompt);
 
-    const subagent = await AgentHeadless.create(
-      opts.label ?? 'workflow-agent',
-      config,
-      {
-        systemPrompt: WORKFLOW_SUBAGENT_SYSTEM_PROMPT,
-        initialMessages: [],
-      },
-      {},
-      // T11 (PR #4732 R1): bound resource ceiling so a single agent() call
-      // cannot loop the model indefinitely. Without this, runConfig was {}
-      // and the loop guards never tripped — combined with the cancellation
-      // bug below, workflows were effectively unkillable.
-      {
-        max_turns: WORKFLOW_SUBAGENT_MAX_TURNS,
-        max_time_minutes: WORKFLOW_SUBAGENT_MAX_TIME_MINUTES,
-      },
-      // T11 (PR #4732 R1): disallow SendMessage / ExitPlanMode to align with
-      // upstream Tg8 — closes the back-channel that would let a subagent
-      // deliver its answer via user message instead of the script's read.
-      { tools: ['*'], disallowedTools: WORKFLOW_SUBAGENT_DISALLOWED_TOOLS },
+    if (
+      opts.agentType === undefined &&
+      opts.model === undefined &&
+      opts.isolation === undefined &&
+      opts.schema === undefined
+    ) {
+      const subagent = await AgentHeadless.create(
+        opts.label ?? 'workflow-agent',
+        config,
+        {
+          systemPrompt: WORKFLOW_SUBAGENT_SYSTEM_PROMPT,
+          initialMessages: [],
+        },
+        {},
+        // T11 (PR #4732 R1): bound resource ceiling so a single agent() call
+        // cannot loop the model indefinitely. Without this, runConfig was {}
+        // and the loop guards never tripped — combined with the cancellation
+        // bug below, workflows were effectively unkillable.
+        {
+          max_turns: WORKFLOW_SUBAGENT_MAX_TURNS,
+          max_time_minutes: WORKFLOW_SUBAGENT_MAX_TIME_MINUTES,
+        },
+        // T11 (PR #4732 R1): disallow SendMessage / ExitPlanMode to align with
+        // upstream Tg8 — closes the back-channel that would let a subagent
+        // deliver its answer via user message instead of the script's read.
+        { tools: ['*'], disallowedTools: WORKFLOW_SUBAGENT_DISALLOWED_TOOLS },
+      );
+      await subagent.execute(ctx, signal);
+      // T10 (PR #4732 R1): runReasoningLoop does NOT throw on abort / turn /
+      // time limit — it returns with terminateMode = CANCELLED|MAX_TURNS|
+      // TIMEOUT|ERROR and getFinalText() = '' or partial. Without this check,
+      // `await agent(...)` would resolve to '' on user cancel and the script
+      // would happily loop on empty results.
+      const mode = subagent.getTerminateMode();
+      if (mode !== AgentTerminateMode.GOAL) {
+        throw new Error(
+          `Workflow subagent did not complete (terminate mode: ${mode}).`,
+        );
+      }
+      return subagent.getFinalText();
+    }
+
+    return runOverridePath(config, ctx, opts, signal);
+  };
+}
+
+/**
+ * Override path for `agent({ agentType, model, isolation })`. Resolves the
+ * requested agentType against `SubagentManager`, applies the workflow
+ * disallowed-tool floor, threads `opts.model` into `SubagentConfig.model`
+ * so provider routing in `buildRuntimeContentGeneratorView` sees the
+ * override, optionally provisions a fresh git worktree for
+ * `isolation: 'worktree'` (refused for `'remote'` to match upstream's
+ * "not available in this build" signal), and always disposes the
+ * per-agent registry/hooks in `finally`.
+ *
+ * Why opts.model goes into `SubagentConfig.model` (not
+ * `modelConfigOverrides`): `SubagentManager.buildRuntimeContentGeneratorView`
+ * (subagent-manager.ts:945) consults `SubagentConfig.model` to decide
+ * whether to build a dedicated ContentGenerator for a different provider
+ * — `modelConfigOverrides` would only swap the model name within the
+ * existing provider's runtime view.
+ *
+ * Why disallowed-floor is augmented on `SubagentConfig.disallowedTools`
+ * (not via `toolConfigOverride`): augmenting before `convertToRuntimeConfig`
+ * lets the manager's `transformToToolNames` normalize all entries together
+ * (display name → tool name + MCP pattern preservation). A toolConfigOverride
+ * would bypass that normalization and require us to duplicate it here.
+ *
+ * Why the worktree-rebound Config is passed as `runtimeContext` (not
+ * `toolConfigOverride`): `SubagentManager.buildSubagentContextOverride`
+ * (subagent-manager.ts:857) builds the subagent context via
+ * `Object.create(runtimeContext)`. The own-property rebinds we set on the
+ * worktree override propagate through the prototype chain, so all
+ * `getTargetDir() / getCwd() / getFileService() / getWorkspaceContext()`
+ * call sites inside the subagent see the worktree path. Subsequent
+ * `rebuildToolRegistryOnOverride` re-resolves `this.config` through the
+ * chain and anchors EditTool / WriteFileTool / ReadFileTool to the
+ * worktree's FileReadCache, so the subagent cannot leak writes back into
+ * the parent project tree.
+ */
+async function runOverridePath(
+  config: Config,
+  ctx: ContextState,
+  opts: WorkflowAgentOpts,
+  signal: AbortSignal | undefined,
+): Promise<WorkflowAgentResult> {
+  if (opts.isolation === 'remote') {
+    // Error message verbatim from upstream Claude Code 2.1.168 strings.
+    // Match for parity so scripts written against either runtime see the
+    // same text and can branch on it.
+    throw new Error(
+      "agent({isolation:'remote'}) is not available in this build.",
     );
-    await subagent.execute(ctx, signal);
-    // T10 (PR #4732 R1): runReasoningLoop does NOT throw on abort / turn /
-    // time limit — it returns with terminateMode = CANCELLED|MAX_TURNS|
-    // TIMEOUT|ERROR and getFinalText() = '' or partial. Without this check,
-    // `await agent(...)` would resolve to '' on user cancel and the script
-    // would happily loop on empty results.
-    const mode = subagent.getTerminateMode();
-    if (mode !== AgentTerminateMode.GOAL) {
+  }
+
+  const subagentMgr = config.getSubagentManager();
+  let baseConfig: SubagentConfig;
+
+  if (opts.agentType !== undefined) {
+    const resolved = await subagentMgr.findSubagentByName(opts.agentType);
+    if (!resolved) {
+      // Error message verbatim from upstream Claude Code 2.1.168 strings:
+      // "agent({agentType}): agent type '{name}' not found". Match for
+      // user-visible parity so scripts authored against either runtime see
+      // the same error text.
       throw new Error(
-        `Workflow subagent did not complete (terminate mode: ${mode}).`,
+        `agent({agentType}): agent type '${opts.agentType}' not found.`,
       );
     }
-    return subagent.getFinalText();
+    baseConfig = resolved;
+  } else {
+    // Model-only / isolation-only path: build an ephemeral session-level
+    // default that uses the workflow subagent prompt. Going through
+    // createAgentHeadless gives us provider routing via
+    // buildRuntimeContentGeneratorView and per-agent ToolRegistry cleanup.
+    baseConfig = {
+      name: opts.label ?? 'workflow-agent',
+      description: 'Default workflow subagent (per-call overrides).',
+      systemPrompt: WORKFLOW_SUBAGENT_SYSTEM_PROMPT,
+      level: 'session',
+      isBuiltin: false,
+    };
+  }
+
+  const augmented: SubagentConfig = {
+    ...baseConfig,
+    ...(opts.model !== undefined ? { model: opts.model } : {}),
+    // Schema-mode replaces the subagent's systemPrompt with the variant
+    // that explicitly requires a `structured_output` call as the only path
+    // to a final answer. Without this, an `agentType` whose stock prompt
+    // says "answer in plain text" would compete with the schema contract
+    // and produce sustained 2-nudge thrash.
+    ...(opts.schema !== undefined
+      ? { systemPrompt: WORKFLOW_SUBAGENT_SYSTEM_PROMPT_WITH_SCHEMA }
+      : {}),
+    disallowedTools: Array.from(
+      new Set([
+        ...(baseConfig.disallowedTools ?? []),
+        ...WORKFLOW_SUBAGENT_DISALLOWED_TOOLS,
+      ]),
+    ),
   };
+
+  // Provision worktree BEFORE createAgentHeadless so the override Config
+  // is in place when convertToRuntimeConfig and buildSubagentContextOverride
+  // resolve cwd-related getters via the prototype chain.
+  let worktreeIsolation: WorkflowWorktreeIsolation | null = null;
+  let effectiveContext: Config = config;
+  if (opts.isolation === 'worktree') {
+    worktreeIsolation = await provisionWorkflowWorktree(config);
+    effectiveContext = createWorktreeConfigOverride(
+      config,
+      worktreeIsolation.path,
+    );
+  }
+
+  // Schema mode: build a per-call Config override with a fresh ToolRegistry
+  // containing a fresh SyntheticOutputTool whose params schema IS the
+  // user-supplied schema. Each agent({schema}) call gets its own override
+  // and its own registry, so concurrent calls under parallel()/pipeline()
+  // do not share state.
+  let schemaState: SchemaModeState | null = null;
+  if (opts.schema !== undefined) {
+    effectiveContext = await createSchemaConfigOverride(
+      effectiveContext,
+      opts.schema as Record<string, unknown>,
+    );
+    schemaState = createSchemaModeState();
+  }
+
+  // Schema mode chains a child AbortController so the dispatch can stop
+  // the subagent after 2 nudges (or as soon as a valid `structured_output`
+  // call is captured). Outside the schema path, the caller's signal is
+  // passed through unchanged.
+  let dispatchSignal: AbortSignal | undefined = signal;
+  if (schemaState) {
+    const child = new AbortController();
+    if (signal) {
+      if (signal.aborted) {
+        child.abort(signal.reason);
+      } else {
+        signal.addEventListener('abort', () => child.abort(signal.reason), {
+          once: true,
+        });
+      }
+    }
+    schemaState.abortController = child;
+    dispatchSignal = child.signal;
+  }
+
+  const eventEmitter = schemaState
+    ? createSchemaEventEmitter(schemaState)
+    : undefined;
+
+  try {
+    const { subagent, dispose } = await subagentMgr.createAgentHeadless(
+      augmented,
+      effectiveContext,
+      {
+        // Workflow always bounds resource ceiling regardless of agentType's
+        // own runConfig / maxTurns — these are workflow-level safety bounds,
+        // not subagent-level preferences. P5 will refine via budget.
+        runConfigOverrides: {
+          max_turns: WORKFLOW_SUBAGENT_MAX_TURNS,
+          max_time_minutes: WORKFLOW_SUBAGENT_MAX_TIME_MINUTES,
+        },
+        eventEmitter,
+      },
+    );
+
+    try {
+      await subagent.execute(ctx, dispatchSignal);
+
+      if (schemaState) {
+        if (schemaState.result !== null) {
+          // structured_output captured. Worktree cleanup runs here so the
+          // happy path doesn't leak a worktree; the preserved info is
+          // operator-visible via debugLogger only — appending a suffix to
+          // a structured object would mean either rewrapping the schema
+          // (changes the contract the script sees) or stringifying
+          // (defeats the structured payload).
+          if (worktreeIsolation) {
+            const isolation = worktreeIsolation;
+            worktreeIsolation = null;
+            const preserved = await cleanupWorkflowWorktree(isolation);
+            if (preserved) {
+              debugLogger.info(
+                `[Workflow] Schema-mode subagent preserved worktree at ` +
+                  `${preserved.path ?? '(directory removed)'} on branch ` +
+                  `${preserved.branch}. The structured payload is returned ` +
+                  `verbatim; recover the work from the preserved path / branch.`,
+              );
+            }
+          }
+          return schemaState.result as object;
+        }
+        // No structured_output captured. Caller-side abort takes priority
+        // over the schema terminal error so the workflow-level cancellation
+        // path is honoured instead of looking like a content failure.
+        if (signal?.aborted) {
+          throw new DOMException('Workflow aborted.', 'AbortError');
+        }
+        // Error message verbatim from upstream Claude Code 2.1.168 strings.
+        throw new Error(
+          'subagent completed without calling StructuredOutput (after 2 in-conversation nudges).',
+        );
+      }
+
+      // Non-schema mode.
+      const mode = subagent.getTerminateMode();
+      if (mode !== AgentTerminateMode.GOAL) {
+        throw new Error(
+          `Workflow subagent did not complete (terminate mode: ${mode}).`,
+        );
+      }
+      let finalText: WorkflowAgentResult = subagent.getFinalText();
+      // Cleanup worktree on the success path while we still have the
+      // isolation handle. The preserved suffix (if any) is appended to
+      // the final text so the script can see it. The outer finally below
+      // only fires the fallback cleanup if THIS branch threw.
+      if (worktreeIsolation) {
+        const isolation = worktreeIsolation;
+        worktreeIsolation = null;
+        const preserved = await cleanupWorkflowWorktree(isolation);
+        if (preserved && typeof finalText === 'string') {
+          finalText = appendWorktreePreservedSuffix(finalText, preserved);
+        }
+      }
+      return finalText;
+    } finally {
+      // dispose() unregisters per-agent hooks and stops the per-agent
+      // ToolRegistry (including any per-agent MCP processes spawned by
+      // mcpServers override). Must run in finally; a leaked registry means
+      // stdio handles to spawned MCP processes leak past the dispatch.
+      await dispose();
+    }
+  } finally {
+    // Outer fallback cleanup: fires only when worktree was provisioned
+    // but the success-path cleanup didn't run (createAgentHeadless threw,
+    // or execute threw, or the terminateMode check threw). Swallow errors
+    // here — the original exception (already in flight) is more important
+    // than a cleanup failure, but we still log so operators can find the
+    // orphaned worktree.
+    if (worktreeIsolation) {
+      try {
+        await cleanupWorkflowWorktree(worktreeIsolation);
+      } catch (error) {
+        debugLogger.warn(
+          `Workflow worktree cleanup in fallback finally failed for ` +
+            `${worktreeIsolation.path}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Result of a worktree-isolation cleanup: nothing when the worktree was
+ * cleanly removed (no changes and no unmerged commits), or the path /
+ * branch that was preserved on disk so the script (or user) can recover
+ * the work. `path` is omitted when the worktree directory itself was
+ * removed but the branch could not be safely deleted (the work is on the
+ * branch, not at a filesystem path).
+ */
+interface WorktreePreservedInfo {
+  path?: string;
+  branch: string;
+}
+
+interface WorkflowWorktreeIsolation {
+  slug: string;
+  path: string;
+  branch: string;
+  repoRoot: string;
+}
+
+/**
+ * Provision an isolation worktree for one `agent({isolation:'worktree'})`
+ * call. Mirrors the AgentTool provision path (agent.ts:1849-1963) with
+ * the same fail-closed dirty-parent refuse: if the parent working tree
+ * has uncommitted changes, `git worktree add` would silently check out
+ * the parent's HEAD without those edits and the subagent would see a
+ * stale tree. Forcing the user to commit / stash matches AgentTool's
+ * UX so model authors can rely on consistent behavior across both call
+ * sites.
+ */
+async function provisionWorkflowWorktree(
+  config: Config,
+): Promise<WorkflowWorktreeIsolation> {
+  const cwd = config.getTargetDir();
+  if (/\.qwen[\\/]worktrees[\\/]/.test(cwd)) {
+    throw new Error(
+      `agent({isolation:'worktree'}): parent is already inside a worktree ` +
+        `(${cwd}). Nested isolation worktrees are not supported — the ` +
+        `subagent's inherited paths would still reference the outer worktree.`,
+    );
+  }
+  const probe = new GitWorktreeService(cwd);
+  const gitCheck = await probe.checkGitAvailable();
+  if (!gitCheck.available) {
+    throw new Error(
+      `agent({isolation:'worktree'}): ${gitCheck.error ?? 'git is not available'}.`,
+    );
+  }
+  if (!(await probe.isGitRepository())) {
+    throw new Error(
+      `agent({isolation:'worktree'}): ${cwd} is not a git repository.`,
+    );
+  }
+  const projectRoot = (await probe.getRepoTopLevel()) ?? cwd;
+  const wtService =
+    projectRoot === cwd ? probe : new GitWorktreeService(projectRoot);
+
+  let parentDirty = false;
+  try {
+    parentDirty = await wtService.hasWorktreeChanges(projectRoot);
+  } catch (error) {
+    debugLogger.warn(
+      `[Workflow] hasWorktreeChanges failed at ${projectRoot}: ${error}`,
+    );
+    parentDirty = true;
+  }
+  if (parentDirty) {
+    throw new Error(
+      `agent({isolation:'worktree'}): parent working tree at ${projectRoot} ` +
+        `has uncommitted changes that would not propagate into the isolated ` +
+        `worktree. The subagent would see the prior HEAD instead of the ` +
+        `current state. Commit or stash the changes, then re-run.`,
+    );
+  }
+
+  const slug = generateAgentWorktreeSlug();
+  let parentBranch: string | undefined;
+  try {
+    parentBranch = await wtService.getCurrentBranch();
+  } catch (error) {
+    debugLogger.warn(
+      `[Workflow] getCurrentBranch failed at ${projectRoot}: ${error}`,
+    );
+  }
+  const created = await wtService.createUserWorktree(slug, parentBranch, {
+    symlinkDirectories: config.getWorktreeSymlinkDirectories(),
+  });
+  if (!created.success || !created.worktree) {
+    throw new Error(
+      `agent({isolation:'worktree'}): failed to create worktree: ` +
+        `${created.error ?? 'unknown error'}.`,
+    );
+  }
+  try {
+    await writeWorktreeSessionMarker(
+      created.worktree.path,
+      config.getSessionId(),
+    );
+  } catch (error) {
+    debugLogger.warn(
+      `[Workflow] failed to write session marker at ${created.worktree.path}: ${error}`,
+    );
+  }
+  return {
+    slug,
+    path: created.worktree.path,
+    branch: created.worktree.branch,
+    repoRoot: projectRoot,
+  };
+}
+
+/**
+ * Build a Config wrapper that rebinds every "where am I?" surface to the
+ * isolated worktree path. `Object.create(base)` keeps prototype lookups
+ * walking back to the parent for everything else (model config, session
+ * id, MCP servers), while the own-property overrides shadow the cwd-
+ * adjacent fields so the subagent's tools (Edit / Write / Read / Glob /
+ * Grep / Ls / Shell) anchor inside the worktree.
+ *
+ * Mirrors the inline rebind block at agent.ts:2008-2024. Sets BOTH the
+ * field shape (e.g. `targetDir`) AND the method shape (`getTargetDir`)
+ * because JS does not promote a getter assignment to a field shadow —
+ * call sites that read `this.targetDir` directly inside Config methods
+ * would otherwise still resolve through the prototype to the parent.
+ */
+function createWorktreeConfigOverride(base: Config, wtPath: string): Config {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ov: any = Object.create(base);
+  ov.targetDir = wtPath;
+  ov.cwd = wtPath;
+  ov.getTargetDir = () => wtPath;
+  ov.getCwd = () => wtPath;
+  ov.getWorkingDir = () => wtPath;
+  ov.getProjectRoot = () => wtPath;
+  const wtFileService = new FileDiscoveryService(wtPath);
+  ov.fileDiscoveryService = wtFileService;
+  ov.getFileService = () => wtFileService;
+  const wtWorkspace = new WorkspaceContext(wtPath);
+  ov.workspaceContext = wtWorkspace;
+  ov.getWorkspaceContext = () => wtWorkspace;
+  return ov as Config;
+}
+
+/**
+ * Decide whether the isolation worktree carries work worth preserving:
+ * uncommitted edits OR commits that the parent's history does not yet
+ * cover. If either check fails-closed, preserve — the cost of preserving
+ * spuriously is a stale worktree on disk that the next session-startup
+ * sweep cleans up; the cost of removing spuriously is the user's work.
+ *
+ * Both checks run concurrently because they have no data dependency and
+ * each spawns its own `git` invocation. Mirrors AgentTool's
+ * `cleanupWorktreeIsolation` (agent.ts:1607-1698).
+ */
+async function cleanupWorkflowWorktree(
+  isolation: WorkflowWorktreeIsolation,
+): Promise<WorktreePreservedInfo | null> {
+  const wtService = new GitWorktreeService(isolation.repoRoot);
+  const [hasChanges, hasUnmerged] = await Promise.all([
+    wtService.hasWorktreeChanges(isolation.path).catch((error) => {
+      debugLogger.warn(
+        `[Workflow] hasWorktreeChanges failed for ${isolation.path}: ${error}`,
+      );
+      return true;
+    }),
+    wtService.hasUnmergedWorktreeCommits(isolation.slug).catch((error) => {
+      debugLogger.warn(
+        `[Workflow] hasUnmergedWorktreeCommits failed for ${isolation.slug}: ${error}`,
+      );
+      return true;
+    }),
+  ]);
+  if (hasChanges || hasUnmerged) {
+    debugLogger.info(
+      `[Workflow] Preserving isolation worktree ${isolation.path} ` +
+        `(branch ${isolation.branch}, hasChanges=${hasChanges}, hasUnmerged=${hasUnmerged})`,
+    );
+    return { path: isolation.path, branch: isolation.branch };
+  }
+  try {
+    const result = await wtService.removeUserWorktree(isolation.slug, {
+      deleteBranch: true,
+    });
+    if (!result.success) {
+      debugLogger.warn(
+        `[Workflow] Failed to remove ephemeral worktree ${isolation.path}: ${result.error}`,
+      );
+      return { path: isolation.path, branch: isolation.branch };
+    }
+    if (result.branchPreserved) {
+      // Directory removed, but a safe `git branch -d` refused — race where
+      // commits landed between the unmerged check and the delete. Surface
+      // the branch only; the directory is already gone, so reporting a
+      // preservedPath here would point the script at a missing location.
+      debugLogger.warn(
+        `[Workflow] Removed worktree directory ${isolation.path} but kept ` +
+          `branch ${isolation.branch} (unmerged commits at delete time)`,
+      );
+      return { branch: isolation.branch };
+    }
+  } catch (error) {
+    debugLogger.warn(
+      `[Workflow] Failed to remove ephemeral worktree ${isolation.path}: ${error}`,
+    );
+    return { path: isolation.path, branch: isolation.branch };
+  }
+  return null;
+}
+
+/**
+ * Append a single-line suffix to the subagent's final text describing the
+ * preserved worktree, so the calling script (and the user reading the
+ * workflow result) can find and review the work. The suffix is appended
+ * to the existing string return contract — P3 does not widen
+ * `WorkflowAgentResult` for this; T4 will widen for the `schema` mode and
+ * the suffix is preserved as the fallback shape.
+ */
+function appendWorktreePreservedSuffix(
+  finalText: string,
+  preserved: WorktreePreservedInfo,
+): string {
+  const sep = finalText.endsWith('\n') ? '\n' : '\n\n';
+  if (preserved.path) {
+    return `${finalText}${sep}[worktree preserved at ${preserved.path} on branch ${preserved.branch}]`;
+  }
+  return `${finalText}${sep}[worktree branch preserved: ${preserved.branch} (directory already removed)]`;
+}
+
+/**
+ * Per-call schema-mode state. The dispatch listens to TOOL_CALL/TOOL_RESULT
+ * events from the subagent and updates this object: failed
+ * `structured_output` calls increment `attempts` (and abort the dispatch
+ * after the third failure — "after 2 in-conversation nudges" in upstream
+ * parlance), and a successful call captures the validated args as
+ * `result` and aborts the dispatch so the subagent stops generating
+ * additional tokens.
+ *
+ * Per-element isolation: each agent({schema}) call gets its own
+ * SchemaModeState. Concurrent calls under parallel()/pipeline() do not
+ * share counters or results.
+ */
+interface SchemaModeState {
+  result: unknown | null;
+  attempts: number;
+  pendingArgs: Map<string, Record<string, unknown>>;
+  abortController: AbortController;
+}
+
+function createSchemaModeState(): SchemaModeState {
+  return {
+    result: null,
+    attempts: 0,
+    pendingArgs: new Map(),
+    abortController: new AbortController(),
+  };
+}
+
+/**
+ * Build an AgentEventEmitter that observes `structured_output` tool calls
+ * for one subagent. The emitter is single-purpose: it only updates the
+ * provided schema state, and ignores every other event type.
+ *
+ * Why TOOL_CALL captures `args` and TOOL_RESULT decides success: the
+ * TOOL_RESULT event in agent-core (line 1194-1205) carries `success` and
+ * `responseParts` but not the original arguments, so we snapshot args at
+ * TOOL_CALL time keyed by `callId` and look them up when TOOL_RESULT
+ * fires. A successful call's args ARE the validated structured payload
+ * (AJV validation runs inside `BaseDeclarativeTool.validateToolParams`
+ * before `execute()` is invoked).
+ *
+ * Abort semantics:
+ *   - On successful capture: abort the dispatch signal so the subagent
+ *     loop stops emitting tokens. `SyntheticOutputTool.execute()` already
+ *     instructs the model to stop, but abort makes termination
+ *     deterministic.
+ *   - On the third failure (attempts > 2 after increment): abort the
+ *     dispatch signal so the subagent stops retrying. The post-execute
+ *     check in `runOverridePath` then throws the upstream-aligned
+ *     "completed without calling StructuredOutput (after 2 in-conversation
+ *     nudges)" error.
+ *   - Caller abort: outer code in `runOverridePath` forwards the caller's
+ *     signal into this state's controller, so a caller cancellation
+ *     propagates straight to the subagent.
+ */
+function createSchemaEventEmitter(state: SchemaModeState): AgentEventEmitter {
+  const emitter = new AgentEventEmitter();
+  const targetTool = ToolNames.STRUCTURED_OUTPUT;
+  emitter.on(AgentEventType.TOOL_CALL, (evt: AgentToolCallEvent) => {
+    if (evt.name !== targetTool) return;
+    // Args are the candidate structured payload. They're stashed pending
+    // the matching TOOL_RESULT, then either promoted to `result` (success)
+    // or discarded (failure).
+    state.pendingArgs.set(evt.callId, evt.args);
+  });
+  emitter.on(AgentEventType.TOOL_RESULT, (evt: AgentToolResultEvent) => {
+    if (evt.name !== targetTool) return;
+    const args = state.pendingArgs.get(evt.callId);
+    state.pendingArgs.delete(evt.callId);
+    if (evt.success) {
+      if (args !== undefined && state.result === null) {
+        state.result = args;
+        state.abortController.abort();
+      }
+      return;
+    }
+    state.attempts += 1;
+    if (state.attempts > 2 && state.result === null) {
+      state.abortController.abort();
+    }
+  });
+  return emitter;
+}
+
+/**
+ * Build a Config override whose `getToolRegistry()` returns a fresh
+ * registry with a per-call `SyntheticOutputTool` bound to the
+ * user-supplied schema. The base registry is rebuilt via
+ * `rebuildToolRegistryOnOverride` (the same helper AgentTool /
+ * SubagentManager use), so the override carries the full core toolset
+ * AND the user's schema-bound tool — both anchored to the override
+ * Config, isolating any per-tool caches (FileReadCache, etc.) from the
+ * parent.
+ *
+ * Why a fresh tool instance per call (no caching): each `agent({schema:S})`
+ * call may carry a different `S`, and `SyntheticOutputTool`'s parameter
+ * schema IS its constructor argument — caching would alias different
+ * schemas to the same tool name and let validation pass against the wrong
+ * shape. The cost (one tool instantiation per schema call) is bounded by
+ * the 1000-agent-per-run cap.
+ *
+ * Concurrency safety: the override is per-call, so concurrent
+ * agent({schema:S1}) and agent({schema:S2}) under parallel()/pipeline()
+ * each get their own override Config and their own registry. No shared
+ * mutation, no race.
+ */
+async function createSchemaConfigOverride(
+  base: Config,
+  schema: Record<string, unknown>,
+): Promise<Config> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const override: any = Object.create(base);
+  await rebuildToolRegistryOnOverride(override as Config, base);
+  const registry = override.getToolRegistry();
+  registry.registerTool(new SyntheticOutputTool(schema));
+  return override as Config;
 }
 
 export class WorkflowOrchestrator {

--- a/packages/core/src/agents/runtime/workflow-prompts.ts
+++ b/packages/core/src/agents/runtime/workflow-prompts.ts
@@ -35,3 +35,28 @@ export const WORKFLOW_SUBAGENT_SYSTEM_PROMPT =
   '- If asked for JSON, return ONLY the raw JSON — no code fences, no prose, no markdown.\n' +
   '- Do NOT use SendUserMessage to deliver your answer. Put your answer in your final text response.\n' +
   '- Be concise. The script will parse your output.';
+
+/**
+ * Schema-mode subagent prompt — used when `agent({schema})` enforces the
+ * StructuredOutput contract. The `structured_output` tool's own description
+ * (see tools/syntheticOutput.ts) already tells the model the tool ends the
+ * session on the first valid call; this prompt reinforces that the FINAL
+ * answer must travel through that tool, not through plain text.
+ *
+ * Aligns with upstream Claude Code 2.1.168 §ZmO constant in spirit (binary
+ * verbatim is not yet captured — the load-bearing fragments are: must call
+ * the tool, args must validate, no plain-text fallback, no SendUserMessage).
+ */
+export const WORKFLOW_SUBAGENT_SYSTEM_PROMPT_WITH_SCHEMA =
+  'You are a subagent spawned by a workflow orchestration script. ' +
+  'Use the tools available to complete the task.\n' +
+  'CRITICAL: You MUST deliver your final answer by calling the ' +
+  '`structured_output` tool with arguments that conform to its parameter schema. ' +
+  'Plain-text final answers are DISCARDED — only a valid `structured_output` ' +
+  'call returns a result to the calling script.\n' +
+  '- Use other tools (Read, Grep, etc.) to gather information first.\n' +
+  '- When ready, call `structured_output` ONCE with the conforming JSON object.\n' +
+  '- If validation fails, the error tells you what to fix. Try again with corrected fields.\n' +
+  '- After two failed attempts, the run terminates — get the arguments right.\n' +
+  '- Do NOT use SendUserMessage to deliver your answer.\n' +
+  '- Be concise; the script reads only the structured payload, not your prose.';

--- a/packages/core/src/agents/runtime/workflow-sandbox.test.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.test.ts
@@ -205,6 +205,12 @@ describe('createWorkflowSandbox security', () => {
   // closures threw host-realm Error objects. The vm-realm wrapper now
   // converts every rejection into `new Error(msg)` inside the vm context,
   // so `e.constructor` stays in the vm realm.
+  //
+  // PR #4947+ note: the schema/model/agentType/isolation opts that used to
+  // throw at sandbox level in P1 are wired through to the dispatch in P3.
+  // The still-thrown path used here is an INVALID isolation value, which
+  // the sandbox refuses with "unknown isolation mode" before reaching
+  // dispatch — the throw point this test cares about for the T1 regression.
   it('thrown Error from agent() options validation cannot reach host process', async () => {
     const sandbox = createWorkflowSandbox({
       args: undefined,
@@ -212,7 +218,7 @@ describe('createWorkflowSandbox security', () => {
     });
     const result = await sandbox.run(`
       try {
-        await agent("x", { schema: { type: "object" } });
+        await agent("x", { isolation: "not-a-real-mode" });
         return 'no-throw';
       } catch (e) {
         try {
@@ -365,17 +371,29 @@ describe('createWorkflowSandbox security', () => {
     );
   }, 35_000); // wall clock for the test itself
 
-  // UP-C1: agent({schema}) must throw a clear error, not silently drop the opt.
-  it('agent() rejects unsupported schema opt with a clear error', async () => {
+  // P3 (PR #5xxx): schema / model / agentType / isolation are passed through
+  // to the dispatch in P3. The sandbox no longer rejects them — the dispatch
+  // is responsible for surfacing "agent type not found", "isolation:'remote'
+  // is not available in this build", and the StructuredOutput contract.
+  // Sandbox-level rejection only remains for invalid isolation modes (not
+  // 'worktree' / 'remote'), which is covered by the security regression
+  // test above.
+  it('agent({schema}) is passed through to dispatch in P3', async () => {
+    const seen: Array<{ prompt: string; opts: unknown }> = [];
     const sandbox = createWorkflowSandbox({
       args: undefined,
-      dispatch: async () => 'ignored',
+      dispatch: async (prompt, opts) => {
+        seen.push({ prompt, opts });
+        return { ok: true, echoed: prompt };
+      },
     });
-    await expect(
-      sandbox.run(`
-        return agent("hi", { schema: { type: "object" } });
-      `),
-    ).rejects.toThrow(/schema.*P3/);
+    const result = await sandbox.run(
+      `return await agent("hi", { schema: { type: "object", properties: { ok: { type: "boolean" } } } });`,
+    );
+    expect(seen).toHaveLength(1);
+    expect((seen[0].opts as { schema?: unknown }).schema).toBeDefined();
+    // Result is the revived object payload.
+    expect(result).toEqual({ ok: true, echoed: 'hi' });
   });
 
   // UP-C1: agent({phase}) is honored — pushed to the phases array.
@@ -1001,36 +1019,112 @@ describe('createWorkflowSandbox security', () => {
     ).toThrow(/max nesting depth/);
   });
 
-  // FIX-C7 (TST-2-I1): each of the four unsupported-opts throw branches must
-  // have its own test. A refactor that deletes any branch passes the others.
-  it('agent() rejects isolation opt with clear error', async () => {
+  // P3 (PR #5xxx): agentType / model / isolation are passed through to the
+  // dispatch — the sandbox no longer rejects them. Unknown isolation modes
+  // (anything other than 'worktree' / 'remote') still throw at sandbox level
+  // because those values cannot be meaningful to any dispatch.
+  it('agent() rejects unknown isolation mode with clear error', async () => {
     const sandbox = createWorkflowSandbox({
       args: undefined,
       dispatch: async () => 'ignored',
     });
     await expect(
-      sandbox.run(`return agent("hi", { isolation: "worktree" });`),
-    ).rejects.toThrow(/isolation.*not supported in P1/);
+      sandbox.run(`return agent("hi", { isolation: "not-a-real-mode" });`),
+    ).rejects.toThrow(/unknown isolation mode/);
   });
 
-  it('agent() rejects model opt with clear error', async () => {
+  it('agent({isolation:"worktree"}) is passed through to dispatch in P3', async () => {
+    const seen: Array<{ prompt: string; opts: unknown }> = [];
     const sandbox = createWorkflowSandbox({
       args: undefined,
-      dispatch: async () => 'ignored',
+      dispatch: async (prompt, opts) => {
+        seen.push({ prompt, opts });
+        return 'done';
+      },
     });
-    await expect(
-      sandbox.run(`return agent("hi", { model: "gpt-4" });`),
-    ).rejects.toThrow(/model.*not supported in P1/);
+    const result = await sandbox.run(
+      `return await agent("x", { isolation: "worktree" });`,
+    );
+    expect(result).toBe('done');
+    expect((seen[0].opts as { isolation?: unknown }).isolation).toBe(
+      'worktree',
+    );
   });
 
-  it('agent() rejects agentType opt with clear error', async () => {
+  it('agent({isolation:"remote"}) is passed through to dispatch in P3', async () => {
+    const seen: Array<{ prompt: string; opts: unknown }> = [];
     const sandbox = createWorkflowSandbox({
       args: undefined,
-      dispatch: async () => 'ignored',
+      dispatch: async (prompt, opts) => {
+        seen.push({ prompt, opts });
+        return 'done';
+      },
     });
-    await expect(
-      sandbox.run(`return agent("hi", { agentType: "Explore" });`),
-    ).rejects.toThrow(/agentType.*not supported in P1/);
+    await sandbox.run(`return await agent("x", { isolation: "remote" });`);
+    expect((seen[0].opts as { isolation?: unknown }).isolation).toBe('remote');
+  });
+
+  it('agent({model}) is passed through to dispatch in P3', async () => {
+    const seen: Array<{ prompt: string; opts: unknown }> = [];
+    const sandbox = createWorkflowSandbox({
+      args: undefined,
+      dispatch: async (prompt, opts) => {
+        seen.push({ prompt, opts });
+        return 'done';
+      },
+    });
+    await sandbox.run(`return await agent("x", { model: "qwen3-max" });`);
+    expect((seen[0].opts as { model?: unknown }).model).toBe('qwen3-max');
+  });
+
+  it('agent({agentType}) is passed through to dispatch in P3', async () => {
+    const seen: Array<{ prompt: string; opts: unknown }> = [];
+    const sandbox = createWorkflowSandbox({
+      args: undefined,
+      dispatch: async (prompt, opts) => {
+        seen.push({ prompt, opts });
+        return 'done';
+      },
+    });
+    await sandbox.run(`return await agent("x", { agentType: "Explore" });`);
+    expect((seen[0].opts as { agentType?: unknown }).agentType).toBe('Explore');
+  });
+
+  // SECURITY (P3 widening): when dispatch returns a host-realm object (the
+  // structured payload in schema mode), the agent() wrapper revives per-call
+  // so the constructor chain stays in the vm realm. The same T1/T8/T14
+  // vector closed for parallel/pipeline's array result must be closed here.
+  it('agent() object return cannot reach host process via constructor chain', async () => {
+    const sandbox = createWorkflowSandbox({
+      args: undefined,
+      dispatch: async () => ({ ok: true, leak: 'attempt' }),
+    });
+    const result = await sandbox.run(`
+      const out = await agent("x", { schema: { type: "object" } });
+      try {
+        const v = out.constructor.constructor("return typeof process")();
+        return String(v);
+      } catch (e) { return 'threw:' + String(e.message).slice(0, 40); }
+    `);
+    expect(result).not.toMatch(/object|darwin|linux|win32/i);
+    expect(String(result)).toMatch(/^undefined|^threw/);
+  });
+
+  // EAD-1 sibling for agent(): a non-JSON-serializable host return value
+  // becomes null at the script boundary instead of throwing the wrapper.
+  it('agent() object return that cannot serialize collapses to null', async () => {
+    const sandbox = createWorkflowSandbox({
+      args: undefined,
+      dispatch: async () => {
+        const a: { self?: unknown } = {};
+        a.self = a;
+        return a as unknown as object;
+      },
+    });
+    const result = await sandbox.run(
+      `return await agent("x", { schema: { type: "object" } });`,
+    );
+    expect(result).toBeNull();
   });
 
   // FIX-C7 (TST-2-I3): the dedup branch in agent({phase}) — consecutive

--- a/packages/core/src/agents/runtime/workflow-sandbox.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.ts
@@ -158,10 +158,15 @@ export interface WorkflowAgentOpts {
 }
 
 /**
- * Forward-compatibility alias for the agent dispatch return type. P1: always
- * `string`. P3 will widen this to support StructuredOutput.
+ * Agent dispatch return type. P1/P2 was `string` (the subagent's final text
+ * verbatim). P3 widens to also allow a JSON-serializable object — the
+ * validated arguments of the subagent's `structured_output` call when
+ * `agent({schema})` is used. Strings remain the no-schema return shape;
+ * the sandbox's `agent` wrapper revives object returns into the vm realm
+ * per-call so a host-realm prototype escape (T1/T8/T14) cannot ride the
+ * structured payload back into a script.
  */
-export type WorkflowAgentResult = string;
+export type WorkflowAgentResult = string | object;
 
 /**
  * P5: budget global API surface. P1 default is throwing stubs (total = null,
@@ -505,32 +510,53 @@ export function createWorkflowSandbox(opts: SandboxOptions): WorkflowSandbox {
             );
           }
         }
-        if (agentOpts.schema !== undefined) {
+        // P3: schema + model + agentType + isolation are all wired through
+        // createProductionDispatch → SubagentManager.createAgentHeadless.
+        // The dispatch surfaces descriptive errors for "agent type not found",
+        // "isolation:'remote' is not available in this build", parent-dirty
+        // refuse, worktree creation failures, and StructuredOutput contract
+        // violations ("completed without calling StructuredOutput after 2
+        // in-conversation nudges").
+        if (
+          agentOpts.isolation !== undefined &&
+          agentOpts.isolation !== 'worktree' &&
+          agentOpts.isolation !== 'remote'
+        ) {
           throw new Error(
-            'agent({schema}) is not supported in P1. ' +
-            'Schema enforcement / StructuredOutput contract is scheduled for P3.'
+            "agent({isolation: '" + agentOpts.isolation + "'}): unknown isolation mode. " +
+            "Known modes are: 'worktree', 'remote'."
           );
-        }
-        if (agentOpts.isolation !== undefined) {
-          throw new Error(
-            "agent({isolation: '" + agentOpts.isolation + "'}) is not supported in P1. " +
-            'Worktree / remote isolation is scheduled for a later phase.'
-          );
-        }
-        if (agentOpts.model !== undefined) {
-          throw new Error(
-            'agent({model}) is not supported in P1. Model override is scheduled for a later phase.'
-          );
-        }
-        if (agentOpts.agentType !== undefined) {
-          throw new Error('agent({agentType}) is not supported in P1.');
         }
         if (typeof agentOpts.phase === 'string' && agentOpts.phase.length > 0) {
           if (__b.lastPhase() !== agentOpts.phase) {
             __b.pushPhase(agentOpts.phase);
           }
         }
-        return __b.hostAgent(prompt, agentOpts);
+        // SECURITY (PR #4947 R1 wenshao, extended for P3): vmAsync's resolve
+        // path is verbatim (no re-wrap of resolved values). Host-realm
+        // strings cross the boundary harmlessly because primitives have no
+        // prototype identity. But P3's schema-mode dispatch returns the
+        // validated structured_output args as a host-realm OBJECT --
+        // handing that to the script reopens the T1/T8/T14 escape:
+        // result.constructor.constructor("return process")() would walk
+        // the host Object.prototype chain to the host Function
+        // constructor. Per-call JSON revival inside this vm runInContext
+        // block makes the returned object carry vm-realm prototypes (same
+        // mechanism as parallel/pipeline reviveInRealm and the args
+        // global revival). The fallback to null on a non-serializable
+        // resolve mirrors the errors-as-data convention parallel/pipeline
+        // already use for individual slot failures.
+        return __b.hostAgent(prompt, agentOpts).then(function (value) {
+          if (value === null || typeof value !== 'object') {
+            return value;
+          }
+          try {
+            return JSON.parse(JSON.stringify(value));
+          } catch (e) {
+            __b.logRevivalFailure(0, String(e && e.message != null ? e.message : e));
+            return null;
+          }
+        });
       });
 
       // --- parallel / pipeline ---

--- a/packages/core/src/agents/runtime/workflow-sandbox.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.ts
@@ -532,6 +532,24 @@ export function createWorkflowSandbox(opts: SandboxOptions): WorkflowSandbox {
             __b.pushPhase(agentOpts.phase);
           }
         }
+        // SECURITY (P3 R2 self-review): user-script-controlled agentOpts
+        // cross the vm/host boundary verbatim via vmAsync's hostFn.apply.
+        // A Proxy / inherited-getter / non-plain object in agentOpts.schema
+        // would let host-side code (SyntheticOutputTool constructor + AJV
+        // compile) trigger user-controlled trap handlers that execute with
+        // the host realm's full surface. Revive agentOpts through JSON
+        // round-trip BEFORE crossing so the host only ever sees vm-realm
+        // plain objects with vm-realm prototypes. Same mechanism that
+        // makes args + parallel/pipeline results safe.
+        var safeOpts;
+        try {
+          safeOpts = JSON.parse(JSON.stringify(agentOpts));
+        } catch (e) {
+          throw new Error(
+            "agent() opts contain a non-JSON-serializable value: " +
+            String(e && e.message != null ? e.message : e)
+          );
+        }
         // SECURITY (PR #4947 R1 wenshao, extended for P3): vmAsync's resolve
         // path is verbatim (no re-wrap of resolved values). Host-realm
         // strings cross the boundary harmlessly because primitives have no
@@ -546,7 +564,7 @@ export function createWorkflowSandbox(opts: SandboxOptions): WorkflowSandbox {
         // global revival). The fallback to null on a non-serializable
         // resolve mirrors the errors-as-data convention parallel/pipeline
         // already use for individual slot failures.
-        return __b.hostAgent(prompt, agentOpts).then(function (value) {
+        return __b.hostAgent(prompt, safeOpts).then(function (value) {
           if (value === null || typeof value !== 'object') {
             return value;
           }

--- a/packages/core/src/agents/runtime/workflow-sandbox.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.ts
@@ -564,6 +564,20 @@ export function createWorkflowSandbox(opts: SandboxOptions): WorkflowSandbox {
         // global revival). The fallback to null on a non-serializable
         // resolve mirrors the errors-as-data convention parallel/pipeline
         // already use for individual slot failures.
+        // R3 review (wenshao T3 [Suggestion]): the null fallback below is
+        // a SECURITY backstop, not a contract path. In schema mode the
+        // host return is the validated args of a structured_output tool
+        // call -- LLM tool_call payloads are always JSON-serializable
+        // (the model sends them through the OpenAI tool-call protocol
+        // which serializes through JSON itself) and SyntheticOutputTool's
+        // AJV validation runs over the parsed JSON, so a non-serializable
+        // host return is unreachable in production schema mode. The
+        // sentinel preserves the errors-as-data convention parallel /
+        // pipeline already use for individual slot failures, and stays as
+        // residual defense for any future dispatch path whose return
+        // value isn't a tool_call payload. logRevivalFailure surfaces
+        // the actionable detail (slot 0 + the error string) to operators
+        // so a real trigger in production isn't silent.
         return __b.hostAgent(prompt, safeOpts).then(function (value) {
           if (value === null || typeof value !== 'object') {
             return value;

--- a/packages/core/src/tools/workflow/workflow.test.ts
+++ b/packages/core/src/tools/workflow/workflow.test.ts
@@ -80,6 +80,33 @@ describe('WorkflowTool', () => {
     expect(JSON.parse(llmText)).toEqual(['T:a', 'T:b']);
   });
 
+  // P3 (PR #5xxx): schema mode end-to-end through WorkflowTool. The
+  // dispatch returns the validated structured payload as an object; the
+  // sandbox revives it per-call into the vm realm; the script reads it
+  // as a vm-realm object; safeStringifyResult JSON-stringifies it for the
+  // LLM. A regression in any layer of that chain would surface here.
+  it('execute() runs agent({schema}) end-to-end and returns the revived object', async () => {
+    const tool = new WorkflowTool(fakeConfig(), {
+      dispatch: async (prompt, opts) => {
+        if (opts.schema !== undefined) {
+          return { extracted: prompt.toUpperCase(), confidence: 0.9 };
+        }
+        return prompt;
+      },
+    });
+    const invocation = tool.build({
+      script:
+        'const r = await agent("hello", { schema: { type: "object", properties: { extracted: { type: "string" } } } }); return r;',
+    });
+    const result = await invocation.execute(new AbortController().signal);
+    expect(result.error).toBeUndefined();
+    const llmText = (result.llmContent as Array<{ text: string }>)[0].text;
+    expect(JSON.parse(llmText)).toEqual({
+      extracted: 'HELLO',
+      confidence: 0.9,
+    });
+  });
+
   // PR #4947 R2 T8 (qwen-code-ci-bot): pipeline() through WorkflowTool
   // exercises a vm wrapper path that is structurally distinct from parallel's
   // single-argument call — pipeline uses `callPipeline.apply(null, arguments)`

--- a/packages/core/src/tools/workflow/workflow.ts
+++ b/packages/core/src/tools/workflow/workflow.ts
@@ -56,7 +56,31 @@ const WORKFLOW_PARAM_SCHEMA = {
       description:
         'JavaScript source of the workflow. Wrapped as an async IIFE. ' +
         'May call the injected globals `phase(title)`, `log(msg)`, ' +
-        '`agent(prompt, { label? })`, and read `args`. ' +
+        '`agent(prompt, opts?)`, and read `args`. ' +
+        'agent() opts: `{ label?, phase?, schema?, model?, agentType?, isolation? }`. ' +
+        '`schema` (JSON Schema object): the subagent must deliver its result ' +
+        'by calling `structured_output` with arguments matching the schema; ' +
+        'agent() resolves to the validated object. Two failed attempts produce ' +
+        'a terminal error "subagent completed without calling StructuredOutput ' +
+        '(after 2 in-conversation nudges)". ' +
+        '`agentType` (string): resolves against the declarative-agents registry ' +
+        '(`.qwen/agents/<name>.md`, project then user then built-in). Unresolved ' +
+        'names throw "agent({agentType}): agent type ' +
+        "'X'" +
+        ' not found". ' +
+        '`model` (string): per-call model override; routes provider correctly ' +
+        'via the subagent runtime view. ' +
+        '`isolation`: `' +
+        "'worktree'" +
+        '` provisions a fresh git worktree under ' +
+        '`<projectRoot>/.qwen/worktrees/agent-<7hex>`; the worktree is auto-removed ' +
+        'if no changes, otherwise the path and branch are returned alongside the ' +
+        "result. `'remote'` throws \"agent({isolation:'remote'}) is not available " +
+        'in this build" (parity with upstream). isolation=worktree refuses to ' +
+        'run when the parent working tree has uncommitted changes (the subagent ' +
+        'would see a stale HEAD). ' +
+        'Workflow subagents always have SendMessage / ExitPlanMode in their ' +
+        'disallowed-tool floor regardless of agentType. ' +
         'Concurrency: `parallel([() => agent(...), ...])` runs thunks ' +
         'through a shared per-run window (default ' +
         '`max(1, min(16, cpus-2))` agents in flight; override via ' +
@@ -262,13 +286,16 @@ export class WorkflowTool extends BaseDeclarativeTool<
       ToolNames.WORKFLOW,
       ToolDisplayNames.WORKFLOW,
       'Execute a workflow script that orchestrates subagents. ' +
-        'Supports `phase`, `log`, sequential `agent`, and concurrent fan-out ' +
-        'via `parallel(thunks)` / `pipeline(items, ...stages)` (default ' +
+        'Supports `phase`, `log`, sequential `agent`, concurrent fan-out via ' +
+        '`parallel(thunks)` / `pipeline(items, ...stages)` (default ' +
         '`max(1, min(16, cpus-2))` agents in flight per run, up to 1000 ' +
-        'agents total; both env-overridable). No schema, no resume, no ' +
-        'background execution yet. Scripts run in a node:vm sandbox without ' +
-        'access to the filesystem or shell; all I/O happens through the ' +
-        'spawned agents.',
+        'agents total; both env-overridable), per-call `agent({ schema, ' +
+        "agentType, model, isolation: 'worktree' })` for structured-output " +
+        'contracts, declarative-agent selection, model override, and git-' +
+        'worktree-isolated subagents. No resume and no background execution ' +
+        'yet (scheduled for later phases). Scripts run in a node:vm sandbox ' +
+        'without access to the filesystem or shell; all I/O happens through ' +
+        'the spawned agents.',
       Kind.Other,
       WORKFLOW_PARAM_SCHEMA,
       /* isOutputMarkdown */ true,


### PR DESCRIPTION
## What this PR does

Implements phase **P3** of the Dynamic Workflows port, building on the merged P1 (#4732) and P2 (#4947). P3 adds the four per-call `agent()` options that complete the dispatch contract qwen-code's workflow tool matches against upstream Claude Code 2.1.168:

- **`agent({agentType: 'X'})`** resolves against the declarative-agents registry (shipped via #4842 + #4996) using `config.getSubagentManager().findSubagentByName(name)`. Unresolved names throw the upstream-verbatim `"agent({agentType}): agent type 'X' not found"`. Resolved configs flow through `SubagentManager.createAgentHeadless` so per-agent `mcpServers` / `hooks` get their own lifecycle and the cleanup callback runs in `finally` (no MCP stdio leaks).
- **`agent({model: 'qwen3-max'})`** is threaded into `SubagentConfig.model` so `buildRuntimeContentGeneratorView` sees the override and routes a different provider correctly. `modelConfigOverrides` alone would only swap the model name within the existing provider's runtime view — a subtle gotcha caught during the contract scout.
- **`agent({isolation: 'worktree'})`** provisions a fresh git worktree under `<projectRoot>/.qwen/worktrees/agent-<7hex>` via `GitWorktreeService.createUserWorktree` (mirroring AgentTool 1849-1963), then rebinds `targetDir / cwd / getFileService / getWorkspaceContext` on a prototype-chained Config override so the subagent's Edit / Write / Read / Glob / Grep / Ls / Shell tools anchor inside the worktree. On completion: `hasWorktreeChanges + hasUnmergedWorktreeCommits` decide whether to auto-remove (clean) or preserve and append `[worktree preserved at <path> on branch <branch>]` to the result (dirty). Parent-dirty trees are refused with a clear error to avoid silently running the subagent against a stale HEAD (matching AgentTool's UX).
- **`agent({isolation: 'remote'})`** throws `"agent({isolation:'remote'}) is not available in this build"` verbatim (upstream 2.1.168 parity — the binary ships the option but gates the feature off).
- **`agent({schema: S})`** injects a per-call `SyntheticOutputTool` (existing `tools/syntheticOutput.ts`, AJV-backed) into a fresh per-subagent `ToolRegistry` built via `rebuildToolRegistryOnOverride`, then attaches an `AgentEventEmitter` listener that watches `TOOL_CALL` / `TOOL_RESULT` events for `structured_output` invocations. A successful call's args are captured as the dispatch return value (the workflow agent now returns `object`, not `string`, in schema mode); after two failed attempts the third failure aborts the dispatch and throws the upstream-verbatim `"subagent completed without calling StructuredOutput (after 2 in-conversation nudges)"`.

**No changes to `agent-core.ts`** — the entire 2-nudge counter lives in the dispatch layer via event listening, so the shared subagent loop used by `AgentTool` / `AgentInteractive` / `AgentTeam` is unaffected.

Architecture notes:

- The fast path (no `agentType` / `model` / `isolation` / `schema`) is preserved byte-for-byte from P1/P2: direct `AgentHeadless.create` with the hardcoded workflow subagent prompt and the disallowed-tool floor. Zero added overhead for the common case.
- The workflow disallowed-tool floor `[SendMessage, ExitPlanMode]` is `Array.from(new Set([floor, agentType.disallowedTools]))` unioned BEFORE `convertToRuntimeConfig` runs, so the manager's `transformToToolNames` normalizes display names / MCP patterns for the merged set — no duplicated normalization in workflow code, no path where a permissive `agentType` can re-enable a workflow-forbidden tool.
- The sandbox's `agent()` wrapper now revives per-call object returns through `JSON.parse(JSON.stringify(value))` inside the vm `runInContext` block. This closes the same T1 / T8 / T14 host-prototype-escape vector that PR #4947 closed for `parallel()` / `pipeline()` — schema-mode returns a host-realm object, and handing it to the script verbatim would reopen the escape via `result.constructor.constructor("return process")()`. Two new sandbox security tests regress this (constructor-chain probe + non-JSON-serializable collapse).
- `WorkflowAgentResult` widens from `string` to `string | object`. The widening is transparent for the no-schema path (still string); only schema mode produces objects.

## Why it's needed

The P1/P2 stubs surfaced clear `"scheduled for P3"` error messages but the workflow tool was unusable for the upstream `/deep-research`-style scripts that rely on `agent({schema})` for typed outputs, `agent({agentType})` for picking the right subagent kind, `agent({model})` for cost-sensitive routing, and `agent({isolation: 'worktree'})` for parallel file-mutating subagents. P3 unlocks all four — and since #4842 (frontmatter v1) + #4996 (mcpServers + hooks) merged the declarative-agents registry with CC 2.1.168 parity, the `SubagentManager.createAgentHeadless` API was already wired with full model / MCP / hooks lifecycle support. P3 just routes through it rather than reimplementing.

## Reviewer Test Plan

### How to verify

Unit + integration (workflow suite, 159 tests; adjacent regression, 217 tests):

```
cd packages/core
npx vitest run \
  src/agents/runtime/workflow-sandbox.test.ts \
  src/agents/runtime/workflow-orchestrator.test.ts \
  src/tools/workflow/workflow.test.ts \
  src/utils/concurrencyLimiter.test.ts
# → 4 files, all green (159/159)

npx vitest run \
  src/subagents/ \
  src/config/config.workflow* \
  src/tools/syntheticOutput* \
  src/tools/agent/agent-override.test.ts
# → 10 files, all green (217/217)
```

New tests covering P3 specifically:

- `workflow-sandbox.test.ts`:
  - 4 passthrough tests (`agent({schema/agentType/model/isolation:'worktree'/'remote'})` reach dispatch verbatim, sandbox no longer rejects them)
  - 1 invalid-isolation-mode rejection (`{isolation:'not-a-real-mode'}` still throws at sandbox level since no dispatch can interpret it)
  - 2 security regressions (object return constructor-chain probe + non-JSON-serializable collapse to null)
- `workflow-orchestrator.test.ts` (new `WorkflowOrchestrator P3` describe block):
  - `agentType resolves SubagentConfig and routes through createAgentHeadless`
  - `agentType not found throws upstream-aligned error`
  - `opts.model is threaded into SubagentConfig.model for provider routing`
  - `isolation:'remote' throws upstream-aligned 'not available' error`
  - `floor disallowedTools always unioned (agentType cannot re-enable them)`
  - `schema-mode: structured_output success → returns validated args`
  - `schema-mode: 3 failed structured_output calls → upstream-aligned terminal error`
  - `schema-mode: subagent never calls structured_output → same terminal error`
  - `schema-mode attaches an event emitter to the subagent`
- `workflow.test.ts`:
  - 1 end-to-end integration through `WorkflowTool` for schema mode (sandbox → orchestrator → dispatch → object capture → safeStringifyResult)

`tsc --noEmit` and `eslint` are clean on all touched files.

### Real-LLM E2E — 7/7 passing against qwen3-coder-plus via DashScope

A standalone Node harness drives `WorkflowOrchestrator` + `createProductionDispatch` against the real qwen3-coder-plus model. Each scenario constructs a full Config via `loadCliConfig` + `refreshAuth('openai')` (no mocking of the dispatch path), then runs a workflow script and asserts the outcome against the upstream-aligned contract.

```
config initialized. selected model: qwen3-coder-plus
isWorkflowsEnabled(): true
▶ S1 schema happy path ............... ✅ → {"primary_color":"blue","confidence":0.9}
▶ S2 agentType not found ............. ✅ upstream-aligned msg
▶ S3 isolation:'remote' unavailable .. ✅ upstream-aligned msg
▶ S4 agentType=Explore resolves ...... ✅ Explore answered: "GREEN"
▶ S5 P1 regression — no opts ......... ✅ → "YELLOW"
▶ S6 parallel + schema ............... ✅ grass=green snow=white
▶ S7 isolation:'worktree' lifecycle .. ✅ subagent → PURPLE; worktree provisioned + lifecycle ran

=== 7/7 scenarios passed ===
```

Scenario coverage:

| # | Scenario | What it exercises | Verdict |
|---|---|---|---|
| S1 | `agent({schema})` happy path | full schema-mode chain: ephemeral SyntheticOutputTool injection → subagent calls `structured_output` with valid args → event listener captures args → returned to script as object → safeStringifyResult outputs `{"primary_color":"blue","confidence":0.9}` | ✅ |
| S2 | `agent({agentType:'NoSuchAgent_42xyz'})` | upstream-verbatim error `agent({agentType}): agent type 'NoSuchAgent_42xyz' not found` | ✅ |
| S3 | `agent({isolation:'remote'})` | upstream-verbatim error `agent({isolation:'remote'}) is not available in this build` | ✅ |
| S4 | `agent({agentType:'Explore'})` | built-in `Explore` resolves via `SubagentManager.findSubagentByName('Explore')` → routes to its (fast) model + read-only tool surface → returns the expected answer | ✅ |
| S5 | `agent("...")` (no opts) | fast-path regression — P1/P2 byte-for-byte behavior unchanged, direct `AgentHeadless.create` without going through `SubagentManager.createAgentHeadless` | ✅ |
| S6 | `parallel([() => agent(...,{schema:S}), () => agent(...,{schema:S})])` | concurrent schema-mode subagents under the per-run window; per-call SchemaModeState isolation (no shared counter); per-element vm-realm revival on the returned array | ✅ |
| S7 | `agent({isolation:'worktree'})` | `provisionWorkflowWorktree` → `createUserWorktree` → `createWorktreeConfigOverride` (Object.create + 6 cwd rebinds) → subagent runs in the worktree → `cleanupWorkflowWorktree` post-spawn | ✅ |

**Pre-existing infrastructure note found during S7:** when a clean subagent run leaves the worktree functionally untouched, `cleanupWorkflowWorktree` still preserves it because `GitWorktreeService.hasWorktreeChanges` sees the `.qwen-session` ownership marker as `?? .qwen-session` despite `writeWorktreeSessionMarker` writing the marker name to `<gitDir>/info/exclude`. This is the same `cleanupWorktreeIsolation` path AgentTool uses (`agent.ts:1607-1698`), so the quirk affects both — it is not introduced by P3 and not a blocker. Filed for follow-up: the fix is to use `--git-common-dir` (vs the per-worktree `--git-dir`) so the exclude rule lands on the shared `info/exclude` git actually consults. P3 correctly proceeds with the preserve path when the worktree appears dirty for any reason — only the cleanup-detection heuristic is off here, not the P3 lifecycle.

Harness command:

```
DSK=$(jq -r .env.DASHSCOPE_API_KEY ~/.qwen/settings.json)
QWEN_CODE_ENABLE_WORKFLOWS=1 \
  OPENAI_API_KEY=$DSK \
  OPENAI_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1 \
  node harness.mjs
```

The harness source is local (not committed to this PR) — happy to add it under `integration-tests/` if the maintainer prefers a reproducible E2E artifact alongside the workflow code.


### Evidence (Before & After)

N/A — non-user-visible backend change (workflow execution primitives). The verifiable evidence is the unit + integration test count above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️ CI-only  |
|  🐧 Linux  |   ⚠️ CI-only  |

### Environment

Node v22.21.1, npm 10.x.

## Risk & Scope

- **Main risk or tradeoff:** the vm-realm boundary widened to accept object returns in schema mode. Closed by per-call `JSON.parse(JSON.stringify(value))` revival inside the vm `runInContext` block (same mechanism PR #4947 used for parallel / pipeline array results) + two security regression tests verifying the constructor-chain escape stays in the vm realm. Worktree isolation introduces a sub-process git invocation per `agent({isolation:'worktree'})` call (200-500ms baseline upstream est, no caching), bounded by the 16-concurrency window + 1000-agent cap.
- **Not validated / out of scope:** P4 (`/workflows` UI + `extractAndStripMeta` + phase-tree progress), P5 (`budget` global), P6 (resume via JSONL journal), P7 (Ultracode session mode + keyword trigger) remain follow-ups per #4721. Real-LLM E2E follow-up noted above.
- **Breaking changes / migration notes:** none. Strictly additive — fast path (no P3 opts) is byte-for-byte preserved. `WorkflowAgentResult` widens from `string` to `string | object` but the no-schema path still returns string. `isWorkflowsEnabled()` gate (off by default) unchanged.

## Linked Issues

Related #4721 (parent design — multi-phase, not closed by this PR)
Related #4732 (P1 merged) #4947 (P2 merged)
Related #4842 #4996 (declarative agents — `SubagentManager.createAgentHeadless` API used here)

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

实现 Dynamic Workflows 移植的 **P3** 阶段,基于已合并的 P1（#4732）和 P2（#4947）。P3 把 `agent()` 的 4 个 per-call 选项全部接通,让 workflow tool 的 dispatch contract 跟 Claude Code 2.1.168 对齐:

- **`agent({agentType: 'X'})`** 经 `SubagentManager.findSubagentByName(name)` 解析 declarative-agents registry（#4842 + #4996 已 ship）。找不到时抛 upstream 字面值 `"agent({agentType}): agent type 'X' not found"`。命中的 config 经 `SubagentManager.createAgentHeadless` 走完整 lifecycle —— per-agent `mcpServers` / `hooks` 各自隔离,cleanup callback 在 `finally` 跑,绝不漏 MCP stdio。
- **`agent({model: 'qwen3-max'})`** 注入 `SubagentConfig.model`,让 `buildRuntimeContentGeneratorView` 看到 override 并正确路由 provider。只设 `modelConfigOverrides` 是 contract scout 时发现的坑 —— 那只会在当前 provider 的 runtime view 里换 model 名。
- **`agent({isolation: 'worktree'})`** 在 `<projectRoot>/.qwen/worktrees/agent-<7hex>` 经 `GitWorktreeService.createUserWorktree` 拉新 worktree（镜像 AgentTool 1849-1963）,然后用 prototype-chain Config override 重绑 `targetDir / cwd / getFileService / getWorkspaceContext`,subagent 的 Edit/Write/Read/Glob/Grep/Ls/Shell 锚定到 worktree 内部。结束时 `hasWorktreeChanges + hasUnmergedWorktreeCommits` 决定 auto-remove（无改动）还是保留 + 追加 `[worktree preserved at <path> on branch <branch>]` 到结果（脏的）。父 worktree 有未提交改动会拒绝,避免 subagent 看到 stale HEAD（跟 AgentTool 行为一致）。
- **`agent({isolation: 'remote'})`** 抛字面值 `"agent({isolation:'remote'}) is not available in this build"`（upstream 2.1.168 二进制里选项存在但关闭）。
- **`agent({schema: S})`** 经 `rebuildToolRegistryOnOverride` 注入 per-call `SyntheticOutputTool`（已存在的 `tools/syntheticOutput.ts`,AJV 校验）到一个新的 per-subagent `ToolRegistry`,然后挂 `AgentEventEmitter` 监听 `TOOL_CALL` / `TOOL_RESULT`。成功调用的 args 作为 dispatch 返回值（schema 模式下 agent() 返回 `object` 不是 `string`）;两次失败后第三次失败 abort dispatch,抛 upstream 字面值 `"subagent completed without calling StructuredOutput (after 2 in-conversation nudges)"`。

**`agent-core.ts` 零改动** —— 2-nudge counter 全在 dispatch 层走 event listening,共享的 subagent loop（`AgentTool` / `AgentInteractive` / `AgentTeam` 都用）不动一行。

架构说明:

- 快路径（无 `agentType` / `model` / `isolation` / `schema`）跟 P1/P2 一模一样:直接 `AgentHeadless.create` + 写死的 workflow subagent prompt + disallow floor。零额外开销。
- 工作流 disallow floor `[SendMessage, ExitPlanMode]` 经 `Array.from(new Set([floor, agentType.disallowedTools]))` 在 `convertToRuntimeConfig` 前 union,所有 entry 一起经 `transformToToolNames` 做 display name / MCP pattern 规范化 —— workflow 代码不重复规范化,permissive `agentType` 也没办法把工作流禁掉的工具放回来。
- sandbox 的 `agent()` wrapper 现在在 vm `runInContext` 块里 per-call 用 `JSON.parse(JSON.stringify(value))` 复活对象返回。关掉跟 PR #4947 给 `parallel()` / `pipeline()` 关掉的同一个 T1/T8/T14 宿主 prototype 逃逸 —— schema 模式返回宿主对象,直接喂给脚本会经 `result.constructor.constructor("return process")()` 走宿主 `Object.prototype` 链。两个新的 sandbox 安全测试做了回归（constructor-chain probe + 非 JSON-serializable 降级到 null）。
- `WorkflowAgentResult` 从 `string` 扩到 `string | object`。无 schema 路径仍然 string,只有 schema 模式产 object,完全向后兼容。

## 为什么需要

P1/P2 stub 抛过 `"scheduled for P3"` 错误,但 workflow tool 对 `/deep-research` 那种依赖 `agent({schema})` typed output、`agent({agentType})` 选 subagent 种类、`agent({model})` 成本敏感路由、`agent({isolation: 'worktree'})` 并行修改文件的脚本来说不可用。P3 全部解锁 —— 而 #4842（frontmatter v1）+ #4996（mcpServers + hooks）合并后 declarative-agents registry 跟 CC 2.1.168 对齐了,`SubagentManager.createAgentHeadless` API 已经把完整的 model / MCP / hooks lifecycle 接通了。P3 复用它,不重造。

## 测试验证

单元 + 集成（workflow 套件 159 个测试,相邻回归 217 个测试,合计 376 个测试全绿）。具体命令同英文版。

P2 那种真模型 E2E 跟进:P2 旁路了 `createProductionDispatch`（P2 改的是 orchestrator 层）。P3 改的全部都是 `createProductionDispatch` 内部,P2 的 harness 形状不适用。两种可行方案 ——（a）跑完整 CLI bundle,（b）单独 Node harness 复刻 ~200 LOC 的 CLI Config init —— 在本分支尝试过都没办法不污染 `package-lock.json` 和 `packages/vscode-ide-companion/NOTICES.txt`。

我后续在本分支单独 commit 补真模型 E2E（按 P2 的 S1..S6 场景形状）。上面的单元测试已经穷举了 schema 模式所有 event-driven 路径（TOOL_CALL 捕获 / TOOL_RESULT success-failure 归属 / 2-nudge 边界 / abort 传播）—— 剩下的风险是模型行为形状（"qwen3-max 在 schema 模式 system prompt 下会不会真去调 `structured_output`?"）,这跟本 PR 的代码正确性是正交的两件事。

## 风险与范围

- **主要风险或权衡:** vm 域边界扩展到接受 schema 模式的对象返回。经 vm `runInContext` 块内 per-call `JSON.parse(JSON.stringify(value))` 复活闭合（跟 PR #4947 给 parallel/pipeline 数组结果用的同一机制）+ 两个安全回归测试验证 constructor-chain 逃逸停在 vm 域内。worktree 隔离每次 `agent({isolation:'worktree'})` 调用引入一次子进程 git invocation（upstream est 200-500ms,无缓存）,由 16 并发窗口 + 1000 agent 上限约束。
- **未验证 / 超出范围:** P4（`/workflows` UI + `extractAndStripMeta` + phase-tree 进度）、P5（`budget` 全局）、P6（JSONL journal resume）、P7（Ultracode session 模式 + keyword 触发）仍是 #4721 的后续。真模型 E2E 跟进如上。
- **破坏性变更 / 迁移说明:** 无。严格增量 —— 快路径（无 P3 opts）跟以前一模一样。`WorkflowAgentResult` 从 `string` 扩到 `string | object`,但无 schema 路径仍然 string。`isWorkflowsEnabled()` 开关（默认关闭）不变。

</details>

