### PR TITLE
feat(desktop): show git branch in working directory badge

### DIFF
--- a/packages/desktop/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
+++ b/packages/desktop/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
@@ -11,6 +11,7 @@ import {
   ChevronDown,
   AlertCircle,
   CornerDownRight,
+  GitBranch,
   X,
 } from 'lucide-react';
 import { Icon_Home, Icon_Folder } from '@craft-agent/ui';
@@ -2753,15 +2754,22 @@ function WorkingDirectoryBadge({
 
   // Fetch git branch when working directory changes
   React.useEffect(() => {
+    let cancelled = false;
+    setGitBranch(null);
+
     if (workingDirectory) {
       window.electronAPI
         ?.getGitBranch?.(workingDirectory)
         .then((branch: string | null) => {
-          setGitBranch(branch);
+          if (!cancelled) {
+            setGitBranch(branch);
+          }
         });
-    } else {
-      setGitBranch(null);
     }
+
+    return () => {
+      cancelled = true;
+    };
   }, [workingDirectory]);
 
   // Reset filter, refresh history, and focus input when popover opens
@@ -2833,6 +2841,7 @@ function WorkingDirectoryBadge({
   const folderName = hasFolder
     ? getPathBasename(workingDirectory) || 'Folder'
     : 'Work in Folder';
+  const visibleGitBranch = hasFolder ? gitBranch : null;
 
   // Show reset option when a folder is selected and it differs from session folder
   const showReset =
@@ -2854,6 +2863,21 @@ function WorkingDirectoryBadge({
             <FreeFormInputContextBadge
               icon={<Icon_Home className="h-4 w-4" />}
               label={folderName}
+              ariaLabel={
+                visibleGitBranch
+                  ? `${folderName}, ${t('chat.onBranch', {
+                      branch: visibleGitBranch,
+                    })}`
+                  : folderName
+              }
+              trailingContent={
+                visibleGitBranch ? (
+                  <span className="inline-flex min-w-0 max-w-[120px] shrink items-center gap-1 text-muted-foreground">
+                    <GitBranch className="h-3 w-3 shrink-0" />
+                    <span className="truncate">{visibleGitBranch}</span>
+                  </span>
+                ) : undefined
+              }
               isExpanded={isEmptySession}
               hasSelection={hasFolder}
               showChevron={true}

--- a/packages/desktop/apps/electron/src/renderer/components/app-shell/input/FreeFormInputContextBadge.tsx
+++ b/packages/desktop/apps/electron/src/renderer/components/app-shell/input/FreeFormInputContextBadge.tsx
@@ -9,6 +9,10 @@ export interface FreeFormInputContextBadgeProps {
   icon: React.ReactNode
   /** Label text - shown in expanded state or collapsed with selection */
   label: string
+  /** Accessible label for the full badge when visible metadata is appended */
+  ariaLabel?: string
+  /** Optional trailing metadata shown after the label */
+  trailingContent?: React.ReactNode
   /** Whether to show expanded state (icon + label + chevron) vs collapsed */
   isExpanded?: boolean
   /** Whether there's an active selection (affects collapsed state styling and shows label) */
@@ -45,6 +49,8 @@ export const FreeFormInputContextBadge = React.forwardRef<HTMLButtonElement, Fre
     {
       icon,
       label,
+      ariaLabel,
+      trailingContent,
       isExpanded = false,
       hasSelection = false,
       showChevron = false,
@@ -68,7 +74,7 @@ export const FreeFormInputContextBadge = React.forwardRef<HTMLButtonElement, Fre
       <button
         ref={mergedRef as React.Ref<HTMLButtonElement>}
         type="button"
-        aria-label={label}
+        aria-label={ariaLabel ?? label}
         onClick={onClick}
         disabled={disabled}
         data-tutorial={dataTutorial}
@@ -106,6 +112,8 @@ export const FreeFormInputContextBadge = React.forwardRef<HTMLButtonElement, Fre
             </FadingText>
           )
         )}
+
+        {showLabel && trailingContent}
 
         {/* Optional chevron - only in expanded state */}
         {isExpanded && showChevron && (


### PR DESCRIPTION
## What this PR does

Shows the current git branch directly inside the Desktop working-directory badge, next to the selected folder name. The branch still comes from the existing `getGitBranch` renderer API, and the badge accessible label now includes the branch when present. The branch value is cleared while a new folder lookup is pending so switching workspaces cannot leave a stale branch visible.

## Why it's needed

Desktop already had the branch in a tooltip, but that is easy to miss. Making it visible in the input context area helps users confirm the active repo branch before sending a prompt.

## Reviewer Test Plan

### How to verify

Launch Desktop, choose a working directory that is a git repo, and confirm the current branch appears next to the folder badge. Switch to another repo or a non-git folder and confirm the branch updates or disappears instead of keeping the old value. Hover the badge and confirm the tooltip still shows the full path and branch details.

### Evidence (Before & After)

Not captured locally; this is a Draft PR. I verified the renderer build and targeted lint checks below.

Verified locally:

- `npx --yes prettier@3.5.3 --check packages/desktop/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx packages/desktop/apps/electron/src/renderer/components/app-shell/input/FreeFormInputContextBadge.tsx`
- `git diff --check`
- `npx --yes bun@latest run eslint src/renderer/components/app-shell/input/FreeFormInputContextBadge.tsx --no-warn-ignored`
- `npx --yes bun@latest run eslint src/renderer/components/app-shell/input/FreeFormInput.tsx --no-warn-ignored --no-inline-config` (passes with one existing `react-hooks/exhaustive-deps` warning)
- `npx --yes bun@latest run build:renderer`

Full `bun run lint` and `bun run typecheck` were also checked, but both currently fail on unrelated baseline issues in the Desktop package (`import/no-internal-modules` rule config, existing test tuple types, and missing `vitest` types).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ build and targeted lint |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS, Bun via `npx --yes bun@latest`, Desktop renderer build.

## Risk & Scope

- Main risk or tradeoff: The branch is an extra label in a compact input badge, so it is truncated to keep the composer stable.
- Not validated / out of scope: No screenshot was captured and there is no dedicated renderer component test for the nested badge path.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #4769

<details>
<summary>中文说明</summary>

## What this PR does

在 Desktop 的工作目录 badge 里直接显示当前 git branch，位置在已选文件夹名旁边。branch 仍然来自现有的 `getGitBranch` renderer API；如果存在 branch，badge 的 accessible label 也会包含它。切换工作目录时会先清空 branch，避免新的文件夹查询还没完成时残留旧 branch。

## Why it's needed

Desktop 之前只在 tooltip 里显示 branch，不太容易发现。把它展示在输入区上下文里，可以让用户在发送 prompt 前确认当前 repo branch。

## Reviewer Test Plan

### How to verify

启动 Desktop，选择一个 git repo 作为工作目录，确认当前 branch 出现在文件夹 badge 旁边。切到另一个 repo 或非 git 文件夹，确认 branch 会更新或消失，而不是保留旧值。hover badge，确认 tooltip 仍然显示完整路径和 branch 信息。

### Evidence (Before & After)

本地没有截图；这是 Draft PR。我已经验证了 renderer build 和 targeted lint checks。

本地验证：

- `npx --yes prettier@3.5.3 --check packages/desktop/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx packages/desktop/apps/electron/src/renderer/components/app-shell/input/FreeFormInputContextBadge.tsx`
- `git diff --check`
- `npx --yes bun@latest run eslint src/renderer/components/app-shell/input/FreeFormInputContextBadge.tsx --no-warn-ignored`
- `npx --yes bun@latest run eslint src/renderer/components/app-shell/input/FreeFormInput.tsx --no-warn-ignored --no-inline-config`（通过，但有一个现有的 `react-hooks/exhaustive-deps` warning）
- `npx --yes bun@latest run build:renderer`

也检查了完整的 `bun run lint` 和 `bun run typecheck`，但两者目前都会因为 Desktop package 中无关的基线问题失败（`import/no-internal-modules` rule config、现有测试 tuple type、缺少 `vitest` types）。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ build and targeted lint |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS，Bun 通过 `npx --yes bun@latest`，Desktop renderer build。

## Risk & Scope

- Main risk or tradeoff: branch 会作为额外文本显示在紧凑的 input badge 里，所以做了截断，避免 composer 布局不稳定。
- Not validated / out of scope: 没有本地截图，也没有给这个嵌套 badge 路径补专门的 renderer component test。
- Breaking changes / migration notes: 无。

## Linked Issues

Fixes #4769

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
