### PR TITLE
fix(extensions): accept uppercase URL schemes when parsing install sources

### DIFF
--- a/packages/core/src/extension/marketplace.test.ts
+++ b/packages/core/src/extension/marketplace.test.ts
@@ -122,6 +122,21 @@ describe('parseInstallSource', () => {
       expect(result.source).toBe('https://example.com:8080/repo');
       expect(result.pluginName).toBeUndefined();
     });
+
+    it('should parse an uppercase HTTPS URL scheme as a git source', async () => {
+      // Mock stat to fail (not a local path)
+      vi.mocked(fs.stat).mockRejectedValueOnce(new Error('ENOENT'));
+
+      const result = await parseInstallSource(
+        'HTTPS://github.com/owner/repo:my-plugin',
+      );
+
+      // The uppercase scheme must be recognized as a URL, so the colon in the
+      // scheme is not mistaken for a pluginName separator.
+      expect(result.source).toBe('HTTPS://github.com/owner/repo');
+      expect(result.type).toBe('git');
+      expect(result.pluginName).toBe('my-plugin');
+    });
   });
 
   describe('git@ URL parsing', () => {

--- a/packages/core/src/extension/marketplace.ts
+++ b/packages/core/src/extension/marketplace.ts
@@ -42,13 +42,16 @@ function parseSourceAndPluginName(source: string): {
   // Check if source contains a colon that could be a pluginName separator
   // We need to handle URL schemes that contain colons
   const urlSchemes = ['http://', 'https://', 'git@', 'sso://'];
+  // URL schemes are case-insensitive, so match against a lowercased copy while
+  // slicing from the original. Offsets stay valid because casing never changes length.
+  const lowerSource = source.toLowerCase();
 
   let repoEndIndex = source.length;
   let hasPluginName = false;
 
   // For URLs, find the last colon after the scheme
   for (const scheme of urlSchemes) {
-    if (source.startsWith(scheme)) {
+    if (lowerSource.startsWith(scheme)) {
       const afterScheme = source.substring(scheme.length);
       const lastColonIndex = afterScheme.lastIndexOf(':');
       if (lastColonIndex !== -1) {
@@ -71,7 +74,7 @@ function parseSourceAndPluginName(source: string): {
   // For non-URL sources (local paths or owner/repo format)
   if (
     repoEndIndex === source.length &&
-    !urlSchemes.some((s) => source.startsWith(s))
+    !urlSchemes.some((s) => lowerSource.startsWith(s))
   ) {
     const lastColonIndex = source.lastIndexOf(':');
     // On Windows, avoid treating drive letter as pluginName separator (e.g., C:\path)
@@ -111,11 +114,13 @@ function convertOwnerRepoToGitHubUrl(ownerRepo: string): string {
  * Check if source is a git URL
  */
 function isGitUrl(source: string): boolean {
+  // URL schemes are case-insensitive (e.g. HTTPS://...), so compare lowercased.
+  const lower = source.toLowerCase();
   return (
-    source.startsWith('http://') ||
-    source.startsWith('https://') ||
-    source.startsWith('git@') ||
-    source.startsWith('sso://')
+    lower.startsWith('http://') ||
+    lower.startsWith('https://') ||
+    lower.startsWith('git@') ||
+    lower.startsWith('sso://')
   );
 }
 


### PR DESCRIPTION
## What this PR does

`qwen extensions install <source>` accepts git URLs, owner/repo shorthand, and local paths. The source parsing matched URL schemes (`http://`, `https://`, `git@`, `sso://`) case-sensitively in two places: `parseSourceAndPluginName`, which splits the source into repo and optional `:pluginName`, and `isGitUrl`, which classifies the source. So a source with an uppercase scheme like `HTTPS://github.com/owner/repo` was not recognized as a URL: `parseSourceAndPluginName` then treated the `:` in the scheme as a `pluginName` separator and mangled the repo, and `isGitUrl` returned false so it was never routed as a git install. This compares both checks against a lowercased copy of the source, while still slicing from the original string (offsets stay valid because casing never changes length).

## Why it's needed

URL schemes are case-insensitive per RFC 3986. #5391 already made the web-fetch tool accept uppercase schemes, and #5426 did the same for `mcp add` transport detection. This extends that to extension install sources so a pasted or copied URL with an uppercase scheme installs the extension instead of failing with a confusing parse error.

## Reviewer Test Plan

### How to verify

```
npx vitest run packages/core/src/extension/marketplace.test.ts
```

Expected: the new test `should parse an uppercase HTTPS URL scheme as a git source` passes. It feeds `HTTPS://github.com/owner/repo:my-plugin` and checks the repo is `HTTPS://github.com/owner/repo`, the type is `git`, and the plugin name is `my-plugin` (i.e. the scheme colon is not mistaken for a plugin separator). It fails on `main` and passes with this change. All 23 tests in the file pass, and the extension install suites (`extensions/install.test.ts`, `extensionsCommand.test.ts`) remain green.

### Evidence (Before & After)

N/A (non–user-visible parsing logic; covered by the unit tests above).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   N/A  |

<!-- ✅ tested · ⚠️ not tested · N/A -->
