### PR TITLE
fix(core): preserve migrated command description strings

### DIFF
--- a/packages/cli/src/services/command-migration-tool.test.ts
+++ b/packages/cli/src/services/command-migration-tool.test.ts
@@ -13,6 +13,10 @@ import {
   migrateTomlCommands,
   generateMigrationPrompt,
 } from './command-migration-tool.js';
+import {
+  parseMarkdownCommand,
+  MarkdownCommandDefSchema,
+} from './markdown-command-parser.js';
 
 describe('command-migration-tool', () => {
   let tempDir: string;
@@ -151,6 +155,33 @@ description = "Test description"`;
         .then(() => true)
         .catch(() => false);
       expect(backupExists).toBe(false);
+    });
+
+    it('should preserve YAML-like descriptions as strings', async () => {
+      const tomlContent = `prompt = "Test prompt"
+description = "false"`;
+
+      await fs.writeFile(path.join(tempDir, 'test.toml'), tomlContent, 'utf-8');
+
+      const result = await migrateTomlCommands({
+        commandDir: tempDir,
+        createBackup: false,
+      });
+
+      expect(result.success).toBe(true);
+
+      const mdContent = await fs.readFile(
+        path.join(tempDir, 'test.md'),
+        'utf-8',
+      );
+      const parsed = parseMarkdownCommand(mdContent);
+      const validationResult = MarkdownCommandDefSchema.safeParse(parsed);
+
+      expect(validationResult.success).toBe(true);
+      if (!validationResult.success) {
+        throw new Error('expected migrated command to be valid markdown');
+      }
+      expect(validationResult.data.frontmatter?.description).toBe('false');
     });
 
     it('should fail if Markdown file already exists', async () => {

--- a/packages/core/src/utils/toml-to-markdown-converter.test.ts
+++ b/packages/core/src/utils/toml-to-markdown-converter.test.ts
@@ -9,6 +9,13 @@ import {
   convertTomlToMarkdown,
   isTomlFormat,
 } from './toml-to-markdown-converter.js';
+import { parse as parseYaml } from './yaml-parser.js';
+
+function readDescriptionFromFrontmatter(markdown: string): unknown {
+  const match = markdown.match(/^---\n([\s\S]*?)\n---\n/);
+  expect(match).not.toBeNull();
+  return parseYaml(match![1])['description'];
+}
 
 describe('convertTomlToMarkdown', () => {
   it('should convert TOML with description to Markdown', () => {
@@ -69,7 +76,20 @@ description = "Command with: special, characters!"`;
 
     const result = convertTomlToMarkdown(tomlContent);
 
-    expect(result).toContain('description: Command with: special, characters!');
+    expect(readDescriptionFromFrontmatter(result)).toBe(
+      'Command with: special, characters!',
+    );
+  });
+
+  it('should preserve YAML-like description strings as strings', () => {
+    for (const description of ['false', '123', 'null', 'line one\nline two']) {
+      const tomlContent = `prompt = "Test prompt"
+description = ${JSON.stringify(description)}`;
+
+      const result = convertTomlToMarkdown(tomlContent);
+
+      expect(readDescriptionFromFrontmatter(result)).toBe(description);
+    }
   });
 });
 

--- a/packages/core/src/utils/toml-to-markdown-converter.ts
+++ b/packages/core/src/utils/toml-to-markdown-converter.ts
@@ -9,6 +9,7 @@
  */
 
 import toml from '@iarna/toml';
+import { stringify as stringifyYaml } from './yaml-parser.js';
 
 export interface TomlCommandFormat {
   prompt: string;
@@ -47,8 +48,13 @@ export function convertTomlToMarkdown(tomlContent: string): string {
 
   // Generate Markdown
   if (description) {
+    const frontmatter = stringifyYaml(
+      { description },
+      { lineWidth: 0 },
+    ).trimEnd();
+
     return `---
-description: ${description}
+${frontmatter}
 ---
 
 ${prompt}


### PR DESCRIPTION
## Summary

- serialize TOML command migration frontmatter with the shared YAML stringifier
- keep YAML-like descriptions such as `false`, `123`, and `null` as strings after migration
- add migration-level coverage that validates the generated Markdown command schema

Fixes #5320

## Test plan

- `npx vitest run src/utils/toml-to-markdown-converter.test.ts` from `packages/core`
- `npx vitest run src/services/command-migration-tool.test.ts` from `packages/cli`
- `npm run typecheck --workspace=packages/core`
- `npm run typecheck --workspace=packages/cli`
- `npm run build --workspace=packages/core`
- `npm run build --workspace=packages/cli`
- `npm run lint`
- `npx prettier --experimental-cli --check packages/core/src/utils/toml-to-markdown-converter.ts packages/core/src/utils/toml-to-markdown-converter.test.ts packages/cli/src/services/command-migration-tool.test.ts`
- `git diff --check`

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.