### PR TITLE
fix(channel): keep qqbot token refresh retrying

### DIFF
--- a/packages/channels/qqbot/src/QQChannel.ts
+++ b/packages/channels/qqbot/src/QQChannel.ts
@@ -539,20 +539,24 @@ export class QQChannel extends ChannelBase {
           process.stderr.write(
             `[QQ:${this.name}] Token refresh failed: ${e}, retrying in 60s\n`,
           );
-          // Retry fetchToken directly instead of going through
-          // scheduleTokenRefresh (which would add another ~60s of
-          // delay from the stale tokenExpiresAt).
-          this.tokenRefreshTimer = setTimeout(() => {
-            if (this.disposed) return;
-            this.fetchToken().catch(() => {
-              process.stderr.write(
-                `[QQ:${this.name}] Token refresh failed again after retry\n`,
-              );
-            });
-          }, 60_000);
+          this.scheduleTokenRefreshRetry();
         });
       }, delay);
     }
+  }
+
+  private scheduleTokenRefreshRetry(): void {
+    if (this.disposed) return;
+    this.stopTokenRefresh();
+    this.tokenRefreshTimer = setTimeout(() => {
+      this.fetchToken().catch((e) => {
+        if (this.disposed) return;
+        process.stderr.write(
+          `[QQ:${this.name}] Token refresh failed: ${e}, retrying in 60s\n`,
+        );
+        this.scheduleTokenRefreshRetry();
+      });
+    }, 60_000);
   }
 
   private stopTokenRefresh(): void {

--- a/packages/channels/qqbot/src/send.test.ts
+++ b/packages/channels/qqbot/src/send.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { isValidChatId, hasMarkdownSyntax, splitText } from './QQChannel.js';
 
 const { mockSendQQMessage, mockFetchAccessToken } = vi.hoisted(() => ({
@@ -60,6 +60,10 @@ vi.mock('@qwen-code/channel-base', () => ({
 }));
 
 const { QQChannel } = await import('./QQChannel.js');
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 /** Create a mock Response-like object for sendQQMessage. */
 function mockResponse(
@@ -379,6 +383,39 @@ describe('sendMessage', () => {
 
     expect(mockSendQQMessage).not.toHaveBeenCalled();
     expect(mockFetchAccessToken).toHaveBeenCalled();
+  });
+
+  it('keeps retrying scheduled token refresh failures until one succeeds', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+    const ch = makeChannel();
+    const chp = ch as unknown as Record<string, unknown>;
+    chp['tokenExpiresAt'] = Date.now() + 120_000;
+    mockFetchAccessToken
+      .mockRejectedValueOnce(new Error('token endpoint down'))
+      .mockRejectedValueOnce(new Error('still down'))
+      .mockResolvedValueOnce({
+        accessToken: 'recovered-token',
+        expiresIn: 7200,
+      });
+
+    (chp['scheduleTokenRefresh'] as () => void).call(ch);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(mockFetchAccessToken).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(mockFetchAccessToken).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(mockFetchAccessToken).toHaveBeenCalledTimes(3);
+    expect(chp['accessToken']).toBe('recovered-token');
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(mockFetchAccessToken).toHaveBeenCalledTimes(3);
+
+    ch.disconnect();
   });
 
   it('catches thrown sendQQMessage errors and stops sending', async () => {


### PR DESCRIPTION
## Summary

- keep QQ Bot token refresh retrying every 60s after repeated token endpoint failures
- stop the retry loop when the channel is disposed
- add fake-timer coverage for repeated failures followed by recovery

Fixes #5411

## Demo

N/A — background token refresh retry behavior covered by unit tests.

## Test plan

- `npx -p node@22 node node_modules/vitest/vitest.mjs run --coverage.enabled=false packages/channels/qqbot/src/send.test.ts packages/channels/qqbot/src/api.test.ts`
- `npx eslint packages/channels/qqbot/src/QQChannel.ts packages/channels/qqbot/src/send.test.ts`
- `npx -p node@22 node node_modules/typescript/bin/tsc --noEmit --project packages/channels/qqbot/tsconfig.json`
- `npx prettier --check packages/channels/qqbot/src/QQChannel.ts packages/channels/qqbot/src/send.test.ts`
- `git diff --check`

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
