### PR TITLE
fix(cli): keep sudo-required npm installs on npm instead of migrating to standalone

### DIFF
--- a/packages/cli/src/utils/installationInfo.test.ts
+++ b/packages/cli/src/utils/installationInfo.test.ts
@@ -597,4 +597,31 @@ describe('getInstallationInfo', () => {
     const infoDisabled = getInstallationInfo(projectRoot, false);
     expect(infoDisabled.updateMessage).toContain('Please run npm install');
   });
+
+  it('should ask for sudo and NOT migrate to standalone when the npm global prefix is not writable', () => {
+    const globalPath = `/usr/lib/node_modules/@qwen-code/qwen-code/cli-entry.js`;
+    process.argv[1] = globalPath;
+    mockedRealPathSync.mockReturnValue(globalPath);
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('Command failed');
+    });
+    // npm global package dir is not writable -> `npm install -g` would need sudo.
+    vi.mocked(fs.accessSync).mockImplementation(() => {
+      throw Object.assign(new Error('EACCES: permission denied'), {
+        code: 'EACCES',
+      });
+    });
+
+    const info = getInstallationInfo(projectRoot, true);
+
+    expect(info.packageManager).toBe(PackageManager.NPM);
+    expect(info.isGlobal).toBe(true);
+    // Must NOT silently migrate to the standalone installer (bundled Node can be
+    // incompatible with the host, e.g. an older glibc).
+    expect(info.isStandalone).toBeUndefined();
+    expect(info.standaloneDir).toBeUndefined();
+    // No updateCommand -> the auto-updater won't attempt an unattended sudo.
+    expect(info.updateCommand).toBeUndefined();
+    expect(info.updateMessage).toContain('sudo');
+  });
 });

--- a/packages/cli/src/utils/installationInfo.ts
+++ b/packages/cli/src/utils/installationInfo.ts
@@ -6,7 +6,6 @@
 
 import { createDebugLogger, isGitRepository } from '@qwen-code/qwen-code-core';
 import * as fs from 'node:fs';
-import * as os from 'node:os';
 import * as path from 'node:path';
 import * as childProcess from 'node:child_process';
 
@@ -177,7 +176,8 @@ export function getInstallationInfo(
       };
     }
 
-    // Check if the package directory is writable to determine whether npm update requires sudo
+    // Check if the npm global package directory is writable to determine
+    // whether `npm install -g` would require sudo.
     const npmPackageDir = path.dirname(path.dirname(realPath));
     let npmPrefixWritable = false;
     try {
@@ -187,32 +187,18 @@ export function getInstallationInfo(
       // Not writable (e.g., /usr/local/lib/node_modules owned by root)
     }
 
-    if (!npmPrefixWritable && isAutoUpdateEnabled) {
-      // npm prefix requires sudo — fall back to standalone update path
-      // which installs to ~/.local/lib/qwen-code/ (user-writable)
-      const installRoot = process.env['HOME'] || os.homedir();
-      if (!installRoot || installRoot === '/') {
-        // Cannot determine a safe user-writable location; skip migration
-        return {
-          packageManager: PackageManager.NPM,
-          isGlobal: true,
-          updateMessage:
-            'Update requires sudo. Run: sudo npm install -g @qwen-code/qwen-code@latest',
-        };
-      }
-      const fallbackStandaloneDir = path.join(
-        installRoot,
-        '.local',
-        'lib',
-        'qwen-code',
-      );
+    if (!npmPrefixWritable) {
+      // The npm global prefix requires sudo. Do NOT silently migrate to the
+      // standalone installer here: that swaps in a bundled Node runtime which
+      // can be incompatible with the host (e.g. an older glibc), breaking users
+      // who were updating fine via npm. Keep npm installs on npm and ask the
+      // user to update with sudo instead. No updateCommand is returned so the
+      // auto-updater does not attempt an unattended sudo.
       return {
         packageManager: PackageManager.NPM,
         isGlobal: true,
-        isStandalone: true,
-        standaloneDir: fallbackStandaloneDir,
         updateMessage:
-          'npm install requires sudo. Migrating to standalone installer for automatic updates.',
+          'Update requires sudo. Please run: sudo npm install -g @qwen-code/qwen-code@latest',
       };
     }
 


### PR DESCRIPTION
## TLDR

When a global npm install needs sudo, auto-update (since #4629) silently migrated it to the standalone installer, which bundles an official Node 22 build requiring `glibc >= 2.28`. On older hosts (e.g. CentOS 7 / glibc 2.17) the bundled node can't load and the update fails with `GLIBC/GLIBCXX not found`. This PR keeps npm installs on npm and asks the user to update with sudo instead.

## What this changes

`packages/cli/src/utils/installationInfo.ts`:

- **Before**: npm global prefix not writable → return `isStandalone: true`, migrate to `~/.local/lib/qwen-code` (bundled Node 22).
- **After**: npm global prefix not writable → return an npm install that asks for sudo (`Update requires sudo. Please run: sudo npm install -g @qwen-code/qwen-code@latest`). No `updateCommand` is returned, so the auto-updater won't attempt an unattended sudo. No silent runtime swap.

Install method now drives update method: npm stays npm; genuine standalone installs are unaffected.

## Reviewer Test Plan

Unit tests (run locally):

- `installationInfo.test.ts` (24) + `handleAutoUpdate.test.ts` (24) → **48 passed**. Added a test asserting a not-writable npm prefix returns the sudo message and does **not** set `isStandalone` / `standaloneDir`.
- Full `packages/cli` suite: **8352 passed / 9 skipped**; the 15 failures are pre-existing flaky UI/timing tests unrelated to this change. A clean baseline run (no patch) failed a *different* set of flaky tests (`serve/server.test.ts`, `ui/auth/AuthDialog.test.tsx`), confirming this change introduces no new failures.

End-to-end on glibc 2.17 (`centos:7`, root-owned npm install, non-root runtime), running the real `getInstallationInfo` before vs after the fix:

<details>
<summary>before / after output</summary>

```text
glibc: ldd (GNU libc) 2.17
qwen bin -> .../lib/node_modules/@qwen-code/qwen-code/cli-entry.js

# BEFORE (current main):
  isStandalone   : true
  standaloneDir  : /home/tester/.local/lib/qwen-code
  updateMessage  : npm install requires sudo. Migrating to standalone installer for automatic updates.
  -> migrates to standalone -> bundled Node 22 -> glibc crash

# AFTER (this PR):
  isStandalone   : undefined
  standaloneDir  : undefined
  updateCommand  : undefined
  updateMessage  : Update requires sudo. Please run: sudo npm install -g @qwen-code/qwen-code@latest
  -> stays on npm, no standalone migration -> glibc crash cannot happen
```

</details>

## Known Limitations

This only fixes the npm auto-update path. Users who **deliberately** run the standalone installer on an old-glibc host still get a bundled Node 22 that won't run — out of scope here; a glibc preflight (or a glibc-217 runtime) for the standalone installer can be a follow-up.

## Linked issues

Closes #5206

<details>
<summary>中文说明</summary>

npm 全局目录需要 sudo 时,#4629 会静默迁移到 standalone,自带的 Node 22 在老 glibc 上跑不起来导致升级失败。本 PR 改为:npm 装的继续走 npm,需要 sudo 就提示用户 sudo,不再静默换运行时。只修 npm 这条路;主动跑 standalone 安装脚本的老 glibc 用户不在本 PR 范围,可后续加 glibc 预检。

**验证**:相关单测 48/48 通过(新增 1 个用例锁死"不迁 standalone");全量 cli 套件无本次改动引入的新失败(失败项为无关 flaky,已用干净基线对照);centos:7(glibc 2.17)真环境 before/after:修复前 `isStandalone: true` 走迁移→崩溃,修复后 `isStandalone: undefined` 返回 sudo 提示→不再崩溃。

</details>
