### PR TITLE
fix(cli): validate GitHub remote hosts

### DIFF
--- a/packages/cli/src/utils/gitUtils.test.ts
+++ b/packages/cli/src/utils/gitUtils.test.ts
@@ -32,7 +32,26 @@ describe('isGitHubRepository', async () => {
   });
 
   it('returns false if the remote is not github.com', async () => {
-    vi.mocked(child_process.execSync).mockReturnValueOnce('https://gitlab.com');
+    vi.mocked(child_process.execSync).mockReturnValueOnce(`
+      origin  https://gitlab.com/owner/repo.git (fetch)
+      origin  https://gitlab.com/owner/repo.git (push)
+    `);
+    expect(isGitHubRepository()).toBe(false);
+  });
+
+  it('returns false for github.com lookalike hosts', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(`
+      origin  https://github.com.evil/owner/repo.git (fetch)
+      origin  https://github.com.evil/owner/repo.git (push)
+    `);
+    expect(isGitHubRepository()).toBe(false);
+  });
+
+  it('returns false when github.com only appears in the path', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(`
+      origin  https://gitlab.com/owner/github.com-mirror.git (fetch)
+      origin  https://gitlab.com/owner/github.com-mirror.git (push)
+    `);
     expect(isGitHubRepository()).toBe(false);
   });
 
@@ -42,6 +61,38 @@ describe('isGitHubRepository', async () => {
       origin  https://github.com/sethvargo/gemini-cli (push)
     `);
     expect(isGitHubRepository()).toBe(true);
+  });
+
+  it('returns true for GitHub SSH remotes', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(`
+      origin  git@github.com:owner/repo.git (fetch)
+      origin  git@github.com:owner/repo.git (push)
+    `);
+    expect(isGitHubRepository()).toBe(true);
+  });
+
+  it('returns true for GitHub SSH URL remotes', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(`
+      origin  ssh://git@github.com/owner/repo.git (fetch)
+      origin  ssh://git@github.com/owner/repo.git (push)
+    `);
+    expect(isGitHubRepository()).toBe(true);
+  });
+
+  it('returns true for GitHub SSH URL remotes with an explicit port', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(`
+      origin  ssh://git@github.com:22/owner/repo.git (fetch)
+      origin  ssh://git@github.com:22/owner/repo.git (push)
+    `);
+    expect(isGitHubRepository()).toBe(true);
+  });
+
+  it('returns false for GitHub SSH lookalike hosts', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(`
+      origin  git@github.com.evil:owner/repo.git (fetch)
+      origin  git@github.com.evil:owner/repo.git (push)
+    `);
+    expect(isGitHubRepository()).toBe(false);
   });
 });
 
@@ -135,6 +186,13 @@ describe('getGitHubRepoInfo', async () => {
   it('returns the owner and repo for SSH URL', async () => {
     vi.mocked(child_process.execSync).mockReturnValueOnce(
       'git@github.com:owner/repo.git',
+    );
+    expect(getGitHubRepoInfo()).toEqual({ owner: 'owner', repo: 'repo' });
+  });
+
+  it('returns the owner and repo for SSH URL with an explicit port', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'ssh://git@github.com:22/owner/repo.git',
     );
     expect(getGitHubRepoInfo()).toEqual({ owner: 'owner', repo: 'repo' });
   });

--- a/packages/cli/src/utils/gitUtils.ts
+++ b/packages/cli/src/utils/gitUtils.ts
@@ -22,15 +22,31 @@ export const isGitHubRepository = (): boolean => {
       }) || ''
     ).trim();
 
-    const pattern = /github\.com/;
-
-    return pattern.test(remotes);
+    return remotes.split('\n').some((line) => {
+      const remoteUrl = line.trim().split(/\s+/)[1];
+      return remoteUrl ? isGitHubRemoteUrl(remoteUrl) : false;
+    });
   } catch (_error) {
     // If any filesystem error occurs, assume not a git repo
     debugLogger.debug(`Failed to get git remote:`, _error);
     return false;
   }
 };
+
+function isGitHubRemoteUrl(remoteUrl: string): boolean {
+  if (remoteUrl.startsWith('git@github.com:')) {
+    return true;
+  }
+  if (remoteUrl.startsWith('git@')) {
+    return false;
+  }
+
+  try {
+    return new URL(remoteUrl).hostname === 'github.com';
+  } catch {
+    return false;
+  }
+}
 
 /**
  * getGitRepoRoot returns the root directory of the git repository.
@@ -126,7 +142,7 @@ export function getGitHubRepoInfo(): { owner: string; repo: string } {
     );
   }
 
-  if (parsedUrl.host !== 'github.com') {
+  if (parsedUrl.hostname !== 'github.com') {
     throw new Error(
       `Owner & repo could not be extracted from remote URL: ${remoteUrl}`,
     );


### PR DESCRIPTION
## Summary

- parse `git remote -v` remote URLs instead of searching the whole output for `github.com`
- reject lookalike hosts such as `github.com.evil`
- keep accepting normal GitHub HTTPS and `git@github.com:owner/repo.git` remotes

Fixes #5326

## Test plan

- `npx vitest run src/utils/gitUtils.test.ts` from `packages/cli`
- `npm run typecheck --workspace=packages/cli`
- `npm run build --workspace=packages/cli`
- `npm run lint`
- `npx prettier --experimental-cli --check packages/cli/src/utils/gitUtils.ts packages/cli/src/utils/gitUtils.test.ts`
- `git diff --check`

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.