### PR TITLE
fix(review): put model footer on its own line in summary reviews

### DIFF
--- a/packages/core/src/skills/bundled/review/SKILL.md
+++ b/packages/core/src/skills/bundled/review/SKILL.md
@@ -571,20 +571,24 @@ gh api repos/{owner}/{repo}/pulls/{pr_number}/reviews \
   --input .qwen/tmp/qwen-review-{target}-review.json
 ```
 
-If there are **no confirmed findings**, submit a single-line review. Use `event=APPROVE` by default; if the presubmit JSON has `downgradeApprove=true`, use `event=COMMENT` and prepend the downgrade reasons to the body:
+If there are **no confirmed findings**, submit a short summary review. Use `event=APPROVE` by default; if the presubmit JSON has `downgradeApprove=true`, use `event=COMMENT` and prepend the downgrade reasons to the body. Separate the footer from the body with a blank line so it renders on its own line — `-f body` does not interpret `\n`, so use a real line break inside the quotes:
 
 ```bash
 # downgradeApprove=false (non-self PR, green CI):
 gh api repos/{owner}/{repo}/pulls/{pr_number}/reviews \
   -f commit_id="{commit_sha}" \
   -f event="APPROVE" \
-  -f body="No issues found. LGTM! ✅ _— YOUR_MODEL_ID via Qwen Code /review_"
+  -f body="No issues found. LGTM! ✅
+
+_— YOUR_MODEL_ID via Qwen Code /review_"
 
 # downgradeApprove=true (self-PR, CI failing, or CI still running):
 gh api repos/{owner}/{repo}/pulls/{pr_number}/reviews \
   -f commit_id="{commit_sha}" \
   -f event="COMMENT" \
-  -f body="No review findings. Downgraded from Approve to Comment: <downgradeReasons joined with '; '>. _— YOUR_MODEL_ID via Qwen Code /review_"
+  -f body="No review findings. Downgraded from Approve to Comment: <downgradeReasons joined with '; '>.
+
+_— YOUR_MODEL_ID via Qwen Code /review_"
 ```
 
 Clean up the JSON file in Step 11.


### PR DESCRIPTION
## What this PR does

This fixes the model attribution footer on the no-findings summary review so it renders on its own line. The two summary-review templates in the bundled review skill appended the footer with a leading space, so it landed on the same line as the body — e.g. `... CI failing: review-pr. _— qwen3.7-max via Qwen Code /review_`. They now put a blank line before the footer, matching the inline-comment template which already separates it with `\n\n`.

## Why it's needed

The footer is meant to sit on its own line, the way the inline-comment path already renders it. The summary path was inconsistent: it joined the footer with a space. There is a second subtlety the template now calls out — `gh ... -f body` does not interpret `\n`, so the fix uses a real line break inside the quotes rather than an escape that would have shown up literally.

## Reviewer Test Plan

### How to verify

This is a prompt/template change in `packages/core/src/skills/bundled/review/SKILL.md`; there is no code path to run. Confirm by reading the diff: the two `-f body=` examples for the no-findings APPROVE and the downgraded COMMENT case now have a blank line before `_— YOUR_MODEL_ID via Qwen Code /review_`. Real-world effect: the next summary review the bot posts will show the footer on its own line instead of trailing the body sentence.

### Evidence (Before & After)

Before: `No review findings ... CI failing: review-pr. _— qwen3.7-max via Qwen Code /review_` (one line).
After: the footer drops to its own line below the summary.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A — template-only change |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

N/A — no runtime.

## Risk & Scope

- Main risk or tradeoff: none of substance; the model now reproduces a multi-line `-f body` example.
- Not validated / out of scope: only touches the two summary-review examples; the inline-comment format was already correct and is unchanged.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复「无发现」摘要 review 的模型署名 footer，让它独立成行。bundled review skill 里两条摘要 review 模板用一个空格把 footer 接在正文后面，于是渲染在同一行——例如 `... CI failing: review-pr. _— qwen3.7-max via Qwen Code /review_`。现在在 footer 前加空行，和内联评论模板（已用 `\n\n` 分隔）保持一致。

## 为什么需要

footer 本应像内联评论那样独立成行，但摘要路径不一致，用了空格拼接。模板里还点出了第二个细节：`gh ... -f body` 不会解释 `\n`，所以这里用真实换行而不是转义，否则会原样显示出 `\n`。

## Reviewer Test Plan

这是 `packages/core/src/skills/bundled/review/SKILL.md` 的 prompt/模板改动，没有可运行的代码路径。看 diff 确认即可：无发现 APPROVE 和降级 COMMENT 两个 `-f body=` 示例，现在在 `_— YOUR_MODEL_ID via Qwen Code /review_` 前都有一个空行。实际效果：bot 下一次发摘要 review 时，footer 会落到正文下方独立一行。

## Risk & Scope

- 主要风险/取舍：基本没有；模型改为复刻一个多行的 `-f body` 示例。
- 未验证/超出范围：只动两条摘要 review 示例；内联评论格式本就正确，未改动。
- 破坏性变更/迁移：无。

## 关联 Issue

无。

</details>
