### PR TITLE
fix(ci): detect incomplete qwen review runs

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -412,6 +412,18 @@ jobs:
             fail "Qwen review completed but produced no output."
           fi
 
+          if grep -Eq '^\[API Error:' "$LOG_PATH"; then
+            fail "Qwen review log contains a top-level API error."
+          fi
+
+          last_result="$(grep '"type":"result"' "$LOG_PATH" | tail -n 1 || true)"
+          if [ -n "$last_result" ] && printf '%s\n' "$last_result" | grep -Eq '"is_error":[[:space:]]*true'; then
+            fail "Qwen review result reported is_error=true."
+          fi
+          if [ -n "$last_result" ] && printf '%s\n' "$last_result" | grep -Eq '\[API Error:'; then
+            fail "Qwen review result contains an API error."
+          fi
+
       - name: 'Post fallback comment on failure'
         if: |-
           failure() &&


### PR DESCRIPTION
## What this PR does

This PR tightens the Qwen PR review workflow's stream-json log checks so a review run fails when the captured output contains an API error instead of reporting a green job.

It keeps the existing success path unchanged, but adds three failure signals: a raw top-level API error line, a final result event with `is_error: true`, and an API-error marker embedded in the final result text. The last case is the important one for #5052 because the headless CLI currently serializes swallowed provider failures as `subtype:"success"` with `is_error:false` while placing `[API Error: ...]` in the result payload.

## Why it's needed

#5052 shows that the automated PR review workflow can silently pass even when Qwen Code dies on a provider/API error. That leaves reviewers with no review output and no fallback comment explaining the failure.

The workflow already has a fallback path for failed review runs. This change makes the false-green API-error shapes fail the review step, so the existing fallback path can run and maintainers get an explicit failure reason.

## Reviewer Test Plan

### How to verify

Review the workflow diff and confirm the `review` step now calls `fail()` when the stream-json log contains one of the API-error shapes above. The fallback comment path should continue to read `steps.review.outputs.failure_reason` under the pre-existing `failure()` condition.

### Evidence (Before & After)

I replayed the added shell checks against real `qwen --output-format stream-json` logs produced by a local deterministic OpenAI-compatible mock provider. The old four checks stayed green for provider failures that serialized as `"subtype":"success","is_error":false,"result":"[API Error: ...]"`. The new checks fail those logs and keep clean success logs green.

Scenario summary:

| Scenario | Old checks | New checks |
| --- | --- | --- |
| Clean text completion | green | green |
| SSE connection killed every request | green false-positive | fail |
| Tool-call turn succeeds, continuation request dies | green false-positive | fail |
| One transient HTTP 429 then success | green | green |
| Persistent HTTP 500 after all retries | green false-positive | fail |

Static checks:

```console
git diff --check
python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/qwen-code-pr-review.yml').read_text())"
bash -n /tmp/extracted-review-step.sh
actionlint .github/workflows/qwen-code-pr-review.yml
```

`actionlint` still reports the pre-existing self-hosted runner label notice for `ecs-qwen`; the added review-step script is clean.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS  | tested |
| Windows | not tested |
|  Linux  | not tested |

### Environment (optional)

macOS local replay with Node v22.22.2, a local mock OpenAI-compatible provider, and the PR's review-step checks extracted into a standalone script. The workflow itself was validated statically.

## Risk & Scope

- Main risk or tradeoff: a successful review whose final result text intentionally quotes a literal `[API Error:` string could fail the review step and trigger the fallback comment. That is preferable to the current false-green failure mode and can be resolved by rerunning or manually reviewing.
- Not validated / out of scope: this does not fix the CLI behavior where provider API errors can be serialized as `subtype:"success"` with `is_error:false`. It is a workflow-side mitigation.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5052.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 收紧 Qwen PR review workflow 对 stream-json 日志的检查：当捕获到的输出里包含 API error 时，review run 应该失败，而不是显示绿色通过。

它不改变正常成功路径，只新增三类失败信号：顶层原始 API error 行、最终 result 事件里 `is_error: true`、以及最终 result 文本中嵌入的 API-error 标记。对 #5052 来说，第三种是关键，因为当前 headless CLI 会把某些 provider 失败序列化成 `subtype:"success"`、`is_error:false`，同时把 `[API Error: ...]` 放进 result payload。

## Why it's needed

#5052 说明自动 PR review workflow 在 Qwen Code 因 provider/API error 失败时可能静默通过。这样 reviewer 看不到 review 输出，也看不到 fallback comment 解释失败原因。

workflow 已经有失败后的 fallback 路径。这个改动让 false-green 的 API-error 形态触发 review step 失败，从而复用现有 fallback 路径，把明确失败原因留给维护者。

## Reviewer Test Plan

### How to verify

检查 workflow diff，确认 `review` step 在 stream-json 日志包含上述 API-error 形态时会调用 `fail()`。已有 fallback comment 路径应继续在 `failure()` 条件下读取 `steps.review.outputs.failure_reason`。

### Evidence (Before & After)

我用本地确定性的 OpenAI 兼容 mock provider 跑出真实 `qwen --output-format stream-json` 日志，再把新增 shell 检查提取出来对这些日志回放。旧的四项检查会让 provider 失败日志保持绿色，即使日志实际是 `"subtype":"success","is_error":false,"result":"[API Error: ...]"`。新检查会让这些日志失败，同时让干净成功日志保持绿色。

场景概览：

| 场景 | 旧检查 | 新检查 |
| --- | --- | --- |
| 正常文本补全 | 绿色 | 绿色 |
| 每次请求都在 SSE 中途断开 | 绿色假阳性 | 失败 |
| 工具调用轮成功，续传请求失败 | 绿色假阳性 | 失败 |
| 一次瞬时 HTTP 429 后成功 | 绿色 | 绿色 |
| 持续 HTTP 500，重试耗尽 | 绿色假阳性 | 失败 |

静态检查：

```console
git diff --check
python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/qwen-code-pr-review.yml').read_text())"
bash -n /tmp/extracted-review-step.sh
actionlint .github/workflows/qwen-code-pr-review.yml
```

`actionlint` 仍然报告已有的 `ecs-qwen` 自托管 runner label 提示；新增 review-step 脚本本身干净。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS  | tested |
| Windows | not tested |
|  Linux  | not tested |

### Environment (optional)

本地 macOS 回放，Node v22.22.2，本地 mock OpenAI 兼容 provider，并将 PR 的 review-step 检查提取成独立脚本执行。workflow 本身做了静态验证。

## Risk & Scope

- 主要风险或权衡：如果一次成功 review 的最终 result 文本故意引用字面量 `[API Error:`，review step 可能失败并触发 fallback comment。相比当前 false-green 的失败模式，这个取舍可以接受，并且可以通过 rerun 或人工 review 处理。
- 未验证 / 范围外：这个 PR 不修 CLI 将 provider API error 序列化成 `subtype:"success"`、`is_error:false` 的根因，只做 workflow 侧缓解。
- 破坏性变更 / 迁移说明：无。

## Linked Issues

Fixes #5052.

</details>
