### PR TITLE
fix(core): never let telemetry file exporters crash the process

### DIFF
--- a/packages/core/src/telemetry/file-exporters.test.ts
+++ b/packages/core/src/telemetry/file-exporters.test.ts
@@ -8,6 +8,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ExportResultCode } from '@opentelemetry/core';
 import { FileSpanExporter } from './file-exporters.js';
 
 type SerializeAccess = { serialize: (data: unknown) => string };
@@ -53,5 +54,55 @@ describe('FileExporter.serialize', () => {
     expect(out).toContain('"name": "span-1"');
     expect(out).toContain('"[Circular]"');
     expect(out.endsWith('\n')).toBe(true);
+  });
+});
+
+// Telemetry is best-effort and must never crash the agent. The outfile is often
+// a relative path resolved against a cwd that lacks the directory (e.g. an ACP
+// session whose process cwd is `/`), which makes createWriteStream emit an
+// async `error` event that, if unhandled, takes down the whole process.
+describe('FileExporter robustness', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'file-exporters-robust-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 50,
+    });
+  });
+
+  it('creates the parent directory when it does not exist', async () => {
+    const nested = path.join(tmpDir, 'a', 'b', 'c');
+    const exporter = new FileSpanExporter(path.join(nested, 'out.jsonl'));
+    expect(fs.existsSync(nested)).toBe(true);
+    await exporter.shutdown();
+  });
+
+  it('does not crash when the outfile path is unusable', async () => {
+    // Make the parent a regular file so the directory — and therefore the
+    // write stream — cannot be created. The async stream `error` must be
+    // absorbed rather than crashing the process.
+    const blocker = path.join(tmpDir, 'blocker');
+    fs.writeFileSync(blocker, 'x');
+    const badPath = path.join(blocker, 'out.jsonl');
+
+    let exporter: FileSpanExporter | undefined;
+    expect(() => {
+      exporter = new FileSpanExporter(badPath);
+    }).not.toThrow();
+
+    const code = await new Promise<ExportResultCode>((resolve) => {
+      exporter!.export([{ name: 'span' } as never], (result) =>
+        resolve(result.code),
+      );
+    });
+    expect(code).toBe(ExportResultCode.FAILED);
+    await exporter!.shutdown();
   });
 });

--- a/packages/core/src/telemetry/file-exporters.ts
+++ b/packages/core/src/telemetry/file-exporters.ts
@@ -5,6 +5,7 @@
  */
 
 import * as fs from 'node:fs';
+import * as path from 'node:path';
 import type { ExportResult } from '@opentelemetry/core';
 import { ExportResultCode } from '@opentelemetry/core';
 import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
@@ -23,7 +24,22 @@ class FileExporter {
   protected writeStream: fs.WriteStream;
 
   constructor(filePath: string) {
+    // Telemetry is best-effort and must never crash the process. Ensure the
+    // parent directory exists (the outfile may be a relative path resolved
+    // against a cwd that lacks it), and attach an `error` handler so an open or
+    // write failure (missing/read-only dir, EACCES) is absorbed instead of
+    // surfacing as an unhandled stream `error` event that takes down the agent.
+    try {
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    } catch {
+      // Directory could not be created; the stream error handler below will
+      // absorb the resulting open failure.
+    }
     this.writeStream = fs.createWriteStream(filePath, { flags: 'a' });
+    this.writeStream.on('error', () => {
+      // Swallow telemetry file errors — exporters report failures through the
+      // ExportResult callback; an unhandled `error` event would crash Node.
+    });
   }
 
   protected serialize(data: unknown): string {


### PR DESCRIPTION
## What this PR does

Makes the file telemetry exporters best-effort so that a telemetry file that cannot be opened can no longer crash the process. The shared `FileExporter` now creates the outfile's parent directory recursively (ignoring failures) and attaches an `error` handler to the write stream, so open/write failures are surfaced through the existing `ExportResult` callback instead of propagating as an unhandled stream `error` event.

## Why it's needed

`FileExporter` opened its outfile with `fs.createWriteStream(filePath, { flags: 'a' })` without ensuring the parent directory existed and without an `error` listener. When the outfile is a relative path such as `.qwen/telemetry.log` resolved against a process whose cwd lacks that directory — which happens for an ACP session whose process cwd is `/` — `createWriteStream` emits an asynchronous `error` event (`ENOENT: ... open '.qwen/telemetry.log'`). With no listener, Node treats this as an unhandled `error` event and terminates the process with exit code 1. To an ACP/desktop client this looks like the agent dying on the first prompt ("ACP connection closed"). Telemetry is best-effort and must never take down the agent.

## Reviewer Test Plan

### How to verify

Construct any file exporter with an outfile whose directory does not exist and cannot be created (e.g. a path whose parent is a regular file, or a relative path under a read-only cwd), then export a record. Before this change the asynchronous stream `error` crashes the process; after it, construction does not throw, the parent directory is created when possible, and an unusable path reports `ExportResultCode.FAILED` through the callback while the process stays alive. End-to-end: run the bundled CLI in ACP mode with `QWEN_TELEMETRY_OUTFILE=.qwen/telemetry.log` from a cwd without `.qwen`, send a prompt — before: the process exits with `ENOENT`; after: the prompt completes normally.

### Evidence (Before & After)

Bundled `cli.js --acp` started from a cwd without `.qwen`, with telemetry writing to `.qwen/telemetry.log`, then a single prompt:

Before:

```
[qwen stderr] Error: ENOENT: no such file or directory, open '.qwen/telemetry.log'
[EXIT] code=1 signal=null
```

After:

```
session/prompt → agent_message_chunk "你好！我是 Qwen Code ..." → { "stopReason": "end_turn" }
(process stays alive; no ENOENT)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npm run build && npm run bundle`, then drove the bundled `dist/cli.js` over ACP; unit tests via `vitest run src/telemetry/file-exporters.test.ts`.

## Risk & Scope

- Main risk or tradeoff: when the outfile genuinely cannot be created the exporter now silently no-ops (errors are swallowed in the stream handler and reported via `ExportResult`) instead of surfacing loudly; this is the intended best-effort behavior for telemetry.
- Not validated / out of scope: Windows and Linux were not run locally (CI covers all three). No change to telemetry enablement, outfile resolution, or OTLP exporters.
- Breaking changes / migration notes: none. Behavior only changes on the previously-crashing path; the happy path (writable outfile) is unchanged, and the parent directory is now created when it is missing but creatable.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让文件型遥测导出器变为 best-effort:当遥测输出文件无法打开时,不再让进程崩溃。共享基类 `FileExporter` 现在会递归创建输出文件的父目录(失败则忽略),并给写入流挂上 `error` 监听,使打开/写入失败通过既有的 `ExportResult` 回调上报,而不是作为未处理的流 `error` 事件抛出。

## 为什么需要

`FileExporter` 之前用 `fs.createWriteStream(filePath, { flags: 'a' })` 打开输出文件,既不确保父目录存在,也没有 `error` 监听。当输出文件是相对路径(如 `.qwen/telemetry.log`),而进程的 cwd 下没有该目录时——例如 ACP 会话的进程 cwd 是 `/`——`createWriteStream` 会异步 emit `error`(`ENOENT: ... open '.qwen/telemetry.log'`)。由于没有监听,Node 将其视为未处理的 `error` 事件并以退出码 1 终止进程。对 ACP/桌面客户端而言,这表现为 agent 在首次发消息时死亡(“ACP connection closed”)。遥测是 best-effort,绝不应拖垮 agent。

## 审阅者测试计划

### 如何验证

用一个目录不存在且无法创建的输出文件(例如父级是普通文件的路径,或只读 cwd 下的相对路径)构造任意文件导出器,然后导出一条记录。改动前异步流 `error` 会崩溃进程;改动后构造不抛错,可创建时会建好父目录,不可用路径则通过回调返回 `ExportResultCode.FAILED` 且进程存活。端到端:在没有 `.qwen` 的 cwd 下,以 `QWEN_TELEMETRY_OUTFILE=.qwen/telemetry.log` 运行打包后的 CLI(ACP 模式)并发消息——改动前进程以 `ENOENT` 退出,改动后对话正常完成。

### 证据(Before & After)

在没有 `.qwen` 的 cwd 下启动打包 `cli.js --acp`,遥测写 `.qwen/telemetry.log`,然后发一条消息:

改动前:

```
[qwen stderr] Error: ENOENT: no such file or directory, open '.qwen/telemetry.log'
[EXIT] code=1 signal=null
```

改动后:

```
session/prompt → agent_message_chunk "你好！我是 Qwen Code ..." → { "stopReason": "end_turn" }
（进程存活;无 ENOENT）
```

### 测试平台

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境(可选)

`npm run build && npm run bundle`,随后用 ACP 驱动打包后的 `dist/cli.js`;单测 `vitest run src/telemetry/file-exporters.test.ts`。

## 风险与范围

- 主要风险/取舍:输出文件确实无法创建时,导出器现在会静默 no-op(错误在流处理器里被吸收、并通过 `ExportResult` 上报),而非显式报错;这正是遥测应有的 best-effort 行为。
- 未验证/范围之外:Windows 与 Linux 未在本地运行(CI 覆盖三平台);不改动遥测开关、outfile 解析或 OTLP 导出器。
- 破坏性变更/迁移说明:无。仅改变此前会崩溃的路径;正常路径(可写 outfile)行为不变,且父目录缺失但可创建时现在会被建好。

## 关联 Issue

N/A

</details>
