### PR TITLE
fix(core): handle stale worktree session markers

### DIFF
--- a/packages/cli/src/startup/worktreeStartup.test.ts
+++ b/packages/cli/src/startup/worktreeStartup.test.ts
@@ -14,7 +14,16 @@ import * as path from 'node:path';
 import {
   setupStartupWorktree,
   buildStartupWorktreeNotice,
+  persistStartupWorktreeSidecar,
 } from './worktreeStartup.js';
+import {
+  readWorktreeSessionMarker,
+  SessionService,
+  Storage,
+  writeRuntimeStatus,
+  writeWorktreeSessionMarker,
+} from '@qwen-code/qwen-code-core';
+import type { Config } from '@qwen-code/qwen-code-core';
 
 const exec = promisify(execFile);
 
@@ -352,6 +361,130 @@ describe('setupStartupWorktree', () => {
         /nested|inside another worktree/,
       );
     }
+  });
+});
+
+describe('persistStartupWorktreeSidecar', () => {
+  vi.setConfig({ testTimeout: 30000, hookTimeout: 30000 });
+
+  let prevCwd: string;
+  let tempRepo: string | null = null;
+  let runtimeDir: string | null = null;
+
+  beforeEach(async () => {
+    prevCwd = process.cwd();
+    runtimeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'qwen-wt-runtime-'));
+    Storage.setRuntimeBaseDir(runtimeDir);
+  });
+
+  afterEach(async () => {
+    process.chdir(prevCwd);
+    Storage.setRuntimeBaseDir(null);
+    if (tempRepo) {
+      await fs.rm(tempRepo, { recursive: true, force: true });
+      tempRepo = null;
+    }
+    if (runtimeDir) {
+      await fs.rm(runtimeDir, { recursive: true, force: true });
+      runtimeDir = null;
+    }
+  });
+
+  function makeConfig(targetDir: string, sessionId: string): Config {
+    const sessionService = new SessionService(targetDir);
+    return {
+      getSessionId: () => sessionId,
+      getSessionService: () => sessionService,
+    } as unknown as Config;
+  }
+
+  it('adopts a stale marker when re-attaching to an inactive owner', async () => {
+    tempRepo = await makeTempRepo();
+    process.chdir(tempRepo);
+
+    const setup = await setupStartupWorktree('adopt-stale');
+    expect(setup?.ok).toBe(true);
+    if (!setup?.ok) return;
+    await writeWorktreeSessionMarker(setup.context.worktreePath, 'old-session');
+    await writeRuntimeStatus(
+      new Storage(setup.context.worktreePath).getRuntimeStatusPath(
+        'old-session',
+      ),
+      {
+        sessionId: 'old-session',
+        workDir: setup.context.worktreePath,
+        pid: 2147483647,
+      },
+    );
+
+    await persistStartupWorktreeSidecar(
+      makeConfig(setup.context.worktreePath, 'new-session'),
+      { ...setup.context, wasReattached: true },
+    );
+
+    expect(await readWorktreeSessionMarker(setup.context.worktreePath)).toBe(
+      'new-session',
+    );
+  });
+
+  it('keeps the marker when the owner runtime is still active', async () => {
+    tempRepo = await makeTempRepo();
+    process.chdir(tempRepo);
+
+    const setup = await setupStartupWorktree('owner-active');
+    expect(setup?.ok).toBe(true);
+    if (!setup?.ok) return;
+    await writeWorktreeSessionMarker(setup.context.worktreePath, 'old-session');
+    await writeRuntimeStatus(
+      new Storage(setup.context.worktreePath).getRuntimeStatusPath(
+        'old-session',
+      ),
+      {
+        sessionId: 'old-session',
+        workDir: setup.context.worktreePath,
+        pid: process.pid,
+      },
+    );
+
+    await persistStartupWorktreeSidecar(
+      makeConfig(setup.context.worktreePath, 'new-session'),
+      { ...setup.context, wasReattached: true },
+    );
+
+    expect(await readWorktreeSessionMarker(setup.context.worktreePath)).toBe(
+      'old-session',
+    );
+  });
+
+  it('finds an active owner under a repo-subdir relative runtime dir', async () => {
+    tempRepo = await makeTempRepo();
+    process.chdir(tempRepo);
+    const packageDir = path.join(tempRepo, 'packages', 'app');
+    await fs.mkdir(packageDir, { recursive: true });
+    Storage.setRuntimeBaseDir('.qwen', packageDir);
+
+    const setup = await setupStartupWorktree('owner-subdir-runtime');
+    expect(setup?.ok).toBe(true);
+    if (!setup?.ok) return;
+    await writeWorktreeSessionMarker(setup.context.worktreePath, 'old-session');
+    await writeRuntimeStatus(
+      new Storage(packageDir).getRuntimeStatusPath('old-session'),
+      {
+        sessionId: 'old-session',
+        workDir: packageDir,
+        pid: process.pid,
+      },
+    );
+
+    Storage.setRuntimeBaseDir('.qwen', setup.context.worktreePath);
+    await persistStartupWorktreeSidecar(
+      makeConfig(setup.context.worktreePath, 'new-session'),
+      { ...setup.context, wasReattached: true },
+    );
+
+    expect(await readWorktreeSessionMarker(setup.context.worktreePath)).toBe(
+      'old-session',
+    );
   });
 });
 

--- a/packages/cli/src/startup/worktreeStartup.ts
+++ b/packages/cli/src/startup/worktreeStartup.ts
@@ -26,6 +26,8 @@ import {
   createDebugLogger,
   GitWorktreeService,
   readWorktreeSession,
+  readWorktreeSessionMarker,
+  isSessionRuntimeActive,
   worktreeBranchForSlug,
   writeWorktreeSession,
   writeWorktreeSessionMarker,
@@ -391,19 +393,28 @@ export async function persistStartupWorktreeSidecar(
     overriddenSlug = previous.slug;
   }
 
-  // Best-effort marker write — same policy as EnterWorktreeTool: a failure
-  // here does not abort the session, the worktree is usable, ownership
-  // checks just treat the worktree as "owner unknown" for future
-  // exit_worktree calls.
-  //
-  // SKIP on re-attach: the marker was written by whichever session
-  // ORIGINALLY created this worktree. Overwriting with the current
-  // session id would let `exit_worktree action="remove"` succeed across
-  // sessions, bypassing Phase A's cross-session ownership guard. The
-  // existing marker stays so the original owner remains canonical; the
-  // current session can still operate INSIDE the worktree (file ops,
-  // commits) — ownership only governs the destructive remove.
-  if (!context.wasReattached) {
+  // Best-effort marker write. On re-attach, adopt only when the previous
+  // owner is not a live runtime anymore; otherwise keep the old marker so
+  // two active sessions cannot both remove the same worktree.
+  let shouldWriteMarker = !context.wasReattached;
+  if (context.wasReattached) {
+    const owner = await readWorktreeSessionMarker(context.worktreePath);
+    if (owner === null || owner === sessionId) {
+      shouldWriteMarker = true;
+    } else {
+      const ownerActive = await isSessionRuntimeActive(owner, [
+        context.repoRoot,
+        context.worktreePath,
+      ]).catch((error) => {
+        debugLogger.warn(
+          `persistStartupWorktreeSidecar: failed to check owner runtime ${owner}: ${error}`,
+        );
+        return true;
+      });
+      shouldWriteMarker = !ownerActive;
+    }
+  }
+  if (shouldWriteMarker) {
     await writeWorktreeSessionMarker(context.worktreePath, sessionId).catch(
       () => {},
     );

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -65,6 +65,7 @@ import {
   restoreWorktreeContext,
   GitWorktreeService,
   readWorktreeSessionMarker,
+  isSessionRuntimeActive,
 } from '@qwen-code/qwen-code-core';
 import { buildResumedHistoryItems } from './utils/resumeHistoryUtils.js';
 import { loadLowlight } from './utils/lowlightLoader.js';
@@ -1256,18 +1257,31 @@ export const AppContainer = (props: AppContainerProps) => {
           const owner = await readWorktreeSessionMarker(activeWorktree.path);
           const currentSessionId = config.getSessionId();
           if (owner !== null && owner !== currentSessionId) {
-            historyManager.addItem(
-              {
-                type: MessageType.ERROR,
-                text:
-                  `Refusing to remove worktree "${activeWorktree.slug}" — ` +
-                  `it was created by a different session (owner=${owner}). ` +
-                  `Resume the owning session to drop it, or remove it ` +
-                  `manually with \`git worktree remove ${activeWorktree.path}\`.`,
-              },
-              Date.now(),
-            );
-            return;
+            const ownerActive = await isSessionRuntimeActive(owner, [
+              activeWorktree.originalCwd,
+              activeWorktree.path,
+            ]).catch((error) => {
+              config
+                .getDebugLogger()
+                .warn(
+                  `Worktree owner runtime check failed for ${owner}: ${error}`,
+                );
+              return true;
+            });
+            if (ownerActive) {
+              historyManager.addItem(
+                {
+                  type: MessageType.ERROR,
+                  text:
+                    `Refusing to remove worktree "${activeWorktree.slug}" — ` +
+                    `it was created by a different session (owner=${owner}). ` +
+                    `Resume the owning session to drop it, or remove it ` +
+                    `manually with \`git worktree remove ${activeWorktree.path}\`.`,
+                },
+                Date.now(),
+              );
+              return;
+            }
           }
           // The user just clicked Remove on a dialog that already showed
           // the dirty-state and unmerged-commit counts ("discards N

--- a/packages/core/src/services/worktreeSessionService.test.ts
+++ b/packages/core/src/services/worktreeSessionService.test.ts
@@ -13,8 +13,11 @@ import {
   writeWorktreeSession,
   clearWorktreeSession,
   restoreWorktreeContext,
+  isSessionRuntimeActive,
   type WorktreeSession,
 } from './worktreeSessionService.js';
+import { Storage } from '../config/storage.js';
+import { writeRuntimeStatus } from '../utils/runtimeStatus.js';
 
 const sample: WorktreeSession = {
   slug: 'my-feature',
@@ -105,6 +108,69 @@ describe('clearWorktreeSession', () => {
 
   it('is a no-op when file does not exist', async () => {
     await expect(clearWorktreeSession(filePath)).resolves.not.toThrow();
+  });
+});
+
+describe('isSessionRuntimeActive', () => {
+  beforeEach(() => {
+    Storage.setRuntimeBaseDir(null);
+  });
+
+  afterEach(() => {
+    Storage.setRuntimeBaseDir(null);
+  });
+
+  it('lets active runtime status win over a dead status found in an earlier root', async () => {
+    const repoRoot = path.join(tmpDir, 'repo');
+    const worktreePath = path.join(repoRoot, '.qwen', 'worktrees', 'feature');
+    await fs.mkdir(worktreePath, { recursive: true });
+
+    Storage.setRuntimeBaseDir(path.join(tmpDir, 'runtime'));
+    await writeRuntimeStatus(
+      new Storage(repoRoot).getRuntimeStatusPath('owner-session'),
+      {
+        sessionId: 'owner-session',
+        workDir: repoRoot,
+        pid: 2147483647,
+      },
+    );
+    await writeRuntimeStatus(
+      new Storage(worktreePath).getRuntimeStatusPath('owner-session'),
+      {
+        sessionId: 'owner-session',
+        workDir: worktreePath,
+        pid: process.pid,
+      },
+    );
+
+    await expect(
+      isSessionRuntimeActive('owner-session', [repoRoot, worktreePath]),
+    ).resolves.toBe(true);
+  });
+
+  it('does not trust repo-contained dead runtime status as proof of inactivity', async () => {
+    const repoRoot = path.join(tmpDir, 'repo');
+    const fakeRuntimeBase = path.join(repoRoot, 'src');
+    await fs.mkdir(fakeRuntimeBase, { recursive: true });
+    Storage.setRuntimeBaseDir(path.join(tmpDir, 'external-runtime'));
+    await writeRuntimeStatus(
+      path.join(
+        fakeRuntimeBase,
+        'projects',
+        'fake-project',
+        'chats',
+        'owner-session.runtime.json',
+      ),
+      {
+        sessionId: 'owner-session',
+        workDir: repoRoot,
+        pid: 2147483647,
+      },
+    );
+
+    await expect(
+      isSessionRuntimeActive('owner-session', repoRoot),
+    ).resolves.toBe(true);
   });
 });
 

--- a/packages/core/src/services/worktreeSessionService.ts
+++ b/packages/core/src/services/worktreeSessionService.ts
@@ -5,9 +5,20 @@
  */
 
 import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
 import * as path from 'node:path';
+import { Storage } from '../config/storage.js';
 import { isNodeError } from '../utils/errors.js';
 import { atomicWriteJSON } from '../utils/atomicFileWrite.js';
+import { readRuntimeStatus } from '../utils/runtimeStatus.js';
+
+const RUNTIME_STATUS_SCAN_MAX_DIRS = 5000;
+const RUNTIME_STATUS_SCAN_SKIP_DIRS = new Set([
+  '.git',
+  '.hg',
+  '.svn',
+  'node_modules',
+]);
 
 /**
  * Persisted state for an active user worktree session. Written when the
@@ -119,6 +130,215 @@ export async function clearWorktreeSession(filePath: string): Promise<void> {
     if (isNodeError(error) && error.code === 'ENOENT') return;
     throw error;
   }
+}
+
+export async function isSessionRuntimeActive(
+  sessionId: string,
+  projectRoots: string | readonly string[],
+): Promise<boolean> {
+  const roots = uniquePaths(
+    (Array.isArray(projectRoots) ? projectRoots : [projectRoots]).map((root) =>
+      path.resolve(root),
+    ),
+  );
+  const runtimeBases = getRuntimeBaseCandidates(roots);
+  let sawDeadRuntimeStatus = false;
+
+  for (const runtimeBase of runtimeBases) {
+    for (const projectRoot of roots) {
+      const statusPath = await Storage.runWithRuntimeBaseDir(
+        runtimeBase,
+        undefined,
+        async () => new Storage(projectRoot).getRuntimeStatusPath(sessionId),
+      );
+      const statusState = await getRuntimeStatusPathState(
+        statusPath,
+        sessionId,
+      );
+      if (statusState === 'active') {
+        return true;
+      }
+      sawDeadRuntimeStatus ||= statusState === 'dead';
+    }
+
+    const baseState = await getRuntimeStatusStateInBase(runtimeBase, sessionId);
+    if (baseState === 'active') {
+      return true;
+    }
+    sawDeadRuntimeStatus ||= baseState === 'dead';
+  }
+
+  const scanResult = await scanRuntimeStatusUnderRoots(roots, sessionId);
+  if (scanResult === 'active' || scanResult === 'incomplete') {
+    return true;
+  }
+
+  return !sawDeadRuntimeStatus;
+}
+
+function getRuntimeBaseCandidates(projectRoots: readonly string[]): string[] {
+  const currentBase = path.resolve(Storage.getRuntimeBaseDir());
+  const candidates = [currentBase];
+
+  for (const root of projectRoots) {
+    const rel = path.relative(root, currentBase);
+    if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) {
+      continue;
+    }
+    for (const candidateRoot of projectRoots) {
+      candidates.push(path.resolve(candidateRoot, rel));
+    }
+  }
+
+  return uniquePaths(candidates);
+}
+
+type RuntimeStatusState = 'active' | 'dead' | 'missing';
+
+async function getRuntimeStatusStateInBase(
+  runtimeBase: string,
+  sessionId: string,
+): Promise<RuntimeStatusState> {
+  const projectsDir = path.join(runtimeBase, 'projects');
+  let entries: Array<import('node:fs').Dirent>;
+  try {
+    entries = await fs.readdir(projectsDir, { withFileTypes: true });
+  } catch (error) {
+    if (isNodeError(error) && error.code === 'ENOENT') {
+      return 'missing';
+    }
+    throw error;
+  }
+
+  let sawDeadRuntimeStatus = false;
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const statusPath = path.join(
+      projectsDir,
+      entry.name,
+      'chats',
+      `${sessionId}.runtime.json`,
+    );
+    const statusState = await getRuntimeStatusPathState(statusPath, sessionId);
+    if (statusState === 'active') {
+      return 'active';
+    }
+    sawDeadRuntimeStatus ||= statusState === 'dead';
+  }
+  return sawDeadRuntimeStatus ? 'dead' : 'missing';
+}
+
+type RuntimeStatusScanResult = 'active' | 'dead' | 'not-found' | 'incomplete';
+
+async function scanRuntimeStatusUnderRoots(
+  roots: readonly string[],
+  sessionId: string,
+): Promise<RuntimeStatusScanResult> {
+  const seen = new Set<string>();
+  const state = { dirs: 0 };
+  let sawDeadRuntimeStatus = false;
+  for (const root of roots) {
+    const result = await scanRuntimeStatusDir(root, sessionId, seen, state);
+    if (result === 'active' || result === 'incomplete') {
+      return result;
+    }
+    sawDeadRuntimeStatus ||= result === 'dead';
+  }
+  return sawDeadRuntimeStatus ? 'dead' : 'not-found';
+}
+
+async function scanRuntimeStatusDir(
+  dir: string,
+  sessionId: string,
+  seen: Set<string>,
+  state: { dirs: number },
+): Promise<RuntimeStatusScanResult> {
+  if (state.dirs >= RUNTIME_STATUS_SCAN_MAX_DIRS) {
+    return 'incomplete';
+  }
+  state.dirs++;
+
+  const realDir = await fs.realpath(dir).catch(() => path.resolve(dir));
+  if (seen.has(realDir)) {
+    return 'not-found';
+  }
+  seen.add(realDir);
+
+  let entries: Array<import('node:fs').Dirent>;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch (error) {
+    if (isNodeError(error) && error.code === 'ENOENT') {
+      return 'not-found';
+    }
+    throw error;
+  }
+
+  let sawDeadRuntimeStatus = false;
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const child = path.join(dir, entry.name);
+    if (entry.name === 'projects') {
+      const baseState = await getRuntimeStatusStateInBase(dir, sessionId);
+      if (baseState === 'active') {
+        return 'active';
+      }
+      sawDeadRuntimeStatus ||= baseState === 'dead';
+      continue;
+    }
+    if (shouldSkipRuntimeStatusScanDir(entry.name, dir)) {
+      continue;
+    }
+    const result = await scanRuntimeStatusDir(child, sessionId, seen, state);
+    if (result !== 'not-found') {
+      if (result === 'dead') {
+        sawDeadRuntimeStatus = true;
+        continue;
+      }
+      return result;
+    }
+  }
+
+  return sawDeadRuntimeStatus ? 'dead' : 'not-found';
+}
+
+function shouldSkipRuntimeStatusScanDir(name: string, parent: string): boolean {
+  if (RUNTIME_STATUS_SCAN_SKIP_DIRS.has(name)) {
+    return true;
+  }
+  return name === 'worktrees' && path.basename(parent) === '.qwen';
+}
+
+async function getRuntimeStatusPathState(
+  statusPath: string,
+  sessionId: string,
+): Promise<RuntimeStatusState> {
+  const status = await readRuntimeStatus(statusPath);
+  if (!status || status.sessionId !== sessionId) {
+    return 'missing';
+  }
+
+  if (status.hostname !== os.hostname()) {
+    return 'active';
+  }
+
+  try {
+    process.kill(status.pid, 0);
+    return 'active';
+  } catch (error) {
+    if (isNodeError(error) && error.code === 'ESRCH') {
+      return 'dead';
+    }
+    return 'active';
+  }
+}
+
+function uniquePaths(paths: readonly string[]): string[] {
+  return [...new Set(paths.map((value) => path.resolve(value)))];
 }
 
 export interface WorktreeRestoreResult {

--- a/packages/core/src/tools/exit-worktree.session.integ.test.ts
+++ b/packages/core/src/tools/exit-worktree.session.integ.test.ts
@@ -16,8 +16,14 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { EnterWorktreeTool } from './enter-worktree.js';
 import { ExitWorktreeTool } from './exit-worktree.js';
-import { readWorktreeSession } from '../services/worktreeSessionService.js';
+import {
+  readWorktreeSession,
+  writeWorktreeSession,
+} from '../services/worktreeSessionService.js';
 import { SessionService } from '../services/sessionService.js';
+import { GitWorktreeService } from '../services/gitWorktreeService.js';
+import { Storage } from '../config/storage.js';
+import { writeRuntimeStatus } from '../utils/runtimeStatus.js';
 import type { Config } from '../config/config.js';
 
 // Real git invocations + user-global hooks can take 10-20s on slow
@@ -45,10 +51,12 @@ describe('ExitWorktreeTool — WorktreeSession sidecar cleanup', () => {
     });
 
     sessionService = new SessionService(repoRoot);
+    Storage.setRuntimeBaseDir(path.join(repoRoot, '.runtime'));
     sessionId = 'session-' + Math.random().toString(36).slice(2, 10);
   });
 
   afterEach(async () => {
+    Storage.setRuntimeBaseDir(null);
     await fs.rm(repoRoot, { recursive: true, force: true });
   });
 
@@ -155,5 +163,210 @@ describe('ExitWorktreeTool — WorktreeSession sidecar cleanup', () => {
       .execute(new AbortController().signal);
     expect(result.error).toBeUndefined();
     // No throw is the assertion.
+  });
+
+  it('removes a re-attached worktree when the old marker owner is inactive', async () => {
+    sessionId = 'old-session';
+    await enterWorktree('reattached-stale');
+    const wtPath = new GitWorktreeService(repoRoot).getUserWorktreePath(
+      'reattached-stale',
+    );
+
+    const currentSessionId = 'new-session';
+    const currentSessionService = new SessionService(wtPath);
+    const currentSessionPath =
+      currentSessionService.getWorktreeSessionPath(currentSessionId);
+    await writeRuntimeStatus(
+      new Storage(wtPath).getRuntimeStatusPath('old-session'),
+      {
+        sessionId: 'old-session',
+        workDir: wtPath,
+        pid: 2147483647,
+      },
+    );
+    const originalHeadCommit = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    }).trim();
+    await writeWorktreeSession(currentSessionPath, {
+      slug: 'reattached-stale',
+      worktreePath: wtPath,
+      worktreeBranch: 'worktree-reattached-stale',
+      originalCwd: repoRoot,
+      originalBranch: 'main',
+      originalHeadCommit,
+    });
+
+    const exitConfig = {
+      getTargetDir: () => wtPath,
+      getSessionId: () => currentSessionId,
+      getSessionService: () => currentSessionService,
+    } as unknown as Config;
+    const result = await new ExitWorktreeTool(exitConfig)
+      .build({
+        name: 'reattached-stale',
+        action: 'remove',
+        discard_changes: true,
+      })
+      .execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    await expect(fs.access(wtPath)).rejects.toBeDefined();
+    expect(await readWorktreeSession(currentSessionPath)).toBeNull();
+  });
+
+  it('removes a stale-owned worktree when launched from inside it without a sidecar', async () => {
+    sessionId = 'old-session';
+    await enterWorktree('cwd-stale');
+    const wtPath = new GitWorktreeService(repoRoot).getUserWorktreePath(
+      'cwd-stale',
+    );
+    const nestedCwd = path.join(wtPath, 'nested');
+    await fs.mkdir(nestedCwd);
+    await writeRuntimeStatus(
+      new Storage(wtPath).getRuntimeStatusPath('old-session'),
+      {
+        sessionId: 'old-session',
+        workDir: wtPath,
+        pid: 2147483647,
+      },
+    );
+
+    const currentSessionService = new SessionService(wtPath);
+    const exitConfig = {
+      getTargetDir: () => nestedCwd,
+      getSessionId: () => 'new-session',
+      getSessionService: () => currentSessionService,
+    } as unknown as Config;
+    const invocation = new ExitWorktreeTool(exitConfig).build({
+      name: 'cwd-stale',
+      action: 'remove',
+      discard_changes: true,
+    });
+    const details = await invocation.getConfirmationDetails(
+      new AbortController().signal,
+    );
+    expect(details.type).toBe('exec');
+    if (details.type === 'exec') {
+      expect(details.command).toContain(`git worktree remove ${wtPath}`);
+      expect(details.command).not.toContain(
+        path.join(nestedCwd, '.qwen', 'worktrees', 'cwd-stale'),
+      );
+    }
+
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    await expect(fs.access(wtPath)).rejects.toBeDefined();
+  });
+
+  it('refuses a re-attached remove when the marker owner runtime is active', async () => {
+    sessionId = 'old-session';
+    await enterWorktree('reattached-active');
+    const wtPath = new GitWorktreeService(repoRoot).getUserWorktreePath(
+      'reattached-active',
+    );
+
+    await writeRuntimeStatus(
+      new Storage(wtPath).getRuntimeStatusPath('old-session'),
+      {
+        sessionId: 'old-session',
+        workDir: wtPath,
+        pid: process.pid,
+      },
+    );
+
+    const currentSessionId = 'new-session';
+    const currentSessionService = new SessionService(wtPath);
+    const originalHeadCommit = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    }).trim();
+    await writeWorktreeSession(
+      currentSessionService.getWorktreeSessionPath(currentSessionId),
+      {
+        slug: 'reattached-active',
+        worktreePath: wtPath,
+        worktreeBranch: 'worktree-reattached-active',
+        originalCwd: repoRoot,
+        originalBranch: 'main',
+        originalHeadCommit,
+      },
+    );
+
+    const exitConfig = {
+      getTargetDir: () => wtPath,
+      getSessionId: () => currentSessionId,
+      getSessionService: () => currentSessionService,
+    } as unknown as Config;
+    const result = await new ExitWorktreeTool(exitConfig)
+      .build({
+        name: 'reattached-active',
+        action: 'remove',
+        discard_changes: true,
+      })
+      .execute(new AbortController().signal);
+
+    expect(result.error?.message).toMatch(
+      /different session.*owner=old-session/i,
+    );
+    await expect(fs.access(wtPath)).resolves.toBeUndefined();
+  });
+
+  it('refuses a re-attached remove when the owner is active under a repo-subdir relative runtime dir', async () => {
+    sessionId = 'old-session';
+    await enterWorktree('reattached-relative-active');
+    const wtPath = new GitWorktreeService(repoRoot).getUserWorktreePath(
+      'reattached-relative-active',
+    );
+
+    const packageDir = path.join(repoRoot, 'packages', 'app');
+    await fs.mkdir(packageDir, { recursive: true });
+    Storage.setRuntimeBaseDir('.qwen', packageDir);
+    await writeRuntimeStatus(
+      new Storage(packageDir).getRuntimeStatusPath('old-session'),
+      {
+        sessionId: 'old-session',
+        workDir: packageDir,
+        pid: process.pid,
+      },
+    );
+
+    Storage.setRuntimeBaseDir('.qwen', wtPath);
+    const currentSessionId = 'new-session';
+    const currentSessionService = new SessionService(wtPath);
+    const originalHeadCommit = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    }).trim();
+    await writeWorktreeSession(
+      currentSessionService.getWorktreeSessionPath(currentSessionId),
+      {
+        slug: 'reattached-relative-active',
+        worktreePath: wtPath,
+        worktreeBranch: 'worktree-reattached-relative-active',
+        originalCwd: repoRoot,
+        originalBranch: 'main',
+        originalHeadCommit,
+      },
+    );
+
+    const exitConfig = {
+      getTargetDir: () => wtPath,
+      getSessionId: () => currentSessionId,
+      getSessionService: () => currentSessionService,
+    } as unknown as Config;
+    const result = await new ExitWorktreeTool(exitConfig)
+      .build({
+        name: 'reattached-relative-active',
+        action: 'remove',
+        discard_changes: true,
+      })
+      .execute(new AbortController().signal);
+
+    expect(result.error?.message).toMatch(
+      /different session.*owner=old-session/i,
+    );
+    await expect(fs.access(wtPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/core/src/tools/exit-worktree.ts
+++ b/packages/core/src/tools/exit-worktree.ts
@@ -23,8 +23,11 @@ import {
 import {
   readWorktreeSession,
   clearWorktreeSession,
+  isSessionRuntimeActive,
+  type WorktreeSession,
 } from '../services/worktreeSessionService.js';
 import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 import { isNodeError } from '../utils/errors.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 
@@ -117,10 +120,9 @@ class ExitWorktreeInvocation extends BaseToolInvocation<
     if (this.params.action !== 'remove') {
       return super.getConfirmationDetails(_abortSignal);
     }
-    const projectRoot = this.config.getTargetDir();
-    const wtService = new GitWorktreeService(projectRoot);
-    const worktreePath = wtService.getUserWorktreePath(this.params.name);
-    const branch = worktreeBranchForSlug(this.params.name);
+    const target = await this.resolveConfirmationTarget();
+    const worktreePath = target.worktreePath;
+    const branch = target.branch;
     const command =
       `git worktree remove ${worktreePath}` + ` && git branch -d ${branch}`;
     const details: ToolExecuteConfirmationDetails = {
@@ -148,11 +150,14 @@ class ExitWorktreeInvocation extends BaseToolInvocation<
     const cwd = this.config.getTargetDir();
     const probe = new GitWorktreeService(cwd);
     const projectRoot = (await probe.getRepoTopLevel()) ?? cwd;
-    const service =
+    let service =
       projectRoot === cwd ? probe : new GitWorktreeService(projectRoot);
 
-    const worktreePath = service.getUserWorktreePath(this.params.name);
-    const branch = worktreeBranchForSlug(this.params.name);
+    let worktreePath = service.getUserWorktreePath(this.params.name);
+    let branch = worktreeBranchForSlug(this.params.name);
+    let currentWorktreeSession: WorktreeSession | null = null;
+    let currentSessionInWorktree = false;
+    let ownerProjectRoot = projectRoot;
 
     // Confirm the worktree directory actually exists before doing anything.
     // Distinguish ENOENT ("not found", legitimate) from any other I/O
@@ -161,18 +166,34 @@ class ExitWorktreeInvocation extends BaseToolInvocation<
     // making it impossible to diagnose a real filesystem problem.
     let exists = false;
     try {
-      const stat = await fs.stat(worktreePath);
-      exists = stat.isDirectory();
+      exists = await isDirectory(worktreePath);
     } catch (error) {
-      if (isNodeError(error) && error.code === 'ENOENT') {
-        exists = false;
+      debugLogger.warn(`exit_worktree: cannot stat ${worktreePath}: ${error}`);
+      return errorResult(
+        `Cannot access worktree at ${worktreePath} (${error instanceof Error ? error.message : String(error)}).`,
+      );
+    }
+    if (!exists) {
+      const resolved = await this.resolveCurrentSessionWorktree();
+      if (resolved) {
+        service = resolved.service;
+        worktreePath = resolved.worktreePath;
+        branch = resolved.branch;
+        currentWorktreeSession = resolved.session;
+        exists = true;
       } else {
-        debugLogger.warn(
-          `exit_worktree: cannot stat ${worktreePath}: ${error}`,
+        const current = await resolveManagedWorktreeFromCwd(
+          cwd,
+          this.params.name,
         );
-        return errorResult(
-          `Cannot access worktree at ${worktreePath} (${error instanceof Error ? error.message : String(error)}).`,
-        );
+        if (current) {
+          service = new GitWorktreeService(current.repoRoot);
+          worktreePath = current.worktreePath;
+          branch = worktreeBranchForSlug(this.params.name);
+          currentSessionInWorktree = true;
+          ownerProjectRoot = current.repoRoot;
+          exists = true;
+        }
       }
     }
     if (!exists) {
@@ -218,11 +239,38 @@ class ExitWorktreeInvocation extends BaseToolInvocation<
     const owner = await readWorktreeSessionMarker(worktreePath);
     const currentSessionId = this.config.getSessionId();
     if (owner !== null && owner !== currentSessionId) {
-      return errorResult(
-        `Refusing to remove worktree "${this.params.name}" — it was ` +
-          `created by a different session (owner=${owner}). Resume the ` +
-          `owning session to drop it, or remove it manually with ` +
-          `\`git worktree remove ${worktreePath}\`.`,
+      currentWorktreeSession ??= await this.readCurrentWorktreeSession();
+      const currentSessionOwnsPath =
+        currentWorktreeSession?.slug === this.params.name &&
+        samePath(currentWorktreeSession.worktreePath, worktreePath);
+      const ownerActive = await isSessionRuntimeActive(
+        owner,
+        currentWorktreeSession
+          ? [
+              currentWorktreeSession.originalCwd,
+              currentWorktreeSession.worktreePath,
+            ]
+          : [ownerProjectRoot, worktreePath],
+      ).catch((error) => {
+        debugLogger.warn(
+          `exit_worktree: failed to check owner runtime ${owner}: ${error}`,
+        );
+        return true;
+      });
+      if (
+        ownerActive ||
+        (!currentSessionOwnsPath && !currentSessionInWorktree)
+      ) {
+        return errorResult(
+          `Refusing to remove worktree "${this.params.name}" — it was ` +
+            `created by a different session (owner=${owner}). Resume the ` +
+            `owning session to drop it, or remove it manually with ` +
+            `\`git worktree remove ${worktreePath}\`.`,
+        );
+      }
+      debugLogger.warn(
+        `exit_worktree: allowing session ${currentSessionId} to remove ` +
+          `${worktreePath}; stale marker owner=${owner}`,
       );
     }
     if (owner === null) {
@@ -352,6 +400,99 @@ class ExitWorktreeInvocation extends BaseToolInvocation<
       );
     }
   }
+
+  private async readCurrentWorktreeSession(): Promise<WorktreeSession | null> {
+    try {
+      const sessionPath = this.config
+        .getSessionService()
+        .getWorktreeSessionPath(this.config.getSessionId());
+      return await readWorktreeSession(sessionPath);
+    } catch (error) {
+      debugLogger.warn(
+        `exit_worktree: failed to read current WorktreeSession sidecar: ${error}`,
+      );
+      return null;
+    }
+  }
+
+  private async resolveCurrentSessionWorktree(): Promise<{
+    service: GitWorktreeService;
+    worktreePath: string;
+    branch: string;
+    session: WorktreeSession;
+  } | null> {
+    const session = await this.readCurrentWorktreeSession();
+    if (!session || session.slug !== this.params.name) {
+      return null;
+    }
+    const service = new GitWorktreeService(session.originalCwd);
+    const expectedPath = service.getUserWorktreePath(this.params.name);
+    if (!samePath(session.worktreePath, expectedPath)) {
+      return null;
+    }
+    try {
+      if (!(await isDirectory(session.worktreePath))) {
+        return null;
+      }
+    } catch (error) {
+      debugLogger.warn(
+        `exit_worktree: cannot stat sidecar worktree ${session.worktreePath}: ${error}`,
+      );
+      return null;
+    }
+    return {
+      service,
+      worktreePath: session.worktreePath,
+      branch: session.worktreeBranch,
+      session,
+    };
+  }
+
+  private async resolveConfirmationTarget(): Promise<{
+    worktreePath: string;
+    branch: string;
+  }> {
+    const cwd = this.config.getTargetDir();
+    const probe = new GitWorktreeService(cwd);
+    const projectRoot = (await probe.getRepoTopLevel()) ?? cwd;
+    const service =
+      projectRoot === cwd ? probe : new GitWorktreeService(projectRoot);
+    const worktreePath = service.getUserWorktreePath(this.params.name);
+    try {
+      if (await isDirectory(worktreePath)) {
+        return {
+          worktreePath,
+          branch: worktreeBranchForSlug(this.params.name),
+        };
+      }
+    } catch {
+      return {
+        worktreePath,
+        branch: worktreeBranchForSlug(this.params.name),
+      };
+    }
+
+    const resolved = await this.resolveCurrentSessionWorktree();
+    if (resolved) {
+      return {
+        worktreePath: resolved.worktreePath,
+        branch: resolved.branch,
+      };
+    }
+
+    const current = await resolveManagedWorktreeFromCwd(cwd, this.params.name);
+    if (current) {
+      return {
+        worktreePath: current.worktreePath,
+        branch: worktreeBranchForSlug(this.params.name),
+      };
+    }
+
+    return {
+      worktreePath,
+      branch: worktreeBranchForSlug(this.params.name),
+    };
+  }
 }
 
 function errorResult(message: string): ToolResult {
@@ -360,6 +501,48 @@ function errorResult(message: string): ToolResult {
     returnDisplay: `Error: ${message}`,
     error: { message },
   };
+}
+
+async function isDirectory(filePath: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(filePath);
+    return stat.isDirectory();
+  } catch (error) {
+    if (isNodeError(error) && error.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function samePath(a: string, b: string): boolean {
+  return path.resolve(a) === path.resolve(b);
+}
+
+async function resolveManagedWorktreeFromCwd(
+  cwd: string,
+  slug: string,
+): Promise<{ repoRoot: string; worktreePath: string } | null> {
+  let cursor = path.resolve(cwd);
+  while (true) {
+    if (
+      path.basename(cursor) === slug &&
+      path.basename(path.dirname(cursor)) === 'worktrees' &&
+      path.basename(path.dirname(path.dirname(cursor))) === '.qwen'
+    ) {
+      const repoRoot = path.dirname(path.dirname(path.dirname(cursor)));
+      if (await isDirectory(cursor)) {
+        return { repoRoot, worktreePath: cursor };
+      }
+      return null;
+    }
+
+    const parent = path.dirname(cursor);
+    if (parent === cursor) {
+      return null;
+    }
+    cursor = parent;
+  }
 }
 
 export class ExitWorktreeTool extends BaseDeclarativeTool<


### PR DESCRIPTION
## What this PR does

This fixes stale `.qwen-session` ownership markers for user worktrees. When a session re-attaches to an existing managed worktree, Qwen Code now adopts the marker only if the previous owner is confirmed inactive. When `exit_worktree` runs from inside an existing worktree, it can resolve the managed worktree from the current sidecar or cwd fallback instead of looking for a nested `.qwen/worktrees/<slug>` path.

The ownership guard remains fail-closed: if the previous owner is still active, or if its runtime status cannot be confidently resolved, removal is refused. Runtime lookup covers the repo root, the worktree path, relative `runtimeOutputDir` layouts from repo/worktree/subdir launches, and bounded scans of runtime `projects/*/chats/<session>.runtime.json` records.

The remove confirmation preview now uses the same fallback target resolution as execution, so the displayed `git worktree remove ...` command matches the actual worktree path.

## Why it's needed

Fixes #5208.

A kept worktree can outlive the session that created it. Starting a later session in the same worktree, or re-attaching with `--worktree`, could leave `.qwen-session` pointing at the old session UUID. The previous strict equality check then blocked cleanup even though the current session was legitimately operating inside that worktree.

At the same time, the marker still protects active sessions from cross-session deletion. This change only treats a marker as stale after checking runtime status and keeps the existing refusal when the owner appears active or cannot be checked safely.

## Reviewer Test Plan

### How to verify

Run the focused tests:

- `npx vitest run src/services/worktreeSessionService.test.ts src/tools/exit-worktree.session.integ.test.ts src/tools/exit-worktree.test.ts` from `packages/core`
- `npx vitest run src/startup/worktreeStartup.test.ts` from `packages/cli`

Run type/build checks:

- `npm run typecheck` from `packages/core`
- `npm run build` from `packages/core`
- `npm run typecheck` from `packages/cli`
- `npm run build` from `packages/cli`

Additional checks:

- `npx eslint packages/core/src/services/worktreeSessionService.ts packages/core/src/services/worktreeSessionService.test.ts packages/core/src/tools/exit-worktree.ts packages/core/src/tools/exit-worktree.session.integ.test.ts packages/cli/src/startup/worktreeStartup.ts packages/cli/src/startup/worktreeStartup.test.ts packages/cli/src/ui/AppContainer.tsx`
- `git diff --check upstream/main..HEAD`

### Evidence (Before & After)

Before: a later session in a kept worktree could fail with `Refusing to remove worktree ... created by a different session (owner=...)`, even when the original owner was no longer running.

After: stale-owner cases are covered by integration tests for `--worktree` re-attach, direct cwd launch inside a managed worktree, active owner protection, repo-subdir relative `runtimeOutputDir`, and active-over-dead runtime status precedence.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ focused tests, lint, typecheck, build |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Node.js local workspace; real git worktree integration tests use temporary repositories.

## Risk & Scope

- Main risk or tradeoff: the stale-owner check is intentionally conservative. If the previous owner's runtime status cannot be confidently found or inspected, Qwen Code keeps refusing removal rather than risking deletion of another active session's worktree.
- Not validated / out of scope: no end-to-end manual TUI recording; this is covered with focused service/tool/startup tests.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5208

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复用户 worktree 里的过期 `.qwen-session` 所有权标记。session 重新挂载已有 managed worktree 时，只有在确认旧 owner 不活跃后，Qwen Code 才会接管 marker。`exit_worktree` 从已有 worktree 内运行时，也可以通过当前 sidecar 或 cwd fallback 定位真实 managed worktree，而不是去找嵌套的 `.qwen/worktrees/<slug>` 路径。

所有权检查仍然 fail-closed：如果旧 owner 仍然活跃，或者无法可靠解析它的 runtime status，就拒绝删除。runtime 查找覆盖 repo root、worktree path、从 repo/worktree/subdir 启动时的相对 `runtimeOutputDir` 布局，以及对 `projects/*/chats/<session>.runtime.json` 的有界扫描。

删除确认预览现在复用和实际执行一致的 fallback 定位逻辑，所以展示的 `git worktree remove ...` 命令会和真实删除目标一致。

## 为什么需要

Fixes #5208。

被 keep 的 worktree 会比创建它的 session 活得更久。后续 session 从同一个 worktree 启动，或者通过 `--worktree` 重新挂载时，`.qwen-session` 可能仍然指向旧 session UUID。之前的严格相等检查会阻止清理，即使当前 session 正在合法使用这个 worktree。

同时，marker 仍然需要防止活跃 session 被跨 session 删除。本 PR 只有在检查 runtime status 后才把 marker 视为过期；如果 owner 看起来活跃或无法安全检查，仍然保持拒绝。

## Reviewer Test Plan

### 如何验证

运行聚焦测试：

- 在 `packages/core` 下运行 `npx vitest run src/services/worktreeSessionService.test.ts src/tools/exit-worktree.session.integ.test.ts src/tools/exit-worktree.test.ts`
- 在 `packages/cli` 下运行 `npx vitest run src/startup/worktreeStartup.test.ts`

运行类型和构建检查：

- 在 `packages/core` 下运行 `npm run typecheck`
- 在 `packages/core` 下运行 `npm run build`
- 在 `packages/cli` 下运行 `npm run typecheck`
- 在 `packages/cli` 下运行 `npm run build`

额外检查：

- `npx eslint packages/core/src/services/worktreeSessionService.ts packages/core/src/services/worktreeSessionService.test.ts packages/core/src/tools/exit-worktree.ts packages/core/src/tools/exit-worktree.session.integ.test.ts packages/cli/src/startup/worktreeStartup.ts packages/cli/src/startup/worktreeStartup.test.ts packages/cli/src/ui/AppContainer.tsx`
- `git diff --check upstream/main..HEAD`

### 证据（Before & After）

Before：后续 session 进入 kept worktree 后，可能报 `Refusing to remove worktree ... created by a different session (owner=...)`，即使原 owner 已经不再运行。

After：新增集成测试覆盖 `--worktree` 重新挂载、从 managed worktree 内直接启动、active owner 保护、repo 子目录相对 `runtimeOutputDir`、以及 active runtime status 优先于较早 dead status 的场景。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ focused tests, lint, typecheck, build |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### 环境（可选）

Node.js 本地 workspace；真实 git worktree 集成测试使用临时 repo。

## Risk & Scope

- 主要风险/取舍：stale-owner 检查是保守的。如果无法可靠找到或检查旧 owner 的 runtime status，Qwen Code 会继续拒绝删除，而不是冒险删除另一个活跃 session 的 worktree。
- 未验证/超出范围：没有录制 TUI 端到端视频；这里用聚焦的 service/tool/startup 测试覆盖。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Fixes #5208

</details>
