### PR TITLE
fix(cli): reject malformed OSC rgb colors

### DIFF
--- a/packages/cli/src/ui/themes/detect-terminal-theme.test.ts
+++ b/packages/cli/src/ui/themes/detect-terminal-theme.test.ts
@@ -62,6 +62,7 @@ describe('detectTerminalTheme', () => {
 
     it('should return undefined for invalid data', async () => {
       expect(parseOscRgb('garbage')).toBeUndefined();
+      expect(parseOscRgb('rgb:0000/0000/0000junk')).toBeUndefined();
       expect(parseOscRgb('')).toBeUndefined();
     });
   });

--- a/packages/cli/src/ui/themes/detect-terminal-theme.ts
+++ b/packages/cli/src/ui/themes/detect-terminal-theme.ts
@@ -44,7 +44,7 @@ function hexComponent(hex: string): number {
 export function parseOscRgb(data: string): Rgb | undefined {
   // rgb:R/G/B
   const rgbMatch =
-    /^rgba?:([0-9a-f]{1,4})\/([0-9a-f]{1,4})\/([0-9a-f]{1,4})/i.exec(data);
+    /^rgba?:([0-9a-f]{1,4})\/([0-9a-f]{1,4})\/([0-9a-f]{1,4})$/i.exec(data);
   if (rgbMatch) {
     return {
       r: hexComponent(rgbMatch[1]!),


### PR DESCRIPTION
## Summary

Fixes #5306.

Tighten OSC 11 `rgb:` color parsing so it rejects trailing junk after the third component. The `#...` branch already requires a full-string match, and the documented `rgb:RRRR/GGGG/BBBB` format should behave the same way.

## Test plan

- `npx vitest run src/ui/themes/detect-terminal-theme.test.ts` from `packages/cli`
- `npm run typecheck --workspace=packages/cli`
- `npm run lint -- --fix packages/cli/src/ui/themes/detect-terminal-theme.ts packages/cli/src/ui/themes/detect-terminal-theme.test.ts`
- `npx prettier --check packages/cli/src/ui/themes/detect-terminal-theme.ts packages/cli/src/ui/themes/detect-terminal-theme.test.ts`
- `git diff --check`

## Demo

N/A — parser-only bug fix.

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
