### PR TITLE
fix(channel): bound qqbot gateway reconnect retries

### DIFF
--- a/packages/channels/qqbot/src/QQChannel.ts
+++ b/packages/channels/qqbot/src/QQChannel.ts
@@ -825,6 +825,7 @@ export class QQChannel extends ChannelBase {
     }
 
     const maxGwRetries = 5;
+    let gatewayAttempted = false;
     for (let attempt = 0; attempt < maxGwRetries; attempt++) {
       try {
         // Refresh token before reconnect attempt
@@ -837,6 +838,7 @@ export class QQChannel extends ChannelBase {
           await this.sleep(2000);
           continue;
         }
+        gatewayAttempted = true;
         await this.connectGateway();
         return; // success
       } catch (e: unknown) {
@@ -849,8 +851,9 @@ export class QQChannel extends ChannelBase {
       }
     }
     process.stderr.write(
-      `[QQ:${this.name}] RC: exhausted ${maxGwRetries} gateway retries, will retry in 60s\n`,
+      `[QQ:${this.name}] RC: exhausted ${maxGwRetries} reconnect retries, will retry in 60s\n`,
     );
+    if (gatewayAttempted) this.reconnectAttempts++;
     this.tryResume = false; // fall back to full IDENTIFY next time
     this.isReconnecting = false; // release guard for future retries
     // Schedule another attempt with longer delay

--- a/packages/channels/qqbot/src/send.test.ts
+++ b/packages/channels/qqbot/src/send.test.ts
@@ -4,6 +4,7 @@ import { isValidChatId, hasMarkdownSyntax, splitText } from './QQChannel.js';
 const {
   mockSendQQMessage,
   mockFetchAccessToken,
+  mockFetchGatewayUrl,
   MockWebSocket,
   mockWebSockets,
 } = vi.hoisted(() => {
@@ -40,6 +41,7 @@ const {
   return {
     mockSendQQMessage: vi.fn(),
     mockFetchAccessToken: vi.fn(),
+    mockFetchGatewayUrl: vi.fn(),
     MockWebSocket,
     mockWebSockets,
   };
@@ -56,7 +58,7 @@ vi.mock('./api.js', () => ({
   sendQQMessage: mockSendQQMessage,
   getApiBase: () => 'https://api.sgroup.qq.com',
   fetchAccessToken: mockFetchAccessToken,
-  fetchGatewayUrl: vi.fn(),
+  fetchGatewayUrl: mockFetchGatewayUrl,
 }));
 
 vi.mock('ws', () => ({
@@ -359,6 +361,7 @@ describe('sendMessage', () => {
       accessToken: 'refreshed-token',
       expiresIn: 7200,
     });
+    mockFetchGatewayUrl.mockResolvedValue('wss://gateway.qq.test/ws');
   });
 
   it('sends plain text to C2C chat with msg_type=0', async () => {
@@ -504,6 +507,56 @@ describe('sendMessage', () => {
 
     await vi.advanceTimersByTimeAsync(60_000);
     expect(mockFetchAccessToken).toHaveBeenCalledTimes(3);
+
+    ch.disconnect();
+  });
+
+  it('counts gateway retry fallback toward the reconnect attempt budget', async () => {
+    vi.useFakeTimers();
+
+    const ch = makeChannel();
+    const chp = ch as unknown as Record<string, unknown>;
+    chp['reconnectAttempts'] = 19;
+    mockFetchGatewayUrl.mockRejectedValue(new Error('gateway down'));
+
+    const reconnect = (chp['reconnectWithRetry'] as () => Promise<void>).call(
+      ch,
+    );
+
+    for (const delay of [2000, 4000, 8000, 16000]) {
+      await vi.advanceTimersByTimeAsync(delay);
+    }
+    await reconnect;
+
+    expect(mockFetchGatewayUrl).toHaveBeenCalledTimes(5);
+    expect(chp['reconnectAttempts']).toBe(20);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(mockFetchGatewayUrl).toHaveBeenCalledTimes(5);
+
+    ch.disconnect();
+  });
+
+  it('does not count token refresh failures as gateway reconnect attempts', async () => {
+    vi.useFakeTimers();
+
+    const ch = makeChannel();
+    const chp = ch as unknown as Record<string, unknown>;
+    chp['reconnectAttempts'] = 19;
+    mockFetchAccessToken.mockRejectedValue(new Error('token endpoint down'));
+
+    const reconnect = (chp['reconnectWithRetry'] as () => Promise<void>).call(
+      ch,
+    );
+
+    for (let i = 0; i < 5; i++) {
+      await vi.advanceTimersByTimeAsync(2000);
+    }
+    await reconnect;
+
+    expect(mockFetchAccessToken).toHaveBeenCalledTimes(5);
+    expect(mockFetchGatewayUrl).not.toHaveBeenCalled();
+    expect(chp['reconnectAttempts']).toBe(19);
 
     ch.disconnect();
   });


### PR DESCRIPTION
## What this PR does

This bounds QQ Bot reconnect fallback cycles when the gateway endpoint keeps failing. A reconnect cycle that actually reaches the gateway now counts toward `maxReconnectAttempts`, while token-refresh-only failures still do not consume that gateway reconnect budget.

It also keeps the existing token-refresh retry coverage from main and adds fake-timer regression tests for persistent gateway failures and token-refresh-only failures.

## Why it is needed

Fixes #5410. Before this change, `reconnectAttempts` only advanced from the WebSocket close handler. If the bot never reached a WebSocket because every gateway lookup failed, `reconnectWithRetry()` could keep scheduling 60s fallback retries without ever exhausting the configured reconnect budget.

## Reviewer Test Plan

### How to verify

Review `packages/channels/qqbot/src/QQChannel.ts` and confirm exhausted gateway fallback cycles increment `reconnectAttempts` only when a gateway attempt happened. The tests cover both sides: dead gateway failures eventually consume the budget, while token endpoint failures do not.

### Evidence

Before: a persistently failing gateway lookup could loop forever because no WebSocket close event occurred and `reconnectAttempts` stayed unchanged. After: a gateway cycle that exhausts the retry loop increments the reconnect attempt counter and stops once the budget is reached.

### Tested on

| OS | Status |
| :--: | :--: |
| macOS | tested locally |
| Windows | CI |
| Linux | CI |

Commands run locally:

- `npx vitest run --coverage.enabled=false packages/channels/qqbot/src/send.test.ts packages/channels/qqbot/src/api.test.ts`
- `npx eslint packages/channels/qqbot/src/QQChannel.ts packages/channels/qqbot/src/send.test.ts`
- `npx prettier --check packages/channels/qqbot/src/QQChannel.ts packages/channels/qqbot/src/send.test.ts`
- `npx tsc --noEmit --project packages/channels/qqbot/tsconfig.json`
- `git diff --check upstream/main`

## Risk & Scope

- Main risk or tradeoff: token-refresh-only failures remain unbounded by this gateway reconnect budget, so temporary token endpoint outages can still self-heal without exhausting gateway attempts.
- Not validated / out of scope: no live QQ Bot gateway was exercised.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5410

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.