### PR TITLE
fix(cli): parse sandbox image registry ports

### DIFF
--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseSandboxImageName } from './sandboxImageName.js';
+
+describe('parseSandboxImageName', () => {
+  it('uses the image basename and tag for container names', () => {
+    expect(parseSandboxImageName('ghcr.io/qwenlm/qwen-code:0.18.3')).toBe(
+      'qwen-code-0.18.3',
+    );
+  });
+
+  it('handles registry ports without treating them as tags', () => {
+    expect(
+      parseSandboxImageName('localhost:5000/team/qwen-code-sandbox:dev'),
+    ).toBe('qwen-code-sandbox-dev');
+  });
+
+  it('handles registry ports when the image is untagged', () => {
+    expect(parseSandboxImageName('localhost:5000/team/qwen-code-sandbox')).toBe(
+      'qwen-code-sandbox',
+    );
+  });
+
+  it('drops digests from generated container names', () => {
+    expect(
+      parseSandboxImageName(
+        'registry.example.com/team/qwen-code-sandbox@sha256:abcdef',
+      ),
+    ).toBe('qwen-code-sandbox');
+  });
+
+  it('keeps tags when dropping digests from generated container names', () => {
+    expect(
+      parseSandboxImageName(
+        'registry.example.com/team/qwen-code-sandbox:dev@sha256:abcdef',
+      ),
+    ).toBe('qwen-code-sandbox-dev');
+  });
+});

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -23,6 +23,7 @@ import {
 } from '@qwen-code/qwen-code-core';
 import { randomBytes } from 'node:crypto';
 import { writeStderrLine } from './stdioHelpers.js';
+import { parseSandboxImageName } from './sandboxImageName.js';
 
 const execAsync = promisify(exec);
 
@@ -100,14 +101,6 @@ async function shouldUseCurrentUserInSandbox(): Promise<boolean> {
   }
 
   return false;
-}
-
-// docker does not allow container names to contain ':' or '/', so we
-// parse those out to shorten the name
-function parseImageName(image: string): string {
-  const [fullName, tag] = image.split(':');
-  const name = fullName.split('/').at(-1) ?? 'unknown-image';
-  return tag ? `${name}-${tag}` : name;
 }
 
 function ports(): string[] {
@@ -603,7 +596,7 @@ export async function start_sandbox(
   }
 
   // name container after image, plus random suffix to avoid conflicts
-  const imageName = parseImageName(image);
+  const imageName = parseSandboxImageName(image);
   const isIntegrationTest =
     process.env['QWEN_CODE_INTEGRATION_TEST'] === 'true';
   let containerName;

--- a/packages/cli/src/utils/sandboxImageName.ts
+++ b/packages/cli/src/utils/sandboxImageName.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Docker does not allow container names to contain ':' or '/', so parse
+// registry paths and image tags into a short container-name prefix.
+export function parseSandboxImageName(image: string): string {
+  const imageWithoutDigest = image.split('@')[0] ?? image;
+  const lastSlash = imageWithoutDigest.lastIndexOf('/');
+  const lastColon = imageWithoutDigest.lastIndexOf(':');
+  const hasTag = lastColon > lastSlash;
+  const fullName = hasTag
+    ? imageWithoutDigest.slice(0, lastColon)
+    : imageWithoutDigest;
+  const tag = hasTag ? imageWithoutDigest.slice(lastColon + 1) : undefined;
+  const name = fullName.split('/').at(-1) || 'unknown-image';
+
+  return tag ? `${name}-${tag}` : name;
+}


### PR DESCRIPTION
## What this PR does

Moves the sandbox image-name parsing out of `sandbox.ts` into a small, dedicated and unit-tested helper (`parseSandboxImageName` in `sandboxImageName.ts`), and fixes how the image reference is split into a Docker container-name prefix:

- The tag separator is now resolved as the last `:` that appears **after** the final `/`, so a registry port such as `localhost:5000` is correctly treated as part of the registry path rather than as an image tag.
- The container-name prefix is still derived from the image **basename** plus its tag (e.g. `ghcr.io/qwenlm/qwen-code:0.18.3` → `qwen-code-0.18.3`).
- Image **digests** (`@sha256:...`) are stripped before parsing, so they no longer leak into the generated name, while any preceding tag is preserved (e.g. `…/qwen-code-sandbox:dev@sha256:…` → `qwen-code-sandbox-dev`).

The previous implementation used `image.split(':')`, which broke on registry ports. Behavior is otherwise unchanged.

## Why it's needed

Fixes #5324. Sandbox container names are derived from the configured image name, but the old parser split on the first `:`. For common private-registry images that include a port, e.g. `localhost:5000/team/qwen-code:dev`, this collapsed the name down to `localhost-5000`, losing the real image basename and tag. After this change the registry port stays part of the registry path and the container name is correctly based on the image basename (`qwen-code-dev`).

## Reviewer Test Plan

### How to verify

Repro: configure a sandbox image with a registry port, e.g. `localhost:5000/team/qwen-code:dev`.
- Expected (old, buggy): container-name prefix `localhost-5000`.
- Expected (new, fixed): container-name prefix `qwen-code-dev`.

The new unit tests cover this repro plus untagged ports, digest stripping, and tag+digest combinations. Verification commands from the PR:

- `npx vitest run src/utils/sandbox.test.ts` from `packages/cli`
- `npm run typecheck --workspace=packages/cli`
- `npm run build --workspace=packages/cli`
- `npm run lint`
- `npx prettier --experimental-cli --check packages/cli/src/utils/sandbox.ts packages/cli/src/utils/sandboxImageName.ts packages/cli/src/utils/sandbox.test.ts`
- `git diff --check`

### Evidence (Before & After)

N/A — non-visible logic fix (internal container-name derivation); covered by the unit tests above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI  |
| 🪟 Windows |  ✅ CI  |
|  🐧 Linux  |  ✅ CI  |

✅ tested · ⚠️ not tested · N/A

### Environment (optional)

Unit tests only (npm workspaces).

## Risk & Scope

- Main risk or tradeoff: Low; scoped to sandbox container-name derivation in `packages/cli`. Behavior change is limited to how the image reference is parsed into a name prefix.
- Not validated / out of scope: No unrelated refactors, public API changes, or UI changes.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5324

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

将 sandbox 镜像名解析逻辑从 `sandbox.ts` 抽取到一个独立、带单元测试的小helper（`sandboxImageName.ts` 中的 `parseSandboxImageName`），并修复了将镜像引用切分为 Docker 容器名前缀的方式：

- 标签（tag）分隔符现在被解析为最后一个 `/` **之后** 出现的最后一个 `:`，因此像 `localhost:5000` 这样的 registry 端口会被正确当作 registry 路径的一部分，而不是被误认为镜像标签。
- 容器名前缀仍然由镜像 **basename** 加上其标签派生而来（例如 `ghcr.io/qwenlm/qwen-code:0.18.3` → `qwen-code-0.18.3`）。
- 镜像 **digest**（`@sha256:...`）在解析前会被剥离，因此不再混入生成的名字中，同时其前面的标签会被保留（例如 `…/qwen-code-sandbox:dev@sha256:…` → `qwen-code-sandbox-dev`）。

旧实现使用 `image.split(':')`，在遇到 registry 端口时会出错。除此之外行为保持不变。

## 为什么需要它

修复 #5324。Sandbox 容器名是从配置的镜像名派生的，但旧解析器在第一个 `:` 处切分。对于包含端口的常见私有 registry 镜像，例如 `localhost:5000/team/qwen-code:dev`，这会把名字压缩成 `localhost-5000`，丢失了真正的镜像 basename 和标签。改动之后，registry 端口会保留为 registry 路径的一部分，容器名正确地基于镜像 basename（`qwen-code-dev`）。

## Reviewer 测试计划

### 如何验证

复现：配置一个带 registry 端口的 sandbox 镜像，例如 `localhost:5000/team/qwen-code:dev`。
- 预期（旧的、有 bug 的）：容器名前缀 `localhost-5000`。
- 预期（新的、已修复的）：容器名前缀 `qwen-code-dev`。

新增的单元测试覆盖了该复现，以及不带标签的端口、digest 剥离、标签 + digest 组合等场景。PR 中的验证命令：

- 在 `packages/cli` 下 `npx vitest run src/utils/sandbox.test.ts`
- `npm run typecheck --workspace=packages/cli`
- `npm run build --workspace=packages/cli`
- `npm run lint`
- `npx prettier --experimental-cli --check packages/cli/src/utils/sandbox.ts packages/cli/src/utils/sandboxImageName.ts packages/cli/src/utils/sandbox.test.ts`
- `git diff --check`

### 证据（前后对比）

N/A —— 非可见的逻辑修复（内部容器名派生）；已由上述单元测试覆盖。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI  |
| 🪟 Windows |  ✅ CI  |
|  🐧 Linux  |  ✅ CI  |

✅ 已测试 · ⚠️ 未测试 · N/A

### 环境（可选）

仅单元测试（npm workspaces）。

## 风险与范围

- 主要风险或权衡：低；范围限定在 `packages/cli` 的 sandbox 容器名派生。行为变化仅限于如何将镜像引用解析为名字前缀。
- 未验证 / 超出范围：没有无关的重构、公共 API 变更或 UI 变更。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

修复 #5324

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
