### PR TITLE
feat(serve): make ACP permission timeout configurable

### DIFF
--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -784,7 +784,12 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     opts.permissionResponseTimeoutMs ?? DEFAULT_PERMISSION_TIMEOUT_MS;
   const permissionTimeoutMs =
     permissionTimeoutRaw > 0 && Number.isFinite(permissionTimeoutRaw)
-      ? permissionTimeoutRaw
+      ? // Clamp to 2^31-1: Node treats setTimeout delays larger than
+        // this as 1ms (TimeoutOverflowWarning), which would make a
+        // huge "effectively never" timeout cancel prompts almost
+        // immediately — the opposite of intent. Mirrors the sibling
+        // `resolvePositiveFiniteMs` / `resolvedChannelIdleTimeoutMs`.
+        Math.min(permissionTimeoutRaw, 2_147_483_647)
       : 0; // 0 = disabled
   const maxPendingRaw =
     opts.maxPendingPermissionsPerSession ?? DEFAULT_MAX_PENDING_PER_SESSION;

--- a/packages/cli/src/commands/serve.test.ts
+++ b/packages/cli/src/commands/serve.test.ts
@@ -24,4 +24,16 @@ describe('serve command args', () => {
     const parsed = buildParser().parseSync('');
     expect(parsed['enable-session-shell']).toBe(false);
   });
+
+  it('parses --permission-response-timeout-ms as a number', () => {
+    const parsed = buildParser().parseSync(
+      '--permission-response-timeout-ms 60000',
+    );
+    expect(parsed['permission-response-timeout-ms']).toBe(60000);
+  });
+
+  it('leaves --permission-response-timeout-ms unset by default', () => {
+    const parsed = buildParser().parseSync('');
+    expect(parsed['permission-response-timeout-ms']).toBeUndefined();
+  });
 });

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -54,6 +54,7 @@ interface ServeArgs {
   'channel-idle-timeout-ms'?: number;
   'session-reap-interval-ms'?: number;
   'session-idle-timeout-ms'?: number;
+  'permission-response-timeout-ms'?: number;
   'rate-limit'?: boolean;
   'rate-limit-prompt'?: number;
   'rate-limit-mutation'?: number;
@@ -216,6 +217,13 @@ export const serveCommand: CommandModule<unknown, ServeArgs> = {
         description:
           'Idle timeout before a disconnected session is reaped (ms). ' +
           '0 = disabled. Default: 1800000 (30 min).',
+      })
+      .option('permission-response-timeout-ms', {
+        type: 'number',
+        description:
+          'Wall-clock timeout for a single human permission / ' +
+          'ask_user_question response in daemon (ACP) mode (ms). ' +
+          '0 = disabled (wait forever). Default: 300000 (5 min).',
       })
       .option('rate-limit', {
         type: 'boolean',
@@ -436,6 +444,12 @@ export const serveCommand: CommandModule<unknown, ServeArgs> = {
           : {}),
         ...(argv['session-idle-timeout-ms'] !== undefined
           ? { sessionIdleTimeoutMs: argv['session-idle-timeout-ms'] }
+          : {}),
+        ...(argv['permission-response-timeout-ms'] !== undefined
+          ? {
+              permissionResponseTimeoutMs:
+                argv['permission-response-timeout-ms'],
+            }
           : {}),
         ...(rateLimit ? { rateLimit: true } : {}),
         ...(rateLimitPrompt !== undefined ? { rateLimitPrompt } : {}),

--- a/packages/cli/src/serve/runQwenServe.test.ts
+++ b/packages/cli/src/serve/runQwenServe.test.ts
@@ -265,3 +265,53 @@ describe('runQwenServe daemon logger wiring', () => {
     }
   });
 });
+
+/**
+ * Boot validation for the embedded `runQwenServe` API: a non-finite
+ * `permissionResponseTimeoutMs` (e.g. config- or NaN-derived) must fail
+ * loud rather than reach the bridge, where it would be treated as the
+ * "disabled" sentinel and silently drop the permission deadline.
+ */
+describe('runQwenServe permissionResponseTimeoutMs validation', () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a non-finite permissionResponseTimeoutMs', async () => {
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'qws-pt-')));
+    const fakeBridge = {
+      spawnOrAttach: vi.fn(),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+      killAllSync: vi.fn(),
+    } as unknown as HttpAcpBridge;
+
+    // Keep the daemon logger inside the temp dir so the boot path before
+    // the validation throw doesn't write into the real ~/.qwen.
+    const origEnv = process.env['QWEN_RUNTIME_DIR'];
+    process.env['QWEN_RUNTIME_DIR'] = tmpDir;
+    try {
+      await expect(
+        runQwenServe(
+          {
+            port: 0,
+            hostname: '127.0.0.1',
+            mode: 'http-bridge',
+            workspace: tmpDir,
+            maxSessions: 1,
+            permissionResponseTimeoutMs: Number.NaN,
+          },
+          { bridge: fakeBridge },
+        ),
+      ).rejects.toThrow(/permissionResponseTimeoutMs/);
+    } finally {
+      delete process.env['QWEN_RUNTIME_DIR'];
+      if (origEnv !== undefined) {
+        process.env['QWEN_RUNTIME_DIR'] = origEnv;
+      }
+    }
+  });
+});

--- a/packages/cli/src/serve/runQwenServe.ts
+++ b/packages/cli/src/serve/runQwenServe.ts
@@ -685,6 +685,22 @@ export async function runQwenServe(
       );
     }
   }
+  // Validate here (not just in the yargs handler) so embedded callers of
+  // `runQwenServe({ permissionResponseTimeoutMs })` also fail loud: the
+  // bridge treats a non-finite / negative value as the "disabled"
+  // sentinel, which would silently drop the permission deadline. Mirrors
+  // `channelIdleTimeoutMs`; out-of-range values are clamped by the bridge.
+  if (opts.permissionResponseTimeoutMs !== undefined) {
+    if (
+      !Number.isFinite(opts.permissionResponseTimeoutMs) ||
+      !Number.isInteger(opts.permissionResponseTimeoutMs) ||
+      opts.permissionResponseTimeoutMs < 0
+    ) {
+      throw new TypeError(
+        `Invalid permissionResponseTimeoutMs: ${opts.permissionResponseTimeoutMs}. Must be a non-negative integer (milliseconds, 0 = disabled / wait forever).`,
+      );
+    }
+  }
   // Per-handle env overrides: `undefined` value means "scrub this
   // var from the child env" — important when a different daemon
   // in the same process set the var globally previously. Always
@@ -876,6 +892,9 @@ export async function runQwenServe(
         : {}),
       ...(opts.sessionIdleTimeoutMs !== undefined
         ? { sessionIdleTimeoutMs: opts.sessionIdleTimeoutMs }
+        : {}),
+      ...(opts.permissionResponseTimeoutMs !== undefined
+        ? { permissionResponseTimeoutMs: opts.permissionResponseTimeoutMs }
         : {}),
       boundWorkspace,
       sessionShellCommandEnabled,

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -975,6 +975,7 @@ export function createServeApp(
       maxSessions: opts.maxSessions,
       maxPendingPromptsPerSession: opts.maxPendingPromptsPerSession,
       eventRingSize: opts.eventRingSize,
+      permissionResponseTimeoutMs: opts.permissionResponseTimeoutMs,
       boundWorkspace,
       sessionShellCommandEnabled,
       // Wire the production status provider so direct embeds / tests

--- a/packages/cli/src/serve/types.ts
+++ b/packages/cli/src/serve/types.ts
@@ -179,6 +179,12 @@ export interface ServeOptions {
   /** Session idle timeout in ms. 0 = disabled. Default: 1800000 (30 min). */
   sessionIdleTimeoutMs?: number;
   /**
+   * Wall-clock timeout in ms for a single human permission /
+   * ask_user_question response in daemon (ACP) mode. 0 = disabled
+   * (wait forever). Default: 300000 (5 min).
+   */
+  permissionResponseTimeoutMs?: number;
+  /**
    * Enable per-tier HTTP rate limiting. Off by default. When enabled,
    * requests exceeding per-tier limits receive 429 + Retry-After.
    */


### PR DESCRIPTION
## What this PR does

Adds a `--permission-response-timeout-ms` flag to `qwen serve` so operators can configure how long the daemon waits for a single human permission / `ask_user_question` response before cancelling the prompt. The value is threaded from the CLI through `ServeOptions` into `createAcpSessionBridge`, overriding the bridge's previously hardcoded 5-minute default. Passing `0` disables the deadline (wait forever).

The change also hardens two edge cases on this newly exposed surface: the bridge clamps the timeout to `2^31-1` so an oversized value can't overflow Node's timer, and `runQwenServe` validates the value at boot so neither the CLI nor embedded callers can silently drop the deadline.

## Why it's needed

In daemon (ACP) mode, every permission / `ask_user_question` prompt goes through the bridge's per-request wall-clock deadline, which was fixed at 5 minutes (`DEFAULT_PERMISSION_TIMEOUT_MS`) with no way to change it. Deployments where a human may take longer than 5 minutes to respond (or where prompts should never auto-cancel) had no escape hatch. This exposes the existing `BridgeOptions.permissionResponseTimeoutMs` knob — already supported programmatically — through the `qwen serve` CLI, matching how the sibling idle/reaper timeouts are wired.

While exposing it, two latent footguns became reachable and are fixed here:
- A value above Node's 32-bit timer limit makes `setTimeout` silently degrade to 1ms, cancelling prompts almost immediately — the opposite of a "long timeout". The bridge now clamps, mirroring the existing `resolvePositiveFiniteMs` / `resolvedChannelIdleTimeoutMs` siblings.
- A malformed value (e.g. `--permission-response-timeout-ms abc` → `NaN`, or a config-derived NaN passed to the embedded `runQwenServe` API) is treated by the bridge as the "disabled" sentinel — silently removing the advertised safety deadline. `runQwenServe` now rejects non-finite / negative / non-integer values at boot, mirroring the existing `channelIdleTimeoutMs` validation; the yargs handler surfaces the thrown message as `qwen serve: ...` and exits non-zero.

## Reviewer Test Plan

### How to verify

Unit tests:

```
cd packages/cli && npx vitest run src/commands/serve.test.ts src/serve/runQwenServe.test.ts src/serve/server.test.ts
cd packages/acp-bridge && npx vitest run src/bridge.test.ts
```

Flag wiring / validation (manual):

```
# Honored
qwen serve --permission-response-timeout-ms 600000   # 10 min
qwen serve --permission-response-timeout-ms 0         # disabled (wait forever)

# Rejected at boot with a clear message + non-zero exit (no longer silently disabled)
qwen serve --permission-response-timeout-ms abc
qwen serve --permission-response-timeout-ms -5
```

Expected: valid values reach the bridge; `0` disables the deadline; malformed/negative values print `qwen serve: Invalid permissionResponseTimeoutMs: ...` and exit 1. An oversized value (e.g. `3000000000`) is clamped to `2^31-1` by the bridge.

### Evidence (Before & After)

N/A (no user-visible / TUI change — new CLI flag + daemon-side behavior). Behavior is covered by the unit tests and manual commands above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests via vitest (`packages/cli`, `packages/acp-bridge`). No sandbox required.

## Risk & Scope

- Main risk or tradeoff: Low — additive CLI flag; default behavior unchanged (still 5 min when the flag is unset). The bridge clamp and boot validation only affect out-of-range or malformed input.
- Not validated / out of scope: The sibling timeout flags `--session-idle-timeout-ms` and `--session-reap-interval-ms` have the same unvalidated-NaN behavior (the bridge maps invalid values to their disabled sentinel); left untouched here to keep this PR focused. The new timeout is not yet surfaced in the daemon status `limits` snapshot.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

给 `qwen serve` 增加 `--permission-response-timeout-ms` 参数,让运维方可以配置 daemon 在取消提示前等待单个人工权限 / `ask_user_question` 应答的时长。该值从 CLI 经 `ServeOptions` 透传到 `createAcpSessionBridge`,覆盖 bridge 之前写死的 5 分钟默认值。传 `0` 表示关闭该截止(无限等待)。

本次同时加固了这个新暴露入口的两个边界:bridge 把超时 clamp 到 `2^31-1`,避免超大值溢出 Node 定时器;`runQwenServe` 在启动时校验该值,使 CLI 和嵌入式调用方都无法静默丢弃截止。

## 为什么需要

在 daemon(ACP)模式下,每个权限 / `ask_user_question` 提示都走 bridge 的单请求挂钟截止,之前固定为 5 分钟(`DEFAULT_PERMISSION_TIMEOUT_MS`)且无法修改。对于人工应答可能超过 5 分钟、或希望提示永不自动取消的部署,没有任何出口。本 PR 把已存在、仅支持编程式传入的 `BridgeOptions.permissionResponseTimeoutMs` 通过 `qwen serve` CLI 暴露出来,接线方式与兄弟的 idle/reaper 超时一致。

暴露过程中,两个潜在 footgun 变得可触发,一并修复:
- 超过 Node 32 位定时器上限的值会让 `setTimeout` 静默退化为 1ms,几乎立刻取消提示——与「长超时」的意图相反。bridge 现在做 clamp,与既有的 `resolvePositiveFiniteMs` / `resolvedChannelIdleTimeoutMs` 兄弟项对齐。
- 非法值(如 `--permission-response-timeout-ms abc` → `NaN`,或经配置传入嵌入式 `runQwenServe` API 的 NaN)会被 bridge 当成「关闭」哨兵——静默移除所宣传的安全截止。`runQwenServe` 现在在启动时拒绝非有限 / 负数 / 非整数的值,与既有的 `channelIdleTimeoutMs` 校验一致;yargs handler 会把抛出的错误以 `qwen serve: ...` 输出并非零退出。

## 审阅者测试计划

### 如何验证

单元测试:

```
cd packages/cli && npx vitest run src/commands/serve.test.ts src/serve/runQwenServe.test.ts src/serve/server.test.ts
cd packages/acp-bridge && npx vitest run src/bridge.test.ts
```

参数接线 / 校验(手动):

```
# 生效
qwen serve --permission-response-timeout-ms 600000   # 10 分钟
qwen serve --permission-response-timeout-ms 0         # 关闭(无限等待)

# 启动时报错并非零退出(不再静默关闭)
qwen serve --permission-response-timeout-ms abc
qwen serve --permission-response-timeout-ms -5
```

预期:合法值会到达 bridge;`0` 关闭截止;非法/负值打印 `qwen serve: Invalid permissionResponseTimeoutMs: ...` 并以 1 退出。超大值(如 `3000000000`)由 bridge clamp 到 `2^31-1`。

### 证据(前 & 后)

N/A(无用户可见 / TUI 改动——仅新增 CLI 参数 + daemon 侧行为)。行为由上述单测与手动命令覆盖。

### 测试平台

|    系统    | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 运行环境(可选)

通过 vitest 跑单测(`packages/cli`、`packages/acp-bridge`),无需 sandbox。

## 风险与范围

- 主要风险/取舍:低——纯新增 CLI 参数;默认行为不变(未传参时仍为 5 分钟)。bridge clamp 与启动校验只影响越界或非法输入。
- 未验证 / 范围之外:兄弟的超时参数 `--session-idle-timeout-ms` 与 `--session-reap-interval-ms` 有相同的 NaN 未校验行为(bridge 会把非法值映射为各自的关闭哨兵),为保持本 PR 聚焦未改动。新超时尚未在 daemon status 的 `limits` 快照中暴露。
- 破坏性变更 / 迁移说明:无。

## 关联 Issue

N/A

</details>
