### PR TITLE
fix(cli): reject malformed ACP timeout strings

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -2849,6 +2849,43 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
+  it('qwen/settings/setMcpServer rejects malformed timeout strings', async () => {
+    const settings = makeCoreSettings();
+    const { agent, agentPromise } = await bootCoreSettingsAgent(settings);
+
+    await expect(
+      agent.extMethod('qwen/settings/setMcpServer', {
+        scope: 'user',
+        name: 'bad-timeout',
+        server: { transport: 'stdio', command: 'node', timeout: '10ms' },
+      }),
+    ).rejects.toThrowError(/Expected a positive integer/);
+
+    await expect(
+      agent.extMethod('qwen/settings/setMcpServer', {
+        scope: 'user',
+        name: 'fractional-timeout',
+        server: { transport: 'stdio', command: 'node', timeout: '1.5' },
+      }),
+    ).rejects.toThrowError(/Expected a positive integer/);
+
+    await agent.extMethod('qwen/settings/setMcpServer', {
+      scope: 'user',
+      name: 'valid-timeout',
+      server: { transport: 'stdio', command: 'node', timeout: '1500' },
+    });
+
+    const persisted = vi
+      .mocked(settings.setValue)
+      .mock.calls.find((call) => call[1] === 'mcpServers')?.[2] as {
+      'valid-timeout': { timeout: number };
+    };
+    expect(persisted['valid-timeout'].timeout).toBe(1500);
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it('qwen/settings/removeMcpServer drops the named server and rejects a missing name', async () => {
     const settings = makeCoreSettings();
     (settings.user.settings as Record<string, unknown>)['mcpServers'] = {
@@ -2942,6 +2979,24 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       .mock.calls.filter((call) => call[1] === 'hooks');
     expect(hookWrites.at(-2)?.[2]).toHaveProperty('PostToolBatch');
     expect(hookWrites.at(-1)?.[2]).toHaveProperty('UserPromptExpansion');
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('qwen/settings/setHook rejects malformed timeout strings', async () => {
+    const settings = makeCoreSettings();
+    const { agent, agentPromise } = await bootCoreSettingsAgent(settings);
+
+    await expect(
+      agent.extMethod('qwen/settings/setHook', {
+        scope: 'user',
+        event: 'PreToolUse',
+        hook: {
+          hooks: [{ type: 'command', command: 'echo hi', timeout: '10ms' }],
+        },
+      }),
+    ).rejects.toThrowError(/Expected a positive integer/);
 
     mockConnectionState.resolve();
     await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -1757,10 +1757,17 @@ function normalizeStringRecord(
 
 function normalizeOptionalNumber(value: unknown): number | undefined {
   if (value === undefined || value === null || value === '') return undefined;
-  const numberValue =
-    typeof value === 'number' ? value : Number.parseInt(String(value), 10);
-  if (!Number.isFinite(numberValue) || numberValue <= 0) {
-    throw RequestError.invalidParams(undefined, 'Expected a positive number');
+  let numberValue: number;
+  if (typeof value === 'number') {
+    numberValue = value;
+  } else if (typeof value === 'string') {
+    const trimmed = value.trim();
+    numberValue = /^\d+$/.test(trimmed) ? Number(trimmed) : Number.NaN;
+  } else {
+    numberValue = Number.NaN;
+  }
+  if (!Number.isInteger(numberValue) || numberValue <= 0) {
+    throw RequestError.invalidParams(undefined, 'Expected a positive integer');
   }
   return numberValue;
 }


### PR DESCRIPTION
## What this PR does

Makes ACP settings timeout normalization strict. The `normalizeOptionalNumber` helper used by the ACP settings paths previously ran `parseInt(String(value), 10)` on incoming timeout values, which silently truncated malformed strings — `"10ms"` was parsed as `10` and `"1.5"` as `1`, then persisted. The helper now accepts a value only when it is a number or a string of pure digits (`/^\d+$/`); anything else (suffixes, fractional, non-numeric) becomes `NaN`. It then requires the result to be a positive integer (`Number.isInteger(...) && value > 0`) and rejects everything else with an `invalidParams` error reading `Expected a positive integer`. This applies to the MCP server timeout and hook command timeout settings handled over ACP (`qwen/settings/setMcpServer`, `qwen/settings/setHook`).

## Why it's needed

Per #5313, ACP settings normalization accepted malformed timeout values because `normalizeOptionalNumber` used `parseInt`. Values like `"10ms"` or `"1.5"` were accepted and persisted as truncated numbers (`10`, `1`) instead of being rejected as invalid params, silently corrupting MCP server and hook timeout settings. The nearby env parser already avoids this kind of truncation, so the ACP request/config path should be strict too. This rejects suffixed/partial numbers up front rather than persisting a wrong value.

## Reviewer Test Plan

### How to verify

Repro: send an ACP settings request with a malformed timeout. Before this change, `{ timeout: '10ms' }` was accepted and persisted as `10`; after it, the request is rejected with `Expected a positive integer`. A pure-digit string such as `'1500'` is still accepted and persisted as the number `1500`.

Verification commands (run from repo root):

- `npx vitest run src/acp-integration/acpAgent.test.ts -t "malformed timeout strings"`
- `npx vitest run src/acp-integration/acpAgent.test.ts`
- `npm run typecheck --workspace=packages/cli`
- `npm run lint`
- `npx prettier --experimental-cli --check packages/cli/src/acp-integration/acpAgent.ts packages/cli/src/acp-integration/acpAgent.test.ts`
- `git diff --check`

### Evidence (Before & After)

N/A — non-visible logic fix; covered by the unit tests above (new regression tests assert that `'10ms'` and `'1.5'` are rejected with `Expected a positive integer`, and that `'1500'` is persisted as `1500`).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI |
| 🪟 Windows |  ✅ CI |
|  🐧 Linux  |  ✅ CI |

✅ tested · ⚠️ not tested · N/A

### Environment (optional)

Unit tests only (npm workspaces). Note: `npm run build --workspace=packages/cli` failed locally for the author because pre-existing ignored `dist` output under `packages/core/dist` is treated as TypeScript input (TS5055 overwrite-input errors), unrelated to this change; CI builds and tests pass on all three platforms.

## Risk & Scope

- Main risk or tradeoff: Low; scoped to ACP settings timeout normalization (`normalizeOptionalNumber`). The behavior change is that previously-truncated malformed timeout strings are now rejected instead of silently persisted as wrong values; valid numeric/integer-string inputs are unaffected.
- Not validated / out of scope: No unrelated refactors, no public API changes, no UI changes.
- Breaking changes / migration notes: None. Inputs that were silently accepted as wrong values are now rejected with a clear error; any caller relying on the old truncation was already getting incorrect timeouts.

## Linked Issues

Fixes #5313

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 ACP 设置中的超时（timeout）归一化变得严格。ACP 设置路径所用的 `normalizeOptionalNumber` 辅助函数此前对传入的超时值执行 `parseInt(String(value), 10)`，这会悄悄截断格式错误的字符串——`"10ms"` 被解析成 `10`，`"1.5"` 被解析成 `1`，随后被持久化保存。现在该辅助函数仅在值为数字、或为纯数字字符串（`/^\d+$/`）时才接受；其他任何情况（带后缀、带小数、非数字）都会变成 `NaN`。随后它要求结果必须是正整数（`Number.isInteger(...) && value > 0`），否则以 `invalidParams` 错误拒绝，错误信息为 `Expected a positive integer`。此逻辑作用于通过 ACP 处理的 MCP server 超时和 hook 命令超时设置（`qwen/settings/setMcpServer`、`qwen/settings/setHook`）。

## 为什么需要它

根据 #5313，ACP 设置归一化因为 `normalizeOptionalNumber` 使用了 `parseInt` 而接受了格式错误的超时值。像 `"10ms"` 或 `"1.5"` 这样的值被接受并被截断持久化为 `10`、`1`，而不是作为非法参数被拒绝，从而悄悄损坏 MCP server 和 hook 的超时设置。附近的环境变量解析器本就避免了这种截断，因此 ACP 的 request/config 路径也应当严格。本改动会提前拒绝带后缀/不完整的数字，而不是持久化一个错误的值。

## 审阅者测试计划

### 如何验证

复现：发送一个带有格式错误超时值的 ACP 设置请求。在本改动之前，`{ timeout: '10ms' }` 会被接受并持久化为 `10`；改动之后，该请求会被拒绝并报 `Expected a positive integer`。纯数字字符串（如 `'1500'`）仍会被接受并持久化为数字 `1500`。

验证命令（在仓库根目录执行）：

- `npx vitest run src/acp-integration/acpAgent.test.ts -t "malformed timeout strings"`
- `npx vitest run src/acp-integration/acpAgent.test.ts`
- `npm run typecheck --workspace=packages/cli`
- `npm run lint`
- `npx prettier --experimental-cli --check packages/cli/src/acp-integration/acpAgent.ts packages/cli/src/acp-integration/acpAgent.test.ts`
- `git diff --check`

### 证据（前后对比）

不适用 —— 这是非可见的逻辑修复；由上述单元测试覆盖（新增的回归测试断言 `'10ms'` 和 `'1.5'` 会被拒绝并报 `Expected a positive integer`，且 `'1500'` 会被持久化为 `1500`）。

### 测试平台

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI |
| 🪟 Windows |  ✅ CI |
|  🐧 Linux  |  ✅ CI |

✅ 已测试 · ⚠️ 未测试 · 不适用

### 环境（可选）

仅单元测试（npm workspaces）。说明：作者本地运行 `npm run build --workspace=packages/cli` 失败，原因是 `packages/core/dist` 下已被忽略的旧 `dist` 产物被当作 TypeScript 输入（TS5055 覆盖输入错误），与本改动无关；CI 在三个平台上的构建与测试均通过。

## 风险与范围

- 主要风险或权衡：低；范围限于 ACP 设置超时归一化（`normalizeOptionalNumber`）。行为变化在于：此前被截断的格式错误超时字符串现在会被拒绝，而不是被悄悄持久化为错误值；合法的数字/整数字符串输入不受影响。
- 未验证 / 范围之外：无无关重构，无公共 API 变更，无 UI 变更。
- 破坏性变更 / 迁移说明：无。此前被悄悄接受为错误值的输入现在会以清晰的错误被拒绝；任何依赖旧截断行为的调用方此前本就拿到的是错误的超时值。

## 关联 Issue

Fixes #5313

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
