### PR TITLE
fix(core): Repair duplicate tool call IDs

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -13,7 +13,7 @@ import {
   fireSessionPermissionDeniedForAutoMode,
   Session,
 } from './Session.js';
-import type { Content } from '@google/genai';
+import type { Content, FunctionCall, Part } from '@google/genai';
 import type { ChatRecord, Config, GeminiChat } from '@qwen-code/qwen-code-core';
 import {
   ApprovalMode,
@@ -5070,6 +5070,61 @@ describe('Session', () => {
         );
         expect(hasPlanReminder).toBe(false);
       });
+    });
+  });
+
+  describe('runToolCalls', () => {
+    type ToolCallInternals = {
+      runToolCalls: (
+        abortSignal: AbortSignal,
+        promptId: string,
+        functionCalls: FunctionCall[],
+      ) => Promise<Part[]>;
+    };
+
+    it('executes only the first duplicate functionCall id in one batch', async () => {
+      const execute = vi.fn().mockResolvedValue({
+        llmContent: 'first result',
+        returnDisplay: 'first result',
+      });
+      mockToolRegistry.getTool.mockReturnValue({
+        name: 'read_file',
+        kind: core.Kind.Read,
+        displayName: 'Read File',
+        description: 'Read file',
+        build: vi.fn().mockReturnValue({
+          params: { file_path: 'a.ts' },
+          execute,
+          getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+          getDescription: vi.fn().mockReturnValue('Read file'),
+          toolLocations: vi.fn().mockReturnValue([]),
+        }),
+        canUpdateOutput: false,
+        isOutputMarkdown: true,
+      });
+
+      const parts = await (session as unknown as ToolCallInternals).runToolCalls(
+        new AbortController().signal,
+        'prompt-dup',
+        [
+          {
+            id: 'dup_id_0001',
+            name: 'read_file',
+            args: { file_path: 'a.ts' },
+          },
+          {
+            id: 'dup_id_0001',
+            name: 'read_file',
+            args: { file_path: 'b.ts' },
+          },
+        ],
+      );
+
+      expect(execute).toHaveBeenCalledOnce();
+      expect(parts.map((part) => part.functionResponse?.id)).toEqual([
+        'dup_id_0001',
+      ]);
+      expect(mockChatRecordingService.recordToolResult).toHaveBeenCalledOnce();
     });
   });
 

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -5126,6 +5126,51 @@ describe('Session', () => {
       ]);
       expect(mockChatRecordingService.recordToolResult).toHaveBeenCalledOnce();
     });
+
+    it('does not dedupe function calls with empty ids in one batch', async () => {
+      const execute = vi.fn().mockResolvedValue({
+        llmContent: 'result',
+        returnDisplay: 'result',
+      });
+      mockToolRegistry.getTool.mockReturnValue({
+        name: 'read_file',
+        kind: core.Kind.Read,
+        displayName: 'Read File',
+        description: 'Read file',
+        build: vi.fn().mockReturnValue({
+          params: { file_path: 'a.ts' },
+          execute,
+          getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+          getDescription: vi.fn().mockReturnValue('Read file'),
+          toolLocations: vi.fn().mockReturnValue([]),
+        }),
+        canUpdateOutput: false,
+        isOutputMarkdown: true,
+      });
+
+      const parts = await (session as unknown as ToolCallInternals).runToolCalls(
+        new AbortController().signal,
+        'prompt-empty',
+        [
+          {
+            id: '',
+            name: 'read_file',
+            args: { file_path: 'a.ts' },
+          },
+          {
+            id: '',
+            name: 'read_file',
+            args: { file_path: 'b.ts' },
+          },
+        ],
+      );
+
+      expect(execute).toHaveBeenCalledTimes(2);
+      expect(parts).toHaveLength(2);
+      expect(mockChatRecordingService.recordToolResult).toHaveBeenCalledTimes(
+        2,
+      );
+    });
   });
 
   describe('dispose', () => {

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -94,6 +94,7 @@ import {
   clearGoalTerminalObserver,
   setGoalTerminalObserver,
   sessionIdContext,
+  dedupeToolCallsById,
 } from '@qwen-code/qwen-code-core';
 import { NOT_CURRENTLY_GENERATING_CANCEL_MESSAGE } from '@qwen-code/acp-bridge/bridgeErrors';
 import { getCommandSubcommandNames } from '../../services/commandMetadata.js';
@@ -153,24 +154,6 @@ import {
 const debugLogger = createDebugLogger('SESSION');
 const USER_CANCEL_ABORT_REASON = 'qwen:user-cancel';
 const DAEMON_RETRY_META_KEY = 'qwen.daemon.retry';
-
-function dedupeFunctionCallsById(
-  functionCalls: FunctionCall[],
-): FunctionCall[] {
-  const seenIds = new Set<string>();
-  const deduped: FunctionCall[] = [];
-  for (const functionCall of functionCalls) {
-    const id = functionCall.id;
-    if (id) {
-      if (seenIds.has(id)) {
-        continue;
-      }
-      seenIds.add(id);
-    }
-    deduped.push(functionCall);
-  }
-  return deduped;
-}
 
 function maskApiKeyForDisplay(apiKey: string | undefined): string {
   const trimmed = apiKey?.trim() ?? '';
@@ -2806,7 +2789,7 @@ export class Session implements SessionContext {
   ): Promise<Part[]> {
     type Batch = { concurrent: boolean; calls: FunctionCall[] };
     const batches: Batch[] = [];
-    for (const fc of dedupeFunctionCallsById(functionCalls)) {
+    for (const fc of dedupeToolCallsById(functionCalls)) {
       const isAgent = fc.name === ToolNames.AGENT;
       const last = batches[batches.length - 1];
       if (isAgent && last?.concurrent) {

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -154,6 +154,24 @@ const debugLogger = createDebugLogger('SESSION');
 const USER_CANCEL_ABORT_REASON = 'qwen:user-cancel';
 const DAEMON_RETRY_META_KEY = 'qwen.daemon.retry';
 
+function dedupeFunctionCallsById(
+  functionCalls: FunctionCall[],
+): FunctionCall[] {
+  const seenIds = new Set<string>();
+  const deduped: FunctionCall[] = [];
+  for (const functionCall of functionCalls) {
+    const id = functionCall.id;
+    if (id) {
+      if (seenIds.has(id)) {
+        continue;
+      }
+      seenIds.add(id);
+    }
+    deduped.push(functionCall);
+  }
+  return deduped;
+}
+
 function maskApiKeyForDisplay(apiKey: string | undefined): string {
   const trimmed = apiKey?.trim() ?? '';
   if (trimmed.length === 0) return '(not set)';
@@ -2788,7 +2806,7 @@ export class Session implements SessionContext {
   ): Promise<Part[]> {
     type Batch = { concurrent: boolean; calls: FunctionCall[] };
     const batches: Batch[] = [];
-    for (const fc of functionCalls) {
+    for (const fc of dedupeFunctionCallsById(functionCalls)) {
       const isAgent = fc.name === ToolNames.AGENT;
       const last = batches[batches.length - 1];
       if (isAgent && last?.concurrent) {

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -2354,6 +2354,79 @@ describe('runNonInteractive', () => {
     expect(toolResultMessages.length).toBe(2);
   });
 
+  it('should execute only the first duplicate tool call id in stream-json format', async () => {
+    (mockConfig.getOutputFormat as Mock).mockReturnValue('stream-json');
+    (mockConfig.getIncludePartialMessages as Mock).mockReturnValue(false);
+    setupMetricsMock();
+
+    const duplicateToolCall: ServerGeminiStreamEvent = {
+      type: GeminiEventType.ToolCallRequest,
+      value: {
+        callId: 'dup_id_0001',
+        name: 'read_file',
+        args: { file_path: 'a.ts' },
+        isClientInitiated: false,
+        prompt_id: 'prompt-id-dup',
+      },
+    };
+    const replayedToolCall: ServerGeminiStreamEvent = {
+      type: GeminiEventType.ToolCallRequest,
+      value: {
+        callId: 'dup_id_0001',
+        name: 'read_file',
+        args: { file_path: 'b.ts' },
+        isClientInitiated: false,
+        prompt_id: 'prompt-id-dup',
+      },
+    };
+
+    mockCoreExecuteToolCall.mockResolvedValue({
+      responseParts: [
+        {
+          functionResponse: {
+            id: 'dup_id_0001',
+            name: 'read_file',
+            response: { output: 'first' },
+          },
+        },
+      ],
+    });
+    mockGeminiClient.sendMessageStream
+      .mockReturnValueOnce(
+        createStreamFromEvents([duplicateToolCall, replayedToolCall]),
+      )
+      .mockReturnValueOnce(
+        createStreamFromEvents([
+          { type: GeminiEventType.Content, value: 'done' },
+          {
+            type: GeminiEventType.Finished,
+            value: {
+              reason: undefined,
+              usageMetadata: { totalTokenCount: 1 },
+            },
+          },
+        ]),
+      );
+
+    await runNonInteractive(
+      mockConfig,
+      mockSettings,
+      'Duplicate tool',
+      'prompt-id-dup',
+    );
+
+    expect(mockCoreExecuteToolCall).toHaveBeenCalledOnce();
+    expect(mockCoreExecuteToolCall).toHaveBeenCalledWith(
+      mockConfig,
+      expect.objectContaining({
+        callId: 'dup_id_0001',
+        args: { file_path: 'a.ts' },
+      }),
+      expect.any(AbortSignal),
+      expect.any(Object),
+    );
+  });
+
   it('should handle userMessage with text content blocks in stream-json input mode', async () => {
     (mockConfig.getOutputFormat as Mock).mockReturnValue('stream-json');
     (mockConfig.getIncludePartialMessages as Mock).mockReturnValue(false);

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -2427,6 +2427,90 @@ describe('runNonInteractive', () => {
     );
   });
 
+  it('should execute every tool call with an empty call id in stream-json format', async () => {
+    (mockConfig.getOutputFormat as Mock).mockReturnValue('stream-json');
+    (mockConfig.getIncludePartialMessages as Mock).mockReturnValue(false);
+    setupMetricsMock();
+
+    const firstToolCall: ServerGeminiStreamEvent = {
+      type: GeminiEventType.ToolCallRequest,
+      value: {
+        callId: '',
+        name: 'read_file',
+        args: { file_path: 'a.ts' },
+        isClientInitiated: false,
+        prompt_id: 'prompt-id-empty',
+      },
+    };
+    const secondToolCall: ServerGeminiStreamEvent = {
+      type: GeminiEventType.ToolCallRequest,
+      value: {
+        callId: '',
+        name: 'read_file',
+        args: { file_path: 'b.ts' },
+        isClientInitiated: false,
+        prompt_id: 'prompt-id-empty',
+      },
+    };
+
+    mockCoreExecuteToolCall.mockResolvedValue({
+      responseParts: [
+        {
+          functionResponse: {
+            id: '',
+            name: 'read_file',
+            response: { output: 'ok' },
+          },
+        },
+      ],
+    });
+    mockGeminiClient.sendMessageStream
+      .mockReturnValueOnce(
+        createStreamFromEvents([firstToolCall, secondToolCall]),
+      )
+      .mockReturnValueOnce(
+        createStreamFromEvents([
+          { type: GeminiEventType.Content, value: 'done' },
+          {
+            type: GeminiEventType.Finished,
+            value: {
+              reason: undefined,
+              usageMetadata: { totalTokenCount: 1 },
+            },
+          },
+        ]),
+      );
+
+    await runNonInteractive(
+      mockConfig,
+      mockSettings,
+      'Empty id tools',
+      'prompt-id-empty',
+    );
+
+    expect(mockCoreExecuteToolCall).toHaveBeenCalledTimes(2);
+    expect(mockCoreExecuteToolCall).toHaveBeenNthCalledWith(
+      1,
+      mockConfig,
+      expect.objectContaining({
+        callId: '',
+        args: { file_path: 'a.ts' },
+      }),
+      expect.any(AbortSignal),
+      expect.any(Object),
+    );
+    expect(mockCoreExecuteToolCall).toHaveBeenNthCalledWith(
+      2,
+      mockConfig,
+      expect.objectContaining({
+        callId: '',
+        args: { file_path: 'b.ts' },
+      }),
+      expect.any(AbortSignal),
+      expect.any(Object),
+    );
+  });
+
   it('should handle userMessage with text content blocks in stream-json input mode', async () => {
     (mockConfig.getOutputFormat as Mock).mockReturnValue('stream-json');
     (mockConfig.getIncludePartialMessages as Mock).mockReturnValue(false);

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -744,10 +744,12 @@ export async function runNonInteractive(
         const toolResponseParts: Part[] = [];
         const seenBatchCallIds = new Set<string>();
         const uniqueBatchRequests = batchRequests.filter((request) => {
-          if (seenBatchCallIds.has(request.callId)) {
-            return false;
+          if (request.callId) {
+            if (seenBatchCallIds.has(request.callId)) {
+              return false;
+            }
+            seenBatchCallIds.add(request.callId);
           }
-          seenBatchCallIds.add(request.callId);
           return true;
         });
 

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -742,6 +742,14 @@ export async function runNonInteractive(
         setModelOverride: (override: string | undefined) => void,
       ): Promise<Part[]> => {
         const toolResponseParts: Part[] = [];
+        const seenBatchCallIds = new Set<string>();
+        const uniqueBatchRequests = batchRequests.filter((request) => {
+          if (seenBatchCallIds.has(request.callId)) {
+            return false;
+          }
+          seenBatchCallIds.add(request.callId);
+          return true;
+        });
 
         // Pre-scan: when --json-schema is active and the model emitted
         // a `structured_output` call alongside other tools in the same
@@ -750,12 +758,14 @@ export async function runNonInteractive(
         // suppress every non-structured sibling. See the multi-shape
         // examples in the main loop's prior comment for the
         // [bad/good/side-effect] permutations.
-        let requestsToExecute = batchRequests;
+        let requestsToExecute = uniqueBatchRequests;
         if (
           config.getJsonSchema() &&
-          batchRequests.some((r) => r.name === ToolNames.STRUCTURED_OUTPUT)
+          uniqueBatchRequests.some(
+            (r) => r.name === ToolNames.STRUCTURED_OUTPUT,
+          )
         ) {
-          requestsToExecute = batchRequests.filter(
+          requestsToExecute = uniqueBatchRequests.filter(
             (r) => r.name === ToolNames.STRUCTURED_OUTPUT,
           );
         }
@@ -886,7 +896,7 @@ export async function runNonInteractive(
         // emitted event log pairs every tool_use with a tool_result
         // AND the retry-turn payload (when reached) doesn't leave
         // Anthropic / OpenAI staring at unpaired tool_use blocks.
-        const unexecutedCalls = batchRequests.filter(
+        const unexecutedCalls = uniqueBatchRequests.filter(
           (r) => !executedCallIds.has(r.callId),
         );
         if (unexecutedCalls.length > 0) {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -746,6 +746,9 @@ export async function runNonInteractive(
         const uniqueBatchRequests = batchRequests.filter((request) => {
           if (request.callId) {
             if (seenBatchCallIds.has(request.callId)) {
+              debugLogger.debug(
+                `Dropping duplicate non-interactive tool callId=${request.callId} name=${request.name}`,
+              );
               return false;
             }
             seenBatchCallIds.add(request.callId);

--- a/packages/core/src/agents/runtime/agent-core.ts
+++ b/packages/core/src/agents/runtime/agent-core.ts
@@ -51,6 +51,7 @@ import type {
   GenerateContentResponseUsageMetadata,
 } from '@google/genai';
 import { GeminiChat } from '../../core/geminiChat.js';
+import { dedupeToolCallsById } from '../../core/toolCallIdUtils.js';
 import type {
   PromptConfig,
   ModelConfig,
@@ -1092,13 +1093,14 @@ export class AgentCore {
     wasOutputTruncated = false,
   ): Promise<Content[]> {
     const toolResponseParts: Part[] = [];
+    const uniqueFunctionCalls = dedupeToolCallsById(functionCalls);
 
     // Build allowed tool names set for filtering
     const allowedToolNames = new Set(toolsList.map((t) => t.name));
 
     // Filter unauthorized tool calls before scheduling
     const authorizedCalls: FunctionCall[] = [];
-    for (const fc of functionCalls) {
+    for (const fc of uniqueFunctionCalls) {
       const callId = fc.id ?? `${fc.name}-${Date.now()}`;
 
       if (!allowedToolNames.has(fc.name)) {

--- a/packages/core/src/agents/runtime/agent-headless.test.ts
+++ b/packages/core/src/agents/runtime/agent-headless.test.ts
@@ -1030,6 +1030,86 @@ describe('subagent.ts', () => {
 
         expect(scope.getTerminateMode()).toBe(AgentTerminateMode.GOAL);
       });
+
+      it('should execute only the first duplicate functionCall id in one model turn', async () => {
+        const listFilesToolDef: FunctionDeclaration = {
+          name: 'list_files',
+          description: 'Lists files',
+          parameters: { type: Type.OBJECT, properties: {} },
+        };
+
+        const { config } = await createMockConfig({
+          getFunctionDeclarationsFiltered: vi
+            .fn()
+            .mockReturnValue([listFilesToolDef]),
+          getTool: vi.fn().mockReturnValue(undefined),
+        });
+        const toolConfig: ToolConfig = { tools: ['list_files'] };
+
+        mockSendMessageStream.mockImplementation(
+          createMockStream([
+            [
+              {
+                id: 'dup_id_0001',
+                name: 'list_files',
+                args: { path: 'a' },
+              },
+              {
+                id: 'dup_id_0001',
+                name: 'list_files',
+                args: { path: 'b' },
+              },
+            ],
+            'stop',
+          ]),
+        );
+
+        const listFilesInvocation = {
+          params: { path: 'a' },
+          getDescription: vi.fn().mockReturnValue('List files'),
+          toolLocations: vi.fn().mockReturnValue([]),
+          getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+          execute: vi.fn().mockResolvedValue({
+            llmContent: 'file1.txt',
+            returnDisplay: 'Listed 1 file',
+          }),
+        };
+        const listFilesTool = {
+          name: 'list_files',
+          displayName: 'List Files',
+          description: 'List files in directory',
+          kind: 'READ' as const,
+          schema: listFilesToolDef,
+          build: vi.fn().mockImplementation(() => listFilesInvocation),
+          canUpdateOutput: false,
+          isOutputMarkdown: true,
+        } as unknown as AnyDeclarativeTool;
+        vi.mocked(
+          (config.getToolRegistry() as unknown as ToolRegistry).getTool,
+        ).mockImplementation((name: string) =>
+          name === 'list_files' ? listFilesTool : undefined,
+        );
+
+        const scope = await AgentHeadless.create(
+          'test-agent',
+          config,
+          promptConfig,
+          defaultModelConfig,
+          defaultRunConfig,
+          toolConfig,
+        );
+
+        await scope.execute(new ContextState());
+
+        expect(listFilesInvocation.execute).toHaveBeenCalledOnce();
+        const secondCallArgs = mockSendMessageStream.mock.calls[1][1];
+        const parts = secondCallArgs.message as Part[];
+        expect(
+          parts
+            .map((part) => part.functionResponse?.id)
+            .filter((id): id is string => Boolean(id)),
+        ).toEqual(['dup_id_0001']);
+      });
     });
 
     describe('execute - Termination and Recovery', () => {

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -822,6 +822,56 @@ describe('CoreToolScheduler', () => {
     );
   });
 
+  it('executes only the first request for duplicate callIds in one batch', async () => {
+    const execute = vi.fn().mockResolvedValue({
+      llmContent: 'first result',
+      returnDisplay: 'first result',
+    });
+    const toolsByName = new Map<string, MockTool>([
+      [
+        'read_file',
+        new MockTool({
+          name: 'read_file',
+          execute,
+        }),
+      ],
+    ]);
+    const { scheduler, onAllToolCallsComplete } =
+      createSchedulerForLegacyToolTests({ toolsByName });
+
+    await scheduler.schedule(
+      [
+        {
+          callId: 'dup_id_0001',
+          name: 'read_file',
+          args: { file_path: 'a.ts' },
+          isClientInitiated: false,
+          prompt_id: 'prompt-dup',
+        },
+        {
+          callId: 'dup_id_0001',
+          name: 'read_file',
+          args: { file_path: 'b.ts' },
+          isClientInitiated: false,
+          prompt_id: 'prompt-dup',
+        },
+      ],
+      new AbortController().signal,
+    );
+
+    expect(execute).toHaveBeenCalledOnce();
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({ file_path: 'a.ts' }),
+    );
+
+    const completedCalls = onAllToolCallsComplete.mock
+      .calls[0][0] as ToolCall[];
+    expect(completedCalls).toHaveLength(1);
+    expect(completedCalls.map((call) => call.request.callId)).toEqual([
+      'dup_id_0001',
+    ]);
+  });
+
   function outputOfFirstCall(
     onAllToolCallsComplete: ReturnType<typeof vi.fn>,
   ): string {

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -872,6 +872,58 @@ describe('CoreToolScheduler', () => {
     ]);
   });
 
+  it('does not dedupe requests with empty callIds in one batch', async () => {
+    const execute = vi.fn().mockResolvedValue({
+      llmContent: 'result',
+      returnDisplay: 'result',
+    });
+    const toolsByName = new Map<string, MockTool>([
+      [
+        'read_file',
+        new MockTool({
+          name: 'read_file',
+          execute,
+        }),
+      ],
+    ]);
+    const { scheduler, onAllToolCallsComplete } =
+      createSchedulerForLegacyToolTests({ toolsByName });
+
+    await scheduler.schedule(
+      [
+        {
+          callId: '',
+          name: 'read_file',
+          args: { file_path: 'a.ts' },
+          isClientInitiated: false,
+          prompt_id: 'prompt-empty',
+        },
+        {
+          callId: '',
+          name: 'read_file',
+          args: { file_path: 'b.ts' },
+          isClientInitiated: false,
+          prompt_id: 'prompt-empty',
+        },
+      ],
+      new AbortController().signal,
+    );
+
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(execute).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ file_path: 'a.ts' }),
+    );
+    expect(execute).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ file_path: 'b.ts' }),
+    );
+
+    const completedCalls = onAllToolCallsComplete.mock
+      .calls[0][0] as ToolCall[];
+    expect(completedCalls).toHaveLength(2);
+  });
+
   function outputOfFirstCall(
     onAllToolCallsComplete: ReturnType<typeof vi.fn>,
   ): string {

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -142,9 +142,7 @@ function dedupeRequestsByCallId(
     if (request.callId) {
       if (seenCallIds.has(request.callId)) {
         debugLogger.debug(
-          'dedupeRequestsByCallId: dropping duplicate callId=%s name=%s',
-          request.callId,
-          request.name,
+          `dedupeRequestsByCallId: dropping duplicate callId=${request.callId} name=${request.name}`,
         );
         continue;
       }
@@ -161,7 +159,6 @@ function dedupeRequestsByCallId(
 // and must exceed the stub size (~2.3K) to avoid cascading re-persistence.
 const GATE_HEADROOM = 3000;
 const GATE_EXEMPT_TOOLS = new Set(['read_file']);
-
 
 function extractTextFromPartListUnion(c: PartListUnion): string {
   if (typeof c === 'string') return c;

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -37,8 +37,6 @@ import {
   truncateToolOutput,
   TOOL_OUTPUT_TRUNCATED_PREFIX,
 } from '../utils/truncation.js';
-
-const debugLogger = createDebugLogger('TOOL_SCHEDULER');
 import {
   ToolConfirmationOutcome,
   ApprovalMode,
@@ -132,6 +130,23 @@ import {
 } from '../telemetry/index.js';
 import { safeJsonStringify } from '../utils/safeJsonStringify.js';
 import { acquireSleepInhibitor } from '../services/sleepInhibitor.js';
+
+const debugLogger = createDebugLogger('TOOL_SCHEDULER');
+
+function dedupeRequestsByCallId(
+  requests: ToolCallRequestInfo[],
+): ToolCallRequestInfo[] {
+  const seenCallIds = new Set<string>();
+  const deduped: ToolCallRequestInfo[] = [];
+  for (const request of requests) {
+    if (seenCallIds.has(request.callId)) {
+      continue;
+    }
+    seenCallIds.add(request.callId);
+    deduped.push(request);
+  }
+  return deduped;
+}
 
 // Gap between the persistence gate and per-tool truncation thresholds.
 // Tools that self-truncate to ~25K add headers bringing output to ~25.4K;
@@ -1664,7 +1679,9 @@ export class CoreToolScheduler {
           'Cannot schedule new tool calls while other tool calls are actively running (executing or awaiting approval).',
         );
       }
-      const requestsToProcess = Array.isArray(request) ? request : [request];
+      const requestsToProcess = dedupeRequestsByCallId(
+        Array.isArray(request) ? request : [request],
+      );
 
       // Prune validation retry state per-tool, not wholesale. Keys are
       // "<toolName>:<errorMessage>"; retain counters only for tools actually

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -139,10 +139,17 @@ function dedupeRequestsByCallId(
   const seenCallIds = new Set<string>();
   const deduped: ToolCallRequestInfo[] = [];
   for (const request of requests) {
-    if (seenCallIds.has(request.callId)) {
-      continue;
+    if (request.callId) {
+      if (seenCallIds.has(request.callId)) {
+        debugLogger.debug(
+          'dedupeRequestsByCallId: dropping duplicate callId=%s name=%s',
+          request.callId,
+          request.name,
+        );
+        continue;
+      }
+      seenCallIds.add(request.callId);
     }
-    seenCallIds.add(request.callId);
     deduped.push(request);
   }
   return deduped;

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -8,10 +8,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type {
   Content,
   GenerateContentConfig,
-  GenerateContentResponse,
   Part,
 } from '@google/genai';
-import { ApiError } from '@google/genai';
+import {
+  ApiError,
+  FinishReason,
+  GenerateContentResponse,
+} from '@google/genai';
 import { AuthType, type ContentGenerator } from '../core/contentGenerator.js';
 import {
   GeminiChat,
@@ -447,6 +450,238 @@ describe('GeminiChat', async () => {
       const modelTurn = history[1]!;
       expect(modelTurn?.parts?.length).toBe(1); // The empty part is discarded
       expect(modelTurn?.parts![0]!.functionCall).toBeDefined();
+    });
+
+    it('suffixes cross-turn reused functionCall ids before yielding and recording history', async () => {
+      chat = new GeminiChat(
+        mockConfig,
+        config,
+        [
+          { role: 'user', parts: [{ text: 'first' }] },
+          {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'dup_id_0001',
+                  name: 'read_file',
+                  args: { file_path: 'a.ts' },
+                },
+              },
+            ],
+          },
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  id: 'dup_id_0001',
+                  name: 'read_file',
+                  response: { output: 'A' },
+                },
+              },
+            ],
+          },
+        ],
+        undefined,
+        uiTelemetryService,
+      );
+
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        (async function* () {
+          yield {
+            functionCalls: [
+              {
+                id: 'dup_id_0001',
+                name: 'read_file',
+                args: { file_path: 'b.ts' },
+              },
+            ],
+            candidates: [
+              {
+                content: {
+                  role: 'model',
+                  parts: [
+                    {
+                      functionCall: {
+                        id: 'dup_id_0001',
+                        name: 'read_file',
+                        args: { file_path: 'b.ts' },
+                      },
+                    },
+                  ],
+                },
+                finishReason: 'STOP',
+              },
+            ],
+          } as unknown as GenerateContentResponse;
+        })(),
+      );
+
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'second' },
+        'prompt-id-dup-tool-call',
+      );
+      const events: StreamEvent[] = [];
+      for await (const event of stream) {
+        events.push(event);
+      }
+
+      const chunk = events.find((event) => event.type === StreamEventType.CHUNK)
+        ?.value as GenerateContentResponse | undefined;
+      expect(chunk?.functionCalls?.map((call) => call.id)).toEqual([
+        'dup_id_0001__qwen_dup_2',
+      ]);
+      expect(
+        chunk?.candidates?.[0]?.content?.parts?.map(
+          (part) => part.functionCall?.id,
+        ),
+      ).toEqual(['dup_id_0001__qwen_dup_2']);
+
+      const history = chat.getHistory();
+      expect(history.at(-1)?.parts?.[0]?.functionCall?.id).toBe(
+        'dup_id_0001__qwen_dup_2',
+      );
+    });
+
+    it('normalizes ids visible through the real GenerateContentResponse functionCalls getter', async () => {
+      chat = new GeminiChat(
+        mockConfig,
+        config,
+        [
+          {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'dup_id_0001',
+                  name: 'read_file',
+                  args: { file_path: 'a.ts' },
+                },
+              },
+            ],
+          },
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  id: 'dup_id_0001',
+                  name: 'read_file',
+                  response: { output: 'A' },
+                },
+              },
+            ],
+          },
+        ],
+        undefined,
+        uiTelemetryService,
+      );
+      const response = new GenerateContentResponse();
+      response.candidates = [
+        {
+          content: {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'dup_id_0001',
+                  name: 'read_file',
+                  args: { file_path: 'b.ts' },
+                },
+              },
+            ],
+          },
+          finishReason: FinishReason.STOP,
+        },
+      ];
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        (async function* () {
+          yield response;
+        })(),
+      );
+
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'second' },
+        'prompt-id-real-response-getter',
+      );
+      const events: StreamEvent[] = [];
+      for await (const event of stream) {
+        events.push(event);
+      }
+
+      const chunk = events.find((event) => event.type === StreamEventType.CHUNK)
+        ?.value as GenerateContentResponse | undefined;
+      expect(chunk?.functionCalls?.map((call) => call.id)).toEqual([
+        'dup_id_0001__qwen_dup_2',
+      ]);
+    });
+
+    it('drops same-turn replayed functionCall ids before yielding and recording history', async () => {
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        (async function* () {
+          yield {
+            functionCalls: [
+              { id: 'dup_id_0001', name: 'read_file', args: {} },
+              { id: 'dup_id_0001', name: 'read_file', args: {} },
+            ],
+            candidates: [
+              {
+                content: {
+                  role: 'model',
+                  parts: [
+                    {
+                      functionCall: {
+                        id: 'dup_id_0001',
+                        name: 'read_file',
+                        args: {},
+                      },
+                    },
+                    {
+                      functionCall: {
+                        id: 'dup_id_0001',
+                        name: 'read_file',
+                        args: {},
+                      },
+                    },
+                  ],
+                },
+                finishReason: 'STOP',
+              },
+            ],
+          } as unknown as GenerateContentResponse;
+        })(),
+      );
+
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'run once' },
+        'prompt-id-same-turn-dup-tool-call',
+      );
+      const events: StreamEvent[] = [];
+      for await (const event of stream) {
+        events.push(event);
+      }
+
+      const chunk = events.find((event) => event.type === StreamEventType.CHUNK)
+        ?.value as GenerateContentResponse | undefined;
+      expect(chunk?.functionCalls?.map((call) => call.id)).toEqual([
+        'dup_id_0001',
+      ]);
+      expect(
+        chunk?.candidates?.[0]?.content?.parts?.map(
+          (part) => part.functionCall?.id,
+        ),
+      ).toEqual(['dup_id_0001']);
+
+      const functionCallIds = chat
+        .getHistory()
+        .at(-1)
+        ?.parts?.map((part) => part.functionCall?.id)
+        .filter((id): id is string => Boolean(id));
+      expect(functionCallIds).toEqual(['dup_id_0001']);
     });
 
     it('should fail if the stream ends with an empty part and has no finishReason', async () => {

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -82,21 +82,37 @@ import {
 
 const debugLogger = createDebugLogger('QWEN_CODE_CHAT');
 
-function syncOwnFunctionCallsField(
+function syncFunctionCallsField(
   response: GenerateContentResponse,
   parts: readonly Part[],
 ): void {
-  const descriptor = Object.getOwnPropertyDescriptor(response, 'functionCalls');
-  if (!descriptor || (!descriptor.writable && !descriptor.set)) {
-    return;
-  }
-
   const functionCalls = parts
     .map((part) => part.functionCall)
     .filter((call): call is FunctionCall => Boolean(call));
-  (
-    response as GenerateContentResponse & { functionCalls?: FunctionCall[] }
-  ).functionCalls = functionCalls.length > 0 ? functionCalls : undefined;
+  const value = functionCalls.length > 0 ? functionCalls : undefined;
+
+  let owner: object | null = response;
+  let descriptor: PropertyDescriptor | undefined;
+  while (owner && !descriptor) {
+    descriptor = Object.getOwnPropertyDescriptor(owner, 'functionCalls');
+    owner = Object.getPrototypeOf(owner);
+  }
+
+  if (descriptor?.set) {
+    (
+      response as GenerateContentResponse & { functionCalls?: FunctionCall[] }
+    ).functionCalls = value;
+    return;
+  }
+
+  if (!descriptor || descriptor.writable || descriptor.get) {
+    Object.defineProperty(response, 'functionCalls', {
+      value,
+      writable: true,
+      configurable: true,
+      enumerable: true,
+    });
+  }
 }
 
 /**
@@ -2839,7 +2855,7 @@ export class GeminiChat {
               usedToolCallIds,
               rawToolCallIdsInCurrentTurn,
             );
-            syncOwnFunctionCallsField(chunk, content.parts);
+            syncFunctionCallsField(chunk, content.parts);
 
             if (content.parts.some((part) => part.functionCall)) {
               hasToolCall = true;

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -11,6 +11,7 @@ import type {
   GenerateContentResponse,
   Content,
   GenerateContentConfig,
+  FunctionCall,
   SendMessageParameters,
   Part,
   Tool,
@@ -74,8 +75,29 @@ import { getContextLengthExceededInfo } from '../utils/contextLengthError.js';
 import { isSystemReminderContent } from '../utils/environmentContext.js';
 import type { SessionStartSource } from '../hooks/types.js';
 import { getCustomSystemPrompt } from './prompts.js';
+import {
+  collectToolCallIdsFromHistory,
+  normalizeModelToolCallIds,
+} from './toolCallIdUtils.js';
 
 const debugLogger = createDebugLogger('QWEN_CODE_CHAT');
+
+function syncOwnFunctionCallsField(
+  response: GenerateContentResponse,
+  parts: readonly Part[],
+): void {
+  const descriptor = Object.getOwnPropertyDescriptor(response, 'functionCalls');
+  if (!descriptor || (!descriptor.writable && !descriptor.set)) {
+    return;
+  }
+
+  const functionCalls = parts
+    .map((part) => part.functionCall)
+    .filter((call): call is FunctionCall => Boolean(call));
+  (
+    response as GenerateContentResponse & { functionCalls?: FunctionCall[] }
+  ).functionCalls = functionCalls.length > 0 ? functionCalls : undefined;
+}
 
 /**
  * Replaces the args on a `structured_output` `functionCall` with the
@@ -2779,6 +2801,8 @@ export class GeminiChat {
   ): AsyncGenerator<GenerateContentResponse> {
     // Collect ALL parts from the model response (including thoughts for recording)
     const allModelParts: Part[] = [];
+    const usedToolCallIds = collectToolCallIdsFromHistory(this.history);
+    const rawToolCallIdsInCurrentTurn = new Set<string>();
     let usageMetadata: GenerateContentResponseUsageMetadata | undefined;
     let coercedUsage:
       | {
@@ -2810,6 +2834,13 @@ export class GeminiChat {
         if (isValidResponse(chunk)) {
           const content = chunk.candidates?.[0]?.content;
           if (content?.parts) {
+            content.parts = normalizeModelToolCallIds(
+              content.parts,
+              usedToolCallIds,
+              rawToolCallIdsInCurrentTurn,
+            );
+            syncOwnFunctionCallsField(chunk, content.parts);
+
             if (content.parts.some((part) => part.functionCall)) {
               hasToolCall = true;
             }

--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -64,6 +64,36 @@ describe('OpenAIContentConverter', () => {
     };
   }
 
+  function hasOpenAIToolCalls(
+    message: OpenAI.Chat.ChatCompletionMessageParam,
+  ): message is OpenAI.Chat.ChatCompletionAssistantMessageParam & {
+    tool_calls: OpenAI.Chat.ChatCompletionMessageToolCall[];
+  } {
+    return (
+      message.role === 'assistant' &&
+      'tool_calls' in message &&
+      Array.isArray(message.tool_calls)
+    );
+  }
+
+  function isOpenAISplitMediaMessage(
+    message: OpenAI.Chat.ChatCompletionMessageParam,
+  ): boolean {
+    return (
+      message.role === 'user' &&
+      Array.isArray(message.content) &&
+      message.content.some((part) => {
+        const typedPart = part as { type?: string };
+        return (
+          typedPart.type === 'image_url' ||
+          typedPart.type === 'input_audio' ||
+          typedPart.type === 'video_url' ||
+          typedPart.type === 'file'
+        );
+      })
+    );
+  }
+
   describe('stream-local parser state', () => {
     it('creates fresh parser instances', () => {
       const ctx1 = new StreamingToolCallParser();
@@ -89,6 +119,39 @@ describe('OpenAIContentConverter', () => {
       expect(ctx2.getBuffer(0)).toBe('{"b":2}');
       expect(ctx1.getToolCallMeta(0).id).toBe('call_A');
       expect(ctx2.getToolCallMeta(0).id).toBe('call_B');
+    });
+
+    it('ignores replay chunks after an id already has complete JSON args', () => {
+      const parser = new StreamingToolCallParser();
+
+      parser.addChunk(0, '{"cmd":"echo hi"}', 'dup_id_0001', 'shell');
+      parser.addChunk(0, '{"cmd":"echo hi"}', 'dup_id_0001', 'shell');
+
+      expect(parser.getBuffer(0)).toBe('{"cmd":"echo hi"}');
+      expect(parser.getCompletedToolCalls()).toEqual([
+        {
+          id: 'dup_id_0001',
+          name: 'shell',
+          args: { cmd: 'echo hi' },
+          index: 0,
+        },
+      ]);
+    });
+
+    it('keeps accumulating normal fragmented JSON before it is complete', () => {
+      const parser = new StreamingToolCallParser();
+
+      parser.addChunk(0, '{"cmd"', 'call_fragmented', 'shell');
+      parser.addChunk(0, ':"echo hi"}', 'call_fragmented', 'shell');
+
+      expect(parser.getCompletedToolCalls()).toEqual([
+        {
+          id: 'call_fragmented',
+          name: 'shell',
+          args: { cmd: 'echo hi' },
+          index: 0,
+        },
+      ]);
     });
 
     it('demuxes interleaved chunks from two concurrent streams correctly (#3516)', () => {
@@ -281,10 +344,10 @@ describe('OpenAIContentConverter', () => {
         ],
       };
 
-      const messages = converter.convertGeminiRequestToOpenAI(
-        request,
-        requestContext,
-      );
+      const messages = converter.convertGeminiRequestToOpenAI(request, {
+        ...requestContext,
+        splitToolMedia: true,
+      });
 
       expect(messages).toEqual([
         {
@@ -302,10 +365,10 @@ describe('OpenAIContentConverter', () => {
         output: 'Raw output text',
       });
 
-      const messages = converter.convertGeminiRequestToOpenAI(
-        request,
-        requestContext,
-      );
+      const messages = converter.convertGeminiRequestToOpenAI(request, {
+        ...requestContext,
+        splitToolMedia: true,
+      });
       const toolMessage = messages.find((message) => message.role === 'tool');
 
       expect(toolMessage).toBeDefined();
@@ -1678,6 +1741,143 @@ describe('OpenAIContentConverter', () => {
         false,
       );
       expect(messages.some((message) => message.role === 'tool')).toBe(false);
+    });
+
+    it('should drop later assistant tool calls that reuse a previous surviving id', () => {
+      const request: GenerateContentParameters = {
+        model: 'models/test',
+        contents: [
+          {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'dup_id_0001',
+                  name: 'read_file',
+                  args: { file_path: 'a.ts' },
+                },
+              },
+            ],
+          },
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  id: 'dup_id_0001',
+                  name: 'read_file',
+                  response: { output: 'A' },
+                },
+              },
+            ],
+          },
+          {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'dup_id_0001',
+                  name: 'read_file',
+                  args: { file_path: 'b.ts' },
+                },
+              },
+            ],
+          },
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  id: 'dup_id_0001',
+                  name: 'read_file',
+                  response: { output: 'B' },
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      const messages = converter.convertGeminiRequestToOpenAI(
+        request,
+        requestContext,
+      );
+
+      const assistantToolCallIds = messages.flatMap((message) =>
+        hasOpenAIToolCalls(message)
+          ? message.tool_calls.map((toolCall) => toolCall.id)
+          : [],
+      );
+      const toolResultIds = messages
+        .filter(
+          (message): message is OpenAI.Chat.ChatCompletionToolMessageParam =>
+            message.role === 'tool' && 'tool_call_id' in message,
+        )
+        .map((message) => message.tool_call_id);
+
+      expect(assistantToolCallIds).toEqual(['dup_id_0001']);
+      expect(toolResultIds).toEqual(['dup_id_0001']);
+    });
+
+    it('should keep only the first adjacent tool response and its split media for a surviving id', () => {
+      const request: GenerateContentParameters = {
+        model: 'models/test',
+        contents: [
+          {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'call_image',
+                  name: 'screenshot',
+                  args: {},
+                },
+              },
+            ],
+          },
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  id: 'call_image',
+                  name: 'screenshot',
+                  response: { output: 'first' },
+                  parts: [
+                    { inlineData: { mimeType: 'image/png', data: 'first' } },
+                  ],
+                },
+              },
+              {
+                functionResponse: {
+                  id: 'call_image',
+                  name: 'screenshot',
+                  response: { output: 'second' },
+                  parts: [
+                    { inlineData: { mimeType: 'image/png', data: 'second' } },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      const messages = converter.convertGeminiRequestToOpenAI(request, {
+        ...requestContext,
+        splitToolMedia: true,
+      });
+      const toolMessages = messages.filter(
+        (message): message is OpenAI.Chat.ChatCompletionToolMessageParam =>
+          message.role === 'tool' && 'tool_call_id' in message,
+      );
+      const splitMediaMessages = messages.filter(isOpenAISplitMediaMessage);
+
+      expect(toolMessages).toHaveLength(1);
+      expect(toolMessages[0]?.content).toBe('first');
+      expect(splitMediaMessages).toHaveLength(1);
+      expect(JSON.stringify(splitMediaMessages[0])).toContain('first');
+      expect(JSON.stringify(splitMediaMessages[0])).not.toContain('second');
     });
 
     it('should keep a tool response after an empty-id tool message', () => {

--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -1819,6 +1819,57 @@ describe('OpenAIContentConverter', () => {
       expect(toolResultIds).toEqual(['dup_id_0001']);
     });
 
+    it('should drop duplicate tool call IDs within a single assistant message', () => {
+      const request: GenerateContentParameters = {
+        model: 'models/test',
+        contents: [
+          {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'dup_id_0001',
+                  name: 'read_file',
+                  args: { file_path: 'a.ts' },
+                },
+              },
+              {
+                functionCall: {
+                  id: 'dup_id_0001',
+                  name: 'read_file',
+                  args: { file_path: 'b.ts' },
+                },
+              },
+            ],
+          },
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  id: 'dup_id_0001',
+                  name: 'read_file',
+                  response: { output: 'A' },
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      const messages = converter.convertGeminiRequestToOpenAI(
+        request,
+        requestContext,
+      );
+      const assistant = messages.find(hasOpenAIToolCalls);
+
+      expect(assistant?.tool_calls).toHaveLength(1);
+      expect(assistant?.tool_calls?.[0].id).toBe('dup_id_0001');
+      expect(assistant?.tool_calls?.[0].function.arguments).toBe(
+        JSON.stringify({ file_path: 'a.ts' }),
+      );
+    });
+
     it('should keep only the first adjacent tool response and its split media for a surviving id', () => {
       const request: GenerateContentParameters = {
         model: 'models/test',

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -545,6 +545,7 @@ function processContent(
   const reasoningParts: string[] = [];
   const toolCalls: OpenAI.Chat.ChatCompletionMessageToolCall[] = [];
   let toolCallIndex = 0;
+  const emittedFunctionResponseIds = new Set<string>();
   // When `splitToolMedia` is enabled, media stripped from tool messages is
   // accumulated here and emitted as a single follow-up user message after
   // ALL tool messages in this group have been pushed. OpenAI Chat
@@ -588,6 +589,14 @@ function processContent(
     }
 
     if (part.functionResponse && role === 'user') {
+      const responseId = part.functionResponse.id;
+      if (responseId) {
+        if (emittedFunctionResponseIds.has(responseId)) {
+          continue;
+        }
+        emittedFunctionResponseIds.add(responseId);
+      }
+
       // Create tool message for the function response (with embedded media)
       const toolMessage = createToolMessage(
         part.functionResponse,
@@ -1436,19 +1445,33 @@ function cleanOrphanedToolCalls(
   messages: OpenAI.Chat.ChatCompletionMessageParam[],
 ): OpenAI.Chat.ChatCompletionMessageParam[] {
   const cleaned: OpenAI.Chat.ChatCompletionMessageParam[] = [];
-  const adjacentToolResponseIdsByAssistant = new Map<number, Set<string>>();
+  const validToolCallsByAssistant = new Map<
+    number,
+    OpenAI.Chat.ChatCompletionMessageToolCall[]
+  >();
   const validToolResponseIndexesByAssistant = new Map<number, number[]>();
   const splitMediaIndexesByAssistant = new Map<number, number[]>();
   const emittedWithAssistant = new Set<number>();
+  const survivingToolCallIds = new Set<string>();
 
   for (let index = 0; index < messages.length; index += 1) {
     const message = messages[index];
     if (hasToolCalls(message)) {
-      const toolCallIds = new Set(
-        message.tool_calls
-          .map((toolCall) => toolCall.id)
-          .filter((id): id is string => Boolean(id)),
-      );
+      const candidateToolCalls: OpenAI.Chat.ChatCompletionMessageToolCall[] =
+        [];
+      const candidateToolCallIds = new Set<string>();
+      for (const toolCall of message.tool_calls) {
+        const id = toolCall.id;
+        if (!id || survivingToolCallIds.has(id)) {
+          continue;
+        }
+        if (candidateToolCallIds.has(id)) {
+          continue;
+        }
+        candidateToolCallIds.add(id);
+        candidateToolCalls.push(toolCall);
+      }
+
       const adjacentToolResponseIds = new Set<string>();
       const toolResponseIndexes: number[] = [];
       const splitMediaIndexes: number[] = [];
@@ -1466,7 +1489,10 @@ function cleanOrphanedToolCalls(
             continue;
           }
 
-          if (toolCallIds.has(nextMessage.tool_call_id)) {
+          if (
+            candidateToolCallIds.has(nextMessage.tool_call_id) &&
+            !adjacentToolResponseIds.has(nextMessage.tool_call_id)
+          ) {
             adjacentToolResponseIds.add(nextMessage.tool_call_id);
             toolResponseIndexes.push(nextIndex);
             lastToolResponseMatchesAssistant = true;
@@ -1493,7 +1519,13 @@ function cleanOrphanedToolCalls(
         break;
       }
 
-      adjacentToolResponseIdsByAssistant.set(index, adjacentToolResponseIds);
+      const validToolCalls = candidateToolCalls.filter((toolCall) =>
+        adjacentToolResponseIds.has(toolCall.id),
+      );
+      for (const toolCall of validToolCalls) {
+        survivingToolCallIds.add(toolCall.id);
+      }
+      validToolCallsByAssistant.set(index, validToolCalls);
       validToolResponseIndexesByAssistant.set(index, toolResponseIndexes);
       splitMediaIndexesByAssistant.set(index, splitMediaIndexes);
     }
@@ -1509,11 +1541,7 @@ function cleanOrphanedToolCalls(
       const reasoningContent = (
         message as ExtendedChatCompletionAssistantMessageParam
       ).reasoning_content;
-      const adjacentToolResponseIds =
-        adjacentToolResponseIdsByAssistant.get(index) ?? new Set<string>();
-      const validToolCalls = message.tool_calls.filter(
-        (toolCall) => toolCall.id && adjacentToolResponseIds.has(toolCall.id),
-      );
+      const validToolCalls = validToolCallsByAssistant.get(index) ?? [];
 
       if (validToolCalls.length > 0) {
         const cleanedMessage = { ...message };

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -545,7 +545,11 @@ function processContent(
   const reasoningParts: string[] = [];
   const toolCalls: OpenAI.Chat.ChatCompletionMessageToolCall[] = [];
   let toolCallIndex = 0;
+  const emittedFunctionCallIds = new Set<string>();
   const emittedFunctionResponseIds = new Set<string>();
+  // New history is normalized before reaching this converter. These local
+  // guards only keep already-corrupted or programmatic duplicate parts from
+  // leaking duplicate IDs into OpenAI payloads.
   // When `splitToolMedia` is enabled, media stripped from tool messages is
   // accumulated here and emitted as a single follow-up user message after
   // ALL tool messages in this group have been pushed. OpenAI Chat
@@ -577,8 +581,19 @@ function processContent(
     }
 
     if ('functionCall' in part && part.functionCall && role === 'assistant') {
+      const callId = part.functionCall.id;
+      if (callId) {
+        if (emittedFunctionCallIds.has(callId)) {
+          debugLogger.debug(
+            `Dropping duplicate functionCall id=${callId} while converting content`,
+          );
+          continue;
+        }
+        emittedFunctionCallIds.add(callId);
+      }
+
       toolCalls.push({
-        id: part.functionCall.id || `call_${toolCallIndex}`,
+        id: callId || `call_${toolCallIndex}`,
         type: 'function' as const,
         function: {
           name: part.functionCall.name || '',

--- a/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.test.ts
@@ -541,7 +541,7 @@ describe('StreamingToolCallParser', () => {
   });
 
   describe('Tool call ID collision detection and mapping', () => {
-    it('should handle tool call ID reuse correctly', () => {
+    it('should ignore replay chunks after a tool call ID completes', () => {
       // First tool call with ID 'call_1' at index 0
       const result1 = parser.addChunk(
         0,
@@ -551,24 +551,21 @@ describe('StreamingToolCallParser', () => {
       );
       expect(result1.complete).toBe(true);
 
-      // Second tool call with same ID 'call_1' should reuse the same internal index
-      // and append to the buffer (this is the actual behavior)
+      // Once the ID has complete JSON, later chunks with the same ID are
+      // provider replay and must not mutate the surviving call.
       const result2 = parser.addChunk(
         0,
         '{"param2": "value2"}',
         'call_1',
         'function2',
       );
-      expect(result2.complete).toBe(false); // Not complete because buffer is malformed
+      expect(result2.complete).toBe(false);
 
-      // Should have updated the metadata but appended to buffer
       expect(parser.getToolCallMeta(0)).toEqual({
         id: 'call_1',
-        name: 'function2',
+        name: 'function1',
       });
-      expect(parser.getBuffer(0)).toBe(
-        '{"param1": "value1"}{"param2": "value2"}',
-      );
+      expect(parser.getBuffer(0)).toBe('{"param1": "value1"}');
     });
 
     it('should detect index collision and find new index', () => {

--- a/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.test.ts
@@ -568,6 +568,26 @@ describe('StreamingToolCallParser', () => {
       expect(parser.getBuffer(0)).toBe('{"param1": "value1"}');
     });
 
+    it('should ignore metadata-only replay chunks after a tool call ID completes', () => {
+      parser.addChunk(0, '{"file_path": "a.ts"}', 'call_1', 'read_file');
+
+      const result = parser.addChunk(0, '', 'call_1', 'shell');
+
+      expect(result.complete).toBe(false);
+      expect(parser.getToolCallMeta(0)).toEqual({
+        id: 'call_1',
+        name: 'read_file',
+      });
+      expect(parser.getCompletedToolCalls()).toEqual([
+        {
+          id: 'call_1',
+          name: 'read_file',
+          args: { file_path: 'a.ts' },
+          index: 0,
+        },
+      ]);
+    });
+
     it('should detect index collision and find new index', () => {
       // First complete tool call at index 0
       parser.addChunk(0, '{"param1": "value1"}', 'call_1', 'function1');

--- a/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.ts
+++ b/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.ts
@@ -69,6 +69,7 @@ export class StreamingToolCallParser {
     name?: string,
   ): ToolCallParseResult {
     let actualIndex = index;
+    const isKnownId = Boolean(id && this.idToIndexMap.has(id));
 
     // Handle tool call ID mapping for collision detection
     if (id) {
@@ -140,25 +141,25 @@ export class StreamingToolCallParser {
       this.toolCallMeta.set(actualIndex, {});
     }
 
+    const currentBuffer = this.buffers.get(actualIndex)!;
+    const currentDepth = this.depths.get(actualIndex)!;
+    if (isKnownId && chunk && currentBuffer.trim() && currentDepth === 0) {
+      try {
+        JSON.parse(currentBuffer);
+        return { complete: false };
+      } catch {
+        // Not complete yet; append the incoming chunk below.
+      }
+    }
+
     // Update metadata
     const meta = this.toolCallMeta.get(actualIndex)!;
     if (id) meta.id = id;
     if (name) meta.name = name;
 
     // Get current state for the actual index
-    const currentBuffer = this.buffers.get(actualIndex)!;
-    const currentDepth = this.depths.get(actualIndex)!;
     const currentInString = this.inStrings.get(actualIndex)!;
     const currentEscape = this.escapes.get(actualIndex)!;
-
-    if (id && chunk && currentBuffer.trim() && currentDepth === 0) {
-      try {
-        const parsed = JSON.parse(currentBuffer);
-        return { complete: true, value: parsed };
-      } catch {
-        // Not complete yet; append the incoming chunk below.
-      }
-    }
 
     // Add chunk to buffer
     const newBuffer = currentBuffer + chunk;

--- a/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.ts
+++ b/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.ts
@@ -151,6 +151,15 @@ export class StreamingToolCallParser {
     const currentInString = this.inStrings.get(actualIndex)!;
     const currentEscape = this.escapes.get(actualIndex)!;
 
+    if (id && chunk && currentBuffer.trim() && currentDepth === 0) {
+      try {
+        const parsed = JSON.parse(currentBuffer);
+        return { complete: true, value: parsed };
+      } catch {
+        // Not complete yet; append the incoming chunk below.
+      }
+    }
+
     // Add chunk to buffer
     const newBuffer = currentBuffer + chunk;
     this.buffers.set(actualIndex, newBuffer);
@@ -245,10 +254,18 @@ export class StreamingToolCallParser {
       args: Record<string, unknown>;
       index: number;
     }> = [];
+    const emittedIds = new Set<string>();
 
     for (const [index, buffer] of this.buffers.entries()) {
       const meta = this.toolCallMeta.get(index);
       if (meta?.name && buffer.trim()) {
+        if (meta.id) {
+          if (emittedIds.has(meta.id)) {
+            continue;
+          }
+          emittedIds.add(meta.id);
+        }
+
         let args: Record<string, unknown> = {};
 
         // Try to parse the final buffer

--- a/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.ts
+++ b/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.ts
@@ -5,6 +5,9 @@
  */
 
 import { safeJsonParse } from '../../utils/safeJsonParse.js';
+import { createDebugLogger } from '../../utils/debugLogger.js';
+
+const debugLogger = createDebugLogger('STREAMING_TOOL_CALL_PARSER');
 
 /**
  * Type definition for the result of parsing a JSON chunk in tool calls
@@ -143,9 +146,12 @@ export class StreamingToolCallParser {
 
     const currentBuffer = this.buffers.get(actualIndex)!;
     const currentDepth = this.depths.get(actualIndex)!;
-    if (isKnownId && chunk && currentBuffer.trim() && currentDepth === 0) {
+    if (isKnownId && currentBuffer.trim() && currentDepth === 0) {
       try {
         JSON.parse(currentBuffer);
+        debugLogger.debug(
+          `Ignoring replay chunk for completed toolCall id=${id}`,
+        );
         return { complete: false };
       } catch {
         // Not complete yet; append the incoming chunk below.

--- a/packages/core/src/core/toolCallIdUtils.test.ts
+++ b/packages/core/src/core/toolCallIdUtils.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { Content, Part } from '@google/genai';
+import {
+  collectToolCallIdsFromHistory,
+  dedupeToolCallsById,
+  normalizeModelToolCallIds,
+} from './toolCallIdUtils.js';
+
+describe('toolCallIdUtils', () => {
+  it('suffixes cross-turn duplicate ids and drops same-turn replays', () => {
+    const history: Content[] = [
+      {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              id: 'dup_id_0001',
+              name: 'read_file',
+              args: { file_path: 'a.ts' },
+            },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              id: 'dup_id_0001',
+              name: 'read_file',
+              response: { output: 'A' },
+            },
+          },
+        ],
+      },
+    ];
+    const seenIds = collectToolCallIdsFromHistory(history);
+    const turnRawIds = new Set<string>();
+    const parts: Part[] = [
+      {
+        functionCall: {
+          id: 'dup_id_0001',
+          name: 'read_file',
+          args: { file_path: 'b.ts' },
+        },
+      },
+      {
+        functionCall: {
+          id: 'dup_id_0001',
+          name: 'read_file',
+          args: { file_path: 'b.ts' },
+        },
+      },
+      { text: 'done' },
+    ];
+
+    const normalized = normalizeModelToolCallIds(parts, seenIds, turnRawIds);
+
+    expect(normalized).toEqual([
+      {
+        functionCall: {
+          id: 'dup_id_0001__qwen_dup_2',
+          name: 'read_file',
+          args: { file_path: 'b.ts' },
+        },
+      },
+      { text: 'done' },
+    ]);
+    expect(seenIds.has('dup_id_0001__qwen_dup_2')).toBe(true);
+  });
+
+  it('generates stable non-empty ids for missing functionCall ids', () => {
+    const seenIds = new Set<string>(['call_qwen_1']);
+
+    const normalized = normalizeModelToolCallIds(
+      [
+        { functionCall: { name: 'first', args: {} } },
+        { functionCall: { name: 'second', args: {} } },
+      ],
+      seenIds,
+      new Set<string>(),
+    );
+
+    expect(normalized.map((part) => part.functionCall?.id)).toEqual([
+      'call_qwen_2',
+      'call_qwen_3',
+    ]);
+  });
+
+  it('deduplicates direct function call batches by id', () => {
+    const calls = [
+      { id: 'call_1', name: 'read_file', args: { file_path: 'a.ts' } },
+      { id: 'call_1', name: 'read_file', args: { file_path: 'a.ts' } },
+      { id: 'call_2', name: 'read_file', args: { file_path: 'b.ts' } },
+      { name: 'missing_id', args: {} },
+      { name: 'missing_id_again', args: {} },
+    ];
+
+    expect(dedupeToolCallsById(calls)).toEqual([
+      calls[0],
+      calls[2],
+      calls[3],
+      calls[4],
+    ]);
+  });
+});

--- a/packages/core/src/core/toolCallIdUtils.ts
+++ b/packages/core/src/core/toolCallIdUtils.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Content, FunctionCall, Part } from '@google/genai';
+
+const DUPLICATE_ID_SUFFIX = '__qwen_dup_';
+const GENERATED_ID_PREFIX = 'call_qwen_';
+
+function addId(ids: Set<string>, id: string | undefined): void {
+  if (id) {
+    ids.add(id);
+  }
+}
+
+function nextAvailableDuplicateId(rawId: string, usedIds: Set<string>): string {
+  if (!usedIds.has(rawId)) {
+    return rawId;
+  }
+
+  for (let suffix = 2; ; suffix += 1) {
+    const candidate = `${rawId}${DUPLICATE_ID_SUFFIX}${suffix}`;
+    if (!usedIds.has(candidate)) {
+      return candidate;
+    }
+  }
+}
+
+function nextGeneratedId(usedIds: Set<string>): string {
+  for (let suffix = 1; ; suffix += 1) {
+    const candidate = `${GENERATED_ID_PREFIX}${suffix}`;
+    if (!usedIds.has(candidate)) {
+      return candidate;
+    }
+  }
+}
+
+export function collectToolCallIdsFromHistory(
+  history: readonly Content[],
+): Set<string> {
+  const ids = new Set<string>();
+  for (const content of history) {
+    for (const part of content.parts ?? []) {
+      addId(ids, part.functionCall?.id);
+      addId(ids, part.functionResponse?.id);
+    }
+  }
+  return ids;
+}
+
+export function normalizeModelToolCallIds(
+  parts: readonly Part[],
+  usedIds: Set<string>,
+  rawIdsInCurrentTurn: Set<string>,
+): Part[] {
+  const normalized: Part[] = [];
+
+  for (const part of parts) {
+    const functionCall = part.functionCall;
+    if (!functionCall) {
+      normalized.push(part);
+      continue;
+    }
+
+    const rawId = functionCall.id;
+    if (rawId) {
+      if (rawIdsInCurrentTurn.has(rawId)) {
+        continue;
+      }
+      rawIdsInCurrentTurn.add(rawId);
+    }
+
+    const id = rawId
+      ? nextAvailableDuplicateId(rawId, usedIds)
+      : nextGeneratedId(usedIds);
+    usedIds.add(id);
+
+    normalized.push({
+      ...part,
+      functionCall: {
+        ...functionCall,
+        id,
+      },
+    });
+  }
+
+  return normalized;
+}
+
+export function dedupeToolCallsById<T extends Pick<FunctionCall, 'id'>>(
+  functionCalls: readonly T[],
+): T[] {
+  const seenIds = new Set<string>();
+  const deduped: T[] = [];
+
+  for (const functionCall of functionCalls) {
+    const id = functionCall.id;
+    if (id) {
+      if (seenIds.has(id)) {
+        continue;
+      }
+      seenIds.add(id);
+    }
+    deduped.push(functionCall);
+  }
+
+  return deduped;
+}

--- a/packages/core/src/core/toolCallIdUtils.ts
+++ b/packages/core/src/core/toolCallIdUtils.ts
@@ -5,9 +5,11 @@
  */
 
 import type { Content, FunctionCall, Part } from '@google/genai';
+import { createDebugLogger } from '../utils/debugLogger.js';
 
 const DUPLICATE_ID_SUFFIX = '__qwen_dup_';
 const GENERATED_ID_PREFIX = 'call_qwen_';
+const debugLogger = createDebugLogger('TOOL_CALL_IDS');
 
 function addId(ids: Set<string>, id: string | undefined): void {
   if (id) {
@@ -67,6 +69,9 @@ export function normalizeModelToolCallIds(
     const rawId = functionCall.id;
     if (rawId) {
       if (rawIdsInCurrentTurn.has(rawId)) {
+        debugLogger.debug(
+          `Dropping same-turn duplicate functionCall id=${rawId} name=${functionCall.name}`,
+        );
         continue;
       }
       rawIdsInCurrentTurn.add(rawId);
@@ -75,6 +80,11 @@ export function normalizeModelToolCallIds(
     const id = rawId
       ? nextAvailableDuplicateId(rawId, usedIds)
       : nextGeneratedId(usedIds);
+    if (rawId && id !== rawId) {
+      debugLogger.debug(
+        `Suffixing cross-turn duplicate functionCall id=${rawId} normalizedId=${id} name=${functionCall.name}`,
+      );
+    }
     usedIds.add(id);
 
     normalized.push({
@@ -99,6 +109,7 @@ export function dedupeToolCallsById<T extends Pick<FunctionCall, 'id'>>(
     const id = functionCall.id;
     if (id) {
       if (seenIds.has(id)) {
+        debugLogger.debug(`Dropping duplicate functionCall id=${id}`);
         continue;
       }
       seenIds.add(id);

--- a/packages/core/src/followup/speculation.test.ts
+++ b/packages/core/src/followup/speculation.test.ts
@@ -4,9 +4,106 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
-import { ensureToolResultPairing } from './speculation.js';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import {
+  abortSpeculation,
+  ensureToolResultPairing,
+  startSpeculation,
+} from './speculation.js';
 import type { Content } from '@google/genai';
+import { ApprovalMode, type Config } from '../config/config.js';
+
+const forkedAgentMocks = vi.hoisted(() => ({
+  runForkedAgent: vi.fn(),
+  sendMessageStream: vi.fn(),
+}));
+
+vi.mock('../utils/forkedAgent.js', () => ({
+  getCacheSafeParams: vi.fn(() => ({
+    generationConfig: {},
+    history: [],
+    model: 'qwen-fast',
+    version: 1,
+  })),
+  createForkedChat: vi.fn(() => ({
+    sendMessageStream: forkedAgentMocks.sendMessageStream,
+  })),
+  runForkedAgent: forkedAgentMocks.runForkedAgent,
+  runWithForkedChatModel: vi.fn(
+    async (
+      _config: Config,
+      model: string,
+      callback: (model: string) => Promise<unknown>,
+    ) => callback(model),
+  ),
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('startSpeculation', () => {
+  it('preserves generated tool call ids in paired responses', async () => {
+    const execute = vi.fn().mockResolvedValue({
+      llmContent: 'file contents',
+      returnDisplay: 'file contents',
+    });
+    const toolRegistry = {
+      ensureTool: vi.fn().mockResolvedValue({
+        build: vi.fn().mockReturnValue({ execute }),
+      }),
+    };
+    const config = {
+      getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
+      getCwd: vi.fn().mockReturnValue(process.cwd()),
+      getFastModel: vi.fn().mockReturnValue(undefined),
+      getToolRegistry: vi.fn().mockReturnValue(toolRegistry),
+    } as unknown as Config;
+
+    forkedAgentMocks.runForkedAgent.mockResolvedValue({
+      jsonResult: { suggestion: '' },
+    });
+    forkedAgentMocks.sendMessageStream.mockImplementation(
+      async function* () {
+        if (forkedAgentMocks.sendMessageStream.mock.calls.length === 1) {
+          yield {
+            type: 'chunk',
+            value: {
+              candidates: [
+                {
+                  content: {
+                    parts: [
+                      {
+                        functionCall: {
+                          id: 'call_123',
+                          name: 'read_file',
+                          args: { path: 'a.ts' },
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          };
+        }
+      },
+    );
+
+    const state = await startSpeculation(config, 'read a.ts');
+    await vi.waitFor(() => {
+      expect(state.status).toBe('completed');
+    });
+
+    expect(execute).toHaveBeenCalledOnce();
+    expect(state.messages[1].parts?.[0].functionCall?.id).toBe('call_123');
+    expect(state.messages[2].parts?.[0].functionResponse?.id).toBe(
+      'call_123',
+    );
+
+    await abortSpeculation(state);
+  });
+});
 
 describe('ensureToolResultPairing', () => {
   it('returns empty array unchanged', () => {

--- a/packages/core/src/followup/speculation.ts
+++ b/packages/core/src/followup/speculation.ts
@@ -241,6 +241,7 @@ async function runSpeculativeLoop(
           if (part.functionCall && part.functionCall.name) {
             modelParts.push({
               functionCall: {
+                ...(part.functionCall.id ? { id: part.functionCall.id } : {}),
                 name: part.functionCall.name,
                 args: part.functionCall.args,
               },
@@ -273,6 +274,7 @@ async function runSpeculativeLoop(
       for (const part of functionCalls) {
         const fc = part.functionCall;
         const name = fc.name ?? '';
+        const id = fc.id;
         const args = (fc.args ?? {}) as Record<string, unknown>;
         const gate = await evaluateToolCall(
           name,
@@ -304,6 +306,7 @@ async function runSpeculativeLoop(
           if (!tool) {
             functionResponses.push({
               functionResponse: {
+                ...(id ? { id } : {}),
                 name,
                 response: { error: `Tool '${name}' not found` },
               },
@@ -322,11 +325,16 @@ async function runSpeculativeLoop(
               ? { output: result.llmContent }
               : { output: JSON.stringify(result.llmContent) };
           functionResponses.push({
-            functionResponse: { name, response: responseContent },
+            functionResponse: {
+              ...(id ? { id } : {}),
+              name,
+              response: responseContent,
+            },
           });
         } catch (error: unknown) {
           functionResponses.push({
             functionResponse: {
+              ...(id ? { id } : {}),
               name,
               response: {
                 error:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,6 +67,7 @@ export * from './core/logger.js';
 export * from './core/nonInteractiveToolExecutor.js';
 export * from './core/prompts.js';
 export * from './core/tokenLimits.js';
+export * from './core/toolCallIdUtils.js';
 export * from './core/turn.js';
 
 // ============================================================================


### PR DESCRIPTION
## What this PR does

This PR makes tool-call ids unique and well-paired across OpenAI-compatible conversations. It normalizes model-emitted function call ids before they enter history, drops same-turn replayed ids, suffixes cross-turn reused ids, and adds final OpenAI payload cleanup so only one surviving assistant tool call and one adjacent tool result remain for each id.

It also adds duplicate-id execution guards for the core scheduler, non-interactive CLI, AgentCore, and ACP Session paths, and keeps speculation-generated function calls and responses paired with the same id.

## Why it's needed

Some OpenAI-compatible providers can reuse the same `tool_call.id` across turns or replay a completed call in the same stream. Qwen previously stored those raw ids directly in history, which could create duplicate tool results in later requests, inflate payloads across turns, and trigger provider validation errors such as `duplicate_tool_result_in_request dup_id_0001`.

The fix keeps same-turn duplicate ids from causing duplicate side effects, while treating cross-turn reused raw ids as new local calls with unique suffixed ids.

## Reviewer Test Plan

### How to verify

Run the focused core tests for id normalization, parser/converter cleanup, GeminiChat history ingestion, scheduler execution, AgentCore execution, and speculation pairing. Run the microcompaction tests to confirm old corrupted reused-id history still uses the conservative disarm behavior. Run the focused CLI tests for non-interactive, TUI stream handling, and ACP Session. Finally run the repository build and typecheck.

Commands used locally: `cd packages/core && npx vitest run src/core/toolCallIdUtils.test.ts src/core/openaiContentGenerator/converter.test.ts src/core/geminiChat.test.ts src/core/coreToolScheduler.test.ts src/agents/runtime/agent-headless.test.ts src/followup/speculation.test.ts`; `cd packages/core && npx vitest run src/services/microcompaction/microcompact.test.ts`; `cd packages/cli && npx vitest run src/nonInteractiveCli.test.ts src/ui/hooks/useGeminiStream.test.tsx src/acp-integration/session/Session.test.ts`; `npm run build && npm run typecheck`.

Expected result: same-turn duplicate tool call ids execute only once, cross-turn reused raw ids are suffixed before entering history, OpenAI payload conversion removes duplicate surviving pairs, and build/typecheck exit successfully.

### Evidence (Before & After)

N/A. This is protocol/history repair with focused automated coverage and no TUI rendering change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS local workspace, Node.js v22.22.3, npm 10.9.8.

## Risk & Scope

- Main risk or tradeoff: If a provider emits two genuinely different calls with the same id in one model turn, Qwen now keeps only the first because same-turn id reuse is invalid and repeating shell/edit calls is the higher-risk behavior.
- Not validated / out of scope: The external #5014 and #5099 reproduction gists were not rerun locally; Anthropic-compatible outbound conversion is not changed in this PR.
- Breaking changes / migration notes: No CLI flags, user settings, or migration steps are added. ACP, JSON stream output, recordings, and tool summaries may show normalized local call ids for reused provider ids.

## Linked Issues

Fixes #5099

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 修复 OpenAI-compatible 会话里的 tool-call id 唯一性和配对问题。它会在模型返回的 function call 写入历史前规范化 id，丢弃同一 turn 内 replay 的重复 id，对跨 turn 复用的 raw id 添加 suffix，并在 OpenAI 出站 payload 阶段做最终清理，保证每个存活 id 只保留一个 assistant tool call 和一个相邻 tool result。

它同时为 core scheduler、non-interactive CLI、AgentCore、ACP Session 增加 duplicate-id 执行兜底，并保证 speculation 生成的 function call 和 function response 使用同一个 id 配对。

## Why it's needed

部分 OpenAI-compatible provider 会跨 turn 复用同一个 `tool_call.id`，或者在同一个 stream 内 replay 一个已完成调用。Qwen 之前会直接把这些 raw id 写入 history，导致后续请求中出现重复 tool result、payload 随轮次膨胀，并触发 `duplicate_tool_result_in_request dup_id_0001` 这类 provider 校验错误。

这次修复会避免同 turn 重复 id 造成重复副作用，同时把跨 turn 复用的 raw id 视为新的本地调用并改写成唯一 suffixed id。

## Reviewer Test Plan

### How to verify

运行 focused core 测试，覆盖 id 规范化、parser/converter 清理、GeminiChat 历史摄入、scheduler 执行、AgentCore 执行以及 speculation 配对。运行 microcompaction 测试，确认旧腐化 reused-id history 仍保留保守 disarm 行为。运行 focused CLI 测试，覆盖 non-interactive、TUI stream handling 和 ACP Session。最后运行仓库 build 和 typecheck。

本地执行命令：`cd packages/core && npx vitest run src/core/toolCallIdUtils.test.ts src/core/openaiContentGenerator/converter.test.ts src/core/geminiChat.test.ts src/core/coreToolScheduler.test.ts src/agents/runtime/agent-headless.test.ts src/followup/speculation.test.ts`；`cd packages/core && npx vitest run src/services/microcompaction/microcompact.test.ts`；`cd packages/cli && npx vitest run src/nonInteractiveCli.test.ts src/ui/hooks/useGeminiStream.test.tsx src/acp-integration/session/Session.test.ts`；`npm run build && npm run typecheck`。

预期结果：同 turn 重复 tool call id 只执行一次，跨 turn 复用 raw id 会在进入 history 前添加 suffix，OpenAI payload conversion 会移除重复存活 pair，并且 build/typecheck 成功退出。

### Evidence (Before & After)

N/A。这是协议和历史修复，有 focused 自动化覆盖，没有 TUI 渲染变化。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 本地工作区，Node.js v22.22.3，npm 10.9.8。

## Risk & Scope

- Main risk or tradeoff: 如果 provider 在同一个 model turn 内用同一个 id 返回两个真实不同的调用，Qwen 现在只保留第一个；因为同 turn id 复用本身违反协议，重复执行 shell/edit 的风险更高。
- Not validated / out of scope: 未在本地重新运行外部 #5014 和 #5099 复现 gist；本 PR 不修改 Anthropic-compatible 出站转换。
- Breaking changes / migration notes: 不新增 CLI flag、用户设置或迁移步骤。ACP、JSON stream output、recording 和 tool summary 在 provider 复用 id 时可能显示规范化后的本地 call id。

## Linked Issues

Fixes #5099

</details>
