### PR TITLE
fix(vscode-ide-companion): create independent McpServer per IDE session

### DIFF
--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -204,8 +204,6 @@ export class IDEServer {
         next();
       });
 
-      const mcpServer = createMcpServer(this.diffManager);
-
       this.openFilesManager = new OpenFilesManager(context);
       const onDidChangeSubscription = this.openFilesManager.onDidChange(() => {
         this.broadcastIdeContextUpdate();
@@ -247,6 +245,8 @@ export class IDEServer {
             }
           }, 30000); // 30 sec
 
+          const mcpServer = createMcpServer(this.diffManager);
+
           transport.onclose = () => {
             clearInterval(keepAlive);
             if (transport.sessionId) {
@@ -255,7 +255,7 @@ export class IDEServer {
               delete this.transports[transport.sessionId];
             }
           };
-          mcpServer.connect(transport);
+          await mcpServer.connect(transport);
         } else {
           this.log(
             'Bad Request: No valid session ID provided for non-initialize request.',


### PR DESCRIPTION
## What this PR does

Moves McpServer creation from a shared singleton into the per-session branch of the POST /mcp handler, so each CLI session gets its own independent McpServer + Protocol + Transport chain. Also adds `await` to the `mcpServer.connect(transport)` call so errors propagate to the existing try/catch instead of becoming unhandled promise rejections.

## Why it's needed

Between v0.16.0 and v0.18.1, the bundled `@modelcontextprotocol/sdk` was upgraded from 1.25.1 to 1.29.0. SDK 1.29.0 includes [PR #820](https://github.com/modelcontextprotocol/typescript-sdk/pull/820) which added a guard in `Protocol.connect()` that throws "Already connected to a transport" when a second session tries to reuse the same Protocol instance.

Because the extension shared a single McpServer across all CLI sessions and called `connect()` without `await`, the throw became an unhandled promise rejection. Critically, the throw happened before `transport.onmessage` was set, so `handleRequest()` never processed the initialize message — the SSE response body was never written, and the CLI hung indefinitely at startup.

Reloading the VS Code window temporarily fixed it (one successful start), but exiting and restarting the CLI caused the hang to recur. Disabling IDE integration in settings.json was the only reliable workaround.

Fixes #5262.

## Reviewer Test Plan

### How to verify

1. Open a VS Code workspace with the Qwen Code companion extension
2. Start `qwen` in the integrated terminal — it should connect successfully
3. Exit `qwen` (Ctrl+C)
4. Start `qwen` again — it should connect successfully (previously hung for minutes)
5. Open a second terminal in the same VS Code window and start another `qwen` — both sessions should work independently

### Evidence (Before & After)

Non-UI change (internal connection architecture). Verified locally with Launch Companion VS Code Extension launch config: second CLI session connects successfully instead of hanging.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

VS Code + companion extension launched via `.vscode/launch.json` "Launch Companion VS Code Extension" config. CLI from `npm run dev`.

## Risk & Scope

- Main risk or tradeoff: Negligible — McpServer is a lightweight wrapper around tool definitions that delegate to the shared DiffManager. Creating one per session adds minimal overhead.
- Not validated / out of scope: Windows and Linux not tested locally; CI will cover.
- Breaking changes / migration notes: None. Fully backward-compatible with both SDK 1.25.1 (no guard) and 1.29.0 (with guard).

## Linked Issues

Fixes #5262

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将 McpServer 的创建从共享单例移到 POST /mcp handler 的 per-session 分支中，使每个 CLI session 拥有独立的 McpServer + Protocol + Transport 链。同时为 `mcpServer.connect(transport)` 添加 `await`，使异常能被现有的 try/catch 捕获，避免成为未处理的 Promise rejection。

## 为什么需要这个改动

在 v0.16.0 和 v0.18.1 之间，捆绑的 `@modelcontextprotocol/sdk` 从 1.25.1 升级到了 1.29.0。SDK 1.29.0 包含了 [PR #820](https://github.com/modelcontextprotocol/typescript-sdk/pull/820)，在 `Protocol.connect()` 中添加了检查：当第二个 session 尝试复用同一个 Protocol 实例时，抛出 "Already connected to a transport"。

由于扩展在所有 CLI session 之间共享单个 McpServer，且调用 `connect()` 时没有 `await`，throw 变成了未处理的 Promise rejection。关键的是，throw 发生在 `transport.onmessage` 被设置之前，导致 `handleRequest()` 永远不处理 initialize 消息——SSE 响应体永远不写入，CLI 在启动时无限期卡住。

重新加载 VS Code 窗口可临时修复（一次成功启动），但退出并重新启动 CLI 会导致卡住重现。在 settings.json 中禁用 IDE 集成是唯一可靠的解决方法。

## 审阅者测试计划

### 如何验证

1. 打开一个安装了 Qwen Code 伴侣扩展的 VS Code 工作区
2. 在集成终端中启动 `qwen` — 应成功连接
3. 退出 `qwen`（Ctrl+C）
4. 再次启动 `qwen` — 应成功连接（之前会卡住数分钟）
5. 在同一 VS Code 窗口打开第二个终端并启动另一个 `qwen` — 两个 session 应独立正常工作

### 风险与范围

- 主要风险：几乎没有 — McpServer 是对 tool 定义的轻量包装，tool 委托给共享的 DiffManager。每个 session 创建一个只增加极小开销。
- 未验证/超出范围：Windows 和 Linux 未在本地测试；CI 会覆盖。
- 破坏性变更/迁移说明：无。与 SDK 1.25.1（无检查）和 1.29.0（有检查）完全向后兼容。

</details>
