### PR TITLE
fix(cli): preserve multiline shell history

### DIFF
--- a/packages/cli/src/ui/hooks/useShellHistory.test.ts
+++ b/packages/cli/src/ui/hooks/useShellHistory.test.ts
@@ -139,7 +139,7 @@ describe('useShellHistory', () => {
       });
       expect(mockedFs.writeFile).toHaveBeenCalledWith(
         MOCKED_HISTORY_FILE,
-        'new_command', // Written to file oldest-first.
+        JSON.stringify(['new_command']), // Written to file oldest-first.
       );
     });
 
@@ -148,6 +148,53 @@ describe('useShellHistory', () => {
       command = result.current.getPreviousCommand();
     });
     expect(command).toBe('new_command');
+  });
+
+  it('should preserve multi-line commands after reloading history', async () => {
+    const multiLineCommand = 'for f in a b; do\n  echo "$f"\ndone';
+
+    const { result, unmount } = renderHook(() =>
+      useShellHistory(MOCKED_PROJECT_ROOT),
+    );
+    await waitFor(() => expect(mockedFs.readFile).toHaveBeenCalled());
+
+    act(() => {
+      result.current.addCommandToHistory(multiLineCommand);
+    });
+
+    await waitFor(() => expect(mockedFs.writeFile).toHaveBeenCalled());
+    const writtenContent = mockedFs.writeFile.mock.calls[0][1] as string;
+    unmount();
+
+    mockedFs.readFile.mockResolvedValue(writtenContent);
+    const { result: reloaded } = renderHook(() =>
+      useShellHistory(MOCKED_PROJECT_ROOT),
+    );
+    await waitFor(() => expect(mockedFs.readFile).toHaveBeenCalledTimes(2));
+
+    let command: string | null = null;
+    act(() => {
+      command = reloaded.current.getPreviousCommand();
+    });
+    expect(command).toBe(multiLineCommand);
+  });
+
+  it('should load JSON history files in newest-first order', async () => {
+    mockedFs.readFile.mockResolvedValue(JSON.stringify(['cmd1', 'cmd2']));
+    const { result } = renderHook(() => useShellHistory(MOCKED_PROJECT_ROOT));
+
+    await waitFor(() => expect(mockedFs.readFile).toHaveBeenCalled());
+
+    let command: string | null = null;
+    act(() => {
+      command = result.current.getPreviousCommand();
+    });
+    expect(command).toBe('cmd2');
+
+    act(() => {
+      command = result.current.getPreviousCommand();
+    });
+    expect(command).toBe('cmd1');
   });
 
   it('should navigate history correctly with previous/next commands', async () => {
@@ -227,11 +274,11 @@ describe('useShellHistory', () => {
     // After adding 'new_cmd': ['new_cmd', 'old_cmd_119', ..., 'old_cmd_21'] (100 items)
     // Written to file (reversed): ['old_cmd_21', ..., 'old_cmd_119', 'new_cmd']
     const writtenContent = mockedFs.writeFile.mock.calls[0][1] as string;
-    const writtenLines = writtenContent.split('\n');
+    const writtenHistory = JSON.parse(writtenContent) as string[];
 
-    expect(writtenLines.length).toBe(100);
-    expect(writtenLines[0]).toBe('old_cmd_21'); // New oldest command
-    expect(writtenLines[99]).toBe('new_cmd'); // Newest command
+    expect(writtenHistory.length).toBe(100);
+    expect(writtenHistory[0]).toBe('old_cmd_21'); // New oldest command
+    expect(writtenHistory[99]).toBe('new_cmd'); // Newest command
   });
 
   it('should move an existing command to the top when re-added', async () => {
@@ -250,8 +297,8 @@ describe('useShellHistory', () => {
     await waitFor(() => expect(mockedFs.writeFile).toHaveBeenCalled());
 
     const writtenContent = mockedFs.writeFile.mock.calls[0][1] as string;
-    const writtenLines = writtenContent.split('\n');
+    const writtenHistory = JSON.parse(writtenContent) as string[];
 
-    expect(writtenLines).toEqual(['cmd2', 'cmd3', 'cmd1']);
+    expect(writtenHistory).toEqual(['cmd2', 'cmd3', 'cmd1']);
   });
 });

--- a/packages/cli/src/ui/hooks/useShellHistory.ts
+++ b/packages/cli/src/ui/hooks/useShellHistory.ts
@@ -36,30 +36,52 @@ async function getHistoryFilePath(
 async function readHistoryFile(filePath: string): Promise<string[]> {
   try {
     const text = await fs.readFile(filePath, 'utf-8');
-    const result: string[] = [];
-    let cur = '';
+    const parsed = parseHistoryFile(text);
+    if (parsed) return parsed;
 
-    for (const raw of text.split(/\r?\n/)) {
-      if (!raw.trim()) continue;
-      const line = raw;
-
-      const m = cur.match(/(\\+)$/);
-      if (m && m[1].length % 2) {
-        // odd number of trailing '\'
-        cur = cur.slice(0, -1) + ' ' + line;
-      } else {
-        if (cur) result.push(cur);
-        cur = line;
-      }
-    }
-
-    if (cur) result.push(cur);
-    return result;
+    return parseLegacyHistoryFile(text);
   } catch (err) {
     if (isNodeError(err) && err.code === 'ENOENT') return [];
     debugLogger.error('Error reading history:', err);
     return [];
   }
+}
+
+function parseHistoryFile(text: string): string[] | undefined {
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (
+      Array.isArray(parsed) &&
+      parsed.every((entry): entry is string => typeof entry === 'string')
+    ) {
+      return parsed;
+    }
+  } catch {
+    // Fall back to the original line-based history format.
+  }
+  return undefined;
+}
+
+function parseLegacyHistoryFile(text: string): string[] {
+  const result: string[] = [];
+  let cur = '';
+
+  for (const raw of text.split(/\r?\n/)) {
+    if (!raw.trim()) continue;
+    const line = raw;
+
+    const m = cur.match(/(\\+)$/);
+    if (m && m[1].length % 2) {
+      // odd number of trailing '\'
+      cur = cur.slice(0, -1) + ' ' + line;
+    } else {
+      if (cur) result.push(cur);
+      cur = line;
+    }
+  }
+
+  if (cur) result.push(cur);
+  return result;
 }
 
 async function writeHistoryFile(
@@ -68,7 +90,7 @@ async function writeHistoryFile(
 ): Promise<void> {
   try {
     await fs.mkdir(path.dirname(filePath), { recursive: true });
-    await fs.writeFile(filePath, history.join('\n'));
+    await fs.writeFile(filePath, JSON.stringify(history));
   } catch (error) {
     debugLogger.error('Error writing shell history:', error);
   }


### PR DESCRIPTION
## What this PR does

This makes newly written shell history use a JSON string array so each command can round-trip as one entry, including commands that contain newline characters. The reader accepts that JSON format first and falls back to the previous line-based parser for existing history files.

## Why it's needed

Shell mode can submit multi-line commands, but the old history file format used raw newlines between entries. After restart, a command like a small `for` loop was split into separate history entries, so pressing up recalled `done` instead of the original command.

## Reviewer Test Plan

### How to verify

Run the shell history hook test. The new coverage writes a multi-line shell command, reloads the hook from the written history content, and verifies the command is recalled as one entry. It also covers JSON history loading order while keeping existing line-based history tests.

### Evidence (Before & After)

Before: a multi-line command was written with raw newlines and reloaded as separate commands. After: newly written history preserves the command as a single JSON string entry, while old line-based history still loads through the fallback parser.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js 24.11.1, local unit/typecheck/build/lint run.

## Risk & Scope

- Main risk or tradeoff: newly written shell history changes from a line-based text file to JSON. Existing files still load through the fallback parser, but older Qwen Code versions would read the new JSON file as a single legacy line.
- Not validated / out of scope: downgrade behavior to older releases.
- Breaking changes / migration notes: none for forward use; the next write naturally stores history in the new format.

## Linked Issues

Fixes #5334

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让新写入的 shell history 使用 JSON 字符串数组保存，因此每条命令都能作为一个 entry 往返，包括包含换行符的命令。读取时会先尝试新 JSON 格式，失败后回退到旧的按行解析器，以兼容已有历史文件。

## Why it's needed

Shell mode 可以提交多行命令，但旧 history 文件格式用原始换行分隔 entry。重启后，一个小 `for` loop 这样的命令会被拆成多条历史；按上方向键先召回的是 `done`，不是原始完整命令。

## Reviewer Test Plan

### How to verify

运行 shell history hook 单测。新增覆盖会写入一个多行 shell 命令，再用写出的 history 内容重新加载 hook，验证它作为一条历史被召回。测试还覆盖 JSON history 的读取顺序，并保留旧 line-based history 测试。

### Evidence (Before & After)

Before: 多行命令用原始换行写入，重载后会被拆成多条命令。After: 新写入的 history 会把该命令保存在一个 JSON string entry 中，同时旧 line-based history 仍通过 fallback parser 读取。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js 24.11.1，本地跑过 unit/typecheck/build/lint。

## Risk & Scope

- Main risk or tradeoff: 新写入的 shell history 从按行文本文件改为 JSON。已有文件仍会通过 fallback parser 加载，但旧版 Qwen Code 会把新 JSON 文件当作一条 legacy line 读取。
- Not validated / out of scope: 降级到旧版本后的行为。
- Breaking changes / migration notes: 正向使用无迁移要求；下一次写入会自然保存成新格式。

## Linked Issues

Fixes #5334

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
