### PR TITLE
fix(core): avoid reconnecting on MCP tool errors

### DIFF
--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -31,6 +31,16 @@ import { ServiceAccountImpersonationProvider } from '../mcp/sa-impersonation-pro
 import { DiscoveredMCPTool } from './mcp-tool.js';
 import type { McpToolAnnotations } from './mcp-tool.js';
 import { SdkControlClientTransport } from './sdk-control-client-transport.js';
+import { MCPServerStatus, updateMCPServerStatus } from './mcp-status.js';
+export {
+  addMCPStatusChangeListener,
+  getAllMCPServerStatuses,
+  getMCPServerStatus,
+  MCPServerStatus,
+  removeMCPServerStatus,
+  removeMCPStatusChangeListener,
+  updateMCPServerStatus,
+} from './mcp-status.js';
 
 import type { FunctionDeclaration } from '@google/genai';
 import { mcpToTool } from '@google/genai';
@@ -187,18 +197,6 @@ export type DiscoveredMCPPrompt = Prompt & {
   serverName: string;
   invoke: (params: Record<string, unknown>) => Promise<GetPromptResult>;
 };
-
-/**
- * Enum representing the connection status of an MCP server
- */
-export enum MCPServerStatus {
-  /** Server is disconnected or experiencing errors */
-  DISCONNECTED = 'disconnected',
-  /** Server is in the process of connecting */
-  CONNECTING = 'connecting',
-  /** Server is connected and ready to use */
-  CONNECTED = 'connected',
-}
 
 /**
  * Enum representing the overall MCP discovery state
@@ -519,11 +517,6 @@ export class McpClient {
 }
 
 /**
- * Map to track the status of each MCP server within the core package
- */
-const serverStatuses: Map<string, MCPServerStatus> = new Map();
-
-/**
  * Track the overall MCP discovery state
  */
 let mcpDiscoveryState: MCPDiscoveryState = MCPDiscoveryState.NOT_STARTED;
@@ -532,84 +525,6 @@ let mcpDiscoveryState: MCPDiscoveryState = MCPDiscoveryState.NOT_STARTED;
  * Map to track which MCP servers have been discovered to require OAuth
  */
 export const mcpServerRequiresOAuth: Map<string, boolean> = new Map();
-
-/**
- * Event listeners for MCP server status changes.
- * `status` is `undefined` when the server has been removed from the registry
- * (e.g. disabled via `/mcp`), so consumers can drop it from their snapshots
- * rather than continue to count it as `DISCONNECTED`.
- */
-type StatusChangeListener = (
-  serverName: string,
-  status: MCPServerStatus | undefined,
-) => void;
-const statusChangeListeners: StatusChangeListener[] = [];
-
-/**
- * Add a listener for MCP server status changes
- */
-export function addMCPStatusChangeListener(
-  listener: StatusChangeListener,
-): void {
-  statusChangeListeners.push(listener);
-}
-
-/**
- * Remove a listener for MCP server status changes
- */
-export function removeMCPStatusChangeListener(
-  listener: StatusChangeListener,
-): void {
-  const index = statusChangeListeners.indexOf(listener);
-  if (index !== -1) {
-    statusChangeListeners.splice(index, 1);
-  }
-}
-
-/**
- * Update the status of an MCP server
- */
-export function updateMCPServerStatus(
-  serverName: string,
-  status: MCPServerStatus,
-): void {
-  serverStatuses.set(serverName, status);
-  // Snapshot the listener list so a listener that detaches itself (or
-  // attaches a new one) during dispatch doesn't mutate the array we're
-  // iterating.
-  for (const listener of [...statusChangeListeners]) {
-    listener(serverName, status);
-  }
-}
-
-/**
- * Remove an MCP server from the status registry and notify listeners.
- * Used when a server is disabled or removed from configuration so it no
- * longer shows up in the Footer's MCP health pill as offline.
- */
-export function removeMCPServerStatus(serverName: string): void {
-  if (!serverStatuses.has(serverName)) {
-    return;
-  }
-  serverStatuses.delete(serverName);
-  for (const listener of [...statusChangeListeners]) {
-    listener(serverName, undefined);
-  }
-}
-
-/**
- * Get the current status of an MCP server
- */
-export function getMCPServerStatus(serverName: string): MCPServerStatus {
-  return serverStatuses.get(serverName) || MCPServerStatus.DISCONNECTED;
-}
-
-/**
- * Get all MCP server statuses
- */
-export function getAllMCPServerStatuses(): Map<string, MCPServerStatus> {
-  return new Map(serverStatuses);
-}
 
 /**
  * Get the current MCP discovery state

--- a/packages/core/src/tools/mcp-status.ts
+++ b/packages/core/src/tools/mcp-status.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Enum representing the connection status of an MCP server
+ */
+export enum MCPServerStatus {
+  /** Server is disconnected or experiencing errors */
+  DISCONNECTED = 'disconnected',
+  /** Server is in the process of connecting */
+  CONNECTING = 'connecting',
+  /** Server is connected and ready to use */
+  CONNECTED = 'connected',
+}
+
+/**
+ * Map to track the status of each MCP server within the core package
+ */
+const serverStatuses: Map<string, MCPServerStatus> = new Map();
+
+/**
+ * Event listeners for MCP server status changes.
+ * `status` is `undefined` when the server has been removed from the registry
+ * (e.g. disabled via `/mcp`), so consumers can drop it from their snapshots
+ * rather than continue to count it as `DISCONNECTED`.
+ */
+type StatusChangeListener = (
+  serverName: string,
+  status: MCPServerStatus | undefined,
+) => void;
+const statusChangeListeners: StatusChangeListener[] = [];
+
+/**
+ * Add a listener for MCP server status changes
+ */
+export function addMCPStatusChangeListener(
+  listener: StatusChangeListener,
+): void {
+  statusChangeListeners.push(listener);
+}
+
+/**
+ * Remove a listener for MCP server status changes
+ */
+export function removeMCPStatusChangeListener(
+  listener: StatusChangeListener,
+): void {
+  const index = statusChangeListeners.indexOf(listener);
+  if (index !== -1) {
+    statusChangeListeners.splice(index, 1);
+  }
+}
+
+/**
+ * Update the status of an MCP server
+ */
+export function updateMCPServerStatus(
+  serverName: string,
+  status: MCPServerStatus,
+): void {
+  serverStatuses.set(serverName, status);
+  // Snapshot the listener list so a listener that detaches itself (or
+  // attaches a new one) during dispatch doesn't mutate the array we're
+  // iterating.
+  for (const listener of [...statusChangeListeners]) {
+    listener(serverName, status);
+  }
+}
+
+/**
+ * Remove an MCP server from the status registry and notify listeners.
+ * Used when a server is disabled or removed from configuration so it no
+ * longer shows up in the Footer's MCP health pill as offline.
+ */
+export function removeMCPServerStatus(serverName: string): void {
+  if (!serverStatuses.has(serverName)) {
+    return;
+  }
+  serverStatuses.delete(serverName);
+  for (const listener of [...statusChangeListeners]) {
+    listener(serverName, undefined);
+  }
+}
+
+/**
+ * Get the current status of an MCP server
+ */
+export function getMCPServerStatus(serverName: string): MCPServerStatus {
+  return serverStatuses.get(serverName) || MCPServerStatus.DISCONNECTED;
+}
+
+/**
+ * Get all MCP server statuses
+ */
+export function getAllMCPServerStatuses(): Map<string, MCPServerStatus> {
+  return new Map(serverStatuses);
+}

--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -17,7 +17,11 @@ import type { ToolResult } from './tools.js';
 import { ToolConfirmationOutcome } from './tools.js';
 import type { CallableTool, Part } from '@google/genai';
 import { ToolErrorType } from './tool-error.js';
-import { updateMCPServerStatus, MCPServerStatus } from './mcp-client.js';
+import {
+  MCPServerStatus,
+  removeMCPServerStatus,
+  updateMCPServerStatus,
+} from './mcp-client.js';
 
 vi.mock('node:fs/promises');
 
@@ -91,6 +95,7 @@ describe('DiscoveredMCPTool', () => {
   });
 
   afterEach(() => {
+    removeMCPServerStatus(serverName);
     vi.restoreAllMocks();
   });
 
@@ -1275,6 +1280,7 @@ describe('DiscoveredMCPTool', () => {
 
       const connectionError = new Error('Connection closed');
 
+      updateMCPServerStatus(serverName, MCPServerStatus.CONNECTED);
       (mockMcpClient.callTool as any).mockRejectedValueOnce(connectionError);
 
       const reconnectTool = new DiscoveredMCPTool(
@@ -1304,12 +1310,30 @@ describe('DiscoveredMCPTool', () => {
         callTool: vi.fn(),
       };
 
+      const retryClient: McpDirectClient = {
+        callTool: vi
+          .fn()
+          .mockResolvedValueOnce({ content: [{ type: 'text', text: 'OK' }] }),
+      };
+      const retryTool = new DiscoveredMCPTool(
+        mockCallableToolInstance,
+        serverName,
+        serverToolName,
+        baseDescription,
+        inputSchema,
+        undefined,
+        undefined,
+        undefined,
+        retryClient,
+      );
+
       const discoverToolsForServer = vi.fn().mockResolvedValue(undefined);
+      const ensureTool = vi.fn().mockResolvedValue(retryTool);
       const mockConfig = {
         isTrustedFolder: () => true,
         getToolRegistry: () => ({
           discoverToolsForServer,
-          ensureTool: vi.fn().mockResolvedValue(null),
+          ensureTool,
         }),
       };
 
@@ -1336,6 +1360,70 @@ describe('DiscoveredMCPTool', () => {
       ).rejects.toThrow('Invalid parameters');
 
       expect(mockMcpClient.callTool).toHaveBeenCalledTimes(1);
+      expect(discoverToolsForServer).not.toHaveBeenCalled();
+      expect(ensureTool).not.toHaveBeenCalled();
+      expect(retryClient.callTool).not.toHaveBeenCalled();
+    });
+
+    it('should not retry aborted calls even when the server is disconnected', async () => {
+      const params = { param: 'test' };
+      const mockMcpClient: McpDirectClient = {
+        callTool: vi.fn(),
+      };
+
+      const retryClient: McpDirectClient = {
+        callTool: vi
+          .fn()
+          .mockResolvedValueOnce({ content: [{ type: 'text', text: 'OK' }] }),
+      };
+      const retryTool = new DiscoveredMCPTool(
+        mockCallableToolInstance,
+        serverName,
+        serverToolName,
+        baseDescription,
+        inputSchema,
+        undefined,
+        undefined,
+        undefined,
+        retryClient,
+      );
+
+      const discoverToolsForServer = vi.fn().mockResolvedValue(undefined);
+      const ensureTool = vi.fn().mockResolvedValue(retryTool);
+      const mockConfig = {
+        isTrustedFolder: () => true,
+        getToolRegistry: () => ({
+          discoverToolsForServer,
+          ensureTool,
+        }),
+      };
+
+      updateMCPServerStatus(serverName, MCPServerStatus.DISCONNECTED);
+      const abortError = new Error('The operation was aborted');
+      abortError.name = 'AbortError';
+      (mockMcpClient.callTool as any).mockRejectedValue(abortError);
+
+      const reconnectTool = new DiscoveredMCPTool(
+        mockCallableToolInstance,
+        serverName,
+        serverToolName,
+        baseDescription,
+        inputSchema,
+        undefined,
+        undefined,
+        mockConfig as any,
+        mockMcpClient,
+      );
+
+      const invocation = reconnectTool.build(params);
+      await expect(
+        invocation.execute(new AbortController().signal),
+      ).rejects.toThrow('The operation was aborted');
+
+      expect(mockMcpClient.callTool).toHaveBeenCalledTimes(1);
+      expect(discoverToolsForServer).not.toHaveBeenCalled();
+      expect(ensureTool).not.toHaveBeenCalled();
+      expect(retryClient.callTool).not.toHaveBeenCalled();
     });
 
     it('should not retry after reconnection attempt fails', async () => {
@@ -1370,6 +1458,7 @@ describe('DiscoveredMCPTool', () => {
       };
 
       const connectionError = new Error('ECONNREFUSED');
+      updateMCPServerStatus(serverName, MCPServerStatus.CONNECTED);
       (mockMcpClient.callTool as any).mockRejectedValue(connectionError);
 
       const reconnectTool = new DiscoveredMCPTool(
@@ -1455,6 +1544,7 @@ describe('DiscoveredMCPTool', () => {
         );
 
         const invocation = reconnectTool.build(params);
+        updateMCPServerStatus(serverName, MCPServerStatus.CONNECTED);
         await invocation.execute(new AbortController().signal);
 
         expect(discoverToolsForServer).toHaveBeenCalled();

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -22,8 +22,21 @@ import { ToolErrorType } from './tool-error.js';
 import type { Config } from '../config/config.js';
 import { truncateToolOutput } from '../utils/truncation.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import { getErrorMessage, isAbortError } from '../utils/errors.js';
+import { getMCPServerStatus, MCPServerStatus } from './mcp-status.js';
 
 const debugLogger = createDebugLogger('MCP_TOOL');
+
+const MCP_CONNECTION_ERROR_PATTERNS = [
+  /ECONNREFUSED/i,
+  /ENOTFOUND/i,
+  /ECONNRESET/i,
+  /ETIMEDOUT/i,
+  /connection (closed|lost)/i,
+  /not connected/i,
+  /disconnected/i,
+  /transport closed/i,
+];
 
 type ToolParams = Record<string, unknown>;
 
@@ -231,6 +244,10 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
   ): Promise<ToolResult> {
     debugLogger.error(`MCP server error '${this.serverName}': ${error}`);
 
+    if (!this.shouldAttemptReconnect(error)) {
+      throw error;
+    }
+
     if (this.retryCount < DiscoveredMCPToolInvocation.MAX_RECONNECT_RETRIES) {
       debugLogger.info(
         `Reconnection attempt ${this.retryCount + 1}/${DiscoveredMCPToolInvocation.MAX_RECONNECT_RETRIES} for MCP server '${this.serverName}'`,
@@ -261,6 +278,21 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
     }
 
     throw error;
+  }
+
+  private shouldAttemptReconnect(error: unknown): boolean {
+    if (isAbortError(error)) {
+      return false;
+    }
+
+    if (getMCPServerStatus(this.serverName) === MCPServerStatus.DISCONNECTED) {
+      return true;
+    }
+
+    const message = getErrorMessage(error);
+    return MCP_CONNECTION_ERROR_PATTERNS.some((pattern) =>
+      pattern.test(message),
+    );
   }
 
   async execute(


### PR DESCRIPTION
## What this PR does

This PR stops the direct-client MCP retry path from reconnecting for ordinary tool errors. Reconnects are still allowed when the server is already marked disconnected or when the thrown error looks like a connection or transport failure.

## Why it's needed

`handleReconnectOnError()` previously attempted MCP rediscovery for every thrown direct-client error. That is useful for transport failures, but it can hide real tool errors such as invalid parameters and retry a side-effecting tool call after rediscovery.

## Reviewer Test Plan

### How to verify

Run the focused MCP tool tests and confirm non-connection tool errors do not call rediscovery, `ensureTool()`, or a retry client. Also confirm connection-like errors still exercise the reconnect path.

### Evidence (Before & After)

Before: a non-connection error from `callTool()` could enter the reconnect path, call `discoverToolsForServer()`, and potentially retry with a rediscovered tool. After: `shouldAttemptReconnect()` throws the original error immediately unless the server is disconnected or the error matches a connection/transport pattern.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Node 22, local repository checkout.

## Risk & Scope

- Main risk or tradeoff: The reconnect decision now depends on server status plus a small set of connection-error message patterns.
- Not validated / out of scope: This does not change MCP transport startup or discovery behavior outside the error retry gate.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5381

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 阻止 direct-client MCP retry path 对普通 tool error 发起重连。服务器已经标记为 disconnected，或 thrown error 看起来像连接/transport 故障时，仍然允许重连。

## Why it's needed

之前 `handleReconnectOnError()` 会对所有 direct-client error 尝试 MCP rediscovery。对 transport failure 来说这是有用的，但它也可能隐藏 invalid parameters 这样的真实 tool error，并在 rediscovery 后重复执行有副作用的 tool call。

## Reviewer Test Plan

### How to verify

运行聚焦的 MCP tool 测试，并确认 non-connection tool error 不会调用 rediscovery、`ensureTool()` 或 retry client。同时确认 connection-like error 仍然会走 reconnect path。

### Evidence (Before & After)

Before: `callTool()` 抛出的 non-connection error 可能进入 reconnect path，调用 `discoverToolsForServer()`，并可能用重新发现的 tool retry。After: `shouldAttemptReconnect()` 只有在 server disconnected 或错误匹配连接/transport pattern 时才重连，否则立即抛出原始错误。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Node 22，本地仓库 checkout。

## Risk & Scope

- Main risk or tradeoff: reconnect 决策现在依赖 server status 加一组连接错误 message pattern。
- Not validated / out of scope: 这不改变 error retry gate 之外的 MCP transport startup 或 discovery 行为。
- Breaking changes / migration notes: 无。

## Linked Issues

Fixes #5381

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
