### PR TITLE
fix(cli): validate restore checkpoints before mutation

### DIFF
--- a/packages/cli/src/ui/commands/restoreCommand.test.ts
+++ b/packages/cli/src/ui/commands/restoreCommand.test.ts
@@ -277,20 +277,29 @@ describe('restoreCommand', () => {
     expect(mockContext.ui.loadHistory).not.toHaveBeenCalled();
   });
 
-  it('should return an error for a checkpoint file missing the toolCall property', async () => {
+  it('should not mutate state for a checkpoint file missing the toolCall property', async () => {
     const checkpointName = 'missing-toolcall';
+    const toolCallData = {
+      history: [{ type: 'user', text: 'do a thing' }],
+      clientHistory: [{ role: 'user', parts: [{ text: 'do a thing' }] }],
+      promptId: 'prompt-abc123',
+    };
     await fs.writeFile(
       path.join(checkpointsDir, `${checkpointName}.json`),
-      JSON.stringify({ history: [] }), // An object that is valid JSON but missing the 'toolCall' property
+      JSON.stringify(toolCallData),
     );
     const command = restoreCommand(mockConfig);
 
     expect(await command?.action?.(mockContext, checkpointName)).toEqual({
       type: 'message',
       messageType: 'error',
-      // A more specific error message would be ideal, but for now, we can assert the current behavior.
-      content: expect.stringContaining('Could not read restorable tool calls.'),
+      content: expect.stringContaining(
+        'Checkpoint is missing a valid toolCall.',
+      ),
     });
+    expect(mockRewind).not.toHaveBeenCalled();
+    expect(mockContext.ui.loadHistory).not.toHaveBeenCalled();
+    expect(mockSetHistory).not.toHaveBeenCalled();
   });
 
   describe('completion', () => {

--- a/packages/cli/src/ui/commands/restoreCommand.ts
+++ b/packages/cli/src/ui/commands/restoreCommand.ts
@@ -86,6 +86,15 @@ async function restoreAction(
       };
     }
 
+    const toolCall = toolCallData.toolCall;
+    if (
+      !toolCall ||
+      typeof toolCall !== 'object' ||
+      typeof toolCall.name !== 'string'
+    ) {
+      throw new Error('Checkpoint is missing a valid toolCall.');
+    }
+
     if (toolCallData.promptId) {
       if (!config) {
         return {
@@ -144,8 +153,8 @@ async function restoreAction(
 
     return {
       type: 'tool',
-      toolName: toolCallData.toolCall.name,
-      toolArgs: toolCallData.toolCall.args,
+      toolName: toolCall.name,
+      toolArgs: toolCall.args,
     };
   } catch (error) {
     return {


### PR DESCRIPTION
## What this PR does

The `/restore` command previously dereferenced the checkpoint's `toolCall` (to read `toolCall.name` / `toolCall.args`) only at the very end, after it had already rewound project files and replaced the conversation history. This change adds an early validation step: right after the checkpoint JSON is parsed (and after the legacy-format check), it verifies that `toolCall` exists, is an object, and has a string `name`. If the checkpoint is missing a valid `toolCall`, it throws `Checkpoint is missing a valid toolCall.`, which falls through to the existing catch block and is surfaced as an error message — without performing any file rewind (`rewind`), UI history load (`loadHistory`), or client history replacement (`setHistory`). Malformed checkpoints therefore stay on the existing error path, but state mutation is no longer attempted before the failure is detected.

## Why it's needed

A malformed checkpoint (one whose JSON contains `history` / `clientHistory` but no `toolCall`) could mutate live state before `/restore` noticed the problem. The previous flow read the JSON, applied `history` via `loadHistory`, applied `clientHistory` via `setHistory`, and only then accessed `toolCall.name`, which threw. The user got an error, but the UI and client conversation history had already been replaced with the checkpoint's stale contents. Validating the `toolCall` before any mutation ensures a bad checkpoint fails cleanly and leaves the current session untouched.

## Reviewer Test Plan

### How to verify

Repro: create a checkpoint JSON that is valid JSON and contains `history`, `clientHistory`, and `promptId` but no `toolCall`, then run `/restore <checkpoint>`.

- Expected (after this change): `/restore` returns the error `Checkpoint is missing a valid toolCall.` and does **not** call `rewind`, `loadHistory`, or `setHistory` — the current session history is preserved.
- Observed before this change: `/restore` replaced `history`/`clientHistory` first, then errored.

Verification commands (from the author, all run during development):

- `npx vitest run src/ui/commands/restoreCommand.test.ts`
- `npx prettier --check packages/cli/src/ui/commands/restoreCommand.ts packages/cli/src/ui/commands/restoreCommand.test.ts`
- `npm run typecheck --workspace=packages/cli`
- `git diff --check upstream/main..HEAD`
- `npm run build --workspace=packages/core`
- `npm run build --workspace=packages/cli`
- `npm run lint`

The updated unit test (`restoreCommand.test.ts`) now asserts the new error message and that `mockRewind`, `mockContext.ui.loadHistory`, and `mockSetHistory` are never called for the missing-`toolCall` case (with `promptId`, `history`, and `clientHistory` all present).

### Evidence (Before & After)

N/A — non-visible logic fix; covered by the unit test above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI  |
| 🪟 Windows |  ✅ CI  |
|  🐧 Linux  |  ✅ CI  |

✅ tested · ⚠️ not tested · N/A

### Environment (optional)

Unit tests only (npm workspaces). Nothing special.

## Risk & Scope

- Main risk or tradeoff: Low; scoped to the `/restore` command (`packages/cli/src/ui/commands/restoreCommand.ts`). The behavior change is limited to malformed checkpoints that lack a valid `toolCall` — they now fail before any state mutation instead of after. Valid checkpoints are unaffected.
- Not validated / out of scope: No unrelated refactors, no public API changes, no UI redesigns. The checkpoint write path and valid-restore flow are unchanged.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5357

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

`/restore` 命令此前只在最后一步才解引用检查点的 `toolCall`（读取 `toolCall.name` / `toolCall.args`），而那时它已经回滚了项目文件并替换了对话历史。本次修改新增了一个提前校验步骤：在解析检查点 JSON 之后（并在旧格式检查之后），立即校验 `toolCall` 是否存在、是否为对象、其 `name` 是否为字符串。如果检查点缺少有效的 `toolCall`，就抛出 `Checkpoint is missing a valid toolCall.`，该错误会落入既有的 catch 块并以错误消息的形式呈现——并且不会执行任何文件回滚（`rewind`）、UI 历史加载（`loadHistory`）或客户端历史替换（`setHistory`）。因此格式错误的检查点仍走既有的错误路径，但不再在检测到失败之前尝试改变状态。

## 为什么需要它

一个格式错误的检查点（其 JSON 含有 `history` / `clientHistory` 但没有 `toolCall`）可能在 `/restore` 发现问题之前就改变了实时状态。此前的流程是：读取 JSON，通过 `loadHistory` 应用 `history`，通过 `setHistory` 应用 `clientHistory`，最后才访问 `toolCall.name` 并抛错。用户会收到一个错误，但 UI 和客户端的对话历史此时已被替换为检查点中陈旧的内容。在任何状态变更之前校验 `toolCall`，可确保坏检查点干净地失败，并使当前会话保持不变。

## 审阅者测试计划

### 如何验证

复现：构造一个 JSON 合法、包含 `history`、`clientHistory` 和 `promptId` 但没有 `toolCall` 的检查点文件，然后运行 `/restore <检查点>`。

- 预期（应用本次修改后）：`/restore` 返回错误 `Checkpoint is missing a valid toolCall.`，且**不**调用 `rewind`、`loadHistory` 或 `setHistory`——当前会话历史被保留。
- 修改前的现象：`/restore` 先替换了 `history`/`clientHistory`，然后才报错。

验证命令（来自作者，均在开发期间运行过）：

- `npx vitest run src/ui/commands/restoreCommand.test.ts`
- `npx prettier --check packages/cli/src/ui/commands/restoreCommand.ts packages/cli/src/ui/commands/restoreCommand.test.ts`
- `npm run typecheck --workspace=packages/cli`
- `git diff --check upstream/main..HEAD`
- `npm run build --workspace=packages/core`
- `npm run build --workspace=packages/cli`
- `npm run lint`

更新后的单元测试（`restoreCommand.test.ts`）现在断言新的错误消息，并断言对于缺少 `toolCall` 的情况（`promptId`、`history`、`clientHistory` 三者均存在），`mockRewind`、`mockContext.ui.loadHistory` 和 `mockSetHistory` 都不会被调用。

### 证据（前后对比）

N/A——非可见逻辑修复；已被上述单元测试覆盖。

### 测试平台

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI  |
| 🪟 Windows |  ✅ CI  |
|  🐧 Linux  |  ✅ CI  |

✅ 已测试 · ⚠️ 未测试 · N/A

### 环境（可选）

仅单元测试（npm workspaces）。无特殊环境。

## 风险与范围

- 主要风险或权衡：低；范围限于 `/restore` 命令（`packages/cli/src/ui/commands/restoreCommand.ts`）。行为变化仅限于缺少有效 `toolCall` 的格式错误检查点——它们现在会在任何状态变更之前失败，而不是在之后。有效检查点不受影响。
- 未验证 / 范围之外：无无关重构、无公共 API 变更、无 UI 重新设计。检查点写入路径和有效恢复流程均未改动。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #5357

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
