### PR TITLE
fix(cli): normalize english output language

### DIFF
--- a/packages/cli/src/ui/commands/languageCommand.test.ts
+++ b/packages/cli/src/ui/commands/languageCommand.test.ts
@@ -549,6 +549,20 @@ describe('languageCommand', () => {
       );
     });
 
+    it('should normalize output language name "english" to "English"', async () => {
+      if (!languageCommand.action) {
+        throw new Error('The language command must have an action.');
+      }
+
+      await languageCommand.action(mockContext, 'output english');
+
+      expect(mockContext.services.settings?.setValue).toHaveBeenCalledWith(
+        expect.anything(),
+        'general.outputLanguage',
+        'English',
+      );
+    });
+
     it('should normalize locale code "de" to "German"', async () => {
       if (!languageCommand.action) {
         throw new Error('The language command must have an action.');

--- a/packages/cli/src/utils/languageUtils.test.ts
+++ b/packages/cli/src/utils/languageUtils.test.ts
@@ -104,6 +104,12 @@ describe('languageUtils', () => {
       expect(normalizeOutputLanguage('en')).toBe('English');
     });
 
+    it('should normalize "english" to "English"', () => {
+      expect(normalizeOutputLanguage('english')).toBe('English');
+      expect(normalizeOutputLanguage('English')).toBe('English');
+      expect(normalizeOutputLanguage('en-US')).toBe('English');
+    });
+
     it('should convert "zh" to "Chinese"', () => {
       expect(normalizeOutputLanguage('zh')).toBe('Chinese');
     });
@@ -134,6 +140,7 @@ describe('languageUtils', () => {
     it('should preserve explicit language names as-is', () => {
       expect(normalizeOutputLanguage('Japanese')).toBe('Japanese');
       expect(normalizeOutputLanguage('French')).toBe('French');
+      expect(normalizeOutputLanguage('french')).toBe('French');
     });
 
     it('should preserve unknown language names as-is', () => {
@@ -164,6 +171,12 @@ describe('languageUtils', () => {
 
     it('should normalize explicit locale codes', () => {
       expect(resolveOutputLanguage('zh')).toBe('Chinese');
+      expect(i18n.detectSystemLanguage).not.toHaveBeenCalled();
+    });
+
+    it('should normalize "english"', () => {
+      expect(resolveOutputLanguage('english')).toBe('English');
+      expect(resolveOutputLanguage('en-US')).toBe('English');
       expect(i18n.detectSystemLanguage).not.toHaveBeenCalled();
     });
 

--- a/packages/cli/src/utils/languageUtils.ts
+++ b/packages/cli/src/utils/languageUtils.ts
@@ -17,6 +17,7 @@ import {
   detectSystemLanguage,
   getLanguageNameFromLocale,
 } from '../i18n/index.js';
+import { SUPPORTED_LANGUAGES } from '../i18n/languages.js';
 
 const LLM_OUTPUT_LANGUAGE_RULE_FILENAME = 'output-language.md';
 const LLM_OUTPUT_LANGUAGE_MARKER_PREFIX = 'qwen-code:llm-output-language:';
@@ -37,14 +38,34 @@ export function isAutoLanguage(value: string | undefined | null): boolean {
  * Unknown inputs are returned as-is to support any language name.
  */
 export function normalizeOutputLanguage(language: string): string {
-  const lowered = language.toLowerCase();
-  const fullName = getLanguageNameFromLocale(lowered);
-  // getLanguageNameFromLocale returns 'English' as default for unknown codes.
-  // Only use the result if it's a known code or explicitly 'en'.
-  if (fullName !== 'English' || lowered === 'en') {
-    return fullName;
+  const normalized = language.trim().replace(/_/g, '-').toLowerCase();
+  const knownLanguageName = SUPPORTED_LANGUAGES.find(
+    (supportedLanguage) =>
+      supportedLanguage.fullName.toLowerCase() === normalized,
+  );
+  if (knownLanguageName) {
+    return knownLanguageName.fullName;
   }
-  return language;
+
+  const knownLocaleCode = SUPPORTED_LANGUAGES.some((supportedLanguage) => {
+    const code = supportedLanguage.code.toLowerCase();
+    const id = supportedLanguage.id.toLowerCase();
+    return (
+      normalized === code ||
+      normalized === id ||
+      normalized.startsWith(`${code}-`) ||
+      normalized.startsWith(`${id}-`) ||
+      normalized.startsWith(`${code}.`) ||
+      normalized.startsWith(`${id}.`) ||
+      normalized.startsWith(`${code}@`) ||
+      normalized.startsWith(`${id}@`)
+    );
+  });
+  if (!knownLocaleCode) {
+    return language;
+  }
+
+  return getLanguageNameFromLocale(normalized);
 }
 
 /**


### PR DESCRIPTION
## What this PR does

- Normalizes supported output language full names case-insensitively.
- Fixes `english` and `en-US` resolving to canonical `English`.
- Keeps unknown custom language names and native names unchanged.
- Adds command-level coverage for `/language output english`.

## Why it's needed

`normalizeOutputLanguage()` used `getLanguageNameFromLocale()` but had to avoid its `"English"` fallback for unknown inputs. That accidentally left explicit `english` unchanged, so `/language output english` could persist lowercase `english` instead of the canonical `English`.

Fixes #5345

## Reviewer Test Plan

How to verify:
- `normalizeOutputLanguage('english')` returns `English`.
- `/language output english` persists `general.outputLanguage` as `English`.
- Unknown custom language names and native names continue to pass through unchanged.

Evidence:
- `npx vitest run src/utils/languageUtils.test.ts`
- `npx vitest run src/ui/commands/languageCommand.test.ts`
- `npm run typecheck --workspace=packages/cli`
- `npm run build --workspace=packages/core`
- `npm run build --workspace=packages/cli`
- `npm run lint`
- `npx prettier --check packages/cli/src/utils/languageUtils.ts packages/cli/src/utils/languageUtils.test.ts packages/cli/src/ui/commands/languageCommand.test.ts`
- `git diff --check`

Tested on:
- macOS
- Node.js 22

## Risk & Scope

Low risk. This is limited to output-language normalization and tests. It only canonicalizes supported English full language names and known locale codes; unknown names still pass through.

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

这个 PR 修复输出语言设置里的大小写规范化：

- `english` 现在会保存成 `English`；
- `en-US` 也会解析成 `English`；
- `/language output english` 加了命令层回归测试；
- 自定义语言名和 native name（例如 `日本語`）仍保持原样，不会被意外改写。

</details>
