### PR TITLE
ci(release): report required Test checks on release PRs and auto-approve

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,9 @@ jobs:
   test:
     name: 'Test (${{ matrix.os }}, Node ${{ matrix.node-version }})'
     needs: 'classify_pr'
-    if: "${{ !cancelled() && needs.classify_pr.outputs.skip_ci != 'true' }}"
+    # Stay running on release-sync PRs so the required Test contexts still
+    # report; the per-step skip_ci guards below make them no-op (pass) there.
+    if: "${{ !cancelled() }}"
     runs-on: '${{ matrix.os }}'
     permissions:
       contents: 'read'
@@ -176,9 +178,11 @@ jobs:
             upload-coverage: 'false'
     steps:
       - name: 'Checkout'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
         uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
 
       - name: 'Set up Node.js ${{ matrix.node-version }}'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
         uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # v6.4.0
         with:
           node-version: '${{ matrix.node-version }}'
@@ -187,6 +191,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org/'
 
       - name: 'Configure npm for rate limiting'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
         run: |-
           npm config set fetch-retry-mintimeout 20000
           npm config set fetch-retry-maxtimeout 120000
@@ -194,17 +199,19 @@ jobs:
           npm config set fetch-timeout 300000
 
       - name: 'Install dependencies'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
         run: |-
           npm ci --prefer-offline --no-audit --progress=false
 
       - name: 'Run tests and generate reports'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
         env:
           NO_COLOR: true
         run: 'npm run test:ci'
 
       - name: 'Publish Test Report (for non-forks)'
         if: |-
-          ${{ always() && (github.event.pull_request.head.repo.full_name == github.repository) }}
+          ${{ always() && needs.classify_pr.outputs.skip_ci != 'true' && (github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: 'dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3' # ratchet:dorny/test-reporter@v2
         with:
           name: 'Test Results (${{ matrix.os }}, Node ${{ matrix.node-version }})'
@@ -214,7 +221,7 @@ jobs:
 
       - name: 'Upload Test Results Artifact (for forks)'
         if: |-
-          ${{ always() && (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
+          ${{ always() && needs.classify_pr.outputs.skip_ci != 'true' && (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
         uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' # v7.0.1
         with:
           name: 'test-results-fork-${{ matrix.node-version }}-${{ matrix.os }}'
@@ -222,7 +229,7 @@ jobs:
 
       - name: 'Upload coverage reports'
         if: |-
-          ${{ always() && matrix.upload-coverage == 'true' }}
+          ${{ always() && needs.classify_pr.outputs.skip_ci != 'true' && matrix.upload-coverage == 'true' }}
         uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' # v7.0.1
         with:
           name: 'coverage-reports-${{ matrix.node-version }}-${{ matrix.os }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
     needs: 'classify_pr'
     # Stay running on release-sync PRs so the required Test contexts still
     # report; the per-step skip_ci guards below make them no-op (pass) there.
-    if: "${{ !cancelled() }}"
+    if: '${{ !cancelled() }}'
     runs-on: '${{ matrix.os }}'
     permissions:
       contents: 'read'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -483,6 +483,18 @@ jobs:
 
           echo "PR_URL=${pr_url}" >> "${GITHUB_OUTPUT}"
 
+      - name: 'Approve release PR'
+        if: |-
+          ${{ needs.prepare.outputs.is_dry_run == 'false' && needs.prepare.outputs.is_nightly == 'false' && needs.prepare.outputs.is_preview == 'false' }}
+        env:
+          # Separate bot account from the PR author (CI_BOT_PAT) so GitHub
+          # allows the approval; covers one of the two required reviews.
+          GITHUB_TOKEN: '${{ secrets.CI_DEV_BOT_PAT }}'
+          PR_URL: '${{ steps.pr.outputs.PR_URL }}'
+        run: |-
+          set -euo pipefail
+          gh pr review "${PR_URL}" --approve --body "Automated approval for the release version bump."
+
       - name: 'Enable auto-merge for release PR'
         if: |-
           ${{ needs.prepare.outputs.is_dry_run == 'false' && needs.prepare.outputs.is_nightly == 'false' && needs.prepare.outputs.is_preview == 'false' }}


### PR DESCRIPTION
## What this PR does

Two changes to the automated release flow, both aimed at letting the `chore(release): vX.Y.Z` version-bump PR merge without manual babysitting.

First, it fixes a deadlock in CI for release-sync PRs. `classify_pr` detects these PRs and sets `skip_ci=true`, and the `test` job carried that condition at the **job level**. A matrix job skipped at job level never expands, so the per-OS contexts `Test (ubuntu-latest, Node 22.x)`, `Test (macos-latest, Node 22.x)`, and `Test (windows-latest, Node 22.x)` — which are required by branch protection — were never reported. The PR then sat forever waiting for status checks that would never arrive. This moves the `skip_ci` guard from the job level down to each working step. The job (and its matrix) now always runs, but on release PRs every step no-ops, so each required context reports a work-free success that satisfies branch protection.

Second, it adds an `Approve release PR` step in `release.yml` that uses `CI_DEV_BOT_PAT` to approve the release PR right after it is created. `main` requires two approving reviews; this covers one of them automatically, so a maintainer only has to add the second.

## Why it's needed

Release PRs like #5243 currently cannot auto-merge: the required `Test (...)` contexts never report (so `mergeStateStatus` stays blocked), and the two required approvals are entirely manual. The release job already enables auto-merge, but it can never fire. After this change the required checks report, one approval is supplied by the bot, and the release PR is one human click away from merging.

## Reviewer Test Plan

### How to verify

The behavior only manifests on an actual release-sync PR (head `release/*`, title `chore(release):`, author `qwen-code-ci-bot`, same-repo), so this is verified by reading the workflow logic plus YAML validation rather than a local run.

- The `test` job `if` no longer references `skip_ci`; it is now `${{ !cancelled() }}`, so the matrix always expands and the three required `Test (...)` contexts are always created.
- Every working step in `test` (Checkout, Set up Node, Configure npm, Install dependencies, Run tests) and the three `always()` upload/report steps now carry `needs.classify_pr.outputs.skip_ci != 'true'`, so on a release PR they all skip and the job concludes as success with no work done.
- On a normal PR / fork PR, `skip_ci` is `false`, so every step runs exactly as before — no behavior change.
- `release.yml` approves the PR with `CI_DEV_BOT_PAT` before enabling auto-merge.

Prerequisites this PR depends on (repo config, not code): `CI_DEV_BOT_PAT` must belong to a bot account distinct from the PR author `qwen-code-ci-bot` (GitHub forbids self-approval) and that account must have write access for the approval to count. Both are confirmed in place.

### Evidence (Before & After)

N/A — CI/workflow change, no user-visible or TUI output. `actionlint` and YAML parsing pass for both files.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

N/A — workflow-only change; no local runtime involved.

## Risk & Scope

- Main risk or tradeoff: on release-sync PRs the required `Test (...)` checks report success without actually running tests. This is intentional — the release was already validated by `quality` + `integration` in `release.yml` before publishing, so re-running on the version-bump PR is redundant. The skip path is gated by all four `classify_pr` conditions, so it cannot be triggered by a normal or fork PR.
- Not validated / out of scope: end-to-end behavior of the real release run (cannot be exercised locally); the second required approval still needs a human.
- Breaking changes / migration notes: none. Branch protection is unchanged.

## Linked Issues

Surfaced by the stuck release PR #5243 (referenced, not auto-closing).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

对自动 release 流程做两处改动，目标都是让 `chore(release): vX.Y.Z` 版本号 PR 不用人工盯着就能合并。

其一，修复 release-sync PR 在 CI 上的死锁。`classify_pr` 会识别这类 PR 并设 `skip_ci=true`，而 `test` job 之前把这个条件写在 **job 级**。matrix job 在 job 级被跳过时根本不会展开，于是分支保护要求的三个 per-OS context `Test (ubuntu-latest, Node 22.x)` / macos / windows 永远不会上报，PR 就一直卡在等待这些永远不会到来的状态检查上。本 PR 把 `skip_ci` 守卫从 job 级下沉到每个干活的 step：job（及其 matrix）始终运行，但在 release PR 上每个 step 都空跑，于是每个 required context 都报一个“没干活的 success”，满足分支保护。

其二，在 `release.yml` 新增 `Approve release PR` 步骤，在 PR 创建后立即用 `CI_DEV_BOT_PAT` 自动 approve。`main` 要求两个 approve，这一步自动覆盖其中一个，维护者只需再点一次。

## 为什么需要

像 #5243 这样的 release PR 目前无法自动合并：required 的 `Test (...)` context 从不上报（`mergeStateStatus` 一直 blocked），两个 required approve 也全靠手动。release job 虽然已开启 auto-merge，但永远触发不了。改完后 required check 能上报、一个 approve 由 bot 提供，release PR 离合并只差一次人工点击。

## 审查验证

该行为只在真实的 release-sync PR（head `release/*`、标题 `chore(release):`、作者 `qwen-code-ci-bot`、同仓库）上出现，因此通过审阅工作流逻辑 + YAML 校验来验证，而非本地运行。

- `test` job 的 `if` 不再引用 `skip_ci`，改为 `${{ !cancelled() }}`，matrix 始终展开，三个 required `Test (...)` context 始终被创建。
- `test` 里所有干活的 step（Checkout / Set up Node / Configure npm / Install deps / Run tests）以及三个带 `always()` 的上传/报告 step 都加上了 `skip_ci != 'true'`，release PR 上全部跳过，job 以 success 收尾且不做任何实际工作。
- 普通 PR / fork PR 上 `skip_ci` 为 `false`，每个 step 行为与之前完全一致，无变化。
- `release.yml` 在开启 auto-merge 之前用 `CI_DEV_BOT_PAT` approve 该 PR。

依赖的前提（属仓库配置，非代码）：`CI_DEV_BOT_PAT` 必须是与 PR 作者 `qwen-code-ci-bot` 不同的 bot 账号（GitHub 禁止给自己的 PR approve），且该账号需有 write 权限，approve 才计入 required reviews。两者均已确认到位。

## 风险与范围

- 主要权衡：release-sync PR 上 required `Test (...)` check 会在不真正跑测试的情况下报 success。这是有意为之——release 在发布前已由 `release.yml` 的 `quality` + `integration` 验证过，版本号 PR 再跑一遍属冗余。跳过路径受 `classify_pr` 四个条件共同约束，普通 PR / fork PR 无法触发。
- 未验证 / 范围外：真实 release 运行的端到端行为（无法本地复现）；第二个 required approve 仍需人工。
- 破坏性变更：无。分支保护不变。

</details>
