### PR TITLE
fix(webui): defer DaemonClient disposal to survive React StrictMode

### DIFF
--- a/packages/webui/src/daemon/workspace/DaemonWorkspaceProvider.tsx
+++ b/packages/webui/src/daemon/workspace/DaemonWorkspaceProvider.tsx
@@ -27,6 +27,10 @@ const DaemonWorkspaceContext = createContext<
   DaemonWorkspaceContextValue | undefined
 >(undefined);
 
+// Module-level sentinel for deferred-disposal StrictMode guard.
+// See the useEffect cleanup in DaemonWorkspaceProvider for details.
+let pendingDisposeClient: DaemonClient | undefined;
+
 export type {
   DaemonWorkspaceActions,
   DaemonWorkspaceContextValue,
@@ -87,6 +91,13 @@ export function DaemonWorkspaceProvider({
     setError(undefined);
     setCapabilities(undefined);
 
+    // Cancel any pending deferred disposal from a previous cleanup (handles
+    // React StrictMode double-invocation: the first cleanup schedules a
+    // disposal microtask, but the synchronous second mount cancels it).
+    if (pendingDisposeClient === client) {
+      pendingDisposeClient = undefined;
+    }
+
     let disposed = false;
     void getCapabilities()
       .then((caps) => {
@@ -104,7 +115,17 @@ export function DaemonWorkspaceProvider({
 
     return () => {
       disposed = true;
-      client.dispose();
+      // Defer disposal by one microtask. In StrictMode the synchronous
+      // re-mount cancels disposal before the microtask fires, preserving
+      // the memoized client. On real unmount or client replacement no
+      // cancellation occurs and disposal proceeds.
+      pendingDisposeClient = client;
+      queueMicrotask(() => {
+        if (pendingDisposeClient === client) {
+          pendingDisposeClient = undefined;
+          client.dispose();
+        }
+      });
     };
   }, [client, getCapabilities]);
 


### PR DESCRIPTION
## Problem

`npm run dev:daemon` launches the web-shell, but the input box shows "Loading..." permanently and the status bar says "Disconnected". The daemon and vite dev server are both healthy — `curl` can create sessions through the vite proxy just fine. The failure is entirely on the browser side.

## Root Cause

`DaemonWorkspaceProvider` wraps `DaemonSessionProvider` and provides a `DaemonClient` via React context. Under React 19's StrictMode (enabled by default in dev), effects are double-invoked: mount → cleanup → mount.

The cleanup in the first pass called `client.dispose()` synchronously, destroying the transport layer of the memoized `DaemonClient`. The second mount reuses the same memoized client (correct behavior per React's `useMemo` contract), but the transport is already closed. When `DaemonSessionProvider` then tries to create a session and subscribe to SSE events, it hits `DaemonTransportClosedError: Transport connection closed` and falls into the error/disconnected state.

## Fix

Defer `client.dispose()` by one microtask using `queueMicrotask()`. StrictMode's synchronous cleanup-then-remount cycle completes before the microtask fires, so the second mount cancels the pending disposal. A module-level sentinel (`pendingDisposeClient`) tracks which client has a pending disposal; the new effect checks this sentinel and clears it on re-mount if it still matches.

Real unmounts and client replacements (e.g. token/baseUrl change triggers a new `useMemo`) proceed normally since no cancellation occurs in those paths.

## Changes

- `packages/webui/src/daemon/workspace/DaemonWorkspaceProvider.tsx`: add deferred disposal with StrictMode cancellation guard in the `useEffect` cleanup.

## Testing

- `DaemonWorkspaceProvider` tests: 9/9 pass
- `DaemonSessionProvider` tests: 71/71 pass
- Manual verification: `npm run dev:daemon` then web-shell connects, session created, input box functional, model displayed correctly.

## Reviewer Test Plan

- Run `npm run dev:daemon` and open the web-shell in Chrome.
- Verify the input box shows "Type a message or @ file path" (not "Loading...").
- Verify the status bar shows the model name and context usage (not "Disconnected").
- Send a prompt and confirm the assistant responds.
