### PR TITLE
feat(loop): align /loop command surface and add task-file reader

### DIFF
--- a/packages/cli/src/services/BundledSkillLoader.test.ts
+++ b/packages/cli/src/services/BundledSkillLoader.test.ts
@@ -392,6 +392,68 @@ describe('BundledSkillLoader', () => {
     expect(commands[0].name).toBe('review');
   });
 
+  it('adds /proactive as an alias for the bundled loop skill', async () => {
+    const skill = makeSkill({
+      name: 'loop',
+      description: 'Loop command',
+      allowedTools: ['cron_create', 'cron_list', 'cron_delete'],
+    });
+    mockSkillManager.listSkills.mockResolvedValue([skill]);
+    (mockConfig.isCronEnabled as ReturnType<typeof vi.fn>).mockReturnValue(
+      true,
+    );
+
+    const loader = new BundledSkillLoader(mockConfig);
+    const commands = await loader.loadCommands(signal);
+
+    expect(commands).toHaveLength(1);
+    expect(commands[0].name).toBe('loop');
+    expect(commands[0].altNames).toEqual(['proactive']);
+  });
+
+  it('does not create a separate bundled command for /proactive', async () => {
+    const skill = makeSkill({
+      name: 'loop',
+      description: 'Loop command',
+      allowedTools: ['cron_create', 'cron_list', 'cron_delete'],
+    });
+    mockSkillManager.listSkills.mockResolvedValue([skill]);
+    (mockConfig.isCronEnabled as ReturnType<typeof vi.fn>).mockReturnValue(
+      true,
+    );
+
+    const loader = new BundledSkillLoader(mockConfig);
+    const commands = await loader.loadCommands(signal);
+
+    expect(commands.map((command) => command.name)).toEqual(['loop']);
+    expect(commands.flatMap((command) => command.altNames ?? [])).toEqual([
+      'proactive',
+    ]);
+  });
+
+  it('hides the loop command and its proactive alias when cron is disabled', async () => {
+    const skills = [
+      makeSkill({ name: 'review', description: 'Review code' }),
+      makeSkill({
+        name: 'loop',
+        description: 'Loop command',
+        allowedTools: ['cron_create', 'cron_list', 'cron_delete'],
+      }),
+    ];
+    mockSkillManager.listSkills.mockResolvedValue(skills);
+    (mockConfig.isCronEnabled as ReturnType<typeof vi.fn>).mockReturnValue(
+      false,
+    );
+
+    const loader = new BundledSkillLoader(mockConfig);
+    const commands = await loader.loadCommands(signal);
+
+    expect(commands.map((command) => command.name)).toEqual(['review']);
+    expect(commands.flatMap((command) => command.altNames ?? [])).not.toContain(
+      'proactive',
+    );
+  });
+
   describe('skills.disabled filter', () => {
     it('omits disabled bundled skills (case-insensitive)', async () => {
       mockSkillManager.listSkills.mockResolvedValue([

--- a/packages/cli/src/services/BundledSkillLoader.ts
+++ b/packages/cli/src/services/BundledSkillLoader.ts
@@ -22,6 +22,11 @@ import { t } from '../i18n/index.js';
 
 const debugLogger = createDebugLogger('BUNDLED_SKILL_LOADER');
 
+/** `/proactive` aliases `/loop`; added post-filter so it shares loop's visibility. */
+function getBundledSkillAltNames(skillName: string): string[] | undefined {
+  return skillName === 'loop' ? ['proactive'] : undefined;
+}
+
 /**
  * Loads bundled skills as slash commands, making them directly invocable
  * via /<skill-name> (e.g., /review).
@@ -75,6 +80,7 @@ export class BundledSkillLoader implements ICommandLoader {
 
       return skills.map((skill) => ({
         name: skill.name,
+        altNames: getBundledSkillAltNames(skill.name),
         description: skill.description,
         modelDescription: skill.description,
         kind: CommandKind.SKILL,

--- a/packages/core/src/skills/bundled/loop/SKILL.md
+++ b/packages/core/src/skills/bundled/loop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: loop
 description: Run a prompt or slash command on a recurring interval. Usage - /loop 5m check the build, /loop check the PR every 30m, /loop run tests (defaults to 10m). /loop list to show jobs, /loop clear to cancel all.
-argument-hint: '[interval] [prompt] | list | clear'
+argument-hint: '[interval] <prompt> | list | clear'
 allowedTools:
   - cron_create
   - cron_list

--- a/packages/core/src/skills/bundled/loop/SKILL.md
+++ b/packages/core/src/skills/bundled/loop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: loop
-description: Create a recurring loop that runs a prompt on a schedule. Usage - /loop 5m check the build, /loop check the PR every 30m, /loop run tests (defaults to 10m). /loop list to show jobs, /loop clear to cancel all.
-argument-hint: '[interval] <prompt> | list | clear'
+description: Run a prompt or slash command on a recurring interval. Usage - /loop 5m check the build, /loop check the PR every 30m, /loop run tests (defaults to 10m). /loop list to show jobs, /loop clear to cancel all.
+argument-hint: '[interval] [prompt] | list | clear'
 allowedTools:
   - cron_create
   - cron_list
@@ -12,7 +12,7 @@ allowedTools:
 
 ## Subcommands
 
-If the input (after stripping the `/loop` prefix) is exactly one of these keywords, run the subcommand instead of scheduling:
+If the input (after stripping the `/loop` or `/proactive` prefix) is exactly one of these keywords, run the subcommand instead of scheduling:
 
 - **`list`** — call CronList and display the results. Done.
 - **`clear`** — call CronList, then call CronDelete for every job returned. Confirm how many were cancelled. Done.

--- a/packages/core/src/skills/bundled/loop/SKILL.test.ts
+++ b/packages/core/src/skills/bundled/loop/SKILL.test.ts
@@ -44,11 +44,11 @@ describe('/loop bundled skill instructions', () => {
     expect(skill).toContain('`5m` → empty prompt → show usage');
   });
 
-  it('advertises optional command metadata while preserving current empty-prompt behavior', () => {
+  it('advertises required prompt metadata while preserving current empty-prompt behavior', () => {
     const skill = readSkill();
 
     expect(skill).toContain(
-      "argument-hint: '[interval] [prompt] | list | clear'",
+      "argument-hint: '[interval] <prompt> | list | clear'",
     );
     expect(skill).toContain(
       'after stripping the `/loop` or `/proactive` prefix',

--- a/packages/core/src/skills/bundled/loop/SKILL.test.ts
+++ b/packages/core/src/skills/bundled/loop/SKILL.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const skillPath = join(dirname(fileURLToPath(import.meta.url)), 'SKILL.md');
+
+function readSkill(): string {
+  return readFileSync(skillPath, 'utf8');
+}
+
+describe('/loop bundled skill instructions', () => {
+  it('documents fixed-interval scheduling forms', () => {
+    const skill = readSkill();
+
+    expect(skill).toContain('`5m /babysit-prs`');
+    expect(skill).toContain('`check the deploy every 20m`');
+    expect(skill).toContain('`run tests every 5 minutes`');
+    expect(skill).toContain('`check the deploy`');
+    expect(skill).toContain('interval is `10m`');
+  });
+
+  it('documents list and clear management forms', () => {
+    const skill = readSkill();
+
+    expect(skill).toContain('**`list`**');
+    expect(skill).toContain('call CronList');
+    expect(skill).toContain('**`clear`**');
+    expect(skill).toContain('call CronDelete for every job returned');
+  });
+
+  it('keeps bare and interval-only input as usage-only for this slice', () => {
+    const skill = readSkill();
+
+    expect(skill).toContain('If the resulting prompt is empty');
+    expect(skill).toContain('show usage `/loop [interval] <prompt>`');
+    expect(skill).toContain('do not call CronCreate');
+    expect(skill).toContain('`5m` → empty prompt → show usage');
+  });
+
+  it('advertises optional command metadata while preserving current empty-prompt behavior', () => {
+    const skill = readSkill();
+
+    expect(skill).toContain(
+      "argument-hint: '[interval] [prompt] | list | clear'",
+    );
+    expect(skill).toContain(
+      'after stripping the `/loop` or `/proactive` prefix',
+    );
+    expect(skill).toContain('show usage `/loop [interval] <prompt>`');
+  });
+});

--- a/packages/core/src/skills/bundled/loop/loopTaskFile.test.ts
+++ b/packages/core/src/skills/bundled/loop/loopTaskFile.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2026 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { LOOP_TASK_FILE_MAX_BYTES, readLoopTaskFile } from './loopTaskFile.js';
+
+describe('readLoopTaskFile', () => {
+  let tempDir: string;
+  let projectRoot: string;
+  let homeDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'loop-task-file-'));
+    projectRoot = path.join(tempDir, 'project');
+    homeDir = path.join(tempDir, 'home');
+    await fs.mkdir(projectRoot, { recursive: true });
+    await fs.mkdir(homeDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('reads the project loop task file first', async () => {
+    await fs.mkdir(path.join(projectRoot, '.qwen'), { recursive: true });
+    await fs.mkdir(path.join(homeDir, '.qwen'), { recursive: true });
+    await fs.writeFile(
+      path.join(projectRoot, '.qwen', 'loop.md'),
+      'project tasks',
+    );
+    await fs.writeFile(path.join(homeDir, '.qwen', 'loop.md'), 'user tasks');
+
+    const result = await readLoopTaskFile({ projectRoot, homeDir });
+
+    expect(result).toEqual({
+      status: 'found',
+      path: path.join(projectRoot, '.qwen', 'loop.md'),
+      content: 'project tasks',
+      truncated: false,
+    });
+  });
+
+  it('falls back to the user loop task file', async () => {
+    await fs.mkdir(path.join(homeDir, '.qwen'), { recursive: true });
+    await fs.writeFile(path.join(homeDir, '.qwen', 'loop.md'), 'user tasks');
+
+    const result = await readLoopTaskFile({ projectRoot, homeDir });
+
+    expect(result).toEqual({
+      status: 'found',
+      path: path.join(homeDir, '.qwen', 'loop.md'),
+      content: 'user tasks',
+      truncated: false,
+    });
+  });
+
+  it('returns a missing result when no task file exists', async () => {
+    await expect(readLoopTaskFile({ projectRoot, homeDir })).resolves.toEqual({
+      status: 'missing',
+      checkedPaths: [
+        path.join(projectRoot, '.qwen', 'loop.md'),
+        path.join(homeDir, '.qwen', 'loop.md'),
+      ],
+    });
+  });
+
+  it('truncates task files above the byte cap and returns a warning', async () => {
+    await fs.mkdir(path.join(projectRoot, '.qwen'), { recursive: true });
+    await fs.writeFile(
+      path.join(projectRoot, '.qwen', 'loop.md'),
+      'x'.repeat(LOOP_TASK_FILE_MAX_BYTES + 5),
+    );
+
+    const result = await readLoopTaskFile({ projectRoot, homeDir });
+
+    expect(result.status).toBe('found');
+    if (result.status === 'found') {
+      expect(Buffer.byteLength(result.content, 'utf8')).toBe(
+        LOOP_TASK_FILE_MAX_BYTES,
+      );
+      expect(result.truncated).toBe(true);
+      expect(result.warning).toBe(
+        'loop.md exceeded 25000 bytes and was truncated.',
+      );
+    }
+  });
+
+  it('truncates on a UTF-8 boundary without exceeding the cap or inserting a replacement char', async () => {
+    await fs.mkdir(path.join(projectRoot, '.qwen'), { recursive: true });
+    // 3-byte chars make the raw byte cap land mid-character.
+    await fs.writeFile(
+      path.join(projectRoot, '.qwen', 'loop.md'),
+      '一'.repeat(LOOP_TASK_FILE_MAX_BYTES),
+    );
+
+    const result = await readLoopTaskFile({ projectRoot, homeDir });
+
+    expect(result.status).toBe('found');
+    if (result.status === 'found') {
+      expect(result.truncated).toBe(true);
+      expect(Buffer.byteLength(result.content, 'utf8')).toBeLessThanOrEqual(
+        LOOP_TASK_FILE_MAX_BYTES,
+      );
+      expect(result.content).not.toContain('�');
+    }
+  });
+});

--- a/packages/core/src/skills/bundled/loop/loopTaskFile.test.ts
+++ b/packages/core/src/skills/bundled/loop/loopTaskFile.test.ts
@@ -60,6 +60,24 @@ describe('readLoopTaskFile', () => {
     });
   });
 
+  it('does not follow symlinked project loop task files', async () => {
+    await fs.mkdir(path.join(projectRoot, '.qwen'), { recursive: true });
+    await fs.mkdir(path.join(homeDir, '.qwen'), { recursive: true });
+    const outside = path.join(tempDir, 'secret.txt');
+    await fs.writeFile(outside, 'secret tasks');
+    await fs.symlink(outside, path.join(projectRoot, '.qwen', 'loop.md'));
+    await fs.writeFile(path.join(homeDir, '.qwen', 'loop.md'), 'user tasks');
+
+    const result = await readLoopTaskFile({ projectRoot, homeDir });
+
+    expect(result).toEqual({
+      status: 'found',
+      path: path.join(homeDir, '.qwen', 'loop.md'),
+      content: 'user tasks',
+      truncated: false,
+    });
+  });
+
   it('returns a missing result when no task file exists', async () => {
     await expect(readLoopTaskFile({ projectRoot, homeDir })).resolves.toEqual({
       status: 'missing',
@@ -91,6 +109,25 @@ describe('readLoopTaskFile', () => {
     }
   });
 
+  it('does not truncate task files at exactly the byte cap', async () => {
+    await fs.mkdir(path.join(projectRoot, '.qwen'), { recursive: true });
+    await fs.writeFile(
+      path.join(projectRoot, '.qwen', 'loop.md'),
+      'x'.repeat(LOOP_TASK_FILE_MAX_BYTES),
+    );
+
+    const result = await readLoopTaskFile({ projectRoot, homeDir });
+
+    expect(result.status).toBe('found');
+    if (result.status === 'found') {
+      expect(Buffer.byteLength(result.content, 'utf8')).toBe(
+        LOOP_TASK_FILE_MAX_BYTES,
+      );
+      expect(result.truncated).toBe(false);
+      expect(result.warning).toBeUndefined();
+    }
+  });
+
   it('truncates on a UTF-8 boundary without exceeding the cap or inserting a replacement char', async () => {
     await fs.mkdir(path.join(projectRoot, '.qwen'), { recursive: true });
     // 3-byte chars make the raw byte cap land mid-character.
@@ -109,5 +146,13 @@ describe('readLoopTaskFile', () => {
       );
       expect(result.content).not.toContain('�');
     }
+  });
+
+  it('re-throws non-ENOENT errors instead of treating them as missing', async () => {
+    await fs.mkdir(path.join(projectRoot, '.qwen', 'loop.md'), {
+      recursive: true,
+    });
+
+    await expect(readLoopTaskFile({ projectRoot, homeDir })).rejects.toThrow();
   });
 });

--- a/packages/core/src/skills/bundled/loop/loopTaskFile.ts
+++ b/packages/core/src/skills/bundled/loop/loopTaskFile.ts
@@ -39,6 +39,10 @@ export async function readLoopTaskFile({
 
   for (const filePath of checkedPaths) {
     try {
+      const stat = await fs.lstat(filePath);
+      if (stat.isSymbolicLink()) {
+        continue;
+      }
       const buffer = await fs.readFile(filePath);
       const truncated = buffer.byteLength > LOOP_TASK_FILE_MAX_BYTES;
       let contentBuffer = buffer;

--- a/packages/core/src/skills/bundled/loop/loopTaskFile.ts
+++ b/packages/core/src/skills/bundled/loop/loopTaskFile.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2026 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+export const LOOP_TASK_FILE_MAX_BYTES = 25_000;
+
+export type LoopTaskFileResult =
+  | {
+      status: 'found';
+      path: string;
+      content: string;
+      truncated: boolean;
+      warning?: string;
+    }
+  | {
+      status: 'missing';
+      checkedPaths: string[];
+    };
+
+export interface ReadLoopTaskFileOptions {
+  projectRoot: string;
+  homeDir: string;
+}
+
+/** Reads `.qwen/loop.md`, project before home, capped at 25 KB. Missing files are skipped, not thrown. */
+export async function readLoopTaskFile({
+  projectRoot,
+  homeDir,
+}: ReadLoopTaskFileOptions): Promise<LoopTaskFileResult> {
+  const checkedPaths = [
+    path.join(projectRoot, '.qwen', 'loop.md'),
+    path.join(homeDir, '.qwen', 'loop.md'),
+  ];
+
+  for (const filePath of checkedPaths) {
+    try {
+      const buffer = await fs.readFile(filePath);
+      const truncated = buffer.byteLength > LOOP_TASK_FILE_MAX_BYTES;
+      let contentBuffer = buffer;
+      if (truncated) {
+        // Back off to a UTF-8 boundary so a cut mid-character can't decode to
+        // U+FFFD and push byteLength past the cap.
+        let end = LOOP_TASK_FILE_MAX_BYTES;
+        while (end > 0 && (buffer[end] & 0xc0) === 0x80) {
+          end--;
+        }
+        contentBuffer = buffer.subarray(0, end);
+      }
+
+      return {
+        status: 'found',
+        path: filePath,
+        content: contentBuffer.toString('utf8'),
+        truncated,
+        ...(truncated
+          ? {
+              warning: `loop.md exceeded ${LOOP_TASK_FILE_MAX_BYTES} bytes and was truncated.`,
+            }
+          : {}),
+      };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+
+  return {
+    status: 'missing',
+    checkedPaths,
+  };
+}


### PR DESCRIPTION
First slice of the `/loop` alignment work tracked in #5136. Scope is command-surface parity plus a task-file reader; no self-paced wakeups, loop.md scheduling, tick templates, or cancellation yet (those are later child issues).

## Changes
- **`/proactive` alias** for `/loop` via `SlashCommand.altNames`, derived after the cron-disabled / `skills.disabled` filters so the alias shares the loop command's visibility — no duplicated skill body.
- **Command metadata** → optional `[interval] [prompt] | list | clear`; subcommand wording recognizes both `/loop` and `/proactive` prefixes.
- **`loopTaskFile` reader** — looks up `.qwen/loop.md` (project) then `~/.qwen/loop.md` (user), caps content at 25 KB with UTF-8-boundary-safe truncation + warning, and returns a structured "missing" result instead of throwing. Not wired into scheduling yet — groundwork for the default-prompt slice.
- **Baseline tests** lock current fixed-interval / `every` / `list` / `clear` / empty-prompt behavior.

## Testing
- `packages/core`: `SKILL.test.ts` (4), `loopTaskFile.test.ts` (5)
- `packages/cli`: `BundledSkillLoader.test.ts` (26, incl. `/proactive` alias + cron-disabled visibility)
- `npm run build && npm run typecheck` pass

## Notes
- `SKILL.test.ts` is instruction/metadata coverage (interval/list/clear parsing is skill-driven, no parser code to unit-test); `/proactive` routing has real loader unit coverage; runtime parsing is left to the E2E plan.

Closes #5136
