### PR TITLE
fix(channels): match sender id as a full segment in SessionRouter

### DIFF
--- a/packages/channels/base/src/SessionRouter.test.ts
+++ b/packages/channels/base/src/SessionRouter.test.ts
@@ -157,6 +157,14 @@ describe('SessionRouter', () => {
       expect(router.hasSession('ch', 'alice')).toBe(true);
       expect(router.hasSession('ch', 'bob')).toBe(false);
     });
+
+    it('does not match a different sender that shares an id prefix', async () => {
+      const router = new SessionRouter(bridge, '/tmp');
+      await router.resolve('ch', 'bobby', 'chat1');
+      // 'bob' is a prefix of 'bobby' but is a distinct sender with no session.
+      expect(router.hasSession('ch', 'bob')).toBe(false);
+      expect(router.hasSession('ch', 'bobby')).toBe(true);
+    });
   });
 
   describe('removeSession', () => {
@@ -180,6 +188,15 @@ describe('SessionRouter', () => {
       const removed = router.removeSession('ch', 'alice');
       expect(removed).toHaveLength(2);
       expect(router.hasSession('ch', 'alice')).toBe(false);
+    });
+
+    it('does not remove a different sender that shares an id prefix', async () => {
+      const router = new SessionRouter(bridge, '/tmp');
+      const bobby = await router.resolve('ch', 'bobby', 'chat1');
+      // Removing 'bob' (a prefix of 'bobby') must not tear down 'bobby'.
+      expect(router.removeSession('ch', 'bob')).toEqual([]);
+      expect(router.hasSession('ch', 'bobby')).toBe(true);
+      expect(router.getTarget(bobby)).toBeDefined();
     });
 
     it('cleans up target mapping after removal', async () => {

--- a/packages/channels/base/src/SessionRouter.ts
+++ b/packages/channels/base/src/SessionRouter.ts
@@ -59,6 +59,16 @@ export class SessionRouter {
     }
   }
 
+  /**
+   * Sender-scoped key prefix for by-sender (no chatId) scans. The trailing
+   * ':' delimiter ensures a sender id matches as a whole segment — without it
+   * sender "bob" would also match another sender "bobby"
+   * (key `${channelName}:bobby:${chatId}`).
+   */
+  private senderPrefix(channelName: string, senderId: string): string {
+    return `${channelName}:${senderId}:`;
+  }
+
   async resolve(
     channelName: string,
     senderId: string,
@@ -86,16 +96,14 @@ export class SessionRouter {
   }
 
   hasSession(channelName: string, senderId: string, chatId?: string): boolean {
-    const key = chatId
-      ? this.routingKey(channelName, senderId, chatId)
-      : `${channelName}:${senderId}`;
-    // If chatId is provided, do exact lookup; otherwise prefix-scan for any match.
-    // The trailing ':' delimiter is required so a sender id is matched as a whole
-    // segment — without it `senderId` "bob" would also match another sender
-    // "bobby" (key `${channelName}:bobby:${chatId}`).
-    if (chatId) return this.toSession.has(key);
+    // If chatId is provided, do an exact lookup; otherwise prefix-scan for any
+    // session belonging to this sender on this channel.
+    if (chatId) {
+      return this.toSession.has(this.routingKey(channelName, senderId, chatId));
+    }
+    const prefix = this.senderPrefix(channelName, senderId);
     for (const k of this.toSession.keys()) {
-      if (k.startsWith(`${channelName}:${senderId}:`)) return true;
+      if (k.startsWith(prefix)) return true;
     }
     return false;
   }
@@ -115,10 +123,7 @@ export class SessionRouter {
       if (sessionId) removedIds.push(sessionId);
     } else {
       // No chatId: remove all sessions for this sender on this channel.
-      // The trailing ':' delimiter is required so the prefix matches the whole
-      // sender segment — without it, removing sender "bob" would also tear down
-      // a different sender "bobby" (key `${channelName}:bobby:${chatId}`).
-      const prefix = `${channelName}:${senderId}:`;
+      const prefix = this.senderPrefix(channelName, senderId);
       for (const k of [...this.toSession.keys()]) {
         if (k.startsWith(prefix)) {
           const sessionId = this.deleteByKey(k);

--- a/packages/channels/base/src/SessionRouter.ts
+++ b/packages/channels/base/src/SessionRouter.ts
@@ -89,10 +89,13 @@ export class SessionRouter {
     const key = chatId
       ? this.routingKey(channelName, senderId, chatId)
       : `${channelName}:${senderId}`;
-    // If chatId is provided, do exact lookup; otherwise prefix-scan for any match
+    // If chatId is provided, do exact lookup; otherwise prefix-scan for any match.
+    // The trailing ':' delimiter is required so a sender id is matched as a whole
+    // segment — without it `senderId` "bob" would also match another sender
+    // "bobby" (key `${channelName}:bobby:${chatId}`).
     if (chatId) return this.toSession.has(key);
     for (const k of this.toSession.keys()) {
-      if (k.startsWith(`${channelName}:${senderId}`)) return true;
+      if (k.startsWith(`${channelName}:${senderId}:`)) return true;
     }
     return false;
   }
@@ -111,8 +114,11 @@ export class SessionRouter {
       const sessionId = this.deleteByKey(key);
       if (sessionId) removedIds.push(sessionId);
     } else {
-      // No chatId: remove all sessions for this sender on this channel
-      const prefix = `${channelName}:${senderId}`;
+      // No chatId: remove all sessions for this sender on this channel.
+      // The trailing ':' delimiter is required so the prefix matches the whole
+      // sender segment — without it, removing sender "bob" would also tear down
+      // a different sender "bobby" (key `${channelName}:bobby:${chatId}`).
+      const prefix = `${channelName}:${senderId}:`;
       for (const k of [...this.toSession.keys()]) {
         if (k.startsWith(prefix)) {
           const sessionId = this.deleteByKey(k);


### PR DESCRIPTION
## Problem

`SessionRouter` keys each session (default `user` scope) as `` `${channelName}:${senderId}:${chatId}` ``. But the **by-sender** (no `chatId`) branches of `hasSession` / `removeSession` prefix-scan with `` `${channelName}:${senderId}` `` — without the trailing `:` delimiter:

```ts
if (k.startsWith(`${channelName}:${senderId}`)) return true;   // hasSession
const prefix = `${channelName}:${senderId}`;                   // removeSession
```

So a sender id is matched as a bare string prefix and collides with any other sender whose id starts with it:

- `hasSession('ch', 'bob')` returns `true` when only `bobby` has a session.
- `removeSession('ch', 'bob')` also deletes `bobby`'s session (key `ch:bobby:chat1`) and returns its id.

## Scope / impact

This is a **latent correctness bug on a public API surface**, not an active hazard in the shipped command paths:

- The built-in `/clear`·`/reset`·`/new` and `/status` handlers always pass `envelope.chatId`, which takes `SessionRouter`'s **exact-lookup** branch and never the buggy prefix scan; shipped adapters (Telegram, DingTalk, WeChat, …) all build a non-empty `chatId`. So the built-in `/reset` path is safe both before and after this change.
- The bug is reachable via the **public, documented, tested** by-sender API — `hasSession(channel, sender)` / `removeSession(channel, sender)` (no `chatId`) — used by external embedders, and by any future in-tree caller of that form (the existing test *"removes all sender sessions when chatId omitted"* exercises exactly this surface).

Thanks to @wenshao for the thorough worktree/runtime verification that pinned down the precise scope (and correctly flagged that this is a defensive public-API fix rather than a `/reset`-triggered multi-user session-loss bug — description updated accordingly).

## Fix

Append the `:` delimiter so the prefix matches the whole sender segment (`` `${channelName}:${senderId}:` ``), extracted into a `senderPrefix()` helper so the invariant lives in one place. `thread`/`single` scopes are unaffected (their keys never contain the sender segment).

## Tests

Regression tests for both methods using a `bob` / `bobby` collision — the existing tests only used disjoint sender ids, so they never exercised it. Reverting only `SessionRouter.ts` to main makes the two new tests fail; with the fix the full `@qwen-code/channel-base` suite passes.
