### PR TITLE
feat(core): auto-reveal exit_plan_mode tool when entering plan mode

### DIFF
--- a/packages/core/src/tools/enterPlanMode.ts
+++ b/packages/core/src/tools/enterPlanMode.ts
@@ -96,6 +96,38 @@ class EnterPlanModeToolInvocation extends BaseToolInvocation<
       };
     }
 
+    // Reveal the exit_plan_mode deferred tool so the model can call it
+    // directly without needing to search for it first. This mirrors the
+    // pattern in ToolSearch's select: path (reveal + setTools sync).
+    try {
+      const registry = this.config.getToolRegistry();
+      const exitPlanModeName = ToolNames.EXIT_PLAN_MODE;
+      const revealedBefore = registry.isDeferredToolRevealed(exitPlanModeName);
+      if (!revealedBefore) {
+        registry.revealDeferredTool(exitPlanModeName);
+        const geminiClient = this.config.getGeminiClient();
+        if (geminiClient) {
+          try {
+            await geminiClient.setTools();
+          } catch (setErr) {
+            // Rollback the reveal on setTools failure so the registry
+            // stays consistent with the chat's declaration list.
+            registry.unrevealDeferredTool(exitPlanModeName);
+            debugLogger.error(
+              `[EnterPlanModeTool] Failed to sync exit_plan_mode tool declaration: ${setErr instanceof Error ? setErr.message : String(setErr)}`,
+            );
+          }
+        }
+      }
+    } catch (error) {
+      // Non-fatal: log the failure but still return success for
+      // entering plan mode. The model can use ToolSearch to find
+      // exit_plan_mode if the reveal failed.
+      debugLogger.warn(
+        `[EnterPlanModeTool] Failed to reveal exit_plan_mode: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
     return {
       llmContent:
         'Plan mode is now active. Continue with read-only investigation, ask the user when needed, and use exit_plan_mode when the plan is ready.',


### PR DESCRIPTION
## What this PR does

When the model calls `enter_plan_mode`, this PR automatically reveals the `exit_plan_mode` deferred tool so the model can invoke it without needing to search for it first. The implementation mirrors the existing pattern in `ToolSearch`'s select path: reveal the deferred tool, sync the tool declaration set via `setTools()`, and roll back the reveal if the sync fails to keep the registry consistent with the chat's declaration list.

## Why it's needed

Currently, after entering plan mode, the model must call `ToolSearch` to discover `exit_plan_mode` before it can transition back to implementation. This adds an unnecessary round-trip. The reveal-on-enter pattern eliminates that friction while preserving correctness through the rollback-on-failure guard.

## Reviewer Test Plan

### How to verify

1. Start a session and enter plan mode (`/plan` or have the model call `enter_plan_mode`).
2. Observe that `exit_plan_mode` appears in the available tool set without the model calling `ToolSearch`.
3. Confirm plan mode exit works correctly by calling `exit_plan_mode`.
4. Optionally: simulate a `setTools` failure by injecting a network error after reveal, verify the reveal is rolled back and the model can still use `ToolSearch` as fallback.

### Evidence (Before & After)

N/A (non-UI, tool registry internal change).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   ✅   |

- Linux: container build + typecheck + lint + esbuild all pass.
- Windows: standalone build + smoke test pass.

## Risk & Scope

- Main risk or tradeoff: `setTools()` is an async IPC round-trip; if it fails, the reveal is rolled back so the model can still discover `exit_plan_mode` via `ToolSearch`. No hard dependency introduced.
- Not validated / out of scope: macOS not tested (no darwin environment available).
- Breaking changes / migration notes: None. This is a purely additive change to an existing tool invocation.

## Linked Issues

N/A (self-discovered improvement, not from an upstream issue).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当模型调用 `enter_plan_mode` 进入计划模式时，自动揭示 `exit_plan_mode` 延迟工具，使模型无需先调用 `ToolSearch` 即可直接退出计划模式。实现方式与 `ToolSearch` 的选择路径一致：揭示延迟工具 → 通过 `setTools()` 同步工具声明 → 同步失败时回滚揭示，保持注册表与聊天声明列表一致。

## 为什么需要

当前进入计划模式后，模型必须先调用 `ToolSearch` 才能发现 `exit_plan_mode`，多了一轮不必要的往返。进入时自动揭示消除了这个摩擦，同时通过回滚保护保证正确性。

## 审查者测试计划

### 验证方法

1. 启动会话，进入计划模式（`/plan` 或让模型调用 `enter_plan_mode`）。
2. 观察 `exit_plan_mode` 出现在可用工具列表中，无需模型调用 `ToolSearch`。
3. 确认调用 `exit_plan_mode` 能正确退出计划模式。
4. 可选：在揭示后注入网络错误模拟 `setTools` 失败，验证揭示被回滚，模型仍可通过 `ToolSearch` 作为回退方案。

### 测试环境

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS    |  ⚠️  |
| 🪟 Windows   |  ✅  |
|  🐧 Linux    |  ✅  |

- Linux：容器内 typecheck + lint + esbuild 全部通过。
- Windows：standalone 构建 + 冒烟测试通过。

## 风险与范围

- 主要风险：`setTools()` 是异步 IPC 往返；失败时揭示被回滚，模型仍可通过 `ToolSearch` 发现 `exit_plan_mode`。无硬依赖。
- 未验证：macOS（无可用的 darwin 环境）。
- 破坏性变更：无。纯增量修改。

## 关联 Issue

无（本地自行挖掘的改进，非来自上游 Issue）。

</details>
