### PR TITLE
fix(core): reject malformed cron numeric fields

### DIFF
--- a/packages/core/src/utils/cronDisplay.test.ts
+++ b/packages/core/src/utils/cronDisplay.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { humanReadableCron } from './cronDisplay.js';
+
+describe('humanReadableCron', () => {
+  it('formats common step expressions', () => {
+    expect(humanReadableCron('*/15 * * * *')).toBe('Every 15 minutes');
+    expect(humanReadableCron('0 */2 * * *')).toBe('Every 2 hours');
+    expect(humanReadableCron('0 0 */3 * *')).toBe('Every 3 days');
+  });
+
+  it('falls back for malformed step expressions', () => {
+    expect(humanReadableCron('*/15x * * * *')).toBe('*/15x * * * *');
+    expect(humanReadableCron('*/0 * * * *')).toBe('*/0 * * * *');
+    expect(humanReadableCron('0 */2x * * *')).toBe('0 */2x * * *');
+    expect(humanReadableCron('0 0 */3x * *')).toBe('0 0 */3x * *');
+  });
+});

--- a/packages/core/src/utils/cronDisplay.ts
+++ b/packages/core/src/utils/cronDisplay.ts
@@ -2,6 +2,14 @@
  * Human-readable cron display for common recurring patterns.
  * Falls back to the raw expression for anything non-trivial.
  */
+const INTEGER_TOKEN_RE = /^\d+$/;
+
+function parsePositiveInteger(token: string): number | undefined {
+  if (!INTEGER_TOKEN_RE.test(token)) return undefined;
+  const value = parseInt(token, 10);
+  return value > 0 ? value : undefined;
+}
+
 export function humanReadableCron(cronExpr: string): string {
   const parts = cronExpr.trim().split(/\s+/);
   if (parts.length !== 5) return cronExpr;
@@ -16,8 +24,8 @@ export function humanReadableCron(cronExpr: string): string {
     mon === '*' &&
     dow === '*'
   ) {
-    const n = parseInt(min!.slice(2), 10);
-    if (!isNaN(n)) {
+    const n = parsePositiveInteger(min!.slice(2));
+    if (n !== undefined) {
       return n === 1 ? 'Every minute' : `Every ${n} minutes`;
     }
   }
@@ -30,8 +38,8 @@ export function humanReadableCron(cronExpr: string): string {
     mon === '*' &&
     dow === '*'
   ) {
-    const n = parseInt(hour!.slice(2), 10);
-    if (!isNaN(n)) {
+    const n = parsePositiveInteger(hour!.slice(2));
+    if (n !== undefined) {
       return n === 1 ? 'Every hour' : `Every ${n} hours`;
     }
   }
@@ -44,8 +52,8 @@ export function humanReadableCron(cronExpr: string): string {
     mon === '*' &&
     dow === '*'
   ) {
-    const n = parseInt(dom!.slice(2), 10);
-    if (!isNaN(n)) {
+    const n = parsePositiveInteger(dom!.slice(2));
+    if (n !== undefined) {
       return n === 1 ? 'Every day' : `Every ${n} days`;
     }
   }

--- a/packages/core/src/utils/cronParser.test.ts
+++ b/packages/core/src/utils/cronParser.test.ts
@@ -64,6 +64,15 @@ describe('parseCron', () => {
   it('throws on invalid step', () => {
     expect(() => parseCron('*/0 * * * *')).toThrow('Invalid step');
   });
+
+  it('throws on malformed numeric tokens', () => {
+    expect(() => parseCron('5x * * * *')).toThrow('Invalid value');
+    expect(() => parseCron('1-5x * * * *')).toThrow('Invalid range');
+    expect(() => parseCron('1-2-3 * * * *')).toThrow('Invalid range');
+    expect(() => parseCron('*/15garbage * * * *')).toThrow('Invalid step');
+    expect(() => parseCron('1-10/3x * * * *')).toThrow('Invalid step');
+    expect(() => parseCron('5/2x * * * *')).toThrow('Invalid step');
+  });
 });
 
 describe('matches', () => {

--- a/packages/core/src/utils/cronParser.ts
+++ b/packages/core/src/utils/cronParser.ts
@@ -26,6 +26,8 @@ const FIELD_RANGES: Array<[number, number]> = [
   [0, 7], // day of week (0 and 7 both mean Sunday)
 ];
 
+const INTEGER_TOKEN_RE = /^\d+$/;
+
 /**
  * Parses a single cron field into a set of matching values.
  * Supports: star, single values, steps (star/N), ranges (a-b), comma lists.
@@ -53,26 +55,37 @@ function parseField(field: string, min: number, max: number): Set<number> {
       rangeStart = min;
       rangeEnd = max;
     } else if (base.includes('-')) {
-      const [startStr, endStr] = base.split('-');
-      rangeStart = parseInt(startStr!, 10);
-      rangeEnd = parseInt(endStr!, 10);
-      if (isNaN(rangeStart) || isNaN(rangeEnd)) {
+      const rangeParts = base.split('-');
+      if (
+        rangeParts.length !== 2 ||
+        !INTEGER_TOKEN_RE.test(rangeParts[0]!) ||
+        !INTEGER_TOKEN_RE.test(rangeParts[1]!)
+      ) {
         throw new Error(`Invalid range: "${base}"`);
       }
+      const [startStr, endStr] = rangeParts;
+      rangeStart = parseInt(startStr!, 10);
+      rangeEnd = parseInt(endStr!, 10);
       if (rangeStart < min || rangeEnd > max || rangeStart > rangeEnd) {
         throw new Error(`Range ${base} out of bounds [${min}-${max}]`);
       }
     } else {
+      if (!INTEGER_TOKEN_RE.test(base)) {
+        throw new Error(`Invalid value: "${base}"`);
+      }
       const val = parseInt(base, 10);
-      if (isNaN(val) || val < min || val > max) {
+      if (val < min || val > max) {
         throw new Error(`Value "${base}" out of bounds [${min}-${max}]`);
       }
       rangeStart = val;
       rangeEnd = val;
     }
 
+    if (stepParts.length === 2 && !INTEGER_TOKEN_RE.test(stepParts[1]!)) {
+      throw new Error(`Invalid step: "${stepParts[1]}"`);
+    }
     const step = stepParts.length === 2 ? parseInt(stepParts[1]!, 10) : 1;
-    if (isNaN(step) || step <= 0) {
+    if (step <= 0) {
       throw new Error(`Invalid step: "${stepParts[1]}"`);
     }
 


### PR DESCRIPTION
## What this PR does

Tightens cron field parsing so numeric tokens are only accepted when the entire token is a valid integer, instead of relying on bare `parseInt()` (which silently ignores trailing characters).

- Single values, range endpoints, and step values are now whole-token validated before conversion. Malformed inputs are rejected with the existing error kinds: a bad single value throws `Invalid value`, a malformed or over-segmented range (e.g. `1-5x`, `1-2-3`) throws `Invalid range`, and a malformed step (e.g. `*/15garbage`, `5/2x`) throws `Invalid step`.
- `humanReadableCron()` applies the same whole-token check to step expressions, so a malformed pattern like `*/15x * * * *` falls back to the raw expression string instead of being summarized as `Every 15 minutes`.
- Adds regression tests for the malformed parser inputs and the display fallbacks.

## Why it's needed

`parseCron()` previously normalized malformed fields by parsing only the leading digits, so `5x * * * *` behaved like `5 * * * *`, `1-5x` like `1-5`, `1-2-3` like `1-2`, and `*/15garbage` like `*/15`. `humanReadableCron()` had the matching problem, displaying `*/15x * * * *` as `Every 15 minutes`.

This matters because `cron_create` validates schedules through `parseCron()` (and `nextFireTime()`) before creating a job. If a malformed expression is silently normalized rather than rejected, a user or the model can create a scheduled task that runs at an unintended cadence instead of failing fast. The fix makes the parser fail fast on malformed numeric fields. (See issue #5348.)

## Reviewer Test Plan

### How to verify

Repro of the original bug: before this change, `parseCron('5x * * * *')` succeeded and behaved like `5 * * * *`, and `humanReadableCron('*/15x * * * *')` returned `Every 15 minutes`. After this change, the parser throws (`Invalid value` / `Invalid range` / `Invalid step`) for malformed tokens, and `humanReadableCron` falls back to the raw string. The added unit tests assert exactly these expected-vs-observed outcomes.

Verification commands already run on this branch:

- `npx vitest run packages/core/src/utils/cronParser.test.ts packages/core/src/utils/cronDisplay.test.ts`
- `npx prettier --check packages/core/src/utils/cronParser.ts packages/core/src/utils/cronParser.test.ts packages/core/src/utils/cronDisplay.ts packages/core/src/utils/cronDisplay.test.ts`
- `npx eslint packages/core/src/utils/cronParser.ts packages/core/src/utils/cronParser.test.ts packages/core/src/utils/cronDisplay.ts packages/core/src/utils/cronDisplay.test.ts`
- `npm run typecheck --workspace=packages/core`
- `git diff --check`

### Evidence (Before & After)

N/A — non-visible logic fix; covered by the unit tests above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI |
| 🪟 Windows |  ✅ CI |
|  🐧 Linux  |  ✅ CI |

✅ tested · ⚠️ not tested · N/A

### Environment (optional)

Unit tests only (npm workspaces).

## Risk & Scope

- Main risk or tradeoff: Low; scoped to cron field parsing and display. The behavior change is limited to rejecting (or, for display, falling back on) malformed numeric tokens that were previously silently normalized. Well-formed expressions are unaffected.
- Not validated / out of scope: No unrelated refactors, no public API changes, no UI redesigns.
- Breaking changes / migration notes: None. Inputs that were already valid keep working; only previously-malformed-but-silently-accepted inputs now fail fast.

## Linked Issues

Fixes #5348

<details>
<summary>中文说明</summary>

## 此 PR 的作用

收紧 cron 字段解析逻辑：只有当整个数字 token 都是合法整数时才接受，而不再依赖原始的 `parseInt()`（它会静默忽略尾部多余字符）。

- 单值、范围端点和步长值在转换前都会进行整 token 校验。非法输入会按既有的错误类型被拒绝：非法单值抛出 `Invalid value`；非法或多段范围（如 `1-5x`、`1-2-3`）抛出 `Invalid range`；非法步长（如 `*/15garbage`、`5/2x`）抛出 `Invalid step`。
- `humanReadableCron()` 对步长表达式应用相同的整 token 校验，因此像 `*/15x * * * *` 这样的非法表达式会回退为原始表达式字符串，而不再被概括为 `Every 15 minutes`。
- 为这些非法解析输入和显示回退新增了回归测试。

## 为什么需要

此前 `parseCron()` 只解析前导数字，从而把非法字段静默归一化：`5x * * * *` 表现得像 `5 * * * *`，`1-5x` 像 `1-5`，`1-2-3` 像 `1-2`，`*/15garbage` 像 `*/15`。`humanReadableCron()` 也有同样的问题，会把 `*/15x * * * *` 显示成 `Every 15 minutes`。

这很重要，因为 `cron_create` 在创建任务前会通过 `parseCron()`（以及 `nextFireTime()`）来校验调度表达式。如果非法表达式被静默归一化而不是被拒绝，用户或模型就可能创建出以非预期频率运行的定时任务，而不是快速失败。本次修复让解析器在遇到非法数字字段时快速失败。（见 issue #5348。）

## 审阅者测试计划

### 如何验证

原始 bug 复现：在本次改动前，`parseCron('5x * * * *')` 会成功并表现得像 `5 * * * *`，`humanReadableCron('*/15x * * * *')` 会返回 `Every 15 minutes`。改动后，对于非法 token，解析器会抛错（`Invalid value` / `Invalid range` / `Invalid step`），而 `humanReadableCron` 会回退为原始字符串。新增的单元测试正是断言这些"期望 vs 实际"的结果。

本分支上已运行的验证命令：

- `npx vitest run packages/core/src/utils/cronParser.test.ts packages/core/src/utils/cronDisplay.test.ts`
- `npx prettier --check packages/core/src/utils/cronParser.ts packages/core/src/utils/cronParser.test.ts packages/core/src/utils/cronDisplay.ts packages/core/src/utils/cronDisplay.test.ts`
- `npx eslint packages/core/src/utils/cronParser.ts packages/core/src/utils/cronParser.test.ts packages/core/src/utils/cronDisplay.ts packages/core/src/utils/cronDisplay.test.ts`
- `npm run typecheck --workspace=packages/core`
- `git diff --check`

### 证据（前后对比）

N/A —— 非可见的逻辑修复；已由上述单元测试覆盖。

### 测试平台

|    操作系统   |  状态  |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI |
| 🪟 Windows |  ✅ CI |
|  🐧 Linux  |  ✅ CI |

✅ 已测试 · ⚠️ 未测试 · N/A

### 环境（可选）

仅单元测试（npm workspaces）。

## 风险与范围

- 主要风险或权衡：低；范围限定在 cron 字段解析与显示。行为变化仅限于拒绝（或在显示时回退）此前被静默归一化的非法数字 token。合法表达式不受影响。
- 未验证 / 范围之外：无无关重构、无公共 API 变更、无 UI 重新设计。
- 破坏性变更 / 迁移说明：无。原本合法的输入继续可用；只有此前"非法但被静默接受"的输入现在会快速失败。

## 关联 Issue

Fixes #5348

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
