### PR TITLE
fix(core): create token file on first save

### DIFF
--- a/packages/core/src/mcp/token-storage/file-token-storage.test.ts
+++ b/packages/core/src/mcp/token-storage/file-token-storage.test.ts
@@ -120,6 +120,39 @@ describe('FileTokenStorage', () => {
   });
 
   describe('setCredentials', () => {
+    it('should create token file when saving credentials for the first time', async () => {
+      mockFs.readFile.mockRejectedValue({ code: 'ENOENT' });
+      mockFs.mkdir.mockResolvedValue(undefined);
+      vi.mocked(atomicWriteFile).mockResolvedValue(undefined);
+
+      const credentials: OAuthCredentials = {
+        serverName: 'test-server',
+        token: {
+          accessToken: 'access-token',
+          tokenType: 'Bearer',
+        },
+        updatedAt: Date.now() - 10000,
+      };
+
+      await storage.setCredentials(credentials);
+
+      expect(mockFs.mkdir).toHaveBeenCalledWith(
+        path.join('/home/test', '.qwen'),
+        { recursive: true, mode: 0o700 },
+      );
+      expect(atomicWriteFile).toHaveBeenCalled();
+
+      const writeCall = vi.mocked(atomicWriteFile).mock.calls[0];
+      const decrypted = storage['decrypt'](writeCall[1] as string);
+      const saved = JSON.parse(decrypted);
+
+      expect(Object.keys(saved)).toEqual(['test-server']);
+      expect(saved['test-server']).toEqual({
+        ...credentials,
+        updatedAt: expect.any(Number),
+      });
+    });
+
     it('should save credentials with encryption', async () => {
       const encryptedData = storage['encrypt'](
         JSON.stringify({ 'existing-server': existingCredentials }),

--- a/packages/core/src/mcp/token-storage/file-token-storage.ts
+++ b/packages/core/src/mcp/token-storage/file-token-storage.ts
@@ -69,7 +69,9 @@ export class FileTokenStorage extends BaseTokenStorage {
     await fs.mkdir(dir, { recursive: true, mode: 0o700 });
   }
 
-  private async loadTokens(): Promise<Map<string, OAuthCredentials>> {
+  private async loadTokens(
+    allowMissing = false,
+  ): Promise<Map<string, OAuthCredentials>> {
     try {
       const data = await fs.readFile(this.tokenFilePath, 'utf-8');
       const decrypted = this.decrypt(data);
@@ -78,6 +80,9 @@ export class FileTokenStorage extends BaseTokenStorage {
     } catch (error: unknown) {
       const err = error as NodeJS.ErrnoException & { message?: string };
       if (err.code === 'ENOENT') {
+        if (allowMissing) {
+          return new Map();
+        }
         throw new Error('Token file does not exist');
       }
       if (
@@ -126,7 +131,7 @@ export class FileTokenStorage extends BaseTokenStorage {
   async setCredentials(credentials: OAuthCredentials): Promise<void> {
     this.validateCredentials(credentials);
 
-    const tokens = await this.loadTokens();
+    const tokens = await this.loadTokens(true);
     const updatedCredentials: OAuthCredentials = {
       ...credentials,
       updatedAt: Date.now(),


### PR DESCRIPTION
## What this PR does

Lets the encrypted file token storage create its token file on the first save instead of failing. `FileTokenStorage.loadTokens()` gains an `allowMissing` flag (default `false`): when set, a missing token file (`ENOENT`) resolves to an empty token map instead of throwing `Token file does not exist`. `setCredentials()` now loads with `allowMissing = true`, so the first credential save starts from an empty map and writes a new token file. The read, delete, and list paths keep calling `loadTokens()` without the flag, so their existing missing-file behavior is unchanged.

## Why it's needed

`FileTokenStorage.setCredentials()` could not create the token file on first save. It called `loadTokens()`, which threw `Token file does not exist` on `ENOENT`, so the very first `setCredentials()` call failed instead of creating `mcp-oauth-tokens-v2.json`. This broke the encrypted file token storage path, including cases where file storage is forced or keychain storage is unavailable. After this change, the first `setCredentials()` call starts from an empty token map and writes a new token file, while read/delete paths keep their current missing-file behavior.

## Reviewer Test Plan

### How to verify

Repro: with no existing token file, the first `FileTokenStorage.setCredentials(...)` call previously threw `Token file does not exist`. Expected after the fix: the call succeeds, creates the `.qwen` directory (mode `0o700`), and atomically writes the token file containing exactly the saved server entry. The added unit test mocks `readFile` to reject with `ENOENT` and asserts that `mkdir` and `atomicWriteFile` are called and that the decrypted payload contains only the new server's credentials.

Verification commands from the author:

- `npx vitest run src/mcp/token-storage/file-token-storage.test.ts src/mcp/token-storage/base-token-storage.test.ts src/mcp/token-storage/hybrid-token-storage.test.ts`
- `npx prettier --check packages/core/src/mcp/token-storage/file-token-storage.ts packages/core/src/mcp/token-storage/file-token-storage.test.ts`
- `npm run typecheck --workspace=packages/core`
- `git diff --check upstream/main..HEAD`
- `npm run build --workspace=packages/core`
- `npm run lint`

### Evidence (Before & After)

N/A — non-visible logic fix; covered by the unit test above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI  |
| 🪟 Windows |  ✅ CI  |
|  🐧 Linux  |  ✅ CI  |

✅ tested · ⚠️ not tested · N/A

### Environment (optional)

Unit tests only (npm workspaces, `packages/core`).

## Risk & Scope

- Main risk or tradeoff: Low; scoped to `packages/core/src/mcp/token-storage/file-token-storage.ts`. The behavior change is limited to the `setCredentials()` first-save path treating a missing token file as an empty map.
- Not validated / out of scope: No unrelated refactors, no public API changes, no UI changes. Read/delete/list missing-file behavior is intentionally left untouched.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5365

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让加密的文件 token 存储在首次保存时能够创建 token 文件，而不是失败。`FileTokenStorage.loadTokens()` 新增了一个 `allowMissing` 参数（默认为 `false`）：当该参数为 `true` 时，token 文件缺失（`ENOENT`）会返回一个空的 token map，而不是抛出 `Token file does not exist`。`setCredentials()` 现在以 `allowMissing = true` 来加载，因此首次保存凭据时会从空 map 开始并写入一个新的 token 文件。读取、删除和列举路径仍然不带该参数调用 `loadTokens()`，因此它们对缺失文件的既有行为保持不变。

## 为什么需要它

`FileTokenStorage.setCredentials()` 在首次保存时无法创建 token 文件。它调用了 `loadTokens()`，而后者在 `ENOENT` 时抛出 `Token file does not exist`，导致第一次调用 `setCredentials()` 就失败，而不是创建 `mcp-oauth-tokens-v2.json`。这破坏了加密文件 token 存储路径，包括强制使用文件存储或 keychain 存储不可用的场景。修复之后，首次 `setCredentials()` 调用会从空 token map 开始并写入一个新的 token 文件，同时读取/删除路径保持其当前的缺失文件行为。

## 审阅者测试计划

### 如何验证

复现：在没有现有 token 文件的情况下，首次调用 `FileTokenStorage.setCredentials(...)` 之前会抛出 `Token file does not exist`。修复后的预期：该调用成功，创建 `.qwen` 目录（权限 `0o700`），并原子地写入仅包含所保存服务器条目的 token 文件。新增的单元测试将 `readFile` mock 为以 `ENOENT` 拒绝，并断言 `mkdir` 与 `atomicWriteFile` 被调用，且解密后的内容仅包含新服务器的凭据。

来自作者的验证命令：

- `npx vitest run src/mcp/token-storage/file-token-storage.test.ts src/mcp/token-storage/base-token-storage.test.ts src/mcp/token-storage/hybrid-token-storage.test.ts`
- `npx prettier --check packages/core/src/mcp/token-storage/file-token-storage.ts packages/core/src/mcp/token-storage/file-token-storage.test.ts`
- `npm run typecheck --workspace=packages/core`
- `git diff --check upstream/main..HEAD`
- `npm run build --workspace=packages/core`
- `npm run lint`

### 证据（前后对比）

N/A —— 非可见的逻辑修复；已由上述单元测试覆盖。

### 测试平台

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |  ✅ CI  |
| 🪟 Windows |  ✅ CI  |
|  🐧 Linux  |  ✅ CI  |

✅ 已测试 · ⚠️ 未测试 · N/A

### 环境（可选）

仅单元测试（npm workspaces，`packages/core`）。

## 风险与范围

- 主要风险或权衡：低；范围限于 `packages/core/src/mcp/token-storage/file-token-storage.ts`。行为变化仅限于 `setCredentials()` 首次保存路径将缺失的 token 文件视为空 map。
- 未验证 / 范围之外：没有无关的重构，没有公共 API 变更，没有 UI 变更。读取/删除/列举的缺失文件行为有意保持不变。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #5365

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
