### PR TITLE
fix(core): default GLM-5.2+ and GLM-6.x onward to 1M context

### DIFF
--- a/packages/core/src/core/tokenLimits.test.ts
+++ b/packages/core/src/core/tokenLimits.test.ts
@@ -185,9 +185,30 @@ describe('tokenLimit', () => {
   });
 
   describe('Zhipu GLM', () => {
-    it('should return 200K for GLM-5 and GLM-4.7 (latest)', () => {
+    it('should default GLM-5.2+ and GLM-6.x onward to 1M (forward default)', () => {
+      expect(tokenLimit('glm-5.2')).toBe(1000000);
+      expect(tokenLimit('GLM-5.2')).toBe(1000000);
+      expect(tokenLimit('glm-5.3')).toBe(1000000);
+      expect(tokenLimit('glm-6')).toBe(1000000);
+      expect(tokenLimit('glm-6.5')).toBe(1000000);
+      expect(tokenLimit('glm-10')).toBe(1000000); // two-digit major
+    });
+
+    it('should strip third-party deploy prefixes before matching', () => {
+      expect(tokenLimit('zai/GLM-5.2')).toBe(1000000);
+      expect(tokenLimit('pai/glm-5.3')).toBe(1000000);
+      expect(tokenLimit('pai/glm-5.1')).toBe(202752);
+    });
+
+    it('should pin GLM-5 / 5.1 and GLM-4.x to 200K', () => {
       expect(tokenLimit('glm-5')).toBe(202752);
+      expect(tokenLimit('glm-5.0')).toBe(202752);
+      expect(tokenLimit('glm-5.1')).toBe(202752);
       expect(tokenLimit('glm-4.7')).toBe(202752);
+    });
+
+    it('should keep non-numeric GLM names on the conservative fallback', () => {
+      expect(tokenLimit('glm-z1')).toBe(202752);
     });
 
     it('should return 200K for legacy GLM (fallback)', () => {

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -132,8 +132,12 @@ const PATTERNS: Array<[RegExp, TokenCount]> = [
   // -------------------
   // Zhipu GLM
   // -------------------
-  [/^glm-5/, 202_752 as TokenCount], // GLM-5: exact vendor limit
-  [/^glm-/, 202_752 as TokenCount], // GLM fallback: 128K
+  // 1M context is the forward default for new GLM releases (GLM-5.2+, GLM-6.x,
+  // and beyond) so they need no future code change. Confirmed 200K families
+  // (GLM-5 / 5.0 / 5.1, GLM-4.x and older) are pinned explicitly first.
+  [/^glm-5(\.[01])?(-|$)/, 202_752 as TokenCount], // GLM-5 / 5.0 / 5.1: 200K
+  [/^glm-(?:[5-9]|\d{2,})/, LIMITS['1m']], // GLM-5.2+, 6.x..9.x, 10.x+: 1M
+  [/^glm-/, 202_752 as TokenCount], // GLM <=4.x / non-numeric fallback: 200K
 
   // -------------------
   // MiniMax


### PR DESCRIPTION
## What this PR does

Updates the GLM context-window auto-detection in `tokenLimits.ts` so that newer GLM models default to a 1M context window, while the confirmed 200K families stay pinned. The ordered rule table becomes:

```ts
[/^glm-5(\.[01])?(-|$)/, 202_752 as TokenCount], // GLM-5 / 5.0 / 5.1: 200K
[/^glm-(?:[5-9]|\d{2,})/, LIMITS['1m']],          // GLM-5.2+, 6.x..9.x, 10.x+: 1M
[/^glm-/, 202_752 as TokenCount],                 // GLM <=4.x / non-numeric fallback: 200K
```

Resulting behavior (first match wins):

| Model | Limit | Why |
|---|---|---|
| `glm-5`, `glm-5.0`, `glm-5.1` | 202752 | confirmed 200K, pinned |
| `glm-5.2`, `glm-5.3`, `glm-6.x` … `glm-9.x`, `glm-10+` | 1,000,000 | forward default for new releases |
| `glm-4.x` and older | 202752 | conservative fallback (single-digit `4` matches neither `[5-9]` nor `\d{2,}`) |
| `glm-z1` (non-numeric) | 202752 | conservative fallback |

Third-party deployment prefixes such as `pai/glm-5.3` are already stripped by `normalize()` (`s.replace(/^.*\//, '')`), so they resolve through the same rules — no extra pattern needed.

## Why it's needed

GLM-5.2 ships a 1M context window, and 1M is becoming the norm for newer GLM releases. The previous `/^glm-5/` rule capped the entire GLM-5 line at `202752`, so `glm-5.2` was auto-detected as ~200K, silently truncating its usable context. Making 1M the forward default means future GLM releases (5.3, 6.x, …), including third-party open-source deployments, get the correct window without another code change.

## Reviewer Test Plan

### How to verify

Run the token-limit unit tests:

```
npx vitest run packages/core/src/core/tokenLimits.test.ts
```

Expected: all tests pass, including the new GLM cases — `glm-5.2 / 5.3 / 6 / 6.5 / 10` and `pai/glm-5.3` resolve to `1000000`; `glm-5 / 5.0 / 5.1`, `glm-4.7`, `pai/glm-5.1`, and `glm-z1` resolve to `202752`.

### Evidence (Before & After)

Non–user-visible change (token-limit lookup table). Before: `tokenLimit('glm-5.2')` → `202752`. After: `tokenLimit('glm-5.2')` → `1000000`. Verified via the unit suite below (59 tests passing).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only (`npx vitest run`), no runtime/sandbox needed.

## Risk & Scope

- Main risk or tradeoff: a hypothetical future GLM-5.x point release that is *not* 1M would now be over-estimated as 1M. Mitigated by pinning the known 200K versions (5/5.0/5.1) explicitly; any such exception only needs one more pinned rule.
- Not validated / out of scope: output-token limits (`OUTPUT_PATTERNS`) are unchanged — `glm-5.2` keeps 16K output via `/^glm-5/`, and `glm-6+` falls back to the default output limit. This PR only touches the input/context window.
- Breaking changes / migration notes: none. Explicit `generationConfig.contextWindowSize` overrides in user settings still take precedence over this auto-detection.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

更新 `tokenLimits.ts` 里 GLM 的上下文窗口自动识别逻辑,让新版 GLM 模型默认采用 1M 上下文窗口,同时把确认为 200K 的老系列显式钉死。有序规则表变为:

```ts
[/^glm-5(\.[01])?(-|$)/, 202_752 as TokenCount], // GLM-5 / 5.0 / 5.1: 200K
[/^glm-(?:[5-9]|\d{2,})/, LIMITS['1m']],          // GLM-5.2+, 6.x..9.x, 10.x+: 1M
[/^glm-/, 202_752 as TokenCount],                 // GLM <=4.x / 非数字命名兜底: 200K
```

最终行为(有序表,先匹配先赢):

| 模型 | 上限 | 原因 |
|---|---|---|
| `glm-5`、`glm-5.0`、`glm-5.1` | 202752 | 确认 200K,钉死 |
| `glm-5.2`、`glm-5.3`、`glm-6.x` … `glm-9.x`、`glm-10+` | 1,000,000 | 新版本前向默认 |
| `glm-4.x` 及更老 | 202752 | 保守兜底(单数字 `4` 既不满足 `[5-9]` 也不满足 `\d{2,}`) |
| `glm-z1`(非数字) | 202752 | 保守兜底 |

第三方部署前缀(如 `pai/glm-5.3`)已由 `normalize()`(`s.replace(/^.*\//, '')`)剥离,走同一套规则,无需额外规则。

## 为什么需要

GLM-5.2 已支持 1M 上下文,且 1M 正成为新版 GLM 的常态。原先的 `/^glm-5/` 规则把整个 GLM-5 系列钉死在 `202752`,导致 `glm-5.2` 被识别成 ~200K,可用上下文被悄悄截断。把 1M 设为前向默认后,未来的 GLM 版本(5.3、6.x…)以及第三方开源部署都能拿到正确窗口,无需再改一次代码。

## Reviewer Test Plan

### 如何验证

运行 token-limit 单测:

```
npx vitest run packages/core/src/core/tokenLimits.test.ts
```

预期:全部通过,包括新增的 GLM 用例 —— `glm-5.2 / 5.3 / 6 / 6.5 / 10` 和 `pai/glm-5.3` 解析为 `1000000`;`glm-5 / 5.0 / 5.1`、`glm-4.7`、`pai/glm-5.1`、`glm-z1` 解析为 `202752`。

### 证据(改动前后)

非用户可见改动(token 上限查表)。改动前:`tokenLimit('glm-5.2')` → `202752`;改动后:`tokenLimit('glm-5.2')` → `1000000`。通过单测套件验证(59 个测试通过)。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境(可选)

仅单元测试(`npx vitest run`),无需运行时/沙箱。

## 风险与范围

- 主要风险/取舍:假设未来某个 GLM-5.x 小版本并非 1M,会被高估成 1M。缓解方式是已把已知的 200K 版本(5/5.0/5.1)显式钉死;若出现此类例外,只需再加一条钉死规则。
- 未验证/不在范围内:输出 token 上限(`OUTPUT_PATTERNS`)未改 —— `glm-5.2` 仍通过 `/^glm-5/` 取 16K 输出,`glm-6+` 落到默认输出上限。本 PR 只动输入/上下文窗口。
- 破坏性改动/迁移说明:无。用户设置里显式的 `generationConfig.contextWindowSize` 仍优先于此自动识别。

## 关联 Issue

无。

</details>