### PR TITLE
fix(channel): scope qqbot session backup path

### DIFF
--- a/packages/channels/qqbot/src/QQChannel.ts
+++ b/packages/channels/qqbot/src/QQChannel.ts
@@ -140,8 +140,9 @@ export class QQChannel extends ChannelBase {
   /** Path to persisted QQ routing state: chatTypeMap, replyMsgId, msgSeqMap. */
   private readonly qqStatePath: string;
   /**
-   * Path to the global sessions.json managed by start.ts.
-   * start.ts deletes it on shutdown, so we back it up.
+   * Path to the SessionRouter persistence file we back up before shutdown.
+   * start.ts passes a shared router; standalone QQChannel instances use a
+   * per-channel router file.
    */
   private readonly globalSessionsPath: string;
   /** Backup of sessions.json so conversations survive daemon restarts. */
@@ -158,6 +159,7 @@ export class QQChannel extends ChannelBase {
     mkdirSync(stateDir, { recursive: true });
     const sessionsPath = join(stateDir, `${safeName}-sessions.json`);
 
+    const hasExternalRouter = Boolean(options?.router);
     const router =
       options?.router ??
       new SessionRouter(bridge, config.cwd, config.sessionScope, sessionsPath);
@@ -165,7 +167,9 @@ export class QQChannel extends ChannelBase {
     super(name, config, bridge, { ...options, router });
     this.qqConfig = config as unknown as QQChannelConfig;
     this.qqStatePath = join(stateDir, `${safeName}-state.json`);
-    this.globalSessionsPath = join(stateDir, 'sessions.json');
+    this.globalSessionsPath = hasExternalRouter
+      ? join(stateDir, 'sessions.json')
+      : sessionsPath;
     this.sessionsBackupPath = join(
       stateDir,
       `${safeName}-sessions-backup.json`,

--- a/packages/channels/qqbot/src/send.test.ts
+++ b/packages/channels/qqbot/src/send.test.ts
@@ -60,6 +60,8 @@ vi.mock('@qwen-code/channel-base', () => ({
 }));
 
 const { QQChannel } = await import('./QQChannel.js');
+type QQChannelOptions = ConstructorParameters<typeof QQChannel>[3];
+type QQChannelRouter = NonNullable<QQChannelOptions>['router'];
 
 /** Create a mock Response-like object for sendQQMessage. */
 function mockResponse(
@@ -207,6 +209,51 @@ describe('splitText', () => {
 
   it('handles empty string', () => {
     expect(splitText('')).toEqual(['']);
+  });
+});
+
+describe('session persistence paths', () => {
+  function makeChannel(name: string, options?: QQChannelOptions): QQChannel {
+    return new QQChannel(
+      name,
+      {
+        type: 'qq',
+        token: '',
+        senderPolicy: 'open' as const,
+        allowedUsers: [],
+        sessionScope: 'user' as const,
+        cwd: '/tmp',
+        groupPolicy: 'disabled' as const,
+        groups: {},
+        appID: 'test-app-id',
+        appSecret: 'test-secret',
+      },
+      {} as unknown as import('@qwen-code/channel-base').AcpBridge,
+      options,
+    );
+  }
+
+  function getGlobalSessionsPath(ch: QQChannel): string {
+    return (ch as unknown as { globalSessionsPath: string }).globalSessionsPath;
+  }
+
+  it('uses per-channel sessions files when QQChannel owns the router', () => {
+    expect(getGlobalSessionsPath(makeChannel('bot one'))).toBe(
+      '/tmp/test-qwen/channels/bot_one-sessions.json',
+    );
+    expect(getGlobalSessionsPath(makeChannel('bot/two'))).toBe(
+      '/tmp/test-qwen/channels/bot_two-sessions.json',
+    );
+  });
+
+  it('keeps the shared sessions file when start.ts provides the router', () => {
+    const externalRouter = {
+      restoreSessions: vi.fn(),
+    } as unknown as QQChannelRouter;
+
+    expect(
+      getGlobalSessionsPath(makeChannel('bot-one', { router: externalRouter })),
+    ).toBe('/tmp/test-qwen/channels/sessions.json');
   });
 });
 


### PR DESCRIPTION
## What this PR does

This keeps QQChannel-owned SessionRouter backup and restore paths aligned with the per-channel sessions path. When `start.ts` provides the shared router, it still preserves the shared `channels/sessions.json` path. The PR also adds regression coverage for both construction modes.

## Why it's needed

Issue #5412 showed that a QQChannel-created SessionRouter could back up sessions to the global channel sessions file instead of the channel-scoped file. That mixes session state across configurations and can restore the wrong data. The fix keeps the fallback path scoped to the QQ channel instance while leaving the explicitly shared router path unchanged.

## Reviewer Test Plan

### How to verify

Check that a QQChannel-created SessionRouter writes backup data under the channel's configured sessions path, and that a shared SessionRouter passed by `start.ts` still uses the existing shared sessions file. The regression tests cover both paths.

### Evidence (Before & After)

Before: QQChannel-owned backup/restore could fall back to `channels/sessions.json`. After: QQChannel-owned backup/restore uses the channel-scoped path, while the shared router case still uses the shared path.

### Tested on

| OS | Status |
| :--: | :--: |
| macOS | tested |
| Windows | CI |
| Linux | CI |

### Environment (optional)

Node 22 via `npx -p node@22`.

Commands run locally:

- `npx -p node@22 node node_modules/vitest/vitest.mjs run --coverage.enabled=false packages/channels/qqbot/src/send.test.ts packages/channels/qqbot/src/api.test.ts`
- `npx prettier --check packages/channels/qqbot/src/QQChannel.ts packages/channels/qqbot/src/send.test.ts`
- `npx eslint packages/channels/qqbot/src/QQChannel.ts packages/channels/qqbot/src/send.test.ts`
- `npx -p node@22 node node_modules/typescript/bin/tsc --noEmit --project packages/channels/qqbot/tsconfig.json`
- `git diff --check`

## Risk & Scope

- Main risk or tradeoff: the main risk is changing the backup path used by QQChannel-created routers; the shared router case is covered so the existing shared file behavior stays intact.
- Not validated / out of scope: no live QQ bot session was run.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5412

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让 QQChannel 自己创建的 SessionRouter backup/restore 路径和 channel 级 sessions 路径保持一致。当 `start.ts` 传入共享 router 时，仍然保留共享的 `channels/sessions.json` 路径。PR 也给两种构造模式都加了回归覆盖。

## Why it's needed

#5412 暴露出一个问题：QQChannel 自己创建的 SessionRouter 可能会把 sessions 备份到全局 channel sessions 文件，而不是当前 channel scoped 文件。这会混用不同配置的 session 状态，也可能恢复错数据。这个修复让 fallback path 跟 QQ channel 实例绑定，同时保持显式传入共享 router 的路径不变。

## Reviewer Test Plan

### How to verify

确认 QQChannel 自己创建的 SessionRouter 会把 backup 数据写到 channel 配置的 sessions path 下，同时 `start.ts` 传入的共享 SessionRouter 仍然使用现有共享 sessions 文件。回归测试覆盖了两种路径。

### Evidence (Before & After)

Before：QQChannel-owned backup/restore 可能 fallback 到 `channels/sessions.json`。After：QQChannel-owned backup/restore 使用 channel-scoped 路径，而 shared router 情况仍然使用共享路径。

### Tested on

| OS | Status |
| :--: | :--: |
| macOS | tested |
| Windows | CI |
| Linux | CI |

### Environment (optional)

通过 `npx -p node@22` 使用 Node 22。

本地运行过：

- `npx -p node@22 node node_modules/vitest/vitest.mjs run --coverage.enabled=false packages/channels/qqbot/src/send.test.ts packages/channels/qqbot/src/api.test.ts`
- `npx prettier --check packages/channels/qqbot/src/QQChannel.ts packages/channels/qqbot/src/send.test.ts`
- `npx eslint packages/channels/qqbot/src/QQChannel.ts packages/channels/qqbot/src/send.test.ts`
- `npx -p node@22 node node_modules/typescript/bin/tsc --noEmit --project packages/channels/qqbot/tsconfig.json`
- `git diff --check`

## Risk & Scope

- Main risk or tradeoff：主要风险是改变 QQChannel-created routers 使用的 backup path；shared router 情况有测试覆盖，保持现有共享文件行为不变。
- Not validated / out of scope：没有运行真实 QQ bot session。
- Breaking changes / migration notes：无。

## Linked Issues

Fixes #5412

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
