### PR TITLE
docs: fix SSE ring size errors and add /workflows command

### DIFF
--- a/docs/developers/examples/daemon-client-quickstart.md
+++ b/docs/developers/examples/daemon-client-quickstart.md
@@ -156,7 +156,7 @@ for await (const event of client.subscribeEvents(session.sessionId, {
 }
 ```
 
-The daemon retains the last 4000 events per session in a ring buffer; gaps beyond that window won't be re-deliverable.
+The daemon retains the last 8000 events per session in a ring buffer; gaps beyond that window won't be re-deliverable.
 
 ## Voting on permissions
 

--- a/docs/developers/qwen-serve-protocol.md
+++ b/docs/developers/qwen-serve-protocol.md
@@ -1085,7 +1085,7 @@ Response:
 
 `attached: true` means the session was already live (either from a prior `session/load`/`session/resume`, or because a coalesced concurrent caller raced just ahead).
 
-**History replay over SSE.** While `loadSession` is in flight on the agent side, the agent emits `session_update` notifications for every persisted turn. The daemon buffers them onto the session's event-bus before the route response returns, so subscribers that immediately call `GET /session/:id/events` with `Last-Event-ID: 0` see the full replay. **The replay ring is bounded** (default 4000 frames per session). Long histories with many tool-call / thought-stream turns can exceed that — the oldest frames are dropped silently. Clients that need full history should subscribe immediately after `load` returns; alternatively they can persist the SSE event ids and use `Last-Event-ID` to resume from a later turn boundary.
+**History replay over SSE.** While `loadSession` is in flight on the agent side, the agent emits `session_update` notifications for every persisted turn. The daemon buffers them onto the session's event-bus before the route response returns, so subscribers that immediately call `GET /session/:id/events` with `Last-Event-ID: 0` see the full replay. **The replay ring is bounded** (default 8000 frames per session). Long histories with many tool-call / thought-stream turns can exceed that — the oldest frames are dropped silently. Clients that need full history should subscribe immediately after `load` returns; alternatively they can persist the SSE event ids and use `Last-Event-ID` to resume from a later turn boundary.
 
 **Errors:**
 

--- a/docs/users/features/commands.md
+++ b/docs/users/features/commands.md
@@ -94,6 +94,7 @@ Commands for managing AI tools and models.
 | `/arena`         | Manage Arena sessions                         | `/arena start`, `/arena status`               |
 | `/goal`          | Set a goal — keep working until condition met | `/goal <condition>`, `/goal clear`            |
 | `/tasks`         | List background tasks                         | `/tasks`                                      |
+| `/workflows`     | Inspect workflow runs                         | `/workflows`, `/workflows <runId>`            |
 | `/lsp`           | Show LSP server status                        | `/lsp`                                        |
 | `/trust`         | Manage folder trust settings                  | `/trust`                                      |
 

--- a/docs/users/qwen-serve.md
+++ b/docs/users/qwen-serve.md
@@ -161,7 +161,7 @@ curl -N http://127.0.0.1:4170/session/$SESSION_ID/events
 The `data:` line is the **full event envelope** — `{id?, v, type, data, originatorClientId?}` — JSON-stringified on a single line. The ACP payload (the `sessionUpdate` block in this example) sits under `data` inside that envelope. The SSE-level `id:` / `event:` lines are convenience for EventSource clients; the same values appear inside the JSON envelope so raw-`fetch` consumers get them too.
 
 Open this **before** sending the prompt — the SSE replay buffer holds the
-last 4000 events so a late subscriber can catch up via `Last-Event-ID`,
+last 8000 events so a late subscriber can catch up via `Last-Event-ID`,
 but for the simple "watch a single prompt" case it's easiest to subscribe
 first and let it stream live.
 
@@ -357,7 +357,7 @@ for await (const event of session.events()) {
 
 Pre-flight `caps.features.session_load` / `caps.features.session_resume` before calling — older daemons return `404`. `unstable_session_resume` is still advertised as a deprecated compatibility alias. Concurrent same-action requests for the same id coalesce; cross-action races (a `load` racing a `resume`) get `409 restore_in_progress` with `Retry-After: 5`. See the [protocol reference](../developers/qwen-serve-protocol.md) for the full error envelope.
 
-Note: history replay is bounded by the SSE ring (default 4000 frames). Long histories with chatty turns can exceed that — earliest frames are dropped silently. For very long sessions, prefer `resume` and rely on the client's local persisted UI.
+Note: history replay is bounded by the SSE ring (default 8000 frames). Long histories with chatty turns can exceed that — earliest frames are dropped silently. For very long sessions, prefer `resume` and rely on the client's local persisted UI.
 
 ## Durability model
 
@@ -365,7 +365,7 @@ Note: history replay is bounded by the SSE ring (default 4000 frames). Long hist
 
 - A child process crash publishes `session_died` and removes the live session from the daemon's maps. The persisted on-disk session **can** be reloaded via `POST /session/:id/load` if a fresh agent child is spawnable.
 - A daemon restart loses every in-flight live session. The persisted sessions remain on disk and can be loaded against a new daemon process, subject to the same workspace binding rules.
-- Long client disconnects (>5 min on a chatty turn) can outrun the SSE replay ring (default 4000 frames) — `Last-Event-ID` reconnect succeeds but state may be incoherent. For mobile / flaky-network clients, plan to re-open SSE on long drops or call `POST /session/:id/load` to replay from disk.
+- Long client disconnects (>5 min on a chatty turn) can outrun the SSE replay ring (default 8000 frames) — `Last-Event-ID` reconnect succeeds but state may be incoherent. For mobile / flaky-network clients, plan to re-open SSE on long drops or call `POST /session/:id/load` to replay from disk.
 - File operations (`writeTextFile`) are atomic across crashes (write-then-rename); they aren't atomic across daemon restarts in the sense of replaying — the file write either landed or it didn't.
 
 If your integration needs server-side cross-restart durability beyond what `session/load` covers (e.g. server-managed retry queues), you still need application-level state recovery. Don't hold long-running, restart-sensitive state inside the daemon's session.
@@ -383,7 +383,7 @@ Stage 1's contract is sized for prototyping. Per [#3889 chiga0 downstream-consum
 
 3. ~~**Client-initiated heartbeat path**~~ — shipped via [#4175](https://github.com/QwenLM/qwen-code/issues/4175) PR 9. `POST /session/:id/heartbeat` records last-seen timestamps on the daemon (capability tag `client_heartbeat`); SDK helpers are `DaemonClient.heartbeat()` / `DaemonSessionClient.heartbeat()`.
 4. **`permission_already_resolved` event** when a vote loses the first-responder race — currently UIs have to infer state from a `404`.
-5. **Larger / per-session-configurable replay ring** — default 4000 covers short drops; mobile / chatty-turn workloads need 8000+ or per-session config.
+5. **Larger / per-session-configurable replay ring** — default 8000 covers short drops; mobile / chatty-turn workloads need 8000+ or per-session config.
 6. **`slow_client_warning` event before `client_evicted`** — soft backpressure so well-behaved slow clients can self-throttle (trim render depth, drop chunks) before being terminated.
 
 **Integration ergonomics:**

--- a/docs/users/qwen-serve.md
+++ b/docs/users/qwen-serve.md
@@ -383,7 +383,7 @@ Stage 1's contract is sized for prototyping. Per [#3889 chiga0 downstream-consum
 
 3. ~~**Client-initiated heartbeat path**~~ — shipped via [#4175](https://github.com/QwenLM/qwen-code/issues/4175) PR 9. `POST /session/:id/heartbeat` records last-seen timestamps on the daemon (capability tag `client_heartbeat`); SDK helpers are `DaemonClient.heartbeat()` / `DaemonSessionClient.heartbeat()`.
 4. **`permission_already_resolved` event** when a vote loses the first-responder race — currently UIs have to infer state from a `404`.
-5. **Larger / per-session-configurable replay ring** — default 8000 covers short drops; mobile / chatty-turn workloads need 8000+ or per-session config.
+5. ~~**Larger replay ring**~~ — bumped to 8000. **Per-session-configurable ring** still open — mobile / chatty-turn workloads may need per-session overrides.
 6. **`slow_client_warning` event before `client_evicted`** — soft backpressure so well-behaved slow clients can self-throttle (trim render depth, drop chunks) before being terminated.
 
 **Integration ergonomics:**


### PR DESCRIPTION
## What this PR does

Corrects the documented SSE / daemon event ring-buffer size from `4000` to `8000` everywhere it appeared in the docs, and adds the `/workflows` slash command to the user commands reference.

## Why it's needed

The docs stated the event ring buffer retains the last **4000** events per session, but the implementation default is **8000**: `DEFAULT_RING_SIZE = 8000` in `packages/acp-bridge/src/eventBus.ts` (daemon event bus) and the `qwen serve` SSE ring `eventRingSize` likewise defaults to `8000` (`packages/cli/src/serve/types.ts`, confirmed by `server.test.ts`). The stale `4000` figure could mislead integrators into under-sizing their gap-recovery / replay logic. Separately, the `/workflows` command (workflow-run inspection, backed by `WorkflowRunRegistry`) shipped recently but was missing from the commands reference.

## Reviewer Test Plan

### How to verify

Confirm the implementation defaults and that no stale ring-buffer `4000` references remain:

```
# Implementation defaults are 8000
grep -n "DEFAULT_RING_SIZE" packages/acp-bridge/src/eventBus.ts        # => 8000
grep -n "Defaults to 8000\|eventRingSize: 8000" packages/cli/src/serve/types.ts packages/cli/src/serve/server.test.ts

# No stale ring-buffer 4000 left in docs (remaining 4000 hits are UUID examples / an unrelated token threshold)
grep -rn "4000" docs/ | grep -i "ring\|event"

# The /workflows command exists
grep -n "name: 'workflows'" packages/cli/src/ui/commands/workflowsCommand.ts   # => line 85
```

Expected: ring-buffer grep over `docs/` returns no matches; the implementation greps return `8000`; the command grep resolves.

### Evidence (Before & After)

N/A — documentation-only change, no user-visible/TUI behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

Docs-only; verified the constants and greps on Linux. Rendering is platform-independent.

### Environment (optional)

N/A — no runtime; verified via `grep` against the source tree.

## Risk & Scope

- Main risk or tradeoff: none — documentation text only, no code or runtime paths changed.
- Not validated / out of scope: the actual ring-buffer behavior is unchanged; this only corrects the documented figure and adds a command reference entry.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把文档中 SSE / daemon 事件环形缓冲区(ring buffer)的大小从 `4000` 更正为 `8000`(所有出现处),并在用户命令参考中补充 `/workflows` 斜杠命令。

## 为什么需要

文档写的是每个会话保留最近 **4000** 个事件,但实现默认值是 **8000**:`packages/acp-bridge/src/eventBus.ts` 中 `DEFAULT_RING_SIZE = 8000`(daemon 事件总线),`qwen serve` 的 SSE 环 `eventRingSize` 同样默认 `8000`(`packages/cli/src/serve/types.ts`,由 `server.test.ts` 验证)。过时的 `4000` 可能误导接入方低估其 gap 恢复 / 重放窗口。另外,`/workflows` 命令(基于 `WorkflowRunRegistry` 的工作流运行查看)近期已加入但命令参考中缺失。

## 如何验证

确认实现默认值,并确保文档中不再有过时的环形缓冲区 `4000` 引用:

```
grep -n "DEFAULT_RING_SIZE" packages/acp-bridge/src/eventBus.ts        # => 8000
grep -rn "4000" docs/ | grep -i "ring\|event"                          # 无匹配
grep -n "name: 'workflows'" packages/cli/src/ui/commands/workflowsCommand.ts
```

## 风险与范围

纯文档改动,不涉及任何代码或运行时路径;无破坏性变更。

</details>
