### PR TITLE
fix(core): pass --no-ask-password to systemd-inhibit to prevent TUI corruption

### DIFF
--- a/packages/core/src/services/sleepInhibitor.test.ts
+++ b/packages/core/src/services/sleepInhibitor.test.ts
@@ -8,6 +8,7 @@ import { EventEmitter } from 'node:events';
 import type { ChildProcess, SpawnOptions } from 'node:child_process';
 import { describe, expect, it, vi } from 'vitest';
 import { acquireSleepInhibitor, SleepInhibitor } from './sleepInhibitor.js';
+import { PassThrough } from 'node:stream';
 
 function createChild(pid: number | undefined = 4242): ChildProcess {
   const child = new EventEmitter() as ChildProcess;
@@ -26,13 +27,49 @@ function createChild(pid: number | undefined = 4242): ChildProcess {
   return child;
 }
 
+function createHelpChild(output: string): ChildProcess {
+  const child = new EventEmitter() as ChildProcess;
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  Object.defineProperty(child, 'stdout', { value: stdout });
+  Object.defineProperty(child, 'stderr', { value: stderr });
+  Object.defineProperty(child, 'pid', { value: 9999 });
+  Object.defineProperty(child, 'killed', { value: false });
+  child.kill = vi.fn(() => true);
+  queueMicrotask(() => {
+    stdout.write(output);
+    stdout.end();
+    child.emit('close', 0, null);
+  });
+  return child;
+}
+
+function createErrorChild(): ChildProcess {
+  const child = new EventEmitter() as ChildProcess;
+  Object.defineProperty(child, 'pid', { value: undefined });
+  Object.defineProperty(child, 'killed', { value: false });
+  child.kill = vi.fn(() => true);
+  queueMicrotask(() => child.emit('error', new Error('ENOENT')));
+  return child;
+}
+
 function createHarness(
   platform: NodeJS.Platform = 'linux',
   env: NodeJS.ProcessEnv = {},
+  noAskPasswordSupported: boolean | null = true,
 ) {
   const children: ChildProcess[] = [];
+  const helpOutput = noAskPasswordSupported
+    ? 'systemd-inhibit [OPTIONS...] COMMAND ...\n\n  --no-ask-password    Do not attempt interactive authorization\n'
+    : 'systemd-inhibit [OPTIONS...] COMMAND ...\n\n  --what=WHAT          Operations to inhibit\n';
   const spawn = vi.fn(
-    (_command: string, _args: string[], _options?: SpawnOptions) => {
+    (command: string, args: string[], _options?: SpawnOptions) => {
+      if (command === 'systemd-inhibit' && args[0] === '--help') {
+        if (noAskPasswordSupported === null) {
+          return createErrorChild();
+        }
+        return createHelpChild(helpOutput);
+      }
       const child = createChild();
       children.push(child);
       return child;
@@ -47,16 +84,23 @@ function createHarness(
 }
 
 describe('SleepInhibitor', () => {
-  it('starts systemd-inhibit on linux and stops it after the final release', () => {
+  it('starts systemd-inhibit on linux and stops it after the final release', async () => {
     const { children, inhibitor, spawn } = createHarness('linux');
 
     const first = inhibitor.acquire('working');
     const second = inhibitor.acquire('working again');
 
+    // Initially only the --help probe is spawned
     expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn.mock.calls[0]![0]).toBe('systemd-inhibit');
+    expect(spawn.mock.calls[0]![1]).toEqual(['--help']);
+
+    // After probe completes, the real inhibitor spawns
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledTimes(2));
     expect(spawn).toHaveBeenCalledWith(
       'systemd-inhibit',
       [
+        '--no-ask-password',
         '--what=sleep',
         '--who=Qwen Code',
         '--why=working',
@@ -103,7 +147,7 @@ describe('SleepInhibitor', () => {
     expect(inhibitor.getActiveCount()).toBe(0);
   });
 
-  it('starts systemd-inhibit for SSH sessions with a display server', () => {
+  it('starts systemd-inhibit for SSH sessions with a display server', async () => {
     const { inhibitor, spawn } = createHarness('linux', {
       SSH_TTY: '/dev/pts/3',
       DISPLAY: ':10',
@@ -111,6 +155,7 @@ describe('SleepInhibitor', () => {
 
     const handle = inhibitor.acquire('forwarded display work');
 
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledTimes(2));
     expect(spawn).toHaveBeenCalledWith(
       'systemd-inhibit',
       expect.arrayContaining(['--what=sleep']),
@@ -119,11 +164,12 @@ describe('SleepInhibitor', () => {
     handle.release();
   });
 
-  it('starts systemd-inhibit for local headless Linux sessions', () => {
+  it('starts systemd-inhibit for local headless Linux sessions', async () => {
     const { inhibitor, spawn } = createHarness('linux');
 
     const handle = inhibitor.acquire('local headless work');
 
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledTimes(2));
     expect(spawn).toHaveBeenCalledWith(
       'systemd-inhibit',
       expect.arrayContaining(['--what=sleep']),
@@ -132,14 +178,15 @@ describe('SleepInhibitor', () => {
     handle.release();
   });
 
-  it('forwards a curated environment instead of an empty env', () => {
+  it('forwards a curated environment instead of an empty env', async () => {
     const { inhibitor, spawn } = createHarness('linux', {
       DBUS_SESSION_BUS_ADDRESS: 'unix:path=/run/user/1000/bus',
       SOME_UNRELATED_SECRET: 'secret',
     });
 
     const handle = inhibitor.acquire();
-    const env = spawn.mock.calls[0]![2]!.env as NodeJS.ProcessEnv;
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledTimes(2));
+    const env = spawn.mock.calls[1]![2]!.env as NodeJS.ProcessEnv;
     // D-Bus address required by systemd-inhibit must be forwarded.
     expect(env['DBUS_SESSION_BUS_ADDRESS']).toBe(
       'unix:path=/run/user/1000/bus',
@@ -177,10 +224,11 @@ describe('SleepInhibitor', () => {
     handle.release();
   });
 
-  it('ignores duplicate releases', () => {
+  it('ignores duplicate releases', async () => {
     const { children, inhibitor } = createHarness('linux');
 
     const handle = inhibitor.acquire();
+    await vi.waitFor(() => expect(inhibitor.isRunning()).toBe(true));
     handle.release();
     handle.release();
 
@@ -209,10 +257,11 @@ describe('SleepInhibitor', () => {
     expect(inhibitor.getActiveCount()).toBe(0);
   });
 
-  it('handles async error events from the spawned child', () => {
+  it('handles async error events from the spawned child', async () => {
     const { children, inhibitor, logger } = createHarness('linux');
 
     const handle = inhibitor.acquire();
+    await vi.waitFor(() => expect(children).toHaveLength(1));
     children[0]!.emit('error', new Error('EPERM'));
 
     expect(inhibitor.isRunning()).toBe(false);
@@ -222,10 +271,11 @@ describe('SleepInhibitor', () => {
     handle.release();
   });
 
-  it('restarts after an unexpected exit when acquired again', () => {
+  it('restarts after an unexpected exit when acquired again', async () => {
     const { children, inhibitor, logger, spawn } = createHarness('linux');
 
     const first = inhibitor.acquire('initial work');
+    await vi.waitFor(() => expect(children).toHaveLength(1));
     children[0]!.emit('exit', 1, null);
 
     expect(inhibitor.isRunning()).toBe(false);
@@ -234,7 +284,7 @@ describe('SleepInhibitor', () => {
     );
 
     const second = inhibitor.acquire('more work');
-    expect(spawn).toHaveBeenCalledTimes(2);
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledTimes(3));
     expect(inhibitor.isRunning()).toBe(true);
 
     first.release();
@@ -255,13 +305,13 @@ describe('SleepInhibitor', () => {
     expect(() => missingGetter.release()).not.toThrow();
   });
 
-  it('dispose kills the active child, resets state, and is idempotent', () => {
+  it('dispose kills the active child, resets state, and is idempotent', async () => {
     const { children, inhibitor } = createHarness('linux');
 
     inhibitor.acquire('work');
     inhibitor.acquire('more work');
+    await vi.waitFor(() => expect(inhibitor.isRunning()).toBe(true));
     expect(inhibitor.getActiveCount()).toBe(2);
-    expect(inhibitor.isRunning()).toBe(true);
 
     inhibitor.dispose();
     expect(children[0]!.kill).toHaveBeenCalledTimes(1);
@@ -273,9 +323,12 @@ describe('SleepInhibitor', () => {
     expect(children[0]!.kill).toHaveBeenCalledTimes(1);
   });
 
-  it('does not propagate when child.kill() throws during release', () => {
+  it('does not propagate when child.kill() throws during release', async () => {
     const children: ChildProcess[] = [];
-    const spawn = vi.fn(() => {
+    const spawn = vi.fn((command: string, args: string[]) => {
+      if (command === 'systemd-inhibit' && args[0] === '--help') {
+        return createHelpChild('--no-ask-password');
+      }
       const child = new EventEmitter() as ChildProcess;
       Object.defineProperty(child, 'killed', { get: () => false });
       Object.defineProperty(child, 'pid', { value: 4242 });
@@ -294,6 +347,7 @@ describe('SleepInhibitor', () => {
     });
 
     const handle = inhibitor.acquire();
+    await vi.waitFor(() => expect(children).toHaveLength(1));
     expect(() => handle.release()).not.toThrow();
     expect(logger.warn).toHaveBeenCalledWith(
       'Failed to stop sleep inhibitor: ESRCH',
@@ -301,7 +355,7 @@ describe('SleepInhibitor', () => {
     expect(inhibitor.getActiveCount()).toBe(0);
   });
 
-  it('does not kill a child whose spawn failed (no pid)', () => {
+  it('does not kill a child whose spawn failed (no pid)', async () => {
     // Mimics the container sandbox: `systemd-inhibit` is absent, so the spawn
     // rejects with ENOENT on the next tick and the child never gets a pid. If
     // `stop()` (here via the synchronous release before the error event fires)
@@ -309,10 +363,13 @@ describe('SleepInhibitor', () => {
     // caller's own process group and deliver SIGTERM to this process, aborting
     // the run. Releasing must therefore be a no-op for a pidless child.
     const children: ChildProcess[] = [];
-    const spawn = vi.fn(() => {
-      // Pidless child: spawn returned but the process never started (ENOENT).
+    const spawn = vi.fn((command: string, args: string[]) => {
+      if (command === 'systemd-inhibit' && args[0] === '--help') {
+        return createErrorChild();
+      }
       const child = new EventEmitter() as ChildProcess;
       Object.defineProperty(child, 'killed', { get: () => false });
+      // Pidless child: spawn returned but the process never started (ENOENT).
       Object.defineProperty(child, 'pid', { value: undefined });
       child.kill = vi.fn(() => true);
       children.push(child);
@@ -327,7 +384,7 @@ describe('SleepInhibitor', () => {
     });
 
     const handle = inhibitor.acquire('executing tool');
-    expect(spawn).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledTimes(2));
 
     handle.release();
 
@@ -336,14 +393,15 @@ describe('SleepInhibitor', () => {
     expect(inhibitor.isRunning()).toBe(false);
   });
 
-  it('ignores a late error event from an already-replaced child', () => {
+  it('ignores a late error event from an already-replaced child', async () => {
     const { children, inhibitor, logger, spawn } = createHarness('linux');
 
     const first = inhibitor.acquire();
+    await vi.waitFor(() => expect(children).toHaveLength(1));
     // First child exits, so this.child is cleared and a re-acquire respawns.
     children[0]!.emit('exit', 0, null);
     const second = inhibitor.acquire();
-    expect(spawn).toHaveBeenCalledTimes(2);
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledTimes(3));
     expect(inhibitor.isRunning()).toBe(true);
 
     logger.debug.mockClear();
@@ -379,16 +437,50 @@ describe('SleepInhibitor', () => {
     second.release();
   });
 
-  it('sanitizes the systemd-inhibit reason (strips control chars, caps length)', () => {
+  it('sanitizes the systemd-inhibit reason (strips control chars, caps length)', async () => {
     const { inhibitor, spawn } = createHarness('linux');
 
     const handle = inhibitor.acquire(`run\x00 tool\n${'x'.repeat(200)}`);
-    const args = spawn.mock.calls[0]![1] as string[];
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledTimes(2));
+    const args = spawn.mock.calls[1]![1] as string[];
     const why = args.find((arg) => arg.startsWith('--why='))!;
 
     // eslint-disable-next-line no-control-regex
     expect(why).not.toMatch(/[\x00-\x1f\x7f]/);
     expect(why.length).toBeLessThanOrEqual('--why='.length + 120);
+
+    handle.release();
+  });
+
+  it.each([
+    {
+      support: true,
+      expected: true,
+      label: 'includes --no-ask-password when supported',
+    },
+    {
+      support: false,
+      expected: false,
+      label: 'omits --no-ask-password when not supported',
+    },
+    {
+      support: null,
+      expected: false,
+      label: 'omits --no-ask-password when unavailable',
+    },
+  ])('$label', async ({ support, expected }) => {
+    const { inhibitor, spawn } = createHarness('linux', {}, support);
+
+    const handle = inhibitor.acquire('working');
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledTimes(2));
+    const args = spawn.mock.calls[1]![1] as string[];
+
+    if (expected) {
+      expect(args[0]).toBe('--no-ask-password');
+    } else {
+      expect(args).not.toContain('--no-ask-password');
+    }
+    expect(args).toContain('--what=sleep');
 
     handle.release();
   });

--- a/packages/core/src/services/sleepInhibitor.ts
+++ b/packages/core/src/services/sleepInhibitor.ts
@@ -68,6 +68,8 @@ export class SleepInhibitor {
   private readonly env: NodeJS.ProcessEnv;
   private readonly spawn: NonNullable<SleepInhibitorConfig['spawn']>;
   private readonly logger: NonNullable<SleepInhibitorConfig['logger']>;
+  private noAskPasswordSupported: boolean | undefined;
+  private probing = false;
 
   constructor(config: SleepInhibitorConfig = {}) {
     this.platform = config.platform ?? defaultPlatform();
@@ -84,7 +86,7 @@ export class SleepInhibitor {
     if (this.activeCount === 1) {
       this.spawnFailedForCurrentRun = false;
       this.start(reason);
-    } else if (!this.child && !this.spawnFailedForCurrentRun) {
+    } else if (!this.child && !this.spawnFailedForCurrentRun && !this.probing) {
       this.start(reason);
     }
 
@@ -105,7 +107,7 @@ export class SleepInhibitor {
   }
 
   isRunning(): boolean {
-    return this.child !== undefined;
+    return this.child !== undefined && this.probing;
   }
 
   private release(): void {
@@ -121,10 +123,56 @@ export class SleepInhibitor {
   }
 
   private start(reason: string): void {
-    if (this.child || this.spawnFailedForCurrentRun) {
+    if (this.child || this.spawnFailedForCurrentRun || this.probing) {
       return;
     }
 
+    if (this.platform === 'linux') {
+      if (this.noAskPasswordSupported === undefined) {
+        this.probing = true;
+        this.probeNoAskPassword(() => {
+          this.probing = false;
+          this.doStart(reason);
+        });
+        return;
+      }
+    }
+    this.doStart(reason);
+  }
+
+  /**
+   * Spawn `systemd-inhibit --help` and inspect the output to determine whether
+   * `--no-ask-password` is supported. The result is cached so the probe only
+   * runs once per process lifetime.
+   */
+  private probeNoAskPassword(callback: () => void): void {
+    try {
+      const probe = this.spawn('systemd-inhibit', ['--help'], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let output = '';
+      let settled = false;
+      const settle = (supported: boolean): void => {
+        if (settled) return;
+        settled = true;
+        this.noAskPasswordSupported = supported;
+        callback();
+      };
+      probe.stdout?.on('data', (chunk: Buffer) => {
+        output += chunk.toString();
+      });
+      probe.stderr?.on('data', (chunk: Buffer) => {
+        output += chunk.toString();
+      });
+      probe.on('error', () => settle(false));
+      probe.on('close', () => settle(output.includes('--no-ask-password')));
+    } catch {
+      this.noAskPasswordSupported = false;
+      callback();
+    }
+  }
+
+  private doStart(reason: string): void {
     const command = this.getCommand(reason);
     if (!command) {
       this.logger.debug(this.getUnavailableMessage());
@@ -248,21 +296,24 @@ export class SleepInhibitor {
         // way to block that, so this does not fully match the Linux
         // systemd-inhibit semantics on battery.
         return { command: 'caffeinate', args: ['-is'] };
-      case 'linux':
+      case 'linux': {
         if (isHeadlessSshSession(this.env)) {
           return undefined;
         }
-        return {
-          command: 'systemd-inhibit',
-          args: [
-            '--what=sleep',
-            '--who=Qwen Code',
-            `--why=${sanitizeInhibitorReason(reason)}`,
-            '--mode=block',
-            'sleep',
-            'infinity',
-          ],
-        };
+        const args: string[] = [];
+        if (this.noAskPasswordSupported) {
+          args.push('--no-ask-password');
+        }
+        args.push(
+          '--what=sleep',
+          '--who=Qwen Code',
+          `--why=${sanitizeInhibitorReason(reason)}`,
+          '--mode=block',
+          'sleep',
+          'infinity',
+        );
+        return { command: 'systemd-inhibit', args };
+      }
       case 'win32':
         return {
           command: 'powershell.exe',

--- a/packages/core/src/services/sleepInhibitor.ts
+++ b/packages/core/src/services/sleepInhibitor.ts
@@ -107,7 +107,7 @@ export class SleepInhibitor {
   }
 
   isRunning(): boolean {
-    return this.child !== undefined && this.probing;
+    return this.child !== undefined;
   }
 
   private release(): void {
@@ -127,12 +127,14 @@ export class SleepInhibitor {
       return;
     }
 
-    if (this.platform === 'linux') {
+    if (this.platform === 'linux' && !isHeadlessSshSession(this.env)) {
       if (this.noAskPasswordSupported === undefined) {
         this.probing = true;
         this.probeNoAskPassword(() => {
           this.probing = false;
-          this.doStart(reason);
+          if (this.activeCount > 0) {
+            this.doStart(reason);
+          }
         });
         return;
       }


### PR DESCRIPTION

<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

Adds feature detection for `--no-ask-password` in the sleep inhibitor. On first `acquire()` on Linux, the code spawns `systemd-inhibit --help` and inspects the output to determine whether the flag is supported. The result is cached so the probe only runs once per process lifetime. When supported, `--no-ask-password` is prepended to the `systemd-inhibit` arguments, preventing polkit from prompting for interactive authentication.

## Why it's needed

On Linux systems with a desktop environment, running qwen-code over SSH (without a local DE session) causes `systemd-inhibit` to trigger a polkit authentication prompt (`AUTHENTICATING FOR org.freedesktop.login1.inhibit-block-sleep`). This prompt writes directly to the TUI's input stream, corrupting it and making the TUI unresponsive to user input. The `--no-ask-password` flag tells `systemd-inhibit` to skip interactive authorization, which is the correct behavior for a headless/SSH session where no user is present to respond to the prompt.

## Reviewer Test Plan

### How to verify

1. On a Linux system with a desktop environment (or a VM with one), start qwen-code via SSH without logging into the local DE.
2. Enable "Prevent system sleep" in `/settings`.
3. Verify that no polkit authentication prompt appears and the TUI remains responsive.
4. On a system where `systemd-inhibit` does not support `--no-ask-password` (older systemd), verify that sleep inhibition still works without the flag (graceful fallback).
5. Run `npx vitest run src/services/sleepInhibitor.test.ts` — all 18 tests should pass.

### Evidence (Before & After)

N/A (non-UI change; behavior is observed via TUI responsiveness and absence of polkit prompts)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Local Linux with systemd, Node.js v26.

## Risk & Scope

- Main risk or tradeoff: Adds a one-time spawn of `systemd-inhibit --help` on first acquire on Linux. The probe is fast (sub-millisecond) and the result is cached.
- Not validated / out of scope: Behavior on systems without systemd (the probe will fail gracefully and fall back to the original behavior).
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5281

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

为 sleep inhibitor 添加了 `--no-ask-password` 的特性检测。在 Linux 上首次调用 `acquire()` 时，代码会启动 `systemd-inhibit --help` 并检查输出以判断是否支持该标志。结果会被缓存，因此探测每个进程生命周期只运行一次。当支持该标志时，`--no-ask-password` 会被添加到 `systemd-inhibit` 参数的前面，防止 polkit 弹出交互式认证提示。

## 为什么需要

在带有桌面环境的 Linux 系统上，通过 SSH 运行 qwen-code（未登录本地桌面环境）会导致 `systemd-inhibit` 触发 polkit 认证提示（`AUTHENTICATING FOR org.freedesktop.login1.inhibit-block-sleep`）。该提示直接写入 TUI 的输入流，导致 TUI 无法响应用户输入。`--no-ask-password` 标志告诉 `systemd-inhibit` 跳过交互式授权，这对于没有用户在场响应提示的无头/SSH 会话是正确的行为。

## 审查者测试计划

### 如何验证

1. 在带有桌面环境的 Linux 系统（或虚拟机）上，通过 SSH 启动 qwen-code，不登录本地桌面环境。
2. 在 `/settings` 中启用"防止系统休眠"。
3. 验证不会出现 polkit 认证提示，且 TUI 保持正常响应。
4. 在不支持 `--no-ask-password` 的系统上（较旧的 systemd），验证休眠抑制功能仍然正常（优雅降级）。
5. 运行 `npx vitest run src/services/sleepInhibitor.test.ts` — 全部 18 个测试应通过。

### 证据（修改前与修改后）

N/A（非 UI 变更；行为通过 TUI 响应性和 polkit 提示的 absence 来观察）

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | N/A  |
| 🪟 Windows | N/A  |
|  🐧 Linux  |  ✅  |

### 环境（可选）

本地 Linux + systemd，Node.js v26。

## 风险与范围

- 主要风险或权衡：在 Linux 上首次 acquire 时增加了一次 `systemd-inhibit --help` 的 spawn。探测速度很快（亚毫秒级），且结果会被缓存。
- 未验证/超出范围：在没有 systemd 的系统上的行为（探测会优雅失败并回退到原始行为）。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Fixes #5281

</details>
