### PR TITLE
feat(cli): add sessions list command with --json and --limit flags

### DIFF
--- a/packages/cli/src/commands/sessions.test.ts
+++ b/packages/cli/src/commands/sessions.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('./sessions/list.js', () => ({
+  listCommand: {
+    command: 'list',
+    describe: 'List sessions',
+  },
+}));
+
+import { sessionsCommand } from './sessions.js';
+import { type Argv } from 'yargs';
+import yargs from 'yargs';
+
+describe('sessions command', () => {
+  it('should have correct command definition', () => {
+    expect(sessionsCommand.command).toBe('sessions');
+    expect(sessionsCommand.describe).toBe('Manage Qwen Code sessions');
+    expect(typeof sessionsCommand.builder).toBe('function');
+    expect(typeof sessionsCommand.handler).toBe('function');
+  });
+
+  it('should not inherit global flags', async () => {
+    const yargsInstance = yargs();
+    const builder = sessionsCommand.builder;
+    if (typeof builder !== 'function') {
+      throw new Error('sessions command builder must be a function');
+    }
+    const builtYargs = await builder(yargsInstance);
+    // getOptions() exists at runtime but is not in @types/yargs.
+    // mcp.test.ts uses the same pattern and is excluded from typecheck.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const options = (builtYargs as any).getOptions();
+
+    // Should have exactly 1 option (help flag)
+    expect(Object.keys(options.key).length).toBe(1);
+    expect(options.key).toHaveProperty('help');
+  });
+
+  it('should register list subcommand', () => {
+    const mockYargs = {
+      command: vi.fn().mockReturnThis(),
+      demandCommand: vi.fn().mockReturnThis(),
+      version: vi.fn().mockReturnThis(),
+    };
+
+    const builder = sessionsCommand.builder;
+    if (typeof builder !== 'function') {
+      throw new Error('sessions command builder must be a function');
+    }
+    builder(mockYargs as unknown as Argv);
+
+    expect(mockYargs.command).toHaveBeenCalledTimes(1);
+
+    const commandCalls = mockYargs.command.mock.calls;
+    const commandNames = commandCalls.map((call) => call[0].command);
+
+    expect(commandNames).toContain('list');
+
+    expect(mockYargs.demandCommand).toHaveBeenCalledWith(
+      1,
+      'You need at least one command before continuing.',
+    );
+  });
+});

--- a/packages/cli/src/commands/sessions.ts
+++ b/packages/cli/src/commands/sessions.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CommandModule, Argv } from 'yargs';
+import { listCommand } from './sessions/list.js';
+
+export const sessionsCommand: CommandModule = {
+  command: 'sessions',
+  describe: 'Manage Qwen Code sessions',
+  builder: (yargs: Argv) =>
+    yargs
+      .command(listCommand)
+      .demandCommand(1, 'You need at least one command before continuing.')
+      .version(false),
+  // demandCommand(1) ensures a subcommand is always required;
+  // yargs automatically shows help when none is provided.
+  handler: () => {},
+};

--- a/packages/cli/src/commands/sessions/common.test.ts
+++ b/packages/cli/src/commands/sessions/common.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach, type Mock } from 'vitest';
+
+const mockLoadSettings = vi.hoisted(() => vi.fn());
+const mockSetRuntimeBaseDir = vi.hoisted(() => vi.fn());
+const mockSessionServiceConstructor = vi.hoisted(() => vi.fn());
+
+vi.mock('../../config/settings.js', () => ({
+  loadSettings: mockLoadSettings,
+}));
+
+vi.mock('@qwen-code/qwen-code-core', () => ({
+  Storage: {
+    setRuntimeBaseDir: mockSetRuntimeBaseDir,
+  },
+  SessionService: mockSessionServiceConstructor,
+}));
+
+import { initSessionService } from './common.js';
+
+const mockedLoadSettings = mockLoadSettings as Mock;
+const mockedSetRuntimeBaseDir = mockSetRuntimeBaseDir as Mock;
+
+describe('common', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should call Storage.setRuntimeBaseDir with correct args', () => {
+    mockedLoadSettings.mockReturnValue({
+      merged: { advanced: { runtimeOutputDir: '/custom/runtime' } },
+    });
+    mockSessionServiceConstructor.mockReturnValue({});
+
+    initSessionService();
+
+    expect(mockedSetRuntimeBaseDir).toHaveBeenCalledWith(
+      '/custom/runtime',
+      process.cwd(),
+    );
+  });
+
+  it('should pass undefined when runtimeOutputDir is not configured', () => {
+    mockedLoadSettings.mockReturnValue({
+      merged: { advanced: {} },
+    });
+    mockSessionServiceConstructor.mockReturnValue({});
+
+    initSessionService();
+
+    expect(mockedSetRuntimeBaseDir).toHaveBeenCalledWith(
+      undefined,
+      process.cwd(),
+    );
+  });
+
+  it('should return a SessionService instance', () => {
+    const mockInstance = { listSessions: vi.fn() };
+    mockedLoadSettings.mockReturnValue({
+      merged: { advanced: {} },
+    });
+    mockSessionServiceConstructor.mockReturnValue(mockInstance);
+
+    const result = initSessionService();
+
+    expect(result).toBe(mockInstance);
+    expect(mockSessionServiceConstructor).toHaveBeenCalledWith(process.cwd());
+  });
+});

--- a/packages/cli/src/commands/sessions/common.ts
+++ b/packages/cli/src/commands/sessions/common.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Storage, SessionService } from '@qwen-code/qwen-code-core';
+import { loadSettings } from '../../config/settings.js';
+
+export function initSessionService(): SessionService {
+  const settings = loadSettings();
+  Storage.setRuntimeBaseDir(
+    settings.merged.advanced?.runtimeOutputDir,
+    process.cwd(),
+  );
+  return new SessionService(process.cwd());
+}

--- a/packages/cli/src/commands/sessions/list.test.ts
+++ b/packages/cli/src/commands/sessions/list.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { vi, describe, it, expect, beforeEach, type Mock } from 'vitest';
-import { handleList } from './list.js';
+import { handleList, SESSION_COL, TIME_COL, TITLE_COL } from './list.js';
 
 const mockWriteStdoutLine = vi.hoisted(() => vi.fn());
 const mockWriteStderrLine = vi.hoisted(() => vi.fn());
@@ -73,7 +73,7 @@ describe('sessions list command', () => {
 
     const calls = mockedWriteStdout.mock.calls.map((c) => c[0]);
     expect(calls.some((c) => c.includes('SESSION ID'))).toBe(true);
-    expect(calls.some((c) => c.includes('STARTED'))).toBe(true);
+    expect(calls.some((c) => c.includes('STARTED (LOCAL)'))).toBe(true);
     expect(calls.some((c) => c.includes('TITLE'))).toBe(true);
     expect(calls.some((c) => c.includes('BRANCH'))).toBe(true);
     expect(calls.some((c) => c.includes('PROMPT'))).toBe(true);
@@ -135,14 +135,14 @@ describe('sessions list command', () => {
     await handleList({});
 
     // customTitle '' is a valid value — should not fall back to prompt.
-    // TITLE column occupies positions 56-79 (24 chars wide).
+    // TITLE column starts after SESSION_COL + 1 + TIME_COL + 1.
     const calls = mockedWriteStdout.mock.calls.map((c) => c[0]);
     const dataLine = calls.find(
       (c) => c.includes('a1b2c3d4') && !c.includes('SESSION ID'),
     );
     expect(dataLine).toBeDefined();
-    // TITLE column should be empty (24 spaces), not containing '你好'
-    const titleCol = dataLine!.slice(56, 80);
+    const titleStart = SESSION_COL + 1 + TIME_COL + 1;
+    const titleCol = dataLine!.slice(titleStart, titleStart + TITLE_COL);
     expect(titleCol.trim()).toBe('');
   });
 
@@ -213,7 +213,10 @@ describe('sessions list command', () => {
     mockedListSessions.mockResolvedValue({
       items: [
         sampleSession,
-        { ...sampleSession, sessionId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb' },
+        {
+          ...sampleSession,
+          sessionId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        },
       ],
       hasMore: false,
     });
@@ -244,6 +247,20 @@ describe('sessions list command', () => {
     mockedListSessions.mockResolvedValue({
       items: [sampleSession],
       hasMore: false,
+    });
+
+    await handleList({});
+
+    const calls = mockedWriteStdout.mock.calls.map((c) => c[0]);
+    expect(calls.some((c) => c.includes('Use --limit to show more'))).toBe(
+      false,
+    );
+  });
+
+  it('should not show hasMore hint when items is empty', async () => {
+    mockedListSessions.mockResolvedValue({
+      items: [],
+      hasMore: true,
     });
 
     await handleList({});

--- a/packages/cli/src/commands/sessions/list.test.ts
+++ b/packages/cli/src/commands/sessions/list.test.ts
@@ -1,0 +1,286 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach, type Mock } from 'vitest';
+import { handleList } from './list.js';
+
+const mockWriteStdoutLine = vi.hoisted(() => vi.fn());
+const mockWriteStderrLine = vi.hoisted(() => vi.fn());
+const mockListSessions = vi.hoisted(() => vi.fn());
+const mockInitSessionService = vi.hoisted(() => vi.fn());
+
+vi.mock('../../utils/stdioHelpers.js', () => ({
+  writeStdoutLine: mockWriteStdoutLine,
+  writeStderrLine: mockWriteStderrLine,
+}));
+
+vi.mock('../../config/settings.js', () => ({
+  loadSettings: vi.fn(() => ({
+    merged: { advanced: {} },
+  })),
+}));
+
+vi.mock('./common.js', () => ({
+  initSessionService: mockInitSessionService,
+}));
+
+const mockedListSessions = mockListSessions as Mock;
+const mockedWriteStdout = mockWriteStdoutLine as Mock;
+const mockedWriteStderr = mockWriteStderrLine as Mock;
+const mockedInit = mockInitSessionService as Mock;
+
+const sampleSession = {
+  sessionId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  cwd: '/Users/test/project',
+  startTime: '2026-06-15T10:30:00.000Z',
+  mtime: 1718447400000,
+  prompt: '帮我写一个 React 组件',
+  gitBranch: 'main',
+  filePath: '/path/to/chats/a1b2c3d4.jsonl',
+  customTitle: 'React 组件开发',
+  titleSource: 'auto',
+};
+
+describe('sessions list command', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockWriteStdoutLine.mockClear();
+    mockWriteStderrLine.mockClear();
+    vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    mockedInit.mockReturnValue({
+      listSessions: mockedListSessions,
+    });
+  });
+
+  it('should display message when no sessions found', async () => {
+    mockedListSessions.mockResolvedValue({ items: [], hasMore: false });
+
+    await handleList({});
+
+    expect(mockedWriteStdout).toHaveBeenCalledWith('No sessions found.');
+  });
+
+  it('should display sessions in human-readable table format', async () => {
+    mockedListSessions.mockResolvedValue({
+      items: [sampleSession],
+      hasMore: false,
+    });
+
+    await handleList({});
+
+    const calls = mockedWriteStdout.mock.calls.map((c) => c[0]);
+    expect(calls.some((c) => c.includes('SESSION ID'))).toBe(true);
+    expect(calls.some((c) => c.includes('STARTED'))).toBe(true);
+    expect(calls.some((c) => c.includes('TITLE'))).toBe(true);
+    expect(calls.some((c) => c.includes('BRANCH'))).toBe(true);
+    expect(calls.some((c) => c.includes('PROMPT'))).toBe(true);
+    expect(
+      calls.some((c) => c.includes('a1b2c3d4') && c.includes('React 组件开发')),
+    ).toBe(true);
+  });
+
+  it('should display dash for missing git branch', async () => {
+    mockedListSessions.mockResolvedValue({
+      items: [{ ...sampleSession, gitBranch: undefined }],
+      hasMore: false,
+    });
+
+    await handleList({});
+
+    const calls = mockedWriteStdout.mock.calls.map((c) => c[0]);
+    const dataLine = calls.find(
+      (c) => c.includes('a1b2c3d4') && !c.includes('SESSION ID'),
+    );
+    expect(dataLine).toBeDefined();
+    expect(dataLine).toContain('-');
+  });
+
+  it('should fall back to prompt when customTitle is missing', async () => {
+    mockedListSessions.mockResolvedValue({
+      items: [
+        {
+          ...sampleSession,
+          customTitle: undefined,
+          prompt: '你好',
+        },
+      ],
+      hasMore: false,
+    });
+
+    await handleList({});
+
+    const calls = mockedWriteStdout.mock.calls.map((c) => c[0]);
+    const dataLine = calls.find(
+      (c) => c.includes('a1b2c3d4') && !c.includes('SESSION ID'),
+    );
+    expect(dataLine).toBeDefined();
+    expect(dataLine).toContain('你好');
+  });
+
+  it('should not fall back to prompt when customTitle is empty string', async () => {
+    mockedListSessions.mockResolvedValue({
+      items: [
+        {
+          ...sampleSession,
+          customTitle: '',
+          prompt: '你好',
+        },
+      ],
+      hasMore: false,
+    });
+
+    await handleList({});
+
+    // customTitle '' is a valid value — should not fall back to prompt.
+    // TITLE column occupies positions 56-79 (24 chars wide).
+    const calls = mockedWriteStdout.mock.calls.map((c) => c[0]);
+    const dataLine = calls.find(
+      (c) => c.includes('a1b2c3d4') && !c.includes('SESSION ID'),
+    );
+    expect(dataLine).toBeDefined();
+    // TITLE column should be empty (24 spaces), not containing '你好'
+    const titleCol = dataLine!.slice(56, 80);
+    expect(titleCol.trim()).toBe('');
+  });
+
+  it('should output JSON Lines format when --json is set', async () => {
+    mockedListSessions.mockResolvedValue({
+      items: [sampleSession],
+      hasMore: false,
+    });
+
+    await handleList({ json: true });
+
+    const calls = mockedWriteStdout.mock.calls;
+    const jsonLines = calls.filter(
+      (c) => c[0] !== undefined && c[0].trim().startsWith('{'),
+    );
+    expect(jsonLines.length).toBe(1);
+
+    const parsed = JSON.parse(jsonLines[0][0]);
+    expect(parsed.sessionId).toBe(sampleSession.sessionId);
+    expect(parsed.startTime).toBe(sampleSession.startTime);
+    expect(parsed.mtime).toBe(sampleSession.mtime);
+    expect(parsed.prompt).toBe(sampleSession.prompt);
+    expect(parsed.gitBranch).toBe('main');
+    expect(parsed.customTitle).toBe('React 组件开发');
+    expect(parsed.titleSource).toBe('auto');
+    expect(parsed.filePath).toBe(sampleSession.filePath);
+  });
+
+  it('should output gitBranch as null in JSON when undefined', async () => {
+    mockedListSessions.mockResolvedValue({
+      items: [{ ...sampleSession, gitBranch: undefined }],
+      hasMore: false,
+    });
+
+    await handleList({ json: true });
+
+    const calls = mockedWriteStdout.mock.calls;
+    const jsonLines = calls.filter(
+      (c) => c[0] !== undefined && c[0].trim().startsWith('{'),
+    );
+    expect(jsonLines.length).toBe(1);
+
+    const parsed = JSON.parse(jsonLines[0][0]);
+    expect(parsed.gitBranch).toBeNull();
+  });
+
+  it('should pass limit option to listSessions', async () => {
+    mockedListSessions.mockResolvedValue({ items: [], hasMore: false });
+
+    await handleList({ limit: 10 });
+
+    expect(mockedListSessions).toHaveBeenCalledWith({
+      size: 10,
+    });
+  });
+
+  it('should default limit to 20', async () => {
+    mockedListSessions.mockResolvedValue({ items: [], hasMore: false });
+
+    await handleList({});
+
+    expect(mockedListSessions).toHaveBeenCalledWith({
+      size: 20,
+    });
+  });
+
+  it('should yield JSON without header for multiple sessions', async () => {
+    mockedListSessions.mockResolvedValue({
+      items: [
+        sampleSession,
+        { ...sampleSession, sessionId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb' },
+      ],
+      hasMore: false,
+    });
+
+    await handleList({ json: true });
+
+    const calls = mockedWriteStdout.mock.calls;
+    const jsonLines = calls.filter(
+      (c) => c[0] !== undefined && c[0].trim().startsWith('{'),
+    );
+    expect(jsonLines.length).toBe(2);
+  });
+
+  it('should show hasMore hint when there are more sessions', async () => {
+    mockedListSessions.mockResolvedValue({
+      items: [sampleSession],
+      hasMore: true,
+    });
+
+    await handleList({});
+
+    expect(mockedWriteStdout).toHaveBeenCalledWith(
+      expect.stringContaining('Use --limit to show more'),
+    );
+  });
+
+  it('should not show hasMore hint when hasMore is false', async () => {
+    mockedListSessions.mockResolvedValue({
+      items: [sampleSession],
+      hasMore: false,
+    });
+
+    await handleList({});
+
+    const calls = mockedWriteStdout.mock.calls.map((c) => c[0]);
+    expect(calls.some((c) => c.includes('Use --limit to show more'))).toBe(
+      false,
+    );
+  });
+
+  it('should handle initSessionService failure', async () => {
+    mockedInit.mockImplementation(() => {
+      throw new Error('settings not found');
+    });
+
+    await handleList({});
+
+    expect(mockedWriteStderr).toHaveBeenCalledWith(
+      expect.stringContaining('initialize session service'),
+    );
+    expect(mockedWriteStderr).toHaveBeenCalledWith(
+      expect.stringContaining('settings not found'),
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it('should handle listSessions failure', async () => {
+    mockedListSessions.mockRejectedValue(new Error('disk full'));
+
+    await handleList({});
+
+    expect(mockedWriteStderr).toHaveBeenCalledWith(
+      expect.stringContaining('failed to list sessions'),
+    );
+    expect(mockedWriteStderr).toHaveBeenCalledWith(
+      expect.stringContaining('disk full'),
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/cli/src/commands/sessions/list.test.ts
+++ b/packages/cli/src/commands/sessions/list.test.ts
@@ -169,6 +169,7 @@ describe('sessions list command', () => {
     expect(parsed.customTitle).toBe('React 组件开发');
     expect(parsed.titleSource).toBe('auto');
     expect(parsed.filePath).toBe(sampleSession.filePath);
+    expect(parsed.cwd).toBe(sampleSession.cwd);
   });
 
   it('should output gitBranch as null in JSON when undefined', async () => {
@@ -269,6 +270,44 @@ describe('sessions list command', () => {
     expect(calls.some((c) => c.includes('Use --limit to show more'))).toBe(
       false,
     );
+  });
+
+  it('should truncate long prompt with ellipsis', async () => {
+    const longPrompt = 'A'.repeat(100);
+    mockedListSessions.mockResolvedValue({
+      items: [{ ...sampleSession, customTitle: undefined, prompt: longPrompt }],
+      hasMore: false,
+    });
+
+    await handleList({});
+
+    const calls = mockedWriteStdout.mock.calls.map((c) => c[0]);
+    const dataLine = calls.find(
+      (c) => c.includes('a1b2c3d4') && !c.includes('SESSION ID'),
+    );
+    expect(dataLine).toBeDefined();
+    // Truncated output should contain ellipsis
+    expect(dataLine).toContain('...');
+    // Full original string must not appear
+    expect(dataLine).not.toContain(longPrompt);
+  });
+
+  it('should truncate CJK characters correctly', async () => {
+    const longCjk = '这是一个非常非常长的中文测试标题文本内容'.repeat(5);
+    mockedListSessions.mockResolvedValue({
+      items: [{ ...sampleSession, customTitle: undefined, prompt: longCjk }],
+      hasMore: false,
+    });
+
+    await handleList({});
+
+    const calls = mockedWriteStdout.mock.calls.map((c) => c[0]);
+    const dataLine = calls.find(
+      (c) => c.includes('a1b2c3d4') && !c.includes('SESSION ID'),
+    );
+    expect(dataLine).toBeDefined();
+    // Full CJK string must not appear (truncated by display width)
+    expect(dataLine).not.toContain(longCjk);
   });
 
   it('should handle initSessionService failure', async () => {

--- a/packages/cli/src/commands/sessions/list.test.ts
+++ b/packages/cli/src/commands/sessions/list.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { vi, describe, it, expect, beforeEach, type Mock } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { handleList, SESSION_COL, TIME_COL, TITLE_COL } from './list.js';
 
 const mockWriteStdoutLine = vi.hoisted(() => vi.fn());
@@ -27,11 +27,6 @@ vi.mock('./common.js', () => ({
   initSessionService: mockInitSessionService,
 }));
 
-const mockedListSessions = mockListSessions as Mock;
-const mockedWriteStdout = mockWriteStdoutLine as Mock;
-const mockedWriteStderr = mockWriteStderrLine as Mock;
-const mockedInit = mockInitSessionService as Mock;
-
 const sampleSession = {
   sessionId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
   cwd: '/Users/test/project',
@@ -47,33 +42,31 @@ const sampleSession = {
 describe('sessions list command', () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    mockWriteStdoutLine.mockClear();
-    mockWriteStderrLine.mockClear();
     vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-    mockedInit.mockReturnValue({
-      listSessions: mockedListSessions,
+    mockInitSessionService.mockReturnValue({
+      listSessions: mockListSessions,
     });
   });
 
   it('should display message when no sessions found', async () => {
-    mockedListSessions.mockResolvedValue({ items: [], hasMore: false });
+    mockListSessions.mockResolvedValue({ items: [], hasMore: false });
 
     await handleList({});
 
-    expect(mockedWriteStdout).toHaveBeenCalledWith('No sessions found.');
+    expect(mockWriteStdoutLine).toHaveBeenCalledWith('No sessions found.');
   });
 
   it('should display sessions in human-readable table format', async () => {
-    mockedListSessions.mockResolvedValue({
+    mockListSessions.mockResolvedValue({
       items: [sampleSession],
       hasMore: false,
     });
 
     await handleList({});
 
-    const calls = mockedWriteStdout.mock.calls.map((c) => c[0]);
+    const calls = mockWriteStdoutLine.mock.calls.map((c) => c[0]);
     expect(calls.some((c) => c.includes('SESSION ID'))).toBe(true);
-    expect(calls.some((c) => c.includes('STARTED (LOCAL)'))).toBe(true);
+    expect(calls.some((c) => c.includes('STARTED'))).toBe(true);
     expect(calls.some((c) => c.includes('TITLE'))).toBe(true);
     expect(calls.some((c) => c.includes('BRANCH'))).toBe(true);
     expect(calls.some((c) => c.includes('PROMPT'))).toBe(true);
@@ -83,14 +76,14 @@ describe('sessions list command', () => {
   });
 
   it('should display dash for missing git branch', async () => {
-    mockedListSessions.mockResolvedValue({
+    mockListSessions.mockResolvedValue({
       items: [{ ...sampleSession, gitBranch: undefined }],
       hasMore: false,
     });
 
     await handleList({});
 
-    const calls = mockedWriteStdout.mock.calls.map((c) => c[0]);
+    const calls = mockWriteStdoutLine.mock.calls.map((c) => c[0]);
     const dataLine = calls.find(
       (c) => c.includes('a1b2c3d4') && !c.includes('SESSION ID'),
     );
@@ -99,7 +92,7 @@ describe('sessions list command', () => {
   });
 
   it('should fall back to prompt when customTitle is missing', async () => {
-    mockedListSessions.mockResolvedValue({
+    mockListSessions.mockResolvedValue({
       items: [
         {
           ...sampleSession,
@@ -112,7 +105,7 @@ describe('sessions list command', () => {
 
     await handleList({});
 
-    const calls = mockedWriteStdout.mock.calls.map((c) => c[0]);
+    const calls = mockWriteStdoutLine.mock.calls.map((c) => c[0]);
     const dataLine = calls.find(
       (c) => c.includes('a1b2c3d4') && !c.includes('SESSION ID'),
     );
@@ -121,7 +114,7 @@ describe('sessions list command', () => {
   });
 
   it('should not fall back to prompt when customTitle is empty string', async () => {
-    mockedListSessions.mockResolvedValue({
+    mockListSessions.mockResolvedValue({
       items: [
         {
           ...sampleSession,
@@ -136,7 +129,7 @@ describe('sessions list command', () => {
 
     // customTitle '' is a valid value — should not fall back to prompt.
     // TITLE column starts after SESSION_COL + 1 + TIME_COL + 1.
-    const calls = mockedWriteStdout.mock.calls.map((c) => c[0]);
+    const calls = mockWriteStdoutLine.mock.calls.map((c) => c[0]);
     const dataLine = calls.find(
       (c) => c.includes('a1b2c3d4') && !c.includes('SESSION ID'),
     );
@@ -147,14 +140,14 @@ describe('sessions list command', () => {
   });
 
   it('should output JSON Lines format when --json is set', async () => {
-    mockedListSessions.mockResolvedValue({
+    mockListSessions.mockResolvedValue({
       items: [sampleSession],
       hasMore: false,
     });
 
     await handleList({ json: true });
 
-    const calls = mockedWriteStdout.mock.calls;
+    const calls = mockWriteStdoutLine.mock.calls;
     const jsonLines = calls.filter(
       (c) => c[0] !== undefined && c[0].trim().startsWith('{'),
     );
@@ -173,14 +166,14 @@ describe('sessions list command', () => {
   });
 
   it('should output gitBranch as null in JSON when undefined', async () => {
-    mockedListSessions.mockResolvedValue({
+    mockListSessions.mockResolvedValue({
       items: [{ ...sampleSession, gitBranch: undefined }],
       hasMore: false,
     });
 
     await handleList({ json: true });
 
-    const calls = mockedWriteStdout.mock.calls;
+    const calls = mockWriteStdoutLine.mock.calls;
     const jsonLines = calls.filter(
       (c) => c[0] !== undefined && c[0].trim().startsWith('{'),
     );
@@ -191,27 +184,27 @@ describe('sessions list command', () => {
   });
 
   it('should pass limit option to listSessions', async () => {
-    mockedListSessions.mockResolvedValue({ items: [], hasMore: false });
+    mockListSessions.mockResolvedValue({ items: [], hasMore: false });
 
     await handleList({ limit: 10 });
 
-    expect(mockedListSessions).toHaveBeenCalledWith({
+    expect(mockListSessions).toHaveBeenCalledWith({
       size: 10,
     });
   });
 
   it('should default limit to 20', async () => {
-    mockedListSessions.mockResolvedValue({ items: [], hasMore: false });
+    mockListSessions.mockResolvedValue({ items: [], hasMore: false });
 
     await handleList({});
 
-    expect(mockedListSessions).toHaveBeenCalledWith({
+    expect(mockListSessions).toHaveBeenCalledWith({
       size: 20,
     });
   });
 
   it('should yield JSON without header for multiple sessions', async () => {
-    mockedListSessions.mockResolvedValue({
+    mockListSessions.mockResolvedValue({
       items: [
         sampleSession,
         {
@@ -224,7 +217,7 @@ describe('sessions list command', () => {
 
     await handleList({ json: true });
 
-    const calls = mockedWriteStdout.mock.calls;
+    const calls = mockWriteStdoutLine.mock.calls;
     const jsonLines = calls.filter(
       (c) => c[0] !== undefined && c[0].trim().startsWith('{'),
     );
@@ -232,41 +225,41 @@ describe('sessions list command', () => {
   });
 
   it('should show hasMore hint when there are more sessions', async () => {
-    mockedListSessions.mockResolvedValue({
+    mockListSessions.mockResolvedValue({
       items: [sampleSession],
       hasMore: true,
     });
 
     await handleList({});
 
-    expect(mockedWriteStdout).toHaveBeenCalledWith(
+    expect(mockWriteStdoutLine).toHaveBeenCalledWith(
       expect.stringContaining('Use --limit to show more'),
     );
   });
 
   it('should not show hasMore hint when hasMore is false', async () => {
-    mockedListSessions.mockResolvedValue({
+    mockListSessions.mockResolvedValue({
       items: [sampleSession],
       hasMore: false,
     });
 
     await handleList({});
 
-    const calls = mockedWriteStdout.mock.calls.map((c) => c[0]);
+    const calls = mockWriteStdoutLine.mock.calls.map((c) => c[0]);
     expect(calls.some((c) => c.includes('Use --limit to show more'))).toBe(
       false,
     );
   });
 
   it('should not show hasMore hint when items is empty', async () => {
-    mockedListSessions.mockResolvedValue({
+    mockListSessions.mockResolvedValue({
       items: [],
       hasMore: true,
     });
 
     await handleList({});
 
-    const calls = mockedWriteStdout.mock.calls.map((c) => c[0]);
+    const calls = mockWriteStdoutLine.mock.calls.map((c) => c[0]);
     expect(calls.some((c) => c.includes('Use --limit to show more'))).toBe(
       false,
     );
@@ -274,14 +267,14 @@ describe('sessions list command', () => {
 
   it('should truncate long prompt with ellipsis', async () => {
     const longPrompt = 'A'.repeat(100);
-    mockedListSessions.mockResolvedValue({
+    mockListSessions.mockResolvedValue({
       items: [{ ...sampleSession, customTitle: undefined, prompt: longPrompt }],
       hasMore: false,
     });
 
     await handleList({});
 
-    const calls = mockedWriteStdout.mock.calls.map((c) => c[0]);
+    const calls = mockWriteStdoutLine.mock.calls.map((c) => c[0]);
     const dataLine = calls.find(
       (c) => c.includes('a1b2c3d4') && !c.includes('SESSION ID'),
     );
@@ -294,14 +287,14 @@ describe('sessions list command', () => {
 
   it('should truncate CJK characters correctly', async () => {
     const longCjk = '这是一个非常非常长的中文测试标题文本内容'.repeat(5);
-    mockedListSessions.mockResolvedValue({
+    mockListSessions.mockResolvedValue({
       items: [{ ...sampleSession, customTitle: undefined, prompt: longCjk }],
       hasMore: false,
     });
 
     await handleList({});
 
-    const calls = mockedWriteStdout.mock.calls.map((c) => c[0]);
+    const calls = mockWriteStdoutLine.mock.calls.map((c) => c[0]);
     const dataLine = calls.find(
       (c) => c.includes('a1b2c3d4') && !c.includes('SESSION ID'),
     );
@@ -310,31 +303,190 @@ describe('sessions list command', () => {
     expect(dataLine).not.toContain(longCjk);
   });
 
+  // --- sanitize() tests ---
+
+  it('should strip CR, LF, and TAB from prompt in human output', async () => {
+    mockListSessions.mockResolvedValue({
+      items: [
+        {
+          ...sampleSession,
+          customTitle: undefined,
+          prompt: 'hello\r\n\tworld',
+        },
+      ],
+      hasMore: false,
+    });
+
+    await handleList({});
+
+    const calls = mockWriteStdoutLine.mock.calls.map((c) => c[0]);
+    const dataLine = calls.find(
+      (c) => c.includes('a1b2c3d4') && !c.includes('SESSION ID'),
+    );
+    expect(dataLine).toBeDefined();
+    // CR, LF, and TAB must all be stripped
+    expect(dataLine).toContain('helloworld');
+    expect(dataLine).not.toContain('\r');
+    expect(dataLine).not.toContain('\n');
+    expect(dataLine).not.toContain('\t');
+  });
+
+  it('should escape ANSI escape sequences in human output', async () => {
+    // After escapeAnsiCtrlCodes, the ESC byte \x1b becomes the 6-char
+    // literal "", so keep the prompt short enough to fit the column.
+    const prompt = '\x1b[31mRED\x1b[0m';
+    mockListSessions.mockResolvedValue({
+      items: [{ ...sampleSession, customTitle: undefined, prompt }],
+      hasMore: false,
+    });
+
+    await handleList({});
+
+    const calls = mockWriteStdoutLine.mock.calls.map((c) => c[0]);
+    const dataLine = calls.find(
+      (c) => c.includes('a1b2c3d4') && !c.includes('SESSION ID'),
+    );
+    expect(dataLine).toBeDefined();
+    // Raw ANSI ESC byte must not appear (escapeAnsiCtrlCodes replaces it
+    // with a literal  escape sequence).
+    expect(dataLine).not.toContain('\x1b');
+    // The visible text should remain.
+    expect(dataLine).toContain('RED');
+  });
+
+  it('should strip bell and backspace C0 control characters', async () => {
+    const prompt = 'ab\x07c\x08d';
+    mockListSessions.mockResolvedValue({
+      items: [{ ...sampleSession, customTitle: undefined, prompt }],
+      hasMore: false,
+    });
+
+    await handleList({});
+
+    const calls = mockWriteStdoutLine.mock.calls.map((c) => c[0]);
+    const dataLine = calls.find(
+      (c) => c.includes('a1b2c3d4') && !c.includes('SESSION ID'),
+    );
+    expect(dataLine).toBeDefined();
+    // C0 controls must be stripped, alphabetic chars remain
+    expect(dataLine).toContain('abcd');
+  });
+
+  it('should not strip printable text in sanitize', async () => {
+    mockListSessions.mockResolvedValue({
+      items: [
+        { ...sampleSession, customTitle: undefined, prompt: 'Hello World 123' },
+      ],
+      hasMore: false,
+    });
+
+    await handleList({});
+
+    const calls = mockWriteStdoutLine.mock.calls.map((c) => c[0]);
+    const dataLine = calls.find(
+      (c) => c.includes('a1b2c3d4') && !c.includes('SESSION ID'),
+    );
+    expect(dataLine).toBeDefined();
+    expect(dataLine).toContain('Hello World 123');
+  });
+
+  it('should sanitize and truncate the time column', async () => {
+    // An invalid startTime hits the isNaN fallback in formatTime, returning
+    // the raw string. sanitize + truncate must prevent raw injection there.
+    mockListSessions.mockResolvedValue({
+      items: [
+        {
+          ...sampleSession,
+          startTime: 'not-a-date\r\n\x1b[31mEVIL\x1b[0m',
+        },
+      ],
+      hasMore: false,
+    });
+
+    await handleList({});
+
+    const calls = mockWriteStdoutLine.mock.calls.map((c) => c[0]);
+    const dataLine = calls.find(
+      (c) => c.includes('a1b2c3d4') && !c.includes('SESSION ID'),
+    );
+    expect(dataLine).toBeDefined();
+    // Raw evil sequences must be gone
+    expect(dataLine).not.toContain('\r');
+    expect(dataLine).not.toContain('\n');
+    expect(dataLine).not.toContain('\x1b');
+    expect(dataLine).not.toContain('EVIL');
+    // The sanitized result is 'not-a-date[31mEVIL[0m' — without the ESC byte,
+    // and truncated. The key point is the raw escape is gone.
+  });
+
+  // --- JSON mode hasMore tests ---
+
+  it('should emit hasMore hint to stderr in JSON mode', async () => {
+    mockListSessions.mockResolvedValue({
+      items: [sampleSession],
+      hasMore: true,
+    });
+
+    await handleList({ json: true });
+
+    // Hint must go to stderr, not stdout
+    const stdoutCalls = mockWriteStdoutLine.mock.calls.map((c) => c[0]);
+    expect(stdoutCalls.some((c) => c.includes('Use --limit'))).toBe(false);
+
+    expect(mockWriteStderrLine).toHaveBeenCalledWith(
+      expect.stringContaining('Use --limit to show more'),
+    );
+  });
+
+  it('should not emit hasMore hint to stderr when hasMore is false in JSON mode', async () => {
+    mockListSessions.mockResolvedValue({
+      items: [sampleSession],
+      hasMore: false,
+    });
+
+    await handleList({ json: true });
+
+    const stderrCalls = mockWriteStderrLine.mock.calls.map((c) => c[0]);
+    expect(stderrCalls.some((c) => c.includes('Use --limit'))).toBe(false);
+  });
+
+  it('should not emit hasMore hint to stderr when items is empty in JSON mode', async () => {
+    mockListSessions.mockResolvedValue({
+      items: [],
+      hasMore: true,
+    });
+
+    await handleList({ json: true });
+
+    const stderrCalls = mockWriteStderrLine.mock.calls.map((c) => c[0]);
+    expect(stderrCalls.some((c) => c.includes('Use --limit'))).toBe(false);
+  });
+
   it('should handle initSessionService failure', async () => {
-    mockedInit.mockImplementation(() => {
+    mockInitSessionService.mockImplementation(() => {
       throw new Error('settings not found');
     });
 
     await handleList({});
 
-    expect(mockedWriteStderr).toHaveBeenCalledWith(
+    expect(mockWriteStderrLine).toHaveBeenCalledWith(
       expect.stringContaining('initialize session service'),
     );
-    expect(mockedWriteStderr).toHaveBeenCalledWith(
+    expect(mockWriteStderrLine).toHaveBeenCalledWith(
       expect.stringContaining('settings not found'),
     );
     expect(process.exit).toHaveBeenCalledWith(1);
   });
 
   it('should handle listSessions failure', async () => {
-    mockedListSessions.mockRejectedValue(new Error('disk full'));
+    mockListSessions.mockRejectedValue(new Error('disk full'));
 
     await handleList({});
 
-    expect(mockedWriteStderr).toHaveBeenCalledWith(
+    expect(mockWriteStderrLine).toHaveBeenCalledWith(
       expect.stringContaining('failed to list sessions'),
     );
-    expect(mockedWriteStderr).toHaveBeenCalledWith(
+    expect(mockWriteStderrLine).toHaveBeenCalledWith(
       expect.stringContaining('disk full'),
     );
     expect(process.exit).toHaveBeenCalledWith(1);

--- a/packages/cli/src/commands/sessions/list.ts
+++ b/packages/cli/src/commands/sessions/list.ts
@@ -21,20 +21,34 @@ export const TIME_COL = 16;
 export const TITLE_COL = 24;
 export const BRANCH_COL = 12;
 
+/**
+ * Format an ISO 8601 timestamp to a UTC short form: YYYY-MM-DD HH:MM.
+ * Uses UTC methods so the human output matches the raw data in JSON.
+ */
 function formatTime(iso: string): string {
   const d = new Date(iso);
   if (isNaN(d.getTime())) return iso;
   const pad = (n: number) => String(n).padStart(2, '0');
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())} ${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}`;
 }
 
 /**
  * Sanitize a user-controllable string for terminal output:
- * 1. Strip \r and \n to prevent carriage-return / log-injection attacks.
- * 2. Escape ANSI control sequences that could manipulate the terminal.
+ * 1. Strip \r, \n, and \t to prevent carriage-return / log-injection
+ *    attacks and to keep table columns aligned.
+ * 2. Escape ANSI escape sequences that could manipulate the terminal.
+ * 3. Strip remaining C0 control characters (0x00-0x08, 0x0b, 0x0c,
+ *    0x0e-0x1f) and C1 controls (0x7f-0x9f) that can cause disruptive
+ *    terminal behaviour (bell, backspace, cursor movement, etc.).
  */
 function sanitize(value: string): string {
-  return escapeAnsiCtrlCodes(value.replace(/[\r\n]/g, ''));
+  // Strip \r, \n, \t — these either inject fake newlines or misalign columns.
+  const stripped = value.replace(/[\r\n\t]/g, '');
+  // Neutralize ANSI escape sequences (e.g. colour codes).
+  const escaped = escapeAnsiCtrlCodes(stripped);
+  // Remove remaining C0/C1 controls that escapeAnsiCtrlCodes doesn't cover.
+  // eslint-disable-next-line no-control-regex
+  return escaped.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]/g, '');
 }
 
 /**
@@ -58,28 +72,15 @@ function truncate(str: string, maxLen: number): string {
   const width = stringWidth(str);
   if (width <= maxLen) return str;
 
-  if (maxLen <= 3) {
-    let result = '';
-    let w = 0;
-    for (const char of str) {
-      const cw = stringWidth(char);
-      if (w + cw > maxLen) break;
-      result += char;
-      w += cw;
-    }
-    return result;
-  }
+  const suffix = maxLen > 3 ? '...' : '';
+  const target = maxLen - stringWidth(suffix);
 
-  const suffix = '...';
-  const suffixWidth = 3;
-  const targetWidth = maxLen - suffixWidth;
   let result = '';
   let w = 0;
   for (const char of str) {
-    const cw = stringWidth(char);
-    if (w + cw > targetWidth) break;
+    w += stringWidth(char);
+    if (w > target) break;
     result += char;
-    w += cw;
   }
   return result + suffix;
 }
@@ -100,7 +101,7 @@ function outputHuman(items: SessionListItem[]): void {
   const header =
     padDisplay('SESSION ID', SESSION_COL) +
     ' ' +
-    padDisplay('STARTED (LOCAL)', TIME_COL) +
+    padDisplay('STARTED', TIME_COL) +
     ' ' +
     padDisplay('TITLE', TITLE_COL) +
     ' ' +
@@ -115,18 +116,17 @@ function outputHuman(items: SessionListItem[]): void {
       sanitize(String(item.sessionId ?? '')),
       SESSION_COL,
     );
-    const time = formatTime(item.startTime);
+    const time = truncate(sanitize(formatTime(item.startTime)), TIME_COL);
+    const sanitizedPrompt = sanitize(item.prompt ?? '');
     const title = truncate(
-      item.customTitle != null
-        ? sanitize(item.customTitle)
-        : sanitize(item.prompt ?? ''),
+      item.customTitle != null ? sanitize(item.customTitle) : sanitizedPrompt,
       TITLE_COL,
     );
     const branch = truncate(
       item.gitBranch != null ? sanitize(item.gitBranch) : '-',
       BRANCH_COL,
     );
-    const prompt = truncate(sanitize(item.prompt ?? ''), PROMPT_COL);
+    const prompt = truncate(sanitizedPrompt, PROMPT_COL);
 
     writeStdoutLine(
       `${padDisplay(sessionId, SESSION_COL)} ${padDisplay(time, TIME_COL)} ${padDisplay(title, TITLE_COL)} ${padDisplay(branch, BRANCH_COL)} ${prompt}`,
@@ -183,6 +183,13 @@ export async function handleList(argv: ListArgs): Promise<void> {
   if (argv.json) {
     for (const item of result.items) {
       writeStdoutLine(JSON.stringify(toJsonItem(item)));
+    }
+    // Emit hasMore hint via stderr so it never contaminates the stdout JSON
+    // stream, keeping pipelines like `qwen sessions list --json | jq …` safe.
+    if (result.items.length > 0 && result.hasMore) {
+      writeStderrLine(
+        `Note: ${result.items.length} sessions shown, more available. Use --limit to show more.`,
+      );
     }
   } else {
     outputHuman(result.items);

--- a/packages/cli/src/commands/sessions/list.ts
+++ b/packages/cli/src/commands/sessions/list.ts
@@ -139,11 +139,12 @@ function toJsonItem(item: SessionListItem): Record<string, unknown> {
     sessionId: item.sessionId,
     startTime: item.startTime,
     mtime: item.mtime,
-    prompt: sanitize(item.prompt ?? ''),
-    gitBranch: item.gitBranch != null ? sanitize(item.gitBranch) : null,
-    customTitle: item.customTitle != null ? sanitize(item.customTitle) : null,
+    prompt: item.prompt,
+    gitBranch: item.gitBranch ?? null,
+    customTitle: item.customTitle ?? null,
     titleSource: item.titleSource ?? null,
     filePath: item.filePath,
+    cwd: item.cwd,
   };
 }
 

--- a/packages/cli/src/commands/sessions/list.ts
+++ b/packages/cli/src/commands/sessions/list.ts
@@ -10,8 +10,16 @@ import type {
   SessionListItem,
   ListSessionsResult,
 } from '@qwen-code/qwen-code-core';
+import stringWidth from 'string-width';
+import { escapeAnsiCtrlCodes } from '../../ui/utils/textUtils.js';
 import { initSessionService } from './common.js';
 import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
+
+/** Fixed column widths for the human-readable table (exported for tests). */
+export const SESSION_COL = 38;
+export const TIME_COL = 16;
+export const TITLE_COL = 24;
+export const BRANCH_COL = 12;
 
 function formatTime(iso: string): string {
   const d = new Date(iso);
@@ -20,10 +28,60 @@ function formatTime(iso: string): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
+/**
+ * Sanitize a user-controllable string for terminal output:
+ * 1. Strip \r and \n to prevent carriage-return / log-injection attacks.
+ * 2. Escape ANSI control sequences that could manipulate the terminal.
+ */
+function sanitize(value: string): string {
+  return escapeAnsiCtrlCodes(value.replace(/[\r\n]/g, ''));
+}
+
+/**
+ * Pad a string to the given display width using spaces.
+ * Uses string-width so CJK characters occupy the correct number of columns.
+ */
+function padDisplay(str: string, width: number): string {
+  const currentWidth = stringWidth(str);
+  if (currentWidth >= width) return str;
+  return str + ' '.repeat(width - currentWidth);
+}
+
+/**
+ * Truncate a string to at most `maxLen` *display columns*.
+ * Appends "..." when truncation occurs and maxLen > 3.
+ *
+ * Unlike String.prototype.slice this iterates by code point and measures
+ * each glyph with string-width, so CJK characters are handled correctly.
+ */
 function truncate(str: string, maxLen: number): string {
-  if (str.length <= maxLen) return str;
-  if (maxLen <= 3) return str.slice(0, maxLen);
-  return str.slice(0, maxLen - 3) + '...';
+  const width = stringWidth(str);
+  if (width <= maxLen) return str;
+
+  if (maxLen <= 3) {
+    let result = '';
+    let w = 0;
+    for (const char of str) {
+      const cw = stringWidth(char);
+      if (w + cw > maxLen) break;
+      result += char;
+      w += cw;
+    }
+    return result;
+  }
+
+  const suffix = '...';
+  const suffixWidth = 3;
+  const targetWidth = maxLen - suffixWidth;
+  let result = '';
+  let w = 0;
+  for (const char of str) {
+    const cw = stringWidth(char);
+    if (w + cw > targetWidth) break;
+    result += char;
+    w += cw;
+  }
+  return result + suffix;
 }
 
 function outputHuman(items: SessionListItem[]): void {
@@ -32,33 +90,46 @@ function outputHuman(items: SessionListItem[]): void {
     return;
   }
 
-  const SESSION_COL = 38;
-  const TIME_COL = 16;
-  const TITLE_COL = 24;
-  const BRANCH_COL = 12;
+  const termWidth = process.stdout.columns ?? 80;
+  // 4 = spaces between the 5 columns (SESSION TIME TITLE BRANCH PROMPT)
+  const PROMPT_COL = Math.max(
+    20,
+    termWidth - SESSION_COL - TIME_COL - TITLE_COL - BRANCH_COL - 4,
+  );
 
   const header =
-    'SESSION ID'.padEnd(SESSION_COL) +
+    padDisplay('SESSION ID', SESSION_COL) +
     ' ' +
-    'STARTED'.padEnd(TIME_COL) +
+    padDisplay('STARTED (LOCAL)', TIME_COL) +
     ' ' +
-    'TITLE'.padEnd(TITLE_COL) +
+    padDisplay('TITLE', TITLE_COL) +
     ' ' +
-    'BRANCH'.padEnd(BRANCH_COL) +
+    padDisplay('BRANCH', BRANCH_COL) +
     ' ' +
     'PROMPT';
 
   writeStdoutLine(header);
 
   for (const item of items) {
-    const sessionId = truncate(String(item.sessionId ?? ''), SESSION_COL);
+    const sessionId = truncate(
+      sanitize(String(item.sessionId ?? '')),
+      SESSION_COL,
+    );
     const time = formatTime(item.startTime);
-    const title = truncate(item.customTitle ?? item.prompt, TITLE_COL);
-    const branch = truncate(item.gitBranch ?? '-', BRANCH_COL);
-    const prompt = truncate(item.prompt, 40);
+    const title = truncate(
+      item.customTitle != null
+        ? sanitize(item.customTitle)
+        : sanitize(item.prompt ?? ''),
+      TITLE_COL,
+    );
+    const branch = truncate(
+      item.gitBranch != null ? sanitize(item.gitBranch) : '-',
+      BRANCH_COL,
+    );
+    const prompt = truncate(sanitize(item.prompt ?? ''), PROMPT_COL);
 
     writeStdoutLine(
-      `${sessionId.padEnd(SESSION_COL)} ${time.padEnd(TIME_COL)} ${title.padEnd(TITLE_COL)} ${branch.padEnd(BRANCH_COL)} ${prompt}`,
+      `${padDisplay(sessionId, SESSION_COL)} ${padDisplay(time, TIME_COL)} ${padDisplay(title, TITLE_COL)} ${padDisplay(branch, BRANCH_COL)} ${prompt}`,
     );
   }
 }
@@ -68,9 +139,9 @@ function toJsonItem(item: SessionListItem): Record<string, unknown> {
     sessionId: item.sessionId,
     startTime: item.startTime,
     mtime: item.mtime,
-    prompt: item.prompt,
-    gitBranch: item.gitBranch ?? null,
-    customTitle: item.customTitle ?? null,
+    prompt: sanitize(item.prompt ?? ''),
+    gitBranch: item.gitBranch != null ? sanitize(item.gitBranch) : null,
+    customTitle: item.customTitle != null ? sanitize(item.customTitle) : null,
     titleSource: item.titleSource ?? null,
     filePath: item.filePath,
   };
@@ -114,7 +185,7 @@ export async function handleList(argv: ListArgs): Promise<void> {
     }
   } else {
     outputHuman(result.items);
-    if (result.hasMore) {
+    if (result.items.length > 0 && result.hasMore) {
       writeStdoutLine(
         `Showing ${result.items.length} sessions. Use --limit to show more.`,
       );
@@ -136,7 +207,7 @@ export const listCommand: CommandModule<unknown, ListArgs> = {
         type: 'number',
         describe: 'Maximum number of sessions to show',
         default: 20,
-        coerce: (v) => (Number.isFinite(v) && v > 0 ? v : 20),
+        coerce: (v) => (Number.isInteger(v) && v > 0 ? v : 20),
       }),
   handler: async (argv) => {
     await handleList(argv);

--- a/packages/cli/src/commands/sessions/list.ts
+++ b/packages/cli/src/commands/sessions/list.ts
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CommandModule, Argv } from 'yargs';
+import type {
+  SessionService,
+  SessionListItem,
+  ListSessionsResult,
+} from '@qwen-code/qwen-code-core';
+import { initSessionService } from './common.js';
+import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function truncate(str: string, maxLen: number): string {
+  if (str.length <= maxLen) return str;
+  if (maxLen <= 3) return str.slice(0, maxLen);
+  return str.slice(0, maxLen - 3) + '...';
+}
+
+function outputHuman(items: SessionListItem[]): void {
+  if (items.length === 0) {
+    writeStdoutLine('No sessions found.');
+    return;
+  }
+
+  const SESSION_COL = 38;
+  const TIME_COL = 16;
+  const TITLE_COL = 24;
+  const BRANCH_COL = 12;
+
+  const header =
+    'SESSION ID'.padEnd(SESSION_COL) +
+    ' ' +
+    'STARTED'.padEnd(TIME_COL) +
+    ' ' +
+    'TITLE'.padEnd(TITLE_COL) +
+    ' ' +
+    'BRANCH'.padEnd(BRANCH_COL) +
+    ' ' +
+    'PROMPT';
+
+  writeStdoutLine(header);
+
+  for (const item of items) {
+    const sessionId = truncate(String(item.sessionId ?? ''), SESSION_COL);
+    const time = formatTime(item.startTime);
+    const title = truncate(item.customTitle ?? item.prompt, TITLE_COL);
+    const branch = truncate(item.gitBranch ?? '-', BRANCH_COL);
+    const prompt = truncate(item.prompt, 40);
+
+    writeStdoutLine(
+      `${sessionId.padEnd(SESSION_COL)} ${time.padEnd(TIME_COL)} ${title.padEnd(TITLE_COL)} ${branch.padEnd(BRANCH_COL)} ${prompt}`,
+    );
+  }
+}
+
+function toJsonItem(item: SessionListItem): Record<string, unknown> {
+  return {
+    sessionId: item.sessionId,
+    startTime: item.startTime,
+    mtime: item.mtime,
+    prompt: item.prompt,
+    gitBranch: item.gitBranch ?? null,
+    customTitle: item.customTitle ?? null,
+    titleSource: item.titleSource ?? null,
+    filePath: item.filePath,
+  };
+}
+
+function formatError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export interface ListArgs {
+  json?: boolean;
+  limit?: number;
+}
+
+export async function handleList(argv: ListArgs): Promise<void> {
+  let svc: SessionService;
+  try {
+    svc = initSessionService();
+  } catch (err) {
+    writeStderrLine(
+      `Error: failed to initialize session service: ${formatError(err)}`,
+    );
+    process.exit(1);
+    return;
+  }
+
+  let result: ListSessionsResult;
+  try {
+    result = await svc.listSessions({
+      size: argv.limit ?? 20,
+    });
+  } catch (err) {
+    writeStderrLine(`Error: failed to list sessions: ${formatError(err)}`);
+    process.exit(1);
+    return;
+  }
+
+  if (argv.json) {
+    for (const item of result.items) {
+      writeStdoutLine(JSON.stringify(toJsonItem(item)));
+    }
+  } else {
+    outputHuman(result.items);
+    if (result.hasMore) {
+      writeStdoutLine(
+        `Showing ${result.items.length} sessions. Use --limit to show more.`,
+      );
+    }
+  }
+}
+
+export const listCommand: CommandModule<unknown, ListArgs> = {
+  command: 'list',
+  describe: 'List sessions',
+  builder: (yargs: Argv) =>
+    yargs
+      .option('json', {
+        type: 'boolean',
+        describe: 'Output as JSON Lines',
+        default: false,
+      })
+      .option('limit', {
+        type: 'number',
+        describe: 'Maximum number of sessions to show',
+        default: 20,
+        coerce: (v) => (Number.isFinite(v) && v > 0 ? v : 20),
+      }),
+  handler: async (argv) => {
+    await handleList(argv);
+  },
+};

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -61,6 +61,7 @@ import { channelCommand } from '../commands/channel.js';
 import { authCommand } from '../commands/auth.js';
 import { reviewCommand } from '../commands/review.js';
 import { serveCommand } from '../commands/serve.js';
+import { sessionsCommand } from '../commands/sessions.js';
 
 // UUID v4 regex pattern for validation
 const SESSION_ID_REGEX =
@@ -1035,7 +1036,9 @@ export async function parseArguments(): Promise<CliArgs> {
     // Register /review skill helpers (presubmit checks, cleanup)
     .command(reviewCommand)
     // Register `qwen serve` (Stage 1 daemon)
-    .command(serveCommand);
+    .command(serveCommand)
+    // Register sessions subcommands
+    .command(sessionsCommand);
 
   yargsInstance
     .version(await getCliVersion()) // This will enable the --version flag based on package.json
@@ -1059,7 +1062,8 @@ export async function parseArguments(): Promise<CliArgs> {
       result._[0] === 'auth' ||
       result._[0] === 'hooks' ||
       result._[0] === 'channel' ||
-      result._[0] === 'review')
+      result._[0] === 'review' ||
+      result._[0] === 'sessions')
   ) {
     // Note: `serve` is intentionally NOT in this list. Its handler blocks
     // forever (after the listener is up); SIGINT/SIGTERM in runQwenServe


### PR DESCRIPTION
## What this PR does

Adds a `qwen sessions` CLI command with a `list` subcommand that enumerates stored Qwen Code sessions from the command line. Supports `--json` for scriptable JSON Lines output and `--limit` for controlling page size. When there are more sessions than the limit, the human-readable output shows a hint to increase the limit.

This is Phase 1 of the sessions management CLI namespace. Follow-up phases tracked in #4825 will add `show` and `rm` subcommands.

## Why it's needed

There is currently no way to inspect stored sessions from the CLI other than the interactive `/resume` picker. This blocks cleanup/hygiene scripts, shell-driven session picking with tools like `fzf`, and CI auditing workflows.

## Reviewer Test Plan

### How to verify

```bash
# Show help
qwen sessions --help
qwen sessions list --help

# Human-readable table (default)
qwen sessions list

# JSON Lines output for scripting
qwen sessions list --json

# Limit results
qwen sessions list --limit 5

# Pipe to jq for filtering
qwen sessions list --json | jq 'select(.gitBranch == "main")'
```

Expected: `list` displays sessions sorted by most recent first in a table with columns for session ID, start time, title, branch, and first prompt. `--json` emits one JSON object per line. `--limit N` restricts output to N sessions with a hint when more exist. `--limit 0` or negative values are coerced to the default of 20.

### Evidence (Before & After)

**Before:** No `sessions` CLI command exists.

**After:**

```
$ qwen sessions list --limit 2
SESSION ID                             STARTED          TITLE                    BRANCH       PROMPT
31cadcd6-1cd2-47e5-a67d-31d006459924  2026-06-16 14:02  Review uncommitted co... worktree-... Base directory for this skill...
892ba362-24a4-45b3-8aa2-4f2ed38659d2  2026-06-16 14:04  Explain session files   worktree-... 讲一下三个文件的逻辑
Showing 2 sessions. Use --limit to show more.
```

```
$ qwen sessions list --json --limit 1
{"sessionId":"31cadcd6-...","startTime":"2026-06-16T06:02:06.610Z","mtime":1781590982131,"prompt":"...","gitBranch":"worktree-feat+sessions-list","customTitle":"Review uncommitted code changes","titleSource":"auto","filePath":"/Users/.../.qwen/projects/.../chats/31cadcd6-....jsonl"}
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

## Risk & Scope

- Main risk or tradeoff: Low. This is a read-only listing command built on the existing `SessionService.listSessions()` API. No changes to session storage or the interactive TUI.
- Not validated / out of scope: `show`, `rm`, `--tag`, `--since`/`--until`, `--cursor` pagination flags are deferred to Phase 2 follow-ups per maintainer guidance on #4825.
- Breaking changes / migration notes: None. This is a new command that does not modify any existing behavior.

## Linked Issues

Resolves #4825 (Phase 1)

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

新增 `qwen sessions` CLI 命令，包含 `list` 子命令，用于从命令行枚举已存储的 Qwen Code 会话。支持 `--json` 输出 JSON Lines 格式用于脚本处理，支持 `--limit` 控制每页数量。当会话数超过限制时，人类可读输出会提示用户使用 `--limit` 查看更多。

这是会话管理 CLI 命名空间的第一阶段。后续阶段（#4825）将添加 `show` 和 `rm` 子命令。

## 为什么需要

目前除了交互式 `/resume` 选择器外，无法从 CLI 查看已存储的会话。这阻碍了清理/归档脚本、基于 `fzf` 等工具的会话选择以及 CI 审计等场景。

## Reviewer 测试计划

### 验证方式

```bash
# 查看帮助
qwen sessions --help
qwen sessions list --help

# 人类可读表格（默认）
qwen sessions list

# JSON Lines 脚本化输出
qwen sessions list --json

# 限制数量
qwen sessions list --limit 5

# 管道配合 jq 过滤
qwen sessions list --json | jq 'select(.gitBranch == "main")'
```

预期：`list` 按最近优先排序展示会话，表格包含会话 ID、开始时间、标题、分支和首条提示。`--json` 每行输出一个 JSON 对象。`--limit N` 限制输出 N 条，超量时显示提示。`--limit 0` 或负值会被强制回退为默认值 20。

### 前后对比

**之前：** 不存在 `sessions` CLI 命令。

**之后：** 见上方英文 Evidence 部分。

## 风险与范围

- 主要风险：低。这是一个只读列出命令，基于现有的 `SessionService.listSessions()` API，不修改会话存储或交互式 TUI。
- 不在范围内：`show`、`rm`、`--tag`、`--since`/`--until`、`--cursor` 分页参数将推迟到 Phase 2，遵循维护者在 #4825 中的指导。
- 破坏性变更：无。这是一个不修改任何现有行为的新命令。

## 关联 Issue

Resolves #4825 (Phase 1)
</details>
