### PR TITLE
fix(cli): reject malformed terminal sequences

### DIFF
--- a/packages/cli/src/utils/terminalSequence.test.ts
+++ b/packages/cli/src/utils/terminalSequence.test.ts
@@ -114,6 +114,12 @@ describe('parseAllowedTerminalSequences', () => {
     it('rejects OSC with no numeric code', () => {
       expect(parseAllowedTerminalSequences('\x1b];hello\x07')).toBeNull();
     });
+
+    it('rejects OSC when the code is not followed by a separator', () => {
+      expect(parseAllowedTerminalSequences('\x1b]9oops\x07')).toBeNull();
+      expect(parseAllowedTerminalSequences('\x1b]9\x07')).toBeNull();
+      expect(parseAllowedTerminalSequences('\x1b]9\x1b\\')).toBeNull();
+    });
   });
 });
 

--- a/packages/cli/src/utils/terminalSequence.ts
+++ b/packages/cli/src/utils/terminalSequence.ts
@@ -85,9 +85,8 @@ function parseOscSequence(input: string, start: number): OscParseResult | null {
   const oscCode = Number(codeStr);
   if (!ALLOWED_OSC_CODES.has(oscCode)) return null;
 
-  // After the code, expect ';' or a terminator
-  // (OSC 0/1/2 can have just a title with ';')
-  if (position >= input.length) return null;
+  // After the code, require ';' before the payload.
+  if (position >= input.length || input[position] !== ';') return null;
 
   // Read until terminator: BEL or ST (ESC \)
   // The ';' after code is part of payload


### PR DESCRIPTION
## What this PR does

Tightens the `terminalSequence` OSC parser so it rejects malformed input where the numeric OSC code is not immediately followed by a `;` separator. Previously, after reading the numeric code the parser began scanning for a terminator straight away, so an input like `ESC]9oopsBEL` was accepted as a valid OSC 9 sequence (with `oops` mistaken for the payload and `BEL` as the terminator). The parser now requires a `;` after the code before the payload; inputs such as `ESC]9oopsBEL`, `ESC]9BEL`, and `ESC]9ESC\` are rejected.

The allowed OSC code list (0, 1, 2, 9, 99, 777) is unchanged — this only tightens the boundary between the numeric code and the payload.

## Why it's needed

The parser's own documentation states the expected shape is `ESC ] <code> ; <payload> <terminator>` and that the code should be followed by `;` or a terminator. But it accepted OSC input where the numeric code was followed by arbitrary text, so a malformed sequence like `ESC]9oopsBEL` was passed through to the terminal as an allowed OSC 9 notification instead of being rejected. This fix makes the parser enforce the documented shape, in line with its "reject invalid input entirely — no partial stripping" policy.

## Reviewer Test Plan

### How to verify

Repro (before this change): a hook-provided `terminalSequence` such as `ESC]9oopsBEL` was parsed as a valid OSC 9 sequence and emitted to the terminal. Expected: it should be rejected (parser returns `null`). Observed after the fix: the malformed sequence is rejected, while well-formed sequences (e.g. `ESC]9;hiBEL`) continue to parse.

Verification commands (from `packages/cli`):

- `npx vitest run src/utils/terminalSequence.test.ts`
- `npm run typecheck --workspace=packages/cli`
- `npm run lint -- --fix packages/cli/src/utils/terminalSequence.ts packages/cli/src/utils/terminalSequence.test.ts`
- `npx prettier --check packages/cli/src/utils/terminalSequence.ts packages/cli/src/utils/terminalSequence.test.ts`
- `git diff --check`

### Evidence (Before & After)

N/A — non-visible logic fix; covered by the unit tests above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI  |
| 🪟 Windows |  ✅ CI  |
|  🐧 Linux  |  ✅ CI  |

✅ tested · ⚠️ not tested · N/A

### Environment (optional)

Unit tests only (npm workspaces).

## Risk & Scope

- Main risk or tradeoff: Low; scoped to the OSC code/payload boundary check in `parseOscSequence`. The only behavior change is that OSC codes not followed by `;` are now rejected.
- Not validated / out of scope: No changes to the allowed OSC code list, no unrelated refactors, no public API changes, no UI changes.
- Breaking changes / migration notes: None. Previously-accepted malformed sequences (code not followed by `;`) are now rejected, which is the intended bug fix.

## Linked Issues

Fixes #5304

<details>
<summary>中文说明</summary>

## 此 PR 的作用

收紧 `terminalSequence` 的 OSC 解析器，使其拒绝数字 OSC 代码后面没有紧跟 `;` 分隔符的非法输入。此前解析器读取完数字代码后会立即开始扫描终止符，因此像 `ESC]9oopsBEL` 这样的输入会被当作合法的 OSC 9 序列接受（`oops` 被误当作 payload，`BEL` 被当作终止符）。现在解析器要求代码之后、payload 之前必须有 `;`；诸如 `ESC]9oopsBEL`、`ESC]9BEL`、`ESC]9ESC\` 等输入都会被拒绝。

允许的 OSC 代码列表（0、1、2、9、99、777）保持不变——本次改动只收紧数字代码与 payload 之间的边界。

## 为什么需要

解析器自身的文档说明期望的形态是 `ESC ] <code> ; <payload> <terminator>`，并说明代码后应跟随 `;` 或终止符。但它却接受了数字代码后跟随任意文本的 OSC 输入，因此像 `ESC]9oopsBEL` 这样的非法序列会作为合法的 OSC 9 通知被透传到终端，而不是被拒绝。此修复让解析器强制遵循其文档化的形态，符合其"完全拒绝非法输入——不做部分剥离"的策略。

## 审查者测试计划

### 如何验证

复现（改动前）：像 `ESC]9oopsBEL` 这样的钩子提供的 `terminalSequence` 会被解析为合法的 OSC 9 序列并发送到终端。预期：应被拒绝（解析器返回 `null`）。修复后观察到：非法序列被拒绝，而格式正确的序列（例如 `ESC]9;hiBEL`）仍能正常解析。

验证命令（在 `packages/cli` 下执行）：

- `npx vitest run src/utils/terminalSequence.test.ts`
- `npm run typecheck --workspace=packages/cli`
- `npm run lint -- --fix packages/cli/src/utils/terminalSequence.ts packages/cli/src/utils/terminalSequence.test.ts`
- `npx prettier --check packages/cli/src/utils/terminalSequence.ts packages/cli/src/utils/terminalSequence.test.ts`
- `git diff --check`

### 证据（修改前后对比）

不适用 —— 这是非可视的逻辑修复；已由上述单元测试覆盖。

### 测试平台

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI  |
| 🪟 Windows |  ✅ CI  |
|  🐧 Linux  |  ✅ CI  |

✅ 已测试 · ⚠️ 未测试 · 不适用

### 环境（可选）

仅单元测试（npm workspaces）。

## 风险与范围

- 主要风险或权衡：低；范围限定在 `parseOscSequence` 中 OSC 代码/payload 的边界检查。唯一的行为变化是：代码后未跟 `;` 的 OSC 现在会被拒绝。
- 未验证 / 范围之外：未改动允许的 OSC 代码列表，无无关重构，无公共 API 变更，无 UI 变更。
- 破坏性变更 / 迁移说明：无。此前被接受的非法序列（代码后未跟 `;`）现在会被拒绝，这正是预期的 bug 修复。

## 关联 Issue

Fixes #5304

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
