### PR TITLE
docs: add CLI subcommands section with qwen sessions list

### DIFF
--- a/docs/users/features/commands.md
+++ b/docs/users/features/commands.md
@@ -526,3 +526,51 @@ Requirements:
 | Shell Escaping         | Prevent command injection  | Automatic processing   |
 | Execution Confirmation | Avoid accidental execution | Dialog confirmation    |
 | Error Reporting        | Help diagnose issues       | View error information |
+
+## 5. CLI Subcommands
+
+These commands are run from the shell as `qwen <subcommand>` before starting an interactive session.
+
+### Session Management
+
+| Command              | Description                       | Usage Examples                                               |
+| -------------------- | --------------------------------- | ------------------------------------------------------------ |
+| `qwen sessions list` | List recent conversation sessions | `qwen sessions list`, `qwen sessions list --json --limit 50` |
+
+#### `qwen sessions list`
+
+Lists your recent Qwen Code sessions with metadata.
+
+**Flags:**
+
+| Flag      | Type    | Default | Description                                     |
+| --------- | ------- | ------- | ----------------------------------------------- |
+| `--json`  | boolean | `false` | Output as JSON Lines (one JSON object per line) |
+| `--limit` | number  | `20`    | Maximum number of sessions to show              |
+
+**Human-readable output (default):**
+
+A table with columns: SESSION ID, STARTED (UTC timestamp), TITLE, BRANCH, PROMPT.
+
+**JSON output (`--json`):**
+
+Outputs JSON Lines on stdout. Each line is a JSON object with fields:
+
+```
+sessionId, startTime, mtime, prompt, gitBranch, customTitle, titleSource, filePath, cwd
+```
+
+The "has more sessions" hint is emitted via stderr so piping to `jq` remains safe.
+
+**Examples:**
+
+```bash
+# Show last 20 sessions (default)
+qwen sessions list
+
+# Show last 50 sessions
+qwen sessions list --limit 50
+
+# Output as JSON for scripting
+qwen sessions list --json | jq .
+```


### PR DESCRIPTION
## Summary

Adds documentation for the `qwen sessions list` CLI command to `docs/users/features/commands.md`. This command was added in commit 14e6ae8c2 but not documented.

## Changes

**docs/users/features/commands.md:**
- Added new section 5 "CLI Subcommands" for shell-level commands
- Documented `qwen sessions list` with:
  - Flag descriptions (`--json`, `--limit`)
  - Output format (table vs JSON Lines)
  - Usage examples
  - stderr behavior for safe piping

## Impact

- Documents the new sessions list command for users
- Establishes a pattern for documenting future CLI subcommands
- Provides clear examples for both interactive and scripting use cases

## Test Plan

- [ ] Verify `qwen sessions list` command exists and works as documented
- [ ] Confirm `--json` and `--limit` flags are available
- [ ] Check that documentation matches actual output format

## Additional Context

The `sessions list` command is the first subcommand under the `qwen sessions` namespace. Future subcommands (`show`, `rm`) are planned per issue #4825.