### PR TITLE
feat(web-shell): support custom footer renderer

### DIFF
--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -542,10 +542,9 @@ function getBackgroundTaskActivityKey(messages: readonly Message[]): string {
 
 function mapToWebShellTaskInfo(
   task: DaemonSessionTaskStatus,
-): WebShellTaskInfo | null {
+): WebShellTaskInfo {
   const base = {
     id: task.id,
-    status: task.status,
     label: task.label,
     description: task.description,
     runtimeMs: task.runtimeMs,
@@ -559,6 +558,7 @@ function mapToWebShellTaskInfo(
       return {
         ...base,
         kind: 'agent',
+        status: task.status,
         subagentType: task.subagentType,
         isBackgrounded: task.isBackgrounded,
         prompt: task.prompt,
@@ -567,6 +567,7 @@ function mapToWebShellTaskInfo(
       return {
         ...base,
         kind: 'shell',
+        status: task.status,
         command: task.command,
         cwd: task.cwd,
         pid: task.pid,
@@ -576,12 +577,13 @@ function mapToWebShellTaskInfo(
       return {
         ...base,
         kind: 'monitor',
+        status: task.status,
         command: task.command,
         pid: task.pid,
         exitCode: task.exitCode,
       };
     default:
-      return null;
+      return task satisfies never;
   }
 }
 
@@ -649,15 +651,6 @@ function QueuedPromptDisplay({
   );
 }
 
-function FooterRendererWrapper({
-  Component,
-  ...props
-}: {
-  Component: FooterRenderer;
-} & Omit<import('./customization').WebShellFooterRenderInfo, never>) {
-  return <Component {...props} />;
-}
-
 export function App({
   onSessionIdChange,
   theme: providedTheme,
@@ -706,6 +699,7 @@ export function App({
       markdown,
     ],
   );
+  const CustomFooter = renderFooter;
   const store = useTranscriptStore();
   const blocks = useTranscriptBlocks();
   const connection = useConnection();
@@ -867,12 +861,7 @@ export function App({
     connection.status === 'connected',
   );
   const footerTasks = useMemo(
-    () =>
-      renderFooter
-        ? backgroundTasks
-            .map(mapToWebShellTaskInfo)
-            .filter((t): t is WebShellTaskInfo => t !== null)
-        : [],
+    () => (renderFooter ? backgroundTasks.map(mapToWebShellTaskInfo) : []),
     [backgroundTasks, renderFooter],
   );
   const statusBarRef = useRef<StatusBarHandle>(null);
@@ -2904,7 +2893,7 @@ export function App({
                   onClearQueuedMessages={clearQueuedPrompts}
                   currentMode={currentMode}
                   sessionName={sessionDisplayName}
-                  dialogOpen={dialogOpen}
+                  dialogOpen={bottomHidden || tasksPanelMessage !== null}
                   followupState={followupState}
                   onAcceptFollowup={onAcceptFollowup}
                   onDismissFollowup={onDismissFollowup}
@@ -2934,9 +2923,8 @@ export function App({
               !tasksPanelMessage &&
               (showShortcuts ? (
                 <ShortcutsPanel onClose={handleCloseShortcuts} />
-              ) : renderFooter ? (
-                <FooterRendererWrapper
-                  Component={renderFooter}
+              ) : CustomFooter ? (
+                <CustomFooter
                   connected={connected}
                   mode={currentMode}
                   model={currentModel}
@@ -2949,15 +2937,18 @@ export function App({
                   }
                   activeGoal={activeGoal}
                   tasks={footerTasks}
-                  onSelectMode={() => setApprovalModeInlineOpen((v) => !v)}
-                  onSelectModel={() =>
-                    setModelInlineMode((v) => (v ? null : 'main'))
-                  }
-                  onShowContext={() => showContextUsage('/context', false)}
-                  onOpenSettings={() => setSettingsInlineOpen((v) => !v)}
-                  onOpenTasks={() => openTasksPanel()}
-                  onReturnToInput={handleReturnToEditor}
-                  onToggleShortcuts={handleToggleShortcuts}
+                  availableModes={MODES_CYCLE}
+                  availableModels={(connection.models ?? []).map((m) => ({
+                    id: m.id,
+                    label: m.label,
+                    contextWindow: m.contextWindow,
+                  }))}
+                  onSelectMode={(mode) => handleSetMode(mode)}
+                  onSelectModel={(model) => {
+                    sessionActions.setModel(model).then(() => {
+                      setCurrentModel(model);
+                    });
+                  }}
                 />
               ) : (
                 <StatusBar

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -21,7 +21,10 @@ import {
   type DaemonStreamingState,
 } from '@qwen-code/webui/daemon-react-sdk';
 import { isDaemonTurnError } from '@qwen-code/sdk/daemon';
-import type { DaemonTranscriptBlock } from '@qwen-code/sdk/daemon';
+import type {
+  DaemonTranscriptBlock,
+  DaemonSessionTaskStatus,
+} from '@qwen-code/sdk/daemon';
 import { extractPendingPermission } from './adapters/transcriptAdapter';
 import { MessageList, type MessageListHandle } from './components/MessageList';
 import { Editor, type EditorHandle } from './components/Editor';
@@ -72,6 +75,7 @@ import { ReleaseSessionDialog } from './components/dialogs/ReleaseSessionDialog'
 import { getLocalCommands } from './constants/localCommands';
 import { mergeCommands } from './hooks/daemonSessionMappers';
 import { useAnimationFrameValue } from './hooks/useAnimationFrameValue';
+import { useBackgroundTasks } from './hooks/useBackgroundTasks';
 import { useMessages } from './hooks/useMessages';
 import { usePanelActive } from './hooks/usePanelActive';
 import { useShallowMemo, useStableArray } from './hooks/useShallowMemo';
@@ -143,6 +147,8 @@ import {
   type WebShellMarkdownCustomization,
   type ToolHeaderExtraRenderer,
   type WelcomeHeaderRenderer,
+  type FooterRenderer,
+  type WebShellTaskInfo,
 } from './customization';
 import type { CommandDisplayCategoryOrder } from './utils/commandDisplay';
 import styles from './App.module.css';
@@ -317,6 +323,8 @@ export interface WebShellProps {
   renderToolHeaderExtra?: ToolHeaderExtraRenderer;
   /** Custom renderer for the welcome header. Receives version, cwd, model, and mode. */
   renderWelcomeHeader?: WelcomeHeaderRenderer;
+  /** Custom component for the footer area below the Editor. Replaces the built-in StatusBar. */
+  renderFooter?: FooterRenderer;
   /** Collapse thinking blocks to 5 lines with a click-to-expand toggle. */
   compactThinking?: boolean;
   /** Auto-collapse completed turns to just the prompt and final answer, with a per-turn toggle. Defaults to true. */
@@ -532,6 +540,51 @@ function getBackgroundTaskActivityKey(messages: readonly Message[]): string {
   return parts.join('|');
 }
 
+function mapToWebShellTaskInfo(
+  task: DaemonSessionTaskStatus,
+): WebShellTaskInfo | null {
+  const base = {
+    id: task.id,
+    status: task.status,
+    label: task.label,
+    description: task.description,
+    runtimeMs: task.runtimeMs,
+    startTime: task.startTime,
+    endTime: task.endTime,
+    error: task.error,
+  };
+
+  switch (task.kind) {
+    case 'agent':
+      return {
+        ...base,
+        kind: 'agent',
+        subagentType: task.subagentType,
+        isBackgrounded: task.isBackgrounded,
+        prompt: task.prompt,
+      };
+    case 'shell':
+      return {
+        ...base,
+        kind: 'shell',
+        command: task.command,
+        cwd: task.cwd,
+        pid: task.pid,
+        exitCode: task.exitCode,
+      };
+    case 'monitor':
+      return {
+        ...base,
+        kind: 'monitor',
+        command: task.command,
+        pid: task.pid,
+        exitCode: task.exitCode,
+      };
+    default:
+      return null;
+  }
+}
+
 function translateCopyMessage(
   message: string,
   t: ReturnType<typeof getTranslator>,
@@ -596,6 +649,15 @@ function QueuedPromptDisplay({
   );
 }
 
+function FooterRendererWrapper({
+  Component,
+  ...props
+}: {
+  Component: FooterRenderer;
+} & Omit<import('./customization').WebShellFooterRenderInfo, never>) {
+  return <Component {...props} />;
+}
+
 export function App({
   onSessionIdChange,
   theme: providedTheme,
@@ -612,6 +674,7 @@ export function App({
   slashCommandCategoryOrder,
   renderToolHeaderExtra,
   renderWelcomeHeader,
+  renderFooter,
   compactThinking = false,
   collapseCompletedTurns = true,
   virtualScrollThreshold,
@@ -629,6 +692,7 @@ export function App({
     () => ({
       renderToolHeaderExtra,
       renderWelcomeHeader,
+      renderFooter,
       compactThinking,
       collapseCompletedTurns,
       markdown,
@@ -636,6 +700,7 @@ export function App({
     [
       renderToolHeaderExtra,
       renderWelcomeHeader,
+      renderFooter,
       compactThinking,
       collapseCompletedTurns,
       markdown,
@@ -796,6 +861,19 @@ export function App({
   const backgroundTaskActivityKey = useMemo(
     () => getBackgroundTaskActivityKey(messages),
     [messages],
+  );
+  const backgroundTasks = useBackgroundTasks(
+    backgroundTaskActivityKey,
+    connection.status === 'connected',
+  );
+  const footerTasks = useMemo(
+    () =>
+      renderFooter
+        ? backgroundTasks
+            .map(mapToWebShellTaskInfo)
+            .filter((t): t is WebShellTaskInfo => t !== null)
+        : [],
+    [backgroundTasks, renderFooter],
   );
   const statusBarRef = useRef<StatusBarHandle>(null);
   const editorRef = useRef<EditorHandle>(null);
@@ -2826,7 +2904,7 @@ export function App({
                   onClearQueuedMessages={clearQueuedPrompts}
                   currentMode={currentMode}
                   sessionName={sessionDisplayName}
-                  dialogOpen={bottomHidden || tasksPanelMessage !== null}
+                  dialogOpen={dialogOpen}
                   followupState={followupState}
                   onAcceptFollowup={onAcceptFollowup}
                   onDismissFollowup={onDismissFollowup}
@@ -2856,6 +2934,31 @@ export function App({
               !tasksPanelMessage &&
               (showShortcuts ? (
                 <ShortcutsPanel onClose={handleCloseShortcuts} />
+              ) : renderFooter ? (
+                <FooterRendererWrapper
+                  Component={renderFooter}
+                  connected={connected}
+                  mode={currentMode}
+                  model={currentModel}
+                  streamingState={streamingState}
+                  contextUsageRatio={
+                    (connection.contextWindow ?? 0) > 0
+                      ? (connection.tokenCount ?? 0) /
+                        (connection.contextWindow ?? 0)
+                      : 0
+                  }
+                  activeGoal={activeGoal}
+                  tasks={footerTasks}
+                  onSelectMode={() => setApprovalModeInlineOpen((v) => !v)}
+                  onSelectModel={() =>
+                    setModelInlineMode((v) => (v ? null : 'main'))
+                  }
+                  onShowContext={() => showContextUsage('/context', false)}
+                  onOpenSettings={() => setSettingsInlineOpen((v) => !v)}
+                  onOpenTasks={() => openTasksPanel()}
+                  onReturnToInput={handleReturnToEditor}
+                  onToggleShortcuts={handleToggleShortcuts}
+                />
               ) : (
                 <StatusBar
                   escapeHint={escapeHintVisible}
@@ -2868,7 +2971,7 @@ export function App({
                   ref={statusBarRef}
                   onOpenTasks={() => openTasksPanel()}
                   onReturnToInput={handleReturnToEditor}
-                  taskActivityKey={backgroundTaskActivityKey}
+                  tasks={backgroundTasks}
                   activeGoal={activeGoal}
                   hideSettings={hideSettings}
                   onToggleShortcuts={handleToggleShortcuts}

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -2943,6 +2943,7 @@ export function App({
                     label: m.label,
                     contextWindow: m.contextWindow,
                   }))}
+                  skills={loadedSkills}
                   onSelectMode={(mode) => handleSetMode(mode)}
                   onSelectModel={(model) => {
                     sessionActions.setModel(model).then(() => {

--- a/packages/web-shell/client/components/StatusBar.tsx
+++ b/packages/web-shell/client/components/StatusBar.tsx
@@ -8,13 +8,10 @@ import {
   type KeyboardEvent,
 } from 'react';
 import type { DaemonSessionTaskStatus } from '@qwen-code/sdk/daemon';
-import { useActions, useConnection } from '@qwen-code/webui/daemon-react-sdk';
+import { useConnection } from '@qwen-code/webui/daemon-react-sdk';
 import { useI18n } from '../i18n';
-import { TASKS_STATUS_ACTIVE_EVENT } from './messages/TasksStatusMessage';
 import styles from './StatusBar.module.css';
 
-const TASKS_POLL_INTERVAL_MS = 3000;
-const MAX_EMPTY_TASK_POLLS = 2;
 const GOAL_PILL_INTERVAL_MS = 1000;
 
 export interface StatusBarHandle {
@@ -53,7 +50,7 @@ interface StatusBarProps {
   onOpenSettings: () => void;
   onOpenTasks?: () => void;
   onReturnToInput?: (text?: string) => void;
-  taskActivityKey?: string;
+  tasks: readonly DaemonSessionTaskStatus[];
   activeGoal?: {
     condition: string;
     setAt: number;
@@ -147,12 +144,6 @@ export function getTaskPillLabel(
   });
 }
 
-function hasActiveTask(tasks: readonly DaemonSessionTaskStatus[]): boolean {
-  return tasks.some(
-    (task) => task.status === 'running' || task.status === 'paused',
-  );
-}
-
 function formatGoalElapsed(ms: number): string {
   if (ms < 1000) return '';
   const seconds = Math.floor(ms / 1000);
@@ -173,7 +164,7 @@ export const StatusBar = forwardRef<StatusBarHandle, StatusBarProps>(
       onOpenSettings,
       onOpenTasks,
       onReturnToInput,
-      taskActivityKey,
+      tasks,
       activeGoal,
       hideSettings,
       onToggleShortcuts,
@@ -181,7 +172,6 @@ export const StatusBar = forwardRef<StatusBarHandle, StatusBarProps>(
     ref,
   ) {
     const connection = useConnection();
-    const actions = useActions();
     const connected = connection.status === 'connected';
     const currentModel = connection.currentModel ?? '';
     const currentMode = connection.currentMode ?? '';
@@ -191,87 +181,8 @@ export const StatusBar = forwardRef<StatusBarHandle, StatusBarProps>(
     const pct = contextWindow > 0 ? (tokenCount / contextWindow) * 100 : 0;
     const pctDisplay = pct.toFixed(1);
     const modeIndicator = getModeIndicator(currentMode, t);
-    const [tasks, setTasks] = useState<DaemonSessionTaskStatus[]>([]);
-    const [pollingActive, setPollingActive] = useState(false);
-    const [tasksPanelActive, setTasksPanelActive] = useState(false);
     const [, setGoalTick] = useState(0);
-    const emptyPollsRef = useRef(0);
-    const tasksRefreshInFlightRef = useRef(false);
     const taskPillRef = useRef<HTMLButtonElement>(null);
-
-    useEffect(() => {
-      if (!connected) {
-        setTasks([]);
-        setPollingActive(false);
-        emptyPollsRef.current = 0;
-        return;
-      }
-    }, [connected]);
-
-    useEffect(() => {
-      if (!connected || !taskActivityKey) return;
-      emptyPollsRef.current = 0;
-      setPollingActive(true);
-    }, [connected, taskActivityKey]);
-
-    useEffect(() => {
-      if (tasksPanelActive) return;
-      if (!connected || !pollingActive) return;
-
-      let disposed = false;
-      const refresh = () => {
-        if (tasksRefreshInFlightRef.current) return;
-        tasksRefreshInFlightRef.current = true;
-        actions
-          .getTasks()
-          .then((snapshot) => {
-            if (disposed) return;
-            setTasks(snapshot.tasks);
-            if (snapshot.tasks.length === 0) {
-              emptyPollsRef.current += 1;
-              if (emptyPollsRef.current >= MAX_EMPTY_TASK_POLLS) {
-                setPollingActive(false);
-              }
-              return;
-            }
-            emptyPollsRef.current = 0;
-            if (!hasActiveTask(snapshot.tasks)) {
-              setPollingActive(false);
-            }
-          })
-          .catch((error: unknown) => {
-            if (disposed) return;
-            console.warn('[web-shell] failed to refresh tasks:', error);
-          })
-          .finally(() => {
-            tasksRefreshInFlightRef.current = false;
-          });
-      };
-
-      refresh();
-      const id = setInterval(refresh, TASKS_POLL_INTERVAL_MS);
-      return () => {
-        disposed = true;
-        clearInterval(id);
-      };
-    }, [actions, connected, pollingActive, tasksPanelActive]);
-
-    useEffect(() => {
-      const onTasksPanelActive = (event: Event) => {
-        const detail = (event as CustomEvent<{ active?: boolean }>).detail;
-        const active = detail?.active === true;
-        setTasksPanelActive(active);
-        if (!active && hasActiveTask(tasks)) {
-          setPollingActive(true);
-        }
-      };
-      window.addEventListener(TASKS_STATUS_ACTIVE_EVENT, onTasksPanelActive);
-      return () =>
-        window.removeEventListener(
-          TASKS_STATUS_ACTIVE_EVENT,
-          onTasksPanelActive,
-        );
-    }, [tasks]);
 
     useEffect(() => {
       if (!activeGoal) return;

--- a/packages/web-shell/client/customization.tsx
+++ b/packages/web-shell/client/customization.tsx
@@ -1,5 +1,11 @@
-import { createContext, useContext, type ReactNode } from 'react';
+import {
+  createContext,
+  useContext,
+  type ComponentType,
+  type ReactNode,
+} from 'react';
 import type { Components, Options } from 'react-markdown';
+import type { DaemonStreamingState } from '@qwen-code/webui/daemon-react-sdk';
 import type { ACPToolCall } from './adapters/types';
 import type { WelcomeHeaderProps } from './components/WelcomeHeader';
 
@@ -44,9 +50,72 @@ export type ToolHeaderExtraRenderer = (
 
 export type WelcomeHeaderRenderer = (props: WelcomeHeaderProps) => ReactNode;
 
+// ---- Background task info (public type for footer renderer) ----
+
+interface WebShellTaskBase {
+  id: string;
+  status: 'running' | 'paused' | 'completed' | 'failed' | 'cancelled';
+  label: string;
+  description: string;
+  runtimeMs: number;
+  startTime: number;
+  endTime?: number;
+  error?: string;
+}
+
+export interface WebShellAgentTask extends WebShellTaskBase {
+  kind: 'agent';
+  subagentType?: string;
+  isBackgrounded: boolean;
+  prompt?: string;
+}
+
+export interface WebShellShellTask extends WebShellTaskBase {
+  kind: 'shell';
+  command: string;
+  cwd: string;
+  pid?: number;
+  exitCode?: number;
+}
+
+export interface WebShellMonitorTask extends WebShellTaskBase {
+  kind: 'monitor';
+  command: string;
+  pid?: number;
+  exitCode?: number;
+}
+
+export type WebShellTaskInfo =
+  | WebShellAgentTask
+  | WebShellShellTask
+  | WebShellMonitorTask;
+
+// ---- Footer renderer ----
+
+export interface WebShellFooterRenderInfo {
+  connected: boolean;
+  mode: string;
+  model: string;
+  streamingState: DaemonStreamingState;
+  contextUsageRatio: number;
+  activeGoal: { condition: string; setAt: number } | null;
+  tasks: readonly WebShellTaskInfo[];
+
+  onSelectMode: () => void;
+  onSelectModel: () => void;
+  onShowContext: () => void;
+  onOpenSettings: () => void;
+  onOpenTasks: () => void;
+  onReturnToInput: (text?: string) => void;
+  onToggleShortcuts: () => void;
+}
+
+export type FooterRenderer = ComponentType<WebShellFooterRenderInfo>;
+
 export interface WebShellCustomization {
   renderToolHeaderExtra?: ToolHeaderExtraRenderer;
   renderWelcomeHeader?: WelcomeHeaderRenderer;
+  renderFooter?: FooterRenderer;
   compactThinking?: boolean;
   /**
    * Auto-collapse each completed turn's intermediate steps (thinking, tool

--- a/packages/web-shell/client/customization.tsx
+++ b/packages/web-shell/client/customization.tsx
@@ -100,6 +100,13 @@ export interface WebShellModelInfo {
   contextWindow?: number;
 }
 
+// ---- Skill info (public type for footer renderer) ----
+
+export interface WebShellSkillInfo {
+  name: string;
+  description: string;
+}
+
 // ---- Footer renderer ----
 
 export interface WebShellFooterRenderInfo {
@@ -112,6 +119,7 @@ export interface WebShellFooterRenderInfo {
   tasks: readonly WebShellTaskInfo[];
   availableModes: readonly string[];
   availableModels: readonly WebShellModelInfo[];
+  skills: readonly WebShellSkillInfo[];
 
   onSelectMode: (mode: string) => void;
   onSelectModel: (model: string) => void;

--- a/packages/web-shell/client/customization.tsx
+++ b/packages/web-shell/client/customization.tsx
@@ -54,7 +54,6 @@ export type WelcomeHeaderRenderer = (props: WelcomeHeaderProps) => ReactNode;
 
 interface WebShellTaskBase {
   id: string;
-  status: 'running' | 'paused' | 'completed' | 'failed' | 'cancelled';
   label: string;
   description: string;
   runtimeMs: number;
@@ -65,6 +64,7 @@ interface WebShellTaskBase {
 
 export interface WebShellAgentTask extends WebShellTaskBase {
   kind: 'agent';
+  status: 'running' | 'paused' | 'completed' | 'failed' | 'cancelled';
   subagentType?: string;
   isBackgrounded: boolean;
   prompt?: string;
@@ -72,6 +72,7 @@ export interface WebShellAgentTask extends WebShellTaskBase {
 
 export interface WebShellShellTask extends WebShellTaskBase {
   kind: 'shell';
+  status: 'running' | 'completed' | 'failed' | 'cancelled';
   command: string;
   cwd: string;
   pid?: number;
@@ -80,6 +81,7 @@ export interface WebShellShellTask extends WebShellTaskBase {
 
 export interface WebShellMonitorTask extends WebShellTaskBase {
   kind: 'monitor';
+  status: 'running' | 'completed' | 'failed' | 'cancelled';
   command: string;
   pid?: number;
   exitCode?: number;
@@ -89,6 +91,14 @@ export type WebShellTaskInfo =
   | WebShellAgentTask
   | WebShellShellTask
   | WebShellMonitorTask;
+
+// ---- Model info (public type for footer renderer) ----
+
+export interface WebShellModelInfo {
+  id: string;
+  label?: string;
+  contextWindow?: number;
+}
 
 // ---- Footer renderer ----
 
@@ -100,14 +110,11 @@ export interface WebShellFooterRenderInfo {
   contextUsageRatio: number;
   activeGoal: { condition: string; setAt: number } | null;
   tasks: readonly WebShellTaskInfo[];
+  availableModes: readonly string[];
+  availableModels: readonly WebShellModelInfo[];
 
-  onSelectMode: () => void;
-  onSelectModel: () => void;
-  onShowContext: () => void;
-  onOpenSettings: () => void;
-  onOpenTasks: () => void;
-  onReturnToInput: (text?: string) => void;
-  onToggleShortcuts: () => void;
+  onSelectMode: (mode: string) => void;
+  onSelectModel: (model: string) => void;
 }
 
 export type FooterRenderer = ComponentType<WebShellFooterRenderInfo>;

--- a/packages/web-shell/client/hooks/useBackgroundTasks.ts
+++ b/packages/web-shell/client/hooks/useBackgroundTasks.ts
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState } from 'react';
+import type { DaemonSessionTaskStatus } from '@qwen-code/sdk/daemon';
+import { useActions } from '@qwen-code/webui/daemon-react-sdk';
+import { TASKS_STATUS_ACTIVE_EVENT } from '../components/messages/TasksStatusMessage';
+
+const TASKS_POLL_INTERVAL_MS = 3000;
+const MAX_EMPTY_TASK_POLLS = 2;
+
+function hasActiveTask(tasks: readonly DaemonSessionTaskStatus[]): boolean {
+  return tasks.some(
+    (task) => task.status === 'running' || task.status === 'paused',
+  );
+}
+
+export function useBackgroundTasks(
+  taskActivityKey: string,
+  connected: boolean,
+): DaemonSessionTaskStatus[] {
+  const actions = useActions();
+  const [tasks, setTasks] = useState<DaemonSessionTaskStatus[]>([]);
+  const [pollingActive, setPollingActive] = useState(false);
+  const [tasksPanelActive, setTasksPanelActive] = useState(false);
+  const emptyPollsRef = useRef(0);
+  const tasksRefreshInFlightRef = useRef(false);
+
+  useEffect(() => {
+    if (!connected) {
+      setTasks([]);
+      setPollingActive(false);
+      emptyPollsRef.current = 0;
+      return;
+    }
+  }, [connected]);
+
+  useEffect(() => {
+    if (!connected || !taskActivityKey) return;
+    emptyPollsRef.current = 0;
+    setPollingActive(true);
+  }, [connected, taskActivityKey]);
+
+  useEffect(() => {
+    if (tasksPanelActive) return;
+    if (!connected || !pollingActive) return;
+
+    let disposed = false;
+    const refresh = () => {
+      if (tasksRefreshInFlightRef.current) return;
+      tasksRefreshInFlightRef.current = true;
+      actions
+        .getTasks()
+        .then((snapshot) => {
+          if (disposed) return;
+          setTasks(snapshot.tasks);
+          if (snapshot.tasks.length === 0) {
+            emptyPollsRef.current += 1;
+            if (emptyPollsRef.current >= MAX_EMPTY_TASK_POLLS) {
+              setPollingActive(false);
+            }
+            return;
+          }
+          emptyPollsRef.current = 0;
+          if (!hasActiveTask(snapshot.tasks)) {
+            setPollingActive(false);
+          }
+        })
+        .catch((error: unknown) => {
+          if (disposed) return;
+          console.warn('[web-shell] failed to refresh tasks:', error);
+        })
+        .finally(() => {
+          tasksRefreshInFlightRef.current = false;
+        });
+    };
+
+    refresh();
+    const id = setInterval(refresh, TASKS_POLL_INTERVAL_MS);
+    return () => {
+      disposed = true;
+      clearInterval(id);
+    };
+  }, [actions, connected, pollingActive, tasksPanelActive]);
+
+  const tasksRef = useRef(tasks);
+  tasksRef.current = tasks;
+
+  useEffect(() => {
+    const onTasksPanelActive = (event: Event) => {
+      const detail = (event as CustomEvent<{ active?: boolean }>).detail;
+      const active = detail?.active === true;
+      setTasksPanelActive(active);
+      if (!active && hasActiveTask(tasksRef.current)) {
+        setPollingActive(true);
+      }
+    };
+    window.addEventListener(TASKS_STATUS_ACTIVE_EVENT, onTasksPanelActive);
+    return () =>
+      window.removeEventListener(TASKS_STATUS_ACTIVE_EVENT, onTasksPanelActive);
+  }, []);
+
+  return tasks;
+}

--- a/packages/web-shell/client/index.ts
+++ b/packages/web-shell/client/index.ts
@@ -16,5 +16,6 @@ export type {
   WebShellAgentTask,
   WebShellShellTask,
   WebShellMonitorTask,
+  WebShellModelInfo,
 } from './customization';
 export type { WelcomeHeaderProps } from './components/WelcomeHeader';

--- a/packages/web-shell/client/index.ts
+++ b/packages/web-shell/client/index.ts
@@ -10,5 +10,11 @@ export type {
   ToolHeaderKind,
   WelcomeHeaderRenderer,
   WebShellMarkdownCustomization,
+  WebShellFooterRenderInfo,
+  FooterRenderer,
+  WebShellTaskInfo,
+  WebShellAgentTask,
+  WebShellShellTask,
+  WebShellMonitorTask,
 } from './customization';
 export type { WelcomeHeaderProps } from './components/WelcomeHeader';

--- a/packages/web-shell/client/index.ts
+++ b/packages/web-shell/client/index.ts
@@ -17,5 +17,6 @@ export type {
   WebShellShellTask,
   WebShellMonitorTask,
   WebShellModelInfo,
+  WebShellSkillInfo,
 } from './customization';
 export type { WelcomeHeaderProps } from './components/WelcomeHeader';


### PR DESCRIPTION
## What this PR does

Adds a `renderFooter` customization prop to the WebShell component, allowing embedders to replace the built-in StatusBar with their own footer component. The custom footer receives connection state, mode/model info, context usage, background tasks, available skills, and callbacks for mode/model selection.

To support this, the background task polling logic previously embedded in StatusBar has been extracted into a standalone `useBackgroundTasks` hook, so both the built-in StatusBar and custom footers share the same task data source. A set of public types (`WebShellTaskInfo`, `WebShellSkillInfo`, `WebShellModelInfo`, `WebShellFooterRenderInfo`, etc.) are exported for third-party footer implementations.

## Why it's needed

The built-in StatusBar is tightly coupled to the web-shell's internal layout and interaction patterns. Embedders who integrate web-shell into their own applications (e.g., managed deployments, custom IDE plugins) may need a different footer layout, additional controls, or different visual styling. This PR provides a clean customization surface without requiring fork-level modifications.

## Reviewer Test Plan

### How to verify

1. Run the web-shell without providing `renderFooter` — the built-in StatusBar should behave exactly as before (no regression).
2. Provide a custom `renderFooter` component and verify it receives all expected props: `connected`, `mode`, `model`, `streamingState`, `contextUsageRatio`, `activeGoal`, `tasks`, `availableModes`, `availableModels`, `skills`, `onSelectMode`, `onSelectModel`.
3. Verify that opening inline panels (approval mode, settings, model picker, etc.) still correctly blurs the Editor and suppresses keyboard shortcuts — the `dialogOpen` prop on Editor is preserved.

### Evidence (Before & After)

N/A — this is a new customization API; no existing behavior changes when `renderFooter` is not provided.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npm run dev` in web-shell package.

## Risk & Scope

- Main risk or tradeoff: The `WebShellFooterRenderInfo` interface defines the public contract for custom footers. Future additions to StatusBar (e.g., new callbacks) will need to be reflected here as well.
- Not validated / out of scope: `hideSettings` and `escapeHintVisible` are not yet exposed to custom footers — these can be added in follow-up PRs if needed.
- Breaking changes / migration notes: None. All changes are purely additive.

## Linked Issues

功能截图：
<img width="2966" height="372" alt="image" src="https://github.com/user-attachments/assets/e8d103fd-64a5-49ab-a1da-b319fda80513" />


N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

为 WebShell 组件新增 `renderFooter` 自定义属性，允许嵌入方使用自己的 footer 组件替换内置的 StatusBar。自定义 footer 会接收连接状态、模式/模型信息、上下文使用率、后台任务、可用 skills 列表，以及模式/模型选择的回调函数。

为此，原先嵌入在 StatusBar 中的后台任务轮询逻辑被提取为独立的 `useBackgroundTasks` hook，使内置 StatusBar 和自定义 footer 共享同一任务数据源。同时导出一组公开类型（`WebShellTaskInfo`、`WebShellSkillInfo`、`WebShellModelInfo`、`WebShellFooterRenderInfo` 等）供第三方 footer 实现使用。

## 为什么需要它

内置 StatusBar 与 web-shell 的内部布局和交互模式紧密耦合。将 web-shell 集成到自有应用中的嵌入方（如管控部署、自定义 IDE 插件）可能需要不同的 footer 布局、额外控件或不同的视觉样式。本 PR 提供了干净的自定义接口，无需 fork 级别修改。

## 审查者测试计划

### 如何验证

1. 不提供 `renderFooter` 运行 web-shell — 内置 StatusBar 应与之前完全一致（无回归）。
2. 提供自定义 `renderFooter` 组件，验证它接收到所有预期的 props：`connected`、`mode`、`model`、`streamingState`、`contextUsageRatio`、`activeGoal`、`tasks`、`availableModes`、`availableModels`、`skills`、`onSelectMode`、`onSelectModel`。
3. 验证打开内联面板（approval mode、settings、model picker 等）时仍然正确 blur Editor 并屏蔽键盘快捷键 — Editor 的 `dialogOpen` prop 保持不变。

### 证据（前后对比）

N/A — 这是一个新的自定义 API；不提供 `renderFooter` 时现有行为不变。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

web-shell 包下 `npm run dev`。

## 风险与范围

- 主要风险或权衡：`WebShellFooterRenderInfo` 接口定义了自定义 footer 的公开契约。未来 StatusBar 新增的功能（如新回调）也需要同步到此接口。
- 未验证 / 超出范围：`hideSettings` 和 `escapeHintVisible` 暂未暴露给自定义 footer — 如有需要可在后续 PR 中添加。
- 破坏性变更 / 迁移说明：无。所有改动均为纯新增。

## 关联 Issue

N/A

</details>
