### PR TITLE
fix(test): unbreak qwen serve integration suites after the daemon batch merge

### DIFF
--- a/integration-tests/cli/qwen-serve-baseline.test.ts
+++ b/integration-tests/cli/qwen-serve-baseline.test.ts
@@ -443,41 +443,35 @@ async function measureRssAtSessionCount(sessionCount: number): Promise<{
       }, 120_000);
 
       // PR 14b cross-check: validate the daemon's in-process MCP
-      // accounting on `GET /workspace/mcp` (`clientCount`, the field
-      // SDK consumers and dashboards see, and the same source the
-      // push-event channel — `mcp_budget_warning` /
-      // `mcp_child_refused_batch` — reads) against external `pgrep -P`
+      // accounting on `GET /workspace/mcp` against external `pgrep -P`
       // measurement.
       //
-      // Architectural note (PR 22a): a `qwen serve` ACP child runs
-      // two `Config` objects, each carrying its own
-      // `McpClientManager`. The bootstrap Config (`runAcpAgent` →
-      // `config.initialize`) discovers MCP servers when the child
-      // starts, and `/workspace/mcp` reads its manager via
-      // `buildWorkspaceMcpStatus(this.config)` (`acpAgent.ts:1399`).
-      // The per-session Config (`newSessionConfig` →
-      // `config.initialize`) spawns a SECOND set of MCP children for
-      // the SAME servers — its accounting is NOT what the
-      // workspace-level snapshot reflects. So pgrep observes
-      // `(1 + sessionCount) * MCP_SERVERS_CONFIGURED` grandchildren
-      // while `clientCount` stays at `MCP_SERVERS_CONFIGURED`.
+      // Architectural note (F2 workspace pool): the daemon hosts a
+      // workspace-shared MCP transport pool (`QwenAgent.mcpPool`).
+      // All sessions of a workspace share ONE transport per configured
+      // server, so pgrep observes exactly `MCP_SERVERS_CONFIGURED`
+      // grandchildren regardless of session count. (Pre-F2, bootstrap
+      // + per-session Configs each ran their own `McpClientManager`,
+      // and this test asserted the historical 2×N duplication.)
+      // Pool accounting surfaces per server cell as `entryCount` /
+      // `entrySummary`; the top-level `clientCount` field reflects the
+      // workspace budget controller's reserved count — 0 when budgets
+      // are off (this suite), NOT the live transport count.
       //
       // What this test validates:
-      // 1. `clientCount` is exactly the configured server count
-      //    (bootstrap manager accounting is honest).
-      // 2. pgrep observes the architectural 2×N grandchildren after
-      //    one session is created — encoded literally so a future
-      //    refactor that unifies bootstrap + session managers (#4175
-      //    follow-up to drop the duplicate discovery) fails this
-      //    assertion and forces a deliberate test update.
+      // 1. pgrep observes exactly N grandchildren after a session is
+      //    created — encoded literally so a refactor that reintroduces
+      //    per-session MCP children fails this assertion and forces a
+      //    deliberate test update (same tripwire spirit as the pre-F2
+      //    2×N assertion this replaces).
+      // 2. Pool accounting is honest: per-server `entryCount` sums to
+      //    the observed pgrep count (no amplification slack at idle —
+      //    the fixtures are stdio-only).
       // 3. `clientCount` NEVER exceeds the observed pgrep count —
       //    the original "snapshot must never over-report" guard.
       //
-      // Skip-gated like the parent describe (POSIX, non-sandbox);
-      // idle MCP fixtures are stdio-only so the relationship between
-      // `clientCount` and pgrep is exact (no amplification slack
-      // required at idle).
-      it('clientCount matches external pgrep observation', async () => {
+      // Skip-gated like the parent describe (POSIX, non-sandbox).
+      it('pool accounting matches external pgrep observation', async () => {
         const ws = makeTempWorkspace('mcp-counter');
         let daemon: SpawnedDaemon | undefined;
         try {
@@ -490,28 +484,35 @@ async function measureRssAtSessionCount(sessionCount: number): Promise<{
           daemon = await spawnDaemon({ workspaceCwd: ws });
           await daemon.client.createOrAttachSession({ workspaceCwd: ws });
 
-          // Wait until the OS sees the FULL post-session set
-          // (`MCP_SERVERS_CONFIGURED * 2` grandchildren — see the
+          // Wait until the OS sees the full pooled set
+          // (`MCP_SERVERS_CONFIGURED` grandchildren — see the
           // architectural note above), then read the snapshot.
           // pgrep first to lock the comparison floor; snapshot
           // second so the daemon can't sneak in a new connect
           // between the two reads.
-          const expectedGrandchildren = MCP_SERVERS_CONFIGURED * 2;
           const observed = await waitForMcpGrandchildren(
             daemon.daemon.pid!,
-            expectedGrandchildren,
+            MCP_SERVERS_CONFIGURED,
           );
           const snapshot = await daemon.client.workspaceMcp();
 
-          // (1) Bootstrap manager accounting is honest.
-          expect(snapshot.clientCount).toBe(MCP_SERVERS_CONFIGURED);
-          // (2) pgrep observes both managers' children. If a future
-          // refactor unifies them, change this to
-          // `MCP_SERVERS_CONFIGURED` (and update the architectural
-          // note above).
-          expect(observed.mcpGrandchildren.length).toBe(expectedGrandchildren);
-          // (3) Snapshot never over-reports OS reality. Holds under
-          // both the current 2× regime and the unified 1× future.
+          // (1) One pooled transport per configured server — no
+          // per-session amplification. If this fails with MORE
+          // children, per-session MCP spawning has been reintroduced;
+          // update the architectural note above deliberately.
+          expect(observed.mcpGrandchildren.length).toBe(MCP_SERVERS_CONFIGURED);
+          // (2) Pool accounting is honest: entryCount sums to the
+          // observed process count. Structural narrowing: the daemon
+          // emits `entryCount` on pool-backed cells but the SDK's
+          // `DaemonWorkspaceMcpServerStatus` doesn't carry the F2
+          // pool fields yet.
+          const pooledEntries = snapshot.servers.reduce(
+            (sum, server) =>
+              sum + ((server as { entryCount?: number }).entryCount ?? 0),
+            0,
+          );
+          expect(pooledEntries).toBe(observed.mcpGrandchildren.length);
+          // (3) Snapshot never over-reports OS reality.
           expect(snapshot.clientCount).toBeLessThanOrEqual(
             observed.mcpGrandchildren.length,
           );

--- a/integration-tests/cli/qwen-serve-routes.test.ts
+++ b/integration-tests/cli/qwen-serve-routes.test.ts
@@ -70,7 +70,26 @@ beforeAll(async () => {
       '--workspace',
       REPO_ROOT,
     ],
-    { stdio: ['ignore', 'pipe', 'pipe'] },
+    {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      // Strip the env toggles that flip conditional capability tags
+      // (`prompt_absolute_deadline`, `writer_idle_timeout`,
+      // `rate_limit`, and the pool tags via the kill switch). The
+      // capabilities baseline below assumes their default state; a
+      // dev machine exporting any of these would otherwise fail the
+      // exact-equality assertion.
+      env: Object.fromEntries(
+        Object.entries(process.env).filter(
+          ([k]) =>
+            ![
+              'QWEN_SERVE_PROMPT_DEADLINE_MS',
+              'QWEN_SERVE_WRITER_IDLE_TIMEOUT_MS',
+              'QWEN_SERVE_RATE_LIMIT',
+              'QWEN_SERVE_NO_MCP_POOL',
+            ].includes(k),
+        ),
+      ),
+    },
   );
   // Read stdout until we see the listening line + parse the port.
   port = await new Promise<number>((resolve, reject) => {
@@ -187,6 +206,15 @@ describe('qwen serve — capabilities envelope', () => {
     // Order must match `SERVE_CAPABILITY_REGISTRY` in
     // `packages/cli/src/serve/capabilities.ts` and the unit-level
     // baseline features in `packages/cli/src/serve/server.test.ts`.
+    //
+    // Conditional tags absent under this suite's spawn flags (no
+    // `--require-auth` / `--allow-origin` / deadline env vars /
+    // rate-limit opt-in): `require_auth`, `allow_origin`,
+    // `prompt_absolute_deadline`, `writer_idle_timeout`, `rate_limit`.
+    // Pool tags (`mcp_workspace_pool`, `mcp_pool_restart`) ARE present
+    // because the workspace MCP pool is on by default, as are
+    // `workspace_settings` / `workspace_reload` (the CLI serve path
+    // always wires `persistSetting` and the workspace service).
     expect(caps.features).toEqual([
       'health',
       'capabilities',
@@ -209,25 +237,45 @@ describe('qwen serve — capabilities envelope', () => {
       'workspace_mcp',
       'workspace_skills',
       'workspace_providers',
+      'auth_provider_install',
       'workspace_memory',
       'workspace_agents',
+      'workspace_agent_generate',
       'workspace_env',
       'workspace_preflight',
       'session_context',
+      'session_context_usage',
       'session_supported_commands',
       'session_tasks',
+      'session_stats',
       'session_close',
       'session_metadata',
       'mcp_guardrails',
+      'workspace_mcp_manage',
       'mcp_guardrail_events',
+      'mcp_server_runtime_mutation',
       'workspace_file_read',
       'workspace_file_bytes',
       'workspace_file_write',
       'session_approval_mode_control',
       'workspace_tool_toggle',
+      'workspace_settings',
       'workspace_init',
       'workspace_mcp_restart',
+      'session_recap',
+      'session_btw',
+      'mcp_workspace_pool',
+      'mcp_pool_restart',
       'auth_device_flow',
+      'permission_mediation',
+      'non_blocking_prompt',
+      'session_language',
+      'session_rewind',
+      'workspace_hooks',
+      'session_hooks',
+      'workspace_extensions',
+      'session_branch',
+      'workspace_reload',
     ]);
   });
 });

--- a/integration-tests/cli/qwen-serve-streaming.test.ts
+++ b/integration-tests/cli/qwen-serve-streaming.test.ts
@@ -226,6 +226,13 @@ describeLLM('qwen serve — multi-client first-responder permission', () => {
       workspaceCwd: REPO_ROOT,
     });
 
+    // Pin the session to `default` approval mode. The ACP child
+    // inherits the host's user-level settings — a developer machine
+    // with `approvalMode: yolo` auto-approves the write below, no
+    // permission_request ever fires, and this test fails only
+    // locally. CI passes because its HOME has no user settings.
+    await client.setSessionApprovalMode(session.sessionId, 'default');
+
     const ac1 = new AbortController();
     const ac2 = new AbortController();
     const seen1: DaemonEvent[] = [];
@@ -314,6 +321,21 @@ describeLLM('qwen serve — multi-client first-responder permission', () => {
     await Promise.race([
       promptTask.catch(() => undefined),
       new Promise((r) => setTimeout(r, 30_000)),
+    ]);
+    // The race above tolerates the turn still running (slow model).
+    // But ABANDONING an in-flight turn wedges the shared session: if
+    // the model asks for a SECOND permission after the allow_once
+    // vote, nobody is left to answer it, the pending request blocks
+    // the turn forever, and the per-session prompt FIFO holds every
+    // later prompt behind it — the Last-Event-ID resume test below
+    // then times out waiting for a turn_complete that never comes
+    // (the exact 60s × 3-retry hang from the 2026-06-12 nightly).
+    // Cancel the active prompt so the session is clean for the next
+    // test; harmless when the turn already finished.
+    await client.cancel(session.sessionId).catch(() => undefined);
+    await Promise.race([
+      promptTask.catch(() => undefined),
+      new Promise((r) => setTimeout(r, 5_000)),
     ]);
     ac1.abort();
     ac2.abort();


### PR DESCRIPTION
## What this PR does

Fixes the three \`qwen serve\` integration test failures that have failed every nightly Release run and every E2E run on main since the daemon-mode feature batch (#4490) merged:

- Resyncs the capabilities envelope baseline with the ~20 features the daemon batch added (verified against a live daemon spawned with the same flags the suite uses), and strips the env toggles that flip conditional capability tags so the exact-equality assertion is hermetic on developer machines.
- Updates the MCP process-accounting tripwire for the workspace MCP pool era: sessions now share one pooled transport per configured server, so the OS sees exactly N MCP children instead of the old 2×N duplication. The assertion fired exactly as its comment promised ("a future refactor that unifies bootstrap + session managers fails this assertion and forces a deliberate test update") — this is that deliberate update, now cross-checking the pool's per-server accounting against pgrep and keeping the never-over-report guard.
- Fixes the real bug behind the Last-Event-ID resume timeout: the multi-client permission test could finish while its turn was still waiting on a second permission vote nobody would ever cast. That abandoned request blocks the session's prompt FIFO forever, and the resume test — sharing the same session via single-session scope — timed out waiting for a turn that never started. The permission test now pins the session to default approval mode (hermetic against host-level user settings, which previously made this test impossible to run on a dev machine with auto-approval configured) and cancels its possibly-in-flight turn before finishing.

## Why it's needed

The nightly release publish has been blocked since 2026-06-12 (run 27386201557), and every push to main burns a failing E2E run. These suites only run in the Release and E2E workflows — not in required PR checks — so the batch merged green while the drift went unnoticed.

## Reviewer Test Plan

### How to verify

- \`npm run build && npm run bundle\`, then from \`integration-tests/\`: \`QWEN_SANDBOX=false npx vitest run cli/qwen-serve-routes.test.ts cli/qwen-serve-baseline.test.ts\` (no model credential needed).
- With a model credential (\`OPENAI_API_KEY\`/\`OPENAI_BASE_URL\`/\`OPENAI_MODEL\`): \`QWEN_SANDBOX=false npx vitest run cli/qwen-serve-streaming.test.ts\` — all three tests should pass, including the permission fan-out path.
- The wedge the streaming fix addresses reproduces on main without this change: prompt a two-step file write under default approval, vote allow-once on the first permission request only, drop all SSE subscribers, then fire any prompt on the same session — its turn never starts and the caller hangs. An explicit session cancel recovers it (~200ms).

### Evidence (Before & After)

| Test | Before (nightly 27386201557) | After (local, OpenAI-compatible endpoint) |
| :-- | :--: | :--: |
| capabilities envelope | ❌ expects 39 features, daemon advertises 59 | ✅ |
| MCP pool accounting vs pgrep | ❌ waits for 4 grandchildren, pool spawns 2 | ✅ |
| permission fan-out + vote race | ✅ in CI only (and left the session wedged) | ✅ exercises the real permission path locally too |
| Last-Event-ID resume | ❌ 60s timeout × 3 retries | ✅ 2.5s |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A (suites are POSIX-gated)  |
|  🐧 Linux  |  ⚠️ (CI)  |

### Environment (optional)

Local bundle (\`npm run build && npm run bundle\`), no sandbox; streaming suite verified end-to-end with a real OpenAI-compatible model.

## Risk & Scope

- Main risk or tradeoff: the capabilities baseline stays a literal list, so it will drift again when the registry grows — that is the tripwire working as designed. The deeper gap is that these suites don't run on PR CI.
- Not validated / out of scope: the daemon-side bug — an abandoned permission request wedges the session's prompt FIFO until an explicit cancel — affects any client that disconnects mid-permission, not just tests. Filed separately; #5033's backpressure bounds the pile-up behind a wedged turn but explicitly defers the never-settling-prompt problem.
- Breaking changes / migration notes: none (test-only).

## Linked Issues

- #4490 (daemon batch that introduced the drift)

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修复自 daemon 功能批次(#4490)合入 main 后,每晚 Release 与每次 E2E 都失败的三个 \`qwen serve\` 集成测试:

- 将 capabilities 基线与批次新增的约 20 个能力重新同步(已对照以相同参数启动的真实 daemon 验证),并在测试启动 daemon 时剥离会翻转条件能力标签的环境变量,保证严格相等断言在开发机上也是封闭的。
- 将 MCP 进程计数的"绊线"断言更新到 workspace MCP 池时代:各 session 现在共享每个 server 一个池化 transport,操作系统只会看到 N 个 MCP 子进程,而非旧架构的 2×N 重复。该断言正是按其注释设计触发的("统一 bootstrap 与 session manager 的重构会使此断言失败,并强制进行一次有意识的测试更新")——本次即为该更新,同时新增了池级 per-server 计数与 pgrep 的交叉校验,并保留"快照不得高于操作系统实际值"的守护断言。
- 修复 Last-Event-ID resume 超时背后的真实问题:多客户端权限测试可能在其回合仍在等待第二次权限投票时就结束——这个被遗弃的权限请求会永久阻塞该 session 的 prompt FIFO,而共享同一 session 的 resume 测试则会一直等不到 turn_complete(已在本地完整复现)。权限测试现在将 session 固定为 default 审批模式(不再受宿主机用户配置影响),并在结束前取消可能仍在执行的回合。

## 为什么需要

自 2026-06-12 起(run 27386201557)每晚发布被阻塞,且每次推送 main 都浪费一次失败的 E2E。这些套件只在 Release 与 E2E 工作流中运行,不在 PR 必检项中,因此批次合入时是绿的,漂移未被发现。

## 评审验证方式

- \`npm run build && npm run bundle\` 后,在 \`integration-tests/\` 下运行 \`QWEN_SANDBOX=false npx vitest run cli/qwen-serve-routes.test.ts cli/qwen-serve-baseline.test.ts\`(无需模型凭证)。
- 配置模型凭证后运行 \`QWEN_SANDBOX=false npx vitest run cli/qwen-serve-streaming.test.ts\`,三个测试应全部通过(包括权限分发路径)。
- 不带本修复时可在 main 上复现卡死:default 审批模式下让模型分两步写文件,只对第一次权限请求投 allow-once,断开所有 SSE 订阅者,再向同一 session 发任意 prompt——其回合永不开始;显式 cancel 可在约 200ms 内恢复。

## 风险与范围

- 主要权衡:capabilities 基线仍是字面列表,注册表增长时会再次漂移——这正是绊线的设计意图;更深层的缺口是这些套件不在 PR CI 中运行。
- 未覆盖/范围外:daemon 侧问题(被遗弃的权限请求会阻塞 session 的 prompt FIFO,直至显式 cancel)影响任何在权限等待中断开的客户端,另行建 issue 跟踪;#5033 的背压机制限制了卡死回合后的堆积量,但明确未解决"永不结束的 prompt"本身。
- 破坏性变更:无(仅测试)。

</details>