### PR TITLE
fix(plan-gate): isolate gate agent AbortSignal from parent signal chain

### DIFF
--- a/packages/core/src/plan-gate/gateReviewAgents.ts
+++ b/packages/core/src/plan-gate/gateReviewAgents.ts
@@ -114,22 +114,19 @@ export function formatEvidence(bundle: EvidenceBundle): string {
  * Signal isolation: The gate agent creates its own independent AbortController
  * with a timeout, rather than directly inheriting the parent's signal. This
  * prevents transient parent-side issues (stream errors, round cleanup) from
- * cascading into the gate agent. The parent signal is only pre-checked before
- * starting — it is NOT monitored during execution. If the parent is already
- * aborted when this function is called, it throws immediately.
+ * cascading into the gate agent. The parent signal is intentionally not
+ * checked or monitored — the gate agent's own 5-minute timeout (matching
+ * runConfig.max_time_minutes) is the sole cancellation mechanism.
  *
  * Returns the parsed `GateAgentResult`, or throws on unrecoverable failure.
  */
 export async function runGateAgent(
   config: Config,
   bundle: EvidenceBundle,
-  parentSignal: AbortSignal,
+  // parentSignal is accepted for API consistency but intentionally unused:
+  // the gate agent is fully isolated from parent-side aborts.
+  _parentSignal: AbortSignal,
 ): Promise<GateAgentResult> {
-  // Fast-fail if the parent context is already cancelled before we start
-  if (parentSignal.aborted) {
-    throw new Error('Parent signal already aborted before gate agent start');
-  }
-
   const evidence = formatEvidence(bundle);
   const taskPrompt = buildReviewPrompt(evidence);
 

--- a/packages/core/src/plan-gate/gateReviewAgents.ts
+++ b/packages/core/src/plan-gate/gateReviewAgents.ts
@@ -211,8 +211,11 @@ export async function runGateAgent(
       }
     }
     cleanup();
-    // Abort the gate controller to clean up any remaining listeners
-    gateAbortController.abort();
+    // Abort only if the controller hasn't been aborted yet (i.e., timeout didn't fire)
+    // This ensures no lingering timers or listeners, but avoids unnecessary abort events
+    if (!gateAbortController.signal.aborted) {
+      gateAbortController.abort();
+    }
   }
 }
 

--- a/packages/core/src/plan-gate/gateReviewAgents.ts
+++ b/packages/core/src/plan-gate/gateReviewAgents.ts
@@ -15,10 +15,11 @@ import { createDebugLogger } from '../utils/debugLogger.js';
 const debugLogger = createDebugLogger('GATE_REVIEW_AGENTS');
 
 /**
- * Timeout for the gate agent in milliseconds. The gate agent should complete
- * within a reasonable time (typically 1-2 minutes for a plan review).
+ * Timeout for the gate agent in milliseconds. The gate agent typically
+ * completes within 1–2 minutes; this 5-minute ceiling accounts for the
+ * runConfig.max_time_minutes limit and provides a safety net against hangs.
  */
-const GATE_AGENT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes, matching runConfig.max_time_minutes
+const GATE_AGENT_TIMEOUT_MS = 5 * 60 * 1000;
 
 // ── Gate agent prompt ──────────────────────────────────────────────────
 
@@ -113,8 +114,9 @@ export function formatEvidence(bundle: EvidenceBundle): string {
  * Signal isolation: The gate agent creates its own independent AbortController
  * with a timeout, rather than directly inheriting the parent's signal. This
  * prevents transient parent-side issues (stream errors, round cleanup) from
- * cascading into the gate agent. The parent signal is only monitored for
- * genuine user-initiated cancellations.
+ * cascading into the gate agent. The parent signal is only pre-checked before
+ * starting — it is NOT monitored during execution. If the parent is already
+ * aborted when this function is called, it throws immediately.
  *
  * Returns the parsed `GateAgentResult`, or throws on unrecoverable failure.
  */

--- a/packages/core/src/plan-gate/gateReviewAgents.ts
+++ b/packages/core/src/plan-gate/gateReviewAgents.ts
@@ -14,6 +14,12 @@ import { createDebugLogger } from '../utils/debugLogger.js';
 
 const debugLogger = createDebugLogger('GATE_REVIEW_AGENTS');
 
+/**
+ * Timeout for the gate agent in milliseconds. The gate agent should complete
+ * within a reasonable time (typically 1-2 minutes for a plan review).
+ */
+const GATE_AGENT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes, matching runConfig.max_time_minutes
+
 // ── Gate agent prompt ──────────────────────────────────────────────────
 
 function buildReviewPrompt(evidence: string): string {
@@ -104,13 +110,24 @@ export function formatEvidence(bundle: EvidenceBundle): string {
  * Runs the gate review agent via `createAgentHeadless`. The agent operates
  * under a forced-PLAN config override and cannot spawn nested agents.
  *
+ * Signal isolation: The gate agent creates its own independent AbortController
+ * with a timeout, rather than directly inheriting the parent's signal. This
+ * prevents transient parent-side issues (stream errors, round cleanup) from
+ * cascading into the gate agent. The parent signal is only monitored for
+ * genuine user-initiated cancellations.
+ *
  * Returns the parsed `GateAgentResult`, or throws on unrecoverable failure.
  */
 export async function runGateAgent(
   config: Config,
   bundle: EvidenceBundle,
-  signal: AbortSignal,
+  parentSignal: AbortSignal,
 ): Promise<GateAgentResult> {
+  // Fast-fail if the parent context is already cancelled before we start
+  if (parentSignal.aborted) {
+    throw new Error('Parent signal already aborted before gate agent start');
+  }
+
   const evidence = formatEvidence(bundle);
   const taskPrompt = buildReviewPrompt(evidence);
 
@@ -129,6 +146,27 @@ export async function runGateAgent(
     ApprovalMode.PLAN,
   );
 
+  // Create an independent AbortController for the gate agent.
+  // This isolates the gate agent from transient parent-side aborts
+  // (e.g., stream errors, round cleanup, NO_FINISH_REASON retries).
+  // The gate agent has its own timeout (GATE_AGENT_TIMEOUT_MS) to prevent
+  // indefinite hangs. We deliberately do NOT propagate parent aborts here
+  // because:
+  // 1. The gate agent is a critical review step that should complete if possible
+  // 2. Parent aborts are often transient (stream retries, round cleanup)
+  // 3. The gate agent's own timeout provides a safety net
+  // If the parent is genuinely cancelled (user closes session), the timeout
+  // will eventually clean up, or the parent's cleanup logic will handle it.
+  const gateAbortController = new AbortController();
+
+  // Add a timeout so the gate agent doesn't hang indefinitely
+  const timeoutId = setTimeout(() => {
+    debugLogger.warn(
+      `[runGateAgent] Gate agent timed out after ${GATE_AGENT_TIMEOUT_MS}ms`,
+    );
+    gateAbortController.abort(new Error('Gate agent timeout'));
+  }, GATE_AGENT_TIMEOUT_MS);
+
   let disposeSubagent: (() => Promise<void>) | undefined;
 
   try {
@@ -142,7 +180,8 @@ export async function runGateAgent(
     const contextState = new ContextState();
     contextState.set('task_prompt', taskPrompt);
 
-    await subagent.execute(contextState, signal);
+    // Pass the isolated gate signal instead of the parent signal
+    await subagent.execute(contextState, gateAbortController.signal);
 
     const terminateMode = subagent.getTerminateMode();
     const rawText = subagent.getFinalText();
@@ -159,6 +198,7 @@ export async function runGateAgent(
 
     return parseGateAgentResult(rawText);
   } finally {
+    clearTimeout(timeoutId);
     // Dispose the subagent (stops its per-spawn ToolRegistry and
     // unregisters per-agent hooks, preventing listener leaks).
     if (disposeSubagent) {
@@ -171,6 +211,8 @@ export async function runGateAgent(
       }
     }
     cleanup();
+    // Abort the gate controller to clean up any remaining listeners
+    gateAbortController.abort();
   }
 }
 

--- a/packages/core/src/plan-gate/gateReviewAgents.ts
+++ b/packages/core/src/plan-gate/gateReviewAgents.ts
@@ -16,8 +16,9 @@ const debugLogger = createDebugLogger('GATE_REVIEW_AGENTS');
 
 /**
  * Timeout for the gate agent in milliseconds. The gate agent typically
- * completes within 1–2 minutes; this 5-minute ceiling accounts for the
- * runConfig.max_time_minutes limit and provides a safety net against hangs.
+ * completes within 1–2 minutes; this is a fixed 5-minute ceiling that
+ * coincides with the typical runConfig.max_time_minutes setting (5 min)
+ * but is independent of it. Provides a safety net against hangs.
  */
 const GATE_AGENT_TIMEOUT_MS = 5 * 60 * 1000;
 

--- a/packages/core/src/plan-gate/planApprovalGate.ts
+++ b/packages/core/src/plan-gate/planApprovalGate.ts
@@ -144,9 +144,9 @@ async function runAgentWithRetry(
 ): Promise<GateAgentResult | null> {
   // Entry-time check: if the parent signal is already aborted before we start,
   // respect it to avoid launching a 5-minute gate agent for an obvious cancellation.
-  // This is the ONLY place we check signal.aborted — during execution, the gate
-  // agent is signal-isolated (see runGateAgent) to prevent transient parent-side
-  // aborts from cascading.
+  // This is the only synchronous signal.aborted check before calling runGateAgent.
+  // The retry loop remains abort-aware via delay() which rejects on abort,
+  // providing a cancellation point between attempts without monitoring mid-flight.
   if (signal.aborted) {
     debugLogger.warn(
       'Gate agent skipped: parent signal already aborted at entry',

--- a/packages/core/src/plan-gate/planApprovalGate.ts
+++ b/packages/core/src/plan-gate/planApprovalGate.ts
@@ -142,12 +142,19 @@ async function runAgentWithRetry(
   bundle: EvidenceBundle,
   signal: AbortSignal,
 ): Promise<GateAgentResult | null> {
+  // Entry-time check: if the parent signal is already aborted before we start,
+  // respect it to avoid launching a 5-minute gate agent for an obvious cancellation.
+  // This is the ONLY place we check signal.aborted — during execution, the gate
+  // agent is signal-isolated (see runGateAgent) to prevent transient parent-side
+  // aborts from cascading.
+  if (signal.aborted) {
+    debugLogger.warn(
+      'Gate agent skipped: parent signal already aborted at entry',
+    );
+    return null;
+  }
+
   for (let attempt = 1; attempt <= MAX_AGENT_RETRIES; attempt++) {
-    // Note: We deliberately do NOT check signal.aborted here.
-    // The gate agent is signal-isolated (see runGateAgent), so parent-side
-    // aborts are typically transient (stream errors, round cleanup). The
-    // gate agent has its own 5-minute timeout as the safety net. If the
-    // parent is truly gone, the caller will discard the result anyway.
     try {
       return await runGateAgent(config, bundle, signal);
     } catch (error) {
@@ -161,9 +168,9 @@ async function runAgentWithRetry(
         );
         return null;
       }
-      // Abort-aware delay: wait 1s between retries using the existing
-      // `delay()` from utils/retry.ts, which rejects when the signal
-      // is aborted. A cancellation during the wait breaks the loop
+      // Abort-aware delay: wait 1s between retries (not after the final attempt).
+      // Uses the existing `delay()` from utils/retry.ts, which rejects when the
+      // signal is aborted. A cancellation during the wait breaks the loop
       // immediately rather than proceeding to another rapid-fire attempt.
       try {
         await delay(1000, signal);

--- a/packages/core/src/plan-gate/planApprovalGate.ts
+++ b/packages/core/src/plan-gate/planApprovalGate.ts
@@ -170,10 +170,15 @@ async function runAgentWithRetry(
 
 /**
  * Sleep for `ms` milliseconds, but return early if `signal` is aborted.
+ * Attaches the abort listener first, then re-checks `signal.aborted` to
+ * eliminate the race window between the initial check and listener setup.
  */
 function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {
-  if (signal.aborted) return Promise.resolve();
   return new Promise<void>((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
     const onAbort = () => {
       clearTimeout(timer);
       resolve();
@@ -183,6 +188,12 @@ function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {
       resolve();
     }, ms);
     signal.addEventListener('abort', onAbort, { once: true });
+    // Re-check after attaching listener to close the race window
+    if (signal.aborted) {
+      clearTimeout(timer);
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }
   });
 }
 

--- a/packages/core/src/plan-gate/planApprovalGate.ts
+++ b/packages/core/src/plan-gate/planApprovalGate.ts
@@ -142,8 +142,16 @@ async function runAgentWithRetry(
   signal: AbortSignal,
 ): Promise<GateAgentResult | null> {
   for (let attempt = 1; attempt <= MAX_AGENT_RETRIES; attempt++) {
+    // Check if the parent signal is already aborted before starting.
+    // Note: This check is for genuine user-initiated cancellations.
+    // Transient parent-side aborts (e.g., stream errors) should not
+    // prevent retries since runGateAgent now isolates the gate agent
+    // from parent signal propagation.
     if (signal.aborted) {
-      debugLogger.warn('Gate agent skipped: signal already aborted');
+      debugLogger.warn(
+        `Gate agent skipped on attempt ${attempt}: parent signal already aborted`,
+      );
+      // If the signal is aborted, don't retry — the user/session is gone
       return null;
     }
     try {
@@ -159,6 +167,8 @@ async function runAgentWithRetry(
         );
         return null;
       }
+      // Add a small delay between retries to allow transient issues to settle
+      await new Promise((resolve) => setTimeout(resolve, 1000));
     }
   }
   return null;

--- a/packages/core/src/plan-gate/planApprovalGate.ts
+++ b/packages/core/src/plan-gate/planApprovalGate.ts
@@ -28,6 +28,7 @@ import {
 } from './types.js';
 import { runGateAgent } from './gateReviewAgents.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import { delay } from '../utils/retry.js';
 
 const debugLogger = createDebugLogger('PLAN_APPROVAL_GATE');
 
@@ -160,41 +161,22 @@ async function runAgentWithRetry(
         );
         return null;
       }
-      // Abort-aware delay: wait 1s between retries, but bail out early
-      // if the parent signal is aborted during the wait.
-      await abortableSleep(1000, signal);
+      // Abort-aware delay: wait 1s between retries using the existing
+      // `delay()` from utils/retry.ts, which rejects when the signal
+      // is aborted. A cancellation during the wait breaks the loop
+      // immediately rather than proceeding to another rapid-fire attempt.
+      try {
+        await delay(1000, signal);
+      } catch {
+        // Signal aborted during delay — stop retrying
+        debugLogger.warn(
+          `Gate agent retry loop cancelled during backoff delay (attempt ${attempt}/${MAX_AGENT_RETRIES})`,
+        );
+        return null;
+      }
     }
   }
   return null;
-}
-
-/**
- * Sleep for `ms` milliseconds, but return early if `signal` is aborted.
- * Attaches the abort listener first, then re-checks `signal.aborted` to
- * eliminate the race window between the initial check and listener setup.
- */
-function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {
-  return new Promise<void>((resolve) => {
-    if (signal.aborted) {
-      resolve();
-      return;
-    }
-    const onAbort = () => {
-      clearTimeout(timer);
-      resolve();
-    };
-    const timer = setTimeout(() => {
-      signal.removeEventListener('abort', onAbort);
-      resolve();
-    }, ms);
-    signal.addEventListener('abort', onAbort, { once: true });
-    // Re-check after attaching listener to close the race window
-    if (signal.aborted) {
-      clearTimeout(timer);
-      signal.removeEventListener('abort', onAbort);
-      resolve();
-    }
-  });
 }
 
 // ── Finding id assignment ──────────────────────────────────────────────

--- a/packages/core/src/plan-gate/planApprovalGate.ts
+++ b/packages/core/src/plan-gate/planApprovalGate.ts
@@ -142,18 +142,11 @@ async function runAgentWithRetry(
   signal: AbortSignal,
 ): Promise<GateAgentResult | null> {
   for (let attempt = 1; attempt <= MAX_AGENT_RETRIES; attempt++) {
-    // Check if the parent signal is already aborted before starting.
-    // Note: This check is for genuine user-initiated cancellations.
-    // Transient parent-side aborts (e.g., stream errors) should not
-    // prevent retries since runGateAgent now isolates the gate agent
-    // from parent signal propagation.
-    if (signal.aborted) {
-      debugLogger.warn(
-        `Gate agent skipped on attempt ${attempt}: parent signal already aborted`,
-      );
-      // If the signal is aborted, don't retry — the user/session is gone
-      return null;
-    }
+    // Note: We deliberately do NOT check signal.aborted here.
+    // The gate agent is signal-isolated (see runGateAgent), so parent-side
+    // aborts are typically transient (stream errors, round cleanup). The
+    // gate agent has its own 5-minute timeout as the safety net. If the
+    // parent is truly gone, the caller will discard the result anyway.
     try {
       return await runGateAgent(config, bundle, signal);
     } catch (error) {
@@ -167,11 +160,30 @@ async function runAgentWithRetry(
         );
         return null;
       }
-      // Add a small delay between retries to allow transient issues to settle
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      // Abort-aware delay: wait 1s between retries, but bail out early
+      // if the parent signal is aborted during the wait.
+      await abortableSleep(1000, signal);
     }
   }
   return null;
+}
+
+/**
+ * Sleep for `ms` milliseconds, but return early if `signal` is aborted.
+ */
+function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
 }
 
 // ── Finding id assignment ──────────────────────────────────────────────

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -146,7 +146,7 @@ export function isUnattendedMode(): boolean {
  * @param signal Optional signal used to abort the delay.
  * @returns A promise that resolves after the delay.
  */
-function delay(ms: number, signal?: AbortSignal): Promise<void> {
+export function delay(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
     if (signal?.aborted) {
       return reject(new Error('Retry aborted by signal'));


### PR DESCRIPTION
## What this PR does

Isolates the Plan Approval Gate review agent from the parent abort-signal chain so transient parent-side aborts can no longer cancel it, and makes the gate's retry loop genuinely retry instead of collapsing to a single attempt. Three changes: (1) `gateReviewAgents.ts` — `runGateAgent` now runs the gate subagent under its own dedicated `AbortController` with a fixed 5-minute timeout (`GATE_AGENT_TIMEOUT_MS`) instead of the inherited parent signal; the parent-signal parameter is kept for signature stability but intentionally unused (renamed `_parentSignal`), and the `finally` block clears the timeout and aborts the controller if it hasn't already fired so no timers or listeners leak. (2) `planApprovalGate.ts` — `runAgentWithRetry` replaces the per-iteration `signal.aborted` check with a single entry-time check (skip launching a gate agent at all if the parent is already aborted), and adds an abort-aware `delay(1000, signal)` backoff between attempts that breaks the loop immediately if the parent is cancelled during the wait. (3) `retry.ts` — the existing `delay()` helper is exported so the gate can reuse it (additive, no behavior change).

## Why it's needed

In AUTO/YOLO pre-plan mode, calling `exit_plan_mode` could leave the user permanently stuck in plan mode through an infinite retry loop. The gate review agent inherited the parent's abort signal all the way down the chain (`masterAbortController → roundAbortController → processFunctionCalls → ExitPlanModeToolInvocation.execute → runPlanApprovalGate → runGateAgent → subagent.execute`). When the parent hit a *transient* condition — e.g. a `NO_FINISH_REASON` stream retry or per-round cleanup — the abort cascaded into the gate agent and cancelled it (`mode=CANCELLED`, no usable output). Compounding this, `runAgentWithRetry` checked `signal.aborted` at the top of every loop iteration, so once the signal was aborted the remaining attempts were skipped instantly — "3 retries" effectively became "1 retry." The gate then reported **unavailable**, `exit_plan_mode` returned an error, the model re-called `exit_plan_mode`, and the same transient failure repeated indefinitely. Representative logs:

```
[WARN] [QWEN_CODE_CHAT] Invalid stream [NO_FINISH_REASON] (retry 1/2)
[WARN] [PLAN_APPROVAL_GATE] Gate agent attempt 1/3 failed: Gate agent terminated with mode=CANCELLED and no usable output
[WARN] [PLAN_APPROVAL_GATE] Gate agent skipped: signal already aborted
[REPAIR] synthesized 1 functionResponse(s): exit_plan_mode(...)
```

Giving the gate agent its own signal + timeout breaks the cascade, and the abort-aware backoff restores real retries while still honoring genuine cancellation at the loop boundaries.

## Reviewer Test Plan

### How to verify

This is non-user-visible signal/retry logic; confirm via the plan-gate suites, typecheck, and build (from repo root):

```
npx vitest run packages/core/src/plan-gate/planApprovalGate.test.ts packages/core/src/plan-gate/gateReviewAgents.test.ts
npm run typecheck --workspace=packages/core
npm run build --workspace=packages/core
```

Behaviorally: enter plan mode under AUTO/YOLO pre-plan mode and trigger `exit_plan_mode` while the parent stream hits a transient `NO_FINISH_REASON` retry. Before — the gate agent is cancelled, retries are skipped, the gate returns "unavailable," and `exit_plan_mode` loops without ever exiting plan mode. After — the gate agent runs under its own signal, survives the transient parent abort, completes its review, and plan mode exits.

A maintainer independently verified this on a real build — a real-code A/B that reproduces the exact bug on the merge-base and confirms the fix on the PR head, plus an integrated TUI run: https://github.com/QwenLM/qwen-code/pull/5185#issuecomment-4739065270

### Evidence (Before & After)

Before — `exit_plan_mode` infinite-retry loop; Plan Approval Gate reports "unavailable"; user cannot leave plan mode (log signature above). After — the gate agent is isolated from transient parent aborts, completes, and plan mode exits cleanly. Internal signal-handling fix with no UI surface; the full before/after is captured in the maintainer A/B verification linked above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

The signal/timeout logic is platform-agnostic (`AbortController` / `setTimeout`); CI exercises macOS, Windows, and Linux.

### Environment (optional)

Plan-gate unit suites + `tsc --noEmit` + `packages/core` build. No special runtime required.

## Risk & Scope

- Main risk or tradeoff: Once the gate agent is actually running, it is intentionally **not** cancellable by the parent — only its own 5-minute timeout (or normal completion) ends it. Genuine user cancellation is still honored *before* launch (entry-time `signal.aborted` check) and *between* retries (abort-aware `delay`), but not mid-gate. This is the deliberate cost of making the gate resilient to transient parent aborts.
- Not validated / out of scope: No new automated tests are added; the existing plan-gate suites cover the retry/gate paths. A reviewer (via Qwen Code /review) suggested follow-up tests for the new branches specifically — abort during the backoff delay, parent-signal isolation (gate keeps running when the parent aborts), asserting `runGateAgent` is not called when pre-aborted, and the 5-minute timeout path. Windows/Linux not exercised locally.
- Breaking changes / migration notes: None. `runGateAgent`'s third parameter is retained (renamed `_parentSignal`) so callers are unaffected; exporting `delay` from `utils/retry.ts` is additive.

## Linked Issues

No separate tracking issue — the root cause and reproduction are documented above (the `exit_plan_mode` / Plan Approval Gate stuck-loop under AUTO/YOLO pre-plan mode).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 Plan Approval Gate 评审 agent 从父级的 abort 信号链中隔离出来,使父级的瞬时 abort 不再能取消它,并让 gate 的重试循环真正重试,而不是退化成只试一次。共三处改动:(1) `gateReviewAgents.ts` —— `runGateAgent` 现在让 gate 子 agent 跑在它自己独立的 `AbortController` 下,带一个固定的 5 分钟超时(`GATE_AGENT_TIMEOUT_MS`),不再使用继承来的父级 signal;父级 signal 参数为保持签名稳定而保留,但被刻意弃用(重命名为 `_parentSignal`),并在 `finally` 中清除定时器、若控制器尚未触发则将其 abort,避免定时器/监听器泄漏。(2) `planApprovalGate.ts` —— `runAgentWithRetry` 把"每轮循环顶部检查 `signal.aborted`"改成单次的入口检查(如果进入时父级已 abort,就根本不启动 gate agent),并在两次尝试之间加入一个 abort 感知的 `delay(1000, signal)` 退避;若退避期间父级被取消,会立即中断循环。(3) `retry.ts` —— 把已有的 `delay()` 辅助函数导出,供 gate 复用(纯新增,无行为变化)。

## 为什么需要它

在 AUTO/YOLO pre-plan 模式下,调用 `exit_plan_mode` 可能让用户永久卡在 plan 模式里,陷入无限重试循环。gate 评审 agent 沿整条链继承了父级的 abort 信号(`masterAbortController → roundAbortController → processFunctionCalls → ExitPlanModeToolInvocation.execute → runPlanApprovalGate → runGateAgent → subagent.execute`)。当父级遇到*瞬时*情况 —— 例如 `NO_FINISH_REASON` 流重试或每轮清理 —— abort 会级联进 gate agent 并把它取消(`mode=CANCELLED`,无可用输出)。雪上加霜的是,`runAgentWithRetry` 在每轮循环顶部检查 `signal.aborted`,所以信号一旦被 abort,剩余尝试就被瞬间跳过 —— "3 次重试"实际变成"1 次重试"。于是 gate 报告 **unavailable**,`exit_plan_mode` 返回错误,模型再次调用 `exit_plan_mode`,同样的瞬时失败无限重复。典型日志:

```
[WARN] [QWEN_CODE_CHAT] Invalid stream [NO_FINISH_REASON] (retry 1/2)
[WARN] [PLAN_APPROVAL_GATE] Gate agent attempt 1/3 failed: Gate agent terminated with mode=CANCELLED and no usable output
[WARN] [PLAN_APPROVAL_GATE] Gate agent skipped: signal already aborted
[REPAIR] synthesized 1 functionResponse(s): exit_plan_mode(...)
```

给 gate agent 自己的 signal + 超时打断了这条级联,abort 感知的退避恢复了真正的重试,同时仍在循环边界处尊重真实的取消。

## 评审者测试计划

### 如何验证

这是非用户可见的 signal/重试逻辑;通过 plan-gate 测试套件、typecheck、构建来确认(在仓库根目录执行):

```
npx vitest run packages/core/src/plan-gate/planApprovalGate.test.ts packages/core/src/plan-gate/gateReviewAgents.test.ts
npm run typecheck --workspace=packages/core
npm run build --workspace=packages/core
```

行为层面:在 AUTO/YOLO pre-plan 模式下进入 plan 模式,并在父级流遇到瞬时 `NO_FINISH_REASON` 重试时触发 `exit_plan_mode`。修复前 —— gate agent 被取消、重试被跳过、gate 返回 "unavailable",`exit_plan_mode` 一直循环、始终无法退出 plan 模式。修复后 —— gate agent 跑在自己的 signal 下,扛过瞬时的父级 abort,完成评审,plan 模式正常退出。

维护者已在真实构建上独立验证 —— 用真实代码 A/B 在 merge-base 上复现了该 bug、并在 PR head 上确认了修复,外加一次集成 TUI 运行:https://github.com/QwenLM/qwen-code/pull/5185#issuecomment-4739065270

### 证据(前后对比)

修复前 —— `exit_plan_mode` 无限重试循环;Plan Approval Gate 报告 "unavailable";用户无法离开 plan 模式(日志特征见上)。修复后 —— gate agent 与瞬时父级 abort 隔离、完成、plan 模式干净退出。这是内部 signal 处理的修复,无 UI 表层;完整前后对比见上方链接的维护者 A/B 验证。

### 测试平台

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

该 signal/超时逻辑与平台无关(`AbortController` / `setTimeout`);CI 会覆盖 macOS、Windows、Linux 三个平台。

### 环境(可选)

plan-gate 单元测试套件 + `tsc --noEmit` + `packages/core` 构建。无需特殊运行环境。

## 风险与范围

- 主要风险或取舍:一旦 gate agent 真正开始运行,它就被刻意设计成**不**可被父级取消 —— 只有它自己的 5 分钟超时(或正常完成)才能结束它。真实的用户取消仍会在*启动前*(入口处的 `signal.aborted` 检查)和*两次重试之间*(abort 感知的 `delay`)被尊重,但在 gate 运行中途不会。这是让 gate 对瞬时父级 abort 具备韧性所付出的有意代价。
- 未验证 / 范围之外:未新增自动化测试;现有 plan-gate 套件覆盖了重试/gate 路径。一位评审者(通过 Qwen Code /review)建议为新增分支专门补测试 —— 退避 delay 期间的 abort、父级 signal 隔离(父级 abort 时 gate 仍继续运行)、断言预先 abort 时 `runGateAgent` 未被调用、以及 5 分钟超时路径。Windows/Linux 未在本地实测。
- 破坏性变更 / 迁移说明:无。`runGateAgent` 的第三个参数被保留(重命名为 `_parentSignal`),调用方不受影响;把 `delay` 从 `utils/retry.ts` 导出是纯新增。

## 关联 Issue

无单独的跟踪 issue —— 根因与复现已在上文说明(AUTO/YOLO pre-plan 模式下 `exit_plan_mode` / Plan Approval Gate 卡死循环)。

</details>
