### PR TITLE
fix(cli): preserve equals in mcp env values

### DIFF
--- a/packages/cli/src/commands/mcp/add.test.ts
+++ b/packages/cli/src/commands/mcp/add.test.ts
@@ -84,6 +84,17 @@ describe('mcp add command', () => {
     });
   });
 
+  it('should preserve equals signs in env values', async () => {
+    await parser.parseAsync('add my-server /path/to/server -e TOKEN=a=b=c');
+
+    expect(mockSetValue).toHaveBeenCalledWith(SettingScope.User, 'mcpServers', {
+      'my-server': expect.objectContaining({
+        command: '/path/to/server',
+        env: { TOKEN: 'a=b=c' },
+      }),
+    });
+  });
+
   it('should auto-detect http transport when commandOrUrl is an https URL', async () => {
     await parser.parseAsync('add http-server https://example.com/mcp');
 

--- a/packages/cli/src/commands/mcp/add.ts
+++ b/packages/cli/src/commands/mcp/add.ts
@@ -149,7 +149,12 @@ async function addMcpServer(
         args: args?.map(String),
         env: env?.reduce(
           (acc, curr) => {
-            const [key, value] = curr.split('=');
+            const separator = curr.indexOf('=');
+            if (separator === -1) {
+              return acc;
+            }
+            const key = curr.slice(0, separator);
+            const value = curr.slice(separator + 1);
             if (key && value) {
               acc[key] = value;
             }


### PR DESCRIPTION
## What this PR does

This PR makes `qwen mcp add -e KEY=value` split environment variable arguments on the first `=` only. Values that contain additional `=` characters are preserved exactly instead of being truncated.

## Why it's needed

Many MCP environment values are signed tokens, base64-like strings, or connection strings that can contain `=`. The old destructuring from `split('=')` kept only the first value segment, so `TOKEN=a=b=c` was saved as `TOKEN=a`.

## Reviewer Test Plan

### How to verify

Run the focused MCP add command test and confirm `-e TOKEN=a=b=c` saves `{ TOKEN: 'a=b=c' }`. Also confirm malformed entries without `=` are still ignored as before.

### Evidence (Before & After)

Before: `TOKEN=a=b=c` was split into `['TOKEN', 'a', 'b', 'c']` and only `a` was stored. After: the parser finds the first separator and slices the rest of the string as the value, so the stored value is `a=b=c`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Node 22, local repository checkout.

## Risk & Scope

- Main risk or tradeoff: Environment values may now contain additional `=` characters, matching normal shell-style `KEY=value` parsing.
- Not validated / out of scope: CLI workspace typecheck currently has unrelated baseline failures around Ink subpath types in this checkout, so this PR was validated with the focused command test, targeted eslint/prettier, full lint, and diff checks.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5374

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让 `qwen mcp add -e KEY=value` 只按第一个 `=` 分割环境变量参数。值里后续出现的 `=` 会被完整保留，不再被截断。

## Why it's needed

很多 MCP 环境变量值是签名 token、类似 base64 的字符串或连接串，里面可能包含 `=`。旧逻辑对 `split('=')` 做解构，只保留第一段 value，所以 `TOKEN=a=b=c` 会被保存成 `TOKEN=a`。

## Reviewer Test Plan

### How to verify

运行聚焦的 MCP add command 测试，并确认 `-e TOKEN=a=b=c` 会保存 `{ TOKEN: 'a=b=c' }`。同时确认没有 `=` 的 malformed entry 仍然像以前一样被忽略。

### Evidence (Before & After)

Before: `TOKEN=a=b=c` 会被拆成 `['TOKEN', 'a', 'b', 'c']`，最终只保存 `a`。After: parser 找到第一个分隔符，并把后面的整段字符串作为 value，所以保存值是 `a=b=c`。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Node 22，本地仓库 checkout。

## Risk & Scope

- Main risk or tradeoff: 环境变量值现在可以包含额外的 `=`，这符合常见 shell-style `KEY=value` 解析方式。
- Not validated / out of scope: 当前 checkout 的 CLI workspace typecheck 存在与本 PR 无关的 Ink subpath 类型基线失败，所以这个 PR 使用聚焦 command 测试、targeted eslint/prettier、全量 lint 和 diff checks 验证。
- Breaking changes / migration notes: 无。

## Linked Issues

Fixes #5374

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
