### PR TITLE
ci(lint): fix actionlint SC2295 in qwen-autofix workflow

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -624,7 +624,7 @@ jobs:
           TARGETS='[]'
           for PR in ${CANDIDATES}; do
             BRANCH="$(gh pr view "${PR}" --repo "${REPO}" --json headRefName --jq '.headRefName')"
-            ISSUE="${BRANCH#${BRANCH_PREFIX}}"
+            ISSUE="${BRANCH#"${BRANCH_PREFIX}"}"
             HEAD_SHA="$(gh api "repos/${REPO}/pulls/${PR}" --jq '.head.sha')"
 
             # Push watermark: the PR's last push. Feedback older than this was in


### PR DESCRIPTION
## What this PR does

Fixes the `actionlint` failure that was breaking the Lint check on every pull request. A shell parameter expansion in the autofix workflow stripped a prefix using a variable that was not quoted, which `shellcheck` (rule SC2295) reports because the unquoted variable is treated as a glob pattern instead of a literal string. The expansion now quotes the prefix variable so the strip is literal.

## Why it's needed

The Lint job runs `actionlint` across all workflow files, and this one finding made Lint fail red on unrelated PRs, adding noise and obscuring real lint regressions. The behavior was also subtly wrong: if the prefix variable ever contained glob metacharacters, the strip would not behave as intended.

## Reviewer Test Plan

### How to verify

Run `actionlint` against the autofix workflow and confirm it reports no findings, where previously it reported SC2295. Equivalently, confirm the Lint check passes on this PR. The runtime behavior is unchanged for normal branch names: the branch prefix is stripped to derive the issue number exactly as before, only now the strip is anchored to the literal prefix.

### Evidence (Before & After)

N/A — CI/lint fix with no user-visible or TUI behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

Verified locally with `actionlint` (exit 0, no findings) on Linux.

### Environment (optional)

N/A

## Risk & Scope

- Main risk or tradeoff: none of note; the change only quotes an existing expansion and does not alter control flow.
- Not validated / out of scope: no other lint findings were addressed in this PR.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复了让每个 PR 的 Lint 检查变红的 `actionlint` 失败。autofix workflow 里一处 shell 参数展开用一个未加引号的变量去剥前缀,`shellcheck`(规则 SC2295)会因为未加引号的变量被当作 glob 模式而非字面字符串而报错。现在给该前缀变量加了引号,使剥前缀按字面进行。

## 为什么需要

Lint job 会对所有 workflow 文件跑 `actionlint`,这一处告警让无关 PR 的 Lint 全部变红,既是噪音又会掩盖真正的 lint 回归。原写法也有潜在隐患:若前缀变量含有 glob 元字符,剥前缀的行为会不符合预期。

## 评审验证计划

### 如何验证

对 autofix workflow 跑 `actionlint`,确认不再有 SC2295 告警(之前会报)。等价地,确认本 PR 的 Lint 检查通过。对正常分支名运行时行为不变:仍按之前的方式剥掉分支前缀得到 issue 号,只是现在锚定到字面前缀。

### 证据(前后对比)

N/A —— CI/lint 修复,无用户可见 / TUI 行为。

### 测试平台

在 Linux 本地用 `actionlint` 验证(exit 0,无告警)。

## 风险与范围

- 主要风险/取舍:基本无;仅给已有展开加引号,不改变控制流。
- 未验证 / 范围外:本 PR 未处理其他 lint 告警。
- 破坏性改动 / 迁移说明:无。

</details>
