### PR TITLE
feat(cli,web-shell): persist goal status in daemon transcript events

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -1015,6 +1015,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
   let lastSessionMock:
     | {
         captureHistorySnapshot: ReturnType<typeof vi.fn>;
+        emitGoalStatus: ReturnType<typeof vi.fn>;
         restoreHistory: ReturnType<typeof vi.fn>;
         rewindToTurn: ReturnType<typeof vi.fn>;
       }
@@ -1318,6 +1319,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         installRewriter: vi.fn(),
         startCronScheduler: vi.fn(),
         dispose: vi.fn(),
+        emitGoalStatus: vi.fn(),
         captureHistorySnapshot: vi
           .fn()
           .mockReturnValue([{ role: 'user', parts: [{ text: 'before' }] }]),
@@ -2299,6 +2301,12 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       }),
     ).resolves.toEqual({ cleared: true, condition: 'ship it' });
     expect(unregisterGoalHook).toHaveBeenCalledWith(innerConfig, sessionId);
+    expect(lastSessionMock?.emitGoalStatus).toHaveBeenCalledWith({
+      kind: 'cleared',
+      condition: 'ship it',
+      iterations: 1,
+      durationMs: expect.any(Number),
+    });
 
     mockConnectionState.resolve();
     await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -5799,6 +5799,14 @@ class QwenAgent implements Agent {
         const session = this.sessionOrThrow(sessionId);
         const config = session.getConfig();
         const cleared = unregisterGoalHook(config, sessionId);
+        if (cleared) {
+          session.emitGoalStatus({
+            kind: 'cleared',
+            condition: cleared.condition,
+            iterations: cleared.iterations,
+            durationMs: Date.now() - cleared.setAt,
+          });
+        }
         debugLogger.info(
           `sessionGoalClear sessionId=${sessionId} cleared=${!!cleared} condition=${cleared?.condition ?? '(none)'}`,
         );

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -126,6 +126,7 @@ import {
 } from '../../nonInteractiveCliCommands.js';
 import { isSlashCommand } from '../../ui/utils/commandUtils.js';
 import { CommandKind } from '../../ui/commands/types.js';
+import { MessageType, type HistoryItemGoalStatus } from '../../ui/types.js';
 import { parseAcpModelOption } from '../../utils/acpModelUtils.js';
 import { classifyApiError } from '../../ui/hooks/useGeminiStream.js';
 import { getPersistScopeForModelSelection } from '../../config/modelProvidersScope.js';
@@ -586,6 +587,14 @@ export class Session implements SessionContext {
           `Failed to emit goal terminal update: ${this.#formatError(error)}`,
         );
       });
+    });
+  }
+
+  emitGoalStatus(status: Omit<HistoryItemGoalStatus, 'id' | 'type'>): void {
+    void this.messageEmitter.emitGoalStatus(status).catch((error) => {
+      debugLogger.warn(
+        `Failed to emit goal status update: ${this.#formatError(error)}`,
+      );
     });
   }
 
@@ -3701,6 +3710,30 @@ export class Session implements SessionContext {
     }
   }
 
+  #emitGoalStatusItems(result: NonInteractiveSlashCommandResult): void {
+    if (!('outputHistoryItems' in result)) {
+      return;
+    }
+    for (const item of result.outputHistoryItems ?? []) {
+      if (item.type === MessageType.GOAL_STATUS) {
+        this.emitGoalStatus({
+          kind: item.kind,
+          condition: item.condition,
+          ...(item.iterations !== undefined
+            ? { iterations: item.iterations }
+            : {}),
+          ...(item.setAt !== undefined ? { setAt: item.setAt } : {}),
+          ...(item.durationMs !== undefined
+            ? { durationMs: item.durationMs }
+            : {}),
+          ...(item.lastReason !== undefined
+            ? { lastReason: item.lastReason }
+            : {}),
+        });
+      }
+    }
+  }
+
   /**
    * Processes the result of a slash command execution.
    *
@@ -3721,6 +3754,8 @@ export class Session implements SessionContext {
     result: NonInteractiveSlashCommandResult,
     originalPrompt: ContentBlock[],
   ): Promise<Part[] | null> {
+    this.#emitGoalStatusItems(result);
+
     switch (result.type) {
       case 'submit_prompt':
         // Command wants to submit a prompt to the model

--- a/packages/cli/src/acp-integration/session/emitters/MessageEmitter.test.ts
+++ b/packages/cli/src/acp-integration/session/emitters/MessageEmitter.test.ts
@@ -106,6 +106,27 @@ describe('MessageEmitter', () => {
     });
   });
 
+  describe('emitGoalStatus', () => {
+    it('should send a goal status update in metadata', async () => {
+      const status = {
+        kind: 'set' as const,
+        condition: 'ship goal support',
+        setAt: 1234,
+      };
+
+      await emitter.emitGoalStatus(status);
+
+      expect(sendUpdateSpy).toHaveBeenCalledTimes(1);
+      expect(sendUpdateSpy).toHaveBeenCalledWith({
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: '' },
+        _meta: {
+          goalStatus: status,
+        },
+      });
+    });
+  });
+
   describe('emitAgentThought', () => {
     it('should send agent_thought_chunk update with text content', async () => {
       await emitter.emitAgentThought('Let me think about this...');

--- a/packages/cli/src/acp-integration/session/emitters/MessageEmitter.ts
+++ b/packages/cli/src/acp-integration/session/emitters/MessageEmitter.ts
@@ -12,6 +12,7 @@ import {
   type GoalTerminalEvent,
 } from '@qwen-code/qwen-code-core';
 import { BaseEmitter } from './BaseEmitter.js';
+import type { HistoryItemGoalStatus } from '../../../ui/types.js';
 
 /**
  * Handles emission of text message chunks (user, agent, thought).
@@ -64,6 +65,18 @@ export class MessageEmitter extends BaseEmitter {
       content: { type: 'text', text: '' },
       _meta: {
         goalTerminal: event,
+      },
+    });
+  }
+
+  async emitGoalStatus(
+    status: Omit<HistoryItemGoalStatus, 'id' | 'type'>,
+  ): Promise<void> {
+    await this.sendUpdate({
+      sessionUpdate: 'agent_message_chunk',
+      content: { type: 'text', text: '' },
+      _meta: {
+        goalStatus: status,
       },
     });
   }

--- a/packages/cli/src/nonInteractiveCliCommands.test.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.test.ts
@@ -235,6 +235,14 @@ describe('handleSlashCommand', () => {
           text: expect.stringContaining('write a hello world script'),
         }),
       ]);
+      expect(result.outputHistoryItems).toEqual([
+        expect.objectContaining({
+          type: 'goal_status',
+          kind: 'set',
+          condition: 'write a hello world script',
+          setAt: expect.any(Number),
+        }),
+      ]);
     }
   });
 
@@ -304,6 +312,16 @@ describe('handleSlashCommand', () => {
       messageType: 'info',
       content: 'Goal cleared: write a hello world script',
     });
+    if (result.type === 'message') {
+      expect(result.outputHistoryItems).toEqual([
+        expect.objectContaining({
+          type: 'goal_status',
+          kind: 'cleared',
+          condition: 'write a hello world script',
+          durationMs: expect.any(Number),
+        }),
+      ]);
+    }
   });
 
   it('should report cleared goal for ACP /goal clear', async () => {

--- a/packages/cli/src/nonInteractiveCliCommands.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.ts
@@ -25,6 +25,7 @@ import {
   type ExecutionMode,
 } from './ui/commands/types.js';
 import { createNonInteractiveUI } from './ui/noninteractive/nonInteractiveUi.js';
+import type { HistoryItemWithoutId } from './ui/types.js';
 import type { LoadedSettings } from './config/settings.js';
 import type { SessionStatsState } from './ui/contexts/SessionContext.js';
 import { t } from './i18n/index.js';
@@ -50,11 +51,13 @@ export type NonInteractiveSlashCommandResult =
   | {
       type: 'submit_prompt';
       content: PartListUnion;
+      outputHistoryItems?: HistoryItemWithoutId[];
     }
   | {
       type: 'message';
       messageType: 'info' | 'warning' | 'error';
       content: string;
+      outputHistoryItems?: HistoryItemWithoutId[];
     }
   | {
       type: 'stream_messages';
@@ -88,12 +91,14 @@ export type NonInteractiveSlashCommandResult =
  */
 function handleCommandResult(
   result: SlashCommandActionReturn,
+  outputHistoryItems?: HistoryItemWithoutId[],
 ): NonInteractiveSlashCommandResult {
   switch (result.type) {
     case 'submit_prompt':
       return {
         type: 'submit_prompt',
         content: result.content,
+        ...(outputHistoryItems?.length ? { outputHistoryItems } : {}),
       };
 
     case 'message':
@@ -101,6 +106,7 @@ function handleCommandResult(
         type: 'message',
         messageType: result.messageType,
         content: result.content,
+        ...(outputHistoryItems?.length ? { outputHistoryItems } : {}),
       };
 
     case 'stream_messages':
@@ -399,6 +405,13 @@ export const handleSlashCommand = async (
 
   const logger = new Logger(config?.getSessionId() || '', config?.storage);
 
+  const outputHistoryItems: HistoryItemWithoutId[] = [];
+  const ui = createNonInteractiveUI();
+  ui.addItem = (item) => {
+    outputHistoryItems.push(item);
+    return 0;
+  };
+
   const context: CommandContext = {
     executionMode,
     services: {
@@ -406,7 +419,7 @@ export const handleSlashCommand = async (
       settings,
       logger,
     },
-    ui: createNonInteractiveUI(),
+    ui,
     session: {
       stats: sessionStats,
       sessionShellAllowlist: new Set(),
@@ -440,11 +453,14 @@ export const handleSlashCommand = async (
     if (hookResult.blockedResult) {
       return hookResult.blockedResult;
     }
-    return handleCommandResult({ ...result, content: hookResult.content });
+    return handleCommandResult(
+      { ...result, content: hookResult.content },
+      outputHistoryItems,
+    );
   }
 
   // Handle different result types
-  return handleCommandResult(result);
+  return handleCommandResult(result, outputHistoryItems);
 };
 
 /**

--- a/packages/cli/src/ui/commands/goalCommand.ts
+++ b/packages/cli/src/ui/commands/goalCommand.ts
@@ -208,6 +208,7 @@ export const goalCommand: SlashCommand = {
       type: MessageType.GOAL_STATUS,
       kind: 'set',
       condition: registered.condition,
+      setAt: registered.setAt,
     };
     context.ui.addItem(setItem, Date.now());
 

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -562,8 +562,9 @@ export type HistoryItemGoalStatus = HistoryItemBase & {
   type: 'goal_status';
   kind: GoalStatusKind;
   condition: string;
-  /** Set for progress and terminal goal states. */
+  /** Set for active, progress, and terminal goal states. */
   iterations?: number;
+  setAt?: number;
   durationMs?: number;
   lastReason?: string;
 };

--- a/packages/sdk-typescript/src/daemon/ui/transcript.ts
+++ b/packages/sdk-typescript/src/daemon/ui/transcript.ts
@@ -928,6 +928,13 @@ function appendStatusBlock(
     ...(event?.type === 'error' && event.source
       ? { source: event.source }
       : {}),
+    ...((event?.type === 'status' || event?.type === 'debug') && event.source
+      ? { source: event.source }
+      : {}),
+    ...((event?.type === 'status' || event?.type === 'debug') &&
+    event.data !== undefined
+      ? { data: event.data }
+      : {}),
   };
   appendBlock(state, block);
   if (opts.clearActiveText !== false) clearActiveText(state);

--- a/packages/sdk-typescript/src/daemon/ui/types.ts
+++ b/packages/sdk-typescript/src/daemon/ui/types.ts
@@ -211,6 +211,8 @@ export interface DaemonUiModelChangedEvent extends DaemonUiEventBase {
 export interface DaemonUiStatusEvent extends DaemonUiEventBase {
   type: 'status' | 'debug';
   text: string;
+  source?: string;
+  data?: unknown;
 }
 
 export interface DaemonUiErrorEvent extends DaemonUiEventBase {
@@ -744,7 +746,8 @@ export interface DaemonStatusTranscriptBlock extends DaemonTranscriptBlockBase {
   text: string;
   code?: string;
   promptId?: string;
-  source?: 'turn_error';
+  source?: string;
+  data?: unknown;
 }
 
 export interface DaemonPromptCancelledTranscriptBlock

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -20,6 +20,7 @@ import {
   type DaemonStreamingState,
 } from '@qwen-code/webui/daemon-react-sdk';
 import { isDaemonTurnError } from '@qwen-code/sdk/daemon';
+import type { DaemonTranscriptBlock } from '@qwen-code/sdk/daemon';
 import { extractPendingPermission } from './adapters/transcriptAdapter';
 import { MessageList, type MessageListHandle } from './components/MessageList';
 import { Editor, type EditorHandle } from './components/Editor';
@@ -113,6 +114,7 @@ import {
 } from './components/messages/McpStatusMessage';
 import {
   GOAL_STATUS_ACTIVE_EVENT,
+  parseGoalStatusMessage,
   serializeGoalStatusMessage,
 } from './components/messages/GoalStatusMessage';
 import { TASKS_STATUS_ACTIVE_EVENT } from './components/messages/TasksStatusMessage';
@@ -177,6 +179,41 @@ interface QueuedPrompt {
 interface ActiveGoalStatus {
   condition: string;
   setAt: number;
+}
+
+interface SendPromptOptionsWithRetry {
+  optimisticUserMessage?: boolean;
+  images?: PromptImage[];
+  retry?: boolean;
+}
+
+type GoalStatusTranscriptBlock = DaemonTranscriptBlock & {
+  text: string;
+  source?: string;
+  data?: unknown;
+};
+
+function getLatestActiveGoalFromBlocks(
+  blocks: readonly DaemonTranscriptBlock[],
+): ActiveGoalStatus | null {
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    const block = blocks[i];
+    if (block.kind !== 'status') continue;
+    const statusBlock = block as GoalStatusTranscriptBlock;
+    const status =
+      statusBlock.source === 'goal'
+        ? parseGoalStatusMessage(statusBlock.data)
+        : parseGoalStatusMessage(statusBlock.text);
+    if (!status) continue;
+    if (status.kind === 'set' || status.kind === 'checking') {
+      return {
+        condition: status.condition,
+        setAt: status.setAt ?? block.serverTimestamp ?? block.createdAt,
+      };
+    }
+    return null;
+  }
+  return null;
 }
 
 interface LocalAnchoredMessage {
@@ -701,11 +738,17 @@ export function App({
         retriedTurnErrorIdRef.current = null;
       }
       setShowRetryHint(false);
-      return sessionActions.sendPrompt(text, {
+      const promptOptions: SendPromptOptionsWithRetry = {
         images,
         optimisticUserMessage: opts?.optimisticUserMessage,
         retry: opts?.retry,
-      });
+      };
+      return (
+        sessionActions.sendPrompt as (
+          promptText: string,
+          options?: SendPromptOptionsWithRetry,
+        ) => ReturnType<typeof sessionActions.sendPrompt>
+      )(text, promptOptions);
     },
     [clearFollowup, sessionActions],
   );
@@ -1287,6 +1330,20 @@ export function App({
   }, [connection.sessionId, onSessionIdChange]);
 
   useEffect(() => {
+    const nextGoal = getLatestActiveGoalFromBlocks(blocks);
+    setActiveGoal((current) => {
+      if (!nextGoal) return current ? null : current;
+      if (
+        current?.condition === nextGoal.condition &&
+        current.setAt === nextGoal.setAt
+      ) {
+        return current;
+      }
+      return nextGoal;
+    });
+  }, [blocks]);
+
+  useEffect(() => {
     const onGoalStatusActive = (event: Event) => {
       const detail = (
         event as CustomEvent<{
@@ -1439,18 +1496,13 @@ export function App({
 
   const handleBusyGoalClear = useCallback(
     (text: string) => {
-      const goalToClear = activeGoalRef.current;
       store.appendLocalUserMessage(text);
-      dispatchGoalCleared(goalToClear);
       sessionActions.clearGoal().catch((error: unknown) => {
-        if (goalToClear) {
-          dispatchGoalSet(goalToClear.condition, goalToClear.setAt);
-        }
         reportError(error, 'Failed to clear /goal');
       });
       return true;
     },
-    [dispatchGoalCleared, dispatchGoalSet, reportError, sessionActions, store],
+    [reportError, sessionActions, store],
   );
 
   const handleGoalSlashCommand = useCallback(
@@ -1471,10 +1523,9 @@ export function App({
         }
         return handleBusyGoalClear(text);
       } else if (goalArg) {
-        const optimisticGoal = { condition: goalArg, setAt: Date.now() };
         store.appendLocalUserMessage(text);
-        dispatchGoalSet(optimisticGoal.condition, optimisticGoal.setAt);
         if (!sendToDaemon) {
+          dispatchGoalSet(goalArg, Date.now());
           return true;
         }
         sendPrompt(text, images, { optimisticUserMessage: false }).catch(
@@ -1538,10 +1589,6 @@ export function App({
             if (promptBlocked) {
               if (isGoalClearCommand(text)) {
                 return handleBusyGoalClear(text);
-              }
-              const goalArg = text.replace(/^\/goal\b/i, '').trim();
-              if (goalArg) {
-                setActiveGoal({ condition: goalArg, setAt: Date.now() });
               }
               return enqueuePrompt(text, images);
             }

--- a/packages/web-shell/client/adapters/messageTypes.ts
+++ b/packages/web-shell/client/adapters/messageTypes.ts
@@ -107,6 +107,8 @@ export interface DaemonSystemMessage extends DaemonMessageMeta {
   content: string;
   variant: 'info' | 'error' | 'warning';
   retryable?: boolean;
+  source?: string;
+  data?: unknown;
 }
 
 export interface DaemonUserShellMessage extends DaemonMessageMeta {

--- a/packages/web-shell/client/adapters/transcriptToMessages.test.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.test.ts
@@ -33,6 +33,7 @@ function statusBlock(
   id: string,
   text: string,
   createdAt: number,
+  overrides: Partial<DaemonStatusTranscriptBlock> = {},
 ): DaemonStatusTranscriptBlock {
   return {
     id,
@@ -41,6 +42,7 @@ function statusBlock(
     clientReceivedAt: createdAt,
     createdAt,
     updatedAt: createdAt,
+    ...overrides,
   };
 }
 
@@ -867,6 +869,32 @@ describe('transcriptBlocksToDaemonMessages', () => {
       role: 'system',
       content: 'Shell command exited with code 0',
     });
+  });
+
+  it('preserves structured status source and data', () => {
+    const data = {
+      kind: 'set',
+      condition: 'ship goal sync',
+      setAt: 1234,
+    };
+    const messages = transcriptBlocksToDaemonMessages([
+      statusBlock('goal-1', '', 1, {
+        source: 'goal',
+        data,
+      }),
+    ]);
+
+    expect(messages).toEqual([
+      {
+        id: 'goal-1',
+        role: 'system',
+        content: '',
+        variant: 'info',
+        source: 'goal',
+        data,
+        timestamp: 1,
+      },
+    ]);
   });
 
   it('appends shell output to preceding tool_group', () => {
@@ -1932,6 +1960,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
         content: 'Request failed',
         variant: 'error',
         retryable: true,
+        source: 'turn_error',
         timestamp: 1,
       },
     ]);

--- a/packages/web-shell/client/adapters/transcriptToMessages.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.ts
@@ -31,6 +31,11 @@ type DaemonPermissionTranscriptBlock = Extract<
   { kind: 'permission' }
 >;
 
+type ExtendedDaemonStatusTranscriptBlock = DaemonStatusTranscriptBlock & {
+  source?: string;
+  data?: unknown;
+};
+
 interface TranscriptMessageLabels {
   promptCancelled?: string;
 }
@@ -408,7 +413,8 @@ export function transcriptBlocksToDaemonMessages(
 
       case 'status':
       case 'debug': {
-        const text = (block as DaemonStatusTranscriptBlock).text;
+        const statusBlock = block as ExtendedDaemonStatusTranscriptBlock;
+        const text = statusBlock.text;
         const todos = parsePlanTodos(text);
         if (todos) {
           messages.push({
@@ -430,13 +436,15 @@ export function transcriptBlocksToDaemonMessages(
           content: text,
           variant: 'info',
           timestamp: blockTime,
+          ...(statusBlock.source ? { source: statusBlock.source } : {}),
+          ...(statusBlock.data !== undefined ? { data: statusBlock.data } : {}),
         });
         needsNewContentMessage = true;
         break;
       }
 
       case 'error': {
-        const errorBlock = block as DaemonStatusTranscriptBlock;
+        const errorBlock = block as ExtendedDaemonStatusTranscriptBlock;
         messages.push({
           id: block.id,
           role: 'system',
@@ -444,6 +452,8 @@ export function transcriptBlocksToDaemonMessages(
           variant: 'error',
           retryable: errorBlock.source === 'turn_error',
           timestamp: blockTime,
+          ...(errorBlock.source ? { source: errorBlock.source } : {}),
+          ...(errorBlock.data !== undefined ? { data: errorBlock.data } : {}),
         });
         needsNewContentMessage = true;
         break;

--- a/packages/web-shell/client/components/MessageItem.tsx
+++ b/packages/web-shell/client/components/MessageItem.tsx
@@ -75,6 +75,8 @@ export const MessageItem = memo(function MessageItem({
           <SystemMessage
             content={message.content}
             variant={message.variant}
+            source={message.source}
+            data={message.data}
             onShowContextDetail={onShowContextDetail}
             isLatest={isLatest}
             showRetryHint={showRetryHint && message.retryable === true}
@@ -161,7 +163,9 @@ function areMessagesEqual(prev: Message, next: Message): boolean {
         next.role === 'system' &&
         prev.content === next.content &&
         prev.variant === next.variant &&
-        prev.retryable === next.retryable
+        prev.retryable === next.retryable &&
+        prev.source === next.source &&
+        prev.data === next.data
       );
     case 'user_shell':
       return (

--- a/packages/web-shell/client/components/dialogs/McpDialog.tsx
+++ b/packages/web-shell/client/components/dialogs/McpDialog.tsx
@@ -22,6 +22,29 @@ interface ServerAction {
   run: () => void;
 }
 
+interface RestartEntry {
+  entryIndex: number;
+  restarted: boolean;
+  durationMs?: number;
+  reason?: string;
+}
+
+interface RestartEntriesResult {
+  serverName: string;
+  entries: RestartEntry[];
+}
+
+function isRestartEntriesResult(
+  result: unknown,
+): result is RestartEntriesResult {
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    'entries' in result &&
+    Array.isArray((result as { entries?: unknown }).entries)
+  );
+}
+
 function getServerStatus(server: DaemonWorkspaceMcpServerStatus): string {
   if (server.disabled) {
     return server.disabledReason
@@ -225,7 +248,7 @@ export function McpDialog({ onClose }: McpDialogProps) {
       setMessage(null);
       restartServer(serverName)
         .then((result) => {
-          if ('entries' in result) {
+          if (isRestartEntriesResult(result)) {
             const restartedCount = result.entries.filter(
               (entry) => entry.restarted,
             ).length;

--- a/packages/web-shell/client/components/messages/GoalStatusMessage.tsx
+++ b/packages/web-shell/client/components/messages/GoalStatusMessage.tsx
@@ -41,15 +41,44 @@ const VALID_GOAL_KINDS = new Set<string>([
 ]);
 
 function parseGoalStatusMessage(
-  content: string,
+  content: unknown,
 ): SerializedGoalStatusMessage | null {
-  const parsed = parseRawGoalStatusMessage(content);
-  if (!parsed || !parsed.kind || !parsed.condition) return null;
-  if (!VALID_GOAL_KINDS.has(parsed.kind)) return null;
-  return parsed;
+  const parsed =
+    typeof content === 'string' ? parseRawGoalStatusMessage(content) : content;
+  return normalizeGoalStatus(parsed);
 }
 
 export { serializeGoalStatusMessage, parseGoalStatusMessage };
+
+function normalizeGoalStatus(
+  value: unknown,
+): SerializedGoalStatusMessage | null {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
+  const kind = record.kind;
+  const condition = record.condition;
+  if (typeof kind !== 'string' || !VALID_GOAL_KINDS.has(kind)) return null;
+  if (typeof condition !== 'string') return null;
+  const iterations = getNumber(record.iterations);
+  const durationMs = getNumber(record.durationMs);
+  const setAt = getNumber(record.setAt);
+  const lastReason =
+    typeof record.lastReason === 'string' ? record.lastReason : undefined;
+  return {
+    kind: kind as GoalStatusKind,
+    condition,
+    ...(iterations !== undefined ? { iterations } : {}),
+    ...(durationMs !== undefined ? { durationMs } : {}),
+    ...(setAt !== undefined ? { setAt } : {}),
+    ...(lastReason !== undefined ? { lastReason } : {}),
+  };
+}
+
+function getNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}
 
 function pluralTurns(n: number, t: ReturnType<typeof useI18n>['t']): string {
   return t(n === 1 ? 'goal.turn' : 'goal.turns', { count: n });

--- a/packages/web-shell/client/components/messages/SystemMessage.tsx
+++ b/packages/web-shell/client/components/messages/SystemMessage.tsx
@@ -18,6 +18,8 @@ import styles from './SystemMessage.module.css';
 interface SystemMessageProps {
   content: string;
   variant: 'info' | 'error' | 'warning';
+  source?: string;
+  data?: unknown;
   /** Run /context detail, exactly like typing it (context-usage panels). */
   onShowContextDetail?: () => void;
   isLatest?: boolean;
@@ -28,6 +30,8 @@ interface SystemMessageProps {
 export const SystemMessage = memo(function SystemMessage({
   content,
   variant,
+  source,
+  data,
   onShowContextDetail,
   isLatest = false,
   showRetryHint = false,
@@ -85,7 +89,11 @@ export const SystemMessage = memo(function SystemMessage({
   }
 
   const goalStatus =
-    variant === 'info' ? parseGoalStatusMessage(content) : null;
+    variant === 'info'
+      ? source === 'goal'
+        ? parseGoalStatusMessage(data)
+        : parseGoalStatusMessage(content)
+      : null;
   if (goalStatus) {
     return (
       <div className={styles.flushMessage}>

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -369,6 +369,59 @@ describe('DaemonSessionProvider', () => {
     expect(sdkMocks.capabilities).toHaveBeenCalledTimes(1);
   });
 
+  it('adds daemon goal status metadata to the transcript', async () => {
+    const session = createMockSession({
+      events: async function* goalStatusEvents() {
+        yield {
+          id: 11,
+          v: 1,
+          type: 'session_update',
+          data: {
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: '' },
+              _meta: {
+                goalStatus: {
+                  kind: 'set',
+                  condition: 'ship goal sync',
+                  setAt: 1234,
+                },
+              },
+            },
+          },
+        };
+      },
+    });
+    sdkMocks.sessions.push(session);
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+
+    function Harness() {
+      blocks = useDaemonTranscriptBlocks();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      autoReconnect: false,
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(blocks).toEqual([
+      expect.objectContaining({
+        kind: 'status',
+        text: '',
+        source: 'goal',
+        data: {
+          kind: 'set',
+          condition: 'ship goal sync',
+          setAt: 1234,
+        },
+      }),
+    ]);
+  });
+
   it('publishes action error notices when no session is connected', async () => {
     let actions: DaemonUiSessionActions | undefined;
     let blocks: readonly DaemonTranscriptBlock[] = [];

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -18,7 +18,6 @@ import {
 } from 'react';
 import {
   DaemonClient,
-  DAEMON_GOAL_STATUS_SENTINEL_PREFIX,
   DaemonHttpError,
   DaemonSessionClient,
   createDaemonTranscriptStore,
@@ -1441,6 +1440,11 @@ function normalizeGoalStatusEvent(event: DaemonEvent): DaemonUiEvent | null {
   }
   const meta = update['_meta'];
   if (!isRecord(meta)) return null;
+  const status = normalizeGoalStatus(meta['goalStatus']);
+  if (status) {
+    return createGoalStatusUiEvent(event, status);
+  }
+
   const terminal = normalizeGoalTerminal(meta['goalTerminal']);
   if (terminal) {
     return createGoalStatusUiEvent(event, terminal);
@@ -1470,7 +1474,37 @@ function createGoalStatusUiEvent(
     ...(event.originatorClientId
       ? { originatorClientId: event.originatorClientId }
       : {}),
-    text: DAEMON_GOAL_STATUS_SENTINEL_PREFIX + JSON.stringify(status),
+    text: '',
+    source: 'goal',
+    data: status,
+  };
+}
+
+function normalizeGoalStatus(value: unknown): Record<string, unknown> | null {
+  if (!isRecord(value)) return null;
+  const kind = getString(value, 'kind');
+  if (
+    kind !== 'set' &&
+    kind !== 'cleared' &&
+    kind !== 'achieved' &&
+    kind !== 'failed' &&
+    kind !== 'aborted'
+  ) {
+    return null;
+  }
+  const condition = getString(value, 'condition');
+  if (!condition) return null;
+  const iterations = getNumber(value, 'iterations');
+  const durationMs = getNumber(value, 'durationMs');
+  const setAt = getNumber(value, 'setAt');
+  const lastReason = getString(value, 'lastReason');
+  return {
+    kind,
+    condition,
+    ...(iterations !== undefined ? { iterations } : {}),
+    ...(durationMs !== undefined ? { durationMs } : {}),
+    ...(setAt !== undefined ? { setAt } : {}),
+    ...(lastReason ? { lastReason } : {}),
   };
 }
 


### PR DESCRIPTION
## What this PR does

Move `/goal` state from frontend-only memory into daemon transcript events so it survives page refresh and syncs across multiple devices. The CLI now emits goal status updates as structured daemon events (`_meta.goalStatus`), which flow through the transcript as status blocks with `source: 'goal'` and a structured `data` payload. The web-shell derives active goal state from transcript blocks on connect, replacing the previous client-side optimistic dispatch that was lost on reload.

The old sentinel-prefix text encoding (`DAEMON_GOAL_STATUS_SENTINEL_PREFIX + JSON.stringify(...)`) is replaced with structured `source`/`data` fields on status transcript blocks, which is cleaner and more extensible. The old format is still parseable for backward compatibility.

## Why it's needed

Previously, `/goal` state was written only to the web-shell's frontend memory via custom DOM events. This meant: (1) refreshing the page lost the active goal display, (2) multiple browser tabs or devices could not see each other's goal state, and (3) the goal status was not part of the session transcript, making it impossible to audit or replay. By persisting goal status as first-class transcript events, the goal lifecycle (set → checking → achieved/cleared/failed) becomes fully traceable and multi-device consistent.

## Reviewer Test Plan

### How to verify

1. Start a daemon session and set a goal: `/goal write a hello world script`
2. Verify the goal pill appears in the status bar
3. Refresh the page — the goal pill should reappear from the transcript
4. Open the same session in a second browser tab — both tabs should show the same goal state
5. Clear the goal: `/goal clear` — verify the pill disappears on both tabs
6. Run existing tests: `cd packages/cli && npx vitest run src/acp-integration/acpAgent.test.ts src/acp-integration/session/emitters/MessageEmitter.test.ts src/nonInteractiveCliCommands.test.ts` and `cd packages/webui && npx vitest run src/daemon/session/DaemonSessionProvider.test.tsx` and `cd packages/web-shell && npx vitest run client/adapters/transcriptToMessages.test.ts`

### Evidence (Before & After)

Before: page refresh loses goal pill, second tab never sees goal state.
After: goal pill restored from transcript on refresh, all tabs stay in sync.



### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

`npm run dev` with local daemon, web-shell connected via browser.

## Risk & Scope

- Main risk or tradeoff: The `sendPrompt` error path for `/goal set` no longer does optimistic rollback — if the daemon call fails, the goal pill won't appear. This is acceptable since a failed goal-set means no hook was registered, so showing a pill would be misleading.
- Not validated / out of scope: Windows and Linux testing (only verified on macOS).
- Breaking changes / migration notes: The old sentinel-prefix text format is still parseable by `parseGoalStatusMessage` for backward compatibility with existing transcripts.

功能截图：
<img width="1516" height="766" alt="image" src="https://github.com/user-attachments/assets/02cda2bd-8e9a-48d1-aa69-39a159fb9c8a" />


## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 变更内容

将 `/goal` 状态从前端内存写入迁移到 daemon transcript 事件，使 goal 状态在页面刷新和多端场景下可持久化和同步。CLI 现在将 goal 状态更新作为结构化 daemon 事件（`_meta.goalStatus`）发出，这些事件以 `source: 'goal'` 和结构化 `data` 的形式流经 transcript。web-shell 在连接时从 transcript blocks 派生活跃 goal 状态，替代了之前页面刷新即丢失的客户端乐观派发方式。

旧的 sentinel 前缀文本编码（`DAEMON_GOAL_STATUS_SENTINEL_PREFIX + JSON.stringify(...)`）被替换为 status transcript block 上的结构化 `source`/`data` 字段，更清晰且更易扩展。旧格式仍可解析以保持向后兼容。

## 为什么需要这个变更

之前 `/goal` 状态仅通过自定义 DOM 事件写入 web-shell 前端内存，导致：(1) 刷新页面丢失活跃 goal 显示，(2) 多个浏览器标签页或设备无法看到彼此的 goal 状态，(3) goal 状态不在 session transcript 中，无法审计或回放。通过将 goal 状态持久化为一等 transcript 事件，goal 生命周期（set → checking → achieved/cleared/failed）变得完全可追溯且多端一致。

## 风险与范围

- 主要风险：`/goal set` 的 `sendPrompt` 错误路径不再做乐观回滚——如果 daemon 调用失败，goal 不会出现。这是可接受的，因为失败的 goal-set 意味着没有注册 hook，显示 goal 反而会误导用户。
- 未验证/不在范围内：Windows 和 Linux 测试（仅在 macOS 上验证）。
- 破坏性变更/迁移说明：旧的 sentinel 前缀文本格式仍可由 `parseGoalStatusMessage` 解析，保持与现有 transcript 的向后兼容。

</details>
