### PR TITLE
fix(weixin): confirm the WEBP signature, not just the RIFF prefix

### DIFF
--- a/packages/channels/weixin/src/send.test.ts
+++ b/packages/channels/weixin/src/send.test.ts
@@ -164,9 +164,41 @@ describe('detectImageMime', () => {
     expect(detectImageMime(buf)).toBe('image/gif');
   });
 
-  it('detects WebP magic bytes (RIFF)', () => {
-    const buf = Buffer.from([0x52, 0x49, 0x46, 0x46]);
+  it('detects WebP magic bytes (RIFF....WEBP)', () => {
+    const buf = Buffer.from([
+      0x52,
+      0x49,
+      0x46,
+      0x46, // "RIFF"
+      0x1a,
+      0x00,
+      0x00,
+      0x00, // file size (little-endian)
+      0x57,
+      0x45,
+      0x42,
+      0x50, // "WEBP"
+    ]);
     expect(detectImageMime(buf)).toBe('image/webp');
+  });
+
+  it('does not misidentify a non-WebP RIFF container (e.g. WAV) as WebP', () => {
+    // WAV is also a RIFF container; only bytes 8-11 distinguish it from WebP.
+    const buf = Buffer.from([
+      0x52,
+      0x49,
+      0x46,
+      0x46, // "RIFF"
+      0x24,
+      0x00,
+      0x00,
+      0x00, // file size
+      0x57,
+      0x41,
+      0x56,
+      0x45, // "WAVE", not "WEBP"
+    ]);
+    expect(() => detectImageMime(buf)).toThrow('Unrecognized image format');
   });
 
   it('detects JPEG magic bytes', () => {

--- a/packages/channels/weixin/src/send.ts
+++ b/packages/channels/weixin/src/send.ts
@@ -80,11 +80,17 @@ export function detectImageMime(data: Buffer): string {
   if (data[0] === 0x47 && data[1] === 0x49 && data[2] === 0x46) {
     return 'image/gif';
   }
+  // WebP is a RIFF container, so the "RIFF" prefix alone is not enough — WAV and
+  // AVI share it. The bytes at offset 8-11 must spell "WEBP" to confirm the type.
   if (
     data[0] === 0x52 &&
     data[1] === 0x49 &&
     data[2] === 0x46 &&
-    data[3] === 0x46
+    data[3] === 0x46 &&
+    data[8] === 0x57 &&
+    data[9] === 0x45 &&
+    data[10] === 0x42 &&
+    data[11] === 0x50
   ) {
     return 'image/webp';
   }


### PR DESCRIPTION
## What this PR does

`detectImageMime` in the WeChat channel now confirms the `WEBP` marker at bytes 8-11 before classifying data as `image/webp`, instead of accepting any input that merely begins with the four `RIFF` bytes.

## Why it's needed

`detectImageMime` is the magic-byte check inside `validateImagePath`, which exists to confirm that an image file's real content matches its claimed extension before it is uploaded. RIFF is a generic container also used by WAV and AVI, so the `RIFF` prefix alone does not prove the data is WebP: a non-WebP RIFF file (for example a WAV renamed to `.webp`) previously returned `image/webp` and so passed the verification. This is the same incomplete-signature problem #2970 fixed for the PNG branch, and core's `imageTokenizer` already validates both `RIFF` and `WEBP`, so this brings the weixin channel in line.

## Reviewer Test Plan

### How to verify

A new unit test feeds a `RIFF....WAVE` buffer and asserts `detectImageMime` throws `Unrecognized image format`; on `main` it wrongly returns `image/webp`. The existing WebP test was updated to use a full `RIFF....WEBP` header (12 bytes) rather than the 4-byte `RIFF` prefix.

```
npx vitest run packages/channels/weixin/src/send.test.ts -t detectImageMime
```

Expected: the `detectImageMime` suite passes (6 tests); the new WAV case fails on `main` and passes with this change.

### Evidence (Before & After)

N/A — non-user-visible parsing fix covered by unit tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   ⚠️   |

Note: three failures in `validateImagePath`/`sendImage` already reproduce on an unmodified `main` on Windows (realpath/backslash mocking) and are unrelated to this change; the `detectImageMime` suite is green.

### Environment (optional)

N/A — unit tests only.

## Risk & Scope

- Main risk or tradeoff: a "WebP" file whose header is shorter than 12 bytes would no longer be detected, but the caller reads 16 bytes and every valid WebP carries the 12-byte `RIFF....WEBP` header, so rejecting shorter input is correct.
- Not validated / out of scope: only the weixin channel's `detectImageMime` is touched; other channels and image paths are unchanged.
- Breaking changes / migration notes: none.

## Linked Issues

None.
