### PR TITLE
feat(triage): make minimal-change an explicit PR review check

### DIFF
--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -83,8 +83,9 @@ curl -s https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.
 - If we cut 80% of the scope, would the remaining 20% already solve the problem?
 - Could we achieve the same goal by modifying something that already exists, instead of adding something new?
 - Can the complexity live outside the codebase (user config, external tool) instead of inside it?
+- **Minimal change:** is every edit in the diff needed for the stated goal, or does it carry unrelated changes, drive-by refactors, formatting churn, or scope creep that should be split into a separate PR? A focused PR that does one thing is easier to review, revert, and reason about.
 
-If you spot a materially simpler path, raise it — not as a blocker, but as a genuine question the contributor should think about before the code review.
+If you spot a materially simpler path, or changes that go beyond the minimal set needed for the stated goal, raise it — not as a blocker, but as a genuine question the contributor should think about before the code review.
 
 Implementation-level concerns (over-abstraction, code duplication, "10 lines vs 10 files") belong in Stage 2a code review — you need to see the code for those.
 
@@ -99,7 +100,7 @@ Template looks good ✓
 
 On direction: <state your honest assessment — aligned and why, or concerns and why>. CHANGELOG <reference if found, or "no direct reference but the area is relevant">.
 
-On approach: <state your honest assessment — the scope feels right / feels like it could be much simpler / here's what I'd consider cutting>. <If you see a simpler path, name it: "Have you considered just X? It might cover most of the use case with a fraction of the complexity.">
+On approach: <state your honest assessment — the scope feels right / feels like it could be much simpler / here's what I'd consider cutting>. <If you see a simpler path, name it: "Have you considered just X? It might cover most of the use case with a fraction of the complexity."> <If the diff carries unrelated changes or drive-by refactors, name them and suggest splitting them out.>
 
 <If passing:> Moving on to code review. 🔍
 <If concerns:> Flagging these for discussion before diving deeper.
@@ -113,7 +114,7 @@ On approach: <state your honest assessment — the scope feels right / feels lik
 
 方向：<直接说判断——对齐的原因/担心的原因>。
 
-方案：<范围合理 / 感觉可以大幅简化 / 建议砍掉的部分>。<如果看到更简路径，点名：有没有考虑过直接 X？可能用很小的复杂度覆盖大部分场景。>
+方案：<范围合理 / 感觉可以大幅简化 / 建议砍掉的部分>。<如果看到更简路径，点名：有没有考虑过直接 X？可能用很小的复杂度覆盖大部分场景。><如果 diff 夹带了无关改动或顺手重构，点名并建议拆成单独 PR。>
 
 <如果通过：> 进入代码审查 🔍
 <如果有顾虑：> 先提出来讨论，再深入看代码。
@@ -217,6 +218,7 @@ Step back and look at the whole picture — the motivation, the implementation, 
 - Does the PR's approach match or exceed my independent proposal? Or did I find a simpler path it missed?
 - Does this solve something users actually care about?
 - Is the code straightforward, or does it feel like it's trying too hard?
+- Is every change in the diff necessary, or did unrelated edits / drive-by refactors bloat it beyond the minimal change the goal needs?
 - After seeing it run, do the results match what the PR promised?
 - If I had to maintain this in six months, would I curse the author or thank them?
 - Am I approving this because it's genuinely good, or because I ran out of reasons to say no?


### PR DESCRIPTION
## What this PR does

Makes the "minimal change" principle an explicit check in the PR triage gatekeeper (`.qwen/skills/triage/references/pr-workflow.md`). Stage 1c gains a dedicated checkpoint asking whether every edit in the diff is needed for the stated goal or whether it carries unrelated changes, drive-by refactors, formatting churn, or scope creep that should be split out. The Stage 1 comment template (English and Chinese) now surfaces unrelated changes to the contributor and suggests splitting them into a separate PR, and the Stage 3 reflection checklist adds an item on whether the diff stayed minimal.

## Why it's needed

The triage skill already nudged toward KISS and simpler solutions, but the "is this diff bigger than it needs to be?" question was only implicit — spread across Stage 1c/2a/3 as a soft signal that was easy to skip. As a result, unrelated changes and drive-by refactors could pass triage without ever being named. Making the minimal-change check explicit gives the reviewer a concrete prompt and gives the contributor visible, actionable feedback — while keeping the existing "genuine question, not a blocker" tone (no new hard gate).

## Reviewer Test Plan

### How to verify

This is a prompt-only change to a triage skill reference doc; there is no runtime code path to execute. To confirm:

1. Read the diff on `.qwen/skills/triage/references/pr-workflow.md`.
2. Confirm Stage 1c now contains a bolded **Minimal change** checkpoint and the closing nudge covers "changes beyond the minimal set."
3. Confirm the Stage 1 comment template (EN + ZH) mentions surfacing unrelated changes / drive-by refactors.
4. Confirm Stage 3 reflect adds the minimal-change checklist item.
5. Confirm the tone stays "genuine question, not a blocker" — no new `request-changes` / hard-gate behavior was introduced.

### Evidence (Before & After)

N/A — prompt/doc change, no user-visible or TUI behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

<!-- Platform-independent prompt doc change; nothing to run per-OS. -->

### Environment (optional)

N/A — no runtime involved.

## Risk & Scope

- Main risk or tradeoff: a slightly more verbose triage Stage 1 comment; the minimal-change point may occasionally be raised on PRs that are already minimal.
- Not validated / out of scope: no change to hard gates / `request-changes` categories — minimal-change remains a non-blocking signal. Stage 2a blocking criteria are untouched.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把"最小改动"原则在 PR triage 网关（`.qwen/skills/triage/references/pr-workflow.md`）里变成显式检查项。Stage 1c 新增一条专门的检查：diff 里每处改动是否都为既定目标所需，有没有夹带无关改动、顺手重构、格式 churn 或 scope creep 该拆成单独 PR。Stage 1 评论模板（中英文）现在会把无关改动对贡献者点名并建议拆分，Stage 3 反思清单也加了一条"diff 是否保持最小"的检查。

## 为什么需要

triage skill 本来就在引导 KISS 和更简方案，但"这个 diff 是不是比需要的大"这个问题一直是隐式的——散在 Stage 1c/2a/3 里、是个容易被跳过的软信号，结果无关改动和顺手重构可能通过 triage 却从没被点名。把最小改动检查显式化，给审查者一个明确的提示、给贡献者可见可执行的反馈，同时保持现有"是真诚的提问、不是 blocker"的口吻（不新增硬门槛）。

## 验证方式

纯 prompt 改动，没有运行时代码路径。确认方式：阅读 diff，核对 Stage 1c 的 **Minimal change** 检查项、Stage 1 模板（中英文）的无关改动提示、Stage 3 reflect 的新清单项，以及口吻仍为"提问而非拦截"（未引入新的 request-changes / 硬门槛）。

## 风险与范围

- 主要权衡：triage Stage 1 评论略微变长；对本就最小的 PR 偶尔也会提一句最小改动。
- 未验证 / 范围外：未改动任何硬门槛 / request-changes 类别，最小改动仍是非阻断信号；Stage 2a 拦截条件未动。
- 破坏性变更：无。

</details>
