### PR TITLE
fix(model): remember selected provider when multiple share a model id (#5173)

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -2520,6 +2520,28 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
+  it('qwen/settings/setCoreValue clears model.baseUrl when setting model.name', async () => {
+    const settings = makeCoreSettings();
+    const { agent, agentPromise } = await bootCoreSettingsAgent(settings);
+
+    await agent.extMethod('qwen/settings/setCoreValue', {
+      scope: 'user',
+      key: 'model.name',
+      value: 'qwen3.7-max',
+    });
+
+    expect(settings.setValue).toHaveBeenCalledWith(
+      'User',
+      'model.name',
+      'qwen3.7-max',
+    );
+    // Id-only selection must clear the paired baseUrl disambiguator (tombstone).
+    expect(settings.setValue).toHaveBeenCalledWith('User', 'model.baseUrl', '');
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it('qwen/settings/getCore excludes untrusted workspace integrations from merged view', async () => {
     const settings = makeCoreSettings();
     (settings as { isTrusted: boolean }).isTrusted = false;

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -6335,6 +6335,13 @@ class QwenAgent implements Agent {
         );
         const scope = toSettingsScope(params['scope']);
         settings.setValue(scope, key, normalizedValue);
+        if (settingKey === 'model.name') {
+          // Selecting a model by id here can't disambiguate providers that
+          // share that id, so clear the paired baseUrl disambiguator left by a
+          // previous model-picker selection. Empty-string tombstone overrides a
+          // lower-scope value on merge (undefined would be dropped from JSON).
+          settings.setValue(scope, 'model.baseUrl', '');
+        }
         if (
           settingKey === 'general.outputLanguage' &&
           typeof normalizedValue === 'string' &&

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -719,11 +719,11 @@ describe('Session', () => {
         'model.name',
         'qwen3-coder-plus',
       );
-      // Id-only switch must clear any stale baseUrl disambiguator.
+      // Id-only switch must clear any stale baseUrl disambiguator (tombstone).
       expect(mockSettings.setValue).toHaveBeenCalledWith(
         SettingScope.User,
         'model.baseUrl',
-        undefined,
+        '',
       );
       expect(mockSettings.setValue).toHaveBeenCalledWith(
         SettingScope.User,

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -719,6 +719,12 @@ describe('Session', () => {
         'model.name',
         'qwen3-coder-plus',
       );
+      // Id-only switch must clear any stale baseUrl disambiguator.
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'model.baseUrl',
+        undefined,
+      );
       expect(mockSettings.setValue).toHaveBeenCalledWith(
         SettingScope.User,
         'security.auth.selectedType',

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -2758,6 +2758,10 @@ export class Session implements SessionContext {
     if (options.persistDefault ?? true) {
       const persistScope = getPersistScopeForModelSelection(this.settings);
       this.settings.setValue(persistScope, 'model.name', parsed.modelId);
+      // Id-only switch: clear any baseUrl disambiguator left by a previous
+      // model-picker selection so the next launch resolves to this provider,
+      // not a stale one sharing the same model id.
+      this.settings.setValue(persistScope, 'model.baseUrl', undefined);
       this.settings.setValue(
         persistScope,
         'security.auth.selectedType',

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -2760,8 +2760,10 @@ export class Session implements SessionContext {
       this.settings.setValue(persistScope, 'model.name', parsed.modelId);
       // Id-only switch: clear any baseUrl disambiguator left by a previous
       // model-picker selection so the next launch resolves to this provider,
-      // not a stale one sharing the same model id.
-      this.settings.setValue(persistScope, 'model.baseUrl', undefined);
+      // not a stale one sharing the same model id. Empty-string tombstone so
+      // the clear overrides a lower-scope value on merge (undefined is dropped
+      // from JSON and would not override).
+      this.settings.setValue(persistScope, 'model.baseUrl', '');
       this.settings.setValue(
         persistScope,
         'security.auth.selectedType',

--- a/packages/cli/src/config/auth.test.ts
+++ b/packages/cli/src/config/auth.test.ts
@@ -34,6 +34,8 @@ describe('validateAuthMethod', () => {
     delete process.env['ANTHROPIC_API_KEY'];
     delete process.env['ANTHROPIC_BASE_URL'];
     delete process.env['GOOGLE_API_KEY'];
+    delete process.env['IDEALAB_KEY'];
+    delete process.env['TOKEN_PLAN_KEY'];
   });
 
   it('should return null for USE_OPENAI with default env key', () => {
@@ -73,6 +75,67 @@ describe('validateAuthMethod', () => {
     } as unknown as ReturnType<typeof settings.loadSettings>);
 
     expect(validateAuthMethod(AuthType.USE_OPENAI)).toBeNull();
+  });
+
+  it('disambiguates by settings.model.baseUrl when providers share a model id', () => {
+    // Two providers with the same id; the persisted baseUrl selects the second.
+    // Only the second provider's env key is set, so validation passes only if
+    // the lookup honors baseUrl rather than matching the first id entry.
+    vi.mocked(settings.loadSettings).mockReturnValue({
+      merged: {
+        model: {
+          name: 'qwen3.7-max',
+          baseUrl: 'https://idealab.example.com/v1',
+        },
+        modelProviders: {
+          openai: [
+            {
+              id: 'qwen3.7-max',
+              baseUrl: 'https://token-plan.example.com/v1',
+              envKey: 'TOKEN_PLAN_KEY',
+            },
+            {
+              id: 'qwen3.7-max',
+              baseUrl: 'https://idealab.example.com/v1',
+              envKey: 'IDEALAB_KEY',
+            },
+          ],
+        },
+      },
+    } as unknown as ReturnType<typeof settings.loadSettings>);
+    process.env['IDEALAB_KEY'] = 'idealab-key';
+
+    expect(validateAuthMethod(AuthType.USE_OPENAI)).toBeNull();
+  });
+
+  it('reports the selected provider env key when providers share a model id', () => {
+    vi.mocked(settings.loadSettings).mockReturnValue({
+      merged: {
+        model: {
+          name: 'qwen3.7-max',
+          baseUrl: 'https://idealab.example.com/v1',
+        },
+        modelProviders: {
+          openai: [
+            {
+              id: 'qwen3.7-max',
+              baseUrl: 'https://token-plan.example.com/v1',
+              envKey: 'TOKEN_PLAN_KEY',
+            },
+            {
+              id: 'qwen3.7-max',
+              baseUrl: 'https://idealab.example.com/v1',
+              envKey: 'IDEALAB_KEY',
+            },
+          ],
+        },
+      },
+    } as unknown as ReturnType<typeof settings.loadSettings>);
+
+    // No env keys set → error must name the selected (IdeaLab) provider's key.
+    const result = validateAuthMethod(AuthType.USE_OPENAI);
+    expect(result).toContain('IDEALAB_KEY');
+    expect(result).not.toContain('TOKEN_PLAN_KEY');
   });
 
   it('should return error with custom envKey hint when modelProviders envKey is set but env var is missing', () => {

--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -66,10 +66,20 @@ function resolveSelectedModel(
   config?: Config,
 ): { modelId: string | undefined; baseUrl: string | undefined } {
   const modelsConfig = config?.getModelsConfig();
+  if (modelsConfig) {
+    // A live Config is the source of truth: pair its model with its own
+    // resolved baseUrl. Do NOT fall back to settings.model.baseUrl here — that
+    // could pair the runtime-selected model with a stale persisted baseUrl from
+    // a previous selection and validate a different duplicate-id provider.
+    return {
+      modelId: modelsConfig.getModel(),
+      baseUrl: modelsConfig.getGenerationConfig()?.baseUrl,
+    };
+  }
+  // Pre-flight (no Config yet): use the persisted selection as a paired unit.
   return {
-    modelId: modelsConfig?.getModel() ?? settings.model?.name,
-    baseUrl:
-      modelsConfig?.getGenerationConfig()?.baseUrl ?? settings.model?.baseUrl,
+    modelId: settings.model?.name,
+    baseUrl: settings.model?.baseUrl,
   };
 }
 

--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -25,8 +25,11 @@ const DEFAULT_ENV_KEYS: Record<string, string> = {
 
 /**
  * Find model configuration from modelProviders by authType and modelId.
- * When multiple models share the same id (different baseUrls), returns the
- * first match. Callers that need an exact match should also compare baseUrl.
+ * When a baseUrl is given, prefers the exact id+baseUrl match (disambiguating
+ * providers that share a model id) and falls back to the first id match if the
+ * paired provider was edited/removed. When no baseUrl is given, returns the
+ * first id match. Mirrors resolveCliGenerationConfig so pre-flight auth
+ * validation checks the same provider that startup resolution selects.
  */
 function findModelConfig(
   modelProviders: ModelProvidersConfig | undefined,
@@ -44,9 +47,30 @@ function findModelConfig(
   }
 
   if (baseUrl) {
-    return models.find((m) => m.id === modelId && m.baseUrl === baseUrl);
+    return (
+      models.find((m) => m.id === modelId && m.baseUrl === baseUrl) ??
+      models.find((m) => m.id === modelId)
+    );
   }
   return models.find((m) => m.id === modelId);
+}
+
+/**
+ * Resolve the selected model id and its paired baseUrl for provider lookup.
+ * Prefers the runtime-resolved generation config (which folds in CLI args, env
+ * vars, settings, and the selected provider), falling back to the persisted
+ * settings.model.{name,baseUrl} when no Config is available yet (pre-flight).
+ */
+function resolveSelectedModel(
+  settings: Settings,
+  config?: Config,
+): { modelId: string | undefined; baseUrl: string | undefined } {
+  const modelsConfig = config?.getModelsConfig();
+  return {
+    modelId: modelsConfig?.getModel() ?? settings.model?.name,
+    baseUrl:
+      modelsConfig?.getGenerationConfig()?.baseUrl ?? settings.model?.baseUrl,
+  };
 }
 
 function hasEnvValue(settings: Settings, envKey: string | undefined): boolean {
@@ -80,12 +104,19 @@ function hasApiKeyForAuth(
     | ModelProvidersConfig
     | undefined;
 
-  // Use config.getModelsConfig().getModel() if available for accurate model ID resolution
-  // that accounts for CLI args, env vars, and settings. Fall back to settings.model.name.
-  const modelId = config?.getModelsConfig().getModel() ?? settings.model?.name;
+  // Use config.getModelsConfig() if available for accurate model resolution
+  // that accounts for CLI args, env vars, and settings. Fall back to the
+  // persisted settings.model.{name,baseUrl}.
+  const { modelId, baseUrl } = resolveSelectedModel(settings, config);
 
-  // Try to find model-specific envKey from modelProviders
-  const modelConfig = findModelConfig(modelProviders, authType, modelId);
+  // Try to find model-specific envKey from modelProviders, disambiguating by
+  // baseUrl so duplicate-id providers resolve to the selected one.
+  const modelConfig = findModelConfig(
+    modelProviders,
+    authType,
+    modelId,
+    baseUrl,
+  );
 
   // If a Config is available, prefer the API key already resolved into the
   // generation config. The unified resolver folds CLI flags (e.g.
@@ -226,10 +257,15 @@ export function validateAuthMethod(
     const modelProviders = settings.merged.modelProviders as
       | ModelProvidersConfig
       | undefined;
-    // Use config.getModelsConfig().getModel() if available for accurate model ID
-    const modelId =
-      config?.getModelsConfig().getModel() ?? settings.merged.model?.name;
-    const modelConfig = findModelConfig(modelProviders, authMethod, modelId);
+    // Resolve the selected model + baseUrl so duplicate-id providers validate
+    // the Anthropic baseUrl of the selected provider, not the first id match.
+    const { modelId, baseUrl } = resolveSelectedModel(settings.merged, config);
+    const modelConfig = findModelConfig(
+      modelProviders,
+      authMethod,
+      modelId,
+      baseUrl,
+    );
 
     if (modelConfig && !modelConfig.baseUrl) {
       return t(

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1121,6 +1121,16 @@ const SETTINGS_SCHEMA = {
         description: 'The model to use for conversations.',
         showInDialog: false,
       },
+      baseUrl: {
+        type: 'string',
+        label: 'Model Base URL',
+        category: 'Model',
+        requiresRestart: false,
+        default: undefined as string | undefined,
+        description:
+          'Base URL paired with model.name; disambiguates which provider to use when multiple modelProviders entries share the same model id.',
+        showInDialog: false,
+      },
       maxSessionTurns: {
         type: 'number',
         label: 'Max Session Turns',

--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -183,6 +183,14 @@ describe('modelCommand', () => {
       'model.name',
       'qwen-max',
     );
+    // `/model <id>` is an id-only switch, so any baseUrl disambiguator left by
+    // a previous model-picker selection must be cleared to avoid resolving to a
+    // different provider on next launch.
+    expect(setValue).toHaveBeenCalledWith(
+      expect.any(String),
+      'model.baseUrl',
+      undefined,
+    );
     expect(result).toEqual({
       type: 'message',
       messageType: 'info',

--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -184,12 +184,12 @@ describe('modelCommand', () => {
       'qwen-max',
     );
     // `/model <id>` is an id-only switch, so any baseUrl disambiguator left by
-    // a previous model-picker selection must be cleared to avoid resolving to a
-    // different provider on next launch.
+    // a previous model-picker selection must be cleared (empty-string tombstone)
+    // to avoid resolving to a different provider on next launch.
     expect(setValue).toHaveBeenCalledWith(
       expect.any(String),
       'model.baseUrl',
-      undefined,
+      '',
     );
     expect(result).toEqual({
       type: 'message',

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -49,11 +49,16 @@ async function switchMainModel(
     );
     persistSetting(settings, 'security.auth.selectedType', parsed.authType);
     persistSetting(settings, 'model.name', parsed.modelId);
+    // `/model <id>` selects by id only, so clear any baseUrl disambiguator left
+    // by a previous model-picker selection — otherwise next launch would
+    // resolve to a different provider than this switch just chose.
+    persistSetting(settings, 'model.baseUrl', undefined);
     return parsed.modelId;
   }
 
   await config.switchModel(currentAuthType, modelArg, undefined);
   persistSetting(settings, 'model.name', modelArg);
+  persistSetting(settings, 'model.baseUrl', undefined);
   return modelArg;
 }
 

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -51,14 +51,16 @@ async function switchMainModel(
     persistSetting(settings, 'model.name', parsed.modelId);
     // `/model <id>` selects by id only, so clear any baseUrl disambiguator left
     // by a previous model-picker selection — otherwise next launch would
-    // resolve to a different provider than this switch just chose.
-    persistSetting(settings, 'model.baseUrl', undefined);
+    // resolve to a different provider than this switch just chose. Use an
+    // empty-string tombstone so the clear overrides a lower-scope value (an
+    // undefined write is dropped from JSON and would not override on merge).
+    persistSetting(settings, 'model.baseUrl', '');
     return parsed.modelId;
   }
 
   await config.switchModel(currentAuthType, modelArg, undefined);
   persistSetting(settings, 'model.name', modelArg);
-  persistSetting(settings, 'model.baseUrl', undefined);
+  persistSetting(settings, 'model.baseUrl', '');
   return modelArg;
 }
 

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -308,10 +308,73 @@ describe('<ModelDialog />', () => {
       'model.name',
       'gpt-4',
     );
+    // The selected provider has no baseUrl, so the disambiguator must be cleared.
+    expect(mockSettings.setValue).toHaveBeenCalledWith(
+      SettingScope.User,
+      'model.baseUrl',
+      undefined,
+    );
     expect(mockSettings.setValue).toHaveBeenCalledWith(
       SettingScope.User,
       'security.auth.selectedType',
       AuthType.USE_OPENAI,
+    );
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists model.baseUrl alongside model.name when the selected provider has a baseUrl', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const { props, mockSettings } = renderComponent({}, {
+      getModel: vi.fn(() => 'qwen3.7-max'),
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      switchModel,
+      getAllConfiguredModels: vi.fn(() => [
+        {
+          id: 'qwen3.7-max',
+          label: '[Token Plan] qwen3.7-max',
+          description: '',
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://token-plan.example.com/v1',
+          envKey: 'TOKEN_PLAN_KEY',
+        },
+        {
+          id: 'qwen3.7-max',
+          label: '[IdeaLab] qwen3.7-max',
+          description: '',
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://idealab.example.com/v1',
+          envKey: 'IDEALAB_KEY',
+        },
+      ]),
+      getContentGeneratorConfig: vi.fn(() => ({
+        authType: AuthType.USE_OPENAI,
+        model: 'qwen3.7-max',
+        baseUrl: 'https://idealab.example.com/v1',
+      })),
+    } as unknown as Partial<Config>);
+
+    const childOnSelect = mockedSelect.mock.calls[0][0].onSelect;
+    // Select the IdeaLab entry (second provider with the same id).
+    await childOnSelect(
+      `${AuthType.USE_OPENAI}::qwen3.7-max\0https://idealab.example.com/v1`,
+    );
+
+    expect(switchModel).toHaveBeenCalledWith(
+      AuthType.USE_OPENAI,
+      'qwen3.7-max',
+      {
+        baseUrl: 'https://idealab.example.com/v1',
+      },
+    );
+    expect(mockSettings.setValue).toHaveBeenCalledWith(
+      SettingScope.User,
+      'model.name',
+      'qwen3.7-max',
+    );
+    expect(mockSettings.setValue).toHaveBeenCalledWith(
+      SettingScope.User,
+      'model.baseUrl',
+      'https://idealab.example.com/v1',
     );
     expect(props.onClose).toHaveBeenCalledTimes(1);
   });

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -380,6 +380,63 @@ describe('<ModelDialog />', () => {
     expect(props.onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('falls back to the picker entry baseUrl when switchModel does not propagate it', async () => {
+    // Regression guard for the `after?.baseUrl ?? selectedEntry?.model.baseUrl`
+    // fallback: if switchModel succeeds but getContentGeneratorConfig returns a
+    // config WITHOUT baseUrl, the disambiguator must still be persisted from the
+    // selected picker entry's baseUrl — otherwise an empty-string tombstone would
+    // be written and the wrong same-id provider would resolve on next launch.
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const { props, mockSettings } = renderComponent({}, {
+      getModel: vi.fn(() => 'qwen3.7-max'),
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      switchModel,
+      getAllConfiguredModels: vi.fn(() => [
+        {
+          id: 'qwen3.7-max',
+          label: '[Token Plan] qwen3.7-max',
+          description: '',
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://token-plan.example.com/v1',
+          envKey: 'TOKEN_PLAN_KEY',
+        },
+        {
+          id: 'qwen3.7-max',
+          label: '[IdeaLab] qwen3.7-max',
+          description: '',
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://idealab.example.com/v1',
+          envKey: 'IDEALAB_KEY',
+        },
+      ]),
+      // Resolved config has NO baseUrl, so `after?.baseUrl` is undefined and the
+      // `?? selectedEntry?.model.baseUrl` fallback must supply the disambiguator.
+      getContentGeneratorConfig: vi.fn(() => ({
+        authType: AuthType.USE_OPENAI,
+        model: 'qwen3.7-max',
+      })),
+    } as unknown as Partial<Config>);
+
+    const childOnSelect = mockedSelect.mock.calls[0][0].onSelect;
+    // Select the IdeaLab entry (second provider with the same id).
+    await childOnSelect(
+      `${AuthType.USE_OPENAI}::qwen3.7-max\0https://idealab.example.com/v1`,
+    );
+
+    expect(mockSettings.setValue).toHaveBeenCalledWith(
+      SettingScope.User,
+      'model.name',
+      'qwen3.7-max',
+    );
+    // baseUrl comes from the picker entry, not the (baseUrl-less) resolved config.
+    expect(mockSettings.setValue).toHaveBeenCalledWith(
+      SettingScope.User,
+      'model.baseUrl',
+      'https://idealab.example.com/v1',
+    );
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
   it('shows MiniMax-M3 image + video modality and 1M context details', () => {
     const { getByText } = renderComponent({}, {
       getModel: vi.fn(() => 'MiniMax-M3'),

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -308,11 +308,12 @@ describe('<ModelDialog />', () => {
       'model.name',
       'gpt-4',
     );
-    // The selected provider has no baseUrl, so the disambiguator must be cleared.
+    // The selected provider has no baseUrl, so the disambiguator must be
+    // cleared with an empty-string tombstone (overrides any lower-scope value).
     expect(mockSettings.setValue).toHaveBeenCalledWith(
       SettingScope.User,
       'model.baseUrl',
-      undefined,
+      '',
     );
     expect(mockSettings.setValue).toHaveBeenCalledWith(
       SettingScope.User,

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -95,9 +95,15 @@ function maskApiKey(apiKey: string | undefined): string {
 function persistModelSelection(
   settings: ReturnType<typeof useSettings>,
   modelId: string,
+  baseUrl?: string,
 ): void {
   const scope = getPersistScopeForModelSelection(settings);
   settings.setValue(scope, 'model.name', modelId);
+  // Persist the paired baseUrl so the correct provider is restored on next
+  // launch when multiple providers share the same model id. Clear it when the
+  // selection has no baseUrl, otherwise a stale value would override the
+  // resolved provider.
+  settings.setValue(scope, 'model.baseUrl', baseUrl);
 }
 
 function persistAuthTypeSelection(
@@ -132,6 +138,7 @@ interface HandleModelSwitchSuccessParams {
   after: ContentGeneratorConfig | undefined;
   effectiveAuthType: AuthType | undefined;
   effectiveModelId: string;
+  effectiveBaseUrl: string | undefined;
   isRuntime: boolean;
 }
 
@@ -141,9 +148,10 @@ function handleModelSwitchSuccess({
   after,
   effectiveAuthType,
   effectiveModelId,
+  effectiveBaseUrl,
   isRuntime,
 }: HandleModelSwitchSuccessParams): void {
-  persistModelSelection(settings, effectiveModelId);
+  persistModelSelection(settings, effectiveModelId, effectiveBaseUrl);
   if (effectiveAuthType) {
     persistAuthTypeSelection(settings, effectiveAuthType);
   }
@@ -553,6 +561,10 @@ export function ModelDialog({
         after,
         effectiveAuthType,
         effectiveModelId,
+        // Persist the selected provider's baseUrl so the right provider is
+        // restored next launch when several share the same id. Runtime models
+        // are keyed by snapshot id, so no baseUrl disambiguator is stored.
+        effectiveBaseUrl: isRuntime ? undefined : selectedEntry?.model.baseUrl,
         isRuntime,
       });
       onClose();

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -563,9 +563,14 @@ export function ModelDialog({
         effectiveAuthType,
         effectiveModelId,
         // Persist the selected provider's baseUrl so the right provider is
-        // restored next launch when several share the same id. Runtime models
-        // are keyed by snapshot id, so no baseUrl disambiguator is stored.
-        effectiveBaseUrl: isRuntime ? undefined : selectedEntry?.model.baseUrl,
+        // restored next launch when several share the same id. Pair it with the
+        // same resolved config that effectiveModelId comes from (`after`) so the
+        // persisted (model.name, model.baseUrl) stays consistent even if
+        // switchModel transforms the id; fall back to the picker entry's
+        // baseUrl. Runtime models are keyed by snapshot id, so no disambiguator.
+        effectiveBaseUrl: isRuntime
+          ? undefined
+          : (after?.baseUrl ?? selectedEntry?.model.baseUrl),
         isRuntime,
       });
       onClose();

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -100,10 +100,11 @@ function persistModelSelection(
   const scope = getPersistScopeForModelSelection(settings);
   settings.setValue(scope, 'model.name', modelId);
   // Persist the paired baseUrl so the correct provider is restored on next
-  // launch when multiple providers share the same model id. Clear it when the
-  // selection has no baseUrl, otherwise a stale value would override the
-  // resolved provider.
-  settings.setValue(scope, 'model.baseUrl', baseUrl);
+  // launch when multiple providers share the same model id. When the selection
+  // has no baseUrl, write an empty-string tombstone (not undefined): undefined
+  // is dropped from JSON, so it would not override a stale model.baseUrl left
+  // in a lower-priority scope, whereas '' is a present value that does.
+  settings.setValue(scope, 'model.baseUrl', baseUrl ?? '');
 }
 
 function persistAuthTypeSelection(

--- a/packages/cli/src/utils/modelConfigUtils.test.ts
+++ b/packages/cli/src/utils/modelConfigUtils.test.ts
@@ -535,6 +535,30 @@ describe('modelConfigUtils', () => {
         );
       });
 
+      it('treats an empty-string tombstone as no disambiguator (first id match)', () => {
+        // A cleared selection persists model.baseUrl: '' so it can override a
+        // stale lower-scope value on merge; the resolver must treat '' as "no
+        // baseUrl" and fall back to the first id match rather than matching a
+        // provider whose baseUrl is literally empty.
+        mockResolved();
+        const settings = makeMockSettings({
+          model: { name: 'qwen3.7-max', baseUrl: '' },
+          modelProviders: {
+            [AuthType.USE_OPENAI]: [tokenPlan, ideaLab],
+          },
+        });
+
+        resolveCliGenerationConfig({
+          argv: {},
+          settings,
+          selectedAuthType: AuthType.USE_OPENAI,
+        });
+
+        expect(vi.mocked(resolveModelConfig)).toHaveBeenCalledWith(
+          expect.objectContaining({ modelProvider: tokenPlan }),
+        );
+      });
+
       it('ignores the persisted baseUrl when the model comes from argv.model, not settings', () => {
         mockResolved();
         const settings = makeMockSettings({

--- a/packages/cli/src/utils/modelConfigUtils.test.ts
+++ b/packages/cli/src/utils/modelConfigUtils.test.ts
@@ -444,6 +444,122 @@ describe('modelConfigUtils', () => {
       );
     });
 
+    describe('provider disambiguation by settings.model.baseUrl', () => {
+      const tokenPlan: ProviderModelConfig = {
+        id: 'qwen3.7-max',
+        name: '[Token Plan] qwen3.7-max',
+        baseUrl: 'https://token-plan.example.com/v1',
+        envKey: 'TOKEN_PLAN_KEY',
+      };
+      const ideaLab: ProviderModelConfig = {
+        id: 'qwen3.7-max',
+        name: '[IdeaLab] qwen3.7-max',
+        baseUrl: 'https://idealab.example.com/v1',
+        envKey: 'IDEALAB_KEY',
+      };
+
+      function mockResolved() {
+        vi.mocked(resolveModelConfig).mockReturnValue({
+          config: { model: 'qwen3.7-max', apiKey: '', baseUrl: '' },
+          sources: {},
+          warnings: [],
+        });
+      }
+
+      it('selects the provider matching the persisted baseUrl, not the first id match', () => {
+        mockResolved();
+        const settings = makeMockSettings({
+          model: {
+            name: 'qwen3.7-max',
+            baseUrl: 'https://idealab.example.com/v1',
+          },
+          modelProviders: {
+            [AuthType.USE_OPENAI]: [tokenPlan, ideaLab],
+          },
+        });
+
+        resolveCliGenerationConfig({
+          argv: {},
+          settings,
+          selectedAuthType: AuthType.USE_OPENAI,
+        });
+
+        // The IdeaLab provider (not the first-listed Token Plan) must be passed
+        // to resolveModelConfig, which is what makes sources.baseUrl.kind become
+        // 'modelProviders' and lets syncAfterAuthRefresh keep it after refresh.
+        expect(vi.mocked(resolveModelConfig)).toHaveBeenCalledWith(
+          expect.objectContaining({ modelProvider: ideaLab }),
+        );
+      });
+
+      it('falls back to the first id match when no baseUrl is persisted (backward compat)', () => {
+        mockResolved();
+        const settings = makeMockSettings({
+          model: { name: 'qwen3.7-max' },
+          modelProviders: {
+            [AuthType.USE_OPENAI]: [tokenPlan, ideaLab],
+          },
+        });
+
+        resolveCliGenerationConfig({
+          argv: {},
+          settings,
+          selectedAuthType: AuthType.USE_OPENAI,
+        });
+
+        expect(vi.mocked(resolveModelConfig)).toHaveBeenCalledWith(
+          expect.objectContaining({ modelProvider: tokenPlan }),
+        );
+      });
+
+      it('falls back to the first id match when the persisted baseUrl no longer matches any provider', () => {
+        mockResolved();
+        const settings = makeMockSettings({
+          model: {
+            name: 'qwen3.7-max',
+            baseUrl: 'https://removed.example.com/v1',
+          },
+          modelProviders: {
+            [AuthType.USE_OPENAI]: [tokenPlan, ideaLab],
+          },
+        });
+
+        resolveCliGenerationConfig({
+          argv: {},
+          settings,
+          selectedAuthType: AuthType.USE_OPENAI,
+        });
+
+        expect(vi.mocked(resolveModelConfig)).toHaveBeenCalledWith(
+          expect.objectContaining({ modelProvider: tokenPlan }),
+        );
+      });
+
+      it('ignores the persisted baseUrl when the model comes from argv.model, not settings', () => {
+        mockResolved();
+        const settings = makeMockSettings({
+          model: {
+            name: 'something-else',
+            baseUrl: 'https://idealab.example.com/v1',
+          },
+          modelProviders: {
+            [AuthType.USE_OPENAI]: [tokenPlan, ideaLab],
+          },
+        });
+
+        resolveCliGenerationConfig({
+          argv: { model: 'qwen3.7-max' },
+          settings,
+          selectedAuthType: AuthType.USE_OPENAI,
+        });
+
+        // argv-resolved model uses id-only lookup → first match.
+        expect(vi.mocked(resolveModelConfig)).toHaveBeenCalledWith(
+          expect.objectContaining({ modelProvider: tokenPlan }),
+        );
+      });
+    });
+
     it('strips a runtime snapshot prefix from settings.model.name (read-side self-heal)', () => {
       const modelProvider: ProviderModelConfig = {
         id: 'gpt-4o',

--- a/packages/cli/src/utils/modelConfigUtils.test.ts
+++ b/packages/cli/src/utils/modelConfigUtils.test.ts
@@ -512,7 +512,7 @@ describe('modelConfigUtils', () => {
         );
       });
 
-      it('falls back to the first id match when the persisted baseUrl no longer matches any provider', () => {
+      it('falls back to the first id match and emits a warning when the persisted baseUrl no longer matches any provider', () => {
         mockResolved();
         const settings = makeMockSettings({
           model: {
@@ -524,7 +524,7 @@ describe('modelConfigUtils', () => {
           },
         });
 
-        resolveCliGenerationConfig({
+        const result = resolveCliGenerationConfig({
           argv: {},
           settings,
           selectedAuthType: AuthType.USE_OPENAI,
@@ -532,6 +532,11 @@ describe('modelConfigUtils', () => {
 
         expect(vi.mocked(resolveModelConfig)).toHaveBeenCalledWith(
           expect.objectContaining({ modelProvider: tokenPlan }),
+        );
+        expect(result.warnings).toEqual(
+          expect.arrayContaining([
+            expect.stringContaining('https://removed.example.com/v1'),
+          ]),
         );
       });
 

--- a/packages/cli/src/utils/modelConfigUtils.ts
+++ b/packages/cli/src/utils/modelConfigUtils.ts
@@ -194,10 +194,13 @@ export function resolveCliGenerationConfig(
       //
       // Note: `settings` is already merged across user/workspace/system scopes.
       // Every writer of model.name (the picker, /model, ACP, provider install)
-      // writes model.baseUrl to the SAME scope, so the pair stays consistent.
-      // The only way they desync is a hand-edited config that sets model.name
-      // in a higher-priority scope without its paired baseUrl; the id-only
-      // fallback bounds the blast radius (it can only pick a same-id provider).
+      // also writes model.baseUrl in the SAME scope — a real URL, or an empty
+      // string tombstone when there is none. The tombstone matters because an
+      // omitted key cannot override a stale model.baseUrl in a lower-priority
+      // scope on merge, but '' (a present value) can. Empty string is treated
+      // as "no disambiguator" here. The only remaining desync is a hand-edited
+      // config that sets model.name in a higher scope with no baseUrl key at
+      // all; the id-only fallback bounds the blast radius to a same-id provider.
       const persistedBaseUrl = settings.model?.baseUrl;
       if (resolvedFromSettings && persistedBaseUrl) {
         modelProvider =

--- a/packages/cli/src/utils/modelConfigUtils.ts
+++ b/packages/cli/src/utils/modelConfigUtils.ts
@@ -182,6 +182,7 @@ export function resolveCliGenerationConfig(
   // so the resolver correctly uses the settings-selected model (no override occurs).
   // The old candidate-loop code that fell through to OPENAI_MODEL is gone.
   let modelProvider: ProviderModelConfig | undefined;
+  let disambiguationWarning: string | undefined;
   if (resolvedModel && authType && settings.modelProviders) {
     const providers = settings.modelProviders[authType];
     if (providers && Array.isArray(providers)) {
@@ -203,10 +204,19 @@ export function resolveCliGenerationConfig(
       // all; the id-only fallback bounds the blast radius to a same-id provider.
       const persistedBaseUrl = settings.model?.baseUrl;
       if (resolvedFromSettings && persistedBaseUrl) {
+        const exactMatch = providers.find(
+          (p) => p.id === resolvedModel && p.baseUrl === persistedBaseUrl,
+        );
         modelProvider =
-          providers.find(
-            (p) => p.id === resolvedModel && p.baseUrl === persistedBaseUrl,
-          ) ?? providers.find((p) => p.id === resolvedModel);
+          exactMatch ?? providers.find((p) => p.id === resolvedModel);
+        // Surface the silent fallback: the paired provider was removed or its
+        // baseUrl changed, so traffic now routes to a different same-id provider.
+        if (!exactMatch && modelProvider) {
+          disambiguationWarning =
+            `Persisted model.baseUrl '${persistedBaseUrl}' no longer matches any provider ` +
+            `for model '${resolvedModel}' (authType '${authType}'); using the first id match ` +
+            `('${modelProvider.baseUrl ?? '(default baseUrl)'}'). Re-select the model to update it.`;
+        }
       } else {
         modelProvider = providers.find((p) => p.id === resolvedModel);
       }
@@ -298,6 +308,7 @@ export function resolveCliGenerationConfig(
     sources: resolved.sources,
     warnings: [
       ...resolved.warnings,
+      ...(disambiguationWarning ? [disambiguationWarning] : []),
       ...(ignoredGenerationConfigWarning
         ? [ignoredGenerationConfigWarning]
         : []),

--- a/packages/cli/src/utils/modelConfigUtils.ts
+++ b/packages/cli/src/utils/modelConfigUtils.ts
@@ -191,6 +191,13 @@ export function resolveCliGenerationConfig(
       // Fall back to the first id match if the paired provider was edited or
       // removed (and for the legacy id-only case where no baseUrl was saved),
       // mirroring auth.ts:findModelConfig.
+      //
+      // Note: `settings` is already merged across user/workspace/system scopes.
+      // Every writer of model.name (the picker, /model, ACP, provider install)
+      // writes model.baseUrl to the SAME scope, so the pair stays consistent.
+      // The only way they desync is a hand-edited config that sets model.name
+      // in a higher-priority scope without its paired baseUrl; the id-only
+      // fallback bounds the blast radius (it can only pick a same-id provider).
       const persistedBaseUrl = settings.model?.baseUrl;
       if (resolvedFromSettings && persistedBaseUrl) {
         modelProvider =

--- a/packages/cli/src/utils/modelConfigUtils.ts
+++ b/packages/cli/src/utils/modelConfigUtils.ts
@@ -157,11 +157,15 @@ export function resolveCliGenerationConfig(
   // Env vars are ONLY considered when neither argv.model nor settings.model.name is set.
   let resolvedModel: string | undefined;
   let sourceEnvVar: string | undefined;
+  // Whether the model came from settings.model.name (vs argv/env). The persisted
+  // settings.model.baseUrl disambiguator only applies to this case.
+  let resolvedFromSettings = false;
   if (argv.model) {
     resolvedModel = argv.model;
   } else if (settings.model?.name) {
     // Self-heal configs already corrupted by older builds.
     resolvedModel = stripRuntimeSnapshotPrefix(settings.model.name);
+    resolvedFromSettings = true;
   } else if (authType && AUTH_ENV_MODEL_VARS[authType]) {
     // Only check env vars for the current auth type
     for (const envVar of AUTH_ENV_MODEL_VARS[authType]) {
@@ -181,7 +185,21 @@ export function resolveCliGenerationConfig(
   if (resolvedModel && authType && settings.modelProviders) {
     const providers = settings.modelProviders[authType];
     if (providers && Array.isArray(providers)) {
-      modelProvider = providers.find((p) => p.id === resolvedModel);
+      // When multiple providers share the same id, disambiguate by the
+      // persisted settings.model.baseUrl (written by the model picker). This
+      // only applies when the model itself came from settings.model.name.
+      // Fall back to the first id match if the paired provider was edited or
+      // removed (and for the legacy id-only case where no baseUrl was saved),
+      // mirroring auth.ts:findModelConfig.
+      const persistedBaseUrl = settings.model?.baseUrl;
+      if (resolvedFromSettings && persistedBaseUrl) {
+        modelProvider =
+          providers.find(
+            (p) => p.id === resolvedModel && p.baseUrl === persistedBaseUrl,
+          ) ?? providers.find((p) => p.id === resolvedModel);
+      } else {
+        modelProvider = providers.find((p) => p.id === resolvedModel);
+      }
     }
   }
 

--- a/packages/core/src/providers/__tests__/install.test.ts
+++ b/packages/core/src/providers/__tests__/install.test.ts
@@ -153,6 +153,8 @@ describe('applyProviderInstallPlan', () => {
       AuthType.USE_OPENAI,
     );
     expect(adapter.setValue).toHaveBeenCalledWith('model.name', 'new-model');
+    // Id-only model selection must clear any stale baseUrl disambiguator.
+    expect(adapter.setValue).toHaveBeenCalledWith('model.baseUrl', undefined);
     expect(adapter.persist).toHaveBeenCalled();
     expect(reloadModelProviders).toHaveBeenCalledWith({
       [AuthType.USE_OPENAI]: [

--- a/packages/core/src/providers/__tests__/install.test.ts
+++ b/packages/core/src/providers/__tests__/install.test.ts
@@ -153,8 +153,9 @@ describe('applyProviderInstallPlan', () => {
       AuthType.USE_OPENAI,
     );
     expect(adapter.setValue).toHaveBeenCalledWith('model.name', 'new-model');
-    // Id-only model selection must clear any stale baseUrl disambiguator.
-    expect(adapter.setValue).toHaveBeenCalledWith('model.baseUrl', undefined);
+    // Id-only model selection must clear any stale baseUrl disambiguator
+    // (empty-string tombstone overrides a lower-scope value on merge).
+    expect(adapter.setValue).toHaveBeenCalledWith('model.baseUrl', '');
     expect(adapter.persist).toHaveBeenCalled();
     expect(reloadModelProviders).toHaveBeenCalledWith({
       [AuthType.USE_OPENAI]: [

--- a/packages/core/src/providers/install.ts
+++ b/packages/core/src/providers/install.ts
@@ -210,6 +210,10 @@ export async function applyProviderInstallPlan(
     currentStep = 'modelSelection';
     if (plan.modelSelection?.modelId) {
       settings.setValue('model.name', plan.modelSelection.modelId);
+      // The plan selects by model id only, so clear any baseUrl disambiguator
+      // left by a previous model-picker selection — otherwise the next launch
+      // could resolve to a stale provider sharing this model id.
+      settings.setValue('model.baseUrl', undefined);
     }
 
     // Provider state metadata

--- a/packages/core/src/providers/install.ts
+++ b/packages/core/src/providers/install.ts
@@ -212,8 +212,10 @@ export async function applyProviderInstallPlan(
       settings.setValue('model.name', plan.modelSelection.modelId);
       // The plan selects by model id only, so clear any baseUrl disambiguator
       // left by a previous model-picker selection — otherwise the next launch
-      // could resolve to a stale provider sharing this model id.
-      settings.setValue('model.baseUrl', undefined);
+      // could resolve to a stale provider sharing this model id. Empty-string
+      // tombstone so the clear overrides a lower-scope value on merge (an
+      // undefined write is dropped from JSON and would not override).
+      settings.setValue('model.baseUrl', '');
     }
 
     // Provider state metadata

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -474,6 +474,10 @@
           "description": "The model to use for conversations.",
           "type": "string"
         },
+        "baseUrl": {
+          "description": "Base URL paired with model.name; disambiguates which provider to use when multiple modelProviders entries share the same model id.",
+          "type": "string"
+        },
         "maxSessionTurns": {
           "description": "Maximum number of user/model/tool turns to keep in a session. -1 means unlimited.",
           "type": "number",


### PR DESCRIPTION
## What this PR does

Makes the model picker remember which provider you selected when several `modelProviders` entries share the same model id but point at different `baseUrl`s. The selected provider's `baseUrl` is now persisted alongside the model name and used to resolve the exact provider on the next launch, so its `baseUrl`, `envKey`, and `generationConfig` are restored instead of silently falling back to the first entry with that id.

Concretely: the picker persists a new `model.baseUrl` setting paired with `model.name`; startup resolution (`resolveCliGenerationConfig`) and pre-flight auth validation (`validateAuthMethod`) disambiguate the provider by that `baseUrl`, preferring the exact `id + baseUrl` match and falling back to the first id match when the paired provider was edited or removed. Every id-only writer of `model.name` (the `/model <id>` command, ACP `setModel`, the generic `qwen/settings/setCoreValue` RPC, and provider install) clears `model.baseUrl` with an empty-string tombstone so a stale disambiguator from a previous selection can't override a later id-only switch — including across settings scopes, where an omitted key would not override a lower-scope value on merge.

This aligns the persistence/resolution layer with `ModelRegistry`'s existing `id + baseUrl` composite key and the `syncAfterAuthRefresh` exact-match path, which were already correct at runtime. The change is contained to the CLI package plus the core provider-install writer.

## Why it's needed

With multiple providers registering the same model id (e.g. `qwen3.7-max` on Token Plan, IdeaLab, and BFF) selecting a non-first one in the picker worked for the live session but was forgotten on restart: persistence only saved `model.name`, and startup matched the provider by id alone (`providers.find(p => p.id === resolvedModel)`), always resolving to the first entry. The user's chosen `baseUrl`/`envKey` were silently replaced. Fixes #5173 (and very likely the sibling report #4877, the same root cause on the picker surface).

## Reviewer Test Plan

### How to verify

Configure three OpenAI providers sharing one model id with distinct base URLs and env keys:

```jsonc
"modelProviders": {
  "openai": [
    { "id": "qwen3.7-max", "baseUrl": "https://token-plan.example/v1", "envKey": "TOKEN_PLAN_KEY" },
    { "id": "qwen3.7-max", "baseUrl": "https://idealab.example/v1",   "envKey": "IDEALAB_KEY" },
    { "id": "qwen3.7-max", "baseUrl": "https://bff.example/v1",       "envKey": "BFF_KEY" }
  ]
}
```

1. Run `qwen`, `/model`, pick the **IdeaLab** `qwen3.7-max`. The info line shows IdeaLab's Base URL.
2. Restart `qwen`. Expected (after): the model still resolves to IdeaLab's `baseUrl`/`envKey`; `~/.qwen/settings.json` now holds `model.name: "qwen3.7-max"` + `model.baseUrl: "https://idealab.example/v1"`. Before this PR it reverted to Token Plan (first entry).
3. Run `/model qwen3.7-max` (bare id): live-switches to the first provider, `model.baseUrl` is cleared (empty string), and a restart resolves to that same first provider — no stale IdeaLab.

### Evidence (Before & After)

N/A (configuration/persistence + auth-resolution logic, no TUI rendering change). Verified via unit tests:

```
✓ packages/cli/src/utils/modelConfigUtils.test.ts   (disambiguation: exact match / backward-compat first match / removed-provider fallback / empty-string tombstone / argv ignores persisted baseUrl)
✓ packages/cli/src/config/auth.test.ts              (pre-flight auth validates the selected duplicate-id provider's envKey)
✓ packages/cli/src/ui/components/ModelDialog.test.tsx
✓ packages/cli/src/ui/commands/modelCommand.test.ts
✓ packages/cli/src/acp-integration/session/Session.test.ts
✓ packages/cli/src/acp-integration/acpAgent.test.ts (setCoreValue model.name clears model.baseUrl)
✓ packages/core/src/providers/__tests__/install.test.ts
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local unit tests via `npx vitest run`; typecheck (`tsc --noEmit`) and eslint clean on changed files.

## Risk & Scope

- Main risk or tradeoff: introduces a new `model.baseUrl` setting that participates in provider resolution. Backward compatible — when unset, behavior is unchanged (first id match). The empty-string value is a deliberate tombstone meaning "no disambiguator".
- Not validated / out of scope: a known narrow cross-scope edge remains — if a *pre-existing/hand-edited* higher-priority scope defines `model.name` (id-only, no tombstone) for a duplicate id while a lower scope holds a `model.baseUrl` that coincidentally matches one of those providers, the lower-scope disambiguator can still apply on merge. The id-only fallback bounds the blast radius to a same-id provider. A complete fix needs per-scope source tracking threaded through `loadCliConfig` (Settings → LoadedSettings), which is disproportionately invasive for this edge; left as a follow-up and documented in code at the resolver site. web-shell/desktop pickers (separate daemon-RPC persistence) are also out of scope.
- Breaking changes / migration notes: none. No migration required.

## Linked Issues

Fixes #5173

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让模型选择器在多个 `modelProviders` 条目共享同一 model id、但 `baseUrl` 不同的情况下，记住你选的是哪个 provider。现在选中 provider 的 `baseUrl` 会与 model name 一起持久化，并在下次启动时用它精确解析对应 provider，从而恢复其 `baseUrl`、`envKey` 和 `generationConfig`，而不是默默回退到第一个同 id 条目。

具体来说：选择器持久化一个与 `model.name` 配对的新设置 `model.baseUrl`；启动解析（`resolveCliGenerationConfig`）和预检鉴权（`validateAuthMethod`）按该 `baseUrl` 消歧，优先精确匹配 `id + baseUrl`，当配对 provider 被改/删时回退到首个 id 匹配。所有按 id-only 写 `model.name` 的路径（`/model <id>` 命令、ACP `setModel`、通用的 `qwen/settings/setCoreValue` RPC、provider 安装）都会用空串 tombstone 清掉 `model.baseUrl`，防止上一次选择留下的陈旧消歧值覆盖后续的 id-only 切换——包括跨 settings scope 的情形（写 undefined 会被 JSON 丢弃，无法在 merge 时覆盖低优先级 scope 的值，空串可以）。

这让持久化/解析层与 `ModelRegistry` 既有的 `id + baseUrl` 复合键、以及运行时已正确的 `syncAfterAuthRefresh` 精确匹配路径保持一致。改动范围限于 CLI 包加上 core 的 provider 安装写入点。

## 为什么需要

当多个 provider 注册同一 model id（如 `qwen3.7-max` 同时在 Token Plan、IdeaLab、BFF）时，在选择器里选非第一个对当前会话有效，但重启后丢失：持久化只存了 `model.name`，启动时仅按 id 匹配 provider（`providers.find(p => p.id === resolvedModel)`），永远解析到第一个条目，用户选的 `baseUrl`/`envKey` 被静默替换。修复 #5173（很可能也一并修复同根因的 #4877）。

## 复核测试计划

### 如何验证

配置三个共享同一 model id、base URL 和 env key 各不相同的 OpenAI provider（见上方英文 JSON）：

1. 运行 `qwen`，`/model`，选 **IdeaLab** 的 `qwen3.7-max`，信息行显示 IdeaLab 的 Base URL。
2. 重启 `qwen`。预期（修复后）：模型仍解析到 IdeaLab 的 `baseUrl`/`envKey`；`~/.qwen/settings.json` 现在含 `model.name: "qwen3.7-max"` + `model.baseUrl: "https://idealab.example/v1"`。修复前会退回 Token Plan（第一个条目）。
3. 运行 `/model qwen3.7-max`（裸 id）：实时切到第一个 provider，`model.baseUrl` 被清为空串，重启后解析到同一个第一个 provider —— 没有陈旧的 IdeaLab。

### 证据（前/后）

N/A（配置/持久化 + 鉴权解析逻辑，无 TUI 渲染变化）。通过单测验证（见上方英文测试列表）。

### 测试平台

见上表（macOS ✅；Windows/Linux ⚠️ 未本地测，依赖 CI）。

## 风险与范围

- 主要风险/取舍：引入参与 provider 解析的新设置 `model.baseUrl`；向后兼容——未设置时行为不变（首个 id 匹配）。空串是刻意的 tombstone，表示「无消歧值」。
- 未验证/范围外：仍有一个已知的窄边界——若**预先存在/手改**的高优先级 scope 定义了 id-only 的 `model.name`（无 tombstone）且低 scope 持有恰好匹配某 provider 的 `model.baseUrl`，merge 时低 scope 的消歧值仍可能生效；id-only 回退把影响限定在同 id provider 内。完整修复需把 per-scope 来源信息穿过 `loadCliConfig`（Settings → LoadedSettings），相对此窄边界过于侵入，留作 follow-up 并已在 resolver 处代码注释说明。web-shell/desktop 选择器（独立 daemon-RPC 持久化）同样在范围外。
- 破坏性变更/迁移：无。

## 关联 Issue

Fixes #5173

</details>
