### PR TITLE
fix: Expand Windows ~\\ home paths and hide phantom (session) entries in the desktop session list

### DIFF
--- a/packages/desktop/packages/server-core/src/sessions/SessionManager.test.ts
+++ b/packages/desktop/packages/server-core/src/sessions/SessionManager.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'bun:test'
+import type { Message } from '@craft-agent/core/types'
+import type { Workspace } from '@craft-agent/shared/config'
+import { createManagedSession, SessionManager } from './SessionManager.ts'
+
+type TestManagedSession = ReturnType<typeof createManagedSession>
+
+const workspace: Workspace = {
+  id: 'workspace-qwen',
+  name: 'qwen-code',
+  slug: 'qwen-code',
+  rootPath: '/tmp/qwen-code',
+  createdAt: Date.parse('2026-06-17T12:00:00.000Z'),
+}
+
+function addSession(
+  manager: SessionManager,
+  managed: TestManagedSession,
+): void {
+  (
+    manager as unknown as { sessions: Map<string, TestManagedSession> }
+  ).sessions.set(managed.id, managed)
+}
+
+describe('SessionManager Qwen canonical mirror filtering', () => {
+  it('hides empty placeholder mirrors even when they have timestamps', () => {
+    const manager = new SessionManager()
+    const sessionId = '8390af4d-5db6-4e4c-b7e8-040d002690c7'
+    const timestamp = Date.parse('2026-06-17T10:15:30.000Z')
+
+    addSession(
+      manager,
+      createManagedSession(
+        {
+          id: sessionId,
+          sdkSessionId: sessionId,
+          name: '(session)',
+          messageCount: 0,
+          createdAt: timestamp,
+          lastUsedAt: timestamp,
+          lastMessageAt: timestamp,
+          llmConnection: 'qwen-code',
+        },
+        workspace,
+      ),
+    )
+
+    expect(manager.getSessions(workspace.id)).toEqual([])
+  })
+
+  it('keeps external sessions with a real title or content', () => {
+    const manager = new SessionManager()
+    const titledSessionId = '12eb7d24-4c31-4ff5-8a9b-f243f9fd1b28'
+    const contentSessionId = 'bbc6bd08-a4f7-4b50-b605-51dbe51ea2de'
+    const timestamp = Date.parse('2026-06-17T10:15:30.000Z')
+
+    addSession(
+      manager,
+      createManagedSession(
+        {
+          id: titledSessionId,
+          sdkSessionId: titledSessionId,
+          name: 'Investigate Windows path expansion',
+          messageCount: 0,
+          lastMessageAt: timestamp,
+          llmConnection: 'qwen-code',
+        },
+        workspace,
+      ),
+    )
+    addSession(
+      manager,
+      createManagedSession(
+        {
+          id: contentSessionId,
+          sdkSessionId: contentSessionId,
+          name: '(session)',
+          lastMessageAt: timestamp - 1,
+          llmConnection: 'qwen-code',
+        },
+        workspace,
+        {
+          messages: [
+            {
+              id: 'msg_1',
+              role: 'user',
+              content: 'real conversation content',
+              timestamp,
+            } as Message,
+          ],
+        },
+      ),
+    )
+
+    expect(
+      manager
+        .getSessions(workspace.id)
+        .map((session) => session.id)
+        .sort(),
+    ).toEqual([contentSessionId, titledSessionId].sort())
+  })
+
+  it('treats malformed empty placeholder records as filterable', () => {
+    const manager = new SessionManager()
+    const sessionId = 'malformed-placeholder'
+    const internals = manager as unknown as {
+      isUnresolvedQwenCanonicalMirror: (
+        managed: Record<string, unknown>,
+      ) => boolean
+    }
+    const malformed = {
+      id: sessionId,
+      sdkSessionId: sessionId,
+      name: '(session)',
+      messageCount: 0,
+      createdAt: Date.parse('2026-06-17T10:15:30.000Z'),
+      lastMessageAt: Date.parse('2026-06-17T10:15:30.000Z'),
+      llmConnection: 'qwen-code',
+    }
+
+    expect(() =>
+      internals.isUnresolvedQwenCanonicalMirror(malformed),
+    ).not.toThrow()
+    expect(internals.isUnresolvedQwenCanonicalMirror(malformed)).toBe(true)
+  })
+})

--- a/packages/desktop/packages/server-core/src/sessions/SessionManager.ts
+++ b/packages/desktop/packages/server-core/src/sessions/SessionManager.ts
@@ -2868,7 +2868,7 @@ export class SessionManager implements ISessionManager {
   }
 
   private hasNoRenderableLocalMessages(managed: ManagedSession): boolean {
-    const loadedMessageCount = managed.messages.length
+    const loadedMessageCount = managed.messages?.length ?? 0
     const persistedMessageCount = managed.messageCount ?? loadedMessageCount
     return loadedMessageCount === 0 && persistedMessageCount === 0
   }
@@ -2882,16 +2882,11 @@ export class SessionManager implements ISessionManager {
       QWEN_CODE_CONNECTION_SLUG
     )
       return false
-    if (managed.messages.length > 0) return false
-    if (managed.name && !this.isExternalSessionPlaceholderTitle(managed.name))
+    if (!this.hasNoRenderableLocalMessages(managed)) return false
+    const title = typeof managed.name === 'string' ? managed.name : undefined
+    if (title && !this.isExternalSessionPlaceholderTitle(title))
       return false
     if (managed.preview || managed.lastMessageRole) return false
-    if (
-      [managed.createdAt, managed.lastUsedAt, managed.lastMessageAt].some(
-        (timestamp) => typeof timestamp === 'number' && timestamp > 0,
-      )
-    )
-      return false
 
     return true
   }

--- a/packages/desktop/packages/shared/src/utils/__tests__/paths.test.ts
+++ b/packages/desktop/packages/shared/src/utils/__tests__/paths.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'bun:test'
+import { homedir } from 'node:os'
+import { join, normalize, resolve } from 'node:path'
+import { expandPath } from '../paths.ts'
+
+describe('expandPath', () => {
+  it('expands Windows-style tilde paths under home', () => {
+    expect(expandPath('~\\.craft-agent\\foo')).toBe(
+      join(homedir(), '.craft-agent', 'foo'),
+    )
+  })
+
+  it('expands bare Windows-style tilde prefixes', () => {
+    expect(expandPath('~\\')).toBe(normalize(homedir()))
+  })
+
+  it('keeps existing home expansion behavior', () => {
+    expect(expandPath('~')).toBe(homedir())
+    expect(expandPath('~/Documents')).toBe(join(homedir(), 'Documents'))
+    expect(expandPath('${HOME}/projects')).toBe(join(homedir(), 'projects'))
+    expect(expandPath('$HOME/projects')).toBe(join(homedir(), 'projects'))
+  })
+
+  it('keeps absolute and relative path behavior unchanged', () => {
+    const absolutePath = join(homedir(), 'already-absolute')
+    const basePath = join(homedir(), 'base')
+
+    expect(expandPath(absolutePath, basePath)).toBe(normalize(absolutePath))
+    expect(expandPath('relative/path', basePath)).toBe(
+      resolve(basePath, 'relative/path'),
+    )
+  })
+})

--- a/packages/desktop/packages/shared/src/utils/paths.ts
+++ b/packages/desktop/packages/shared/src/utils/paths.ts
@@ -33,9 +33,15 @@ export function expandPath(inputPath: string, basePath?: string): string {
     return home;
   }
 
-  // Handle ~/ prefix
-  if (expanded.startsWith('~/')) {
-    expanded = join(home, expanded.slice(2));
+  // Handle ~/ and ~\ prefixes
+  if (expanded.startsWith('~/') || expanded.startsWith('~\\')) {
+    expanded = join(
+      home,
+      ...expanded
+        .slice(2)
+        .split(/[/\\]+/)
+        .filter(Boolean),
+    );
   }
 
   // Handle ${HOME} and $HOME variables


### PR DESCRIPTION
## What this PR does

This PR fixes two related defects that surface on the Windows desktop client after running certain skill/tool tasks: phantom conversations titled `(session)` showing up in the session list, and a literal `~` folder being created under the app install directory.

1. **Windows `~\` home-path expansion** (`packages/desktop/packages/shared/src/utils/paths.ts`): `expandPath()` previously only expanded the Unix-style `~/` prefix. A Windows-style `~\Documents\...` or `~\.craft-agent\...` path fell through to the relative-path branch and was resolved against the process working directory — which on the desktop app is the install directory — creating a stray literal `~` folder. The fix extends the tilde branch to also match `~\`, splitting the remainder on either separator (`/` or `\`) and joining each segment against the home directory, so Windows-style home paths expand correctly. This mirrors the dual-separator handling already used elsewhere in the codebase.

2. **Hide empty `(session)` placeholder mirrors in the desktop session list** (`packages/desktop/packages/server-core/src/sessions/SessionManager.ts`): The phantom `(session)` entries are unresolved Qwen canonical-mirror placeholders with zero messages and no preview/content. The previous `isUnresolvedQwenCanonicalMirror()` logic short-circuited to "show this session" whenever any of its `createdAt` / `lastUsedAt` / `lastMessageAt` timestamps was non-zero — which these placeholders always have — so they were never filtered out. The fix:
   - removes that timestamp short-circuit so a non-zero timestamp no longer forces an empty placeholder to be shown;
   - routes the empty-content check through `hasNoRenderableLocalMessages()`, which considers both the loaded message array and the persisted `messageCount`;
   - hardens the helpers against malformed records by null-safely reading `managed.messages?.length ?? 0` and by only treating `managed.name` as a title when it is actually a string.

   Net effect: empty `(session)` placeholders are filtered out of the session list, while sessions with a real title or real message content continue to be shown.

## Why it's needed

On the Windows desktop client (Desktop v0.04), running skill/tool tasks produced extra `(session)` conversations the user never created — they open with no real chat content, only tool-call/execution records or nearly empty — and also caused a literal `~` directory to be created under the app install directory. Per issue #5244, the expected behavior is: `~\...` should expand to the user home just like `~/...`, no literal `~` folder should be created under the install directory, and empty external sessions (zero `messageCount`, no preview/prompt/title) should not appear as user-visible conversations in the main session list.

## Reviewer Test Plan

### How to verify

- **Windows path expansion** — call `expandPath('~\\.craft-agent\\foo')` and confirm it returns `join(homedir(), '.craft-agent', 'foo')` rather than a path under the current working directory; confirm `expandPath('~\\')` resolves to the home directory; confirm the existing `~`, `~/`, `$HOME`, `${HOME}` cases are unchanged. These are covered by the new unit tests in `packages/desktop/packages/shared/src/utils/__tests__/paths.test.ts`.
- **Phantom session filtering** — construct a `(session)` managed session with zero messages and non-zero timestamps and confirm `getSessions()` no longer returns it; confirm sessions with a real title or real message content are still returned; confirm `isUnresolvedQwenCanonicalMirror()` does not throw on a malformed placeholder record. These are covered by the new unit tests in `packages/desktop/packages/server-core/src/sessions/SessionManager.test.ts`.
- Standard workspace gates apply: lint, typecheck, and the full test suite (run via the repo's npm workspace scripts).

### Evidence (Before & After)

N/A — non-visible logic/path-handling fixes; behavior is covered by the new unit tests above. The user-facing symptom (phantom `(session)` rows in the desktop session list) is documented with screenshots in issue #5244; this change removes those rows by filtering empty placeholder mirrors.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI |
| 🪟 Windows |  ✅ CI |
|  🐧 Linux  |  ✅ CI |

✅ tested · ⚠️ not tested · N/A

### Environment (optional)

Unit tests added for both fixes; validated through the repository CI matrix (Node 22.x on ubuntu/macos/windows-latest).

## Risk & Scope

- Main risk or tradeoff: Low; scoped to the desktop shared `expandPath()` helper and the desktop `SessionManager` placeholder-filtering logic. The path change only adds a new `~\` branch and broadens segment splitting; the session change only stops showing empty `(session)` placeholders that have a timestamp.
- Not validated / out of scope: No unrelated refactors, no public API changes, no UI redesigns; non-Windows path behavior is unchanged.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5244

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

本 PR 修复了在 Windows 桌面端运行某些 skill / tool 任务后出现的两个相关缺陷：会话列表中出现名为 `(session)` 的幽灵会话，以及在应用安装目录下创建出一个字面量 `~` 文件夹。

1. **Windows `~\` home 路径展开**（`packages/desktop/packages/shared/src/utils/paths.ts`）：`expandPath()` 之前只展开 Unix 风格的 `~/` 前缀。Windows 风格的 `~\Documents\...` 或 `~\.craft-agent\...` 路径不会被命中，落到相对路径分支，被解析到进程当前工作目录下——在桌面应用里就是安装目录——从而创建出一个多余的字面量 `~` 文件夹。修复方式是把波浪号分支扩展为同时匹配 `~\`，把剩余部分按任意分隔符（`/` 或 `\`）切分后逐段与 home 目录拼接，使 Windows 风格的 home 路径能正确展开。这与代码库其他位置已有的双分隔符处理保持一致。

2. **在桌面会话列表中隐藏空的 `(session)` 占位镜像**（`packages/desktop/packages/server-core/src/sessions/SessionManager.ts`）：这些幽灵 `(session)` 条目是未解析的 Qwen canonical-mirror 占位记录，消息数为零、没有预览/内容。之前的 `isUnresolvedQwenCanonicalMirror()` 逻辑只要 `createdAt` / `lastUsedAt` / `lastMessageAt` 中任意一个时间戳非零，就会短路成"显示该会话"——而这些占位记录总是带有时间戳——所以它们永远不会被过滤掉。本次修复：
   - 移除该时间戳短路，使非零时间戳不再强制显示空占位记录；
   - 把空内容判断改为走 `hasNoRenderableLocalMessages()`，它会同时考虑已加载的消息数组和持久化的 `messageCount`；
   - 通过空安全地读取 `managed.messages?.length ?? 0`、并且只在 `managed.name` 确实是字符串时才将其当作标题，从而增强对畸形记录的健壮性。

   最终效果：空的 `(session)` 占位记录被从会话列表中过滤掉，而拥有真实标题或真实消息内容的会话继续正常显示。

## 为什么需要

在 Windows 桌面端（Desktop v0.04）上，运行 skill / tool 任务会产生用户从未主动创建的额外 `(session)` 会话——打开后没有真实聊天内容，只有工具调用 / 执行记录，或几乎为空——同时还会在应用安装目录下创建出一个字面量 `~` 目录。根据 issue #5244，预期行为是：`~\...` 应当像 `~/...` 一样展开到用户 home；安装目录下不应创建字面量 `~` 文件夹；`messageCount` 为零且没有 preview / prompt / title 的外部 session 不应出现在主会话列表中作为用户可见的普通对话。

## 审阅者测试计划

### 如何验证

- **Windows 路径展开**——调用 `expandPath('~\\.craft-agent\\foo')`，确认它返回 `join(homedir(), '.craft-agent', 'foo')`，而不是当前工作目录下的路径；确认 `expandPath('~\\')` 解析到 home 目录；确认已有的 `~`、`~/`、`$HOME`、`${HOME}` 用例行为不变。这些由 `packages/desktop/packages/shared/src/utils/__tests__/paths.test.ts` 中新增的单元测试覆盖。
- **幽灵会话过滤**——构造一个零消息、带非零时间戳的 `(session)` 受管会话，确认 `getSessions()` 不再返回它；确认拥有真实标题或真实消息内容的会话仍被返回；确认 `isUnresolvedQwenCanonicalMirror()` 在畸形占位记录上不抛异常。这些由 `packages/desktop/packages/server-core/src/sessions/SessionManager.test.ts` 中新增的单元测试覆盖。
- 标准工作区检查同样适用：lint、类型检查，以及完整测试套件（通过仓库的 npm workspace 脚本运行）。

### 证据（前后对比）

N/A——这是不可见的逻辑 / 路径处理修复，行为由上面新增的单元测试覆盖。用户可见症状（桌面会话列表中的幽灵 `(session)` 行）在 issue #5244 中已有截图记录；本次改动通过过滤空占位镜像移除了这些行。

### 测试平台

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI |
| 🪟 Windows |  ✅ CI |
|  🐧 Linux  |  ✅ CI |

✅ 已测试 · ⚠️ 未测试 · N/A

### 运行环境（可选）

为两处修复均新增了单元测试；通过仓库 CI 矩阵验证（Node 22.x，ubuntu / macos / windows-latest）。

## 风险与范围

- 主要风险或权衡：低；范围限定在桌面 shared 的 `expandPath()` 辅助函数和桌面 `SessionManager` 的占位过滤逻辑。路径改动只新增 `~\` 分支并扩展分段切分；会话改动只停止显示带时间戳的空 `(session)` 占位记录。
- 未验证 / 范围外：无无关重构、无公共 API 变更、无 UI 重设计；非 Windows 路径行为保持不变。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #5244

</details>
