### PR TITLE
fix(core): add GLM-5.2 to Z.AI preset

### DIFF
--- a/packages/core/src/core/tokenLimits.test.ts
+++ b/packages/core/src/core/tokenLimits.test.ts
@@ -335,7 +335,11 @@ describe('tokenLimit with output type', () => {
     });
 
     it('should return correct output limits for GLM', () => {
-      expect(tokenLimit('glm-5', 'output')).toBe(16384);
+      expect(tokenLimit('glm-5.2', 'output')).toBe(131072);
+      expect(tokenLimit('GLM-5.2', 'output')).toBe(131072);
+      expect(tokenLimit('glm-5.1', 'output')).toBe(131072);
+      expect(tokenLimit('glm-5', 'output')).toBe(131072);
+      expect(tokenLimit('glm-5-turbo', 'output')).toBe(131072);
       expect(tokenLimit('glm-4.7', 'output')).toBe(16384);
     });
 

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -189,7 +189,7 @@ const OUTPUT_PATTERNS: Array<[RegExp, TokenCount]> = [
   [/^deepseek-chat/, LIMITS['8k']],
 
   // Zhipu GLM
-  [/^glm-5/, LIMITS['16k']],
+  [/^glm-5(?:\.\d+)?(?:-|$)/, LIMITS['128k']],
   [/^glm-4\.7/, LIMITS['16k']],
 
   // MiniMax

--- a/packages/core/src/providers/__tests__/presets/zai.test.ts
+++ b/packages/core/src/providers/__tests__/presets/zai.test.ts
@@ -32,12 +32,20 @@ describe('zaiProvider', () => {
     const plan = buildInstallPlan(zaiProvider, {
       baseUrl: 'https://api.z.ai/api/coding/paas/v4',
       apiKey: 'sk-zai',
-      modelIds: ['GLM-5.1', 'GLM-5'],
+      modelIds: ['GLM-5.2', 'GLM-5.1', 'GLM-5'],
     });
 
     const models = plan.modelProviders?.[0]?.models;
-    expect(models).toHaveLength(2);
+    expect(models).toHaveLength(3);
     expect(models?.[0]).toMatchObject({
+      id: 'GLM-5.2',
+      name: '[Z.AI] GLM-5.2',
+      generationConfig: {
+        contextWindowSize: 1000000,
+        extra_body: { enable_thinking: true },
+      },
+    });
+    expect(models?.[1]).toMatchObject({
       id: 'GLM-5.1',
       name: '[Z.AI] GLM-5.1',
       generationConfig: {
@@ -45,7 +53,7 @@ describe('zaiProvider', () => {
         extra_body: { enable_thinking: true },
       },
     });
-    expect(models?.[1]).toMatchObject({
+    expect(models?.[2]).toMatchObject({
       id: 'GLM-5',
       generationConfig: { contextWindowSize: 204800 },
     });

--- a/packages/core/src/providers/presets/zai.ts
+++ b/packages/core/src/providers/presets/zai.ts
@@ -28,6 +28,7 @@ export const zaiProvider: ProviderConfig = {
   ],
   envKey: 'ZAI_API_KEY',
   models: [
+    { id: 'GLM-5.2', contextWindowSize: 1000000, enableThinking: true },
     { id: 'GLM-5.1', contextWindowSize: 204800, enableThinking: true },
     { id: 'GLM-5', contextWindowSize: 204800 },
     { id: 'GLM-5-Turbo', contextWindowSize: 204800 },


### PR DESCRIPTION
## What this PR does

Adds GLM-5.2 to the Z.AI provider preset with a 1M context window and thinking enabled. It also updates GLM-5-family output-token detection so GLM-5, GLM-5.1, GLM-5.2, and GLM-5-* variants use the documented 128K output limit.

## Why it's needed

Z.AI exposes GLM-5.2, but the provider install preset did not include it yet, so users had to add the model manually. The token-limit table also still treated the GLM-5 family as 16K output, which is too low for the current GLM-5 docs.

## Reviewer Test Plan

### How to verify

Confirm the Z.AI preset includes GLM-5.2 with a 1,000,000-token context window and `enable_thinking` enabled. Also confirm `tokenLimits` returns 131072 output tokens for GLM-5, GLM-5.1, GLM-5.2, and GLM-5-* model ids without matching unrelated ids like GLM-4.7.

### Evidence (Before & After)

Before: GLM-5.2 was missing from the Z.AI preset, and GLM-5-family output tokens were capped at 16K.

After: the preset includes GLM-5.2, and the focused tests cover the 128K GLM-5-family output limit.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Local validation from this branch:

- `npx vitest run --coverage.enabled=false src/providers/__tests__/presets/zai.test.ts src/core/tokenLimits.test.ts`
- `npx vitest run --coverage.enabled=false src/core/tokenLimits.test.ts`
- `npx prettier --check packages/core/src/providers/presets/zai.ts packages/core/src/providers/__tests__/presets/zai.test.ts packages/core/src/core/tokenLimits.ts packages/core/src/core/tokenLimits.test.ts`
- `npx eslint packages/core/src/providers/presets/zai.ts packages/core/src/providers/__tests__/presets/zai.test.ts packages/core/src/core/tokenLimits.ts packages/core/src/core/tokenLimits.test.ts`
- `npm run typecheck --workspace=packages/core`
- `npm run build --workspace=packages/core`
- `git diff --check`

## Risk & Scope

- Main risk or tradeoff: the GLM-5-family output limit changes from 16K to 128K, based on the current Z.AI model docs.
- Not validated / out of scope: no runtime call was made against the hosted Z.AI API.
- Breaking changes / migration notes: none expected.

## Linked Issues

Fixes #5393

<details>
<summary>中文说明</summary>

## What this PR does

给 Z.AI provider preset 增加 GLM-5.2，配置 1M 上下文窗口并启用 thinking。同时更新 GLM-5 系列的输出 token 检测，让 GLM-5、GLM-5.1、GLM-5.2 和 GLM-5-* 变体使用文档里的 128K 输出上限。

## Why it's needed

Z.AI 已经提供 GLM-5.2，但 provider 安装 preset 里还没有这个模型，用户只能手动添加。token limit 表里 GLM-5 系列也还按 16K 输出处理，低于当前 GLM-5 文档里的上限。

## Reviewer Test Plan

### How to verify

确认 Z.AI preset 里包含 GLM-5.2，context window 是 1,000,000，并且启用了 `enable_thinking`。同时确认 `tokenLimits` 对 GLM-5、GLM-5.1、GLM-5.2 和 GLM-5-* model id 返回 131072 输出 token，且不会误匹配 GLM-4.7 这类无关 id。

### Evidence (Before & After)

Before: Z.AI preset 里没有 GLM-5.2，GLM-5 系列输出 token 上限是 16K。

After: preset 包含 GLM-5.2，相关测试覆盖了 GLM-5 系列 128K 输出上限。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

本地在当前分支跑过这些验证：

- `npx vitest run --coverage.enabled=false src/providers/__tests__/presets/zai.test.ts src/core/tokenLimits.test.ts`
- `npx vitest run --coverage.enabled=false src/core/tokenLimits.test.ts`
- `npx prettier --check packages/core/src/providers/presets/zai.ts packages/core/src/providers/__tests__/presets/zai.test.ts packages/core/src/core/tokenLimits.ts packages/core/src/core/tokenLimits.test.ts`
- `npx eslint packages/core/src/providers/presets/zai.ts packages/core/src/providers/__tests__/presets/zai.test.ts packages/core/src/core/tokenLimits.ts packages/core/src/core/tokenLimits.test.ts`
- `npm run typecheck --workspace=packages/core`
- `npm run build --workspace=packages/core`
- `git diff --check`

## Risk & Scope

- Main risk or tradeoff: GLM-5 系列输出上限从 16K 调到 128K，依据是当前 Z.AI 模型文档。
- Not validated / out of scope: 没有直接调用线上 Z.AI API。
- Breaking changes / migration notes: 预计没有。

## Linked Issues

Fixes #5393

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
