### PR TITLE
fix(desktop): keep latest feed stable-only

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -598,24 +598,28 @@ jobs:
             gh release create "${create_args[@]}"
           fi
 
-          feed_title="Qwen Code Desktop latest"
-          feed_notes="Auto-update feed for ${RELEASE_TAG}. See https://github.com/${GH_REPO}/releases/tag/${RELEASE_TAG}."
-          feed_upload_args=("$UPDATE_FEED_TAG" "${assets[@]}" --clobber)
-          if gh release view "$UPDATE_FEED_TAG" >/dev/null 2>&1; then
-            gh release edit "$UPDATE_FEED_TAG" \
-              --draft=false \
-              --prerelease=false \
-              --latest=false \
-              --target "$RELEASE_TARGET" \
-              --title "$feed_title" \
-              --notes "$feed_notes"
-            gh release upload "${feed_upload_args[@]}"
+          if [ "$RELEASE_DRAFT" = "true" ] || [ "$RELEASE_PRERELEASE" = "true" ]; then
+            echo "Skipping $UPDATE_FEED_TAG update for draft or prerelease desktop release."
           else
-            gh release create "$UPDATE_FEED_TAG" "${assets[@]}" \
-              --latest=false \
-              --target "$RELEASE_TARGET" \
-              --title "$feed_title" \
-              --notes "$feed_notes"
+            feed_title="Qwen Code Desktop latest"
+            feed_notes="Auto-update feed for ${RELEASE_TAG}. See https://github.com/${GH_REPO}/releases/tag/${RELEASE_TAG}."
+            feed_upload_args=("$UPDATE_FEED_TAG" "${assets[@]}" --clobber)
+            if gh release view "$UPDATE_FEED_TAG" >/dev/null 2>&1; then
+              gh release edit "$UPDATE_FEED_TAG" \
+                --draft=false \
+                --prerelease=false \
+                --latest=false \
+                --target "$RELEASE_TARGET" \
+                --title "$feed_title" \
+                --notes "$feed_notes"
+              gh release upload "${feed_upload_args[@]}"
+            else
+              gh release create "$UPDATE_FEED_TAG" "${assets[@]}" \
+                --latest=false \
+                --target "$RELEASE_TARGET" \
+                --title "$feed_title" \
+                --notes "$feed_notes"
+            fi
           fi
 
   sync-version:


### PR DESCRIPTION
## What this PR does

This PR prevents draft and prerelease desktop releases from updating the fixed `desktop-latest` auto-update feed. Versioned `desktop-v*` releases are still created or updated as before, but the stable update feed is only refreshed when the release inputs are `draft=false` and `prerelease=false`.

## Why it's needed

The fixed `desktop-latest` release is the feed packaged desktop builds use for stable auto-updates. Draft or prerelease artifacts should not replace that feed, because doing so could make stable installations discover a build that maintainers intended only for review or prerelease validation.

## Reviewer Test Plan

### How to verify

Confirm that the desktop release workflow skips the `desktop-latest` update when either `draft=true` or `prerelease=true`, and only creates or clobbers `desktop-latest` when both flags are false.

Local checks run: `.github/workflows/desktop-release.yml` parsed successfully as YAML. `git diff --check` completed successfully.

### Evidence (Before & After)

N/A for UI. Before this change, any non-dry-run desktop release path would refresh `desktop-latest`. After this change, draft and prerelease desktop releases log that the feed update is skipped.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local Codex workspace on macOS with GitHub CLI.

## Risk & Scope

- Main risk or tradeoff: draft and prerelease desktop releases will no longer be reachable through the stable update feed, so maintainers need to install those artifacts manually or use their versioned release page for validation.
- Not validated / out of scope: a live GitHub Actions release run was not executed locally.
- Breaking changes / migration notes: none for stable users.

## Linked Issues

Follow-up to #5139.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 阻止 draft 和 prerelease 的 desktop release 更新固定的 `desktop-latest` 自动更新 feed。带版本的 `desktop-v*` release 仍然会照常创建或更新，但只有当 release 输入为 `draft=false` 且 `prerelease=false` 时，稳定更新 feed 才会被刷新。

## Why it's needed

固定的 `desktop-latest` release 是已打包 desktop 应用用于稳定自动更新的 feed。Draft 或 prerelease artifacts 不应该替换这个 feed，否则稳定安装版本可能发现一个维护者原本只打算用于 review 或 prerelease 验证的构建。

## Reviewer Test Plan

### How to verify

确认 desktop release workflow 在 `draft=true` 或 `prerelease=true` 时会跳过 `desktop-latest` 更新，并且只有两个标志都为 false 时才会创建或覆盖 `desktop-latest`。

本地已运行检查：`.github/workflows/desktop-release.yml` 可以成功按 YAML 解析。`git diff --check` 成功完成。

### Evidence (Before & After)

UI 不适用。修改前，任何非 dry-run 的 desktop release 路径都会刷新 `desktop-latest`。修改后，draft 和 prerelease desktop release 会打印日志说明 feed 更新已跳过。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 macOS Codex workspace，使用 GitHub CLI。

## Risk & Scope

- Main risk or tradeoff: draft 和 prerelease desktop release 不再能通过稳定更新 feed 访问，因此维护者需要手动安装这些 artifacts，或通过它们自己的 versioned release 页面验证。
- Not validated / out of scope: 没有在本地执行真实的 GitHub Actions release run。
- Breaking changes / migration notes: 对稳定用户没有破坏性变更。

## Linked Issues

Follow-up to #5139.

</details>
