### PR TITLE
fix(cli): calculate response rate from phase token delta

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -304,6 +304,8 @@ describe('AppContainer State Management', () => {
       thought: null,
       cancelOngoingRequest: vi.fn(),
       retryLastPrompt: vi.fn(),
+      streamingResponseLengthRef: { current: 0 },
+      isReceivingContent: false,
     });
     mockedUseVim.mockReturnValue({ handleInput: vi.fn() });
     mockedUseFolderTrust.mockReturnValue({
@@ -351,6 +353,8 @@ describe('AppContainer State Management', () => {
     mockedUseLoadingIndicator.mockReturnValue({
       elapsedTime: '0.0s',
       currentLoadingPhrase: '',
+      taskStartTokens: 0,
+      taskStartStreamingChars: 0,
     });
     mockedUseTerminalSize.mockReturnValue({ columns: 80, rows: 24 });
 
@@ -828,6 +832,8 @@ describe('AppContainer State Management', () => {
         thought: null,
         cancelOngoingRequest: vi.fn(),
         retryLastPrompt: vi.fn(),
+        streamingResponseLengthRef: { current: 0 },
+        isReceivingContent: false,
       });
       mockedUseMessageQueue.mockReturnValue({
         messageQueue: [],
@@ -866,6 +872,8 @@ describe('AppContainer State Management', () => {
         thought: null,
         cancelOngoingRequest: vi.fn(),
         retryLastPrompt: vi.fn(),
+        streamingResponseLengthRef: { current: 0 },
+        isReceivingContent: false,
       });
       mockedUseMessageQueue.mockReturnValue({
         messageQueue: [],
@@ -969,7 +977,11 @@ describe('AppContainer State Management', () => {
         if (typeof candidate === 'function') {
           capturedOnCancelSubmit = candidate as CapturedCancelSubmit;
         }
-        return streamReturnValue;
+        return {
+          ...streamReturnValue,
+          streamingResponseLengthRef: { current: 0 },
+          isReceivingContent: false,
+        };
       });
     };
 
@@ -2293,6 +2305,8 @@ describe('AppContainer State Management', () => {
         thought: { subject: thoughtSubject },
         cancelOngoingRequest: vi.fn(),
         retryLastPrompt: vi.fn(),
+        streamingResponseLengthRef: { current: 0 },
+        isReceivingContent: false,
       });
 
       // Act: Render the container
@@ -2337,6 +2351,8 @@ describe('AppContainer State Management', () => {
         thought: null,
         cancelOngoingRequest: vi.fn(),
         retryLastPrompt: vi.fn(),
+        streamingResponseLengthRef: { current: 0 },
+        isReceivingContent: false,
       });
 
       // Act: Render the container
@@ -2382,6 +2398,8 @@ describe('AppContainer State Management', () => {
         thought: { subject: thoughtSubject },
         cancelOngoingRequest: vi.fn(),
         retryLastPrompt: vi.fn(),
+        streamingResponseLengthRef: { current: 0 },
+        isReceivingContent: false,
       });
 
       // Act: Render the container
@@ -2427,6 +2445,8 @@ describe('AppContainer State Management', () => {
         thought: { subject: shortTitle },
         cancelOngoingRequest: vi.fn(),
         retryLastPrompt: vi.fn(),
+        streamingResponseLengthRef: { current: 0 },
+        isReceivingContent: false,
       });
 
       // Act: Render the container
@@ -2477,6 +2497,8 @@ describe('AppContainer State Management', () => {
         thought: { subject: title },
         cancelOngoingRequest: vi.fn(),
         retryLastPrompt: vi.fn(),
+        streamingResponseLengthRef: { current: 0 },
+        isReceivingContent: false,
       });
 
       // Act: Render the container
@@ -2524,6 +2546,8 @@ describe('AppContainer State Management', () => {
         thought: null,
         cancelOngoingRequest: vi.fn(),
         retryLastPrompt: vi.fn(),
+        streamingResponseLengthRef: { current: 0 },
+        isReceivingContent: false,
       });
 
       // Act: Render the container
@@ -2587,6 +2611,8 @@ describe('AppContainer State Management', () => {
         thought: null,
         cancelOngoingRequest: vi.fn(),
         retryLastPrompt: vi.fn(),
+        streamingResponseLengthRef: { current: 0 },
+        isReceivingContent: false,
       });
 
       const { unmount } = render(
@@ -2679,6 +2705,8 @@ describe('AppContainer State Management', () => {
         thought: null,
         cancelOngoingRequest: vi.fn(),
         retryLastPrompt: vi.fn(),
+        streamingResponseLengthRef: { current: 0 },
+        isReceivingContent: false,
       });
 
       const { unmount } = render(
@@ -2793,6 +2821,8 @@ describe('AppContainer State Management', () => {
         cancelOngoingRequest: vi.fn(),
         retryLastPrompt: vi.fn(),
         activePtyId: 'some-id',
+        streamingResponseLengthRef: { current: 0 },
+        isReceivingContent: false,
       });
 
       render(
@@ -3022,6 +3052,8 @@ describe('AppContainer State Management', () => {
         thought: null,
         cancelOngoingRequest: mockCancelOngoingRequest,
         retryLastPrompt: vi.fn(),
+        streamingResponseLengthRef: { current: 0 },
+        isReceivingContent: false,
       });
 
       const mockHandleSlashCommand = vi.fn();
@@ -3099,6 +3131,8 @@ describe('AppContainer State Management', () => {
         thought: null,
         cancelOngoingRequest: vi.fn(),
         retryLastPrompt: vi.fn(),
+        streamingResponseLengthRef: { current: 0 },
+        isReceivingContent: false,
       });
 
       render(
@@ -3153,6 +3187,8 @@ describe('AppContainer State Management', () => {
         thought: null,
         cancelOngoingRequest: vi.fn(),
         retryLastPrompt: vi.fn(),
+        streamingResponseLengthRef: { current: 0 },
+        isReceivingContent: false,
       });
 
       render(
@@ -3212,6 +3248,8 @@ describe('AppContainer State Management', () => {
         thought: null,
         cancelOngoingRequest: vi.fn(),
         retryLastPrompt: vi.fn(),
+        streamingResponseLengthRef: { current: 0 },
+        isReceivingContent: false,
       });
 
       render(
@@ -3804,6 +3842,8 @@ describe('AppContainer State Management', () => {
         thought: null,
         cancelOngoingRequest: vi.fn(),
         retryLastPrompt: vi.fn(),
+        streamingResponseLengthRef: { current: 0 },
+        isReceivingContent: false,
       });
       vi.spyOn(mockConfig, 'getIdeMode').mockReturnValue(true);
 
@@ -3846,6 +3886,8 @@ describe('AppContainer State Management', () => {
         thought: null,
         cancelOngoingRequest: vi.fn(),
         retryLastPrompt: vi.fn(),
+        streamingResponseLengthRef: { current: 0 },
+        isReceivingContent: false,
       });
       vi.spyOn(mockConfig, 'getIdeMode').mockReturnValue(false);
 

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -258,6 +258,34 @@ function isToolExecuting(pendingHistoryItems: HistoryItemWithoutId[]) {
   });
 }
 
+function getResponseCandidateTokens(
+  pendingGeminiHistoryItems: HistoryItemWithoutId[],
+): number {
+  let tokens = 0;
+
+  for (const item of pendingGeminiHistoryItems) {
+    if (item.type !== 'tool_group') {
+      continue;
+    }
+
+    for (const tool of item.tools) {
+      const display = tool.resultDisplay;
+      if (
+        typeof display === 'object' &&
+        display !== null &&
+        'type' in display &&
+        display.type === 'task_execution' &&
+        'tokenCount' in display &&
+        typeof display.tokenCount === 'number'
+      ) {
+        tokens += display.tokenCount;
+      }
+    }
+  }
+
+  return tokens;
+}
+
 function useStableStickyTodos(todos: TodoItem[] | null): TodoItem[] | null {
   const renderKey = getStickyTodosRenderKey(todos);
   const stableTodosRef = useRef<{
@@ -2837,16 +2865,21 @@ export const AppContainer = (props: AppContainerProps) => {
     [historyManager, setShowCommandMigrationNudge, config.storage],
   );
 
-  const currentCandidatesTokens = Object.values(
-    sessionStats.metrics?.models ?? {},
-  ).reduce((acc, model) => acc + (model.tokens?.candidates ?? 0), 0);
+  const responseCandidateTokens = getResponseCandidateTokens(
+    pendingGeminiHistoryItems,
+  );
 
-  const { elapsedTime, currentLoadingPhrase, taskStartTokens } =
-    useLoadingIndicator(
-      streamingState,
-      settings.merged.ui?.customWittyPhrases,
-      currentCandidatesTokens,
-    );
+  const {
+    elapsedTime,
+    currentLoadingPhrase,
+    taskStartTokens,
+    taskStartStreamingChars,
+  } = useLoadingIndicator(
+    streamingState,
+    settings.merged.ui?.customWittyPhrases,
+    responseCandidateTokens,
+    streamingResponseLengthRef.current,
+  );
 
   useAttentionNotifications({
     isFocused,
@@ -3441,6 +3474,8 @@ export const AppContainer = (props: AppContainerProps) => {
       isFeedbackDialogOpen,
       // Per-task token tracking
       taskStartTokens,
+      taskStartStreamingChars,
+      responseCandidateTokens,
       // Real-time token display
       streamingResponseLengthRef,
       isReceivingContent,
@@ -3574,6 +3609,8 @@ export const AppContainer = (props: AppContainerProps) => {
       isFeedbackDialogOpen,
       // Per-task token tracking
       taskStartTokens,
+      taskStartStreamingChars,
+      responseCandidateTokens,
       // Real-time token display
       streamingResponseLengthRef,
       isReceivingContent,

--- a/packages/cli/src/ui/components/Composer.test.tsx
+++ b/packages/cli/src/ui/components/Composer.test.tsx
@@ -38,14 +38,25 @@ import { StreamingState } from '../types.js';
 vi.mock('./LoadingIndicator.js', () => ({
   LoadingIndicator: ({
     currentLoadingPhrase,
+    candidatesTokens,
+    taskStartTokens,
+    taskStartStreamingChars,
     showResponseTokensPerSecond,
   }: {
     currentLoadingPhrase?: string;
+    candidatesTokens?: number;
+    taskStartTokens?: number;
+    taskStartStreamingChars?: number;
     showResponseTokensPerSecond?: boolean;
   }) => (
     <Text>
       LoadingIndicator
       {currentLoadingPhrase ? `: ${currentLoadingPhrase}` : ''}
+      {typeof candidatesTokens === 'number' ? `: ${candidatesTokens}` : ''}
+      {typeof taskStartTokens === 'number' ? `: start ${taskStartTokens}` : ''}
+      {typeof taskStartStreamingChars === 'number'
+        ? `: chars ${taskStartStreamingChars}`
+        : ''}
       {showResponseTokensPerSecond ? ': show t/s' : ''}
     </Text>
   ),
@@ -132,6 +143,8 @@ const createMockUIState = (overrides: Partial<UIState> = {}): UIState =>
     nightly: false,
     isTrustedFolder: true,
     taskStartTokens: 0,
+    taskStartStreamingChars: 0,
+    responseCandidateTokens: 0,
     streamingResponseLengthRef: { current: 0 },
     isReceivingContent: false,
     pendingGeminiHistoryItems: [],
@@ -209,6 +222,9 @@ describe('Composer', () => {
       const uiState = createMockUIState({
         streamingState: StreamingState.Responding,
         currentLoadingPhrase: 'Analyzing',
+        responseCandidateTokens: 550,
+        taskStartTokens: 500,
+        taskStartStreamingChars: 200,
       });
       const config = createMockConfig({
         getShowResponseTokensPerSecond: vi.fn(() => true),
@@ -216,7 +232,9 @@ describe('Composer', () => {
 
       const { lastFrame } = renderComposer(uiState, config);
 
-      expect(lastFrame()).toContain('LoadingIndicator: Analyzing: show t/s');
+      expect(lastFrame()).toContain('LoadingIndicator: Analyzing');
+      expect(lastFrame()).toContain(': 550: start 500: chars 200');
+      expect(lastFrame()).toContain(': show t/s');
     });
 
     // ─── Narrow-terminal suppression (suppressBottomLoadingIndicator) ───

--- a/packages/cli/src/ui/components/Composer.tsx
+++ b/packages/cli/src/ui/components/Composer.tsx
@@ -16,7 +16,7 @@ import { useUIActions } from '../contexts/UIActionsContext.js';
 import { useVimModeState } from '../contexts/VimModeContext.js';
 import { useConfig } from '../contexts/ConfigContext.js';
 import { theme } from '../semantic-colors.js';
-import { StreamingState, type HistoryItemToolGroup } from '../types.js';
+import { StreamingState } from '../types.js';
 import { FeedbackDialog } from '../FeedbackDialog.js';
 import { t } from '../../i18n/index.js';
 
@@ -31,6 +31,9 @@ export const Composer = () => {
     showAutoAcceptIndicator,
     streamingResponseLengthRef,
     isReceivingContent,
+    responseCandidateTokens,
+    taskStartTokens,
+    taskStartStreamingChars,
   } = uiState;
 
   // Real-time token animation is performed inside LoadingIndicator itself, so
@@ -46,28 +49,6 @@ export const Composer = () => {
   const suppressBottomLoadingIndicator =
     uiState.streamingState === StreamingState.Responding &&
     uiState.terminalWidth <= 30;
-
-  // Aggregate agent tool tokens from executing tool calls. Only changes when
-  // a subagent reports progress, so it doesn't drive the animation loop.
-  let agentTokens = 0;
-  for (const item of uiState.pendingGeminiHistoryItems ?? []) {
-    if (item.type === 'tool_group') {
-      const toolGroup = item as HistoryItemToolGroup;
-      for (const tool of toolGroup.tools) {
-        const display = tool.resultDisplay;
-        if (
-          typeof display === 'object' &&
-          display !== null &&
-          'type' in display &&
-          display.type === 'task_execution' &&
-          'tokenCount' in display &&
-          typeof display.tokenCount === 'number'
-        ) {
-          agentTokens += display.tokenCount;
-        }
-      }
-    }
-  }
 
   // State for keyboard shortcuts display toggle
   const [showShortcuts, setShowShortcuts] = useState(false);
@@ -103,7 +84,9 @@ export const Composer = () => {
               : uiState.currentLoadingPhrase
           }
           elapsedTime={uiState.elapsedTime}
-          candidatesTokens={agentTokens}
+          candidatesTokens={responseCandidateTokens}
+          taskStartTokens={taskStartTokens}
+          taskStartStreamingChars={taskStartStreamingChars}
           streamingCharsRef={streamingResponseLengthRef}
           isStreaming={isStreaming}
           showResponseTokensPerSecond={config.getShowResponseTokensPerSecond()}

--- a/packages/cli/src/ui/components/LoadingIndicator.test.tsx
+++ b/packages/cli/src/ui/components/LoadingIndicator.test.tsx
@@ -349,6 +349,27 @@ describe('<LoadingIndicator />', () => {
       expect(output).toContain('100 t/s');
     });
 
+    it('should calculate response tokens/sec from tokens produced after the timer reset', () => {
+      const streamingCharsRef = { current: 400 };
+      const { lastFrame } = renderWithContext(
+        <LoadingIndicator
+          {...defaultProps}
+          candidatesTokens={550}
+          taskStartTokens={500}
+          taskStartStreamingChars={200}
+          streamingCharsRef={streamingCharsRef}
+          isStreaming
+          showResponseTokensPerSecond
+        />,
+        StreamingState.Responding,
+        120,
+      );
+      const output = lastFrame();
+      expect(output).toContain('↓ 650 tokens');
+      expect(output).toContain('20 t/s');
+      expect(output).not.toContain('130 t/s');
+    });
+
     it('should format sub-10 response tokens/sec with one decimal place', () => {
       const { lastFrame } = renderWithContext(
         <LoadingIndicator

--- a/packages/cli/src/ui/components/LoadingIndicator.tsx
+++ b/packages/cli/src/ui/components/LoadingIndicator.tsx
@@ -22,6 +22,8 @@ interface LoadingIndicatorProps {
   elapsedTime: number;
   rightContent?: React.ReactNode;
   candidatesTokens?: number;
+  taskStartTokens?: number;
+  taskStartStreamingChars?: number;
   /**
    * Live-updating character counter for the streaming response. When provided
    * together with `isStreaming`, the indicator animates a token estimate
@@ -46,6 +48,8 @@ export const LoadingIndicator: React.FC<LoadingIndicatorProps> = ({
   elapsedTime,
   rightContent,
   candidatesTokens,
+  taskStartTokens = 0,
+  taskStartStreamingChars = 0,
   streamingCharsRef,
   isStreaming,
   showResponseTokensPerSecond = false,
@@ -76,6 +80,13 @@ export const LoadingIndicator: React.FC<LoadingIndicatorProps> = ({
 
   const streamingTokens = streamingCharsRef ? Math.round(animatedChars / 4) : 0;
   const outputTokens = (candidatesTokens ?? 0) + streamingTokens;
+  const taskStartStreamingTokens = streamingCharsRef
+    ? Math.round(taskStartStreamingChars / 4)
+    : 0;
+  const outputTokensSinceTimerStart = Math.max(
+    0,
+    outputTokens - taskStartTokens - taskStartStreamingTokens,
+  );
   const showTokens = !isNarrow && outputTokens > 0;
   const tokenArrow = isReceivingContent ? '↓' : '↑';
 
@@ -90,7 +101,7 @@ export const LoadingIndicator: React.FC<LoadingIndicatorProps> = ({
     showResponseTokensPerSecond &&
     isReceivingContent &&
     elapsedTime > 0
-      ? ` · ${formatTokensPerSecond(outputTokens / elapsedTime)}`
+      ? ` · ${formatTokensPerSecond(outputTokensSinceTimerStart / elapsedTime)}`
       : '';
 
   const cancelAndTimerContent =

--- a/packages/cli/src/ui/components/MainContent.test.tsx
+++ b/packages/cli/src/ui/components/MainContent.test.tsx
@@ -220,6 +220,8 @@ const createUIState = (overrides: Partial<UIState> = {}): UIState =>
     isHooksDialogOpen: false,
     isFeedbackDialogOpen: false,
     taskStartTokens: 0,
+    taskStartStreamingChars: 0,
+    responseCandidateTokens: 0,
     streamingResponseLengthRef: { current: 0 },
     isReceivingContent: false,
     sessionName: null,

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -177,6 +177,8 @@ export interface UIState {
   isFeedbackDialogOpen: boolean;
   // Per-task token tracking
   taskStartTokens: number;
+  taskStartStreamingChars: number;
+  responseCandidateTokens: number;
   // Real-time token display: ref to streaming output char length (polled, not state)
   streamingResponseLengthRef: React.RefObject<number>;
   // True = receiving content (↓), false = waiting for API response (↑)

--- a/packages/cli/src/ui/hooks/useLoadingIndicator.test.ts
+++ b/packages/cli/src/ui/hooks/useLoadingIndicator.test.ts
@@ -137,44 +137,51 @@ describe('useLoadingIndicator', () => {
   describe('token tracking', () => {
     it('should capture token snapshot when task starts', () => {
       const { result, rerender } = renderHook(
-        ({ streamingState, currentCandidatesTokens }) =>
+        ({ streamingState, currentCandidatesTokens, currentStreamingChars }) =>
           useLoadingIndicator(
             streamingState,
             undefined,
             currentCandidatesTokens,
+            currentStreamingChars,
           ),
         {
           initialProps: {
             streamingState: StreamingState.Idle,
             currentCandidatesTokens: 100,
+            currentStreamingChars: 400,
           },
         },
       );
 
       expect(result.current.taskStartTokens).toBe(0);
+      expect(result.current.taskStartStreamingChars).toBe(0);
 
       act(() => {
         rerender({
           streamingState: StreamingState.Responding,
           currentCandidatesTokens: 100,
+          currentStreamingChars: 400,
         });
       });
 
       expect(result.current.taskStartTokens).toBe(100);
+      expect(result.current.taskStartStreamingChars).toBe(400);
     });
 
     it('should reset token snapshot when transitioning from Responding to Idle', async () => {
       const { result, rerender } = renderHook(
-        ({ streamingState, currentCandidatesTokens }) =>
+        ({ streamingState, currentCandidatesTokens, currentStreamingChars }) =>
           useLoadingIndicator(
             streamingState,
             undefined,
             currentCandidatesTokens,
+            currentStreamingChars,
           ),
         {
           initialProps: {
             streamingState: StreamingState.Idle,
             currentCandidatesTokens: 0,
+            currentStreamingChars: 0,
           },
         },
       );
@@ -183,15 +190,18 @@ describe('useLoadingIndicator', () => {
         rerender({
           streamingState: StreamingState.Responding,
           currentCandidatesTokens: 0,
+          currentStreamingChars: 0,
         });
       });
       expect(result.current.taskStartTokens).toBe(0);
+      expect(result.current.taskStartStreamingChars).toBe(0);
 
       await act(async () => {
         await vi.advanceTimersByTimeAsync(1000);
         rerender({
           streamingState: StreamingState.Responding,
           currentCandidatesTokens: 500,
+          currentStreamingChars: 2000,
         });
       });
 
@@ -199,35 +209,41 @@ describe('useLoadingIndicator', () => {
         rerender({
           streamingState: StreamingState.Idle,
           currentCandidatesTokens: 500,
+          currentStreamingChars: 2000,
         });
       });
 
       expect(result.current.taskStartTokens).toBe(0);
+      expect(result.current.taskStartStreamingChars).toBe(0);
     });
 
     it('should reset token snapshot when transitioning from WaitingForConfirmation to Responding', async () => {
       const { result, rerender } = renderHook(
-        ({ streamingState, currentCandidatesTokens }) =>
+        ({ streamingState, currentCandidatesTokens, currentStreamingChars }) =>
           useLoadingIndicator(
             streamingState,
             undefined,
             currentCandidatesTokens,
+            currentStreamingChars,
           ),
         {
           initialProps: {
             streamingState: StreamingState.Responding,
             currentCandidatesTokens: 100,
+            currentStreamingChars: 400,
           },
         },
       );
 
       expect(result.current.taskStartTokens).toBe(100);
+      expect(result.current.taskStartStreamingChars).toBe(400);
 
       await act(async () => {
         await vi.advanceTimersByTimeAsync(5000);
         rerender({
           streamingState: StreamingState.Responding,
           currentCandidatesTokens: 500,
+          currentStreamingChars: 2000,
         });
       });
 
@@ -235,6 +251,7 @@ describe('useLoadingIndicator', () => {
         rerender({
           streamingState: StreamingState.WaitingForConfirmation,
           currentCandidatesTokens: 500,
+          currentStreamingChars: 2000,
         });
       });
 
@@ -242,10 +259,12 @@ describe('useLoadingIndicator', () => {
         rerender({
           streamingState: StreamingState.Responding,
           currentCandidatesTokens: 500,
+          currentStreamingChars: 2000,
         });
       });
 
       expect(result.current.taskStartTokens).toBe(500);
+      expect(result.current.taskStartStreamingChars).toBe(2000);
     });
   });
 });

--- a/packages/cli/src/ui/hooks/useLoadingIndicator.ts
+++ b/packages/cli/src/ui/hooks/useLoadingIndicator.ts
@@ -13,6 +13,7 @@ export const useLoadingIndicator = (
   streamingState: StreamingState,
   customWittyPhrases?: string[],
   currentCandidatesTokens?: number,
+  currentStreamingChars?: number,
 ) => {
   const [timerResetKey, setTimerResetKey] = useState(0);
   const isTimerActive = streamingState === StreamingState.Responding;
@@ -29,6 +30,7 @@ export const useLoadingIndicator = (
 
   const [retainedElapsedTime, setRetainedElapsedTime] = useState(0);
   const [taskStartTokens, setTaskStartTokens] = useState(0);
+  const [taskStartStreamingChars, setTaskStartStreamingChars] = useState(0);
   const prevStreamingStateRef = useRef<StreamingState | null>(null);
 
   useEffect(() => {
@@ -39,6 +41,7 @@ export const useLoadingIndicator = (
       setTimerResetKey((prevKey) => prevKey + 1);
       setRetainedElapsedTime(0);
       setTaskStartTokens(currentCandidatesTokens ?? 0);
+      setTaskStartStreamingChars(currentStreamingChars ?? 0);
     } else if (
       streamingState === StreamingState.Idle &&
       prevStreamingStateRef.current === StreamingState.Responding
@@ -46,17 +49,24 @@ export const useLoadingIndicator = (
       setTimerResetKey((prevKey) => prevKey + 1);
       setRetainedElapsedTime(0);
       setTaskStartTokens(0);
+      setTaskStartStreamingChars(0);
     } else if (
       streamingState === StreamingState.Responding &&
       prevStreamingStateRef.current !== StreamingState.Responding
     ) {
       setTaskStartTokens(currentCandidatesTokens ?? 0);
+      setTaskStartStreamingChars(currentStreamingChars ?? 0);
     } else if (streamingState === StreamingState.WaitingForConfirmation) {
       setRetainedElapsedTime(elapsedTimeFromTimer);
     }
 
     prevStreamingStateRef.current = streamingState;
-  }, [streamingState, elapsedTimeFromTimer, currentCandidatesTokens]);
+  }, [
+    streamingState,
+    elapsedTimeFromTimer,
+    currentCandidatesTokens,
+    currentStreamingChars,
+  ]);
 
   return {
     elapsedTime:
@@ -65,5 +75,6 @@ export const useLoadingIndicator = (
         : elapsedTimeFromTimer,
     currentLoadingPhrase,
     taskStartTokens,
+    taskStartStreamingChars,
   };
 };


### PR DESCRIPTION
## What this PR does

Adjusts the optional response token-rate display added in #5401 so `t/s` is calculated from tokens produced after the current loading timer started.

The visible token count remains cumulative for the current turn. Only the speed calculation uses the phase-local delta, so the rate does not spike after a tool confirmation or tool-result continuation resets the timer.

## Why it's needed

Reviewer feedback on #5401 pointed out that `outputTokens / elapsedTime` can be inflated after `WaitingForConfirmation -> Responding`: token counters can keep accumulating across the turn while the loading timer resets for the new response phase.

This follow-up keeps the user-facing counter stable while making the speed hint match the same phase as the timer.

## Reviewer Test Plan

### How to verify

1. Enable `"showResponseTokensPerSecond": true` under `ui`.
2. Trigger a response that enters a tool-confirmation or tool-result continuation path.
3. Confirm the displayed token count continues to show cumulative turn output.
4. Confirm the `t/s` value is based on tokens generated since the timer reset, not the whole turn's accumulated token count.

Targeted validation commands run locally:

```bash
npx vitest run --coverage.enabled=false src/ui/components/MainContent.test.tsx src/ui/components/Composer.test.tsx src/ui/components/LoadingIndicator.test.tsx src/ui/hooks/useLoadingIndicator.test.ts src/config/settingsSchema.test.ts
npx eslint packages/cli/src/ui/AppContainer.tsx packages/cli/src/ui/AppContainer.test.tsx packages/cli/src/ui/components/MainContent.test.tsx packages/cli/src/ui/components/Composer.tsx packages/cli/src/ui/components/Composer.test.tsx packages/cli/src/ui/components/LoadingIndicator.tsx packages/cli/src/ui/components/LoadingIndicator.test.tsx packages/cli/src/ui/hooks/useLoadingIndicator.ts packages/cli/src/ui/hooks/useLoadingIndicator.test.ts packages/cli/src/ui/contexts/UIStateContext.tsx
npx prettier --check packages/cli/src/ui/AppContainer.tsx packages/cli/src/ui/AppContainer.test.tsx packages/cli/src/ui/components/MainContent.test.tsx packages/cli/src/ui/components/Composer.tsx packages/cli/src/ui/components/Composer.test.tsx packages/cli/src/ui/components/LoadingIndicator.tsx packages/cli/src/ui/components/LoadingIndicator.test.tsx packages/cli/src/ui/hooks/useLoadingIndicator.ts packages/cli/src/ui/hooks/useLoadingIndicator.test.ts packages/cli/src/ui/contexts/UIStateContext.tsx
git diff --check
```

### Evidence (Before & After)

Before: cumulative tokens could be divided by a freshly reset timer, so a continuation could briefly show an inflated value like `2500 t/s`.

After: the token count can still show cumulative output, but the rate is calculated from the token delta since the timer baseline. Unit coverage includes a `650 tokens` display that reports `20 t/s` instead of `130 t/s`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Local npm workspace checkout. Cross-platform coverage is left to the PR CI matrix.

## Risk & Scope

- Main risk or tradeoff: this threads two baseline values through the UI state so the displayed count and rate can intentionally use different scopes.
- Not validated / out of scope: full live TUI verification for the tool-confirmation path was not run locally.
- Breaking changes / migration notes: none. This only affects the opt-in `ui.showResponseTokensPerSecond` display.

Note: `AppContainer.test.tsx` is blocked in this local worktree by missing/conflicting generated workspace artifacts such as `@qwen-code/acp-bridge/eventBus` and core `dist` declaration outputs. The touched AppContainer code was covered by eslint, and the rendering/token-rate behavior is covered by targeted component and hook tests.

## Linked Issues

Follow-up to #5401.

<details>
<summary>中文说明</summary>

## What this PR does

调整 #5401 新增的可选响应 token 速率显示，让 `t/s` 基于当前 loading timer 启动之后产生的 token 增量计算。

可见 token 计数仍然保持当前 turn 的累计值。只有速度计算使用当前阶段的增量，因此在工具确认或 tool-result continuation 重置 timer 后，速率不会被累计 token 数放大。

## Why it's needed

#5401 的 reviewer 指出，`WaitingForConfirmation -> Responding` 之后，`outputTokens / elapsedTime` 可能被放大：token 计数会跨整个 turn 累计，但 loading timer 会为新的响应阶段重置。

这个 follow-up 保持用户看到的 token 计数不变，同时让速度提示和 timer 使用同一个阶段口径。

## Reviewer Test Plan

### How to verify

1. 在 `ui` 下开启 `"showResponseTokensPerSecond": true`。
2. 触发一个会进入工具确认或 tool-result continuation 的响应。
3. 确认显示的 token count 仍然是当前 turn 的累计输出。
4. 确认 `t/s` 基于 timer 重置后的新增 token 计算，而不是整个 turn 的累计 token。

本地已运行上方列出的定向验证命令。

### Evidence (Before & After)

修改前：累计 token 可能除以刚重置的 timer，continuation 时可能短暂显示类似 `2500 t/s` 的放大值。

修改后：token count 仍可显示累计输出，但速率按 timer baseline 之后的 token 增量计算。单元测试覆盖了显示 `650 tokens` 但报告 `20 t/s` 而不是 `130 t/s` 的路径。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

本地 npm workspace checkout。跨平台覆盖交给 PR CI 矩阵验证。

## Risk & Scope

- 主要风险或取舍：这次把两个 baseline 值穿过 UI state，这样可见计数和速率可以有意使用不同 scope。
- 未验证 / 不在范围内：本地没有跑完整 live TUI 工具确认路径。
- Breaking changes / 迁移说明：无。只影响 opt-in 的 `ui.showResponseTokensPerSecond` 显示。

说明：`AppContainer.test.tsx` 在这个本地 worktree 里会被缺失/冲突的生成 workspace 产物阻塞，比如 `@qwen-code/acp-bridge/eventBus` 和 core `dist` declaration outputs。触及的 AppContainer 代码已由 eslint 覆盖，渲染和 token-rate 行为由定向组件/hook 测试覆盖。

## Linked Issues

#5401 的 follow-up。

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
