### PR TITLE
fix(channel): track qqbot close reconnect timer

### DIFF
--- a/packages/channels/qqbot/src/QQChannel.ts
+++ b/packages/channels/qqbot/src/QQChannel.ts
@@ -633,7 +633,11 @@ export class QQChannel extends ChannelBase {
           `[QQ:${this.name}] Reconnecting in ${delay}ms (attempt ${this.reconnectAttempts}/${this.maxReconnectAttempts})\n`,
         );
         if (!this.isReconnecting) {
-          setTimeout(() => this.reconnectWithRetry(), delay);
+          this.reconnectTimer = setTimeout(
+            () => this.reconnectWithRetry(),
+            delay,
+          );
+          this.reconnectTimer.unref();
         }
       } else if (this.reconnectAttempts >= this.maxReconnectAttempts) {
         process.stderr.write(

--- a/packages/channels/qqbot/src/send.test.ts
+++ b/packages/channels/qqbot/src/send.test.ts
@@ -1,10 +1,49 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { isValidChatId, hasMarkdownSyntax, splitText } from './QQChannel.js';
 
-const { mockSendQQMessage, mockFetchAccessToken } = vi.hoisted(() => ({
-  mockSendQQMessage: vi.fn(),
-  mockFetchAccessToken: vi.fn(),
-}));
+const {
+  mockSendQQMessage,
+  mockFetchAccessToken,
+  MockWebSocket,
+  mockWebSockets,
+} = vi.hoisted(() => {
+  const mockWebSockets: unknown[] = [];
+
+  class MockWebSocket {
+    static OPEN = 1;
+    readyState = MockWebSocket.OPEN;
+    send = vi.fn();
+    close = vi.fn();
+    private readonly listeners = new Map<
+      string,
+      Array<(...args: unknown[]) => void>
+    >();
+
+    constructor(_url: string) {
+      mockWebSockets.push(this);
+    }
+
+    on(event: string, listener: (...args: unknown[]) => void): this {
+      const listeners = this.listeners.get(event) ?? [];
+      listeners.push(listener);
+      this.listeners.set(event, listeners);
+      return this;
+    }
+
+    emit(event: string, ...args: unknown[]): void {
+      for (const listener of this.listeners.get(event) ?? []) {
+        listener(...args);
+      }
+    }
+  }
+
+  return {
+    mockSendQQMessage: vi.fn(),
+    mockFetchAccessToken: vi.fn(),
+    MockWebSocket,
+    mockWebSockets,
+  };
+});
 
 vi.mock('node:fs', () => ({
   mkdirSync: vi.fn(),
@@ -18,6 +57,10 @@ vi.mock('./api.js', () => ({
   getApiBase: () => 'https://api.sgroup.qq.com',
   fetchAccessToken: mockFetchAccessToken,
   fetchGatewayUrl: vi.fn(),
+}));
+
+vi.mock('ws', () => ({
+  default: MockWebSocket,
 }));
 
 vi.mock('./accounts.js', () => ({
@@ -423,5 +466,62 @@ describe('sendMessage', () => {
       'test-token',
       { content: 'a'.repeat(500), msg_type: 0, msg_id: 'msg-789', msg_seq: 2 },
     );
+  });
+});
+
+describe('gateway reconnect timer', () => {
+  function makeChannel(): QQChannel {
+    return new QQChannel(
+      'test-bot',
+      {
+        type: 'qq',
+        token: '',
+        senderPolicy: 'open' as const,
+        allowedUsers: [],
+        sessionScope: 'user' as const,
+        cwd: '/tmp',
+        groupPolicy: 'disabled' as const,
+        groups: {},
+        appID: 'test-app-id',
+        appSecret: 'test-secret',
+      },
+      {} as unknown as import('@qwen-code/channel-base').AcpBridge,
+    );
+  }
+
+  beforeEach(() => {
+    mockWebSockets.length = 0;
+  });
+
+  it('tracks and unrefs reconnect timers scheduled by close handler', () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const ch = makeChannel();
+    const chp = ch as unknown as {
+      dialGateway: (
+        url: string,
+        resolve: () => void,
+        reject: (err: Error) => void,
+      ) => void;
+      reconnectTimer: ReturnType<typeof setTimeout> | null;
+    };
+
+    chp.dialGateway('wss://gateway.example.test', vi.fn(), vi.fn());
+    const ws = mockWebSockets[0] as {
+      emit(event: string, ...args: unknown[]): void;
+    };
+
+    ws.emit('close', 4001);
+
+    const timer = chp.reconnectTimer;
+    expect(timer).not.toBeNull();
+    expect(timer?.hasRef()).toBe(false);
+
+    try {
+      ch.disconnect();
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(timer);
+      expect(chp.reconnectTimer).toBeNull();
+    } finally {
+      clearTimeoutSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## What this PR does

This stores the QQ bot close-handler reconnect timeout in `this.reconnectTimer`, calls `.unref()` on that timeout, and keeps `disconnect()` responsible for clearing it. It also adds a regression test that triggers the real close handler and verifies disconnect clears the timer.

## Why it's needed

Issue #5413 showed that the close-handler reconnect backoff could keep the daemon process alive because the timeout was not tracked or unrefed. Tracking the timer makes cleanup reliable, and unrefing it prevents a pending reconnect delay from being the only reason the Node process stays open.

## Reviewer Test Plan

### How to verify

Check that the close handler stores its reconnect timer, that the timer is unrefed, and that `disconnect()` clears the pending timer. The regression test exercises the actual close handler instead of only mocking the final state.

### Evidence (Before & After)

Before: a close-handler reconnect timeout could remain referenced and keep the daemon alive during backoff. After: the timeout is tracked, unrefed, and cleared on disconnect.

### Tested on

| OS | Status |
| :--: | :--: |
| macOS | tested |
| Windows | CI |
| Linux | CI |

### Environment (optional)

Node 22 via `npx -p node@22`.

Commands run locally:

- `npx -p node@22 node node_modules/vitest/vitest.mjs run --coverage.enabled=false packages/channels/qqbot/src/send.test.ts packages/channels/qqbot/src/api.test.ts`
- `npx prettier --check packages/channels/qqbot/src/QQChannel.ts packages/channels/qqbot/src/send.test.ts`
- `npx eslint packages/channels/qqbot/src/QQChannel.ts packages/channels/qqbot/src/send.test.ts`
- `npx -p node@22 node node_modules/typescript/bin/tsc --noEmit --project packages/channels/qqbot/tsconfig.json`
- `git diff --check`

## Risk & Scope

- Main risk or tradeoff: reconnect timer cleanup changes can affect close/reconnect timing, but the same reconnect path is still used and the timer is now visible to disconnect cleanup.
- Not validated / out of scope: no live QQ bot connection was run.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5413

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 把 QQ bot close handler 里的 reconnect timeout 存到 `this.reconnectTimer`，对这个 timeout 调用 `.unref()`，并继续由 `disconnect()` 负责清理它。同时增加了一个回归测试：触发真实 close handler，并验证 disconnect 会清掉 timer。

## Why it's needed

#5413 暴露出 close-handler reconnect backoff 可能让 daemon 进程一直不退出，因为这个 timeout 没有被跟踪，也没有 unref。跟踪 timer 可以让 cleanup 更可靠，unref 则避免一个等待重连的延迟成为 Node 进程保持打开的唯一原因。

## Reviewer Test Plan

### How to verify

确认 close handler 会保存 reconnect timer，timer 会被 unref，并且 `disconnect()` 会清理待执行 timer。回归测试执行真实 close handler，而不是只 mock 最终状态。

### Evidence (Before & After)

Before：close-handler reconnect timeout 可能保持 referenced，在 backoff 期间让 daemon 进程不退出。After：timeout 被跟踪、unref，并会在 disconnect 时清理。

### Tested on

| OS | Status |
| :--: | :--: |
| macOS | tested |
| Windows | CI |
| Linux | CI |

### Environment (optional)

通过 `npx -p node@22` 使用 Node 22。

本地运行过：

- `npx -p node@22 node node_modules/vitest/vitest.mjs run --coverage.enabled=false packages/channels/qqbot/src/send.test.ts packages/channels/qqbot/src/api.test.ts`
- `npx prettier --check packages/channels/qqbot/src/QQChannel.ts packages/channels/qqbot/src/send.test.ts`
- `npx eslint packages/channels/qqbot/src/QQChannel.ts packages/channels/qqbot/src/send.test.ts`
- `npx -p node@22 node node_modules/typescript/bin/tsc --noEmit --project packages/channels/qqbot/tsconfig.json`
- `git diff --check`

## Risk & Scope

- Main risk or tradeoff：reconnect timer cleanup 的变化可能影响 close/reconnect 时序，但仍然使用同一条 reconnect path，并且 timer 现在会被 disconnect cleanup 看见。
- Not validated / out of scope：没有运行真实 QQ bot 连接。
- Breaking changes / migration notes：无。

## Linked Issues

Fixes #5413

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
