### PR TITLE
fix(openai): add streaming inactivity watchdog to prevent mid-stream hangs

### DIFF
--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -81,6 +81,7 @@ export type ContentGeneratorConfig = {
   enableOpenAILogging?: boolean;
   openAILoggingDir?: string;
   timeout?: number; // Timeout configuration in milliseconds
+  streamIdleTimeoutMs?: number; // Inactivity timeout between streamed chunks, in ms (<= 0 disables)
   maxRetries?: number; // Maximum retries for rate-limit errors
   retryErrorCodes?: number[]; // Additional error codes that trigger rate-limit retry
   enableCacheControl?: boolean; // Enable cache control for DashScope providers

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -20,7 +20,10 @@ import {
   StreamEventType,
   type StreamEvent,
 } from './geminiChat.js';
-import { StreamContentError } from './openaiContentGenerator/pipeline.js';
+import {
+  StreamContentError,
+  StreamIdleTimeoutError,
+} from './openaiContentGenerator/pipeline.js';
 import type { Config } from '../config/config.js';
 import { setSimulate429 } from '../utils/testUtils.js';
 import { uiTelemetryService } from '../telemetry/uiTelemetry.js';
@@ -5424,6 +5427,92 @@ describe('GeminiChat', async () => {
       );
     }
     expect(turn2.parts[0].text).toBe('Successful response after empty');
+  });
+  it('retries the stream once when it stalls mid-flight (StreamIdleTimeoutError)', async () => {
+    // 1. First call yields a partial chunk then the idle watchdog fires;
+    //    second call returns a valid stream.
+    vi.mocked(mockContentGenerator.generateContentStream)
+      .mockImplementationOnce(
+        async () =>
+          (async function* () {
+            yield {
+              candidates: [{ content: { parts: [{ text: 'partial' }] } }],
+            } as unknown as GenerateContentResponse;
+            throw new StreamIdleTimeoutError(1234);
+          })(),
+      )
+      .mockImplementationOnce(
+        async () =>
+          (async function* () {
+            yield {
+              candidates: [
+                {
+                  content: { parts: [{ text: 'recovered response' }] },
+                  finishReason: 'STOP',
+                },
+              ],
+            } as unknown as GenerateContentResponse;
+          })(),
+      );
+
+    // 2. Consume the stream.
+    const stream = await chat.sendMessageStream(
+      'test-model',
+      { message: 'test idle retry' },
+      'prompt-id-idle-retry',
+    );
+    const chunks: StreamEvent[] = [];
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+
+    // 3. Assert: exactly one re-stream, a RETRY event surfaced, the recovered
+    //    response delivered, and the discarded partial absent from history.
+    expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(2);
+    expect(chunks.some((c) => c.type === StreamEventType.RETRY)).toBe(true);
+    expect(
+      chunks.some(
+        (c) =>
+          c.type === StreamEventType.CHUNK &&
+          c.value.candidates?.[0]?.content?.parts?.[0]?.text ===
+            'recovered response',
+      ),
+    ).toBe(true);
+
+    const history = chat.getHistory();
+    expect(history.length).toBe(2);
+    const turn2 = history[1];
+    if (!turn2?.parts?.[0] || !('text' in turn2.parts[0])) {
+      throw new Error('Test setup error: second turn is not a valid text part.');
+    }
+    expect(turn2.parts[0].text).toBe('recovered response');
+  });
+  it('propagates StreamIdleTimeoutError after the retry budget is exhausted', async () => {
+    // Every attempt stalls mid-stream — the bounded retry must give up and
+    // surface the error rather than looping or hanging.
+    vi.mocked(mockContentGenerator.generateContentStream).mockImplementation(
+      async () =>
+        (async function* () {
+          yield {
+            candidates: [{ content: { parts: [{ text: 'partial' }] } }],
+          } as unknown as GenerateContentResponse;
+          throw new StreamIdleTimeoutError(1234);
+        })(),
+    );
+
+    const stream = await chat.sendMessageStream(
+      'test-model',
+      { message: 'test idle exhausted' },
+      'prompt-id-idle-exhausted',
+    );
+    const consume = async () => {
+      for await (const _chunk of stream) {
+        // drain
+      }
+    };
+    await expect(consume()).rejects.toBeInstanceOf(StreamIdleTimeoutError);
+    // 1 initial + 1 retry = 2 attempts (INVALID_CONTENT_RETRY_OPTIONS.maxAttempts).
+    expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(2);
   });
   it('should queue a subsequent sendMessageStream call until the first stream is fully consumed', async () => {
     // 1. Create a promise to manually control the stream's lifecycle

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -81,6 +81,7 @@ import {
   collectToolCallIdsFromHistory,
   normalizeModelToolCallIds,
 } from './toolCallIdUtils.js';
+import { StreamIdleTimeoutError } from './openaiContentGenerator/pipeline.js';
 
 const debugLogger = createDebugLogger('QWEN_CODE_CHAT');
 
@@ -2293,6 +2294,30 @@ export class GeminiChat {
                 continue;
               }
             }
+
+            // A mid-stream idle timeout (provider stalled after headers) is
+            // transient: re-issue the stream once before giving up, mirroring
+            // the invalid-content path above (same bounded budget + partial
+            // cleanup). Without this the stalled turn fails outright; with it a
+            // single provider hiccup self-heals — the common case behind
+            // parallel-subagent fan-out hangs.
+            if (error instanceof StreamIdleTimeoutError) {
+              if (attempt < INVALID_CONTENT_RETRY_OPTIONS.maxAttempts - 1) {
+                popPartialIfPushed();
+                debugLogger.warn('Stream idle timeout; retrying stream', {
+                  retryPath: 'stream',
+                  retryDecision: 'retry',
+                  attempt: attempt + 1,
+                  maxAttempts: INVALID_CONTENT_RETRY_OPTIONS.maxAttempts,
+                });
+                await delay(
+                  INVALID_CONTENT_RETRY_OPTIONS.initialDelayMs * (attempt + 1),
+                  params.config?.abortSignal,
+                ).promise;
+                continue;
+              }
+            }
+
             break;
           }
         }

--- a/packages/core/src/core/openaiContentGenerator/constants.ts
+++ b/packages/core/src/core/openaiContentGenerator/constants.ts
@@ -1,6 +1,24 @@
 export const DEFAULT_TIMEOUT = 120000;
 export const DEFAULT_MAX_RETRIES = 3;
 
+/**
+ * Inactivity (read) timeout for streaming responses, in milliseconds.
+ *
+ * The OpenAI SDK's `timeout` only bounds time-to-headers: once the response
+ * headers arrive it clears its watchdog (client `fetchWithTimeout` clears the
+ * timer in `finally`), so a provider that opens a stream and then stalls
+ * mid-flight — headers received, SSE body goes silent — is no longer bounded
+ * by anything and the consuming `for await` suspends forever. This value caps
+ * the gap between two consecutive chunks; exceeding it aborts the request so
+ * the stall surfaces as a retryable error instead of a permanent hang.
+ *
+ * It is an *inactivity* budget (reset on every chunk), not a total-duration
+ * budget, so long-but-live streams are unaffected. Override via the
+ * `QWEN_CODE_STREAM_IDLE_TIMEOUT_MS` env var or `contentGenerator.streamIdleTimeoutMs`;
+ * a value `<= 0` disables the watchdog.
+ */
+export const DEFAULT_STREAM_IDLE_TIMEOUT = 120000;
+
 export const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
 export const DEFAULT_DASHSCOPE_BASE_URL =
   'https://dashscope.aliyuncs.com/compatible-mode/v1';

--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -10,7 +10,11 @@ import type OpenAI from 'openai';
 import type { GenerateContentParameters } from '@google/genai';
 import { GenerateContentResponse, Type, FinishReason } from '@google/genai';
 import type { ErrorHandler, PipelineConfig } from './types.js';
-import { ContentGenerationPipeline, StreamContentError } from './pipeline.js';
+import {
+  ContentGenerationPipeline,
+  StreamContentError,
+  StreamIdleTimeoutError,
+} from './pipeline.js';
 import { OpenAIContentConverter } from './converter.js';
 import { openaiRequestCaptureContext } from './requestCaptureContext.js';
 import { StreamingToolCallParser } from './streamingToolCallParser.js';
@@ -1362,6 +1366,146 @@ describe('ContentGenerationPipeline', () => {
           signal: undefined,
         }),
       );
+    });
+
+    it('aborts and throws StreamIdleTimeoutError when the stream stalls mid-flight', async () => {
+      const request: GenerateContentParameters = {
+        model: 'test-model',
+        contents: [{ parts: [{ text: 'Hello' }], role: 'user' }],
+      };
+      // Short inactivity budget so the test resolves quickly.
+      mockContentGeneratorConfig.streamIdleTimeoutMs = 50;
+
+      const mockChunk1 = {
+        id: 'chunk-1',
+        choices: [{ delta: { content: 'Hello' }, finish_reason: null }],
+      } as OpenAI.Chat.ChatCompletionChunk;
+
+      const returnSpy = vi.fn(() =>
+        Promise.resolve({ value: undefined, done: true as const }),
+      );
+      let sent = false;
+      const mockStream: AsyncIterable<OpenAI.Chat.ChatCompletionChunk> = {
+        [Symbol.asyncIterator]() {
+          return {
+            next() {
+              if (!sent) {
+                sent = true;
+                return Promise.resolve({ value: mockChunk1, done: false });
+              }
+              // Provider opened the stream then went silent forever.
+              return new Promise<
+                IteratorResult<OpenAI.Chat.ChatCompletionChunk>
+              >(() => {});
+            },
+            return: returnSpy,
+          };
+        },
+      };
+
+      const firstGemini = new GenerateContentResponse();
+      firstGemini.candidates = [
+        { content: { parts: [{ text: 'Hello' }], role: 'model' } },
+      ];
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([]);
+      (mockConverter.convertOpenAIChunkToGemini as Mock).mockReturnValue(
+        firstGemini,
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue(
+        mockStream,
+      );
+
+      const resultGenerator = await pipeline.executeStream(request, 'pid');
+      const drain = async () => {
+        const seen: GenerateContentResponse[] = [];
+        for await (const r of resultGenerator) seen.push(r);
+        return seen;
+      };
+
+      await expect(drain()).rejects.toBeInstanceOf(StreamIdleTimeoutError);
+      // The stalled iterator must be torn down so the socket is released.
+      expect(returnSpy).toHaveBeenCalled();
+    });
+
+    it('passes the stream through unchanged when the idle watchdog is disabled (<= 0)', async () => {
+      const request: GenerateContentParameters = {
+        model: 'test-model',
+        contents: [{ parts: [{ text: 'Hello' }], role: 'user' }],
+      };
+      mockContentGeneratorConfig.streamIdleTimeoutMs = 0; // disabled
+
+      const mockChunk = {
+        id: 'chunk-1',
+        choices: [{ delta: { content: 'Hi' }, finish_reason: 'stop' }],
+      } as OpenAI.Chat.ChatCompletionChunk;
+      const mockStream = {
+        async *[Symbol.asyncIterator]() {
+          yield mockChunk;
+        },
+      };
+      const gemini = new GenerateContentResponse();
+      gemini.candidates = [
+        { content: { parts: [{ text: 'Hi' }], role: 'model' } },
+      ];
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([]);
+      (mockConverter.convertOpenAIChunkToGemini as Mock).mockReturnValue(gemini);
+      (mockClient.chat.completions.create as Mock).mockResolvedValue(
+        mockStream,
+      );
+
+      const gen = await pipeline.executeStream(request, 'pid');
+      const results: GenerateContentResponse[] = [];
+      for await (const r of gen) results.push(r);
+      expect(results).toHaveLength(1);
+      expect(results[0]).toBe(gemini);
+    });
+
+    it('does not fire while the stream stays active (idle timer resets per chunk)', async () => {
+      const request: GenerateContentParameters = {
+        model: 'test-model',
+        contents: [{ parts: [{ text: 'Hello' }], role: 'user' }],
+      };
+      // Each inter-chunk gap (40ms) stays under the budget while the total
+      // stream duration (~120ms) exceeds it — proves the timer resets per chunk
+      // rather than bounding the whole stream.
+      mockContentGeneratorConfig.streamIdleTimeoutMs = 100;
+
+      const mk = (id: string, content: string, fin: string | null) =>
+        ({
+          id,
+          choices: [{ delta: { content }, finish_reason: fin }],
+        }) as OpenAI.Chat.ChatCompletionChunk;
+
+      const mockStream = {
+        async *[Symbol.asyncIterator]() {
+          for (const c of [
+            mk('c1', 'a', null),
+            mk('c2', 'b', null),
+            mk('c3', 'c', 'stop'),
+          ]) {
+            await new Promise((r) => setTimeout(r, 40));
+            yield c;
+          }
+        },
+      };
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([]);
+      (mockConverter.convertOpenAIChunkToGemini as Mock).mockImplementation(
+        (chunk: OpenAI.Chat.ChatCompletionChunk) => {
+          const r = new GenerateContentResponse();
+          const text = chunk.choices?.[0]?.delta?.content ?? '';
+          r.candidates = [{ content: { parts: [{ text }], role: 'model' } }];
+          return r;
+        },
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue(
+        mockStream,
+      );
+
+      const gen = await pipeline.executeStream(request, 'pid');
+      const results: GenerateContentResponse[] = [];
+      for await (const r of gen) results.push(r);
+      expect(results).toHaveLength(3);
     });
 
     it('should filter empty responses', async () => {

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -20,6 +20,7 @@ import type { PipelineConfig, RequestContext } from './types.js';
 import { redactProxyError } from '../../utils/runtimeFetchOptions.js';
 import { runtimeDiagnostics } from '../../utils/runtimeDiagnostics.js';
 import { createChildAbortController } from '../../utils/abortController.js';
+import { DEFAULT_STREAM_IDLE_TIMEOUT } from './constants.js';
 
 /**
  * Error thrown when the API returns an error embedded as stream content
@@ -31,6 +32,26 @@ export class StreamContentError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'StreamContentError';
+  }
+}
+
+/**
+ * Error thrown when a streaming response stalls mid-flight: the upstream
+ * provider opened the stream (headers received) but then stopped sending SSE
+ * chunks for longer than the configured inactivity budget. Surfaced as a
+ * dedicated type so the consuming retry loop (GeminiChat.sendMessageStream) can
+ * treat a stalled stream as transient and re-issue the request, rather than
+ * letting the `for await` hang forever (see {@link DEFAULT_STREAM_IDLE_TIMEOUT}).
+ */
+export class StreamIdleTimeoutError extends Error {
+  readonly idleTimeoutMs: number;
+  constructor(idleTimeoutMs: number) {
+    super(
+      `Streaming response stalled: no data received from the provider for ` +
+        `${Math.round(idleTimeoutMs / 1000)}s. The connection was aborted.`,
+    );
+    this.name = 'StreamIdleTimeoutError';
+    this.idleTimeoutMs = idleTimeoutMs;
   }
 }
 
@@ -111,19 +132,31 @@ export class ContentGenerationPipeline {
           throw e;
         }
 
+        // Stage 1.5: Guard the raw stream with an inactivity watchdog so a
+        // provider that stalls mid-stream (headers received, SSE body goes
+        // silent) surfaces as a retryable StreamIdleTimeoutError instead of
+        // hanging the consuming `for await` forever — the OpenAI SDK only
+        // bounds time-to-headers. Wrapping the *raw* stream means every chunk,
+        // including the ones processStreamWithLogging filters out, resets the
+        // idle timer.
+        const guardedStream = this.withStreamIdleTimeout(
+          stream,
+          this.resolveStreamIdleTimeoutMs(),
+        );
+
         // Stage 2: Process stream with conversion and logging.
         // When a per-request controller exists, wrap in an async generator
         // that aborts it once the stream is fully consumed or abandoned, so
         // the child signal's reverse-cleanup fires and the parent listener
         // is released.
         if (!perRequestAc) {
-          return this.processStreamWithLogging(stream, context, request);
+          return this.processStreamWithLogging(guardedStream, context, request);
         }
         // Capture the narrowed controller so the closure below sees a non-
         // nullable type (TS does not propagate narrowing into nested funcs).
         const ac = perRequestAc;
         const innerStream = this.processStreamWithLogging(
-          stream,
+          guardedStream,
           context,
           request,
         );
@@ -137,6 +170,87 @@ export class ContentGenerationPipeline {
         return drainThenCleanup();
       },
     );
+  }
+
+  /**
+   * Resolve the streaming inactivity timeout (ms). Precedence:
+   * `QWEN_CODE_STREAM_IDLE_TIMEOUT_MS` env var > `contentGenerator.streamIdleTimeoutMs`
+   * config > {@link DEFAULT_STREAM_IDLE_TIMEOUT}. A non-positive result disables
+   * the watchdog (passthrough).
+   */
+  private resolveStreamIdleTimeoutMs(): number {
+    const raw = process.env['QWEN_CODE_STREAM_IDLE_TIMEOUT_MS'];
+    if (raw !== undefined && raw.trim() !== '') {
+      const parsed = Number(raw);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+    const configured = this.contentGeneratorConfig.streamIdleTimeoutMs;
+    if (typeof configured === 'number' && Number.isFinite(configured)) {
+      return configured;
+    }
+    return DEFAULT_STREAM_IDLE_TIMEOUT;
+  }
+
+  /**
+   * Wrap a raw provider stream with an inactivity watchdog. Each pull races the
+   * next chunk against a timer that is reset every iteration; if no chunk
+   * arrives within `idleTimeoutMs`, the underlying iterator is closed (which
+   * aborts the SDK request and releases the stalled socket) and a
+   * {@link StreamIdleTimeoutError} is thrown. The timer guards only the time
+   * spent awaiting the provider — it is cleared before the chunk is yielded, so
+   * slow downstream consumers never trip it. A non-positive `idleTimeoutMs`
+   * disables the watchdog.
+   */
+  private async *withStreamIdleTimeout(
+    stream: AsyncIterable<OpenAI.Chat.ChatCompletionChunk>,
+    idleTimeoutMs: number,
+  ): AsyncGenerator<OpenAI.Chat.ChatCompletionChunk> {
+    if (!(idleTimeoutMs > 0)) {
+      yield* stream;
+      return;
+    }
+
+    const iterator = stream[Symbol.asyncIterator]();
+    try {
+      while (true) {
+        const nextPromise = iterator.next();
+        // If the idle timer wins the race we abandon this pending read; it will
+        // reject later once the request aborts. Attach a no-op catch now so the
+        // late rejection never surfaces as an unhandledRejection.
+        nextPromise.catch(() => {});
+
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        let result: IteratorResult<OpenAI.Chat.ChatCompletionChunk>;
+        try {
+          result = await Promise.race([
+            nextPromise,
+            new Promise<never>((_, reject) => {
+              timer = setTimeout(
+                () => reject(new StreamIdleTimeoutError(idleTimeoutMs)),
+                idleTimeoutMs,
+              );
+              // Don't let the watchdog alone keep the event loop (and CLI) alive.
+              timer.unref?.();
+            }),
+          ]);
+        } finally {
+          if (timer) clearTimeout(timer);
+        }
+
+        if (result.done) return;
+        yield result.value;
+      }
+    } finally {
+      // Best-effort close of the underlying iterator on every exit path (idle
+      // timeout, consumer break/throw, normal completion). For the OpenAI SDK
+      // stream this calls controller.abort(), tearing down a stalled connection
+      // even when no per-request AbortController is present.
+      try {
+        await iterator.return?.();
+      } catch {
+        // ignore teardown errors — the original outcome already propagated
+      }
+    }
   }
 
   /**
@@ -247,6 +361,13 @@ export class ContentGenerationPipeline {
       // the caller's retry logic (e.g., TPM throttling retry in sendMessageStream)
       if (error instanceof StreamContentError) {
         throw redactProxyError(error);
+      }
+
+      // A mid-stream idle timeout is already a clean, typed signal for the
+      // caller's retry loop — bypass the provider error handler (which is
+      // shaped for SDK/HTTP errors) so the error identity survives upstream.
+      if (error instanceof StreamIdleTimeoutError) {
+        throw error;
       }
 
       // Use shared error handling logic


### PR DESCRIPTION
## What this PR does

Adds an inactivity (read) watchdog around OpenAI-compatible streaming responses so a stream that stalls mid-flight surfaces as a retryable error instead of hanging forever. Each streamed chunk resets a per-request timer; if no chunk arrives within `streamIdleTimeoutMs` (default 120s, configurable via the `QWEN_CODE_STREAM_IDLE_TIMEOUT_MS` env var or `contentGenerator.streamIdleTimeoutMs`, a value `<= 0` disables it), the in-flight request is aborted (releasing the socket) and a typed `StreamIdleTimeoutError` is thrown. `GeminiChat.sendMessageStream` recognizes this as a transient stream failure and re-issues the request once — bounded, with partial-turn cleanup — before surfacing it, so a single provider hiccup self-heals.

## Why it's needed

The OpenAI SDK's `timeout` only bounds time-to-headers: its `fetchWithTimeout` clears the abort timer in a `finally` the moment the response headers arrive, so once a stream has started the SDK no longer enforces any timeout on the body. If a provider opens the stream (200 OK) and then goes silent mid-flight — the SSE body stops while the connection stays half-open — the consuming `for await` suspends forever. Nothing downstream bounds it either: the per-round child abort controller only fires on a parent abort, and the agent reasoning loop's time budget is checked between rounds, never mid-stream.

This is usually invisible for a single chat turn but becomes a frequent, hard hang when one model response fans out many concurrent streaming sub-agents — for example a multi-agent review that launches 9 in parallel. The parent awaits `Promise.all` over all sub-agents, so a single stalled upstream stream wedges the whole batch at "waiting for results...". With N concurrent streams the probability that at least one stalls grows roughly N×, and HTTP/2 multiplexing (many SSE streams sharing one connection) lets one stream stall without erroring its siblings — which matches the intermittent, parallel-only nature of the hang.

## Reviewer Test Plan

### How to verify

Unit tests cover the behavior directly:
- A stream that yields one chunk then stalls is aborted and throws `StreamIdleTimeoutError` after the idle budget, and the underlying iterator is closed to release the socket.
- A live stream whose inter-chunk gaps stay under the budget but whose total duration exceeds it completes normally — proving the timer is an inactivity budget reset per chunk, not a total-duration cap.
- A `<= 0` budget disables the watchdog (passthrough).
- At the `GeminiChat` layer, a mid-stream `StreamIdleTimeoutError` triggers exactly one bounded re-stream that recovers, and an always-stalling stream propagates the error after the retry budget is exhausted — no infinite loop, no hang.

```
cd packages/core
npx vitest run src/core/openaiContentGenerator/pipeline.test.ts src/core/geminiChat.test.ts
npx tsc --noEmit
```

Expected: all pass (239 tests), tsc clean. To exercise the knob manually, set `QWEN_CODE_STREAM_IDLE_TIMEOUT_MS=5000` and confirm a stalled stream aborts after ~5s instead of hanging.

### Evidence (Before & After)

Non–user-visible (core streaming/runtime). Before: a provider that stalls a stream mid-flight hangs the consuming `for await` indefinitely, and a parallel sub-agent fan-out wedges at "waiting for results...". After: the stalled stream is aborted after the inactivity budget, retried once, and otherwise fails cleanly — the batch proceeds instead of hanging.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

Unit tests only (`npx vitest run`, `npx tsc --noEmit`, `npx eslint`).

## Risk & Scope

- Main risk or tradeoff: a too-aggressive idle budget could abort a legitimately slow stream. Mitigated by a conservative 120s inactivity default (a live stream resets the timer on every chunk, including usage-only/empty ones) and a `<= 0` disable switch; because the abort is wired into the existing bounded stream-retry, a false positive degrades to one extra re-stream rather than a failure.
- Not validated / out of scope: only the OpenAI-compatible streaming path is guarded (this is the default qwen / DashScope route). The Anthropic streaming path and the non-streaming body-read path share the same theoretical gap and are left for a follow-up. Windows/Linux not exercised locally (covered by CI).
- Breaking changes / migration notes: none. The new config field and env var are optional; default behavior only changes for streams that were previously hanging.

## Linked Issues

N/A — no tracking issue; surfaced as an intermittent hang during parallel multi-agent runs.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

为 OpenAI 兼容的流式响应加了一道**不活动(读)看门狗**,让"中途卡住"的流变成可重试的错误,而不是永久挂起。每收到一个 chunk 就重置一个 per-request 计时器;若在 `streamIdleTimeoutMs`(默认 120 秒,可通过 `QWEN_CODE_STREAM_IDLE_TIMEOUT_MS` 环境变量或 `contentGenerator.streamIdleTimeoutMs` 配置,`<= 0` 关闭)内没有任何 chunk 到达,就中止当前请求(释放 socket)并抛出带类型的 `StreamIdleTimeoutError`。`GeminiChat.sendMessageStream` 把它识别为瞬时流故障,在最终上报前**有界地重新建流一次**(带半截 turn 清理),从而让单次 provider 抖动自愈。

## 为什么需要

OpenAI SDK 的 `timeout` 只约束"到响应头为止"的时间:它的 `fetchWithTimeout` 在响应头一到达就在 `finally` 里 `clearTimeout`,于是流一旦开始,SDK 就不再对 body 施加任何超时。如果 provider 打开了流(200 OK)然后中途静默——SSE body 停止、连接半开——消费端的 `for await` 会永久挂起。下游也没有任何兜底:per-round 子 abort controller 只在父级 abort 时触发,而 agent 推理循环的时间预算只在**轮次之间**检查,从不覆盖流中途。

这在单轮对话里通常看不出来,但当一次模型响应**并发扇出多个流式子 agent** 时(例如一次多 agent review 并行启动 9 个)就成了高频硬挂起。父级对所有子 agent `await Promise.all`,所以**只要一条上游流卡住,整批就卡在 "waiting for results..."**。N 条并发流时"至少一条卡住"的概率约放大 N 倍;而 HTTP/2 多路复用(多条 SSE 流共用一条连接)会让某条流卡住却不报错、不影响兄弟流——这与该挂起"偶发、仅并行时出现"的特征完全吻合。

## 评审验证计划

### 如何验证

单元测试直接覆盖:
- 一条先吐一个 chunk 然后卡住的流,在 idle 预算后被中止并抛 `StreamIdleTimeoutError`,且底层迭代器被关闭以释放 socket。
- 一条活跃流:每个 chunk 间隔都小于预算、但总时长超过预算 → 正常完成,证明该计时器是"每个 chunk 重置的不活动预算",而非"总时长上限"。
- `<= 0` 关闭看门狗(透传)。
- 在 `GeminiChat` 层:流中途的 `StreamIdleTimeoutError` 恰好触发一次有界重新建流并恢复;而始终卡住的流在重试预算耗尽后把错误向上传播——无限循环不可能,也不会挂起。

```
cd packages/core
npx vitest run src/core/openaiContentGenerator/pipeline.test.ts src/core/geminiChat.test.ts
npx tsc --noEmit
```

预期:全部通过(239 个测试),tsc 干净。手动验证开关:设 `QWEN_CODE_STREAM_IDLE_TIMEOUT_MS=5000`,确认卡住的流在约 5 秒后中止而非挂起。

### 证据(Before & After)

非用户可见(核心流式/运行时)。之前:provider 把流卡在中途会让消费端 `for await` 无限挂起,并行子 agent 扇出会卡在 "waiting for results..."。之后:卡住的流在不活动预算后被中止、重试一次,否则干净失败——整批继续推进而不是挂死。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ 已测 · ⚠️ 未测 · N/A -->

### 环境(可选)

仅单元测试(`npx vitest run`、`npx tsc --noEmit`、`npx eslint`)。

## 风险与范围

- 主要风险/权衡:过于激进的 idle 预算可能中止一条确实很慢的流。已通过保守的 120 秒不活动默认值(活跃流每个 chunk——包括纯 usage/空 chunk——都会重置计时器)和 `<= 0` 关闭开关来缓解;由于中止被接入了既有的有界流式重试,误判最多退化为一次额外的重新建流,而非失败。
- 未验证/超出范围:只保护了 OpenAI 兼容流式路径(这是默认的 qwen / DashScope 路由)。Anthropic 流式路径与非流式 body 读取存在同类理论缺口,留作后续。Windows/Linux 未在本地跑(由 CI 覆盖)。
- 破坏性变更/迁移说明:无。新增的配置字段与环境变量都是可选的;默认行为只对"原本就会挂起"的流发生改变。

## 关联 Issue

N/A——无跟踪 issue;在并行多 agent 运行中以偶发挂起的形式暴露。

</details>
