### PR TITLE
fix(core): resolve tilde paths before search permission checks

### DIFF
--- a/packages/core/src/tools/glob.test.ts
+++ b/packages/core/src/tools/glob.test.ts
@@ -659,6 +659,25 @@ describe('GlobTool', () => {
       expect(result.llmContent).toContain('[5 files truncated] ...');
     });
   });
+
+  describe('getDefaultPermission', () => {
+    it('should return allow for paths within workspace', async () => {
+      const params: GlobToolParams = { pattern: '*', path: 'sub' };
+      const invocation = globTool.build(params);
+      const permission = await invocation.getDefaultPermission();
+      expect(permission).toBe('allow');
+    });
+
+    it('should return ask for tilde paths outside workspace', async () => {
+      const params: GlobToolParams = {
+        pattern: '*',
+        path: '~/outside-workspace',
+      };
+      const invocation = globTool.build(params);
+      const permission = await invocation.getDefaultPermission();
+      expect(permission).toBe('ask');
+    });
+  });
 });
 
 describe('sortFileEntries', () => {

--- a/packages/core/src/tools/glob.ts
+++ b/packages/core/src/tools/glob.ts
@@ -12,6 +12,7 @@ import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
 import { ToolNames, ToolDisplayNames } from './tool-names.js';
 import {
   resolveAndValidatePath,
+  resolvePath,
   isSubpath,
   unescapePath,
 } from '../utils/paths.js';
@@ -114,7 +115,7 @@ class GlobToolInvocation extends BaseToolInvocation<
       return 'allow'; // Default workspace directory
     }
     const workspaceContext = this.config.getWorkspaceContext();
-    const resolvedPath = path.resolve(
+    const resolvedPath = resolvePath(
       this.config.getTargetDir(),
       this.params.path,
     );

--- a/packages/core/src/tools/grep.test.ts
+++ b/packages/core/src/tools/grep.test.ts
@@ -597,6 +597,25 @@ describe('GrepTool', () => {
     });
   });
 
+  describe('getDefaultPermission', () => {
+    it('should return allow for paths within workspace', async () => {
+      const params: GrepToolParams = { pattern: 'hello', path: 'sub' };
+      const invocation = grepTool.build(params);
+      const permission = await invocation.getDefaultPermission();
+      expect(permission).toBe('allow');
+    });
+
+    it('should return ask for tilde paths outside workspace', async () => {
+      const params: GrepToolParams = {
+        pattern: 'hello',
+        path: '~/outside-workspace',
+      };
+      const invocation = grepTool.build(params);
+      const permission = await invocation.getDefaultPermission();
+      expect(permission).toBe('ask');
+    });
+  });
+
   describe('Result limiting', () => {
     beforeEach(async () => {
       // Create many test files with matches to test limiting

--- a/packages/core/src/tools/grep.ts
+++ b/packages/core/src/tools/grep.ts
@@ -15,6 +15,7 @@ import { ToolNames, ToolDisplayNames } from './tool-names.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import {
   resolveAndValidatePath,
+  resolvePath,
   isSubpath,
   unescapePath,
 } from '../utils/paths.js';
@@ -91,7 +92,7 @@ class GrepToolInvocation extends BaseToolInvocation<
       return 'allow'; // Default workspace directory
     }
     const workspaceContext = this.config.getWorkspaceContext();
-    const resolvedPath = path.resolve(
+    const resolvedPath = resolvePath(
       this.config.getTargetDir(),
       this.params.path,
     );

--- a/packages/core/src/tools/ripGrep.test.ts
+++ b/packages/core/src/tools/ripGrep.test.ts
@@ -1132,5 +1132,15 @@ describe('RipGrepTool', () => {
       const permission = await invocation.getDefaultPermission();
       expect(permission).toBe('ask');
     });
+
+    it('should return ask for tilde paths outside workspace', async () => {
+      const params: RipGrepToolParams = {
+        pattern: 'hello',
+        path: '~/outside-workspace',
+      };
+      const invocation = grepTool.build(params);
+      const permission = await invocation.getDefaultPermission();
+      expect(permission).toBe('ask');
+    });
   });
 });

--- a/packages/core/src/tools/ripGrep.ts
+++ b/packages/core/src/tools/ripGrep.ts
@@ -9,7 +9,11 @@ import path from 'node:path';
 import type { ToolInvocation, ToolResult } from './tools.js';
 import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
 import { ToolNames } from './tool-names.js';
-import { resolveAndValidatePath, unescapePath } from '../utils/paths.js';
+import {
+  resolveAndValidatePath,
+  resolvePath,
+  unescapePath,
+} from '../utils/paths.js';
 import { getErrorMessage } from '../utils/errors.js';
 import type { Config } from '../config/config.js';
 import { runRipgrep } from '../utils/ripgrepUtils.js';
@@ -149,7 +153,7 @@ class GrepToolInvocation extends BaseToolInvocation<
       return 'allow'; // Default workspace directory
     }
     const workspaceContext = this.config.getWorkspaceContext();
-    const resolvedPath = path.resolve(
+    const resolvedPath = resolvePath(
       this.config.getTargetDir(),
       this.params.path,
     );


### PR DESCRIPTION
## What this PR does

This PR makes the search tools use the existing tilde-aware path resolver before deciding the default permission for an explicit search path. `glob`, `grep`, and `ripgrep` now resolve `~/...` the same way they resolve paths during validation instead of treating `~` as a literal child of the workspace.

## Why it's needed

The permission check previously used `path.resolve(targetDir, params.path)`. For a path like `~/outside-workspace`, Node treats `~` as a normal path segment, so the resolved path appears to be inside the workspace even though the user meant a home-directory path. That can make search tools default to `allow` for a path that should require confirmation.

## Reviewer Test Plan

### How to verify

Run the focused search tool tests and confirm each tool still allows a normal relative workspace path while returning `ask` for a tilde path outside the workspace.

### Evidence (Before & After)

Before: `~/outside-workspace` could be resolved as a literal workspace child path during the default permission check. After: `resolvePath()` expands `~` first, so the workspace containment check sees the real home-directory path and returns `ask` when it is outside the workspace.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Node 22, local repository checkout.

## Risk & Scope

- Main risk or tradeoff: Explicit tilde paths that previously looked like workspace-relative literal `~` paths may now require confirmation when they resolve outside the workspace.
- Not validated / out of scope: No UI or sandbox behavior changed; this only touches default permission path resolution for search tools.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5376

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让 search tools 在判断显式搜索路径的默认权限前，使用已有的支持 `~` 展开的路径解析逻辑。`glob`、`grep` 和 `ripgrep` 现在会像路径校验阶段一样解析 `~/...`，而不是把 `~` 当成 workspace 下的普通字面目录。

## Why it's needed

之前 permission check 使用 `path.resolve(targetDir, params.path)`。对 `~/outside-workspace` 这样的路径，Node 会把 `~` 当成普通路径片段，所以解析结果看起来像在 workspace 内，尽管用户实际表达的是 home 目录路径。这会让 search tools 对本应确认的路径默认返回 `allow`。

## Reviewer Test Plan

### How to verify

运行聚焦的 search tool 测试，并确认每个工具仍然允许普通的 workspace 相对路径，同时对 workspace 外的 tilde 路径返回 `ask`。

### Evidence (Before & After)

Before: `~/outside-workspace` 在默认权限检查里可能被解析成 workspace 下的字面子路径。After: `resolvePath()` 会先展开 `~`，所以 workspace containment check 会看到真实的 home 目录路径，并在它位于 workspace 外时返回 `ask`。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Node 22，本地仓库 checkout。

## Risk & Scope

- Main risk or tradeoff: 之前看起来像 workspace 相对字面 `~` 目录的显式 tilde 路径，现在如果解析到 workspace 外，会要求确认。
- Not validated / out of scope: 没有改 UI 或 sandbox 行为；这里只影响 search tools 的默认权限路径解析。
- Breaking changes / migration notes: 无。

## Linked Issues

Fixes #5376

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
