### PR TITLE
feat(web-shell): show message time on hover

### DIFF
--- a/packages/acp-bridge/src/bridgeClient.test.ts
+++ b/packages/acp-bridge/src/bridgeClient.test.ts
@@ -476,6 +476,66 @@ describe('BridgeClient — A2UI session update publishing', () => {
   });
 });
 
+describe('BridgeClient — original timestamp preservation', () => {
+  const noPermissionFlow = () => {
+    throw new Error('test: permission flow should not run');
+  };
+
+  function makeClientFor(sessionId: string, publish: ReturnType<typeof vi.fn>) {
+    const fakeEntry = { sessionId, events: { publish } };
+    return new BridgeClient(
+      ((sid: string) => (sid === sessionId ? fakeEntry : undefined)) as never,
+      noPermissionFlow as never,
+      { request: noPermissionFlow } as never,
+      0,
+      Infinity,
+    );
+  }
+
+  it('lifts a replayed update._meta.timestamp to the envelope serverTimestamp', async () => {
+    const publish = vi.fn().mockReturnValue(true);
+    const client = makeClientFor('sess:replay', publish);
+    // A previous-day epoch — must survive to the envelope so EventBus does not
+    // overwrite it with publish-time Date.now().
+    const original = 1_700_000_000_000;
+
+    await client.sessionUpdate({
+      sessionId: 'sess:replay',
+      update: {
+        sessionUpdate: 'user_message_chunk',
+        content: { type: 'text', text: 'hi' },
+        _meta: { timestamp: original },
+      },
+    } as Parameters<BridgeClient['sessionUpdate']>[0]);
+
+    expect(publish).toHaveBeenCalledTimes(1);
+    const frame = publish.mock.calls[0][0] as {
+      _meta?: { serverTimestamp?: number };
+    };
+    expect(frame._meta?.serverTimestamp).toBe(original);
+  });
+
+  it('passes no envelope _meta for live updates without a timestamp', async () => {
+    const publish = vi.fn().mockReturnValue(true);
+    const client = makeClientFor('sess:live', publish);
+
+    await client.sessionUpdate({
+      sessionId: 'sess:live',
+      update: {
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'yo' },
+      },
+    } as Parameters<BridgeClient['sessionUpdate']>[0]);
+
+    expect(publish).toHaveBeenCalledTimes(1);
+    const frame = publish.mock.calls[0][0] as {
+      _meta?: { serverTimestamp?: number };
+    };
+    // No envelope _meta → EventBus.publish applies its own Date.now() fallback.
+    expect(frame._meta).toBeUndefined();
+  });
+});
+
 /**
  * Wenshao review #4335 / 3271978365 — `requestPermission`'s pre-publish
  * `CancelSentinelCollisionError` guard prevents an orphan SSE

--- a/packages/acp-bridge/src/bridgeClient.ts
+++ b/packages/acp-bridge/src/bridgeClient.ts
@@ -431,10 +431,27 @@ export class BridgeClient implements Client {
       }
       params = a2ui.sanitizedParams;
     }
+    // History replay re-emits each persisted record carrying its ORIGINAL
+    // wall-clock time as an epoch-ms `timestamp` nested in `update._meta` (set
+    // by the message/tool emitters). Lift it to the envelope-level
+    // `serverTimestamp` so `EventBus.publish` preserves it instead of stamping
+    // publish-time `Date.now()` — otherwise a resumed session renders every
+    // historical message at the resume moment instead of when it was sent.
+    // Live updates without such a timestamp pass no envelope `_meta` and keep
+    // the EventBus `Date.now()` fallback unchanged.
+    const updateMeta = (params.update as { _meta?: Record<string, unknown> })
+      ._meta;
+    const originalTs =
+      updateMeta?.['serverTimestamp'] ?? updateMeta?.['timestamp'];
+    const serverTimestamp =
+      typeof originalTs === 'number' && Number.isFinite(originalTs)
+        ? originalTs
+        : undefined;
     events.publish({
       type: 'session_update',
       data: params,
       ...originator,
+      ...(serverTimestamp !== undefined ? { _meta: { serverTimestamp } } : {}),
     });
   }
 

--- a/packages/web-shell/client/adapters/messageTypes.ts
+++ b/packages/web-shell/client/adapters/messageTypes.ts
@@ -60,14 +60,28 @@ export interface DaemonMessageTodoItem {
   priority?: 'high' | 'medium' | 'low';
 }
 
-export interface DaemonUserMessage {
+/**
+ * Fields shared by every history message. Kept as a base interface so a new
+ * cross-cutting field is declared once rather than on each role.
+ */
+export interface DaemonMessageMeta {
+  /**
+   * Wall-clock epoch milliseconds when the backing transcript block was first
+   * observed, populated from `serverTimestamp ?? clientReceivedAt`. Surfaced
+   * as a hover tooltip in the message list. Undefined for synthetic messages
+   * that have no backing block.
+   */
+  timestamp?: number;
+}
+
+export interface DaemonUserMessage extends DaemonMessageMeta {
   id: string;
   role: 'user';
   content: string;
   images?: Array<{ data: string; mimeType: string }>;
 }
 
-export interface DaemonAssistantMessage {
+export interface DaemonAssistantMessage extends DaemonMessageMeta {
   id: string;
   role: 'assistant';
   content: string;
@@ -75,19 +89,19 @@ export interface DaemonAssistantMessage {
   isStreaming?: boolean;
 }
 
-export interface DaemonToolGroupMessage {
+export interface DaemonToolGroupMessage extends DaemonMessageMeta {
   id: string;
   role: 'tool_group';
   tools: DaemonMessageToolCall[];
 }
 
-export interface DaemonPlanMessage {
+export interface DaemonPlanMessage extends DaemonMessageMeta {
   id: string;
   role: 'plan';
   todos: DaemonMessageTodoItem[];
 }
 
-export interface DaemonSystemMessage {
+export interface DaemonSystemMessage extends DaemonMessageMeta {
   id: string;
   role: 'system';
   content: string;
@@ -95,7 +109,7 @@ export interface DaemonSystemMessage {
   retryable?: boolean;
 }
 
-export interface DaemonUserShellMessage {
+export interface DaemonUserShellMessage extends DaemonMessageMeta {
   id: string;
   role: 'user_shell';
   command: string;
@@ -103,7 +117,7 @@ export interface DaemonUserShellMessage {
   cwd?: string;
 }
 
-export interface DaemonBtwMessage {
+export interface DaemonBtwMessage extends DaemonMessageMeta {
   id: string;
   role: 'btw';
   question: string;
@@ -111,7 +125,7 @@ export interface DaemonBtwMessage {
   isPending: boolean;
 }
 
-export interface DaemonInsightProgressMessage {
+export interface DaemonInsightProgressMessage extends DaemonMessageMeta {
   id: string;
   role: 'insight_progress';
   stage: string;
@@ -119,13 +133,13 @@ export interface DaemonInsightProgressMessage {
   detail?: string;
 }
 
-export interface DaemonInsightReadyMessage {
+export interface DaemonInsightReadyMessage extends DaemonMessageMeta {
   id: string;
   role: 'insight_ready';
   path: string;
 }
 
-export interface DaemonInsightErrorMessage {
+export interface DaemonInsightErrorMessage extends DaemonMessageMeta {
   id: string;
   role: 'insight_error';
   error: string;

--- a/packages/web-shell/client/adapters/transcriptToMessages.test.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.test.ts
@@ -148,6 +148,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
       {
         id: 'plan-1',
         role: 'plan',
+        timestamp: 1,
         todos: [
           {
             id: 'plan-0',
@@ -183,6 +184,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
       {
         id: 'plan-1',
         role: 'plan',
+        timestamp: 1,
         todos: [
           {
             id: 'plan-1',
@@ -231,6 +233,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
       {
         id: 'tg-todo-1',
         role: 'tool_group',
+        timestamp: 1,
         tools: [
           expect.objectContaining({
             callId: 'todo-call-1',
@@ -255,6 +258,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
       {
         id: 'tg-t1',
         role: 'tool_group',
+        timestamp: 1,
         tools: [
           expect.objectContaining({ callId: 'tc1', toolName: 'Read' }),
           expect.objectContaining({ callId: 'tc2', toolName: 'Grep' }),
@@ -378,6 +382,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
       {
         id: 'insight-1-ip',
         role: 'insight_progress',
+        timestamp: 1,
         stage: 'scan',
         progress: 0.5,
         detail: 'reading',
@@ -396,11 +401,36 @@ describe('transcriptBlocksToDaemonMessages', () => {
     ]);
 
     expect(messages).toEqual([
-      { id: 'insight-1-t-0', role: 'assistant', content: 'before' },
-      { id: 'insight-1-ir-0', role: 'insight_ready', path: '/tmp/report.md' },
-      { id: 'insight-1-t-2', role: 'assistant', content: 'middle' },
-      { id: 'insight-1-ie-0', role: 'insight_error', error: 'boom' },
-      { id: 'insight-1-t-4', role: 'assistant', content: 'after' },
+      {
+        id: 'insight-1-t-0',
+        role: 'assistant',
+        content: 'before',
+        timestamp: 1,
+      },
+      {
+        id: 'insight-1-ir-0',
+        role: 'insight_ready',
+        path: '/tmp/report.md',
+        timestamp: 1,
+      },
+      {
+        id: 'insight-1-t-2',
+        role: 'assistant',
+        content: 'middle',
+        timestamp: 1,
+      },
+      {
+        id: 'insight-1-ie-0',
+        role: 'insight_error',
+        error: 'boom',
+        timestamp: 1,
+      },
+      {
+        id: 'insight-1-t-4',
+        role: 'assistant',
+        content: 'after',
+        timestamp: 1,
+      },
     ]);
   });
 
@@ -813,6 +843,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
         role: 'assistant',
         content: 'hello world',
         isStreaming: false,
+        timestamp: 1,
       },
     ]);
   });
@@ -1876,6 +1907,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
         content: 'Connection lost',
         variant: 'error',
         retryable: false,
+        timestamp: 1,
       },
     ]);
   });
@@ -1900,6 +1932,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
         content: 'Request failed',
         variant: 'error',
         retryable: true,
+        timestamp: 1,
       },
     ]);
   });
@@ -1922,6 +1955,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
         role: 'system',
         content: 'Session initialized',
         variant: 'info',
+        timestamp: 1,
       },
     ]);
   });
@@ -1938,6 +1972,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
         content: '',
         thinking: 'let me think about this',
         isStreaming: false,
+        timestamp: 1,
       },
     ]);
   });
@@ -2008,9 +2043,21 @@ describe('transcriptBlocksToDaemonMessages', () => {
     ]);
 
     expect(messages).toEqual([
-      { id: 'a1', role: 'assistant', content: 'first', isStreaming: false },
-      { id: 'u1', role: 'user', content: 'question' },
-      { id: 'a2', role: 'assistant', content: 'second', isStreaming: false },
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: 'first',
+        isStreaming: false,
+        timestamp: 1,
+      },
+      { id: 'u1', role: 'user', content: 'question', timestamp: 2 },
+      {
+        id: 'a2',
+        role: 'assistant',
+        content: 'second',
+        isStreaming: false,
+        timestamp: 3,
+      },
     ]);
   });
 
@@ -2027,6 +2074,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
         content: 'here is my answer',
         thinking: 'analyzing...',
         isStreaming: false,
+        timestamp: 1,
       },
     ]);
   });
@@ -2074,6 +2122,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
         role: 'system',
         content: 'Request cancelled.',
         variant: 'info',
+        timestamp: 20,
       },
     ]);
   });
@@ -2090,6 +2139,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
         role: 'system',
         content: '请求已取消。',
         variant: 'info',
+        timestamp: 20,
       },
     ]);
   });

--- a/packages/web-shell/client/adapters/transcriptToMessages.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.ts
@@ -85,6 +85,10 @@ export function transcriptBlocksToDaemonMessages(
 
   for (let i = 0; i < blocks.length; i++) {
     const block = blocks[i];
+    // Wall-clock of this block, surfaced as a hover tooltip on the rendered
+    // message. Prefer the daemon-authoritative stamp so every client agrees;
+    // fall back to the local receive time when the daemon left it unset.
+    const blockTime = block.serverTimestamp ?? block.clientReceivedAt;
 
     switch (block.kind) {
       case 'user': {
@@ -95,6 +99,7 @@ export function transcriptBlocksToDaemonMessages(
           id: block.id,
           role: 'user',
           content: textBlock.text,
+          timestamp: blockTime,
         };
         // Attach images if present
         if (textBlock.images && textBlock.images.length > 0) {
@@ -134,6 +139,7 @@ export function transcriptBlocksToDaemonMessages(
                   id: `${block.id}-ir-${readyCount++}`,
                   role: 'insight_ready',
                   path: seg.data.path,
+                  timestamp: blockTime,
                 });
               } else if (seg.data.type === 'insight_error') {
                 hasTerminal = true;
@@ -141,6 +147,7 @@ export function transcriptBlocksToDaemonMessages(
                   id: `${block.id}-ie-${errorCount++}`,
                   role: 'insight_error',
                   error: seg.data.error,
+                  timestamp: blockTime,
                 });
               }
             } else {
@@ -148,6 +155,7 @@ export function transcriptBlocksToDaemonMessages(
                 id: `${block.id}-t-${messages.length}`,
                 role: 'assistant',
                 content: seg.text,
+                timestamp: blockTime,
               });
               currentAssistantIdx = messages.length - 1;
             }
@@ -159,6 +167,7 @@ export function transcriptBlocksToDaemonMessages(
               stage: lastProgress.stage,
               progress: lastProgress.progress,
               detail: lastProgress.detail,
+              timestamp: blockTime,
             });
           }
           needsNewContentMessage = true;
@@ -182,6 +191,7 @@ export function transcriptBlocksToDaemonMessages(
             role: 'assistant',
             content: textBlock.text,
             isStreaming: textBlock.streaming,
+            timestamp: blockTime,
           });
           currentAssistantIdx = messages.length - 1;
           needsNewContentMessage = false;
@@ -221,6 +231,7 @@ export function transcriptBlocksToDaemonMessages(
             content: '',
             thinking: textBlock.text,
             isStreaming: textBlock.streaming,
+            timestamp: blockTime,
           });
           currentAssistantIdx = messages.length - 1;
           needsNewContentMessage = false;
@@ -254,7 +265,7 @@ export function transcriptBlocksToDaemonMessages(
           break;
         }
 
-        appendToolCallMessage(messages, block.id, toolCall);
+        appendToolCallMessage(messages, block.id, toolCall, blockTime);
         toolsByCallId.set(toolCall.callId, toolCall);
         needsNewContentMessage = true;
         break;
@@ -300,6 +311,7 @@ export function transcriptBlocksToDaemonMessages(
                 rawOutput: shellBlock.text,
               },
             ],
+            timestamp: blockTime,
           });
           needsNewContentMessage = true;
         }
@@ -314,6 +326,7 @@ export function transcriptBlocksToDaemonMessages(
           command: shellBlock.command,
           output: shellBlock.text,
           ...(shellBlock.cwd ? { cwd: shellBlock.cwd } : {}),
+          timestamp: blockTime,
         });
         needsNewContentMessage = true;
         break;
@@ -367,13 +380,23 @@ export function transcriptBlocksToDaemonMessages(
             if (!isSubAgentPermission) {
               permissionToolCall.status = 'in_progress';
             }
-            appendToolCallMessage(messages, block.id, permissionToolCall);
+            appendToolCallMessage(
+              messages,
+              block.id,
+              permissionToolCall,
+              blockTime,
+            );
             toolsByCallId.set(permissionToolCall.callId, permissionToolCall);
             needsNewContentMessage = true;
           } else {
             permissionToolCall.status = 'failed';
             permissionToolCall.endTime = permBlock.updatedAt;
-            appendToolCallMessage(messages, block.id, permissionToolCall);
+            appendToolCallMessage(
+              messages,
+              block.id,
+              permissionToolCall,
+              blockTime,
+            );
             toolsByCallId.set(permissionToolCall.callId, permissionToolCall);
             needsNewContentMessage = true;
           }
@@ -392,6 +415,7 @@ export function transcriptBlocksToDaemonMessages(
             id: block.id,
             role: 'plan',
             todos,
+            timestamp: blockTime,
           });
           needsNewContentMessage = true;
           break;
@@ -405,6 +429,7 @@ export function transcriptBlocksToDaemonMessages(
           role: 'system',
           content: text,
           variant: 'info',
+          timestamp: blockTime,
         });
         needsNewContentMessage = true;
         break;
@@ -418,6 +443,7 @@ export function transcriptBlocksToDaemonMessages(
           content: errorBlock.text,
           variant: 'error',
           retryable: errorBlock.source === 'turn_error',
+          timestamp: blockTime,
         });
         needsNewContentMessage = true;
         break;
@@ -429,6 +455,7 @@ export function transcriptBlocksToDaemonMessages(
           role: 'system',
           content: promptCancelledText,
           variant: 'info',
+          timestamp: blockTime,
         });
         needsNewContentMessage = true;
         break;
@@ -457,6 +484,7 @@ function appendToolCallMessage(
   messages: DaemonMessage[],
   blockId: string,
   toolCall: DaemonMessageToolCall,
+  timestamp?: number,
 ): void {
   // Native CLI groups every tool call of one scheduler batch into a single
   // bordered tool_group (mapToDisplay in useReactToolScheduler). The daemon
@@ -485,6 +513,7 @@ function appendToolCallMessage(
     id: `tg-${blockId}`,
     role: 'tool_group',
     tools: [toolCall],
+    timestamp,
   });
 }
 

--- a/packages/web-shell/client/components/MessageItem.tsx
+++ b/packages/web-shell/client/components/MessageItem.tsx
@@ -1,10 +1,11 @@
-import { memo } from 'react';
+import { memo, type ReactElement } from 'react';
 import type {
   ACPToolCall,
   Message,
   PermissionRequest,
   TodoItem,
 } from '../adapters/types';
+import { MessageTimestamp } from './MessageTimestamp';
 import { UserMessage } from './messages/UserMessage';
 import { AssistantMessage } from './messages/AssistantMessage';
 import { SystemMessage } from './messages/SystemMessage';
@@ -43,73 +44,83 @@ export const MessageItem = memo(function MessageItem({
   onRetryClick,
   shellOutputMaxLines,
 }: MessageItemProps) {
-  switch (message.role) {
-    case 'user':
-      return <UserMessage content={message.content} images={message.images} />;
-    case 'assistant':
-      return (
-        <AssistantMessage
-          content={message.content}
-          thinking={message.thinking}
-          isStreaming={message.isStreaming}
-        />
-      );
-    case 'tool_group':
-      return (
-        <ToolGroup
-          tools={message.tools}
-          pendingApproval={pendingApproval}
-          onConfirm={onConfirm}
-          workspaceCwd={workspaceCwd}
-          shellOutputMaxLines={shellOutputMaxLines}
-        />
-      );
-    case 'plan':
-      return <PlanMessage todos={message.todos} />;
-    case 'system':
-      return (
-        <SystemMessage
-          content={message.content}
-          variant={message.variant}
-          onShowContextDetail={onShowContextDetail}
-          isLatest={isLatest}
-          showRetryHint={showRetryHint && message.retryable === true}
-          onRetryClick={onRetryClick}
-        />
-      );
-    case 'user_shell':
-      return (
-        <UserShellMessage command={message.command} output={message.output} />
-      );
-    case 'btw':
-      return (
-        <BtwMessage
-          question={message.question}
-          answer={message.answer}
-          isPending={message.isPending}
-        />
-      );
-    case 'insight_progress':
-      return (
-        <InsightProgress
-          progress={{
-            stage: message.stage,
-            progress: message.progress,
-            detail: message.detail,
-          }}
-        />
-      );
-    case 'insight_ready':
-      return <InsightReady path={message.path} />;
-    case 'insight_error':
-      return (
-        <div style={{ color: 'var(--error-color, #e06c75)' }}>
-          {message.error}
-        </div>
-      );
-    default:
-      return null;
-  }
+  const body = ((): ReactElement | null => {
+    switch (message.role) {
+      case 'user':
+        return (
+          <UserMessage content={message.content} images={message.images} />
+        );
+      case 'assistant':
+        return (
+          <AssistantMessage
+            content={message.content}
+            thinking={message.thinking}
+            isStreaming={message.isStreaming}
+          />
+        );
+      case 'tool_group':
+        return (
+          <ToolGroup
+            tools={message.tools}
+            pendingApproval={pendingApproval}
+            onConfirm={onConfirm}
+            workspaceCwd={workspaceCwd}
+            shellOutputMaxLines={shellOutputMaxLines}
+          />
+        );
+      case 'plan':
+        return <PlanMessage todos={message.todos} />;
+      case 'system':
+        return (
+          <SystemMessage
+            content={message.content}
+            variant={message.variant}
+            onShowContextDetail={onShowContextDetail}
+            isLatest={isLatest}
+            showRetryHint={showRetryHint && message.retryable === true}
+            onRetryClick={onRetryClick}
+          />
+        );
+      case 'user_shell':
+        return (
+          <UserShellMessage command={message.command} output={message.output} />
+        );
+      case 'btw':
+        return (
+          <BtwMessage
+            question={message.question}
+            answer={message.answer}
+            isPending={message.isPending}
+          />
+        );
+      case 'insight_progress':
+        return (
+          <InsightProgress
+            progress={{
+              stage: message.stage,
+              progress: message.progress,
+              detail: message.detail,
+            }}
+          />
+        );
+      case 'insight_ready':
+        return <InsightReady path={message.path} />;
+      case 'insight_error':
+        return (
+          <div style={{ color: 'var(--error-color, #e06c75)' }}>
+            {message.error}
+          </div>
+        );
+      default:
+        return null;
+    }
+  })();
+
+  if (body === null) return null;
+
+  return (
+    <MessageTimestamp timestamp={message.timestamp}>{body}</MessageTimestamp>
+  );
 }, areMessageItemPropsEqual);
 
 function areMessageItemPropsEqual(
@@ -130,6 +141,7 @@ function areMessageItemPropsEqual(
 function areMessagesEqual(prev: Message, next: Message): boolean {
   if (prev === next) return true;
   if (prev.id !== next.id || prev.role !== next.role) return false;
+  if (prev.timestamp !== next.timestamp) return false;
   switch (prev.role) {
     case 'user':
       return (

--- a/packages/web-shell/client/components/MessageTimestamp.module.css
+++ b/packages/web-shell/client/components/MessageTimestamp.module.css
@@ -1,0 +1,28 @@
+.row {
+  position: relative;
+}
+
+/*
+ * Anchored inside the message's top-right corner rather than floating above
+ * it: the message list (`.list`) is `overflow-y: auto`, so a tooltip spilling
+ * outside the row box would be clipped or trigger a scrollbar. Staying within
+ * the row keeps it visible at the scroll edges. `pointer-events: none` lets
+ * clicks and inner hover interactions (tool expand, links) pass through.
+ */
+.tip {
+  position: absolute;
+  top: 2px;
+  right: 4px;
+  z-index: 5;
+  color: var(--text-dimmed);
+  font-size: 11px;
+  line-height: 1.4;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
+.row:hover > .tip {
+  opacity: 1;
+}

--- a/packages/web-shell/client/components/MessageTimestamp.test.tsx
+++ b/packages/web-shell/client/components/MessageTimestamp.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import { act, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { MessageTimestamp, formatTimestamp } from './MessageTimestamp';
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+afterEach(() => {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+});
+
+function render(node: ReactNode): HTMLElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(node));
+  mounted.push({ root, container });
+  return container;
+}
+
+describe('formatTimestamp', () => {
+  // Built from local-time parts so expectations are timezone independent
+  // (month is 0-based: 5 = June).
+  const now = new Date(2026, 5, 13, 12, 0, 0);
+
+  it('shows only HH:mm:ss for a same-day timestamp', () => {
+    const ts = new Date(2026, 5, 13, 9, 8, 7).getTime();
+    expect(formatTimestamp(ts, now)).toBe('09:08:07');
+  });
+
+  it('shows full yyyy-MM-dd HH:mm:ss for an earlier day in the same year', () => {
+    const ts = new Date(2026, 0, 2, 9, 8, 7).getTime();
+    expect(formatTimestamp(ts, now)).toBe('2026-01-02 09:08:07');
+  });
+
+  it('shows full yyyy-MM-dd HH:mm:ss for a previous year', () => {
+    // Same month/day as `now` but last year — must not be read as "today".
+    const ts = new Date(2025, 5, 13, 9, 8, 7).getTime();
+    expect(formatTimestamp(ts, now)).toBe('2025-06-13 09:08:07');
+  });
+});
+
+describe('MessageTimestamp', () => {
+  it('reveals the wall-clock time as a hover tooltip when a timestamp is set', () => {
+    const ts = new Date(2026, 5, 13, 9, 8, 7).getTime();
+    const container = render(
+      <MessageTimestamp timestamp={ts}>
+        <div>body</div>
+      </MessageTimestamp>,
+    );
+
+    const tip = container.querySelector('span[aria-hidden="true"]');
+    expect(tip).not.toBeNull();
+    // Every variant ends in HH:mm:ss; the leading parts depend on the real
+    // "now", so assert the shape rather than an exact string here.
+    expect(tip?.textContent).toMatch(/\d{2}:\d{2}:\d{2}$/);
+    expect(container.textContent).toContain('body');
+  });
+
+  it('renders children unchanged with no tooltip when timestamp is undefined', () => {
+    const container = render(
+      <MessageTimestamp>
+        <div data-testid="child">body</div>
+      </MessageTimestamp>,
+    );
+
+    expect(container.querySelector('span[aria-hidden="true"]')).toBeNull();
+    // No wrapper element is introduced: the child stays a direct child of the
+    // mount container, so message spacing/structure is untouched.
+    const child = container.querySelector('[data-testid="child"]');
+    expect(child).not.toBeNull();
+    expect(child?.parentElement).toBe(container);
+  });
+});

--- a/packages/web-shell/client/components/MessageTimestamp.tsx
+++ b/packages/web-shell/client/components/MessageTimestamp.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from 'react';
+import styles from './MessageTimestamp.module.css';
+
+interface MessageTimestampProps {
+  /** Wall-clock epoch ms of the message; omitted for synthetic messages. */
+  timestamp?: number;
+  children: ReactNode;
+}
+
+/**
+ * Wraps a rendered history message and reveals its wall-clock time as a
+ * CSS-only tooltip on hover. When the message carries no timestamp the
+ * children render unchanged, so no empty wrapper is introduced.
+ */
+export function MessageTimestamp({
+  timestamp,
+  children,
+}: MessageTimestampProps) {
+  if (timestamp === undefined) {
+    return <>{children}</>;
+  }
+  return (
+    <div className={styles.row}>
+      {children}
+      <span className={styles.tip} aria-hidden="true">
+        {formatTimestamp(timestamp)}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Local-time clock, dropping the date only for same-day timestamps:
+ * - same day → `HH:mm:ss`
+ * - earlier  → `yyyy-MM-dd HH:mm:ss`
+ *
+ * Fixed order and zero-padded (unlike toLocaleString) so stacked timestamps
+ * align. `now` is injectable so the branch logic is unit-testable without
+ * depending on the wall clock.
+ */
+export function formatTimestamp(ts: number, now: Date = new Date()): string {
+  const d = new Date(ts);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const hms = `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+  const sameDay =
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate();
+  if (sameDay) {
+    return hms;
+  }
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${hms}`;
+}


### PR DESCRIPTION
## What this PR does

Adds an on-hover timestamp to every message in the daemon **web-shell**, and fixes a daemon-side bug that made resumed sessions lose each message's original time. In the UI, every transcript message now carries its block's wall-clock time and reveals it as a CSS-only hover tooltip (anchored inside the row's top-right with `pointer-events: none`, so the `overflow-y: auto` message list never clips it and inner interactions still pass through). The time is shown in local time, zero-padded: same-day messages as `HH:mm:ss`, older ones as `yyyy-MM-dd HH:mm:ss`. On the daemon side, `BridgeClient.sessionUpdate` now lifts the replayed `update._meta.timestamp` up to the event envelope's `serverTimestamp` so it survives to the client.

## Why it's needed

When reviewing a conversation it is useful to see when each message was sent, and the web-shell had no such affordance. While adding it I found that resumed history showed the wrong time: every message from a previous-day session displayed today's time (the moment of resume) rather than when it was actually sent — so the new tooltip would have been misleading exactly where it is most useful. History replay (`MessageEmitter`) re-emits each persisted record with its original epoch-ms time nested in `update._meta.timestamp`, but `sessionUpdate` published the frame without lifting it to the envelope, so `EventBus.publish` stamped `_meta.serverTimestamp` with publish-time `Date.now()`, and the client's `extractServerTimestamp` reads the envelope value at higher priority than the nested original. Live messages were unaffected (their `Date.now()` ≈ the real time), which is why only `/resume` exposed it.

## Reviewer Test Plan

### How to verify

Unit tests cover both halves. acp-bridge: `cd packages/acp-bridge && npx vitest run` → 445 passed (incl. 2 new in `bridgeClient.test.ts` — one asserts a replayed `update._meta.timestamp` reaches the envelope `serverTimestamp`, the other asserts live updates without a timestamp emit no envelope `_meta` so the `Date.now()` fallback is unchanged). web-shell: `cd packages/web-shell && npx vitest run` → 250 passed (incl. 5 new for `formatTimestamp` same-day / previous-day / previous-year branches and `MessageTimestamp` rendering). Typecheck, eslint and prettier are clean for all touched files. For the end-to-end UI: restart the daemon (rebuild if you run from `dist`; `dev:daemon` runs from source via tsx), `/resume` a session created on a previous day, then hover its messages — older ones should read `yyyy-MM-dd HH:mm:ss`, today's `HH:mm:ss`.

### Evidence (Before & After)

Before: after resuming a previous-day session, every message's hover tooltip showed today's date/time (the resume moment). After: each message shows its original send time — same-day `HH:mm:ss`, older `yyyy-MM-dd HH:mm:ss`. Screenshots are not attached: this is the daemon web-shell, which I could not launch in my working environment, so the visual before/after needs a reviewer running the daemon. The underlying behavior is verified by the unit tests above (timestamp preservation in acp-bridge plus the formatter branches in web-shell).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

Unit tests only (vitest), on macOS. The daemon was not launched locally; the logic is platform-independent (TypeScript + CSS) and CI runs the suites on all three OSes.

## Risk & Scope

- Main risk or tradeoff: the acp-bridge change sets the envelope `serverTimestamp` from `update._meta.timestamp` for every `session_update`, not only replay. It is backward-compatible — live updates that carry no such timestamp pass no envelope `_meta`, so `EventBus.publish` keeps its existing `Date.now()` fallback; ordering is unaffected because the client orders by `eventId`, not `serverTimestamp`.
- Not validated / out of scope: the end-to-end UI was not exercised in a live daemon + browser (see Evidence); the parallel-agents aggregate view (`ParallelAgentsGroup`) is not routed through `MessageItem` and so has no hover tooltip — it aggregates multiple tool groups and has no single per-message time.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

为 daemon **web-shell** 的每条消息增加鼠标悬停显示时间，并修复一个导致 resume 历史会话丢失每条消息原始时间的 daemon 端 bug。在 UI 中，每条 transcript 消息现在都携带其 block 的墙钟时间，并以纯 CSS 的悬停 tooltip 呈现（定位在消息行右上角内侧，`pointer-events: none`，这样 `overflow-y: auto` 的消息列表不会裁切它，内部交互也能正常穿透）。时间按本地时区、补零显示：当天消息为 `HH:mm:ss`，更早的为 `yyyy-MM-dd HH:mm:ss`。在 daemon 端，`BridgeClient.sessionUpdate` 现在会把重放所携带的 `update._meta.timestamp` 提升到事件 envelope 的 `serverTimestamp`，使其能够传到客户端。

## Why it's needed

回看一段会话时，知道每条消息的发送时间很有用，而 web-shell 此前没有这个能力。在添加这个功能时我发现 resume 的历史显示了错误的时间：往日会话的每条消息都显示成了当天时间（resume 的时刻），而不是其实际发送时间——也就是说，恰恰在最需要它的场景下，这个新 tooltip 反而会产生误导。历史重放（`MessageEmitter`）会把每条持久化记录连同其原始的 epoch 毫秒时间一起重新发出，嵌在 `update._meta.timestamp` 中，但 `sessionUpdate` 在发布帧时没有把它提升到 envelope，于是 `EventBus.publish` 用发布时刻的 `Date.now()` 覆盖了 `_meta.serverTimestamp`，而客户端的 `extractServerTimestamp` 读取 envelope 值的优先级高于嵌套的原始值。实时消息不受影响（其 `Date.now()` ≈ 真实时间），这就是为什么只有 `/resume` 才会暴露这个问题。

## Reviewer Test Plan

### How to verify

单元测试覆盖了两部分。acp-bridge：`cd packages/acp-bridge && npx vitest run` → 445 通过（含 `bridgeClient.test.ts` 中 2 个新测试——一个断言重放的 `update._meta.timestamp` 能到达 envelope 的 `serverTimestamp`，另一个断言不带时间戳的实时更新不会发出 envelope `_meta`，从而保持 `Date.now()` 回退不变）。web-shell：`cd packages/web-shell && npx vitest run` → 250 通过（含 5 个新测试，覆盖 `formatTimestamp` 的当天 / 往日 / 往年分支以及 `MessageTimestamp` 渲染）。所有改动文件的 typecheck、eslint、prettier 均干净。端到端 UI：重启 daemon（若从 `dist` 运行需先重新构建；`dev:daemon` 通过 tsx 从源码运行），`/resume` 一个往日创建的会话，然后悬停其消息——更早的应显示 `yyyy-MM-dd HH:mm:ss`，当天的显示 `HH:mm:ss`。

### Evidence (Before & After)

之前：resume 一个往日会话后，每条消息的悬停 tooltip 显示当天日期/时间（resume 时刻）。之后：每条消息显示其原始发送时间——当天 `HH:mm:ss`，更早 `yyyy-MM-dd HH:mm:ss`。未附截图：这是 daemon web-shell，我在工作环境中无法启动它，因此视觉上的前后对比需要 reviewer 运行 daemon 来确认。底层行为已由上述单元测试验证（acp-bridge 的时间戳保留，以及 web-shell 的格式化分支）。

### Tested on

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ 已测试 · ⚠️ 未测试 · N/A -->

### Environment (optional)

仅单元测试（vitest），在 macOS 上运行。未在本地启动 daemon；该逻辑与平台无关（TypeScript + CSS），且 CI 会在三个操作系统上运行测试套件。

## Risk & Scope

- 主要风险或权衡：acp-bridge 的改动会为每个 `session_update`（不仅是重放）从 `update._meta.timestamp` 设置 envelope `serverTimestamp`。它是向后兼容的——不带该时间戳的实时更新不会传 envelope `_meta`，因此 `EventBus.publish` 保持其原有的 `Date.now()` 回退；排序不受影响，因为客户端按 `eventId` 排序，而非 `serverTimestamp`。
- 未验证 / 不在范围：未在真实运行的 daemon + 浏览器中执行端到端 UI 验证（见 Evidence）；并行 agent 聚合视图（`ParallelAgentsGroup`）不经过 `MessageItem`，因此没有悬停 tooltip——它聚合了多个 tool group，没有单一的每条消息时间。
- 破坏性变更 / 迁移说明：无。

## Linked Issues

N/A

</details>

<img width="3018" height="328" alt="image" src="https://github.com/user-attachments/assets/c858d3ac-e748-4cd6-95ba-292a71abf0b0" />
