### PR TITLE
fix(core): slice auto-memory history before transcript build

### DIFF
--- a/packages/core/src/memory/extract.test.ts
+++ b/packages/core/src/memory/extract.test.ts
@@ -112,6 +112,43 @@ describe('auto-memory extraction', () => {
     expect(cursor.processedOffset).toBe(2);
   });
 
+  it('builds transcripts only from history after the extraction cursor', async () => {
+    vi.mocked(runAutoMemoryExtractionByAgent).mockResolvedValue({
+      touchedTopics: [],
+      touchedProjectScope: false,
+      touchedUserScope: false,
+      systemMessage: undefined,
+    });
+    await fs.writeFile(
+      getAutoMemoryExtractCursorPath(projectRoot),
+      JSON.stringify({
+        sessionId: 'session-1',
+        processedOffset: 1,
+        updatedAt: new Date().toISOString(),
+      }),
+      'utf-8',
+    );
+
+    const processedMessage = {
+      role: 'user' as const,
+      get parts(): never {
+        throw new Error('processed history should not be read');
+      },
+    };
+    const result = await runAutoMemoryExtract({
+      projectRoot,
+      sessionId: 'session-1',
+      config: mockConfig,
+      history: [
+        processedMessage,
+        { role: 'user', parts: [{ text: 'new preference' }] },
+      ],
+    });
+
+    expect(runAutoMemoryExtractionByAgent).toHaveBeenCalledTimes(1);
+    expect(result.cursor.processedOffset).toBe(2);
+  });
+
   it('throws when config is missing because heuristic fallback was removed', async () => {
     await expect(
       runAutoMemoryExtract({

--- a/packages/core/src/memory/extract.ts
+++ b/packages/core/src/memory/extract.ts
@@ -46,10 +46,11 @@ export interface AutoMemoryExtractResult {
 
 export function buildTranscriptMessages(
   history: Content[],
+  startOffset = 0,
 ): AutoMemoryTranscriptMessage[] {
   return history
     .map((message, index) => ({
-      offset: index,
+      offset: startOffset + index,
       role: message.role,
       text: partToString(message.parts ?? [])
         .replace(/\s+/g, ' ')
@@ -153,13 +154,18 @@ export async function runAutoMemoryExtract(params: {
     );
   }
 
-  const transcript = buildTranscriptMessages(params.history);
   const currentCursor = await readExtractCursor(params.projectRoot);
-  const slice = loadUnprocessedTranscriptSlice(
-    params.sessionId,
-    transcript,
-    currentCursor,
-  );
+  const startOffset =
+    currentCursor.sessionId === params.sessionId
+      ? (currentCursor.processedOffset ?? 0)
+      : 0;
+  const slice = {
+    messages: buildTranscriptMessages(
+      params.history.slice(startOffset),
+      startOffset,
+    ),
+    nextProcessedOffset: params.history.length,
+  };
 
   if (!params.config) {
     throw new Error(


### PR DESCRIPTION
## What this PR does

Reads the managed auto-memory extraction cursor before building transcript strings, then converts only the unprocessed history slice while preserving offsets from the original session history.

## Why it's needed

Managed auto-memory currently converts the full history into normalized strings before applying its extraction cursor. Large already-processed text histories can therefore exhaust the Node heap during or after `/quit`, even though only the short unprocessed tail is needed. Applying the cursor first removes that duplicate full-history allocation and advances the cursor using the actual history length.

## Reviewer Test Plan

### How to verify

Write an extraction cursor whose processed offset skips the first history entry, make that processed entry throw if its parts are read, and run managed auto-memory extraction. The extraction should complete, process the new user entry, and advance the cursor to the full history length without reading the processed entry.

### Evidence (Before & After)

N/A - internal memory extraction path.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | N/A |

### Environment (optional)

Node.js v24.15.0, npm 11.12.1.

## Risk & Scope

- Main risk or tradeoff: the extraction cursor now represents an offset into the original history array rather than the count of filtered transcript messages.
- Not validated / out of scope: transcript size budgets, shutdown cancellation, and memory-pressure gating.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5147

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在构建 managed auto-memory transcript 字符串之前先读取 extraction cursor，只转换尚未处理的 history 切片，同时保留原始会话 history 中的 offset。

## 为什么需要

当前 managed auto-memory 会先把完整 history 转换并规范化为字符串，然后才应用 extraction cursor。大段已经处理过的文本历史仍会被再次完整分配，因此即使真正需要的只是很短的未处理尾部，也可能在 `/quit` 期间或之后耗尽 Node heap。先应用 cursor 可以消除这次不必要的全量历史分配，并按实际 history 长度推进 cursor。

## Reviewer Test Plan

### 如何验证

写入一个跳过第一条 history 的 extraction cursor，让这条已处理消息在读取 parts 时直接抛错，然后执行 managed auto-memory extraction。提取过程应正常完成、处理新的用户消息、将 cursor 推进到完整 history 长度，并且不读取已处理消息。

### 前后证据

不适用，属于内部 memory extraction 路径。

### 测试环境

Windows，Node.js v24.15.0，npm 11.12.1。

## 风险与范围

- 主要风险或取舍：extraction cursor 现在明确表示原始 history 数组中的 offset，而不是过滤后 transcript 消息的数量。
- 未验证 / 不在范围内：transcript 大小预算、shutdown cancellation 和 memory-pressure gate。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #5147

</details>
