### PR TITLE
fix(dingtalk): split oversized markdown lines

### DIFF
--- a/packages/channels/dingtalk/src/markdown.test.ts
+++ b/packages/channels/dingtalk/src/markdown.test.ts
@@ -78,7 +78,42 @@ describe('DingTalk markdown utilities', () => {
       const chunks = splitChunks(text);
       expect(chunks.length).toBeGreaterThan(1);
       chunks.forEach((chunk) => {
-        expect(chunk.length).toBeLessThanOrEqual(3900); // allow small overhead
+        expect(chunk.length).toBeLessThanOrEqual(3800);
+      });
+    });
+
+    it('splits a single long line', () => {
+      const text = 'a'.repeat(5000);
+      const chunks = splitChunks(text);
+      expect(chunks.length).toBe(2);
+      expect(chunks.join('')).toBe(text);
+      chunks.forEach((chunk) => {
+        expect(chunk.length).toBeLessThanOrEqual(3800);
+      });
+    });
+
+    it('preserves surrounding newlines when splitting a long line', () => {
+      const text = ['before', 'b'.repeat(5000), 'after'].join('\n');
+      const chunks = splitChunks(text);
+      expect(chunks.length).toBe(2);
+      expect(chunks.join('')).toBe(text);
+    });
+
+    it('preserves the newline when the chunk boundary falls before a long line', () => {
+      const text = 'a'.repeat(3799) + '\n' + 'b'.repeat(5000);
+      const chunks = splitChunks(text);
+      expect(chunks.join('')).toBe(text);
+      chunks.forEach((chunk) => {
+        expect(chunk.length).toBeLessThanOrEqual(3800);
+      });
+    });
+
+    it('does not add fences for long plain text with inline backticks', () => {
+      const text = 'before ``` inline ``` ' + 'x'.repeat(5000);
+      const chunks = splitChunks(text);
+      expect(chunks.join('')).toBe(text);
+      chunks.forEach((chunk) => {
+        expect(chunk.length).toBeLessThanOrEqual(3800);
       });
     });
 
@@ -103,6 +138,58 @@ describe('DingTalk markdown utilities', () => {
       // continued code block.
       expect(chunks[1]!.startsWith('```\n\n')).toBe(false);
       expect(chunks[1]!.startsWith('```\nx')).toBe(true);
+    });
+
+    it('splits a long code line while preserving fences', () => {
+      const longCode = '```\n' + 'x'.repeat(5000) + '\n```';
+      const chunks = splitChunks(longCode);
+      expect(chunks.length).toBeGreaterThan(1);
+      expect(chunks[0]!.endsWith('\n```')).toBe(true);
+      expect(chunks[1]!.startsWith('```\nx')).toBe(true);
+      chunks.forEach((chunk) => {
+        expect(chunk.length).toBeLessThanOrEqual(3800);
+      });
+    });
+
+    it('accounts for closing fence overhead when splitting code chunks', () => {
+      const longCode = '```\n' + 'x'.repeat(3793) + '\n```';
+      const chunks = splitChunks(longCode);
+      expect(chunks.length).toBeGreaterThan(1);
+      chunks.forEach((chunk) => {
+        expect(chunk.length).toBeLessThanOrEqual(3800);
+      });
+    });
+
+    it('keeps chunks within limit when a long code line ends with a fence', () => {
+      const longCode = '```\n' + 'x'.repeat(5000) + '```';
+      const chunks = splitChunks(longCode);
+      expect(chunks.length).toBeGreaterThan(1);
+      chunks.forEach((chunk) => {
+        expect(chunk.length).toBeLessThanOrEqual(3800);
+      });
+    });
+
+    it('keeps room for closing fences after a long opening fence line', () => {
+      const longCode = '```' + 'x'.repeat(3797) + '\ny\n```';
+      const chunks = splitChunks(longCode);
+      expect(chunks.length).toBeGreaterThan(1);
+      expect(chunks[0]!.endsWith('\n```')).toBe(true);
+      expect(chunks[1]!.startsWith('```\n')).toBe(true);
+      chunks.forEach((chunk) => {
+        expect(chunk.length).toBeLessThanOrEqual(3800);
+      });
+    });
+
+    it('does not split an opening fence delimiter across chunks', () => {
+      const longCode =
+        'a'.repeat(3794) + '\n```' + 'x'.repeat(100) + '\ny\n```';
+      const chunks = splitChunks(longCode);
+      expect(chunks.join('')).toBe(longCode);
+      expect(chunks[0]!.endsWith('\n`')).toBe(false);
+      expect(chunks[1]!.startsWith('\n```')).toBe(true);
+      chunks.forEach((chunk) => {
+        expect(chunk.length).toBeLessThanOrEqual(3800);
+      });
     });
   });
 

--- a/packages/channels/dingtalk/src/markdown.ts
+++ b/packages/channels/dingtalk/src/markdown.ts
@@ -91,20 +91,91 @@ export function splitChunks(text: string): string[] {
   const lines = text.split('\n');
   let inCode = false;
 
-  for (const line of lines) {
-    const fenceCount = (line.match(/```/g) || []).length;
-
-    if (buf.length + line.length + 1 > CHUNK_LIMIT && buf.length > 0) {
-      if (inCode) {
-        buf += '\n```';
-      }
-      chunks.push(buf);
-      buf = inCode ? '```' : '';
+  const flush = (keepCodeOpen = inCode) => {
+    if (keepCodeOpen) {
+      buf += '\n```';
     }
+    chunks.push(buf);
+    buf = keepCodeOpen ? '```' : '';
+  };
 
-    buf += (buf ? '\n' : '') + line;
+  const appendLine = (
+    line: string,
+    needsLineBreak: boolean,
+    closesCodeFence: boolean,
+    leavesCodeFenceOpen: boolean,
+  ) => {
+    let remaining = line;
+    let prefixPending = needsLineBreak;
+    let lineOpenedFenceInBuffer = false;
 
-    if (fenceCount % 2 === 1) {
+    while (remaining.length > 0 || prefixPending) {
+      const prefix = prefixPending ? '\n' : '';
+      const fitsAsFinalPiece =
+        remaining.length <= CHUNK_LIMIT - buf.length - prefix.length;
+      const closeFenceOverhead =
+        (inCode && !(closesCodeFence && fitsAsFinalPiece)) ||
+        (!inCode && leavesCodeFenceOpen)
+          ? '\n```'.length
+          : 0;
+      const available =
+        CHUNK_LIMIT - closeFenceOverhead - buf.length - prefix.length;
+
+      if (available <= 0) {
+        flush(inCode || lineOpenedFenceInBuffer);
+        continue;
+      }
+
+      let pieceLength = Math.min(available, remaining.length);
+      if (pieceLength < remaining.length) {
+        for (
+          let fenceStart = Math.max(0, pieceLength - 2);
+          fenceStart < pieceLength;
+          fenceStart++
+        ) {
+          if (
+            remaining.slice(fenceStart, fenceStart + 3) === '```' &&
+            pieceLength < fenceStart + 3
+          ) {
+            pieceLength = fenceStart;
+            break;
+          }
+        }
+      }
+
+      if (pieceLength === 0 && remaining.length > 0) {
+        flush(inCode || lineOpenedFenceInBuffer);
+        continue;
+      }
+
+      const piece = remaining.slice(0, pieceLength);
+      const appendedText = prefix + piece;
+      buf += appendedText;
+      remaining = remaining.slice(piece.length);
+      prefixPending = false;
+      lineOpenedFenceInBuffer ||=
+        !inCode && leavesCodeFenceOpen && appendedText.includes('```');
+
+      if (remaining.length > 0) {
+        const keepCodeOpen = inCode || lineOpenedFenceInBuffer;
+        flush(keepCodeOpen);
+        prefixPending = keepCodeOpen;
+      }
+    }
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] || '';
+    const fenceCount = (line.match(/```/g) || []).length;
+    const togglesCodeFence = fenceCount % 2 === 1;
+    appendLine(
+      line,
+      i > 0,
+      inCode && togglesCodeFence,
+      inCode !== togglesCodeFence,
+    );
+
+    if (togglesCodeFence) {
       inCode = !inCode;
     }
   }


### PR DESCRIPTION
## Summary
- Split DingTalk markdown lines that exceed the 3800 character chunk limit.
- Preserve plain-text newlines around split long lines.
- Keep code fences closed and reopened across chunk boundaries, including long code lines and fence delimiter boundary cases.

## Test Plan
- npx vitest run --config vitest.config.ts from packages/channels/dingtalk
- npm run build --workspace=@qwen-code/channel-dingtalk
- npx eslint packages/channels/dingtalk/src/markdown.ts packages/channels/dingtalk/src/markdown.test.ts
- npx prettier --check packages/channels/dingtalk/src/markdown.ts packages/channels/dingtalk/src/markdown.test.ts
- git diff --check
- subagent review: no blockers

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.