### PR TITLE
fix(core): block broad shell self-kill commands

### DIFF
--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -263,6 +263,38 @@ describe('ShellTool', () => {
       expect(error).toBeNull();
     });
 
+    it('should reject broad kill commands that can terminate qwen-code', async () => {
+      for (const command of [
+        'taskkill /F /IM node.exe',
+        'killall node',
+        'pkill -f qwen-code',
+      ]) {
+        expect(() =>
+          shellTool.build({
+            command,
+            is_background: false,
+          }),
+        ).toThrow(
+          'Blocked: this command may terminate the running qwen-code process',
+        );
+      }
+    });
+
+    it('should allow targeted process kills', async () => {
+      expect(
+        shellTool.validateToolParams({
+          command: 'taskkill /PID 1234 /F',
+          is_background: false,
+        }),
+      ).toBeNull();
+      expect(
+        shellTool.validateToolParams({
+          command: 'kill 1234',
+          is_background: false,
+        }),
+      ).toBeNull();
+    });
+
     it('should guide model to split and use intentional-sleep for sleep chains', async () => {
       const error = shellTool.validateToolParams({
         command: 'sleep 5 && echo ok',

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -52,10 +52,12 @@ import type { AnsiOutput } from '../utils/terminalSerializer.js';
 import { isSubpaths, makeRelative, shortenPath } from '../utils/paths.js';
 import {
   buildShellExecWarnings,
+  detectSelfKillCommand,
   getCommandRoot,
   getCommandRoots,
   getShellConfiguration,
   hasShellSubstitution,
+  SHELL_SELF_KILL_REJECTION,
   type ShellConfiguration,
   type ShellType,
   splitCommands,
@@ -4760,11 +4762,15 @@ export class ShellTool extends BaseDeclarativeTool<
   ): string | null {
     // NOTE: Permission checks (read-only detection, PM rules) are handled at
     // L3 (getDefaultPermission) and L4 (PM override) in coreToolScheduler.
-    // This method only performs pure parameter validation.
+    // This method handles parameter validation plus non-overridable shell
+    // safety gates that must run before auto/YOLO execution.
     if (!params.command.trim()) {
       return 'Command cannot be empty.';
     }
     const strippedCommand = stripShellWrapper(params.command);
+    if (detectSelfKillCommand(params.command)) {
+      return SHELL_SELF_KILL_REJECTION;
+    }
     if (
       params.is_background &&
       hasTopLevelTrailingBackgroundOperator(strippedCommand)

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -589,9 +589,35 @@ describe('detectSelfKillCommand', () => {
 
   it('detects broad Unix killall and pkill patterns', () => {
     expect(detectSelfKillCommand('killall -9 node')).toBe(true);
+    expect(detectSelfKillCommand('pkill node')).toBe(true);
     expect(detectSelfKillCommand('pkill -f qwen-code')).toBe(true);
     expect(detectSelfKillCommand('pkill -f /usr/bin/node')).toBe(true);
+    expect(detectSelfKillCommand('pkill -9f node')).toBe(true);
     expect(detectSelfKillCommand("bash -lc 'pkill -f qwen'")).toBe(true);
+  });
+
+  it('detects self-kill commands in chains and execution prefixes', () => {
+    expect(detectSelfKillCommand('echo setup && killall node')).toBe(true);
+    expect(detectSelfKillCommand('false || taskkill /F /IM node.exe')).toBe(
+      true,
+    );
+    expect(detectSelfKillCommand('sudo killall node')).toBe(true);
+    expect(detectSelfKillCommand('env FOO=bar pkill -f qwen-code')).toBe(true);
+    expect(detectSelfKillCommand('command -p killall node')).toBe(true);
+  });
+
+  it('detects taskkill inline and dash-prefixed image options', () => {
+    expect(detectSelfKillCommand('taskkill /IM:node.exe /F')).toBe(true);
+    expect(
+      detectSelfKillCommand('taskkill /FI:"IMAGENAME eq qwen-code.exe" /F'),
+    ).toBe(true);
+    expect(detectSelfKillCommand('taskkill -IM node.exe -F')).toBe(true);
+  });
+
+  it('detects glob patterns emitted by shell parsing', () => {
+    expect(detectSelfKillCommand('killall node*')).toBe(true);
+    expect(detectSelfKillCommand('pkill -f node*')).toBe(true);
+    expect(detectSelfKillCommand('taskkill /IM node*')).toBe(true);
   });
 
   it('detects taskkill through Windows shell wrappers', () => {
@@ -606,6 +632,11 @@ describe('detectSelfKillCommand', () => {
     expect(
       detectSelfKillCommand('powershell -Command taskkill /F /IM node.exe'),
     ).toBe(true);
+    expect(
+      detectSelfKillCommand(
+        'powershell -ExecutionPolicy Bypass -Command "taskkill /F /IM node.exe"',
+      ),
+    ).toBe(true);
     expect(detectSelfKillCommand('cmd.exe /c taskkill /F /IM node.exe')).toBe(
       true,
     );
@@ -616,6 +647,7 @@ describe('detectSelfKillCommand', () => {
     expect(detectSelfKillCommand('kill 1234')).toBe(false);
     expect(detectSelfKillCommand('pkill -f vite')).toBe(false);
     expect(detectSelfKillCommand('pkill -f "node server.js"')).toBe(false);
+    expect(detectSelfKillCommand('pkill -9f "node server.js"')).toBe(false);
     expect(detectSelfKillCommand('pkill -F qwen-code.pid vite')).toBe(false);
     expect(detectSelfKillCommand('taskkill /IM notepad.exe')).toBe(false);
   });

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -10,6 +10,7 @@ import {
   checkArgumentSafety,
   checkCommandPermissions,
   COMMAND_SUBSTITUTION_WARNING,
+  detectSelfKillCommand,
   escapeShellArg,
   getCommandRoots,
   getShellConfiguration,
@@ -507,6 +508,18 @@ describe('stripShellWrapper', () => {
     expect(stripShellWrapper('cmd.exe /c "dir"')).toEqual('dir');
   });
 
+  it('should preserve the full unquoted command after cmd.exe /c', async () => {
+    expect(stripShellWrapper('cmd.exe /c taskkill /F /IM node.exe')).toEqual(
+      'taskkill /F /IM node.exe',
+    );
+  });
+
+  it('should preserve the full unquoted command after PowerShell -Command', async () => {
+    expect(
+      stripShellWrapper('powershell -Command taskkill /F /IM node.exe'),
+    ).toEqual('taskkill /F /IM node.exe');
+  });
+
   it('should not strip anything if no wrapper is present', async () => {
     expect(stripShellWrapper('ls -l')).toEqual('ls -l');
   });
@@ -563,6 +576,48 @@ describe('stripTrailingBackgroundAmp', () => {
     expect(stripTrailingBackgroundAmp('sleep 5 & echo done')).toBe(
       'sleep 5 & echo done',
     );
+  });
+});
+
+describe('detectSelfKillCommand', () => {
+  it('detects broad Windows taskkill patterns that target qwen-code hosts', () => {
+    expect(detectSelfKillCommand('taskkill /F /IM node.exe 2>nul')).toBe(true);
+    expect(
+      detectSelfKillCommand('taskkill /FI "IMAGENAME eq qwen-code.exe" /F'),
+    ).toBe(true);
+  });
+
+  it('detects broad Unix killall and pkill patterns', () => {
+    expect(detectSelfKillCommand('killall -9 node')).toBe(true);
+    expect(detectSelfKillCommand('pkill -f qwen-code')).toBe(true);
+    expect(detectSelfKillCommand('pkill -f /usr/bin/node')).toBe(true);
+    expect(detectSelfKillCommand("bash -lc 'pkill -f qwen'")).toBe(true);
+  });
+
+  it('detects taskkill through Windows shell wrappers', () => {
+    expect(
+      detectSelfKillCommand('powershell -Command "taskkill /F /IM node.exe"'),
+    ).toBe(true);
+    expect(
+      detectSelfKillCommand(
+        'pwsh -NoProfile -Command "taskkill /F /IM node.exe"',
+      ),
+    ).toBe(true);
+    expect(
+      detectSelfKillCommand('powershell -Command taskkill /F /IM node.exe'),
+    ).toBe(true);
+    expect(detectSelfKillCommand('cmd.exe /c taskkill /F /IM node.exe')).toBe(
+      true,
+    );
+  });
+
+  it('allows targeted process kills and unrelated process patterns', () => {
+    expect(detectSelfKillCommand('taskkill /PID 1234 /F')).toBe(false);
+    expect(detectSelfKillCommand('kill 1234')).toBe(false);
+    expect(detectSelfKillCommand('pkill -f vite')).toBe(false);
+    expect(detectSelfKillCommand('pkill -f "node server.js"')).toBe(false);
+    expect(detectSelfKillCommand('pkill -F qwen-code.pid vite')).toBe(false);
+    expect(detectSelfKillCommand('taskkill /IM notepad.exe')).toBe(false);
   });
 });
 

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -396,7 +396,7 @@ const QWEN_PROCESS_PATTERN =
   /(^|[^a-z0-9_-])qwen(?:-code)?(?:\.exe)?(?=$|[^a-z0-9_-])/i;
 const TASKKILL_IMAGE_FILTER_PATTERN = /\bimagename\s+eq\s+(.+)$/i;
 
-const EXEC_PREFIX_OPTIONS_WITH_VALUES = new Set([
+const SUDO_OPTIONS_WITH_VALUES = new Set([
   '-u',
   '--user',
   '-g',
@@ -409,6 +409,17 @@ const EXEC_PREFIX_OPTIONS_WITH_VALUES = new Set([
   '--close-from',
   '-T',
   '--command-timeout',
+]);
+
+const COMMAND_OPTIONS_WITH_VALUES = new Set<string>();
+
+const ENV_OPTIONS_WITH_VALUES = new Set([
+  '-u',
+  '--unset',
+  '-S',
+  '--split-string',
+  '-C',
+  '--chdir',
 ]);
 
 const KILLALL_OPTIONS_WITH_VALUES = new Set([
@@ -454,9 +465,22 @@ export const SHELL_SELF_KILL_REJECTION =
 
 function parseShellSegment(segment: string): string[] | null {
   try {
-    return parse(segment, (key) => '$' + key).filter(
-      (token): token is string => typeof token === 'string',
-    );
+    return parse(segment, (key) => '$' + key)
+      .map((token) => {
+        if (typeof token === 'string') {
+          return token;
+        }
+        if (
+          typeof token === 'object' &&
+          token !== null &&
+          'pattern' in token &&
+          typeof token.pattern === 'string'
+        ) {
+          return token.pattern;
+        }
+        return null;
+      })
+      .filter((token): token is string => token !== null);
   } catch {
     return null;
   }
@@ -479,6 +503,15 @@ function optionHasInlineValue(token: string): boolean {
   return token.includes('=') || token.includes(':');
 }
 
+function shortOptionBundleHasFlag(token: string, flag: string): boolean {
+  return (
+    token.startsWith('-') &&
+    !token.startsWith('--') &&
+    token.length > 2 &&
+    token.slice(1).toLowerCase().includes(flag.toLowerCase().slice(1))
+  );
+}
+
 function matchesSelfProcessPattern(value: string): boolean {
   return SELF_KILL_PROCESS_PATTERN.test(value);
 }
@@ -493,12 +526,17 @@ function isBroadNodeFullPattern(value: string): boolean {
     .replace(/^(\^|\\b|\.\*)+/, '')
     .replace(/(\$|\\b|\.\*)+$/, '');
   const base = normalized.split(/[\\/]/).pop()?.toLowerCase();
-  return base === 'node' || base === 'node.exe';
+  return (
+    base === 'node' ||
+    base === 'node.exe' ||
+    /^node(?:\.exe)?[*?]+$/.test(base ?? '')
+  );
 }
 
 function consumeOptionsWithValues(
   tokens: string[],
   startIndex: number,
+  optionsWithValues: Set<string>,
 ): number {
   let index = startIndex;
   while (index < tokens.length) {
@@ -510,7 +548,10 @@ function consumeOptionsWithValues(
 
     index++;
     if (
-      EXEC_PREFIX_OPTIONS_WITH_VALUES.has(normalized) &&
+      (optionsWithValues.has(normalized) ||
+        [...optionsWithValues].some((option) =>
+          shortOptionBundleHasFlag(token, option),
+        )) &&
       !optionHasInlineValue(token)
     ) {
       index++;
@@ -528,17 +569,29 @@ function unwrapExecutionPrefixes(tokens: string[]): string[] {
   while (index < tokens.length) {
     const root = normalizeExecutableName(tokens[index]!);
     if (root === 'sudo') {
-      index = consumeOptionsWithValues(tokens, index + 1);
+      index = consumeOptionsWithValues(
+        tokens,
+        index + 1,
+        SUDO_OPTIONS_WITH_VALUES,
+      );
       continue;
     }
 
     if (root === 'command') {
-      index = consumeOptionsWithValues(tokens, index + 1);
+      index = consumeOptionsWithValues(
+        tokens,
+        index + 1,
+        COMMAND_OPTIONS_WITH_VALUES,
+      );
       continue;
     }
 
     if (root === 'env') {
-      index = consumeOptionsWithValues(tokens, index + 1);
+      index = consumeOptionsWithValues(
+        tokens,
+        index + 1,
+        ENV_OPTIONS_WITH_VALUES,
+      );
       while (
         index < tokens.length &&
         ENV_ASSIGNMENT_REGEX.test(tokens[index]!)
@@ -560,6 +613,8 @@ function getCommandSegments(command: string, depth = 0): string[] {
     const stripped = stripShellWrapper(segment);
     if (stripped !== segment && depth < 3) {
       segments.push(...getCommandSegments(stripped, depth + 1));
+    } else if (stripped !== segment) {
+      segments.push(stripped);
     } else {
       segments.push(segment);
     }
@@ -650,7 +705,11 @@ function pkillTargetsSelf(tokens: string[]): boolean {
     }
 
     const normalized = optionKey(token);
-    if (normalized === '-f' || normalized === '--full') {
+    if (
+      normalized === '-f' ||
+      normalized === '--full' ||
+      shortOptionBundleHasFlag(token, '-f')
+    ) {
       usesFullCommandLine = true;
       continue;
     }
@@ -678,6 +737,10 @@ function pkillTargetsSelf(tokens: string[]): boolean {
 }
 
 export function detectSelfKillCommand(command: string): boolean {
+  if (!/kill/i.test(command)) {
+    return false;
+  }
+
   const segments = getCommandSegments(command);
   for (const segment of segments) {
     const parsed = parseShellSegment(segment);
@@ -1008,11 +1071,23 @@ function isShellWrapperFlagToken(normalizedToken: string): boolean {
 
 function shellWrapperFlagConsumesOperand(token: string): boolean {
   const normalized = getNormalizedShellToken(token);
-  return normalized === '-o' || normalized === '+o';
+  if (optionHasInlineValue(token)) {
+    return false;
+  }
+  return (
+    normalized === '-o' ||
+    normalized === '+o' ||
+    normalized === '-executionpolicy' ||
+    normalized === '-file' ||
+    normalized === '-encodedcommand'
+  );
 }
 
 function shellWrapperCommandConsumesRest(wrapperToken: string): boolean {
   const base = getShellWrapperBase(wrapperToken);
+  // POSIX shells pass exactly one argument after -c as the command string.
+  // cmd.exe and PowerShell treat the remaining tokens after /c or -Command as
+  // the command, so unquoted inner commands need the full rest of the line.
   return (
     base === 'cmd' ||
     base === 'cmd.exe' ||

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -366,7 +366,12 @@ export function stripShellWrapper(command: string): string {
     if (isMonitorCommandMarker(wrapperToken.token, token.token)) {
       const commandToken = takeLeadingToken(token.rest);
       if (!commandToken) return trimmed;
-      const { value: innerCommand } = stripSymmetricQuotes(commandToken.token);
+      const { value: innerCommand, quote } = stripSymmetricQuotes(
+        commandToken.token,
+      );
+      if (!quote && shellWrapperCommandConsumesRest(wrapperToken.token)) {
+        return token.rest.trimStart() || trimmed;
+      }
       return innerCommand || trimmed;
     }
 
@@ -383,6 +388,321 @@ export function stripShellWrapper(command: string): string {
       rest = operandToken.rest;
     }
   }
+}
+
+const SELF_KILL_PROCESS_PATTERN =
+  /(^|[^a-z0-9_-])(node(?:\.exe)?|qwen(?:-code)?(?:\.exe)?)(?=$|[^a-z0-9_-])/i;
+const QWEN_PROCESS_PATTERN =
+  /(^|[^a-z0-9_-])qwen(?:-code)?(?:\.exe)?(?=$|[^a-z0-9_-])/i;
+const TASKKILL_IMAGE_FILTER_PATTERN = /\bimagename\s+eq\s+(.+)$/i;
+
+const EXEC_PREFIX_OPTIONS_WITH_VALUES = new Set([
+  '-u',
+  '--user',
+  '-g',
+  '--group',
+  '-h',
+  '--host',
+  '-p',
+  '--prompt',
+  '-C',
+  '--close-from',
+  '-T',
+  '--command-timeout',
+]);
+
+const KILLALL_OPTIONS_WITH_VALUES = new Set([
+  '-n',
+  '--ns',
+  '-o',
+  '--older-than',
+  '-s',
+  '--signal',
+  '-t',
+  '--tty',
+  '-u',
+  '--user',
+  '-y',
+  '--younger-than',
+  '-Z',
+  '--context',
+]);
+
+const PKILL_OPTIONS_WITH_VALUES = new Set([
+  '-F',
+  '--pidfile',
+  '-G',
+  '--group',
+  '-g',
+  '--pgroup',
+  '-P',
+  '--parent',
+  '-s',
+  '--session',
+  '-t',
+  '--terminal',
+  '-T',
+  '--thread',
+  '-U',
+  '--uid',
+  '-u',
+  '--euid',
+]);
+
+export const SHELL_SELF_KILL_REJECTION =
+  'Blocked: this command may terminate the running qwen-code process because it targets all node/qwen-code processes. Use task_stop for managed background shells, or kill a specific PID instead.';
+
+function parseShellSegment(segment: string): string[] | null {
+  try {
+    return parse(segment, (key) => '$' + key).filter(
+      (token): token is string => typeof token === 'string',
+    );
+  } catch {
+    return null;
+  }
+}
+
+function normalizeExecutableName(token: string): string {
+  const executable = token.split(/[\\/]/).pop() ?? token;
+  return executable.toLowerCase().replace(/\.exe$/, '');
+}
+
+function isOptionToken(token: string): boolean {
+  return token.startsWith('-');
+}
+
+function optionKey(token: string): string {
+  return token.startsWith('--') ? token.toLowerCase() : token;
+}
+
+function optionHasInlineValue(token: string): boolean {
+  return token.includes('=') || token.includes(':');
+}
+
+function matchesSelfProcessPattern(value: string): boolean {
+  return SELF_KILL_PROCESS_PATTERN.test(value);
+}
+
+function matchesQwenProcessPattern(value: string): boolean {
+  return QWEN_PROCESS_PATTERN.test(value);
+}
+
+function isBroadNodeFullPattern(value: string): boolean {
+  const normalized = value
+    .trim()
+    .replace(/^(\^|\\b|\.\*)+/, '')
+    .replace(/(\$|\\b|\.\*)+$/, '');
+  const base = normalized.split(/[\\/]/).pop()?.toLowerCase();
+  return base === 'node' || base === 'node.exe';
+}
+
+function consumeOptionsWithValues(
+  tokens: string[],
+  startIndex: number,
+): number {
+  let index = startIndex;
+  while (index < tokens.length) {
+    const token = tokens[index]!;
+    const normalized = optionKey(token);
+    if (!isOptionToken(token)) {
+      break;
+    }
+
+    index++;
+    if (
+      EXEC_PREFIX_OPTIONS_WITH_VALUES.has(normalized) &&
+      !optionHasInlineValue(token)
+    ) {
+      index++;
+    }
+  }
+  return index;
+}
+
+function unwrapExecutionPrefixes(tokens: string[]): string[] {
+  let index = 0;
+  while (index < tokens.length && ENV_ASSIGNMENT_REGEX.test(tokens[index]!)) {
+    index++;
+  }
+
+  while (index < tokens.length) {
+    const root = normalizeExecutableName(tokens[index]!);
+    if (root === 'sudo') {
+      index = consumeOptionsWithValues(tokens, index + 1);
+      continue;
+    }
+
+    if (root === 'command') {
+      index = consumeOptionsWithValues(tokens, index + 1);
+      continue;
+    }
+
+    if (root === 'env') {
+      index = consumeOptionsWithValues(tokens, index + 1);
+      while (
+        index < tokens.length &&
+        ENV_ASSIGNMENT_REGEX.test(tokens[index]!)
+      ) {
+        index++;
+      }
+      continue;
+    }
+
+    break;
+  }
+
+  return tokens.slice(index);
+}
+
+function getCommandSegments(command: string, depth = 0): string[] {
+  const segments: string[] = [];
+  for (const segment of splitCommands(command)) {
+    const stripped = stripShellWrapper(segment);
+    if (stripped !== segment && depth < 3) {
+      segments.push(...getCommandSegments(stripped, depth + 1));
+    } else {
+      segments.push(segment);
+    }
+  }
+  return segments;
+}
+
+function commandArguments(tokens: string[], optionsWithValues: Set<string>) {
+  const args: string[] = [];
+  for (let index = 1; index < tokens.length; index++) {
+    const token = tokens[index]!;
+    if (token === '--') {
+      args.push(...tokens.slice(index + 1));
+      break;
+    }
+
+    const normalized = optionKey(token);
+    if (isOptionToken(token)) {
+      if (optionsWithValues.has(normalized) && !optionHasInlineValue(token)) {
+        index++;
+      }
+      continue;
+    }
+
+    args.push(token);
+  }
+  return args;
+}
+
+function taskkillTargetsSelf(tokens: string[]): boolean {
+  for (let index = 1; index < tokens.length; index++) {
+    const token = tokens[index]!;
+    const normalized = token.toLowerCase();
+
+    if (normalized === '/im' || normalized === '-im') {
+      const imageName = tokens[index + 1];
+      if (imageName && matchesSelfProcessPattern(imageName)) {
+        return true;
+      }
+      index++;
+      continue;
+    }
+
+    if (normalized.startsWith('/im:') || normalized.startsWith('-im:')) {
+      if (matchesSelfProcessPattern(token.slice(4))) {
+        return true;
+      }
+      continue;
+    }
+
+    if (normalized === '/fi' || normalized === '-fi') {
+      const filter = tokens[index + 1];
+      const imageName = filter?.match(TASKKILL_IMAGE_FILTER_PATTERN)?.[1];
+      if (imageName && matchesSelfProcessPattern(imageName)) {
+        return true;
+      }
+      index++;
+      continue;
+    }
+
+    if (normalized.startsWith('/fi:') || normalized.startsWith('-fi:')) {
+      const imageName = token
+        .slice(4)
+        .match(TASKKILL_IMAGE_FILTER_PATTERN)?.[1];
+      if (imageName && matchesSelfProcessPattern(imageName)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function killallTargetsSelf(tokens: string[]): boolean {
+  return commandArguments(tokens, KILLALL_OPTIONS_WITH_VALUES).some((arg) =>
+    matchesSelfProcessPattern(arg),
+  );
+}
+
+function pkillTargetsSelf(tokens: string[]): boolean {
+  let usesFullCommandLine = false;
+  const args: string[] = [];
+  for (let index = 1; index < tokens.length; index++) {
+    const token = tokens[index]!;
+    if (token === '--') {
+      args.push(...tokens.slice(index + 1));
+      break;
+    }
+
+    const normalized = optionKey(token);
+    if (normalized === '-f' || normalized === '--full') {
+      usesFullCommandLine = true;
+      continue;
+    }
+
+    if (isOptionToken(token)) {
+      if (
+        PKILL_OPTIONS_WITH_VALUES.has(normalized) &&
+        !optionHasInlineValue(token)
+      ) {
+        index++;
+      }
+      continue;
+    }
+
+    args.push(token);
+  }
+
+  if (usesFullCommandLine) {
+    return args.some(
+      (arg) => matchesQwenProcessPattern(arg) || isBroadNodeFullPattern(arg),
+    );
+  }
+
+  return args.some((arg) => matchesSelfProcessPattern(arg));
+}
+
+export function detectSelfKillCommand(command: string): boolean {
+  const segments = getCommandSegments(command);
+  for (const segment of segments) {
+    const parsed = parseShellSegment(segment);
+    if (!parsed) {
+      continue;
+    }
+
+    const tokens = unwrapExecutionPrefixes(parsed);
+    if (tokens.length === 0) {
+      continue;
+    }
+
+    const root = normalizeExecutableName(tokens[0]!);
+    if (root === 'taskkill' && taskkillTargetsSelf(tokens)) {
+      return true;
+    }
+    if (root === 'killall' && killallTargetsSelf(tokens)) {
+      return true;
+    }
+    if (root === 'pkill' && pkillTargetsSelf(tokens)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 /**
@@ -670,7 +990,11 @@ function isKnownMonitorWrapperToken(token: string): boolean {
     base === 'zsh' ||
     base === 'zsh.exe' ||
     base === 'cmd' ||
-    base === 'cmd.exe'
+    base === 'cmd.exe' ||
+    base === 'powershell' ||
+    base === 'powershell.exe' ||
+    base === 'pwsh' ||
+    base === 'pwsh.exe'
   );
 }
 
@@ -687,12 +1011,33 @@ function shellWrapperFlagConsumesOperand(token: string): boolean {
   return normalized === '-o' || normalized === '+o';
 }
 
+function shellWrapperCommandConsumesRest(wrapperToken: string): boolean {
+  const base = getShellWrapperBase(wrapperToken);
+  return (
+    base === 'cmd' ||
+    base === 'cmd.exe' ||
+    base === 'powershell' ||
+    base === 'powershell.exe' ||
+    base === 'pwsh' ||
+    base === 'pwsh.exe'
+  );
+}
+
 function isMonitorCommandMarker(wrapperToken: string, token: string): boolean {
   const base = getShellWrapperBase(wrapperToken);
   const normalized = getNormalizedShellToken(token);
 
   if (base === 'cmd' || base === 'cmd.exe') {
     return normalized === '/c';
+  }
+
+  if (
+    base === 'powershell' ||
+    base === 'powershell.exe' ||
+    base === 'pwsh' ||
+    base === 'pwsh.exe'
+  ) {
+    return normalized === '-command' || normalized === '-c';
   }
 
   return normalized === '-c' || /^-[a-z]*c[a-z]*$/i.test(normalized);


### PR DESCRIPTION
## What this PR does

This blocks broad shell kill commands that can terminate the running qwen-code process before permission or auto-execution logic runs.

The guard detects risky `taskkill`, `killall`, and `pkill` patterns across shell wrappers, execution prefixes, command chains, glob patterns, and common Windows option forms while keeping targeted PID kills and narrower unrelated `pkill -f` patterns allowed.

## Why it is needed

Fixes #4854. The agent can otherwise approve or auto-run broad commands such as `taskkill /F /IM node.exe`, which may kill the qwen-code process itself. This needs to be rejected before permissions, including in YOLO/auto-approve mode.

## Reviewer Test Plan

### How to verify

Review `packages/core/src/utils/shell-utils.ts` and confirm `detectSelfKillCommand()` is called from shell parameter validation before shell execution. The unit tests cover direct commands, shell wrappers, execution prefixes, chained commands, Windows inline options, glob targets, bundled `pkill -f` flags, and allowed targeted/unrelated kills.

### Evidence

Before: broad process-name kills such as `taskkill /F /IM node.exe` could pass through shell validation. After: those commands fail parameter validation with the self-kill rejection message before execution.

### Tested on

| OS | Status |
| :--: | :--: |
| macOS | tested locally |
| Windows | CI |
| Linux | CI |

Commands run locally:

- `npx vitest run --coverage.enabled=false packages/core/src/utils/shell-utils.test.ts packages/core/src/tools/shell.test.ts`
- `npx eslint packages/core/src/utils/shell-utils.ts packages/core/src/tools/shell.ts packages/core/src/utils/shell-utils.test.ts packages/core/src/tools/shell.test.ts`
- `npx prettier --check packages/core/src/utils/shell-utils.ts packages/core/src/tools/shell.ts packages/core/src/utils/shell-utils.test.ts packages/core/src/tools/shell.test.ts`
- `npm run build --workspace packages/core`
- `npx tsc --noEmit --project packages/core/tsconfig.json`
- `git diff --check upstream/main`

## Risk & Scope

- Main risk or tradeoff: this is a non-overridable validation guard for broad self-kill patterns. Users can still kill a specific PID when they really need to stop something.
- Not validated / out of scope: this is not a full shell security boundary and does not try to catch every indirect kill construction such as command substitution pipelines.
- Breaking changes / migration notes: broad `node` / `qwen-code` process-name kills are intentionally rejected by the shell tool.

## Linked Issues

Fixes #4854

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.