### PR TITLE
fix(cli): keep keypress handlers current

### DIFF
--- a/packages/cli/src/ui/components/messages/AskUserQuestionDialog.test.tsx
+++ b/packages/cli/src/ui/components/messages/AskUserQuestionDialog.test.tsx
@@ -13,6 +13,29 @@ import stripAnsi from 'strip-ansi';
 
 const wait = (ms = 50) => new Promise((resolve) => setTimeout(resolve, ms));
 const clean = (value: string | undefined) => stripAnsi(value ?? '');
+const waitForFrame = async (
+  predicate: () => void,
+  options: { timeout?: number; interval?: number } = {},
+) => {
+  const { timeout = 1000, interval = 10 } = options;
+  const start = Date.now();
+  let lastError: unknown;
+
+  while (Date.now() - start < timeout) {
+    try {
+      predicate();
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+    await wait(interval);
+  }
+
+  if (lastError) {
+    throw lastError;
+  }
+  throw new Error('waitForFrame timed out');
+};
 
 const createSingleQuestion = (
   overrides: Partial<
@@ -301,22 +324,36 @@ describe('<AskUserQuestionDialog />', () => {
       await wait();
 
       stdin.write('4'); // Select "Other" custom input
-      await wait(150);
-      expect(clean(lastFrame())).toContain('❯ 4.');
+      await waitForFrame(() => {
+        expect(clean(lastFrame())).toContain('❯ 4.');
+      });
+      await wait();
 
       stdin.write('j');
-      await wait(150);
+      await waitForFrame(() => {
+        const frame = clean(lastFrame());
+        expect(frame).toContain('❯ 4.');
+        expect(frame).toContain('j');
+      });
+
       stdin.write('k');
-      await wait(150);
-      expect(clean(lastFrame())).toContain('❯ 4.');
+      await waitForFrame(() => {
+        const frame = clean(lastFrame());
+        expect(frame).toContain('❯ 4.');
+        expect(frame).toContain('jk');
+      });
 
       stdin.write('\u0010'); // Ctrl+P
       await wait();
-      expect(clean(lastFrame())).toContain('❯ 3. Green');
+      await waitForFrame(() => {
+        expect(clean(lastFrame())).toContain('❯ 3. Green');
+      });
 
       stdin.write('\u000E'); // Ctrl+N
       await wait();
-      expect(clean(lastFrame())).toContain('❯ 4.');
+      await waitForFrame(() => {
+        expect(clean(lastFrame())).toContain('❯ 4.');
+      });
 
       unmount();
     });

--- a/packages/cli/src/ui/hooks/useKeypress.ts
+++ b/packages/cli/src/ui/hooks/useKeypress.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import type { KeypressHandler, Key } from '../contexts/KeypressContext.js';
 import { useKeypressContext } from '../contexts/KeypressContext.js';
 
@@ -22,15 +22,22 @@ export function useKeypress(
   { isActive }: { isActive: boolean },
 ) {
   const { subscribe, unsubscribe } = useKeypressContext();
+  const onKeypressRef = useRef(onKeypress);
+
+  onKeypressRef.current = onKeypress;
+
+  const handleKeypress = useCallback<KeypressHandler>((key) => {
+    onKeypressRef.current(key);
+  }, []);
 
   useEffect(() => {
     if (!isActive) {
       return;
     }
 
-    subscribe(onKeypress);
+    subscribe(handleKeypress);
     return () => {
-      unsubscribe(onKeypress);
+      unsubscribe(handleKeypress);
     };
-  }, [isActive, onKeypress, subscribe, unsubscribe]);
+  }, [isActive, handleKeypress, subscribe, unsubscribe]);
 }


### PR DESCRIPTION
## What this PR does

This keeps keypress subscriptions stable while still dispatching to the latest handler from the current render. It also tightens the AskUserQuestionDialog regression test so bare `j`/`k` stay in the custom input, while Ctrl+P/Ctrl+N still move the selected option.

## Why it's needed

While checking #5415, the macOS test run exposed a timing issue where AskUserQuestionDialog could receive input through a stale keypress callback. In that state, typing `j` after moving to the custom input could be handled as list navigation instead of text input. Keeping the subscribed wrapper stable removes that post-render/pre-effect stale handler window without changing the keypress context API.

## Reviewer Test Plan

### How to verify

Confirm that AskUserQuestionDialog keeps the custom input selected when bare `j`/`k` are typed, and that Ctrl+P/Ctrl+N still navigate choices. The targeted test covers that regression together with the existing `useKeypress` behavior.

### Evidence (Before & After)

Before: the macOS CI run seen while checking #5415 failed the AskUserQuestionDialog custom input test because `j` moved selection back to `Blue` instead of staying on `Other`. After: the targeted AskUserQuestionDialog and useKeypress test files pass locally, and this PR's CI passed on macOS, Windows, and Linux.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ✅ CI |
|  🐧 Linux  | ✅ CI |

### Environment (optional)

Node 22 via `npx -p node@22`.

Commands run locally:

- `npx -p node@22 node node_modules/vitest/vitest.mjs run --coverage.enabled=false packages/cli/src/ui/components/messages/AskUserQuestionDialog.test.tsx packages/cli/src/ui/hooks/useKeypress.test.ts`
- `npx prettier --check packages/cli/src/ui/hooks/useKeypress.ts packages/cli/src/ui/components/messages/AskUserQuestionDialog.test.tsx`
- `npx eslint packages/cli/src/ui/hooks/useKeypress.ts packages/cli/src/ui/components/messages/AskUserQuestionDialog.test.tsx`
- `git diff --check`

## Risk & Scope

- Main risk or tradeoff: `useKeypress` now keeps one subscribed wrapper per active registration and reads the latest handler from a ref, so any issue would likely show up around subscription ordering or active/inactive toggles.
- Not validated / out of scope: no manual TUI session was recorded; this is covered by the focused Ink tests instead.
- Breaking changes / migration notes: none.

## Linked Issues

Related: #5415

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让 keypress 订阅保持稳定，同时仍然把事件分发给当前 render 里的最新 handler。它也收紧了 AskUserQuestionDialog 的回归测试，确认普通 `j`/`k` 会留在自定义输入框里，而 Ctrl+P/Ctrl+N 仍然能移动选项。

## Why it's needed

检查 #5415 时，macOS 测试暴露出一个时序问题：AskUserQuestionDialog 可能通过旧的 keypress callback 收到输入。在这种状态下，移动到自定义输入框后输入 `j`，有机会被旧逻辑当成列表导航，而不是文本输入。稳定订阅 wrapper 可以去掉 render 之后、effect 更新之前这段 stale handler 窗口，同时不改 keypress context API。

## Reviewer Test Plan

### How to verify

确认 AskUserQuestionDialog 在输入普通 `j`/`k` 时仍然选中自定义输入框，同时 Ctrl+P/Ctrl+N 仍然可以切换选项。目标测试覆盖了这个回归，也覆盖了现有 `useKeypress` 行为。

### Evidence (Before & After)

Before：检查 #5415 时看到的 macOS CI 在 AskUserQuestionDialog 自定义输入测试失败，因为 `j` 把选中项移动回了 `Blue`，没有留在 `Other`。After：本地目标 AskUserQuestionDialog 和 useKeypress 测试通过，本 PR 的 CI 也已经在 macOS、Windows、Linux 通过。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ✅ CI |
|  🐧 Linux  | ✅ CI |

### Environment (optional)

通过 `npx -p node@22` 使用 Node 22。

本地运行过：

- `npx -p node@22 node node_modules/vitest/vitest.mjs run --coverage.enabled=false packages/cli/src/ui/components/messages/AskUserQuestionDialog.test.tsx packages/cli/src/ui/hooks/useKeypress.test.ts`
- `npx prettier --check packages/cli/src/ui/hooks/useKeypress.ts packages/cli/src/ui/components/messages/AskUserQuestionDialog.test.tsx`
- `npx eslint packages/cli/src/ui/hooks/useKeypress.ts packages/cli/src/ui/components/messages/AskUserQuestionDialog.test.tsx`
- `git diff --check`

## Risk & Scope

- Main risk or tradeoff：`useKeypress` 现在对每个 active registration 保持一个订阅 wrapper，并从 ref 读取最新 handler；如果有问题，大概率会出现在订阅顺序或 active/inactive 切换上。
- Not validated / out of scope：没有录手动 TUI session；这里用聚焦的 Ink 测试覆盖。
- Breaking changes / migration notes：无。

## Linked Issues

Related: #5415

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
