### PR TITLE
fix(core): read SHORT-typed TIFF dimensions correctly on big-endian files

### DIFF
--- a/packages/core/src/utils/request-tokenizer/imageTokenizer.test.ts
+++ b/packages/core/src/utils/request-tokenizer/imageTokenizer.test.ts
@@ -154,4 +154,51 @@ describe('ImageTokenizer', () => {
       }
     });
   });
+
+  describe('TIFF dimension extraction', () => {
+    // Build a minimal single-IFD TIFF whose ImageWidth/ImageLength are stored
+    // as SHORT (type 3) -- the most common TIFF layout for small dimensions.
+    function buildShortTiff(
+      byteOrder: 'II' | 'MM',
+      width: number,
+      height: number,
+    ): string {
+      const buf = Buffer.alloc(38);
+      const le = byteOrder === 'II';
+      buf.write(byteOrder, 0, 'ascii');
+      const w16 = (off: number, v: number) =>
+        le ? buf.writeUInt16LE(v, off) : buf.writeUInt16BE(v, off);
+      const w32 = (off: number, v: number) =>
+        le ? buf.writeUInt32LE(v, off) : buf.writeUInt32BE(v, off);
+      w16(2, 42); // magic
+      w32(4, 8); // IFD starts at offset 8
+      w16(8, 2); // two directory entries
+      // entry 0: ImageWidth (0x0100), SHORT, count 1, value left-justified
+      w16(10, 0x0100);
+      w16(12, 3);
+      w32(14, 1);
+      w16(18, width);
+      // entry 1: ImageLength (0x0101), SHORT, count 1
+      w16(22, 0x0101);
+      w16(24, 3);
+      w32(26, 1);
+      w16(30, height);
+      w32(34, 0); // next-IFD offset
+      return buf.toString('base64');
+    }
+
+    it('reads SHORT dimensions from a big-endian (MM) TIFF', async () => {
+      const tiff = buildShortTiff('MM', 800, 600);
+      const metadata = await tokenizer.extractImageMetadata(tiff, 'image/tiff');
+      expect(metadata.width).toBe(800);
+      expect(metadata.height).toBe(600);
+    });
+
+    it('reads SHORT dimensions from a little-endian (II) TIFF', async () => {
+      const tiff = buildShortTiff('II', 1024, 768);
+      const metadata = await tokenizer.extractImageMetadata(tiff, 'image/tiff');
+      expect(metadata.width).toBe(1024);
+      expect(metadata.height).toBe(768);
+    });
+  });
 });

--- a/packages/core/src/utils/request-tokenizer/imageTokenizer.ts
+++ b/packages/core/src/utils/request-tokenizer/imageTokenizer.ts
@@ -420,16 +420,25 @@ export class ImageTokenizer {
         ? buffer.readUInt16LE(entryOffset + 2)
         : buffer.readUInt16BE(entryOffset + 2);
 
-      const value = isLittleEndian
-        ? buffer.readUInt32LE(entryOffset + 8)
-        : buffer.readUInt32BE(entryOffset + 8);
+      // A SHORT (type 3) value occupies only the first two bytes of the
+      // 4-byte value field. Reading it as a 32-bit int happens to work on
+      // little-endian (II) files but yields value << 16 on big-endian (MM)
+      // ones, so read it according to the field type.
+      const value =
+        type === 3
+          ? isLittleEndian
+            ? buffer.readUInt16LE(entryOffset + 8)
+            : buffer.readUInt16BE(entryOffset + 8)
+          : isLittleEndian
+            ? buffer.readUInt32LE(entryOffset + 8)
+            : buffer.readUInt32BE(entryOffset + 8);
 
       if (tag === 0x0100) {
         // ImageWidth
-        width = type === 3 ? value : value; // SHORT or LONG
+        width = value;
       } else if (tag === 0x0101) {
         // ImageLength (height)
-        height = type === 3 ? value : value; // SHORT or LONG
+        height = value;
       }
 
       if (width > 0 && height > 0) break;


### PR DESCRIPTION
## What this PR does

Fixes TIFF dimension parsing in the image tokenizer so SHORT-typed `ImageWidth`/`ImageLength` are read correctly on big-endian (`MM`) files. `extractTiffDimensions` read every IFD entry value as a 32-bit int and then assigned it through a no-op ternary (`width = type === 3 ? value : value`). A TIFF SHORT (type 3) occupies only the first two bytes of the 4-byte value field, so reading 32-bit happens to work on little-endian (`II`) files but returns `value << 16` on big-endian ones. The fix reads the value according to its field type (16-bit for SHORT, 32-bit otherwise) and drops the no-op ternaries.

## Why it's needed

SHORT is the common storage for image dimensions, so any big-endian TIFF parses to multi-million-pixel dimensions. After `calculateTokensWithScaling` clamps to `maxPixels`, the token estimate for that whole format/endianness class gets pinned to the per-image maximum regardless of the image's real size — a large, silent over-count in token accounting.

## Reviewer Test Plan

### How to verify

Run the image tokenizer unit tests. Two new cases build a minimal single-IFD TIFF with SHORT-typed dimensions: the big-endian case asserts `extractImageMetadata` returns the real `800×600` instead of the pre-fix `52428800×39321600`, and the little-endian case guards against regression.

`npx vitest run packages/core/src/utils/request-tokenizer/imageTokenizer.test.ts`

Expected: 11 passed. The big-endian case fails on `main` before the fix and passes after.

### Evidence (Before & After)

Non-UI change (token-accounting math), so this is captured by the added unit test rather than a screenshot. Before the fix the big-endian SHORT case returns `width = 52428800`; after, `width = 800`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️ not tested   |
| 🪟 Windows |   ✅ tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Unit tests only (`vitest`).

## Risk & Scope

- Main risk or tradeoff: low — the change only affects how SHORT-typed IFD values are decoded; the LONG-typed and little-endian paths are byte-for-byte unchanged.
- Not validated / out of scope: real-world TIFF files beyond the synthetic fixtures used in the tests.
- Breaking changes / migration notes: none.
