### PR TITLE
fix(cli): clarify unavailable model configuration hint

### DIFF
--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -230,7 +230,7 @@ describe('modelCommand', () => {
       content:
         "Model 'missing-model' is not available for auth type 'qwen-oauth'.\n" +
         "No models are configured for auth type 'qwen-oauth'.\n" +
-        'Configure models in settings.modelProviders or run /model to select an available model.',
+        'Configure models in settings.modelProviders and ensure the required environment variables are set. In interactive mode, run /auth to configure or switch providers, or run /model without arguments to choose from configured models.',
     });
   });
 
@@ -308,7 +308,7 @@ describe('modelCommand', () => {
       content:
         "Model 'definitely-not-a-model' is not available for auth type 'openai'.\n" +
         "Available models for 'openai': gpt-4.\n" +
-        'Configure models in settings.modelProviders or run /model to select an available model.',
+        'Configure models in settings.modelProviders and ensure the required environment variables are set. In interactive mode, run /auth to configure or switch providers, or run /model without arguments to choose from configured models.',
     });
   });
 
@@ -347,7 +347,7 @@ describe('modelCommand', () => {
       content:
         "Model 'gpt-4o' is not available for auth type 'openai'.\n" +
         "No models are configured for auth type 'openai'.\n" +
-        'Configure models in settings.modelProviders or run /model to select an available model.',
+        'Configure models in settings.modelProviders and ensure the required environment variables are set. In interactive mode, run /auth to configure or switch providers, or run /model without arguments to choose from configured models.',
     });
   });
 
@@ -545,7 +545,50 @@ describe('modelCommand', () => {
       content:
         "Fast model 'missing-model' is not configured for any auth type.\n" +
         'Configured models: qwen-turbo.\n' +
-        'Configure models in settings.modelProviders or run /model to select an available model.',
+        'Configure models in settings.modelProviders and ensure the required environment variables are set. In interactive mode, run /auth to configure or switch providers, or run /model --fast without a model to choose from configured models.',
+    });
+  });
+
+  it('should reject unavailable authType-qualified fast models', async () => {
+    const setValue = vi.fn();
+    const setFastModel = vi.fn();
+    mockContext = createMockCommandContext({
+      invocation: {
+        raw: '/model --fast openai:missing-model',
+        name: 'model',
+        args: '--fast openai:missing-model',
+      },
+      services: {
+        config: {
+          getContentGeneratorConfig: vi.fn().mockReturnValue({
+            model: 'claude-opus-4-7',
+            authType: AuthType.USE_ANTHROPIC,
+          }),
+          getAvailableModelsForAuthType: vi.fn((authType: AuthType) =>
+            authType === AuthType.USE_OPENAI
+              ? [{ id: 'gpt-4', label: 'GPT-4', authType }]
+              : [],
+          ),
+          setFastModel,
+        },
+        settings: createMockSettings(setValue),
+      },
+    });
+
+    const result = await modelCommand.action!(
+      mockContext,
+      '--fast openai:missing-model',
+    );
+
+    expect(setValue).not.toHaveBeenCalled();
+    expect(setFastModel).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content:
+        "Fast model 'missing-model' is not available for auth type 'openai'.\n" +
+        "Available models for 'openai': gpt-4.\n" +
+        'Configure models in settings.modelProviders and ensure the required environment variables are set. In interactive mode, run /auth to configure or switch providers, or run /model --fast without a model to choose from configured models.',
     });
   });
 
@@ -593,6 +636,45 @@ describe('modelCommand', () => {
   });
 
   describe('non-interactive mode', () => {
+    it('should use interactive-only wording for unavailable direct switches', async () => {
+      const setValue = vi.fn();
+      const switchModel = vi.fn();
+      mockContext = createMockCommandContext({
+        executionMode: 'non_interactive',
+        invocation: {
+          raw: '/model missing-model',
+          name: 'model',
+          args: 'missing-model',
+        },
+        services: {
+          config: {
+            getContentGeneratorConfig: vi.fn().mockReturnValue({
+              model: 'qwen-plus',
+              authType: AuthType.USE_OPENAI,
+            }),
+            getAvailableModelsForAuthType: vi
+              .fn()
+              .mockReturnValue([{ id: 'gpt-4', label: 'GPT-4' }]),
+            switchModel,
+          },
+          settings: createMockSettings(setValue),
+        },
+      });
+
+      const result = await modelCommand.action!(mockContext, 'missing-model');
+
+      expect(switchModel).not.toHaveBeenCalled();
+      expect(setValue).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content:
+          "Model 'missing-model' is not available for auth type 'openai'.\n" +
+          "Available models for 'openai': gpt-4.\n" +
+          'Configure models in settings.modelProviders and ensure the required environment variables are set. In interactive mode, run /auth to configure or switch providers, or run /model without arguments to choose from configured models.',
+      });
+    });
+
     it('should return current model without triggering dialog when no args', async () => {
       mockContext = createMockCommandContext({
         executionMode: 'non_interactive',

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -22,6 +22,12 @@ import {
 import type { LoadedSettings } from '../../config/settings.js';
 import { parseAcpModelOption } from '../../utils/acpModelUtils.js';
 
+const MAIN_MODEL_CONFIGURATION_HINT =
+  'Configure models in settings.modelProviders and ensure the required environment variables are set. In interactive mode, run /auth to configure or switch providers, or run /model without arguments to choose from configured models.';
+
+const FAST_MODEL_CONFIGURATION_HINT =
+  'Configure models in settings.modelProviders and ensure the required environment variables are set. In interactive mode, run /auth to configure or switch providers, or run /model --fast without a model to choose from configured models.';
+
 function persistSetting(
   settings: LoadedSettings,
   path: string,
@@ -81,7 +87,9 @@ function formatUnavailableModelMessage(
   return (
     `${kind} '${modelName}' is not available for auth type '${authType}'.\n` +
     `${availableModelsLine}\n` +
-    'Configure models in settings.modelProviders or run /model to select an available model.'
+    (kind === 'Fast model'
+      ? FAST_MODEL_CONFIGURATION_HINT
+      : MAIN_MODEL_CONFIGURATION_HINT)
   );
 }
 
@@ -100,7 +108,7 @@ function formatUnavailableFastModelMessage(
   return (
     `Fast model '${modelName}' is not configured for any auth type.\n` +
     `${availableModelsLine}\n` +
-    'Configure models in settings.modelProviders or run /model to select an available model.'
+    FAST_MODEL_CONFIGURATION_HINT
   );
 }
 


### PR DESCRIPTION
## What this PR does

Updates the unavailable-model error shown by `/model <model-id>` and `/model --fast <model-id>`.

The message now points users to `settings.modelProviders` and required environment variables first, then clearly marks `/auth` and the no-argument `/model` picker as interactive-mode helpers. The fast-model path uses the matching `/model --fast` picker wording.

## Why it's needed

#4616 shows a confusing case where a user runs `/model qwen3.7-max` and gets told to "run /model" again. That hint is not useful when the user is already inside `/model`, and it is also inaccurate for non-interactive invocations where no-argument `/model` only prints the current model instead of opening a picker.

This keeps the fix scoped to the error guidance text and tests.

## Reviewer Test Plan

### How to verify

1. Configure an auth type with a limited model list, such as `openai` with only `gpt-4`.
2. Run `/model missing-model`.
3. Confirm the error lists configured models for that auth type and points to `settings.modelProviders` / env vars.
4. Confirm the `/auth` and no-argument `/model` picker guidance is explicitly marked as interactive-mode guidance.
5. Run `/model --fast openai:missing-model` and confirm the fast-model hint uses `/model --fast` wording.

Targeted validation commands run locally:

```bash
npx vitest run --coverage.enabled=false src/ui/commands/modelCommand.test.ts
npx eslint packages/cli/src/ui/commands/modelCommand.ts packages/cli/src/ui/commands/modelCommand.test.ts
npx prettier --check packages/cli/src/ui/commands/modelCommand.ts packages/cli/src/ui/commands/modelCommand.test.ts
git diff --check upstream/main...HEAD
```

### Evidence (Before & After)

Before: `Configure models in settings.modelProviders or run /model to select an available model.`

After: `Configure models in settings.modelProviders and ensure the required environment variables are set. In interactive mode, run /auth to configure or switch providers, or run /model without arguments to choose from configured models.`

For fast models, the picker hint uses `/model --fast without a model`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Local npm workspace checkout.

## Risk & Scope

- Main risk or tradeoff: this is a wording-only UX change, so the main risk is making the hint too verbose.
- Not validated / out of scope: no live interactive CLI smoke was run locally.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #4616

<details>
<summary>中文说明</summary>

## What this PR does

更新 `/model <model-id>` 和 `/model --fast <model-id>` 在模型不可用时显示的错误提示。

新的提示先引导用户检查 `settings.modelProviders` 和必需的环境变量，然后明确说明 `/auth` 和无参数 `/model` 选择器是 interactive mode 下的辅助方式。fast-model 路径则使用对应的 `/model --fast` 选择器文案。

## Why it's needed

#4616 里的用户运行 `/model qwen3.7-max` 后，错误又提示他“run /model”，这个提示不够有用，因为用户已经在用 `/model`。在 non-interactive 调用里也不准确，因为无参数 `/model` 只会打印当前模型，不会打开选择器。

这个 PR 只改错误提示文案和对应测试。

## Reviewer Test Plan

### How to verify

1. 配置一个模型列表有限的 auth type，比如 `openai` 下面只有 `gpt-4`。
2. 运行 `/model missing-model`。
3. 确认错误会列出该 auth type 下的已配置模型，并指向 `settings.modelProviders` / 环境变量。
4. 确认 `/auth` 和无参数 `/model` 选择器明确标成 interactive-mode guidance。
5. 运行 `/model --fast openai:missing-model`，确认 fast-model 提示使用 `/model --fast` 文案。

本地已运行上方列出的定向验证命令。

### Evidence (Before & After)

修改前：`Configure models in settings.modelProviders or run /model to select an available model.`

修改后：`Configure models in settings.modelProviders and ensure the required environment variables are set. In interactive mode, run /auth to configure or switch providers, or run /model without arguments to choose from configured models.`

fast model 路径会使用 `/model --fast without a model` 的选择器提示。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

本地 npm workspace checkout。

## Risk & Scope

- 主要风险或取舍：这是纯文案 UX 改动，主要风险是提示稍长。
- 未验证 / 不在范围内：本地没有跑真实 interactive CLI smoke。
- Breaking changes / 迁移说明：无。

## Linked Issues

Fixes #4616

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
