### PR TITLE
fix(core): strengthen exit_plan_mode descriptions to prevent empty plan parameter

### DIFF
--- a/packages/core/src/tools/exitPlanMode.test.ts
+++ b/packages/core/src/tools/exitPlanMode.test.ts
@@ -91,6 +91,25 @@ describe('ExitPlanModeTool', () => {
     });
   });
 
+  describe('non-empty plan constraint in descriptions', () => {
+    it('should mention non-empty constraint in plan parameter description', () => {
+      const schema = tool.schema as {
+        parametersJsonSchema: {
+          properties: { plan: { description: string } };
+        };
+      };
+      expect(schema.parametersJsonSchema.properties.plan.description).toContain(
+        'empty strings will be rejected',
+      );
+    });
+
+    it('should mention non-empty constraint in tool description', () => {
+      expect(tool.schema.description).toContain(
+        'empty strings will be rejected',
+      );
+    });
+  });
+
   describe('validateToolParams', () => {
     it('should accept valid parameters', () => {
       const params: ExitPlanModeParams = {

--- a/packages/core/src/tools/exitPlanMode.ts
+++ b/packages/core/src/tools/exitPlanMode.ts
@@ -45,6 +45,7 @@ IMPORTANT: Only use this tool when the task requires planning the implementation
 ## Before Using This Tool
 Ensure your plan is complete and unambiguous:
 - If you have unresolved questions about requirements or approach, use AskUserQuestion first (in earlier phases)
+- The plan parameter MUST contain your actual plan content — empty strings will be rejected
 - Once your plan is finalized, use THIS tool to request approval
 
 **Important:** Do NOT use AskUserQuestion to ask "Is this plan okay?" or "Should I proceed?" - that's exactly what THIS tool does. ExitPlanMode inherently requests user approval of your plan.
@@ -64,7 +65,7 @@ const exitPlanModeToolSchemaData: FunctionDeclaration = {
       plan: {
         type: 'string',
         description:
-          'The plan you came up with, that you want to run by the user for approval. Supports markdown. The plan should be pretty concise.',
+          'The plan you came up with, that you want to run by the user for approval. Supports markdown. The plan should be pretty concise. Must contain your actual plan content — empty strings will be rejected.',
       },
       originalRequest: {
         type: 'string',


### PR DESCRIPTION
## What this PR does

Strengthens the tool description and parameter schema for `exit_plan_mode` to explicitly state that the `plan` parameter must contain actual plan content and that empty strings will be rejected. This reduces the likelihood of the model generating empty `plan` values, avoiding wasted LLM retry turns.

## Why it's needed

When in plan mode, the model sometimes calls `exit_plan_mode` with an empty string for the `plan` parameter (e.g., `{ "plan": "" }`). The tool's parameter validation correctly rejects this, but this wastes a full LLM turn (tokens + latency) and occasionally triggers the retry loop detector after repeated failures.

The current parameter description does not explicitly state the non-empty constraint. JSON Schema's `required` only ensures the key exists — it does not prevent empty string values. Weaker or smaller models may interpret `{ "plan": "" }` as satisfying the schema requirement.

This is a follow-up to #4853, where Finding 3 noted that weaker models struggle with the plan mode exit path.

## Reviewer Test Plan

### How to verify

1. Run the unit tests to ensure the new constraint tests pass:
   ```bash
   cd packages/core && npx vitest run src/tools/exitPlanMode.test.ts
   ```
2. Verify the tool description and parameter schema contain the non-empty constraint text by inspecting `packages/core/src/tools/exitPlanMode.ts`.
3. Optionally, run `npm run dev`, enter plan mode with `/plan`, and observe whether the model still generates empty `plan` parameters.

### Evidence (Before & After)

N/A — prompt-level change, no TUI impact. The modified text is part of the model-facing tool description, not user-visible UI.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Local development, `npm run dev`.

## Risk & Scope

- Main risk or tradeoff: Prompt-only change with no code logic modifications. Risk is minimal — the added text clarifies an existing constraint that the validation layer already enforces.
- Not validated / out of scope: Cross-model A/B testing to quantify the reduction in empty `plan` occurrences. If the prompt optimization proves insufficient, deeper fixes (system prompt reinforcement, error message improvement, or schema validation restoration) may be needed as follow-ups.
- Breaking changes / migration notes: None. No API or config changes.

## Linked Issues

Fixes #5177

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

强化了 `exit_plan_mode` 的工具描述和参数 schema，明确声明 `plan` 参数必须包含实际的计划内容，空字符串将被拒绝。这降低了模型生成空 `plan` 值的可能性，避免浪费 LLM 重试轮次。

## 为什么需要

当处于 plan mode 时，模型有时会调用 `exit_plan_mode` 但传入空字符串的 `plan` 参数（如 `{ "plan": "" }`）。工具的参数校验能正确拒绝这种情况，但这浪费了一个完整的 LLM 回合（token + 延迟），最坏情况下会在重复失败后触发重试循环检测器。

当前的参数描述没有显式声明非空约束。JSON Schema 的 `required` 仅确保键存在——不阻止空字符串值。较弱或较小的模型可能认为 `{ "plan": "" }` 满足了 schema 要求。

这是 #4853 的后续工作，该 PR 的发现 3 指出较弱的模型在 plan mode 退出路径上存在困难。

## 审查者测试计划

### 如何验证

1. 运行单元测试确保新的约束测试通过：
   ```bash
   cd packages/core && npx vitest run src/tools/exitPlanMode.test.ts
   ```
2. 检查 `packages/core/src/tools/exitPlanMode.ts` 中的工具描述和参数 schema 是否包含非空约束文本。
3. 可选地，运行 `npm run dev`，使用 `/plan` 进入 plan mode，观察模型是否仍生成空 `plan` 参数。

### 证据（修改前后）

N/A — 纯提示词修改，无 TUI 影响。修改的文本是模型面向的工具描述的一部分，非用户可见 UI。

### 测试平台

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### 环境（可选）

本地开发环境，`npm run dev`。

## 风险与范围

- 主要风险或权衡：纯提示词修改，无代码逻辑变更。风险极低——新增文本澄清了验证层已经强制执行的现有约束。
- 未验证/范围外：跨模型 A/B 测试以量化空 `plan` 出现次数的减少。如果提示词优化效果不理想，可能需要后续进行更深层的修复（系统提示词强化、错误消息优化或 schema 校验恢复）。
- 破坏性变更：无。无 API 或配置变更。

## 关联 Issue

修复 #5177

</details>
