### PR TITLE
fix(ci): fail PR review job when the run aborts mid-review

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -412,6 +412,29 @@ jobs:
             fail "Qwen review completed but produced no output."
           fi
 
+          # qwen can exit 0 even when the run aborted mid-review (e.g. the model
+          # connection dropped before the review was posted). In that case the
+          # final stream-json `result` event still renders the error inline and
+          # carries subtype=success / is_error=false, so the checks above all
+          # pass and the job goes green without ever posting a comment. Inspect
+          # the terminal `result` event explicitly and treat an errored or
+          # aborted run as a failure so the fallback-comment step runs.
+          RESULT_LINE="$(grep '"type":"result"' "$LOG_PATH" | tail -n1 || true)"
+          if [ -z "$RESULT_LINE" ]; then
+            fail "Qwen review produced no result event (run aborted before completion)."
+          fi
+          RESULT_IS_ERROR="$(printf '%s' "$RESULT_LINE" | jq -r '.is_error // false')"
+          RESULT_SUBTYPE="$(printf '%s' "$RESULT_LINE" | jq -r '.subtype // ""')"
+          RESULT_TEXT="$(printf '%s' "$RESULT_LINE" | jq -r '.result // ""')"
+          if [ "$RESULT_IS_ERROR" = "true" ] || [ "$RESULT_SUBTYPE" != "success" ]; then
+            fail "Qwen review ended in an error result (subtype=${RESULT_SUBTYPE}, is_error=${RESULT_IS_ERROR})."
+          fi
+          case "$RESULT_TEXT" in
+            *"[API Error"*)
+              fail "Qwen review aborted with an API error before posting comments."
+              ;;
+          esac
+
       - name: 'Post fallback comment on failure'
         if: |-
           failure() &&


### PR DESCRIPTION
## What this PR does

The `review-pr` job in `qwen-code-pr-review.yml` now inspects the terminal stream-json `result` event after `qwen` exits, and fails the job when the review aborted before it could post anything. A failed check routes into the existing fallback-comment step instead of leaving a silent green check.

## Why it's needed

When the model connection drops mid-review (for example `[API Error: terminated (cause: other side closed)]`), `qwen` still exits `0` and emits a final `result` event with `subtype=success` and `is_error=false`, with the error only rendered inline in the `result` text. The job's existing guards only cover the exit code, the `tee` status, the timeout sentinel, and an empty log, so all of them pass and the job goes green even though no review comment was ever posted. Run [27405038120](https://github.com/QwenLM/qwen-code/actions/runs/27405038120) (PR #5006) is a concrete example: it reached the "Launching 5 review agents in parallel" step, hit the API error, exited 0, and posted nothing while reporting success. This makes a broken review indistinguishable from a clean one.

## Reviewer Test Plan

### How to verify

The new block reads the last `{"type":"result"}` line from the review log and fails when it is missing, when `is_error` is `true`, when `subtype` is not `success`, or when the `result` text contains an inlined `[API Error`. You can confirm the detection logic against the real failing payload and a genuine success payload:

```bash
# Failing payload from run 27405038120 (subtype=success, is_error=false — only the text reveals the abort)
LINE='{"type":"result","subtype":"success","is_error":false,"result":"Launching 5 review agents in parallel.\n\n[API Error: terminated (cause: other side closed)]"}'
T="$(printf '%s' "$LINE" | jq -r '.result // ""')"
case "$T" in *"[API Error"*) echo "caught -> would fail" ;; *) echo "missed" ;; esac   # -> caught -> would fail

# Genuine success still passes
OK='{"type":"result","subtype":"success","is_error":false,"result":"Review complete. Posted 3 inline comments."}'
TO="$(printf '%s' "$OK" | jq -r '.result // ""')"
case "$TO" in *"[API Error"*) echo "would fail" ;; *) echo "passes" ;; esac           # -> passes
```

The workflow YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/qwen-code-pr-review.yml'))"`). `jq` is preinstalled on the runner.

### Evidence (Before & After)

Before: a mid-review API abort exits 0, the job is green, and no comment is posted. After: the same abort is detected from the terminal `result` event, the job fails, and the existing "Post fallback comment on failure" step runs so the PR gets a signal.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested (YAML + detection logic locally) |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ not tested (job runs on the self-hosted Linux runner) |

### Environment (optional)

Logic verified locally with `jq` and `python3` YAML parsing. No runtime/dev server involved; the change is confined to the workflow shell step.

## Risk & Scope

- Main risk or tradeoff: the `[API Error` text match is a heuristic on the terminal `result` event; it is scoped to that single event's `.result` field (not a full-log grep) to avoid flagging reviews whose content merely discusses API errors.
- Not validated / out of scope: a more robust completion signal — having `/review` emit an explicit machine-readable "submitted" marker that the workflow asserts on — is intentionally left as a follow-up since it touches the review command internals rather than CI. The stale-worktree annotations on the runner (`cannot delete branch ... used by worktree`) that make the abort more likely are also out of scope here.
- Breaking changes / migration notes: none. This only tightens failure detection in CI; a genuinely successful review is unaffected.

## Linked Issues

Refs #5052

<details>
<summary>中文说明</summary>

## What this PR does

`qwen-code-pr-review.yml` 的 `review-pr` job 现在会在 `qwen` 退出后检查末尾那条 stream-json `result` 事件，并在 review 还没来得及提交任何内容就中断时把 job 判为失败。一旦判失败，就会走已有的 fallback-comment step，而不是留下一个静默的绿勾。

## Why it's needed

当模型连接在 review 中途被掐断（例如 `[API Error: terminated (cause: other side closed)]`）时，`qwen` 仍以 `0` 退出，并发出一条 `subtype=success`、`is_error=false` 的末尾 `result` 事件，错误只被内联渲染进 `result` 文本里。job 现有的判定只覆盖退出码、`tee` 状态、timeout 标志和空日志，于是这些检查全部通过、job 显示绿色，但 PR 上从未留下任何 review 评论。Run [27405038120](https://github.com/QwenLM/qwen-code/actions/runs/27405038120)（PR #5006）就是实例：它走到「Launching 5 review agents in parallel」时遇到 API error、退出码 0、什么都没发，却报告成功。这让"挂掉的 review"和"正常的 review"无法区分。

## Reviewer Test Plan

### How to verify

新加的逻辑读取 review 日志最后一条 `{"type":"result"}`，在它缺失、`is_error` 为 `true`、`subtype` 不是 `success`、或 `result` 文本含内联 `[API Error` 时判失败。可用真实失败 payload 与正常成功 payload 验证（见上方英文中的脚本）：失败 case 被 `[API Error` 文本命中、正常 case 通过。workflow YAML 解析正常，`jq` 在 runner 上预装。

### Evidence (Before & After)

Before：review 中途 API 中断仍以 0 退出、job 绿、无评论。After：同样的中断会被末尾 `result` 事件检测到、job 失败、已有的 fallback comment step 运行，PR 至少能拿到信号。

### Tested on

见上方表格。

### Environment (optional)

本地用 `jq` 和 `python3` YAML 解析验证。改动仅限 workflow 的 shell step，不涉及运行时。

## Risk & Scope

- Main risk or tradeoff：`[API Error` 文本匹配是对末尾 `result` 事件的启发式判断；只针对该事件的 `.result` 字段（不是全文 grep），避免误伤"内容本身在讨论 API error"的 review。
- Not validated / out of scope：更稳的完成信号——让 `/review` 输出一个显式、机器可识别的"已提交"标记、再由 workflow 断言——刻意留作后续，因为那要改 review 命令内部而非 CI。runner 上让中断更易发生的残留 worktree annotation 也不在本 PR 范围内。
- Breaking changes / migration notes：无。本改动只收紧 CI 的失败检测，正常成功的 review 不受影响。

## Linked Issues

Refs #5052

</details>