### PR TITLE
fix(web-shell): summarize grep_search results

### DIFF
--- a/packages/web-shell/client/components/messages/toolFormatting.test.ts
+++ b/packages/web-shell/client/components/messages/toolFormatting.test.ts
@@ -135,6 +135,99 @@ describe('toolFormatting', () => {
     ).toBe('Found 1 matching file(s)');
   });
 
+  it('matches CLI-style grep_search result summaries', () => {
+    expect(
+      getToolResultSummary(
+        tool({
+          toolName: 'grep_search',
+          rawOutput: 'src/a.ts:1:TODO\nsrc/b.ts:2:TODO\n',
+        }),
+      ),
+    ).toBe('2 result(s)');
+  });
+
+  it('keeps grep_search returnDisplay summaries unchanged', () => {
+    expect(
+      getToolResultSummary(
+        tool({
+          toolName: 'grep_search',
+          rawOutput: 'Found 2 matches',
+        }),
+      ),
+    ).toBe('Found 2 matches');
+
+    expect(
+      getToolResultSummary(
+        tool({
+          toolName: 'grep_search',
+          rawOutput: 'Found 1 match',
+        }),
+      ),
+    ).toBe('Found 1 match');
+  });
+
+  it('keeps truncated grep_search returnDisplay summaries unchanged', () => {
+    expect(
+      getToolResultSummary(
+        tool({
+          toolName: 'grep_search',
+          rawOutput: 'Found 12 matches (truncated)',
+        }),
+      ),
+    ).toBe('Found 12 matches (truncated)');
+  });
+
+  it('keeps empty grep_search returnDisplay summaries unchanged', () => {
+    expect(
+      getToolResultSummary(
+        tool({
+          toolName: 'grep_search',
+          rawOutput: 'No matches found',
+        }),
+      ),
+    ).toBe('No matches found');
+  });
+
+  it('prefers grep_search returnDisplay when content is also present', () => {
+    expect(
+      getToolResultSummary(
+        tool({
+          toolName: 'grep_search',
+          rawOutput: 'Found 2 matches',
+          content: [
+            {
+              type: 'content',
+              content: {
+                type: 'text',
+                text: 'Found 2 matches for pattern "TODO" in path "./":\n---\nsrc/a.ts:1:TODO\nsrc/b.ts:2:TODO',
+              },
+            },
+          ],
+        }),
+      ),
+    ).toBe('Found 2 matches');
+  });
+
+  it('prefers empty grep_search returnDisplay when content is also present', () => {
+    expect(
+      getToolResultSummary(
+        tool({
+          toolName: 'grep_search',
+          rawOutput: 'No matches found',
+          content: [
+            {
+              type: 'content',
+              content: {
+                type: 'text',
+                text: 'No matches found for pattern "TODO" in path "./".',
+              },
+            },
+          ],
+        }),
+      ),
+    ).toBe('No matches found');
+  });
+
   it('matches CLI-style shell fallback descriptions', () => {
     expect(
       getToolDescription(

--- a/packages/web-shell/client/components/messages/toolFormatting.ts
+++ b/packages/web-shell/client/components/messages/toolFormatting.ts
@@ -102,10 +102,17 @@ export function extractText(tool: ACPToolCall): string | null {
 export function getToolResultSummary(tool: ACPToolCall): string {
   if (tool.status !== 'completed' && tool.status !== 'failed') return '';
 
+  const name = tool.toolName.toLowerCase();
+  if (name === 'grep_search' || name === 'grep' || name === 'search') {
+    const rawSummary = parseGrepSummary(
+      (extractRawOutputText(tool.rawOutput) ?? '').trim(),
+    );
+    if (rawSummary) return rawSummary;
+  }
+
   const text = extractText(tool);
   if (!text) return '';
 
-  const name = tool.toolName.toLowerCase();
   const lines = text.split('\n');
   const lineCount = lines.length;
 
@@ -129,7 +136,10 @@ export function getToolResultSummary(tool: ACPToolCall): string {
     return truncateText(firstLine, 80);
   }
 
-  if (name === 'grep' || name === 'search') {
+  if (name === 'grep_search' || name === 'grep' || name === 'search') {
+    const summary = parseGrepSummary(text.trim());
+    if (summary) return summary;
+
     const matchCount = lines.filter((l) => l.trim()).length;
     return `${matchCount} result(s)`;
   }
@@ -184,6 +194,12 @@ function getDescriptionFromTitle(
   }
 
   return formatDescriptionPaths(title, workspaceCwd);
+}
+
+function parseGrepSummary(text: string): string | null {
+  if (text === 'No matches found') return text;
+  if (/^Found \d+ match(?:es)?(?: \(truncated\))?$/.test(text)) return text;
+  return null;
 }
 
 function getDescriptionFromArgs(


### PR DESCRIPTION
## What this PR does

Updates the web-shell tool result summary logic so `grep_search` uses the same non-empty-line result count as `grep` and `search`.

## Why it's needed

`grep_search` is already treated as a grep-style tool when formatting descriptions, but completed results fell through to the generic first-line summary. Multi-line grep_search output now shows `N result(s)` consistently with the other grep aliases.

## Reviewer Test Plan

### How to verify

Run the tool formatting test and confirm `grep_search` raw output with two non-empty lines is summarized as `2 result(s)`.

### Evidence (Before & After)

N/A. This is formatter behavior covered by unit tests.

### Tested on

| OS | Status |
| :-- | :-- |
| macOS | tested |
| Windows | not tested locally |
| Linux | not tested locally |

### Environment (optional)

Local npm workspace tests on macOS. `npm run build --workspace=packages/web-shell` was attempted, but the local build is currently blocked by generated dependency dist ordering outside this diff (`@qwen-code/webui/daemon-react-sdk` / `@qwen-code/sdk/daemon` export mismatch). The touched formatter test and eslint checks pass.

## Risk & Scope

- Main risk or tradeoff: low; this only adds the existing `grep_search` wire name to an existing grep-style summary branch.
- Not validated / out of scope: full web-shell build in this checkout due unrelated generated dist mismatch; CI should validate a clean environment.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5293

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

更新 web-shell 的工具结果摘要逻辑，让 `grep_search` 和 `grep`、`search` 一样按非空行数显示结果数量。

## 为什么需要

`grep_search` 在描述格式化里已经被当成 grep 类工具处理，但完成后的结果摘要会落到通用的第一行摘要。多行 grep_search 输出现在会一致显示为 `N result(s)`。

## Reviewer Test Plan

### 如何验证

运行 tool formatting 测试，确认两行非空 `grep_search` raw output 会被摘要为 `2 result(s)`。

### Evidence (Before & After)

N/A。这是单元测试覆盖的格式化行为。

### Tested on

| OS | Status |
| :-- | :-- |
| macOS | tested |
| Windows | not tested locally |
| Linux | not tested locally |

### Environment (optional)

macOS 本地 npm workspace 测试。尝试过 `npm run build --workspace=packages/web-shell`，但当前 checkout 的本地 build 被本 diff 外的生成依赖 dist 顺序问题挡住了（`@qwen-code/webui/daemon-react-sdk` / `@qwen-code/sdk/daemon` export mismatch）。本次触及的 formatter 测试和 eslint 检查均通过。

## Risk & Scope

- Main risk or tradeoff: 风险低；只是把已有 `grep_search` wire name 加入现有 grep 类结果摘要分支。
- Not validated / out of scope: 这个 checkout 里完整 web-shell build 被无关生成 dist mismatch 阻塞；CI 会在干净环境验证。
- Breaking changes / migration notes: 无。

## Linked Issues

Fixes #5293

</details>