### PR TITLE
feat(extensions): add i18n support for extension displayName and description

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -140,32 +140,6 @@
       "env": {
         "GEMINI_SANDBOX": "false"
       }
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Dev Extensions List (zh)",
-      "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev", "--", "extensions", "list"],
-      "skipFiles": ["<node_internals>/**"],
-      "cwd": "${workspaceFolder}",
-      "console": "integratedTerminal",
-      "env": {
-        "QWEN_CODE_LANG": "zh"
-      }
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Dev Extensions List (en)",
-      "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev", "--", "extensions", "list"],
-      "skipFiles": ["<node_internals>/**"],
-      "cwd": "${workspaceFolder}",
-      "console": "integratedTerminal",
-      "env": {
-        "QWEN_CODE_LANG": "en"
-      }
     }
   ],
   "inputs": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -140,6 +140,32 @@
       "env": {
         "GEMINI_SANDBOX": "false"
       }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Dev Extensions List (zh)",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev", "--", "extensions", "list"],
+      "skipFiles": ["<node_internals>/**"],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "env": {
+        "QWEN_CODE_LANG": "zh"
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Dev Extensions List (en)",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev", "--", "extensions", "list"],
+      "skipFiles": ["<node_internals>/**"],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "env": {
+        "QWEN_CODE_LANG": "en"
+      }
     }
   ],
   "inputs": [

--- a/packages/acp-bridge/src/status.ts
+++ b/packages/acp-bridge/src/status.ts
@@ -876,6 +876,7 @@ export interface ServeExtensionEntry {
   kind: 'extension';
   id: string;
   name: string;
+  displayName?: string;
   version: string;
   isActive: boolean;
   path: string;

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -3026,6 +3026,7 @@ class QwenAgent implements Agent {
       const extensionManager = new ExtensionManager({
         workspaceDir: cwd,
         isWorkspaceTrusted: settings.isTrusted,
+        locale: getCurrentLanguage(),
       });
       await extensionManager.refreshCache();
       extensions = extensionManager.getLoadedExtensions();
@@ -3052,6 +3053,7 @@ class QwenAgent implements Agent {
         return {
           id: extension.id,
           name: extension.name,
+          displayName: extension.displayName,
           version: extension.version,
           isActive: extension.isActive,
           path: extension.path,
@@ -3097,11 +3099,18 @@ class QwenAgent implements Agent {
         'extension',
       ).map((entry) => ({
         ...entry,
-        server: { ...entry.server, extensionName: extension.name },
+        server: {
+          ...entry.server,
+          extensionName: extension.displayName ?? extension.name,
+        },
       })),
     );
     const extensionHooks = activeExtensions.flatMap((extension) =>
-      readHooks({ hooks: extension.hooks ?? {} }, 'extension', extension.name),
+      readHooks(
+        { hooks: extension.hooks ?? {} },
+        'extension',
+        extension.displayName ?? extension.name,
+      ),
     );
 
     // Build the merged MCP/hook lists from the user and workspace settings
@@ -4513,6 +4522,7 @@ class QwenAgent implements Agent {
             kind: 'extension',
             id: ext.id,
             name: ext.name,
+            displayName: ext.displayName,
             version: ext.version,
             isActive: ext.isActive,
             path: ext.path,
@@ -6512,6 +6522,7 @@ class QwenAgent implements Agent {
         const extensionManager = new ExtensionManager({
           workspaceDir: cwd,
           isWorkspaceTrusted: !!isWorkspaceTrusted(settings.merged),
+          locale: getCurrentLanguage(),
         });
         await extensionManager.refreshCache();
         const extension = extensionManager

--- a/packages/cli/src/commands/extensions/consent.ts
+++ b/packages/cli/src/commands/extensions/consent.ts
@@ -162,8 +162,9 @@ export function extensionConsentString(
     );
   }
   const mcpServerEntries = Object.entries(extensionConfig.mcpServers || {});
+  const displayLabel = extensionConfig.displayName ?? extensionConfig.name;
   output.push(
-    t('Installing extension "{{name}}".', { name: extensionConfig.name }),
+    t('Installing extension "{{name}}".', { name: displayLabel }),
   );
   if (
     typeof extensionConfig.description === 'string' &&

--- a/packages/cli/src/commands/extensions/examples/mcp-server/qwen-extension.json
+++ b/packages/cli/src/commands/extensions/examples/mcp-server/qwen-extension.json
@@ -1,6 +1,13 @@
 {
   "name": "mcp-server-example",
-  "description": "Example extension that provides an MCP server",
+  "displayName": {
+    "en": "MCP Server Example",
+    "zh": "MCP 服务器示例"
+  },
+  "description": {
+    "en": "Example extension that provides an MCP server",
+    "zh": "提供 MCP 服务器的示例扩展"
+  },
   "version": "1.0.0",
   "mcpServers": {
     "nodeServer": {

--- a/packages/cli/src/commands/extensions/install.ts
+++ b/packages/cli/src/commands/extensions/install.ts
@@ -19,7 +19,7 @@ import {
   requestConsentNonInteractive,
   requestChoicePluginNonInteractive,
 } from './consent.js';
-import { t } from '../../i18n/index.js';
+import { t, getCurrentLanguage } from '../../i18n/index.js';
 
 interface InstallArgs {
   source: string;
@@ -70,6 +70,7 @@ export async function handleInstall(args: InstallArgs) {
     const workspaceDir = process.cwd();
     const extensionManager = new ExtensionManager({
       workspaceDir,
+      locale: getCurrentLanguage(),
       isWorkspaceTrusted: !!isWorkspaceTrusted(
         loadSettings(workspaceDir).merged,
       ),

--- a/packages/cli/src/commands/extensions/list.ts
+++ b/packages/cli/src/commands/extensions/list.ts
@@ -8,10 +8,18 @@ import type { CommandModule } from 'yargs';
 import { getErrorMessage } from '../../utils/errors.js';
 import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
 import { extensionToOutputString, getExtensionManager } from './utils.js';
-import { t } from '../../i18n/index.js';
+import { t, initializeI18n } from '../../i18n/index.js';
+import { loadSettings } from '../../config/settings.js';
+import type { SupportedLanguage } from '../../i18n/index.js';
 
 export async function handleList() {
   try {
+    const settings = loadSettings();
+    const langSetting =
+      process.env['QWEN_CODE_LANG'] ||
+      (settings.merged.general?.language as string) ||
+      'auto';
+    await initializeI18n(langSetting as SupportedLanguage | 'auto');
     const extensionManager = await getExtensionManager();
     const extensions = extensionManager.getLoadedExtensions();
 

--- a/packages/cli/src/commands/extensions/list.ts
+++ b/packages/cli/src/commands/extensions/list.ts
@@ -8,18 +8,19 @@ import type { CommandModule } from 'yargs';
 import { getErrorMessage } from '../../utils/errors.js';
 import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
 import { extensionToOutputString, getExtensionManager } from './utils.js';
-import { t, initializeI18n } from '../../i18n/index.js';
+import {
+  t,
+  initializeI18n,
+  resolveLanguageSetting,
+} from '../../i18n/index.js';
 import { loadSettings } from '../../config/settings.js';
-import type { SupportedLanguage } from '../../i18n/index.js';
 
 export async function handleList() {
   try {
     const settings = loadSettings();
-    const langSetting =
-      process.env['QWEN_CODE_LANG'] ||
-      (settings.merged.general?.language as string) ||
-      'auto';
-    await initializeI18n(langSetting as SupportedLanguage | 'auto');
+    await initializeI18n(
+      resolveLanguageSetting(settings.merged.general?.language as string),
+    );
     const extensionManager = await getExtensionManager();
     const extensions = extensionManager.getLoadedExtensions();
 

--- a/packages/cli/src/commands/extensions/uninstall.ts
+++ b/packages/cli/src/commands/extensions/uninstall.ts
@@ -14,7 +14,7 @@ import {
 } from './consent.js';
 import { isWorkspaceTrusted } from '../../config/trustedFolders.js';
 import { loadSettings } from '../../config/settings.js';
-import { t } from '../../i18n/index.js';
+import { t, getCurrentLanguage } from '../../i18n/index.js';
 
 interface UninstallArgs {
   name: string; // can be extension name or source URL.
@@ -25,6 +25,7 @@ export async function handleUninstall(args: UninstallArgs) {
     const workspaceDir = process.cwd();
     const extensionManager = new ExtensionManager({
       workspaceDir,
+      locale: getCurrentLanguage(),
       requestConsent: requestConsentOrFail.bind(
         null,
         requestConsentNonInteractive,

--- a/packages/cli/src/commands/extensions/utils.ts
+++ b/packages/cli/src/commands/extensions/utils.ts
@@ -7,6 +7,8 @@
 import {
   ExtensionManager,
   redactUrlCredentials,
+  getExtensionDisplayName,
+  getExtensionDescription,
   type Extension,
 } from '@qwen-code/qwen-code-core';
 import { loadSettings } from '../../config/settings.js';
@@ -19,12 +21,13 @@ import { isWorkspaceTrusted } from '../../config/trustedFolders.js';
 import * as os from 'node:os';
 import chalk from 'chalk';
 import stripAnsi from 'strip-ansi';
-import { t } from '../../i18n/index.js';
+import { t, getCurrentLanguage } from '../../i18n/index.js';
 
 export async function getExtensionManager(): Promise<ExtensionManager> {
   const workspaceDir = process.cwd();
   const extensionManager = new ExtensionManager({
     workspaceDir,
+    locale: getCurrentLanguage(),
     requestConsent: requestConsentOrFail.bind(
       null,
       requestConsentNonInteractive,
@@ -53,12 +56,12 @@ export function extensionToOutputString(
   );
 
   const status = workspaceEnabled ? chalk.green('✓') : chalk.red('✗');
-  let output = `${inline ? '' : status} ${extension.config.name} (${extension.config.version})`;
-  if (
-    typeof extension.config.description === 'string' &&
-    extension.config.description
-  ) {
-    output += `\n ${t('Description:')} ${stripAnsi(extension.config.description)}`;
+  const locale = getCurrentLanguage();
+  const displayLabel = getExtensionDisplayName(extension, locale);
+  let output = `${inline ? '' : status} ${displayLabel} (${extension.config.version})`;
+  const desc = getExtensionDescription(extension, locale);
+  if (desc) {
+    output += `\n ${t('Description:')} ${stripAnsi(desc)}`;
   }
   output += `\n ${t('Path:')} ${extension.path}`;
   if (extension.installMetadata) {

--- a/packages/cli/src/commands/mcp/list.ts
+++ b/packages/cli/src/commands/mcp/list.ts
@@ -19,6 +19,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { isWorkspaceTrusted } from '../../config/trustedFolders.js';
 import { assembleMcpServers } from '../../config/mcpServers.js';
 import { loadMcpApprovals } from '../../config/mcpApprovals.js';
+import { getCurrentLanguage } from '../../i18n/index.js';
 
 const COLOR_GREEN = '\u001b[32m';
 const COLOR_YELLOW = '\u001b[33m';
@@ -32,6 +33,7 @@ async function getMcpServersFromConfig(): Promise<
   const extensionManager = new ExtensionManager({
     isWorkspaceTrusted: !!isWorkspaceTrusted(settings.merged),
     telemetrySettings: settings.merged.telemetry,
+    locale: getCurrentLanguage(),
   });
   await extensionManager.refreshCache();
   const extensions = extensionManager.getLoadedExtensions();

--- a/packages/cli/src/commands/mcp/reconnect.ts
+++ b/packages/cli/src/commands/mcp/reconnect.ts
@@ -16,6 +16,7 @@ import { isWorkspaceTrusted } from '../../config/trustedFolders.js';
 import type { MCPServerConfig } from '@qwen-code/qwen-code-core';
 import { getPendingGatedMcpServers } from '../../config/mcpApprovals.js';
 import { assembleMcpServers } from '../../config/mcpServers.js';
+import { getCurrentLanguage } from '../../i18n/index.js';
 
 async function getMcpServersFromConfig(
   extensionManager?: ExtensionManager,
@@ -26,6 +27,7 @@ async function getMcpServersFromConfig(
     new ExtensionManager({
       isWorkspaceTrusted: !!isWorkspaceTrusted(settings.merged),
       telemetrySettings: settings.merged.telemetry,
+      locale: getCurrentLanguage(),
     });
 
   if (!extensionManager) {
@@ -119,6 +121,7 @@ async function reconnectAllMcpServers(): Promise<void> {
   const extensionManager = new ExtensionManager({
     isWorkspaceTrusted: !!isWorkspaceTrusted(settings.merged),
     telemetrySettings: settings.merged.telemetry,
+    locale: getCurrentLanguage(),
   });
   await extensionManager.refreshCache();
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -85,8 +85,17 @@ import {
   validateMaxToolCalls,
   validateMaxWallTimeSetting,
 } from '../utils/runBudget.js';
+import { detectSystemLanguage } from '../i18n/index.js';
 
 const debugLogger = createDebugLogger('CONFIG');
+
+function resolveLocaleForExtensions(settings: Settings): string {
+  const envLang = process.env['QWEN_CODE_LANG'];
+  if (envLang) return envLang;
+  const settingsLang = settings.general?.language as string | undefined;
+  if (settingsLang && settingsLang !== 'auto') return settingsLang;
+  return detectSystemLanguage();
+}
 
 const VALID_APPROVAL_MODE_VALUES = [
   'plan',
@@ -1908,6 +1917,7 @@ export async function loadCliConfig(
       settings.tools?.computerUse?.maxImageDimension,
     emitToolUseSummaries: settings.experimental?.emitToolUseSummaries ?? true,
     listExtensions: argv.listExtensions || false,
+    locale: resolveLocaleForExtensions(settings),
     overrideExtensions: overrideExtensions || argv.extensions,
     noBrowser: !!process.env['NO_BROWSER'],
     authType: selectedAuthType,

--- a/packages/cli/src/core/initializer.test.ts
+++ b/packages/cli/src/core/initializer.test.ts
@@ -21,6 +21,8 @@ vi.mock('./theme.js', () => ({
 
 vi.mock('../i18n/index.js', () => ({
   initializeI18n: (...args: unknown[]) => mockInitializeI18n(...args),
+  resolveLanguageSetting: (settingsLang?: string) =>
+    process.env['QWEN_CODE_LANG'] || settingsLang || 'auto',
 }));
 
 const mockConnect = vi.fn();

--- a/packages/cli/src/core/initializer.ts
+++ b/packages/cli/src/core/initializer.ts
@@ -14,7 +14,10 @@ import {
 import { type LoadedSettings } from '../config/settings.js';
 import { performInitialAuth } from './auth.js';
 import { validateTheme } from './theme.js';
-import { initializeI18n, type SupportedLanguage } from '../i18n/index.js';
+import {
+  initializeI18n,
+  resolveLanguageSetting,
+} from '../i18n/index.js';
 
 export interface InitializationResult {
   authError: string | null;
@@ -35,11 +38,9 @@ export async function initializeApp(
   settings: LoadedSettings,
 ): Promise<InitializationResult> {
   // Initialize i18n system
-  const languageSetting =
-    process.env['QWEN_CODE_LANG'] ||
-    (settings.merged.general?.language as string) ||
-    'auto';
-  await initializeI18n(languageSetting as SupportedLanguage | 'auto');
+  await initializeI18n(
+    resolveLanguageSetting(settings.merged.general?.language as string),
+  );
 
   // Use authType from modelsConfig which respects CLI --auth-type argument
   // over settings.security.auth.selectedType

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -47,7 +47,10 @@ import {
   type InitializationResult,
 } from './core/initializer.js';
 import { handleList as handleListExtensions } from './commands/extensions/list.js';
-import { initializeI18n, type SupportedLanguage } from './i18n/index.js';
+import {
+  initializeI18n,
+  resolveLanguageSetting,
+} from './i18n/index.js';
 import { runNonInteractive } from './nonInteractiveCli.js';
 import {
   setupStartupWorktree,
@@ -475,11 +478,9 @@ export async function main() {
   }
 
   if (argv.listExtensions) {
-    const langSetting =
-      process.env['QWEN_CODE_LANG'] ||
-      (settings.merged.general?.language as string) ||
-      'auto';
-    await initializeI18n(langSetting as SupportedLanguage | 'auto');
+    await initializeI18n(
+      resolveLanguageSetting(settings.merged.general?.language as string),
+    );
     await handleListExtensions();
     process.exit(0);
   }

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -47,6 +47,7 @@ import {
   type InitializationResult,
 } from './core/initializer.js';
 import { handleList as handleListExtensions } from './commands/extensions/list.js';
+import { initializeI18n, type SupportedLanguage } from './i18n/index.js';
 import { runNonInteractive } from './nonInteractiveCli.js';
 import {
   setupStartupWorktree,
@@ -474,6 +475,11 @@ export async function main() {
   }
 
   if (argv.listExtensions) {
+    const langSetting =
+      process.env['QWEN_CODE_LANG'] ||
+      (settings.merged.general?.language as string) ||
+      'auto';
+    await initializeI18n(langSetting as SupportedLanguage | 'auto');
     await handleListExtensions();
     process.exit(0);
   }

--- a/packages/cli/src/i18n/index.ts
+++ b/packages/cli/src/i18n/index.ts
@@ -303,3 +303,15 @@ export async function initializeI18n(
 ): Promise<void> {
   await setLanguageAsync(lang ?? 'auto');
 }
+
+/**
+ * Resolves the language setting from env / settings / auto-detect.
+ * Shared by initializer.ts and extension commands that run before full init.
+ */
+export function resolveLanguageSetting(
+  settingsLanguage?: string,
+): SupportedLanguage | 'auto' {
+  return (
+    process.env['QWEN_CODE_LANG'] || settingsLanguage || 'auto'
+  ) as SupportedLanguage | 'auto';
+}

--- a/packages/cli/src/services/FileCommandLoader.ts
+++ b/packages/cli/src/services/FileCommandLoader.ts
@@ -182,7 +182,7 @@ export class FileCommandLoader implements ICommandLoader {
         for (const cmdPath of commandsPaths) {
           dirs.push({
             path: cmdPath,
-            extensionName: ext.name,
+            extensionName: ext.displayName ?? ext.name,
           });
         }
       }

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -11,13 +11,14 @@ import {
   type SlashCommand,
   CommandKind,
 } from './types.js';
-import { t } from '../../i18n/index.js';
+import { t, getCurrentLanguage } from '../../i18n/index.js';
 import {
   ExtensionManager,
   openBrowserSecurely,
   parseInstallSource,
   createDebugLogger,
   redactUrlCredentials,
+  getExtensionDisplayName,
 } from '@qwen-code/qwen-code-core';
 
 const debugLogger = createDebugLogger('EXTENSIONS_COMMAND');
@@ -169,7 +170,8 @@ async function listTextAction(context: CommandContext, _args: string) {
       );
     }
     const capsStr = caps.length > 0 ? ` [${caps.join(', ')}]` : '';
-    output += `- [${status}] **${ext.name}** v${ext.version}${source}${capsStr}\n`;
+    const displayLabel = getExtensionDisplayName(ext, getCurrentLanguage());
+    output += `- [${status}] **${displayLabel}** v${ext.version}${source}${capsStr}\n`;
   }
 
   return {

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -19,6 +19,7 @@ import {
   createDebugLogger,
   redactUrlCredentials,
   getExtensionDisplayName,
+  getExtensionDescription,
 } from '@qwen-code/qwen-code-core';
 
 const debugLogger = createDebugLogger('EXTENSIONS_COMMAND');
@@ -151,11 +152,12 @@ async function listTextAction(context: CommandContext, _args: string) {
       active: String(active.length),
     }) + '\n\n';
 
+  const locale = getCurrentLanguage();
   for (const ext of extensions) {
     const status = ext.isActive ? '✓' : '✗';
-    const source = ext.installMetadata?.source
-      ? ` (${redactUrlCredentials(ext.installMetadata.source)})`
-      : '';
+    const displayLabel = getExtensionDisplayName(ext, locale);
+    const description = getExtensionDescription(ext, locale);
+
     const caps: string[] = [];
     const mcpCount = ext.mcpServers ? Object.keys(ext.mcpServers).length : 0;
     if (mcpCount > 0) {
@@ -170,8 +172,15 @@ async function listTextAction(context: CommandContext, _args: string) {
       );
     }
     const capsStr = caps.length > 0 ? ` [${caps.join(', ')}]` : '';
-    const displayLabel = getExtensionDisplayName(ext, getCurrentLanguage());
-    output += `- [${status}] **${displayLabel}** v${ext.version}${source}${capsStr}\n`;
+    output += `- [${status}] **${displayLabel}**${capsStr}\n`;
+    if (description) {
+      const maxLen = 80;
+      const truncated =
+        description.length > maxLen
+          ? description.slice(0, maxLen - 1) + '…'
+          : description;
+      output += `  ${truncated}\n`;
+    }
   }
 
   return {

--- a/packages/cli/src/ui/components/extensions/ExtensionsManagerDialog.tsx
+++ b/packages/cli/src/ui/components/extensions/ExtensionsManagerDialog.tsx
@@ -17,9 +17,13 @@ import { MANAGEMENT_STEPS, type ExtensionAction } from './types.js';
 import { theme } from '../../semantic-colors.js';
 import { useKeypress } from '../../hooks/useKeypress.js';
 import { useUIState } from '../../contexts/UIStateContext.js';
-import { t } from '../../../i18n/index.js';
+import { t, getCurrentLanguage } from '../../../i18n/index.js';
 import type { Extension, Config } from '@qwen-code/qwen-code-core';
-import { SettingScope, createDebugLogger } from '@qwen-code/qwen-code-core';
+import {
+  SettingScope,
+  createDebugLogger,
+  getExtensionDisplayName,
+} from '@qwen-code/qwen-code-core';
 import { ExtensionUpdateState } from '../../state/extensions.js';
 import { getErrorMessage } from '../../../utils/errors.js';
 import { useTerminalSize } from '../../hooks/useTerminalSize.js';
@@ -155,7 +159,7 @@ export function ExtensionsManagerDialog({
       // Show success message
       setSuccessMessage(
         t('Extension "{{name}}" updated successfully.', {
-          name: selectedExtension.name,
+          name: getExtensionDisplayName(selectedExtension, getCurrentLanguage()),
         }),
       );
 
@@ -242,7 +246,7 @@ export function ExtensionsManagerDialog({
         const actionKey = newState ? 'enabled' : 'disabled';
         setSuccessMessage(
           t(`Extension "{{name}}" ${actionKey} successfully.`, {
-            name: selectedExtension.name,
+            name: getExtensionDisplayName(selectedExtension, getCurrentLanguage()),
           }),
         );
         setErrorMessage(null);
@@ -257,7 +261,7 @@ export function ExtensionsManagerDialog({
         setErrorMessage(
           t('Failed to {{action}} extension "{{name}}": {{error}}', {
             action: newState ? 'enable' : 'disable',
-            name: selectedExtension.name,
+            name: getExtensionDisplayName(selectedExtension, getCurrentLanguage()),
             error: getErrorMessage(error),
           }),
         );
@@ -336,7 +340,7 @@ export function ExtensionsManagerDialog({
         case MANAGEMENT_STEPS.EXTENSION_LIST:
           return t('Manage Extensions');
         case MANAGEMENT_STEPS.ACTION_SELECTION:
-          return selectedExtension?.name || t('Choose Action');
+          return selectedExtension ? getExtensionDisplayName(selectedExtension, getCurrentLanguage()) : t('Choose Action');
         case MANAGEMENT_STEPS.EXTENSION_DETAIL:
           return t('Extension Details');
         case MANAGEMENT_STEPS.DISABLE_SCOPE_SELECT:
@@ -473,7 +477,7 @@ export function ExtensionsManagerDialog({
             <Text>
               {updateInProgress
                 ? t('Updating {{name}}...', {
-                    name: selectedExtension?.name || '',
+                    name: selectedExtension ? getExtensionDisplayName(selectedExtension, getCurrentLanguage()) : '',
                   })
                 : t('Update complete!')}
             </Text>

--- a/packages/cli/src/ui/components/extensions/steps/ExtensionDetailStep.tsx
+++ b/packages/cli/src/ui/components/extensions/steps/ExtensionDetailStep.tsx
@@ -9,6 +9,7 @@ import { theme } from '../../../semantic-colors.js';
 import {
   redactUrlCredentials,
   getExtensionDisplayName,
+  getExtensionDescription,
   type Extension,
 } from '@qwen-code/qwen-code-core';
 import { t, getCurrentLanguage } from '../../../../i18n/index.js';
@@ -33,6 +34,9 @@ export const ExtensionDetailStep = ({
   const activeColor = isActive ? theme.status.success : theme.text.secondary;
   const activeString = isActive ? t('active') : t('disabled');
 
+  const locale = getCurrentLanguage();
+  const description = getExtensionDescription(ext, locale);
+
   // Fixed width for labels to ensure alignment
   const LABEL_WIDTH = 12;
 
@@ -43,8 +47,17 @@ export const ExtensionDetailStep = ({
           <Box width={LABEL_WIDTH} flexShrink={0}>
             <Text color={theme.text.primary}>{t('Name:')}</Text>
           </Box>
-          <Text>{getExtensionDisplayName(ext, getCurrentLanguage())}</Text>
+          <Text>{getExtensionDisplayName(ext, locale)}</Text>
         </Box>
+
+        {description && (
+          <Box>
+            <Box width={LABEL_WIDTH} flexShrink={0}>
+              <Text color={theme.text.primary}>{t('Description:')}</Text>
+            </Box>
+            <Text color={theme.text.secondary}>{description}</Text>
+          </Box>
+        )}
 
         <Box>
           <Box width={LABEL_WIDTH} flexShrink={0}>

--- a/packages/cli/src/ui/components/extensions/steps/ExtensionDetailStep.tsx
+++ b/packages/cli/src/ui/components/extensions/steps/ExtensionDetailStep.tsx
@@ -8,9 +8,10 @@ import { Box, Text } from 'ink';
 import { theme } from '../../../semantic-colors.js';
 import {
   redactUrlCredentials,
+  getExtensionDisplayName,
   type Extension,
 } from '@qwen-code/qwen-code-core';
-import { t } from '../../../../i18n/index.js';
+import { t, getCurrentLanguage } from '../../../../i18n/index.js';
 
 interface ExtensionDetailStepProps {
   selectedExtension: Extension | null;
@@ -42,7 +43,7 @@ export const ExtensionDetailStep = ({
           <Box width={LABEL_WIDTH} flexShrink={0}>
             <Text color={theme.text.primary}>{t('Name:')}</Text>
           </Box>
-          <Text>{ext.name}</Text>
+          <Text>{getExtensionDisplayName(ext, getCurrentLanguage())}</Text>
         </Box>
 
         <Box>

--- a/packages/cli/src/ui/components/extensions/steps/ExtensionListStep.tsx
+++ b/packages/cli/src/ui/components/extensions/steps/ExtensionListStep.tsx
@@ -12,7 +12,9 @@ import { keyMatchers, Command } from '../../../keyMatchers.js';
 import {
   type Extension,
   getExtensionDisplayName,
+  getExtensionDescription,
 } from '@qwen-code/qwen-code-core';
+import { useTerminalSize } from '../../../hooks/useTerminalSize.js';
 import { t, getCurrentLanguage } from '../../../../i18n/index.js';
 import { ExtensionUpdateState } from '../../../state/extensions.js';
 
@@ -29,17 +31,17 @@ export const ExtensionListStep = ({
 }: ExtensionListStepProps) => {
   const [selectedIndex, setSelectedIndex] = useState(0);
 
+  const { columns: termWidth } = useTerminalSize();
+
   // Calculate max widths for each column for alignment
-  const { maxNameWidth, maxVersionWidth, maxStatusWidth } = useMemo(() => {
+  const { maxNameWidth, maxStatusWidth } = useMemo(() => {
     let maxName = 0;
-    let maxVersion = 0;
     let maxStatus = 0;
     for (const ext of extensions) {
       maxName = Math.max(
         maxName,
         getExtensionDisplayName(ext, getCurrentLanguage()).length,
       );
-      maxVersion = Math.max(maxVersion, ext.version.length);
       const statusLength = ext.isActive
         ? t('active').length
         : t('disabled').length;
@@ -47,7 +49,6 @@ export const ExtensionListStep = ({
     }
     return {
       maxNameWidth: maxName,
-      maxVersionWidth: maxVersion,
       maxStatusWidth: maxStatus,
     };
   }, [extensions]);
@@ -126,11 +127,36 @@ export const ExtensionListStep = ({
     return stateMap[state] || state;
   };
 
+  const truncateDescription = (
+    text: string,
+    maxWidth: number,
+    maxLines: number,
+  ): string[] => {
+    if (maxWidth <= 0) return [];
+    const lines: string[] = [];
+    let remaining = text;
+    for (let i = 0; i < maxLines; i++) {
+      if (!remaining) break;
+      if (remaining.length <= maxWidth || i === maxLines - 1) {
+        lines.push(
+          remaining.length > maxWidth
+            ? remaining.slice(0, maxWidth - 1) + '…'
+            : remaining,
+        );
+        break;
+      }
+      lines.push(remaining.slice(0, maxWidth));
+      remaining = remaining.slice(maxWidth);
+    }
+    return lines;
+  };
+
   const renderExtensionItem = (
     extension: Extension,
     index: number,
     isSelected: boolean,
   ) => {
+    const locale = getCurrentLanguage();
     const isActive = extension.isActive;
     const activeColor = isActive ? theme.status.success : theme.text.secondary;
     const activeString = isActive ? t('active') : t('disabled');
@@ -139,28 +165,42 @@ export const ExtensionListStep = ({
     const stateColor = getUpdateStateColor(updateState);
     const stateText = getLocalizedUpdateState(updateState);
 
+    const description = getExtensionDescription(extension, locale);
+    // selector(2) + name + gap(2) + status + gap(2) + update state
+    const fixedWidth = 2 + maxNameWidth + 2 + maxStatusWidth + 4 + 15;
+    const descWidth = Math.max(0, termWidth - fixedWidth);
+    const descLines = description
+      ? truncateDescription(description, descWidth, 2)
+      : [];
+
     return (
-      <Box key={extension.name} alignItems="center">
-        <Box minWidth={2} flexShrink={0}>
-          <Text color={isSelected ? theme.text.accent : theme.text.primary}>
-            {isSelected ? '●' : ' '}
-          </Text>
+      <Box key={extension.name} flexDirection="column" marginBottom={descLines.length > 0 ? 1 : 0}>
+        <Box alignItems="center">
+          <Box minWidth={2} flexShrink={0}>
+            <Text color={isSelected ? theme.text.accent : theme.text.primary}>
+              {isSelected ? '●' : ' '}
+            </Text>
+          </Box>
+          <Box width={maxNameWidth} flexShrink={0}>
+            <Text
+              color={isSelected ? theme.text.accent : theme.text.primary}
+              wrap="truncate"
+            >
+              {getExtensionDisplayName(extension, locale)}
+            </Text>
+          </Box>
+          <Box width={maxStatusWidth + 4} flexShrink={0}>
+            <Text color={activeColor}>  ({activeString})</Text>
+          </Box>
+          {stateText && <Text color={stateColor}>[{stateText}]</Text>}
         </Box>
-        <Box width={maxNameWidth} flexShrink={0}>
-          <Text
-            color={isSelected ? theme.text.accent : theme.text.primary}
-            wrap="truncate"
-          >
-            {getExtensionDisplayName(extension, getCurrentLanguage())}
-          </Text>
-        </Box>
-        <Box width={maxVersionWidth + 8} flexShrink={0}>
-          <Text color={theme.text.secondary}> v{extension.version}</Text>
-        </Box>
-        <Box width={maxStatusWidth + 8} flexShrink={0}>
-          <Text color={activeColor}>({activeString})</Text>
-        </Box>
-        {stateText && <Text color={stateColor}>[{stateText}]</Text>}
+        {descLines.length > 0 && (
+          <Box paddingLeft={2} flexDirection="column">
+            {descLines.map((line, i) => (
+              <Text key={i} color={theme.text.secondary}>{line}</Text>
+            ))}
+          </Box>
+        )}
       </Box>
     );
   };

--- a/packages/cli/src/ui/components/extensions/steps/ExtensionListStep.tsx
+++ b/packages/cli/src/ui/components/extensions/steps/ExtensionListStep.tsx
@@ -9,8 +9,11 @@ import { Box, Text } from 'ink';
 import { theme } from '../../../semantic-colors.js';
 import { useKeypress } from '../../../hooks/useKeypress.js';
 import { keyMatchers, Command } from '../../../keyMatchers.js';
-import { type Extension } from '@qwen-code/qwen-code-core';
-import { t } from '../../../../i18n/index.js';
+import {
+  type Extension,
+  getExtensionDisplayName,
+} from '@qwen-code/qwen-code-core';
+import { t, getCurrentLanguage } from '../../../../i18n/index.js';
 import { ExtensionUpdateState } from '../../../state/extensions.js';
 
 interface ExtensionListStepProps {
@@ -32,7 +35,10 @@ export const ExtensionListStep = ({
     let maxVersion = 0;
     let maxStatus = 0;
     for (const ext of extensions) {
-      maxName = Math.max(maxName, ext.name.length);
+      maxName = Math.max(
+        maxName,
+        getExtensionDisplayName(ext, getCurrentLanguage()).length,
+      );
       maxVersion = Math.max(maxVersion, ext.version.length);
       const statusLength = ext.isActive
         ? t('active').length
@@ -145,7 +151,7 @@ export const ExtensionListStep = ({
             color={isSelected ? theme.text.accent : theme.text.primary}
             wrap="truncate"
           >
-            {extension.name}
+            {getExtensionDisplayName(extension, getCurrentLanguage())}
           </Text>
         </Box>
         <Box width={maxVersionWidth + 8} flexShrink={0}>

--- a/packages/cli/src/ui/components/extensions/steps/ScopeSelectStep.tsx
+++ b/packages/cli/src/ui/components/extensions/steps/ScopeSelectStep.tsx
@@ -6,9 +6,12 @@
 
 import { Box, Text } from 'ink';
 import { RadioButtonSelect } from '../../shared/RadioButtonSelect.js';
-import { type Extension } from '@qwen-code/qwen-code-core';
+import {
+  type Extension,
+  getExtensionDisplayName,
+} from '@qwen-code/qwen-code-core';
 import { theme } from '../../../semantic-colors.js';
-import { t } from '../../../../i18n/index.js';
+import { t, getCurrentLanguage } from '../../../../i18n/index.js';
 
 interface ScopeSelectStepProps {
   selectedExtension: Extension | null;
@@ -52,8 +55,12 @@ export function ScopeSelectStep({
 
   const title =
     mode === 'disable'
-      ? t('Disable "{{name}}" - Select Scope', { name: selectedExtension.name })
-      : t('Enable "{{name}}" - Select Scope', { name: selectedExtension.name });
+      ? t('Disable "{{name}}" - Select Scope', {
+          name: getExtensionDisplayName(selectedExtension, getCurrentLanguage()),
+        })
+      : t('Enable "{{name}}" - Select Scope', {
+          name: getExtensionDisplayName(selectedExtension, getCurrentLanguage()),
+        });
 
   return (
     <Box flexDirection="column" gap={1}>

--- a/packages/cli/src/ui/components/extensions/steps/UninstallConfirmStep.tsx
+++ b/packages/cli/src/ui/components/extensions/steps/UninstallConfirmStep.tsx
@@ -5,11 +5,14 @@
  */
 
 import { Box, Text } from 'ink';
-import { type Extension } from '@qwen-code/qwen-code-core';
-import { createDebugLogger } from '@qwen-code/qwen-code-core';
+import {
+  type Extension,
+  createDebugLogger,
+  getExtensionDisplayName,
+} from '@qwen-code/qwen-code-core';
 import { theme } from '../../../semantic-colors.js';
 import { useKeypress } from '../../../hooks/useKeypress.js';
-import { t } from '../../../../i18n/index.js';
+import { t, getCurrentLanguage } from '../../../../i18n/index.js';
 
 interface UninstallConfirmStepProps {
   selectedExtension: Extension | null;
@@ -54,7 +57,7 @@ export function UninstallConfirmStep({
     <Box flexDirection="column" gap={1}>
       <Text color={theme.status.error}>
         {t('Are you sure you want to uninstall extension "{{name}}"?', {
-          name: selectedExtension.name,
+          name: getExtensionDisplayName(selectedExtension, getCurrentLanguage()),
         })}
       </Text>
       <Text color={theme.text.secondary}>

--- a/packages/cli/src/ui/components/extensions/steps/__snapshots__/ExtensionListStep.test.tsx.snap
+++ b/packages/cli/src/ui/components/extensions/steps/__snapshots__/ExtensionListStep.test.tsx.snap
@@ -8,25 +8,25 @@ Use '/extensions install' to install your first extension."
 exports[`ExtensionListStep Snapshots > should render list with multiple extensions 1`] = `
 "3 extensions installed
 
-● active-extension   v1.0.0      (active)        [up to date]
-  disabled-extension v1.0.0      (disabled)      [not updatable]
-  update-available   v1.0.0      (active)        [update available]"
+● active-extension    (active)  [up to date]
+  disabled-extension  (disabled)[not updatable]
+  update-available    (active)  [update available]"
 `;
 
 exports[`ExtensionListStep Snapshots > should render list with single extension 1`] = `
 "1 extensions installed
 
-● test-extension v1.0.0      (active)"
+● test-extension  (active)"
 `;
 
 exports[`ExtensionListStep Snapshots > should render with checking status 1`] = `
 "1 extensions installed
 
-● checking-extension v1.0.0      (active)      [checking for updates]"
+● checking-extension  (active)[checking for updates]"
 `;
 
 exports[`ExtensionListStep Snapshots > should render with error status 1`] = `
 "1 extensions installed
 
-● error-extension v1.0.0      (active)      [error]"
+● error-extension  (active)[error]"
 `;

--- a/packages/cli/src/ui/components/hooks/HooksManagementDialog.tsx
+++ b/packages/cli/src/ui/components/hooks/HooksManagementDialog.tsx
@@ -369,7 +369,7 @@ export function HooksManagementDialog({
                     {
                       config: hookConfig,
                       source: HooksConfigSource.Extensions,
-                      sourceDisplay: extension.name,
+                      sourceDisplay: extension.displayName ?? extension.name,
                       sourcePath: extension.path,
                       enabled: true,
                     },

--- a/packages/cli/src/ui/components/views/ExtensionsList.tsx
+++ b/packages/cli/src/ui/components/views/ExtensionsList.tsx
@@ -7,7 +7,11 @@
 import { Box, Text } from 'ink';
 import { useUIState } from '../../contexts/UIStateContext.js';
 import { ExtensionUpdateState } from '../../state/extensions.js';
-import { createDebugLogger } from '@qwen-code/qwen-code-core';
+import {
+  createDebugLogger,
+  getExtensionDisplayName,
+} from '@qwen-code/qwen-code-core';
+import { getCurrentLanguage } from '../../../i18n/index.js';
 
 const debugLogger = createDebugLogger('EXTENSIONS_LIST');
 
@@ -57,7 +61,7 @@ export const ExtensionsList = () => {
           return (
             <Box key={ext.name} flexDirection="column" marginBottom={1}>
               <Text>
-                <Text color="cyan">{`${ext.name} (v${ext.version})`}</Text>
+                <Text color="cyan">{`${getExtensionDisplayName(ext, getCurrentLanguage())} (v${ext.version})`}</Text>
                 <Text color={activeColor}>{` - ${activeString}`}</Text>
                 {<Text color={stateColor}>{` (${stateText})`}</Text>}
               </Text>

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.ts
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ExtensionManager } from '@qwen-code/qwen-code-core';
+import {
+  type ExtensionManager,
+  getExtensionDisplayName,
+} from '@qwen-code/qwen-code-core';
+import { getCurrentLanguage } from '../../i18n/index.js';
 import { getErrorMessage } from '../../utils/errors.js';
 import {
   ExtensionUpdateState,
@@ -291,7 +295,7 @@ export const useExtensionUpdates = (
             addItem(
               {
                 type: MessageType.INFO,
-                text: `Extension "${extension.name}" successfully updated: ${result.originalVersion} → ${result.updatedVersion}.`,
+                text: `Extension "${getExtensionDisplayName(extension, getCurrentLanguage())}" successfully updated: ${result.originalVersion} → ${result.updatedVersion}.`,
               },
               Date.now(),
             );

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -827,6 +827,8 @@ export interface ConfigParameters {
   emitToolUseSummaries?: boolean;
   listExtensions?: boolean;
   overrideExtensions?: string[];
+  /** Locale code for resolving localizable extension fields (e.g., 'en', 'zh'). */
+  locale?: string;
   allowedMcpServers?: string[];
   excludedMcpServers?: string[];
   /**
@@ -1555,6 +1557,7 @@ export class Config {
       workspaceDir: this.targetDir,
       enabledExtensionOverrides: this.overrideExtensions,
       isWorkspaceTrusted: this.isTrustedFolder(),
+      locale: params.locale,
     });
     this.enableManagedAutoMemory = params.enableManagedAutoMemory ?? true;
     this.enableManagedAutoDream = params.enableManagedAutoDream ?? true;

--- a/packages/core/src/extension/extensionManager.ts
+++ b/packages/core/src/extension/extensionManager.ts
@@ -56,6 +56,11 @@ import { glob } from 'glob';
 import { createHash } from 'node:crypto';
 import { ExtensionStorage } from './storage.js';
 import {
+  resolveExtensionConfigLocale,
+  type RawExtensionConfig,
+  type LocalizableString,
+} from './i18n.js';
+import {
   getEnvContents,
   maybePromptForSettings,
   promptForSetting,
@@ -105,6 +110,7 @@ export interface ExtensionChannelConfig {
 export interface Extension {
   id: string;
   name: string;
+  displayName?: string;
   version: string;
   isActive: boolean;
   path: string;
@@ -125,7 +131,13 @@ export interface Extension {
 export interface ExtensionConfig {
   name: string;
   version: string;
+  displayName?: string;
   description?: string;
+  /** Original localizable values before resolution, for runtime re-resolution on language change. */
+  _rawLocalizable?: {
+    displayName?: LocalizableString;
+    description?: LocalizableString;
+  };
   mcpServers?: Record<string, MCPServerConfig>;
   lspServers?: string | Record<string, unknown>;
   contextFileName?: string | string[];
@@ -178,6 +190,8 @@ export interface ExtensionManagerOptions {
   /** Override list of enabled extension names (from CLI -e flag) */
   enabledExtensionOverrides?: string[];
   isWorkspaceTrusted: boolean;
+  /** Locale code for resolving localizable fields (e.g., 'en', 'zh'). Defaults to 'en'. */
+  locale?: string;
   telemetrySettings?: TelemetrySettings;
   config?: Config;
   requestConsent?: (options?: ExtensionRequestOptions) => Promise<void>;
@@ -306,6 +320,7 @@ export class ExtensionManager {
   private config?: Config;
   private telemetrySettings?: TelemetrySettings;
   private isWorkspaceTrusted: boolean;
+  private readonly locale: string;
   private requestConsent: (options?: ExtensionRequestOptions) => Promise<void>;
   private requestSetting?: (setting: ExtensionSetting) => Promise<string>;
   private requestChoicePlugin: (
@@ -314,6 +329,7 @@ export class ExtensionManager {
 
   constructor(options: ExtensionManagerOptions) {
     this.workspaceDir = options.workspaceDir ?? process.cwd();
+    this.locale = options.locale ?? 'en';
     this.enabledExtensionNamesOverride =
       options.enabledExtensionOverrides?.map((name) => name.toLowerCase()) ??
       [];
@@ -664,6 +680,7 @@ export class ExtensionManager {
       const extension: Extension = {
         id: getExtensionId(config, installMetadata),
         name: config.name,
+        displayName: config.displayName,
         version:
           config.version ||
           installMetadata?.marketplaceConfig?.metadata?.version ||
@@ -806,13 +823,15 @@ export class ExtensionManager {
     }
     try {
       const configContent = fs.readFileSync(configFilePath, 'utf-8');
-      const config = recursivelyHydrateStrings(JSON.parse(configContent), {
+      const rawConfig = recursivelyHydrateStrings(JSON.parse(configContent), {
         extensionPath: extensionDir,
         CLAUDE_PLUGIN_ROOT: extensionDir,
         workspacePath: workspaceDir,
         '/': path.sep,
         pathSeparator: path.sep,
-      }) as unknown as ExtensionConfig;
+      }) as unknown as RawExtensionConfig;
+
+      const config = resolveExtensionConfigLocale(rawConfig, this.locale);
 
       if (!config.name) {
         throw new Error(

--- a/packages/core/src/extension/i18n.test.ts
+++ b/packages/core/src/extension/i18n.test.ts
@@ -1,0 +1,140 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  resolveLocalizableString,
+  resolveExtensionConfigLocale,
+  type RawExtensionConfig,
+} from './i18n.js';
+
+describe('resolveLocalizableString', () => {
+  it('should return undefined for undefined input', () => {
+    expect(resolveLocalizableString(undefined, 'en')).toBeUndefined();
+  });
+
+  it('should return plain string unchanged', () => {
+    expect(resolveLocalizableString('hello', 'en')).toBe('hello');
+    expect(resolveLocalizableString('hello', 'zh')).toBe('hello');
+  });
+
+  it('should resolve exact locale match', () => {
+    const value = { en: 'Hello', zh: '你好', ja: 'こんにちは' };
+    expect(resolveLocalizableString(value, 'zh')).toBe('你好');
+    expect(resolveLocalizableString(value, 'ja')).toBe('こんにちは');
+  });
+
+  it('should fall back to base language', () => {
+    const value = { en: 'Hello', zh: '你好' };
+    expect(resolveLocalizableString(value, 'zh-TW')).toBe('你好');
+    expect(resolveLocalizableString(value, 'zh-CN')).toBe('你好');
+  });
+
+  it('should prefer exact match over base language', () => {
+    const value = { en: 'Hello', zh: '你好', 'zh-TW': '你好（繁體）' };
+    expect(resolveLocalizableString(value, 'zh-TW')).toBe('你好（繁體）');
+    expect(resolveLocalizableString(value, 'zh')).toBe('你好');
+  });
+
+  it('should fall back to en when no match', () => {
+    const value = { en: 'Hello', zh: '你好' };
+    expect(resolveLocalizableString(value, 'ja')).toBe('Hello');
+    expect(resolveLocalizableString(value, 'de')).toBe('Hello');
+  });
+
+  it('should fall back to first value when no en', () => {
+    const value = { zh: '你好', ja: 'こんにちは' };
+    expect(resolveLocalizableString(value, 'de')).toBe('你好');
+  });
+
+  it('should return undefined for empty record', () => {
+    expect(resolveLocalizableString({}, 'en')).toBeUndefined();
+  });
+});
+
+describe('resolveExtensionConfigLocale', () => {
+  const baseConfig: RawExtensionConfig = {
+    name: 'test-ext',
+    version: '1.0.0',
+  };
+
+  it('should pass through config with plain string fields', () => {
+    const raw: RawExtensionConfig = {
+      ...baseConfig,
+      description: 'A test extension',
+      displayName: 'Test Extension',
+    };
+    const resolved = resolveExtensionConfigLocale(raw, 'en');
+    expect(resolved.name).toBe('test-ext');
+    expect(resolved.description).toBe('A test extension');
+    expect(resolved.displayName).toBe('Test Extension');
+  });
+
+  it('should resolve locale map description', () => {
+    const raw: RawExtensionConfig = {
+      ...baseConfig,
+      description: { en: 'English desc', zh: '中文描述' },
+    };
+    expect(resolveExtensionConfigLocale(raw, 'zh').description).toBe(
+      '中文描述',
+    );
+    expect(resolveExtensionConfigLocale(raw, 'en').description).toBe(
+      'English desc',
+    );
+  });
+
+  it('should resolve locale map displayName', () => {
+    const raw: RawExtensionConfig = {
+      ...baseConfig,
+      displayName: { en: 'My Extension', zh: '我的扩展' },
+    };
+    expect(resolveExtensionConfigLocale(raw, 'zh').displayName).toBe(
+      '我的扩展',
+    );
+    expect(resolveExtensionConfigLocale(raw, 'en').displayName).toBe(
+      'My Extension',
+    );
+  });
+
+  it('should resolve settings descriptions', () => {
+    const raw: RawExtensionConfig = {
+      ...baseConfig,
+      settings: [
+        {
+          name: 'api-key',
+          description: { en: 'API key', zh: 'API 密钥' },
+          envVar: 'API_KEY',
+        },
+        {
+          name: 'plain-setting',
+          description: 'A plain setting',
+          envVar: 'PLAIN',
+        },
+      ],
+    };
+    const resolved = resolveExtensionConfigLocale(raw, 'zh');
+    expect(resolved.settings![0]!.description).toBe('API 密钥');
+    expect(resolved.settings![1]!.description).toBe('A plain setting');
+  });
+
+  it('should handle missing optional fields', () => {
+    const resolved = resolveExtensionConfigLocale(baseConfig, 'en');
+    expect(resolved.description).toBeUndefined();
+    expect(resolved.displayName).toBeUndefined();
+    expect(resolved.settings).toBeUndefined();
+  });
+
+  it('should preserve non-localizable fields', () => {
+    const raw: RawExtensionConfig = {
+      ...baseConfig,
+      contextFileName: 'CUSTOM.md',
+      commands: ['commands/'],
+    };
+    const resolved = resolveExtensionConfigLocale(raw, 'en');
+    expect(resolved.contextFileName).toBe('CUSTOM.md');
+    expect(resolved.commands).toEqual(['commands/']);
+  });
+});

--- a/packages/core/src/extension/i18n.test.ts
+++ b/packages/core/src/extension/i18n.test.ts
@@ -53,6 +53,16 @@ describe('resolveLocalizableString', () => {
   it('should return undefined for empty record', () => {
     expect(resolveLocalizableString({}, 'en')).toBeUndefined();
   });
+
+  it('should skip non-string values in locale map', () => {
+    const value = { en: 123, zh: '中文' } as unknown as Record<string, string>;
+    expect(resolveLocalizableString(value, 'en')).toBe('中文');
+  });
+
+  it('should return undefined when all values are non-string', () => {
+    const value = { en: 123, zh: 456 } as unknown as Record<string, string>;
+    expect(resolveLocalizableString(value, 'en')).toBeUndefined();
+  });
 });
 
 describe('resolveExtensionConfigLocale', () => {

--- a/packages/core/src/extension/i18n.ts
+++ b/packages/core/src/extension/i18n.ts
@@ -42,17 +42,18 @@ export function resolveLocalizableString(
   if (value === undefined) return undefined;
   if (typeof value === 'string') return value;
 
-  if (value[locale]) return value[locale];
-
   const baseLang = locale.split('-')[0];
-  if (baseLang !== locale && baseLang && value[baseLang]) return value[baseLang];
-
-  if (value['en']) return value['en'];
-
-  const keys = Object.keys(value);
-  if (keys.length > 0) return value[keys[0]!];
-
-  return undefined;
+  const prioritized = [
+    value[locale],
+    baseLang !== locale ? value[baseLang!] : undefined,
+    value['en'],
+  ];
+  for (const v of prioritized) {
+    if (typeof v === 'string' && v) return v;
+  }
+  return Object.values(value).find(
+    (v): v is string => typeof v === 'string' && v.length > 0,
+  );
 }
 
 /**

--- a/packages/core/src/extension/i18n.ts
+++ b/packages/core/src/extension/i18n.ts
@@ -117,5 +117,6 @@ export function getExtensionDescription(
 ): string | undefined {
   const raw = ext.config?._rawLocalizable?.description;
   if (raw) return resolveLocalizableString(raw, locale);
-  return ext.config?.description;
+  const desc = ext.config?.description;
+  return typeof desc === 'string' ? desc : undefined;
 }

--- a/packages/core/src/extension/i18n.ts
+++ b/packages/core/src/extension/i18n.ts
@@ -1,0 +1,121 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ExtensionConfig } from './extensionManager.js';
+import type { ExtensionSetting } from './extensionSettings.js';
+
+/**
+ * A string field that can be either a plain string or a locale map.
+ * Keys in the record are locale codes (e.g., 'en', 'zh', 'zh-TW', 'ja').
+ */
+export type LocalizableString = string | Record<string, string>;
+
+/**
+ * Raw shape of qwen-extension.json before locale resolution.
+ * `description`, `displayName`, and setting descriptions may be locale maps.
+ */
+export interface RawExtensionConfig
+  extends Omit<ExtensionConfig, 'description' | 'displayName' | 'settings'> {
+  description?: LocalizableString;
+  displayName?: LocalizableString;
+  settings?: RawExtensionSetting[];
+}
+
+export interface RawExtensionSetting
+  extends Omit<ExtensionSetting, 'description'> {
+  description: LocalizableString;
+}
+
+/**
+ * Resolves a LocalizableString to a plain string for the given locale.
+ *
+ * Fallback chain:
+ *   exact match (e.g., 'zh-TW') → base language (e.g., 'zh') → 'en' → first value
+ */
+export function resolveLocalizableString(
+  value: LocalizableString | undefined,
+  locale: string,
+): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === 'string') return value;
+
+  if (value[locale]) return value[locale];
+
+  const baseLang = locale.split('-')[0];
+  if (baseLang !== locale && baseLang && value[baseLang]) return value[baseLang];
+
+  if (value['en']) return value['en'];
+
+  const keys = Object.keys(value);
+  if (keys.length > 0) return value[keys[0]!];
+
+  return undefined;
+}
+
+/**
+ * Resolves all localizable fields in a raw extension config to plain strings.
+ */
+export function resolveExtensionConfigLocale(
+  rawConfig: RawExtensionConfig,
+  locale: string,
+): ExtensionConfig {
+  const {
+    displayName,
+    description,
+    settings: rawSettings,
+    ...rest
+  } = rawConfig;
+
+  const hasLocalizableFields =
+    (typeof displayName === 'object' && displayName !== null) ||
+    (typeof description === 'object' && description !== null);
+
+  const resolved: ExtensionConfig = {
+    ...rest,
+    displayName: resolveLocalizableString(displayName, locale),
+    description: resolveLocalizableString(description, locale),
+    ...(hasLocalizableFields
+      ? { _rawLocalizable: { displayName, description } }
+      : {}),
+  };
+
+  if (rawSettings) {
+    resolved.settings = rawSettings.map(
+      (setting): ExtensionSetting => ({
+        ...setting,
+        description:
+          resolveLocalizableString(setting.description, locale) ?? '',
+      }),
+    );
+  }
+
+  return resolved;
+}
+
+/**
+ * Resolves extension displayName for the given locale at display time.
+ * Falls back to the pre-resolved value, then to extension name.
+ */
+export function getExtensionDisplayName(
+  ext: { name: string; displayName?: string; config?: ExtensionConfig },
+  locale: string,
+): string {
+  const raw = ext.config?._rawLocalizable?.displayName;
+  if (raw) return resolveLocalizableString(raw, locale) ?? ext.name;
+  return ext.displayName ?? ext.name;
+}
+
+/**
+ * Resolves extension description for the given locale at display time.
+ */
+export function getExtensionDescription(
+  ext: { config?: ExtensionConfig; description?: string },
+  locale: string,
+): string | undefined {
+  const raw = ext.config?._rawLocalizable?.description;
+  if (raw) return resolveLocalizableString(raw, locale);
+  return ext.config?.description;
+}

--- a/packages/core/src/extension/index.ts
+++ b/packages/core/src/extension/index.ts
@@ -1,4 +1,5 @@
 export * from './extensionManager.js';
+export * from './i18n.js';
 export * from './variables.js';
 export * from './github.js';
 export * from './extensionSettings.js';

--- a/packages/core/src/skills/skill-manager.ts
+++ b/packages/core/src/skills/skill-manager.ts
@@ -959,7 +959,7 @@ export class SkillManager {
           }
           skills.push({
             ...skill,
-            extensionName: extension.name,
+            extensionName: extension.displayName ?? extension.name,
             // Normalize so downstream consumers reading `skill.priority`
             // (e.g. the `/skills` display sort) observe the same value
             // reflected by the warning above.

--- a/packages/desktop/apps/electron/src/renderer/lib/qwen-settings-snapshot.ts
+++ b/packages/desktop/apps/electron/src/renderer/lib/qwen-settings-snapshot.ts
@@ -33,6 +33,7 @@ function normalizeExtension(
   return {
     id: extension.id ?? extension.name ?? '',
     name: extension.name ?? extension.id ?? '',
+    displayName: extension.displayName,
     version: extension.version,
     isActive: extension.isActive,
     path: extension.path,

--- a/packages/desktop/apps/electron/src/renderer/pages/settings/QwenSettingsPage.tsx
+++ b/packages/desktop/apps/electron/src/renderer/pages/settings/QwenSettingsPage.tsx
@@ -1398,7 +1398,7 @@ function ExtensionCard({
     <SettingsCard className="px-4 py-3.5">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <div className="text-sm font-medium">{extension.name}</div>
+          <div className="text-sm font-medium">{extension.displayName ?? extension.name}</div>
           <div className="text-xs text-muted-foreground mt-0.5">
             {extension.version} ·{' '}
             {extension.isActive

--- a/packages/desktop/packages/shared/src/protocol/dto.ts
+++ b/packages/desktop/packages/shared/src/protocol/dto.ts
@@ -643,6 +643,7 @@ export interface QwenExtensionSettingDefinition {
 export interface QwenExtensionSettingsEntry {
   id: string
   name: string
+  displayName?: string
   version?: string
   isActive?: boolean
   path?: string


### PR DESCRIPTION
## What this PR does

Adds internationalization (i18n) support to `qwen-extension.json`, allowing extension authors to provide locale-aware `displayName` and `description` fields. When the CLI runs in different languages, it displays the corresponding localized text. Also shows description in the interactive extension management UI (list and detail views).

## Why it's needed

Extension metadata (name, description) was previously hardcoded as plain strings with no localization support, even though the CLI already has a mature i18n system supporting 9 languages. Extension authors serving multilingual users had no way to provide translated metadata.

## Reviewer Test Plan

### How to verify

1. Edit any installed extension's `qwen-extension.json` to use locale maps:
   ```json
   {
     "name": "my-ext",
     "displayName": { "en": "My Extension", "zh": "我的扩展" },
     "description": { "en": "A useful tool", "zh": "一个有用的工具" }
   }
   ```
2. Run `QWEN_CODE_LANG=zh npm run dev -- extensions list` — should show Chinese displayName and description.
3. Run `QWEN_CODE_LANG=en npm run dev -- extensions list` — should show English displayName and description.
4. Run `npm run dev`, use `/language ui zh-CN`, then `/extensions list` and `/extensions manage` — should show Chinese text dynamically.
5. Verify backward compatibility: extensions with plain string `description` still work unchanged.
6. Run `cd packages/core && npx vitest run src/extension/i18n.test.ts --no-coverage` — 14 tests should pass.

### Evidence (Before & After)

**Before (no i18n):**
```
✓ dataworks-di-extension (1.0.0-27d7defb8b-20260616035359)
```

**After (zh):**
```
✓ DataWorks 数据集成 (1.0.0-27d7defb8b-20260616035359)
 描述: DataWorks 数据集成扩展，提供 DI 任务管理与调试能力
```

**After (en):**
```
✓ DataWorks Data Integration (1.0.0-27d7defb8b-20260616035359)
 Description: Data integration extension for DataWorks, providing DI task management and debugging capabilities
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npm run dev` (tsx, no build needed)

## Risk & Scope

- Main risk or tradeoff: Adds `_rawLocalizable` field to `ExtensionConfig` for runtime re-resolution on language change; slightly increases memory per loaded extension.
- Not validated / out of scope: Desktop app rendering of displayName (type updated but UI not locally tested on desktop build).
- Breaking changes / migration notes: None — fully backward compatible. Plain string fields continue to work. New `displayName` field is optional.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

为 `qwen-extension.json` 添加国际化（i18n）支持，允许扩展作者为 `displayName` 和 `description` 字段提供多语言值。CLI 在不同语言环境下会展示对应语言的文本。同时在交互式扩展管理界面（列表和详情视图）中展示描述信息。

## 为什么需要

扩展元数据（名称、描述）此前只能使用纯字符串，没有本地化支持，尽管 CLI 已有成熟的 i18n 系统（支持 9 种语言）。面向多语言用户的扩展作者无法提供翻译后的元数据。

## 审阅测试计划

### 如何验证

1. 编辑任意已安装扩展的 `qwen-extension.json`，使用多语言格式：
   ```json
   {
     "name": "my-ext",
     "displayName": { "en": "My Extension", "zh": "我的扩展" },
     "description": { "en": "A useful tool", "zh": "一个有用的工具" }
   }
   ```
2. 运行 `QWEN_CODE_LANG=zh npm run dev -- extensions list` — 应显示中文 displayName 和描述。
3. 运行 `QWEN_CODE_LANG=en npm run dev -- extensions list` — 应显示英文 displayName 和描述。
4. 运行 `npm run dev`，使用 `/language ui zh-CN`，然后 `/extensions list` 和 `/extensions manage` — 应动态显示中文文本。
5. 验证向后兼容性：使用纯字符串 `description` 的扩展仍然正常工作。
6. 运行 `cd packages/core && npx vitest run src/extension/i18n.test.ts --no-coverage` — 14 个测试应全部通过。

## 风险与范围

- 主要风险/权衡：在 `ExtensionConfig` 上增加 `_rawLocalizable` 字段用于语言切换时的运行时重新解析，略微增加每个已加载扩展的内存占用。
- 未验证/超出范围：桌面端 displayName 的渲染（类型已更新但未在桌面端本地构建中测试）。
- 破坏性变更/迁移说明：无 — 完全向后兼容。纯字符串字段继续正常工作。新增的 `displayName` 字段为可选。

</details>