### PR TITLE
fix(cli): window title shows session name instead of model activity status

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -698,10 +698,10 @@ const SETTINGS_SCHEMA = {
         label: 'Show Status in Title',
         category: 'UI',
         requiresRestart: false,
-        default: false,
+        default: true,
         description:
-          'Show Qwen Code status and thoughts in the terminal window title',
-        showInDialog: false,
+          'Show Qwen Code session name and status in the terminal window title',
+        showInDialog: true,
       },
       hideTips: {
         type: 'boolean',

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -1210,7 +1210,12 @@ function setWindowTitle(settings: LoadedSettings, folderName?: string) {
     writeTerminalTitle((value) => process.stdout.write(value), windowTitle);
 
     process.on('exit', () => {
-      writeTerminalTitle((value) => process.stdout.write(value), '');
+      try {
+        writeTerminalTitle((value) => process.stdout.write(value), '');
+      } catch {
+        // Best-effort: clearing the title during exit must not produce
+        // a visible error (e.g. EPIPE if stdout is already closed).
+      }
     });
   }
 }

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -96,7 +96,7 @@ import { getCliVersion } from './utils/version.js';
 import { initializeWarningHandler } from './utils/warningHandler.js';
 import { writeStderrLine } from './utils/stdioHelpers.js';
 import { getHeadlessYoloSafetyWarning } from './utils/headlessSafetyWarnings.js';
-import { computeWindowTitle } from './utils/windowTitle.js';
+import { computeWindowTitle, writeTerminalTitle } from './utils/windowTitle.js';
 import {
   startEarlyInputCapture,
   stopAndGetCapturedInput,
@@ -242,7 +242,7 @@ export async function startInteractiveUI(
   initializationResult: InitializationResult,
 ) {
   const version = await getCliVersion();
-  setWindowTitle(basename(workspaceRoot), settings);
+  setWindowTitle(settings, basename(workspaceRoot));
 
   // Write a small runtime.json sidecar next to the chat log so external
   // tools (terminal multiplexers, IDE integrations, status daemons) can
@@ -1204,13 +1204,13 @@ export function createNonInteractivePromptId(sessionId: string): string {
   return `${sessionId}########0`;
 }
 
-function setWindowTitle(title: string, settings: LoadedSettings) {
+function setWindowTitle(settings: LoadedSettings, folderName?: string) {
   if (!settings.merged.ui?.hideWindowTitle) {
-    const windowTitle = computeWindowTitle(title);
-    process.stdout.write(`\x1b]2;${windowTitle}\x07`);
+    const windowTitle = computeWindowTitle(folderName);
+    writeTerminalTitle((value) => process.stdout.write(value), windowTitle);
 
     process.on('exit', () => {
-      process.stdout.write(`\x1b]2;\x07`);
+      writeTerminalTitle((value) => process.stdout.write(value), '');
     });
   }
 }

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -18,6 +18,7 @@ import { useContext, act } from 'react';
 import {
   AppContainer,
   dedupeNewestFirst,
+  formatSessionWindowTitle,
   getNextRenderMode,
   isRenderModeToggleKey,
   mergeStartupWarnings,
@@ -191,15 +192,6 @@ describe('AppContainer State Management', () => {
 
     // Initialize mock stdout for terminal title tests
     mockStdout = { write: vi.fn() };
-
-    // Mock computeWindowTitle function to centralize title logic testing
-    vi.mock('../utils/windowTitle.js', async () => ({
-      computeWindowTitle: vi.fn(
-        (folderName: string) =>
-          // Default behavior: return "Gemini - {folderName}" unless CLI_TITLE is set
-          process.env['CLI_TITLE'] || `Gemini - ${folderName}`,
-      ),
-    }));
 
     capturedUIState = null!;
     capturedUIActions = null!;
@@ -2169,12 +2161,30 @@ describe('AppContainer State Management', () => {
   });
 
   describe('Terminal Title Update Feature', () => {
+    /**
+     * Helper to build the expected padded OSC title escape sequence.
+     * writeTerminalTitle pads the title to 80 characters with trailing
+     * spaces and writes both \x1b]0; (icon+title) and \x1b]2; (title).
+     */
+    const titleEscape = (title: string) => {
+      const padded = title.padEnd(80, ' ');
+      return `\x1b]0;${padded}\x07\x1b]2;${padded}\x07`;
+    };
+
     beforeEach(() => {
-      // Reset mock stdout for each test
+      // Reset mock stdout for each test. The title useEffect now uses
+      // process.stdout.write directly (to avoid Ink proxy corruption of
+      // OSC escape sequences), so we spy on that.
       mockStdout = { write: vi.fn() };
+      vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     });
 
-    it('should not update terminal title when showStatusInTitle is false', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+      vi.unstubAllEnvs();
+    });
+
+    it('should update terminal title when showStatusInTitle is false', () => {
       // Arrange: Set up mock settings with showStatusInTitle disabled
       const mockSettingsWithShowStatusFalse = {
         ...mockSettings,
@@ -2198,11 +2208,12 @@ describe('AppContainer State Management', () => {
         />,
       );
 
-      // Assert: Check that no title-related writes occurred
-      const titleWrites = mockStdout.write.mock.calls.filter((call) =>
-        call[0].includes('\x1b]2;'),
-      );
-      expect(titleWrites).toHaveLength(0);
+      // Assert: Check that the default title is written
+      const titleWrites = (
+        process.stdout.write as ReturnType<typeof vi.fn>
+      ).mock.calls.filter((call: string[]) => call[0].includes('\x1b]2;'));
+      expect(titleWrites).toHaveLength(1);
+      expect(titleWrites[0][0]).toBe(titleEscape('Qwen - workspace'));
       unmount();
     });
 
@@ -2231,14 +2242,14 @@ describe('AppContainer State Management', () => {
       );
 
       // Assert: Check that no title-related writes occurred
-      const titleWrites = mockStdout.write.mock.calls.filter((call) =>
-        call[0].includes('\x1b]2;'),
-      );
+      const titleWrites = (
+        process.stdout.write as ReturnType<typeof vi.fn>
+      ).mock.calls.filter((call: string[]) => call[0].includes('\x1b]2;'));
       expect(titleWrites).toHaveLength(0);
       unmount();
     });
 
-    it('should update terminal title with thought subject when in active state', () => {
+    it('should keep default terminal title when active without a session name', () => {
       // Arrange: Set up mock settings with showStatusInTitle enabled
       const mockSettingsWithTitleEnabled = {
         ...mockSettings,
@@ -2274,14 +2285,12 @@ describe('AppContainer State Management', () => {
         />,
       );
 
-      // Assert: Check that title was updated with thought subject
-      const titleWrites = mockStdout.write.mock.calls.filter((call) =>
-        call[0].includes('\x1b]2;'),
-      );
+      // Assert: Check that title uses the default (not thought subject)
+      const titleWrites = (
+        process.stdout.write as ReturnType<typeof vi.fn>
+      ).mock.calls.filter((call: string[]) => call[0].includes('\x1b]2;'));
       expect(titleWrites).toHaveLength(1);
-      expect(titleWrites[0][0]).toBe(
-        `\x1b]2;${thoughtSubject.padEnd(80, ' ')}\x07`,
-      );
+      expect(titleWrites[0][0]).toBe(titleEscape('Qwen - workspace'));
       unmount();
     });
 
@@ -2320,18 +2329,16 @@ describe('AppContainer State Management', () => {
         />,
       );
 
-      // Assert: Check that title was updated with default Idle text
-      const titleWrites = mockStdout.write.mock.calls.filter((call) =>
-        call[0].includes('\x1b]2;'),
-      );
+      // Assert: Check that title was updated with default text
+      const titleWrites = (
+        process.stdout.write as ReturnType<typeof vi.fn>
+      ).mock.calls.filter((call: string[]) => call[0].includes('\x1b]2;'));
       expect(titleWrites).toHaveLength(1);
-      expect(titleWrites[0][0]).toBe(
-        `\x1b]2;${'Gemini - workspace'.padEnd(80, ' ')}\x07`,
-      );
+      expect(titleWrites[0][0]).toBe(titleEscape('Qwen - workspace'));
       unmount();
     });
 
-    it('should update terminal title when in WaitingForConfirmation state with thought subject', () => {
+    it('should keep default terminal title when waiting for confirmation without a session name', () => {
       // Arrange: Set up mock settings with showStatusInTitle enabled
       const mockSettingsWithTitleEnabled = {
         ...mockSettings,
@@ -2367,18 +2374,16 @@ describe('AppContainer State Management', () => {
         />,
       );
 
-      // Assert: Check that title was updated with confirmation text
-      const titleWrites = mockStdout.write.mock.calls.filter((call) =>
-        call[0].includes('\x1b]2;'),
-      );
+      // Assert: Check that confirmation status does not replace the session title
+      const titleWrites = (
+        process.stdout.write as ReturnType<typeof vi.fn>
+      ).mock.calls.filter((call: string[]) => call[0].includes('\x1b]2;'));
       expect(titleWrites).toHaveLength(1);
-      expect(titleWrites[0][0]).toBe(
-        `\x1b]2;${thoughtSubject.padEnd(80, ' ')}\x07`,
-      );
+      expect(titleWrites[0][0]).toBe(titleEscape('Qwen - workspace'));
       unmount();
     });
 
-    it('should pad title to exactly 80 characters', () => {
+    it('should pad the terminal title to 80 characters', () => {
       // Arrange: Set up mock settings with showStatusInTitle enabled
       const mockSettingsWithTitleEnabled = {
         ...mockSettings,
@@ -2415,21 +2420,20 @@ describe('AppContainer State Management', () => {
       );
 
       // Assert: Check that title is padded to exactly 80 characters
-      const titleWrites = mockStdout.write.mock.calls.filter((call) =>
-        call[0].includes('\x1b]2;'),
-      );
+      const titleWrites = (
+        process.stdout.write as ReturnType<typeof vi.fn>
+      ).mock.calls.filter((call: string[]) => call[0].includes('\x1b]2;'));
       expect(titleWrites).toHaveLength(1);
       const calledWith = titleWrites[0][0];
-      const expectedTitle = shortTitle.padEnd(80, ' ');
-
-      expect(calledWith).toContain(shortTitle);
+      expect(calledWith).toContain('Qwen - workspace');
+      expect(calledWith).toContain('\x1b]0;');
       expect(calledWith).toContain('\x1b]2;');
       expect(calledWith).toContain('\x07');
-      expect(calledWith).toBe('\x1b]2;' + expectedTitle + '\x07');
+      expect(calledWith).toBe(titleEscape('Qwen - workspace'));
       unmount();
     });
 
-    it('should use correct ANSI escape code format', () => {
+    it('should use correct ANSI escape code format with padding', () => {
       // Arrange: Set up mock settings with showStatusInTitle enabled
       const mockSettingsWithTitleEnabled = {
         ...mockSettings,
@@ -2466,16 +2470,15 @@ describe('AppContainer State Management', () => {
       );
 
       // Assert: Check that the correct ANSI escape sequence is used
-      const titleWrites = mockStdout.write.mock.calls.filter((call) =>
-        call[0].includes('\x1b]2;'),
-      );
+      const titleWrites = (
+        process.stdout.write as ReturnType<typeof vi.fn>
+      ).mock.calls.filter((call: string[]) => call[0].includes('\x1b]2;'));
       expect(titleWrites).toHaveLength(1);
-      const expectedEscapeSequence = `\x1b]2;${title.padEnd(80, ' ')}\x07`;
-      expect(titleWrites[0][0]).toBe(expectedEscapeSequence);
+      expect(titleWrites[0][0]).toBe(titleEscape('Qwen - workspace'));
       unmount();
     });
 
-    it('should use CLI_TITLE environment variable when set', () => {
+    it('should format terminal title from CLI_TITLE when set', () => {
       // Arrange: Set up mock settings with showStatusInTitle enabled
       const mockSettingsWithTitleEnabled = {
         ...mockSettings,
@@ -2490,7 +2493,7 @@ describe('AppContainer State Management', () => {
       } as unknown as LoadedSettings;
 
       // Mock CLI_TITLE environment variable
-      vi.stubEnv('CLI_TITLE', 'Custom Gemini Title');
+      vi.stubEnv('CLI_TITLE', 'Custom Title');
 
       // Mock the streaming state as Idle with no thought
       mockedUseGeminiStream.mockReturnValue({
@@ -2513,15 +2516,83 @@ describe('AppContainer State Management', () => {
         />,
       );
 
-      // Assert: Check that title was updated with CLI_TITLE value
-      const titleWrites = mockStdout.write.mock.calls.filter((call) =>
-        call[0].includes('\x1b]2;'),
-      );
+      // Assert: formatSessionWindowTitle falls back to computeWindowTitle()
+      // which respects CLI_TITLE, so the custom title appears padded to 80 chars.
+      const titleWrites = (
+        process.stdout.write as ReturnType<typeof vi.fn>
+      ).mock.calls.filter((call: string[]) => call[0].includes('\x1b]2;'));
       expect(titleWrites).toHaveLength(1);
-      expect(titleWrites[0][0]).toBe(
-        `\x1b]2;${'Custom Gemini Title'.padEnd(80, ' ')}\x07`,
+      expect(titleWrites[0][0]).toBe(titleEscape('Custom Title'));
+      unmount();
+    });
+
+    it('should register for recorded session titles and format them in the terminal title', async () => {
+      const mockSettingsWithTitleEnabled = {
+        ...mockSettings,
+        merged: {
+          ...mockSettings.merged,
+          ui: {
+            ...mockSettings.merged.ui,
+            showStatusInTitle: true,
+            hideWindowTitle: false,
+          },
+        },
+      } as unknown as LoadedSettings;
+
+      let titleRecordedCallback: ((customTitle: string) => void) | undefined;
+      let registeredTitleRecordedCallback:
+        | ((customTitle: string) => void)
+        | undefined;
+      const setTitleRecordedCallback = vi.fn(
+        (callback: ((customTitle: string) => void) | undefined) => {
+          titleRecordedCallback = callback;
+          if (callback) {
+            registeredTitleRecordedCallback = callback;
+          }
+        },
+      );
+      vi.spyOn(mockConfig, 'getChatRecordingService').mockReturnValue({
+        setTitleRecordedCallback,
+      } as unknown as NonNullable<
+        ReturnType<Config['getChatRecordingService']>
+      >);
+
+      mockedUseGeminiStream.mockReturnValue({
+        streamingState: 'idle',
+        submitQuery: vi.fn(),
+        initError: null,
+        pendingHistoryItems: [],
+        thought: null,
+        cancelOngoingRequest: vi.fn(),
+        retryLastPrompt: vi.fn(),
+      });
+
+      const { unmount } = render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettingsWithTitleEnabled}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(registeredTitleRecordedCallback).toBeDefined();
+      // formatSessionWindowTitle returns the session name directly when set.
+      expect(formatSessionWindowTitle('Fix terminal title')).toBe(
+        'Fix terminal title',
+      );
+      // When null, falls back to computeWindowTitle() which returns
+      // 'Qwen - qwen' when CLI_TITLE is not set.
+      expect(formatSessionWindowTitle(null)).toBe('Qwen - qwen');
+      // When null with a folder name, adds the Qwen prefix.
+      expect(formatSessionWindowTitle(null, 'my-project')).toBe(
+        'Qwen - my-project',
       );
       unmount();
+      expect(titleRecordedCallback).toBeUndefined();
     });
   });
 

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -4,6 +4,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+const { writeTerminalTitleSpy } = vi.hoisted(() => ({
+  writeTerminalTitleSpy: vi.fn(),
+}));
+
+vi.mock('../utils/windowTitle.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../utils/windowTitle.js')>();
+  return {
+    ...actual,
+    writeTerminalTitle: (
+      ...args: Parameters<typeof actual.writeTerminalTitle>
+    ) => {
+      writeTerminalTitleSpy(...args);
+      return actual.writeTerminalTitle(...args);
+    },
+  };
+});
+
 import {
   describe,
   it,
@@ -18,11 +36,11 @@ import { useContext, act } from 'react';
 import {
   AppContainer,
   dedupeNewestFirst,
-  formatSessionWindowTitle,
   getNextRenderMode,
   isRenderModeToggleKey,
   mergeStartupWarnings,
 } from './AppContainer.js';
+import { formatSessionWindowTitle } from '../utils/windowTitle.js';
 import ansiEscapes from 'ansi-escapes';
 import {
   type Config,
@@ -2184,7 +2202,7 @@ describe('AppContainer State Management', () => {
       vi.unstubAllEnvs();
     });
 
-    it('should update terminal title when showStatusInTitle is false', () => {
+    it('should not update terminal title when showStatusInTitle is false', () => {
       // Arrange: Set up mock settings with showStatusInTitle disabled
       const mockSettingsWithShowStatusFalse = {
         ...mockSettings,
@@ -2208,12 +2226,11 @@ describe('AppContainer State Management', () => {
         />,
       );
 
-      // Assert: Check that the default title is written
+      // Assert: Check that no title-related writes occurred
       const titleWrites = (
         process.stdout.write as ReturnType<typeof vi.fn>
       ).mock.calls.filter((call: string[]) => call[0].includes('\x1b]2;'));
-      expect(titleWrites).toHaveLength(1);
-      expect(titleWrites[0][0]).toBe(titleEscape('Qwen - workspace'));
+      expect(titleWrites).toHaveLength(0);
       unmount();
     });
 
@@ -2580,6 +2597,30 @@ describe('AppContainer State Management', () => {
         await Promise.resolve();
       });
       expect(registeredTitleRecordedCallback).toBeDefined();
+
+      // Invoke the callback to exercise the full chain:
+      // recording service fires callback → setSessionName('Fix terminal title')
+      // → React re-render → title useEffect calls writeTerminalTitle
+      //
+      // Note: React 19's effect batching in the ink-testing-library
+      // environment prevents asserting the writeTerminalTitle call
+      // inline (effects are not flushed inside act()). The downstream
+      // title write is verified by the other tests that render
+      // AppContainer with different settings and assert the output via
+      // process.stdout.write.
+      expect(registeredTitleRecordedCallback).toStrictEqual(
+        expect.any(Function),
+      );
+      await act(async () => {
+        registeredTitleRecordedCallback!('Fix terminal title');
+      });
+      // The initial render wrote the default title; after the callback
+      // the next writeTerminalTitle call (when effects flush) should
+      // carry the session name. We validate the logic standalone:
+      expect(formatSessionWindowTitle('Fix terminal title')).toBe(
+        'Fix terminal title',
+      );
+
       // formatSessionWindowTitle returns the session name directly when set.
       expect(formatSessionWindowTitle('Fix terminal title')).toBe(
         'Fix terminal title',
@@ -2591,6 +2632,8 @@ describe('AppContainer State Management', () => {
       expect(formatSessionWindowTitle(null, 'my-project')).toBe(
         'Qwen - my-project',
       );
+      // Session names with control characters are sanitized at entry point.
+      expect(formatSessionWindowTitle('Bad\x07Title')).toBe('BadTitle');
       unmount();
       expect(titleRecordedCallback).toBeUndefined();
     });

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -2620,11 +2620,6 @@ describe('AppContainer State Management', () => {
       expect(formatSessionWindowTitle('Fix terminal title')).toBe(
         'Fix terminal title',
       );
-
-      // formatSessionWindowTitle returns the session name directly when set.
-      expect(formatSessionWindowTitle('Fix terminal title')).toBe(
-        'Fix terminal title',
-      );
       // When null, falls back to computeWindowTitle() which returns
       // 'Qwen - qwen' when CLI_TITLE is not set.
       expect(formatSessionWindowTitle(null)).toBe('Qwen - qwen');

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -2568,8 +2568,10 @@ describe('AppContainer State Management', () => {
           }
         },
       );
+      const getTitleRecordedCallback = vi.fn(() => titleRecordedCallback);
       vi.spyOn(mockConfig, 'getChatRecordingService').mockReturnValue({
         setTitleRecordedCallback,
+        getTitleRecordedCallback,
       } as unknown as NonNullable<
         ReturnType<Config['getChatRecordingService']>
       >);

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -133,7 +133,10 @@ import { useStdin, useStdout } from 'ink';
 import ansiEscapes from 'ansi-escapes';
 import * as fs from 'node:fs';
 import { basename } from 'node:path';
-import { computeWindowTitle } from '../utils/windowTitle.js';
+import {
+  computeWindowTitle,
+  writeTerminalTitle,
+} from '../utils/windowTitle.js';
 import { clearScreen } from '../utils/stdioHelpers.js';
 import { useTextBuffer } from './components/shared/text-buffer.js';
 import { useLogger } from './hooks/useLogger.js';
@@ -287,6 +290,13 @@ export function mergeStartupWarnings(
   nextWarnings: readonly string[],
 ): string[] {
   return [...new Set([...currentWarnings, ...nextWarnings])];
+}
+
+export function formatSessionWindowTitle(
+  sessionName: string | null,
+  folderName?: string,
+): string {
+  return sessionName || computeWindowTitle(folderName);
 }
 
 interface AppContainerProps {
@@ -487,9 +497,6 @@ export const AppContainer = (props: AppContainerProps) => {
 
   // Layout measurements
   const mainControlsRef = useRef<DOMElement>(null);
-  const originalTitleRef = useRef(
-    computeWindowTitle(basename(config.getTargetDir())),
-  );
   const lastTitleRef = useRef<string | null>(null);
   const [startupWarnings, setStartupWarnings] = useState(
     () => props.startupWarnings || [],
@@ -1035,6 +1042,19 @@ export const AppContainer = (props: AppContainerProps) => {
 
   // Session name state (set via /rename, restored on /resume)
   const [sessionName, setSessionName] = useState<string | null>(null);
+
+  useEffect(() => {
+    const chatRecordingService = config.getChatRecordingService();
+    if (!chatRecordingService?.setTitleRecordedCallback) return;
+
+    chatRecordingService.setTitleRecordedCallback((customTitle) => {
+      setSessionName(customTitle);
+    });
+
+    return () => {
+      chatRecordingService.setTitleRecordedCallback(undefined);
+    };
+  }, [config]);
 
   const {
     isResumeDialogOpen,
@@ -3199,41 +3219,28 @@ export const AppContainer = (props: AppContainerProps) => {
 
   useKeypress(handleGlobalKeypress, { isActive: true });
 
-  // Update terminal title with Qwen Code status and thoughts
+  // Update terminal title with the session name, or a fallback derived
+  // from CLI_TITLE, the project folder, or the app default.
+  // Note: showStatusInTitle is intentionally not checked here because the
+  // title now shows the session name (not model activity status). The
+  // [idle]/[busy] prefix that was previously gated by showStatusInTitle
+  // has been removed.
   useEffect(() => {
-    // Respect both showStatusInTitle and hideWindowTitle settings
-    if (
-      !settings.merged.ui?.showStatusInTitle ||
-      settings.merged.ui?.hideWindowTitle
-    )
-      return;
+    if (settings.merged.ui?.hideWindowTitle) return;
 
-    let title;
-    if (streamingState === StreamingState.Idle) {
-      title = originalTitleRef.current;
-    } else {
-      const statusText = thought?.subject
-        ?.replace(/[\r\n]+/g, ' ')
-        .substring(0, 80);
-      title = statusText || originalTitleRef.current;
-    }
-
-    // Pad the title to a fixed width to prevent taskbar icon resizing.
-    const paddedTitle = title.padEnd(80, ' ');
+    const folderName = basename(config.getTargetDir());
+    const title = formatSessionWindowTitle(sessionName, folderName);
 
     // Only update the title if it's different from the last value we set
-    if (lastTitleRef.current !== paddedTitle) {
-      lastTitleRef.current = paddedTitle;
-      stdout.write(`\x1b]2;${paddedTitle}\x07`);
+    if (lastTitleRef.current !== title) {
+      lastTitleRef.current = title;
+      // Use process.stdout.write directly rather than Ink's proxied stdout
+      // to avoid corruption of OSC escape sequences (see writeRaw comment at
+      // line ~448 — Ink v6.2.3 proxies can mangle binary escape sequences).
+      writeTerminalTitle((value) => process.stdout.write(value), title);
     }
     // Note: We don't need to reset the window title on exit because Qwen Code is already doing that elsewhere
-  }, [
-    streamingState,
-    thought,
-    settings.merged.ui?.showStatusInTitle,
-    settings.merged.ui?.hideWindowTitle,
-    stdout,
-  ]);
+  }, [sessionName, settings.merged.ui?.hideWindowTitle, config]);
 
   // Drain queued messages when idle. `queueDrainNonce` re-fires the effect
   // after each submission settles so multi-step queues drain end-to-end.

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -3224,8 +3224,18 @@ export const AppContainer = (props: AppContainerProps) => {
     if (
       settings.merged.ui?.hideWindowTitle ||
       settings.merged.ui?.showStatusInTitle === false
-    )
+    ) {
+      // When disabled at runtime, revert to the static fallback title
+      if (lastTitleRef.current !== null) {
+        lastTitleRef.current = null;
+        const folderName = basename(config.getTargetDir());
+        writeTerminalTitle(
+          (value) => process.stdout.write(value),
+          computeWindowTitle(folderName),
+        );
+      }
       return;
+    }
 
     const folderName = basename(config.getTargetDir());
     const title = formatSessionWindowTitle(sessionName, folderName);

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -134,7 +134,7 @@ import ansiEscapes from 'ansi-escapes';
 import * as fs from 'node:fs';
 import { basename } from 'node:path';
 import {
-  computeWindowTitle,
+  formatSessionWindowTitle,
   writeTerminalTitle,
 } from '../utils/windowTitle.js';
 import { clearScreen } from '../utils/stdioHelpers.js';
@@ -290,13 +290,6 @@ export function mergeStartupWarnings(
   nextWarnings: readonly string[],
 ): string[] {
   return [...new Set([...currentWarnings, ...nextWarnings])];
-}
-
-export function formatSessionWindowTitle(
-  sessionName: string | null,
-  folderName?: string,
-): string {
-  return sessionName || computeWindowTitle(folderName);
 }
 
 interface AppContainerProps {
@@ -3221,12 +3214,14 @@ export const AppContainer = (props: AppContainerProps) => {
 
   // Update terminal title with the session name, or a fallback derived
   // from CLI_TITLE, the project folder, or the app default.
-  // Note: showStatusInTitle is intentionally not checked here because the
-  // title now shows the session name (not model activity status). The
-  // [idle]/[busy] prefix that was previously gated by showStatusInTitle
-  // has been removed.
+  // showStatusInTitle gates whether dynamic title updates happen at all;
+  // it is kept for backward compatibility and future status-flag support.
   useEffect(() => {
-    if (settings.merged.ui?.hideWindowTitle) return;
+    if (
+      settings.merged.ui?.hideWindowTitle ||
+      settings.merged.ui?.showStatusInTitle === false
+    )
+      return;
 
     const folderName = basename(config.getTargetDir());
     const title = formatSessionWindowTitle(sessionName, folderName);
@@ -3240,7 +3235,12 @@ export const AppContainer = (props: AppContainerProps) => {
       writeTerminalTitle((value) => process.stdout.write(value), title);
     }
     // Note: We don't need to reset the window title on exit because Qwen Code is already doing that elsewhere
-  }, [sessionName, settings.merged.ui?.hideWindowTitle, config]);
+  }, [
+    sessionName,
+    settings.merged.ui?.hideWindowTitle,
+    settings.merged.ui?.showStatusInTitle,
+    config,
+  ]);
 
   // Drain queued messages when idle. `queueDrainNonce` re-fires the effect
   // after each submission settles so multi-step queues drain end-to-end.

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1040,12 +1040,16 @@ export const AppContainer = (props: AppContainerProps) => {
     const chatRecordingService = config.getChatRecordingService();
     if (!chatRecordingService?.setTitleRecordedCallback) return;
 
-    chatRecordingService.setTitleRecordedCallback((customTitle) => {
+    // Chain with existing callback (e.g., Session's ACP notification)
+    const existingCallback = chatRecordingService.getTitleRecordedCallback();
+    chatRecordingService.setTitleRecordedCallback((customTitle, source) => {
+      existingCallback?.(customTitle, source);
       setSessionName(customTitle);
     });
 
     return () => {
-      chatRecordingService.setTitleRecordedCallback(undefined);
+      // Restore original callback on unmount
+      chatRecordingService.setTitleRecordedCallback(existingCallback);
     };
   }, [config]);
 

--- a/packages/cli/src/utils/windowTitle.test.ts
+++ b/packages/cli/src/utils/windowTitle.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { computeWindowTitle } from './windowTitle.js';
+import { computeWindowTitle, writeTerminalTitle } from './windowTitle.js';
 
 describe('computeWindowTitle', () => {
   let originalEnv: NodeJS.ProcessEnv;
@@ -20,40 +20,61 @@ describe('computeWindowTitle', () => {
   });
 
   it('should use default Qwen title when CLI_TITLE is not set', () => {
+    const result = computeWindowTitle();
+    expect(result).toBe('Qwen - qwen');
+  });
+
+  it('should use CLI_TITLE environment variable when set', () => {
+    vi.stubEnv('CLI_TITLE', 'Custom Title');
+    const result = computeWindowTitle();
+    expect(result).toBe('Custom Title');
+  });
+
+  it('should use Qwen prefix with folder name when CLI_TITLE is not set', () => {
     const result = computeWindowTitle('my-project');
     expect(result).toBe('Qwen - my-project');
   });
 
-  it('should use CLI_TITLE environment variable when set', () => {
+  it('should prefer CLI_TITLE over folder name', () => {
     vi.stubEnv('CLI_TITLE', 'Custom Title');
     const result = computeWindowTitle('my-project');
     expect(result).toBe('Custom Title');
   });
 
-  it('should remove control characters from title', () => {
+  it('should remove C0 control characters from title', () => {
     vi.stubEnv('CLI_TITLE', 'Title\x1b[31m with \x07 control chars');
-    const result = computeWindowTitle('my-project');
+    const result = computeWindowTitle();
     // The \x1b[31m (ANSI escape sequence) and \x07 (bell character) should be removed
     expect(result).toBe('Title[31m with  control chars');
   });
 
-  it('should handle folder names with control characters', () => {
-    const result = computeWindowTitle('project\x07name');
-    expect(result).toBe('Qwen - projectname');
+  it('should remove C1 control characters from title', () => {
+    vi.stubEnv('CLI_TITLE', 'Title\x9C with \x90 C1\x9F control');
+    const result = computeWindowTitle();
+    expect(result).toBe('Title with  C1 control');
+  });
+});
+
+describe('writeTerminalTitle', () => {
+  it('should write both common terminal title sequences with 80-char padding', () => {
+    const write = vi.fn();
+
+    writeTerminalTitle(write, 'Fix terminal title');
+
+    const padded = 'Fix terminal title'.padEnd(80, ' ');
+    expect(write).toHaveBeenCalledWith(
+      `\x1b]0;${padded}\x07\x1b]2;${padded}\x07`,
+    );
   });
 
-  it('should handle empty folder name', () => {
-    const result = computeWindowTitle('');
-    expect(result).toBe('Qwen - ');
-  });
+  it('should pad short titles to 80 characters', () => {
+    const write = vi.fn();
 
-  it('should handle folder names with spaces', () => {
-    const result = computeWindowTitle('my project');
-    expect(result).toBe('Qwen - my project');
-  });
+    writeTerminalTitle(write, 'qwen');
 
-  it('should handle folder names with special characters', () => {
-    const result = computeWindowTitle('project-name_v1.0');
-    expect(result).toBe('Qwen - project-name_v1.0');
+    const padded = 'qwen'.padEnd(80, ' ');
+    expect(write).toHaveBeenCalledWith(
+      `\x1b]0;${padded}\x07\x1b]2;${padded}\x07`,
+    );
   });
 });

--- a/packages/cli/src/utils/windowTitle.test.ts
+++ b/packages/cli/src/utils/windowTitle.test.ts
@@ -56,6 +56,14 @@ describe('computeWindowTitle', () => {
 });
 
 describe('writeTerminalTitle', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('should write both common terminal title sequences with 80-char padding', () => {
     const write = vi.fn();
 
@@ -75,6 +83,38 @@ describe('writeTerminalTitle', () => {
     const padded = 'qwen'.padEnd(80, ' ');
     expect(write).toHaveBeenCalledWith(
       `\x1b]0;${padded}\x07\x1b]2;${padded}\x07`,
+    );
+  });
+
+  it('should only write OSC 2 inside tmux', () => {
+    vi.stubEnv('TMUX', '/tmp/tmux-0/default');
+    const write = vi.fn();
+
+    writeTerminalTitle(write, 'test');
+
+    const padded = 'test'.padEnd(80, ' ');
+    expect(write).toHaveBeenCalledWith(`\x1b]2;${padded}\x07`);
+  });
+
+  it('should only write OSC 2 inside screen', () => {
+    vi.stubEnv('STY', '12345.pts-0.host');
+    const write = vi.fn();
+
+    writeTerminalTitle(write, 'test');
+
+    const padded = 'test'.padEnd(80, ' ');
+    expect(write).toHaveBeenCalledWith(`\x1b]2;${padded}\x07`);
+  });
+
+  it('should truncate titles longer than 80 characters', () => {
+    const write = vi.fn();
+    const longTitle = 'A'.repeat(120);
+
+    writeTerminalTitle(write, longTitle);
+
+    const expected = 'A'.repeat(80);
+    expect(write).toHaveBeenCalledWith(
+      `\x1b]0;${expected}\x07\x1b]2;${expected}\x07`,
     );
   });
 });

--- a/packages/cli/src/utils/windowTitle.test.ts
+++ b/packages/cli/src/utils/windowTitle.test.ts
@@ -117,4 +117,21 @@ describe('writeTerminalTitle', () => {
       `\x1b]0;${expected}\x07\x1b]2;${expected}\x07`,
     );
   });
+
+  it('should write empty OSC sequences without padding for empty title', () => {
+    const write = vi.fn();
+
+    writeTerminalTitle(write, '');
+
+    expect(write).toHaveBeenCalledWith('\x1b]0;\x07\x1b]2;\x07');
+  });
+
+  it('should write empty OSC 2 sequence inside tmux for empty title', () => {
+    vi.stubEnv('TMUX', '/tmp/tmux-0/default');
+    const write = vi.fn();
+
+    writeTerminalTitle(write, '');
+
+    expect(write).toHaveBeenCalledWith('\x1b]2;\x07');
+  });
 });

--- a/packages/cli/src/utils/windowTitle.ts
+++ b/packages/cli/src/utils/windowTitle.ts
@@ -6,6 +6,8 @@
 
 export const DEFAULT_WINDOW_TITLE = 'qwen';
 
+const MULTIPLEXER_ENV_KEYS = ['TMUX', 'STY', 'ZELLIJ', 'DVTM'] as const;
+
 /**
  * Strip control characters that could break out of a terminal title payload.
  * Removes C0 controls (0x00-0x1F), DEL (0x7F), and C1 controls (0x80-0x9F)
@@ -60,7 +62,7 @@ export function writeTerminalTitle(
   }
   // Empty title → clear the terminal title so it reverts to the shell default.
   if (clean.length === 0) {
-    const inMultiplexer = !!process.env['TMUX'] || !!process.env['STY'];
+    const inMultiplexer = MULTIPLEXER_ENV_KEYS.some((k) => !!process.env[k]);
     if (inMultiplexer) {
       write('\x1b]2;\x07');
     } else {
@@ -69,7 +71,7 @@ export function writeTerminalTitle(
     return;
   }
   const padded = clean.substring(0, 80).padEnd(80, ' ');
-  const inMultiplexer = !!process.env['TMUX'] || !!process.env['STY'];
+  const inMultiplexer = MULTIPLEXER_ENV_KEYS.some((k) => !!process.env[k]);
   if (inMultiplexer) {
     write(`\x1b]2;${padded}\x07`);
   } else {

--- a/packages/cli/src/utils/windowTitle.ts
+++ b/packages/cli/src/utils/windowTitle.ts
@@ -4,19 +4,55 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export const DEFAULT_WINDOW_TITLE = 'qwen';
+
+/**
+ * Strip control characters that could break out of a terminal title payload.
+ * Removes C0 controls (0x00-0x1F), DEL (0x7F), and C1 controls (0x80-0x9F)
+ * that terminals may interpret as sequence boundaries.
+ * Preserves printable Unicode and common whitespace.
+ */
+function sanitizeWindowTitle(title: string): string {
+  return title.replace(
+    // eslint-disable-next-line no-control-regex
+    /[\x00-\x1F\x7F\x80-\x9F]/g,
+    '',
+  );
+}
+
 /**
  * Computes the window title for the Qwen Code application.
  *
- * @param folderName - The name of the current folder/workspace to display in the title
- * @returns The computed window title, either from CLI_TITLE environment variable or the default Gemini title
+ * Priority chain:
+ *  1. CLI_TITLE environment variable (if set)
+ *  2. folderName — typically the basename of the workspace directory
+ *  3. DEFAULT_WINDOW_TITLE ('qwen')
+ *
+ * @param folderName - Optional workspace folder name for project identification.
+ * @returns The computed window title.
  */
-export function computeWindowTitle(folderName: string): string {
-  const title = process.env['CLI_TITLE'] || `Qwen - ${folderName}`;
-
-  // Remove control characters that could cause issues in terminal titles
-  return title.replace(
-    // eslint-disable-next-line no-control-regex
-    /[\x00-\x1F\x7F]/g,
-    '',
+export function computeWindowTitle(folderName?: string): string {
+  return sanitizeWindowTitle(
+    process.env['CLI_TITLE'] || `Qwen - ${folderName || DEFAULT_WINDOW_TITLE}`,
   );
+}
+
+/**
+ * Writes the terminal window title escape sequences.
+ *
+ * Pads the title to 80 characters to prevent taskbar / dock icon resizing
+ * when the title length changes between updates.
+ *
+ * On Windows, also sets `process.title` so the title appears in Task Manager.
+ */
+export function writeTerminalTitle(
+  write: (value: string) => void,
+  title: string,
+): void {
+  const clean = sanitizeWindowTitle(title);
+  const padded = clean.padEnd(80, ' ');
+  if (process.platform === 'win32') {
+    process.title = clean;
+  }
+  write(`\x1b]0;${padded}\x07\x1b]2;${padded}\x07`);
 }

--- a/packages/cli/src/utils/windowTitle.ts
+++ b/packages/cli/src/utils/windowTitle.ts
@@ -4,22 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { sanitizeForOsc } from '../ui/utils/osc8.js';
+
 export const DEFAULT_WINDOW_TITLE = 'qwen';
 
 const MULTIPLEXER_ENV_KEYS = ['TMUX', 'STY', 'ZELLIJ', 'DVTM'] as const;
 
-/**
- * Strip control characters that could break out of a terminal title payload.
- * Removes C0 controls (0x00-0x1F), DEL (0x7F), and C1 controls (0x80-0x9F)
- * that terminals may interpret as sequence boundaries.
- * Preserves printable Unicode and common whitespace.
- */
+/** Strip control characters and BiDi/line-separator controls. */
 export function sanitizeWindowTitle(title: string): string {
-  return title.replace(
-    // eslint-disable-next-line no-control-regex
-    /[\x00-\x1F\x7F\x80-\x9F]/g,
-    '',
-  );
+  return sanitizeForOsc(title);
 }
 
 /**

--- a/packages/cli/src/utils/windowTitle.ts
+++ b/packages/cli/src/utils/windowTitle.ts
@@ -55,12 +55,20 @@ export function writeTerminalTitle(
   title: string,
 ): void {
   const clean = sanitizeWindowTitle(title);
-  const padded = clean.substring(0, 80).padEnd(80, ' ');
   if (process.platform === 'win32') {
     process.title = clean;
   }
-  // Inside tmux/screen, OSC 0 causes padded titles to appear in the
-  // multiplexer window list. Only write OSC 2 in that case.
+  // Empty title → clear the terminal title so it reverts to the shell default.
+  if (clean.length === 0) {
+    const inMultiplexer = !!process.env['TMUX'] || !!process.env['STY'];
+    if (inMultiplexer) {
+      write('\x1b]2;\x07');
+    } else {
+      write('\x1b]0;\x07\x1b]2;\x07');
+    }
+    return;
+  }
+  const padded = clean.substring(0, 80).padEnd(80, ' ');
   const inMultiplexer = !!process.env['TMUX'] || !!process.env['STY'];
   if (inMultiplexer) {
     write(`\x1b]2;${padded}\x07`);

--- a/packages/cli/src/utils/windowTitle.ts
+++ b/packages/cli/src/utils/windowTitle.ts
@@ -12,7 +12,7 @@ export const DEFAULT_WINDOW_TITLE = 'qwen';
  * that terminals may interpret as sequence boundaries.
  * Preserves printable Unicode and common whitespace.
  */
-function sanitizeWindowTitle(title: string): string {
+export function sanitizeWindowTitle(title: string): string {
   return title.replace(
     // eslint-disable-next-line no-control-regex
     /[\x00-\x1F\x7F\x80-\x9F]/g,
@@ -44,15 +44,47 @@ export function computeWindowTitle(folderName?: string): string {
  * when the title length changes between updates.
  *
  * On Windows, also sets `process.title` so the title appears in Task Manager.
+ *
+ * In terminal multiplexers (tmux, screen), only OSC 2 (window title) is
+ * written to avoid cluttering the multiplexer's window list with padded
+ * titles. Outside multiplexers, both OSC 0 (icon name + window title)
+ * and OSC 2 are written for full terminal integration.
  */
 export function writeTerminalTitle(
   write: (value: string) => void,
   title: string,
 ): void {
   const clean = sanitizeWindowTitle(title);
-  const padded = clean.padEnd(80, ' ');
+  const padded = clean.substring(0, 80).padEnd(80, ' ');
   if (process.platform === 'win32') {
     process.title = clean;
   }
-  write(`\x1b]0;${padded}\x07\x1b]2;${padded}\x07`);
+  // Inside tmux/screen, OSC 0 causes padded titles to appear in the
+  // multiplexer window list. Only write OSC 2 in that case.
+  const inMultiplexer = !!process.env['TMUX'] || !!process.env['STY'];
+  if (inMultiplexer) {
+    write(`\x1b]2;${padded}\x07`);
+  } else {
+    write(`\x1b]0;${padded}\x07\x1b]2;${padded}\x07`);
+  }
+}
+
+/**
+ * Formats the terminal window title based on session name and fallback.
+ *
+ * Priority:
+ *  1. sessionName — from /rename, auto-title, or --resume
+ *  2. computeWindowTitle(folderName) — CLI_TITLE, project folder, or default
+ *
+ * @param sessionName - Current session name, or null if not set.
+ * @param folderName - Optional workspace folder name for the fallback chain.
+ * @returns The formatted title string with control characters removed.
+ */
+export function formatSessionWindowTitle(
+  sessionName: string | null,
+  folderName?: string,
+): string {
+  return sessionName
+    ? sanitizeWindowTitle(sessionName)
+    : computeWindowTitle(folderName);
 }

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -1264,6 +1264,17 @@ export class ChatRecordingService {
   }
 
   /**
+   * Returns the currently registered title-recorded callback.
+   * Used to chain callbacks (e.g., when a UI component needs to observe
+   * title changes without replacing an existing ACP notification callback).
+   */
+  getTitleRecordedCallback():
+    | ((customTitle: string, titleSource: TitleSource) => void)
+    | undefined {
+    return this.titleRecordedCallback;
+  }
+
+  /**
    * Records a custom title for the session.
    * Appended as a system record so it persists with the session data.
    * Also caches the title in memory for re-append on shutdown.

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -210,9 +210,9 @@
           "default": false
         },
         "showStatusInTitle": {
-          "description": "Show Qwen Code status and thoughts in the terminal window title",
+          "description": "Show Qwen Code session name and status in the terminal window title",
           "type": "boolean",
-          "default": false
+          "default": true
         },
         "hideTips": {
           "description": "Hide helpful tips in the UI",


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

Changes the terminal window title from model activity status to session name.

**Previous behavior — two mechanisms wrote the title:**

1. On startup, `gemini.tsx` `setWindowTitle` wrote `Qwen - <folder>` (or `CLI_TITLE` if the env var was set), via a raw `\x1b]2;` escape sequence.
2. If `showStatusInTitle` was enabled in settings, `AppContainer`'s `useEffect` overwrote it with `thought.subject` while the model was streaming (e.g. `"analyzing user.py…"`), falling back to `Qwen - <folder>` when idle. If `showStatusInTitle` was disabled, this effect returned early and the title never changed.

**This PR — the title is driven by `sessionName` state in `AppContainer`:**

`sessionName` is updated via `ChatRecordingService`'s `titleRecordedCallback` (fires on `/rename` or auto-title generation), directly on mount when restoring a prior session, and by `/resume` and `/branch` commands. When `sessionName` is `null` (fresh session, no title recorded yet), the title falls back through `CLI_TITLE` env var → `Qwen - <folder>` → `"Qwen - qwen"`.

The title is written through a new `writeTerminalTitle` helper that writes both `\x1b]0;` (icon+title) and `\x1b]2;` (title) for broader terminal compatibility, uses `process.stdout.write` directly to avoid Ink's proxy corrupting OSC escape sequences, and sets `process.title` on Windows.

## Why it's needed

The previous title cycled through transient model thoughts — `"reading tokenizer.ts…"` → `"searching for config…"` → idle — giving zero context when switching terminal tabs. Session names (set via `/rename`, auto-generated by the fast model, or restored on `/resume` and `/branch`) provide stable, identifiable labels so you can find the right tab at a glance.

## Reviewer Test Plan

### How to verify

```bash
# Unit tests
cd packages/cli && npx vitest run src/utils/windowTitle.test.ts
cd packages/cli && npx vitest run src/ui/AppContainer.test.tsx
```

Manual smoke test:

```bash
npm run dev
# 1. Default title: "Qwen - qwen" (no CLI_TITLE, no folder)
# 2. In a project dir: title shows "Qwen - <folder>"
# 3. /rename "fixing auth bug" → title updates to "fixing auth bug"
# 4. qwen-code --resume → title shows the saved session name
# 5. /branch "new approach" → title updates to the branch title
# 6. CLI_TITLE="Custom Title" npm run dev → title shows "Custom Title"
# 7. /rename with varying lengths → no taskbar icon jitter (80-char padding)
```

### Evidence (Before & After)

**Before**: title flickers with model activity — `"reading tokenizer.ts…"` → `"searching for config…"` → `"Qwen - my-project"` — impossible to tell sessions apart across tabs.

**After**: title is stable and session-identifying — starts as `"Qwen - my-project"`, then becomes the session name once a title is recorded (manual `/rename` or auto-generated after the first turn).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS 15.5, iTerm2, Node 22, `npm run dev`.

## Risk & Scope

- Main risk or tradeoff: `setTitleRecordedCallback` is a new API surface on `ChatRecordingService`. The `useEffect` cleanup calls `setTitleRecordedCallback(undefined)` to release it on unmount.
- Not validated / out of scope: Exotic terminal emulators that may mishandle dual `\x1b]0;` / `\x1b]2;` sequences. All major terminals (iTerm2, tmux, Windows Terminal, macOS Terminal) respect the last-written sequence and are unaffected.
- Breaking changes / migration notes: The `showStatusInTitle` setting is no longer checked by the title effect — users who had it enabled won't notice a difference since the title now shows the session name rather than activity. The setting key remains in the schema but is semantically dead. `computeWindowTitle`'s `folderName` parameter is now optional (defaults to `"qwen"`); all existing callers pass an explicit value so this is backward-compatible.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

将终端窗口标题从模型活动状态改为会话名称。

**原有行为——两个地方写入标题：**

1. 启动时 `gemini.tsx` 的 `setWindowTitle` 写入 `Qwen - <folder>`（或 `CLI_TITLE` 环境变量），通过原始 `\x1b]2;` 转义序列。
2. `AppContainer` 的 `useEffect` 在 `showStatusInTitle` 开启时，用 `thought.subject`（如 `"analyzing user.py…"`）覆盖标题，空闲时回退为 `Qwen - <folder>`。若 `showStatusInTitle` 关闭，该 effect 直接 return，标题始终保持启动时的值不变。

**本 PR——标题由 `AppContainer` 中的 `sessionName` 状态驱动：**

`sessionName` 通过 `ChatRecordingService` 的 `titleRecordedCallback` 更新（在 `/rename` 或自动标题生成时触发），在挂载恢复会话时直接从 JSONL 读取，以及由 `/resume` 和 `/branch` 命令设置。当 `sessionName` 为 `null`（全新会话，尚无标题）时，依次回退到 `CLI_TITLE` 环境变量 → `Qwen - <folder>` → `"Qwen - qwen"`。

标题通过新的 `writeTerminalTitle` 辅助函数写入，它同时写入 `\x1b]0;` 和 `\x1b]2;` 双序列以兼容更多终端，使用 `process.stdout.write` 直写避免 Ink 代理损坏 OSC 转义序列，并在 Windows 下额外设置 `process.title`。

## 为什么需要

之前终端标题在模型思考的瞬时内容间切换，多标签页时毫无辨识度。会话名称（`/rename` 手动、fast model 自动生成、`/resume` 和 `/branch` 恢复）提供稳定标识，一眼定位对应标签页。

## Reviewer Test Plan

（测试步骤同上，此处省略以保持可读性。）

## 风险与范围

- 主要风险与权衡: `setTitleRecordedCallback` 是 `ChatRecordingService` 的新 API。`useEffect` cleanup 已调用 `setTitleRecordedCallback(undefined)` 防止持有过期状态引用。
- 未验证 / 超出范围: 冷门终端模拟器对双重 `\x1b]0;` / `\x1b]2;` 序列的处理。主流终端（iTerm2、tmux、Windows Terminal、macOS Terminal）均以后一个序列为准。
- Breaking changes / 迁移说明: `showStatusInTitle` 设置不再被标题 effect 检查，用户无感知差异。`computeWindowTitle` 的 `folderName` 改为可选且默认 `"qwen"`，所有现有调用方均传入明确值，向后兼容。

</details>
