### PR TITLE
docs: Revamp README for clarity and focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <a href="https://trendshift.io/repositories/15287" target="_blank"><img src="https://trendshift.io/api/badge/repositories/15287" alt="QwenLM%2Fqwen-code | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
-**An open-source AI agent that lives in your terminal.**
+**The open-source AI coding agent that lives in your terminal.**
 
 <a href="https://qwenlm.github.io/qwen-code-docs/zh/users/overview">中文</a> |
 <a href="https://qwenlm.github.io/qwen-code-docs/de/users/overview">Deutsch</a> |
@@ -18,471 +18,73 @@
 
 </div>
 
-## 🎉 News
-
-- **2026-04-15**: Qwen OAuth free tier has been discontinued. To continue using Qwen Code, switch to [Alibaba Cloud Coding Plan](https://modelstudio.console.alibabacloud.com/?tab=coding-plan#/efm/coding-plan-index), [OpenRouter](https://openrouter.ai), [Fireworks AI](https://app.fireworks.ai), or bring your own API key. Run `qwen auth` to configure.
-
-- **2026-04-13**: Qwen OAuth free tier policy update: daily quota adjusted to 100 requests/day (from 1,000).
-
-- **2026-04-02**: Qwen3.6-Plus is now live! Get an API key from [Alibaba Cloud ModelStudio](https://modelstudio.console.alibabacloud.com/ap-southeast-1?tab=doc#/doc/?type=model&url=2840914_2&modelId=qwen3.6-plus) to access it through the OpenAI-compatible API.
-
-- **2026-02-16**: Qwen3.5-Plus is now live!
-
 ## Why Qwen Code?
 
-Qwen Code is an open-source AI agent for the terminal, optimized for Qwen series models. It helps you understand large codebases, automate tedious work, and ship faster.
+- **Agentic out of the box** — Auto-Memory, Auto-Skills, SubAgents, Agent Teams, and MCP. Dynamic workflows, zero setup.
+- **Open-source, inside and out** — The framework and the Qwen models are open-source. They evolve together. No vendor lock-in.
+- **Multi-protocol** — Supports OpenAI, Anthropic, Gemini, and Qwen APIs. Any third-party provider or local model (Ollama / vLLM). Switch at runtime.
+- **Beyond the terminal** — IDE plugins, Desktop app, daemon mode, SDKs, and IM bots (Telegram / DingTalk / WeChat / Feishu).
 
-- **Multi-protocol, flexible providers**: use OpenAI / Anthropic / Gemini-compatible APIs, [Alibaba Cloud Coding Plan](https://modelstudio.console.alibabacloud.com/?tab=coding-plan#/efm/coding-plan-index), [OpenRouter](https://openrouter.ai), [Fireworks AI](https://app.fireworks.ai), or bring your own API key.
-- **Open-source, co-evolving**: both the framework and the Qwen3-Coder model are open-source—and they ship and evolve together.
-- **Agentic workflow, feature-rich**: rich built-in tools (Skills, SubAgents) for a full agentic workflow and a Claude Code-like experience.
-- **Terminal-first, IDE-friendly**: built for developers who live in the command line, with optional integration for VS Code, Zed, and JetBrains IDEs.
-
-![](https://gw.alicdn.com/imgextra/i1/O1CN01D2DviS1wwtEtMwIzJ_!!6000000006373-2-tps-1600-900.png)
+> [!TIP]
+> Qwen Code is actively iterating on itself — using its own agent and models to file issues, submit PRs, review code, run tests, and approve merges. It has already become the **#2 contributor** to this repository. Powered by the community, driven by AI.
 
 ## Installation
 
-### Quick Install (Recommended)
-
-#### Linux / macOS
+**Linux / macOS:**
 
 ```bash
 curl -fsSL https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com/installation/install-qwen-standalone.sh | bash
 ```
 
-#### Windows
+**Windows:**
 
 ```powershell
 irm https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com/installation/install-qwen-standalone.ps1 | iex
 ```
 
-> **Note**: It's recommended to restart your terminal after installation to ensure environment variables take effect.
+> Restart your terminal after installation to ensure environment variables take effect.
 
-### Manual Installation
+<details>
+<summary>NPM / Homebrew</summary>
 
-#### Prerequisites
-
-Make sure you have Node.js 22 or later installed. Download it from [nodejs.org](https://nodejs.org/en/download).
-
-#### NPM
+**NPM** (requires [Node.js 22+](https://nodejs.org/)):
 
 ```bash
 npm install -g @qwen-code/qwen-code@latest
 ```
 
-#### Homebrew (macOS, Linux)
+**Homebrew** (macOS / Linux):
 
 ```bash
 brew install qwen-code
 ```
 
+</details>
+
 ## Quick Start
 
 ```bash
-# Start Qwen Code (interactive)
-qwen
-
-# Then, in the session:
-/help
-/auth
+qwen          # Launch interactive terminal UI
+# Inside the session:
+/auth         # Configure your provider and API key
 ```
 
-On first use, you'll be prompted to sign in. You can run `/auth` anytime to switch authentication methods.
+![Qwen Code](https://img.alicdn.com/imgextra/i2/O1CN01K0nwj41RM1Il8kB0t_!!6000000002096-2-tps-1544-1060.png)
 
-Example prompts:
+## How to Use Qwen Code
 
-```text
-What does this project do?
-Explain the codebase structure.
-Help me refactor this function.
-Generate unit tests for this module.
-```
+| Mode            | Command         | Use Case                                                                                                                                                                                                                                        |
+| --------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Interactive** | `qwen`          | Terminal UI with rich rendering, `@file` references, slash commands                                                                                                                                                                             |
+| **Headless**    | `qwen -p "..."` | Scripts, CI/CD, batch processing — no UI                                                                                                                                                                                                        |
+| **IDE**         | —               | [VS Code](https://qwenlm.github.io/qwen-code-docs/en/users/integration-vscode/), [Zed](https://qwenlm.github.io/qwen-code-docs/en/users/integration-zed/), [JetBrains](https://qwenlm.github.io/qwen-code-docs/en/users/integration-jetbrains/) |
+| **Desktop**     | —               | [Qwen Code Desktop](https://github.com/QwenLM/qwen-code/releases/tag/desktop-latest) — GUI for macOS, Windows, Linux                                                                                                                            |
+| **Daemon**      | `qwen serve`    | Shared agent session over HTTP+SSE (ACP). Multiple clients, one agent. [Docs](https://qwenlm.github.io/qwen-code-docs/en/users/qwen-serve)                                                                                                      |
+| **SDK**         | —               | [TypeScript](./packages/sdk-typescript/README.md), [Python](./packages/sdk-python/README.md), [Java](./packages/sdk-java/qwencode/README.md)                                                                                                    |
+| **IM Bot**      | `qwen channel`  | Connect to Telegram, DingTalk, WeChat, or Feishu                                                                                                                                                                                                |
 
 <details>
-<summary>Click to watch a demo video</summary>
-
-<video src="https://cloud.video.taobao.com/vod/HLfyppnCHplRV9Qhz2xSqeazHeRzYtG-EYJnHAqtzkQ.mp4" controls>
-Your browser does not support the video tag.
-</video>
-
-</details>
-
-## 🦞 Use Qwen Code for Coding Tasks in Claw
-
-Copy the prompt below and paste it into your agent:
-
-```
-Use Qwen Code as a coding agent. First, fetch and read this skill reference:
-https://raw.githubusercontent.com/QwenLM/qwen-code/refs/heads/main/.qwen/skills/qwen-code-claw/SKILL.md
-Then follow the instructions inside to install, authenticate, and use Qwen Code via acpx for all coding tasks.
-```
-
-## Authentication
-
-Qwen Code supports the following authentication methods:
-
-- **API Key (recommended)**: use an API key from Alibaba Cloud Model Studio ([Beijing](https://bailian.console.aliyun.com/) / [intl](https://modelstudio.console.alibabacloud.com/)) or any supported provider (OpenAI, Anthropic, Google GenAI, and other compatible endpoints).
-- **Coding Plan**: subscribe to the Alibaba Cloud Coding Plan ([Beijing](https://bailian.console.aliyun.com/cn-beijing?tab=coding-plan#/efm/coding-plan-index) / [intl](https://modelstudio.console.alibabacloud.com/?tab=coding-plan#/efm/coding-plan-index)) for a fixed monthly fee with higher quotas.
-
-> ⚠️ **Qwen OAuth was discontinued on April 15, 2026.** If you were previously using Qwen OAuth, please switch to one of the methods above. Run `qwen` and then `/auth` to reconfigure.
-
-#### API Key (recommended)
-
-Use an API key to connect to Alibaba Cloud Model Studio or any supported provider. Supports multiple protocols:
-
-- **OpenAI-compatible**: Alibaba Cloud ModelStudio, ModelScope, OpenAI, OpenRouter, and other OpenAI-compatible providers
-- **Anthropic**: Claude models
-- **Google GenAI**: Gemini models
-
-The **recommended** way to configure models and providers is by editing `~/.qwen/settings.json` (create it if it doesn't exist). This file lets you define all available models, API keys, and default settings in one place.
-
-##### Quick Setup in 3 Steps
-
-**Step 1:** Create or edit `~/.qwen/settings.json`
-
-Here is a complete example:
-
-```json
-{
-  "modelProviders": {
-    "openai": [
-      {
-        "id": "qwen3.6-plus",
-        "name": "qwen3.6-plus",
-        "baseUrl": "https://dashscope.aliyuncs.com/compatible-mode/v1",
-        "description": "Qwen3-Coder via Dashscope",
-        "envKey": "DASHSCOPE_API_KEY"
-      }
-    ]
-  },
-  "env": {
-    "DASHSCOPE_API_KEY": "sk-xxxxxxxxxxxxx"
-  },
-  "security": {
-    "auth": {
-      "selectedType": "openai"
-    }
-  },
-  "model": {
-    "name": "qwen3.6-plus"
-  }
-}
-```
-
-**Step 2:** Understand each field
-
-| Field                        | What it does                                                                                                                          |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `modelProviders`             | Declares which models are available and how to connect to them. Keys like `openai`, `anthropic`, `gemini` represent the API protocol. |
-| `modelProviders[].id`        | The model ID sent to the API (e.g. `qwen3.6-plus`, `gpt-4o`).                                                                         |
-| `modelProviders[].envKey`    | The name of the environment variable that holds your API key.                                                                         |
-| `modelProviders[].baseUrl`   | The API endpoint URL (required for non-default endpoints).                                                                            |
-| `env`                        | A fallback place to store API keys (lowest priority; prefer `.env` files or `export` for sensitive keys).                             |
-| `security.auth.selectedType` | The protocol to use on startup (`openai`, `anthropic`, `gemini`, `vertex-ai`).                                                        |
-| `model.name`                 | The default model to use when Qwen Code starts.                                                                                       |
-
-**Step 3:** Start Qwen Code — your configuration takes effect automatically:
-
-```bash
-qwen
-```
-
-Use the `/model` command at any time to switch between all configured models.
-
-##### More Examples
-
-<details>
-<summary>Coding Plan (Alibaba Cloud ModelStudio) — fixed monthly fee, higher quotas</summary>
-
-```json
-{
-  "modelProviders": {
-    "openai": [
-      {
-        "id": "qwen3.6-plus",
-        "name": "qwen3.6-plus (Coding Plan)",
-        "baseUrl": "https://coding.dashscope.aliyuncs.com/v1",
-        "description": "qwen3.6-plus from ModelStudio Coding Plan",
-        "envKey": "BAILIAN_CODING_PLAN_API_KEY"
-      },
-      {
-        "id": "qwen3.5-plus",
-        "name": "qwen3.5-plus (Coding Plan)",
-        "baseUrl": "https://coding.dashscope.aliyuncs.com/v1",
-        "description": "qwen3.5-plus with thinking enabled from ModelStudio Coding Plan",
-        "envKey": "BAILIAN_CODING_PLAN_API_KEY",
-        "generationConfig": {
-          "extra_body": {
-            "enable_thinking": true
-          }
-        }
-      },
-      {
-        "id": "glm-4.7",
-        "name": "glm-4.7 (Coding Plan)",
-        "baseUrl": "https://coding.dashscope.aliyuncs.com/v1",
-        "description": "glm-4.7 with thinking enabled from ModelStudio Coding Plan",
-        "envKey": "BAILIAN_CODING_PLAN_API_KEY",
-        "generationConfig": {
-          "extra_body": {
-            "enable_thinking": true
-          }
-        }
-      },
-      {
-        "id": "kimi-k2.5",
-        "name": "kimi-k2.5 (Coding Plan)",
-        "baseUrl": "https://coding.dashscope.aliyuncs.com/v1",
-        "description": "kimi-k2.5 with thinking enabled from ModelStudio Coding Plan",
-        "envKey": "BAILIAN_CODING_PLAN_API_KEY",
-        "generationConfig": {
-          "extra_body": {
-            "enable_thinking": true
-          }
-        }
-      }
-    ]
-  },
-  "env": {
-    "BAILIAN_CODING_PLAN_API_KEY": "sk-xxxxxxxxxxxxx"
-  },
-  "security": {
-    "auth": {
-      "selectedType": "openai"
-    }
-  },
-  "model": {
-    "name": "qwen3.6-plus"
-  }
-}
-```
-
-> Subscribe to the Coding Plan and get your API key at [Alibaba Cloud ModelStudio (Beijing)](https://bailian.console.aliyun.com/cn-beijing?tab=coding-plan#/efm/coding-plan-index) or [Alibaba Cloud ModelStudio (intl)](https://modelstudio.console.alibabacloud.com/?tab=coding-plan#/efm/coding-plan-index).
-
-</details>
-
-<details>
-<summary>Multiple providers (OpenAI + Anthropic + Gemini)</summary>
-
-```json
-{
-  "modelProviders": {
-    "openai": [
-      {
-        "id": "gpt-4o",
-        "name": "GPT-4o",
-        "envKey": "OPENAI_API_KEY",
-        "baseUrl": "https://api.openai.com/v1"
-      }
-    ],
-    "anthropic": [
-      {
-        "id": "claude-sonnet-4-20250514",
-        "name": "Claude Sonnet 4",
-        "envKey": "ANTHROPIC_API_KEY"
-      }
-    ],
-    "gemini": [
-      {
-        "id": "gemini-2.5-pro",
-        "name": "Gemini 2.5 Pro",
-        "envKey": "GEMINI_API_KEY"
-      }
-    ]
-  },
-  "env": {
-    "OPENAI_API_KEY": "sk-xxxxxxxxxxxxx",
-    "ANTHROPIC_API_KEY": "sk-ant-xxxxxxxxxxxxx",
-    "GEMINI_API_KEY": "AIzaxxxxxxxxxxxxx"
-  },
-  "security": {
-    "auth": {
-      "selectedType": "openai"
-    }
-  },
-  "model": {
-    "name": "gpt-4o"
-  }
-}
-```
-
-</details>
-
-<details>
-<summary>Enable thinking mode (for supported models like qwen3.5-plus)</summary>
-
-```json
-{
-  "modelProviders": {
-    "openai": [
-      {
-        "id": "qwen3.5-plus",
-        "name": "qwen3.5-plus (thinking)",
-        "envKey": "DASHSCOPE_API_KEY",
-        "baseUrl": "https://dashscope.aliyuncs.com/compatible-mode/v1",
-        "generationConfig": {
-          "extra_body": {
-            "enable_thinking": true
-          }
-        }
-      }
-    ]
-  },
-  "env": {
-    "DASHSCOPE_API_KEY": "sk-xxxxxxxxxxxxx"
-  },
-  "security": {
-    "auth": {
-      "selectedType": "openai"
-    }
-  },
-  "model": {
-    "name": "qwen3.5-plus"
-  }
-}
-```
-
-</details>
-
-> **Tip:** You can also set API keys via `export` in your shell or `.env` files, which take higher priority than `settings.json` → `env`. See the [authentication guide](https://qwenlm.github.io/qwen-code-docs/en/users/configuration/auth/) for full details.
-
-> **Security note:** Never commit API keys to version control. The `~/.qwen/settings.json` file is in your home directory and should stay private.
-
-#### Local Model Setup (Ollama / vLLM)
-
-You can also run models locally — no API key or cloud account needed. This is not an authentication method; instead, configure your local model endpoint in `~/.qwen/settings.json` using the `modelProviders` field.
-
-Set `generationConfig.contextWindowSize` inside the matching provider entry
-and adjust it to the context length configured on your local server.
-
-<details>
-<summary>Ollama setup</summary>
-
-1. Install Ollama from [ollama.com](https://ollama.com/)
-2. Pull a model: `ollama pull qwen3:32b`
-3. Configure `~/.qwen/settings.json`:
-
-```json
-{
-  "modelProviders": {
-    "openai": [
-      {
-        "id": "qwen3:32b",
-        "name": "Qwen3 32B (Ollama)",
-        "baseUrl": "http://localhost:11434/v1",
-        "description": "Qwen3 32B running locally via Ollama",
-        "generationConfig": {
-          "contextWindowSize": 131072
-        }
-      }
-    ]
-  },
-  "security": {
-    "auth": {
-      "selectedType": "openai"
-    }
-  },
-  "model": {
-    "name": "qwen3:32b"
-  }
-}
-```
-
-</details>
-
-<details>
-<summary>vLLM setup</summary>
-
-1. Install vLLM: `pip install vllm`
-2. Start the server: `vllm serve Qwen/Qwen3-32B`
-3. Configure `~/.qwen/settings.json`:
-
-```json
-{
-  "modelProviders": {
-    "openai": [
-      {
-        "id": "Qwen/Qwen3-32B",
-        "name": "Qwen3 32B (vLLM)",
-        "baseUrl": "http://localhost:8000/v1",
-        "description": "Qwen3 32B running locally via vLLM",
-        "generationConfig": {
-          "contextWindowSize": 131072
-        }
-      }
-    ]
-  },
-  "security": {
-    "auth": {
-      "selectedType": "openai"
-    }
-  },
-  "model": {
-    "name": "Qwen/Qwen3-32B"
-  }
-}
-```
-
-</details>
-
-## Usage
-
-As an open-source terminal agent, you can use Qwen Code in five primary ways:
-
-1. Interactive mode (terminal UI)
-2. Headless mode (scripts, CI)
-3. IDE integration (VS Code, Zed)
-4. SDKs (TypeScript, Python, Java)
-5. Daemon mode — `qwen serve` exposes ACP over HTTP+SSE so multiple clients share one agent (experimental)
-
-#### Interactive mode
-
-```bash
-cd your-project/
-qwen
-```
-
-Run `qwen` in your project folder to launch the interactive terminal UI. Use `@` to reference local files (for example `@src/main.ts`).
-
-#### Headless mode
-
-```bash
-cd your-project/
-qwen -p "your question"
-```
-
-Use `-p` to run Qwen Code without the interactive UI—ideal for scripts, automation, and CI/CD. Learn more: [Headless mode](https://qwenlm.github.io/qwen-code-docs/en/users/features/headless).
-
-#### IDE integration
-
-Use Qwen Code inside your editor (VS Code, Zed, and JetBrains IDEs):
-
-- [Use in VS Code](https://qwenlm.github.io/qwen-code-docs/en/users/integration-vscode/)
-- [Use in Zed](https://qwenlm.github.io/qwen-code-docs/en/users/integration-zed/)
-- [Use in JetBrains IDEs](https://qwenlm.github.io/qwen-code-docs/en/users/integration-jetbrains/)
-
-#### Daemon mode (`qwen serve`, experimental)
-
-```bash
-cd your-project/
-qwen serve
-# → qwen serve listening on http://127.0.0.1:4170 (mode=http-bridge)
-```
-
-Run Qwen Code as a local HTTP daemon so IDE plugins, web UIs, CI scripts and custom CLIs all share **one** agent session over HTTP+SSE — instead of each spawning their own subprocess. Loopback bind has no auth by default (set `QWEN_SERVER_TOKEN` to enable bearer auth even on loopback); remote binds (`--hostname 0.0.0.0`) **require** a token — boot refuses without one. See:
-
-- [Daemon mode user guide](https://qwenlm.github.io/qwen-code-docs/en/users/qwen-serve)
-- [HTTP protocol reference](https://qwenlm.github.io/qwen-code-docs/en/developers/qwen-serve-protocol)
-- [DaemonClient TypeScript quickstart](https://qwenlm.github.io/qwen-code-docs/en/developers/examples/daemon-client-quickstart)
-
-#### SDKs
-
-Build on top of Qwen Code with the available SDKs:
-
-- TypeScript: [Use the Qwen Code SDK](./packages/sdk-typescript/README.md)
-- Python: [Use the Python SDK](./packages/sdk-python/README.md)
-- Java: [Use the Java SDK](./packages/sdk-java/qwencode/README.md)
-
-Python SDK example:
+<summary>SDK example (Python)</summary>
 
 ```python
 import asyncio
@@ -507,79 +109,47 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-## Commands & Shortcuts
+</details>
 
-### Session Commands
+## Capabilities
 
-- `/help` - Display available commands
-- `/clear` - Clear conversation history
-- `/compress` - Compress history to save tokens
-- `/stats` - Show current session information
-- `/bug` - Submit a bug report
-- `/exit` or `/quit` - Exit Qwen Code
+If you know Claude Code, you already know Qwen Code — and then some. We've put significant effort into [bringing Qwen Code to feature parity with Claude Code](https://github.com/wenshao/codeagents/blob/main/docs/comparison/qwen-code-improvement-report.md), improving both breadth and reliability across the board.
 
-### Keyboard Shortcuts
-
-- `Ctrl+C` - Cancel current operation
-- `Ctrl+D` - Exit (on empty line)
-- `Up/Down` - Navigate command history
-
-> Learn more about [Commands](https://qwenlm.github.io/qwen-code-docs/en/users/features/commands/)
->
-> **Tip**: In YOLO mode (`--yolo`), vision switching happens automatically without prompts when images are detected. Learn more about [Approval Mode](https://qwenlm.github.io/qwen-code-docs/en/users/features/approval-mode/)
-
-## Configuration
-
-Qwen Code can be configured via `settings.json`, environment variables, and CLI flags.
-
-| File                    | Scope         | Description                                                                             |
-| ----------------------- | ------------- | --------------------------------------------------------------------------------------- |
-| `~/.qwen/settings.json` | User (global) | Applies to all your Qwen Code sessions. **Recommended for `modelProviders` and `env`.** |
-| `.qwen/settings.json`   | Project       | Applies only when running Qwen Code in this project. Overrides user settings.           |
-
-The most commonly used top-level fields in `settings.json`:
-
-| Field                        | Description                                                                                          |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `modelProviders`             | Define available models per protocol (`openai`, `anthropic`, `gemini`, `vertex-ai`).                 |
-| `env`                        | Fallback environment variables (e.g. API keys). Lower priority than shell `export` and `.env` files. |
-| `security.auth.selectedType` | The protocol to use on startup (e.g. `openai`).                                                      |
-| `model.name`                 | The default model to use when Qwen Code starts.                                                      |
-
-> See the [Authentication](#api-key-flexible) section above for complete `settings.json` examples, and the [settings reference](https://qwenlm.github.io/qwen-code-docs/en/users/configuration/settings/) for all available options.
-
-## Benchmark Results
-
-### Terminal-Bench Performance
-
-| Agent     | Model              | Accuracy |
-| --------- | ------------------ | -------- |
-| Qwen Code | Qwen3-Coder-480A35 | 37.5%    |
-| Qwen Code | Qwen3-Coder-30BA3B | 31.3%    |
+| Feature                                                            | Qwen Code | Claude Code |
+| ------------------------------------------------------------------ | :-------: | :---------: |
+| SubAgents, Agent Teams, Dynamic Workflows                          |     ✓     |      ✓      |
+| Auto-Memory, Auto-Skills, Hooks                                    |     ✓     |      ✓      |
+| Built-in Skills (/review, /batch, /loop, /debug…)                  |     ✓     |      ✓      |
+| MCP, Plan Mode, LSP Integration                                    |     ✓     |      ✓      |
+| Auto Mode, Sandbox, Git Worktrees                                  |     ✓     |      ✓      |
+| Computer Use (desktop automation)                                  |     ✓     |      ✓      |
+| IDE Plugins (VS Code / JetBrains / Zed)                            |     ✓     |      ✓      |
+| SDK (TypeScript / Python / Java)                                   |     ✓     |      ✓      |
+| Headless Mode, Session Management                                  |     ✓     |      ✓      |
+| Open-source — model and framework                                  |     ✓     |      —      |
+| Multi-protocol (OpenAI / Anthropic / Gemini / Qwen + any provider) |     ✓     |      —      |
+| Agent Arena (multi-model head-to-head on same task)                |     ✓     |      —      |
+| Daemon Mode — `qwen serve` (multi-client shared agent)             |     ✓     |      —      |
+| IM Channels (Telegram / DingTalk / WeChat / Feishu)                |     ✓     |      —      |
 
 ## Ecosystem
 
-Looking for a graphical interface?
+- [**Qwen Code Desktop**](https://github.com/QwenLM/qwen-code/releases/tag/desktop-latest) — Official desktop app for macOS, Windows, and Linux
+- [**AionUi**](https://github.com/iOfficeAI/AionUi) — A modern GUI for command-line AI tools including Qwen Code
+- [**Gemini CLI Desktop**](https://github.com/Piebald-AI/gemini-cli-desktop) — A cross-platform desktop/web/mobile UI for Qwen Code
 
-- [**Qwen Code Desktop**](https://github.com/QwenLM/qwen-code/releases/tag/desktop-latest) Official desktop app for macOS, Windows, and Linux
-- [**AionUi**](https://github.com/iOfficeAI/AionUi) A modern GUI for command-line AI tools including Qwen Code
-- [**Gemini CLI Desktop**](https://github.com/Piebald-AI/gemini-cli-desktop) A cross-platform desktop/web/mobile UI for Qwen Code
+- [**🦞 Qwen Code Claw**](https://github.com/openclaw/acpx) — Let other agents (Claude, Codex, etc.) delegate coding tasks to Qwen Code via ACP. Paste this prompt into your agent:
 
-## Troubleshooting
+```text
+Use Qwen Code as a coding agent. First, fetch and read this skill reference:
+https://raw.githubusercontent.com/QwenLM/qwen-code/refs/heads/main/.qwen/skills/qwen-code-claw/SKILL.md
+Then follow the instructions inside to install, authenticate, and use Qwen Code via acpx for all coding tasks.
+```
 
-If you encounter issues, check the [troubleshooting guide](https://qwenlm.github.io/qwen-code-docs/en/users/support/troubleshooting/).
+## Contributing
 
-**Common issues:**
-
-- **`Qwen OAuth free tier was discontinued on 2026-04-15`**: Qwen OAuth is no longer available. Run `qwen` → `/auth` and switch to API Key or Coding Plan. See the [Authentication](#authentication) section above for setup instructions.
-
-To report a bug from within the CLI, run `/bug` and include a short title and repro steps.
-
-## Connect with Us
-
-- Discord: https://discord.gg/RN7tqZCeDK
-- Dingtalk: https://qr.dingtalk.com/action/joingroup?code=v1,k1,+FX6Gf/ZDlTahTIRi8AEQhIaBlqykA0j+eBKKdhLeAE=&_dt_no_comment=1&origin=1
+Contributions are welcome! See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.
 
 ## Acknowledgments
 
-This project is based on [Google Gemini CLI](https://github.com/google-gemini/gemini-cli). We acknowledge and appreciate the excellent work of the Gemini CLI team. Our main contribution focuses on parser-level adaptations to better support Qwen-Coder models.
+This project was originally based on [Google Gemini CLI](https://github.com/google-gemini/gemini-cli) v0.8. We gratefully acknowledge the Gemini CLI team's excellent work. Starting from Qwen Code v0.1, we stopped syncing with upstream and began independent development as a multi-protocol, multi-platform agent framework with deep integrations for Qwen models and beyond.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 - **Beyond the terminal** — IDE plugins, Desktop app, daemon mode, SDKs, and IM bots (Telegram / DingTalk / WeChat / Feishu).
 
 > [!TIP]
-> Qwen Code is actively iterating on itself — using its own agent and models to file issues, submit PRs, review code, run tests, and approve merges. It has already become the **#2 contributor** to this repository. Powered by the community, driven by AI.
+> Qwen Code is actively iterating on itself — using its own agent and models to file issues, submit PRs, review code, and run tests. Powered by the community, driven by AI.
 
 ## Installation
 
@@ -69,6 +69,8 @@ qwen          # Launch interactive terminal UI
 /auth         # Configure your provider and API key
 ```
 
+See the [Authentication Guide](https://qwenlm.github.io/qwen-code-docs/en/users/configuration/auth/) and [Settings Reference](https://qwenlm.github.io/qwen-code-docs/en/users/configuration/settings/) for detailed setup.
+
 ![Qwen Code](https://img.alicdn.com/imgextra/i2/O1CN01K0nwj41RM1Il8kB0t_!!6000000002096-2-tps-1544-1060.png)
 
 ## How to Use Qwen Code
@@ -79,7 +81,7 @@ qwen          # Launch interactive terminal UI
 | **Headless**    | `qwen -p "..."` | Scripts, CI/CD, batch processing — no UI                                                                                                                                                                                                        |
 | **IDE**         | —               | [VS Code](https://qwenlm.github.io/qwen-code-docs/en/users/integration-vscode/), [Zed](https://qwenlm.github.io/qwen-code-docs/en/users/integration-zed/), [JetBrains](https://qwenlm.github.io/qwen-code-docs/en/users/integration-jetbrains/) |
 | **Desktop**     | —               | [Qwen Code Desktop](https://github.com/QwenLM/qwen-code/releases/tag/desktop-latest) — GUI for macOS, Windows, Linux                                                                                                                            |
-| **Daemon**      | `qwen serve`    | Shared agent session over HTTP+SSE (ACP). Multiple clients, one agent. [Docs](https://qwenlm.github.io/qwen-code-docs/en/users/qwen-serve)                                                                                                      |
+| **Daemon**      | `qwen serve`    | Shared agent session over HTTP+SSE (ACP). Multiple clients, one agent. _(experimental)_ [Docs](https://qwenlm.github.io/qwen-code-docs/en/users/qwen-serve)                                                                                     |
 | **SDK**         | —               | [TypeScript](./packages/sdk-typescript/README.md), [Python](./packages/sdk-python/README.md), [Java](./packages/sdk-java/qwencode/README.md)                                                                                                    |
 | **IM Bot**      | `qwen channel`  | Connect to Telegram, DingTalk, WeChat, or Feishu                                                                                                                                                                                                |
 
@@ -119,12 +121,12 @@ If you know Claude Code, you already know Qwen Code — and then some. We've put
 | ------------------------------------------------------------------ | :-------: | :---------: |
 | SubAgents, Agent Teams, Dynamic Workflows                          |     ✓     |      ✓      |
 | Auto-Memory, Auto-Skills, Hooks                                    |     ✓     |      ✓      |
-| Built-in Skills (/review, /batch, /loop, /debug…)                  |     ✓     |      ✓      |
+| Built-in Skills (/review, /batch, /loop, /bugfix…)                 |     ✓     |      ✓      |
 | MCP, Plan Mode, LSP Integration                                    |     ✓     |      ✓      |
 | Auto Mode, Sandbox, Git Worktrees                                  |     ✓     |      ✓      |
 | Computer Use (desktop automation)                                  |     ✓     |      ✓      |
 | IDE Plugins (VS Code / JetBrains / Zed)                            |     ✓     |      ✓      |
-| SDK (TypeScript / Python / Java)                                   |     ✓     |      ✓      |
+| SDK                                                                |     ✓     |      ✓      |
 | Headless Mode, Session Management                                  |     ✓     |      ✓      |
 | Open-source — model and framework                                  |     ✓     |      —      |
 | Multi-protocol (OpenAI / Anthropic / Gemini / Qwen + any provider) |     ✓     |      —      |
@@ -152,4 +154,4 @@ Contributions are welcome! See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelin
 
 ## Acknowledgments
 
-This project was originally based on [Google Gemini CLI](https://github.com/google-gemini/gemini-cli) v0.8. We gratefully acknowledge the Gemini CLI team's excellent work. Starting from Qwen Code v0.1, we stopped syncing with upstream and began independent development as a multi-protocol, multi-platform agent framework with deep integrations for Qwen models and beyond.
+This project was originally based on [Google Gemini CLI](https://github.com/google-gemini/gemini-cli) v0.8.2. We gratefully acknowledge the Gemini CLI team's excellent work. Starting from Qwen Code v0.1, we stopped syncing with upstream and began independent development as a multi-protocol, multi-platform agent framework with deep integrations for Qwen models and beyond.


### PR DESCRIPTION
## What this PR does

Strips the README back to what a first-time visitor actually needs: understand the value prop, install, start using it, and see what makes Qwen Code different. The old README had grown into a dense reference manual — verbose auth examples, config tables, troubleshooting, news entries, and demo videos that most visitors skip.

The flow is restructured to: Why → Installation → Quick Start → How to Use → Capabilities → Ecosystem → Contributing → Acknowledgments.

## Why it's needed

A README is a landing page, not a manual. Detailed setup, configuration, and troubleshooting belong in the [official docs site](https://qwenlm.github.io/qwen-code-docs/en/users/overview/). The previous README overwhelmed new visitors with 500+ lines before they even reached the install button. This revamp brings it down to ~160 lines that front-load the product story.

## Reviewer Test Plan

### How to verify

Open the rendered README on GitHub and check the following:

- The flow reads naturally: Why → Install → Quick Start → How to Use → Capabilities → Ecosystem → Contributing → Acknowledgments
- Quick Start links to the [Authentication Guide](https://qwenlm.github.io/qwen-code-docs/en/users/configuration/auth/) and [Settings Reference](https://qwenlm.github.io/qwen-code-docs/en/users/configuration/settings/) for detailed setup
- The Capabilities comparison table is accurate (Claude Code column reflects only features it actually has — no Java SDK entry)
- Daemon mode is marked *(experimental)* consistent with `serve.ts` source code
- Acknowledgments correctly states "v0.8.2" (verified via PR #838, the last upstream sync)
- The Claw prompt block links to `main` branch (standard OSS convention)

### Evidence (Before & After)

Non-UI change (documentation). N/A.

Before: 564 lines. After: ~160 lines.

**Removed:** News section, demo video, verbose Authentication walkthrough (with multi-provider JSON examples, Ollama/vLLM setup, Coding Plan details), Configuration tables, Troubleshooting section, Commands & Shortcuts reference, Benchmark Results table, community links (Discord/DingTalk), example prompts, Session Commands list.

**Added:**
- GitHub alert (TIP) highlighting that Qwen Code self-iterates
- Capabilities comparison table vs Claude Code
- Contributing section linking to CONTRIBUTING.md
- Claw section rebranded as ecosystem list item with proper [openclaw/acpx](https://github.com/openclaw/acpx) link
- Auth docs links after Quick Start (added during review feedback)

**Updated:**
- Tagline: "An open-source AI agent" → "The open-source AI coding agent"
- Acknowledgments: clarified fork origin (Gemini CLI v0.8.2) and independent development since Qwen Code v0.1
- Installation: compacted from nested headers to inline bold labels
- Hero image replaced

**Review feedback addressed (commit `3f064e2`):**
- Added auth docs links after Quick Start (was missing after removing ~300 lines of auth docs)
- Changed `/debug` → `/bugfix` in comparison table (`/debug` is not a valid command)
- Marked Daemon mode as *(experimental)* per `serve.ts` source code
- Simplified SDK row — Claude Code has no Java SDK
- Fixed Gemini CLI version pin from `v0.8` to `v0.8.2` (verified via PR #838)
- Removed unverifiable "#2 contributor" rank claim
- Removed "approve merges" phrase (agent reviews PRs but has no merge authority)
- Retained parity link — wenshao is a core maintainer, not a random fork

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment

N/A — documentation-only change.

## Risk & Scope

- Main risk or tradeoff: Users who relied on the README for inline auth examples or config tables now need to click through to the docs site. This is intentional — the docs site is the right home for that content.
- Not validated / out of scope: Translated READMEs (zh, de, fr, ja, ru, pt-BR) are not updated in this PR.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

将 README 精简为首次访客真正需要的内容：理解价值主张 → 安装 → 开始使用 → 了解差异化。旧 README 已膨胀为 500+ 行的参考手册——冗长的认证示例、配置表格、故障排除、新闻条目、演示视频，大多数访客根本不看。

重新组织为：Why → Installation → Quick Start → How to Use → Capabilities → Ecosystem → Contributing → Acknowledgments。

## 为什么需要

README 是落地页，不是手册。详细的安装、配置、故障排除内容应放在[官方文档站](https://qwenlm.github.io/qwen-code-docs/en/users/overview/)。旧版本在新访客看到安装按钮之前就塞了 500+ 行内容。本次改版精简至 ~160 行，将产品故事前置。

## 主要变化

**删除：** News、演示视频、完整 Authentication 教程、Configuration 表格、Troubleshooting、命令快捷键参考、Benchmark 结果、社区链接、示例 prompt、Session Commands

**新增：** GitHub TIP 标签、Capabilities 对比表、Contributing 入口、Claw 生态列表项、Quick Start 后的认证文档链接

**更新：** tagline、Acknowledgments（明确 fork 来源 Gemini CLI v0.8.2 和自主研发起点）、Installation 精简、替换 hero 图片

**Review 反馈处理：** 修正 `/debug` → `/bugfix`、Daemon 标记 experimental、SDK 行简化、版本号修正为 v0.8.2、移除不可验证的 "#2 contributor" 排名和有误导性的 "approve merges" 表述、保留 wenshao parity 链接（核心维护者）

## 风险与范围

- 主要风险：依赖 README 内联认证示例的用户现在需要点击跳转到文档站。这是有意设计。
- 未覆盖：多语言 README 未在此 PR 更新。
- 破坏性变更：无。

</details>