### PR TITLE
feat(web-shell): show time on parallel-agents box and sub-agent tools

### DIFF
--- a/packages/web-shell/client/components/MessageList.test.ts
+++ b/packages/web-shell/client/components/MessageList.test.ts
@@ -8,7 +8,11 @@ import {
   VIRTUAL_SCROLL_THRESHOLD,
 } from './MessageList';
 
-function makeAgentToolGroup(id: string, toolName = 'Agent'): Message {
+function makeAgentToolGroup(
+  id: string,
+  toolName = 'Agent',
+  timestamp?: number,
+): Message {
   return {
     id,
     role: 'tool_group',
@@ -20,6 +24,7 @@ function makeAgentToolGroup(id: string, toolName = 'Agent'): Message {
         args: { description: `task ${id}` },
       },
     ],
+    ...(timestamp !== undefined ? { timestamp } : {}),
   };
 }
 
@@ -99,6 +104,18 @@ describe('groupParallelAgents', () => {
       expect(items[0].agents).toHaveLength(3);
       expect(items[0].agents[0].callId).toBe('call-1');
       expect(items[0].agents[2].callId).toBe('call-3');
+    }
+  });
+
+  it('carries the first launch time onto the grouped parallel-agents row', () => {
+    const msgs = [
+      makeAgentToolGroup('1', 'Agent', 1000),
+      makeAgentToolGroup('2', 'Agent', 2000),
+    ];
+    const items = groupParallelAgents(msgs);
+    expect(items[0].type).toBe('parallel_agents');
+    if (items[0].type === 'parallel_agents') {
+      expect(items[0].timestamp).toBe(1000);
     }
   });
 

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -20,6 +20,7 @@ import {
 } from '../adapters/toolClassification';
 import { CompactModeContext } from '../App';
 import { MessageItem } from './MessageItem';
+import { MessageTimestamp } from './MessageTimestamp';
 import { ParallelAgentsGroup } from './messages/tools/ParallelAgentsGroup';
 import { ToolApproval } from './messages/ToolApproval';
 import { AskUserQuestion } from './messages/AskUserQuestion';
@@ -83,7 +84,16 @@ function getLastUserMessageId(messages: Message[]): string | null {
 
 export type DisplayItem =
   | { type: 'message'; key: string; message: Message }
-  | { type: 'parallel_agents'; key: string; agents: ACPToolCall[] };
+  | {
+      type: 'parallel_agents';
+      key: string;
+      agents: ACPToolCall[];
+      /**
+       * Wall-clock time of the first grouped launch, carried so the grouped
+       * box reveals its time on hover exactly like a standalone message row.
+       */
+      timestamp?: number;
+    };
 
 function isAgentOnlyToolGroup(msg: Message): boolean {
   return (
@@ -229,6 +239,7 @@ export function groupParallelAgents(messages: Message[]): DisplayItem[] {
           type: 'parallel_agents',
           key: `par-${grouped[0].id}`,
           agents: grouped.map((m) => (m as { tools: ACPToolCall[] }).tools[0]),
+          timestamp: grouped[0].timestamp,
         });
         i = j;
         continue;
@@ -244,6 +255,7 @@ export function groupParallelAgents(messages: Message[]): DisplayItem[] {
           type: 'parallel_agents',
           key: `par-${grouped[0].id}`,
           agents: grouped.map((m) => (m as { tools: ACPToolCall[] }).tools[0]),
+          timestamp: grouped[0].timestamp,
         });
       } else {
         items.push({
@@ -677,11 +689,13 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
 
         if (item.type === 'parallel_agents') {
           return (
-            <ParallelAgentsGroup
-              agents={item.agents}
-              pendingApproval={pendingApproval}
-              onConfirm={onConfirm}
-            />
+            <MessageTimestamp timestamp={item.timestamp}>
+              <ParallelAgentsGroup
+                agents={item.agents}
+                pendingApproval={pendingApproval}
+                onConfirm={onConfirm}
+              />
+            </MessageTimestamp>
           );
         }
 

--- a/packages/web-shell/client/components/messages/tools/SubAgentPanel.module.css
+++ b/packages/web-shell/client/components/messages/tools/SubAgentPanel.module.css
@@ -142,3 +142,32 @@
 .tools .panel {
   border-left-width: 2px;
 }
+
+/*
+ * Per-sub-tool hover time. Deliberately a *separate* class pair from the
+ * message-level MessageTimestamp (.row/.tip): the Tools list nests inside a
+ * message that is already wrapped by MessageTimestamp, and reusing the same
+ * hover rule across both layers couples them. These scoped names keep the
+ * sub-tool tooltip independent of the surrounding message's time tooltip.
+ */
+.toolTimeRow {
+  position: relative;
+}
+
+.toolTimeRow > .toolTimeTip {
+  position: absolute;
+  top: 2px;
+  right: 4px;
+  z-index: 5;
+  color: var(--text-dimmed);
+  font-size: 11px;
+  line-height: 1.4;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
+.toolTimeRow:hover > .toolTimeTip {
+  opacity: 1;
+}

--- a/packages/web-shell/client/components/messages/tools/SubAgentPanel.test.tsx
+++ b/packages/web-shell/client/components/messages/tools/SubAgentPanel.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { I18nProvider } from '../../../i18n';
+import type { ACPToolCall } from '../../../adapters/types';
+import { formatTimestamp } from '../../MessageTimestamp';
+
+// SubAgentPanel pulls in ToolGroup, which imports App only for
+// CompactModeContext; loading the real App module would drag the whole
+// application graph into this unit test.
+vi.mock('../../../App', async () => {
+  const { createContext } = await import('react');
+  return { CompactModeContext: createContext(false) };
+});
+
+const { SubAgentPanel } = await import('./SubAgentPanel');
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+afterEach(() => {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+});
+
+function renderPanel(tool: ACPToolCall): HTMLElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <I18nProvider language="en">
+        <SubAgentPanel tool={tool} defaultExpanded inline hideHeader />
+      </I18nProvider>,
+    );
+  });
+  mounted.push({ root, container });
+  return container;
+}
+
+function makeAgentWithSubTool(subTool: ACPToolCall): ACPToolCall {
+  return {
+    callId: 'agent-1',
+    toolName: 'Task',
+    status: 'completed',
+    args: { description: 'demo agent' },
+    subTools: [subTool],
+  };
+}
+
+describe('SubAgentPanel sub-tool timestamps', () => {
+  it('renders each sub-tool start time, like the main transcript rows', () => {
+    // A past date so formatTimestamp always renders the dated form; the
+    // expectation is derived from the same formatter, so it matches
+    // regardless of the test machine's clock or timezone.
+    const startTime = new Date('2020-01-02T03:04:05').getTime();
+    const container = renderPanel(
+      makeAgentWithSubTool({
+        callId: 'sub-1',
+        toolName: 'Read',
+        status: 'completed',
+        startTime,
+      }),
+    );
+    expect(container.textContent).toContain(formatTimestamp(startTime));
+  });
+
+  it('renders a sub-tool without a start time unchanged (no time shown)', () => {
+    const reference = new Date('2020-01-02T03:04:05').getTime();
+    const container = renderPanel(
+      makeAgentWithSubTool({
+        callId: 'sub-1',
+        toolName: 'Read',
+        status: 'completed',
+      }),
+    );
+    expect(container.textContent).not.toContain(formatTimestamp(reference));
+  });
+});

--- a/packages/web-shell/client/components/messages/tools/SubAgentPanel.tsx
+++ b/packages/web-shell/client/components/messages/tools/SubAgentPanel.tsx
@@ -13,6 +13,7 @@ import { useWebShellCustomization } from '../../../customization';
 // each other's exports at render time — never in top-level code.
 import { ToolLine } from '../ToolGroup';
 import { Markdown } from '../Markdown';
+import { formatTimestamp } from '../../MessageTimestamp';
 import {
   formatDurationMs,
   formatElapsed,
@@ -70,11 +71,40 @@ function isTaskExecution(raw: unknown): raw is TaskExecution {
   );
 }
 
+/**
+ * Reveals a single sub-tool's wall-clock start time on hover in its top-right
+ * corner, mirroring how the main transcript surfaces each message's time —
+ * but via a scoped class pair (not MessageTimestamp) so the nested tooltip
+ * stays independent of the enclosing message's own time tooltip.
+ */
+function SubToolTime({
+  timestamp,
+  children,
+}: {
+  timestamp?: number;
+  children: ReactNode;
+}) {
+  if (timestamp === undefined) return <>{children}</>;
+  return (
+    <div className={styles.toolTimeRow}>
+      {children}
+      <span className={styles.toolTimeTip} aria-hidden="true">
+        {formatTimestamp(timestamp)}
+      </span>
+    </div>
+  );
+}
+
 const SubToolLine = memo(function SubToolLine({ tool }: { tool: ACPToolCall }) {
-  if (tool.subTools || tool.subContent) return <SubAgentPanel tool={tool} />;
   // Same row as the main transcript: one-line summary, expandable to
   // the full output / diff / file content where the tool has any.
-  return <ToolLine tool={tool} />;
+  const body =
+    tool.subTools || tool.subContent ? (
+      <SubAgentPanel tool={tool} />
+    ) : (
+      <ToolLine tool={tool} />
+    );
+  return <SubToolTime timestamp={tool.startTime}>{body}</SubToolTime>;
 });
 
 function TaskToolCallLine({ tc }: { tc: TaskToolCall }) {


### PR DESCRIPTION
## What this PR does

Two sub-agent surfaces were missing the per-message hover timestamp added in #5079, leaving them inconsistent with the rest of the transcript. This adds it to both: the parallel-agents box (`Parallel agents · N/N done`) and each sub-tool row inside a sub-agent panel's Tools list now reveal their wall-clock time on hover in the top-right corner, exactly like a regular transcript message.

## Why it's needed

#5079 shipped per-message hover timestamps so users can tell when each step happened — useful when scanning a long or resumed session. But it only covered content routed through `MessageItem`. Two sub-agent views bypass that path and were left with no time at all: a multi-agent run collapses into a single `ParallelAgentsGroup` box rendered directly in `MessageList`, and a sub-agent's individual tool calls render inside `SubAgentPanel` instead of as standalone messages. A user inspecting what a (parallel) sub-agent did, and when, had no timestamp on either surface — that is the inconsistency this PR removes.

## Reviewer Test Plan

### How to verify

1. Open the web-shell on a session that ran ≥2 parallel sub-agents (so a `Parallel agents · N/N done` box appears) and/or a sub-agent that made tool calls.
2. Hover the parallel-agents box → its wall-clock time appears in the top-right, using the same tooltip as any message.
3. Expand a sub-agent, open its Tools tab, hover a tool row → that row's start time appears in the top-right.
4. Confirm the enclosing message's own timestamp still shows and nothing is clipped by the scroll containers.

Expected: each surface shows `HH:mm:ss` (or `yyyy-MM-dd HH:mm:ss` for older entries) on hover, top-right; the non-hover state shows nothing; a row without a start time renders unchanged (no empty wrapper).

### Evidence (Before & After)

**Before** — hovering the `Parallel agents · N/N done` box shows no time; hovering a sub-tool row in a sub-agent's Tools list shows no time.

**After** — verified in a real browser (Playwright/chromium) against a live daemon session: hovering the parallel-agents box reveals `2026-06-13 19:05:27` top-right (computed `opacity: 1`, `visibility: visible`, not clipped by the surrounding `overflow` containers); hovering a `ReadFile` sub-tool row reveals `23:46:16` top-right; both coexist with the enclosing message's own time tooltip (they use independent class pairs, confirmed on-screen together).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local `vite` dev server (web-shell, port 5173) against a running daemon session; unit tests via `vitest`; real-browser hover checks via Playwright/chromium. Windows/Linux rely on CI (unit tests only; the hover behavior is plain CSS with no platform-specific code).

## Risk & Scope

- Main risk or tradeoff: purely additive UI (a hover-only tooltip). The parallel box reuses the existing `formatTimestamp` + `MessageTimestamp`; sub-tool rows use a scoped `.toolTimeRow`/`.toolTimeTip` class pair, deliberately separate from `MessageTimestamp`'s `.row`/`.tip` so the nested tooltip never couples to the enclosing message's.
- Not validated / out of scope: sub-tool calls replayed from a background task's `rawOutput.toolCalls` (`TaskToolCall`) carry no time field, so those rows intentionally stay timeless; Windows/Linux hover not manually verified (CSS-only, covered by CI unit tests).
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #5079 (message-time-on-hover); no issue to auto-close.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

有两个子代理界面没有应用 #5079 引入的逐条消息 hover 时间戳，和其余对话不一致。本 PR 给两者都补上：并行智能体外框（`并行智能体 · N/N 完成`）和子代理面板 Tools 列表里的每个子工具行，现在都会在 hover 时于右上角显示其挂钟时间，与普通对话消息完全一致。

## 为什么需要

#5079 上线了逐条消息的 hover 时间戳，让用户知道每一步发生的时间——在浏览长会话或恢复的会话时很有用。但它只覆盖了走 `MessageItem` 渲染的内容。有两个子代理界面绕过了这条路径、完全没有时间：多个并行子代理会被折叠成一个直接在 `MessageList` 里渲染的 `ParallelAgentsGroup` 外框；而子代理自身的工具调用渲染在 `SubAgentPanel` 内部，而非独立消息。用户想查看一个（并行）子代理在什么时间做了什么时，这两处都没有时间——这正是本 PR 消除的不一致。

## 审查测试计划

### 如何验证

1. 打开 web-shell，进入一个跑过 ≥2 个并行子代理（会出现 `并行智能体 · N/N 完成` 外框）且/或有工具调用的子代理的会话。
2. hover 并行智能体外框 → 右上角出现其挂钟时间，使用与任意消息相同的浮层。
3. 展开一个子代理，打开它的 Tools 标签，hover 某个工具行 → 右上角出现该行的开始时间。
4. 确认外层消息自身的时间戳仍然显示，且没有被滚动容器裁剪。

预期：每个界面在 hover 时于右上角显示 `HH:mm:ss`（较早的为 `yyyy-MM-dd HH:mm:ss`）；非 hover 状态不显示；没有开始时间的行保持原样（不产生空壳包裹）。

### 证据（前 & 后）

**前**——hover `并行智能体 · N/N 完成` 外框不显示时间；hover 子代理 Tools 列表里的子工具行不显示时间。

**后**——在真实浏览器（Playwright/chromium）连真实 daemon 会话验证：hover 并行智能体外框，右上角显示 `2026-06-13 19:05:27`（computed `opacity: 1`、`visibility: visible`，未被周围 `overflow` 容器裁剪）；hover `ReadFile` 子工具行，右上角显示 `23:46:16`；两者与外层消息自身的时间浮层共存（使用各自独立的类，已在屏幕上同时确认）。

### 测试平台

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

本地 `vite` dev server（web-shell，端口 5173）连运行中的 daemon 会话；单测用 `vitest`；真实浏览器 hover 检查用 Playwright/chromium。Windows/Linux 依赖 CI（仅单测；hover 行为是纯 CSS，无平台相关代码）。

## 风险与范围

- 主要风险或取舍：纯增量 UI（仅 hover 浮层）。并行框复用现有的 `formatTimestamp` + `MessageTimestamp`；子工具行使用作用域隔离的 `.toolTimeRow`/`.toolTimeTip` 类对，刻意与 `MessageTimestamp` 的 `.row`/`.tip` 分开，使嵌套浮层绝不与外层消息耦合。
- 未验证 / 不在范围：从后台任务的 `rawOutput.toolCalls`（`TaskToolCall`）回放的子工具调用结构里没有时间字段，因此那些行有意保持无时间；Windows/Linux 的 hover 未手动验证（纯 CSS，由 CI 单测覆盖）。
- 破坏性改动 / 迁移说明：无。

## 关联 Issue

#5079（消息 hover 时间）的后续；无需自动关闭的 issue。

</details>

<img width="2974" height="1352" alt="image" src="https://github.com/user-attachments/assets/84edf796-c554-4a7c-952a-aa9137e0966b" />
