### PR TITLE
fix(memory): avoid stale tool schema recall

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -581,6 +581,68 @@ describe('Gemini Client (client.ts)', () => {
       expect(resumedClient.getChat().getLastPromptTokenCount()).toBe(123_456);
     });
 
+    it('seeds recently completed tools from resumed history', async () => {
+      vi.mocked(mockConfig.getResumedSessionData).mockReturnValue({
+        conversation: {
+          sessionId: 'resumed-session-id',
+          projectHash: 'project-hash',
+          startTime: new Date(0).toISOString(),
+          lastUpdated: new Date(0).toISOString(),
+          messages: [
+            {
+              message: {
+                role: 'model',
+                parts: [
+                  {
+                    functionCall: {
+                      id: 'call_read',
+                      name: 'read_file',
+                      args: {},
+                    },
+                  },
+                ],
+              },
+            },
+            {
+              message: {
+                role: 'user',
+                parts: [
+                  {
+                    functionResponse: {
+                      id: 'call_read',
+                      name: 'read_file',
+                      response: { ok: true },
+                    },
+                  },
+                ],
+              },
+            },
+            {
+              message: {
+                role: 'model',
+                parts: [
+                  {
+                    functionCall: {
+                      id: 'call_pending',
+                      name: 'write_file',
+                      args: {},
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        filePath: '/test/session.jsonl',
+        lastCompletedUuid: null,
+      } as unknown as ReturnType<Config['getResumedSessionData']>);
+
+      const resumedClient = new GeminiClient(mockConfig);
+      await resumedClient.initialize();
+
+      expect(resumedClient['recentCompletedToolNames']).toEqual(['read_file']);
+    });
+
     it('uses Startup SessionStart source for non-resumed initialize without explicit source', async () => {
       const hookSystem = {
         fireSessionStartEvent: vi.fn().mockResolvedValue(
@@ -1644,6 +1706,14 @@ describe('Gemini Client (client.ts)', () => {
       await client.resetChat();
 
       expect(client['lastHookMicrocompactionTimestamp']).toBeNull();
+    });
+
+    it('clears recently completed tools', async () => {
+      client.recordCompletedToolCall('read_file');
+
+      await client.resetChat();
+
+      expect(client['recentCompletedToolNames']).toEqual([]);
     });
   });
 

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -3630,6 +3630,7 @@ hello
         getHistory: vi.fn().mockReturnValue([]),
       };
       client['chat'] = mockChat as GeminiChat;
+      client.recordCompletedToolCall('mcp__ata__article-list-query');
 
       const stream = client.sendMessageStream(
         [{ text: 'Please answer tersely' }],
@@ -3646,6 +3647,7 @@ hello
         expect.objectContaining({
           config: mockConfig,
           excludedFilePaths: expect.any(Set),
+          recentTools: ['mcp__ata__article-list-query'],
         }),
       );
       expect(mockTurnRunFn).toHaveBeenCalledWith(

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -128,6 +128,7 @@ import { type File, type IdeContext } from '../ide/types.js';
 import { PermissionMode, type StopHookOutput } from '../hooks/types.js';
 
 const MAX_TURNS = 100;
+const MAX_RECENT_TOOL_NAMES_FOR_MEMORY = 20;
 
 export enum SendMessageType {
   UserQuery = 'userQuery',
@@ -211,6 +212,7 @@ export class GeminiClient {
   private lastPromptId: string | undefined = undefined;
   private lastSentIdeContext: IdeContext | undefined;
   private forceFullIdeContext = true;
+  private recentCompletedToolNames: string[] = [];
   private pendingMemoryPrefetch: MemoryPrefetchHandle | undefined;
   private lastSessionStartContext: string | undefined;
   private lastSessionStartSource: SessionStartSource | undefined;
@@ -286,7 +288,10 @@ export class GeminiClient {
     // Check if we're resuming from a previous session
     const resumedSessionData = this.config.getResumedSessionData();
     if (resumedSessionData) {
-      replayUiTelemetryFromConversation(resumedSessionData.conversation, this.config.getSessionId());
+      replayUiTelemetryFromConversation(
+        resumedSessionData.conversation,
+        this.config.getSessionId(),
+      );
       // Convert resumed session to API history format
       // Each ChatRecord's message field is already a Content object
       const resumedHistory = buildApiHistoryFromConversation(
@@ -1494,6 +1499,16 @@ export class GeminiClient {
     toolName: string,
     args?: Record<string, unknown>,
   ): void {
+    const normalizedToolName = toolName.trim();
+    if (normalizedToolName) {
+      this.recentCompletedToolNames = [
+        ...this.recentCompletedToolNames.filter(
+          (name) => name !== normalizedToolName,
+        ),
+        normalizedToolName,
+      ].slice(-MAX_RECENT_TOOL_NAMES_FOR_MEMORY);
+    }
+
     if (args && SKILL_WRITE_TOOL_NAMES.has(toolName)) {
       const filePath = args['file_path'] ?? args['path'] ?? args['target_file'];
       if (
@@ -1692,6 +1707,7 @@ export class GeminiClient {
             .recall(this.config.getProjectRoot(), partToString(request), {
               config: this.config,
               excludedFilePaths: this.surfacedRelevantAutoMemoryPaths,
+              recentTools: [...this.recentCompletedToolNames],
               abortSignal: controller.signal,
             })
             .catch((error: unknown) => {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -297,6 +297,7 @@ export class GeminiClient {
       const resumedHistory = buildApiHistoryFromConversation(
         resumedSessionData.conversation,
       );
+      this.seedRecentCompletedToolNamesFromHistory(resumedHistory);
       await this.startChat(
         resumedHistory,
         sessionStartSource ?? SessionStartSource.Resume,
@@ -641,6 +642,7 @@ export class GeminiClient {
     this.cachedGitStatus = undefined;
     this.lastApiCompletionTimestamp = null;
     this.lastHookMicrocompactionTimestamp = null;
+    this.recentCompletedToolNames = [];
     // startChat() rewrites the chat to its initial state. Any prior
     // read_file tool results the FileReadCache still tracks are no
     // longer in history, so a follow-up Read would serve a placeholder
@@ -1499,15 +1501,7 @@ export class GeminiClient {
     toolName: string,
     args?: Record<string, unknown>,
   ): void {
-    const normalizedToolName = toolName.trim();
-    if (normalizedToolName) {
-      this.recentCompletedToolNames = [
-        ...this.recentCompletedToolNames.filter(
-          (name) => name !== normalizedToolName,
-        ),
-        normalizedToolName,
-      ].slice(-MAX_RECENT_TOOL_NAMES_FOR_MEMORY);
-    }
+    this.rememberCompletedToolName(toolName);
 
     if (args && SKILL_WRITE_TOOL_NAMES.has(toolName)) {
       const filePath = args['file_path'] ?? args['path'] ?? args['target_file'];
@@ -1519,6 +1513,45 @@ export class GeminiClient {
       }
     }
     this.toolCallCount += 1;
+  }
+
+  private rememberCompletedToolName(toolName: string): void {
+    const normalizedToolName = toolName.trim();
+    if (!normalizedToolName) {
+      return;
+    }
+    this.recentCompletedToolNames = [
+      ...this.recentCompletedToolNames.filter(
+        (name) => name !== normalizedToolName,
+      ),
+      normalizedToolName,
+    ].slice(-MAX_RECENT_TOOL_NAMES_FOR_MEMORY);
+  }
+
+  private seedRecentCompletedToolNamesFromHistory(history: Content[]): void {
+    const completedCallIds = new Set<string>();
+    for (const message of history) {
+      for (const part of message.parts ?? []) {
+        const responseId = part.functionResponse?.id;
+        if (responseId) {
+          completedCallIds.add(responseId);
+        }
+      }
+    }
+
+    this.recentCompletedToolNames = [];
+    for (const message of history) {
+      for (const part of message.parts ?? []) {
+        const call = part.functionCall;
+        if (!call?.name) {
+          continue;
+        }
+        if (call.id && !completedCallIds.has(call.id)) {
+          continue;
+        }
+        this.rememberCompletedToolName(call.name);
+      }
+    }
   }
 
   private async microcompactIdleHistory(

--- a/packages/core/src/memory/prompt.test.ts
+++ b/packages/core/src/memory/prompt.test.ts
@@ -32,6 +32,16 @@ describe('managed auto-memory prompt helpers', () => {
     expect(prompt).toContain('User prefers terse responses.');
   });
 
+  it('warns extraction not to save MCP tool schemas or failed calls', () => {
+    const prompt = buildManagedAutoMemoryPrompt('/tmp/project/.qwen/memory');
+
+    expect(prompt).toContain(
+      'MCP tool names, parameter schemas, field mappings, guessed tool-call formats, or raw failed tool-call transcripts',
+    );
+    expect(prompt).toContain('confirmed durable workaround');
+    expect(prompt).toContain('live tool definitions are authoritative');
+  });
+
   it('appends managed auto-memory after existing hierarchical memory', () => {
     const result = appendManagedAutoMemoryToUserMemory(
       '--- Context from: QWEN.md ---\nProject rules',

--- a/packages/core/src/memory/prompt.ts
+++ b/packages/core/src/memory/prompt.ts
@@ -99,6 +99,7 @@ export const WHAT_NOT_TO_SAVE_SECTION: readonly string[] = [
   '- Code patterns, conventions, architecture, file paths, or project structure — these can be derived by reading the current project state.',
   '- Git history, recent changes, or who-changed-what — `git log` / `git blame` are authoritative.',
   '- Debugging solutions or fix recipes — the fix is in the code; the commit message has the context.',
+  '- MCP tool names, parameter schemas, field mappings, guessed tool-call formats, or raw failed tool-call transcripts — live tool definitions are authoritative and may change. Save a tool-related note only when it captures a confirmed durable workaround, warning, owner, or escalation path.',
   '- Anything already documented in QWEN.md or AGENTS.md files.',
   '- Ephemeral task details: in-progress work, temporary state, current conversation context.',
   '',

--- a/packages/core/src/memory/recall.test.ts
+++ b/packages/core/src/memory/recall.test.ts
@@ -65,6 +65,40 @@ const docs: ScannedAutoMemoryDocument[] = [
   },
 ];
 
+const activeToolDocs: ScannedAutoMemoryDocument[] = [
+  {
+    type: 'reference',
+    filePath: '/tmp/ata-tool.md',
+    relativePath: 'ata-tool.md',
+    filename: 'ata-tool.md',
+    title: 'ATA tool schema notes',
+    description:
+      'article-list-query parameter schema and failed tool-call attempts',
+    body: '# ATA tool schema notes\n\n- ata::article-list-query failed with guessed field mappings.',
+    mtimeMs: 4,
+  },
+  {
+    type: 'reference',
+    filePath: '/tmp/ata-gotcha.md',
+    relativePath: 'ata-gotcha.md',
+    filename: 'ata-gotcha.md',
+    title: 'ATA tool gotcha',
+    description: 'article-list-query known workaround for transient failures',
+    body: '# ATA tool gotcha\n\n- mcp__ata__article-list-query can return systemError during index rotation; retry after checking the ATA oncall note.',
+    mtimeMs: 6,
+  },
+  {
+    type: 'reference',
+    filePath: '/tmp/ata-owner.md',
+    relativePath: 'ata-owner.md',
+    filename: 'ata-owner.md',
+    title: 'ATA escalation',
+    description: 'ATA service owner and escalation path',
+    body: '# ATA escalation\n\n- Ask the ATA oncall when the service returns systemError.',
+    mtimeMs: 5,
+  },
+];
+
 describe('auto-memory relevant recall', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -132,6 +166,33 @@ describe('auto-memory relevant recall', () => {
     );
     expect(result.selectedDocs.map((doc) => doc.filePath)).not.toContain(
       '/tmp/user.md',
+    );
+  });
+
+  it('keeps active tool schemas out of heuristic fallback', async () => {
+    vi.mocked(scanAutoMemoryTopicDocuments).mockResolvedValue(activeToolDocs);
+    vi.mocked(selectRelevantAutoMemoryDocumentsByModel).mockRejectedValue(
+      new Error('selector failed'),
+    );
+
+    const result = await resolveRelevantAutoMemoryPromptForQuery(
+      '/tmp/project',
+      'read the ATA article with article-list-query',
+      {
+        config: {} as Config,
+        recentTools: ['mcp__ata__article-list-query'],
+      },
+    );
+
+    expect(result.strategy).toBe('heuristic');
+    expect(result.selectedDocs.map((doc) => doc.filePath)).not.toContain(
+      '/tmp/ata-tool.md',
+    );
+    expect(result.selectedDocs.map((doc) => doc.filePath)).toContain(
+      '/tmp/ata-gotcha.md',
+    );
+    expect(result.selectedDocs.map((doc) => doc.filePath)).toContain(
+      '/tmp/ata-owner.md',
     );
   });
 });

--- a/packages/core/src/memory/recall.ts
+++ b/packages/core/src/memory/recall.ts
@@ -20,6 +20,41 @@ const MAX_RELEVANT_DOCS = 5;
 const MAX_DOC_BODY_CHARS = 1_200;
 const debugLogger = createDebugLogger('AUTO_MEMORY_RECALL');
 
+const ACTIVE_TOOL_USAGE_MEMORY_MARKERS = [
+  'api docs',
+  'api documentation',
+  'failed call',
+  'failed tool call',
+  'failed tool-call',
+  'field mapping',
+  'field mappings',
+  'guessed call',
+  'guessed tool',
+  'mcp tool',
+  'parameter schema',
+  'parameter schemas',
+  'tool schema',
+  'tool schemas',
+  'tool usage',
+  'usage reference',
+];
+
+const DURABLE_ACTIVE_TOOL_MEMORY_MARKERS = [
+  'credential',
+  'credentials',
+  'escalation',
+  'gotcha',
+  'gotchas',
+  'known issue',
+  'known issues',
+  'owner',
+  'ownership',
+  'warning',
+  'warnings',
+  'workaround',
+  'workarounds',
+];
+
 const TYPE_KEYWORDS: Record<string, string[]> = {
   user: ['user', 'preference', 'preferences', 'background', 'role', 'terse'],
   feedback: ['feedback', 'rule', 'rules', 'avoid', 'style', 'summary'],
@@ -45,6 +80,58 @@ function normalizeBody(body: string): string {
     return '';
   }
   return trimmed;
+}
+
+function toolAliases(toolName: string): string[] {
+  const normalized = toolName.trim().toLowerCase();
+  const aliases = [normalized];
+
+  if (normalized.includes('::')) {
+    aliases.push(normalized.split('::').at(-1) ?? '');
+  }
+
+  if (normalized.startsWith('mcp__')) {
+    const parts = normalized.split('__');
+    if (parts.length >= 3) {
+      aliases.push(parts.slice(2).join('__'));
+      aliases.push(parts.at(-1) ?? '');
+    }
+  }
+
+  return Array.from(
+    new Set(aliases.map((alias) => alias.trim()).filter(Boolean)),
+  );
+}
+
+function isActiveToolUsageMemory(
+  doc: ScannedAutoMemoryDocument,
+  recentTools: readonly string[],
+): boolean {
+  if (recentTools.length === 0) {
+    return false;
+  }
+
+  const haystack = [doc.title, doc.description, normalizeBody(doc.body)]
+    .join(' ')
+    .toLowerCase();
+  const namesActiveTool = recentTools.some((toolName) =>
+    toolAliases(toolName).some((alias) => haystack.includes(alias)),
+  );
+  if (!namesActiveTool) {
+    return false;
+  }
+
+  if (
+    DURABLE_ACTIVE_TOOL_MEMORY_MARKERS.some((marker) =>
+      haystack.includes(marker),
+    )
+  ) {
+    return false;
+  }
+
+  return ACTIVE_TOOL_USAGE_MEMORY_MARKERS.some((marker) =>
+    haystack.includes(marker),
+  );
 }
 
 function scoreDocument(
@@ -276,7 +363,14 @@ export async function resolveRelevantAutoMemoryPromptForQuery(
     };
   }
 
-  const selectedDocs = selectRelevantAutoMemoryDocuments(query, docs, limit);
+  const heuristicDocs = docs.filter(
+    (doc) => !isActiveToolUsageMemory(doc, options.recentTools ?? []),
+  );
+  const selectedDocs = selectRelevantAutoMemoryDocuments(
+    query,
+    heuristicDocs,
+    limit,
+  );
   const strategy: RelevantAutoMemoryPromptResult['strategy'] =
     selectedDocs.length > 0 ? 'heuristic' : 'none';
   if (options.config && !options.abortSignal?.aborted) {

--- a/packages/core/src/memory/relevanceSelector.test.ts
+++ b/packages/core/src/memory/relevanceSelector.test.ts
@@ -129,6 +129,31 @@ describe('selectRelevantAutoMemoryDocumentsByModel', () => {
     );
   });
 
+  it('tells the selector not to recall active tool schemas or failed calls', async () => {
+    vi.mocked(runSideQuery).mockResolvedValue({
+      selected_memories: [],
+    });
+
+    await selectRelevantAutoMemoryDocumentsByModel(
+      mockConfig,
+      'read the ATA article',
+      docs,
+      2,
+      ['mcp__ata__article-list-query'],
+    );
+
+    const options = vi.mocked(runSideQuery).mock.calls[0]![1];
+    expect(options.systemInstruction).toContain(
+      'parameter schemas, field mappings, guessed call formats, or failed-call transcripts',
+    );
+    expect(options.systemInstruction).toContain(
+      'known gotchas, warnings, or confirmed workarounds',
+    );
+    expect(JSON.stringify(options.contents)).toContain(
+      'Recently used tools: mcp__ata__article-list-query',
+    );
+  });
+
   it('lets runSideQuery choose the default side-query model when fast model is configured', async () => {
     vi.mocked(mockConfig.getFastModel).mockReturnValue('fast-flash-model');
     vi.mocked(runSideQuery).mockResolvedValue({

--- a/packages/core/src/memory/relevanceSelector.ts
+++ b/packages/core/src/memory/relevanceSelector.ts
@@ -17,7 +17,7 @@ const SELECT_MEMORIES_SYSTEM_PROMPT = `You are selecting memories that will be u
 Return a list of filenames for the memories that will clearly be useful to the assistant as it processes the user's query (up to 5). Only include memories that you are certain will be helpful based on their name and description.
 - If you are unsure if a memory will be useful in processing the user's query, then do not include it in your list. Be selective and discerning.
 - If there are no memories in the list that would clearly be useful, feel free to return an empty list.
-- If a list of recently-used tools is provided, do not select memories that are usage reference or API documentation for those tools (the assistant is already exercising them). DO still select memories containing warnings, gotchas, or known issues about those tools — active use is exactly when those matter.`;
+- If a list of recently-used tools is provided, do not select memories that are usage reference, API documentation, parameter schemas, field mappings, guessed call formats, or failed-call transcripts for those tools. Live tool definitions are the source of truth. Do still select durable operational context that cannot be obtained from the live schema, such as credentials location, ownership, external escalation paths, known gotchas, warnings, or confirmed workarounds.`;
 
 const RESPONSE_SCHEMA: Record<string, unknown> = {
   type: 'object',


### PR DESCRIPTION
## What this PR does

This makes managed auto-memory more conservative around MCP and other live tool definitions. It stops auto-memory from saving MCP tool names, parameter schemas, field mappings, guessed call formats, or failed tool-call attempts, tightens model-based recall so active tool schemas are not selected while the tool is in use, and applies the same protection to the heuristic recall fallback.

## Why it's needed

Issue #4976 describes a long tool-call loop where stale or guessed tool usage could become persistent context and influence later calls. Live tool definitions are a better source of truth than memory for names, parameter shapes, and call formats. Keeping those details out of extraction and recall reduces the chance that old failed attempts get injected near a future tool call.

## Reviewer Test Plan

### How to verify

Run the focused memory tests and checks below. The new tests cover the extraction prompt guard, model-selector prompt guidance, and heuristic fallback filtering for recently used tools.

### Evidence (Before & After)

N/A for UI. Before this change, the heuristic fallback ignored `recentTools`, so a memory document about `ata::article-list-query` parameter schemas or failed calls could still be selected when the model selector failed. After this change, those active-tool schema memories are filtered while durable operational context, such as an escalation path, can still be recalled.

### Tested on

| OS | Status |
| :-- | :-- |
| Windows | tested |
| macOS | not tested |
| Linux | not tested |

### Environment (optional)

Node.js from the local repository environment after `npm ci`.

Commands run:

```bash
npm run test --workspace=@qwen-code/qwen-code-core -- src/memory/prompt.test.ts src/memory/relevanceSelector.test.ts src/memory/recall.test.ts
npx eslint packages/core/src/memory/prompt.ts packages/core/src/memory/relevanceSelector.ts packages/core/src/memory/recall.ts packages/core/src/memory/prompt.test.ts packages/core/src/memory/relevanceSelector.test.ts packages/core/src/memory/recall.test.ts --max-warnings 0
npx prettier --check packages/core/src/memory/prompt.ts packages/core/src/memory/relevanceSelector.ts packages/core/src/memory/recall.ts packages/core/src/memory/prompt.test.ts packages/core/src/memory/relevanceSelector.test.ts packages/core/src/memory/recall.test.ts
npm run typecheck --workspace=@qwen-code/qwen-code-core
git diff --check
```

## Risk & Scope

- Main risk or tradeoff: the marker-based fallback filter intentionally ignores active-tool schema/failed-call memories, but it preserves non-schema operational memories such as ownership or escalation notes.
- Not validated / out of scope: this does not redesign MCP tool discovery or add schema-first tool loading; it only prevents memory from reinforcing stale tool-call details.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #4976

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 让 managed auto-memory 在 MCP 和其他实时工具定义相关场景下更保守：不再保存 MCP 工具名、参数 schema、字段映射、猜测出来的调用格式或失败工具调用记录；同时加强模型选择器的提示，避免在工具正在使用时召回该工具的旧 schema 记忆；并给 heuristic fallback 补上同样的过滤。

## 为什么需要

#4976 描述了一次很长的工具调用绕路。问题之一是旧的、猜测出来的工具用法可能被保存进 memory，并在后续会话中靠近工具调用上下文被注入。工具名、参数形状、调用格式应该以当前 live tool definitions 为准，而不是以旧 memory 为准。这个改动降低了错误调用被跨会话放大的概率。

## 验证

本地在 Windows 上跑了 memory 相关的 focused tests、ESLint、Prettier check、core typecheck 和 `git diff --check`。新增测试覆盖提取提示、模型选择器提示，以及模型选择器失败后 heuristic fallback 对活跃工具 schema/失败调用 memory 的过滤。

## 范围和风险

这个 PR 不重做 MCP 工具发现流程，也不实现 schema-first 工具加载；它只修 memory 侧，避免 memory 强化过时工具调用细节。fallback 过滤是有条件的：必须同时命中当前活跃工具名和 schema/参数/失败调用等标记；owner、escalation path 这类持久运维上下文仍可召回。

</details>
