### PR TITLE
fix(core): reject invalid cron task entries

### DIFF
--- a/packages/core/src/services/cronTasksFile.test.ts
+++ b/packages/core/src/services/cronTasksFile.test.ts
@@ -105,17 +105,14 @@ describe('cronTasksFile', () => {
       await expect(readCronTasks(tmpDir)).rejects.toThrow(/JSON array/);
     });
 
-    it('filters out invalid entries', async () => {
+    it('throws for invalid task entries', async () => {
       const data = [
         makeTask(),
         { id: 'bad', missing: 'fields' },
         makeTask({ id: 'good2' }),
       ];
       await seedTasksFile(tmpDir, JSON.stringify(data));
-      const result = await readCronTasks(tmpDir);
-      expect(result).toHaveLength(2);
-      expect(result[0]!.id).toBe('test001');
-      expect(result[1]!.id).toBe('good2');
+      await expect(readCronTasks(tmpDir)).rejects.toThrow(/Invalid task entry/);
     });
 
     it('reads valid tasks', async () => {
@@ -271,6 +268,20 @@ describe('cronTasksFile', () => {
       ).rejects.toThrow(/Malformed JSON/);
       // The corrupted (hand-recoverable) content survives untouched.
       expect(await fs.readFile(filePath, 'utf-8')).toBe('NOT JSON{{{');
+    });
+
+    it('refuses to clobber a file with invalid task entries', async () => {
+      const filePath = getCronFilePath(tmpDir);
+      const raw = JSON.stringify([makeTask(), { id: 'bad' }]);
+      await seedTasksFile(tmpDir, raw);
+
+      await expect(
+        updateCronTasks(tmpDir, (tasks) => [
+          ...tasks,
+          makeTask({ id: 'new-task' }),
+        ]),
+      ).rejects.toThrow(/Invalid task entry/);
+      expect(await fs.readFile(filePath, 'utf-8')).toBe(raw);
     });
 
     it('does not displace a fresh lock created after the stale inspection', async () => {

--- a/packages/core/src/services/cronTasksFile.ts
+++ b/packages/core/src/services/cronTasksFile.ts
@@ -13,11 +13,8 @@ import * as path from 'node:path';
 import { Mutex } from 'async-mutex';
 
 import { atomicWriteJSON } from '../utils/atomicFileWrite.js';
-import { createDebugLogger } from '../utils/debugLogger.js';
 import { getProjectHash } from '../utils/paths.js';
 import { Storage } from '../config/storage.js';
-
-const debugLogger = createDebugLogger('CRON_TASKS_FILE');
 
 export interface DurableCronTask {
   id: string;
@@ -105,21 +102,14 @@ export async function readCronTasks(
       `Expected a JSON array in ${filePath} — fix or delete the file; refusing to treat it as an empty schedule.`,
     );
   }
-  const valid = parsed.filter(isValidTask);
-  // A single malformed entry in an otherwise-valid array is dropped here,
-  // and the next update persists the filtered list — silently losing what
-  // the user hand-edited. Can't carry unknown shapes through the typed
-  // pipeline yet (tracked as follow-up), so at least surface the drop.
-  if (valid.length !== parsed.length) {
-    debugLogger.warn(
-      `Dropped ${parsed.length - valid.length} invalid task entr${
-        parsed.length - valid.length === 1 ? 'y' : 'ies'
-      } from ${filePath}; a later write will persist without ${
-        parsed.length - valid.length === 1 ? 'it' : 'them'
-      }.`,
-    );
+  for (const [index, task] of parsed.entries()) {
+    if (!isValidTask(task)) {
+      throw new Error(
+        `Invalid task entry at index ${index} in ${filePath} — fix or delete the entry; refusing to drop it from the schedule.`,
+      );
+    }
   }
-  return valid;
+  return parsed;
 }
 
 export async function writeCronTasks(


### PR DESCRIPTION
## What this PR does

Makes durable cron task reads fail closed when `scheduled_tasks.json` contains an invalid task entry inside an otherwise-valid array. Previously `readCronTasks()` ran `parsed.filter(isValidTask)`, silently dropping malformed entries and only emitting a debug warning; a later `updateCronTasks()` would then persist the filtered list and permanently delete the dropped entry. The function now iterates over every parsed entry and throws an error (`Invalid task entry at index <n> in <file> — fix or delete the entry; refusing to drop it from the schedule.`) on the first invalid one, returning the array unchanged when all entries are valid. This aligns invalid-entry handling with the existing behavior for malformed JSON and non-array JSON: surface the corruption and refuse to write through it. The now-unused debug logger is removed.

## Why it's needed

`readCronTasks()` filtering invalid entries out of `scheduled_tasks.json` meant a subsequent `updateCronTasks()` call could write the filtered list back and permanently delete a malformed (but recoverable, user-hand-edited) entry. Malformed JSON and non-array files already fail closed to avoid clobbering recoverable user data; arrays with invalid task entries should behave the same so users do not silently lose data on the next write.

## Reviewer Test Plan

### How to verify

Repro: seed `scheduled_tasks.json` with an array containing one invalid task entry alongside valid ones, then call `readCronTasks()` / `updateCronTasks()`.

- Expected before: the invalid entry is silently filtered out, and the next `updateCronTasks()` persists the truncated list, losing the entry.
- Observed after: `readCronTasks()` rejects with `/Invalid task entry/`, and `updateCronTasks()` refuses to write — the on-disk file is left byte-for-byte unchanged.

Verification commands (run from `packages/core` unless noted):

- `npx vitest run src/services/cronTasksFile.test.ts`
- `npm run typecheck --workspace=packages/core`
- `npm run build --workspace=packages/core`
- `npm run lint -- --fix packages/core/src/services/cronTasksFile.ts packages/core/src/services/cronTasksFile.test.ts`
- `npx prettier --check packages/core/src/services/cronTasksFile.ts packages/core/src/services/cronTasksFile.test.ts`
- `git diff --check`

### Evidence (Before & After)

N/A — non-visible storage-validation logic fix; covered by the unit tests above (a read that now throws on invalid entries, plus an update that refuses to clobber the file and asserts the on-disk bytes are unchanged).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI  |
| 🪟 Windows |  ✅ CI  |
|  🐧 Linux  |  ✅ CI  |

✅ tested · ⚠️ not tested · N/A

### Environment (optional)

Unit tests only (npm workspaces); no special environment required.

## Risk & Scope

- Main risk or tradeoff: Low; scoped to `packages/core/src/services/cronTasksFile.ts`. Behavior change is limited to reads of `scheduled_tasks.json` that contain invalid task entries — these now throw instead of being silently filtered. Files with malformed JSON or non-array JSON already threw, and fully-valid arrays are unaffected.
- Not validated / out of scope: No unrelated refactors, no public API changes, no UI changes. Carrying unknown/invalid task shapes through the typed pipeline (auto-recovery) remains a follow-up and is not attempted here.
- Breaking changes / migration notes: None. (A caller that previously relied on silent filtering of corrupt entries will now see an error surfaced instead, by design.)

## Linked Issues

Fixes #5308

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让持久化的 cron 任务读取在 `scheduled_tasks.json` 的合法数组中包含非法任务条目时「快速失败、拒绝继续」。此前 `readCronTasks()` 执行 `parsed.filter(isValidTask)`，会静默丢弃非法条目，仅打印一条 debug 警告；随后的 `updateCronTasks()` 会把过滤后的列表写回磁盘，从而永久删除被丢弃的条目。现在该函数会遍历每一个解析出的条目，遇到第一个非法条目就抛出错误（`Invalid task entry at index <n> in <file> — fix or delete the entry; refusing to drop it from the schedule.`），当所有条目都合法时则原样返回数组。这样就让「非法条目」的处理与现有的「非法 JSON」「非数组 JSON」处理保持一致：暴露损坏、拒绝写穿。同时移除了已不再使用的 debug logger。

## 为什么需要它

`readCronTasks()` 过滤掉 `scheduled_tasks.json` 中的非法条目，意味着随后的一次 `updateCronTasks()` 调用会把过滤后的列表写回，从而永久删除一个非法（但可恢复、由用户手工编辑的）条目。非法 JSON 和非数组文件已经会快速失败以避免覆盖可恢复的用户数据；包含非法任务条目的数组也应当采取相同行为，使用户不会在下一次写入时悄无声息地丢失数据。

## 评审者测试计划

### 如何验证

复现：在 `scheduled_tasks.json` 中写入一个数组，包含一个非法任务条目以及若干合法条目，然后调用 `readCronTasks()` / `updateCronTasks()`。

- 修复前的预期：非法条目被静默过滤掉，下一次 `updateCronTasks()` 会持久化被截断的列表，导致该条目丢失。
- 修复后的观察：`readCronTasks()` 以 `/Invalid task entry/` 拒绝，`updateCronTasks()` 拒绝写入——磁盘上的文件逐字节保持不变。

验证命令（除特别说明外，均在 `packages/core` 目录下执行）：

- `npx vitest run src/services/cronTasksFile.test.ts`
- `npm run typecheck --workspace=packages/core`
- `npm run build --workspace=packages/core`
- `npm run lint -- --fix packages/core/src/services/cronTasksFile.ts packages/core/src/services/cronTasksFile.test.ts`
- `npx prettier --check packages/core/src/services/cronTasksFile.ts packages/core/src/services/cronTasksFile.test.ts`
- `git diff --check`

### 证据（前后对比）

N/A —— 非用户可见的存储校验逻辑修复；已由上述单元测试覆盖（一个在遇到非法条目时会抛错的读取测试，外加一个拒绝覆盖文件并断言磁盘字节保持不变的更新测试）。

### 测试平台

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI  |
| 🪟 Windows |  ✅ CI  |
|  🐧 Linux  |  ✅ CI  |

✅ 已测试 · ⚠️ 未测试 · N/A

### 环境（可选）

仅单元测试（npm workspaces）；无需特殊环境。

## 风险与范围

- 主要风险或取舍：低；范围限定在 `packages/core/src/services/cronTasksFile.ts`。行为变化仅限于读取包含非法任务条目的 `scheduled_tasks.json`——这些情况现在会抛错，而非被静默过滤。非法 JSON 或非数组 JSON 的文件本来就会抛错，完全合法的数组不受影响。
- 未验证 / 范围之外：没有无关重构，没有公共 API 变更，没有 UI 变更。把未知/非法的任务形状贯穿类型化管线（自动恢复）仍是后续工作，本 PR 不做尝试。
- 破坏性变更 / 迁移说明：无。（此前依赖静默过滤损坏条目的调用方，现在会按设计看到抛出的错误。）

## 关联 Issue

Fixes #5308

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
