### PR TITLE
fix(telemetry): Propagate daemon ACP trace context

### DIFF
--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -89,19 +89,32 @@ describe('createAcpSessionBridge', () => {
   it('uses bridge telemetry for channel/session/prompt dispatch and prompt metadata injection', async () => {
     const handle = makeChannel();
     const operations: string[] = [];
+    const events: string[] = [];
     const spanAttributes = new Map<string, Record<string, unknown>>();
     const telemetry: BridgeTelemetry = {
-      captureContext: () => ({ captured: true }),
-      async runWithContext(_captured, fn) {
+      captureContext: () => {
+        events.push('capture');
+        return { captured: true };
+      },
+      async runWithContext(captured, fn) {
+        events.push(
+          `run:${(captured as { captured?: boolean } | undefined)?.captured === true}`,
+        );
         return await fn();
       },
       async withSpan(operation, attributes, fn) {
         operations.push(operation);
         spanAttributes.set(operation, attributes);
-        return await fn();
+        events.push(`span:${operation}:start`);
+        try {
+          return await fn();
+        } finally {
+          events.push(`span:${operation}:end`);
+        }
       },
       event() {},
       injectPromptContext(request) {
+        events.push('inject');
         const meta =
           (request as { _meta?: Record<string, unknown> })._meta ?? {};
         return {
@@ -141,6 +154,12 @@ describe('createAcpSessionBridge', () => {
         'prompt.dispatch',
       ]),
     );
+    expect(events.slice(-4)).toEqual([
+      'run:true',
+      'span:prompt.dispatch:start',
+      'inject',
+      'span:prompt.dispatch:end',
+    ]);
     expect(handle.agent.promptCalls[0]!._meta).toMatchObject({
       keep: 'value',
       'qwen.telemetry.traceparent': 'daemon-traceparent',

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -11,6 +11,7 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import request from 'supertest';
+import { trace, type Span } from '@opentelemetry/api';
 import {
   createServeApp,
   detectFromLoopback,
@@ -2964,6 +2965,34 @@ describe('createServeApp', () => {
       expect(bridge.promptCalls[0]?.context?.promptId).toBe(res.body.promptId);
     });
 
+    it('adds the generated promptId to the active daemon request span', async () => {
+      const setAttribute = vi.fn();
+      const getSpanSpy = vi.spyOn(trace, 'getSpan').mockReturnValue({
+        setAttribute,
+        spanContext: () => ({
+          traceId: '1'.repeat(32),
+          spanId: '2'.repeat(16),
+          traceFlags: 1,
+        }),
+      } as unknown as Span);
+      const bridge = fakeBridge();
+      const app = createServeApp(baseOpts, undefined, { bridge });
+      try {
+        const res = await request(app)
+          .post('/session/session-A/prompt')
+          .set('Host', `127.0.0.1:${baseOpts.port}`)
+          .send({ prompt: [{ type: 'text', text: 'hi' }] });
+
+        expect(res.status).toBe(202);
+        expect(setAttribute).toHaveBeenCalledWith(
+          'qwen-code.prompt_id',
+          res.body.promptId,
+        );
+      } finally {
+        getSpanSpy.mockRestore();
+      }
+    });
+
     it('400 when prompt body is missing', async () => {
       const bridge = fakeBridge();
       const app = createServeApp(baseOpts, undefined, { bridge });
@@ -3478,9 +3507,7 @@ describe('createServeApp', () => {
         { bridge, boundWorkspace: WS_BOUND },
       );
       const res = await request(app)
-        .get(
-          `/workspace/${encodeURIComponent(WS_BOUND)}/sessions?size=0`,
-        )
+        .get(`/workspace/${encodeURIComponent(WS_BOUND)}/sessions?size=0`)
         .set('Host', `127.0.0.1:${baseOpts.port}`);
       expect(res.status).toBe(200);
       expect(res.body.sessions).toHaveLength(1);
@@ -3494,9 +3521,7 @@ describe('createServeApp', () => {
         { bridge, boundWorkspace: WS_BOUND },
       );
       const res = await request(app)
-        .get(
-          `/workspace/${encodeURIComponent(WS_BOUND)}/sessions?size=200`,
-        )
+        .get(`/workspace/${encodeURIComponent(WS_BOUND)}/sessions?size=200`)
         .set('Host', `127.0.0.1:${baseOpts.port}`);
       expect(res.status).toBe(200);
     });

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -17,6 +17,7 @@ import {
   SessionService,
   shouldShowStep,
   TrustGateError,
+  addDaemonRequestAttribute,
   emitDaemonLog,
   hashDaemonWorkspace,
   recordDaemonBridgeError,
@@ -276,9 +277,7 @@ export async function listWorkspaceSessionsForResponse(
   });
 
   const nextCursor =
-    persisted.nextCursor != null
-      ? String(persisted.nextCursor)
-      : undefined;
+    persisted.nextCursor != null ? String(persisted.nextCursor) : undefined;
 
   return { sessions, nextCursor };
 }
@@ -2190,6 +2189,7 @@ export function createServeApp(
       });
       return;
     }
+    addDaemonRequestAttribute('qwen-code.prompt_id', promptId);
 
     const abort = new AbortController();
     const effectiveDeadlineMs = resolvePromptDeadlineMs(

--- a/packages/core/src/telemetry/daemon-tracing.test.ts
+++ b/packages/core/src/telemetry/daemon-tracing.test.ts
@@ -6,6 +6,7 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  propagation,
   SpanStatusCode,
   trace,
   type Span,
@@ -29,6 +30,110 @@ import {
 describe('daemon-tracing', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it('injects traceparent from the active span without the global propagator', () => {
+    const traceId = '1234567890abcdef1234567890abcdef';
+    const spanId = 'abcdef1234567890';
+    const activeSpan = {
+      spanContext: () => ({
+        traceId,
+        spanId,
+        traceFlags: 1,
+      }),
+    } as Span;
+    vi.spyOn(trace, 'getActiveSpan').mockReturnValue(activeSpan);
+    const injectSpy = vi.spyOn(propagation, 'inject');
+
+    const injected = injectDaemonTraceContext({
+      prompt: [],
+      _meta: {
+        keep: true,
+        [DAEMON_TRACEPARENT_META_KEY]: 'client-spoof',
+        [DAEMON_TRACESTATE_META_KEY]: 'client-state',
+      },
+    });
+
+    expect(injectSpy).not.toHaveBeenCalled();
+    expect((injected._meta as Record<string, unknown>)['keep']).toBe(true);
+    expect(
+      (injected._meta as Record<string, unknown>)[DAEMON_TRACEPARENT_META_KEY],
+    ).toBe(`00-${traceId}-${spanId}-01`);
+    expect(
+      (injected._meta as Record<string, unknown>)[DAEMON_TRACESTATE_META_KEY],
+    ).toBeUndefined();
+  });
+
+  it('injects the active bridge span context through the bridge telemetry seam', async () => {
+    const traceId = 'fedcba0987654321fedcba0987654321';
+    const daemonSpan = {
+      spanContext: () => ({
+        traceId,
+        spanId: '1111111111111111',
+        traceFlags: 1,
+      }),
+    } as Span;
+    const bridgeSpan = {
+      spanContext: () => ({
+        traceId,
+        spanId: '2222222222222222',
+        traceFlags: 1,
+      }),
+      setStatus: vi.fn(),
+      end: vi.fn(),
+      setAttribute: vi.fn(),
+      setAttributes: vi.fn(),
+      recordException: vi.fn(),
+    } as unknown as Span;
+    let activeSpan: Span | undefined = daemonSpan;
+    vi.spyOn(trace, 'getActiveSpan').mockImplementation(() => activeSpan);
+    const startActiveSpan = vi.fn(
+      async (
+        _name: string,
+        _opts: unknown,
+        fn: (span: Span) => Promise<unknown>,
+      ) => {
+        activeSpan = bridgeSpan;
+        try {
+          return await fn(bridgeSpan);
+        } finally {
+          activeSpan = daemonSpan;
+        }
+      },
+    );
+    vi.spyOn(trace, 'getTracer').mockReturnValue({
+      startActiveSpan,
+    } as unknown as Tracer);
+
+    const telemetry = createDaemonBridgeTelemetry();
+    const captured = telemetry.captureContext();
+    let injected: { _meta?: Record<string, unknown> } | undefined;
+    await telemetry.runWithContext(captured, async () => {
+      await telemetry.withSpan(
+        'prompt.dispatch',
+        { 'session.id': 'session-A' },
+        async () => {
+          injected = telemetry.injectPromptContext({
+            prompt: [],
+            _meta: {},
+          });
+        },
+      );
+    });
+
+    const extracted = extractDaemonTraceContext(injected);
+    expect(trace.getSpanContext(extracted!)?.traceId).toBe(traceId);
+    expect(trace.getSpanContext(extracted!)?.spanId).toBe('2222222222222222');
+    expect(startActiveSpan).toHaveBeenCalledWith(
+      'qwen-code.daemon.bridge',
+      expect.objectContaining({
+        attributes: expect.objectContaining({
+          'qwen-code.daemon.operation': 'prompt.dispatch',
+          'session.id': 'session-A',
+        }),
+      }),
+      expect.any(Function),
+    );
   });
 
   it('extracts daemon trace context from reserved prompt metadata keys', () => {

--- a/packages/core/src/telemetry/daemon-tracing.ts
+++ b/packages/core/src/telemetry/daemon-tracing.ts
@@ -19,6 +19,10 @@ import { logs, type LogAttributes } from '@opentelemetry/api-logs';
 import { SERVICE_NAME } from './constants.js';
 import { isTelemetrySdkInitialized } from './sdk.js';
 import { truncateSpanError } from './session-tracing.js';
+import {
+  formatTraceparent,
+  getActiveSpanTraceContext,
+} from './trace-context.js';
 
 export const DAEMON_TRACEPARENT_META_KEY = 'qwen.telemetry.traceparent';
 export const DAEMON_TRACESTATE_META_KEY = 'qwen.telemetry.tracestate';
@@ -54,13 +58,6 @@ function errorType(error: unknown): string {
 
 const INVALID_TRACE_ID = '0'.repeat(32);
 const INVALID_SPAN_ID = '0'.repeat(16);
-
-function activeSpanContextIsValid(): boolean {
-  const span = trace.getSpan(otelContext.active());
-  if (!span) return false;
-  const ctx = span.spanContext();
-  return ctx.traceId !== INVALID_TRACE_ID && ctx.spanId !== INVALID_SPAN_ID;
-}
 
 function stripReservedTraceMeta(meta: unknown): Record<string, unknown> {
   if (!meta || typeof meta !== 'object' || Array.isArray(meta)) return {};
@@ -241,22 +238,12 @@ export async function runWithDaemonTelemetryContext<T>(
 
 export function injectDaemonTraceContext<T extends object>(request: T): T {
   const currentMeta = (request as { _meta?: unknown })._meta;
-
-  if (!activeSpanContextIsValid()) {
-    return currentMeta
-      ? { ...request, _meta: stripReservedTraceMeta(currentMeta) }
-      : request;
-  }
-
   const nextMeta = stripReservedTraceMeta(currentMeta);
+
   try {
-    const carrier: Record<string, string> = {};
-    propagation.inject(otelContext.active(), carrier);
-    if (carrier['traceparent']) {
-      nextMeta[DAEMON_TRACEPARENT_META_KEY] = carrier['traceparent'];
-    }
-    if (carrier['tracestate']) {
-      nextMeta[DAEMON_TRACESTATE_META_KEY] = carrier['tracestate'];
+    const ctx = getActiveSpanTraceContext();
+    if (ctx) {
+      nextMeta[DAEMON_TRACEPARENT_META_KEY] = formatTraceparent(ctx);
     }
   } catch {
     // Telemetry must not affect prompt forwarding.

--- a/packages/core/src/telemetry/session-tracing.test.ts
+++ b/packages/core/src/telemetry/session-tracing.test.ts
@@ -995,6 +995,51 @@ describe('session-tracing', () => {
       expect(exec?.attributes['session.id']).toBe('session-A');
     });
 
+    it('stamps a blocked-on-user span with the owning session id via the tool parent', () => {
+      setSessionContext(undefined, 'session-B-global');
+      startInteractionSpan(createMockConfig({ sessionId: 'session-A' }), {
+        promptId: 'p-a',
+        model: 'm',
+        messageType: 'acp_prompt',
+      });
+
+      const toolSpan = startToolSpan('Bash', { 'tool.call_id': 'c1' });
+      const blockedSpan = startToolBlockedOnUserSpan(toolSpan, {
+        call_id: 'c1',
+      });
+      endToolBlockedOnUserSpan(blockedSpan, { decision: 'proceed_once' });
+      endToolSpan(toolSpan, { success: true });
+
+      const blocked = mockSpans.find(
+        (s) => s.name === 'qwen-code.tool.blocked_on_user',
+      );
+      expect(blocked?.attributes['session.id']).toBe('session-A');
+    });
+
+    it('stamps a hook span with the owning session id via the logical parent', () => {
+      setSessionContext(undefined, 'session-B-global');
+      startInteractionSpan(createMockConfig({ sessionId: 'session-A' }), {
+        promptId: 'p-a',
+        model: 'm',
+        messageType: 'acp_prompt',
+      });
+
+      const toolSpan = startToolSpan('Bash', { 'tool.call_id': 'c1' });
+      let hookSpan!: ReturnType<typeof startHookSpan>;
+      runInToolSpanContext(toolSpan, () => {
+        hookSpan = startHookSpan({
+          hookEvent: 'PreToolUse',
+          toolName: 'Bash',
+          toolUseId: 'use-1',
+        });
+      });
+      endHookSpan(hookSpan, { success: true, shouldProceed: true });
+      endToolSpan(toolSpan, { success: true });
+
+      const hook = mockSpans.find((s) => s.name === 'qwen-code.hook');
+      expect(hook?.attributes['session.id']).toBe('session-A');
+    });
+
     it('isolates concurrent sessions: each tool span carries its own session id', async () => {
       // Two interactions for two different sessions while the global is stale.
       setSessionContext(undefined, 'stale-global');

--- a/packages/core/src/telemetry/session-tracing.ts
+++ b/packages/core/src/telemetry/session-tracing.ts
@@ -1024,8 +1024,16 @@ export function startToolBlockedOnUserSpan(
   const ctx = parentSpanCtx
     ? trace.setSpan(otelContext.active(), parentSpanCtx.span)
     : resolveParentContext(undefined);
+  const sessionParentCtx =
+    parentSpanCtx ??
+    subagentContext.getStore() ??
+    interactionContext.getStore() ??
+    undefined;
+  const sessionId = resolveSessionId(sessionParentCtx);
 
-  const attributes: Attributes = {};
+  const attributes: Attributes = {
+    ...(sessionId ? { 'session.id': sessionId } : {}),
+  };
   if (attrs?.tool_name !== undefined) attributes['tool.name'] = attrs.tool_name;
   if (attrs?.call_id !== undefined) attributes['tool.call_id'] = attrs.call_id;
 
@@ -1149,8 +1157,10 @@ export function startHookSpan(opts: StartHookSpanOptions): Span {
     interactionContext.getStore() ??
     undefined;
   const ctx = resolveParentContext(parentCtx);
+  const sessionId = resolveSessionId(parentCtx);
 
   const attributes: Attributes = {
+    ...(sessionId ? { 'session.id': sessionId } : {}),
     hook_event: opts.hookEvent,
     'tool.name': opts.toolName,
   };


### PR DESCRIPTION
## What this PR does

This PR keeps daemon-to-ACP telemetry stitched through prompt dispatch by deriving the ACP prompt metadata `traceparent` from the active daemon bridge span instead of relying on the global outbound propagator. It also records the generated prompt id on the active daemon HTTP request span and stamps deferred blocked-on-user and hook spans with the owning session id resolved from their logical parent context.

The regression coverage exercises the daemon trace metadata injection path, the bridge prompt dispatch span ordering, the daemon prompt id span attribute, and the multi-session session attribution cases for deferred spans.

## Why it's needed

`qwen serve` installs a no-op outbound propagator by default, so using `propagation.inject()` for daemon-to-ACP prompt metadata could leave the ACP child interaction without a usable parent `traceparent`. The daemon HTTP span also generated a `promptId` without attaching it to the current request span, and some deferred spans could fall back to a stale process-global session id in multi-session daemon scenarios. Together these gaps made the daemon HTTP span → bridge span → ACP child interaction span chain harder to reconstruct in OTel backends.

## Reviewer Test Plan

### How to verify

Run `cd packages/core && npx vitest run src/telemetry/daemon-tracing.test.ts src/telemetry/session-tracing.test.ts` and expect 130 passing tests.

Run `cd packages/acp-bridge && npx vitest run src/bridge.test.ts` and expect 251 passing tests.

Run `cd packages/cli && npx vitest run src/serve/server.test.ts` and expect 408 passing tests.

Run `npx prettier --check packages/core/src/telemetry/daemon-tracing.ts packages/core/src/telemetry/daemon-tracing.test.ts packages/core/src/telemetry/session-tracing.ts packages/core/src/telemetry/session-tracing.test.ts packages/cli/src/serve/server.ts packages/cli/src/serve/server.test.ts packages/acp-bridge/src/bridge.test.ts` and expect all matched files to use Prettier code style.

Run `npm run build && npm run typecheck` and expect exit code 0. Local output still includes existing VS Code companion curly lint warnings, Browserslist stale-data warnings, and the existing web-shell chunk-size warning.

### Evidence (Before & After)

N/A

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js v22.22.3, npm 10.9.8.

## Risk & Scope

- Main risk or tradeoff: The daemon now synthesizes ACP prompt `traceparent` from the active span and continues stripping client-supplied reserved trace metadata; `tracestate` is not synthesized because this codebase has no internal tracestate source for this path.
- Not validated / out of scope: Windows and Linux were not run locally; CI should cover cross-platform behavior.
- Breaking changes / migration notes: None.

## Linked Issues

Related to #4554.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让 daemon 到 ACP 的 prompt dispatch telemetry 链路保持贯通：ACP prompt metadata 里的 `traceparent` 改为从当前 active daemon bridge span 派生，不再依赖全局 outbound propagator。同时，生成的 prompt id 会写到当前 daemon HTTP request span 上，deferred 的 blocked-on-user 和 hook spans 也会从逻辑父上下文解析 owning session id。

回归测试覆盖 daemon trace metadata 注入路径、bridge prompt dispatch span 顺序、daemon prompt id span attribute，以及 deferred spans 在多 session 场景下的 session 归因。

## Why it's needed

`qwen serve` 默认安装 no-op outbound propagator，因此用 `propagation.inject()` 写 daemon 到 ACP 的 prompt metadata 时，ACP child interaction 可能拿不到可用的父级 `traceparent`。daemon HTTP span 也生成了 `promptId` 但没有写回当前 request span，部分 deferred spans 在多 session daemon 场景下还可能退回到过期的进程全局 session id。这些缺口会让 OTel 后端里 “daemon HTTP span → bridge span → ACP child interaction span” 链路更难还原。

## Reviewer Test Plan

### How to verify

运行 `cd packages/core && npx vitest run src/telemetry/daemon-tracing.test.ts src/telemetry/session-tracing.test.ts`，预期 130 个测试通过。

运行 `cd packages/acp-bridge && npx vitest run src/bridge.test.ts`，预期 251 个测试通过。

运行 `cd packages/cli && npx vitest run src/serve/server.test.ts`，预期 408 个测试通过。

运行 `npx prettier --check packages/core/src/telemetry/daemon-tracing.ts packages/core/src/telemetry/daemon-tracing.test.ts packages/core/src/telemetry/session-tracing.ts packages/core/src/telemetry/session-tracing.test.ts packages/cli/src/serve/server.ts packages/cli/src/serve/server.test.ts packages/acp-bridge/src/bridge.test.ts`，预期所有匹配文件符合 Prettier 格式。

运行 `npm run build && npm run typecheck`，预期退出码为 0。本地输出仍包含既有的 VS Code companion curly lint warnings、Browserslist stale-data warnings，以及既有的 web-shell chunk-size warning。

### Evidence (Before & After)

N/A

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js v22.22.3，npm 10.9.8。

## Risk & Scope

- Main risk or tradeoff: daemon 现在会从 active span 合成 ACP prompt `traceparent`，并继续剥离客户端传入的保留 trace metadata；由于这条路径在代码库里没有内部 `tracestate` 来源，因此不会合成 `tracestate`。
- Not validated / out of scope: 本地未跑 Windows 和 Linux；跨平台行为交给 CI 覆盖。
- Breaking changes / migration notes: 无。

## Linked Issues

关联 #4554。

</details>