### PR TITLE
ci(e2e): stop running the E2E matrix on every PR push

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - 'main'
       - 'feat/e2e/**'
-  pull_request:
-    branches:
-      - 'main'
   merge_group:
 
 concurrency:

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -624,7 +624,7 @@ jobs:
           TARGETS='[]'
           for PR in ${CANDIDATES}; do
             BRANCH="$(gh pr view "${PR}" --repo "${REPO}" --json headRefName --jq '.headRefName')"
-            ISSUE="${BRANCH#${BRANCH_PREFIX}}"
+            ISSUE="${BRANCH#"${BRANCH_PREFIX}"}"
             HEAD_SHA="$(gh api "repos/${REPO}/pulls/${PR}" --jq '.head.sha')"
 
             # Push watermark: the PR's last push. Feedback older than this was in


### PR DESCRIPTION
## What this PR does

Two CI-only changes:

1. Stops running the full End-to-End test matrix on every same-repo pull request push. After this change the E2E suite runs only on pushes to `main` / `feat/e2e/**` and inside the merge queue, instead of also firing on each PR commit.
2. Fixes an `actionlint` (shellcheck SC2295) finding in the autofix workflow where a prefix-strip parameter expansion used an unquoted variable as a pattern. Quoting it makes the strip literal and turns the repo-wide Lint check green again.

## Why it's needed

Running the full E2E matrix (Linux no-sandbox, Linux Docker, and macOS) on every same-repo PR push made each open PR consume several hosted runners at once, and the scarce macOS hosted runners in particular saturated the organization's hosted-runner pool. The result was a long backlog: jobs across CI, automated PR review, and triage sat queued for an extended time, while the self-hosted runners were idle but could not be reached because their gate jobs were stuck waiting for hosted runners. Moving E2E off the per-PR-push path removes that load. Coverage is preserved because the merge queue still runs E2E in the base-repo context (with secrets) immediately before a change merges — the same gating model already used for the CLI integration tests. Fork PRs were already skipped (no access to secrets), so they are unaffected.

The actionlint fix is bundled here because that finding was failing the Lint check on every pull request (including this one), adding noise and masking real lint regressions; it is a one-line, no-behavior-change fix.

## Reviewer Test Plan

### How to verify

For the E2E trigger change: open or update a same-repo pull request and confirm the E2E workflow no longer starts from the PR push, then confirm a push to `main` still starts E2E and a change entering the merge queue still runs E2E before it merges. For the lint fix: confirm the Lint check passes on this PR (it previously failed with SC2295), and that the autofix workflow still derives the issue number by stripping the branch prefix exactly as before.

### Evidence (Before & After)

N/A — CI configuration/lint changes with no user-visible or TUI behavior. The lint fix was verified locally with `actionlint` (exit 0, no findings).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

Workflow-trigger change is exercised on GitHub Actions; the lint fix was verified locally with `actionlint` on Linux.

### Environment (optional)

N/A

## Risk & Scope

- Main risk or tradeoff: PRs no longer show a live E2E status while open; the E2E signal moves to merge-queue time, so a contract/capability regression surfaces when the change is queued to merge rather than on each push.
- Not validated / out of scope: no other lint findings were addressed.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

两个纯 CI 改动:

1. 不再在每个同仓库 PR 的 push 上跑整套 E2E 测试矩阵。改动后,E2E 只在 push 到 `main` / `feat/e2e/**` 以及合并队列里运行,不再随每个 PR 提交触发。
2. 修复 autofix workflow 里一处 `actionlint`(shellcheck SC2295)告警:剥前缀的参数展开用了未加引号的变量当模式。加引号后按字面剥,并让全仓库的 Lint 检查重新转绿。

## 为什么需要

在每个同仓库 PR push 上跑整套 E2E 矩阵(Linux 无沙箱、Linux Docker、macOS)会让每个打开的 PR 同时占用多个托管 runner,尤其稀缺的 macOS 托管 runner 把组织的托管池打满。结果是大面积积压:CI、自动 PR review、triage 的任务长时间排队,而自建 runner 明明空闲却够不着——它们的门禁 job 卡在等待托管 runner。把 E2E 从「每个 PR push」这条路上移走就消除了这部分负载。覆盖率不受影响:合并队列仍会在变更合入前于 base 仓库上下文(带 secrets)跑 E2E,这与 CLI 集成测试已采用的把关方式一致。fork PR 本来就被跳过(拿不到 secrets),不受影响。

actionlint 修复一并放在这里,是因为该告警让每个 PR(包括本 PR)的 Lint 都失败,既是噪音又会掩盖真正的 lint 回归;它是一行、不改变行为的修复。

## 评审验证计划

### 如何验证

E2E 触发改动:新建或更新一个同仓库 PR,确认 E2E workflow 不再因 PR push 启动;再确认 push 到 `main` 仍会启动 E2E、变更进入合并队列时仍会在合并前跑 E2E。lint 修复:确认本 PR 的 Lint 检查通过(之前因 SC2295 失败),且 autofix workflow 仍按之前的方式剥分支前缀得到 issue 号。

### 证据(前后对比)

N/A —— CI 配置/lint 改动,无用户可见 / TUI 行为。lint 修复已在本地用 `actionlint` 验证(exit 0,无告警)。

### 测试平台

工作流触发器改动在 GitHub Actions 上体现;lint 修复在 Linux 本地用 `actionlint` 验证。

## 风险与范围

- 主要风险/取舍:PR 打开期间不再有实时 E2E 状态;E2E 信号移到合并队列阶段,契约/能力回归会在变更进队列合并时暴露,而非每次 push。
- 未验证 / 范围外:未处理其他 lint 告警。
- 破坏性改动 / 迁移说明:无。

</details>
