### PR TITLE
fix: Qwen PR review proxy bypass, stale-worktree cleanup, and footer line break

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -351,7 +351,69 @@ jobs:
           if ! command -v qwen >/dev/null 2>&1; then
             fail "qwen CLI is required on the review runner."
           fi
-          qwen --version
+
+          # shellcheck disable=SC2016
+          configure_qwen_network() {
+            local openai_host proxy_bin
+            openai_host="$(node -e 'console.log(new URL(process.env.OPENAI_BASE_URL).hostname)')"
+            export NO_PROXY="${NO_PROXY:+$NO_PROXY,}${openai_host}"
+            export no_proxy="${no_proxy:+$no_proxy,}${openai_host}"
+
+            # qwen currently reads HTTP(S)_PROXY directly and does not apply
+            # NO_PROXY when constructing its proxy agent. Clear proxy env for
+            # qwen itself, while restoring it for child gh/git commands.
+            export QWEN_CI_HTTPS_PROXY="${HTTPS_PROXY:-}"
+            export QWEN_CI_https_proxy="${https_proxy:-}"
+            export QWEN_CI_HTTP_PROXY="${HTTP_PROXY:-}"
+            export QWEN_CI_http_proxy="${http_proxy:-}"
+            proxy_bin="$RUNNER_TEMP/qwen-network-bin"
+            mkdir -p "$proxy_bin"
+
+            if command -v gh >/dev/null 2>&1; then
+              local real_gh
+              real_gh="$(command -v gh)"
+              export QWEN_CI_REAL_GH="$real_gh"
+              {
+                printf '%s\n' '#!/usr/bin/env bash'
+                printf '%s\n' '[ -n "${QWEN_CI_HTTPS_PROXY:-}" ] && export HTTPS_PROXY="$QWEN_CI_HTTPS_PROXY"'
+                printf '%s\n' '[ -n "${QWEN_CI_https_proxy:-}" ] && export https_proxy="$QWEN_CI_https_proxy"'
+                printf '%s\n' '[ -n "${QWEN_CI_HTTP_PROXY:-}" ] && export HTTP_PROXY="$QWEN_CI_HTTP_PROXY"'
+                printf '%s\n' '[ -n "${QWEN_CI_http_proxy:-}" ] && export http_proxy="$QWEN_CI_http_proxy"'
+                printf '%s\n' 'exec "$QWEN_CI_REAL_GH" "$@"'
+              } > "$proxy_bin/gh"
+              chmod +x "$proxy_bin/gh"
+            fi
+
+            if command -v git >/dev/null 2>&1; then
+              local real_git
+              real_git="$(command -v git)"
+              export QWEN_CI_REAL_GIT="$real_git"
+              {
+                printf '%s\n' '#!/usr/bin/env bash'
+                printf '%s\n' '[ -n "${QWEN_CI_HTTPS_PROXY:-}" ] && export HTTPS_PROXY="$QWEN_CI_HTTPS_PROXY"'
+                printf '%s\n' '[ -n "${QWEN_CI_https_proxy:-}" ] && export https_proxy="$QWEN_CI_https_proxy"'
+                printf '%s\n' '[ -n "${QWEN_CI_HTTP_PROXY:-}" ] && export HTTP_PROXY="$QWEN_CI_HTTP_PROXY"'
+                printf '%s\n' '[ -n "${QWEN_CI_http_proxy:-}" ] && export http_proxy="$QWEN_CI_http_proxy"'
+                printf '%s\n' 'exec "$QWEN_CI_REAL_GIT" "$@"'
+              } > "$proxy_bin/git"
+              chmod +x "$proxy_bin/git"
+            fi
+
+            export PATH="$proxy_bin:$PATH"
+            unset HTTPS_PROXY https_proxy HTTP_PROXY http_proxy
+
+            echo "qwen_path=$(command -v qwen)"
+            qwen --version
+            echo "openai_host=${openai_host}"
+            echo "qwen_http_proxy=disabled"
+            if [ -n "${QWEN_CI_HTTPS_PROXY}${QWEN_CI_https_proxy}${QWEN_CI_HTTP_PROXY}${QWEN_CI_http_proxy}" ]; then
+              echo "child_git_github_proxy=restored"
+            else
+              echo "child_git_github_proxy=unset"
+            fi
+          }
+
+          configure_qwen_network
 
           case "$TIMEOUT_MINUTES" in
             ''|*[!0-9]*)

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -263,6 +263,29 @@ jobs:
       pull-requests: 'write'
       issues: 'write'
     steps:
+      # Self-hosted runners reuse the workspace, so an interrupted review can
+      # leave a stale `.qwen/tmp/review-pr-*` worktree or `qwen-review/*` branch
+      # that trips the checkout below. Prune defensively; never fail the job.
+      - name: 'Clean stale review worktrees'
+        run: |-
+          set -uo pipefail
+          # `.git` is a directory in a normal checkout but a gitlink file in a
+          # worktree; -e covers both, and a missing .git (first run) too.
+          if [ ! -e .git ]; then
+            echo "no prior workspace; nothing to clean"
+            exit 0
+          fi
+          rm -rf .qwen/tmp/review-pr-* 2>/dev/null || true
+          git worktree prune -v || true
+          git for-each-ref --format='%(refname:short)' 'refs/heads/qwen-review/*' \
+            | while read -r stale_ref; do
+                if [ -n "$stale_ref" ]; then
+                  git branch -D "$stale_ref" || true
+                fi
+              done
+          git worktree prune -v || true
+          echo "stale review worktrees cleaned"
+
       # SECURITY: checkout trusted base code; /review fetches PR diff context.
       - name: 'Checkout base branch'
         uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -378,7 +378,13 @@ jobs:
           # shellcheck disable=SC2016
           configure_qwen_network() {
             local openai_host proxy_bin
+            if ! command -v node >/dev/null 2>&1; then
+              fail "node is required to parse OPENAI_BASE_URL for the proxy bypass."
+            fi
             openai_host="$(node -e 'console.log(new URL(process.env.OPENAI_BASE_URL).hostname)')"
+            if [ -z "$openai_host" ]; then
+              fail "Could not parse a hostname from OPENAI_BASE_URL."
+            fi
             export NO_PROXY="${NO_PROXY:+$NO_PROXY,}${openai_host}"
             export no_proxy="${no_proxy:+$no_proxy,}${openai_host}"
 
@@ -389,7 +395,7 @@ jobs:
             export QWEN_CI_https_proxy="${https_proxy:-}"
             export QWEN_CI_HTTP_PROXY="${HTTP_PROXY:-}"
             export QWEN_CI_http_proxy="${http_proxy:-}"
-            proxy_bin="$RUNNER_TEMP/qwen-network-bin"
+            proxy_bin="${RUNNER_TEMP:-/tmp}/qwen-network-bin"
             mkdir -p "$proxy_bin"
 
             if command -v gh >/dev/null 2>&1; then

--- a/packages/core/src/skills/bundled/review/SKILL.md
+++ b/packages/core/src/skills/bundled/review/SKILL.md
@@ -571,20 +571,24 @@ gh api repos/{owner}/{repo}/pulls/{pr_number}/reviews \
   --input .qwen/tmp/qwen-review-{target}-review.json
 ```
 
-If there are **no confirmed findings**, submit a single-line review. Use `event=APPROVE` by default; if the presubmit JSON has `downgradeApprove=true`, use `event=COMMENT` and prepend the downgrade reasons to the body:
+If there are **no confirmed findings**, submit a short summary review. Use `event=APPROVE` by default; if the presubmit JSON has `downgradeApprove=true`, use `event=COMMENT` and prepend the downgrade reasons to the body. Separate the footer from the body with a blank line so it renders on its own line — `-f body` does not interpret `\n`, so use a real line break inside the quotes:
 
 ```bash
 # downgradeApprove=false (non-self PR, green CI):
 gh api repos/{owner}/{repo}/pulls/{pr_number}/reviews \
   -f commit_id="{commit_sha}" \
   -f event="APPROVE" \
-  -f body="No issues found. LGTM! ✅ _— YOUR_MODEL_ID via Qwen Code /review_"
+  -f body="No issues found. LGTM! ✅
+
+_— YOUR_MODEL_ID via Qwen Code /review_"
 
 # downgradeApprove=true (self-PR, CI failing, or CI still running):
 gh api repos/{owner}/{repo}/pulls/{pr_number}/reviews \
   -f commit_id="{commit_sha}" \
   -f event="COMMENT" \
-  -f body="No review findings. Downgraded from Approve to Comment: <downgradeReasons joined with '; '>. _— YOUR_MODEL_ID via Qwen Code /review_"
+  -f body="No review findings. Downgraded from Approve to Comment: <downgradeReasons joined with '; '>.
+
+_— YOUR_MODEL_ID via Qwen Code /review_"
 ```
 
 Clean up the JSON file in Step 11.


### PR DESCRIPTION
## What this PR does

This bundles three reliability fixes for the Qwen PR review tooling:

1. **Proxy bypass for the review workflow.** Before invoking qwen, the `Run review` step appends the `OPENAI_BASE_URL` host to `NO_PROXY`/`no_proxy`, clears `HTTP(S)_PROXY` for the qwen process itself, and drops `gh`/`git` wrappers on `PATH` so qwen reaches the model endpoint directly while those child processes still go through the proxy for GitHub. It prints `qwen_http_proxy=disabled` / `child_git_github_proxy=restored` diagnostics.
2. **Stale review-worktree cleanup.** A best-effort pre-checkout step prunes leftover `.qwen/tmp/review-pr-*` worktrees and `qwen-review/*` branches that an interrupted review can leave on a self-hosted runner. It never fails the job.
3. **Review footer line break.** The no-findings summary review templates appended the model attribution footer with a leading space, so it rendered on the same line as the body. They now separate it with a blank line, matching the inline-comment format.

## Why it's needed

The review workflow had no proxy bypass and relied only on the runner's `NO_PROXY`, which qwen does not consult when building its proxy agent — so model calls were forced through the corporate proxy and the job died with `[API Error: terminated (cause: other side closed)]`, posting _"Qwen Code review did not complete successfully: Qwen review aborted with an API error before posting comments."_ See e.g. run [27547374941](https://github.com/QwenLM/qwen-code/actions/runs/27547374941) (a `pull_request_target` run on the current `main` workflow). That is the root cause of the review failures in production. The new triage pipeline (`qwen-pr-triage.yml`, c92d1ca) already carries this bypass and ran clean across two real runs; this ports the same helper back into the legacy workflow to stop the bleeding. The worktree cleanup removes a recurring source of checkout warnings on the self-hosted runner. The footer fix is a small rendering correction so the attribution sits on its own line.

This is a hotfix to the legacy workflow: parts 1 and 2 become obsolete once it is removed in favor of the new triage pipeline. The footer fix (part 3) is independent and permanent.

## Reviewer Test Plan

### How to verify

Static checks (done locally):

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/qwen-code-pr-review.yml'))"` → OK
- `actionlint` → only two errors, both pre-existing and unrelated (`environment.deployment` line 144, self-hosted label `ecs-qwen` line 260); identical on `origin/main`
- `bash -n` on the `Run review` and `Clean stale review worktrees` steps → OK

Runtime (proxy bypass) — verified by dispatching the branch against a real PR:

- `gh workflow run "🧐 Qwen Pull Request Review" --ref fix/pr-review-proxy-bypass -f pr_number=5164 -f review_mode=dry-run -f timeout_minutes=30`
- Run `27546812697` completed `success`; log showed `qwen_http_proxy=disabled`, `child_git_github_proxy=restored`, no `terminated`, and qwen produced a full review.

Footer fix: read the diff — the two no-findings `-f body=` examples now have a blank line before `_— YOUR_MODEL_ID via Qwen Code /review_`.

### Evidence (Before & After)

Proxy bypass:

- **Before** (current `main` workflow, no bypass): run [27547374941](https://github.com/QwenLM/qwen-code/actions/runs/27547374941) failed with `[API Error: terminated (cause: other side closed)]` and posted _"Qwen review aborted with an API error before posting comments."_
- **After** (this branch, dispatched dry-run on #5164): run [27546812697](https://github.com/QwenLM/qwen-code/actions/runs/27546812697) succeeded — `qwen_http_proxy=disabled`, `child_git_github_proxy=restored`, no `terminated`, full review produced.

Footer — Before: `... review-pr. _— qwen3.7-max via Qwen Code /review_` (one line); After: footer drops to its own line.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ static checks (YAML / actionlint / bash -n) |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ proxy bypass verified on the self-hosted runner via dispatch run `27546812697` (dry-run on #5164) |

### Environment (optional)

N/A — CI workflow + prompt template, no local runtime.

## Risk & Scope

- Main risk or tradeoff: the `gh`/`git` wrappers rewrite `PATH`; they only restore proxy vars when set, matching the validated triage pipeline. The cleanup step is best-effort and guarded so it cannot fail the job.
- Not validated / out of scope: no end-to-end review run exercising the worktree-cleanup path (it is defensive and self-heals); lint/typecheck/unit tests do not apply to CI YAML or a prompt template.
- Breaking changes / migration notes: none. Parts 1–2 are a temporary hotfix, obsolete once the legacy workflow is deleted.

## Linked Issues

None — internal CI hotfix.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

打包三项 Qwen PR 评审工具链的可靠性修复:

1. **评审 workflow 的代理绕过。** 调用 qwen 前,`Run review` 步骤把 `OPENAI_BASE_URL` 的 host 追加进 `NO_PROXY`/`no_proxy`,清掉 qwen 进程自身的 `HTTP(S)_PROXY`,并在 `PATH` 上放 `gh`/`git` wrapper——让 qwen 直连模型端点,同时这些子进程访问 GitHub 时仍走代理。打印 `qwen_http_proxy=disabled` / `child_git_github_proxy=restored` 诊断。
2. **清理残留评审 worktree。** 在 checkout 前加一个 best-effort 步骤,清掉中断的评审在 self-hosted runner 上残留的 `.qwen/tmp/review-pr-*` worktree 和 `qwen-review/*` 分支。绝不让 job 失败。
3. **评审 footer 换行。** 无发现摘要 review 模板用空格把模型署名 footer 接在正文后,导致同一行渲染。现在用空行分隔,和内联评论格式一致。

## 为什么需要

评审 workflow 没有代理绕过,只依赖 runner 的 `NO_PROXY`,而 qwen 构造 proxy agent 时不读它,模型请求被强行走公司代理,任务最终以 `[API Error: terminated (cause: other side closed)]` 告终,并发出 _"Qwen Code review did not complete successfully: Qwen review aborted with an API error before posting comments."_。例见 run [27547374941](https://github.com/QwenLM/qwen-code/actions/runs/27547374941)(当前 `main` workflow 的一次 `pull_request_target` run)——这是生产上评审失败的根因。新的 triage 流水线(`qwen-pr-triage.yml`,c92d1ca)已带这段绕过,两次真实 run 干净;本 PR 把同一段移植回旧 workflow 止血。worktree 清理消掉 self-hosted runner 上反复出现的 checkout 警告来源。footer 修复是个小的渲染纠正,让署名独立成行。

这是对旧 workflow 的止血:第 1、2 项在旧 workflow 被新 triage 流水线替换删除后自动作废;footer(第 3 项)是独立且永久的修复。

## Reviewer Test Plan

静态校验(本地已做):

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/qwen-code-pr-review.yml'))"` → OK
- `actionlint` → 仅 2 个改动前就存在、与本改动无关的报错(`environment.deployment` 第 144 行、self-hosted 标签 `ecs-qwen` 第 260 行),与 origin/main 一致
- 对 `Run review` 与 `Clean stale review worktrees` 步骤跑 `bash -n` → OK

运行时(代理绕过)——用分支 dispatch 到真实 PR 验证:

- `gh workflow run "🧐 Qwen Pull Request Review" --ref fix/pr-review-proxy-bypass -f pr_number=5164 -f review_mode=dry-run -f timeout_minutes=30`
- Run `27546812697` 结果 `success`;日志含 `qwen_http_proxy=disabled`、`child_git_github_proxy=restored`、无 `terminated`,qwen 完整跑完评审。

footer 修复:看 diff——两个无发现 `-f body=` 示例现在在 `_— YOUR_MODEL_ID via Qwen Code /review_` 前都有空行。

证据(Before/After):

- **Before**(当前 `main` workflow,无绕过):run [27547374941](https://github.com/QwenLM/qwen-code/actions/runs/27547374941) 以 `[API Error: terminated (cause: other side closed)]` 失败,发出 _"Qwen review aborted with an API error before posting comments."_。
- **After**(本分支,dispatch 到 #5164 的 dry-run):run [27546812697](https://github.com/QwenLM/qwen-code/actions/runs/27546812697) 成功——`qwen_http_proxy=disabled`、`child_git_github_proxy=restored`、无 `terminated`,完整跑完评审。

## Risk & Scope

- 主要风险/取舍:`gh`/`git` wrapper 改写 `PATH`,仅在代理变量存在时恢复,逻辑与已验证的 triage 流水线一致。清理步骤是 best-effort 且有保护,不会让 job 失败。
- 未验证/超出范围:未端到端跑过 worktree 清理路径(它是防御性的、会自愈);lint/typecheck/单测对 CI YAML 和 prompt 模板不适用。
- 破坏性变更/迁移:无。第 1、2 项属临时止血,旧 workflow 删除后作废。

## 关联 Issue

无(内部 CI 止血)。

</details>
