### PR TITLE
fix(cli): correct sandbox settings schema

### DIFF
--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -120,6 +120,14 @@ describe('SettingsSchema', () => {
       );
     });
 
+    it('should define tools.sandbox schema override as boolean or string', () => {
+      expect(
+        getSettingsSchema().tools.properties.sandbox.jsonSchemaOverride,
+      ).toEqual({
+        anyOf: [{ type: 'boolean' }, { type: 'string' }],
+      });
+    });
+
     it('should have top-level proxy setting in schema', () => {
       expect(getSettingsSchema().proxy).toBeDefined();
       expect(getSettingsSchema().proxy.type).toBe('string');

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1777,6 +1777,9 @@ const SETTINGS_SCHEMA = {
         description:
           'Sandbox execution environment (can be a boolean or a path string).',
         showInDialog: false,
+        jsonSchemaOverride: {
+          anyOf: [{ type: 'boolean' }, { type: 'string' }],
+        },
       },
       sandboxImage: {
         type: 'string',

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -796,9 +796,15 @@
       "type": "object",
       "properties": {
         "sandbox": {
-          "description": "Sandbox execution environment (can be a boolean or a path string).",
-          "type": "object",
-          "additionalProperties": true
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Sandbox execution environment (can be a boolean or a path string)."
         },
         "sandboxImage": {
           "description": "Sandbox image URI used by Docker/Podman when --sandbox-image and QWEN_SANDBOX_IMAGE are not set.",


### PR DESCRIPTION
## What this PR does

This updates the generated settings schema for `tools.sandbox` so editors accept the documented/runtime-supported shapes: a boolean or a string.

It keeps the runtime setting behavior unchanged, regenerates the VS Code companion schema from the CLI settings schema source, and adds a small regression test for the schema override.

## Why it's needed

The docs show `tools.sandbox` as `boolean or string`, including `{"tools": {"sandbox": true}}`, but the generated JSON Schema currently marks it as an object. That makes valid sandbox settings look invalid in editors that consume the schema.

## Reviewer Test Plan

### How to verify

Open a settings file with the generated schema and confirm both `"tools": { "sandbox": true }` and `"tools": { "sandbox": "docker" }` are accepted as valid shapes.

### Evidence (Before & After)

N/A — this is schema metadata and test coverage, not a visual/TUI rendering change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local Node.js workspace tests on macOS.

## Risk & Scope

- Main risk or tradeoff: The change only affects schema validation/intellisense for `tools.sandbox`; runtime sandbox parsing is unchanged.
- Not validated / out of scope: No live sandbox launch was needed because this PR only changes generated schema metadata.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5270

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 更新了 `tools.sandbox` 的生成 settings schema，让编辑器接受文档和运行时支持的两种合法写法：boolean 或 string。

运行时 setting 行为保持不变，并从 CLI settings schema 源重新生成了 VS Code companion schema。新增了一个小的回归测试来锁住这个 schema override。

## 为什么需要

文档里 `tools.sandbox` 是 `boolean or string`，也包含 `{"tools": {"sandbox": true}}` 这样的示例，但当前生成的 JSON Schema 把它标成了 object。使用这个 schema 的编辑器会把合法 sandbox 配置标成无效。

## Reviewer Test Plan

### 如何验证

打开使用生成 schema 的 settings 文件，确认 `"tools": { "sandbox": true }` 和 `"tools": { "sandbox": "docker" }` 都是合法形态。

### Before & After 证据

N/A — 这是 schema metadata 和测试覆盖，不是可视化/TUI 渲染变化。

### 本地验证系统

macOS 已测试；Windows/Linux 未单独测试。

### 环境

macOS 本地 Node.js workspace 测试。

## 风险与范围

- 主要风险或取舍：只影响 `tools.sandbox` 的 schema validation/intellisense；运行时 sandbox 解析不变。
- 未验证 / 不在范围：因为这个 PR 只改生成 schema metadata，所以不需要跑真实 sandbox launch。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #5270

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
