### PR TITLE
fix(cli): preserve workspace trust state for extensions

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -6528,7 +6528,8 @@ class QwenAgent implements Agent {
         const settings = loadSettings(cwd);
         const extensionManager = new ExtensionManager({
           workspaceDir: cwd,
-          isWorkspaceTrusted: !!isWorkspaceTrusted(settings.merged),
+          isWorkspaceTrusted:
+            isWorkspaceTrusted(settings.merged).isTrusted ?? true,
           locale: getCurrentLanguage(),
         });
         await extensionManager.refreshCache();

--- a/packages/cli/src/commands/extensions/install.ts
+++ b/packages/cli/src/commands/extensions/install.ts
@@ -71,9 +71,8 @@ export async function handleInstall(args: InstallArgs) {
     const extensionManager = new ExtensionManager({
       workspaceDir,
       locale: getCurrentLanguage(),
-      isWorkspaceTrusted: !!isWorkspaceTrusted(
-        loadSettings(workspaceDir).merged,
-      ),
+      isWorkspaceTrusted:
+        isWorkspaceTrusted(loadSettings(workspaceDir).merged).isTrusted ?? true,
       requestConsent,
       requestChoicePlugin: requestChoicePluginNonInteractive,
     });

--- a/packages/cli/src/commands/extensions/uninstall.ts
+++ b/packages/cli/src/commands/extensions/uninstall.ts
@@ -30,9 +30,8 @@ export async function handleUninstall(args: UninstallArgs) {
         null,
         requestConsentNonInteractive,
       ),
-      isWorkspaceTrusted: !!isWorkspaceTrusted(
-        loadSettings(workspaceDir).merged,
-      ),
+      isWorkspaceTrusted:
+        isWorkspaceTrusted(loadSettings(workspaceDir).merged).isTrusted ?? true,
     });
     await extensionManager.refreshCache();
     await extensionManager.uninstallExtension(args.name, false);

--- a/packages/cli/src/commands/extensions/utils.ts
+++ b/packages/cli/src/commands/extensions/utils.ts
@@ -33,7 +33,8 @@ export async function getExtensionManager(): Promise<ExtensionManager> {
       requestConsentNonInteractive,
     ),
     requestChoicePlugin: requestChoicePluginNonInteractive,
-    isWorkspaceTrusted: !!isWorkspaceTrusted(loadSettings(workspaceDir).merged),
+    isWorkspaceTrusted:
+      isWorkspaceTrusted(loadSettings(workspaceDir).merged).isTrusted ?? true,
   });
   await extensionManager.refreshCache();
   return extensionManager;

--- a/packages/cli/src/commands/mcp/list.test.ts
+++ b/packages/cli/src/commands/mcp/list.test.ts
@@ -95,7 +95,10 @@ describe('mcp list command', () => {
     MockedClient.mockImplementation(() => mockClient);
     mockedCreateTransport.mockResolvedValue(mockTransport);
     MockedExtensionManager.mockImplementation(() => mockExtensionManager);
-    mockedIsWorkspaceTrusted.mockReturnValue(true);
+    mockedIsWorkspaceTrusted.mockReturnValue({
+      isTrusted: true,
+      source: 'file',
+    });
     mockedAssembleMcpServers.mockImplementation((servers) => servers ?? {});
     mockedLoadMcpApprovals.mockReturnValue({
       getState: vi.fn(() => 'approved'),
@@ -109,6 +112,22 @@ describe('mcp list command', () => {
 
     expect(mockWriteStdoutLine).toHaveBeenCalledWith(
       'No MCP servers configured.',
+    );
+  });
+
+  it('passes explicit untrusted workspace state to the extension manager', async () => {
+    mockedLoadSettings.mockReturnValue({ merged: { mcpServers: {} } });
+    mockedIsWorkspaceTrusted.mockReturnValue({
+      isTrusted: false,
+      source: 'file',
+    });
+
+    await listMcpServers();
+
+    expect(MockedExtensionManager).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isWorkspaceTrusted: false,
+      }),
     );
   });
 

--- a/packages/cli/src/commands/mcp/list.ts
+++ b/packages/cli/src/commands/mcp/list.ts
@@ -31,7 +31,7 @@ async function getMcpServersFromConfig(): Promise<
 > {
   const settings = loadSettings();
   const extensionManager = new ExtensionManager({
-    isWorkspaceTrusted: !!isWorkspaceTrusted(settings.merged),
+    isWorkspaceTrusted: isWorkspaceTrusted(settings.merged).isTrusted ?? true,
     telemetrySettings: settings.merged.telemetry,
     locale: getCurrentLanguage(),
   });

--- a/packages/cli/src/commands/mcp/reconnect.test.ts
+++ b/packages/cli/src/commands/mcp/reconnect.test.ts
@@ -8,6 +8,7 @@ import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { reconnectCommand } from './reconnect.js';
 import { loadSettings } from '../../config/settings.js';
 import { assembleMcpServers } from '../../config/mcpServers.js';
+import { isWorkspaceTrusted } from '../../config/trustedFolders.js';
 import { Config, ExtensionManager } from '@qwen-code/qwen-code-core';
 
 const mockWriteStdoutLine = vi.hoisted(() => vi.fn());
@@ -15,6 +16,7 @@ const mockWriteStderrLine = vi.hoisted(() => vi.fn());
 const mockProcessExit = vi.hoisted(() => vi.fn());
 const mockGetPendingGatedMcpServers = vi.hoisted(() => vi.fn());
 const mockAssembleMcpServers = vi.hoisted(() => vi.fn());
+const mockIsWorkspaceTrusted = vi.hoisted(() => vi.fn());
 
 vi.mock('../../utils/stdioHelpers.js', () => ({
   writeStdoutLine: mockWriteStdoutLine,
@@ -30,7 +32,7 @@ vi.mock('../../config/mcpServers.js', () => ({
 }));
 
 vi.mock('../../config/trustedFolders.js', () => ({
-  isWorkspaceTrusted: vi.fn().mockReturnValue(true),
+  isWorkspaceTrusted: mockIsWorkspaceTrusted,
 }));
 
 vi.mock('../../config/mcpApprovals.js', () => ({
@@ -46,6 +48,7 @@ vi.mock('@qwen-code/qwen-code-core', () => ({
 
 const mockedLoadSettings = loadSettings as vi.Mock;
 const mockedAssembleMcpServers = assembleMcpServers as vi.Mock;
+const mockedIsWorkspaceTrusted = isWorkspaceTrusted as vi.Mock;
 const MockedConfig = Config as vi.Mock;
 const MockedExtensionManager = ExtensionManager as vi.Mock;
 
@@ -87,6 +90,10 @@ describe('mcp reconnect command', () => {
     MockedExtensionManager.mockImplementation(() => mockExtensionManager);
     mockGetPendingGatedMcpServers.mockReturnValue([]);
     mockedAssembleMcpServers.mockImplementation((servers) => servers ?? {});
+    mockedIsWorkspaceTrusted.mockReturnValue({
+      isTrusted: true,
+      source: 'file',
+    });
 
     Object.defineProperty(process, 'exit', {
       value: mockProcessExit,
@@ -147,6 +154,31 @@ describe('mcp reconnect command', () => {
       );
       expect(mockToolRegistry.discoverToolsForServer).toHaveBeenCalledWith(
         'approved',
+      );
+    });
+
+    it('passes explicit untrusted workspace state to the extension manager', async () => {
+      mockedLoadSettings.mockReturnValue({
+        merged: {
+          mcpServers: {
+            'test-server': { command: '/path/to/server' },
+          },
+        },
+      });
+      mockedIsWorkspaceTrusted.mockReturnValue({
+        isTrusted: false,
+        source: 'file',
+      });
+
+      const handler = reconnectCommand.handler as (
+        argv: Record<string, unknown>,
+      ) => Promise<void>;
+      await handler({ 'server-name': 'test-server', all: false });
+
+      expect(MockedExtensionManager).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isWorkspaceTrusted: false,
+        }),
       );
     });
 

--- a/packages/cli/src/commands/mcp/reconnect.ts
+++ b/packages/cli/src/commands/mcp/reconnect.ts
@@ -25,7 +25,7 @@ async function getMcpServersFromConfig(
   const extManager =
     extensionManager ??
     new ExtensionManager({
-      isWorkspaceTrusted: !!isWorkspaceTrusted(settings.merged),
+      isWorkspaceTrusted: isWorkspaceTrusted(settings.merged).isTrusted ?? true,
       telemetrySettings: settings.merged.telemetry,
       locale: getCurrentLanguage(),
     });
@@ -119,7 +119,7 @@ async function reconnectMcpServer(serverName: string): Promise<void> {
 async function reconnectAllMcpServers(): Promise<void> {
   const settings = loadSettings();
   const extensionManager = new ExtensionManager({
-    isWorkspaceTrusted: !!isWorkspaceTrusted(settings.merged),
+    isWorkspaceTrusted: isWorkspaceTrusted(settings.merged).isTrusted ?? true,
     telemetrySettings: settings.merged.telemetry,
     locale: getCurrentLanguage(),
   });


### PR DESCRIPTION
## What this PR does

Replaces the `!!isWorkspaceTrusted(...)` boolean coercion with `isWorkspaceTrusted(...).isTrusted ?? true` at every CLI site that constructs an `ExtensionManager`, so an explicitly untrusted workspace is passed through as untrusted instead of always-trusted. All seven affected call sites are converted — `acp-integration/acpAgent.ts`, the three `extensions/` command helpers (`install.ts`, `uninstall.ts`, `utils.ts`), `mcp/list.ts`, and both sites in `mcp/reconnect.ts` — and the unknown-trust case still defaults to trusted via `?? true`. Adds regression tests to the MCP `list` and `reconnect` suites asserting that an explicitly untrusted workspace reaches `ExtensionManager` as `isWorkspaceTrusted: false`.

## Why it's needed

`isWorkspaceTrusted()` returns a `TrustResult` object (`{ isTrusted: boolean | undefined, source }`), not a boolean. The old `!!isWorkspaceTrusted(...)` coerced that object — which is always truthy — to `true`, so every workspace was treated as trusted regardless of its real trust state. In an explicitly untrusted workspace this silently bypassed the untrusted-folder gate in `ExtensionManager`, letting `qwen mcp list`, `qwen mcp reconnect`, and the `extensions` install/uninstall paths initialize extension/MCP loading as if trusted. `.isTrusted ?? true` reads the real value while preserving the established `undefined ⇒ trusted` default (the same convention used by the folder-trust checks elsewhere in the codebase). This is a security-relevant fix: it restores the untrusted-workspace gate these commands were meant to honor.

| `TrustResult` returned | OLD `!!x` | NEW `x.isTrusted ?? true` |
| --- | --- | --- |
| `{ isTrusted: false }` | `true` ❌ | `false` ✅ |
| `{ isTrusted: true }` | `true` | `true` |
| `{ isTrusted: undefined }` (unknown) | `true` | `true` (default-trusted) |

## Reviewer Test Plan

### How to verify

Unit regression coverage — from `packages/cli`:

```
npx vitest run src/commands/mcp/list.test.ts src/commands/mcp/reconnect.test.ts
```

The new cases mock `isWorkspaceTrusted()` to return `{ isTrusted: false, source: 'file' }` and assert `ExtensionManager` is constructed with `isWorkspaceTrusted: false` (previously it received `true`).

Behavioral — in a workspace with folder trust enabled and the folder explicitly marked untrusted, run `qwen mcp list` / `qwen mcp reconnect` / `qwen extensions install …`. Before: the command initializes extension/MCP loading as trusted (gate bypassed). After: the untrusted state is honored.

A maintainer verified this on a **real `qwen` binary built from the PR head** via a tmux A/B of `qwen extensions install` inside an untrusted workspace (`folderTrust` enabled + folder marked `DO_NOT_TRUST`) against a pre-fix build: https://github.com/QwenLM/qwen-code/pull/5369#issuecomment-4747236297

### Evidence (Before & After)

Before — an untrusted workspace is coerced to trusted (`!!{ isTrusted: false } === true`) and the untrusted-folder gate is bypassed. After — `{ isTrusted: false }` is passed through as `false` and the gate engages. See the truth table above and the maintainer real-binary A/B linked above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

The boolean-coercion fix is platform-agnostic; CI exercises macOS, Windows, and Linux.

### Environment (optional)

Vitest unit suites (`packages/cli`) + a real-binary `qwen` tmux run for the behavioral check. No special runtime required.

## Risk & Scope

- Main risk or tradeoff: Low, and security-positive — it stops treating explicitly untrusted workspaces as trusted. The only behavioral change is at these `ExtensionManager` construction sites; the unknown-trust default (`?? true`) is unchanged, so trusted and unknown-trust workspaces behave exactly as before.
- Not validated / out of scope: No change to the trust-evaluation logic itself or to `ExtensionManager`'s downstream gating — only the value passed in is corrected. Windows/Linux not exercised locally (platform-agnostic logic).
- Breaking changes / migration notes: None. Behavior changes only for workspaces that are explicitly untrusted, which were previously mishandled.

## Linked Issues

Fixes #5368.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在每一个构造 `ExtensionManager` 的 CLI 调用点,把 `!!isWorkspaceTrusted(...)` 的布尔强制转换换成 `isWorkspaceTrusted(...).isTrusted ?? true`,这样一个被明确标记为「不信任」的工作区会被如实地按「不信任」传入,而不是一律变成「信任」。受影响的七个调用点全部完成转换 —— `acp-integration/acpAgent.ts`、三个 `extensions/` 命令辅助文件(`install.ts`、`uninstall.ts`、`utils.ts`)、`mcp/list.ts`,以及 `mcp/reconnect.ts` 中的两处;信任状态未知时仍通过 `?? true` 默认为「信任」。同时在 MCP `list` 与 `reconnect` 测试套件中新增回归测试,断言一个明确不信任的工作区会以 `isWorkspaceTrusted: false` 传到 `ExtensionManager`。

## 为什么需要它

`isWorkspaceTrusted()` 返回的是一个 `TrustResult` 对象(`{ isTrusted: boolean | undefined, source }`),而不是布尔值。旧的 `!!isWorkspaceTrusted(...)` 把这个**永远为真**的对象强制转换成了 `true`,于是无论真实信任状态如何,每个工作区都被当成「信任」。在一个明确不信任的工作区里,这会静默绕过 `ExtensionManager` 的「不信任文件夹」闸门,使 `qwen mcp list`、`qwen mcp reconnect` 以及 `extensions` 的 install/uninstall 路径像在受信任环境中一样初始化扩展/MCP 加载。`.isTrusted ?? true` 读取的是真实值,同时保留了既有的「未知 ⇒ 信任」默认约定(与代码库其他地方的文件夹信任检查一致)。这是一个与安全相关的修复:它恢复了这些命令本应遵守的「不信任工作区」闸门。

| 返回的 `TrustResult` | 旧 `!!x` | 新 `x.isTrusted ?? true` |
| --- | --- | --- |
| `{ isTrusted: false }` | `true` ❌ | `false` ✅ |
| `{ isTrusted: true }` | `true` | `true` |
| `{ isTrusted: undefined }`(未知) | `true` | `true`(默认信任) |

## 评审者测试计划

### 如何验证

单元回归覆盖 —— 在 `packages/cli` 目录下:

```
npx vitest run src/commands/mcp/list.test.ts src/commands/mcp/reconnect.test.ts
```

新增用例把 `isWorkspaceTrusted()` mock 成返回 `{ isTrusted: false, source: 'file' }`,并断言 `ExtensionManager` 是以 `isWorkspaceTrusted: false` 构造的(此前它收到的是 `true`)。

行为层面 —— 在一个开启了文件夹信任、且该文件夹被明确标记为不信任的工作区里,运行 `qwen mcp list` / `qwen mcp reconnect` / `qwen extensions install …`。修复前:命令会以「信任」初始化扩展/MCP 加载(闸门被绕过)。修复后:不信任状态被正确尊重。

维护者已在**从 PR head 构建出的真实 `qwen` 二进制**上验证过 —— 在一个不信任工作区(`folderTrust` 开启 + 文件夹标记为 `DO_NOT_TRUST`)里对 `qwen extensions install` 做了 tmux A/B,与修复前的构建对比:https://github.com/QwenLM/qwen-code/pull/5369#issuecomment-4747236297

### 证据(前后对比)

修复前 —— 不信任工作区被强制转换成信任(`!!{ isTrusted: false } === true`),不信任文件夹闸门被绕过。修复后 —— `{ isTrusted: false }` 被如实地按 `false` 传入,闸门生效。详见上方真值表与上方链接的维护者真实二进制 A/B。

### 测试平台

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

该布尔强制转换修复与平台无关;CI 会覆盖 macOS、Windows、Linux。

### 环境(可选)

Vitest 单元测试套件(`packages/cli`)+ 一次真实二进制 `qwen` 的 tmux 运行用于行为验证。无需特殊运行环境。

## 风险与范围

- 主要风险或取舍:低,且对安全有正面意义 —— 它不再把明确不信任的工作区当成信任。唯一的行为变化发生在这些 `ExtensionManager` 构造点;未知信任的默认值(`?? true`)保持不变,因此信任与未知信任的工作区行为与之前完全一致。
- 未验证 / 范围之外:不改动信任评估逻辑本身,也不改动 `ExtensionManager` 下游的闸门 —— 只是修正了传入的值。Windows/Linux 未在本地实测(逻辑与平台无关)。
- 破坏性变更 / 迁移说明:无。只有此前被错误处理的「明确不信任」工作区的行为会发生变化。

## 关联 Issue

Fixes #5368。

</details>
