### PR TITLE
fix(core): expire tokens at buffer boundary

### DIFF
--- a/packages/core/src/mcp/token-storage/base-token-storage.test.ts
+++ b/packages/core/src/mcp/token-storage/base-token-storage.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { BaseTokenStorage } from './base-token-storage.js';
 import type { OAuthCredentials, OAuthToken } from './types.js';
 
@@ -54,6 +54,10 @@ describe('BaseTokenStorage', () => {
 
   beforeEach(() => {
     storage = new TestTokenStorage('qwen-code-mcp-oauth');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   describe('validateCredentials', () => {
@@ -183,6 +187,42 @@ describe('BaseTokenStorage', () => {
       };
 
       expect(storage.isTokenExpired(credentials)).toBe(true);
+    });
+
+    it('should expire tokens exactly at the 5-minute buffer boundary', () => {
+      const now = new Date('2026-01-01T00:00:00.000Z');
+      vi.useFakeTimers();
+      vi.setSystemTime(now);
+
+      const credentials: OAuthCredentials = {
+        serverName: 'test-server',
+        token: {
+          accessToken: 'access-token',
+          tokenType: 'Bearer',
+          expiresAt: now.getTime() + 5 * 60 * 1000,
+        },
+        updatedAt: now.getTime(),
+      };
+
+      expect(storage.isTokenExpired(credentials)).toBe(true);
+    });
+
+    it('should keep tokens valid just outside the 5-minute buffer boundary', () => {
+      const now = new Date('2026-01-01T00:00:00.000Z');
+      vi.useFakeTimers();
+      vi.setSystemTime(now);
+
+      const credentials: OAuthCredentials = {
+        serverName: 'test-server',
+        token: {
+          accessToken: 'access-token',
+          tokenType: 'Bearer',
+          expiresAt: now.getTime() + 5 * 60 * 1000 + 1,
+        },
+        updatedAt: now.getTime(),
+      };
+
+      expect(storage.isTokenExpired(credentials)).toBe(false);
     });
   });
 

--- a/packages/core/src/mcp/token-storage/base-token-storage.ts
+++ b/packages/core/src/mcp/token-storage/base-token-storage.ts
@@ -40,7 +40,7 @@ export abstract class BaseTokenStorage implements TokenStorage {
       return false;
     }
     const bufferMs = 5 * 60 * 1000;
-    return Date.now() > credentials.token.expiresAt - bufferMs;
+    return Date.now() + bufferMs >= credentials.token.expiresAt;
   }
 
   protected sanitizeServerName(serverName: string): string {


### PR DESCRIPTION
Fixes #5359

## Summary

- treat tokens as expired at the exact 5-minute refresh buffer boundary
- align `BaseTokenStorage` with the existing `MCPOAuthTokenStorage` boundary behavior
- add boundary tests for exactly at the buffer and just outside it

## Test Plan

- `npx vitest run src/mcp/token-storage/base-token-storage.test.ts src/mcp/oauth-token-storage.test.ts`
- `npx prettier --check packages/core/src/mcp/token-storage/base-token-storage.ts packages/core/src/mcp/token-storage/base-token-storage.test.ts`
- `npm run typecheck --workspace=packages/core`
- `git diff --check upstream/main..HEAD`
- `npm run build --workspace=packages/core`
- `npm run lint`

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
