### PR TITLE
fix(core): honor skipLoopDetection for the deterministic tool-call loop

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -6070,7 +6070,7 @@ Other open files:
       expect(mockCheckNextSpeaker).not.toHaveBeenCalled();
     });
 
-    it('keeps deterministic tool-call checks when skipLoopDetection is true', async () => {
+    it('does not run loop checks when skipLoopDetection is true', async () => {
       // Arrange
       // Ensure config returns true for skipLoopDetection
       vi.spyOn(client['config'], 'getSkipLoopDetection').mockReturnValue(true);
@@ -6106,13 +6106,14 @@ Other open files:
         // consume stream
       }
 
-      expect(ldMock.addAndCheckDeterministicToolCallLoop).toHaveBeenCalledTimes(
-        2,
-      );
+      // Assert - neither detector path runs when skipLoopDetection is true
+      expect(
+        ldMock.addAndCheckDeterministicToolCallLoop,
+      ).not.toHaveBeenCalled();
       expect(ldMock.addAndCheckHeuristicLoops).not.toHaveBeenCalled();
     });
 
-    it('hard-stops identical tool calls even when skipLoopDetection is true', async () => {
+    it('does not hard-stop identical tool calls when skipLoopDetection is true', async () => {
       vi.spyOn(client['config'], 'getSkipLoopDetection').mockReturnValue(true);
 
       mockTurnRunFn.mockReturnValue(
@@ -6141,6 +6142,45 @@ Other open files:
           [{ text: 'repeat a tool' }],
           new AbortController().signal,
           'prompt-id-skip-loop-identical',
+        ),
+      );
+
+      // skipLoopDetection defaults to true, so even repeated identical calls
+      // must not be halted — the documented escape hatch stays effective.
+      expect(events.some((e) => e.type === GeminiEventType.LoopDetected)).toBe(
+        false,
+      );
+    });
+
+    it('hard-stops identical tool calls when loop detection is enabled', async () => {
+      vi.spyOn(client['config'], 'getSkipLoopDetection').mockReturnValue(false);
+
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          for (let i = 0; i < 5; i++) {
+            yield {
+              type: GeminiEventType.ToolCallRequest,
+              value: {
+                callId: `repeat-${i}`,
+                name: 'run_shell_command',
+                args: { command: 'echo repeated' },
+              },
+            };
+          }
+        })(),
+      );
+
+      const mockChat: Partial<GeminiChat> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+      };
+      client['chat'] = mockChat as GeminiChat;
+
+      const events = await fromAsync(
+        client.sendMessageStream(
+          [{ text: 'repeat a tool' }],
+          new AbortController().signal,
+          'prompt-id-loop-identical',
         ),
       );
 

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -2097,11 +2097,20 @@ export class GeminiClient {
           didUpdateIdeContextState = true;
         }
 
+        // Loop detection is opt-in: `model.skipLoopDetection` defaults to true
+        // (see settingsSchema) to avoid false-positive interruptions. Keep BOTH
+        // the deterministic identical-tool-call check and the heuristic checks
+        // behind this single flag so the documented `model.skipLoopDetection`
+        // escape hatch stays honest (including the non-interactive hint in
+        // nonInteractiveCli.ts). The deterministic split, retry-reset, and
+        // pending-call splice below still apply once detection is enabled.
+        const skipLoopDetection = this.config.getSkipLoopDetection();
         const deterministicToolCallLoop =
+          !skipLoopDetection &&
           this.loopDetector.addAndCheckDeterministicToolCallLoop(event);
         const heuristicLoop =
           !deterministicToolCallLoop &&
-          !this.config.getSkipLoopDetection() &&
+          !skipLoopDetection &&
           this.loopDetector.addAndCheckHeuristicLoops(event);
         if (deterministicToolCallLoop || heuristicLoop) {
           const loopType = this.loopDetector.getLastLoopType();


### PR DESCRIPTION
## What this PR does

Restores `model.skipLoopDetection` as the single gate for **all** streaming loop detection, including the deterministic identical-tool-call check, so that loop detection stays fully off under the default configuration and the documented escape hatch works again.

## Why it's needed

#5036 split the identical-tool-call detector into a "deterministic" path and deliberately ran it **outside** the `skipLoopDetection` gate (only the heuristic detectors stayed behind the flag). That breaks two established contracts. First, `skipLoopDetection` **defaults to `true`** — both in the CLI wiring (`settings.model?.skipLoopDetection ?? true`) and in the settings schema, which documents the intent verbatim: *"Defaults to true to avoid false-positive interruptions; set to false to re-enable as an unattended-run guardrail."* After #5036 the identical-tool-call hard-stop fired even for that default config, silently re-introducing the very false-positive interruptions the default was chosen to avoid. Second, it broke the documented escape hatch: `nonInteractiveCli.ts` tells users *"Set the `model.skipLoopDetection` setting to true to disable"*, but that no longer disabled this halt — and in non-interactive mode there is no disable dialog (`disableForSession()` is unreachable), so a halted run had no documented way out.

This PR gates both detector paths behind the one flag again. The runaway-identical-call guard from #5036 stays available as an explicit opt-in (`skipLoopDetection: false`) without overriding the default-off product decision, and all of #5036's improvements — the deterministic split, the retry-reset of the consecutive counter, and the pending-tool-call splice — are preserved for the opt-in path.

## Reviewer Test Plan

### How to verify

Confirm the gate is applied to both paths in `packages/core/src/core/client.ts` (the `skipLoopDetection` variable now short-circuits `addAndCheckDeterministicToolCallLoop` as well as `addAndCheckHeuristicLoops`), then run the targeted checks below.

```bash
npm run test:ci --workspace=packages/core -- src/services/loopDetectionService.test.ts src/core/client.test.ts
npx prettier --check packages/core/src/core/client.ts packages/core/src/core/client.test.ts
npx eslint packages/core/src/core/client.ts packages/core/src/core/client.test.ts
npm run typecheck --workspace=packages/core
```

Expected: the service-level loop tests pass unchanged (the #5036 retry-reset / `getConsecutiveToolCallCount` tests are untouched), and the three client-level tests below pass — `does not run loop checks when skipLoopDetection is true` (neither detector path is invoked under the default), `does not hard-stop identical tool calls when skipLoopDetection is true` (5 identical calls produce no `LoopDetected` under the default), and `hard-stops identical tool calls when loop detection is enabled` (with `skipLoopDetection: false`, 5 identical calls still hard-stop with `CONSECUTIVE_IDENTICAL_TOOL_CALLS`).

### Evidence (Before & After)

This is request-halting behavior gated by a config flag, not a visible TUI state, so screenshots are N/A; the deterministic evidence is the unit tests. **Before** (with #5036, default `skipLoopDetection: true`): five identical tool calls emit `LoopDetected` / `CONSECUTIVE_IDENTICAL_TOOL_CALLS` and the run is halted with *"A potential loop was detected … The request has been halted."* **After** (this PR, same default): the same five calls emit no `LoopDetected` and the stream proceeds; with `skipLoopDetection: false` the hard-stop still fires. Local run: `loopDetectionService.test.ts` 45 passed; `client.test.ts` loop tests 6 passed (including the 3 above); prettier / eslint / `tsc --noEmit` clean.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A — macOS verified locally; Windows/Linux covered by CI -->

### Environment (optional)

Local unit tests only (vitest under `packages/core`); no runtime/sandbox needed.

## Risk & Scope

- Main risk or tradeoff: changes **who** the loop halt applies to — it reverts the default-config halt introduced by #5036 while keeping the guard for `skipLoopDetection: false`. No threshold or detector-logic change.
- Not validated / out of scope: the heuristic detectors (read-file loop, action stagnation, content chanting, repetitive thoughts) are unchanged; their behavior is unaffected beyond remaining behind the same flag they were already behind.
- Breaking changes / migration notes: none. Reverse-audited that `addAndCheckDeterministicToolCallLoop` / `addAndCheckHeuristicLoops` have exactly one consumer (`client.ts`); the non-interactive path consumes the `LoopDetected` event, so this single gate covers both interactive and non-interactive runs.

## Linked Issues

Relates to #5036 (corrects a regression introduced there). No closing keyword — there is no separate open issue.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 `model.skipLoopDetection` 重新恢复为**所有**流式循环检测(包括确定性的"连续相同工具调用"检测)的唯一开关,使默认配置下循环检测完全关闭,并让有文档的逃生通道重新生效。

## 为什么需要

#5036 把"相同工具调用"检测拆成了一条确定性路径,并刻意让它跑在 `skipLoopDetection` 开关**之外**(只有启发式检测器还在开关后面)。这破坏了两个既定契约。其一,`skipLoopDetection` **默认就是 `true`**——CLI 层(`settings.model?.skipLoopDetection ?? true`)和 settings schema 都是,schema 描述还原文写明了意图:*"Defaults to true to avoid false-positive interruptions; set to false to re-enable as an unattended-run guardrail."* #5036 之后,相同工具调用的 hard-stop 对该默认配置也会触发,等于悄悄把"默认关闭以避免误报打断"这个决策推翻了。其二,它破坏了有文档的逃生通道:`nonInteractiveCli.ts` 提示用户*"把 `model.skipLoopDetection` 设为 true 即可关闭"*,但这已经关不掉该 halt;而非交互模式没有 disable 对话框(`disableForSession()` 够不着),撞上后没有任何有文档的关法。

本 PR 把两条检测路径重新关回同一个开关后面。#5036 的"相同调用失控"兜底作为显式 opt-in(`skipLoopDetection: false`)依然可用,不推翻默认关闭的产品决策;同时 #5036 的全部改进——确定性拆分、连续计数的 retry 重置、重复 pending 调用的 splice——在 opt-in 路径上全部保留。

## Reviewer Test Plan

### 如何验证

确认 `packages/core/src/core/client.ts` 里的开关同时作用于两条路径(`skipLoopDetection` 变量现在对 `addAndCheckDeterministicToolCallLoop` 和 `addAndCheckHeuristicLoops` 都做了短路),然后运行下面的针对性检查:

```bash
npm run test:ci --workspace=packages/core -- src/services/loopDetectionService.test.ts src/core/client.test.ts
npx prettier --check packages/core/src/core/client.ts packages/core/src/core/client.test.ts
npx eslint packages/core/src/core/client.ts packages/core/src/core/client.test.ts
npm run typecheck --workspace=packages/core
```

预期:service 层循环测试照常通过(#5036 的 retry 重置 / `getConsecutiveToolCallCount` 测试未改动),下面三个 client 层测试通过——`does not run loop checks when skipLoopDetection is true`(默认下两条路径都不被调用)、`does not hard-stop identical tool calls when skipLoopDetection is true`(默认下 5 次相同调用不产生 `LoopDetected`)、`hard-stops identical tool calls when loop detection is enabled`(`skipLoopDetection: false` 时 5 次相同调用仍以 `CONSECUTIVE_IDENTICAL_TOOL_CALLS` hard-stop)。

### 证据(前后对比)

这是由配置开关控制的"请求中止"行为,不是可见的 TUI 状态,因此截图不适用;确定性证据是单元测试。**修改前**(#5036,默认 `skipLoopDetection: true`):5 次相同工具调用发出 `LoopDetected` / `CONSECUTIVE_IDENTICAL_TOOL_CALLS`,运行被中止并提示*"A potential loop was detected … The request has been halted."* **修改后**(本 PR,同样默认):同样 5 次调用不再发出 `LoopDetected`,流继续;`skipLoopDetection: false` 时 hard-stop 仍触发。本地运行:`loopDetectionService.test.ts` 45 通过;`client.test.ts` 循环测试 6 通过(含上述 3 个);prettier / eslint / `tsc --noEmit` 干净。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ 已测 · ⚠️ 未测 · N/A —— macOS 本地已验证;Windows/Linux 由 CI 覆盖 -->

### 环境(可选)

仅本地单元测试(`packages/core` 下的 vitest);无需运行时/沙箱。

## 风险与范围

- 主要风险或权衡:改变 halt 的**适用对象**——撤销 #5036 对默认配置的拦截,同时为 `skipLoopDetection: false` 保留兜底。未改任何阈值或检测逻辑。
- 未验证 / 范围之外:启发式检测器(read-file loop、action stagnation、content chanting、repetitive thoughts)未改动;除了仍处于它们本就所在的同一开关后面之外,行为不受影响。
- 破坏性变更 / 迁移说明:无。已反向审计:`addAndCheckDeterministicToolCallLoop` / `addAndCheckHeuristicLoops` 只有 `client.ts` 一个消费点;非交互路径消费的是 `LoopDetected` 事件,所以这一个开关同时覆盖交互/非交互。

## 关联 Issue

关联 #5036(修正其引入的回归)。不使用关闭关键字——没有单独的 open issue。

</details>
