### PR TITLE
fix(auth): preserve custom provider models on install

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -139,22 +139,45 @@ vi.mock('@qwen-code/qwen-code-core', () => ({
       uiGroup: 'third-party',
     },
   ],
-  findProviderById: vi.fn((id: string) =>
-    id === 'deepseek'
-      ? {
-          id: 'deepseek',
-          label: 'DeepSeek API Key',
-          description: 'Quick setup for DeepSeek',
-          protocol: 'openai',
-          baseUrl: 'https://api.deepseek.com',
-          envKey: 'DEEPSEEK_API_KEY',
-          models: [{ id: 'deepseek-chat' }],
-          modelsEditable: true,
-          modelNamePrefix: 'DeepSeek',
-          uiGroup: 'third-party',
-        }
-      : undefined,
-  ),
+  findProviderById: vi.fn((id: string) => {
+    if (id === 'deepseek') {
+      return {
+        id: 'deepseek',
+        label: 'DeepSeek API Key',
+        description: 'Quick setup for DeepSeek',
+        protocol: 'openai',
+        baseUrl: 'https://api.deepseek.com',
+        envKey: 'DEEPSEEK_API_KEY',
+        models: [{ id: 'deepseek-chat' }],
+        modelsEditable: true,
+        modelNamePrefix: 'DeepSeek',
+        uiGroup: 'third-party',
+      };
+    }
+    if (id === 'custom-openai-compatible') {
+      return {
+        id: 'custom-openai-compatible',
+        label: 'Custom Provider',
+        description: 'Manually connect a custom provider',
+        protocol: 'openai',
+        protocolOptions: ['openai', 'anthropic', 'gemini'],
+        baseUrl: undefined,
+        envKey: (protocol: string, baseUrl: string) =>
+          `QWEN_CUSTOM_API_KEY_${protocol}_${baseUrl.replace(
+            /[^A-Za-z0-9]/g,
+            '_',
+          )}`,
+        models: undefined,
+        modelsEditable: true,
+        modelNamePrefix: '',
+        uiGroup: 'third-party',
+        ownsModel: (model: { envKey?: string }) =>
+          typeof model.envKey === 'string' &&
+          model.envKey.startsWith('QWEN_CUSTOM_API_KEY_'),
+      };
+    }
+    return undefined;
+  }),
   getDefaultBaseUrlForProtocol: vi.fn(() => 'https://api.openai.com/v1'),
   getDefaultModelIds: vi.fn(
     (provider: { models?: Array<{ id: string }> }) =>
@@ -172,8 +195,12 @@ vi.mock('@qwen-code/qwen-code-core', () => ({
           : (selectedBaseUrl ?? ''),
   ),
   resolveOwnsModel: vi.fn(
-    (provider: { envKey: string }) => (model: { envKey?: string }) =>
-      model.envKey === provider.envKey,
+    (provider: {
+      envKey: string;
+      ownsModel?: (model: { envKey?: string }) => boolean;
+    }) =>
+      provider.ownsModel ??
+      ((model: { envKey?: string }) => model.envKey === provider.envKey),
   ),
   ExtensionManager: vi.fn().mockImplementation(() => ({
     refreshCache: mockExtensionManagerState.refreshCache,
@@ -206,12 +233,19 @@ vi.mock('@qwen-code/qwen-code-core', () => ({
     TodoCreated: 'TodoCreated',
     TodoCompleted: 'TodoCompleted',
   },
-  buildInstallPlan: vi.fn((provider, inputs) => ({
-    providerId: provider.id,
-    authType: inputs.protocol ?? provider.protocol,
-    env: { [provider.envKey]: inputs.apiKey },
-    modelSelection: { modelId: inputs.modelIds[0] },
-  })),
+  buildInstallPlan: vi.fn((provider, inputs) => {
+    const authType = inputs.protocol ?? provider.protocol;
+    const envKey =
+      typeof provider.envKey === 'function'
+        ? provider.envKey(authType, inputs.baseUrl)
+        : provider.envKey;
+    return {
+      providerId: provider.id,
+      authType,
+      env: { [envKey]: inputs.apiKey },
+      modelSelection: { modelId: inputs.modelIds[0] },
+    };
+  }),
   applyProviderInstallPlan: vi.fn().mockResolvedValue({
     updatedModelProviders: {},
   }),
@@ -3840,6 +3874,78 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     expect(buildInstallPlan).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'deepseek' }),
       expect.objectContaining({ apiKey: 'sk-existing' }),
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('qwen/providers/connect reuses the custom apiKey for the requested baseUrl only', async () => {
+    const customEnvKey = (protocol: string, baseUrl: string) =>
+      `QWEN_CUSTOM_API_KEY_${protocol}_${baseUrl.replace(
+        /[^A-Za-z0-9]/g,
+        '_',
+      )}`;
+    const firstBaseUrl = 'https://api.first.example/v1';
+    const secondBaseUrl = 'https://api.second.example/v1';
+    const firstEnvKey = customEnvKey('openai', firstBaseUrl);
+    const secondEnvKey = customEnvKey('openai', secondBaseUrl);
+    const settings = {
+      ...makeSessionSettings(),
+      merged: {
+        mcpServers: {},
+        env: {
+          [firstEnvKey]: 'sk-first',
+          [secondEnvKey]: 'sk-second',
+        },
+        modelProviders: {
+          openai: [
+            {
+              id: 'custom-model',
+              baseUrl: firstBaseUrl,
+              envKey: firstEnvKey,
+            },
+            {
+              id: 'custom-model',
+              baseUrl: secondBaseUrl,
+              envKey: secondEnvKey,
+            },
+          ],
+        },
+      },
+    } as unknown as LoadedSettings;
+    const agentPromise = runAcpAgent(mockConfig, settings, mockArgv);
+
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    await expect(
+      agent.extMethod('qwen/providers/connect', {
+        providerId: 'custom-openai-compatible',
+        protocol: 'openai',
+        baseUrl: secondBaseUrl,
+        modelIds: ['custom-model'],
+      }),
+    ).resolves.toMatchObject({
+      success: true,
+      providerId: 'custom-openai-compatible',
+    });
+
+    expect(buildInstallPlan).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'custom-openai-compatible' }),
+      expect.objectContaining({
+        apiKey: 'sk-second',
+        baseUrl: secondBaseUrl,
+      }),
+    );
+    expect(buildInstallPlan).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ apiKey: 'sk-first' }),
     );
 
     mockConnectionState.resolve();

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -1514,18 +1514,10 @@ function readExistingProviderConfig(
 function resolveExistingProviderApiKey(
   config: ProviderConfig,
   settings: LoadedSettings,
+  protocol: ProviderConfig['protocol'],
+  baseUrl: string,
 ): string | undefined {
-  const existing = findExistingProviderModels(config, settings);
-  const firstModel = existing?.models[0];
-  const protocol = existing?.protocol ?? config.protocol;
-  const baseUrl =
-    typeof firstModel?.baseUrl === 'string'
-      ? firstModel.baseUrl
-      : resolveBaseUrl(config);
-  const envKey =
-    typeof firstModel?.envKey === 'string'
-      ? firstModel.envKey
-      : resolveProviderEnvKey(config, protocol, baseUrl);
+  const envKey = resolveProviderEnvKey(config, protocol, baseUrl);
   return readSettingsEnv(settings, envKey);
 }
 
@@ -1564,7 +1556,10 @@ function serializeProviderConfig(
 function readProviderSetupInputs(
   config: ProviderConfig,
   params: Record<string, unknown>,
-  existingApiKey?: string,
+  resolveExistingApiKey?: (
+    protocol: ProviderConfig['protocol'],
+    baseUrl: string,
+  ) => string | undefined,
 ): ProviderSetupInputs {
   const protocol = readOptionalString(params['protocol'], 'protocol') as
     | AuthType
@@ -1597,7 +1592,8 @@ function readProviderSetupInputs(
   // `apiKey` is optional on update: when the client omits it (e.g. it only
   // received `hasApiKey` from the list response), fall back to the stored key.
   const apiKey =
-    readOptionalString(params['apiKey'], 'apiKey') ?? existingApiKey;
+    readOptionalString(params['apiKey'], 'apiKey') ??
+    resolveExistingApiKey?.(protocol ?? config.protocol, baseUrl);
   if (!apiKey) {
     throw RequestError.invalidParams(undefined, 'Invalid or missing apiKey');
   }
@@ -4853,7 +4849,13 @@ class QwenAgent implements Agent {
         const inputs = readProviderSetupInputs(
           providerConfig,
           params,
-          resolveExistingProviderApiKey(providerConfig, this.settings),
+          (protocol, baseUrl) =>
+            resolveExistingProviderApiKey(
+              providerConfig,
+              this.settings,
+              protocol,
+              baseUrl,
+            ),
         );
         const persistScope = readProviderConnectScope(params['scope']);
         const plan = buildInstallPlan(providerConfig, inputs);

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -4861,10 +4861,10 @@ class QwenAgent implements Agent {
           settings: createLoadedSettingsAdapter(this.settings, persistScope),
           reloadModelProviders: (modelProviders) =>
             this.config.reloadModelProvidersConfig(modelProviders),
-          syncAuthState: (authType, modelId) =>
+          syncAuthState: (authType, modelId, baseUrl) =>
             this.config
               .getModelsConfig()
-              .syncAfterAuthRefresh(authType, modelId),
+              .syncAfterAuthRefresh(authType, modelId, baseUrl),
           refreshAuth: (authType) => this.config.refreshAuth(authType),
         });
 
@@ -4874,6 +4874,9 @@ class QwenAgent implements Agent {
           providerLabel: providerConfig.label,
           authType: plan.authType,
           modelId: plan.modelSelection?.modelId,
+          ...(plan.modelSelection?.baseUrl
+            ? { baseUrl: plan.modelSelection.baseUrl }
+            : {}),
         };
       }
       case 'qwen/skills/install': {

--- a/packages/cli/src/ui/auth/useAuth.ts
+++ b/packages/cli/src/ui/auth/useAuth.ts
@@ -172,8 +172,10 @@ export const useAuthCommand = (
         await applyProviderInstallPlan(plan, {
           settings: createLoadedSettingsAdapter(settings),
           reloadModelProviders: (mp) => config.reloadModelProvidersConfig(mp),
-          syncAuthState: (authType, modelId) =>
-            config.getModelsConfig().syncAfterAuthRefresh(authType, modelId),
+          syncAuthState: (authType, modelId, baseUrl) =>
+            config
+              .getModelsConfig()
+              .syncAfterAuthRefresh(authType, modelId, baseUrl),
           refreshAuth: (authType) => config.refreshAuth(authType),
         });
 

--- a/packages/cli/src/ui/hooks/useProviderUpdates.test.ts
+++ b/packages/cli/src/ui/hooks/useProviderUpdates.test.ts
@@ -300,6 +300,7 @@ describe('useProviderUpdates', () => {
     expect(mockModelsConfig.syncAfterAuthRefresh).toHaveBeenCalledWith(
       AuthType.USE_OPENAI,
       'qwen3.5-plus',
+      undefined,
     );
   });
 

--- a/packages/cli/src/ui/hooks/useProviderUpdates.ts
+++ b/packages/cli/src/ui/hooks/useProviderUpdates.ts
@@ -240,8 +240,10 @@ export function useProviderUpdates(
         await applyProviderInstallPlan(installPlan, {
           settings: createLoadedSettingsAdapter(settings),
           reloadModelProviders: (mp) => config.reloadModelProvidersConfig(mp),
-          syncAuthState: (authType, modelId) =>
-            config.getModelsConfig().syncAfterAuthRefresh(authType, modelId),
+          syncAuthState: (authType, modelId, baseUrl) =>
+            config
+              .getModelsConfig()
+              .syncAfterAuthRefresh(authType, modelId, baseUrl),
           refreshAuth: (authType) => config.refreshAuth(authType),
           doRefreshAuth: false,
         });

--- a/packages/core/src/models/modelsConfig.test.ts
+++ b/packages/core/src/models/modelsConfig.test.ts
@@ -1398,6 +1398,47 @@ describe('ModelsConfig', () => {
     expect(modelsConfig.getGenerationConfig().model).toBe('model-a');
   });
 
+  it('should use explicit provider baseUrl when syncing after provider install', () => {
+    const modelProvidersConfig: ModelProvidersConfig = {
+      openai: [
+        {
+          id: 'shared-model',
+          name: 'Shared Model (old)',
+          baseUrl: 'https://old.example.com/v1',
+          envKey: 'OLD_API_KEY',
+        },
+        {
+          id: 'shared-model',
+          name: 'Shared Model (new)',
+          baseUrl: 'https://new.example.com/v1',
+          envKey: 'NEW_API_KEY',
+        },
+      ],
+    };
+
+    const modelsConfig = new ModelsConfig({
+      initialAuthType: AuthType.USE_OPENAI,
+      modelProvidersConfig,
+      generationConfig: {
+        model: 'shared-model',
+        baseUrl: 'https://old.example.com/v1',
+      },
+    });
+
+    modelsConfig.syncAfterAuthRefresh(
+      AuthType.USE_OPENAI,
+      'shared-model',
+      'https://new.example.com/v1',
+    );
+
+    expect(modelsConfig.getModel()).toBe('shared-model');
+    expect(modelsConfig.getGenerationConfig()).toMatchObject({
+      model: 'shared-model',
+      baseUrl: 'https://new.example.com/v1',
+      apiKeyEnvKey: 'NEW_API_KEY',
+    });
+  });
+
   it('should maintain consistency between currentModelId and _generationConfig.model during setModel', async () => {
     const modelProvidersConfig: ModelProvidersConfig = {
       openai: [

--- a/packages/core/src/models/modelsConfig.ts
+++ b/packages/core/src/models/modelsConfig.ts
@@ -955,7 +955,11 @@ export class ModelsConfig {
    * 4. If no default is available, leave the generationConfig incomplete and let
    *    resolveContentGeneratorConfigWithSources throw exceptions as expected.
    */
-  syncAfterAuthRefresh(authType: AuthType, modelId?: string): void {
+  syncAfterAuthRefresh(
+    authType: AuthType,
+    modelId?: string,
+    providerBaseUrlOverride?: string,
+  ): void {
     this.strictModelProviderSelection = false;
     const previousAuthType = this.currentAuthType;
     this.currentAuthType = authType;
@@ -967,9 +971,10 @@ export class ModelsConfig {
     // Prefer exact match (id+baseUrl) when the current baseUrl was set by a
     // model provider switch; fall back to any model with the same id.
     const providerBaseUrl =
-      this.generationConfigSources['baseUrl']?.kind === 'modelProviders'
+      providerBaseUrlOverride ??
+      (this.generationConfigSources['baseUrl']?.kind === 'modelProviders'
         ? this._generationConfig.baseUrl
-        : undefined;
+        : undefined);
     const resolved = modelId
       ? (this.modelRegistry.getModel(authType, modelId, providerBaseUrl) ??
         this.modelRegistry.getModel(authType, modelId))

--- a/packages/core/src/providers/__tests__/install.test.ts
+++ b/packages/core/src/providers/__tests__/install.test.ts
@@ -173,6 +173,7 @@ describe('applyProviderInstallPlan', () => {
     expect(syncAuthState).toHaveBeenCalledWith(
       AuthType.USE_OPENAI,
       'new-model',
+      undefined,
     );
     expect(refreshAuth).toHaveBeenCalledWith(AuthType.USE_OPENAI);
     expect(adapter.cleanupBackup).toHaveBeenCalled();

--- a/packages/core/src/providers/__tests__/install.test.ts
+++ b/packages/core/src/providers/__tests__/install.test.ts
@@ -9,6 +9,9 @@ import { AuthType } from '../../core/contentGenerator.js';
 import type { ModelProvidersConfig } from '../../models/types.js';
 import {
   applyProviderInstallPlan,
+  buildInstallPlan,
+  customProvider,
+  generateCustomEnvKey,
   ProviderInstallError,
   type ProviderInstallPlan,
   type ProviderSettingsAdapter,
@@ -256,6 +259,76 @@ describe('applyProviderInstallPlan', () => {
       { id: 'gpt-4o', baseUrl: 'https://proxy-a.example/v1' },
       { id: 'gpt-3.5', baseUrl: 'https://api.openai.com/v1' },
     ]);
+  });
+
+  it('preserves existing custom provider models and selects the installed endpoint', async () => {
+    const baseUrl = 'http://new.example/v1';
+    const otherBaseUrl = 'http://192.168.100.100:8000/v1';
+    const envKey = generateCustomEnvKey(AuthType.USE_OPENAI, baseUrl);
+    const otherEnvKey = generateCustomEnvKey(AuthType.USE_OPENAI, otherBaseUrl);
+    const syncAuthState = vi.fn();
+    const adapter = createAdapter({
+      [AuthType.USE_OPENAI]: [
+        // Same model id, different baseUrl: keep both and select the one just
+        // installed.
+        {
+          id: 'model-b',
+          name: 'model-b',
+          baseUrl: otherBaseUrl,
+          envKey: otherEnvKey,
+        },
+        { id: 'model-a', name: 'model-a', baseUrl, envKey },
+        {
+          id: 'shared-model',
+          name: 'shared-model',
+          baseUrl: otherBaseUrl,
+          envKey: otherEnvKey,
+        },
+      ],
+    });
+    const plan = buildInstallPlan(customProvider, {
+      protocol: AuthType.USE_OPENAI,
+      baseUrl,
+      apiKey: 'sk-new',
+      modelIds: ['model-b'],
+    });
+
+    expect(plan.modelProviders?.[0]?.ownsModel).toBeUndefined();
+    expect(plan.modelSelection).toEqual({ modelId: 'model-b', baseUrl });
+
+    try {
+      await applyProviderInstallPlan(plan, {
+        settings: adapter,
+        syncAuthState,
+        doRefreshAuth: false,
+      });
+    } finally {
+      delete process.env[envKey];
+    }
+
+    expect(adapter.setValue).toHaveBeenCalledWith('modelProviders.openai', [
+      { id: 'model-b', name: 'model-b', baseUrl, envKey },
+      {
+        id: 'model-b',
+        name: 'model-b',
+        baseUrl: otherBaseUrl,
+        envKey: otherEnvKey,
+      },
+      { id: 'model-a', name: 'model-a', baseUrl, envKey },
+      {
+        id: 'shared-model',
+        name: 'shared-model',
+        baseUrl: otherBaseUrl,
+        envKey: otherEnvKey,
+      },
+    ]);
+    expect(adapter.setValue).toHaveBeenCalledWith('model.name', 'model-b');
+    expect(adapter.setValue).toHaveBeenCalledWith('model.baseUrl', baseUrl);
+    expect(syncAuthState).toHaveBeenCalledWith(
+      AuthType.USE_OPENAI,
+      'model-b',
+      baseUrl,
+    );
   });
 
   it('writes provider state and legacy credentials', async () => {

--- a/packages/core/src/providers/__tests__/presets/custom-provider.test.ts
+++ b/packages/core/src/providers/__tests__/presets/custom-provider.test.ts
@@ -110,11 +110,7 @@ describe('customProvider', () => {
     ]);
   });
 
-  it('owns any model whose envKey starts with the QWEN_CUSTOM_API_KEY_ prefix', () => {
-    // Without ownsModel, applyModelProvidersPatch falls back to id+baseUrl
-    // identity matching, so reinstalling a custom provider under a different
-    // baseUrl would leave the old entries behind. Prefix-match cleanly
-    // identifies "ours" without false positives against presets.
+  it('keeps custom ownership detection but merges installs by model identity', () => {
     expect(customProvider.ownsModel).toBeTypeOf('function');
     expect(
       customProvider.ownsModel?.({
@@ -128,11 +124,20 @@ describe('customProvider', () => {
         envKey: 'DEEPSEEK_API_KEY',
       }),
     ).toBe(false);
-    expect(
-      customProvider.ownsModel?.({
-        id: 'no-env-key',
-      }),
-    ).toBe(false);
+    expect(customProvider.mergeModelsByIdentity).toBe(true);
+
+    const plan = buildInstallPlan(customProvider, {
+      protocol: AuthType.USE_OPENAI,
+      baseUrl: 'https://my-proxy.com/v1',
+      apiKey: 'sk-my-key',
+      modelIds: ['model-a'],
+    });
+
+    expect(plan.modelProviders?.[0]?.ownsModel).toBeUndefined();
+    expect(plan.modelSelection).toEqual({
+      modelId: 'model-a',
+      baseUrl: 'https://my-proxy.com/v1',
+    });
   });
 
   it('shows protocol, baseUrl, models, and advancedConfig steps', () => {

--- a/packages/core/src/providers/install.ts
+++ b/packages/core/src/providers/install.ts
@@ -84,7 +84,11 @@ export interface ApplyProviderInstallPlanOptions {
   /** Callback to reload model providers config in the runtime. */
   reloadModelProviders?: (mp: ModelProvidersConfig) => void;
   /** Callback to sync auth state after install. */
-  syncAuthState?: (authType: AuthType, modelId: string) => void;
+  syncAuthState?: (
+    authType: AuthType,
+    modelId: string,
+    baseUrl?: string,
+  ) => void;
   /** Callback to refresh auth after install. */
   refreshAuth?: (authType: AuthType) => Promise<void>;
   /** Whether to call refreshAuth after install. Defaults to true. */
@@ -210,12 +214,16 @@ export async function applyProviderInstallPlan(
     currentStep = 'modelSelection';
     if (plan.modelSelection?.modelId) {
       settings.setValue('model.name', plan.modelSelection.modelId);
-      // The plan selects by model id only, so clear any baseUrl disambiguator
-      // left by a previous model-picker selection — otherwise the next launch
-      // could resolve to a stale provider sharing this model id. Empty-string
-      // tombstone so the clear overrides a lower-scope value on merge (an
-      // undefined write is dropped from JSON and would not override).
-      settings.setValue('model.baseUrl', '');
+      if (plan.modelSelection.baseUrl) {
+        settings.setValue('model.baseUrl', plan.modelSelection.baseUrl);
+      } else {
+        // The plan selects by model id only, so clear any baseUrl disambiguator
+        // left by a previous model-picker selection — otherwise the next launch
+        // could resolve to a stale provider sharing this model id. Empty-string
+        // tombstone so the clear overrides a lower-scope value on merge (an
+        // undefined write is dropped from JSON and would not override).
+        settings.setValue('model.baseUrl', '');
+      }
     }
 
     // Provider state metadata
@@ -235,7 +243,15 @@ export async function applyProviderInstallPlan(
     reloadModelProviders?.(updatedModelProviders);
     if (plan.modelSelection?.modelId) {
       currentStep = 'syncAuthState';
-      syncAuthState?.(plan.authType, plan.modelSelection.modelId);
+      if (plan.modelSelection.baseUrl) {
+        syncAuthState?.(
+          plan.authType,
+          plan.modelSelection.modelId,
+          plan.modelSelection.baseUrl,
+        );
+      } else {
+        syncAuthState?.(plan.authType, plan.modelSelection.modelId);
+      }
     }
     if (doRefreshAuth && refreshAuth) {
       currentStep = 'refreshAuth';

--- a/packages/core/src/providers/install.ts
+++ b/packages/core/src/providers/install.ts
@@ -243,15 +243,11 @@ export async function applyProviderInstallPlan(
     reloadModelProviders?.(updatedModelProviders);
     if (plan.modelSelection?.modelId) {
       currentStep = 'syncAuthState';
-      if (plan.modelSelection.baseUrl) {
-        syncAuthState?.(
-          plan.authType,
-          plan.modelSelection.modelId,
-          plan.modelSelection.baseUrl,
-        );
-      } else {
-        syncAuthState?.(plan.authType, plan.modelSelection.modelId);
-      }
+      syncAuthState?.(
+        plan.authType,
+        plan.modelSelection.modelId,
+        plan.modelSelection.baseUrl,
+      );
     }
     if (doRefreshAuth && refreshAuth) {
       currentStep = 'refreshAuth';

--- a/packages/core/src/providers/presets/custom-provider.ts
+++ b/packages/core/src/providers/presets/custom-provider.ts
@@ -110,14 +110,13 @@ export const customProvider: ProviderConfig = {
   models: undefined,
   modelNamePrefix: '',
   showAdvancedConfig: true,
-  // Without this, applyModelProvidersPatch falls back to id+baseUrl identity
-  // matching, so reinstalling a custom provider under a different baseUrl
-  // leaves the old model entries behind — they accumulate over time.
-  // Every key we mint via generateCustomEnvKey starts with the well-known
-  // prefix, so a prefix match cleanly identifies "ours" without false
-  // positives against preset entries.
+  // Detect existing custom entries by our env-key namespace for UI/ACP flows,
+  // but merge installs by id+baseUrl so /auth can add another custom model
+  // without deleting models from other endpoints or different models on the
+  // same endpoint.
   ownsModel: (model) =>
     typeof model.envKey === 'string' &&
     model.envKey.startsWith(CUSTOM_API_KEY_ENV_PREFIX),
+  mergeModelsByIdentity: true,
   uiGroup: 'custom',
 };

--- a/packages/core/src/providers/provider-config.ts
+++ b/packages/core/src/providers/provider-config.ts
@@ -226,24 +226,37 @@ export function buildInstallPlan(
   const protocol = inputs.protocol ?? config.protocol;
   const envKey = resolveEnvKey(config, inputs);
   const models = inputs.prebuiltModels ?? buildModelConfigs(config, inputs);
+  const ownsModel = config.mergeModelsByIdentity
+    ? undefined
+    : resolveOwnsModel(config);
+  const firstModel = models[0];
   if (models.length === 0) {
     throw new Error(
       `No models configured for provider "${config.id}". Check model list or provider configuration.`,
     );
   }
-  const firstModelId = models[0]?.id;
+  const firstModelId = firstModel?.id;
+  const modelSelection =
+    firstModelId === undefined
+      ? undefined
+      : {
+          modelId: firstModelId,
+          ...(config.mergeModelsByIdentity && firstModel.baseUrl
+            ? { baseUrl: firstModel.baseUrl }
+            : {}),
+        };
 
   return {
     providerId: config.id,
     authType: protocol,
     env: { [envKey]: inputs.apiKey },
-    ...(firstModelId ? { modelSelection: { modelId: firstModelId } } : {}),
+    ...(modelSelection ? { modelSelection } : {}),
     modelProviders: [
       {
         authType: protocol,
         models,
         mergeStrategy: 'prepend-and-remove-owned' as const,
-        ownsModel: resolveOwnsModel(config),
+        ...(ownsModel ? { ownsModel } : {}),
       },
     ],
     providerState: resolveProviderState(config, inputs.baseUrl, models),

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -93,6 +93,14 @@ export interface ProviderConfig {
   ownsModel?: (model: ProviderModelConfig) => boolean;
 
   /**
+   * Install-time merge behavior. When true, installs replace only incoming
+   * model identities (id + baseUrl) instead of every model matched by
+   * ownsModel. Useful for user-defined providers where multiple endpoints and
+   * model IDs can coexist under one provider config.
+   */
+  mergeModelsByIdentity?: boolean;
+
+  /**
    * UI grouping hint — used by AuthDialog to organize providers into sections.
    * Providers with the same `uiGroup` appear together under a shared heading.
    */
@@ -152,6 +160,7 @@ export interface ProviderInstallPlan {
   };
   modelSelection?: {
     modelId: string;
+    baseUrl?: string;
   };
   modelProviders?: ProviderModelProvidersPatch[];
   providerState?: ProviderInstallState;


### PR DESCRIPTION
## Summary
- keep custom provider ownership detection for UI/ACP discovery, but merge custom provider installs by model identity
- persist and pass through model.baseUrl during provider install so same model IDs on different endpoints select the newly installed endpoint
- add regression coverage for preserving custom provider models and baseUrl-specific sync

Refs #4814

## Tests
- from packages/core: npx -p node@22 node ../../scripts/build_package.js
- npx -p node@22 node node_modules/vitest/vitest.mjs run --coverage.enabled=false packages/core/src/providers/__tests__ packages/core/src/models/modelsConfig.test.ts
- npx -p node@22 node node_modules/typescript/bin/tsc --noEmit --project packages/core/tsconfig.json
- npx -p node@22 node node_modules/eslint/bin/eslint.js packages/cli/src/acp-integration/acpAgent.ts packages/cli/src/ui/auth/useAuth.ts packages/cli/src/ui/hooks/useProviderUpdates.ts packages/core/src/models/modelsConfig.test.ts packages/core/src/models/modelsConfig.ts packages/core/src/providers/__tests__/install.test.ts packages/core/src/providers/__tests__/presets/custom-provider.test.ts packages/core/src/providers/install.ts packages/core/src/providers/presets/custom-provider.ts packages/core/src/providers/provider-config.ts packages/core/src/providers/types.ts
- npx -p node@22 node node_modules/prettier/bin/prettier.cjs --check packages/cli/src/acp-integration/acpAgent.ts packages/cli/src/ui/auth/useAuth.ts packages/cli/src/ui/hooks/useProviderUpdates.ts packages/core/src/models/modelsConfig.test.ts packages/core/src/models/modelsConfig.ts packages/core/src/providers/__tests__/install.test.ts packages/core/src/providers/__tests__/presets/custom-provider.test.ts packages/core/src/providers/install.ts packages/core/src/providers/presets/custom-provider.ts packages/core/src/providers/provider-config.ts packages/core/src/providers/types.ts
- git diff --check

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.