### PR TITLE
fix(cli): correct context filename settings schema

### DIFF
--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -291,6 +291,17 @@ describe('SettingsSchema', () => {
       ).toEqual([]);
     });
 
+    it('should define context.fileName schema override as string or string array', () => {
+      expect(
+        getSettingsSchema().context?.properties.fileName.jsonSchemaOverride,
+      ).toEqual({
+        anyOf: [
+          { type: 'string' },
+          { type: 'array', items: { type: 'string' } },
+        ],
+      });
+    });
+
     it('should have loadFromIncludeDirectories setting in schema', () => {
       expect(
         getSettingsSchema().context?.properties.loadFromIncludeDirectories,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1332,8 +1332,14 @@ const SETTINGS_SCHEMA = {
         category: 'Context',
         requiresRestart: false,
         default: undefined as string | string[] | undefined,
-        description: 'The name of the context file.',
+        description: 'The name of the context file or files.',
         showInDialog: false,
+        jsonSchemaOverride: {
+          anyOf: [
+            { type: 'string' },
+            { type: 'array', items: { type: 'string' } },
+          ],
+        },
       },
       importFormat: {
         type: 'string',

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -570,9 +570,18 @@
       "type": "object",
       "properties": {
         "fileName": {
-          "description": "The name of the context file.",
-          "type": "object",
-          "additionalProperties": true
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "description": "The name of the context file or files."
         },
         "importFormat": {
           "description": "The format to use when importing memory.",


### PR DESCRIPTION
## What this PR does

This updates the generated settings schema for `context.fileName` so editors accept the documented shapes: a single string or an array of strings.

It keeps the runtime setting type unchanged and regenerates the VS Code companion schema from the CLI settings schema source. A small regression test now locks the schema override in place.

## Why it's needed

The docs describe `context.fileName` as `string or array of strings`, but the generated JSON Schema currently marks it as an object. That makes valid settings look invalid in editors that consume the schema.

## Reviewer Test Plan

### How to verify

Open a settings file with the generated schema and confirm both `"context": { "fileName": "QWEN.md" }` and `"context": { "fileName": ["QWEN.md", "README.md"] }` are accepted as valid shapes.

### Evidence (Before & After)

N/A — this is schema metadata and test coverage, not a visual/TUI rendering change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local Node.js workspace tests on macOS.

## Risk & Scope

- Main risk or tradeoff: The change only affects schema validation/intellisense for `context.fileName`; runtime settings parsing is unchanged.
- Not validated / out of scope: This does not attempt to resolve the broader runtime/debug discussion in #5267.
- Breaking changes / migration notes: None.

## Linked Issues

Refs #5267

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 更新了 `context.fileName` 的生成 settings schema，让编辑器接受文档中描述的两种合法写法：单个字符串，或字符串数组。

运行时 setting 类型保持不变，并从 CLI settings schema 源重新生成了 VS Code companion schema。新增了一个小的回归测试来锁住这个 schema override。

## 为什么需要

文档里 `context.fileName` 是 `string or array of strings`，但当前生成的 JSON Schema 把它标成了 object。使用这个 schema 的编辑器会把合法配置标成无效。

## Reviewer Test Plan

### 如何验证

打开使用生成 schema 的 settings 文件，确认 `"context": { "fileName": "QWEN.md" }` 和 `"context": { "fileName": ["QWEN.md", "README.md"] }` 都是合法形态。

### Before & After 证据

N/A — 这是 schema metadata 和测试覆盖，不是可视化/TUI 渲染变化。

### 本地验证系统

macOS 已测试；Windows/Linux 未单独测试。

### 环境

macOS 本地 Node.js workspace 测试。

## 风险与范围

- 主要风险或取舍：只影响 `context.fileName` 的 schema validation/intellisense；运行时 settings 解析不变。
- 未验证 / 不在范围：不尝试解决 #5267 中更宽的 runtime/debug 讨论。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Refs #5267

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
