### PR TITLE
fix(cli): expand windows-style tilde paths

### DIFF
--- a/packages/cli/src/utils/resolvePath.test.ts
+++ b/packages/cli/src/utils/resolvePath.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { resolvePath } from './resolvePath.js';
+
+describe('resolvePath', () => {
+  it('returns an empty string unchanged', () => {
+    expect(resolvePath('')).toBe('');
+  });
+
+  it('expands bare tilde to the home directory', () => {
+    expect(resolvePath('~')).toBe(path.normalize(os.homedir()));
+  });
+
+  it('expands POSIX-style tilde paths', () => {
+    expect(resolvePath('~/schemas/input.json')).toBe(
+      path.join(os.homedir(), 'schemas', 'input.json'),
+    );
+  });
+
+  it('keeps the existing POSIX-style trailing separator behavior', () => {
+    expect(resolvePath('~/')).toBe(path.normalize(`${os.homedir()}/`));
+  });
+
+  it('expands Windows-style tilde paths', () => {
+    expect(resolvePath('~\\schemas\\input.json')).toBe(
+      path.join(os.homedir(), 'schemas', 'input.json'),
+    );
+  });
+
+  it('expands USERPROFILE references case-insensitively', () => {
+    expect(resolvePath('%USERPROFILE%\\schemas\\input.json')).toBe(
+      path.normalize(`${os.homedir()}\\schemas\\input.json`),
+    );
+  });
+
+  it('normalizes relative paths without resolving them', () => {
+    expect(resolvePath('nested/../schema.json')).toBe(
+      path.normalize('schema.json'),
+    );
+  });
+});

--- a/packages/cli/src/utils/resolvePath.ts
+++ b/packages/cli/src/utils/resolvePath.ts
@@ -16,6 +16,14 @@ export function resolvePath(p: string): string {
     expandedPath = os.homedir() + p.substring('%userprofile%'.length);
   } else if (p === '~' || p.startsWith('~/')) {
     expandedPath = os.homedir() + p.substring(1);
+  } else if (p.startsWith('~\\')) {
+    expandedPath = path.join(
+      os.homedir(),
+      ...p
+        .substring(2)
+        .split(/[/\\]+/)
+        .filter(Boolean),
+    );
   }
   return path.normalize(expandedPath);
 }


### PR DESCRIPTION
## What this PR does

Teaches the CLI path resolver (`resolvePath`) to expand Windows-style tilde paths. Previously the resolver only expanded `%USERPROFILE%…`, bare `~`, and POSIX-style `~/…` paths; a path that began with a backslash tilde such as `~\schemas\input.json` fell through unexpanded and was treated as a literal relative path, so the home directory was never substituted. The PR adds a branch for inputs starting with `~\`: it joins `os.homedir()` with the remaining segments (splitting on both `/` and `\` and dropping empty segments), so `~\schemas\input.json` now resolves to `<home>/schemas/input.json`. The existing `~/…`, bare `~`, and `%USERPROFILE%` behavior is unchanged — the new case is appended as an `else if` after the existing branches. A new unit-test file adds focused coverage for empty input, bare `~`, POSIX `~/`, the POSIX trailing-separator case, Windows `~\`, case-insensitive `%USERPROFILE%`, and relative-path normalization.

## Why it's needed

`resolvePath` is what resolves `@`-prefixed file arguments to `--json-schema` (it is called on the path portion in `packages/cli/src/config/config.ts`, the `resolveJsonSchemaArg` flow). On Windows, users naturally type tilde paths with backslashes (e.g. `--json-schema @~\schemas\input.json`). Before this change the `~\` prefix was left unexpanded, so the home directory was not substituted and the schema file would not be found at the intended location. Expanding `~\…` the same way `~/…` is already expanded makes tilde paths behave consistently for Windows users.

## Reviewer Test Plan

### How to verify

1. Apply the branch and run the unit tests:
   - `npx vitest run packages/cli/src/utils/resolvePath.test.ts packages/cli/src/config/jsonSchemaArg.test.ts`
   - `npx eslint packages/cli/src/utils/resolvePath.ts packages/cli/src/utils/resolvePath.test.ts`
   - `npx prettier --check packages/cli/src/utils/resolvePath.ts packages/cli/src/utils/resolvePath.test.ts`
   - `git diff --check`
2. Expected vs observed: `resolvePath('~\\schemas\\input.json')` returns `path.join(os.homedir(), 'schemas', 'input.json')` (home directory expanded), while `resolvePath('~/schemas/input.json')`, `resolvePath('~')`, and `%USERPROFILE%\…` continue to return exactly what they returned before. The new `resolvePath.test.ts` asserts each of these.

### Evidence (Before & After)

N/A — non-visible logic fix (a path-string resolver, no TUI surface); covered by the unit tests above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI  |
| 🪟 Windows |  ✅ CI  |
|  🐧 Linux  |  ✅ CI  |

✅ tested · ⚠️ not tested · N/A

### Environment (optional)

Unit tests only (npm workspaces); no special environment required.

## Risk & Scope

- Main risk or tradeoff: Low; scoped to `packages/cli/src/utils/resolvePath.ts`. The behavior change is limited to inputs that begin with `~\`, which previously were not expanded at all; all other inputs (`~/…`, bare `~`, `%USERPROFILE%`, relative, and absolute paths) take the same branches as before.
- Not validated / out of scope: No unrelated refactors, no public API changes, no UI changes. A pre-existing `npm run typecheck --workspace=packages/cli` failure on `upstream/main` (in `src/acp-integration/session/Session.ts` and `src/serve/server.ts`) is unrelated to this PR, which only touches `packages/cli/src/utils/resolvePath*`.
- Breaking changes / migration notes: None.

## Linked Issues

No linked issue. This PR was opened directly against the `resolvePath` resolver and does not reference or close an existing issue.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 CLI 的路径解析器 `resolvePath` 能够展开 Windows 风格的波浪号路径。此前解析器只展开 `%USERPROFILE%…`、单独的 `~` 以及 POSIX 风格的 `~/…`；以反斜杠加波浪号开头的路径（例如 `~\schemas\input.json`）会原样落空、被当作普通相对路径处理，主目录不会被替换。本 PR 为以 `~\` 开头的输入新增一个分支：把 `os.homedir()` 与剩余的路径片段拼接（同时按 `/` 和 `\` 切分并丢弃空片段），于是 `~\schemas\input.json` 现在会解析为 `<home>/schemas/input.json`。原有的 `~/…`、单独的 `~` 以及 `%USERPROFILE%` 行为保持不变——新分支是追加在已有分支之后的 `else if`。新增的单元测试文件针对空输入、单独的 `~`、POSIX 的 `~/`、POSIX 末尾分隔符的情形、Windows 的 `~\`、大小写不敏感的 `%USERPROFILE%`，以及相对路径的归一化提供了集中覆盖。

## 为什么需要

`resolvePath` 用于解析传给 `--json-schema` 的、以 `@` 开头的文件参数（在 `packages/cli/src/config/config.ts` 的 `resolveJsonSchemaArg` 流程中对路径部分调用它）。在 Windows 上，用户很自然地会用反斜杠来写波浪号路径（例如 `--json-schema @~\schemas\input.json`）。在本次修改之前，`~\` 前缀不会被展开，主目录不会被替换，于是 schema 文件无法在预期位置被找到。让 `~\…` 像现有的 `~/…` 一样被展开，可以让波浪号路径对 Windows 用户表现一致。

## 审阅者测试计划

### 如何验证

1. 应用该分支并运行单元测试：
   - `npx vitest run packages/cli/src/utils/resolvePath.test.ts packages/cli/src/config/jsonSchemaArg.test.ts`
   - `npx eslint packages/cli/src/utils/resolvePath.ts packages/cli/src/utils/resolvePath.test.ts`
   - `npx prettier --check packages/cli/src/utils/resolvePath.ts packages/cli/src/utils/resolvePath.test.ts`
   - `git diff --check`
2. 期望与实际对比：`resolvePath('~\\schemas\\input.json')` 返回 `path.join(os.homedir(), 'schemas', 'input.json')`（主目录已展开），而 `resolvePath('~/schemas/input.json')`、`resolvePath('~')` 以及 `%USERPROFILE%\…` 仍返回与改动前完全一致的结果。新增的 `resolvePath.test.ts` 对以上每一项都做了断言。

### 证据（改动前 & 改动后）

N/A——这是不可见的逻辑修复（一个路径字符串解析器，没有 TUI 界面）；由上述单元测试覆盖。

### 测试平台

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI  |
| 🪟 Windows |  ✅ CI  |
|  🐧 Linux  |  ✅ CI  |

✅ 已测试 · ⚠️ 未测试 · N/A

### 环境（可选）

仅单元测试（npm workspaces）；无需特殊环境。

## 风险与范围

- 主要风险或权衡：低；仅限于 `packages/cli/src/utils/resolvePath.ts`。行为变化仅限于以 `~\` 开头的输入——这类输入此前根本不会被展开；其它所有输入（`~/…`、单独的 `~`、`%USERPROFILE%`、相对路径与绝对路径）走的分支与之前完全相同。
- 未验证 / 范围之外：无无关的重构，无公共 API 变更，无 UI 变更。`upstream/main` 上已存在的 `npm run typecheck --workspace=packages/cli` 失败（位于 `src/acp-integration/session/Session.ts` 和 `src/serve/server.ts`）与本 PR 无关，本 PR 只改动 `packages/cli/src/utils/resolvePath*`。
- 破坏性变更 / 迁移说明：无。

## 关联的 Issue

无关联 issue。本 PR 直接针对 `resolvePath` 解析器提出，未引用或关闭任何已有 issue。

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
