### PR TITLE
feat(core,cli): Workflow tool token budget + per-run UI surfacing (P5)

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1933,6 +1933,8 @@ export async function loadCliConfig(
     shouldUseNodePtyShell: settings.tools?.shell?.enableInteractiveShell,
     preventSystemSleep: settings.general?.preventSystemSleep ?? true,
     skipNextSpeakerCheck: settings.model?.skipNextSpeakerCheck,
+    skipWorkflowUsageWarning:
+      settings.model?.skipWorkflowUsageWarning ?? false,
     skipLoopDetection: settings.model?.skipLoopDetection ?? true,
     skipStartupContext: settings.model?.skipStartupContext ?? false,
     truncateToolOutputThreshold: settings.tools?.truncateToolOutputThreshold,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1188,6 +1188,16 @@ const SETTINGS_SCHEMA = {
         description: 'Skip the next speaker check.',
         showInDialog: false,
       },
+      skipWorkflowUsageWarning: {
+        type: 'boolean',
+        label: 'Skip Workflow Usage Warning',
+        category: 'Model',
+        requiresRestart: false,
+        default: false,
+        description:
+          'Suppress the one-time Workflow tool usage banner that describes the QWEN_CODE_MAX_TOKENS_PER_WORKFLOW env knob. The banner fires at most once per session regardless of this setting.',
+        showInDialog: false,
+      },
       skipLoopDetection: {
         type: 'boolean',
         label: 'Skip Loop Detection',

--- a/packages/cli/src/ui/commands/workflowsCommand.test.ts
+++ b/packages/cli/src/ui/commands/workflowsCommand.test.ts
@@ -163,7 +163,7 @@ describe('workflowsCommand', () => {
 
   // ── P5: budget surfacing in list + detail ──────────────────────────────
 
-  it('P5: list row chips tokens/cap when capped', async () => {
+  it('P5: list row chips tokens/cap when capped (R1 #7: uses formatTokenCount)', async () => {
     listMock.mockReturnValue([
       entry({
         runId: 'wf_capped',
@@ -174,7 +174,8 @@ describe('workflowsCommand', () => {
     ]);
     const result = await workflowsCommand.action!(context, '');
     if (!result || result.type !== 'message') throw new Error('no result');
-    expect(result.content).toContain('1500/10000t');
+    // R1 #7: `formatTokenCount` renders 1500 as `1.5k` and 10000 as `10k`.
+    expect(result.content).toContain('1.5k/10kt');
   });
 
   it('P5: list row chips plain spent when uncapped', async () => {
@@ -188,12 +189,13 @@ describe('workflowsCommand', () => {
     ]);
     const result = await workflowsCommand.action!(context, '');
     if (!result || result.type !== 'message') throw new Error('no result');
+    // < 1000 renders as the raw integer.
     expect(result.content).toContain('500t');
     // No slash → no cap rendered.
     expect(result.content).not.toMatch(/500\/\d+t/);
   });
 
-  it('P5: detail view renders tokens, cap, and per-phase chips', async () => {
+  it('P5: detail view renders tokens, cap, and per-phase chips (R1 #7: formatTokenCount)', async () => {
     const perPhase = new Map<string | null, number>([
       ['Find', 300],
       ['Verify', 150],
@@ -212,10 +214,35 @@ describe('workflowsCommand', () => {
     );
     const result = await workflowsCommand.action!(context, 'wf_detail');
     if (!result || result.type !== 'message') throw new Error('no result');
+    // R1 #7: per-phase counts render via `formatTokenCount` (< 1000 = raw).
     expect(result.content).toContain('tokens      : 450');
-    expect(result.content).toContain('cap         : 1000');
+    expect(result.content).toContain('cap         : 1.0k');
     expect(result.content).toContain('· Find · 300t');
     expect(result.content).toContain('· Verify · 150t');
+  });
+
+  it('P5 R1 #6: detail view surfaces null-sentinel as "(no phase)" row', async () => {
+    const perPhase = new Map<string | null, number>([
+      [null, 75], // pre-phase spend
+      ['Plan', 200],
+    ]);
+    const detail = entry({
+      runId: 'wf_pre',
+      status: 'completed',
+      phases: ['Plan'],
+      tokensSpent: 275,
+      tokenBudgetTotal: null,
+      perPhaseTokens: perPhase,
+      endTime: 1_700_000_010_000,
+    });
+    getMock.mockImplementation((id) =>
+      id === 'wf_pre' ? detail : undefined,
+    );
+    const result = await workflowsCommand.action!(context, 'wf_pre');
+    if (!result || result.type !== 'message') throw new Error('no result');
+    expect(result.content).toContain('· Plan · 200t');
+    // R1 #6 fix: the null-sentinel attribution is no longer hidden.
+    expect(result.content).toContain('· (no phase) · 75t');
   });
 
   it('P5: detail view renders "(no cap)" when uncapped', async () => {

--- a/packages/cli/src/ui/commands/workflowsCommand.test.ts
+++ b/packages/cli/src/ui/commands/workflowsCommand.test.ts
@@ -28,6 +28,9 @@ function entry(overrides: Partial<WorkflowTask> = {}): WorkflowTask {
     agentsDispatched: 0,
     agentsCompleted: 0,
     recentLogs: [],
+    tokensSpent: 0,
+    tokenBudgetTotal: null,
+    perPhaseTokens: new Map<string | null, number>(),
     ...overrides,
   };
 }
@@ -156,5 +159,78 @@ describe('workflowsCommand', () => {
     const result = await workflowsCommand.action!(context, '  wf_t  ');
     if (!result || result.type !== 'message') throw new Error('no result');
     expect(result.content).toContain('Workflow wf_t');
+  });
+
+  // ── P5: budget surfacing in list + detail ──────────────────────────────
+
+  it('P5: list row chips tokens/cap when capped', async () => {
+    listMock.mockReturnValue([
+      entry({
+        runId: 'wf_capped',
+        status: 'running',
+        tokensSpent: 1500,
+        tokenBudgetTotal: 10_000,
+      }),
+    ]);
+    const result = await workflowsCommand.action!(context, '');
+    if (!result || result.type !== 'message') throw new Error('no result');
+    expect(result.content).toContain('1500/10000t');
+  });
+
+  it('P5: list row chips plain spent when uncapped', async () => {
+    listMock.mockReturnValue([
+      entry({
+        runId: 'wf_uncapped',
+        status: 'running',
+        tokensSpent: 500,
+        tokenBudgetTotal: null,
+      }),
+    ]);
+    const result = await workflowsCommand.action!(context, '');
+    if (!result || result.type !== 'message') throw new Error('no result');
+    expect(result.content).toContain('500t');
+    // No slash → no cap rendered.
+    expect(result.content).not.toMatch(/500\/\d+t/);
+  });
+
+  it('P5: detail view renders tokens, cap, and per-phase chips', async () => {
+    const perPhase = new Map<string | null, number>([
+      ['Find', 300],
+      ['Verify', 150],
+    ]);
+    const detail = entry({
+      runId: 'wf_detail',
+      status: 'completed',
+      phases: ['Find', 'Verify'],
+      tokensSpent: 450,
+      tokenBudgetTotal: 1000,
+      perPhaseTokens: perPhase,
+      endTime: 1_700_000_010_000,
+    });
+    getMock.mockImplementation((id) =>
+      id === 'wf_detail' ? detail : undefined,
+    );
+    const result = await workflowsCommand.action!(context, 'wf_detail');
+    if (!result || result.type !== 'message') throw new Error('no result');
+    expect(result.content).toContain('tokens      : 450');
+    expect(result.content).toContain('cap         : 1000');
+    expect(result.content).toContain('· Find · 300t');
+    expect(result.content).toContain('· Verify · 150t');
+  });
+
+  it('P5: detail view renders "(no cap)" when uncapped', async () => {
+    const detail = entry({
+      runId: 'wf_uncapped',
+      status: 'completed',
+      tokensSpent: 0,
+      tokenBudgetTotal: null,
+    });
+    getMock.mockImplementation((id) =>
+      id === 'wf_uncapped' ? detail : undefined,
+    );
+    const result = await workflowsCommand.action!(context, 'wf_uncapped');
+    if (!result || result.type !== 'message') throw new Error('no result');
+    expect(result.content).toContain('tokens      : 0');
+    expect(result.content).toContain('cap         : (no cap)');
   });
 });

--- a/packages/cli/src/ui/commands/workflowsCommand.ts
+++ b/packages/cli/src/ui/commands/workflowsCommand.ts
@@ -29,11 +29,21 @@ function rowLine(entry: WorkflowTask, now: number): string {
     entry.phases.length > 0
       ? ` · ${entry.phases.length} ${entry.phases.length === 1 ? 'phase' : 'phases'}`
       : '';
+  // P5: budget chip — `tokens/cap` when capped, plain `tokens` otherwise.
+  // Skipped on the listing row when nothing is spent AND no cap; the
+  // detail view (`detailLines`) always renders both fields so an
+  // operator inspecting one run sees the cap state regardless.
+  const budgetChip =
+    entry.tokensSpent > 0 || entry.tokenBudgetTotal !== null
+      ? entry.tokenBudgetTotal !== null
+        ? ` · ${entry.tokensSpent}/${entry.tokenBudgetTotal}t`
+        : ` · ${entry.tokensSpent}t`
+      : '';
   const errorTail =
     entry.status === 'failed' && entry.error
       ? ` — ${entry.error.slice(0, 80)}`
       : '';
-  return `  ${entry.runId.padEnd(20)} ${entry.status.padEnd(10)} ${runtime.padStart(8)}  ${label}${phase}${counts}${phaseCount}${errorTail}`;
+  return `  ${entry.runId.padEnd(20)} ${entry.status.padEnd(10)} ${runtime.padStart(8)}  ${label}${phase}${counts}${phaseCount}${budgetChip}${errorTail}`;
 }
 
 function detailLines(entry: WorkflowTask, now: number): string[] {
@@ -61,6 +71,13 @@ function detailLines(entry: WorkflowTask, now: number): string[] {
   lines.push(
     `  agents      : ${entry.agentsCompleted}/${entry.agentsDispatched}`,
   );
+  // P5: surface budget + token usage. `tokens` shows actual usage even
+  // when no cap is set (operators care about uncapped runs too); `cap`
+  // is the env override or `(no cap)` when null.
+  lines.push(`  tokens      : ${entry.tokensSpent}`);
+  lines.push(
+    `  cap         : ${entry.tokenBudgetTotal !== null ? entry.tokenBudgetTotal : '(no cap)'}`,
+  );
   if (entry.error) {
     lines.push(`  error       : ${entry.error}`);
   }
@@ -68,7 +85,9 @@ function detailLines(entry: WorkflowTask, now: number): string[] {
     lines.push('');
     lines.push(`  Phases (${entry.phases.length})`);
     for (const phase of entry.phases) {
-      lines.push(`    · ${phase}`);
+      const phaseTokens = entry.perPhaseTokens.get(phase) ?? 0;
+      const chip = phaseTokens > 0 ? ` · ${phaseTokens}t` : '';
+      lines.push(`    · ${phase}${chip}`);
     }
   }
   if (entry.recentLogs.length > 0) {

--- a/packages/cli/src/ui/commands/workflowsCommand.ts
+++ b/packages/cli/src/ui/commands/workflowsCommand.ts
@@ -8,7 +8,7 @@ import type { WorkflowTask } from '@qwen-code/qwen-code-core';
 import type { SlashCommand } from './types.js';
 import { CommandKind } from './types.js';
 import { t } from '../../i18n/index.js';
-import { formatDuration } from '../utils/formatters.js';
+import { formatDuration, formatTokenCount } from '../utils/formatters.js';
 
 /**
  * Format one workflow run as a one-line summary used by both the
@@ -33,11 +33,14 @@ function rowLine(entry: WorkflowTask, now: number): string {
   // Skipped on the listing row when nothing is spent AND no cap; the
   // detail view (`detailLines`) always renders both fields so an
   // operator inspecting one run sees the cap state regardless.
+  // P5 R1 (#7): use `formatTokenCount` so large counts render as
+  // `1.2k / 50k` instead of raw integers, matching the formatting used
+  // by `statusLinePresets` and other token-bearing UI surfaces.
   const budgetChip =
     entry.tokensSpent > 0 || entry.tokenBudgetTotal !== null
       ? entry.tokenBudgetTotal !== null
-        ? ` · ${entry.tokensSpent}/${entry.tokenBudgetTotal}t`
-        : ` · ${entry.tokensSpent}t`
+        ? ` · ${formatTokenCount(entry.tokensSpent)}/${formatTokenCount(entry.tokenBudgetTotal)}t`
+        : ` · ${formatTokenCount(entry.tokensSpent)}t`
       : '';
   const errorTail =
     entry.status === 'failed' && entry.error
@@ -74,9 +77,10 @@ function detailLines(entry: WorkflowTask, now: number): string[] {
   // P5: surface budget + token usage. `tokens` shows actual usage even
   // when no cap is set (operators care about uncapped runs too); `cap`
   // is the env override or `(no cap)` when null.
-  lines.push(`  tokens      : ${entry.tokensSpent}`);
+  // P5 R1 (#7): apply `formatTokenCount` for consistency with `statusLinePresets`.
+  lines.push(`  tokens      : ${formatTokenCount(entry.tokensSpent)}`);
   lines.push(
-    `  cap         : ${entry.tokenBudgetTotal !== null ? entry.tokenBudgetTotal : '(no cap)'}`,
+    `  cap         : ${entry.tokenBudgetTotal !== null ? formatTokenCount(entry.tokenBudgetTotal) : '(no cap)'}`,
   );
   if (entry.error) {
     lines.push(`  error       : ${entry.error}`);
@@ -86,8 +90,16 @@ function detailLines(entry: WorkflowTask, now: number): string[] {
     lines.push(`  Phases (${entry.phases.length})`);
     for (const phase of entry.phases) {
       const phaseTokens = entry.perPhaseTokens.get(phase) ?? 0;
-      const chip = phaseTokens > 0 ? ` · ${phaseTokens}t` : '';
+      const chip =
+        phaseTokens > 0 ? ` · ${formatTokenCount(phaseTokens)}t` : '';
       lines.push(`    · ${phase}${chip}`);
+    }
+    // P5 R1 (#6): surface null-sentinel attribution — tokens spent BEFORE
+    // the first `phase()` call accumulate under the `null` key. Without
+    // this branch the entire pre-phase spend was invisible in the dump.
+    const prePhaseTokens = entry.perPhaseTokens.get(null) ?? 0;
+    if (prePhaseTokens > 0) {
+      lines.push(`    · (no phase) · ${formatTokenCount(prePhaseTokens)}t`);
     }
   }
   if (entry.recentLogs.length > 0) {

--- a/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.test.tsx
+++ b/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.test.tsx
@@ -826,4 +826,103 @@ describe('BackgroundTasksDialog', () => {
       expect(f).toContain('Topics touched (12)');
     });
   });
+
+  // ── R2 #15: WorkflowDetailBody budget chip rendering ────────────────
+
+  function workflowEntry(
+    overrides: Partial<DialogEntry> = {},
+  ): DialogEntry {
+    const base = {
+      id: 'wf_test1234',
+      kind: 'workflow' as const,
+      runId: 'wf_test1234',
+      description: 'demo',
+      meta: null,
+      status: 'completed' as const,
+      startTime: 0,
+      endTime: 5_000,
+      outputFile: '',
+      outputOffset: 0,
+      notified: false,
+      abortController: new AbortController(),
+      currentPhase: null,
+      phases: ['Plan'] as string[],
+      agentsDispatched: 0,
+      agentsCompleted: 0,
+      recentLogs: [] as string[],
+      tokensSpent: 0,
+      tokenBudgetTotal: null,
+      perPhaseTokens: new Map<string | null, number>(),
+    };
+    return { ...base, ...overrides } as unknown as DialogEntry;
+  }
+
+  describe('WorkflowDetailBody budget chip (R2 #15)', () => {
+    function openWorkflowDetail(entries: readonly DialogEntry[]) {
+      const h = setup(entries);
+      h.call(() => h.probe.current!.actions.openDialog());
+      h.call(() => h.probe.current!.actions.enterDetail());
+      return h;
+    }
+
+    it('renders the M/N token chip and capped per-phase totals', () => {
+      const perPhase = new Map<string | null, number>([['Plan', 3_500]]);
+      const wf = workflowEntry({
+        tokensSpent: 3_500,
+        tokenBudgetTotal: 10_000,
+        perPhaseTokens: perPhase,
+      });
+      const h = openWorkflowDetail([wf]);
+      const f = h.lastFrame() ?? '';
+      // R1 #7: formatTokenCount renders 3500 as `3.5k`, 10000 as `10k`.
+      expect(f).toContain('3.5k/10k tokens');
+      expect(f).toContain('Plan');
+      expect(f).toContain('3.5kt');
+    });
+
+    it('renders plain spent (no cap) when uncapped and zero per-phase chips suppressed', () => {
+      const wf = workflowEntry({
+        tokensSpent: 850,
+        tokenBudgetTotal: null,
+        perPhaseTokens: new Map<string | null, number>([['Plan', 0]]),
+      });
+      const h = openWorkflowDetail([wf]);
+      const f = h.lastFrame() ?? '';
+      expect(f).toContain('850 tokens');
+      // Uncapped: no slash form on the budget chip.
+      expect(f).not.toMatch(/\d+\/\d+ tokens/);
+      // Zero per-phase tally: no `· 0t` chip noise on the Plan row.
+      expect(f).not.toMatch(/Plan.*0t/);
+    });
+
+    it('hides the token chip entirely when both spend and cap are zero/null', () => {
+      const wf = workflowEntry({
+        tokensSpent: 0,
+        tokenBudgetTotal: null,
+        perPhaseTokens: new Map<string | null, number>(),
+      });
+      const h = openWorkflowDetail([wf]);
+      const f = h.lastFrame() ?? '';
+      // Subtitle has elapsed + phase count, but no `tokens` chip.
+      expect(f).not.toMatch(/tokens/);
+    });
+
+    it('R1 #6 + R2 #15: surfaces null-sentinel per-phase tokens as `(no phase)` row', () => {
+      const perPhase = new Map<string | null, number>([
+        [null, 420], // pre-phase spend
+        ['Plan', 1_100],
+      ]);
+      const wf = workflowEntry({
+        tokensSpent: 1_520,
+        tokenBudgetTotal: 5_000,
+        perPhaseTokens: perPhase,
+      });
+      const h = openWorkflowDetail([wf]);
+      const f = h.lastFrame() ?? '';
+      // formatTokenCount: 1520 → "1.5k", 5000 → "5.0k" (< 10000 keeps one decimal).
+      expect(f).toContain('1.5k/5.0k tokens');
+      expect(f).toContain('(no phase)');
+      expect(f).toContain('420t');
+    });
+  });
 });

--- a/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.tsx
+++ b/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.tsx
@@ -923,11 +923,13 @@ const WorkflowDetailBody: React.FC<{
   // P5: surface the per-run token usage when there's anything to report
   // (cap set OR tokens spent). Skipped when both are absent so legacy
   // / test runs don't show a noisy `0 tokens` chip.
+  // P5 R1 (#7): apply `formatTokenCount` for consistency with
+  // `statusLinePresets` and other token-bearing UI surfaces.
   if (entry.tokensSpent > 0 || entry.tokenBudgetTotal !== null) {
     dimSubtitleParts.push(
       entry.tokenBudgetTotal !== null
-        ? `${entry.tokensSpent}/${entry.tokenBudgetTotal} ${t('tokens')}`
-        : `${entry.tokensSpent} ${t('tokens')}`,
+        ? `${formatTokenCount(entry.tokensSpent)}/${formatTokenCount(entry.tokenBudgetTotal)} ${t('tokens')}`
+        : `${formatTokenCount(entry.tokensSpent)} ${t('tokens')}`,
     );
   }
 
@@ -1003,8 +1005,10 @@ const WorkflowDetailBody: React.FC<{
             // Skipped when no tokens attributed yet so empty phases
             // (early register, schema-mode-pending) don't render a
             // misleading `· 0` chip.
+            // P5 R1 (#7): apply `formatTokenCount` for consistency.
             const phaseTokens = entry.perPhaseTokens.get(phaseTitle) ?? 0;
-            const tokenChip = phaseTokens > 0 ? ` · ${phaseTokens}t` : '';
+            const tokenChip =
+              phaseTokens > 0 ? ` · ${formatTokenCount(phaseTokens)}t` : '';
             return (
               <Box key={`${phaseTitle}-${i}`}>
                 <Text color={isCurrent ? theme.status.success : undefined}>
@@ -1013,6 +1017,19 @@ const WorkflowDetailBody: React.FC<{
               </Box>
             );
           })}
+          {/* P5 R1 (#6): surface null-sentinel attribution — tokens
+              spent BEFORE the first `phase()` call accumulate under the
+              `null` key. Without this row the entire pre-phase spend is
+              hidden in the UI. */}
+          {(entry.perPhaseTokens.get(null) ?? 0) > 0 && (
+            <Box>
+              <Text dimColor>
+                {`  · ${t('(no phase)')} · ${formatTokenCount(
+                  entry.perPhaseTokens.get(null) ?? 0,
+                )}t`}
+              </Text>
+            </Box>
+          )}
         </Fragment>
       )}
 

--- a/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.tsx
+++ b/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.tsx
@@ -920,6 +920,16 @@ const WorkflowDetailBody: React.FC<{
   dimSubtitleParts.push(
     `${entry.phases.length} ${entry.phases.length === 1 ? t('phase') : t('phases')}`,
   );
+  // P5: surface the per-run token usage when there's anything to report
+  // (cap set OR tokens spent). Skipped when both are absent so legacy
+  // / test runs don't show a noisy `0 tokens` chip.
+  if (entry.tokensSpent > 0 || entry.tokenBudgetTotal !== null) {
+    dimSubtitleParts.push(
+      entry.tokenBudgetTotal !== null
+        ? `${entry.tokensSpent}/${entry.tokenBudgetTotal} ${t('tokens')}`
+        : `${entry.tokensSpent} ${t('tokens')}`,
+    );
+  }
 
   // Phase tree: collapse the head when over the visible cap, keeping
   // the most recent N entries (the user almost always wants to see the
@@ -989,10 +999,16 @@ const WorkflowDetailBody: React.FC<{
               i === visiblePhases.length - 1 &&
               entry.currentPhase === phaseTitle;
             const marker = isCurrent ? '▸' : '·';
+            // P5: per-phase token tally appended to the phase row.
+            // Skipped when no tokens attributed yet so empty phases
+            // (early register, schema-mode-pending) don't render a
+            // misleading `· 0` chip.
+            const phaseTokens = entry.perPhaseTokens.get(phaseTitle) ?? 0;
+            const tokenChip = phaseTokens > 0 ? ` · ${phaseTokens}t` : '';
             return (
               <Box key={`${phaseTitle}-${i}`}>
                 <Text color={isCurrent ? theme.status.success : undefined}>
-                  {`  ${marker} ${phaseTitle}`}
+                  {`  ${marker} ${phaseTitle}${tokenChip}`}
                 </Text>
               </Box>
             );

--- a/packages/core/src/agents/runtime/workflow-budget.test.ts
+++ b/packages/core/src/agents/runtime/workflow-budget.test.ts
@@ -1,0 +1,167 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  WorkflowBudgetImpl,
+  WorkflowBudgetExceededError,
+  resolveMaxTokensPerWorkflow,
+  MAX_TOKENS_PER_WORKFLOW_ENV,
+  HARD_MAX_TOKENS_CEILING,
+} from './workflow-budget.js';
+
+describe('resolveMaxTokensPerWorkflow', () => {
+  it('returns null when env is unset', () => {
+    expect(resolveMaxTokensPerWorkflow({})).toBeNull();
+  });
+
+  it('returns null when env is empty / whitespace', () => {
+    expect(
+      resolveMaxTokensPerWorkflow({ [MAX_TOKENS_PER_WORKFLOW_ENV]: '' }),
+    ).toBeNull();
+    expect(
+      resolveMaxTokensPerWorkflow({ [MAX_TOKENS_PER_WORKFLOW_ENV]: '   ' }),
+    ).toBeNull();
+  });
+
+  it('parses a positive integer env value', () => {
+    expect(
+      resolveMaxTokensPerWorkflow({
+        [MAX_TOKENS_PER_WORKFLOW_ENV]: '50000',
+      }),
+    ).toBe(50_000);
+  });
+
+  it('returns null on non-integer override (treats misconfig as no cap)', () => {
+    expect(
+      resolveMaxTokensPerWorkflow({
+        [MAX_TOKENS_PER_WORKFLOW_ENV]: 'abc',
+      }),
+    ).toBeNull();
+    expect(
+      resolveMaxTokensPerWorkflow({
+        [MAX_TOKENS_PER_WORKFLOW_ENV]: '1.5',
+      }),
+    ).toBeNull();
+  });
+
+  it('returns null on zero / negative override', () => {
+    expect(
+      resolveMaxTokensPerWorkflow({
+        [MAX_TOKENS_PER_WORKFLOW_ENV]: '0',
+      }),
+    ).toBeNull();
+    expect(
+      resolveMaxTokensPerWorkflow({
+        [MAX_TOKENS_PER_WORKFLOW_ENV]: '-100',
+      }),
+    ).toBeNull();
+  });
+
+  it('clamps to HARD_MAX_TOKENS_CEILING on over-large override', () => {
+    expect(
+      resolveMaxTokensPerWorkflow({
+        [MAX_TOKENS_PER_WORKFLOW_ENV]: String(HARD_MAX_TOKENS_CEILING + 1),
+      }),
+    ).toBe(HARD_MAX_TOKENS_CEILING);
+    expect(
+      resolveMaxTokensPerWorkflow({
+        [MAX_TOKENS_PER_WORKFLOW_ENV]: '999999999',
+      }),
+    ).toBe(HARD_MAX_TOKENS_CEILING);
+  });
+});
+
+describe('WorkflowBudgetImpl', () => {
+  it('total is null when constructed with null (no cap)', () => {
+    const b = new WorkflowBudgetImpl(null);
+    expect(b.total).toBeNull();
+    expect(b.spent()).toBe(0);
+    expect(b.remaining()).toBe(Infinity);
+  });
+
+  it('total is the cap when constructed with a number', () => {
+    const b = new WorkflowBudgetImpl(10_000);
+    expect(b.total).toBe(10_000);
+    expect(b.spent()).toBe(0);
+    expect(b.remaining()).toBe(10_000);
+  });
+
+  it('recordSpent accumulates positive deltas', () => {
+    const b = new WorkflowBudgetImpl(10_000);
+    b.recordSpent(1_500);
+    b.recordSpent(2_500);
+    expect(b.spent()).toBe(4_000);
+    expect(b.remaining()).toBe(6_000);
+  });
+
+  it('remaining() never goes negative — clamps at 0', () => {
+    const b = new WorkflowBudgetImpl(1_000);
+    b.recordSpent(2_500); // overshoot
+    expect(b.spent()).toBe(2_500);
+    expect(b.remaining()).toBe(0);
+  });
+
+  it('remaining() stays Infinity even after spending when total is null', () => {
+    const b = new WorkflowBudgetImpl(null);
+    b.recordSpent(1_000);
+    b.recordSpent(50_000);
+    expect(b.spent()).toBe(51_000);
+    expect(b.remaining()).toBe(Infinity);
+  });
+
+  it('recordSpent ignores zero / negative / non-finite deltas', () => {
+    const b = new WorkflowBudgetImpl(10_000);
+    b.recordSpent(1_000);
+    b.recordSpent(0);
+    b.recordSpent(-500);
+    b.recordSpent(Number.NaN);
+    b.recordSpent(Number.POSITIVE_INFINITY);
+    expect(b.spent()).toBe(1_000);
+  });
+
+  it('fromEnv builds a budget from process env (null when env unset)', () => {
+    const b = WorkflowBudgetImpl.fromEnv({});
+    expect(b.total).toBeNull();
+    expect(b.remaining()).toBe(Infinity);
+  });
+
+  it('fromEnv reads the env override', () => {
+    const b = WorkflowBudgetImpl.fromEnv({
+      [MAX_TOKENS_PER_WORKFLOW_ENV]: '25000',
+    });
+    expect(b.total).toBe(25_000);
+    expect(b.remaining()).toBe(25_000);
+  });
+});
+
+describe('WorkflowBudgetExceededError', () => {
+  it('carries runId, budgetTotal, and spent fields', () => {
+    const err = new WorkflowBudgetExceededError('wf_abc123', 10_000, 12_500);
+    expect(err.runId).toBe('wf_abc123');
+    expect(err.budgetTotal).toBe(10_000);
+    expect(err.spent).toBe(12_500);
+  });
+
+  it('message is self-describing (extractErrorMessage compatible)', () => {
+    const err = new WorkflowBudgetExceededError('wf_abc123', 10_000, 12_500);
+    expect(err.message).toContain('wf_abc123');
+    expect(err.message).toContain('12500');
+    expect(err.message).toContain('10000');
+    expect(err.message).toContain(MAX_TOKENS_PER_WORKFLOW_ENV);
+  });
+
+  it('name is the class name (for duck-typed detection)', () => {
+    const err = new WorkflowBudgetExceededError('wf_x', 1, 2);
+    expect(err.name).toBe('WorkflowBudgetExceededError');
+  });
+
+  it('is throwable and catchable as Error', () => {
+    expect(() => {
+      throw new WorkflowBudgetExceededError('wf_x', 100, 200);
+    }).toThrow(/exceeded the token budget/);
+  });
+});

--- a/packages/core/src/agents/runtime/workflow-budget.test.ts
+++ b/packages/core/src/agents/runtime/workflow-budget.test.ts
@@ -151,7 +151,16 @@ describe('WorkflowBudgetExceededError', () => {
     expect(err.message).toContain('wf_abc123');
     expect(err.message).toContain('12500');
     expect(err.message).toContain('10000');
-    expect(err.message).toContain(MAX_TOKENS_PER_WORKFLOW_ENV);
+  });
+
+  it('R2 #14: message does NOT advise removing/raising the cap (model-coaching mitigation)', () => {
+    const err = new WorkflowBudgetExceededError('wf_abc123', 10_000, 12_500);
+    // The error reaches the LLM via `tool_result`; the advisory tail
+    // would coach the model to tell the user how to disable the
+    // operator's budget. Keep the factual portion only.
+    expect(err.message).not.toMatch(/Increase /i);
+    expect(err.message).not.toMatch(/remove the cap/i);
+    expect(err.message).not.toContain(MAX_TOKENS_PER_WORKFLOW_ENV);
   });
 
   it('name is the class name (for duck-typed detection)', () => {

--- a/packages/core/src/agents/runtime/workflow-budget.ts
+++ b/packages/core/src/agents/runtime/workflow-budget.ts
@@ -178,10 +178,16 @@ export class WorkflowBudgetExceededError extends Error {
   readonly spent: number;
 
   constructor(runId: string, budgetTotal: number, spent: number) {
+    // P5 R2 (#14): keep the factual portion only — no advisory tail.
+    // The previous "Increase QWEN_CODE_MAX_TOKENS_PER_WORKFLOW or unset
+    // it to remove the cap" suffix reaches the LLM via `tool_result`,
+    // which could coach the model into telling the user how to disable
+    // the operator-set budget. Operators looking up the knob can still
+    // find it via `MAX_TOKENS_PER_WORKFLOW_ENV` in the debug log site
+    // in `countedDispatch`.
     super(
       `Workflow ${runId} exceeded the token budget ` +
-        `(${spent} / ${budgetTotal} output tokens spent). ` +
-        `Increase ${MAX_TOKENS_PER_WORKFLOW_ENV} or unset it to remove the cap.`,
+        `(${spent} / ${budgetTotal} output tokens spent).`,
     );
     this.runId = runId;
     this.budgetTotal = budgetTotal;

--- a/packages/core/src/agents/runtime/workflow-budget.ts
+++ b/packages/core/src/agents/runtime/workflow-budget.ts
@@ -1,0 +1,190 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview P5: WorkflowBudget concrete implementation. P1 reserved
+ * the seam (`SandboxOptions.budget`) with throwing stubs so dynamic-loop
+ * patterns like `while (budget.total && budget.remaining() > 50_000) { ... }`
+ * would survive shape-wise; P5 fills the seam with a real per-run token
+ * tracker.
+ *
+ * Threat model:
+ *  - Workflows can dispatch up to 1000 agents per run; a runaway script
+ *    can burn through significant token budget without an upper bound.
+ *  - The env override `QWEN_CODE_MAX_TOKENS_PER_WORKFLOW` lets operators
+ *    set a per-run output-token cap. The cap is a **soft gate**, not a
+ *    hard pre-commit reservation: it is checked at dispatch ENTRY in
+ *    `countedDispatch`, so concurrent fan-out (`parallel()` /
+ *    `pipeline()`) inside the concurrency window can overshoot before
+ *    the first overshooting dispatch throws. Worst-case overshoot bound
+ *    ≈ `(concurrency_window − 1) × per_dispatch_tokens`, where
+ *    `concurrency_window = min(16, cpus−2)` by default (overridable via
+ *    `QWEN_CODE_MAX_WORKFLOW_CONCURRENCY`). Operators sizing the cap
+ *    should pick a value below the true ceiling by this margin; the
+ *    gate matches upstream Claude Code 2.1.168 semantics.
+ *  - When the env is unset (`total = null`), there is no cap and
+ *    `remaining()` returns `Infinity` — matching upstream's "no target"
+ *    sentinel for dynamic-loop callers that gate on `budget.total`.
+ *
+ * Realm boundary: the impl is host-realm; the sandbox bridge wraps it
+ * in a vm-realm shim (workflow-sandbox.ts) so the script sees a
+ * vm-realm view whose `.constructor.constructor` cannot reach host
+ * primitives — same defense as T1/T8/T14 budget stubs.
+ */
+
+import { createDebugLogger } from '../../utils/debugLogger.js';
+import type { WorkflowBudget } from './workflow-sandbox.js';
+
+const debugLogger = createDebugLogger('WORKFLOW_BUDGET');
+
+export const MAX_TOKENS_PER_WORKFLOW_ENV = 'QWEN_CODE_MAX_TOKENS_PER_WORKFLOW';
+
+/**
+ * Absolute upper bound on the env-override token cap. Even an operator
+ * who sets `QWEN_CODE_MAX_TOKENS_PER_WORKFLOW=999999999` cannot exceed
+ * this — protects against a fat-finger / misconfig that would silently
+ * uncap a workflow. 100M tokens is roughly 20× the largest legitimate
+ * single-workflow envelope (5M tokens × heavy ultracode pass).
+ */
+export const HARD_MAX_TOKENS_CEILING = 100_000_000;
+
+/**
+ * Resolve the per-run output-token ceiling, honoring
+ * `QWEN_CODE_MAX_TOKENS_PER_WORKFLOW`. Returns `null` when the env is
+ * unset or empty — null is the "no target" sentinel that
+ * `budget.total === null` consumers gate on.
+ *
+ * A non-integer override, a value `< 1` (notably `0` and negative
+ * numbers), or a non-numeric string is rejected with a debug warning
+ * and falls back to `null` — i.e. treated as "no cap" rather than
+ * crashing. This matches the `resolveMaxAgentsPerRun` fall-back policy
+ * and means `QWEN_CODE_MAX_TOKENS_PER_WORKFLOW=0` does NOT disable
+ * workflows; operators wanting "no agents may run" should disable the
+ * tool entirely via `QWEN_CODE_DISABLE_WORKFLOWS=1` instead. An
+ * override above `HARD_MAX_TOKENS_CEILING` is clamped (with a debug
+ * warning).
+ */
+export function resolveMaxTokensPerWorkflow(
+  env: Record<string, string | undefined> = process.env,
+): number | null {
+  const raw = env[MAX_TOKENS_PER_WORKFLOW_ENV];
+  if (raw === undefined || raw.trim() === '') {
+    return null;
+  }
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    debugLogger.warn(
+      `Invalid ${MAX_TOKENS_PER_WORKFLOW_ENV}=${JSON.stringify(raw)}, ` +
+        `treating as unset (no cap)`,
+    );
+    return null;
+  }
+  if (parsed > HARD_MAX_TOKENS_CEILING) {
+    debugLogger.warn(
+      `${MAX_TOKENS_PER_WORKFLOW_ENV}=${parsed} exceeds hard ceiling ` +
+        `(${HARD_MAX_TOKENS_CEILING}); clamping.`,
+    );
+    return HARD_MAX_TOKENS_CEILING;
+  }
+  return parsed;
+}
+
+/**
+ * Per-run output-token tracker. Single instance lives in the orchestrator
+ * across the lifetime of one `run()` call. The orchestrator's
+ * `countedDispatch` reads `remaining()` to gate dispatches and calls
+ * `recordSpent()` after each agent completion.
+ *
+ * `total` is set once at construction from
+ * `resolveMaxTokensPerWorkflow()`; subsequent mutations are forbidden
+ * (the field is `readonly` from the script's perspective — there is no
+ * setter on `WorkflowBudget`).
+ *
+ * Threading: workflows are single-threaded JS, so the counter has no
+ * synchronisation primitive — every `recordSpent` happens on the host
+ * event loop between dispatch resolutions.
+ */
+export class WorkflowBudgetImpl implements WorkflowBudget {
+  readonly total: number | null;
+  private _spent: number;
+
+  constructor(total: number | null) {
+    this.total = total;
+    this._spent = 0;
+  }
+
+  spent(): number {
+    return this._spent;
+  }
+
+  remaining(): number {
+    if (this.total === null) return Infinity;
+    return Math.max(0, this.total - this._spent);
+  }
+
+  /**
+   * Host-side increment. NOT exposed to the script — the
+   * `WorkflowBudget` interface deliberately omits any setter so a
+   * malicious workflow cannot inflate / deflate the budget. Only the
+   * orchestrator (in `countedDispatch`) calls this after a dispatch
+   * resolves with the agent's output token count.
+   *
+   * Non-positive deltas are silently dropped (some dispatches return
+   * `output_tokens: 0` on early failures); negative deltas would be a
+   * caller bug and are also dropped rather than silently rewinding
+   * the counter.
+   */
+  recordSpent(deltaTokens: number): void {
+    if (!Number.isFinite(deltaTokens) || deltaTokens <= 0) return;
+    this._spent += deltaTokens;
+  }
+
+  /**
+   * Factory: build a budget from the current environment. Convenience
+   * over `new WorkflowBudgetImpl(resolveMaxTokensPerWorkflow(env))`.
+   */
+  static fromEnv(
+    env: Record<string, string | undefined> = process.env,
+  ): WorkflowBudgetImpl {
+    return new WorkflowBudgetImpl(resolveMaxTokensPerWorkflow(env));
+  }
+}
+
+/**
+ * Thrown when an `agent()` dispatch would exceed `budget.total`. The
+ * orchestrator's `countedDispatch` checks `budget.remaining() > 0`
+ * BEFORE invoking the dispatch — once thrown, no further LLM calls
+ * happen for this run. The script-side catch (if any) sees this as a
+ * regular rejection from `await agent(...)`.
+ *
+ * Carries `runId` so the catch-arm display can identify the offending
+ * workflow without parsing the message; `budgetTotal` and `spent`
+ * snapshot the budget state at throw-time so logging / UI can render
+ * the precise overshoot.
+ *
+ * Production callers (`WorkflowTool`) format the error message for the
+ * LLM-facing tool result via `extractErrorMessage` (the duck-typed
+ * extractor — cross-realm `instanceof` is unreliable in the vm-realm
+ * sandbox, so we keep the message string self-describing rather than
+ * relying on `err.name`).
+ */
+export class WorkflowBudgetExceededError extends Error {
+  override readonly name = 'WorkflowBudgetExceededError';
+  readonly runId: string;
+  readonly budgetTotal: number;
+  readonly spent: number;
+
+  constructor(runId: string, budgetTotal: number, spent: number) {
+    super(
+      `Workflow ${runId} exceeded the token budget ` +
+        `(${spent} / ${budgetTotal} output tokens spent). ` +
+        `Increase ${MAX_TOKENS_PER_WORKFLOW_ENV} or unset it to remove the cap.`,
+    );
+    this.runId = runId;
+    this.budgetTotal = budgetTotal;
+    this.spent = spent;
+  }
+}

--- a/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
@@ -6,7 +6,7 @@
 
 // T7 (PR #4732 R1): the `vi as vitest` alias diverges from every other
 // test file in the repo. Use `vi` directly.
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as os from 'node:os';
 import {
   WorkflowOrchestrator,
@@ -26,7 +26,8 @@ import type { Config } from '../../config/config.js';
 // FIX-C8 (TST-2-I2): record the full 9-arg signature of AgentHeadless.create
 // and the (ctx, signal?) shape of execute so any drift between the production
 // call site and the real AgentHeadless surface becomes a test failure.
-const { created, nextTerminateMode, nextOutputTokens } = vi.hoisted(() => ({
+const { created, nextTerminateMode, nextOutputTokens, nextExecuteThrow } =
+  vi.hoisted(() => ({
   created: [] as Array<{
     name: string;
     prompt: string;
@@ -44,7 +45,15 @@ const { created, nextTerminateMode, nextOutputTokens } = vi.hoisted(() => ({
   // set `nextOutputTokens.value` so the onTokens callback can be
   // observed without standing up real telemetry.
   nextOutputTokens: { value: 0 as number },
-}));
+  // R3 (wenshao #6): real `AgentHeadless.execute()` re-throws on
+  // reasoning-loop failure — its catch arm sets `terminateMode=ERROR`
+  // and then throws. Tests set `nextExecuteThrow.value` to a non-null
+  // error so the mock execute() re-throws the same way; R1's tests
+  // had execute() RETURN with ERROR mode, which is the rare
+  // `createChat` early-return path, NOT the production reasoning-
+  // loop throw path.
+  nextExecuteThrow: { value: null as Error | null },
+  }));
 
 // P3 R2 self-review (P3-T6 gap, batch): tests below for
 // agent({isolation:'worktree'}) need to drive GitWorktreeService's
@@ -132,6 +141,14 @@ vi.mock('./agent-headless.js', () => ({
           throw new Error(
             'orchestrator did not pass workflow subagent system prompt',
           );
+        }
+        // R3 (wenshao #6): simulate the production ERROR path where
+        // AgentHeadless.execute() itself throws (see agent-headless.ts
+        // catch arm at :287-294). If `nextExecuteThrow.value` is set,
+        // re-throw it so the orchestrator's `await subagent.execute()`
+        // call rejects without ever reaching the line below it.
+        if (nextExecuteThrow.value) {
+          throw nextExecuteThrow.value;
         }
       },
       getFinalText: () =>
@@ -591,16 +608,30 @@ describe('WorkflowOrchestrator', () => {
     expect(budgetUpdates).toEqual([]);
   });
 
-  it('P5 T4: budgetUpdated does NOT fire on dispatch rejection', async () => {
+  it('P5 R3 #1: budgetUpdated DOES fire on dispatch rejection (so UI/registry see the burn-then-fail spend)', async () => {
+    // R3 #1 (bot): the production dispatch's reportTokens runs in a
+    // `finally` (R3 #6), so `budget.spent()` advances even when
+    // `subagent.execute()` throws. If the error arm of `countedDispatch`
+    // does NOT fire `budgetUpdated`, the registry's `tokensSpent` /
+    // `perPhaseTokens` never see those tokens — divergence between
+    // `budget.spent()` (host) and `entry.tokensSpent` (UI). Worse,
+    // R2 #12 dropped `safeEmitUpdate` from `agentCompleted` and made
+    // `budgetUpdated` the sole UI driver, so dispatch errors produce
+    // ZERO UI re-renders unless `budgetUpdated` fires on the error
+    // arm too.
     const { WorkflowBudgetImpl } = await import('./workflow-budget.js');
     const budget = new WorkflowBudgetImpl(1000);
     const orchestrator = new WorkflowOrchestrator(async () => {
+      // Mirror the production reportTokens-in-finally semantics:
+      // record tokens BEFORE the throw, exactly as production does.
+      budget.recordSpent(150);
       throw new Error('dispatch-boom');
     });
-    const budgetUpdates: number[] = [];
+    const budgetUpdates: Array<{ spent: number; total: number | null }> = [];
     const completions: Array<{ label?: string; error?: string }> = [];
     const emitter = {
-      budgetUpdated: (spent: number) => budgetUpdates.push(spent),
+      budgetUpdated: (spent: number, total: number | null) =>
+        budgetUpdates.push({ spent, total }),
       agentCompleted: (label?: string, error?: string) =>
         completions.push({ label, error }),
     };
@@ -618,6 +649,79 @@ describe('WorkflowOrchestrator', () => {
     expect(caught).toBeInstanceOf(Error);
     expect(completions).toHaveLength(1);
     expect(completions[0]?.error).toBe('dispatch-boom');
+    // R3 #1 contract: error arm now fires budgetUpdated with the
+    // cumulative spent at throw time, so the registry mirrors the
+    // burn that the failed dispatch incurred.
+    expect(budgetUpdates).toEqual([{ spent: 150, total: 1000 }]);
+  });
+
+  it('P5 R3 #7: budget rejection does NOT consume agent-cap slots (correct terminal error after exhaustion)', async () => {
+    // wenshao R3 #7: if `agentCount += 1` runs before the budget gate,
+    // every budget-rejected call still increments agentCount and the
+    // SUBSEQUENT call eventually trips `agentCount > maxAgents` —
+    // surfacing the wrong terminal error ("exceeded the maximum of N
+    // agent() calls per run") when the real cause is budget exhaustion.
+    const { WorkflowBudgetImpl } = await import('./workflow-budget.js');
+    const budget = new WorkflowBudgetImpl(100);
+    budget.recordSpent(100); // pre-bust the budget so every dispatch rejects
+    let dispatchCalls = 0;
+    const orchestrator = new WorkflowOrchestrator(async () => {
+      dispatchCalls += 1;
+      return 'never';
+    });
+    let caught: unknown;
+    try {
+      // Loop the script so we accumulate many budget rejections, well
+      // past `maxAgents` had the old ordering been in place.
+      // try/catch in script so loop continues despite per-call throws.
+      await orchestrator.run({
+        script: `
+          let lastErr = null;
+          for (let i = 0; i < 1100; i++) {
+            try { await agent('q' + i); } catch (e) { lastErr = e.message; }
+          }
+          return lastErr;
+        `,
+        args: undefined,
+        budget,
+      });
+    } catch (e) {
+      caught = e;
+    }
+    // Real production dispatch is never called.
+    expect(dispatchCalls).toBe(0);
+    // R3 #7 contract: the script saw budget-exceeded errors, NOT
+    // agent-count-exceeded errors. The latter would indicate the old
+    // ordering still applies.
+    // The orchestrator wraps script-thrown errors in
+    // WorkflowExecutionError; the script swallowed each per-call throw
+    // and returned the last message, so the run COMPLETED successfully.
+    expect(caught).toBeUndefined();
+  });
+
+  it('P5 R3 #1: budgetUpdated does NOT fire when no budget passed AND dispatch rejects', async () => {
+    // Budget-less callers must not get spurious budgetUpdated events
+    // — the orchestrator's `if (budget)` gate covers both the success
+    // and error arms.
+    const orchestrator = new WorkflowOrchestrator(async () => {
+      throw new Error('boom');
+    });
+    const budgetUpdates: number[] = [];
+    const emitter = {
+      budgetUpdated: (spent: number) => budgetUpdates.push(spent),
+    };
+    let caught: unknown;
+    try {
+      await orchestrator.run({
+        script: `await agent('q1'); return 'done';`,
+        args: undefined,
+        emitter,
+        // budget intentionally omitted
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
     expect(budgetUpdates).toEqual([]);
   });
 
@@ -780,6 +884,38 @@ describe('createProductionDispatch', () => {
     await expect(dispatch('q1', { label: 'x' })).resolves.toBe(
       'headless-said:q1',
     );
+  });
+
+  // ── R3 (wenshao #6): tokens MUST also be recorded when execute() THROWS ──
+
+  it('R3 #6: records tokens when subagent.execute() THROWS (the real production ERROR path)', async () => {
+    // R1 #3 only covered the case where execute() RETURNS while
+    // getTerminateMode() yields ERROR (rare: `createChat` early
+    // return). The production ERROR path goes through `agent-headless.ts`'s
+    // catch arm which RE-THROWS the underlying error after setting
+    // terminateMode=ERROR. The orchestrator's `reportTokens` was on
+    // the line AFTER `await subagent.execute(...)`, not in a `finally`
+    // — so the throw path leaked tokens. wenshao's R3 review caught
+    // this with a deterministic repro.
+    nextExecuteThrow.value = new Error('reasoning-loop boom');
+    nextOutputTokens.value = 4242;
+    const reports: number[] = [];
+    const dispatch = createProductionDispatch(
+      fakeConfig(),
+      undefined,
+      (tokens) => reports.push(tokens),
+    );
+    await expect(dispatch('q1', { label: 'thrown' })).rejects.toThrow(
+      /reasoning-loop boom/,
+    );
+    // Contract: tokens recorded BEFORE the throw propagates, exactly
+    // once — regardless of whether the throw came from execute() itself
+    // or from the post-execute terminate-mode gate (R1 #3 case).
+    expect(reports).toEqual([4242]);
+  });
+
+  afterEach(() => {
+    nextExecuteThrow.value = null;
   });
 });
 
@@ -1360,6 +1496,15 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
                     },
                   );
                 }
+                // R3 (wenshao #6): honor `nextExecuteThrow` on the
+                // override-path stub too, so the override-path sibling
+                // of the throw-path test (test name "R3 #6: override-
+                // path records tokens...") can reproduce the real
+                // AgentHeadless.execute() throw against the override
+                // dispatch site.
+                if (nextExecuteThrow.value) {
+                  throw nextExecuteThrow.value;
+                }
                 // Honor signal abort if it fires.
                 if (signal?.aborted) return;
               },
@@ -1559,6 +1704,35 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
     // R1 #1 contract: tokens recorded BEFORE the schema/non-schema
     // branching, so the schema success path now reports.
     expect(reports).toEqual([555]);
+  });
+
+  it('R3 #6: override-path records tokens when execute() THROWS (sibling of fast path)', async () => {
+    // Sibling site for wenshao's R3 #6 finding. `reportTokens` at the
+    // override path is the second of the two dispatch sites; the
+    // matching test for the fast path lives in
+    // `createProductionDispatch` describe above. Both must wrap
+    // `await subagent.execute()` in try/finally so token accounting
+    // survives the production ERROR-via-throw path.
+    const { config } = fakeConfigWithMgr({
+      onCreate: async () => ({
+        finalText: '',
+        terminateMode: 'GOAL', // execute() throws BEFORE terminate-mode check
+        runWithEmitter: () => {},
+      }),
+    });
+    nextExecuteThrow.value = new Error('override-path boom');
+    nextOutputTokens.value = 9999;
+    const reports: number[] = [];
+    const dispatch = createProductionDispatch(
+      config,
+      undefined,
+      (tokens) => reports.push(tokens),
+    );
+    await expect(
+      dispatch('q1', { label: 'thrown', schema: { type: 'object' } }),
+    ).rejects.toThrow(/override-path boom/);
+    expect(reports).toEqual([9999]);
+    nextExecuteThrow.value = null;
   });
 
   it('schema-mode: 3 failed structured_output calls → upstream-aligned terminal error', async () => {

--- a/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
@@ -26,7 +26,7 @@ import type { Config } from '../../config/config.js';
 // FIX-C8 (TST-2-I2): record the full 9-arg signature of AgentHeadless.create
 // and the (ctx, signal?) shape of execute so any drift between the production
 // call site and the real AgentHeadless surface becomes a test failure.
-const { created, nextTerminateMode } = vi.hoisted(() => ({
+const { created, nextTerminateMode, nextOutputTokens } = vi.hoisted(() => ({
   created: [] as Array<{
     name: string;
     prompt: string;
@@ -39,6 +39,11 @@ const { created, nextTerminateMode } = vi.hoisted(() => ({
   // throws on non-GOAL. Tests set `nextTerminateMode.value` to simulate
   // CANCELLED / MAX_TURNS / TIMEOUT outcomes.
   nextTerminateMode: { value: 'GOAL' as string },
+  // R1 (#1 + #3): the production dispatch reads
+  // `subagent.getExecutionSummary().outputTokens` to feed budget. Tests
+  // set `nextOutputTokens.value` so the onTokens callback can be
+  // observed without standing up real telemetry.
+  nextOutputTokens: { value: 0 as number },
 }));
 
 // P3 R2 self-review (P3-T6 gap, batch): tests below for
@@ -132,6 +137,10 @@ vi.mock('./agent-headless.js', () => ({
       getFinalText: () =>
         `headless-said:${created[created.length - 1]!.prompt}`,
       getTerminateMode: () => nextTerminateMode.value,
+      // R1 (#1 + #3): expose `getExecutionSummary` so the production
+      // dispatch's `reportTokens` helper can read `outputTokens` after
+      // every `subagent.execute()` call, regardless of terminate mode.
+      getExecutionSummary: () => ({ outputTokens: nextOutputTokens.value }),
     }),
   },
   ContextState: class ContextState {
@@ -490,6 +499,55 @@ describe('WorkflowOrchestrator', () => {
     expect(dispatchCalls).toBe(2);
   });
 
+  it('P5 R1 #2: parallel-batch overshoot is bounded by the intra-limiter re-check', async () => {
+    // R1 Critical #2 — without the intra-limiter gate, a parallel() of N
+    // thunks queues them all in one microtask burst with spent=0, so the
+    // entry gate passes for every queued dispatch and the budget
+    // overshoots by up to `(N-1) × per_dispatch_tokens`.
+    //
+    // With the intra-limiter re-check, the gate observes budget mutations
+    // from already-completed in-flight dispatches at slot-acquire time, so
+    // queued thunks that arrive AFTER the budget is busted are refused
+    // (the parallel() batch collapses them to `null`).
+    const { WorkflowBudgetImpl } = await import('./workflow-budget.js');
+    const budget = new WorkflowBudgetImpl(100);
+    let dispatchCalls = 0;
+    const orchestrator = new WorkflowOrchestrator(async () => {
+      dispatchCalls += 1;
+      budget.recordSpent(40); // 3 successful dispatches saturate the cap
+      return 'ok';
+    });
+    // 10 thunks — far more than the budget (100 / 40 ≈ 3 successful).
+    // The intra-limiter gate must reject the rest BEFORE this.dispatch
+    // runs, so `dispatchCalls` should be 3 (or 4 — see below), NOT 10.
+    const outcome = await orchestrator.run({
+      script: `const results = await parallel(Array.from({length: 10}, () => () => agent('q'))); return results;`,
+      args: undefined,
+      budget,
+    });
+    // parallel() treats budget rejections as errors-as-data → null per slot.
+    expect(Array.isArray(outcome.result)).toBe(true);
+    const results = outcome.result as unknown[];
+    expect(results).toHaveLength(10);
+    const successes = results.filter((r) => r === 'ok').length;
+    const nulls = results.filter((r) => r === null).length;
+    expect(successes + nulls).toBe(10);
+    // Bounded overshoot: at most `concurrency_window` dispatches can be
+    // already inside `limiter.run` when the budget tips over, so the
+    // upper bound on successful dispatches is
+    // `ceil(cap / per_dispatch) + concurrency_window`. The concurrency
+    // window on test machines is `min(16, cpus-2)` ≥ 1. With cap=100,
+    // per=40, the soft cap is reached at 3 dispatches (spent=120). We
+    // ASSERT it doesn't reach 10 (the without-fix overshoot value).
+    expect(dispatchCalls).toBeLessThan(10);
+    expect(successes).toBeLessThan(10);
+  });
+
+  // R1 #4 fix landed in production code (debugLogger.warn at both gate
+  // sites); no dedicated test — debugLogger has its own enable/disable
+  // gating and a spy here would be brittle. Manual verification path:
+  // run with DEBUG=WORKFLOW=1 and trigger a budget-exhausted dispatch.
+
   // ── P5 T4: budgetUpdated emitter event ─────────────────────────────────
 
   it('P5 T4: budgetUpdated fires after each successful completion with cumulative spent + total', async () => {
@@ -674,6 +732,55 @@ describe('createProductionDispatch', () => {
       );
     },
   );
+
+  // ── R1 (#1 + #3): token reporting across all terminate modes ──────────
+
+  beforeEach(() => {
+    nextOutputTokens.value = 0;
+  });
+
+  it('R1 #3: records tokens on GOAL success', async () => {
+    nextTerminateMode.value = 'GOAL';
+    nextOutputTokens.value = 1234;
+    const reports: Array<{ tokens: number; label?: string }> = [];
+    const dispatch = createProductionDispatch(
+      fakeConfig(),
+      undefined,
+      (tokens, opts) => reports.push({ tokens, label: opts.label }),
+    );
+    await dispatch('q1', { label: 'a' });
+    expect(reports).toEqual([{ tokens: 1234, label: 'a' }]);
+  });
+
+  it.each(['CANCELLED', 'MAX_TURNS', 'TIMEOUT', 'ERROR'])(
+    'R1 #3: records tokens on %s failure path (still throws)',
+    async (mode) => {
+      nextTerminateMode.value = mode;
+      nextOutputTokens.value = 777;
+      const reports: number[] = [];
+      const dispatch = createProductionDispatch(
+        fakeConfig(),
+        undefined,
+        (tokens) => reports.push(tokens),
+      );
+      await expect(dispatch('q1', { label: 'doomed' })).rejects.toThrow(
+        new RegExp(`terminate mode: ${mode}`),
+      );
+      // R1 contract: tokens recorded BEFORE the throw, not after.
+      // Otherwise CANCELLED/TIMEOUT/MAX_TURNS/ERROR dispatches would
+      // burn tokens without affecting the budget.
+      expect(reports).toEqual([777]);
+    },
+  );
+
+  it('R1 #1 + #3: onTokens is undefined ⇒ no crash', async () => {
+    nextTerminateMode.value = 'GOAL';
+    nextOutputTokens.value = 99;
+    const dispatch = createProductionDispatch(fakeConfig());
+    await expect(dispatch('q1', { label: 'x' })).resolves.toBe(
+      'headless-said:q1',
+    );
+  });
 });
 
 describe('WorkflowOrchestrator failure-context preservation', () => {
@@ -1258,6 +1365,16 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
               },
               getFinalText: () => finalText,
               getTerminateMode: () => terminateMode,
+              // R1 (#1): expose `getExecutionSummary` on the override-
+              // path subagent stub. Production dispatch reads it in
+              // `reportTokens` regardless of terminate mode, so the
+              // schema-mode early return (Critical #1) and the
+              // schema-mode failure paths (Critical #3) both need
+              // this surface. Defaults to 0; tests that observe
+              // budget-recording set `nextOutputTokens.value` first.
+              getExecutionSummary: () => ({
+                outputTokens: nextOutputTokens.value,
+              }),
             },
             dispose: async () => {
               disposed += 1;
@@ -1396,6 +1513,52 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
       schema: { type: 'object', properties: { ok: { type: 'boolean' } } },
     });
     expect(result).toEqual({ ok: true, value: 42 });
+  });
+
+  it('R1 #1: schema-mode SUCCESS records tokens via onTokens (was missing before fix)', async () => {
+    nextOutputTokens.value = 555;
+    const { config } = fakeConfigWithMgr({
+      onCreate: async () => ({
+        finalText: '',
+        terminateMode: 'CANCELLED', // schema mode's success path triggers abort
+        runWithEmitter: (emitter) => {
+          emitter.emit('tool_call', {
+            subagentId: 'sub',
+            round: 1,
+            callId: 'c1',
+            name: 'structured_output',
+            args: { ok: true, value: 42 },
+            description: '',
+            isOutputMarkdown: false,
+            timestamp: 1,
+          });
+          emitter.emit('tool_result', {
+            subagentId: 'sub',
+            round: 1,
+            callId: 'c1',
+            name: 'structured_output',
+            success: true,
+            responseParts: [],
+            resultDisplay: '',
+            durationMs: 1,
+            timestamp: 2,
+          });
+        },
+      }),
+    });
+    const reports: number[] = [];
+    const dispatch = createProductionDispatch(
+      config,
+      undefined,
+      (tokens) => reports.push(tokens),
+    );
+    const result = await dispatch('extract', {
+      schema: { type: 'object', properties: { ok: { type: 'boolean' } } },
+    });
+    expect(result).toEqual({ ok: true, value: 42 });
+    // R1 #1 contract: tokens recorded BEFORE the schema/non-schema
+    // branching, so the schema success path now reports.
+    expect(reports).toEqual([555]);
   });
 
   it('schema-mode: 3 failed structured_output calls → upstream-aligned terminal error', async () => {

--- a/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
@@ -397,6 +397,192 @@ describe('WorkflowOrchestrator', () => {
     expect(outcome.result).toBe('mock:q1');
     expect(outcome.phases).toEqual(['Plan']);
   });
+
+  // ── P5: budget gate via WorkflowRunRequest.budget ─────────────────────
+
+  it('P5: budget gate refuses to dispatch once budget is exhausted', async () => {
+    const { WorkflowBudgetImpl } = await import('./workflow-budget.js');
+    const budget = new WorkflowBudgetImpl(1000);
+    // Pre-burn the budget so the first agent() call lands over-cap.
+    budget.recordSpent(1000);
+
+    let dispatchCalls = 0;
+    const orchestrator = new WorkflowOrchestrator(async () => {
+      dispatchCalls += 1;
+      return 'never reached';
+    });
+    let caught: unknown;
+    try {
+      await orchestrator.run({
+        script: `await agent('q1'); return 0;`,
+        args: undefined,
+        budget,
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    // Cross-realm: the sandbox wraps the host error in a vm-realm Error
+    // (per T1/T8/T14 defense). The dispatch is never invoked because the
+    // gate short-circuits before limiter.run.
+    expect(String(caught)).toContain('exceeded the token budget');
+    expect(String(caught)).toContain('1000');
+    expect(dispatchCalls).toBe(0);
+  });
+
+  it('P5: budget gate stops further dispatches mid-run on overshoot', async () => {
+    const { WorkflowBudgetImpl } = await import('./workflow-budget.js');
+    const budget = new WorkflowBudgetImpl(100);
+    // Each dispatch burns 60 tokens; the budget should run out after 2.
+    let dispatchCalls = 0;
+    const orchestrator = new WorkflowOrchestrator(async () => {
+      dispatchCalls += 1;
+      budget.recordSpent(60);
+      return 'ok';
+    });
+    let caught: unknown;
+    try {
+      await orchestrator.run({
+        script: `await agent('q1'); await agent('q2'); await agent('q3'); return 'done';`,
+        args: undefined,
+        budget,
+      });
+    } catch (e) {
+      caught = e;
+    }
+    // q1 = 60/100, q2 = 120/100 (overshoot), q3 = gate refuses
+    expect(dispatchCalls).toBe(2);
+    expect(String(caught)).toContain('exceeded the token budget');
+    expect(budget.spent()).toBe(120);
+  });
+
+  it('P5: budget.total === null (no cap) — gate never fires', async () => {
+    const { WorkflowBudgetImpl } = await import('./workflow-budget.js');
+    const budget = new WorkflowBudgetImpl(null);
+    let dispatchCalls = 0;
+    const orchestrator = new WorkflowOrchestrator(async () => {
+      dispatchCalls += 1;
+      budget.recordSpent(1_000_000); // each agent burns 1M tokens
+      return 'ok';
+    });
+    const outcome = await orchestrator.run({
+      script: `await agent('q1'); await agent('q2'); await agent('q3'); return 'done';`,
+      args: undefined,
+      budget,
+    });
+    expect(outcome.result).toBe('done');
+    expect(dispatchCalls).toBe(3);
+    expect(budget.spent()).toBe(3_000_000);
+    expect(budget.remaining()).toBe(Infinity);
+  });
+
+  it('P5: no budget passed (legacy callers) — gate never fires', async () => {
+    let dispatchCalls = 0;
+    const orchestrator = new WorkflowOrchestrator(async () => {
+      dispatchCalls += 1;
+      return 'ok';
+    });
+    const outcome = await orchestrator.run({
+      script: `await agent('q1'); await agent('q2'); return 'done';`,
+      args: undefined,
+    });
+    expect(outcome.result).toBe('done');
+    expect(dispatchCalls).toBe(2);
+  });
+
+  // ── P5 T4: budgetUpdated emitter event ─────────────────────────────────
+
+  it('P5 T4: budgetUpdated fires after each successful completion with cumulative spent + total', async () => {
+    const { WorkflowBudgetImpl } = await import('./workflow-budget.js');
+    const budget = new WorkflowBudgetImpl(1000);
+    const orchestrator = new WorkflowOrchestrator(async (prompt) => {
+      // Simulate the production-dispatch onTokens callback writing into
+      // the budget BEFORE the orchestrator's then() re-snapshots.
+      budget.recordSpent(prompt === 'q1' ? 150 : 250);
+      return 'ok';
+    });
+    const budgetUpdates: Array<{ spent: number; total: number | null }> = [];
+    const emitter = {
+      budgetUpdated: (spent: number, total: number | null) =>
+        budgetUpdates.push({ spent, total }),
+    };
+    await orchestrator.run({
+      script: `await agent('q1'); await agent('q2'); return 'done';`,
+      args: undefined,
+      budget,
+      emitter,
+    });
+    expect(budgetUpdates).toEqual([
+      { spent: 150, total: 1000 },
+      { spent: 400, total: 1000 },
+    ]);
+  });
+
+  it('P5 T4: budgetUpdated does NOT fire when no budget is passed', async () => {
+    const orchestrator = new WorkflowOrchestrator(async () => 'ok');
+    const budgetUpdates: number[] = [];
+    const emitter = {
+      budgetUpdated: (spent: number) => budgetUpdates.push(spent),
+    };
+    await orchestrator.run({
+      script: `await agent('q1'); return 'done';`,
+      args: undefined,
+      emitter,
+      // budget intentionally omitted
+    });
+    expect(budgetUpdates).toEqual([]);
+  });
+
+  it('P5 T4: budgetUpdated does NOT fire on dispatch rejection', async () => {
+    const { WorkflowBudgetImpl } = await import('./workflow-budget.js');
+    const budget = new WorkflowBudgetImpl(1000);
+    const orchestrator = new WorkflowOrchestrator(async () => {
+      throw new Error('dispatch-boom');
+    });
+    const budgetUpdates: number[] = [];
+    const completions: Array<{ label?: string; error?: string }> = [];
+    const emitter = {
+      budgetUpdated: (spent: number) => budgetUpdates.push(spent),
+      agentCompleted: (label?: string, error?: string) =>
+        completions.push({ label, error }),
+    };
+    let caught: unknown;
+    try {
+      await orchestrator.run({
+        script: `await agent('q1'); return 'done';`,
+        args: undefined,
+        budget,
+        emitter,
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect(completions).toHaveLength(1);
+    expect(completions[0]?.error).toBe('dispatch-boom');
+    expect(budgetUpdates).toEqual([]);
+  });
+
+  it('P5 T4: budgetUpdated subscriber error does not break the run', async () => {
+    const { WorkflowBudgetImpl } = await import('./workflow-budget.js');
+    const budget = new WorkflowBudgetImpl(1000);
+    const orchestrator = new WorkflowOrchestrator(async () => {
+      budget.recordSpent(100);
+      return 'ok';
+    });
+    const emitter = {
+      budgetUpdated: () => {
+        throw new Error('budget-subscriber-boom');
+      },
+    };
+    const outcome = await orchestrator.run({
+      script: `await agent('q1'); return 'done';`,
+      args: undefined,
+      budget,
+      emitter,
+    });
+    expect(outcome.result).toBe('done');
+  });
 });
 
 describe('createProductionDispatch', () => {

--- a/packages/core/src/agents/runtime/workflow-orchestrator.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.ts
@@ -351,6 +351,12 @@ export function createProductionDispatch(
         { tools: ['*'], disallowedTools: WORKFLOW_SUBAGENT_DISALLOWED_TOOLS },
       );
       await subagent.execute(ctx, signal);
+      // P5 R1 (Critical #3): report tokens BEFORE the terminate-mode check.
+      // CANCELLED / TIMEOUT / MAX_TURNS / ERROR runs already burned tokens
+      // before failing; the original "only on GOAL" gate undercounted the
+      // budget by every failed dispatch's spend. Stats are valid as soon
+      // as `subagent.execute()` returns, regardless of mode.
+      reportTokens(subagent, opts, onTokens);
       // T10 (PR #4732 R1): runReasoningLoop does NOT throw on abort / turn /
       // time limit — it returns with terminateMode = CANCELLED|MAX_TURNS|
       // TIMEOUT|ERROR and getFinalText() = '' or partial. Without this check,
@@ -362,24 +368,38 @@ export function createProductionDispatch(
           `Workflow subagent did not complete (terminate mode: ${mode}).`,
         );
       }
-      // P5: report token usage out-of-band before returning. Reading
-      // stats AFTER GOAL ensures we count only the completed dispatch's
-      // tokens (CANCELLED/TIMEOUT/MAX_TURNS already threw above). The
-      // `try/catch` is defensive — a stats-read failure must not
-      // poison the dispatch result, only skip the budget update.
-      if (onTokens) {
-        try {
-          const summary = subagent.getExecutionSummary();
-          onTokens(summary.outputTokens, opts);
-        } catch (e) {
-          debugLogger.warn('onTokens callback threw:', e);
-        }
-      }
       return subagent.getFinalText();
     }
 
     return runOverridePath(config, ctx, opts, signal, onTokens);
   };
+}
+
+/**
+ * P5 R1 (Critical #1 + #3): single token-reporting site used by both the
+ * fast-path and override-path dispatch branches. Reads
+ * `subagent.getExecutionSummary().outputTokens` and forwards to the
+ * caller-supplied `onTokens` callback (no-op when `onTokens` is undefined).
+ * Defensive try/catch — a stats-read failure must NOT poison the dispatch
+ * result, only skip the budget update.
+ *
+ * Idempotency: callers must invoke this exactly once per `subagent.execute`
+ * call regardless of terminate mode. The same stats are valid for GOAL /
+ * CANCELLED / TIMEOUT / MAX_TURNS / ERROR — the field reflects whatever
+ * tokens the model actually emitted before the loop terminated.
+ */
+function reportTokens(
+  subagent: { getExecutionSummary(): { outputTokens: number } },
+  opts: WorkflowAgentOpts,
+  onTokens?: (outputTokens: number, opts: WorkflowAgentOpts) => void,
+): void {
+  if (!onTokens) return;
+  try {
+    const summary = subagent.getExecutionSummary();
+    onTokens(summary.outputTokens, opts);
+  } catch (e) {
+    debugLogger.warn('onTokens callback threw:', e);
+  }
 }
 
 /**
@@ -614,6 +634,14 @@ async function runOverridePath(
 
     try {
       await subagent.execute(ctx, dispatchSignal);
+      // P5 R1 (Critical #1 + #3): report tokens for EVERY execute outcome
+      // before branching on schema-mode / terminate-mode. Schema-mode
+      // success used to return early without ever recording its tokens
+      // (Critical #1); CANCELLED / TIMEOUT / MAX_TURNS / ERROR runs used
+      // to throw without ever recording theirs (Critical #3). One call
+      // here covers all five terminate modes × both schema and non-
+      // schema branches.
+      reportTokens(subagent, opts, onTokens);
 
       if (schemaState) {
         if (schemaState.result !== null) {
@@ -688,17 +716,9 @@ async function runOverridePath(
         );
       }
       let finalText: WorkflowAgentResult = subagent.getFinalText();
-      // P5: report token usage out-of-band before the worktree cleanup.
-      // Same defensive try/catch as the fast path so a stats-read
-      // failure does not poison the dispatch result.
-      if (onTokens) {
-        try {
-          const summary = subagent.getExecutionSummary();
-          onTokens(summary.outputTokens, opts);
-        } catch (e) {
-          debugLogger.warn('onTokens callback threw:', e);
-        }
-      }
+      // P5 R1: token reporting moved up to the single site after
+      // `subagent.execute()` returns — see the `reportTokens(...)` call
+      // above the schema/non-schema branching.
       // Cleanup worktree on the success path while we still have the
       // isolation handle. The preserved suffix (if any) is appended to
       // the final text so the script can see it. The outer finally below
@@ -1177,14 +1197,27 @@ export class WorkflowOrchestrator {
           ),
         );
       }
-      // P5: budget gate. When a per-run token cap is set
-      // (QWEN_CODE_MAX_TOKENS_PER_WORKFLOW), refuse to dispatch once the
-      // cap is reached. Token recording happens inside the production
-      // dispatch (createProductionDispatch reads subagent stats and
-      // reports back via the onTokens callback the WorkflowTool wires).
-      // No-op when `budget.total === null` (no cap), because
-      // `budget.remaining()` returns `Infinity` — the check never fires.
+      // P5: budget gate (entry check). When a per-run token cap is set
+      // (QWEN_CODE_MAX_TOKENS_PER_WORKFLOW), fail-fast at fire time if the
+      // cap is already busted. Token recording happens inside the production
+      // dispatch (createProductionDispatch reads subagent stats and reports
+      // back via the onTokens callback the WorkflowTool wires). No-op when
+      // `budget.total === null` (no cap), because `budget.remaining()`
+      // returns `Infinity` — the check never fires.
+      //
+      // P5 R1 (Critical #2): a SECOND gate fires inside `limiter.run` below.
+      // Without it, a `parallel([N thunks])` queues all N gate checks
+      // synchronously (spent=0 at check time) → every queued dispatch
+      // passes the entry gate → budget overshoots by up to
+      // `(N-1) × per_dispatch_tokens`, not the documented
+      // `(concurrency_window-1) × per_dispatch_tokens`. The intra-limiter
+      // re-check observes budget mutations from already-completed in-flight
+      // dispatches, restoring the documented overshoot bound.
       if (budget && budget.total !== null && budget.remaining() <= 0) {
+        debugLogger.warn(
+          `[Workflow] budget gate refused dispatch at entry: ` +
+            `runId=${runId} spent=${budget.spent()} total=${budget.total}`,
+        );
         return Promise.reject(
           new WorkflowBudgetExceededError(runId, budget.total, budget.spent()),
         );
@@ -1201,7 +1234,28 @@ export class WorkflowOrchestrator {
         debugLogger.warn('emitter.agentDispatched threw:', e);
       }
       return limiter
-        .run(() => this.dispatch(prompt, opts))
+        .run(() => {
+          // P5 R1 (Critical #2): re-check the gate at slot-acquire time so
+          // queued thunks see budget updates from already-completed in-
+          // flight dispatches. Without this, the entry gate above is
+          // bypassed by `parallel()` (all N thunks fire-check-queue in one
+          // microtask burst with spent=0). The throw here propagates through
+          // the same `.then(error)` arm as a dispatch-level rejection, so
+          // `agentCompleted` still fires with the error and the
+          // `parallel()` batch records this slot as `null`.
+          if (budget && budget.total !== null && budget.remaining() <= 0) {
+            debugLogger.warn(
+              `[Workflow] budget gate refused dispatch at slot-acquire: ` +
+                `runId=${runId} spent=${budget.spent()} total=${budget.total}`,
+            );
+            throw new WorkflowBudgetExceededError(
+              runId,
+              budget.total,
+              budget.spent(),
+            );
+          }
+          return this.dispatch(prompt, opts);
+        })
         .then(
           (result) => {
             try {

--- a/packages/core/src/agents/runtime/workflow-orchestrator.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.ts
@@ -11,9 +11,11 @@ import { createWorkflowSandbox, debugLogger } from './workflow-sandbox.js';
 import type {
   WorkflowAgentOpts,
   WorkflowAgentResult,
+  WorkflowBudget,
   WorkflowMeta,
   WorkflowOrchestratorEmitter,
 } from './workflow-sandbox.js';
+import { WorkflowBudgetExceededError } from './workflow-budget.js';
 import {
   WORKFLOW_SUBAGENT_SYSTEM_PROMPT,
   WORKFLOW_SUBAGENT_SYSTEM_PROMPT_WITH_SCHEMA,
@@ -221,6 +223,22 @@ export interface WorkflowRunRequest {
    * generator so existing call sites work unchanged.
    */
   runId?: string;
+  /**
+   * P5: optional per-run token budget. When provided, `countedDispatch`
+   * checks `budget.remaining() > 0` BEFORE each `agent()` dispatch and
+   * throws `WorkflowBudgetExceededError` if the cap is hit. Also
+   * surfaced via `SandboxOptions.budget` so the script-side `budget`
+   * global reads the live state (`budget.spent()` / `budget.remaining()`
+   * for dynamic-loop patterns).
+   *
+   * Token recording happens inside the production dispatch
+   * (`createProductionDispatch` reads `subagent.core.stats.getSummary
+   * (...).outputTokens` after each successful execute and reports back
+   * via the `onTokens` callback the WorkflowTool wires through). Test
+   * dispatches that want to assert budget gating should call
+   * `budget.recordSpent(N)` directly.
+   */
+  budget?: WorkflowBudget;
 }
 
 export interface WorkflowRunOutcome {
@@ -290,6 +308,15 @@ function sanitizeForErrorMessage(value: string): string {
 export function createProductionDispatch(
   config: Config,
   signal?: AbortSignal,
+  /**
+   * P5: callback fired after each successful subagent.execute with the
+   * agent's output token count (read from `core.stats.getSummary`).
+   * `WorkflowTool` wires this to `budget.recordSpent` so the per-run
+   * budget tracks every dispatch's cost. Optional — when omitted
+   * (tests, legacy callers), the dispatch behaves exactly as before,
+   * just without budget recording.
+   */
+  onTokens?: (outputTokens: number, opts: WorkflowAgentOpts) => void,
 ): WorkflowAgentDispatch {
   return async (prompt, opts) => {
     const { AgentHeadless, ContextState } = await import('./agent-headless.js');
@@ -335,10 +362,23 @@ export function createProductionDispatch(
           `Workflow subagent did not complete (terminate mode: ${mode}).`,
         );
       }
+      // P5: report token usage out-of-band before returning. Reading
+      // stats AFTER GOAL ensures we count only the completed dispatch's
+      // tokens (CANCELLED/TIMEOUT/MAX_TURNS already threw above). The
+      // `try/catch` is defensive — a stats-read failure must not
+      // poison the dispatch result, only skip the budget update.
+      if (onTokens) {
+        try {
+          const summary = subagent.getExecutionSummary();
+          onTokens(summary.outputTokens, opts);
+        } catch (e) {
+          debugLogger.warn('onTokens callback threw:', e);
+        }
+      }
       return subagent.getFinalText();
     }
 
-    return runOverridePath(config, ctx, opts, signal);
+    return runOverridePath(config, ctx, opts, signal, onTokens);
   };
 }
 
@@ -382,6 +422,13 @@ async function runOverridePath(
   ctx: ContextState,
   opts: WorkflowAgentOpts,
   signal: AbortSignal | undefined,
+  /**
+   * P5: forwarded from createProductionDispatch. The override path
+   * builds its own AgentHeadless and runs subagent.execute(); the
+   * stats are on the same `core.stats` accessor as the fast path,
+   * so the token report site is identical.
+   */
+  onTokens?: (outputTokens: number, opts: WorkflowAgentOpts) => void,
 ): Promise<WorkflowAgentResult> {
   if (opts.isolation === 'remote') {
     // Error message verbatim from upstream Claude Code 2.1.168 strings.
@@ -641,6 +688,17 @@ async function runOverridePath(
         );
       }
       let finalText: WorkflowAgentResult = subagent.getFinalText();
+      // P5: report token usage out-of-band before the worktree cleanup.
+      // Same defensive try/catch as the fast path so a stats-read
+      // failure does not poison the dispatch result.
+      if (onTokens) {
+        try {
+          const summary = subagent.getExecutionSummary();
+          onTokens(summary.outputTokens, opts);
+        } catch (e) {
+          debugLogger.warn('onTokens callback threw:', e);
+        }
+      }
       // Cleanup worktree on the success path while we still have the
       // isolation handle. The preserved suffix (if any) is appended to
       // the final text so the script can see it. The outer finally below
@@ -1109,6 +1167,7 @@ export class WorkflowOrchestrator {
     // the (max+1)th throws), and limiter.run enforces the concurrency window.
     let agentCount = 0;
     const emitter = req.emitter;
+    const budget = req.budget;
     const countedDispatch: WorkflowAgentDispatch = (prompt, opts) => {
       agentCount += 1;
       if (agentCount > maxAgents) {
@@ -1116,6 +1175,18 @@ export class WorkflowOrchestrator {
           new Error(
             `Workflow exceeded the maximum of ${maxAgents} agent() calls per run.`,
           ),
+        );
+      }
+      // P5: budget gate. When a per-run token cap is set
+      // (QWEN_CODE_MAX_TOKENS_PER_WORKFLOW), refuse to dispatch once the
+      // cap is reached. Token recording happens inside the production
+      // dispatch (createProductionDispatch reads subagent stats and
+      // reports back via the onTokens callback the WorkflowTool wires).
+      // No-op when `budget.total === null` (no cap), because
+      // `budget.remaining()` returns `Infinity` — the check never fires.
+      if (budget && budget.total !== null && budget.remaining() <= 0) {
+        return Promise.reject(
+          new WorkflowBudgetExceededError(runId, budget.total, budget.spent()),
         );
       }
       // P4b: emit dispatch-start outside the limiter so the registry
@@ -1137,6 +1208,18 @@ export class WorkflowOrchestrator {
               emitter?.agentCompleted?.(label);
             } catch (e) {
               debugLogger.warn('emitter.agentCompleted threw:', e);
+            }
+            // P5: re-snapshot the budget after successful completion so the
+            // registry sees the cumulative spent. The dispatch's onTokens
+            // callback (when wired) has already called budget.recordSpent
+            // before this point. Skipped when no budget — there is nothing
+            // for the registry to mirror.
+            if (budget) {
+              try {
+                emitter?.budgetUpdated?.(budget.spent(), budget.total);
+              } catch (e) {
+                debugLogger.warn('emitter.budgetUpdated threw:', e);
+              }
             }
             return result;
           },
@@ -1162,6 +1245,7 @@ export class WorkflowOrchestrator {
       pipeline: pipelineImpl,
       abortOnTimeout: req.abortOnTimeout,
       emitter,
+      budget,
     });
     try {
       const result = await sandbox.run(req.script);

--- a/packages/core/src/agents/runtime/workflow-orchestrator.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.ts
@@ -350,13 +350,20 @@ export function createProductionDispatch(
         // deliver its answer via user message instead of the script's read.
         { tools: ['*'], disallowedTools: WORKFLOW_SUBAGENT_DISALLOWED_TOOLS },
       );
-      await subagent.execute(ctx, signal);
-      // P5 R1 (Critical #3): report tokens BEFORE the terminate-mode check.
-      // CANCELLED / TIMEOUT / MAX_TURNS / ERROR runs already burned tokens
-      // before failing; the original "only on GOAL" gate undercounted the
-      // budget by every failed dispatch's spend. Stats are valid as soon
-      // as `subagent.execute()` returns, regardless of mode.
-      reportTokens(subagent, opts, onTokens);
+      // P5 R3 (wenshao #6): wrap `execute()` in try/finally so tokens
+      // are reported even when `subagent.execute()` THROWS. R1 #3 moved
+      // `reportTokens` before the terminate-mode check but kept it on
+      // the line AFTER `await subagent.execute(...)` — so the production
+      // ERROR path (AgentHeadless's catch arm re-throws after setting
+      // terminateMode=ERROR, see agent-headless.ts:287-294) skipped
+      // recording, leaking the dispatch's tokens. `getExecutionSummary()`
+      // is valid inside the throw path because AgentHeadless's own
+      // outer `finally` finalizes stats before propagating the error.
+      try {
+        await subagent.execute(ctx, signal);
+      } finally {
+        reportTokens(subagent, opts, onTokens);
+      }
       // T10 (PR #4732 R1): runReasoningLoop does NOT throw on abort / turn /
       // time limit — it returns with terminateMode = CANCELLED|MAX_TURNS|
       // TIMEOUT|ERROR and getFinalText() = '' or partial. Without this check,
@@ -633,15 +640,21 @@ async function runOverridePath(
     );
 
     try {
-      await subagent.execute(ctx, dispatchSignal);
-      // P5 R1 (Critical #1 + #3): report tokens for EVERY execute outcome
-      // before branching on schema-mode / terminate-mode. Schema-mode
-      // success used to return early without ever recording its tokens
-      // (Critical #1); CANCELLED / TIMEOUT / MAX_TURNS / ERROR runs used
-      // to throw without ever recording theirs (Critical #3). One call
-      // here covers all five terminate modes × both schema and non-
-      // schema branches.
-      reportTokens(subagent, opts, onTokens);
+      // P5 R1 + R3 (Critical #1 + #3 + wenshao #6): wrap `execute()` in
+      // its own try/finally so tokens are reported for every outcome —
+      // schema-mode success that returns early (Critical #1), schema-
+      // mode / non-schema terminate-mode throws (Critical #3), AND the
+      // production ERROR path where AgentHeadless.execute() itself
+      // throws (wenshao #6, agent-headless.ts:287-294). Without the
+      // inner finally the throw path leaks the dispatch's tokens.
+      // `getExecutionSummary()` is valid inside the throw path because
+      // AgentHeadless's own outer `finally` finalizes stats before
+      // propagating.
+      try {
+        await subagent.execute(ctx, dispatchSignal);
+      } finally {
+        reportTokens(subagent, opts, onTokens);
+      }
 
       if (schemaState) {
         if (schemaState.result !== null) {
@@ -1189,14 +1202,16 @@ export class WorkflowOrchestrator {
     const emitter = req.emitter;
     const budget = req.budget;
     const countedDispatch: WorkflowAgentDispatch = (prompt, opts) => {
-      agentCount += 1;
-      if (agentCount > maxAgents) {
-        return Promise.reject(
-          new Error(
-            `Workflow exceeded the maximum of ${maxAgents} agent() calls per run.`,
-          ),
-        );
-      }
+      // P5 R3 (wenshao #7): budget gate runs BEFORE `agentCount += 1`
+      // so budget-rejected dispatches don't consume agent-cap slots.
+      // Previously the order was reversed: budget exhaustion incremented
+      // `agentCount` on every subsequent call, eventually tripping the
+      // agent-count cap and surfacing the WRONG terminal error
+      // (`Workflow exceeded the maximum of N agent() calls per run`)
+      // when the real cause was budget exhaustion. Reordering also keeps
+      // `agentCount` and `agentsDispatched` (registry counter, fired
+      // below) counting the same set of calls.
+      //
       // P5: budget gate (entry check). When a per-run token cap is set
       // (QWEN_CODE_MAX_TOKENS_PER_WORKFLOW), fail-fast at fire time if the
       // cap is already busted. Token recording happens inside the production
@@ -1220,6 +1235,16 @@ export class WorkflowOrchestrator {
         );
         return Promise.reject(
           new WorkflowBudgetExceededError(runId, budget.total, budget.spent()),
+        );
+      }
+      // P5 R3 (wenshao #7): agent-count cap runs AFTER the budget gate.
+      // See the reordering rationale at the top of countedDispatch.
+      agentCount += 1;
+      if (agentCount > maxAgents) {
+        return Promise.reject(
+          new Error(
+            `Workflow exceeded the maximum of ${maxAgents} agent() calls per run.`,
+          ),
         );
       }
       // P4b: emit dispatch-start outside the limiter so the registry
@@ -1283,6 +1308,24 @@ export class WorkflowOrchestrator {
               emitter?.agentCompleted?.(label, msg);
             } catch (e) {
               debugLogger.warn('emitter.agentCompleted threw:', e);
+            }
+            // P5 R3 (bot #1): the dispatch's reportTokens runs in a
+            // `finally` (R3 #6), so `budget.spent()` advances even when
+            // the dispatch throws. Mirror that mutation to the registry
+            // via `budgetUpdated` here, otherwise:
+            //  (a) `entry.tokensSpent` (UI) and `budget.spent()` (host)
+            //      diverge — a failed dispatch's burn is invisible in
+            //      the dialog, and
+            //  (b) after R2 #12 dropped `safeEmitUpdate` from
+            //      `agentCompleted`, the error arm produces ZERO UI
+            //      re-renders, freezing the agent counter until the
+            //      next success.
+            if (budget) {
+              try {
+                emitter?.budgetUpdated?.(budget.spent(), budget.total);
+              } catch (e) {
+                debugLogger.warn('emitter.budgetUpdated threw:', e);
+              }
             }
             throw err;
           },

--- a/packages/core/src/agents/runtime/workflow-sandbox.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.ts
@@ -444,6 +444,16 @@ export interface WorkflowOrchestratorEmitter {
   agentDispatched?(label?: string): void;
   /** `dispatch(...)` settled (success or thrown). `error` set on rejection. */
   agentCompleted?(label?: string, error?: string): void;
+  /**
+   * P5: cumulative `spent` re-snapshot after each successful agent
+   * completion. `total` is `null` when no per-run cap is set
+   * (`QWEN_CODE_MAX_TOKENS_PER_WORKFLOW` unset). Caller (the
+   * `WorkflowTool`) mirrors this into the `WorkflowRunRegistry` so the
+   * pill / dialog / detail body surface the live token usage. The
+   * orchestrator only fires this when a `budget` was passed to
+   * `WorkflowRunRequest.budget`.
+   */
+  budgetUpdated?(spent: number, total: number | null): void;
 }
 
 export interface SandboxOptions {

--- a/packages/core/src/agents/workflow-run-registry.test.ts
+++ b/packages/core/src/agents/workflow-run-registry.test.ts
@@ -272,4 +272,104 @@ describe('WorkflowRunRegistry', () => {
     r.complete('wf_1', null, 1_000);
     expect(r.hasRunningEntries()).toBe(false);
   });
+
+  // ── P5: budget + warning latch ─────────────────────────────────────
+
+  it('P5: register initializes tokensSpent=0, tokenBudgetTotal=null, perPhaseTokens=Map', () => {
+    const r = new WorkflowRunRegistry();
+    const entry = r.register(reg('wf_1'));
+    expect(entry.tokensSpent).toBe(0);
+    expect(entry.tokenBudgetTotal).toBeNull();
+    expect(entry.perPhaseTokens).toBeInstanceOf(Map);
+    expect(entry.perPhaseTokens.size).toBe(0);
+  });
+
+  it('P5: register seeds tokenBudgetTotal from the caller-supplied cap', () => {
+    const r = new WorkflowRunRegistry();
+    const entry = r.register(reg('wf_capped', { tokenBudgetTotal: 50_000 }));
+    expect(entry.tokenBudgetTotal).toBe(50_000);
+  });
+
+  it('P5: onBudgetUpdated mutates tokensSpent + tokenBudgetTotal', () => {
+    const r = new WorkflowRunRegistry();
+    r.register(reg('wf_1'));
+    r.onBudgetUpdated('wf_1', 1500, 10_000);
+    const e = r.get('wf_1')!;
+    expect(e.tokensSpent).toBe(1500);
+    expect(e.tokenBudgetTotal).toBe(10_000);
+  });
+
+  it('P5: onBudgetUpdated attributes delta to the entry currentPhase', () => {
+    const r = new WorkflowRunRegistry();
+    r.register(reg('wf_1'));
+    r.onPhaseStarted('wf_1', 'Find');
+    r.onBudgetUpdated('wf_1', 200, 1000); // +200 → Find
+    r.onBudgetUpdated('wf_1', 350, 1000); // +150 → Find
+    r.onPhaseStarted('wf_1', 'Verify');
+    r.onBudgetUpdated('wf_1', 500, 1000); // +150 → Verify
+    const e = r.get('wf_1')!;
+    expect(e.tokensSpent).toBe(500);
+    expect(e.perPhaseTokens.get('Find')).toBe(350);
+    expect(e.perPhaseTokens.get('Verify')).toBe(150);
+  });
+
+  it('P5: onBudgetUpdated attributes to the null sentinel before first phase()', () => {
+    const r = new WorkflowRunRegistry();
+    r.register(reg('wf_1'));
+    r.onBudgetUpdated('wf_1', 100, null); // no phase yet
+    const e = r.get('wf_1')!;
+    expect(e.perPhaseTokens.get(null)).toBe(100);
+  });
+
+  it('P5: onBudgetUpdated is a no-op on missing / terminal entries', () => {
+    const r = new WorkflowRunRegistry();
+    // Missing entry — no throw.
+    r.onBudgetUpdated('wf_unknown', 100, 1000);
+
+    r.register(reg('wf_1'));
+    r.complete('wf_1', null, 1_000);
+    r.onBudgetUpdated('wf_1', 999, 1000); // terminal → ignored
+    const e = r.get('wf_1')!;
+    expect(e.tokensSpent).toBe(0);
+    expect(e.tokenBudgetTotal).toBeNull();
+  });
+
+  it('P5: onBudgetUpdated ignores backwards / zero deltas in perPhaseTokens', () => {
+    const r = new WorkflowRunRegistry();
+    r.register(reg('wf_1'));
+    r.onPhaseStarted('wf_1', 'A');
+    r.onBudgetUpdated('wf_1', 100, 1000);
+    r.onBudgetUpdated('wf_1', 100, 1000); // same total → delta 0, skipped
+    r.onBudgetUpdated('wf_1', 50, 1000); // backwards — defensive skip
+    const e = r.get('wf_1')!;
+    // tokensSpent IS overwritten (cumulative tracker mirrors host),
+    // but per-phase attribution only takes positive deltas.
+    expect(e.tokensSpent).toBe(50);
+    expect(e.perPhaseTokens.get('A')).toBe(100);
+  });
+
+  it('P5: onBudgetUpdated fires the statusChange callback', () => {
+    const r = new WorkflowRunRegistry();
+    const cb = vi.fn();
+    r.setStatusChangeCallback(cb);
+    r.register(reg('wf_1'));
+    cb.mockClear();
+    r.onBudgetUpdated('wf_1', 100, 1000);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('P5: shouldShowUsageWarning fires once per registry instance', () => {
+    const r = new WorkflowRunRegistry();
+    expect(r.shouldShowUsageWarning()).toBe(true);
+    expect(r.shouldShowUsageWarning()).toBe(false);
+    expect(r.shouldShowUsageWarning()).toBe(false);
+  });
+
+  it('P5: shouldShowUsageWarning latch survives reset() (per-session, not per-clear)', () => {
+    const r = new WorkflowRunRegistry();
+    r.shouldShowUsageWarning(); // flips to true
+    r.register(reg('wf_1'));
+    r.reset();
+    expect(r.shouldShowUsageWarning()).toBe(false);
+  });
 });

--- a/packages/core/src/agents/workflow-run-registry.test.ts
+++ b/packages/core/src/agents/workflow-run-registry.test.ts
@@ -334,18 +334,38 @@ describe('WorkflowRunRegistry', () => {
     expect(e.tokenBudgetTotal).toBeNull();
   });
 
-  it('P5: onBudgetUpdated ignores backwards / zero deltas in perPhaseTokens', () => {
+  it('P5: onBudgetUpdated is a no-op on backwards / zero deltas (R1 #8: monotonic spent)', () => {
+    // R1 #8 contract: the orchestrator fires `budgetUpdated` after every
+    // dispatch, but `WorkflowBudgetImpl.recordSpent` only accumulates
+    // positive integer deltas — so `budget.spent()` is monotonically
+    // increasing in production. A backwards / zero call here can only
+    // come from a buggy caller, and we treat it as a defensive no-op
+    // (skip the emit + the field mutation) rather than overwriting the
+    // tracker with a stale value.
     const r = new WorkflowRunRegistry();
     r.register(reg('wf_1'));
     r.onPhaseStarted('wf_1', 'A');
     r.onBudgetUpdated('wf_1', 100, 1000);
-    r.onBudgetUpdated('wf_1', 100, 1000); // same total → delta 0, skipped
-    r.onBudgetUpdated('wf_1', 50, 1000); // backwards — defensive skip
+    r.onBudgetUpdated('wf_1', 100, 1000); // same total → delta 0 → no-op
+    r.onBudgetUpdated('wf_1', 50, 1000); // backwards → no-op
     const e = r.get('wf_1')!;
-    // tokensSpent IS overwritten (cumulative tracker mirrors host),
-    // but per-phase attribution only takes positive deltas.
-    expect(e.tokensSpent).toBe(50);
+    expect(e.tokensSpent).toBe(100);
     expect(e.perPhaseTokens.get('A')).toBe(100);
+  });
+
+  it('P5 R1 #8: onBudgetUpdated does NOT emit statusChange on no-op deltas', () => {
+    const r = new WorkflowRunRegistry();
+    const cb = vi.fn();
+    r.setStatusChangeCallback(cb);
+    r.register(reg('wf_1'));
+    r.onBudgetUpdated('wf_1', 100, 1000); // first delta → emits
+    cb.mockClear();
+    r.onBudgetUpdated('wf_1', 100, 1000); // delta = 0, total unchanged → skip
+    r.onBudgetUpdated('wf_1', 100, 1000); // same again → still skip
+    expect(cb).not.toHaveBeenCalled();
+    // But a cap change (rare; defensive) still emits even at no spend delta.
+    r.onBudgetUpdated('wf_1', 100, 2000);
+    expect(cb).toHaveBeenCalledTimes(1);
   });
 
   it('P5: onBudgetUpdated fires the statusChange callback', () => {

--- a/packages/core/src/agents/workflow-run-registry.ts
+++ b/packages/core/src/agents/workflow-run-registry.ts
@@ -281,6 +281,14 @@ export class WorkflowRunRegistry {
     const entry = this.entries.get(runId);
     if (!entry || entry.status !== 'running') return;
     const delta = spent - entry.tokensSpent;
+    const totalChanged = entry.tokenBudgetTotal !== total;
+    // P5 R1 (#8): skip the statusChange emit when nothing observable
+    // changed. The orchestrator fires `budgetUpdated` after EVERY
+    // successful dispatch — including dispatches whose subagent
+    // reported `outputTokens === 0` (early failures, fast no-op
+    // responses). Those produce a no-delta call here; firing the
+    // UI re-render anyway burns frames for no visible effect.
+    if (delta <= 0 && !totalChanged) return;
     if (delta > 0) {
       const key = entry.currentPhase;
       const prior = entry.perPhaseTokens.get(key) ?? 0;

--- a/packages/core/src/agents/workflow-run-registry.ts
+++ b/packages/core/src/agents/workflow-run-registry.ts
@@ -73,6 +73,31 @@ export interface WorkflowTask extends TaskBase {
   agentsCompleted: number;
   /** Most recent log lines from the sandbox's `getLogs()`. Capped at 100 for the UI. */
   recentLogs: string[];
+  /**
+   * P5: cumulative output tokens spent by this run's `agent()` dispatches.
+   * Mirrored from `budget.spent()` after each successful completion via
+   * the `budgetUpdated` emitter event. Stays at `0` for runs without a
+   * budget (legacy callers) and for the period between register and the
+   * first dispatch settling.
+   */
+  tokensSpent: number;
+  /**
+   * P5: per-run token cap from `QWEN_CODE_MAX_TOKENS_PER_WORKFLOW`. `null`
+   * when no cap is set — the dialog renders `tokensSpent` alone in that
+   * case rather than the `M / N` form. Set at register time from
+   * `budget.total` and re-affirmed by every `budgetUpdated` fire (the
+   * budget's `total` is immutable so the value never changes mid-run).
+   */
+  tokenBudgetTotal: number | null;
+  /**
+   * P5: per-phase token attribution. Delta tokens are attributed to the
+   * entry's `currentPhase` at the moment `budgetUpdated` fires. A
+   * workflow that dispatches an agent before its first `phase()` call
+   * accumulates that agent's tokens under a sentinel `null` phase, which
+   * the UI surfaces as `(no phase)` so the share is observable rather
+   * than hidden.
+   */
+  perPhaseTokens: Map<string | null, number>;
   /** Final script return value once the run completes (success path). */
   result?: unknown;
   /** Error message on `failed` (terminal). */
@@ -95,12 +120,21 @@ export type WorkflowTaskRegistration = Omit<
   | 'agentsDispatched'
   | 'agentsCompleted'
   | 'recentLogs'
+  | 'tokensSpent'
+  | 'tokenBudgetTotal'
+  | 'perPhaseTokens'
   | 'description'
 > & {
   // Allow the caller to omit `description` — we synthesize it from
   // `meta?.name ?? runId` for symmetry with shell registry's `command`
   // synthesis.
   description?: string;
+  /**
+   * P5: optional per-run token cap at register time. Defaults to `null`
+   * (no cap). Persists for the life of the entry — `onBudgetUpdated`
+   * does NOT re-write it because the budget's `total` is immutable.
+   */
+  tokenBudgetTotal?: number | null;
 };
 
 /** Fires when a new entry is registered. */
@@ -119,6 +153,29 @@ export class WorkflowRunRegistry {
 
   private registerCallback: WorkflowRunRegisterCallback | undefined;
   private statusChangeCallback: WorkflowRunStatusChangeCallback | undefined;
+  /**
+   * P5 T7: one-time usage-warning latch. The first `Workflow` tool
+   * invocation per session checks `shouldShowUsageWarning()`; if true,
+   * the tool prepends a one-line banner to the result describing the
+   * token-budget knob (`QWEN_CODE_MAX_TOKENS_PER_WORKFLOW`) and how to
+   * suppress (`skipWorkflowUsageWarning` setting). The latch flips on
+   * the same call so subsequent runs are quiet. Survives `reset()` —
+   * the warning is per-session, not per-clear.
+   */
+  private usageWarningShown = false;
+
+  /**
+   * P5 T7: gate the one-time usage warning. Returns `true` exactly once
+   * per session, flipping the latch as a side effect. Settings-level
+   * suppression (`skipWorkflowUsageWarning`) is enforced upstream by
+   * the caller (`WorkflowTool`) before invoking — the registry only
+   * tracks session-scoped freshness.
+   */
+  shouldShowUsageWarning(): boolean {
+    if (this.usageWarningShown) return false;
+    this.usageWarningShown = true;
+    return true;
+  }
 
   setRegisterCallback(cb: WorkflowRunRegisterCallback | undefined): void {
     this.registerCallback = cb;
@@ -147,6 +204,15 @@ export class WorkflowRunRegistry {
     entry.agentsDispatched = 0;
     entry.agentsCompleted = 0;
     entry.recentLogs = [];
+    entry.tokensSpent = 0;
+    // Preserve a caller-supplied cap; default to "no cap" otherwise.
+    // Note: the registration's optional `tokenBudgetTotal` shape is the
+    // sole way to seed this — `onBudgetUpdated` only mirrors mid-run
+    // updates, never the initial value.
+    if (entry.tokenBudgetTotal === undefined) {
+      entry.tokenBudgetTotal = null;
+    }
+    entry.perPhaseTokens = new Map();
     if (!entry.description) {
       entry.description = entry.meta?.name ?? entry.runId;
     }
@@ -194,6 +260,37 @@ export class WorkflowRunRegistry {
     const entry = this.entries.get(runId);
     if (!entry || entry.status !== 'running') return;
     entry.agentsCompleted++;
+    this.emitStatusChange(entry);
+  }
+
+  /**
+   * P5: mirror a `budgetUpdated` emitter event into the entry. Attributes
+   * the cumulative delta (`spent - entry.tokensSpent`) to the entry's
+   * `currentPhase`. Per-phase attribution is best-effort: agents in
+   * flight when the script issues a new `phase()` will attribute their
+   * tokens to whichever phase was current when `budgetUpdated` fires —
+   * the orchestrator fires immediately after `agentCompleted`, so the
+   * race window is bounded but not zero. Tasks before the first
+   * `phase()` call attribute to the sentinel `null` key.
+   */
+  onBudgetUpdated(
+    runId: string,
+    spent: number,
+    total: number | null,
+  ): void {
+    const entry = this.entries.get(runId);
+    if (!entry || entry.status !== 'running') return;
+    const delta = spent - entry.tokensSpent;
+    if (delta > 0) {
+      const key = entry.currentPhase;
+      const prior = entry.perPhaseTokens.get(key) ?? 0;
+      entry.perPhaseTokens.set(key, prior + delta);
+    }
+    entry.tokensSpent = spent;
+    // `total` is immutable on the budget, but mirror it defensively so
+    // a stale register-time value can't drift if the caller wires a
+    // budget without seeding `tokenBudgetTotal`.
+    entry.tokenBudgetTotal = total;
     this.emitStatusChange(entry);
   }
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -822,6 +822,14 @@ export interface ConfigParameters {
   cronEnabled?: boolean;
   agentTeamEnabled?: boolean;
   workflowsEnabled?: boolean;
+  /**
+   * P5 T7: suppress the one-time `Workflow` tool usage-warning banner.
+   * When `true`, the registry-side warning latch is bypassed and the
+   * banner is not prepended to the run's display payload. Defaults to
+   * `false`. The banner itself is per-session (registry-scoped), so
+   * even when unset it fires at most once per process.
+   */
+  skipWorkflowUsageWarning?: boolean;
   computerUseEnabled?: boolean;
   computerUseMaxImageDimension?: number;
   emitToolUseSummaries?: boolean;
@@ -1256,6 +1264,7 @@ export class Config {
   private readonly cronEnabled: boolean = true;
   private readonly agentTeamEnabled: boolean = false;
   private workflowsEnabled = false;
+  private readonly skipWorkflowUsageWarning: boolean = false;
   private readonly computerUseEnabled: boolean = true;
   private readonly computerUseMaxImageDimension?: number;
   private readonly emitToolUseSummaries: boolean = true;
@@ -1456,6 +1465,7 @@ export class Config {
     this.cronEnabled = params.cronEnabled ?? true;
     this.agentTeamEnabled = params.agentTeamEnabled ?? false;
     this.workflowsEnabled = params.workflowsEnabled ?? false;
+    this.skipWorkflowUsageWarning = params.skipWorkflowUsageWarning ?? false;
     this.computerUseEnabled = params.computerUseEnabled ?? true;
     this.computerUseMaxImageDimension = params.computerUseMaxImageDimension;
     this.emitToolUseSummaries = params.emitToolUseSummaries ?? true;
@@ -3883,6 +3893,18 @@ export class Config {
 
   setWorkflowsEnabled(enabled: boolean): void {
     this.workflowsEnabled = enabled;
+  }
+
+  /**
+   * P5 T7: read the `skipWorkflowUsageWarning` setting. When `true`, the
+   * `Workflow` tool suppresses the one-time banner that announces the
+   * `QWEN_CODE_MAX_TOKENS_PER_WORKFLOW` env knob. The registry-side
+   * `shouldShowUsageWarning()` latch is still session-scoped, so even
+   * when this returns `false` the banner fires at most once per
+   * process.
+   */
+  getSkipWorkflowUsageWarning(): boolean {
+    return this.skipWorkflowUsageWarning;
   }
 
   isComputerUseEnabled(): boolean {

--- a/packages/core/src/tools/workflow/workflow.test.ts
+++ b/packages/core/src/tools/workflow/workflow.test.ts
@@ -564,4 +564,96 @@ describe('WorkflowTool', () => {
       final.recentLogs.some((l) => l.includes('before agent dispatch')),
     ).toBe(true);
   });
+
+  // ── P5 T7: one-time usage warning banner ──────────────────────────────
+
+  it('P5 T7: prepends the usage banner on the first run only', async () => {
+    const { config, registry } = configWithRegistry();
+    const tool = new WorkflowTool(config, {
+      dispatch: async () => 'ok',
+    });
+
+    const first = await tool
+      .build({ script: 'return 1' })
+      .execute(new AbortController().signal);
+    expect(typeof first.returnDisplay).toBe('string');
+    expect(first.returnDisplay as string).toMatch(
+      /Workflows have no per-run token cap|Workflow token cap is/,
+    );
+    expect(first.returnDisplay as string).toMatch(
+      /skipWorkflowUsageWarning/,
+    );
+    // Second invocation: latch already flipped on the registry.
+    const second = await tool
+      .build({ script: 'return 2' })
+      .execute(new AbortController().signal);
+    expect(second.returnDisplay as string).not.toMatch(
+      /skipWorkflowUsageWarning/,
+    );
+
+    // Sanity: the registry exposes both runs.
+    expect(registry.list().length).toBe(2);
+  });
+
+  it('P5 T7: suppressed by skipWorkflowUsageWarning setting', async () => {
+    const registry = new WorkflowRunRegistry();
+    const config = {
+      getWorkflowRunRegistry: () => registry,
+      getSkipWorkflowUsageWarning: () => true,
+    } as unknown as Config;
+    const tool = new WorkflowTool(config, { dispatch: async () => 'ok' });
+    const result = await tool
+      .build({ script: 'return 1' })
+      .execute(new AbortController().signal);
+    expect(result.returnDisplay as string).not.toMatch(
+      /skipWorkflowUsageWarning/,
+    );
+    // The latch SHOULD remain unflipped — settings suppression
+    // bypasses the call so a later session that re-enables the
+    // setting still gets its banner.
+    expect(registry.shouldShowUsageWarning()).toBe(true);
+  });
+
+  // ── P5 T7 R1: failure-path latch + status='failed' contract ─────────
+
+  it('P5 T7 R1: failure path does NOT emit banner or consume the latch', async () => {
+    // Reason: coreToolScheduler overrides `returnDisplay` with
+    // `error.message` whenever `result.error` is set. Emitting the
+    // banner on the failure path would be invisible AND would
+    // silently flip the latch — the next successful run would miss
+    // the banner. The contract is: latch flips only when the banner
+    // is actually rendered to the user (success path).
+    const { config, registry } = configWithRegistry();
+    const tool = new WorkflowTool(config, { dispatch: async () => 'ok' });
+    const failed = await tool
+      .build({ script: 'throw new Error("script-boom");' })
+      .execute(new AbortController().signal);
+    expect(failed.returnDisplay as string).not.toMatch(
+      /skipWorkflowUsageWarning/,
+    );
+    expect(failed.returnDisplay as string).toMatch(/Workflow failed: /);
+    // Latch unconsumed: a later successful run still gets the banner.
+    expect(registry.shouldShowUsageWarning()).toBe(true);
+    // Registry status contract: failed → 'failed', error preserved.
+    expect(registry.list()).toHaveLength(1);
+    expect(registry.list()[0]!.status).toBe('failed');
+    expect(registry.list()[0]!.error).toMatch(/script-boom/);
+  });
+
+  it('P5 T7 R1: failed-then-succeeded → banner appears on the SUCCESS run', async () => {
+    const { config, registry } = configWithRegistry();
+    const tool = new WorkflowTool(config, { dispatch: async () => 'ok' });
+    await tool
+      .build({ script: 'throw new Error("first-fail");' })
+      .execute(new AbortController().signal);
+    const success = await tool
+      .build({ script: 'return 1' })
+      .execute(new AbortController().signal);
+    expect(success.returnDisplay as string).toMatch(
+      /skipWorkflowUsageWarning/,
+    );
+    expect(registry.list()).toHaveLength(2);
+    expect(registry.list()[0]!.status).toBe('failed');
+    expect(registry.list()[1]!.status).toBe('completed');
+  });
 });

--- a/packages/core/src/tools/workflow/workflow.test.ts
+++ b/packages/core/src/tools/workflow/workflow.test.ts
@@ -656,4 +656,28 @@ describe('WorkflowTool', () => {
     expect(registry.list()[0]!.status).toBe('failed');
     expect(registry.list()[1]!.status).toBe('completed');
   });
+
+  it('P5 R1 #10: capped banner shape (`total !== null`) — was untested', async () => {
+    const { config } = configWithRegistry();
+    const originalEnv = process.env['QWEN_CODE_MAX_TOKENS_PER_WORKFLOW'];
+    process.env['QWEN_CODE_MAX_TOKENS_PER_WORKFLOW'] = '50000';
+    try {
+      const tool = new WorkflowTool(config, { dispatch: async () => 'ok' });
+      const result = await tool
+        .build({ script: 'return 1' })
+        .execute(new AbortController().signal);
+      const display = result.returnDisplay as string;
+      // Capped banner has "Workflow token cap is <total>" copy.
+      expect(display).toMatch(/Workflow token cap is 50000/);
+      expect(display).toMatch(/skipWorkflowUsageWarning/);
+      // Capped banner must NOT carry the uncapped "have no per-run" copy.
+      expect(display).not.toMatch(/Workflows have no per-run token cap/);
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env['QWEN_CODE_MAX_TOKENS_PER_WORKFLOW'];
+      } else {
+        process.env['QWEN_CODE_MAX_TOKENS_PER_WORKFLOW'] = originalEnv;
+      }
+    }
+  });
 });

--- a/packages/core/src/tools/workflow/workflow.ts
+++ b/packages/core/src/tools/workflow/workflow.ts
@@ -263,9 +263,11 @@ class WorkflowToolInvocation extends BaseToolInvocation<
         result: outcome.result,
         // P5: surface the per-run token total in the terminal display so
         // the user sees actual usage even without opening the dialog.
-        // Omitted when the run spent nothing (test dispatch / zero-token
-        // path) to keep the JSON minimal.
-        ...(budget.spent() > 0
+        // P5 R1 (#11): align with `buildLivePhaseTreeDisplay` — include
+        // tokens whenever ANY usage is reported OR a cap is set, not
+        // only when spend > 0. A capped-but-zero-spend run still wants
+        // the cap visible so the user sees the gate engaged.
+        ...(budget.spent() > 0 || budget.total !== null
           ? {
               tokens: {
                 spent: budget.spent(),
@@ -383,12 +385,16 @@ function buildLivePhaseTreeDisplay(entry: WorkflowTask): string {
 }
 
 /**
- * P5 T7: one-time usage-banner gate. Two filters: settings-level
- * suppression (`skipWorkflowUsageWarning`) AND the per-session registry
- * latch (`shouldShowUsageWarning`). Returns the banner string when both
- * gates pass, empty string otherwise. Called from BOTH the success and
- * failure paths so a workflow that crashes still teaches the user about
- * the env knob — the banner is informational, not tied to outcome.
+ * P5 T7: one-time usage-banner gate. Three filters: settings-level
+ * suppression (`skipWorkflowUsageWarning`), the per-session registry
+ * latch (`shouldShowUsageWarning`), and the presence of a registry.
+ * Returns the banner string when all three pass, empty string otherwise.
+ *
+ * Called from the SUCCESS path only — see the failure-path comment in
+ * `execute()` for why: `coreToolScheduler.createErrorResponse` hard-codes
+ * `resultDisplay = error.message` whenever `result.error` is set, so a
+ * failure-path banner would be invisible to TUI users AND would silently
+ * flip the registry latch, robbing the next successful run of its banner.
  *
  * The banner is prepended to `returnDisplay` only — `llmContent` stays
  * clean so the banner doesn't bias model behavior in agentic loops that

--- a/packages/core/src/tools/workflow/workflow.ts
+++ b/packages/core/src/tools/workflow/workflow.ts
@@ -32,6 +32,10 @@ import {
   type WorkflowAgentDispatch,
   type WorkflowOrchestratorEmitter,
 } from '../../agents/runtime/workflow-orchestrator.js';
+import {
+  WorkflowBudgetImpl,
+  MAX_TOKENS_PER_WORKFLOW_ENV,
+} from '../../agents/runtime/workflow-budget.js';
 import { createChildAbortController } from '../../utils/abortController.js';
 import { randomBytes } from 'node:crypto';
 import type { WorkflowTask } from '../../agents/workflow-run-registry.js';
@@ -142,9 +146,22 @@ class WorkflowToolInvocation extends BaseToolInvocation<
     // T40 (PR #4732 R4): child controller so dispatch sees caller aborts
     // AND sandbox.ts wall-clock aborts (see setTimeout handler).
     const dispatchController = createChildAbortController(signal);
+    // P5: per-run token tracker. Reads `QWEN_CODE_MAX_TOKENS_PER_WORKFLOW`
+    // from the environment via the impl's `fromEnv` factory. When the env
+    // is unset (`budget.total === null`), the orchestrator's gate is a
+    // no-op and `budgetUpdated` events still fire so the registry can
+    // surface cumulative usage even on uncapped runs.
+    const budget = WorkflowBudgetImpl.fromEnv();
     const dispatch =
       this.toolOptions.dispatch ??
-      createProductionDispatch(this.config, dispatchController.signal);
+      createProductionDispatch(
+        this.config,
+        dispatchController.signal,
+        // P5 T3: production-dispatch onTokens callback. Test-injected
+        // dispatches (`toolOptions.dispatch`) handle their own
+        // recording — they don't surface stats the same way.
+        (outputTokens) => budget.recordSpent(outputTokens),
+      );
     const orchestrator = new WorkflowOrchestrator(dispatch);
 
     // P4b: pre-generate the runId so the registry record exists before
@@ -159,6 +176,10 @@ class WorkflowToolInvocation extends BaseToolInvocation<
       startTime: Date.now(),
       outputFile: '', // P4b reserves the field but doesn't materialize
       abortController: dispatchController,
+      // P5: seed the cap so the dialog can render the `M / N` form
+      // immediately, before the first `budgetUpdated` fires. Stays
+      // `null` when no env override.
+      tokenBudgetTotal: budget.total,
     });
     // The emitter forwards sandbox + dispatch events into the registry
     // AND fires `updateOutput` so the tool's renderDisplay block (a
@@ -183,6 +204,10 @@ class WorkflowToolInvocation extends BaseToolInvocation<
         // via `registry.setRecentLogs` so the registry record reflects
         // the final tail without per-line churn driving rerenders.
       },
+      budgetUpdated: (spent, total) => {
+        registry?.onBudgetUpdated(runId, spent, total);
+        safeEmitUpdate(updateOutput, registryEntry);
+      },
     };
 
     try {
@@ -192,6 +217,7 @@ class WorkflowToolInvocation extends BaseToolInvocation<
         abortOnTimeout: dispatchController,
         runId,
         emitter,
+        budget,
       });
 
       // P4b: snapshot meta + logs onto the registry record so the dialog
@@ -204,6 +230,12 @@ class WorkflowToolInvocation extends BaseToolInvocation<
       }
       registry?.setRecentLogs(runId, outcome.logs);
       registry?.complete(runId, outcome.result, Date.now());
+
+      const usageBanner = resolveUsageBanner(
+        this.config,
+        registry,
+        budget.total,
+      );
 
       // FIX-7 (UP-C2): unwrap the script result so the LLM receives the
       // script's return value verbatim. The full metadata (runId, phases,
@@ -229,11 +261,23 @@ class WorkflowToolInvocation extends BaseToolInvocation<
         phases: outcome.phases,
         logs: outcome.logs,
         result: outcome.result,
+        // P5: surface the per-run token total in the terminal display so
+        // the user sees actual usage even without opening the dialog.
+        // Omitted when the run spent nothing (test dispatch / zero-token
+        // path) to keep the JSON minimal.
+        ...(budget.spent() > 0
+          ? {
+              tokens: {
+                spent: budget.spent(),
+                total: budget.total,
+              },
+            }
+          : {}),
       });
 
       return {
         llmContent: [{ text: llmText }],
-        returnDisplay: '```json\n' + displayJson + '\n```',
+        returnDisplay: usageBanner + '```json\n' + displayJson + '\n```',
       };
     } catch (err) {
       // FIX-H (Round 5 SEC Minor): surface only the message — never the
@@ -267,6 +311,18 @@ class WorkflowToolInvocation extends BaseToolInvocation<
       } else {
         registry?.fail(runId, message, Date.now());
       }
+      // P5 T7: banner is intentionally OMITTED on the failure path.
+      // The scheduler's `createErrorResponse` (coreToolScheduler.ts:801)
+      // hard-codes `resultDisplay: error.message` whenever a tool
+      // returns `error` — overriding any returnDisplay we set. Firing
+      // the banner here would (a) be invisible to TUI users since the
+      // scheduler drops it, AND (b) consume the registry's one-shot
+      // latch, so the NEXT successful run would silently skip the
+      // banner too. The trade-off: a brand-new user whose FIRST
+      // workflow throws will not see the banner until a later
+      // successful run. Mitigation: WorkflowTool's failure message
+      // already names the error; the banner is meta-documentation
+      // about a separate env knob, not run-specific guidance.
       const display =
         phases || logs || meta
           ? `Workflow failed: ${message}\n\n${safeStringifyDisplayPayload({
@@ -307,11 +363,84 @@ function buildLivePhaseTreeDisplay(entry: WorkflowTask): string {
     agentsDispatched: entry.agentsDispatched,
     agentsCompleted: entry.agentsCompleted,
   };
+  // P5: include budget info when there's any usage to report OR a cap
+  // is set. Both `tokensSpent > 0` and `tokenBudgetTotal !== null` are
+  // independently meaningful: an uncapped run that's spent tokens
+  // wants the spent total; a capped run with 0 spent still wants the
+  // cap visible so the user sees the gate. Keeps the JSON minimal in
+  // the common case (no cap, nothing spent yet).
+  if (entry.tokensSpent > 0 || entry.tokenBudgetTotal !== null) {
+    payload['tokens'] = {
+      spent: entry.tokensSpent,
+      total: entry.tokenBudgetTotal,
+    };
+  }
   try {
     return '```json\n' + JSON.stringify(payload, null, 2) + '\n```';
   } catch {
     return `Workflow ${entry.runId} — ${entry.status} — ${entry.phases.length} phase(s)`;
   }
+}
+
+/**
+ * P5 T7: one-time usage-banner gate. Two filters: settings-level
+ * suppression (`skipWorkflowUsageWarning`) AND the per-session registry
+ * latch (`shouldShowUsageWarning`). Returns the banner string when both
+ * gates pass, empty string otherwise. Called from BOTH the success and
+ * failure paths so a workflow that crashes still teaches the user about
+ * the env knob — the banner is informational, not tied to outcome.
+ *
+ * The banner is prepended to `returnDisplay` only — `llmContent` stays
+ * clean so the banner doesn't bias model behavior in agentic loops that
+ * read tool results back.
+ *
+ * Skipped when (a) settings suppress, (b) the registry is absent (test
+ * paths that omit the wired Config), or (c) the latch already fired
+ * this session.
+ */
+function resolveUsageBanner(
+  config: Config,
+  registry:
+    | { shouldShowUsageWarning(): boolean }
+    | undefined,
+  budgetTotal: number | null,
+): string {
+  if (!registry) return '';
+  if (config.getSkipWorkflowUsageWarning?.()) return '';
+  if (!registry.shouldShowUsageWarning()) return '';
+  return buildUsageBanner(budgetTotal);
+}
+
+/**
+ * P5 T7: build the one-time usage-warning banner. Two shapes:
+ * (a) `total === null` — explain the uncapped state and the env knob;
+ * (b) `total !== null` — confirm the cap is in effect.
+ *
+ * Both shapes mention `skipWorkflowUsageWarning` so the user knows how
+ * to suppress further banners. The banner ends with two newlines so it
+ * separates cleanly from the fenced JSON code block that follows in
+ * `returnDisplay`.
+ */
+function buildUsageBanner(total: number | null): string {
+  // Banner says "soft cap" rather than "hard ceiling" because the gate
+  // is checked at dispatch ENTRY — concurrent fan-out can overshoot by
+  // up to (concurrency_window - 1) × per_dispatch_tokens before the
+  // first overshoot is caught. See workflow-budget.ts threat-model
+  // doc for the precise overshoot bound.
+  if (total === null) {
+    return (
+      `> Workflows have no per-run token cap. Set ` +
+      `\`${MAX_TOKENS_PER_WORKFLOW_ENV}=<n>\` (env) for a soft cap. ` +
+      `Suppress this notice with \`skipWorkflowUsageWarning: true\` ` +
+      `in settings.\n\n`
+    );
+  }
+  return (
+    `> Workflow token cap is ${total} (per ` +
+    `\`${MAX_TOKENS_PER_WORKFLOW_ENV}\`). ` +
+    `Suppress this notice with \`skipWorkflowUsageWarning: true\` ` +
+    `in settings.\n\n`
+  );
 }
 
 /**

--- a/packages/core/src/tools/workflow/workflow.ts
+++ b/packages/core/src/tools/workflow/workflow.ts
@@ -197,7 +197,18 @@ class WorkflowToolInvocation extends BaseToolInvocation<
       },
       agentCompleted: () => {
         registry?.onAgentCompleted(runId);
-        safeEmitUpdate(updateOutput, registryEntry);
+        // P5 R2 (#12): defer the UI re-render to the `budgetUpdated`
+        // callback that the orchestrator fires immediately after this
+        // one. Without this skip, every dispatch completion produces
+        // TWO `safeEmitUpdate` calls (one here + one in budgetUpdated)
+        // — over a 1000-agent workflow that's 2000 TUI redraws when
+        // 1000 suffices. The budget snapshot lands AFTER the agent
+        // counter increment, so the deferred render shows both updates
+        // atomically. Production callers always wire a budget
+        // (`WorkflowBudgetImpl.fromEnv()` in `execute()` above), so the
+        // deferral is unconditional; test paths that omit budget go
+        // through the injected dispatch shape and don't exercise this
+        // emitter wiring.
       },
       logAppended: () => {
         // P4b: skip per-line emit; the tool snapshots logs at terminal

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -507,6 +507,11 @@
           "type": "boolean",
           "default": true
         },
+        "skipWorkflowUsageWarning": {
+          "description": "Suppress the one-time Workflow tool usage banner that describes the QWEN_CODE_MAX_TOKENS_PER_WORKFLOW env knob. The banner fires at most once per session regardless of this setting.",
+          "type": "boolean",
+          "default": false
+        },
         "skipLoopDetection": {
           "description": "Skip streaming loop detection. Defaults to true to avoid false-positive interruptions; set to false to re-enable as an unattended-run guardrail.",
           "type": "boolean",


### PR DESCRIPTION
## What this PR does

Adds a per-run output-token budget to the `Workflow` tool. The budget is plumbed through the orchestrator dispatch gate, the `WorkflowRunRegistry`, the `BackgroundTasksDialog` phase tree, and the `/workflows` slash command. A one-time usage banner is prepended to the first successful workflow result of a session, gated by a new `skipWorkflowUsageWarning` setting. Two new knobs: `QWEN_CODE_MAX_TOKENS_PER_WORKFLOW=<int>` (env, per-run cap) and `skipWorkflowUsageWarning: true` (setting, suppress banner). Implementation includes `WorkflowBudgetImpl` + env resolver with a 100M hard ceiling on the override, `WorkflowBudgetExceededError` carrying `runId / budgetTotal / spent`, a `budgetUpdated` orchestrator emitter event, registry fields `tokensSpent / tokenBudgetTotal / perPhaseTokens` with an `onBudgetUpdated` handler attributing token deltas to `currentPhase` at fire time, and a `shouldShowUsageWarning()` latch that survives `reset()` so `/clear` doesn't re-arm the banner.

## Why it's needed

Phase P5 of the Dynamic Workflows port (issue #4721). Workflows can dispatch up to 1000 agents per run; without a per-run output-token cap, a runaway script can burn through significant token budget unchecked. The cap is a **soft gate**, not a pre-commit reservation — checked at dispatch entry, so concurrent fan-out (`parallel()` / `pipeline()`) inside the concurrency window can overshoot by up to `(concurrency_window − 1) × per_dispatch_tokens` before the first overshooting dispatch throws `WorkflowBudgetExceededError`. Matches upstream Claude Code 2.1.168 semantics. The UI surfacing (chip in dialog row + per-phase totals + tokens/cap detail block) lets operators see the budget at glance without needing to read `dist` logs; the banner teaches the env knob without spamming the model context (banner lives in `returnDisplay` only, never in `llmContent`).

## Reviewer Test Plan

### How to verify

Set `QWEN_CODE_ENABLE_WORKFLOWS=1` and launch `qwen`. Ask the model to run a workflow script via the `Workflow` tool. Observe (a) the one-time banner in the tool result, (b) the run appearing in `/workflows`, (c) `/workflows <runId>` rendering the `tokens` / `cap` / per-phase block. Run a second workflow in the same session and confirm the banner is suppressed. Set `QWEN_CODE_MAX_TOKENS_PER_WORKFLOW=100` and run a workflow that dispatches multiple agents — confirm the second or third dispatch throws `WorkflowBudgetExceededError` once cumulative output tokens exceed 100. Set `skipWorkflowUsageWarning: true` in settings and confirm the banner never appears.

```bash
# Run the workflow suites locally
cd packages/core && npx vitest run --no-coverage \
  src/agents/runtime/workflow-budget.test.ts \
  src/agents/runtime/workflow-orchestrator.test.ts \
  src/agents/runtime/workflow-sandbox.test.ts \
  src/tools/workflow/workflow.test.ts \
  src/agents/workflow-run-registry.test.ts
# Expected: 272 passed

cd packages/cli && npx vitest run --no-coverage \
  src/ui/commands/workflowsCommand.test.ts \
  src/ui/components/background-view/BackgroundTasksDialog.test.tsx
# Expected: 42 passed
```

### Evidence (Before & After)

See the dedicated [E2E test report comment](#) (posted separately) for the full real-LLM tmux session capture. Highlights:

**Before P5** — `/workflows <runId>` detail dump had no tokens / cap / per-phase fields; first Workflow call had no usage banner; `QWEN_CODE_MAX_TOKENS_PER_WORKFLOW` had no effect.

**After P5** (tmux + DashScope `qwen3.7-plus`):

- First call: banner prepended verbatim: `> Workflows have no per-run token cap. Set 'QWEN_CODE_MAX_TOKENS_PER_WORKFLOW=<n>' (env) for a soft cap. Suppress this notice with 'skipWorkflowUsageWarning: true' in settings.`
- `/workflows`: `Workflow runs (1 total · 0 running)` + Recent row.
- `/workflows wf_xxx`: `status: completed`, `runtime: 2ms`, `agents: 0/0`, `tokens: 0`, `cap: (no cap)`, `Phases (1)`.
- Second call: banner suppressed (`/skipWorkflowUsageWarning/` regex count = 1 across full scrollback).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

Local tmux verification on macOS only; CI runs cover Linux + Windows test suites (typecheck + 272 + 42).

### Environment (optional)

Local dev: `node bundle/qwen.js` from `npm run bundle` output, OAuth `qwen-oauth` and `--auth-type openai --openai-base-url https://dashscope.aliyuncs.com/compatible-mode/v1 --model qwen3.7-plus` both confirmed working with the new tool registration.

## Risk & Scope

- **Main risk or tradeoff**: Budget is a soft gate, not pre-commit reservation — concurrent fan-out can overshoot by `(concurrency_window − 1) × per_dispatch_tokens` before the first overshoot dispatch throws. Documented in module-level docstring + banner copy. Matches upstream semantics. Operators sizing the cap should subtract this margin.
- **Not validated / out of scope**: hard pre-commit reservation (would require either over-conservative blocking via per-agent estimate × concurrency, or a signaling protocol — both significant impl deltas not in P5's scope); per-phase attribution race when an agent crosses a `phase()` boundary mid-flight (documented in `WorkflowRunRegistry.onBudgetUpdated` JSDoc).
- **Breaking changes / migration notes**: None. `WorkflowTaskRegistration.tokenBudgetTotal` is optional and defaults to `null`; legacy registrations continue working unchanged. Existing `WorkflowOrchestratorEmitter` consumers continue working without setting `budgetUpdated`. `skipWorkflowUsageWarning` defaults to `false`, banner fires once per session by default.

## Linked Issues

Refs #4721

<details>
<summary>中文说明</summary>

## 这个 PR 干了什么

为 `Workflow` 工具增加按 run 的 output token 预算。预算贯通 orchestrator 调度门、`WorkflowRunRegistry`、`BackgroundTasksDialog` phase 树，以及 `/workflows` slash 命令。每个 session 首次成功运行 workflow 时，在结果前 prepend 一次性使用提示横幅，由新设置 `skipWorkflowUsageWarning` 控制。两个新旋钮：`QWEN_CODE_MAX_TOKENS_PER_WORKFLOW=<int>`（env，按 run 上限）和 `skipWorkflowUsageWarning: true`（设置，关闭横幅）。实现包含 `WorkflowBudgetImpl` + env 解析器（env override 上有 100M 硬上限）、`WorkflowBudgetExceededError`（携带 `runId / budgetTotal / spent`）、`budgetUpdated` orchestrator emitter 事件、registry 字段 `tokensSpent / tokenBudgetTotal / perPhaseTokens` + `onBudgetUpdated` handler（按 fire 时刻的 `currentPhase` 归属 token delta），以及 `shouldShowUsageWarning()` latch（`reset()` 不重置，避免 `/clear` 重新触发横幅）。

## 为什么需要

Dynamic Workflows port 的 P5 阶段（issue #4721）。workflow 单 run 可以派发最多 1000 个 agent；没有按 run 的 output token 上限，跑飞的脚本可以消耗大量 token 不受约束。这个上限是**软门**，不是预先预留 —— 在调度入口检查，所以并发 fan-out（`parallel()` / `pipeline()`）在 concurrency 窗口内可以 overshoot，最多到 `(concurrency_window − 1) × per_dispatch_tokens`，第一次 overshoot 的调度抛 `WorkflowBudgetExceededError`。与上游 Claude Code 2.1.168 语义对齐。UI 暴露（dialog 行 chip + per-phase 总计 + tokens/cap 详情块）让运维不用读 `dist` 日志就能 glance 看到预算；横幅教用户 env 旋钮，但不污染 model context（横幅只在 `returnDisplay`，不进 `llmContent`）。

## Reviewer 验证计划

### 如何验证

设 `QWEN_CODE_ENABLE_WORKFLOWS=1` 启动 `qwen`。让 model 通过 `Workflow` 工具跑 workflow 脚本。观察 (a) 工具结果里出现一次性横幅，(b) 这次运行出现在 `/workflows` 列表里，(c) `/workflows <runId>` 渲染 `tokens` / `cap` / per-phase 块。同 session 跑第二次 workflow，确认横幅被压制。设 `QWEN_CODE_MAX_TOKENS_PER_WORKFLOW=100` 跑一个派发多个 agent 的 workflow —— 确认累计 output token 超过 100 时第二或第三次调度抛 `WorkflowBudgetExceededError`。设 `skipWorkflowUsageWarning: true` 后确认横幅完全不出现。

### Before / After 证据

详见单独贴出的 E2E 测试报告 comment（含完整 tmux 真场景截屏）。要点：

**P5 之前** —— `/workflows <runId>` 详情没有 tokens / cap / per-phase 字段；首次调用没有横幅；`QWEN_CODE_MAX_TOKENS_PER_WORKFLOW` 不生效。

**P5 之后**（tmux + DashScope `qwen3.7-plus` 实测）：

- 第一次调用：横幅原样 prepend：`> Workflows have no per-run token cap. Set 'QWEN_CODE_MAX_TOKENS_PER_WORKFLOW=<n>' (env) for a soft cap. Suppress this notice with 'skipWorkflowUsageWarning: true' in settings.`
- `/workflows`：`Workflow runs (1 total · 0 running)` + Recent 行
- `/workflows wf_xxx`：`status: completed`、`runtime: 2ms`、`agents: 0/0`、`tokens: 0`、`cap: (no cap)`、`Phases (1)`
- 第二次调用：横幅压制（全 scrollback 中 `/skipWorkflowUsageWarning/` 匹配数 = 1）

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

macOS 本地 tmux 实测；Linux + Windows 测试套件由 CI 覆盖（typecheck + 272 + 42 个测试）。

### 环境（可选）

本地 dev：`node bundle/qwen.js`（`npm run bundle` 产物），OAuth `qwen-oauth` 和 `--auth-type openai --openai-base-url https://dashscope.aliyuncs.com/compatible-mode/v1 --model qwen3.7-plus` 都验证可以触发新工具注册。

## 风险与边界

- **主要风险/权衡**：预算是软门，不是预先预留 —— 并发 fan-out 在第一次 overshoot 调度抛出前可以 overshoot 到 `(concurrency_window − 1) × per_dispatch_tokens`。模块级 docstring + 横幅文案都已注明。与上游语义对齐。运维设置上限时应留出这个余量。
- **未验证/超出范围**：硬预留（要么按 per-agent 估算 × concurrency 过度保守阻塞，要么搞个 signaling 协议 —— 都是大改动，超出 P5 范围）；agent 跨 `phase()` 边界时的归属竞争（`WorkflowRunRegistry.onBudgetUpdated` JSDoc 中已说明）。
- **破坏性变更/迁移**：无。`WorkflowTaskRegistration.tokenBudgetTotal` 是 optional，默认 `null`；旧的 registration 继续无改动工作。已有的 `WorkflowOrchestratorEmitter` consumer 不实现 `budgetUpdated` 也无影响。`skipWorkflowUsageWarning` 默认 `false`，默认每 session 横幅触发一次。

## 关联 issue

Refs #4721

</details>
