### PR TITLE
fix(test): add daemon_status to serve capabilities integration assertion

### DIFF
--- a/integration-tests/cli/qwen-serve-routes.test.ts
+++ b/integration-tests/cli/qwen-serve-routes.test.ts
@@ -217,6 +217,7 @@ describe('qwen serve — capabilities envelope', () => {
     // always wires `persistSetting` and the workspace service).
     expect(caps.features).toEqual([
       'health',
+      'daemon_status',
       'capabilities',
       'session_create',
       'session_scope_override',


### PR DESCRIPTION
## TLDR

The scheduled Release pipeline on `main` is red because one integration assertion went stale. `daemon_status` was added to `SERVE_CAPABILITY_REGISTRY`, but the `qwen serve` capabilities integration test was never updated, so its `caps.features` assertion fails. This PR syncs the expected list.

## What was broken

`integration-tests/cli/qwen-serve-routes.test.ts` asserts the full ordered `caps.features` array. After `daemon_status` was registered (right after `health`), the served envelope returns 59 features while the test still expected 58:

```
AssertionError: expected [ 'health', 'daemon_status', …(59) ]
                to deeply equal [ 'health', 'capabilities', …(58) ]
```

This failed both `Integration Tests (No Sandbox)` and `Integration Tests (Docker)` jobs.

## The fix

Add `'daemon_status'` between `'health'` and `'capabilities'` in the expected array, matching the registry order in `packages/cli/src/serve/capabilities.ts`. The unit-level baseline in `packages/cli/src/serve/server.test.ts` already includes `daemon_status` — only the integration assertion was out of sync.

## Reviewer Test Plan

- `integration-tests/cli/qwen-serve-routes.test.ts` → `qwen serve — capabilities envelope > advertises all baseline capabilities` should pass.
