### PR TITLE
fix(core): share memory filename config state

### DIFF
--- a/packages/core/src/memory/const.test.ts
+++ b/packages/core/src/memory/const.test.ts
@@ -4,12 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { vi, describe, it, expect } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 import {
+  AGENT_CONTEXT_FILENAME,
+  DEFAULT_CONTEXT_FILENAME,
   setGeminiMdFilename,
   getCurrentGeminiMdFilename,
   getAllGeminiMdFilenames,
 } from './const.js';
+import {
+  setGeminiMdFilename as setToolGeminiMdFilename,
+  getCurrentGeminiMdFilename as getToolCurrentGeminiMdFilename,
+  getAllGeminiMdFilenames as getToolAllGeminiMdFilenames,
+} from '../tools/memory-config.js';
 
 // Mock dependencies
 vi.mock(import('node:fs/promises'), async (importOriginal) => {
@@ -24,6 +31,10 @@ vi.mock(import('node:fs/promises'), async (importOriginal) => {
 vi.mock('os');
 
 describe('setGeminiMdFilename', () => {
+  beforeEach(() => {
+    setGeminiMdFilename([DEFAULT_CONTEXT_FILENAME, AGENT_CONTEXT_FILENAME]);
+  });
+
   it('should update currentGeminiMdFilename when a valid new name is provided', () => {
     const newName = 'CUSTOM_CONTEXT.md';
     setGeminiMdFilename(newName);
@@ -44,5 +55,15 @@ describe('setGeminiMdFilename', () => {
     setGeminiMdFilename(newNames);
     expect(getCurrentGeminiMdFilename()).toBe('CUSTOM_CONTEXT.md');
     expect(getAllGeminiMdFilenames()).toEqual(newNames);
+  });
+
+  it('shares filename state with the legacy tools memory config entrypoint', () => {
+    setGeminiMdFilename(['CUSTOM_CONTEXT.md', 'AGENTS.md']);
+    expect(getToolCurrentGeminiMdFilename()).toBe('CUSTOM_CONTEXT.md');
+    expect(getToolAllGeminiMdFilenames()).toEqual(getAllGeminiMdFilenames());
+
+    setToolGeminiMdFilename('LEGACY_CONTEXT.md');
+    expect(getCurrentGeminiMdFilename()).toBe('LEGACY_CONTEXT.md');
+    expect(getAllGeminiMdFilenames()).toEqual(['LEGACY_CONTEXT.md']);
   });
 });

--- a/packages/core/src/tools/memory-config.ts
+++ b/packages/core/src/tools/memory-config.ts
@@ -9,39 +9,11 @@
  * Extracted from memoryTool.ts to avoid loading the full tool module
  * when only the filename configuration is needed.
  */
-
-export const DEFAULT_CONTEXT_FILENAME = 'QWEN.md';
-export const AGENT_CONTEXT_FILENAME = 'AGENTS.md';
-export const MEMORY_SECTION_HEADER = '## Qwen Added Memories';
-
-// This variable will hold the currently configured filename for context files.
-// It defaults to include both QWEN.md and AGENTS.md but can be overridden by setGeminiMdFilename.
-// QWEN.md is first to maintain backward compatibility (used by /init command and save_memory tool).
-let currentGeminiMdFilename: string | string[] = [
-  DEFAULT_CONTEXT_FILENAME,
+export {
   AGENT_CONTEXT_FILENAME,
-];
-
-export function setGeminiMdFilename(newFilename: string | string[]): void {
-  if (Array.isArray(newFilename)) {
-    if (newFilename.length > 0) {
-      currentGeminiMdFilename = newFilename.map((name) => name.trim());
-    }
-  } else if (newFilename && newFilename.trim() !== '') {
-    currentGeminiMdFilename = newFilename.trim();
-  }
-}
-
-export function getCurrentGeminiMdFilename(): string {
-  if (Array.isArray(currentGeminiMdFilename)) {
-    return currentGeminiMdFilename[0];
-  }
-  return currentGeminiMdFilename;
-}
-
-export function getAllGeminiMdFilenames(): string[] {
-  if (Array.isArray(currentGeminiMdFilename)) {
-    return currentGeminiMdFilename;
-  }
-  return [currentGeminiMdFilename];
-}
+  DEFAULT_CONTEXT_FILENAME,
+  getAllGeminiMdFilenames,
+  getCurrentGeminiMdFilename,
+  MEMORY_SECTION_HEADER,
+  setGeminiMdFilename,
+} from '../memory/const.js';


### PR DESCRIPTION
## Summary

- make `tools/memory-config.ts` re-export the memory filename config from `memory/const.ts`
- add regression coverage that the legacy tools entrypoint and memory entrypoint share the same state

Part of #4063.

## Test plan

- `npx -p node@22 node node_modules/vitest/vitest.mjs run --coverage.enabled=false packages/core/src/memory/const.test.ts packages/core/src/memory/writeContextFile.test.ts packages/core/src/config/config.test.ts`
- `npx prettier --check packages/core/src/tools/memory-config.ts packages/core/src/memory/const.test.ts`
- `npx eslint packages/core/src/tools/memory-config.ts packages/core/src/memory/const.test.ts`
- `git diff --check`

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.