### PR TITLE
test(cli): enable load config model selection coverage

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -2275,7 +2275,36 @@ describe('loadCliConfig with --mcp-config', () => {
 });
 
 describe('loadCliConfig model selection', () => {
-  it.skip('selects a model from settings.json if provided', async () => {
+  const originalArgv = process.argv;
+  const authEnvKeys = [
+    'QWEN_OAUTH',
+    'OPENAI_API_KEY',
+    'OPENAI_MODEL',
+    'OPENAI_BASE_URL',
+    'QWEN_MODEL',
+    'GEMINI_API_KEY',
+    'GEMINI_MODEL',
+    'GOOGLE_API_KEY',
+    'GOOGLE_MODEL',
+    'ANTHROPIC_API_KEY',
+    'ANTHROPIC_MODEL',
+    'ANTHROPIC_BASE_URL',
+  ] as const;
+
+  beforeEach(() => {
+    vi.mocked(os.homedir).mockReturnValue('/mock/home/user');
+    for (const key of authEnvKeys) {
+      vi.stubEnv(key, undefined);
+    }
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('selects a model from settings.json if provided', async () => {
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments();
     const config = await loadCliConfig(
@@ -2292,7 +2321,7 @@ describe('loadCliConfig model selection', () => {
     expect(config.getModel()).toBe('qwen3-coder-plus');
   });
 
-  it.skip('uses the default gemini model if nothing is set', async () => {
+  it('uses the default Qwen model if nothing is set', async () => {
     process.argv = ['node', 'script.js']; // No model set.
     const argv = await parseArguments();
     const config = await loadCliConfig(


### PR DESCRIPTION
## What this PR does

Re-enables the `loadCliConfig` model selection tests that cover settings-based model selection and the default model fallback. The tests now clear auth/model environment variables inside the describe block so external shell or CI env does not change what the fallback test is asserting.

## Why it's needed

These tests were still skipped even though the current implementation passes them. Bringing them back restores coverage for a small but important config path, and the env cleanup keeps the default fallback assertion stable when variables like `GEMINI_MODEL` or `OPENAI_MODEL` are present.

## Reviewer Test Plan

### How to verify

Run the config test file and the focused model-selection tests with auth/model env vars set. The focused test should still pass and report the default Qwen model when no settings or argv model is provided.

### Evidence (Before & After)

N/A

### Tested on

|     OS     |    Status     |
| :--------: | :-----------: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node 22.x via the repo test setup.

## Risk & Scope

- Main risk or tradeoff: Test-only change; the main risk is the model fallback test being influenced by local auth/model env, which is handled by the describe-level env cleanup.
- Not validated / out of scope: Windows and Linux were not run locally.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5273

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

重新启用 `loadCliConfig` 的模型选择测试，覆盖从 settings 选择模型以及默认模型 fallback 两条路径。测试现在会在这个 describe 内清理 auth/model 相关环境变量，避免本地 shell 或 CI 环境影响 fallback 断言。

## 为什么需要

这两个测试之前还处于 skip 状态，但当前实现已经能通过。恢复它们可以补回配置路径覆盖，同时 env cleanup 能保证在存在 `GEMINI_MODEL`、`OPENAI_MODEL` 这类变量时，默认 fallback 测试仍然稳定。

## Reviewer Test Plan

### 如何验证

运行 config 测试文件，并在设置 auth/model 环境变量的情况下运行聚焦的 model-selection 测试。聚焦测试应仍然通过，并在没有 settings 或 argv model 时返回默认 Qwen 模型。

### 前后证据

N/A

### 本地测试系统

|     OS     |     状态      |
| :--------: | :-----------: |
|  🍏 macOS  |   ✅ 已测试   |
| 🪟 Windows | ⚠️ 未本地测试 |
|  🐧 Linux  | ⚠️ 未本地测试 |

### 环境

Node 22.x，使用仓库测试配置。

## 风险与范围

- 主要风险或取舍：这是 test-only 改动；主要风险是模型 fallback 测试被本地 auth/model 环境变量影响，已通过 describe 级 env cleanup 处理。
- 未验证 / 范围外：没有在本地跑 Windows 和 Linux。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #5273

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
