### PR TITLE
fix(core): respect home path boundary when tildeifying

### DIFF
--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -667,8 +667,8 @@ describe('resolveAndValidatePath', () => {
 describe('tildeifyPath', () => {
   it('replaces home directory with tilde', () => {
     const homeDir = os.homedir();
-    const result = tildeifyPath(`${homeDir}/documents/file.txt`);
-    expect(result).toBe('~/documents/file.txt');
+    const result = tildeifyPath(path.join(homeDir, 'documents', 'file.txt'));
+    expect(result).toBe(`~${path.sep}documents${path.sep}file.txt`);
   });
 
   it('returns path unchanged if it does not start with home directory', () => {
@@ -680,6 +680,13 @@ describe('tildeifyPath', () => {
     const homeDir = os.homedir();
     const result = tildeifyPath(homeDir);
     expect(result).toBe('~');
+  });
+
+  it('does not replace paths that only share the home directory prefix', () => {
+    const homeDir = os.homedir();
+    const siblingPath = `${homeDir}2${path.sep}project${path.sep}file.txt`;
+    const result = tildeifyPath(siblingPath);
+    expect(result).toBe(siblingPath);
   });
 
   it('handles paths with home directory in the middle', () => {

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -64,15 +64,18 @@ const UNESCAPE_REGEX = (() => {
 
 /**
  * Replaces the home directory with a tilde.
- * @param path - The path to tildeify.
+ * @param filePath - The path to tildeify.
  * @returns The tildeified path.
  */
-export function tildeifyPath(path: string): string {
+export function tildeifyPath(filePath: string): string {
   const homeDir = os.homedir();
-  if (path.startsWith(homeDir)) {
-    return path.replace(homeDir, '~');
+  if (filePath === homeDir) {
+    return '~';
   }
-  return path;
+  if (filePath.startsWith(`${homeDir}${path.sep}`)) {
+    return filePath.replace(homeDir, '~');
+  }
+  return filePath;
 }
 
 /**


### PR DESCRIPTION
## What this PR does

This tightens path tildeification so only the exact home directory, or paths inside it, are shortened to `~`. Paths that merely share the same string prefix as the home directory are left unchanged.

## Why it's needed

The previous prefix check could turn a sibling directory into an invalid-looking home path. For example, if the home directory is `/Users/alice`, `/Users/alice2/project` became `~2/project` even though it is not inside `/Users/alice`.

## Reviewer Test Plan

### How to verify

Run the paths unit test. The coverage keeps the existing exact-home and home-child behavior, uses native separators for cross-platform expectations, and adds a regression case for a sibling path whose name starts with the home directory string.

### Evidence (Before & After)

Before: a sibling path such as `/Users/alice2/project/file.txt` could be rendered as `~2/project/file.txt`. After: only `/Users/alice` and native child paths below it are tildeified; sibling prefix paths stay unchanged.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js 24.11.1, local unit/typecheck/build/lint run.

## Risk & Scope

- Main risk or tradeoff: this intentionally uses the platform-native path separator when deciding whether a path is inside home, matching the existing path utility behavior.
- Not validated / out of scope: mixed-separator paths on Windows are left as existing behavior.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5332

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 收紧了路径 tilde 化逻辑：只有精确等于 home 目录，或者位于 home 目录下面的路径，才会被缩短成 `~`。只是字符串前缀碰巧相同的路径会保持原样。

## Why it's needed

之前的前缀判断会把 sibling 目录错误显示成 home 路径。例如 home 目录是 `/Users/alice` 时，`/Users/alice2/project` 会变成 `~2/project`，但它并不在 `/Users/alice` 下面。

## Reviewer Test Plan

### How to verify

运行 paths 单测。测试保留了 exact home 和 home 子路径行为，用平台原生分隔符做跨平台期望，并新增了 home 字符串前缀 sibling 路径的回归用例。

### Evidence (Before & After)

Before: 类似 `/Users/alice2/project/file.txt` 的 sibling 路径可能被渲染成 `~2/project/file.txt`。After: 只有 `/Users/alice` 以及它下面的原生子路径会被 tilde 化；sibling 前缀路径保持不变。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js 24.11.1，本地跑过 unit/typecheck/build/lint。

## Risk & Scope

- Main risk or tradeoff: 判断路径是否在 home 下时刻意使用平台原生路径分隔符，和现有 path 工具行为保持一致。
- Not validated / out of scope: Windows 上混合分隔符路径保持现有行为。
- Breaking changes / migration notes: 无。

## Linked Issues

Fixes #5332

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>