### PR TITLE
fix(cli): wrap long status lines

### DIFF
--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -155,6 +155,45 @@ describe('<Footer />', () => {
       expect(frame).toContain('████░░░░ 34% context');
     });
 
+    it('wraps long status line output without growing past two lines', () => {
+      const longLine = [
+        'visible-start',
+        ...Array.from({ length: 40 }, (_, index) => `chunk-${index}`),
+        'hidden-tail',
+      ].join(' ');
+      useStatusLineMock.mockReturnValue({
+        lines: [longLine],
+        useThemeColors: false,
+        respectUserColors: false,
+        hideContextIndicator: false,
+      });
+      const { lastFrame } = renderWithWidth(16, createMockUIState());
+      const frame = lastFrame()!;
+      expect(frame).toContain('visible-start');
+      expect(frame).not.toContain('hidden-tail');
+      expect(frame).not.toContain('? for shortcuts');
+    });
+
+    it('clips later status line entries after wrapped output reaches two lines', () => {
+      const longLine = [
+        'first-line-start',
+        ...Array.from({ length: 40 }, (_, index) => `part-${index}`),
+        'first-line-tail',
+      ].join(' ');
+      useStatusLineMock.mockReturnValue({
+        lines: [longLine, 'second-status-line'],
+        useThemeColors: false,
+        respectUserColors: false,
+        hideContextIndicator: false,
+      });
+      const { lastFrame } = renderWithWidth(16, createMockUIState());
+      const frame = lastFrame()!;
+      expect(frame).toContain('first-line-start');
+      expect(frame).not.toContain('first-line-tail');
+      expect(frame).not.toContain('second-status-line');
+      expect(frame).not.toContain('? for shortcuts');
+    });
+
     it('suppresses hint when status line is active', () => {
       useStatusLineMock.mockReturnValue({
         lines: ['status info'],

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -170,6 +170,7 @@ describe('<Footer />', () => {
       const { lastFrame } = renderWithWidth(16, createMockUIState());
       const frame = lastFrame()!;
       expect(frame).toContain('visible-start');
+      expect(frame).toContain('chunk-10');
       expect(frame).not.toContain('hidden-tail');
       expect(frame).not.toContain('? for shortcuts');
     });

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -15,7 +15,7 @@ import { BackgroundTasksPill } from './background-view/BackgroundTasksPill.js';
 import { MCPHealthPill } from './mcp/MCPHealthPill.js';
 import { isNarrowWidth } from '../utils/isNarrowWidth.js';
 
-import { useStatusLine } from '../hooks/useStatusLine.js';
+import { MAX_STATUS_LINES, useStatusLine } from '../hooks/useStatusLine.js';
 import { useConfigInitMessage } from '../hooks/useConfigInitMessage.js';
 import { useUIState } from '../contexts/UIStateContext.js';
 import { useConfig } from '../contexts/ConfigContext.js';
@@ -153,26 +153,36 @@ export const Footer: React.FC = () => {
       gap={isNarrow ? 0 : 1}
     >
       {/* Left column — status line on top, hints/mode on bottom */}
-      <Box flexDirection="column" flexShrink={isNarrow ? 0 : 1}>
+      <Box
+        flexDirection="column"
+        flexGrow={1}
+        flexShrink={isNarrow ? 0 : 1}
+        minWidth={0}
+      >
         {statusLineLines.length > 0 &&
           !uiState.ctrlCPressedOnce &&
-          !uiState.ctrlDPressedOnce &&
-          statusLineLines.map((line, i) => (
-            <Text
-              key={`status-line-${i}`}
-              color={
-                respectUserColors
-                  ? undefined
-                  : useThemeColors
-                    ? theme.text.accent
-                    : undefined
-              }
-              dimColor={respectUserColors ? false : !useThemeColors}
-              wrap="truncate"
+          !uiState.ctrlDPressedOnce && (
+            <Box
+              flexDirection="column"
+              maxHeight={MAX_STATUS_LINES}
+              overflow="hidden"
+              width="100%"
             >
-              {line}
-            </Text>
-          ))}
+              <Text
+                color={
+                  respectUserColors
+                    ? undefined
+                    : useThemeColors
+                      ? theme.text.accent
+                      : undefined
+                }
+                dimColor={respectUserColors ? false : !useThemeColors}
+                wrap="wrap"
+              >
+                {statusLineLines.join('\n')}
+              </Text>
+            </Box>
+          )}
         {/* Built-in worktree indicator. Shown by default whenever a
             worktree is active so the user always has a UI affordance,
             even when a custom statusline is configured — their script


### PR DESCRIPTION
## What this PR does

Wraps long custom status line output in the footer instead of truncating it on narrow terminals. The rendered status line area is still capped by `MAX_STATUS_LINES`, so wrapped output cannot grow the footer indefinitely.

## Why it's needed

Long custom status lines could previously disappear after the first row on narrow terminals. That made useful prompt/status details hard to read. Wrapping keeps the overflow visible while preserving the existing two-line footer bound.

## Reviewer Test Plan

### How to verify

- Configure `ui.statusLine` to emit a long line in a narrow terminal or tmux pane.
- Confirm the long line wraps onto the second footer row instead of truncating on row one.
- Confirm later status line entries are clipped once the wrapped output fills the two-row cap.
- Run `npm exec -- vitest run packages/cli/src/ui/components/Footer.test.tsx`.
- Run `npm exec -- eslint packages/cli/src/ui/components/Footer.tsx packages/cli/src/ui/components/Footer.test.tsx --ext .ts,.tsx`.
- Run `npm run typecheck --workspace packages/cli`.

### Evidence (Before & After)

Before, with the pre-fix `wrap="truncate"` behavior, the long line stayed on one row and later chunks were hidden:

```text
visible-start chunk-0 chunk-1 chunk-2 chunk-3...
```

After this change, the same content wraps into the bounded status area:

```text
visible-start chunk-0 chunk-1 chunk-2 chunk-3 chunk-4 chunk-5 chunk-6 chunk-7 chunk-8 chunk-9
chunk-10 chunk-11 chunk-12 chunk-13 chunk-14 chunk-15 chunk-16 chunk-17 chunk-18 chunk-19
```

The new unit test now asserts `chunk-10`, which is only visible when the long status line wraps. I also checked the mutation locally by temporarily changing `wrap="wrap"` back to `wrap="truncate"`; the test failed as expected.

Runtime A/B was also verified in a real Linux tmux narrow-pane CLI run in the PR comments.

### Tested on

| OS | Status |
| --- | --- |
| macOS | Local unit test, eslint, and CLI typecheck passed |
| Linux | Runtime A/B verified in tmux by reviewer |
| Windows | Not tested locally |

### Environment (optional)

Local verification used Node `v26.3.0`. The runtime tmux verification in the PR comments used Node 22 on Linux.

## Risk & Scope

Main tradeoff: a very long status line can now consume both allowed footer rows, so later status line entries may be clipped sooner than before.

Out of scope: this does not change status line command execution, command output collection, or status line configuration.

Breaking changes / migration notes: none.

## Linked Issues

Fixes #5064

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 footer 里的自定义 status line 在窄终端中换行显示，而不是在第一行直接截断。渲染区域仍然受 `MAX_STATUS_LINES` 限制，所以过长输出不会无限撑高 footer。

## 为什么需要

之前长 status line 在窄终端里第一行之后会被隐藏，很多有用的状态信息看不到。现在改为换行后，内容更容易读，同时保留两行上限。

## Reviewer Test Plan

### 如何验证

- 配置 `ui.statusLine` 输出一条很长的 status line，并在窄终端或 tmux pane 中运行。
- 确认长行会换到 footer 第二行，而不是在第一行被截断。
- 确认 wrapped 输出占满两行后，后续 status line 仍会被裁掉，footer 高度保持不变。
- 运行 `npm exec -- vitest run packages/cli/src/ui/components/Footer.test.tsx`。
- 运行 `npm exec -- eslint packages/cli/src/ui/components/Footer.tsx packages/cli/src/ui/components/Footer.test.tsx --ext .ts,.tsx`。
- 运行 `npm run typecheck --workspace packages/cli`。

### Before / After 证据

修复前的 `wrap="truncate"` 行为会把长行留在第一行，后续 token 被隐藏：

```text
visible-start chunk-0 chunk-1 chunk-2 chunk-3...
```

修复后，同样的内容会在两行 status 区域内换行：

```text
visible-start chunk-0 chunk-1 chunk-2 chunk-3 chunk-4 chunk-5 chunk-6 chunk-7 chunk-8 chunk-9
chunk-10 chunk-11 chunk-12 chunk-13 chunk-14 chunk-15 chunk-16 chunk-17 chunk-18 chunk-19
```

新增测试现在会断言 `chunk-10`，这个 token 只有在长 status line 真正换行后才可见。我也本地临时把 `wrap="wrap"` 改回 `wrap="truncate"` 做过 mutation check，测试会按预期失败。

PR 评论里也有 reviewer 在真实 Linux tmux 窄 pane CLI 下做的 A/B 验证。

### 测试平台

| OS | 状态 |
| --- | --- |
| macOS | 本地 unit test、eslint、CLI typecheck 通过 |
| Linux | reviewer 已在 tmux 中做 runtime A/B 验证 |
| Windows | 本地未测 |

### 环境

本地验证使用 Node `v26.3.0`。PR 评论里的 tmux runtime 验证使用 Linux + Node 22。

## 风险和范围

主要权衡：非常长的 status line 现在可能占满两行 footer，因此后续 status line entry 可能比以前更早被裁掉。

不在范围内：没有改 status line command 的执行、输出收集或配置逻辑。

破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #5064

</details>
