### PR TITLE
fix(core): ignore agent names without active teams

### DIFF
--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -338,6 +338,35 @@ describe('AgentTool', () => {
       ]);
     });
 
+    it('does not expose teammate name when teams are disabled', () => {
+      const schema = agentTool.schema;
+      const parameters = schema.parametersJsonSchema as {
+        properties: {
+          name?: unknown;
+        };
+      };
+
+      expect(parameters.properties.name).toBeUndefined();
+    });
+
+    it('exposes teammate name when teams are enabled', async () => {
+      vi.mocked(config.isAgentTeamEnabled).mockReturnValue(true);
+
+      const teamAgentTool = new AgentTool(config);
+      await vi.runAllTimersAsync();
+
+      const schema = teamAgentTool.schema;
+      const parameters = schema.parametersJsonSchema as {
+        properties: {
+          name?: {
+            description?: string;
+          };
+        };
+      };
+
+      expect(parameters.properties.name?.description).toContain('active team');
+    });
+
     it('should generate schema without enum when no subagents available', async () => {
       vi.mocked(mockSubagentManager.listSubagents).mockResolvedValue([]);
 
@@ -519,8 +548,10 @@ describe('AgentTool', () => {
   });
 
   describe('team routing', () => {
-    it('rejects `name` when no team is active', async () => {
+    it('falls back to one-shot when `name` is supplied without a team', async () => {
       vi.mocked(config.getTeamManager).mockReturnValue(null);
+      vi.mocked(mockSubagentManager.loadSubagent).mockResolvedValue(null);
+
       const invocation = agentTool.build({
         description: 'Spawn helper',
         prompt: 'Do work',
@@ -528,11 +559,11 @@ describe('AgentTool', () => {
         name: 'helper',
       });
       const result = await invocation.execute(new AbortController().signal);
-      expect(result.error).toBeDefined();
-      expect(result.llmContent).toContain('no active team');
-      expect(result.llmContent).toContain('"helper"');
-      // Subagent must NOT have been spawned as a one-shot fallback.
-      expect(mockSubagentManager.loadSubagent).not.toHaveBeenCalled();
+
+      expect(result.llmContent).not.toContain('no active team');
+      expect(mockSubagentManager.loadSubagent).toHaveBeenCalledWith(
+        'file-search',
+      );
     });
   });
 

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -203,6 +203,13 @@ export interface AgentParams {
 
 const debugLogger = createDebugLogger('AGENT');
 
+const TEAM_AGENT_NAME_PROPERTY = {
+  type: 'string',
+  description:
+    'When provided, spawn as a named teammate via the active team ' +
+    'instead of a one-shot subagent. Requires an active team context.',
+};
+
 /**
  * Maps ApprovalMode to PermissionMode for hook events.
  */
@@ -540,12 +547,9 @@ export class AgentTool extends BaseDeclarativeTool<AgentParams, ToolResult> {
           description:
             'Set to true to run this agent in the background. You will be notified when it completes.',
         },
-        name: {
-          type: 'string',
-          description:
-            'When provided, spawn as a named teammate via the active team ' +
-            'instead of a one-shot subagent. Requires an active team context.',
-        },
+        ...(config.isAgentTeamEnabled()
+          ? { name: TEAM_AGENT_NAME_PROPERTY }
+          : {}),
         isolation: {
           type: 'string',
           enum: ['worktree'],
@@ -725,6 +729,7 @@ assistant: Uses the ${ToolNames.AGENT} tool to launch the test-runner agent
         subagent_type?: {
           enum?: string[];
         };
+        name?: typeof TEAM_AGENT_NAME_PROPERTY;
       };
     };
     if (schema.properties && schema.properties.subagent_type) {
@@ -732,6 +737,13 @@ assistant: Uses the ${ToolNames.AGENT} tool to launch the test-runner agent
         schema.properties.subagent_type.enum = subagentNames;
       } else {
         delete schema.properties.subagent_type.enum;
+      }
+    }
+    if (schema.properties) {
+      if (this.config.isAgentTeamEnabled()) {
+        schema.properties.name = TEAM_AGENT_NAME_PROPERTY;
+      } else {
+        delete schema.properties.name;
       }
     }
   }
@@ -1630,29 +1642,17 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
     updateOutput?: (output: ToolResultDisplay) => void,
   ): Promise<ToolResult> {
     // ─── Team routing ────────────────────────────────────
-    // When a team is active AND the caller passed an explicit
-    // `name`, route through TeamManager as a named teammate.
-    // Without a name we fall through to the regular one-shot
-    // subagent flow — the schema says "When provided, spawn as
-    // a named teammate," so the absence of `name` means the
-    // caller wants a one-shot, not a teammate.
+    // A name only means "spawn a teammate" while a team is active. Older
+    // prompts may still pass it without a team; treat that as a normal
+    // one-shot agent instead of failing the whole task.
     if (this.params.name && !isTeammate()) {
-      // The schema for `name` says it requires an active team,
-      // so reject the call up front instead of silently launching
-      // a different kind of agent (one-shot subagent) that
-      // ignores the supplied name.
       if (!this.config.getTeamManager()) {
-        const msg =
-          `Cannot spawn teammate "${this.params.name}": no active team. ` +
-          `Use team_create to start a team first, or omit "name" to ` +
-          `launch a one-shot subagent.`;
-        return {
-          llmContent: msg,
-          returnDisplay: msg,
-          error: { message: msg },
-        };
+        debugLogger.debug(
+          `[AgentTool] Ignoring teammate name "${this.params.name}" because no team is active.`,
+        );
+      } else {
+        return this.executeTeammate(this.params.name, signal, updateOutput);
       }
-      return this.executeTeammate(this.params.name, signal, updateOutput);
     }
 
     // ── Isolation state hoisted to the outermost scope ────────────


### PR DESCRIPTION
## What this PR does

When agent teams are disabled, the Agent tool no longer advertises the teammate-only `name` parameter in its schema. If an older prompt or bundled workflow still sends `name` without an active team, the tool now ignores that name and runs the requested agent as a normal one-shot subagent instead of failing immediately.

## Why it's needed

Fixes #5100. The current schema always exposes `name`, while the guidance that explains team usage is only shown when teams are enabled. That gives the model a parameter it can fill even though there is no active team. The resulting hard error is especially painful for `/review`, where named review agents can turn into repeated failed spawns. Hiding the parameter when teams are off removes the bad steering, and the fallback keeps existing prompts from aborting the task if `name` leaks through anyway.

## Reviewer Test Plan

### How to verify

With teams disabled, inspect the Agent tool schema and confirm `name` is absent. Then call the Agent tool with `name` anyway; it should proceed through the normal one-shot subagent path instead of returning a "no active team" error. With teams enabled, `name` should still be present in the schema for teammate spawning.

### Evidence (Before & After)

Before: the unit test asserted that `name` without an active team returned a hard "no active team" error and did not load the requested subagent. After: the updated test asserts that `name` is hidden when teams are disabled, visible when teams are enabled, and a leaked `name` falls back to the one-shot subagent path.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Windows 11, Node.js v24.15.0, npm 11.12.1.

Validated locally:

```bash
npx prettier --check packages/core/src/tools/agent/agent.ts packages/core/src/tools/agent/agent.test.ts
npx eslint packages/core/src/tools/agent/agent.ts packages/core/src/tools/agent/agent.test.ts --max-warnings 0
cd packages/core && npx vitest run src/tools/agent/agent.test.ts
npm run typecheck --workspace=@qwen-code/qwen-code-core -- --pretty false
npm run build --workspace=@qwen-code/qwen-code-core
git diff --check
```

## Risk & Scope

- Main risk or tradeoff: if a caller expected `name` to fail loudly without a team, it now behaves like a normal one-shot agent. That is intentional because `name` is only meaningful for active teams.
- Not validated / out of scope: I did not change the bundled `/review` skill or add a separate repeated-call circuit breaker.
- Breaking changes / migration notes: none expected.

## Linked Issues

Fixes #5100

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

当 agent team 功能关闭时，Agent tool 不再在 schema 中暴露只属于 teammate 场景的 `name` 参数。如果旧 prompt 或内置流程仍然在没有 active team 的情况下传入 `name`，现在会忽略这个名字，并按普通 one-shot subagent 执行，而不是立刻失败。

## 为什么需要

修复 #5100。当前 schema 始终暴露 `name`，但解释 team 用法的 guidance 只有在 team 功能启用时才出现。这会让模型看到一个可填的参数，却不知道它需要 active team。对 `/review` 这种会命名多个 review agent 的流程来说，这个 hard error 很容易变成重复失败调用。关闭 team 时隐藏参数可以避免错误引导；fallback 则保证历史 prompt 即便传入 `name` 也不会直接中止任务。

## Reviewer Test Plan

### 如何验证

在 team 功能关闭时，检查 Agent tool schema，确认没有 `name`。然后即使手动传入 `name`，也应该进入普通 one-shot subagent 路径，而不是返回 “no active team” 错误。team 功能开启时，`name` 仍然应该出现在 schema 中，用于 teammate spawn。

### 前后证据

修改前：单测断言没有 active team 时传入 `name` 会返回 hard error，并且不会加载目标 subagent。修改后：单测断言 team 关闭时 `name` 被隐藏，team 开启时 `name` 可见，并且泄漏进来的 `name` 会降级到 one-shot subagent 路径。

### 本地验证环境

Windows 11，Node.js v24.15.0，npm 11.12.1。已本地运行上方列出的格式、lint、单测、typecheck、build 和 diff check。

## 风险与范围

- 主要风险或取舍：如果某个调用方依赖 “无 team + name 必须报错”，现在会变成普通 one-shot agent。这是有意行为，因为 `name` 只有在 active team 下才有 teammate 语义。
- 未覆盖范围：没有修改内置 `/review` skill，也没有单独增加重复调用熔断器。
- 破坏性变更 / 迁移说明：预计没有。

</details>
