### PR TITLE
fix(cli): validate channel service pidfile

### DIFF
--- a/packages/cli/src/commands/channel/pidfile.test.ts
+++ b/packages/cli/src/commands/channel/pidfile.test.ts
@@ -79,6 +79,50 @@ describe('writeServiceInfo + readServiceInfo', () => {
     expect(filePath in fsStore).toBe(false);
   });
 
+  it('cleans up and returns null for a pidfile with pid 0', () => {
+    const filePath = getPidFilePath();
+    fsStore[filePath] = JSON.stringify({
+      pid: 0,
+      startedAt: new Date().toISOString(),
+      channels: ['telegram'],
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    process.kill = vi.fn(() => true) as any;
+
+    const info = readServiceInfo();
+
+    expect(info).toBeNull();
+    expect(process.kill).not.toHaveBeenCalled();
+    expect(filePath in fsStore).toBe(false);
+  });
+
+  it('cleans up and returns null for malformed service info', () => {
+    const filePath = getPidFilePath();
+    const invalidPidfiles = [
+      { pid: -1, startedAt: new Date().toISOString(), channels: ['telegram'] },
+      { pid: 1.5, startedAt: new Date().toISOString(), channels: ['telegram'] },
+      {
+        pid: '1234',
+        startedAt: new Date().toISOString(),
+        channels: ['telegram'],
+      },
+      { pid: 1234, startedAt: 'not-a-date', channels: ['telegram'] },
+      { pid: 1234, startedAt: new Date().toISOString(), channels: 'telegram' },
+      { pid: 1234, startedAt: new Date().toISOString(), channels: [42] },
+    ];
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    process.kill = vi.fn(() => true) as any;
+
+    for (const info of invalidPidfiles) {
+      fsStore[filePath] = JSON.stringify(info);
+      expect(readServiceInfo()).toBeNull();
+      expect(filePath in fsStore).toBe(false);
+    }
+
+    expect(process.kill).not.toHaveBeenCalled();
+  });
+
   it('cleans up and returns null for stale PID (dead process)', () => {
     // First write with alive process
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -135,6 +179,13 @@ describe('signalService', () => {
     signalService(1234);
     expect(process.kill).toHaveBeenCalledWith(1234, 'SIGTERM');
   });
+
+  it('returns false for pid 0 without sending a signal', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    process.kill = vi.fn(() => true) as any;
+    expect(signalService(0)).toBe(false);
+    expect(process.kill).not.toHaveBeenCalled();
+  });
 });
 
 describe('waitForExit', () => {
@@ -146,6 +197,16 @@ describe('waitForExit', () => {
 
     const result = await waitForExit(9999, 1000, 50);
     expect(result).toBe(true);
+  });
+
+  it('treats pid 0 as already exited without polling it', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    process.kill = vi.fn(() => true) as any;
+
+    const result = await waitForExit(0, 1000, 50);
+
+    expect(result).toBe(true);
+    expect(process.kill).not.toHaveBeenCalled();
   });
 
   it('returns true when process dies within timeout', async () => {

--- a/packages/cli/src/commands/channel/pidfile.ts
+++ b/packages/cli/src/commands/channel/pidfile.ts
@@ -18,8 +18,39 @@ function pidFilePath(): string {
   return path.join(Storage.getGlobalQwenDir(), 'channels', 'service.pid');
 }
 
+function isValidPid(pid: unknown): pid is number {
+  return typeof pid === 'number' && Number.isSafeInteger(pid) && pid > 0;
+}
+
+function isServiceInfo(value: unknown): value is ServiceInfo {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const info = value as Partial<ServiceInfo>;
+  return (
+    isValidPid(info.pid) &&
+    typeof info.startedAt === 'string' &&
+    !Number.isNaN(Date.parse(info.startedAt)) &&
+    Array.isArray(info.channels) &&
+    info.channels.every((channel) => typeof channel === 'string')
+  );
+}
+
+function unlinkPidFile(filePath: string): void {
+  try {
+    unlinkSync(filePath);
+  } catch {
+    // best-effort
+  }
+}
+
 /** Check if a process is alive. */
 function isProcessAlive(pid: number): boolean {
+  if (!isValidPid(pid)) {
+    return false;
+  }
+
   try {
     process.kill(pid, 0);
     return true;
@@ -37,30 +68,28 @@ export function readServiceInfo(): ServiceInfo | null {
   const filePath = pidFilePath();
   if (!existsSync(filePath)) return null;
 
-  let info: ServiceInfo;
+  let parsed: unknown;
   try {
-    info = JSON.parse(readFileSync(filePath, 'utf-8'));
+    parsed = JSON.parse(readFileSync(filePath, 'utf-8'));
   } catch {
     // Corrupt file — clean up
-    try {
-      unlinkSync(filePath);
-    } catch {
-      // best-effort
-    }
+    unlinkPidFile(filePath);
     return null;
   }
 
-  if (!isProcessAlive(info.pid)) {
+  if (!isServiceInfo(parsed)) {
+    // Invalid file — clean up before treating it as a running service.
+    unlinkPidFile(filePath);
+    return null;
+  }
+
+  if (!isProcessAlive(parsed.pid)) {
     // Stale PID — process is dead, clean up
-    try {
-      unlinkSync(filePath);
-    } catch {
-      // best-effort
-    }
+    unlinkPidFile(filePath);
     return null;
   }
 
-  return info;
+  return parsed;
 }
 
 /** Write PID file with current process info. */
@@ -84,11 +113,7 @@ export function writeServiceInfo(channels: string[]): void {
 export function removeServiceInfo(): void {
   const filePath = pidFilePath();
   if (existsSync(filePath)) {
-    try {
-      unlinkSync(filePath);
-    } catch {
-      // best-effort
-    }
+    unlinkPidFile(filePath);
   }
 }
 
@@ -100,6 +125,10 @@ export function signalService(
   pid: number,
   signal: NodeJS.Signals = 'SIGTERM',
 ): boolean {
+  if (!isValidPid(pid)) {
+    return false;
+  }
+
   try {
     process.kill(pid, signal);
     return true;


### PR DESCRIPTION
## What this PR does

Hardens the channel service PID-file handling so a malformed or leftover `service.pid` can no longer be mistaken for a running service or trigger a dangerous signal.

- **Validates the PID file before trusting it.** `readServiceInfo()` now parses the file as `unknown` and runs it through an `isServiceInfo` type guard: the record must be an object whose `pid` is a strictly-positive safe integer (`isValidPid`), whose `startedAt` is a parseable date string, and whose `channels` is an array of strings. Anything that fails (`pid: 0`, `pid: -1`, fractional/`NaN`/string PIDs, wrong shape, corrupt JSON) is treated as invalid.
- **Cleans up malformed files instead of probing them.** Both the corrupt-JSON path and the new invalid-shape path delete the file (via a shared `unlinkPidFile` best-effort helper) and return `null`, so an invalid PID is never passed to `process.kill`.
- **Guards the signal/probe/wait helpers.** `isProcessAlive`, `signalService`, and (transitively) `waitForExit` now reject non-positive / invalid PIDs up front: `isProcessAlive(0)` returns `false`, `signalService(0)` returns `false` without signalling, and `waitForExit(0, …)` returns `true` immediately without polling. This closes the case where `process.kill(0, sig)` would target the **caller's entire process group** (and `pid -1` every signalable process).

Net effect: a planted `pid: 0` file that previously reported `running (PID 0)` and let `qwen channel stop` signal its own process group is now cleaned up and reported as "no service running". Existing behavior for valid live PIDs, stale (dead) PIDs, and already-handled corrupt files is unchanged.

## Why it's needed

`process.kill(pid, sig)` has special POSIX semantics for non-positive PIDs: `pid 0` signals the **caller's whole process group** and `pid -1` signals **every process the user may signal**. The pre-PR code trusted whatever PID sat in `~/.qwen/channels/service.pid`. A malformed or leftover pidfile containing `pid: 0` would therefore (a) be reported as a *running* service by `qwen channel status`, and (b) make `qwen channel stop` call `process.kill(0, 'SIGTERM')` — signalling its own process group, i.e. a self-kill / local DoS. This is preventive robustness/security hardening of that path; it is not tied to a specific user-filed issue.

## Reviewer Test Plan

### How to verify

Author's verification commands (all from the original PR body — kept as-is):

- `npx vitest run packages/cli/src/commands/channel/pidfile.test.ts`
- `npx vitest run packages/cli/src/commands/channel`
- `npx eslint packages/cli/src/commands/channel/pidfile.ts packages/cli/src/commands/channel/pidfile.test.ts`
- `npx prettier --check packages/cli/src/commands/channel/pidfile.ts packages/cli/src/commands/channel/pidfile.test.ts`
- `npm run build --workspace=packages/core`
- `npm run typecheck --workspace=packages/cli`
- `git diff --check upstream/main...HEAD`

The new unit tests assert the repro directly: a `pid: 0` file is cleaned up and `readServiceInfo()` returns `null` without calling `process.kill`; a battery of malformed records (`pid: -1`, `1.5`, `"1234"`, bad `startedAt`, non-array / non-string `channels`) all clean up and return `null`; `signalService(0)` returns `false` and never signals; and `waitForExit(0, …)` resolves `true` without polling.

End-to-end (optional, POSIX): plant a `~/.qwen/channels/service.pid` with `{"pid":0,…}`, then run `qwen channel status` (expected: "No channel service is running", file removed) and `qwen channel stop` inside a contained process group (expected: no signal sent, group untouched).

### Evidence (Before & After)

N/A — non-visible logic/safety fix in the `channel` PID-file helpers; covered by the unit tests above (the new tests assert the `pid: 0` and malformed-record paths clean up and never call `process.kill`). A separate end-to-end A/B verification of the real `qwen channel status` / `stop` commands is recorded in a maintainer comment on this PR thread.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ CI |
| 🪟 Windows | ✅ CI |
|  🐧 Linux  | ✅ CI · ✅ local |

✅ tested · ⚠️ not tested · N/A

`Test (macos-latest / windows-latest / ubuntu-latest, Node 22.x)` all pass on this PR. Linux additionally has the maintainer's real-binary `qwen channel` A/B verification above (the platform where the bad signal semantics actually bite).

### Environment (optional)

Unit tests run via npm workspaces (`packages/cli`). The dangerous `kill(0|-1)` semantics are POSIX; the `isValidPid` guard is platform-agnostic.

## Risk & Scope

- **Main risk or tradeoff:** Low; scoped to `packages/cli/src/commands/channel/pidfile.ts`. The behavior change is limited to rejecting/cleaning up *invalid* pidfiles (non-positive, non-safe-integer, NaN, or wrong-shape records); valid live/stale-PID and already-handled corrupt-file paths are unchanged.
- **Not validated / out of scope:** PID **reuse** — a structurally valid but recycled PID (e.g. a stale file whose PID was reused, or `pid: 1`) is still trusted; that is a separate problem this PR does not claim to solve. No unrelated refactors, public API changes, or UI changes. `startedAt` validation is intentionally lenient (any parseable date), since `writeServiceInfo` only ever emits ISO strings.
- **Breaking changes / migration notes:** None.

## Linked Issues

No linked issue — this is a preventive robustness/security fix for the channel PID-file path; there is no corresponding open GitHub issue this PR closes.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

加固 channel 服务的 PID 文件处理，使得一个异常或残留的 `service.pid` 不再可能被误判为「正在运行的服务」，也不再可能触发危险的信号调用。

- **在信任之前校验 PID 文件。** `readServiceInfo()` 现在先把文件解析为 `unknown`，再通过 `isServiceInfo` 类型守卫：记录必须是对象，其 `pid` 为严格正的安全整数（`isValidPid`），`startedAt` 为可解析的日期字符串，`channels` 为字符串数组。任何不满足的情况（`pid: 0`、`pid: -1`、小数/`NaN`/字符串 PID、结构错误、损坏 JSON）都被视为无效。
- **对异常文件直接清理而非探测。** 损坏 JSON 路径与新增的「结构无效」路径都会删除文件（通过共享的尽力而为辅助函数 `unlinkPidFile`）并返回 `null`，因此无效 PID 永远不会被传给 `process.kill`。
- **守卫发信号/探测/等待辅助函数。** `isProcessAlive`、`signalService`、以及（间接地）`waitForExit` 现在在入口处就拒绝非正数 / 无效 PID：`isProcessAlive(0)` 返回 `false`，`signalService(0)` 不发信号直接返回 `false`，`waitForExit(0, …)` 不轮询直接返回 `true`。这堵上了 `process.kill(0, sig)` 会作用于**调用方整个进程组**（而 `pid -1` 作用于所有可发信号的进程）的口子。

最终效果：一个预置的 `pid: 0` 文件，之前会被报告为 `running (PID 0)` 并让 `qwen channel stop` 向自己的进程组发信号，现在会被清理并报告为「无服务运行」。对有效存活 PID、陈旧（已死）PID、以及原本已处理的损坏文件，行为保持不变。

## 为什么需要

`process.kill(pid, sig)` 对非正数 PID 有特殊的 POSIX 语义：`pid 0` 会向**调用方的整个进程组**发信号，`pid -1` 会向**该用户能发信号的所有进程**发信号。PR 之前的代码无条件信任 `~/.qwen/channels/service.pid` 里的 PID。因此一个含 `pid: 0` 的异常或残留 pidfile 会：(a) 被 `qwen channel status` 报告为*正在运行*的服务；(b) 让 `qwen channel stop` 调用 `process.kill(0, 'SIGTERM')`——向自己的进程组发信号，即自杀式 / 本地 DoS。这是对该路径的预防性健壮性/安全加固，并非针对某个用户提交的 issue。

## 审查者测试计划

### 如何验证

作者的验证命令（全部来自原始 PR 描述，原样保留）：

- `npx vitest run packages/cli/src/commands/channel/pidfile.test.ts`
- `npx vitest run packages/cli/src/commands/channel`
- `npx eslint packages/cli/src/commands/channel/pidfile.ts packages/cli/src/commands/channel/pidfile.test.ts`
- `npx prettier --check packages/cli/src/commands/channel/pidfile.ts packages/cli/src/commands/channel/pidfile.test.ts`
- `npm run build --workspace=packages/core`
- `npm run typecheck --workspace=packages/cli`
- `git diff --check upstream/main...HEAD`

新增的单元测试直接验证了复现：`pid: 0` 的文件被清理、`readServiceInfo()` 返回 `null` 且未调用 `process.kill`；一批异常记录（`pid: -1`、`1.5`、`"1234"`、错误的 `startedAt`、非数组 / 非字符串 `channels`）全部被清理并返回 `null`；`signalService(0)` 返回 `false` 且从不发信号；`waitForExit(0, …)` 不轮询直接 resolve 为 `true`。

端到端（可选，POSIX）：预置一个 `{"pid":0,…}` 的 `~/.qwen/channels/service.pid`，然后运行 `qwen channel status`（预期：「No channel service is running」，文件被删除）以及在受控进程组里运行 `qwen channel stop`（预期：不发信号，进程组不受影响）。

### 证据（前 & 后）

N/A —— `channel` PID 文件辅助函数中的非可见逻辑/安全修复，由上述单元测试覆盖（新增测试断言 `pid: 0` 与异常记录路径会被清理且从不调用 `process.kill`）。针对真实 `qwen channel status` / `stop` 命令的端到端 A/B 验证记录在本 PR 讨论串的一条维护者评论中。

### 测试平台

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ CI |
| 🪟 Windows | ✅ CI |
|  🐧 Linux  | ✅ CI · ✅ 本地 |

✅ 已测试 · ⚠️ 未测试 · N/A

本 PR 的 `Test (macos-latest / windows-latest / ubuntu-latest, Node 22.x)` 全部通过。Linux 另有上述维护者的真实二进制 `qwen channel` A/B 验证（这恰恰是危险信号语义会真正触发的平台）。

### 环境（可选）

单元测试通过 npm workspaces（`packages/cli`）运行。危险的 `kill(0|-1)` 语义属于 POSIX；`isValidPid` 守卫与平台无关。

## 风险与范围

- **主要风险或权衡：** 低；范围限于 `packages/cli/src/commands/channel/pidfile.ts`。行为变化仅限于拒绝/清理*无效*的 pidfile（非正数、非安全整数、NaN 或结构错误的记录）；有效存活/陈旧 PID 以及原本已处理的损坏文件路径不变。
- **未验证 / 范围外：** PID **复用**——一个结构有效但被复用的 PID（例如残留文件的 PID 已被复用，或 `pid: 1`）仍会被信任；那是本 PR 不声称解决的另一类问题。无无关重构、公共 API 变更或 UI 变更。`startedAt` 校验有意保持宽松（任何可解析的日期），因为 `writeServiceInfo` 只会写 ISO 字符串。
- **破坏性变更 / 迁移说明：** 无。

## 关联 Issue

无关联 issue——这是对 channel PID 文件路径的预防性健壮性/安全修复，没有对应的开放 GitHub issue 被本 PR 关闭。

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
