### PR TITLE
fix(e2e): add daemon_status to serve capabilities baseline; run E2E on PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,13 +5,16 @@ on:
     branches:
       - 'main'
       - 'feat/e2e/**'
+  pull_request:
+    branches:
+      - 'main'
   merge_group:
 
 concurrency:
   group: |-
-    ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'main' || github.run_id }}
+    ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'main' || github.event.pull_request.number || github.run_id }}
   cancel-in-progress: |-
-    ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 jobs:
   e2e-test-linux:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,15 +11,26 @@ on:
   merge_group:
 
 concurrency:
+  # Key on the head ref so a `push` to a `feat/e2e/**` branch and a
+  # `pull_request` from that same branch share one group and cancel each
+  # other instead of running the matrix twice for the same change.
   group: |-
-    ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'main' || github.event.pull_request.number || github.run_id }}
+    ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  # Cancel superseded PR / feature-branch runs, but let every `main`
+  # commit finish (complete per-commit e2e signal, matching ci.yml) and
+  # never cancel merge-queue runs.
   cancel-in-progress: |-
-    ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/main') }}
 
 jobs:
   e2e-test-linux:
     name: 'E2E Test (Linux) - ${{ matrix.sandbox }}'
     runs-on: 'ubuntu-latest'
+    # Skip on fork PRs: forks have no access to repository secrets
+    # (OPENAI_*, DOCKERHUB_*), so the matrix would fail unconditionally
+    # and show misleading red status. Same-repo PRs run normally.
+    if: |-
+      ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     strategy:
       matrix:
         sandbox:
@@ -89,6 +100,9 @@ jobs:
   e2e-test-macos:
     name: 'E2E Test - macOS'
     runs-on: 'macos-latest'
+    # Skip on fork PRs (no secrets) — see e2e-test-linux above.
+    if: |-
+      ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2

--- a/integration-tests/cli/qwen-serve-routes.test.ts
+++ b/integration-tests/cli/qwen-serve-routes.test.ts
@@ -217,6 +217,7 @@ describe('qwen serve — capabilities envelope', () => {
     // always wires `persistSetting` and the workspace service).
     expect(caps.features).toEqual([
       'health',
+      'daemon_status',
       'capabilities',
       'session_create',
       'session_scope_override',


### PR DESCRIPTION
## What this PR does

Two related changes. First, it realigns the hard-coded expected feature list in the `qwen serve — capabilities envelope` integration test with the source-of-truth `SERVE_CAPABILITY_REGISTRY`: the `daemon_status` tag is inserted between `health` and `capabilities`, matching the registry order. Second, it makes the E2E workflow run on pull requests targeting `main` (not just on push-to-main / merge queue), and keys workflow concurrency on the PR number so a new push to a PR cancels the superseded run.

## Why it's needed

PR #5174 (`feat(cli): Add daemon status API`) added the `daemon_status` capability to `SERVE_CAPABILITY_REGISTRY` and to the unit-level baseline in `packages/cli/src/serve/server.test.ts`, but it did not update the integration test, which keeps its own independent copy of the expected list. As a result the daemon now advertises 61 features while the integration test expected 60, and the E2E job began failing on `main` (run 27651882148: `AssertionError: expected [ 'health', 'daemon_status', …(59) ] to deeply equal [ 'health', 'capabilities', …(58) ]` at `qwen-serve-routes.test.ts:218`).

The reason it slipped through review: the E2E workflow only triggered on `push` to `main` / `feat/e2e/**` and `merge_group`, never on regular PRs. So #5174's CI ran the unit tests (updated, green) but never exercised this integration assertion, and the breakage only surfaced after merge. Adding a `pull_request` trigger closes that gap so capability/contract regressions are caught at PR time.

## Reviewer Test Plan

### How to verify

```
npm ci && npm run build && npm run bundle
QWEN_SANDBOX=false npx vitest run --root ./integration-tests \
  cli/qwen-serve-routes.test.ts -t "advertises all baseline capabilities"
```

- Expected on current `main` (without this fix): the test fails with `expected [ …, 'daemon_status', … ] to deeply equal [ …, 'capabilities', … ]`.
- Expected with this fix: the test passes.

This route needs no model credentials — the test only spawns `qwen serve` and probes `GET /capabilities`, whose handshake works without auth.

### Evidence (Before & After)

- **Before** (CI on `main`, run 27651882148, E2E Test Linux `sandbox:none`): `FAIL cli/qwen-serve-routes.test.ts > qwen serve — capabilities envelope > advertises all baseline capabilities` — `1 failed | 308 passed`.
- **After** (local, against a fresh `npm run bundle`):

```
 ✓ cli/qwen-serve-routes.test.ts (26 tests | 25 skipped) 716ms
 Test Files  1 passed (1)
      Tests  1 passed | 25 skipped (26)
```

Cross-checked independently: deriving the advertised set from `SERVE_CAPABILITY_REGISTRY` minus the conditional tags that are off under this suite's spawn flags (`require_auth`, `allow_origin`, `prompt_absolute_deadline`, `writer_idle_timeout`, `session_shell_command`, `rate_limit`) yields exactly the 61 entries the updated test expects, in order.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

macOS: ran the targeted integration test locally (passes). Linux/Windows: not run locally — covered by CI (Linux is where the original failure was observed).

### Environment (optional)

Node 22, `QWEN_SANDBOX=false`. No model credentials required for the verified test.

## Risk & Scope

- **Main risk / tradeoff:** the new `pull_request` trigger means PRs from forks would run E2E **without** repository secrets (`OPENAI_API_KEY` / `OPENAI_BASE_URL` / `OPENAI_MODEL`), causing unconditional failures and misleading red status. To prevent this, a same-repo `if:` gate is added to both jobs (`e2e-test-linux` and `e2e-test-macos`): fork PRs are skipped entirely (`github.event.pull_request.head.repo.full_name == github.repository`), while same-repo branch PRs run normally with full secrets access.
- **CI cost:** E2E now also runs on every PR push targeting `main`. Concurrency is keyed on the PR number with `cancel-in-progress`, so superseded PR runs are cancelled to bound the cost. `push`-to-`main` and `merge_group` behavior is unchanged.
- **Not validated / out of scope:** the full E2E suite was not run locally (the model-dependent tests need secrets); those are left to CI.
- **Breaking changes / migration notes:** none. Test + CI configuration only; no shipped code changes.

## Linked Issues

Surfaced by E2E run https://github.com/QwenLM/qwen-code/actions/runs/27651882148 on `main`.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

两处相关改动。其一,把 `qwen serve — capabilities envelope` 集成测试里硬编码的期望能力清单与权威来源 `SERVE_CAPABILITY_REGISTRY` 重新对齐:在 `health` 和 `capabilities` 之间插入 `daemon_status`,与注册表顺序一致。其二,让 E2E workflow 在面向 `main` 的 pull request 上也触发(此前只在 push-to-main / merge queue 触发),并把并发组的 key 改为 PR 编号,这样同一 PR 的新 push 会取消被取代的旧 run。

## 为什么需要

PR #5174(`feat(cli): Add daemon status API`)把 `daemon_status` 能力加进了 `SERVE_CAPABILITY_REGISTRY` 以及 `packages/cli/src/serve/server.test.ts` 的单元 baseline,但没有更新这个集成测试 —— 它单独保存了一份期望清单。结果 daemon 现在广播 61 项能力,而集成测试只期望 60 项,E2E 在 `main` 上开始失败(run 27651882148:`AssertionError: expected [ 'health', 'daemon_status', …(59) ] to deeply equal [ 'health', 'capabilities', …(58) ]`,位置 `qwen-serve-routes.test.ts:218`)。

漏过 review 的原因:E2E workflow 只在 `push` 到 `main` / `feat/e2e/**` 以及 `merge_group` 时触发,普通 PR 从不触发。所以 #5174 的 CI 跑了单元测试(已同步、绿),却从没执行这条集成断言,问题直到合并后才暴露。加上 `pull_request` 触发就堵住了这个缺口,让能力/契约回归在 PR 阶段就被拦住。

## Reviewer Test Plan(评审验证)

### 如何验证

```
npm ci && npm run build && npm run bundle
QWEN_SANDBOX=false npx vitest run --root ./integration-tests \
  cli/qwen-serve-routes.test.ts -t "advertises all baseline capabilities"
```

- 当前 `main`(无此修复)预期:测试失败,报 `expected [ …, 'daemon_status', … ] to deeply equal [ …, 'capabilities', … ]`。
- 应用此修复后预期:测试通过。

该路由不需要模型凭证 —— 测试只 spawn `qwen serve` 并探测 `GET /capabilities`,其握手无需鉴权。

### 证据(Before & After)

- **Before**(`main` 上 CI,run 27651882148,E2E Test Linux `sandbox:none`):`FAIL cli/qwen-serve-routes.test.ts > qwen serve — capabilities envelope > advertises all baseline capabilities` —— `1 failed | 308 passed`。
- **After**(本地,基于一次新鲜的 `npm run bundle`):

```
 ✓ cli/qwen-serve-routes.test.ts (26 tests | 25 skipped) 716ms
 Test Files  1 passed (1)
      Tests  1 passed | 25 skipped (26)
```

独立交叉验证:从 `SERVE_CAPABILITY_REGISTRY` 推导广播集,减去本测试 spawn 条件下未开启的条件标签(`require_auth`、`allow_origin`、`prompt_absolute_deadline`、`writer_idle_timeout`、`session_shell_command`、`rate_limit`),恰好得到更新后测试期望的 61 项,且顺序一致。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS:本地跑了目标集成测试(通过)。Linux/Windows:未本地运行 —— 由 CI 覆盖(原始失败正是在 Linux 上观察到的)。

### 环境(可选)

Node 22,`QWEN_SANDBOX=false`。所验证的测试不需要模型凭证。

## 风险与范围

- **主要风险/取舍:** 新增的 `pull_request` 触发意味着来自 fork 的 PR 运行 E2E 时**拿不到**仓库 secrets(`OPENAI_API_KEY` / `OPENAI_BASE_URL` / `OPENAI_MODEL`),会无条件失败并产生误导性红色状态。为此,两个 job(`e2e-test-linux` 和 `e2e-test-macos`)都添加了同仓 `if:` 门禁:fork PR 直接跳过(`github.event.pull_request.head.repo.full_name == github.repository`),同仓分支 PR 正常运行,拥有完整 secrets 访问。
- **CI 成本:** E2E 现在也会在每次面向 `main` 的 PR push 上运行。并发组以 PR 编号为 key 并开启 `cancel-in-progress`,被取代的旧 run 会被取消以控制成本。`push`-to-`main` 与 `merge_group` 行为不变。
- **未验证/超出范围:** 未在本地运行完整 E2E 套件(依赖模型的用例需要 secrets),交由 CI。
- **破坏性改动/迁移说明:** 无。仅测试 + CI 配置改动,不涉及发布代码。

## 关联 Issue

由 `main` 上的 E2E run https://github.com/QwenLM/qwen-code/actions/runs/27651882148 暴露。

</details>

