### PR TITLE
fix(release): allow cli-entry.js in standalone dist allowlist

### DIFF
--- a/scripts/create-standalone-package.js
+++ b/scripts/create-standalone-package.js
@@ -44,6 +44,9 @@ const DIST_REQUIRED_PATHS = [
 ];
 const DIST_ALLOWED_ENTRIES = new Set([
   'cli.js',
+  // bin wrapper emitted by prepare-package.js that re-spawns `node --expose-gc
+  // cli.js`; ships in dist/ as the package `bin` entry (#4914).
+  'cli-entry.js',
   // fzf fuzzy-search worker; esbuild emits it as a standalone entry that must
   // sit next to cli.js so `new URL('./fzfWorker.js', ...)` resolves at runtime.
   'fzfWorker.js',


### PR DESCRIPTION
## What this PR does

Adds `cli-entry.js` to the standalone packager's allowed dist-entry list (`DIST_ALLOWED_ENTRIES` in `scripts/create-standalone-package.js`), so the standalone release build no longer rejects it as an unexpected asset.

## Why it's needed

The standalone release build is currently broken on `main`. #4914 added a `dist/cli-entry.js` bin wrapper — it re-spawns `node --expose-gc cli.js` — emitted by `prepare-package.js`, but it was never registered in the packager's strict dist allowlist. The release job fails with `Error: Unexpected dist asset: .../dist/cli-entry.js` ([failing run](https://github.com/QwenLM/qwen-code/actions/runs/27532223939/job/81377924218)). This is the same class of miss that #5049 fixed for `fzfWorker.js`, and the fix is identical: register the new entry.

## Reviewer Test Plan

### How to verify

`scripts/create-standalone-package.js` walks `dist/` and calls `fail()` on any entry not in `DIST_ALLOWED_ENTRIES`. Before this change `cli-entry.js` (created by `prepare-package.js`) is not in the set, so packaging aborts. After this change it is allowed and copied into the standalone `lib/` like the other runtime assets. Confirm by running the release packaging step (`npm run package:standalone:release`) and checking it completes past the asset-validation stage instead of erroring on `cli-entry.js`.

### Evidence (Before & After)

N/A — release-tooling change, not user-visible.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

`node -c scripts/create-standalone-package.js` passes; pre-commit prettier/eslint clean.

### Environment (optional)

N/A

## Risk & Scope

- Main risk or tradeoff: Minimal — adds one string to an allowlist; no behavior change beyond letting an already-emitted asset through.
- Not validated / out of scope: Whether the `cli-entry.js` wrapper itself is the right design is out of scope — see the discussion on #4914. This PR is the minimal hotfix to unblock release.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 `cli-entry.js` 加入 standalone 打包脚本的 dist 产物白名单（`scripts/create-standalone-package.js` 的 `DIST_ALLOWED_ENTRIES`），让 standalone release 构建不再把它当成意外产物拒绝掉。

## 为什么需要

standalone release 构建当前在 `main` 上是挂的。#4914 通过 `prepare-package.js` 新增了一个 `dist/cli-entry.js` 的 bin wrapper（它会 re-spawn `node --expose-gc cli.js`），但从未在打包脚本的严格白名单里登记。release job 因此报 `Error: Unexpected dist asset: .../dist/cli-entry.js`（[失败的 run](https://github.com/QwenLM/qwen-code/actions/runs/27532223939/job/81377924218)）。这和 #5049 修 `fzfWorker.js` 是同一类疏漏，修法也一样：把新产物登记进去。

## 验证方式

`scripts/create-standalone-package.js` 会遍历 `dist/`，对任何不在 `DIST_ALLOWED_ENTRIES` 里的产物调用 `fail()`。改动前 `cli-entry.js`（由 `prepare-package.js` 生成）不在集合里，所以打包中止；改动后它被放行，和其他运行时产物一样拷进 standalone 的 `lib/`。运行 release 打包步骤（`npm run package:standalone:release`），确认它能越过产物校验阶段、不再因 `cli-entry.js` 报错即可。

## 风险与范围

- 主要风险/取舍：极小——只往白名单加一个字符串，除了放行一个本就会生成的产物外没有行为变化。
- 未验证/范围外：`cli-entry.js` 这个 wrapper 本身的设计是否合理不在本 PR 范围内，见 #4914 的讨论。本 PR 只是解锁 release 的最小修复。
- 破坏性变更/迁移说明：无。

</details>
