### PR TITLE
feat(web-shell): per-turn time & tokens on the collapse seam, below the prompt

### DIFF
--- a/packages/sdk-typescript/src/daemon/ui/normalizer.ts
+++ b/packages/sdk-typescript/src/daemon/ui/normalizer.ts
@@ -15,6 +15,7 @@ import type {
   DaemonUiEvent,
   DaemonUiPermissionOption,
   DaemonUiToolProvenance,
+  DaemonTurnUsage,
   NormalizeDaemonEventOptions,
 } from './types.js';
 import { DAEMON_PLAN_TOOL_CALL_ID } from './types.js';
@@ -471,16 +472,29 @@ function normalizeSessionUpdate(
     }
     case 'agent_message_chunk': {
       const text = getTextContent(update['content']);
-      if (!text) return [];
       const parentToolCallId = extractParentToolCallId(update);
-      return [
-        {
+      const events: DaemonUiEvent[] = [];
+      if (text) {
+        events.push({
           ...base,
           type: 'assistant.text.delta' as const,
           text,
           ...(parentToolCallId ? { parentToolCallId } : {}),
-        },
-      ];
+        });
+      }
+      // A turn's per-round token usage rides on an otherwise-empty
+      // `agent_message_chunk` (`_meta.usage`, text blank), so this frame is the
+      // only carrier — emit it even when there is no assistant text to show.
+      const usage = extractAssistantUsage(update);
+      if (usage) {
+        events.push({
+          ...base,
+          type: 'assistant.usage' as const,
+          usage,
+          ...(parentToolCallId ? { parentToolCallId } : {}),
+        });
+      }
+      return events;
     }
     case 'agent_thought_chunk': {
       const text = getTextContent(update['content']);
@@ -551,6 +565,24 @@ function extractParentToolCallId(
 ): string | undefined {
   const meta = isRecord(update['_meta']) ? update['_meta'] : undefined;
   return meta ? getString(meta, 'parentToolCallId') : undefined;
+}
+
+/**
+ * Read the token usage the daemon stamps on `agent_message_chunk._meta.usage`.
+ * Returns undefined when no usage is present (older agents, non-usage chunks) so
+ * the caller emits no `assistant.usage` event; a present-but-partial frame keeps
+ * whichever side it has and zero-fills the other.
+ */
+function extractAssistantUsage(
+  update: Record<string, unknown>,
+): DaemonTurnUsage | undefined {
+  const meta = isRecord(update['_meta']) ? update['_meta'] : undefined;
+  const usage = meta && isRecord(meta['usage']) ? meta['usage'] : undefined;
+  if (!usage) return undefined;
+  const inputTokens = numberField(usage, 'inputTokens');
+  const outputTokens = numberField(usage, 'outputTokens');
+  if (inputTokens === undefined && outputTokens === undefined) return undefined;
+  return { inputTokens: inputTokens ?? 0, outputTokens: outputTokens ?? 0 };
 }
 
 function normalizeToolUpdate(

--- a/packages/sdk-typescript/src/daemon/ui/normalizer.ts
+++ b/packages/sdk-typescript/src/daemon/ui/normalizer.ts
@@ -582,7 +582,14 @@ function extractAssistantUsage(
   const inputTokens = numberField(usage, 'inputTokens');
   const outputTokens = numberField(usage, 'outputTokens');
   if (inputTokens === undefined && outputTokens === undefined) return undefined;
-  return { inputTokens: inputTokens ?? 0, outputTokens: outputTokens ?? 0 };
+  // Cached-read tokens are a subset already counted in inputTokens; carried so
+  // renderers can break out the cache hit, not added to the total again.
+  const cachedTokens = numberField(usage, 'cachedReadTokens');
+  return {
+    inputTokens: inputTokens ?? 0,
+    outputTokens: outputTokens ?? 0,
+    ...(cachedTokens !== undefined ? { cachedTokens } : {}),
+  };
 }
 
 function normalizeToolUpdate(

--- a/packages/sdk-typescript/src/daemon/ui/terminal.ts
+++ b/packages/sdk-typescript/src/daemon/ui/terminal.ts
@@ -16,6 +16,9 @@ export function daemonUiEventToTerminalText(event: DaemonUiEvent): string {
       return sanitizeTerminalText(event.text).replace(/\r?\n/g, '\r\n');
     case 'assistant.done':
       return '';
+    case 'assistant.usage':
+      // Metadata only (token counts); no transcript line to render.
+      return '';
     case 'thought.text.delta':
       return terminalLine('thought', event.text, '2');
     case 'tool.update':

--- a/packages/sdk-typescript/src/daemon/ui/transcript.ts
+++ b/packages/sdk-typescript/src/daemon/ui/transcript.ts
@@ -421,25 +421,32 @@ function clearActiveAssistant(state: DaemonTranscriptState): void {
 }
 
 /**
- * Fold a round's token usage onto the active assistant block. The daemon emits
- * usage right after that round's assistant text, so the active block is the one
- * it belongs to; multiple rounds accumulate, and renderers sum a turn's blocks.
- * No active block (a rare usage frame with no preceding assistant text) drops
- * the count rather than minting a stray empty block.
+ * Fold a round's token usage onto the active top-level assistant block. The
+ * daemon emits usage right after that round's assistant text, so the active
+ * block is the one it belongs to; multiple rounds accumulate, and renderers sum
+ * a turn's blocks for the total.
+ *
+ * Sub-agent rounds (which arrive with a parentToolCallId) are folded in too:
+ * their tokens are part of the spawning turn's real cost, and the parent is
+ * blocked on the Task call while they run, so the top-level active block is
+ * still that turn's. Excluding them made the turn under-count badly against
+ * /stats. The sub-agent's own *text* still lives on its parent-keyed block; only
+ * the usage counter rides the top-level block.
+ *
+ * No active block (a rare usage frame with no preceding top-level assistant
+ * text) drops the count rather than minting a stray empty block.
  */
 function applyAssistantUsage(
   state: DaemonTranscriptState,
   event: Extract<DaemonUiEvent, { type: 'assistant.usage' }>,
 ): void {
-  // Top-level turn usage only — a sub-agent round arrives with parentToolCallId,
-  // and folding it onto the parent's block would over-count the turn.
-  if (event.parentToolCallId != null) return;
   const block = getWritableBlockById(state, state.activeAssistantBlockId);
   if (!block || block.kind !== 'assistant') return;
   const prev = block.usage;
   block.usage = {
     inputTokens: (prev?.inputTokens ?? 0) + event.usage.inputTokens,
     outputTokens: (prev?.outputTokens ?? 0) + event.usage.outputTokens,
+    cachedTokens: (prev?.cachedTokens ?? 0) + (event.usage.cachedTokens ?? 0),
   };
   block.updatedAt = state.now;
 }

--- a/packages/sdk-typescript/src/daemon/ui/transcript.ts
+++ b/packages/sdk-typescript/src/daemon/ui/transcript.ts
@@ -239,6 +239,9 @@ function applyDaemonTranscriptEvent(
         propagateCancellationToInFlightTools(next);
       }
       break;
+    case 'assistant.usage':
+      applyAssistantUsage(next, event);
+      break;
     case 'thought.text.delta':
       appendTextDelta(
         next,
@@ -415,6 +418,30 @@ function finalizeStreamingTextBlock(
 function clearActiveAssistant(state: DaemonTranscriptState): void {
   finalizeStreamingTextBlock(state, state.activeAssistantBlockId);
   state.activeAssistantBlockId = undefined;
+}
+
+/**
+ * Fold a round's token usage onto the active assistant block. The daemon emits
+ * usage right after that round's assistant text, so the active block is the one
+ * it belongs to; multiple rounds accumulate, and renderers sum a turn's blocks.
+ * No active block (a rare usage frame with no preceding assistant text) drops
+ * the count rather than minting a stray empty block.
+ */
+function applyAssistantUsage(
+  state: DaemonTranscriptState,
+  event: Extract<DaemonUiEvent, { type: 'assistant.usage' }>,
+): void {
+  // Top-level turn usage only — a sub-agent round arrives with parentToolCallId,
+  // and folding it onto the parent's block would over-count the turn.
+  if (event.parentToolCallId != null) return;
+  const block = getWritableBlockById(state, state.activeAssistantBlockId);
+  if (!block || block.kind !== 'assistant') return;
+  const prev = block.usage;
+  block.usage = {
+    inputTokens: (prev?.inputTokens ?? 0) + event.usage.inputTokens,
+    outputTokens: (prev?.outputTokens ?? 0) + event.usage.outputTokens,
+  };
+  block.updatedAt = state.now;
 }
 
 function clearActiveThought(state: DaemonTranscriptState): void {

--- a/packages/sdk-typescript/src/daemon/ui/types.ts
+++ b/packages/sdk-typescript/src/daemon/ui/types.ts
@@ -21,6 +21,7 @@ export type DaemonUiEventType =
   | 'user.shell.command'
   | 'assistant.text.delta'
   | 'assistant.done'
+  | 'assistant.usage'
   | 'thought.text.delta'
   | 'tool.update'
   | 'shell.output'
@@ -102,6 +103,31 @@ export interface DaemonUiUserShellCommandEvent extends DaemonUiEventBase {
 export interface DaemonUiAssistantDoneEvent extends DaemonUiEventBase {
   type: 'assistant.done';
   reason?: string;
+}
+
+/**
+ * Token usage the agent reports for one model round, carried on the daemon's
+ * `agent_message_chunk._meta.usage`. A turn issues one of these per model call,
+ * so a turn's total is the sum of its rounds. Counts are top-level only —
+ * sub-agent (delegated) usage arrives with a `parentToolCallId` and is excluded
+ * so a delegated call's tokens are not attributed to the parent turn.
+ */
+export interface DaemonTurnUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
+/**
+ * Per-round token usage. Emitted from `agent_message_chunk` frames that carry
+ * `_meta.usage` (their text is empty, so they surface no assistant text). The
+ * reducer folds the counts onto the round's active assistant block; renderers
+ * sum a turn's blocks for a per-turn total.
+ */
+export interface DaemonUiAssistantUsageEvent extends DaemonUiEventBase {
+  type: 'assistant.usage';
+  usage: DaemonTurnUsage;
+  /** Set when the usage belongs to a sub-agent round; excluded from turn totals. */
+  parentToolCallId?: string;
 }
 
 /**
@@ -454,6 +480,7 @@ export type DaemonUiEvent =
   | DaemonUiUserImageEvent
   | DaemonUiUserShellCommandEvent
   | DaemonUiAssistantDoneEvent
+  | DaemonUiAssistantUsageEvent
   | DaemonUiToolUpdateEvent
   | DaemonUiShellOutputEvent
   | DaemonUiUserShellOutputEvent
@@ -676,6 +703,13 @@ export interface DaemonTextTranscriptBlock extends DaemonTranscriptBlockBase {
   collapsed?: boolean;
   /** Used by the reducer for per-subAgent block routing; renderers may use it for nesting. */
   parentToolCallId?: string;
+  /**
+   * Token usage folded onto this assistant block by the reducer from the
+   * round's `assistant.usage` event(s). Summed across a turn's assistant blocks
+   * for a per-turn total. Assistant blocks only; absent until a usage frame
+   * lands (and on sessions whose agent predates usage stamping).
+   */
+  usage?: DaemonTurnUsage;
 }
 
 export interface DaemonToolTranscriptBlock extends DaemonTranscriptBlockBase {

--- a/packages/sdk-typescript/src/daemon/ui/types.ts
+++ b/packages/sdk-typescript/src/daemon/ui/types.ts
@@ -115,6 +115,11 @@ export interface DaemonUiAssistantDoneEvent extends DaemonUiEventBase {
 export interface DaemonTurnUsage {
   inputTokens: number;
   outputTokens: number;
+  /**
+   * Cached-read tokens for the round — a subset of `inputTokens` (already
+   * counted in it, not additive). Absent when the round reported none.
+   */
+  cachedTokens?: number;
 }
 
 /**

--- a/packages/sdk-typescript/test/unit/daemonUi.test.ts
+++ b/packages/sdk-typescript/test/unit/daemonUi.test.ts
@@ -237,22 +237,72 @@ describe('daemon UI normalizer and transcript reducer', () => {
     ]);
   });
 
-  it('excludes sub-agent usage (parentToolCallId) from the parent block', () => {
+  it('folds sub-agent usage (parentToolCallId) into the parent turn total', () => {
     const state = reduceDaemonTranscriptEvents(
       createDaemonTranscriptState({ now: 1 }),
       [
         { type: 'assistant.text.delta', text: 'answer' },
+        // The parent's own round.
+        { type: 'assistant.usage', usage: { inputTokens: 100, outputTokens: 20 } },
+        // A round from a spawned sub-agent — part of the turn's real cost.
         {
           type: 'assistant.usage',
-          usage: { inputTokens: 100, outputTokens: 20 },
+          usage: { inputTokens: 5000, outputTokens: 800 },
           parentToolCallId: 'sub-1',
         },
       ],
       { now: 2 },
     );
 
-    expect(state.blocks).toMatchObject([{ kind: 'assistant', text: 'answer' }]);
-    expect((state.blocks[0] as { usage?: unknown }).usage).toBeUndefined();
+    expect(state.blocks).toMatchObject([
+      {
+        kind: 'assistant',
+        text: 'answer',
+        usage: { inputTokens: 5100, outputTokens: 820 },
+      },
+    ]);
+  });
+
+  it('carries and accumulates cached-read tokens', () => {
+    const events = normalizeDaemonEvent({
+      id: 11,
+      v: 1,
+      type: 'session_update',
+      data: {
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: '' },
+          _meta: {
+            usage: { inputTokens: 30, outputTokens: 12, cachedReadTokens: 24 },
+          },
+        },
+      },
+    });
+    expect(events).toMatchObject([
+      {
+        type: 'assistant.usage',
+        usage: { inputTokens: 30, outputTokens: 12, cachedTokens: 24 },
+      },
+    ]);
+
+    const state = reduceDaemonTranscriptEvents(
+      createDaemonTranscriptState({ now: 1 }),
+      [
+        { type: 'assistant.text.delta', text: 'a' },
+        {
+          type: 'assistant.usage',
+          usage: { inputTokens: 30, outputTokens: 12, cachedTokens: 24 },
+        },
+        {
+          type: 'assistant.usage',
+          usage: { inputTokens: 10, outputTokens: 3, cachedTokens: 8 },
+        },
+      ],
+      { now: 2 },
+    );
+    expect(state.blocks[0]).toMatchObject({
+      usage: { inputTokens: 40, outputTokens: 15, cachedTokens: 32 },
+    });
   });
 
   it('drops usage with no active assistant block rather than minting one', () => {

--- a/packages/sdk-typescript/test/unit/daemonUi.test.ts
+++ b/packages/sdk-typescript/test/unit/daemonUi.test.ts
@@ -152,7 +152,10 @@ describe('daemon UI normalizer and transcript reducer', () => {
       },
     });
 
-    expect(events).toMatchObject([{ type: 'assistant.text.delta' }]);
+    expect(events).toMatchObject([
+      { type: 'assistant.text.delta' },
+      { type: 'assistant.usage', usage: { inputTokens: 0, outputTokens: 1 } },
+    ]);
 
     let state = reduceDaemonTranscriptEvents(
       createDaemonTranscriptState({ now: 1 }),
@@ -175,6 +178,91 @@ describe('daemon UI normalizer and transcript reducer', () => {
     expect(state.blocks).toMatchObject([
       { kind: 'assistant', text: 'done', streaming: false },
     ]);
+  });
+
+  it('emits assistant.usage from an empty-text usage chunk (no text delta)', () => {
+    const events = normalizeDaemonEvent({
+      id: 9,
+      v: 1,
+      type: 'session_update',
+      data: {
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: '' },
+          _meta: { usage: { inputTokens: 30, outputTokens: 12 } },
+        },
+      },
+    });
+
+    // The blank text would otherwise be dropped; the usage must still survive.
+    expect(events).toMatchObject([
+      { type: 'assistant.usage', usage: { inputTokens: 30, outputTokens: 12 } },
+    ]);
+  });
+
+  it('emits no usage event when the chunk carries no _meta.usage', () => {
+    const events = normalizeDaemonEvent({
+      id: 9,
+      v: 1,
+      type: 'session_update',
+      data: {
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'hello' },
+        },
+      },
+    });
+
+    expect(events).toMatchObject([{ type: 'assistant.text.delta' }]);
+    expect(events).toHaveLength(1);
+  });
+
+  it('folds per-round usage onto the active assistant block, accumulating', () => {
+    const state = reduceDaemonTranscriptEvents(
+      createDaemonTranscriptState({ now: 1 }),
+      [
+        { type: 'assistant.text.delta', text: 'answer' },
+        { type: 'assistant.usage', usage: { inputTokens: 100, outputTokens: 20 } },
+        { type: 'assistant.usage', usage: { inputTokens: 5, outputTokens: 3 } },
+      ],
+      { now: 2 },
+    );
+
+    expect(state.blocks).toMatchObject([
+      {
+        kind: 'assistant',
+        text: 'answer',
+        usage: { inputTokens: 105, outputTokens: 23 },
+      },
+    ]);
+  });
+
+  it('excludes sub-agent usage (parentToolCallId) from the parent block', () => {
+    const state = reduceDaemonTranscriptEvents(
+      createDaemonTranscriptState({ now: 1 }),
+      [
+        { type: 'assistant.text.delta', text: 'answer' },
+        {
+          type: 'assistant.usage',
+          usage: { inputTokens: 100, outputTokens: 20 },
+          parentToolCallId: 'sub-1',
+        },
+      ],
+      { now: 2 },
+    );
+
+    expect(state.blocks).toMatchObject([{ kind: 'assistant', text: 'answer' }]);
+    expect((state.blocks[0] as { usage?: unknown }).usage).toBeUndefined();
+  });
+
+  it('drops usage with no active assistant block rather than minting one', () => {
+    const state = reduceDaemonTranscriptEvents(
+      createDaemonTranscriptState({ now: 1 }),
+      [{ type: 'assistant.usage', usage: { inputTokens: 9, outputTokens: 9 } }],
+      { now: 2 },
+    );
+
+    expect(state.blocks).toHaveLength(0);
   });
 
   it('finalizes scalar thought blocks when the assistant turn finishes', () => {

--- a/packages/web-shell/client/adapters/messageTypes.ts
+++ b/packages/web-shell/client/adapters/messageTypes.ts
@@ -87,6 +87,13 @@ export interface DaemonAssistantMessage extends DaemonMessageMeta {
   content: string;
   thinking?: string;
   isStreaming?: boolean;
+  /**
+   * Token usage folded onto this assistant block by the daemon SDK reducer
+   * (summed when several blocks merge into one message). Summed again across a
+   * turn's assistant messages for the per-turn total shown on the fold toggle.
+   * Absent on sessions whose agent predates usage stamping.
+   */
+  usage?: { inputTokens: number; outputTokens: number };
 }
 
 export interface DaemonToolGroupMessage extends DaemonMessageMeta {

--- a/packages/web-shell/client/adapters/messageTypes.ts
+++ b/packages/web-shell/client/adapters/messageTypes.ts
@@ -93,7 +93,7 @@ export interface DaemonAssistantMessage extends DaemonMessageMeta {
    * turn's assistant messages for the per-turn total shown on the fold toggle.
    * Absent on sessions whose agent predates usage stamping.
    */
-  usage?: { inputTokens: number; outputTokens: number };
+  usage?: { inputTokens: number; outputTokens: number; cachedTokens?: number };
 }
 
 export interface DaemonToolGroupMessage extends DaemonMessageMeta {

--- a/packages/web-shell/client/adapters/transcriptToMessages.test.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.test.ts
@@ -334,6 +334,21 @@ describe('transcriptBlocksToDaemonMessages', () => {
     expect((messages[0] as { usage?: unknown }).usage).toBeUndefined();
   });
 
+  it('carries cached-read tokens through onto the message', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      textBlock('a1', 'assistant', 'answer', 1, false, {
+        usage: { inputTokens: 200, outputTokens: 80, cachedTokens: 150 },
+      }),
+    ]);
+
+    expect(messages).toMatchObject([
+      {
+        role: 'assistant',
+        usage: { inputTokens: 200, outputTokens: 80, cachedTokens: 150 },
+      },
+    ]);
+  });
+
   it('starts a new tool_group after an intervening thought block', () => {
     const messages = transcriptBlocksToDaemonMessages([
       toolBlock('t1', 'tc1', 'completed', 1, { toolName: 'Read' }),

--- a/packages/web-shell/client/adapters/transcriptToMessages.test.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.test.ts
@@ -291,6 +291,49 @@ describe('transcriptBlocksToDaemonMessages', () => {
     ]);
   });
 
+  it('carries token usage from an assistant block onto the message', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      textBlock('a1', 'assistant', 'final answer', 1, false, {
+        usage: { inputTokens: 200, outputTokens: 80 },
+      }),
+    ]);
+
+    expect(messages).toMatchObject([
+      {
+        role: 'assistant',
+        content: 'final answer',
+        usage: { inputTokens: 200, outputTokens: 80 },
+      },
+    ]);
+  });
+
+  it('sums usage when consecutive assistant blocks merge into one message', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      textBlock('a1', 'assistant', 'hi ', 1, false, {
+        usage: { inputTokens: 100, outputTokens: 40 },
+      }),
+      textBlock('a2', 'assistant', 'there', 2, false, {
+        usage: { inputTokens: 20, outputTokens: 8 },
+      }),
+    ]);
+
+    expect(messages).toMatchObject([
+      {
+        role: 'assistant',
+        content: 'hi there',
+        usage: { inputTokens: 120, outputTokens: 48 },
+      },
+    ]);
+  });
+
+  it('leaves usage undefined when no assistant block reports it', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      textBlock('a1', 'assistant', 'no usage here', 1),
+    ]);
+
+    expect((messages[0] as { usage?: unknown }).usage).toBeUndefined();
+  });
+
   it('starts a new tool_group after an intervening thought block', () => {
     const messages = transcriptBlocksToDaemonMessages([
       toolBlock('t1', 'tc1', 'completed', 1, { toolName: 'Read' }),

--- a/packages/web-shell/client/adapters/transcriptToMessages.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.ts
@@ -75,14 +75,16 @@ function parseDaemonTodoItemsFromEntries(
  * side has usage, so the message field stays absent rather than a spurious 0/0.
  */
 function mergeAssistantUsage(
-  a: { inputTokens: number; outputTokens: number } | undefined,
-  b: { inputTokens: number; outputTokens: number } | undefined,
-): { inputTokens: number; outputTokens: number } | undefined {
+  a: { inputTokens: number; outputTokens: number; cachedTokens?: number } | undefined,
+  b: { inputTokens: number; outputTokens: number; cachedTokens?: number } | undefined,
+): { inputTokens: number; outputTokens: number; cachedTokens?: number } | undefined {
   if (!a) return b;
   if (!b) return a;
+  const cachedTokens = (a.cachedTokens ?? 0) + (b.cachedTokens ?? 0);
   return {
     inputTokens: a.inputTokens + b.inputTokens,
     outputTokens: a.outputTokens + b.outputTokens,
+    ...(cachedTokens > 0 ? { cachedTokens } : {}),
   };
 }
 

--- a/packages/web-shell/client/adapters/transcriptToMessages.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.ts
@@ -69,6 +69,23 @@ function parseDaemonTodoItemsFromEntries(
   return todos.length > 0 ? todos : undefined;
 }
 
+/**
+ * Sum the per-block token usage the SDK reducer stamped onto assistant blocks
+ * when several merge into one rendered message. Returns undefined when neither
+ * side has usage, so the message field stays absent rather than a spurious 0/0.
+ */
+function mergeAssistantUsage(
+  a: { inputTokens: number; outputTokens: number } | undefined,
+  b: { inputTokens: number; outputTokens: number } | undefined,
+): { inputTokens: number; outputTokens: number } | undefined {
+  if (!a) return b;
+  if (!b) return a;
+  return {
+    inputTokens: a.inputTokens + b.inputTokens,
+    outputTokens: a.outputTokens + b.outputTokens,
+  };
+}
+
 export function transcriptBlocksToDaemonMessages(
   blocks: readonly DaemonTranscriptBlock[],
   options: TranscriptMessageOptions = {},
@@ -186,10 +203,12 @@ export function transcriptBlocksToDaemonMessages(
             ? messages[currentAssistantIdx]
             : undefined;
         if (target && target.role === 'assistant' && !needsNewContentMessage) {
+          const usage = mergeAssistantUsage(target.usage, textBlock.usage);
           messages[currentAssistantIdx!] = {
             ...target,
             content: target.content + textBlock.text,
             isStreaming: textBlock.streaming,
+            ...(usage ? { usage } : {}),
           };
           needsNewContentMessage = false;
         } else {
@@ -199,6 +218,7 @@ export function transcriptBlocksToDaemonMessages(
             content: textBlock.text,
             isStreaming: textBlock.streaming,
             timestamp: blockTime,
+            ...(textBlock.usage ? { usage: textBlock.usage } : {}),
           });
           currentAssistantIdx = messages.length - 1;
           needsNewContentMessage = false;

--- a/packages/web-shell/client/adapters/types.ts
+++ b/packages/web-shell/client/adapters/types.ts
@@ -51,6 +51,20 @@ export interface TurnCollapseHead {
   collapsed: boolean;
   /** number of display rows hidden behind the toggle while collapsed. */
   hiddenCount: number;
+  /**
+   * Wall-clock span from the prompt to the turn's last step, in ms. Derived
+   * from block timestamps (so it survives replay); undefined when either end
+   * lacks a timestamp. Approximate — a step's own runtime past its start is not
+   * captured.
+   */
+  elapsedMs?: number;
+  /**
+   * Per-turn token usage, summed from the turn's assistant messages. Both fields
+   * are present together or the pair is undefined (older sessions stamp no
+   * usage). Sub-agent tokens are excluded (see the SDK reducer).
+   */
+  inputTokens?: number;
+  outputTokens?: number;
 }
 
 export interface ContentBlock {

--- a/packages/web-shell/client/adapters/types.ts
+++ b/packages/web-shell/client/adapters/types.ts
@@ -65,6 +65,8 @@ export interface TurnCollapseHead {
    */
   inputTokens?: number;
   outputTokens?: number;
+  /** Cached-read tokens — a subset of inputTokens, surfaced only when > 0. */
+  cachedTokens?: number;
 }
 
 export interface ContentBlock {

--- a/packages/web-shell/client/adapters/types.ts
+++ b/packages/web-shell/client/adapters/types.ts
@@ -67,6 +67,13 @@ export interface TurnCollapseHead {
   outputTokens?: number;
   /** Cached-read tokens — a subset of inputTokens, surfaced only when > 0. */
   cachedTokens?: number;
+  /**
+   * Prompt wall-clock (ms) for a still-running turn. Present only while the turn
+   * is active; the row ticks `now - liveStartedAt` once a second so the elapsed
+   * advances smoothly instead of jumping per step. Absent once complete, when
+   * the frozen `elapsedMs` is shown.
+   */
+  liveStartedAt?: number;
 }
 
 export interface ContentBlock {

--- a/packages/web-shell/client/components/MessageItem.tsx
+++ b/packages/web-shell/client/components/MessageItem.tsx
@@ -165,7 +165,8 @@ function turnCollapseEqual(
     a.hiddenCount === b.hiddenCount &&
     a.elapsedMs === b.elapsedMs &&
     a.inputTokens === b.inputTokens &&
-    a.outputTokens === b.outputTokens
+    a.outputTokens === b.outputTokens &&
+    a.cachedTokens === b.cachedTokens
   );
 }
 

--- a/packages/web-shell/client/components/MessageItem.tsx
+++ b/packages/web-shell/client/components/MessageItem.tsx
@@ -162,7 +162,10 @@ function turnCollapseEqual(
   return (
     a.turnId === b.turnId &&
     a.collapsed === b.collapsed &&
-    a.hiddenCount === b.hiddenCount
+    a.hiddenCount === b.hiddenCount &&
+    a.elapsedMs === b.elapsedMs &&
+    a.inputTokens === b.inputTokens &&
+    a.outputTokens === b.outputTokens
   );
 }
 

--- a/packages/web-shell/client/components/MessageItem.tsx
+++ b/packages/web-shell/client/components/MessageItem.tsx
@@ -166,7 +166,8 @@ function turnCollapseEqual(
     a.elapsedMs === b.elapsedMs &&
     a.inputTokens === b.inputTokens &&
     a.outputTokens === b.outputTokens &&
-    a.cachedTokens === b.cachedTokens
+    a.cachedTokens === b.cachedTokens &&
+    a.liveStartedAt === b.liveStartedAt
   );
 }
 

--- a/packages/web-shell/client/components/MessageList.test.ts
+++ b/packages/web-shell/client/components/MessageList.test.ts
@@ -423,9 +423,28 @@ describe('applyTurnCollapse', () => {
     ]);
     const out = collapseItems(items, { isResponding: true });
     // Every row stays visible; the head carries the seam but is not collapsed.
+    // While live there is no final answer, so the trailing assistant text counts
+    // as a step too (tool group + assistant text = 2).
     expect(rowIds(out)).toEqual(['u1', 'g1', 'a1']);
     expect(messageRow(out[0]).collapse?.collapsed).toBe(false);
-    expect(messageRow(out[0]).collapse?.hiddenCount).toBe(1);
+    expect(messageRow(out[0]).collapse?.hiddenCount).toBe(2);
+  });
+
+  it('collapsing the active turn folds to prompt + seam (no stranded line)', () => {
+    const items = groupParallelAgents([
+      makeUserMessage('u1'),
+      makeMultiToolGroup('g1'),
+      // An intermediate status line, not a final answer — the turn is still live.
+      { id: 'a1', role: 'assistant', content: 'Deterministic analysis clean…' },
+    ]);
+    const out = collapseItems(items, {
+      isResponding: true,
+      overrides: new Map([['u1', false]]),
+    });
+    // No final answer yet, so the fold drops the intermediate text too — only
+    // the prompt row (carrying the seam) survives.
+    expect(rowIds(out)).toEqual(['u1']);
+    expect(messageRow(out[0]).collapse?.collapsed).toBe(true);
   });
 
   it('collapses earlier turns but leaves the active last turn expanded', () => {

--- a/packages/web-shell/client/components/MessageList.test.ts
+++ b/packages/web-shell/client/components/MessageList.test.ts
@@ -596,6 +596,74 @@ describe('applyTurnCollapse', () => {
     expect(rowIds(out)).toEqual(['u1', 'a1']);
     expect(messageRow(out[0]).collapse?.collapsed).toBe(true);
   });
+
+  it('records elapsed (prompt → last step) and token usage on the head', () => {
+    const items = groupParallelAgents([
+      { id: 'u1', role: 'user', content: 'hi', timestamp: 1_000 },
+      {
+        id: 'g1',
+        role: 'tool_group',
+        tools: [{ callId: 'c1', toolName: 'Read', status: 'completed' }],
+        timestamp: 2_000,
+      },
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: 'final',
+        timestamp: 5_000,
+        usage: { inputTokens: 3100, outputTokens: 5100 },
+      },
+    ]);
+    const out = collapseItems(items);
+    expect(messageRow(out[0]).collapse).toEqual({
+      turnId: 'u1',
+      collapsed: true,
+      hiddenCount: 1,
+      elapsedMs: 4_000,
+      inputTokens: 3100,
+      outputTokens: 5100,
+    });
+  });
+
+  it('sums token usage across a turn (hidden mid-turn text + final answer)', () => {
+    const items = groupParallelAgents([
+      { id: 'u1', role: 'user', content: 'hi', timestamp: 1_000 },
+      {
+        id: 'a0',
+        role: 'assistant',
+        content: 'mid-turn note',
+        timestamp: 2_000,
+        usage: { inputTokens: 100, outputTokens: 50 },
+      },
+      {
+        id: 'g1',
+        role: 'tool_group',
+        tools: [{ callId: 'c1', toolName: 'Read', status: 'completed' }],
+        timestamp: 3_000,
+      },
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: 'final',
+        timestamp: 4_000,
+        usage: { inputTokens: 200, outputTokens: 80 },
+      },
+    ]);
+    const head = messageRow(collapseItems(items)[0]).collapse;
+    expect(head?.inputTokens).toBe(300);
+    expect(head?.outputTokens).toBe(130);
+    expect(head?.elapsedMs).toBe(3_000);
+  });
+
+  it('omits elapsed/usage when the turn carries no timestamps or usage', () => {
+    const items = groupParallelAgents([
+      makeUserMessage('u1'),
+      makeMultiToolGroup('g1'),
+      makeAssistantMessage('a1'),
+    ]);
+    const head = messageRow(collapseItems(items)[0]).collapse;
+    expect(head).toEqual({ turnId: 'u1', collapsed: true, hiddenCount: 1 });
+  });
 });
 
 describe('findTurnIdForIndex', () => {

--- a/packages/web-shell/client/components/MessageList.test.ts
+++ b/packages/web-shell/client/components/MessageList.test.ts
@@ -415,18 +415,20 @@ describe('applyTurnCollapse', () => {
     });
   });
 
-  it('never collapses the active turn while responding', () => {
+  it('tags but keeps the active turn expanded while responding', () => {
     const items = groupParallelAgents([
       makeUserMessage('u1'),
       makeMultiToolGroup('g1'),
       makeAssistantMessage('a1'),
     ]);
     const out = collapseItems(items, { isResponding: true });
+    // Every row stays visible; the head carries the seam but is not collapsed.
     expect(rowIds(out)).toEqual(['u1', 'g1', 'a1']);
-    expect(messageRow(out[0]).collapse).toBeUndefined();
+    expect(messageRow(out[0]).collapse?.collapsed).toBe(false);
+    expect(messageRow(out[0]).collapse?.hiddenCount).toBe(1);
   });
 
-  it('collapses earlier turns but leaves the active last turn open', () => {
+  it('collapses earlier turns but leaves the active last turn expanded', () => {
     const items = groupParallelAgents([
       makeUserMessage('u1'),
       makeMultiToolGroup('g1'),
@@ -437,7 +439,34 @@ describe('applyTurnCollapse', () => {
     const out = collapseItems(items, { isResponding: true });
     expect(rowIds(out)).toEqual(['u1', 'a1', 'u2', 'g2']);
     expect(messageRow(out[0]).collapse?.collapsed).toBe(true);
-    expect(messageRow(out[2]).collapse).toBeUndefined();
+    expect(messageRow(out[2]).collapse?.collapsed).toBe(false);
+  });
+
+  it('shows live metrics on the active turn without collapsing it', () => {
+    const items = groupParallelAgents([
+      { id: 'u1', role: 'user', content: 'hi', timestamp: 1_000 },
+      {
+        id: 'g1',
+        role: 'tool_group',
+        tools: [{ callId: 'c1', toolName: 'Read', status: 'in_progress' }],
+        timestamp: 3_000,
+      },
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: 'working',
+        timestamp: 3_500,
+        usage: { inputTokens: 120, outputTokens: 30 },
+      },
+    ]);
+    const out = collapseItems(items, { isResponding: true });
+    // Active turn stays fully expanded, yet the seam carries live metrics.
+    expect(rowIds(out)).toEqual(['u1', 'g1', 'a1']);
+    const head = messageRow(out[0]).collapse;
+    expect(head?.collapsed).toBe(false);
+    expect(head?.elapsedMs).toBe(2_500);
+    expect(head?.inputTokens).toBe(120);
+    expect(head?.outputTokens).toBe(30);
   });
 
   it('does not tag a turn with no intermediate steps', () => {

--- a/packages/web-shell/client/components/MessageList.test.ts
+++ b/packages/web-shell/client/components/MessageList.test.ts
@@ -423,11 +423,11 @@ describe('applyTurnCollapse', () => {
     ]);
     const out = collapseItems(items, { isResponding: true });
     // Every row stays visible; the head carries the seam but is not collapsed.
-    // While live there is no final answer, so the trailing assistant text counts
-    // as a step too (tool group + assistant text = 2).
+    // The streamed answer is provisional (not a step), so only the tool group
+    // counts — a step-less reply stays step-less rather than flashing "1 step".
     expect(rowIds(out)).toEqual(['u1', 'g1', 'a1']);
     expect(messageRow(out[0]).collapse?.collapsed).toBe(false);
-    expect(messageRow(out[0]).collapse?.hiddenCount).toBe(2);
+    expect(messageRow(out[0]).collapse?.hiddenCount).toBe(1);
   });
 
   it('collapsing the active turn folds to prompt + seam (no stranded line)', () => {
@@ -445,6 +445,55 @@ describe('applyTurnCollapse', () => {
     // the prompt row (carrying the seam) survives.
     expect(rowIds(out)).toEqual(['u1']);
     expect(messageRow(out[0]).collapse?.collapsed).toBe(true);
+  });
+
+  it('keeps a step-less reply step-less while it streams', () => {
+    const items = groupParallelAgents([
+      { id: 'u1', role: 'user', content: '你好', timestamp: 1_000 },
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: '你好！',
+        timestamp: 1_500,
+        usage: { inputTokens: 100, outputTokens: 20 },
+      },
+    ]);
+    const head = messageRow(collapseItems(items, { isResponding: true })[0])
+      .collapse;
+    // The streamed answer is provisional, not a step → nothing to fold, so no
+    // chevron flashes in then out when the turn completes.
+    expect(head?.hiddenCount).toBe(0);
+  });
+
+  it('marks the active turn live with its prompt timestamp', () => {
+    const items = groupParallelAgents([
+      { id: 'u1', role: 'user', content: 'hi', timestamp: 1_000 },
+      {
+        id: 'g1',
+        role: 'tool_group',
+        tools: [{ callId: 'c1', toolName: 'Read', status: 'in_progress' }],
+        timestamp: 2_000,
+      },
+    ]);
+    const head = messageRow(collapseItems(items, { isResponding: true })[0])
+      .collapse;
+    expect(head?.liveStartedAt).toBe(1_000);
+  });
+
+  it('does not mark a completed turn live', () => {
+    const items = groupParallelAgents([
+      { id: 'u1', role: 'user', content: 'hi', timestamp: 1_000 },
+      {
+        id: 'g1',
+        role: 'tool_group',
+        tools: [{ callId: 'c1', toolName: 'Read', status: 'completed' }],
+        timestamp: 2_000,
+      },
+      { id: 'a1', role: 'assistant', content: 'done', timestamp: 3_000 },
+    ]);
+    expect(
+      messageRow(collapseItems(items)[0]).collapse?.liveStartedAt,
+    ).toBeUndefined();
   });
 
   it('collapses earlier turns but leaves the active last turn expanded', () => {

--- a/packages/web-shell/client/components/MessageList.test.ts
+++ b/packages/web-shell/client/components/MessageList.test.ts
@@ -712,6 +712,50 @@ describe('applyTurnCollapse', () => {
     const head = messageRow(collapseItems(items)[0]).collapse;
     expect(head).toEqual({ turnId: 'u1', collapsed: true, hiddenCount: 1 });
   });
+
+  it('shows a chevron-less metrics seam on a step-less turn', () => {
+    const items = groupParallelAgents([
+      { id: 'u1', role: 'user', content: '你好', timestamp: 1_000 },
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: '你好！有什么可以帮你的吗？',
+        timestamp: 1_900,
+        usage: { inputTokens: 1200, outputTokens: 45 },
+      },
+    ]);
+    const out = collapseItems(items);
+    // Nothing foldable, but the metrics still surface and all rows stay visible.
+    expect(rowIds(out)).toEqual(['u1', 'a1']);
+    const head = messageRow(out[0]).collapse;
+    expect(head?.hiddenCount).toBe(0);
+    expect(head?.collapsed).toBe(false);
+    expect(head?.elapsedMs).toBe(900);
+    expect(head?.inputTokens).toBe(1200);
+    expect(head?.outputTokens).toBe(45);
+  });
+
+  it('sums cached-read tokens across the turn', () => {
+    const items = groupParallelAgents([
+      { id: 'u1', role: 'user', content: 'hi', timestamp: 1_000 },
+      {
+        id: 'g1',
+        role: 'tool_group',
+        tools: [{ callId: 'c1', toolName: 'Read', status: 'completed' }],
+        timestamp: 2_000,
+      },
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: 'done',
+        timestamp: 3_000,
+        usage: { inputTokens: 2000, outputTokens: 100, cachedTokens: 1800 },
+      },
+    ]);
+    expect(messageRow(collapseItems(items)[0]).collapse?.cachedTokens).toBe(
+      1800,
+    );
+  });
 });
 
 describe('findTurnIdForIndex', () => {

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -471,12 +471,17 @@ export function applyTurnCollapse(
       pendingApprovalCallId,
     );
 
-    // Final answer = last assistant-with-content row in (start, end].
+    // Final answer = last assistant-with-content row in (start, end]. An active
+    // turn has none yet — its latest assistant text is just another streaming
+    // step — so leave it unset; otherwise collapsing the turn would strand that
+    // intermediate line instead of folding down to the prompt + seam.
     let answerIdx = -1;
-    for (let i = end; i > start; i--) {
-      if (isAssistantAnswer(items[i])) {
-        answerIdx = i;
-        break;
+    if (!isActiveTurn) {
+      for (let i = end; i > start; i--) {
+        if (isAssistantAnswer(items[i])) {
+          answerIdx = i;
+          break;
+        }
       }
     }
 

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -371,12 +371,16 @@ function itemTimestamp(item: DisplayItem): number | undefined {
 }
 
 /**
- * Per-turn token usage contribution of a row: only top-level assistant messages
- * carry usage (sub-agent rounds are excluded upstream in the SDK reducer).
+ * Per-turn token usage contribution of a row. The SDK reducer folds each round's
+ * usage — including the sub-agent rounds a turn spawns — onto the turn's
+ * top-level assistant blocks, so summing the turn's assistant messages yields
+ * its true total cost.
  */
 function itemAssistantUsage(
   item: DisplayItem,
-): { inputTokens: number; outputTokens: number } | undefined {
+):
+  | { inputTokens: number; outputTokens: number; cachedTokens?: number }
+  | undefined {
   return item.type === 'message' && item.message.role === 'assistant'
     ? item.message.usage
     : undefined;
@@ -489,6 +493,7 @@ export function applyTurnCollapse(
     let lastStepTs: number | undefined;
     let inputTokens = 0;
     let outputTokens = 0;
+    let cachedTokens = 0;
     let hasUsage = false;
     for (let i = start + 1; i <= end; i++) {
       if (isHideableStep(items[i], i === answerIdx)) hiddenCount++;
@@ -500,24 +505,10 @@ export function applyTurnCollapse(
       if (usage) {
         inputTokens += usage.inputTokens;
         outputTokens += usage.outputTokens;
+        cachedTokens += usage.cachedTokens ?? 0;
         hasUsage = true;
       }
     }
-
-    if (hasPendingApproval || hiddenCount === 0) {
-      // Not foldable: the inline approve/reject UI must stay reachable, or the
-      // turn has no steps yet. Emit it untouched.
-      for (let i = start; i <= end; i++) result.push(items[i]);
-      continue;
-    }
-
-    // The active (streaming) turn still gets the seam so its live step / time /
-    // token metrics are visible, but defaults to expanded so the streaming rows
-    // stay shown; a completed turn defaults to collapsed. Either can be toggled.
-    const expanded = overrides.has(turnId)
-      ? (overrides.get(turnId) as boolean)
-      : isActiveTurn;
-    const collapsed = !expanded;
 
     const promptTs = head.message.timestamp;
     const elapsedMs =
@@ -526,6 +517,26 @@ export function applyTurnCollapse(
       lastStepTs >= promptTs
         ? lastStepTs - promptTs
         : undefined;
+    const hasMetrics = hasUsage || elapsedMs !== undefined;
+
+    if (hasPendingApproval || (hiddenCount === 0 && !hasMetrics)) {
+      // Nothing to add: the inline approve/reject UI must stay reachable, or the
+      // turn has neither foldable steps nor a measured metric. Emit it untouched.
+      for (let i = start; i <= end; i++) result.push(items[i]);
+      continue;
+    }
+
+    // A turn with foldable steps gets a chevron and defaults to expanded while
+    // streaming, collapsed once complete. A step-less turn (e.g. a plain "hi"
+    // reply) has nothing to fold, so it stays expanded and shows a chevron-less
+    // metrics line. An explicit user toggle always wins.
+    const expanded =
+      hiddenCount === 0
+        ? true
+        : overrides.has(turnId)
+          ? (overrides.get(turnId) as boolean)
+          : isActiveTurn;
+    const collapsed = !expanded;
 
     result.push({
       type: 'message',
@@ -537,6 +548,7 @@ export function applyTurnCollapse(
         hiddenCount,
         ...(elapsedMs !== undefined ? { elapsedMs } : {}),
         ...(hasUsage ? { inputTokens, outputTokens } : {}),
+        ...(cachedTokens > 0 ? { cachedTokens } : {}),
       },
     });
 

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -475,17 +475,15 @@ export function applyTurnCollapse(
       pendingApprovalCallId,
     );
 
-    // Final answer = last assistant-with-content row in (start, end]. An active
-    // turn has none yet — its latest assistant text is just another streaming
-    // step — so leave it unset; otherwise collapsing the turn would strand that
-    // intermediate line instead of folding down to the prompt + seam.
+    // Final answer = last assistant-with-content row in (start, end]. On an
+    // active turn this is provisional (the latest streamed text), so it is not
+    // counted as a step — keeping a step-less reply step-less — but it is folded
+    // away with everything else when the live turn is collapsed (see below).
     let answerIdx = -1;
-    if (!isActiveTurn) {
-      for (let i = end; i > start; i--) {
-        if (isAssistantAnswer(items[i])) {
-          answerIdx = i;
-          break;
-        }
+    for (let i = end; i > start; i--) {
+      if (isAssistantAnswer(items[i])) {
+        answerIdx = i;
+        break;
       }
     }
 
@@ -549,6 +547,9 @@ export function applyTurnCollapse(
         ...(elapsedMs !== undefined ? { elapsedMs } : {}),
         ...(hasUsage ? { inputTokens, outputTokens } : {}),
         ...(cachedTokens > 0 ? { cachedTokens } : {}),
+        ...(isActiveTurn && promptTs !== undefined
+          ? { liveStartedAt: promptTs }
+          : {}),
       },
     });
 
@@ -559,9 +560,11 @@ export function applyTurnCollapse(
 
     // Collapsed: drop the hideable steps; keep the final answer (its own
     // thinking stripped) and any non-step rows (errors, cancellations, command
-    // output) in their original places.
+    // output) in their original places. On an active turn the "answer" is still
+    // streaming, so fold it away too rather than strand a provisional line.
     for (let i = start + 1; i <= end; i++) {
       const item = items[i];
+      if (i === answerIdx && isActiveTurn) continue;
       if (isHideableStep(item, i === answerIdx)) continue;
       if (
         i === answerIdx &&

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -365,6 +365,23 @@ function isHideableStep(item: DisplayItem, isFinalAnswer: boolean): boolean {
   }
 }
 
+/** Wall-clock stamp of a display row, whichever variant carries it. */
+function itemTimestamp(item: DisplayItem): number | undefined {
+  return item.type === 'message' ? item.message.timestamp : item.timestamp;
+}
+
+/**
+ * Per-turn token usage contribution of a row: only top-level assistant messages
+ * carry usage (sub-agent rounds are excluded upstream in the SDK reducer).
+ */
+function itemAssistantUsage(
+  item: DisplayItem,
+): { inputTokens: number; outputTokens: number } | undefined {
+  return item.type === 'message' && item.message.role === 'assistant'
+    ? item.message.usage
+    : undefined;
+}
+
 /**
  * Walk backwards from `index` to the user-message row that heads its turn and
  * return that turn's id, or null when `index` precedes the first turn.
@@ -464,8 +481,22 @@ export function applyTurnCollapse(
     }
 
     let hiddenCount = 0;
+    let lastStepTs: number | undefined;
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let hasUsage = false;
     for (let i = start + 1; i <= end; i++) {
       if (isHideableStep(items[i], i === answerIdx)) hiddenCount++;
+      const ts = itemTimestamp(items[i]);
+      if (ts !== undefined) {
+        lastStepTs = lastStepTs === undefined ? ts : Math.max(lastStepTs, ts);
+      }
+      const usage = itemAssistantUsage(items[i]);
+      if (usage) {
+        inputTokens += usage.inputTokens;
+        outputTokens += usage.outputTokens;
+        hasUsage = true;
+      }
     }
 
     if (isActiveTurn || hasPendingApproval || hiddenCount === 0) {
@@ -480,11 +511,25 @@ export function applyTurnCollapse(
       : false;
     const collapsed = !expanded;
 
+    const promptTs = head.message.timestamp;
+    const elapsedMs =
+      promptTs !== undefined &&
+      lastStepTs !== undefined &&
+      lastStepTs >= promptTs
+        ? lastStepTs - promptTs
+        : undefined;
+
     result.push({
       type: 'message',
       key: head.key,
       message: head.message,
-      collapse: { turnId, collapsed, hiddenCount },
+      collapse: {
+        turnId,
+        collapsed,
+        hiddenCount,
+        ...(elapsedMs !== undefined ? { elapsedMs } : {}),
+        ...(hasUsage ? { inputTokens, outputTokens } : {}),
+      },
     });
 
     if (!collapsed) {

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -686,6 +686,10 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
       ReadonlyMap<string, boolean>
     >(() => new Map());
     const handleToggleCollapse = useCallback((turnId: string) => {
+      // (Un)folding a turn is the user reading history, not following the tail.
+      // Pause follow so the height change does not yank the viewport to the
+      // bottom — the toggled prompt row stays where it is on screen.
+      shouldFollow.current = false;
       setCollapseOverrides((prev) => {
         const currentlyExpanded = prev.get(turnId) ?? false;
         const next = new Map(prev);

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -499,16 +499,19 @@ export function applyTurnCollapse(
       }
     }
 
-    if (isActiveTurn || hasPendingApproval || hiddenCount === 0) {
-      // Nothing to fold (still streaming, awaiting an approval, or no steps):
-      // emit the turn untouched so live/actionable rows stay visible.
+    if (hasPendingApproval || hiddenCount === 0) {
+      // Not foldable: the inline approve/reject UI must stay reachable, or the
+      // turn has no steps yet. Emit it untouched.
       for (let i = start; i <= end; i++) result.push(items[i]);
       continue;
     }
 
+    // The active (streaming) turn still gets the seam so its live step / time /
+    // token metrics are visible, but defaults to expanded so the streaming rows
+    // stay shown; a completed turn defaults to collapsed. Either can be toggled.
     const expanded = overrides.has(turnId)
       ? (overrides.get(turnId) as boolean)
-      : false;
+      : isActiveTurn;
     const collapsed = !expanded;
 
     const promptTs = head.message.timestamp;

--- a/packages/web-shell/client/components/messages/UserMessage.module.css
+++ b/packages/web-shell/client/components/messages/UserMessage.module.css
@@ -5,6 +5,16 @@
   align-items: baseline;
 }
 
+/*
+ * Collapsed turn: tighten the gap below the prompt+toggle seam so the fold
+ * summary sits snug against the final answer rather than carrying a full
+ * inter-message gap. Scoped to the collapsed state — an expanded turn keeps the
+ * normal 12px down to its first revealed step.
+ */
+.message.collapsedHead {
+  margin-bottom: 2px;
+}
+
 .prefix {
   color: var(--user-color);
   font-weight: 700;
@@ -20,29 +30,44 @@
 }
 
 /*
- * Per-turn fold toggle, right-aligned on the prompt row but inset by a gutter
- * so it clears the hover timestamp that MessageTimestamp pins to the row's
- * top-right corner (position: absolute; right: 4px). The gutter fits a same-day
- * HH:mm:ss stamp, so the toggle and the timestamp sit side by side instead of
- * overlapping.
+ * Per-turn fold seam: its own line below the prompt text, clear of the hover
+ * timestamp pinned to the row's top-right. Only the chevron button toggles the
+ * turn; the trailing summary is inert text. `fit-content` keeps the row hugging
+ * its content rather than spanning the width.
  */
-.collapseToggle {
-  flex-shrink: 0;
-  align-self: baseline;
-  margin-right: 64px;
-  background: none;
-  border: none;
-  padding: 0 2px;
-  color: var(--text-dimmed);
-  font-family: inherit;
+.collapseRow {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  width: fit-content;
+  margin-top: 2px;
   font-size: 12px;
   line-height: 1.2;
-  white-space: nowrap;
+}
+
+/* The sole expand/collapse control — just the chevron glyph. */
+.collapseToggle {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--text-dimmed);
+  font: inherit;
   cursor: pointer;
 }
 
 .collapseToggle:hover {
   color: var(--text-secondary);
+}
+
+/*
+ * Step count · duration · tokens. Inert (no fold affordance) and identical in
+ * both states, so toggling never reflows the row.
+ */
+.collapseMeta {
+  color: var(--text-dimmed);
+  white-space: nowrap;
+  cursor: default;
 }
 
 .images {

--- a/packages/web-shell/client/components/messages/UserMessage.module.css
+++ b/packages/web-shell/client/components/messages/UserMessage.module.css
@@ -38,14 +38,17 @@
 .collapseRow {
   display: flex;
   align-items: baseline;
-  gap: 4px;
   width: fit-content;
   margin-top: 2px;
   font-size: 12px;
   line-height: 1.2;
 }
 
-/* The sole expand/collapse control — just the chevron glyph. */
+/*
+ * The expand/collapse control: the chevron plus the step count, together, so
+ * the click target is comfortably sized (not a lone glyph). Only this toggles
+ * the turn — the trailing metrics are inert.
+ */
 .collapseToggle {
   flex-shrink: 0;
   background: none;
@@ -53,6 +56,7 @@
   padding: 0;
   color: var(--text-dimmed);
   font: inherit;
+  white-space: nowrap;
   cursor: pointer;
 }
 
@@ -61,8 +65,9 @@
 }
 
 /*
- * Step count · duration · tokens. Inert (no fold affordance) and identical in
- * both states, so toggling never reflows the row.
+ * Duration · tokens. Inert (no fold affordance) and identical collapsed vs
+ * expanded, so toggling never reflows the row. Carries its own leading "·"
+ * separator after the toggle.
  */
 .collapseMeta {
   color: var(--text-dimmed);

--- a/packages/web-shell/client/components/messages/UserMessage.test.tsx
+++ b/packages/web-shell/client/components/messages/UserMessage.test.tsx
@@ -46,7 +46,7 @@ describe('UserMessage collapse toggle', () => {
     expect(container.querySelector('button')).toBeNull();
   });
 
-  it('shows the hidden-step count and aria-expanded=false when collapsed', () => {
+  it('shows the step count and aria-expanded=false when collapsed', () => {
     const container = render(
       <UserMessage
         content="hi"
@@ -56,11 +56,11 @@ describe('UserMessage collapse toggle', () => {
     );
     const btn = container.querySelector('button')!;
     expect(btn).not.toBeNull();
-    expect(btn.textContent).toContain('5 steps');
+    expect(container.textContent).toContain('5 steps');
     expect(btn.getAttribute('aria-expanded')).toBe('false');
   });
 
-  it('pluralizes a single hidden step as "1 step"', () => {
+  it('pluralizes a single step as "1 step"', () => {
     const container = render(
       <UserMessage
         content="hi"
@@ -68,7 +68,7 @@ describe('UserMessage collapse toggle', () => {
         onToggleCollapse={() => {}}
       />,
     );
-    const text = container.querySelector('button')!.textContent ?? '';
+    const text = container.textContent ?? '';
     expect(text).toContain('1 step');
     expect(text).not.toContain('1 steps');
   });
@@ -86,7 +86,7 @@ describe('UserMessage collapse toggle', () => {
     ).toBe('true');
   });
 
-  it('calls onToggleCollapse with the turn id on click', () => {
+  it('calls onToggleCollapse with the turn id when the chevron is clicked', () => {
     const onToggle = vi.fn();
     const container = render(
       <UserMessage
@@ -97,5 +97,87 @@ describe('UserMessage collapse toggle', () => {
     );
     click(container.querySelector('button')!);
     expect(onToggle).toHaveBeenCalledWith('turn-7');
+  });
+
+  it('appends elapsed and ↑input ↓output tokens when present', () => {
+    const container = render(
+      <UserMessage
+        content="hi"
+        collapse={head({
+          hiddenCount: 5,
+          elapsedMs: 12_400,
+          inputTokens: 3100,
+          outputTokens: 5100,
+        })}
+        onToggleCollapse={() => {}}
+      />,
+    );
+    const text = container.textContent ?? '';
+    expect(text).toContain('5 steps');
+    expect(text).toContain('12.4s');
+    expect(text).toContain('↑3.1k');
+    expect(text).toContain('↓5.1k');
+  });
+
+  it('keeps only the chevron clickable; the summary is inert text', () => {
+    const container = render(
+      <UserMessage
+        content="hi"
+        collapse={head({
+          hiddenCount: 5,
+          elapsedMs: 12_400,
+          inputTokens: 3100,
+        })}
+        onToggleCollapse={() => {}}
+      />,
+    );
+    const btn = container.querySelector('button')!;
+    // The button carries only the chevron glyph — never the summary text.
+    expect(btn.textContent).toBe('▸');
+    const meta = btn.nextElementSibling!;
+    expect(meta.tagName).toBe('SPAN');
+    expect(meta.textContent).toContain('5 steps');
+  });
+
+  it('renders identical summary text collapsed vs expanded (no reflow)', () => {
+    const base = {
+      hiddenCount: 5,
+      elapsedMs: 12_400,
+      inputTokens: 3100,
+      outputTokens: 5100,
+    };
+    const metaOf = (c: HTMLElement) =>
+      c.querySelector('button')!.nextElementSibling!.textContent;
+    const collapsed = render(
+      <UserMessage
+        content="hi"
+        collapse={head({ ...base, collapsed: true })}
+        onToggleCollapse={() => {}}
+      />,
+    );
+    const expanded = render(
+      <UserMessage
+        content="hi"
+        collapse={head({ ...base, collapsed: false })}
+        onToggleCollapse={() => {}}
+      />,
+    );
+    // Same summary in both states — only the chevron glyph flips.
+    expect(metaOf(collapsed)).toBe(metaOf(expanded));
+    expect(collapsed.querySelector('button')!.textContent).toBe('▸');
+    expect(expanded.querySelector('button')!.textContent).toBe('▾');
+  });
+
+  it('renders just the step count when no metadata is measured', () => {
+    const container = render(
+      <UserMessage
+        content="hi"
+        collapse={head({ hiddenCount: 3 })}
+        onToggleCollapse={() => {}}
+      />,
+    );
+    const meta = container.querySelector('button')!.nextElementSibling!;
+    expect(meta.textContent).toContain('3 steps');
+    expect(meta.textContent).not.toContain('·');
   });
 });

--- a/packages/web-shell/client/components/messages/UserMessage.test.tsx
+++ b/packages/web-shell/client/components/messages/UserMessage.test.tsx
@@ -119,7 +119,7 @@ describe('UserMessage collapse toggle', () => {
     expect(text).toContain('↓5.1k');
   });
 
-  it('keeps only the chevron clickable; the summary is inert text', () => {
+  it('puts the chevron + step count in the toggle, metrics inert', () => {
     const container = render(
       <UserMessage
         content="hi"
@@ -127,19 +127,23 @@ describe('UserMessage collapse toggle', () => {
           hiddenCount: 5,
           elapsedMs: 12_400,
           inputTokens: 3100,
+          outputTokens: 5100,
         })}
         onToggleCollapse={() => {}}
       />,
     );
     const btn = container.querySelector('button')!;
-    // The button carries only the chevron glyph — never the summary text.
-    expect(btn.textContent).toBe('▸');
+    // The toggle carries the chevron AND the step count (a roomy target)…
+    expect(btn.textContent).toMatch(/^[▸▾] 5 steps$/);
+    // …while the metrics live outside the button, in an inert span.
+    expect(btn.textContent).not.toContain('12.4s');
     const meta = btn.nextElementSibling!;
     expect(meta.tagName).toBe('SPAN');
-    expect(meta.textContent).toContain('5 steps');
+    expect(meta.textContent).toContain('12.4s');
+    expect(meta.textContent).toContain('↑3.1k');
   });
 
-  it('renders identical summary text collapsed vs expanded (no reflow)', () => {
+  it('keeps the toggle + metrics stable collapsed vs expanded (no reflow)', () => {
     const base = {
       hiddenCount: 5,
       elapsedMs: 12_400,
@@ -148,6 +152,8 @@ describe('UserMessage collapse toggle', () => {
     };
     const metaOf = (c: HTMLElement) =>
       c.querySelector('button')!.nextElementSibling!.textContent;
+    const btnOf = (c: HTMLElement) =>
+      c.querySelector('button')!.textContent;
     const collapsed = render(
       <UserMessage
         content="hi"
@@ -162,13 +168,14 @@ describe('UserMessage collapse toggle', () => {
         onToggleCollapse={() => {}}
       />,
     );
-    // Same summary in both states — only the chevron glyph flips.
+    // Inert metrics identical; the toggle differs only by the chevron glyph
+    // (same-width in the mono font), so the row never reflows on toggle.
     expect(metaOf(collapsed)).toBe(metaOf(expanded));
-    expect(collapsed.querySelector('button')!.textContent).toBe('▸');
-    expect(expanded.querySelector('button')!.textContent).toBe('▾');
+    expect(btnOf(collapsed)).toBe('▸ 5 steps');
+    expect(btnOf(expanded)).toBe('▾ 5 steps');
   });
 
-  it('renders just the step count when no metadata is measured', () => {
+  it('renders only the toggle when no metrics are measured', () => {
     const container = render(
       <UserMessage
         content="hi"
@@ -176,12 +183,14 @@ describe('UserMessage collapse toggle', () => {
         onToggleCollapse={() => {}}
       />,
     );
-    const meta = container.querySelector('button')!.nextElementSibling!;
-    expect(meta.textContent).toContain('3 steps');
-    expect(meta.textContent).not.toContain('·');
+    const btn = container.querySelector('button')!;
+    expect(btn.textContent).toContain('3 steps');
+    // No metrics → no inert span and no stray separator.
+    expect(btn.nextElementSibling).toBeNull();
+    expect(container.textContent).not.toContain('·');
   });
 
-  it('shows cached reads parenthetically on input when present', () => {
+  it('shows cached reads parenthetically on input, with their share', () => {
     const container = render(
       <UserMessage
         content="hi"
@@ -193,7 +202,30 @@ describe('UserMessage collapse toggle', () => {
         onToggleCollapse={() => {}}
       />,
     );
-    expect(container.textContent).toContain('↑3.1k (2.8k cached) ↓5.1k');
+    expect(container.textContent).toContain('↑3.1k (2.8k cached, 90%) ↓5.1k');
+  });
+
+  it('ticks elapsed from liveStartedAt on a live turn', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    try {
+      const container = render(
+        <UserMessage
+          content="hi"
+          collapse={head({
+            hiddenCount: 0,
+            liveStartedAt: 7_600,
+            inputTokens: 5,
+            outputTokens: 5,
+          })}
+          onToggleCollapse={() => {}}
+        />,
+      );
+      // now (10_000) − liveStartedAt (7_600) = 2.4s, ticked live.
+      expect(container.textContent).toContain('2.4s');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('omits the cached note when there are no cached reads', () => {

--- a/packages/web-shell/client/components/messages/UserMessage.test.tsx
+++ b/packages/web-shell/client/components/messages/UserMessage.test.tsx
@@ -180,4 +180,54 @@ describe('UserMessage collapse toggle', () => {
     expect(meta.textContent).toContain('3 steps');
     expect(meta.textContent).not.toContain('·');
   });
+
+  it('shows cached reads parenthetically on input when present', () => {
+    const container = render(
+      <UserMessage
+        content="hi"
+        collapse={head({
+          inputTokens: 3100,
+          outputTokens: 5100,
+          cachedTokens: 2800,
+        })}
+        onToggleCollapse={() => {}}
+      />,
+    );
+    expect(container.textContent).toContain('↑3.1k (2.8k cached) ↓5.1k');
+  });
+
+  it('omits the cached note when there are no cached reads', () => {
+    const container = render(
+      <UserMessage
+        content="hi"
+        collapse={head({ inputTokens: 3100, outputTokens: 5100 })}
+        onToggleCollapse={() => {}}
+      />,
+    );
+    const text = container.textContent ?? '';
+    expect(text).toContain('↑3.1k ↓5.1k');
+    expect(text).not.toContain('cached');
+  });
+
+  it('renders a chevron-less metrics line for a step-less turn', () => {
+    const container = render(
+      <UserMessage
+        content="hi"
+        collapse={head({
+          hiddenCount: 0,
+          elapsedMs: 1_200,
+          inputTokens: 1200,
+          outputTokens: 45,
+        })}
+        onToggleCollapse={() => {}}
+      />,
+    );
+    // No fold control when there is nothing to fold…
+    expect(container.querySelector('button')).toBeNull();
+    // …but the metrics still show, without a step count.
+    const text = container.textContent ?? '';
+    expect(text).toContain('1.2s');
+    expect(text).toContain('↑1.2k');
+    expect(text).not.toContain('step');
+  });
 });

--- a/packages/web-shell/client/components/messages/UserMessage.tsx
+++ b/packages/web-shell/client/components/messages/UserMessage.tsx
@@ -18,6 +18,45 @@ interface UserMessageProps {
   onToggleCollapse?: (turnId: string) => void;
 }
 
+type Translate = (key: string, vars?: Record<string, string | number>) => string;
+
+/** Compact turn duration: `820ms` · `12.4s` · `1m 5s`. */
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${Math.max(0, Math.round(ms))}ms`;
+  const totalSeconds = ms / 1000;
+  if (totalSeconds < 60) return `${totalSeconds.toFixed(1)}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = Math.round(totalSeconds - minutes * 60);
+  return `${minutes}m ${seconds}s`;
+}
+
+/** Token count abbreviated past 1k (e.g. `3.1k`), matching the context badge. */
+function formatTokenCount(tokens: number): string {
+  return tokens >= 1000 ? `${(tokens / 1000).toFixed(1)}k` : `${tokens}`;
+}
+
+/**
+ * Summary shown beside the fold chevron — identical whether the turn is
+ * collapsed or expanded, so toggling only flips the chevron glyph and never
+ * reflows the row. The step count is always present; duration and
+ * `↑input ↓output` tokens join only when measured. e.g.
+ * `3 steps · 12.4s · ↑3.1k ↓5.1k`.
+ */
+function collapseMetaText(collapse: TurnCollapseHead, t: Translate): string {
+  const parts = [t('turn.hiddenSteps', { count: collapse.hiddenCount })];
+  if (collapse.elapsedMs !== undefined) {
+    parts.push(formatDuration(collapse.elapsedMs));
+  }
+  if (collapse.inputTokens !== undefined && collapse.outputTokens !== undefined) {
+    parts.push(
+      `↑${formatTokenCount(collapse.inputTokens)} ↓${formatTokenCount(
+        collapse.outputTokens,
+      )}`,
+    );
+  }
+  return parts.join(' · ');
+}
+
 export const UserMessage = memo(function UserMessage({
   content,
   images,
@@ -26,7 +65,13 @@ export const UserMessage = memo(function UserMessage({
 }: UserMessageProps) {
   const { t } = useI18n();
   return (
-    <div className={styles.message}>
+    <div
+      className={
+        collapse?.collapsed
+          ? `${styles.message} ${styles.collapsedHead}`
+          : styles.message
+      }
+    >
       <span className={styles.prefix}>
         <PromptChevron />
       </span>
@@ -50,23 +95,26 @@ export const UserMessage = memo(function UserMessage({
           </div>
         )}
         {content}
+        {collapse && onToggleCollapse && (
+          <div className={styles.collapseRow}>
+            <button
+              type="button"
+              className={styles.collapseToggle}
+              onClick={() => onToggleCollapse(collapse.turnId)}
+              aria-expanded={!collapse.collapsed}
+              aria-label={
+                collapse.collapsed ? t('turn.expand') : t('turn.collapse')
+              }
+              title={collapse.collapsed ? t('turn.expand') : t('turn.collapse')}
+            >
+              {collapse.collapsed ? '▸' : '▾'}
+            </button>
+            <span className={styles.collapseMeta}>
+              {collapseMetaText(collapse, t)}
+            </span>
+          </div>
+        )}
       </div>
-      {collapse && onToggleCollapse && (
-        <button
-          type="button"
-          className={styles.collapseToggle}
-          onClick={() => onToggleCollapse(collapse.turnId)}
-          aria-expanded={!collapse.collapsed}
-          aria-label={
-            collapse.collapsed ? t('turn.expand') : t('turn.collapse')
-          }
-          title={collapse.collapsed ? t('turn.expand') : t('turn.collapse')}
-        >
-          {collapse.collapsed
-            ? `⌄ ${t('turn.hiddenSteps', { count: collapse.hiddenCount })}`
-            : '⌃'}
-        </button>
-      )}
     </div>
   );
 });

--- a/packages/web-shell/client/components/messages/UserMessage.tsx
+++ b/packages/web-shell/client/components/messages/UserMessage.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 import { PromptChevron } from '../PromptChevron';
 import { isSafeImageSrc } from './Markdown';
 import { useI18n } from '../../i18n';
@@ -36,27 +36,28 @@ function formatTokenCount(tokens: number): string {
 }
 
 /**
- * Summary shown beside the fold chevron — identical whether the turn is
- * collapsed or expanded, so toggling only flips the chevron glyph and never
- * reflows the row. The step count is always present; duration and
- * `↑input ↓output` tokens join only when measured. e.g.
- * `3 steps · 12.4s · ↑3.1k ↓5.1k`.
+ * Inert metrics shown after the fold toggle: duration and `↑input ↓output`
+ * tokens, each present only when measured. Cached reads are a subset of input,
+ * shown parenthetically on ↑input with their share ("↑3.1k (2.8k cached, 90%)")
+ * so they read as "of which N cached", not an additive figure. e.g.
+ * `12.4s · ↑3.1k (2.8k cached, 90%) ↓5.1k`.
  */
-function collapseMetaText(collapse: TurnCollapseHead, t: Translate): string {
+function metricsText(
+  collapse: TurnCollapseHead,
+  elapsedMs: number | undefined,
+  t: Translate,
+): string {
   const parts: string[] = [];
-  // A step-less turn (nothing to fold) still shows time/tokens, just no count.
-  if (collapse.hiddenCount > 0) {
-    parts.push(t('turn.hiddenSteps', { count: collapse.hiddenCount }));
-  }
-  if (collapse.elapsedMs !== undefined) {
-    parts.push(formatDuration(collapse.elapsedMs));
+  if (elapsedMs !== undefined) {
+    parts.push(formatDuration(elapsedMs));
   }
   if (collapse.inputTokens !== undefined && collapse.outputTokens !== undefined) {
-    // Cached reads are a subset of input — shown parenthetically on ↑input so
-    // it reads as "of which N cached", not an extra additive figure.
+    const cachedTokens = collapse.cachedTokens ?? 0;
     const cached =
-      collapse.cachedTokens && collapse.cachedTokens > 0
-        ? ` (${formatTokenCount(collapse.cachedTokens)} ${t('turn.cached')})`
+      cachedTokens > 0 && collapse.inputTokens > 0
+        ? ` (${formatTokenCount(cachedTokens)} ${t('turn.cached')}, ${Math.round(
+            (cachedTokens / collapse.inputTokens) * 100,
+          )}%)`
         : '';
     parts.push(
       `↑${formatTokenCount(collapse.inputTokens)}${cached} ↓${formatTokenCount(
@@ -67,6 +68,22 @@ function collapseMetaText(collapse: TurnCollapseHead, t: Translate): string {
   return parts.join(' · ');
 }
 
+/**
+ * Wall-clock that re-renders this row once a second while `active`, so a live
+ * turn's elapsed advances smoothly instead of jumping per step. Idle (and for
+ * completed turns) it never ticks. App code, so `Date.now()` is available.
+ */
+function useNowTicker(active: boolean): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!active) return;
+    setNow(Date.now());
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [active]);
+  return now;
+}
+
 export const UserMessage = memo(function UserMessage({
   content,
   images,
@@ -74,6 +91,35 @@ export const UserMessage = memo(function UserMessage({
   onToggleCollapse,
 }: UserMessageProps) {
   const { t } = useI18n();
+
+  // A live turn ticks `now - liveStartedAt`; a completed turn shows its frozen
+  // elapsedMs. The ref clamps the shown value monotonically so it never steps
+  // backward when a live turn settles onto its (timestamp-derived) final figure.
+  const liveStartedAt = collapse?.liveStartedAt;
+  const now = useNowTicker(liveStartedAt !== undefined);
+  const elapsedSeenRef = useRef(0);
+  let displayElapsedMs: number | undefined;
+  if (liveStartedAt !== undefined) {
+    elapsedSeenRef.current = Math.max(
+      elapsedSeenRef.current,
+      Math.max(0, now - liveStartedAt),
+    );
+    displayElapsedMs = elapsedSeenRef.current;
+  } else if (collapse?.elapsedMs !== undefined) {
+    elapsedSeenRef.current = Math.max(
+      elapsedSeenRef.current,
+      collapse.elapsedMs,
+    );
+    displayElapsedMs = elapsedSeenRef.current;
+  } else {
+    displayElapsedMs = undefined;
+  }
+
+  // The chevron and step count toggle together (one comfortably-sized target);
+  // the trailing metrics are inert. A step-less turn has no toggle, just metrics.
+  const hasToggle = !!collapse && collapse.hiddenCount > 0;
+  const metrics = collapse ? metricsText(collapse, displayElapsedMs, t) : '';
+
   return (
     <div
       className={
@@ -105,9 +151,9 @@ export const UserMessage = memo(function UserMessage({
           </div>
         )}
         {content}
-        {collapse && onToggleCollapse && (
+        {collapse && onToggleCollapse && (hasToggle || metrics) && (
           <div className={styles.collapseRow}>
-            {collapse.hiddenCount > 0 && (
+            {hasToggle && (
               <button
                 type="button"
                 className={styles.collapseToggle}
@@ -120,12 +166,16 @@ export const UserMessage = memo(function UserMessage({
                   collapse.collapsed ? t('turn.expand') : t('turn.collapse')
                 }
               >
-                {collapse.collapsed ? '▸' : '▾'}
+                {`${collapse.collapsed ? '▸' : '▾'} ${t('turn.hiddenSteps', {
+                  count: collapse.hiddenCount,
+                })}`}
               </button>
             )}
-            <span className={styles.collapseMeta}>
-              {collapseMetaText(collapse, t)}
-            </span>
+            {metrics && (
+              <span className={styles.collapseMeta}>
+                {hasToggle ? ` · ${metrics}` : metrics}
+              </span>
+            )}
           </div>
         )}
       </div>

--- a/packages/web-shell/client/components/messages/UserMessage.tsx
+++ b/packages/web-shell/client/components/messages/UserMessage.tsx
@@ -43,13 +43,23 @@ function formatTokenCount(tokens: number): string {
  * `3 steps · 12.4s · ↑3.1k ↓5.1k`.
  */
 function collapseMetaText(collapse: TurnCollapseHead, t: Translate): string {
-  const parts = [t('turn.hiddenSteps', { count: collapse.hiddenCount })];
+  const parts: string[] = [];
+  // A step-less turn (nothing to fold) still shows time/tokens, just no count.
+  if (collapse.hiddenCount > 0) {
+    parts.push(t('turn.hiddenSteps', { count: collapse.hiddenCount }));
+  }
   if (collapse.elapsedMs !== undefined) {
     parts.push(formatDuration(collapse.elapsedMs));
   }
   if (collapse.inputTokens !== undefined && collapse.outputTokens !== undefined) {
+    // Cached reads are a subset of input — shown parenthetically on ↑input so
+    // it reads as "of which N cached", not an extra additive figure.
+    const cached =
+      collapse.cachedTokens && collapse.cachedTokens > 0
+        ? ` (${formatTokenCount(collapse.cachedTokens)} ${t('turn.cached')})`
+        : '';
     parts.push(
-      `↑${formatTokenCount(collapse.inputTokens)} ↓${formatTokenCount(
+      `↑${formatTokenCount(collapse.inputTokens)}${cached} ↓${formatTokenCount(
         collapse.outputTokens,
       )}`,
     );
@@ -97,18 +107,22 @@ export const UserMessage = memo(function UserMessage({
         {content}
         {collapse && onToggleCollapse && (
           <div className={styles.collapseRow}>
-            <button
-              type="button"
-              className={styles.collapseToggle}
-              onClick={() => onToggleCollapse(collapse.turnId)}
-              aria-expanded={!collapse.collapsed}
-              aria-label={
-                collapse.collapsed ? t('turn.expand') : t('turn.collapse')
-              }
-              title={collapse.collapsed ? t('turn.expand') : t('turn.collapse')}
-            >
-              {collapse.collapsed ? '▸' : '▾'}
-            </button>
+            {collapse.hiddenCount > 0 && (
+              <button
+                type="button"
+                className={styles.collapseToggle}
+                onClick={() => onToggleCollapse(collapse.turnId)}
+                aria-expanded={!collapse.collapsed}
+                aria-label={
+                  collapse.collapsed ? t('turn.expand') : t('turn.collapse')
+                }
+                title={
+                  collapse.collapsed ? t('turn.expand') : t('turn.collapse')
+                }
+              >
+                {collapse.collapsed ? '▸' : '▾'}
+              </button>
+            )}
             <span className={styles.collapseMeta}>
               {collapseMetaText(collapse, t)}
             </span>

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -773,6 +773,7 @@ const EN: Messages = {
   'todo.title': 'Current tasks',
   'turn.collapse': 'Collapse steps',
   'turn.expand': 'Expand steps',
+  'turn.cached': 'cached',
   'turn.hiddenSteps': (v) => {
     const n = v?.count ?? 0;
     return `${n} step${n === 1 ? '' : 's'}`;
@@ -1592,6 +1593,7 @@ const ZH: Messages = {
   'todo.title': '当前任务',
   'turn.collapse': '折叠步骤',
   'turn.expand': '展开步骤',
+  'turn.cached': '缓存',
   'turn.hiddenSteps': (v) => `${v?.count ?? 0} 步`,
   'tasks.title': '后台任务',
   'tasks.empty': '当前没有运行中的任务',


### PR DESCRIPTION
## What this PR does

In the web-shell transcript each completed turn can be folded to just its prompt and final answer. This moves the fold control off the prompt row's right edge onto its own line in the seam between the prompt and the steps, and turns that line into a per-turn metrics readout: step count, elapsed time, and `↑input ↓output` token usage (with cached reads broken out). Only the leading `▸`/`▾` chevron toggles the turn — the trailing `3 steps · 12.4s · ↑3.1k (2.8k cached) ↓5.1k` summary is inert text, identical collapsed vs expanded so toggling only flips the chevron and never reflows the row.

It applies to every turn, not just folded ones:

- The **active (streaming)** turn shows the seam live — step / time / token metrics update as the agent works — while staying expanded so the streaming rows remain visible. Collapsing a live turn folds down to just the prompt + seam (it has no final answer yet, so no intermediate line is stranded).
- A **step-less** turn (a plain "hi" reply that runs no tools or thinking) shows a chevron-less metrics line, since there is nothing to fold but the cost is still worth seeing.

Surfacing tokens needed an SDK daemon-ui change: the daemon already reports each round's usage (including sub-agent rounds) on an otherwise-empty `agent_message_chunk` (`_meta.usage`), but the normalizer dropped empty-text chunks. It now emits a dedicated `assistant.usage` event and the reducer folds the counts — sub-agent rounds included — onto the round's top-level assistant block, so the web-shell can read `block.usage` and sum a turn's true total.

## Why it's needed

The previous toggle sat at the prompt row's right edge, needed a hard-coded gutter to dodge the hover timestamp, and showed only a hidden-step count. Putting the control in the seam is more intuitive and removes the gutter hack, and showing per-turn time + tokens (incl. cached and sub-agent cost) lets you see what each response cost at a glance while scanning a transcript.

## Reviewer Test Plan

### How to verify

Unit tests cover each layer:

- `cd packages/sdk-typescript && npx vitest run test/unit/daemonUi.test.ts` — normalizer emits `assistant.usage` (with cached) from an empty-text usage chunk; the reducer folds/accumulates onto the active block, **including sub-agent rounds**; no stray block when none is active.
- `cd packages/web-shell && npx vitest run` — `transcriptToMessages` carries/sums `block.usage` (incl. cached); `applyTurnCollapse` sums per-turn tokens + cached and derives elapsed from timestamps, tags active and step-less turns; `UserMessage` renders a chevron-only / chevron-less seam whose summary is identical collapsed vs expanded.

In a running web-shell: complete a turn with steps, let it collapse, confirm `▸ N steps · <time> · ↑<in> (<cached> cached) ↓<out>`; click only the chevron to expand; confirm no horizontal shift on toggle. Send a plain "hi" and confirm its reply shows a chevron-less `<time> · ↑in ↓out` line. Run a turn that spawns sub-agents and confirm its token total reflects the sub-agent cost (much closer to `/stats`, though `/stats` is whole-session and still larger). Reopen a past session and confirm tokens still render.

### Evidence (Before & After)

Before — toggle right-aligned on the prompt row, step count only:

```
❯ refactor the auth module                     ⌄ 3 steps
done — extracted validateToken()…
```

After — seam below the prompt; chevron-only control; time + tokens (+ cached):

```
❯ refactor the auth module
  ▸ 3 steps · 12.4s · ↑3.1k (2.8k cached) ↓5.1k
  done — extracted validateToken()…
```

Verified via the unit tests, `tsc`, and `eslint`; real-app screenshots not captured.

### Tested on

|     OS     |           Status            |
| :--------: | :-------------------------: |
|  🍏 macOS  | ✅ unit tests + tsc + eslint |
| 🪟 Windows |        ⚠️ not tested        |
|  🐧 Linux  |        ⚠️ not tested        |

### Environment (optional)

Unit tests only (vitest); no live daemon run.

## Risk & Scope

- Main risk or tradeoff: elapsed is derived from block start timestamps (prompt → last step), so it slightly under-counts the final step's own runtime; the accurate per-turn `durationMs` is live-only and not persisted, so timestamps are used for consistency across live and replay.
- Sub-agent token attribution: a sub-agent round's usage is folded onto the parent turn's active top-level block (the parent is blocked on the Task call while it runs). A round that arrives with no active top-level block (rare) is dropped; background agents that span turns may attribute to the turn active when their usage lands.
- Scope: per-turn totals are intentionally narrower than `/stats` (which is the whole session across all turns and models), so they will not match exactly.
- Breaking changes / migration notes: none. The new SDK `assistant.usage` event and `DaemonTextTranscriptBlock.usage` field (with optional `cachedTokens`) are additive; older sessions that carry no usage simply show the step count (and time when available).

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

web-shell 的对话记录里,每个已完成回合可折叠成"只剩 prompt + 最终答案"。本 PR 把折叠控件从 prompt 行右端,挪到 prompt 与步骤之间的接缝处单独成行,并把这行做成**每回合指标**:步数、耗时、`↑输入 ↓输出`(并单列缓存命中)。只有前导 `▸`/`▾` 箭头能折叠;后面的 `3 steps · 12.4s · ↑3.1k (2.8k cached) ↓5.1k` 是惰性文字,折叠/展开两态一致,切换只翻箭头、行宽不变。

适用于所有回合,不止被折叠的:

- **运行中(流式)** 回合实时显示接缝——步数/耗时/token 随 agent 工作更新——同时保持展开以便看到流式输出。折叠一个运行中回合会收到只剩 prompt + 接缝(此时还没有最终答案,不会残留中间行)。
- **无步骤** 回合(纯"你好"这种、不跑工具/思考)显示一个无箭头的指标行——没什么可折叠,但成本仍值得看。

显示 token 需要改 SDK 的 daemon-ui:daemon 本就在一个空文本 `agent_message_chunk`(`_meta.usage`)上逐轮上报用量(含子代理轮次),但 normalizer 之前丢弃空文本 chunk。现在改为 emit 专用 `assistant.usage` 事件,reducer 把计数(含子代理轮次)累加到该轮的顶层助手块上,web-shell 即可读 `block.usage` 并汇总出回合真实总量。

## 为什么需要

之前开关在 prompt 行右端,要硬编码留白避开悬停时间戳,且只显示步数。把控件放进接缝更直观、去掉留白 hack;显示每回合耗时 + token(含缓存与子代理成本)让你浏览记录时一眼看清每次回复的成本。

## Reviewer Test Plan(评审验证)

### 如何验证

单测覆盖每一层:

- `cd packages/sdk-typescript && npx vitest run test/unit/daemonUi.test.ts` —— normalizer 从空文本 usage chunk emit `assistant.usage`(含 cached);reducer 累加到活跃块、**含子代理轮次**;无活跃块时不造空块。
- `cd packages/web-shell && npx vitest run` —— `transcriptToMessages` 透传/求和 `block.usage`(含 cached);`applyTurnCollapse` 按回合汇总 token + cached、用时间戳算 elapsed、给运行中与无步骤回合打标;`UserMessage` 渲染"仅箭头/无箭头"接缝,摘要两态一致。

在运行中的 web-shell:完成一个有步骤的回合并折叠,确认 `▸ N steps · <时间> · ↑<入> (<cached> cached) ↓<出>`;只点箭头能展开;切换不横向跳动。发一句"你好",确认其回复显示无箭头的 `<时间> · ↑入 ↓出`。跑一个派生子代理的回合,确认其 token 总量体现了子代理成本(更接近 `/stats`,但 `/stats` 是整会话累计、仍更大)。重开历史会话,确认 token 仍显示。

### 证据(前 / 后)

之前 —— 开关右对齐在 prompt 行,只有步数:

```
❯ refactor the auth module                     ⌄ 3 steps
done — extracted validateToken()…
```

之后 —— 接缝在 prompt 下方;仅箭头可点;带耗时 + token(+ 缓存):

```
❯ refactor the auth module
  ▸ 3 steps · 12.4s · ↑3.1k (2.8k cached) ↓5.1k
  done — extracted validateToken()…
```

通过单测、`tsc`、`eslint` 验证;未截真实应用图。

### 测试平台

|    系统    |          状态          |
| :--------: | :--------------------: |
|  🍏 macOS  | ✅ 单测 + tsc + eslint |
| 🪟 Windows |       ⚠️ 未测试        |
|  🐧 Linux  |       ⚠️ 未测试        |

### 运行环境(可选)

仅单测(vitest);未实跑 daemon。

## 风险与范围

- 主要取舍:耗时由块起始时间戳推导(prompt → 最后一步),略少算最后一步自身运行时间;准确的 per-turn `durationMs` 仅 live 有、未持久化,故统一用时间戳以保证 live 与回放一致。
- 子代理归属:子代理轮次的 usage 累加到父回合的顶层活跃块(子代理运行时父回合正阻塞在 Task 调用上)。极少数无活跃顶层块时丢弃;跨回合的后台代理可能归到其用量落地时活跃的回合。
- 范围:每回合总量有意比 `/stats`(整会话、所有回合与 model 累计)窄,不会完全相等。
- 破坏性变更:无。新增 SDK `assistant.usage` 事件与 `DaemonTextTranscriptBlock.usage`(含可选 `cachedTokens`)均为增量;不带用量的旧会话只显示步数(有时间戳时也显示耗时)。

## 关联 Issue

无。

</details>
