### PR TITLE
fix(cli): render a sub-minute duration that rounds to 60s as "1m"

### DIFF
--- a/packages/cli/src/ui/utils/formatters.test.ts
+++ b/packages/cli/src/ui/utils/formatters.test.ts
@@ -155,6 +155,16 @@ describe('formatters', () => {
       expect(formatDuration(-100)).toBe('0s');
     });
 
+    it('should roll a sub-minute value up to "1m" when it rounds to 60s', () => {
+      // 59.95s and up round to "60.0" at one decimal, which is not a valid
+      // sub-minute reading; it should render as the minute it rounds to,
+      // matching formatDuration(60000) === '1m'.
+      expect(formatDuration(59949)).toBe('59.9s');
+      expect(formatDuration(59950)).toBe('1m');
+      expect(formatDuration(59999)).toBe('1m');
+      expect(formatDuration(59950, { hideTrailingZeros: true })).toBe('1m');
+    });
+
     describe('with hideTrailingZeros', () => {
       it('drops .0 suffix for whole seconds under a minute', () => {
         expect(formatDuration(5000, { hideTrailingZeros: true })).toBe('5s');

--- a/packages/cli/src/ui/utils/formatters.ts
+++ b/packages/cli/src/ui/utils/formatters.ts
@@ -90,6 +90,12 @@ export const formatDuration = (
 
   if (totalSeconds < 60) {
     const formatted = totalSeconds.toFixed(1);
+    // toFixed can round up across the minute boundary (e.g. 59.95s -> "60.0"),
+    // which is not a valid sub-minute reading. Render it as the minute it
+    // rounds to, matching formatDuration(60000) === '1m'.
+    if (parseFloat(formatted) >= 60) {
+      return '1m';
+    }
     if (options?.hideTrailingZeros && formatted.endsWith('.0')) {
       return `${formatted.slice(0, -2)}s`;
     }


### PR DESCRIPTION
## What this PR does

`formatDuration` renders a duration under a minute with one decimal second (e.g. `12.3s`). When the value is at least 59.95s, `toFixed(1)` rounds it up to `"60.0"`, so the function printed `60.0s` (or `60s` with `hideTrailingZeros`). This change detects that the rounded value reached 60 and renders it as `1m` instead, matching `formatDuration(60000) === "1m"`.

## Why it's needed

`60.0s` is not a valid sub-minute reading — once the displayed value rounds to a full minute it should roll over into the minute format, the same way `formatDuration(60000)` already returns `1m`. It is a small but visible inconsistency in the elapsed-time indicators that use this helper.

## Reviewer Test Plan

### How to verify

```
npx vitest run packages/cli/src/ui/utils/formatters.test.ts -t formatDuration
```

A new case asserts `formatDuration(59950) === "1m"`, `formatDuration(59999) === "1m"`, the `hideTrailingZeros` variant, and that `formatDuration(59949)` still returns `59.9s`. The 60s case fails on `main` (returns `60.0s`) and passes with this change; the existing 32 cases are unchanged.

### Evidence (Before & After)

N/A — a formatting helper covered by unit tests. Before: `formatDuration(59950) === "60.0s"`. After: `"1m"`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

N/A — unit tests only.

## Risk & Scope

- Main risk or tradeoff: only the sub-minute branch of `formatDuration` changes; the 59.95–59.999s window now reads `1m`. No other input range is affected.
- Not validated / out of scope: callers of `formatDuration` are untouched.
- Breaking changes / migration notes: none.

## Linked Issues

None.
