### PR TITLE
fix(cli): clarify cumulative statusline token labels

### DIFF
--- a/docs/users/features/status-line.md
+++ b/docs/users/features/status-line.md
@@ -88,8 +88,8 @@ Add a `statusLine` object under the `ui` key in `~/.qwen/settings.json`:
 | `model`                |         | Current model name without reasoning level                         |
 | `git-branch`           | Yes     | Current Git branch name (hidden when not in a git repo)            |
 | `context-remaining`    | Yes     | Percentage of context window remaining (e.g. `Context 65.7% left`) |
-| `total-input-tokens`   |         | Total input tokens used in session (e.g. `30.0k in`)               |
-| `total-output-tokens`  |         | Total output tokens used in session (e.g. `5.0k out`)              |
+| `total-input-tokens`   |         | Cumulative input tokens used in session (e.g. `30.0k total in`)    |
+| `total-output-tokens`  |         | Cumulative output tokens used in session (e.g. `5.0k total out`)   |
 | `current-dir`          | Yes     | Current working directory                                          |
 | `project-name`         |         | Project name (basename of working directory)                       |
 | `pull-request-number`  |         | Open PR number for the current branch (requires `gh` CLI)          |
@@ -102,6 +102,8 @@ Add a `statusLine` object under the `ui` key in `~/.qwen/settings.json`:
 | `session-id`           |         | Current session identifier                                         |
 
 Items marked **Default** are pre-selected when you first open the `/statusline` dialog.
+
+`total-input-tokens` and `total-output-tokens` are session totals. They add up token usage across turns, so input tokens can grow quickly because each new model request includes the current conversation context again. Use `used-tokens` when you want the current prompt size instead of cumulative session spend.
 
 ### Example output
 

--- a/packages/cli/src/ui/statusLinePresets.test.ts
+++ b/packages/cli/src/ui/statusLinePresets.test.ts
@@ -163,7 +163,7 @@ describe('statusLinePresets', () => {
         data,
       ),
     ).toEqual([
-      'qwen3-code-plus high | qwen3-code-plus | feature/pr-4087-statusline | Context 75% left | 1.2k in | 340 out | /repo/project | project | #4087 | +12 -3 | Context 25% used | Ready | v1.2.3 | 1.0k window | 250 used | session-123',
+      'qwen3-code-plus high | qwen3-code-plus | feature/pr-4087-statusline | Context 75% left | 1.2k total in | 340 total out | /repo/project | project | #4087 | +12 -3 | Context 25% used | Ready | v1.2.3 | 1.0k window | 250 used | session-123',
     ]);
   });
 

--- a/packages/cli/src/ui/statusLinePresets.ts
+++ b/packages/cli/src/ui/statusLinePresets.ts
@@ -406,10 +406,10 @@ export function buildStatusLinePresetParts(
         }
         break;
       case 'total-input-tokens':
-        parts.push(`${formatTokenCount(data.totalInputTokens)} in`);
+        parts.push(`${formatTokenCount(data.totalInputTokens)} total in`);
         break;
       case 'total-output-tokens':
-        parts.push(`${formatTokenCount(data.totalOutputTokens)} out`);
+        parts.push(`${formatTokenCount(data.totalOutputTokens)} total out`);
         break;
       case 'session-id':
         if (data.sessionId) {


### PR DESCRIPTION
## What this PR does

Clarifies the preset status line labels for cumulative token counters:

- `total-input-tokens` now renders as `total in`
- `total-output-tokens` now renders as `total out`
- the status line docs now explicitly distinguish session totals from the current prompt size shown by `used-tokens`

## Why it's needed

The old `in` / `out` labels were easy to read as per-message token counts. They are actually session-cumulative totals, so the numbers can grow quickly as the conversation history is resent across turns. This PR makes that visible without changing the underlying token calculation.

## Reviewer Test Plan

### How to verify

Enable `total-input-tokens`, `total-output-tokens`, and `used-tokens` in preset status line mode. Confirm cumulative counters render with `total in` / `total out`, while `used-tokens` still renders the current prompt size as `used`.

### Evidence (Before & After)

Before: `1.2k in | 340 out | 250 used`

After: `1.2k total in | 340 total out | 250 used`

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Local validation from this branch:

- `npx prettier --check packages/cli/src/ui/statusLinePresets.ts packages/cli/src/ui/statusLinePresets.test.ts docs/users/features/status-line.md`
- `npx vitest run --coverage.enabled=false src/ui/statusLinePresets.test.ts` in `packages/cli`
- `npx eslint packages/cli/src/ui/statusLinePresets.ts packages/cli/src/ui/statusLinePresets.test.ts`
- `git diff --check`

## Risk & Scope

- Main risk or tradeoff: this changes the visible label text for users who enabled these optional preset items.
- Not validated / out of scope: no changes to token accounting, aggregation, or context percentage calculation.
- Breaking changes / migration notes: none expected.

## Linked Issues

Refs #4951

<details>
<summary>中文说明</summary>

## What this PR does

澄清 preset status line 里的累计 token 计数标签：

- `total-input-tokens` 现在显示为 `total in`
- `total-output-tokens` 现在显示为 `total out`
- status line 文档明确区分 session 累计值，以及 `used-tokens` 显示的当前 prompt 大小

## Why it's needed

旧的 `in` / `out` 很容易被误读成单条消息的 token 数。它们实际是当前 session 的累计值，所以随着每轮重新发送对话历史，数字会涨得很快。这个 PR 只让含义更清楚，不改底层 token 计算。

## Reviewer Test Plan

### How to verify

在 preset status line 模式里启用 `total-input-tokens`、`total-output-tokens` 和 `used-tokens`。确认累计计数显示为 `total in` / `total out`，而 `used-tokens` 仍显示当前 prompt 大小的 `used`。

### Evidence (Before & After)

Before: `1.2k in | 340 out | 250 used`

After: `1.2k total in | 340 total out | 250 used`

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

本地在当前分支跑过这些验证：

- `npx prettier --check packages/cli/src/ui/statusLinePresets.ts packages/cli/src/ui/statusLinePresets.test.ts docs/users/features/status-line.md`
- `npx vitest run --coverage.enabled=false src/ui/statusLinePresets.test.ts` in `packages/cli`
- `npx eslint packages/cli/src/ui/statusLinePresets.ts packages/cli/src/ui/statusLinePresets.test.ts`
- `git diff --check`

## Risk & Scope

- Main risk or tradeoff: 对启用了这些可选 preset item 的用户，可见标签文字会变化。
- Not validated / out of scope: 不修改 token 统计、聚合或 context percentage 计算。
- Breaking changes / migration notes: 预计没有。

## Linked Issues

Refs #4951

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
