### PR TITLE
feat(cli): import Claude MCP servers

### DIFF
--- a/packages/cli/src/config/claudeMcpImport.test.ts
+++ b/packages/cli/src/config/claudeMcpImport.test.ts
@@ -1,0 +1,418 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getClaudeDesktopConfigPath,
+  importClaudeMcpServers,
+  loadClaudeMcpSources,
+} from './claudeMcpImport.js';
+import { SettingScope, type LoadedSettings } from './settings.js';
+
+describe('claude MCP import', () => {
+  let tmpDir: string;
+  let homeDir: string;
+  let projectDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-mcp-import-'));
+    homeDir = path.join(tmpDir, 'home');
+    projectDir = path.join(tmpDir, 'project');
+    fs.mkdirSync(homeDir, { recursive: true });
+    fs.mkdirSync(projectDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeJson(filePath: string, value: unknown) {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
+  }
+
+  function createSettings(options?: {
+    userMcpServers?: Record<string, unknown>;
+    workspaceMcpServers?: Record<string, unknown>;
+    mergedMcpServers?: Record<string, unknown>;
+    inHome?: boolean;
+  }): LoadedSettings {
+    const userSettings = {
+      ...(options?.userMcpServers && {
+        mcpServers: options.userMcpServers,
+      }),
+    };
+    const workspaceSettings = {
+      ...(options?.workspaceMcpServers && {
+        mcpServers: options.workspaceMcpServers,
+      }),
+    };
+    const userFile = path.join(homeDir, '.qwen', 'settings.json');
+    const workspaceFile = options?.inHome
+      ? userFile
+      : path.join(projectDir, '.qwen', 'settings.json');
+    const mergedMcpServers =
+      options?.mergedMcpServers ??
+      (options?.userMcpServers || options?.workspaceMcpServers
+        ? {
+            ...(options?.userMcpServers ?? {}),
+            ...(options?.workspaceMcpServers ?? {}),
+          }
+        : undefined);
+
+    return {
+      merged: {
+        ...(mergedMcpServers && { mcpServers: mergedMcpServers }),
+      },
+      user: { path: userFile, settings: userSettings },
+      workspace: { path: workspaceFile, settings: workspaceSettings },
+      forScope: vi.fn((scope: SettingScope) =>
+        scope === SettingScope.User
+          ? { path: userFile, settings: userSettings }
+          : { path: workspaceFile, settings: workspaceSettings },
+      ),
+      setValue: vi.fn((scope: SettingScope, key: string, value: unknown) => {
+        const target =
+          scope === SettingScope.User ? userSettings : workspaceSettings;
+        target[key as keyof typeof target] = value as never;
+      }),
+    } as unknown as LoadedSettings;
+  }
+
+  it('imports Claude Code user MCP servers from .claude.json', () => {
+    writeJson(path.join(homeDir, '.claude.json'), {
+      mcpServers: {
+        userServer: { command: 'node', args: ['user.js'] },
+      },
+      projects: {
+        [projectDir]: {
+          mcpServers: {
+            projectServer: { command: 'node', args: ['project.js'] },
+          },
+        },
+        [path.join(tmpDir, 'other')]: {
+          mcpServers: {
+            otherProjectServer: { command: 'node', args: ['other.js'] },
+          },
+        },
+      },
+    });
+
+    const settings = createSettings();
+    const result = importClaudeMcpServers({
+      source: 'claude-code',
+      scope: 'user',
+      settings,
+      cwd: projectDir,
+      homeDir,
+    });
+
+    expect(result.imported.map((entry) => entry.name)).toEqual(['userServer']);
+    expect(settings.setValue).toHaveBeenCalledWith(
+      SettingScope.User,
+      'mcpServers',
+      expect.objectContaining({
+        userServer: { command: 'node', args: ['user.js'] },
+      }),
+    );
+  });
+
+  it('imports Claude Code current-project MCP servers into project scope', () => {
+    writeJson(path.join(homeDir, '.claude.json'), {
+      mcpServers: {
+        userServer: { command: 'node', args: ['user.js'] },
+      },
+      projects: {
+        [projectDir]: {
+          mcpServers: {
+            projectServer: { command: 'node', args: ['project.js'] },
+          },
+        },
+      },
+    });
+
+    const settings = createSettings();
+    const result = importClaudeMcpServers({
+      source: 'claude-code',
+      scope: 'project',
+      settings,
+      cwd: projectDir,
+      homeDir,
+    });
+
+    expect(result.imported.map((entry) => entry.name)).toEqual([
+      'projectServer',
+    ]);
+    expect(settings.setValue).toHaveBeenCalledWith(
+      SettingScope.Workspace,
+      'mcpServers',
+      expect.objectContaining({
+        projectServer: { command: 'node', args: ['project.js'] },
+      }),
+    );
+  });
+
+  it('imports Claude Code .claude/settings.json files by matching target scope', () => {
+    writeJson(path.join(projectDir, '.claude', 'settings.json'), {
+      mcpServers: {
+        projectSettingsServer: { command: 'node', args: ['project.js'] },
+      },
+    });
+    writeJson(path.join(homeDir, '.claude', 'settings.json'), {
+      mcpServers: {
+        globalSettingsServer: { command: 'node', args: ['global.js'] },
+      },
+    });
+
+    const settings = createSettings();
+    const result = importClaudeMcpServers({
+      source: 'claude-code',
+      scope: 'user',
+      settings,
+      cwd: projectDir,
+      homeDir,
+    });
+
+    expect(result.imported.map((entry) => entry.name)).toEqual([
+      'globalSettingsServer',
+    ]);
+    expect(settings.setValue).toHaveBeenCalledWith(
+      SettingScope.User,
+      'mcpServers',
+      expect.objectContaining({
+        globalSettingsServer: { command: 'node', args: ['global.js'] },
+      }),
+    );
+  });
+
+  it('imports Claude Desktop MCP servers from the platform config path', () => {
+    const desktopPath = getClaudeDesktopConfigPath(homeDir, 'darwin');
+    writeJson(desktopPath, {
+      mcpServers: {
+        desktopServer: {
+          command: 'uvx',
+          args: ['mcp-server'],
+        },
+      },
+    });
+
+    const settings = createSettings();
+    const result = importClaudeMcpServers({
+      source: 'claude-desktop',
+      scope: 'user',
+      settings,
+      homeDir,
+      platform: 'darwin',
+    });
+
+    expect(result.scanned[0]?.path).toBe(desktopPath);
+    expect(result.imported).toEqual([
+      { name: 'desktopServer', source: 'Claude Desktop' },
+    ]);
+    expect(settings.setValue).toHaveBeenCalledWith(
+      SettingScope.User,
+      'mcpServers',
+      expect.objectContaining({
+        desktopServer: { command: 'uvx', args: ['mcp-server'] },
+      }),
+    );
+  });
+
+  it('skips existing server names instead of overwriting them', () => {
+    writeJson(path.join(homeDir, '.claude.json'), {
+      mcpServers: {
+        keep: { command: 'new' },
+        fresh: { command: 'fresh' },
+      },
+    });
+
+    const settings = createSettings({
+      userMcpServers: {
+        keep: { command: 'existing' },
+      },
+    });
+    const result = importClaudeMcpServers({
+      source: 'claude-code',
+      scope: 'user',
+      settings,
+      homeDir,
+    });
+
+    expect(result.imported).toEqual([{ name: 'fresh', source: 'Claude Code' }]);
+    expect(result.skipped).toEqual([
+      { name: 'keep', source: 'Claude Code', reason: 'already-exists' },
+    ]);
+    expect(settings.setValue).toHaveBeenCalledWith(
+      SettingScope.User,
+      'mcpServers',
+      expect.objectContaining({
+        keep: { command: 'existing' },
+        fresh: { command: 'fresh' },
+      }),
+    );
+  });
+
+  it('skips server names that cannot be persisted safely', () => {
+    fs.writeFileSync(
+      path.join(homeDir, '.claude.json'),
+      '{"mcpServers":{"__proto__":{"command":"node"}}}',
+    );
+
+    const settings = createSettings();
+    const result = importClaudeMcpServers({
+      source: 'claude-code',
+      scope: 'user',
+      settings,
+      homeDir,
+    });
+
+    expect(settings.setValue).not.toHaveBeenCalled();
+    expect(result.skipped).toEqual([
+      {
+        name: '__proto__',
+        source: 'Claude Code',
+        reason: 'reserved-name',
+      },
+    ]);
+  });
+
+  it('skips names that already exist in the effective settings', () => {
+    writeJson(path.join(projectDir, '.claude', 'settings.json'), {
+      mcpServers: {
+        keep: { command: 'new' },
+        fresh: { command: 'fresh' },
+      },
+    });
+
+    const settings = createSettings({
+      userMcpServers: {
+        keep: { command: 'existing-user' },
+      },
+    });
+    const result = importClaudeMcpServers({
+      source: 'claude-code',
+      scope: 'project',
+      settings,
+      cwd: projectDir,
+      homeDir,
+    });
+
+    expect(result.imported).toEqual([
+      { name: 'fresh', source: 'Claude Code project settings' },
+    ]);
+    expect(result.skipped).toEqual([
+      {
+        name: 'keep',
+        source: 'Claude Code project settings',
+        reason: 'already-exists',
+      },
+    ]);
+    expect(settings.setValue).toHaveBeenCalledWith(
+      SettingScope.Workspace,
+      'mcpServers',
+      expect.objectContaining({
+        fresh: { command: 'fresh' },
+      }),
+    );
+  });
+
+  it('writes to workspace settings when project scope is requested', () => {
+    writeJson(path.join(projectDir, '.claude', 'settings.json'), {
+      mcpServers: {
+        local: { command: 'node' },
+      },
+    });
+
+    const settings = createSettings();
+    importClaudeMcpServers({
+      source: 'claude-code',
+      scope: 'project',
+      settings,
+      cwd: projectDir,
+      homeDir,
+    });
+
+    expect(settings.setValue).toHaveBeenCalledWith(
+      SettingScope.Workspace,
+      'mcpServers',
+      expect.objectContaining({
+        local: { command: 'node' },
+      }),
+    );
+  });
+
+  it('rejects project scope when workspace settings resolve to the user file', () => {
+    writeJson(path.join(homeDir, '.claude.json'), {
+      mcpServers: {
+        local: { command: 'node' },
+      },
+    });
+
+    expect(() =>
+      importClaudeMcpServers({
+        source: 'claude-code',
+        scope: 'project',
+        settings: createSettings({ inHome: true }),
+        homeDir,
+      }),
+    ).toThrow('Please use --scope user');
+  });
+
+  it('reports malformed configs without writing settings', () => {
+    fs.writeFileSync(path.join(homeDir, '.claude.json'), '{ nope');
+    const settings = createSettings();
+
+    const result = importClaudeMcpServers({
+      source: 'claude-code',
+      scope: 'user',
+      settings,
+      homeDir,
+    });
+
+    expect(result.errors[0]).toContain('Failed to parse');
+    expect(result.imported).toEqual([]);
+    expect(settings.setValue).not.toHaveBeenCalled();
+  });
+
+  it('reports unreadable config paths instead of treating them as absent', () => {
+    fs.mkdirSync(path.join(homeDir, '.claude.json'));
+    const settings = createSettings();
+
+    const result = importClaudeMcpServers({
+      source: 'claude-code',
+      scope: 'user',
+      settings,
+      homeDir,
+    });
+
+    expect(result.errors[0]).toContain('Failed to read');
+    expect(result.imported).toEqual([]);
+    expect(settings.setValue).not.toHaveBeenCalled();
+  });
+
+  it('returns checked source paths when no Claude configs exist', () => {
+    const sources = loadClaudeMcpSources({
+      source: 'all',
+      cwd: projectDir,
+      homeDir,
+      platform: 'darwin',
+    });
+
+    expect(sources.map((source) => source.found)).toEqual([
+      false,
+      false,
+      false,
+    ]);
+    expect(sources.map((source) => source.path)).toEqual([
+      path.join(homeDir, '.claude.json'),
+      path.join(homeDir, '.claude', 'settings.json'),
+      getClaudeDesktopConfigPath(homeDir, 'darwin'),
+    ]);
+  });
+});

--- a/packages/cli/src/config/claudeMcpImport.ts
+++ b/packages/cli/src/config/claudeMcpImport.ts
@@ -1,0 +1,507 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { MCPServerConfig } from '@qwen-code/qwen-code-core';
+import stripJsonComments from 'strip-json-comments';
+import { SettingScope, type LoadedSettings } from './settings.js';
+
+export type ClaudeMcpImportSource = 'all' | 'claude-code' | 'claude-desktop';
+export type ClaudeMcpImportScope = 'user' | 'project';
+
+export interface ClaudeMcpImportOptions {
+  source: ClaudeMcpImportSource;
+  scope: ClaudeMcpImportScope;
+  settings: LoadedSettings;
+  cwd?: string;
+  homeDir?: string;
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+}
+
+export interface ClaudeMcpSourceResult {
+  source: Exclude<ClaudeMcpImportSource, 'all'>;
+  label: string;
+  path: string;
+  servers: Record<string, MCPServerConfig>;
+  errors: string[];
+  found: boolean;
+}
+
+export interface ImportedClaudeMcpServer {
+  name: string;
+  source: string;
+}
+
+export interface SkippedClaudeMcpServer {
+  name: string;
+  source: string;
+  reason: 'already-exists' | 'invalid' | 'reserved-name';
+}
+
+export interface ClaudeMcpImportResult {
+  scope: ClaudeMcpImportScope;
+  settingScope: SettingScope.User | SettingScope.Workspace;
+  scanned: ClaudeMcpSourceResult[];
+  imported: ImportedClaudeMcpServer[];
+  skipped: SkippedClaudeMcpServer[];
+  errors: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isReadableConfigError(error: unknown): error is NodeJS.ErrnoException {
+  return !!error && typeof error === 'object' && 'code' in error;
+}
+
+function isReservedServerName(name: string): boolean {
+  return name === '__proto__' || name === 'constructor' || name === 'prototype';
+}
+
+function emptyServerRecord(): Record<string, MCPServerConfig> {
+  return Object.create(null) as Record<string, MCPServerConfig>;
+}
+
+function readJsonObject(filePath: string): {
+  found: boolean;
+  data?: Record<string, unknown>;
+  error?: string;
+} {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, 'utf-8');
+  } catch (error) {
+    if (
+      isReadableConfigError(error) &&
+      (error.code === 'ENOENT' || error.code === 'ENOTDIR')
+    ) {
+      return { found: false };
+    }
+
+    return {
+      found: true,
+      error: `Failed to read ${filePath}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+
+  if (!raw.trim()) {
+    return { found: false };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripJsonComments(raw));
+  } catch (error) {
+    return {
+      found: true,
+      error: `Failed to parse ${filePath}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+
+  if (!isRecord(parsed)) {
+    return {
+      found: true,
+      error: `${filePath} must contain a JSON object`,
+    };
+  }
+
+  return { found: true, data: parsed };
+}
+
+function copyMcpServers(
+  value: unknown,
+  sourcePath: string,
+  servers: Record<string, MCPServerConfig>,
+  errors: string[],
+) {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!isRecord(value)) {
+    errors.push(`${sourcePath} has no "mcpServers" object`);
+    return;
+  }
+
+  for (const [name, serverConfig] of Object.entries(value)) {
+    if (!isRecord(serverConfig)) {
+      errors.push(`${sourcePath}: server "${name}" is not an object - skipped`);
+      continue;
+    }
+    servers[name] = serverConfig as MCPServerConfig;
+  }
+}
+
+function normalizeProjectPath(projectPath: string): string {
+  return path.resolve(projectPath);
+}
+
+function getClaudeProjectSettings(
+  projects: unknown,
+  cwd: string,
+): Record<string, unknown> | undefined {
+  if (!isRecord(projects)) {
+    return undefined;
+  }
+
+  const normalizedCwd = normalizeProjectPath(cwd);
+  for (const [projectPath, projectSettings] of Object.entries(projects)) {
+    if (
+      normalizeProjectPath(projectPath) === normalizedCwd &&
+      isRecord(projectSettings)
+    ) {
+      return projectSettings;
+    }
+  }
+
+  return undefined;
+}
+
+export function getClaudeCodeConfigPath(homeDir = os.homedir()): string {
+  return path.join(homeDir, '.claude.json');
+}
+
+export function getClaudeDesktopConfigPath(
+  homeDir = os.homedir(),
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  if (platform === 'win32') {
+    const appData =
+      env['APPDATA'] ?? path.win32.join(homeDir, 'AppData', 'Roaming');
+    return path.win32.join(appData, 'Claude', 'claude_desktop_config.json');
+  }
+
+  if (platform === 'darwin') {
+    return path.join(
+      homeDir,
+      'Library',
+      'Application Support',
+      'Claude',
+      'claude_desktop_config.json',
+    );
+  }
+
+  return path.join(homeDir, '.config', 'Claude', 'claude_desktop_config.json');
+}
+
+function loadMcpServersFromSettingsFile(
+  filePath: string,
+  label: string,
+  source: Exclude<ClaudeMcpImportSource, 'all'>,
+): ClaudeMcpSourceResult {
+  const errors: string[] = [];
+  const servers = emptyServerRecord();
+  const parsed = readJsonObject(filePath);
+
+  if (!parsed.found) {
+    return {
+      source,
+      label,
+      path: filePath,
+      servers,
+      errors,
+      found: false,
+    };
+  }
+
+  if (!parsed.data) {
+    return {
+      source,
+      label,
+      path: filePath,
+      servers,
+      errors: parsed.error ? [parsed.error] : errors,
+      found: true,
+    };
+  }
+
+  copyMcpServers(parsed.data['mcpServers'], filePath, servers, errors);
+
+  return {
+    source,
+    label,
+    path: filePath,
+    servers,
+    errors,
+    found: true,
+  };
+}
+
+function loadClaudeCodeJsonMcpServers(
+  homeDir: string,
+  cwd: string,
+  scope: ClaudeMcpImportScope,
+): ClaudeMcpSourceResult {
+  const filePath = getClaudeCodeConfigPath(homeDir);
+  const errors: string[] = [];
+  const servers = emptyServerRecord();
+  const parsed = readJsonObject(filePath);
+
+  if (!parsed.found) {
+    return {
+      source: 'claude-code',
+      label: 'Claude Code',
+      path: filePath,
+      servers,
+      errors,
+      found: false,
+    };
+  }
+
+  if (!parsed.data) {
+    return {
+      source: 'claude-code',
+      label: 'Claude Code',
+      path: filePath,
+      servers,
+      errors: parsed.error ? [parsed.error] : errors,
+      found: true,
+    };
+  }
+
+  if (scope === 'user') {
+    copyMcpServers(parsed.data['mcpServers'], filePath, servers, errors);
+  } else {
+    const projectSettings = getClaudeProjectSettings(
+      parsed.data['projects'],
+      cwd,
+    );
+    if (projectSettings) {
+      copyMcpServers(
+        projectSettings['mcpServers'],
+        `${filePath} projects["${normalizeProjectPath(cwd)}"]`,
+        servers,
+        errors,
+      );
+    }
+  }
+
+  return {
+    source: 'claude-code',
+    label: 'Claude Code',
+    path: filePath,
+    servers,
+    errors,
+    found: true,
+  };
+}
+
+function loadClaudeCodeMcpSources(
+  homeDir: string,
+  cwd: string,
+  scope: ClaudeMcpImportScope,
+): ClaudeMcpSourceResult[] {
+  const candidates =
+    scope === 'project'
+      ? [
+          loadMcpServersFromSettingsFile(
+            path.join(cwd, '.claude', 'settings.json'),
+            'Claude Code project settings',
+            'claude-code',
+          ),
+          loadClaudeCodeJsonMcpServers(homeDir, cwd, scope),
+        ]
+      : [
+          loadClaudeCodeJsonMcpServers(homeDir, cwd, scope),
+          loadMcpServersFromSettingsFile(
+            path.join(homeDir, '.claude', 'settings.json'),
+            'Claude Code global settings',
+            'claude-code',
+          ),
+        ];
+
+  const seen = new Set<string>();
+  return candidates.filter((candidate) => {
+    if (seen.has(candidate.path)) {
+      return false;
+    }
+    seen.add(candidate.path);
+    return true;
+  });
+}
+
+function loadClaudeDesktopMcpServers(
+  homeDir: string,
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+): ClaudeMcpSourceResult {
+  const filePath = getClaudeDesktopConfigPath(homeDir, platform, env);
+  const errors: string[] = [];
+  const servers = emptyServerRecord();
+  const parsed = readJsonObject(filePath);
+
+  if (!parsed.found) {
+    return {
+      source: 'claude-desktop',
+      label: 'Claude Desktop',
+      path: filePath,
+      servers,
+      errors,
+      found: false,
+    };
+  }
+
+  if (!parsed.data) {
+    return {
+      source: 'claude-desktop',
+      label: 'Claude Desktop',
+      path: filePath,
+      servers,
+      errors: parsed.error ? [parsed.error] : errors,
+      found: true,
+    };
+  }
+
+  copyMcpServers(parsed.data['mcpServers'], filePath, servers, errors);
+
+  return {
+    source: 'claude-desktop',
+    label: 'Claude Desktop',
+    path: filePath,
+    servers,
+    errors,
+    found: true,
+  };
+}
+
+export function loadClaudeMcpSources(
+  options: Pick<
+    ClaudeMcpImportOptions,
+    'source' | 'cwd' | 'homeDir' | 'env' | 'platform'
+  > &
+    Partial<Pick<ClaudeMcpImportOptions, 'scope'>>,
+): ClaudeMcpSourceResult[] {
+  const homeDir = options.homeDir ?? os.homedir();
+  const cwd = options.cwd ?? process.cwd();
+  const platform = options.platform ?? process.platform;
+  const env = options.env ?? process.env;
+  const scope = options.scope ?? 'user';
+
+  const sources: ReadonlyArray<Exclude<ClaudeMcpImportSource, 'all'>> =
+    options.source === 'all'
+      ? (['claude-code', 'claude-desktop'] as const)
+      : ([options.source] as const);
+
+  return sources.flatMap((source) =>
+    source === 'claude-code'
+      ? loadClaudeCodeMcpSources(homeDir, cwd, scope)
+      : [loadClaudeDesktopMcpServers(homeDir, platform, env)],
+  );
+}
+
+function getSettingScope(
+  settings: LoadedSettings,
+  scope: ClaudeMcpImportScope,
+): SettingScope.User | SettingScope.Workspace {
+  if (scope === 'user') {
+    return SettingScope.User;
+  }
+
+  if (settings.workspace.path === settings.user.path) {
+    throw new Error(
+      'Please use --scope user to edit settings in the home directory.',
+    );
+  }
+
+  return SettingScope.Workspace;
+}
+
+function addServerNamesFromRecord(value: unknown, names: Set<string>) {
+  if (!isRecord(value)) {
+    return;
+  }
+
+  for (const name of Object.keys(value)) {
+    names.add(name);
+  }
+}
+
+function copyExistingServers(
+  settings: LoadedSettings,
+  settingScope: SettingScope.User | SettingScope.Workspace,
+): {
+  nextServers: Record<string, MCPServerConfig>;
+  existingNames: Set<string>;
+} {
+  const existingServers = settings.forScope(settingScope).settings.mcpServers;
+  const existingNames = new Set<string>();
+
+  if (existingServers === undefined) {
+    addServerNamesFromRecord(settings.merged?.mcpServers, existingNames);
+    return { nextServers: emptyServerRecord(), existingNames };
+  }
+
+  if (!isRecord(existingServers)) {
+    throw new Error('Existing mcpServers setting must be an object.');
+  }
+
+  const copy = emptyServerRecord();
+  for (const [name, serverConfig] of Object.entries(existingServers)) {
+    copy[name] = serverConfig as MCPServerConfig;
+    existingNames.add(name);
+  }
+  addServerNamesFromRecord(settings.merged?.mcpServers, existingNames);
+  return { nextServers: copy, existingNames };
+}
+
+export function importClaudeMcpServers(
+  options: ClaudeMcpImportOptions,
+): ClaudeMcpImportResult {
+  const settingScope = getSettingScope(options.settings, options.scope);
+  const { nextServers, existingNames } = copyExistingServers(
+    options.settings,
+    settingScope,
+  );
+  const scanned = loadClaudeMcpSources(options);
+  const imported: ImportedClaudeMcpServer[] = [];
+  const skipped: SkippedClaudeMcpServer[] = [];
+  const errors = scanned.flatMap((source) => source.errors);
+
+  for (const source of scanned) {
+    for (const [name, serverConfig] of Object.entries(source.servers)) {
+      if (isReservedServerName(name)) {
+        skipped.push({ name, source: source.label, reason: 'reserved-name' });
+        continue;
+      }
+
+      if (!isRecord(serverConfig)) {
+        skipped.push({ name, source: source.label, reason: 'invalid' });
+        continue;
+      }
+
+      if (existingNames.has(name)) {
+        skipped.push({ name, source: source.label, reason: 'already-exists' });
+        continue;
+      }
+
+      nextServers[name] = serverConfig as MCPServerConfig;
+      existingNames.add(name);
+      imported.push({ name, source: source.label });
+    }
+  }
+
+  if (imported.length > 0) {
+    options.settings.setValue(settingScope, 'mcpServers', nextServers);
+  }
+
+  return {
+    scope: options.scope,
+    settingScope,
+    scanned,
+    imported,
+    skipped,
+    errors,
+  };
+}

--- a/packages/cli/src/config/claudeMcpImport.ts
+++ b/packages/cli/src/config/claudeMcpImport.ts
@@ -41,7 +41,7 @@ export interface ImportedClaudeMcpServer {
 export interface SkippedClaudeMcpServer {
   name: string;
   source: string;
-  reason: 'already-exists' | 'invalid' | 'reserved-name';
+  reason: 'already-exists' | 'reserved-name';
 }
 
 export interface ClaudeMcpImportResult {
@@ -473,11 +473,6 @@ export function importClaudeMcpServers(
     for (const [name, serverConfig] of Object.entries(source.servers)) {
       if (isReservedServerName(name)) {
         skipped.push({ name, source: source.label, reason: 'reserved-name' });
-        continue;
-      }
-
-      if (!isRecord(serverConfig)) {
-        skipped.push({ name, source: source.label, reason: 'invalid' });
         continue;
       }
 

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -976,6 +976,8 @@ export default {
     'No managed auto-memory entries matched: {{query}}',
   'Consolidate managed auto-memory topic files.':
     'Consolidate managed auto-memory topic files.',
+  'Import MCP servers from Claude configs':
+    'Import MCP servers from Claude configs',
   'Open MCP management dialog': 'Open MCP management dialog',
   'Could not retrieve tool registry.': 'Could not retrieve tool registry.',
   "Successfully authenticated and refreshed tools for '{{name}}'.":

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -833,6 +833,7 @@ export default {
   'No managed auto-memory entries matched: {{query}}':
     '沒有匹配的託管自動記憶條目：{{query}}',
   'Consolidate managed auto-memory topic files.': '整理託管自動記憶主題檔案',
+  'Import MCP servers from Claude configs': '從 Claude 設定匯入 MCP 伺服器',
   'Open MCP management dialog': '打開 MCP 管理對話框',
   'Could not retrieve tool registry.': '無法檢索工具註冊表',
   "Successfully authenticated and refreshed tools for '{{name}}'.":

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -922,6 +922,7 @@ export default {
   'No managed auto-memory entries matched: {{query}}':
     '没有匹配的托管自动记忆条目：{{query}}',
   'Consolidate managed auto-memory topic files.': '整理托管自动记忆主题文件',
+  'Import MCP servers from Claude configs': '从 Claude 配置导入 MCP 服务器',
   'Open MCP management dialog': '打开 MCP 管理对话框',
   'Could not retrieve tool registry.': '无法检索工具注册表',
   "Successfully authenticated and refreshed tools for '{{name}}'.":

--- a/packages/cli/src/services/BuiltinCommandLoader.test.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.test.ts
@@ -192,6 +192,9 @@ describe('BuiltinCommandLoader', () => {
     const ideCmd = commands.find((c) => c.name === 'ide');
     expect(ideCmd).toBeDefined();
 
+    const importConfigCmd = commands.find((c) => c.name === 'import-config');
+    expect(importConfigCmd).toBeDefined();
+
     const mcpCmd = commands.find((c) => c.name === 'mcp');
     expect(mcpCmd).toBeDefined();
 

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -35,6 +35,7 @@ import { goalCommand } from '../ui/commands/goalCommand.js';
 import { helpCommand } from '../ui/commands/helpCommand.js';
 import { hooksCommand } from '../ui/commands/hooksCommand.js';
 import { ideCommand } from '../ui/commands/ideCommand.js';
+import { importConfigCommand } from '../ui/commands/importConfigCommand.js';
 import { createDebugLogger } from '@qwen-code/qwen-code-core';
 import { initCommand } from '../ui/commands/initCommand.js';
 import { languageCommand } from '../ui/commands/languageCommand.js';
@@ -124,6 +125,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       helpCommand,
       hooksCommand,
       resolvedIdeCommand,
+      importConfigCommand,
       initCommand,
       languageCommand,
       mcpCommand,

--- a/packages/cli/src/ui/commands/importConfigCommand.test.ts
+++ b/packages/cli/src/ui/commands/importConfigCommand.test.ts
@@ -113,4 +113,28 @@ describe('importConfigCommand', () => {
     expect(message.content).toContain('No new Claude MCP servers imported');
     expect(message.content).toContain('/home/u/.claude.json');
   });
+
+  it('keeps no-op imports with source warnings as warnings', () => {
+    const message = formatClaudeMcpImportResult({
+      scope: 'user',
+      settingScope: SettingScope.User,
+      scanned: [],
+      imported: [],
+      skipped: [
+        {
+          name: 'filesystem',
+          source: 'Claude Code',
+          reason: 'already-exists',
+        },
+      ],
+      errors: [
+        '/home/u/.claude.json: server "broken" is not an object - skipped',
+      ],
+    } satisfies ClaudeMcpImportResult);
+
+    expect(message.messageType).toBe('warning');
+    expect(message.content).toContain('No new Claude MCP servers imported');
+    expect(message.content).toContain('Skipped existing server(s): filesystem');
+    expect(message.content).toContain('Warnings:');
+  });
 });

--- a/packages/cli/src/ui/commands/importConfigCommand.test.ts
+++ b/packages/cli/src/ui/commands/importConfigCommand.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { SettingScope } from '../../config/settings.js';
+import {
+  formatClaudeMcpImportResult,
+  importConfigCommand,
+  parseImportConfigArgs,
+  resolveImportSourceForScope,
+} from './importConfigCommand.js';
+import { CommandKind } from './types.js';
+import type { ClaudeMcpImportResult } from '../../config/claudeMcpImport.js';
+
+describe('importConfigCommand', () => {
+  it('is a built-in command available in all execution modes', () => {
+    expect(importConfigCommand.name).toBe('import-config');
+    expect(importConfigCommand.kind).toBe(CommandKind.BUILT_IN);
+    expect(importConfigCommand.supportedModes).toEqual([
+      'interactive',
+      'non_interactive',
+      'acp',
+    ]);
+  });
+
+  it('parses default arguments', () => {
+    expect(parseImportConfigArgs('')).toEqual({
+      source: 'all',
+      sourceExplicit: false,
+      scope: 'user',
+      help: false,
+    });
+  });
+
+  it('parses source and scope arguments', () => {
+    expect(parseImportConfigArgs('claude-code --scope project')).toEqual({
+      source: 'claude-code',
+      sourceExplicit: true,
+      scope: 'project',
+      help: false,
+    });
+    expect(parseImportConfigArgs('--from=desktop -s user')).toEqual({
+      source: 'claude-desktop',
+      sourceExplicit: true,
+      scope: 'user',
+      help: false,
+    });
+  });
+
+  it('reports invalid arguments', () => {
+    const result = parseImportConfigArgs('claude-code --scope system');
+    expect(result.error).toContain('--scope');
+  });
+
+  it('uses project Claude Code configs for default project-scope imports', () => {
+    expect(resolveImportSourceForScope('all', 'project', false)).toBe(
+      'claude-code',
+    );
+  });
+
+  it('keeps an explicit all source when importing to project scope', () => {
+    expect(resolveImportSourceForScope('all', 'project', true)).toBe('all');
+  });
+
+  it('formats imported and skipped servers', () => {
+    const message = formatClaudeMcpImportResult({
+      scope: 'user',
+      settingScope: SettingScope.User,
+      scanned: [],
+      imported: [
+        { name: 'filesystem', source: 'Claude Code' },
+        { name: 'github', source: 'Claude Desktop' },
+      ],
+      skipped: [
+        {
+          name: 'context7',
+          source: 'Claude Code',
+          reason: 'already-exists',
+        },
+      ],
+      errors: [],
+    } satisfies ClaudeMcpImportResult);
+
+    expect(message.messageType).toBe('warning');
+    expect(message.content).toContain('Imported 2 MCP server(s)');
+    expect(message.content).toContain('filesystem, github');
+    expect(message.content).toContain('Skipped existing server(s): context7');
+  });
+
+  it('lists checked paths when nothing was imported', () => {
+    const message = formatClaudeMcpImportResult({
+      scope: 'user',
+      settingScope: SettingScope.User,
+      scanned: [
+        {
+          source: 'claude-code',
+          label: 'Claude Code',
+          path: '/home/u/.claude.json',
+          servers: {},
+          errors: [],
+          found: false,
+        },
+      ],
+      imported: [],
+      skipped: [],
+      errors: [],
+    } satisfies ClaudeMcpImportResult);
+
+    expect(message.messageType).toBe('info');
+    expect(message.content).toContain('No new Claude MCP servers imported');
+    expect(message.content).toContain('/home/u/.claude.json');
+  });
+});

--- a/packages/cli/src/ui/commands/importConfigCommand.ts
+++ b/packages/cli/src/ui/commands/importConfigCommand.ts
@@ -1,0 +1,346 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { t } from '../../i18n/index.js';
+import {
+  importClaudeMcpServers,
+  type ClaudeMcpImportResult,
+  type ClaudeMcpImportScope,
+  type ClaudeMcpImportSource,
+} from '../../config/claudeMcpImport.js';
+import type {
+  CommandContext,
+  MessageActionReturn,
+  SlashCommand,
+} from './types.js';
+import { CommandKind } from './types.js';
+
+const SOURCE_ALIASES: Record<string, ClaudeMcpImportSource> = {
+  all: 'all',
+  claude: 'claude-code',
+  'claude-code': 'claude-code',
+  code: 'claude-code',
+  desktop: 'claude-desktop',
+  'claude-desktop': 'claude-desktop',
+};
+
+interface ParsedImportConfigArgs {
+  source: ClaudeMcpImportSource;
+  sourceExplicit: boolean;
+  scope: ClaudeMcpImportScope;
+  help: boolean;
+  error?: string;
+}
+
+function parseSource(value: string): ClaudeMcpImportSource | undefined {
+  return SOURCE_ALIASES[value.toLowerCase()];
+}
+
+function parseScope(value: string): ClaudeMcpImportScope | undefined {
+  if (value === 'user' || value === 'project') {
+    return value;
+  }
+  return undefined;
+}
+
+export function parseImportConfigArgs(args: string): ParsedImportConfigArgs {
+  const tokens = args.trim().split(/\s+/).filter(Boolean);
+  let source: ClaudeMcpImportSource = 'all';
+  let sourceWasSet = false;
+  let scope: ClaudeMcpImportScope = 'user';
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (token === '--help' || token === '-h' || token === 'help') {
+      return { source, sourceExplicit: sourceWasSet, scope, help: true };
+    }
+
+    if (token === '--from') {
+      const value = tokens[++i];
+      if (!value) {
+        return {
+          source,
+          sourceExplicit: sourceWasSet,
+          scope,
+          help: false,
+          error: t('Missing value for --from.'),
+        };
+      }
+      const parsed = parseSource(value);
+      if (!parsed) {
+        return {
+          source,
+          sourceExplicit: sourceWasSet,
+          scope,
+          help: false,
+          error: t('Unknown import source: {{source}}', { source: value }),
+        };
+      }
+      source = parsed;
+      sourceWasSet = true;
+      continue;
+    }
+
+    if (token.startsWith('--from=')) {
+      const value = token.slice('--from='.length);
+      const parsed = parseSource(value);
+      if (!parsed) {
+        return {
+          source,
+          sourceExplicit: sourceWasSet,
+          scope,
+          help: false,
+          error: t('Unknown import source: {{source}}', { source: value }),
+        };
+      }
+      source = parsed;
+      sourceWasSet = true;
+      continue;
+    }
+
+    if (token === '--scope' || token === '-s') {
+      const value = tokens[++i];
+      const parsed = value ? parseScope(value) : undefined;
+      if (!parsed) {
+        return {
+          source,
+          sourceExplicit: sourceWasSet,
+          scope,
+          help: false,
+          error: t('Expected --scope to be "user" or "project".'),
+        };
+      }
+      scope = parsed;
+      continue;
+    }
+
+    if (token.startsWith('--scope=')) {
+      const value = token.slice('--scope='.length);
+      const parsed = parseScope(value);
+      if (!parsed) {
+        return {
+          source,
+          sourceExplicit: sourceWasSet,
+          scope,
+          help: false,
+          error: t('Expected --scope to be "user" or "project".'),
+        };
+      }
+      scope = parsed;
+      continue;
+    }
+
+    const parsed = parseSource(token);
+    if (parsed && !sourceWasSet) {
+      source = parsed;
+      sourceWasSet = true;
+      continue;
+    }
+
+    return {
+      source,
+      sourceExplicit: sourceWasSet,
+      scope,
+      help: false,
+      error: t('Unknown argument: {{arg}}', { arg: token }),
+    };
+  }
+
+  return { source, sourceExplicit: sourceWasSet, scope, help: false };
+}
+
+export function resolveImportSourceForScope(
+  source: ClaudeMcpImportSource,
+  scope: ClaudeMcpImportScope,
+  sourceExplicit: boolean,
+): ClaudeMcpImportSource {
+  if (scope === 'project' && source === 'all' && !sourceExplicit) {
+    return 'claude-code';
+  }
+  return source;
+}
+
+function usage(): string {
+  return [
+    t('Import MCP servers from Claude configs.'),
+    '',
+    t(
+      'Usage: /import-config [all|claude-code|claude-desktop] [--scope user|project]',
+    ),
+    '',
+    t('Examples:'),
+    '  /import-config',
+    '  /import-config claude-code',
+    '  /import-config claude-desktop --scope user',
+    '  /import-config --scope project',
+  ].join('\n');
+}
+
+function formatNameList(names: string[]): string {
+  if (names.length <= 6) {
+    return names.join(', ');
+  }
+  return `${names.slice(0, 6).join(', ')} +${names.length - 6} more`;
+}
+
+export function formatClaudeMcpImportResult(
+  result: ClaudeMcpImportResult,
+): MessageActionReturn {
+  const target = result.scope === 'user' ? 'user' : 'project';
+  const importedNames = result.imported.map((entry) => entry.name);
+  const skippedExisting = result.skipped
+    .filter((entry) => entry.reason === 'already-exists')
+    .map((entry) => entry.name);
+  const skippedInvalid = result.skipped
+    .filter((entry) => entry.reason === 'invalid')
+    .map((entry) => entry.name);
+  const skippedReserved = result.skipped
+    .filter((entry) => entry.reason === 'reserved-name')
+    .map((entry) => entry.name);
+  const checkedPaths = result.scanned.map((entry) => entry.path);
+  const lines: string[] = [];
+
+  if (result.imported.length > 0) {
+    lines.push(
+      t('Imported {{count}} MCP server(s) to {{scope}} settings: {{names}}', {
+        count: String(result.imported.length),
+        scope: target,
+        names: formatNameList(importedNames),
+      }),
+    );
+  } else {
+    lines.push(
+      t('No new Claude MCP servers imported into {{scope}} settings.', {
+        scope: target,
+      }),
+    );
+  }
+
+  if (skippedExisting.length > 0) {
+    lines.push(
+      t('Skipped existing server(s): {{names}}', {
+        names: formatNameList([...new Set(skippedExisting)]),
+      }),
+    );
+  }
+
+  if (skippedInvalid.length > 0) {
+    lines.push(
+      t('Skipped invalid server(s): {{names}}', {
+        names: formatNameList([...new Set(skippedInvalid)]),
+      }),
+    );
+  }
+
+  if (skippedReserved.length > 0) {
+    lines.push(
+      t('Skipped unsupported server name(s): {{names}}', {
+        names: formatNameList([...new Set(skippedReserved)]),
+      }),
+    );
+  }
+
+  if (result.errors.length > 0) {
+    lines.push('', t('Warnings:'));
+    lines.push(...result.errors.map((error) => `  - ${error}`));
+  }
+
+  if (
+    result.imported.length === 0 &&
+    result.skipped.length === 0 &&
+    result.errors.length === 0
+  ) {
+    lines.push('', t('Checked:'));
+    lines.push(...checkedPaths.map((filePath) => `  - ${filePath}`));
+  }
+
+  const messageType =
+    result.errors.length > 0 && result.imported.length === 0
+      ? 'error'
+      : result.errors.length > 0 || result.skipped.length > 0
+        ? 'warning'
+        : 'info';
+
+  return {
+    type: 'message',
+    messageType,
+    content: lines.join('\n'),
+  };
+}
+
+export const importConfigCommand: SlashCommand = {
+  name: 'import-config',
+  get description() {
+    return t('Import MCP servers from Claude configs');
+  },
+  argumentHint: '[all|claude-code|claude-desktop] [--scope user|project]',
+  examples: [
+    '/import-config',
+    '/import-config claude-code',
+    '/import-config claude-desktop --scope user',
+    '/import-config --scope project',
+  ],
+  kind: CommandKind.BUILT_IN,
+  supportedModes: ['interactive', 'non_interactive', 'acp'] as const,
+  action: async (
+    context: CommandContext,
+    args: string,
+  ): Promise<MessageActionReturn> => {
+    const parsed = parseImportConfigArgs(args);
+    if (parsed.help) {
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: usage(),
+      };
+    }
+
+    if (parsed.error) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: `${parsed.error}\n\n${usage()}`,
+      };
+    }
+
+    try {
+      const importSource = resolveImportSourceForScope(
+        parsed.source,
+        parsed.scope,
+        parsed.sourceExplicit,
+      );
+      const result = importClaudeMcpServers({
+        source: importSource,
+        scope: parsed.scope,
+        settings: context.services.settings,
+        cwd: context.services.config?.getTargetDir() ?? process.cwd(),
+      });
+      return formatClaudeMcpImportResult(result);
+    } catch (error) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content:
+          error instanceof Error
+            ? error.message
+            : t('Import failed: {{error}}', {
+                error: String(error),
+              }),
+      };
+    }
+  },
+  completion: async (_context, partialArg) => {
+    const current = partialArg.trimStart();
+    const candidates = [
+      'all',
+      'claude-code',
+      'claude-desktop',
+      '--scope user',
+      '--scope project',
+    ];
+    return candidates.filter((candidate) => candidate.startsWith(current));
+  },
+};

--- a/packages/cli/src/ui/commands/importConfigCommand.ts
+++ b/packages/cli/src/ui/commands/importConfigCommand.ts
@@ -194,9 +194,6 @@ export function formatClaudeMcpImportResult(
   const skippedExisting = result.skipped
     .filter((entry) => entry.reason === 'already-exists')
     .map((entry) => entry.name);
-  const skippedInvalid = result.skipped
-    .filter((entry) => entry.reason === 'invalid')
-    .map((entry) => entry.name);
   const skippedReserved = result.skipped
     .filter((entry) => entry.reason === 'reserved-name')
     .map((entry) => entry.name);
@@ -227,14 +224,6 @@ export function formatClaudeMcpImportResult(
     );
   }
 
-  if (skippedInvalid.length > 0) {
-    lines.push(
-      t('Skipped invalid server(s): {{names}}', {
-        names: formatNameList([...new Set(skippedInvalid)]),
-      }),
-    );
-  }
-
   if (skippedReserved.length > 0) {
     lines.push(
       t('Skipped unsupported server name(s): {{names}}', {
@@ -258,11 +247,7 @@ export function formatClaudeMcpImportResult(
   }
 
   const messageType =
-    result.errors.length > 0 && result.imported.length === 0
-      ? 'error'
-      : result.errors.length > 0 || result.skipped.length > 0
-        ? 'warning'
-        : 'info';
+    result.errors.length > 0 || result.skipped.length > 0 ? 'warning' : 'info';
 
   return {
     type: 'message',


### PR DESCRIPTION
## Summary

- add `/import-config` for Phase 1 Claude config migration: MCP servers only
- import Claude Code user/project MCP settings and Claude Desktop MCP settings into Qwen settings
- preserve existing effective MCP server names, skip unsupported reserved names, and report unreadable/malformed config warnings

Refs #4845

## Testing

- `npm exec -- vitest run packages/cli/src/config/claudeMcpImport.test.ts packages/cli/src/ui/commands/importConfigCommand.test.ts packages/cli/src/services/BuiltinCommandLoader.test.ts`
- `npm run typecheck --workspace packages/cli`
- `npm run lint --workspace packages/cli`
- `npm run check-i18n --workspace packages/cli`
- `git diff --check`

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
