### PR TITLE
test(core): enable agent headless termination coverage

### DIFF
--- a/packages/core/src/agents/runtime/agent-headless.test.ts
+++ b/packages/core/src/agents/runtime/agent-headless.test.ts
@@ -1158,53 +1158,55 @@ describe('subagent.ts', () => {
         expect(scope.getTerminateMode()).toBe(AgentTerminateMode.MAX_TURNS);
       });
 
-      it.skip('should terminate with TIMEOUT if the time limit is reached during an LLM call', async () => {
+      it('should terminate with TIMEOUT if the time limit is reached during an LLM call', async () => {
         // Use fake timers to reliably test timeouts
         vi.useFakeTimers();
 
-        const { config } = await createMockConfig();
-        const runConfig: RunConfig = { max_time_minutes: 5, max_turns: 100 };
+        try {
+          const { config } = await createMockConfig();
+          const runConfig: RunConfig = { max_time_minutes: 5, max_turns: 100 };
 
-        // We need to control the resolution of the sendMessageStream promise to advance the timer during execution.
-        let resolveStream: (
-          value: AsyncGenerator<unknown, void, unknown>,
-        ) => void;
-        const streamPromise = new Promise<
-          AsyncGenerator<unknown, void, unknown>
-        >((resolve) => {
+          // We need to control the resolution of the sendMessageStream promise to advance the timer during execution.
+          let resolveStream: (
+            value: AsyncGenerator<unknown, void, unknown>,
+          ) => void;
+          const streamPromise = new Promise<
+            AsyncGenerator<unknown, void, unknown>
+          >((resolve) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            resolveStream = resolve as any;
+          });
+
+          // The LLM call will hang until we resolve the promise.
+          mockSendMessageStream.mockReturnValue(streamPromise);
+
+          const scope = await AgentHeadless.create(
+            'test-agent',
+            config,
+            promptConfig,
+            defaultModelConfig,
+            runConfig,
+          );
+
+          const runPromise = scope.execute(new ContextState());
+
+          // Advance time beyond the limit (6 minutes) while the agent is awaiting the LLM response.
+          await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
+
+          // Now resolve the stream. The model returns 'stop'.
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          resolveStream = resolve as any;
-        });
+          resolveStream!(createMockStream(['stop'])() as any);
 
-        // The LLM call will hang until we resolve the promise.
-        mockSendMessageStream.mockReturnValue(streamPromise);
+          await runPromise;
 
-        const scope = await AgentHeadless.create(
-          'test-agent',
-          config,
-          promptConfig,
-          defaultModelConfig,
-          runConfig,
-        );
-
-        const runPromise = scope.execute(new ContextState());
-
-        // Advance time beyond the limit (6 minutes) while the agent is awaiting the LLM response.
-        await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
-
-        // Now resolve the stream. The model returns 'stop'.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        resolveStream!(createMockStream(['stop'])() as any);
-
-        await runPromise;
-
-        expect(scope.getTerminateMode()).toBe(AgentTerminateMode.TIMEOUT);
-        expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
-
-        vi.useRealTimers();
+          expect(scope.getTerminateMode()).toBe(AgentTerminateMode.TIMEOUT);
+          expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
+        } finally {
+          vi.useRealTimers();
+        }
       });
 
-      it.skip('should terminate with ERROR if the model call throws', async () => {
+      it('should terminate with ERROR if the model call throws', async () => {
         const { config } = await createMockConfig();
         mockSendMessageStream.mockRejectedValue(new Error('API Failure'));
 


### PR DESCRIPTION
## What this PR does

Re-enables AgentHeadless termination coverage for timeout and model-call failure paths. The timeout test now restores real timers with try/finally so fake timers cannot leak into later tests.

## Why it's needed

The runtime already records TIMEOUT and ERROR terminate modes for these paths, but both regression tests were still skipped. Restoring them makes the headless agent termination behavior visible to CI again.

## Reviewer Test Plan

### How to verify

Run the AgentHeadless test file and confirm the TIMEOUT and ERROR termination tests pass together with the rest of the file.

### Evidence (Before & After)

N/A. This is test coverage only.

### Tested on

| OS | Status |
| :-- | :-- |
| macOS | tested |
| Windows | not tested locally |
| Linux | not tested locally |

### Environment (optional)

Local npm workspace tests on macOS.

## Risk & Scope

- Main risk or tradeoff: low; this only re-enables skipped tests and adds fake-timer cleanup around the timeout case.
- Not validated / out of scope: Windows and Linux local runs; CI covers those platforms.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5290

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

重新启用 AgentHeadless 在超时和模型调用失败路径上的终止模式测试。超时测试现在用 try/finally 恢复真实 timer，避免 fake timers 泄漏到后续测试。

## 为什么需要

运行时代码已经会在这些路径记录 TIMEOUT 和 ERROR terminate mode，但对应回归测试仍然是 skipped。恢复测试后，headless agent 的终止行为会重新进入 CI 覆盖。

## Reviewer Test Plan

### 如何验证

运行 AgentHeadless 测试文件，确认 TIMEOUT 和 ERROR 两个终止模式测试以及整份测试文件都通过。

### Evidence (Before & After)

N/A。这是测试覆盖改动。

### Tested on

| OS | Status |
| :-- | :-- |
| macOS | tested |
| Windows | not tested locally |
| Linux | not tested locally |

### Environment (optional)

macOS 本地 npm workspace 测试。

## Risk & Scope

- Main risk or tradeoff: 风险低；只恢复 skipped 测试，并给超时测试补上 fake timer 清理。
- Not validated / out of scope: Windows 和 Linux 没有本地跑；交给 CI 覆盖。
- Breaking changes / migration notes: 无。

## Linked Issues

Fixes #5290

</details>