### PR TITLE
fix(cli): return fresh empty mcp json results

### DIFF
--- a/packages/cli/src/config/mcpJson.test.ts
+++ b/packages/cli/src/config/mcpJson.test.ts
@@ -31,6 +31,17 @@ describe('loadProjectMcpServers', () => {
     expect(result.errors).toEqual([]);
   });
 
+  it('returns a fresh empty result when .mcp.json is absent', () => {
+    const first = loadProjectMcpServers(dir);
+    first.servers['stale'] = { command: 'node' };
+    first.errors.push('stale error');
+
+    const second = loadProjectMcpServers(dir);
+    expect(second.servers).toEqual({});
+    expect(second.errors).toEqual([]);
+    expect(second).not.toBe(first);
+  });
+
   it('loads servers and tags each with scope: project', () => {
     write(
       JSON.stringify({

--- a/packages/cli/src/config/mcpJson.ts
+++ b/packages/cli/src/config/mcpJson.ts
@@ -26,12 +26,6 @@ export interface LoadProjectMcpServersResult {
   errors: string[];
 }
 
-const EMPTY: LoadProjectMcpServersResult = {
-  servers: {},
-  path: undefined,
-  errors: [],
-};
-
 /**
  * Load project-scoped MCP servers from `<projectRoot>/.mcp.json`.
  *
@@ -51,7 +45,7 @@ export function loadProjectMcpServers(
     raw = fs.readFileSync(filePath, 'utf-8');
   } catch {
     // Missing/unreadable file is the common case — not an error.
-    return EMPTY;
+    return { servers: {}, path: undefined, errors: [] };
   }
 
   let parsed: unknown;


### PR DESCRIPTION
## What this PR does

Makes `loadProjectMcpServers()` return a fresh, independent result object every time the project `.mcp.json` file is missing or unreadable. Previously this code path returned a single module-level shared `EMPTY` constant, so every missing-file call handed back the same `servers` and `errors` objects. This PR drops that shared constant and returns a new `{ servers: {}, path: undefined, errors: [] }` literal on each call, matching the parse/error paths which already build fresh objects. It also adds a regression test asserting that mutating one missing-file result does not leak into a later load.

## Why it's needed

The shared `EMPTY` object caused cross-project state leaks: if any caller mutated the returned `servers` or `errors`, a subsequent `loadProjectMcpServers()` call for a different project would observe that stale mutation. For example, after `loadProjectMcpServers('/tmp/project-a')` pushes into `errors`, a later `loadProjectMcpServers('/tmp/project-b')` would still see the leftover `errors` entry. Each call should get a fresh empty result instead.

## Reviewer Test Plan

### How to verify

Reproduction: call `loadProjectMcpServers()` for a directory with no `.mcp.json`, mutate the returned `servers`/`errors`, then call it again for another directory.

- Expected: the second call returns an empty, independent result (`servers === {}`, `errors === []`) that is a different object than the first.
- Observed before the fix: the second call still carried the mutation from the first (shared `EMPTY` object).
- Observed after the fix: the second call returns a fresh empty result, no leakage.

This is covered by the new unit test in `packages/cli/src/config/mcpJson.test.ts` ("returns a fresh empty result when .mcp.json is absent").

Verification commands run:

- `npx vitest run src/config/mcpJson.test.ts`
- `npm run build --workspace=packages/core`
- `npm run typecheck --workspace=packages/cli`
- `npm run build --workspace=packages/cli`
- `npx prettier --check packages/cli/src/config/mcpJson.ts packages/cli/src/config/mcpJson.test.ts`
- `git diff --check upstream/main..HEAD`
- `npm run lint`

### Evidence (Before & After)

N/A — non-visible logic fix; covered by the unit test above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI  |
| 🪟 Windows |  ✅ CI  |
|  🐧 Linux  |  ✅ CI  |

✅ tested · ⚠️ not tested · N/A

### Environment (optional)

Unit tests only (npm workspaces).

## Risk & Scope

- Main risk or tradeoff: Low; scoped to the missing/unreadable-file branch of `loadProjectMcpServers()` in `packages/cli/src/config/mcpJson.ts`. The behavior change is limited to returning a fresh object instead of a shared one; the returned values are identical.
- Not validated / out of scope: No unrelated refactors, public API changes, or UI changes.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5347

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 `loadProjectMcpServers()` 在项目的 `.mcp.json` 文件缺失或不可读时，每次都返回一个全新的、相互独立的结果对象。此前这条代码路径返回的是一个模块级共享的 `EMPTY` 常量，因此每一次"文件缺失"的调用都会拿到同一个 `servers` 和 `errors` 对象。本 PR 移除了这个共享常量，改为在每次调用时返回一个新的 `{ servers: {}, path: undefined, errors: [] }` 字面量，与解析/错误路径（它们本来就构造新对象）保持一致。同时新增了一个回归测试，断言对某一次"文件缺失"结果的修改不会泄漏到后续的加载中。

## 为什么需要

共享的 `EMPTY` 对象会导致跨项目的状态泄漏：如果任何调用方修改了返回的 `servers` 或 `errors`，随后针对另一个项目的 `loadProjectMcpServers()` 调用就会观察到这个被污染的旧状态。例如，在 `loadProjectMcpServers('/tmp/project-a')` 向 `errors` push 之后，后续的 `loadProjectMcpServers('/tmp/project-b')` 仍会看到残留的 `errors` 条目。每次调用都应当得到一个全新的空结果。

## Reviewer 测试计划

### 如何验证

复现：对一个没有 `.mcp.json` 的目录调用 `loadProjectMcpServers()`，修改返回的 `servers`/`errors`，然后再对另一个目录调用一次。

- 预期：第二次调用返回一个空的、独立的结果（`servers === {}`，`errors === []`），并且是与第一次不同的对象。
- 修复前观察到的：第二次调用仍然带有第一次的修改（共享的 `EMPTY` 对象）。
- 修复后观察到的：第二次调用返回全新的空结果，无泄漏。

这一点由 `packages/cli/src/config/mcpJson.test.ts` 中新增的单元测试覆盖（"returns a fresh empty result when .mcp.json is absent"）。

执行的验证命令：

- `npx vitest run src/config/mcpJson.test.ts`
- `npm run build --workspace=packages/core`
- `npm run typecheck --workspace=packages/cli`
- `npm run build --workspace=packages/cli`
- `npx prettier --check packages/cli/src/config/mcpJson.ts packages/cli/src/config/mcpJson.test.ts`
- `git diff --check upstream/main..HEAD`
- `npm run lint`

### 证据（前后对比）

N/A —— 非可见的逻辑修复；已由上面的单元测试覆盖。

### 测试平台

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI  |
| 🪟 Windows |  ✅ CI  |
|  🐧 Linux  |  ✅ CI  |

✅ 已测试 · ⚠️ 未测试 · N/A

### 运行环境（可选）

仅单元测试（npm workspaces）。

## 风险与范围

- 主要风险或权衡：低；仅限于 `packages/cli/src/config/mcpJson.ts` 中 `loadProjectMcpServers()` 处理"文件缺失/不可读"的分支。行为变化仅在于返回一个新对象而非共享对象；返回的值完全相同。
- 未验证 / 范围之外：没有无关的重构、公共 API 变更或 UI 变更。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #5347

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
