### PR TITLE
fix(core): avoid glob prefix cache reuse

### DIFF
--- a/packages/core/src/utils/filesearch/result-cache.test.ts
+++ b/packages/core/src/utils/filesearch/result-cache.test.ts
@@ -4,8 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { test, expect } from 'vitest';
+import { afterEach, test, expect, vi } from 'vitest';
 import { ResultCache } from './result-cache.js';
+
+afterEach(() => {
+  vi.doUnmock('picomatch');
+  vi.resetModules();
+});
 
 test('ResultCache basic usage', async () => {
   const files = [
@@ -51,5 +56,50 @@ test('ResultCache best base query', async () => {
   // Search for a more specific query that starts with the broader one
   const { files: resultFiles, isExactMatch } = await cache.get('foobar');
   expect(resultFiles).toEqual(['foo.txt', 'foobar.js']);
+  expect(isExactMatch).toBe(false);
+});
+
+test('ResultCache does not use glob prefix matches as base queries', async () => {
+  const files = ['app.js', 'component.jsx'];
+  const cache = new ResultCache(files);
+
+  cache.set('*.js', ['app.js']);
+
+  const { files: resultFiles, isExactMatch } = await cache.get('*.jsx');
+  expect(resultFiles).toEqual(files);
+  expect(isExactMatch).toBe(false);
+});
+
+test('ResultCache does not reuse plain prefix when query becomes glob', async () => {
+  const files = ['foo.txt', 'foobar.js', 'baz.md'];
+  const cache = new ResultCache(files);
+
+  cache.set('foo', ['foo.txt', 'foobar.js']);
+
+  const { files: resultFiles, isExactMatch } = await cache.get('foo*');
+  expect(resultFiles).toEqual(files);
+  expect(isExactMatch).toBe(false);
+});
+
+test('ResultCache does not reuse glob cached key as prefix for plain query', async () => {
+  vi.resetModules();
+  // Isolate the cached-key guard; real glob keys usually make prefix queries
+  // glob queries too, which would be stopped by the query guard first.
+  vi.doMock('picomatch', () => ({
+    default: {
+      scan: (query: string) => ({ isGlob: query === 'foo' }),
+    },
+  }));
+
+  const { ResultCache: ResultCacheWithMockedGlobScan } = await import(
+    './result-cache.js'
+  );
+  const files = ['foo.txt', 'foobar.js', 'baz.md'];
+  const cache = new ResultCacheWithMockedGlobScan(files);
+
+  cache.set('foo', ['foo.txt']);
+
+  const { files: resultFiles, isExactMatch } = await cache.get('foobar');
+  expect(resultFiles).toEqual(files);
   expect(isExactMatch).toBe(false);
 });

--- a/packages/core/src/utils/filesearch/result-cache.ts
+++ b/packages/core/src/utils/filesearch/result-cache.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import picomatch from 'picomatch';
+
 /**
  * Implements an in-memory cache for file search results.
  * This cache optimizes subsequent searches by leveraging previously computed results.
@@ -43,9 +45,15 @@ export class ResultCache {
     // This finds the most specific, already-cached query that is a prefix
     // of the current query.
     let bestBaseQuery = '';
-    for (const key of this.cache?.keys?.() ?? []) {
-      if (query.startsWith(key) && key.length > bestBaseQuery.length) {
-        bestBaseQuery = key;
+    if (!hasGlobSyntax(query)) {
+      for (const key of this.cache?.keys?.() ?? []) {
+        if (
+          !hasGlobSyntax(key) &&
+          query.startsWith(key) &&
+          key.length > bestBaseQuery.length
+        ) {
+          bestBaseQuery = key;
+        }
       }
     }
 
@@ -64,4 +72,8 @@ export class ResultCache {
   set(query: string, results: string[]): void {
     this.cache.set(query, results);
   }
+}
+
+function hasGlobSyntax(query: string): boolean {
+  return picomatch.scan(query).isGlob;
 }


### PR DESCRIPTION
## What this PR does

This PR stops glob-shaped file search queries from reusing prefix cache entries as their search base unless the query is an exact cache hit. Non-glob prefix reuse remains available for ordinary text searches, while glob searches now start from the full file list to preserve order-independent results.

## Why it is needed

The cache lookup logic allowed a previous glob query to become the base for a later glob query when the strings shared a prefix. That makes correctness depend on a narrower cached result set instead of the complete file list. Even though the current matcher semantics make the reported end-to-end miss hard to reproduce, this change preserves the intended invariant and prevents a future matcher change from turning prefix reuse into a real miss.

## Reviewer Test Plan

### How to verify

Run the focused result-cache and file-search tests. The new regression test constructs a narrow cached glob base and verifies that a different glob query does not reuse it. Existing exact-cache behavior and non-glob prefix-cache behavior should continue to pass.

Commands run locally:

```bash
npx vitest run src/utils/filesearch/result-cache.test.ts src/services/fileSearch.test.ts
npm run typecheck --workspace=packages/core
npm run build --workspace=packages/core
npm run lint --workspace=packages/core
npx prettier --check packages/core/src/utils/filesearch/result-cache.ts packages/core/src/utils/filesearch/result-cache.test.ts
git diff --check
```

### Evidence (Before & After)

Before: the new regression test fails when `ResultCache.get("*.jsx")` can reuse a prior `*.js` cache entry as the base.

After: the new regression test passes, and exact glob cache hits still return cached results.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Local Node/npm workspace, focused Vitest and package-level validation commands.

## Risk & Scope

- Main risk or tradeoff: glob cache misses may scan the full file list instead of a smaller prefix result set, but exact glob cache hits still use the cache.
- Not validated / out of scope: no user-visible UI behavior changes.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5363

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 会阻止 glob 形态的文件搜索查询复用前缀缓存结果，除非查询本身是精确缓存命中。普通文本搜索仍然可以使用非 glob 的前缀缓存优化；glob 搜索会从完整文件列表开始过滤，从而保证结果不依赖之前执行过什么搜索。

## Why it is needed

原来的缓存查找逻辑允许前一个 glob 查询在字符串前缀匹配时成为后一个 glob 查询的过滤基础。这样正确性会依赖一个更窄的缓存结果集，而不是完整文件列表。虽然当前 matcher 语义让 issue 里的端到端漏匹配很难直接复现，这个改动仍然守住了预期的不变量，也避免将来 matcher 行为变化后前缀复用变成真实漏匹配。

## Reviewer Test Plan

### How to verify

运行聚焦的 result-cache 和 file-search 测试。新增回归测试会构造一个较窄的 glob 缓存 base，并确认另一个 glob 查询不会复用它。已有的精确缓存命中行为和非 glob 前缀缓存行为应继续通过。

本地运行过的命令：

```bash
npx vitest run src/utils/filesearch/result-cache.test.ts src/services/fileSearch.test.ts
npm run typecheck --workspace=packages/core
npm run build --workspace=packages/core
npm run lint --workspace=packages/core
npx prettier --check packages/core/src/utils/filesearch/result-cache.ts packages/core/src/utils/filesearch/result-cache.test.ts
git diff --check
```

### Evidence (Before & After)

Before：当 `ResultCache.get("*.jsx")` 可以复用之前的 `*.js` 缓存作为 base 时，新增回归测试会失败。

After：新增回归测试通过，精确 glob 缓存命中仍然返回缓存结果。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

本地 Node/npm workspace，运行了聚焦 Vitest 和包级验证命令。

## Risk & Scope

- Main risk or tradeoff：glob 缓存未命中时可能会扫描完整文件列表，而不是较小的前缀结果集；但精确 glob 缓存命中仍然使用缓存。
- Not validated / out of scope：没有用户可见 UI 行为变化。
- Breaking changes / migration notes：无。

## Linked Issues

Fixes #5363

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.