### PR TITLE
fix(agent): make forking explicit; keep omitted subagent_type awaitable

### DIFF
--- a/docs/users/features/sub-agents.md
+++ b/docs/users/features/sub-agents.md
@@ -12,9 +12,9 @@ Subagents are independent AI assistants that:
 - **Work autonomously** - Once given a task, they work independently until completion or failure
 - **Provide detailed feedback** - You can see their progress, tool usage, and execution statistics in real-time
 
-## Fork Subagent (Implicit Fork)
+## Fork Subagent
 
-In addition to named subagents, Qwen Code supports **implicit forking** — when the AI omits the `subagent_type` parameter, it triggers a fork that inherits the parent's full conversation context.
+In addition to named subagents, Qwen Code supports **forking** — selected explicitly with `subagent_type: "fork"` (available in interactive sessions). A fork inherits the parent's full conversation context and runs detached in the background. Omitting `subagent_type` does **not** fork; it launches the general-purpose subagent, which runs to completion and returns its result inline.
 
 ### How Fork Differs from Named Subagents
 
@@ -59,7 +59,7 @@ Fork children cannot create further forks. This is enforced at runtime — if a 
 ## How Subagents Work
 
 1. **Configuration**: You create Subagents configurations that define their behavior, tools, and system prompts
-2. **Delegation**: The main AI can automatically delegate tasks to appropriate Subagents — or implicitly fork when no specific subagent type is needed
+2. **Delegation**: The main AI can automatically delegate tasks to appropriate Subagents — or fork itself (`subagent_type: "fork"`) when it wants to inherit the full conversation context and discard the intermediate output
 3. **Execution**: Subagents work independently, using their configured tools to complete tasks
 4. **Results**: They return results and execution summaries back to the main conversation
 

--- a/packages/cli/src/ui/commands/forkCommand.test.ts
+++ b/packages/cli/src/ui/commands/forkCommand.test.ts
@@ -25,6 +25,7 @@ vi.mock('../../i18n/index.js', () => ({
 vi.mock('@qwen-code/qwen-code-core', () => ({
   createDebugLogger: () => ({ debug: () => undefined }),
   ToolNames: { AGENT: 'agent' },
+  FORK_SUBAGENT_TYPE: 'fork',
 }));
 
 describe('forkCommand', () => {
@@ -171,12 +172,13 @@ describe('forkCommand', () => {
     expect(mockGetTool).toHaveBeenCalledWith('agent');
 
     // Builds a background fork: full directive as prompt, run_in_background,
-    // no subagent_type (→ implicit FORK_AGENT).
+    // and an explicit subagent_type "fork" (→ FORK_AGENT; omitting it would
+    // select a general-purpose subagent instead).
     expect(mockBuild).toHaveBeenCalledTimes(1);
     const builtParams = mockBuild.mock.calls[0][0];
     expect(builtParams.prompt).toBe('review the current code');
     expect(builtParams.run_in_background).toBe(true);
-    expect(builtParams.subagent_type).toBeUndefined();
+    expect(builtParams.subagent_type).toBe('fork');
     expect(builtParams.description).toBeTruthy();
 
     expect(mockExecute).toHaveBeenCalledTimes(1);

--- a/packages/cli/src/ui/commands/forkCommand.ts
+++ b/packages/cli/src/ui/commands/forkCommand.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { createDebugLogger, ToolNames } from '@qwen-code/qwen-code-core';
+import {
+  createDebugLogger,
+  ToolNames,
+  FORK_SUBAGENT_TYPE,
+} from '@qwen-code/qwen-code-core';
 import type { AgentParams } from '@qwen-code/qwen-code-core';
 import type {
   CommandContext,
@@ -102,8 +106,9 @@ export const forkCommand: SlashCommand = {
       };
     }
 
-    // Route through the Agent tool's background path (omitting subagent_type
-    // selects the implicit FORK_AGENT). This reuses the full background
+    // Route through the Agent tool's background path. `subagent_type: "fork"`
+    // explicitly selects the FORK_AGENT (omitting it would launch a
+    // general-purpose subagent instead). This reuses the full background
     // machinery: registration in the BackgroundTaskRegistry, live activity
     // streaming, a JSONL transcript, completion stats, and a terminal
     // task-notification — all surfaced by the existing background-tasks
@@ -121,6 +126,7 @@ export const forkCommand: SlashCommand = {
     const params: AgentParams = {
       description: deriveForkDescription(directive),
       prompt: directive,
+      subagent_type: FORK_SUBAGENT_TYPE,
       run_in_background: true,
     };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -143,6 +143,7 @@ export type {
 } from './tools/shell.js';
 export type { SkillTool, SkillParams } from './tools/skill.js';
 export type { AgentTool, AgentParams } from './tools/agent/agent.js';
+export { FORK_SUBAGENT_TYPE } from './tools/agent/fork-subagent.js';
 export type {
   WorkflowTool,
   WorkflowParams,

--- a/packages/core/src/skills/bundled/review/SKILL.md
+++ b/packages/core/src/skills/bundled/review/SKILL.md
@@ -159,7 +159,9 @@ Assign severity based on the tool's own categorization:
 
 ## Step 4: Parallel multi-dimensional review
 
-Launch review agents by invoking all `task` tools in a **single response**. The runtime executes agent tools concurrently — they will run in parallel. You MUST include all tool calls in one response; do NOT send them one at a time. Launch **9 agents** for same-repo reviews (Agent 6 has three persona variants 6a/6b/6c that each count as a separate parallel agent), or **8 agents** (skip Agent 7: Build & Test) for cross-repo lightweight mode since there is no local codebase to build/test. Each agent should focus exclusively on its dimension.
+Launch review agents by invoking all `agent` tools in a **single response**. The runtime executes agent tools concurrently — they will run in parallel. You MUST include all tool calls in one response; do NOT send them one at a time. Launch **9 agents** for same-repo reviews (Agent 6 has three persona variants 6a/6b/6c that each count as a separate parallel agent), or **8 agents** (skip Agent 7: Build & Test) for cross-repo lightweight mode since there is no local codebase to build/test. Each agent should focus exclusively on its dimension.
+
+**Every agent MUST be an awaitable subagent: set `subagent_type: "general-purpose"` on every `agent` call.** Do NOT fork them — do not omit `subagent_type`, and never set `subagent_type: "fork"`. A fork runs fire-and-forget and its findings never come back to you, so the review would stall in Step 5 with nothing to aggregate. You need every agent's findings returned to you inline.
 
 **IMPORTANT**: Keep each agent's prompt **short** (under 200 words) to fit all tool calls in one response. Do NOT paste the full diff — give each agent:
 

--- a/packages/core/src/skills/bundled/simplify/SKILL.md
+++ b/packages/core/src/skills/bundled/simplify/SKILL.md
@@ -39,7 +39,7 @@ Use `git diff HEAD` whenever staged changes exist. Otherwise use `git diff`.
 
 ## Step 2: Launch three review passes in parallel
 
-Use the `agent` tool and launch all review passes in a single response so they run concurrently. Each pass must receive the same review scope and diff command. These passes are read-only: each one inspects and reports findings only and must not modify files — all edits happen later in Step 4.
+Use the `agent` tool and launch all review passes in a single response so they run concurrently. **Set `subagent_type: "general-purpose"` on every call — each pass must be an awaitable subagent whose findings return to you inline. Do NOT fork them: do not omit `subagent_type`, and never set `subagent_type: "fork"`. A fork runs fire-and-forget and never returns its findings, so there would be nothing to aggregate in Step 3.** Each pass must receive the same review scope and diff command. These passes are read-only: each one inspects and reports findings only and must not modify files — all edits happen later in Step 4.
 
 Keep each review prompt short and focused. Do not paste the full diff into the prompt. Tell each pass to read the diff itself and inspect only files relevant to its findings.
 

--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -338,6 +338,30 @@ describe('AgentTool', () => {
       ]);
     });
 
+    it('does not advertise "fork" in the enum, even when interactive', async () => {
+      // `fork` is intentionally omitted from the enum so the model is not
+      // steered to fork result-bearing work; it stays valid via validation.
+      (config as unknown as Record<string, unknown>)['isInteractive'] = vi
+        .fn()
+        .mockReturnValue(true);
+      const interactiveTool = new AgentTool(config);
+      await vi.runAllTimersAsync();
+
+      const schema = interactiveTool.schema;
+      const properties = schema.parametersJsonSchema as {
+        properties: {
+          subagent_type: {
+            enum?: string[];
+          };
+        };
+      };
+      expect(properties.properties.subagent_type.enum).toEqual([
+        'file-search',
+        'code-review',
+      ]);
+      expect(properties.properties.subagent_type.enum).not.toContain('fork');
+    });
+
     it('does not expose teammate name when teams are disabled', () => {
       const schema = agentTool.schema;
       const parameters = schema.parametersJsonSchema as {
@@ -454,15 +478,34 @@ describe('AgentTool', () => {
       ).toMatch(/isolation/i);
     });
 
-    it('rejects isolation without subagent_type (fork is not isolatable)', () => {
-      const { subagent_type: _ignored, ...forkParams } = validParams;
+    it('rejects isolation without an explicit subagent_type', () => {
+      const { subagent_type: _ignored, ...noTypeParams } = validParams;
       void _ignored;
       expect(
         agentTool.validateToolParams({
-          ...forkParams,
+          ...noTypeParams,
           isolation: 'worktree',
         }),
       ).toMatch(/subagent_type/i);
+    });
+
+    it('accepts subagent_type "fork" without consulting the registry', () => {
+      expect(
+        agentTool.validateToolParams({
+          ...validParams,
+          subagent_type: 'fork',
+        }),
+      ).toBeNull();
+    });
+
+    it('rejects isolation combined with subagent_type "fork"', () => {
+      expect(
+        agentTool.validateToolParams({
+          ...validParams,
+          subagent_type: 'fork',
+          isolation: 'worktree',
+        }),
+      ).toMatch(/fork/i);
     });
   });
 
@@ -1115,7 +1158,7 @@ describe('AgentTool', () => {
     });
   });
 
-  describe('Fork dispatch (subagent_type omitted)', () => {
+  describe('Fork dispatch (subagent_type: "fork")', () => {
     let mockAgent: AgentHeadless;
     let mockContextState: ContextState;
 
@@ -1185,6 +1228,7 @@ describe('AgentTool', () => {
       const params: AgentParams = {
         description: 'some task',
         prompt: 'do the thing',
+        subagent_type: 'fork',
       };
 
       const invocation = (
@@ -1196,6 +1240,36 @@ describe('AgentTool', () => {
         'general-purpose',
       );
       expect(AgentHeadless.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('omitting subagent_type uses general-purpose, not fork', async () => {
+      // Restored contract: omission resolves to the awaitable general-purpose
+      // subagent (inline result), never a fork — even in interactive mode.
+      const mockLoadedSubagent: SubagentConfig = {
+        name: 'general-purpose',
+        description: 'General-purpose agent',
+        systemPrompt: 'You are a general-purpose agent.',
+        level: 'builtin',
+        filePath: '<builtin:general-purpose>',
+      };
+      vi.mocked(mockSubagentManager.loadSubagent).mockResolvedValue(
+        mockLoadedSubagent,
+      );
+
+      const params: AgentParams = {
+        description: 'some task',
+        prompt: 'do the thing',
+      };
+
+      const invocation = (
+        agentTool as AgentToolWithProtectedMethods
+      ).createInvocation(params);
+      await invocation.execute();
+
+      expect(mockSubagentManager.loadSubagent).toHaveBeenCalledWith(
+        'general-purpose',
+      );
+      expect(AgentHeadless.create).not.toHaveBeenCalled();
     });
 
     it('falls back to general-purpose when non-interactive', async () => {
@@ -1218,6 +1292,7 @@ describe('AgentTool', () => {
       const params: AgentParams = {
         description: 'fork task',
         prompt: 'do the thing',
+        subagent_type: 'fork',
       };
 
       const invocation = (
@@ -1236,6 +1311,7 @@ describe('AgentTool', () => {
       const params: AgentParams = {
         description: 'fork task',
         prompt: 'do the thing',
+        subagent_type: 'fork',
       };
 
       const invocation = (
@@ -1312,6 +1388,7 @@ describe('AgentTool', () => {
       const params: AgentParams = {
         description: 'fork task',
         prompt: 'do the thing',
+        subagent_type: 'fork',
       };
       const invocation = (
         agentTool as AgentToolWithProtectedMethods
@@ -1324,7 +1401,7 @@ describe('AgentTool', () => {
       expect(stopSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('routes owned monitor notifications and cleanup for implicit forks', async () => {
+    it('routes owned monitor notifications and cleanup for forks', async () => {
       let releaseExecute: (() => void) | undefined;
       vi.mocked(mockAgent.execute).mockImplementation(
         () =>
@@ -1345,6 +1422,7 @@ describe('AgentTool', () => {
       const params: AgentParams = {
         description: 'fork task',
         prompt: 'do the thing',
+        subagent_type: 'fork',
       };
       const invocation = (
         agentTool as AgentToolWithProtectedMethods
@@ -3028,6 +3106,7 @@ describe('AgentTool', () => {
       const forkParams: AgentParams = {
         description: 'Fork task',
         prompt: 'Investigate issue',
+        subagent_type: 'fork',
         run_in_background: true,
       };
       const generationConfig = {

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -37,6 +37,7 @@ import type { AgentExternalInput } from '../../agents/runtime/agent-types.js';
 import type { Content, FunctionDeclaration } from '@google/genai';
 import {
   FORK_AGENT,
+  FORK_SUBAGENT_TYPE,
   FORK_PLACEHOLDER_RESULT,
   buildForkedMessages,
   buildChildMessage,
@@ -635,7 +636,7 @@ ${subagentDescriptions}
 
 ${
   isForkSubagentEnabled(this.config)
-    ? `When using the Agent tool, specify a subagent_type to use a specialized agent, or omit it to fork yourself — a fork inherits your full conversation context.`
+    ? `When using the Agent tool, specify a subagent_type to select which agent type to use. If omitted, the general-purpose agent is used and returns its result to you inline. A fork (\`subagent_type: "fork"\`) runs detached and fire-and-forget — its result does NOT come back to you, so use it ONLY for work whose output you won't need. When you need the agent's findings back (review, audit, aggregation, verification), use a regular subagent, never a fork.`
     : `When using the Agent tool, specify a subagent_type parameter to select which agent type to use. If omitted, the general-purpose agent is used.`
 }
 
@@ -663,9 +664,9 @@ ${
     ? `
 ## When to fork
 
-Fork yourself (omit \`subagent_type\`) when the intermediate tool output isn't worth keeping in your context. The criterion is qualitative — "will I need this output again" — not task size.
-- **Research**: fork open-ended questions. If research can be broken into independent questions, launch parallel forks in one message. A fork beats a fresh subagent for this — it inherits context and shares your cache.
-- **Implementation**: prefer to fork implementation work that requires more than a couple of edits. Do research before jumping to implementation.
+A fork (\`subagent_type: "fork"\`) runs detached and fire-and-forget: it inherits your full context, but its findings do NOT come back to you in a form you can act on. **Never fork work whose output you need** — reviews, audits, parallel investigations you must aggregate, verification, anything where you have to read or combine the results. For all of that, launch regular awaitable subagents instead (omit \`subagent_type\` for general-purpose, or name a specific type); each returns its result to you inline, and several in one message still run concurrently. Omitting \`subagent_type\` does NOT fork.
+
+Fork only when you genuinely won't need the result back — a detached background chore the user asked you to kick off and move on from. The criterion is qualitative: "will I need to read this output?" If yes, don't fork.
 
 Forks are cheap because they share your prompt cache. Don't set \`model\` on a fork — a different model can't reuse the parent's cache. Pass a short \`name\` (one or two words, lowercase) so the user can track the fork.
 
@@ -733,6 +734,12 @@ assistant: Uses the ${ToolNames.AGENT} tool to launch the test-runner agent
       };
     };
     if (schema.properties && schema.properties.subagent_type) {
+      // Only real, loadable subagents are advertised in the enum. `fork` is a
+      // deliberate pseudo-type, NOT listed here: dangling it as a casual option
+      // led the model to fork result-bearing work (e.g. review agents), whose
+      // findings a fork never returns. Forking stays reachable for intentional
+      // use — validation accepts `subagent_type: "fork"` and `/fork` passes it
+      // directly — it just isn't offered as a default pick.
       if (subagentNames.length > 0) {
         schema.properties.subagent_type.enum = subagentNames;
       } else {
@@ -773,15 +780,20 @@ assistant: Uses the ${ToolNames.AGENT} tool to launch the test-runner agent
       ) {
         return 'Parameter "subagent_type" must be a non-empty string.';
       }
-      // Validate that the subagent exists (case-insensitive)
+      // Validate that the subagent exists (case-insensitive). `fork` is an
+      // explicit pseudo-type resolved by the dispatch logic (not a loadable
+      // subagent), so accept it regardless of the registered list; when
+      // forking is unavailable, dispatch falls back to general-purpose.
       const lowerType = params.subagent_type.toLowerCase();
-      const subagentExists = this.availableSubagents.some(
-        (subagent) => subagent.name.toLowerCase() === lowerType,
-      );
+      if (lowerType !== FORK_SUBAGENT_TYPE) {
+        const subagentExists = this.availableSubagents.some(
+          (subagent) => subagent.name.toLowerCase() === lowerType,
+        );
 
-      if (!subagentExists) {
-        const availableNames = this.availableSubagents.map((s) => s.name);
-        return `Subagent "${params.subagent_type}" not found. Available subagents: ${availableNames.join(', ')}`;
+        if (!subagentExists) {
+          const availableNames = this.availableSubagents.map((s) => s.name);
+          return `Subagent "${params.subagent_type}" not found. Available subagents: ${availableNames.join(', ')}`;
+        }
       }
     }
 
@@ -789,12 +801,15 @@ assistant: Uses the ${ToolNames.AGENT} tool to launch the test-runner agent
       if (params.isolation !== 'worktree') {
         return 'Parameter "isolation" must be "worktree" when set.';
       }
-      // Forks (no subagent_type) reuse the parent's full conversation
-      // context — putting them in a separate worktree would split
-      // intent from working tree and confuse path resolution. Require
-      // an explicit subagent_type when requesting isolation.
-      if (!params.subagent_type) {
-        return 'Parameter "isolation" requires "subagent_type" to be set.';
+      // Isolation puts the agent in a separate git worktree. A fork reuses
+      // the parent's conversation context and working tree, so it can't be
+      // isolated; and the general-purpose default is only worth isolating
+      // when asked for explicitly. Require an explicit, non-fork subagent_type.
+      if (
+        !params.subagent_type ||
+        params.subagent_type.toLowerCase() === FORK_SUBAGENT_TYPE
+      ) {
+        return 'Parameter "isolation" requires an explicit subagent_type (and cannot be "fork").';
       }
     }
 
@@ -1794,13 +1809,23 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
     let restoreParentPM: () => void = () => {};
 
     try {
-      // When subagent_type is omitted and fork is available in an interactive
-      // session, use fork. Otherwise fall back to general-purpose.
-      const isFork =
-        !this.params.subagent_type && isForkSubagentEnabled(this.config);
-      const effectiveSubagentType =
-        this.params.subagent_type ??
-        (isFork ? undefined : DEFAULT_BUILTIN_SUBAGENT_TYPE);
+      // Forking is explicit: `subagent_type: "fork"` selects a fork, and only
+      // when forking is available (interactive session). Any other value — or
+      // an omitted subagent_type — resolves to a real, awaitable subagent
+      // (general-purpose by default) whose result is returned inline. This
+      // keeps the long-standing "omit ⇒ awaitable general-purpose" contract
+      // that skills and callers depend on; a fork is opt-in, never the default.
+      const requestedType = this.params.subagent_type;
+      const isForkRequested =
+        requestedType?.toLowerCase() === FORK_SUBAGENT_TYPE;
+      const isFork = isForkRequested && isForkSubagentEnabled(this.config);
+      const effectiveSubagentType = isFork
+        ? undefined
+        : isForkRequested
+          ? // Explicit fork requested but unavailable (non-interactive) →
+            // fall back to the awaitable general-purpose subagent.
+            DEFAULT_BUILTIN_SUBAGENT_TYPE
+          : (requestedType ?? DEFAULT_BUILTIN_SUBAGENT_TYPE);
       let subagentConfig: SubagentConfig;
 
       if (isFork) {
@@ -2448,7 +2473,7 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
         // For forks, wrap the body in runInForkContext so the recursive-fork
         // guard in execute() fires if the fork child's model calls `agent`
         // again — otherwise background forks bypass the ALS marker and can
-        // spawn nested implicit forks.
+        // spawn nested forks.
         const bgBody = async (recordSpanOutcome: SubagentOutcomeSink) => {
           try {
             await bgSubagent.execute(contextState, bgAbortController.signal);
@@ -2620,9 +2645,9 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
         // `parentAgentId` in the sidecar meta. Also wrap in
         // qwen-code.subagent span (#3731 Phase 3) — background is
         // fire-and-forget, so the span gets a new traceId + `Link` to the
-        // invoking AGENT tool span. `invocationKind` distinguishes the
-        // implicit fork (no subagent_type) from a named background agent;
-        // both are long-lived enough to qualify for the 4h TTL safety net.
+        // invoking AGENT tool span. `invocationKind` distinguishes a fork
+        // (subagent_type: "fork") from a named background agent; both are
+        // long-lived enough to qualify for the 4h TTL safety net.
         const framedBgBody = () =>
           this.runWithSubagentSpan(
             this.buildSubagentSpanSpec(

--- a/packages/core/src/tools/agent/fork-subagent.ts
+++ b/packages/core/src/tools/agent/fork-subagent.ts
@@ -8,13 +8,16 @@ export const FORK_SUBAGENT_TYPE = 'fork';
 /**
  * Fork subagent availability gate.
  *
- * Fork is available by default in interactive sessions. Non-interactive
- * sessions (e.g. `qwen -p`, SDK headless, CI/CD) lack a terminal UI for fork
- * progress display and permission prompts, which can cause hangs or silent
- * failures.
+ * Fork is available in interactive sessions. Non-interactive sessions
+ * (e.g. `qwen -p`, SDK headless, CI/CD) lack a terminal UI for fork progress
+ * display and permission prompts, which can cause hangs or silent failures.
  *
- * When fork is unavailable, omitting `subagent_type` falls back to a
- * general-purpose subagent instead of forking.
+ * Forking is an explicit choice — the caller selects it with
+ * `subagent_type: "fork"`. Omitting `subagent_type` always resolves to the
+ * general-purpose subagent (awaitable, returns its result inline), never a
+ * fork. This preserves the long-standing "omit ⇒ awaitable subagent" contract
+ * that skills and callers depend on. When fork is unavailable, an explicit
+ * `subagent_type: "fork"` also falls back to the general-purpose subagent.
  */
 export function isForkSubagentEnabled(config: Config): boolean {
   return config.isInteractive();
@@ -26,7 +29,7 @@ export const FORK_DIRECTIVE_PREFIX = 'Directive: ';
 export const FORK_AGENT = {
   name: FORK_SUBAGENT_TYPE,
   description:
-    'Implicit fork — inherits full conversation context. Not selectable via subagent_type; triggered by omitting subagent_type.',
+    'Fork yourself — inherits your full conversation context. Selected explicitly via `subagent_type: "fork"` (only in interactive sessions). Runs detached in the background; you are notified when it completes.',
   tools: ['*'],
   systemPrompt:
     'You are a forked worker process. Follow the directive in the conversation history. Execute tasks directly using available tools. Do not spawn sub-agents.',


### PR DESCRIPTION
## What this PR does

This makes forking an explicit, deliberate choice and stops the model from reaching for it when it needs the agents' results back. Three layers: (1) **dispatch** — `subagent_type: "fork"` selects a fork (interactive sessions only; otherwise general-purpose), while an omitted `subagent_type` resolves to an awaitable general-purpose subagent whose result returns inline (never a fork), and `/fork` passes `subagent_type: "fork"` explicitly; (2) **prompt** — the Agent tool no longer advertises `fork` in the `subagent_type` enum, drops the "launch parallel forks for research" guidance, and reframes the description and "When to fork" around "never fork work whose output you need"; (3) **skills** — the bundled `review` and `simplify` skills launch their parallel agents with `subagent_type: "general-purpose"` and are told explicitly not to fork, because they aggregate findings.

## Why it's needed

#4963 ("enable fork subagents by default") changed the meaning of an omitted `subagent_type` for every interactive session — from "awaitable general-purpose subagent whose result is returned inline" to "fire-and-forget background fork" — with no opt-out. A fork's findings never flow back into the parent turn, so any caller that spawns parallel agents and then aggregates their results breaks: the bundled `review`/`simplify` skills (which launch 9/3 parallel agents and collect their findings), third-party skills, and the model's own delegation pattern. Two failure modes were observed on real `/review` runs: the orchestrator either spins on identical `todo_write` calls until the upstream API rejects the request with `<400> InternalError.Algo.InvalidParameter: Repetitive tool calls detected`, or it correctly ends its turn and then waits forever for fork results that never return, so the review silently never completes. Making the dispatch default awaitable is necessary but not sufficient: once `fork` was advertised, the model began passing `subagent_type: "fork"` explicitly for the review agents — so the prompt and the skills also have to stop steering it to fork work whose results it must aggregate.

## Reviewer Test Plan

### How to verify

Unit tests cover the dispatch contract and the enum:
- `npx vitest run packages/core/src/tools/agent/agent.test.ts` — omitting `subagent_type` resolves to general-purpose (not a fork); `subagent_type: "fork"` forks when interactive and falls back to general-purpose when non-interactive; validation accepts `fork`; the enum does NOT advertise `fork`; `isolation` + `fork` is rejected.
- `npx vitest run packages/cli/src/ui/commands/forkCommand.test.ts` — `/fork` builds params with `subagent_type: "fork"`.

Manual repro (interactive session, large diff, `/review` or `/simplify`). Before: the parallel review agents return "Fork started — processing in background" and the run either dies with the Repetitive-tool-calls 400 or hangs forever with the review never completing. After: each agent is launched with `subagent_type: "general-purpose"`, fetches the diff itself (the review prompts are self-contained), and returns its findings inline, so the orchestrator can dedup/verify/post; `/fork` still launches a background fork as before.

### Evidence (Before & After)

N/A (no user-visible UI change). Behavioral: Before — an omitted `subagent_type` (or an explicit `fork` the model was nudged toward) ⇒ background fork, findings never returned, `review`/`simplify` 400 or hang. After — review/simplify agents are awaitable general-purpose subagents whose findings return inline; forking happens only via explicit `subagent_type: "fork"` and `/fork`, for fire-and-forget work.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS: the affected unit suites pass locally (core Agent tool 107/107, cli forkCommand 15/15) and the full `npm run build` is green; the fix was verified live in the built `packages/core/dist` that `npm start` loads. Windows/Linux: not run locally — relying on CI.

### Environment (optional)

Unit tests + a local `npm run build && npm start` smoke. No sandbox needed.

## Risk & Scope

- Main risk or tradeoff: review/simplify agents now run as general-purpose subagents instead of forks, so they no longer share the parent's prompt-cache prefix — slightly higher token cost in exchange for findings that actually return. The dispatch meaning of an omitted `subagent_type` returns to general-purpose; callers that relied on the post-#4963 "omit ⇒ fork" behavior must now pass `subagent_type: "fork"` (the only in-repo caller, `/fork`, is updated here).
- Not validated / out of scope: the parent-side notification drain (forks still only report when the session is idle) and the loop-detection default (`model.skipLoopDetection`, off by default) are untouched — separate hardening opportunities, not the root cause.
- Breaking changes / migration notes: corrective change to the #4963 behavior. Forking stays default-available in interactive sessions; it is now requested explicitly (`subagent_type: "fork"`) instead of by omitting the type, and the model is no longer steered to fork work whose results it needs.

## Linked Issues

Re: #4963 — reconsiders the default it introduced (no closing keyword; #4963 is a merged PR).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 fork 改成**显式、刻意的选择**,并阻止模型在"需要拿回结果"时去 fork。三层:(1) **派发** —— `subagent_type: "fork"` 才选 fork(仅交互式;否则 general-purpose),省略 `subagent_type` 解析为可 await 的 general-purpose、结果内联返回(绝不 fork),`/fork` 显式传 `subagent_type: "fork"`;(2) **prompt** —— Agent 工具不再把 `fork` 列进 `subagent_type` enum,删掉"launch parallel forks for research"的诱导,并把描述与 "When to fork" 改写为"输出你还要用的工作绝不 fork";(3) **skill** —— 内置 `review`、`simplify` 用 `subagent_type: "general-purpose"` 启动并行 agent,并明确告知不要 fork,因为它们要聚合结论。

## 为什么需要

#4963("enable fork subagents by default")在所有交互式会话中改变了"省略 `subagent_type`"的含义 —— 从"可 await 的 general-purpose、结果内联返回"变成"fire-and-forget 后台 fork",且无关闭开关。fork 的结论永不回流到父轮次,于是任何"并行派 agent 再聚合结果"的调用方都坏掉:内置 `review`/`simplify`(并行派 9/3 个 agent 再收结论)、第三方 skill、以及模型自身的委派习惯。真实 `/review` 上观察到两种失败:编排者要么不停发相同 `todo_write` 直到上游以 `<400> InternalError.Algo.InvalidParameter: Repetitive tool calls detected` 拒绝;要么正确结束本轮后永远空等 fork 结果、评审静默不收尾。仅把派发默认改成可 await 还不够:一旦 enum 里有了 `fork`,模型就开始**显式**给评审 agent 传 `subagent_type: "fork"` —— 所以 prompt 和 skill 也必须停止把它往"fork 需要聚合结果的工作"上引导。

## 评审者测试计划

### 如何验证

单元测试覆盖派发契约与 enum:
- `npx vitest run packages/core/src/tools/agent/agent.test.ts` —— 省略 `subagent_type` 解析为 general-purpose(非 fork);`subagent_type: "fork"` 交互式下 fork、非交互式下回退 general-purpose;校验放行 `fork`;enum **不**列出 `fork`;`isolation` 与 `fork` 组合被拒。
- `npx vitest run packages/cli/src/ui/commands/forkCommand.test.ts` —— `/fork` 构造参数带 `subagent_type: "fork"`。

手动复现(交互式、大 diff、`/review` 或 `/simplify`)。之前:并行评审 agent 返回 "Fork started — processing in background",该运行要么以 Repetitive-tool-calls 400 失败、要么永久挂起评审不收尾。之后:每个 agent 用 `subagent_type: "general-purpose"` 启动,自己取 diff(评审 prompt 是自包含的),结论内联返回,编排者得以去重/验证/发评论;`/fork` 仍照旧启动后台 fork。

### 证据(前后对比)

N/A(无用户可见 UI 变化)。行为:之前 —— 省略 `subagent_type`(或模型被引导显式传 `fork`)⇒ 后台 fork、结论不回流、`review`/`simplify` 400 或挂起。之后 —— review/simplify 的 agent 是可 await 的 general-purpose 子代理、结论内联返回;fork 仅经显式 `subagent_type: "fork"` 与 `/fork` 触发,用于 fire-and-forget 工作。

### 测试平台

仅 macOS:受影响单元套件本地通过(core Agent 工具 107/107,cli forkCommand 15/15),完整 `npm run build` 通过;并在 `npm start` 实际加载的 `packages/core/dist` 构建产物里验证了修复。Windows/Linux:本地未跑,依赖 CI。

### 环境(可选)

单元测试 + 本地 `npm run build && npm start` 冒烟。无需 sandbox。

## 风险与范围

- 主要风险/取舍:review/simplify 的 agent 现在作为 general-purpose 子代理运行(而非 fork),因此不再共享父会话的 prompt cache 前缀 —— 略增 token 成本,换来结论真正回流。省略 `subagent_type` 的派发含义回到 general-purpose;依赖 #4963 之后"省略即 fork"的调用方现在须显式传 `subagent_type: "fork"`(仓库内唯一此类调用方 `/fork` 已更新)。
- 未验证/超出范围:父侧通知排空(fork 仍只在会话空闲时上报)与循环检测默认值(`model.skipLoopDetection`,默认关)未改 —— 独立加固点,非根因。
- 破坏性变更/迁移:对 #4963 行为的纠正。fork 在交互式会话仍默认可用,只是现在需显式请求(`subagent_type: "fork"`),不再靠省略触发,模型也不再被引导去 fork 需要结果的工作。

</details>
