### PR TITLE
fix(core): read short VP8L WebP dimensions

### DIFF
--- a/packages/core/src/utils/request-tokenizer/imageTokenizer.test.ts
+++ b/packages/core/src/utils/request-tokenizer/imageTokenizer.test.ts
@@ -103,6 +103,69 @@ describe('ImageTokenizer', () => {
   });
 
   describe('WebP dimension extraction', () => {
+    function buildWebp(format: string, totalLength: number): Buffer {
+      const buf = Buffer.alloc(totalLength);
+      buf.write('RIFF', 0, 'ascii');
+      buf.writeUInt32LE(totalLength - 8, 4);
+      buf.write('WEBP', 8, 'ascii');
+      buf.write(format, 12, 'ascii');
+      buf.writeUInt32LE(Math.max(totalLength - 20, 0), 16);
+      return buf;
+    }
+
+    function buildVp8lWebp(
+      width: number,
+      height: number,
+      signature = 0x2f,
+    ): Buffer {
+      const buf = buildWebp('VP8L', 26);
+      buf.writeUInt32LE(5, 16);
+      buf.writeUInt8(signature, 20);
+      buf.writeUInt32LE((width - 1) | ((height - 1) << 14), 21);
+      return buf;
+    }
+
+    it('should extract dimensions from a short VP8L lossless WebP', async () => {
+      const width = 17;
+      const height = 13;
+
+      const buf = buildVp8lWebp(width, height);
+
+      const metadata = await tokenizer.extractImageMetadata(
+        buf.toString('base64'),
+        'image/webp',
+      );
+
+      expect(metadata.width).toBe(width);
+      expect(metadata.height).toBe(height);
+    });
+
+    it('should fall back for VP8L with an invalid lossless signature', async () => {
+      const buf = buildVp8lWebp(17, 13, 0x00);
+
+      const metadata = await tokenizer.extractImageMetadata(
+        buf.toString('base64'),
+        'image/webp',
+      );
+
+      expect(metadata.width).toBe(512);
+      expect(metadata.height).toBe(512);
+    });
+
+    it('should still reject short VP8 and VP8X WebP files', async () => {
+      const formats = ['VP8 ', 'VP8X'];
+
+      for (const format of formats) {
+        const metadata = await tokenizer.extractImageMetadata(
+          buildWebp(format, 26).toString('base64'),
+          'image/webp',
+        );
+
+        expect(metadata.width).toBe(512);
+        expect(metadata.height).toBe(512);
+      }
+    });
+
     it('should extract canvas dimensions from VP8X', async () => {
       const width = 100;
       const height = 80;

--- a/packages/core/src/utils/request-tokenizer/imageTokenizer.ts
+++ b/packages/core/src/utils/request-tokenizer/imageTokenizer.ts
@@ -199,7 +199,7 @@ export class ImageTokenizer {
     width: number;
     height: number;
   } {
-    if (buffer.length < 30) {
+    if (buffer.length < 16) {
       throw new Error('Invalid WebP: too short');
     }
 
@@ -213,17 +213,29 @@ export class ImageTokenizer {
     const format = buffer.subarray(12, 16).toString('ascii');
 
     if (format === 'VP8 ') {
+      if (buffer.length < 30) {
+        throw new Error('Invalid VP8 WebP: too short');
+      }
       // Lossy: 14-bit width/height at bytes 26-27 and 28-29 (little-endian)
       const width = buffer.readUInt16LE(26) & 0x3fff;
       const height = buffer.readUInt16LE(28) & 0x3fff;
       return { width, height };
     } else if (format === 'VP8L') {
+      if (buffer.length < 25) {
+        throw new Error('Invalid VP8L WebP: too short');
+      }
+      if (buffer[20] !== 0x2f) {
+        throw new Error('Invalid VP8L WebP signature');
+      }
       // Lossless: 14-bit (width-1) then (height-1) packed from byte 21 (little-endian)
       const bits = buffer.readUInt32LE(21);
       const width = (bits & 0x3fff) + 1;
       const height = ((bits >> 14) & 0x3fff) + 1;
       return { width, height };
     } else if (format === 'VP8X') {
+      if (buffer.length < 30) {
+        throw new Error('Invalid VP8X WebP: too short');
+      }
       // Extended: 24-bit (canvas width-1) at bytes 24-26 and (height-1) at bytes 27-29 (little-endian)
       const width = buffer.readUIntLE(24, 3) + 1;
       const height = buffer.readUIntLE(27, 3) + 1;


### PR DESCRIPTION
## What this PR does

Fixes WebP dimension extraction for short VP8L lossless files by lowering the shared WebP minimum length check and validating the actual length required by each chunk type. VP8 and VP8X still require 30 bytes, while VP8L can be parsed once bytes 21-24 are available and the lossless signature byte is valid.

## Why it's needed

A minimal VP8L WebP can be shorter than 30 bytes because its dimensions are packed into bytes 21-24. The old shared 30-byte guard rejected those files before reaching the VP8L parser, so metadata fell back to 512x512 instead of using the real dimensions.

## Reviewer Test Plan

### How to verify

Run the image tokenizer tests and confirm the short VP8L case returns the encoded dimensions, invalid VP8L signatures fall back, and short VP8/VP8X files still fall back.

### Evidence (Before & After)

N/A. This is parser behavior covered by unit tests.

### Tested on

| OS | Status |
| :-- | :-- |
| macOS | tested |
| Windows | not tested locally |
| Linux | not tested locally |

### Environment (optional)

Local npm workspace tests on macOS.

## Risk & Scope

- Main risk or tradeoff: low; the change only moves WebP length checks to the format-specific branches and adds VP8L signature validation.
- Not validated / out of scope: Windows and Linux local runs; CI covers those platforms.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5291

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复短 VP8L lossless WebP 的尺寸解析：把 WebP 统一的最小长度检查下放到各个 chunk 类型里。VP8 和 VP8X 仍然要求 30 字节；VP8L 在 bytes 21-24 可读且 lossless signature 正确时就可以解析。

## 为什么需要

最小 VP8L WebP 可能短于 30 字节，因为它的尺寸信息打包在 bytes 21-24。旧的统一 30 字节检查会在进入 VP8L 解析前直接拒绝这些文件，导致 metadata 回退成 512x512，而不是读取真实尺寸。

## Reviewer Test Plan

### 如何验证

运行 image tokenizer 测试，确认短 VP8L 样例返回编码尺寸、无效 VP8L signature 会回退、短 VP8/VP8X 仍然会回退。

### Evidence (Before & After)

N/A。这是单元测试覆盖的解析行为。

### Tested on

| OS | Status |
| :-- | :-- |
| macOS | tested |
| Windows | not tested locally |
| Linux | not tested locally |

### Environment (optional)

macOS 本地 npm workspace 测试。

## Risk & Scope

- Main risk or tradeoff: 风险低；只把 WebP 长度检查移动到具体格式分支，并增加 VP8L signature 校验。
- Not validated / out of scope: Windows 和 Linux 没有本地跑；交给 CI 覆盖。
- Breaking changes / migration notes: 无。

## Linked Issues

Fixes #5291

</details>