### PR TITLE
fix(monitor): batch-drain notifications to reduce token waste

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -2312,6 +2312,10 @@ export class Session implements SessionContext {
         ) {
           break;
         }
+        // ACP processes notifications one-at-a-time (no batch) because each
+        // notification carries distinct task metadata (taskId, status, kind,
+        // toolUseId) used in display and response _meta. Merging would
+        // misattribute the combined response to a single task.
         const item = this.notificationQueue.shift()!;
         await sessionIdContext.run(this.config.getSessionId(), () =>
           this.#executeBackgroundNotificationPromptInner(item),

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -2313,7 +2313,9 @@ export class Session implements SessionContext {
           break;
         }
         const item = this.notificationQueue.shift()!;
-        await this.#executeBackgroundNotificationPrompt(item);
+        await sessionIdContext.run(this.config.getSessionId(), () =>
+          this.#executeBackgroundNotificationPromptInner(item),
+        );
       }
     } finally {
       this.notificationProcessing = false;
@@ -2331,15 +2333,6 @@ export class Session implements SessionContext {
         void this.#drainNotificationQueue();
       }
     }
-  }
-
-  async #executeBackgroundNotificationPrompt(
-    item: BackgroundNotificationQueueItem,
-  ): Promise<void> {
-    // Same session-ID binding rationale as #executePrompt.
-    return sessionIdContext.run(this.config.getSessionId(), () =>
-      this.#executeBackgroundNotificationPromptInner(item),
-    );
   }
 
   async #executeBackgroundNotificationPromptInner(

--- a/packages/cli/src/nonInteractive/session.ts
+++ b/packages/cli/src/nonInteractive/session.ts
@@ -200,7 +200,7 @@ class Session {
       }
       if (meta.status === 'running' && typeof registry.get === 'function') {
         const entry = registry.get(meta.monitorId);
-        if (entry && entry.status !== 'running') return;
+        if (!entry || entry.status !== 'running') return;
       }
       this.enqueueMonitorNotification({
         displayText,

--- a/packages/cli/src/nonInteractive/session.ts
+++ b/packages/cli/src/nonInteractive/session.ts
@@ -198,6 +198,10 @@ class Session {
       if (this.isShuttingDown || this.abortController.signal.aborted) {
         return;
       }
+      if (meta.status === 'running') {
+        const entry = registry.get?.(meta.monitorId);
+        if (!entry || entry.status !== 'running') return;
+      }
       this.enqueueMonitorNotification({
         displayText,
         modelText,
@@ -457,29 +461,34 @@ class Session {
     }
   }
 
-  private async processMonitorNotification(
-    notification: MonitorQueueItem,
+  private async processMonitorNotificationBatch(
+    batch: MonitorQueueItem[],
   ): Promise<void> {
     await this.waitForInitialization();
 
-    this.outputAdapter.emitUserMessage([{ text: notification.displayText }]);
-    this.outputAdapter.emitSystemMessage(
-      'task_notification',
-      notification.sdkNotification,
-    );
+    for (const item of batch) {
+      this.outputAdapter.emitUserMessage([{ text: item.displayText }]);
+      this.outputAdapter.emitSystemMessage(
+        'task_notification',
+        item.sdkNotification,
+      );
+    }
+
+    const combinedModelText = batch.map((n) => n.modelText).join('\n\n');
+    const combinedDisplayText = batch.map((n) => n.displayText).join('; ');
 
     const promptId = this.getNextPromptId();
     await runNonInteractive(
       this.config,
       this.settings,
-      notification.modelText,
+      combinedModelText,
       promptId,
       {
         abortController: this.abortController,
         adapter: this.outputAdapter,
         controlService: this.controlService ?? undefined,
         sendMessageType: SendMessageType.Notification,
-        notificationDisplayText: notification.displayText,
+        notificationDisplayText: combinedDisplayText,
         captureMonitorNotifications: false,
         captureMonitorRegistrations: false,
       },
@@ -515,15 +524,15 @@ class Session {
         continue;
       }
 
-      const notification = this.monitorQueue.shift();
-      if (!notification) {
+      if (this.monitorQueue.length === 0) {
         continue;
       }
+      const batch = this.monitorQueue.splice(0);
       try {
-        await this.processMonitorNotification(notification);
+        await this.processMonitorNotificationBatch(batch);
       } catch (error) {
         debugLogger.error(
-          '[Session] Error processing monitor notification:',
+          '[Session] Error processing monitor notification batch:',
           error,
         );
         this.emitErrorResult(error);

--- a/packages/cli/src/nonInteractive/session.ts
+++ b/packages/cli/src/nonInteractive/session.ts
@@ -198,9 +198,9 @@ class Session {
       if (this.isShuttingDown || this.abortController.signal.aborted) {
         return;
       }
-      if (meta.status === 'running') {
-        const entry = registry.get?.(meta.monitorId);
-        if (!entry || entry.status !== 'running') return;
+      if (meta.status === 'running' && typeof registry.get === 'function') {
+        const entry = registry.get(meta.monitorId);
+        if (entry && entry.status !== 'running') return;
       }
       this.enqueueMonitorNotification({
         displayText,

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -87,6 +87,7 @@ describe('runNonInteractive', () => {
     setNotificationCallback: ReturnType<typeof vi.fn>;
     setRegisterCallback: ReturnType<typeof vi.fn>;
     getRunning: ReturnType<typeof vi.fn>;
+    get: ReturnType<typeof vi.fn>;
     abortAll: ReturnType<typeof vi.fn>;
   };
   let mockCoreExecuteToolCall: Mock;
@@ -146,6 +147,7 @@ describe('runNonInteractive', () => {
       setNotificationCallback: vi.fn(),
       setRegisterCallback: vi.fn(),
       getRunning: vi.fn().mockReturnValue([]),
+      get: vi.fn().mockReturnValue({ status: 'running' }),
       abortAll: vi.fn(),
     };
 

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -629,7 +629,7 @@ export async function runNonInteractive(
               typeof monitorRegistry.get === 'function'
             ) {
               const entry = monitorRegistry.get(meta.monitorId);
-              if (entry && entry.status !== 'running') return;
+              if (!entry || entry.status !== 'running') return;
             }
 
             const queueItem = {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -624,9 +624,12 @@ export async function runNonInteractive(
         // originating turn has already completed.
         monitorRegistry.setNotificationCallback(
           (displayText, modelText, meta) => {
-            if (meta.status === 'running') {
-              const entry = monitorRegistry.get?.(meta.monitorId);
-              if (!entry || entry.status !== 'running') return;
+            if (
+              meta.status === 'running' &&
+              typeof monitorRegistry.get === 'function'
+            ) {
+              const entry = monitorRegistry.get(meta.monitorId);
+              if (entry && entry.status !== 'running') return;
             }
 
             const queueItem = {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -624,6 +624,11 @@ export async function runNonInteractive(
         // originating turn has already completed.
         monitorRegistry.setNotificationCallback(
           (displayText, modelText, meta) => {
+            if (meta.status === 'running') {
+              const entry = monitorRegistry.get?.(meta.monitorId);
+              if (!entry || entry.status !== 'running') return;
+            }
+
             const queueItem = {
               displayText,
               modelText,
@@ -1159,9 +1164,33 @@ export async function runNonInteractive(
           // notifications could exceed the cap silently in headless runs.
           const drainOneItem = async () => {
             if (localQueue.length === 0) return;
-            const item = localQueue.shift()!;
 
-            emitNotificationToSdk(item);
+            // Batch-drain: take contiguous same-type items from the front
+            // of the queue. Cron prompts run individually — each needs its
+            // own slash/shell/@ preprocessing and approval cycle.
+            const targetType = localQueue[0]!.sendMessageType;
+            let splitIdx = targetType === SendMessageType.Cron ? 1 : 0;
+            if (splitIdx === 0) {
+              while (
+                splitIdx < localQueue.length &&
+                localQueue[splitIdx]!.sendMessageType === targetType
+              ) {
+                splitIdx++;
+              }
+            }
+            const batch = localQueue.splice(0, splitIdx);
+
+            if (batch.length === 0) return;
+
+            for (const queueItem of batch) {
+              emitNotificationToSdk(queueItem);
+            }
+
+            const item = {
+              displayText: batch.map((i) => i.displayText).join('; '),
+              modelText: batch.map((i) => i.modelText).join('\n\n'),
+              sendMessageType: targetType,
+            };
 
             turnCount++;
             if (

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -727,7 +727,7 @@ export async function runNonInteractive(
 
       /**
        * Shared per-turn tool-call dispatch for the main-turn loop and
-       * `drainOneItem`. Both call sites used to reproduce ~120 lines of
+       * `drainBatch`. Both call sites used to reproduce ~120 lines of
        * near-identical logic that filtered `structured_output` to its
        * own pre-scan when `--json-schema` is active, executed each
        * request through `executeToolCall`, captured the `structured_output`
@@ -1165,7 +1165,7 @@ export async function runNonInteractive(
           // Drain-turns count toward getMaxSessionTurns() for symmetry with the main
           // loop — otherwise a looping cron or a model that keeps replying to
           // notifications could exceed the cap silently in headless runs.
-          const drainOneItem = async () => {
+          const drainBatch = async () => {
             if (localQueue.length === 0) return;
 
             // Batch-drain: take contiguous same-type items from the front
@@ -1319,7 +1319,7 @@ export async function runNonInteractive(
                 // call captured the terminal contract — no point running
                 // more queued prompts that can't influence the result.
                 if (structuredSubmission !== undefined) return;
-                await drainOneItem();
+                await drainBatch();
               }
             })();
             drainPromise = p;
@@ -1388,7 +1388,7 @@ export async function runNonInteractive(
 
               // Propagate drain failures. Without this, a rejected
               // drainLocalQueue() (e.g. a text-mode API error surfacing
-              // out of drainOneItem) would be swallowed by `void` and
+              // out of drainBatch) would be swallowed by `void` and
               // checkCronDone would never fire — hanging the run.
               const onDrainError = (err: unknown) => {
                 abortController.signal.removeEventListener('abort', onAbort);

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -386,10 +386,18 @@ describe('useGeminiStream', () => {
     });
 
     const callback = mockBackgroundShellRegistry.setNotificationCallback.mock
-      .calls[0][0] as (displayText: string, modelText: string) => void;
+      .calls[0][0] as (
+      displayText: string,
+      modelText: string,
+      meta: { shellId: string; status: string; exitCode: number | null },
+    ) => void;
 
     act(() => {
-      callback(displayText, modelText);
+      callback(displayText, modelText, {
+        shellId: 'shell-1',
+        status: 'completed',
+        exitCode: 0,
+      });
     });
 
     await waitFor(() => {

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -386,18 +386,10 @@ describe('useGeminiStream', () => {
     });
 
     const callback = mockBackgroundShellRegistry.setNotificationCallback.mock
-      .calls[0][0] as (
-      displayText: string,
-      modelText: string,
-      meta: { shellId: string; status: string; exitCode: number | null },
-    ) => void;
+      .calls[0][0] as (displayText: string, modelText: string) => void;
 
     act(() => {
-      callback(displayText, modelText, {
-        shellId: 'shell-1',
-        status: 'completed',
-        exitCode: 0,
-      });
+      callback(displayText, modelText);
     });
 
     await waitFor(() => {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -2721,7 +2721,7 @@ export const useGeminiStream = (
         notificationDisplayText: combinedDisplayText,
       });
     }
-  }, [streamingState, submitQuery, notificationTrigger, addItem, config]);
+  }, [streamingState, submitQuery, notificationTrigger, addItem]);
 
   // ─── Teammate message integration ─────────────────────────
   // Each entry carries the full nonce-tagged envelope (`modelText`,

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -2548,11 +2548,6 @@ export const useGeminiStream = (
       displayText: string;
       modelText: string;
       sendMessageType: SendMessageType;
-      meta?: {
-        taskId?: string;
-        kind?: 'monitor' | 'agent' | 'shell';
-        status?: string;
-      };
     }>
   >([]);
   const [notificationTrigger, setNotificationTrigger] = useState(0);
@@ -2614,12 +2609,11 @@ export const useGeminiStream = (
   // Register background agent notification callback onto the shared queue.
   useEffect(() => {
     const registry = config.getBackgroundTaskRegistry();
-    registry.setNotificationCallback((displayText, modelText, meta) => {
+    registry.setNotificationCallback((displayText, modelText) => {
       notificationQueueRef.current.push({
         displayText,
         modelText,
         sendMessageType: SendMessageType.Notification,
-        meta: { taskId: meta.agentId, kind: 'agent', status: meta.status },
       });
       setNotificationTrigger((n) => n + 1);
     });
@@ -2631,12 +2625,11 @@ export const useGeminiStream = (
   // Register background shell terminal notification callback onto the shared queue.
   useEffect(() => {
     const registry = config.getBackgroundShellRegistry();
-    registry.setNotificationCallback((displayText, modelText, meta) => {
+    registry.setNotificationCallback((displayText, modelText) => {
       notificationQueueRef.current.push({
         displayText,
         modelText,
         sendMessageType: SendMessageType.Notification,
-        meta: { taskId: meta.shellId, kind: 'shell', status: meta.status },
       });
       setNotificationTrigger((n) => n + 1);
     });
@@ -2651,17 +2644,12 @@ export const useGeminiStream = (
     registry.setNotificationCallback((displayText, modelText, meta) => {
       if (meta.status === 'running' && typeof registry.get === 'function') {
         const entry = registry.get(meta.monitorId);
-        if (entry && entry.status !== 'running') return;
+        if (!entry || entry.status !== 'running') return;
       }
       notificationQueueRef.current.push({
         displayText,
         modelText,
         sendMessageType: SendMessageType.Notification,
-        meta: {
-          taskId: meta.monitorId,
-          kind: 'monitor',
-          status: meta.status,
-        },
       });
       setNotificationTrigger((n) => n + 1);
     });

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -2649,9 +2649,9 @@ export const useGeminiStream = (
   useEffect(() => {
     const registry = config.getMonitorRegistry();
     registry.setNotificationCallback((displayText, modelText, meta) => {
-      if (meta.status === 'running') {
+      if (meta.status === 'running' && typeof registry.get === 'function') {
         const entry = registry.get(meta.monitorId);
-        if (!entry || entry.status !== 'running') return;
+        if (entry && entry.status !== 'running') return;
       }
       notificationQueueRef.current.push({
         displayText,

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -2548,6 +2548,11 @@ export const useGeminiStream = (
       displayText: string;
       modelText: string;
       sendMessageType: SendMessageType;
+      meta?: {
+        taskId?: string;
+        kind?: 'monitor' | 'agent' | 'shell';
+        status?: string;
+      };
     }>
   >([]);
   const [notificationTrigger, setNotificationTrigger] = useState(0);
@@ -2609,11 +2614,12 @@ export const useGeminiStream = (
   // Register background agent notification callback onto the shared queue.
   useEffect(() => {
     const registry = config.getBackgroundTaskRegistry();
-    registry.setNotificationCallback((displayText, modelText) => {
+    registry.setNotificationCallback((displayText, modelText, meta) => {
       notificationQueueRef.current.push({
         displayText,
         modelText,
         sendMessageType: SendMessageType.Notification,
+        meta: { taskId: meta.agentId, kind: 'agent', status: meta.status },
       });
       setNotificationTrigger((n) => n + 1);
     });
@@ -2625,11 +2631,12 @@ export const useGeminiStream = (
   // Register background shell terminal notification callback onto the shared queue.
   useEffect(() => {
     const registry = config.getBackgroundShellRegistry();
-    registry.setNotificationCallback((displayText, modelText) => {
+    registry.setNotificationCallback((displayText, modelText, meta) => {
       notificationQueueRef.current.push({
         displayText,
         modelText,
         sendMessageType: SendMessageType.Notification,
+        meta: { taskId: meta.shellId, kind: 'shell', status: meta.status },
       });
       setNotificationTrigger((n) => n + 1);
     });
@@ -2641,11 +2648,20 @@ export const useGeminiStream = (
   // Register monitor notification callback onto the shared queue.
   useEffect(() => {
     const registry = config.getMonitorRegistry();
-    registry.setNotificationCallback((displayText, modelText) => {
+    registry.setNotificationCallback((displayText, modelText, meta) => {
+      if (meta.status === 'running') {
+        const entry = registry.get(meta.monitorId);
+        if (!entry || entry.status !== 'running') return;
+      }
       notificationQueueRef.current.push({
         displayText,
         modelText,
         sendMessageType: SendMessageType.Notification,
+        meta: {
+          taskId: meta.monitorId,
+          kind: 'monitor',
+          status: meta.status,
+        },
       });
       setNotificationTrigger((n) => n + 1);
     });
@@ -2654,26 +2670,58 @@ export const useGeminiStream = (
     };
   }, [config]);
 
-  // When idle, drain the unified queue one item at a time.
-  // Skip when another submission is in flight (e.g. the teammate
-  // drain effect won this render) — the queue stays intact and
-  // the effect will re-fire when streamingState returns to Idle.
+  // When idle, batch-drain all contiguous same-type notifications from the
+  // front of the queue into a single API call. This reduces token waste: N
+  // notifications that accumulate while the model is busy become 1 roundtrip
+  // instead of N sequential ones. Skip when another submission is in flight
+  // (e.g. the teammate drain effect won this render) — the queue stays
+  // intact and the effect will re-fire when streamingState returns to Idle.
   useEffect(() => {
     if (
       streamingState === StreamingState.Idle &&
       !isSubmittingQueryRef.current &&
       notificationQueueRef.current.length > 0
     ) {
-      const item = notificationQueueRef.current.shift()!;
-      addItem(
-        { type: 'notification' as const, text: item.displayText },
-        Date.now(),
-      );
-      submitQuery(item.modelText, item.sendMessageType, undefined, {
-        notificationDisplayText: item.displayText,
+      const queue = notificationQueueRef.current;
+      const targetType = queue[0]!.sendMessageType;
+
+      // Cron prompts must run as individual turns — each needs its own
+      // slash/shell/@ preprocessing and approval cycle. Only batch
+      // Notification items (which pass through without preprocessing).
+      if (targetType === SendMessageType.Cron) {
+        const item = queue.shift()!;
+        addItem(
+          { type: 'notification' as const, text: item.displayText },
+          Date.now(),
+        );
+        submitQuery(item.modelText, item.sendMessageType, undefined, {
+          notificationDisplayText: item.displayText,
+        });
+        return;
+      }
+
+      // Drain contiguous leading Notification items into one batch.
+      let splitIdx = 0;
+      while (
+        splitIdx < queue.length &&
+        queue[splitIdx]!.sendMessageType === targetType
+      ) {
+        splitIdx++;
+      }
+      const batch = queue.splice(0, splitIdx);
+
+      const now = Date.now();
+      for (const item of batch) {
+        addItem({ type: 'notification' as const, text: item.displayText }, now);
+      }
+
+      const combinedModelText = batch.map((e) => e.modelText).join('\n\n');
+      const combinedDisplayText = batch.map((e) => e.displayText).join('; ');
+      submitQuery(combinedModelText, targetType, undefined, {
+        notificationDisplayText: combinedDisplayText,
       });
     }
-  }, [streamingState, submitQuery, notificationTrigger, addItem]);
+  }, [streamingState, submitQuery, notificationTrigger, addItem, config]);
 
   // ─── Teammate message integration ─────────────────────────
   // Each entry carries the full nonce-tagged envelope (`modelText`,

--- a/packages/core/src/services/monitorRegistry.test.ts
+++ b/packages/core/src/services/monitorRegistry.test.ts
@@ -915,4 +915,50 @@ describe('MonitorRegistry', () => {
       expect(cb).not.toHaveBeenCalled();
     });
   });
+
+  describe('notified flag prevents duplicate terminal notifications', () => {
+    it('complete() then cancel() emits only one terminal notification', () => {
+      const callback = vi.fn();
+      registry.setNotificationCallback(callback);
+      registry.register(createEntry());
+
+      registry.complete('mon-1', 0);
+      const terminalCalls = callback.mock.calls.filter(
+        (args: unknown[]) =>
+          (args[1] as string).includes('<status>completed</status>') ||
+          (args[1] as string).includes('<status>cancelled</status>'),
+      );
+      expect(terminalCalls).toHaveLength(1);
+    });
+
+    it('cancel({notify:false}) prevents subsequent complete() from emitting', () => {
+      const ac = new AbortController();
+      const callback = vi.fn();
+      registry.setNotificationCallback(callback);
+      registry.register(createEntry({ abortController: ac }));
+
+      registry.cancel('mon-1', { notify: false });
+      registry.complete('mon-1', 0);
+
+      const terminalCalls = callback.mock.calls.filter((args: unknown[]) =>
+        (args[1] as string).includes('<status>'),
+      );
+      expect(terminalCalls).toHaveLength(0);
+    });
+
+    it('idle timeout then cancel emits only one terminal notification', () => {
+      const callback = vi.fn();
+      registry.setNotificationCallback(callback);
+      registry.register(createEntry({ idleTimeoutMs: 100 }));
+
+      vi.advanceTimersByTime(100);
+
+      const terminalCalls = callback.mock.calls.filter(
+        (args: unknown[]) =>
+          (args[1] as string).includes('<status>completed</status>') ||
+          (args[1] as string).includes('<status>cancelled</status>'),
+      );
+      expect(terminalCalls).toHaveLength(1);
+    });
+  });
 });

--- a/packages/core/src/services/monitorRegistry.ts
+++ b/packages/core/src/services/monitorRegistry.ts
@@ -299,6 +299,7 @@ export class MonitorRegistry {
 
     if (options.notify === false) {
       this.settle(entry, 'cancelled');
+      entry.notified = true;
       debugLogger.info(`Monitor cancelled: ${monitorId}`);
       entry.abortController.abort();
       this.dispatchOwnerLifecycleWake(entry);
@@ -530,6 +531,9 @@ export class MonitorRegistry {
 
   /** Emit a terminal notification (completed/failed/cancelled). */
   private emitTerminalNotification(entry: MonitorTask, detail?: string): void {
+    if (entry.notified) return;
+    entry.notified = true;
+
     const statusText =
       entry.status === 'completed'
         ? 'completed'


### PR DESCRIPTION
## What this PR does

Batch-drains monitor notification queues instead of processing one-at-a-time, and adds push-time stale event filtering. Together these reduce the number of LLM API roundtrips caused by monitor events — previously each stdout line from a monitor triggered a full roundtrip, even when the LLM would just respond "已忽略".

Three changes:
1. **Batch drain**: contiguous same-type Notification items are spliced from the queue and combined into a single `submitQuery` / `sendMessageStream` call. Cron items still drain individually since they need per-item slash/shell/@ preprocessing.
2. **Push-time stale filter**: monitor callbacks now check registry status before enqueuing running-status events, dropping events whose monitor has already settled.
3. **`notified` flag**: `MonitorRegistry.emitTerminalNotification` now uses the inherited `TaskBase.notified` field (previously set but never read) to prevent duplicate terminal notifications from racing code paths (complete/cancel/idle-timeout).

Applied consistently across interactive CLI (`useGeminiStream.ts`), nonInteractive session, nonInteractiveCli, and ACP session paths. ACP path intentionally keeps per-item processing since it only receives terminal notifications (running events are already filtered at push time) and each notification carries distinct task metadata that cannot be merged.

## Why it's needed

Users reported monitor as a "token waste machine". Root cause: each monitor stdout line became a `<task-notification>` event, each event triggered a full LLM API roundtrip (including complete conversation context as input tokens), and the LLM often just responded "已忽略" / "Late event, ignoring" — pure waste. With default `max_events=1000`, a single monitor could produce 1000 sequential roundtrips.

## Reviewer Test Plan

### How to verify

1. Run `npx vitest run packages/core/src/services/monitorRegistry.test.ts packages/core/src/tools/monitor.test.ts packages/cli/src/ui/hooks/useGeminiStream.test.tsx packages/cli/src/nonInteractiveCli.test.ts` — all 283 tests pass
2. `npx tsc --noEmit -p packages/core/tsconfig.json && npx tsc --noEmit -p packages/cli/tsconfig.json` — zero type errors
3. Manual: start a `tail -f` monitor, let events accumulate while the LLM is processing, observe that idle → drain produces 1 API call (not N)

### Evidence (Before & After)

**Before**: 20 monitor events = 20 sequential LLM roundtrips, each with full context. User sees 20 "已忽略" responses.

**After**: 20 monitor events accumulated while busy → 1 batched roundtrip. Stale events from settled monitors are filtered at push time and never enter the queue.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

## Risk & Scope

- Main risk or tradeoff: Batched notifications combine multiple `<task-notification>` XML blocks into one user message. The LLM sees all events at once rather than one-by-one. This is intentional — the LLM can still process each event in the batch.
- Not validated / out of scope: No upper bound on batch size (bounded by max_events + push-time filter). No mid-turn attachment injection (Claude Code's approach — significantly more complex, deferred).
- Breaking changes / migration notes: None for end users. Internal: `useGeminiStream` notification queue item type gains an optional `meta` field.

## Linked Issues

Supersedes #5162 (closed — wrong base branch).

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)