### PR TITLE
fix(core): fall back to encrypted-file storage for extension secrets when keychain is unavailable

### DIFF
--- a/packages/core/src/extension/extensionSettings.ts
+++ b/packages/core/src/extension/extensionSettings.ts
@@ -12,7 +12,7 @@ import { ExtensionStorage } from './storage.js';
 import type { ExtensionConfig } from './extensionManager.js';
 import prompts from 'prompts';
 import { EXTENSION_SETTINGS_FILENAME } from './variables.js';
-import { KeychainTokenStorage } from '../mcp/token-storage/keychain-token-storage.js';
+import { HybridTokenStorage } from '../mcp/token-storage/hybrid-token-storage.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 
 const debugLogger = createDebugLogger('EXT_SETTINGS');
@@ -85,7 +85,7 @@ export async function maybePromptForSettings(
   // The user can change the scope later using the `settings set` command.
   const scope = ExtensionSettingScope.USER;
   const envFilePath = getEnvFilePath(extensionName, scope);
-  const keychain = new KeychainTokenStorage(
+  const keychain = new HybridTokenStorage(
     getKeychainStorageName(extensionName, extensionId, scope),
   );
 
@@ -160,7 +160,7 @@ export async function getScopedEnvContents(
   scope: ExtensionSettingScope,
 ): Promise<Record<string, string>> {
   const { name: extensionName } = extensionConfig;
-  const keychain = new KeychainTokenStorage(
+  const keychain = new HybridTokenStorage(
     getKeychainStorageName(extensionName, extensionId, scope),
   );
   const envFilePath = getEnvFilePath(extensionName, scope);
@@ -232,7 +232,7 @@ export async function updateSetting(
   }
 
   const newValue = await requestSetting(settingToUpdate);
-  const keychain = new KeychainTokenStorage(
+  const keychain = new HybridTokenStorage(
     getKeychainStorageName(extensionName, extensionId, scope),
   );
 
@@ -303,7 +303,7 @@ function getSettingsChanges(
 
 async function clearSettings(
   envFilePath: string,
-  keychain: KeychainTokenStorage,
+  keychain: HybridTokenStorage,
 ) {
   if (fsSync.existsSync(envFilePath)) {
     await fs.writeFile(envFilePath, '');

--- a/packages/core/src/mcp/token-storage/file-token-storage.test.ts
+++ b/packages/core/src/mcp/token-storage/file-token-storage.test.ts
@@ -382,4 +382,82 @@ describe('FileTokenStorage', () => {
       );
     });
   });
+
+  describe('secret storage', () => {
+    const secretFilePath = path.join(
+      '/home/test',
+      '.qwen',
+      'extension-secrets-v1.json',
+    );
+
+    beforeEach(() => {
+      mockFs.mkdir.mockResolvedValue(undefined);
+      vi.mocked(atomicWriteFile).mockResolvedValue(undefined);
+    });
+
+    it('isAvailable() is always true for the file backend', async () => {
+      await expect(storage.isAvailable()).resolves.toBe(true);
+    });
+
+    it('returns null / empty when no secret file exists', async () => {
+      mockFs.readFile.mockRejectedValue({ code: 'ENOENT' });
+
+      await expect(storage.getSecret('API_KEY')).resolves.toBeNull();
+      await expect(storage.listSecrets()).resolves.toEqual([]);
+    });
+
+    it('persists a secret encrypted under the service name', async () => {
+      mockFs.readFile.mockRejectedValue({ code: 'ENOENT' });
+
+      await storage.setSecret('API_KEY', 'sk-123');
+
+      expect(atomicWriteFile).toHaveBeenCalledTimes(1);
+      const [writtenPath, writtenData, writeOptions] =
+        vi.mocked(atomicWriteFile).mock.calls[0];
+      expect(writtenPath).toBe(secretFilePath);
+      expect(writtenData).toMatch(/^[0-9a-f]+:[0-9a-f]+:[0-9a-f]+$/);
+      expect(writeOptions).toEqual({
+        mode: 0o600,
+        forceMode: true,
+        noFollow: true,
+      });
+      expect(JSON.parse(storage['decrypt'](writtenData as string))).toEqual({
+        'test-storage': { API_KEY: 'sk-123' },
+      });
+    });
+
+    it('reads back a stored secret and ignores other keys and services', async () => {
+      const encrypted = storage['encrypt'](
+        JSON.stringify({
+          'test-storage': { API_KEY: 'sk-123' },
+          'other-service': { API_KEY: 'sk-other' },
+        }),
+      );
+      mockFs.readFile.mockResolvedValue(encrypted);
+
+      await expect(storage.getSecret('API_KEY')).resolves.toBe('sk-123');
+      await expect(storage.getSecret('MISSING')).resolves.toBeNull();
+      await expect(storage.listSecrets()).resolves.toEqual(['API_KEY']);
+    });
+
+    it('deletes a secret and drops the now-empty service bucket', async () => {
+      const encrypted = storage['encrypt'](
+        JSON.stringify({ 'test-storage': { API_KEY: 'sk-123' } }),
+      );
+      mockFs.readFile.mockResolvedValue(encrypted);
+
+      await storage.deleteSecret('API_KEY');
+
+      expect(atomicWriteFile).toHaveBeenCalledTimes(1);
+      const [, writtenData] = vi.mocked(atomicWriteFile).mock.calls[0];
+      expect(JSON.parse(storage['decrypt'](writtenData as string))).toEqual({});
+    });
+
+    it('deleting a missing secret is a no-op (no write, no throw)', async () => {
+      mockFs.readFile.mockRejectedValue({ code: 'ENOENT' });
+
+      await expect(storage.deleteSecret('API_KEY')).resolves.toBeUndefined();
+      expect(atomicWriteFile).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/core/src/mcp/token-storage/file-token-storage.ts
+++ b/packages/core/src/mcp/token-storage/file-token-storage.ts
@@ -9,18 +9,27 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import * as crypto from 'node:crypto';
 import { BaseTokenStorage } from './base-token-storage.js';
-import type { OAuthCredentials } from './types.js';
+import type { OAuthCredentials, SecretStorage } from './types.js';
 import { Storage } from '../../config/storage.js';
 import { atomicWriteFile } from '../../utils/atomicFileWrite.js';
 
-export class FileTokenStorage extends BaseTokenStorage {
+// Secrets are keyed by service name so a single encrypted file can hold secrets
+// for many callers, mirroring how the keychain backend namespaces by service.
+type SecretFileContents = Record<string, Record<string, string>>;
+
+export class FileTokenStorage
+  extends BaseTokenStorage
+  implements SecretStorage
+{
   private readonly tokenFilePath: string;
+  private readonly secretFilePath: string;
   private readonly encryptionKey: Buffer;
 
   constructor(serviceName: string) {
     super(serviceName);
     const configDir = Storage.getGlobalQwenDir();
     this.tokenFilePath = path.join(configDir, 'mcp-oauth-tokens-v2.json');
+    this.secretFilePath = path.join(configDir, 'extension-secrets-v1.json');
     this.encryptionKey = this.deriveEncryptionKey();
   }
 
@@ -186,5 +195,64 @@ export class FileTokenStorage extends BaseTokenStorage {
         throw error;
       }
     }
+  }
+
+  private async loadSecrets(): Promise<SecretFileContents> {
+    try {
+      const data = await fs.readFile(this.secretFilePath, 'utf-8');
+      return JSON.parse(this.decrypt(data)) as SecretFileContents;
+    } catch (error: unknown) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code === 'ENOENT') {
+        return {};
+      }
+      throw error;
+    }
+  }
+
+  private async saveSecrets(secrets: SecretFileContents): Promise<void> {
+    await this.ensureDirectoryExists();
+    const encrypted = this.encrypt(JSON.stringify(secrets));
+    await atomicWriteFile(this.secretFilePath, encrypted, {
+      mode: 0o600,
+      forceMode: true,
+      noFollow: true,
+    });
+  }
+
+  // The encrypted file is always usable, so the file backend is always available.
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+
+  async setSecret(key: string, value: string): Promise<void> {
+    const secrets = await this.loadSecrets();
+    (secrets[this.serviceName] ??= {})[key] = value;
+    await this.saveSecrets(secrets);
+  }
+
+  async getSecret(key: string): Promise<string | null> {
+    const secrets = await this.loadSecrets();
+    return secrets[this.serviceName]?.[key] ?? null;
+  }
+
+  // Idempotent: deleting a missing secret is a no-op (the keychain backend
+  // throws, but extension-settings callers do not depend on that signal).
+  async deleteSecret(key: string): Promise<void> {
+    const secrets = await this.loadSecrets();
+    const bucket = secrets[this.serviceName];
+    if (!bucket || !(key in bucket)) {
+      return;
+    }
+    delete bucket[key];
+    if (Object.keys(bucket).length === 0) {
+      delete secrets[this.serviceName];
+    }
+    await this.saveSecrets(secrets);
+  }
+
+  async listSecrets(): Promise<string[]> {
+    const secrets = await this.loadSecrets();
+    return Object.keys(secrets[this.serviceName] ?? {});
   }
 }

--- a/packages/core/src/mcp/token-storage/hybrid-token-storage.test.ts
+++ b/packages/core/src/mcp/token-storage/hybrid-token-storage.test.ts
@@ -41,6 +41,10 @@ interface MockStorage {
   listServers: ReturnType<typeof vi.fn>;
   getAllCredentials: ReturnType<typeof vi.fn>;
   clearAll: ReturnType<typeof vi.fn>;
+  setSecret?: ReturnType<typeof vi.fn>;
+  getSecret?: ReturnType<typeof vi.fn>;
+  deleteSecret?: ReturnType<typeof vi.fn>;
+  listSecrets?: ReturnType<typeof vi.fn>;
 }
 
 describe('HybridTokenStorage', () => {
@@ -62,15 +66,24 @@ describe('HybridTokenStorage', () => {
       listServers: vi.fn(),
       getAllCredentials: vi.fn(),
       clearAll: vi.fn(),
+      setSecret: vi.fn(),
+      getSecret: vi.fn(),
+      deleteSecret: vi.fn(),
+      listSecrets: vi.fn(),
     };
 
     mockFileStorage = {
+      isAvailable: vi.fn(),
       getCredentials: vi.fn(),
       setCredentials: vi.fn(),
       deleteCredentials: vi.fn(),
       listServers: vi.fn(),
       getAllCredentials: vi.fn(),
       clearAll: vi.fn(),
+      setSecret: vi.fn(),
+      getSecret: vi.fn(),
+      deleteSecret: vi.fn(),
+      listSecrets: vi.fn(),
     };
 
     (
@@ -269,6 +282,43 @@ describe('HybridTokenStorage', () => {
       await storage.clearAll();
 
       expect(mockKeychainStorage.clearAll).toHaveBeenCalled();
+    });
+  });
+
+  describe('secret storage', () => {
+    it('delegates secrets to the keychain when available', async () => {
+      mockKeychainStorage.isAvailable!.mockResolvedValue(true);
+      mockKeychainStorage.getSecret!.mockResolvedValue('sk-keychain');
+
+      await expect(storage.getSecret('API_KEY')).resolves.toBe('sk-keychain');
+      expect(mockKeychainStorage.getSecret).toHaveBeenCalledWith('API_KEY');
+      expect(mockFileStorage.getSecret).not.toHaveBeenCalled();
+      await expect(storage.isAvailable()).resolves.toBe(true);
+    });
+
+    it('falls back to encrypted-file secrets when keychain is unavailable', async () => {
+      mockKeychainStorage.isAvailable!.mockResolvedValue(false);
+      mockFileStorage.isAvailable!.mockResolvedValue(true);
+      mockFileStorage.getSecret!.mockResolvedValue('sk-file');
+
+      await expect(storage.getSecret('API_KEY')).resolves.toBe('sk-file');
+      expect(mockFileStorage.getSecret).toHaveBeenCalledWith('API_KEY');
+      expect(mockKeychainStorage.getSecret).not.toHaveBeenCalled();
+      expect(await storage.getStorageType()).toBe(
+        TokenStorageType.ENCRYPTED_FILE,
+      );
+
+      await storage.setSecret('API_KEY', 'value');
+      expect(mockFileStorage.setSecret).toHaveBeenCalledWith(
+        'API_KEY',
+        'value',
+      );
+
+      await storage.deleteSecret('API_KEY');
+      expect(mockFileStorage.deleteSecret).toHaveBeenCalledWith('API_KEY');
+
+      await storage.listSecrets();
+      expect(mockFileStorage.listSecrets).toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/src/mcp/token-storage/hybrid-token-storage.ts
+++ b/packages/core/src/mcp/token-storage/hybrid-token-storage.ts
@@ -6,21 +6,26 @@
 
 import { BaseTokenStorage } from './base-token-storage.js';
 import { FileTokenStorage } from './file-token-storage.js';
-import type { TokenStorage, OAuthCredentials } from './types.js';
+import type { TokenStorage, SecretStorage, OAuthCredentials } from './types.js';
 import { TokenStorageType } from './types.js';
 
 const FORCE_FILE_STORAGE_ENV_VAR = 'QWEN_CODE_FORCE_FILE_STORAGE';
 
-export class HybridTokenStorage extends BaseTokenStorage {
-  private storage: TokenStorage | null = null;
+type HybridBackend = TokenStorage & SecretStorage;
+
+export class HybridTokenStorage
+  extends BaseTokenStorage
+  implements SecretStorage
+{
+  private storage: HybridBackend | null = null;
   private storageType: TokenStorageType | null = null;
-  private storageInitPromise: Promise<TokenStorage> | null = null;
+  private storageInitPromise: Promise<HybridBackend> | null = null;
 
   constructor(serviceName: string) {
     super(serviceName);
   }
 
-  private async initializeStorage(): Promise<TokenStorage> {
+  private async initializeStorage(): Promise<HybridBackend> {
     const forceFileStorage = process.env[FORCE_FILE_STORAGE_ENV_VAR] === 'true';
 
     if (!forceFileStorage) {
@@ -46,7 +51,7 @@ export class HybridTokenStorage extends BaseTokenStorage {
     return this.storage;
   }
 
-  private async getStorage(): Promise<TokenStorage> {
+  private async getStorage(): Promise<HybridBackend> {
     if (this.storage !== null) {
       return this.storage;
     }
@@ -93,5 +98,33 @@ export class HybridTokenStorage extends BaseTokenStorage {
   async getStorageType(): Promise<TokenStorageType> {
     await this.getStorage();
     return this.storageType!;
+  }
+
+  // Secret API — delegates to whichever backend is active (keychain when
+  // available, otherwise the encrypted file). This is what lets sensitive
+  // extension settings degrade gracefully to file storage without a keychain.
+  async isAvailable(): Promise<boolean> {
+    const storage = await this.getStorage();
+    return storage.isAvailable();
+  }
+
+  async setSecret(key: string, value: string): Promise<void> {
+    const storage = await this.getStorage();
+    await storage.setSecret(key, value);
+  }
+
+  async getSecret(key: string): Promise<string | null> {
+    const storage = await this.getStorage();
+    return storage.getSecret(key);
+  }
+
+  async deleteSecret(key: string): Promise<void> {
+    const storage = await this.getStorage();
+    await storage.deleteSecret(key);
+  }
+
+  async listSecrets(): Promise<string[]> {
+    const storage = await this.getStorage();
+    return storage.listSecrets();
   }
 }

--- a/packages/core/src/mcp/token-storage/types.ts
+++ b/packages/core/src/mcp/token-storage/types.ts
@@ -36,6 +36,20 @@ export interface TokenStorage {
   clearAll(): Promise<void>;
 }
 
+/**
+ * Storage for arbitrary named secrets (e.g. sensitive extension settings),
+ * scoped to the backing store's service name. Implemented by both the keychain
+ * and the encrypted-file backends so that secrets degrade gracefully to file
+ * storage when the OS keychain is unavailable.
+ */
+export interface SecretStorage {
+  isAvailable(): Promise<boolean>;
+  setSecret(key: string, value: string): Promise<void>;
+  getSecret(key: string): Promise<string | null>;
+  deleteSecret(key: string): Promise<void>;
+  listSecrets(): Promise<string[]>;
+}
+
 export enum TokenStorageType {
   KEYCHAIN = 'keychain',
   ENCRYPTED_FILE = 'encrypted_file',

--- a/packages/core/src/telemetry/file-exporters.test.ts
+++ b/packages/core/src/telemetry/file-exporters.test.ts
@@ -8,6 +8,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ExportResultCode } from '@opentelemetry/core';
 import { FileSpanExporter } from './file-exporters.js';
 
 type SerializeAccess = { serialize: (data: unknown) => string };
@@ -53,5 +54,55 @@ describe('FileExporter.serialize', () => {
     expect(out).toContain('"name": "span-1"');
     expect(out).toContain('"[Circular]"');
     expect(out.endsWith('\n')).toBe(true);
+  });
+});
+
+// Telemetry is best-effort and must never crash the agent. The outfile is often
+// a relative path resolved against a cwd that lacks the directory (e.g. an ACP
+// session whose process cwd is `/`), which makes createWriteStream emit an
+// async `error` event that, if unhandled, takes down the whole process.
+describe('FileExporter robustness', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'file-exporters-robust-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 50,
+    });
+  });
+
+  it('creates the parent directory when it does not exist', async () => {
+    const nested = path.join(tmpDir, 'a', 'b', 'c');
+    const exporter = new FileSpanExporter(path.join(nested, 'out.jsonl'));
+    expect(fs.existsSync(nested)).toBe(true);
+    await exporter.shutdown();
+  });
+
+  it('does not crash when the outfile path is unusable', async () => {
+    // Make the parent a regular file so the directory — and therefore the
+    // write stream — cannot be created. The async stream `error` must be
+    // absorbed rather than crashing the process.
+    const blocker = path.join(tmpDir, 'blocker');
+    fs.writeFileSync(blocker, 'x');
+    const badPath = path.join(blocker, 'out.jsonl');
+
+    let exporter: FileSpanExporter | undefined;
+    expect(() => {
+      exporter = new FileSpanExporter(badPath);
+    }).not.toThrow();
+
+    const code = await new Promise<ExportResultCode>((resolve) => {
+      exporter!.export([{ name: 'span' } as never], (result) =>
+        resolve(result.code),
+      );
+    });
+    expect(code).toBe(ExportResultCode.FAILED);
+    await exporter!.shutdown();
   });
 });

--- a/packages/core/src/telemetry/file-exporters.ts
+++ b/packages/core/src/telemetry/file-exporters.ts
@@ -5,6 +5,7 @@
  */
 
 import * as fs from 'node:fs';
+import * as path from 'node:path';
 import type { ExportResult } from '@opentelemetry/core';
 import { ExportResultCode } from '@opentelemetry/core';
 import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
@@ -23,7 +24,22 @@ class FileExporter {
   protected writeStream: fs.WriteStream;
 
   constructor(filePath: string) {
+    // Telemetry is best-effort and must never crash the process. Ensure the
+    // parent directory exists (the outfile may be a relative path resolved
+    // against a cwd that lacks it), and attach an `error` handler so an open or
+    // write failure (missing/read-only dir, EACCES) is absorbed instead of
+    // surfacing as an unhandled stream `error` event that takes down the agent.
+    try {
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    } catch {
+      // Directory could not be created; the stream error handler below will
+      // absorb the resulting open failure.
+    }
     this.writeStream = fs.createWriteStream(filePath, { flags: 'a' });
+    this.writeStream.on('error', () => {
+      // Swallow telemetry file errors — exporters report failures through the
+      // ExportResult callback; an unhandled `error` event would crash Node.
+    });
   }
 
   protected serialize(data: unknown): string {


### PR DESCRIPTION
## What this PR does

Sensitive extension settings now fall back to encrypted-file storage when the OS keychain is unavailable, instead of failing the operation outright. This adds a `SecretStorage` interface, implements it on `FileTokenStorage` (AES-256-GCM encrypted file, namespaced by service name, reusing the existing token-file encryption), delegates it from `HybridTokenStorage` to whichever backend is active, and switches extension settings from `KeychainTokenStorage` to `HybridTokenStorage`. When the OS keychain is available the behavior is unchanged (keychain is still used); when it is not, secrets transparently use the encrypted file — mirroring how MCP OAuth credentials already degrade.

## Why it's needed

Extension settings persisted sensitive values exclusively through `KeychainTokenStorage`, whose `getSecret`/`setSecret`/`deleteSecret`/`listSecrets` throw `Keychain is not available` whenever the optional `keytar` native module cannot be loaded. `keytar` is not a declared dependency, so any environment without it is affected — most notably the ACP/desktop runtime, which does not bundle it.

The single keychain read site (`getScopedEnvContents`) is reached eagerly by `qwen/settings/getCore` (`buildCoreSettings` enumerates every loaded extension and reads each sensitive value to populate the settings snapshot). Because that read is unguarded, a missing keychain makes the **entire** settings snapshot fail with `-32603 Internal error: Keychain is not available`, and any session that loads extension env fails the same way. MCP OAuth credentials already degrade gracefully via `HybridTokenStorage`; extension secrets did not, so this brings them in line.

## Reviewer Test Plan

### How to verify

Reproduce with any environment where `keytar` cannot be loaded (e.g. a bundled CLI without the native module). Start the agent in ACP mode and send `initialize` followed by `qwen/settings/getCore` for a workspace that has at least one extension with a `sensitive` setting. Before this change the second request returns a JSON-RPC error; after it returns the full settings snapshot. The encrypted-file round-trip can also be exercised directly through `HybridTokenStorage` (`setSecret` → `getSecret` → `listSecrets` → `deleteSecret`), confirming `getStorageType()` is `encrypted_file` and a missing key returns `null` rather than throwing.

### Evidence (Before & After)

`qwen/settings/getCore` against a build with no `keytar` present, same workspace (an extension with a sensitive `NANOBANANA_API_KEY` setting):

Before:

```json
{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"Internal error","data":{"details":"Keychain is not available"}}}
```

After:

```json
{"jsonrpc":"2.0","id":1,"result":{"user":{"path":".../.qwen/settings.json","values":{...}},"workspace":{...},"merged":{"values":{...},"mcpServers":[...],"hooks":[]},"extensions":[{"name":"nanobanana","settings":[{"name":"API Key","envVar":"NANOBANANA_API_KEY","sensitive":true,"hasUserValue":false,"hasWorkspaceValue":false}]}, ...],"isTrusted":true}}
```

Encrypted-file fallback round-trip via `HybridTokenStorage` (no keychain):

```json
{"isAvailable":true,"storageType":"encrypted_file","setThenGet":"hunter2","list":["MY_SECRET"],"afterDelete":null,"missingKey":null}
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npm run build && npm run bundle`, then ran the bundled `dist/cli.js` under Node with no `keytar` resolvable; `HybridTokenStorage` round-trip exercised against source via `tsx`.

## Risk & Scope

- Main risk or tradeoff: when the keychain is unavailable, secrets are written to a new encrypted file (`extension-secrets-v1.json`, mode `0600`) under the global Qwen dir. There is no cross-migration — values written under one backend are not visible to the other if keychain availability later changes. Behavior when the keychain *is* available is unchanged.
- Not validated / out of scope: Windows and Linux were not run locally (CI covers all three platforms); no automatic migration of existing keychain-stored secrets to the file backend.
- Breaking changes / migration notes: none. The change is additive (`SecretStorage` interface plus a new encrypted file); no public API or on-disk format is removed or changed.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

敏感的扩展设置在操作系统钥匙串(keychain)不可用时,会回退到加密文件存储,而不是直接让操作失败。具体做法:新增 `SecretStorage` 接口;在 `FileTokenStorage` 上实现它(AES-256-GCM 加密文件,按 service name 命名空间,复用既有的 token 文件加密);由 `HybridTokenStorage` 转发给当前生效的后端;并把扩展设置从 `KeychainTokenStorage` 改为 `HybridTokenStorage`。keychain 可用时行为不变(仍用 keychain);不可用时,secret 透明地改用加密文件——与 MCP OAuth 凭据已有的降级方式一致。

## 为什么需要

扩展设置此前只通过 `KeychainTokenStorage` 持久化敏感值,而它的 `getSecret`/`setSecret`/`deleteSecret`/`listSecrets` 在可选的原生模块 `keytar` 无法加载时会抛出 `Keychain is not available`。`keytar` 并非声明依赖,因此任何缺少它的环境都会受影响——尤其是不打包 keytar 的 ACP/桌面运行时。

唯一读取 keychain 的位置(`getScopedEnvContents`)会被 `qwen/settings/getCore` 主动触发(`buildCoreSettings` 会遍历每个已加载扩展并读取其每个敏感值来构建设置快照)。由于该读取没有任何守卫,keychain 缺失会让**整个**设置快照以 `-32603 Internal error: Keychain is not available` 失败,任何加载扩展 env 的会话也会同样失败。MCP OAuth 凭据早已通过 `HybridTokenStorage` 优雅降级,扩展 secret 此前没有,本 PR 让二者对齐。

## 审阅者测试计划

### 如何验证

在任何 `keytar` 无法加载的环境复现(例如不含原生模块的打包 CLI)。以 ACP 模式启动 agent,对一个至少含有一个 `sensitive` 设置的扩展的工作区,依次发送 `initialize` 和 `qwen/settings/getCore`。改动前第二个请求返回 JSON-RPC 错误,改动后返回完整设置快照。也可直接通过 `HybridTokenStorage` 验证加密文件往返(`setSecret` → `getSecret` → `listSecrets` → `deleteSecret`),确认 `getStorageType()` 为 `encrypted_file`,且不存在的 key 返回 `null` 而非抛错。

### 证据(Before & After)

对一个不含 `keytar` 的构建、同一工作区(某扩展含敏感设置 `NANOBANANA_API_KEY`)执行 `qwen/settings/getCore`:

改动前:

```json
{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"Internal error","data":{"details":"Keychain is not available"}}}
```

改动后:

```json
{"jsonrpc":"2.0","id":1,"result":{"user":{"path":".../.qwen/settings.json","values":{...}},"workspace":{...},"merged":{"values":{...},"mcpServers":[...],"hooks":[]},"extensions":[{"name":"nanobanana","settings":[{"name":"API Key","envVar":"NANOBANANA_API_KEY","sensitive":true,"hasUserValue":false,"hasWorkspaceValue":false}]}, ...],"isTrusted":true}}
```

无 keychain 时经 `HybridTokenStorage` 的加密文件往返:

```json
{"isAvailable":true,"storageType":"encrypted_file","setThenGet":"hunter2","list":["MY_SECRET"],"afterDelete":null,"missingKey":null}
```

### 测试平台

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境(可选)

`npm run build && npm run bundle`,随后在没有可解析 `keytar` 的 Node 下运行打包后的 `dist/cli.js`;并用 `tsx` 直接对源码运行 `HybridTokenStorage` 往返验证。

## 风险与范围

- 主要风险/取舍:keychain 不可用时,secret 会写入全局 Qwen 目录下的新加密文件(`extension-secrets-v1.json`,权限 `0600`)。两个后端之间没有互相迁移——若 keychain 可用性之后发生变化,一个后端写入的值不会被另一个看到。keychain 可用时行为不变。
- 未验证/范围之外:Windows 与 Linux 未在本地运行(CI 覆盖三平台);不会把已存于 keychain 的 secret 自动迁移到文件后端。
- 破坏性变更/迁移说明:无。改动是增量的(新增 `SecretStorage` 接口与一个新的加密文件),没有移除或修改任何公开 API 或磁盘格式。

## 关联 Issue

N/A

</details>
