### PR TITLE
fix(desktop): detect WebP and AVI in RIFF magic-byte sniffing

### DIFF
--- a/packages/desktop/packages/shared/src/utils/__tests__/binary-detection.test.ts
+++ b/packages/desktop/packages/shared/src/utils/__tests__/binary-detection.test.ts
@@ -29,6 +29,17 @@ const MINIMAL_PNG = Buffer.from(
   'base64'
 );
 
+// RIFF containers share the "RIFF" prefix; bytes 8-11 carry the actual form tag.
+const riffBuffer = (form: string) =>
+  Buffer.concat([
+    Buffer.from([0x52, 0x49, 0x46, 0x46]), // "RIFF"
+    Buffer.from([0x24, 0x00, 0x00, 0x00]), // chunk size (non-zero, like a real file)
+    Buffer.from(form, 'ascii'), // form tag at bytes 8-11
+    Buffer.alloc(16),
+  ]);
+const MINIMAL_WEBP = riffBuffer('WEBP');
+const MINIMAL_WAV = riffBuffer('WAVE');
+
 // Large PNG-like binary: PNG magic + binary junk with null bytes (>= 256 base64 chars, >= 128 decoded bytes)
 const LARGE_PNG_BINARY = (() => {
   const buf = Buffer.alloc(300);
@@ -381,6 +392,14 @@ describe('detectExtensionFromMagic', () => {
 
   test('returns empty for tiny buffer', () => {
     expect(detectExtensionFromMagic(Buffer.from([0x89]))).toBe('');
+  });
+
+  test('detects WebP from the RIFF form tag, not as WAV', () => {
+    expect(detectExtensionFromMagic(MINIMAL_WEBP)).toBe('.webp');
+  });
+
+  test('still detects WAV from the RIFF/WAVE form tag', () => {
+    expect(detectExtensionFromMagic(MINIMAL_WAV)).toBe('.wav');
   });
 });
 

--- a/packages/desktop/packages/shared/src/utils/binary-detection.ts
+++ b/packages/desktop/packages/shared/src/utils/binary-detection.ts
@@ -32,7 +32,6 @@ const MAGIC_SIGNATURES: Array<{ bytes: number[]; ext: string }> = [
   { bytes: [0x42, 0x4D], ext: '.bmp' },                        // BM
   { bytes: [0x49, 0x44, 0x33], ext: '.mp3' },                  // ID3 (MP3 with ID3 tag)
   { bytes: [0xFF, 0xFB], ext: '.mp3' },                        // MP3 frame sync
-  { bytes: [0x52, 0x49, 0x46, 0x46], ext: '.wav' },           // RIFF (WAV container)
   { bytes: [0x4F, 0x67, 0x67, 0x53], ext: '.ogg' },           // OggS
   { bytes: [0x66, 0x4C, 0x61, 0x43], ext: '.flac' },          // fLaC
 ];
@@ -117,6 +116,23 @@ export function looksLikeBinary(buffer: Buffer): boolean {
  */
 export function detectExtensionFromMagic(buffer: Buffer): string {
   if (buffer.length < 8) return '';
+
+  // RIFF is a shared container (WAV, WebP, AVI); the four-character form tag at
+  // bytes 8-11 is what actually distinguishes them, so the "RIFF" prefix alone
+  // is ambiguous and must not be assumed to be WAV.
+  if (
+    buffer.length >= 12 &&
+    buffer[0] === 0x52 &&
+    buffer[1] === 0x49 &&
+    buffer[2] === 0x46 &&
+    buffer[3] === 0x46
+  ) {
+    const form = buffer.toString('ascii', 8, 12);
+    if (form === 'WEBP') return '.webp';
+    if (form === 'AVI ') return '.avi';
+    if (form === 'WAVE') return '.wav';
+    return '';
+  }
 
   for (const sig of MAGIC_SIGNATURES) {
     if (sig.bytes.every((byte, i) => buffer[i] === byte)) {


### PR DESCRIPTION
## What

`detectExtensionFromMagic` (desktop `binary-detection.ts`) now distinguishes RIFF container subtypes by the four-character form tag at bytes 8-11, so WebP and AVI are no longer reported as `.wav`.

## Why

The `MAGIC_SIGNATURES` table mapped the bare `RIFF` prefix (bytes 0-3) straight to `.wav`. But RIFF is a shared container — WAV, WebP and AVI all start with `RIFF`, and only the form tag at bytes 8-11 (`WAVE` / `WEBP` / `AVI `) tells them apart. As a result any WebP or AVI binary flowing through the magic-byte fallback (`getMimeExtension` when MIME is unknown, `extractBase64Binary`, `saveBinaryResponse`) was mislabeled `.wav`.

This is the same RIFF-prefix-is-not-enough issue already fixed for the weixin channel (`ea97f297d`, "confirm the WEBP signature, not just the RIFF prefix"); the desktop binary detector still had the bare-prefix check. Unknown RIFF subtypes now return `''` instead of guessing `.wav`.

## Reviewer Test Plan

```
cd packages/desktop/packages/shared && bun test src/utils/__tests__/binary-detection.test.ts
```

Added cases assert a RIFF/`WEBP` buffer resolves to `.webp` (previously `.wav`) while a RIFF/`WAVE` buffer still resolves to `.wav`.

## Risk

Low. Only changes how RIFF-prefixed buffers are classified; WAV detection is preserved by a regression test, and non-RIFF signatures are untouched.
