### PR TITLE
feat(core): let grep results satisfy prior-read checks

### DIFF
--- a/packages/core/src/tools/grep.test.ts
+++ b/packages/core/src/tools/grep.test.ts
@@ -14,6 +14,7 @@ import type { Config } from '../config/config.js';
 import { createMockWorkspaceContext } from '../test-utils/mockWorkspaceContext.js';
 import { ToolErrorType } from './tool-error.js';
 import * as glob from 'glob';
+import { FileReadCache } from '../services/fileReadCache.js';
 
 vi.mock('glob', { spy: true });
 
@@ -84,6 +85,7 @@ vi.mock('child_process', async (importOriginal) => {
 describe('GrepTool', () => {
   let tempRootDir: string;
   let grepTool: GrepTool;
+  let fileReadCache: FileReadCache;
   const abortSignal = new AbortController().signal;
 
   const mockConfig = {
@@ -99,6 +101,11 @@ describe('GrepTool', () => {
   beforeEach(async () => {
     Object.assign(mockConfig, {
       getTruncateToolOutputThreshold: () => 25000,
+    });
+    fileReadCache = new FileReadCache();
+    Object.assign(mockConfig, {
+      getFileReadCache: () => fileReadCache,
+      getFileReadCacheDisabled: () => false,
     });
     tempRootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'grep-tool-root-'));
     grepTool = new GrepTool(mockConfig);
@@ -214,6 +221,23 @@ describe('GrepTool', () => {
         path.join(tempRootDir, 'fileA.txt'),
         path.join(tempRootDir, 'sub', 'fileC.txt'),
       ]);
+
+      const fileAStats = await fs.stat(path.join(tempRootDir, 'fileA.txt'));
+      const fileCStats = await fs.stat(
+        path.join(tempRootDir, 'sub', 'fileC.txt'),
+      );
+      const fileARead = fileReadCache.check(fileAStats);
+      const fileCRead = fileReadCache.check(fileCStats);
+      expect(fileARead.state).toBe('fresh');
+      expect(fileCRead.state).toBe('fresh');
+      if (fileARead.state === 'fresh') {
+        expect(fileARead.entry.lastReadWasFull).toBe(false);
+        expect(fileARead.entry.lastReadCacheable).toBe(true);
+      }
+      if (fileCRead.state === 'fresh') {
+        expect(fileCRead.entry.lastReadWasFull).toBe(false);
+        expect(fileCRead.entry.lastReadCacheable).toBe(true);
+      }
     });
 
     it('normalizes CRLF fallback grep output without dropping result paths', () => {

--- a/packages/core/src/tools/grep.ts
+++ b/packages/core/src/tools/grep.ts
@@ -27,6 +27,7 @@ import type { PermissionDecision } from '../permissions/types.js';
 import type { FileExclusions } from '../utils/ignorePatterns.js';
 import { ToolErrorType } from './tool-error.js';
 import { isCommandAvailable } from '../utils/shell-utils.js';
+import { recordGrepResultFileReads } from './grepReadTracking.js';
 
 const debugLogger = createDebugLogger('GREP');
 
@@ -268,16 +269,19 @@ class GrepToolInvocation extends BaseToolInvocation<
         displayMessage += ` (truncated)`;
       }
 
+      const resultFilePaths = Array.from(
+        new Set(
+          visibleMatches
+            .map((match) => match.absoluteFilePath)
+            .filter((filePath) => filePath !== ''),
+        ),
+      );
+      await recordGrepResultFileReads(this.config, resultFilePaths);
+
       return {
         llmContent: llmContent.trim(),
         returnDisplay: displayMessage,
-        resultFilePaths: Array.from(
-          new Set(
-            visibleMatches
-              .map((match) => match.absoluteFilePath)
-              .filter((filePath) => filePath !== ''),
-          ),
-        ),
+        resultFilePaths,
       };
     } catch (error) {
       debugLogger.error(`Error during GrepLogic execution: ${error}`);

--- a/packages/core/src/tools/grepReadTracking.test.ts
+++ b/packages/core/src/tools/grepReadTracking.test.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import type { Config } from '../config/config.js';
+import { FileReadCache } from '../services/fileReadCache.js';
+import { recordGrepResultFileReads } from './grepReadTracking.js';
+
+describe('recordGrepResultFileReads', () => {
+  let tempRootDir: string;
+  let fileReadCache: FileReadCache;
+
+  beforeEach(async () => {
+    tempRootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'grep-read-cache-'));
+    fileReadCache = new FileReadCache();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(tempRootDir, { recursive: true, force: true });
+  });
+
+  function mockConfig(
+    cache: FileReadCache | undefined = fileReadCache,
+    disabled = false,
+  ): Config {
+    return {
+      getFileReadCacheDisabled: () => disabled,
+      getFileReadCache: () => cache,
+    } as unknown as Config;
+  }
+
+  it('does nothing when the cache is disabled', async () => {
+    const filePath = path.join(tempRootDir, 'result.ts');
+    await fs.writeFile(filePath, 'match');
+    const stats = await fs.stat(filePath);
+
+    await recordGrepResultFileReads(mockConfig(fileReadCache, true), [
+      filePath,
+    ]);
+
+    expect(fileReadCache.check(stats).state).toBe('unknown');
+  });
+
+  it('does nothing when the config has no cache', async () => {
+    const filePath = path.join(tempRootDir, 'result.ts');
+    await fs.writeFile(filePath, 'match');
+
+    await expect(
+      recordGrepResultFileReads(mockConfig(undefined), [filePath]),
+    ).resolves.toBeUndefined();
+  });
+
+  it('records text grep results as partial cacheable reads', async () => {
+    const filePath = path.join(tempRootDir, 'result.ts');
+    await fs.writeFile(filePath, 'const value = "match";');
+    const stats = await fs.stat(filePath);
+
+    await recordGrepResultFileReads(mockConfig(), [filePath]);
+
+    const result = fileReadCache.check(stats);
+    expect(result.state).toBe('fresh');
+    if (result.state === 'fresh') {
+      expect(result.entry.lastReadWasFull).toBe(false);
+      expect(result.entry.lastReadCacheable).toBe(true);
+    }
+  });
+
+  it('does not make notebook grep results cacheable', async () => {
+    const filePath = path.join(tempRootDir, 'notebook.ipynb');
+    await fs.writeFile(filePath, '{"cells":[{"source":"match"}]}');
+    const stats = await fs.stat(filePath);
+
+    await recordGrepResultFileReads(mockConfig(), [filePath]);
+
+    const result = fileReadCache.check(stats);
+    expect(result.state).toBe('fresh');
+    if (result.state === 'fresh') {
+      expect(result.entry.lastReadWasFull).toBe(false);
+      expect(result.entry.lastReadCacheable).toBe(false);
+    }
+  });
+
+  it('ignores non-file grep result paths', async () => {
+    const dirPath = path.join(tempRootDir, 'nested');
+    await fs.mkdir(dirPath);
+    const stats = await fs.stat(dirPath);
+
+    await recordGrepResultFileReads(mockConfig(), [dirPath]);
+
+    expect(fileReadCache.check(stats).state).toBe('unknown');
+  });
+
+  it('ignores result paths that disappear before stat', async () => {
+    await expect(
+      recordGrepResultFileReads(mockConfig(), [
+        path.join(tempRootDir, 'missing.ts'),
+      ]),
+    ).resolves.toBeUndefined();
+  });
+
+  it('continues after a stat failure', async () => {
+    const filePath = path.join(tempRootDir, 'result.ts');
+    const blockedPath = path.join(tempRootDir, 'blocked.ts');
+    await fs.writeFile(filePath, 'match');
+    const stats = await fs.stat(filePath);
+    const actualStat = fs.stat.bind(fs);
+    vi.spyOn(fs, 'stat').mockImplementation(async (target) => {
+      if (target === blockedPath) {
+        throw Object.assign(new Error('denied'), { code: 'EACCES' });
+      }
+      return actualStat(target);
+    });
+
+    await recordGrepResultFileReads(mockConfig(), [blockedPath, filePath]);
+
+    expect(fileReadCache.check(stats).state).toBe('fresh');
+  });
+});

--- a/packages/core/src/tools/grepReadTracking.ts
+++ b/packages/core/src/tools/grepReadTracking.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { Config } from '../config/config.js';
+import { createDebugLogger } from '../utils/debugLogger.js';
+
+const STAT_BATCH_SIZE = 50;
+const NON_CACHEABLE_GREP_EXTENSIONS = new Set(['.ipynb']);
+const debugLogger = createDebugLogger('GREP_READ_TRACKING');
+
+export async function recordGrepResultFileReads(
+  config: Config,
+  filePaths: string[],
+): Promise<void> {
+  if (config.getFileReadCacheDisabled?.()) {
+    return;
+  }
+  const cache = config.getFileReadCache?.();
+  if (!cache) {
+    return;
+  }
+
+  const uniqueFilePaths = Array.from(new Set(filePaths));
+  for (let i = 0; i < uniqueFilePaths.length; i += STAT_BATCH_SIZE) {
+    const batch = uniqueFilePaths.slice(i, i + STAT_BATCH_SIZE);
+    await Promise.all(
+      batch.map(async (filePath) => {
+        try {
+          const stats = await fs.stat(filePath);
+          if (!stats.isFile()) {
+            return;
+          }
+          cache.recordRead(filePath, stats, {
+            full: false,
+            cacheable: isGrepResultCacheable(filePath),
+          });
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+            debugLogger.debug(
+              'Failed to stat grep result path',
+              filePath,
+              error,
+            );
+          }
+        }
+      }),
+    );
+  }
+}
+
+function isGrepResultCacheable(filePath: string): boolean {
+  return !NON_CACHEABLE_GREP_EXTENSIONS.has(
+    path.extname(filePath).toLowerCase(),
+  );
+}

--- a/packages/core/src/tools/ripGrep.test.ts
+++ b/packages/core/src/tools/ripGrep.test.ts
@@ -23,6 +23,7 @@ import { createMockWorkspaceContext } from '../test-utils/mockWorkspaceContext.j
 import { spawn } from 'node:child_process';
 import { runRipgrep } from '../utils/ripgrepUtils.js';
 import { DEFAULT_FILE_FILTERING_OPTIONS } from '../config/constants.js';
+import { FileReadCache } from '../services/fileReadCache.js';
 
 // Mock ripgrepUtils
 vi.mock('../utils/ripgrepUtils.js', () => ({
@@ -40,6 +41,7 @@ describe('RipGrepTool', () => {
   let tempRootDir: string;
   let grepTool: RipGrepTool;
   let fileExclusionsMock: { getGlobExcludes: () => string[] };
+  let fileReadCache: FileReadCache;
   const abortSignal = new AbortController().signal;
   const sep = '\x1f';
 
@@ -63,9 +65,12 @@ describe('RipGrepTool', () => {
     fileExclusionsMock = {
       getGlobExcludes: vi.fn().mockReturnValue([]),
     };
+    fileReadCache = new FileReadCache();
     Object.assign(mockConfig, {
       getFileExclusions: () => fileExclusionsMock,
       getFileFilteringOptions: () => DEFAULT_FILE_FILTERING_OPTIONS,
+      getFileReadCache: () => fileReadCache,
+      getFileReadCacheDisabled: () => false,
     });
     grepTool = new RipGrepTool(mockConfig);
 
@@ -185,6 +190,21 @@ describe('RipGrepTool', () => {
         path.join(tempRootDir, 'fileA.txt'),
         path.join(tempRootDir, 'sub/fileC.txt'),
       ]);
+
+      const fileAStats = await fs.stat(path.join(tempRootDir, 'fileA.txt'));
+      const fileCStats = await fs.stat(path.join(tempRootDir, 'sub/fileC.txt'));
+      const fileARead = fileReadCache.check(fileAStats);
+      const fileCRead = fileReadCache.check(fileCStats);
+      expect(fileARead.state).toBe('fresh');
+      expect(fileCRead.state).toBe('fresh');
+      if (fileARead.state === 'fresh') {
+        expect(fileARead.entry.lastReadWasFull).toBe(false);
+        expect(fileARead.entry.lastReadCacheable).toBe(true);
+      }
+      if (fileCRead.state === 'fresh') {
+        expect(fileCRead.entry.lastReadWasFull).toBe(false);
+        expect(fileCRead.entry.lastReadCacheable).toBe(true);
+      }
     });
 
     it('should treat summary-only JSON output as no matches', async () => {

--- a/packages/core/src/tools/ripGrep.ts
+++ b/packages/core/src/tools/ripGrep.ts
@@ -18,6 +18,7 @@ import type { FileFilteringOptions } from '../config/constants.js';
 import { DEFAULT_FILE_FILTERING_OPTIONS } from '../config/constants.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import type { PermissionDecision } from '../permissions/types.js';
+import { recordGrepResultFileReads } from './grepReadTracking.js';
 
 const debugLogger = createDebugLogger('RIPGREP');
 const RIPGREP_FIELD_SEPARATOR = '';
@@ -366,6 +367,7 @@ class GrepToolInvocation extends BaseToolInvocation<
           ),
         ),
       );
+      await recordGrepResultFileReads(this.config, resultFilePaths);
 
       return {
         llmContent: llmContent.trim(),


### PR DESCRIPTION
## What this PR does

This PR lets the structured grep tools stamp the session FileReadCache for files whose matching lines are actually returned to the model. Both the JS fallback GrepTool and the ripgrep-backed implementation now record visible result file paths as partial, cacheable text reads, so a follow-up Edit or WriteFile can use the existing prior-read enforcement path instead of requiring a separate read_file call.

## Why it's needed

Issue #4939 points out that grep-to-edit is a common workflow: the model has already seen the matching line, but Edit currently rejects the file because only read_file populates FileReadCache. Reusing recordRead keeps the existing mtime/size drift check and non-text rejection behavior intact, while avoiding an unnecessary extra tool call for files that grep already exposed.

## Reviewer Test Plan

### How to verify

Run the focused tool tests and confirm grep/ripgrep results still return the same resultFilePaths while the matching files are marked fresh in FileReadCache. The change intentionally records grep output as full: false, cacheable: true, so it satisfies prior-read enforcement without enabling the read_file full-read fast path.

Commands I ran locally:

```bash
npm test --workspace=@qwen-code/qwen-code-core -- src/tools/grep.test.ts src/tools/ripGrep.test.ts
npm run lint --workspace=@qwen-code/qwen-code-core
npm run typecheck --workspace=@qwen-code/qwen-code-core
npx prettier --check packages/core/src/tools/grepReadTracking.ts packages/core/src/tools/grep.ts packages/core/src/tools/ripGrep.ts packages/core/src/tools/grep.test.ts packages/core/src/tools/ripGrep.test.ts
git diff --check
```

### Evidence (Before & After)

N/A. This is core tool state tracking rather than a UI change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS     | not tested |
| Windows    | tested |
|  Linux     | not tested |

### Environment (optional)

Windows 11, Node/npm from the local Qwen Code workspace. `npm ci` completed first; it reported existing npm audit/deprecation warnings but no install failure.

## Risk & Scope

- Main risk or tradeoff: a grep hit only proves the model saw matching lines, not the full file. This matches the existing prior-read contract because checkPriorRead does not require full reads; the mtime/size drift check remains the safety gate.
- Not validated / out of scope: this does not parse arbitrary shell grep/egrep/fgrep commands. The triage note on #4939 recommended splitting that harder path into a separate design/PR.
- Breaking changes / migration notes: none.

## Linked Issues

Part of #4939.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让结构化 grep 工具在把匹配行返回给模型时，同步把这些文件记录到当前会话的 FileReadCache。JS fallback 的 GrepTool 和 ripgrep 版本都会把可见结果文件记录为 partial、cacheable 的文本 read，因此后续 Edit / WriteFile 可以复用现有 prior-read enforcement，不再强制再调用一次 read_file。

## Why it's needed

#4939 提到 grep 到 edit 是非常常见的路径：模型已经看到了匹配行，但当前只有 read_file 会写入 FileReadCache，所以 Edit 仍会拒绝。这里复用 recordRead，保留现有的 mtime/size 漂移检查和非文本文件保护，同时减少一次没有必要的工具调用。

## Reviewer Test Plan

### How to verify

运行 focused tool tests，确认 grep/ripgrep 仍返回相同的 resultFilePaths，并且匹配文件在 FileReadCache 里变成 fresh。这个改动刻意用 full: false, cacheable: true 记录 grep 输出，所以它只满足 prior-read enforcement，不会误触发 read_file 的 full-read fast path。

本地已运行：

```bash
npm test --workspace=@qwen-code/qwen-code-core -- src/tools/grep.test.ts src/tools/ripGrep.test.ts
npm run lint --workspace=@qwen-code/qwen-code-core
npm run typecheck --workspace=@qwen-code/qwen-code-core
npx prettier --check packages/core/src/tools/grepReadTracking.ts packages/core/src/tools/grep.ts packages/core/src/tools/ripGrep.ts packages/core/src/tools/grep.test.ts packages/core/src/tools/ripGrep.test.ts
git diff --check
```

### Evidence (Before & After)

N/A。这里改的是 core tool 状态记录，不是 UI 行为。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS     | not tested |
| Windows    | tested |
|  Linux     | not tested |

### Environment (optional)

Windows 11，本地 Qwen Code workspace 的 Node/npm。先运行了 `npm ci`，安装成功；只出现已有 npm audit / deprecated package 警告。

## Risk & Scope

- 主要风险 / tradeoff：grep 命中只能证明模型看到了匹配行，不代表完整文件。但这与现有 prior-read contract 一致，因为 checkPriorRead 本来不要求 full read；mtime/size 漂移检查仍然是安全边界。
- 未验证 / 不在范围内：本 PR 不解析任意 shell grep/egrep/fgrep 命令。#4939 的 triage 也建议把这个更复杂的路径拆成单独设计 / PR。
- Breaking changes / migration notes：无。

## Linked Issues

#4939 的一部分。

</details>
