### PR TITLE
fix(core): honor ripgrep builtin setting at runtime

### DIFF
--- a/packages/core/src/tools/ripGrep.test.ts
+++ b/packages/core/src/tools/ripGrep.test.ts
@@ -638,6 +638,30 @@ describe('RipGrepTool', () => {
         returnDisplay: 'Error: ripgrep binary not found.',
       });
     });
+
+    it('should pass useBuiltinRipgrep setting to ripgrep execution', async () => {
+      const systemOnlyConfig = {
+        ...mockConfig,
+        getUseBuiltinRipgrep: () => false,
+      } as unknown as Config;
+      const systemOnlyGrepTool = new RipGrepTool(systemOnlyConfig);
+
+      (runRipgrep as Mock).mockResolvedValue({
+        stdout: `fileA.txt${sep}1${sep}hello world${EOL}`,
+        truncated: false,
+        error: undefined,
+      });
+
+      const params: RipGrepToolParams = { pattern: 'hello' };
+      const invocation = systemOnlyGrepTool.build(params);
+      await invocation.execute(abortSignal);
+
+      expect(runRipgrep).toHaveBeenCalledWith(
+        expect.any(Array),
+        abortSignal,
+        false,
+      );
+    });
   });
 
   describe('multi-directory workspace', () => {
@@ -684,6 +708,7 @@ describe('RipGrepTool', () => {
           secondDir,
         ]),
         expect.anything(),
+        true,
       );
 
       await fs.rm(secondDir, { recursive: true, force: true });

--- a/packages/core/src/tools/ripGrep.ts
+++ b/packages/core/src/tools/ripGrep.ts
@@ -446,7 +446,11 @@ class GrepToolInvocation extends BaseToolInvocation<
     // Pass all search paths to ripgrep (it supports multiple paths natively)
     rgArgs.push(...paths);
 
-    const result = await runRipgrep(rgArgs, options.signal);
+    const result = await runRipgrep(
+      rgArgs,
+      options.signal,
+      this.config.getUseBuiltinRipgrep(),
+    );
     if (result.error && !result.stdout) {
       throw result.error;
     }

--- a/packages/core/src/utils/ripgrepUtils.test.ts
+++ b/packages/core/src/utils/ripgrepUtils.test.ts
@@ -4,11 +4,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
-import { getBuiltinRipgrep } from './ripgrepUtils.js';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  _resetRipgrepUtilsCachesForTest,
+  getBuiltinRipgrep,
+  resolveRipgrep,
+} from './ripgrepUtils.js';
+import { fileExists } from './fileUtils.js';
+import { isCommandAvailable } from './shell-utils.js';
 import path from 'node:path';
 
+vi.mock('./fileUtils.js', () => ({
+  fileExists: vi.fn(),
+}));
+
+vi.mock('./shell-utils.js', () => ({
+  execCommand: vi.fn(),
+  isCommandAvailable: vi.fn(),
+}));
+
 describe('ripgrepUtils', () => {
+  beforeEach(() => {
+    _resetRipgrepUtilsCachesForTest();
+    vi.mocked(fileExists).mockReset();
+    vi.mocked(isCommandAvailable).mockReset();
+  });
+
   describe('getBuiltinRipgrep', () => {
     it('should return path with .exe extension on Windows', () => {
       const originalPlatform = process.platform;
@@ -130,6 +151,37 @@ describe('ripgrepUtils', () => {
       // Restore original values
       Object.defineProperty(process, 'platform', { value: originalPlatform });
       Object.defineProperty(process, 'arch', { value: originalArch });
+    });
+  });
+
+  describe('resolveRipgrep', () => {
+    it('keeps builtin and system selections cached separately', async () => {
+      vi.mocked(fileExists).mockResolvedValue(true);
+      vi.mocked(isCommandAvailable).mockReturnValue({
+        available: true,
+        error: undefined,
+      });
+
+      await expect(resolveRipgrep(true)).resolves.toMatchObject({
+        mode: 'builtin',
+      });
+      await expect(resolveRipgrep(false)).resolves.toEqual({
+        mode: 'system',
+        command: 'rg',
+      });
+    });
+
+    it('falls back to system ripgrep when builtin is enabled but unavailable', async () => {
+      vi.mocked(fileExists).mockResolvedValue(false);
+      vi.mocked(isCommandAvailable).mockReturnValue({
+        available: true,
+        error: undefined,
+      });
+
+      await expect(resolveRipgrep(true)).resolves.toEqual({
+        mode: 'system',
+        command: 'rg',
+      });
     });
   });
 });

--- a/packages/core/src/utils/ripgrepUtils.ts
+++ b/packages/core/src/utils/ripgrepUtils.ts
@@ -48,9 +48,15 @@ export interface RipgrepRunResult {
   error?: Error;
 }
 
-let cachedSelection: RipgrepSelection | null = null;
+const cachedSelections = new Map<boolean, RipgrepSelection>();
 let cachedHealth: RipgrepHealth | null = null;
 let macSigningAttempted = false;
+
+export function _resetRipgrepUtilsCachesForTest(): void {
+  cachedSelections.clear();
+  cachedHealth = null;
+  macSigningAttempted = false;
+}
 
 function wslTimeout(): number {
   return process.platform === 'linux' && process.env['WSL_INTEROP']
@@ -145,22 +151,25 @@ export function getBuiltinRipgrep(): string | null {
 export async function resolveRipgrep(
   useBuiltin: boolean = true,
 ): Promise<RipgrepSelection | null> {
+  const cachedSelection = cachedSelections.get(useBuiltin);
   if (cachedSelection) return cachedSelection;
 
   if (useBuiltin) {
     // Try bundled ripgrep first
     const rgPath = getBuiltinRipgrep();
     if (rgPath && (await fileExists(rgPath))) {
-      cachedSelection = { mode: 'builtin', command: rgPath };
-      return cachedSelection;
+      const selection = { mode: 'builtin' as const, command: rgPath };
+      cachedSelections.set(useBuiltin, selection);
+      return selection;
     }
     // Fallback to system rg if bundled binary is not available
   }
 
   const { available, error } = isCommandAvailable(RIPGREP_COMMAND);
   if (available) {
-    cachedSelection = { mode: 'system', command: RIPGREP_COMMAND };
-    return cachedSelection;
+    const selection = { mode: 'system' as const, command: RIPGREP_COMMAND };
+    cachedSelections.set(useBuiltin, selection);
+    return selection;
   }
 
   if (error) {
@@ -252,14 +261,16 @@ export async function canUseRipgrep(
  * Runs ripgrep with the provided arguments
  * @param args The arguments to pass to ripgrep
  * @param signal The signal to abort the ripgrep process
+ * @param useBuiltin Whether to try the bundled ripgrep before falling back to system ripgrep
  * @returns The result of running ripgrep
  * @throws {Error} If an error occurs while running ripgrep.
  */
 export async function runRipgrep(
   args: string[],
   signal?: AbortSignal,
+  useBuiltin: boolean = true,
 ): Promise<RipgrepRunResult> {
-  const selection = await resolveRipgrep();
+  const selection = await resolveRipgrep(useBuiltin);
   if (!selection) {
     throw new Error('ripgrep not found.');
   }


### PR DESCRIPTION
## What this PR does

The `tools.useBuiltinRipgrep` setting was honored at tool-registration time but ignored during actual grep execution. This PR threads the setting through to the execution path so the user's preference is respected when a search runs.

- `GrepToolInvocation` now passes `this.config.getUseBuiltinRipgrep()` into `runRipgrep()`, and `runRipgrep()` forwards that flag to `resolveRipgrep(useBuiltin)` instead of always resolving with the default `useBuiltin=true`.
- The ripgrep resolution cache is partitioned by the `useBuiltin` flag. The single `cachedSelection` is replaced with a `Map<boolean, RipgrepSelection>`, so a previously cached bundled selection can no longer be returned when a caller explicitly requests system-only resolution (and vice versa).
- A test-only `_resetRipgrepUtilsCachesForTest()` helper is added to clear the selection cache, health cache, and the mac-signing flag between tests.
- Adds coverage: the tool forwards the setting to execution (`useBuiltin=false` reaches `runRipgrep`), builtin vs. system selections are cached separately, and an enabled-but-unavailable builtin falls back to system `rg`.

## Why it's needed

Per #5361, when a user sets `tools.useBuiltinRipgrep=false`, the intent is that grep execution resolves only the system `rg`. Registration correctly checked the setting via `canUseRipgrep(this.getUseBuiltinRipgrep())`, but `RipGrepTool` then called `runRipgrep(rgArgs, options.signal)`, and `runRipgrep()` invoked `resolveRipgrep()` with its default `useBuiltin=true` — so the setting was effectively ignored at runtime. Additionally, because the resolution cache was not partitioned by `useBuiltin`, a `resolveRipgrep(false)` call could return a previously cached bundled selection, overriding the user's preference. This change makes execution honor the setting and prevents cached bundled selections from leaking across resolution modes.

## Reviewer Test Plan

### How to verify

Repro of the bug: set `tools.useBuiltinRipgrep=false` and run a grep. Before this change, execution could still resolve the bundled ripgrep (especially after an earlier check populated the shared cache); after this change, execution resolves the system `rg` only, and bundled/system selections never cross-contaminate via the cache.

Verification commands (all from the original body):

- `npx vitest run src/utils/ripgrepUtils.test.ts`
- `npx vitest run src/tools/ripGrep.test.ts`
- `npx prettier --check packages/core/src/utils/ripgrepUtils.ts packages/core/src/utils/ripgrepUtils.test.ts packages/core/src/tools/ripGrep.ts packages/core/src/tools/ripGrep.test.ts`
- `npm run typecheck --workspace=packages/core`
- `git diff --check upstream/main..HEAD`
- `npm run build --workspace=packages/core`
- `npm run lint`

### Evidence (Before & After)

N/A — non-visible logic fix; covered by the unit tests above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI |
| 🪟 Windows |  ✅ CI |
|  🐧 Linux  |  ✅ CI |

✅ tested · ⚠️ not tested · N/A

### Environment (optional)

Unit tests only (npm workspaces, `packages/core`).

## Risk & Scope

- Main risk or tradeoff: Low; scoped to ripgrep resolution/execution in `packages/core`. Behavior change is limited to honoring `tools.useBuiltinRipgrep` at execution time and partitioning the resolution cache by that flag.
- Not validated / out of scope: No unrelated refactors, no public API changes, no UI changes.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5361

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

`tools.useBuiltinRipgrep` 设置过去只在工具注册阶段被遵守，实际执行 grep 时却被忽略。本 PR 把该设置一路传递到执行路径，使搜索真正运行时也能尊重用户的偏好。

- `GrepToolInvocation` 现在把 `this.config.getUseBuiltinRipgrep()` 传入 `runRipgrep()`，并且 `runRipgrep()` 会把该标志转发给 `resolveRipgrep(useBuiltin)`，而不再总是用默认的 `useBuiltin=true` 来解析。
- ripgrep 解析缓存按 `useBuiltin` 标志进行分区。原先单一的 `cachedSelection` 被替换为 `Map<boolean, RipgrepSelection>`，因此当调用方显式请求"仅系统"解析时，不会再返回先前缓存的内置（bundled）选择，反之亦然。
- 新增一个仅供测试使用的 `_resetRipgrepUtilsCachesForTest()` 辅助函数，用于在测试之间清空选择缓存、健康检查缓存以及 mac 签名标志。
- 新增测试覆盖：工具会把设置转发给执行（`useBuiltin=false` 能到达 `runRipgrep`）、内置与系统选择被分别缓存、以及内置已启用但不可用时回退到系统 `rg`。

## 为什么需要

根据 #5361，当用户设置 `tools.useBuiltinRipgrep=false` 时，期望 grep 执行只解析系统 `rg`。注册阶段通过 `canUseRipgrep(this.getUseBuiltinRipgrep())` 正确检查了该设置，但 `RipGrepTool` 随后调用的是 `runRipgrep(rgArgs, options.signal)`，而 `runRipgrep()` 又以默认的 `useBuiltin=true` 调用 `resolveRipgrep()` —— 于是该设置在运行时实际上被忽略了。此外，由于解析缓存没有按 `useBuiltin` 分区，`resolveRipgrep(false)` 可能返回先前缓存的内置选择，从而覆盖用户偏好。本次改动使执行阶段遵守该设置，并防止缓存的内置选择在不同解析模式之间泄漏。

## 评审者测试计划

### 如何验证

复现 bug：设置 `tools.useBuiltinRipgrep=false` 后执行一次 grep。在本次改动之前，执行仍可能解析到内置 ripgrep（尤其是在更早的检查已经填充了共享缓存之后）；改动之后，执行只解析系统 `rg`，并且内置/系统选择不会再通过缓存相互污染。

验证命令（均来自原始正文）：

- `npx vitest run src/utils/ripgrepUtils.test.ts`
- `npx vitest run src/tools/ripGrep.test.ts`
- `npx prettier --check packages/core/src/utils/ripgrepUtils.ts packages/core/src/utils/ripgrepUtils.test.ts packages/core/src/tools/ripGrep.ts packages/core/src/tools/ripGrep.test.ts`
- `npm run typecheck --workspace=packages/core`
- `git diff --check upstream/main..HEAD`
- `npm run build --workspace=packages/core`
- `npm run lint`

### 证据（改动前后对比）

N/A —— 非可见的逻辑修复；已由上述单元测试覆盖。

### 测试平台

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI |
| 🪟 Windows |  ✅ CI |
|  🐧 Linux  |  ✅ CI |

✅ 已测试 · ⚠️ 未测试 · N/A

### 环境（可选）

仅单元测试（npm workspaces，`packages/core`）。

## 风险与范围

- 主要风险或取舍：低；范围限定在 `packages/core` 的 ripgrep 解析/执行。行为改变仅限于在执行时遵守 `tools.useBuiltinRipgrep`，以及按该标志对解析缓存进行分区。
- 未验证 / 范围之外：没有无关的重构，没有公共 API 改动，没有 UI 改动。
- 破坏性改动 / 迁移说明：无。

## 关联 Issue

Fixes #5361

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
