### PR TITLE
fix(cli): enforce stdin byte limit

### DIFF
--- a/packages/cli/src/utils/readStdin.test.ts
+++ b/packages/cli/src/utils/readStdin.test.ts
@@ -109,4 +109,30 @@ describe('readStdin', () => {
 
     await expect(promise).resolves.toBe('chunk1chunk2');
   });
+
+  it('should enforce the stdin limit by UTF-8 byte size', async () => {
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    const stderrSpy = vi.fn(() => true);
+    (process.stderr as { write: unknown }).write = stderrSpy;
+
+    const maxStdinSize = 8 * 1024 * 1024;
+    const input = '😀'.repeat(maxStdinSize / 4 + 1);
+    mockStdin.read.mockReturnValueOnce(input).mockReturnValueOnce(null);
+
+    try {
+      const promise = readStdin();
+
+      onReadableHandler();
+
+      const result = await promise;
+      expect(Buffer.byteLength(result, 'utf8')).toBe(maxStdinSize);
+      expect(result).toBe('😀'.repeat(maxStdinSize / 4));
+      expect(mockStdin.destroy).toHaveBeenCalledOnce();
+      expect(stderrSpy).toHaveBeenCalledWith(
+        `Warning: stdin input truncated to ${maxStdinSize} bytes.\n`,
+      );
+    } finally {
+      (process.stderr as { write: typeof originalWrite }).write = originalWrite;
+    }
+  });
 });

--- a/packages/cli/src/utils/readStdin.ts
+++ b/packages/cli/src/utils/readStdin.ts
@@ -6,11 +6,28 @@
 
 import { writeStderrLine } from './stdioHelpers.js';
 
+function takeUtf8Prefix(value: string, maxBytes: number): string {
+  let bytes = 0;
+  let end = 0;
+
+  for (const char of value) {
+    const charBytes = Buffer.byteLength(char, 'utf8');
+    if (bytes + charBytes > maxBytes) {
+      break;
+    }
+    bytes += charBytes;
+    end += char.length;
+  }
+
+  return value.slice(0, end);
+}
+
 export async function readStdin(): Promise<string> {
   const MAX_STDIN_SIZE = 8 * 1024 * 1024; // 8MB
   return new Promise((resolve, reject) => {
     let data = '';
     let totalSize = 0;
+    let settled = false;
     process.stdin.setEncoding('utf8');
 
     const pipedInputShouldBeAvailableInMs = 500;
@@ -29,26 +46,38 @@ export async function readStdin(): Promise<string> {
           pipedInputTimerId = null;
         }
 
-        if (totalSize + chunk.length > MAX_STDIN_SIZE) {
+        const chunkSize = Buffer.byteLength(chunk, 'utf8');
+        if (totalSize + chunkSize > MAX_STDIN_SIZE) {
           const remainingSize = MAX_STDIN_SIZE - totalSize;
-          data += chunk.slice(0, remainingSize);
+          const prefix = takeUtf8Prefix(chunk, remainingSize);
+          data += prefix;
+          totalSize += Buffer.byteLength(prefix, 'utf8');
           writeStderrLine(
             `Warning: stdin input truncated to ${MAX_STDIN_SIZE} bytes.`,
           );
+          finish();
           process.stdin.destroy(); // Stop reading further
-          break;
+          return;
         }
         data += chunk;
-        totalSize += chunk.length;
+        totalSize += chunkSize;
       }
     };
 
-    const onEnd = () => {
+    const finish = () => {
+      if (settled) return;
+      settled = true;
       cleanup();
       resolve(data);
     };
 
+    const onEnd = () => {
+      finish();
+    };
+
     const onError = (err: Error) => {
+      if (settled) return;
+      settled = true;
       cleanup();
       reject(err);
     };


### PR DESCRIPTION
## What this PR does

This makes piped stdin truncation enforce the existing 8MB limit by UTF-8 byte size instead of JavaScript string length. When truncation happens, it keeps only complete characters, emits the existing warning, resolves the read immediately, and then stops reading from stdin.

## Why it's needed

The current check counts characters after stdin is decoded as UTF-8, so multi-byte input can exceed the advertised 8MB byte limit. The truncation path also relied on an `end` event after destroying stdin, which is not guaranteed for a real stream.

## Reviewer Test Plan

### How to verify

Run the stdin unit test. The new coverage feeds emoji input whose UTF-8 byte size is just over 8MB, verifies the returned text is exactly 8MB, verifies no surrogate pair is split, and verifies the read resolves without manually sending an `end` event after truncation.

### Evidence (Before & After)

Before: multi-byte stdin could return more than 8MB of UTF-8 data, and the truncation path could wait forever for `end` after destroying stdin. After: multi-byte stdin is capped at exactly 8MB, the warning is preserved, and the read resolves as soon as truncation is applied.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js 24.11.1, local unit/typecheck/build/lint run.

## Risk & Scope

- Main risk or tradeoff: the added unit test allocates an 8MB stdin string so it exercises the real production limit, but it stays scoped to one test file.
- Not validated / out of scope: full interactive stdin flows on Windows and Linux were left to CI.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5329

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让管道 stdin 的截断按 UTF-8 字节数执行现有的 8MB 限制，而不是按 JavaScript 字符串长度计算。发生截断时，会保留完整字符、输出原有 warning、立即 resolve 本次读取，然后停止继续读取 stdin。

## Why it's needed

当前逻辑在 stdin 解码成 UTF-8 字符串后按字符数检查，所以多字节输入可能超过对外说明的 8MB 字节限制。截断路径还依赖 destroy stdin 后继续收到 `end` 事件，真实 stream 里这个事件不保证发生。

## Reviewer Test Plan

### How to verify

运行 stdin 单测。新增覆盖会输入 UTF-8 字节数刚超过 8MB 的 emoji，验证返回内容正好是 8MB、不会切断 surrogate pair，并且截断后不需要手动发送 `end` 事件也会 resolve。

### Evidence (Before & After)

Before: 多字节 stdin 可能返回超过 8MB 的 UTF-8 数据，且截断路径可能在 destroy stdin 后一直等待 `end`。After: 多字节 stdin 会被精确限制在 8MB，warning 保持不变，并且完成截断后立即 resolve。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js 24.11.1，本地跑过 unit/typecheck/build/lint。

## Risk & Scope

- Main risk or tradeoff: 新增单测会分配一个 8MB stdin 字符串，用真实生产限制做覆盖，但范围只在一个测试文件内。
- Not validated / out of scope: Windows 和 Linux 上的完整交互式 stdin 流程交给 CI 覆盖。
- Breaking changes / migration notes: 无。

## Linked Issues

Fixes #5329

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>