### PR TITLE
fix(cli): preserve empty MCP prompt args

### DIFF
--- a/packages/cli/src/services/McpPromptLoader.test.ts
+++ b/packages/cli/src/services/McpPromptLoader.test.ts
@@ -101,6 +101,25 @@ describe('McpPromptLoader', () => {
       expect(result).toEqual({ named: 'value', pos: 'positional' });
     });
 
+    it('should preserve empty optional named arguments', () => {
+      const loader = new McpPromptLoader(mockConfig);
+      const promptArgs: PromptArgument[] = [{ name: 'trail', required: false }];
+      const userArgs = '--trail=""';
+      const result = loader.parseArgs(userArgs, promptArgs);
+      expect(result).toEqual({ trail: '' });
+    });
+
+    it('should treat empty required named arguments as provided', () => {
+      const loader = new McpPromptLoader(mockConfig);
+      const promptArgs: PromptArgument[] = [
+        { name: 'name', required: true },
+        { name: 'age', required: true },
+      ];
+      const userArgs = '--name="" --age=""';
+      const result = loader.parseArgs(userArgs, promptArgs);
+      expect(result).toEqual({ name: '', age: '' });
+    });
+
     it('should handle positional args followed by named args', () => {
       const loader = new McpPromptLoader(mockConfig);
       const promptArgs: PromptArgument[] = [

--- a/packages/cli/src/services/McpPromptLoader.ts
+++ b/packages/cli/src/services/McpPromptLoader.ts
@@ -277,13 +277,13 @@ export class McpPromptLoader implements ICommandLoader {
       return promptInputs;
     }
     for (const arg of promptArgs) {
-      if (argValues[arg.name]) {
+      if (Object.hasOwn(argValues, arg.name)) {
         promptInputs[arg.name] = argValues[arg.name];
       }
     }
 
     const unfilledArgs = promptArgs.filter(
-      (arg) => arg.required && !promptInputs[arg.name],
+      (arg) => arg.required && !Object.hasOwn(promptInputs, arg.name),
     );
 
     if (unfilledArgs.length === 1) {


### PR DESCRIPTION
## What this PR does

Fixes argument parsing in the MCP prompt loader so that a named argument explicitly set to an empty string is treated as **provided** rather than missing.

In `McpPromptLoader.parseArgs`, two truthy checks are replaced with presence checks (`Object.hasOwn`):

- When copying parsed values into the prompt inputs, the loader now keys off whether the argument name is present, not whether its value is truthy. This preserves optional empty named args like `--trail=""` (previously dropped, producing `{}`).
- When computing the unfilled/required arguments, the loader now checks presence instead of truthiness, so required named args like `--name=""` are no longer reported as missing.

## Why it's needed

MCP prompt named arguments explicitly set to an empty string were parsed as if they were absent. An empty string is still a valid string value, but the old truthy checks in `McpPromptLoader.parseArgs` discarded it:

- `--trail=""` produced `{}` for an optional `trail` argument.
- `--name="" --age=""` reported both required arguments as missing, even though both flags were supplied.

This fix makes the parser track whether a named argument was present rather than whether its value is truthy. (See issue #5322.)

## Reviewer Test Plan

### How to verify

Reproduce the bug by passing empty-string named args to an MCP prompt: with the old code, `--trail=""` yields `{}` and `--name="" --age=""` is flagged as missing required arguments; with this change, the empty values are preserved (`{ trail: '' }`, `{ name: '', age: '' }`) and required args are no longer reported missing.

This is covered by two new unit tests in `McpPromptLoader.test.ts` ("should preserve empty optional named arguments" and "should treat empty required named arguments as provided").

Verification commands run by the author:

- `npx vitest run src/services/McpPromptLoader.test.ts` from `packages/cli`
- `npm run typecheck --workspace=packages/cli`
- `npm run build --workspace=packages/core`
- `npm run build --workspace=packages/cli`
- `npm run lint`
- `npx prettier --experimental-cli --check packages/cli/src/services/McpPromptLoader.ts packages/cli/src/services/McpPromptLoader.test.ts`
- `git diff --check`

### Evidence (Before & After)

N/A — non-visible logic fix; covered by the unit tests above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI |
| 🪟 Windows |  ✅ CI |
|  🐧 Linux  |  ✅ CI |

✅ tested · ⚠️ not tested · N/A

### Environment (optional)

Unit tests only (npm workspaces).

## Risk & Scope

- Main risk or tradeoff: Low; scoped to `McpPromptLoader.parseArgs`. The behavior change is limited to named arguments whose value is an empty string — they are now retained instead of dropped.
- Not validated / out of scope: No unrelated refactors, public API changes, or UI changes.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5322

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复 MCP prompt 加载器的参数解析：当某个具名参数被显式设置为空字符串时，现在会被视为**已提供**，而不是缺失。

在 `McpPromptLoader.parseArgs` 中，两处真值（truthy）判断被替换为存在性判断（`Object.hasOwn`）：

- 将已解析的值拷贝到 prompt 输入时，加载器现在依据参数名是否存在来判断，而不是依据其值是否为真值。这样就能保留像 `--trail=""` 这样的可选空参数（此前会被丢弃，得到 `{}`）。
- 计算未填写/必填参数时，加载器现在改用存在性判断而非真值判断，因此像 `--name=""` 这样的必填具名参数不再被报告为缺失。

## 为什么需要它

被显式设置为空字符串的 MCP prompt 具名参数此前会被当作不存在处理。空字符串仍然是合法的字符串值，但 `McpPromptLoader.parseArgs` 中旧的真值判断把它丢弃了：

- 对于可选的 `trail` 参数，`--trail=""` 会得到 `{}`。
- `--name="" --age=""` 会把这两个必填参数都报告为缺失，尽管两个标志都已传入。

本次修复让解析器跟踪具名参数是否存在，而不是判断其值是否为真值。（见 issue #5322。）

## 审阅者测试计划

### 如何验证

复现该 bug：向 MCP prompt 传入空字符串具名参数。使用旧代码时，`--trail=""` 得到 `{}`，而 `--name="" --age=""` 会被标记为缺失必填参数；应用本次改动后，空值被保留（`{ trail: '' }`、`{ name: '', age: '' }`），且必填参数不再被报告为缺失。

这一点由 `McpPromptLoader.test.ts` 中两个新增单元测试覆盖（"should preserve empty optional named arguments" 与 "should treat empty required named arguments as provided"）。

作者运行的验证命令：

- 在 `packages/cli` 下执行 `npx vitest run src/services/McpPromptLoader.test.ts`
- `npm run typecheck --workspace=packages/cli`
- `npm run build --workspace=packages/core`
- `npm run build --workspace=packages/cli`
- `npm run lint`
- `npx prettier --experimental-cli --check packages/cli/src/services/McpPromptLoader.ts packages/cli/src/services/McpPromptLoader.test.ts`
- `git diff --check`

### 证据（前后对比）

N/A —— 非可见的逻辑修复；已由上述单元测试覆盖。

### 测试平台

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI |
| 🪟 Windows |  ✅ CI |
|  🐧 Linux  |  ✅ CI |

✅ 已测试 · ⚠️ 未测试 · N/A

### 环境（可选）

仅单元测试（npm workspaces）。

## 风险与范围

- 主要风险或权衡：低；范围限定在 `McpPromptLoader.parseArgs`。行为变化仅限于值为空字符串的具名参数——它们现在会被保留而非丢弃。
- 未验证 / 范围之外：没有无关的重构、公共 API 变更或 UI 变更。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #5322

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
