### PR TITLE
fix(cli): support Ctrl+P/N in completions

### DIFF
--- a/docs/users/reference/keyboard-shortcuts.md
+++ b/docs/users/reference/keyboard-shortcuts.md
@@ -51,11 +51,11 @@ This document lists the available keyboard shortcuts in Qwen Code.
 
 ## Suggestions
 
-| Shortcut        | Description                            |
-| --------------- | -------------------------------------- |
-| `Down Arrow`    | Navigate down through the suggestions. |
-| `Tab` / `Enter` | Accept the selected suggestion.        |
-| `Up Arrow`      | Navigate up through the suggestions.   |
+| Shortcut                | Description                            |
+| ----------------------- | -------------------------------------- |
+| `Down Arrow` / `Ctrl+N` | Navigate down through the suggestions. |
+| `Tab` / `Enter`         | Accept the selected suggestion.        |
+| `Up Arrow` / `Ctrl+P`   | Navigate up through the suggestions.   |
 
 ## Radio Button Select
 

--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -166,9 +166,15 @@ export const defaultKeyBindings: KeyBindingConfig = {
 
   // Auto-completion
   [Command.ACCEPT_SUGGESTION]: [{ key: 'tab' }, { key: 'return', ctrl: false }],
-  // Completion navigation uses only arrow keys
-  [Command.COMPLETION_UP]: [{ key: 'up', shift: false }],
-  [Command.COMPLETION_DOWN]: [{ key: 'down', shift: false }],
+  // Completion navigation: arrows + readline/Vim-style Ctrl+P/Ctrl+N
+  [Command.COMPLETION_UP]: [
+    { key: 'up', shift: false },
+    { key: 'p', ctrl: true },
+  ],
+  [Command.COMPLETION_DOWN]: [
+    { key: 'down', shift: false },
+    { key: 'n', ctrl: true },
+  ],
 
   // Text input
   // Must also exclude shift to allow shift+enter for newline

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -763,13 +763,14 @@ describe('InputPrompt', () => {
     expect(mockCommandCompletion.navigateUp).toHaveBeenCalledTimes(1);
     expect(mockCommandCompletion.navigateDown).not.toHaveBeenCalled();
 
-    // Ctrl+P should navigate history, not completion
-    // Two-step edge: pre-position cursor at col 0 so Ctrl+P directly triggers history
+    // Ctrl+P should navigate completion while suggestions are visible.
+    // Two-step edge: pre-position cursor at col 0 so a fallthrough would
+    // directly trigger history.
     mockBuffer.visualCursor = [0, 0];
     stdin.write('\u0010'); // Ctrl+P
     await wait();
-    expect(mockCommandCompletion.navigateUp).toHaveBeenCalledTimes(1);
-    expect(mockInputHistory.navigateUp).toHaveBeenCalled();
+    expect(mockCommandCompletion.navigateUp).toHaveBeenCalledTimes(2);
+    expect(mockInputHistory.navigateUp).not.toHaveBeenCalled();
 
     unmount();
   });
@@ -794,13 +795,14 @@ describe('InputPrompt', () => {
     expect(mockCommandCompletion.navigateDown).toHaveBeenCalledTimes(1);
     expect(mockCommandCompletion.navigateUp).not.toHaveBeenCalled();
 
-    // Ctrl+N should navigate history, not completion
-    // Two-step edge: pre-position cursor at end so Ctrl+N directly triggers history
+    // Ctrl+N should navigate completion while suggestions are visible.
+    // Two-step edge: pre-position cursor at end so a fallthrough would
+    // directly trigger history.
     mockBuffer.visualCursor = [0, '/mem'.length];
     stdin.write('\u000E'); // Ctrl+N
     await wait();
-    expect(mockCommandCompletion.navigateDown).toHaveBeenCalledTimes(1);
-    expect(mockInputHistory.navigateDown).toHaveBeenCalled();
+    expect(mockCommandCompletion.navigateDown).toHaveBeenCalledTimes(2);
+    expect(mockInputHistory.navigateDown).not.toHaveBeenCalled();
 
     unmount();
   });
@@ -1226,6 +1228,39 @@ describe('InputPrompt', () => {
     expect(props.buffer.setText).toHaveBeenNthCalledWith(2, '/export md');
     expect(props.buffer.setText).toHaveBeenNthCalledWith(3, '/export json');
     expect(mockInputHistory.navigateDown).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('should keep cycling export formats with Ctrl+P/N after arrow navigation fills input', async () => {
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      showSuggestions: true,
+      suggestions: [
+        { label: 'html', value: 'html' },
+        { label: 'md', value: 'md' },
+        { label: 'json', value: 'json' },
+        { label: 'jsonl', value: 'jsonl' },
+      ],
+      activeSuggestionIndex: 0,
+      isPerfectMatch: true,
+    });
+    props.buffer.setText('/export');
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    await wait();
+
+    stdin.write('\u001B[B');
+    await wait();
+    stdin.write('\u000E');
+    await wait();
+    stdin.write('\u0010');
+    await wait();
+
+    expect(props.buffer.setText).toHaveBeenNthCalledWith(2, '/export md');
+    expect(props.buffer.setText).toHaveBeenNthCalledWith(3, '/export json');
+    expect(props.buffer.setText).toHaveBeenNthCalledWith(4, '/export md');
+    expect(mockInputHistory.navigateDown).not.toHaveBeenCalled();
+    expect(mockInputHistory.navigateUp).not.toHaveBeenCalled();
     unmount();
   });
 

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -428,8 +428,8 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   const inputHistory = useInputHistory({
     userMessages,
     onSubmit: handleSubmitAndClear,
-    // History navigation (Ctrl+P/N) now always works since completion navigation
-    // only uses arrow keys. Only disable in shell mode.
+    // History navigation still owns Ctrl+P/N when the completion menu is not
+    // handling them. Only disable in shell mode.
     isActive: !shellModeActive,
     currentQuery: buffer.text,
     onChange: customSetTextAndResetCompletionSignal,

--- a/packages/cli/src/ui/hooks/useExportCompletion.ts
+++ b/packages/cli/src/ui/hooks/useExportCompletion.ts
@@ -228,7 +228,6 @@ export function useExportCompletion(
       if (
         cyclingActiveRef.current &&
         parsedFormat !== null &&
-        !key.ctrl &&
         !key.meta &&
         !key.paste &&
         (isCompletionUpKey || isCompletionDownKey || isCompletionTabKey)

--- a/packages/cli/src/ui/keyMatchers.test.ts
+++ b/packages/cli/src/ui/keyMatchers.test.ts
@@ -40,10 +40,11 @@ describe('keyMatchers', () => {
     [Command.NAVIGATION_DOWN]: (key: Key) => key.name === 'down' && !key.shift,
     [Command.ACCEPT_SUGGESTION]: (key: Key) =>
       key.name === 'tab' || (key.name === 'return' && !key.ctrl),
-    // Completion navigation only uses arrow keys (not Ctrl+P/N)
-    // to allow Ctrl+P/N to always navigate history
-    [Command.COMPLETION_UP]: (key: Key) => key.name === 'up' && !key.shift,
-    [Command.COMPLETION_DOWN]: (key: Key) => key.name === 'down' && !key.shift,
+    // Completion navigation uses arrows plus readline/Vim-style Ctrl+P/N.
+    [Command.COMPLETION_UP]: (key: Key) =>
+      (key.name === 'up' && !key.shift) || (key.ctrl && key.name === 'p'),
+    [Command.COMPLETION_DOWN]: (key: Key) =>
+      (key.name === 'down' && !key.shift) || (key.ctrl && key.name === 'n'),
     [Command.ESCAPE]: (key: Key) => key.name === 'escape',
     [Command.SUBMIT]: (key: Key) =>
       key.name === 'return' && !key.ctrl && !key.meta && !key.paste,
@@ -200,26 +201,24 @@ describe('keyMatchers', () => {
       negative: [createKey('return', { ctrl: true }), createKey('space')],
     },
     {
-      // Completion navigation only uses arrow keys (not Ctrl+P/N)
-      // to allow Ctrl+P/N to always navigate history
+      // Completion navigation uses arrows plus readline/Vim-style Ctrl+P.
       command: Command.COMPLETION_UP,
-      positive: [createKey('up')],
+      positive: [createKey('up'), createKey('p', { ctrl: true })],
       negative: [
         createKey('p'),
         createKey('down'),
-        createKey('p', { ctrl: true }),
+        createKey('n', { ctrl: true }),
         createKey('up', { shift: true }),
       ],
     },
     {
-      // Completion navigation only uses arrow keys (not Ctrl+P/N)
-      // to allow Ctrl+P/N to always navigate history
+      // Completion navigation uses arrows plus readline/Vim-style Ctrl+N.
       command: Command.COMPLETION_DOWN,
-      positive: [createKey('down')],
+      positive: [createKey('down'), createKey('n', { ctrl: true })],
       negative: [
         createKey('n'),
         createKey('up'),
-        createKey('n', { ctrl: true }),
+        createKey('p', { ctrl: true }),
         createKey('down', { shift: true }),
       ],
     },


### PR DESCRIPTION
## What this PR does

Adds `Ctrl+P` and `Ctrl+N` as navigation keys for the autocomplete menu. When completion suggestions are visible, `Ctrl+P` moves to the previous suggestion and `Ctrl+N` moves to the next suggestion. When suggestions are not visible, the existing input-history behavior remains unchanged.

## Why it's needed

Issue #2561 asks for Vim/readline-style navigation in `@` file selection and `/` command completion. The current code still lets completion navigation use only arrow keys, while `Ctrl+P` / `Ctrl+N` fall through to prompt history even when the completion menu is open.

## Reviewer Test Plan

### How to verify

Run the focused CLI suites and checks below. The updated tests cover `Ctrl+P` / `Ctrl+N` navigating completion while suggestions are visible, preserving history behavior when suggestions are hidden, and keeping export-specific completion behavior intact.

```bash
cd packages/cli && npx vitest run src/ui/components/InputPrompt.test.tsx src/ui/keyMatchers.test.ts src/ui/hooks/useCommandCompletion.test.ts src/ui/hooks/useExportCompletion.test.ts
npx eslint packages/cli/src/config/keyBindings.ts packages/cli/src/ui/components/InputPrompt.tsx packages/cli/src/ui/components/InputPrompt.test.tsx packages/cli/src/ui/keyMatchers.test.ts
cd packages/cli && npm run typecheck
cd packages/core && npm run build && cd ../cli && npm run build
npm run check-i18n --workspace=packages/cli
git diff --check
```

### Evidence (Before & After)

Before: `Ctrl+P` / `Ctrl+N` navigated prompt history even while completion suggestions were visible. After: completion suggestions handle those keys first; normal prompt-history navigation still works when there is no completion menu.

Local validation passed: 249 related Vitest tests, touched-file ESLint, CLI typecheck, core+CLI build, `check-i18n`, Prettier check, and `git diff --check`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS local checkout, Node/npm workspace scripts. Windows and Linux are left to CI.

## Risk & Scope

- Main risk or tradeoff: `Ctrl+P` / `Ctrl+N` now prioritize the visible completion menu over prompt history. This is limited to the completion-active path and matches the requested Vim/readline-style menu behavior.
- Not validated / out of scope: Manual terminal-level validation across every terminal emulator's Ctrl-key handling.
- Breaking changes / migration notes: None expected.

## Linked Issues

Fixes #2561

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 给 autocomplete 菜单增加 `Ctrl+P` 和 `Ctrl+N` 导航。completion suggestions 显示时，`Ctrl+P` 选择上一个 suggestion，`Ctrl+N` 选择下一个 suggestion。suggestions 不显示时，原有的 prompt history 行为保持不变。

## Why it's needed

Issue #2561 希望 `@` 文件选择和 `/` 命令补全支持 Vim/readline 风格导航。当前代码中 completion navigation 仍然只支持方向键，completion 菜单打开时 `Ctrl+P` / `Ctrl+N` 仍会落到 prompt history。

## Reviewer Test Plan

### How to verify

运行上面的 focused CLI suites 和检查。更新后的测试覆盖了 suggestions 显示时 `Ctrl+P` / `Ctrl+N` 导航 completion、suggestions 隐藏时保留 history 行为，以及 export-specific completion 行为不被破坏。

### Evidence (Before & After)

Before：completion suggestions 显示时，`Ctrl+P` / `Ctrl+N` 仍会导航 prompt history。After：completion suggestions 会优先处理这些按键；没有 completion 菜单时，普通 prompt history navigation 仍然工作。

本地验证已通过：249 个相关 Vitest tests、touched-file ESLint、CLI typecheck、core+CLI build、`check-i18n`、Prettier check 和 `git diff --check`。

### Tested on

见上方 OS 表。macOS 本地已测；Windows 和 Linux 交给 CI。

### Environment (optional)

macOS 本地 checkout，Node/npm workspace scripts。

## Risk & Scope

- Main risk or tradeoff：`Ctrl+P` / `Ctrl+N` 现在会在 completion 菜单可见时优先操作 completion，而不是 prompt history。这个变化只限于 completion-active 路径，并符合 issue 请求的 Vim/readline 菜单行为。
- Not validated / out of scope：没有手动验证所有终端模拟器对 Ctrl 键的传递差异。
- Breaking changes / migration notes：预计无破坏性变更。

## Linked Issues

Fixes #2561

</details>
