### PR TITLE
fix(cli): drop AgentView cleanup setState that can trip React #185 (#5199)

### DIFF
--- a/packages/cli/src/ui/components/agent-view/AgentChatContent.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentChatContent.tsx
@@ -129,7 +129,10 @@ export const AgentChatContent = ({
   useEffect(() => {
     if (readonly) return;
     setAgentShellFocused(embeddedShellFocused);
-    return () => setAgentShellFocused(false);
+    // Intentionally not resetting on unmount: calling setState on a parent
+    // context provider during effect cleanup triggers React error #185
+    // ("Cannot update a component while rendering a different component")
+    // when both child and provider unmount in the same commit phase.
   }, [embeddedShellFocused, readonly, setAgentShellFocused]);
 
   useEffect(() => {

--- a/packages/cli/src/ui/hooks/useCommandMigration.ts
+++ b/packages/cli/src/ui/hooks/useCommandMigration.ts
@@ -21,26 +21,34 @@ export function useCommandMigration(
   const [tomlFiles, setTomlFiles] = useState<string[]>([]);
 
   useEffect(() => {
+    let cancelled = false;
+
     const checkTomlCommands = async () => {
       const allFiles: string[] = [];
 
       // Check workspace commands directory (.qwen/commands)
       const workspaceCommandsDir = storage.getProjectCommandsDir();
       const workspaceFiles = await detectTomlCommands(workspaceCommandsDir);
+      if (cancelled) return;
       allFiles.push(...workspaceFiles.map((f) => `workspace: ${f}`));
 
       // Check user commands directory (~/.qwen/commands)
       const userCommandsDir = Storage.getUserCommandsDir();
       const userFiles = await detectTomlCommands(userCommandsDir);
+      if (cancelled) return;
       allFiles.push(...userFiles.map((f) => `user: ${f}`));
 
-      if (allFiles.length > 0) {
+      if (!cancelled && allFiles.length > 0) {
         setTomlFiles(allFiles);
         setShowMigrationNudge(true);
       }
     };
 
     checkTomlCommands();
+
+    return () => {
+      cancelled = true;
+    };
   }, [storage]);
 
   return {

--- a/packages/cli/src/ui/hooks/useGitBranchName.ts
+++ b/packages/cli/src/ui/hooks/useGitBranchName.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { isCommandAvailable, execCommand } from '@qwen-code/qwen-code-core';
 import fs from 'node:fs';
 import fsPromises from 'node:fs/promises';
@@ -13,63 +13,65 @@ import path from 'node:path';
 export function useGitBranchName(cwd: string): string | undefined {
   const [branchName, setBranchName] = useState<string | undefined>(undefined);
 
-  const fetchBranchName = useCallback(async () => {
-    try {
-      if (!isCommandAvailable('git').available) {
-        return;
-      }
+  useEffect(() => {
+    let cancelled = false;
 
-      const { stdout } = await execCommand(
-        'git',
-        ['rev-parse', '--abbrev-ref', 'HEAD'],
-        { cwd },
-      );
-      const branch = stdout.toString().trim();
-      if (branch && branch !== 'HEAD') {
-        setBranchName(branch);
-      } else {
-        const { stdout: hashStdout } = await execCommand(
+    const fetchWithGuard = async () => {
+      try {
+        if (!isCommandAvailable('git').available) {
+          return;
+        }
+
+        const { stdout } = await execCommand(
           'git',
-          ['rev-parse', '--short', 'HEAD'],
+          ['rev-parse', '--abbrev-ref', 'HEAD'],
           { cwd },
         );
-        setBranchName(hashStdout.toString().trim());
+        if (cancelled) return;
+        const branch = stdout.toString().trim();
+        if (branch && branch !== 'HEAD') {
+          setBranchName(branch);
+        } else {
+          const { stdout: hashStdout } = await execCommand(
+            'git',
+            ['rev-parse', '--short', 'HEAD'],
+            { cwd },
+          );
+          if (!cancelled) {
+            setBranchName(hashStdout.toString().trim());
+          }
+        }
+      } catch {
+        if (!cancelled) setBranchName(undefined);
       }
-    } catch (_error) {
-      setBranchName(undefined);
-    }
-  }, [cwd, setBranchName]);
+    };
 
-  useEffect(() => {
-    fetchBranchName(); // Initial fetch
+    fetchWithGuard();
 
     const gitLogsHeadPath = path.join(cwd, '.git', 'logs', 'HEAD');
     let watcher: fs.FSWatcher | undefined;
 
     const setupWatcher = async () => {
       try {
-        // Check if .git/logs/HEAD exists, as it might not in a new repo or orphaned head
         await fsPromises.access(gitLogsHeadPath, fs.constants.F_OK);
+        if (cancelled) return;
         watcher = fs.watch(gitLogsHeadPath, (eventType: string) => {
-          // Changes to .git/logs/HEAD (appends) indicate HEAD has likely changed
           if (eventType === 'change' || eventType === 'rename') {
-            // Handle rename just in case
-            fetchBranchName();
+            if (!cancelled) fetchWithGuard();
           }
         });
       } catch (_watchError) {
-        // Silently ignore watcher errors (e.g. permissions or file not existing),
-        // similar to how exec errors are handled.
-        // The branch name will simply not update automatically.
+        // Silently ignore watcher errors
       }
     };
 
     setupWatcher();
 
     return () => {
+      cancelled = true;
       watcher?.close();
     };
-  }, [cwd, fetchBranchName]);
+  }, [cwd]);
 
   return branchName;
 }

--- a/packages/cli/src/ui/hooks/useLogger.ts
+++ b/packages/cli/src/ui/hooks/useLogger.ts
@@ -19,6 +19,8 @@ export const useLogger = (storage: Storage, sessionId: string) => {
       return;
     }
 
+    let cancelled = false;
+
     const newLogger = new Logger(sessionId, storage);
     /**
      * Start async initialization, no need to await. Using await slows down the
@@ -28,9 +30,15 @@ export const useLogger = (storage: Storage, sessionId: string) => {
     newLogger
       .initialize()
       .then(() => {
-        setLogger(newLogger);
+        if (!cancelled) {
+          setLogger(newLogger);
+        }
       })
       .catch(() => {});
+
+    return () => {
+      cancelled = true;
+    };
   }, [storage, sessionId]);
 
   return logger;

--- a/packages/cli/src/ui/hooks/useShellHistory.ts
+++ b/packages/cli/src/ui/hooks/useShellHistory.ts
@@ -83,13 +83,22 @@ export function useShellHistory(
   const [historyFilePath, setHistoryFilePath] = useState<string | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
+
     async function loadHistory() {
       const filePath = await getHistoryFilePath(projectRoot, storage);
+      if (cancelled) return;
       setHistoryFilePath(filePath);
       const loadedHistory = await readHistoryFile(filePath);
-      setHistory(loadedHistory.reverse()); // Newest first
+      if (!cancelled) {
+        setHistory(loadedHistory.reverse()); // Newest first
+      }
     }
     loadHistory();
+
+    return () => {
+      cancelled = true;
+    };
   }, [projectRoot, storage]);
 
   const addCommandToHistory = useCallback(

--- a/packages/cli/src/ui/hooks/useWorktreeSession.ts
+++ b/packages/cli/src/ui/hooks/useWorktreeSession.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import fs from 'node:fs';
 import fsPromises from 'node:fs/promises';
 import path from 'node:path';
@@ -33,20 +33,22 @@ import { readWorktreeSession } from '@qwen-code/qwen-code-core';
 export function useWorktreeSession(config: Config): WorktreeSession | null {
   const [session, setSession] = useState<WorktreeSession | null>(null);
 
-  const load = useCallback(async () => {
-    try {
-      const filePath = config
-        .getSessionService()
-        .getWorktreeSessionPath(config.getSessionId());
-      const ws = await readWorktreeSession(filePath);
-      setSession(ws);
-    } catch {
-      setSession(null);
-    }
-  }, [config]);
-
   useEffect(() => {
-    void load();
+    let cancelled = false;
+
+    const safeLoad = async () => {
+      try {
+        const filePath = config
+          .getSessionService()
+          .getWorktreeSessionPath(config.getSessionId());
+        const ws = await readWorktreeSession(filePath);
+        if (!cancelled) setSession(ws);
+      } catch {
+        if (!cancelled) setSession(null);
+      }
+    };
+
+    void safeLoad();
 
     const filePath = config
       .getSessionService()
@@ -55,35 +57,18 @@ export function useWorktreeSession(config: Config): WorktreeSession | null {
     const fileName = path.basename(filePath);
 
     let watcher: fs.FSWatcher | undefined;
-    let cancelled = false;
 
     const setupWatcher = async () => {
       try {
-        // Ensure the chats directory exists so fs.watch doesn't ENOENT
-        // when no session has ever been written for this project. The
-        // recursive mkdir is idempotent.
         await fsPromises.mkdir(dirPath, { recursive: true });
         if (cancelled) return;
-        // Watch the parent dir so create/delete/rename events on the
-        // sidecar (which may not exist at mount time) are caught.
-        //
-        // `filename` may come back as a Buffer on Linux when no
-        // encoding is configured at the libuv layer, so the previous
-        // `filename === fileName` (string) comparison silently never
-        // matched and the watcher fired but never reloaded. Normalize
-        // via toString() to cover both shapes. `filename` is also
-        // nullable on some platforms (e.g. recursive watchers without
-        // event payloads) — treat null as "unknown file, reload to be
-        // safe" since the worktree state is small and the load is cheap.
         watcher = fs.watch(dirPath, (_eventType, filename) => {
           if (filename === null || filename.toString() === fileName) {
-            void load();
+            void safeLoad();
           }
         });
       } catch {
-        // Watcher setup is best-effort: the hook still returns whatever
-        // load() resolved with on mount. Without a watcher, the UI just
-        // doesn't react to sidecar changes until the next re-mount.
+        // Watcher setup is best-effort
       }
     };
 
@@ -93,7 +78,7 @@ export function useWorktreeSession(config: Config): WorktreeSession | null {
       cancelled = true;
       watcher?.close();
     };
-  }, [config, load]);
+  }, [config]);
 
   return session;
 }


### PR DESCRIPTION
> Carried forward from #5242 by @aspnmy (authorship preserved on the commit). That PR bundled this UI fix with the loop circuit breaker (now #5279) and a community Chinese README. The README is intentionally left out per the author's note; this PR is just the React-error fix.

## What this PR does

Removes an effect-cleanup `setState` in `AgentChatContent` that reset the `AgentView` context provider's `agentShellFocused` on unmount (`return () => setAgentShellFocused(false)`), and hardens five async UI hooks (`useShellHistory`, `useLogger`, `useCommandMigration`, `useGitBranchName`, `useWorktreeSession`) so their post-`await` `setState` calls are skipped after the component unmounts, via a `cancelled` flag set in each effect's cleanup.

## Why it's needed

A user hit a minified **React #185** crash (#5199). In React 19 that error decodes to *"Maximum update depth exceeded… React limits the number of nested updates to prevent infinite loops."* — i.e. an update loop, **not** a setState-after-unmount warning (React 19 no longer emits that one). The most plausible trigger here is the `AgentChatContent` cleanup `setState`: when the child and the `AgentView` provider unmount in the same commit, resetting provider state from the child's cleanup re-enters the provider and can feed the nested-update loop. `agentShellFocused` is already re-established when `AgentChatContent` mounts, so the cleanup reset is redundant and is dropped. The five hook guards are defensive hardening in the same spirit (React 19 tolerates the unguarded case silently, but the guards prevent stale updates and wasted renders).

## Reviewer Test Plan

### How to verify

```
# CLI typecheck (the 6 touched files are clean; repo has unrelated pre-existing errors)
cd packages/cli && npx tsc --noEmit

# Existing hook suites for the touched hooks
cd packages/cli && npx vitest run \
  src/ui/hooks/useShellHistory.test.ts \
  src/ui/hooks/useGitBranchName.test.ts \
  src/ui/hooks/useWorktreeSession.test.tsx
# → Test Files 3 passed; Tests 16 passed | 2 skipped
```

A reviewer should confirm: (1) the touched files typecheck and the three hook suites pass with no regressions; (2) the `AgentChatContent` change only removes the cleanup reset and `agentShellFocused` is still set correctly on mount; (3) the hook guards only gate `setState` behind `!cancelled` and don't change the resolved values.

### Evidence (Before & After)

N/A — the failure is a non-deterministic minified runtime error. **The crash was not reproduced in this PR's CI**; verification here is correctness review + typecheck + the existing hook suites. The original reporter (@aspnmy) found these changes resolved the crash on their setup (Windows). See Risk.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS: local `tsc --noEmit` + the three hook suites. Windows was the original repro environment but isn't re-tested here. CI builds/tests all three.

## Risk & Scope

- Main risk or tradeoff: `AgentChatContent` no longer resets `agentShellFocused` to `false` on unmount. Assessed low-risk — the only readers (`AgentTabBar`, `AgentComposer`) are co-located under the same provider and unmount with it, and `AgentChatContent` re-sets the value from `embeddedShellFocused` on every mount, so any stale `true` is transient and self-correcting. Worth a sanity check from someone who knows the agent-view focus lifecycle.
- Not validated / out of scope: the minified #185 itself was not reproduced in CI (non-deterministic). The fix targets the most plausible trigger and is backed by correctness review.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #5199 — leaving it open (rather than `Closes`) until a maintainer confirms the crash is gone on the reporter's setup, since it wasn't reproduced here.

<details>
<summary>中文说明</summary>

> 从 #5242 拆分而来，原作者 @aspnmy（commit 保留其署名）。那个 PR 把这个 UI 修复和循环断路器（现 #5279）以及社区中文 README 打包在一起。中文 README 按作者意见不包含；本 PR 只含 React 报错修复。

## 这个 PR 做了什么

移除 `AgentChatContent` 里一个 effect cleanup 的 `setState`——它在卸载时把 `AgentView` context provider 的 `agentShellFocused` 重置（`return () => setAgentShellFocused(false)`）；并为五个异步 UI hook（`useShellHistory`、`useLogger`、`useCommandMigration`、`useGitBranchName`、`useWorktreeSession`）加上 `cancelled` 标志（在各自 effect 的 cleanup 里置位），使组件卸载后 `await` 之后的 `setState` 被跳过。

## 为什么需要

有用户碰到 minified **React #185** 崩溃（#5199）。在 React 19 里该错误解码为*"Maximum update depth exceeded…（嵌套更新过多，React 为防止死循环而限制）"*——即更新死循环，**不是** setState-after-unmount 警告（React 19 已不再发那个警告）。这里最可能的触发点是 `AgentChatContent` 的 cleanup `setState`：当子组件与 `AgentView` provider 在同一次 commit 卸载时，从子组件 cleanup 里重置 provider 状态会再次进入 provider，可能喂给嵌套更新循环。`agentShellFocused` 在 `AgentChatContent` 挂载时已经会被重新设置，所以这个 cleanup 重置是多余的，予以移除。五个 hook 的防护是同一思路下的防御性加固（React 19 会静默容忍未防护的情况，但防护可避免陈旧更新和无谓渲染）。

## 审查测试计划

### 如何验证

```
# CLI 类型检查（改动的 6 个文件干净；仓库存在与本改动无关的既有错误）
cd packages/cli && npx tsc --noEmit

# 受影响 hook 的既有测试
cd packages/cli && npx vitest run \
  src/ui/hooks/useShellHistory.test.ts \
  src/ui/hooks/useGitBranchName.test.ts \
  src/ui/hooks/useWorktreeSession.test.tsx
# → 3 个文件通过；16 通过 | 2 跳过
```

审查者应确认：(1) 改动文件类型检查通过、三个 hook 套件无回归；(2) `AgentChatContent` 仅移除了 cleanup 重置，挂载时 `agentShellFocused` 仍被正确设置；(3) hook 防护只是把 `setState` 放到 `!cancelled` 之后，不改变解析出的值。

### 证据（Before & After）

N/A——该故障是非确定性的 minified 运行时错误。**本 PR 的 CI 未复现该崩溃**；这里的验证是代码审查 + 类型检查 + 既有 hook 套件。原报告者（@aspnmy）在其环境（Windows）上确认这些改动解决了崩溃。见风险一节。

### 测试平台

|    系统    | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

macOS：本地 `tsc --noEmit` + 三个 hook 套件。Windows 是原始复现环境，但这里未重新测试。CI 覆盖三平台的构建/测试。

## 风险与范围

- 主要风险或取舍：`AgentChatContent` 不再在卸载时把 `agentShellFocused` 重置为 `false`。评估为低风险——唯一的读取方（`AgentTabBar`、`AgentComposer`）都在同一 provider 下、与其一起卸载，且 `AgentChatContent` 每次挂载都会用 `embeddedShellFocused` 重新设置该值，所以任何陈旧的 `true` 都是瞬态且会自我纠正。建议熟悉 agent-view 焦点生命周期的人复核一下。
- 未验证 / 范围之外：minified #185 本身未在 CI 复现（非确定性）。修复针对最可能的触发点，并有代码审查支撑。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Refs #5199 —— 暂不用 `Closes`，保留开启，直到维护者在报告者环境确认崩溃消失，因为这里未能复现。

</details>
