### PR TITLE
test(cli): Cover rewind selection and confirm flow

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -3400,6 +3400,23 @@ describe('AppContainer State Management', () => {
       );
     });
 
+    it('shows an error when restoring files without a prompt id', async () => {
+      const harness = renderRewindHarness();
+
+      await runRewind(rewindUserItem(3, 'second prompt'), 'code');
+
+      expect(harness.rewind).not.toHaveBeenCalled();
+      expect(harness.truncateHistory).not.toHaveBeenCalled();
+      expect(harness.loadHistory).not.toHaveBeenCalled();
+      expect(harness.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          text: 'Cannot restore files: this turn was created before file checkpointing was enabled.',
+        }),
+        expect.any(Number),
+      );
+    });
+
     it('truncates conversation when both-mode file restore succeeds', async () => {
       const harness = renderRewindHarness();
 
@@ -3444,6 +3461,13 @@ describe('AppContainer State Management', () => {
       expect(harness.loadHistory).not.toHaveBeenCalled();
       expect(harness.setText).not.toHaveBeenCalled();
       expect(harness.rewindRecording).not.toHaveBeenCalled();
+      expect(harness.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'info',
+          text: 'Restored 1 file(s).',
+        }),
+        expect.any(Number),
+      );
     });
 
     it('rewinds conversation only without restoring files', async () => {
@@ -3458,6 +3482,11 @@ describe('AppContainer State Management', () => {
         { id: 2, type: 'gemini', text: 'first response' },
       ]);
       expect(harness.setText).toHaveBeenCalledWith('second prompt');
+      expect(harness.rewindRecording).toHaveBeenCalledWith(
+        1,
+        { truncatedCount: 2 },
+        harness.snapshots.slice(0, 2),
+      );
     });
 
     it('shows an error and returns for conversation-only rewind with no client', async () => {

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -44,7 +44,9 @@ import {
   type HistoryItemWithoutId,
   ToolCallStatus,
 } from './types.js';
+import type { RestoreOption } from './components/RewindSelector.js';
 import { Box, measureElement } from 'ink';
+import type { Content } from '@google/genai';
 
 // Mock useStdout to capture terminal title writes
 let mockStdout: { write: ReturnType<typeof vi.fn> };
@@ -390,6 +392,140 @@ describe('AppContainer State Management', () => {
   afterEach(() => {
     cleanup();
   });
+
+  const rewindUserItem = (
+    id: number,
+    text: string,
+    promptId?: string,
+  ): HistoryItem => ({
+    id,
+    type: 'user',
+    text,
+    promptId,
+  });
+
+  const apiUser = (text: string): Content => ({
+    role: 'user',
+    parts: [{ text }],
+  });
+
+  const apiModel = (text: string): Content => ({
+    role: 'model',
+    parts: [{ text }],
+  });
+
+  type RewindHarnessOptions = {
+    apiHistory?: Content[];
+    fileRewindResult?: {
+      filesChanged: string[];
+      filesFailed: string[];
+    };
+    fileRewindError?: Error;
+    noGeminiClient?: boolean;
+  };
+
+  const renderRewindHarness = (options: RewindHarnessOptions = {}) => {
+    const history: HistoryItem[] = [
+      rewindUserItem(1, 'first prompt', 'prompt-1'),
+      { id: 2, type: 'gemini', text: 'first response' },
+      rewindUserItem(3, 'second prompt', 'prompt-2'),
+      { id: 4, type: 'gemini', text: 'second response' },
+    ];
+    const target = history[2]!;
+    const addItem = vi.fn();
+    const loadHistory = vi.fn();
+    const truncateToItem = vi.fn();
+    mockedUseHistory.mockReturnValue({
+      history,
+      addItem,
+      updateItem: vi.fn(),
+      clearItems: vi.fn(),
+      loadHistory,
+      truncateToItem,
+    });
+
+    const setText = vi.fn();
+    mockedUseTextBuffer.mockReturnValue({
+      text: '',
+      setText,
+    });
+
+    const apiHistory = options.apiHistory ?? [
+      apiUser('first prompt'),
+      apiModel('first response'),
+      apiUser('second prompt'),
+      apiModel('second response'),
+    ];
+    const getHistoryShallow = vi.fn(() => apiHistory);
+    const truncateHistory = vi.fn();
+    const geminiClient = {
+      initialize: vi.fn().mockResolvedValue(undefined),
+      setTools: vi.fn().mockResolvedValue(undefined),
+      isInitialized: vi.fn().mockReturnValue(false),
+      getHistoryShallow,
+      truncateHistory,
+    } as unknown as GeminiClient;
+    vi.spyOn(mockConfig, 'getGeminiClient').mockReturnValue(
+      options.noGeminiClient ? (null as unknown as GeminiClient) : geminiClient,
+    );
+
+    const rewind = vi.fn();
+    if (options.fileRewindError) {
+      rewind.mockRejectedValue(options.fileRewindError);
+    } else {
+      rewind.mockResolvedValue(
+        options.fileRewindResult ?? {
+          filesChanged: ['src/foo.ts'],
+          filesFailed: [],
+        },
+      );
+    }
+    const snapshots = [
+      { promptId: 'prompt-1' },
+      { promptId: 'prompt-2' },
+      { promptId: 'prompt-3' },
+    ];
+    const getSnapshots = vi.fn(() => snapshots);
+    vi.spyOn(mockConfig, 'getFileHistoryService').mockReturnValue({
+      rewind,
+      getSnapshots,
+    } as unknown as ReturnType<Config['getFileHistoryService']>);
+
+    const rewindRecording = vi.fn();
+    vi.spyOn(mockConfig, 'getChatRecordingService').mockReturnValue({
+      rewindRecording,
+    } as unknown as NonNullable<ReturnType<Config['getChatRecordingService']>>);
+
+    render(
+      <AppContainer
+        config={mockConfig}
+        settings={mockSettings}
+        version="1.0.0"
+        initializationResult={mockInitResult}
+      />,
+    );
+
+    return {
+      target,
+      addItem,
+      loadHistory,
+      setText,
+      rewind,
+      getHistoryShallow,
+      truncateHistory,
+      rewindRecording,
+      snapshots,
+    };
+  };
+
+  const runRewind = async (userItem: HistoryItem, option: RestoreOption) => {
+    await act(async () => {
+      await (capturedUIActions.handleRewindConfirm(
+        userItem,
+        option,
+      ) as unknown as Promise<void>);
+    });
+  };
 
   describe('Basic Rendering', () => {
     it('renders without crashing with minimal props', () => {
@@ -3215,6 +3351,186 @@ describe('AppContainer State Management', () => {
       await flushEffects();
 
       expect(trigger.activeCount()).toBe(0);
+    });
+  });
+
+  describe('handleRewindConfirm', () => {
+    it('skips conversation truncation when both-mode file restore fails', async () => {
+      const harness = renderRewindHarness({
+        fileRewindResult: {
+          filesChanged: [],
+          filesFailed: ['src/bad.ts'],
+        },
+      });
+
+      await runRewind(harness.target, 'both');
+
+      expect(harness.rewind).toHaveBeenCalledWith('prompt-2', true);
+      expect(harness.truncateHistory).not.toHaveBeenCalled();
+      expect(harness.loadHistory).not.toHaveBeenCalled();
+      expect(harness.setText).not.toHaveBeenCalled();
+      expect(harness.rewindRecording).not.toHaveBeenCalled();
+      expect(harness.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          text: 'Failed to restore 1 file(s): bad.ts',
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it('skips conversation truncation when both-mode file restore throws', async () => {
+      const harness = renderRewindHarness({
+        fileRewindError: new Error('snapshot missing'),
+      });
+
+      await runRewind(harness.target, 'both');
+
+      expect(harness.rewind).toHaveBeenCalledWith('prompt-2', true);
+      expect(harness.truncateHistory).not.toHaveBeenCalled();
+      expect(harness.loadHistory).not.toHaveBeenCalled();
+      expect(harness.setText).not.toHaveBeenCalled();
+      expect(harness.rewindRecording).not.toHaveBeenCalled();
+      expect(harness.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          text: 'Failed to restore files: snapshot missing',
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it('truncates conversation when both-mode file restore succeeds', async () => {
+      const harness = renderRewindHarness();
+
+      await runRewind(harness.target, 'both');
+
+      expect(harness.rewind).toHaveBeenCalledWith('prompt-2', true);
+      expect(harness.truncateHistory).toHaveBeenCalledWith(2);
+      expect(harness.loadHistory).toHaveBeenCalledWith([
+        rewindUserItem(1, 'first prompt', 'prompt-1'),
+        { id: 2, type: 'gemini', text: 'first response' },
+      ]);
+      expect(harness.setText).toHaveBeenCalledWith('second prompt');
+      expect(harness.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'info',
+          text: 'Conversation rewound. Edit your prompt and press Enter to continue.',
+        }),
+        expect.any(Number),
+      );
+      expect(harness.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'info',
+          text: 'Restored 1 file(s).',
+        }),
+        expect.any(Number),
+      );
+      expect(harness.rewindRecording).toHaveBeenCalledWith(
+        1,
+        { truncatedCount: 2 },
+        harness.snapshots.slice(0, 2),
+      );
+    });
+
+    it('restores code only without truncating conversation history', async () => {
+      const harness = renderRewindHarness();
+
+      await runRewind(harness.target, 'code');
+
+      expect(harness.rewind).toHaveBeenCalledWith('prompt-2', false);
+      expect(harness.getHistoryShallow).not.toHaveBeenCalled();
+      expect(harness.truncateHistory).not.toHaveBeenCalled();
+      expect(harness.loadHistory).not.toHaveBeenCalled();
+      expect(harness.setText).not.toHaveBeenCalled();
+      expect(harness.rewindRecording).not.toHaveBeenCalled();
+    });
+
+    it('rewinds conversation only without restoring files', async () => {
+      const harness = renderRewindHarness();
+
+      await runRewind(harness.target, 'conversation');
+
+      expect(harness.rewind).not.toHaveBeenCalled();
+      expect(harness.truncateHistory).toHaveBeenCalledWith(2);
+      expect(harness.loadHistory).toHaveBeenCalledWith([
+        rewindUserItem(1, 'first prompt', 'prompt-1'),
+        { id: 2, type: 'gemini', text: 'first response' },
+      ]);
+      expect(harness.setText).toHaveBeenCalledWith('second prompt');
+    });
+
+    it('shows an error and returns for conversation-only rewind with no client', async () => {
+      const harness = renderRewindHarness({ noGeminiClient: true });
+
+      await runRewind(harness.target, 'conversation');
+
+      expect(harness.rewind).not.toHaveBeenCalled();
+      expect(harness.truncateHistory).not.toHaveBeenCalled();
+      expect(harness.loadHistory).not.toHaveBeenCalled();
+      expect(harness.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          text: 'Cannot rewind conversation: no active model client.',
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it('falls back to code restore for both-mode rewind with no client', async () => {
+      const harness = renderRewindHarness({ noGeminiClient: true });
+
+      await runRewind(harness.target, 'both');
+
+      expect(harness.rewind).toHaveBeenCalledWith('prompt-2', false);
+      expect(harness.truncateHistory).not.toHaveBeenCalled();
+      expect(harness.loadHistory).not.toHaveBeenCalled();
+      expect(harness.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'info',
+          text: 'Code restored, but conversation could not be rewound (no active client).',
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it('surfaces unexpected outer errors through history', async () => {
+      const harness = renderRewindHarness();
+      vi.spyOn(mockConfig, 'getGeminiClient').mockImplementation(() => {
+        throw new Error('client exploded');
+      });
+
+      await runRewind(harness.target, 'conversation');
+
+      expect(harness.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          text: 'Rewind failed: client exploded',
+        }),
+        expect.any(Number),
+      );
+      expect(harness.rewind).not.toHaveBeenCalled();
+      expect(harness.truncateHistory).not.toHaveBeenCalled();
+      expect(harness.loadHistory).not.toHaveBeenCalled();
+    });
+
+    it('bails before file restore when the target turn is compressed', async () => {
+      const harness = renderRewindHarness({
+        apiHistory: [apiUser('first prompt'), apiModel('first response')],
+      });
+
+      await runRewind(harness.target, 'both');
+
+      expect(harness.rewind).not.toHaveBeenCalled();
+      expect(harness.truncateHistory).not.toHaveBeenCalled();
+      expect(harness.loadHistory).not.toHaveBeenCalled();
+      expect(harness.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          text: 'Cannot rewind to a turn that was compressed. Try a more recent turn.',
+        }),
+        expect.any(Number),
+      );
     });
   });
 

--- a/packages/cli/src/ui/components/RewindSelector.test.tsx
+++ b/packages/cli/src/ui/components/RewindSelector.test.tsx
@@ -95,6 +95,31 @@ describe('RewindSelector', () => {
     expect(lastFrame()).toContain('› #2 second prompt');
   });
 
+  it('navigates the pick list with arrow keys and cancels with Escape', () => {
+    const onCancel = vi.fn();
+
+    const { lastFrame } = render(
+      <RewindSelector
+        history={[userTurn(1, 'first prompt'), userTurn(2, 'second prompt')]}
+        onRewind={vi.fn()}
+        onCancel={onCancel}
+        fileCheckpointingEnabled={false}
+        fileHistoryService={fileHistoryService}
+      />,
+    );
+
+    expect(lastFrame()).toContain('› #2 second prompt');
+
+    pressKey({ name: 'up' });
+    expect(lastFrame()).toContain('› #1 first prompt');
+
+    pressKey({ name: 'down' });
+    expect(lastFrame()).toContain('› #2 second prompt');
+
+    pressKey({ name: 'escape' });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
   it('renders restore options with diff stats for the selected turn', async () => {
     vi.spyOn(fileHistoryService, 'getDiffStats').mockResolvedValue({
       filesChanged: ['src/foo.ts', 'src/bar.ts'],
@@ -123,6 +148,7 @@ describe('RewindSelector', () => {
     expect(lastFrame()).toContain('(+3 -1 in 2 files)');
     expect(lastFrame()).toContain('Restore conversation only');
     expect(lastFrame()).toContain('Restore code only');
+    expect(lastFrame()).toContain('Never mind');
   });
 
   it('returns from restore options to the pick list on Escape', async () => {
@@ -237,5 +263,87 @@ describe('RewindSelector', () => {
       expect.objectContaining({ id: 2 }),
       'conversation',
     );
+  });
+
+  it.each([
+    ['n', { sequence: 'n' }],
+    ['Escape', { name: 'escape' }],
+  ] as const)(
+    'returns to the pick list when legacy confirm receives %s',
+    (_label, key) => {
+      const onRewind = vi.fn();
+
+      const { lastFrame } = render(
+        <RewindSelector
+          history={[userTurn(1, 'first prompt'), userTurn(2, 'second prompt')]}
+          onRewind={onRewind}
+          onCancel={vi.fn()}
+          fileCheckpointingEnabled={false}
+          fileHistoryService={fileHistoryService}
+        />,
+      );
+
+      pressKey({ name: 'return' });
+      expect(lastFrame()).toContain(
+        'This will remove all conversation after this turn.',
+      );
+
+      pressKey(key);
+
+      expect(onRewind).not.toHaveBeenCalled();
+      expect(lastFrame()).toContain('› #2 second prompt');
+      expect(lastFrame()).not.toContain(
+        'This will remove all conversation after this turn.',
+      );
+    },
+  );
+
+  it('blocks restore-option keypresses while rewind is pending', async () => {
+    vi.spyOn(fileHistoryService, 'getDiffStats').mockResolvedValue({
+      filesChanged: ['src/foo.ts'],
+      insertions: 2,
+      deletions: 0,
+    });
+    const onCancel = vi.fn();
+    let resolveRewind: (() => void) | undefined;
+    const onRewind = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRewind = resolve;
+        }),
+    );
+
+    const { lastFrame } = render(
+      <RewindSelector
+        history={[
+          userTurn(1, 'first prompt', 'prompt-1'),
+          userTurn(2, 'second prompt', 'prompt-2'),
+        ]}
+        onRewind={onRewind}
+        onCancel={onCancel}
+        fileCheckpointingEnabled={true}
+        fileHistoryService={fileHistoryService}
+      />,
+    );
+
+    pressKey({ name: 'return' });
+    await flush();
+
+    pressKey({ name: 'return' });
+    await flush();
+
+    expect(onRewind).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 2 }),
+      'both',
+    );
+    expect(lastFrame()).toContain('Restoring...');
+
+    pressKey({ name: 'escape' });
+
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(lastFrame()).toContain('Restoring...');
+
+    resolveRewind!();
+    await flush();
   });
 });


### PR DESCRIPTION
## What this PR does

This PR adds focused regression coverage for the rewind selector flow and the rewind confirmation orchestration. The tests now cover selector navigation and cancel paths, restore option fallback states, the restoring keypress guard, and the main rewind confirmation branches for code, conversation, combined restore, no-client fallback, compressed turns, and file restore failures.

## Why it's needed

Issue #4187 tracks missing automated coverage for rewind behavior that was previously verified manually. These paths coordinate UI state, file checkpoint restore, API history truncation, buffer prefill, and chat recording updates, so focused tests reduce the risk of future regressions leaving files and conversation history out of sync.

## Reviewer Test Plan

### How to verify

Run `cd packages/cli && npx vitest run src/ui/components/RewindSelector.test.tsx src/ui/AppContainer.test.tsx` and expect both test files to pass, including the new rewind selector and handleRewindConfirm cases. Run `npm run typecheck` from the repository root and expect TypeScript checks to complete successfully across workspaces.

### Evidence (Before & After)

N/A. This is a non-user-visible test coverage change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js v22.22.3, npm 10.9.8.

## Risk & Scope

- Main risk or tradeoff: The new AppContainer tests use the existing context-capture harness and mocks to exercise the rewind action directly, so they intentionally validate orchestration behavior without driving the full dialog UI.
- Not validated / out of scope: Full end-to-end terminal rewind sessions, cross-platform runtime behavior, and production code changes are out of scope.
- Breaking changes / migration notes: None.

## Linked Issues

Closes #4187

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 为 rewind selector 流程和 rewind confirm 编排逻辑增加了聚焦的回归测试。测试现在覆盖 selector 导航和取消路径、restore options 的 fallback 状态、restoring 状态下的按键屏蔽，以及 code、conversation、both restore、no-client fallback、compressed turn、file restore failure 等主要 rewind confirm 分支。

## Why it's needed

Issue #4187 追踪的是 rewind 行为缺少自动化覆盖的问题，此前这些路径主要依赖手工验证。这些路径会同时协调 UI 状态、文件 checkpoint 恢复、API history 截断、buffer 预填和 chat recording 更新，因此聚焦测试可以降低未来回归导致文件和对话历史状态不一致的风险。

## Reviewer Test Plan

### How to verify

运行 `cd packages/cli && npx vitest run src/ui/components/RewindSelector.test.tsx src/ui/AppContainer.test.tsx`，预期两个测试文件都通过，并包含新增的 rewind selector 和 handleRewindConfirm 用例。然后在仓库根目录运行 `npm run typecheck`，预期所有 workspace 的 TypeScript 检查成功完成。

### Evidence (Before & After)

N/A。这是非用户可见的测试覆盖改动。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js v22.22.3，npm 10.9.8。

## Risk & Scope

- Main risk or tradeoff: 新增的 AppContainer 测试使用现有 context-capture harness 和 mocks 直接触发 rewind action，因此它们刻意验证编排行为，而不是驱动完整 dialog UI。
- Not validated / out of scope: 完整的端到端终端 rewind 会话、跨平台运行时行为和生产代码改动不在本 PR 范围内。
- Breaking changes / migration notes: 无。

## Linked Issues

Closes #4187

</details>