### PR TITLE
fix(cli,core): prevent memory monitor starvation during autonomous loops via heartbeat fallback

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -91,6 +91,9 @@ vi.mock('./hooks/useFocus.js');
 vi.mock('./hooks/useBracketedPaste.js');
 vi.mock('./hooks/useKeypress.js');
 vi.mock('./hooks/useLoadingIndicator.js');
+vi.mock('./hooks/useMemoryMonitor.js', () => ({
+  useMemoryMonitor: () => {},
+}));
 vi.mock('./hooks/useFolderTrust.js');
 vi.mock('./hooks/useIdeTrustListener.js');
 vi.mock('./hooks/useMessageQueue.js');

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -91,8 +91,11 @@ vi.mock('./hooks/useFocus.js');
 vi.mock('./hooks/useBracketedPaste.js');
 vi.mock('./hooks/useKeypress.js');
 vi.mock('./hooks/useLoadingIndicator.js');
+const { mockUseMemoryMonitor } = vi.hoisted(() => ({
+  mockUseMemoryMonitor: vi.fn(),
+}));
 vi.mock('./hooks/useMemoryMonitor.js', () => ({
-  useMemoryMonitor: () => {},
+  useMemoryMonitor: mockUseMemoryMonitor,
 }));
 vi.mock('./hooks/useFolderTrust.js');
 vi.mock('./hooks/useIdeTrustListener.js');
@@ -3668,5 +3671,94 @@ describe('dedupeNewestFirst', () => {
         'first prompt',
       ]),
     ).toEqual(['first prompt', 'third prompt', 'second prompt']);
+  });
+});
+
+describe('useMemoryMonitor integration', () => {
+  let mockConfig: Config;
+  let mockSettings: LoadedSettings;
+  let mockInitResult: InitializationResult;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    // Bypass the global useMemoryMonitor mock for this describe block,
+    // so AppContainer runs the real hook.
+    const real = await vi.importActual<
+      typeof import('./hooks/useMemoryMonitor.js')
+    >('./hooks/useMemoryMonitor.js');
+    mockUseMemoryMonitor.mockImplementation(real.useMemoryMonitor);
+
+    mockConfig = makeFakeConfig();
+    vi.spyOn(mockConfig, 'getTargetDir').mockReturnValue('/test/workspace');
+    const mockGeminiClient: Partial<GeminiClient> = {
+      initialize: vi.fn().mockResolvedValue(undefined),
+      setTools: vi.fn().mockResolvedValue(undefined),
+      isInitialized: vi.fn().mockReturnValue(false),
+    };
+    vi.spyOn(mockConfig, 'getGeminiClient').mockReturnValue(
+      mockGeminiClient as GeminiClient,
+    );
+
+    mockSettings = {
+      merged: {
+        hideTips: false,
+        theme: 'default',
+        ui: { showStatusInTitle: false, hideWindowTitle: false },
+      },
+      setValue: vi.fn(),
+    } as unknown as LoadedSettings;
+
+    mockInitResult = {
+      themeError: null,
+      authError: null,
+      shouldOpenAuthDialog: false,
+      geminiMdFileCount: 0,
+    } as InitializationResult;
+  });
+
+  afterEach(() => {
+    cleanup();
+    // Restore the global mock so other describe blocks are unaffected.
+    mockUseMemoryMonitor.mockImplementation(() => {});
+  });
+
+  it('registers starvation callback on mount', () => {
+    const setOnStarvationCallback = vi.fn();
+    vi.spyOn(mockConfig, 'getMemoryPressureMonitor').mockReturnValue({
+      setOnStarvationCallback,
+    } as unknown as ReturnType<Config['getMemoryPressureMonitor']>);
+
+    render(
+      <AppContainer
+        config={mockConfig}
+        settings={mockSettings}
+        version="1.0.0"
+        initializationResult={mockInitResult}
+      />,
+    );
+
+    expect(setOnStarvationCallback).toHaveBeenCalledTimes(1);
+    expect(setOnStarvationCallback).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('clears starvation callback on unmount', () => {
+    const setOnStarvationCallback = vi.fn();
+    vi.spyOn(mockConfig, 'getMemoryPressureMonitor').mockReturnValue({
+      setOnStarvationCallback,
+    } as unknown as ReturnType<Config['getMemoryPressureMonitor']>);
+
+    const { unmount } = render(
+      <AppContainer
+        config={mockConfig}
+        settings={mockSettings}
+        version="1.0.0"
+        initializationResult={mockInitResult}
+      />,
+    );
+
+    unmount();
+
+    expect(setOnStarvationCallback).toHaveBeenLastCalledWith(undefined);
   });
 });

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -311,7 +311,7 @@ export const AppContainer = (props: AppContainerProps) => {
   // handlers can read the latest snapshot at call time without reactive deps.
   const historyRef = useRef(historyManager.history);
   historyRef.current = historyManager.history;
-  useMemoryMonitor(historyManager);
+  useMemoryMonitor({ ...historyManager, config });
   const [debugMessage, setDebugMessage] = useState<string>('');
   const [quittingMessages, setQuittingMessages] = useState<
     HistoryItem[] | null

--- a/packages/cli/src/ui/hooks/useMemoryMonitor.test.ts
+++ b/packages/cli/src/ui/hooks/useMemoryMonitor.test.ts
@@ -20,6 +20,15 @@ vi.mock('@qwen-code/qwen-code-core', () => ({
   createDebugLogger: () => mockDebugLogger,
 }));
 
+const mockSetOnToolCompleteCallback = vi.fn();
+vi.mock('../contexts/ConfigContext.js', () => ({
+  useConfig: () => ({
+    getMemoryPressureMonitor: () => ({
+      setOnToolCompleteCallback: mockSetOnToolCompleteCallback,
+    }),
+  }),
+}));
+
 import {
   useMemoryMonitor,
   MEMORY_CHECK_INTERVAL,

--- a/packages/cli/src/ui/hooks/useMemoryMonitor.test.ts
+++ b/packages/cli/src/ui/hooks/useMemoryMonitor.test.ts
@@ -20,11 +20,11 @@ vi.mock('@qwen-code/qwen-code-core', () => ({
   createDebugLogger: () => mockDebugLogger,
 }));
 
-const mockSetOnToolCompleteCallback = vi.fn();
+const mockSetOnStarvationCallback = vi.fn();
 vi.mock('../contexts/ConfigContext.js', () => ({
   useConfig: () => ({
     getMemoryPressureMonitor: () => ({
-      setOnToolCompleteCallback: mockSetOnToolCompleteCallback,
+      setOnStarvationCallback: mockSetOnStarvationCallback,
     }),
   }),
 }));

--- a/packages/cli/src/ui/hooks/useMemoryMonitor.test.ts
+++ b/packages/cli/src/ui/hooks/useMemoryMonitor.test.ts
@@ -20,14 +20,14 @@ vi.mock('@qwen-code/qwen-code-core', () => ({
   createDebugLogger: () => mockDebugLogger,
 }));
 
+import type { Config } from '@qwen-code/qwen-code-core';
+
 const mockSetOnStarvationCallback = vi.fn();
-vi.mock('../contexts/ConfigContext.js', () => ({
-  useConfig: () => ({
-    getMemoryPressureMonitor: () => ({
-      setOnStarvationCallback: mockSetOnStarvationCallback,
-    }),
+const mockConfig = {
+  getMemoryPressureMonitor: () => ({
+    setOnStarvationCallback: mockSetOnStarvationCallback,
   }),
-}));
+} as unknown as Config;
 
 import {
   useMemoryMonitor,
@@ -57,7 +57,7 @@ describe('useMemoryMonitor', () => {
     memoryUsageSpy.mockReturnValue({
       rss: MEMORY_WARNING_THRESHOLD / 2,
     } as NodeJS.MemoryUsage);
-    renderHook(() => useMemoryMonitor({ addItem }));
+    renderHook(() => useMemoryMonitor({ addItem, config: mockConfig }));
     vi.advanceTimersByTime(10000);
     expect(addItem).not.toHaveBeenCalled();
   });
@@ -66,7 +66,7 @@ describe('useMemoryMonitor', () => {
     memoryUsageSpy.mockReturnValue({
       rss: MEMORY_WARNING_THRESHOLD * 1.5,
     } as NodeJS.MemoryUsage);
-    renderHook(() => useMemoryMonitor({ addItem }));
+    renderHook(() => useMemoryMonitor({ addItem, config: mockConfig }));
     vi.advanceTimersByTime(MEMORY_CHECK_INTERVAL);
     expect(addItem).toHaveBeenCalledTimes(1);
     expect(addItem).toHaveBeenCalledWith(
@@ -82,7 +82,9 @@ describe('useMemoryMonitor', () => {
     memoryUsageSpy.mockReturnValue({
       rss: MEMORY_WARNING_THRESHOLD * 1.5,
     } as NodeJS.MemoryUsage);
-    const { rerender } = renderHook(() => useMemoryMonitor({ addItem }));
+    const { rerender } = renderHook(() =>
+      useMemoryMonitor({ addItem, config: mockConfig }),
+    );
     vi.advanceTimersByTime(MEMORY_CHECK_INTERVAL);
     expect(addItem).toHaveBeenCalledTimes(1);
 
@@ -102,7 +104,9 @@ describe('useMemoryMonitor', () => {
       heapUsed: MEMORY_UI_COMPACT_THRESHOLD() + 1,
       heapTotal: MEMORY_UI_COMPACT_THRESHOLD() * 2,
     } as NodeJS.MemoryUsage);
-    renderHook(() => useMemoryMonitor({ addItem, compactOldItems }));
+    renderHook(() =>
+      useMemoryMonitor({ addItem, compactOldItems, config: mockConfig }),
+    );
     vi.advanceTimersByTime(MEMORY_DEBUG_INTERVAL);
     expect(compactOldItems).toHaveBeenCalledTimes(1);
   });
@@ -114,7 +118,9 @@ describe('useMemoryMonitor', () => {
       heapUsed: MEMORY_UI_COMPACT_THRESHOLD() - 1,
       heapTotal: MEMORY_UI_COMPACT_THRESHOLD() * 2,
     } as NodeJS.MemoryUsage);
-    renderHook(() => useMemoryMonitor({ addItem, compactOldItems }));
+    renderHook(() =>
+      useMemoryMonitor({ addItem, compactOldItems, config: mockConfig }),
+    );
     vi.advanceTimersByTime(MEMORY_DEBUG_INTERVAL);
     expect(compactOldItems).not.toHaveBeenCalled();
   });
@@ -126,7 +132,9 @@ describe('useMemoryMonitor', () => {
       heapUsed: MEMORY_UI_COMPACT_THRESHOLD() + 1,
       heapTotal: MEMORY_UI_COMPACT_THRESHOLD() * 2,
     } as NodeJS.MemoryUsage);
-    renderHook(() => useMemoryMonitor({ addItem, compactOldItems }));
+    renderHook(() =>
+      useMemoryMonitor({ addItem, compactOldItems, config: mockConfig }),
+    );
 
     // First call triggers compaction
     vi.advanceTimersByTime(MEMORY_DEBUG_INTERVAL);
@@ -149,7 +157,9 @@ describe('useMemoryMonitor', () => {
       heapUsed: MEMORY_UI_COMPACT_THRESHOLD() - 1,
       heapTotal: MEMORY_UI_COMPACT_THRESHOLD() * 2,
     } as NodeJS.MemoryUsage);
-    renderHook(() => useMemoryMonitor({ addItem, compactOldItems }));
+    renderHook(() =>
+      useMemoryMonitor({ addItem, compactOldItems, config: mockConfig }),
+    );
 
     // Warning fires and self-destructs
     vi.advanceTimersByTime(MEMORY_CHECK_INTERVAL);
@@ -179,7 +189,9 @@ describe('useMemoryMonitor', () => {
     } as NodeJS.MemoryUsage);
     mockDebugLogger.error.mockClear();
 
-    renderHook(() => useMemoryMonitor({ addItem, compactOldItems }));
+    renderHook(() =>
+      useMemoryMonitor({ addItem, compactOldItems, config: mockConfig }),
+    );
 
     // First tick — compactOldItems throws, error is caught
     vi.advanceTimersByTime(MEMORY_DEBUG_INTERVAL);
@@ -192,5 +204,73 @@ describe('useMemoryMonitor', () => {
     // Advance past cooldown + one more interval tick — compactOldItems is called again and succeeds
     vi.advanceTimersByTime(UI_COMPACT_COOLDOWN_MS + MEMORY_DEBUG_INTERVAL);
     expect(compactOldItems).toHaveBeenCalledTimes(2);
+  });
+
+  describe('starvation heartbeat', () => {
+    it('triggers runMemoryCheck when interval has not run for > 60 s', () => {
+      memoryUsageSpy.mockReturnValue({
+        rss: 1024,
+        heapUsed: 100,
+        heapTotal: 200,
+      } as NodeJS.MemoryUsage);
+
+      // Freeze Date.now at hook-init time so we can control the elapsed
+      // time seen by the starvation callback independently of the timer
+      // queue (vi.advanceTimersByTime only advances the queue, not Date.now).
+      const initTime = 1_000_000;
+      let nowTime = initTime;
+      const dateSpy = vi.spyOn(Date, 'now').mockImplementation(() => nowTime);
+
+      renderHook(() => useMemoryMonitor({ addItem, config: mockConfig }));
+
+      const starvationCallback = mockSetOnStarvationCallback.mock.calls[0]![0]!;
+
+      // Advance the timer queue past 60 s WITHOUT firing intervals
+      // (Date.now is still frozen at initTime, so intervals see the same
+      // timestamp and their elapsed-time guard doesn't trip).
+      vi.advanceTimersByTime(61_000);
+
+      // Now jump Date.now forward so the starvation guard trips.
+      nowTime = initTime + 61_001;
+      memoryUsageSpy.mockClear();
+      starvationCallback();
+
+      // runMemoryCheck calls process.memoryUsage().
+      expect(memoryUsageSpy).toHaveBeenCalled();
+
+      dateSpy.mockRestore();
+    });
+
+    it('skips runMemoryCheck when interval ran recently', () => {
+      memoryUsageSpy.mockReturnValue({
+        rss: 1024,
+        heapUsed: 100,
+        heapTotal: 200,
+      } as NodeJS.MemoryUsage);
+      renderHook(() => useMemoryMonitor({ addItem, config: mockConfig }));
+
+      const starvationCallback = mockSetOnStarvationCallback.mock.calls[0]![0]!;
+
+      // Don't advance time — interval is fresh (just ran at init).
+      memoryUsageSpy.mockClear();
+      starvationCallback();
+
+      expect(memoryUsageSpy).not.toHaveBeenCalled();
+    });
+
+    it('unregisters callback on unmount', () => {
+      memoryUsageSpy.mockReturnValue({
+        rss: 1024,
+        heapUsed: 100,
+        heapTotal: 200,
+      } as NodeJS.MemoryUsage);
+      const { unmount } = renderHook(() =>
+        useMemoryMonitor({ addItem, config: mockConfig }),
+      );
+
+      unmount();
+
+      expect(mockSetOnStarvationCallback).toHaveBeenLastCalledWith(undefined);
+    });
   });
 });

--- a/packages/cli/src/ui/hooks/useMemoryMonitor.ts
+++ b/packages/cli/src/ui/hooks/useMemoryMonitor.ts
@@ -128,14 +128,14 @@ export const useMemoryMonitor = ({
     const monitor = config.getMemoryPressureMonitor();
     if (!monitor) return;
 
-    monitor.setOnToolCompleteCallback(() => {
+    monitor.setOnStarvationCallback(() => {
       if (Date.now() - lastIntervalRunRef.current > 60_000) {
         runMemoryCheck();
       }
     });
 
     return () => {
-      monitor.setOnToolCompleteCallback(undefined);
+      monitor.setOnStarvationCallback(undefined);
     };
   }, [config, runMemoryCheck]);
 };

--- a/packages/cli/src/ui/hooks/useMemoryMonitor.ts
+++ b/packages/cli/src/ui/hooks/useMemoryMonitor.ts
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import process from 'node:process';
 import os from 'node:os';
 import v8 from 'v8';
 import { createDebugLogger } from '@qwen-code/qwen-code-core';
 import { type HistoryItemWithoutId, MessageType } from '../types.js';
+import { useConfig } from '../contexts/ConfigContext.js';
 
 const debugLogger = createDebugLogger('MEMORY_MONITOR');
 
@@ -36,56 +37,59 @@ export const useMemoryMonitor = ({
   compactOldItems,
 }: MemoryMonitorOptions) => {
   const lastCompactRef = useRef(0);
+  const lastIntervalRunRef = useRef(Date.now());
+  const config = useConfig();
+
+  const runMemoryCheck = useCallback(() => {
+    const memUsage = process.memoryUsage();
+    const heapUsed = memUsage.heapUsed / 1024 / 1024;
+    const heapTotal = memUsage.heapTotal / 1024 / 1024;
+    const rss = memUsage.rss / 1024 / 1024;
+    const external = memUsage.external / 1024 / 1024;
+    const arrayBuffers = memUsage.arrayBuffers / 1024 / 1024;
+
+    if (debugLogger.isEnabled()) {
+      debugLogger.debug(
+        `[MEMORY_USAGE] ` +
+          `heapUsed=${heapUsed.toFixed(1)}MB, ` +
+          `heapTotal=${heapTotal.toFixed(1)}MB, ` +
+          `rss=${rss.toFixed(1)}MB, ` +
+          `external=${external.toFixed(1)}MB, ` +
+          `arrayBuffers=${arrayBuffers.toFixed(1)}MB, ` +
+          `heapUtilization=${((heapUsed / heapTotal) * 100).toFixed(1)}%`,
+      );
+    }
+
+    // UI history compaction when heap exceeds threshold
+    const now = Date.now();
+    if (
+      compactOldItems &&
+      memUsage.heapUsed > MEMORY_UI_COMPACT_THRESHOLD() &&
+      now - lastCompactRef.current > UI_COMPACT_COOLDOWN_MS
+    ) {
+      lastCompactRef.current = now;
+      if (debugLogger.isEnabled()) {
+        debugLogger.debug(
+          `[UI_COMPACT] heapUsed=${heapUsed.toFixed(1)}MB ` +
+            `exceeds ${(MEMORY_UI_COMPACT_THRESHOLD() / 1024 / 1024).toFixed(0)}MB threshold, ` +
+            `compacting UI history`,
+        );
+      }
+      try {
+        compactOldItems();
+      } catch (err) {
+        debugLogger.error(
+          `[UI_COMPACT] compactOldItems failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    lastIntervalRunRef.current = Date.now();
+  }, [compactOldItems]);
 
   useEffect(() => {
     // Debug logging + UI compaction interval — runs every 30 s, never cleared.
-    // UI compaction lives here (not in the warning interval) because the
-    // warning interval self-destructs via clearInterval once RSS exceeds 7 GB,
-    // which would also kill the compaction check.
-    const debugIntervalId = setInterval(() => {
-      const memUsage = process.memoryUsage();
-      const heapUsed = memUsage.heapUsed / 1024 / 1024;
-      const heapTotal = memUsage.heapTotal / 1024 / 1024;
-      const rss = memUsage.rss / 1024 / 1024;
-      const external = memUsage.external / 1024 / 1024;
-      const arrayBuffers = memUsage.arrayBuffers / 1024 / 1024;
-
-      if (debugLogger.isEnabled()) {
-        debugLogger.debug(
-          `[MEMORY_USAGE] ` +
-            `heapUsed=${heapUsed.toFixed(1)}MB, ` +
-            `heapTotal=${heapTotal.toFixed(1)}MB, ` +
-            `rss=${rss.toFixed(1)}MB, ` +
-            `external=${external.toFixed(1)}MB, ` +
-            `arrayBuffers=${arrayBuffers.toFixed(1)}MB, ` +
-            `heapUtilization=${((heapUsed / heapTotal) * 100).toFixed(1)}%`,
-        );
-      }
-
-      // UI history compaction when heap exceeds threshold
-      const now = Date.now();
-      if (
-        compactOldItems &&
-        memUsage.heapUsed > MEMORY_UI_COMPACT_THRESHOLD() &&
-        now - lastCompactRef.current > UI_COMPACT_COOLDOWN_MS
-      ) {
-        lastCompactRef.current = now;
-        if (debugLogger.isEnabled()) {
-          debugLogger.debug(
-            `[UI_COMPACT] heapUsed=${heapUsed.toFixed(1)}MB ` +
-              `exceeds ${(MEMORY_UI_COMPACT_THRESHOLD() / 1024 / 1024).toFixed(0)}MB threshold, ` +
-              `compacting UI history`,
-          );
-        }
-        try {
-          compactOldItems();
-        } catch (err) {
-          debugLogger.error(
-            `[UI_COMPACT] compactOldItems failed: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
-      }
-    }, MEMORY_DEBUG_INTERVAL);
+    const debugIntervalId = setInterval(runMemoryCheck, MEMORY_DEBUG_INTERVAL);
 
     // Warning interval — warns once then self-destructs.
     const warningIntervalId = setInterval(() => {
@@ -115,5 +119,23 @@ export const useMemoryMonitor = ({
       clearInterval(debugIntervalId);
       clearInterval(warningIntervalId);
     };
-  }, [addItem, compactOldItems]);
+  }, [addItem, runMemoryCheck]);
+
+  // Heartbeat: Core's MemoryPressureMonitor notifies us when its
+  // queueMicrotask has been starved for ≥ 60 s. If our own setInterval
+  // hasn't run in that window either, force a full check.
+  useEffect(() => {
+    const monitor = config.getMemoryPressureMonitor();
+    if (!monitor) return;
+
+    monitor.setOnToolCompleteCallback(() => {
+      if (Date.now() - lastIntervalRunRef.current > 60_000) {
+        runMemoryCheck();
+      }
+    });
+
+    return () => {
+      monitor.setOnToolCompleteCallback(undefined);
+    };
+  }, [config, runMemoryCheck]);
 };

--- a/packages/cli/src/ui/hooks/useMemoryMonitor.ts
+++ b/packages/cli/src/ui/hooks/useMemoryMonitor.ts
@@ -8,9 +8,8 @@ import { useCallback, useEffect, useRef } from 'react';
 import process from 'node:process';
 import os from 'node:os';
 import v8 from 'v8';
-import { createDebugLogger } from '@qwen-code/qwen-code-core';
+import { createDebugLogger, type Config } from '@qwen-code/qwen-code-core';
 import { type HistoryItemWithoutId, MessageType } from '../types.js';
-import { useConfig } from '../contexts/ConfigContext.js';
 
 const debugLogger = createDebugLogger('MEMORY_MONITOR');
 
@@ -30,15 +29,16 @@ export const UI_COMPACT_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
 interface MemoryMonitorOptions {
   addItem: (item: HistoryItemWithoutId, timestamp: number) => void;
   compactOldItems?: () => void;
+  config: Config;
 }
 
 export const useMemoryMonitor = ({
   addItem,
   compactOldItems,
+  config,
 }: MemoryMonitorOptions) => {
   const lastCompactRef = useRef(0);
   const lastIntervalRunRef = useRef(Date.now());
-  const config = useConfig();
 
   const runMemoryCheck = useCallback(() => {
     const memUsage = process.memoryUsage();

--- a/packages/core/src/services/memoryPressureMonitor.test.ts
+++ b/packages/core/src/services/memoryPressureMonitor.test.ts
@@ -611,6 +611,78 @@ describe('MemoryPressureMonitor', () => {
 
       vi.restoreAllMocks();
     });
+
+    it('falls back to synchronous check when microtask is starved ≥ 60 s', () => {
+      setOsTotalmem(16 * 1024 * 1024 * 1024);
+      const evictSpy = vi.fn().mockReturnValue(0);
+      const starvationCb = vi.fn();
+      const monitor = new MemoryPressureMonitor(
+        createMockConfig({
+          fileReadCache: { evictNotAccessedSince: evictSpy },
+        }),
+        { ...DEFAULT_PRESSURE_CONFIG, cleanupCooldownMs: 0 },
+      );
+      monitor.setOnStarvationCallback(starvationCb);
+
+      vi.spyOn(process, 'memoryUsage').mockReturnValue({
+        rss: 9 * 1024 * 1024 * 1024, // soft pressure
+        heapTotal: 0,
+        heapUsed: 0,
+        external: 0,
+        arrayBuffers: 0,
+      });
+
+      // First call queues a microtask (which we do NOT drain).
+      monitor.scheduleCheck();
+
+      // Advance Date.now past the 60 s starvation threshold.
+      const base = Date.now();
+      vi.spyOn(Date, 'now').mockReturnValue(base + 61_000);
+
+      // Second call detects starvation and runs performCheck synchronously.
+      monitor.scheduleCheck();
+
+      expect(evictSpy).toHaveBeenCalledTimes(1);
+      expect(starvationCb).toHaveBeenCalledTimes(1);
+      expect(mockDebugLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('[STARVATION]'),
+      );
+
+      vi.restoreAllMocks();
+    });
+
+    it('swallows onStarvationCallback errors', () => {
+      setOsTotalmem(16 * 1024 * 1024 * 1024);
+      const monitor = new MemoryPressureMonitor(createMockConfig(), {
+        ...DEFAULT_PRESSURE_CONFIG,
+        cleanupCooldownMs: 0,
+      });
+      monitor.setOnStarvationCallback(() => {
+        throw new Error('callback boom');
+      });
+
+      vi.spyOn(process, 'memoryUsage').mockReturnValue({
+        rss: 9 * 1024 * 1024 * 1024,
+        heapTotal: 0,
+        heapUsed: 0,
+        external: 0,
+        arrayBuffers: 0,
+      });
+
+      monitor.scheduleCheck();
+
+      // Advance Date.now past the 60 s starvation threshold.
+      const base = Date.now();
+      vi.spyOn(Date, 'now').mockReturnValue(base + 61_000);
+
+      // Should not throw despite the callback error.
+      expect(() => monitor.scheduleCheck()).not.toThrow();
+      expect(mockDebugLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('onStarvation callback failed: callback boom'),
+      );
+
+      vi.restoreAllMocks();
+    });
   });
 
   describe('performCheck with cleanup', () => {

--- a/packages/core/src/services/memoryPressureMonitor.ts
+++ b/packages/core/src/services/memoryPressureMonitor.ts
@@ -247,7 +247,7 @@ export class MemoryPressureMonitor extends EventEmitter {
   private pendingCheck = false;
   private lastCheckTime = 0;
   private checkGeneration = 0;
-  private onToolCompleteCallback?: () => void;
+  private onStarvationCallback?: () => void;
   private cleanupInProgress = false;
   // Sampling runs every pressure check, so a persistent failure would spam the
   // logs. Surface the first failure at error level (so operators can tell
@@ -314,8 +314,8 @@ export class MemoryPressureMonitor extends EventEmitter {
   }
 
   /** Register a callback invoked when the monitor detects starvation. */
-  setOnToolCompleteCallback(cb: (() => void) | undefined): void {
-    this.onToolCompleteCallback = cb;
+  setOnStarvationCallback(cb: (() => void) | undefined): void {
+    this.onStarvationCallback = cb;
   }
 
   /**
@@ -328,11 +328,20 @@ export class MemoryPressureMonitor extends EventEmitter {
     const now = Date.now();
 
     if (this.pendingCheck && now - this.lastCheckTime > 60_000) {
+      debugLogger.warn(
+        `[STARVATION] Microtask starved for ${((now - this.lastCheckTime) / 1000).toFixed(1)}s; running synchronous pressure check`,
+      );
       this.pendingCheck = false;
       this.checkGeneration++;
       this.lastCheckTime = now;
       this.performCheck();
-      this.onToolCompleteCallback?.();
+      try {
+        this.onStarvationCallback?.();
+      } catch (err) {
+        debugLogger.error(
+          `onStarvation callback failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
       return;
     }
 

--- a/packages/core/src/services/memoryPressureMonitor.ts
+++ b/packages/core/src/services/memoryPressureMonitor.ts
@@ -245,6 +245,9 @@ export class MemoryPressureMonitor extends EventEmitter {
   private readonly coreConfig: Config;
 
   private pendingCheck = false;
+  private lastCheckTime = 0;
+  private checkGeneration = 0;
+  private onToolCompleteCallback?: () => void;
   private cleanupInProgress = false;
   // Sampling runs every pressure check, so a persistent failure would spam the
   // logs. Surface the first failure at error level (so operators can tell
@@ -310,16 +313,36 @@ export class MemoryPressureMonitor extends EventEmitter {
     this.lastCleanupTime = 0;
   }
 
+  /** Register a callback invoked when the monitor detects starvation. */
+  setOnToolCompleteCallback(cb: (() => void) | undefined): void {
+    this.onToolCompleteCallback = cb;
+  }
+
   /**
    * Schedule a deferred memory check after a tool finishes execution.
    * Uses queueMicrotask to batch checks across concurrently-completing
-   * tools within the same event-loop tick.
+   * tools within the same event-loop tick. Falls back to synchronous
+   * execution when the microtask has been starved for ≥ 60 s.
    */
   scheduleCheck(): void {
+    const now = Date.now();
+
+    if (this.pendingCheck && now - this.lastCheckTime > 60_000) {
+      this.pendingCheck = false;
+      this.checkGeneration++;
+      this.lastCheckTime = now;
+      this.performCheck();
+      this.onToolCompleteCallback?.();
+      return;
+    }
+
     if (this.pendingCheck) return;
     this.pendingCheck = true;
+    const gen = ++this.checkGeneration;
     queueMicrotask(() => {
+      if (gen !== this.checkGeneration) return;
       try {
+        this.lastCheckTime = Date.now();
         this.performCheck();
       } finally {
         this.pendingCheck = false;

--- a/packages/core/src/services/memoryPressureMonitor.ts
+++ b/packages/core/src/services/memoryPressureMonitor.ts
@@ -245,7 +245,7 @@ export class MemoryPressureMonitor extends EventEmitter {
   private readonly coreConfig: Config;
 
   private pendingCheck = false;
-  private lastCheckTime = 0;
+  private lastCheckTime = Date.now();
   private checkGeneration = 0;
   private onStarvationCallback?: () => void;
   private cleanupInProgress = false;

--- a/packages/core/src/services/memoryPressureMonitor.ts
+++ b/packages/core/src/services/memoryPressureMonitor.ts
@@ -339,7 +339,7 @@ export class MemoryPressureMonitor extends EventEmitter {
         this.onStarvationCallback?.();
       } catch (err) {
         debugLogger.error(
-          `onStarvation callback failed: ${err instanceof Error ? err.message : String(err)}`,
+          `onStarvation callback failed: ${getErrorMessage(err)}`,
         );
       }
       return;


### PR DESCRIPTION
## What this PR does

Under autonomous agent/goal loops, the event loop has zero idle time — `queueMicrotask` and `setInterval` callbacks never fire, so both memory monitors are completely starved. UI history grows until OOM.

Fix: Core's `scheduleCheck()` detects starvation (≥60s since last successful check) and falls back to synchronous execution. On fallback, it fires a heartbeat callback to CLI. CLI checks if its own `setInterval` has been silent for ≥60s, and if so runs the full memory check inline.

## Why it's needed

During autonomous agent/goal loops, the event loop has no idle time. Both monitors get starved:

- **Core** `scheduleCheck()` uses `queueMicrotask` — no microtask gap, never executes
- **CLI** `useMemoryMonitor` uses `setInterval` (30s/60s) — timer phase never reached

UI history grows unbounded

## Reviewer Test Plan

### Before / After

**Before:** Both monitors completely starved during autonomous loops. Memory grows until OOM.

**After:** Core detects starvation after 60s, falls back to synchronous check, notifies CLI via heartbeat. CLI detects its `setInterval` hasn't run in 60s, runs full check inline.

### How to verify

1. Run existing tests:

```shell
cd packages/core && npx vitest run src/services/memoryPressureMonitor.test.ts
cd packages/cli && npx vitest run src/ui/hooks/useMemoryMonitor.test.ts
```

2. Build + typecheck:

```shell
npm run build && npm run typecheck
```

3. Manual: start CLI, run a `/goal` with continuous tool operations, confirm `[MEMORY_USAGE]` logs keep appearing (previously stopped after a few minutes).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A   |
| 🪟 Windows |    N/A  |
|  🐧 Linux  |  ✅    |

## Risk & Scope

- Main risk or tradeoff: Normal path unchanged — starvation fallback only activates after 60s of zero idle time.
- Breaking changes / migration notes: None. `setOnToolCompleteCallback` is additive.

## Linked Issues

Closes: #4815
Follow-up to #4824 #4892

<details>
<summary>中文</summary>

## 本 PR 做了什么

自主 agent/goal 循环下事件循环零空闲，`queueMicrotask` 和 `setInterval` 回调完全饿死，两个内存监控器都不执行。UI 历史无限增长。

修复：Core 的 `scheduleCheck()` 检测饿死（距上次成功检查 ≥60s）后降级为同步执行，同时通过心跳通知 CLI。CLI 发现自己的 `setInterval` 超过 60s 没跑，主动执行完整内存检查。

## 为什么需要

自主 agent/goal 循环期间事件循环没有空闲，两个监控器都被饿死：

- **Core** `scheduleCheck()` 用 `queueMicrotask` — 没有微任务间隙，不执行
- **CLI** `useMemoryMonitor` 用 `setInterval`（30s/60s）— timer 阶段到不了

UI 历史无限增长

## 审查者测试计划

### 改前 / 改后

**改前：** 自主循环期间两个监控器完全饿死，内存持续增长直到 OOM。

**改后：** Core 60s 后检测到饿死，降级同步检查，通过心跳通知 CLI。CLI 发现 `setInterval` 超 60s 没跑，主动执行完整检查。

### 如何验证

1. 运行测试：

```shell
cd packages/core && npx vitest run src/services/memoryPressureMonitor.test.ts
cd packages/cli && npx vitest run src/ui/hooks/useMemoryMonitor.test.ts
```

2. 构建 + 类型检查：

```shell
npm run build && npm run typecheck
```

3. 手动：启动 CLI，跑持续工具操作的 `/goal`，确认 `[MEMORY_USAGE]` 日志持续输出（之前几分钟后就停了）。

### 测试环境

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   N/A   |
| 🪟 Windows |    N/A  |
|  🐧 Linux  |  ✅    |

## 风险与范围

- 主要风险或权衡：正常路径不变，饿死兜底仅在零空闲超 60s 时激活。
- 破坏性变更 / 迁移说明：无。`setOnToolCompleteCallback` 是新增接口。


</details>
