### PR TITLE
fix(cli): parse sandbox mounts with windows drives

### DIFF
--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from 'vitest';
 import { isContainerPathWithinWorkdir } from './sandbox-path.js';
 import { parseSandboxImageName } from './sandboxImageName.js';
+import { parseSandboxMountSpec } from './sandboxMounts.js';
 
 describe('isContainerPathWithinWorkdir', () => {
   it('allows the workdir itself', () => {
@@ -74,5 +75,59 @@ describe('parseSandboxImageName', () => {
         'registry.example.com/team/qwen-code-sandbox:dev@sha256:abcdef',
       ),
     ).toBe('qwen-code-sandbox-dev');
+  });
+});
+
+describe('parseSandboxMountSpec', () => {
+  it('defaults container path and options', () => {
+    expect(parseSandboxMountSpec('/host/path')).toEqual({
+      from: '/host/path',
+      to: '/host/path',
+      opts: 'ro',
+    });
+  });
+
+  it('parses explicit container path and options', () => {
+    expect(parseSandboxMountSpec('/host/path:/container/path:rw')).toEqual({
+      from: '/host/path',
+      to: '/container/path',
+      opts: 'rw',
+    });
+  });
+
+  it('defaults an empty container path to the host path', () => {
+    expect(parseSandboxMountSpec('/host/path::rw')).toEqual({
+      from: '/host/path',
+      to: '/host/path',
+      opts: 'rw',
+    });
+  });
+
+  it('keeps the drive-letter colon in Windows host paths', () => {
+    expect(
+      parseSandboxMountSpec('C:\\Users\\me:/workspace:rw', 'win32'),
+    ).toEqual({
+      from: 'C:\\Users\\me',
+      to: '/workspace',
+      opts: 'rw',
+    });
+  });
+
+  it('keeps the drive-letter colon in Windows host paths with forward slashes', () => {
+    expect(parseSandboxMountSpec('C:/Users/me:/workspace:rw', 'win32')).toEqual(
+      {
+        from: 'C:/Users/me',
+        to: '/workspace',
+        opts: 'rw',
+      },
+    );
+  });
+
+  it('keeps a bare Windows host path intact', () => {
+    expect(parseSandboxMountSpec('C:\\Users\\me', 'win32')).toEqual({
+      from: 'C:\\Users\\me',
+      to: 'C:\\Users\\me',
+      opts: 'ro',
+    });
   });
 });

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -25,6 +25,7 @@ import { randomBytes } from 'node:crypto';
 import { writeStderrLine } from './stdioHelpers.js';
 import { parseSandboxImageName } from './sandboxImageName.js';
 import { isContainerPathWithinWorkdir } from './sandbox-path.js';
+import { parseSandboxMountSpec } from './sandboxMounts.js';
 
 const execAsync = promisify(exec);
 
@@ -519,9 +520,7 @@ export async function start_sandbox(
     for (let mount of process.env['SANDBOX_MOUNTS'].split(',')) {
       if (mount.trim()) {
         // parse mount as from:to:opts
-        let [from, to, opts] = mount.trim().split(':');
-        to = to || from; // default to mount at same path inside container
-        opts = opts || 'ro'; // default to read-only
+        const { from, to, opts } = parseSandboxMountSpec(mount);
         mount = `${from}:${to}:${opts}`;
         // check that from path is absolute
         if (!path.isAbsolute(from)) {

--- a/packages/cli/src/utils/sandboxMounts.ts
+++ b/packages/cli/src/utils/sandboxMounts.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import os from 'node:os';
+
+export function parseSandboxMountSpec(
+  rawMount: string,
+  platform: NodeJS.Platform = os.platform(),
+): { from: string; to: string; opts: string } {
+  const mount = rawMount.trim();
+  const mountSeparator =
+    platform === 'win32' && /^[A-Za-z]:[\\/]/.test(mount)
+      ? mount.indexOf(':', 2)
+      : mount.indexOf(':');
+
+  const from = mountSeparator === -1 ? mount : mount.slice(0, mountSeparator);
+  const rest = mountSeparator === -1 ? '' : mount.slice(mountSeparator + 1);
+  const [toPart, optsPart] = rest.split(':');
+
+  return {
+    from,
+    to: toPart || from,
+    opts: optsPart || 'ro',
+  };
+}


### PR DESCRIPTION
## What this PR does

- Adds a small `parseSandboxMountSpec` helper for `SANDBOX_MOUNTS`.
- Preserves Windows drive-letter prefixes when parsing host/container/options segments.
- Adds coverage for default mounts, explicit target/options, empty target, and Windows drive paths.

## Why

`SANDBOX_MOUNTS` was parsed with `split(':')`, so a Windows host path like `C:\Users\me:/workspace:rw` was split at the drive-letter colon and rejected as `from = "C"`.

Fixes #5386.

## Reviewer Test Plan

- [x] `npm test --workspace=packages/cli -- sandbox.test.ts`
- [x] `npx prettier --check packages/cli/src/utils/sandbox.ts packages/cli/src/utils/sandbox.test.ts packages/cli/src/utils/sandboxMounts.ts`
- [x] `npm run lint --workspace=packages/cli`
- [x] `git diff --check upstream/main...HEAD`
- [ ] `npm run typecheck --workspace=packages/cli` (currently blocked locally by unrelated upstream/main issues: stale ACP test property references fixed in #5384, plus local generated/build artifact gaps)

## Risk

Low. The parser keeps the existing POSIX forms unchanged and only treats a leading Windows drive prefix specially on `win32`.

## Linked Issues

Fixes #5386

## 中文说明

修复 `SANDBOX_MOUNTS` 在 Windows 路径下的解析问题。之前 `C:\Users\me:/workspace:rw` 会被冒号拆成 `C` 和 `\Users\me`，现在会保留盘符部分，只把后面的 `:/workspace:rw` 当作挂载目标和选项解析。

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
