### PR TITLE
fix(daemon): Avoid replaying truncated session diffs

### DIFF
--- a/packages/cli/src/acp-integration/session/emitters/ToolCallEmitter.test.ts
+++ b/packages/cli/src/acp-integration/session/emitters/ToolCallEmitter.test.ts
@@ -231,6 +231,11 @@ describe('ToolCallEmitter', () => {
           _meta: { toolName: 'edit_file', provenance: 'builtin' },
         }),
       );
+      expect(sendUpdateSpy.mock.calls[0][0].rawOutput).toEqual({
+        fileName: '/test/file.ts',
+        originalContent: 'old content',
+        newContent: 'new content',
+      });
     });
 
     it('should not replay truncated session previews as full diffs', async () => {

--- a/packages/cli/src/acp-integration/session/emitters/ToolCallEmitter.test.ts
+++ b/packages/cli/src/acp-integration/session/emitters/ToolCallEmitter.test.ts
@@ -266,6 +266,7 @@ describe('ToolCallEmitter', () => {
           _meta: { toolName: 'edit_file', provenance: 'builtin' },
         }),
       );
+      expect(sendUpdateSpy.mock.calls[0][0].rawOutput).toBeUndefined();
     });
 
     it('should transform message parts to content', async () => {

--- a/packages/cli/src/acp-integration/session/emitters/ToolCallEmitter.ts
+++ b/packages/cli/src/acp-integration/session/emitters/ToolCallEmitter.ts
@@ -171,7 +171,10 @@ export class ToolCallEmitter extends BaseEmitter {
     };
 
     // Add rawOutput from resultDisplay
-    if (params.resultDisplay !== undefined) {
+    if (
+      params.resultDisplay !== undefined &&
+      !this.isTruncatedSessionDiffDisplay(params.resultDisplay)
+    ) {
       (update as Record<string, unknown>)['rawOutput'] = params.resultDisplay;
     }
 
@@ -353,7 +356,7 @@ export class ToolCallEmitter extends BaseEmitter {
 
     // Check if this is a diff display (edit tool result)
     if ('fileName' in obj && 'newContent' in obj) {
-      if (obj['truncatedForSession'] === true) {
+      if (this.isTruncatedSessionDiffDisplay(resultDisplay)) {
         return {
           type: 'content',
           content: {
@@ -372,6 +375,17 @@ export class ToolCallEmitter extends BaseEmitter {
     }
 
     return null;
+  }
+
+  private isTruncatedSessionDiffDisplay(resultDisplay: unknown): boolean {
+    if (!resultDisplay || typeof resultDisplay !== 'object') return false;
+
+    const obj = resultDisplay as Record<string, unknown>;
+    return (
+      obj['truncatedForSession'] === true &&
+      'fileName' in obj &&
+      'newContent' in obj
+    );
   }
 
   /**

--- a/packages/web-shell/client/adapters/transcriptToMessages.test.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.test.ts
@@ -2328,6 +2328,12 @@ describe('transcriptBlocksToDaemonMessages', () => {
     const tool =
       messages[0].role === 'tool_group' ? messages[0].tools[0] : undefined;
     expect(tool?.rawOutput).toBeUndefined();
+    expect(tool?.content).toEqual([
+      {
+        type: 'content',
+        content: { type: 'text', text: 'rendered elsewhere' },
+      },
+    ]);
   });
 
   it('mergeToolCall updates fields from completion block', () => {
@@ -2582,7 +2588,7 @@ describe('transcriptBlocksToDaemonMessages', () => {
     expect(execTool?.subContent).toBe('Running...');
   });
 
-  it('does not pass content, locations, or preview to DaemonMessageToolCall', () => {
+  it('passes content but not locations or preview to DaemonMessageToolCall', () => {
     const messages = transcriptBlocksToDaemonMessages([
       toolBlock('t1', 'tc1', 'completed', 1, {
         toolName: 'Edit',
@@ -2603,7 +2609,14 @@ describe('transcriptBlocksToDaemonMessages', () => {
       messages[0].role === 'tool_group' ? messages[0].tools[0] : undefined;
     expect(tool).toBeDefined();
     expect(tool?.callId).toBe('tc1');
-    expect('content' in tool!).toBe(false);
+    expect(tool?.content).toEqual([
+      {
+        type: 'diff',
+        path: '/path/file.ts',
+        oldText: 'old',
+        newText: 'new',
+      },
+    ]);
     expect('locations' in tool!).toBe(false);
     expect('preview' in tool!).toBe(false);
   });

--- a/packages/web-shell/client/adapters/transcriptToMessages.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.ts
@@ -15,6 +15,7 @@ import type {
 import type {
   DaemonMessage,
   DaemonMessageToolCall,
+  DaemonMessageToolCallContent,
   DaemonMessageToolCallStatus,
   DaemonMessageToolKind,
   DaemonMessageTodoItem,
@@ -645,6 +646,7 @@ function daemonToolBlockToToolCall(
 ): DaemonMessageToolCall {
   const rawOutput = getToolRawOutput(block);
   const isBackgroundAgent = isBackgroundAgentBlock(block, rawOutput);
+  const content = normalizeToolContent(block.content);
   const statusMap: Record<string, DaemonMessageToolCallStatus> = {
     running: 'in_progress',
     pending: 'pending',
@@ -676,6 +678,7 @@ function daemonToolBlockToToolCall(
     parentToolCallId: block.parentToolCallId,
     startTime: block.createdAt,
     endTime: isComplete && !isBackgroundAgent ? block.updatedAt : undefined,
+    ...(content ? { content } : {}),
   };
 }
 
@@ -811,6 +814,59 @@ function getToolRawOutput(block: DaemonToolTranscriptBlock): unknown {
         ? block.rawOutput
         : block.details,
   };
+}
+
+function normalizeToolContent(
+  value: unknown,
+): DaemonMessageToolCallContent[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+
+  const content = value.flatMap((entry): DaemonMessageToolCallContent[] => {
+    const item = getRecord(entry);
+    if (!item) return [];
+
+    const type = item['type'];
+    if (type === 'content') {
+      const body = getRecord(item['content']);
+      if (!body || typeof body['type'] !== 'string') return [];
+      return [
+        {
+          type: 'content',
+          content: { ...body, type: body['type'] },
+        },
+      ];
+    }
+
+    if (type === 'diff') {
+      const newText = item['newText'];
+      if (typeof newText !== 'string') return [];
+
+      const path = item['path'];
+      const oldText = item['oldText'];
+      return [
+        {
+          type: 'diff',
+          ...(typeof path === 'string' ? { path } : {}),
+          ...(typeof oldText === 'string' ? { oldText } : {}),
+          newText,
+        },
+      ];
+    }
+
+    if (type === 'terminal') {
+      const terminalId = item['terminalId'];
+      return [
+        {
+          type: 'terminal',
+          ...(typeof terminalId === 'string' ? { terminalId } : {}),
+        },
+      ];
+    }
+
+    return [];
+  });
+
+  return content.length > 0 ? content : undefined;
 }
 
 function isAskUserQuestionBlock(block: DaemonToolTranscriptBlock): boolean {

--- a/packages/web-shell/client/components/messages/ToolGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.test.tsx
@@ -39,6 +39,15 @@ function makeShellTool(
   };
 }
 
+function makeEditTool(overrides: Partial<ACPToolCall>): ACPToolCall {
+  return {
+    callId: 'call-edit-1',
+    toolName: 'edit',
+    status: 'completed',
+    ...overrides,
+  };
+}
+
 function renderTool(tool: ACPToolCall): HTMLElement {
   const container = document.createElement('div');
   document.body.appendChild(container);
@@ -102,6 +111,14 @@ function click(el: Element): void {
   act(() => {
     el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
   });
+}
+
+function expandTool(container: HTMLElement): void {
+  const chevron = [...container.querySelectorAll('span')].find(
+    (s) => s.textContent === '▸',
+  );
+  expect(chevron).toBeTruthy();
+  click(chevron!.parentElement!);
 }
 
 describe('shell tool output expand toggle', () => {
@@ -345,5 +362,79 @@ describe('auto-collapse on finish', () => {
     // Completion must NOT override the user's explicit expand.
     renderStatus('completed');
     expect(container.textContent).toContain('▾');
+  });
+});
+
+describe('edit raw diff rendering', () => {
+  it('ignores truncated session rawOutput diffs', () => {
+    const fullDiff = '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new';
+
+    const normal = renderTool(
+      makeEditTool({
+        rawOutput: {
+          fileDiff: fullDiff,
+        },
+      }),
+    );
+    expandTool(normal);
+    expect(normal.textContent).toContain('old');
+    expect(normal.textContent).toContain('new');
+
+    const truncated = renderTool(
+      makeEditTool({
+        rawOutput: {
+          fileName: '/test/file.ts',
+          newContent: 'preview only',
+          fileDiff: fullDiff,
+          truncatedForSession: true,
+        },
+      }),
+    );
+    expect(truncated.textContent).not.toContain('old');
+    expect(truncated.textContent).not.toContain('new');
+  });
+
+  it('renders truncated session preview text when no diff is available', () => {
+    const preview =
+      'Full diff omitted from saved session history for /test/file.ts.';
+    const container = renderTool(
+      makeEditTool({
+        content: [
+          {
+            type: 'content',
+            content: { type: 'text', text: preview },
+          },
+        ],
+      }),
+    );
+
+    expandTool(container);
+    expect(container.textContent).toContain(preview);
+  });
+
+  it('expands write preview text when no diff is available', () => {
+    const preview =
+      'Full diff omitted from saved session history for /test/file.ts.';
+    const container = renderTool(
+      makeEditTool({
+        toolName: 'write',
+        content: [
+          {
+            type: 'content',
+            content: { type: 'text', text: preview },
+          },
+        ],
+      }),
+    );
+
+    expect(container.querySelector('pre')).toBeNull();
+
+    const writeLabel = Array.from(container.querySelectorAll('span')).find(
+      (el) => el.textContent === 'WriteFile',
+    );
+    expect(writeLabel).toBeDefined();
+    click(writeLabel!);
+
+    expect(container.querySelector('pre')?.textContent).toBe(preview);
   });
 });

--- a/packages/web-shell/client/components/messages/ToolGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.test.tsx
@@ -394,6 +394,33 @@ describe('edit raw diff rendering', () => {
     expect(truncated.textContent).not.toContain('new');
   });
 
+  it('shows preview and suppresses truncated rawOutput diffs', () => {
+    const fullDiff = '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new';
+    const preview =
+      'Full diff omitted from saved session history for /test/file.ts.';
+    const container = renderTool(
+      makeEditTool({
+        content: [
+          {
+            type: 'content',
+            content: { type: 'text', text: preview },
+          },
+        ],
+        rawOutput: {
+          fileName: '/test/file.ts',
+          newContent: 'preview only',
+          fileDiff: fullDiff,
+          truncatedForSession: true,
+        },
+      }),
+    );
+
+    expandTool(container);
+    expect(container.textContent).toContain(preview);
+    expect(container.textContent).not.toContain('old');
+    expect(container.textContent).not.toContain('new');
+  });
+
   it('renders truncated session preview text when no diff is available', () => {
     const preview =
       'Full diff omitted from saved session history for /test/file.ts.';

--- a/packages/web-shell/client/components/messages/ToolGroup.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.tsx
@@ -64,7 +64,7 @@ function hasExpandableContent(tool: ACPToolCall): boolean {
   if (isAskUserQuestionToolName(tool.toolName)) return !!extractText(tool);
   // write_file shows content from args even before completion
   if (name === 'write_file' || name === 'writefile') {
-    return !!getWriteContent(tool);
+    return !!getWriteContent(tool) || hasEditContent(tool);
   }
   if (tool.status !== 'completed' && tool.status !== 'failed') return false;
   if (isShellToolName(name)) {
@@ -72,7 +72,7 @@ function hasExpandableContent(tool: ACPToolCall): boolean {
     return !!text && text.trim().length > 0 && text.split('\n').length > 1;
   }
   if (name === 'edit' || name === 'write' || name === 'editfile') {
-    return hasDiffContent(tool);
+    return hasEditContent(tool);
   }
   if (name === 'read' || name === 'read_file' || name === 'readfile') {
     const text = extractText(tool);
@@ -104,11 +104,11 @@ function hasDetailView(tool: ACPToolCall): boolean {
 
 function hasDiffContent(tool: ACPToolCall): boolean {
   if (tool.content?.some((b) => b.type === 'diff')) return true;
-  if (tool.rawOutput && typeof tool.rawOutput === 'object') {
-    const raw = tool.rawOutput as Record<string, unknown>;
-    if (typeof raw.fileDiff === 'string' && raw.fileDiff) return true;
-  }
-  return false;
+  return !!getRawFileDiff(tool);
+}
+
+function hasEditContent(tool: ACPToolCall): boolean {
+  return hasDiffContent(tool) || !!extractText(tool);
 }
 
 function extractDiff(tool: ACPToolCall): string {
@@ -118,11 +118,22 @@ function extractDiff(tool: ACPToolCall): string {
       return buildUnifiedDiff(diffBlock.oldText || '', diffBlock.newText || '');
     }
   }
+  return getRawFileDiff(tool);
+}
+
+function getRawFileDiff(tool: ACPToolCall): string {
   if (tool.rawOutput && typeof tool.rawOutput === 'object') {
     const raw = tool.rawOutput as Record<string, unknown>;
+    if (isTruncatedSessionDiff(raw)) return '';
     if (typeof raw.fileDiff === 'string') return raw.fileDiff;
   }
   return '';
+}
+
+function isTruncatedSessionDiff(raw: Record<string, unknown>): boolean {
+  return (
+    raw.truncatedForSession === true && 'fileName' in raw && 'newContent' in raw
+  );
 }
 
 const MAX_DIFF_PRODUCT = 250_000;
@@ -294,12 +305,17 @@ function ExpandedReadContent({ tool }: { tool: ACPToolCall }) {
   );
 }
 
-function ExpandedEditDiff({ tool }: { tool: ACPToolCall }) {
+function ExpandedEditContent({ tool }: { tool: ACPToolCall }) {
   const diff = useMemo(() => extractDiff(tool), [tool]);
-  if (!diff) return null;
+  const text = useMemo(() => extractText(tool) || '', [tool]);
+  if (!diff && !text) return null;
   return (
     <div className={styles.expandedEdit}>
-      <DiffView diff={diff} />
+      {diff ? (
+        <DiffView diff={diff} />
+      ) : (
+        <pre className={styles.expandedOutput}>{text}</pre>
+      )}
     </div>
   );
 }
@@ -845,10 +861,10 @@ export const ToolLine = memo(function ToolLine({
             <ExpandedBashOutput tool={tool} maxLines={shellOutputMaxLines} />
           )}
           {(name === 'write_file' || name === 'writefile') && (
-            <ExpandedEditDiff tool={tool} />
+            <ExpandedEditContent tool={tool} />
           )}
           {(name === 'edit' || name === 'write' || name === 'editfile') && (
-            <ExpandedEditDiff tool={tool} />
+            <ExpandedEditContent tool={tool} />
           )}
           {(name === 'read' || name === 'read_file' || name === 'readfile') && (
             <ExpandedReadContent tool={tool} />


### PR DESCRIPTION
## What this PR does

This PR changes saved-session tool replay so truncated edit/write diff displays are treated as preview-only content instead of being replayed again through raw output. The web shell now preserves normalized tool content from daemon transcript blocks, ignores truncated raw diff fallbacks, and shows the omitted-diff preview text when no diff is available.

## Why it's needed

Long session histories can contain truncated file diff result displays. Before this change, replay still copied that truncated display into raw output, which let web-shell consumers recover and render the raw diff payload as if it were a full diff and also kept unnecessary payload in replayed session events. Removing that raw replay exposed another gap: web-shell was dropping normal tool content from transcript blocks, so the human-readable preview could disappear. This PR fixes both sides of that path.

## Reviewer Test Plan

### How to verify

Run the focused tests for daemon replay, web-shell transcript adaptation, and web-shell tool rendering. The daemon test should show truncated session diffs no longer include raw output. The adapter test should show tool content is preserved without converting it into raw output. The renderer test should show truncated raw diff fallbacks are ignored while the preview text remains visible and expandable.

Commands used locally: `cd packages/cli && npx vitest run src/acp-integration/session/emitters/ToolCallEmitter.test.ts`; `cd packages/web-shell && npx vitest run client/adapters/transcriptToMessages.test.ts`; `cd packages/web-shell && npx vitest run client/components/messages/ToolGroup.test.tsx`; `git diff --check`; `npx prettier --check packages/cli/src/acp-integration/session/emitters/ToolCallEmitter.ts packages/cli/src/acp-integration/session/emitters/ToolCallEmitter.test.ts packages/web-shell/client/adapters/transcriptToMessages.ts packages/web-shell/client/adapters/transcriptToMessages.test.ts packages/web-shell/client/components/messages/ToolGroup.tsx packages/web-shell/client/components/messages/ToolGroup.test.tsx`; `npm run build`; `npm run typecheck`.

### Evidence (Before & After)

Before: a saved truncated edit/write diff could still be replayed as raw output, so web-shell fallback rendering could treat `fileDiff` as a displayable full diff; if raw output was omitted, web-shell transcript adaptation dropped the content preview. After: truncated session diffs are emitted only as preview content, web-shell keeps that content, ignores truncated raw diff fallbacks, and renders the preview text when no diff is available. The before/after behavior is covered by focused regression tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local repository workspace with npm scripts; validation used package-level Vitest tests plus repository `npm run build` and `npm run typecheck`.

## Risk & Scope

- Main risk or tradeoff: consumers that were relying on truncated saved-session diff displays through raw output will now receive the intended preview content instead of the structured diff payload.
- Not validated / out of scope: the external ingress 503 shown in the original report was not reproduced locally; this PR addresses the concrete replay/display payload path found in the attached session history.
- Breaking changes / migration notes: none expected.

## Linked Issues

Fixes #5106

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 调整了已保存会话里的工具回放逻辑：对已截断的 edit/write diff 展示，只作为预览内容回放，不再再次通过 raw output 回放。web shell 现在会保留 daemon transcript 工具块里的规范化 content，忽略已截断的 raw diff fallback，并在没有 diff 可展示时显示“diff 已省略”的预览文本。

## Why it's needed

长会话历史里可能包含已截断的文件 diff result display。变更前，回放仍会把这个截断 display 复制进 raw output，web-shell 的 fallback 渲染可能继续把 `fileDiff` 当成完整 diff 展示，同时也让回放事件保留了不必要的负载。移除这部分 raw replay 后又暴露了另一个缺口：web-shell 会丢弃 transcript 工具块里的普通 tool content，导致人可读的预览文本可能消失。这个 PR 同时修复了这条路径的两端。

## Reviewer Test Plan

### How to verify

运行 daemon 回放、web-shell transcript 适配和 web-shell 工具渲染的聚焦测试。daemon 测试应确认已截断 session diff 不再包含 raw output；adapter 测试应确认 tool content 被保留且不会被冒充成 raw output；renderer 测试应确认已截断 raw diff fallback 被忽略，同时预览文本仍可见并可展开。

本地使用的命令：`cd packages/cli && npx vitest run src/acp-integration/session/emitters/ToolCallEmitter.test.ts`；`cd packages/web-shell && npx vitest run client/adapters/transcriptToMessages.test.ts`；`cd packages/web-shell && npx vitest run client/components/messages/ToolGroup.test.tsx`；`git diff --check`；`npx prettier --check packages/cli/src/acp-integration/session/emitters/ToolCallEmitter.ts packages/cli/src/acp-integration/session/emitters/ToolCallEmitter.test.ts packages/web-shell/client/adapters/transcriptToMessages.ts packages/web-shell/client/adapters/transcriptToMessages.test.ts packages/web-shell/client/components/messages/ToolGroup.tsx packages/web-shell/client/components/messages/ToolGroup.test.tsx`；`npm run build`；`npm run typecheck`。

### Evidence (Before & After)

Before：已保存且被截断的 edit/write diff 仍可能作为 raw output 回放，因此 web-shell fallback 渲染会把 `fileDiff` 当成可展示的完整 diff；如果省略 raw output，web-shell transcript 适配又会丢掉 content 预览。After：已截断 session diff 只作为预览 content 发出，web-shell 保留这段 content，忽略已截断的 raw diff fallback，并在没有 diff 时渲染预览文本。这个前后行为已由聚焦回归测试覆盖。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地仓库 workspace，验证使用 package 级 Vitest 测试以及仓库级 `npm run build` 和 `npm run typecheck`。

## Risk & Scope

- Main risk or tradeoff：依赖通过 raw output 读取已截断保存会话 diff display 的消费者，现在会收到预期的 preview content，而不是结构化 diff payload。
- Not validated / out of scope：原始反馈截图里的外部 ingress 503 没有在本地复现；这个 PR 处理的是从附带 session 历史里定位到的具体回放/展示负载路径。
- Breaking changes / migration notes：预计无。

## Linked Issues

Fixes #5106

</details>
