### PR TITLE
fix(cli): show full plan for gate failures

### DIFF
--- a/packages/core/src/tools/exitPlanMode.test.ts
+++ b/packages/core/src/tools/exitPlanMode.test.ts
@@ -8,13 +8,27 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ExitPlanModeTool, type ExitPlanModeParams } from './exitPlanMode.js';
 import { ApprovalMode, type Config } from '../config/config.js';
 import { ToolConfirmationOutcome } from './tools.js';
+import { runPlanApprovalGate } from '../plan-gate/planApprovalGate.js';
+import type { GateDecision, MergedGateFinding } from '../plan-gate/types.js';
+
+vi.mock('../plan-gate/planApprovalGate.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../plan-gate/planApprovalGate.js')>();
+
+  return {
+    ...actual,
+    runPlanApprovalGate: vi.fn(),
+  };
+});
 
 describe('ExitPlanModeTool', () => {
   let tool: ExitPlanModeTool;
   let mockConfig: Config;
   let approvalMode: ApprovalMode;
+  const mockedRunPlanApprovalGate = vi.mocked(runPlanApprovalGate);
 
   beforeEach(() => {
+    mockedRunPlanApprovalGate.mockReset();
     approvalMode = ApprovalMode.PLAN;
     mockConfig = {
       getApprovalMode: vi.fn(() => approvalMode),
@@ -344,6 +358,14 @@ describe('ExitPlanModeTool', () => {
   });
 
   describe('YOLO mode', () => {
+    const finding: MergedGateFinding = {
+      id: 'GF-1',
+      severity: 'P2',
+      issue: 'The plan omits the rollback path.',
+      rationale: 'Autonomous execution would not know how to recover safely.',
+      suggestedFix: 'Add rollback steps before exiting plan mode.',
+    };
+
     it('should restore YOLO via user_override gate path', async () => {
       // With the gate, YOLO exit goes through the autonomous path.
       // user_override skips the gate and restores prePlanMode.
@@ -412,5 +434,100 @@ describe('ExitPlanModeTool', () => {
       const permission = await invocation.getDefaultPermission();
       expect(permission).toBe('ask');
     });
+
+    it.each<{
+      name: string;
+      decision: GateDecision;
+      expectedMessage: string;
+      expectedDetail: string;
+      expectedNeedsUserPending?: boolean;
+      expectedCapEscalationPending?: boolean;
+    }>([
+      {
+        name: 'blocked',
+        decision: { kind: 'blocked', findings: [finding] },
+        expectedMessage: 'Plan gate: blocked (1 finding(s))',
+        expectedDetail: 'GF-1',
+      },
+      {
+        name: 'needs_user',
+        decision: {
+          kind: 'needs_user',
+          findings: [finding],
+          questions: ['Which migration path should be used?'],
+        },
+        expectedMessage: 'Plan gate: needs user input (1 question(s))',
+        expectedDetail: 'Which migration path should be used?',
+        expectedNeedsUserPending: true,
+      },
+      {
+        name: 'cap_escalation',
+        decision: { kind: 'cap_escalation', blockingFindings: [finding] },
+        expectedMessage: 'Plan gate: cap reached with 1 blocking finding(s)',
+        expectedDetail: 'Approve execution',
+        expectedCapEscalationPending: true,
+      },
+      {
+        name: 'unavailable',
+        decision: { kind: 'unavailable', reason: 'review model timed out' },
+        expectedMessage: 'Plan gate: unavailable - review model timed out',
+        expectedDetail: 'review model timed out',
+      },
+    ])(
+      'should keep the submitted plan visible when the gate returns $name',
+      async ({
+        decision,
+        expectedMessage,
+        expectedDetail,
+        expectedNeedsUserPending,
+        expectedCapEscalationPending,
+      }) => {
+        approvalMode = ApprovalMode.PLAN;
+        const gateState = {
+          entryId: 1,
+          reviewCount: 0,
+          gateMode: 'capped' as const,
+          lastFindings: [],
+          capEscalationPending: false,
+          needsUserPending: false,
+        };
+        (mockConfig.getPrePlanMode as ReturnType<typeof vi.fn>).mockReturnValue(
+          ApprovalMode.YOLO,
+        );
+        (
+          mockConfig.getPlanGateState as ReturnType<typeof vi.fn>
+        ).mockReturnValue(gateState);
+        mockedRunPlanApprovalGate.mockResolvedValue(decision);
+
+        const params: ExitPlanModeParams = {
+          plan: '1. Update the parser.\n2. Add regression tests.',
+          originalRequest: 'Fix plan mode display',
+        };
+        const signal = new AbortController().signal;
+
+        const result = await tool.build(params).execute(signal);
+
+        expect(result.llmContent).toContain(expectedDetail);
+        expect(result.returnDisplay).toEqual({
+          type: 'plan_summary',
+          message: expectedMessage,
+          plan: expect.stringContaining(params.plan),
+          rejected: true,
+        });
+        expect(result.returnDisplay).toEqual(
+          expect.objectContaining({
+            plan: expect.stringContaining(expectedDetail),
+          }),
+        );
+        expect(gateState.needsUserPending).toBe(
+          Boolean(expectedNeedsUserPending),
+        );
+        expect(gateState.capEscalationPending).toBe(
+          Boolean(expectedCapEscalationPending),
+        );
+        expect(mockConfig.savePlan).not.toHaveBeenCalled();
+        expect(approvalMode).toBe(ApprovalMode.PLAN);
+      },
+    );
   });
 });

--- a/packages/core/src/tools/exitPlanMode.ts
+++ b/packages/core/src/tools/exitPlanMode.ts
@@ -174,6 +174,19 @@ class ExitPlanModeToolInvocation extends BaseToolInvocation<
     }
   }
 
+  private buildRejectedGateDisplay(
+    message: string,
+    plan: string,
+    details: string,
+  ): ToolResult['returnDisplay'] {
+    return {
+      type: 'plan_summary',
+      message,
+      plan: `${plan.trimEnd()}\n\n---\n\n${details}`,
+      rejected: true,
+    };
+  }
+
   async execute(signal: AbortSignal): Promise<ToolResult> {
     const { plan, originalRequest, researchSummary, resolutionSummary } =
       this.params;
@@ -242,29 +255,56 @@ class ExitPlanModeToolInvocation extends BaseToolInvocation<
               'Gate approved' + (notes ? `\n\n${notes}` : ''),
             );
           }
-          case 'blocked':
+          case 'blocked': {
+            const llmContent = formatBlockedResponse(decision);
+            const message = `Plan gate: blocked (${decision.findings.length} finding(s))`;
             return {
-              llmContent: formatBlockedResponse(decision),
-              returnDisplay: `Plan gate: blocked (${decision.findings.length} finding(s))`,
-            };
-          case 'needs_user':
-            gateState.needsUserPending = true;
-            return {
-              llmContent: formatNeedsUserResponse(decision),
-              returnDisplay: `Plan gate: needs user input (${decision.questions.length} question(s))`,
-            };
-          case 'cap_escalation': {
-            gateState.capEscalationPending = true;
-            return {
-              llmContent: formatCapEscalationResponse(decision),
-              returnDisplay: `Plan gate: cap reached with ${decision.blockingFindings.length} blocking finding(s)`,
+              llmContent,
+              returnDisplay: this.buildRejectedGateDisplay(
+                message,
+                plan,
+                llmContent,
+              ),
             };
           }
-          case 'unavailable':
+          case 'needs_user': {
+            gateState.needsUserPending = true;
+            const llmContent = formatNeedsUserResponse(decision);
+            const message = `Plan gate: needs user input (${decision.questions.length} question(s))`;
             return {
-              llmContent: formatUnavailableResponse(decision),
-              returnDisplay: `Plan gate: unavailable — ${decision.reason}`,
+              llmContent,
+              returnDisplay: this.buildRejectedGateDisplay(
+                message,
+                plan,
+                llmContent,
+              ),
             };
+          }
+          case 'cap_escalation': {
+            gateState.capEscalationPending = true;
+            const llmContent = formatCapEscalationResponse(decision);
+            const message = `Plan gate: cap reached with ${decision.blockingFindings.length} blocking finding(s)`;
+            return {
+              llmContent,
+              returnDisplay: this.buildRejectedGateDisplay(
+                message,
+                plan,
+                llmContent,
+              ),
+            };
+          }
+          case 'unavailable': {
+            const llmContent = formatUnavailableResponse(decision);
+            const message = `Plan gate: unavailable - ${decision.reason}`;
+            return {
+              llmContent,
+              returnDisplay: this.buildRejectedGateDisplay(
+                message,
+                plan,
+                llmContent,
+              ),
+            };
+          }
           default: {
             const _exhaustive: never = decision;
             return {


### PR DESCRIPTION
## What this PR does

Keeps the submitted plan visible when the autonomous plan approval gate does not approve execution. The `blocked`, `needs_user`, `cap_escalation`, and `unavailable` outcomes now return the same structured `plan_summary` display shape used by approved plans, with `rejected: true` and the gate details appended after the original plan.

## Why it's needed

Fixes #5075. The approved path already sends `{ type: 'plan_summary', message, plan }`, so the TUI can render the full plan. The non-approved gate paths returned only a short string such as `Plan gate: blocked (1 finding(s))`, which left users unable to read the plan that had just been rejected or blocked.

## Reviewer Test Plan

### How to verify

Trigger `exit_plan_mode` from an AUTO or YOLO pre-plan session where the plan gate returns a non-approved outcome. The CLI should still show the submitted plan body, followed by the gate findings or questions, instead of only showing a one-line gate status.

### Evidence (Before & After)

Before: `exitPlanMode.ts` returned plain string `returnDisplay` values for gate `blocked`, `needs_user`, `cap_escalation`, and `unavailable`, so `PlanSummaryDisplay` never received the plan. After: `exitPlanMode.test.ts` covers all four non-approved gate outcomes and asserts that `returnDisplay` is a rejected `plan_summary` containing both the original plan text and the gate details.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Windows PowerShell, Node/npm from the repository dev setup. Validation commands: `npm run test --workspace=packages/core -- src/tools/exitPlanMode.test.ts`; `npx prettier --check packages/core/src/tools/exitPlanMode.ts packages/core/src/tools/exitPlanMode.test.ts`; `npx eslint packages/core/src/tools/exitPlanMode.ts packages/core/src/tools/exitPlanMode.test.ts`; `npm run typecheck --workspace=packages/core`; `npm run build --workspace=packages/core`.

## Risk & Scope

- Main risk or tradeoff: the rejected plan display now includes the gate details below a separator inside the plan summary body, so users see both the original plan and why the gate stopped it in one panel.
- Not validated / out of scope: no live TUI screenshot was captured; this PR validates the tool result shape at the core layer.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5075

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

当自动 plan approval gate 没有批准执行时，仍然保留并展示用户刚提交的完整 plan。`blocked`、`needs_user`、`cap_escalation`、`unavailable` 四种结果现在都会返回和 approved 路径一致的结构化 `plan_summary`，并设置 `rejected: true`，同时把 gate 的发现或问题追加在原 plan 后面。

## 为什么需要

修复 #5075。approved 路径已经返回 `{ type: 'plan_summary', message, plan }`，所以 TUI 能渲染完整 plan。但 gate 非批准路径之前只返回一行字符串，例如 `Plan gate: blocked (1 finding(s))`，导致用户看不到刚被阻止的完整 plan。

## Reviewer Test Plan

### 如何验证

在 AUTO 或 YOLO pre-plan session 中触发 `exit_plan_mode`，并让 plan gate 返回非批准结果。CLI 应该展示完整 plan，并在后面展示 gate findings 或 questions，而不是只显示一行 gate 状态。

### Before / After 证据

Before：`exitPlanMode.ts` 对 `blocked`、`needs_user`、`cap_escalation`、`unavailable` 返回纯字符串 `returnDisplay`，`PlanSummaryDisplay` 收不到 plan。After：`exitPlanMode.test.ts` 覆盖四种非批准 gate 结果，断言 `returnDisplay` 是 rejected `plan_summary`，且包含原始 plan 和 gate 细节。

### 测试环境

Windows PowerShell，本地 Node/npm 开发环境。已运行：`npm run test --workspace=packages/core -- src/tools/exitPlanMode.test.ts`；`npx prettier --check packages/core/src/tools/exitPlanMode.ts packages/core/src/tools/exitPlanMode.test.ts`；`npx eslint packages/core/src/tools/exitPlanMode.ts packages/core/src/tools/exitPlanMode.test.ts`；`npm run typecheck --workspace=packages/core`；`npm run build --workspace=packages/core`。

## 风险与范围

- 主要风险或取舍：rejected plan display 会在同一个 plan summary 面板里用分隔线追加 gate 细节，让用户同时看到原 plan 和被阻止原因。
- 未验证 / 不在范围内：没有录制真实 TUI 截图；本 PR 在 core 层验证 tool result shape。
- 破坏性变更 / 迁移说明：无。

</details>
