### PR TITLE
fix(ci): gate PR review and triage on write permission

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -46,32 +46,27 @@ concurrency:
 jobs:
   ack-review-request:
     # KEEP IN SYNC with review-pr.if (explicit-trigger branches).
+    # Authorization is delegated to the `authorize` job (write+ permission);
+    # this `if` only matches the /review command shape.
+    needs: ['authorize']
     if: |-
-      (github.event_name == 'issue_comment' &&
+      needs.authorize.outputs.should_review == 'true' &&
+      ((github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         github.event.issue.state == 'open' &&
         (github.event.comment.body == '@qwen-code /review' ||
          startsWith(github.event.comment.body, '@qwen-code /review ') ||
-         startsWith(github.event.comment.body, format('@qwen-code /review{0}', '\n'))) &&
-        (github.event.comment.author_association == 'OWNER' ||
-         github.event.comment.author_association == 'MEMBER' ||
-         github.event.comment.author_association == 'COLLABORATOR')) ||
+         startsWith(github.event.comment.body, format('@qwen-code /review{0}', '\n')))) ||
       (github.event_name == 'pull_request_review_comment' &&
         github.event.pull_request.state == 'open' &&
         (github.event.comment.body == '@qwen-code /review' ||
          startsWith(github.event.comment.body, '@qwen-code /review ') ||
-         startsWith(github.event.comment.body, format('@qwen-code /review{0}', '\n'))) &&
-        (github.event.comment.author_association == 'OWNER' ||
-         github.event.comment.author_association == 'MEMBER' ||
-         github.event.comment.author_association == 'COLLABORATOR')) ||
+         startsWith(github.event.comment.body, format('@qwen-code /review{0}', '\n')))) ||
       (github.event_name == 'pull_request_review' &&
         github.event.pull_request.state == 'open' &&
         (github.event.review.body == '@qwen-code /review' ||
          startsWith(github.event.review.body, '@qwen-code /review ') ||
-         startsWith(github.event.review.body, format('@qwen-code /review{0}', '\n'))) &&
-        (github.event.review.author_association == 'OWNER' ||
-         github.event.review.author_association == 'MEMBER' ||
-         github.event.review.author_association == 'COLLABORATOR'))
+         startsWith(github.event.review.body, format('@qwen-code /review{0}', '\n')))))
     concurrency:
       group: 'qwen-pr-ack-${{ github.event.issue.number || github.event.pull_request.number }}'
       cancel-in-progress: false
@@ -128,15 +123,14 @@ jobs:
           echo "bot_login=qwen-code-ci-bot" >> "$GITHUB_OUTPUT"
 
   delay-automatic-review:
+    needs: ['authorize']
     if: |-
       github.event_name == 'pull_request_target' &&
       (github.event.action == 'opened' ||
        github.event.action == 'synchronize') &&
       github.event.pull_request.state == 'open' &&
       !github.event.pull_request.draft &&
-      (github.event.pull_request.author_association == 'OWNER' ||
-       github.event.pull_request.author_association == 'MEMBER' ||
-       github.event.pull_request.author_association == 'COLLABORATOR')
+      needs.authorize.outputs.should_review == 'true'
     runs-on: 'ubuntu-latest'
     # Configured in repo settings with a 30-minute wait timer.
     environment:
@@ -170,30 +164,75 @@ jobs:
           fi
           echo "should_review=true" >> "$GITHUB_OUTPUT"
 
-  authorize-review-request:
-    needs: ['review-config']
+  authorize:
+    # Single source of truth for "may this trigger spend review compute".
+    # The principal whose permission decides eligibility is the PR author
+    # (automatic PR events), the commenter (comment/review command events), or
+    # the requester (review_requested). They must have write+ permission.
+    # This replaces the per-path author_association checks, which are
+    # unreliable for fork PRs (a write user pushing from a fork is reported as
+    # CONTRIBUTOR, not MEMBER), so fork PRs by trusted authors now qualify.
+    # Only run for PR-target events and /review command comments — not every
+    # unrelated comment — to avoid spawning a job per comment. The downstream
+    # `if`s still do the exact /review body match; this prefix is just a filter.
     if: |-
-      github.event_name == 'pull_request_target' &&
-      github.event.action == 'review_requested' &&
-      github.event.requested_reviewer.login == needs.review-config.outputs.bot_login &&
-      github.event.pull_request.state == 'open' &&
-      !github.event.pull_request.draft
+      github.event_name == 'pull_request_target' ||
+      ((github.event_name == 'issue_comment' ||
+        github.event_name == 'pull_request_review_comment') &&
+       startsWith(github.event.comment.body, '@qwen-code /review')) ||
+      (github.event_name == 'pull_request_review' &&
+       startsWith(github.event.review.body, '@qwen-code /review'))
     runs-on: 'ubuntu-latest'
+    timeout-minutes: 5
     permissions:
       contents: 'read'
     outputs:
-      should_review: '${{ steps.sender_permission.outputs.should_review }}'
+      should_review: '${{ steps.principal_permission.outputs.should_review }}'
     steps:
-      - name: 'Check requester permission'
-        id: 'sender_permission'
+      - name: 'Check principal write permission'
+        id: 'principal_permission'
         env:
-          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-          REQUESTER: '${{ github.event.sender.login }}'
+          # CI_BOT_PAT (not GITHUB_TOKEN): reading a user's collaborator
+          # permission requires write/maintain/admin access, which the
+          # GITHUB_TOKEN with contents:read does not have. Safe here — this job
+          # runs no agent, checks out nothing, and processes no untrusted PR
+          # content; it only reads event metadata and calls one read API.
+          GH_TOKEN: '${{ secrets.CI_BOT_PAT }}'
+          EVENT_NAME: '${{ github.event_name }}'
+          PR_ACTION: '${{ github.event.action }}'
+          PR_AUTHOR: '${{ github.event.pull_request.user.login }}'
+          COMMENT_USER: '${{ github.event.comment.user.login }}'
+          REVIEW_USER: '${{ github.event.review.user.login }}'
+          SENDER: '${{ github.event.sender.login }}'
         run: |-
           set -euo pipefail
-          if ! permission="$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${REQUESTER}/permission" --jq '.permission')"; then
-            echo "Failed to check permission for ${REQUESTER}." >&2
-            echo "Failed to check permission for ${REQUESTER}." >> "$GITHUB_STEP_SUMMARY"
+          # Select the principal whose permission gates this trigger.
+          case "$EVENT_NAME" in
+            pull_request_target)
+              if [ "$PR_ACTION" = "review_requested" ]; then
+                principal="$SENDER"
+              else
+                principal="$PR_AUTHOR"
+              fi
+              ;;
+            issue_comment|pull_request_review_comment)
+              principal="$COMMENT_USER"
+              ;;
+            pull_request_review)
+              principal="$REVIEW_USER"
+              ;;
+            *)
+              principal=""
+              ;;
+          esac
+          if [ -z "$principal" ]; then
+            echo "No principal resolved for ${EVENT_NAME}; denying." >> "$GITHUB_STEP_SUMMARY"
+            echo "should_review=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Fail closed: any API error or non-write permission denies the run.
+          if ! permission="$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${principal}/permission" --jq '.permission' 2>/dev/null)"; then
+            echo "Failed to check permission for ${principal}; denying." >> "$GITHUB_STEP_SUMMARY"
             echo "should_review=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -202,18 +241,18 @@ jobs:
               echo "should_review=true" >> "$GITHUB_OUTPUT"
               ;;
             *)
-              echo "Skipping requested review: ${REQUESTER} lacks write permission or permission check failed." >> "$GITHUB_STEP_SUMMARY"
+              echo "Denying review: ${principal} permission is '${permission}' (needs write)." >> "$GITHUB_STEP_SUMMARY"
               echo "should_review=false" >> "$GITHUB_OUTPUT"
               ;;
           esac
 
   review-pr:
-    needs:
-      ['review-config', 'delay-automatic-review', 'authorize-review-request']
-    # pull_request_target routing:
-    # - review_requested uses authorize-review-request and skips delay
+    needs: ['review-config', 'delay-automatic-review', 'authorize']
+    # pull_request_target routing (every path additionally gated by the
+    # `authorize` job = the principal has write+ permission):
+    # - review_requested checks the requester and skips delay
     # - opened/synchronize uses delay-automatic-review
-    # - reopened/ready_for_review runs immediately for trusted PR authors
+    # - reopened/ready_for_review runs immediately
     # KEEP IN SYNC with ack-review-request.if (explicit-trigger branches).
     if: |-
       always() &&
@@ -221,41 +260,32 @@ jobs:
       (github.event_name == 'pull_request_target' &&
        github.event.pull_request.state == 'open' &&
        !github.event.pull_request.draft &&
+       needs.authorize.outputs.should_review == 'true' &&
        ((github.event.action == 'review_requested' &&
-         github.event.requested_reviewer.login == needs.review-config.outputs.bot_login &&
-         needs.authorize-review-request.outputs.should_review == 'true') ||
+         github.event.requested_reviewer.login == needs.review-config.outputs.bot_login) ||
         (github.event.action != 'review_requested' &&
          ((github.event.action != 'opened' &&
            github.event.action != 'synchronize') ||
-          needs.delay-automatic-review.outputs.should_review == 'true') &&
-         (github.event.pull_request.author_association == 'OWNER' ||
-          github.event.pull_request.author_association == 'MEMBER' ||
-          github.event.pull_request.author_association == 'COLLABORATOR')))) ||
+          needs.delay-automatic-review.outputs.should_review == 'true')))) ||
       (github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         github.event.issue.state == 'open' &&
         (github.event.comment.body == '@qwen-code /review' ||
          startsWith(github.event.comment.body, '@qwen-code /review ') ||
          startsWith(github.event.comment.body, format('@qwen-code /review{0}', '\n'))) &&
-        (github.event.comment.author_association == 'OWNER' ||
-         github.event.comment.author_association == 'MEMBER' ||
-         github.event.comment.author_association == 'COLLABORATOR')) ||
+        needs.authorize.outputs.should_review == 'true') ||
       (github.event_name == 'pull_request_review_comment' &&
         github.event.pull_request.state == 'open' &&
         (github.event.comment.body == '@qwen-code /review' ||
          startsWith(github.event.comment.body, '@qwen-code /review ') ||
          startsWith(github.event.comment.body, format('@qwen-code /review{0}', '\n'))) &&
-        (github.event.comment.author_association == 'OWNER' ||
-         github.event.comment.author_association == 'MEMBER' ||
-         github.event.comment.author_association == 'COLLABORATOR')) ||
+        needs.authorize.outputs.should_review == 'true') ||
       (github.event_name == 'pull_request_review' &&
         github.event.pull_request.state == 'open' &&
         (github.event.review.body == '@qwen-code /review' ||
          startsWith(github.event.review.body, '@qwen-code /review ') ||
          startsWith(github.event.review.body, format('@qwen-code /review{0}', '\n'))) &&
-        (github.event.review.author_association == 'OWNER' ||
-         github.event.review.author_association == 'MEMBER' ||
-         github.event.review.author_association == 'COLLABORATOR')))
+        needs.authorize.outputs.should_review == 'true'))
     timeout-minutes: 90
     runs-on: ['self-hosted', 'linux', 'x64', 'ecs-qwen']
     permissions:

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -176,12 +176,13 @@ jobs:
     # unrelated comment — to avoid spawning a job per comment. The downstream
     # `if`s still do the exact /review body match; this prefix is just a filter.
     if: |-
-      github.event_name == 'pull_request_target' ||
-      ((github.event_name == 'issue_comment' ||
-        github.event_name == 'pull_request_review_comment') &&
-       startsWith(github.event.comment.body, '@qwen-code /review')) ||
-      (github.event_name == 'pull_request_review' &&
-       startsWith(github.event.review.body, '@qwen-code /review'))
+      github.repository == 'QwenLM/qwen-code' &&
+      (github.event_name == 'pull_request_target' ||
+       ((github.event_name == 'issue_comment' ||
+         github.event_name == 'pull_request_review_comment') &&
+        startsWith(github.event.comment.body, '@qwen-code /review')) ||
+       (github.event_name == 'pull_request_review' &&
+        startsWith(github.event.review.body, '@qwen-code /review')))
     runs-on: 'ubuntu-latest'
     timeout-minutes: 5
     permissions:
@@ -231,11 +232,19 @@ jobs:
             exit 0
           fi
           # Fail closed: any API error or non-write permission denies the run.
-          if ! permission="$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${principal}/permission" --jq '.permission' 2>/dev/null)"; then
-            echo "Failed to check permission for ${principal}; denying." >> "$GITHUB_STEP_SUMMARY"
+          api_error_file="$(mktemp)"
+          if ! permission="$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${principal}/permission" --jq '.permission' 2>"$api_error_file")"; then
+            api_error="$(cat "$api_error_file")"
+            rm -f "$api_error_file"
+            api_error="${api_error:-unknown error}"
+            api_error="${api_error//$'\r'/ }"
+            api_error="${api_error//$'\n'/ }"
+            echo "::error::Permission API call failed for ${principal}: ${api_error}"
+            echo "Failed to check permission for ${principal} (API error: ${api_error}); denying." >> "$GITHUB_STEP_SUMMARY"
             echo "should_review=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          rm -f "$api_error_file"
           case "$permission" in
             admin|maintain|write)
               echo "should_review=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -23,8 +23,8 @@ jobs:
   authorize:
     # Gate PR and /triage-comment triggers on the principal having write+
     # permission: the PR author for PR events, the commenter for /triage
-    # comments. Replaces the same-repo-only fork check and the comment
-    # author_association check, so fork PRs by trusted authors are triaged.
+    # comments. Replaces the old eligibility checks based on same-repo PRs and
+    # comment author_association, so fork PRs by trusted authors are triaged.
     # `issues` and `workflow_dispatch` triggers do not need this gate.
     if: |-
       github.repository == 'QwenLM/qwen-code' &&
@@ -82,19 +82,30 @@ jobs:
     needs: ['authorize']
     timeout-minutes: 30
     concurrency:
-      group: '${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.event.inputs.number }}'
-      # GitHub evaluates concurrency before the job `if`, and it cannot call
-      # the permission API, so this only controls cancellation (a coarse event
-      # match), not eligibility. The real write-permission gate is the
-      # `authorize` job below.
+      # GitHub evaluates concurrency before the job `if`, but after `needs`.
+      # Keep non-runnable PR/comment triggers out of the shared per-number
+      # group so they cannot cancel or replace an authorized run.
+      group: >-
+        ${{
+          (
+            (github.event_name == 'pull_request_target' &&
+             (github.event.pull_request.draft == true ||
+              needs.authorize.outputs.should_run != 'true')) ||
+            (github.event_name == 'issue_comment' &&
+             needs.authorize.outputs.should_run != 'true')
+          ) &&
+          format('{0}-run-{1}', github.workflow, github.run_id) ||
+          format('{0}-{1}', github.workflow, github.event.issue.number || github.event.pull_request.number || github.event.inputs.number)
+        }}
       cancel-in-progress: >-
         ${{
           github.event_name == 'issues' ||
-          (github.event_name == 'pull_request_target' &&
-           github.event.pull_request.draft == false) ||
           github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'issue_comment' &&
-           startsWith(github.event.comment.body, '@qwen-code /triage'))
+          (((github.event_name == 'pull_request_target' &&
+             github.event.pull_request.draft == false) ||
+            (github.event_name == 'issue_comment' &&
+             startsWith(github.event.comment.body, '@qwen-code /triage'))) &&
+           needs.authorize.outputs.should_run == 'true')
         }}
     runs-on: 'ubuntu-latest'
     # startsWith (not contains) prevents false triggers from comments that

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -20,41 +20,99 @@ permissions:
   pull-requests: 'write'
 
 jobs:
+  authorize:
+    # Gate PR and /triage-comment triggers on the principal having write+
+    # permission: the PR author for PR events, the commenter for /triage
+    # comments. Replaces the same-repo-only fork check and the comment
+    # author_association check, so fork PRs by trusted authors are triaged.
+    # `issues` and `workflow_dispatch` triggers do not need this gate.
+    if: |-
+      github.repository == 'QwenLM/qwen-code' &&
+      (github.event_name == 'pull_request_target' ||
+       (github.event_name == 'issue_comment' &&
+        startsWith(github.event.comment.body, '@qwen-code /triage')))
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 5
+    permissions:
+      contents: 'read'
+    outputs:
+      should_run: '${{ steps.perm.outputs.should_run }}'
+    steps:
+      - name: 'Check principal write permission'
+        id: 'perm'
+        env:
+          # CI_BOT_PAT (not GITHUB_TOKEN): reading a user's collaborator
+          # permission requires write/maintain/admin access, which the
+          # GITHUB_TOKEN with contents:read does not have. Safe here — this job
+          # runs no agent, checks out nothing, and processes no untrusted PR
+          # content; it only reads event metadata and calls one read API.
+          GH_TOKEN: '${{ secrets.CI_BOT_PAT }}'
+          EVENT_NAME: '${{ github.event_name }}'
+          PR_AUTHOR: '${{ github.event.pull_request.user.login }}'
+          COMMENT_USER: '${{ github.event.comment.user.login }}'
+        run: |-
+          set -euo pipefail
+          case "$EVENT_NAME" in
+            pull_request_target) principal="$PR_AUTHOR" ;;
+            issue_comment) principal="$COMMENT_USER" ;;
+            *) principal="" ;;
+          esac
+          if [ -z "$principal" ]; then
+            echo "No principal resolved for ${EVENT_NAME}; denying." >> "$GITHUB_STEP_SUMMARY"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Fail closed: any API error or non-write permission denies the run.
+          if ! permission="$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${principal}/permission" --jq '.permission' 2>/dev/null)"; then
+            echo "Failed to check permission for ${principal}; denying." >> "$GITHUB_STEP_SUMMARY"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          case "$permission" in
+            admin|maintain|write)
+              echo "should_run=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Denying triage: ${principal} permission is '${permission}' (needs write)." >> "$GITHUB_STEP_SUMMARY"
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
   triage:
+    needs: ['authorize']
     timeout-minutes: 30
     concurrency:
       group: '${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.event.inputs.number }}'
-      # Repeat the maintainer /triage check here intentionally: GitHub
-      # evaluates concurrency before the job `if`, so this controls
-      # cancellation, not job eligibility. Other job gates below can diverge.
+      # GitHub evaluates concurrency before the job `if`, and it cannot call
+      # the permission API, so this only controls cancellation (a coarse event
+      # match), not eligibility. The real write-permission gate is the
+      # `authorize` job below.
       cancel-in-progress: >-
         ${{
           github.event_name == 'issues' ||
           (github.event_name == 'pull_request_target' &&
-           github.event.pull_request.head.repo.full_name == github.repository &&
            github.event.pull_request.draft == false) ||
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'issue_comment' &&
-           startsWith(github.event.comment.body, '@qwen-code /triage') &&
-           (github.event.comment.author_association == 'OWNER' ||
-            github.event.comment.author_association == 'MEMBER' ||
-            github.event.comment.author_association == 'COLLABORATOR'))
+           startsWith(github.event.comment.body, '@qwen-code /triage'))
         }}
     runs-on: 'ubuntu-latest'
     # startsWith (not contains) prevents false triggers from comments that
     # mention the phrase in quoted text or mid-sentence descriptions.
+    # always() so the job still evaluates when the upstream `authorize` job is
+    # skipped (issues / workflow_dispatch paths, which need no permission gate).
     if: >-
+      always() &&
       github.repository == 'QwenLM/qwen-code' && (
         github.event_name == 'issues' ||
-        (github.event_name == 'pull_request_target' &&
-         github.event.pull_request.head.repo.full_name == github.repository &&
-         github.event.pull_request.draft == false) ||
         github.event_name == 'workflow_dispatch' ||
-        (github.event_name == 'issue_comment' &&
-         startsWith(github.event.comment.body, '@qwen-code /triage') &&
-         (github.event.comment.author_association == 'OWNER' ||
-          github.event.comment.author_association == 'MEMBER' ||
-          github.event.comment.author_association == 'COLLABORATOR'))
+        (
+          ((github.event_name == 'pull_request_target' &&
+            github.event.pull_request.draft == false) ||
+           (github.event_name == 'issue_comment' &&
+            startsWith(github.event.comment.body, '@qwen-code /triage'))) &&
+          needs.authorize.outputs.should_run == 'true'
+        )
       )
     steps:
       - name: 'Checkout repo'

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -63,11 +63,19 @@ jobs:
             exit 0
           fi
           # Fail closed: any API error or non-write permission denies the run.
-          if ! permission="$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${principal}/permission" --jq '.permission' 2>/dev/null)"; then
-            echo "Failed to check permission for ${principal}; denying." >> "$GITHUB_STEP_SUMMARY"
+          api_error_file="$(mktemp)"
+          if ! permission="$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${principal}/permission" --jq '.permission' 2>"$api_error_file")"; then
+            api_error="$(cat "$api_error_file")"
+            rm -f "$api_error_file"
+            api_error="${api_error:-unknown error}"
+            api_error="${api_error//$'\r'/ }"
+            api_error="${api_error//$'\n'/ }"
+            echo "::error::Permission API call failed for ${principal}: ${api_error}"
+            echo "Failed to check permission for ${principal} (API error: ${api_error}); denying." >> "$GITHUB_STEP_SUMMARY"
             echo "should_run=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          rm -f "$api_error_file"
           case "$permission" in
             admin|maintain|write)
               echo "should_run=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What this PR does

Replaces the trigger-authorization in the two legacy Qwen CI workflows (`qwen-code-pr-review.yml` and `qwen-triage.yml`). A new `authorize` job resolves the triggering principal — the PR author for automatic PR events, the commenter for `/review` and `/triage` comment commands, and the requester for `review_requested` — and verifies it has admin/maintain/write permission via the collaborators API. Downstream jobs gate on its output. This removes the per-path `author_association` checks and the same-repo-only fork check that previously gated these workflows.

## Why it's needed

The triage job currently requires `head.repo == base`, so every fork PR is skipped regardless of author — write users' fork PRs are never triaged. Review is gated on `author_association`, which is inconsistent for forks: write collaborators show as `COLLABORATOR` and already pass, but it does not reliably reflect actual permission. Moving both review and triage onto a real write-permission check lets fork PRs by trusted authors trigger consistently, and tightens the comment commands to actual write permission. External actors without write permission still cannot trigger the model-calling jobs.

## Reviewer Test Plan

### How to verify

CI-only change to workflow gating. Verified locally: `actionlint` reports only the two pre-existing findings (`deployment` key, `ecs-qwen` runner label), YAML parses, and `bash -n` passes on the new `authorize` shell scripts. The authorization logic was traced end-to-end across every trigger path (automatic PR open/synchronize/reopened/ready_for_review, `review_requested`, `/review` and `/triage` comments, `workflow_dispatch`, and `issues`).

### Evidence (Before & After)

N/A (non–user-visible CI change).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A — `actionlint` + YAML parse + `bash -n`.

## Risk & Scope

- Main risk or tradeoff: the `authorize` job uses `CI_BOT_PAT` because reading a user's collaborator permission requires write/maintain/admin access (the `GITHUB_TOKEN` with `contents: read` does not have it). This is safe — the job runs no agent, checks out nothing, and processes no untrusted PR content; it only reads event metadata and calls one read API. The gate fails closed: any API error or non-write permission denies the run.
- Not validated / out of scope: this collaborators-permission gate has never executed in production before (the `review_requested` path that used it was skipped in all recent runs), so confirm behavior after merge with one write-user trigger and one non-write-user trigger. The review agent's token model and prompt-injection posture are unchanged by this PR.
- Migration note: the job `authorize-review-request` was renamed to `authorize`. If branch protection lists the old job name as a required status check, update it to avoid blocking merges.

## Linked Issues

None (internal CI change).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

替换两个旧版 Qwen CI 工作流(`qwen-code-pr-review.yml` 和 `qwen-triage.yml`)的触发授权。新增一个 `authorize` job,解析触发主体——自动 PR 事件取 PR 作者,`/review` 与 `/triage` 评论命令取评论者,`review_requested` 取请求者——并通过 collaborators API 校验其是否具备 admin/maintain/write 权限,下游 job 据此门控。这移除了原先分散在各路径的 `author_association` 检查,以及 triage 里"仅同仓库分支"的 fork 检查。

## 为什么需要

triage job 现在要求 `head.repo == base`,所以不管作者是谁,所有 fork PR 都被跳过——write 用户的 fork PR 从来不会被 triage。review 走的是 `author_association`,对 fork 不一致:write 协作者显示为 `COLLABORATOR` 已经能过,但它不能可靠反映真实权限。把 review 和 triage 都挪到真正的 write 权限判断上,让受信任作者的 fork PR 一致触发,并把评论命令收紧到真正的 write 权限。无 write 权限的外部人仍无法触发调用模型的 job。

## Reviewer Test Plan

### 如何验证

仅改 CI 工作流门控。本地校验:`actionlint` 只剩两个原有报错(`deployment` key、`ecs-qwen` runner label),YAML 可解析,新增的 `authorize` shell 脚本 `bash -n` 通过。授权逻辑已对每条触发路径端到端追踪(自动 PR open/synchronize/reopened/ready_for_review、`review_requested`、`/review` 与 `/triage` 评论、`workflow_dispatch`、`issues`)。

### 证据(Before & After)

N/A(非用户可见的 CI 改动)。

### 风险与范围

- 主要风险/取舍:`authorize` job 使用 `CI_BOT_PAT`,因为读取用户的协作者权限需要 write/maintain/admin 访问(`GITHUB_TOKEN` 的 `contents: read` 不具备)。这是安全的——该 job 不跑 agent、不 checkout、不处理任何不可信 PR 内容,只读事件元数据并调一个只读 API。门控 fail-closed:任何 API 错误或非 write 权限都拒绝运行。
- 未验证/范围外:这个协作者权限门此前从未在生产中执行过(用到它的 `review_requested` 路径在近期所有 run 中都被跳过),合并后请用一个 write 用户触发 + 一个非 write 用户触发来确认行为。本 PR 不改变评审 agent 的 token 模型与 prompt 注入面。
- 迁移说明:job `authorize-review-request` 已改名为 `authorize`。若分支保护把旧 job 名设成了 required status check,请更新,以免卡住合并。

## 关联 Issue

无(仓库内部 CI 改动)。

</details>
