### PR TITLE
fix(core): preserve invalid schema length strings

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -4186,6 +4186,38 @@ describe('OpenAIContentConverter', () => {
       });
     });
 
+    it('should not truncate non-integer length constraints', () => {
+      const params = {
+        type: 'object',
+        properties: {
+          text: {
+            type: 'string',
+            minLength: '1.5',
+            maxLength: '   ',
+          },
+          items: {
+            type: 'array',
+            minItems: '10px',
+            maxItems: '1.5',
+          },
+        },
+      };
+
+      const result = converter.convertGeminiToolParametersToOpenAI(params);
+      const properties = result?.['properties'] as Record<string, unknown>;
+
+      expect(properties?.['text']).toEqual({
+        type: 'string',
+        minLength: '1.5',
+        maxLength: '   ',
+      });
+      expect(properties?.['items']).toEqual({
+        type: 'array',
+        minItems: '10px',
+        maxItems: '1.5',
+      });
+    });
+
     it('should handle nested objects', () => {
       const params = {
         type: 'object',

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -285,8 +285,13 @@ export function convertGeminiToolParametersToOpenAI(
         key === 'maxItems'
       ) {
         // Ensure length constraints are integers, not strings
-        if (typeof value === 'string' && !isNaN(Number(value))) {
-          result[key] = parseInt(value, 10);
+        const numberValue = typeof value === 'string' ? Number(value) : NaN;
+        if (
+          typeof value === 'string' &&
+          value.trim() !== '' &&
+          Number.isInteger(numberValue)
+        ) {
+          result[key] = numberValue;
         } else {
           result[key] = value;
         }


### PR DESCRIPTION
## What this PR does

Tightens the OpenAI schema conversion in `convertGeminiToolParametersToOpenAI` for the string-valued length/item constraints `minLength`, `maxLength`, `minItems`, and `maxItems`. These fields are now only coerced from a string to a number when the string is non-empty (after trimming) and represents an actual integer. The conversion uses the parsed `Number(...)` value directly instead of `parseInt(...)`.

Previously the guard accepted any string that satisfied `!isNaN(Number(value))` and then wrote `parseInt(value, 10)`, so a value like `"1.5"` passed the check and was silently truncated to `1` (and a whitespace-only string like `"   "` coerced to `0`). With this change, such non-integer strings are left untouched and the original value is preserved.

Numeric constraints such as `minimum`, `maximum`, and `multipleOf` are not affected by this change.

## Why it's needed

`convertGeminiToolParametersToOpenAI()` checked `Number(value)` but then converted with `parseInt(value, 10)`. A value such as `"1.5"` passes the numeric check but is written as `1`, silently changing the schema. Length and item constraints should only be converted when the string represents an integer; otherwise the original value must be preserved rather than truncated. See issue #5310.

## Reviewer Test Plan

### How to verify

Repro: pass a tool parameter schema where a length/item constraint is a non-integer string (e.g. `minLength: "1.5"`, `maxLength: "   "`, `minItems: "10px"`, `maxItems: "1.5"`) through `convertGeminiToolParametersToOpenAI`.

- Expected (after fix): the non-integer / non-numeric / whitespace strings are preserved verbatim instead of being truncated to `1`/`0`. Valid integer strings still convert to numbers.
- Observed (before fix): `"1.5"` was silently written as `1`.

Verification commands (run from `packages/core` unless noted):

- `npx vitest run src/core/openaiContentGenerator/converter.test.ts -t "convertGeminiToolParametersToOpenAI"`
- `npx vitest run src/core/openaiContentGenerator/converter.test.ts`
- `npm run typecheck --workspace=packages/core`
- `npm run build --workspace=packages/core`
- `npm run lint -- --fix packages/core/src/core/openaiContentGenerator/converter.ts packages/core/src/core/openaiContentGenerator/converter.test.ts`
- `npx prettier --check packages/core/src/core/openaiContentGenerator/converter.ts packages/core/src/core/openaiContentGenerator/converter.test.ts`
- `git diff --check`

### Evidence (Before & After)

N/A — non-visible logic fix; covered by the unit tests above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI |
| 🪟 Windows |  ✅ CI |
|  🐧 Linux  |  ✅ CI |

✅ tested · ⚠️ not tested · N/A

### Environment (optional)

Unit tests only (npm workspaces).

## Risk & Scope

- Main risk or tradeoff: Low; scoped to the length/item constraint branch of `convertGeminiToolParametersToOpenAI` in `packages/core`. Behavior change is limited to how string-valued `minLength`/`maxLength`/`minItems`/`maxItems` are handled (non-integer strings are now preserved instead of truncated).
- Not validated / out of scope: No unrelated refactors, no public API changes, no changes to numeric constraints (`minimum`/`maximum`/`multipleOf`), no UI changes.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5310

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

收紧了 `convertGeminiToolParametersToOpenAI` 中对字符串型长度/数量约束 `minLength`、`maxLength`、`minItems`、`maxItems` 的转换逻辑。现在只有当字符串在去除首尾空白后非空、且表示一个真正的整数时，才会把它从字符串转换为数字；转换时直接使用解析得到的 `Number(...)` 值，而不再使用 `parseInt(...)`。

此前的判断条件接受任何满足 `!isNaN(Number(value))` 的字符串，然后写入 `parseInt(value, 10)`，因此像 `"1.5"` 这样的值能通过检查并被静默截断为 `1`（而像 `"   "` 这样的纯空白字符串会被转换为 `0`）。改动之后，这类非整数字符串保持不变，原始值得以保留。

`minimum`、`maximum`、`multipleOf` 等数值约束不受此改动影响。

## 为什么需要它

`convertGeminiToolParametersToOpenAI()` 先检查 `Number(value)`，却用 `parseInt(value, 10)` 进行转换。像 `"1.5"` 这样的值能通过数值检查，但会被写成 `1`，从而静默地改变了 schema。长度和数量约束只应在字符串表示整数时才转换；否则必须保留原始值，而不是截断它。详见 issue #5310。

## 评审者测试计划

### 如何验证

复现：构造一个工具参数 schema，其中长度/数量约束为非整数字符串（例如 `minLength: "1.5"`、`maxLength: "   "`、`minItems: "10px"`、`maxItems: "1.5"`），传入 `convertGeminiToolParametersToOpenAI`。

- 预期（修复后）：非整数 / 非数值 / 纯空白字符串原样保留，而不再被截断为 `1`/`0`。合法的整数字符串仍会转换为数字。
- 实际（修复前）：`"1.5"` 被静默写成 `1`。

验证命令（除非另有说明，均在 `packages/core` 目录下执行）：

- `npx vitest run src/core/openaiContentGenerator/converter.test.ts -t "convertGeminiToolParametersToOpenAI"`
- `npx vitest run src/core/openaiContentGenerator/converter.test.ts`
- `npm run typecheck --workspace=packages/core`
- `npm run build --workspace=packages/core`
- `npm run lint -- --fix packages/core/src/core/openaiContentGenerator/converter.ts packages/core/src/core/openaiContentGenerator/converter.test.ts`
- `npx prettier --check packages/core/src/core/openaiContentGenerator/converter.ts packages/core/src/core/openaiContentGenerator/converter.test.ts`
- `git diff --check`

### 证据（前后对比）

N/A — 这是不可见的逻辑修复；已由上述单元测试覆盖。

### 测试平台

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI |
| 🪟 Windows |  ✅ CI |
|  🐧 Linux  |  ✅ CI |

✅ 已测试 · ⚠️ 未测试 · N/A

### 环境（可选）

仅单元测试（npm workspaces）。

## 风险与范围

- 主要风险或取舍：低；改动范围限于 `packages/core` 中 `convertGeminiToolParametersToOpenAI` 的长度/数量约束分支。行为变更仅限于字符串型 `minLength`/`maxLength`/`minItems`/`maxItems` 的处理方式（非整数字符串现在会被保留而非截断）。
- 未验证 / 范围之外：没有无关的重构，没有公共 API 变更，没有改动数值约束（`minimum`/`maximum`/`multipleOf`），没有 UI 变更。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #5310

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
