### PR TITLE
fix(cli): import extension channels via file urls

### DIFF
--- a/packages/cli/src/commands/channel/start.test.ts
+++ b/packages/cli/src/commands/channel/start.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const mockSetGlobalDispatcher = vi.hoisted(() => vi.fn());
 const mockProxyAgent = vi.hoisted(() =>
@@ -84,7 +86,11 @@ vi.mock('@qwen-code/channel-base', () => ({
   SessionRouter: mockSessionRouter,
 }));
 
-import { resolveProxy, startCommand } from './start.js';
+import {
+  resolveExtensionChannelEntrySpecifier,
+  resolveProxy,
+  startCommand,
+} from './start.js';
 
 type StartCommandArgs = Parameters<NonNullable<typeof startCommand.handler>>[0];
 
@@ -165,6 +171,17 @@ describe('resolveProxy', () => {
 
     expect(proxy).toBe('http://env.example.com:8080');
     expect(mockProxyAgent).toHaveBeenCalledWith('http://env.example.com:8080');
+  });
+});
+
+describe('resolveExtensionChannelEntrySpecifier', () => {
+  it('returns a file URL for extension channel entry paths', () => {
+    const extensionPath = join('/tmp', 'qwen extension');
+    const entry = join('dist', 'channel.js');
+
+    expect(resolveExtensionChannelEntrySpecifier(extensionPath, entry)).toBe(
+      pathToFileURL(join(extensionPath, entry)).href,
+    );
   });
 });
 

--- a/packages/cli/src/commands/channel/start.ts
+++ b/packages/cli/src/commands/channel/start.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import type { CommandModule } from 'yargs';
 import { ProxyAgent, setGlobalDispatcher } from 'undici';
 import { normalizeProxyUrl, Storage } from '@qwen-code/qwen-code-core';
@@ -64,6 +65,13 @@ function loadChannelsConfig(): Record<string, unknown> {
   return channels || {};
 }
 
+export function resolveExtensionChannelEntrySpecifier(
+  extensionPath: string,
+  entry: string,
+): string {
+  return pathToFileURL(path.join(extensionPath, entry)).href;
+}
+
 /**
  * Load channel plugins from active extensions.
  * Extensions declare channels in their qwen-extension.json manifest.
@@ -85,9 +93,12 @@ async function loadChannelsFromExtensions(): Promise<number> {
           continue;
         }
 
-        const entryPath = path.join(ext.path, channelDef.entry);
+        const entrySpecifier = resolveExtensionChannelEntrySpecifier(
+          ext.path,
+          channelDef.entry,
+        );
         try {
-          const module = (await import(entryPath)) as {
+          const module = (await import(entrySpecifier)) as {
             plugin?: ChannelPlugin;
           };
           const plugin = module.plugin;


### PR DESCRIPTION
## Summary
- Resolve extension channel entry paths to file URL specifiers before dynamic import.
- Keep manifest entries relative to the extension root.
- Add coverage for file URL specifier generation with paths that need URL encoding.

## Test Plan
- npx vitest run packages/cli/src/commands/channel/start.test.ts
- npx vitest run packages/cli/src/commands/channel
- npx eslint packages/cli/src/commands/channel/start.ts packages/cli/src/commands/channel/start.test.ts
- npx prettier --check packages/cli/src/commands/channel/start.ts packages/cli/src/commands/channel/start.test.ts
- npm run typecheck --workspace=packages/cli
- git diff --check
- subagent review: no blockers

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.