### PR TITLE
Fix completed prompt lifecycle race

### DIFF
--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -823,6 +823,7 @@ describe('DaemonSessionProvider', () => {
         stopReason: 'end_turn',
       });
     });
+    expect(streamingState).toBe('waiting');
 
     await act(async () => {
       secondTurnComplete.resolve();

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -838,6 +838,72 @@ describe('DaemonSessionProvider', () => {
     });
   });
 
+  it('rejects the prompt when turn_error arrives before acceptance returns', async () => {
+    const accepted = createDeferred<NonBlockingPromptAccepted>();
+    const turnError = createDeferred<void>();
+    const prompt = vi.fn().mockReturnValueOnce(accepted.promise);
+    const session = createMockSession({
+      prompt,
+      events: async function* acceptedPromptEvents(
+        opts: { signal?: AbortSignal } = {},
+      ) {
+        await Promise.race([
+          turnError.promise,
+          new Promise<void>((resolve) =>
+            opts.signal?.addEventListener('abort', () => resolve(), {
+              once: true,
+            }),
+          ),
+        ]);
+        if (opts.signal?.aborted) return;
+        yield {
+          v: 1,
+          id: 11,
+          type: 'turn_error',
+          timestamp: '2025-01-01T00:00:00.000Z',
+          sessionId: 'session-1',
+          data: {
+            promptId: 'prompt-1',
+            message: 'Something went wrong',
+            code: 'internal_error',
+          },
+        };
+      },
+    });
+    sdkMocks.sessions.push(session);
+    let actions: DaemonUiSessionActions | undefined;
+    let streamingState: ReturnType<typeof useDaemonStreamingState> = 'idle';
+
+    function Harness() {
+      actions = useDaemonActions();
+      streamingState = useDaemonStreamingState();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    const providerActions = requireActions(actions);
+
+    let promptResult: Promise<unknown> | undefined;
+    await act(async () => {
+      promptResult = providerActions.sendPrompt('fail me');
+      await flushPromises();
+    });
+    expect(streamingState).toBe('waiting');
+
+    await act(async () => {
+      turnError.resolve();
+      await flushPromises();
+    });
+    expect(streamingState).toBe('idle');
+
+    const pending = promptResult;
+    if (!pending) throw new Error('prompt was not started');
+    await act(async () => {
+      accepted.resolve({ promptId: 'prompt-1', lastEventId: 10 });
+      await expect(pending).rejects.toThrow('Something went wrong');
+    });
+  });
+
   it('sends image prompt content through the daemon action', async () => {
     const prompt = vi.fn(async () => ({ stopReason: 'end_turn' }));
     const session = createMockSession({

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -732,6 +732,112 @@ describe('DaemonSessionProvider', () => {
     });
   });
 
+  it('allows the next prompt after a turn completes before acceptance returns', async () => {
+    const firstAccepted = createDeferred<NonBlockingPromptAccepted>();
+    const secondAccepted = createDeferred<NonBlockingPromptAccepted>();
+    const firstTurnComplete = createDeferred<void>();
+    const secondTurnComplete = createDeferred<void>();
+    const prompt = vi
+      .fn()
+      .mockReturnValueOnce(firstAccepted.promise)
+      .mockReturnValueOnce(secondAccepted.promise);
+    const session = createMockSession({
+      prompt,
+      events: async function* acceptedPromptEvents(
+        opts: { signal?: AbortSignal } = {},
+      ) {
+        await Promise.race([
+          firstTurnComplete.promise,
+          new Promise<void>((resolve) =>
+            opts.signal?.addEventListener('abort', () => resolve(), {
+              once: true,
+            }),
+          ),
+        ]);
+        if (opts.signal?.aborted) return;
+        yield {
+          v: 1,
+          id: 11,
+          type: 'turn_complete',
+          timestamp: '2025-01-01T00:00:00.000Z',
+          sessionId: 'session-1',
+          data: { promptId: 'prompt-1', stopReason: 'end_turn' },
+        };
+        await Promise.race([
+          secondTurnComplete.promise,
+          new Promise<void>((resolve) =>
+            opts.signal?.addEventListener('abort', () => resolve(), {
+              once: true,
+            }),
+          ),
+        ]);
+        if (opts.signal?.aborted) return;
+        yield {
+          v: 1,
+          id: 12,
+          type: 'turn_complete',
+          timestamp: '2025-01-01T00:00:01.000Z',
+          sessionId: 'session-1',
+          data: { promptId: 'prompt-2', stopReason: 'end_turn' },
+        };
+      },
+    });
+    sdkMocks.sessions.push(session);
+    let actions: DaemonUiSessionActions | undefined;
+    let streamingState: ReturnType<typeof useDaemonStreamingState> = 'idle';
+
+    function Harness() {
+      actions = useDaemonActions();
+      streamingState = useDaemonStreamingState();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    const providerActions = requireActions(actions);
+
+    let firstPrompt: Promise<unknown> | undefined;
+    await act(async () => {
+      firstPrompt = providerActions.sendPrompt('/directory');
+      await flushPromises();
+    });
+    expect(streamingState).toBe('waiting');
+
+    await act(async () => {
+      firstTurnComplete.resolve();
+      await flushPromises();
+    });
+    expect(streamingState).toBe('idle');
+
+    let secondPrompt: Promise<unknown> | undefined;
+    await act(async () => {
+      secondPrompt = providerActions.sendPrompt('next prompt');
+      await flushPromises();
+    });
+    expect(prompt).toHaveBeenCalledTimes(2);
+
+    const pendingFirstPrompt = firstPrompt;
+    if (!pendingFirstPrompt) throw new Error('first prompt was not started');
+    await act(async () => {
+      firstAccepted.resolve({ promptId: 'prompt-1', lastEventId: 10 });
+      await expect(pendingFirstPrompt).resolves.toEqual({
+        stopReason: 'end_turn',
+      });
+    });
+
+    await act(async () => {
+      secondTurnComplete.resolve();
+      await flushPromises();
+    });
+    const pendingSecondPrompt = secondPrompt;
+    if (!pendingSecondPrompt) throw new Error('second prompt was not started');
+    await act(async () => {
+      secondAccepted.resolve({ promptId: 'prompt-2', lastEventId: 11 });
+      await expect(pendingSecondPrompt).resolves.toEqual({
+        stopReason: 'end_turn',
+      });
+    });
+  });
+
   it('sends image prompt content through the daemon action', async () => {
     const prompt = vi.fn(async () => ({ stopReason: 'end_turn' }));
     const session = createMockSession({

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -837,6 +837,7 @@ describe('DaemonSessionProvider', () => {
         stopReason: 'end_turn',
       });
     });
+    expect(streamingState).toBe('idle');
   });
 
   it('rejects the prompt when turn_error arrives before acceptance returns', async () => {

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -30,7 +30,7 @@ import {
   type DaemonTurnCompleteData,
   type DaemonUiEvent,
 } from '@qwen-code/sdk/daemon';
-import { createDaemonSessionActions, promptSettledKey } from './actions.js';
+import { createDaemonSessionActions, getPromptSettledKey } from './actions.js';
 import {
   detachDaemonClient,
   getStableClientId,
@@ -1197,7 +1197,7 @@ function settleActivePromptFromTurnEvent(
       active.resolve(result);
     } else {
       activePrompts.delete(sessionId);
-      settledPrompts.set(promptSettledKey(sessionId, promptId), {
+      settledPrompts.set(getPromptSettledKey(sessionId, promptId), {
         status: 'resolved',
         result,
       });
@@ -1210,7 +1210,7 @@ function settleActivePromptFromTurnEvent(
       active.reject(error);
     } else {
       activePrompts.delete(sessionId);
-      settledPrompts.set(promptSettledKey(sessionId, promptId), {
+      settledPrompts.set(getPromptSettledKey(sessionId, promptId), {
         status: 'rejected',
         error,
       });

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -30,7 +30,7 @@ import {
   type DaemonTurnCompleteData,
   type DaemonUiEvent,
 } from '@qwen-code/sdk/daemon';
-import { createDaemonSessionActions } from './actions.js';
+import { createDaemonSessionActions, promptSettledKey } from './actions.js';
 import {
   detachDaemonClient,
   getStableClientId,
@@ -77,6 +77,7 @@ import type {
   DaemonSessionProviderProps,
   DaemonWorkspaceEventSignals,
   PendingSessionLoad,
+  SettledPrompt,
 } from './types.js';
 
 export type {
@@ -199,6 +200,7 @@ export function DaemonSessionProvider({
   const sessionRef = useRef<DaemonSessionClient | undefined>(undefined);
   const lastSessionIdRef = useRef<string | undefined>(undefined);
   const activePromptsRef = useRef<Map<string, ActivePrompt>>(new Map());
+  const settledPromptsRef = useRef<Map<string, SettledPrompt>>(new Map());
   const pendingSessionLoadRef = useRef<PendingSessionLoad | undefined>(
     undefined,
   );
@@ -625,6 +627,7 @@ export function DaemonSessionProvider({
             for (const replayEvent of replayEvents) {
               settleActivePromptFromTurnEvent(
                 activePromptsRef.current,
+                settledPromptsRef.current,
                 activeSession.sessionId,
                 replayEvent,
                 store,
@@ -752,6 +755,7 @@ export function DaemonSessionProvider({
                   for (const replayEvent of replaySourceEvents) {
                     settleActivePromptFromTurnEvent(
                       activePromptsRef.current,
+                      settledPromptsRef.current,
                       activeSession.sessionId,
                       replayEvent,
                       store,
@@ -772,6 +776,7 @@ export function DaemonSessionProvider({
               }
               const activePromptSettled = settleActivePromptFromTurnEvent(
                 activePromptsRef.current,
+                settledPromptsRef.current,
                 activeSession.sessionId,
                 event,
                 store,
@@ -1122,6 +1127,7 @@ export function DaemonSessionProvider({
         store,
         sessionRef,
         activePromptsRef,
+        settledPromptsRef,
         pendingSessionLoadRef,
         pendingSessionLoadIdRef,
         heartbeatSupportedRef,
@@ -1157,6 +1163,7 @@ export function DaemonSessionProvider({
 
 function settleActivePromptFromTurnEvent(
   activePrompts: Map<string, ActivePrompt>,
+  settledPrompts: Map<string, SettledPrompt>,
   sessionId: string,
   event: DaemonEvent,
   store: DaemonTranscriptStore,
@@ -1189,10 +1196,10 @@ function settleActivePromptFromTurnEvent(
       activePrompts.delete(sessionId);
       active.resolve(result);
     } else {
-      activePrompts.set(sessionId, {
-        ...active,
-        promptId,
-        pendingResult: result,
+      activePrompts.delete(sessionId);
+      settledPrompts.set(promptSettledKey(sessionId, promptId), {
+        status: 'resolved',
+        result,
       });
     }
   } catch (error) {
@@ -1202,10 +1209,10 @@ function settleActivePromptFromTurnEvent(
       activePrompts.delete(sessionId);
       active.reject(error);
     } else {
-      activePrompts.set(sessionId, {
-        ...active,
-        promptId,
-        pendingError: error,
+      activePrompts.delete(sessionId);
+      settledPrompts.set(promptSettledKey(sessionId, promptId), {
+        status: 'rejected',
+        error,
       });
     }
   }

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -208,7 +208,10 @@ export function createDaemonSessionActions({
         if (active?.controller === ctrl) {
           activePromptsRef.current.delete(sessionId);
         }
-        if (sessionRef.current?.sessionId === sessionId) {
+        if (
+          sessionRef.current?.sessionId === sessionId &&
+          !activePromptsRef.current.has(sessionId)
+        ) {
           setPromptStatus('idle');
         }
       }

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -34,6 +34,7 @@ import type {
   DaemonNoticeOperation,
   DaemonPromptStatus,
   DaemonSessionActions,
+  SettledPrompt,
   PendingSessionLoad,
 } from './types.js';
 
@@ -45,6 +46,7 @@ export interface CreateDaemonSessionActionsArgs {
   store: DaemonTranscriptStore;
   sessionRef: RefBox<DaemonSessionClient | undefined>;
   activePromptsRef: RefBox<Map<string, ActivePrompt>>;
+  settledPromptsRef: RefBox<Map<string, SettledPrompt>>;
   pendingSessionLoadRef: RefBox<PendingSessionLoad | undefined>;
   pendingSessionLoadIdRef: RefBox<number>;
   heartbeatSupportedRef: RefBox<boolean>;
@@ -62,6 +64,7 @@ export function createDaemonSessionActions({
   store,
   sessionRef,
   activePromptsRef,
+  settledPromptsRef,
   pendingSessionLoadRef,
   pendingSessionLoadIdRef,
   heartbeatSupportedRef,
@@ -113,6 +116,7 @@ export function createDaemonSessionActions({
       };
     });
     setPromptStatus('idle');
+    settledPromptsRef.current.clear();
     clearPassiveAssistantDoneTimer(passiveAssistantDoneTimerRef);
     store.reset();
     setRestoreMode(mode);
@@ -167,6 +171,7 @@ export function createDaemonSessionActions({
         if (isNonBlockingAccepted(result)) {
           return await waitForAcceptedPromptCompletion(
             activePromptsRef.current,
+            settledPromptsRef.current,
             sessionId,
             ctrl,
             result.promptId,
@@ -393,6 +398,7 @@ export function createDaemonSessionActions({
         active.controller.abort();
       }
       activePromptsRef.current.clear();
+      settledPromptsRef.current.clear();
       setPromptStatus('idle');
       clearPassiveAssistantDoneTimer(passiveAssistantDoneTimerRef);
       if (pendingSessionLoadRef.current) {
@@ -771,11 +777,23 @@ export function createDaemonSessionActions({
 
 function waitForAcceptedPromptCompletion(
   activePrompts: Map<string, ActivePrompt>,
+  settledPrompts: Map<string, SettledPrompt>,
   sessionId: string,
   controller: AbortController,
   promptId: string,
 ): Promise<PromptResult> {
   return new Promise<PromptResult>((resolve, reject) => {
+    const settledKey = promptSettledKey(sessionId, promptId);
+    const settled = settledPrompts.get(settledKey);
+    if (settled) {
+      settledPrompts.delete(settledKey);
+      if (settled.status === 'resolved') {
+        resolve(settled.result);
+      } else {
+        reject(settled.error);
+      }
+      return;
+    }
     const active = activePrompts.get(sessionId);
     if (active?.controller !== controller) {
       reject(new DOMException('Aborted', 'AbortError'));
@@ -783,16 +801,6 @@ function waitForAcceptedPromptCompletion(
     }
     if (active.promptId !== undefined && active.promptId !== promptId) {
       reject(new Error(`Prompt accepted with unexpected id ${promptId}`));
-      return;
-    }
-    if (active.pendingResult !== undefined) {
-      activePrompts.delete(sessionId);
-      resolve(active.pendingResult);
-      return;
-    }
-    if (active.pendingError !== undefined) {
-      activePrompts.delete(sessionId);
-      reject(active.pendingError);
       return;
     }
     if (controller.signal.aborted) {
@@ -829,6 +837,10 @@ function waitForAcceptedPromptCompletion(
     });
     controller.signal.addEventListener('abort', onAbort, { once: true });
   });
+}
+
+export function promptSettledKey(sessionId: string, promptId: string): string {
+  return `${sessionId}:${promptId}`;
 }
 
 function getModeFromSessionContext(

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -783,6 +783,10 @@ function waitForAcceptedPromptCompletion(
   promptId: string,
 ): Promise<PromptResult> {
   return new Promise<PromptResult>((resolve, reject) => {
+    // IMPORTANT: Check settledPrompts BEFORE activePrompts. The turn event
+    // may have already freed the active slot (allowing a new prompt to start).
+    // If we checked activePrompts first, we'd find the NEXT prompt's controller
+    // and incorrectly reject this one as aborted.
     const settledKey = promptSettledKey(sessionId, promptId);
     const settled = settledPrompts.get(settledKey);
     if (settled) {

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -250,7 +250,10 @@ export function createDaemonSessionActions({
         ) {
           activePromptsRef.current.delete(session.sessionId);
         }
-        if (sessionRef.current?.sessionId === session.sessionId) {
+        if (
+          sessionRef.current?.sessionId === session.sessionId &&
+          !activePromptsRef.current.has(session.sessionId)
+        ) {
           setPromptStatus('idle');
         }
       }
@@ -850,7 +853,7 @@ export function getPromptSettledKey(
   sessionId: string,
   promptId: string,
 ): string {
-  return `${sessionId}:${promptId}`;
+  return JSON.stringify([sessionId, promptId]);
 }
 
 function getModeFromSessionContext(

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -790,7 +790,7 @@ function waitForAcceptedPromptCompletion(
     // may have already freed the active slot (allowing a new prompt to start).
     // If we checked activePrompts first, we'd find the NEXT prompt's controller
     // and incorrectly reject this one as aborted.
-    const settledKey = promptSettledKey(sessionId, promptId);
+    const settledKey = getPromptSettledKey(sessionId, promptId);
     const settled = settledPrompts.get(settledKey);
     if (settled) {
       settledPrompts.delete(settledKey);
@@ -846,7 +846,10 @@ function waitForAcceptedPromptCompletion(
   });
 }
 
-export function promptSettledKey(sessionId: string, promptId: string): string {
+export function getPromptSettledKey(
+  sessionId: string,
+  promptId: string,
+): string {
   return `${sessionId}:${promptId}`;
 }
 

--- a/packages/webui/src/daemon/session/types.ts
+++ b/packages/webui/src/daemon/session/types.ts
@@ -331,9 +331,11 @@ export interface ActivePrompt {
   promptId?: string;
   resolve?: (result: PromptResult) => void;
   reject?: (error: unknown) => void;
-  pendingResult?: PromptResult;
-  pendingError?: unknown;
 }
+
+export type SettledPrompt =
+  | { status: 'resolved'; result: PromptResult }
+  | { status: 'rejected'; error: unknown };
 
 export interface PendingSessionLoad {
   id: number;


### PR DESCRIPTION
## What this PR does

This PR fixes a daemon session lifecycle race where a fast prompt can complete over SSE before the `/prompt` HTTP acceptance response returns.

When a matching `turn_complete` or `turn_error` arrives before the prompt action has bound its resolver, the provider now releases the active prompt slot immediately and stores the settled result by session and prompt id. When the HTTP acceptance response arrives later, the prompt promise resolves from that settled cache instead of keeping the session marked busy.

## Why it's needed

Fast slash commands such as `/directory` can emit `user_message_chunk`, `agent_message_chunk`, and `turn_complete` almost immediately. In that ordering, the UI can already show the turn as complete while the provider still keeps the session in `activePromptsRef`.

That stale active prompt slot makes the next prompt fail with `Prompt failed: A prompt is already in progress`, even though the daemon has already sent `turn_complete`.

The fix keeps the lifecycle consistent: a terminal turn event releases the busy slot immediately, while the original prompt promise still resolves correctly once the delayed acceptance response is observed.

## Reviewer Test Plan

### How to verify

Run web-shell and submit a fast slash command such as `/directory` that returns usage text immediately. After the usage output appears and the turn completes, submit another prompt. The second prompt should send normally instead of showing `Prompt failed: A prompt is already in progress`.

### Evidence (Before & After)

Before: A fast slash command could receive `turn_complete` over SSE, render as complete, and still leave the provider's active prompt slot occupied until the HTTP acceptance response returned. A following prompt during that window failed as already in progress.

After: The terminal SSE event releases the active slot immediately, and a following prompt can be sent while the original prompt promise is later resolved from the settled result cache.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

`cd packages/webui && npx vitest run src/daemon/session/DaemonSessionProvider.test.tsx`

## Risk & Scope

- Main risk or tradeoff: The provider now keeps a small settled-prompt cache for completion events that arrive before acceptance. Entries are consumed when the matching acceptance arrives and cleared on session switches/new sessions.
- Not validated / out of scope: Full manual browser matrix across Windows and Linux.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 修复 daemon session 生命周期里的一个时序问题：某些很快完成的 prompt 会先通过 SSE 收到完成事件，随后 `/prompt` HTTP accepted 响应才返回。

当匹配的 `turn_complete` 或 `turn_error` 早于 prompt action 绑定 resolver 到达时，provider 现在会立即释放 active prompt slot，并按 session 和 prompt id 暂存已完成结果。稍后 HTTP accepted 响应返回时，prompt promise 会从这个 settled cache 中 resolve，而不是继续让 session 保持 busy。

## Why it's needed

像 `/directory` 这样的快速斜杠命令可能几乎立刻发出 `user_message_chunk`、`agent_message_chunk` 和 `turn_complete`。在这个顺序下，界面已经能展示 turn 完成，但 provider 里仍然把 session 保留在 `activePromptsRef`。

这个过期的 active prompt slot 会导致下一条 prompt 报错：`Prompt failed: A prompt is already in progress`，即使 daemon 已经发送了 `turn_complete`。

修复后生命周期保持一致：终止性的 turn 事件会立即释放 busy slot，同时原来的 prompt promise 仍会在稍后观察到 delayed acceptance response 时正确 resolve。

## Reviewer Test Plan

### How to verify

运行 web-shell，提交一个会立即返回 usage 文本的快速斜杠命令，例如 `/directory`。usage 输出出现并且 turn 完成后，再提交另一条 prompt。第二条 prompt 应正常发送，而不是显示 `Prompt failed: A prompt is already in progress`。

### Evidence (Before & After)

Before：快速斜杠命令可以先通过 SSE 收到 `turn_complete` 并在界面上显示完成，但 provider 的 active prompt slot 会继续被占用直到 HTTP accepted 响应返回。在这个窗口内发送下一条 prompt 会报 already in progress。

After：终止性的 SSE 事件会立即释放 active slot；下一条 prompt 可以发送；原 prompt promise 会稍后从 settled result cache 中完成。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

`cd packages/webui && npx vitest run src/daemon/session/DaemonSessionProvider.test.tsx`

## Risk & Scope

- Main risk or tradeoff: provider 新增了一个很小的 settled-prompt cache，用于保存早于 accepted 响应到达的完成事件。匹配的 accepted 返回后会消费对应 entry，并且 session switch/new session 时会清理。
- Not validated / out of scope: 没有覆盖 Windows 和 Linux 的完整手动浏览器矩阵。
- Breaking changes / migration notes: 无。

## Linked Issues

N/A

</details>
