### PR TITLE
fix(cli): submit fast tool results after stream end

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -1323,9 +1323,9 @@ describe('useGeminiStream', () => {
     expect(client.recordCompletedToolCall).not.toHaveBeenCalled();
   });
 
-  it('runs Race A dedup BEFORE the isResponding early-return (regression guard)', async () => {
+  it('runs Race A dedup BEFORE the active-stream early-return (regression guard)', async () => {
     // The dedup block in handleCompletedTools is intentionally placed
-    // ABOVE the `if (isResponding) return;` early-return: the scheduler's
+    // ABOVE the active-stream early-return: the scheduler's
     // `onAllToolCallsComplete` is single-shot per batch, so if the dedup
     // sat below the guard a tool whose result was already paired in
     // history would be left in `completed-but-not-submitted` forever
@@ -1472,8 +1472,8 @@ describe('useGeminiStream', () => {
     });
 
     // The dedup MUST still fire — markToolsAsSubmitted called with the
-    // deduped callId — even though the early-return on isResponding
-    // would otherwise skip every later branch.
+    // deduped callId — even though the active-stream guard would
+    // otherwise skip every later branch.
     await waitFor(() => {
       expect(mockMarkToolsAsSubmitted).toHaveBeenCalledWith([
         'call_race_A_responding',
@@ -1486,6 +1486,238 @@ describe('useGeminiStream', () => {
 
     // Release the held stream so the test exits cleanly.
     releaseStream();
+  });
+
+  it('submits a fast tool result after the stream ended but before React replaces the callback', async () => {
+    const responseParts: Part[] = [
+      {
+        functionResponse: {
+          id: 'call_fast_after_stream',
+          name: 'read_file',
+          response: { error: 'ENOENT: missing file' },
+        },
+      },
+    ];
+    const fastFailedTool = {
+      request: {
+        callId: 'call_fast_after_stream',
+        name: 'read_file',
+        args: { path: '/tmp/missing.txt' },
+        isClientInitiated: false,
+        prompt_id: 'prompt-fast-after-stream',
+      },
+      status: 'error',
+      responseSubmittedToGemini: false,
+      response: {
+        callId: 'call_fast_after_stream',
+        responseParts,
+        resultDisplay: undefined,
+        error: new Error('ENOENT: missing file'),
+        errorType: ToolErrorType.UNHANDLED_EXCEPTION,
+      },
+      tool: {
+        name: 'read_file',
+        displayName: 'ReadFile',
+        description: 'Read a file',
+        build: vi.fn(),
+      } as any,
+      invocation: {
+        getDescription: () => 'read /tmp/missing.txt',
+      } as unknown as AnyToolInvocation,
+    } as unknown as TrackedCompletedToolCall;
+
+    const client = new MockedGeminiClientClass(mockConfig);
+    let capturedOnComplete:
+      | ((completedTools: TrackedToolCall[]) => Promise<void>)
+      | null = null;
+    mockUseReactToolScheduler.mockImplementation((onComplete) => {
+      capturedOnComplete = onComplete;
+      return [[], mockScheduleToolCalls, mockMarkToolsAsSubmitted];
+    });
+
+    let releaseStream!: () => void;
+    const holdStream = new Promise<void>((resolve) => {
+      releaseStream = resolve;
+    });
+    // eslint-disable-next-line require-yield
+    const heldStream = (async function* () {
+      await holdStream;
+    })();
+    mockSendMessageStream.mockReturnValue(heldStream);
+
+    const { result } = renderHook(() =>
+      useGeminiStream(
+        client,
+        [],
+        mockAddItem,
+        mockConfig,
+        mockLoadedSettings,
+        mockOnDebugMessage,
+        mockHandleSlashCommand,
+        false,
+        () => 'vscode' as EditorType,
+        () => {},
+        () => Promise.resolve(),
+        false,
+        () => {},
+        () => {},
+        () => {},
+        () => {},
+        80,
+        24,
+      ),
+    );
+
+    let submitPromise: Promise<unknown> | undefined;
+    act(() => {
+      submitPromise = result.current.submitQuery('edit the missing file');
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Save the callback from the render where React state still says
+    // "responding". The scheduler can call this stale closure if a tool
+    // finishes immediately after the stream returns.
+    const staleOnComplete = capturedOnComplete;
+    expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
+
+    releaseStream();
+    await act(async () => {
+      await submitPromise;
+    });
+
+    const staleCompletedOnComplete = staleOnComplete as
+      | ((completedTools: TrackedCompletedToolCall[]) => Promise<void>)
+      | null;
+    await act(async () => {
+      await staleCompletedOnComplete?.([fastFailedTool]);
+    });
+
+    await waitFor(() => {
+      expect(mockSendMessageStream).toHaveBeenCalledTimes(2);
+    });
+    expect(mockSendMessageStream).toHaveBeenNthCalledWith(
+      2,
+      responseParts,
+      expect.any(AbortSignal),
+      'prompt-fast-after-stream',
+      expect.objectContaining({ type: SendMessageType.ToolResult }),
+    );
+    expect(mockMarkToolsAsSubmitted).toHaveBeenCalledWith([
+      'call_fast_after_stream',
+    ]);
+  });
+
+  it('drops a fast tool result after cancellation even if the stale callback runs later', async () => {
+    const responseParts: Part[] = [
+      {
+        functionResponse: {
+          id: 'call_fast_after_cancel',
+          name: 'read_file',
+          response: { output: 'secret file contents' },
+        },
+      },
+    ];
+    const fastToolAfterCancel = {
+      request: {
+        callId: 'call_fast_after_cancel',
+        name: 'read_file',
+        args: { path: '/tmp/secret.txt' },
+        isClientInitiated: false,
+        prompt_id: 'prompt-fast-after-cancel',
+      },
+      status: 'success',
+      responseSubmittedToGemini: false,
+      response: {
+        callId: 'call_fast_after_cancel',
+        responseParts,
+        resultDisplay: undefined,
+        error: undefined,
+        errorType: undefined,
+      },
+      tool: {
+        name: 'read_file',
+        displayName: 'ReadFile',
+        description: 'Read a file',
+        build: vi.fn(),
+      } as any,
+      invocation: {
+        getDescription: () => 'read /tmp/secret.txt',
+      } as unknown as AnyToolInvocation,
+    } as unknown as TrackedCompletedToolCall;
+
+    const client = new MockedGeminiClientClass(mockConfig);
+    let capturedOnComplete:
+      | ((completedTools: TrackedCompletedToolCall[]) => Promise<void>)
+      | null = null;
+    mockUseReactToolScheduler.mockImplementation((onComplete) => {
+      capturedOnComplete = onComplete;
+      return [[], mockScheduleToolCalls, mockMarkToolsAsSubmitted];
+    });
+
+    let releaseStream!: () => void;
+    const holdStream = new Promise<void>((resolve) => {
+      releaseStream = resolve;
+    });
+    // eslint-disable-next-line require-yield
+    const heldStream = (async function* () {
+      await holdStream;
+    })();
+    mockSendMessageStream.mockReturnValue(heldStream);
+
+    const { result } = renderHook(() =>
+      useGeminiStream(
+        client,
+        [],
+        mockAddItem,
+        mockConfig,
+        mockLoadedSettings,
+        mockOnDebugMessage,
+        mockHandleSlashCommand,
+        false,
+        () => 'vscode' as EditorType,
+        () => {},
+        () => Promise.resolve(),
+        false,
+        () => {},
+        () => {},
+        () => {},
+        () => {},
+        80,
+        24,
+      ),
+    );
+
+    let submitPromise: Promise<unknown> | undefined;
+    act(() => {
+      submitPromise = result.current.submitQuery('read the file');
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const staleOnComplete = capturedOnComplete;
+    expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.cancelOngoingRequest();
+    });
+    releaseStream();
+    await act(async () => {
+      await submitPromise;
+    });
+
+    await act(async () => {
+      await staleOnComplete?.([fastToolAfterCancel]);
+    });
+
+    expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
+    expect(mockMarkToolsAsSubmitted).toHaveBeenCalledWith([
+      'call_fast_after_cancel',
+    ]);
   });
 
   it('handles a mixed batch (one deduped + one non-deduped) without double-counting telemetry', async () => {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -347,6 +347,8 @@ export const useGeminiStream = (
   const lastPromptErroredRef = useRef(false);
   const dualOutput = useDualOutput();
   const [isResponding, setIsResponding] = useState<boolean>(false);
+  // React state can lag by one render; this tracks the actual stream lifetime.
+  const activeModelStreamsRef = useRef(0);
   const [thought, setThought] = useState<ThoughtSummary | null>(null);
   // Hold the latest history in a ref so handleCompletedTools can read it
   // without depending on `history` (which would recreate the tool scheduler
@@ -1855,6 +1857,7 @@ export const useGeminiStream = (
           logUserRetry(config, new UserRetryEvent(prompt_id));
         }
 
+        activeModelStreamsRef.current += 1;
         setIsResponding(true);
         setInitError(null);
         // Entering "requesting" phase — no content yet for this API call.
@@ -1969,7 +1972,13 @@ export const useGeminiStream = (
           }
         } finally {
           submitPromptOnCompleteRef.current = null;
-          setIsResponding(false);
+          activeModelStreamsRef.current = Math.max(
+            0,
+            activeModelStreamsRef.current - 1,
+          );
+          if (activeModelStreamsRef.current === 0) {
+            setIsResponding(false);
+          }
           isSubmittingQueryRef.current = false;
         }
       });
@@ -2114,14 +2123,14 @@ export const useGeminiStream = (
           },
         );
 
-      // History-based dedup MUST run before the `isResponding` early-return.
+      // History-based dedup MUST run before the active-stream early-return.
       // If a synthetic `functionResponse` for this callId is already in
       // chat.history (planted on session-load by
       // `client.repairOrphanedToolUseTurnsInHistory` or on every
       // `chat.sendMessageStream` push by the inline repair pass), the
       // in-flight scheduler result must be marked submitted NOW —
       // `useReactToolScheduler.allToolCallsCompleteHandler` is single-shot
-      // per batch, so a later isResponding=true early-return would leave
+      // per batch, so a later active-stream early-return would leave
       // the tool stuck in `completed-but-not-submitted` forever (Race A
       // surfaced in PR #4176 review). The real result is dropped on the
       // wire — same trade-off upstream Claude Code makes when its
@@ -2182,7 +2191,7 @@ export const useGeminiStream = (
         markToolsAsSubmitted(dedupedCallIds);
       }
 
-      if (isResponding) {
+      if (activeModelStreamsRef.current > 0) {
         return;
       }
 
@@ -2231,6 +2240,16 @@ export const useGeminiStream = (
       }
 
       if (geminiTools.length === 0) {
+        return;
+      }
+
+      if (
+        turnCancelledRef.current ||
+        abortControllerRef.current?.signal.aborted
+      ) {
+        markToolsAsSubmitted(
+          geminiTools.map((toolCall) => toolCall.request.callId),
+        );
         return;
       }
 
@@ -2409,7 +2428,6 @@ export const useGeminiStream = (
       submitQuery(responsesToSend, SendMessageType.ToolResult, prompt_ids[0]);
     },
     [
-      isResponding,
       submitQuery,
       markToolsAsSubmitted,
       geminiClient,


### PR DESCRIPTION
## What this PR does

Fixes the tool-result handoff race where a very fast tool completion could be dropped after the model stream had already ended but before React replaced `handleCompletedTools` with a fresh callback. The hook now tracks the actual `sendMessageStream` lifetime in a synchronous ref and uses that for the active-stream guard, while keeping the existing `isResponding` state for UI rendering.

## Why it's needed

#4672 reports AUTO_EDIT / YOLO turns stalling after a read/edit error until the next user instruction. The maintainer root-cause analysis points to `handleCompletedTools` reading stale `isResponding` from a React callback closure: the stream finishes, a tool fails immediately, and the old callback still sees `isResponding === true`, returns early, and never sends the tool error back to the model. AUTO_EDIT / YOLO removes the approval delay, so the race is easier to hit there.

## Reviewer Test Plan

### How to verify

Run `npm run test --workspace=packages/cli -- src/ui/hooks/useGeminiStream.test.tsx`. The new regression test is `submits a fast tool result after the stream ended but before React replaces the callback`; it saves the callback captured while React state still says responding, ends the held stream, then fires a fast failed `read_file` result through that stale callback and verifies a ToolResult request is sent.

### Evidence (Before & After)

Before: the stale callback path returned at the `isResponding` guard and dropped the tool result, so the second `sendMessageStream` call never happened. After: the guard reads the actual stream-lifetime ref, sees that the stream has ended, marks the tool submitted, and sends the failed tool result back to the model.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Windows 11, Node v24.15.0, npm 11.12.1.

Validation run locally:

```text
npm run test --workspace=packages/cli -- src/ui/hooks/useGeminiStream.test.tsx -t "fast tool result"  # 1 passed
npm run test --workspace=packages/cli -- src/ui/hooks/useGeminiStream.test.tsx                      # 104 passed
npm run typecheck --workspace=packages/cli                                                        # passed
npm run lint --workspace=packages/cli -- src/ui/hooks/useGeminiStream.ts src/ui/hooks/useGeminiStream.test.tsx  # passed
npm run build --workspace=packages/cli                                                            # passed
```

## Risk & Scope

- Main risk or tradeoff: the guard now depends on actual stream lifetime instead of React render timing. A small counter is used so overlapping streams, such as `/btw`, do not clear the guard early.
- Not validated / out of scope: manual YOLO-mode terminal reproduction on macOS/Linux was not run locally; the regression is covered at the hook level.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #4672

<details>
<summary>中文说明</summary>

## What this PR does

修复一个工具结果回传的竞态：模型流已经结束，但 React 还没来得及把 `handleCompletedTools` 换成新闭包时，快速完成或快速失败的工具结果可能被旧闭包丢掉。现在 hook 用同步 ref 记录真实的 `sendMessageStream` 生命周期，并用它做 active-stream guard；原来的 `isResponding` state 仍然只负责 UI 渲染语义。

## Why it's needed

#4672 反馈 AUTO_EDIT / YOLO 模式下读文件或编辑出错后，本轮不会继续更新文件，需要下一次用户指令才恢复。maintainer 已定位根因：`handleCompletedTools` 从 React callback 闭包里读到旧的 `isResponding`。时序是模型流先结束，工具马上失败，旧 callback 仍认为 `isResponding === true`，于是提前 return，模型收不到工具错误，agent loop 卡住。AUTO_EDIT / YOLO 没有 approval 延迟，所以更容易撞到这个窗口。

## Reviewer Test Plan

### How to verify

运行 `npm run test --workspace=packages/cli -- src/ui/hooks/useGeminiStream.test.tsx`。新增回归测试 `submits a fast tool result after the stream ended but before React replaces the callback`：测试先保存 React state 仍是 responding 时捕获的旧 callback，再结束 held stream，然后让一个快速失败的 `read_file` 结果走这个旧 callback，验证它仍会发送 ToolResult 请求。

### Evidence (Before & After)

修复前：旧 callback 会在 `isResponding` guard 直接 return，工具结果被丢弃，第二次 `sendMessageStream` 不会发生。修复后：guard 读取真实 stream-lifetime ref，发现模型流已经结束，于是标记工具已提交，并把失败的工具结果回传给模型。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Windows 11，Node v24.15.0，npm 11.12.1。

## Risk & Scope

- 主要风险/取舍：guard 现在依赖真实 stream 生命周期，不再依赖 React render 时机。这里用了一个小 counter，避免 `/btw` 这类重叠 stream 提前清掉 guard。
- 未验证/不在范围内：本地没有在 macOS/Linux 上手动复现 YOLO 终端流程；本 PR 用 hook 级回归测试覆盖该竞态。
- 破坏性变更/迁移：无。

## Linked Issues

Fixes #4672

</details>
