### PR TITLE
fix(cli): avoid agent composer unmount reset

### DIFF
--- a/packages/cli/src/ui/components/agent-view/AgentComposer.test.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentComposer.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render } from 'ink-testing-library';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AgentStatus } from '@qwen-code/qwen-code-core';
+import {
+  useAgentViewActions,
+  useAgentViewState,
+} from '../../contexts/AgentViewContext.js';
+import { useConfig } from '../../contexts/ConfigContext.js';
+import { useAgentStreamingState } from '../../hooks/useAgentStreamingState.js';
+import { useKeypress } from '../../hooks/useKeypress.js';
+import { usePreferredEditor } from '../../hooks/usePreferredEditor.js';
+import { useTerminalSize } from '../../hooks/useTerminalSize.js';
+import { StreamingState } from '../../types.js';
+import { useTextBuffer } from '../shared/text-buffer.js';
+import { AgentComposer } from './AgentComposer.js';
+
+vi.mock('../../contexts/AgentViewContext.js');
+vi.mock('../../contexts/ConfigContext.js');
+vi.mock('../../hooks/useAgentStreamingState.js');
+vi.mock('../../hooks/useKeypress.js');
+vi.mock('../../hooks/usePreferredEditor.js');
+vi.mock('../../hooks/useTerminalSize.js');
+vi.mock('../shared/text-buffer.js');
+vi.mock('../BaseTextInput.js', () => ({ BaseTextInput: () => null }));
+vi.mock('../LoadingIndicator.js', () => ({ LoadingIndicator: () => null }));
+vi.mock('../QueuedMessageDisplay.js', () => ({
+  QueuedMessageDisplay: () => null,
+}));
+vi.mock('./AgentFooter.js', () => ({ AgentFooter: () => null }));
+
+describe('AgentComposer', () => {
+  const setAgentInputBufferText = vi.fn();
+  const setAgentTabBarFocused = vi.fn();
+  const setAgentApprovalMode = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(useAgentViewState).mockReturnValue({
+      activeView: 'agent-1',
+      agents: new Map([
+        [
+          'agent-1',
+          {
+            modelId: 'qwen',
+            color: 'cyan',
+            interactiveAgent: {
+              cancelCurrentRound: vi.fn(),
+              enqueueMessage: vi.fn(),
+              getError: vi.fn(),
+              getLastRoundError: vi.fn(),
+            },
+          },
+        ],
+      ]),
+      agentShellFocused: false,
+      agentInputBufferText: '',
+      agentTabBarFocused: false,
+      agentApprovalModes: new Map(),
+    } as never);
+    vi.mocked(useAgentViewActions).mockReturnValue({
+      setAgentInputBufferText,
+      setAgentTabBarFocused,
+      setAgentApprovalMode,
+    } as never);
+    vi.mocked(useConfig).mockReturnValue({
+      getContentGeneratorConfig: () => undefined,
+    } as never);
+    vi.mocked(usePreferredEditor).mockReturnValue(undefined);
+    vi.mocked(useTerminalSize).mockReturnValue({ columns: 80, rows: 24 });
+    vi.mocked(useKeypress).mockImplementation(() => {});
+    vi.mocked(useAgentStreamingState).mockReturnValue({
+      status: AgentStatus.IDLE,
+      streamingState: StreamingState.Idle,
+      isInputActive: true,
+      elapsedTime: 0,
+      lastPromptTokenCount: 0,
+    } as never);
+    vi.mocked(useTextBuffer).mockReturnValue({
+      text: 'draft',
+      allVisualLines: ['draft'],
+      visualCursor: [0, 5],
+    } as never);
+  });
+
+  it('does not reset the parent input-buffer state during unmount', () => {
+    const { unmount } = render(<AgentComposer agentId="agent-1" />);
+
+    expect(setAgentInputBufferText).toHaveBeenCalledWith('draft');
+    setAgentInputBufferText.mockClear();
+
+    unmount();
+
+    expect(setAgentInputBufferText).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/ui/components/agent-view/AgentComposer.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentComposer.tsx
@@ -133,10 +133,9 @@ export const AgentComposer: React.FC<AgentComposerProps> = ({ agentId }) => {
     preferredEditor,
   });
 
-  // Sync agent buffer text to context so AgentTabBar can guard tab switching
+  // Sync the active agent buffer text to context.
   useEffect(() => {
     setAgentInputBufferText(buffer.text);
-    return () => setAgentInputBufferText('');
   }, [buffer.text, setAgentInputBufferText]);
 
   // When agent input is not active (agent running, completed, etc.),

--- a/packages/cli/src/ui/contexts/AgentViewContext.tsx
+++ b/packages/cli/src/ui/contexts/AgentViewContext.tsx
@@ -48,7 +48,7 @@ export interface AgentViewState {
   agents: ReadonlyMap<string, RegisteredAgent>;
   /** Whether any agent tab's embedded shell currently has input focus. */
   agentShellFocused: boolean;
-  /** Current text in the active agent tab's input buffer (empty when on main). */
+  /** Last synced text from the active agent tab's input buffer. */
   agentInputBufferText: string;
   /** Whether the tab bar has keyboard focus (vs the agent input). */
   agentTabBarFocused: boolean;


### PR DESCRIPTION
## What this PR does

Removes the `useEffect` cleanup in `AgentComposer` that reset the parent `AgentViewContext` input-buffer state (`setAgentInputBufferText('')`) when the composer unmounted. The component keeps syncing the active agent's buffer text to context on mount and on every update (`setAgentInputBufferText(buffer.text)`); only the unmount-time reset is dropped. Because that reset is gone, `agentInputBufferText` is now a "last-synced" value rather than something guaranteed to be cleared on unmount, so the field's doc comment in `AgentViewContext.tsx` is updated to say "Last synced text from the active agent tab's input buffer." A unit test is added asserting that unmounting `AgentComposer` does not call the parent input-buffer setter.

The change is deliberately narrower than the closed PR #5228: it does not touch `InputPrompt.tsx`, so the existing #4171 tab-consumer cleanup stays in place.

## Why it's needed

Issue #5199 reports a crash with minified React error #185 ("Cannot update a component while rendering a different component"). The stack trace shows the failure originating from `commitHookEffectListUnmount` → `dispatchSetState`: a child component's `useEffect` cleanup was calling `setState` on a parent context provider that was unmounting in the same commit phase. `AgentComposer`'s cleanup did exactly that — it called `setAgentInputBufferText('')` on the parent `AgentViewContext` during unmount — which could surface the React #185 error and crash the render. Removing the cleanup eliminates the parent-setState-during-unmount path. The buffer text is internal plumbing (used to coordinate agent-tab state, not directly rendered), so dropping the forced reset on unmount has no functional downside.

## Reviewer Test Plan

### How to verify

Repro (from the issue): the crash occurs when an `AgentComposer` unmounts while its parent `AgentViewContext` provider is unmounting in the same React commit (e.g. tearing down the agent view), producing React error #185.

- Expected before: unmounting the composer can trigger React error #185 (the cleanup calls `setAgentInputBufferText('')` on the unmounting parent context).
- Expected after: unmount no longer calls the parent setter, so the React #185 path is gone. The added test (`does not reset the parent input-buffer state during unmount`) renders `AgentComposer`, then unmounts it and asserts `setAgentInputBufferText` is not called during unmount.

Verification commands (run by the author):

- `npx vitest run packages/cli/src/ui/components/agent-view/AgentComposer.test.tsx`
- `npx vitest run packages/cli/src/ui/components/agent-view`
- `npx vitest run packages/cli/src/ui/components/InputPrompt.test.tsx -t "onTabConsumerChange reporting"`
- `npx eslint packages/cli/src/ui/components/agent-view/AgentComposer.tsx packages/cli/src/ui/components/agent-view/AgentComposer.test.tsx packages/cli/src/ui/contexts/AgentViewContext.tsx`
- `npx prettier --check packages/cli/src/ui/components/agent-view/AgentComposer.tsx packages/cli/src/ui/components/agent-view/AgentComposer.test.tsx packages/cli/src/ui/contexts/AgentViewContext.tsx`
- `npm run build --workspace=packages/core`
- `npm run build --workspace=packages/acp-bridge`
- `npm run typecheck --workspace=packages/cli`
- `git diff --check upstream/main...HEAD`

### Evidence (Before & After)

This is a crash fix, not a layout/widget change. The user-observable effect is a render crash, not a visible UI element: `agentInputBufferText` is internal state used to coordinate agent-tab behavior and is not text drawn on screen.

- Before: unmounting the agent composer while the parent `AgentViewContext` unmounts in the same commit could throw minified React error #185 and crash the render (see the stack trace in #5199).
- After: the unmount-time parent `setState` is removed, so that crash path no longer exists; the regression is locked in by the new unit test.

No screenshot was captured: the symptom is an intermittent React-internal crash (error #185 overlay/stack trace) triggered by a specific unmount-ordering commit, not a deterministic on-screen state, so a meaningful Before/After screenshot could not be reliably reproduced. The behavior is instead covered by the added unit test.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI |
| 🪟 Windows |  ✅ CI |
|  🐧 Linux  |  ✅ CI |

✅ tested · ⚠️ not tested · N/A

### Environment (optional)

Unit tests only (npm workspaces). No special environment required.

## Risk & Scope

- Main risk or tradeoff: Low; scoped to `AgentComposer` and a doc comment in `AgentViewContext`. The only behavior change is that the active agent's input-buffer text is no longer force-cleared in context on composer unmount (it retains its last-synced value).
- Not validated / out of scope: No changes to `InputPrompt.tsx` (the #4171 tab-consumer cleanup is intentionally preserved). No unrelated refactors, public API changes, or UI redesigns.
- Breaking changes / migration notes: None.

## Linked Issues

Refs #5199

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

移除了 `AgentComposer` 中的 `useEffect` 清理逻辑——该逻辑在组件卸载（unmount）时会重置父级 `AgentViewContext` 的输入缓冲状态（调用 `setAgentInputBufferText('')`）。组件仍然会在挂载时以及每次更新时把当前 active agent 的缓冲文本同步到 context（`setAgentInputBufferText(buffer.text)`），仅去掉了卸载时的那次重置。由于不再重置，`agentInputBufferText` 现在是一个"最近一次同步的值"，而不是"卸载后保证被清空"的值，因此同步更新了 `AgentViewContext.tsx` 中该字段的文档注释为"Last synced text from the active agent tab's input buffer."（active agent tab 输入缓冲的最近同步文本）。同时新增了一个单元测试，断言卸载 `AgentComposer` 时不会再调用父级的输入缓冲 setter。

此改动有意比已关闭的 PR #5228 更小：它不触碰 `InputPrompt.tsx`，因此现有的 #4171 tab-consumer 清理逻辑保持原样。

## 为什么需要它

Issue #5199 报告了一个崩溃，错误为压缩后的 React error #185（"Cannot update a component while rendering a different component"，无法在渲染另一个组件时更新当前组件）。堆栈显示该错误源自 `commitHookEffectListUnmount` → `dispatchSetState`：即一个子组件的 `useEffect` 清理函数，在同一个 commit 阶段对正在卸载的父级 context provider 调用了 `setState`。`AgentComposer` 的清理逻辑正是如此——它在卸载时对父级 `AgentViewContext` 调用了 `setAgentInputBufferText('')`——这会触发 React #185 错误并导致渲染崩溃。移除该清理逻辑就消除了"卸载期间对父级 setState"的路径。缓冲文本属于内部状态（用于协调 agent tab 的行为，并非直接渲染到界面上的文本），因此去掉卸载时的强制重置不会带来功能上的副作用。

## Reviewer Test Plan（审阅者测试计划）

### 如何验证

复现（来自 issue）：当 `AgentComposer` 在与其父级 `AgentViewContext` provider 处于同一个 React commit 阶段一起卸载时（例如销毁 agent 视图），会出现崩溃，报 React error #185。

- 修复前预期：卸载 composer 可能触发 React error #185（清理逻辑对正在卸载的父级 context 调用 `setAgentInputBufferText('')`）。
- 修复后预期：卸载时不再调用父级 setter，因此 React #185 路径消失。新增测试（`does not reset the parent input-buffer state during unmount`）会渲染 `AgentComposer`，再将其卸载，并断言卸载期间不会调用 `setAgentInputBufferText`。

验证命令（由作者执行）：

- `npx vitest run packages/cli/src/ui/components/agent-view/AgentComposer.test.tsx`
- `npx vitest run packages/cli/src/ui/components/agent-view`
- `npx vitest run packages/cli/src/ui/components/InputPrompt.test.tsx -t "onTabConsumerChange reporting"`
- `npx eslint packages/cli/src/ui/components/agent-view/AgentComposer.tsx packages/cli/src/ui/components/agent-view/AgentComposer.test.tsx packages/cli/src/ui/contexts/AgentViewContext.tsx`
- `npx prettier --check packages/cli/src/ui/components/agent-view/AgentComposer.tsx packages/cli/src/ui/components/agent-view/AgentComposer.test.tsx packages/cli/src/ui/contexts/AgentViewContext.tsx`
- `npm run build --workspace=packages/core`
- `npm run build --workspace=packages/acp-bridge`
- `npm run typecheck --workspace=packages/cli`
- `git diff --check upstream/main...HEAD`

### Evidence（修复前后对比）

这是一个崩溃修复，而非布局/控件改动。用户可观察到的是渲染崩溃，而不是某个可见的界面元素：`agentInputBufferText` 是用于协调 agent tab 行为的内部状态，并不会作为文本绘制到屏幕上。

- 修复前：当 agent composer 与父级 `AgentViewContext` 在同一个 commit 阶段一起卸载时，可能抛出压缩版 React error #185 并导致渲染崩溃（见 #5199 中的堆栈）。
- 修复后：卸载时对父级的 `setState` 被移除，因此该崩溃路径不复存在；并由新增的单元测试锁定该回归。

未提供截图：该症状是一个由特定卸载时序的 commit 触发的、间歇性的 React 内部崩溃（error #185 的报错/堆栈），而非确定性的屏幕状态，因此无法稳定复现出有意义的前后对比截图。改为通过新增单元测试来覆盖该行为。

### Tested on（已测试平台）

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI |
| 🪟 Windows |  ✅ CI |
|  🐧 Linux  |  ✅ CI |

✅ 已测试 · ⚠️ 未测试 · N/A

### Environment（环境，可选）

仅单元测试（npm workspaces）。无需特殊环境。

## Risk & Scope（风险与范围）

- 主要风险或权衡：低；范围限定在 `AgentComposer` 以及 `AgentViewContext` 中的一处文档注释。唯一的行为变化是：composer 卸载时不再强制清空 context 中 active agent 的输入缓冲文本（它会保留最近一次同步的值）。
- 未验证 / 范围之外：未改动 `InputPrompt.tsx`（有意保留 #4171 的 tab-consumer 清理逻辑）。没有无关的重构、公共 API 改动或 UI 重新设计。
- 破坏性变更 / 迁移说明：无。

## Linked Issues（关联 issue）

Refs #5199

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
