### PR TITLE
fix(cli): show thinking in full transcript mode

### DIFF
--- a/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
@@ -16,6 +16,7 @@ import type {
 import { ToolGroupMessage } from './messages/ToolGroupMessage.js';
 import { renderWithProviders } from '../../test-utils/render.js';
 import { ConfigContext } from '../contexts/ConfigContext.js';
+import { CompactModeProvider } from '../contexts/CompactModeContext.js';
 
 // Mock child components
 vi.mock('./messages/ToolGroupMessage.js', () => ({
@@ -333,5 +334,76 @@ describe('<HistoryItemDisplay />', () => {
     );
     expect(lastFrame()).toContain('Read txt files');
     expect(lastFrame()).toContain('●');
+  });
+
+  it('renders committed thinking text in full transcript mode', () => {
+    const item: HistoryItem = {
+      id: 1,
+      type: 'gemini_thought',
+      text: 'Inspecting the repository',
+      durationMs: 1200,
+    };
+
+    const { lastFrame } = renderWithProviders(
+      <CompactModeProvider value={{ compactMode: false, compactInline: false }}>
+        <HistoryItemDisplay item={item} terminalWidth={100} isPending={false} />
+      </CompactModeProvider>,
+    );
+
+    const output = lastFrame() ?? '';
+    expect(output).toContain('Thought for');
+    expect(output).toContain('Inspecting the repository');
+  });
+
+  it('renders committed thinking continuations in full transcript mode', () => {
+    const item: HistoryItem = {
+      id: 1,
+      type: 'gemini_thought_content',
+      text: 'Continuing the reasoning',
+    };
+
+    const { lastFrame } = renderWithProviders(
+      <CompactModeProvider value={{ compactMode: false, compactInline: false }}>
+        <HistoryItemDisplay item={item} terminalWidth={100} isPending={false} />
+      </CompactModeProvider>,
+    );
+
+    expect(lastFrame()).toContain('Continuing the reasoning');
+  });
+
+  it('keeps committed thinking collapsed in compact mode', () => {
+    const item: HistoryItem = {
+      id: 1,
+      type: 'gemini_thought',
+      text: 'Inspecting the repository',
+      durationMs: 1200,
+    };
+
+    const { lastFrame } = renderWithProviders(
+      <CompactModeProvider value={{ compactMode: true, compactInline: false }}>
+        <HistoryItemDisplay item={item} terminalWidth={100} isPending={false} />
+      </CompactModeProvider>,
+    );
+
+    const output = lastFrame() ?? '';
+    expect(output).toContain('Thought for');
+    expect(output).toContain('ctrl+o to expand');
+    expect(output).not.toContain('Inspecting the repository');
+  });
+
+  it('keeps committed thinking continuations hidden in compact mode', () => {
+    const item: HistoryItem = {
+      id: 1,
+      type: 'gemini_thought_content',
+      text: 'Continuing the reasoning',
+    };
+
+    const { lastFrame } = renderWithProviders(
+      <CompactModeProvider value={{ compactMode: true, compactInline: false }}>
+        <HistoryItemDisplay item={item} terminalWidth={100} isPending={false} />
+      </CompactModeProvider>,
+    );
+
+    expect(lastFrame()).not.toContain('Continuing the reasoning');
   });
 });

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -181,12 +181,11 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
           sourceCopyIndexOffsets={sourceCopyIndexOffsets}
         />
       )}
-      {/* TODO(follow-up): wire expanded={compactMode} once Ctrl+O is decoupled */}
       {itemForDisplay.type === 'gemini_thought' && (
         <ThinkMessage
           text={itemForDisplay.text.trimEnd()}
           isPending={isPending}
-          expanded={false}
+          expanded={!compactMode}
           availableTerminalHeight={
             availableTerminalHeightGemini ?? availableTerminalHeight
           }
@@ -198,7 +197,7 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
         <ThinkMessageContent
           text={itemForDisplay.text.trimEnd()}
           isPending={isPending}
-          expanded={false}
+          expanded={!compactMode}
           availableTerminalHeight={
             availableTerminalHeightGemini ?? availableTerminalHeight
           }

--- a/packages/cli/src/ui/components/messages/ConversationMessages.test.tsx
+++ b/packages/cli/src/ui/components/messages/ConversationMessages.test.tsx
@@ -28,7 +28,7 @@ describe('<ThinkMessage />', () => {
     );
     const output = lastFrame();
     expect(output).toContain('Thinking');
-    expect(output).not.toContain('ctrl+o to expand');
+    expect(output).toContain('ctrl+o to expand');
     expect(output).not.toContain('Analyzing the code structure');
   });
 
@@ -45,7 +45,7 @@ describe('<ThinkMessage />', () => {
       <ThinkMessage {...defaultProps} isPending={false} />,
     );
     const output = lastFrame();
-    expect(output).not.toContain('ctrl+o to expand');
+    expect(output).toContain('ctrl+o to expand');
     expect(output).not.toContain('Analyzing the code structure');
   });
 
@@ -61,7 +61,7 @@ describe('<ThinkMessage />', () => {
     const output = lastFrame();
     expect(output).toContain('Thought for');
     expect(output).toContain('15s');
-    expect(output).not.toContain('ctrl+o to expand');
+    expect(output).toContain('ctrl+o to expand');
   });
 
   it('should show present-tense duration while pending (streaming)', () => {

--- a/packages/cli/src/ui/components/messages/ConversationMessages.tsx
+++ b/packages/cli/src/ui/components/messages/ConversationMessages.tsx
@@ -386,11 +386,9 @@ export const ThinkMessage: React.FC<ThinkMessageProps> = ({
       durationMs != null
         ? `${t('Thought for')} ${formatDuration(durationMs)}`
         : t('Thinking');
-    // TODO(follow-up): restore "(ctrl+o to expand)" hint once Ctrl+O is
-    // decoupled from compactMode so it can toggle thinking blocks independently.
     return (
       <Text dimColor italic>
-        {label}
+        {label} {t('(ctrl+o to expand)')}
       </Text>
     );
   }


### PR DESCRIPTION
## Summary

- show committed thinking blocks in full transcript mode while keeping compact mode collapsed
- add the Ctrl+O hint to collapsed committed thinking blocks
- cover full transcript and compact-mode wiring in HistoryItemDisplay tests

Fixes #5261

## Test plan

- npx vitest run packages/cli/src/ui/components/HistoryItemDisplay.test.tsx packages/cli/src/ui/components/messages/ConversationMessages.test.tsx
- npx prettier --check packages/cli/src/ui/components/HistoryItemDisplay.tsx packages/cli/src/ui/components/HistoryItemDisplay.test.tsx packages/cli/src/ui/components/messages/ConversationMessages.tsx packages/cli/src/ui/components/messages/ConversationMessages.test.tsx
- npx eslint packages/cli/src/ui/components/HistoryItemDisplay.tsx packages/cli/src/ui/components/HistoryItemDisplay.test.tsx packages/cli/src/ui/components/messages/ConversationMessages.tsx packages/cli/src/ui/components/messages/ConversationMessages.test.tsx
- npm run typecheck --workspace=packages/cli
- npm run check-i18n --workspace=packages/cli
- git diff --check

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
