### PR TITLE
feat(web-shell): reveal full tool detail and auto-collapse finished tools

### DIFF
--- a/packages/web-shell/client/components/messages/ToolGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.test.tsx
@@ -271,4 +271,46 @@ describe('auto-collapse on finish', () => {
     render('completed');
     expect(container.textContent).toContain('SubToolMarker');
   });
+
+  it('keeps a tool the user manually expanded open when it completes', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    // Long command → the row is expandable/clickable even while running.
+    const command = `echo ${'z'.repeat(80)}`;
+    const renderStatus = (status: ACPToolCall['status']) =>
+      act(() => {
+        root.render(
+          <I18nProvider language="en">
+            <ToolGroup
+              tools={[
+                {
+                  callId: 'call-usertoggle',
+                  toolName: 'run_shell_command',
+                  status,
+                  args: { command },
+                  rawOutput: { output: 'done' },
+                },
+              ]}
+            />
+          </I18nProvider>,
+        );
+      });
+
+    renderStatus('in_progress');
+    const chevron = () =>
+      [...container.querySelectorAll('span')].find(
+        (s) => s.textContent === '▾' || s.textContent === '▸',
+      );
+    // Toggle twice → marks the row user-controlled, ending in the expanded state.
+    click(chevron()!.parentElement!);
+    click(chevron()!.parentElement!);
+    expect(container.textContent).toContain('▾');
+
+    // Completion must NOT override the user's explicit expand.
+    renderStatus('completed');
+    expect(container.textContent).toContain('▾');
+  });
 });

--- a/packages/web-shell/client/components/messages/ToolGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.test.tsx
@@ -167,25 +167,33 @@ describe('shell tool output expand toggle', () => {
 });
 
 describe('tool description expand toggle', () => {
-  it('keeps a finished command collapsed but reveals it in full on expand', () => {
+  it('relocates the full command from the header into a wrapped block on expand', () => {
     const command = `npm run build && npm run test && npm run lint -- ${'x'.repeat(
       80,
     )}`;
     const container = renderTool(makeShellCommandTool(command));
 
-    // Completed → collapsed: chevron points right. The full command (no longer
-    // hard-capped at one line's worth of characters) is present in the header.
+    // textContent alone can't prove relocation (it concatenates the whole
+    // subtree, so the command is present in either state). Assert the DOM move
+    // instead: collapsed, the full command lives in the header's single-line
+    // arg <span> (CSS-ellipsised); expanded, it is no longer in any leaf <span>
+    // but reflowed into the wrapped block below.
+    const commandInLeafSpan = () =>
+      [...container.querySelectorAll('span')].some(
+        (s) => s.textContent === command,
+      );
+
     expect(container.textContent).toContain('▸');
-    expect(container.textContent).toContain(command);
+    expect(commandInLeafSpan()).toBe(true);
 
     const chevron = [...container.querySelectorAll('span')].find(
       (s) => s.textContent === '▸',
     );
     click(chevron!.parentElement!);
 
-    // Expanded → chevron flips and the full command is reflowed below.
     expect(container.textContent).toContain('▾');
-    expect(container.textContent).toContain(command);
+    expect(commandInLeafSpan()).toBe(false);
+    expect(container.textContent).toContain(command); // still present, in the block
   });
 });
 

--- a/packages/web-shell/client/components/messages/ToolGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.test.tsx
@@ -195,6 +195,31 @@ describe('tool description expand toggle', () => {
     expect(commandInLeafSpan()).toBe(false);
     expect(container.textContent).toContain(command); // still present, in the block
   });
+
+  it('keeps the result summary when expanding a long-description tool with no detail view', () => {
+    // glob with a long pattern: descExpandable but no kind-specific renderer.
+    const pattern = `**/${'x'.repeat(80)}/*.ts`;
+    const container = renderTool({
+      callId: 'call-glob',
+      toolName: 'glob',
+      status: 'completed',
+      args: { pattern },
+      rawOutput: 'a.ts\nb.ts\nc.ts',
+    });
+
+    const chevron = [...container.querySelectorAll('span')].find(
+      (s) => s.textContent === '▸',
+    );
+    expect(chevron).toBeTruthy(); // long pattern → expandable
+    expect(container.textContent).toContain('matching file'); // summary, collapsed
+
+    click(chevron!.parentElement!);
+
+    // Expanded: the summary must NOT be lost (no detail view replaces it), and
+    // the full pattern is reflowed into the block.
+    expect(container.textContent).toContain('matching file');
+    expect(container.textContent).toContain(pattern);
+  });
 });
 
 describe('auto-collapse on finish', () => {

--- a/packages/web-shell/client/components/messages/ToolGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.test.tsx
@@ -27,28 +27,69 @@ afterEach(() => {
   }
 });
 
-function makeShellTool(output: string): ACPToolCall {
+function makeShellTool(
+  output: string,
+  status: ACPToolCall['status'] = 'completed',
+): ACPToolCall {
   return {
     callId: 'call-shell-1',
     toolName: 'Shell',
-    status: 'completed',
+    status,
     rawOutput: { output },
   };
 }
 
-function renderShellTool(output: string): HTMLElement {
+function renderTool(tool: ACPToolCall): HTMLElement {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
   act(() => {
     root.render(
       <I18nProvider language="en">
-        <ToolGroup tools={[makeShellTool(output)]} />
+        <ToolGroup tools={[tool]} />
       </I18nProvider>,
     );
   });
   mounted.push({ root, container });
   return container;
+}
+
+function renderShellTool(output: string): HTMLElement {
+  const container = renderTool(makeShellTool(output));
+  // Completed tools collapse to a one-line summary by default; open the row so
+  // the assertions below can inspect the bash-output view.
+  const chevron = [...container.querySelectorAll('span')].find(
+    (s) => s.textContent === '▸',
+  );
+  if (chevron?.parentElement) click(chevron.parentElement);
+  return container;
+}
+
+function makeShellCommandTool(command: string): ACPToolCall {
+  return {
+    callId: 'call-shell-cmd',
+    toolName: 'run_shell_command',
+    status: 'completed',
+    args: { command },
+    rawOutput: { output: 'done' },
+  };
+}
+
+function makeAgentTool(status: ACPToolCall['status']): ACPToolCall {
+  return {
+    callId: 'agent-1',
+    toolName: 'task',
+    status,
+    args: { description: 'agentDescMarker' },
+    subTools: [
+      {
+        callId: 'agent-1-sub-1',
+        toolName: 'Read',
+        status: 'completed',
+        args: { file_path: '/ws/SubToolMarker.ts' },
+      },
+    ],
+  };
 }
 
 function getExpandButton(container: HTMLElement): HTMLButtonElement {
@@ -122,5 +163,112 @@ describe('shell tool output expand toggle', () => {
     expect(pre?.textContent).not.toContain('line2');
     expect(button.textContent).toBe('▼ Show all (8 lines)');
     expect(button.getAttribute('aria-expanded')).toBe('false');
+  });
+});
+
+describe('tool description expand toggle', () => {
+  it('keeps a finished command collapsed but reveals it in full on expand', () => {
+    const command = `npm run build && npm run test && npm run lint -- ${'x'.repeat(
+      80,
+    )}`;
+    const container = renderTool(makeShellCommandTool(command));
+
+    // Completed → collapsed: chevron points right. The full command (no longer
+    // hard-capped at one line's worth of characters) is present in the header.
+    expect(container.textContent).toContain('▸');
+    expect(container.textContent).toContain(command);
+
+    const chevron = [...container.querySelectorAll('span')].find(
+      (s) => s.textContent === '▸',
+    );
+    click(chevron!.parentElement!);
+
+    // Expanded → chevron flips and the full command is reflowed below.
+    expect(container.textContent).toContain('▾');
+    expect(container.textContent).toContain(command);
+  });
+});
+
+describe('auto-collapse on finish', () => {
+  it('collapses a completed tool to its summary by default', () => {
+    const container = renderTool(makeShellTool('a\nb\nc\nd'));
+    // The expanded bash <pre> is not rendered until the user opens the row.
+    expect(container.querySelector('pre')).toBeNull();
+    expect(container.textContent).toContain('▸');
+  });
+
+  it('keeps a running tool expanded so streaming output stays visible', () => {
+    const container = renderTool(
+      makeShellTool('streaming output', 'in_progress'),
+    );
+    expect(container.querySelector('pre')?.textContent).toContain('streaming');
+  });
+
+  it('keeps a failed tool expanded so the error stays visible', () => {
+    const container = renderTool(
+      makeShellTool('error: boom\n  at step 1', 'failed'),
+    );
+    expect(container.querySelector('pre')?.textContent).toContain('boom');
+  });
+
+  it('auto-collapses a running tool when it transitions to completed', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    const output = 'line1\nline2\nline3\nline4';
+    act(() => {
+      root.render(
+        <I18nProvider language="en">
+          <ToolGroup tools={[makeShellTool(output, 'in_progress')]} />
+        </I18nProvider>,
+      );
+    });
+    // Running → expanded: the bash output is visible.
+    expect(container.querySelector('pre')).not.toBeNull();
+
+    // Same callId, now finished → the row collapses on its own.
+    act(() => {
+      root.render(
+        <I18nProvider language="en">
+          <ToolGroup tools={[makeShellTool(output, 'completed')]} />
+        </I18nProvider>,
+      );
+    });
+    expect(container.querySelector('pre')).toBeNull();
+  });
+
+  it('does not collapse an agent the user expanded when it completes', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    const render = (status: ACPToolCall['status']) =>
+      act(() => {
+        root.render(
+          <I18nProvider language="en">
+            <ToolGroup tools={[makeAgentTool(status)]} />
+          </I18nProvider>,
+        );
+      });
+
+    render('in_progress');
+    // Agents start collapsed: the sub-tool panel is hidden.
+    expect(container.textContent).not.toContain('SubToolMarker');
+
+    // Expand by clicking the agent's summary row.
+    const summaryLabel = [...container.querySelectorAll('span')].find(
+      (s) => s.textContent === 'task:',
+    );
+    expect(summaryLabel).toBeTruthy();
+    click(summaryLabel!.parentElement!);
+    expect(container.textContent).toContain('SubToolMarker');
+
+    // Completion must NOT yank the panel shut: the collapse-on-finish effect
+    // is scoped to non-agent tools.
+    render('completed');
+    expect(container.textContent).toContain('SubToolMarker');
   });
 });

--- a/packages/web-shell/client/components/messages/ToolGroup.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.tsx
@@ -154,6 +154,10 @@ function buildUnifiedDiff(oldText: string, newText: string): string {
 const MAX_BASH_LINE_CHARS = 150;
 const MAX_READ_LINES = 25;
 
+// A description longer than this is likely ellipsised on a normal-width row, so
+// the row becomes expandable to re-flow the full text into a wrapped block.
+const DESCRIPTION_EXPAND_THRESHOLD = 60;
+
 export function resolveShellOutputMaxLines(
   settings: readonly DaemonSettingDescriptor[],
 ): number {
@@ -411,6 +415,10 @@ function getAgentDisplayInfo(
 }
 
 function shouldAutoExpand(tool: ACPToolCall): boolean {
+  // Once a tool completes successfully, collapse it to its one-line summary so
+  // the transcript stays scannable; the user can click to reopen it. Failures
+  // stay expanded so the error output remains visible without an extra click.
+  if (tool.status === 'completed') return false;
   const name = tool.toolName.toLowerCase();
   if (isAskUserQuestionToolName(tool.toolName)) return true;
   if (name === 'write_file' || name === 'writefile') return true;
@@ -462,6 +470,27 @@ function ToolHeaderExtra({ info }: { info: ToolHeaderExtraRenderInfo }) {
       description={info.description}
       elapsed={info.elapsed}
     />
+  );
+}
+
+function isDescriptionExpandable(description: string): boolean {
+  return (
+    description.length > DESCRIPTION_EXPAND_THRESHOLD ||
+    description.includes('\n')
+  );
+}
+
+function ToggleChevron({
+  expandable,
+  expanded,
+}: {
+  expandable: boolean;
+  expanded: boolean;
+}) {
+  return (
+    <span className={styles.lineToggle} aria-hidden="true">
+      {expandable ? (expanded ? '▾' : '▸') : ''}
+    </span>
   );
 }
 
@@ -611,6 +640,14 @@ export const ToolLine = memo(function ToolLine({
     return () => clearInterval(id);
   }, [isRunningAgent]);
 
+  // Collapse a regular tool to its one-line summary once it completes
+  // successfully. Agents are excluded — they keep whatever expand state the
+  // user chose, driven from their own panel — and failures stay open so the
+  // error output remains visible.
+  useEffect(() => {
+    if (!isAgent && tool.status === 'completed') setExpanded(false);
+  }, [isAgent, tool.status]);
+
   if (isAgent) {
     if (hasApproval && onConfirm) {
       return (
@@ -712,10 +749,16 @@ export const ToolLine = memo(function ToolLine({
     isShellToolName(tool.toolName) || isWebFetchToolName(tool.toolName)
       ? ''
       : formatElapsed(tool.startTime, tool.endTime);
-  const expandable = hasExpandableContent(tool);
 
   const name = tool.toolName.toLowerCase();
   const isTodo = name === 'todowrite';
+  // A row expands when it has detail output (bash/diff/read content) or when
+  // its description is long enough to be ellipsised. When a long description is
+  // expanded we move it out of the header into a wrapped block below, so the
+  // header drops its single-line copy.
+  const descExpandable = !isTodo && isDescriptionExpandable(description);
+  const expandable = !isTodo && (hasExpandableContent(tool) || descExpandable);
+  const relocateDescription = expanded && descExpandable;
 
   if (hasApproval && onConfirm) {
     return (
@@ -731,6 +774,7 @@ export const ToolLine = memo(function ToolLine({
         className={`${styles.lineMain} ${expandable ? styles.lineExpandable : ''}`}
         onClick={expandable ? () => setExpanded(!expanded) : undefined}
       >
+        <ToggleChevron expandable={expandable} expanded={expanded} />
         <StatusIcon status={tool.status} />
         <span className={styles.lineName}>{displayName}</span>
         <ToolHeaderExtra
@@ -738,13 +782,16 @@ export const ToolLine = memo(function ToolLine({
             kind: getToolHeaderKind(tool),
             tool,
             displayName,
-            description,
+            description: relocateDescription ? '' : description,
             elapsed,
             workspaceCwd,
           }}
         />
       </div>
       {isTodo && <TodoWriteContent tool={tool} />}
+      {relocateDescription && (
+        <div className={styles.lineFullArg}>{description}</div>
+      )}
       {!isTodo && !expanded && result && (
         <div className={styles.lineOutput}>{result}</div>
       )}

--- a/packages/web-shell/client/components/messages/ToolGroup.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.tsx
@@ -1,4 +1,4 @@
-import { memo, useContext, useEffect, useMemo, useState } from 'react';
+import { memo, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import type { DaemonSettingDescriptor } from '@qwen-code/webui/daemon-react-sdk';
 import type {
   ACPToolCall,
@@ -415,9 +415,13 @@ function getAgentDisplayInfo(
 }
 
 function shouldAutoExpand(tool: ACPToolCall): boolean {
-  // Once a tool completes successfully, collapse it to its one-line summary so
-  // the transcript stays scannable; the user can click to reopen it. Failures
-  // stay expanded so the error output remains visible without an extra click.
+  // Only the verbose tool kinds below (shell/edit/write/ask) auto-expand, and
+  // only while pending/in-progress or after failing: a successful completion
+  // collapses them to a one-line summary so the transcript stays scannable
+  // (click to reopen), while a failure of those kinds stays expanded so its
+  // error output is visible without a click. Every other tool kind is collapsed
+  // by default regardless of status — its summary line already shows the
+  // outcome and it stays click-to-expand.
   if (tool.status === 'completed') return false;
   const name = tool.toolName.toLowerCase();
   if (isAskUserQuestionToolName(tool.toolName)) return true;
@@ -615,11 +619,16 @@ export const ToolLine = memo(function ToolLine({
   const [expanded, setExpanded] = useState(
     () => !compactMode && shouldAutoExpand(tool),
   );
+  // Set once the user explicitly toggles this row, so auto-collapse-on-
+  // completion never silently overrides their choice.
+  const userToggledRef = useRef(false);
   const [now, setNow] = useState(() => Date.now());
 
   useEffect(
     () => {
       setExpanded(compactMode ? false : shouldAutoExpand(tool));
+      // A new tool identity (or compact-mode toggle) resets the manual latch.
+      userToggledRef.current = false;
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [compactMode, tool.callId, tool.toolName],
@@ -641,11 +650,14 @@ export const ToolLine = memo(function ToolLine({
   }, [isRunningAgent]);
 
   // Collapse a regular tool to its one-line summary once it completes
-  // successfully. Agents are excluded — they keep whatever expand state the
-  // user chose, driven from their own panel — and failures stay open so the
+  // successfully — unless the user explicitly toggled this row, in which case
+  // their choice wins. Agents are excluded (they keep whatever expand state the
+  // user chose, driven from their own panel) and failures stay open so the
   // error output remains visible.
   useEffect(() => {
-    if (!isAgent && tool.status === 'completed') setExpanded(false);
+    if (!isAgent && tool.status === 'completed' && !userToggledRef.current) {
+      setExpanded(false);
+    }
   }, [isAgent, tool.status]);
 
   if (isAgent) {
@@ -772,7 +784,14 @@ export const ToolLine = memo(function ToolLine({
     <div className={styles.line}>
       <div
         className={`${styles.lineMain} ${expandable ? styles.lineExpandable : ''}`}
-        onClick={expandable ? () => setExpanded(!expanded) : undefined}
+        onClick={
+          expandable
+            ? () => {
+                userToggledRef.current = true;
+                setExpanded((value) => !value);
+              }
+            : undefined
+        }
       >
         <ToggleChevron expandable={expandable} expanded={expanded} />
         <StatusIcon status={tool.status} />

--- a/packages/web-shell/client/components/messages/ToolGroup.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.tsx
@@ -81,6 +81,27 @@ function hasExpandableContent(tool: ACPToolCall): boolean {
   return false;
 }
 
+// Tools whose expanded row renders a kind-specific detail view (shell output /
+// diff / file content / Q&A). Must stay in sync with the renderers in
+// ToolLine's lineDetail block below. Tools NOT in this set have nothing extra
+// to show when expanded, so they keep their one-line result summary instead of
+// hiding it behind an empty detail area.
+function hasDetailView(tool: ACPToolCall): boolean {
+  const name = tool.toolName.toLowerCase();
+  return (
+    isShellToolName(name) ||
+    name === 'write_file' ||
+    name === 'writefile' ||
+    name === 'edit' ||
+    name === 'write' ||
+    name === 'editfile' ||
+    name === 'read' ||
+    name === 'read_file' ||
+    name === 'readfile' ||
+    isAskUserQuestionToolName(tool.toolName)
+  );
+}
+
 function hasDiffContent(tool: ACPToolCall): boolean {
   if (tool.content?.some((b) => b.type === 'diff')) return true;
   if (tool.rawOutput && typeof tool.rawOutput === 'object') {
@@ -771,6 +792,10 @@ export const ToolLine = memo(function ToolLine({
   const descExpandable = !isTodo && isDescriptionExpandable(description);
   const expandable = !isTodo && (hasExpandableContent(tool) || descExpandable);
   const relocateDescription = expanded && descExpandable;
+  // Whether the expanded row renders a kind-specific detail view. When it does
+  // not (e.g. grep/glob/web_fetch with a long description), keep the result
+  // summary visible instead of replacing it with an empty detail area.
+  const detailView = hasDetailView(tool);
 
   if (hasApproval && onConfirm) {
     return (
@@ -811,10 +836,10 @@ export const ToolLine = memo(function ToolLine({
       {relocateDescription && (
         <div className={styles.lineFullArg}>{description}</div>
       )}
-      {!isTodo && !expanded && result && (
+      {!isTodo && result && (!expanded || !detailView) && (
         <div className={styles.lineOutput}>{result}</div>
       )}
-      {!isTodo && expanded && (
+      {!isTodo && expanded && detailView && (
         <div className={styles.lineDetail}>
           {isShellToolName(name) && (
             <ExpandedBashOutput tool={tool} maxLines={shellOutputMaxLines} />

--- a/packages/web-shell/client/components/messages/toolFormatting.test.ts
+++ b/packages/web-shell/client/components/messages/toolFormatting.test.ts
@@ -170,4 +170,24 @@ describe('toolFormatting', () => {
       ),
     ).toBe('3 line(s)');
   });
+
+  it('keeps long shell commands in full instead of capping at one line', () => {
+    const command = `echo ${'a'.repeat(200)}`;
+    expect(
+      getToolDescription(
+        tool({ toolName: 'run_shell_command', args: { command } }),
+      ),
+    ).toBe(command);
+  });
+
+  it('still bounds a pathologically long description', () => {
+    const result = getToolDescription(
+      tool({
+        toolName: 'run_shell_command',
+        args: { command: 'x'.repeat(5000) },
+      }),
+    );
+    expect(result.length).toBeLessThan(5000);
+    expect(result.endsWith('...')).toBe(true);
+  });
 });

--- a/packages/web-shell/client/components/messages/toolFormatting.ts
+++ b/packages/web-shell/client/components/messages/toolFormatting.ts
@@ -49,14 +49,21 @@ export function truncateText(text: string, max: number): string {
   return text.slice(0, max) + '...';
 }
 
+// The tool-header description is shown single-line (CSS-ellipsised) when the
+// row is collapsed and fully wrapped when it is expanded, so we keep the whole
+// string rather than hard-capping it at a line's worth of characters. A
+// generous ceiling still guards against a pathological multi-megabyte command
+// bloating the DOM.
+const MAX_DESCRIPTION_LENGTH = 2000;
+
 export function getToolDescription(
   tool: ACPToolCall,
   workspaceCwd?: string,
 ): string {
   const fromTitle = getDescriptionFromTitle(tool, workspaceCwd);
-  if (fromTitle) return truncateText(fromTitle, 120);
+  if (fromTitle) return truncateText(fromTitle, MAX_DESCRIPTION_LENGTH);
   const fromArgs = getDescriptionFromArgs(tool, workspaceCwd);
-  if (fromArgs) return truncateText(fromArgs, 120);
+  if (fromArgs) return truncateText(fromArgs, MAX_DESCRIPTION_LENGTH);
   return '';
 }
 
@@ -177,7 +184,7 @@ function getDescriptionFromArgs(
     if (args.description) {
       description += ` (${String(args.description).replace(/\n/g, ' ')})`;
     }
-    return truncateText(description, 120);
+    return truncateText(description, MAX_DESCRIPTION_LENGTH);
   }
   if (name === 'grep_search' || name === 'grep' || name === 'search') {
     const pattern = args.pattern ?? args.query;

--- a/packages/web-shell/client/components/messages/tools/ToolChrome.module.css
+++ b/packages/web-shell/client/components/messages/tools/ToolChrome.module.css
@@ -24,6 +24,18 @@
   min-width: 0;
 }
 
+/* Leading disclosure column. Rendered (blank) for every tool row so names stay
+   aligned; shows ▸/▾ only when the row can expand. */
+.lineToggle {
+  width: 12px;
+  flex-shrink: 0;
+  font-size: 10px;
+  line-height: 1;
+  color: var(--text-dimmed);
+  text-align: center;
+  user-select: none;
+}
+
 .icon {
   font-size: 13px;
   flex-shrink: 0;
@@ -108,6 +120,21 @@
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   line-height: 1.4;
+}
+
+/* Full, wrapped tool argument shown below the header when the row is expanded
+   (the header drops its single-line ellipsised copy). Aligns with the expanded
+   output block below it. */
+.lineFullArg {
+  margin-left: 16px;
+  margin-top: 2px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .lineDetail {


### PR DESCRIPTION
## What this PR does

Improves how tool calls render in the web-shell transcript in two ways. First, the full tool description (the shell command, file path, or arguments) is now reachable: it was hard-capped at 120 characters in JS *before* reaching the DOM, so a long command was unreadable even on a wide screen — now the full text reaches the DOM, collapsed rows ellipsise via CSS (which adapts to window width), and clicking a row reflows the full description into a wrapped monospace block below the header, with a leading disclosure chevron (`▸`/`▾`) marking expandable rows. Second, a tool now auto-collapses to its one-line summary once it completes successfully, while running tools stay expanded so you can watch live output and failed tools stay expanded so the error stays visible; sub-agent panels keep whatever expand state the user chose and are never force-collapsed on completion.

## Why it's needed

Two readability papercuts. A long shell command or path showed as `npm run build && npm run te…` with no way to see the rest — the 120-char JS cap meant the remainder never even reached the DOM, so widening the window didn't help. And shell/edit/write rows stayed expanded forever, so a session with many tool calls filled the transcript with stale output and became hard to scan.

## Reviewer Test Plan

### How to verify

1. `npm --workspace packages/web-shell run dev` and open the web-shell.
2. Run a long shell command (e.g. `echo` with a ~150-char argument). While it runs the row is expanded; once it completes it collapses to a one-line summary with a `▸` chevron.
3. Click the row — it expands, the chevron flips to `▾`, and the full command reflows into a wrapped block above the output.
4. Run a failing command — it stays expanded so the error is visible without a click.
5. Expand a running sub-agent's panel and let it finish — it stays open (not force-collapsed).
6. Observe that a collapsed long description now ellipsises to the window width (widen the window and more of the command shows) rather than cutting off at a fixed 120 chars.

### Evidence (Before & After)

This is a DOM-behavior change verified via jsdom unit tests that pin the exact observable outcomes; a live cross-browser screenshot isn't producible in this environment, so the tests stand in as the evidence.

```
Before:   ✓ Shell  npm run build && npm run te…        (rest never reaches the DOM; row stays expanded forever)
After ▸:  ✓ Shell  npm run build && npm run test && …  (full text in DOM, CSS-clipped to width; collapsed once finished)
After ▾:  ✓ Shell                                       (click → full command wraps below, then output)
            npm run build && npm run test && npm run lint --fix
            <output…>
```

`vitest run` → **261 pass** (web-shell), including 9 new tests: full-command-reaches-DOM, chevron toggle, completed→collapsed (both on mount and on a live `in_progress`→`completed` transition), running-stays-expanded, failed-stays-expanded, and a sub-agent regression guard (an expanded agent must survive completion).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests via `vitest` (jsdom). Full `npm run build` (app + lib) passes; `tsc` and `eslint` are clean on the changed files.

## Risk & Scope

- Main risk or tradeoff: auto-collapse changes the default verbosity (finished shell/edit/write rows now start collapsed instead of expanded), and a small leading chevron gutter shifts tool-row content right uniformly. Both are cosmetic and covered by tests.
- Not validated / out of scope: persisted task-execution summaries (`TaskToolCallLine`, shown only on history/session load) are intentionally unchanged — they are lightweight records with no expandable detail; no live cross-browser screenshot (verified via jsdom instead).
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## What this PR does（这个 PR 做了什么）

从两方面改进 web-shell 对话流里工具调用的渲染。其一，完整的工具描述（shell 命令、文件路径或参数）现在可见：它原本在进入 DOM *之前*就被 JS 硬截断到 120 字符，所以一条长命令即使在宽屏上也看不全——现在完整文本进入 DOM，折叠行改由 CSS 省略（随窗口宽度自适应），点击工具行会把完整描述在表头下方换行成等宽块铺开，并以前置的展开三角（`▸`/`▾`）标记可展开的行。其二，工具在成功完成后会自动收起成一行摘要，而运行中的工具保持展开以便看实时输出、失败的工具保持展开以便看到错误；子代理面板保留用户选择的展开状态，完成时绝不会被强制收起。

## Why it's needed（为什么需要）

两个可读性痛点。长 shell 命令或路径显示为 `npm run build && npm run te…` 且无法看到剩余部分——120 字符的 JS 上限意味着剩余内容根本没进入 DOM，所以拉宽窗口也没用。而 shell/edit/write 行会一直保持展开，导致工具调用很多的会话历史区堆满陈旧输出、难以扫读。

## Reviewer Test Plan（审查者测试计划）

### How to verify（如何验证）

1. `npm --workspace packages/web-shell run dev` 并打开 web-shell。
2. 运行一条长 shell 命令（如带 ~150 字符参数的 `echo`）。运行时该行展开；完成后收起成带 `▸` 三角的一行摘要。
3. 点击该行——展开，三角翻成 `▾`，完整命令在输出上方换行铺开。
4. 运行一条会失败的命令——保持展开，错误无需点击即可见。
5. 展开一个运行中的子代理面板并让它结束——保持打开（不被强制收起）。
6. 观察折叠的长描述现在随窗口宽度省略（拉宽窗口会显示更多命令），而非固定在 120 字符处截断。

### Evidence (Before & After)（前后证据）

这是一处 DOM 行为改动，通过 jsdom 单测精确锁定可观测结果来验证；此环境无法产出真实跨浏览器截图，故以单测作为证据。

```
之前:    ✓ Shell  npm run build && npm run te…        (剩余部分从不进入 DOM；行永远展开)
之后 ▸:  ✓ Shell  npm run build && npm run test && …  (完整文本在 DOM 中，按宽度 CSS 省略；完成即收起)
之后 ▾:  ✓ Shell                                       (点击 → 完整命令换行铺开，再接输出)
            npm run build && npm run test && npm run lint --fix
            <输出…>
```

`vitest run` → web-shell **261 通过**，含 9 个新增测试：完整命令进入 DOM、chevron 切换、完成即收起（mount 态 + 运行→完成的实时跃迁两种）、运行保持展开、失败保持展开、以及子代理回归守护（展开的代理在完成后必须保持展开）。

### Tested on（测试平台）

仅本地 macOS 验证（✅）；Windows / Linux 未测（⚠️，由 CI 覆盖）。

### Environment (optional)（环境，可选）

通过 `vitest`（jsdom）跑单测。完整 `npm run build`（app + lib）通过；改动文件 `tsc`、`eslint` 干净。

## Risk & Scope（风险与范围）

- 主要风险/取舍：自动收起改变了默认详略（完成的 shell/edit/write 行现在默认收起而非展开），且前置的 chevron 槽位会让工具行内容统一右移一点。两者均为外观层面且有测试覆盖。
- 未验证/范围外：持久化的任务执行摘要（`TaskToolCallLine`，仅在历史/会话加载时出现）有意保持不变——它们是无可展开详情的轻量记录；未做真实跨浏览器截图（改以 jsdom 验证）。
- 破坏性变更/迁移说明：无。

## Linked Issues（关联 issue）

无。

</details>
