### PR TITLE
fix(core): keep qwen3.6-flash and kimi-k2.6 presets text-only

### DIFF
--- a/packages/core/src/providers/__tests__/presets/alibaba-token-plan.test.ts
+++ b/packages/core/src/providers/__tests__/presets/alibaba-token-plan.test.ts
@@ -52,8 +52,22 @@ describe('token plan provider', () => {
     ).toEqual({
       extra_body: { enable_thinking: true },
       contextWindowSize: 1000000,
-      modalities: { image: true, video: true },
     });
+    expect(
+      template.find((model) => model.id === 'kimi-k2.6')?.generationConfig,
+    ).toEqual({
+      extra_body: { enable_thinking: true },
+      contextWindowSize: 262144,
+    });
+    // Plus/2.5 variants are genuinely multimodal and stay that way.
+    expect(
+      template.find((model) => model.id === 'qwen3.6-plus')?.generationConfig
+        ?.modalities,
+    ).toEqual({ image: true, video: true });
+    expect(
+      template.find((model) => model.id === 'kimi-k2.5')?.generationConfig
+        ?.modalities,
+    ).toEqual({ image: true, video: true });
     expect(plan.providerId).toBe('token-plan');
     expect(plan.authType).toBe(AuthType.USE_OPENAI);
     expect(plan.env).toEqual({ [TOKEN_PLAN_ENV_KEY]: 'sk-token' });

--- a/packages/core/src/providers/__tests__/presets/idealab.test.ts
+++ b/packages/core/src/providers/__tests__/presets/idealab.test.ts
@@ -63,6 +63,20 @@ describe('idealabProvider', () => {
     });
   });
 
+  it('does not mark kimi-k2.6 as multimodal', () => {
+    const plan = buildInstallPlan(idealabProvider, {
+      baseUrl: 'https://idealab.alibaba-inc.com/api/openai/v1',
+      apiKey: 'sk-idealab',
+      modelIds: ['bailian/kimi-k2.6'],
+    });
+
+    const models = plan.modelProviders?.[0]?.models;
+    expect(models?.[0]?.generationConfig).toEqual({
+      extra_body: { enable_thinking: true },
+      contextWindowSize: 262144,
+    });
+  });
+
   it('falls back gracefully for unknown model IDs', () => {
     const plan = buildInstallPlan(idealabProvider, {
       baseUrl: 'https://idealab.alibaba-inc.com/api/openai/v1',

--- a/packages/core/src/providers/presets/alibaba-token-plan.ts
+++ b/packages/core/src/providers/presets/alibaba-token-plan.ts
@@ -27,7 +27,6 @@ const TOKEN_PLAN_MODELS: ModelSpec[] = [
     id: 'qwen3.6-flash',
     contextWindowSize: 1000000,
     enableThinking: true,
-    modalities: { image: true, video: true },
   },
   { id: 'deepseek-v4-pro', contextWindowSize: 1000000 },
   { id: 'deepseek-v4-flash', contextWindowSize: 1000000 },
@@ -36,7 +35,6 @@ const TOKEN_PLAN_MODELS: ModelSpec[] = [
     id: 'kimi-k2.6',
     contextWindowSize: 262144,
     enableThinking: true,
-    modalities: { image: true, video: true },
   },
   {
     id: 'kimi-k2.5',

--- a/packages/core/src/providers/presets/idealab.ts
+++ b/packages/core/src/providers/presets/idealab.ts
@@ -36,7 +36,6 @@ export const idealabProvider: ProviderConfig = {
       id: 'bailian/kimi-k2.6',
       contextWindowSize: 262144,
       enableThinking: true,
-      modalities: { image: true, video: true },
     },
   ],
   modelsEditable: true,


### PR DESCRIPTION
## What

Drop the stray `modalities: { image: true, video: true }` from the `qwen3.6-flash` and `kimi-k2.6` entries in the Token Plan preset, and from `bailian/kimi-k2.6` in the Idealab preset.

## Why

`modalityDefaults` (`packages/core/src/core/modalityDefaults.ts`) only treats the multimodal variants — `qwen3.6-plus` and `kimi-k2.5` — as image/video capable; everything else under `^qwen` / `^kimi-` falls through to the text-only default. These three preset entries declared image/video anyway, which overstates what the models accept and can mislead the vision bridge.

This is the same class of mismatch #5268 fixed for the DeepSeek presets — it just missed the Token Plan and Idealab entries. The genuinely multimodal `qwen3.6-plus` / `kimi-k2.5` entries are left untouched.

## Reviewer Test Plan

```
npx vitest run packages/core/src/providers/__tests__/presets/alibaba-token-plan.test.ts packages/core/src/providers/__tests__/presets/idealab.test.ts
```

The preset tests now assert `qwen3.6-flash` and `kimi-k2.6` resolve to text-only, and add regression assertions that `qwen3.6-plus` / `kimi-k2.5` keep their image+video modalities.

## Risk

Low. Removes overstated modality flags from three text-only presets only; the multimodal Plus/2.5 entries are unchanged and guarded by the new assertions.
