### PR TITLE
fix(core): target microcompaction cache disarms

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -1951,16 +1951,19 @@ describe('Gemini Client (client.ts)', () => {
   function mockFileReadCacheStub(): {
     clear: ReturnType<typeof vi.fn>;
     markReadEvictedFromHistory: ReturnType<typeof vi.fn>;
+    invalidateByPath: ReturnType<typeof vi.fn>;
   } {
     const clear = vi.fn();
     // Default: every disarm matches an entry (true). Tests that need
     // the inode-miss fallback override the return value per-call.
     const markReadEvictedFromHistory = vi.fn().mockReturnValue(true);
+    const invalidateByPath = vi.fn();
     vi.mocked(mockConfig.getFileReadCache).mockReturnValue({
       clear,
       markReadEvictedFromHistory,
+      invalidateByPath,
     } as unknown as ReturnType<Config['getFileReadCache']>);
-    return { clear, markReadEvictedFromHistory };
+    return { clear, markReadEvictedFromHistory, invalidateByPath };
   }
 
   describe('thinking block idle cleanup and latch', () => {
@@ -2432,12 +2435,13 @@ describe('Gemini Client (client.ts)', () => {
       expect(markReadEvictedFromHistory).not.toHaveBeenCalled();
     });
 
-    it('falls back to a blanket clear when an evicted path cannot be stat’d (Codex P2)', async () => {
+    it('invalidates only the path when an evicted path cannot be stat’d', async () => {
       // Path is recovered (id linkage present) so it lands in
       // evictedReadPaths, but the file does not exist on disk, so the
-      // client's stat fails. Leaving the entry armed would risk a
-      // dangling placeholder, so it must fall back to the safe wipe.
-      const { clear, markReadEvictedFromHistory } = mockFileReadCacheStub();
+      // client's stat fails. The fallback should still target only the
+      // recovered path.
+      const { clear, markReadEvictedFromHistory, invalidateByPath } =
+        mockFileReadCacheStub();
 
       const history: Content[] = [];
       for (let i = 0; i < 6; i++) {
@@ -2486,15 +2490,19 @@ describe('Gemini Client (client.ts)', () => {
         /* drain */
       }
 
-      expect(clear).toHaveBeenCalled();
+      expect(invalidateByPath).toHaveBeenCalledWith(
+        join(mcTmpDir, 'ghost-0.ts'),
+      );
+      expect(clear).not.toHaveBeenCalled();
       expect(markReadEvictedFromHistory).not.toHaveBeenCalled();
     });
 
-    it('falls back to a blanket clear on a MIXED batch — one path on disk, one a ghost (mimo F9)', async () => {
+    it('keeps a mixed batch targeted when one path is on disk and one is a ghost', async () => {
       // Most realistic production case: several files evicted, most on
-      // disk, one deleted since. A single unresolvable path must still
-      // force the safe blanket wipe rather than a partial disarm.
-      const { clear, markReadEvictedFromHistory } = mockFileReadCacheStub();
+      // disk, one deleted since. A single unresolvable path should not
+      // force unrelated cache entries to be wiped.
+      const { clear, markReadEvictedFromHistory, invalidateByPath } =
+        mockFileReadCacheStub();
 
       // keepRecent = 5 in this suite, so 7 results blank the 2 oldest:
       // index 0 (real, stats OK) and index 1 (ghost, stat fails).
@@ -2553,19 +2561,18 @@ describe('Gemini Client (client.ts)', () => {
         /* drain */
       }
 
-      // The ghost path makes the batch not-fully-disarmed → safe wipe.
-      expect(clear).toHaveBeenCalled();
-      // The on-disk path was still attempted before the batch was
-      // deemed unresolvable.
-      expect(markReadEvictedFromHistory).toHaveBeenCalled();
+      expect(markReadEvictedFromHistory).toHaveBeenCalledTimes(1);
+      expect(invalidateByPath).toHaveBeenCalledWith(ghostPath);
+      expect(clear).not.toHaveBeenCalled();
     });
 
-    it('falls back to a blanket clear when an evicted path stats to a different inode (Codex P2)', async () => {
+    it('invalidates only the path when an evicted path stats to a different inode', async () => {
       // Path stats fine, but resolves to an inode the cache never
       // recorded (file replaced / symlink retargeted since the read),
       // so markReadEvictedFromHistory finds no entry and returns false.
-      // A stale entry could stay armed, so fall back to the safe wipe.
-      const { clear, markReadEvictedFromHistory } = mockFileReadCacheStub();
+      // The path fallback should remove only the matching resident entry.
+      const { clear, markReadEvictedFromHistory, invalidateByPath } =
+        mockFileReadCacheStub();
       markReadEvictedFromHistory.mockReturnValue(false);
 
       const { history } = await makeReadFileResponses(6);
@@ -2586,9 +2593,9 @@ describe('Gemini Client (client.ts)', () => {
         /* drain */
       }
 
-      // It attempted the surgical disarm, found no entry, then wiped.
       expect(markReadEvictedFromHistory).toHaveBeenCalled();
-      expect(clear).toHaveBeenCalled();
+      expect(invalidateByPath).toHaveBeenCalledWith(join(mcTmpDir, '0.ts'));
+      expect(clear).not.toHaveBeenCalled();
     });
 
     it('does not touch the cache when the idle gap is below the threshold', async () => {
@@ -2947,9 +2954,11 @@ describe('Gemini Client (client.ts)', () => {
       expect(client['forceFullIdeContext']).toBe(true);
     });
 
-    it('performs surgical disarm and falls back to clear() on inode miss', async () => {
-      const { clear, markReadEvictedFromHistory } = mockFileReadCacheStub();
+    it('uses targeted path fallback when fast compression sees an inode miss', async () => {
+      const { clear, markReadEvictedFromHistory, invalidateByPath } =
+        mockFileReadCacheStub();
       markReadEvictedFromHistory.mockReturnValueOnce(false); // inode mismatch
+      const evictedPath = join(mcTmpDir, 'test-file.ts');
       const compressFast = vi.fn().mockReturnValue({
         info: {
           originalTokenCount: 1000,
@@ -2958,7 +2967,7 @@ describe('Gemini Client (client.ts)', () => {
         },
         microcompactMeta: {
           unresolvedEvictedReads: 0,
-          evictedReadPaths: [join(mcTmpDir, 'test-file.ts')],
+          evictedReadPaths: [evictedPath],
           toolsCleared: 2,
           mediaCleared: 0,
           tokensSaved: 700,
@@ -2968,7 +2977,7 @@ describe('Gemini Client (client.ts)', () => {
           thresholdMinutes: 60,
         },
       });
-      await writeFile(join(mcTmpDir, 'test-file.ts'), 'test content');
+      await writeFile(evictedPath, 'test content');
       client['chat'] = {
         compressFast,
       } as unknown as GeminiChat;
@@ -2978,7 +2987,8 @@ describe('Gemini Client (client.ts)', () => {
 
       expect(result.compressionStatus).toBe(CompressionStatus.COMPRESSED);
       expect(markReadEvictedFromHistory).toHaveBeenCalledOnce();
-      expect(clear).toHaveBeenCalledOnce();
+      expect(invalidateByPath).toHaveBeenCalledWith(evictedPath);
+      expect(clear).not.toHaveBeenCalled();
       expect(client['forceFullIdeContext']).toBe(true);
     });
 

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -2700,8 +2700,9 @@ export class GeminiClient {
 
   /**
    * Surgically disarm FileReadCache entries for files evicted by
-   * microcompaction. Falls back to a blanket clear() when any evicted
-   * path can't be resolved.
+   * microcompaction. Falls back to a blanket clear() only when a blanked read
+   * cannot be linked to any path; path-level resolution failures are targeted
+   * to that path so one ghost file does not wipe unrelated cache entries.
    *
    * Shared by pre-send microcompaction and /compress-fast.
    */
@@ -2726,23 +2727,28 @@ export class GeminiClient {
         fsPromises.stat(p).catch(() => undefined),
       ),
     );
-    let fullyDisarmed = true;
-    for (const stats of statResults) {
-      if (!stats || !fileReadCache.markReadEvictedFromHistory(stats)) {
-        fullyDisarmed = false;
+    let usedPathFallback = false;
+    for (let i = 0; i < meta.evictedReadPaths.length; i++) {
+      const stats = statResults[i];
+      if (stats && fileReadCache.markReadEvictedFromHistory(stats)) {
+        continue;
+      }
+      const evictedPath = meta.evictedReadPaths[i];
+      if (evictedPath) {
+        fileReadCache.invalidateByPath(evictedPath);
+        usedPathFallback = true;
       }
     }
-    if (fullyDisarmed) {
+    if (usedPathFallback) {
       debugLogger.debug(
-        `[FILE_READ_CACHE] disarmed fast-path for ` +
+        `[FILE_READ_CACHE] disarmed fast-path by path for ` +
           `${meta.evictedReadPaths.length} file(s) after ${logTag}`,
       );
     } else {
       debugLogger.debug(
-        `[FILE_READ_CACHE] clear after ${logTag} ` +
-          '(an evicted path was unresolvable)',
+        `[FILE_READ_CACHE] disarmed fast-path for ` +
+          `${meta.evictedReadPaths.length} file(s) after ${logTag}`,
       );
-      fileReadCache.clear();
     }
   }
 

--- a/packages/core/src/services/fileReadCache.test.ts
+++ b/packages/core/src/services/fileReadCache.test.ts
@@ -570,6 +570,39 @@ describe('FileReadCache', () => {
       );
     });
 
+    it('invalidates a stale resident entry by its last observed path', () => {
+      const cache = new FileReadCache();
+      const stats = makeStats();
+      cache.recordRead('/x/foo.ts', stats, { full: true, cacheable: true });
+
+      expect(cache.invalidateByPath('/x/foo.ts')).toBe(true);
+      expect(cache.check(stats).state).toBe('unknown');
+    });
+
+    it('invalidates by a relative path that resolves to the recorded path', () => {
+      const cache = new FileReadCache();
+      const stats = makeStats();
+      const relative = path.join('x', 'foo.ts');
+      cache.recordRead(path.resolve(relative), stats, {
+        full: true,
+        cacheable: true,
+      });
+
+      expect(cache.invalidateByPath(relative)).toBe(true);
+      expect(cache.check(stats).state).toBe('unknown');
+    });
+
+    it('returns false when no entry was recorded for the path', () => {
+      const cache = new FileReadCache();
+      cache.recordRead('/x/foo.ts', makeStats(), {
+        full: true,
+        cacheable: true,
+      });
+
+      expect(cache.invalidateByPath('/x/other.ts')).toBe(false);
+      expect(cache.size()).toBe(1);
+    });
+
     it('a subsequent real read re-arms the fast-path (resident again)', () => {
       const cache = new FileReadCache();
       const stats = makeStats();

--- a/packages/core/src/services/fileReadCache.ts
+++ b/packages/core/src/services/fileReadCache.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Stats } from 'node:fs';
+import { resolve as resolvePath } from 'node:path';
 
 /**
  * Session-scoped cache that tracks which files the model has Read or
@@ -294,9 +295,10 @@ export class FileReadCache {
    * Returns `true` if a matching entry was found and disarmed; `false`
    * if there is no entry for `stats` (never tracked, or `stats`
    * resolved to a different inode than recorded — file replaced /
-   * symlink retargeted since the read). A `false` is NOT harmless: the
-   * stale entry stays armed, so the caller must fall back to
-   * {@link clear} just as it does for an unstattable path.
+   * symlink retargeted since the read). A `false` can still leave a
+   * stale entry armed, so callers that know the original path should
+   * fall back to {@link invalidateByPath}; callers without a path must
+   * fall back to {@link clear}.
    */
   markReadEvictedFromHistory(stats: Stats): boolean {
     const entry = this.byInode.get(FileReadCache.inodeKey(stats));
@@ -310,6 +312,29 @@ export class FileReadCache {
   /** Remove the entry for the given Stats, if any. */
   invalidate(stats: Stats): void {
     this.byInode.delete(FileReadCache.inodeKey(stats));
+  }
+
+  /**
+   * Best-effort targeted fallback when a caller cannot resolve a path to the
+   * inode it previously read (for example the file was deleted or replaced).
+   * Prefer {@link invalidate} / {@link markReadEvictedFromHistory} when Stats
+   * are available; this only matches the last observed path string.
+   *
+   * @returns true when at least one entry was removed.
+   */
+  invalidateByPath(absPath: string): boolean {
+    const target = resolvePath(absPath);
+    let removed = false;
+    for (const [key, entry] of this.byInode) {
+      if (
+        entry.realPath === absPath ||
+        resolvePath(entry.realPath) === target
+      ) {
+        this.byInode.delete(key);
+        removed = true;
+      }
+    }
+    return removed;
   }
 
   /** Drop every entry. Used by tests and on Config shutdown. */

--- a/packages/core/src/services/microcompaction/microcompact.test.ts
+++ b/packages/core/src/services/microcompaction/microcompact.test.ts
@@ -902,6 +902,72 @@ describe('microcompactHistory evictedReadPaths (issue #4239)', () => {
     expect(result.meta!.unresolvedEvictedReads).toBe(0);
   });
 
+  it('does not report a path when a kept read_file result for the same file remains', () => {
+    const history: Content[] = [
+      fileCall('old', 'read_file', '/proj/same.ts'),
+      fileResult('old', 'read_file', 'old long content '.repeat(50)),
+      fileCall('keep', 'read_file', '/proj/same.ts'),
+      fileResult('keep', 'read_file', 'newer full content'),
+    ];
+
+    const result = microcompactHistory(history, TWO_HOURS_AGO, {
+      toolResultsThresholdMinutes: 5,
+      toolResultsNumToKeep: 1,
+    });
+
+    expect(result.meta!.toolsCleared).toBe(1);
+    expect(result.meta!.evictedReadPaths).toEqual([]);
+    expect(result.meta!.unresolvedEvictedReads).toBe(0);
+  });
+
+  it('does not report a path when a pending kept result for the same file remains', () => {
+    const history: Content[] = [
+      fileCall('old', 'read_file', '/proj/same.ts'),
+      fileResult('old', 'read_file', 'old long content '.repeat(50)),
+      fileCall('keep', 'read_file', '/proj/same.ts'),
+    ];
+
+    const result = microcompactHistory(
+      history,
+      Date.now(),
+      {
+        toolResultsThresholdMinutes: 60,
+        toolResultsNumToKeep: 1,
+        toolResultsTotalCharsThreshold: 10,
+      },
+      {
+        sizeOnly: true,
+        pendingContent: fileResult('keep', 'read_file', 'newer full content'),
+      },
+    );
+
+    expect(result.meta!.triggerReason).toBe('size');
+    expect(result.meta!.toolsCleared).toBe(1);
+    expect(result.meta!.evictedReadPaths).toEqual([]);
+    expect(result.meta!.unresolvedEvictedReads).toBe(0);
+  });
+
+  it('does not let a kept reused id protect ambiguous candidate paths', () => {
+    const history: Content[] = [
+      fileCall('dup', 'read_file', '/proj/first.ts'),
+      fileResult('dup', 'read_file', 'first old content '.repeat(50)),
+      fileCall('dup', 'read_file', '/proj/second.ts'),
+      fileResult('dup', 'read_file', 'second kept content'),
+    ];
+
+    const result = microcompactHistory(history, TWO_HOURS_AGO, {
+      toolResultsThresholdMinutes: 5,
+      toolResultsNumToKeep: 1,
+    });
+
+    expect(result.meta!.toolsCleared).toBe(1);
+    expect([...result.meta!.evictedReadPaths].sort()).toEqual([
+      '/proj/first.ts',
+      '/proj/second.ts',
+    ]);
+    expect(result.meta!.unresolvedEvictedReads).toBe(0);
+  });
+
   it('disarms ALL paths sharing a reused functionCall.id (mimo F1)', () => {
     // Pathological/resumed history reuses one id across two files.
     // The blanked result must disarm BOTH candidate paths — keeping

--- a/packages/core/src/services/microcompaction/microcompact.ts
+++ b/packages/core/src/services/microcompaction/microcompact.ts
@@ -297,6 +297,40 @@ function buildClearMap(
   return clearMap;
 }
 
+function getFilePathsForResponse(
+  part: Part | undefined,
+  callIdToFilePath: Map<string, string[]>,
+): string[] | undefined {
+  const response = part?.functionResponse;
+  if (!response?.id || !response.name || !FILE_PATH_TOOLS.has(response.name)) {
+    return undefined;
+  }
+  const paths = callIdToFilePath.get(response.id);
+  return paths && paths.length > 0 ? [...new Set(paths)] : undefined;
+}
+
+function buildKeptFilePaths(
+  history: Content[],
+  refs: PartRef[],
+  keepRefs: Set<string>,
+  callIdToFilePath: Map<string, string[]>,
+): Set<string> {
+  const kept = new Set<string>();
+  for (const ref of refs) {
+    if (!keepRefs.has(refKey(ref))) continue;
+    const part = getPart(history, ref);
+    if (!part || isErrorResponse(part) || isAlreadyCleared(part)) continue;
+    const paths = getFilePathsForResponse(part, callIdToFilePath);
+    // If an id maps to multiple possible paths, a kept result cannot prove
+    // which file is still resident. Keep the #4239-safe behavior and do not
+    // let it protect any candidate path from disarming.
+    if (paths?.length === 1) {
+      kept.add(paths[0]!);
+    }
+  }
+  return kept;
+}
+
 interface SizeClearPlan {
   clearRefs: PartRef[];
   toolRefs: PartRef[];
@@ -446,6 +480,8 @@ export function microcompactHistory(
   let toolResultCharsAfter: number | undefined;
   let pendingToolResultChars: number | undefined;
   let toolResultsTotalCharsThreshold: number | undefined;
+  let keptPathHistory = history;
+  let keptPathRefs: PartRef[] = [];
 
   if (opts?.force) {
     triggerReason = 'force';
@@ -473,18 +509,23 @@ export function microcompactHistory(
     ]);
     const allRefs: PartRef[] = [...tool, ...media, ...nestedMedia];
     clearRefs = allRefs.filter((r) => !keepRefs.has(refKey(r)));
+    keptPathRefs = tool;
   } else {
+    const pending = normalizePendingContent(opts?.pendingContent);
     const sizePlan = planSizeBasedClearing(
       history,
       settings,
       keepRecent,
-      opts?.pendingContent,
+      pending,
     );
     if (!sizePlan) {
       return { history };
     }
     triggerReason = 'size';
     tool = sizePlan.toolRefs.filter((r) => r.contentIndex < history.length);
+    keptPathHistory =
+      pending.length > 0 ? [...history, ...pending] : keptPathHistory;
+    keptPathRefs = sizePlan.toolRefs;
     keepRefs = sizePlan.keepToolRefs;
     clearRefs = sizePlan.clearRefs;
     toolResultCharsBefore = sizePlan.toolResultCharsBefore;
@@ -507,7 +548,13 @@ export function microcompactHistory(
 
   if (clearRefs.length > 0) {
     const clearMap = buildClearMap(clearRefs);
-    const callIdToFilePath = buildCallIdToFilePath(history);
+    const callIdToFilePath = buildCallIdToFilePath(keptPathHistory);
+    const keptFilePaths = buildKeptFilePaths(
+      keptPathHistory,
+      keptPathRefs,
+      keepRefs,
+      callIdToFilePath,
+    );
 
     result = history.map((content, ci) => {
       const partsToClean = clearMap.get(ci);
@@ -529,14 +576,17 @@ export function microcompactHistory(
           toolsCleared++;
           touched = true;
           // Record the blanked file's path so the caller disarms its
-          // fast-path; if unrecoverable, count it so the caller falls
-          // back to the blanket wipe (issue #4239).
+          // fast-path unless a kept result for the same path is still
+          // quotable from history. If unrecoverable, count it so the
+          // caller falls back to the blanket wipe (issue #4239).
           if (FILE_PATH_TOOLS.has(part.functionResponse.name)) {
-            const filePaths = part.functionResponse.id
-              ? callIdToFilePath.get(part.functionResponse.id)
-              : undefined;
+            const filePaths = getFilePathsForResponse(part, callIdToFilePath);
             if (filePaths && filePaths.length > 0) {
-              for (const p of filePaths) evictedReadPaths.add(p);
+              for (const p of filePaths) {
+                if (!keptFilePaths.has(p)) {
+                  evictedReadPaths.add(p);
+                }
+              }
             } else {
               unresolvedEvictedReads++;
             }


### PR DESCRIPTION
## What this PR does

This avoids reporting evicted read paths when a kept same-path tool result remains quotable. It adds a path-level FileReadCache fallback for stat failures or inode mismatches, while keeping the blanket clear fallback for idless or unlinkable blanked reads.

## Why it's needed

Issue #4259 showed that microcompaction could disarm quoting for a file path even when the conversation still retained a same-path read result that should remain quotable. That makes later file references look unavailable even though useful read context is still present. The fix lets the cache fall back by path when identity checks are unavailable, without trusting unrelated blanked reads.

## Reviewer Test Plan

### How to verify

Check that microcompaction keeps a path quotable when a retained same-path read result exists, and still clears broadly for idless or unlinkable blanked reads. The tests cover the FileReadCache fallback and the microcompaction/client behavior that consumes it.

### Evidence (Before & After)

Before: a blanked read could cause microcompaction to report a path as evicted even when a kept same-path read remained in context. After: same-path retained reads keep that path quotable, and the broad clear fallback remains for ambiguous blanked reads.

### Tested on

| OS | Status |
| :--: | :--: |
| macOS | tested |
| Windows | CI |
| Linux | CI |

### Environment (optional)

Node 22 via `npx -p node@22`.

Commands run locally:

- `npx -p node@22 node node_modules/vitest/vitest.mjs run --coverage.enabled=false packages/core/src/services/microcompaction/microcompact.test.ts packages/core/src/services/fileReadCache.test.ts packages/core/src/core/client.test.ts`
- `npx -p node@22 node node_modules/typescript/bin/tsc --noEmit --project packages/core/tsconfig.json`
- `npx -p node@22 node node_modules/eslint/bin/eslint.js packages/core/src/services/microcompaction/microcompact.ts packages/core/src/services/microcompaction/microcompact.test.ts packages/core/src/services/fileReadCache.ts packages/core/src/services/fileReadCache.test.ts packages/core/src/core/client.ts packages/core/src/core/client.test.ts`
- `npx -p node@22 node node_modules/prettier/bin/prettier.cjs --check packages/core/src/services/microcompaction/microcompact.ts packages/core/src/services/microcompaction/microcompact.test.ts packages/core/src/services/fileReadCache.ts packages/core/src/services/fileReadCache.test.ts packages/core/src/core/client.ts packages/core/src/core/client.test.ts`
- `git diff --check`

## Risk & Scope

- Main risk or tradeoff: path fallback is intentionally limited to retained same-path reads, so it improves stat-failure/inode-mismatch handling without making unrelated paths quotable.
- Not validated / out of scope: no full interactive microcompaction session was recorded.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #4259

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 避免在仍然保留同路径可引用 tool result 时，把对应 read path 报告成已驱逐。它为 stat 失败或 inode 不匹配增加了 path-level FileReadCache fallback，同时保留 idless 或无法关联路径的 blanked reads 的 blanket clear fallback。

## Why it's needed

#4259 暴露出 microcompaction 可能会让一个文件路径失去引用能力，即使对话里还保留着同路径、仍应可引用的 read result。这样后续文件引用会看起来不可用，但实际上还有有用的 read context。这个修复在 identity check 不可用时按 path fallback，同时不会信任无关的 blanked reads。

## Reviewer Test Plan

### How to verify

确认当保留了同路径 read result 时，microcompaction 会让该 path 继续可引用；同时对于 idless 或无法关联路径的 blanked reads，仍然会走 broad clear。测试覆盖了 FileReadCache fallback，以及消费它的 microcompaction/client 行为。

### Evidence (Before & After)

Before：blanked read 可能让 microcompaction 把某个 path 报告成已驱逐，即使 context 里还保留着同路径 read。After：同路径 retained reads 会让该 path 保持可引用，ambiguous blanked reads 仍然保留 broad clear fallback。

### Tested on

| OS | Status |
| :--: | :--: |
| macOS | tested |
| Windows | CI |
| Linux | CI |

### Environment (optional)

通过 `npx -p node@22` 使用 Node 22。

本地运行过：

- `npx -p node@22 node node_modules/vitest/vitest.mjs run --coverage.enabled=false packages/core/src/services/microcompaction/microcompact.test.ts packages/core/src/services/fileReadCache.test.ts packages/core/src/core/client.test.ts`
- `npx -p node@22 node node_modules/typescript/bin/tsc --noEmit --project packages/core/tsconfig.json`
- `npx -p node@22 node node_modules/eslint/bin/eslint.js packages/core/src/services/microcompaction/microcompact.ts packages/core/src/services/microcompaction/microcompact.test.ts packages/core/src/services/fileReadCache.ts packages/core/src/services/fileReadCache.test.ts packages/core/src/core/client.ts packages/core/src/core/client.test.ts`
- `npx -p node@22 node node_modules/prettier/bin/prettier.cjs --check packages/core/src/services/microcompaction/microcompact.ts packages/core/src/services/microcompaction/microcompact.test.ts packages/core/src/services/fileReadCache.ts packages/core/src/services/fileReadCache.test.ts packages/core/src/core/client.ts packages/core/src/core/client.test.ts`
- `git diff --check`

## Risk & Scope

- Main risk or tradeoff：path fallback 被限制在 retained same-path reads 上，所以它改善 stat-failure/inode-mismatch 场景，但不会让无关路径变成可引用。
- Not validated / out of scope：没有录制完整 interactive microcompaction session。
- Breaking changes / migration notes：无。

## Linked Issues

Fixes #4259

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
