### PR TITLE
ci: run CLI integration tests in the merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,3 +293,45 @@ jobs:
 
       - name: 'Perform CodeQL Analysis'
         uses: 'github/codeql-action/analyze@df559355d593797519d70b90fc8edd5db049e7a2' # ratchet:github/codeql-action/analyze@v3
+
+  # Integration tests run only in the merge queue, not on every PR push.
+  # They are the suite that previously ran *only* in the nightly Release
+  # pipeline (`release.yml`), so regressions stayed hidden until release
+  # time. Gating them on `merge_group` catches the failure before the PR
+  # lands on `main`, while keeping the per-PR critical path fast. The
+  # `merge_group` event runs in the base-repo context, so the same model
+  # secrets used by the release jobs are available here.
+  #
+  # Until merge queue is enabled on `main` this job simply never triggers,
+  # so adding it is a no-op for existing PR/push runs. Reuses the exact
+  # `test:integration:cli:sandbox:none` script from `release.yml`.
+  integration_cli:
+    name: 'Integration Tests (CLI, No Sandbox)'
+    if: "${{ github.event_name == 'merge_group' }}"
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: 'read'
+    env:
+      OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
+      OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
+      OPENAI_MODEL: '${{ secrets.OPENAI_MODEL }}'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
+
+      - name: 'Setup Node.js'
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: 'package-lock.json'
+
+      - name: 'Install Dependencies'
+        env:
+          NPM_CONFIG_PREFER_OFFLINE: 'true'
+        run: |-
+          npm ci --no-audit --progress=false
+
+      - name: 'Run CLI Integration Tests'
+        run: |-
+          npm run test:integration:cli:sandbox:none


### PR DESCRIPTION
## What this PR does

Adds a CI job that runs the existing CLI integration suite in the GitHub merge queue. The job is gated on the `merge_group` event, so it runs when a PR is queued for merge rather than on every PR push, and reuses the same `test:integration:cli:sandbox:none` npm script and model secrets that the nightly release pipeline already uses.

## Why it's needed

Integration tests under `integration-tests/` currently run only in the nightly, cron-triggered Release pipeline — they never run on PRs or on push to `main`. As a result, a PR that breaks an integration test passes CI, merges green, and the breakage stays hidden until the next release is blocked, by which point the author has moved on and a maintainer has to bisect. Of the last 17 Release failures, 13 were these integration test jobs (see #5219 for the full data). Gating the suite on `merge_group` catches the regression before the PR lands on `main`, while keeping the per-PR critical path fast.

## Reviewer Test Plan

### How to verify

This is a CI-config-only change with no application code. Confirm the new `integration_cli` job is gated on `if: github.event_name == 'merge_group'` so it does not run on normal PR/push, that it reuses the `test:integration:cli:sandbox:none` script and the `OPENAI_*` secrets already used by `release.yml`, and that the workflow is syntactically valid. The job will not trigger until merge queue is enabled on `main`, so this PR's own CI does not execute it — that is expected. Locally: `actionlint .github/workflows/ci.yml` passes and the YAML parses.

### Evidence (Before & After)

N/A — non-user-visible CI configuration change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

N/A — workflow configuration only; `actionlint` used for validation.

## Risk & Scope

- Main risk or tradeoff: once merge queue is enabled and this job is marked required, a flaky run could block the queue. Mitigation: keep it non-required for a few days first, observe stability (duration, flakiness, API quota), then mark required.
- Not validated / out of scope: enabling merge queue itself and marking the check required are admin branch-protection settings, done separately after merge. The Docker / interactive integration suites are intentionally left to the nightly Release pipeline.
- Breaking changes / migration notes: none. The job is a no-op until merge queue is enabled, so merging this changes nothing for existing PR/push runs.

## Linked Issues

Refs #5219

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

新增一个 CI job，在 GitHub merge queue 中运行已有的 CLI 集成测试套件。该 job 通过 `merge_group` 事件触发，因此它在 PR 进入合并队列时运行，而不是每次 PR push 都跑；并且复用了 nightly Release 流水线已经在用的同一个 `test:integration:cli:sandbox:none` npm 脚本和模型 secret。

## 为什么需要

`integration-tests/` 下的集成测试目前只在每天定时触发的 Release 流水线里运行——它在 PR 阶段、push 到 `main` 时都不会跑。结果是：改坏集成测试的 PR 通过 CI、全绿合入，问题一直隐藏到下一次发版被挡才暴露；那时 PR 作者早已转场，只能由维护者回头 bisect。最近 17 次 Release 失败里有 13 次就是这些集成测试 job（完整数据见 #5219）。把这套测试挂到 `merge_group` 上，能在 PR 落到 `main` 之前就拦住回归，同时保持每次 PR 的关键路径足够快。

## 评审验证计划

### 如何验证

这是一个纯 CI 配置改动，不含应用代码。请确认：新增的 `integration_cli` job 以 `if: github.event_name == 'merge_group'` 限定，因此不会在普通 PR/push 上运行；它复用了 `release.yml` 已经在用的 `test:integration:cli:sandbox:none` 脚本和 `OPENAI_*` secret；workflow 语法有效。该 job 在 `main` 启用 merge queue 之前不会触发，所以本 PR 自身的 CI 不会执行它——这是预期行为。本地：`actionlint .github/workflows/ci.yml` 通过，YAML 解析通过。

### 证据（前后对比）

N/A —— 非用户可见的 CI 配置改动。

### 测试环境

见上表，均为 N/A（仅 workflow 配置）。

### 运行环境（可选）

N/A —— 仅 workflow 配置；使用 `actionlint` 校验。

## 风险与范围

- 主要风险/取舍：一旦启用 merge queue 并把该 job 设成 required，flaky 的运行可能堵住队列。缓解：先保持非 required 跑几天，观察稳定性（耗时、flaky、API 配额），验稳后再设 required。
- 未验证 / 超出范围：启用 merge queue 本身、以及把该 check 设成 required，都是 admin 的分支保护设置，合并后单独处理。Docker / interactive 集成套件有意保留在 nightly Release 流水线。
- 破坏性改动 / 迁移说明：无。该 job 在启用 merge queue 之前是 no-op，所以合并本 PR 对现有 PR/push 运行没有任何影响。

## 关联 Issue

Refs #5219

</details>
