### PR TITLE
docs: fix MCP token path, daemon UI event count, add Feishu channel

### DIFF
--- a/docs/developers/daemon/00-index.md
+++ b/docs/developers/daemon/00-index.md
@@ -49,7 +49,7 @@ Pick the path that matches your goal:
 
 - [`13-sdk-daemon-client.md`](./13-sdk-daemon-client.md) - TypeScript SDK: `DaemonClient`, `DaemonSessionClient`, `DaemonAuthFlow`, SSE parser, event reducers, `ui/*` transcript layer.
 - [`14-cli-tui-adapter.md`](./14-cli-tui-adapter.md) - shared UI transcript layer and the legacy CLI TUI daemon adapter relationship.
-- [`15-channel-adapters.md`](./15-channel-adapters.md) - `DaemonChannelBridge` shared base plus DingTalk, WeChat (Weixin), Telegram per-channel adapters.
+- [`15-channel-adapters.md`](./15-channel-adapters.md) - `DaemonChannelBridge` shared base plus DingTalk, WeChat (Weixin), Telegram, Feishu per-channel adapters.
 - [`16-vscode-ide-adapter.md`](./16-vscode-ide-adapter.md) - `DaemonIdeConnection`, loopback-only enforcement, webview bridging.
 
 ### Reference appendices
@@ -134,7 +134,7 @@ Use these anchors when moving from the docs into the latest `main` code:
 | Area                         | Current state                                                                                                                                                | Primary docs                                                                                                                                  |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | TypeScript SDK daemon client | `DaemonClient`, `DaemonSessionClient`, `DaemonAuthFlow`, SSE parser, event reducers, feature preflight, and UI transcript exports are documented.            | [`13`](./13-sdk-daemon-client.md)                                                                                                             |
-| Shared UI transcript layer   | SDK `daemon/ui/*` normalizes daemon events into 36 UI semantic event types, reduces them into transcript blocks, and provides renderers/conformance helpers. | [`14`](./14-cli-tui-adapter.md), [`../daemon-ui/README.md`](../daemon-ui/README.md), [`../daemon-ui/MIGRATION.md`](../daemon-ui/MIGRATION.md) |
+| Shared UI transcript layer   | SDK `daemon/ui/*` normalizes daemon events into 37 UI semantic event types, reduces them into transcript blocks, and provides renderers/conformance helpers. | [`14`](./14-cli-tui-adapter.md), [`../daemon-ui/README.md`](../daemon-ui/README.md), [`../daemon-ui/MIGRATION.md`](../daemon-ui/MIGRATION.md) |
 | Web UI daemon consumer       | `packages/webui/src/daemon/` consumes the SDK transcript store through React providers and adapters.                                                         | [`14`](./14-cli-tui-adapter.md), [`../daemon-client-adapters/web-ui.md`](../daemon-client-adapters/web-ui.md)                                 |
 | CLI TUI / channels / VS Code | Legacy paths still exist; migration to shared transcript primitives is documented as follow-up work, not completed behavior.                                 | [`14`](./14-cli-tui-adapter.md), [`15`](./15-channel-adapters.md), [`16`](./16-vscode-ide-adapter.md)                                         |
 

--- a/docs/developers/daemon/01-architecture.md
+++ b/docs/developers/daemon/01-architecture.md
@@ -16,7 +16,7 @@ flowchart LR
         WUI["Web UI<br/>(packages/webui/src/daemon)"]
         TUI["CLI TUI<br/>(packages/cli/src/ui/daemon)"]
         IDE["VS Code IDE<br/>(packages/vscode-ide-companion)"]
-        CH["Channel bots<br/>(DingTalk / WeChat / Telegram)"]
+        CH["Channel bots<br/>(DingTalk / WeChat / Telegram / Feishu)"]
         SDK["Any SDK consumer<br/>(packages/sdk-typescript/src/daemon)"]
     end
 

--- a/docs/developers/daemon/01-architecture.md
+++ b/docs/developers/daemon/01-architecture.md
@@ -104,6 +104,7 @@ flowchart TB
         DT["channels/dingtalk"]
         WX["channels/weixin"]
         TG["channels/telegram"]
+        FS["channels/feishu"]
         IDEA["vscode-ide-companion/<br/>daemonIdeConnection.ts"]
     end
 

--- a/docs/developers/daemon/13-sdk-daemon-client.md
+++ b/docs/developers/daemon/13-sdk-daemon-client.md
@@ -219,7 +219,7 @@ sequenceDiagram
 The SDK also exports `packages/sdk-typescript/src/daemon/ui/`, a host-neutral
 set of primitives that turn daemon events into transcript blocks:
 
-- `normalizeDaemonEvent(evt)` maps the 43 known daemon wire events into 36 UI-friendly `DaemonUiEventType` values; unmodeled or malformed events normalize to `debug`.
+- `normalizeDaemonEvent(evt)` maps the 43 known daemon wire events into 37 UI-friendly `DaemonUiEventType` values; unmodeled or malformed events normalize to `debug`.
 - `createDaemonTranscriptState()` plus `reduceDaemonTranscriptEvents(state, events)` projects UI events into `DaemonTranscriptBlock[]`.
 - `createDaemonTranscriptStore()` wraps subscribe / dispatch.
 - `render.ts` / `terminal.ts` provide HTML and terminal baseline renderers, while `toolPreview.ts` produces tool-call summaries.

--- a/docs/developers/daemon/14-cli-tui-adapter.md
+++ b/docs/developers/daemon/14-cli-tui-adapter.md
@@ -6,7 +6,7 @@
 
 `packages/sdk-typescript/src/daemon/ui/` adds a `ui/*` subpackage to the SDK. It turns the daemon SSE event stream into UI-renderable transcript blocks through reusable primitives:
 
-- **Normalization** (`normalizer.ts`): maps the daemon wire schema's 43 known event types (see [`09-event-schema.md`](./09-event-schema.md)) into 36 UI-friendly `DaemonUiEventType` semantic events such as `assistant.text.delta`, `tool.update`, and `session.metadata.changed`.
+- **Normalization** (`normalizer.ts`): maps the daemon wire schema's 43 known event types (see [`09-event-schema.md`](./09-event-schema.md)) into 37 UI-friendly `DaemonUiEventType` semantic events such as `assistant.text.delta`, `tool.update`, and `session.metadata.changed`.
 - **State machine** (`transcript.ts`, `store.ts`): pure reducer plus subscribable store that projects UI events into an ordered `DaemonTranscriptBlock[]`.
 - **Renderers** (`render.ts`, `terminal.ts`, `toolPreview.ts`): transcript blocks to HTML, terminal text, and tool preview strings. Hosts can use or replace them.
 - **Conformance** (`conformance.ts`): cross-host consistency tests used when channel, TUI, and IDE surfaces migrate to these primitives.
@@ -41,7 +41,7 @@ The first production consumer is **`packages/webui/src/daemon/`** ([#4328](https
 
 ### `DaemonUiEventType` vocabulary
 
-`ui/types.ts` defines 36 UI event types, grouped by domain.
+`ui/types.ts` defines 37 UI event types, grouped by domain.
 
 **Chat stream (Stage 1)**
 
@@ -117,7 +117,7 @@ flowchart LR
     A --> B["DaemonClient.subscribeEvents<br/>parseSseStream"]
     B --> C["asKnownDaemonEvent<br/>(09-event-schema.md)"]
     C --> D["normalizeDaemonEvent<br/>ui/normalizer.ts"]
-    D --> E["DaemonUiEvent<br/>(36 UI-friendly types)"]
+    D --> E["DaemonUiEvent<br/>(37 UI-friendly types)"]
     E --> F["reduceDaemonTranscriptEvents<br/>ui/transcript.ts"]
     F --> G["DaemonTranscriptState +<br/>DaemonTranscriptBlock[]"]
     G --> H["renderer<br/>(render.ts HTML / terminal.ts / host custom)"]

--- a/docs/developers/daemon/15-channel-adapters.md
+++ b/docs/developers/daemon/15-channel-adapters.md
@@ -2,13 +2,13 @@
 
 ## Overview
 
-`packages/channels/` contains the **IM channel adapters** that turn a chat platform's incoming message into a daemon prompt and the daemon's outbound events into chat platform messages. Three concrete channels ship today: DingTalk, WeChat (Weixin), and Telegram. They share a base layer (`packages/channels/base/`) plus a `DaemonChannelBridge` that handles session multiplexing and SSE consumption.
+`packages/channels/` contains the **IM channel adapters** that turn a chat platform's incoming message into a daemon prompt and the daemon's outbound events into chat platform messages. Four concrete channels ship today: DingTalk, WeChat (Weixin), Telegram, and Feishu. They share a base layer (`packages/channels/base/`) plus a `DaemonChannelBridge` that handles session multiplexing and SSE consumption.
 
 Each channel maps inbound chat traffic to daemon sessions under a configurable `SessionScope` (`user`, `thread`, or `single`). The adapter delegates to `DaemonChannelBridge`, which delegates to the SDK's `DaemonSessionClient` (see [`13-sdk-daemon-client.md`](./13-sdk-daemon-client.md)).
 
 ## Responsibilities
 
-- Receive inbound messages from the channel's native transport (DingTalk WebSocket stream, WeChat HTTP long-poll, Telegram Bot long-poll).
+- Receive inbound messages from the channel's native transport (DingTalk WebSocket stream, WeChat HTTP long-poll, Telegram Bot long-poll, Feishu WebSocket or HTTP webhook).
 - Resolve `(senderId, groupId?)` into a daemon session via `DaemonChannelSessionFactory`.
 - Forward the user message as a daemon prompt and stream the response back as outbound chat messages, possibly chunked.
 - Render permission requests as chat-native prompts when interactive; otherwise auto-approve according to `ChannelConfig.approvalMode`.
@@ -172,15 +172,15 @@ sequenceDiagram
 | `chunkSize`, `chunkIntervalMs`           | Outbound block streaming settings.                                                                        |
 | `daemon: { baseUrl, token?, clientId? }` | Forwarded to `DaemonChannelSessionFactory`.                                                               |
 
-Channel-specific keys layer on top (DingTalk: `streamCredentials`; WeChat: `ilinkUrl`, `botId`; Telegram: `botToken`).
+Channel-specific keys layer on top (DingTalk: `streamCredentials`; WeChat: `ilinkUrl`, `botId`; Telegram: `botToken`; Feishu: `appId`, `appSecret`, `verificationToken`).
 
 ## Caveats & Known Limits
 
 - **Channels do not directly import `@qwen-code/sdk`.** They go through `ChannelBase` → `DaemonChannelBridge` → `DaemonChannelSessionClient` (which the bridge constructs from the SDK). The indirection lets the bridge swap implementations, such as a test stub, without requiring channel changes.
-- **Permission UX is per-channel.** DingTalk uses markdown buttons; WeChat is text-only; Telegram uses inline keyboards. No common "interactive permission widget" abstraction yet.
+- **Permission UX is per-channel.** DingTalk uses markdown buttons; WeChat is text-only; Telegram uses inline keyboards; Feishu uses interactive card buttons. No common "interactive permission widget" abstraction yet.
 - **Auto-approve is a deployment-side decision**, not a daemon-side one. The daemon's `permission_mediation` policy still applies; auto-approve only means the channel responds without prompting the human. Do not combine `auto` with `enforce`-grade workflows.
 - **Per-channel rate limits / message-size limits are the adapter's job.** `DaemonChannelBridge` only handles chunking; pushing past WeChat's per-message size or Telegram's flood limit is on the adapter.
-- **No DingTalk / WeChat / Telegram reverse-call** — channels are one-way (chat → daemon → chat). The IM platform's native push path, such as a DingTalk card callback, is not wired into the bridge yet.
+- **No DingTalk / WeChat / Telegram / Feishu reverse-call** — channels are one-way (chat → daemon → chat). The IM platform's native push path, such as a DingTalk card callback, is not wired into the bridge yet.
 
 ## References
 

--- a/docs/developers/daemon/15-channel-adapters.md
+++ b/docs/developers/daemon/15-channel-adapters.md
@@ -65,6 +65,7 @@ Handles common cross-cutting concerns: sender gating (allowlist / denylist), gro
 | DingTalk        | `packages/channels/dingtalk/src/DingtalkAdapter.ts` | DingTalk Stream SDK WebSocket       | Sends via `sessionWebhook` POST; media images downloaded via DT API, base64 in envelope. |
 | WeChat (Weixin) | `packages/channels/weixin/src/WeixinAdapter.ts`     | iLink Bot HTTP long-poll            | Sends via proprietary `sendText` / `sendImage` API; typing indicators.                   |
 | Telegram        | `packages/channels/telegram/src/TelegramAdapter.ts` | Telegram Bot API long-poll (grammy) | Sends HTML chunks via `sendMessage`.                                                     |
+| Feishu          | `packages/channels/feishu/src/FeishuAdapter.ts`     | Feishu/Lark Stream WebSocket (default) or HTTP webhook | Sends via Lark SDK as interactive cards; webhook mode requires `encryptKey` for HMAC signature verification. |
 
 Each adapter implements:
 
@@ -81,6 +82,9 @@ Each adapter implements:
 | **DingTalk** | WebSocket stream  | `senderStaffId` (+ optional `conversationId` for groups) | Inline buttons via DT markdown      | `ChannelConfig.approvalMode = 'auto' \| 'prompt'` |
 | **WeChat**   | HTTP long-poll    | `senderWxid` (+ optional `groupWxid`)                    | Text-only prompts with reply tokens | Same                                              |
 | **Telegram** | Bot API long-poll | `from.id` (+ optional `chat.id` for groups)              | Inline keyboard buttons             | Same                                              |
+| **Feishu**   | WebSocket stream / HTTP webhook | `sender.open_id` (+ optional `chat_id` for groups)       | Interactive card buttons            | Same                                              |
+
+> **Note:** The "Permission UX" column describes each platform's native affordance, but none is wired up yet — `AcpBridge.requestPermission` currently auto-approves every request (`packages/channels/base/src/AcpBridge.ts`), and `ChannelConfig.approvalMode` is declared but not yet read. Interactive approval is planned (Phase 5).
 
 ## Workflow
 

--- a/docs/developers/daemon/15-channel-adapters.md
+++ b/docs/developers/daemon/15-channel-adapters.md
@@ -172,12 +172,12 @@ sequenceDiagram
 | `chunkSize`, `chunkIntervalMs`           | Outbound block streaming settings.                                                                        |
 | `daemon: { baseUrl, token?, clientId? }` | Forwarded to `DaemonChannelSessionFactory`.                                                               |
 
-Channel-specific keys layer on top (DingTalk: `streamCredentials`; WeChat: `ilinkUrl`, `botId`; Telegram: `botToken`; Feishu: `appId`, `appSecret`, `verificationToken`).
+Channel-specific keys layer on top (DingTalk: `streamCredentials`; WeChat: `ilinkUrl`, `botId`; Telegram: `botToken`; Feishu: `clientId` (appId), `clientSecret` (appSecret), `verificationToken`, `encryptKey` (webhook mode)).
 
 ## Caveats & Known Limits
 
 - **Channels do not directly import `@qwen-code/sdk`.** They go through `ChannelBase` → `DaemonChannelBridge` → `DaemonChannelSessionClient` (which the bridge constructs from the SDK). The indirection lets the bridge swap implementations, such as a test stub, without requiring channel changes.
-- **Permission UX is per-channel.** DingTalk uses markdown buttons; WeChat is text-only; Telegram uses inline keyboards; Feishu uses interactive card buttons. No common "interactive permission widget" abstraction yet.
+- **Permission UX is per-channel.** DingTalk uses markdown buttons; WeChat is text-only; Telegram uses inline keyboards; Feishu uses interactive card buttons. (All currently auto-approve via `AcpBridge`; interactive approval is planned.) No common "interactive permission widget" abstraction yet.
 - **Auto-approve is a deployment-side decision**, not a daemon-side one. The daemon's `permission_mediation` policy still applies; auto-approve only means the channel responds without prompting the human. Do not combine `auto` with `enforce`-grade workflows.
 - **Per-channel rate limits / message-size limits are the adapter's job.** `DaemonChannelBridge` only handles chunking; pushing past WeChat's per-message size or Telegram's flood limit is on the adapter.
 - **No DingTalk / WeChat / Telegram / Feishu reverse-call** — channels are one-way (chat → daemon → chat). The IM platform's native push path, such as a DingTalk card callback, is not wired into the bridge yet.

--- a/docs/developers/tools/mcp-server.md
+++ b/docs/developers/tools/mcp-server.md
@@ -212,7 +212,7 @@ Use the `/mcp auth` command to manage OAuth authentication:
 
 OAuth tokens are automatically:
 
-- **Stored securely** in `~/.qwen/mcp-oauth-tokens.json`
+- **Stored securely** in `~/.qwen/mcp-oauth-tokens-v2.json` (AES-256-GCM encrypted), with keychain storage preferred when available
 - **Refreshed** when expired (if refresh tokens are available)
 - **Validated** before each connection attempt
 - **Cleaned up** when invalid or expired

--- a/docs/users/features/mcp.md
+++ b/docs/users/features/mcp.md
@@ -281,7 +281,7 @@ OAuth configuration properties:
 
 OAuth tokens are automatically:
 
-- **Stored securely** in `~/.qwen/mcp-oauth-tokens.json`
+- **Stored securely** in `~/.qwen/mcp-oauth-tokens-v2.json` (AES-256-GCM encrypted), with keychain storage preferred when available
 - **Refreshed** when expired (if refresh tokens are available)
 - **Validated** before each connection attempt
 


### PR DESCRIPTION
## What this PR does

Corrects three stale or missing items in the documentation, found during a docs audit against latest `main`: it updates the MCP OAuth token storage path to the current encrypted `v2` file (and notes keychain preference), fixes the daemon UI semantic event type count from 36 to 37, and adds the Feishu channel adapter — which already ships in code — to the daemon channel-adapter docs, the architecture diagram, and the navigation index.

## Why it's needed

The documentation described state that no longer matches the code, which misleads users and developers. The MCP docs pointed at the old plaintext `~/.qwen/mcp-oauth-tokens.json`, but tokens are now stored in `~/.qwen/mcp-oauth-tokens-v2.json` (AES-256-GCM encrypted), with keychain preferred when available — a wrong path/format confuses anyone inspecting or troubleshooting stored credentials. The daemon index claimed 36 UI semantic event types while the `DaemonUiEventType` union now has 37, and a stale count undermines trust in the reference table. The Feishu adapter already ships in `packages/channels/feishu/`, but the docs only listed DingTalk, WeChat, and Telegram, leaving the channel undiscoverable from the documentation.

## Reviewer Test Plan

### How to verify

This is a documentation-only change; verification is confirming each corrected value against the source it documents. Grep `packages/core/src/mcp/token-storage/` (e.g. `file-token-storage.ts`) for `mcp-oauth-tokens-v2` to confirm the v2 filename and encryption. Count the `DaemonUiEventType` union members in `packages/sdk-typescript/src/daemon/ui/types.ts`; the expected total is 37. Confirm `packages/channels/feishu/` exists with `FeishuAdapter.ts` and that its config keys are `clientId` (appId), `clientSecret` (appSecret), `verificationToken`, and `encryptKey` (required for webhook mode). Finally, confirm the Mermaid diagram in `01-architecture.md` and the tables in `15-channel-adapters.md` render correctly with Feishu included.

### Evidence (Before & After)

N/A — documentation-only change with no user-visible or TUI runtime behavior. The diff is the evidence: corrected MCP token path, the `36` → `37` event-type count, and Feishu added across the overview, transport, config keys, permission UX, and caveats.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

Documentation-only change; verified by checking the documented values against the source code rather than by running the app per-OS.

## Risk & Scope

- Main risk or tradeoff: None — Markdown documentation only; no code, configuration, or runtime behavior changes.
- Not validated / out of scope: No changes to the Feishu adapter implementation itself; this only documents the already-shipping adapter.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修正文档审计中发现的三处过时或缺失内容（基于最新 `main`）：将 MCP OAuth token 存储路径更新为当前加密的 `v2` 文件（并说明优先使用 keychain），把 daemon UI 语义事件类型数量从 36 修正为 37，并将代码中已经发布的 Feishu 渠道适配器补充到 daemon 渠道适配器文档、架构图和导航索引中。

## 为什么需要

文档描述的状态已与代码不符，会误导用户和开发者。MCP 文档仍指向旧的明文路径 `~/.qwen/mcp-oauth-tokens.json`，但 token 现已存储于 `~/.qwen/mcp-oauth-tokens-v2.json`（AES-256-GCM 加密），并在可用时优先使用 keychain——错误的路径/格式会让排查凭据存储的人困惑。daemon 索引声称有 36 个 UI 语义事件类型，而 `DaemonUiEventType` 联合类型现在有 37 个，过时的计数会削弱参考表的可信度。Feishu 适配器已在 `packages/channels/feishu/` 中发布，但文档只列出了 DingTalk、WeChat 和 Telegram，使该渠道在文档中无法被发现。

## 审阅测试计划

### 如何验证

这是纯文档改动；验证方式是将每个修正后的值与其所记录的源码对照确认。grep `packages/core/src/mcp/token-storage/`（如 `file-token-storage.ts`）中的 `mcp-oauth-tokens-v2` 以确认 v2 文件名与加密。统计 `packages/sdk-typescript/src/daemon/ui/types.ts` 中 `DaemonUiEventType` 联合类型的成员数量，预期为 37。确认 `packages/channels/feishu/` 存在且包含 `FeishuAdapter.ts`，其配置键为 `clientId`（appId）、`clientSecret`（appSecret）、`verificationToken`、`encryptKey`（webhook 模式必需）。最后确认 `01-architecture.md` 的 Mermaid 图与 `15-channel-adapters.md` 的表格在包含 Feishu 后渲染正常。

### 证据（前后对比）

N/A——纯文档改动，无用户可见或 TUI 运行时行为。diff 即为证据：修正后的 MCP token 路径、`36` → `37` 的事件类型计数，以及在概述、传输、配置键、权限 UX 和注意事项中加入的 Feishu。

### 测试平台

纯文档改动；通过将所记录的值与源码对照来验证，而非按操作系统运行应用，因此各平台均标记为 N/A。

## 风险与范围

- 主要风险或权衡：无——仅 Markdown 文档；无代码、配置或运行时行为变化。
- 未验证 / 超出范围：未改动 Feishu 适配器实现本身；本 PR 仅记录已发布的适配器。
- 破坏性变更 / 迁移说明：无。

</details>
