### PR TITLE
fix(core): Persist file history snapshot updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ CLAUDE.md
 
 # Qwen Code Configs
 .qwen/*
+!.qwen/design/
+!.qwen/design/**
+!.qwen/e2e-tests/
+!.qwen/e2e-tests/**
 !.qwen/commands/
 !.qwen/commands/**
 !.qwen/skills/

--- a/.gitignore
+++ b/.gitignore
@@ -30,10 +30,6 @@ CLAUDE.md
 
 # Qwen Code Configs
 .qwen/*
-!.qwen/design/
-!.qwen/design/**
-!.qwen/e2e-tests/
-!.qwen/e2e-tests/**
 !.qwen/commands/
 !.qwen/commands/**
 !.qwen/skills/

--- a/.qwen/design/2026-06-13-file-history-snapshot-persistence.md
+++ b/.qwen/design/2026-06-13-file-history-snapshot-persistence.md
@@ -1,0 +1,60 @@
+# File History Snapshot Persistence
+
+## Summary
+
+This change closes the A+C persistence gaps for `/rewind` file history without
+changing the persisted JSONL schema.
+
+`file_history_snapshot` records remain append-only system records. Resume
+reconstructs file history by reading all snapshot records in linear history and
+deduplicating by `promptId` with last-wins semantics. That means an updated
+snapshot for the same prompt can be appended later without rewriting old logs.
+
+## Snapshot Update Recording
+
+`makeSnapshot(promptId)` still creates the turn-boundary snapshot and the caller
+still records it explicitly. The missing last-turn case is handled by giving
+`FileHistoryService` an optional recorder callback. When `trackEdit(filePath)`
+successfully adds a new backup to the latest snapshot, or heals a failed backup
+entry in that snapshot, it invokes the recorder with the updated snapshot.
+
+Duplicate `trackEdit` calls for an already captured non-failed file do not
+record again because the snapshot did not change.
+
+Recorder errors are swallowed and logged. File editing must remain best-effort:
+file-history persistence must not make edit or write tools fail.
+
+## Persistence Shape
+
+No schema version is added. The existing payload already has enough structure
+for backward-compatible reconstruction:
+
+```json
+{
+  "type": "system",
+  "subtype": "file_history_snapshot",
+  "systemPayload": {
+    "snapshots": []
+  }
+}
+```
+
+Old logs without these records still resume with no file-history state. Malformed
+snapshot records are skipped with a warning, and valid later records remain
+usable.
+
+No explicit `isSnapshotUpdate` flag is added. Appending another
+`file_history_snapshot` record with the same `promptId` has the same practical
+behavior because `SessionService.loadSession()` already applies last-wins
+deduplication by `promptId`.
+
+## Scope
+
+This is A+C only.
+
+B1 simulated `sed -i` coverage is left for a separate PR. Generic shell edit
+tracking, `getDiffStats` concurrency limiting, and per-file failure reasons are
+also deferred. Claude Code does not support those behaviors today, so qwen-code
+should not add them as part of this compatibility pass.
+
+No migration is required because the persisted record shape is unchanged.

--- a/.qwen/e2e-tests/2026-06-13-file-history-snapshot-persistence.md
+++ b/.qwen/e2e-tests/2026-06-13-file-history-snapshot-persistence.md
@@ -1,0 +1,56 @@
+# File History Snapshot Persistence E2E Plan
+
+## Goal
+
+Verify that `/rewind` file-history state survives session resume when tool edits
+occur after the turn-boundary `makeSnapshot()` and before process exit.
+
+## Scenario
+
+- Enable file checkpointing and chat recording.
+- Start an interactive session in a temporary project.
+- Ask the model to edit or write a file through the normal edit/write tool
+  path.
+- Exit immediately after the edit completes, before sending another prompt.
+- Resume the same session.
+- Run `/rewind` to the prompt that scheduled the edit.
+
+## Expected Results
+
+- The resumed session includes the updated `file_history_snapshot` record for
+  the edited turn.
+- `/rewind` can restore the edited file to its pre-edit state.
+- The JSONL record shape remains a system record with subtype
+  `file_history_snapshot` and a `systemPayload.snapshots` array.
+- No `schemaVersion` or `isSnapshotUpdate` field is required.
+
+## Commands
+
+Build the local CLI first:
+
+```bash
+npm run build && npm run bundle
+```
+
+Run the scenario in a throwaway project and inspect the generated chat JSONL.
+Use a clean user config, or confirm local settings have not disabled
+checkpointing.
+
+```bash
+REPO_ROOT="/Users/jinye.djy/.codex/worktrees/6393/qwen-code"
+TMP_PROJECT="$(mktemp -d)"
+cd "$TMP_PROJECT"
+printf 'before\n' > a.txt
+
+node "$REPO_ROOT/dist/cli.js" --chat-recording
+```
+
+Inside the TUI, ask Qwen Code to replace `before` with `after` in `a.txt`, then
+exit immediately after the edit tool completes. Resume the session with the same
+CLI build and run `/rewind`.
+
+## Status
+
+Not executed as part of this implementation pass. The regression is covered by
+focused unit tests for snapshot recording, JSONL persistence, resume
+reconstruction, client prompt flow, and ACP prompt flow.

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -198,7 +198,14 @@ describe('Session', () => {
     recordToolResult: ReturnType<typeof vi.fn>;
     recordSlashCommand: ReturnType<typeof vi.fn>;
     recordNotification: ReturnType<typeof vi.fn>;
+    recordFileHistorySnapshot: ReturnType<typeof vi.fn>;
     rewindRecording: ReturnType<typeof vi.fn>;
+  };
+  let mockFileHistoryService: {
+    makeSnapshot: ReturnType<typeof vi.fn>;
+    getSnapshots: ReturnType<typeof vi.fn>;
+    restoreFromSnapshots: ReturnType<typeof vi.fn>;
+    rewind: ReturnType<typeof vi.fn>;
   };
   let mockGeminiClient: {
     getChat: ReturnType<typeof vi.fn>;
@@ -264,7 +271,14 @@ describe('Session', () => {
       recordToolResult: vi.fn(),
       recordSlashCommand: vi.fn(),
       recordNotification: vi.fn(),
+      recordFileHistorySnapshot: vi.fn(),
       rewindRecording: vi.fn(),
+    };
+    mockFileHistoryService = {
+      makeSnapshot: vi.fn().mockResolvedValue(undefined),
+      getSnapshots: vi.fn().mockReturnValue([]),
+      restoreFromSnapshots: vi.fn(),
+      rewind: vi.fn(),
     };
 
     mockToolRegistry = {
@@ -307,12 +321,7 @@ describe('Session', () => {
         .fn()
         .mockReturnValue(mockBackgroundShellRegistry),
       getMonitorRegistry: vi.fn().mockReturnValue(mockMonitorRegistry),
-      getFileHistoryService: vi.fn().mockReturnValue({
-        makeSnapshot: vi.fn().mockResolvedValue(undefined),
-        getSnapshots: vi.fn().mockReturnValue([]),
-        restoreFromSnapshots: vi.fn(),
-        rewind: vi.fn(),
-      }),
+      getFileHistoryService: vi.fn().mockReturnValue(mockFileHistoryService),
     } as unknown as Config;
 
     mockClient = {
@@ -1149,6 +1158,36 @@ describe('Session', () => {
   });
 
   describe('prompt', () => {
+    it('records the latest file history snapshot after makeSnapshot', async () => {
+      const latestSnapshot = {
+        promptId: 'test-session-id########1',
+        timestamp: new Date('2026-06-13T00:00:00.000Z'),
+        trackedFileBackups: {
+          'a.txt': {
+            backupFileName: 'backup-a',
+            version: 1,
+            backupTime: new Date('2026-06-13T00:00:01.000Z'),
+          },
+        },
+      };
+      mockFileHistoryService.getSnapshots.mockReturnValue([latestSnapshot]);
+      mockChat.sendMessageStream = vi
+        .fn()
+        .mockResolvedValue(createEmptyStream());
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'edit file' }],
+      });
+
+      expect(mockFileHistoryService.makeSnapshot).toHaveBeenCalledWith(
+        'test-session-id########1',
+      );
+      expect(
+        mockChatRecordingService.recordFileHistorySnapshot,
+      ).toHaveBeenCalledWith(latestSnapshot);
+    });
+
     it('drains background task notifications through ACP after the prompt is idle', async () => {
       mockChat.sendMessageStream = vi
         .fn()

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -454,6 +454,39 @@ describe('Server Config (config.ts)', () => {
     }
   });
 
+  it('drops stale file history callbacks after session switch', async () => {
+    const projectDir = await mkdtemp(path.join(os.tmpdir(), 'qwen-config-'));
+    const storageDir = await mkdtemp(path.join(os.tmpdir(), 'qwen-storage-'));
+    const config = new Config({
+      ...baseParams,
+      cwd: projectDir,
+      fileCheckpointingEnabled: true,
+    });
+    const recordFileHistorySnapshot = vi.fn();
+    vi.spyOn(config, 'getChatRecordingService').mockReturnValue({
+      recordFileHistorySnapshot,
+    } as unknown as ReturnType<Config['getChatRecordingService']>);
+    const getGlobalQwenDirSpy = vi
+      .spyOn(Storage, 'getGlobalQwenDir')
+      .mockReturnValue(storageDir);
+
+    try {
+      const trackedFile = path.join(projectDir, 'a.txt');
+      await writeFile(trackedFile, 'original');
+
+      const oldFileHistoryService = config.getFileHistoryService();
+      await oldFileHistoryService.makeSnapshot('p1');
+      config.startNewSession('new-session-id');
+      await oldFileHistoryService.trackEdit(trackedFile);
+
+      expect(recordFileHistorySnapshot).not.toHaveBeenCalled();
+    } finally {
+      getGlobalQwenDirSpy.mockRestore();
+      await rm(projectDir, { recursive: true, force: true });
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
   describe('FileReadCache isolation', () => {
     it('returns a distinct cache for child Configs created via Object.create', () => {
       // Subagent / scoped-agent / fork construction all use

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -422,11 +422,9 @@ describe('Server Config (config.ts)', () => {
       chatRecording: true,
     });
     const recordedSnapshots: FileHistorySnapshot[] = [];
-    const recordFileHistorySnapshot = vi.fn(
-      (snapshot: FileHistorySnapshot) => {
-        recordedSnapshots.push(structuredClone(snapshot));
-      },
-    );
+    const recordFileHistorySnapshot = vi.fn((snapshot: FileHistorySnapshot) => {
+      recordedSnapshots.push(structuredClone(snapshot));
+    });
     vi.spyOn(config, 'getChatRecordingService').mockReturnValue({
       recordFileHistorySnapshot,
     } as unknown as ReturnType<Config['getChatRecordingService']>);
@@ -721,6 +719,28 @@ describe('Server Config (config.ts)', () => {
       const newSessionId = config.startNewSession();
 
       expect(refreshSessionContext).toHaveBeenCalledWith(newSessionId);
+    });
+
+    it('flushes the outgoing chat recording service when switching sessions', () => {
+      const config = new Config({
+        ...baseParams,
+        chatRecording: true,
+      });
+      const finalize = vi.fn();
+      const flush = vi.fn().mockResolvedValue(undefined);
+      (
+        config as unknown as {
+          chatRecordingService?: {
+            finalize: () => void;
+            flush: () => Promise<void>;
+          };
+        }
+      ).chatRecordingService = { finalize, flush };
+
+      config.startNewSession();
+
+      expect(finalize).toHaveBeenCalledTimes(1);
+      expect(flush).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Mock } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import type { ConfigParameters, SandboxConfig } from './config.js';
 import {
   Config,
@@ -408,6 +409,46 @@ describe('Server Config (config.ts)', () => {
 
     expect(config.getAppendSystemPrompt()).toBe('Be extra concise.');
     expect(config.getSystemPrompt()).toBeUndefined();
+  });
+
+  it('wires file history snapshot updates to chat recording', async () => {
+    const projectDir = await mkdtemp(path.join(os.tmpdir(), 'qwen-config-'));
+    const storageDir = await mkdtemp(path.join(os.tmpdir(), 'qwen-storage-'));
+    const config = new Config({
+      ...baseParams,
+      cwd: projectDir,
+      fileCheckpointingEnabled: true,
+      chatRecording: true,
+    });
+    const recordFileHistorySnapshot = vi.fn();
+    vi.spyOn(config, 'getChatRecordingService').mockReturnValue({
+      recordFileHistorySnapshot,
+    } as unknown as ReturnType<Config['getChatRecordingService']>);
+    const getGlobalQwenDirSpy = vi
+      .spyOn(Storage, 'getGlobalQwenDir')
+      .mockReturnValue(storageDir);
+
+    try {
+      const trackedFile = path.join(projectDir, 'a.txt');
+      await writeFile(trackedFile, 'original');
+
+      const fileHistoryService = config.getFileHistoryService();
+      await fileHistoryService.makeSnapshot('p1');
+      await fileHistoryService.trackEdit(trackedFile);
+
+      const snapshot = fileHistoryService.getSnapshots()[0];
+      expect(recordFileHistorySnapshot).toHaveBeenCalledWith(snapshot);
+      expect(snapshot.trackedFileBackups['a.txt']).toEqual(
+        expect.objectContaining({
+          backupFileName: expect.any(String),
+          version: 1,
+        }),
+      );
+    } finally {
+      getGlobalQwenDirSpy.mockRestore();
+      await rm(projectDir, { recursive: true, force: true });
+      await rm(storageDir, { recursive: true, force: true });
+    }
   });
 
   describe('FileReadCache isolation', () => {

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -56,6 +56,7 @@ import * as runtimeStatus from '../utils/runtimeStatus.js';
 import { ExtensionManager } from '../extension/extensionManager.js';
 import { SkillManager } from '../skills/skill-manager.js';
 import { HookSystem } from '../hooks/index.js';
+import type { FileHistorySnapshot } from '../services/fileHistoryService.js';
 
 function createToolMock(toolName: string) {
   const ToolMock = vi.fn();
@@ -420,7 +421,12 @@ describe('Server Config (config.ts)', () => {
       fileCheckpointingEnabled: true,
       chatRecording: true,
     });
-    const recordFileHistorySnapshot = vi.fn();
+    const recordedSnapshots: FileHistorySnapshot[] = [];
+    const recordFileHistorySnapshot = vi.fn(
+      (snapshot: FileHistorySnapshot) => {
+        recordedSnapshots.push(structuredClone(snapshot));
+      },
+    );
     vi.spyOn(config, 'getChatRecordingService').mockReturnValue({
       recordFileHistorySnapshot,
     } as unknown as ReturnType<Config['getChatRecordingService']>);
@@ -436,9 +442,8 @@ describe('Server Config (config.ts)', () => {
       await fileHistoryService.makeSnapshot('p1');
       await fileHistoryService.trackEdit(trackedFile);
 
-      const snapshot = fileHistoryService.getSnapshots()[0];
-      expect(recordFileHistorySnapshot).toHaveBeenCalledWith(snapshot);
-      expect(snapshot.trackedFileBackups['a.txt']).toEqual(
+      expect(recordFileHistorySnapshot).toHaveBeenCalledTimes(1);
+      expect(recordedSnapshots[0].trackedFileBackups['a.txt']).toEqual(
         expect.objectContaining({
           backupFileName: expect.any(String),
           version: 1,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2239,11 +2239,15 @@ export class Config {
     sessionData?: ResumedSessionData,
   ): string {
     // Finalize the outgoing session before switching.
+    const outgoingChatRecordingService = this.chatRecordingService;
     try {
-      this.chatRecordingService?.finalize();
+      outgoingChatRecordingService?.finalize();
     } catch {
       // Best-effort — don't block session switch
     }
+    void outgoingChatRecordingService?.flush().catch(() => {
+      // Best-effort — don't block session switch
+    });
 
     const previousSessionId = this.sessionId;
     this.sessionId = sessionId ?? randomUUID();

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -3819,18 +3819,20 @@ export class Config {
 
   getFileHistoryService(): FileHistoryService {
     if (!this.fileHistoryService) {
-      this.fileHistoryService = new FileHistoryService(
+      const service = new FileHistoryService(
         this.sessionId,
         this.fileCheckpointingEnabled,
         this.cwd,
         (snapshot) => {
+          if (this.fileHistoryService !== service) return;
           this.getChatRecordingService()?.recordFileHistorySnapshot(snapshot);
         },
       );
+      this.fileHistoryService = service;
       const snapshots = this.sessionData?.fileHistorySnapshots;
-      if (snapshots?.length && this.fileHistoryService.isEnabled()) {
-        this.fileHistoryService.restoreFromSnapshots(snapshots);
-        void this.fileHistoryService.validateRestoredSnapshots().catch((e) => {
+      if (snapshots?.length && service.isEnabled()) {
+        service.restoreFromSnapshots(snapshots);
+        void service.validateRestoredSnapshots().catch((e) => {
           this.debugLogger.error(
             `FileHistory: validateRestoredSnapshots failed: ${e}`,
           );

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -3823,6 +3823,9 @@ export class Config {
         this.sessionId,
         this.fileCheckpointingEnabled,
         this.cwd,
+        (snapshot) => {
+          this.getChatRecordingService()?.recordFileHistorySnapshot(snapshot);
+        },
       );
       const snapshots = this.sessionData?.fileHistorySnapshots;
       if (snapshots?.length && this.fileHistoryService.isEnabled()) {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -73,6 +73,7 @@ import {
   clearActiveGoal,
   setActiveGoal,
 } from '../goals/activeGoalStore.js';
+import type { FileHistorySnapshot } from '../services/fileHistoryService.js';
 
 // Mock fs module to prevent actual file system operations during tests
 const mockFileSystem = new Map<string, string>();
@@ -367,6 +368,12 @@ describe('Gemini Client (client.ts)', () => {
   let mockConfig: Config;
   let client: GeminiClient;
   let mockGenerateContentFn: Mock;
+  let mockFileHistoryService: {
+    makeSnapshot: ReturnType<typeof vi.fn>;
+    getSnapshots: ReturnType<typeof vi.fn>;
+    restoreFromSnapshots: ReturnType<typeof vi.fn>;
+    rewind: ReturnType<typeof vi.fn>;
+  };
   let mockMemoryManager: {
     scheduleExtract: ReturnType<typeof vi.fn>;
     scheduleDream: ReturnType<typeof vi.fn>;
@@ -406,6 +413,12 @@ describe('Gemini Client (client.ts)', () => {
     mockGenerateContentFn = vi.fn().mockResolvedValue({
       candidates: [{ content: { parts: [{ text: '{"key": "value"}' }] } }],
     });
+    mockFileHistoryService = {
+      makeSnapshot: vi.fn().mockResolvedValue(undefined),
+      getSnapshots: vi.fn().mockReturnValue([]),
+      restoreFromSnapshots: vi.fn(),
+      rewind: vi.fn(),
+    };
 
     // Disable 429 simulation for tests
     setSimulate429(false);
@@ -491,6 +504,7 @@ describe('Gemini Client (client.ts)', () => {
       getBaseLlmClient: vi.fn(),
       getSkipLoopDetection: vi.fn().mockReturnValue(false),
       getChatRecordingService: vi.fn().mockReturnValue(undefined),
+      getFileHistoryService: vi.fn().mockReturnValue(mockFileHistoryService),
       getResumedSessionData: vi.fn().mockReturnValue(undefined),
       getArenaAgentClient: vi.fn().mockReturnValue(null),
       getManagedAutoMemoryEnabled: vi.fn().mockReturnValue(true),
@@ -6561,6 +6575,103 @@ Other open files:
           /* consume */
         }
         expect(recordAttributionSnapshot).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('file history snapshot persistence', () => {
+      let recordFileHistorySnapshot: ReturnType<typeof vi.fn>;
+      const latestSnapshot: FileHistorySnapshot = {
+        promptId: 'prompt-uq',
+        timestamp: new Date('2026-06-13T00:00:00.000Z'),
+        trackedFileBackups: {
+          'a.txt': {
+            backupFileName: 'backup-a',
+            version: 1,
+            backupTime: new Date('2026-06-13T00:00:01.000Z'),
+          },
+        },
+      };
+
+      beforeEach(() => {
+        recordFileHistorySnapshot = vi.fn();
+        mockFileHistoryService.makeSnapshot.mockResolvedValue(undefined);
+        mockFileHistoryService.getSnapshots.mockReturnValue([latestSnapshot]);
+        vi.mocked(mockConfig.getChatRecordingService).mockReturnValue({
+          recordAttributionSnapshot: vi.fn(),
+          recordFileHistorySnapshot,
+          recordUserMessage: vi.fn(),
+          recordCronPrompt: vi.fn(),
+        } as unknown as ReturnType<Config['getChatRecordingService']>);
+
+        mockTurnRunFn.mockReturnValue(
+          (async function* () {
+            yield { type: GeminiEventType.Content, value: 'ok' };
+          })(),
+        );
+      });
+
+      async function collectStream(
+        messageType: SendMessageType,
+        promptId = 'prompt-uq',
+      ): Promise<ServerGeminiStreamEvent[]> {
+        const stream = client.sendMessageStream(
+          [{ text: 'user' }],
+          new AbortController().signal,
+          promptId,
+          { type: messageType },
+        );
+        const chunks: ServerGeminiStreamEvent[] = [];
+        for await (const chunk of stream) {
+          chunks.push(chunk);
+        }
+        return chunks;
+      }
+
+      it('calls makeSnapshot for UserQuery turns', async () => {
+        await collectStream(SendMessageType.UserQuery, 'prompt-file-history');
+
+        expect(mockFileHistoryService.makeSnapshot).toHaveBeenCalledWith(
+          'prompt-file-history',
+        );
+      });
+
+      it('records the latest snapshot after a UserQuery snapshot', async () => {
+        await collectStream(SendMessageType.UserQuery);
+
+        expect(recordFileHistorySnapshot).toHaveBeenCalledWith(latestSnapshot);
+      });
+
+      it('does not call makeSnapshot for ToolResult and Retry turns', async () => {
+        await collectStream(SendMessageType.ToolResult, 'prompt-tool-result');
+        await collectStream(SendMessageType.Retry, 'prompt-retry');
+
+        expect(mockFileHistoryService.makeSnapshot).not.toHaveBeenCalled();
+      });
+
+      it('swallows makeSnapshot rejection and still yields content', async () => {
+        mockFileHistoryService.makeSnapshot.mockRejectedValueOnce(
+          new Error('snapshot failed'),
+        );
+
+        const chunks = await collectStream(SendMessageType.UserQuery);
+
+        expect(chunks).toContainEqual({
+          type: GeminiEventType.Content,
+          value: 'ok',
+        });
+      });
+
+      it('swallows recordFileHistorySnapshot errors and still yields content', async () => {
+        recordFileHistorySnapshot.mockImplementationOnce(() => {
+          throw new Error('record failed');
+        });
+
+        const chunks = await collectStream(SendMessageType.UserQuery);
+
+        expect(chunks).toContainEqual({
+          type: GeminiEventType.Content,
+          value: 'ok',
+        });
       });
     });
   });

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -1772,10 +1772,9 @@ export class GeminiClient {
       }
 
       if (messageType !== SendMessageType.Retry) {
-        // Snapshot on every non-retry turn. ToolResult turns run right after
-        // tool execution, so their snapshot captures edits that a prior
-        // UserQuery turn scheduled. Without this, a resumed session only sees
-        // the UserQuery-time snapshot (empty) and loses tool-driven edits.
+        // Attribution snapshots are recorded on every non-retry turn. File
+        // history snapshots are created only at UserQuery boundaries; later
+        // tool edits update that latest snapshot through trackEdit().
         this.config
           .getChatRecordingService()
           ?.recordAttributionSnapshot(

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -18,6 +18,7 @@ import {
 import * as jsonl from '../utils/jsonl-utils.js';
 import type { Part } from '@google/genai';
 import type { FileDiff } from '../tools/tools.js';
+import type { FileHistorySnapshot } from './fileHistoryService.js';
 
 vi.mock('node:path');
 vi.mock('node:child_process');
@@ -188,6 +189,105 @@ describe('ChatRecordingService', () => {
       expect(systemRecord.subtype).toBe('at_command');
       expect(systemRecord.systemPayload).toEqual(payload);
       expect(systemRecord.parentUuid).toBe(userRecord.uuid);
+    });
+  });
+
+  describe('recordFileHistorySnapshot', () => {
+    const oldSnapshot: FileHistorySnapshot = {
+      promptId: 'p1',
+      timestamp: new Date('2026-06-13T00:00:00.000Z'),
+      trackedFileBackups: {
+        'a.txt': {
+          backupFileName: 'backup-a-v1',
+          version: 1,
+          backupTime: new Date('2026-06-13T00:00:01.000Z'),
+        },
+      },
+    };
+    const updatedSnapshot: FileHistorySnapshot = {
+      promptId: 'p1',
+      timestamp: new Date('2026-06-13T00:01:00.000Z'),
+      trackedFileBackups: {
+        'a.txt': {
+          backupFileName: 'backup-a-v2',
+          version: 2,
+          backupTime: new Date('2026-06-13T00:01:01.000Z'),
+        },
+        'b.txt': {
+          backupFileName: null,
+          version: 1,
+          backupTime: new Date('2026-06-13T00:01:02.000Z'),
+        },
+      },
+    };
+
+    it('writes a system record with the serialized snapshot payload', async () => {
+      chatRecordingService.recordFileHistorySnapshot(oldSnapshot);
+      await chatRecordingService.flush();
+
+      expect(jsonl.writeLine).toHaveBeenCalledTimes(1);
+      const record = vi.mocked(jsonl.writeLine).mock.calls[0][1] as ChatRecord;
+      expect(record.type).toBe('system');
+      expect(record.subtype).toBe('file_history_snapshot');
+      expect(JSON.parse(JSON.stringify(record.systemPayload))).toEqual({
+        snapshots: [
+          {
+            promptId: 'p1',
+            timestamp: '2026-06-13T00:00:00.000Z',
+            trackedFileBackups: {
+              'a.txt': {
+                backupFileName: 'backup-a-v1',
+                version: 1,
+                backupTime: '2026-06-13T00:00:01.000Z',
+              },
+            },
+          },
+        ],
+      });
+    });
+
+    it('writes a batch of serialized snapshots in order', async () => {
+      chatRecordingService.recordFileHistorySnapshotBatch([
+        oldSnapshot,
+        updatedSnapshot,
+      ]);
+      await chatRecordingService.flush();
+
+      expect(jsonl.writeLine).toHaveBeenCalledTimes(1);
+      const record = vi.mocked(jsonl.writeLine).mock.calls[0][1] as ChatRecord;
+      expect(record.type).toBe('system');
+      expect(record.subtype).toBe('file_history_snapshot');
+      expect(JSON.parse(JSON.stringify(record.systemPayload))).toEqual({
+        snapshots: [
+          {
+            promptId: 'p1',
+            timestamp: '2026-06-13T00:00:00.000Z',
+            trackedFileBackups: {
+              'a.txt': {
+                backupFileName: 'backup-a-v1',
+                version: 1,
+                backupTime: '2026-06-13T00:00:01.000Z',
+              },
+            },
+          },
+          {
+            promptId: 'p1',
+            timestamp: '2026-06-13T00:01:00.000Z',
+            trackedFileBackups: {
+              'a.txt': {
+                backupFileName: 'backup-a-v2',
+                version: 2,
+                backupTime: '2026-06-13T00:01:01.000Z',
+              },
+              'b.txt': {
+                backupFileName: null,
+                version: 1,
+                backupTime: '2026-06-13T00:01:02.000Z',
+              },
+            },
+          },
+        ],
+      });
     });
   });
 

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -311,14 +311,30 @@ describe('ChatRecordingService', () => {
       });
     });
 
-    it('coalesces single-snapshot updates by prompt id before flush', async () => {
+    it('appends single-snapshot updates in order so resume can last-win', async () => {
       chatRecordingService.recordFileHistorySnapshot(oldSnapshot);
       chatRecordingService.recordFileHistorySnapshot(updatedSnapshot);
       await chatRecordingService.flush();
 
-      expect(jsonl.writeLine).toHaveBeenCalledTimes(1);
-      const record = vi.mocked(jsonl.writeLine).mock.calls[0][1] as ChatRecord;
-      expect(JSON.parse(JSON.stringify(record.systemPayload))).toEqual({
+      expect(jsonl.writeLine).toHaveBeenCalledTimes(2);
+      const first = vi.mocked(jsonl.writeLine).mock.calls[0][1] as ChatRecord;
+      const second = vi.mocked(jsonl.writeLine).mock.calls[1][1] as ChatRecord;
+      expect(JSON.parse(JSON.stringify(first.systemPayload))).toEqual({
+        snapshots: [
+          {
+            promptId: 'p1',
+            timestamp: '2026-06-13T00:00:00.000Z',
+            trackedFileBackups: {
+              'a.txt': {
+                backupFileName: 'backup-a-v1',
+                version: 1,
+                backupTime: '2026-06-13T00:00:01.000Z',
+              },
+            },
+          },
+        ],
+      });
+      expect(JSON.parse(JSON.stringify(second.systemPayload))).toEqual({
         snapshots: [
           {
             promptId: 'p1',
@@ -340,6 +356,49 @@ describe('ChatRecordingService', () => {
       });
     });
 
+    it('retains distinct prompt ids in one batch', async () => {
+      chatRecordingService.recordFileHistorySnapshotBatch([
+        oldSnapshot,
+        failedSnapshot,
+      ]);
+      await chatRecordingService.flush();
+
+      expect(jsonl.writeLine).toHaveBeenCalledTimes(1);
+      const record = vi.mocked(jsonl.writeLine).mock.calls[0][1] as ChatRecord;
+      expect(JSON.parse(JSON.stringify(record.systemPayload))).toEqual({
+        snapshots: [
+          {
+            promptId: 'p1',
+            timestamp: '2026-06-13T00:00:00.000Z',
+            trackedFileBackups: {
+              'a.txt': {
+                backupFileName: 'backup-a-v1',
+                version: 1,
+                backupTime: '2026-06-13T00:00:01.000Z',
+              },
+            },
+          },
+          {
+            promptId: 'p2',
+            timestamp: '2026-06-13T00:02:00.000Z',
+            trackedFileBackups: {
+              'failed.txt': {
+                backupFileName: 'backup-failed-v1',
+                version: 1,
+                backupTime: '2026-06-13T00:02:01.000Z',
+                failed: true,
+              },
+              'deleted.txt': {
+                backupFileName: null,
+                version: 2,
+                backupTime: '2026-06-13T00:02:02.000Z',
+              },
+            },
+          },
+        ],
+      });
+    });
+
     it('round-trips serialized snapshots through JSON and deserialization', () => {
       expect(
         deserializeSnapshots([
@@ -348,19 +407,20 @@ describe('ChatRecordingService', () => {
       ).toEqual([failedSnapshot]);
     });
 
-    it('drops pending single-snapshot updates before rewind re-records survivors', async () => {
+    it('re-records surviving snapshots after rewind on the active branch', async () => {
       chatRecordingService.recordFileHistorySnapshot(updatedSnapshot);
-      chatRecordingService.rewindRecording(
-        0,
-        { truncatedCount: 1 },
-        [oldSnapshot],
-      );
+      chatRecordingService.rewindRecording(0, { truncatedCount: 1 }, [
+        oldSnapshot,
+      ]);
       await chatRecordingService.flush();
 
-      expect(jsonl.writeLine).toHaveBeenCalledTimes(2);
-      const rewind = vi.mocked(jsonl.writeLine).mock.calls[0][1] as ChatRecord;
+      expect(jsonl.writeLine).toHaveBeenCalledTimes(3);
+      const staleSnapshot = vi.mocked(jsonl.writeLine).mock
+        .calls[0][1] as ChatRecord;
+      const rewind = vi.mocked(jsonl.writeLine).mock.calls[1][1] as ChatRecord;
       const snapshots = vi.mocked(jsonl.writeLine).mock
-        .calls[1][1] as ChatRecord;
+        .calls[2][1] as ChatRecord;
+      expect(staleSnapshot.subtype).toBe('file_history_snapshot');
       expect(rewind.subtype).toBe('rewind');
       expect(JSON.parse(JSON.stringify(snapshots.systemPayload))).toEqual({
         snapshots: [
@@ -830,6 +890,27 @@ describe('ChatRecordingService', () => {
       });
       await chatRecordingService.flush();
       expect(jsonl.writeLine).toHaveBeenCalledTimes(3);
+    });
+
+    it('refreshes the cached git branch at the attribution turn boundary', async () => {
+      vi.mocked(execSync)
+        .mockReturnValueOnce('main\n')
+        .mockReturnValueOnce('feature\n');
+
+      chatRecordingService.recordUserMessage([{ text: 'first' }]);
+      await chatRecordingService.flush();
+      chatRecordingService.recordAttributionSnapshot({
+        ...baseSnapshot,
+        promptCount: 1,
+      });
+      await chatRecordingService.flush();
+
+      const userRecord = vi.mocked(jsonl.writeLine).mock
+        .calls[0][1] as ChatRecord;
+      const attributionRecord = vi.mocked(jsonl.writeLine).mock
+        .calls[1][1] as ChatRecord;
+      expect(userRecord.gitBranch).toBe('main');
+      expect(attributionRecord.gitBranch).toBe('feature');
     });
 
     // Sessions that touch many files emit a non-retry turn snapshot

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -18,7 +18,11 @@ import {
 import * as jsonl from '../utils/jsonl-utils.js';
 import type { Part } from '@google/genai';
 import type { FileDiff } from '../tools/tools.js';
-import type { FileHistorySnapshot } from './fileHistoryService.js';
+import {
+  deserializeSnapshots,
+  serializeSnapshot,
+  type FileHistorySnapshot,
+} from './fileHistoryService.js';
 
 vi.mock('node:path');
 vi.mock('node:child_process');
@@ -220,6 +224,23 @@ describe('ChatRecordingService', () => {
         },
       },
     };
+    const failedSnapshot: FileHistorySnapshot = {
+      promptId: 'p2',
+      timestamp: new Date('2026-06-13T00:02:00.000Z'),
+      trackedFileBackups: {
+        'failed.txt': {
+          backupFileName: 'backup-failed-v1',
+          version: 1,
+          backupTime: new Date('2026-06-13T00:02:01.000Z'),
+          failed: true,
+        },
+        'deleted.txt': {
+          backupFileName: null,
+          version: 2,
+          backupTime: new Date('2026-06-13T00:02:02.000Z'),
+        },
+      },
+    };
 
     it('writes a system record with the serialized snapshot payload', async () => {
       chatRecordingService.recordFileHistorySnapshot(oldSnapshot);
@@ -283,6 +304,74 @@ describe('ChatRecordingService', () => {
                 backupFileName: null,
                 version: 1,
                 backupTime: '2026-06-13T00:01:02.000Z',
+              },
+            },
+          },
+        ],
+      });
+    });
+
+    it('coalesces single-snapshot updates by prompt id before flush', async () => {
+      chatRecordingService.recordFileHistorySnapshot(oldSnapshot);
+      chatRecordingService.recordFileHistorySnapshot(updatedSnapshot);
+      await chatRecordingService.flush();
+
+      expect(jsonl.writeLine).toHaveBeenCalledTimes(1);
+      const record = vi.mocked(jsonl.writeLine).mock.calls[0][1] as ChatRecord;
+      expect(JSON.parse(JSON.stringify(record.systemPayload))).toEqual({
+        snapshots: [
+          {
+            promptId: 'p1',
+            timestamp: '2026-06-13T00:01:00.000Z',
+            trackedFileBackups: {
+              'a.txt': {
+                backupFileName: 'backup-a-v2',
+                version: 2,
+                backupTime: '2026-06-13T00:01:01.000Z',
+              },
+              'b.txt': {
+                backupFileName: null,
+                version: 1,
+                backupTime: '2026-06-13T00:01:02.000Z',
+              },
+            },
+          },
+        ],
+      });
+    });
+
+    it('round-trips serialized snapshots through JSON and deserialization', () => {
+      expect(
+        deserializeSnapshots([
+          JSON.parse(JSON.stringify(serializeSnapshot(failedSnapshot))),
+        ]),
+      ).toEqual([failedSnapshot]);
+    });
+
+    it('drops pending single-snapshot updates before rewind re-records survivors', async () => {
+      chatRecordingService.recordFileHistorySnapshot(updatedSnapshot);
+      chatRecordingService.rewindRecording(
+        0,
+        { truncatedCount: 1 },
+        [oldSnapshot],
+      );
+      await chatRecordingService.flush();
+
+      expect(jsonl.writeLine).toHaveBeenCalledTimes(2);
+      const rewind = vi.mocked(jsonl.writeLine).mock.calls[0][1] as ChatRecord;
+      const snapshots = vi.mocked(jsonl.writeLine).mock
+        .calls[1][1] as ChatRecord;
+      expect(rewind.subtype).toBe('rewind');
+      expect(JSON.parse(JSON.stringify(snapshots.systemPayload))).toEqual({
+        snapshots: [
+          {
+            promptId: 'p1',
+            timestamp: '2026-06-13T00:00:00.000Z',
+            trackedFileBackups: {
+              'a.txt': {
+                backupFileName: 'backup-a-v1',
+                version: 1,
+                backupTime: '2026-06-13T00:00:01.000Z',
               },
             },
           },

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -536,6 +536,14 @@ export class ChatRecordingService {
    * hydrate.
    */
   private lastAttributionSnapshotJson: string | undefined;
+  private cachedGitBranch:
+    | { cwd: string; branch: string | undefined }
+    | undefined;
+  private pendingFileHistorySnapshots = new Map<
+    string,
+    SerializedFileHistorySnapshot
+  >();
+  private fileHistorySnapshotFlushScheduled = false;
 
   /**
    * Approximate bytes of JSONL content appended since the last
@@ -668,16 +676,24 @@ export class ChatRecordingService {
   private createBaseRecord(
     type: ChatRecord['type'],
   ): Omit<ChatRecord, 'message' | 'tokens' | 'model' | 'toolCallsMetadata'> {
+    const cwd = this.config.getProjectRoot();
     return {
       uuid: randomUUID(),
       parentUuid: this.lastRecordUuid,
       sessionId: this.getSessionId(),
       timestamp: new Date().toISOString(),
       type,
-      cwd: this.config.getProjectRoot(),
+      cwd,
       version: this.config.getCliVersion() || 'unknown',
-      gitBranch: getGitBranch(this.config.getProjectRoot()),
+      gitBranch: this.getCachedGitBranch(cwd),
     };
+  }
+
+  private getCachedGitBranch(cwd: string): string | undefined {
+    if (!this.cachedGitBranch || this.cachedGitBranch.cwd !== cwd) {
+      this.cachedGitBranch = { cwd, branch: getGitBranch(cwd) };
+    }
+    return this.cachedGitBranch.branch;
   }
 
   /**
@@ -821,6 +837,7 @@ export class ChatRecordingService {
    * teardown to ensure no records are dropped.
    */
   async flush(): Promise<void> {
+    this.flushPendingFileHistorySnapshots();
     await this.writeChain;
   }
 
@@ -1181,6 +1198,9 @@ export class ChatRecordingService {
       // post-rewind identical snapshot would be skipped and the rewound
       // session would lose all attribution state on restore.
       this.lastAttributionSnapshotJson = undefined;
+      // Pending single-snapshot updates belong to the branch that is about to
+      // be abandoned. Surviving file-history state is re-appended below.
+      this.pendingFileHistorySnapshots.clear();
 
       const record: ChatRecord = {
         ...this.createBaseRecord('system'),
@@ -1288,6 +1308,7 @@ export class ChatRecordingService {
         // best-effort
       }
     }
+    this.flushPendingFileHistorySnapshots();
     if (!this.currentCustomTitle) {
       return;
     }
@@ -1383,17 +1404,54 @@ export class ChatRecordingService {
   }
 
   recordFileHistorySnapshot(snapshot: FileHistorySnapshot): void {
-    this.recordFileHistorySnapshotBatch([snapshot]);
+    try {
+      this.pendingFileHistorySnapshots.set(
+        snapshot.promptId,
+        serializeSnapshot(snapshot),
+      );
+      this.scheduleFileHistorySnapshotFlush();
+    } catch (error) {
+      debugLogger.error('Error saving file history snapshot:', error);
+    }
   }
 
   recordFileHistorySnapshotBatch(snapshots: FileHistorySnapshot[]): void {
+    if (snapshots.length === 0) return;
+    try {
+      const serialized = snapshots.map(serializeSnapshot);
+      this.flushPendingFileHistorySnapshots();
+      this.appendSerializedFileHistorySnapshotBatch(serialized);
+    } catch (error) {
+      debugLogger.error('Error saving file history snapshot batch:', error);
+    }
+  }
+
+  private scheduleFileHistorySnapshotFlush(): void {
+    if (this.fileHistorySnapshotFlushScheduled) return;
+    this.fileHistorySnapshotFlushScheduled = true;
+    queueMicrotask(() => {
+      this.fileHistorySnapshotFlushScheduled = false;
+      this.flushPendingFileHistorySnapshots();
+    });
+  }
+
+  private flushPendingFileHistorySnapshots(): void {
+    if (this.pendingFileHistorySnapshots.size === 0) return;
+    const snapshots = [...this.pendingFileHistorySnapshots.values()];
+    this.pendingFileHistorySnapshots.clear();
+    this.appendSerializedFileHistorySnapshotBatch(snapshots);
+  }
+
+  private appendSerializedFileHistorySnapshotBatch(
+    snapshots: SerializedFileHistorySnapshot[],
+  ): void {
     if (snapshots.length === 0) return;
     try {
       const record: ChatRecord = {
         ...this.createBaseRecord('system'),
         type: 'system',
         subtype: 'file_history_snapshot',
-        systemPayload: { snapshots: snapshots.map(serializeSnapshot) },
+        systemPayload: { snapshots },
       };
       this.appendRecord(record);
     } catch (error) {

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -1416,7 +1416,6 @@ export class ChatRecordingService {
   private appendSerializedFileHistorySnapshotBatch(
     snapshots: SerializedFileHistorySnapshot[],
   ): void {
-    if (snapshots.length === 0) return;
     try {
       const record: ChatRecord = {
         ...this.createBaseRecord('system'),

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -539,11 +539,6 @@ export class ChatRecordingService {
   private cachedGitBranch:
     | { cwd: string; branch: string | undefined }
     | undefined;
-  private pendingFileHistorySnapshots = new Map<
-    string,
-    SerializedFileHistorySnapshot
-  >();
-  private fileHistorySnapshotFlushScheduled = false;
 
   /**
    * Approximate bytes of JSONL content appended since the last
@@ -837,7 +832,6 @@ export class ChatRecordingService {
    * teardown to ensure no records are dropped.
    */
   async flush(): Promise<void> {
-    this.flushPendingFileHistorySnapshots();
     await this.writeChain;
   }
 
@@ -1198,10 +1192,6 @@ export class ChatRecordingService {
       // post-rewind identical snapshot would be skipped and the rewound
       // session would lose all attribution state on restore.
       this.lastAttributionSnapshotJson = undefined;
-      // Pending single-snapshot updates belong to the branch that is about to
-      // be abandoned. Surviving file-history state is re-appended below.
-      this.pendingFileHistorySnapshots.clear();
-
       const record: ChatRecord = {
         ...this.createBaseRecord('system'),
         type: 'system',
@@ -1308,7 +1298,6 @@ export class ChatRecordingService {
         // best-effort
       }
     }
-    this.flushPendingFileHistorySnapshots();
     if (!this.currentCustomTitle) {
       return;
     }
@@ -1368,6 +1357,7 @@ export class ChatRecordingService {
   recordAttributionSnapshot(snapshot: AttributionSnapshot): void {
     let json: string | undefined;
     try {
+      this.cachedGitBranch = undefined;
       json = JSON.stringify(snapshot);
       if (json === this.lastAttributionSnapshotJson) {
         return;
@@ -1405,11 +1395,9 @@ export class ChatRecordingService {
 
   recordFileHistorySnapshot(snapshot: FileHistorySnapshot): void {
     try {
-      this.pendingFileHistorySnapshots.set(
-        snapshot.promptId,
+      this.appendSerializedFileHistorySnapshotBatch([
         serializeSnapshot(snapshot),
-      );
-      this.scheduleFileHistorySnapshotFlush();
+      ]);
     } catch (error) {
       debugLogger.error('Error saving file history snapshot:', error);
     }
@@ -1419,27 +1407,10 @@ export class ChatRecordingService {
     if (snapshots.length === 0) return;
     try {
       const serialized = snapshots.map(serializeSnapshot);
-      this.flushPendingFileHistorySnapshots();
       this.appendSerializedFileHistorySnapshotBatch(serialized);
     } catch (error) {
       debugLogger.error('Error saving file history snapshot batch:', error);
     }
-  }
-
-  private scheduleFileHistorySnapshotFlush(): void {
-    if (this.fileHistorySnapshotFlushScheduled) return;
-    this.fileHistorySnapshotFlushScheduled = true;
-    queueMicrotask(() => {
-      this.fileHistorySnapshotFlushScheduled = false;
-      this.flushPendingFileHistorySnapshots();
-    });
-  }
-
-  private flushPendingFileHistorySnapshots(): void {
-    if (this.pendingFileHistorySnapshots.size === 0) return;
-    const snapshots = [...this.pendingFileHistorySnapshots.values()];
-    this.pendingFileHistorySnapshots.clear();
-    this.appendSerializedFileHistorySnapshotBatch(snapshots);
   }
 
   private appendSerializedFileHistorySnapshotBatch(

--- a/packages/core/src/services/fileHistoryService.test.ts
+++ b/packages/core/src/services/fileHistoryService.test.ts
@@ -30,7 +30,10 @@ vi.mock('../utils/debugLogger.js', () => ({
   }),
 }));
 
-import { FileHistoryService } from './fileHistoryService.js';
+import {
+  FileHistoryService,
+  type FileHistorySnapshot,
+} from './fileHistoryService.js';
 
 describe('FileHistoryService', () => {
   let projectDir: string;
@@ -63,7 +66,10 @@ describe('FileHistoryService', () => {
 
   describe('trackEdit', () => {
     it('records the updated latest snapshot after tracking a file', async () => {
-      const recordSnapshot = vi.fn();
+      const recordedSnapshots: FileHistorySnapshot[] = [];
+      const recordSnapshot = vi.fn((snapshot: FileHistorySnapshot) => {
+        recordedSnapshots.push(structuredClone(snapshot));
+      });
       const recordingService = new FileHistoryService(
         'test-session',
         true,
@@ -77,7 +83,7 @@ describe('FileHistoryService', () => {
       await recordingService.trackEdit(file);
 
       expect(recordSnapshot).toHaveBeenCalledTimes(1);
-      const recorded = recordSnapshot.mock.calls[0][0];
+      const recorded = recordedSnapshots[0];
       expect(recorded.promptId).toBe('p1');
       expect(recorded.trackedFileBackups['a.txt']).toEqual(
         expect.objectContaining({
@@ -106,7 +112,10 @@ describe('FileHistoryService', () => {
     });
 
     it('records again when a second file is tracked in the same snapshot', async () => {
-      const recordSnapshot = vi.fn();
+      const recordedSnapshots: FileHistorySnapshot[] = [];
+      const recordSnapshot = vi.fn((snapshot: FileHistorySnapshot) => {
+        recordedSnapshots.push(structuredClone(snapshot));
+      });
       const recordingService = new FileHistoryService(
         'test-session',
         true,
@@ -123,7 +132,7 @@ describe('FileHistoryService', () => {
       await recordingService.trackEdit(secondFile);
 
       expect(recordSnapshot).toHaveBeenCalledTimes(2);
-      const recorded = recordSnapshot.mock.calls[1][0];
+      const recorded = recordedSnapshots[1];
       expect(recorded.trackedFileBackups['a.txt']).toEqual(
         expect.objectContaining({
           backupFileName: expect.any(String),
@@ -233,7 +242,10 @@ describe('FileHistoryService', () => {
     // the failed flag stays sticky until the file content changes,
     // permanently poisoning rewind for that file.
     it('heals a failed entry on the next trackEdit attempt', async () => {
-      const recordSnapshot = vi.fn();
+      const recordedSnapshots: FileHistorySnapshot[] = [];
+      const recordSnapshot = vi.fn((snapshot: FileHistorySnapshot) => {
+        recordedSnapshots.push(structuredClone(snapshot));
+      });
       service = new FileHistoryService(
         'test-session',
         true,
@@ -270,7 +282,7 @@ describe('FileHistoryService', () => {
       expect(p2Backup.failed).toBeFalsy();
       expect(p2Backup.backupFileName).not.toBeNull();
       expect(recordSnapshot).toHaveBeenCalledTimes(2);
-      expect(recordSnapshot.mock.calls[1][0]).toEqual(
+      expect(recordedSnapshots[1]).toEqual(
         expect.objectContaining({
           promptId: 'p2',
           trackedFileBackups: expect.objectContaining({

--- a/packages/core/src/services/fileHistoryService.test.ts
+++ b/packages/core/src/services/fileHistoryService.test.ts
@@ -111,6 +111,26 @@ describe('FileHistoryService', () => {
       expect(recordSnapshot).toHaveBeenCalledTimes(1);
     });
 
+    it('does not record when the snapshot is removed while backup is in flight', async () => {
+      const recordSnapshot = vi.fn();
+      const recordingService = new FileHistoryService(
+        'test-session',
+        true,
+        projectDir,
+        recordSnapshot,
+      );
+      const file = join(projectDir, 'a.txt');
+      await writeFile(file, 'original');
+
+      await recordingService.makeSnapshot('p1');
+      const edit = recordingService.trackEdit(file);
+      recordingService.restoreFromSnapshots([]);
+      await edit;
+
+      expect(recordSnapshot).not.toHaveBeenCalled();
+      expect(recordingService.getSnapshots()).toEqual([]);
+    });
+
     it('records again when a second file is tracked in the same snapshot', async () => {
       const recordedSnapshots: FileHistorySnapshot[] = [];
       const recordSnapshot = vi.fn((snapshot: FileHistorySnapshot) => {

--- a/packages/core/src/services/fileHistoryService.test.ts
+++ b/packages/core/src/services/fileHistoryService.test.ts
@@ -62,6 +62,109 @@ describe('FileHistoryService', () => {
   });
 
   describe('trackEdit', () => {
+    it('records the updated latest snapshot after tracking a file', async () => {
+      const recordSnapshot = vi.fn();
+      const recordingService = new FileHistoryService(
+        'test-session',
+        true,
+        projectDir,
+        recordSnapshot,
+      );
+      const file = join(projectDir, 'a.txt');
+      await writeFile(file, 'original');
+
+      await recordingService.makeSnapshot('p1');
+      await recordingService.trackEdit(file);
+
+      expect(recordSnapshot).toHaveBeenCalledTimes(1);
+      const recorded = recordSnapshot.mock.calls[0][0];
+      expect(recorded.promptId).toBe('p1');
+      expect(recorded.trackedFileBackups['a.txt']).toEqual(
+        expect.objectContaining({
+          backupFileName: expect.any(String),
+          version: 1,
+        }),
+      );
+    });
+
+    it('does not record duplicate tracking for the same file', async () => {
+      const recordSnapshot = vi.fn();
+      const recordingService = new FileHistoryService(
+        'test-session',
+        true,
+        projectDir,
+        recordSnapshot,
+      );
+      const file = join(projectDir, 'a.txt');
+      await writeFile(file, 'original');
+
+      await recordingService.makeSnapshot('p1');
+      await recordingService.trackEdit(file);
+      await recordingService.trackEdit(file);
+
+      expect(recordSnapshot).toHaveBeenCalledTimes(1);
+    });
+
+    it('records again when a second file is tracked in the same snapshot', async () => {
+      const recordSnapshot = vi.fn();
+      const recordingService = new FileHistoryService(
+        'test-session',
+        true,
+        projectDir,
+        recordSnapshot,
+      );
+      const firstFile = join(projectDir, 'a.txt');
+      const secondFile = join(projectDir, 'b.txt');
+      await writeFile(firstFile, 'a-original');
+      await writeFile(secondFile, 'b-original');
+
+      await recordingService.makeSnapshot('p1');
+      await recordingService.trackEdit(firstFile);
+      await recordingService.trackEdit(secondFile);
+
+      expect(recordSnapshot).toHaveBeenCalledTimes(2);
+      const recorded = recordSnapshot.mock.calls[1][0];
+      expect(recorded.trackedFileBackups['a.txt']).toEqual(
+        expect.objectContaining({
+          backupFileName: expect.any(String),
+          version: 1,
+        }),
+      );
+      expect(recorded.trackedFileBackups['b.txt']).toEqual(
+        expect.objectContaining({
+          backupFileName: expect.any(String),
+          version: 1,
+        }),
+      );
+    });
+
+    it('swallows recorder errors after tracking a file', async () => {
+      const recordSnapshot = vi.fn(() => {
+        throw new Error('record failed');
+      });
+      const recordingService = new FileHistoryService(
+        'test-session',
+        true,
+        projectDir,
+        recordSnapshot,
+      );
+      const file = join(projectDir, 'a.txt');
+      await writeFile(file, 'original');
+
+      await recordingService.makeSnapshot('p1');
+      await expect(recordingService.trackEdit(file)).resolves.toBeUndefined();
+
+      expect(recordSnapshot).toHaveBeenCalledTimes(1);
+      expect(
+        recordingService.getSnapshots()[0].trackedFileBackups['a.txt'],
+      ).toEqual(
+        expect.objectContaining({
+          backupFileName: expect.any(String),
+          version: 1,
+        }),
+      );
+    });
+
     it('should back up file before first edit in a snapshot', async () => {
       const file = join(projectDir, 'a.txt');
       await writeFile(file, 'original');
@@ -130,6 +233,13 @@ describe('FileHistoryService', () => {
     // the failed flag stays sticky until the file content changes,
     // permanently poisoning rewind for that file.
     it('heals a failed entry on the next trackEdit attempt', async () => {
+      const recordSnapshot = vi.fn();
+      service = new FileHistoryService(
+        'test-session',
+        true,
+        projectDir,
+        recordSnapshot,
+      );
       const file = join(projectDir, 'a.txt');
       await writeFile(file, 'p1-content');
 
@@ -159,6 +269,15 @@ describe('FileHistoryService', () => {
       expect(p2Backup).toBeDefined();
       expect(p2Backup.failed).toBeFalsy();
       expect(p2Backup.backupFileName).not.toBeNull();
+      expect(recordSnapshot).toHaveBeenCalledTimes(2);
+      expect(recordSnapshot.mock.calls[1][0]).toEqual(
+        expect.objectContaining({
+          promptId: 'p2',
+          trackedFileBackups: expect.objectContaining({
+            'a.txt': p2Backup,
+          }),
+        }),
+      );
 
       // Verify the on-disk backup at the new name actually contains the
       // current file content. Catches a regression where the heal path

--- a/packages/core/src/services/fileHistoryService.test.ts
+++ b/packages/core/src/services/fileHistoryService.test.ts
@@ -644,6 +644,69 @@ describe('FileHistoryService', () => {
       // Path outside cwd should be preserved as-is.
       expect(snapshots[0].trackedFileBackups[externalPath]).toBeDefined();
     });
+
+    it('records failed markers when restored backup files are missing', async () => {
+      const recordedSnapshots: FileHistorySnapshot[] = [];
+      const recordSnapshot = vi.fn((snapshot: FileHistorySnapshot) => {
+        recordedSnapshots.push(structuredClone(snapshot));
+      });
+      const fresh = new FileHistoryService(
+        'test-session',
+        true,
+        projectDir,
+        recordSnapshot,
+      );
+
+      fresh.restoreFromSnapshots([
+        {
+          promptId: 'p1',
+          trackedFileBackups: {
+            'a.txt': {
+              backupFileName: 'deadbeefcafebabe@v1',
+              version: 1,
+              backupTime: new Date('2026-06-13T00:00:00.000Z'),
+            },
+          },
+          timestamp: new Date('2026-06-13T00:00:01.000Z'),
+        },
+      ]);
+
+      await fresh.validateRestoredSnapshots();
+
+      const backup = fresh.getSnapshots()[0]!.trackedFileBackups['a.txt']!;
+      expect(backup.failed).toBe(true);
+      expect(recordSnapshot).toHaveBeenCalledTimes(1);
+      expect(recordedSnapshots[0]!.trackedFileBackups['a.txt']?.failed).toBe(
+        true,
+      );
+    });
+
+    it('does not restore backup files that escape the session directory', async () => {
+      const fresh = new FileHistoryService('test-session', true, projectDir);
+      const victim = join(projectDir, 'victim.txt');
+      await writeFile(victim, 'current');
+      await writeFile(join(storageDir, 'outside.txt'), 'outside');
+
+      fresh.restoreFromSnapshots([
+        {
+          promptId: 'p1',
+          trackedFileBackups: {
+            'victim.txt': {
+              backupFileName: '../../outside.txt',
+              version: 1,
+              backupTime: new Date('2026-06-13T00:00:00.000Z'),
+            },
+          },
+          timestamp: new Date('2026-06-13T00:00:01.000Z'),
+        },
+      ]);
+
+      const result = await fresh.rewind('p1');
+
+      expect(result.filesChanged).toEqual([]);
+      expect(result.filesFailed).toContain(victim);
+      expect(await readFile(victim, 'utf-8')).toBe('current');
+    });
   });
 
   describe('snapshot eviction', () => {

--- a/packages/core/src/services/fileHistoryService.ts
+++ b/packages/core/src/services/fileHistoryService.ts
@@ -681,6 +681,10 @@ export class FileHistoryService {
 
     // Re-check after async backup — concurrent calls write the same
     // deterministic path, so the second overwrites the first harmlessly.
+    if (!this.state.snapshots.includes(mostRecent)) {
+      return;
+    }
+
     // Allow overwriting a `failed` entry so the heal path actually
     // records the fresh backup (otherwise we'd leave the failed marker
     // in place even though we successfully captured the file).
@@ -695,6 +699,10 @@ export class FileHistoryService {
     }
   }
 
+  /**
+   * Creates the next turn snapshot. Callers that need session persistence must
+   * record `getSnapshots().at(-1)` after this resolves.
+   */
   async makeSnapshot(promptId: string): Promise<void> {
     if (!this.enabled) return;
 

--- a/packages/core/src/services/fileHistoryService.ts
+++ b/packages/core/src/services/fileHistoryService.ts
@@ -49,6 +49,8 @@ export interface FileHistoryState {
   trackedFiles: Set<string>;
 }
 
+type FileHistorySnapshotRecorder = (snapshot: FileHistorySnapshot) => void;
+
 export interface DiffStats {
   filesChanged: string[];
   insertions: number;
@@ -550,11 +552,18 @@ export class FileHistoryService {
   private readonly sessionId: string;
   private readonly enabled: boolean;
   private readonly cwd: string;
+  private readonly onSnapshotUpdated?: FileHistorySnapshotRecorder;
 
-  constructor(sessionId: string, enabled: boolean, cwd: string) {
+  constructor(
+    sessionId: string,
+    enabled: boolean,
+    cwd: string,
+    onSnapshotUpdated?: FileHistorySnapshotRecorder,
+  ) {
     this.sessionId = sessionId;
     this.enabled = enabled;
     this.cwd = cwd;
+    this.onSnapshotUpdated = onSnapshotUpdated;
   }
 
   isEnabled(): boolean {
@@ -563,6 +572,14 @@ export class FileHistoryService {
 
   getSnapshots(): FileHistorySnapshot[] {
     return this.state.snapshots;
+  }
+
+  private recordSnapshotUpdate(snapshot: FileHistorySnapshot): void {
+    try {
+      this.onSnapshotUpdated?.(snapshot);
+    } catch (error) {
+      debugLogger.error(`FileHistory: recordSnapshotUpdate failed: ${error}`);
+    }
   }
 
   restoreFromSnapshots(snapshots: FileHistorySnapshot[]): void {
@@ -671,9 +688,11 @@ export class FileHistoryService {
     if (!current || current.failed) {
       mostRecent.trackedFileBackups[trackingPath] = backup;
       this.state.trackedFiles.add(trackingPath);
+      this.recordSnapshotUpdate(mostRecent);
+      debugLogger.debug(
+        `FileHistory: Tracked file modification for ${filePath}`,
+      );
     }
-
-    debugLogger.debug(`FileHistory: Tracked file modification for ${filePath}`);
   }
 
   async makeSnapshot(promptId: string): Promise<void> {

--- a/packages/core/src/services/fileHistoryService.ts
+++ b/packages/core/src/services/fileHistoryService.ts
@@ -625,11 +625,16 @@ export class FileHistoryService {
       const batch = names.slice(i, i + BATCH_SIZE);
       const results = await Promise.all(
         batch.map(async (name) => {
+          let backupPath: string;
           try {
-            return await pathExists(resolveBackupPath(name, this.sessionId));
-          } catch {
+            backupPath = resolveBackupPath(name, this.sessionId);
+          } catch (e) {
+            debugLogger.error(
+              `FileHistory: rejected backupFileName during validation: ${name}: ${e}`,
+            );
             return false;
           }
+          return await pathExists(backupPath);
         }),
       );
       for (let j = 0; j < batch.length; j++) {

--- a/packages/core/src/services/fileHistoryService.ts
+++ b/packages/core/src/services/fileHistoryService.ts
@@ -15,7 +15,7 @@ import {
   stat,
   unlink,
 } from 'node:fs/promises';
-import { dirname, isAbsolute, join, relative, sep } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { diffLines, structuredPatch, type Hunk } from 'diff';
 import { Storage } from '../config/storage.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
@@ -208,12 +208,16 @@ function getBackupFileName(filePath: string, version: number): string {
 }
 
 function resolveBackupPath(backupFileName: string, sessionId: string): string {
-  return join(
+  const baseDir = resolve(
     Storage.getGlobalQwenDir(),
     FILE_HISTORY_DIR,
     sessionId,
-    backupFileName,
   );
+  const backupPath = resolve(baseDir, backupFileName);
+  if (!backupPath.startsWith(baseDir + sep)) {
+    throw new Error(`backupFileName escapes base directory: ${backupFileName}`);
+  }
+  return backupPath;
 }
 
 // Copy `src` to `dst`, creating the destination directory if it doesn't exist.
@@ -620,9 +624,13 @@ export class FileHistoryService {
     for (let i = 0; i < names.length; i += BATCH_SIZE) {
       const batch = names.slice(i, i + BATCH_SIZE);
       const results = await Promise.all(
-        batch.map((name) =>
-          pathExists(resolveBackupPath(name, this.sessionId)),
-        ),
+        batch.map(async (name) => {
+          try {
+            return await pathExists(resolveBackupPath(name, this.sessionId));
+          } catch {
+            return false;
+          }
+        }),
       );
       for (let j = 0; j < batch.length; j++) {
         if (!results[j]) missing.add(batch[j]);
@@ -633,12 +641,17 @@ export class FileHistoryService {
 
     // Single synchronous pass to mark failures — minimizes the mutation
     // window so concurrent makeSnapshot/trackEdit see a consistent state.
+    const affectedSnapshots = new Set<FileHistorySnapshot>();
     for (const snapshot of this.state.snapshots) {
       for (const backup of Object.values(snapshot.trackedFileBackups)) {
         if (backup.backupFileName && missing.has(backup.backupFileName)) {
           backup.failed = true;
+          affectedSnapshots.add(snapshot);
         }
       }
+    }
+    for (const snapshot of affectedSnapshots) {
+      this.recordSnapshotUpdate(snapshot);
     }
 
     debugLogger.warn(

--- a/packages/core/src/services/sessionService.test.ts
+++ b/packages/core/src/services/sessionService.test.ts
@@ -413,6 +413,166 @@ describe('SessionService', () => {
       expect(loaded?.lastCompletedUuid).toBe('b2');
     });
 
+    it('keeps the latest file history snapshot for a prompt id', async () => {
+      const now = Date.now();
+      statSyncSpy.mockReturnValue({
+        mtimeMs: now,
+        isFile: () => true,
+      } as fs.Stats);
+
+      const firstSnapshotRecord: ChatRecord = {
+        ...recordB1,
+        uuid: 's1',
+        parentUuid: 'b1',
+        type: 'system',
+        subtype: 'file_history_snapshot',
+        message: undefined,
+        systemPayload: {
+          snapshots: [
+            {
+              promptId: 'p1',
+              timestamp: '2026-06-13T00:00:00.000Z',
+              trackedFileBackups: {
+                'a.txt': {
+                  backupFileName: 'old-backup',
+                  version: 1,
+                  backupTime: '2026-06-13T00:00:01.000Z',
+                },
+              },
+            },
+          ],
+        },
+      };
+      const updatedSnapshotRecord: ChatRecord = {
+        ...recordB1,
+        uuid: 's2',
+        parentUuid: 's1',
+        type: 'system',
+        subtype: 'file_history_snapshot',
+        message: undefined,
+        systemPayload: {
+          snapshots: [
+            {
+              promptId: 'p1',
+              timestamp: '2026-06-13T00:01:00.000Z',
+              trackedFileBackups: {
+                'a.txt': {
+                  backupFileName: 'updated-backup',
+                  version: 2,
+                  backupTime: '2026-06-13T00:01:01.000Z',
+                },
+              },
+            },
+          ],
+        },
+      };
+      vi.mocked(jsonl.read).mockResolvedValue([
+        recordB1,
+        firstSnapshotRecord,
+        updatedSnapshotRecord,
+      ]);
+
+      const loaded = await sessionService.loadSession(sessionIdB);
+
+      expect(loaded?.fileHistorySnapshots).toEqual([
+        {
+          promptId: 'p1',
+          timestamp: new Date('2026-06-13T00:01:00.000Z'),
+          trackedFileBackups: {
+            'a.txt': {
+              backupFileName: 'updated-backup',
+              version: 2,
+              backupTime: new Date('2026-06-13T00:01:01.000Z'),
+              failed: undefined,
+            },
+          },
+        },
+      ]);
+    });
+
+    it('leaves file history snapshots undefined when none are recorded', async () => {
+      const now = Date.now();
+      statSyncSpy.mockReturnValue({
+        mtimeMs: now,
+        isFile: () => true,
+      } as fs.Stats);
+      vi.mocked(jsonl.read).mockResolvedValue([recordB1, recordB2]);
+
+      const loaded = await sessionService.loadSession(sessionIdB);
+
+      expect(loaded?.fileHistorySnapshots).toBeUndefined();
+    });
+
+    it('skips malformed file history snapshot records and keeps later valid ones', async () => {
+      const now = Date.now();
+      statSyncSpy.mockReturnValue({
+        mtimeMs: now,
+        isFile: () => true,
+      } as fs.Stats);
+
+      const malformedSnapshotRecord = {
+        ...recordB1,
+        uuid: 'bad-snapshot',
+        parentUuid: 'b1',
+        type: 'system',
+        subtype: 'file_history_snapshot',
+        message: undefined,
+        systemPayload: {
+          snapshots: [
+            {
+              promptId: 'bad',
+              timestamp: 'not-enough-fields',
+            },
+          ],
+        },
+      } as unknown as ChatRecord;
+      const validSnapshotRecord: ChatRecord = {
+        ...recordB1,
+        uuid: 'good-snapshot',
+        parentUuid: 'bad-snapshot',
+        type: 'system',
+        subtype: 'file_history_snapshot',
+        message: undefined,
+        systemPayload: {
+          snapshots: [
+            {
+              promptId: 'p1',
+              timestamp: '2026-06-13T00:00:00.000Z',
+              trackedFileBackups: {
+                'a.txt': {
+                  backupFileName: 'backup-a',
+                  version: 1,
+                  backupTime: '2026-06-13T00:00:01.000Z',
+                },
+              },
+            },
+          ],
+        },
+      };
+      vi.mocked(jsonl.read).mockResolvedValue([
+        recordB1,
+        malformedSnapshotRecord,
+        validSnapshotRecord,
+      ]);
+
+      const loaded = await sessionService.loadSession(sessionIdB);
+
+      expect(loaded?.fileHistorySnapshots).toEqual([
+        {
+          promptId: 'p1',
+          timestamp: new Date('2026-06-13T00:00:00.000Z'),
+          trackedFileBackups: {
+            'a.txt': {
+              backupFileName: 'backup-a',
+              version: 1,
+              backupTime: new Date('2026-06-13T00:00:01.000Z'),
+              failed: undefined,
+            },
+          },
+        },
+      ]);
+    });
+
     it('should return undefined when session file is empty', async () => {
       vi.mocked(jsonl.read).mockResolvedValue([]);
 

--- a/packages/core/src/services/sessionService.test.ts
+++ b/packages/core/src/services/sessionService.test.ts
@@ -490,6 +490,92 @@ describe('SessionService', () => {
       ]);
     });
 
+    it('ignores file history snapshots on a rewound inactive branch', async () => {
+      statSyncSpy.mockReturnValue({
+        mtimeMs: Date.now(),
+        isFile: () => true,
+      } as fs.Stats);
+
+      const staleSnapshotRecord: ChatRecord = {
+        ...recordB1,
+        uuid: 'stale-snapshot',
+        parentUuid: 'b1',
+        type: 'system',
+        subtype: 'file_history_snapshot',
+        message: undefined,
+        systemPayload: {
+          snapshots: [
+            {
+              promptId: 'p1',
+              timestamp: '2026-06-13T00:00:00.000Z',
+              trackedFileBackups: {
+                'a.txt': {
+                  backupFileName: 'stale-backup',
+                  version: 1,
+                  backupTime: '2026-06-13T00:00:01.000Z',
+                },
+              },
+            },
+          ],
+        },
+      };
+      const rewindRecord: ChatRecord = {
+        ...recordB1,
+        uuid: 'rewind',
+        parentUuid: 'b1',
+        type: 'system',
+        subtype: 'rewind',
+        message: undefined,
+        systemPayload: { truncatedCount: 1 },
+      };
+      const survivingSnapshotRecord: ChatRecord = {
+        ...recordB1,
+        uuid: 'surviving-snapshot',
+        parentUuid: 'rewind',
+        type: 'system',
+        subtype: 'file_history_snapshot',
+        message: undefined,
+        systemPayload: {
+          snapshots: [
+            {
+              promptId: 'p1',
+              timestamp: '2026-06-13T00:01:00.000Z',
+              trackedFileBackups: {
+                'a.txt': {
+                  backupFileName: 'surviving-backup',
+                  version: 2,
+                  backupTime: '2026-06-13T00:01:01.000Z',
+                },
+              },
+            },
+          ],
+        },
+      };
+      vi.mocked(jsonl.read).mockResolvedValue([
+        recordB1,
+        staleSnapshotRecord,
+        rewindRecord,
+        survivingSnapshotRecord,
+      ]);
+
+      const loaded = await sessionService.loadSession(sessionIdB);
+
+      expect(loaded?.fileHistorySnapshots).toEqual([
+        {
+          promptId: 'p1',
+          timestamp: new Date('2026-06-13T00:01:00.000Z'),
+          trackedFileBackups: {
+            'a.txt': {
+              backupFileName: 'surviving-backup',
+              version: 2,
+              backupTime: new Date('2026-06-13T00:01:01.000Z'),
+              failed: undefined,
+            },
+          },
+        },
+      ]);
+    });
+
     it('leaves file history snapshots undefined when none are recorded', async () => {
       const now = Date.now();
       statSyncSpy.mockReturnValue({


### PR DESCRIPTION
## What this PR does

This PR makes file-history snapshot updates durable during a turn by recording the latest snapshot immediately after a tracked edit actually adds or heals a backup. The change keeps the existing append-only `file_history_snapshot` record shape, preserves explicit turn-boundary recording, and documents why `schemaVersion` and `isSnapshotUpdate` are not needed.

## Why it's needed

A session could previously exit after an edit/write tool captured file backups but before the next `UserQuery` `makeSnapshot()`, leaving resume without the last turn's updated file-history state. Persisting the mutated latest snapshot closes that last-turn `/rewind` gap while preserving backward compatibility and last-wins reconstruction by `promptId`.

## Reviewer Test Plan

### How to verify

Run `cd packages/core && npx vitest run src/services/fileHistoryService.test.ts src/services/sessionService.test.ts src/services/chatRecordingService.test.ts src/core/client.test.ts src/config/config.test.ts` and confirm all 543 focused core tests pass. Run `cd packages/cli && npx vitest run src/acp-integration/session/Session.test.ts` and confirm all 125 ACP session tests pass. Run `npm run build && npm run typecheck` and confirm it exits 0. Reviewers should also confirm that repeated snapshot records for the same `promptId` remain append-only and resume keeps the later record, that duplicate `trackEdit` calls for an already captured non-failed file do not record again, and that recorder failures remain best-effort and do not block edit/write behavior.

### Evidence (Before & After)

Before: if the process exited after a tool edit but before another prompt created the next snapshot, resume could reconstruct only the turn-boundary snapshot and lose the edited turn's file-history state. After: the updated latest snapshot is recorded immediately after `trackEdit` mutates it, and focused tests cover snapshot update recording, JSONL serialization, resume last-wins reconstruction, client prompt flow, ACP prompt flow, and recorder error handling. Manual TUI E2E evidence is not included; an E2E plan is added for the resume plus `/rewind` scenario.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS local checkout, Node.js v22.22.3, npm 10.9.8. `npm run build && npm run typecheck` exits 0 with existing warnings from the VS Code companion curly lint rules plus Browserslist/chunk-size warnings.

## Risk & Scope

- Main risk or tradeoff: Recording updated snapshots after edit tracking adds more append-only system records in sessions with multiple tracked file edits, but it avoids rewriting logs and keeps the existing resume deduplication model.
- Not validated / out of scope: Manual TUI E2E was not executed in this pass. Generic shell edit tracking, simulated `sed -i` coverage, `getDiffStats` concurrency limiting, and per-file failure reasons remain out of scope.
- Breaking changes / migration notes: No breaking changes and no migration are required because the persisted `file_history_snapshot` payload shape is unchanged.

## Linked Issues

Refs #4204

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 让单轮内的 file-history snapshot 更新变成持久化：当被跟踪的编辑真正新增备份或修复 failed 备份后，立即记录最新 snapshot。改动保持现有追加式 `file_history_snapshot` 记录形态，保留显式的 turn-boundary 记录，并说明为什么不需要 `schemaVersion` 和 `isSnapshotUpdate`。

## 为什么需要

之前会话可能在 edit/write 工具捕获文件备份之后、下一次 `UserQuery` `makeSnapshot()` 之前退出，导致 resume 时缺少最后一轮更新后的 file-history 状态。持久化被修改过的最新 snapshot 可以补上这个 last-turn `/rewind` 缺口，同时保持向后兼容，并继续使用按 `promptId` last-wins 的恢复模型。

## Reviewer Test Plan

### How to verify

运行 `cd packages/core && npx vitest run src/services/fileHistoryService.test.ts src/services/sessionService.test.ts src/services/chatRecordingService.test.ts src/core/client.test.ts src/config/config.test.ts`，确认 543 个 core focused tests 全部通过。运行 `cd packages/cli && npx vitest run src/acp-integration/session/Session.test.ts`，确认 125 个 ACP session tests 全部通过。运行 `npm run build && npm run typecheck`，确认退出码为 0。Reviewer 还应确认同一个 `promptId` 的重复 snapshot 记录仍然是 append-only 且 resume 保留后写入记录，已捕获且非 failed 文件的重复 `trackEdit` 不会再次记录，并且 recorder 失败仍保持 best-effort，不阻塞 edit/write 行为。

### Evidence (Before & After)

Before：如果进程在工具编辑后、下一次 prompt 创建新 snapshot 前退出，resume 可能只能重建 turn-boundary snapshot，从而丢失该编辑轮的 file-history 状态。After：`trackEdit` 修改最新 snapshot 后会立即记录更新后的 snapshot，focused tests 覆盖 snapshot update recording、JSONL 序列化、resume last-wins 重建、client prompt flow、ACP prompt flow 和 recorder 错误处理。本 PR 未包含手动 TUI E2E 证据；已为 resume 加 `/rewind` 场景补充 E2E 计划。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 本地 checkout，Node.js v22.22.3，npm 10.9.8。`npm run build && npm run typecheck` 退出码为 0，同时保留既有的 VS Code companion curly lint warnings 以及 Browserslist/chunk-size warnings。

## Risk & Scope

- Main risk or tradeoff：在包含多个被跟踪文件编辑的会话中，编辑后记录更新 snapshot 会增加追加式 system records 数量，但这避免了重写日志，并保持现有 resume 去重模型。
- Not validated / out of scope：本轮未执行手动 TUI E2E。通用 shell 编辑跟踪、模拟 `sed -i` 覆盖、`getDiffStats` 并发限制和 per-file failure reasons 仍不在范围内。
- Breaking changes / migration notes：没有 breaking changes，也不需要迁移，因为持久化的 `file_history_snapshot` payload 形态保持不变。

## Linked Issues

关联 #4204。

</details>