### PR TITLE
fix(model): disambiguate providers sharing a model id by baseUrl

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1121,6 +1121,16 @@ const SETTINGS_SCHEMA = {
         description: 'The model to use for conversations.',
         showInDialog: false,
       },
+      baseUrl: {
+        type: 'string',
+        label: 'Model Base URL',
+        category: 'Model',
+        requiresRestart: false,
+        default: undefined as string | undefined,
+        description:
+          'Base URL of the selected model provider. Persisted alongside the model name so providers that share a model id but differ by endpoint resolve to the one that was selected.',
+        showInDialog: false,
+      },
       maxSessionTurns: {
         type: 'number',
         label: 'Max Session Turns',

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -95,9 +95,14 @@ function maskApiKey(apiKey: string | undefined): string {
 function persistModelSelection(
   settings: ReturnType<typeof useSettings>,
   modelId: string,
+  baseUrl?: string,
 ): void {
   const scope = getPersistScopeForModelSelection(settings);
   settings.setValue(scope, 'model.name', modelId);
+  // Persist the provider baseUrl alongside the name so resolveCliGenerationConfig
+  // can pick the exact provider when several share this model id (#5173). Always
+  // write it — passing undefined clears a baseUrl left by a previous selection.
+  settings.setValue(scope, 'model.baseUrl', baseUrl);
 }
 
 function persistAuthTypeSelection(
@@ -143,7 +148,7 @@ function handleModelSwitchSuccess({
   effectiveModelId,
   isRuntime,
 }: HandleModelSwitchSuccessParams): void {
-  persistModelSelection(settings, effectiveModelId);
+  persistModelSelection(settings, effectiveModelId, after?.baseUrl);
   if (effectiveAuthType) {
     persistAuthTypeSelection(settings, effectiveAuthType);
   }

--- a/packages/cli/src/utils/modelConfigUtils.test.ts
+++ b/packages/cli/src/utils/modelConfigUtils.test.ts
@@ -404,6 +404,76 @@ describe('modelConfigUtils', () => {
       );
     });
 
+    it('resolves the provider matching the persisted baseUrl when several share a model id', () => {
+      const tokenPlan: ProviderModelConfig = {
+        id: 'qwen3.7-max',
+        name: 'qwen3.7-max',
+        baseUrl: 'https://tokenplan.example.com',
+      };
+      const ideaLab: ProviderModelConfig = {
+        id: 'qwen3.7-max',
+        name: 'qwen3.7-max',
+        baseUrl: 'https://idealab.example.com',
+      };
+      const settings = makeMockSettings({
+        model: { name: 'qwen3.7-max', baseUrl: 'https://idealab.example.com' },
+        modelProviders: {
+          [AuthType.USE_OPENAI]: [tokenPlan, ideaLab],
+        },
+      });
+
+      vi.mocked(resolveModelConfig).mockReturnValue({
+        config: { model: 'qwen3.7-max', apiKey: '', baseUrl: '' },
+        sources: {},
+        warnings: [],
+      });
+
+      resolveCliGenerationConfig({
+        argv: {},
+        settings,
+        selectedAuthType: AuthType.USE_OPENAI,
+      });
+
+      expect(vi.mocked(resolveModelConfig)).toHaveBeenCalledWith(
+        expect.objectContaining({ modelProvider: ideaLab }),
+      );
+    });
+
+    it('falls back to the first id match when no baseUrl was persisted', () => {
+      const tokenPlan: ProviderModelConfig = {
+        id: 'qwen3.7-max',
+        name: 'qwen3.7-max',
+        baseUrl: 'https://tokenplan.example.com',
+      };
+      const ideaLab: ProviderModelConfig = {
+        id: 'qwen3.7-max',
+        name: 'qwen3.7-max',
+        baseUrl: 'https://idealab.example.com',
+      };
+      const settings = makeMockSettings({
+        model: { name: 'qwen3.7-max' },
+        modelProviders: {
+          [AuthType.USE_OPENAI]: [tokenPlan, ideaLab],
+        },
+      });
+
+      vi.mocked(resolveModelConfig).mockReturnValue({
+        config: { model: 'qwen3.7-max', apiKey: '', baseUrl: '' },
+        sources: {},
+        warnings: [],
+      });
+
+      resolveCliGenerationConfig({
+        argv: {},
+        settings,
+        selectedAuthType: AuthType.USE_OPENAI,
+      });
+
+      expect(vi.mocked(resolveModelConfig)).toHaveBeenCalledWith(
+        expect.objectContaining({ modelProvider: tokenPlan }),
+      );
+    });
+
     it('should find modelProvider from settings.model.name when argv.model is not provided', () => {
       const argv = {};
       const modelProvider: ProviderModelConfig = {

--- a/packages/cli/src/utils/modelConfigUtils.ts
+++ b/packages/cli/src/utils/modelConfigUtils.ts
@@ -181,7 +181,19 @@ export function resolveCliGenerationConfig(
   if (resolvedModel && authType && settings.modelProviders) {
     const providers = settings.modelProviders[authType];
     if (providers && Array.isArray(providers)) {
-      modelProvider = providers.find((p) => p.id === resolvedModel);
+      // Providers can share a model id but differ by baseUrl (e.g. the same
+      // model served through several endpoints). When the selection persisted
+      // a baseUrl, match on the composite (id + baseUrl) key so we resolve the
+      // exact provider the user picked rather than the first id match.
+      const persistedBaseUrl = settings.model?.baseUrl;
+      if (persistedBaseUrl) {
+        modelProvider = providers.find(
+          (p) => p.id === resolvedModel && p.baseUrl === persistedBaseUrl,
+        );
+      }
+      // Fall back to id-only for selections saved before baseUrl was persisted
+      // and for configs where a single provider matches the id.
+      modelProvider ??= providers.find((p) => p.id === resolvedModel);
     }
   }
 


### PR DESCRIPTION
## What

When several `modelProviders` entries share a model `id` but use different `baseUrl`s (the same model served through multiple endpoints, e.g. Token Plan / IdeaLab / BFF all exposing `qwen3.7-max`), the chosen provider now survives a restart.

- `persistModelSelection` saves the selected provider's `baseUrl` as `model.baseUrl` alongside `model.name`.
- `resolveCliGenerationConfig` resolves the provider by the composite `(id + baseUrl)` key when a `baseUrl` was persisted, and falls back to id-only matching otherwise.
- Adds the `model.baseUrl` settings field.

## Why

Fixes #5173. Previously `persistModelSelection` saved only `model.name`, and `resolveCliGenerationConfig` matched providers with `providers.find(p => p.id === resolvedModel)` — i.e. by id alone. So picking IdeaLab's `qwen3.7-max` was forgotten on the next launch and always resolved to the first matching entry (Token Plan), using the wrong `baseUrl`/`envKey`. The model picker already distinguishes these providers via a composite `id + baseUrl` key; this aligns persistence and startup resolution with that.

The fallback keeps behavior unchanged for the common single-provider case and for selections saved before this change (no `model.baseUrl` yet).

## Reviewer Test Plan

- `npx vitest run packages/cli/src/utils/modelConfigUtils.test.ts` — adds two cases: composite-key resolution picks the provider matching the persisted `baseUrl`, and id-only fallback when no `baseUrl` was persisted. All 50 tests pass.
- Reverting the resolver change alone makes the composite-key test fail (it resolves the first id match), confirming the regression it guards.

## Risk

Low. The composite match only engages when `model.baseUrl` is set; otherwise resolution is unchanged. Always writing `model.baseUrl` on selection (including `undefined`) clears a stale baseUrl from a previous pick. No migration needed — older configs without `model.baseUrl` keep the previous id-only behavior.
