### PR TITLE
fix(core): skip sleep inhibitor in headless ssh

### DIFF
--- a/packages/core/src/services/sleepInhibitor.test.ts
+++ b/packages/core/src/services/sleepInhibitor.test.ts
@@ -26,7 +26,10 @@ function createChild(pid: number | undefined = 4242): ChildProcess {
   return child;
 }
 
-function createHarness(platform: NodeJS.Platform = 'linux') {
+function createHarness(
+  platform: NodeJS.Platform = 'linux',
+  env: NodeJS.ProcessEnv = {},
+) {
   const children: ChildProcess[] = [];
   const spawn = vi.fn(
     (_command: string, _args: string[], _options?: SpawnOptions) => {
@@ -39,7 +42,7 @@ function createHarness(platform: NodeJS.Platform = 'linux') {
     debug: vi.fn(),
     warn: vi.fn(),
   };
-  const inhibitor = new SleepInhibitor({ platform, spawn, logger });
+  const inhibitor = new SleepInhibitor({ platform, env, spawn, logger });
   return { children, inhibitor, logger, spawn };
 }
 
@@ -79,27 +82,71 @@ describe('SleepInhibitor', () => {
     expect(inhibitor.isRunning()).toBe(false);
   });
 
-  it('forwards a curated environment instead of an empty env', () => {
+  it('skips systemd-inhibit for headless SSH sessions on Linux', () => {
+    const { inhibitor, logger, spawn } = createHarness('linux', {
+      SSH_CONNECTION: '10.0.0.1 55555 10.0.0.2 22',
+    });
+
+    const first = inhibitor.acquire('working over SSH');
+    const second = inhibitor.acquire('more SSH work');
+
+    expect(spawn).not.toHaveBeenCalled();
+    expect(inhibitor.isRunning()).toBe(false);
+    expect(inhibitor.getActiveCount()).toBe(2);
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Sleep inhibition skipped for headless SSH session.',
+    );
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+
+    first.release();
+    second.release();
+    expect(inhibitor.getActiveCount()).toBe(0);
+  });
+
+  it('starts systemd-inhibit for SSH sessions with a display server', () => {
+    const { inhibitor, spawn } = createHarness('linux', {
+      SSH_TTY: '/dev/pts/3',
+      DISPLAY: ':10',
+    });
+
+    const handle = inhibitor.acquire('forwarded display work');
+
+    expect(spawn).toHaveBeenCalledWith(
+      'systemd-inhibit',
+      expect.arrayContaining(['--what=sleep']),
+      expect.any(Object),
+    );
+    handle.release();
+  });
+
+  it('starts systemd-inhibit for local headless Linux sessions', () => {
     const { inhibitor, spawn } = createHarness('linux');
-    const previous = process.env['DBUS_SESSION_BUS_ADDRESS'];
-    process.env['DBUS_SESSION_BUS_ADDRESS'] = 'unix:path=/run/user/1000/bus';
-    try {
-      const handle = inhibitor.acquire();
-      const env = spawn.mock.calls[0]![2]!.env as NodeJS.ProcessEnv;
-      // D-Bus address required by systemd-inhibit must be forwarded.
-      expect(env['DBUS_SESSION_BUS_ADDRESS']).toBe(
-        'unix:path=/run/user/1000/bus',
-      );
-      // Arbitrary parent env vars must NOT be forwarded.
-      expect(env).not.toHaveProperty('SOME_UNRELATED_SECRET');
-      handle.release();
-    } finally {
-      if (previous === undefined) {
-        delete process.env['DBUS_SESSION_BUS_ADDRESS'];
-      } else {
-        process.env['DBUS_SESSION_BUS_ADDRESS'] = previous;
-      }
-    }
+
+    const handle = inhibitor.acquire('local headless work');
+
+    expect(spawn).toHaveBeenCalledWith(
+      'systemd-inhibit',
+      expect.arrayContaining(['--what=sleep']),
+      expect.any(Object),
+    );
+    handle.release();
+  });
+
+  it('forwards a curated environment instead of an empty env', () => {
+    const { inhibitor, spawn } = createHarness('linux', {
+      DBUS_SESSION_BUS_ADDRESS: 'unix:path=/run/user/1000/bus',
+      SOME_UNRELATED_SECRET: 'secret',
+    });
+
+    const handle = inhibitor.acquire();
+    const env = spawn.mock.calls[0]![2]!.env as NodeJS.ProcessEnv;
+    // D-Bus address required by systemd-inhibit must be forwarded.
+    expect(env['DBUS_SESSION_BUS_ADDRESS']).toBe(
+      'unix:path=/run/user/1000/bus',
+    );
+    // Arbitrary parent env vars must NOT be forwarded.
+    expect(env).not.toHaveProperty('SOME_UNRELATED_SECRET');
+    handle.release();
   });
 
   it('uses caffeinate on macOS', () => {
@@ -148,6 +195,7 @@ describe('SleepInhibitor', () => {
     const logger = { debug: vi.fn(), warn: vi.fn() };
     const inhibitor = new SleepInhibitor({
       platform: 'linux',
+      env: {},
       spawn,
       logger,
     });
@@ -238,7 +286,12 @@ describe('SleepInhibitor', () => {
       return child;
     });
     const logger = { debug: vi.fn(), warn: vi.fn() };
-    const inhibitor = new SleepInhibitor({ platform: 'linux', spawn, logger });
+    const inhibitor = new SleepInhibitor({
+      platform: 'linux',
+      env: {},
+      spawn,
+      logger,
+    });
 
     const handle = inhibitor.acquire();
     expect(() => handle.release()).not.toThrow();
@@ -266,7 +319,12 @@ describe('SleepInhibitor', () => {
       return child;
     });
     const logger = { debug: vi.fn(), warn: vi.fn() };
-    const inhibitor = new SleepInhibitor({ platform: 'linux', spawn, logger });
+    const inhibitor = new SleepInhibitor({
+      platform: 'linux',
+      env: {},
+      spawn,
+      logger,
+    });
 
     const handle = inhibitor.acquire('executing tool');
     expect(spawn).toHaveBeenCalledTimes(1);

--- a/packages/core/src/services/sleepInhibitor.ts
+++ b/packages/core/src/services/sleepInhibitor.ts
@@ -21,6 +21,7 @@ export interface SleepInhibitorHandle {
 
 export interface SleepInhibitorConfig {
   platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
   spawn?: (
     command: string,
     args: string[],
@@ -34,6 +35,14 @@ const NOOP_HANDLE: SleepInhibitorHandle = {
 };
 
 const MAX_INHIBITOR_REASON_LENGTH = 120;
+const LINUX_DISPLAY_ENV_VARS = ['DISPLAY', 'WAYLAND_DISPLAY', 'MIR_SOCKET'];
+const SSH_ENV_VARS = ['SSH_CONNECTION', 'SSH_TTY', 'SSH_CLIENT'];
+
+function isHeadlessSshSession(env: NodeJS.ProcessEnv): boolean {
+  const hasSshSession = SSH_ENV_VARS.some((key) => Boolean(env[key]));
+  const hasDisplay = LINUX_DISPLAY_ENV_VARS.some((key) => Boolean(env[key]));
+  return hasSshSession && !hasDisplay;
+}
 
 /**
  * Sanitize the inhibitor reason before it is passed to `systemd-inhibit
@@ -56,11 +65,13 @@ export class SleepInhibitor {
   private child: ChildProcess | undefined;
   private spawnFailedForCurrentRun = false;
   private readonly platform: NodeJS.Platform;
+  private readonly env: NodeJS.ProcessEnv;
   private readonly spawn: NonNullable<SleepInhibitorConfig['spawn']>;
   private readonly logger: NonNullable<SleepInhibitorConfig['logger']>;
 
   constructor(config: SleepInhibitorConfig = {}) {
     this.platform = config.platform ?? defaultPlatform();
+    this.env = config.env ?? process.env;
     this.spawn =
       config.spawn ??
       ((command, args, options) => defaultSpawn(command, args, options ?? {}));
@@ -116,9 +127,7 @@ export class SleepInhibitor {
 
     const command = this.getCommand(reason);
     if (!command) {
-      this.logger.debug(
-        `Sleep inhibition is unsupported on platform ${this.platform}.`,
-      );
+      this.logger.debug(this.getUnavailableMessage());
       // Latch so we don't re-check and re-log the unsupported platform on
       // every subsequent acquire() within the same run.
       this.spawnFailedForCurrentRun = true;
@@ -196,7 +205,7 @@ export class SleepInhibitor {
     ];
     const env: NodeJS.ProcessEnv = {};
     for (const key of allowList) {
-      const value = process.env[key];
+      const value = this.env[key];
       if (value !== undefined) {
         env[key] = value;
       }
@@ -240,6 +249,9 @@ export class SleepInhibitor {
         // systemd-inhibit semantics on battery.
         return { command: 'caffeinate', args: ['-is'] };
       case 'linux':
+        if (isHeadlessSshSession(this.env)) {
+          return undefined;
+        }
         return {
           command: 'systemd-inhibit',
           args: [
@@ -266,6 +278,13 @@ export class SleepInhibitor {
       default:
         return undefined;
     }
+  }
+
+  private getUnavailableMessage(): string {
+    if (this.platform === 'linux' && isHeadlessSshSession(this.env)) {
+      return 'Sleep inhibition skipped for headless SSH session.';
+    }
+    return `Sleep inhibition is unsupported on platform ${this.platform}.`;
   }
 }
 


### PR DESCRIPTION
## What this PR does

Skips the Linux sleep inhibitor (`systemd-inhibit`) when Qwen Code is running in a headless SSH session. A session is treated as headless SSH when an SSH environment variable is present (`SSH_CONNECTION`, `SSH_TTY`, or `SSH_CLIENT`) and no display-server variable is set (`DISPLAY`, `WAYLAND_DISPLAY`, or `MIR_SOCKET`); in that case `acquire()` becomes a no-op instead of spawning `systemd-inhibit`, and a `Sleep inhibition skipped for headless SSH session.` debug message is logged.

SSH sessions that do have a display server (e.g. X11 forwarding) and local headless Linux sessions are unaffected and keep using `systemd-inhibit`. macOS (`caffeinate`) and Windows behavior is unchanged. As part of the change, the inhibitor now resolves its environment from an injectable `env` config option (defaulting to `process.env`), so both the headless-SSH detection and the existing `systemd-inhibit` env allow-list read from the same source.

## Why it's needed

When connecting over SSH to a Linux machine that has a desktop environment installed but where no DE session is logged in, launching Qwen Code caused `systemd-inhibit` to trigger a PolicyKit authentication prompt (`AUTHENTICATING FOR org.freedesktop.login1.inhibit-block-sleep`). That prompt was written directly into the TUI and consumed the input stream, leaving the TUI unable to respond to user input. The only workaround was disabling the feature in `/settings`. Skipping the inhibitor in headless SSH sessions avoids the auth prompt entirely while preserving sleep inhibition everywhere it can work without prompting.

## Reviewer Test Plan

### How to verify

Repro (before this change): SSH into a Linux host that has a desktop environment but no logged-in DE session, then start Qwen Code. Expected before: a `AUTHENTICATING FOR org.freedesktop.login1.inhibit-block-sleep` prompt appears in the TUI and the TUI stops responding to input. Observed after this change: no auth prompt; the TUI is responsive, and a `Sleep inhibition skipped for headless SSH session.` debug message is emitted instead of spawning `systemd-inhibit`.

Automated verification (commands from this PR):

- `npm run test --workspace=packages/core -- src/services/sleepInhibitor.test.ts`
- `npx eslint packages/core/src/services/sleepInhibitor.ts packages/core/src/services/sleepInhibitor.test.ts`
- `npm run typecheck --workspace=packages/core`
- `git diff --check`

The unit tests assert each branch: headless SSH skips `systemd-inhibit` (and counts active handles without spawning), SSH-with-`DISPLAY` still spawns `systemd-inhibit`, local headless Linux still spawns it, and the curated env allow-list still forwards `DBUS_SESSION_BUS_ADDRESS` while dropping unrelated vars.

### Evidence (Before & After)

N/A — non-visible logic fix; covered by the unit tests above. The user-facing effect is the absence of the PolicyKit auth prompt rather than a new TUI element.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI  |
| 🪟 Windows |  ✅ CI  |
|  🐧 Linux  |  ✅ CI  |

✅ tested · ⚠️ not tested · N/A

### Environment (optional)

Unit tests only (npm workspaces, `packages/core`).

## Risk & Scope

- Main risk or tradeoff: Low; scoped to `packages/core/src/services/sleepInhibitor.ts`. Behavior change is limited to Linux headless SSH sessions, where sleep inhibition is intentionally not attempted (the host is remote, so keeping the local machine awake is not the user's concern there).
- Not validated / out of scope: No unrelated refactors, no public API changes, no UI redesigns; macOS and Windows paths are untouched.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5281

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

当 Qwen Code 运行在无显示服务器的 SSH 会话（headless SSH）中时，跳过 Linux 的睡眠抑制器（`systemd-inhibit`）。判定为 headless SSH 的条件是：存在某个 SSH 环境变量（`SSH_CONNECTION`、`SSH_TTY` 或 `SSH_CLIENT`），且没有设置任何显示服务器变量（`DISPLAY`、`WAYLAND_DISPLAY` 或 `MIR_SOCKET`）；此时 `acquire()` 变为空操作而不再启动 `systemd-inhibit`，并记录一条 `Sleep inhibition skipped for headless SSH session.` 的 debug 日志。

带有显示服务器的 SSH 会话（例如 X11 转发）以及本地的 headless Linux 会话不受影响，仍然使用 `systemd-inhibit`。macOS（`caffeinate`）和 Windows 的行为保持不变。作为本次改动的一部分，抑制器现在通过一个可注入的 `env` 配置项来解析环境变量（默认仍为 `process.env`），因此 headless SSH 的检测和原有的 `systemd-inhibit` 环境变量白名单读取的是同一来源。

## 为什么需要它

当通过 SSH 连接到一台安装了桌面环境、但没有登入任何 DE 会话的 Linux 机器时，启动 Qwen Code 会导致 `systemd-inhibit` 触发 PolicyKit 认证提示（`AUTHENTICATING FOR org.freedesktop.login1.inhibit-block-sleep`）。该提示被直接输出到 TUI 中并占用了输入流，导致 TUI 无法响应用户输入。当时唯一的规避方法是在 `/settings` 中禁用该功能。在 headless SSH 会话中跳过抑制器可以彻底避免该认证提示，同时在所有能够无提示工作的场景下保留睡眠抑制。

## Reviewer 测试计划

### 如何验证

复现步骤（在本改动之前）：SSH 登入一台安装了桌面环境但没有登入 DE 会话的 Linux 主机，然后启动 Qwen Code。改动前的预期：TUI 中出现 `AUTHENTICATING FOR org.freedesktop.login1.inhibit-block-sleep` 提示，且 TUI 不再响应输入。本改动后的实际表现：不再出现认证提示；TUI 正常响应，并且会发出 `Sleep inhibition skipped for headless SSH session.` 的 debug 日志，而不是启动 `systemd-inhibit`。

自动化验证（本 PR 中的命令）：

- `npm run test --workspace=packages/core -- src/services/sleepInhibitor.test.ts`
- `npx eslint packages/core/src/services/sleepInhibitor.ts packages/core/src/services/sleepInhibitor.test.ts`
- `npm run typecheck --workspace=packages/core`
- `git diff --check`

单元测试覆盖了每个分支：headless SSH 跳过 `systemd-inhibit`（在不启动子进程的情况下仍对活跃句柄计数）、带 `DISPLAY` 的 SSH 仍然启动 `systemd-inhibit`、本地 headless Linux 仍然启动它，以及精选的环境变量白名单仍会转发 `DBUS_SESSION_BUS_ADDRESS` 并丢弃无关变量。

### 证据（前后对比）

N/A —— 非可见的逻辑修复；已由上述单元测试覆盖。用户可感知的效果是 PolicyKit 认证提示的消失，而不是新增某个 TUI 元素。

### 测试平台

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI  |
| 🪟 Windows |  ✅ CI  |
|  🐧 Linux  |  ✅ CI  |

✅ 已测试 · ⚠️ 未测试 · N/A

### 环境（可选）

仅单元测试（npm workspaces，`packages/core`）。

## 风险与范围

- 主要风险或权衡：低；范围限定在 `packages/core/src/services/sleepInhibitor.ts`。行为变化仅限于 Linux 的 headless SSH 会话，在这种场景下有意不再尝试睡眠抑制（主机是远端的，因此让本地机器保持唤醒并不是用户在此关心的事）。
- 未验证 / 范围之外：没有无关的重构，没有公共 API 变更，没有 UI 改版；macOS 和 Windows 路径保持不变。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #5281

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
