### PR TITLE
fix(core): validate cron numeric tokens

### DIFF
--- a/packages/core/src/utils/cronDisplay.test.ts
+++ b/packages/core/src/utils/cronDisplay.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { humanReadableCron } from './cronDisplay.js';
+
+describe('humanReadableCron', () => {
+  it('formats common step patterns', () => {
+    expect(humanReadableCron('*/5 * * * *')).toBe('Every 5 minutes');
+    expect(humanReadableCron('0 */2 * * *')).toBe('Every 2 hours');
+    expect(humanReadableCron('0 9 */3 * *')).toBe('Every 3 days');
+  });
+
+  it('leaves malformed step expressions unchanged', () => {
+    expect(humanReadableCron('*/15garbage * * * *')).toBe(
+      '*/15garbage * * * *',
+    );
+    expect(humanReadableCron('0 */2x * * *')).toBe('0 */2x * * *');
+    expect(humanReadableCron('0 9 */3x * *')).toBe('0 9 */3x * *');
+  });
+});

--- a/packages/core/src/utils/cronDisplay.ts
+++ b/packages/core/src/utils/cronDisplay.ts
@@ -2,6 +2,14 @@
  * Human-readable cron display for common recurring patterns.
  * Falls back to the raw expression for anything non-trivial.
  */
+function parseStepExpression(field: string): number | null {
+  const match = /^\*\/(\d+)$/.exec(field);
+  if (!match) return null;
+
+  const value = Number(match[1]!);
+  return value > 0 ? value : null;
+}
+
 export function humanReadableCron(cronExpr: string): string {
   const parts = cronExpr.trim().split(/\s+/);
   if (parts.length !== 5) return cronExpr;
@@ -9,45 +17,39 @@ export function humanReadableCron(cronExpr: string): string {
   const [min, hour, dom, mon, dow] = parts;
 
   // */N * * * * → Every N minutes
+  const minuteStep = parseStepExpression(min!);
   if (
-    min!.startsWith('*/') &&
+    minuteStep !== null &&
     hour === '*' &&
     dom === '*' &&
     mon === '*' &&
     dow === '*'
   ) {
-    const n = parseInt(min!.slice(2), 10);
-    if (!isNaN(n)) {
-      return n === 1 ? 'Every minute' : `Every ${n} minutes`;
-    }
+    return minuteStep === 1 ? 'Every minute' : `Every ${minuteStep} minutes`;
   }
 
   // 0 */N * * * → Every N hours (or single minute with */N hours)
+  const hourStep = parseStepExpression(hour!);
   if (
     /^\d+$/.test(min!) &&
-    hour!.startsWith('*/') &&
+    hourStep !== null &&
     dom === '*' &&
     mon === '*' &&
     dow === '*'
   ) {
-    const n = parseInt(hour!.slice(2), 10);
-    if (!isNaN(n)) {
-      return n === 1 ? 'Every hour' : `Every ${n} hours`;
-    }
+    return hourStep === 1 ? 'Every hour' : `Every ${hourStep} hours`;
   }
 
   // M H */N * * → Every N days
+  const dayStep = parseStepExpression(dom!);
   if (
     /^\d+$/.test(min!) &&
     /^\d+$/.test(hour!) &&
-    dom!.startsWith('*/') &&
+    dayStep !== null &&
     mon === '*' &&
     dow === '*'
   ) {
-    const n = parseInt(dom!.slice(2), 10);
-    if (!isNaN(n)) {
-      return n === 1 ? 'Every day' : `Every ${n} days`;
-    }
+    return dayStep === 1 ? 'Every day' : `Every ${dayStep} days`;
   }
 
   return cronExpr;

--- a/packages/core/src/utils/cronParser.test.ts
+++ b/packages/core/src/utils/cronParser.test.ts
@@ -64,6 +64,13 @@ describe('parseCron', () => {
   it('throws on invalid step', () => {
     expect(() => parseCron('*/0 * * * *')).toThrow('Invalid step');
   });
+
+  it('throws on malformed numeric tokens', () => {
+    expect(() => parseCron('5x * * * *')).toThrow('Invalid value');
+    expect(() => parseCron('1-5x * * * *')).toThrow('Invalid range');
+    expect(() => parseCron('1-2-3 * * * *')).toThrow('Invalid range');
+    expect(() => parseCron('*/15garbage * * * *')).toThrow('Invalid step');
+  });
 });
 
 describe('matches', () => {

--- a/packages/core/src/utils/cronParser.ts
+++ b/packages/core/src/utils/cronParser.ts
@@ -26,6 +26,13 @@ const FIELD_RANGES: Array<[number, number]> = [
   [0, 7], // day of week (0 and 7 both mean Sunday)
 ];
 
+function parseIntegerToken(token: string, description: string): number {
+  if (!/^\d+$/.test(token)) {
+    throw new Error(`Invalid ${description}: "${token}"`);
+  }
+  return Number(token);
+}
+
 /**
  * Parses a single cron field into a set of matching values.
  * Supports: star, single values, steps (star/N), ranges (a-b), comma lists.
@@ -53,26 +60,32 @@ function parseField(field: string, min: number, max: number): Set<number> {
       rangeStart = min;
       rangeEnd = max;
     } else if (base.includes('-')) {
-      const [startStr, endStr] = base.split('-');
-      rangeStart = parseInt(startStr!, 10);
-      rangeEnd = parseInt(endStr!, 10);
-      if (isNaN(rangeStart) || isNaN(rangeEnd)) {
+      const rangeParts = base.split('-');
+      if (
+        rangeParts.length !== 2 ||
+        !/^\d+$/.test(rangeParts[0]!) ||
+        !/^\d+$/.test(rangeParts[1]!)
+      ) {
         throw new Error(`Invalid range: "${base}"`);
       }
+      const [startStr, endStr] = rangeParts;
+      rangeStart = Number(startStr!);
+      rangeEnd = Number(endStr!);
       if (rangeStart < min || rangeEnd > max || rangeStart > rangeEnd) {
         throw new Error(`Range ${base} out of bounds [${min}-${max}]`);
       }
     } else {
-      const val = parseInt(base, 10);
-      if (isNaN(val) || val < min || val > max) {
+      const val = parseIntegerToken(base, 'value');
+      if (val < min || val > max) {
         throw new Error(`Value "${base}" out of bounds [${min}-${max}]`);
       }
       rangeStart = val;
       rangeEnd = val;
     }
 
-    const step = stepParts.length === 2 ? parseInt(stepParts[1]!, 10) : 1;
-    if (isNaN(step) || step <= 0) {
+    const step =
+      stepParts.length === 2 ? parseIntegerToken(stepParts[1]!, 'step') : 1;
+    if (step <= 0) {
       throw new Error(`Invalid step: "${stepParts[1]}"`);
     }
 


### PR DESCRIPTION
Fixes #5348

## Summary
- Add whole-token numeric validation for cron single values, ranges, and step expressions
- Reject malformed range expressions with extra separators or trailing characters
- Keep humanReadableCron() from formatting malformed step expressions as valid schedules
- Add focused regression tests for malformed parser and display inputs

## Validation
- npm exec --workspace=packages/core vitest run src/utils/cronParser.test.ts src/utils/cronDisplay.test.ts
- npm exec prettier -- --check packages/core/src/utils/cronParser.ts packages/core/src/utils/cronDisplay.ts packages/core/src/utils/cronParser.test.ts packages/core/src/utils/cronDisplay.test.ts
- git diff HEAD --check

## Demo
N/A - internal validation fix with no visual UI change.