### PR TITLE
fix(hooks): remove the dead updatedMCPToolOutput field (#5422)

### DIFF
--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -729,7 +729,6 @@ export interface PostToolUseOutput extends HookOutput {
     hookEventName: 'PostToolUse';
     additionalContext?: string;
   };
-  updatedMCPToolOutput?: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
## What this PR does

Removes the `updatedMCPToolOutput` field from the `PostToolUseOutput` hook type. The field is declared but never read — a repo-wide search finds it only as the declaration in `packages/core/src/hooks/types.ts`, with no consumer in the executor, aggregator, scheduler, or SDK (the analogous `updatedInput` is fully wired by contrast).

## Why it's needed

The hook-output contract should reflect what the runtime actually honors. A declared-but-unimplemented field misleads integrators into emitting `updatedMCPToolOutput` expecting it to rewrite MCP tool output, when nothing reads it. If that capability is wanted later it would need real wiring plus tests; this just drops the dead declaration. Reported in #5422; confirmed dead by the triage and by @wenshao's review.

## Reviewer Test Plan

### How to verify

Search the repo for `updatedMCPToolOutput`: before this PR it appears only as the type field in `packages/core/src/hooks/types.ts`; after, there are zero occurrences. Because nothing consumes it, removing it changes no runtime behavior. `npm run build` (typecheck) still passes.

### Evidence (Before & After)

N/A — non-user-visible, type-only change.

### Tested on

|     OS     |       Status        |
| :--------: | :-----------------: |
|  🍏 macOS  |         N/A         |
| 🪟 Windows |         N/A         |
|  🐧 Linux  | ✅ typecheck / build |

### Environment (optional)

N/A — type-only change, no runtime.
