### PR TITLE
fix: warn on oversized context instructions

### DIFF
--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -365,6 +365,123 @@ describe('gemini.tsx main function', () => {
     );
   });
 
+  it('writes non-interactive warnings discovered during config initialization', async () => {
+    const originalNoRelaunch = process.env['QWEN_CODE_NO_RELAUNCH'];
+    const originalIsTTY = Object.getOwnPropertyDescriptor(
+      process.stdin,
+      'isTTY',
+    );
+    process.env['QWEN_CODE_NO_RELAUNCH'] = 'true';
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      configurable: true,
+    });
+
+    const processExitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((code) => {
+        throw new MockProcessExitError(code);
+      });
+    const { loadCliConfig, parseArguments } = await import(
+      './config/config.js'
+    );
+    const { loadSettings } = await import('./config/settings.js');
+    const cleanupModule = await import('./utils/cleanup.js');
+    const validatorModule = await import('./validateNonInterActiveAuth.js');
+    const nonInteractiveModule = await import('./nonInteractiveCli.js');
+    const initializerModule = await import('./core/initializer.js');
+    const startupWarningsModule = await import('./utils/startupWarnings.js');
+    const userStartupWarningsModule = await import(
+      './utils/userStartupWarnings.js'
+    );
+
+    mockWriteStderrLine.mockClear();
+    vi.mocked(cleanupModule.runExitCleanup).mockResolvedValue(undefined);
+    vi.spyOn(initializerModule, 'initializeApp').mockResolvedValue({
+      authError: null,
+      themeError: null,
+      shouldOpenAuthDialog: false,
+      geminiMdFileCount: 0,
+    });
+    vi.spyOn(startupWarningsModule, 'getStartupWarnings').mockResolvedValue([]);
+    vi.spyOn(
+      userStartupWarningsModule,
+      'getUserStartupWarnings',
+    ).mockResolvedValue([]);
+    vi.spyOn(nonInteractiveModule, 'runNonInteractive').mockResolvedValue(0);
+
+    let initialized = false;
+    const configStub = {
+      isInteractive: () => false,
+      getQuestion: () => 'hello',
+      getSandbox: () => false,
+      getApprovalMode: () => ApprovalMode.DEFAULT,
+      getDebugMode: () => false,
+      getListExtensions: () => false,
+      getMcpServers: () => ({}),
+      initialize: vi.fn().mockImplementation(async () => {
+        initialized = true;
+      }),
+      waitForMcpReady: vi.fn().mockResolvedValue(undefined),
+      getFailedMcpServerNames: () => [],
+      getIdeMode: () => false,
+      getExperimentalZedIntegration: () => false,
+      getScreenReader: () => false,
+      getGeminiMdFileCount: () => 0,
+      getProjectRoot: () => '/',
+      getOutputFormat: () => OutputFormat.TEXT,
+      getWarnings: () => (initialized ? ['late memory warning'] : []),
+      getModelsConfig: () => ({ getCurrentAuthType: () => null }),
+      getContentGeneratorConfig: () => undefined,
+      getUsageStatisticsEnabled: () => true,
+      getSessionId: () => 'test-session-id',
+      getProxy: () => undefined,
+    } as unknown as Config;
+
+    vi.mocked(parseArguments).mockResolvedValue({
+      extensions: [],
+    } as unknown as CliArgs);
+    vi.mocked(loadSettings).mockReturnValue({
+      errors: [],
+      merged: {
+        advanced: {},
+        security: { auth: {} },
+        ui: {},
+      },
+      setValue: vi.fn(),
+      forScope: () => ({ settings: {}, originalSettings: {}, path: '' }),
+      migrationWarnings: [],
+      getUserHooks: () => undefined,
+      getProjectHooks: () => undefined,
+    } as never);
+    vi.mocked(loadCliConfig).mockResolvedValue(configStub);
+    vi.spyOn(validatorModule, 'validateNonInteractiveAuth').mockResolvedValue(
+      configStub,
+    );
+
+    try {
+      await main();
+    } catch (error) {
+      if (!(error instanceof MockProcessExitError)) {
+        throw error;
+      }
+    } finally {
+      processExitSpy.mockRestore();
+      if (originalIsTTY) {
+        Object.defineProperty(process.stdin, 'isTTY', originalIsTTY);
+      } else {
+        delete (process.stdin as { isTTY?: unknown }).isTTY;
+      }
+      if (originalNoRelaunch !== undefined) {
+        process.env['QWEN_CODE_NO_RELAUNCH'] = originalNoRelaunch;
+      } else {
+        delete process.env['QWEN_CODE_NO_RELAUNCH'];
+      }
+    }
+
+    expect(mockWriteStderrLine).toHaveBeenCalledWith('late memory warning');
+  });
+
   it('creates non-interactive prompt ids that preserve session correlation', () => {
     expect(createNonInteractivePromptId('test-session-id')).toBe(
       'test-session-id########0',

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -976,6 +976,7 @@ export async function main() {
           : []),
       ]),
     ];
+    const emittedStartupWarnings = new Set(startupWarnings);
 
     // Surface critical startup warnings (corrupted settings, recovery, etc.)
     // to stderr so they are visible regardless of UI mode. In interactive
@@ -1074,6 +1075,11 @@ export async function main() {
     if (inputFormat !== InputFormat.STREAM_JSON) {
       profileCheckpoint('config_initialize_start');
       await config.initialize();
+      for (const warning of config.getWarnings()) {
+        if (emittedStartupWarnings.has(warning)) continue;
+        emittedStartupWarnings.add(warning);
+        writeStderrLine(warning);
+      }
       profileCheckpoint('config_initialize_end');
 
       // Non-interactive paths feed a prompt to the model immediately after

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -20,6 +20,7 @@ import {
   dedupeNewestFirst,
   getNextRenderMode,
   isRenderModeToggleKey,
+  mergeStartupWarnings,
 } from './AppContainer.js';
 import ansiEscapes from 'ansi-escapes';
 import {
@@ -607,6 +608,15 @@ describe('AppContainer State Management', () => {
 
       // Should render and unmount cleanly
       expect(() => unmount()).not.toThrow();
+    });
+
+    it('dedupes startup warnings produced during config initialization', () => {
+      expect(
+        mergeStartupWarnings(
+          ['early warning', 'same warning'],
+          ['same warning', 'late memory warning'],
+        ),
+      ).toEqual(['early warning', 'same warning', 'late memory warning']);
     });
 
     it('provides UIStateContext with state management', () => {

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -282,6 +282,13 @@ export function dedupeNewestFirst(messages: readonly string[]): string[] {
   return result;
 }
 
+export function mergeStartupWarnings(
+  currentWarnings: readonly string[],
+  nextWarnings: readonly string[],
+): string[] {
+  return [...new Set([...currentWarnings, ...nextWarnings])];
+}
+
 interface AppContainerProps {
   config: Config;
   settings: LoadedSettings;
@@ -484,6 +491,9 @@ export const AppContainer = (props: AppContainerProps) => {
     computeWindowTitle(basename(config.getTargetDir())),
   );
   const lastTitleRef = useRef<string | null>(null);
+  const [startupWarnings, setStartupWarnings] = useState(
+    () => props.startupWarnings || [],
+  );
   const staticExtraHeight = 3;
 
   // Prefetch the lowlight chunk on mount so the dynamic import is already
@@ -520,6 +530,9 @@ export const AppContainer = (props: AppContainerProps) => {
       // handled by the global catch.
       profileCheckpoint('config_initialize_start');
       await config.initialize();
+      setStartupWarnings((currentWarnings) =>
+        mergeStartupWarnings(currentWarnings, config.getWarnings()),
+      );
       profileCheckpoint('config_initialize_end');
       setConfigInitialized(true);
       profileCheckpoint('input_enabled');
@@ -3715,7 +3728,7 @@ export const AppContainer = (props: AppContainerProps) => {
           <AppContext.Provider
             value={{
               version: props.version,
-              startupWarnings: props.startupWarnings || [],
+              startupWarnings,
             }}
           >
             <CompactModeProvider value={compactModeValue}>

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1538,6 +1538,108 @@ describe('Server Config (config.ts)', () => {
     expect(config.getUserMemory()).toContain('[Project Memory](project.md)');
   });
 
+  it('refreshHierarchicalMemory should include appended auto-memory in the context warning estimate', async () => {
+    const config = new Config({
+      ...baseParams,
+      generationConfig: { contextWindowSize: 1000 },
+    });
+
+    vi.mocked(loadServerHierarchicalMemory).mockResolvedValue({
+      memoryContent: 'short project rules',
+      fileCount: 1,
+      ruleCount: 0,
+      conditionalRules: [],
+      projectRoot: '/tmp',
+    });
+    vi.mocked(readAutoMemoryIndex).mockResolvedValueOnce(
+      '# Managed Auto-Memory Index\n\n' + 'remember this '.repeat(80),
+    );
+
+    await config.refreshHierarchicalMemory();
+
+    expect(config.getWarnings()).toContainEqual(
+      expect.stringContaining('Loaded QWEN.md/context instructions'),
+    );
+  });
+
+  it('refreshHierarchicalMemory should warn when always-loaded context is large for the model window', async () => {
+    const config = new Config({
+      ...baseParams,
+      generationConfig: { contextWindowSize: 1000 },
+    });
+
+    vi.mocked(loadServerHierarchicalMemory).mockResolvedValueOnce({
+      memoryContent: 'a'.repeat(800),
+      fileCount: 1,
+      ruleCount: 0,
+      conditionalRules: [],
+      projectRoot: '/tmp',
+    });
+
+    await config.refreshHierarchicalMemory();
+
+    expect(config.getWarnings()).toContainEqual(
+      expect.stringContaining('Loaded QWEN.md/context instructions'),
+    );
+    expect(config.getWarnings()).toContainEqual(
+      expect.stringContaining("model's 1,000 token context window"),
+    );
+    expect(config.getWarnings()).toContainEqual(
+      expect.stringContaining('more than 15%'),
+    );
+  });
+
+  it('getWarnings should include oversized context before initialize refresh runs', () => {
+    const config = new Config({
+      ...baseParams,
+      userMemory: 'a'.repeat(800),
+      generationConfig: { contextWindowSize: 1000 },
+    });
+
+    expect(config.getWarnings()).toContainEqual(
+      expect.stringContaining('Loaded QWEN.md/context instructions'),
+    );
+  });
+
+  it('getWarnings should use the model token limit when no contextWindowSize is configured', () => {
+    const config = new Config({
+      ...baseParams,
+      model: 'unknown-model-for-context-warning-test',
+      userMemory: 'a'.repeat(100_000),
+    });
+
+    expect(config.getWarnings()).toContainEqual(
+      expect.stringContaining("model's 131,072 token context window"),
+    );
+  });
+
+  it('refreshHierarchicalMemory should not warn for small always-loaded context', async () => {
+    const config = new Config({
+      ...baseParams,
+      enableManagedAutoMemory: false,
+      generationConfig: { contextWindowSize: 1000 },
+    });
+
+    vi.mocked(loadServerHierarchicalMemory).mockResolvedValueOnce({
+      memoryContent: 'short project context',
+      fileCount: 1,
+      ruleCount: 0,
+      conditionalRules: [],
+      projectRoot: '/tmp',
+    });
+    vi.mocked(readAutoMemoryIndex).mockResolvedValueOnce(null);
+
+    await config.refreshHierarchicalMemory();
+
+    expect(
+      config
+        .getWarnings()
+        .some((warning) =>
+          warning.includes('Loaded QWEN.md/context instructions'),
+        ),
+    ).toBe(false);
+  });
+
   it('relocateWorkingDirectory should update the session working roots', async () => {
     const config = new Config(baseParams);
     const newDir = path.resolve('/path/to/other');

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -36,6 +36,7 @@ import {
   createContentGenerator,
   resolveContentGeneratorConfigWithSources,
 } from '../core/contentGenerator.js';
+import { tokenLimit } from '../core/tokenLimits.js';
 import { getRuntimeContentGenerator } from '../agents/runtime/agent-context.js';
 
 // Services
@@ -148,6 +149,7 @@ import {
 import { DEFAULT_QWEN_EMBEDDING_MODEL } from './models.js';
 import { Storage } from './storage.js';
 import { ChatRecordingService } from '../services/chatRecordingService.js';
+import { CHARS_PER_TOKEN } from '../services/tokenEstimation.js';
 import {
   clearRuntimeStatus,
   writeRuntimeStatus,
@@ -174,6 +176,8 @@ import { CommitAttributionService } from '../services/commitAttribution.js';
 
 const gitCoAuthorLogger = createDebugLogger('GIT_CO_AUTHOR');
 const memoryPressureConfigLogger = createDebugLogger('MEMORY_PRESSURE');
+
+const MEMORY_CONTEXT_WARNING_RATIO = 0.15;
 
 import {
   ModelsConfig,
@@ -2123,6 +2127,33 @@ export class Config {
     );
   }
 
+  private buildMemoryContextWarning(memoryContent: string): string | undefined {
+    const contextWindowSize =
+      this.getContentGeneratorConfig()?.contextWindowSize ??
+      this.modelsConfig.getGenerationConfig().contextWindowSize ??
+      tokenLimit(this.getModel(), 'input');
+    if (!contextWindowSize || contextWindowSize <= 0 || !memoryContent) {
+      return undefined;
+    }
+
+    const estimatedTokens = Math.ceil(memoryContent.length / CHARS_PER_TOKEN);
+    const thresholdTokens = Math.floor(
+      contextWindowSize * MEMORY_CONTEXT_WARNING_RATIO,
+    );
+    if (estimatedTokens <= thresholdTokens) {
+      return undefined;
+    }
+
+    return (
+      `Warning: Loaded QWEN.md/context instructions use about ` +
+      `${estimatedTokens.toLocaleString()} tokens, more than ` +
+      `${Math.round(MEMORY_CONTEXT_WARNING_RATIO * 100)}% of this ` +
+      `model's ${contextWindowSize.toLocaleString()} token context window. ` +
+      `Consider trimming long always-loaded context or moving details into ` +
+      `on-demand files.`
+    );
+  }
+
   private getMemoryDiscoveryDirectories(): string[] {
     if (!this.shouldLoadMemoryFromIncludeDirectories()) {
       return [];
@@ -2277,7 +2308,12 @@ export class Config {
    * and should be displayed to the user during startup.
    */
   getWarnings(): string[] {
-    return this.warnings;
+    const memoryContextWarning = this.buildMemoryContextWarning(
+      this.getUserMemory(),
+    );
+    return memoryContextWarning
+      ? [...this.warnings, memoryContextWarning]
+      : this.warnings;
   }
 
   getDebugLogger(): DebugLogger {


### PR DESCRIPTION
## What this PR does

Adds a startup warning when the always-loaded QWEN.md / context instruction block is estimated to use more than 15% of the active model context window. The warning is produced from the existing `Config.getWarnings()` path, so the current startup notification plumbing displays it without a new UI component or a new setting.

The estimate intentionally stays simple (`chars / 4`) because this is a guardrail, not billing telemetry. It uses the initialized content generator config when available, and falls back to `ModelsConfig` so the warning still works during startup memory refresh before auth has created the runtime content generator.

## Why it's needed

Oversized QWEN.md / AGENTS.md files silently consume model context before the user sends a prompt. Issue #4941 asks for a context-window-scaled warning so users notice this before quality degrades, especially when switching between models with different context sizes.

This keeps the first version small: no per-file breakdown, no historical trend storage, and no configurable threshold until there is user demand for those knobs.

## Reviewer Test Plan

### How to verify

Create or mock a large always-loaded context block and a small `contextWindowSize`; after `refreshHierarchicalMemory()`, `config.getWarnings()` should include the oversized-context warning. With a small context block, no warning should be added.

### Evidence (Before & After)

N/A for screenshots. This is a startup warning path covered by unit tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️ not tested   |
| 🪟 Windows |   ✅ tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Windows 11, Node/npm from the local checkout. Dependencies installed with `npm ci --ignore-scripts --no-audit --progress=false` to avoid running the full release prepare/build pipeline.

Commands run:

```bash
npm exec -- vitest run packages/core/src/config/config.test.ts
npm exec -- eslint packages/core/src/config/config.ts packages/core/src/config/config.test.ts
npm exec -- prettier --check packages/core/src/config/config.ts packages/core/src/config/config.test.ts
git diff --check
npm run typecheck --workspace=packages/core
npm run build --workspace=packages/core
```

`vitest` passed all 215 `config.test.ts` tests. It still prints the existing repository warning about `integration-tests/tsconfig.json` using a non-array substitution for `"//"`; that warning is unrelated to this change.

## Risk & Scope

- Main risk or tradeoff: char-count token estimation can be imprecise, but it is only used to warn when the always-loaded context is clearly large.
- Not validated / out of scope: exact tokenizer accounting, per-source breakdown, trend/history tracking, and a user-configurable threshold.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #4941

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

当始终加载的 QWEN.md / 上下文指令块估算后超过当前模型上下文窗口的 15% 时，新增一条启动警告。警告走现有的 `Config.getWarnings()` 路径，因此不需要新增 UI 组件或新设置，现有启动通知链路会负责展示。

估算方式刻意保持简单：`字符数 / 4`。这里的目标是防护提醒，不是计费统计。实现优先使用已初始化的 content generator config；如果启动阶段 memory refresh 发生在 auth 创建 runtime content generator 之前，则回退到 `ModelsConfig` 里的 generation config。

## 为什么需要

过大的 QWEN.md / AGENTS.md 会在用户输入前就悄悄占掉模型上下文。#4941 希望这个提示能随模型 context window 缩放，尤其是在不同上下文大小的模型之间切换时，让用户提前看到风险，而不是等输出质量下降后才排查。

这个版本刻意收窄范围：不做逐文件明细、不保存历史趋势、不新增可配置阈值，等真实用户需要这些旋钮时再加。

## Reviewer Test Plan

### 如何验证

构造或 mock 一个很大的 always-loaded context block，并设置较小的 `contextWindowSize`；执行 `refreshHierarchicalMemory()` 后，`config.getWarnings()` 应包含 oversized-context warning。对于较小的 context block，不应新增这条 warning。

### 前后证据

没有截图。这里是启动 warning 路径，已通过单元测试覆盖。

### 本地测试环境

Windows 11，本地 checkout 的 Node/npm。依赖用 `npm ci --ignore-scripts --no-audit --progress=false` 安装，避免触发完整 release prepare/build 流程。

已运行命令：

```bash
npm exec -- vitest run packages/core/src/config/config.test.ts
npm exec -- eslint packages/core/src/config/config.ts packages/core/src/config/config.test.ts
npm exec -- prettier --check packages/core/src/config/config.ts packages/core/src/config/config.test.ts
git diff --check
npm run typecheck --workspace=packages/core
npm run build --workspace=packages/core
```

`vitest` 中 `config.test.ts` 的 215 个测试全部通过。测试过程中仍会打印仓库既有的 `integration-tests/tsconfig.json` warning：`"//"` substitution 不是数组；该 warning 与本 PR 无关。

## 风险与范围

- 主要风险 / 取舍：字符数估算 token 不可能完全精确，但这里只用于明显过大的 always-loaded context 的启动提醒。
- 未覆盖 / 不在范围：精确 tokenizer 统计、逐文件拆分、历史趋势记录、用户可配置阈值。
- 破坏性变更 / 迁移说明：无。

## 关联 issue

Fixes #4941

</details>
