### PR TITLE
fix(core): hard-stop repeated identical tool calls

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -49,6 +49,7 @@ import {
   Turn,
   type ServerGeminiStreamEvent,
 } from './turn.js';
+import { LoopType } from '../telemetry/types.js';
 
 vi.mock('../utils/retry.js', () => ({
   retryWithBackoff: vi.fn(async (fn) => await fn()),
@@ -270,6 +271,8 @@ vi.mock('../telemetry/loggers.js', () => ({
   logChatCompression: vi.fn(),
   logNextSpeakerCheck: vi.fn(),
   logApiRequest: vi.fn(),
+  logLoopDetected: vi.fn(),
+  logLoopDetectionDisabled: vi.fn(),
 }));
 
 const { mockClientDebugLogger } = vi.hoisted(() => ({
@@ -4096,7 +4099,7 @@ hello
 
       // Force LoopDetector to trip on the first event.
       const loopDetector = client['loopDetector'];
-      vi.spyOn(loopDetector, 'addAndCheck').mockReturnValue(true);
+      vi.spyOn(loopDetector, 'addAndCheckHeuristicLoops').mockReturnValue(true);
       vi.spyOn(loopDetector, 'getLastLoopType').mockReturnValue(null);
 
       mockTurnRunFn.mockReturnValue(
@@ -6012,14 +6015,15 @@ Other open files:
       expect(mockCheckNextSpeaker).not.toHaveBeenCalled();
     });
 
-    it('does not run loop checks when skipLoopDetection is true', async () => {
+    it('keeps deterministic tool-call checks when skipLoopDetection is true', async () => {
       // Arrange
       // Ensure config returns true for skipLoopDetection
       vi.spyOn(client['config'], 'getSkipLoopDetection').mockReturnValue(true);
 
       // Replace loop detector with spies
       const ldMock = {
-        addAndCheck: vi.fn().mockReturnValue(false),
+        addAndCheckDeterministicToolCallLoop: vi.fn().mockReturnValue(false),
+        addAndCheckHeuristicLoops: vi.fn().mockReturnValue(false),
         reset: vi.fn(),
       };
       // @ts-expect-error override private for testing
@@ -6047,8 +6051,49 @@ Other open files:
         // consume stream
       }
 
-      // Assert - loop detection methods should not be called when skipLoopDetection is true
-      expect(ldMock.addAndCheck).not.toHaveBeenCalled();
+      expect(ldMock.addAndCheckDeterministicToolCallLoop).toHaveBeenCalledTimes(
+        2,
+      );
+      expect(ldMock.addAndCheckHeuristicLoops).not.toHaveBeenCalled();
+    });
+
+    it('hard-stops identical tool calls even when skipLoopDetection is true', async () => {
+      vi.spyOn(client['config'], 'getSkipLoopDetection').mockReturnValue(true);
+
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          for (let i = 0; i < 5; i++) {
+            yield {
+              type: GeminiEventType.ToolCallRequest,
+              value: {
+                callId: `repeat-${i}`,
+                name: 'run_shell_command',
+                args: { command: 'echo repeated' },
+              },
+            };
+          }
+        })(),
+      );
+
+      const mockChat: Partial<GeminiChat> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+      };
+      client['chat'] = mockChat as GeminiChat;
+
+      const events = await fromAsync(
+        client.sendMessageStream(
+          [{ text: 'repeat a tool' }],
+          new AbortController().signal,
+          'prompt-id-skip-loop-identical',
+        ),
+      );
+
+      expect(events.at(-1)).toEqual({
+        type: GeminiEventType.LoopDetected,
+        value: { loopType: LoopType.CONSECUTIVE_IDENTICAL_TOOL_CALLS },
+      });
+      expect(events).toHaveLength(5);
     });
 
     describe('retry sendMessageType', () => {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -111,7 +111,7 @@ import { promptIdContext } from '../utils/promptIdContext.js';
 import { retryWithBackoff, isUnattendedMode } from '../utils/retry.js';
 import { subagentNameContext } from '../utils/subagentNameContext.js';
 import { escapeSystemReminderTags } from '../utils/xml.js';
-import { ApiRetryEvent } from '../telemetry/types.js';
+import { ApiRetryEvent, LoopType } from '../telemetry/types.js';
 import { logApiRetry } from '../telemetry/loggers.js';
 
 // Hook types and utilities
@@ -321,10 +321,7 @@ export class GeminiClient {
     this.initializedSessionId = sessionId;
 
     // Clean up stale tool result files from previous sessions (fire-and-forget)
-    void cleanupOldToolResults(
-      Storage.getGlobalTempDir(),
-      24 * 60 * 60 * 1000,
-    );
+    void cleanupOldToolResults(Storage.getGlobalTempDir(), 24 * 60 * 60 * 1000);
   }
 
   /**
@@ -658,10 +655,7 @@ export class GeminiClient {
     debugLogger.debug('[FILE_READ_CACHE] clear after resetChat');
     this.config.getFileReadCache().clear();
     // Clean up old tool result overflow files on /clear
-    void cleanupOldToolResults(
-      Storage.getGlobalTempDir(),
-      24 * 60 * 60 * 1000,
-    );
+    void cleanupOldToolResults(Storage.getGlobalTempDir(), 24 * 60 * 60 * 1000);
     this.config.getBaseLlmClient().clearPerModelGeneratorCache();
     // Abort any in-flight auto-memory recall so the stale controller
     // does not leak into the next session.
@@ -2096,24 +2090,40 @@ export class GeminiClient {
           didUpdateIdeContextState = true;
         }
 
-        if (!this.config.getSkipLoopDetection()) {
-          if (this.loopDetector.addAndCheck(event)) {
-            const loopType = this.loopDetector.getLastLoopType();
-            yield {
-              type: GeminiEventType.LoopDetected,
-              ...(loopType && { value: { loopType } }),
-            };
-            if (arenaAgentClient) {
-              await arenaAgentClient.reportError('Loop detected');
-            }
-            this.lastApiCompletionTimestamp = Date.now();
-            if (isTopLevelInteraction)
-              endInteractionSpan('error', { errorMessage: 'loop detected' });
-            // finally cleanup catches this, but cancel explicitly to match
-            // the cleanup pattern at other early-return sites.
-            this.cancelPendingMemoryPrefetch();
-            return turn;
+        const deterministicToolCallLoop =
+          this.loopDetector.addAndCheckDeterministicToolCallLoop(event);
+        const heuristicLoop =
+          !deterministicToolCallLoop &&
+          !this.config.getSkipLoopDetection() &&
+          this.loopDetector.addAndCheckHeuristicLoops(event);
+        if (deterministicToolCallLoop || heuristicLoop) {
+          const loopType = this.loopDetector.getLastLoopType();
+          if (
+            event.type === GeminiEventType.ToolCallRequest &&
+            loopType === LoopType.CONSECUTIVE_IDENTICAL_TOOL_CALLS
+          ) {
+            const repeatedCount =
+              this.loopDetector.getConsecutiveToolCallCount();
+            const repeatedStartIndex = Math.max(
+              0,
+              turn.pendingToolCalls.length - repeatedCount,
+            );
+            turn.pendingToolCalls.splice(repeatedStartIndex);
           }
+          yield {
+            type: GeminiEventType.LoopDetected,
+            ...(loopType && { value: { loopType } }),
+          };
+          if (arenaAgentClient) {
+            await arenaAgentClient.reportError('Loop detected');
+          }
+          this.lastApiCompletionTimestamp = Date.now();
+          if (isTopLevelInteraction)
+            endInteractionSpan('error', { errorMessage: 'loop detected' });
+          // finally cleanup catches this, but cancel explicitly to match
+          // the cleanup pattern at other early-return sites.
+          this.cancelPendingMemoryPrefetch();
+          return turn;
         }
         // Update arena status on Finished events — stats are derived
         // automatically from uiTelemetryService by the reporter.

--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -142,6 +142,39 @@ describe('LoopDetectionService', () => {
       expect(loggers.logLoopDetected).toHaveBeenCalledTimes(1);
     });
 
+    it('should reset the deterministic tool-call counter on retry', () => {
+      const event = createToolCallRequestEvent('testTool', { param: 'value' });
+      for (let i = 0; i < TOOL_CALL_LOOP_THRESHOLD - 1; i++) {
+        expect(service.addAndCheckDeterministicToolCallLoop(event)).toBe(false);
+      }
+
+      expect(
+        service.addAndCheckDeterministicToolCallLoop({
+          type: GeminiEventType.Retry,
+        } as ServerGeminiStreamEvent),
+      ).toBe(false);
+
+      for (let i = 0; i < TOOL_CALL_LOOP_THRESHOLD - 1; i++) {
+        expect(service.addAndCheckDeterministicToolCallLoop(event)).toBe(false);
+      }
+      expect(loggers.logLoopDetected).not.toHaveBeenCalled();
+    });
+
+    it('should expose the current consecutive tool-call count', () => {
+      const event = createToolCallRequestEvent('testTool', { param: 'value' });
+      for (let i = 0; i < TOOL_CALL_LOOP_THRESHOLD - 1; i++) {
+        service.addAndCheckDeterministicToolCallLoop(event);
+      }
+
+      expect(service.getConsecutiveToolCallCount()).toBe(
+        TOOL_CALL_LOOP_THRESHOLD - 1,
+      );
+      expect(service.addAndCheckDeterministicToolCallLoop(event)).toBe(true);
+      expect(service.getConsecutiveToolCallCount()).toBe(
+        TOOL_CALL_LOOP_THRESHOLD,
+      );
+    });
+
     it('should not detect a loop when disabled for session', () => {
       service.disableForSession();
       expect(loggers.logLoopDetectionDisabled).toHaveBeenCalledTimes(1);

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -102,6 +102,10 @@ export class LoopDetectionService {
     return this.lastLoopType;
   }
 
+  getConsecutiveToolCallCount(): number {
+    return this.toolCallRepetitionCount;
+  }
+
   /**
    * Disables loop detection for the current session.
    */
@@ -125,6 +129,14 @@ export class LoopDetectionService {
    * @returns true if a loop is detected, false otherwise
    */
   addAndCheck(event: ServerGeminiStreamEvent): boolean {
+    if (this.addAndCheckDeterministicToolCallLoop(event)) {
+      return true;
+    }
+
+    return this.addAndCheckHeuristicLoops(event);
+  }
+
+  addAndCheckHeuristicLoops(event: ServerGeminiStreamEvent): boolean {
     if (this.loopDetected || this.disabledForSession) {
       return this.loopDetected;
     }
@@ -139,12 +151,11 @@ export class LoopDetectionService {
         // observable progress — any prior thoughts should not carry over.
         this.thoughtHistory = [];
 
-        const toolCallLoop = this.checkToolCallLoop(event.value);
         this.trackToolCall(event.value);
         const readFileLoop = this.checkReadFileLoop();
         const actionStagnation = this.checkActionStagnation();
 
-        this.loopDetected = toolCallLoop || readFileLoop || actionStagnation;
+        this.loopDetected = readFileLoop || actionStagnation;
         break;
       }
       case GeminiEventType.Content: {
@@ -158,6 +169,31 @@ export class LoopDetectionService {
       }
       default:
         break;
+    }
+    return this.loopDetected;
+  }
+
+  addAndCheckDeterministicToolCallLoop(
+    event: ServerGeminiStreamEvent,
+  ): boolean {
+    if (this.loopDetected) {
+      return true;
+    }
+
+    if (event.type === GeminiEventType.Retry) {
+      this.resetToolCallCount();
+      return false;
+    }
+
+    if (
+      this.disabledForSession ||
+      event.type !== GeminiEventType.ToolCallRequest
+    ) {
+      return false;
+    }
+
+    if (this.checkToolCallLoop(event.value)) {
+      this.loopDetected = true;
     }
     return this.loopDetected;
   }


### PR DESCRIPTION
## What this PR does

Moves the repeated-identical-tool-call hard stop into the core stream loop instead of the TUI hook.

Concretely:

- `LoopDetectionService` now exposes a deterministic identical-tool-call backstop separately from heuristic loop checks.
- `GeminiClient.sendMessageStream()` always runs that deterministic backstop before yielding or scheduling more stream events, even when `model.skipLoopDetection` is enabled.
- Heuristic loop detection still respects `model.skipLoopDetection` and the existing session disable path.
- When the deterministic backstop fires, core removes the repeated pending tool-call tail from `Turn.pendingToolCalls` before returning, so earlier distinct pending calls are preserved.
- The previous CLI-local scheduler guard is removed, so the behavior applies consistently to TUI, non-interactive mode, ACP/serve, and SDK callers.

## Why it's needed

Issue #5015 shows a deterministic provider stream that can repeat the exact same tool call and arguments indefinitely. The existing identical-call detector already recognizes this pattern, but the check lived behind the soft loop-detection gate in the core client path. That means clients or modes that skip heuristic loop detection could still execute repeated side-effecting calls.

This PR keeps `skipLoopDetection` as a heuristic-loop setting while making the narrow deterministic identical-tool-call backstop run in core for every client.

## Reviewer Test Plan

### How to verify

Run the focused core/client tests and confirm that repeated identical `ToolCallRequest` events produce `LoopDetected` even when `skipLoopDetection` is true. Also confirm the CLI hook tests still pass after removing the TUI-local guard.

### Evidence (Before & After)

Before this change, `GeminiClient.sendMessageStream()` skipped all loop checks when `model.skipLoopDetection` was true. After this change, only heuristic detectors are skipped; the deterministic identical-tool-call backstop still fires and core stops before handing another repeated tail to pending tool scheduling.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment

Windows 11, Node/npm from the existing repo workspace.

Commands run:

```bash
npm run test --workspace=packages/core -- src/services/loopDetectionService.test.ts
npm run test --workspace=packages/core -- src/core/client.test.ts
npm run test --workspace=packages/cli -- src/ui/hooks/useGeminiStream.test.tsx
npm run typecheck --workspace=packages/core
npm run typecheck --workspace=packages/cli
npx prettier --check packages/core/src/core/client.ts packages/core/src/core/client.test.ts packages/core/src/services/loopDetectionService.ts packages/core/src/services/loopDetectionService.test.ts packages/cli/src/ui/hooks/useGeminiStream.ts packages/cli/src/ui/hooks/useGeminiStream.test.tsx
npx eslint packages/core/src/core/client.ts packages/core/src/core/client.test.ts packages/core/src/services/loopDetectionService.ts packages/core/src/services/loopDetectionService.test.ts packages/cli/src/ui/hooks/useGeminiStream.ts packages/cli/src/ui/hooks/useGeminiStream.test.tsx --max-warnings 0
git diff --check upstream/main --
```

I also rebuilt `packages/core` and `packages/acp-bridge` before rerunning the CLI typecheck so the local workspace outputs matched the rebased source.

## Risk & Scope

- Main risk or tradeoff: a legitimate workflow that asks for the exact same tool and arguments five times in a row now hits the same core identical-call backstop even if heuristic loop detection is skipped. That is intentionally narrower than keeping all loop detectors enabled.
- Not validated / out of scope: live provider replay from the gist in #5015 and end-to-end TUI recording.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5015

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把连续相同工具调用的硬保护从 TUI hook 移到 core 的流处理路径。

具体来说：

- `LoopDetectionService` 将确定性的“连续相同 tool call”保护和启发式 loop 检测拆开。
- `GeminiClient.sendMessageStream()` 会始终先运行这个确定性保护，即使开启了 `model.skipLoopDetection`。
- 其它启发式 loop 检测仍然遵守 `model.skipLoopDetection` 和现有 session disable 路径。
- 当确定性保护触发时，core 会先从 `Turn.pendingToolCalls` 中移除重复尾部，再返回；此前不同的 pending tool call 会保留。
- 旧的 CLI 本地调度保护已移除，因此 TUI、非交互模式、ACP/serve 和 SDK 调用方都会走同一套 core 行为。

## 为什么需要

#5015 展示了一个确定性 provider 流：模型可能持续请求完全相同的工具和参数。已有 detector 能识别这个模式，但 core client 里整体被软性 loop detection gate 控制。这样在跳过启发式 loop detection 的客户端或模式下，仍可能继续执行重复的副作用工具调用。

这个 PR 保留 `skipLoopDetection` 作为启发式检测开关，但让范围更窄、更确定的 identical-tool-call backstop 在 core 中始终生效。

## 验证

已运行 core service/client focused tests、CLI hook focused test、core/CLI typecheck、Prettier、ESLint 和 `git diff --check`。命令见英文 Test Plan。

</details>
