### PR TITLE
fix(core): track attached stdout fd redirects

### DIFF
--- a/packages/core/src/permissions/shell-semantics.test.ts
+++ b/packages/core/src/permissions/shell-semantics.test.ts
@@ -466,6 +466,22 @@ describe('extractShellOperations', () => {
     });
   });
 
+  it('combined stdout fd redirect 1>file without space', () => {
+    const ops = extractShellOperations('echo hi 1>.qwen/settings.json', CWD);
+    expect(ops).toContainEqual({
+      virtualTool: 'write_file',
+      filePath: `${CWD}/.qwen/settings.json`,
+    });
+  });
+
+  it('combined stdout fd append redirect 1>>file without space', () => {
+    const ops = extractShellOperations('echo hi 1>>.qwen/settings.json', CWD);
+    expect(ops).toContainEqual({
+      virtualTool: 'write_file',
+      filePath: `${CWD}/.qwen/settings.json`,
+    });
+  });
+
   it('redirect 2>/dev/null: ignored (no op)', () => {
     const ops = extractShellOperations('cat /etc/passwd 2>/dev/null', CWD);
     expect(ops).not.toContainEqual(
@@ -960,6 +976,20 @@ describe('extractShellOperationsAcrossCommand', () => {
     expect(
       extractShellOperationsAcrossCommand(
         'cd "$QWEN_HOME" && echo hi > /tmp/out.txt',
+        '/repo',
+      ),
+    ).toEqual([
+      {
+        virtualTool: 'write_file',
+        filePath: '/tmp/out.txt',
+        cwdUnknown: true,
+        pathMayDependOnCwd: false,
+      },
+    ]);
+
+    expect(
+      extractShellOperationsAcrossCommand(
+        'cd "$QWEN_HOME" && echo hi 1>/tmp/out.txt',
         '/repo',
       ),
     ).toEqual([

--- a/packages/core/src/permissions/shell-semantics.ts
+++ b/packages/core/src/permissions/shell-semantics.ts
@@ -234,7 +234,7 @@ function isNetworkPseudoDevice(target: string): boolean {
  * Handles:
  *   `> file`   `>> file`  `< file`   (with or without space)
  *   `2> file`  `2>> file` `&> file`  `&>> file`
- *   Combined forms: `>file`, `>>file`, `2>/dev/null`
+ *   Combined forms: `>file`, `>>file`, `1>file`, `2>/dev/null`
  */
 function extractRedirects(tokens: string[], cwd: string): RedirectResult {
   const readFiles: string[] = [];
@@ -299,7 +299,7 @@ function extractRedirects(tokens: string[], cwd: string): RedirectResult {
     }
     // ── Combined redirect tokens without space: `>file`, `>>file`, etc. ───
     else {
-      const m = tok.match(/^(<<-?|>>|>|2>>|2>|&>>|&>|<)(.+)$/);
+      const m = tok.match(/^(<<-?|1>>|1>|>>|>|2>>|2>|&>>|&>|<)(.+)$/);
       if (m) {
         const op = m[1]!;
         const target = m[2]!;
@@ -2319,7 +2319,9 @@ function hasAbsolutePathTokenForOperation(
   filePath: string,
 ): boolean {
   for (const token of tokenize(command)) {
-    const redirectTarget = token.match(/^(?:>>|>|2>>|2>|&>>|&>|<)(.+)$/)?.[1];
+    const redirectTarget = token.match(
+      /^(?:1>>|1>|>>|>|2>>|2>|&>>|&>|<)(.+)$/,
+    )?.[1];
     const candidate = redirectTarget ?? token;
     if (
       looksLikePath(candidate) &&


### PR DESCRIPTION
Fixes #5316

## Summary

- Track attached stdout fd redirects like  and  as write operations
- Keep attached absolute fd redirects from being marked cwd-dependent after dynamic 
- Add regression coverage for both overwrite and append forms

## Testing

- npx vitest run src/permissions/shell-semantics.test.ts -t "combined stdout fd|does not mark absolute writes"
- npx vitest run src/permissions/shell-semantics.test.ts
- npm run typecheck --workspace=packages/core
- npm run build --workspace=packages/core
- npm run lint
- npx prettier --experimental-cli --check packages/core/src/permissions/shell-semantics.ts packages/core/src/permissions/shell-semantics.test.ts
- git diff --check

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.