### PR TITLE
fix(core): read BMP height as signed int32 for top-down bitmaps

### DIFF
--- a/packages/core/src/utils/request-tokenizer/imageTokenizer.test.ts
+++ b/packages/core/src/utils/request-tokenizer/imageTokenizer.test.ts
@@ -201,4 +201,33 @@ describe('ImageTokenizer', () => {
       expect(metadata.height).toBe(768);
     });
   });
+
+  describe('BMP dimension extraction', () => {
+    function buildBmp(width: number, height: number): string {
+      // A negative height encodes a top-down BMP per the BITMAPINFOHEADER spec.
+      const buf = Buffer.alloc(26);
+      buf.write('BM', 0, 'ascii');
+      buf.writeUInt32LE(26, 2); // file size
+      buf.writeUInt32LE(0, 6); // reserved
+      buf.writeUInt32LE(26, 10); // pixel data offset
+      buf.writeUInt32LE(40, 14); // BITMAPINFOHEADER size
+      buf.writeInt32LE(width, 18);
+      buf.writeInt32LE(height, 22);
+      return buf.toString('base64');
+    }
+
+    it('reads a bottom-up (positive height) BMP', async () => {
+      const bmp = buildBmp(120, 80);
+      const metadata = await tokenizer.extractImageMetadata(bmp, 'image/bmp');
+      expect(metadata.width).toBe(120);
+      expect(metadata.height).toBe(80);
+    });
+
+    it('reads a top-down (negative height) BMP as its absolute height', async () => {
+      const bmp = buildBmp(100, -50);
+      const metadata = await tokenizer.extractImageMetadata(bmp, 'image/bmp');
+      expect(metadata.width).toBe(100);
+      expect(metadata.height).toBe(50);
+    });
+  });
 });

--- a/packages/core/src/utils/request-tokenizer/imageTokenizer.ts
+++ b/packages/core/src/utils/request-tokenizer/imageTokenizer.ts
@@ -354,7 +354,9 @@ export class ImageTokenizer {
     }
 
     const width = buffer.readUInt32LE(18);
-    const height = buffer.readUInt32LE(22);
+    // Height is a signed int32: a negative value means a top-down BMP. Read it
+    // signed so Math.abs recovers the real height instead of a ~4-billion value.
+    const height = buffer.readInt32LE(22);
 
     return { width, height: Math.abs(height) }; // Height can be negative for top-down BMPs
   }


### PR DESCRIPTION
## What this PR does

Reads the BMP height field as a signed `int32` instead of `uint32` so top-down bitmaps report their real height. `extractBmpDimensions` already intends to handle the negative-height case (`Math.abs(height)` with a "Height can be negative for top-down BMPs" comment), but it reads the field with `readUInt32LE`, so a negative height like `-50` becomes `4294967246` *before* `Math.abs` runs — and `Math.abs` of an already-huge positive number is still huge. Switching to `readInt32LE` lets `Math.abs` recover the true height.

## Why it's needed

A BMP stores a negative height to signal top-down row order — a valid, spec-defined layout. With the unsigned read, any top-down BMP parses to a ~4-billion-pixel height, and after `calculateTokensWithScaling` clamps to `maxPixels` the token estimate is pinned to the per-image maximum regardless of the image's real size — a large, silent over-count for that whole class of BMPs. (Same failure mode as the TIFF SHORT fix in #5209, just on the BMP path.)

## Reviewer Test Plan

### How to verify

Run the image tokenizer unit tests. Two new cases build a minimal BMP header: a bottom-up (positive height) BMP and a top-down (negative height) one. The top-down case asserts the height comes back as its absolute value (`50`) rather than the pre-fix `4294967246`.

`npx vitest run packages/core/src/utils/request-tokenizer/imageTokenizer.test.ts`

Expected: 13 passed. The top-down case fails on `main` (`expected 4294967246 to be 50`) and passes with the fix.

### Evidence (Before & After)

Non-UI change (token-accounting math), captured by the added unit test. Before: top-down BMP height `4294967246`; after: `50`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️ not tested   |
| 🪟 Windows |   ✅ tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Unit tests only (`vitest`).

## Risk & Scope

- Main risk or tradeoff: low — only the height read changes; bottom-up BMPs (the common case) are unaffected since a positive value reads the same signed or unsigned. Width stays unsigned (BMP width is always positive).
- Not validated / out of scope: real-world BMP files beyond the synthetic header fixtures.
- Breaking changes / migration notes: none.
