### PR TITLE
fix(cli): accept uppercase URL schemes in mcp add transport detection

### DIFF
--- a/packages/cli/src/commands/mcp/add.test.ts
+++ b/packages/cli/src/commands/mcp/add.test.ts
@@ -115,6 +115,16 @@ describe('mcp add command', () => {
     });
   });
 
+  it('should auto-detect http transport when commandOrUrl uses an uppercase URL scheme', async () => {
+    await parser.parseAsync('add http-server HTTPS://example.com/mcp');
+
+    expect(mockSetValue).toHaveBeenCalledWith(SettingScope.User, 'mcpServers', {
+      'http-server': {
+        httpUrl: 'HTTPS://example.com/mcp',
+      },
+    });
+  });
+
   it('should respect explicit transport even when commandOrUrl is a URL', async () => {
     await parser.parseAsync(
       'add --transport sse sse-server https://example.com/sse-endpoint',

--- a/packages/cli/src/commands/mcp/add.ts
+++ b/packages/cli/src/commands/mcp/add.ts
@@ -302,11 +302,7 @@ export const addCommand: CommandModule = {
         // Auto-detect transport from URL if not explicitly specified
         if (!argv['transport']) {
           const commandOrUrl = argv['commandOrUrl'] as string;
-          if (
-            commandOrUrl &&
-            (commandOrUrl.startsWith('http://') ||
-              commandOrUrl.startsWith('https://'))
-          ) {
+          if (commandOrUrl && /^https?:\/\//i.test(commandOrUrl)) {
             argv['transport'] = 'http';
           } else {
             argv['transport'] = 'stdio';


### PR DESCRIPTION
## What this PR does

`qwen mcp add <name> <url>` auto-detects the transport as `http` when the argument looks like a URL. The detection used `startsWith('http://') || startsWith('https://')`, which is case-sensitive, so a URL with an uppercase scheme like `HTTPS://example.com/mcp` was not recognized and the transport silently fell back to `stdio`. The command then tried to spawn the URL as a local command and failed. This switches the check to the case-insensitive `/^https?:\/\//i` regex so any-case `http`/`https` schemes are detected as HTTP transport.

## Why it's needed

URL schemes are case-insensitive per RFC 3986, and #5391 already made the web-fetch tool accept uppercase schemes for the same reason. This brings `mcp add` in line with that behavior so a pasted or copied URL with an uppercase scheme is handled instead of producing a confusing "command not found" style error.

## Reviewer Test Plan

### How to verify

`vitest` covers the auto-detection. The added case mirrors the existing http/https cases but with an uppercase scheme.

```
npx vitest run packages/cli/src/commands/mcp/add.test.ts
```

Expected: the new test `should auto-detect http transport when commandOrUrl uses an uppercase URL scheme` passes, and the server is stored under `httpUrl` (HTTP transport) rather than as a stdio command. It fails on `main` (transport falls back to `stdio`) and passes with this change. All 27 tests in the file pass.

### Evidence (Before & After)

N/A (non–user-visible logic; covered by the unit test above).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   N/A  |

<!-- ✅ tested · ⚠️ not tested · N/A -->
