### PR TITLE
fix(core): support GIF image token metadata

### DIFF
--- a/packages/core/src/utils/request-tokenizer/imageTokenizer.test.ts
+++ b/packages/core/src/utils/request-tokenizer/imageTokenizer.test.ts
@@ -178,6 +178,22 @@ describe('ImageTokenizer', () => {
         expect(metadata.height).toBeGreaterThan(0);
       }
     });
+
+    it('should extract dimensions from GIF images', async () => {
+      const buf = Buffer.alloc(10);
+      buf.write('GIF89a', 0, 'ascii');
+      buf.writeUInt16LE(2, 6);
+      buf.writeUInt16LE(3, 8);
+
+      const metadata = await tokenizer.extractImageMetadata(
+        buf.toString('base64'),
+        'image/gif',
+      );
+
+      expect(metadata.width).toBe(2);
+      expect(metadata.height).toBe(3);
+      expect(metadata.mimeType).toBe('image/gif');
+    });
   });
 
   describe('TIFF dimension extraction', () => {

--- a/packages/core/src/utils/request-tokenizer/supportedImageFormats.ts
+++ b/packages/core/src/utils/request-tokenizer/supportedImageFormats.ts
@@ -10,6 +10,7 @@
  */
 export const SUPPORTED_IMAGE_MIME_TYPES = [
   'image/bmp',
+  'image/gif',
   'image/jpeg',
   'image/jpg', // Alternative MIME type for JPEG
   'image/png',

--- a/packages/vscode-ide-companion/src/utils/imageSupport.ts
+++ b/packages/vscode-ide-companion/src/utils/imageSupport.ts
@@ -63,6 +63,7 @@ export function unescapePath(filePath: string): string {
 
 const PASTED_IMAGE_MIME_TO_EXTENSION: Record<string, string> = {
   'image/bmp': '.bmp',
+  'image/gif': '.gif',
   'image/heic': '.heic',
   'image/jpeg': '.jpg',
   'image/jpg': '.jpg',

--- a/packages/vscode-ide-companion/src/webview/utils/imageHandler.test.ts
+++ b/packages/vscode-ide-companion/src/webview/utils/imageHandler.test.ts
@@ -184,6 +184,19 @@ describe('normalizeImageAttachment', () => {
   it('rejects attachments with unsupported image mime types', () => {
     expect(
       normalizeImageAttachment({
+        id: 'img-unsupported',
+        name: 'vector.svg',
+        type: 'image/svg+xml',
+        size: 114,
+        data: 'data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=',
+        timestamp: Date.now(),
+      }),
+    ).toBeNull();
+  });
+
+  it('accepts GIF attachments when normalizing pasted images', () => {
+    expect(
+      normalizeImageAttachment({
         id: 'img-1',
         name: 'animated.gif',
         type: 'image/gif',
@@ -191,7 +204,11 @@ describe('normalizeImageAttachment', () => {
         data: 'data:image/gif;base64,R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs=',
         timestamp: Date.now(),
       }),
-    ).toBeNull();
+    ).toMatchObject({
+      name: 'animated.gif',
+      type: 'image/gif',
+      data: 'R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs=',
+    });
   });
 
   it('rejects attachments whose decoded payload exceeds the enforced byte limit', () => {


### PR DESCRIPTION
## What this PR does

This adds `image/gif` to the supported image MIME type list so the existing GIF dimension parser is reachable during image token metadata extraction. It also adds a GIF89a regression test that verifies exact logical screen dimensions.

## Why it's needed

The tokenizer already had GIF header parsing logic, but GIF was missing from the supported MIME list. As a result, GIF inputs were marked unsupported before parsing and always fell back to the default 512x512 metadata.

## Reviewer Test Plan

### How to verify

Run the image tokenizer unit test. The new coverage builds a minimal GIF89a header with width 2 and height 3 and verifies `extractImageMetadata(..., "image/gif")` returns those exact dimensions.

### Evidence (Before & After)

Before: `image/gif` returned fallback metadata (`512x512`) even for a valid GIF header. After: `image/gif` is accepted as supported and the existing GIF parser returns the header dimensions.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js 24.11.1, local unit/typecheck/build/lint run.

## Risk & Scope

- Main risk or tradeoff: supported-format warnings now include GIF, matching the parser and tokenizer comments.
- Not validated / out of scope: animated-frame counting; this only extracts logical screen dimensions for token estimation.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5339

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 把 `image/gif` 加入支持的图片 MIME 类型列表，让已有的 GIF 尺寸解析逻辑在图片 token metadata 提取时真正可达。同时新增了一个 GIF89a 回归测试，验证 logical screen 的精确宽高。

## Why it's needed

tokenizer 已经有 GIF header 解析逻辑，但 GIF 漏在支持 MIME 列表之外。因此 GIF 输入会在解析前被标记为 unsupported，并总是回退到默认 512x512 metadata。

## Reviewer Test Plan

### How to verify

运行 image tokenizer 单测。新增覆盖会构造一个最小 GIF89a header，宽 2、高 3，并验证 `extractImageMetadata(..., "image/gif")` 返回精确尺寸。

### Evidence (Before & After)

Before: 即使是合法 GIF header，`image/gif` 也返回 fallback metadata (`512x512`)。After: `image/gif` 被视为 supported，已有 GIF parser 返回 header 中的尺寸。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js 24.11.1，本地跑过 unit/typecheck/build/lint。

## Risk & Scope

- Main risk or tradeoff: supported-format warning 现在会包含 GIF，这和 parser 以及 tokenizer 注释保持一致。
- Not validated / out of scope: 不处理动画帧计数；这里只提取 logical screen 尺寸用于 token 估算。
- Breaking changes / migration notes: 无。

## Linked Issues

Fixes #5339

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
