### PR TITLE
fix(cli): hide unconfigured discontinued OAuth model

### DIFF
--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -139,6 +139,31 @@ describe('<ModelDialog />', () => {
     expect(props.showNumbers).toBe(true);
   });
 
+  it('hides discontinued qwen-oauth models for other auth types', () => {
+    renderComponent(
+      {},
+      {
+        getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+        getAllConfiguredModels: vi.fn(() => [
+          {
+            id: DEFAULT_QWEN_MODEL,
+            label: DEFAULT_QWEN_MODEL,
+            authType: AuthType.QWEN_OAUTH,
+          },
+          {
+            id: 'gpt-4',
+            label: 'GPT-4',
+            authType: AuthType.USE_OPENAI,
+          },
+        ]),
+      },
+    );
+
+    const items = mockedSelect.mock.calls[0][0].items;
+    expect(items).toHaveLength(1);
+    expect(items[0].value).toBe(`${AuthType.USE_OPENAI}::gpt-4`);
+  });
+
   it('initializes with the model from ConfigContext', () => {
     const mockGetModel = vi.fn(() => DEFAULT_QWEN_MODEL);
     renderComponent(
@@ -483,48 +508,6 @@ describe('<ModelDialog />', () => {
     );
     expect(deepseekIndex).toBeGreaterThanOrEqual(0);
     expect(mockedSelect.mock.calls[0][0].initialIndex).toBe(deepseekIndex);
-  });
-
-  it('blocks switching to qwen-oauth from another authType (discontinued)', async () => {
-    const switchModel = vi.fn().mockResolvedValue(undefined);
-    const getAuthType = vi.fn(() => AuthType.USE_OPENAI);
-    const getAvailableModelsForAuthType = vi.fn((t: AuthType) => {
-      if (t === AuthType.USE_OPENAI) {
-        return [{ id: 'gpt-4', label: 'GPT-4', authType: t }];
-      }
-      if (t === AuthType.QWEN_OAUTH) {
-        return getFilteredQwenModels().map((m) => ({
-          id: m.id,
-          label: m.label,
-          authType: AuthType.QWEN_OAUTH,
-        }));
-      }
-      return [];
-    });
-
-    const mockConfigWithSwitchAuthType = {
-      getAuthType,
-      getModel: vi.fn(() => 'gpt-4'),
-      getContentGeneratorConfig: vi.fn(() => ({
-        authType: AuthType.USE_OPENAI,
-        model: 'gpt-4',
-      })),
-      switchModel,
-      getAvailableModelsForAuthType,
-    };
-
-    const { props } = renderComponent(
-      {},
-      mockConfigWithSwitchAuthType as unknown as Partial<Config>,
-    );
-
-    const childOnSelect = mockedSelect.mock.calls[0][0].onSelect;
-    await childOnSelect(`${AuthType.QWEN_OAUTH}::${DEFAULT_QWEN_MODEL}`);
-
-    // qwen-oauth is discontinued — switchModel should NOT be called
-    expect(switchModel).not.toHaveBeenCalled();
-    // Dialog should NOT close
-    expect(props.onClose).not.toHaveBeenCalled();
   });
 
   it('passes onHighlight to DescriptiveRadioButtonSelect', () => {

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -209,7 +209,12 @@ export function ModelDialog({
 
     // Separate runtime models from registry models
     const runtimeModels = allModels.filter((m) => m.isRuntimeModel);
-    const registryModels = allModels.filter((m) => !m.isRuntimeModel);
+    const registryModels = allModels.filter(
+      (m) =>
+        !m.isRuntimeModel &&
+        (m.authType !== AuthType.QWEN_OAUTH ||
+          authType === AuthType.QWEN_OAUTH),
+    );
 
     // Group registry models by authType
     const modelsByAuthTypeMap = new Map<AuthType, CoreAvailableModel[]>();
@@ -262,7 +267,7 @@ export function ModelDialog({
     }
 
     return result;
-  }, [config]);
+  }, [authType, config]);
 
   const MODEL_OPTIONS = useMemo(
     () =>


### PR DESCRIPTION
## What this PR does

The interactive `/model` picker now hides the discontinued built-in Qwen OAuth model when the current session uses another authentication provider. Existing Qwen OAuth sessions still see the discontinued entry, so their migration warning remains available.

## Why it's needed

`getAllConfiguredModels()` includes the built-in Qwen OAuth registry entry even when a user has no OAuth configuration. That made API-key and OpenAI-compatible users see an unusable discontinued model as the first picker option. Filtering only the dialog's non-runtime registry entries removes the misleading option without changing the global registry or runtime compatibility.

## Reviewer Test Plan

### How to verify

Open `/model` while authenticated through an OpenAI-compatible provider and confirm no `qwen-oauth` row is shown. Open it in an existing Qwen OAuth session and confirm the discontinued row and warning remain visible.

### Evidence (Before & After)

Before: non-OAuth users see `[qwen-oauth] coder-model (Discontinued)` as the first row. After: the row is omitted unless Qwen OAuth is the active auth type. Focused component tests cover both sides.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | N/A |

### Environment (optional)

Node.js 24; repository dependencies installed locally.

## Risk & Scope

- Main risk or tradeoff: existing Qwen OAuth sessions must still see the migration warning; this remains covered.
- Not validated / out of scope: no live OAuth login was attempted.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5160

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

交互式 `/model` 选择器现在会在当前会话使用其它认证提供商时隐藏已经停用的内置 Qwen OAuth 模型。已有 Qwen OAuth 会话仍能看到停用条目，因此迁移提示不会丢失。

## 为什么需要修改

`getAllConfiguredModels()` 即使在用户没有配置 OAuth 时也会包含内置 Qwen OAuth 注册项，导致 API Key 和 OpenAI 兼容提供商用户把一个不可用的停用模型看作第一个选项。本次只过滤选择器中的非运行时注册项，不改变全局模型注册和现有运行时兼容行为。

## Reviewer Test Plan

### 验证方式

使用 OpenAI 兼容提供商认证后打开 `/model`，确认不再显示 `qwen-oauth` 行；在已有 Qwen OAuth 会话中打开，确认停用条目和警告仍然可见。

### 修改前后证据

修改前，非 OAuth 用户会把 `[qwen-oauth] coder-model (Discontinued)` 看到为第一行；修改后，只有当前认证类型为 Qwen OAuth 时才显示该行。聚焦组件测试覆盖了两侧行为。

### 已测试环境

Windows，Node.js 24；本地安装仓库依赖。聚焦测试、lint、完整 build 和全工作区 typecheck 均通过。

## 风险与范围

- 主要风险：已有 Qwen OAuth 会话仍需看到迁移警告，测试已覆盖。
- 未验证 / 范围外：未尝试真实 OAuth 登录。
- 破坏性变更：无。

## 关联 Issue

Fixes #5160

</details>
