### PR TITLE
fix(cli): truncate session picker text by display width

### DIFF
--- a/packages/cli/src/ui/utils/sessionPickerUtils.test.ts
+++ b/packages/cli/src/ui/utils/sessionPickerUtils.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect } from 'vitest';
 import type { SessionListItem } from '@qwen-code/qwen-code-core';
 import { filterSessions, truncateText } from './sessionPickerUtils.js';
+import { getCachedStringWidth } from './textUtils.js';
 
 function s(overrides: Partial<SessionListItem>): SessionListItem {
   return {
@@ -54,6 +55,23 @@ describe('sessionPickerUtils', () => {
 
     it('returns only the first line even if there are multiple line breaks', () => {
       expect(truncateText('hello\n\nworld', 20)).toBe('hello');
+    });
+
+    it('truncates CJK text by display width', () => {
+      const result = truncateText('修复登录问题'.repeat(8), 20);
+      expect(getCachedStringWidth(result)).toBeLessThanOrEqual(20);
+      expect(result).toBe('修复登录问题修复...');
+    });
+
+    it('does not split complex emoji grapheme clusters', () => {
+      expect(truncateText('🇨🇳abcdef', 2)).toBe('🇨🇳');
+      expect(truncateText('👩🏽abcdef', 6)).toBe('👩🏽a...');
+      expect(truncateText('👨‍👩‍👧‍👦abcdef', 6)).toBe('👨‍👩‍👧‍👦a...');
+    });
+
+    it('returns an empty string for non-positive widths', () => {
+      expect(truncateText('abcdef', 0)).toBe('');
+      expect(truncateText('abcdef', -1)).toBe('');
     });
   });
 

--- a/packages/cli/src/ui/utils/sessionPickerUtils.ts
+++ b/packages/cli/src/ui/utils/sessionPickerUtils.ts
@@ -5,6 +5,11 @@
  */
 
 import type { SessionListItem } from '@qwen-code/qwen-code-core';
+import { getCachedStringWidth } from './textUtils.js';
+
+const graphemeSegmenter = new Intl.Segmenter(undefined, {
+  granularity: 'grapheme',
+});
 
 /**
  * State for managing loaded sessions in the session picker.
@@ -24,14 +29,37 @@ export const SESSION_PAGE_SIZE = 20;
  * Truncates text to fit within a given width, adding ellipsis if needed.
  */
 export function truncateText(text: string, maxWidth: number): string {
+  const widthLimit = Math.max(0, Math.floor(maxWidth));
+  if (widthLimit === 0) {
+    return '';
+  }
+
   const firstLine = text.split(/\r?\n/, 1)[0];
-  if (firstLine.length <= maxWidth) {
+  if (getCachedStringWidth(firstLine) <= widthLimit) {
     return firstLine;
   }
-  if (maxWidth <= 3) {
-    return firstLine.slice(0, maxWidth);
+
+  if (widthLimit <= 3) {
+    return truncateToDisplayWidth(firstLine, widthLimit);
   }
-  return firstLine.slice(0, maxWidth - 3) + '...';
+
+  return `${truncateToDisplayWidth(firstLine, widthLimit - 3)}...`;
+}
+
+function truncateToDisplayWidth(text: string, maxWidth: number): string {
+  let width = 0;
+  let result = '';
+
+  for (const { segment } of graphemeSegmenter.segment(text)) {
+    const segmentWidth = getCachedStringWidth(segment);
+    if (width + segmentWidth > maxWidth) {
+      break;
+    }
+    result += segment;
+    width += segmentWidth;
+  }
+
+  return result;
 }
 
 /**


### PR DESCRIPTION
## What this PR does

This makes session and rewind picker text truncation use terminal display width instead of JavaScript string length. It also truncates on grapheme cluster boundaries so CJK text and complex emoji fit the requested column budget without splitting flags, skin-tone emoji, or ZWJ emoji.

## Why it's needed

The picker currently slices by string length. CJK and emoji-heavy session titles can overflow the intended width, and negative widths can return unexpected text. This can make picker rows misalign or spill into neighboring columns.

## Reviewer Test Plan

### How to verify

Run the session picker utils test. The new coverage verifies CJK text stays within the requested display width, complex emoji grapheme clusters are not split, and non-positive widths return an empty string. Existing ASCII and newline truncation tests still pass.

### Evidence (Before & After)

Before: `truncateText("修复登录问题".repeat(8), 20)` returned a string with display width 37, and `truncateText("abcdef", -1)` returned `abcde`. After: CJK output is capped to the requested display width and non-positive widths return an empty string.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js 24.11.1, local unit/typecheck/build/lint run.

## Risk & Scope

- Main risk or tradeoff: truncation now uses `string-width` and `Intl.Segmenter`, so it is slightly more work than a raw string slice but only runs on picker row text.
- Not validated / out of scope: visual screenshot testing in a real terminal.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5337

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让 session 和 rewind picker 的文本截断按终端显示宽度计算，而不是按 JavaScript 字符串长度计算。同时按 grapheme cluster 边界截断，保证 CJK 文本和复杂 emoji 能落在目标列宽内，也不会切坏旗帜、肤色修饰 emoji 或 ZWJ emoji。

## Why it's needed

当前 picker 使用字符串长度切片。CJK 或 emoji 较多的 session 标题会超过预期宽度，负宽度还会返回异常文本。这会让 picker 行错位或挤到相邻列。

## Reviewer Test Plan

### How to verify

运行 session picker utils 单测。新增覆盖会验证 CJK 文本不超过目标显示宽度、复杂 emoji grapheme cluster 不被拆开、非正宽度返回空字符串。已有 ASCII 和换行截断测试仍然通过。

### Evidence (Before & After)

Before: `truncateText("修复登录问题".repeat(8), 20)` 返回的字符串显示宽度是 37，`truncateText("abcdef", -1)` 返回 `abcde`。After: CJK 输出被限制在请求显示宽度内，非正宽度返回空字符串。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js 24.11.1，本地跑过 unit/typecheck/build/lint。

## Risk & Scope

- Main risk or tradeoff: 截断现在使用 `string-width` 和 `Intl.Segmenter`，比原始字符串切片略重，但只作用于 picker 行文本。
- Not validated / out of scope: 没做真实终端截图测试。
- Breaking changes / migration notes: 无。

## Linked Issues

Fixes #5337

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
