### PR TITLE
fix release integration env controls

### DIFF
--- a/integration-tests/cli/qwen-config-dir.test.ts
+++ b/integration-tests/cli/qwen-config-dir.test.ts
@@ -57,6 +57,7 @@ describe('QWEN_HOME environment variable', () => {
     // Always clean up env vars regardless of test outcome
     delete process.env['QWEN_HOME'];
     delete process.env['QWEN_RUNTIME_DIR'];
+    delete process.env['QWEN_DEBUG_LOG_FILE'];
     await rig.cleanup();
   });
 
@@ -324,6 +325,7 @@ describe('QWEN_HOME environment variable', () => {
 
       process.env['QWEN_HOME'] = customConfigDir;
       process.env['QWEN_RUNTIME_DIR'] = runtimeDir;
+      process.env['QWEN_DEBUG_LOG_FILE'] = '1';
 
       try {
         await rig.run('say hello');

--- a/integration-tests/cli/simple-mcp-server.test.ts
+++ b/integration-tests/cli/simple-mcp-server.test.ts
@@ -169,6 +169,7 @@ rpc.send({
 
 describe('simple-mcp-server', () => {
   const rig = new TestRig();
+  let previousLegacyMcpBlocking: string | undefined;
   let previousMcpApprovalsPath: string | undefined;
 
   beforeAll(async () => {
@@ -177,6 +178,7 @@ describe('simple-mcp-server', () => {
     // request fires without the MCP `add` tool wired into the model's tool
     // surface, so the model answers `15` directly and `foundToolCall` stays
     // false. Remove once QwenLM/qwen-code#4163 is fixed.
+    previousLegacyMcpBlocking = process.env['QWEN_CODE_LEGACY_MCP_BLOCKING'];
     process.env['QWEN_CODE_LEGACY_MCP_BLOCKING'] = '1';
 
     // Setup test directory with MCP server configuration
@@ -238,6 +240,12 @@ describe('simple-mcp-server', () => {
   });
 
   afterAll(() => {
+    if (previousLegacyMcpBlocking === undefined) {
+      delete process.env['QWEN_CODE_LEGACY_MCP_BLOCKING'];
+    } else {
+      process.env['QWEN_CODE_LEGACY_MCP_BLOCKING'] = previousLegacyMcpBlocking;
+    }
+
     if (previousMcpApprovalsPath === undefined) {
       delete process.env['QWEN_CODE_MCP_APPROVALS_PATH'];
     } else {

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -634,6 +634,22 @@ export async function start_sandbox(
       `QWEN_CODE_TEST_VAR=${process.env['QWEN_CODE_TEST_VAR']}`,
     );
   }
+  for (const envVar of [
+    'QWEN_DEBUG_LOG_FILE',
+    'QWEN_CODE_LEGACY_MCP_BLOCKING',
+  ] as const) {
+    if (process.env[envVar]) {
+      args.push('--env', `${envVar}=${process.env[envVar]}`);
+    }
+  }
+  if (process.env['QWEN_CODE_MCP_APPROVALS_PATH']) {
+    args.push(
+      '--env',
+      `QWEN_CODE_MCP_APPROVALS_PATH=${getContainerPath(
+        process.env['QWEN_CODE_MCP_APPROVALS_PATH'],
+      )}`,
+    );
+  }
 
   // copy GEMINI_API_KEY(s)
   if (process.env['GEMINI_API_KEY']) {


### PR DESCRIPTION
## What this PR does

Restores the release integration test controls that became implicit after debug file logging was made opt-in.

This makes the QWEN_RUNTIME_DIR debug-log assertion explicitly enable file logging, and passes the release integration environment controls into the Docker sandbox so the sandboxed CLI sees the same test setup as the host process.

## Why it's needed

The scheduled release workflow started failing after #4914 changed debug log file creation to require `QWEN_DEBUG_LOG_FILE=1`. The existing QWEN_HOME/QWEN_RUNTIME_DIR integration test still expected debug files without opting in, and Docker integration lost the MCP test controls at the sandbox boundary.

## Reviewer Test Plan

### How to verify

Run the affected no-sandbox integration files and confirm `qwen-config-dir` and `simple-mcp-server` pass. In Docker CI, confirm the same tests no longer fail because `QWEN_DEBUG_LOG_FILE`, `QWEN_CODE_LEGACY_MCP_BLOCKING`, and `QWEN_CODE_MCP_APPROVALS_PATH` are available inside the sandbox.

### Evidence (Before & After)

Before: release run 27516870586 failed in `qwen-config-dir.test.ts` because no debug log files were created, and Docker `simple-mcp-server.test.ts` could not observe the expected MCP tool call. After: `QWEN_SANDBOX=false npx vitest run --root ./integration-tests cli/qwen-config-dir.test.ts cli/simple-mcp-server.test.ts --poolOptions.threads.maxThreads 1` passes with 2 files and 8 tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS, Node.js v22.22.0. `npm install` completed and ran `build`/`bundle`; `npx prettier --check integration-tests/cli/qwen-config-dir.test.ts integration-tests/cli/simple-mcp-server.test.ts packages/cli/src/utils/sandbox.ts`; `npx eslint integration-tests/cli/qwen-config-dir.test.ts integration-tests/cli/simple-mcp-server.test.ts packages/cli/src/utils/sandbox.ts`; `npm run typecheck`.

## Risk & Scope

- Main risk or tradeoff: Docker sandbox now forwards three narrowly scoped Qwen integration/control environment variables when present.
- Not validated / out of scope: local Docker integration was not run; CI should validate the Docker sandbox path.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5117

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

恢复 release integration tests 依赖的测试控制变量，适配 #4914 之后 debug file logging 需要显式 opt-in 的行为。

这个改动让 QWEN_RUNTIME_DIR 的 debug log 断言显式设置 `QWEN_DEBUG_LOG_FILE=1`，并把 release integration 需要的环境变量传进 Docker sandbox，确保 sandbox 内 CLI 看到的测试配置和宿主进程一致。

## 为什么需要

#4914 把 debug log file 创建改成需要 `QWEN_DEBUG_LOG_FILE=1` 后，定时 release workflow 开始失败。原来的 QWEN_HOME/QWEN_RUNTIME_DIR integration test 没有显式 opt-in 却仍然期待 debug 文件；Docker integration 还会在 sandbox 边界丢失 MCP 测试控制变量。

## Reviewer Test Plan

### 如何验证

运行受影响的 no-sandbox integration 文件，确认 `qwen-config-dir` 和 `simple-mcp-server` 通过。在 Docker CI 中，确认同一组测试不再因为 `QWEN_DEBUG_LOG_FILE`、`QWEN_CODE_LEGACY_MCP_BLOCKING` 和 `QWEN_CODE_MCP_APPROVALS_PATH` 没有进入 sandbox 而失败。

### 证据（修改前/修改后）

修改前：release run 27516870586 中 `qwen-config-dir.test.ts` 因未生成 debug log files 失败，Docker `simple-mcp-server.test.ts` 无法观察到预期 MCP tool call。修改后：`QWEN_SANDBOX=false npx vitest run --root ./integration-tests cli/qwen-config-dir.test.ts cli/simple-mcp-server.test.ts --poolOptions.threads.maxThreads 1` 通过，2 个文件、8 个测试。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### 环境（可选）

本地 macOS，Node.js v22.22.0。`npm install` 完成并触发 `build`/`bundle`；已运行 `npx prettier --check integration-tests/cli/qwen-config-dir.test.ts integration-tests/cli/simple-mcp-server.test.ts packages/cli/src/utils/sandbox.ts`、`npx eslint integration-tests/cli/qwen-config-dir.test.ts integration-tests/cli/simple-mcp-server.test.ts packages/cli/src/utils/sandbox.ts`、`npm run typecheck`。

## 风险和范围

- 主要风险或取舍：Docker sandbox 现在会在存在时转发 3 个范围很窄的 Qwen integration/control 环境变量。
- 未验证 / 不在范围内：本地没有跑 Docker integration；Docker sandbox 路径交给 CI 验证。
- Breaking changes / migration notes：无。

## 关联 Issues

Fixes #5117

</details>