### PR TITLE
fix(core): read WebP VP8X canvas height from the correct byte offset

### DIFF
--- a/packages/core/src/utils/request-tokenizer/imageTokenizer.test.ts
+++ b/packages/core/src/utils/request-tokenizer/imageTokenizer.test.ts
@@ -102,6 +102,31 @@ describe('ImageTokenizer', () => {
     });
   });
 
+  describe('WebP dimension extraction', () => {
+    it('should extract canvas dimensions from VP8X', async () => {
+      const width = 100;
+      const height = 80;
+
+      const buf = Buffer.alloc(30);
+      buf.write('RIFF', 0, 'ascii');
+      buf.writeUInt32LE(22, 4);
+      buf.write('WEBP', 8, 'ascii');
+      buf.write('VP8X', 12, 'ascii');
+      buf.writeUInt32LE(10, 16); // VP8X chunk size
+      buf.writeUInt8(0, 20); // flags
+      buf.writeUIntLE(width - 1, 24, 3); // canvas width minus one (24-bit LE)
+      buf.writeUIntLE(height - 1, 27, 3); // canvas height minus one (24-bit LE)
+
+      const metadata = await tokenizer.extractImageMetadata(
+        buf.toString('base64'),
+        'image/webp',
+      );
+
+      expect(metadata.width).toBe(width);
+      expect(metadata.height).toBe(height);
+    });
+  });
+
   describe('batch processing', () => {
     it('should process multiple images serially', async () => {
       const pngBase64 =

--- a/packages/core/src/utils/request-tokenizer/imageTokenizer.ts
+++ b/packages/core/src/utils/request-tokenizer/imageTokenizer.ts
@@ -213,15 +213,18 @@ export class ImageTokenizer {
     const format = buffer.subarray(12, 16).toString('ascii');
 
     if (format === 'VP8 ') {
+      // Lossy: 14-bit width/height at bytes 26-27 and 28-29 (little-endian)
       const width = buffer.readUInt16LE(26) & 0x3fff;
       const height = buffer.readUInt16LE(28) & 0x3fff;
       return { width, height };
     } else if (format === 'VP8L') {
+      // Lossless: 14-bit (width-1) then (height-1) packed from byte 21 (little-endian)
       const bits = buffer.readUInt32LE(21);
       const width = (bits & 0x3fff) + 1;
       const height = ((bits >> 14) & 0x3fff) + 1;
       return { width, height };
     } else if (format === 'VP8X') {
+      // Extended: 24-bit (canvas width-1) at bytes 24-26 and (height-1) at bytes 27-29 (little-endian)
       const width = buffer.readUIntLE(24, 3) + 1;
       const height = buffer.readUIntLE(27, 3) + 1;
       return { width, height };

--- a/packages/core/src/utils/request-tokenizer/imageTokenizer.ts
+++ b/packages/core/src/utils/request-tokenizer/imageTokenizer.ts
@@ -222,8 +222,8 @@ export class ImageTokenizer {
       const height = ((bits >> 14) & 0x3fff) + 1;
       return { width, height };
     } else if (format === 'VP8X') {
-      const width = (buffer.readUInt32LE(24) & 0xffffff) + 1;
-      const height = (buffer.readUInt32LE(26) & 0xffffff) + 1;
+      const width = buffer.readUIntLE(24, 3) + 1;
+      const height = buffer.readUIntLE(27, 3) + 1;
       return { width, height };
     }
 


### PR DESCRIPTION
## What this PR does

Fixes the canvas height read for WebP images in the extended (VP8X) format. The height was being read starting one byte too early, so the parser returned a garbage height for any VP8X image.

## Why it's needed

In a VP8X chunk the canvas dimensions are two 24-bit little-endian values: width-minus-one at byte 24, height-minus-one at byte 27. The code read width correctly with `readUInt32LE(24) & 0xffffff` but read height from offset 26 (`readUInt32LE(26) & 0xffffff`), which spans bytes 26-28 instead of 27-29. So width comes out right and height is wrong.

I switched both lines to `readUIntLE(offset, 3)`, which reads exactly the 3 bytes we want. This also avoids a subtler trap: a naive `readUInt32LE(27)` would touch byte 30 and throw a RangeError on a minimal 30-byte VP8X header, which is still allowed by the existing `buffer.length < 30` guard. `readUIntLE(27, 3)` stays in bounds.

## Reviewer Test Plan

### How to verify

Added a unit test that builds a minimal 30-byte VP8X header for a 100x80 canvas and asserts the parsed dimensions.

```
npx vitest run packages/core/src/utils/request-tokenizer/imageTokenizer.test.ts
```

Before the fix the new test fails with `expected 20225 to be 80` (width 100 is already correct). After the fix all 10 tests pass.

### Evidence (Before & After)

N/A (not user-visible; covered by the unit test output above).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Unit tests only.

## Risk & Scope

- Main risk or tradeoff: none meaningful; the change is a 2-line offset correction with identical behavior for width.
- Not validated / out of scope: real-world VP8X files with extension chunks beyond the 30-byte header (header layout is fixed, so this does not affect the dimension read).
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

本 PR 修正 WebP 扩展格式（VP8X）画布高度的读取偏移。VP8X chunk 里画布尺寸是两个 24 位小端值：width-1 在第 24 字节，height-1 在第 27 字节。原代码用 `readUInt32LE(24) & 0xffffff` 正确读出宽度，但高度从偏移 26 读（`readUInt32LE(26) & 0xffffff`），覆盖的是第 26-28 字节而非 27-29，导致宽度正确、高度错误。

改为两行都用 `readUIntLE(offset, 3)`，正好读取需要的 3 个字节。这也避开了一个隐患：直接写 `readUInt32LE(27)` 会触及第 30 字节，在仅 30 字节的最小 VP8X 头上抛 RangeError，而这种长度仍被现有的 `buffer.length < 30` 守卫放行；`readUIntLE(27, 3)` 不会越界。

新增单元测试构造一个 100x80 画布的最小 30 字节 VP8X 头并断言解析结果。修复前该测试报 `expected 20225 to be 80`（宽度 100 本就正确），修复后全部 10 个测试通过。

```
npx vitest run packages/core/src/utils/request-tokenizer/imageTokenizer.test.ts
```

</details>
