### PR TITLE
feat(core): persist oversized tool results to disk (#4095 Phase 4)

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1166,6 +1166,9 @@ export class Config {
   private sessionService: SessionService | undefined = undefined;
   private chatRecordingService: ChatRecordingService | undefined = undefined;
   private fileCheckpointingEnabled: boolean;
+  // Object (not primitive) so sub-agents via Object.create(parentConfig)
+  // share the same budget instance through prototype lookup.
+  private readonly toolResultBudget = { bytesWritten: 0 };
   private fileHistoryService: FileHistoryService | undefined;
   private readonly proxy: string | undefined;
   private cwd: string;
@@ -2269,6 +2272,7 @@ export class Config {
     // constructed via Object.create — those should clear their own
     // cache, not the parent's.
     this.getFileReadCache().clear();
+    this.toolResultBudget.bytesWritten = 0;
     this.getMemoryPressureMonitor()?.resetForNewSession();
     this.fileHistoryService = undefined;
     refreshSessionContext(this.sessionId);
@@ -4243,6 +4247,14 @@ export class Config {
     }
 
     return this.toolOutputBatchBudget;
+  }
+
+  trackToolResultBytes(n: number): void {
+    this.toolResultBudget.bytesWritten += n;
+  }
+
+  getToolResultBytesWritten(): number {
+    return this.toolResultBudget.bytesWritten;
   }
 
   getOutputFormat(): OutputFormat {

--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -320,6 +320,10 @@ export class Storage {
     return targetDir;
   }
 
+  getToolResultsDir(): string {
+    return path.join(this.getProjectTempDir(), 'tool-results');
+  }
+
   ensureProjectTempDirExists(): void {
     fs.mkdirSync(this.getProjectTempDir(), { recursive: true });
   }

--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -78,6 +78,7 @@ When requested to perform tasks like fixing bugs, adding features, refactoring, 
 **Key Principle:** Start with a reasonable plan based on available information, then adapt as you learn. Users prefer seeing progress quickly rather than waiting for perfect understanding.
 
 - Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are NOT part of the user's provided input or the tool result.
+- When you see a <persisted-output> tag in a tool result, the full output was saved to disk because it was too large. Use the read_file tool to access the complete content if the preview is insufficient.
 
 ## New Applications
 
@@ -308,6 +309,7 @@ When requested to perform tasks like fixing bugs, adding features, refactoring, 
 **Key Principle:** Start with a reasonable plan based on available information, then adapt as you learn. Users prefer seeing progress quickly rather than waiting for perfect understanding.
 
 - Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are NOT part of the user's provided input or the tool result.
+- When you see a <persisted-output> tag in a tool result, the full output was saved to disk because it was too large. Use the read_file tool to access the complete content if the preview is insufficient.
 
 ## New Applications
 
@@ -553,6 +555,7 @@ When requested to perform tasks like fixing bugs, adding features, refactoring, 
 **Key Principle:** Start with a reasonable plan based on available information, then adapt as you learn. Users prefer seeing progress quickly rather than waiting for perfect understanding.
 
 - Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are NOT part of the user's provided input or the tool result.
+- When you see a <persisted-output> tag in a tool result, the full output was saved to disk because it was too large. Use the read_file tool to access the complete content if the preview is insufficient.
 
 ## New Applications
 
@@ -778,6 +781,7 @@ When requested to perform tasks like fixing bugs, adding features, refactoring, 
 **Key Principle:** Start with a reasonable plan based on available information, then adapt as you learn. Users prefer seeing progress quickly rather than waiting for perfect understanding.
 
 - Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are NOT part of the user's provided input or the tool result.
+- When you see a <persisted-output> tag in a tool result, the full output was saved to disk because it was too large. Use the read_file tool to access the complete content if the preview is insufficient.
 
 ## New Applications
 
@@ -1003,6 +1007,7 @@ When requested to perform tasks like fixing bugs, adding features, refactoring, 
 **Key Principle:** Start with a reasonable plan based on available information, then adapt as you learn. Users prefer seeing progress quickly rather than waiting for perfect understanding.
 
 - Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are NOT part of the user's provided input or the tool result.
+- When you see a <persisted-output> tag in a tool result, the full output was saved to disk because it was too large. Use the read_file tool to access the complete content if the preview is insufficient.
 
 ## New Applications
 
@@ -1228,6 +1233,7 @@ When requested to perform tasks like fixing bugs, adding features, refactoring, 
 **Key Principle:** Start with a reasonable plan based on available information, then adapt as you learn. Users prefer seeing progress quickly rather than waiting for perfect understanding.
 
 - Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are NOT part of the user's provided input or the tool result.
+- When you see a <persisted-output> tag in a tool result, the full output was saved to disk because it was too large. Use the read_file tool to access the complete content if the preview is insufficient.
 
 ## New Applications
 
@@ -1453,6 +1459,7 @@ When requested to perform tasks like fixing bugs, adding features, refactoring, 
 **Key Principle:** Start with a reasonable plan based on available information, then adapt as you learn. Users prefer seeing progress quickly rather than waiting for perfect understanding.
 
 - Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are NOT part of the user's provided input or the tool result.
+- When you see a <persisted-output> tag in a tool result, the full output was saved to disk because it was too large. Use the read_file tool to access the complete content if the preview is insufficient.
 
 ## New Applications
 
@@ -1678,6 +1685,7 @@ When requested to perform tasks like fixing bugs, adding features, refactoring, 
 **Key Principle:** Start with a reasonable plan based on available information, then adapt as you learn. Users prefer seeing progress quickly rather than waiting for perfect understanding.
 
 - Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are NOT part of the user's provided input or the tool result.
+- When you see a <persisted-output> tag in a tool result, the full output was saved to disk because it was too large. Use the read_file tool to access the complete content if the preview is insufficient.
 
 ## New Applications
 
@@ -1903,6 +1911,7 @@ When requested to perform tasks like fixing bugs, adding features, refactoring, 
 **Key Principle:** Start with a reasonable plan based on available information, then adapt as you learn. Users prefer seeing progress quickly rather than waiting for perfect understanding.
 
 - Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are NOT part of the user's provided input or the tool result.
+- When you see a <persisted-output> tag in a tool result, the full output was saved to disk because it was too large. Use the read_file tool to access the complete content if the preview is insufficient.
 
 ## New Applications
 
@@ -2128,6 +2137,7 @@ When requested to perform tasks like fixing bugs, adding features, refactoring, 
 **Key Principle:** Start with a reasonable plan based on available information, then adapt as you learn. Users prefer seeing progress quickly rather than waiting for perfect understanding.
 
 - Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are NOT part of the user's provided input or the tool result.
+- When you see a <persisted-output> tag in a tool result, the full output was saved to disk because it was too large. Use the read_file tool to access the complete content if the preview is insufficient.
 
 ## New Applications
 
@@ -2376,6 +2386,7 @@ When requested to perform tasks like fixing bugs, adding features, refactoring, 
 **Key Principle:** Start with a reasonable plan based on available information, then adapt as you learn. Users prefer seeing progress quickly rather than waiting for perfect understanding.
 
 - Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are NOT part of the user's provided input or the tool result.
+- When you see a <persisted-output> tag in a tool result, the full output was saved to disk because it was too large. Use the read_file tool to access the complete content if the preview is insufficient.
 
 ## New Applications
 
@@ -2687,6 +2698,7 @@ When requested to perform tasks like fixing bugs, adding features, refactoring, 
 **Key Principle:** Start with a reasonable plan based on available information, then adapt as you learn. Users prefer seeing progress quickly rather than waiting for perfect understanding.
 
 - Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are NOT part of the user's provided input or the tool result.
+- When you see a <persisted-output> tag in a tool result, the full output was saved to disk because it was too large. Use the read_file tool to access the complete content if the preview is insufficient.
 
 ## New Applications
 
@@ -2935,6 +2947,7 @@ When requested to perform tasks like fixing bugs, adding features, refactoring, 
 **Key Principle:** Start with a reasonable plan based on available information, then adapt as you learn. Users prefer seeing progress quickly rather than waiting for perfect understanding.
 
 - Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are NOT part of the user's provided input or the tool result.
+- When you see a <persisted-output> tag in a tool result, the full output was saved to disk because it was too large. Use the read_file tool to access the complete content if the preview is insufficient.
 
 ## New Applications
 
@@ -3242,6 +3255,7 @@ When requested to perform tasks like fixing bugs, adding features, refactoring, 
 **Key Principle:** Start with a reasonable plan based on available information, then adapt as you learn. Users prefer seeing progress quickly rather than waiting for perfect understanding.
 
 - Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are NOT part of the user's provided input or the tool result.
+- When you see a <persisted-output> tag in a tool result, the full output was saved to disk because it was too large. Use the read_file tool to access the complete content if the preview is insufficient.
 
 ## New Applications
 
@@ -3467,6 +3481,7 @@ When requested to perform tasks like fixing bugs, adding features, refactoring, 
 **Key Principle:** Start with a reasonable plan based on available information, then adapt as you learn. Users prefer seeing progress quickly rather than waiting for perfect understanding.
 
 - Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are NOT part of the user's provided input or the tool result.
+- When you see a <persisted-output> tag in a tool result, the full output was saved to disk because it was too large. Use the read_file tool to access the complete content if the preview is insufficient.
 
 ## New Applications
 

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -17,6 +17,8 @@ import process from 'node:process';
 // Config
 import { ApprovalMode, type Config } from '../config/config.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import { cleanupOldToolResults } from '../utils/toolResultCleanup.js';
+import { Storage } from '../config/storage.js';
 import { recordStartupEvent } from '../utils/startupEventSink.js';
 import {
   microcompactHistory,
@@ -311,6 +313,12 @@ export class GeminiClient {
     }
 
     this.initializedSessionId = sessionId;
+
+    // Clean up stale tool result files from previous sessions (fire-and-forget)
+    void cleanupOldToolResults(
+      Storage.getGlobalTempDir(),
+      24 * 60 * 60 * 1000,
+    );
   }
 
   /**
@@ -642,6 +650,11 @@ export class GeminiClient {
     // pointing at content the model can no longer retrieve.
     debugLogger.debug('[FILE_READ_CACHE] clear after resetChat');
     this.config.getFileReadCache().clear();
+    // Clean up old tool result overflow files on /clear
+    void cleanupOldToolResults(
+      Storage.getGlobalTempDir(),
+      24 * 60 * 60 * 1000,
+    );
     this.config.getBaseLlmClient().clearPerModelGeneratorCache();
     // Abort any in-flight auto-memory recall so the stale controller
     // does not leak into the next session.

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -724,7 +724,10 @@ describe('CoreToolScheduler', () => {
         }),
         storage: {
           getProjectTempDir: () => '/tmp',
+          getToolResultsDir: () => '/tmp/tool-results',
         },
+        getToolResultBytesWritten: () => 0,
+        trackToolResultBytes: vi.fn(),
         getTruncateToolOutputThreshold: () =>
           DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
         getTruncateToolOutputLines: () => DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
@@ -3030,7 +3033,10 @@ describe('CoreToolScheduler', () => {
         }),
         storage: {
           getProjectTempDir: () => '/tmp',
+          getToolResultsDir: () => '/tmp/tool-results',
         },
+        getToolResultBytesWritten: () => 0,
+        trackToolResultBytes: vi.fn(),
         getTruncateToolOutputThreshold: () =>
           DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
         getTruncateToolOutputLines: () => DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
@@ -3119,7 +3125,10 @@ describe('CoreToolScheduler', () => {
         }),
         storage: {
           getProjectTempDir: () => '/tmp',
+          getToolResultsDir: () => '/tmp/tool-results',
         },
+        getToolResultBytesWritten: () => 0,
+        trackToolResultBytes: vi.fn(),
         getTruncateToolOutputThreshold: () =>
           DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
         getTruncateToolOutputLines: () => DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
@@ -8103,7 +8112,10 @@ describe('Fire hook functions integration', () => {
         }),
         storage: {
           getProjectTempDir: () => '/tmp',
+          getToolResultsDir: () => '/tmp/tool-results',
         },
+        getToolResultBytesWritten: () => 0,
+        trackToolResultBytes: vi.fn(),
         getTruncateToolOutputThreshold: () =>
           DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
         getTruncateToolOutputLines: () => DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -68,6 +68,10 @@ import { CONCURRENCY_SAFE_KINDS } from '../tools/tools.js';
 import { isShellCommandReadOnly } from '../utils/shellReadOnlyChecker.js';
 import { stripShellWrapper } from '../utils/shell-utils.js';
 import {
+  isAlreadyTruncated,
+  persistAndTruncateToolResult,
+} from '../utils/truncation.js';
+import {
   injectPermissionRulesIfMissing,
   persistPermissionOutcome,
 } from './permission-helpers.js';
@@ -128,6 +132,49 @@ import {
 } from '../telemetry/index.js';
 import { safeJsonStringify } from '../utils/safeJsonStringify.js';
 import { acquireSleepInhibitor } from '../services/sleepInhibitor.js';
+
+const GATE_HEADROOM = 3000;
+const GATE_EXEMPT_TOOLS = new Set(['read_file']);
+
+function recalcContentLength(c: PartListUnion): number | undefined {
+  if (typeof c === 'string') return c.length;
+  if (Array.isArray(c)) {
+    const parts = toParts(c);
+    return parts.reduce((n, p) => n + (p.text?.length ?? 0), 0);
+  }
+  if (c && typeof c === 'object' && 'text' in c) {
+    const text = (c as { text?: string }).text;
+    if (typeof text === 'string') return text.length;
+  }
+  return undefined;
+}
+
+function extractTextFromPartListUnion(c: PartListUnion): string {
+  if (typeof c === 'string') return c;
+  if (Array.isArray(c)) {
+    const parts = toParts(c);
+    return parts.map((p) => p.text ?? '').join('\n');
+  }
+  if (c && typeof c === 'object') {
+    if ('text' in c) {
+      const text = (c as { text?: string }).text;
+      if (typeof text === 'string') return text;
+    }
+    if ('functionResponse' in c) {
+      const fr = (
+        c as {
+          functionResponse?: { response?: Record<string, unknown> };
+        }
+      ).functionResponse;
+      const resp = fr?.response;
+      if (resp) {
+        if (typeof resp['output'] === 'string') return resp['output'];
+        if (typeof resp['content'] === 'string') return resp['content'];
+      }
+    }
+  }
+  return '';
+}
 
 const TOOL_FAILURE_KIND_ATTRIBUTE = 'tool.failure_kind';
 const TOOL_FAILURE_KIND_PRE_HOOK_BLOCKED = 'pre_hook_blocked';
@@ -3121,6 +3168,8 @@ export class CoreToolScheduler {
 
       if (toolResult.error === undefined) {
         let content = toolResult.llmContent;
+        let contentLength: number | undefined =
+          typeof content === 'string' ? content.length : undefined;
 
         // Deferred metadata: PostToolUse hook context and skill/rule reminders
         // are captured here and appended AFTER the model-facing truncation
@@ -3197,6 +3246,15 @@ export class CoreToolScheduler {
             return;
           }
         }
+
+        // Universal post-execution truncation gate — persists oversized
+        // tool results to disk before system-reminders are appended.
+        content = await this.maybePersistLargeToolResult(
+          callId,
+          toolName,
+          content,
+        );
+        contentLength = recalcContentLength(content) ?? contentLength;
 
         // Collect filesystem paths the tool just touched. Different tools
         // use different parameter names: `file_path` (read/edit/write),
@@ -3420,9 +3478,9 @@ export class CoreToolScheduler {
           );
         }
 
-        // Computed AFTER truncation so it reflects the model-facing length,
+        // Recompute AFTER truncation so it reflects the model-facing length,
         // consistent with the batch-offload path (which also updates it).
-        const contentLength =
+        contentLength =
           typeof content === 'string' ? content.length : undefined;
 
         const response = convertToFunctionResponse(toolName, callId, content);
@@ -3478,6 +3536,22 @@ export class CoreToolScheduler {
           if (failureHookResult.additionalContext) {
             errorMessage += `\n\n${failureHookResult.additionalContext}`;
           }
+        }
+
+        // Truncate oversized error messages (e.g., large stderr)
+        const errorGateThreshold =
+          this.config.getTruncateToolOutputThreshold() + GATE_HEADROOM;
+        if (
+          errorMessage.length > errorGateThreshold &&
+          !isAlreadyTruncated(errorMessage)
+        ) {
+          const persistResult = await persistAndTruncateToolResult(
+            callId,
+            toolName,
+            errorMessage,
+            this.config,
+          );
+          errorMessage = persistResult.content;
         }
 
         addToolResultAttributes(
@@ -3733,6 +3807,47 @@ export class CoreToolScheduler {
     }
   }
 
+  private async maybePersistLargeToolResult(
+    callId: string,
+    toolName: string,
+    content: PartListUnion,
+  ): Promise<PartListUnion> {
+    if (GATE_EXEMPT_TOOLS.has(toolName)) return content;
+
+    const text = extractTextFromPartListUnion(content);
+    if (!text || isAlreadyTruncated(text)) return content;
+
+    const gateThreshold =
+      this.config.getTruncateToolOutputThreshold() + GATE_HEADROOM;
+    if (text.length <= gateThreshold) return content;
+
+    const result = await persistAndTruncateToolResult(
+      callId,
+      toolName,
+      text,
+      this.config,
+    );
+
+    if (result.outputFile) {
+      debugLogger.debug(
+        `Persisted ${toolName} result (${result.bytesWritten} bytes) to ${result.outputFile}`,
+      );
+    }
+
+    // Preserve non-text parts (media) when content is Part[]
+    if (Array.isArray(content)) {
+      const mediaParts = content.filter(
+        (p) =>
+          (p as { inlineData?: unknown }).inlineData ||
+          (p as { fileData?: unknown }).fileData,
+      );
+      const stubPart: Part = { text: result.content };
+      return mediaParts.length > 0 ? [stubPart, ...mediaParts] : [stubPart];
+    }
+
+    return result.content;
+  }
+
   /**
    * Records tool results to the chat recording service.
    * This captures both the raw Content (for API reconstruction) and
@@ -3826,6 +3941,7 @@ export class CoreToolScheduler {
     if (typeof output !== 'string') return null;
     if (fr.parts && fr.parts.length > 0) return null; // media present
     if (output.startsWith(TOOL_OUTPUT_TRUNCATED_PREFIX)) return null; // already
+    if (output.startsWith('<persisted-output>')) return null;
 
     let truncated: { content: string; outputFile?: string };
     try {

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -133,21 +133,13 @@ import {
 import { safeJsonStringify } from '../utils/safeJsonStringify.js';
 import { acquireSleepInhibitor } from '../services/sleepInhibitor.js';
 
+// Gap between the persistence gate and per-tool truncation thresholds.
+// Tools that self-truncate to ~25K add headers bringing output to ~25.4K;
+// the headroom ensures the gate only fires for genuinely un-truncated output
+// and must exceed the stub size (~2.3K) to avoid cascading re-persistence.
 const GATE_HEADROOM = 3000;
 const GATE_EXEMPT_TOOLS = new Set(['read_file']);
 
-function recalcContentLength(c: PartListUnion): number | undefined {
-  if (typeof c === 'string') return c.length;
-  if (Array.isArray(c)) {
-    const parts = toParts(c);
-    return parts.reduce((n, p) => n + (p.text?.length ?? 0), 0);
-  }
-  if (c && typeof c === 'object' && 'text' in c) {
-    const text = (c as { text?: string }).text;
-    if (typeof text === 'string') return text.length;
-  }
-  return undefined;
-}
 
 function extractTextFromPartListUnion(c: PartListUnion): string {
   if (typeof c === 'string') return c;
@@ -3254,7 +3246,6 @@ export class CoreToolScheduler {
           toolName,
           content,
         );
-        contentLength = recalcContentLength(content) ?? contentLength;
 
         // Collect filesystem paths the tool just touched. Different tools
         // use different parameter names: `file_path` (read/edit/write),

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -214,6 +214,7 @@ When requested to perform tasks like fixing bugs, adding features, refactoring, 
 **Key Principle:** Start with a reasonable plan based on available information, then adapt as you learn. Users prefer seeing progress quickly rather than waiting for perfect understanding.
 
 - Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are NOT part of the user's provided input or the tool result.
+- When you see a <persisted-output> tag in a tool result, the full output was saved to disk because it was too large. Use the read_file tool to access the complete content if the preview is insufficient.
 
 ## New Applications
 

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -786,6 +786,31 @@ export class ToolOutputTruncatedEvent implements BaseTelemetryEvent {
   }
 }
 
+export class ToolResultPersistedEvent implements BaseTelemetryEvent {
+  readonly eventName = 'tool_result_persisted';
+  readonly 'event.timestamp' = new Date().toISOString();
+  'event.name': string;
+  tool_name: string;
+  bytes_written: number;
+  output_file: string;
+  prompt_id: string;
+
+  constructor(
+    prompt_id: string,
+    details: {
+      toolName: string;
+      bytesWritten: number;
+      outputFile: string;
+    },
+  ) {
+    this['event.name'] = this.eventName;
+    this.prompt_id = prompt_id;
+    this.tool_name = details.toolName;
+    this.bytes_written = details.bytesWritten;
+    this.output_file = details.outputFile;
+  }
+}
+
 export class ExtensionUninstallEvent implements BaseTelemetryEvent {
   'event.name': 'extension_uninstall';
   'event.timestamp': string;
@@ -1032,6 +1057,7 @@ export type TelemetryEvent =
   | ExtensionInstallEvent
   | ExtensionUninstallEvent
   | ToolOutputTruncatedEvent
+  | ToolResultPersistedEvent
   | ModelSlashCommandEvent
   | AuthEvent
   | HookCallEvent

--- a/packages/core/src/utils/toolResultCleanup.ts
+++ b/packages/core/src/utils/toolResultCleanup.ts
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { createDebugLogger } from './debugLogger.js';
+
+const debugLogger = createDebugLogger('TOOL_RESULT_CLEANUP');
+
+export interface CleanupResult {
+  filesDeleted: number;
+  bytesFreed: number;
+  errors: number;
+}
+
+export async function cleanupOldToolResults(
+  globalTempDir: string,
+  maxAgeMs: number,
+): Promise<CleanupResult> {
+  const result: CleanupResult = { filesDeleted: 0, bytesFreed: 0, errors: 0 };
+
+  let projectDirs: string[];
+  try {
+    projectDirs = await fs.readdir(globalTempDir);
+  } catch (error) {
+    debugLogger.debug(`Cannot read globalTempDir ${globalTempDir}:`, error);
+    return result;
+  }
+
+  const now = Date.now();
+
+  for (const projectHash of projectDirs) {
+    const projectDir = path.join(globalTempDir, projectHash);
+
+    let projectStat;
+    try {
+      projectStat = await fs.lstat(projectDir);
+    } catch (error) {
+      debugLogger.debug(`Cannot stat ${projectDir}:`, error);
+      result.errors++;
+      continue;
+    }
+    if (!projectStat.isDirectory()) continue;
+
+    await cleanupDirectory(
+      path.join(projectDir, 'tool-results'),
+      now,
+      maxAgeMs,
+      result,
+    );
+    await cleanupLegacyOutputFiles(projectDir, now, maxAgeMs, result);
+  }
+
+  if (result.filesDeleted > 0) {
+    debugLogger.debug(
+      `Cleaned up ${result.filesDeleted} tool result files, freed ${Math.round(result.bytesFreed / 1024)} KB`,
+    );
+  }
+  if (result.errors > 0) {
+    debugLogger.warn(
+      `${result.errors} errors during tool result cleanup`,
+    );
+  }
+
+  return result;
+}
+
+async function cleanupDirectory(
+  dir: string,
+  now: number,
+  maxAgeMs: number,
+  result: CleanupResult,
+): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dir);
+  } catch (error) {
+    debugLogger.debug(`Cannot read directory ${dir}:`, error);
+    return;
+  }
+
+  for (const entry of entries) {
+    await tryDeleteIfOld(path.join(dir, entry), now, maxAgeMs, result);
+  }
+}
+
+async function cleanupLegacyOutputFiles(
+  dir: string,
+  now: number,
+  maxAgeMs: number,
+  result: CleanupResult,
+): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dir);
+  } catch (error) {
+    debugLogger.debug(`Cannot read directory ${dir}:`, error);
+    return;
+  }
+
+  for (const entry of entries) {
+    if (!entry.endsWith('.output')) continue;
+    await tryDeleteIfOld(path.join(dir, entry), now, maxAgeMs, result);
+  }
+}
+
+async function tryDeleteIfOld(
+  filePath: string,
+  now: number,
+  maxAgeMs: number,
+  result: CleanupResult,
+): Promise<void> {
+  try {
+    const stat = await fs.lstat(filePath);
+    if (!stat.isFile()) return;
+    if (now - stat.mtimeMs < maxAgeMs) return;
+
+    await fs.unlink(filePath);
+    result.filesDeleted++;
+    result.bytesFreed += stat.size;
+  } catch (error) {
+    if (
+      error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      error.code === 'ENOENT'
+    ) {
+      return;
+    }
+    debugLogger.debug(`Failed to clean up ${filePath}:`, error);
+    result.errors++;
+  }
+}

--- a/packages/core/src/utils/truncation.ts
+++ b/packages/core/src/utils/truncation.ts
@@ -336,7 +336,7 @@ export async function truncateLlmContent(
 export function isAlreadyTruncated(content: string): boolean {
   return (
     content.includes('... [CONTENT TRUNCATED] ...') ||
-    content.includes('<persisted-output>')
+    content.startsWith('<persisted-output>')
   );
 }
 
@@ -475,10 +475,8 @@ ${preview}
 </persisted-output>`;
   }
 
-  return `<persisted-output>
-Output too large (${sizeKb} KB). ${filePathOrNote}
+  return `Output too large (${sizeKb} KB). ${filePathOrNote}
 
 Preview (up to ${PREVIEW_SIZE_CHARS} chars):
-${preview}
-</persisted-output>`;
+${preview}`;
 }

--- a/packages/core/src/utils/truncation.ts
+++ b/packages/core/src/utils/truncation.ts
@@ -402,6 +402,7 @@ export async function persistAndTruncateToolResult(
   // Reserve budget before async write; rollback on failure below.
   config.trackToolResultBytes(byteSize);
 
+  // eslint-disable-next-line no-control-regex
   const safeCallId = path.basename(callId).replace(/\x00/g, '_');
   if (!safeCallId || safeCallId === '.' || safeCallId === '..') {
     debugLogger.warn(`Invalid callId for disk persistence: ${JSON.stringify(callId)}`);

--- a/packages/core/src/utils/truncation.ts
+++ b/packages/core/src/utils/truncation.ts
@@ -10,8 +10,16 @@ import * as crypto from 'node:crypto';
 import type { Part, PartListUnion } from '@google/genai';
 import { ReadFileTool } from '../tools/read-file.js';
 import type { Config } from '../config/config.js';
+import { atomicWriteFile } from './atomicFileWrite.js';
+import { createDebugLogger } from './debugLogger.js';
 import { logToolOutputTruncated } from '../telemetry/loggers.js';
 import { ToolOutputTruncatedEvent } from '../telemetry/types.js';
+
+const debugLogger = createDebugLogger('TRUNCATION');
+
+const PREVIEW_SIZE_CHARS = 2000;
+const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024; // 50MB
+const MAX_SESSION_BYTES = 500 * 1024 * 1024; // 500MB
 
 /**
  * Stable prefix every truncated tool output starts with. Used as an
@@ -163,7 +171,11 @@ ${truncatedContent}`;
       content: wrappedMessage,
       outputFile,
     };
-  } catch (_error) {
+  } catch (error) {
+    debugLogger.warn(
+      `Failed to save truncated output to ${outputFile}:`,
+      error,
+    );
     return {
       content:
         truncatedContent + `\n[Note: Could not save full output to file]`,
@@ -319,4 +331,153 @@ export async function truncateLlmContent(
     content: [{ text: result.content } as Part, ...mediaParts],
     outputFile: result.outputFile,
   };
+}
+
+export function isAlreadyTruncated(content: string): boolean {
+  return (
+    content.includes('... [CONTENT TRUNCATED] ...') ||
+    content.includes('<persisted-output>')
+  );
+}
+
+function generatePreview(content: string): string {
+  let text =
+    content.length <= PREVIEW_SIZE_CHARS
+      ? content
+      : (() => {
+          const slice = content.slice(0, PREVIEW_SIZE_CHARS);
+          const lastNewline = slice.lastIndexOf('\n');
+          return (
+            (lastNewline > 0 ? slice.slice(0, lastNewline) : slice) + '\n...'
+          );
+        })();
+  // Escape tags that could reshape the model-visible structure
+  text = text
+    .replace(/<\/?persisted-output>/g, (m) => `&lt;${m.slice(1, -1)}&gt;`)
+    .replace(/<\/?system-reminder>/g, (m) => `&lt;${m.slice(1, -1)}&gt;`);
+  return text;
+}
+
+export interface PersistResult {
+  content: string;
+  outputFile?: string;
+  bytesWritten: number;
+}
+
+export async function persistAndTruncateToolResult(
+  callId: string,
+  toolName: string,
+  content: string,
+  config: Config,
+): Promise<PersistResult> {
+  const byteSize = Buffer.byteLength(content, 'utf-8');
+
+  // Hard size cap — content already in memory, just skip disk persistence
+  if (byteSize > MAX_FILE_SIZE_BYTES) {
+    debugLogger.warn(
+      `Tool result for ${toolName} exceeds ${MAX_FILE_SIZE_BYTES} bytes (${byteSize}), skipping disk persistence`,
+    );
+    return {
+      content: buildStub(content, byteSize, '(file too large to persist)'),
+      bytesWritten: 0,
+    };
+  }
+
+  // Session budget check — reserve bytes synchronously before async I/O
+  // to prevent parallel tool calls from all passing the check simultaneously.
+  const budgetUsed = config.getToolResultBytesWritten();
+  if (budgetUsed + byteSize > MAX_SESSION_BYTES) {
+    debugLogger.warn(
+      `Session tool result budget exhausted (${budgetUsed} + ${byteSize} > ${MAX_SESSION_BYTES}), skipping disk persistence`,
+    );
+    return {
+      content: buildStub(
+        content,
+        byteSize,
+        '(session disk budget exhausted)',
+      ),
+      bytesWritten: 0,
+    };
+  }
+  // Reserve budget before async write; rollback on failure below.
+  config.trackToolResultBytes(byteSize);
+
+  const safeCallId = path.basename(callId).replace(/\x00/g, '_');
+  if (!safeCallId || safeCallId === '.' || safeCallId === '..') {
+    debugLogger.warn(`Invalid callId for disk persistence: ${JSON.stringify(callId)}`);
+    config.trackToolResultBytes(-byteSize);
+    return {
+      content: buildStub(content, byteSize, '(invalid callId)'),
+      bytesWritten: 0,
+    };
+  }
+  const toolResultsDir = config.storage.getToolResultsDir();
+  const outputFile = path.join(toolResultsDir, `${safeCallId}.txt`);
+
+  try {
+    await fs.mkdir(toolResultsDir, { recursive: true });
+    await atomicWriteFile(outputFile, content, {
+      mode: 0o600,
+      forceMode: true,
+      noFollow: true,
+      flush: false,
+    });
+
+    return {
+      content: buildStub(content, byteSize, outputFile),
+      outputFile,
+      bytesWritten: byteSize,
+    };
+  } catch (error) {
+    // Rollback budget reservation on write failure
+    config.trackToolResultBytes(-byteSize);
+    debugLogger.warn(
+      `Failed to persist tool result to ${outputFile}:`,
+      error,
+    );
+    try {
+      const fallback = await truncateAndSaveToFile(
+        content,
+        `${toolName}_${crypto.randomBytes(6).toString('hex')}`,
+        config.storage.getProjectTempDir(),
+        config.getTruncateToolOutputThreshold(),
+        config.getTruncateToolOutputLines(),
+      );
+      return { content: fallback.content, bytesWritten: 0 };
+    } catch (fallbackError) {
+      debugLogger.warn('Fallback truncation also failed:', fallbackError);
+      return {
+        content: buildStub(content, byteSize, '(disk persistence unavailable)'),
+        bytesWritten: 0,
+      };
+    }
+  }
+}
+
+function buildStub(
+  content: string,
+  byteSize: number,
+  filePathOrNote: string,
+): string {
+  const preview = generatePreview(content);
+  const sizeKb = Math.round(byteSize / 1024);
+  const isFilePath = path.isAbsolute(filePathOrNote);
+
+  if (isFilePath) {
+    return `<persisted-output>
+Output too large (${sizeKb} KB). Full output saved to: ${filePathOrNote}
+Note: this file may be cleaned up after 24 hours.
+To read the complete output, use the ${ReadFileTool.Name} tool with the absolute file path above.
+
+Preview (up to ${PREVIEW_SIZE_CHARS} chars):
+${preview}
+</persisted-output>`;
+  }
+
+  return `<persisted-output>
+Output too large (${sizeKb} KB). ${filePathOrNote}
+
+Preview (up to ${PREVIEW_SIZE_CHARS} chars):
+${preview}
+</persisted-output>`;
 }


### PR DESCRIPTION
## What this PR does

Persists oversized tool results (>28K chars) to disk as `tool-results/<callId>.txt`, replacing the full content in the LLM context with a `<persisted-output>` stub containing a 2KB preview and a file pointer. The model can recover the full output via `read_file`. Also adds 24-hour file cleanup on startup and `/clear`, and a per-session disk budget (500MB cumulative, 50MB per-file).

## Why it's needed

Large tool outputs (e.g. `find /`, `cat` on a big file, MCP tools returning massive JSON) can cause OOM and pollute the LLM context window, degrading response quality. The existing `truncateAndSaveToFile` only covers Shell/MCP tools and uses random filenames with no cleanup. This PR adds a universal gate that catches all tool types, with organized storage, budget controls, and automatic cleanup.

## Reviewer Test Plan

### How to verify

1. Run a command that produces large output: `find / -name "*.ts" 2>/dev/null | head -50000`
2. Observe the tool result is replaced with a `<persisted-output>` stub showing file path + 2KB preview
3. Verify the file exists at the path shown in the stub, with `ls -la` confirming `0o600` permissions
4. Use `read_file` on the persisted file to confirm full content is recoverable
5. Run `/clear` and check debug logs for cleanup activity
6. Run a small command (e.g. `echo hello`) and confirm output passes through unchanged
7. Run a command whose output is already truncated by the shell tool — confirm no double-file creation

### Evidence (Before & After)

N/A — non-UI change. Core truncation infrastructure, no visual impact.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  ⚠️   |
|  🐧 Linux  |  ⚠️   |

### Environment (optional)

Local dev: `npm run dev` on macOS. TypeScript compilation verified. Unit tests deferred (worktree environment lacks full node_modules).

## Risk & Scope

- Main risk or tradeoff: Content exceeding the budget cap (50MB single file or 500MB session) gets only a 2KB preview with no disk file — the model cannot recover the full output. This is intentional to prevent disk exhaustion.
- Not validated / out of scope: `ToolResultPersistedEvent` telemetry is defined but not wired to emit (deferred to follow-up PR). Unit tests for the new functions are not included in this PR.
- Breaking changes / migration notes: None. The gate only activates for outputs exceeding the threshold; all existing behavior is preserved.

## Linked Issues

Partial fix for #4095 (Phase 4: Tool Result Disk Overflow)

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

将超大工具结果（>28K 字符）持久化到磁盘的 `tool-results/<callId>.txt` 文件中，在 LLM 上下文中用包含 2KB 预览和文件指针的 `<persisted-output>` 桩替换完整内容。模型可以通过 `read_file` 恢复完整输出。同时添加了启动和 `/clear` 时的 24 小时文件清理，以及每会话磁盘预算（累计 500MB，单文件 50MB）。

## 为什么需要

大型工具输出（如 `find /`、对大文件执行 `cat`、MCP 工具返回大量 JSON）可能导致 OOM 并污染 LLM 上下文窗口，降低响应质量。现有的 `truncateAndSaveToFile` 仅覆盖 Shell/MCP 工具，使用随机文件名且无清理机制。此 PR 添加了通用截断门，覆盖所有工具类型，具有有序存储、预算控制和自动清理功能。

## 审阅者测试计划

### 如何验证

1. 运行产生大量输出的命令：`find / -name "*.ts" 2>/dev/null | head -50000`
2. 观察工具结果被替换为 `<persisted-output>` 桩，显示文件路径和 2KB 预览
3. 验证桩中显示路径的文件存在，`ls -la` 确认权限为 `0o600`
4. 对持久化文件使用 `read_file` 确认完整内容可恢复
5. 运行 `/clear` 并检查调试日志中的清理活动
6. 运行小命令（如 `echo hello`）确认输出不变通过
7. 运行已被 shell 工具截断的命令输出——确认无双文件创建

### 证据（前后对比）

N/A — 非 UI 改动。核心截断基础设施，无视觉影响。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️ |
|  🐧 Linux  |  ⚠️ |

## 风险和范围

- 主要风险/权衡：超过预算上限（单文件 50MB 或会话 500MB）的内容只能获得 2KB 预览，没有磁盘文件——模型无法恢复完整输出。这是为了防止磁盘耗尽的有意设计。
- 未验证/超出范围：`ToolResultPersistedEvent` 遥测已定义但未接线发射（推迟到后续 PR）。新函数的单元测试未包含在此 PR 中。
- 破坏性变更/迁移说明：无。截断门仅在输出超过阈值时激活；所有现有行为保持不变。

## 关联 Issue

部分修复 #4095（Phase 4: Tool Result Disk Overflow）

</details>

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)