### PR TITLE
fix(core): preserve background agent launch flags

### DIFF
--- a/packages/core/src/agents/agent-transcript.ts
+++ b/packages/core/src/agents/agent-transcript.ts
@@ -33,6 +33,7 @@ import type {
   AgentBootstrapRecordPayload,
   ChatRecord,
 } from '../services/chatRecordingService.js';
+import type { SandboxConfig } from '../config/config.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { _recoverObjectsFromLine } from '../utils/jsonl-utils.js';
 import type { FunctionDeclaration, Content } from '@google/genai';
@@ -108,6 +109,8 @@ export interface AgentMeta {
   lastUpdatedAt?: string;
   /** Resolved approval mode used when the agent was launched. */
   resolvedApprovalMode?: string;
+  /** Launch-time CLI/runtime flags that should survive process restart. */
+  persistedCliFlags?: AgentPersistedCliFlags;
   /** Canonical subagent config name used to recreate this agent. */
   subagentName?: string;
   /** UI hint preserved for resumed task rows. */
@@ -116,6 +119,17 @@ export interface AgentMeta {
   resumeCount?: number;
   /** Last terminal error, if any. */
   lastError?: string;
+}
+
+export interface AgentPersistedCliFlags {
+  /** Mirrors resolvedApprovalMode; kept here so the restored flag set is explicit. */
+  approvalMode?: string;
+  bare?: boolean;
+  sandbox?: SandboxConfig | null;
+  screenReader?: boolean;
+  model?: string;
+  maxSessionTurns?: number;
+  maxToolCalls?: number;
 }
 
 /**

--- a/packages/core/src/agents/background-agent-resume.test.ts
+++ b/packages/core/src/agents/background-agent-resume.test.ts
@@ -88,6 +88,12 @@ describe('BackgroundAgentResumeService', () => {
       getHookSystem: () => hookSystem,
       getStopHookBlockingCap: () => options.stopHookBlockingCap ?? 8,
       getApprovalMode: () => 'default',
+      getModel: () => 'parent-model',
+      getBareMode: () => false,
+      getSandbox: () => undefined,
+      getScreenReader: () => false,
+      getMaxSessionTurns: () => -1,
+      getMaxToolCalls: () => -1,
       isTrustedFolder: () => true,
       getProjectRoot: () => tempDir,
       getCliVersion: () => 'test-version',
@@ -841,6 +847,93 @@ describe('BackgroundAgentResumeService', () => {
     expect(createAgentHeadless).toHaveBeenCalledTimes(1);
     const [, overriddenConfig] = createAgentHeadless.mock.calls[0]!;
     expect(overriddenConfig.getApprovalMode()).toBe('default');
+  }, 20000);
+
+  it('restores persisted launch flags while resuming an agent', async () => {
+    const sessionId = 'session-cli-flags';
+    const agentId = 'agent-cli-flags';
+    const metaPath = getAgentMetaPath(tempDir, sessionId, agentId);
+    const outputFile = getAgentJsonlPath(tempDir, sessionId, agentId);
+
+    writeAgentMeta(metaPath, {
+      agentId,
+      agentType: 'researcher',
+      description: 'Resume with launch flags',
+      parentSessionId: sessionId,
+      parentAgentId: null,
+      createdAt: '2026-04-20T00:00:00.000Z',
+      status: 'running',
+      subagentName: 'researcher',
+      resolvedApprovalMode: 'auto-edit',
+      persistedCliFlags: {
+        approvalMode: 'auto-edit',
+        bare: true,
+        sandbox: { command: 'docker', image: 'qwen-code-sandbox' },
+        screenReader: true,
+        model: 'agent-model',
+        maxSessionTurns: 7,
+        maxToolCalls: 11,
+      },
+    });
+    fs.writeFileSync(
+      outputFile,
+      JSON.stringify({
+        uuid: 'u1',
+        parentUuid: null,
+        sessionId,
+        timestamp: '2026-04-20T00:00:00.000Z',
+        type: 'user',
+        message: { role: 'user', parts: [{ text: 'Resume with flags' }] },
+      }) + '\n',
+      'utf8',
+    );
+
+    registry.register({
+      agentId,
+      description: 'Resume with launch flags',
+      subagentType: 'researcher',
+      status: 'paused',
+      startTime: Date.now(),
+      abortController: new AbortController(),
+      prompt: 'Resume with launch flags',
+      outputFile,
+      metaPath,
+      isBackgrounded: true,
+    });
+
+    const createAgentHeadless = vi.fn().mockResolvedValue({
+      subagent: {
+        execute: vi.fn(async () => undefined),
+        setExternalMessageProvider: vi.fn(),
+        getCore: () => ({ getEventEmitter: () => new AgentEventEmitter() }),
+        getExecutionSummary: () => ({
+          totalTokens: 0,
+          totalDurationMs: 0,
+        }),
+        getTerminateMode: () => AgentTerminateMode.GOAL,
+        getFinalText: () => 'done',
+      },
+      dispose: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const { service, subagentManager } = createService();
+    subagentManager.createAgentHeadless = createAgentHeadless;
+
+    const resumed = await service.resumeBackgroundAgent(agentId, 'continue');
+
+    expect(resumed).toBeDefined();
+    expect(createAgentHeadless).toHaveBeenCalledTimes(1);
+    const [, overriddenConfig] = createAgentHeadless.mock.calls[0]!;
+    expect(overriddenConfig.getApprovalMode()).toBe('auto-edit');
+    expect(overriddenConfig.getBareMode()).toBe(true);
+    expect(overriddenConfig.getSandbox()).toEqual({
+      command: 'docker',
+      image: 'qwen-code-sandbox',
+    });
+    expect(overriddenConfig.getScreenReader()).toBe(true);
+    expect(overriddenConfig.getModel()).toBe('agent-model');
+    expect(overriddenConfig.getMaxSessionTurns()).toBe(7);
+    expect(overriddenConfig.getMaxToolCalls()).toBe(11);
   }, 20000);
 
   it('coalesces concurrent resume calls into a single running agent', async () => {

--- a/packages/core/src/agents/background-agent-resume.ts
+++ b/packages/core/src/agents/background-agent-resume.ts
@@ -560,7 +560,10 @@ export class BackgroundAgentResumeService {
         'default',
       );
       const resolvedApprovalMode = reconcileResumedApprovalMode(
-        normalizeApprovalMode(meta.resolvedApprovalMode, parentApprovalMode),
+        normalizeApprovalMode(
+          meta.resolvedApprovalMode ?? meta.persistedCliFlags?.approvalMode,
+          parentApprovalMode,
+        ),
         parentApprovalMode,
         this.config.isTrustedFolder(),
       );
@@ -576,6 +579,7 @@ export class BackgroundAgentResumeService {
         await createApprovalModeOverride(
           this.config,
           resolvedApprovalMode as ApprovalMode,
+          { persistedCliFlags: meta.persistedCliFlags },
         );
       // Mirror the launch path's permission-bubbling gate (agent.ts): an
       // agent whose definition uses `approvalMode: bubble` surfaces

--- a/packages/core/src/tools/agent/agent-override.test.ts
+++ b/packages/core/src/tools/agent/agent-override.test.ts
@@ -214,6 +214,42 @@ describe('createApprovalModeOverride bound-tool isolation', () => {
     expect((childNonBareWrite as any).config).toBe(childNonBare);
   });
 
+  it('applies persisted launch flags before rebuilding the child registry', async () => {
+    const parent = new Config({ ...baseParams, bareMode: false });
+    const parentRegistry = await parent.createToolRegistry(undefined, {
+      skipDiscovery: true,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (parent as any).toolRegistry = parentRegistry;
+
+    const { config: child } = await createApprovalModeOverride(
+      parent,
+      ApprovalMode.AUTO_EDIT,
+      {
+        persistedCliFlags: {
+          bare: true,
+          sandbox: null,
+          screenReader: true,
+          model: 'agent-model',
+          maxSessionTurns: 7,
+          maxToolCalls: 11,
+        },
+      },
+    );
+
+    expect(child.getBareMode()).toBe(true);
+    expect(child.getSandbox()).toBeUndefined();
+    expect(child.getScreenReader()).toBe(true);
+    expect(child.getModel()).toBe('agent-model');
+    expect(child.getMaxSessionTurns()).toBe(7);
+    expect(child.getMaxToolCalls()).toBe(11);
+
+    await child.getToolRegistry().warmAll();
+    expect(child.getToolRegistry().getAllToolNames()).not.toContain(
+      ToolNames.WRITE_FILE,
+    );
+  });
+
   describe('TOOL_REGISTRY_REBUILT marker propagation', () => {
     // Reviewer raised a concern that
     // `Object.prototype.hasOwnProperty.call(base, 'getToolRegistry')`

--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -169,6 +169,12 @@ describe('AgentTool', () => {
       getTeamManager: vi.fn().mockReturnValue(undefined),
       isAgentTeamEnabled: vi.fn().mockReturnValue(false),
       getApprovalMode: vi.fn().mockReturnValue('default'),
+      getModel: vi.fn().mockReturnValue('parent-model'),
+      getBareMode: vi.fn().mockReturnValue(false),
+      getSandbox: vi.fn().mockReturnValue(undefined),
+      getScreenReader: vi.fn().mockReturnValue(false),
+      getMaxSessionTurns: vi.fn().mockReturnValue(-1),
+      getMaxToolCalls: vi.fn().mockReturnValue(-1),
       isTrustedFolder: vi.fn().mockReturnValue(true),
       isInteractive: vi.fn().mockReturnValue(false),
       isForkSubagentEnabled: vi.fn().mockReturnValue(false),
@@ -2758,6 +2764,15 @@ describe('AgentTool', () => {
           status: 'running',
           agentType: 'file-search',
           description: 'Search files',
+          persistedCliFlags: expect.objectContaining({
+            approvalMode: 'auto-edit',
+            bare: false,
+            sandbox: null,
+            screenReader: false,
+            model: 'parent-model',
+            maxSessionTurns: -1,
+            maxToolCalls: -1,
+          }),
         }),
       );
       // Finally block patches the sidecar to the terminal status —
@@ -2895,9 +2910,8 @@ describe('AgentTool', () => {
 
       await invocation.execute();
 
-      const createCalls = vi.mocked(
-        mockSubagentManager.createAgentHeadless,
-      ).mock.calls;
+      const createCalls = vi.mocked(mockSubagentManager.createAgentHeadless)
+        .mock.calls;
       const createdConfig = createCalls[createCalls.length - 1][1] as Config;
       expect(createdConfig.getShouldAvoidPermissionPrompts()).toBe(true);
     });

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -96,6 +96,7 @@ import {
   attachJsonlTranscriptWriter,
   patchAgentMeta,
   writeAgentMeta,
+  type AgentPersistedCliFlags,
 } from '../../agents/agent-transcript.js';
 import { getGitBranch } from '../../utils/gitUtils.js';
 
@@ -379,6 +380,57 @@ export interface ApprovalModeOverrideHandle {
   cleanup: () => void;
 }
 
+export interface ApprovalModeOverrideOptions {
+  persistedCliFlags?: AgentPersistedCliFlags;
+}
+
+function hasOwn(value: object, key: PropertyKey): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function applyPersistedCliFlagOverrides(
+  override: Config,
+  flags: AgentPersistedCliFlags | undefined,
+): void {
+  if (!flags) return;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ov = override as any;
+  if (flags.bare !== undefined) {
+    ov.getBareMode = () => flags.bare;
+  }
+  if (hasOwn(flags, 'sandbox')) {
+    const sandbox = flags.sandbox ?? undefined;
+    ov.getSandbox = () => sandbox;
+  }
+  if (flags.screenReader !== undefined) {
+    ov.getScreenReader = () => flags.screenReader;
+  }
+  if (flags.model !== undefined) {
+    ov.getModel = () => flags.model;
+  }
+  if (flags.maxSessionTurns !== undefined) {
+    ov.getMaxSessionTurns = () => flags.maxSessionTurns;
+  }
+  if (flags.maxToolCalls !== undefined) {
+    ov.getMaxToolCalls = () => flags.maxToolCalls;
+  }
+}
+
+function capturePersistedCliFlags(
+  config: Config,
+  resolvedApprovalMode: ApprovalMode,
+): AgentPersistedCliFlags {
+  return {
+    approvalMode: resolvedApprovalMode,
+    bare: config.getBareMode(),
+    sandbox: config.getSandbox() ?? null,
+    screenReader: config.getScreenReader(),
+    model: config.getModel(),
+    maxSessionTurns: config.getMaxSessionTurns(),
+    maxToolCalls: config.getMaxToolCalls(),
+  };
+}
+
 /**
  * Creates a Config override with a different approval mode.
  *
@@ -411,10 +463,12 @@ export interface ApprovalModeOverrideHandle {
 export async function createApprovalModeOverride(
   base: Config,
   mode: ApprovalMode,
+  options: ApprovalModeOverrideOptions = {},
 ): Promise<ApprovalModeOverrideHandle> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const override = Object.create(base) as any;
   override.getApprovalMode = (): ApprovalMode => mode;
+  applyPersistedCliFlagOverrides(override as Config, options.persistedCliFlags);
   await rebuildToolRegistryOnOverride(override as Config, base);
 
   let cleanup: () => void = () => {};
@@ -2306,6 +2360,10 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
           status: 'running',
           lastUpdatedAt: new Date().toISOString(),
           resolvedApprovalMode,
+          persistedCliFlags: capturePersistedCliFlags(
+            this.config,
+            resolvedApprovalMode,
+          ),
           subagentName: subagentConfig.name,
           agentColor: subagentConfig.color,
           resumeCount: 0,
@@ -2854,6 +2912,10 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
           status: 'running',
           lastUpdatedAt: new Date().toISOString(),
           resolvedApprovalMode,
+          persistedCliFlags: capturePersistedCliFlags(
+            this.config,
+            resolvedApprovalMode,
+          ),
           subagentName: subagentConfig.name,
           agentColor: subagentConfig.color,
           resumeCount: 0,


### PR DESCRIPTION
## What this PR does

Preserves the launch-time background-agent runtime flags in the agent meta sidecar and reapplies them when the interrupted agent is resumed after a process restart.

The persisted allow-list covers the flags from #4884 that affect resumed execution behavior: approval mode, bare mode, sandbox, screen reader mode, model, max session turns, and max tool calls. The resume path applies these overrides before rebuilding the child tool registry, so a restored bare-mode agent gets the matching tool surface instead of only restored getter values.

## Why it's needed

Today the resume path creates the resumed agent config through prototype delegation from the current parent session. That means an agent launched with one runtime shape can resume with the flags from a later parent process. For example, a background agent originally launched with a sandbox or a specific model can silently resume without that sandbox or under the parent's new model.

This keeps old sidecars backward compatible: sidecars without the new persisted flag snapshot continue to fall back to the current behavior. Existing `resolvedApprovalMode` reconciliation, including folder-trust downgrades, is preserved.

## Reviewer Test Plan

### How to verify

Run the focused core tests around background-agent resume and agent config overrides. The new tests assert that persisted flags are written at launch, restored during resume, and applied before tool-registry rebuild.

Commands used locally:

```bash
npm ci
npm run test --workspace=packages/core -- agents/background-agent-resume.test.ts tools/agent/agent-override.test.ts tools/agent/agent.test.ts
npm run typecheck --workspace=packages/core
npx eslint packages/core/src/agents/agent-transcript.ts packages/core/src/agents/background-agent-resume.ts packages/core/src/agents/background-agent-resume.test.ts packages/core/src/tools/agent/agent.ts packages/core/src/tools/agent/agent-override.test.ts packages/core/src/tools/agent/agent.test.ts --max-warnings 0
git diff --check upstream/main..HEAD
```

### Evidence (Before & After)

N/A — this is a non-UI runtime correctness fix. The added tests cover the before/after behavior directly.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | N/A |

### Environment (optional)

Windows 11, Node/npm from the local development environment.

## Risk & Scope

- Main risk or tradeoff: this extends the meta sidecar schema. The field is optional and the resume path still supports older sidecars.
- Not validated / out of scope: end-to-end process-kill/resume through the TUI; covered here with unit-level resume tests instead.
- Breaking changes / migration notes: none expected.

## Linked Issues

Fixes #4884

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 会把 background agent 启动时的运行 flag 保存到 agent meta sidecar，并在进程重启后 resume 该 agent 时重新应用这些 flag。

持久化的 allow-list 覆盖 #4884 中会影响恢复执行行为的 flag：approval mode、bare mode、sandbox、screen reader mode、model、max session turns 和 max tool calls。resume 路径会在重建子 agent 的 tool registry 之前应用这些 override，所以恢复 bare-mode agent 时拿到的是匹配的工具集，而不只是 getter 值被恢复。

## 为什么需要

当前 resume 路径通过原型链从当前父会话派生 resumed agent config。这会导致一个用旧 flag 启动的 background agent，在之后的父进程里被恢复时悄悄继承新的父会话 flag。例如原本带 sandbox 或指定 model 启动的 agent，可能恢复成没有 sandbox 或使用父会话的新 model。

这个改动保持旧 sidecar 兼容：没有新 flag 快照的旧 sidecar 仍然走当前 fallback 行为。现有 `resolvedApprovalMode` 调和逻辑，包括 folder trust 被撤销时的降级，也保持不变。

## Reviewer Test Plan

### 如何验证

运行 background-agent resume 和 agent config override 的核心测试。新增测试会验证启动时写入持久化 flag、resume 时恢复 flag，以及在 tool registry 重建前应用 flag。

本地已运行：

```bash
npm ci
npm run test --workspace=packages/core -- agents/background-agent-resume.test.ts tools/agent/agent-override.test.ts tools/agent/agent.test.ts
npm run typecheck --workspace=packages/core
npx eslint packages/core/src/agents/agent-transcript.ts packages/core/src/agents/background-agent-resume.ts packages/core/src/agents/background-agent-resume.test.ts packages/core/src/tools/agent/agent.ts packages/core/src/tools/agent/agent-override.test.ts packages/core/src/tools/agent/agent.test.ts --max-warnings 0
git diff --check upstream/main..HEAD
```

### Evidence（Before & After）

N/A。这是非 UI 的运行时正确性修复，新增测试直接覆盖 before/after 行为。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | N/A |

### Environment（可选）

Windows 11，本地开发环境中的 Node/npm。

## 风险与范围

- 主要风险或取舍：扩展了 meta sidecar schema。新字段是 optional，resume 路径仍兼容旧 sidecar。
- 未验证 / 不在范围内：没有做完整 TUI 进程 kill/resume 的端到端测试；本 PR 用 resume 单测覆盖该路径。
- 破坏性变更 / 迁移说明：预期没有。

## 关联 Issue

Fixes #4884

</details>
