### PR TITLE
fix(core): parse OAuth resource metadata params

### DIFF
--- a/packages/core/src/mcp/oauth-utils.test.ts
+++ b/packages/core/src/mcp/oauth-utils.test.ts
@@ -251,10 +251,75 @@ describe('OAuthUtils', () => {
       );
     });
 
+    it('should parse resource metadata URI with optional whitespace around equals', () => {
+      const header =
+        'Bearer realm="example", resource_metadata = "https://example.com/.well-known/oauth-protected-resource"';
+      const result = OAuthUtils.parseWWWAuthenticateHeader(header);
+      expect(result).toBe(
+        'https://example.com/.well-known/oauth-protected-resource',
+      );
+    });
+
+    it('should parse single-quoted resource metadata URI', () => {
+      const header =
+        'Bearer realm="example", resource_metadata=\'https://example.com/.well-known/oauth-protected-resource\'';
+      const result = OAuthUtils.parseWWWAuthenticateHeader(header);
+      expect(result).toBe(
+        'https://example.com/.well-known/oauth-protected-resource',
+      );
+    });
+
+    it('should preserve apostrophes inside double-quoted resource metadata URI', () => {
+      const header =
+        'Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource?name=o\'hara"';
+      const result = OAuthUtils.parseWWWAuthenticateHeader(header);
+      expect(result).toBe(
+        "https://example.com/.well-known/oauth-protected-resource?name=o'hara",
+      );
+    });
+
+    it('should ignore apostrophes in other auth params', () => {
+      const header =
+        'Bearer ext=can\'t, resource_metadata="https://example.com/.well-known/oauth-protected-resource"';
+      const result = OAuthUtils.parseWWWAuthenticateHeader(header);
+      expect(result).toBe(
+        'https://example.com/.well-known/oauth-protected-resource',
+      );
+    });
+
     it('should return null when no resource metadata URI is found', () => {
       const header = 'Bearer realm="example"';
       const result = OAuthUtils.parseWWWAuthenticateHeader(header);
       expect(result).toBeNull();
+    });
+
+    it('should not parse malformed resource metadata values', () => {
+      expect(
+        OAuthUtils.parseWWWAuthenticateHeader(
+          'Bearer resource_metadata=https://example.com/.well-known/oauth-protected-resource',
+        ),
+      ).toBeNull();
+      expect(
+        OAuthUtils.parseWWWAuthenticateHeader('Bearer resource_metadata=""'),
+      ).toBeNull();
+      expect(
+        OAuthUtils.parseWWWAuthenticateHeader(
+          'Bearer resource_metadata=\'https://example.com/.well-known/oauth-protected-resource"',
+        ),
+      ).toBeNull();
+    });
+
+    it('should only parse standalone resource metadata params', () => {
+      expect(
+        OAuthUtils.parseWWWAuthenticateHeader(
+          'Bearer not_resource_metadata="https://example.com/.well-known/oauth-protected-resource"',
+        ),
+      ).toBeNull();
+      expect(
+        OAuthUtils.parseWWWAuthenticateHeader(
+          'Bearer error_description="missing, resource_metadata=\'https://example.com/.well-known/oauth-protected-resource\'"',
+        ),
+      ).toBeNull();
     });
   });
 

--- a/packages/core/src/mcp/oauth-utils.ts
+++ b/packages/core/src/mcp/oauth-utils.ts
@@ -10,6 +10,82 @@ import { createDebugLogger } from '../utils/debugLogger.js';
 
 const debugLogger = createDebugLogger('MCP_OAUTH');
 
+function splitAuthParams(value: string): string[] {
+  const params: string[] = [];
+  let start = 0;
+  let quote: '"' | "'" | undefined;
+  let escaped = false;
+
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (quote) {
+      if (char === '\\') {
+        escaped = true;
+      } else if (char === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      const beforeQuote = value.slice(start, i).trimEnd();
+      if (beforeQuote.endsWith('=')) {
+        quote = char;
+      }
+      continue;
+    }
+
+    if (char === ',') {
+      params.push(value.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+
+  params.push(value.slice(start).trim());
+  return params;
+}
+
+function parseResourceMetadataParam(rawParam: string): string | null {
+  const param = rawParam.replace(/^Bearer\s+/i, '').trim();
+  const prefix = /^resource_metadata\s*=\s*/.exec(param);
+  if (!prefix) {
+    return null;
+  }
+
+  const rest = param.slice(prefix[0].length).trim();
+  const quote = rest[0];
+  if (quote !== '"' && quote !== "'") {
+    return null;
+  }
+
+  let value = '';
+  let escaped = false;
+  for (let i = 1; i < rest.length; i++) {
+    const char = rest[i];
+    if (escaped) {
+      value += char;
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (char === quote) {
+      return rest.slice(i + 1).trim() === '' && value.length > 0 ? value : null;
+    }
+    value += char;
+  }
+
+  return null;
+}
+
 /**
  * OAuth authorization server metadata as per RFC 8414.
  */
@@ -297,10 +373,11 @@ export class OAuthUtils {
    * @returns The resource metadata URI if found
    */
   static parseWWWAuthenticateHeader(header: string): string | null {
-    // Parse Bearer realm and resource_metadata
-    const match = header.match(/resource_metadata="([^"]+)"/);
-    if (match) {
-      return match[1];
+    for (const rawParam of splitAuthParams(header)) {
+      const resourceMetadata = parseResourceMetadataParam(rawParam);
+      if (resourceMetadata !== null) {
+        return resourceMetadata;
+      }
     }
     return null;
   }


### PR DESCRIPTION
## What this PR does

- Parses `resource_metadata` as a standalone `WWW-Authenticate` auth-param.
- Accepts optional whitespace around `=`.
- Accepts single-quoted values while keeping double-quoted values working.
- Rejects malformed or non-standalone matches such as `not_resource_metadata` and quoted error text.

## Why it's needed

MCP OAuth discovery currently only recognizes the strict form:

```text
resource_metadata="..."
```

Some servers may return equivalent challenges with whitespace around `=` or single-quoted values. The previous parser missed those, while a simple broader regex can accidentally parse `resource_metadata` text inside another parameter. This keeps the compatibility fix scoped to real auth params.

Fixes #5343

## Reviewer Test Plan

How to verify:
- Return a `WWW-Authenticate` header with `resource_metadata = "..."`.
- Return a `WWW-Authenticate` header with `resource_metadata='...'`.
- Confirm malformed values and `resource_metadata` text inside other params are ignored.

Evidence:
- `npx vitest run src/mcp/oauth-utils.test.ts`
- `npm run typecheck --workspace=packages/core`
- `npm run build --workspace=packages/core`
- `npm run lint`
- `npx prettier --check packages/core/src/mcp/oauth-utils.ts packages/core/src/mcp/oauth-utils.test.ts`
- `git diff --check`

Tested on:
- macOS
- Node.js 22

## Risk & Scope

Low risk. The change is limited to MCP OAuth `WWW-Authenticate` parsing and tests. It only broadens parsing for standalone `resource_metadata` auth params and rejects false positives more strictly than the previous global match.

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

这个 PR 修复 MCP OAuth discovery 里的 `WWW-Authenticate` 解析：

- 支持 `resource_metadata = "..."` 这种等号两侧带空格的写法；
- 支持 `resource_metadata='...'` 这种单引号写法；
- 不再把 `not_resource_metadata` 或 `error_description` 里的文字误识别成 metadata URL；
- 空值、未加引号、引号不匹配、尾部 junk 都会返回 `null`。

</details>
