### PR TITLE
fix(acp): scrub simple env for spawned children

### DIFF
--- a/packages/acp-bridge/src/spawnChannel.test.ts
+++ b/packages/acp-bridge/src/spawnChannel.test.ts
@@ -20,6 +20,8 @@
  *   - `QWEN_SERVER_TOKEN` (the daemon's own bearer token) leaking into
  *     the spawned agent's environment, where prompt-injection could
  *     turn the agent into an authenticated client of its own daemon.
+ *   - `QWEN_CODE_SIMPLE` leaking from the daemon/IDE process into
+ *     per-session ACP children, where it would silently suppress skills.
  *   - An `overrides` map smuggling a scrubbed key BACK into the child
  *     env (defense-in-depth — operators / embedders can pass overrides,
  *     but the denylist still wins).
@@ -30,12 +32,84 @@
  * Each branch listed below is now regression-guarded by an assertion.
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import type { ChildProcess } from 'node:child_process';
+import { PassThrough } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockSpawn = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: mockSpawn,
+  };
+});
+
 import {
+  createSpawnChannelFactory,
   createStderrForwarder,
   getAcpMemoryArgs,
   scrubChildEnv,
 } from './spawnChannel.js';
+
+function createFakeChildProcess(): ChildProcess {
+  return Object.assign(new EventEmitter(), {
+    stdin: new PassThrough(),
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    pid: 12345,
+    exitCode: null,
+    signalCode: null,
+    kill: vi.fn(() => true),
+  }) as unknown as ChildProcess;
+}
+
+describe('createSpawnChannelFactory env policy', () => {
+  const originalArgv1 = process.argv[1];
+  let originalSimple: string | undefined;
+  let originalServerToken: string | undefined;
+
+  beforeEach(() => {
+    mockSpawn.mockReset();
+    originalSimple = process.env['QWEN_CODE_SIMPLE'];
+    originalServerToken = process.env['QWEN_SERVER_TOKEN'];
+    process.argv[1] = '/tmp/qwen.js';
+    process.env['QWEN_CODE_SIMPLE'] = '1';
+    process.env['QWEN_SERVER_TOKEN'] = 'secret';
+  });
+
+  afterEach(() => {
+    process.argv[1] = originalArgv1;
+    if (originalSimple === undefined) {
+      delete process.env['QWEN_CODE_SIMPLE'];
+    } else {
+      process.env['QWEN_CODE_SIMPLE'] = originalSimple;
+    }
+    if (originalServerToken === undefined) {
+      delete process.env['QWEN_SERVER_TOKEN'];
+    } else {
+      process.env['QWEN_SERVER_TOKEN'] = originalServerToken;
+    }
+  });
+
+  it('scrubs daemon-only env vars from the spawned ACP child', async () => {
+    mockSpawn.mockReturnValue(createFakeChildProcess());
+
+    const factory = createSpawnChannelFactory();
+    await factory('/tmp/project', {
+      QWEN_CODE_SIMPLE: '1',
+      QWEN_SERVER_TOKEN: 'override-secret',
+    });
+
+    const spawnOptions = mockSpawn.mock.calls[0]?.[2] as
+      | { env?: NodeJS.ProcessEnv }
+      | undefined;
+    expect(spawnOptions?.env).not.toHaveProperty('QWEN_CODE_SIMPLE');
+    expect(spawnOptions?.env).not.toHaveProperty('QWEN_SERVER_TOKEN');
+    expect(spawnOptions?.env?.['QWEN_CODE_NO_RELAUNCH']).toBe('true');
+  });
+});
 
 describe('createStderrForwarder', () => {
   it('calls onDiagnosticLine for each complete line', () => {
@@ -133,7 +207,7 @@ describe('createStderrForwarder', () => {
 // of any current production denylist. The multi-key test below
 // forward-guards expansion when a future sandboxed-agent mode grows
 // the production set per the WARNING on `SCRUBBED_CHILD_ENV_KEYS`.
-const SCRUBBED = new Set<string>(['QWEN_SERVER_TOKEN']);
+const SCRUBBED = new Set<string>(['QWEN_SERVER_TOKEN', 'QWEN_CODE_SIMPLE']);
 
 describe('scrubChildEnv (defaultSpawnChannelFactory env policy)', () => {
   it('shallow-clones source — never aliases into the live process.env', () => {
@@ -147,6 +221,13 @@ describe('scrubChildEnv (defaultSpawnChannelFactory env policy)', () => {
     const source = { QWEN_SERVER_TOKEN: 'super-secret', PATH: '/usr/bin' };
     const result = scrubChildEnv(source, SCRUBBED);
     expect(result).not.toHaveProperty('QWEN_SERVER_TOKEN');
+    expect(result['PATH']).toBe('/usr/bin');
+  });
+
+  it('strips QWEN_CODE_SIMPLE from the child env', () => {
+    const source = { QWEN_CODE_SIMPLE: '1', PATH: '/usr/bin' };
+    const result = scrubChildEnv(source, SCRUBBED);
+    expect(result).not.toHaveProperty('QWEN_CODE_SIMPLE');
     expect(result['PATH']).toBe('/usr/bin');
   });
 
@@ -185,6 +266,14 @@ describe('scrubChildEnv (defaultSpawnChannelFactory env policy)', () => {
       QWEN_SERVER_TOKEN: 'sneaky-attempt-via-override',
     });
     expect(result).not.toHaveProperty('QWEN_SERVER_TOKEN');
+  });
+
+  it('overrides CANNOT re-introduce QWEN_CODE_SIMPLE', () => {
+    const source = { PATH: '/usr/bin' };
+    const result = scrubChildEnv(source, SCRUBBED, {
+      QWEN_CODE_SIMPLE: '1',
+    });
+    expect(result).not.toHaveProperty('QWEN_CODE_SIMPLE');
   });
 
   it('overrides CANNOT undo the scrub by setting undefined for a scrubbed key', () => {
@@ -229,17 +318,20 @@ describe('scrubChildEnv (defaultSpawnChannelFactory env policy)', () => {
     // anticipates), this verifies the loop handles multiple keys.
     const sandboxScrub = new Set<string>([
       'QWEN_SERVER_TOKEN',
+      'QWEN_CODE_SIMPLE',
       'AWS_SECRET_ACCESS_KEY',
       'OPENAI_API_KEY',
     ]);
     const source = {
       QWEN_SERVER_TOKEN: 't1',
-      AWS_SECRET_ACCESS_KEY: 't2',
-      OPENAI_API_KEY: 't3',
+      QWEN_CODE_SIMPLE: 't2',
+      AWS_SECRET_ACCESS_KEY: 't3',
+      OPENAI_API_KEY: 't4',
       PATH: '/usr/bin',
     };
     const result = scrubChildEnv(source, sandboxScrub);
     expect(result).not.toHaveProperty('QWEN_SERVER_TOKEN');
+    expect(result).not.toHaveProperty('QWEN_CODE_SIMPLE');
     expect(result).not.toHaveProperty('AWS_SECRET_ACCESS_KEY');
     expect(result).not.toHaveProperty('OPENAI_API_KEY');
     expect(result['PATH']).toBe('/usr/bin');

--- a/packages/acp-bridge/src/spawnChannel.ts
+++ b/packages/acp-bridge/src/spawnChannel.ts
@@ -230,11 +230,15 @@ const KILL_HARD_DEADLINE_MS = 10_000;
  * environment. Everything else is passed through — see the
  * threat-model rationale at the call site in `defaultSpawnChannelFactory`.
  *
- * Currently just `QWEN_SERVER_TOKEN`: the daemon's own bearer token,
- * which the agent doesn't need (it speaks to the daemon over stdio,
- * not HTTP). Leaving it in the child's env would let prompt injection
- * turn the agent into an authenticated client of its own daemon — an
- * escalation the agent doesn't otherwise have.
+ * `QWEN_SERVER_TOKEN`: the daemon's own bearer token, which the agent
+ * doesn't need (it speaks to the daemon over stdio, not HTTP). Leaving
+ * it in the child's env would let prompt injection turn the agent into
+ * an authenticated client of its own daemon — an escalation the agent
+ * doesn't otherwise have.
+ *
+ * `QWEN_CODE_SIMPLE`: an invocation-level bare-mode override. Letting a
+ * daemon or IDE environment leak it into per-session `qwen --acp`
+ * children silently disables skills in those children.
  *
  * **WARNING**: this denylist is correct *only because the agent
  * already has unrestricted shell-tool access* — anything in the env
@@ -250,6 +254,7 @@ const KILL_HARD_DEADLINE_MS = 10_000;
  */
 const SCRUBBED_CHILD_ENV_KEYS: ReadonlySet<string> = new Set([
   'QWEN_SERVER_TOKEN',
+  'QWEN_CODE_SIMPLE',
 ]);
 
 /**
@@ -259,9 +264,8 @@ const SCRUBBED_CHILD_ENV_KEYS: ReadonlySet<string> = new Set([
  *
  *   1. Start from a shallow clone of `source` (no aliasing into the
  *      daemon's `process.env`).
- *   2. Delete every key listed in `scrubbed` (the daemon-internal secret
- *      denylist — currently just `QWEN_SERVER_TOKEN`, see security
- *      rationale on the constant).
+ *   2. Delete every key listed in `scrubbed` (the daemon-internal
+ *      child-env denylist; see the rationale on the constant).
  *   3. Apply `overrides` per-handle. `undefined` value deletes the key
  *      (lets an embedded caller scrub a stale inherited var without
  *      mutating the daemon's global `process.env`). Anything else


### PR DESCRIPTION
## What this PR does

Prevents daemon-spawned `qwen --acp` children from inheriting `QWEN_CODE_SIMPLE` from the daemon or IDE environment. The existing `QWEN_SERVER_TOKEN` scrub behavior is unchanged.

## Why it's needed

`QWEN_CODE_SIMPLE` enables bare mode, which suppresses skills. If a long-running daemon or embedding environment has that variable set, every ACP child spawned through `defaultSpawnChannelFactory` can silently start without skills even when the session itself did not ask for bare mode.

## Reviewer Test Plan

### How to verify

Run the focused `spawnChannel` tests and confirm the production spawn factory passes a child env without `QWEN_CODE_SIMPLE` or `QWEN_SERVER_TOKEN`, including when overrides try to re-add them.

### Evidence (Before & After)

N/A - this is non-UI child-process env hardening covered by unit tests.

### Tested on

|     OS     |     Status     |
| :--------: | :------------: |
|  🍏 macOS  |    ✅ tested    |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

- `npx vitest run src/spawnChannel.test.ts` from `packages/acp-bridge`
- `npx prettier --check packages/acp-bridge/src/spawnChannel.ts packages/acp-bridge/src/spawnChannel.test.ts`
- `npx eslint packages/acp-bridge/src/spawnChannel.ts packages/acp-bridge/src/spawnChannel.test.ts`
- `npm run typecheck --workspace=packages/acp-bridge`
- `npm run build --workspace=packages/core`
- `npm run build --workspace=packages/acp-bridge`
- `git diff --check`

## Risk & Scope

- Main risk or tradeoff: Low; this only affects ACP children spawned by the daemon bridge and preserves explicit direct `qwen --acp` invocation semantics.
- Not validated / out of scope: Zed or other clients that launch `qwen --acp` directly. This PR is narrow hardening for daemon-spawned ACP children only.
- Breaking changes / migration notes: None expected. Users who intentionally want bare mode for a daemon-spawned child should pass that as an explicit child env override only if a future API supports it safely; current scrubbed keys intentionally cannot be reintroduced by overrides.

## Linked Issues

Refs #5007

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

阻止 daemon 自己 spawn 出来的 `qwen --acp` 子进程继承 daemon 或 IDE 环境里的 `QWEN_CODE_SIMPLE`。原有的 `QWEN_SERVER_TOKEN` scrub 行为不变。

## 为什么需要

`QWEN_CODE_SIMPLE` 会启用 bare mode，而 bare mode 会隐藏 skills。如果长期运行的 daemon 或嵌入环境里设置了这个变量，通过 `defaultSpawnChannelFactory` 创建的 ACP 子进程可能在会话本身没有请求 bare mode 的情况下静默丢失 skills。

## Reviewer Test Plan

### 如何验证

运行 focused `spawnChannel` 测试，确认生产 spawn factory 传给 child 的 env 不包含 `QWEN_CODE_SIMPLE` 或 `QWEN_SERVER_TOKEN`，包括 overrides 试图重新加入这些变量的情况。

### 前后证据

N/A - 这是非 UI 的 child-process env hardening，由单元测试覆盖。

### 本地验证

- `npx vitest run src/spawnChannel.test.ts` from `packages/acp-bridge`
- `npx prettier --check packages/acp-bridge/src/spawnChannel.ts packages/acp-bridge/src/spawnChannel.test.ts`
- `npx eslint packages/acp-bridge/src/spawnChannel.ts packages/acp-bridge/src/spawnChannel.test.ts`
- `npm run typecheck --workspace=packages/acp-bridge`
- `npm run build --workspace=packages/core`
- `npm run build --workspace=packages/acp-bridge`
- `git diff --check`

## 风险和范围

- 主要风险/取舍：低；只影响 daemon bridge 创建的 ACP 子进程，并保留 direct `qwen --acp` 显式调用语义。
- 未验证/不在范围内：Zed 或其他直接启动 `qwen --acp` 的客户端。这个 PR 只是针对 daemon-spawned ACP child 的窄 hardening。
- 破坏性变更/迁移说明：预期无。若用户确实想让 daemon-spawned child 进入 bare mode，未来需要通过安全的显式 API 支持；当前 scrubbed keys 不能通过 overrides 重新引入是有意行为。

## 关联 Issue

Refs #5007

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
