### PR TITLE
fix(dingtalk): reopen code fences without inserting a blank line

### DIFF
--- a/packages/channels/dingtalk/src/markdown.test.ts
+++ b/packages/channels/dingtalk/src/markdown.test.ts
@@ -93,6 +93,17 @@ describe('DingTalk markdown utilities', () => {
         expect(chunks[1]!.trimStart().startsWith('```')).toBe(true);
       }
     });
+
+    it('reopens code fences without inserting a blank line', () => {
+      const longCode = '```\n' + 'x\n'.repeat(2000) + '```';
+      const chunks = splitChunks(longCode);
+      expect(chunks.length).toBeGreaterThan(1);
+      // The reopened fence must be followed by the code, not a blank line.
+      // A blank line here renders as spurious leading whitespace in the
+      // continued code block.
+      expect(chunks[1]!.startsWith('```\n\n')).toBe(false);
+      expect(chunks[1]!.startsWith('```\nx')).toBe(true);
+    });
   });
 
   describe('extractTitle', () => {

--- a/packages/channels/dingtalk/src/markdown.ts
+++ b/packages/channels/dingtalk/src/markdown.ts
@@ -99,7 +99,7 @@ export function splitChunks(text: string): string[] {
         buf += '\n```';
       }
       chunks.push(buf);
-      buf = inCode ? '```\n' : '';
+      buf = inCode ? '```' : '';
     }
 
     buf += (buf ? '\n' : '') + line;


### PR DESCRIPTION
## What this PR does

In `splitChunks`, when a code block spans the chunk limit the next chunk reopens the fence with a value that already ends in a newline, and the line-append step then adds a second newline. The continued chunk therefore begins with the fence followed by a blank line instead of the code. This drops the trailing newline from the reopened fence and lets the existing append add the single separator.

## Why it's needed

A fenced code block longer than the 3800-char DingTalk limit gets a spurious blank first line in every continued chunk, which renders as leading whitespace inside the code. The existing fence test only checked `trimStart().startsWith('```')`, so it didn't catch the extra newline.

## Reviewer Test Plan

### How to verify

Run `npx vitest run packages/channels/dingtalk/src/markdown.test.ts`. The new test `reopens code fences without inserting a blank line` builds a code block past the chunk limit and asserts the continued chunk starts with the fence directly followed by the code, not a blank line. It fails before this change and passes after; the other 16 markdown tests are unchanged.

### Evidence (Before & After)

N/A — non–user-visible string handling, covered by the new unit test.
