### PR TITLE
fix(core): accept uppercase web fetch schemes

### DIFF
--- a/packages/core/src/tools/web-fetch.test.ts
+++ b/packages/core/src/tools/web-fetch.test.ts
@@ -54,6 +54,26 @@ describe('WebFetchTool', () => {
       );
     });
 
+    it.each(['HTTPS://example.com', 'Http://example.com'])(
+      'should accept uppercase http url schemes: %s',
+      (url) => {
+        const tool = new WebFetchTool(mockConfig);
+        expect(() =>
+          tool.build({ url, prompt: 'summarize this' }),
+        ).not.toThrow();
+      },
+    );
+
+    it.each(['ftp://example.com', 'http:example.com', 'http:/example.com'])(
+      'should reject invalid or unsupported url schemes: %s',
+      (url) => {
+        const tool = new WebFetchTool(mockConfig);
+        expect(() => tool.build({ url, prompt: 'summarize this' })).toThrow(
+          "The 'url' must be a valid URL starting with http:// or https://.",
+        );
+      },
+    );
+
     it('should return WEB_FETCH_FALLBACK_FAILED on fetch failure', async () => {
       vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(true);
       vi.spyOn(fetchUtils, 'fetchWithTimeout').mockRejectedValue(

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -305,10 +305,7 @@ export class WebFetchTool extends BaseDeclarativeTool<
     if (!params.url || params.url.trim() === '') {
       return "The 'url' parameter cannot be empty.";
     }
-    if (
-      !params.url.startsWith('http://') &&
-      !params.url.startsWith('https://')
-    ) {
+    if (!/^https?:\/\//i.test(params.url)) {
       return "The 'url' must be a valid URL starting with http:// or https://.";
     }
     if (!params.prompt || params.prompt.trim() === '') {


### PR DESCRIPTION
## What this PR does

Allows `web_fetch` URL validation to accept uppercase and mixed-case HTTP schemes such as `HTTPS://example.com` and `Http://example.com`, while still requiring the URL to start with `http://` or `https://`.

## Why it's needed

URL schemes are case-insensitive, but `web_fetch` currently checks `http://` and `https://` with case-sensitive string prefixes. That rejects otherwise valid URLs before the tool can fetch them.

## Reviewer Test Plan

### How to verify

Confirm that `WebFetchTool.build()` accepts `HTTPS://example.com` and `Http://example.com`, and still rejects unsupported or malformed schemes such as `ftp://example.com`, `http:example.com`, and `http:/example.com`.

### Evidence (Before & After)

N/A - focused validation tests cover the non-UI behavior.

### Tested on

|     OS     |     Status     |
| :--------: | :------------: |
|  🍏 macOS  |    ✅ tested    |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

- `npx vitest run src/tools/web-fetch.test.ts` from `packages/core`
- `npx prettier --check packages/core/src/tools/web-fetch.ts packages/core/src/tools/web-fetch.test.ts`
- `npx eslint packages/core/src/tools/web-fetch.ts packages/core/src/tools/web-fetch.test.ts`
- `npm run typecheck --workspace=packages/core`
- `npm run build --workspace=packages/core`
- `git diff --check`

## Risk & Scope

- Main risk or tradeoff: Low; this only changes URL validation for the web fetch tool and keeps the existing `http://` / `https://` requirement.
- Not validated / out of scope: Full cross-platform CI locally. Current upstream CI may still show the ACP cancel test baseline failure until #5384 lands.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5390

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 `web_fetch` 的 URL 校验接受 `HTTPS://example.com` 和 `Http://example.com` 这种大写/混合大小写 HTTP scheme，同时仍然要求 URL 以 `http://` 或 `https://` 开头。

## 为什么需要

URL scheme 本身是大小写不敏感的，但 `web_fetch` 之前用大小写敏感的字符串前缀检查 `http://` 和 `https://`，导致一些合法 URL 在发起请求前就被拒绝。

## Reviewer Test Plan

### 如何验证

确认 `WebFetchTool.build()` 接受 `HTTPS://example.com` 和 `Http://example.com`，同时仍然拒绝 `ftp://example.com`、`http:example.com`、`http:/example.com` 这类不支持或格式不正确的 scheme。

### 前后证据

N/A - 这是非 UI 行为，focused validation tests 已覆盖。

### 本地验证

- `npx vitest run src/tools/web-fetch.test.ts` from `packages/core`
- `npx prettier --check packages/core/src/tools/web-fetch.ts packages/core/src/tools/web-fetch.test.ts`
- `npx eslint packages/core/src/tools/web-fetch.ts packages/core/src/tools/web-fetch.test.ts`
- `npm run typecheck --workspace=packages/core`
- `npm run build --workspace=packages/core`
- `git diff --check`

## 风险和范围

- 主要风险/取舍：低；只改 `web_fetch` 工具的 URL 校验，并保留原来的 `http://` / `https://` 要求。
- 未验证/不在范围内：没有在本地跑完整跨平台 CI。当前 upstream CI 可能仍会在 #5384 合并前出现 ACP cancel test 的 baseline 失败。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Fixes #5390

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
