### PR TITLE
fix(cli): ignore expired live agents in focus navigation

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -43,6 +43,8 @@ const mockViewActions = vi.hoisted(() => ({
   setBgPillFocused: vi.fn(),
   setLivePanelFocused: vi.fn(),
   setLivePanelSelectedIndex: vi.fn(),
+  setBgSelectedIndex: vi.fn(),
+  enterBgDetailFromPanel: vi.fn(),
 }));
 
 vi.mock('../hooks/useShellHistory.js');
@@ -186,6 +188,8 @@ describe('InputPrompt', () => {
     mockViewActions.setBgPillFocused.mockReset();
     mockViewActions.setLivePanelFocused.mockReset();
     mockViewActions.setLivePanelSelectedIndex.mockReset();
+    mockViewActions.setBgSelectedIndex.mockReset();
+    mockViewActions.enterBgDetailFromPanel.mockReset();
 
     mockedUseUIState.mockReturnValue({
       isFeedbackDialogOpen: false,
@@ -221,6 +225,8 @@ describe('InputPrompt', () => {
       setPillFocused: mockViewActions.setBgPillFocused,
       setLivePanelFocused: mockViewActions.setLivePanelFocused,
       setLivePanelSelectedIndex: mockViewActions.setLivePanelSelectedIndex,
+      setSelectedIndex: mockViewActions.setBgSelectedIndex,
+      enterDetailFromPanel: mockViewActions.enterBgDetailFromPanel,
     } as unknown as ReturnType<typeof useBackgroundTaskViewActions>);
 
     mockCommandContext = createMockCommandContext();
@@ -4305,7 +4311,7 @@ describe('InputPrompt', () => {
         agentApprovalModes: new Map(),
       } as unknown as ReturnType<typeof useAgentViewState>);
       mockedUseBackgroundTaskViewState.mockReturnValue({
-        entries: [{ kind: 'agent', agentId: 'bg-agent' }],
+        entries: [{ kind: 'agent', agentId: 'bg-agent', status: 'running' }],
         selectedIndex: 0,
         dialogMode: 'closed',
         dialogOpen: false,
@@ -4330,9 +4336,8 @@ describe('InputPrompt', () => {
     });
 
     it('arrow Down still falls through to the tab bar when the only bg entry is a non-agent (shell) task', async () => {
-      // bgAgentCount (not bgEntries.length) gates the panel jump: a lone shell
-      // task does not render the live panel, so Down must reach the tab bar
-      // instead of focusing a panel that would immediately auto-unfocus.
+      // The rendered live-agent roster (not bgEntries.length) gates the
+      // panel jump: a lone shell task does not render the live panel.
       (mockInputHistory.navigateDown as Mock).mockReturnValue(false);
       mockedUseAgentViewState.mockReturnValue({
         activeView: 'main',
@@ -4344,6 +4349,48 @@ describe('InputPrompt', () => {
       } as unknown as ReturnType<typeof useAgentViewState>);
       mockedUseBackgroundTaskViewState.mockReturnValue({
         entries: [{ kind: 'shell', shellId: 'bg-shell' }],
+        selectedIndex: 0,
+        dialogMode: 'closed',
+        dialogOpen: false,
+        pillFocused: false,
+        livePanelFocused: false,
+        livePanelSelectedIndex: 0,
+      } as unknown as ReturnType<typeof useBackgroundTaskViewState>);
+      mockBuffer.setText('draft');
+      mockBuffer.visualCursor = [0, 'draft'.length];
+
+      const { stdin, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+
+      stdin.write('\u001B[B'); // Down arrow
+      await wait();
+
+      expect(mockViewActions.setAgentTabBarFocused).toHaveBeenCalledWith(true);
+      expect(mockViewActions.setLivePanelFocused).not.toHaveBeenCalled();
+      unmount();
+    });
+
+    it('arrow Down skips terminal bg agents after the live panel visibility window (#5067)', async () => {
+      (mockInputHistory.navigateDown as Mock).mockReturnValue(false);
+      mockedUseAgentViewState.mockReturnValue({
+        activeView: 'main',
+        agents: new Map([['agent-1', {}]]),
+        agentShellFocused: false,
+        agentInputBufferText: '',
+        agentTabBarFocused: false,
+        agentApprovalModes: new Map(),
+      } as unknown as ReturnType<typeof useAgentViewState>);
+      mockedUseBackgroundTaskViewState.mockReturnValue({
+        entries: [
+          {
+            kind: 'agent',
+            agentId: 'done-bg-agent',
+            status: 'completed',
+            endTime: Date.now() - 9000,
+          },
+        ],
         selectedIndex: 0,
         dialogMode: 'closed',
         dialogOpen: false,
@@ -4379,7 +4426,7 @@ describe('InputPrompt', () => {
         agentApprovalModes: new Map(),
       } as unknown as ReturnType<typeof useAgentViewState>);
       mockedUseBackgroundTaskViewState.mockReturnValue({
-        entries: [{ kind: 'agent', agentId: 'bg-agent' }],
+        entries: [{ kind: 'agent', agentId: 'bg-agent', status: 'running' }],
         selectedIndex: 0,
         dialogMode: 'closed',
         dialogOpen: false,
@@ -4414,7 +4461,7 @@ describe('InputPrompt', () => {
         agentApprovalModes: new Map(),
       } as unknown as ReturnType<typeof useAgentViewState>);
       mockedUseBackgroundTaskViewState.mockReturnValue({
-        entries: [{ kind: 'agent', agentId: 'bg-agent' }],
+        entries: [{ kind: 'agent', agentId: 'bg-agent', status: 'running' }],
         selectedIndex: 0,
         dialogMode: 'closed',
         dialogOpen: false,
@@ -4433,6 +4480,80 @@ describe('InputPrompt', () => {
 
       expect(mockViewActions.setLivePanelFocused).toHaveBeenCalledWith(false);
       expect(mockViewActions.setAgentTabBarFocused).not.toHaveBeenCalled();
+      unmount();
+    });
+
+    it('Down from an expired live panel falls through to the tab bar', async () => {
+      mockedUseAgentViewState.mockReturnValue({
+        activeView: 'main',
+        agents: new Map([['agent-1', {}]]),
+        agentShellFocused: false,
+        agentInputBufferText: '',
+        agentTabBarFocused: false,
+        agentApprovalModes: new Map(),
+      } as unknown as ReturnType<typeof useAgentViewState>);
+      mockedUseBackgroundTaskViewState.mockReturnValue({
+        entries: [
+          {
+            kind: 'agent',
+            agentId: 'done-bg-agent',
+            status: 'completed',
+            endTime: Date.now() - 9000,
+          },
+        ],
+        selectedIndex: 0,
+        dialogMode: 'closed',
+        dialogOpen: false,
+        pillFocused: false,
+        livePanelFocused: true,
+        livePanelSelectedIndex: 1,
+      } as unknown as ReturnType<typeof useBackgroundTaskViewState>);
+
+      const { stdin, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+
+      stdin.write('\u001B[B'); // Down arrow
+      await wait();
+
+      expect(mockViewActions.setLivePanelFocused).toHaveBeenCalledWith(false);
+      expect(mockViewActions.setAgentTabBarFocused).toHaveBeenCalledWith(true);
+      unmount();
+    });
+
+    it('Enter on the live panel maps visible agents back to their bg entry index', async () => {
+      mockedUseBackgroundTaskViewState.mockReturnValue({
+        entries: [
+          { kind: 'shell', shellId: 'bg-shell' },
+          { kind: 'agent', agentId: 'first-live-agent', status: 'running' },
+          {
+            kind: 'agent',
+            agentId: 'expired-agent',
+            status: 'completed',
+            endTime: Date.now() - 9000,
+          },
+          { kind: 'agent', agentId: 'second-live-agent', status: 'running' },
+        ],
+        selectedIndex: 0,
+        dialogMode: 'closed',
+        dialogOpen: false,
+        pillFocused: false,
+        livePanelFocused: true,
+        livePanelSelectedIndex: 2,
+      } as unknown as ReturnType<typeof useBackgroundTaskViewState>);
+
+      const { stdin, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+
+      stdin.write('\r'); // Enter
+      await wait();
+
+      expect(mockViewActions.setBgSelectedIndex).toHaveBeenCalledWith(3);
+      expect(mockViewActions.enterBgDetailFromPanel).toHaveBeenCalled();
+      expect(mockViewActions.setLivePanelFocused).toHaveBeenCalledWith(false);
       unmount();
     });
 

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -53,6 +53,7 @@ import {
   useBackgroundTaskViewState,
   useBackgroundTaskViewActions,
 } from '../contexts/BackgroundTaskViewContext.js';
+import { isLiveAgentPanelVisibleEntry } from './background-view/liveAgentPanelVisibility.js';
 import { FEEDBACK_DIALOG_KEYS } from '../FeedbackDialog.js';
 import { BaseTextInput } from './BaseTextInput.js';
 import type { RenderLineOptions } from './BaseTextInput.js';
@@ -164,10 +165,8 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     setSelectedIndex: setBgSelectedIndex,
   } = useBackgroundTaskViewActions();
   const hasAgents = agents.size > 0;
-  // Live-panel roster: count only `kind === 'agent'` entries — exactly what the
-  // LiveAgentPanel renders, so it's the right gate for focusing the panel.
-  const bgAgentCount = useMemo(
-    () => bgEntries.filter((e) => e.kind === 'agent').length,
+  const getVisibleBgAgents = useCallback(
+    () => bgEntries.filter((e) => isLiveAgentPanelVisibleEntry(e, Date.now())),
     [bgEntries],
   );
   const hasActiveToolConfirmation = useMemo(
@@ -519,13 +518,18 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   // top→bottom order: live agent panel (if bg sub-agents) → tab bar (if
   // Arena) → stay put. Always consumes the key.
   const descendFromComposer = useCallback((): boolean => {
-    if (bgAgentCount > 0) {
+    if (getVisibleBgAgents().length > 0) {
       setLivePanelFocused(true);
     } else if (hasAgents) {
       setAgentTabBarFocused(true);
     }
     return true;
-  }, [bgAgentCount, hasAgents, setLivePanelFocused, setAgentTabBarFocused]);
+  }, [
+    getVisibleBgAgents,
+    hasAgents,
+    setLivePanelFocused,
+    setAgentTabBarFocused,
+  ]);
 
   const handleInput = useCallback(
     (key: Key): boolean => {
@@ -538,8 +542,21 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       // Enter opens dialog for selected agent, Esc/↑-at-top returns
       // focus to composer. Printable chars type through (auto-unfocus).
       if (livePanelFocused) {
+        const visibleBgAgents = getVisibleBgAgents();
+        if (visibleBgAgents.length === 0) {
+          setLivePanelFocused(false);
+          if (
+            key.sequence &&
+            key.sequence.length === 1 &&
+            !key.ctrl &&
+            !key.meta
+          ) {
+            return false;
+          }
+          return descendFromComposer();
+        }
         if (key.name === 'down' || (key.ctrl && key.name === 'n')) {
-          const maxIdx = bgAgentCount; // 0=main, 1..N=agents
+          const maxIdx = visibleBgAgents.length; // 0=main, 1..N=agents
           if (livePanelSelectedIndex < maxIdx) {
             setLivePanelSelectedIndex(livePanelSelectedIndex + 1);
           } else if (hasAgents) {
@@ -567,8 +584,14 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
             setLivePanelFocused(false);
           } else {
             const agentIdx = livePanelSelectedIndex - 1;
-            if (agentIdx < bgAgentCount) {
-              setBgSelectedIndex(agentIdx);
+            const entry = visibleBgAgents[agentIdx];
+            const entryIdx = entry
+              ? bgEntries.findIndex(
+                  (e) => e.kind === 'agent' && e.agentId === entry.agentId,
+                )
+              : -1;
+            if (entryIdx >= 0) {
+              setBgSelectedIndex(entryIdx);
               enterBgDetailFromPanel();
             }
             setLivePanelFocused(false);
@@ -1396,7 +1419,8 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       setLivePanelSelectedIndex,
       livePanelFocused,
       livePanelSelectedIndex,
-      bgAgentCount,
+      bgEntries,
+      getVisibleBgAgents,
       descendFromComposer,
       enterBgDetailFromPanel,
       setBgSelectedIndex,

--- a/packages/cli/src/ui/components/agent-view/AgentTabBar.test.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentTabBar.test.tsx
@@ -85,7 +85,7 @@ describe('AgentTabBar', () => {
       setAgentTabBarFocused,
     } as never);
     vi.mocked(useBackgroundTaskViewState).mockReturnValue({
-      entries: [{ kind: 'agent', agentId: 'bg-agent' }],
+      entries: [{ kind: 'agent', agentId: 'bg-agent', status: 'running' }],
     } as never);
     vi.mocked(useBackgroundTaskViewActions).mockReturnValue({
       setLivePanelFocused,
@@ -137,6 +137,25 @@ describe('AgentTabBar', () => {
     setActiveView('main');
     vi.mocked(useBackgroundTaskViewState).mockReturnValue({
       entries: [{ kind: 'shell', shellId: 'bg-shell' }],
+    } as never);
+    render(<AgentTabBar />);
+
+    pressKey({ name: 'up', sequence: '[A' });
+    expect(setAgentTabBarFocused).toHaveBeenCalledWith(false);
+    expect(setLivePanelFocused).not.toHaveBeenCalled();
+  });
+
+  it('Up ignores terminal bg agents after the live panel visibility window (#5067)', () => {
+    setActiveView('main');
+    vi.mocked(useBackgroundTaskViewState).mockReturnValue({
+      entries: [
+        {
+          kind: 'agent',
+          agentId: 'done-bg-agent',
+          status: 'completed',
+          endTime: Date.now() - 9000,
+        },
+      ],
     } as never);
     render(<AgentTabBar />);
 

--- a/packages/cli/src/ui/components/agent-view/AgentTabBar.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentTabBar.tsx
@@ -35,6 +35,7 @@ import {
 import { useKeypress } from '../../hooks/useKeypress.js';
 import { useUIState } from '../../contexts/UIStateContext.js';
 import { theme } from '../../semantic-colors.js';
+import { isLiveAgentPanelVisibleEntry } from '../background-view/liveAgentPanelVisibility.js';
 
 // ─── Status Indicators ──────────────────────────────────────
 
@@ -70,9 +71,8 @@ export const AgentTabBar: React.FC = () => {
   const { entries: bgEntries } = useBackgroundTaskViewState();
   const { setLivePanelFocused } = useBackgroundTaskViewActions();
   const { embeddedShellFocused } = useUIState();
-  // Gate panel focus on the panel's own render condition (`kind === 'agent'`),
-  // not `bgEntries.length` (which also counts shell/monitor/dream tasks).
-  const hasBgAgentRoster = bgEntries.some((e) => e.kind === 'agent');
+  const hasVisibleBgAgentRoster = () =>
+    bgEntries.some((e) => isLiveAgentPanelVisibleEntry(e, Date.now()));
 
   useKeypress(
     (key) => {
@@ -88,7 +88,7 @@ export const AgentTabBar: React.FC = () => {
         // On Main, ascend to the live agent panel above the tab bar. On agent
         // tabs the panel isn't rendered, so ↑ just returns to the composer
         // (keeping AgentComposer's ↓/↑ round-trip symmetric).
-        if (activeView === 'main' && hasBgAgentRoster) {
+        if (activeView === 'main' && hasVisibleBgAgentRoster()) {
           setLivePanelFocused(true);
         }
       } else if (key.name === 'down' || (key.ctrl && key.name === 'n')) {

--- a/packages/cli/src/ui/components/background-view/LiveAgentPanel.test.tsx
+++ b/packages/cli/src/ui/components/background-view/LiveAgentPanel.test.tsx
@@ -9,7 +9,11 @@ import { act } from '@testing-library/react';
 import { render } from 'ink-testing-library';
 import type { Config } from '@qwen-code/qwen-code-core';
 import { LiveAgentPanel } from './LiveAgentPanel.js';
-import { BackgroundTaskViewStateContext } from '../../contexts/BackgroundTaskViewContext.js';
+import {
+  BackgroundTaskViewActionsContext,
+  BackgroundTaskViewStateContext,
+  type BackgroundTaskViewActions,
+} from '../../contexts/BackgroundTaskViewContext.js';
 import { ConfigContext } from '../../contexts/ConfigContext.js';
 import type {
   AgentDialogEntry,
@@ -56,6 +60,8 @@ function renderPanel(
      * about the snapshot path (panel falls back gracefully).
      */
     config?: Config;
+    livePanelFocused?: boolean;
+    actions?: Partial<BackgroundTaskViewActions>;
   } = { entries: [] },
 ) {
   const state = {
@@ -64,9 +70,25 @@ function renderPanel(
     dialogMode: options.dialogOpen ? ('list' as const) : ('closed' as const),
     dialogOpen: Boolean(options.dialogOpen),
     pillFocused: false,
-    livePanelFocused: false,
+    livePanelFocused: Boolean(options.livePanelFocused),
     livePanelSelectedIndex: 0,
   };
+  const actions = {
+    moveSelectionUp: () => false,
+    moveSelectionDown: () => false,
+    openDialog: vi.fn(),
+    closeDialog: vi.fn(),
+    enterDetail: vi.fn(),
+    exitDetail: vi.fn(),
+    cancelSelected: vi.fn(),
+    resumeSelected: async () => {},
+    enterDetailFromPanel: vi.fn(),
+    setPillFocused: vi.fn(),
+    setLivePanelFocused: vi.fn(),
+    setLivePanelSelectedIndex: vi.fn(),
+    setSelectedIndex: vi.fn(),
+    ...options.actions,
+  } as BackgroundTaskViewActions;
   // Wrap render() in act() so the panel's mount-time effect (the
   // 1s wall-clock interval) is flushed inside React's scheduler boundary
   // — silences the "update inside a test was not wrapped in act"
@@ -75,9 +97,11 @@ function renderPanel(
   act(() => {
     result = render(
       <ConfigContext.Provider value={options.config}>
-        <BackgroundTaskViewStateContext.Provider value={state}>
-          <LiveAgentPanel width={options.width} maxRows={options.maxRows} />
-        </BackgroundTaskViewStateContext.Provider>
+        <BackgroundTaskViewActionsContext.Provider value={actions}>
+          <BackgroundTaskViewStateContext.Provider value={state}>
+            <LiveAgentPanel width={options.width} maxRows={options.maxRows} />
+          </BackgroundTaskViewStateContext.Provider>
+        </BackgroundTaskViewActionsContext.Provider>
       </ConfigContext.Provider>,
     );
   });
@@ -586,6 +610,26 @@ describe('<LiveAgentPanel />', () => {
     });
     frame = lastFrame() ?? '';
     expect(frame).toBe('');
+  });
+
+  it('releases focus when the selected terminal row has aged out (#5067)', () => {
+    const setLivePanelFocused = vi.fn();
+    const expired = agentEntry({
+      agentId: 'expired-focus-1',
+      subagentType: 'researcher',
+      description: 'researcher: already gone',
+      status: 'completed',
+      startTime: -10_000,
+      endTime: -9_000,
+    });
+
+    renderPanel({
+      entries: [expired],
+      livePanelFocused: true,
+      actions: { setLivePanelFocused },
+    });
+
+    expect(setLivePanelFocused).toHaveBeenCalledWith(false);
   });
 
   it('drops rows where the snapshot is terminal AND has no endTime', () => {

--- a/packages/cli/src/ui/components/background-view/LiveAgentPanel.tsx
+++ b/packages/cli/src/ui/components/background-view/LiveAgentPanel.tsx
@@ -34,7 +34,10 @@ import {
   ToolDisplayNames,
   ToolNames,
 } from '@qwen-code/qwen-code-core';
-import { useBackgroundTaskViewState } from '../../contexts/BackgroundTaskViewContext.js';
+import {
+  useBackgroundTaskViewActions,
+  useBackgroundTaskViewState,
+} from '../../contexts/BackgroundTaskViewContext.js';
 import { ConfigContext } from '../../contexts/ConfigContext.js';
 import { theme } from '../../semantic-colors.js';
 import { formatDuration, formatTokenCount } from '../../utils/formatters.js';
@@ -43,6 +46,7 @@ import type {
   AgentDialogEntry,
   DialogEntry,
 } from '../../hooks/useBackgroundTaskView.js';
+import { isLiveAgentPanelVisibleEntry } from './liveAgentPanelVisibility.js';
 
 interface LiveAgentPanelProps {
   /**
@@ -60,13 +64,6 @@ interface LiveAgentPanelProps {
 }
 
 const DEFAULT_MAX_ROWS = 12;
-// Keep terminal entries on the panel briefly so the user gets visual
-// feedback ("✓ done · 12s") when a subagent finishes, then they fall off
-// and the user goes to BackgroundTasksDialog for a deeper look. Mirrors
-// Claude Code's `RECENT_COMPLETED_TTL_MS = 30_000` knob, scaled down
-// because the panel is denser and we have the dialog as the long-term
-// review surface.
-const TERMINAL_VISIBLE_MS = 8000;
 // Re-export under a panel-local alias so the source of truth stays
 // in `subagents/builtin-agents.ts` (a backend rename of the default
 // type would otherwise silently re-introduce the redundant
@@ -181,6 +178,7 @@ export const LiveAgentPanel: React.FC<LiveAgentPanelProps> = ({
 }) => {
   const { entries, dialogOpen, livePanelFocused, livePanelSelectedIndex } =
     useBackgroundTaskViewState();
+  const { setLivePanelFocused } = useBackgroundTaskViewActions();
   // Reach for Config via the raw context (NOT useConfig) so the panel
   // can degrade to snapshot-only when no provider is mounted — e.g.
   // unit tests that render the component in isolation. useConfig
@@ -206,12 +204,7 @@ export const LiveAgentPanel: React.FC<LiveAgentPanelProps> = ({
   useEffect(() => {
     if (dialogOpen) return;
     const needsTick = (whenMs: number) =>
-      entries.some((e) => {
-        if (!isAgentEntry(e)) return false;
-        if (e.status === 'running' || e.status === 'paused') return true;
-        if (e.endTime === undefined) return false;
-        return whenMs - e.endTime <= TERMINAL_VISIBLE_MS;
-      });
+      entries.some((e) => isLiveAgentPanelVisibleEntry(e, whenMs));
     if (!needsTick(Date.now())) return;
     const id = setInterval(() => {
       const wallNow = Date.now();
@@ -351,6 +344,16 @@ export const LiveAgentPanel: React.FC<LiveAgentPanelProps> = ({
     return next;
   }, [entries, config, now]);
 
+  const hasVisibleAgent = liveAgentSnapshots.some((entry) =>
+    isLiveAgentPanelVisibleEntry(entry, now),
+  );
+
+  useEffect(() => {
+    if (livePanelFocused && !hasVisibleAgent) {
+      setLivePanelFocused(false);
+    }
+  }, [hasVisibleAgent, livePanelFocused, setLivePanelFocused]);
+
   // Defense in depth: don't compete with the dialog. Under
   // DefaultAppLayout this branch is unreachable because the layout
   // already gates the panel on `!uiState.dialogsVisible` (which folds
@@ -387,11 +390,7 @@ const LiveAgentPanelBody: React.FC<{
   const visibleAgents: LivePanelEntry[] = snapshots
     .map((entry) => ({
       ...entry,
-      expired:
-        entry.status !== 'running' &&
-        entry.status !== 'paused' &&
-        entry.endTime !== undefined &&
-        now - entry.endTime > TERMINAL_VISIBLE_MS,
+      expired: !isLiveAgentPanelVisibleEntry(entry, now),
     }))
     .filter((entry) => !entry.expired);
 

--- a/packages/cli/src/ui/components/background-view/liveAgentPanelVisibility.ts
+++ b/packages/cli/src/ui/components/background-view/liveAgentPanelVisibility.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  AgentDialogEntry,
+  DialogEntry,
+} from '../../hooks/useBackgroundTaskView.js';
+
+// Keep this shared with keyboard focus gates: anything counted here
+// must be something the live panel can actually render.
+export const TERMINAL_VISIBLE_MS = 8000;
+
+export function isLiveAgentPanelVisibleEntry(
+  entry: DialogEntry,
+  nowMs: number,
+): entry is AgentDialogEntry {
+  if (entry.kind !== 'agent') return false;
+  if (entry.status === 'running' || entry.status === 'paused') return true;
+  if (entry.endTime === undefined) return false;
+  return nowMs - entry.endTime <= TERMINAL_VISIBLE_MS;
+}


### PR DESCRIPTION
Fixes #5067.

## Summary
- Share the live-agent panel visibility predicate between rendering and keyboard focus gates.
- Stop composer and tab-bar navigation from focusing terminal agents after the panel visibility window.
- Release stale live-panel focus once the rendered agent roster ages out.

## To verify
- npm test --workspace @qwen-code/qwen-code -- src/ui/components/InputPrompt.test.tsx src/ui/components/agent-view/AgentTabBar.test.tsx src/ui/components/background-view/LiveAgentPanel.test.tsx
- npm run lint --workspace @qwen-code/qwen-code -- --max-warnings 0
- npm run typecheck --workspace @qwen-code/qwen-code
