### PR TITLE
fix(core): keep DeepSeek presets text-only

### DIFF
--- a/packages/core/src/providers/__tests__/presets/alibaba-standard.test.ts
+++ b/packages/core/src/providers/__tests__/presets/alibaba-standard.test.ts
@@ -5,14 +5,14 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { AuthType } from '../../../core/contentGenerator.js';
+import { alibabaStandardProvider } from '../../presets/alibaba-standard.js';
 import {
-  AuthType,
-  alibabaStandardProvider,
   buildInstallPlan,
   getDefaultModelIds,
   resolveBaseUrl,
   providerMatchesCredentials,
-} from '@qwen-code/qwen-code-core';
+} from '../../provider-config.js';
 
 describe('alibabaStandardProvider', () => {
   it('has correct provider config', () => {
@@ -78,6 +78,23 @@ describe('alibabaStandardProvider', () => {
       name: '[ModelStudio Standard] custom-model',
     });
     expect(models?.[1]?.generationConfig).toBeUndefined();
+  });
+
+  it('does not mark DeepSeek models as multimodal', () => {
+    const plan = buildInstallPlan(alibabaStandardProvider, {
+      baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+      apiKey: 'sk-standard',
+      modelIds: ['deepseek-v4-pro', 'deepseek-v4-flash'],
+    });
+
+    const models = plan.modelProviders?.[0]?.models;
+    expect(models?.[0]?.generationConfig).toEqual({
+      extra_body: { enable_thinking: true },
+      contextWindowSize: 1000000,
+    });
+    expect(models?.[1]?.generationConfig).toEqual({
+      contextWindowSize: 1000000,
+    });
   });
 
   it('auto-derives ownership via envKey + prefix', () => {

--- a/packages/core/src/providers/__tests__/presets/deepseek.test.ts
+++ b/packages/core/src/providers/__tests__/presets/deepseek.test.ts
@@ -5,11 +5,9 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import {
-  AuthType,
-  deepseekProvider,
-  buildInstallPlan,
-} from '@qwen-code/qwen-code-core';
+import { AuthType } from '../../../core/contentGenerator.js';
+import { deepseekProvider } from '../../presets/deepseek.js';
+import { buildInstallPlan } from '../../provider-config.js';
 
 describe('deepseekProvider', () => {
   it('has correct provider config', () => {
@@ -34,7 +32,13 @@ describe('deepseekProvider', () => {
     expect(models?.[0]).toMatchObject({
       id: 'deepseek-v4-flash',
       name: '[DeepSeek] deepseek-v4-flash',
-      generationConfig: { contextWindowSize: 1000000 },
+    });
+    expect(models?.[0]?.generationConfig).toEqual({
+      contextWindowSize: 1000000,
+    });
+    expect(models?.[1]?.generationConfig).toEqual({
+      extra_body: { enable_thinking: true },
+      contextWindowSize: 1000000,
     });
   });
 

--- a/packages/core/src/providers/__tests__/presets/idealab.test.ts
+++ b/packages/core/src/providers/__tests__/presets/idealab.test.ts
@@ -5,11 +5,9 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import {
-  AuthType,
-  idealabProvider,
-  buildInstallPlan,
-} from '@qwen-code/qwen-code-core';
+import { AuthType } from '../../../core/contentGenerator.js';
+import { idealabProvider } from '../../presets/idealab.js';
+import { buildInstallPlan } from '../../provider-config.js';
 
 describe('idealabProvider', () => {
   it('has correct provider config', () => {
@@ -40,7 +38,28 @@ describe('idealabProvider', () => {
     expect(models?.[1]).toMatchObject({
       id: 'bailian/deepseek-v4-pro',
       name: '[Idealab] bailian/deepseek-v4-pro',
-      generationConfig: { contextWindowSize: 1000000 },
+      generationConfig: {
+        extra_body: { enable_thinking: true },
+        contextWindowSize: 1000000,
+      },
+    });
+  });
+
+  it('does not mark DeepSeek models as multimodal', () => {
+    const plan = buildInstallPlan(idealabProvider, {
+      baseUrl: 'https://idealab.alibaba-inc.com/api/openai/v1',
+      apiKey: 'sk-idealab',
+      modelIds: ['bailian/deepseek-v4-pro', 'bailian/deepseek-v4-flash'],
+    });
+
+    const models = plan.modelProviders?.[0]?.models;
+    expect(models?.[0]?.generationConfig).toEqual({
+      extra_body: { enable_thinking: true },
+      contextWindowSize: 1000000,
+    });
+    expect(models?.[1]?.generationConfig).toEqual({
+      extra_body: { enable_thinking: true },
+      contextWindowSize: 1000000,
     });
   });
 

--- a/packages/core/src/providers/presets/alibaba-standard.ts
+++ b/packages/core/src/providers/presets/alibaba-standard.ts
@@ -52,7 +52,6 @@ export const alibabaStandardProvider: ProviderConfig = {
       id: 'deepseek-v4-pro',
       contextWindowSize: 1000000,
       enableThinking: true,
-      modalities: { image: true, video: true },
     },
     { id: 'deepseek-v4-flash', contextWindowSize: 1000000 },
   ],

--- a/packages/core/src/providers/presets/deepseek.ts
+++ b/packages/core/src/providers/presets/deepseek.ts
@@ -19,7 +19,6 @@ export const deepseekProvider: ProviderConfig = {
       id: 'deepseek-v4-pro',
       contextWindowSize: 1000000,
       enableThinking: true,
-      modalities: { image: true, video: true },
     },
     { id: 'deepseek-v4-flash', contextWindowSize: 1000000 },
   ],

--- a/packages/core/src/providers/presets/idealab.ts
+++ b/packages/core/src/providers/presets/idealab.ts
@@ -26,13 +26,11 @@ export const idealabProvider: ProviderConfig = {
       id: 'bailian/deepseek-v4-pro',
       contextWindowSize: 1000000,
       enableThinking: true,
-      modalities: { image: true, video: true },
     },
     {
       id: 'bailian/deepseek-v4-flash',
       contextWindowSize: 1000000,
       enableThinking: true,
-      modalities: { image: true, video: true },
     },
     {
       id: 'bailian/kimi-k2.6',


### PR DESCRIPTION
## What this PR does

This removes the incorrect image/video capability metadata from the DeepSeek V4 defaults used by the built-in provider setup flows. The text-only defaults still keep their existing context window and thinking configuration where it was already present.

It also tightens the provider install-plan tests so DeepSeek V4 entries are checked exactly and cannot silently regain multimodal metadata later.

## Why it's needed

DeepSeek V4 is text-only. When `/auth` installs a preset with `modalities: { image: true, video: true }`, Qwen Code may later try to send image/video inputs to a backend that does not support them.

## Reviewer Test Plan

### How to verify

Use the DeepSeek, ModelStudio Standard, or Idealab setup path with the DeepSeek V4 models and confirm the generated model config has no `generationConfig.modalities` field. The context window and thinking settings should remain unchanged where those defaults already existed.

### Evidence (Before & After)

N/A — this is provider metadata and regression-test coverage, not a visual/TUI rendering change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local Node.js workspace tests on macOS.

## Risk & Scope

- Main risk or tradeoff: Users who expected the incorrect DeepSeek vision metadata will now get text-only model config, which matches the provider capability.
- Not validated / out of scope: Real DeepSeek API-key setup against the live service was not exercised.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5252

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 移除了内置 provider setup 流程里 DeepSeek V4 默认配置中错误的 image/video 能力标记。文本模型默认配置仍保留原有的 context window 和 thinking 配置。

同时收紧了 provider install-plan 的回归测试，确保 DeepSeek V4 条目不会在之后又悄悄带回 multimodal metadata。

## 为什么需要

DeepSeek V4 是纯文本模型。`/auth` 安装 preset 时如果写入 `modalities: { image: true, video: true }`，后续 Qwen Code 可能会尝试把图片或视频输入发给不支持这些能力的后端。

## Reviewer Test Plan

### 如何验证

通过 DeepSeek、ModelStudio Standard 或 Idealab 的 setup 路径选择 DeepSeek V4 模型，确认生成的 model config 不包含 `generationConfig.modalities` 字段。原本已有的 context window 和 thinking 默认配置应保持不变。

### Before & After 证据

N/A — 这是 provider metadata 和回归测试覆盖，不是可视化/TUI 渲染变化。

### 本地验证系统

macOS 已测试；Windows/Linux 未单独测试。

### 环境

macOS 本地 Node.js workspace 测试。

## 风险与范围

- 主要风险或取舍：如果有人依赖了错误的 DeepSeek vision metadata，现在会得到 text-only 模型配置；这和 provider 实际能力一致。
- 未验证 / 不在范围：没有用真实 DeepSeek API key 跑 live setup。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #5252

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
