### PR TITLE
fix(cli): bound streaming thought render buffers

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -3323,6 +3323,81 @@ describe('useGeminiStream', () => {
       });
     });
 
+    it('splits oversized streamed thoughts so the pending item stays bounded', async () => {
+      vi.useFakeTimers();
+
+      const splitLimit = 16_384;
+      const tailLength = 123;
+      const longThought = 'a'.repeat(splitLimit * 2 + tailLength);
+      vi.mocked(findLastSafeSplitPoint).mockImplementation(
+        (s: string, max?: number) =>
+          max !== undefined && s.length > max ? max : s.length,
+      );
+
+      let releaseStream!: () => void;
+      const holdStream = new Promise<void>((resolve) => {
+        releaseStream = resolve;
+      });
+
+      const mockStream = (async function* () {
+        yield {
+          type: ServerGeminiEventType.Thought,
+          value: { description: longThought },
+        };
+        await holdStream;
+      })();
+      mockSendMessageStream.mockReturnValue(mockStream);
+
+      const { result } = renderTestHook();
+
+      act(() => {
+        void result.current.submitQuery('test query');
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(60);
+      });
+
+      const thoughtItems = mockAddItem.mock.calls
+        .map(([item]) => item as HistoryItem)
+        .filter(
+          (item) =>
+            item.type === 'gemini_thought' ||
+            item.type === 'gemini_thought_content',
+        );
+      expect(thoughtItems).toEqual([
+        expect.objectContaining({
+          type: 'gemini_thought',
+          text: 'a'.repeat(splitLimit),
+          durationMs: expect.any(Number),
+        }),
+        expect.objectContaining({
+          type: 'gemini_thought_content',
+          text: 'a'.repeat(splitLimit),
+        }),
+      ]);
+      expect(result.current.pendingHistoryItems).toEqual([
+        expect.objectContaining({
+          type: 'gemini_thought_content',
+          text: 'a'.repeat(tailLength),
+        }),
+      ]);
+      expect(result.current.thought?.description).toHaveLength(4_096);
+
+      act(() => {
+        result.current.cancelOngoingRequest();
+      });
+
+      await act(async () => {
+        releaseStream();
+      });
+    });
+
     it('does not render leading blank thought chunks as an empty thought item', async () => {
       vi.useFakeTimers();
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -282,6 +282,8 @@ const EDIT_TOOL_NAMES = new Set([
   ToolNames.NOTEBOOK_EDIT,
 ]);
 const STREAM_UPDATE_THROTTLE_MS = 60;
+const STREAM_PENDING_ITEM_MAX_CHARS = 16_384;
+const LOADING_THOUGHT_DESCRIPTION_MAX_CHARS = 4_096;
 
 type BufferedStreamEvent =
   | { kind: 'content'; value: string }
@@ -293,6 +295,14 @@ function showCitations(settings: LoadedSettings): boolean {
     return enabled;
   }
   return true;
+}
+
+function clampLoadingThoughtDescription(description: string): string {
+  if (description.length <= LOADING_THOUGHT_DESCRIPTION_MAX_CHARS) {
+    return description;
+  }
+
+  return description.slice(0, LOADING_THOUGHT_DESCRIPTION_MAX_CHARS);
 }
 
 /**
@@ -956,14 +966,19 @@ export const useGeminiStream = (
       }
       // Split large messages for better rendering performance. Ideally,
       // we should maximize the amount of output sent to <Static />.
-      const splitPoint = findLastSafeSplitPoint(newGeminiMessageBuffer);
-      if (splitPoint === newGeminiMessageBuffer.length) {
-        // Update the existing message with accumulated content
-        setPendingHistoryItem((item) => ({
-          type: item?.type as 'gemini' | 'gemini_content',
-          text: newGeminiMessageBuffer,
-        }));
-      } else {
+      let nextPendingType = pendingHistoryItemRef.current?.type as
+        | 'gemini'
+        | 'gemini_content';
+      while (newGeminiMessageBuffer.length > STREAM_PENDING_ITEM_MAX_CHARS) {
+        const splitPoint = findLastSafeSplitPoint(
+          newGeminiMessageBuffer,
+          STREAM_PENDING_ITEM_MAX_CHARS,
+        );
+        const safeSplitPoint =
+          splitPoint > 0 && splitPoint < newGeminiMessageBuffer.length
+            ? splitPoint
+            : STREAM_PENDING_ITEM_MAX_CHARS;
+
         // This indicates that we need to split up this Gemini Message.
         // Splitting a message is primarily a performance consideration. There is a
         // <Static> component at the root of App.tsx which takes care of rendering
@@ -972,20 +987,23 @@ export const useGeminiStream = (
         // multiple times per-second (as streaming occurs). Prior to this change you'd
         // see heavy flickering of the terminal. This ensures that larger messages get
         // broken up so that there are more "statically" rendered.
-        const beforeText = newGeminiMessageBuffer.substring(0, splitPoint);
-        const afterText = newGeminiMessageBuffer.substring(splitPoint);
+        const beforeText = newGeminiMessageBuffer.substring(0, safeSplitPoint);
+        const afterText = newGeminiMessageBuffer.substring(safeSplitPoint);
         addItem(
           {
-            type: pendingHistoryItemRef.current?.type as
-              | 'gemini'
-              | 'gemini_content',
+            type: nextPendingType,
             text: beforeText,
           },
           userMessageTimestamp,
         );
-        setPendingHistoryItem({ type: 'gemini_content', text: afterText });
+        nextPendingType = 'gemini_content';
         newGeminiMessageBuffer = afterText;
       }
+      // Update the existing message with accumulated content.
+      setPendingHistoryItem({
+        type: nextPendingType,
+        text: newGeminiMessageBuffer,
+      });
       return newGeminiMessageBuffer;
     },
     [addItem, pendingHistoryItemRef, setPendingHistoryItem],
@@ -994,23 +1012,31 @@ export const useGeminiStream = (
   const mergeThought = useCallback(
     (incoming: ThoughtSummary) => {
       setThought((prev) => {
+        const incomingDescription = incoming.description
+          ? clampLoadingThoughtDescription(incoming.description)
+          : incoming.description;
         if (!prev) {
           if (debugLogger.isEnabled()) {
             debugLogger.debug(
               `[THOUGHT_MERGE] New thought: ` +
                 `subjectLength=${incoming.subject?.length ?? 0}, ` +
-                `description length=${incoming.description?.length ?? 0}`,
+                `description length=${incomingDescription?.length ?? 0}`,
             );
           }
-          return incoming;
+          return {
+            ...incoming,
+            description: incomingDescription,
+          };
         }
         const subject = incoming.subject || prev.subject;
-        const description = `${prev.description ?? ''}${incoming.description ?? ''}`;
+        const description = clampLoadingThoughtDescription(
+          `${prev.description ?? ''}${incomingDescription ?? ''}`,
+        );
         if (debugLogger.isEnabled()) {
           debugLogger.debug(
             `[THOUGHT_MERGE] Accumulating thought: ` +
               `prev length=${prev.description?.length ?? 0}, ` +
-              `incoming length=${incoming.description?.length ?? 0}, ` +
+              `incoming length=${incomingDescription?.length ?? 0}, ` +
               `total length=${description.length}`,
           );
         }
@@ -1021,7 +1047,11 @@ export const useGeminiStream = (
   );
 
   const handleThoughtEvent = useCallback(
-    (eventValue: ThoughtSummary, currentThoughtBuffer: string): string => {
+    (
+      eventValue: ThoughtSummary,
+      currentThoughtBuffer: string,
+      userMessageTimestamp: number,
+    ): string => {
       if (turnCancelledRef.current) {
         return '';
       }
@@ -1031,7 +1061,7 @@ export const useGeminiStream = (
         return currentThoughtBuffer;
       }
 
-      const newThoughtBuffer = currentThoughtBuffer + thoughtText;
+      let newThoughtBuffer = currentThoughtBuffer + thoughtText;
       if (newThoughtBuffer.trim().length === 0) {
         return newThoughtBuffer;
       }
@@ -1043,6 +1073,7 @@ export const useGeminiStream = (
 
       if (startingNewThought) {
         thoughtStartTimeRef.current = Date.now();
+        newThoughtBuffer = description;
       }
 
       // Keep the transient `thought` (subject) in sync for the window title.
@@ -1054,17 +1085,61 @@ export const useGeminiStream = (
       // Stream the accumulated reasoning into a pending history item so it
       // renders height-limited above the answer and can later be committed as
       // a collapsible block.
-      setPendingThoughtItem({
-        type: 'gemini_thought',
-        text: stripLeadingBlankLines(newThoughtBuffer),
-        durationMs: thoughtStartTimeRef.current
+      let pendingThoughtType: 'gemini_thought' | 'gemini_thought_content' =
+        startingNewThought
+          ? 'gemini_thought'
+          : pendingThoughtItemRef.current?.type === 'gemini_thought_content'
+            ? 'gemini_thought_content'
+            : 'gemini_thought';
+      const getThoughtDurationMs = () =>
+        thoughtStartTimeRef.current
           ? Date.now() - thoughtStartTimeRef.current
-          : 0,
-      });
+          : 0;
+      const buildThoughtItem = (
+        type: 'gemini_thought' | 'gemini_thought_content',
+        text: string,
+      ): HistoryItemWithoutId =>
+        type === 'gemini_thought'
+          ? {
+              type,
+              text,
+              durationMs: getThoughtDurationMs(),
+            }
+          : {
+              type,
+              text,
+            };
 
-      return startingNewThought ? description : newThoughtBuffer;
+      let splitPoint = findLastSafeSplitPoint(
+        newThoughtBuffer,
+        STREAM_PENDING_ITEM_MAX_CHARS,
+      );
+      while (newThoughtBuffer.length > STREAM_PENDING_ITEM_MAX_CHARS) {
+        const safeSplitPoint =
+          splitPoint > 0 && splitPoint < newThoughtBuffer.length
+            ? splitPoint
+            : STREAM_PENDING_ITEM_MAX_CHARS;
+        const beforeText = newThoughtBuffer.substring(0, safeSplitPoint);
+        const afterText = newThoughtBuffer.substring(safeSplitPoint);
+        addItem(
+          buildThoughtItem(pendingThoughtType, beforeText),
+          userMessageTimestamp,
+        );
+        pendingThoughtType = 'gemini_thought_content';
+        newThoughtBuffer = afterText;
+        splitPoint = findLastSafeSplitPoint(
+          newThoughtBuffer,
+          STREAM_PENDING_ITEM_MAX_CHARS,
+        );
+      }
+
+      setPendingThoughtItem(
+        buildThoughtItem(pendingThoughtType, newThoughtBuffer),
+      );
+
+      return newThoughtBuffer;
     },
-    [mergeThought, setPendingThoughtItem],
+    [addItem, mergeThought, pendingThoughtItemRef, setPendingThoughtItem],
   );
 
   // Commit the streamed reasoning to history as a collapsible block (or drop
@@ -1467,40 +1542,49 @@ export const useGeminiStream = (
           const nextEvent = bufferedEvents.shift()!;
 
           if (nextEvent.kind === 'content') {
-            let mergedContent = nextEvent.value;
+            const contentParts = [nextEvent.value];
 
             while (bufferedEvents[0]?.kind === 'content') {
               const queuedContent = bufferedEvents.shift();
               if (queuedContent?.kind !== 'content') {
                 break;
               }
-              mergedContent += queuedContent.value;
+              contentParts.push(queuedContent.value);
             }
 
             geminiMessageBuffer = handleContentEvent(
-              mergedContent,
+              contentParts.join(''),
               geminiMessageBuffer,
               userMessageTimestamp,
             );
             continue;
           }
 
-          let mergedThought = nextEvent.value;
+          let subject = nextEvent.value.subject;
+          const thoughtDescriptions: string[] = [];
+          if (nextEvent.value.description) {
+            thoughtDescriptions.push(nextEvent.value.description);
+          }
 
           while (bufferedEvents[0]?.kind === 'thought') {
             const queuedThought = bufferedEvents.shift();
             if (queuedThought?.kind !== 'thought') {
               break;
             }
-            mergedThought = {
-              subject: queuedThought.value.subject || mergedThought.subject,
-              description: `${mergedThought.description ?? ''}${
-                queuedThought.value.description ?? ''
-              }`,
-            };
+            subject = queuedThought.value.subject || subject;
+            if (queuedThought.value.description) {
+              thoughtDescriptions.push(queuedThought.value.description);
+            }
           }
 
-          thoughtBuffer = handleThoughtEvent(mergedThought, thoughtBuffer);
+          thoughtBuffer = handleThoughtEvent(
+            {
+              subject,
+              description: thoughtDescriptions.join(''),
+            },
+            thoughtBuffer,
+            userMessageTimestamp,
+          );
         }
       };
 

--- a/packages/cli/src/ui/utils/markdownUtilities.test.ts
+++ b/packages/cli/src/ui/utils/markdownUtilities.test.ts
@@ -46,5 +46,30 @@ describe('markdownUtilities', () => {
       const content = 'Single line of text';
       expect(findLastSafeSplitPoint(content)).toBe(content.length);
     });
+
+    it('should hard split a long single line when a max length is provided', () => {
+      const content = 'a'.repeat(100);
+      expect(findLastSafeSplitPoint(content, 40)).toBe(40);
+    });
+
+    it('should prefer a safe newline before the max length', () => {
+      const content = 'first line\nsecond line\nthird line';
+      expect(findLastSafeSplitPoint(content, 18)).toBe(11);
+    });
+
+    it('should not split past the max length for a boundary newline', () => {
+      const content = `${'a'.repeat(40)}\n\nrest`;
+      expect(findLastSafeSplitPoint(content, 40)).toBe(40);
+    });
+
+    it('should preserve an opening code block when possible with a max length', () => {
+      const content = 'intro\n\n```ts\nconst value = 1;\n';
+      expect(findLastSafeSplitPoint(content, 20)).toBe(7);
+    });
+
+    it('should hard split an oversized leading code block with a max length', () => {
+      const content = '```ts\n' + 'a'.repeat(100);
+      expect(findLastSafeSplitPoint(content, 40)).toBe(40);
+    });
   });
 });

--- a/packages/cli/src/ui/utils/markdownUtilities.ts
+++ b/packages/cli/src/ui/utils/markdownUtilities.ts
@@ -7,32 +7,36 @@
 /*
 **Background & Purpose:**
 
-The `findSafeSplitPoint` function is designed to address the challenge of displaying or processing large, potentially streaming, pieces of Markdown text. When content (e.g., from an LLM like Gemini) arrives in chunks or grows too large for a single display unit (like a message bubble), it needs to be split. A naive split (e.g., just at a character limit) can break Markdown formatting, especially critical for multi-line elements like code blocks, lists, or blockquotes, leading to incorrect rendering.
+The `findLastSafeSplitPoint` function finds an index where a large or
+streaming Markdown string can be split. It prefers Markdown-friendly boundaries
+so rendered history chunks do not break fenced code blocks unnecessarily.
 
-This function aims to find an *intelligent* or "safe" index within the provided `content` string at which to make such a split, prioritizing the preservation of Markdown integrity.
+**Behavior, in priority order:**
 
-**Key Expectations & Behavior (Prioritized):**
+1.  **No split if already short enough:**
+    * When `idealMaxLength` is provided and `content.length` is less than or
+      equal to it, return `content.length`.
 
-1.  **No Split if Short Enough:**
-    * If `content.length` is less than or equal to `idealMaxLength`, the function should return `content.length` (indicating no split is necessary for length reasons).
+2.  **Fenced code block safety:**
+    * If the search endpoint is inside a fenced code block, split before that
+      block when possible.
+    * When a length cap is provided and the block starts at the beginning of
+      `content`, return the cap instead. This intentionally hard-splits
+      oversized leading code blocks so streaming pending render items stay
+      bounded.
 
-2.  **Code Block Integrity (Highest Priority for Safety):**
-    * The function must try to avoid splitting *inside* a fenced code block (i.e., between ` ``` ` and ` ``` `).
-    * If `idealMaxLength` falls within a code block:
-        * The function will attempt to return an index that splits the content *before* the start of that code block.
-        * If a code block starts at the very beginning of the `content` and `idealMaxLength` falls within it (meaning the block itself is too long for the first chunk), the function might return `0`. This effectively makes the first chunk empty, pushing the entire oversized code block to the second part of the split.
-    * When considering splits near code blocks, the function prefers to keep the entire code block intact in one of the resulting chunks.
+3.  **Markdown-aware newline splitting:**
+    * Prefer the last double newline (`\n\n`) at or before the search endpoint.
+    * When a length cap is provided, fall back to the last single newline (`\n`)
+      at or before the cap.
+    * Chosen newline split points must not be inside a fenced code block.
 
-3.  **Markdown-Aware Newline Splitting (If Not Governed by Code Block Logic):**
-    * If `idealMaxLength` does not fall within a code block (or after code block considerations have been made), the function will look for natural break points by scanning backwards from `idealMaxLength`:
-        * **Paragraph Breaks:** It prioritizes splitting after a double newline (`\n\n`), as this typically signifies the end of a paragraph or a block-level element.
-        * **Single Line Breaks:** If no double newline is found in a suitable range, it will look for a single newline (`\n`).
-    * Any newline chosen as a split point must also not be inside a code block.
-
-4.  **Fall back to `idealMaxLength`:**
-    * If no "safer" split point (respecting code blocks or finding suitable newlines) is identified before or at `idealMaxLength`, and `idealMaxLength` itself is not determined to be an unsafe split point (e.g., inside a code block), the function may return a length larger than `idealMaxLength`, again it CANNOT break markdown formatting. This could happen with very long lines of text without Markdown block structures or newlines.
-
-**In essence, `findSafeSplitPoint` tries to be a good Markdown citizen when forced to divide content, preferring structural boundaries over arbitrary character limits, with a strong emphasis on not corrupting code blocks.**
+4.  **Fallback behavior:**
+    * Without `idealMaxLength`, preserve the historical conservative behavior:
+      return `content.length` when no safe block boundary exists.
+    * With `idealMaxLength`, return the cap when no safer boundary exists. This
+      keeps a single very long line from remaining one ever-growing pending
+      render item.
 */
 
 /**
@@ -90,18 +94,29 @@ const findEnclosingCodeBlockStart = (
   return -1;
 };
 
-export const findLastSafeSplitPoint = (content: string) => {
-  const enclosingBlockStart = findEnclosingCodeBlockStart(
-    content,
-    content.length,
-  );
+export const findLastSafeSplitPoint = (
+  content: string,
+  idealMaxLength?: number,
+) => {
+  const hasLengthCap = idealMaxLength !== undefined;
+  const searchEnd = hasLengthCap
+    ? Math.min(Math.max(idealMaxLength, 0), content.length)
+    : content.length;
+
+  if (hasLengthCap && content.length <= searchEnd) {
+    return content.length;
+  }
+
+  const enclosingBlockStart = findEnclosingCodeBlockStart(content, searchEnd);
   if (enclosingBlockStart !== -1) {
     // The end of the content is contained in a code block. Split right before.
-    return enclosingBlockStart;
+    return hasLengthCap && enclosingBlockStart === 0
+      ? searchEnd
+      : enclosingBlockStart;
   }
 
   // Search for the last double newline (\n\n) not in a code block.
-  let searchStartIndex = content.length;
+  let searchStartIndex = searchEnd;
   while (searchStartIndex >= 0) {
     const dnlIndex = content.lastIndexOf('\n\n', searchStartIndex);
     if (dnlIndex === -1) {
@@ -110,7 +125,10 @@ export const findLastSafeSplitPoint = (content: string) => {
     }
 
     const potentialSplitPoint = dnlIndex + 2;
-    if (!isIndexInsideCodeBlock(content, potentialSplitPoint)) {
+    if (
+      potentialSplitPoint <= searchEnd &&
+      !isIndexInsideCodeBlock(content, potentialSplitPoint)
+    ) {
       return potentialSplitPoint;
     }
 
@@ -119,7 +137,28 @@ export const findLastSafeSplitPoint = (content: string) => {
     searchStartIndex = dnlIndex - 1;
   }
 
-  // If no safe double newline is found, return content.length
-  // to keep the entire content as one piece.
-  return content.length;
+  if (hasLengthCap) {
+    searchStartIndex = searchEnd;
+    while (searchStartIndex >= 0) {
+      const nlIndex = content.lastIndexOf('\n', searchStartIndex);
+      if (nlIndex === -1) {
+        break;
+      }
+
+      const potentialSplitPoint = nlIndex + 1;
+      if (
+        potentialSplitPoint <= searchEnd &&
+        !isIndexInsideCodeBlock(content, potentialSplitPoint)
+      ) {
+        return potentialSplitPoint;
+      }
+
+      searchStartIndex = nlIndex - 1;
+    }
+  }
+
+  // Without a length cap, keep the historical behavior: only split on a safe
+  // block boundary. With a cap, fall back to the cap so a single long line
+  // cannot remain one ever-growing pending render item forever.
+  return hasLengthCap ? searchEnd : content.length;
 };


### PR DESCRIPTION
## What this PR does

Bounds the amount of streamed assistant output and streamed reasoning text that remains in the live TUI pending render item. Long content is split into static history chunks, while only the latest tail remains pending. Streamed reasoning uses the same approach, preserving the collapsible thought block shape by emitting an initial `gemini_thought` chunk followed by `gemini_thought_content` continuations when needed.

It also gives the Markdown split helper an optional max-length cap, keeps the previous conservative behavior when no cap is supplied, batches adjacent stream chunks with array joins instead of repeated string concatenation, and caps the transient loading thought description state.

## Why it's needed

On current `main`, `findLastSafeSplitPoint()` has no max-length fallback. For a long single-line reasoning stream, it returns `content.length`, so the same pending thought item keeps growing and gets re-rendered repeatedly. With a 1,000,000 character thought streamed in small chunks, the active Ink/React render item can grow extremely large and memory usage accelerates as the stream gets longer.

This change keeps full output in history while bounding the repeatedly rendered tail to 16,384 characters.

## Reviewer Test Plan

### How to verify

Reviewers can confirm the bounded behavior by checking that `findLastSafeSplitPoint(content, max)` returns `max` for long single-line content, and that the stream hook test commits oversized thought chunks to history while leaving only the short tail in `pendingHistoryItems`.

Run `cd packages/cli && npx vitest run src/ui/utils/markdownUtilities.test.ts src/ui/hooks/useGeminiStream.test.tsx`.

Run `cd packages/cli && npm run typecheck`.

Run `cd packages/cli && npm run build`.

Run `cd packages/cli && npm run lint`.

Optional split simulation from repo root: `node --import tsx/esm --input-type=module -e 'import { findLastSafeSplitPoint } from "./packages/cli/src/ui/utils/markdownUtilities.ts"; const limit = 16_384; const chunkSize = 60; const target = 1_000_000; let pending = ""; let historyItems = 0; let historyChars = 0; let maxPending = 0; for (let written = 0; written < target; written += chunkSize) { pending += "a".repeat(Math.min(chunkSize, target - written)); while (pending.length > limit) { const splitPoint = findLastSafeSplitPoint(pending, limit); const safeSplitPoint = splitPoint > 0 && splitPoint < pending.length ? splitPoint : limit; historyItems += 1; historyChars += safeSplitPoint; pending = pending.slice(safeSplitPoint); } maxPending = Math.max(maxPending, pending.length); } console.log(JSON.stringify({ target, chunkSize, limit, historyItems, historyChars, pending: pending.length, maxPending, totalChars: historyChars + pending.length }));'`.

### Evidence (Before & After)

Before: `main` had no length cap in `findLastSafeSplitPoint()`, so a long single-line thought had no split point and stayed as one growing pending render item.

After: focused tests pass with 133 tests total across the two touched test files. The 1,000,000 character / 60 character chunk simulation produced `{"target":1000000,"chunkSize":60,"limit":16384,"historyItems":61,"historyChars":999424,"pending":576,"maxPending":16384,"totalChars":1000000}`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS worktree with Node dependencies installed via `npm install`. I ran focused CLI tests, CLI typecheck, CLI build, and CLI lint. I did not run full `npm run preflight`.

## Risk & Scope

- Main risk or tradeoff: Oversized leading fenced code blocks can now be hard-split at the cap to keep the pending render item bounded, so formatting across chunk boundaries may be less perfect for pathological long code blocks.
- Not validated / out of scope: Full interactive TUI memory profiling on Windows/Linux and full `npm run preflight`.
- Breaking changes / migration notes: None. Full streamed text is preserved; only the live pending render item is bounded.

## Linked Issues

No linked issue. This is a focused bug fix found by inspecting upstream `main` for the same streaming thought memory growth behavior.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

限制流式 assistant 输出和流式 reasoning 文本中仍留在 TUI 实时 pending 渲染项里的内容大小。长内容会拆成静态 history chunk，只保留最新尾段继续 pending。流式 reasoning 也使用同样方式，在需要时先提交一个 `gemini_thought` chunk，再提交后续 `gemini_thought_content` continuation，从而保留可折叠思考块的展示形态。

同时，这个 PR 给 Markdown split helper 增加了可选最大长度 cap；不传 cap 时保持原来的保守行为；把相邻 stream chunk 的合并从反复字符串拼接改为数组 join；并限制 transient loading thought description 状态的长度。

## 为什么需要

当前 `main` 上的 `findLastSafeSplitPoint()` 没有最大长度 fallback。对于一条很长的单行 reasoning stream，它会返回 `content.length`，导致同一个 pending thought item 一直增长并被重复重渲染。当 1,000,000 字符的 thought 以小 chunk 流式到达时，活跃的 Ink/React 渲染项会变得非常大，并且内存使用会随着 stream 变长而加速增长。

这个改动会把完整输出保存在 history 中，同时把反复渲染的尾段限制在 16,384 字符。

## Reviewer Test Plan

### 如何验证

Reviewer 可以确认 `findLastSafeSplitPoint(content, max)` 对长单行内容会返回 `max`，并确认 stream hook 测试会把超长 thought chunk 提交到 history，只在 `pendingHistoryItems` 中留下短尾段。

运行 `cd packages/cli && npx vitest run src/ui/utils/markdownUtilities.test.ts src/ui/hooks/useGeminiStream.test.tsx`。

运行 `cd packages/cli && npm run typecheck`。

运行 `cd packages/cli && npm run build`。

运行 `cd packages/cli && npm run lint`。

可选的拆分模拟命令见英文正文；它会用 1,000,000 字符、每 chunk 60 字符验证 pending 上限。

### 证据（Before & After）

Before：`main` 上 `findLastSafeSplitPoint()` 没有长度 cap，因此长单行 thought 没有 split point，会作为一个持续增长的 pending render item 保留。

After：两个相关测试文件共 133 个测试通过。1,000,000 字符 / 60 字符 chunk 的模拟输出为 `{"target":1000000,"chunkSize":60,"limit":16384,"historyItems":61,"historyChars":999424,"pending":576,"maxPending":16384,"totalChars":1000000}`。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### 环境（可选）

本地 macOS worktree，通过 `npm install` 安装依赖。我运行了聚焦 CLI 测试、CLI typecheck、CLI build 和 CLI lint。没有运行完整的 `npm run preflight`。

## 风险与范围

- 主要风险或取舍：超长且从开头开始的 fenced code block 现在可能会按 cap 硬切，以保证 pending render item 有界，因此极端长代码块跨 chunk 的格式化可能没有以前完美。
- 未验证 / 不在范围内：Windows/Linux 上的完整交互式 TUI 内存 profiling，以及完整 `npm run preflight`。
- Breaking changes / 迁移说明：无。完整流式文本仍会保留，只限制实时 pending 渲染项。

## 关联 Issue

没有关联 issue。这是通过检查上游 `main` 发现同样存在流式 thought 内存增长行为后提交的聚焦 bug fix。

</details>
