### PR TITLE
feat(skills): support user-invocable frontmatter

### DIFF
--- a/docs/users/features/skills.md
+++ b/docs/users/features/skills.md
@@ -118,8 +118,34 @@ Notes:
 
 - Globs are matched relative to the project root with [picomatch](https://github.com/micromatch/picomatch); files outside the project root never trigger activation.
 - A path-gated Skill **stays activated for the rest of the session** once a matching file is touched. A new session, or a `refreshCache` triggered by editing any Skill file, resets activations.
-- `paths:` only gates **model** discovery, and only at the SkillTool listing level. You can always invoke a path-gated Skill yourself via `/<skill-name>` or the `/skills` picker — that user path runs the Skill body regardless of activation state. The model side, however, stays gated until a matching file is touched: a slash invocation does **not** unlock model-side activation, so if you want the model to chain off your invocation (call `Skill { skill: ... }` itself), also access a file matching the skill's `paths:` first.
+- `paths:` only gates **model** discovery, and only at the SkillTool listing level. Unless `user-invocable: false` is set, you can always invoke a path-gated Skill yourself via `/<skill-name>` or the `/skills` picker — that user path runs the Skill body regardless of activation state. The model side, however, stays gated until a matching file is touched: a slash invocation does **not** unlock model-side activation, so if you want the model to chain off your invocation (call `Skill { skill: ... }` itself), also access a file matching the skill's `paths:` first.
 - Combining `paths:` with `disable-model-invocation: true` is allowed but the gate has no effect — the Skill is hidden from the model regardless, so path activation never advertises it.
+
+### Optional: control user and model invocation
+
+Skills are user-invocable by default. To hide a Skill from direct slash-command use while keeping it available for model invocation, set `user-invocable: false`:
+
+```yaml
+---
+name: model-only-helper
+description: Helper the model can call when appropriate
+user-invocable: false
+---
+```
+
+This removes the Skill from `/<skill-name>` invocation and `/skills` picker results. It does not hide the Skill from the model.
+
+To hide a Skill from model invocation while keeping direct user invocation available, set `disable-model-invocation: true`:
+
+```yaml
+---
+name: manual-helper
+description: Helper you invoke manually
+disable-model-invocation: true
+---
+```
+
+You can combine both fields, but then the Skill is not reachable through the normal user or model invocation paths.
 
 ## Add supporting files
 
@@ -170,9 +196,9 @@ To view available Skills, ask Qwen Code directly:
 What Skills are available?
 ```
 
-> **Heads up — model vs. user view.** Asking the model only surfaces Skills the model can currently see. If a Skill uses `paths:` (see "Optional: gate a Skill on file paths" above), it stays out of that listing until a matching file has been touched. The full set is always visible to you via the `/skills` slash command and on disk.
+> **Heads up — model vs. user view.** Asking the model only surfaces Skills the model can currently see. If a Skill uses `paths:` (see "Optional: gate a Skill on file paths" above), it stays out of that listing until a matching file has been touched. The `/skills` slash command shows Skills you can invoke directly; Skills with `user-invocable: false` remain visible on disk and may still be visible to the model.
 
-Or browse the full list with the slash command (always shows every Skill, including path-gated ones that have not activated yet):
+Or browse the user-invocable list with the slash command (including path-gated Skills that have not activated yet):
 
 ```text
 /skills

--- a/packages/cli/src/services/BundledSkillLoader.test.ts
+++ b/packages/cli/src/services/BundledSkillLoader.test.ts
@@ -96,6 +96,27 @@ describe('BundledSkillLoader', () => {
     expect(commands[0]?.argumentHint).toBe('[topic]');
   });
 
+  it('should default bundled skills to user-invocable slash commands', async () => {
+    const skill = makeSkill();
+    mockSkillManager.listSkills.mockResolvedValue([skill]);
+
+    const loader = new BundledSkillLoader(mockConfig);
+    const commands = await loader.loadCommands(signal);
+
+    expect(commands[0]?.userInvocable).toBe(true);
+  });
+
+  it('should propagate userInvocable from bundled skills to slash commands', async () => {
+    const skill = makeSkill({ userInvocable: false });
+    mockSkillManager.listSkills.mockResolvedValue([skill]);
+
+    const loader = new BundledSkillLoader(mockConfig);
+    const commands = await loader.loadCommands(signal);
+
+    expect(commands[0]?.userInvocable).toBe(false);
+    expect(commands[0]?.modelInvocable).toBe(true);
+  });
+
   it('should load bundled skills as slash commands', async () => {
     const skill = makeSkill();
     mockSkillManager.listSkills.mockResolvedValue([skill]);

--- a/packages/cli/src/services/BundledSkillLoader.ts
+++ b/packages/cli/src/services/BundledSkillLoader.ts
@@ -80,6 +80,7 @@ export class BundledSkillLoader implements ICommandLoader {
         kind: CommandKind.SKILL,
         source: 'bundled-skill' as const,
         sourceLabel: t('Skill'),
+        userInvocable: skill.userInvocable ?? true,
         modelInvocable: !skill.disableModelInvocation,
         argumentHint: skill.argumentHint,
         whenToUse: skill.whenToUse,

--- a/packages/cli/src/services/CommandService.test.ts
+++ b/packages/cli/src/services/CommandService.test.ts
@@ -174,6 +174,53 @@ describe('CommandService', () => {
     expect(loader2.loadCommands).toHaveBeenCalledWith(signal);
   });
 
+  it('should exclude non-user-invocable commands from user command modes', async () => {
+    const userCommand = {
+      ...createMockCommand('user-command', CommandKind.FILE),
+      userInvocable: true,
+      modelInvocable: true,
+    };
+    const modelOnlyCommand = {
+      ...createMockCommand('model-only-command', CommandKind.FILE),
+      userInvocable: false,
+      modelInvocable: true,
+    };
+    const service = await CommandService.create(
+      [new MockCommandLoader([userCommand, modelOnlyCommand])],
+      new AbortController().signal,
+    );
+
+    expect(service.getCommands().map((cmd) => cmd.name)).toEqual([
+      'user-command',
+      'model-only-command',
+    ]);
+    expect(
+      service.getCommandsForMode('interactive').map((cmd) => cmd.name),
+    ).toEqual(['user-command']);
+    expect(service.getModelInvocableCommands().map((cmd) => cmd.name)).toEqual([
+      'user-command',
+      'model-only-command',
+    ]);
+  });
+
+  it('should exclude commands that are neither user nor model invocable', async () => {
+    const hiddenCommand = {
+      ...createMockCommand('hidden-command', CommandKind.FILE),
+      userInvocable: false,
+      modelInvocable: false,
+    };
+    const service = await CommandService.create(
+      [new MockCommandLoader([hiddenCommand])],
+      new AbortController().signal,
+    );
+
+    expect(service.getCommands().map((cmd) => cmd.name)).toEqual([
+      'hidden-command',
+    ]);
+    expect(service.getCommandsForMode('interactive')).toEqual([]);
+    expect(service.getModelInvocableCommands()).toEqual([]);
+  });
+
   it('should rename extension commands when they conflict', async () => {
     const builtinCommand = createMockCommand('deploy', CommandKind.BUILT_IN);
     const userCommand = createMockCommand('sync', CommandKind.FILE);

--- a/packages/cli/src/services/CommandService.ts
+++ b/packages/cli/src/services/CommandService.ts
@@ -131,12 +131,14 @@ export class CommandService {
 
   /**
    * Returns commands available in the specified execution mode.
-   * Hidden commands are excluded.
+   * Hidden and non-user-invocable commands are excluded.
    */
   getCommandsForMode(mode: ExecutionMode): readonly SlashCommand[] {
     return Object.freeze(
       filterCommandsForMode(
-        this.commands.filter((cmd) => !cmd.hidden),
+        this.commands.filter(
+          (cmd) => !cmd.hidden && cmd.userInvocable !== false,
+        ),
         mode,
       ),
     );

--- a/packages/cli/src/services/SkillCommandLoader.test.ts
+++ b/packages/cli/src/services/SkillCommandLoader.test.ts
@@ -88,6 +88,33 @@ describe('SkillCommandLoader', () => {
     expect(commands[0]?.argumentHint).toBe('[topic]');
   });
 
+  it('should default skills to user-invocable slash commands', async () => {
+    const skill = makeSkill();
+    mockSkillManager.listSkills.mockImplementation(
+      ({ level }: { level: string }) =>
+        Promise.resolve(level === 'user' ? [skill] : []),
+    );
+
+    const loader = new SkillCommandLoader(mockConfig);
+    const commands = await loader.loadCommands(signal);
+
+    expect(commands[0]?.userInvocable).toBe(true);
+  });
+
+  it('should propagate userInvocable from skills to slash commands', async () => {
+    const skill = makeSkill({ userInvocable: false });
+    mockSkillManager.listSkills.mockImplementation(
+      ({ level }: { level: string }) =>
+        Promise.resolve(level === 'user' ? [skill] : []),
+    );
+
+    const loader = new SkillCommandLoader(mockConfig);
+    const commands = await loader.loadCommands(signal);
+
+    expect(commands[0]?.userInvocable).toBe(false);
+    expect(commands[0]?.modelInvocable).toBe(true);
+  });
+
   it('should query user, project, and extension levels', async () => {
     const loader = new SkillCommandLoader(mockConfig);
     await loader.loadCommands(signal);

--- a/packages/cli/src/services/SkillCommandLoader.ts
+++ b/packages/cli/src/services/SkillCommandLoader.ts
@@ -67,9 +67,12 @@ export class SkillCommandLoader implements ICommandLoader {
       const visibleSkills = allSkills.filter(
         (skill) => !disabled.has(skill.name.toLowerCase()),
       );
+      const nonUserInvocableCount = visibleSkills.filter(
+        (skill) => skill.userInvocable === false,
+      ).length;
 
       debugLogger.debug(
-        `Loaded ${userSkills.length} user + ${projectSkills.length} project + ${extensionSkills.length} extension skill(s) as slash commands; ${allSkills.length - visibleSkills.length} hidden by skills.disabled`,
+        `Loaded ${userSkills.length} user + ${projectSkills.length} project + ${extensionSkills.length} extension skill(s) as slash commands; ${allSkills.length - visibleSkills.length} hidden by skills.disabled; ${nonUserInvocableCount} marked non-user-invocable`,
       );
 
       return visibleSkills.map((skill) => {
@@ -104,6 +107,7 @@ export class SkillCommandLoader implements ICommandLoader {
             : skill.level === 'project'
               ? 'project'
               : 'user',
+          userInvocable: skill.userInvocable ?? true,
           modelInvocable,
           argumentHint: skill.argumentHint,
           whenToUse: skill.whenToUse,

--- a/packages/cli/src/ui/commands/skillsCommand.test.ts
+++ b/packages/cli/src/ui/commands/skillsCommand.test.ts
@@ -14,6 +14,7 @@ interface FakeSkill {
   name: string;
   description?: string;
   priority?: number;
+  userInvocable?: boolean;
 }
 
 function makeContext(opts: {
@@ -125,6 +126,28 @@ describe('skillsCommand bare entry', () => {
     );
   });
 
+  it('omits non-user-invocable skills from the non-interactive listing', async () => {
+    if (!skillsCommand.action) throw new Error('action missing');
+    const context = makeContext({
+      skills: [
+        { name: 'alpha' },
+        { name: 'model-only', userInvocable: false },
+        { name: 'gamma' },
+      ],
+      executionMode: 'non_interactive',
+    });
+
+    await skillsCommand.action(context, '');
+
+    expect(context.ui.addItem).toHaveBeenCalledWith(
+      {
+        type: MessageType.SKILLS_LIST,
+        skills: [{ name: 'alpha' }, { name: 'gamma' }],
+      },
+      expect.any(Number),
+    );
+  });
+
   it('omits disabled skills from the non-interactive listing', async () => {
     if (!skillsCommand.action) throw new Error('action missing');
     const context = makeContext({
@@ -140,6 +163,24 @@ describe('skillsCommand bare entry', () => {
       {
         type: MessageType.SKILLS_LIST,
         skills: [{ name: 'alpha' }, { name: 'gamma' }],
+      },
+      expect.any(Number),
+    );
+  });
+
+  it('shows no available skills when all loaded skills are not user invocable', async () => {
+    if (!skillsCommand.action) throw new Error('action missing');
+    const context = makeContext({
+      skills: [{ name: 'model-only', userInvocable: false }],
+      executionMode: 'acp',
+    });
+
+    await skillsCommand.action(context, '');
+
+    expect(context.ui.addItem).toHaveBeenCalledWith(
+      {
+        type: MessageType.INFO,
+        text: 'All skills are marked as non-user-invocable.',
       },
       expect.any(Number),
     );

--- a/packages/cli/src/ui/commands/skillsCommand.ts
+++ b/packages/cli/src/ui/commands/skillsCommand.ts
@@ -56,19 +56,25 @@ export const skillsCommand: SlashCommand = {
     // single normalization pass instead of drifting independently.
     const disabled =
       context.services.config?.getDisabledSkillNames() ?? new Set<string>();
-    const visibleSkills = skills.filter(
+    const userInvocableSkills = skills.filter(
+      (skill) => skill.userInvocable !== false,
+    );
+    const visibleSkills = userInvocableSkills.filter(
       (s) => !disabled.has(s.name.toLowerCase()),
     );
     if (visibleSkills.length === 0) {
+      const text =
+        skills.length > 0 && userInvocableSkills.length === 0
+          ? t('All skills are marked as non-user-invocable.')
+          : userInvocableSkills.length === 0
+            ? t('No skills are currently available.')
+            : t(
+                'All available skills are disabled. Edit ~/.qwen/settings.json or .qwen/settings.json (skills.disabled) to re-enable.',
+              );
       context.ui.addItem(
         {
           type: MessageType.INFO,
-          text:
-            skills.length === 0
-              ? t('No skills are currently available.')
-              : t(
-                  'All available skills are disabled. Edit ~/.qwen/settings.json or .qwen/settings.json (skills.disabled) to re-enable.',
-                ),
+          text,
         },
         Date.now(),
       );

--- a/packages/cli/src/ui/components/skills/SkillsManagerDialog.tsx
+++ b/packages/cli/src/ui/components/skills/SkillsManagerDialog.tsx
@@ -187,7 +187,10 @@ export function SkillsManagerDialog({
     (async () => {
       try {
         const list = await skillManager.listSkills();
-        if (!cancelled) setSkills(sortSkills(list));
+        const userInvocableList = list.filter(
+          (skill) => skill.userInvocable !== false,
+        );
+        if (!cancelled) setSkills(sortSkills(userInvocableList));
       } catch (e) {
         if (!cancelled) {
           setLoadError(e instanceof Error ? e.message : String(e));

--- a/packages/cli/src/ui/utils/commandUtils.test.ts
+++ b/packages/cli/src/ui/utils/commandUtils.test.ts
@@ -575,6 +575,14 @@ describe('findSlashCommandTokens', () => {
       userInvocable: true,
       hidden: true,
     },
+    {
+      name: 'model-only',
+      description: 'Model-only command',
+      kind: 'built-in' as const,
+      modelInvocable: true,
+      userInvocable: false,
+      hidden: false,
+    },
   ] as Parameters<typeof findSlashCommandTokens>[1];
 
   it('returns empty array for empty text', () => {
@@ -596,6 +604,15 @@ describe('findSlashCommandTokens', () => {
     });
   });
 
+  it('marks line-start non-user-invocable command as invalid', () => {
+    const tokens = findSlashCommandTokens('/model-only', mockCommands);
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]).toMatchObject({
+      commandName: 'model-only',
+      valid: false,
+    });
+  });
+
   it('marks mid-input modelInvocable command as valid', () => {
     const tokens = findSlashCommandTokens(
       'please /review this code',
@@ -603,6 +620,18 @@ describe('findSlashCommandTokens', () => {
     );
     expect(tokens).toHaveLength(1);
     expect(tokens[0]).toMatchObject({ commandName: 'review', valid: true });
+  });
+
+  it('marks mid-input model-only command as valid', () => {
+    const tokens = findSlashCommandTokens(
+      'please /model-only this code',
+      mockCommands,
+    );
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]).toMatchObject({
+      commandName: 'model-only',
+      valid: true,
+    });
   });
 
   it('marks mid-input non-modelInvocable command as invalid', () => {

--- a/packages/core/src/skills/skill-load.test.ts
+++ b/packages/core/src/skills/skill-load.test.ts
@@ -12,7 +12,11 @@ import {
   parsePriorityField,
   normalizeSkillPriority,
 } from './skill-load.js';
-import { parseModelField, parsePathsField } from './types.js';
+import {
+  parseModelField,
+  parsePathsField,
+  parseUserInvocableField,
+} from './types.js';
 import * as fs from 'fs/promises';
 
 // Mock file system operations
@@ -236,6 +240,27 @@ Body.
       );
 
       expect(config.priority).toBeUndefined();
+    });
+
+    it('should parse user-invocable from frontmatter', () => {
+      mockParseYaml.mockReturnValueOnce({
+        name: 'test-skill',
+        description: 'A test skill',
+        'user-invocable': false,
+      });
+
+      const markdown = `---
+name: test-skill
+description: A test skill
+user-invocable: false
+---
+
+Skill body.
+`;
+
+      const config = parseSkillContent(markdown, testFilePath);
+
+      expect(config.userInvocable).toBe(false);
     });
 
     it('should throw error for invalid format without frontmatter', () => {
@@ -518,6 +543,28 @@ Symlinked skill body.
     });
   });
 
+  describe('parseUserInvocableField', () => {
+    it('returns undefined when user-invocable is omitted', () => {
+      expect(parseUserInvocableField({})).toBeUndefined();
+    });
+
+    it('parses boolean and string values', () => {
+      expect(parseUserInvocableField({ 'user-invocable': true })).toBe(true);
+      expect(parseUserInvocableField({ 'user-invocable': false })).toBe(false);
+      expect(parseUserInvocableField({ 'user-invocable': 'true' })).toBe(true);
+      expect(parseUserInvocableField({ 'user-invocable': 'false' })).toBe(
+        false,
+      );
+    });
+
+    it('ignores invalid values so the default remains user-invocable', () => {
+      expect(
+        parseUserInvocableField({ 'user-invocable': 'no' }),
+      ).toBeUndefined();
+      expect(parseUserInvocableField({ 'user-invocable': 0 })).toBeUndefined();
+    });
+  });
+
   describe('parsePathsField', () => {
     it('returns the cleaned array for a valid paths frontmatter', () => {
       expect(
@@ -681,6 +728,19 @@ Symlinked skill body.
       );
       expect(config.disableModelInvocation).toBe(true);
       expect(config.paths).toEqual(['src/**/*.ts']);
+    });
+
+    it('extracts user-invocable', () => {
+      mockParseYaml.mockReturnValueOnce({
+        name: 'model-only-helper',
+        description: 'Model-only helper',
+        'user-invocable': false,
+      });
+      const config = parseSkillContent(
+        `---\nname: model-only-helper\ndescription: Model-only helper\nuser-invocable: false\n---\n\nBody.\n`,
+        '/test/extension/skills/model-only-helper/SKILL.md',
+      );
+      expect(config.userInvocable).toBe(false);
     });
 
     it('extracts when_to_use', () => {

--- a/packages/core/src/skills/skill-load.ts
+++ b/packages/core/src/skills/skill-load.ts
@@ -3,6 +3,7 @@ import {
   type SkillValidationResult,
   parseModelField,
   parsePathsField,
+  parseUserInvocableField,
   validateSkillName,
 } from './types.js';
 import { validateSymlinkTarget } from './symlinkScope.js';
@@ -165,6 +166,7 @@ export function parseSkillContent(
     disableModelInvocationRaw === true || disableModelInvocationRaw === 'true'
       ? true
       : undefined;
+  const userInvocable = parseUserInvocableField(frontmatter);
 
   // Optional `paths` frontmatter: glob patterns that gate when this skill
   // is offered to the model (conditional skill).
@@ -197,6 +199,7 @@ export function parseSkillContent(
     level: 'extension',
     whenToUse,
     disableModelInvocation,
+    userInvocable,
     paths,
     priority,
   };

--- a/packages/core/src/skills/skill-manager.test.ts
+++ b/packages/core/src/skills/skill-manager.test.ts
@@ -354,6 +354,31 @@ Skill body.
       expect(config.priority).toBeUndefined();
     });
 
+    it('should parse user-invocable from frontmatter', () => {
+      mockParseYaml.mockReturnValueOnce({
+        name: 'test-skill',
+        description: 'A test skill',
+        'user-invocable': false,
+      });
+
+      const markdown = `---
+name: test-skill
+description: A test skill
+user-invocable: false
+---
+
+Skill body.
+`;
+
+      const config = manager.parseSkillContent(
+        markdown,
+        validSkillConfig.filePath,
+        'project',
+      );
+
+      expect(config.userInvocable).toBe(false);
+    });
+
     it('should parse content with paths (conditional skill)', () => {
       const markdown = `---
 name: tsx-helper

--- a/packages/core/src/skills/skill-manager.ts
+++ b/packages/core/src/skills/skill-manager.ts
@@ -24,6 +24,7 @@ import {
   SkillErrorCode,
   parseModelField,
   parsePathsField,
+  parseUserInvocableField,
   validateSkillName,
 } from './types.js';
 import type { Config } from '../config/config.js';
@@ -723,7 +724,8 @@ export class SkillManager {
       // Extract optional model field
       const model = parseModelField(frontmatter);
 
-      // Extract argument-hint, when_to_use, and disable-model-invocation
+      // Extract argument-hint, when_to_use, disable-model-invocation, and
+      // user-invocable
       const argumentHint =
         typeof frontmatter['argument-hint'] === 'string'
           ? frontmatter['argument-hint']
@@ -738,6 +740,7 @@ export class SkillManager {
         disableModelInvocationRaw === 'true'
           ? true
           : undefined;
+      const userInvocable = parseUserInvocableField(frontmatter);
 
       // Optional `paths` frontmatter: glob patterns that gate when this skill
       // is offered to the model (conditional skill).
@@ -764,6 +767,7 @@ export class SkillManager {
         body: body.trim(),
         whenToUse,
         disableModelInvocation,
+        userInvocable,
         paths,
         priority,
       };

--- a/packages/core/src/skills/types.ts
+++ b/packages/core/src/skills/types.ts
@@ -112,6 +112,13 @@ export interface SkillConfig {
   disableModelInvocation?: boolean;
 
   /**
+   * Whether users can invoke this skill directly via `/<skill-name>`.
+   * Defaults to true. Parsed from the `user-invocable` frontmatter field in
+   * SKILL.md.
+   */
+  userInvocable?: boolean;
+
+  /**
    * Optional glob patterns that gate when this skill is offered to the model.
    * When present and non-empty, the skill is a "conditional skill": it stays
    * out of the SkillTool listing until a tool invocation touches a file path
@@ -154,6 +161,28 @@ export function parseModelField(
     return undefined;
   }
   return trimmed;
+}
+
+/**
+ * Parse the `user-invocable` field from skill frontmatter.
+ * Returns `undefined` when omitted or set to an invalid value, preserving the
+ * command-layer default that skills are user-invocable unless explicitly
+ * disabled.
+ */
+export function parseUserInvocableField(
+  frontmatter: Record<string, unknown>,
+): boolean | undefined {
+  const raw = frontmatter['user-invocable'];
+  if (raw === undefined) {
+    return undefined;
+  }
+  if (raw === true || raw === 'true') {
+    return true;
+  }
+  if (raw === false || raw === 'false') {
+    return false;
+  }
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

Add support for `user-invocable: false` in skill frontmatter so model-oriented skills can stay available to the model without being exposed through user slash-command entry points.

This wires the parsed field through skill command creation and the user-facing skill surfaces. Model invocation remains controlled separately by `disable-model-invocation`.

Refs #2338.

## Reviewer Test Plan

- Create a skill with `user-invocable: false` and no `disable-model-invocation`; verify it is hidden from direct slash-command entry points and the skills picker, while remaining eligible for model invocation.
- Create a normal skill without the field; verify existing slash invocation and skills picker behavior is unchanged.
- Create a skill with `disable-model-invocation: true`; verify it remains manually invocable unless `user-invocable: false` is also set.

## Validation

- `cd packages/core && npx vitest run src/skills/skill-load.test.ts src/skills/skill-manager.test.ts`
- `cd packages/cli && npx vitest run src/services/SkillCommandLoader.test.ts src/services/BundledSkillLoader.test.ts src/services/CommandService.test.ts src/ui/commands/skillsCommand.test.ts src/ui/utils/commandUtils.test.ts`
- `cd packages/core && npm run typecheck`
- `cd packages/cli && npm run typecheck`
- `cd packages/core && npm run build`
- `cd packages/cli && npm run build`