### PR TITLE
fix(core): keep token escalation warm across agent rounds

### DIFF
--- a/packages/core/src/agents/runtime/agent-core.ts
+++ b/packages/core/src/agents/runtime/agent-core.ts
@@ -654,6 +654,7 @@ export class AgentCore {
     let turnCounter = 0;
     let finalText = '';
     let terminateMode: AgentTerminateMode | null = null;
+    let stickyMaxOutputTokens: number | undefined;
 
     while (true) {
       // Check abort before starting a new round — prevents unnecessary API
@@ -689,6 +690,9 @@ export class AgentCore {
           config: {
             abortSignal: roundAbortController.signal,
             tools: [{ functionDeclarations: toolsList }],
+            ...(stickyMaxOutputTokens !== undefined
+              ? { maxOutputTokens: stickyMaxOutputTokens }
+              : {}),
           },
         };
 
@@ -728,6 +732,9 @@ export class AgentCore {
           // retry does not inherit stale data (e.g. wasOutputTruncated) from a
           // previous attempt that may have hit MAX_TOKENS.
           if (streamEvent.type === 'retry') {
+            if (streamEvent.maxOutputTokensEscalated !== undefined) {
+              stickyMaxOutputTokens = streamEvent.maxOutputTokensEscalated;
+            }
             functionCalls.length = 0;
             roundText = '';
             roundThoughtText = '';

--- a/packages/core/src/agents/runtime/agent-headless.test.ts
+++ b/packages/core/src/agents/runtime/agent-headless.test.ts
@@ -1671,6 +1671,96 @@ describe('subagent.ts', () => {
           'rejected to prevent writing truncated content',
         );
       });
+
+      it('keeps automatic max token escalation warm for the next agent round', async () => {
+        const writeFileToolDef: FunctionDeclaration = {
+          name: WriteFileTool.Name,
+          description: 'Writes a file',
+          parameters: { type: Type.OBJECT, properties: {} },
+        };
+
+        const { config } = await createMockConfig({
+          getFunctionDeclarationsFiltered: vi
+            .fn()
+            .mockReturnValue([writeFileToolDef]),
+          getTool: vi.fn().mockImplementation((name: string) => {
+            if (name === WriteFileTool.Name) {
+              return new WriteFileTool(config);
+            }
+            return undefined;
+          }),
+        });
+
+        const toolConfig: ToolConfig = { tools: [WriteFileTool.Name] };
+        let callCount = 0;
+        mockSendMessageStream.mockImplementation(async () => {
+          callCount++;
+          if (callCount === 1) {
+            return (async function* () {
+              yield {
+                type: 'retry',
+                maxOutputTokensEscalated: 65_536,
+              };
+              yield {
+                type: 'chunk',
+                value: {
+                  functionCalls: [
+                    {
+                      id: 'call_write_complete',
+                      name: WriteFileTool.Name,
+                      args: {
+                        file_path: '/tmp/sticky-escalation.txt',
+                        content: 'hello',
+                      },
+                    },
+                  ],
+                },
+              };
+              yield {
+                type: 'chunk',
+                value: {
+                  candidates: [
+                    { finishReason: 'STOP', content: { parts: [] } },
+                  ],
+                },
+              };
+            })();
+          }
+
+          return (async function* () {
+            yield {
+              type: 'chunk',
+              value: {
+                candidates: [
+                  {
+                    finishReason: 'STOP',
+                    content: { parts: [{ text: 'done' }] },
+                  },
+                ],
+              },
+            };
+          })();
+        });
+
+        const scope = await AgentHeadless.create(
+          'test-agent',
+          config,
+          promptConfig,
+          defaultModelConfig,
+          defaultRunConfig,
+          toolConfig,
+        );
+
+        await scope.execute(new ContextState());
+
+        expect(mockSendMessageStream).toHaveBeenCalledTimes(2);
+        expect(
+          mockSendMessageStream.mock.calls[0][1].config.maxOutputTokens,
+        ).toBeUndefined();
+        expect(
+          mockSendMessageStream.mock.calls[1][1].config.maxOutputTokens,
+        ).toBe(65_536);
+      });
     });
   });
 });

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -5908,6 +5908,37 @@ describe('GeminiChat', async () => {
       );
     });
 
+    it('should not re-escalate when the request already uses the escalated output limit', async () => {
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        makeStream([makeChunk([{ text: 'still partial' }], 'MAX_TOKENS')]),
+      );
+
+      const stream = await chat.sendMessageStream(
+        'gemini-3-pro',
+        {
+          message: 'continue the agent task',
+          config: { maxOutputTokens: 65_536 },
+        },
+        'prompt-sticky-escalation',
+      );
+
+      const events: StreamEvent[] = [];
+      for await (const event of stream) {
+        events.push(event);
+      }
+
+      expect(
+        events.some(
+          (event) =>
+            event.type === StreamEventType.RETRY &&
+            event.maxOutputTokensEscalated !== undefined,
+        ),
+      ).toBe(false);
+      expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
+        1,
+      );
+    });
+
     it('should coalesce overlapping recovery continuation text', async () => {
       const streams = [
         makeStream([makeChunk([{ text: 'discarded initial' }], 'MAX_TOKENS')]),

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -208,6 +208,8 @@ export type StreamEvent =
        *  fresh restart (escalation). The UI should keep the accumulated text
        *  buffer so the continuation appends to it. */
       isContinuation?: boolean;
+      /** Set when the retry raised the automatic max output token limit. */
+      maxOutputTokensEscalated?: number;
     }
   | { type: StreamEventType.COMPRESSED; info: ChatCompressionInfo };
 
@@ -2202,19 +2204,29 @@ export class GeminiChat {
         // models.
         // Placed outside the retry loop so that any errors from the
         // escalated stream propagate directly (not caught by retry logic).
+        const requestedMaxOutputTokens = params.config?.maxOutputTokens;
+        const escalatedLimit = Math.max(
+          ESCALATED_MAX_TOKENS,
+          tokenLimit(model, 'output'),
+        );
+        const shouldEscalateMaxOutputTokens =
+          requestedMaxOutputTokens === undefined ||
+          requestedMaxOutputTokens < escalatedLimit;
+
         if (
           lastError === null &&
           lastFinishReason === FinishReason.MAX_TOKENS &&
           !maxTokensEscalated &&
-          !hasUserMaxTokensOverride
+          !hasUserMaxTokensOverride &&
+          shouldEscalateMaxOutputTokens
         ) {
           maxTokensEscalated = true;
-          const escalatedLimit = Math.max(
-            ESCALATED_MAX_TOKENS,
-            tokenLimit(model, 'output'),
-          );
+          const startingLimitLabel =
+            requestedMaxOutputTokens === undefined
+              ? 'capped default'
+              : `${requestedMaxOutputTokens} tokens`;
           debugLogger.info(
-            `Output truncated at capped default. Escalating to ${escalatedLimit} tokens.`,
+            `Output truncated at ${startingLimitLabel}. Escalating to ${escalatedLimit} tokens.`,
           );
           // Remove partial model response from history
           // (processStreamResponse already pushed it)
@@ -2225,7 +2237,10 @@ export class GeminiChat {
             self.history.pop();
           }
           // Signal UI to discard partial output
-          yield { type: StreamEventType.RETRY };
+          yield {
+            type: StreamEventType.RETRY,
+            maxOutputTokensEscalated: escalatedLimit,
+          };
           // Retry with escalated max_tokens
           const escalatedParams: SendMessageParameters = {
             ...params,


### PR DESCRIPTION
## What this PR does

This PR keeps automatic output-token escalation warm across the rest of a headless agent run. When `GeminiChat` has to retry a truncated response with a larger `maxOutputTokens`, `AgentCore` now carries that escalated limit into later tool-result rounds instead of dropping back to the capped default. It also prevents `GeminiChat` from re-escalating when the current request is already using the escalated output limit.

## Why it's needed

In #4964, a headless agent could successfully retry a truncated first response, execute a tool call, and then truncate again on the next agent round because the larger output budget was not preserved. The first version of this PR preserved the budget at the agent layer, but review caught one remaining edge: `GeminiChat` still treated the per-request sticky limit as non-user config, so a later `MAX_TOKENS` finish could emit another identical escalation retry and duplicate API call. This update closes that edge without changing user-provided or environment-provided token limits.

## Reviewer Test Plan

### How to verify

Run the core tests below. The new regression checks that a request already carrying the escalated `maxOutputTokens` does not emit another `maxOutputTokensEscalated` retry and does not make a duplicate stream call. The existing agent-headless regression checks that the escalated limit is preserved into the next agent round after a tool call.

### Evidence (Before & After)

N/A. This is non-UI agent/core behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Windows 11, Node/npm from the repo workspace.

Validated locally:

```bash
npm run test --workspace=packages/core -- src/core/geminiChat.test.ts
npm run test --workspace=packages/core -- src/agents/runtime/agent-headless.test.ts
npm run typecheck --workspace=packages/core
npx prettier --check packages/core/src/core/geminiChat.ts packages/core/src/core/geminiChat.test.ts packages/core/src/agents/runtime/agent-core.ts packages/core/src/agents/runtime/agent-headless.test.ts
npx eslint packages/core/src/core/geminiChat.ts packages/core/src/core/geminiChat.test.ts packages/core/src/agents/runtime/agent-core.ts packages/core/src/agents/runtime/agent-headless.test.ts --max-warnings 0
git diff --check
```

One parallel verification attempt ran two coverage-enabled Vitest targets at the same time and hit a `coverage/.tmp/coverage-0.json` ENOENT while the tests themselves had passed. Re-running the affected target by itself passed.

## Risk & Scope

- Main risk or tradeoff: a later round that is already at the escalated limit will keep the truncated partial response instead of making an identical second API call at the same limit.
- Not validated / out of scope: full integration flow against a live provider.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #4964

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 让 headless agent run 中的自动 output-token 升级在后续轮次继续生效。`GeminiChat` 因为响应被截断而用更大的 `maxOutputTokens` 重试后，`AgentCore` 会把这个升级后的限制带到后面的工具结果轮次里，而不是回到 capped default。同时，如果当前请求已经使用升级后的 output limit，`GeminiChat` 不会再触发一次相同额度的升级重试。

## 为什么需要

在 #4964 里，headless agent 可能第一轮响应被截断，重试成功并执行工具调用；但下一轮 agent 响应又回到较小输出预算，导致再次截断。这个 PR 的第一版已经在 agent 层保留了预算，但 review 指出还有一个边界：`GeminiChat` 没有把 per-request sticky limit 视为已经升级过的限制，所以后续 `MAX_TOKENS` 仍可能发出一次相同额度的 retry，造成重复 API 调用。本次更新补上这个边界，同时不改变用户显式配置或环境变量里的 token limit。

## Reviewer Test Plan

### How to verify

运行上面的 core 测试。新增回归测试会确认：当请求已经携带升级后的 `maxOutputTokens` 时，不会再发出 `maxOutputTokensEscalated` retry，也不会重复调用 stream API。已有 agent-headless 回归测试会确认：工具调用后的下一轮 agent round 仍然复用升级后的限制。

### Evidence (Before & After)

N/A。这是非 UI 的 agent/core 行为。

### Tested on

同英文表格。

### Environment (optional)

Windows 11，本地仓库 Node/npm 环境。

## Risk & Scope

- 主要风险或取舍：如果后续轮次已经达到升级后的 limit 仍被截断，会保留当前 partial response，而不是再用相同 limit 重复调用一次 API。
- 未验证 / 不在范围：真实 provider 的完整 integration flow。
- 破坏性变更 / 迁移说明：无。

## Linked Issues

Fixes #4964

</details>
