### PR TITLE
refactor(tools): rename TodoWrite tool display name to TodoList

### DIFF
--- a/integration-tests/concurrent-runner/export-html-from-chatrecord-jsonl.js
+++ b/integration-tests/concurrent-runner/export-html-from-chatrecord-jsonl.js
@@ -524,7 +524,7 @@ const TOOL_DISPLAY_NAME_BY_NAME = {
   grep_search: 'Grep',
   glob: 'Glob',
   run_shell_command: 'Shell',
-  todo_write: 'TodoWrite',
+  todo_write: 'TodoList',
   save_memory: 'SaveMemory',
   task: 'Task',
   skill: 'Skill',

--- a/packages/cli/src/commands/extensions/examples/agent/agents/diary.md
+++ b/packages/cli/src/commands/extensions/examples/agent/agents/diary.md
@@ -10,7 +10,7 @@ tools:
   - ReadManyFiles
   - NotebookRead
   - WebFetch
-  - TodoWrite
+  - TodoList
 modelConfig:
   model: qwen3-coder-plus
 ---

--- a/packages/cli/src/commands/extensions/examples/starter/agents/diary.md
+++ b/packages/cli/src/commands/extensions/examples/starter/agents/diary.md
@@ -10,7 +10,7 @@ tools:
   - ReadManyFiles
   - NotebookRead
   - WebFetch
-  - TodoWrite
+  - TodoList
 modelConfig:
   model: qwen3-coder-plus
 ---

--- a/packages/cli/src/i18n/index.test.ts
+++ b/packages/cli/src/i18n/index.test.ts
@@ -167,7 +167,7 @@ describe('localizeToolDisplayName', () => {
 
     // The namespaced `toolDisplayName.*` key translates the badge...
     expect(localizeToolDisplayName('Shell')).toBe('运行命令');
-    expect(localizeToolDisplayName('TodoWrite')).toBe('任务清单');
+    expect(localizeToolDisplayName('TodoList')).toBe('任务清单');
     // Proper tool names / acronyms are intentionally kept in English.
     expect(localizeToolDisplayName('Agent')).toBe('Agent');
     expect(localizeToolDisplayName('Grep')).toBe('Grep');
@@ -183,7 +183,7 @@ describe('localizeToolDisplayName', () => {
     );
     await setLanguageAsync('en');
 
-    expect(localizeToolDisplayName('TodoWrite')).toBe('TodoWrite');
+    expect(localizeToolDisplayName('TodoList')).toBe('TodoList');
     expect(localizeToolDisplayName('Shell')).toBe('Shell');
     // An unknown tool name passes through unchanged.
     expect(localizeToolDisplayName('MysteryTool')).toBe('MysteryTool');

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -24,7 +24,7 @@ export default {
   'toolDisplayName.Glob': 'toolDisplayName.Glob',
   'toolDisplayName.Shell': 'toolDisplayName.Shell',
   'toolDisplayName.Shell Command': 'toolDisplayName.Shell Command',
-  'toolDisplayName.TodoWrite': 'toolDisplayName.TodoWrite',
+  'toolDisplayName.TodoList': 'toolDisplayName.TodoList',
   'toolDisplayName.SaveMemory': 'toolDisplayName.SaveMemory',
   'toolDisplayName.Agent': 'toolDisplayName.Agent',
   'toolDisplayName.Skill': 'toolDisplayName.Skill',

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -24,7 +24,7 @@ export default {
   'toolDisplayName.Glob': 'Glob',
   'toolDisplayName.Shell': '運行命令',
   'toolDisplayName.Shell Command': 'Shell 命令',
-  'toolDisplayName.TodoWrite': '任務清單',
+  'toolDisplayName.TodoList': '任務清單',
   'toolDisplayName.SaveMemory': '儲存記憶',
   'toolDisplayName.Agent': 'Agent',
   'toolDisplayName.Skill': '技能',

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -24,7 +24,7 @@ export default {
   'toolDisplayName.Glob': 'Glob',
   'toolDisplayName.Shell': '运行命令',
   'toolDisplayName.Shell Command': 'Shell 命令',
-  'toolDisplayName.TodoWrite': '任务清单',
+  'toolDisplayName.TodoList': '任务清单',
   'toolDisplayName.SaveMemory': '保存记忆',
   'toolDisplayName.Agent': 'Agent',
   'toolDisplayName.Skill': '技能',

--- a/packages/cli/src/ui/utils/export/collect.ts
+++ b/packages/cli/src/ui/utils/export/collect.ts
@@ -611,7 +611,7 @@ class ExportSessionContext implements SessionContext {
       toolCall: {
         toolCallId: uuid, // Use the same uuid as toolCallId for plan updates
         kind: 'todowrite',
-        title: 'TodoWrite',
+        title: 'TodoList',
         status: 'completed',
         content: todoContent,
         timestamp: Date.parse(timestamp),

--- a/packages/core/src/extension/claude-converter.ts
+++ b/packages/core/src/extension/claude-converter.ts
@@ -108,7 +108,7 @@ const CLAUDE_TOOLS_MAPPING: Record<string, string | string[]> = {
   Read: 'ReadFile',
   Skill: 'Skill',
   Task: 'Task',
-  TodoWrite: 'TodoWrite',
+  TodoWrite: 'TodoList',
   WebFetch: 'WebFetch',
   WebSearch: 'None',
   Write: 'WriteFile',

--- a/packages/core/src/permissions/permission-manager.test.ts
+++ b/packages/core/src/permissions/permission-manager.test.ts
@@ -63,6 +63,16 @@ describe('resolveToolName', () => {
     expect(resolveToolName('TaskTool')).toBe('agent');
   });
 
+  it('resolves TodoList aliases (incl. legacy TodoWrite) to todo_write', async () => {
+    expect(resolveToolName('todo_write')).toBe('todo_write');
+    // The display name shown in the UI; a user writing allow: ["TodoList"]
+    // must resolve to the tool, not be silently dropped.
+    expect(resolveToolName('TodoList')).toBe('todo_write');
+    // Legacy display name (renamed from TodoWrite) keeps resolving.
+    expect(resolveToolName('TodoWrite')).toBe('todo_write');
+    expect(resolveToolName('TodoWriteTool')).toBe('todo_write');
+  });
+
   it('returns unknown names unchanged', async () => {
     expect(resolveToolName('my_mcp_tool')).toBe('my_mcp_tool');
     expect(resolveToolName('mcp__server__tool')).toBe('mcp__server__tool');

--- a/packages/core/src/permissions/rule-parser.ts
+++ b/packages/core/src/permissions/rule-parser.ts
@@ -88,8 +88,10 @@ export const TOOL_NAME_ALIASES: Readonly<Record<string, string>> = {
   ListFilesTool: 'list_directory',
   ReadFolder: 'list_directory', // legacy display name
 
-  // TodoWrite tool
+  // TodoList tool (wire name todo_write; class TodoWriteTool)
   todo_write: 'todo_write',
+  TodoList: 'todo_write',
+  // Legacy display name (renamed from "TodoWrite")
   TodoWrite: 'todo_write',
   TodoWriteTool: 'todo_write',
 
@@ -341,7 +343,7 @@ const CANONICAL_TO_RULE_DISPLAY: Readonly<Record<string, string>> = {
   skill: 'Skill',
   // Others
   save_memory: 'SaveMemory',
-  todo_write: 'TodoWrite',
+  todo_write: 'TodoList',
   lsp: 'Lsp',
   exit_plan_mode: 'ExitPlanMode',
   enter_plan_mode: 'EnterPlanMode',
@@ -459,7 +461,7 @@ const DISPLAY_NAME_TO_VERB: Readonly<Record<string, string>> = {
   Agent: 'use agent',
   Skill: 'use skill',
   SaveMemory: 'save memory',
-  TodoWrite: 'write todos',
+  TodoList: 'write todos',
   Lsp: 'use LSP',
   ExitPlanMode: 'exit plan mode',
   EnterPlanMode: 'enter plan mode',

--- a/packages/core/src/tools/todoWrite.test.ts
+++ b/packages/core/src/tools/todoWrite.test.ts
@@ -645,7 +645,7 @@ describe('TodoWriteTool', () => {
     });
 
     it('should have correct display name', () => {
-      expect(tool.displayName).toBe('TodoWrite');
+      expect(tool.displayName).toBe('TodoList');
     });
 
     it('should have correct kind', () => {

--- a/packages/core/src/tools/tool-names.ts
+++ b/packages/core/src/tools/tool-names.ts
@@ -71,7 +71,7 @@ export const ToolDisplayNames = {
   GREP: 'Grep',
   GLOB: 'Glob',
   SHELL: 'Shell',
-  TODO_WRITE: 'TodoWrite',
+  TODO_WRITE: 'TodoList',
   MEMORY: 'SaveMemory',
   AGENT: 'Agent',
   SKILL: 'Skill',
@@ -117,4 +117,5 @@ export const ToolDisplayNamesMigration = {
   FindFiles: ToolDisplayNames.GLOB, // Old display name for Glob
   ReadFolder: ToolDisplayNames.LS, // Old display name for ListFiles
   Task: ToolDisplayNames.AGENT, // Old display name for Agent (renamed from Task)
+  TodoWrite: ToolDisplayNames.TODO_WRITE, // Old display name for TodoList (renamed from TodoWrite)
 } as const;

--- a/packages/core/src/utils/tool-utils.test.ts
+++ b/packages/core/src/utils/tool-utils.test.ts
@@ -129,6 +129,18 @@ describe('isToolEnabled', () => {
     expect(isToolEnabled(ToolNames.GLOB, ['FindFiles'], undefined)).toBe(true);
   });
 
+  it('keeps the pre-rename TodoWrite display name working as a legacy alias', () => {
+    // The display name was renamed from 'TodoWrite' to 'TodoList'; existing
+    // coreTools/excludeTools configs that reference the old name must still
+    // resolve via ToolDisplayNamesMigration.
+    expect(isToolEnabled(ToolNames.TODO_WRITE, ['TodoWrite'], undefined)).toBe(
+      true,
+    );
+    expect(isToolEnabled(ToolNames.TODO_WRITE, undefined, ['TodoWrite'])).toBe(
+      false,
+    );
+  });
+
   it('enables tool when coreTools contains an argument-specific pattern', () => {
     expect(
       isToolEnabled(ToolNames.SHELL, ['Shell(git status)'], undefined),

--- a/packages/sdk-typescript/src/daemon/ui/normalizer.ts
+++ b/packages/sdk-typescript/src/daemon/ui/normalizer.ts
@@ -704,7 +704,7 @@ function normalizePlanUpdate(
     toolCallId: planCallId,
     title: 'Updated Plan',
     status: 'completed',
-    toolName: 'TodoWrite',
+    toolName: 'todo_write',
     toolKind: 'updated_plan',
     content: [
       {

--- a/packages/sdk-typescript/test/unit/daemonUi.test.ts
+++ b/packages/sdk-typescript/test/unit/daemonUi.test.ts
@@ -90,7 +90,7 @@ describe('daemon UI normalizer and transcript reducer', () => {
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({
       type: 'tool.update',
-      toolName: 'TodoWrite',
+      toolName: 'todo_write',
       rawOutput: {
         entries: [{ content: 'Task', status: 'completed', priority: 'medium' }],
         stats: {

--- a/packages/web-shell/client/components/messages/ToolGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.test.tsx
@@ -384,7 +384,7 @@ describe('todo_write tool rendering', () => {
 
   it('expands to the full list on click', () => {
     const container = renderTodoTool(makeTodoTool());
-    expandTool(container, 'TodoWrite');
+    expandTool(container, 'TodoList');
     expect(container.textContent).toContain('First task');
     expect(container.textContent).toContain('Second task');
     expect(container.textContent).toContain('Third task');

--- a/packages/web-shell/client/components/messages/toolFormatting.test.ts
+++ b/packages/web-shell/client/components/messages/toolFormatting.test.ts
@@ -213,7 +213,7 @@ describe('toolFormatting', () => {
 
     it('falls back to the English display name when the locale has no entry', () => {
       const t = getTranslator('en');
-      expect(localizeToolDisplayName('todo_write', t)).toBe('TodoWrite');
+      expect(localizeToolDisplayName('todo_write', t)).toBe('TodoList');
       expect(localizeToolDisplayName('grep_search', t)).toBe('Grep');
     });
 

--- a/packages/web-shell/client/components/messages/toolFormatting.ts
+++ b/packages/web-shell/client/components/messages/toolFormatting.ts
@@ -7,7 +7,7 @@ export const TOOL_DISPLAY_NAMES: Record<string, string> = {
   grep_search: 'Grep',
   glob: 'Glob',
   run_shell_command: 'Shell',
-  todo_write: 'TodoWrite',
+  todo_write: 'TodoList',
   save_memory: 'SaveMemory',
   agent: 'Agent',
   skill: 'Skill',

--- a/packages/webui/src/components/toolcalls/UpdatedPlanToolCall.stories.tsx
+++ b/packages/webui/src/components/toolcalls/UpdatedPlanToolCall.stories.tsx
@@ -27,7 +27,7 @@ export const MixedStatus: Story = {
     toolCall: {
       toolCallId: 'plan-1',
       kind: 'todo_write',
-      title: 'TodoWrite',
+      title: 'TodoList',
       status: 'completed',
       content: [
         {
@@ -47,7 +47,7 @@ export const AllCompleted: Story = {
     toolCall: {
       toolCallId: 'plan-2',
       kind: 'todo_write',
-      title: 'TodoWrite',
+      title: 'TodoList',
       status: 'completed',
       content: [
         {
@@ -67,7 +67,7 @@ export const AllPending: Story = {
     toolCall: {
       toolCallId: 'plan-3',
       kind: 'todo_write',
-      title: 'TodoWrite',
+      title: 'TodoList',
       status: 'completed',
       content: [
         {
@@ -87,7 +87,7 @@ export const WithError: Story = {
     toolCall: {
       toolCallId: 'plan-4',
       kind: 'todo_write',
-      title: 'TodoWrite',
+      title: 'TodoList',
       status: 'failed',
       content: [
         {

--- a/packages/webui/src/components/toolcalls/UpdatedPlanToolCall.tsx
+++ b/packages/webui/src/components/toolcalls/UpdatedPlanToolCall.tsx
@@ -132,7 +132,7 @@ export const UpdatedPlanToolCall: FC<BaseToolCallProps> = ({
   if (errors.length > 0) {
     return (
       <PlanToolCallContainer
-        label="TodoWrite"
+        label="TodoList"
         status="error"
         isFirst={isFirst}
         isLast={isLast}

--- a/packages/webui/src/components/toolcalls/labelUtils.test.ts
+++ b/packages/webui/src/components/toolcalls/labelUtils.test.ts
@@ -21,13 +21,13 @@ describe('getToolDisplayLabel', () => {
   it('normalizes todo write labels even when older titles are still present', () => {
     expect(
       getToolDisplayLabel({ kind: 'todo_write', title: 'Updated Plan' }),
-    ).toBe('TodoWrite');
+    ).toBe('TodoList');
     expect(
       getToolDisplayLabel({ kind: 'update_todos', title: 'Update Todos' }),
-    ).toBe('TodoWrite');
+    ).toBe('TodoList');
     expect(
       getToolDisplayLabel({ kind: 'updated_plan', title: 'Updated Plan' }),
-    ).toBe('TodoWrite');
+    ).toBe('TodoList');
   });
 
   it('uses core names for read-family tools by kind', () => {

--- a/packages/webui/src/components/toolcalls/labelUtils.ts
+++ b/packages/webui/src/components/toolcalls/labelUtils.ts
@@ -59,7 +59,7 @@ export const getToolDisplayLabel = ({
     case 'update_todos':
     case 'updated_plan':
     case 'updatedplan':
-      return 'TodoWrite';
+      return 'TodoList';
     case 'web_fetch':
     case 'webfetch':
     case 'fetch':

--- a/packages/webui/src/daemon/session/selectors.ts
+++ b/packages/webui/src/daemon/session/selectors.ts
@@ -72,6 +72,7 @@ export function extractDaemonTodosFromToolBlock(
   const toolKind = (block.toolKind ?? '').toLowerCase();
   if (
     toolName !== 'todowrite' &&
+    toolName !== 'todo_write' &&
     toolKind !== 'updated_plan' &&
     toolKind !== 'todo' &&
     toolKind !== 'other'


### PR DESCRIPTION
## What this PR does

Renames the todo tool's user-facing display name from "TodoWrite" to "TodoList" across every surface that renders it — the terminal UI badge, the web-shell, and the webui — while keeping the wire/schema tool name `todo_write` unchanged. Existing model tool calls and any `coreTools` / `excludeTools` configuration that referenced the old "TodoWrite" display name keep working via a back-compat alias.

It also fixes a related inconsistency in the daemon path: when todo updates are routed through the ACP plan path (`ToolCallEmitter` → `PlanEmitter.emitPlan`), the SDK daemon normalizer minted the literal `toolName: 'TodoWrite'`, which the web-shell could not localize because its display map is keyed on the wire name `todo_write` — so the badge showed the raw "TodoWrite" instead of a localized label. The normalizer now emits the wire name `todo_write`, so the existing display + i18n machinery renders "TodoList" (and "任务清单" in Chinese) for plan-routed todos.

## Why it's needed

"TodoWrite" doubles awkwardly as both a display label and an internal identifier, and after the tool's description was broadened to cover planning, the "Todo" framing reads as a low-level chore list rather than the task/plan tracker it has become. "TodoList" reads cleanly as the name of the artifact the tool manages and aligns with the localized Chinese label "任务清单" (task list), while staying in the Todo namespace so it isn't conflated with the async Task* tools (TaskCreate/TaskList/…). The rename is applied to user-facing display only; the model-facing wire name stays `todo_write` so tool-call behavior and prompts are unaffected.

## Reviewer Test Plan

### How to verify

- TUI badge: run the CLI and trigger a multi-step task so the todo tool is invoked; the tool badge reads **TodoList** (English) / **任务清单** (Chinese), where it previously read **TodoWrite**.
- web-shell (`npm run dev:daemon`): trigger todos; the tool group header reads **TodoList** instead of **TodoWrite**. (Because the daemon normalizer ships via the sdk dist, this requires `npm run build` for the sdk plus a fresh Vite dep bundle.)
- Back-compat: a config with `coreTools: ["TodoWrite"]` still enables the tool, resolved via `ToolDisplayNamesMigration`.
- Unit suites listed below.

### Evidence (Before & After)

Badge label: **Before** `TodoWrite` → **After** `TodoList` (Chinese stays `任务清单`). Visual capture is pending a maintainer run; the change is verified at the unit level across every surface:

- core: `tool-utils.test.ts` (incl. a new case asserting the legacy `TodoWrite` display name still enables/excludes the tool), `todoWrite.test.ts`
- cli: `i18n/index.test.ts` (incl. the guard that every core display name has a zh translation)
- web-shell: `toolFormatting.test.ts`, `ToolGroup.test.tsx`, `todos.test.ts`
- webui: `labelUtils.test.ts`, daemon `selectors.test.ts`, `DaemonSessionProvider.test.tsx`
- sdk: `daemonUi.test.ts`

All green.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS: unit suites above. Windows/Linux not run locally; the change is a platform-independent string/label rename.

### Environment (optional)

Unit tests via vitest; web-shell via `npm run dev:daemon` (Vite dev server + daemon).

## Risk & Scope

- Main risk or tradeoff: a surface that derives the todo display label from the literal "TodoWrite" and is not covered here would show a stale label. The change swept core / cli / web-shell / webui / sdk; no case-sensitive `=== 'TodoWrite'` consumer remains.
- Not validated / out of scope: **desktop** intentionally keeps "TodoWrite" as an internal tool identifier (it humanizes to "Updating Tasks" / "Todo List Updated" for users, so the raw string is never shown); the cli transcript export keeps "TodoWrite" as part of the export → reader contract.
- Breaking changes / migration notes: none. The wire name `todo_write` is unchanged, and the old "TodoWrite" display name still resolves for tool enable/exclude configuration via `ToolDisplayNamesMigration`.

## Linked Issues

(none)

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 todo 工具面向用户的**显示名**从 “TodoWrite” 改为 “TodoList”,覆盖所有会渲染它的界面——终端 UI 徽章、web-shell、webui——同时保持 wire/schema 工具名 `todo_write` 不变。已有的模型工具调用、以及任何引用旧 “TodoWrite” 显示名的 `coreTools` / `excludeTools` 配置,都通过一个向后兼容别名继续生效。

同时修复 daemon 路径上的一处相关不一致:当 todo 更新走 ACP plan 路径(`ToolCallEmitter` → `PlanEmitter.emitPlan`)时,SDK daemon normalizer 硬编码了 `toolName: 'TodoWrite'`,而 web-shell 的显示映射是按 wire 名 `todo_write` 建键的,无法本地化,于是徽章显示出原始的 “TodoWrite” 而非本地化标签。现在 normalizer 改为发出 wire 名 `todo_write`,使既有的显示 + i18n 机制对 plan 路径的 todo 渲染出 “TodoList”(中文 “任务清单”)。

## 为什么需要

“TodoWrite” 同时承担了显示标签和内部标识符两种角色;而且在该工具的描述被扩展到涵盖 planning 之后,“Todo” 的措辞更像低层的杂事清单,而非它如今承担的任务/计划跟踪器。“TodoList” 直接命名该工具管理的“清单”产物,与本地化中文标签“任务清单”对齐,并留在 Todo 命名空间(不与异步 Task* 工具 TaskCreate/TaskList 等混淆)。本次改名只作用于面向用户的显示;面向模型的 wire 名保持 `todo_write`,因此工具调用行为与提示词不受影响。

## 评审验证计划

### 如何验证

- TUI 徽章:运行 CLI 并触发一个多步骤任务以调用 todo 工具;工具徽章显示 **TodoList**(英文)/ **任务清单**(中文),此前是 **TodoWrite**。
- web-shell(`npm run dev:daemon`):触发 todo;工具组标题显示 **TodoList** 而非 **TodoWrite**。(因为 daemon normalizer 经 sdk dist 分发,需先 `npm run build` sdk 并重新生成 Vite 依赖打包。)
- 向后兼容:配置 `coreTools: ["TodoWrite"]` 仍能启用该工具(经 `ToolDisplayNamesMigration` 解析)。
- 下列单元测试。

### 证据(前后对比)

徽章标签:**改前** `TodoWrite` → **改后** `TodoList`(中文仍为 `任务清单`)。可视化截图待维护者运行确认;改动已在所有界面的单元层面验证:

- core:`tool-utils.test.ts`(含新增用例:断言旧 `TodoWrite` 显示名仍能启用/排除工具)、`todoWrite.test.ts`
- cli:`i18n/index.test.ts`(含“每个核心显示名都有 zh 翻译”的守卫)
- web-shell:`toolFormatting.test.ts`、`ToolGroup.test.tsx`、`todos.test.ts`
- webui:`labelUtils.test.ts`、daemon `selectors.test.ts`、`DaemonSessionProvider.test.tsx`
- sdk:`daemonUi.test.ts`

全部通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS:上述单元测试。Windows/Linux 未在本地运行;本改动是与平台无关的字符串/标签改名。

### 运行环境(可选)

单元测试经 vitest;web-shell 经 `npm run dev:daemon`(Vite dev server + daemon)。

## 风险与范围

- 主要风险/取舍:若某个界面是从字面量 “TodoWrite” 派生 todo 显示标签且未被本 PR 覆盖,则会显示陈旧标签。本次已横扫 core / cli / web-shell / webui / sdk;不再存在任何大小写敏感的 `=== 'TodoWrite'` 消费方。
- 未验证 / 范围之外:**desktop** 刻意保留 “TodoWrite” 作为内部工具标识符(它对用户 humanize 成 “Updating Tasks” / “Todo List Updated”,从不直接展示原始串);cli 的 transcript 导出保留 “TodoWrite” 作为导出→阅读器契约的一部分。
- 破坏性变更 / 迁移说明:无。wire 名 `todo_write` 不变,旧 “TodoWrite” 显示名在工具启用/排除配置中仍可经 `ToolDisplayNamesMigration` 解析。

## 关联 Issue

(无)

</details>
