### PR TITLE
test(cli): enable table foreground reset coverage

### DIFF
--- a/packages/cli/src/ui/utils/TableRenderer.test.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.test.tsx
@@ -460,19 +460,13 @@ describe('<TableRenderer />', () => {
     expectAllLinesToHaveSameVisibleWidth(output);
   });
 
-  // TODO: re-enable after ink 7 re-upgrade. The `[39m` (foreground-only
-  // reset) variant added in #4050 only wraps "colored reset" at width=18 under
-  // ink 7's <Text> wrapping; ink 6 keeps it on a single line. The functional
-  // assertions (foreground cleared, equal widths) still pass — only the
-  // wrap-position assertion is ink-7-specific.
-  it.skip('does not preserve foreground after an explicit foreground reset', () => {
+  it('does not preserve foreground after an explicit foreground reset', () => {
     const output = renderTable(
       ['Color'],
       [['\u001b[38;5;45mcolored\u001b[39m reset']],
       18,
     );
 
-    expectWrappedContinuation(output, 'colored reset', 'reset');
     expect(foregroundAtText(output, 'reset')).toBeUndefined();
     expectAllLinesToHaveSameVisibleWidth(output);
   });


### PR DESCRIPTION
## What this PR does

Re-enables the `TableRenderer` foreground-only reset test for `\x1b[39m`. The stale wrap-position assertion is removed, while the functional checks remain: text after the foreground reset should not keep the previous ANSI foreground, and the rendered table should keep stable visible widths.

## Why it's needed

This test was skipped while the repo moved between Ink versions because one assertion depended on a narrow-width wrapping detail. The current renderer still benefits from the reset coverage, and adjacent tests already cover foreground preservation across wrapped lines.

## Reviewer Test Plan

### How to verify

Run the `TableRenderer` test file. It should pass all 60 tests, including the restored foreground reset case.

### Evidence (Before & After)

N/A

### Tested on

|     OS     |    Status     |
| :--------: | :-----------: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node 22.x via the repo test setup.

## Risk & Scope

- Main risk or tradeoff: Test-only change; this intentionally removes a layout-specific wrap assertion that no longer matches the current renderer.
- Not validated / out of scope: Windows and Linux were not run locally.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5277

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

重新启用 `TableRenderer` 针对 `\x1b[39m` foreground-only reset 的测试。删除过期的 wrap-position 断言，但保留功能性检查：foreground reset 后的文本不应继承前面的 ANSI 前景色，并且渲染后的表格可见宽度保持稳定。

## 为什么需要

这个测试是在仓库切换 Ink 版本期间被 skip 的，因为其中一个断言依赖窄宽度下的换行细节。当前 renderer 仍然需要 reset 行为覆盖，而相邻测试已经覆盖跨换行保留 foreground 的场景。

## Reviewer Test Plan

### 如何验证

运行 `TableRenderer` 测试文件。它应该通过全部 60 个测试，包括恢复的 foreground reset 用例。

### 前后证据

N/A

### 本地测试系统

|     OS     |     状态      |
| :--------: | :-----------: |
|  🍏 macOS  |   ✅ 已测试   |
| 🪟 Windows | ⚠️ 未本地测试 |
|  🐧 Linux  | ⚠️ 未本地测试 |

### 环境

Node 22.x，使用仓库测试配置。

## 风险与范围

- 主要风险或取舍：这是 test-only 改动；这里有意删除了一个与当前 renderer 不匹配的布局细节断言。
- 未验证 / 范围外：没有在本地跑 Windows 和 Linux。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #5277

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
