### PR TITLE
fix(core): validate grep result limits

### DIFF
--- a/docs/developers/tools/file-system.md
+++ b/docs/developers/tools/file-system.md
@@ -155,7 +155,7 @@ notebook_edit(
   - `pattern` (string, required): The regular expression pattern to search for in file contents (e.g., `"function\\s+myFunction"`, `"log.*Error"`).
   - `path` (string, optional): File or directory to search in. Defaults to current working directory.
   - `glob` (string, optional): Glob pattern to filter files (e.g. `"*.js"`, `"src/**/*.{ts,tsx}"`).
-  - `limit` (number, optional): Limit output to first N matching lines. Optional - shows all matches if not specified.
+  - `limit` (integer, optional): Limit output to first N matching lines. Must be a positive integer. Optional - shows all matches if not specified.
 - **Behavior:**
   - Uses ripgrep for fast search when available; otherwise falls back to a JavaScript-based search implementation.
   - Returns matching lines with file paths and line numbers.

--- a/packages/core/src/tools/grep.test.ts
+++ b/packages/core/src/tools/grep.test.ts
@@ -154,6 +154,20 @@ describe('GrepTool', () => {
       expect(grepTool.validateToolParams(params)).toBeNull();
     });
 
+    it('should return null for a positive integer limit', () => {
+      const params: GrepToolParams = { pattern: 'hello', limit: 2 };
+      expect(grepTool.validateToolParams(params)).toBeNull();
+    });
+
+    it.each([
+      [0, 'params/limit must be >= 1'],
+      [-1, 'params/limit must be >= 1'],
+      [1.5, 'params/limit must be integer'],
+    ])('should return error for invalid limit %s', (limit, expectedError) => {
+      const params: GrepToolParams = { pattern: 'hello', limit };
+      expect(grepTool.validateToolParams(params)).toBe(expectedError);
+    });
+
     it('should return error if pattern is missing', () => {
       const params = { path: '.' } as unknown as GrepToolParams;
       expect(grepTool.validateToolParams(params)).toBe(
@@ -639,8 +653,7 @@ describe('GrepTool', () => {
       expect(result.returnDisplay).toBe('Found 30 matches');
     });
 
-    it('should not validate limit parameter', () => {
-      // limit parameter has no validation constraints in the new implementation
+    it('should validate a positive limit parameter', () => {
       const params = { pattern: 'test', limit: 5 };
       const error = grepTool.validateToolParams(params as GrepToolParams);
       expect(error).toBeNull();

--- a/packages/core/src/tools/grep.ts
+++ b/packages/core/src/tools/grep.ts
@@ -628,9 +628,10 @@ export class GrepTool extends BaseDeclarativeTool<GrepToolParams, ToolResult> {
               'File or directory to search in. Defaults to current working directory.',
           },
           limit: {
-            type: 'number',
+            type: 'integer',
+            minimum: 1,
             description:
-              'Limit output to first N matching lines. Optional - shows all matches if not specified.',
+              'Limit output to first N matching lines. Must be a positive integer. Optional - shows all matches if not specified.',
           },
         },
         required: ['pattern'],
@@ -647,6 +648,13 @@ export class GrepTool extends BaseDeclarativeTool<GrepToolParams, ToolResult> {
   protected override validateToolParamValues(
     params: GrepToolParams,
   ): string | null {
+    if (
+      params.limit !== undefined &&
+      (!Number.isInteger(params.limit) || params.limit <= 0)
+    ) {
+      return 'limit must be a positive integer';
+    }
+
     // Validate pattern is a valid regex
     try {
       new RegExp(params.pattern);

--- a/packages/core/src/tools/ripGrep.test.ts
+++ b/packages/core/src/tools/ripGrep.test.ts
@@ -118,6 +118,20 @@ describe('RipGrepTool', () => {
       expect(grepTool.validateToolParams(params)).toBeNull();
     });
 
+    it('should return null for a positive integer limit', () => {
+      const params: RipGrepToolParams = { pattern: 'hello', limit: 2 };
+      expect(grepTool.validateToolParams(params)).toBeNull();
+    });
+
+    it.each([
+      [0, 'params/limit must be >= 1'],
+      [-1, 'params/limit must be >= 1'],
+      [1.5, 'params/limit must be integer'],
+    ])('should return error for invalid limit %s', (limit, expectedError) => {
+      const params: RipGrepToolParams = { pattern: 'hello', limit };
+      expect(grepTool.validateToolParams(params)).toBe(expectedError);
+    });
+
     it('should return error if pattern is missing', () => {
       const params = { path: '.' } as unknown as RipGrepToolParams;
       expect(grepTool.validateToolParams(params)).toBe(

--- a/packages/core/src/tools/ripGrep.ts
+++ b/packages/core/src/tools/ripGrep.ts
@@ -524,9 +524,10 @@ export class RipGrepTool extends BaseDeclarativeTool<
               'File or directory to search in (rg PATH). Defaults to current working directory.',
           },
           limit: {
-            type: 'number',
+            type: 'integer',
+            minimum: 1,
             description:
-              'Limit output to first N lines/entries. Optional - shows all matches if not specified.',
+              'Limit output to first N lines/entries. Must be a positive integer. Optional - shows all matches if not specified.',
           },
         },
         required: ['pattern'],
@@ -549,6 +550,13 @@ export class RipGrepTool extends BaseDeclarativeTool<
     );
     if (errors) {
       return errors;
+    }
+
+    if (
+      params.limit !== undefined &&
+      (!Number.isInteger(params.limit) || params.limit <= 0)
+    ) {
+      return 'limit must be a positive integer';
     }
 
     // Validate pattern is a valid regex


### PR DESCRIPTION
## What this PR does

This PR validates the optional `limit` parameter for both grep-backed search tools. If `limit` is provided, it must now be a positive integer. The tool schemas, tests, and `grep_search` developer docs all use the same constraint.

## Why it's needed

`limit` previously accepted any number, including `0`, negative values, and floats. Those values flow into result slicing, so `limit: 0` can report matches while showing no lines, and negative values can silently drop matches from the end.

## Reviewer Test Plan

### How to verify

Run the focused grep tool tests and confirm both `GrepTool` and `RipGrepTool` accept a positive integer limit and reject `0`, negative, and non-integer limits.

### Evidence (Before & After)

Before: `limit: 0`, `limit: -1`, and `limit: 1.5` passed parameter validation.

After: both grep tools reject those values through schema/validation and still accept positive integers such as `limit: 2`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Node/npm workspace checkout.

## Risk & Scope

- Main risk or tradeoff: callers that passed non-positive or fractional limits now get validation errors instead of truncated output.
- Not validated / out of scope: no changes to grep matching, path handling, or output formatting beyond rejecting invalid limits.
- Breaking changes / migration notes: invalid `limit` values must be changed to positive integers.

## Linked Issues

Fixes #5387

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 为两个 grep-backed search tools 校验可选的 `limit` 参数。现在如果传入 `limit`，它必须是正整数。工具 schema、测试和 `grep_search` 开发者文档都同步使用同一约束。

## 为什么需要

之前 `limit` 接受任意 number，包括 `0`、负数和小数。这些值会进入结果切片逻辑，所以 `limit: 0` 可能报告找到匹配但不展示任何行，负数则可能静默丢掉末尾匹配。

## Reviewer Test Plan

### 如何验证

运行聚焦的 grep tool 测试，并确认 `GrepTool` 和 `RipGrepTool` 都接受正整数 limit，同时拒绝 `0`、负数和非整数 limit。

### 证据（Before & After）

Before：`limit: 0`、`limit: -1` 和 `limit: 1.5` 都能通过参数校验。

After：两个 grep tools 都会通过 schema/validation 拒绝这些值，同时仍接受 `limit: 2` 这样的正整数。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment（可选）

Node/npm workspace checkout。

## 风险和范围

- 主要风险或取舍：传入非正数或小数 limit 的调用方现在会得到校验错误，而不是截断后的输出。
- 未验证 / 范围外：不修改 grep 匹配、路径处理或输出格式，只拒绝 invalid limit。
- Breaking changes / 迁移说明：invalid `limit` 值需要改成正整数。

## 关联 Issue

Fixes #5387

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>