### PR TITLE
fix(core): detect dat files by content

### DIFF
--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -872,6 +872,31 @@ describe('fileUtils', () => {
       expect(await detectFileType(filePathForDetectTest)).toBe('text');
     });
 
+    it('uses content detection for text-looking .dat files', async () => {
+      mockMimeGetType.mockReturnValueOnce(null);
+      const filePath = path.join(tempRootDir, 'controller.dat');
+      actualNodeFs.writeFileSync(
+        filePath,
+        '<?php\nfunction handleRequest() {\n  return true;\n}\n',
+      );
+      try {
+        expect(await detectFileType(filePath)).toBe('text');
+      } finally {
+        actualNodeFs.unlinkSync(filePath);
+      }
+    });
+
+    it('still treats binary-looking .dat files as binary', async () => {
+      mockMimeGetType.mockReturnValueOnce(null);
+      const filePath = path.join(tempRootDir, 'payload.dat');
+      actualNodeFs.writeFileSync(filePath, Buffer.from([0x00, 0xff, 0x00]));
+      try {
+        expect(await detectFileType(filePath)).toBe('binary');
+      } finally {
+        actualNodeFs.unlinkSync(filePath);
+      }
+    });
+
     it('returns text for files with a text/* mime even when the content looks binary (issue #3964 encrypted FS)', async () => {
       // Frank-Shaw-FS reports `.cpp` / `.c` / `.h` source files on
       // Windows encrypted / DRM-protected file systems being
@@ -1246,6 +1271,19 @@ describe('fileUtils', () => {
         'Cannot display content of binary file',
       );
       expect(result.returnDisplay).toContain('Skipped binary file: app.exe');
+    });
+
+    it('should read text-looking .dat files as text', async () => {
+      const filePath = path.join(tempRootDir, 'legacy-controller.dat');
+      const content = '<?php echo "ok";\n';
+      actualNodeFs.writeFileSync(filePath, content);
+      mockMimeGetType.mockReturnValueOnce(null);
+
+      const result = await processSingleFileContent(filePath, mockConfig);
+
+      expect(result.llmContent).toBe(content);
+      expect(result.returnDisplay).toBe('');
+      expect(result.error).toBeUndefined();
     });
 
     it('should handle path being a directory', async () => {

--- a/packages/core/src/utils/ignorePatterns.test.ts
+++ b/packages/core/src/utils/ignorePatterns.test.ts
@@ -214,9 +214,12 @@ describe('BINARY_EXTENSIONS', () => {
   });
 
   it('should include additional binary extensions', () => {
-    expect(BINARY_EXTENSIONS).toContain('.dat');
     expect(BINARY_EXTENSIONS).toContain('.obj');
     expect(BINARY_EXTENSIONS).toContain('.wasm');
+  });
+
+  it('should not force generic data extensions to binary', () => {
+    expect(BINARY_EXTENSIONS).not.toContain('.dat');
   });
 
   it('should include media file extensions', () => {

--- a/packages/core/src/utils/ignorePatterns.ts
+++ b/packages/core/src/utils/ignorePatterns.ts
@@ -269,7 +269,6 @@ export const BINARY_EXTENSIONS: string[] = [
     ...PYTHON_EXCLUDES,
   ]),
   // Additional binary extensions not in the main patterns
-  '.dat',
   '.obj',
   '.o',
   '.a',


### PR DESCRIPTION
## What this PR does

Stops treating every `.dat` file as binary based on extension alone. `.dat` files now follow the existing content-based fallback: text-looking `.dat` files are read as text, while binary-looking `.dat` files with null bytes still classify as binary.

## Why it's needed

Issue #2845 reports source-like content, such as PHP code saved with a `.dat` extension, being skipped as binary. Since `.dat` is a generic data extension rather than an unambiguous binary format, extension-only blocking makes the file reader do the wrong thing for valid text payloads.

## Reviewer Test Plan

### How to verify

Run the focused core tests and checks below. The new tests cover text-looking `.dat` detection, binary-looking `.dat` detection, `processSingleFileContent` reading a `.dat` text file, and the `BINARY_EXTENSIONS` contract.

```bash
cd packages/core && npx vitest run src/utils/fileUtils.test.ts src/utils/ignorePatterns.test.ts src/tools/read-file.test.ts
npx eslint packages/core/src/utils/ignorePatterns.ts packages/core/src/utils/ignorePatterns.test.ts packages/core/src/utils/fileUtils.test.ts
cd packages/core && npm run typecheck
cd packages/core && npm run build
git diff --check
```

### Evidence (Before & After)

Before: `detectFileType()` returned `binary` for text-looking `.dat` files before checking file content, and `processSingleFileContent()` skipped them with `Cannot display content of binary file`. After: text-looking `.dat` files go through content sampling and are read as text; `.dat` files with null bytes still return `binary`.

Local validation passed: 183 focused Vitest tests, touched-file ESLint, core typecheck, core build, and `git diff --check`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS local checkout, Node/npm workspace scripts. Windows and Linux are left to CI.

## Risk & Scope

- Main risk or tradeoff: Some ASCII-only `.dat` payloads that previously skipped as binary will now be exposed as text. This is intentional for generic `.dat` files and keeps truly binary content protected by the existing null-byte/content heuristic.
- Not validated / out of scope: Manual testing against very large `.dat` files or every possible application-specific `.dat` format.
- Breaking changes / migration notes: No migration needed.

## Linked Issues

Fixes #2845

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 不再仅凭 `.dat` 扩展名把所有文件都判成 binary。`.dat` 文件现在会走现有的内容检测 fallback：看起来像文本的 `.dat` 会按文本读取，带 null byte、看起来像二进制的 `.dat` 仍会判为 binary。

## Why it's needed

Issue #2845 报告了类似 PHP 代码这类源码内容保存成 `.dat` 后被跳过为 binary 的问题。`.dat` 是泛化的数据扩展名，不是明确的二进制格式，所以只靠扩展名拦截会让文件读取逻辑错误处理合法的文本内容。

## Reviewer Test Plan

### How to verify

运行上面的 focused core tests 和检查。新增测试覆盖了文本 `.dat` 检测、二进制 `.dat` 检测、`processSingleFileContent` 读取 `.dat` 文本文件，以及 `BINARY_EXTENSIONS` 的约束。

### Evidence (Before & After)

Before：`detectFileType()` 会在检查内容之前直接把文本 `.dat` 返回为 `binary`，`processSingleFileContent()` 会用 `Cannot display content of binary file` 跳过它。After：文本 `.dat` 会进入内容采样并按文本读取；带 null byte 的 `.dat` 仍返回 `binary`。

本地验证已通过：183 个 focused Vitest tests、touched-file ESLint、core typecheck、core build 和 `git diff --check`。

### Tested on

见上方 OS 表。macOS 本地已测；Windows 和 Linux 交给 CI。

### Environment (optional)

macOS 本地 checkout，Node/npm workspace scripts。

## Risk & Scope

- Main risk or tradeoff：部分 ASCII-only `.dat` payload 以前会被跳过为 binary，现在会暴露为文本。这对泛化 `.dat` 文件是预期行为，同时真正的二进制内容仍受现有 null-byte/content heuristic 保护。
- Not validated / out of scope：未手动测试超大 `.dat` 文件或所有应用专属 `.dat` 格式。
- Breaking changes / migration notes：不需要迁移。

## Linked Issues

Fixes #2845

</details>
