### PR TITLE
fix(core): skip auto-title generation when history has no user message

### DIFF
--- a/packages/core/src/services/chatRecordingService.autoTitle.test.ts
+++ b/packages/core/src/services/chatRecordingService.autoTitle.test.ts
@@ -549,4 +549,61 @@ describe('ChatRecordingService - auto-title trigger', () => {
     expect(chatRecordingService.getCurrentCustomTitle()).toBe('user-chosen');
     expect(chatRecordingService.getCurrentTitleSource()).toBe('manual');
   });
+
+  it('skips title generation when history has no user message', async () => {
+    /**
+     * This test verifies that auto-title is not triggered when the history
+     * contains only model messages (e.g., initialization context) without
+     * any user message. This prevents titles like "初始化项目上下文" when
+     * the user hasn't sent any message yet.
+     */
+
+    // Simulate tryGenerateSessionTitle returning empty_history because
+    // the history only has model messages (initialization context)
+    tryGenerateSessionTitleMock.mockResolvedValueOnce({
+      ok: false,
+      reason: 'empty_history',
+    });
+
+    // Simulate the first assistant turn completing with initialization context
+    chatRecordingService.recordAssistantTurn({
+      model: 'qwen-plus',
+      message: [{ text: '已加载项目上下文，准备就绪。' }],
+    });
+
+    await flushMicrotasks();
+
+    // Verify: the mock was called and returned empty_history
+    expect(tryGenerateSessionTitleMock).toHaveBeenCalledOnce();
+    // Verify: NO title was generated because history had no user message
+    const titleRecord = findCustomTitleRecord();
+    expect(titleRecord).toBeUndefined();
+    expect(chatRecordingService.getCurrentCustomTitle()).toBeUndefined();
+
+    // Now simulate user sends "你好" and gets a response
+    vi.mocked(jsonl.writeLine).mockClear();
+    tryGenerateSessionTitleMock.mockClear();
+
+    // This time, tryGenerateSessionTitle succeeds because history now has user message
+    tryGenerateSessionTitleMock.mockResolvedValueOnce({
+      ok: true,
+      title: '问候会话',
+      modelUsed: 'qwen-turbo',
+    });
+
+    chatRecordingService.recordAssistantTurn({
+      model: 'qwen-plus',
+      message: [{ text: '你好！有什么可以帮助你的？' }],
+    });
+
+    await flushMicrotasks();
+
+    // Now the title should be generated based on the actual conversation
+    const newTitleRecord = findCustomTitleRecord();
+    expect(newTitleRecord).toBeDefined();
+    expect(
+      (newTitleRecord?.systemPayload as { customTitle?: string })?.customTitle,
+    ).toBe('问候会话');
+    expect(chatRecordingService.getCurrentCustomTitle()).toBe('问候会话');
+  });
 });

--- a/packages/core/src/services/sessionTitle.test.ts
+++ b/packages/core/src/services/sessionTitle.test.ts
@@ -75,6 +75,39 @@ describe('tryGenerateSessionTitle', () => {
     expect(outcome).toEqual({ ok: false, reason: 'empty_history' });
   });
 
+  it('returns {ok:false, reason:"empty_history"} when history has only startup prelude (no real user message)', async () => {
+    // Guard: auto-title should not be generated based solely on the
+    // initialization prelude — a role:'user' <system-reminder> message
+    // seeded by getInitialChatHistory. Without the guard, the title model
+    // would be called with only the startup context and produce a title
+    // like "初始化项目上下文" instead of one based on the user's actual
+    // first message.
+    const { config, generateJson } = makeConfig({
+      fastModel: 'qwen-turbo',
+      history: [
+        {
+          role: 'user',
+          parts: [
+            {
+              text: "<system-reminder>\nThis is the Qwen Code. We are setting up the context for our chat.\nToday's date is Monday, June 15, 2026.\nMy operating system is: linux\nI'm currently working in the directory: /home/me/project\n</system-reminder>",
+            },
+          ],
+        },
+        {
+          role: 'model',
+          parts: [{ text: 'Got it! How can I help you today?' }],
+        },
+      ],
+    });
+    const outcome = await tryGenerateSessionTitle(
+      config,
+      new AbortController().signal,
+    );
+    expect(outcome).toEqual({ ok: false, reason: 'empty_history' });
+    // The title model must NOT be called — the guard should short-circuit.
+    expect(generateJson).not.toHaveBeenCalled();
+  });
+
   it('returns {ok:false, reason:"model_error"} when the LLM throws', async () => {
     const { config } = makeConfig({
       fastModel: 'qwen-turbo',

--- a/packages/core/src/services/sessionTitle.ts
+++ b/packages/core/src/services/sessionTitle.ts
@@ -7,6 +7,7 @@
 import type { Content } from '@google/genai';
 import type { Config } from '../config/config.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import { isSystemReminderContent } from '../utils/environmentContext.js';
 import { runSideQuery } from '../utils/sideQuery.js';
 import { stripTerminalControlSequences } from '../utils/terminalSafe.js';
 import { SESSION_TITLE_MAX_LENGTH } from './sessionService.js';
@@ -115,6 +116,23 @@ export async function tryGenerateSessionTitle(
 
     const fullHistory = geminiClient.getHistoryShallow();
     if (fullHistory.length < 2) return { ok: false, reason: 'empty_history' };
+
+    // Guard: skip title generation if no real user message exists in history.
+    // This prevents the title from being generated based solely on
+    // initialization context (e.g., workspace loading, system prompts)
+    // before the user has actually said anything. Without this guard, a
+    // session that sends a prompt immediately after creation could get a
+    // title like "初始化项目上下文" instead of one based on the user's
+    // actual message.
+    //
+    // The startup prelude is a role:'user' message wrapping
+    // <system-reminder> content (see getInitialChatHistory), so we must
+    // exclude it via isSystemReminderContent to avoid misclassifying it
+    // as a real user turn.
+    const hasUserMessage = fullHistory.some(
+      (msg) => msg.role === 'user' && !isSystemReminderContent(msg),
+    );
+    if (!hasUserMessage) return { ok: false, reason: 'empty_history' };
 
     const dialog = filterToDialog(fullHistory);
     const recentHistory = takeRecentDialog(dialog, RECENT_MESSAGE_WINDOW);


### PR DESCRIPTION
## What this PR does

Adds a guard in `tryGenerateSessionTitle` that checks if the full history contains any user message (`role === 'user'`). If not, returns `empty_history` and skips title generation until a real user message exists.

## Why it's needed

When a daemon session is created and a prompt is sent immediately, the auto-title feature generates a title based on initialization context (e.g., "初始化项目上下文") instead of the user's actual first message (e.g., "你好"). This happens because:

1. Session is created with some initialization content
2. User sends a prompt immediately
3. `maybeTriggerAutoTitle()` fires after the first assistant turn
4. `tryGenerateSessionTitle()` sees enough history (init context + prompt response) and generates a title based on the init content
5. Once the title is set, it's locked — subsequent turns never re-generate

This fix ensures the title is only generated when there's at least one user message in history, preventing titles from being based solely on system initialization.

## Reviewer Test Plan

1. Create a new session and immediately send "你好"
2. Wait for the first assistant turn to complete
3. Verify the auto-generated title is based on the conversation, not initialization context
4. Run the new unit test: `cd packages/core && npx vitest run src/services/chatRecordingService.autoTitle.test.ts -t "fix: skips title generation"`

## Tested on

| OS      | Status |
| ------- | ------ |
| macOS   | ✅     |

## Risk & Scope

- **Risk**: Low — only affects auto-title generation timing
- **Scope**: `packages/core/src/services/sessionTitle.ts` + test
- **Breaking changes**: None
- **Out of scope**: Title quality/coverage heuristics (future improvement)

## Linked Issues

N/A — small bug fix identified during daemon session testing.
