### PR TITLE
fix(desktop): handle git branch badge edge cases

### DIFF
--- a/packages/desktop/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
+++ b/packages/desktop/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
@@ -2757,20 +2757,22 @@ function WorkingDirectoryBadge({
     let cancelled = false;
     setGitBranch(null);
 
-    if (workingDirectory) {
-      window.electronAPI
-        ?.getGitBranch?.(workingDirectory)
-        .then((branch: string | null) => {
-          if (!cancelled) {
-            setGitBranch(branch);
-          }
-        });
+    if (!workingDirectory || workingDirectory === sessionFolderPath) {
+      return;
     }
+
+    window.electronAPI
+      ?.getGitBranch?.(workingDirectory)
+      .then((branch: string | null) => {
+        if (!cancelled) {
+          setGitBranch(branch);
+        }
+      });
 
     return () => {
       cancelled = true;
     };
-  }, [workingDirectory]);
+  }, [workingDirectory, sessionFolderPath]);
 
   // Reset filter, refresh history, and focus input when popover opens
   React.useEffect(() => {

--- a/packages/desktop/packages/server-core/src/handlers/rpc/system.git-branch.test.ts
+++ b/packages/desktop/packages/server-core/src/handlers/rpc/system.git-branch.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { execSync } from 'child_process'
+import { RPC_CHANNELS } from '@craft-agent/shared/protocol'
+import type { HandlerDeps } from '../handler-deps'
+import type {
+  HandlerFn,
+  RequestContext,
+  RpcServer,
+} from '@craft-agent/server-core/transport'
+import { registerSystemCoreHandlers } from './system'
+
+function createGetGitBranchHandler() {
+  const handlers = new Map<string, HandlerFn>()
+  const server: RpcServer = {
+    handle(channel, handler) {
+      handlers.set(channel, handler)
+    },
+    push() {},
+    async invokeClient() {
+      return undefined
+    },
+  }
+
+  const deps: HandlerDeps = {
+    sessionManager: {} as HandlerDeps['sessionManager'],
+    oauthFlowStore: {} as HandlerDeps['oauthFlowStore'],
+    platform: {
+      appRootPath: '/',
+      resourcesPath: '/',
+      isPackaged: false,
+      appVersion: '0.0.0-test',
+      isDebugMode: true,
+      logger: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
+      imageProcessor: {
+        getMetadata: async () => null,
+        process: async () => Buffer.from(''),
+      },
+    },
+  }
+
+  registerSystemCoreHandlers(server, deps)
+
+  const handler = handlers.get(RPC_CHANNELS.git.GET_BRANCH)
+  if (!handler) {
+    throw new Error('GET_BRANCH handler not registered')
+  }
+  return handler
+}
+
+function git(cwd: string, command: string): string {
+  return execSync(`git ${command}`, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim()
+}
+
+describe('registerSystemCoreHandlers GET_BRANCH', () => {
+  it('returns the current branch name', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'qwen-git-branch-'))
+    const ctx: RequestContext = {
+      clientId: 'client-1',
+      workspaceId: null,
+      webContentsId: null,
+    }
+    try {
+      git(dir, 'init -b feature/test-branch')
+      git(dir, 'config user.name Test')
+      git(dir, 'config user.email test@example.com')
+      git(dir, 'commit --allow-empty -m initial')
+
+      const getGitBranch = createGetGitBranchHandler()
+
+      await expect(getGitBranch(ctx, dir)).resolves.toBe('feature/test-branch')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('returns null for detached HEAD', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'qwen-git-branch-'))
+    const ctx: RequestContext = {
+      clientId: 'client-1',
+      workspaceId: null,
+      webContentsId: null,
+    }
+    try {
+      git(dir, 'init')
+      git(dir, 'config user.name Test')
+      git(dir, 'config user.email test@example.com')
+      git(dir, 'commit --allow-empty -m initial')
+      const commit = git(dir, 'rev-parse HEAD')
+      git(dir, `checkout --detach ${commit}`)
+
+      const getGitBranch = createGetGitBranchHandler()
+
+      await expect(getGitBranch(ctx, dir)).resolves.toBeNull()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/desktop/packages/server-core/src/handlers/rpc/system.ts
+++ b/packages/desktop/packages/server-core/src/handlers/rpc/system.ts
@@ -214,7 +214,7 @@ export function registerSystemCoreHandlers(
         stdio: ['pipe', 'pipe', 'pipe'],
         timeout: 5000,
       }).trim()
-      return branch || null
+      return branch && branch !== 'HEAD' ? branch : null
     } catch {
       return null
     }


### PR DESCRIPTION
## Summary

Follow-up to #5082 review feedback:
- skip `getGitBranch` when the selected working directory is the session folder
- hide detached HEAD by normalizing the core git branch RPC result to `null`
- add branch-name coverage for both normal branch and detached HEAD handling

## Validation

- `git diff --check`
- `npx prettier --check packages/desktop/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx packages/desktop/packages/server-core/src/handlers/rpc/system.ts packages/desktop/packages/server-core/src/handlers/rpc/system.git-branch.test.ts`
- `npm run typecheck` in `packages/desktop/packages/server-core`
- `npx --yes bun@latest test packages/server-core/src/handlers/rpc/system.git-branch.test.ts` in `packages/desktop`

Also tried `npm run lint` and `npm run typecheck` in `packages/desktop/apps/electron`; both currently fail on existing unrelated issues outside this patch.

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.