### PR TITLE
feat(desktop): compile macOS 26+ Liquid Glass Assets.car in brand-create

### DIFF
--- a/packages/desktop/.agents/skills/desktop-brand-builder/scripts/brand-create.ts
+++ b/packages/desktop/.agents/skills/desktop-brand-builder/scripts/brand-create.ts
@@ -3,10 +3,12 @@ import {
   copyFileSync,
   existsSync,
   mkdirSync,
+  mkdtempSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { extname, join, resolve } from 'node:path';
 
 interface BrandInput {
@@ -130,10 +132,15 @@ async function run(cmd: string[], cwd: string): Promise<void> {
   }
 }
 
+interface BrandAssetsResult {
+  macIcon: string;
+  hasAssetsCar: boolean;
+}
+
 async function writeBrandAssets(
   config: BrandConfig,
   desktopRoot: string,
-): Promise<string> {
+): Promise<BrandAssetsResult> {
   const requireFromDesktop = createRequire(join(desktopRoot, 'package.json'));
   const sharp = requireFromDesktop('sharp') as typeof import('sharp');
   const electronDir = join(desktopRoot, 'apps', 'electron');
@@ -157,7 +164,7 @@ async function writeBrandAssets(
   await writePng(join(brandDir, 'dock.png'), 512);
   await writePng(join(brandDir, 'symbol.png'), 512);
 
-  if (process.platform !== 'darwin') return 'icon.png';
+  if (process.platform !== 'darwin') return { macIcon: 'icon.png', hasAssetsCar: false };
 
   const iconset = join(brandDir, 'icon.iconset');
   rmSync(iconset, { recursive: true, force: true });
@@ -184,7 +191,91 @@ async function writeBrandAssets(
     ['iconutil', '-c', 'icns', iconset, '-o', join(brandDir, 'icon.icns')],
     brandDir,
   );
-  return 'icon.icns';
+
+  const hasAssetsCar = await compileAssetsCar(config, brandDir, writePng);
+  return { macIcon: 'icon.icns', hasAssetsCar };
+}
+
+async function compileAssetsCar(
+  config: BrandConfig,
+  brandDir: string,
+  writePng: (output: string, size: number) => Promise<void>,
+): Promise<boolean> {
+  const xcassets = join(brandDir, 'Assets.xcassets');
+  const appiconset = join(xcassets, 'AppIcon.appiconset');
+  rmSync(xcassets, { recursive: true, force: true });
+  mkdirSync(appiconset, { recursive: true });
+
+  writeFileSync(
+    join(xcassets, 'Contents.json'),
+    JSON.stringify({ info: { author: 'xcode', version: 1 } }),
+  );
+
+  const entries = [
+    { file: 'icon_16.png', size: 16, scale: '1x', dims: '16x16' },
+    { file: 'icon_32.png', size: 32, scale: '2x', dims: '16x16' },
+    { file: 'icon_32.png', size: 32, scale: '1x', dims: '32x32' },
+    { file: 'icon_64.png', size: 64, scale: '2x', dims: '32x32' },
+    { file: 'icon_128.png', size: 128, scale: '1x', dims: '128x128' },
+    { file: 'icon_256.png', size: 256, scale: '2x', dims: '128x128' },
+    { file: 'icon_256.png', size: 256, scale: '1x', dims: '256x256' },
+    { file: 'icon_512.png', size: 512, scale: '2x', dims: '256x256' },
+    { file: 'icon_512.png', size: 512, scale: '1x', dims: '512x512' },
+    { file: 'icon_1024.png', size: 1024, scale: '2x', dims: '512x512' },
+  ];
+
+  const uniqueSizes = new Set(entries.map((e) => e.size));
+  for (const size of uniqueSizes) {
+    await writePng(join(appiconset, `icon_${size}.png`), size);
+  }
+
+  writeFileSync(
+    join(appiconset, 'Contents.json'),
+    JSON.stringify({
+      images: entries.map((e) => ({
+        filename: e.file,
+        idiom: 'mac',
+        scale: e.scale,
+        size: e.dims,
+      })),
+      info: { author: 'xcode', version: 1 },
+    }),
+  );
+
+  const outDir = mkdtempSync(join(tmpdir(), 'assets-car-'));
+  const partialPlist = join(outDir, 'partial-info.plist');
+  const proc = Bun.spawn({
+    cmd: [
+      'xcrun', 'actool', xcassets,
+      '--compile', outDir,
+      '--app-icon', 'AppIcon',
+      '--platform', 'macosx',
+      '--minimum-deployment-target', '14.0',
+      '--output-partial-info-plist', partialPlist,
+    ],
+    cwd: brandDir,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    console.log('Warning: actool compilation failed, skipping Assets.car');
+    rmSync(xcassets, { recursive: true, force: true });
+    return false;
+  }
+
+  const compiledCar = join(outDir, 'Assets.car');
+  if (!existsSync(compiledCar)) {
+    console.log('Warning: actool produced no Assets.car, skipping');
+    rmSync(xcassets, { recursive: true, force: true });
+    return false;
+  }
+
+  copyFileSync(compiledCar, join(brandDir, 'Assets.car'));
+  rmSync(xcassets, { recursive: true, force: true });
+  rmSync(outDir, { recursive: true, force: true });
+  console.log('Assets.car compiled successfully');
+  return true;
 }
 
 function tsString(value: string): string {
@@ -203,8 +294,11 @@ function helpMenuLinks(config: BrandConfig): string {
     ]`;
 }
 
-function brandBlock(config: BrandConfig, macIcon: string): string {
+function brandBlock(config: BrandConfig, macIcon: string, hasAssetsCar: boolean): string {
   const resourceDir = `resources/brands/${config.brandId}`;
+  const liquidGlassLine = hasAssetsCar
+    ? `\n      liquidGlassAssetsCar: ${tsString(`${resourceDir}/Assets.car`)},`
+    : '';
 
   return `  ${tsString(config.brandId)}: {
     id: ${tsString(config.brandId)},
@@ -223,7 +317,7 @@ function brandBlock(config: BrandConfig, macIcon: string): string {
       macIcon: ${tsString(`${resourceDir}/${macIcon}`)},
       winIcon: ${tsString(`${resourceDir}/icon.png`)},
       linuxIcon: ${tsString(`${resourceDir}/icon.png`)},
-      devDockIcon: ${tsString(`${resourceDir}/dock.png`)},
+      devDockIcon: ${tsString(`${resourceDir}/dock.png`)},${liquidGlassLine}
     },
     credits: '',
     creditsShort: '',
@@ -236,6 +330,7 @@ function registerBrand(
   config: BrandConfig,
   desktopRoot: string,
   macIcon: string,
+  hasAssetsCar: boolean,
 ): void {
   const brandingPath = join(
     desktopRoot,
@@ -259,15 +354,15 @@ function registerBrand(
 
   writeFileSync(
     brandingPath,
-    source.replace(marker, `\n${brandBlock(config, macIcon)}${marker}`),
+    source.replace(marker, `\n${brandBlock(config, macIcon, hasAssetsCar)}${marker}`),
   );
 }
 
 async function main(): Promise<void> {
   const desktopRoot = desktopRootFromArgs();
   const config = loadConfig(configPathFromArgs());
-  const macIcon = await writeBrandAssets(config, desktopRoot);
-  registerBrand(config, desktopRoot, macIcon);
+  const { macIcon, hasAssetsCar } = await writeBrandAssets(config, desktopRoot);
+  registerBrand(config, desktopRoot, macIcon, hasAssetsCar);
 
   console.log(`Created brand ${config.brandId}`);
   console.log(`App name: ${config.appName}`);
@@ -275,6 +370,9 @@ async function main(): Promise<void> {
   console.log(
     `Assets: ${join(desktopRoot, 'apps', 'electron', 'resources', 'brands', config.brandId)}`,
   );
+  if (hasAssetsCar) {
+    console.log('Assets.car: generated (macOS 26+ Liquid Glass icon)');
+  }
 }
 
 main().catch((error: unknown) => {


### PR DESCRIPTION
## What this PR does

Teaches the brand-create skill script to compile a macOS 26+ Liquid Glass `Assets.car` automatically alongside the existing `icon.icns`. After this change, every brand produced by `brand-create` ships with a ready-to-bundle Liquid Glass icon, and the `afterPack` hook's "Pre-compiled Assets.car not found" warning disappears. The generated `branding.ts` block now includes the optional `liquidGlassAssetsCar` field only when the compile actually succeeded, mirroring the existing convention used by the `qwen-code` and `openwork` brands.

## Why it's needed

Before this change, `brand-create` only produced `icon.icns` for macOS. The `afterPack.cjs` hook was already wired to copy a pre-compiled `Assets.car` from `resources/brands/<brand>/Assets.car` into the app bundle so macOS 26+ could render the new Liquid Glass icon treatment — but the script never emitted one. The result was that every branded build logged:

```
Warning: Pre-compiled Assets.car not found for brand <id>
The app will use the fallback icon.icns on all macOS versions
```

The warning was benign but ubiquitous: on macOS 26+ the app fell back to the legacy `.icns` rendering, missing the new icon treatment Apple now applies to every modern app. Fixing this at the skill layer means every future brand — and every teammate who runs `brand-create` for a white-label build — gets a correct icon without hand-editing the brand directory or running Xcode manually.

## Reviewer Test Plan

### How to verify

1. Run the script on a macOS host with Xcode command-line tools installed:
   ```
   bun run packages/desktop/.agents/skills/desktop-brand-builder/scripts/brand-create.ts \
     --desktop-root $(pwd)/packages/desktop \
     --config /tmp/brand.json
   ```
   where `brand.json` contains at minimum `{ "brandId": "acme-ai", "logo": "/path/to/logo.png", "website": "https://acme.ai" }`.
2. Confirm the script ends with `Assets.car: generated (macOS 26+ Liquid Glass icon)`.
3. Confirm `packages/desktop/apps/electron/resources/brands/acme-ai/Assets.car` exists and `file` identifies it as a Mac OS X BOM.
4. Confirm no scratch `Assets.xcassets` directory or `/tmp/assets-car-*` tmp dir is left behind.
5. Confirm `packages/shared/src/branding.ts` now registers the new brand with a `liquidGlassAssetsCar: 'resources/brands/acme-ai/Assets.car'` line inside the `assets:` block.
6. Build a branded DMG with `CRAFT_BRAND=acme-ai bun run electron:dist:mac`. The `afterPack` hook should log `Liquid Glass icon copied:` and the build should no longer print the "Pre-compiled Assets.car not found" warning for that brand. Inspect the output app bundle at `<Brand>.app/Contents/Resources/Assets.car` — it should exist (~600 KB).
7. On a non-macOS host (or a macOS host with `xcrun` removed from `PATH`), re-run the script and confirm it logs `Warning: actool compilation failed, skipping Assets.car` and still produces a fully valid brand directory with `icon.icns`, `dock.png`, `symbol.png`, etc.

### Evidence (Before & After)

**Before** — every branded macOS build logged:

```
afterPack: looking for Assets.car at …/resources/brands/<brand>/Assets.car
Warning: Pre-compiled Assets.car not found for brand <brand>
The app will use the fallback icon.icns on all macOS versions
```

The app bundle at `<Brand>.app/Contents/Resources/` contained only `icon.icns`.

**After** — the skill script output:

```
Assets.car compiled successfully
Created brand <brand>
App name: <Brand>
App ID: <reversed-host>.desktop
Assets: …/resources/brands/<brand>
Assets.car: generated (macOS 26+ Liquid Glass icon)
```

and `afterPack` logged `Liquid Glass icon copied: …/<Brand>.app/Contents/Resources/Assets.car`. The final `.app` bundle contains a ~593 KB `Assets.car` next to `icon.icns`, and `hdiutil verify` on the produced DMG returns VALID.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

macOS host was used for both the positive path (actool present, Assets.car emitted) and the fallback path (simulated actool failure, graceful skip). The `compileAssetsCar` function's fallback branch returns `hasAssetsCar: false` without raising, so Windows / Linux CI hosts that lack `xcrun` still produce a valid brand directory — just without the Liquid Glass asset, which is a macOS-only feature anyway.

---

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 `desktop-brand-builder` 的 `brand-create` 脚本在 macOS 宿主上自动用 `xcrun actool` 编译出 macOS 26+ Liquid Glass 风格所需的 `Assets.car`，并在 `branding.ts` 中按编译是否成功条件化地写入 `liquidGlassAssetsCar` 字段。从此每一个由 `brand-create` 生成的品牌都自带可被 `afterPack` 钩子直接复制进 `.app` 的 Liquid Glass 图标资产，不再打印 "Pre-compiled Assets.car not found" 警告。

## 为什么需要

之前 `brand-create` 只为 macOS 生成 `icon.icns`。`afterPack.cjs` 已经写好了"如果 `resources/brands/<brand>/Assets.car` 存在就复制进 `.app` 包"的逻辑，但 `brand-create` 从未生成这个文件——于是每一次打品牌包都会输出：

```
Warning: Pre-compiled Assets.car not found for brand <id>
The app will use the fallback icon.icns on all macOS versions
```

这条 warning 本身不致命，但意味着在 macOS 26+ 上 app 只能回退到老的 `.icns` 渲染，错过 Apple 现在默认给所有现代 app 启用的 Liquid Glass 图标效果。把这个修复下沉到 skill 层，以后任何同事跑 `brand-create` 生成白标包，都不需要再手动编辑品牌目录或打开 Xcode。

## 关键实现点

- 在生成 `icon.iconset` / `icon.icns` 之后，临时构建一个 `Assets.xcassets/AppIcon.appiconset/`，复用已有的 16–1024 尺寸 PNG。
- 调用 `xcrun actool … --compile <tmpdir> --app-icon AppIcon --platform macosx --minimum-deployment-target 14.0 --output-partial-info-plist <tmpdir>/partial-info.plist`，把产物中的 `Assets.car` 复制回品牌目录。
- 成功路径和失败路径都清理 `Assets.xcassets` 临时目录与 tmp 编译输出，避免残留。
- `actool` 不存在或返回非零时 graceful 回退为 `icon.icns`，`writeBrandAssets` 的返回值从 `string` 升级为 `BrandAssetsResult { macIcon, hasAssetsCar }`。
- `brandBlock()` 仅在 `hasAssetsCar === true` 时写出 `liquidGlassAssetsCar: '…'` 行，与 `qwen-code` / `openwork` 的现有写法保持一致。

## 验证方式

1. macOS 上跑 `brand-create`，末尾应看到 `Assets.car: generated (macOS 26+ Liquid Glass icon)`。
2. `resources/brands/<brand>/Assets.car` 存在，`file` 显示 Mac OS X BOM。
3. 无残留 `Assets.xcassets` 或 `/tmp/assets-car-*`。
4. `branding.ts` 中对应品牌的 `assets:` 块多出一行 `liquidGlassAssetsCar: 'resources/brands/<brand>/Assets.car'`。
5. `CRAFT_BRAND=<brand> bun run electron:dist:mac` 后，`afterPack` 应打印 `Liquid Glass icon copied:`，`.app/Contents/Resources/Assets.car` 约 600 KB，DMG `hdiutil verify` 为 VALID。
6. 在非 macOS 或 `xcrun` 不在 PATH 的环境重跑，应打印 `Warning: actool compilation failed, skipping Assets.car` 并仍然生成完整品牌目录。

已测：macOS (arm64)，Windows / Linux 通过代码路径分析确认 graceful 回退。

</details>
