### PR TITLE
fix(core): parse grep results with colon paths

### DIFF
--- a/packages/core/src/tools/grep.test.ts
+++ b/packages/core/src/tools/grep.test.ts
@@ -252,13 +252,317 @@ describe('GrepTool', () => {
       const filePath = path.join(tempRootDir, 'crlf.txt');
 
       const matches = invocationForPrivateMethod.parseGrepOutput(
-        `crlf.txt:1:hello world\r${os.EOL}`,
+        'crlf.txt:1:hello world\r\n',
         tempRootDir,
       );
 
       expect(matches[0]).toMatchObject({
         absoluteFilePath: filePath,
         line: 'hello world',
+      });
+    });
+
+    it('parses plain grep output for paths containing colons', () => {
+      const invocationForPrivateMethod = grepTool.build({
+        pattern: 'world',
+      }) as unknown as {
+        parseGrepOutput: (
+          output: string,
+          basePath: string,
+        ) => Array<{
+          absoluteFilePath: string;
+          filePath: string;
+          line: string;
+          lineNumber: number;
+        }>;
+      };
+      const filePath = path.join('dir:name', 'file.txt');
+
+      const matches = invocationForPrivateMethod.parseGrepOutput(
+        `${filePath}:1:hello: world\n`,
+        tempRootDir,
+      );
+
+      expect(matches[0]).toMatchObject({
+        absoluteFilePath: path.join(tempRootDir, filePath),
+        filePath,
+        line: 'hello: world',
+        lineNumber: 1,
+      });
+    });
+
+    it('parses git grep -z output for paths containing colons', () => {
+      const invocationForPrivateMethod = grepTool.build({
+        pattern: 'world',
+      }) as unknown as {
+        parseGrepOutput: (
+          output: string,
+          basePath: string,
+        ) => Array<{
+          absoluteFilePath: string;
+          filePath: string;
+          line: string;
+          lineNumber: number;
+        }>;
+      };
+      const filePath = path.join('notes', '2026-06-19T09:20:00.txt');
+
+      const matches = invocationForPrivateMethod.parseGrepOutput(
+        `${filePath}\0${12}\0hello: world\n`,
+        tempRootDir,
+      );
+
+      expect(matches[0]).toMatchObject({
+        absoluteFilePath: path.join(tempRootDir, filePath),
+        filePath,
+        line: 'hello: world',
+        lineNumber: 12,
+      });
+    });
+
+    it('parses multiple git grep -z matches', () => {
+      const invocationForPrivateMethod = grepTool.build({
+        pattern: 'world',
+      }) as unknown as {
+        parseGrepOutput: (
+          output: string,
+          basePath: string,
+        ) => Array<{
+          absoluteFilePath: string;
+          filePath: string;
+          line: string;
+          lineNumber: number;
+        }>;
+      };
+
+      const matches = invocationForPrivateMethod.parseGrepOutput(
+        `first.txt\0${1}\0hello world\nsecond.txt\0${2}\0world again\n`,
+        tempRootDir,
+      );
+
+      expect(matches).toHaveLength(2);
+      expect(matches[0]).toMatchObject({
+        absoluteFilePath: path.join(tempRootDir, 'first.txt'),
+        filePath: 'first.txt',
+        line: 'hello world',
+        lineNumber: 1,
+      });
+      expect(matches[1]).toMatchObject({
+        absoluteFilePath: path.join(tempRootDir, 'second.txt'),
+        filePath: 'second.txt',
+        line: 'world again',
+        lineNumber: 2,
+      });
+    });
+
+    it('parses git grep -z output without a trailing newline', () => {
+      const invocationForPrivateMethod = grepTool.build({
+        pattern: 'world',
+      }) as unknown as {
+        parseGrepOutput: (
+          output: string,
+          basePath: string,
+        ) => Array<{
+          absoluteFilePath: string;
+          filePath: string;
+          line: string;
+          lineNumber: number;
+        }>;
+      };
+
+      const matches = invocationForPrivateMethod.parseGrepOutput(
+        `tail.txt\0${3}\0world at eof`,
+        tempRootDir,
+      );
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]).toMatchObject({
+        absoluteFilePath: path.join(tempRootDir, 'tail.txt'),
+        filePath: 'tail.txt',
+        line: 'world at eof',
+        lineNumber: 3,
+      });
+    });
+
+    it('skips unframed binary notices in git grep -z output', () => {
+      const invocationForPrivateMethod = grepTool.build({
+        pattern: 'world',
+      }) as unknown as {
+        parseGrepOutput: (
+          output: string,
+          basePath: string,
+        ) => Array<{
+          absoluteFilePath: string;
+          filePath: string;
+          line: string;
+          lineNumber: number;
+        }>;
+      };
+      const filePath = 'normal.txt';
+
+      const matches = invocationForPrivateMethod.parseGrepOutput(
+        `Binary file binary.bin matches\n${filePath}\0${7}\0hello world\n`,
+        tempRootDir,
+      );
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]).toMatchObject({
+        absoluteFilePath: path.join(tempRootDir, filePath),
+        filePath,
+        line: 'hello world',
+        lineNumber: 7,
+      });
+    });
+
+    it('parses system grep --null output for paths containing colons', () => {
+      const invocationForPrivateMethod = grepTool.build({
+        pattern: 'world',
+      }) as unknown as {
+        parseGrepOutput: (
+          output: string,
+          basePath: string,
+        ) => Array<{
+          absoluteFilePath: string;
+          filePath: string;
+          line: string;
+          lineNumber: number;
+        }>;
+      };
+      const filePath = path.join('dir:123:file.txt');
+
+      const matches = invocationForPrivateMethod.parseGrepOutput(
+        `${filePath}\0${12}:hello: world\n`,
+        tempRootDir,
+      );
+
+      expect(matches[0]).toMatchObject({
+        absoluteFilePath: path.join(tempRootDir, filePath),
+        filePath,
+        line: 'hello: world',
+        lineNumber: 12,
+      });
+    });
+
+    it('parses multiple system grep --null matches', () => {
+      const invocationForPrivateMethod = grepTool.build({
+        pattern: 'world',
+      }) as unknown as {
+        parseGrepOutput: (
+          output: string,
+          basePath: string,
+        ) => Array<{
+          absoluteFilePath: string;
+          filePath: string;
+          line: string;
+          lineNumber: number;
+        }>;
+      };
+
+      const matches = invocationForPrivateMethod.parseGrepOutput(
+        `first.txt\0${1}:hello world\nsecond.txt\0${2}:world again\n`,
+        tempRootDir,
+      );
+
+      expect(matches).toHaveLength(2);
+      expect(matches[0]).toMatchObject({
+        absoluteFilePath: path.join(tempRootDir, 'first.txt'),
+        filePath: 'first.txt',
+        line: 'hello world',
+        lineNumber: 1,
+      });
+      expect(matches[1]).toMatchObject({
+        absoluteFilePath: path.join(tempRootDir, 'second.txt'),
+        filePath: 'second.txt',
+        line: 'world again',
+        lineNumber: 2,
+      });
+    });
+
+    it('parses system grep --null output without a trailing newline', () => {
+      const invocationForPrivateMethod = grepTool.build({
+        pattern: 'world',
+      }) as unknown as {
+        parseGrepOutput: (
+          output: string,
+          basePath: string,
+        ) => Array<{
+          absoluteFilePath: string;
+          filePath: string;
+          line: string;
+          lineNumber: number;
+        }>;
+      };
+
+      const matches = invocationForPrivateMethod.parseGrepOutput(
+        `tail.txt\0${3}:world at eof`,
+        tempRootDir,
+      );
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]).toMatchObject({
+        absoluteFilePath: path.join(tempRootDir, 'tail.txt'),
+        filePath: 'tail.txt',
+        line: 'world at eof',
+        lineNumber: 3,
+      });
+    });
+
+    it('skips malformed system grep --null records and keeps following matches', () => {
+      const invocationForPrivateMethod = grepTool.build({
+        pattern: 'world',
+      }) as unknown as {
+        parseGrepOutput: (
+          output: string,
+          basePath: string,
+        ) => Array<{
+          absoluteFilePath: string;
+          filePath: string;
+          line: string;
+          lineNumber: number;
+        }>;
+      };
+
+      const matches = invocationForPrivateMethod.parseGrepOutput(
+        `broken.txt\0missing-separator\nvalid.txt\0${4}:world after malformed\n`,
+        tempRootDir,
+      );
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]).toMatchObject({
+        absoluteFilePath: path.join(tempRootDir, 'valid.txt'),
+        filePath: 'valid.txt',
+        line: 'world after malformed',
+        lineNumber: 4,
+      });
+    });
+
+    it('skips unframed binary notices in system grep --null output', () => {
+      const invocationForPrivateMethod = grepTool.build({
+        pattern: 'world',
+      }) as unknown as {
+        parseGrepOutput: (
+          output: string,
+          basePath: string,
+        ) => Array<{
+          absoluteFilePath: string;
+          filePath: string;
+          line: string;
+          lineNumber: number;
+        }>;
+      };
+      const filePath = 'normal.txt';
+
+      const matches = invocationForPrivateMethod.parseGrepOutput(
+        `Binary file ./binary.bin matches\n${filePath}\0${7}:hello world\n`,
+        tempRootDir,
+      );
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]).toMatchObject({
+        absoluteFilePath: path.join(tempRootDir, filePath),
+        filePath,
+        line: 'hello world',
+        lineNumber: 7,
       });
     });
 

--- a/packages/core/src/tools/grep.ts
+++ b/packages/core/src/tools/grep.ts
@@ -6,7 +6,6 @@
 
 import fsPromises from 'node:fs/promises';
 import path from 'node:path';
-import { EOL } from 'node:os';
 import { spawn } from 'node:child_process';
 import { globStream } from 'glob';
 import type { ToolInvocation, ToolResult } from './tools.js';
@@ -299,8 +298,11 @@ class GrepToolInvocation extends BaseToolInvocation<
 
   /**
    * Parses the standard output of grep-like commands (git grep, system grep).
-   * Expects format: filePath:lineNumber:lineContent
-   * Handles colons within file paths and line content correctly.
+   * Primary formats are null-delimited:
+   * - git grep -z -n: filePath\0lineNumber\0lineContent\n
+   * - grep --null -n: filePath\0lineNumber:lineContent\n
+   * Also accepts legacy colon-delimited output as a fallback.
+   * Handles colons within file paths and line content correctly for null-delimited output.
    * @param {string} output The raw stdout string.
    * @param {string} basePath The absolute directory the search was run from, for relative paths.
    * @returns {GrepMatch[]} Array of match objects.
@@ -309,27 +311,11 @@ class GrepToolInvocation extends BaseToolInvocation<
     const results: GrepMatch[] = [];
     if (!output) return results;
 
-    const lines = output.split(EOL); // Use OS-specific end-of-line
-
-    for (const line of lines) {
-      if (!line.trim()) continue;
-
-      // Find the index of the first colon.
-      const firstColonIndex = line.indexOf(':');
-      if (firstColonIndex === -1) continue; // Malformed
-
-      // Find the index of the second colon, searching *after* the first one.
-      const secondColonIndex = line.indexOf(':', firstColonIndex + 1);
-      if (secondColonIndex === -1) continue; // Malformed
-
-      // Extract parts based on the found colon indices
-      const filePathRaw = line.substring(0, firstColonIndex);
-      const lineNumberStr = line.substring(
-        firstColonIndex + 1,
-        secondColonIndex,
-      );
-      const lineContent = line.substring(secondColonIndex + 1);
-
+    const pushMatch = (
+      filePathRaw: string,
+      lineNumberStr: string,
+      lineContent: string,
+    ) => {
       const lineNumber = parseInt(lineNumberStr, 10);
 
       if (!isNaN(lineNumber)) {
@@ -343,6 +329,74 @@ class GrepToolInvocation extends BaseToolInvocation<
           line: lineContent.replace(/\r$/, ''),
         });
       }
+    };
+
+    if (output.includes('\0')) {
+      let index = 0;
+      while (index < output.length) {
+        const pathEnd = output.indexOf('\0', index);
+        if (pathEnd === -1) break;
+
+        const nextNewline = output.indexOf('\n', index);
+        if (nextNewline !== -1 && nextNewline < pathEnd) {
+          debugLogger.debug(
+            `Skipping unframed grep output line: ${output.substring(
+              index,
+              nextNewline,
+            )}`,
+          );
+          index = nextNewline + 1;
+          continue;
+        }
+
+        const filePathRaw = output.substring(index, pathEnd);
+        const afterPath = pathEnd + 1;
+        const nextNull = output.indexOf('\0', afterPath);
+        let lineEnd = output.indexOf('\n', afterPath);
+        if (lineEnd === -1) lineEnd = output.length;
+
+        if (nextNull !== -1 && nextNull < lineEnd) {
+          // git grep -z -n emits: path\0lineNumber\0lineContent\n
+          const lineNumberStr = output.substring(afterPath, nextNull);
+          let contentEnd = output.indexOf('\n', nextNull + 1);
+          if (contentEnd === -1) contentEnd = output.length;
+          const lineContent = output.substring(nextNull + 1, contentEnd);
+          pushMatch(filePathRaw, lineNumberStr, lineContent);
+          index = contentEnd + 1;
+          continue;
+        }
+
+        // grep --null -n emits: path\0lineNumber:lineContent\n
+        const rest = output.substring(afterPath, lineEnd);
+        const separator = rest.indexOf(':');
+        if (separator !== -1) {
+          pushMatch(
+            filePathRaw,
+            rest.substring(0, separator),
+            rest.substring(separator + 1),
+          );
+        } else {
+          debugLogger.debug(
+            `Skipping malformed grep --null record for ${filePathRaw}`,
+          );
+        }
+        index = lineEnd + 1;
+      }
+      return results;
+    }
+
+    // Legacy/non-current callers may still pass colon-delimited grep output.
+    const lines = output.split('\n');
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+
+      const normalizedLine = line.replace(/\r$/, '');
+      const match = normalizedLine.match(/^(.+?):(\d+):(.*)$/);
+      if (!match) continue; // Malformed
+
+      const [, filePathRaw, lineNumberStr, lineContent] = match;
+      pushMatch(filePathRaw, lineNumberStr, lineContent);
     }
     return results;
   }
@@ -385,6 +439,7 @@ class GrepToolInvocation extends BaseToolInvocation<
           'grep',
           '--untracked',
           '-n',
+          '-z',
           '-E',
           '--ignore-case',
           pattern,
@@ -433,7 +488,7 @@ class GrepToolInvocation extends BaseToolInvocation<
       const { available: grepAvailable } = isCommandAvailable('grep');
       if (grepAvailable) {
         strategyUsed = 'system grep';
-        const grepArgs = ['-r', '-n', '-H', '-E'];
+        const grepArgs = ['-r', '-n', '-H', '-E', '--null'];
         // Extract directory names from exclusion patterns for grep --exclude-dir
         const globExcludes = this.fileExclusions.getGlobExcludes();
         const commonExcludes = globExcludes


### PR DESCRIPTION
## What this PR does

This PR makes the grep tool parse file paths and match lines without losing data when either side contains colons. It handles NUL-delimited output from `git grep -z -n` and `grep --null -n -H`, and keeps a legacy parser for colon-delimited output.

## Why it's needed

The old parser split grep output on the first two colons. That breaks for valid file paths such as `dir:name/file.txt` or timestamped paths, and it can also mishandle match content that contains colons. Using NUL-delimited output where available gives the parser an unambiguous path boundary.

## Reviewer Test Plan

### How to verify

Run the focused grep tests and confirm matches are parsed correctly for plain grep-style output, `git grep -z` output, and system `grep --null` output when file paths contain colons.

### Evidence (Before & After)

Before: a path like `dir:name/file.txt:1:hello` could be parsed as path `dir` with an invalid line number segment. After: NUL-delimited output is parsed by its real separators, and legacy colon-delimited output uses a line-number-aware pattern so path colons and content colons are preserved.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Node 22, local repository checkout.

## Risk & Scope

- Main risk or tradeoff: The parser now has separate branches for NUL-delimited and legacy grep output formats.
- Not validated / out of scope: I did not run a full end-to-end CLI grep session on Windows; local validation covered parser tests, core typecheck/build, full lint, and diff checks.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5370

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让 grep tool 在文件路径或匹配内容包含冒号时，也能正确解析结果。它支持 `git grep -z -n` 和 `grep --null -n -H` 的 NUL 分隔输出，同时保留对旧式冒号分隔输出的解析。

## Why it's needed

旧 parser 会按前两个冒号拆 grep 输出。这会破坏 `dir:name/file.txt` 或带时间戳的合法路径，也可能误处理包含冒号的匹配内容。能使用 NUL 分隔输出时，parser 就有了明确的路径边界。

## Reviewer Test Plan

### How to verify

运行聚焦的 grep 测试，并确认当文件路径包含冒号时，plain grep-style output、`git grep -z` output 和 system `grep --null` output 都能被正确解析。

### Evidence (Before & After)

Before: `dir:name/file.txt:1:hello` 这样的路径可能会被解析成 path `dir`，后面的 line number segment 也无效。After: NUL 分隔输出按真实分隔符解析，旧式冒号分隔输出使用感知 line number 的 pattern，因此路径里的冒号和内容里的冒号都会被保留。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Node 22，本地仓库 checkout。

## Risk & Scope

- Main risk or tradeoff: parser 现在对 NUL 分隔和旧式 grep output 有不同分支。
- Not validated / out of scope: 我没有在 Windows 上跑完整端到端 CLI grep 会话；本地验证覆盖了 parser tests、core typecheck/build、full lint 和 diff checks。
- Breaking changes / migration notes: 无。

## Linked Issues

Fixes #5370

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
