### PR TITLE
docs: rewrite CLAUDE.md to point to AGENTS.md as authoritative source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ package-lock.json
 .cursor
 .qoder
 .claude
-CLAUDE.md
 .codex
 
 # Qwen Code Configs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+**Read [`AGENTS.md`](AGENTS.md) — it is the single source of truth for all coding conventions, build/test commands, code style, commit conventions, PR workflow, and review guidelines. All rules in AGENTS.md apply to Claude Code.**


### PR DESCRIPTION
## What this PR does

The existing `CLAUDE.md` was a standalone ~100-line project overview with no reference to `AGENTS.md`, and was gitignored so it was never tracked. When contributors use Claude Code to submit PRs, Claude Code reads only `CLAUDE.md` — it never sees our PR template, commit conventions, or review workflow defined in `AGENTS.md`. This led to PRs like #5137 where the tool followed its own context file style instead of our project conventions.

This PR:
- Rewrites `CLAUDE.md` as a thin pointer that tells Claude Code to read `AGENTS.md` as the single source of truth
- Removes `CLAUDE.md` from `.gitignore` so it is tracked in version control

No duplicated content — `AGENTS.md` remains the authoritative source for all rules.

## Why it is needed

Our project already supports multiple AI coding tools — Qwen Code reads `QWEN.md` + `AGENTS.md`, Codex reads `AGENTS.md` (same file, zero extra work), and Gemini CLI reads `GEMINI.md`. But `CLAUDE.md` was previously gitignored and contained a standalone project overview with no reference to our actual conventions.

By making `CLAUDE.md` a lightweight bridge to `AGENTS.md` instead of a parallel source of truth, we ensure all contributors — regardless of which AI coding tool they use — follow the same PR workflow, commit conventions, and code style. No product code changes needed; this is purely a repository-level fix.

## Reviewer Test Plan

### How to verify

1. Open this repo in Claude Code (or simulate what Claude Code would read)
2. Confirm Claude Code now sees the `AGENTS.md` reference and PR template requirement
3. Verify `.gitignore` no longer ignores `CLAUDE.md`

### Evidence (Before and After)

- **Before:** `CLAUDE.md` was gitignored and contained a ~100-line standalone project overview with no mention of `AGENTS.md`, PR template, or commit conventions.
- **After:** `CLAUDE.md` is tracked in git. It is a 3-line pointer to `AGENTS.md` — the single source of truth.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

## Risk and Scope

- Main risk or tradeoff: None. The file is a pointer, not a duplicate source of truth.
- Not validated / out of scope: Other tools config files (GEMINI.md, etc.) — not in scope.
- Breaking changes / migration notes: None.

## Linked Issues

Related: #5137

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

现有的 `CLAUDE.md` 是一份约 100 行的独立项目概述，没有引用 `AGENTS.md`，且被 `.gitignore` 忽略从未纳入版本控制。当贡献者使用 Claude Code 提交 PR 时，Claude Code 只读 `CLAUDE.md`——它永远看不到我们在 `AGENTS.md` 中定义的 PR 模板、commit 规范和 review 流程。这导致像 #5137 这样的 PR，工具遵循的是自己 context file 的风格而不是项目的规范。

本 PR：
- 将 `CLAUDE.md` 重写为 3 行指针文件，告诉 Claude Code 去读 `AGENTS.md` 作为唯一权威来源
- 从 `.gitignore` 中移除 `CLAUDE.md` 使其纳入版本控制

不重复任何内容——`AGENTS.md` 仍然是所有规则的唯一来源。

## 为什么需要

我们的项目已经支持多种 AI 编码工具——Qwen Code 读 `QWEN.md` + `AGENTS.md`，Codex 读 `AGENTS.md`（同名文件，零额外工作），Gemini CLI 读 `GEMINI.md`。但 `CLAUDE.md` 之前被 gitignore 忽略，且内容是一份独立的项目概述，完全没有引用我们的实际规范。

通过让 `CLAUDE.md` 成为指向 `AGENTS.md` 的轻量桥梁，而不是平行的信息源，我们确保所有贡献者——无论使用哪种 AI 编码工具——都遵循相同的 PR 流程、commit 规范和代码风格。不需要改动产品代码，纯粹是仓库层面的修复。

</details>
