### PR TITLE
ci: publish autofix PRs as qwen-code-ci-bot

### DIFF
--- a/.github/workflows/qwen-scheduled-issue-autofix.yml
+++ b/.github/workflows/qwen-scheduled-issue-autofix.yml
@@ -428,11 +428,19 @@ jobs:
         if: |-
           ${{ steps.decision.outputs.go_issue != '' && inputs.dry_run != true }}
         env:
-          # AUTOFIX_BOT_TOKEN (a PAT or GitHub App token) is preferred so the
-          # created PR triggers CI; PRs created with GITHUB_TOKEN do not.
-          GITHUB_TOKEN: '${{ secrets.AUTOFIX_BOT_TOKEN || secrets.GITHUB_TOKEN }}'
+          # The qwen-code-ci-bot PAT (QWEN_CODE_BOT_TOKEN, falling back to
+          # CI_BOT_PAT — the same secrets the issue follow-up bot uses) opens
+          # the PR as qwen-code-ci-bot. This is required: the default
+          # GITHUB_TOKEN is blocked from creating PRs ("GitHub Actions is not
+          # permitted to create or approve pull requests"), and PRs it does
+          # create do not trigger CI. The bot PAT clears both problems.
+          GITHUB_TOKEN: '${{ secrets.QWEN_CODE_BOT_TOKEN || secrets.CI_BOT_PAT }}'
           ISSUE: '${{ steps.decision.outputs.go_issue }}'
         run: |-
+          if [[ -z "${GITHUB_TOKEN}" ]]; then
+            echo '::error::QWEN_CODE_BOT_TOKEN or CI_BOT_PAT is required to publish the PR as qwen-code-ci-bot.'
+            exit 1
+          fi
           BRANCH="autofix/issue-${ISSUE}"
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git"
           git push --force-with-lease origin "${BRANCH}"


### PR DESCRIPTION
## Summary

The scheduled issue autofix workflow's **Publish PR** step has been failing at the final step. The most recent run developed and verified a fix and pushed the branch, then died on:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
```

Root cause: the step's token was `secrets.AUTOFIX_BOT_TOKEN || secrets.GITHUB_TOKEN`, but `AUTOFIX_BOT_TOKEN` was never configured, so it fell back to the default `GITHUB_TOKEN` — which GitHub blocks from creating pull requests. The default token also does not trigger CI on PRs it manages to create.

## Change

Use the `qwen-code-ci-bot` PAT (`QWEN_CODE_BOT_TOKEN`, falling back to `CI_BOT_PAT`) — the **same secrets the issue follow-up bot already uses**. As a real-account token it:

- bypasses the "GitHub Actions is not permitted to create or approve pull requests" restriction, and
- triggers CI on the opened PR (which `GITHUB_TOKEN` would not).

The PR is therefore authored by `qwen-code-ci-bot`, consistent with the other issue bots. A guard is added that fails with a clear message if neither secret is configured, instead of silently falling back to a token that cannot create PRs.

## Prerequisite

`qwen-code-ci-bot`'s PAT must have **contents: write** (push the branch) and **pull-requests: write** (open the PR). A classic `repo`-scoped PAT covers both; a fine-grained PAT needs Contents + Pull requests write on this repo.

## Testing

Workflow-only change; no application code touched. The autofix branch from the failed run is already pushed, so a `workflow_dispatch` re-run will exercise this path end to end once the secret scope is confirmed.
