### PR TITLE
fix(cli): update acp cancel test flag

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -7865,7 +7865,7 @@ describe('Session', () => {
       expect(execute).not.toHaveBeenCalled();
       const { parts } = result;
       expect(parts).toHaveLength(1);
-      expect(result.stopAfterUserQuestionCancel).toBe(false);
+      expect(result.stopAfterPermissionCancel).toBe(false);
       expect(parts[0].functionResponse?.id).toBe('shell_1__qwen_dup_2');
       expect(parts[0].functionResponse?.response).toEqual({
         error: expect.stringContaining(
@@ -7936,7 +7936,7 @@ describe('Session', () => {
 
       expect(mockToolRegistry.getTool).not.toHaveBeenCalled();
       const { parts } = result;
-      expect(result.stopAfterUserQuestionCancel).toBe(false);
+      expect(result.stopAfterPermissionCancel).toBe(false);
       expect(parts[0].functionResponse?.id).toBe('todo_1__qwen_dup_2');
       expect(parts[0].functionResponse?.response).toEqual({
         error: expect.stringContaining(
@@ -8016,7 +8016,7 @@ describe('Session', () => {
 
       expect(execute).toHaveBeenCalledTimes(2);
       const { parts } = result;
-      expect(result.stopAfterUserQuestionCancel).toBe(false);
+      expect(result.stopAfterPermissionCancel).toBe(false);
       expect(parts.map((part) => part.functionResponse?.id)).toEqual([
         'call_a',
         'dup_mid__qwen_dup_2',


### PR DESCRIPTION
## What this PR does

Updates the remaining ACP session duplicate-call assertions to check `stopAfterPermissionCancel`, matching the renamed `RunToolResult` field used by the session implementation.

## Why it's needed

`upstream/main` still had three assertions for the old `stopAfterUserQuestionCancel` flag after #5258 renamed the field. That leaves `packages/cli` typecheck red even though the runtime/test intent is unchanged.

## Reviewer Test Plan

### How to verify

Confirm there are no remaining `stopAfterUserQuestionCancel` references, then run the ACP session test file and CLI typecheck. The target test suite passes, and the old TS2551 errors disappear; my local checkout still reports the pre-existing Ink patch resolution errors for `ink/dom` and `CursorContext`.

### Evidence (Before & After)

Before: `npm run typecheck --workspace=packages/cli` reported TS2551 for `stopAfterUserQuestionCancel` in `Session.test.ts`.

After: `npx vitest run src/acp-integration/session/Session.test.ts` passes 164 tests, and CLI typecheck no longer reports any `stopAfterUserQuestionCancel` errors.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node/npm workspace checkout; package commands run from `packages/cli` where noted.

## Risk & Scope

- Main risk or tradeoff: very low; this only updates test assertions to the current result field name.
- Not validated / out of scope: no runtime ACP behavior changes.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5383

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 ACP session duplicate-call 测试里剩下的断言改为检查 `stopAfterPermissionCancel`，和 session 实现当前使用的 `RunToolResult` 字段保持一致。

## 为什么需要

#5258 重命名字段后，`upstream/main` 里仍有三处测试断言引用旧的 `stopAfterUserQuestionCancel` 标记。这会让 `packages/cli` typecheck 变红，但运行时和测试意图本身没有变化。

## Reviewer Test Plan

### 如何验证

确认仓库里不再残留 `stopAfterUserQuestionCancel` 引用，然后运行 ACP session 测试文件和 CLI typecheck。目标测试套件通过，旧的 TS2551 错误消失；我的本地 checkout 仍会报已有的 Ink patch resolution 错误，涉及 `ink/dom` 和 `CursorContext`。

### 证据（Before & After）

Before：`npm run typecheck --workspace=packages/cli` 会在 `Session.test.ts` 中报 `stopAfterUserQuestionCancel` 的 TS2551。

After：`npx vitest run src/acp-integration/session/Session.test.ts` 通过 164 个测试，CLI typecheck 不再报告任何 `stopAfterUserQuestionCancel` 错误。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment（可选）

Node/npm workspace checkout；相关 package 命令按需在 `packages/cli` 下运行。

## 风险和范围

- 主要风险或取舍：很低，只是把测试断言更新到当前结果字段名。
- 未验证 / 范围外：不修改运行时 ACP 行为。
- Breaking changes / 迁移说明：无。

## 关联 Issue

Fixes #5383

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.