### PR TITLE
fix(core): simplify edit tool description to path only

### DIFF
--- a/packages/core/src/tools/edit.test.ts
+++ b/packages/core/src/tools/edit.test.ts
@@ -1043,7 +1043,7 @@ describe('EditTool', () => {
       );
     });
 
-    it('should return a snippet of old and new strings if they are different', () => {
+    it('should return the file path when old and new strings differ', () => {
       const testFileName = 'test.txt';
       const params: EditToolParams = {
         file_path: path.join(rootDir, testFileName),
@@ -1051,14 +1051,10 @@ describe('EditTool', () => {
         new_string: 'this is the new string value',
       };
       const invocation = tool.build(params);
-      // shortenPath will be called internally, resulting in just the file name
-      // The snippets are truncated at 30 chars + '...'
-      expect(invocation.getDescription()).toBe(
-        `${testFileName}: this is the old string value => this is the new string value`,
-      );
+      expect(invocation.getDescription()).toBe(testFileName);
     });
 
-    it('should handle very short strings correctly in the description', () => {
+    it('should return the file path for short strings', () => {
       const testFileName = 'short.txt';
       const params: EditToolParams = {
         file_path: path.join(rootDir, testFileName),
@@ -1066,22 +1062,7 @@ describe('EditTool', () => {
         new_string: 'new',
       };
       const invocation = tool.build(params);
-      expect(invocation.getDescription()).toBe(`${testFileName}: old => new`);
-    });
-
-    it('should truncate long strings in the description', () => {
-      const testFileName = 'long.txt';
-      const params: EditToolParams = {
-        file_path: path.join(rootDir, testFileName),
-        old_string:
-          'this is a very long old string that will definitely be truncated',
-        new_string:
-          'this is a very long new string that will also be truncated',
-      };
-      const invocation = tool.build(params);
-      expect(invocation.getDescription()).toBe(
-        `${testFileName}: this is a very long old string... => this is a very long new string...`,
-      );
+      expect(invocation.getDescription()).toBe(testFileName);
     });
   });
 

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -427,17 +427,10 @@ class EditToolInvocation implements ToolInvocation<EditToolParams, ToolResult> {
       return `Create ${shortenPath(relativePath)}`;
     }
 
-    const oldStringSnippet =
-      this.params.old_string.split('\n')[0].substring(0, 30) +
-      (this.params.old_string.length > 30 ? '...' : '');
-    const newStringSnippet =
-      this.params.new_string.split('\n')[0].substring(0, 30) +
-      (this.params.new_string.length > 30 ? '...' : '');
-
     if (this.params.old_string === this.params.new_string) {
       return `No file changes to ${shortenPath(relativePath)}`;
     }
-    return `${shortenPath(relativePath)}: ${oldStringSnippet} => ${newStringSnippet}`;
+    return shortenPath(relativePath);
   }
 
   /**


### PR DESCRIPTION
## What this PR does

The edit tool's `getDescription()` previously embedded code snippets from `old_string` and `new_string` (first 30 chars of the first line, joined by `=>`). This PR simplifies it to return only the file path, matching the write-file tool's convention.

## Why it's needed

When the code snippet contains tab characters, the rendering pipeline breaks: `string-width` (which we use directly in 10+ places and Ink uses internally) [counts `\t` as 0 width](https://github.com/sindresorhus/string-width/issues/45), but terminals render tabs as 4-8 columns (advancing to the next tab stop). Ink's layout engine thinks the description fits on one line, but the terminal wraps it to two lines. This causes the `CompactToolGroupDisplay` box border (`borderStyle="round"`) to be redrawn at the wrong position on every render frame, producing stacked/duplicated borders.

The DiffRenderer already handles this correctly by replacing tabs with spaces before rendering. However, since the full diff is already rendered below the description, embedding code snippets in the description is redundant — the user sees the exact same content in the diff display.

## Reviewer Test Plan

### How to verify

1. Run `npm run build && npm run bundle` then `npm run dev`.
2. Trigger an edit on a file where the `old_string` starts with a tab-indented line (e.g., Go code with tab indentation).
3. Verify the edit tool's header line shows just the file path (no code snippets), and the box border renders cleanly without duplication.

### Evidence (Before & After)

Before: `Edit pkg/app/qz/cmd_test.go: \t_, err := runCommand(t, tp,... => \t_, err := runCommand(t, tp,...` — causes border stacking bug when tab is present.

After: `Edit pkg/app/qz/cmd_test.go` — clean, no tab characters, diff below shows the same information.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅     |
| 🪟 Windows | N/A    |
|  🐧 Linux  | N/A    |

## Risk & Scope

- Main risk or tradeoff: Users who relied on the inline snippet in scrollback history lose that quick preview, but the diff is always available.
- Not validated / out of scope: UI-layer tab sanitization for other tools' descriptions (no other tool currently embeds code content in its description).
- Breaking changes / migration notes: None. The description is display-only and not part of any API contract.

<details>
<summary>中文说明</summary>

edit 工具的 `getDescription()` 之前会在描述中嵌入 `old_string` 和 `new_string` 的代码片段（第一行前30个字符，用 `=>` 连接）。本次 PR 将其简化为仅返回文件路径，与 write-file 工具保持一致。

当代码片段包含 tab 字符时，渲染管线会出问题：`string-width`（我们在 10+ 处直接使用，Ink 内部也依赖它）[将 `\t` 计为 0 宽度](https://github.com/sindresorhus/string-width/issues/45)，但终端会将 tab 渲染为 4-8 列（前进到下一个 tab stop）。Ink 的布局引擎认为描述能放在一行内，但终端实际上将其换行为两行。这导致 `CompactToolGroupDisplay` 的边框（`borderStyle="round"`）在每次渲染帧时被重绘到错误的位置，产生堆叠/重复的边框。

DiffRenderer 通过在渲染前将 tab 替换为空格已经正确处理了这个问题。但由于完整 diff 已经在描述下方渲染，在描述中嵌入代码片段是冗余的——用户在 diff 展示中看到的是完全相同的内容。

</details>
