### PR TITLE
test(cli): enable command search long suggestion coverage

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -3354,7 +3354,7 @@ describe('InputPrompt', () => {
       unmount();
     });
 
-    it.skip('expands and collapses long suggestion via Right/Left arrows', async () => {
+    it('expands and collapses long suggestion via Right/Left arrows', async () => {
       props.shellModeActive = false;
       const longValue = 'l'.repeat(200);
 
@@ -3373,20 +3373,22 @@ describe('InputPrompt', () => {
       await wait();
 
       stdin.write('\x12');
-      await wait();
-
-      expect(clean(stdout.lastFrame())).toContain('→');
+      await waitFor(() => {
+        expect(clean(stdout.lastFrame())).toContain('→');
+      });
 
       stdin.write('\u001B[C');
-      await wait();
-      expect(clean(stdout.lastFrame())).toContain('←');
+      await waitFor(() => {
+        expect(clean(stdout.lastFrame())).toContain('←');
+      });
       expect(stdout.lastFrame()).toMatchSnapshot(
         'command-search-expanded-match',
       );
 
       stdin.write('\u001B[D');
-      await wait();
-      expect(clean(stdout.lastFrame())).toContain('→');
+      await waitFor(() => {
+        expect(clean(stdout.lastFrame())).toContain('→');
+      });
       expect(stdout.lastFrame()).toMatchSnapshot(
         'command-search-collapsed-match',
       );

--- a/packages/cli/src/ui/components/__snapshots__/InputPrompt.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/InputPrompt.test.tsx.snap
@@ -1,21 +1,20 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`InputPrompt > command search (Ctrl+R when not in shell) > expands and collapses long suggestion via Right/Left arrows > command-search-collapsed-match 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ (r:)    Type your message or @path/to/file                                                       │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
- lllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll →
- lllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll
- ..."
+"────────────────────────────────────────────────────────────────────────────────
+(r:)    Type your message or @path/to/file
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  lllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll →
+  lllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll..."
 `;
 
 exports[`InputPrompt > command search (Ctrl+R when not in shell) > expands and collapses long suggestion via Right/Left arrows > command-search-expanded-match 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ (r:)    Type your message or @path/to/file                                                       │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
- lllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll ←
- lllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll
- llllllllllllllllllllllllllllllllllllllllllllllllll"
+"────────────────────────────────────────────────────────────────────────────────
+(r:)    Type your message or @path/to/file
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  lllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll ←
+  lllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll
+  llllllllllllllllllllllllllllllllllllllllllllll"
 `;
 
 exports[`InputPrompt > command search (Ctrl+R when not in shell) > renders match window and expanded view (snapshots) > command-search-collapsed-match 1`] = `


### PR DESCRIPTION
## What this PR does

Re-enables the command-search test that expands and collapses long suggestions with the Right and Left arrow keys, and refreshes the two snapshots for the current prompt rendering.

## Why it's needed

The behavior is working again, but the regression coverage was still skipped. Bringing it back protects the long-suggestion expand/collapse path and keeps the snapshots aligned with the current InputPrompt layout.

## Reviewer Test Plan

### How to verify

Run the InputPrompt test file and confirm the long command-search suggestion test passes with the updated expanded and collapsed snapshots.

### Evidence (Before & After)

N/A. This is test coverage only.

### Tested on

| OS | Status |
| :-- | :-- |
| macOS | tested |
| Windows | not tested locally |
| Linux | not tested locally |

### Environment (optional)

Local npm workspace tests on macOS.

## Risk & Scope

- Main risk or tradeoff: low; this only re-enables an existing skipped test and updates its snapshots.
- Not validated / out of scope: Windows and Linux local runs; CI covers those platforms.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5280

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

重新启用命令搜索里长建议项通过 Right/Left 箭头展开和收起的测试，并刷新当前 InputPrompt 渲染对应的两个快照。

## 为什么需要

这个行为现在已经可以正常工作，但对应的回归测试还处于 skipped 状态。恢复测试可以覆盖长建议项的展开/收起路径，也让快照和当前布局保持一致。

## Reviewer Test Plan

### 如何验证

运行 InputPrompt 测试文件，确认长命令搜索建议项测试通过，并且展开/收起两个快照符合当前渲染。

### Evidence (Before & After)

N/A。这是测试覆盖改动。

### Tested on

| OS | Status |
| :-- | :-- |
| macOS | tested |
| Windows | not tested locally |
| Linux | not tested locally |

### Environment (optional)

macOS 本地 npm workspace 测试。

## Risk & Scope

- Main risk or tradeoff: 风险低；只恢复一个已有 skipped 测试并更新快照。
- Not validated / out of scope: Windows 和 Linux 没有本地跑；交给 CI 覆盖。
- Breaking changes / migration notes: 无。

## Linked Issues

Fixes #5280

</details>