### PR TITLE
fix(weixin): show allowed image directories

### DIFF
--- a/packages/channels/weixin/src/send.test.ts
+++ b/packages/channels/weixin/src/send.test.ts
@@ -266,6 +266,20 @@ describe('validateImagePath', () => {
     );
   });
 
+  it('reports the allowed directories when a Windows image path is rejected', () => {
+    const imagePath = 'D:\\WorkGroup\\QwenCode\\002\\hello.png';
+    const workspaceDir = 'D:\\OtherProject';
+    mockRealpathSync.mockImplementation((p: string) => {
+      if (p.includes('hello.png')) return imagePath;
+      if (p.includes('OtherProject')) return workspaceDir;
+      return p;
+    });
+
+    expect(() => validateImagePath(imagePath, [workspaceDir])).toThrow(
+      `Image path outside allowed directories: ${imagePath}. Allowed directories: /tmp, ${workspaceDir}`,
+    );
+  });
+
   it('does not treat POSIX backslashes as directory separators', () => {
     const imagePath = '/home/user/project\\escape.png';
     mockRealpathSync.mockImplementation((p: string) => {

--- a/packages/channels/weixin/src/send.ts
+++ b/packages/channels/weixin/src/send.ts
@@ -67,6 +67,16 @@ function isInsideAllowedDir(realPath: string, allowedDir: string): boolean {
   );
 }
 
+function trimDisplayDir(dir: string): string {
+  if (/^[a-zA-Z]:[\\/]?$/.test(dir)) return dir;
+  const trimmed = dir.replace(/[\\/]+$/, '');
+  return trimmed || dir;
+}
+
+function formatAllowedImageDirs(dirs: readonly string[]): string {
+  return Array.from(new Set(dirs.map(trimDisplayDir))).join(', ');
+}
+
 /** Image magic bytes → MIME type mapping. */
 export function detectImageMime(data: Buffer): string {
   if (
@@ -148,7 +158,9 @@ export function validateImagePath(
   ];
 
   if (!ALLOWED_DIRS.some((dir) => isInsideAllowedDir(real, dir))) {
-    throw new Error(`Image path outside allowed directories: ${real}`);
+    throw new Error(
+      `Image path outside allowed directories: ${real}. Allowed directories: ${formatAllowedImageDirs(ALLOWED_DIRS)}`,
+    );
   }
 
   // Verify magic bytes match the extension (read only first 16 bytes to


### PR DESCRIPTION
## Summary

- Keep the existing Weixin image sandbox allowlist unchanged.
- Include the allowed image directories in the "outside allowed directories" error.
- Add regression coverage for a rejected Windows image path.

Refs #4441

## Test Plan

- npx vitest run --config vitest.config.ts src/send.test.ts (from packages/channels/weixin)
- npx vitest run --config vitest.config.ts (from packages/channels/weixin)
- npm run build --workspace=@qwen-code/channel-weixin
- npx eslint packages/channels/weixin/src/send.ts packages/channels/weixin/src/send.test.ts
- npx prettier --check packages/channels/weixin/src/send.ts packages/channels/weixin/src/send.test.ts
- git diff --check
- Subagent review: no blockers

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.