### PR TITLE
fix(release): allow fzfWorker.js in standalone dist allowlist

### DIFF
--- a/scripts/create-standalone-package.js
+++ b/scripts/create-standalone-package.js
@@ -44,6 +44,9 @@ const DIST_REQUIRED_PATHS = [
 ];
 const DIST_ALLOWED_ENTRIES = new Set([
   'cli.js',
+  // fzf fuzzy-search worker; esbuild emits it as a standalone entry that must
+  // sit next to cli.js so `new URL('./fzfWorker.js', ...)` resolves at runtime.
+  'fzfWorker.js',
   'chunks',
   'vendor',
   'bundled',


### PR DESCRIPTION
## What this PR does

Adds `fzfWorker.js` to the `DIST_ALLOWED_ENTRIES` allowlist in `scripts/create-standalone-package.js`, so the standalone packer accepts the fzf worker bundle that esbuild now emits at `dist/fzfWorker.js`.

## Why it's needed

The fzf fuzzy-search feature added a second esbuild entry that outputs `dist/fzfWorker.js` next to `dist/cli.js` (it has to live there so `new URL('./fzfWorker.js', ...)` resolves at runtime). `scripts/prepare-package.js` was updated to whitelist this file for the npm tarball, but `scripts/create-standalone-package.js` keeps its **own** allowlist that was not updated. Its `copyRuntimeAssets` step fails on any unexpected dist entry, so the release job's `Build Standalone Archives` step aborted with `Error: Unexpected dist asset: .../dist/fzfWorker.js` and the whole release failed (see #5048 / run 27417076690). This change syncs the standalone allowlist with `prepare-package.js`.

## Reviewer Test Plan

### How to verify

Build the bundle, then run the standalone packer for one target against a downloaded Node runtime. Before the change it fails on the unexpected asset; after it produces an archive that contains `lib/fzfWorker.js`.

```bash
npm run bundle
node scripts/create-standalone-package.js --target darwin-arm64 \
  --node-archive <node-vX-darwin-arm64.tar.gz> \
  --out-dir /tmp/out --skip-checksums --version 0.18.0
tar tzf /tmp/out/qwen-code-darwin-arm64.tar.gz | grep 'lib/fzfWorker.js'
```

### Evidence (Before & After)

Reproduced the failing `Build Standalone Archives` step locally in tmux. Full terminal capture is in the PR comment below.

- **Before** (allowlist without `fzfWorker.js`): `Error: Unexpected dist asset: .../dist/fzfWorker.js`, exit 1 — same error as the failed release run.
- **After** (this PR): `Created qwen-code-darwin-arm64.tar.gz`, exit 0; the archive contains `qwen-code/lib/fzfWorker.js` alongside `qwen-code/lib/cli.js`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

Verified on macOS (darwin-arm64). The change is a platform-independent allowlist entry shared by all five release targets, so it behaves identically on Windows and Linux; those targets were not packaged locally.

### Environment (optional)

Local `npm run bundle` + `node scripts/create-standalone-package.js` against a Node 22.22.0 darwin-arm64 runtime archive. No sandbox.

## Risk & Scope

- Main risk or tradeoff: none meaningful — adds a single known filename to a packaging allowlist.
- Not validated / out of scope: did not run the full five-target `package:standalone:release` (Node downloads were throttled); validated the exact failing code path on darwin-arm64 instead.
- Breaking changes / migration notes: none.

## Linked Issues

Closes #5048

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 `scripts/create-standalone-package.js` 的 `DIST_ALLOWED_ENTRIES` 白名单里加入 `fzfWorker.js`，让 standalone 打包脚本接受 esbuild 新产出的 `dist/fzfWorker.js`。

## 为什么需要

fzf 模糊搜索功能新增了一个 esbuild 入口，输出 `dist/fzfWorker.js`，且必须与 `dist/cli.js` 同级（运行时靠 `new URL('./fzfWorker.js', ...)` 解析）。`scripts/prepare-package.js`（npm tarball 白名单）已经同步了这个文件，但 `scripts/create-standalone-package.js` 维护着**另一份独立的**白名单，没有同步。它的 `copyRuntimeAssets` 遇到白名单外的 dist 文件就会失败，因此 release 的 `Build Standalone Archives` 步骤报 `Error: Unexpected dist asset: .../dist/fzfWorker.js` 并导致整个发布失败（见 #5048 / run 27417076690）。本次改动把 standalone 白名单与 `prepare-package.js` 对齐。

## 如何验证

先 `npm run bundle`，再用下载好的 Node runtime 对单个目标跑 standalone 打包。改动前会因为意外的 dist 文件失败，改动后能产出包含 `lib/fzfWorker.js` 的归档。详见下方评论里的完整终端输出。

- **改动前**（白名单无 `fzfWorker.js`）：`Error: Unexpected dist asset: .../dist/fzfWorker.js`，退出码 1 —— 与失败的 release run 报错一致。
- **改动后**（本 PR）：`Created qwen-code-darwin-arm64.tar.gz`，退出码 0；归档内同时包含 `qwen-code/lib/fzfWorker.js` 与 `qwen-code/lib/cli.js`。

## 风险与范围

- 主要风险：基本没有，只是往打包白名单里加一个已知文件名。
- 未验证 / 范围外：未跑完整的五目标 `package:standalone:release`（Node 下载被限速），改为在 darwin-arm64 上验证了出错的那段代码路径。
- 破坏性变更：无。

</details>
