### PR TITLE
fix(acp): load extension commands in daemon sessions

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -4796,6 +4796,30 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     mockConnectionState.resolve();
     await agentPromise;
   });
+
+  it('passes undefined (not []) as the extension override to loadCliConfig', async () => {
+    await setupSessionMocks('session-ext-override');
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+
+    // [] is truthy and silently blocks all extension commands (#5216).
+    expect(vi.mocked(loadCliConfig).mock.calls[0]?.[3]).toBeUndefined();
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
 });
 
 // Regression coverage for the MR-review finding that ACP renameSession

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -2069,6 +2069,37 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
+  it('does not override extensions with an empty list for ACP sessions', async () => {
+    await setupSessionMocks('session-extensions');
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+
+    expect(loadCliConfig).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      '/tmp',
+      undefined,
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it('allows cancelling paused agent tasks', async () => {
     const sessionId = '11111111-1111-1111-1111-111111111111';
     const innerConfig = await setupSessionMocks(sessionId);

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -2069,37 +2069,6 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
-  it('does not override extensions with an empty list for ACP sessions', async () => {
-    await setupSessionMocks('session-extensions');
-
-    const agentPromise = runAcpAgent(
-      mockConfig,
-      makeSessionSettings(),
-      mockArgv,
-    );
-    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
-    const agent = capturedAgentFactory!({
-      get closed() {
-        return mockConnectionState.promise;
-      },
-    }) as AgentLike;
-
-    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
-
-    expect(loadCliConfig).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.anything(),
-      '/tmp',
-      undefined,
-      expect.anything(),
-      expect.anything(),
-      expect.anything(),
-    );
-
-    mockConnectionState.resolve();
-    await agentPromise;
-  });
-
   it('allows cancelling paused agent tasks', async () => {
     const sessionId = '11111111-1111-1111-1111-111111111111';
     const innerConfig = await setupSessionMocks(sessionId);

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -6777,6 +6777,9 @@ class QwenAgent implements Agent {
       settings,
       argvForSession,
       cwd,
+      // ACP sessions do not provide an extension override. Passing [] is a
+      // truthy override and prevents default/argv extension commands from
+      // loading, so leave it unset to preserve normal CLI behavior.
       undefined,
       // Pass separated hooks for proper source attribution
       {

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -6777,7 +6777,7 @@ class QwenAgent implements Agent {
       settings,
       argvForSession,
       cwd,
-      [],
+      undefined,
       // Pass separated hooks for proper source attribution
       {
         userHooks: this.settings.getUserHooks(),


### PR DESCRIPTION
## What this PR does

This PR lets ACP daemon sessions keep the normal extension command loading behavior instead of explicitly overriding extensions with an empty list.

## Why it's needed

ACP sessions currently pass an empty extension override into CLI config loading. That empty list is treated as an explicit override, so default extension commands and commands selected through normal CLI extension handling are not loaded for web-shell daemon sessions. Leaving the override unset preserves the standard CLI behavior while still allowing session-specific settings to be applied.

## Reviewer Test Plan

### How to verify

Start a web-shell daemon session with extensions available and confirm extension-provided slash commands are present. In code review, confirm the ACP config loading path no longer passes an explicit empty extension override, so `loadCliConfig` can use its normal extension resolution.

### Evidence (Before & After)

Before: ACP daemon sessions passed an empty extension override, which prevented extension commands from loading. After: ACP daemon sessions leave the override unset, so extension commands load through the normal CLI path.

Local verification: `cd packages/cli && npm run typecheck` passed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local TypeScript typecheck only; no daemon runtime environment was launched locally.

## Risk & Scope

- Main risk or tradeoff: ACP sessions now rely on normal CLI extension resolution instead of forcing no extensions, so any extension already selected by default or argv can contribute commands in daemon sessions.
- Not validated / out of scope: Full manual web-shell runtime verification with an installed extension was not performed locally.
- Breaking changes / migration notes: None expected.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让 ACP daemon session 保持正常的 extension command 加载行为，而不是用一个空列表显式覆盖 extensions。

## Why it's needed

ACP session 之前会向 CLI 配置加载传入一个空的 extension override。这个空列表会被当作显式覆盖，因此默认 extension commands 以及通过正常 CLI extension 处理选中的 commands 都不会在 web-shell daemon session 中加载。保持 override 未设置可以保留标准 CLI 行为，同时仍然应用 session 级设置。

## Reviewer Test Plan

### How to verify

启动一个带可用 extensions 的 web-shell daemon session，并确认 extension 提供的 slash commands 存在。代码评审时，确认 ACP 配置加载路径不再传入显式空 extension override，因此 `loadCliConfig` 可以使用正常的 extension 解析逻辑。

### Evidence (Before & After)

Before：ACP daemon session 传入空 extension override，导致 extension commands 不加载。After：ACP daemon session 保持 override 未设置，因此 extension commands 通过正常 CLI 路径加载。

本地验证：`cd packages/cli && npm run typecheck` 已通过。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

仅本地 TypeScript typecheck；没有本地启动 daemon runtime 环境。

## Risk & Scope

- Main risk or tradeoff：ACP session 现在依赖正常 CLI extension 解析，而不是强制无 extensions，因此默认或 argv 已选中的 extension 可以在 daemon session 中提供 commands。
- Not validated / out of scope：未在本地用已安装 extension 做完整 web-shell runtime 手动验证。
- Breaking changes / migration notes：预计没有。

## Linked Issues

N/A

</details>
