### PR TITLE
fix(cli): handle session search graphemes

### DIFF
--- a/packages/cli/src/ui/hooks/useSessionSearchInput.test.ts
+++ b/packages/cli/src/ui/hooks/useSessionSearchInput.test.ts
@@ -29,6 +29,12 @@ describe('isPrintableSearchChar', () => {
     expect(isPrintableSearchChar(k({ name: 'a', sequence: 'a' }))).toBe(true);
   });
 
+  it('accepts one printable emoji grapheme cluster', () => {
+    expect(isPrintableSearchChar(k({ name: '', sequence: '🚀' }))).toBe(true);
+    expect(isPrintableSearchChar(k({ name: '', sequence: '🇨🇳' }))).toBe(true);
+    expect(isPrintableSearchChar(k({ name: '', sequence: '👨‍👩‍👧‍👦' }))).toBe(true);
+  });
+
   it('accepts SPACE — caller decides whether to seed it', () => {
     // The picker's outer handler suppresses leading-whitespace queries
     // separately. The predicate itself only filters by character class.
@@ -75,6 +81,15 @@ describe('isPrintableSearchChar', () => {
       false,
     );
     expect(isPrintableSearchChar(k({ name: 'escape', sequence: '' }))).toBe(
+      false,
+    );
+  });
+
+  it('rejects C1 control characters', () => {
+    expect(isPrintableSearchChar(k({ name: 'csi', sequence: '\u009b' }))).toBe(
+      false,
+    );
+    expect(isPrintableSearchChar(k({ name: 'nel', sequence: '\u0085' }))).toBe(
       false,
     );
   });
@@ -237,6 +252,40 @@ describe('useSessionSearchInput', () => {
     });
     expect(result.current.searchQuery).toBe('a');
     expect(onExitToList).not.toHaveBeenCalled();
+  });
+
+  it('Backspace removes one whole emoji grapheme', () => {
+    const onExitToList = vi.fn();
+    const { result } = renderHook(() =>
+      useSessionSearchInput({ onExitToList }),
+    );
+    act(() => {
+      result.current.setSearchQuery('a🚀');
+    });
+
+    act(() => {
+      result.current.handleSearchKey(k({ name: 'backspace', sequence: '' }));
+    });
+
+    expect(result.current.searchQuery).toBe('a');
+    expect(onExitToList).not.toHaveBeenCalled();
+  });
+
+  it('Backspace through the last emoji clears the query AND exits to list', () => {
+    const onExitToList = vi.fn();
+    const { result } = renderHook(() =>
+      useSessionSearchInput({ onExitToList }),
+    );
+    act(() => {
+      result.current.setSearchQuery('👨‍👩‍👧‍👦');
+    });
+
+    act(() => {
+      result.current.handleSearchKey(k({ name: 'backspace', sequence: '' }));
+    });
+
+    expect(result.current.searchQuery).toBe('');
+    expect(onExitToList).toHaveBeenCalledTimes(1);
   });
 
   it('Backspace through the last char clears the query AND exits to list', () => {

--- a/packages/cli/src/ui/hooks/useSessionSearchInput.ts
+++ b/packages/cli/src/ui/hooks/useSessionSearchInput.ts
@@ -27,6 +27,19 @@ import { useCallback, useRef, useState } from 'react';
 import type { Key } from './useKeypress.js';
 
 const DELETION_KEY_NAMES = new Set(['backspace', 'delete']);
+const graphemeSegmenter = new Intl.Segmenter(undefined, {
+  granularity: 'grapheme',
+});
+
+function splitGraphemes(value: string): string[] {
+  return Array.from(graphemeSegmenter.segment(value), ({ segment }) => segment);
+}
+
+function removeLastGrapheme(value: string): string {
+  const graphemes = splitGraphemes(value);
+  graphemes.pop();
+  return graphemes.join('');
+}
 
 /**
  * Normalize deletion-key detection so Windows terminals that deliver
@@ -51,7 +64,7 @@ const isDeletionKey = (key: Key): boolean =>
  *   - any modified key (Ctrl/Meta combos handled separately);
  *   - bracketed pastes (a multi-line paste should never silently
  *     become a search query);
- *   - control characters (sequences below 0x20 like Tab/Enter/Esc);
+ *   - control characters (C0 and C1, including CSI);
  *   - DEL (0x7F) — Backspace's sequence byte, otherwise it would
  *     slip past the printable check and produce a literal DEL
  *     character in the query.
@@ -63,9 +76,11 @@ const isDeletionKey = (key: Key): boolean =>
  */
 export function isPrintableSearchChar(key: Key): boolean {
   if (key.ctrl || key.meta || key.paste) return false;
-  if (key.sequence.length !== 1) return false;
-  const code = key.sequence.charCodeAt(0);
-  return code >= 0x20 && code !== 0x7f;
+  const graphemes = splitGraphemes(key.sequence);
+  if (graphemes.length !== 1) return false;
+  const code = graphemes[0].codePointAt(0);
+  if (code === undefined) return false;
+  return code >= 0x20 && code !== 0x7f && (code < 0x80 || code > 0x9f);
 }
 
 export interface UseSessionSearchInputOptions {
@@ -170,7 +185,7 @@ export function useSessionSearchInput(
       if (isDeletionKey(key)) {
         // Pop one char. The ref-backed setter detects when the last
         // char is removed and exits to list mode immediately.
-        setSearchQuery((q) => q.slice(0, -1));
+        setSearchQuery(removeLastGrapheme);
         return;
       }
 


### PR DESCRIPTION
## What this PR does

- Treats a single grapheme cluster as one printable session search input.
- Deletes one whole grapheme at a time for Backspace/Delete in session search.
- Keeps control characters rejected, including C1 controls such as CSI.

## Why it's needed

Session search used `sequence.length === 1` and `slice(0, -1)`, so emoji input was either rejected or split into broken surrogate/ZWJ fragments when deleting.

Fixes #5341

## Reviewer Test Plan

How to verify:
- Type an emoji, flag, or ZWJ emoji into session search.
- Press Backspace/Delete and confirm the whole grapheme is removed.
- Confirm control sequences still do not seed the search query.

Evidence:
- `npx vitest run src/ui/hooks/useSessionSearchInput.test.ts`
- `npm run typecheck --workspace=packages/cli`
- `npm run build --workspace=packages/cli`
- `npm run lint`
- `npx prettier --check packages/cli/src/ui/hooks/useSessionSearchInput.ts packages/cli/src/ui/hooks/useSessionSearchInput.test.ts`
- `git diff --check upstream/main...HEAD`

Tested on:
- macOS
- Node.js 22

## Risk & Scope

Low risk. This is limited to the session search input hook and its tests.

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

这个 PR 修复 session search 对 emoji/grapheme 的处理：

- `🚀`、`🇨🇳`、`👨‍👩‍👧‍👦` 这类单个 grapheme 现在可以作为一个搜索字符输入；
- Backspace/Delete 删除一个完整 grapheme，不再留下半个 surrogate 或 ZWJ 片段；
- 仍然拒绝 C0/DEL/C1 控制字符，避免 CSI 等控制序列进入搜索文本。

</details>
