### PR TITLE
fix(web-shell): improve slash command panel layering

### DIFF
--- a/packages/web-shell/client/completions/slashCompletion.ts
+++ b/packages/web-shell/client/completions/slashCompletion.ts
@@ -360,6 +360,9 @@ export function slashCompletionSource(
               }
             : {}),
           detail: n.description || undefined,
+          ...(isSkillList && n.description
+            ? { info: `/${n.name}\n\n${n.description}` }
+            : {}),
           apply: `${command} `,
         };
       });
@@ -391,9 +394,14 @@ export function slashCompletionSource(
       .sort((a, b) => compareSlashCommands(a, b, lp, categoryOrder));
     const options = filteredCommands.map((c): Completion => {
       const command = `/${c.name}`;
+      const category = getCommandDisplayCategory(c);
+      const showCommandInfo = category === 'custom' || category === 'skill';
       return {
         label: command,
         detail: c.description || undefined,
+        ...(showCommandInfo && c.description
+          ? { info: `${command}\n\n${c.description}` }
+          : {}),
         apply: `${command} `,
         section: getCommandSection(c, translate, categoryOrder),
       };

--- a/packages/web-shell/client/components/Editor.module.css
+++ b/packages/web-shell/client/components/Editor.module.css
@@ -207,26 +207,59 @@
   color: #fff;
 }
 
-:global(.cm-tooltip-autocomplete) {
+:global([data-web-shell-tooltip-portal]) {
+  pointer-events: none;
+}
+
+:global([data-web-shell-tooltip-portal] .cm-tooltip) {
+  z-index: var(--web-shell-tooltip-z-index, 1000);
+  pointer-events: auto;
+}
+
+:global([data-web-shell-tooltip-portal] .cm-tooltip-autocomplete) {
+  --web-shell-completion-label-width: 20ch;
+  --web-shell-completion-column-gap: 2ch;
+  --web-shell-completion-detail-start: calc(
+    var(--web-shell-completion-label-width) +
+      var(--web-shell-completion-column-gap)
+  );
   min-width: 500px !important;
   max-width: 700px !important;
   max-height: 400px !important;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4) !important;
+  background: var(--bg-secondary, #161616) !important;
+  border: 1px solid var(--border-color, #2a2a2a) !important;
+  border-radius: 6px !important;
+  overflow: visible;
 }
 
-:global(.cm-tooltip-autocomplete > ul) {
+:global([data-web-shell-tooltip-portal] .cm-tooltip-autocomplete > ul) {
   max-height: 380px !important;
+  overflow: auto;
+  border-radius: 6px;
+  font-family: var(--font-mono, monospace);
+  font-size: 13px;
 }
 
-:global(.cm-tooltip-autocomplete ul li) {
+:global([data-web-shell-tooltip-portal] .cm-tooltip-autocomplete ul li) {
   display: flex !important;
   align-items: baseline;
   min-width: 0;
   padding: 4px 8px !important;
+  color: var(--text-primary, #e4e4e4) !important;
   overflow: hidden;
 }
 
-:global(.cm-tooltip-autocomplete completion-section) {
+:global(
+  [data-web-shell-tooltip-portal] .cm-tooltip-autocomplete ul li[aria-selected]
+) {
+  background: var(--bg-tertiary, #1e1e1e) !important;
+  color: var(--accent-color, #4a9eff) !important;
+}
+
+:global(
+  [data-web-shell-tooltip-portal] .cm-tooltip-autocomplete completion-section
+) {
   display: block !important;
   height: 0;
   margin: 6px 10px 3px;
@@ -234,56 +267,136 @@
   border-bottom: 1px solid var(--border-color) !important;
 }
 
-:global(.cm-tooltip-autocomplete completion-section:first-of-type) {
+:global(
+  [data-web-shell-tooltip-portal]
+    .cm-tooltip-autocomplete
+    completion-section:first-of-type
+) {
   display: none !important;
 }
 
-:global(.cm-tooltip-autocomplete .cm-completionLabel) {
+:global(
+  [data-web-shell-tooltip-portal] .cm-tooltip-autocomplete .cm-completionLabel
+) {
+  font-family: var(--font-mono, monospace);
   flex-shrink: 0;
-  min-width: 14ch;
-  max-width: 28ch;
+  width: var(--web-shell-completion-label-width);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-:global(.cm-tooltip-autocomplete .cm-completionDetail) {
+:global(
+  [data-web-shell-tooltip-portal] .cm-tooltip-autocomplete .cm-completionDetail
+) {
   flex: 1 1 auto;
   min-width: 0;
+  font-style: normal;
   color: var(--text-secondary);
   font-size: 13px;
-  margin-left: 2ch;
+  margin-left: var(--web-shell-completion-column-gap);
   opacity: 0.8;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-:global(.cm-tooltip-autocomplete ul li.cm-file-completion .cm-completionLabel) {
+:global(
+  [data-web-shell-tooltip-portal]
+    .cm-tooltip-autocomplete
+    ul
+    li.cm-file-completion
+    .cm-completionLabel
+) {
   flex: 1 1 auto;
+  width: auto;
   min-width: 0;
   max-width: none;
 }
 
-:global(.cm-tooltip-autocomplete ul li.cm-skill-completion) {
-  align-items: flex-start !important;
+:global(
+  [data-web-shell-tooltip-portal]
+    .cm-tooltip-autocomplete
+    ul
+    li.cm-command-info-completion
+) {
+  display: grid !important;
+  grid-template-columns: var(--web-shell-completion-label-width) minmax(0, 1fr);
+  column-gap: var(--web-shell-completion-column-gap);
+  align-items: baseline !important;
 }
 
 :global(
-  .cm-tooltip-autocomplete ul li.cm-skill-completion .cm-completionLabel
+  [data-web-shell-tooltip-portal]
+    .cm-tooltip-autocomplete
+    ul
+    li.cm-command-info-completion
+    .cm-completionLabel
 ) {
-  align-self: center;
+  min-width: 0;
+  max-width: none;
 }
 
 :global(
-  .cm-tooltip-autocomplete ul li.cm-skill-completion .cm-completionDetail
+  [data-web-shell-tooltip-portal]
+    .cm-tooltip-autocomplete
+    ul
+    li.cm-command-info-completion
+    .cm-completionDetail
 ) {
-  white-space: normal !important;
-  display: -webkit-box !important;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  line-height: 1.35;
-  max-height: 2.7em;
+  margin-left: 0;
+  white-space: nowrap;
+}
+
+:global([data-web-shell-tooltip-portal] .cm-tooltip.cm-completionInfo) {
+  z-index: 1;
+  width: min(
+    calc(100% - var(--web-shell-completion-detail-start)),
+    calc(100vw - 32px)
+  );
+  max-width: min(
+    calc(100% - var(--web-shell-completion-detail-start)),
+    calc(100vw - 32px)
+  ) !important;
+  max-height: min(280px, calc(100vh - 32px));
+  padding: 8px 10px;
+  overflow: auto;
+  border: 1px solid var(--border-color, #2a2a2a);
+  border-radius: 6px;
+  background: var(--bg-secondary, #161616);
+  color: var(--text-primary, #e4e4e4);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  font-family: var(--font-sans, system-ui, sans-serif);
+  font-size: 13px;
+  line-height: 1.45;
+  white-space: pre-line;
+  overflow-wrap: anywhere;
+}
+
+:global(
+  [data-web-shell-tooltip-portal] .cm-completionInfo.cm-completionInfo-right
+) {
+  margin-left: var(--web-shell-completion-column-gap);
+}
+
+:global(
+  [data-web-shell-tooltip-portal]
+    .cm-completionInfo.cm-completionInfo-right-narrow
+) {
+  left: var(--web-shell-completion-detail-start);
+}
+
+:global(
+  [data-web-shell-tooltip-portal] .cm-completionInfo.cm-completionInfo-left
+) {
+  margin-right: var(--web-shell-completion-column-gap);
+}
+
+:global(
+  [data-web-shell-tooltip-portal]
+    .cm-completionInfo.cm-completionInfo-left-narrow
+) {
+  right: var(--web-shell-completion-detail-start);
 }
 
 @media (max-width: 700px) {

--- a/packages/web-shell/client/components/Editor.tsx
+++ b/packages/web-shell/client/components/Editor.tsx
@@ -6,7 +6,7 @@ import {
   useCallback,
   useState,
 } from 'react';
-import { EditorView, keymap, placeholder } from '@codemirror/view';
+import { EditorView, keymap, placeholder, tooltips } from '@codemirror/view';
 import { EditorState, Compartment, Prec } from '@codemirror/state';
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
 import {
@@ -268,6 +268,70 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
 
   useEffect(() => {
     if (!containerRef.current) return;
+
+    // Create a tooltip portal div on document.body so autocomplete
+    // dropdowns escape any ancestor `overflow: hidden` (e.g. the host
+    // app's container). We sync the current theme class and computed CSS
+    // variables so the portal keeps the same colors after theme changes.
+    const tooltipPortal = document.createElement('div');
+    tooltipPortal.setAttribute('data-web-shell-tooltip-portal', '');
+    tooltipPortal.style.position = 'fixed';
+    tooltipPortal.style.inset = '0';
+    tooltipPortal.style.zIndex = 'var(--web-shell-tooltip-z-index)';
+    tooltipPortal.style.pointerEvents = 'none';
+    const THEME_RE = /\b\S*theme(?:Dark|Light)\S*/gi;
+    const syncTheme = () => {
+      let el: Element | null = containerRef.current;
+      let themeClass: string | null = null;
+      if (containerRef.current) {
+        const computedStyle = getComputedStyle(containerRef.current);
+        for (let i = 0; i < computedStyle.length; i += 1) {
+          const name = computedStyle[i];
+          if (name.startsWith('--')) {
+            tooltipPortal.style.setProperty(
+              name,
+              computedStyle.getPropertyValue(name),
+            );
+          }
+        }
+        if (
+          !computedStyle.getPropertyValue('--web-shell-tooltip-z-index').trim()
+        ) {
+          tooltipPortal.style.setProperty(
+            '--web-shell-tooltip-z-index',
+            '1000',
+          );
+        }
+      }
+      while (el) {
+        const match = el.className?.match?.(THEME_RE);
+        if (match) {
+          themeClass = match[0];
+          break;
+        }
+        el = el.parentElement;
+      }
+      if (themeClass) {
+        // Keep only the theme class on the portal - old theme class
+        // from a previous sync is replaced atomically.
+        tooltipPortal.className = themeClass;
+      }
+    };
+    syncTheme();
+    document.body.appendChild(tooltipPortal);
+
+    // Observe class changes on every ancestor up to (and including)
+    // the themed one, so light↔dark switches propagate to the portal.
+    const observer = new MutationObserver(syncTheme);
+    let el: Element | null = containerRef.current;
+    while (el) {
+      observer.observe(el, {
+        attributes: true,
+        attributeFilter: ['class', 'style'],
+      });
+      if (el.className?.match?.(THEME_RE)) break;
+      el = el.parentElement;
+    }
 
     const submitText = (view: EditorView, textOverride?: string) => {
       const rawText = (textOverride ?? view.state.doc.toString()).trim();
@@ -592,16 +656,34 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
           activateOnTyping: true,
           icons: false,
           optionClass: (completion) =>
-            completion.type === 'skill'
-              ? 'cm-skill-completion'
-              : completion.type === 'file'
-                ? 'cm-file-completion'
+            completion.type === 'file'
+              ? 'cm-file-completion'
+              : completion.info
+                ? 'cm-command-info-completion'
                 : '',
           aboveCursor: true,
+          positionInfo: (_view, list, option, info, space) => {
+            const infoHeight = info.bottom - info.top;
+            const spaceBelow = space.bottom - list.bottom;
+            const placeBelow =
+              spaceBelow >= infoHeight || spaceBelow > list.top;
+            const side = placeBelow ? 'top' : 'bottom';
+            const offset = placeBelow
+              ? option.bottom - list.top
+              : list.bottom - option.top;
+            return {
+              style: `${side}: ${offset}px`,
+              class: 'cm-completionInfo-right-narrow',
+            };
+          },
           activateOnCompletion: (completion) =>
             typeof completion.apply === 'string' &&
             completion.apply.endsWith(' '),
         }),
+        // Render tooltips (including autocomplete panel) inside a portal
+        // div on document.body so host-app containers with
+        // `overflow: hidden` cannot clip the dropdown.
+        tooltips({ parent: tooltipPortal }),
         placeholderCompartment.of(placeholder('')),
         EditorView.lineWrapping,
         editableCompartment.of(EditorView.editable.of(true)),
@@ -723,79 +805,6 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
             borderLeftColor: 'var(--accent-color, #4a9eff)',
             borderLeftWidth: '2px',
           },
-          '.cm-tooltip-autocomplete': {
-            background: 'var(--bg-secondary, #161616)',
-            border: '1px solid var(--border-color, #2a2a2a)',
-            borderRadius: '6px',
-            overflow: 'hidden',
-          },
-          '.cm-tooltip-autocomplete ul': {
-            fontFamily: 'var(--font-mono, monospace)',
-            fontSize: '13px',
-          },
-          '.cm-tooltip-autocomplete ul li': {
-            display: 'flex',
-            alignItems: 'baseline',
-            minWidth: '0',
-            padding: '4px 10px',
-            color: 'var(--text-primary, #e4e4e4)',
-            overflow: 'hidden',
-          },
-          '.cm-tooltip-autocomplete ul li[aria-selected]': {
-            background: 'var(--bg-tertiary, #1e1e1e)',
-            color: 'var(--accent-color, #4a9eff)',
-          },
-          '.cm-tooltip-autocomplete completion-section': {
-            display: 'block',
-            height: '0',
-            margin: '6px 10px 3px',
-            padding: '0',
-            borderBottom: '1px solid var(--border-color, #2a2a2a)',
-          },
-          '.cm-tooltip-autocomplete completion-section:first-of-type': {
-            display: 'none',
-          },
-          '.cm-completionLabel': {
-            fontFamily: 'var(--font-mono, monospace)',
-            flexShrink: '0',
-            minWidth: '14ch',
-            maxWidth: '28ch',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          },
-          '.cm-completionDetail': {
-            flex: '1 1 auto',
-            minWidth: '0',
-            fontStyle: 'normal',
-            color: 'var(--text-dimmed, #666)',
-            marginLeft: '8px',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          },
-          '.cm-tooltip-autocomplete ul li.cm-file-completion .cm-completionLabel':
-            {
-              flex: '1 1 auto',
-              minWidth: '0',
-              maxWidth: 'none',
-            },
-          '.cm-tooltip-autocomplete ul li.cm-skill-completion': {
-            alignItems: 'flex-start',
-          },
-          '.cm-tooltip-autocomplete ul li.cm-skill-completion .cm-completionLabel':
-            {
-              alignSelf: 'center',
-            },
-          '.cm-tooltip-autocomplete ul li.cm-skill-completion .cm-completionDetail':
-            {
-              whiteSpace: 'normal',
-              display: '-webkit-box',
-              WebkitLineClamp: '2',
-              WebkitBoxOrient: 'vertical',
-              lineHeight: '1.35',
-              maxHeight: '2.7em',
-            },
         }),
       ],
     });
@@ -811,6 +820,8 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
     return () => {
       view.destroy();
       viewRef.current = null;
+      observer.disconnect();
+      tooltipPortal.remove();
     };
   }, []);
 
@@ -849,6 +860,17 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
     });
     view.focus();
   }, [draftText, draftVersion]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view || completionStatus(view.state) !== 'active') return;
+    closeCompletion(view);
+    window.setTimeout(() => {
+      if (viewRef.current === view) {
+        startCompletion(view);
+      }
+    }, 0);
+  }, [language]);
 
   useEffect(() => {
     const view = viewRef.current;


### PR DESCRIPTION
## What this PR does

This improves the web-shell slash command completion panel so it escapes host containers that clip overflow, keeps its styling in sync with theme changes, and shows longer custom command and skill descriptions in a dedicated info panel aligned with the description column.

## Why it's needed

When web-shell is embedded inside another app, the slash command panel can be clipped or visually covered by surrounding layout. Long custom command and skill descriptions are also hard to inspect in the single-line completion list. This change keeps the completion list compact while making the full command description available without disturbing the main input layout.

## Reviewer Test Plan

### How to verify

Open web-shell, type `/` in the composer, and confirm the slash command panel is visible above surrounding content. Select a custom command or skill with a long description and confirm the info panel appears within the completion panel area, aligned to the description column, instead of jumping to the far right on wide viewports. Toggle light/dark theme and UI language while the panel is open and confirm the panel keeps the correct colors and refreshes localized section text.

### Evidence (Before & After)

Before: the slash command panel could be clipped by host layout and long descriptions were truncated without a focused full-description view.

After: the completion tooltip renders through a body-level portal, custom command and skill entries expose a full info panel, and the panel stays aligned with the description column across wide and narrow viewports.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Verified with `cd packages/web-shell && npx vitest run client/completions/slashCompletion.test.ts` and Prettier checks for the changed files.

## Risk & Scope

- Main risk or tradeoff: completion tooltip positioning is customized for the web-shell slash command panel, so future CodeMirror tooltip behavior changes may require revisiting this layout.
- Not validated / out of scope: browser top-layer UI such as native opened `<dialog>` elements can still appear above normal z-index stacking by design.
- Breaking changes / migration notes: none.
<img width="1426" height="1120" alt="image" src="https://github.com/user-attachments/assets/00c0a0bc-ec29-4358-838b-594028e801d0" />

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 优化了 web-shell 的斜杠命令补全面板，让它可以脱离会裁剪 overflow 的宿主容器，主题切换时保持样式同步，并为自定义命令和 skill 的长描述提供一个和描述列对齐的独立 info 面板。

## 为什么需要

当 web-shell 被嵌入外部应用时，斜杠命令面板可能被外层布局裁剪或遮挡。自定义命令和 skill 的长描述也很难在单行补全列表中完整查看。这个修改保持主列表紧凑，同时提供完整描述，不影响输入区布局。

## Reviewer Test Plan

### 如何验证

打开 web-shell，在输入框中输入 `/`，确认斜杠命令面板能显示在周围内容之上。选择带长描述的自定义命令或 skill，确认 info 面板显示在补全面板区域内，并和描述列对齐，而不是在宽屏时跳到很远的右侧。切换浅色/深色主题和 UI 语言，确认面板颜色正确，并刷新本地化分组文案。

### 证据（Before & After）

Before：斜杠命令面板可能被宿主布局裁剪，长描述只能在单行列表里被截断。

After：补全 tooltip 通过 body 级 portal 渲染，自定义命令和 skill 会展示完整 info 面板，并且在宽窄视口下都和描述列保持对齐。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### 环境（可选）

已通过 `cd packages/web-shell && npx vitest run client/completions/slashCompletion.test.ts` 和相关变更文件的 Prettier 检查验证。

## 风险与范围

- 主要风险或取舍：这里对 web-shell 斜杠命令面板的 CodeMirror tooltip 定位做了定制，未来如果 CodeMirror tooltip 行为变化，可能需要重新检查布局。
- 未验证 / 不在范围内：浏览器 top layer，例如原生打开的 `<dialog>`，按机制仍可能显示在普通 z-index 之上。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

N/A

</details>
