### PR TITLE
fix(cli): use writeSync in exit handler to disable SGR mouse mode

### DIFF
--- a/packages/cli/src/ui/hooks/useMouseEvents.ts
+++ b/packages/cli/src/ui/hooks/useMouseEvents.ts
@@ -10,10 +10,12 @@
  */
 
 import { useEffect, useRef } from 'react';
+import { writeSync } from 'node:fs';
 import { useStdin, useStdout, useInput } from 'ink';
 import {
   enableMouseEvents,
   disableMouseEvents,
+  DISABLE_SGR_MOUSE,
   parseSGRMouseEvent,
   type MouseEvent,
 } from '../utils/mouse.js';
@@ -75,10 +77,16 @@ export function useMouseEvents(
     // never runs and the terminal stays in SGR mouse-tracking mode after
     // qwen exits — wheel events would be echoed as literal escape
     // sequences. Hook `exit` to write the disable seq one more time as
-    // a fallback. Node never throws from an `exit` listener, so even if
-    // stdout is broken (EPIPE) the process still terminates cleanly.
+    // a fallback. Use writeSync(fd=1) instead of stdout.write because
+    // during the `exit` event the event loop is stopped and async writes
+    // never reach the terminal — leaving the terminal stuck in SGR mouse
+    // mode (mouse unusable after qwen exits).
     const onExit = () => {
-      disableMouseEvents(stdout);
+      try {
+        writeSync(1, DISABLE_SGR_MOUSE);
+      } catch {
+        // fd 1 may already be closed (EPIPE, parent killed), ignore
+      }
     };
     process.on('exit', onExit);
 

--- a/packages/cli/src/ui/utils/mouse.ts
+++ b/packages/cli/src/ui/utils/mouse.ts
@@ -190,7 +190,7 @@ export function isIncompleteMouseSequence(buffer: string): boolean {
 // `?1006h` = SGR extended coordinates (handles cols/rows beyond 223).
 // Sent together — most terminals ignore unknown modes silently.
 const ENABLE_SGR_MOUSE = '\x1b[?1002h\x1b[?1006h';
-const DISABLE_SGR_MOUSE = '\x1b[?1006l\x1b[?1002l';
+export const DISABLE_SGR_MOUSE = '\x1b[?1006l\x1b[?1002l';
 
 export function enableMouseEvents(stdout: NodeJS.WriteStream): void {
   stdout.write(ENABLE_SGR_MOUSE);


### PR DESCRIPTION
## Summary

When Qwen Code exits (Ctrl+C, SIGTERM, or abnormal termination), the terminal remains in SGR mouse-tracking mode. This makes the mouse unusable — scrolling produces literal escape sequences instead of scrolling the terminal.

## Root Cause

In `useMouseEvents.ts`, the `process.on('exit')` fallback handler calls `stdout.write(DISABLE_SGR_MOUSE)` to restore the terminal. However, during Node.js's `exit` event, the event loop is already stopped, and `stdout.write` is asynchronous — the disable sequence never reaches the terminal.

## Fix

Replace `stdout.write()` with `fs.writeSync(1, DISABLE_SGR_MOUSE)` in the `process.on('exit')` handler. `writeSync` is synchronous and works during the `exit` event.

The normal React unmount cleanup path continues to use `stdout.write()`, which is reliable during regular shutdown. This change only affects the exit fallback path.

## Files Changed

- `packages/cli/src/ui/utils/mouse.ts` — export `DISABLE_SGR_MOUSE` constant (previously internal)
- `packages/cli/src/ui/hooks/useMouseEvents.ts` — use `writeSync` instead of `stdout.write` in exit handler, with try/catch

## Verification

- `tsc --noEmit`: no errors
- `eslint`: clean
- `vitest mouse.test.ts`: 15/15 tests pass

## Demo

N/A — internal fix, no user-facing UI change.

Fixes #5212