### PR TITLE
feat(web-shell): expose transcript event changes

### DIFF
--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -315,8 +315,12 @@ export interface WebShellProps {
   onConnectionChange?: (status: string) => void;
   /** Called when prompt status changes (idle/waiting/responding). */
   onStreamingStateChange?: (state: DaemonStreamingState) => void;
-  /** Called whenever transcript blocks change. Receives the full blocks array from useTranscriptBlocks(). */
-  onEventChange?: (blocks: readonly DaemonTranscriptBlock[]) => void;
+  /**
+   * Called whenever transcript blocks change. Receives the full blocks array
+   * from useTranscriptBlocks(). Fires on every streaming delta during active
+   * generation, so consumers should debounce or throttle expensive work.
+   */
+  onTranscriptChange?: (blocks: readonly DaemonTranscriptBlock[]) => void;
   /** Called when a critical error occurs (auth failure, session gone, etc). */
   onError?: (error: Error) => void;
   /** Called when `/bug` is invoked. Receives system info. If omitted, web-shell opens the report URL itself. */
@@ -694,7 +698,6 @@ export function App({
   style: externalStyle,
   onConnectionChange,
   onStreamingStateChange,
-  onEventChange,
   onError,
   onBugReport,
   hiddenSlashCommands,
@@ -706,6 +709,7 @@ export function App({
   collapseCompletedTurns = true,
   virtualScrollThreshold,
   markdown,
+  onTranscriptChange,
   onToast,
   composerRef,
   composerInput,
@@ -1619,8 +1623,8 @@ export function App({
   }, [connection.status, onConnectionChange]);
 
   useEffect(() => {
-    onEventChange?.(blocks);
-  }, [blocks, onEventChange]);
+    onTranscriptChange?.(blocks);
+  }, [blocks, onTranscriptChange]);
 
   useEffect(() => {
     if (connection.error) {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -315,6 +315,8 @@ export interface WebShellProps {
   onConnectionChange?: (status: string) => void;
   /** Called when prompt status changes (idle/waiting/responding). */
   onStreamingStateChange?: (state: DaemonStreamingState) => void;
+  /** Called whenever transcript blocks change. Receives the full blocks array from useTranscriptBlocks(). */
+  onEventChange?: (blocks: readonly DaemonTranscriptBlock[]) => void;
   /** Called when a critical error occurs (auth failure, session gone, etc). */
   onError?: (error: Error) => void;
   /** Called when `/bug` is invoked. Receives system info. If omitted, web-shell opens the report URL itself. */
@@ -692,6 +694,7 @@ export function App({
   style: externalStyle,
   onConnectionChange,
   onStreamingStateChange,
+  onEventChange,
   onError,
   onBugReport,
   hiddenSlashCommands,
@@ -1614,6 +1617,10 @@ export function App({
   useEffect(() => {
     onConnectionChange?.(connection.status);
   }, [connection.status, onConnectionChange]);
+
+  useEffect(() => {
+    onEventChange?.(blocks);
+  }, [blocks, onEventChange]);
 
   useEffect(() => {
     if (connection.error) {

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -22,6 +22,7 @@ import {
   useDaemonConnection,
   useDaemonSessionNotices,
   useDaemonPendingPermissions,
+  useDaemonPromptStatus,
   useDaemonStreamingState,
   useDaemonTranscriptBlocks,
   useDaemonTranscriptState,
@@ -1680,6 +1681,45 @@ describe('DaemonSessionProvider', () => {
     expect(blocks).toMatchObject([
       { kind: 'assistant', text: 'initial replay', streaming: false },
     ]);
+  });
+
+  it('keeps replayed non-turn events from marking a prompt as waiting', async () => {
+    const session = createMockSession({
+      replaySnapshot: {
+        compactedReplay: [
+          {
+            id: 1,
+            v: 1,
+            type: 'session_update',
+            data: {
+              update: {
+                sessionUpdate: 'agent_message_chunk',
+                content: { type: 'text', text: 'initial replay' },
+              },
+            },
+          },
+        ],
+        liveJournal: [],
+      },
+    });
+    sdkMocks.sessions.push(session);
+    let promptStatus: ReturnType<typeof useDaemonPromptStatus> = 'idle';
+
+    function Harness() {
+      promptStatus = useDaemonPromptStatus();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      reconnectDelayMs: 1,
+      maxReconnectDelayMs: 1,
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(promptStatus).toBe('idle');
   });
 
   it('finishes replayed assistant streaming when replay ends with turn_error', async () => {

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -1722,6 +1722,45 @@ describe('DaemonSessionProvider', () => {
     expect(promptStatus).toBe('idle');
   });
 
+  it('marks replayed user turns without terminal events as waiting', async () => {
+    const session = createMockSession({
+      replaySnapshot: {
+        compactedReplay: [
+          {
+            id: 1,
+            v: 1,
+            type: 'session_update',
+            data: {
+              update: {
+                sessionUpdate: 'user_message_chunk',
+                content: { type: 'text', text: 'replayed prompt' },
+              },
+            },
+          },
+        ],
+        liveJournal: [],
+      },
+    });
+    sdkMocks.sessions.push(session);
+    let promptStatus: ReturnType<typeof useDaemonPromptStatus> = 'idle';
+
+    function Harness() {
+      promptStatus = useDaemonPromptStatus();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      reconnectDelayMs: 1,
+      maxReconnectDelayMs: 1,
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(promptStatus).toBe('waiting');
+  });
+
   it('finishes replayed assistant streaming when replay ends with turn_error', async () => {
     const session = createMockSession({
       replaySnapshot: {

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -633,7 +633,7 @@ export function DaemonSessionProvider({
                 { requireBoundPromptId: true },
               );
             }
-            // If replay has events but no terminal signal
+            // If replay has a user message but no terminal signal
             // (turn_complete/turn_error/prompt_cancelled), the turn was
             // likely still in progress — seed promptStatus so the loading
             // indicator shows immediately instead of flickering.

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -643,7 +643,8 @@ export function DaemonSessionProvider({
                 e.type === 'turn_error' ||
                 e.type === 'prompt_cancelled',
             );
-            if (replayEvents.length > 0 && !hasTurnTerminalEvent) {
+            const hasReplayUserMessage = replayEvents.some(isUserMessageEvent);
+            if (hasReplayUserMessage && !hasTurnTerminalEvent) {
               setPromptStatus((s) => (s === 'idle' ? 'waiting' : s));
             }
             setConnection((c) => ({ ...c, catchingUp: undefined }));
@@ -1214,6 +1215,15 @@ function settleActivePromptFromTurnEvent(
 
 function isPromptLifecycleTurnEvent(event: DaemonEvent): boolean {
   return event.type === 'turn_complete';
+}
+
+function isUserMessageEvent(event: DaemonEvent): boolean {
+  if (event.type !== 'session_update') return false;
+  const data = event.data as
+    | { update?: { sessionUpdate?: unknown } }
+    | null
+    | undefined;
+  return data?.update?.sessionUpdate === 'user_message_chunk';
 }
 
 function normalizeAndFilterEvent(


### PR DESCRIPTION
## What this PR does

This PR adds a web-shell callback that lets host applications observe transcript block changes as the shell processes user, assistant, and tool events. It also tightens prompt-status recovery during daemon replay so replayed non-user events do not incorrectly mark a fresh prompt as waiting.

## Why it's needed

Consumers embedding web-shell need a direct way to react to the transcript/event stream without reimplementing the shell's internal transcript reducer. Separately, replay recovery should only infer an in-progress prompt when replay contains a user message without a terminal event; otherwise a new session or non-turn replay can briefly look like a prompt is still running.

## Reviewer Test Plan

### How to verify

Use web-shell with an `onEventChange` callback and confirm it receives the full transcript blocks array whenever the displayed transcript changes after user, assistant, or tool activity. Resume or create a session whose replay snapshot contains only non-user session updates and confirm the prompt status stays idle instead of showing a waiting/in-progress state.

### Evidence (Before & After)

N/A for screenshots. Local verification passed for the focused daemon session test, the webui build, the web-shell build, and ESLint over the changed packages.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

`cd packages/webui && npx vitest run src/daemon/session/DaemonSessionProvider.test.tsx`

`npm run build --workspace=@qwen-code/webui`

`npm run build --workspace=@qwen-code/web-shell`

`npx eslint packages/webui packages/web-shell --ext .ts,.tsx --max-warnings 0`

## Risk & Scope

- Main risk or tradeoff: `onEventChange` receives the full transcript blocks array on every transcript change, so consumers should treat the value as read-only and avoid expensive synchronous work in the callback.
- Not validated / out of scope: full browser matrix and end-to-end host integration outside the local package checks.
- Breaking changes / migration notes: none. Existing web-shell users are unaffected unless they pass the new callback.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 为 web-shell 增加了一个回调，让宿主应用可以在 shell 处理 user、assistant、tool 等事件并更新 transcript blocks 时得到通知。同时收紧了 daemon replay 阶段的 prompt 状态恢复逻辑，避免只有非用户事件的 replay 把新会话误判成 waiting。

## Why it's needed

嵌入 web-shell 的消费方需要一种直接观察 transcript/event 变化的方式，而不需要重新实现 shell 内部的 transcript reducer。另一方面，replay 恢复只应该在 replay 中存在用户消息且没有终止事件时推断 prompt 仍在进行；否则新会话或非 turn replay 会短暂表现得像仍有 prompt 在运行。

## Reviewer Test Plan

### How to verify

在 web-shell 中传入 `onEventChange` 回调，确认用户、助手或工具活动导致展示内容变化时，它会收到完整的 transcript blocks 数组。恢复或创建一个 replay snapshot 只包含非用户 session update 的会话，确认 prompt status 保持 idle，而不是显示 waiting 或进行中状态。

### Evidence (Before & After)

截图不适用。本地已通过聚焦的 daemon session 测试、webui build、web-shell build，以及对变更 package 的 ESLint 检查。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

`cd packages/webui && npx vitest run src/daemon/session/DaemonSessionProvider.test.tsx`

`npm run build --workspace=@qwen-code/webui`

`npm run build --workspace=@qwen-code/web-shell`

`npx eslint packages/webui packages/web-shell --ext .ts,.tsx --max-warnings 0`

## Risk & Scope

- Main risk or tradeoff: `onEventChange` 会在每次 transcript 变化时收到完整的 transcript blocks 数组，因此消费方应把它当作只读数据，并避免在回调中执行昂贵的同步逻辑。
- Not validated / out of scope: 未覆盖完整浏览器矩阵，也未做本地 package 检查之外的宿主集成 E2E。
- Breaking changes / migration notes: 无。现有 web-shell 使用方不传新回调时不受影响。

## Linked Issues

N/A

</details>
