### PR TITLE
feat(core+cli): Workflow P4 — meta + /workflows + phase-tree (#4721)

### DIFF
--- a/packages/cli/src/services/BuiltinCommandLoader.test.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.test.ts
@@ -133,6 +133,7 @@ describe('BuiltinCommandLoader', () => {
       getDisableAllHooks: vi.fn().mockReturnValue(false),
       getManagedAutoMemoryEnabled: vi.fn().mockReturnValue(true),
       isLspEnabled: vi.fn().mockReturnValue(false),
+      isWorkflowsEnabled: vi.fn().mockReturnValue(false),
     } as unknown as Config;
 
     restoreCommandMock.mockReturnValue({

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -9,6 +9,7 @@ import type { SlashCommand } from '../ui/commands/types.js';
 import type { Config } from '@qwen-code/qwen-code-core';
 import { aboutCommand } from '../ui/commands/aboutCommand.js';
 import { tasksCommand } from '../ui/commands/tasksCommand.js';
+import { workflowsCommand } from '../ui/commands/workflowsCommand.js';
 import { agentsCommand } from '../ui/commands/agentsCommand.js';
 import { arenaCommand } from '../ui/commands/arenaCommand.js';
 import { approvalModeCommand } from '../ui/commands/approvalModeCommand.js';
@@ -100,6 +101,12 @@ export class BuiltinCommandLoader implements ICommandLoader {
       aboutCommand,
       agentsCommand,
       tasksCommand,
+      // Gated behind isWorkflowsEnabled — feature flag honors
+      // QWEN_CODE_ENABLE_WORKFLOWS (opt-in) and QWEN_CODE_DISABLE_WORKFLOWS
+      // (kill switch). When the flag is off the command vanishes entirely
+      // from typeahead and help, matching the established convention for
+      // experimental builtins.
+      this.config?.isWorkflowsEnabled() ? workflowsCommand : null,
       arenaCommand,
       approvalModeCommand,
       authCommand,

--- a/packages/cli/src/ui/commands/clearCommand.test.ts
+++ b/packages/cli/src/ui/commands/clearCommand.test.ts
@@ -90,6 +90,11 @@ describe('clearCommand', () => {
             abortAll: mockAbortMonitors,
             reset: mockResetMonitors,
           }),
+          getWorkflowRunRegistry: () => ({
+            hasRunningEntries: vi.fn().mockReturnValue(false),
+            reset: vi.fn(),
+            abortAll: vi.fn(),
+          }),
         },
       },
       session: {
@@ -343,6 +348,11 @@ describe('clearCommand', () => {
               abortAll: mockAbortMonitors,
               reset: mockResetMonitors,
             }),
+            getWorkflowRunRegistry: () => ({
+              hasRunningEntries: vi.fn().mockReturnValue(false),
+              reset: vi.fn(),
+              abortAll: vi.fn(),
+            }),
           },
         },
         session: {
@@ -405,6 +415,11 @@ describe('clearCommand', () => {
             getMonitorRegistry: vi.fn().mockReturnValue({
               getRunning: vi.fn().mockReturnValue([]),
               reset: vi.fn(),
+            }),
+            getWorkflowRunRegistry: vi.fn().mockReturnValue({
+              hasRunningEntries: vi.fn().mockReturnValue(false),
+              reset: vi.fn(),
+              abortAll: vi.fn(),
             }),
             getHookSystem: mockGetHookSystem,
             startNewSession: mockStartNewSession,
@@ -517,6 +532,11 @@ describe('clearCommand', () => {
             getMonitorRegistry: vi.fn().mockReturnValue({
               getRunning: vi.fn().mockReturnValue([]),
               reset: vi.fn(),
+            }),
+            getWorkflowRunRegistry: vi.fn().mockReturnValue({
+              hasRunningEntries: vi.fn().mockReturnValue(false),
+              reset: vi.fn(),
+              abortAll: vi.fn(),
             }),
             getHookSystem: mockGetHookSystem,
             startNewSession: mockStartNewSession,

--- a/packages/cli/src/ui/commands/workflowsCommand.test.ts
+++ b/packages/cli/src/ui/commands/workflowsCommand.test.ts
@@ -1,0 +1,160 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { workflowsCommand } from './workflowsCommand.js';
+import { type CommandContext } from './types.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import type { WorkflowTask } from '@qwen-code/qwen-code-core';
+
+function entry(overrides: Partial<WorkflowTask> = {}): WorkflowTask {
+  return {
+    id: 'wf_aaaaaaaa',
+    kind: 'workflow',
+    runId: 'wf_aaaaaaaa',
+    description: 'demo',
+    meta: null,
+    status: 'running',
+    startTime: 1_700_000_000_000,
+    outputFile: '',
+    outputOffset: 0,
+    notified: false,
+    abortController: new AbortController(),
+    currentPhase: null,
+    phases: [],
+    agentsDispatched: 0,
+    agentsCompleted: 0,
+    recentLogs: [],
+    ...overrides,
+  };
+}
+
+describe('workflowsCommand', () => {
+  let context: CommandContext;
+  let listMock: ReturnType<typeof vi.fn>;
+  let getMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    listMock = vi.fn().mockReturnValue([] as WorkflowTask[]);
+    getMock = vi.fn().mockReturnValue(undefined);
+    context = createMockCommandContext({
+      services: {
+        config: {
+          getWorkflowRunRegistry: () => ({
+            list: listMock,
+            get: getMock,
+          }),
+        },
+      },
+      executionMode: 'interactive',
+    } as unknown as Parameters<typeof createMockCommandContext>[0]);
+  });
+
+  it('returns info message when there are no runs', async () => {
+    const result = await workflowsCommand.action!(context, '');
+    expect(result).toMatchObject({
+      type: 'message',
+      messageType: 'info',
+      content: 'No workflow runs recorded yet.',
+    });
+  });
+
+  it('lists active + recent buckets with running first', async () => {
+    listMock.mockReturnValue([
+      entry({
+        runId: 'wf_done',
+        status: 'completed',
+        endTime: 1_700_000_010_000,
+      }),
+      entry({
+        runId: 'wf_running',
+        meta: { name: 'capitals', description: 'd' },
+        status: 'running',
+        currentPhase: 'Plan',
+        phases: ['Plan'],
+        agentsDispatched: 2,
+        agentsCompleted: 1,
+      }),
+    ]);
+    const result = await workflowsCommand.action!(context, '');
+    if (!result || result.type !== 'message') throw new Error('no result');
+    expect(result.content).toContain('Workflow runs (2 total · 1 running)');
+    const activeIdx = result.content.indexOf('Active');
+    const recentIdx = result.content.indexOf('Recent');
+    // Active section comes before Recent in the output.
+    expect(activeIdx).toBeGreaterThan(-1);
+    expect(recentIdx).toBeGreaterThan(activeIdx);
+    expect(result.content).toContain('wf_running');
+    expect(result.content).toContain('Plan');
+    expect(result.content).toContain('1/2 agents');
+    expect(result.content).toContain('wf_done');
+    expect(result.content).toContain('capitals');
+  });
+
+  it('omits the interactive tip in non_interactive / acp modes', async () => {
+    const ctx = createMockCommandContext({
+      services: {
+        config: {
+          getWorkflowRunRegistry: () => ({ list: listMock, get: getMock }),
+        },
+      },
+      executionMode: 'non_interactive',
+    } as unknown as Parameters<typeof createMockCommandContext>[0]);
+    listMock.mockReturnValue([entry()]);
+    const result = await workflowsCommand.action!(ctx, '');
+    if (!result || result.type !== 'message') throw new Error('no result');
+    expect(result.content).not.toMatch(/Tip:/);
+  });
+
+  it('detail view: known runId returns full per-field dump', async () => {
+    const detail = entry({
+      runId: 'wf_target',
+      meta: {
+        name: 'demo',
+        description: 'd',
+        whenToUse: 'when stuff',
+      },
+      status: 'completed',
+      phases: ['A', 'B'],
+      agentsDispatched: 3,
+      agentsCompleted: 3,
+      recentLogs: ['log1', 'log2'],
+      endTime: 1_700_000_010_000,
+    });
+    getMock.mockImplementation((id) =>
+      id === 'wf_target' ? detail : undefined,
+    );
+    const result = await workflowsCommand.action!(context, 'wf_target');
+    if (!result || result.type !== 'message') throw new Error('no result');
+    expect(result.messageType).toBe('info');
+    expect(result.content).toContain('Workflow wf_target');
+    expect(result.content).toContain('name        : demo');
+    expect(result.content).toContain('whenToUse   : when stuff');
+    expect(result.content).toContain('agents      : 3/3');
+    expect(result.content).toContain('· A');
+    expect(result.content).toContain('· B');
+    expect(result.content).toContain('log1');
+    expect(result.content).toContain('log2');
+  });
+
+  it('detail view: unknown runId returns clear error', async () => {
+    getMock.mockReturnValue(undefined);
+    const result = await workflowsCommand.action!(context, 'wf_missing');
+    expect(result).toMatchObject({
+      type: 'message',
+      messageType: 'error',
+      content: 'Unknown workflow runId: wf_missing',
+    });
+  });
+
+  it('argument is trimmed before lookup', async () => {
+    const target = entry({ runId: 'wf_t' });
+    getMock.mockImplementation((id) => (id === 'wf_t' ? target : undefined));
+    const result = await workflowsCommand.action!(context, '  wf_t  ');
+    if (!result || result.type !== 'message') throw new Error('no result');
+    expect(result.content).toContain('Workflow wf_t');
+  });
+});

--- a/packages/cli/src/ui/commands/workflowsCommand.ts
+++ b/packages/cli/src/ui/commands/workflowsCommand.ts
@@ -1,0 +1,179 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { WorkflowTask } from '@qwen-code/qwen-code-core';
+import type { SlashCommand } from './types.js';
+import { CommandKind } from './types.js';
+import { t } from '../../i18n/index.js';
+import { formatDuration } from '../utils/formatters.js';
+
+/**
+ * Format one workflow run as a one-line summary used by both the
+ * top-level listing and the per-run detail view.
+ */
+function rowLine(entry: WorkflowTask, now: number): string {
+  const endTime = entry.endTime ?? now;
+  const runtime = formatDuration(endTime - entry.startTime, {
+    hideTrailingZeros: true,
+  });
+  const label = entry.meta?.name ?? entry.runId;
+  const phase = entry.currentPhase ? ` · ${entry.currentPhase}` : '';
+  const counts =
+    entry.agentsDispatched > 0
+      ? ` · ${entry.agentsCompleted}/${entry.agentsDispatched} agents`
+      : '';
+  const phaseCount =
+    entry.phases.length > 0
+      ? ` · ${entry.phases.length} ${entry.phases.length === 1 ? 'phase' : 'phases'}`
+      : '';
+  const errorTail =
+    entry.status === 'failed' && entry.error
+      ? ` — ${entry.error.slice(0, 80)}`
+      : '';
+  return `  ${entry.runId.padEnd(20)} ${entry.status.padEnd(10)} ${runtime.padStart(8)}  ${label}${phase}${counts}${phaseCount}${errorTail}`;
+}
+
+function detailLines(entry: WorkflowTask, now: number): string[] {
+  const lines: string[] = [];
+  const endTime = entry.endTime ?? now;
+  const runtime = formatDuration(endTime - entry.startTime, {
+    hideTrailingZeros: true,
+  });
+
+  lines.push(`Workflow ${entry.runId}`);
+  if (entry.meta?.name) {
+    lines.push(`  name        : ${entry.meta.name}`);
+  }
+  if (entry.meta?.description) {
+    lines.push(`  description : ${entry.meta.description}`);
+  }
+  if (entry.meta?.whenToUse) {
+    lines.push(`  whenToUse   : ${entry.meta.whenToUse}`);
+  }
+  lines.push(`  status      : ${entry.status}`);
+  lines.push(`  runtime     : ${runtime}`);
+  if (entry.currentPhase) {
+    lines.push(`  currentPhase: ${entry.currentPhase}`);
+  }
+  lines.push(
+    `  agents      : ${entry.agentsCompleted}/${entry.agentsDispatched}`,
+  );
+  if (entry.error) {
+    lines.push(`  error       : ${entry.error}`);
+  }
+  if (entry.phases.length > 0) {
+    lines.push('');
+    lines.push(`  Phases (${entry.phases.length})`);
+    for (const phase of entry.phases) {
+      lines.push(`    · ${phase}`);
+    }
+  }
+  if (entry.recentLogs.length > 0) {
+    lines.push('');
+    lines.push(`  Logs (last ${entry.recentLogs.length})`);
+    for (const line of entry.recentLogs) {
+      lines.push(`    ${line}`);
+    }
+  }
+  return lines;
+}
+
+export const workflowsCommand: SlashCommand = {
+  name: 'workflows',
+  get description() {
+    return t(
+      'List active and completed workflow runs (text dump — interactive dialog opens via the footer pill)',
+    );
+  },
+  get argumentHint() {
+    return t('[runId]');
+  },
+  kind: CommandKind.BUILT_IN,
+  // Same triple-mode coverage as `/tasks`: the dialog is richer in
+  // interactive mode but headless / acp consumers need the text dump
+  // as their only inspection path.
+  supportedModes: ['interactive', 'non_interactive', 'acp'] as const,
+  action: async (context, args) => {
+    const { config } = context.services;
+    if (!config) {
+      return {
+        type: 'message' as const,
+        messageType: 'error' as const,
+        content: 'Config not available.',
+      };
+    }
+    const registry = config.getWorkflowRunRegistry();
+    const allEntries = registry.list();
+
+    // Targeted detail view: `/workflows wf_abc123` opens the detail
+    // dump for that run if it exists. Reject early on unknown runId so
+    // the user sees a clear error instead of an empty listing.
+    const trimmedArgs = (args ?? '').trim();
+    if (trimmedArgs.length > 0) {
+      const target = registry.get(trimmedArgs);
+      if (!target) {
+        return {
+          type: 'message' as const,
+          messageType: 'error' as const,
+          content: `Unknown workflow runId: ${trimmedArgs}`,
+        };
+      }
+      return {
+        type: 'message' as const,
+        messageType: 'info' as const,
+        content: detailLines(target, Date.now()).join('\n'),
+      };
+    }
+
+    if (allEntries.length === 0) {
+      return {
+        type: 'message' as const,
+        messageType: 'info' as const,
+        content: 'No workflow runs recorded yet.',
+      };
+    }
+
+    const now = Date.now();
+    // Order: running first (oldest startTime first inside the bucket so
+    // long-runners stay visible), then terminal by endTime DESC. Mirrors
+    // the dialog's two-bucket sort.
+    const running = allEntries
+      .filter((e) => e.status === 'running')
+      .sort((a, b) => a.startTime - b.startTime);
+    const terminal = allEntries
+      .filter((e) => e.status !== 'running')
+      .sort((a, b) => (b.endTime ?? 0) - (a.endTime ?? 0));
+
+    const lines: string[] = [];
+    if (context.executionMode === 'interactive') {
+      lines.push(
+        t(
+          'Tip: focus the Background tasks pill in the footer (use ↓ from an empty composer) and press Enter for the interactive dialog with phase tree + live updates.',
+        ),
+        '',
+      );
+    }
+    lines.push(
+      `Workflow runs (${allEntries.length} total · ${running.length} running)`,
+      '',
+    );
+    if (running.length > 0) {
+      lines.push('Active');
+      for (const entry of running) lines.push(rowLine(entry, now));
+      lines.push('');
+    }
+    if (terminal.length > 0) {
+      lines.push('Recent');
+      for (const entry of terminal) lines.push(rowLine(entry, now));
+    }
+
+    return {
+      type: 'message' as const,
+      messageType: 'info' as const,
+      content: lines.join('\n'),
+    };
+  },
+};

--- a/packages/cli/src/ui/commands/workflowsCommand.ts
+++ b/packages/cli/src/ui/commands/workflowsCommand.ts
@@ -151,7 +151,7 @@ export const workflowsCommand: SlashCommand = {
     if (context.executionMode === 'interactive') {
       lines.push(
         t(
-          'Tip: focus the Background tasks pill in the footer (use ↓ from an empty composer) and press Enter for the interactive dialog with phase tree + live updates.',
+          'Tip: use `/workflows <runId>` for the per-run detail view (name, description, phase tree, recent logs).',
         ),
         '',
       );

--- a/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.test.tsx
+++ b/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.test.tsx
@@ -37,6 +37,8 @@ vi.mock('../../hooks/useBackgroundTaskView.js', () => ({
         return entry.shellId;
       case 'monitor':
         return entry.monitorId;
+      case 'workflow':
+        return entry.runId;
       case 'dream':
         return entry.dreamId;
       default: {

--- a/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.tsx
+++ b/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.tsx
@@ -31,6 +31,7 @@ import {
   type BackgroundApproval,
   type MonitorTask,
   type ToolCallConfirmationDetails,
+  type WorkflowTask,
 } from '@qwen-code/qwen-code-core';
 import { ToolConfirmationMessage } from '../messages/ToolConfirmationMessage.js';
 import { formatDuration, formatTokenCount } from '../../utils/formatters.js';
@@ -192,6 +193,15 @@ function rowLabel(entry: DialogEntry): string {
       return `${SHELL_ROW_PREFIX} ${entry.command}`;
     case 'monitor':
       return `[monitor] ${entry.description}`;
+    case 'workflow': {
+      const label = entry.meta?.name ?? entry.runId;
+      const phase = entry.currentPhase ? ` · ${entry.currentPhase}` : '';
+      const counts =
+        entry.agentsDispatched > 0
+          ? ` (${entry.agentsCompleted}/${entry.agentsDispatched})`
+          : '';
+      return `[workflow] ${label}${phase}${counts}`;
+    }
     case 'dream':
       return formatDreamRowLabel(entry);
     default: {
@@ -357,6 +367,14 @@ const DetailBody: React.FC<{
     case 'monitor':
       return (
         <MonitorDetailBody
+          entry={entry}
+          maxHeight={maxHeight}
+          maxWidth={maxWidth}
+        />
+      );
+    case 'workflow':
+      return (
+        <WorkflowDetailBody
           entry={entry}
           maxHeight={maxHeight}
           maxWidth={maxWidth}
@@ -865,6 +883,156 @@ const MonitorDetailBody: React.FC<{
           </Box>
           <Box>
             <Text color={errorColor} wrap="wrap">
+              {entry.error}
+            </Text>
+          </Box>
+        </Fragment>
+      )}
+    </MaxSizedBox>
+  );
+};
+
+// ─── Workflow detail body ──────────────────────────────────
+//
+// Shows the workflow's declared meta (name + description + whenToUse),
+// the phase tree with truncation, per-phase dispatch counts, and the
+// log tail. Phase tree is capped at MAX_VISIBLE_PHASES with a "+N more
+// above" header so deeply nested fan-outs don't blow the dialog body.
+// Logs are the most recent tail; the registry caps at 100 lines but
+// the body further truncates to fit the available height.
+
+const MAX_VISIBLE_PHASES = 20;
+const MAX_VISIBLE_LOG_LINES = 10;
+
+const WorkflowDetailBody: React.FC<{
+  entry: WorkflowTask;
+  maxHeight: number;
+  maxWidth: number;
+}> = ({ entry, maxHeight, maxWidth }) => {
+  const title = `${t('Workflow')} › ${entry.meta?.name ?? entry.runId}`;
+  const terminal = terminalStatusPresentation(entry.status);
+  const dimSubtitleParts: string[] = [elapsedFor(entry)];
+  if (entry.agentsDispatched > 0) {
+    dimSubtitleParts.push(
+      `${entry.agentsCompleted}/${entry.agentsDispatched} ${t('agents')}`,
+    );
+  }
+  dimSubtitleParts.push(
+    `${entry.phases.length} ${entry.phases.length === 1 ? t('phase') : t('phases')}`,
+  );
+
+  // Phase tree: collapse the head when over the visible cap, keeping
+  // the most recent N entries (the user almost always wants to see the
+  // current state, not the launch sequence).
+  const phaseOverflow = Math.max(0, entry.phases.length - MAX_VISIBLE_PHASES);
+  const visiblePhases = entry.phases.slice(-MAX_VISIBLE_PHASES);
+
+  // Log tail: similar truncation logic; show "+N more above" header if
+  // the registry has more than the visible window.
+  const logOverflow = Math.max(
+    0,
+    entry.recentLogs.length - MAX_VISIBLE_LOG_LINES,
+  );
+  const visibleLogs = entry.recentLogs.slice(-MAX_VISIBLE_LOG_LINES);
+
+  const hasError = Boolean(entry.error);
+
+  return (
+    <MaxSizedBox
+      maxHeight={maxHeight}
+      maxWidth={maxWidth}
+      overflowDirection="bottom"
+    >
+      <Box>
+        <Text bold color={theme.text.accent}>
+          {title}
+        </Text>
+      </Box>
+      <Box>
+        {terminal && (
+          <Text color={terminal.color}>
+            {`${terminal.icon} ${statusVerb(entry.status)} · `}
+          </Text>
+        )}
+        <Text color={theme.text.secondary}>{dimSubtitleParts.join(' · ')}</Text>
+      </Box>
+
+      {entry.meta?.description && (
+        <Fragment>
+          <Box />
+          <Box>
+            <Text wrap="wrap">{entry.meta.description}</Text>
+          </Box>
+        </Fragment>
+      )}
+
+      <Box />
+      <Box>
+        <Text bold dimColor>
+          {t('Phases')}
+        </Text>
+      </Box>
+      {entry.phases.length === 0 ? (
+        <Box>
+          <Text dimColor>{t('(no phase recorded yet)')}</Text>
+        </Box>
+      ) : (
+        <Fragment>
+          {phaseOverflow > 0 && (
+            <Box>
+              <Text dimColor>{`+${phaseOverflow} ${t('more above')}`}</Text>
+            </Box>
+          )}
+          {visiblePhases.map((phaseTitle, i) => {
+            const isCurrent =
+              entry.status === 'running' &&
+              i === visiblePhases.length - 1 &&
+              entry.currentPhase === phaseTitle;
+            const marker = isCurrent ? '▸' : '·';
+            return (
+              <Box key={`${phaseTitle}-${i}`}>
+                <Text color={isCurrent ? theme.status.success : undefined}>
+                  {`  ${marker} ${phaseTitle}`}
+                </Text>
+              </Box>
+            );
+          })}
+        </Fragment>
+      )}
+
+      {entry.recentLogs.length > 0 && (
+        <Fragment>
+          <Box />
+          <Box>
+            <Text bold dimColor>
+              {t('Logs')}
+            </Text>
+          </Box>
+          {logOverflow > 0 && (
+            <Box>
+              <Text dimColor>{`+${logOverflow} ${t('more above')}`}</Text>
+            </Box>
+          )}
+          {visibleLogs.map((line, i) => (
+            <Box key={`log-${i}`}>
+              <Text wrap="truncate-end" dimColor>
+                {line}
+              </Text>
+            </Box>
+          ))}
+        </Fragment>
+      )}
+
+      {hasError && (
+        <Fragment>
+          <Box />
+          <Box>
+            <Text bold color={theme.status.error}>
+              {t('Error')}
+            </Text>
+          </Box>
+          <Box>
+            <Text color={theme.status.error} wrap="wrap">
               {entry.error}
             </Text>
           </Box>

--- a/packages/cli/src/ui/components/background-view/BackgroundTasksPill.tsx
+++ b/packages/cli/src/ui/components/background-view/BackgroundTasksPill.tsx
@@ -20,6 +20,7 @@ const KIND_NAMES = {
   agent: { singular: 'local agent', plural: 'local agents' },
   shell: { singular: 'shell', plural: 'shells' },
   monitor: { singular: 'monitor', plural: 'monitors' },
+  workflow: { singular: 'workflow', plural: 'workflows' },
   dream: { singular: 'dream', plural: 'dreams' },
 } as const;
 
@@ -61,16 +62,19 @@ export function getPillLabel(entries: readonly DialogEntry[]): string {
 }
 
 function groupAndFormat(entries: readonly DialogEntry[]): string {
-  const counts = { agent: 0, shell: 0, monitor: 0, dream: 0 };
+  const counts = { agent: 0, shell: 0, monitor: 0, workflow: 0, dream: 0 };
   for (const e of entries) counts[e.kind]++;
   const parts: string[] = [];
   // Order: shell first (matches Claude Code's pill convention), then
-  // agent, then monitor, then dream. Dream sits last because it is
+  // agent, then monitor, then workflow (user-initiated multi-phase
+  // orchestration), then dream. Dream sits last because it is
   // system-initiated (not user-triggered) and the user is least likely
-  // to need it at a glance.
+  // to need it at a glance; workflows are user-triggered so they sit
+  // immediately after monitors and before dream.
   if (counts.shell > 0) parts.push(formatCount('shell', counts.shell));
   if (counts.agent > 0) parts.push(formatCount('agent', counts.agent));
   if (counts.monitor > 0) parts.push(formatCount('monitor', counts.monitor));
+  if (counts.workflow > 0) parts.push(formatCount('workflow', counts.workflow));
   if (counts.dream > 0) parts.push(formatCount('dream', counts.dream));
   return parts.join(', ');
 }

--- a/packages/cli/src/ui/contexts/BackgroundTaskViewContext.tsx
+++ b/packages/cli/src/ui/contexts/BackgroundTaskViewContext.tsx
@@ -259,6 +259,15 @@ export function BackgroundTaskViewProvider({
         }
         break;
       }
+      case 'workflow':
+        // Aborts the orchestrator + in-flight dispatches via the
+        // registry's cancel — flips status to 'cancelled' and signals
+        // the AbortController the WorkflowTool wired into the run.
+        // The tool's catch arm sees signal.aborted and records the
+        // terminal in the registry; the registry.cancel here is the
+        // first half of that race (idempotent on either ordering).
+        config.getWorkflowRunRegistry().cancel(target.runId, Date.now());
+        break;
       default: {
         const _exhaustive: never = target;
         throw new Error(

--- a/packages/cli/src/ui/hooks/useBackgroundTaskView.test.ts
+++ b/packages/cli/src/ui/hooks/useBackgroundTaskView.test.ts
@@ -73,6 +73,7 @@ function makeConfig(opts: {
   shells: () => unknown[];
   monitors: () => unknown[];
   dreams?: () => unknown[];
+  workflows?: () => unknown[];
 }) {
   const agentReg = makeFakeRegistry();
   const shellReg = makeFakeRegistry();
@@ -92,6 +93,10 @@ function makeConfig(opts: {
     getMonitorRegistry: () => ({
       ...monitorReg,
       getAll: opts.monitors,
+    }),
+    getWorkflowRunRegistry: () => ({
+      list: () => opts.workflows?.() ?? [],
+      setStatusChangeCallback: () => {},
     }),
     getMemoryManager: () => ({
       subscribe: memoryMgr.subscribe,
@@ -395,7 +400,7 @@ describe('useBackgroundTaskView', () => {
           timestamp: Date.now(),
         },
       ],
-    } as typeof agents[number];
+    } as (typeof agents)[number];
 
     act(() => agentReg.fireApproval());
 

--- a/packages/cli/src/ui/hooks/useBackgroundTaskView.ts
+++ b/packages/cli/src/ui/hooks/useBackgroundTaskView.ts
@@ -33,6 +33,7 @@ import {
   type MonitorTask,
   type ShellTask,
   type TaskState,
+  type WorkflowTask,
 } from '@qwen-code/qwen-code-core';
 
 // Cap on retained terminal dream entries surfaced via the dialog.
@@ -116,6 +117,8 @@ export function entryId(entry: DialogEntry): string {
       return entry.shellId;
     case 'monitor':
       return entry.monitorId;
+    case 'workflow':
+      return entry.runId;
     case 'dream':
       return entry.dreamId;
     default: {
@@ -137,6 +140,7 @@ export function useBackgroundTaskView(
     const agentRegistry = config.getBackgroundTaskRegistry();
     const shellRegistry = config.getBackgroundShellRegistry();
     const monitorRegistry = config.getMonitorRegistry();
+    const workflowRegistry = config.getWorkflowRunRegistry();
     const memoryManager = config.getMemoryManager();
     const projectRoot = config.getProjectRoot();
     // Dream snapshot signature, kept as a defense-in-depth dedup for
@@ -161,6 +165,7 @@ export function useBackgroundTaskView(
       const agentEntries: AgentTask[] = [...agentRegistry.getAll()];
       const shellEntries: ShellTask[] = [...shellRegistry.getAll()];
       const monitorEntries: MonitorTask[] = [...monitorRegistry.getAll()];
+      const workflowEntries: WorkflowTask[] = [...workflowRegistry.list()];
       // Dream entries: only surface tasks that actually fired.
       // `pending` is a sub-second transition state and `skipped`
       // records arise from the rare race where the schedule-time
@@ -246,6 +251,7 @@ export function useBackgroundTaskView(
         ...agentEntries,
         ...shellEntries,
         ...monitorEntries,
+        ...workflowEntries,
         ...dreamEntries,
       ].sort((a, b) => {
         const aActive = isActive(a);
@@ -278,6 +284,7 @@ export function useBackgroundTaskView(
     agentRegistry.setStatusChangeCallback(refreshFromRegistry);
     shellRegistry.setStatusChangeCallback(refreshFromRegistry);
     monitorRegistry.setStatusChangeCallback(refreshFromRegistry);
+    workflowRegistry.setStatusChangeCallback(refreshFromRegistry);
 
     // Permission bubbling: a background agent parking (or resolving) a tool
     // call for approval mutates `pendingApprovals` without a status change,
@@ -310,6 +317,7 @@ export function useBackgroundTaskView(
       agentRegistry.setStatusChangeCallback(undefined);
       shellRegistry.setStatusChangeCallback(undefined);
       monitorRegistry.setStatusChangeCallback(undefined);
+      workflowRegistry.setStatusChangeCallback(undefined);
       agentRegistry.setApprovalChangeCallback(undefined);
       unsubscribeMemory();
     };

--- a/packages/cli/src/ui/hooks/useResumeCommand.test.ts
+++ b/packages/cli/src/ui/hooks/useResumeCommand.test.ts
@@ -175,6 +175,11 @@ describe('useResumeCommand', () => {
         getRunning: vi.fn().mockReturnValue([]),
         reset: resetMonitorRegistry,
       }),
+      getWorkflowRunRegistry: () => ({
+        hasRunningEntries: vi.fn().mockReturnValue(false),
+        reset: vi.fn(),
+        abortAll: vi.fn(),
+      }),
       loadPausedBackgroundAgents: vi.fn().mockResolvedValue([]),
       getBackgroundAgentResumeService: () => ({
         buildRecoveredBackgroundAgentsNotice: vi.fn(),
@@ -271,6 +276,11 @@ describe('useResumeCommand', () => {
         getRunning: vi.fn().mockReturnValue([]),
         reset: vi.fn(),
       }),
+      getWorkflowRunRegistry: () => ({
+        hasRunningEntries: vi.fn().mockReturnValue(false),
+        reset: vi.fn(),
+        abortAll: vi.fn(),
+      }),
       loadPausedBackgroundAgents: vi
         .fn()
         .mockResolvedValue([{ agentId: 'a' }, { agentId: 'b' }]),
@@ -329,6 +339,11 @@ describe('useResumeCommand', () => {
       getMonitorRegistry: () => ({
         getRunning: vi.fn().mockReturnValue([]),
         reset: vi.fn(),
+      }),
+      getWorkflowRunRegistry: () => ({
+        hasRunningEntries: vi.fn().mockReturnValue(false),
+        reset: vi.fn(),
+        abortAll: vi.fn(),
       }),
       getTargetDir: () => '/tmp',
       getDebugLogger: () => ({
@@ -393,6 +408,11 @@ describe('useResumeCommand', () => {
           },
         ]),
         reset: vi.fn(),
+      }),
+      getWorkflowRunRegistry: () => ({
+        hasRunningEntries: vi.fn().mockReturnValue(false),
+        reset: vi.fn(),
+        abortAll: vi.fn(),
       }),
       getTargetDir: () => '/tmp',
       getDebugLogger: () => ({

--- a/packages/cli/src/ui/utils/backgroundWorkUtils.test.ts
+++ b/packages/cli/src/ui/utils/backgroundWorkUtils.test.ts
@@ -15,6 +15,7 @@ function createMockConfig(overrides?: {
   hasUnfinalizedTasks?: boolean;
   runningMonitors?: unknown[];
   hasRunningEntries?: boolean;
+  hasRunningWorkflows?: boolean;
 }): Config {
   return {
     getBackgroundTaskRegistry: () => ({
@@ -27,6 +28,10 @@ function createMockConfig(overrides?: {
     }),
     getBackgroundShellRegistry: () => ({
       hasRunningEntries: () => overrides?.hasRunningEntries ?? false,
+      reset: vi.fn(),
+    }),
+    getWorkflowRunRegistry: () => ({
+      hasRunningEntries: () => overrides?.hasRunningWorkflows ?? false,
       reset: vi.fn(),
     }),
   } as unknown as Config;
@@ -56,6 +61,17 @@ describe('hasBlockingBackgroundWork', () => {
   it('returns true when shell entries are running', () => {
     expect(
       hasBlockingBackgroundWork(createMockConfig({ hasRunningEntries: true })),
+    ).toBe(true);
+  });
+
+  // R7 (wenshao): workflow registry is the 4th sibling. Without
+  // including it in the OR chain, /clear and session-resume happily
+  // ran while a workflow was mid-run, orphaning the dispatch loop.
+  it('returns true when a workflow is still running', () => {
+    expect(
+      hasBlockingBackgroundWork(
+        createMockConfig({ hasRunningWorkflows: true }),
+      ),
     ).toBe(true);
   });
 
@@ -96,15 +112,17 @@ describe('hasBlockingBackgroundWork', () => {
 });
 
 describe('resetBackgroundStateForSessionSwitch', () => {
-  it('calls reset on all three registries', () => {
+  it('calls reset on all four registries', () => {
     const resetTasks = vi.fn();
     const resetMonitors = vi.fn();
     const resetShells = vi.fn();
+    const resetWorkflows = vi.fn();
 
     const config = {
       getBackgroundTaskRegistry: () => ({ reset: resetTasks }),
       getMonitorRegistry: () => ({ reset: resetMonitors }),
       getBackgroundShellRegistry: () => ({ reset: resetShells }),
+      getWorkflowRunRegistry: () => ({ reset: resetWorkflows }),
     } as unknown as Config;
 
     resetBackgroundStateForSessionSwitch(config);
@@ -112,5 +130,6 @@ describe('resetBackgroundStateForSessionSwitch', () => {
     expect(resetTasks).toHaveBeenCalledOnce();
     expect(resetMonitors).toHaveBeenCalledOnce();
     expect(resetShells).toHaveBeenCalledOnce();
+    expect(resetWorkflows).toHaveBeenCalledOnce();
   });
 });

--- a/packages/cli/src/ui/utils/backgroundWorkUtils.ts
+++ b/packages/cli/src/ui/utils/backgroundWorkUtils.ts
@@ -10,7 +10,12 @@ export function hasBlockingBackgroundWork(config: Config): boolean {
   return (
     config.getBackgroundTaskRegistry().hasUnfinalizedTasks() ||
     config.getMonitorRegistry().getRunning().length > 0 ||
-    config.getBackgroundShellRegistry().hasRunningEntries()
+    config.getBackgroundShellRegistry().hasRunningEntries() ||
+    // R7 (wenshao): the WorkflowRunRegistry is a 4th sibling that the
+    // earlier P4b commit forgot to wire here. Without this OR clause,
+    // /clear and session-resume happily ran while a workflow was
+    // mid-run, orphaning the dispatch loop.
+    config.getWorkflowRunRegistry().hasRunningEntries()
   );
 }
 
@@ -18,4 +23,8 @@ export function resetBackgroundStateForSessionSwitch(config: Config): void {
   config.getBackgroundTaskRegistry().reset();
   config.getMonitorRegistry().reset();
   config.getBackgroundShellRegistry().reset();
+  // R7 (wenshao): symmetric with hasBlockingBackgroundWork — without
+  // this call, terminal workflow rows from the previous session
+  // leaked into the next session's pill / dialog / /workflows list.
+  config.getWorkflowRunRegistry().reset();
 }

--- a/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
@@ -274,6 +274,129 @@ describe('WorkflowOrchestrator', () => {
       }),
     ).rejects.toThrow(/agent-crashed/);
   });
+
+  // P4b Round 5 (wenshao): the emitter field on WorkflowRunRequest and
+  // its firing sites (sandbox safePhase, sandbox safeLog, orchestrator
+  // countedDispatch before + after) are the only channel that keeps the
+  // WorkflowRunRegistry record in sync with the live run. If a refactor
+  // drops one of these callback sites — or removes the defensive
+  // try/catch around `agentCompleted` on the rejection path — the UI
+  // would show stale dispatch counts or missing phases with no test
+  // catching it. These three tests pin the contract.
+
+  it('emitter callbacks fire in expected order with expected args', async () => {
+    const orchestrator = new WorkflowOrchestrator(
+      async (prompt) => `mock:${prompt}`,
+    );
+    const events: Array<{ kind: string; payload: unknown }> = [];
+    const emitter = {
+      phaseStarted: (title: string) =>
+        events.push({ kind: 'phase', payload: title }),
+      agentDispatched: (label?: string) =>
+        events.push({ kind: 'dispatched', payload: label }),
+      agentCompleted: (label?: string, error?: string) =>
+        events.push({ kind: 'completed', payload: { label, error } }),
+      logAppended: (line: string) =>
+        events.push({ kind: 'log', payload: line }),
+    };
+    const outcome = await orchestrator.run({
+      script: `
+        phase('Plan');
+        log('starting');
+        await agent('q1', { label: 'first' });
+        phase('Build');
+        await agent('q2', { label: 'second' });
+        return 'ok';
+      `,
+      args: undefined,
+      emitter,
+    });
+
+    expect(outcome.result).toBe('ok');
+    expect(outcome.phases).toEqual(['Plan', 'Build']);
+    // Event ordering: phase('Plan') → log('starting') → dispatch first →
+    // complete first → phase('Build') → dispatch second → complete second.
+    // No barriers between sandbox-side emits (phase/log) and dispatch
+    // emits — the test only pins the relative ordering across the run,
+    // not exact wall-clock interleaving.
+    const kinds = events.map((e) => e.kind);
+    expect(kinds).toEqual([
+      'phase',
+      'log',
+      'dispatched',
+      'completed',
+      'phase',
+      'dispatched',
+      'completed',
+    ]);
+    expect(events[0]!.payload).toBe('Plan');
+    expect(events[1]!.payload).toBe('starting');
+    expect(events[2]!.payload).toBe('first');
+    expect(events[3]!.payload).toEqual({ label: 'first', error: undefined });
+    expect(events[4]!.payload).toBe('Build');
+    expect(events[5]!.payload).toBe('second');
+    expect(events[6]!.payload).toEqual({ label: 'second', error: undefined });
+  });
+
+  it('agentCompleted carries the error message on dispatch rejection', async () => {
+    const orchestrator = new WorkflowOrchestrator(async () => {
+      throw new Error('dispatch-boom');
+    });
+    const completions: Array<{ label?: string; error?: string }> = [];
+    const emitter = {
+      agentCompleted: (label?: string, error?: string) =>
+        completions.push({ label, error }),
+    };
+    await expect(
+      orchestrator.run({
+        script: `await agent("x", { label: "doomed" }); return 0;`,
+        args: undefined,
+        emitter,
+      }),
+    ).rejects.toThrow(/dispatch-boom/);
+
+    expect(completions).toHaveLength(1);
+    expect(completions[0]).toEqual({
+      label: 'doomed',
+      error: 'dispatch-boom',
+    });
+  });
+
+  it('emitter subscriber errors do not break the run (defensive try/catch)', async () => {
+    const orchestrator = new WorkflowOrchestrator(
+      async (prompt) => `mock:${prompt}`,
+    );
+    // Every callback throws — should be swallowed so the orchestration
+    // still completes. Without the defensive try/catch around each emit
+    // site, the first thrown subscriber error would surface as the run
+    // failure even though the script body is fine.
+    const emitter = {
+      phaseStarted: () => {
+        throw new Error('phase-subscriber-boom');
+      },
+      agentDispatched: () => {
+        throw new Error('dispatched-subscriber-boom');
+      },
+      agentCompleted: () => {
+        throw new Error('completed-subscriber-boom');
+      },
+      logAppended: () => {
+        throw new Error('log-subscriber-boom');
+      },
+    };
+    const outcome = await orchestrator.run({
+      script: `
+        phase('Plan');
+        log('hello');
+        const a = await agent('q1');
+        return a;
+      `,
+      args: undefined,
+      emitter,
+    });
+    expect(outcome.result).toBe('mock:q1');
+    expect(outcome.phases).toEqual(['Plan']);
+  });
 });
 
 describe('createProductionDispatch', () => {

--- a/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
@@ -177,6 +177,54 @@ describe('WorkflowOrchestrator', () => {
     expect(outcome.result).toBe('world');
   });
 
+  // P4: outcome.meta surfaces the extracted `export const meta = {...}`
+  // declaration. Null when the script omits it.
+  it('outcome.meta is null when the script has no meta declaration', async () => {
+    const orchestrator = new WorkflowOrchestrator(async () => 'unused');
+    const outcome = await orchestrator.run({
+      script: `return 1`,
+      args: undefined,
+    });
+    expect(outcome.meta).toBeNull();
+  });
+
+  it('outcome.meta is the parsed meta when the script declares one', async () => {
+    const orchestrator = new WorkflowOrchestrator(async () => 'unused');
+    const outcome = await orchestrator.run({
+      script: `export const meta = { name: 'demo', description: 'demo workflow', phases: [{ title: 'plan' }] }
+               return 1`,
+      args: undefined,
+    });
+    expect(outcome.meta).toEqual({
+      name: 'demo',
+      description: 'demo workflow',
+      phases: [{ title: 'plan' }],
+    });
+    expect(outcome.result).toBe(1);
+  });
+
+  // P4: a script body that throws still surfaces the meta on the wrapped
+  // WorkflowExecutionError so the user-facing display can identify which
+  // workflow ran before the body failed.
+  it('WorkflowExecutionError carries meta when the body throws AFTER meta parsed', async () => {
+    const orchestrator = new WorkflowOrchestrator(async () => 'unused');
+    let caught: unknown;
+    try {
+      await orchestrator.run({
+        script: `export const meta = { name: 'fails', description: 'will throw' }
+                 throw new Error("body boom")`,
+        args: undefined,
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(WorkflowExecutionError);
+    expect((caught as WorkflowExecutionError).meta).toEqual({
+      name: 'fails',
+      description: 'will throw',
+    });
+  });
+
   it('surfaces a thrown error from the script', async () => {
     const orchestrator = new WorkflowOrchestrator(async () => 'unused');
     await expect(

--- a/packages/core/src/agents/runtime/workflow-orchestrator.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.ts
@@ -12,6 +12,7 @@ import type {
   WorkflowAgentOpts,
   WorkflowAgentResult,
   WorkflowMeta,
+  WorkflowOrchestratorEmitter,
 } from './workflow-sandbox.js';
 import {
   WORKFLOW_SUBAGENT_SYSTEM_PROMPT,
@@ -180,7 +181,7 @@ export class WorkflowExecutionError extends Error {
 // FIX-E (Round 4 ARCH-I1): single source of truth for the dispatch return
 // type is `workflow-sandbox.ts`. Re-exported here so external consumers
 // (WorkflowTool) can import the alias from the orchestrator module.
-export type { WorkflowAgentResult, WorkflowMeta };
+export type { WorkflowAgentResult, WorkflowMeta, WorkflowOrchestratorEmitter };
 
 export interface WorkflowRunRequest {
   script: string;
@@ -200,6 +201,24 @@ export interface WorkflowRunRequest {
    * until their internal `max_time_minutes` limit.
    */
   abortOnTimeout?: AbortController;
+  /**
+   * P4b: optional host-side event channel. When provided, the orchestrator
+   * fires `agentDispatched` / `agentCompleted` inside `countedDispatch`
+   * and the sandbox fires `phaseStarted` / `logAppended` from `safePhase`
+   * / `safeLog`. Wired into `SandboxOptions.emitter` and used by
+   * `WorkflowTool` to keep the `WorkflowRunRegistry` record in sync
+   * with the run state for the pill + dialog + detail body.
+   */
+  emitter?: WorkflowOrchestratorEmitter;
+  /**
+   * P4b: pre-generated run identifier (shape `wf_<hex>`). Callers that
+   * need the id at register-time (e.g. `WorkflowTool` registering the
+   * run with `WorkflowRunRegistry` before `run()` resolves) must
+   * pre-generate one and pass it here. Omitted by tests and by the
+   * historical contract; orchestrator falls back to its own generator
+   * so existing call sites work unchanged.
+   */
+  runId?: string;
 }
 
 export interface WorkflowRunOutcome {
@@ -1057,7 +1076,14 @@ export class WorkflowOrchestrator {
     // queued dispatches promptly. Sync-loop protection is the 30s vm
     // timeout in workflow-sandbox.ts; async-loop cancellation flows through
     // dispatch's subagent.execute path.
-    const runId = generateRunId();
+    //
+    // P4b: callers (`WorkflowTool`) may pre-generate `runId` and pass it
+    // in so they can register the run with `WorkflowRunRegistry` BEFORE
+    // `run()` resolves — necessary because the registry needs the id at
+    // emit time, not at resolve time. The orchestrator validates the
+    // shape (`wf_<hex>`) but otherwise trusts the caller. When omitted,
+    // the orchestrator generates one as before.
+    const runId = req.runId ?? generateRunId();
 
     const maxAgents = resolveMaxAgentsPerRun();
     const signal = req.abortOnTimeout?.signal;
@@ -1078,6 +1104,7 @@ export class WorkflowOrchestrator {
     // cap regardless of launch path (increment-then-check: calls 1..max pass,
     // the (max+1)th throws), and limiter.run enforces the concurrency window.
     let agentCount = 0;
+    const emitter = req.emitter;
     const countedDispatch: WorkflowAgentDispatch = (prompt, opts) => {
       agentCount += 1;
       if (agentCount > maxAgents) {
@@ -1087,7 +1114,38 @@ export class WorkflowOrchestrator {
           ),
         );
       }
-      return limiter.run(() => this.dispatch(prompt, opts));
+      // P4b: emit dispatch-start outside the limiter so the registry
+      // sees "queued" the moment the script issued the call, not after
+      // a slot frees. Symmetric agentCompleted fires after the dispatch
+      // settles (success or thrown) — defensive try/catch on both so a
+      // subscriber error never propagates into the script.
+      const label = typeof opts.label === 'string' ? opts.label : undefined;
+      try {
+        emitter?.agentDispatched?.(label);
+      } catch (e) {
+        debugLogger.warn('emitter.agentDispatched threw:', e);
+      }
+      return limiter
+        .run(() => this.dispatch(prompt, opts))
+        .then(
+          (result) => {
+            try {
+              emitter?.agentCompleted?.(label);
+            } catch (e) {
+              debugLogger.warn('emitter.agentCompleted threw:', e);
+            }
+            return result;
+          },
+          (err) => {
+            const msg = err instanceof Error ? err.message : String(err);
+            try {
+              emitter?.agentCompleted?.(label, msg);
+            } catch (e) {
+              debugLogger.warn('emitter.agentCompleted threw:', e);
+            }
+            throw err;
+          },
+        );
     };
 
     const parallelImpl = makeParallelImpl(signal);
@@ -1099,6 +1157,7 @@ export class WorkflowOrchestrator {
       parallel: parallelImpl,
       pipeline: pipelineImpl,
       abortOnTimeout: req.abortOnTimeout,
+      emitter,
     });
     try {
       const result = await sandbox.run(req.script);

--- a/packages/core/src/agents/runtime/workflow-orchestrator.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.ts
@@ -11,6 +11,7 @@ import { createWorkflowSandbox, debugLogger } from './workflow-sandbox.js';
 import type {
   WorkflowAgentOpts,
   WorkflowAgentResult,
+  WorkflowMeta,
 } from './workflow-sandbox.js';
 import {
   WORKFLOW_SUBAGENT_SYSTEM_PROMPT,
@@ -164,6 +165,13 @@ export class WorkflowExecutionError extends Error {
     message: string,
     readonly phases: string[],
     readonly logs: string[],
+    /**
+     * The extracted meta if it was parsed before the script body threw —
+     * null otherwise (no declaration in the source, or malformed meta
+     * which itself was the failure). Surfaced so the tool's failure
+     * display can still show the workflow's name / description / phases.
+     */
+    readonly meta: WorkflowMeta | null = null,
   ) {
     super(message);
   }
@@ -172,7 +180,7 @@ export class WorkflowExecutionError extends Error {
 // FIX-E (Round 4 ARCH-I1): single source of truth for the dispatch return
 // type is `workflow-sandbox.ts`. Re-exported here so external consumers
 // (WorkflowTool) can import the alias from the orchestrator module.
-export type { WorkflowAgentResult };
+export type { WorkflowAgentResult, WorkflowMeta };
 
 export interface WorkflowRunRequest {
   script: string;
@@ -199,6 +207,14 @@ export interface WorkflowRunOutcome {
   result: unknown;
   phases: string[];
   logs: string[];
+  /**
+   * The script's `export const meta = {...}` declaration (P4). `null` when
+   * the script omits the declaration. Surfaced verbatim from the sandbox's
+   * `getMeta()` so callers (`/workflows` listing, phase-tree UI) can read
+   * the workflow's name / description / phases / whenToUse without
+   * re-parsing the script source.
+   */
+  meta: WorkflowMeta | null;
 }
 
 export type WorkflowAgentDispatch = (
@@ -1091,6 +1107,7 @@ export class WorkflowOrchestrator {
         result,
         phases: sandbox.getPhases(),
         logs: sandbox.getLogs(),
+        meta: sandbox.getMeta(),
       };
     } catch (err) {
       // T19 (PR #4732 R1): preserve phases and logs accumulated before the
@@ -1105,6 +1122,7 @@ export class WorkflowOrchestrator {
         extractErrorMessage(err),
         sandbox.getPhases(),
         sandbox.getLogs(),
+        sandbox.getMeta(),
       );
     }
   }

--- a/packages/core/src/agents/runtime/workflow-orchestrator.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.ts
@@ -211,12 +211,14 @@ export interface WorkflowRunRequest {
    */
   emitter?: WorkflowOrchestratorEmitter;
   /**
-   * P4b: pre-generated run identifier (shape `wf_<hex>`). Callers that
-   * need the id at register-time (e.g. `WorkflowTool` registering the
-   * run with `WorkflowRunRegistry` before `run()` resolves) must
-   * pre-generate one and pass it here. Omitted by tests and by the
-   * historical contract; orchestrator falls back to its own generator
-   * so existing call sites work unchanged.
+   * P4b: pre-generated run identifier. Callers that need the id at
+   * register-time (e.g. `WorkflowTool` registering the run with
+   * `WorkflowRunRegistry` before `run()` resolves) must pre-generate
+   * one and pass it here. The orchestrator does NOT validate the
+   * shape — it trusts the caller (the production caller uses
+   * `wf_<8hex>` to match `generateRunId()`). Omitted by tests and by
+   * the historical contract; orchestrator falls back to its own
+   * generator so existing call sites work unchanged.
    */
   runId?: string;
 }
@@ -1080,9 +1082,11 @@ export class WorkflowOrchestrator {
     // P4b: callers (`WorkflowTool`) may pre-generate `runId` and pass it
     // in so they can register the run with `WorkflowRunRegistry` BEFORE
     // `run()` resolves — necessary because the registry needs the id at
-    // emit time, not at resolve time. The orchestrator validates the
-    // shape (`wf_<hex>`) but otherwise trusts the caller. When omitted,
-    // the orchestrator generates one as before.
+    // emit time, not at resolve time. The orchestrator trusts the caller
+    // and does not validate the shape — the only production caller
+    // (`WorkflowTool`) uses the same `wf_<8hex>` generator as
+    // `generateRunId()`. When omitted, the orchestrator generates one
+    // as before.
     const runId = req.runId ?? generateRunId();
 
     const maxAgents = resolveMaxAgentsPerRun();

--- a/packages/core/src/agents/runtime/workflow-p4a-meta-live.live.test.ts
+++ b/packages/core/src/agents/runtime/workflow-p4a-meta-live.live.test.ts
@@ -33,8 +33,8 @@ import {
   WorkflowOrchestrator,
   WorkflowExecutionError,
   type WorkflowAgentDispatch,
-  type WorkflowAgentOpts,
 } from './workflow-orchestrator.js';
+import type { WorkflowAgentOpts } from './workflow-sandbox.js';
 
 const apiKey = process.env['DASHSCOPE_API_KEY'];
 const baseUrl =
@@ -42,7 +42,12 @@ const baseUrl =
   'https://dashscope.aliyuncs.com/compatible-mode/v1';
 const MODEL = 'qwen3-coder-plus';
 
-const liveDispatch: WorkflowAgentDispatch = async (
+// Inferred return type is Promise<string> so callers can assign directly to
+// `string`. `WorkflowAgentDispatch` widens the return to
+// `string | object` (the schema-mode object shape), which is fine for
+// orchestrator interop because string is a subtype — but `lastText: string`
+// downstream would not accept the wider type.
+const liveDispatch = async (
   prompt: string,
   _opts: WorkflowAgentOpts,
 ): Promise<string> => {
@@ -98,19 +103,18 @@ function formatDisplay(outcome: {
 const describeOrSkip = apiKey ? describe : describe.skip;
 
 describeOrSkip('P4a real-LLM E2E (DashScope qwen3-coder-plus)', () => {
-  it(
-    'A: meta declaration parsed + agent call returns real LLM text',
-    async () => {
-      let agentCalls = 0;
-      let lastText = '';
-      const tap: WorkflowAgentDispatch = async (prompt, opts) => {
-        agentCalls++;
-        lastText = await liveDispatch(prompt, opts);
-        return lastText;
-      };
-      const orch = new WorkflowOrchestrator(tap);
-      const outcome = await orch.run({
-        script: `
+  it('A: meta declaration parsed + agent call returns real LLM text', async () => {
+    let agentCalls = 0;
+    let lastText = '';
+    const tap: WorkflowAgentDispatch = async (prompt, opts) => {
+      agentCalls++;
+      lastText = await liveDispatch(prompt, opts);
+      return lastText;
+    };
+    const orch = new WorkflowOrchestrator(tap);
+    const outcome = await orch.run({
+      args: undefined,
+      script: `
           export const meta = {
             name: 'capitals',
             description: 'Look up capitals via a single agent call',
@@ -121,110 +125,101 @@ describeOrSkip('P4a real-LLM E2E (DashScope qwen3-coder-plus)', () => {
           const answer = await agent('What is the capital of France? Reply with the single city name only.')
           return { answer }
         `,
-      });
-      const display = formatDisplay(outcome);
-      console.log('[A] display:', display);
-      console.log('[A] llm text:', lastText);
+    });
+    const display = formatDisplay(outcome);
+    console.log('[A] display:', display);
+    console.log('[A] llm text:', lastText);
 
-      expect(outcome.meta).toEqual({
-        name: 'capitals',
-        description: 'Look up capitals via a single agent call',
-        whenToUse: 'demo only',
-        phases: [{ title: 'Lookup', detail: 'one agent call' }],
-      });
-      expect(display).toContain('"meta":');
-      expect(display).toContain('"name": "capitals"');
-      expect(display).toContain('"whenToUse": "demo only"');
-      // Adversarial review (HIGH × 3 lenses): toEqual is structural and does
-      // NOT check prototype identity. A regression that returns the vm-realm
-      // `raw` value directly (skipping the host-realm copy at workflow-
-      // sandbox.ts:283-294) would re-open the T1/T8/T14 realm escape via
-      // `outcome.meta.constructor.constructor('return process')()`. Verify the
-      // returned object AND its nested phases array AND phase entries are all
-      // host-realm — the toEqual above doesn't catch any of these.
-      expect(Object.getPrototypeOf(outcome.meta)).toBe(Object.prototype);
-      const metaPhases = (outcome.meta as { phases: object[] }).phases;
-      expect(Object.getPrototypeOf(metaPhases)).toBe(Array.prototype);
-      expect(Object.getPrototypeOf(metaPhases[0])).toBe(Object.prototype);
-      expect(agentCalls).toBe(1);
-      expect(lastText.toLowerCase()).toMatch(/paris/);
-      expect((outcome.result as { answer: string }).answer.toLowerCase()).toMatch(
-        /paris/,
-      );
-    },
-    60_000,
-  );
+    expect(outcome.meta).toEqual({
+      name: 'capitals',
+      description: 'Look up capitals via a single agent call',
+      whenToUse: 'demo only',
+      phases: [{ title: 'Lookup', detail: 'one agent call' }],
+    });
+    expect(display).toContain('"meta":');
+    expect(display).toContain('"name": "capitals"');
+    expect(display).toContain('"whenToUse": "demo only"');
+    // Adversarial review (HIGH × 3 lenses): toEqual is structural and does
+    // NOT check prototype identity. A regression that returns the vm-realm
+    // `raw` value directly (skipping the host-realm copy at workflow-
+    // sandbox.ts:283-294) would re-open the T1/T8/T14 realm escape via
+    // `outcome.meta.constructor.constructor('return process')()`. Verify the
+    // returned object AND its nested phases array AND phase entries are all
+    // host-realm — the toEqual above doesn't catch any of these.
+    expect(Object.getPrototypeOf(outcome.meta)).toBe(Object.prototype);
+    const metaPhases = (outcome.meta as { phases: object[] }).phases;
+    expect(Object.getPrototypeOf(metaPhases)).toBe(Array.prototype);
+    expect(Object.getPrototypeOf(metaPhases[0])).toBe(Object.prototype);
+    expect(agentCalls).toBe(1);
+    expect(lastText.toLowerCase()).toMatch(/paris/);
+    expect((outcome.result as { answer: string }).answer.toLowerCase()).toMatch(
+      /paris/,
+    );
+  }, 60_000);
 
-  it(
-    'B: script with NO meta — outcome.meta is null and display omits meta',
-    async () => {
-      let agentCalls = 0;
-      let lastText = '';
-      const tap: WorkflowAgentDispatch = async (prompt, opts) => {
-        agentCalls++;
-        lastText = await liveDispatch(prompt, opts);
-        return lastText;
-      };
-      const orch = new WorkflowOrchestrator(tap);
-      const outcome = await orch.run({
-        script: `
+  it('B: script with NO meta — outcome.meta is null and display omits meta', async () => {
+    let agentCalls = 0;
+    let lastText = '';
+    const tap: WorkflowAgentDispatch = async (prompt, opts) => {
+      agentCalls++;
+      lastText = await liveDispatch(prompt, opts);
+      return lastText;
+    };
+    const orch = new WorkflowOrchestrator(tap);
+    const outcome = await orch.run({
+      args: undefined,
+      script: `
           phase('Lookup')
           const answer = await agent('What is the capital of Japan? Reply with the single city name only.')
           return { answer }
         `,
-      });
-      const display = formatDisplay(outcome);
-      console.log('[B] display:', display);
-      console.log('[B] llm text:', lastText);
+    });
+    const display = formatDisplay(outcome);
+    console.log('[B] display:', display);
+    console.log('[B] llm text:', lastText);
 
-      expect(outcome.meta).toBeNull();
-      const parsed = JSON.parse(display) as Record<string, unknown>;
-      expect('meta' in parsed).toBe(false);
-      expect(agentCalls).toBe(1);
-      expect(lastText.toLowerCase()).toMatch(/tokyo/);
-    },
-    60_000,
-  );
+    expect(outcome.meta).toBeNull();
+    const parsed = JSON.parse(display) as Record<string, unknown>;
+    expect('meta' in parsed).toBe(false);
+    expect(agentCalls).toBe(1);
+    expect(lastText.toLowerCase()).toMatch(/tokyo/);
+  }, 60_000);
 
-  it(
-    'C: malformed meta (missing name) — throws before any agent call',
-    async () => {
-      let agentCalls = 0;
-      const tap: WorkflowAgentDispatch = async (prompt, opts) => {
-        agentCalls++;
-        return liveDispatch(prompt, opts);
-      };
-      const orch = new WorkflowOrchestrator(tap);
-      await expect(
-        orch.run({
-          script: `
+  it('C: malformed meta (missing name) — throws before any agent call', async () => {
+    let agentCalls = 0;
+    const tap: WorkflowAgentDispatch = async (prompt, opts) => {
+      agentCalls++;
+      return liveDispatch(prompt, opts);
+    };
+    const orch = new WorkflowOrchestrator(tap);
+    await expect(
+      orch.run({
+        args: undefined,
+        script: `
             export const meta = { description: 'missing name field' }
             phase('Lookup')
             const answer = await agent('Should not be called')
             return { answer }
           `,
-        }),
-      ).rejects.toThrow(/meta\.name/i);
-      expect(agentCalls).toBe(0);
-    },
-    20_000,
-  );
+      }),
+    ).rejects.toThrow(/meta\.name/i);
+    expect(agentCalls).toBe(0);
+  }, 20_000);
 
-  it(
-    'D: meta survives on WorkflowExecutionError when body throws',
-    async () => {
-      let agentCalls = 0;
-      let lastText = '';
-      const tap: WorkflowAgentDispatch = async (prompt, opts) => {
-        agentCalls++;
-        lastText = await liveDispatch(prompt, opts);
-        return lastText;
-      };
-      const orch = new WorkflowOrchestrator(tap);
-      let caught: unknown;
-      try {
-        await orch.run({
-          script: `
+  it('D: meta survives on WorkflowExecutionError when body throws', async () => {
+    let agentCalls = 0;
+    let lastText = '';
+    const tap: WorkflowAgentDispatch = async (prompt, opts) => {
+      agentCalls++;
+      lastText = await liveDispatch(prompt, opts);
+      return lastText;
+    };
+    const orch = new WorkflowOrchestrator(tap);
+    let caught: unknown;
+    try {
+      await orch.run({
+        args: undefined,
+        script: `
             export const meta = {
               name: 'throws-after-agent',
               description: 'agent runs then body throws',
@@ -233,37 +228,34 @@ describeOrSkip('P4a real-LLM E2E (DashScope qwen3-coder-plus)', () => {
             const answer = await agent('What is the capital of Italy? Reply with the single city name only.')
             throw new Error('intentional script body failure')
           `,
-        });
-      } catch (e) {
-        caught = e;
-      }
-      console.log('[D] caught:', String(caught));
-      console.log('[D] llm text:', lastText);
-      expect(caught).toBeInstanceOf(WorkflowExecutionError);
-      const err = caught as WorkflowExecutionError;
-      expect(err.meta).toEqual({
-        name: 'throws-after-agent',
-        description: 'agent runs then body throws',
       });
-      expect(err.message).toMatch(/intentional script body failure/);
-      expect(agentCalls).toBe(1);
-      expect(lastText.toLowerCase()).toMatch(/rome/);
-    },
-    60_000,
-  );
+    } catch (e) {
+      caught = e;
+    }
+    console.log('[D] caught:', String(caught));
+    console.log('[D] llm text:', lastText);
+    expect(caught).toBeInstanceOf(WorkflowExecutionError);
+    const err = caught as WorkflowExecutionError;
+    expect(err.meta).toEqual({
+      name: 'throws-after-agent',
+      description: 'agent runs then body throws',
+    });
+    expect(err.message).toMatch(/intentional script body failure/);
+    expect(agentCalls).toBe(1);
+    expect(lastText.toLowerCase()).toMatch(/rome/);
+  }, 60_000);
 
-  it(
-    'E: real-world parallel() fan-out — meta.phases titles match executed phases',
-    async () => {
-      const seen: string[] = [];
-      const tap: WorkflowAgentDispatch = async (prompt, opts) => {
-        const out = await liveDispatch(prompt, opts);
-        seen.push(out);
-        return out;
-      };
-      const orch = new WorkflowOrchestrator(tap);
-      const outcome = await orch.run({
-        script: `
+  it('E: real-world parallel() fan-out — meta.phases titles match executed phases', async () => {
+    const seen: string[] = [];
+    const tap: WorkflowAgentDispatch = async (prompt, opts) => {
+      const out = await liveDispatch(prompt, opts);
+      seen.push(out);
+      return out;
+    };
+    const orch = new WorkflowOrchestrator(tap);
+    const outcome = await orch.run({
+      args: undefined,
+      script: `
           export const meta = {
             name: 'multi-lens-review',
             description: 'Fan out 3 reviewers in parallel, return the verdicts',
@@ -279,50 +271,47 @@ describeOrSkip('P4a real-LLM E2E (DashScope qwen3-coder-plus)', () => {
           ])
           return { verdicts }
         `,
-      });
-      console.log('[E] meta:', JSON.stringify(outcome.meta));
-      console.log('[E] phases:', JSON.stringify(outcome.phases));
-      console.log('[E] result:', JSON.stringify(outcome.result));
-      console.log('[E] seen verdicts:', JSON.stringify(seen));
+    });
+    console.log('[E] meta:', JSON.stringify(outcome.meta));
+    console.log('[E] phases:', JSON.stringify(outcome.phases));
+    console.log('[E] result:', JSON.stringify(outcome.result));
+    console.log('[E] seen verdicts:', JSON.stringify(seen));
 
-      expect(outcome.meta).toEqual({
-        name: 'multi-lens-review',
-        description: 'Fan out 3 reviewers in parallel, return the verdicts',
-        phases: [{ title: 'Review', detail: '3 lenses in parallel' }],
-      });
-      expect(outcome.phases).toEqual(['Review']);
-      // meta.phases[].title must match what actually ran — this catches a
-      // future regression where the meta declaration drifts from the script
-      // body or where extractAndStripMeta returns a stale/leaked binding.
-      const declaredTitles = (
-        outcome.meta as { phases: Array<{ title: string }> }
-      ).phases.map((p) => p.title);
-      expect(declaredTitles).toEqual(outcome.phases);
+    expect(outcome.meta).toEqual({
+      name: 'multi-lens-review',
+      description: 'Fan out 3 reviewers in parallel, return the verdicts',
+      phases: [{ title: 'Review', detail: '3 lenses in parallel' }],
+    });
+    expect(outcome.phases).toEqual(['Review']);
+    // meta.phases[].title must match what actually ran — this catches a
+    // future regression where the meta declaration drifts from the script
+    // body or where extractAndStripMeta returns a stale/leaked binding.
+    const declaredTitles = (
+      outcome.meta as { phases: Array<{ title: string }> }
+    ).phases.map((p) => p.title);
+    expect(declaredTitles).toEqual(outcome.phases);
 
-      const verdicts = (outcome.result as { verdicts: string[] }).verdicts;
-      expect(verdicts).toHaveLength(3);
-      // Position-aligned to the parallel() input order.
-      expect(verdicts[0].toUpperCase()).toContain('RED');
-      expect(verdicts[1].toUpperCase()).toContain('GREEN');
-      expect(verdicts[2].toUpperCase()).toContain('BLUE');
-      expect(seen).toHaveLength(3);
-    },
-    90_000,
-  );
+    const verdicts = (outcome.result as { verdicts: string[] }).verdicts;
+    expect(verdicts).toHaveLength(3);
+    // Position-aligned to the parallel() input order.
+    expect(verdicts[0].toUpperCase()).toContain('RED');
+    expect(verdicts[1].toUpperCase()).toContain('GREEN');
+    expect(verdicts[2].toUpperCase()).toContain('BLUE');
+    expect(seen).toHaveLength(3);
+  }, 90_000);
 
-  it(
-    'F: real-world pipeline() multi-stage — meta.phases declares both, both run',
-    async () => {
-      let translateCalls = 0;
-      let upperCalls = 0;
-      const tap: WorkflowAgentDispatch = async (prompt, opts) => {
-        if (prompt.includes('Translate')) translateCalls++;
-        else if (prompt.includes('uppercase')) upperCalls++;
-        return liveDispatch(prompt, opts);
-      };
-      const orch = new WorkflowOrchestrator(tap);
-      const outcome = await orch.run({
-        script: `
+  it('F: real-world pipeline() multi-stage — meta.phases declares both, both run', async () => {
+    let translateCalls = 0;
+    let upperCalls = 0;
+    const tap: WorkflowAgentDispatch = async (prompt, opts) => {
+      if (prompt.includes('Translate')) translateCalls++;
+      else if (prompt.includes('uppercase')) upperCalls++;
+      return liveDispatch(prompt, opts);
+    };
+    const orch = new WorkflowOrchestrator(tap);
+    const outcome = await orch.run({
+      args: undefined,
+      script: `
           export const meta = {
             name: 'translate-then-shout',
             description: 'Pipeline two stages per item: translate, then uppercase',
@@ -339,36 +328,34 @@ describeOrSkip('P4a real-LLM E2E (DashScope qwen3-coder-plus)', () => {
           )
           return { results }
         `,
-      });
-      console.log('[F] meta:', JSON.stringify(outcome.meta));
-      console.log('[F] phases:', JSON.stringify(outcome.phases));
-      console.log('[F] result:', JSON.stringify(outcome.result));
-      console.log('[F] dispatch counts:', { translateCalls, upperCalls });
+    });
+    console.log('[F] meta:', JSON.stringify(outcome.meta));
+    console.log('[F] phases:', JSON.stringify(outcome.phases));
+    console.log('[F] result:', JSON.stringify(outcome.result));
+    console.log('[F] dispatch counts:', { translateCalls, upperCalls });
 
-      expect(outcome.meta).toEqual({
-        name: 'translate-then-shout',
-        description: 'Pipeline two stages per item: translate, then uppercase',
-        phases: [
-          { title: 'Translate', detail: 'EN -> FR' },
-          { title: 'Shout', detail: 'uppercase' },
-        ],
-      });
-      // Both declared phases were actually exercised in this run.
-      const phaseSet = new Set(outcome.phases);
-      expect(phaseSet.has('Translate')).toBe(true);
-      expect(phaseSet.has('Shout')).toBe(true);
+    expect(outcome.meta).toEqual({
+      name: 'translate-then-shout',
+      description: 'Pipeline two stages per item: translate, then uppercase',
+      phases: [
+        { title: 'Translate', detail: 'EN -> FR' },
+        { title: 'Shout', detail: 'uppercase' },
+      ],
+    });
+    // Both declared phases were actually exercised in this run.
+    const phaseSet = new Set(outcome.phases);
+    expect(phaseSet.has('Translate')).toBe(true);
+    expect(phaseSet.has('Shout')).toBe(true);
 
-      const results = (outcome.result as { results: string[] }).results;
-      expect(results).toHaveLength(2);
-      // Each item flowed through BOTH stages — uppercase final.
-      for (const r of results) {
-        expect(r).toBe(r.toUpperCase());
-        expect(r.length).toBeGreaterThan(0);
-      }
-      // Each input visited each stage exactly once.
-      expect(translateCalls).toBe(2);
-      expect(upperCalls).toBe(2);
-    },
-    120_000,
-  );
+    const results = (outcome.result as { results: string[] }).results;
+    expect(results).toHaveLength(2);
+    // Each item flowed through BOTH stages — uppercase final.
+    for (const r of results) {
+      expect(r).toBe(r.toUpperCase());
+      expect(r.length).toBeGreaterThan(0);
+    }
+    // Each input visited each stage exactly once.
+    expect(translateCalls).toBe(2);
+    expect(upperCalls).toBe(2);
+  }, 120_000);
 });

--- a/packages/core/src/agents/runtime/workflow-p4a-meta-live.live.test.ts
+++ b/packages/core/src/agents/runtime/workflow-p4a-meta-live.live.test.ts
@@ -1,0 +1,374 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * P4a real-LLM E2E — drives WorkflowOrchestrator with a dispatch that hits
+ * qwen3-coder-plus via DashScope. Skipped by default; runs only when
+ * `DASHSCOPE_API_KEY` is set in the environment.
+ *
+ * Verifies end-to-end:
+ *  - extractAndStripMeta correctly parses `export const meta = {...}` from a
+ *    script that ALSO contains real agent() calls (the meta strip does not
+ *    confuse the brace walker when followed by an executable body)
+ *  - the script body runs successfully after the meta block is stripped
+ *    (agent() returns a real LLM response)
+ *  - outcome.meta surfaces on the resolved WorkflowRunOutcome
+ *  - WorkflowExecutionError.meta is carried through on a body-throw path
+ *    (failure path of safeStringifyDisplayPayload in WorkflowTool)
+ *  - a missing required field on the meta literal throws BEFORE any agent
+ *    call (no LLM budget burnt on a malformed meta)
+ *
+ * Why this is in addition to the unit tests: the unit tests exercise
+ * extractAndStripMeta and the orchestrator with a fake dispatch. This
+ * test wires the same code through a real LLM call so we know the P3
+ * dispatch surface and the P4a meta surface coexist without interference
+ * in the live path.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  WorkflowOrchestrator,
+  WorkflowExecutionError,
+  type WorkflowAgentDispatch,
+  type WorkflowAgentOpts,
+} from './workflow-orchestrator.js';
+
+const apiKey = process.env['DASHSCOPE_API_KEY'];
+const baseUrl =
+  process.env['DASHSCOPE_BASE_URL'] ||
+  'https://dashscope.aliyuncs.com/compatible-mode/v1';
+const MODEL = 'qwen3-coder-plus';
+
+const liveDispatch: WorkflowAgentDispatch = async (
+  prompt: string,
+  _opts: WorkflowAgentOpts,
+): Promise<string> => {
+  const res = await fetch(`${baseUrl}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You are a workflow subagent. Return the final answer as plain text only — no preamble, no markdown, no quotes. Keep the answer terse (≤ 1 sentence).',
+        },
+        { role: 'user', content: prompt },
+      ],
+      temperature: 0,
+      max_tokens: 80,
+    }),
+  });
+  if (!res.ok) {
+    const txt = await res.text();
+    throw new Error(`DashScope ${res.status}: ${txt.slice(0, 200)}`);
+  }
+  const data = (await res.json()) as {
+    choices?: Array<{ message?: { content?: string } }>;
+  };
+  return (data.choices?.[0]?.message?.content ?? '').trim();
+};
+
+// Mirrors WorkflowTool.safeStringifyDisplayPayload — same conditional
+// inclusion of `meta` only when set, same key ordering.
+function formatDisplay(outcome: {
+  runId: string;
+  meta?: unknown;
+  phases: unknown;
+  logs: unknown;
+  result: unknown;
+}): string {
+  const payload: Record<string, unknown> = {
+    runId: outcome.runId,
+    ...(outcome.meta ? { meta: outcome.meta } : {}),
+    phases: outcome.phases,
+    logs: outcome.logs,
+    result: outcome.result,
+  };
+  return JSON.stringify(payload, null, 2);
+}
+
+const describeOrSkip = apiKey ? describe : describe.skip;
+
+describeOrSkip('P4a real-LLM E2E (DashScope qwen3-coder-plus)', () => {
+  it(
+    'A: meta declaration parsed + agent call returns real LLM text',
+    async () => {
+      let agentCalls = 0;
+      let lastText = '';
+      const tap: WorkflowAgentDispatch = async (prompt, opts) => {
+        agentCalls++;
+        lastText = await liveDispatch(prompt, opts);
+        return lastText;
+      };
+      const orch = new WorkflowOrchestrator(tap);
+      const outcome = await orch.run({
+        script: `
+          export const meta = {
+            name: 'capitals',
+            description: 'Look up capitals via a single agent call',
+            whenToUse: 'demo only',
+            phases: [{ title: 'Lookup', detail: 'one agent call' }],
+          }
+          phase('Lookup')
+          const answer = await agent('What is the capital of France? Reply with the single city name only.')
+          return { answer }
+        `,
+      });
+      const display = formatDisplay(outcome);
+      console.log('[A] display:', display);
+      console.log('[A] llm text:', lastText);
+
+      expect(outcome.meta).toEqual({
+        name: 'capitals',
+        description: 'Look up capitals via a single agent call',
+        whenToUse: 'demo only',
+        phases: [{ title: 'Lookup', detail: 'one agent call' }],
+      });
+      expect(display).toContain('"meta":');
+      expect(display).toContain('"name": "capitals"');
+      expect(display).toContain('"whenToUse": "demo only"');
+      // Adversarial review (HIGH × 3 lenses): toEqual is structural and does
+      // NOT check prototype identity. A regression that returns the vm-realm
+      // `raw` value directly (skipping the host-realm copy at workflow-
+      // sandbox.ts:283-294) would re-open the T1/T8/T14 realm escape via
+      // `outcome.meta.constructor.constructor('return process')()`. Verify the
+      // returned object AND its nested phases array AND phase entries are all
+      // host-realm — the toEqual above doesn't catch any of these.
+      expect(Object.getPrototypeOf(outcome.meta)).toBe(Object.prototype);
+      const metaPhases = (outcome.meta as { phases: object[] }).phases;
+      expect(Object.getPrototypeOf(metaPhases)).toBe(Array.prototype);
+      expect(Object.getPrototypeOf(metaPhases[0])).toBe(Object.prototype);
+      expect(agentCalls).toBe(1);
+      expect(lastText.toLowerCase()).toMatch(/paris/);
+      expect((outcome.result as { answer: string }).answer.toLowerCase()).toMatch(
+        /paris/,
+      );
+    },
+    60_000,
+  );
+
+  it(
+    'B: script with NO meta — outcome.meta is null and display omits meta',
+    async () => {
+      let agentCalls = 0;
+      let lastText = '';
+      const tap: WorkflowAgentDispatch = async (prompt, opts) => {
+        agentCalls++;
+        lastText = await liveDispatch(prompt, opts);
+        return lastText;
+      };
+      const orch = new WorkflowOrchestrator(tap);
+      const outcome = await orch.run({
+        script: `
+          phase('Lookup')
+          const answer = await agent('What is the capital of Japan? Reply with the single city name only.')
+          return { answer }
+        `,
+      });
+      const display = formatDisplay(outcome);
+      console.log('[B] display:', display);
+      console.log('[B] llm text:', lastText);
+
+      expect(outcome.meta).toBeNull();
+      const parsed = JSON.parse(display) as Record<string, unknown>;
+      expect('meta' in parsed).toBe(false);
+      expect(agentCalls).toBe(1);
+      expect(lastText.toLowerCase()).toMatch(/tokyo/);
+    },
+    60_000,
+  );
+
+  it(
+    'C: malformed meta (missing name) — throws before any agent call',
+    async () => {
+      let agentCalls = 0;
+      const tap: WorkflowAgentDispatch = async (prompt, opts) => {
+        agentCalls++;
+        return liveDispatch(prompt, opts);
+      };
+      const orch = new WorkflowOrchestrator(tap);
+      await expect(
+        orch.run({
+          script: `
+            export const meta = { description: 'missing name field' }
+            phase('Lookup')
+            const answer = await agent('Should not be called')
+            return { answer }
+          `,
+        }),
+      ).rejects.toThrow(/meta\.name/i);
+      expect(agentCalls).toBe(0);
+    },
+    20_000,
+  );
+
+  it(
+    'D: meta survives on WorkflowExecutionError when body throws',
+    async () => {
+      let agentCalls = 0;
+      let lastText = '';
+      const tap: WorkflowAgentDispatch = async (prompt, opts) => {
+        agentCalls++;
+        lastText = await liveDispatch(prompt, opts);
+        return lastText;
+      };
+      const orch = new WorkflowOrchestrator(tap);
+      let caught: unknown;
+      try {
+        await orch.run({
+          script: `
+            export const meta = {
+              name: 'throws-after-agent',
+              description: 'agent runs then body throws',
+            }
+            phase('Lookup')
+            const answer = await agent('What is the capital of Italy? Reply with the single city name only.')
+            throw new Error('intentional script body failure')
+          `,
+        });
+      } catch (e) {
+        caught = e;
+      }
+      console.log('[D] caught:', String(caught));
+      console.log('[D] llm text:', lastText);
+      expect(caught).toBeInstanceOf(WorkflowExecutionError);
+      const err = caught as WorkflowExecutionError;
+      expect(err.meta).toEqual({
+        name: 'throws-after-agent',
+        description: 'agent runs then body throws',
+      });
+      expect(err.message).toMatch(/intentional script body failure/);
+      expect(agentCalls).toBe(1);
+      expect(lastText.toLowerCase()).toMatch(/rome/);
+    },
+    60_000,
+  );
+
+  it(
+    'E: real-world parallel() fan-out — meta.phases titles match executed phases',
+    async () => {
+      const seen: string[] = [];
+      const tap: WorkflowAgentDispatch = async (prompt, opts) => {
+        const out = await liveDispatch(prompt, opts);
+        seen.push(out);
+        return out;
+      };
+      const orch = new WorkflowOrchestrator(tap);
+      const outcome = await orch.run({
+        script: `
+          export const meta = {
+            name: 'multi-lens-review',
+            description: 'Fan out 3 reviewers in parallel, return the verdicts',
+            phases: [
+              { title: 'Review', detail: '3 lenses in parallel' },
+            ],
+          }
+          phase('Review')
+          const verdicts = await parallel([
+            () => agent('Return the single word RED.'),
+            () => agent('Return the single word GREEN.'),
+            () => agent('Return the single word BLUE.'),
+          ])
+          return { verdicts }
+        `,
+      });
+      console.log('[E] meta:', JSON.stringify(outcome.meta));
+      console.log('[E] phases:', JSON.stringify(outcome.phases));
+      console.log('[E] result:', JSON.stringify(outcome.result));
+      console.log('[E] seen verdicts:', JSON.stringify(seen));
+
+      expect(outcome.meta).toEqual({
+        name: 'multi-lens-review',
+        description: 'Fan out 3 reviewers in parallel, return the verdicts',
+        phases: [{ title: 'Review', detail: '3 lenses in parallel' }],
+      });
+      expect(outcome.phases).toEqual(['Review']);
+      // meta.phases[].title must match what actually ran — this catches a
+      // future regression where the meta declaration drifts from the script
+      // body or where extractAndStripMeta returns a stale/leaked binding.
+      const declaredTitles = (
+        outcome.meta as { phases: Array<{ title: string }> }
+      ).phases.map((p) => p.title);
+      expect(declaredTitles).toEqual(outcome.phases);
+
+      const verdicts = (outcome.result as { verdicts: string[] }).verdicts;
+      expect(verdicts).toHaveLength(3);
+      // Position-aligned to the parallel() input order.
+      expect(verdicts[0].toUpperCase()).toContain('RED');
+      expect(verdicts[1].toUpperCase()).toContain('GREEN');
+      expect(verdicts[2].toUpperCase()).toContain('BLUE');
+      expect(seen).toHaveLength(3);
+    },
+    90_000,
+  );
+
+  it(
+    'F: real-world pipeline() multi-stage — meta.phases declares both, both run',
+    async () => {
+      let translateCalls = 0;
+      let upperCalls = 0;
+      const tap: WorkflowAgentDispatch = async (prompt, opts) => {
+        if (prompt.includes('Translate')) translateCalls++;
+        else if (prompt.includes('uppercase')) upperCalls++;
+        return liveDispatch(prompt, opts);
+      };
+      const orch = new WorkflowOrchestrator(tap);
+      const outcome = await orch.run({
+        script: `
+          export const meta = {
+            name: 'translate-then-shout',
+            description: 'Pipeline two stages per item: translate, then uppercase',
+            phases: [
+              { title: 'Translate', detail: 'EN -> FR' },
+              { title: 'Shout', detail: 'uppercase' },
+            ],
+          }
+          const inputs = ['cat', 'dog']
+          const results = await pipeline(
+            inputs,
+            (word) => agent(\`Translate the English word "\${word}" to French. Reply with the single French word only.\`, { phase: 'Translate' }),
+            (frenchWord) => agent(\`Return "\${frenchWord}" in uppercase. Reply with just the uppercase letters.\`, { phase: 'Shout' }),
+          )
+          return { results }
+        `,
+      });
+      console.log('[F] meta:', JSON.stringify(outcome.meta));
+      console.log('[F] phases:', JSON.stringify(outcome.phases));
+      console.log('[F] result:', JSON.stringify(outcome.result));
+      console.log('[F] dispatch counts:', { translateCalls, upperCalls });
+
+      expect(outcome.meta).toEqual({
+        name: 'translate-then-shout',
+        description: 'Pipeline two stages per item: translate, then uppercase',
+        phases: [
+          { title: 'Translate', detail: 'EN -> FR' },
+          { title: 'Shout', detail: 'uppercase' },
+        ],
+      });
+      // Both declared phases were actually exercised in this run.
+      const phaseSet = new Set(outcome.phases);
+      expect(phaseSet.has('Translate')).toBe(true);
+      expect(phaseSet.has('Shout')).toBe(true);
+
+      const results = (outcome.result as { results: string[] }).results;
+      expect(results).toHaveLength(2);
+      // Each item flowed through BOTH stages — uppercase final.
+      for (const r of results) {
+        expect(r).toBe(r.toUpperCase());
+        expect(r.length).toBeGreaterThan(0);
+      }
+      // Each input visited each stage exactly once.
+      expect(translateCalls).toBe(2);
+      expect(upperCalls).toBe(2);
+    },
+    120_000,
+  );
+});

--- a/packages/core/src/agents/runtime/workflow-sandbox.test.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.test.ts
@@ -5,7 +5,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { stripExportMeta, createWorkflowSandbox } from './workflow-sandbox.js';
+import {
+  stripExportMeta,
+  extractAndStripMeta,
+  createWorkflowSandbox,
+} from './workflow-sandbox.js';
 
 describe('stripExportMeta', () => {
   it('returns input unchanged when no export meta present', () => {
@@ -136,6 +140,125 @@ return x;`;
   });
 });
 
+describe('extractAndStripMeta', () => {
+  // P4: extracts the `export const meta = {...}` declaration into a typed
+  // object AND strips it from the script source (delegates to the same
+  // brace-walker stripExportMeta uses). `meta: null` when the script has no
+  // declaration; throws when the declaration is present but malformed.
+  it('returns meta: null and unchanged source when no meta declaration', () => {
+    const src = `phase("plan")\nreturn 1`;
+    const { stripped, meta } = extractAndStripMeta(src);
+    expect(stripped).toBe(src);
+    expect(meta).toBeNull();
+  });
+
+  it('extracts the required name + description fields', () => {
+    const src = `export const meta = { name: 'demo', description: 'a demo workflow' }\nreturn 1`;
+    const { stripped, meta } = extractAndStripMeta(src);
+    expect(stripped.trim()).toBe('return 1');
+    expect(meta).toEqual({ name: 'demo', description: 'a demo workflow' });
+  });
+
+  it('extracts optional whenToUse + phases array', () => {
+    const src = `export const meta = {
+      name: 'multi',
+      description: 'multi-phase',
+      whenToUse: 'when the user needs a multi-phase report',
+      phases: [
+        { title: 'collect' },
+        { title: 'analyse', detail: 'aggregate findings', model: 'qwen3-coder-plus' },
+      ],
+    }
+    return 1;`;
+    const { meta } = extractAndStripMeta(src);
+    expect(meta).toEqual({
+      name: 'multi',
+      description: 'multi-phase',
+      whenToUse: 'when the user needs a multi-phase report',
+      phases: [
+        { title: 'collect' },
+        { title: 'analyse', detail: 'aggregate findings', model: 'qwen3-coder-plus' },
+      ],
+    });
+  });
+
+  it('throws upstream-verbatim error when name is missing', () => {
+    const src = `export const meta = { description: 'no name' }\nreturn 1`;
+    expect(() => extractAndStripMeta(src)).toThrow(
+      /^meta\.name must be a non-empty string$/,
+    );
+  });
+
+  it('throws upstream-verbatim error when description is missing', () => {
+    const src = `export const meta = { name: 'x' }\nreturn 1`;
+    expect(() => extractAndStripMeta(src)).toThrow(
+      /^meta\.description must be a non-empty string$/,
+    );
+  });
+
+  it('throws when name is empty string', () => {
+    const src = `export const meta = { name: '', description: 'd' }\nreturn 1`;
+    expect(() => extractAndStripMeta(src)).toThrow(
+      /^meta\.name must be a non-empty string$/,
+    );
+  });
+
+  it('throws when phases is not an array', () => {
+    const src = `export const meta = { name: 'n', description: 'd', phases: 'oops' }\nreturn 1`;
+    expect(() => extractAndStripMeta(src)).toThrow(/phases must be an array/);
+  });
+
+  it('throws when a phase is missing its title', () => {
+    const src = `export const meta = { name: 'n', description: 'd', phases: [{ detail: 'no title here' }] }\nreturn 1`;
+    expect(() => extractAndStripMeta(src)).toThrow(
+      /phases\[\]\.title must be a non-empty string/,
+    );
+  });
+
+  // Security regression: the meta-eval vm context has no globals at all
+  // (Object.create(null) prototype), so the model cannot reach host
+  // primitives during meta evaluation — even ones that the script-side
+  // sandbox normally provides (args, agent, phase, log, parallel,
+  // pipeline). Referencing any of them throws ReferenceError.
+  it('rejects meta that references a name that does not exist in the eval context', () => {
+    const src = `export const meta = { name: args.x, description: 'd' }\nreturn 1`;
+    expect(() => extractAndStripMeta(src)).toThrow(
+      /failed to evaluate meta object literal/,
+    );
+  });
+
+  // Security regression: the meta-eval context's globalThis is null-
+  // prototyped, so the model has no bridge to host primitives like
+  // `process`, `require`, or the workflow-sandbox bridge globals
+  // (`args` / `agent` / `phase` / `log` / etc.). The vm realm still
+  // exposes its OWN intrinsics (`Object`, `Math`, `Date`, …) which is
+  // fine — meta extraction is one-shot at tool-invocation time, not
+  // replayed on resume, so it can be non-deterministic without breaking
+  // the resume contract that the script body honors.
+  it('meta source cannot reference a workflow-sandbox bridge global (args)', () => {
+    const src = `export const meta = { name: args.x, description: 'd' }\nreturn 1`;
+    expect(() => extractAndStripMeta(src)).toThrow(
+      /failed to evaluate meta object literal/,
+    );
+  });
+
+  it('meta source cannot reach the host process / require / fs', () => {
+    const src1 = `export const meta = { name: process.version, description: 'd' }\nreturn 1`;
+    expect(() => extractAndStripMeta(src1)).toThrow(
+      /failed to evaluate meta object literal/,
+    );
+    const src2 = `export const meta = { name: 'x', description: require('fs').readFileSync('/etc/passwd', 'utf8') }\nreturn 1`;
+    expect(() => extractAndStripMeta(src2)).toThrow(
+      /failed to evaluate meta object literal/,
+    );
+  });
+
+  it('unbalanced braces still throw the stripExportMeta error', () => {
+    const src = `export const meta = { name: 'x'`;
+    expect(() => extractAndStripMeta(src)).toThrow(/unbalanced/i);
+  });
+});
+
 describe('createWorkflowSandbox', () => {
   it('exposes args verbatim', async () => {
     const sandbox = createWorkflowSandbox({
@@ -174,6 +297,45 @@ describe('createWorkflowSandbox', () => {
     });
     const result = await sandbox.run(`return 1 + 2`);
     expect(result).toBe(3);
+  });
+
+  // P4: meta declaration in the script is extracted before the body runs
+  // and exposed via getMeta(). The script body sees the stripped source.
+  it('getMeta() returns null when no export const meta declaration', async () => {
+    const sandbox = createWorkflowSandbox({
+      args: undefined,
+      dispatch: async () => 'ignored',
+    });
+    await sandbox.run(`return 42`);
+    expect(sandbox.getMeta()).toBeNull();
+  });
+
+  it('getMeta() returns the parsed meta when present', async () => {
+    const sandbox = createWorkflowSandbox({
+      args: undefined,
+      dispatch: async () => 'ignored',
+    });
+    const result = await sandbox.run(
+      `export const meta = { name: 'unit', description: 'unit-test workflow', phases: [{ title: 'one' }] }\nreturn 'done'`,
+    );
+    expect(result).toBe('done');
+    expect(sandbox.getMeta()).toEqual({
+      name: 'unit',
+      description: 'unit-test workflow',
+      phases: [{ title: 'one' }],
+    });
+  });
+
+  it('getMeta() failure on malformed meta propagates as the run rejection', async () => {
+    const sandbox = createWorkflowSandbox({
+      args: undefined,
+      dispatch: async () => 'ignored',
+    });
+    await expect(
+      sandbox.run(
+        `export const meta = { name: 'x' }\nreturn 1`,
+      ),
+    ).rejects.toThrow(/^meta\.description must be a non-empty string$/);
   });
 });
 

--- a/packages/core/src/agents/runtime/workflow-sandbox.test.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.test.ts
@@ -257,6 +257,36 @@ describe('extractAndStripMeta', () => {
     const src = `export const meta = { name: 'x'`;
     expect(() => extractAndStripMeta(src)).toThrow(/unbalanced/i);
   });
+
+  // P4a adversarial review (HIGH × 3 lenses): the docstring at
+  // workflow-sandbox.ts:283-294 promises the returned meta is HOST-realm —
+  // a per-field copy that defends against T1/T8/T14-style vm-realm escape
+  // via `outcome.meta.constructor.constructor('return process')()`. Verify
+  // the contract: returned meta + its nested phases array + each phase
+  // entry must all sit on the host-realm prototype chain so
+  // `.constructor` reaches host `Object` / `Array`, not a vm-realm peer.
+  // Without this, a regression that returns the vm-eval'd value directly
+  // would silently pass every structural `toEqual` check in the suite.
+  it('returned meta + phases array + phase entries are all host-realm objects', () => {
+    const src = `export const meta = {
+      name: 'realm',
+      description: 'realm-identity check',
+      whenToUse: 'tests',
+      phases: [
+        { title: 'a' },
+        { title: 'b', detail: 'has detail', model: 'qwen3' },
+      ],
+    }
+    return 1`;
+    const { meta } = extractAndStripMeta(src);
+    expect(meta).not.toBeNull();
+    expect(Object.getPrototypeOf(meta as object)).toBe(Object.prototype);
+    const phases = (meta as { phases: object[] }).phases;
+    expect(Object.getPrototypeOf(phases)).toBe(Array.prototype);
+    for (const p of phases) {
+      expect(Object.getPrototypeOf(p)).toBe(Object.prototype);
+    }
+  });
 });
 
 describe('createWorkflowSandbox', () => {

--- a/packages/core/src/agents/runtime/workflow-sandbox.test.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.test.ts
@@ -177,7 +177,11 @@ describe('extractAndStripMeta', () => {
       whenToUse: 'when the user needs a multi-phase report',
       phases: [
         { title: 'collect' },
-        { title: 'analyse', detail: 'aggregate findings', model: 'qwen3-coder-plus' },
+        {
+          title: 'analyse',
+          detail: 'aggregate findings',
+          model: 'qwen3-coder-plus',
+        },
       ],
     });
   });
@@ -287,6 +291,35 @@ describe('extractAndStripMeta', () => {
       expect(Object.getPrototypeOf(p)).toBe(Object.prototype);
     }
   });
+
+  // P4a Round 3 (wenshao): a Promise (e.g. `import('node:fs')`) used as a
+  // value in the meta literal previously crashed the host process. The
+  // synchronous `runInContext` returns normally with a dangling rejection
+  // scheduled for the next tick; validateMeta passes (the field isn't on
+  // the contract surface so it's silently dropped); the workflow even
+  // returns its result; THEN the unhandled rejection terminates the
+  // process under Node's default `--unhandled-rejections=throw`. The fix
+  // is to walk the eval result, neutralise any thenables with a `.catch`
+  // so they no longer trigger the unhandled-rejection handler, and throw
+  // an explicit error so the bad meta is rejected up front.
+  it('throws when meta value is a Promise (dynamic import) — no unhandled rejection crash', () => {
+    const src = `export const meta = { name: 'x', description: 'd', extra: import('node:fs') }\nreturn 1`;
+    expect(() => extractAndStripMeta(src)).toThrow(
+      /meta values must not be Promises/,
+    );
+  });
+
+  it('throws when meta value is a Promise nested inside a phases entry', () => {
+    const src = `export const meta = {
+      name: 'x',
+      description: 'd',
+      phases: [{ title: 't', extra: import('node:fs') }],
+    }
+    return 1`;
+    expect(() => extractAndStripMeta(src)).toThrow(
+      /meta values must not be Promises/,
+    );
+  });
 });
 
 describe('createWorkflowSandbox', () => {
@@ -362,9 +395,7 @@ describe('createWorkflowSandbox', () => {
       dispatch: async () => 'ignored',
     });
     await expect(
-      sandbox.run(
-        `export const meta = { name: 'x' }\nreturn 1`,
-      ),
+      sandbox.run(`export const meta = { name: 'x' }\nreturn 1`),
     ).rejects.toThrow(/^meta\.description must be a non-empty string$/);
   });
 });

--- a/packages/core/src/agents/runtime/workflow-sandbox.test.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.test.ts
@@ -223,9 +223,12 @@ describe('extractAndStripMeta', () => {
   // (Object.create(null) prototype), so the model cannot reach host
   // primitives during meta evaluation — even ones that the script-side
   // sandbox normally provides (args, agent, phase, log, parallel,
-  // pipeline). Referencing any of them throws ReferenceError.
-  it('rejects meta that references a name that does not exist in the eval context', () => {
-    const src = `export const meta = { name: args.x, description: 'd' }\nreturn 1`;
+  // pipeline). Referencing any of them throws ReferenceError. Two
+  // shapes pinned: a truly unknown identifier (R7 dedup — was a
+  // duplicate of the bridge-global case below) and explicit `args`
+  // bridge-global access.
+  it('rejects meta that references an unknown identifier', () => {
+    const src = `export const meta = { name: totallyUnknown, description: 'd' }\nreturn 1`;
     expect(() => extractAndStripMeta(src)).toThrow(
       /failed to evaluate meta object literal/,
     );
@@ -319,6 +322,24 @@ describe('extractAndStripMeta', () => {
     expect(() => extractAndStripMeta(src)).toThrow(
       /meta values must not be Promises/,
     );
+  });
+
+  // P4 Round 7 (wenshao): `phase('X'); phase('X')` previously yielded
+  // `outcome.phases = ['X','X']` (sandbox unconditional push) while the
+  // registry's onPhaseStarted deduped to `entry.phases = ['X']`. The
+  // two arrays diverged on the same run — terminal display vs live UI
+  // showed different phase lists. Fix at the sandbox layer so the
+  // sandbox is the single source of truth; the docstring on safePhase
+  // / phase() can then promise dedup without lying.
+  it('consecutive identical phase titles dedup at the sandbox layer', async () => {
+    const sandbox = createWorkflowSandbox({
+      args: undefined,
+      dispatch: async () => 'ignored',
+    });
+    await sandbox.run(
+      `phase('X'); phase('X'); phase('Y'); phase('X'); return 1`,
+    );
+    expect(sandbox.getPhases()).toEqual(['X', 'Y', 'X']);
   });
 
   // P4 Round 4 (wenshao): the R3 thenable walker recursed without a

--- a/packages/core/src/agents/runtime/workflow-sandbox.test.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.test.ts
@@ -320,6 +320,45 @@ describe('extractAndStripMeta', () => {
       /meta values must not be Promises/,
     );
   });
+
+  // P4 Round 4 (wenshao): the R3 thenable walker recursed without a
+  // seen-guard. A meta literal that builds a cyclic object via spread
+  // (no getters, no Promises, no exotic constructs — just self-reference)
+  // overflows the call stack. The walker's RangeError propagates OUT of
+  // extractAndStripMeta because the try/catch only wraps the vm-eval, so
+  // the run failure surfaces as `Maximum call stack size exceeded` rather
+  // than the meta-validation error this guard exists to produce. A
+  // WeakSet bounds the recursion against cycles AND against future
+  // shapes where the same node is reached through multiple keys.
+  it('rejects a cyclic meta value built via spread without stack-overflowing', () => {
+    const src = `export const meta = {
+      name: 'x',
+      description: 'y',
+      ...(function () { const a = {}; a.self = a; return a; })(),
+    }
+    return 1`;
+    // The cyclic field should be silently ignored by validateMeta (it's
+    // not a contract field), so the run succeeds with just the required
+    // fields surviving — but only if the walker terminates first.
+    const { meta } = extractAndStripMeta(src);
+    expect(meta).toEqual({ name: 'x', description: 'y' });
+  });
+
+  it('rejects a cyclic meta value reached through nested arrays/objects', () => {
+    const src = `export const meta = {
+      name: 'x',
+      description: 'y',
+      // Cycle reached through phases[0].back → ref back to outer container.
+      ...(function () {
+        const outer = { items: [] };
+        outer.items.push({ ref: outer });
+        return outer;
+      })(),
+    }
+    return 1`;
+    const { meta } = extractAndStripMeta(src);
+    expect(meta).toEqual({ name: 'x', description: 'y' });
+  });
 });
 
 describe('createWorkflowSandbox', () => {

--- a/packages/core/src/agents/runtime/workflow-sandbox.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.ts
@@ -22,6 +22,33 @@
  * supported — model-authored `meta` should avoid them.
  */
 export function stripExportMeta(source: string): string {
+  const bounds = findMetaBlockBounds(source);
+  if (!bounds) return source;
+  return source.slice(0, bounds.exportIdx) + source.slice(bounds.afterMeta);
+}
+
+/**
+ * Locate the `export const meta = {...}` declaration's bounds in the source.
+ *
+ * Shared by stripExportMeta (P1) and extractAndStripMeta (P4). Anchors at file
+ * start (no `/m` flag — see T33 comment below); walks the brace block while
+ * skipping over comment / regex / string contexts; throws on unbalanced
+ * braces rather than returning a truncated string (T9/T17 — silently
+ * deleting the script body is the worst-case failure mode).
+ *
+ * Returns null when no meta declaration is present at the file start —
+ * callers treat this as "no meta", not an error.
+ */
+function findMetaBlockBounds(source: string): {
+  /** Start offset of the `export const meta` match. */
+  exportIdx: number;
+  /** Offset of the `{` opening the meta object literal. */
+  startBrace: number;
+  /** Offset of the matching `}` closing the literal (inclusive). */
+  endBraceIncl: number;
+  /** Offset past meta + any trailing whitespace + optional `;`. */
+  afterMeta: number;
+} | null {
   // T33 (PR #4732 R4): anchor at file start (no `/m` flag). Per the design
   // doc, `export const meta = {...}` must be the script's FIRST statement.
   // With `/m`, the regex matched every line-start occurrence — including
@@ -29,7 +56,7 @@ export function stripExportMeta(source: string): string {
   // out of the string body, silently corrupting the script.
   const re = /^\s*export\s+const\s+meta\s*=\s*\{/;
   const match = re.exec(source);
-  if (!match) return source;
+  if (!match) return null;
   const exportIdx = match.index;
   const startBrace = source.indexOf('{', exportIdx);
   let depth = 1;
@@ -101,9 +128,170 @@ export function stripExportMeta(source: string): string {
         'the workflow script cannot be safely stripped. Check the meta block syntax.',
     );
   }
+  const endBraceIncl = i - 1;
   // Skip trailing whitespace and an optional semicolon.
   while (i < source.length && /[\s;]/.test(source[i]!)) i++;
-  return source.slice(0, exportIdx) + source.slice(i);
+  return { exportIdx, startBrace, endBraceIncl, afterMeta: i };
+}
+
+/**
+ * The `meta` object shape — verbatim from upstream Claude Code 2.1.168.
+ * `name` and `description` are mandatory; `whenToUse` and `phases` are
+ * optional. Each phase carries a mandatory `title` and optional `detail`
+ * / `model`. P4 surfaces this shape on `WorkflowRunOutcome.meta` so
+ * `/workflows` listing and the phase-tree UI can read it directly.
+ */
+export interface WorkflowMeta {
+  name: string;
+  description: string;
+  whenToUse?: string;
+  phases?: Array<{ title: string; detail?: string; model?: string }>;
+}
+
+/**
+ * Strip `export const meta = {...}` from the script AND extract the meta
+ * object as a plain host-realm value, ready to surface on `WorkflowRunOutcome`.
+ *
+ * Implementation:
+ *   1. `findMetaBlockBounds` (shared with `stripExportMeta`) locates the
+ *      object-literal source range via the brace-walker.
+ *   2. The literal source is evaluated as `(${metaSource})` inside a fresh
+ *      vm context whose globalThis is a null-prototyped object — no
+ *      bridge to the host realm, no access to host primitives like
+ *      `process` / `require` / the workflow-sandbox bridge globals
+ *      (`args` / `agent` / `phase` / `log` / etc.). The vm realm DOES
+ *      provide its own intrinsics (`Object`, `Array`, `Math`, `Date`,
+ *      `JSON`, …) which is fine: meta extraction is a one-shot at tool-
+ *      invocation time, not replayed during resume, so non-determinism in
+ *      the meta literal (a `Date.now()` call in `meta.name`) does not
+ *      break the resume contract that the script body honors.
+ *   3. The vm result is walked field-by-field and copied into a new
+ *      host-realm plain object. No JSON round-trip is needed because every
+ *      contract field is a primitive — strings and arrays of plain
+ *      objects with string fields — so prototype identity on the
+ *      intermediate values is irrelevant.
+ *
+ * Returns `{ stripped, meta: null }` when no meta declaration is present
+ * (callers treat this as "no meta"). Throws when meta is present but
+ * malformed: vm eval failure, missing required field, or wrong field type.
+ * Error messages for the missing-required-field cases match upstream
+ * 2.1.168 verbatim so script authors see one consistent error text.
+ */
+export function extractAndStripMeta(source: string): {
+  stripped: string;
+  meta: WorkflowMeta | null;
+} {
+  const bounds = findMetaBlockBounds(source);
+  if (!bounds) return { stripped: source, meta: null };
+
+  const metaSource = source.slice(bounds.startBrace, bounds.endBraceIncl + 1);
+  const stripped =
+    source.slice(0, bounds.exportIdx) + source.slice(bounds.afterMeta);
+
+  // Null-prototyped globalThis: no host bridge (no `process` / `require`
+  // / `args` / workflow-sandbox bridge globals). The vm realm still
+  // provides its own intrinsics, but that's intentional — see the
+  // docstring above.
+  const metaContext = vm.createContext(Object.create(null));
+  let raw: unknown;
+  try {
+    raw = new vm.Script(`(${metaSource})`).runInContext(metaContext);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(
+      `extractAndStripMeta: failed to evaluate meta object literal: ${msg}`,
+    );
+  }
+
+  const meta = validateMeta(raw);
+  return { stripped, meta };
+}
+
+/**
+ * Validate the vm-eval'd meta value and copy it into a fresh host-realm
+ * plain object. Throws on shape violation with the upstream-aligned error
+ * message text for the required-field cases.
+ *
+ * Field rules:
+ *   - `name`           required, non-empty string
+ *   - `description`    required, non-empty string
+ *   - `whenToUse`      optional, string (may be empty)
+ *   - `phases`         optional, Array of plain objects with:
+ *                        `title`   required, non-empty string
+ *                        `detail`  optional, string
+ *                        `model`   optional, string
+ */
+function validateMeta(value: unknown): WorkflowMeta {
+  if (value === null || typeof value !== 'object') {
+    throw new Error('meta must be an object');
+  }
+  const obj = value as Record<string, unknown>;
+  if (typeof obj['name'] !== 'string' || (obj['name'] as string).length === 0) {
+    // Verbatim from upstream Claude Code 2.1.168.
+    throw new Error('meta.name must be a non-empty string');
+  }
+  if (
+    typeof obj['description'] !== 'string' ||
+    (obj['description'] as string).length === 0
+  ) {
+    // Verbatim from upstream Claude Code 2.1.168.
+    throw new Error('meta.description must be a non-empty string');
+  }
+  if (
+    obj['whenToUse'] !== undefined &&
+    typeof obj['whenToUse'] !== 'string'
+  ) {
+    throw new Error('meta.whenToUse must be a string');
+  }
+  let phases:
+    | Array<{ title: string; detail?: string; model?: string }>
+    | undefined;
+  if (obj['phases'] !== undefined) {
+    if (!Array.isArray(obj['phases'])) {
+      throw new Error('meta.phases must be an array');
+    }
+    phases = [];
+    for (const p of obj['phases'] as unknown[]) {
+      if (p === null || typeof p !== 'object') {
+        throw new Error('meta.phases entries must be objects');
+      }
+      const ph = p as Record<string, unknown>;
+      if (
+        typeof ph['title'] !== 'string' ||
+        (ph['title'] as string).length === 0
+      ) {
+        throw new Error('meta.phases[].title must be a non-empty string');
+      }
+      const phase: { title: string; detail?: string; model?: string } = {
+        title: ph['title'] as string,
+      };
+      if (ph['detail'] !== undefined) {
+        if (typeof ph['detail'] !== 'string') {
+          throw new Error('meta.phases[].detail must be a string');
+        }
+        phase.detail = ph['detail'] as string;
+      }
+      if (ph['model'] !== undefined) {
+        if (typeof ph['model'] !== 'string') {
+          throw new Error('meta.phases[].model must be a string');
+        }
+        phase.model = ph['model'] as string;
+      }
+      phases.push(phase);
+    }
+  }
+
+  const out: WorkflowMeta = {
+    name: obj['name'] as string,
+    description: obj['description'] as string,
+  };
+  if (obj['whenToUse'] !== undefined) {
+    out.whenToUse = obj['whenToUse'] as string;
+  }
+  if (phases !== undefined) {
+    out.phases = phases;
+  }
+  return out;
 }
 
 /**
@@ -259,12 +447,22 @@ export interface WorkflowSandbox {
    * Execute the user-authored script source. The script is wrapped as an async
    * IIFE so it may use top-level `await` and `return`. Returns the script's
    * top-level return value.
+   *
+   * `export const meta = {...}` is extracted before parsing and exposed via
+   * `getMeta()` — the script body sees the meta-stripped source.
    */
   run(scriptSource: string): Promise<unknown>;
   /** Phase titles announced by the script in order. */
   getPhases(): string[];
   /** Log lines emitted by the script in order. */
   getLogs(): string[];
+  /**
+   * The script's `export const meta = {...}` declaration, validated and
+   * extracted before the script body runs. `null` when the script omits
+   * the declaration. Throws (during `run`) when the declaration is
+   * present but malformed.
+   */
+  getMeta(): WorkflowMeta | null;
 }
 
 /**
@@ -721,9 +919,15 @@ export function createWorkflowSandbox(opts: SandboxOptions): WorkflowSandbox {
 
   const maxWallClockMs = resolveMaxWallClockMs(opts);
 
+  let extractedMeta: WorkflowMeta | null = null;
   return {
     async run(scriptSource: string): Promise<unknown> {
-      const stripped = stripExportMeta(scriptSource);
+      // P4: extract `export const meta = {...}` once before the body runs.
+      // The stripped source is what the vm executes; the meta object is
+      // surfaced via `getMeta()` after the run (or after a malformed-meta
+      // throw, in which case the caller's catch block sees a clear error).
+      const { stripped, meta } = extractAndStripMeta(scriptSource);
+      extractedMeta = meta;
       const wrapped = `(async () => {\n${stripped}\n})()`;
       const script = new vm.Script(wrapped, {
         filename: 'workflow.js',
@@ -769,5 +973,6 @@ export function createWorkflowSandbox(opts: SandboxOptions): WorkflowSandbox {
     },
     getPhases: () => [...phases],
     getLogs: () => [...logs],
+    getMeta: () => extractedMeta,
   };
 }

--- a/packages/core/src/agents/runtime/workflow-sandbox.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.ts
@@ -624,6 +624,17 @@ export function createWorkflowSandbox(opts: SandboxOptions): WorkflowSandbox {
   const safePhase = (title: string): void => {
     if (phases.length < MAX_PHASE_ENTRIES) {
       const t = String(title);
+      // R7 (wenshao): collapse consecutive identical titles so the
+      // sandbox is the single source of truth for the phase list.
+      // Without this, `outcome.phases` (terminal `returnDisplay` JSON)
+      // carried duplicates while `entry.phases` on the registry
+      // (live UI / `/workflows` detail) was deduped by the registry's
+      // own `onPhaseStarted` collapse — the same run showed different
+      // phase counts in the terminal output vs the live UI. The
+      // `agent({phase})` wrapper already dedups (see the `__b.lastPhase()`
+      // check); this brings the bare `phase()` global into the same
+      // contract.
+      if (phases[phases.length - 1] === t) return;
       phases.push(t);
       // P4b: emit to host-side subscriber. Same defensive try/catch as
       // safeLog — subscriber errors must not bubble into the script.

--- a/packages/core/src/agents/runtime/workflow-sandbox.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.ts
@@ -203,8 +203,54 @@ export function extractAndStripMeta(source: string): {
     );
   }
 
+  // P4a R3 (wenshao): a Promise (e.g. `import('node:fs')`) used as a
+  // value in the meta literal would otherwise leave a dangling rejection
+  // behind — `runInContext` returns synchronously with the Promise scheduled
+  // to reject on the next tick, validateMeta drops the non-contract field
+  // silently, and the run completes successfully. Then Node's default
+  // `--unhandled-rejections=throw` terminates the host process, decoupled
+  // from the run that triggered it. Walk `raw`, neutralise any thenables
+  // with `.catch(() => {})` so the rejection is marked handled, and reject
+  // the meta literal up front.
+  rejectThenablesInMeta(raw);
+
   const meta = validateMeta(raw);
   return { stripped, meta };
+}
+
+/**
+ * Recursively scan a vm-eval'd value, marking any thenable as handled
+ * (so its rejection cannot terminate the host on the next tick) and
+ * throwing an explicit "meta values must not be Promises" so the
+ * malformed meta is reported clearly.
+ *
+ * Recurses through plain objects and arrays — `phases[]` entries may
+ * embed an `import()` below the top level.
+ */
+function rejectThenablesInMeta(value: unknown): void {
+  if (value === null || typeof value !== 'object') return;
+  const maybeThen = (value as { then?: unknown }).then;
+  if (typeof maybeThen === 'function') {
+    // Mark handled so Node's unhandled-rejection trap does not later kill
+    // the process. `.catch` on a non-Promise thenable would synchronously
+    // throw if the implementation is non-standard, so swallow defensively.
+    try {
+      (value as Promise<unknown>).catch(() => {});
+    } catch {
+      /* non-standard thenable — already rejecting below */
+    }
+    throw new Error(
+      'extractAndStripMeta: meta values must not be Promises ' +
+        '(no async / dynamic import allowed in meta literal)',
+    );
+  }
+  if (Array.isArray(value)) {
+    for (const v of value) rejectThenablesInMeta(v);
+    return;
+  }
+  for (const v of Object.values(value as Record<string, unknown>)) {
+    rejectThenablesInMeta(v);
+  }
 }
 
 /**
@@ -237,10 +283,7 @@ function validateMeta(value: unknown): WorkflowMeta {
     // Verbatim from upstream Claude Code 2.1.168.
     throw new Error('meta.description must be a non-empty string');
   }
-  if (
-    obj['whenToUse'] !== undefined &&
-    typeof obj['whenToUse'] !== 'string'
-  ) {
+  if (obj['whenToUse'] !== undefined && typeof obj['whenToUse'] !== 'string') {
     throw new Error('meta.whenToUse must be a string');
   }
   let phases:

--- a/packages/core/src/agents/runtime/workflow-sandbox.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.ts
@@ -227,8 +227,19 @@ export function extractAndStripMeta(source: string): {
  * Recurses through plain objects and arrays — `phases[]` entries may
  * embed an `import()` below the top level.
  */
-function rejectThenablesInMeta(value: unknown): void {
+function rejectThenablesInMeta(
+  value: unknown,
+  seen: WeakSet<object> = new WeakSet(),
+): void {
   if (value === null || typeof value !== 'object') return;
+  // P4 Round 4 (wenshao): a cyclic meta literal built via spread of a
+  // self-referential object would otherwise overflow the call stack on
+  // this walk — the walker exists to reject Promises before they leave
+  // a dangling rejection, but the walk itself must terminate on any
+  // shape vm-eval can return. Track visited nodes in a WeakSet so cycles
+  // and shared subgraphs both early-return without re-walking.
+  if (seen.has(value as object)) return;
+  seen.add(value as object);
   const maybeThen = (value as { then?: unknown }).then;
   if (typeof maybeThen === 'function') {
     // Mark handled so Node's unhandled-rejection trap does not later kill
@@ -245,11 +256,11 @@ function rejectThenablesInMeta(value: unknown): void {
     );
   }
   if (Array.isArray(value)) {
-    for (const v of value) rejectThenablesInMeta(v);
+    for (const v of value) rejectThenablesInMeta(v, seen);
     return;
   }
   for (const v of Object.values(value as Record<string, unknown>)) {
-    rejectThenablesInMeta(v);
+    rejectThenablesInMeta(v, seen);
   }
 }
 

--- a/packages/core/src/agents/runtime/workflow-sandbox.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.ts
@@ -409,6 +409,32 @@ export interface WorkflowBudget {
   remaining(): number;
 }
 
+/**
+ * P4b: host-side live-event channel for the orchestrator and sandbox to
+ * notify external consumers (typically the `WorkflowRunRegistry`) when
+ * a phase boundary or agent dispatch happens, or when the script logs
+ * something. Every method is host-realm (called from sandbox closures
+ * and `countedDispatch`) — no vm-realm bridge concerns.
+ *
+ * All methods are no-ops by default — implementations are free to
+ * implement only the events they care about.
+ *
+ * Truncation: `phaseStarted` / `logAppended` are NOT called once the
+ * sandbox's internal `MAX_PHASE_ENTRIES` / `MAX_LOG_LINES` cap has
+ * been reached, mirroring `getPhases()` / `getLogs()` so a chatty
+ * workflow does not flood the registry with thousands of events.
+ */
+export interface WorkflowOrchestratorEmitter {
+  /** Sandbox `phase(title)` was called. */
+  phaseStarted?(title: string): void;
+  /** Sandbox `log(...)` produced one line of output (or `console.log`). */
+  logAppended?(line: string): void;
+  /** Orchestrator's `countedDispatch` is about to invoke `dispatch(...)`. */
+  agentDispatched?(label?: string): void;
+  /** `dispatch(...)` settled (success or thrown). `error` set on rejection. */
+  agentCompleted?(label?: string, error?: string): void;
+}
+
 export interface SandboxOptions {
   /** Value bound to the `args` global inside the script. */
   args: unknown;
@@ -460,6 +486,15 @@ export interface SandboxOptions {
    * `abort()` in a `finally` block to cancel any straggler dispatch).
    */
   abortOnTimeout?: AbortController;
+  /**
+   * P4b: optional host-side event channel. When provided, the sandbox's
+   * `safePhase` / `safeLog` closures fire `phaseStarted` / `logAppended`
+   * on every accepted entry (after the per-cap truncation guard). The
+   * caller (typically `WorkflowTool` via `WorkflowOrchestrator`) wires
+   * these into the `WorkflowRunRegistry` so the UI surfaces (pill /
+   * dialog / detail body) can re-render without polling `getPhases()`.
+   */
+  emitter?: WorkflowOrchestratorEmitter;
 }
 
 /**
@@ -560,7 +595,16 @@ export function createWorkflowSandbox(opts: SandboxOptions): WorkflowSandbox {
 
   const safeLog = (msg: unknown): void => {
     if (logs.length < MAX_LOG_LINES) {
-      logs.push(String(msg));
+      const line = String(msg);
+      logs.push(line);
+      // P4b: emit to host-side subscriber (registry). Defensive try/catch
+      // because a subscriber error must not interrupt script execution
+      // — the script body has no business knowing about UI plumbing.
+      try {
+        opts.emitter?.logAppended?.(line);
+      } catch (e) {
+        debugLogger.warn('emitter.logAppended threw:', e);
+      }
     } else if (logs.length === MAX_LOG_LINES) {
       logs.push(`[workflow log truncated at ${MAX_LOG_LINES} lines]`);
     }
@@ -568,7 +612,15 @@ export function createWorkflowSandbox(opts: SandboxOptions): WorkflowSandbox {
 
   const safePhase = (title: string): void => {
     if (phases.length < MAX_PHASE_ENTRIES) {
-      phases.push(String(title));
+      const t = String(title);
+      phases.push(t);
+      // P4b: emit to host-side subscriber. Same defensive try/catch as
+      // safeLog — subscriber errors must not bubble into the script.
+      try {
+        opts.emitter?.phaseStarted?.(t);
+      } catch (e) {
+        debugLogger.warn('emitter.phaseStarted threw:', e);
+      }
     } else if (phases.length === MAX_PHASE_ENTRIES) {
       phases.push(
         `[workflow phases truncated at ${MAX_PHASE_ENTRIES} entries]`,

--- a/packages/core/src/agents/tasks/types.ts
+++ b/packages/core/src/agents/tasks/types.ts
@@ -29,15 +29,23 @@
  */
 
 /**
- * Discriminator over the task kinds tracked by the three task registries.
- * Each kind's per-kind state intersects with `TaskBase` to form the
- * union member; see `TaskState`.
+ * Discriminator over the task kinds tracked by the four core task
+ * registries. Each kind's per-kind state intersects with `TaskBase`
+ * to form the union member; see `TaskState`.
  *
- * Dream tasks (`MemoryManager`) are intentionally outside this union
- * for now — they have a separate lifecycle and their inclusion is
- * deferred to a follow-up.
+ * Dream tasks (`MemoryManager`) are intentionally outside this union —
+ * they have a separate lifecycle and their inclusion is deferred to a
+ * follow-up.
+ *
+ * `workflow` (P4b) is registered/observed via `WorkflowRunRegistry` and
+ * differs from the others in that the registry NEVER emits a
+ * `<task-notification>` envelope — `WorkflowTool` already returns its
+ * own llmContent + returnDisplay payload to the model on terminal, so
+ * a second envelope would duplicate the signal. The kind is widened
+ * here so the UI surfaces (pill / dialog / detail body) can switch on
+ * `entry.kind === 'workflow'`.
  */
-export type TaskKind = 'agent' | 'shell' | 'monitor';
+export type TaskKind = 'agent' | 'shell' | 'monitor' | 'workflow';
 
 /**
  * Lifecycle states a task can occupy. `paused` and `cancelled` are
@@ -112,11 +120,12 @@ export type TaskRegistration<T extends TaskBase> = Omit<
 import type { AgentTask } from '../background-tasks.js';
 import type { ShellTask } from '../../services/backgroundShellRegistry.js';
 import type { MonitorTask } from '../../services/monitorRegistry.js';
+import type { WorkflowTask } from '../workflow-run-registry.js';
 
 /**
- * Discriminated union over every task kind tracked by the three
+ * Discriminated union over every task kind tracked by the four
  * registries. Switch on `kind` to narrow to the per-kind shape.
  */
-export type TaskState = AgentTask | ShellTask | MonitorTask;
+export type TaskState = AgentTask | ShellTask | MonitorTask | WorkflowTask;
 
-export type { AgentTask, ShellTask, MonitorTask };
+export type { AgentTask, ShellTask, MonitorTask, WorkflowTask };

--- a/packages/core/src/agents/workflow-run-registry.test.ts
+++ b/packages/core/src/agents/workflow-run-registry.test.ts
@@ -190,4 +190,86 @@ describe('WorkflowRunRegistry', () => {
     // Must not throw.
     expect(() => r.complete('wf_throw', null, 1)).not.toThrow();
   });
+
+  // P4 Round 7 (wenshao): dialog-initiated cancel marks status='cancelled'
+  // synchronously, then the abort propagates to the tool's catch arm which
+  // calls setRecentLogs(runId, logs). The previous guard rejected this
+  // because status !== 'running', so cancelled workflows showed an empty
+  // Logs section in the dialog. The fix allows setRecentLogs after the
+  // 'cancelled' transition — Ctrl+C (signal.aborted at execute()'s top
+  // before the dialog touches the registry) is unchanged, and the
+  // unchanged guard still rejects logs arriving after 'completed' or
+  // 'failed' (those terminal states are final).
+  it('setRecentLogs after a cancel transition still writes (dialog-initiated)', () => {
+    const r = new WorkflowRunRegistry();
+    r.register(reg('wf_late_logs'));
+    r.cancel('wf_late_logs', 5_000);
+    r.setRecentLogs('wf_late_logs', ['line1', 'line2']);
+    const e = r.get('wf_late_logs')!;
+    expect(e.recentLogs).toEqual(['line1', 'line2']);
+    expect(e.status).toBe('cancelled');
+  });
+
+  it('setRecentLogs after complete/fail is rejected (terminal states are final)', () => {
+    const r = new WorkflowRunRegistry();
+    r.register(reg('wf_done'));
+    r.complete('wf_done', null, 1_000);
+    r.setRecentLogs('wf_done', ['too late']);
+    expect(r.get('wf_done')!.recentLogs).toEqual([]);
+
+    r.register(reg('wf_fail'));
+    r.fail('wf_fail', 'boom', 2_000);
+    r.setRecentLogs('wf_fail', ['too late']);
+    expect(r.get('wf_fail')!.recentLogs).toEqual([]);
+  });
+
+  // P4 Round 7 (wenshao): WorkflowRunRegistry must expose reset() and
+  // abortAll() to match its three sibling registries (agent, shell,
+  // monitor). Without these, /clear and session-resume leak prior-
+  // session workflow state into the next session — pill / dialog /
+  // /workflows listing all show stale rows, and in-flight workflows
+  // keep executing after the user cleared the session.
+  it('reset() drops every entry without aborting controllers', () => {
+    const r = new WorkflowRunRegistry();
+    const ac1 = new AbortController();
+    r.register(reg('wf_1', { abortController: ac1 }));
+    r.register(reg('wf_2'));
+    r.complete('wf_2', null, 1_000);
+    expect(r.list()).toHaveLength(2);
+    r.reset();
+    expect(r.list()).toEqual([]);
+    // Sibling shell registry's reset() does NOT touch processes — same
+    // contract here: reset just drops in-memory entries; abortAll() is
+    // the controller-aborting path.
+    expect(ac1.signal.aborted).toBe(false);
+  });
+
+  it('abortAll() aborts every running entry and marks them cancelled', () => {
+    const r = new WorkflowRunRegistry();
+    const ac1 = new AbortController();
+    const ac2 = new AbortController();
+    const acDone = new AbortController();
+    r.register(reg('wf_run1', { abortController: ac1 }));
+    r.register(reg('wf_run2', { abortController: ac2 }));
+    r.register(reg('wf_done', { abortController: acDone }));
+    r.complete('wf_done', null, 1_000);
+    r.abortAll();
+    expect(ac1.signal.aborted).toBe(true);
+    expect(ac2.signal.aborted).toBe(true);
+    // Already-terminal entry's controller is NOT re-aborted (no-op for
+    // settled entries).
+    expect(acDone.signal.aborted).toBe(false);
+    expect(r.get('wf_run1')!.status).toBe('cancelled');
+    expect(r.get('wf_run2')!.status).toBe('cancelled');
+    expect(r.get('wf_done')!.status).toBe('completed');
+  });
+
+  it('hasRunningEntries() reflects the running subset', () => {
+    const r = new WorkflowRunRegistry();
+    expect(r.hasRunningEntries()).toBe(false);
+    r.register(reg('wf_1'));
+    expect(r.hasRunningEntries()).toBe(true);
+    r.complete('wf_1', null, 1_000);
+    expect(r.hasRunningEntries()).toBe(false);
+  });
 });

--- a/packages/core/src/agents/workflow-run-registry.test.ts
+++ b/packages/core/src/agents/workflow-run-registry.test.ts
@@ -1,0 +1,193 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  WorkflowRunRegistry,
+  MAX_RETAINED_TERMINAL_WORKFLOWS,
+  type WorkflowTaskRegistration,
+} from './workflow-run-registry.js';
+
+function reg(
+  runId: string,
+  overrides: Partial<WorkflowTaskRegistration> = {},
+): WorkflowTaskRegistration {
+  return {
+    runId,
+    meta: null,
+    description: 'wf',
+    status: 'running',
+    startTime: 1_700_000_000_000,
+    outputFile: `/tmp/${runId}.jsonl`,
+    abortController: new AbortController(),
+    ...overrides,
+  } as WorkflowTaskRegistration;
+}
+
+describe('WorkflowRunRegistry', () => {
+  it('register graduates the registration to a WorkflowTask in place', () => {
+    const r = new WorkflowRunRegistry();
+    const registration = reg('wf_1');
+    const entry = r.register(registration);
+    expect(entry).toBe(registration);
+    expect(entry.id).toBe('wf_1');
+    expect(entry.kind).toBe('workflow');
+    expect(entry.currentPhase).toBeNull();
+    expect(entry.phases).toEqual([]);
+    expect(entry.agentsDispatched).toBe(0);
+    expect(entry.agentsCompleted).toBe(0);
+    expect(entry.recentLogs).toEqual([]);
+    expect(entry.outputOffset).toBe(0);
+    expect(entry.notified).toBe(false);
+  });
+
+  it('register synthesizes description from meta.name when omitted', () => {
+    const r = new WorkflowRunRegistry();
+    const entry = r.register(
+      reg('wf_named', {
+        description: undefined,
+        meta: { name: 'capitals', description: 'd' },
+      }),
+    );
+    expect(entry.description).toBe('capitals');
+  });
+
+  it('register falls back to runId when meta is null and no description', () => {
+    const r = new WorkflowRunRegistry();
+    const entry = r.register(reg('wf_anon', { description: undefined }));
+    expect(entry.description).toBe('wf_anon');
+  });
+
+  it('onPhaseStarted appends + sets currentPhase, dedupes consecutive', () => {
+    const r = new WorkflowRunRegistry();
+    r.register(reg('wf_1'));
+    r.onPhaseStarted('wf_1', 'Plan');
+    r.onPhaseStarted('wf_1', 'Plan'); // dedup
+    r.onPhaseStarted('wf_1', 'Build');
+    const e = r.get('wf_1')!;
+    expect(e.phases).toEqual(['Plan', 'Build']);
+    expect(e.currentPhase).toBe('Build');
+  });
+
+  it('onAgentDispatched + onAgentCompleted increment counters', () => {
+    const r = new WorkflowRunRegistry();
+    r.register(reg('wf_1'));
+    r.onAgentDispatched('wf_1');
+    r.onAgentDispatched('wf_1');
+    r.onAgentCompleted('wf_1');
+    const e = r.get('wf_1')!;
+    expect(e.agentsDispatched).toBe(2);
+    expect(e.agentsCompleted).toBe(1);
+  });
+
+  it('setRecentLogs caps at 100 entries (keeps the tail)', () => {
+    const r = new WorkflowRunRegistry();
+    r.register(reg('wf_1'));
+    const logs = Array.from({ length: 250 }, (_, i) => `line ${i}`);
+    r.setRecentLogs('wf_1', logs);
+    const e = r.get('wf_1')!;
+    expect(e.recentLogs).toHaveLength(100);
+    expect(e.recentLogs[0]).toBe('line 150');
+    expect(e.recentLogs[99]).toBe('line 249');
+  });
+
+  it('complete settles the entry and ignores subsequent transitions', () => {
+    const r = new WorkflowRunRegistry();
+    r.register(reg('wf_1'));
+    r.complete('wf_1', { answer: 'Paris' }, 2_000);
+    const e = r.get('wf_1')!;
+    expect(e.status).toBe('completed');
+    expect(e.endTime).toBe(2_000);
+    expect(e.result).toEqual({ answer: 'Paris' });
+    expect(e.notified).toBe(true);
+
+    r.fail('wf_1', 'too late', 3_000);
+    r.cancel('wf_1', 4_000);
+    r.onPhaseStarted('wf_1', 'ignored');
+    expect(e.status).toBe('completed');
+    expect(e.error).toBeUndefined();
+    expect(e.endTime).toBe(2_000);
+    expect(e.phases).toEqual([]); // onPhaseStarted is gated by status
+  });
+
+  it('fail records the message and settles', () => {
+    const r = new WorkflowRunRegistry();
+    r.register(reg('wf_1'));
+    r.fail('wf_1', 'boom', 5_000);
+    const e = r.get('wf_1')!;
+    expect(e.status).toBe('failed');
+    expect(e.error).toBe('boom');
+    expect(e.endTime).toBe(5_000);
+  });
+
+  it('cancel aborts the controller and settles', () => {
+    const r = new WorkflowRunRegistry();
+    const ac = new AbortController();
+    r.register(reg('wf_1', { abortController: ac }));
+    expect(ac.signal.aborted).toBe(false);
+    r.cancel('wf_1', 6_000);
+    expect(ac.signal.aborted).toBe(true);
+    const e = r.get('wf_1')!;
+    expect(e.status).toBe('cancelled');
+  });
+
+  it('terminal entries are evicted once over the retention cap', () => {
+    const r = new WorkflowRunRegistry();
+    for (let i = 0; i < MAX_RETAINED_TERMINAL_WORKFLOWS + 5; i++) {
+      r.register(reg(`wf_${i}`));
+      r.complete(`wf_${i}`, null, 1_000 + i);
+    }
+    const all = r.list();
+    expect(all).toHaveLength(MAX_RETAINED_TERMINAL_WORKFLOWS);
+    // Oldest-by-endTime are evicted first; the surviving subset must be
+    // the most recently-completed ones.
+    const ids = all.map((e) => e.runId);
+    expect(ids).toContain(`wf_${MAX_RETAINED_TERMINAL_WORKFLOWS + 4}`);
+    expect(ids).not.toContain('wf_0');
+  });
+
+  it('running entries are never evicted', () => {
+    const r = new WorkflowRunRegistry();
+    r.register(reg('runner')); // stays running
+    for (let i = 0; i < MAX_RETAINED_TERMINAL_WORKFLOWS + 3; i++) {
+      r.register(reg(`done_${i}`));
+      r.complete(`done_${i}`, null, 2_000 + i);
+    }
+    expect(r.get('runner')).toBeDefined();
+    expect(r.get('runner')!.status).toBe('running');
+  });
+
+  it('register callback fires synchronously inside register()', () => {
+    const r = new WorkflowRunRegistry();
+    const cb = vi.fn();
+    r.setRegisterCallback(cb);
+    const e = r.register(reg('wf_cb'));
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith(e);
+  });
+
+  it('statusChange fires on register + every transition', () => {
+    const r = new WorkflowRunRegistry();
+    const cb = vi.fn();
+    r.setStatusChangeCallback(cb);
+    r.register(reg('wf_sc'));
+    r.onPhaseStarted('wf_sc', 'Plan');
+    r.onAgentDispatched('wf_sc');
+    r.complete('wf_sc', 'ok', 7_000);
+    // 1 (register) + 1 (phase) + 1 (dispatched) + 1 (complete) = 4
+    expect(cb).toHaveBeenCalledTimes(4);
+  });
+
+  it('errors thrown by status-change callback do not break the call site', () => {
+    const r = new WorkflowRunRegistry();
+    r.setStatusChangeCallback(() => {
+      throw new Error('subscriber blew up');
+    });
+    r.register(reg('wf_throw'));
+    // Must not throw.
+    expect(() => r.complete('wf_throw', null, 1)).not.toThrow();
+  });
+});

--- a/packages/core/src/agents/workflow-run-registry.ts
+++ b/packages/core/src/agents/workflow-run-registry.ts
@@ -1,0 +1,291 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Tracks in-flight and recently-finished workflow runs spawned via the
+ * `Workflow` tool. Sibling of `BackgroundTaskRegistry` (agents),
+ * `BackgroundShellRegistry` (shells), and `MonitorRegistry` (monitors).
+ * Each entry holds the metadata that the footer pill, the `/workflows`
+ * slash command, and the Background tasks dialog use to query, observe,
+ * or cancel a running workflow.
+ *
+ * State machine: register → running → { completed | failed | cancelled }.
+ * Transitions out of running are one-shot — complete / fail / cancel
+ * become no-ops once the entry has settled.
+ *
+ * Unlike `BackgroundTaskRegistry`, the workflow registry does NOT emit
+ * any `<task-notification>` XML or model-facing prose — `WorkflowTool`
+ * already returns its own llmContent + returnDisplay payload to the
+ * model when the run terminates, so a second envelope would duplicate
+ * the signal. The registry is UI-only: its callbacks drive the pill
+ * counts, the dialog roster, and the per-phase detail body.
+ */
+
+import type { TaskBase, TaskRegistration } from './tasks/types.js';
+import type { WorkflowMeta } from './runtime/workflow-sandbox.js';
+import { createDebugLogger } from '../utils/debugLogger.js';
+
+const debugLogger = createDebugLogger('WORKFLOW_REGISTRY');
+
+/**
+ * Cap on terminal entries retained for dialog history. Picked smaller
+ * than `MAX_RETAINED_TERMINAL_AGENTS` (32) because workflow rows carry
+ * the heavier label (workflow name + phase tree) and because users
+ * typically run far fewer workflows than agents per session.
+ */
+export const MAX_RETAINED_TERMINAL_WORKFLOWS = 10;
+
+export type WorkflowStatus = 'running' | 'completed' | 'failed' | 'cancelled';
+
+/**
+ * Workflow kind of `TaskState`. Tracks one orchestrator run — the
+ * top-level `Workflow` tool call, not its internal subagent dispatches
+ * (those are routed through the regular subagent path and recorded by
+ * `BackgroundTaskRegistry` when backgrounded). The `phases` array is
+ * the sandbox's `getPhases()` snapshot; `currentPhase` is the head of
+ * the most recent `phase()` call.
+ */
+export interface WorkflowTask extends TaskBase {
+  kind: 'workflow';
+  /** Run identifier (e.g. `wf_<8hex>`); aliased to `TaskBase.id`. */
+  runId: string;
+  /**
+   * Parsed `export const meta = {...}` from the workflow script, or
+   * `null` if the script had no meta declaration. The pill / dialog
+   * row label falls back to `runId` when meta is null.
+   */
+  meta: WorkflowMeta | null;
+  status: WorkflowStatus;
+  /** Title of the most recent `phase(...)` call, or `null` before the first phase. */
+  currentPhase: string | null;
+  /**
+   * All phase titles seen so far (deduplicated against the previous
+   * entry — matches the sandbox's `safePhase` collapse). Capped at
+   * `MAX_PHASE_ENTRIES` (10_000) by the sandbox.
+   */
+  phases: string[];
+  /** Cumulative `agent()` dispatches issued by this run. */
+  agentsDispatched: number;
+  /** Cumulative `agent()` dispatches that have resolved (success or thrown). */
+  agentsCompleted: number;
+  /** Most recent log lines from the sandbox's `getLogs()`. Capped at 100 for the UI. */
+  recentLogs: string[];
+  /** Final script return value once the run completes (success path). */
+  result?: unknown;
+  /** Error message on `failed` (terminal). */
+  error?: string;
+}
+
+/**
+ * Shape callers pass to `register()`. The four `TaskBase` fields the
+ * registry derives — `id`, `kind`, `outputOffset`, `notified` — are
+ * omitted; everything else (including `outputFile`) is supplied by the
+ * caller. `currentPhase` / `phases` / `agentsDispatched` /
+ * `agentsCompleted` / `recentLogs` all default to their empty
+ * counterparts at register time and become observable via subsequent
+ * `onPhaseStarted` / `onAgentDispatched` / etc.
+ */
+export type WorkflowTaskRegistration = Omit<
+  TaskRegistration<WorkflowTask>,
+  | 'currentPhase'
+  | 'phases'
+  | 'agentsDispatched'
+  | 'agentsCompleted'
+  | 'recentLogs'
+  | 'description'
+> & {
+  // Allow the caller to omit `description` — we synthesize it from
+  // `meta?.name ?? runId` for symmetry with shell registry's `command`
+  // synthesis.
+  description?: string;
+};
+
+/** Fires when a new entry is registered. */
+export type WorkflowRunRegisterCallback = (entry: WorkflowTask) => void;
+
+/**
+ * Fires whenever the entry's `status`, `currentPhase`, or dispatch
+ * counts change. Symmetric with the other registries' `statusChange`
+ * callback so the unified `useBackgroundTaskView` hook can subscribe
+ * to all four with the same shape.
+ */
+export type WorkflowRunStatusChangeCallback = (entry?: WorkflowTask) => void;
+
+export class WorkflowRunRegistry {
+  private readonly entries = new Map<string, WorkflowTask>();
+
+  private registerCallback: WorkflowRunRegisterCallback | undefined;
+  private statusChangeCallback: WorkflowRunStatusChangeCallback | undefined;
+
+  setRegisterCallback(cb: WorkflowRunRegisterCallback | undefined): void {
+    this.registerCallback = cb;
+  }
+
+  setStatusChangeCallback(
+    cb: WorkflowRunStatusChangeCallback | undefined,
+  ): void {
+    this.statusChangeCallback = cb;
+  }
+
+  /**
+   * Register a new run. Mutates the registration in place to graduate
+   * it to a `WorkflowTask` (sets `id`, `kind`, derived counters), so
+   * callers can keep using their local reference post-register and
+   * observers see updates without an extra `get()`.
+   */
+  register(registration: WorkflowTaskRegistration): WorkflowTask {
+    const entry = registration as WorkflowTask;
+    entry.id = registration.runId;
+    entry.kind = 'workflow';
+    entry.outputOffset = 0;
+    entry.notified = false;
+    entry.currentPhase = null;
+    entry.phases = [];
+    entry.agentsDispatched = 0;
+    entry.agentsCompleted = 0;
+    entry.recentLogs = [];
+    if (!entry.description) {
+      entry.description = entry.meta?.name ?? entry.runId;
+    }
+    this.entries.set(entry.runId, entry);
+    debugLogger.info(`Registered workflow run: ${entry.runId}`);
+
+    if (this.registerCallback) {
+      try {
+        this.registerCallback(entry);
+      } catch (error) {
+        debugLogger.error('Failed to emit register callback:', error);
+      }
+    }
+    this.emitStatusChange(entry);
+    return entry;
+  }
+
+  /**
+   * Append a phase title. Mirrors the sandbox's `safePhase` collapse:
+   * a phase identical to the most recent entry is treated as the same
+   * phase and not re-appended. `currentPhase` is set unconditionally.
+   *
+   * @param runId  the run to update
+   * @param title  the phase title from the sandbox `phase()` call
+   */
+  onPhaseStarted(runId: string, title: string): void {
+    const entry = this.entries.get(runId);
+    if (!entry || entry.status !== 'running') return;
+    entry.currentPhase = title;
+    const last = entry.phases[entry.phases.length - 1];
+    if (last !== title) entry.phases.push(title);
+    this.emitStatusChange(entry);
+  }
+
+  /** Cumulative dispatch counter — incremented before each `agent()` call resolves. */
+  onAgentDispatched(runId: string): void {
+    const entry = this.entries.get(runId);
+    if (!entry || entry.status !== 'running') return;
+    entry.agentsDispatched++;
+    this.emitStatusChange(entry);
+  }
+
+  /** Cumulative completion counter — incremented after each `agent()` call settles. */
+  onAgentCompleted(runId: string): void {
+    const entry = this.entries.get(runId);
+    if (!entry || entry.status !== 'running') return;
+    entry.agentsCompleted++;
+    this.emitStatusChange(entry);
+  }
+
+  /**
+   * Replace the recent-log tail. The sandbox owns the source-of-truth
+   * `getLogs()` array; we mirror it here for the UI so the dialog
+   * doesn't have to thread a sandbox reference. Capped at 100 entries
+   * (the tail) so a chatty workflow doesn't bloat the registry.
+   */
+  setRecentLogs(runId: string, logs: readonly string[]): void {
+    const entry = this.entries.get(runId);
+    if (!entry || entry.status !== 'running') return;
+    const tail = logs.length > 100 ? logs.slice(-100) : Array.from(logs);
+    entry.recentLogs = tail;
+    this.emitStatusChange(entry);
+  }
+
+  complete(runId: string, result: unknown, endTime: number): void {
+    const entry = this.entries.get(runId);
+    if (!entry || entry.status !== 'running') return;
+    entry.status = 'completed';
+    entry.endTime = endTime;
+    entry.result = result;
+    entry.notified = true;
+    this.emitStatusChange(entry);
+    this.evictTerminal();
+  }
+
+  fail(runId: string, message: string, endTime: number): void {
+    const entry = this.entries.get(runId);
+    if (!entry || entry.status !== 'running') return;
+    entry.status = 'failed';
+    entry.endTime = endTime;
+    entry.error = message;
+    entry.notified = true;
+    this.emitStatusChange(entry);
+    this.evictTerminal();
+  }
+
+  /**
+   * Mark a running entry as cancelled and abort its controller. No-op
+   * if the entry has already settled — protects against an explicit
+   * dialog cancel racing with the natural complete/fail path.
+   */
+  cancel(runId: string, endTime: number): void {
+    const entry = this.entries.get(runId);
+    if (!entry || entry.status !== 'running') return;
+    entry.status = 'cancelled';
+    entry.endTime = endTime;
+    entry.notified = true;
+    try {
+      entry.abortController.abort();
+    } catch (error) {
+      debugLogger.error('Failed to abort workflow controller:', error);
+    }
+    this.emitStatusChange(entry);
+    this.evictTerminal();
+  }
+
+  get(runId: string): WorkflowTask | undefined {
+    return this.entries.get(runId);
+  }
+
+  /** All entries (running + terminal, no filter). Iteration order = registration order. */
+  list(): WorkflowTask[] {
+    return Array.from(this.entries.values());
+  }
+
+  /**
+   * Sweep terminal entries when they exceed `MAX_RETAINED_TERMINAL_WORKFLOWS`.
+   * Running entries are always retained. Oldest terminal entries
+   * (by `endTime`) are evicted first.
+   */
+  private evictTerminal(): void {
+    const terminal = this.list().filter((e) => e.status !== 'running');
+    if (terminal.length <= MAX_RETAINED_TERMINAL_WORKFLOWS) return;
+    terminal.sort((a, b) => (a.endTime ?? 0) - (b.endTime ?? 0));
+    const toEvict = terminal.slice(
+      0,
+      terminal.length - MAX_RETAINED_TERMINAL_WORKFLOWS,
+    );
+    for (const e of toEvict) {
+      this.entries.delete(e.runId);
+    }
+  }
+
+  private emitStatusChange(entry: WorkflowTask): void {
+    if (!this.statusChangeCallback) return;
+    try {
+      this.statusChangeCallback(entry);
+    } catch (error) {
+      debugLogger.error('Failed to emit workflow status change:', error);
+    }
+  }
+}

--- a/packages/core/src/agents/workflow-run-registry.ts
+++ b/packages/core/src/agents/workflow-run-registry.ts
@@ -202,10 +202,19 @@ export class WorkflowRunRegistry {
    * `getLogs()` array; we mirror it here for the UI so the dialog
    * doesn't have to thread a sandbox reference. Capped at 100 entries
    * (the tail) so a chatty workflow doesn't bloat the registry.
+   *
+   * R7 (wenshao): allowed after a `'cancelled'` transition too. The
+   * dialog-initiated cancel path calls `registry.cancel()` first
+   * (status flips to `'cancelled'` synchronously), then the abort
+   * propagates to the tool's catch arm which calls `setRecentLogs`.
+   * Without this, dialog-cancelled runs always showed an empty Logs
+   * section. `'completed'` / `'failed'` are still rejected — those
+   * terminal states ARE final (no late-arriving logs to absorb).
    */
   setRecentLogs(runId: string, logs: readonly string[]): void {
     const entry = this.entries.get(runId);
-    if (!entry || entry.status !== 'running') return;
+    if (!entry) return;
+    if (entry.status !== 'running' && entry.status !== 'cancelled') return;
     const tail = logs.length > 100 ? logs.slice(-100) : Array.from(logs);
     entry.recentLogs = tail;
     this.emitStatusChange(entry);
@@ -260,6 +269,75 @@ export class WorkflowRunRegistry {
   /** All entries (running + terminal, no filter). Iteration order = registration order. */
   list(): WorkflowTask[] {
     return Array.from(this.entries.values());
+  }
+
+  /**
+   * R7 (wenshao): true if any entry is still `'running'`. Mirrors the
+   * three sibling registries' `hasUnfinalizedTasks()` /
+   * `hasRunningEntries()` / `getRunning().length > 0` so the unified
+   * `hasBlockingBackgroundWork()` helper (the gate `/clear` and session-
+   * resume both use to refuse a switch with live work) can count
+   * workflow runs the same way.
+   */
+  hasRunningEntries(): boolean {
+    for (const entry of this.entries.values()) {
+      if (entry.status === 'running') return true;
+    }
+    return false;
+  }
+
+  /**
+   * R7 (wenshao): drop every in-memory entry without touching
+   * controllers. Mirrors `BackgroundShellRegistry.reset()` and the
+   * other siblings' contract — callers (`/clear`, session-resume)
+   * MUST verify via `hasRunningEntries()` first that no still-running
+   * work exists before invoking. The companion path that aborts
+   * controllers is `abortAll()`.
+   */
+  reset(): void {
+    if (this.entries.size === 0) return;
+    // Snapshot a sample entry for the statusChange callback so a single
+    // subscriber notify is enough — the only consumer
+    // (`useBackgroundTaskView`) ignores the entry arg and re-pulls
+    // `list()` on every fire.
+    const sample = this.entries.values().next().value as
+      | WorkflowTask
+      | undefined;
+    this.entries.clear();
+    if (sample) this.emitStatusChange(sample);
+  }
+
+  /**
+   * R7 (wenshao): cancel every still-running entry. Called on session/
+   * Config shutdown so workflow runs don't outlive the CLI process and
+   * leak orphaned dispatches. Symmetric with `BackgroundShellRegistry.
+   * abortAll()` and `BackgroundTaskRegistry.abortAll()`.
+   *
+   * Settles each entry inline (status → 'cancelled', abort the
+   * controller) and fires the status-change callback exactly once
+   * after the loop — the per-entry `cancel()` path would have fired
+   * the callback for every running entry, wasteful on shutdown.
+   */
+  abortAll(): void {
+    const endTime = Date.now();
+    let lastCancelled: WorkflowTask | undefined;
+    for (const entry of Array.from(this.entries.values())) {
+      if (entry.status !== 'running') continue;
+      entry.status = 'cancelled';
+      entry.endTime = endTime;
+      entry.notified = true;
+      try {
+        entry.abortController.abort();
+      } catch (error) {
+        debugLogger.error(
+          'abortAll: failed to abort workflow controller:',
+          error,
+        );
+      }
+      lastCancelled = entry;
+    }
+    if (lastCancelled) this.emitStatusChange(lastCancelled);
+    this.evictTerminal();
   }
 
   /**

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -89,6 +89,7 @@ import { BackgroundTaskRegistry } from '../agents/background-tasks.js';
 import { MonitorRegistry } from '../services/monitorRegistry.js';
 import { BackgroundAgentResumeService } from '../agents/background-agent-resume.js';
 import { BackgroundShellRegistry } from '../services/backgroundShellRegistry.js';
+import { WorkflowRunRegistry } from '../agents/workflow-run-registry.js';
 import { FileReadCache } from '../services/fileReadCache.js';
 import { resolveStopHookBlockingCap } from '../hooks/stopHookCap.js';
 import {
@@ -1108,6 +1109,7 @@ export class Config {
   private readonly monitorRegistry = new MonitorRegistry();
   private backgroundAgentResumeService?: BackgroundAgentResumeService;
   private readonly backgroundShellRegistry = new BackgroundShellRegistry();
+  private readonly workflowRunRegistry = new WorkflowRunRegistry();
   // Field initializer runs once on the parent Config; child Configs
   // built via Object.create(parent) intentionally do NOT pick this up
   // — see getFileReadCache() for the per-instance lazy initialization
@@ -4423,6 +4425,10 @@ export class Config {
 
   getBackgroundShellRegistry(): BackgroundShellRegistry {
     return this.backgroundShellRegistry;
+  }
+
+  getWorkflowRunRegistry(): WorkflowRunRegistry {
+    return this.workflowRunRegistry;
   }
 
   /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -195,6 +195,7 @@ export {
 export * from './services/shellExecutionService.js';
 export * from './services/monitorRegistry.js';
 export * from './services/backgroundShellRegistry.js';
+export * from './agents/workflow-run-registry.js';
 export * from './services/toolUseSummary.js';
 export * from './services/usageHistoryService.js';
 export * from './utils/bareMode.js';

--- a/packages/core/src/tools/workflow/workflow.test.ts
+++ b/packages/core/src/tools/workflow/workflow.test.ts
@@ -484,4 +484,84 @@ describe('WorkflowTool', () => {
     expect(entry.status).toBe('cancelled');
     expect(entry.endTime).toBeDefined();
   });
+
+  // P4 Round 7 (wenshao): end-to-end simulation of the dialog-cancel
+  // race. The dialog's `cancelSelected` calls `registry.cancel()` which
+  // flips status to 'cancelled' + aborts the registry entry's
+  // controller (the same `dispatchController` the tool's catch arm
+  // sees). Then the in-flight dispatch rejects, the catch arm runs,
+  // and `setRecentLogs(runId, logs)` is called — pre-fix this was
+  // rejected by the `status === 'running'` guard, so the cancelled
+  // dialog row always showed an empty Logs section. Post-fix the
+  // guard allows 'cancelled' too and the script's `log()` output
+  // survives.
+  //
+  // This drives the EXACT production flow: real WorkflowTool +
+  // real WorkflowRunRegistry + real sandbox emitting through the
+  // real emitter wiring. The dialog itself isn't reachable in the
+  // current TUI build (pre-existing pill-focus infra gap that
+  // wenshao R7 noted is out of P4 scope), so this test stands in
+  // for what a tmux dialog-cancel would assert.
+  it('R7: dialog-cancel race during run — logs accumulated before cancel survive', async () => {
+    const { config, registry } = configWithRegistry();
+    // Controllable dispatch: hangs until the in-flight reject is
+    // triggered externally (simulating the dialog cancel's abort
+    // cascading through dispatchController into the dispatch).
+    let dispatchInflight:
+      | { reject: (err: Error) => void; prompt: string }
+      | undefined;
+    const dispatch = async (prompt: string): Promise<string> =>
+      new Promise<string>((_resolve, reject) => {
+        dispatchInflight = { reject, prompt };
+      });
+
+    const tool = new WorkflowTool(config, { dispatch });
+    const invocation = tool.build({
+      script: `
+        phase('Plan');
+        log('before agent dispatch');
+        const a = await agent('q1');
+        log('after agent: ' + a);
+        return { a };
+      `,
+    });
+
+    const outerSignal = new AbortController().signal;
+    const executePromise = invocation.execute(outerSignal);
+
+    // Wait for execute() to register the run and queue the dispatch.
+    for (let i = 0; i < 200; i++) {
+      if (registry.list().length > 0 && dispatchInflight) break;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(registry.list()).toHaveLength(1);
+    const runId = registry.list()[0]!.runId;
+
+    // Simulate the dialog cancel: flip status to 'cancelled' AND abort
+    // the registry entry's controller. The dispatchController IS this
+    // controller, so aborting it causes the dispatch to be cascaded.
+    registry.cancel(runId, Date.now());
+    expect(registry.get(runId)!.status).toBe('cancelled');
+
+    // Cause the in-flight dispatch to reject (the production path: the
+    // dispatchController abort propagates through the orchestrator's
+    // limiter / countedDispatch to the test dispatch).
+    dispatchInflight!.reject(new Error('aborted by dialog cancel'));
+
+    // Tool's catch arm runs. With R7 fix the setRecentLogs call lands;
+    // before R7 it was silently dropped because the guard rejected
+    // 'cancelled'.
+    const result = await executePromise;
+    expect(result.error).toBeDefined();
+
+    const final = registry.get(runId)!;
+    expect(final.status).toBe('cancelled');
+    // R7 fix verification: logs accumulated BEFORE the cancel are
+    // preserved on the registry entry so the dialog's Logs section
+    // is non-empty.
+    expect(final.recentLogs.length).toBeGreaterThan(0);
+    expect(
+      final.recentLogs.some((l) => l.includes('before agent dispatch')),
+    ).toBe(true);
+  });
 });

--- a/packages/core/src/tools/workflow/workflow.test.ts
+++ b/packages/core/src/tools/workflow/workflow.test.ts
@@ -322,4 +322,46 @@ describe('WorkflowTool', () => {
     const llmText = (result.llmContent as Array<{ text: string }>)[0]!.text;
     expect(llmText).toBe('(workflow returned no value)');
   });
+
+  // P4a adversarial review (MEDIUM): if a script's return value happens to
+  // have the same shape as a WorkflowMeta declaration (`{ name, description,
+  // phases }`), the safeStringifyDisplayPayload spread must NOT clobber the
+  // top-level `meta` key with the result. Both must appear distinctly in
+  // the display so the user can see the declared meta independently of
+  // whatever the script happened to return.
+  it('execute() display surfaces meta + meta-shaped result distinctly', async () => {
+    const tool = new WorkflowTool(fakeConfig(), {
+      dispatch: async () => 'unused',
+    });
+    const invocation = tool.build({
+      script: `
+        export const meta = { name: 'declared', description: 'the declared meta' }
+        return { name: 'returned', description: 'looks like meta but is the script result', phases: [{ title: 'X' }] }
+      `,
+    });
+    const result = await invocation.execute(new AbortController().signal);
+    expect(result.error).toBeUndefined();
+    const display = result.returnDisplay as string;
+    const jsonText = display.replace(/^```json\n/, '').replace(/\n```$/, '');
+    const parsed = JSON.parse(jsonText) as {
+      meta: { name: string; description: string };
+      result: { name: string; description: string; phases: object[] };
+    };
+    expect(parsed.meta).toEqual({
+      name: 'declared',
+      description: 'the declared meta',
+    });
+    expect(parsed.result).toEqual({
+      name: 'returned',
+      description: 'looks like meta but is the script result',
+      phases: [{ title: 'X' }],
+    });
+    // Defensive: the literal text appearance of both names must be
+    // distinct — a regression that merged them would still satisfy a
+    // single-side toEqual on a shared object, so check the rendered
+    // display contains both string literals at separate offsets.
+    expect(display.indexOf('"declared"')).toBeGreaterThan(-1);
+    expect(display.indexOf('"returned"')).toBeGreaterThan(-1);
+    expect(display.indexOf('"declared"')).not.toBe(display.indexOf('"returned"'));
+  });
 });

--- a/packages/core/src/tools/workflow/workflow.test.ts
+++ b/packages/core/src/tools/workflow/workflow.test.ts
@@ -362,6 +362,8 @@ describe('WorkflowTool', () => {
     // display contains both string literals at separate offsets.
     expect(display.indexOf('"declared"')).toBeGreaterThan(-1);
     expect(display.indexOf('"returned"')).toBeGreaterThan(-1);
-    expect(display.indexOf('"declared"')).not.toBe(display.indexOf('"returned"'));
+    expect(display.indexOf('"declared"')).not.toBe(
+      display.indexOf('"returned"'),
+    );
   });
 });

--- a/packages/core/src/tools/workflow/workflow.test.ts
+++ b/packages/core/src/tools/workflow/workflow.test.ts
@@ -224,6 +224,56 @@ describe('WorkflowTool', () => {
     expect(display).not.toContain('display payload not JSON-serializable');
   });
 
+  // P4: execute() surfaces the extracted `export const meta = {...}` in
+  // the returnDisplay payload so the user (and a future /workflows
+  // listing) can see the workflow's name / description / phases.
+  it('execute() surfaces meta in returnDisplay when the script declares it', async () => {
+    const tool = new WorkflowTool(fakeConfig(), {
+      dispatch: async () => 'ignored',
+    });
+    const invocation = tool.build({
+      script: `export const meta = { name: 'demo', description: 'demo workflow', phases: [{ title: 'plan' }] }
+               return 1;`,
+    });
+    const result = await invocation.execute(new AbortController().signal);
+    expect(result.error).toBeUndefined();
+    const display = String(result.returnDisplay);
+    expect(display).toContain('"meta"');
+    expect(display).toContain('demo workflow');
+    expect(display).toContain('"phases"');
+  });
+
+  it('execute() omits meta key from returnDisplay when the script has no declaration', async () => {
+    const tool = new WorkflowTool(fakeConfig(), {
+      dispatch: async () => 'ignored',
+    });
+    const invocation = tool.build({
+      script: 'return 1;',
+    });
+    const result = await invocation.execute(new AbortController().signal);
+    const display = String(result.returnDisplay);
+    expect(display).not.toContain('"meta"');
+  });
+
+  // P4: when the script body throws AFTER meta parsed, the meta is still
+  // visible on the failure display via the WorkflowExecutionError.meta
+  // field that the tool's catch block surfaces.
+  it('execute() includes meta in failure returnDisplay when body throws', async () => {
+    const tool = new WorkflowTool(fakeConfig(), {
+      dispatch: async () => 'ignored',
+    });
+    const invocation = tool.build({
+      script: `export const meta = { name: 'fails', description: 'will throw' }
+               throw new Error("body boom")`,
+    });
+    const result = await invocation.execute(new AbortController().signal);
+    expect(result.error).toBeDefined();
+    const display = String(result.returnDisplay);
+    expect(display).toContain('Workflow failed');
+    expect(display).toContain('"fails"');
+    expect(display).toContain('will throw');
+  });
+
   // TST-C3: llmContent must be the unwrapped script return value (FIX-7).
   it('execute() strips the JSON wrapper from llmContent (script return is verbatim)', async () => {
     const tool = new WorkflowTool(fakeConfig(), {

--- a/packages/core/src/tools/workflow/workflow.test.ts
+++ b/packages/core/src/tools/workflow/workflow.test.ts
@@ -8,9 +8,29 @@ import { describe, it, expect } from 'vitest';
 import { WorkflowTool } from './workflow.js';
 import type { Config } from '../../config/config.js';
 import { ToolNames, ToolDisplayNames } from '../tool-names.js';
+import { WorkflowRunRegistry } from '../../agents/workflow-run-registry.js';
 
 function fakeConfig(): Config {
   return {} as unknown as Config;
+}
+
+/**
+ * P4b Round 5 (wenshao): the registry integration path inside
+ * `WorkflowTool.execute()` (register → emitter → complete/fail/cancel)
+ * is not exercised by `fakeConfig()` because optional chaining short-
+ * circuits the missing `getWorkflowRunRegistry()` method. This helper
+ * builds a config with a real `WorkflowRunRegistry` and returns the
+ * registry handle so tests can inspect post-run state.
+ */
+function configWithRegistry(): {
+  config: Config;
+  registry: WorkflowRunRegistry;
+} {
+  const registry = new WorkflowRunRegistry();
+  const config = {
+    getWorkflowRunRegistry: () => registry,
+  } as unknown as Config;
+  return { config, registry };
 }
 
 describe('WorkflowTool', () => {
@@ -365,5 +385,103 @@ describe('WorkflowTool', () => {
     expect(display.indexOf('"declared"')).not.toBe(
       display.indexOf('"returned"'),
     );
+  });
+
+  // P4b Round 5 (wenshao): the registry integration seam — register on
+  // execute() start, emitter wires the live state, complete on success,
+  // fail on caught exception, cancel on signal.aborted — was completely
+  // unexercised by tests using fakeConfig() (optional chaining short-
+  // circuited the missing getWorkflowRunRegistry method, so every call
+  // site resolved to undefined). These three tests pin the contract
+  // against the actual WorkflowRunRegistry instance.
+
+  it('execute() success path registers the run + mirrors meta/phases/result + transitions to completed', async () => {
+    const { config, registry } = configWithRegistry();
+    const tool = new WorkflowTool(config, {
+      dispatch: async () => 'mock-answer',
+    });
+    const invocation = tool.build({
+      script: `
+        export const meta = { name: 'demo', description: 'desc' }
+        phase('Plan')
+        phase('Build')
+        const a = await agent('q1')
+        return { a }
+      `,
+    });
+    const result = await invocation.execute(new AbortController().signal);
+    expect(result.error).toBeUndefined();
+
+    const entries = registry.list();
+    expect(entries).toHaveLength(1);
+    const entry = entries[0]!;
+    expect(entry.status).toBe('completed');
+    expect(entry.runId).toMatch(/^wf_[a-f0-9]{16}$/);
+    // The tool fast-tracks meta.name → entry.description when the
+    // synthesized default (runId) was used at register time.
+    expect(entry.description).toBe('demo');
+    expect(entry.meta).toEqual({ name: 'demo', description: 'desc' });
+    expect(entry.phases).toEqual(['Plan', 'Build']);
+    expect(entry.currentPhase).toBe('Build');
+    expect(entry.agentsDispatched).toBe(1);
+    expect(entry.agentsCompleted).toBe(1);
+    expect(entry.result).toEqual({ a: 'mock-answer' });
+    expect(entry.error).toBeUndefined();
+    expect(entry.endTime).toBeDefined();
+  });
+
+  it('execute() failure path records the error message + transitions to failed', async () => {
+    const { config, registry } = configWithRegistry();
+    const tool = new WorkflowTool(config, {
+      dispatch: async () => 'unused',
+    });
+    const invocation = tool.build({
+      script: `
+        phase('Plan')
+        throw new Error('intentional script body failure')
+      `,
+    });
+    const result = await invocation.execute(new AbortController().signal);
+    expect(result.error).toBeDefined();
+
+    const entries = registry.list();
+    expect(entries).toHaveLength(1);
+    const entry = entries[0]!;
+    expect(entry.status).toBe('failed');
+    expect(entry.error).toMatch(/intentional script body failure/);
+    expect(entry.phases).toEqual(['Plan']);
+    expect(entry.endTime).toBeDefined();
+  });
+
+  it('execute() pre-aborted signal transitions the entry to cancelled (not failed)', async () => {
+    const { config, registry } = configWithRegistry();
+    // Pre-abort so dispatch sees the cancellation immediately. The catch
+    // arm distinguishes user-intent (signal.aborted) from script bugs.
+    const aborter = new AbortController();
+    aborter.abort();
+    const tool = new WorkflowTool(config, {
+      dispatch: async () => {
+        throw new Error('aborted-by-signal');
+      },
+    });
+    const invocation = tool.build({
+      script: `
+        phase('Plan')
+        await agent('q1')
+        return 1
+      `,
+    });
+    const result = await invocation.execute(aborter.signal);
+    expect(result.error).toBeDefined();
+
+    const entries = registry.list();
+    expect(entries).toHaveLength(1);
+    const entry = entries[0]!;
+    // The fail-vs-cancel branching at workflow.ts catch arm: when
+    // signal.aborted is true at the moment of catch, the registry
+    // records 'cancelled' so the dialog distinguishes user-initiated
+    // stops from script bugs.
+    expect(entry.status).toBe('cancelled');
+    expect(entry.endTime).toBeDefined();
   });
 });

--- a/packages/core/src/tools/workflow/workflow.ts
+++ b/packages/core/src/tools/workflow/workflow.ts
@@ -163,8 +163,14 @@ class WorkflowToolInvocation extends BaseToolInvocation<
       // try/catch with a clear placeholder so a serialization issue
       // degrades gracefully instead of masquerading as a run failure.
       const llmText = safeStringifyResult(outcome.result);
+      // P4: surface the extracted `export const meta` declaration in the
+      // display payload so the user (and future /workflows listing) can
+      // see the workflow's name / description / phases without re-reading
+      // the script. Omitted when the script had no meta declaration to
+      // keep the payload shape minimal.
       const displayJson = safeStringifyDisplayPayload({
         runId: outcome.runId,
+        ...(outcome.meta ? { meta: outcome.meta } : {}),
         phases: outcome.phases,
         logs: outcome.logs,
         result: outcome.result,
@@ -189,9 +195,16 @@ class WorkflowToolInvocation extends BaseToolInvocation<
       const phases =
         err instanceof WorkflowExecutionError ? err.phases : undefined;
       const logs = err instanceof WorkflowExecutionError ? err.logs : undefined;
+      // P4: also surface the extracted meta on the failure path. The script
+      // body may have thrown long after the meta declaration parsed
+      // cleanly; keeping name/description/phases visible on failure helps
+      // the user identify which workflow ran.
+      const meta =
+        err instanceof WorkflowExecutionError ? err.meta : undefined;
       const display =
-        phases || logs
+        phases || logs || meta
           ? `Workflow failed: ${message}\n\n${safeStringifyDisplayPayload({
+              ...(meta ? { meta } : {}),
               phases: phases ?? [],
               logs: logs ?? [],
             })}`

--- a/packages/core/src/tools/workflow/workflow.ts
+++ b/packages/core/src/tools/workflow/workflow.ts
@@ -30,8 +30,11 @@ import {
   WorkflowExecutionError,
   createProductionDispatch,
   type WorkflowAgentDispatch,
+  type WorkflowOrchestratorEmitter,
 } from '../../agents/runtime/workflow-orchestrator.js';
 import { createChildAbortController } from '../../utils/abortController.js';
+import { randomBytes } from 'node:crypto';
+import type { WorkflowTask } from '../../agents/workflow-run-registry.js';
 
 export interface WorkflowParams {
   /** Inline JavaScript source for the workflow. Required in P1. */
@@ -133,7 +136,7 @@ class WorkflowToolInvocation extends BaseToolInvocation<
 
   override async execute(
     signal: AbortSignal,
-    _updateOutput?: (output: ToolResultDisplay) => void,
+    updateOutput?: (output: ToolResultDisplay) => void,
     _shellExecutionConfig?: ShellExecutionConfig,
   ): Promise<ToolResult> {
     // T40 (PR #4732 R4): child controller so dispatch sees caller aborts
@@ -143,12 +146,64 @@ class WorkflowToolInvocation extends BaseToolInvocation<
       this.toolOptions.dispatch ??
       createProductionDispatch(this.config, dispatchController.signal);
     const orchestrator = new WorkflowOrchestrator(dispatch);
+
+    // P4b: pre-generate the runId so the registry record exists before
+    // the first sandbox event fires. Without this, `agentDispatched` /
+    // `phaseStarted` callbacks would have no entry to update.
+    const runId = `wf_${randomBytes(8).toString('hex')}`;
+    const registry = this.config.getWorkflowRunRegistry?.();
+    const registryEntry = registry?.register({
+      runId,
+      meta: null, // populated after meta parses; safe default until then
+      status: 'running',
+      startTime: Date.now(),
+      outputFile: '', // P4b reserves the field but doesn't materialize
+      abortController: dispatchController,
+    });
+    // The emitter forwards sandbox + dispatch events into the registry
+    // AND fires `updateOutput` so the tool's renderDisplay block (a
+    // phase-tree-shaped JSON) refreshes live in the TUI. Each method
+    // is fail-safe: registry mutation errors are swallowed by the
+    // registry itself; updateOutput errors are caught here.
+    const emitter: WorkflowOrchestratorEmitter = {
+      phaseStarted: (title) => {
+        registry?.onPhaseStarted(runId, title);
+        safeEmitUpdate(updateOutput, registryEntry);
+      },
+      agentDispatched: () => {
+        registry?.onAgentDispatched(runId);
+        safeEmitUpdate(updateOutput, registryEntry);
+      },
+      agentCompleted: () => {
+        registry?.onAgentCompleted(runId);
+        safeEmitUpdate(updateOutput, registryEntry);
+      },
+      logAppended: () => {
+        // P4b: skip per-line emit; the tool snapshots logs at terminal
+        // via `registry.setRecentLogs` so the registry record reflects
+        // the final tail without per-line churn driving rerenders.
+      },
+    };
+
     try {
       const outcome = await orchestrator.run({
         script: this.params.script,
         args: this.params.args,
         abortOnTimeout: dispatchController,
+        runId,
+        emitter,
       });
+
+      // P4b: snapshot meta + logs onto the registry record so the dialog
+      // detail body reflects the final state once the run terminates.
+      if (registryEntry) {
+        registryEntry.meta = outcome.meta;
+        if (outcome.meta?.name && registryEntry.description === runId) {
+          registryEntry.description = outcome.meta.name;
+        }
+      }
+      registry?.setRecentLogs(runId, outcome.logs);
+      registry?.complete(runId, outcome.result, Date.now());
 
       // FIX-7 (UP-C2): unwrap the script result so the LLM receives the
       // script's return value verbatim. The full metadata (runId, phases,
@@ -199,8 +254,19 @@ class WorkflowToolInvocation extends BaseToolInvocation<
       // body may have thrown long after the meta declaration parsed
       // cleanly; keeping name/description/phases visible on failure helps
       // the user identify which workflow ran.
-      const meta =
-        err instanceof WorkflowExecutionError ? err.meta : undefined;
+      const meta = err instanceof WorkflowExecutionError ? err.meta : undefined;
+      // P4b: surface the failure / abort to the registry. A caller-aborted
+      // run (`signal.aborted === true`) becomes `cancelled` rather than
+      // `failed` so the dialog distinguishes user intent from script bugs.
+      if (registryEntry) {
+        if (meta && !registryEntry.meta) registryEntry.meta = meta;
+      }
+      if (logs) registry?.setRecentLogs(runId, logs);
+      if (signal.aborted) {
+        registry?.cancel(runId, Date.now());
+      } else {
+        registry?.fail(runId, message, Date.now());
+      }
       const display =
         phases || logs || meta
           ? `Workflow failed: ${message}\n\n${safeStringifyDisplayPayload({
@@ -221,6 +287,49 @@ class WorkflowToolInvocation extends BaseToolInvocation<
       // T40: cancel any straggler subagent on natural completion.
       dispatchController.abort();
     }
+  }
+}
+
+/**
+ * P4b: render an in-flight workflow as a compact JSON block for
+ * `_updateOutput`. Same shape as the terminal `returnDisplay` so the
+ * TUI does not need a separate live renderer. Logs are omitted from
+ * the live snapshot — they would churn at >10Hz and the per-line
+ * channel adds little value while a workflow is still running.
+ */
+function buildLivePhaseTreeDisplay(entry: WorkflowTask): string {
+  const payload: Record<string, unknown> = {
+    runId: entry.runId,
+    ...(entry.meta ? { meta: entry.meta } : {}),
+    status: entry.status,
+    currentPhase: entry.currentPhase,
+    phases: entry.phases,
+    agentsDispatched: entry.agentsDispatched,
+    agentsCompleted: entry.agentsCompleted,
+  };
+  try {
+    return '```json\n' + JSON.stringify(payload, null, 2) + '\n```';
+  } catch {
+    return `Workflow ${entry.runId} — ${entry.status} — ${entry.phases.length} phase(s)`;
+  }
+}
+
+/**
+ * Defensive bridge from the emitter's host-realm callbacks to
+ * `updateOutput`. The TUI's renderer wraps the callback in its own
+ * try/catch but we add another layer here because an outer throw
+ * inside `phaseStarted` would propagate up through the vm-realm
+ * `bridge.pushPhase` call and corrupt the script's `phase()` global.
+ */
+function safeEmitUpdate(
+  updateOutput: ((output: ToolResultDisplay) => void) | undefined,
+  entry: WorkflowTask | undefined,
+): void {
+  if (!updateOutput || !entry) return;
+  try {
+    updateOutput(buildLivePhaseTreeDisplay(entry));
+  } catch {
+    // Renderer errors must not interrupt orchestration.
   }
 }
 
@@ -312,7 +421,7 @@ export class WorkflowTool extends BaseDeclarativeTool<
       Kind.Other,
       WORKFLOW_PARAM_SCHEMA,
       /* isOutputMarkdown */ true,
-      /* canUpdateOutput */ false,
+      /* canUpdateOutput */ true,
     );
   }
 


### PR DESCRIPTION
## What this PR does

Implements phase **P4** of the Dynamic Workflows port (per [#4721](https://github.com/QwenLM/qwen-code/issues/4721)), building on the merged P1 (#4732), P2 (#4947), and P3 (#5034). Both halves of P4 ship in this PR:

- **P4a — meta extraction** (commits `5b56c3979 / 55c23a027 / 402df8f23`): `extractAndStripMeta` replaces P1's `stripExportMeta` call site inside `createWorkflowSandbox.run`; `WorkflowMeta` is a first-class field on `WorkflowRunOutcome` / `WorkflowExecutionError`; `WorkflowTool` display payload surfaces it when present.
- **P4b — `/workflows` command + phase-tree UI** (commit `c3f9d845e`): `WorkflowRunRegistry` (4th sibling of `BackgroundTaskRegistry` / `BackgroundShellRegistry` / `MonitorRegistry`), TaskKind widening to add `'workflow'`, `WorkflowOrchestratorEmitter` for live phase / dispatch events, `BackgroundTasksPill` count + `WorkflowDetailBody` phase tree in the unified dialog, new `/workflows` slash command listing active + completed runs.

### P4a architecture

Reuse the P1 brace-walker (zero-dep, no parser deps — matches the P1 design posture; no `acorn` / `@babel/parser` introduced) to locate the meta object literal's source range, then evaluate the literal inside a fresh `vm.createContext(Object.create(null))`. The eval context has a **null-prototyped `globalThis` and no host bridge** — no access to `args` / `process` / `require` / the workflow-sandbox bridge globals. The vm realm still exposes its OWN intrinsics (`Object` / `Math` / `Date` / `JSON`), which is fine: meta extraction is one-shot at tool invocation, not replayed on resume, so non-determinism in the meta literal does not break the resume contract the script body honours. `validateMeta` walks the eval result field-by-field and copies into a fresh host-realm plain object — no JSON round-trip needed because every contract field is a primitive. After eval, `rejectThenablesInMeta` recursively walks the result, marks any dangling thenable handled with `.catch(() => {})` (so Node's default `--unhandled-rejections=throw` cannot terminate the host on the next tick), and throws an explicit error — closing the R3 dynamic-`import()` crash vector wenshao reproduced.

P4a user-visible additions:
- `extractAndStripMeta(source)` exported from `workflow-sandbox.ts`
- `WorkflowMeta` interface — verbatim shape from upstream Claude Code 2.1.168:
  ```ts
  interface WorkflowMeta {
    name: string;
    description: string;
    whenToUse?: string;
    phases?: Array<{ title: string; detail?: string; model?: string }>;
  }
  ```
- `WorkflowSandbox.getMeta()` accessor alongside `getPhases()` / `getLogs()`
- `WorkflowRunOutcome.meta: WorkflowMeta | null` (non-breaking)
- `WorkflowExecutionError.meta: WorkflowMeta | null` so failure display shows the workflow's name / description / phases even when the script body throws after meta parsed cleanly
- `WorkflowTool.execute` adds `meta` to the returnDisplay payload when present (omitted when the script had no meta)

Error messages verbatim from upstream where applicable:
- `meta.name must be a non-empty string`
- `meta.description must be a non-empty string`

### P4b architecture

`TaskKind` widens from 3 → 4 (`'agent' | 'shell' | 'monitor' | 'workflow'`); `TaskState` picks up `WorkflowTask` (carries runId, meta, current phase, phase history, dispatch counters, recent logs). New `WorkflowRunRegistry` is a sibling of the three existing per-kind registries — same `register / cancel / get / list / on('statusChange')` shape so `useBackgroundTaskView` subscribes the same way. Eviction is `MAX_RETAINED_TERMINAL_WORKFLOWS = 10`, sized smaller than `MAX_RETAINED_TERMINAL_AGENTS = 32` because workflow rows carry heavier labels (name + phase tree) and users typically run far fewer workflows than agents per session.

A new `WorkflowOrchestratorEmitter` interface lets the orchestrator + sandbox emit events into the host without crossing the vm-realm boundary: `phaseStarted` fires from `safePhase`, `agentDispatched` / `agentCompleted` fire from the orchestrator's `countedDispatch`, `logAppended` fires from `safeLog`. Defensive `try/catch` around every emit so a subscriber error never bubbles into the script. The orchestrator accepts an optional `runId` in `WorkflowRunRequest` so `WorkflowTool` can pre-generate the id and register the run with the registry BEFORE `run()` resolves — without this, the registry would never see the dispatch events.

`WorkflowTool` registers the run at `execute()` start, wires the emitter to the registry's `onPhaseStarted` / `onAgentDispatched` / `onAgentCompleted`, flips `canUpdateOutput` to `true` so the tool result block live-renders as a JSON snapshot of the phase tree, and routes terminals to `registry.complete` / `fail` / `cancel`. `signal.aborted === true` → `cancel` rather than `fail`, so the dialog distinguishes user intent from script bugs.

CLI side:
- `BackgroundTasksPill.tsx`: `KIND_NAMES` gains `workflow`, counts accumulator + sort order updated. Order is `shell → agent → monitor → workflow → dream` (user-initiated before system-initiated). The pill renders `N workflow(s)` alongside existing kinds.
- `useBackgroundTaskView.ts`: subscribes to the workflow registry, includes workflow entries in the merged `DialogEntry[]`. `entryId` switch adds `case 'workflow': return entry.runId`.
- `BackgroundTasksDialog.tsx`: new inline `WorkflowDetailBody` matches `MonitorDetailBody` style — header (name + description + whenToUse + status + runtime), phase tree truncated at `MAX_VISIBLE_PHASES = 20` with `+N more above`, log tail truncated at `MAX_VISIBLE_LOG_LINES = 10`, error block on failure. Row label: `[workflow] <name> · <currentPhase> (M/N agents)`. `rowLabel` / `DetailBody` / `cancelSelected` switches all gain a workflow case.
- `BackgroundTaskViewContext.tsx` `cancelSelected`: `case 'workflow': config.getWorkflowRunRegistry().cancel(target.runId, Date.now())`. Idempotent with the `WorkflowTool`'s `signal.aborted` catch arm.
- New `packages/cli/src/ui/commands/workflowsCommand.ts`: bare `/workflows` lists active + completed runs (running first, terminal by endTime DESC). `/workflows <runId>` opens a per-run detail dump (meta block + status + phase tree + recent logs + errors). `argumentHint` is `[runId]`. Registered in `BuiltinCommandLoader.ts` gated by `Config.isWorkflowsEnabled()` — command vanishes from typeahead when the env-var kill switch (`QWEN_CODE_DISABLE_WORKFLOWS=1`) is set or the opt-in flag (`QWEN_CODE_ENABLE_WORKFLOWS=1`) is absent.

### Scope deferrals

| Out of scope | Reason | Plan |
|---|---|---|
| ACP daemon protocol widening (`packages/acp-bridge/src/bridgeTypes.ts`, `status.ts`, `tasksSnapshot.ts`) | Cross-SDK + web-shell contract — independent review safer | Follow-up PR P4c |
| Per-phase token rollup in `WorkflowDetailBody` | Needs P5's budget tracker | Lands with P5 |
| `/workflows save <runId>` / `/workflows inspect` subcommands | Future enhancement; binary strings reference upstream but no concrete need yet | Future |
| Pause / resume keybindings in the workflow detail body | Needs P6's resume cache | Lands with P6 |

## Why it's needed

P1's `stripExportMeta` only DELETED the `export const meta` declaration so the script could parse as a Node `vm` script. The meta object itself was discarded. P2/P3 ran workflows from tool calls but the user couldn't tell a workflow was running — no pill count, no dialog row, no progress UI. P4 (a+b) makes workflows visible in the TUI by piping the orchestrator's runs through the same background-task envelope that `agent` / `shell` / `monitor` already use, and surfaces the meta declaration so users can identify which workflow ran without re-reading the script source.

## Reviewer Test Plan

### How to verify

```bash
cd packages/core
npx vitest run \
  src/agents/workflow-run-registry.test.ts \
  src/agents/runtime/workflow-sandbox.test.ts \
  src/agents/runtime/workflow-orchestrator.test.ts \
  src/tools/workflow/workflow.test.ts
# → 4 files, all green (~223 tests including 14 new registry tests)

cd ../cli
npx vitest run \
  src/ui/commands/workflowsCommand.test.ts \
  src/ui/components/background-view/BackgroundTasksPill.test.tsx \
  src/ui/components/background-view/BackgroundTasksDialog.test.tsx \
  src/ui/hooks/useBackgroundTaskView.test.ts
# → 4 files, all green (~73 tests)
```

New tests for P4a specifically:

- `workflow-sandbox.test.ts` (14 new under `describe('extractAndStripMeta')`): contract extraction, error-message verbatim, host-realm prototype identity, Promise-rejection guard (top-level + nested).
- `workflow-sandbox.test.ts` (3 new under `createWorkflowSandbox`): getMeta lifecycle.
- `workflow-orchestrator.test.ts` (3 new): outcome.meta null/parsed + error.meta carries on body throw.
- `workflow.test.ts` (4 new): display surfaces meta, omits when absent, failure-path meta, meta-shaped result collision.

New tests for P4b specifically:

- `workflow-run-registry.test.ts` (14 new): register / phase / dispatch / log-tail / complete / fail / cancel / eviction / running-never-evicted / register-callback / status-change-callback / error-tolerance.
- `workflowsCommand.test.ts` (6 new): empty-runs message / list-with-running-first / non-interactive omits tip / detail-view-known-runId / detail-view-unknown-runId-error / runId trim.

`tsc --noEmit` + `eslint` + `prettier --check` clean on `packages/core` and `packages/cli`.

### Real-LLM E2E (P4a)

Ran 6/6 against `qwen3-coder-plus` via DashScope (OpenAI-compatible endpoint), gated by `DASHSCOPE_API_KEY` so CI without the env skips the file. See [`workflow-p4a-meta-live.live.test.ts`](https://github.com/QwenLM/qwen-code/blob/lazzy/workflow-p4-meta-workflows-pill/packages/core/src/agents/runtime/workflow-p4a-meta-live.live.test.ts).

| | Scenario | Wall-clock | What it verifies end-to-end |
|---|---|---|---|
| A | meta + single `agent()` | 787ms | `outcome.meta` mirrors the declared literal; display surfaces full meta block; `Object.getPrototypeOf(outcome.meta) === Object.prototype` + same for `phases[]` array + each phase entry — guards the T1/T8/T14 realm-escape boundary end-to-end |
| B | no meta + single `agent()` | 581ms | `outcome.meta === null`; display payload completely omits the `meta` key (conditional spread) |
| C | malformed meta (missing `name`) | **4ms** | Throws `meta.name …` **before** the sandbox runs — 0 agent dispatches (no LLM budget burnt on a bad meta) |
| D | meta + `agent()` + body `throw` | 715ms | `WorkflowExecutionError.meta` carries the parsed meta on the failure path; agent was called once; failure-display includes meta block |
| E | `parallel()` 3-fan-out + meta | 640ms | Real concurrency (dispatch arrival order `[BLUE,RED,GREEN]` ≠ result order `[RED,GREEN,BLUE]` — position-aligned by `parallel()`); `meta.phases[].title` matches the executed phase list |
| F | `pipeline()` 2-stage + meta | 1361ms | Both declared phases (`Translate` → `Shout`) actually run; each input visits each stage exactly once (2/2 dispatch counts per stage); `cat`→`chat`→`CHAT`, `dog`→`chien`→`CHIEN` |

### R3 review (wenshao) — addressed in 402df8f23

- **Critical**: dynamic `import()` (or any Promise-valued meta field) crashed the host process via dangling unhandled rejection after `runInContext` returned. Fix: `rejectThenablesInMeta` recursively walks the eval result, neutralises any thenable with `.catch(() => {})`, throws an explicit `meta values must not be Promises` error. 2 RED-first regression tests (top-level + nested in `phases[]`).
- **Critical**: `tsc --noEmit` 11 errors in the new live E2E test file blocked CI Lint + all 3 Test jobs. Fix: imported `WorkflowAgentOpts` from `workflow-sandbox.js`; dropped `liveDispatch`'s explicit type annotation; added required `args: undefined` to every `orch.run({ script })` call.
- 5 R3 Suggestions declined (out of scope or latent). See R3 triage summary at https://github.com/QwenLM/qwen-code/pull/5094#issuecomment-4703975703.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️ CI-only  |
|  🐧 Linux  |   ⚠️ CI-only  |

## Risk & Scope

- **Main risk or tradeoff** — TaskKind widening from 3 → 4 ripples through every exhaustive `kind` switch in core + cli. The TypeScript surface forces every site to either handle workflow or fail to compile. CI typecheck on this branch verifies the rippling is complete inside CLI + core; the ACP daemon protocol surface (cross-SDK contract) is explicitly deferred to a follow-up PR — temporary filter at the ACP boundary will be added there. Within P4b's scope every consumer has been updated.
- **Security boundary unchanged** — workflows run through the same `vm.createContext` sandbox as P1-P3; the P4b emitter is purely host-side (called from `safePhase` / `safeLog` closures + `countedDispatch`), never crosses the vm realm. Promise-valued meta fields rejected before they can leave a dangling rejection.
- **Not validated / out of scope** — ACP daemon propagation (P4c), per-phase token rollup (P5), pause/resume (P6), ultracode keyword trigger (P7).
- **Breaking changes / migration notes** — none for non-CLI consumers. CLI consumers see a new builtin command (`/workflows`) that defaults to hidden when `isWorkflowsEnabled()` is false, so it doesn't surface in typeahead by default. `WorkflowRunOutcome.meta` is non-breaking — existing destructuring of `{ runId, result, phases, logs }` continues to work. `TaskKind` is widened from a closed 3-string union to 4 — strict pattern-matching consumers MUST add a workflow case (TypeScript will surface this).

## Linked Issues

Related #4721 (parent design — multi-phase, not closed by this PR)
