### PR TITLE
fix(web-shell): simplify collapse metadata display

### DIFF
--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -2892,7 +2892,6 @@ export function App({
                     isResponding={streamingState !== 'idle'}
                     workspaceCwd={connection.workspaceCwd || ''}
                     shellOutputMaxLines={shellOutputMaxLines}
-                    commands={commands}
                     showRetryHint={showRetryHint}
                     onRetryClick={handleRetry}
                     welcomeHeader={welcomeHeader}

--- a/packages/web-shell/client/components/MessageItem.tsx
+++ b/packages/web-shell/client/components/MessageItem.tsx
@@ -1,7 +1,6 @@
 import { memo, type ReactElement } from 'react';
 import type {
   ACPToolCall,
-  CommandInfo,
   Message,
   PermissionRequest,
   TodoItem,
@@ -33,7 +32,6 @@ interface MessageItemProps {
   showRetryHint?: boolean;
   onRetryClick?: () => void;
   shellOutputMaxLines: number;
-  commands?: readonly CommandInfo[];
   /** Present on a collapsible turn's prompt row; renders the collapse toggle. */
   collapse?: TurnCollapseHead;
   onToggleCollapse?: (turnId: string) => void;
@@ -49,7 +47,6 @@ export const MessageItem = memo(function MessageItem({
   showRetryHint = false,
   onRetryClick,
   shellOutputMaxLines,
-  commands,
   collapse,
   onToggleCollapse,
 }: MessageItemProps) {
@@ -60,7 +57,6 @@ export const MessageItem = memo(function MessageItem({
           <UserMessage
             content={message.content}
             images={message.images}
-            commands={commands}
             collapse={collapse}
             onToggleCollapse={onToggleCollapse}
           />
@@ -152,7 +148,6 @@ function areMessageItemPropsEqual(
   if (prev.showRetryHint !== next.showRetryHint) return false;
   if (prev.onRetryClick !== next.onRetryClick) return false;
   if (prev.shellOutputMaxLines !== next.shellOutputMaxLines) return false;
-  if (prev.commands !== next.commands) return false;
   if (prev.onToggleCollapse !== next.onToggleCollapse) return false;
   if (!turnCollapseEqual(prev.collapse, next.collapse)) return false;
   return areMessagesEqual(prev.message, next.message);

--- a/packages/web-shell/client/components/MessageList.test.ts
+++ b/packages/web-shell/client/components/MessageList.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { Message } from '../adapters/types';
 import {
   applyTurnCollapse,
@@ -499,6 +499,40 @@ describe('applyTurnCollapse', () => {
       collapseItems(items, { isResponding: true })[0],
     ).collapse;
     expect(head?.liveStartedAt).toBe(1_000);
+  });
+
+  it('marks a prompt-only active turn live with its prompt timestamp', () => {
+    const items = groupParallelAgents([
+      { id: 'u1', role: 'user', content: 'hi', timestamp: 1_000 },
+    ]);
+    const head = messageRow(
+      collapseItems(items, { isResponding: true })[0],
+    ).collapse;
+    expect(head).toMatchObject({
+      collapsed: false,
+      hiddenCount: 0,
+      liveStartedAt: 1_000,
+    });
+  });
+
+  it('marks a prompt-only active turn live without a prompt timestamp', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    try {
+      const items = groupParallelAgents([
+        { id: 'u1', role: 'user', content: 'hi' },
+      ]);
+      const head = messageRow(
+        collapseItems(items, { isResponding: true })[0],
+      ).collapse;
+      expect(head).toMatchObject({
+        collapsed: false,
+        hiddenCount: 0,
+        liveStartedAt: 10_000,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('does not mark a completed turn live', () => {

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -12,12 +12,7 @@ import {
   type MutableRefObject,
 } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import type {
-  CommandInfo,
-  Message,
-  ACPToolCall,
-  TurnCollapseHead,
-} from '../adapters/types';
+import type { Message, ACPToolCall, TurnCollapseHead } from '../adapters/types';
 import type { PermissionRequest } from '../adapters/types';
 import {
   isBackgroundSubAgentToolCall,
@@ -55,7 +50,6 @@ interface MessageListProps {
   tailKey?: string;
   virtualScrollThreshold?: number;
   shellOutputMaxLines: number;
-  commands?: readonly CommandInfo[];
   /**
    * When true, scroll the tail content into view the moment it first appears
    * even if the user had scrolled up. Opt-in per caller so unrelated inline
@@ -683,7 +677,6 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
       tailKey = 'tail',
       virtualScrollThreshold = VIRTUAL_SCROLL_THRESHOLD,
       shellOutputMaxLines,
-      commands,
       autoScrollTailIntoView = false,
       showRetryHint = false,
       onRetryClick,
@@ -1141,7 +1134,6 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
             showRetryHint={showRetryHint}
             onRetryClick={onRetryClick}
             shellOutputMaxLines={shellOutputMaxLines}
-            commands={commands}
             collapse={item.collapse}
             onToggleCollapse={handleToggleCollapse}
           />
@@ -1164,7 +1156,6 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
         showRetryHint,
         onRetryClick,
         shellOutputMaxLines,
-        commands,
         handleToggleCollapse,
       ],
     );

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -529,13 +529,15 @@ export function applyTurnCollapse(
     }
 
     const promptTs = head.message.timestamp;
+    const liveStartedAt = isActiveTurn ? (promptTs ?? Date.now()) : undefined;
     const elapsedMs =
       promptTs !== undefined &&
       lastStepTs !== undefined &&
       lastStepTs >= promptTs
         ? lastStepTs - promptTs
         : undefined;
-    const hasMetrics = hasUsage || elapsedMs !== undefined;
+    const hasMetrics =
+      hasUsage || elapsedMs !== undefined || liveStartedAt !== undefined;
 
     if (hasPendingApproval || (hiddenCount === 0 && !hasMetrics)) {
       // Nothing to add: the inline approve/reject UI must stay reachable, or the
@@ -568,9 +570,7 @@ export function applyTurnCollapse(
         ...(hasUsage ? { inputTokens, outputTokens } : {}),
         ...(cachedTokens > 0 ? { cachedTokens } : {}),
         ...(toolCallCount > 0 ? { toolCallCount } : {}),
-        ...(isActiveTurn && promptTs !== undefined
-          ? { liveStartedAt: promptTs }
-          : {}),
+        ...(liveStartedAt !== undefined ? { liveStartedAt } : {}),
       },
     });
 

--- a/packages/web-shell/client/components/messages/UserMessage.test.tsx
+++ b/packages/web-shell/client/components/messages/UserMessage.test.tsx
@@ -86,6 +86,38 @@ describe('UserMessage collapse toggle', () => {
     expect(container.querySelector('button')).toBeNull();
   });
 
+  it('shows elapsed time while a turn is still running', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    try {
+      const container = render(
+        <UserMessage
+          content="hi"
+          collapse={head({ hiddenCount: 0, liveStartedAt: 7_600 })}
+          onToggleCollapse={() => {}}
+        />,
+      );
+
+      expect(container.textContent).toContain('2.4s');
+      expect(container.querySelector('button')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('shows metadata for tool calls without hidden steps', () => {
+    const container = render(
+      <UserMessage
+        content="hi"
+        collapse={head({ hiddenCount: 0, toolCallCount: 2 })}
+        onToggleCollapse={() => {}}
+      />,
+    );
+
+    expect(container.textContent).toContain('2 tool calls');
+    expect(container.querySelector('button')).toBeNull();
+  });
+
   it('pluralizes a single execution step as "Execution 1 step"', () => {
     const container = render(
       <UserMessage

--- a/packages/web-shell/client/components/messages/UserMessage.test.tsx
+++ b/packages/web-shell/client/components/messages/UserMessage.test.tsx
@@ -60,32 +60,30 @@ describe('UserMessage collapse toggle', () => {
     expect(btn.getAttribute('aria-expanded')).toBe('false');
   });
 
-  it('hides collapse metadata for slash commands', () => {
+  it('keeps collapse metadata for slash commands with hidden steps', () => {
     const container = render(
       <UserMessage
         content="/review"
-        commands={[{ name: 'review', description: 'Review changes' }]}
         collapse={head({ elapsedMs: 12_400, toolCallCount: 3 })}
         onToggleCollapse={() => {}}
       />,
     );
     expect(container.textContent).toContain('/review');
-    expect(container.textContent).not.toContain('Execution 5 steps');
-    expect(container.textContent).not.toContain('12.4s');
-    expect(container.querySelector('button')).toBeNull();
+    expect(container.textContent).toContain('Execution 5 steps');
+    expect(container.textContent).toContain('12.4s');
   });
 
-  it('keeps collapse metadata for unknown slash-prefixed text', () => {
+  it('hides collapse metadata when elapsed time is the only detail', () => {
     const container = render(
       <UserMessage
-        content="/Users/project"
-        commands={[{ name: 'review', description: 'Review changes' }]}
-        collapse={head({ elapsedMs: 12_400, toolCallCount: 3 })}
+        content="hi"
+        collapse={head({ hiddenCount: 0, elapsedMs: 12_400 })}
         onToggleCollapse={() => {}}
       />,
     );
-    expect(container.textContent).toContain('Execution 5 steps');
-    expect(container.textContent).toContain('12.4s');
+    expect(container.textContent).toContain('hi');
+    expect(container.textContent).not.toContain('12.4s');
+    expect(container.querySelector('button')).toBeNull();
   });
 
   it('pluralizes a single execution step as "Execution 1 step"', () => {

--- a/packages/web-shell/client/components/messages/UserMessage.tsx
+++ b/packages/web-shell/client/components/messages/UserMessage.tsx
@@ -2,7 +2,7 @@ import { memo, useEffect, useRef, useState } from 'react';
 import { PromptChevron } from '../PromptChevron';
 import { isSafeImageSrc } from './Markdown';
 import { useI18n } from '../../i18n';
-import type { CommandInfo, TurnCollapseHead } from '../../adapters/types';
+import type { TurnCollapseHead } from '../../adapters/types';
 import styles from './UserMessage.module.css';
 
 interface UserMessageImage {
@@ -13,7 +13,6 @@ interface UserMessageImage {
 interface UserMessageProps {
   content: string;
   images?: UserMessageImage[];
-  commands?: readonly CommandInfo[];
   /** When set, renders a toggle that folds/unfolds this turn's steps. */
   collapse?: TurnCollapseHead;
   onToggleCollapse?: (turnId: string) => void;
@@ -78,6 +77,14 @@ function metricsText(
   return parts.join(' · ');
 }
 
+function hasNonDurationMetrics(collapse: TurnCollapseHead): boolean {
+  return (
+    (collapse.inputTokens !== undefined &&
+      collapse.outputTokens !== undefined) ||
+    (collapse.toolCallCount !== undefined && collapse.toolCallCount > 0)
+  );
+}
+
 /**
  * Wall-clock that re-renders this row once a second while `active`, so a live
  * turn's elapsed advances smoothly instead of jumping per step. Idle (and for
@@ -94,35 +101,26 @@ function useNowTicker(active: boolean): number {
   return now;
 }
 
-function isKnownSlashCommandPrompt(
-  content: string,
-  commands: readonly CommandInfo[] | undefined,
-): boolean {
-  if (!commands?.length) return false;
-  const trimmed = content.trimStart();
-  if (!trimmed.startsWith('/')) return false;
-  const firstToken = trimmed.split(/\s+/, 1)[0]?.slice(1);
-  if (!firstToken) return false;
-  return commands.some((command) => command.name === firstToken);
-}
-
 export const UserMessage = memo(function UserMessage({
   content,
   images,
-  commands,
   collapse,
   onToggleCollapse,
 }: UserMessageProps) {
   const { t } = useI18n();
 
+  const hasToggle = !!collapse && collapse.hiddenCount > 0;
+  const showDurationMetric =
+    !!collapse && (hasToggle || hasNonDurationMetrics(collapse));
+
   // A live turn ticks `now - liveStartedAt`; a completed turn shows its frozen
   // elapsedMs. The ref clamps the shown value monotonically so it never steps
   // backward when a live turn settles onto its (timestamp-derived) final figure.
   const liveStartedAt = collapse?.liveStartedAt;
-  const now = useNowTicker(liveStartedAt !== undefined);
+  const now = useNowTicker(liveStartedAt !== undefined && showDurationMetric);
   const elapsedSeenRef = useRef(0);
   let displayElapsedMs: number | undefined;
-  if (liveStartedAt !== undefined) {
+  if (liveStartedAt !== undefined && showDurationMetric) {
     elapsedSeenRef.current = Math.max(
       elapsedSeenRef.current,
       Math.max(0, now - liveStartedAt),
@@ -140,9 +138,8 @@ export const UserMessage = memo(function UserMessage({
 
   // The chevron and step count toggle together (one comfortably-sized target);
   // the trailing metrics are inert. A step-less turn has no toggle, just metrics.
-  const hasToggle = !!collapse && collapse.hiddenCount > 0;
   const metrics = collapse ? metricsText(collapse, displayElapsedMs, t) : '';
-  const isSlashCommand = isKnownSlashCommandPrompt(content, commands);
+  const showMetrics = !!metrics && showDurationMetric;
 
   return (
     <div
@@ -175,39 +172,33 @@ export const UserMessage = memo(function UserMessage({
           </div>
         )}
         {content}
-        {!isSlashCommand &&
-          collapse &&
-          onToggleCollapse &&
-          (hasToggle || metrics) && (
-            <div className={styles.collapseRow}>
-              {hasToggle && (
-                <button
-                  type="button"
-                  className={styles.collapseToggle}
-                  onClick={() => onToggleCollapse(collapse.turnId)}
-                  aria-expanded={!collapse.collapsed}
-                  aria-label={
-                    collapse.collapsed ? t('turn.expand') : t('turn.collapse')
-                  }
-                  title={
-                    collapse.collapsed ? t('turn.expand') : t('turn.collapse')
-                  }
-                >
-                  {`${collapse.collapsed ? '▸' : '▾'} ${t(
-                    'turn.executionSteps',
-                    {
-                      count: collapse.hiddenCount,
-                    },
-                  )}`}
-                </button>
-              )}
-              {metrics && (
-                <span className={styles.collapseMeta}>
-                  {hasToggle ? ` · ${metrics}` : metrics}
-                </span>
-              )}
-            </div>
-          )}
+        {collapse && onToggleCollapse && (hasToggle || showMetrics) && (
+          <div className={styles.collapseRow}>
+            {hasToggle && (
+              <button
+                type="button"
+                className={styles.collapseToggle}
+                onClick={() => onToggleCollapse(collapse.turnId)}
+                aria-expanded={!collapse.collapsed}
+                aria-label={
+                  collapse.collapsed ? t('turn.expand') : t('turn.collapse')
+                }
+                title={
+                  collapse.collapsed ? t('turn.expand') : t('turn.collapse')
+                }
+              >
+                {`${collapse.collapsed ? '▸' : '▾'} ${t('turn.executionSteps', {
+                  count: collapse.hiddenCount,
+                })}`}
+              </button>
+            )}
+            {showMetrics && (
+              <span className={styles.collapseMeta}>
+                {hasToggle ? ` · ${metrics}` : metrics}
+              </span>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/web-shell/client/components/messages/UserMessage.tsx
+++ b/packages/web-shell/client/components/messages/UserMessage.tsx
@@ -77,6 +77,7 @@ function metricsText(
   return parts.join(' · ');
 }
 
+// Must track the same non-duration fields rendered by metricsText().
 function hasNonDurationMetrics(collapse: TurnCollapseHead): boolean {
   return (
     (collapse.inputTokens !== undefined &&
@@ -110,23 +111,26 @@ export const UserMessage = memo(function UserMessage({
   const { t } = useI18n();
 
   const hasToggle = !!collapse && collapse.hiddenCount > 0;
-  const showDurationMetric =
-    !!collapse && (hasToggle || hasNonDurationMetrics(collapse));
+  const liveStartedAt = collapse?.liveStartedAt;
+  const showMetadataRow =
+    !!collapse &&
+    (hasToggle ||
+      liveStartedAt !== undefined ||
+      hasNonDurationMetrics(collapse));
 
   // A live turn ticks `now - liveStartedAt`; a completed turn shows its frozen
   // elapsedMs. The ref clamps the shown value monotonically so it never steps
   // backward when a live turn settles onto its (timestamp-derived) final figure.
-  const liveStartedAt = collapse?.liveStartedAt;
-  const now = useNowTicker(liveStartedAt !== undefined && showDurationMetric);
+  const now = useNowTicker(liveStartedAt !== undefined && showMetadataRow);
   const elapsedSeenRef = useRef(0);
   let displayElapsedMs: number | undefined;
-  if (liveStartedAt !== undefined && showDurationMetric) {
+  if (liveStartedAt !== undefined && showMetadataRow) {
     elapsedSeenRef.current = Math.max(
       elapsedSeenRef.current,
       Math.max(0, now - liveStartedAt),
     );
     displayElapsedMs = elapsedSeenRef.current;
-  } else if (collapse?.elapsedMs !== undefined) {
+  } else if (showMetadataRow && collapse?.elapsedMs !== undefined) {
     elapsedSeenRef.current = Math.max(
       elapsedSeenRef.current,
       collapse.elapsedMs,
@@ -139,7 +143,7 @@ export const UserMessage = memo(function UserMessage({
   // The chevron and step count toggle together (one comfortably-sized target);
   // the trailing metrics are inert. A step-less turn has no toggle, just metrics.
   const metrics = collapse ? metricsText(collapse, displayElapsedMs, t) : '';
-  const showMetrics = !!metrics && showDurationMetric;
+  const showMetrics = !!metrics && showMetadataRow;
 
   return (
     <div


### PR DESCRIPTION
## What this PR does

This PR removes the special-case filtering that hid turn collapse metadata for known slash-command prompts in web-shell user messages. It also hides the collapse metadata row when elapsed time is the only available detail for completed turns, so prompt rows do not show a low-value standalone duration. Additionally, active (in-progress) turns now always show a live elapsed time ticker, even when no other metrics are available yet.

## Why it's needed

Slash-command text alone is not a reliable signal for whether web-shell should suppress collapse metadata. Some slash commands are implemented entirely in the frontend, some are passed through ACP without local execution logic, and some are passed through and then execute real agent-side behavior. Because those paths can produce different amounts of hidden work, the user-message renderer should not decide purely from the prompt text and command registry that slash commands never need execution metadata. The display now follows the actual available metadata instead: useful step, token, or tool details are shown, while a row that only contains elapsed time is suppressed as noise — except for active turns, where the live ticker provides useful real-time feedback.

The gating flag was renamed from `showDurationMetric` to `showMetadataRow` to accurately reflect that it controls the entire collapse row (duration, tokens, and tool calls), not just the duration.

## Reviewer Test Plan

### How to verify

Review a web-shell turn whose prompt is a slash command and has collapsed hidden work; it should still show the execution step metadata. Review a completed turn that has no hidden steps and only an elapsed duration; it should not render a standalone metadata row. Review an active (in-progress) turn with no steps or metrics yet; it should show a live elapsed time ticker. Confirm the command list is no longer threaded into user-message rendering only for this filtering decision.

### Evidence (Before & After)

Before: known slash-command prompts suppressed collapse metadata even when hidden execution work existed, step-less turns could show a row containing only elapsed time, and prompt-only active turns had no collapse head at all. After: slash-command prompts use the same metadata display rules as other prompts, elapsed-only rows on completed turns are omitted, and active turns always show a live elapsed ticker via `liveStartedAt` (falling back to `Date.now()` when no prompt timestamp is available).

Local verification: `cd packages/web-shell && npx vitest run client/components/messages/UserMessage.test.tsx` passed. `cd packages/web-shell && npx vitest run client/components/MessageList.test.ts` passed. `cd packages/web-shell && npm run build` passed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local unit tests and web-shell production build.

## Risk & Scope

- Main risk or tradeoff: Slash-command prompt rows can now show collapse metadata when there is hidden work, which is more accurate but slightly more visible than the previous special case. Active turns now always render a live elapsed ticker, adding a small visual element to prompt-only turns during processing.
- Not validated / out of scope: Full manual browser verification with every slash-command execution path was not performed locally.
- Breaking changes / migration notes: None expected.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 移除了 web-shell 用户消息里针对已知 slash-command prompt 隐藏 turn collapse metadata 的特殊过滤逻辑。对于已完成的 turn，当可用详情只有耗时时，不再展示 collapse metadata 行。对于进行中的 active turn，即使尚无其他指标，也会始终显示实时耗时 ticker。

## Why it's needed

单靠 slash-command 文本不能可靠判断 web-shell 是否应该隐藏 collapse metadata。有些 slash command 完全由前端实现，有些会通过 ACP 透传但本地没有执行逻辑，还有一些会透传后执行真正的 agent 侧逻辑。现在展示逻辑改为基于实际可用 metadata：有用的步骤、token 或工具详情会展示，已完成 turn 只有耗时的一行作为噪音隐藏——但进行中的 turn 始终显示实时耗时 ticker 以提供即时反馈。

门控标志从 `showDurationMetric` 重命名为 `showMetadataRow`，以准确反映它控制的是整个 collapse 行（耗时、token、工具调用），而不仅仅是耗时。

## Reviewer Test Plan

### How to verify

检查一个 prompt 为 slash command 且存在 collapsed hidden work 的 web-shell turn；它仍应展示 execution step metadata。检查一个已完成且没有 hidden steps、只有 elapsed duration 的 turn；它不应渲染独立 metadata 行。检查一个正在进行、尚无 steps 或指标的 active turn；它应显示实时耗时 ticker。确认 command list 不再仅为了这个过滤判断传入 user-message 渲染。

### Evidence (Before & After)

Before：已知 slash-command prompt 即使存在隐藏执行工作也会隐藏 collapse metadata，没有 steps 的 turn 可能显示只有耗时的一行，prompt-only 的 active turn 完全没有 collapse head。After：slash-command prompt 和其他 prompt 使用相同的 metadata 展示规则，已完成 turn 只包含耗时的行会被省略，active turn 始终通过 `liveStartedAt` 显示实时 elapsed ticker（无 prompt timestamp 时 fallback 到 `Date.now()`）。

本地验证：`cd packages/web-shell && npx vitest run client/components/messages/UserMessage.test.tsx` 已通过。`cd packages/web-shell && npx vitest run client/components/MessageList.test.ts` 已通过。`cd packages/web-shell && npm run build` 已通过。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地单测和 web-shell production build。

## Risk & Scope

- Main risk or tradeoff：当 slash-command prompt 存在隐藏工作时，现在会展示 collapse metadata；active turn 现在始终渲染实时 elapsed ticker，在 prompt-only turn 处理期间增加了一个小的视觉元素。
- Not validated / out of scope：未在本地针对每一种 slash-command 执行路径做完整浏览器手动验证。
- Breaking changes / migration notes：预计没有。

## Linked Issues

N/A

</details>