### PR TITLE
docs(cli): document tmux scroll workaround

### DIFF
--- a/docs/users/reference/keyboard-shortcuts.md
+++ b/docs/users/reference/keyboard-shortcuts.md
@@ -83,6 +83,12 @@ Active only when `ui.useTerminalBuffer` is enabled (Settings → UI → Virtuali
 
 When `ui.useTerminalBuffer` is on, the terminal forwards mouse events to qwen-code so the wheel can drive the in-app viewport. As a side effect, **native click-and-drag text selection is consumed by the program** — hold `Shift` (or `Option` on macOS Terminal / iTerm) while dragging to bypass mouse capture and select text the usual way.
 
+### tmux trackpad scrolling
+
+Inside tmux, some terminals translate trackpad or wheel gestures into plain `Up Arrow` and `Down Arrow` sequences before qwen-code sees them. Those bytes are identical to real arrow-key presses, so qwen-code cannot tell whether you meant to scroll the viewport or navigate prompt history.
+
+If trackpad scrolling changes the prompt history in tmux, enable `ui.useTerminalBuffer`; then use `Shift+Up` / `Shift+Down`, or the mouse wheel when tmux forwards wheel events to the app. If you prefer host scrollback, adjust your tmux mouse bindings for wheel events.
+
 ## IDE Integration
 
 | Shortcut | Description                       |

--- a/docs/users/support/troubleshooting.md
+++ b/docs/users/support/troubleshooting.md
@@ -85,6 +85,11 @@ This guide provides solutions to common issues and debugging tips, including top
   - **Cause:** The `DEBUG` and `DEBUG_MODE` variables are automatically excluded from project `.env` files to prevent interference with the CLI behavior.
   - **Solution:** Use a `.qwen/.env` file instead, or configure the `advanced.excludedEnvVars` setting in your `settings.json` to exclude fewer variables.
 
+- **Trackpad scrolling in tmux changes prompt history instead of scrolling the conversation**
+  - **Issue:** In a tmux session, trackpad or wheel scrolling may cycle through previous prompts, similar to pressing `Up Arrow` or `Down Arrow`.
+  - **Cause:** tmux can translate wheel gestures into plain arrow-key sequences. Those sequences are indistinguishable from real arrow-key presses by the time qwen-code receives them.
+  - **Solution:** Enable `ui.useTerminalBuffer`; then use `Shift+Up` / `Shift+Down`, or the mouse wheel when tmux forwards wheel events to the app. If you prefer host scrollback, adjust your tmux mouse bindings for wheel events.
+
 ## IDE Companion not connecting
 
 - Ensure VS Code has a single workspace folder open.


### PR DESCRIPTION
## What this PR does

Documents the tmux trackpad/wheel scrolling limitation in the keyboard shortcut reference and troubleshooting guide. It explains that tmux can translate wheel gestures into plain Up/Down arrow sequences, which qwen-code cannot distinguish from real prompt-history navigation keys, and points users to the supported workarounds.

## Why it's needed

Issue #5159 reports trackpad scrolling in tmux cycling prompt history instead of scrolling the conversation. The issue triage identified this as a tmux escape-sequence limitation rather than a reliable client-side detection problem, so the safest fix is to make the limitation and the correct `ui.useTerminalBuffer` workaround discoverable in user docs.

## Reviewer Test Plan

### How to verify

Review `docs/users/reference/keyboard-shortcuts.md` and `docs/users/support/troubleshooting.md` and confirm the tmux workaround mentions `ui.useTerminalBuffer`, `Shift+Up` / `Shift+Down`, mouse wheel forwarding, and tmux-side wheel bindings without referencing the non-existent `ui.scrollMode` setting.

### Evidence (Before & After)

Before: the keyboard shortcut reference documented history scrollback keys but did not call out the tmux trackpad case from #5159, and the troubleshooting guide had no searchable entry for this behavior. After: both docs explain why tmux wheel gestures can become prompt-history navigation and how users can work around it.

Validation run locally: `npx prettier --check docs/users/reference/keyboard-shortcuts.md docs/users/support/troubleshooting.md` and `git diff --check`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Docs-only change. Local validation used Prettier and `git diff --check`; no runtime session was required.

## Risk & Scope

- Main risk or tradeoff: This documents a workaround rather than adding a fragile heuristic to guess whether bare Up/Down came from tmux wheel translation.
- Not validated / out of scope: Manual macOS tmux trackpad reproduction and terminal-specific tmux wheel binding examples.
- Breaking changes / migration notes: None.

## Linked Issues

Closes #5159

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

本文档 PR 在快捷键参考和 troubleshooting 指南中补充 tmux 触控板/滚轮滚动限制。它说明 tmux 可能会把滚轮手势转换成普通的 Up/Down 方向键序列，而 qwen-code 无法区分这些序列和真实的 prompt history 导航按键，并指向已支持的 workaround。

## Why it's needed

Issue #5159 报告了在 tmux 中用触控板滚动会切换 prompt history，而不是滚动对话内容。issue triage 已确认这是 tmux 转义序列层面的限制，而不是客户端能可靠检测的问题，因此最安全的修复是把这个限制和正确的 `ui.useTerminalBuffer` workaround 写进用户文档。

## Reviewer Test Plan

### How to verify

查看 `docs/users/reference/keyboard-shortcuts.md` 和 `docs/users/support/troubleshooting.md`，确认 tmux workaround 提到了 `ui.useTerminalBuffer`、`Shift+Up` / `Shift+Down`、mouse wheel forwarding 和 tmux 侧 wheel bindings，并且没有引用不存在的 `ui.scrollMode` 设置。

### Evidence (Before & After)

Before：快捷键参考文档记录了 history scrollback 快捷键，但没有说明 #5159 里的 tmux 触控板场景；troubleshooting 指南也没有可搜索的对应条目。After：两处文档都说明了为什么 tmux 滚轮手势可能变成 prompt history 导航，以及用户可以怎样绕过。

本地验证已运行：`npx prettier --check docs/users/reference/keyboard-shortcuts.md docs/users/support/troubleshooting.md` 和 `git diff --check`。

### Tested on

见上方 OS 表。本 PR 是 docs-only 改动，Windows/Linux 不适用。

### Environment (optional)

仅文档改动。本地验证使用 Prettier 和 `git diff --check`；不需要运行时会话。

## Risk & Scope

- Main risk or tradeoff：本 PR 文档化 workaround，而不是加入脆弱的启发式逻辑去猜测裸 Up/Down 是否来自 tmux 滚轮转换。
- Not validated / out of scope：没有手动复现 macOS tmux 触控板场景，也没有提供各终端专属的 tmux wheel binding 示例。
- Breaking changes / migration notes：无。

## Linked Issues

Closes #5159

</details>
