### PR TITLE
fix(cli): Stop after cancelled permissions

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -232,6 +232,7 @@ describe('Session', () => {
     name: string,
     execute: ReturnType<typeof vi.fn>,
     type: core.ToolCallConfirmationDetails['type'] = 'ask_user_question',
+    onConfirm: ReturnType<typeof vi.fn> = vi.fn().mockResolvedValue(undefined),
   ) {
     return {
       name,
@@ -249,7 +250,7 @@ describe('Session', () => {
             type === 'ask_user_question'
               ? [{ header: 'Continue?', question: 'Continue?' }]
               : undefined,
-          onConfirm: vi.fn().mockResolvedValue(undefined),
+          onConfirm,
         }),
         getDescription: vi.fn().mockReturnValue(name),
         toolLocations: vi.fn().mockReturnValue([]),
@@ -6215,7 +6216,7 @@ describe('Session', () => {
         functionCalls: FunctionCall[],
       ) => Promise<{
         parts: Part[];
-        stopAfterUserQuestionCancel: boolean;
+        stopAfterPermissionCancel: boolean;
       }>;
     };
 
@@ -6234,6 +6235,27 @@ describe('Session', () => {
           type: 'ask_user_question',
           title: 'Question',
           questions: [{ header: 'Continue?', question: 'Continue?' }],
+        },
+        respond,
+        timestamp: Date.now(),
+      });
+    }
+
+    function emitNestedInfoPermission(
+      eventEmitter: EventEmitter,
+      respond: ReturnType<typeof vi.fn>,
+    ) {
+      eventEmitter.emit(core.AgentEventType.TOOL_WAITING_APPROVAL, {
+        subagentId: 'subagent-1',
+        round: 1,
+        callId: 'nested_shell',
+        name: core.ToolNames.SHELL,
+        description: 'Shell permission',
+        args: {},
+        confirmationDetails: {
+          type: 'info',
+          title: 'Shell permission',
+          prompt: 'Allow shell?',
         },
         respond,
         timestamp: Date.now(),
@@ -6298,7 +6320,7 @@ describe('Session', () => {
         },
       ]);
 
-      expect(result.stopAfterUserQuestionCancel).toBe(true);
+      expect(result.stopAfterPermissionCancel).toBe(true);
       expect(result.parts).toHaveLength(1);
       expect(result.parts[0]?.functionResponse?.id).toBe('question_call');
       expect(result.parts[0]?.functionResponse?.response).toEqual({
@@ -6337,7 +6359,7 @@ describe('Session', () => {
         },
       ]);
 
-      expect(result.stopAfterUserQuestionCancel).toBe(true);
+      expect(result.stopAfterPermissionCancel).toBe(true);
       expect(questionExecute).not.toHaveBeenCalled();
       expect(shellExecute).not.toHaveBeenCalled();
       expect(result.parts.map((part) => part.functionResponse?.id)).toEqual([
@@ -6346,7 +6368,7 @@ describe('Session', () => {
       ]);
       expect(result.parts[1]?.functionResponse?.response).toEqual({
         error:
-          'Skipped because ask_user_question was cancelled before the user answered; user input is required before continuing.',
+          'Skipped because a permission request was cancelled before the user answered; user input is required before continuing.',
       });
       expect(mockChatRecordingService.recordToolResult).toHaveBeenCalledWith(
         [result.parts[1]],
@@ -6431,7 +6453,7 @@ describe('Session', () => {
         ],
       );
 
-      expect(result.stopAfterUserQuestionCancel).toBe(true);
+      expect(result.stopAfterPermissionCancel).toBe(true);
       expect(shellExecute).not.toHaveBeenCalled();
       expect(result.parts.map((part) => part.functionResponse?.id)).toEqual([
         'question_call',
@@ -6439,7 +6461,7 @@ describe('Session', () => {
       ]);
       expect(result.parts[1]?.functionResponse?.response).toEqual({
         error:
-          'Skipped because ask_user_question was cancelled before the user answered; user input is required before continuing.',
+          'Skipped because a permission request was cancelled before the user answered; user input is required before continuing.',
       });
     });
 
@@ -6476,7 +6498,7 @@ describe('Session', () => {
         },
       ]);
 
-      expect(result.stopAfterUserQuestionCancel).toBe(true);
+      expect(result.stopAfterPermissionCancel).toBe(true);
       expect(result.parts.map((part) => part.functionResponse?.id)).toEqual([
         'question_call',
         `${core.ToolNames.SHELL}-skip-1`,
@@ -6484,10 +6506,16 @@ describe('Session', () => {
       ]);
     });
 
-    it('does not stop the turn for non-question permission cancellation', async () => {
-      const execute = vi.fn();
-      mockToolRegistry.getTool.mockReturnValue(
-        mockConfirmingTool(core.ToolNames.SHELL, execute, 'exec'),
+    it('skips later tools after non-question permission cancellation', async () => {
+      const cancelledExecute = vi.fn();
+      const laterExecute = vi.fn().mockResolvedValue({
+        llmContent: 'should not execute',
+        returnDisplay: 'should not execute',
+      });
+      mockToolRegistry.getTool.mockImplementation((name: string) =>
+        name === core.ToolNames.SHELL
+          ? mockConfirmingTool(name, cancelledExecute, 'exec')
+          : mockAllowedTool(name, laterExecute),
       );
       vi.mocked(mockClient.requestPermission).mockResolvedValueOnce({
         outcome: { outcome: 'cancelled' },
@@ -6501,12 +6529,172 @@ describe('Session', () => {
           name: core.ToolNames.SHELL,
           args: { command: 'echo denied' },
         },
+        {
+          id: 'read_call',
+          name: core.ToolNames.READ_FILE,
+          args: { file_path: '/tmp/should-not-run' },
+        },
       ]);
 
-      expect(result.stopAfterUserQuestionCancel).toBe(false);
-      expect(result.parts).toHaveLength(1);
-      expect(result.parts[0]?.functionResponse?.id).toBe('shell_call');
-      expect(execute).not.toHaveBeenCalled();
+      expect(result.stopAfterPermissionCancel).toBe(true);
+      expect(result.parts.map((part) => part.functionResponse?.id)).toEqual([
+        'shell_call',
+        'read_call',
+      ]);
+      expect(result.parts[1]?.functionResponse?.response).toEqual({
+        error:
+          'Skipped because a permission request was cancelled before the user answered; user input is required before continuing.',
+      });
+      expect(cancelledExecute).not.toHaveBeenCalled();
+      expect(laterExecute).not.toHaveBeenCalled();
+    });
+
+    it('skips later tools after selecting the reject permission option', async () => {
+      const rejectedExecute = vi.fn();
+      const laterExecute = vi.fn().mockResolvedValue({
+        llmContent: 'should not execute',
+        returnDisplay: 'should not execute',
+      });
+      mockToolRegistry.getTool.mockImplementation((name: string) =>
+        name === core.ToolNames.SHELL
+          ? mockConfirmingTool(name, rejectedExecute, 'exec')
+          : mockAllowedTool(name, laterExecute),
+      );
+      vi.mocked(mockClient.requestPermission).mockResolvedValueOnce({
+        outcome: {
+          outcome: 'selected',
+          optionId: core.ToolConfirmationOutcome.Cancel,
+        },
+      });
+
+      const result = await (
+        session as unknown as ToolCallInternals
+      ).runToolCalls(new AbortController().signal, 'prompt-shell-reject', [
+        {
+          id: 'shell_call',
+          name: core.ToolNames.SHELL,
+          args: { command: 'echo denied' },
+        },
+        {
+          id: 'read_call',
+          name: core.ToolNames.READ_FILE,
+          args: { file_path: '/tmp/should-not-run' },
+        },
+      ]);
+
+      expect(result.stopAfterPermissionCancel).toBe(true);
+      expect(result.parts.map((part) => part.functionResponse?.id)).toEqual([
+        'shell_call',
+        'read_call',
+      ]);
+      expect(result.parts[1]?.functionResponse?.response).toEqual({
+        error:
+          'Skipped because a permission request was cancelled before the user answered; user input is required before continuing.',
+      });
+      expect(rejectedExecute).not.toHaveBeenCalled();
+      expect(laterExecute).not.toHaveBeenCalled();
+    });
+
+    it('skips later tools when cancellation confirmation cleanup fails', async () => {
+      const rejectedExecute = vi.fn();
+      const laterExecute = vi.fn().mockResolvedValue({
+        llmContent: 'should not execute',
+        returnDisplay: 'should not execute',
+      });
+      const onConfirm = vi.fn().mockRejectedValue(new Error('cleanup failed'));
+      mockToolRegistry.getTool.mockImplementation((name: string) =>
+        name === core.ToolNames.SHELL
+          ? mockConfirmingTool(name, rejectedExecute, 'exec', onConfirm)
+          : mockAllowedTool(name, laterExecute),
+      );
+      vi.mocked(mockClient.requestPermission).mockResolvedValueOnce({
+        outcome: { outcome: 'cancelled' },
+      });
+
+      const result = await (
+        session as unknown as ToolCallInternals
+      ).runToolCalls(
+        new AbortController().signal,
+        'prompt-shell-cancel-cleanup-failed',
+        [
+          {
+            id: 'shell_call',
+            name: core.ToolNames.SHELL,
+            args: { command: 'echo denied' },
+          },
+          {
+            id: 'read_call',
+            name: core.ToolNames.READ_FILE,
+            args: { file_path: '/tmp/should-not-run' },
+          },
+        ],
+      );
+
+      expect(result.stopAfterPermissionCancel).toBe(true);
+      expect(onConfirm).toHaveBeenCalledWith(
+        core.ToolConfirmationOutcome.Cancel,
+        { answers: undefined },
+      );
+      expect(result.parts.map((part) => part.functionResponse?.id)).toEqual([
+        'shell_call',
+        'read_call',
+      ]);
+      expect(result.parts[1]?.functionResponse?.response).toEqual({
+        error:
+          'Skipped because a permission request was cancelled before the user answered; user input is required before continuing.',
+      });
+      expect(rejectedExecute).not.toHaveBeenCalled();
+      expect(laterExecute).not.toHaveBeenCalled();
+    });
+
+    it('skips later tools after non-question permission request failure', async () => {
+      const failedPermissionExecute = vi.fn();
+      const laterExecute = vi.fn().mockResolvedValue({
+        llmContent: 'should not execute',
+        returnDisplay: 'should not execute',
+      });
+      mockToolRegistry.getTool.mockImplementation((name: string) =>
+        name === core.ToolNames.SHELL
+          ? mockConfirmingTool(name, failedPermissionExecute, 'exec')
+          : mockAllowedTool(name, laterExecute),
+      );
+      vi.mocked(mockClient.requestPermission).mockRejectedValueOnce(
+        new Error('client disconnected'),
+      );
+
+      const result = await (
+        session as unknown as ToolCallInternals
+      ).runToolCalls(
+        new AbortController().signal,
+        'prompt-shell-permission-failed',
+        [
+          {
+            id: 'shell_call',
+            name: core.ToolNames.SHELL,
+            args: { command: 'echo denied' },
+          },
+          {
+            id: 'read_call',
+            name: core.ToolNames.READ_FILE,
+            args: { file_path: '/tmp/should-not-run' },
+          },
+        ],
+      );
+
+      expect(result.stopAfterPermissionCancel).toBe(true);
+      expect(result.parts.map((part) => part.functionResponse?.id)).toEqual([
+        'shell_call',
+        'read_call',
+      ]);
+      expect(result.parts[0]?.functionResponse?.response).toEqual({
+        error: `Permission request failed for "${core.ToolNames.SHELL}": client disconnected`,
+      });
+      expect(result.parts[1]?.functionResponse?.response).toEqual({
+        error:
+          'Skipped because a permission request was cancelled before the user answered; user input is required before continuing.',
+      });
+      expect(failedPermissionExecute).not.toHaveBeenCalled();
+      expect(laterExecute).not.toHaveBeenCalled();
     });
 
     it('stops and aborts Agent tool execution after nested ask_user_question cancellation', async () => {
@@ -6556,7 +6744,69 @@ describe('Session', () => {
         },
       ]);
 
-      expect(result.stopAfterUserQuestionCancel).toBe(true);
+      expect(result.stopAfterPermissionCancel).toBe(true);
+      expect(executeSignal?.aborted).toBe(true);
+      expect(respond).toHaveBeenCalledWith(
+        core.ToolConfirmationOutcome.Cancel,
+        {
+          answers: undefined,
+        },
+      );
+      expect(result.parts[0]?.functionResponse?.id).toBe('agent_call');
+    });
+
+    it('stops and aborts Agent tool execution after nested non-question permission cancellation', async () => {
+      const eventEmitter = new EventEmitter();
+      let executeSignal: AbortSignal | undefined;
+      const respond = vi.fn().mockResolvedValue(undefined);
+      const execute = vi
+        .fn()
+        .mockImplementation(async (signal: AbortSignal) => {
+          executeSignal = signal;
+          emitNestedInfoPermission(eventEmitter, respond);
+          await vi.waitFor(() => {
+            expect(signal.aborted).toBe(true);
+          });
+          return {
+            llmContent: 'agent stopped',
+            returnDisplay: 'agent stopped',
+          };
+        });
+      mockToolRegistry.getTool.mockReturnValue({
+        name: core.ToolNames.AGENT,
+        kind: core.Kind.Think,
+        displayName: 'Agent',
+        description: 'Agent',
+        build: vi.fn().mockReturnValue({
+          params: { subagent_type: 'explore' },
+          eventEmitter,
+          execute,
+          getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+          getDescription: vi.fn().mockReturnValue('Agent'),
+          toolLocations: vi.fn().mockReturnValue([]),
+        }),
+        canUpdateOutput: false,
+        isOutputMarkdown: true,
+      });
+      vi.mocked(mockClient.requestPermission).mockResolvedValueOnce({
+        outcome: { outcome: 'cancelled' },
+      });
+
+      const result = await (
+        session as unknown as ToolCallInternals
+      ).runToolCalls(
+        new AbortController().signal,
+        'prompt-agent-nested-shell-cancel',
+        [
+          {
+            id: 'agent_call',
+            name: core.ToolNames.AGENT,
+            args: { subagent_type: 'explore' },
+          },
+        ],
+      );
+
+      expect(result.stopAfterPermissionCancel).toBe(true);
       expect(executeSignal?.aborted).toBe(true);
       expect(respond).toHaveBeenCalledWith(
         core.ToolConfirmationOutcome.Cancel,
@@ -6624,7 +6874,7 @@ describe('Session', () => {
 
       await Promise.resolve();
 
-      expect(result.stopAfterUserQuestionCancel).toBe(true);
+      expect(result.stopAfterPermissionCancel).toBe(true);
       const subagentUpdates = vi
         .mocked(mockClient.sessionUpdate)
         .mock.calls.map(([params]) => params.update)
@@ -6703,7 +6953,7 @@ describe('Session', () => {
         },
       ]);
 
-      expect(result.stopAfterUserQuestionCancel).toBe(true);
+      expect(result.stopAfterPermissionCancel).toBe(true);
       expect(questionExecute).toHaveBeenCalledOnce();
       expect(siblingExecute).toHaveBeenCalledOnce();
       expect(siblingSignal?.aborted).toBe(true);
@@ -6755,7 +7005,7 @@ describe('Session', () => {
         },
       ]);
 
-      expect(result.stopAfterUserQuestionCancel).toBe(false);
+      expect(result.stopAfterPermissionCancel).toBe(false);
       expect(execute).toHaveBeenCalledTimes(2);
       expect(receivedAbortStates).toEqual([true, true]);
     });
@@ -6829,7 +7079,7 @@ describe('Session', () => {
           },
         ]);
 
-        expect(result.stopAfterUserQuestionCancel).toBe(true);
+        expect(result.stopAfterPermissionCancel).toBe(true);
         expect(questionExecute).toHaveBeenCalledOnce();
         expect(secondExecute).not.toHaveBeenCalled();
         expect(thirdExecute).not.toHaveBeenCalled();
@@ -6840,11 +7090,11 @@ describe('Session', () => {
         ]);
         expect(result.parts[1]?.functionResponse?.response).toEqual({
           error:
-            'Skipped because ask_user_question was cancelled before the user answered; user input is required before continuing.',
+            'Skipped because a permission request was cancelled before the user answered; user input is required before continuing.',
         });
         expect(result.parts[2]?.functionResponse?.response).toEqual({
           error:
-            'Skipped because ask_user_question was cancelled before the user answered; user input is required before continuing.',
+            'Skipped because a permission request was cancelled before the user answered; user input is required before continuing.',
         });
       } finally {
         if (previousMaxConcurrency === undefined) {
@@ -6935,7 +7185,7 @@ describe('Session', () => {
         },
       ]);
 
-      expect(result.stopAfterUserQuestionCancel).toBe(true);
+      expect(result.stopAfterPermissionCancel).toBe(true);
       expect(questionExecute).toHaveBeenCalledOnce();
       expect(siblingExecute).toHaveBeenCalledOnce();
       expect(shellExecute).not.toHaveBeenCalled();
@@ -6946,7 +7196,7 @@ describe('Session', () => {
       ]);
       expect(result.parts[2]?.functionResponse?.response).toEqual({
         error:
-          'Skipped because ask_user_question was cancelled before the user answered; user input is required before continuing.',
+          'Skipped because a permission request was cancelled before the user answered; user input is required before continuing.',
       });
     });
 
@@ -7027,7 +7277,7 @@ describe('Session', () => {
         ],
       );
 
-      expect(result.stopAfterUserQuestionCancel).toBe(true);
+      expect(result.stopAfterPermissionCancel).toBe(true);
       const hookRequests = messageBus.request.mock.calls.map(([request]) => {
         const eventName =
           typeof request === 'object' &&
@@ -7104,7 +7354,7 @@ describe('Session', () => {
         },
       ]);
 
-      expect(result.stopAfterUserQuestionCancel).toBe(true);
+      expect(result.stopAfterPermissionCancel).toBe(true);
       expect(messageBus.request).toHaveBeenCalledWith(
         expect.objectContaining({
           eventName: 'PostToolUseFailure',
@@ -7177,7 +7427,7 @@ describe('Session', () => {
         ],
       );
 
-      expect(result.stopAfterUserQuestionCancel).toBe(true);
+      expect(result.stopAfterPermissionCancel).toBe(true);
       expect(messageBus.request).toHaveBeenCalledWith(
         expect.objectContaining({
           eventName: 'PostToolUseFailure',
@@ -7232,7 +7482,7 @@ describe('Session', () => {
       expect(result.parts.map((part) => part.functionResponse?.id)).toEqual([
         'dup_id_0001',
       ]);
-      expect(result.stopAfterUserQuestionCancel).toBe(false);
+      expect(result.stopAfterPermissionCancel).toBe(false);
       expect(mockChatRecordingService.recordToolResult).toHaveBeenCalledOnce();
     });
 
@@ -7274,7 +7524,7 @@ describe('Session', () => {
 
       expect(execute).toHaveBeenCalledTimes(2);
       expect(result.parts).toHaveLength(2);
-      expect(result.stopAfterUserQuestionCancel).toBe(false);
+      expect(result.stopAfterPermissionCancel).toBe(false);
       expect(mockChatRecordingService.recordToolResult).toHaveBeenCalledTimes(
         2,
       );

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -6697,6 +6697,78 @@ describe('Session', () => {
       expect(laterExecute).not.toHaveBeenCalled();
     });
 
+    it('cleans up Agent sub-agent listeners when permission request fails before execution', async () => {
+      const eventEmitter = new EventEmitter();
+      const execute = vi.fn();
+      const onConfirm = vi.fn().mockResolvedValue(undefined);
+      mockToolRegistry.getTool.mockReturnValue({
+        name: core.ToolNames.AGENT,
+        kind: core.Kind.Think,
+        displayName: 'Agent',
+        description: 'Agent',
+        build: vi.fn().mockReturnValue({
+          params: { subagent_type: 'explore' },
+          eventEmitter,
+          execute,
+          getDefaultPermission: vi.fn().mockResolvedValue('ask'),
+          getConfirmationDetails: vi.fn().mockResolvedValue({
+            type: 'info',
+            title: 'Agent permission',
+            prompt: 'Allow agent?',
+            onConfirm,
+          }),
+          getDescription: vi.fn().mockReturnValue('Agent'),
+          toolLocations: vi.fn().mockReturnValue([]),
+        }),
+        canUpdateOutput: false,
+        isOutputMarkdown: true,
+      });
+      vi.mocked(mockClient.requestPermission).mockRejectedValueOnce(
+        new Error('client disconnected'),
+      );
+
+      const result = await (
+        session as unknown as ToolCallInternals
+      ).runToolCalls(
+        new AbortController().signal,
+        'prompt-agent-permission-failed',
+        [
+          {
+            id: 'agent_call',
+            name: core.ToolNames.AGENT,
+            args: { subagent_type: 'explore' },
+          },
+        ],
+      );
+
+      eventEmitter.emit(core.AgentEventType.TOOL_RESULT, {
+        subagentId: 'subagent-1',
+        round: 1,
+        callId: 'late_tool',
+        name: core.ToolNames.SHELL,
+        success: true,
+        responseParts: [{ text: 'late result' }],
+        resultDisplay: 'late result',
+        timestamp: Date.now(),
+      });
+      await Promise.resolve();
+
+      expect(result.stopAfterPermissionCancel).toBe(true);
+      expect(execute).not.toHaveBeenCalled();
+      expect(onConfirm).toHaveBeenCalledWith(
+        core.ToolConfirmationOutcome.Cancel,
+      );
+      const subagentUpdates = vi
+        .mocked(mockClient.sessionUpdate)
+        .mock.calls.map(([params]) => params.update)
+        .filter(
+          (update) =>
+            update.sessionUpdate === 'tool_call_update' &&
+            update._meta?.provenance === 'subagent',
+        );
+      expect(subagentUpdates).toEqual([]);
+    });
+
     it('stops and aborts Agent tool execution after nested ask_user_question cancellation', async () => {
       const eventEmitter = new EventEmitter();
       let executeSignal: AbortSignal | undefined;
@@ -7191,6 +7263,113 @@ describe('Session', () => {
       expect(shellExecute).not.toHaveBeenCalled();
       expect(result.parts.map((part) => part.functionResponse?.id)).toEqual([
         'agent_question',
+        'agent_sibling',
+        'shell_after',
+      ]);
+      expect(result.parts[2]?.functionResponse?.response).toEqual({
+        error:
+          'Skipped because a permission request was cancelled before the user answered; user input is required before continuing.',
+      });
+    });
+
+    it('skips later sequential batches after nested non-question permission cancellation', async () => {
+      const permissionEventEmitter = new EventEmitter();
+      const siblingEventEmitter = new EventEmitter();
+      let siblingSignal: AbortSignal | undefined;
+      const respond = vi.fn().mockResolvedValue(undefined);
+      const permissionExecute = vi
+        .fn()
+        .mockImplementation(async (signal: AbortSignal) => {
+          emitNestedInfoPermission(permissionEventEmitter, respond);
+          await vi.waitFor(() => {
+            expect(signal.aborted).toBe(true);
+          });
+          return {
+            llmContent: 'agent stopped',
+            returnDisplay: 'agent stopped',
+          };
+        });
+      const siblingExecute = vi
+        .fn()
+        .mockImplementation(async (signal: AbortSignal) => {
+          siblingSignal = signal;
+          await waitForAbortOrTick(signal);
+          return {
+            llmContent: 'sibling stopped',
+            returnDisplay: 'sibling stopped',
+          };
+        });
+      const shellExecute = vi.fn().mockResolvedValue({
+        llmContent: 'shell result',
+        returnDisplay: 'shell result',
+      });
+      mockToolRegistry.getTool.mockImplementation((name: string) => {
+        if (name !== core.ToolNames.AGENT) {
+          return mockAllowedTool(name, shellExecute);
+        }
+        return {
+          name: core.ToolNames.AGENT,
+          kind: core.Kind.Think,
+          displayName: 'Agent',
+          description: 'Agent',
+          build: vi.fn().mockImplementation((args: Record<string, unknown>) => {
+            const isPermissionAgent = args['_test_id'] === 'permission';
+            return {
+              params: { subagent_type: 'explore', ...args },
+              eventEmitter: isPermissionAgent
+                ? permissionEventEmitter
+                : siblingEventEmitter,
+              execute: isPermissionAgent ? permissionExecute : siblingExecute,
+              getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+              getDescription: vi.fn().mockReturnValue('Agent'),
+              toolLocations: vi.fn().mockReturnValue([]),
+            };
+          }),
+          canUpdateOutput: false,
+          isOutputMarkdown: true,
+        };
+      });
+      vi.mocked(mockClient.requestPermission).mockResolvedValueOnce({
+        outcome: { outcome: 'cancelled' },
+      });
+
+      const result = await (
+        session as unknown as ToolCallInternals
+      ).runToolCalls(
+        new AbortController().signal,
+        'prompt-agent-shell-cancel',
+        [
+          {
+            id: 'agent_permission',
+            name: core.ToolNames.AGENT,
+            args: { _test_id: 'permission', subagent_type: 'explore' },
+          },
+          {
+            id: 'agent_sibling',
+            name: core.ToolNames.AGENT,
+            args: { _test_id: 'sibling', subagent_type: 'explore' },
+          },
+          {
+            id: 'shell_after',
+            name: core.ToolNames.SHELL,
+            args: { command: 'echo should-not-run' },
+          },
+        ],
+      );
+
+      expect(result.stopAfterPermissionCancel).toBe(true);
+      expect(permissionExecute).toHaveBeenCalledOnce();
+      expect(siblingExecute).toHaveBeenCalledOnce();
+      expect(siblingSignal?.aborted).toBe(true);
+      expect(shellExecute).not.toHaveBeenCalled();
+      expect(respond).toHaveBeenCalledWith(
+        core.ToolConfirmationOutcome.Cancel,
+        {
+          answers: undefined,
+        },
+      );
+      expect(result.parts.map((part) => part.functionResponse?.id)).toEqual([
+        'agent_permission',
         'agent_sibling',
         'shell_after',
       ]);

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -174,11 +174,11 @@ type AutoCompressionSendResult =
 
 type RunToolResult = {
   parts: Part[];
-  stopAfterUserQuestionCancel: boolean;
+  stopAfterPermissionCancel: boolean;
 };
 
-const ASK_USER_QUESTION_CANCEL_SKIP_MESSAGE =
-  'Skipped because ask_user_question was cancelled before the user answered; user input is required before continuing.';
+const PERMISSION_CANCEL_SKIP_MESSAGE =
+  'Skipped because a permission request was cancelled before the user answered; user input is required before continuing.';
 
 // The drain is served from an in-memory queue, so a conforming client answers
 // near-instantly (or rejects with -32601). No response within this window
@@ -1525,8 +1525,8 @@ export class Session implements SessionContext {
                     promptId,
                     functionCalls,
                   );
-                  if (toolRun.stopAfterUserQuestionCancel) {
-                    await this.#preserveCancelledAskUserQuestionToolRun(
+                  if (toolRun.stopAfterPermissionCancel) {
+                    await this.#preserveCancelledPermissionToolRun(
                       toolRun,
                       pendingSend.signal,
                     );
@@ -1799,8 +1799,8 @@ export class Session implements SessionContext {
               promptId,
               functionCalls,
             );
-            if (toolRun.stopAfterUserQuestionCancel) {
-              await this.#preserveCancelledAskUserQuestionToolRun(
+            if (toolRun.stopAfterPermissionCancel) {
+              await this.#preserveCancelledPermissionToolRun(
                 toolRun,
                 pendingSend.signal,
               );
@@ -1973,7 +1973,7 @@ export class Session implements SessionContext {
     }
   }
 
-  async #preserveCancelledAskUserQuestionToolRun(
+  async #preserveCancelledPermissionToolRun(
     toolRun: RunToolResult,
     abortSignal: AbortSignal,
   ): Promise<void> {
@@ -2418,8 +2418,8 @@ export class Session implements SessionContext {
                     promptId,
                     functionCalls,
                   );
-                  if (toolRun.stopAfterUserQuestionCancel) {
-                    await this.#preserveCancelledAskUserQuestionToolRun(
+                  if (toolRun.stopAfterPermissionCancel) {
+                    await this.#preserveCancelledPermissionToolRun(
                       toolRun,
                       ac.signal,
                     );
@@ -2731,8 +2731,8 @@ export class Session implements SessionContext {
                 promptId,
                 functionCalls,
               );
-              if (toolRun.stopAfterUserQuestionCancel) {
-                await this.#preserveCancelledAskUserQuestionToolRun(
+              if (toolRun.stopAfterPermissionCancel) {
+                await this.#preserveCancelledPermissionToolRun(
                   toolRun,
                   ac.signal,
                 );
@@ -3098,10 +3098,10 @@ export class Session implements SessionContext {
         functionResponse: {
           id: callId,
           name: toolName,
-          response: { error: ASK_USER_QUESTION_CANCEL_SKIP_MESSAGE },
+          response: { error: PERMISSION_CANCEL_SKIP_MESSAGE },
         },
       };
-      const error = new Error(ASK_USER_QUESTION_CANCEL_SKIP_MESSAGE);
+      const error = new Error(PERMISSION_CANCEL_SKIP_MESSAGE);
       try {
         this.config.getChatRecordingService()?.recordToolResult([part], {
           callId,
@@ -3137,7 +3137,7 @@ export class Session implements SessionContext {
     const runBounded = async (
       calls: FunctionCall[],
       runAbortSignal: AbortSignal,
-      onStopAfterUserQuestionCancel?: () => void,
+      onStopAfterPermissionCancel?: () => void,
       shouldSkipUnstarted?: () => boolean,
     ): Promise<RunToolResult[]> => {
       const parsed = parseInt(
@@ -3153,7 +3153,7 @@ export class Session implements SessionContext {
         if (runAbortSignal.aborted && shouldSkipUnstarted?.()) {
           results[idx] = {
             parts: [await recordSkippedToolCall(calls[idx])],
-            stopAfterUserQuestionCancel: false,
+            stopAfterPermissionCancel: false,
           };
           continue;
         }
@@ -3161,7 +3161,7 @@ export class Session implements SessionContext {
           runAbortSignal,
           promptId,
           calls[idx],
-          onStopAfterUserQuestionCancel,
+          onStopAfterPermissionCancel,
         )
           .then((r) => {
             results[idx] = r;
@@ -3182,7 +3182,7 @@ export class Session implements SessionContext {
     for (const batch of batches) {
       if (batch.concurrent && batch.calls.length > 1) {
         const batchAbortController = new AbortController();
-        let batchStopAfterUserQuestionCancel = false;
+        let batchStopAfterPermissionCancel = false;
         const propagateAbort = () => {
           batchAbortController.abort(abortSignal.reason);
         };
@@ -3193,8 +3193,8 @@ export class Session implements SessionContext {
             once: true,
           });
         }
-        const stopBatchAfterUserQuestionCancel = () => {
-          batchStopAfterUserQuestionCancel = true;
+        const stopBatchAfterPermissionCancel = () => {
+          batchStopAfterPermissionCancel = true;
           batchAbortController.abort(USER_CANCEL_ABORT_REASON);
         };
         let results: RunToolResult[];
@@ -3202,8 +3202,8 @@ export class Session implements SessionContext {
           results = await runBounded(
             batch.calls,
             batchAbortController.signal,
-            stopBatchAfterUserQuestionCancel,
-            () => batchStopAfterUserQuestionCancel,
+            stopBatchAfterPermissionCancel,
+            () => batchStopAfterPermissionCancel,
           );
         } finally {
           abortSignal.removeEventListener('abort', propagateAbort);
@@ -3211,24 +3211,24 @@ export class Session implements SessionContext {
         let shouldStop = false;
         for (const r of results) {
           parts.push(...r.parts);
-          shouldStop ||= r.stopAfterUserQuestionCancel;
+          shouldStop ||= r.stopAfterPermissionCancel;
         }
         if (shouldStop) {
           await appendSkippedAfter(parts, batch.calls[batch.calls.length - 1]);
-          return { parts, stopAfterUserQuestionCancel: true };
+          return { parts, stopAfterPermissionCancel: true };
         }
       } else {
         for (const fc of batch.calls) {
           const r = await this.runTool(abortSignal, promptId, fc);
           parts.push(...r.parts);
-          if (r.stopAfterUserQuestionCancel) {
+          if (r.stopAfterPermissionCancel) {
             await appendSkippedAfter(parts, fc);
-            return { parts, stopAfterUserQuestionCancel: true };
+            return { parts, stopAfterPermissionCancel: true };
           }
         }
       }
     }
-    return { parts, stopAfterUserQuestionCancel: false };
+    return { parts, stopAfterPermissionCancel: false };
   }
 
   /**
@@ -3270,7 +3270,7 @@ export class Session implements SessionContext {
     abortSignal: AbortSignal,
     promptId: string,
     fc: FunctionCall,
-    onStopAfterUserQuestionCancel?: () => void,
+    onStopAfterPermissionCancel?: () => void,
   ): Promise<RunToolResult> {
     const callId = fc.id ?? `${fc.name}-${Date.now()}`;
     let args = (fc.args ?? {}) as Record<string, unknown>;
@@ -3278,7 +3278,7 @@ export class Session implements SessionContext {
     const startTime = Date.now();
     let spanError: string | undefined;
     let activeToolAbortSignal = abortSignal;
-    let nestedAskUserQuestionCancelled = false;
+    let nestedPermissionCancelled = false;
     let agentToolAbortController: AbortController | undefined;
     let removeAgentToolAbortPropagation: (() => void) | undefined;
 
@@ -3315,7 +3315,7 @@ export class Session implements SessionContext {
     const earlyErrorResponse = async (
       error: Error,
       toolName = fc.name ?? 'unknown_tool',
-      opts?: { stopAfterUserQuestionCancel?: boolean },
+      opts?: { stopAfterPermissionCancel?: boolean },
     ) => {
       spanError = error.message;
       removeAgentToolAbortPropagation?.();
@@ -3333,7 +3333,7 @@ export class Session implements SessionContext {
       });
       return {
         parts: errorParts,
-        stopAfterUserQuestionCancel: opts?.stopAfterUserQuestionCancel ?? false,
+        stopAfterPermissionCancel: opts?.stopAfterPermissionCancel ?? false,
       };
     };
 
@@ -3431,9 +3431,9 @@ export class Session implements SessionContext {
               parentToolCallId,
               subagentType,
               () => {
-                nestedAskUserQuestionCancelled = true;
+                nestedPermissionCancelled = true;
                 agentToolAbortController?.abort(USER_CANCEL_ABORT_REASON);
-                onStopAfterUserQuestionCancel?.();
+                onStopAfterPermissionCancel?.();
               },
             );
 
@@ -3732,24 +3732,74 @@ export class Session implements SessionContext {
                   _meta: { toolName },
                 },
               };
+              const stopAfterPermissionCancel = () => {
+                onStopAfterPermissionCancel?.();
+                return earlyErrorResponse(
+                  new Error(`Tool "${toolName}" was canceled by the user.`),
+                  toolName,
+                  { stopAfterPermissionCancel: true },
+                );
+              };
 
-              const output = (await this.client.requestPermission(
-                params,
-              )) as RequestPermissionResponse & {
+              let output: RequestPermissionResponse & {
                 answers?: Record<string, string>;
               };
-              const outcome =
-                output.outcome.outcome === 'cancelled'
-                  ? ToolConfirmationOutcome.Cancel
-                  : z
-                      .nativeEnum(ToolConfirmationOutcome)
-                      .parse(output.outcome.optionId);
+              let outcome: ToolConfirmationOutcome;
+              try {
+                output = (await this.client.requestPermission(
+                  params,
+                )) as RequestPermissionResponse & {
+                  answers?: Record<string, string>;
+                };
+                outcome =
+                  output.outcome.outcome === 'cancelled'
+                    ? ToolConfirmationOutcome.Cancel
+                    : z
+                        .nativeEnum(ToolConfirmationOutcome)
+                        .parse(output.outcome.optionId);
+              } catch (error) {
+                debugLogger.error(
+                  `Permission request failed for tool ${toolName}:`,
+                  error,
+                );
+                try {
+                  await confirmationDetails.onConfirm(
+                    ToolConfirmationOutcome.Cancel,
+                  );
+                } catch (confirmError) {
+                  debugLogger.error(
+                    `Failed to cancel tool ${toolName} after permission request failure:`,
+                    confirmError,
+                  );
+                }
+                onStopAfterPermissionCancel?.();
+                return earlyErrorResponse(
+                  new Error(
+                    `Permission request failed for "${toolName}": ${this.#formatError(
+                      error,
+                    )}`,
+                  ),
+                  toolName,
+                  { stopAfterPermissionCancel: true },
+                );
+              }
 
               recordAutoModeFallbackResolution(outcome);
 
-              await confirmationDetails.onConfirm(outcome, {
-                answers: output.answers,
-              });
+              try {
+                await confirmationDetails.onConfirm(outcome, {
+                  answers: output.answers,
+                });
+              } catch (error) {
+                if (outcome !== ToolConfirmationOutcome.Cancel) {
+                  throw error;
+                }
+                debugLogger.error(
+                  `Failed to confirm cancellation for tool ${toolName}:`,
+                  error,
+                );
+                return stopAfterPermissionCancel();
+              }
 
               // Persist permission rules when user explicitly chose "Always Allow".
               // This branch is only reached for tools that went through
@@ -3787,21 +3837,11 @@ export class Session implements SessionContext {
 
               switch (outcome) {
                 case ToolConfirmationOutcome.Cancel:
-                  if (toolName === ToolNames.ASK_USER_QUESTION) {
-                    onStopAfterUserQuestionCancel?.();
-                  }
                   // Route through earlyErrorResponse so spanError carries the
                   // cancellation reason (plain errorResponse leaves it unset,
                   // which makes endToolSpan fall back to the generic 'tool
                   // error' message) and the declined call is still recorded.
-                  return earlyErrorResponse(
-                    new Error(`Tool "${toolName}" was canceled by the user.`),
-                    toolName,
-                    {
-                      stopAfterUserQuestionCancel:
-                        toolName === ToolNames.ASK_USER_QUESTION,
-                    },
-                  );
+                  return stopAfterPermissionCancel();
                 case ToolConfirmationOutcome.ProceedOnce:
                 case ToolConfirmationOutcome.ProceedAlways:
                 case ToolConfirmationOutcome.ProceedAlwaysProject:
@@ -3948,7 +3988,7 @@ export class Session implements SessionContext {
             messageBusForTool &&
             !toolResult.error &&
             !aborted &&
-            !nestedAskUserQuestionCancelled
+            !nestedPermissionCancelled
           ) {
             // Use the same response shape as core (llmContent/returnDisplay)
             const toolResponse = {
@@ -4080,7 +4120,7 @@ export class Session implements SessionContext {
           }
           return {
             parts: responseParts,
-            stopAfterUserQuestionCancel: nestedAskUserQuestionCancelled,
+            stopAfterPermissionCancel: nestedPermissionCancelled,
           };
         } catch (e) {
           // Ensure cleanup on error
@@ -4140,7 +4180,7 @@ export class Session implements SessionContext {
 
           return {
             parts: errorResponse(error),
-            stopAfterUserQuestionCancel: nestedAskUserQuestionCancelled,
+            stopAfterPermissionCancel: nestedPermissionCancelled,
           };
         }
       }); // end runInToolSpanContext

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -3281,6 +3281,14 @@ export class Session implements SessionContext {
     let nestedPermissionCancelled = false;
     let agentToolAbortController: AbortController | undefined;
     let removeAgentToolAbortPropagation: (() => void) | undefined;
+    let subAgentCleanupFunctions: Array<() => void> = [];
+
+    const cleanupAgentToolResources = () => {
+      subAgentCleanupFunctions.forEach((cleanup) => cleanup());
+      subAgentCleanupFunctions = [];
+      removeAgentToolAbortPropagation?.();
+      removeAgentToolAbortPropagation = undefined;
+    };
 
     const errorResponse = (error: Error) => {
       const durationMs = Date.now() - startTime;
@@ -3318,7 +3326,7 @@ export class Session implements SessionContext {
       opts?: { stopAfterPermissionCancel?: boolean },
     ) => {
       spanError = error.message;
-      removeAgentToolAbortPropagation?.();
+      cleanupAgentToolResources();
       if (toolName !== ToolNames.TODO_WRITE) {
         await this.toolCallEmitter.emitError(callId, toolName, error);
       }
@@ -3394,9 +3402,6 @@ export class Session implements SessionContext {
             };
           }
         }
-
-        // Track cleanup functions for sub-agent event listeners
-        let subAgentCleanupFunctions: Array<() => void> = [];
 
         // Generate tool_use_id for hook tracking (aligned with core path)
         const toolUseId = generateToolUseId();
@@ -3940,8 +3945,7 @@ export class Session implements SessionContext {
           }
 
           // Clean up event listeners
-          subAgentCleanupFunctions.forEach((cleanup) => cleanup());
-          removeAgentToolAbortPropagation?.();
+          cleanupAgentToolResources();
 
           // enter_plan_mode and the AUTO/YOLO gate path of exit_plan_mode change the
           // approval mode inside execute() without going through the user-confirmation
@@ -4124,8 +4128,7 @@ export class Session implements SessionContext {
           };
         } catch (e) {
           // Ensure cleanup on error
-          subAgentCleanupFunctions.forEach((cleanup) => cleanup());
-          removeAgentToolAbortPropagation?.();
+          cleanupAgentToolResources();
 
           const error = e instanceof Error ? e : new Error(String(e));
           spanError = error.message;

--- a/packages/cli/src/acp-integration/session/SubAgentTracker.test.ts
+++ b/packages/cli/src/acp-integration/session/SubAgentTracker.test.ts
@@ -549,13 +549,13 @@ describe('SubAgentTracker', () => {
       requestPermissionSpy.mockResolvedValue({
         outcome: { outcome: 'cancelled' },
       });
-      const onAskUserQuestionCancel = vi.fn();
+      const onPermissionCancel = vi.fn();
       tracker = new SubAgentTracker(
         mockContext,
         mockClient,
         'parent-call-123',
         'test-subagent',
-        onAskUserQuestionCancel,
+        onPermissionCancel,
       );
       tracker.setup(eventEmitter, abortController.signal);
 
@@ -581,23 +581,23 @@ describe('SubAgentTracker', () => {
           },
         );
       });
-      expect(onAskUserQuestionCancel).toHaveBeenCalledOnce();
+      expect(onPermissionCancel).toHaveBeenCalledOnce();
       expect(respondSpy.mock.invocationCallOrder[0]).toBeLessThan(
-        onAskUserQuestionCancel.mock.invocationCallOrder[0],
+        onPermissionCancel.mock.invocationCallOrder[0],
       );
     });
 
-    it('does not notify when a non-question subagent tool is cancelled', async () => {
+    it('notifies when a non-question subagent tool is cancelled', async () => {
       requestPermissionSpy.mockResolvedValue({
         outcome: { outcome: 'cancelled' },
       });
-      const onAskUserQuestionCancel = vi.fn();
+      const onPermissionCancel = vi.fn();
       tracker = new SubAgentTracker(
         mockContext,
         mockClient,
         'parent-call-123',
         'test-subagent',
-        onAskUserQuestionCancel,
+        onPermissionCancel,
       );
       tracker.setup(eventEmitter, abortController.signal);
 
@@ -619,30 +619,29 @@ describe('SubAgentTracker', () => {
           },
         );
       });
-      expect(onAskUserQuestionCancel).not.toHaveBeenCalled();
+      expect(onPermissionCancel).toHaveBeenCalledOnce();
+      expect(respondSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        onPermissionCancel.mock.invocationCallOrder[0],
+      );
     });
 
-    it('notifies when nested ask_user_question permission request fails', async () => {
+    it('notifies when nested permission request fails', async () => {
       requestPermissionSpy.mockRejectedValue(new Error('Network error'));
-      const onAskUserQuestionCancel = vi.fn();
+      const onPermissionCancel = vi.fn();
       tracker = new SubAgentTracker(
         mockContext,
         mockClient,
         'parent-call-123',
         'test-subagent',
-        onAskUserQuestionCancel,
+        onPermissionCancel,
       );
       tracker.setup(eventEmitter, abortController.signal);
 
       const respondSpy = vi.fn().mockResolvedValue(undefined);
       const event = createApprovalEvent({
-        name: ToolNames.ASK_USER_QUESTION,
-        callId: 'call-ask',
-        confirmationDetails: {
-          type: 'ask_user_question',
-          title: 'Question',
-          questions: [{ question: 'Continue?', header: 'Question' }],
-        } as AgentApprovalRequestEvent['confirmationDetails'],
+        name: 'shell',
+        callId: 'call-shell',
+        confirmationDetails: createInfoConfirmation(),
         respond: respondSpy,
       });
 
@@ -651,40 +650,36 @@ describe('SubAgentTracker', () => {
       await vi.waitFor(() => {
         expect(respondSpy).toHaveBeenCalledWith(ToolConfirmationOutcome.Cancel);
       });
-      expect(onAskUserQuestionCancel).toHaveBeenCalledOnce();
-      expect(onAskUserQuestionCancel.mock.invocationCallOrder[0]).toBeLessThan(
+      expect(onPermissionCancel).toHaveBeenCalledOnce();
+      expect(onPermissionCancel.mock.invocationCallOrder[0]).toBeLessThan(
         respondSpy.mock.invocationCallOrder[0],
       );
     });
 
-    it('notifies when nested ask_user_question permission failure cannot respond', async () => {
+    it('notifies when nested permission failure cannot respond', async () => {
       requestPermissionSpy.mockRejectedValue(new Error('Network error'));
-      const onAskUserQuestionCancel = vi.fn();
+      const onPermissionCancel = vi.fn();
       tracker = new SubAgentTracker(
         mockContext,
         mockClient,
         'parent-call-123',
         'test-subagent',
-        onAskUserQuestionCancel,
+        onPermissionCancel,
       );
       tracker.setup(eventEmitter, abortController.signal);
 
       const respondSpy = vi.fn().mockRejectedValue(new Error('Already closed'));
       const event = createApprovalEvent({
-        name: ToolNames.ASK_USER_QUESTION,
-        callId: 'call-ask',
-        confirmationDetails: {
-          type: 'ask_user_question',
-          title: 'Question',
-          questions: [{ question: 'Continue?', header: 'Question' }],
-        } as AgentApprovalRequestEvent['confirmationDetails'],
+        name: 'shell',
+        callId: 'call-shell',
+        confirmationDetails: createInfoConfirmation(),
         respond: respondSpy,
       });
 
       eventEmitter.emit(AgentEventType.TOOL_WAITING_APPROVAL, event);
 
       await vi.waitFor(() => {
-        expect(onAskUserQuestionCancel).toHaveBeenCalledOnce();
+        expect(onPermissionCancel).toHaveBeenCalledOnce();
       });
       expect(respondSpy).toHaveBeenCalledWith(ToolConfirmationOutcome.Cancel);
     });

--- a/packages/cli/src/acp-integration/session/SubAgentTracker.ts
+++ b/packages/cli/src/acp-integration/session/SubAgentTracker.ts
@@ -18,7 +18,6 @@ import type {
 import {
   AgentEventType,
   ToolConfirmationOutcome,
-  ToolNames,
   createDebugLogger,
 } from '@qwen-code/qwen-code-core';
 import { z } from 'zod';
@@ -64,7 +63,7 @@ export class SubAgentTracker {
     private readonly client: AgentSideConnection,
     parentToolCallId: string,
     subagentType: string,
-    private readonly onAskUserQuestionCancel?: () => void,
+    private readonly onPermissionCancel?: () => void,
   ) {
     this.toolCallEmitter = new ToolCallEmitter(ctx);
     this.messageEmitter = new MessageEmitter(ctx);
@@ -232,11 +231,8 @@ export class SubAgentTracker {
         await event.respond(outcome, {
           answers: 'answers' in output ? output.answers : undefined,
         });
-        if (
-          outcome === ToolConfirmationOutcome.Cancel &&
-          event.name === ToolNames.ASK_USER_QUESTION
-        ) {
-          this.onAskUserQuestionCancel?.();
+        if (outcome === ToolConfirmationOutcome.Cancel) {
+          this.onPermissionCancel?.();
         }
       } catch (error) {
         // If permission request fails, cancel the tool call
@@ -244,12 +240,10 @@ export class SubAgentTracker {
           `Permission request failed for subagent tool ${event.name}:`,
           error,
         );
-        if (event.name === ToolNames.ASK_USER_QUESTION) {
-          // Fail closed: if the client cannot answer a nested user question,
-          // stop the parent turn instead of letting later tools run without the
-          // required user input.
-          this.onAskUserQuestionCancel?.();
-        }
+        // Fail closed: if the client cannot answer a nested permission
+        // request, stop the parent turn instead of letting later tools run
+        // without the required user input.
+        this.onPermissionCancel?.();
         try {
           await event.respond(ToolConfirmationOutcome.Cancel);
         } catch (respondError) {


### PR DESCRIPTION
## What this PR does

This PR makes ACP permission cancellation stop the current turn for every tool permission request, not just `ask_user_question`. When a permission vote resolves as cancelled, when the reject option maps to `Cancel`, or when the permission request channel fails, the declined tool is recorded and later tool calls in the same model response are skipped. It applies the same fail-closed behavior to nested Agent tool permission requests so a subagent cancellation aborts the parent Agent turn instead of letting sibling or subsequent tools continue.

## Why it's needed

A daemon permission timeout resolves as cancelled after the configured permission timeout. Before this change, that cancellation only stopped the turn for `ask_user_question`; ordinary shell, file, or MCP permission cancellations could still allow later tool calls from the same assistant step to run. This made a timed-out or explicitly cancelled permission prompt look cancelled in the UI while the model could continue executing follow-up tools.

## Reviewer Test Plan

### How to verify

Run the focused ACP session tests and confirm cancelled ordinary permissions, selected reject options, permission request failures, and nested subagent permission cancellations all stop the turn and skip later tool calls. For an end-to-end check, start the daemon/WebShell, create a session, set approval mode to `default`, prompt for two shell commands that write `/tmp/qwen_cancel_first_5218` and `/tmp/qwen_cancel_second_5218`, then cancel the permission request; the first tool should be reported as cancelled, the second should be skipped, the turn should complete with `end_turn`, and neither sentinel file should exist.

### Evidence (Before & After)

Before: a cancelled or timed-out non-`ask_user_question` permission could still let later tool calls from the same assistant step continue. After: local daemon/WebShell HTTP/SSE verification emitted one `permission_request`, the cancel vote returned `200`, the first `run_shell_command` tool result was cancelled, the second tool result was skipped with the permission-cancel skip message, `turn_complete.stopReason` was `end_turn`, and both `/tmp/qwen_cancel_first_5218` and `/tmp/qwen_cancel_second_5218` were absent.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS local workspace with Node `v22.22.3` and npm `10.9.8`; daemon/WebShell E2E used `QWEN_SERVER_TOKEN=codex-local-verify npm run dev:daemon -- --port 4170`.

## Risk & Scope

- Main risk or tradeoff: Cancelled permission requests now stop remaining tool calls in the same model response for all permissioned tools, intentionally prioritizing the user's cancellation over continuing with model-planned follow-up tools.
- Not validated / out of scope: Browser-panel click automation was blocked by Codex Browser policy, so the E2E validation used daemon HTTP/SSE and daemon logs; Windows and Linux were not tested locally.
- Breaking changes / migration notes: No API or schema changes; this is a behavior fix for cancelled permission requests.

## Linked Issues

Follow-up to #5218.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让 ACP 权限取消对所有工具权限请求都会停止当前 turn，而不再只针对 `ask_user_question`。当权限投票结果是 cancelled、当拒绝选项映射到 `Cancel`、或者权限请求通道失败时，被拒绝的工具会被记录，同一个模型响应里的后续工具调用会被跳过。嵌套 Agent 工具里的权限请求也采用同样的 fail-closed 行为，因此 subagent 的权限取消会中止父级 Agent turn，而不会继续执行 sibling 或后续工具。

## Why it's needed

daemon 权限超时会在配置的权限超时后解析为 cancelled。在这个改动之前，这种取消只会让 `ask_user_question` 停止 turn；普通 shell、file 或 MCP 权限取消仍可能让同一个 assistant step 里的后续工具继续运行。这会导致权限提示在 UI 上看起来已经取消或超时，但模型仍继续执行后续工具。

## Reviewer Test Plan

### How to verify

运行聚焦的 ACP session 测试，确认普通权限取消、选择拒绝选项、权限请求失败、以及嵌套 subagent 权限取消都会停止 turn 并跳过后续工具。端到端验证可以启动 daemon/WebShell，创建 session，将 approval mode 设置为 `default`，发送要求两个 shell command 分别写入 `/tmp/qwen_cancel_first_5218` 和 `/tmp/qwen_cancel_second_5218` 的 prompt，然后取消权限请求；预期第一个工具显示 cancelled，第二个工具显示 skipped，turn 以 `end_turn` 完成，并且两个哨兵文件都不存在。

### Evidence (Before & After)

Before：取消或超时的非 `ask_user_question` 权限请求仍可能让同一个 assistant step 里的后续工具继续执行。After：本地 daemon/WebShell HTTP/SSE 验证产生了一个 `permission_request`，cancel vote 返回 `200`，第一个 `run_shell_command` 工具结果为 cancelled，第二个工具结果为带 permission-cancel skip message 的 skipped，`turn_complete.stopReason` 为 `end_turn`，且 `/tmp/qwen_cancel_first_5218` 和 `/tmp/qwen_cancel_second_5218` 都不存在。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 本地工作区，Node `v22.22.3`，npm `10.9.8`；daemon/WebShell E2E 使用 `QWEN_SERVER_TOKEN=codex-local-verify npm run dev:daemon -- --port 4170`。

## Risk & Scope

- Main risk or tradeoff：取消的权限请求现在会对所有需要权限的工具停止同一个模型响应中的剩余工具调用，这是有意优先尊重用户取消而不是继续执行模型规划的后续工具。
- Not validated / out of scope：浏览器面板点击自动化被 Codex Browser 策略阻止，因此 E2E 验证使用 daemon HTTP/SSE 和 daemon 日志；Windows 和 Linux 没有在本地测试。
- Breaking changes / migration notes：没有 API 或 schema 变更；这是对权限取消行为的修复。

## Linked Issues

Follow-up to #5218.

</details>
