### PR TITLE
test(cli): cover selection list scroll up

### DIFF
--- a/packages/cli/src/ui/components/shared/BaseSelectionList.test.tsx
+++ b/packages/cli/src/ui/components/shared/BaseSelectionList.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { waitFor } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 import { renderWithProviders } from '../../../test-utils/render.js';
 import {
   BaseSelectionList,
@@ -22,6 +22,16 @@ const mockTheme = {
   text: { primary: 'COLOR_PRIMARY', secondary: 'COLOR_SECONDARY' },
   status: { success: 'COLOR_SUCCESS' },
 } as typeof theme;
+
+const renderSelectionList = (
+  component: Parameters<typeof renderWithProviders>[0],
+): ReturnType<typeof renderWithProviders> => {
+  let rendered!: ReturnType<typeof renderWithProviders>;
+  act(() => {
+    rendered = renderWithProviders(component);
+  });
+  return rendered;
+};
 
 vi.mock('../../semantic-colors.js', () => ({
   theme: {
@@ -74,7 +84,7 @@ describe('BaseSelectionList', () => {
       ...props,
     };
 
-    return renderWithProviders(<BaseSelectionList {...defaultProps} />);
+    return renderSelectionList(<BaseSelectionList {...defaultProps} />);
   };
 
   beforeEach(() => {
@@ -286,7 +296,7 @@ describe('BaseSelectionList', () => {
         ),
       );
 
-      const { rerender, lastFrame } = renderWithProviders(
+      const { rerender, lastFrame } = renderSelectionList(
         <BaseSelectionList {...componentProps} />,
       );
 
@@ -297,7 +307,10 @@ describe('BaseSelectionList', () => {
           setActiveIndex: vi.fn(),
         });
 
-        rerender(<BaseSelectionList {...componentProps} />);
+        await act(async () => {
+          rerender(<BaseSelectionList {...componentProps} />);
+        });
+        await act(async () => {});
 
         await waitFor(() => {
           expect(lastFrame()).toContain(longList[newIndex]!.label);
@@ -316,7 +329,7 @@ describe('BaseSelectionList', () => {
       expect(output).not.toContain('Item 4');
     });
 
-    it.skip('should scroll up when activeIndex moves before the visible window', async () => {
+    it('should scroll up when activeIndex moves before the visible window', async () => {
       const { updateActiveIndex, lastFrame } = renderScrollableList(0);
 
       await updateActiveIndex(4);


### PR DESCRIPTION
## What this PR does

Re-enables the `BaseSelectionList` scroll-up coverage that verifies the visible window moves back up when `activeIndex` jumps before the current window. The test file now wraps Ink renders and rerenders in `act`, which keeps the restored test and the existing suite aligned with React's update semantics.

## Why it's needed

The component already handles this case, but the regression test was still skipped. Restoring it protects the scroll offset behavior for selection lists and removes the React `act(...)` warning noise from this test file.

## Reviewer Test Plan

### How to verify

Run the `BaseSelectionList` test file. It should pass all 26 tests without React `act(...)` warnings, including the restored scroll-up case.

### Evidence (Before & After)

N/A

### Tested on

|     OS     |    Status     |
| :--------: | :-----------: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node 22.x via the repo test setup.

## Risk & Scope

- Main risk or tradeoff: Test-only change; the `act` wrapper changes only how the test flushes Ink/React updates, not runtime behavior.
- Not validated / out of scope: Windows and Linux were not run locally.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5275

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

重新启用 `BaseSelectionList` 的 scroll-up 覆盖，验证当 `activeIndex` 跳到当前可见窗口之前时，可见窗口会向上移动。测试文件现在会用 `act` 包住 Ink render 和 rerender，让恢复的测试以及现有测试都符合 React 更新语义。

## 为什么需要

组件当前已经能处理这个场景，但对应回归测试仍然被 skip。恢复它可以保护选择列表的 scroll offset 行为，同时去掉这个测试文件里的 React `act(...)` warning 噪声。

## Reviewer Test Plan

### 如何验证

运行 `BaseSelectionList` 测试文件。它应该通过全部 26 个测试，并且没有 React `act(...)` warning，包括恢复的 scroll-up 用例。

### 前后证据

N/A

### 本地测试系统

|     OS     |     状态      |
| :--------: | :-----------: |
|  🍏 macOS  |   ✅ 已测试   |
| 🪟 Windows | ⚠️ 未本地测试 |
|  🐧 Linux  | ⚠️ 未本地测试 |

### 环境

Node 22.x，使用仓库测试配置。

## 风险与范围

- 主要风险或取舍：这是 test-only 改动；`act` wrapper 只改变测试如何 flush Ink/React 更新，不影响运行时行为。
- 未验证 / 范围外：没有在本地跑 Windows 和 Linux。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #5275

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
