### PR TITLE
fix(daemon): centralize mid-turn event constant + recover timed-out drains

### DIFF
--- a/packages/acp-bridge/package.json
+++ b/packages/acp-bridge/package.json
@@ -47,6 +47,10 @@
       "types": "./dist/bridgeTypes.d.ts",
       "import": "./dist/bridgeTypes.js"
     },
+    "./daemonEventTypes": {
+      "types": "./dist/daemonEventTypes.d.ts",
+      "import": "./dist/daemonEventTypes.js"
+    },
     "./bridgeOptions": {
       "types": "./dist/bridgeOptions.d.ts",
       "import": "./dist/bridgeOptions.js"

--- a/packages/acp-bridge/src/bridgeClient.ts
+++ b/packages/acp-bridge/src/bridgeClient.ts
@@ -19,6 +19,7 @@ import type {
 } from '@agentclientprotocol/sdk';
 import { RequestError } from '@agentclientprotocol/sdk';
 import type { BridgeEvent, EventBus } from './eventBus.js';
+import { MID_TURN_MESSAGE_INJECTED_EVENT } from './daemonEventTypes.js';
 import { MID_TURN_QUEUE_DRAIN_METHOD } from './bridgeTypes.js';
 import type { MidTurnQueueEntry } from './bridgeTypes.js';
 import type { BridgeFileSystem } from './bridgeFileSystem.js';
@@ -202,13 +203,15 @@ function sliceLineRange(
 // source of truth shared with the child-side caller in `Session.ts`).
 
 /**
- * SSE frame published when mid-turn messages are actually drained into the
- * running turn. The browser consumes it to move those messages out of its
- * pending queue so they aren't resent as the next turn (a transient dedupe
- * signal — it isn't rendered as a transcript item).
+ * `MID_TURN_MESSAGE_INJECTED_EVENT` (the SSE frame `type` published when mid-turn
+ * messages are drained into the running turn) is imported from
+ * `./daemonEventTypes.js` — the single source of truth the SDK re-exports, so the
+ * validator and the browser consumer share the same literal. The browser consumes
+ * the frame to
+ * move those messages out of its pending queue so they aren't resent as the next
+ * turn (a transient dedupe signal — it isn't rendered as a transcript item).
  * `data: { sessionId, messages: string[] }`.
  */
-const MID_TURN_MESSAGE_INJECTED_EVENT = 'mid_turn_message_injected';
 
 export interface BridgeClientSessionEntry {
   sessionId: string;

--- a/packages/acp-bridge/src/daemonEventTypes.ts
+++ b/packages/acp-bridge/src/daemonEventTypes.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Daemon SSE event-`type` wire literals shared across the daemon publisher
+ * (`acp-bridge`), the SDK validator/reducer, and the browser consumer.
+ *
+ * Kept in this DEPENDENCY-FREE module (no `import type` from core, unlike
+ * `bridgeTypes.ts`) so the SDK can re-export these from `@qwen-code/sdk/daemon`
+ * via its build-time devDep on acp-bridge WITHOUT pulling acp-bridge's type
+ * graph into the SDK's bundled `.d.ts` — the same lightweight pattern as
+ * `mcpTimeouts.ts`.
+ */
+
+/**
+ * Published when the daemon drains queued mid-turn messages into the running
+ * turn. The browser consumes it to move those messages out of its pending queue
+ * so they aren't resent as the next turn (a transient dedupe signal). Single
+ * source of truth: a rename here propagates to every importer, so it can't
+ * silently break browser-side dedup. `data: { sessionId, messages: string[] }`.
+ */
+export const MID_TURN_MESSAGE_INJECTED_EVENT = 'mid_turn_message_injected';

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -2774,6 +2774,103 @@ describe('Session', () => {
         expect(drainCalls).toHaveLength(5);
       }, 30_000);
 
+      it('recovers a drain that timed out and injects it on the next batch', async () => {
+        // The daemon answers the drain (splices + SSE-publishes, so the browser
+        // already deduped) but we time out waiting. The late response must not be
+        // discarded — it is recovered and injected on the NEXT batch instead of
+        // being lost from both queues.
+        const tool = {
+          name: 'read_file',
+          kind: core.Kind.Read,
+          build: vi.fn().mockReturnValue({
+            params: { path: '/tmp/test.txt' },
+            getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+            getDescription: vi.fn().mockReturnValue('Read file'),
+            toolLocations: vi.fn().mockReturnValue([]),
+            execute: vi
+              .fn()
+              .mockResolvedValue({ llmContent: 'ok', returnDisplay: 'ok' }),
+          }),
+        };
+        mockToolRegistry.getTool.mockReturnValue(tool);
+        mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.YOLO);
+
+        // Prompt 1's drain: a promise we resolve LATE (after the timeout fires)
+        // with the messages the daemon drained. Prompt 2's drain: empty.
+        let resolveLate: (value: { messages: string[] }) => void = () => {};
+        const latePromise = new Promise<{ messages: string[] }>((res) => {
+          resolveLate = res;
+        });
+        let drainCalls = 0;
+        mockClient.extMethod = vi.fn((method: string) => {
+          if (method !== 'craft/drainMidTurnQueue') return Promise.resolve({});
+          drainCalls += 1;
+          return drainCalls === 1
+            ? latePromise
+            : Promise.resolve({ messages: [] });
+        });
+
+        const toolCallStream = () =>
+          createStreamWithChunks([
+            {
+              type: core.StreamEventType.CHUNK,
+              value: {
+                functionCalls: [
+                  {
+                    id: 'c',
+                    name: 'read_file',
+                    args: { path: '/tmp/test.txt' },
+                  },
+                ],
+              },
+            },
+          ]);
+        const streamMock = vi.fn();
+        for (let i = 0; i < 2; i++) {
+          streamMock
+            .mockResolvedValueOnce(toolCallStream())
+            .mockResolvedValueOnce(createEmptyStream());
+        }
+        mockChat.sendMessageStream = streamMock;
+
+        const prompt = {
+          sessionId: 'test-session-id',
+          prompt: [{ type: 'text' as const, text: 'read file' }],
+        };
+
+        // Prompt 1: the drain times out (latePromise still pending). Nothing is
+        // injected yet.
+        await session.prompt(prompt);
+
+        // The daemon's answer finally arrives. The timeout branch's handler
+        // stashes it for recovery; flush microtasks so the push lands.
+        resolveLate({ messages: ['please also check tests'] });
+        await new Promise((r) => setTimeout(r, 0));
+
+        // Prompt 2: the drain flushes the recovered message into this batch.
+        await session.prompt(prompt);
+
+        const midTurnPart = {
+          text: '\n[User message received during tool execution]: please also check tests',
+        };
+        // Injected into prompt 2's follow-up (4th sendMessageStream call), not
+        // prompt 1's (which timed out with nothing to inject).
+        const calls = vi.mocked(mockChat.sendMessageStream).mock.calls;
+        expect(calls[1]?.[1].message).not.toEqual(
+          expect.arrayContaining([midTurnPart]),
+        );
+        expect(calls[3]?.[1].message).toEqual(
+          expect.arrayContaining([midTurnPart]),
+        );
+        // Recorded exactly once, at injection time.
+        expect(
+          mockChatRecordingService.recordMidTurnUserMessage,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          mockChatRecordingService.recordMidTurnUserMessage,
+        ).toHaveBeenCalledWith([midTurnPart], 'please also check tests');
+      }, 20_000);
+
       it('keeps mid-turn drain enabled after a transient error', async () => {
         const tool = {
           name: 'read_file',

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -450,6 +450,11 @@ export class Session implements SessionContext {
   private lastPromptTokenCountChat: GeminiChat | null = null;
   private midTurnDrainUnavailable = false;
   private midTurnDrainTimeoutStrikes = 0;
+  // Messages from a drain that the daemon answered but we timed out waiting for
+  // (the daemon already spliced + SSE-published them). Re-injected on the next
+  // batch so a transient stall can't silently lose them. See
+  // `#drainMidTurnUserMessages`.
+  private midTurnRecoveredMessages: string[] = [];
 
   // Background notification drain state. ACP does not have the TUI's idle
   // hook, so the session serializes registry callbacks through this queue.
@@ -1893,7 +1898,16 @@ export class Session implements SessionContext {
   }
 
   async #drainMidTurnUserMessages(): Promise<Part[]> {
-    if (this.midTurnDrainUnavailable) return [];
+    // Flush anything recovered from a PRIOR timed-out drain first: the daemon
+    // splices + SSE-publishes synchronously, so on a timeout the browser has
+    // already deduped those messages — discarding the late response would lose
+    // them from both queues. We stash them (see the timeout branch) and
+    // re-inject them here on the next batch.
+    const recovered = this.#takeRecoveredMidTurnMessages();
+
+    if (this.midTurnDrainUnavailable) {
+      return this.#formatMidTurnParts(recovered);
+    }
 
     let drainPromise: ReturnType<AgentSideConnection['extMethod']> | undefined;
     try {
@@ -1914,28 +1928,10 @@ export class Session implements SessionContext {
         clearTimeout(timeoutHandle);
       }
       this.midTurnDrainTimeoutStrikes = 0;
-      // A client may legally resolve with `result: null` (passed through
-      // unwrapped by the ACP SDK); guard the object access so that doesn't
-      // throw a TypeError and get misclassified as a transient drain error.
-      const messages =
-        response &&
-        typeof response === 'object' &&
-        Array.isArray(response['messages'])
-          ? response['messages'].filter(
-              (message): message is string =>
-                typeof message === 'string' && message.trim().length > 0,
-            )
-          : [];
-
-      return messages.map((message) => {
-        const part = {
-          text: `\n[User message received during tool execution]: ${message}`,
-        };
-        this.config
-          .getChatRecordingService()
-          ?.recordMidTurnUserMessage([part], message);
-        return part;
-      });
+      return this.#formatMidTurnParts([
+        ...recovered,
+        ...this.#extractMidTurnMessages(response),
+      ]);
     } catch (error) {
       // The ACP SDK rejects with the raw JSON-RPC error object
       // (`{ code, message, data }`), which is not an `Error` instance, so
@@ -1955,9 +1951,20 @@ export class Session implements SessionContext {
       const isTimeout = error instanceof MidTurnDrainTimeoutError;
       if (isTimeout) {
         this.midTurnDrainTimeoutStrikes += 1;
-        // The lost race leaves the request pending; if the client settles it
-        // later, a rejection must not surface as an unhandled rejection.
-        drainPromise?.catch(() => {});
+        // The lost race leaves the drain request pending. The daemon answers it
+        // by splicing the queue + publishing the SSE echo (so the browser has
+        // already deduped), then returns the messages — which we just timed out
+        // waiting for. Instead of discarding that late response (losing the
+        // messages from both queues = silent loss), recover it and inject it on
+        // the next batch. A late REJECTION is still swallowed (no unhandled
+        // rejection); only a resolved payload carries messages.
+        drainPromise
+          ?.then((late) => {
+            this.midTurnRecoveredMessages.push(
+              ...this.#extractMidTurnMessages(late),
+            );
+          })
+          .catch(() => {});
       }
       // Repeated timeouts are also permanent: a conforming client answers
       // (or rejects with -32601) immediately, so sustained silence means the
@@ -1978,8 +1985,52 @@ export class Session implements SessionContext {
       debugLogger.warn(
         `Mid-turn queue drain ${isPermanentError ? 'permanently ' : ''}unavailable [session ${this.sessionId}]: ${errorMessage}`,
       );
-      return [];
+      // Even on a failed/timed-out drain, still inject anything recovered from
+      // an EARLIER timeout so a transient stall never strands those messages.
+      return this.#formatMidTurnParts(recovered);
     }
+  }
+
+  /** Read and clear the buffer of messages recovered from a timed-out drain. */
+  #takeRecoveredMidTurnMessages(): string[] {
+    if (this.midTurnRecoveredMessages.length === 0) return [];
+    const out = this.midTurnRecoveredMessages;
+    this.midTurnRecoveredMessages = [];
+    return out;
+  }
+
+  /**
+   * Extract the trimmed, non-empty string messages from a drain response. A
+   * client may legally resolve with `result: null` (passed through unwrapped by
+   * the ACP SDK), so guard the object access — a TypeError here would otherwise
+   * be misclassified as a transient drain error.
+   */
+  #extractMidTurnMessages(response: unknown): string[] {
+    return response &&
+      typeof response === 'object' &&
+      Array.isArray((response as { messages?: unknown }).messages)
+      ? (response as { messages: unknown[] }).messages.filter(
+          (message): message is string =>
+            typeof message === 'string' && message.trim().length > 0,
+        )
+      : [];
+  }
+
+  /**
+   * Wrap each mid-turn message as an agent-visible `Part` and record it once to
+   * the chat transcript. Recording happens on injection (here), so a recovered
+   * message is recorded exactly once even though its drain timed out earlier.
+   */
+  #formatMidTurnParts(messages: string[]): Part[] {
+    return messages.map((message) => {
+      const part = {
+        text: `\n[User message received during tool execution]: ${message}`,
+      };
+      this.config
+        .getChatRecordingService()
+        ?.recordMidTurnUserMessage([part], message);
+      return part;
+    });
   }
 
   /**

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -1906,7 +1906,7 @@ export class Session implements SessionContext {
     const recovered = this.#takeRecoveredMidTurnMessages();
 
     if (this.midTurnDrainUnavailable) {
-      return this.#formatMidTurnParts(recovered);
+      return this.#buildMidTurnParts(recovered);
     }
 
     let drainPromise: ReturnType<AgentSideConnection['extMethod']> | undefined;
@@ -1928,7 +1928,7 @@ export class Session implements SessionContext {
         clearTimeout(timeoutHandle);
       }
       this.midTurnDrainTimeoutStrikes = 0;
-      return this.#formatMidTurnParts([
+      return this.#buildMidTurnParts([
         ...recovered,
         ...this.#extractMidTurnMessages(response),
       ]);
@@ -1960,9 +1960,13 @@ export class Session implements SessionContext {
         // rejection); only a resolved payload carries messages.
         drainPromise
           ?.then((late) => {
-            this.midTurnRecoveredMessages.push(
-              ...this.#extractMidTurnMessages(late),
-            );
+            const recovered = this.#extractMidTurnMessages(late);
+            if (recovered.length > 0) {
+              debugLogger.debug(
+                `[mid-turn] recovered ${recovered.length} message(s) from a timed-out drain [session ${this.sessionId}]`,
+              );
+              this.midTurnRecoveredMessages.push(...recovered);
+            }
           })
           .catch(() => {});
       }
@@ -1987,7 +1991,7 @@ export class Session implements SessionContext {
       );
       // Even on a failed/timed-out drain, still inject anything recovered from
       // an EARLIER timeout so a transient stall never strands those messages.
-      return this.#formatMidTurnParts(recovered);
+      return this.#buildMidTurnParts(recovered);
     }
   }
 
@@ -2021,7 +2025,7 @@ export class Session implements SessionContext {
    * the chat transcript. Recording happens on injection (here), so a recovered
    * message is recorded exactly once even though its drain timed out earlier.
    */
-  #formatMidTurnParts(messages: string[]): Part[] {
+  #buildMidTurnParts(messages: string[]): Part[] {
     return messages.map((message) => {
       const part = {
         text: `\n[User message received during tool execution]: ${message}`,

--- a/packages/sdk-typescript/src/daemon/events.ts
+++ b/packages/sdk-typescript/src/daemon/events.ts
@@ -10,6 +10,16 @@ import type {
   DaemonMcpTransport,
   PermissionOutcome,
 } from './types.js';
+// Single source of truth: the daemon publisher owns the wire literal in
+// acp-bridge's dependency-free `daemonEventTypes` module. We re-export it so the
+// validator/reducer below, and the browser consumer via `@qwen-code/sdk/daemon`,
+// share the exact same value — a rename can't silently break browser-side dedup.
+// The build-time devDep on acp-bridge inlines the value into the published bundle
+// (same lightweight mechanism as `@qwen-code/acp-bridge/mcpTimeouts`). A `const`
+// keeps its literal type, so it still narrows in `switch (event.type)` and works
+// as a `typeof`-d type argument.
+import { MID_TURN_MESSAGE_INJECTED_EVENT } from '@qwen-code/acp-bridge/daemonEventTypes';
+export { MID_TURN_MESSAGE_INJECTED_EVENT };
 
 export const DAEMON_KNOWN_EVENT_TYPE_VALUES = [
   'session_update',
@@ -21,7 +31,7 @@ export const DAEMON_KNOWN_EVENT_TYPE_VALUES = [
   'session_died',
   'session_closed',
   'session_metadata_updated',
-  'mid_turn_message_injected',
+  MID_TURN_MESSAGE_INJECTED_EVENT,
   'client_evicted',
   'slow_client_warning',
   'stream_error',
@@ -779,7 +789,7 @@ export type DaemonSessionMetadataUpdatedEvent = DaemonEventEnvelope<
   DaemonSessionMetadataUpdatedData
 >;
 export type DaemonMidTurnMessageInjectedEvent = DaemonEventEnvelope<
-  'mid_turn_message_injected',
+  typeof MID_TURN_MESSAGE_INJECTED_EVENT,
   DaemonMidTurnMessageInjectedData
 >;
 export type DaemonClientEvictedEvent = DaemonEventEnvelope<
@@ -1360,7 +1370,7 @@ export function asKnownDaemonEvent(
       return isSessionMetadataUpdatedData(event.data)
         ? (event as DaemonSessionMetadataUpdatedEvent)
         : undefined;
-    case 'mid_turn_message_injected':
+    case MID_TURN_MESSAGE_INJECTED_EVENT:
       return isMidTurnMessageInjectedData(event.data)
         ? (event as DaemonMidTurnMessageInjectedEvent)
         : undefined;
@@ -1850,7 +1860,7 @@ export function reduceDaemonSessionEvent(
     case 'mcp_server_added':
     case 'mcp_server_removed':
     case 'settings_reloaded':
-    case 'mid_turn_message_injected':
+    case MID_TURN_MESSAGE_INJECTED_EVENT:
       return base;
     case 'session_rewound':
       return {

--- a/packages/sdk-typescript/src/daemon/index.ts
+++ b/packages/sdk-typescript/src/daemon/index.ts
@@ -56,6 +56,7 @@ export {
 export {
   asKnownDaemonEvent,
   DAEMON_KNOWN_EVENT_TYPE_VALUES,
+  MID_TURN_MESSAGE_INJECTED_EVENT,
   createDaemonAuthState,
   createDaemonSessionViewState,
   isDaemonEventType,

--- a/packages/sdk-typescript/test/unit/daemonEvents.test.ts
+++ b/packages/sdk-typescript/test/unit/daemonEvents.test.ts
@@ -9,13 +9,27 @@ import {
   asKnownDaemonEvent,
   createDaemonAuthState,
   createDaemonSessionViewState,
+  DAEMON_KNOWN_EVENT_TYPE_VALUES,
   isDaemonEventType,
+  MID_TURN_MESSAGE_INJECTED_EVENT,
   reduceDaemonAuthEvent,
   reduceDaemonAuthEvents,
   reduceDaemonSessionEvent,
   reduceDaemonSessionEvents,
 } from '../../src/daemon/events.js';
 import type { DaemonEvent } from '../../src/daemon/types.js';
+
+describe('MID_TURN_MESSAGE_INJECTED_EVENT (shared wire constant)', () => {
+  it('is the wire literal and a registered known event type', () => {
+    // The same const is imported by the daemon publisher (acp-bridge) and the
+    // browser consumer (webui), so this also pins THEIR matching. Changing the
+    // wire string is a deliberate protocol change and must update this literal.
+    expect(MID_TURN_MESSAGE_INJECTED_EVENT).toBe('mid_turn_message_injected');
+    expect(DAEMON_KNOWN_EVENT_TYPE_VALUES).toContain(
+      MID_TURN_MESSAGE_INJECTED_EVENT,
+    );
+  });
+});
 
 describe('daemon event schema', () => {
   it('narrows known daemon events by discriminator', () => {

--- a/packages/webui/src/daemon/midTurnInjectedSidechannel.ts
+++ b/packages/webui/src/daemon/midTurnInjectedSidechannel.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { MID_TURN_MESSAGE_INJECTED_EVENT } from '@qwen-code/sdk/daemon';
 import type { DaemonMidTurnMessageInjectedData } from '@qwen-code/sdk/daemon';
 
 /**
@@ -132,7 +133,7 @@ export function parseSidechannelMidTurnInjected(
 ): DaemonMidTurnMessageInjectedData | undefined {
   if (!event || typeof event !== 'object') return undefined;
   const record = event as Record<string, unknown>;
-  if (record['type'] !== 'mid_turn_message_injected') return undefined;
+  if (record['type'] !== MID_TURN_MESSAGE_INJECTED_EVENT) return undefined;
   const data = record['data'];
   if (!data || typeof data !== 'object') return undefined;
   const dataRecord = data as Record<string, unknown>;


### PR DESCRIPTION
## What this PR does

A follow-up to #5175 that addresses two `/review` suggestions left on that (now merged) PR. First, it makes the `mid_turn_message_injected` SSE event `type` a single shared constant instead of a bare string literal duplicated across three packages. Second, it closes a narrow window where a mid-turn message could be silently lost for one turn when the ACP child's drain request times out after the daemon has already drained and broadcast it.

## Why it's needed

The mid-turn drain feature touches the same wire string `'mid_turn_message_injected'` in three independent places: the daemon publisher (`acp-bridge/bridgeClient.ts`), the SDK validator/reducer (`sdk-typescript/daemon/events.ts`), and the browser consumer (`webui/midTurnInjectedSidechannel.ts`). A rename or typo in any one — with the others unchanged — silently breaks browser-side dedup: the drain still works, but injected messages are no longer removed from the browser's pending queue and get double-delivered next turn. The sibling `craft/drainMidTurnQueue` method string was already centralized; this brings the event type to parity.

Separately, the daemon answers the child's drain by splicing its in-memory queue and publishing the `mid_turn_message_injected` SSE frame (which the browser uses to dedup) before the response travels back to the child. The child races that response against a 2 s timeout. When the timeout fires first, the child discarded the late response — so the messages were gone from both the daemon queue and the browser queue, yet never reached the model: a silent one-turn loss. Localhost IPC rarely approaches 2 s, but the impact is silent data loss.

## Reviewer Test Plan

### How to verify

Constant centralization: the event type now lives once in `acp-bridge/src/daemonEventTypes.ts` — a dependency-free module (like `mcpTimeouts.ts`) so the SDK re-exports it through its build-time devDep on acp-bridge without dragging acp-bridge's type graph into the SDK's bundled `.d.ts`. `bridgeClient.ts`, the SDK, and webui all import the single binding, so a rename either propagates everywhere or fails to compile.

- `cd packages/sdk-typescript && npx vitest run test/unit/daemonEvents.test.ts test/unit/daemon-public-surface.test.ts` → 102 pass, incl. the new `MID_TURN_MESSAGE_INJECTED_EVENT` rename-safety assertion (value === wire literal, registered in the known-event set).
- `cd packages/acp-bridge && npx vitest run src/bridgeClient.test.ts` → 23 pass.
- `cd packages/webui && npx vitest run src/daemon` → 141 pass.

Drain-timeout recovery: on a timed-out drain the child now recovers the late response (the daemon already drained + broadcast it) and injects it on the next tool batch instead of discarding it.

- `cd packages/cli && npx vitest run src/acp-integration/session/Session.test.ts` → 146 pass, incl. the new `recovers a drain that timed out and injects it on the next batch` (times out batch 1, resolves the daemon's answer late, asserts it is injected on batch 2 and recorded exactly once).

Typecheck: `npx tsc --noEmit` clean in `acp-bridge` / `sdk-typescript` / `webui` / `cli`. Builds: `npm run build` clean for `acp-bridge` → `sdk-typescript` → `webui`; the event const inlines into the SDK's published bundle (`index.cjs`/`mjs`, `daemon/index.js`/`cjs`), so there is no new runtime acp-bridge dependency.

### Evidence (Before & After)

N/A — non-user-visible (a shared constant plus a daemon/child drain-recovery code path; no UI change). Behavior is pinned by the unit tests above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ unit tests + `tsc --noEmit` + package builds |
| 🪟 Windows | ⚠️ not tested (CI) |
|  🐧 Linux  | ⚠️ not tested (CI) |

### Environment (optional)

Unit tests + `tsc --noEmit` + `npm run build` (`acp-bridge`, `sdk-typescript`, `webui`) on macOS. No live daemon/browser session.

## Risk & Scope

- Main risk or tradeoff: the recovered drain response is injected on the NEXT tool batch (or, if the turn already ended, the next turn's first batch) — a graceful late delivery consistent with the existing next-turn fallback, since the browser already deduped it. The recovery buffer flushes on the next drain, so a transient stall can't strand messages. The constant move adds a tiny dependency-free `daemonEventTypes` subpath to acp-bridge; the SDK's value is inlined at build time (same mechanism as `mcpTimeouts`), so there is no new runtime dependency and no SDK-bundle bloat.
- Not validated / out of scope: a true two-phase ack protocol (publish-after-child-ack) for the drain — the recovery approach is self-contained on the child side and needs no protocol change. The publish-failed (bus-closed) degradation is unchanged and teardown-only.
- Breaking changes / migration notes: none. `MID_TURN_MESSAGE_INJECTED_EVENT` is additively exported from `@qwen-code/sdk/daemon`; the wire string is unchanged.

## Linked Issues

Follow-up to #5175 (post-merge review comments).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这是 #5175（已合并）的后续，处理该 PR 上 `/review` 留下的两条建议。其一，把 `mid_turn_message_injected` 这个 SSE 事件 `type` 从三个包里各自硬编码的字符串字面量，收敛为单一共享常量。其二,堵住一个狭窄窗口：当 ACP 子进程的 drain 请求在 daemon 已经排空并广播之后才超时，mid-turn 消息可能被静默丢失一轮。

## 为什么需要

mid-turn drain 特性在三个独立位置用到同一个 wire 字符串 `'mid_turn_message_injected'`：daemon 发布方（`acp-bridge/bridgeClient.ts`）、SDK 校验/归约（`sdk-typescript/daemon/events.ts`）、浏览器消费方（`webui/midTurnInjectedSidechannel.ts`）。任何一处改名/打错而其它处不变，都会静默破坏浏览器侧去重：drain 仍工作，但注入的消息不再从浏览器待发队列移除，下一轮被重复投递。兄弟方法字符串 `craft/drainMidTurnQueue` 已经集中化；本 PR 让事件类型对齐。

另外，daemon 应答子进程的 drain 时，会先 splice 其内存队列并发布 `mid_turn_message_injected` SSE 帧（浏览器据此去重），然后响应才回传给子进程。子进程用 2 秒超时与该响应竞速。若超时先触发，子进程会丢弃这个迟到的响应——于是消息从 daemon 队列和浏览器队列都消失了，却从未到达模型：静默丢一轮。本地 IPC 极少接近 2 秒，但影响是静默数据丢失。

## 审阅者测试计划

### 如何验证

常量集中化：事件类型现在只在 `acp-bridge/src/daemonEventTypes.ts` 定义——一个无依赖模块（类似 `mcpTimeouts.ts`），这样 SDK 通过其对 acp-bridge 的构建期 devDep 再导出它，而不会把 acp-bridge 的类型图拖进 SDK 打包后的 `.d.ts`。`bridgeClient.ts`、SDK、webui 都 import 这唯一绑定，改名要么处处传播、要么编译失败。

- `cd packages/sdk-typescript && npx vitest run test/unit/daemonEvents.test.ts test/unit/daemon-public-surface.test.ts` → 102 通过，含新增 `MID_TURN_MESSAGE_INJECTED_EVENT` 防改名断言（值 === wire 字面量、且登记在 known-event 集合）。
- `cd packages/acp-bridge && npx vitest run src/bridgeClient.test.ts` → 23 通过。
- `cd packages/webui && npx vitest run src/daemon` → 141 通过。

Drain 超时恢复：drain 超时后，子进程现在恢复迟到的响应（daemon 已排空+广播）并在下一批 tool 注入，而不是丢弃。

- `cd packages/cli && npx vitest run src/acp-integration/session/Session.test.ts` → 146 通过，含新增 `recovers a drain that timed out and injects it on the next batch`（第 1 批超时，迟到 resolve daemon 的应答，断言在第 2 批注入且恰好记录一次）。

类型检查：`npx tsc --noEmit` 在 `acp-bridge` / `sdk-typescript` / `webui` / `cli` 干净。构建：`npm run build` 在 `acp-bridge` → `sdk-typescript` → `webui` 干净；事件常量在构建时内联进 SDK 发布包（`index.cjs`/`mjs`、`daemon/index.js`/`cjs`），因此没有新的运行时 acp-bridge 依赖。

### 证据（前后对比）

N/A——非用户可见（共享常量 + daemon/子进程的 drain 恢复代码路径；无 UI 变化）。行为由上述单测钉住。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 单测 + `tsc --noEmit` + 打包 |
| 🪟 Windows | ⚠️ 未测（CI） |
|  🐧 Linux  | ⚠️ 未测（CI） |

### 环境（可选）

macOS 上的单测 + `tsc --noEmit` + `npm run build`（`acp-bridge`、`sdk-typescript`、`webui`）。无 live daemon/浏览器会话。

## 风险与范围

- 主要风险/权衡：恢复的 drain 响应在下一批 tool（或若 turn 已结束，则下一轮第一批）注入——一种优雅的迟到投递，与既有的「下一轮」兜底一致，因为浏览器已去重。恢复缓冲在下一次 drain 时清空，瞬时停顿不会滞留消息。常量迁移给 acp-bridge 增加一个无依赖的 `daemonEventTypes` 子路径；SDK 的值在构建时内联（与 `mcpTimeouts` 同机制），因此无新增运行时依赖、不增大 SDK 包。
- 未验证/范围外：真正的两阶段 ack 协议（子进程 ack 后再 publish）——恢复方案在子进程侧自洽、无需改协议。publish 失败（bus 关闭）的降级不变，且仅在 teardown 出现。
- 破坏性变更/迁移说明：无。`MID_TURN_MESSAGE_INJECTED_EVENT` 是从 `@qwen-code/sdk/daemon` 增量导出；wire 字符串不变。

## 关联 Issue

#5175 的后续（合并后评审意见）。

</details>
