### PR TITLE
fix(core): detect top-level MCP callable errors

### DIFF
--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -220,6 +220,52 @@ describe('DiscoveredMCPTool', () => {
     );
 
     it.each([
+      { isErrorValue: true, description: 'true (bool)' },
+      { isErrorValue: 'true', description: '"true" (str)' },
+    ])(
+      'should return a structured error if callable tool reports top-level isError ${description}',
+      async ({ isErrorValue }) => {
+        const tool = new DiscoveredMCPTool(
+          mockCallableToolInstance,
+          serverName,
+          serverToolName,
+          baseDescription,
+          inputSchema,
+        );
+        const params = { param: 'topLevelIsErrorCase' };
+        const functionCall = {
+          name: serverToolName,
+          args: params,
+        };
+        const mockMcpToolResponseParts: Part[] = [
+          {
+            functionResponse: {
+              name: serverToolName,
+              response: {
+                isError: isErrorValue,
+                content: [{ type: 'text', text: 'failed' }],
+              },
+            },
+          },
+        ];
+        mockCallTool.mockResolvedValue(mockMcpToolResponseParts);
+        const expectedErrorMessage = `MCP tool '${
+          serverToolName
+        }' reported tool error for function call: ${safeJsonStringify(
+          functionCall,
+        )} with response: ${safeJsonStringify(mockMcpToolResponseParts)}`;
+        const invocation = tool.build(params);
+        const result = await invocation.execute(new AbortController().signal);
+
+        expect(result.error?.type).toBe(ToolErrorType.MCP_TOOL_ERROR);
+        expect(result.llmContent).toBe(expectedErrorMessage);
+        expect(result.returnDisplay).toContain(
+          `Error: MCP tool '${serverToolName}' reported an error.`,
+        );
+      },
+    );
+
+    it.each([
       { isErrorValue: false, description: 'false (bool)' },
       { isErrorValue: 'false', description: '"false" (str)' },
     ])(
@@ -270,6 +316,38 @@ describe('DiscoveredMCPTool', () => {
           { text: stringifiedResponseContent },
         ]);
         expect(toolResult.returnDisplay).toBe(stringifiedResponseContent);
+      },
+    );
+
+    it.each([
+      { isErrorValue: false, description: 'false (bool)' },
+      { isErrorValue: 'false', description: '"false" (str)' },
+    ])(
+      'should consider top-level isError ${description} to be a success',
+      async ({ isErrorValue }) => {
+        const params = { param: 'topLevelIsErrorFalseCase' };
+        const successMessage = 'top-level false is success';
+        const mockMcpToolResponseParts: Part[] = [
+          {
+            functionResponse: {
+              name: serverToolName,
+              response: {
+                isError: isErrorValue,
+                content: [{ type: 'text', text: successMessage }],
+              },
+            },
+          },
+        ];
+        mockCallTool.mockResolvedValue(mockMcpToolResponseParts);
+
+        const invocation = tool.build(params);
+        const toolResult = await invocation.execute(
+          new AbortController().signal,
+        );
+
+        expect(toolResult.error).toBeUndefined();
+        expect(toolResult.llmContent).toEqual([{ text: successMessage }]);
+        expect(toolResult.returnDisplay).toBe(successMessage);
       },
     );
 

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -184,10 +184,15 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
     }
 
     if (response) {
-      const error = (response as { error?: McpError })?.error;
-      const isError = error?.isError;
+      const typedResponse = response as { error?: McpError } & McpError;
+      const topLevelIsError = typedResponse.isError;
+      if (topLevelIsError === true || topLevelIsError === 'true') {
+        return true;
+      }
 
-      if (error && (isError === true || isError === 'true')) {
+      const error = typedResponse.error;
+      const isError = error?.isError;
+      if (isError === true || isError === 'true') {
         return true;
       }
     }


### PR DESCRIPTION
## What this PR does

This PR treats top-level callable MCP `response.isError` values as MCP tool errors. It preserves the existing nested `response.error.isError` handling and keeps explicit `isError: false` / `"false"` responses on the success path.

## Why it's needed

The callable fallback can receive MCP results shaped like `functionResponse.response.isError`, while the direct-client wrapper can expose errors as `response.error.isError`. The old error detector only checked the nested form, so callable fallback results with top-level `isError: true` could be rendered as successful tool output.

## Reviewer Test Plan

### How to verify

Run the focused MCP tool tests and confirm callable responses with top-level `isError: true` and `"true"` return `MCP_TOOL_ERROR`, while `false` and `"false"` remain successful.

### Evidence (Before & After)

Before: a callable response containing top-level `isError: true` could bypass `isMCPToolError()` because only `response.error.isError` was inspected. After: the detector checks the top-level flag first and returns the same structured MCP tool error path used for nested errors.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Node 22, local repository checkout.

## Risk & Scope

- Main risk or tradeoff: Callable MCP responses with top-level `isError: true` now fail the tool invocation instead of being treated as success.
- Not validated / out of scope: No MCP transport behavior changed; this only updates local result classification for callable fallback responses.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5379

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 会把 callable MCP 顶层 `response.isError` 识别为 MCP tool error。它保留已有的嵌套 `response.error.isError` 处理，并让明确的 `isError: false` / `"false"` 继续走成功路径。

## Why it's needed

callable fallback 可能收到 `functionResponse.response.isError` 形态的 MCP 结果，而 direct-client wrapper 可能把错误暴露成 `response.error.isError`。旧的错误检测只检查嵌套形态，所以 callable fallback 返回顶层 `isError: true` 时可能被当成成功工具输出渲染。

## Reviewer Test Plan

### How to verify

运行聚焦的 MCP tool 测试，并确认 callable response 中顶层 `isError: true` 和 `"true"` 会返回 `MCP_TOOL_ERROR`，而 `false` 和 `"false"` 仍然成功。

### Evidence (Before & After)

Before: 包含顶层 `isError: true` 的 callable response 可能绕过 `isMCPToolError()`，因为旧逻辑只检查 `response.error.isError`。After: detector 会先检查顶层 flag，并返回和嵌套错误相同的 structured MCP tool error 路径。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Node 22，本地仓库 checkout。

## Risk & Scope

- Main risk or tradeoff: 顶层 `isError: true` 的 callable MCP response 现在会让 tool invocation 失败，而不是被当成 success。
- Not validated / out of scope: 没有改 MCP transport 行为；这里只更新 callable fallback response 的本地结果分类。
- Breaking changes / migration notes: 无。

## Linked Issues

Fixes #5379

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
