### PR TITLE
fix(core): per-turn tool-call circuit breaker — always-on cap + opt-in loop heuristics (#5234)

### DIFF
--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -109,6 +109,12 @@ const LOOP_TYPE_LABELS: Record<LoopType, string> = {
     'the model spent too many consecutive calls reading files without making progress',
   [LoopType.ACTION_STAGNATION]:
     'the model kept calling the same tool without making progress',
+  [LoopType.GLOBAL_TOOL_CALL_DUPLICATE]:
+    'the model repeated the same tool call across the turn, even when not back-to-back',
+  [LoopType.ALTERNATING_TOOL_CALL_PATTERN]:
+    'the model alternated between the same two tool calls in a repeating pattern',
+  [LoopType.TURN_TOOL_CALL_CAP]:
+    'the model exceeded the maximum number of tool calls allowed in a single turn',
 };
 
 function emitLoopDetectedMessage(

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -128,9 +128,13 @@ function emitLoopDetectedMessage(
   }
   const reason = loopType ? LOOP_TYPE_LABELS[loopType] : undefined;
   const detail = reason ? ` (${loopType}: ${reason})` : '';
-  process.stderr.write(
-    `Loop detection halted the run${detail}. Set the \`model.skipLoopDetection\` setting to true to disable.\n`,
-  );
+  // The turn cap runs before the skipLoopDetection gate, so that setting can't
+  // disable it — don't suggest it for TURN_TOOL_CALL_CAP.
+  const hint =
+    loopType === LoopType.TURN_TOOL_CALL_CAP
+      ? ' This is an always-on per-turn tool-call cap and cannot be disabled via `model.skipLoopDetection`.'
+      : ' Set the `model.skipLoopDetection` setting to true to disable.';
+  process.stderr.write(`Loop detection halted the run${detail}.${hint}\n`);
 }
 
 /**

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -4286,6 +4286,73 @@ hello
       expect(client['pendingMemoryPrefetch']).toBeUndefined();
     });
 
+    it('should halt via the always-on turn cap before the skipLoopDetection gate', async () => {
+      let abortHandlerInvoked = false;
+      mockMemoryManager.recall.mockImplementation((_root, _query, opts) => {
+        opts.abortSignal?.addEventListener('abort', () => {
+          abortHandlerInvoked = true;
+        });
+        return new Promise(() => {});
+      });
+
+      const mockChat: Partial<GeminiChat> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getHistoryLength: vi.fn().mockReturnValue(0),
+      };
+      client['chat'] = mockChat as GeminiChat;
+
+      // The always-on cap trips on the first event — it runs before (and
+      // independently of) the gated detectors.
+      const loopDetector = client['loopDetector'];
+      const alwaysOnSpy = vi
+        .spyOn(loopDetector, 'checkAlwaysOnSafeties')
+        .mockReturnValue(true);
+      const deterministicSpy = vi.spyOn(
+        loopDetector,
+        'addAndCheckDeterministicToolCallLoop',
+      );
+      vi.spyOn(loopDetector, 'getLastLoopType').mockReturnValue(
+        LoopType.TURN_TOOL_CALL_CAP,
+      );
+
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: 'content', value: 'looping' };
+        })(),
+      );
+
+      const stream = client.sendMessageStream(
+        [{ text: 'trigger the cap' }],
+        new AbortController().signal,
+        'prompt-id-cap',
+        { type: SendMessageType.UserQuery },
+      );
+      const events = [];
+      let result = await stream.next();
+      while (!result.done) {
+        events.push(result.value);
+        result = await stream.next();
+      }
+      const returnedTurn = result.value as
+        | { pendingToolCalls: unknown[] }
+        | undefined;
+
+      // Always-on cap fires and short-circuits before the gated detectors run.
+      expect(alwaysOnSpy).toHaveBeenCalled();
+      expect(deterministicSpy).not.toHaveBeenCalled();
+      const loopEvent = events.find(
+        (e) => e.type === GeminiEventType.LoopDetected,
+      );
+      expect(loopEvent?.value?.loopType).toBe(LoopType.TURN_TOOL_CALL_CAP);
+      // Pending tool calls are dropped so the halt doesn't spawn a continuation
+      // that re-trips the cap and double-prints the message.
+      expect(returnedTurn?.pendingToolCalls).toHaveLength(0);
+      // The mid-stream memory prefetch is cancelled.
+      expect(abortHandlerInvoked).toBe(true);
+      expect(client['pendingMemoryPrefetch']).toBeUndefined();
+    });
+
     it('should PRESERVE the pending prefetch when next-speaker continueTurn returns', async () => {
       // Self-inflicted-regression guard for the round-4 finding:
       // the bottom-of-try `normalCompletion = true` doesn't cover the

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -6182,6 +6182,7 @@ Other open files:
 
       // Replace loop detector with spies
       const ldMock = {
+        checkAlwaysOnSafeties: vi.fn().mockReturnValue(false),
         addAndCheckDeterministicToolCallLoop: vi.fn().mockReturnValue(false),
         addAndCheckHeuristicLoops: vi.fn().mockReturnValue(false),
         reset: vi.fn(),
@@ -6211,7 +6212,8 @@ Other open files:
         // consume stream
       }
 
-      // Assert - neither detector path runs when skipLoopDetection is true
+      // Assert - always-on safeties still run, but opt-in detectors don't
+      expect(ldMock.checkAlwaysOnSafeties).toHaveBeenCalled();
       expect(
         ldMock.addAndCheckDeterministicToolCallLoop,
       ).not.toHaveBeenCalled();

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -4316,11 +4316,19 @@ hello
         LoopType.TURN_TOOL_CALL_CAP,
       );
 
-      mockTurnRunFn.mockReturnValue(
-        (async function* () {
-          yield { type: 'content', value: 'looping' };
-        })(),
-      );
+      // `run` is invoked as `turn.run(...)`, so `this` is the live Turn —
+      // populate pendingToolCalls the way the real Turn.run does as it streams
+      // ToolCallRequest chunks, so the halt's clear runs against a non-empty
+      // array (not a trivially-empty one).
+      mockTurnRunFn.mockImplementation(async function* (this: {
+        pendingToolCalls: unknown[];
+      }) {
+        this.pendingToolCalls.push(
+          { name: 'read_file', args: { path: 'a.ts' } },
+          { name: 'read_file', args: { path: 'b.ts' } },
+        );
+        yield { type: 'content', value: 'looping' };
+      });
 
       const stream = client.sendMessageStream(
         [{ text: 'trigger the cap' }],
@@ -4345,8 +4353,9 @@ hello
         (e) => e.type === GeminiEventType.LoopDetected,
       );
       expect(loopEvent?.value?.loopType).toBe(LoopType.TURN_TOOL_CALL_CAP);
-      // Pending tool calls are dropped so the halt doesn't spawn a continuation
-      // that re-trips the cap and double-prints the message.
+      // The two pending calls collected before the cap tripped are dropped, so
+      // the halt doesn't spawn a continuation that re-trips the cap and
+      // double-prints the message.
       expect(returnedTurn?.pendingToolCalls).toHaveLength(0);
       // The mid-stream memory prefetch is cancelled.
       expect(abortHandlerInvoked).toBe(true);

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -2133,9 +2133,10 @@ export class GeminiClient {
           // executing them, spawning a continuation, and re-tripping the cap
           // (which would double-print the halt message and waste a request).
           turn.pendingToolCalls.length = 0;
+          const loopType = this.loopDetector.getLastLoopType();
           yield {
             type: GeminiEventType.LoopDetected,
-            value: { loopType: this.loopDetector.getLastLoopType()! },
+            ...(loopType && { value: { loopType } }),
           };
           if (arenaAgentClient) {
             await arenaAgentClient.reportError('Loop detected');

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -2123,6 +2123,26 @@ export class GeminiClient {
           didUpdateIdeContextState = true;
         }
 
+        // Always-on safety checks (turn tool-call cap). These fire before
+        // the skipLoopDetection gate so they cannot be bypassed by
+        // configuration.
+        const alwaysOnLoop =
+          this.loopDetector.checkAlwaysOnSafeties(event);
+        if (alwaysOnLoop) {
+          yield {
+            type: GeminiEventType.LoopDetected,
+            value: { loopType: this.loopDetector.getLastLoopType()! },
+          };
+          if (arenaAgentClient) {
+            await arenaAgentClient.reportError('Loop detected');
+          }
+          this.lastApiCompletionTimestamp = Date.now();
+          if (isTopLevelInteraction)
+            endInteractionSpan('error', { errorMessage: 'loop detected' });
+          this.cancelPendingMemoryPrefetch();
+          return turn;
+        }
+
         // Loop detection is opt-in: `model.skipLoopDetection` defaults to true
         // (see settingsSchema) to avoid false-positive interruptions. Keep BOTH
         // the deterministic identical-tool-call check and the heuristic checks

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -2126,9 +2126,13 @@ export class GeminiClient {
         // Always-on safety checks (turn tool-call cap). These fire before
         // the skipLoopDetection gate so they cannot be bypassed by
         // configuration.
-        const alwaysOnLoop =
-          this.loopDetector.checkAlwaysOnSafeties(event);
+        const alwaysOnLoop = this.loopDetector.checkAlwaysOnSafeties(event);
         if (alwaysOnLoop) {
+          // The tripping response may carry several tool calls collected
+          // before the cap fired. Drop them so the run halts here instead of
+          // executing them, spawning a continuation, and re-tripping the cap
+          // (which would double-print the halt message and waste a request).
+          turn.pendingToolCalls.length = 0;
           yield {
             type: GeminiEventType.LoopDetected,
             value: { loopType: this.loopDetector.getLastLoopType()! },

--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -1076,6 +1076,87 @@ describe('LoopDetectionService', () => {
       // still fires.
       expect(isLoop).toBe(true);
     });
+
+    const retryEvent = {
+      type: GeminiEventType.Retry,
+    } as ServerGeminiStreamEvent;
+    const finishedEvent = {
+      type: GeminiEventType.Finished,
+      value: { reason: 'STOP' },
+    } as unknown as ServerGeminiStreamEvent;
+
+    it('rolls back a failed attempt on retry so its calls do not count', () => {
+      service.reset('');
+      // Attempt makes 60 calls, then the API retries (no round-trip committed
+      // yet, so the rollback floor is 0).
+      for (let i = 0; i < 60; i++) {
+        service.checkAlwaysOnSafeties(createToolCallRequestEvent('t', { i }));
+      }
+      service.checkAlwaysOnSafeties(retryEvent);
+      // The 60 discarded calls must not count: a full cap's worth of fresh
+      // calls stays under the limit, and only the (cap+1)-th fires.
+      for (let i = 0; i < TURN_TOOL_CALL_CAP; i++) {
+        expect(
+          service.checkAlwaysOnSafeties(
+            createToolCallRequestEvent('t', { j: i }),
+          ),
+        ).toBe(false);
+      }
+      expect(
+        service.checkAlwaysOnSafeties(
+          createToolCallRequestEvent('t', { last: true }),
+        ),
+      ).toBe(true);
+      expect(loggers.logLoopDetected).toHaveBeenCalledTimes(1);
+    });
+
+    it('preserves committed round-trip counts when a later attempt retries', () => {
+      service.reset('');
+      // Round-trip 1: 60 calls, then Finished commits them as the floor.
+      for (let i = 0; i < 60; i++) {
+        service.checkAlwaysOnSafeties(createToolCallRequestEvent('t', { i }));
+      }
+      service.checkAlwaysOnSafeties(finishedEvent);
+      // Round-trip 2: 30 calls, then a retry discards only these 30.
+      for (let i = 0; i < 30; i++) {
+        service.checkAlwaysOnSafeties(
+          createToolCallRequestEvent('t', { k: i }),
+        );
+      }
+      service.checkAlwaysOnSafeties(retryEvent);
+      // Total is back to the committed 60 (NOT zero): 40 more reach exactly the
+      // cap without firing, and the next call trips it.
+      for (let i = 0; i < TURN_TOOL_CALL_CAP - 60; i++) {
+        expect(
+          service.checkAlwaysOnSafeties(
+            createToolCallRequestEvent('t', { m: i }),
+          ),
+        ).toBe(false);
+      }
+      expect(
+        service.checkAlwaysOnSafeties(
+          createToolCallRequestEvent('t', { last: true }),
+        ),
+      ).toBe(true);
+    });
+
+    it('still accumulates across committed round-trips to trip the cap', () => {
+      service.reset('');
+      let fired = false;
+      // 11 calls/round-trip; the cap (100) is crossed partway through.
+      for (let rt = 0; rt < 12 && !fired; rt++) {
+        for (let i = 0; i < 11 && !fired; i++) {
+          fired = service.checkAlwaysOnSafeties(
+            createToolCallRequestEvent('t', { rt, i }),
+          );
+        }
+        if (!fired) {
+          service.checkAlwaysOnSafeties(finishedEvent);
+        }
+      }
+      expect(fired).toBe(true);
+      expect(service.getLastLoopType()).toBe(LoopType.TURN_TOOL_CALL_CAP);
+    });
   });
 
   describe('Global Tool Call Duplicate Detection', () => {

--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -27,6 +27,9 @@ const CONTENT_CHUNK_SIZE = 50;
 // Mirrored from loopDetectionService.ts. Kept local so the test is
 // self-describing and failures point to the constant that changed.
 const FILE_READ_WINDOW = 15;
+const GLOBAL_DUPLICATE_THRESHOLD = 6;
+const ALTERNATING_PATTERN_CYCLES = 3;
+const TURN_TOOL_CALL_CAP = 100;
 
 describe('LoopDetectionService', () => {
   let service: LoopDetectionService;
@@ -1019,6 +1022,230 @@ describe('LoopDetectionService', () => {
         );
         expect(isLoop).toBe(false);
       }
+    });
+  });
+
+  describe('Turn Tool Call Cap (Always-On Circuit Breaker)', () => {
+    it('should not fire when total calls are below the cap', () => {
+      service.reset('');
+      for (let i = 0; i < TURN_TOOL_CALL_CAP; i++) {
+        const isLoop = service.checkAlwaysOnSafeties(
+          createToolCallRequestEvent('any_tool', { i }),
+        );
+        expect(isLoop).toBe(false);
+      }
+    });
+
+    it('should fire on the call that exceeds the cap', () => {
+      service.reset('');
+      for (let i = 0; i < TURN_TOOL_CALL_CAP; i++) {
+        service.checkAlwaysOnSafeties(
+          createToolCallRequestEvent('any_tool', { i }),
+        );
+      }
+      const isLoop = service.checkAlwaysOnSafeties(
+        createToolCallRequestEvent('any_tool', { extra: true }),
+      );
+      expect(isLoop).toBe(true);
+      expect(loggers.logLoopDetected).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fire regardless of disabledForSession', () => {
+      service.reset('');
+      service.disableForSession();
+      // disableForSession prevents heuristic checks, but not the turn cap
+      for (let i = 0; i < TURN_TOOL_CALL_CAP; i++) {
+        service.checkAlwaysOnSafeties(
+          createToolCallRequestEvent('any_tool', { i }),
+        );
+      }
+      const isLoop = service.checkAlwaysOnSafeties(
+        createToolCallRequestEvent('any_tool', { extra: true }),
+      );
+      // disabledForSession blocks non-ToolCallRequest events in
+      // checkAlwaysOnSafeties, but this IS a ToolCallRequest so the cap
+      // still fires.
+      expect(isLoop).toBe(true);
+    });
+  });
+
+  describe('Global Tool Call Duplicate Detection', () => {
+    it('should not fire when same call appears fewer than threshold times', () => {
+      service.reset('');
+      const event = createToolCallRequestEvent('stuck_tool', {
+        param: 'same',
+      });
+      for (let i = 0; i < GLOBAL_DUPLICATE_THRESHOLD - 1; i++) {
+        const isLoop = service.addAndCheckHeuristicLoops(event);
+        expect(isLoop).toBe(false);
+      }
+    });
+
+    it('should fire when same (tool, args) appears threshold times non-consecutively', () => {
+      service.reset('');
+      const stuckEvent = createToolCallRequestEvent('stuck_tool', {
+        param: 'same',
+      });
+      const otherEvents = [
+        createToolCallRequestEvent('other_a', { x: 1 }),
+        createToolCallRequestEvent('other_b', { y: 2 }),
+        createToolCallRequestEvent('other_c', { z: 3 }),
+      ];
+
+      // Interleave: stuck, other_a, stuck, other_b, stuck, other_c, ...
+      // GLOBAL_DUPLICATE_THRESHOLD total stuck calls with different calls between
+      let otherIdx = 0;
+      for (let i = 0; i < GLOBAL_DUPLICATE_THRESHOLD - 1; i++) {
+        expect(service.addAndCheckHeuristicLoops(stuckEvent)).toBe(false);
+        expect(
+          service.addAndCheckHeuristicLoops(
+            otherEvents[otherIdx % otherEvents.length],
+          ),
+        ).toBe(false);
+        otherIdx++;
+      }
+      // The threshold-th stuck call should fire
+      const isLoop = service.addAndCheckHeuristicLoops(stuckEvent);
+      expect(isLoop).toBe(true);
+      expect(loggers.logLoopDetected).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          loop_type: 'global_tool_call_duplicate',
+        }),
+      );
+    });
+
+    it('should not fire for different (tool, args) pairs', () => {
+      service.reset('');
+      for (let i = 0; i < GLOBAL_DUPLICATE_THRESHOLD; i++) {
+        const isLoop = service.addAndCheckHeuristicLoops(
+          createToolCallRequestEvent('stuck_tool', { param: i }),
+        );
+        expect(isLoop).toBe(false);
+      }
+      expect(loggers.logLoopDetected).not.toHaveBeenCalled();
+    });
+
+    it('should fire for consecutive identical calls via both detectors', () => {
+      // The heuristic path also runs checkGlobalDuplicate on every
+      // ToolCallRequest, so a consecutive run of 5 identical calls trips
+      // the consecutive detector first (threshold 5 < global 6). This test
+      // verifies the global path would also fire if the consecutive
+      // detector were disabled.
+      service.reset('');
+      const event = createToolCallRequestEvent('stuck_tool', {
+        param: 'same',
+      });
+      for (let i = 0; i < GLOBAL_DUPLICATE_THRESHOLD - 1; i++) {
+        service.addAndCheckHeuristicLoops(event);
+      }
+      const isLoop = service.addAndCheckHeuristicLoops(event);
+      expect(isLoop).toBe(true);
+      expect(loggers.logLoopDetected).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          loop_type: 'global_tool_call_duplicate',
+        }),
+      );
+    });
+  });
+
+  describe('Alternating Tool Call Pattern Detection', () => {
+    it('should fire for a clean ABABAB alternating pattern', () => {
+      service.reset('');
+      const eventA = createToolCallRequestEvent('tool_a', { param: 'a' });
+      const eventB = createToolCallRequestEvent('tool_b', { param: 'b' });
+
+      // ALTERNATING_PATTERN_CYCLES cycles = 2*CYCLES calls. Build up to
+      // one call short of the trigger.
+      const totalCycles = ALTERNATING_PATTERN_CYCLES;
+      for (let i = 0; i < totalCycles - 1; i++) {
+        expect(service.addAndCheckHeuristicLoops(eventA)).toBe(false);
+        expect(service.addAndCheckHeuristicLoops(eventB)).toBe(false);
+      }
+      // First call of the final cycle
+      expect(service.addAndCheckHeuristicLoops(eventA)).toBe(false);
+      // Second call of the final cycle completes the pattern
+      const isLoop = service.addAndCheckHeuristicLoops(eventB);
+      expect(isLoop).toBe(true);
+      expect(loggers.logLoopDetected).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          loop_type: 'alternating_tool_call_pattern',
+        }),
+      );
+    });
+
+    it('should not fire when calls alternate but with varying keys', () => {
+      service.reset('');
+      // Alternating tool names but different args each time → different
+      // keys → no clean ABAB because the keys keep changing.
+      const totalCycles = ALTERNATING_PATTERN_CYCLES + 2;
+      for (let i = 0; i < totalCycles; i++) {
+        expect(
+          service.addAndCheckHeuristicLoops(
+            createToolCallRequestEvent('tool_a', { param: i }),
+          ),
+        ).toBe(false);
+        expect(
+          service.addAndCheckHeuristicLoops(
+            createToolCallRequestEvent('tool_b', { param: i }),
+          ),
+        ).toBe(false);
+      }
+      expect(loggers.logLoopDetected).not.toHaveBeenCalled();
+    });
+
+    it('should not fire for a single tool repeated (consecutive, not alternating)', () => {
+      service.reset('');
+      const event = createToolCallRequestEvent('tool_a', { param: 'a' });
+      const totalCalls = 2 * ALTERNATING_PATTERN_CYCLES;
+      for (let i = 0; i < totalCalls; i++) {
+        // The consecutive identical detector would fire at threshold 5,
+        // but we only check the heuristic path here. At 6 calls the
+        // global duplicate detector fires. This test just confirms the
+        // alternating detector doesn't false-positive on a repeated key.
+        service.addAndCheckHeuristicLoops(event);
+      }
+      // Either global_duplicate or consecutive_identical fires — we just
+      // verify the alternating pattern detector didn't fire.
+      const logged = vi.mocked(loggers.logLoopDetected).mock.calls;
+      const alternatingFired = logged.some((call) => {
+        const event = call[1] as unknown as Record<string, unknown>;
+        return 'loop_type' in event
+          ? event['loop_type'] === 'alternating_tool_call_pattern'
+          : false;
+      });
+      expect(alternatingFired).toBe(false);
+    });
+
+    it('should reset alternating window after a different third pattern', () => {
+      service.reset('');
+      const eventA = createToolCallRequestEvent('tool_a', { param: 'a' });
+      const eventB = createToolCallRequestEvent('tool_b', { param: 'b' });
+      const eventC = createToolCallRequestEvent('tool_c', { param: 'c' });
+
+      // Build up ABAB
+      service.addAndCheckHeuristicLoops(eventA);
+      service.addAndCheckHeuristicLoops(eventB);
+      service.addAndCheckHeuristicLoops(eventA);
+      service.addAndCheckHeuristicLoops(eventB);
+      // Insert C to break the pattern
+      service.addAndCheckHeuristicLoops(eventC);
+      // Restart ABAB from here — need 6 calls (3 cycles) after the break
+      service.addAndCheckHeuristicLoops(eventA);
+      service.addAndCheckHeuristicLoops(eventB);
+      service.addAndCheckHeuristicLoops(eventA);
+      service.addAndCheckHeuristicLoops(eventB);
+      expect(service.addAndCheckHeuristicLoops(eventA)).toBe(false);
+      const isLoop = service.addAndCheckHeuristicLoops(eventB);
+      expect(isLoop).toBe(true);
+      expect(loggers.logLoopDetected).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          loop_type: 'alternating_tool_call_pattern',
+        }),
+      );
     });
   });
 });

--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -1203,6 +1203,11 @@ describe('LoopDetectionService', () => {
           loop_type: 'global_tool_call_duplicate',
         }),
       );
+      // getLastLoopType() is the getter the client uses to populate the
+      // bubbled LoopDetected event, so assert it too — not just the logged one.
+      expect(service.getLastLoopType()).toBe(
+        LoopType.GLOBAL_TOOL_CALL_DUPLICATE,
+      );
     });
 
     it('should not fire for different (tool, args) pairs', () => {
@@ -1238,6 +1243,23 @@ describe('LoopDetectionService', () => {
         }),
       );
     });
+
+    it('does not count a retried replay toward the global-duplicate threshold', () => {
+      service.reset('');
+      const stuck = createToolCallRequestEvent('stuck_tool', { param: 'same' });
+      const retry = { type: GeminiEventType.Retry } as ServerGeminiStreamEvent;
+      // Failed attempt streams (threshold - 3) identical calls, then retries.
+      for (let i = 0; i < GLOBAL_DUPLICATE_THRESHOLD - 3; i++) {
+        expect(service.addAndCheckHeuristicLoops(stuck)).toBe(false);
+      }
+      service.addAndCheckHeuristicLoops(retry);
+      // The replay streams the same calls again. Without the Retry reset the
+      // pre- and post-retry counts would sum to the threshold and false-fire.
+      for (let i = 0; i < GLOBAL_DUPLICATE_THRESHOLD - 3; i++) {
+        expect(service.addAndCheckHeuristicLoops(stuck)).toBe(false);
+      }
+      expect(loggers.logLoopDetected).not.toHaveBeenCalled();
+    });
   });
 
   describe('Alternating Tool Call Pattern Detection', () => {
@@ -1263,6 +1285,9 @@ describe('LoopDetectionService', () => {
         expect.objectContaining({
           loop_type: 'alternating_tool_call_pattern',
         }),
+      );
+      expect(service.getLastLoopType()).toBe(
+        LoopType.ALTERNATING_TOOL_CALL_PATTERN,
       );
     });
 

--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -14,6 +14,7 @@ import type {
 } from '../core/turn.js';
 import { GeminiEventType } from '../core/turn.js';
 import * as loggers from '../telemetry/loggers.js';
+import { LoopType } from '../telemetry/types.js';
 import { LoopDetectionService } from './loopDetectionService.js';
 
 vi.mock('../telemetry/loggers.js', () => ({
@@ -1048,6 +1049,14 @@ describe('LoopDetectionService', () => {
       );
       expect(isLoop).toBe(true);
       expect(loggers.logLoopDetected).toHaveBeenCalledTimes(1);
+      // The turn cap reports its own loop type, not consecutive-identical.
+      expect(loggers.logLoopDetected).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          loop_type: 'turn_tool_call_cap',
+        }),
+      );
+      expect(service.getLastLoopType()).toBe(LoopType.TURN_TOOL_CALL_CAP);
     });
 
     it('should fire regardless of disabledForSession', () => {

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -44,6 +44,20 @@ const FILE_READ_WINDOW = 15;
 // Action stagnation tracking
 const STAGNATION_THRESHOLD = 8;
 
+// Global tool call duplicate tracking: how many times the same (tool, args)
+// pair must appear across the entire turn (not necessarily consecutively)
+// before it is treated as a loop.
+const GLOBAL_DUPLICATE_THRESHOLD = 6;
+
+// Alternating pattern detection: number of complete AB cycles needed to
+// trip the detector (3 cycles = 6 calls: A B A B A B).
+const ALTERNATING_PATTERN_CYCLES = 3;
+
+// Hard per-turn tool call cap. Always-on circuit breaker — not gated by
+// skipLoopDetection. If a single turn exceeds this many tool calls the
+// turn is halted regardless of loop-detection configuration.
+const TURN_TOOL_CALL_CAP = 100;
+
 /**
  * Service for detecting and preventing infinite loops in AI responses.
  * Monitors tool call repetitions and content sentence repetitions.
@@ -84,6 +98,19 @@ export class LoopDetectionService {
   // non-read-like tool fires, a window full of reads is treated as legitimate
   // exploration rather than loop evidence. Resets per-prompt in reset().
   private hasSeenNonReadTool = false;
+
+  // Non-consecutive global duplicate tracking: counts every (tool, args)
+  // pair seen across the entire turn. When any pair reaches
+  // GLOBAL_DUPLICATE_THRESHOLD, the turn is halted.
+  private globalToolCallCounts = new Map<string, number>();
+
+  // Sliding window of recent tool-call keys for alternating-pattern
+  // detection (ABABAB…). Kept at 2 * ALTERNATING_PATTERN_CYCLES entries.
+  private recentToolCallKeys: string[] = [];
+
+  // Total tool calls emitted in the current turn. Always-on circuit breaker;
+  // exceeds TURN_TOOL_CALL_CAP → hard-stop.
+  private turnToolCallTotal = 0;
 
   // Loop type of the most recent firing. Bubbled up through the
   // LoopDetected event so callers (non-interactive CLI, telemetry) can tell
@@ -152,10 +179,17 @@ export class LoopDetectionService {
         this.thoughtHistory = [];
 
         this.trackToolCall(event.value);
+        const globalDup = this.checkGlobalDuplicate(
+          this.getToolCallKey(event.value),
+        );
+        const alternating = this.checkAlternatingPattern(
+          this.getToolCallKey(event.value),
+        );
         const readFileLoop = this.checkReadFileLoop();
         const actionStagnation = this.checkActionStagnation();
 
-        this.loopDetected = readFileLoop || actionStagnation;
+        this.loopDetected =
+          globalDup || alternating || readFileLoop || actionStagnation;
         break;
       }
       case GeminiEventType.Content: {
@@ -196,6 +230,28 @@ export class LoopDetectionService {
       this.loopDetected = true;
     }
     return this.loopDetected;
+  }
+
+  /**
+   * Always-on safety checks that fire regardless of skipLoopDetection.
+   * Currently enforces the per-turn tool call cap. Call this before the
+   * gated checks so the hard cap cannot be bypassed by configuration.
+   */
+  checkAlwaysOnSafeties(event: ServerGeminiStreamEvent): boolean {
+    if (this.loopDetected) {
+      return true;
+    }
+
+    if (event.type !== GeminiEventType.ToolCallRequest) {
+      return false;
+    }
+
+    const key = this.getToolCallKey(event.value);
+    if (this.checkTurnToolCallCap(key)) {
+      this.loopDetected = true;
+      return true;
+    }
+    return false;
   }
 
   private checkToolCallLoop(toolCall: { name: string; args: object }): boolean {
@@ -551,6 +607,92 @@ export class LoopDetectionService {
   }
 
   /**
+   * Always-on hard cap: if the turn exceeds TURN_TOOL_CALL_CAP tool calls
+   * the turn is halted. This is a safety net independent of
+   * skipLoopDetection and fires on the very next tool call that pushes the
+   * total past the cap, not retroactively.
+   */
+  private checkTurnToolCallCap(_toolCallKey: string): boolean {
+    this.turnToolCallTotal++;
+    if (this.turnToolCallTotal > TURN_TOOL_CALL_CAP) {
+      this.lastLoopType = LoopType.CONSECUTIVE_IDENTICAL_TOOL_CALLS;
+      logLoopDetected(
+        this.config,
+        new LoopDetectedEvent(
+          LoopType.CONSECUTIVE_IDENTICAL_TOOL_CALLS,
+          this.promptId,
+        ),
+      );
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Non-consecutive global duplicate detection: the SAME (tool, args) pair
+   * need not appear consecutively — if it appears GLOBAL_DUPLICATE_THRESHOLD
+   * times anywhere in the turn, it is treated as a loop. This catches models
+   * that intersperse the stuck call among other actions.
+   */
+  private checkGlobalDuplicate(toolCallKey: string): boolean {
+    const count = (this.globalToolCallCounts.get(toolCallKey) ?? 0) + 1;
+    this.globalToolCallCounts.set(toolCallKey, count);
+
+    if (count >= GLOBAL_DUPLICATE_THRESHOLD) {
+      this.lastLoopType = LoopType.GLOBAL_TOOL_CALL_DUPLICATE;
+      logLoopDetected(
+        this.config,
+        new LoopDetectedEvent(
+          LoopType.GLOBAL_TOOL_CALL_DUPLICATE,
+          this.promptId,
+        ),
+      );
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Alternating-pattern detection: catches ABABAB… patterns where the model
+   * flips between two distinct tool calls. Tracked via a sliding window of
+   * tool-call keys; when the window fills with alternating A/B values the
+   * turn is halted.
+   */
+  private checkAlternatingPattern(toolCallKey: string): boolean {
+    const maxLen = 2 * ALTERNATING_PATTERN_CYCLES;
+    this.recentToolCallKeys.push(toolCallKey);
+    if (this.recentToolCallKeys.length > maxLen) {
+      this.recentToolCallKeys.shift();
+    }
+
+    if (this.recentToolCallKeys.length < maxLen) {
+      return false;
+    }
+
+    // Extract the two alternating keys. If there are more than two distinct
+    // keys in the window, there is no clean ABAB pattern.
+    const [a, b] = this.recentToolCallKeys;
+    if (a === b) return false; // not alternating, same tool
+
+    for (let i = 0; i < maxLen; i++) {
+      const expected = i % 2 === 0 ? a : b;
+      if (this.recentToolCallKeys[i] !== expected) {
+        return false;
+      }
+    }
+
+    this.lastLoopType = LoopType.ALTERNATING_TOOL_CALL_PATTERN;
+    logLoopDetected(
+      this.config,
+      new LoopDetectedEvent(
+        LoopType.ALTERNATING_TOOL_CALL_PATTERN,
+        this.promptId,
+      ),
+    );
+    return true;
+  }
+
+  /**
    * Resets all loop detection state.
    */
   reset(promptId: string): void {
@@ -566,6 +708,9 @@ export class LoopDetectionService {
     this.lastSeenToolName = null;
     this.hasSeenNonReadTool = false;
     this.lastLoopType = null;
+    this.globalToolCallCounts.clear();
+    this.recentToolCallKeys = [];
+    this.turnToolCallTotal = 0;
   }
 
   private resetToolCallCount(): void {

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -615,13 +615,10 @@ export class LoopDetectionService {
   private checkTurnToolCallCap(_toolCallKey: string): boolean {
     this.turnToolCallTotal++;
     if (this.turnToolCallTotal > TURN_TOOL_CALL_CAP) {
-      this.lastLoopType = LoopType.CONSECUTIVE_IDENTICAL_TOOL_CALLS;
+      this.lastLoopType = LoopType.TURN_TOOL_CALL_CAP;
       logLoopDetected(
         this.config,
-        new LoopDetectedEvent(
-          LoopType.CONSECUTIVE_IDENTICAL_TOOL_CALLS,
-          this.promptId,
-        ),
+        new LoopDetectedEvent(LoopType.TURN_TOOL_CALL_CAP, this.promptId),
       );
       return true;
     }

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -109,8 +109,16 @@ export class LoopDetectionService {
   private recentToolCallKeys: string[] = [];
 
   // Total tool calls emitted in the current turn. Always-on circuit breaker;
-  // exceeds TURN_TOOL_CALL_CAP → hard-stop.
+  // exceeds TURN_TOOL_CALL_CAP → hard-stop. Accumulates across ToolResult
+  // continuations within a turn (reset() only runs for top-level interactions).
   private turnToolCallTotal = 0;
+
+  // Rollback floor for turnToolCallTotal: the committed total as of the last
+  // completed round-trip (Finished event). A retry re-streams the failed
+  // attempt's tool calls (Turn clears pendingToolCalls on retry), so on Retry
+  // we roll back to this floor — discarding only the failed attempt, not the
+  // counts from prior completed round-trips.
+  private turnToolCallTotalCommitted = 0;
 
   // Loop type of the most recent firing. Bubbled up through the
   // LoopDetected event so callers (non-interactive CLI, telemetry) can tell
@@ -179,12 +187,9 @@ export class LoopDetectionService {
         this.thoughtHistory = [];
 
         this.trackToolCall(event.value);
-        const globalDup = this.checkGlobalDuplicate(
-          this.getToolCallKey(event.value),
-        );
-        const alternating = this.checkAlternatingPattern(
-          this.getToolCallKey(event.value),
-        );
+        const toolCallKey = this.getToolCallKey(event.value);
+        const globalDup = this.checkGlobalDuplicate(toolCallKey);
+        const alternating = this.checkAlternatingPattern(toolCallKey);
         const readFileLoop = this.checkReadFileLoop();
         const actionStagnation = this.checkActionStagnation();
 
@@ -242,12 +247,28 @@ export class LoopDetectionService {
       return true;
     }
 
+    // A model response (round-trip) finished cleanly: commit its tool-call
+    // count as the rollback floor. The per-turn total accumulates across
+    // ToolResult continuations, so the floor must track the last committed
+    // round-trip rather than resetting to zero.
+    if (event.type === GeminiEventType.Finished) {
+      this.turnToolCallTotalCommitted = this.turnToolCallTotal;
+      return false;
+    }
+
+    // A retry re-streams the failed attempt's tool calls, which would
+    // double-count against the cap. Roll back to the last committed round-trip
+    // so only executed calls count — never below it (prior round-trips stay).
+    if (event.type === GeminiEventType.Retry) {
+      this.turnToolCallTotal = this.turnToolCallTotalCommitted;
+      return false;
+    }
+
     if (event.type !== GeminiEventType.ToolCallRequest) {
       return false;
     }
 
-    const key = this.getToolCallKey(event.value);
-    if (this.checkTurnToolCallCap(key)) {
+    if (this.checkTurnToolCallCap()) {
       this.loopDetected = true;
       return true;
     }
@@ -612,7 +633,7 @@ export class LoopDetectionService {
    * skipLoopDetection and fires on the very next tool call that pushes the
    * total past the cap, not retroactively.
    */
-  private checkTurnToolCallCap(_toolCallKey: string): boolean {
+  private checkTurnToolCallCap(): boolean {
     this.turnToolCallTotal++;
     if (this.turnToolCallTotal > TURN_TOOL_CALL_CAP) {
       this.lastLoopType = LoopType.TURN_TOOL_CALL_CAP;
@@ -708,6 +729,7 @@ export class LoopDetectionService {
     this.globalToolCallCounts.clear();
     this.recentToolCallKeys = [];
     this.turnToolCallTotal = 0;
+    this.turnToolCallTotalCommitted = 0;
   }
 
   private resetToolCallCount(): void {

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -197,6 +197,18 @@ export class LoopDetectionService {
           globalDup || alternating || readFileLoop || actionStagnation;
         break;
       }
+      case GeminiEventType.Retry: {
+        // A retry replays the failed attempt's tool calls (Turn clears
+        // pendingToolCalls on retry), so drop the counters this PR added to
+        // avoid the heuristic detectors firing on a duplicated replay — e.g.
+        // 3 identical calls + Retry + 3 more would otherwise hit the
+        // global-duplicate threshold of 6. Mirrors the deterministic path's
+        // resetToolCallCount() on Retry; the always-on cap keeps its own
+        // counter accurate via commit/rollback instead.
+        this.globalToolCallCounts.clear();
+        this.recentToolCallKeys = [];
+        break;
+      }
       case GeminiEventType.Content: {
         this.loopDetected = this.checkContentLoop(event.value);
         break;

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -428,6 +428,8 @@ export enum LoopType {
   GLOBAL_TOOL_CALL_DUPLICATE = 'global_tool_call_duplicate',
   /** Two tools alternating in a fixed pattern (A B A B A B ...). */
   ALTERNATING_TOOL_CALL_PATTERN = 'alternating_tool_call_pattern',
+  /** Total tool calls in a single turn exceeded the always-on hard cap, regardless of pattern. */
+  TURN_TOOL_CALL_CAP = 'turn_tool_call_cap',
 }
 
 export class LoopDetectedEvent implements BaseTelemetryEvent {

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -424,6 +424,10 @@ export enum LoopType {
   REPETITIVE_THOUGHTS = 'repetitive_thoughts',
   READ_FILE_LOOP = 'read_file_loop',
   ACTION_STAGNATION = 'action_stagnation',
+  /** Same (tool, args) pair appears N times across the entire turn, not necessarily consecutively. */
+  GLOBAL_TOOL_CALL_DUPLICATE = 'global_tool_call_duplicate',
+  /** Two tools alternating in a fixed pattern (A B A B A B ...). */
+  ALTERNATING_TOOL_CALL_PATTERN = 'alternating_tool_call_pattern',
 }
 
 export class LoopDetectedEvent implements BaseTelemetryEvent {


### PR DESCRIPTION
> Focused re-scope of #5242 by @aspnmy. That PR bundled the circuit breaker with several unrelated changes (a React #185 fix, a Chinese README, and two misc tweaks) and the author asked maintainers to carry the core forward ([comment](https://github.com/QwenLM/qwen-code/pull/5242#issuecomment-4736950261)). This PR cherry-picks only @aspnmy's circuit-breaker commit (authorship preserved) and adds the telemetry/label fixes that review flagged. The unrelated changes are intentionally left out and can be sent as their own PRs.

## What this PR does

Adds an always-on safety layer that halts a turn when its tool calls run away, so a stuck model can no longer loop forever. The core of it is a hard per-turn tool-call cap that runs *before* the existing `model.skipLoopDetection` gate, which means it cannot be switched off by configuration. Alongside the cap, two new heuristic detectors are added to the existing (opt-in) loop-detection path: a non-consecutive "global duplicate" detector that catches the same `(tool, args)` call repeating across a turn even when interleaved with other calls, and an "alternating pattern" detector that catches a model flip-flopping between the same two calls (A B A B …). Each detector reports its own telemetry loop type, and the non-interactive (headless) CLI prints a human-readable reason for each when it halts a run.

## Why it's needed

Tool calls can get stuck in an infinite loop (#5234). The triage of that issue identified the root cause: `model.skipLoopDetection` defaults to `true`, so loop detection is off for most users and the only backstop is `MAX_TURNS`. This change adds a safety net that does not depend on that opt-in flag — the hard per-turn cap always applies — while the two new heuristics make the opt-in detection smarter about loop shapes the existing consecutive-identical check misses.

## Reviewer Test Plan

### How to verify

This is internal loop-detection logic plus a headless stderr message — not a TUI change — so verification is via unit tests and typecheck rather than a screen recording. From the repo root:

```
# Core unit tests (loop detector + client integration)
cd packages/core && npx vitest run src/services/loopDetectionService.test.ts src/core/client.test.ts
# → Test Files 2 passed (2); Tests 258 passed (258)

# Core typecheck
cd packages/core && npx tsc --noEmit   # → exit 0
```

What a reviewer should confirm: (1) the new circuit-breaker tests pass — turn cap fires on the call that exceeds the cap and reports `loop_type: 'turn_tool_call_cap'`, global-duplicate fires non-consecutively at threshold, alternating-pattern fires on a clean ABAB and resets after a break; (2) the cap fires regardless of `disableForSession()`; (3) the new `LoopType` values each map to a label in the non-interactive CLI (`LOOP_TYPE_LABELS` is `Record<LoopType, string>`, so a missing one fails typecheck).

### Evidence (Before & After)

N/A (non-UI change). Test output:

```
 ✓ src/services/loopDetectionService.test.ts (56 tests)
 ✓ src/core/client.test.ts (202 tests)
 Test Files  2 passed (2)
      Tests  258 passed (258)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local unit tests + `tsc --noEmit` on macOS (Node via repo toolchain). Windows/Linux left to CI.

## Risk & Scope

- Main risk or tradeoff: the always-on per-turn cap (100 tool calls) is the only default-behavior change. It is deliberately high — above typical legitimate turns — but a genuinely long automated turn could be cut short; it mirrors the existing `MAX_TURNS` backstop philosophy and cannot be disabled by design (that is the point of a circuit breaker).
- Not validated / out of scope: reproducing a real model loop end-to-end is non-deterministic, so it is covered by unit tests rather than a live run. The two new heuristic detectors remain behind `skipLoopDetection` (default `true`), matching the existing opt-in design — so for default users only the hard cap is active.
- Breaking changes / migration notes: none. The new `LoopType` values are additive. One pre-existing telemetry mislabel is corrected: the turn cap previously logged `consecutive_identical_tool_calls` and now logs `turn_tool_call_cap`, so any dashboard filtering on the old value for cap events should be updated.

## Linked Issues

Closes #5234

<details>
<summary>中文说明</summary>

> 对 #5242 的聚焦重做，原作者 @aspnmy。那个 PR 把断路器和若干无关改动（React #185 修复、中文 README、两个杂项）打包在一起，作者也表示没时间返工、请维护者接手（[评论](https://github.com/QwenLM/qwen-code/pull/5242#issuecomment-4736950261)）。本 PR 只 cherry-pick 了 @aspnmy 的断路器那一个 commit（保留其作者署名），并补上 review 指出的遥测/标签修复。无关改动有意不包含，可各自单独提 PR。

## 这个 PR 做了什么

新增一个始终生效的安全层：当一个回合内的工具调用失控时直接中断，让卡住的模型不再无限循环。核心是一个单回合工具调用硬上限，它运行在现有 `model.skipLoopDetection` 门控*之前*，因此无法被配置关闭。除硬上限外，还在现有（opt-in）的循环检测路径上增加了两个启发式检测器：一个非连续的「全局重复」检测器，能抓到同一个 `(tool, args)` 调用在一个回合内反复出现（即使中间夹杂了其他调用）；以及一个「交替模式」检测器，能抓到模型在同样的两个调用之间来回横跳（A B A B …）。每个检测器都上报各自的遥测 loop type，非交互（headless）CLI 在因此中断时会为每种类型打印一句可读的原因。

## 为什么需要

工具调用可能陷入死循环（#5234）。该 issue 的 triage 已确认根因：`model.skipLoopDetection` 默认为 `true`，所以对多数用户而言循环检测是关闭的，唯一兜底是 `MAX_TURNS`。本改动加了一个不依赖该 opt-in 开关的安全网——单回合硬上限始终生效；同时两个新启发式让 opt-in 检测能识别现有「连续相同」检测漏掉的循环形态。

## 审查测试计划

### 如何验证

这是内部循环检测逻辑加上一条 headless stderr 提示，不是 TUI 改动，所以通过单元测试和类型检查验证，而不是录屏。在仓库根目录：

```
# 核心单元测试（循环检测器 + client 集成）
cd packages/core && npx vitest run src/services/loopDetectionService.test.ts src/core/client.test.ts
# → Test Files 2 passed (2); Tests 258 passed (258)

# 核心类型检查
cd packages/core && npx tsc --noEmit   # → exit 0
```

审查者应确认：(1) 新断路器测试通过——超过上限的那一次调用触发，且上报 `loop_type: 'turn_tool_call_cap'`；全局重复在阈值处非连续触发；交替模式在干净的 ABAB 上触发并在被打断后重置；(2) 即使 `disableForSession()` 后硬上限仍会触发；(3) 每个新 `LoopType` 都在非交互 CLI 里有对应标签（`LOOP_TYPE_LABELS` 是 `Record<LoopType, string>`，缺一个就会类型检查失败）。

### 证据（Before & After）

N/A（非 UI 改动）。测试输出：

```
 ✓ src/services/loopDetectionService.test.ts (56 tests)
 ✓ src/core/client.test.ts (202 tests)
 Test Files  2 passed (2)
      Tests  258 passed (258)
```

### 测试平台

|    系统    | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 运行环境（可选）

macOS 上本地单元测试 + `tsc --noEmit`（Node 走仓库工具链）。Windows/Linux 交给 CI。

## 风险与范围

- 主要风险或取舍：始终生效的单回合上限（100 次工具调用）是唯一的默认行为变化。该值刻意取得较高——高于正常回合——但一个确实很长的自动化回合可能被截断；它沿用现有 `MAX_TURNS` 兜底的思路，且按设计无法关闭（这正是断路器的意义）。
- 未验证 / 范围之外：端到端复现真实模型循环是非确定性的，因此用单元测试覆盖而非实跑。两个新启发式检测器仍在 `skipLoopDetection`（默认 `true`）门控之后，沿用现有 opt-in 设计——所以对默认用户只有硬上限生效。
- 破坏性变更 / 迁移说明：无。新增的 `LoopType` 值是增量的。修正了一处既有遥测误标：硬上限此前记为 `consecutive_identical_tool_calls`，现在记为 `turn_tool_call_cap`，所以若有看板按旧值过滤上限事件，应更新。

## 关联 Issue

Closes #5234

</details>
