### PR TITLE
fix(core): auto-retry transport stream errors before the first chunk

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -4613,7 +4613,7 @@ describe('GeminiChat', async () => {
       ).toBe(true);
     });
 
-    it('keeps RETRYABLE_STREAM_TRANSPORT_CODES a subset of the classifier set', () => {
+    it('classifies every allow-listed stream transport code as retryable transport', () => {
       // Drift guard: the stream allow-list is a hand-curated subset of the
       // classifier's transport codes. If a code is renamed/removed there, or
       // a typo is introduced here, this fails instead of silently never

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -20,6 +20,8 @@ import {
   StreamEventType,
   type StreamEvent,
 } from './geminiChat.js';
+import { RETRYABLE_STREAM_TRANSPORT_CODES } from './stream-transport-retry.js';
+import { classifyRetryError } from '../utils/retryErrorClassification.js';
 import { StreamContentError } from './openaiContentGenerator/pipeline.js';
 import type { Config } from '../config/config.js';
 import { setSimulate429 } from '../utils/testUtils.js';
@@ -4438,6 +4440,416 @@ describe('GeminiChat', async () => {
         expect(history.some((h) => h.parts?.some((p) => p.functionCall))).toBe(
           false,
         );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('retries retryable transport stream errors and succeeds on a later attempt', async () => {
+      vi.useFakeTimers();
+      try {
+        const transportError = Object.assign(new TypeError('terminated'), {
+          cause: Object.assign(new Error('other side closed'), {
+            code: 'UND_ERR_SOCKET',
+          }),
+        });
+
+        vi.mocked(mockContentGenerator.generateContentStream)
+          .mockResolvedValueOnce(
+            (async function* () {
+              throw transportError;
+
+              yield {} as GenerateContentResponse;
+            })(),
+          )
+          .mockResolvedValueOnce(
+            (async function* () {
+              yield {
+                candidates: [
+                  {
+                    content: {
+                      parts: [{ text: 'Recovered after transport retry' }],
+                    },
+                    finishReason: 'STOP',
+                  },
+                ],
+              } as unknown as GenerateContentResponse;
+            })(),
+          );
+
+        const stream = await chat.sendMessageStream(
+          'test-model',
+          { message: 'test' },
+          'prompt-transport-retry',
+        );
+        const events = await collectStreamWithFakeTimers(stream, 5_000);
+
+        expect(
+          mockContentGenerator.generateContentStream,
+        ).toHaveBeenCalledTimes(2);
+        expect(
+          events.filter((event) => event.type === StreamEventType.RETRY),
+        ).toHaveLength(1);
+        expect(
+          events.some(
+            (event) =>
+              event.type === StreamEventType.CHUNK &&
+              event.value.candidates?.[0]?.content?.parts?.[0]?.text ===
+                'Recovered after transport retry',
+          ),
+        ).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('stops retrying retryable transport stream errors after the retry budget is exhausted', async () => {
+      vi.useFakeTimers();
+      try {
+        const transportError = Object.assign(new TypeError('terminated'), {
+          cause: Object.assign(new Error('other side closed'), {
+            code: 'UND_ERR_SOCKET',
+          }),
+        });
+
+        vi.mocked(
+          mockContentGenerator.generateContentStream,
+        ).mockImplementation(() =>
+          Promise.resolve(
+            (async function* () {
+              throw transportError;
+
+              yield {} as GenerateContentResponse;
+            })(),
+          ),
+        );
+
+        const stream = await chat.sendMessageStream(
+          'test-model',
+          { message: 'test' },
+          'prompt-transport-retry-exhausted',
+        );
+        const events: StreamEvent[] = [];
+        // Collect in the background and capture the terminal error manually:
+        // the rejection only settles after fake timers advance past both retry
+        // delays, so a deferred `expect().rejects` here would either deadlock
+        // (awaited before advancing) or trip `vitest/valid-expect` (not
+        // awaited). Catch-and-assert sidesteps both.
+        let caughtError: unknown;
+        const collecting = (async () => {
+          try {
+            for await (const event of stream) {
+              events.push(event);
+            }
+          } catch (error) {
+            caughtError = error;
+          }
+        })();
+
+        await vi.advanceTimersByTimeAsync(0);
+        await vi.advanceTimersByTimeAsync(10_000);
+        await collecting;
+
+        expect(caughtError).toBeInstanceOf(Error);
+        expect((caughtError as Error).message).toContain('terminated');
+        expect(
+          mockContentGenerator.generateContentStream,
+        ).toHaveBeenCalledTimes(3);
+        expect(
+          events.filter((event) => event.type === StreamEventType.RETRY),
+        ).toHaveLength(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not retry retryable transport stream errors after yielding a chunk', async () => {
+      const transportError = Object.assign(new TypeError('terminated'), {
+        cause: Object.assign(new Error('other side closed'), {
+          code: 'UND_ERR_SOCKET',
+        }),
+      });
+
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        (async function* () {
+          yield {
+            candidates: [
+              {
+                content: {
+                  parts: [{ text: 'Partial response before socket close' }],
+                },
+              },
+            ],
+          } as unknown as GenerateContentResponse;
+          throw transportError;
+        })(),
+      );
+
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'test' },
+        'prompt-transport-no-retry-after-chunk',
+      );
+      const events: StreamEvent[] = [];
+      await expect(async () => {
+        for await (const event of stream) {
+          events.push(event);
+        }
+      }).rejects.toThrow('terminated');
+
+      expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(
+        events.filter((event) => event.type === StreamEventType.RETRY),
+      ).toHaveLength(0);
+      expect(
+        events.some(
+          (event) =>
+            event.type === StreamEventType.CHUNK &&
+            event.value.candidates?.[0]?.content?.parts?.[0]?.text ===
+              'Partial response before socket close',
+        ),
+      ).toBe(true);
+    });
+
+    it('keeps RETRYABLE_STREAM_TRANSPORT_CODES a subset of the classifier set', () => {
+      // Drift guard: the stream allow-list is a hand-curated subset of the
+      // classifier's transport codes. If a code is renamed/removed there, or
+      // a typo is introduced here, this fails instead of silently never
+      // retrying.
+      for (const code of RETRYABLE_STREAM_TRANSPORT_CODES) {
+        expect(classifyRetryError({ code })).toMatchObject({
+          kind: 'transport',
+          diagnosis: 'retryable',
+          transportCode: code,
+        });
+      }
+    });
+
+    it.each([...RETRYABLE_STREAM_TRANSPORT_CODES])(
+      'retries a pre-first-chunk transport error carrying code %s',
+      async (transportCode) => {
+        vi.useFakeTimers();
+        try {
+          const transportError = Object.assign(new TypeError('terminated'), {
+            cause: Object.assign(new Error('socket failure'), {
+              code: transportCode,
+            }),
+          });
+
+          vi.mocked(mockContentGenerator.generateContentStream)
+            .mockResolvedValueOnce(
+              (async function* () {
+                throw transportError;
+
+                yield {} as GenerateContentResponse;
+              })(),
+            )
+            .mockResolvedValueOnce(
+              (async function* () {
+                yield {
+                  candidates: [
+                    {
+                      content: {
+                        parts: [{ text: `Recovered from ${transportCode}` }],
+                      },
+                      finishReason: 'STOP',
+                    },
+                  ],
+                } as unknown as GenerateContentResponse;
+              })(),
+            );
+
+          const stream = await chat.sendMessageStream(
+            'test-model',
+            { message: 'test' },
+            `prompt-transport-${transportCode}`,
+          );
+          const events = await collectStreamWithFakeTimers(stream, 5_000);
+
+          expect(
+            mockContentGenerator.generateContentStream,
+          ).toHaveBeenCalledTimes(2);
+          expect(
+            events.filter((event) => event.type === StreamEventType.RETRY),
+          ).toHaveLength(1);
+          expect(
+            events.some(
+              (event) =>
+                event.type === StreamEventType.CHUNK &&
+                event.value.candidates?.[0]?.content?.parts?.[0]?.text ===
+                  `Recovered from ${transportCode}`,
+            ),
+          ).toBe(true);
+        } finally {
+          vi.useRealTimers();
+        }
+      },
+    );
+
+    it('retries a transport error whose code is on the error itself (no cause)', async () => {
+      vi.useFakeTimers();
+      try {
+        // getTransportCode checks the direct `error.code` before `cause.code`;
+        // the other tests only exercise the `cause` path.
+        const transportError = Object.assign(new Error('socket reset'), {
+          code: 'ECONNRESET',
+        });
+
+        vi.mocked(mockContentGenerator.generateContentStream)
+          .mockResolvedValueOnce(
+            (async function* () {
+              throw transportError;
+
+              yield {} as GenerateContentResponse;
+            })(),
+          )
+          .mockResolvedValueOnce(
+            (async function* () {
+              yield {
+                candidates: [
+                  {
+                    content: { parts: [{ text: 'Recovered via direct code' }] },
+                    finishReason: 'STOP',
+                  },
+                ],
+              } as unknown as GenerateContentResponse;
+            })(),
+          );
+
+        const stream = await chat.sendMessageStream(
+          'test-model',
+          { message: 'test' },
+          'prompt-transport-direct-code',
+        );
+        const events = await collectStreamWithFakeTimers(stream, 5_000);
+
+        expect(
+          mockContentGenerator.generateContentStream,
+        ).toHaveBeenCalledTimes(2);
+        expect(
+          events.filter((event) => event.type === StreamEventType.RETRY),
+        ).toHaveLength(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not retry a transport error that carries an HTTP 4xx status', async () => {
+      // A definitive 4xx is a permanent client error; the socket-level cause
+      // must not relabel it as retryable (classifier keeps 4xx authoritative).
+      const transportError = Object.assign(new TypeError('terminated'), {
+        status: 400,
+        cause: Object.assign(new Error('other side closed'), {
+          code: 'ECONNRESET',
+        }),
+      });
+
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        (async function* () {
+          throw transportError;
+
+          yield {} as GenerateContentResponse;
+        })(),
+      );
+
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'test' },
+        'prompt-transport-4xx-no-retry',
+      );
+      const events: StreamEvent[] = [];
+      await expect(async () => {
+        for await (const event of stream) {
+          events.push(event);
+        }
+      }).rejects.toThrow('terminated');
+
+      expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(
+        events.filter((event) => event.type === StreamEventType.RETRY),
+      ).toHaveLength(0);
+    });
+
+    it('does not retry a transport code outside the stream allow-list', async () => {
+      // ECONNREFUSED classifies as transport/retryable but is excluded from
+      // RETRYABLE_STREAM_TRANSPORT_CODES (permanent misconfiguration, not a
+      // transient blip), so the stream path must not replay it.
+      const transportError = Object.assign(new TypeError('terminated'), {
+        cause: Object.assign(new Error('connection refused'), {
+          code: 'ECONNREFUSED',
+        }),
+      });
+
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        (async function* () {
+          throw transportError;
+
+          yield {} as GenerateContentResponse;
+        })(),
+      );
+
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'test' },
+        'prompt-transport-not-allowlisted',
+      );
+      const events: StreamEvent[] = [];
+      await expect(async () => {
+        for await (const event of stream) {
+          events.push(event);
+        }
+      }).rejects.toThrow('terminated');
+
+      expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(
+        events.filter((event) => event.type === StreamEventType.RETRY),
+      ).toHaveLength(0);
+    });
+
+    it('surfaces an abort fired during the transport retry delay without retrying again', async () => {
+      vi.useFakeTimers();
+      try {
+        const transportError = Object.assign(new TypeError('terminated'), {
+          cause: Object.assign(new Error('other side closed'), {
+            code: 'UND_ERR_SOCKET',
+          }),
+        });
+        const abortController = new AbortController();
+
+        vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+          (async function* () {
+            throw transportError;
+
+            yield {} as GenerateContentResponse;
+          })(),
+        );
+
+        const stream = await chat.sendMessageStream(
+          'test-model',
+          { message: 'test', config: { abortSignal: abortController.signal } },
+          'prompt-transport-abort-delay',
+        );
+
+        const iterator = stream[Symbol.asyncIterator]();
+        // First event is the RETRY emitted before the 1s transport delay.
+        const first = await iterator.next();
+        expect(first.value.type).toBe(StreamEventType.RETRY);
+
+        // Abort while the generator is awaiting the retry delay.
+        const nextPromise = iterator.next();
+        abortController.abort();
+        await expect(nextPromise).rejects.toThrow();
+
+        // Only the initial attempt ran; the abort cut the retry short.
+        expect(
+          mockContentGenerator.generateContentStream,
+        ).toHaveBeenCalledTimes(1);
       } finally {
         vi.useRealTimers();
       }

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -77,6 +77,7 @@ import { getContextLengthExceededInfo } from '../utils/contextLengthError.js';
 import { isSystemReminderContent } from '../utils/environmentContext.js';
 import type { SessionStartSource } from '../hooks/types.js';
 import { getCustomSystemPrompt } from './prompts.js';
+import { RETRYABLE_STREAM_TRANSPORT_CODES } from './stream-transport-retry.js';
 import {
   collectToolCallIdsFromHistory,
   normalizeModelToolCallIds,
@@ -306,6 +307,11 @@ const INVALID_CONTENT_RETRY_OPTIONS: ContentRetryOptions = {
 const INVALID_STREAM_RETRY_CONFIG = {
   maxRetries: 2,
   initialDelayMs: 2000,
+};
+
+const TRANSPORT_STREAM_RETRY_CONFIG = {
+  maxRetries: 2,
+  initialDelayMs: 1000,
 };
 
 /**
@@ -1957,6 +1963,7 @@ export class GeminiChat {
         let lastError: unknown = new Error('Request failed after all retries.');
         let rateLimitRetryCount = 0;
         let invalidStreamRetryCount = 0;
+        let transportStreamRetryCount = 0;
         let reactiveCompressionAttempted = false;
         let suppressNextRetryEvent = false;
 
@@ -1982,13 +1989,15 @@ export class GeminiChat {
           attempt < INVALID_CONTENT_RETRY_OPTIONS.maxAttempts;
           attempt++
         ) {
+          let streamYieldedChunk = false;
           try {
             if (suppressNextRetryEvent) {
               suppressNextRetryEvent = false;
             } else if (
               attempt > 0 ||
               rateLimitRetryCount > 0 ||
-              invalidStreamRetryCount > 0
+              invalidStreamRetryCount > 0 ||
+              transportStreamRetryCount > 0
             ) {
               yield { type: StreamEventType.RETRY };
             }
@@ -2002,6 +2011,7 @@ export class GeminiChat {
 
             lastFinishReason = undefined;
             for await (const chunk of stream) {
+              streamYieldedChunk = true;
               const fr = chunk.candidates?.[0]?.finishReason;
               if (fr) lastFinishReason = fr;
               yield { type: StreamEventType.CHUNK, value: chunk };
@@ -2064,13 +2074,16 @@ export class GeminiChat {
             // These arrive as StreamContentError with finish_reason="error_finish"
             // from the pipeline, containing the throttling message in the content.
             // Covers TPM throttling, GLM rate limits, and other provider throttling.
+            // Classify once per failed attempt; reused by the rate-limit
+            // diagnostics below and the transport-retry decision further down.
+            const classification = classifyRetryError(error, {
+              authType: cgConfig?.authType,
+              extraRetryErrorCodes,
+            });
+
             const isRateLimit = isRateLimitError(error, extraRetryErrorCodes);
             if (isRateLimit) {
               const details = getRateLimitErrorDetails(error);
-              const classification = classifyRetryError(error, {
-                authType: cgConfig?.authType,
-                extraRetryErrorCodes,
-              });
               // The classifier is observation-only here; stream retry control
               // remains governed by isRateLimitError and the retry budget.
               const diagnosticFields = {
@@ -2127,6 +2140,61 @@ export class GeminiChat {
                 attempts: rateLimitRetryCount,
                 maxRetries: maxRateLimitRetries,
                 ...diagnosticFields,
+              });
+            }
+
+            // Replay only curated socket-level failures before any response
+            // chunk has reached callers.
+            const isRetryableStreamTransportError =
+              classification.kind === 'transport' &&
+              classification.transportCode !== undefined &&
+              RETRYABLE_STREAM_TRANSPORT_CODES.has(
+                classification.transportCode,
+              );
+            if (
+              isRetryableStreamTransportError &&
+              !streamYieldedChunk &&
+              transportStreamRetryCount <
+                TRANSPORT_STREAM_RETRY_CONFIG.maxRetries
+            ) {
+              popPartialIfPushed();
+              transportStreamRetryCount++;
+              const delayMs =
+                TRANSPORT_STREAM_RETRY_CONFIG.initialDelayMs *
+                transportStreamRetryCount;
+              debugLogger.warn('Transport stream retry scheduled', {
+                retryPath: 'stream',
+                retryDecision: 'retry',
+                attempt: transportStreamRetryCount,
+                maxRetries: TRANSPORT_STREAM_RETRY_CONFIG.maxRetries,
+                retryDelayMs: delayMs,
+                errorKind: classification.kind,
+                transportCode: classification.transportCode,
+              });
+              yield { type: StreamEventType.RETRY };
+              suppressNextRetryEvent = true;
+              // Don't count transport retries against the content retry limit.
+              attempt--;
+              await delay(delayMs, params.config?.abortSignal).promise;
+              continue;
+            }
+            if (isRetryableStreamTransportError && streamYieldedChunk) {
+              debugLogger.warn('Transport stream retry skipped', {
+                retryPath: 'stream',
+                retryDecision: 'skipped_after_chunk',
+                attempts: transportStreamRetryCount,
+                maxRetries: TRANSPORT_STREAM_RETRY_CONFIG.maxRetries,
+                errorKind: classification.kind,
+                transportCode: classification.transportCode,
+              });
+            } else if (isRetryableStreamTransportError) {
+              debugLogger.warn('Transport stream retry exhausted', {
+                retryPath: 'stream',
+                retryDecision: 'exhausted',
+                attempts: transportStreamRetryCount,
+                maxRetries: TRANSPORT_STREAM_RETRY_CONFIG.maxRetries,
+                errorKind: classification.kind,
+                transportCode: classification.transportCode,
               });
             }
 

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -2178,19 +2178,15 @@ export class GeminiChat {
               await delay(delayMs, params.config?.abortSignal).promise;
               continue;
             }
-            if (isRetryableStreamTransportError && streamYieldedChunk) {
-              debugLogger.warn('Transport stream retry skipped', {
+            if (isRetryableStreamTransportError) {
+              // Reached only when the retry above did not fire: either a chunk
+              // was already yielded (replaying would duplicate output) or the
+              // retry budget is exhausted. Either way the error propagates.
+              debugLogger.warn('Transport stream retry not taken', {
                 retryPath: 'stream',
-                retryDecision: 'skipped_after_chunk',
-                attempts: transportStreamRetryCount,
-                maxRetries: TRANSPORT_STREAM_RETRY_CONFIG.maxRetries,
-                errorKind: classification.kind,
-                transportCode: classification.transportCode,
-              });
-            } else if (isRetryableStreamTransportError) {
-              debugLogger.warn('Transport stream retry exhausted', {
-                retryPath: 'stream',
-                retryDecision: 'exhausted',
+                retryDecision: streamYieldedChunk
+                  ? 'skipped_after_chunk'
+                  : 'exhausted',
                 attempts: transportStreamRetryCount,
                 maxRetries: TRANSPORT_STREAM_RETRY_CONFIG.maxRetries,
                 errorKind: classification.kind,

--- a/packages/core/src/core/stream-transport-retry.ts
+++ b/packages/core/src/core/stream-transport-retry.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Internal stream retry allow-list. Keep this outside geminiChat.ts because
+// that file is re-exported from the package barrel, and this retry policy is
+// not part of the public API.
+export const RETRYABLE_STREAM_TRANSPORT_CODES: ReadonlySet<string> = new Set([
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'UND_ERR_BODY_TIMEOUT',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_SOCKET',
+]);


### PR DESCRIPTION
## What this PR does

Adds a bounded automatic retry on the streaming model-call path (`sendMessageStream`) for transient transport-level stream drops that happen *before the first chunk is yielded*. The retry decision is driven by the existing structured `classifyRetryError()` transport code, not by an HTTP status (there isn't one) and not by string-matching the error message. Once any chunk has been yielded, the error propagates unchanged.

## Why it's needed

Streaming model calls can intermittently drop at the transport layer and surface as `[API Error: terminated (cause: other side closed)]` — an undici/socket failure (`UND_ERR_SOCKET`, `UND_ERR_BODY_TIMEOUT`, `ECONNRESET`, `ETIMEDOUT`, …), not an HTTP status error. So it can't be retried by status code, and matching the `"terminated (cause: other side closed)"` string is fragile.

This is defense-in-depth, not the only remedy. The frequent occurrences in the PR-review CI had an **environmental root cause** — a proxy sitting between the runner and the model endpoint terminating the streaming connection — fixed directly in #5168. This PR is the complementary **resilience layer**: regardless of *why* a transient transport drop happens (proxy, flaky network, server-side reset), if it occurs **before the first chunk is yielded** — when no response data has reached the user yet — the request is replayed (bounded, idempotent-safe) instead of failing the whole turn.

## Reviewer Test Plan

### How to verify

`npx vitest run packages/core/src/core/geminiChat.test.ts` → 192 passed. The new tests cover: retry-then-succeed across all six allow-listed codes (`it.each`), exhaustion after the 2-retry budget, no-retry after a chunk was already yielded, a code on `error.code` directly vs nested under `cause`, a transport error carrying an HTTP 4xx (must *not* retry — permanent error stays authoritative), a non-allow-listed transport code such as `ECONNREFUSED` (must *not* retry), abort fired during the retry delay, and a drift test asserting the stream allow-list stays a subset of the classifier's `TRANSPORT_ERROR_CODES`.

Expected vs observed: before the first chunk, a retryable transport error triggers up to 2 retries with linear backoff and emits one `RETRY` event per attempt; after any chunk, the error propagates unchanged with zero retries. Both confirmed by the assertions above.

### Evidence (Before & After)

Non–user-visible (core reliability / retry control flow). N/A for screenshots — behavioral evidence is the unit tests above plus `tsc --noEmit`, `eslint`, and `prettier --check` all green locally.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS: local unit tests + typecheck + lint. Windows/Linux: not tested locally, covered by CI.

### Environment (optional)

Unit tests only — N/A runtime.

## Risk & Scope

- Main risk or tradeoff: a request that fails before the first chunk is now replayed up to 2×. Bounded, idempotent (no partial output was emitted), and on an independent budget so it does not consume the content-retry limit.
- Not validated / out of scope: mid-stream drops *after* the first chunk are intentionally not retried (would duplicate already-streamed output); connection-refused / DNS-class transport codes (`ECONNREFUSED`, `ENOTFOUND`, …) are intentionally excluded as permanent-misconfiguration signals rather than transient blips.
- Breaking changes / migration notes: none. The allow-list lives in an internal, non-barrel-exported module and is not part of the public core API.

## Linked Issues

Addresses #2938 (one of two layers — see #5168 for the environment-specific root-cause fix).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在流式模型调用路径（`sendMessageStream`）上，为**首个 chunk 产出之前**发生的瞬时传输层断流增加了有界的自动重试。重试判定基于已有的结构化分类器 `classifyRetryError()` 提取的 transport code，而不是 HTTP 状态码（这类错误根本没有状态码），也不是对错误字符串做匹配。一旦已经产出过任何 chunk，错误原样向上抛出。

## 为什么需要

流式模型调用会偶发在传输层断流，表现为 `[API Error: terminated (cause: other side closed)]`——这是 undici/socket 层的失败（`UND_ERR_SOCKET`、`UND_ERR_BODY_TIMEOUT`、`ECONNRESET`、`ETIMEDOUT` 等），不是 HTTP 状态错误。所以无法靠状态码重试，而匹配 `"terminated (cause: other side closed)"` 字符串又很脆弱。

这是 defense-in-depth，并非唯一手段。PR-review CI 上之所以频发，有一个**环境根因**——runner 与模型端点之间的代理把流式连接掐断了——该根因已在 #5168 直接修复。本 PR 是互补的**韧性层**：无论瞬时断流是什么原因（代理、网络抖动、服务端 reset），只要发生在**首个 chunk 产出之前**（此时还没有任何响应数据到达用户），就重放请求（有界、幂等安全），而不是让整轮失败。

## 评审验证计划

`npx vitest run packages/core/src/core/geminiChat.test.ts` → 192 通过。新增测试覆盖：六个白名单 code 各自的"重试后成功"（`it.each`）、用尽 2 次重试预算、已产出 chunk 后不再重试、code 直接挂在 `error.code` 上 vs 嵌在 `cause` 下、携带 HTTP 4xx 的传输错误（必须**不**重试，永久错误优先）、不在白名单内的传输码如 `ECONNREFUSED`（必须**不**重试）、重试延迟期间触发 abort，以及一个防漂移测试断言流白名单始终是分类器 `TRANSPORT_ERROR_CODES` 的子集。

预期 vs 实际：首个 chunk 之前，可重试的传输错误触发至多 2 次线性退避重试，每次发一个 `RETRY` 事件；任何 chunk 之后，错误原样抛出、零重试。均由上述断言确认。

## 证据

非用户可见（核心可靠性/重试控制流），截图 N/A——行为证据即上述单测，外加本地 `tsc --noEmit`、`eslint`、`prettier --check` 全绿。

## 风险与范围

- 主要风险/取舍：首个 chunk 之前失败的请求现在会被至多重放 2 次。有界、幂等（未产出任何部分输出），且使用独立预算，不占用 content-retry 限额。
- 未验证/范围之外：首个 chunk **之后**的中途断流刻意不重试（会重复已经流出的输出）；连接拒绝/DNS 类传输码（`ECONNREFUSED`、`ENOTFOUND` 等）作为永久配置问题而非瞬时抖动，刻意排除。
- 破坏性变更/迁移说明：无。白名单位于内部、非 barrel 导出的模块，不属于 core 公共 API。

## 关联 Issue

Addresses #2938（两层之一；环境根因修复见 #5168）。

</details>

