### PR TITLE
fix(cli): respect sandbox path boundaries

### DIFF
--- a/packages/cli/src/utils/sandbox-path.ts
+++ b/packages/cli/src/utils/sandbox-path.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import path from 'node:path';
+
+export function isContainerPathWithinWorkdir(
+  containerWorkdir: string,
+  containerPath: string,
+): boolean {
+  const normalize = (value: string) => {
+    const normalized = path.posix
+      .normalize(value.replace(/\\/g, '/'))
+      .replace(/\/+$/, '')
+      .toLowerCase();
+    return normalized || '/';
+  };
+
+  const normalizedWorkdir = normalize(containerWorkdir);
+  const normalizedPath = normalize(containerPath);
+
+  if (normalizedWorkdir === '/') {
+    return normalizedPath.startsWith('/');
+  }
+
+  return (
+    normalizedPath === normalizedWorkdir ||
+    normalizedPath.startsWith(`${normalizedWorkdir}/`)
+  );
+}

--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -5,7 +5,41 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { isContainerPathWithinWorkdir } from './sandbox-path.js';
 import { parseSandboxImageName } from './sandboxImageName.js';
+
+describe('isContainerPathWithinWorkdir', () => {
+  it('allows the workdir itself', () => {
+    expect(isContainerPathWithinWorkdir('/repo/app', '/repo/app')).toBe(true);
+  });
+
+  it('allows paths under the workdir', () => {
+    expect(isContainerPathWithinWorkdir('/repo/app', '/repo/app/bin')).toBe(
+      true,
+    );
+  });
+
+  it('rejects sibling paths with the same prefix', () => {
+    expect(
+      isContainerPathWithinWorkdir('/repo/app', '/repo/app-tools/bin'),
+    ).toBe(false);
+  });
+
+  it('allows absolute paths under the filesystem root workdir', () => {
+    expect(isContainerPathWithinWorkdir('/', '/bin')).toBe(true);
+  });
+
+  it('normalizes trailing slashes and case for container paths', () => {
+    expect(
+      isContainerPathWithinWorkdir('/C/Repo/App/', '/c/repo/app/bin'),
+    ).toBe(true);
+  });
+
+  it('handles converted Windows drive roots without matching sibling drives', () => {
+    expect(isContainerPathWithinWorkdir('/c', '/c/tools')).toBe(true);
+    expect(isContainerPathWithinWorkdir('/c', '/c2/tools')).toBe(false);
+  });
+});
 
 describe('parseSandboxImageName', () => {
   it('uses the image basename and tag for container names', () => {

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -24,6 +24,7 @@ import {
 import { randomBytes } from 'node:crypto';
 import { writeStderrLine } from './stdioHelpers.js';
 import { parseSandboxImageName } from './sandboxImageName.js';
+import { isContainerPathWithinWorkdir } from './sandbox-path.js';
 
 const execAsync = promisify(exec);
 
@@ -121,9 +122,7 @@ function entrypoint(workdir: string, cliArgs: string[]): string[] {
     const paths = process.env['PATH'].split(pathSeparator);
     for (const p of paths) {
       const containerPath = getContainerPath(p);
-      if (
-        containerPath.toLowerCase().startsWith(containerWorkdir.toLowerCase())
-      ) {
+      if (isContainerPathWithinWorkdir(containerWorkdir, containerPath)) {
         pathSuffix += `:${containerPath}`;
       }
     }
@@ -137,9 +136,7 @@ function entrypoint(workdir: string, cliArgs: string[]): string[] {
     const paths = process.env['PYTHONPATH'].split(pathSeparator);
     for (const p of paths) {
       const containerPath = getContainerPath(p);
-      if (
-        containerPath.toLowerCase().startsWith(containerWorkdir.toLowerCase())
-      ) {
+      if (isContainerPathWithinWorkdir(containerWorkdir, containerPath)) {
         pythonPathSuffix += `:${containerPath}`;
       }
     }
@@ -723,8 +720,13 @@ export async function start_sandbox(
   // also mount-replace VIRTUAL_ENV directory with <project_settings>/sandbox.venv
   // sandbox can then set up this new VIRTUAL_ENV directory using sandbox.bashrc (see below)
   // directory will be empty if not set up, which is still preferable to having host binaries
+  const virtualEnv = process.env['VIRTUAL_ENV'];
   if (
-    process.env['VIRTUAL_ENV']?.toLowerCase().startsWith(workdir.toLowerCase())
+    virtualEnv &&
+    isContainerPathWithinWorkdir(
+      getContainerPath(workdir),
+      getContainerPath(virtualEnv),
+    )
   ) {
     const sandboxVenvPath = path.resolve(
       SETTINGS_DIRECTORY_NAME,
@@ -733,14 +735,8 @@ export async function start_sandbox(
     if (!fs.existsSync(sandboxVenvPath)) {
       fs.mkdirSync(sandboxVenvPath, { recursive: true });
     }
-    args.push(
-      '--volume',
-      `${sandboxVenvPath}:${getContainerPath(process.env['VIRTUAL_ENV'])}`,
-    );
-    args.push(
-      '--env',
-      `VIRTUAL_ENV=${getContainerPath(process.env['VIRTUAL_ENV'])}`,
-    );
+    args.push('--volume', `${sandboxVenvPath}:${getContainerPath(virtualEnv)}`);
+    args.push('--env', `VIRTUAL_ENV=${getContainerPath(virtualEnv)}`);
   }
 
   // copy additional environment variables from SANDBOX_ENV


### PR DESCRIPTION
## What this PR does

This PR replaces string-prefix sandbox path checks with a normalized path-segment boundary check. The same helper is used when passing through workspace-local `PATH` and `PYTHONPATH` entries and when deciding whether `VIRTUAL_ENV` can be mounted into the sandbox.

## Why it's needed

The old check used `startsWith()` on normalized strings, so a sibling path like `/repo/app-tools` could be treated as if it were inside `/repo/app`. That can leak host paths into the sandbox passthrough logic even though they are outside the workspace boundary.

## Reviewer Test Plan

### How to verify

Run the focused sandbox tests and confirm workspace paths are allowed, nested paths are allowed, sibling-prefix paths are rejected, root workdir behavior is preserved, and converted Windows drive roots such as `/c` do not match `/c2`.

### Evidence (Before & After)

Before: `/repo/app-tools/bin` satisfied the old `startsWith('/repo/app')` check. After: `isContainerPathWithinWorkdir()` only accepts the exact workdir or paths beginning with `${workdir}/`, so sibling-prefix paths are rejected.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Node 22, local repository checkout.

## Risk & Scope

- Main risk or tradeoff: Sandbox passthroughs now require a real path-segment relationship instead of a raw string prefix relationship.
- Not validated / out of scope: I did not run a real Docker/Podman sandbox session; this PR validates the path-boundary helper and the thin call sites through unit tests and lint.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5373

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 把 sandbox 路径判断从字符串前缀检查，替换成规范化后的路径段边界检查。同一个 helper 会用于透传 workspace 内的 `PATH`、`PYTHONPATH` 项，也用于判断 `VIRTUAL_ENV` 是否可以挂载进 sandbox。

## Why it's needed

旧逻辑对规范化字符串使用 `startsWith()`，所以 `/repo/app-tools` 这样的兄弟目录可能会被当成 `/repo/app` 里面的路径。这会让 workspace 边界外的 host 路径进入 sandbox passthrough 逻辑。

## Reviewer Test Plan

### How to verify

运行聚焦的 sandbox 测试，并确认 workdir 自身允许、子路径允许、同前缀兄弟路径拒绝、根目录 workdir 行为保持不变，以及 `/c` 这样的 Windows drive 转换根不会匹配 `/c2`。

### Evidence (Before & After)

Before: `/repo/app-tools/bin` 会通过旧的 `startsWith('/repo/app')` 检查。After: `isContainerPathWithinWorkdir()` 只接受精确 workdir 或以 `${workdir}/` 开头的路径，所以同前缀兄弟路径会被拒绝。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Node 22，本地仓库 checkout。

## Risk & Scope

- Main risk or tradeoff: sandbox passthrough 现在要求真实路径段包含关系，而不是原始字符串前缀关系。
- Not validated / out of scope: 我没有运行真实 Docker/Podman sandbox 会话；这个 PR 通过单测和 lint 验证路径边界 helper 以及很薄的调用点。
- Breaking changes / migration notes: 无。

## Linked Issues

Fixes #5373

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
