### PR TITLE
fix(extensions): accept uppercase marketplace source schemes

### DIFF
--- a/packages/core/src/extension/claude-converter.test.ts
+++ b/packages/core/src/extension/claude-converter.test.ts
@@ -203,6 +203,8 @@ describe('convertClaudePluginPackage', () => {
   beforeEach(() => {
     // Create a temporary directory for test files
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-test-'));
+    vi.mocked(downloadFromGitHubRelease).mockReset();
+    vi.mocked(cloneFromGit).mockReset();
   });
 
   afterEach(() => {
@@ -376,6 +378,46 @@ describe('convertClaudePluginPackage', () => {
     ).rejects.toThrow(/resolves through a symlink outside the marketplace/);
 
     fs.rmSync(secretDir, { recursive: true, force: true });
+  });
+
+  it('treats uppercase HTTPS marketplace plugin sources as URLs', async () => {
+    const pluginSourceDir = path.join(testDir, 'plugin-uppercase-url');
+    const marketplaceDir = path.join(pluginSourceDir, '.claude-plugin');
+    fs.mkdirSync(marketplaceDir, { recursive: true });
+
+    const marketplaceConfig: ClaudeMarketplaceConfig = {
+      name: 'test-marketplace',
+      owner: { name: 'Test Owner', email: 'test@example.com' },
+      plugins: [
+        {
+          name: 'remote',
+          version: '1.0.0',
+          source: 'HTTPS://github.com/owner/plugin',
+          strict: false,
+        },
+      ],
+    };
+    fs.writeFileSync(
+      path.join(marketplaceDir, 'marketplace.json'),
+      JSON.stringify(marketplaceConfig, null, 2),
+      'utf-8',
+    );
+    vi.mocked(downloadFromGitHubRelease).mockResolvedValue(undefined as never);
+
+    const result = await convertClaudePluginPackage(pluginSourceDir, 'remote');
+
+    expect(result.config.name).toBe('remote');
+    expect(downloadFromGitHubRelease).toHaveBeenCalledWith(
+      {
+        source: 'HTTPS://github.com/owner/plugin',
+        type: 'git',
+        originSource: 'Claude',
+      },
+      expect.any(String),
+    );
+    expect(cloneFromGit).not.toHaveBeenCalled();
+
+    fs.rmSync(result.convertedDir, { recursive: true, force: true });
   });
 
   it('should use all skills from folder when config does not specify skills', async () => {

--- a/packages/core/src/extension/http-client.ts
+++ b/packages/core/src/extension/http-client.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as http from 'node:http';
+import * as https from 'node:https';
+
+export type HttpClient = typeof http | typeof https;
+
+export function clientForUrl(url: string): HttpClient {
+  const protocol = new URL(url).protocol.toLowerCase();
+  if (protocol === 'https:') {
+    return https;
+  }
+  if (protocol === 'http:') {
+    return http;
+  }
+  throw new Error(`Unsupported URL protocol: ${protocol}`);
+}

--- a/packages/core/src/extension/marketplace.test.ts
+++ b/packages/core/src/extension/marketplace.test.ts
@@ -24,11 +24,11 @@ vi.mock('node:fs', () => ({
   },
 }));
 
-vi.mock('node:https', () => ({
+vi.mock('node:http', () => ({
   get: vi.fn(),
 }));
 
-vi.mock('node:http', () => ({
+vi.mock('node:https', () => ({
   get: vi.fn(),
 }));
 
@@ -49,12 +49,13 @@ describe('parseInstallSource', () => {
     vi.mocked(https.get).mockImplementation((_url, _options, callback) => {
       const mockRes = {
         statusCode: 404,
+        resume: vi.fn(),
         on: vi.fn(),
       };
       if (typeof callback === 'function') {
         callback(mockRes as never);
       }
-      return { on: vi.fn() } as never;
+      return { on: vi.fn(), setTimeout: vi.fn(), destroy: vi.fn() } as never;
     });
     vi.mocked(http.get).mockImplementation((_url, _options, callback) => {
       const mockRes = {
@@ -337,7 +338,7 @@ describe('parseInstallSource', () => {
         if (typeof callback === 'function') {
           callback(mockRes as never);
         }
-        return { on: vi.fn() } as never;
+        return { on: vi.fn(), setTimeout: vi.fn(), destroy: vi.fn() } as never;
       });
 
       const result = await parseInstallSource('owner/repo');
@@ -428,6 +429,110 @@ describe('parseInstallSource', () => {
         'git@github.com:owner/repo.git',
       );
       expect(result).toEqual(cfg);
+    });
+
+    it('resolves a marketplace from an uppercase HTTPS GitHub source', async () => {
+      vi.mocked(fs.stat).mockRejectedValueOnce(new Error('ENOENT'));
+      const cfg = {
+        name: 'uppercase-url-marketplace',
+        owner: { name: 'Owner' },
+        plugins: [{ name: 'p1' }],
+      };
+      vi.mocked(https.get).mockImplementation((_url, _options, callback) => {
+        const mockRes = {
+          statusCode: 200,
+          resume: vi.fn(),
+          on: vi.fn((event, handler) => {
+            if (event === 'data') {
+              handler(Buffer.from(JSON.stringify(cfg)));
+            }
+            if (event === 'end') {
+              handler();
+            }
+          }),
+        };
+        if (typeof callback === 'function') {
+          callback(mockRes as never);
+        }
+        return { on: vi.fn(), setTimeout: vi.fn(), destroy: vi.fn() } as never;
+      });
+
+      const result = await loadMarketplaceConfigFromSource(
+        'HTTPS://github.com/owner/repo',
+      );
+
+      expect(result).toEqual(cfg);
+    });
+
+    it('resolves a direct JSON marketplace from an uppercase HTTPS source', async () => {
+      vi.mocked(fs.stat).mockRejectedValueOnce(new Error('ENOENT'));
+      const cfg = {
+        name: 'uppercase-direct-marketplace',
+        owner: { name: 'Owner' },
+        plugins: [{ name: 'p1' }],
+      };
+      vi.mocked(https.get).mockImplementation((_url, _options, callback) => {
+        const mockRes = {
+          statusCode: 200,
+          resume: vi.fn(),
+          on: vi.fn((event, handler) => {
+            if (event === 'data') {
+              handler(Buffer.from(JSON.stringify(cfg)));
+            }
+            if (event === 'end') {
+              handler();
+            }
+          }),
+        };
+        if (typeof callback === 'function') {
+          callback(mockRes as never);
+        }
+        return { on: vi.fn(), setTimeout: vi.fn(), destroy: vi.fn() } as never;
+      });
+
+      const result = await loadMarketplaceConfigFromSource(
+        'HTTPS://example.com/marketplace.json',
+      );
+
+      expect(result).toEqual(cfg);
+    });
+
+    it('resolves a direct JSON marketplace from an uppercase HTTP source', async () => {
+      vi.mocked(fs.stat).mockRejectedValueOnce(new Error('ENOENT'));
+      const cfg = {
+        name: 'uppercase-http-marketplace',
+        owner: { name: 'Owner' },
+        plugins: [{ name: 'p1' }],
+      };
+      vi.mocked(http.get).mockImplementation((_url, _options, callback) => {
+        const mockRes = {
+          statusCode: 200,
+          resume: vi.fn(),
+          on: vi.fn((event, handler) => {
+            if (event === 'data') {
+              handler(Buffer.from(JSON.stringify(cfg)));
+            }
+            if (event === 'end') {
+              handler();
+            }
+          }),
+        };
+        if (typeof callback === 'function') {
+          callback(mockRes as never);
+        }
+        return { on: vi.fn(), setTimeout: vi.fn(), destroy: vi.fn() } as never;
+      });
+
+      const result = await loadMarketplaceConfigFromSource(
+        'HTTP://example.com/marketplace.json',
+      );
+
+      expect(result).toEqual(cfg);
+      expect(https.get).not.toHaveBeenCalledWith(
+        'HTTP://example.com/marketplace.json',
+        expect.anything(),
+        expect.anything(),
+      );
     });
 
     // A non-GitHub https URL reaches fetchUrl via a single direct-JSON fetch,

--- a/packages/core/src/extension/marketplace.ts
+++ b/packages/core/src/extension/marketplace.ts
@@ -9,12 +9,12 @@ import type { ExtensionInstallMetadata } from '../config/config.js';
 import type { ClaudeMarketplaceConfig } from './claude-converter.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import * as http from 'node:http';
-import * as https from 'node:https';
+import type { ClientRequest, IncomingMessage } from 'node:http';
 import { stat } from 'node:fs/promises';
 import { parseGitHubRepoForReleases } from './github.js';
 import { isScopedNpmPackage } from './npm.js';
 import { redactUrlCredentials } from './redaction.js';
+import { clientForUrl } from './http-client.js';
 
 export interface MarketplaceInstallOptions {
   marketplaceUrl: string;
@@ -141,11 +141,17 @@ function fetchUrl(
   url: string,
   headers: Record<string, string>,
 ): Promise<string | null> {
-  const protocol = new URL(url).protocol;
-  const client = protocol === 'http:' ? http : https;
-
   return new Promise((resolve) => {
+    let client: ReturnType<typeof clientForUrl>;
+    try {
+      client = clientForUrl(url);
+    } catch {
+      resolve(null);
+      return;
+    }
+
     let settled = false;
+    let req: ClientRequest | undefined;
     const done = (value: string | null) => {
       if (settled) return;
       settled = true;
@@ -156,10 +162,11 @@ function fetchUrl(
     // chunk, so a server trickling bytes can keep the request alive forever.
     // Pair it with an absolute wall-clock deadline.
     const hardDeadline = setTimeout(() => {
-      req.destroy();
+      req?.destroy();
       done(null);
     }, MARKETPLACE_FETCH_TIMEOUT_MS);
-    const req = client.get(url, { headers }, (res) => {
+
+    const onResponse = (res: IncomingMessage) => {
       if (res.statusCode !== 200) {
         res.resume(); // drain so the socket can be freed
         done(null);
@@ -170,7 +177,7 @@ function fetchUrl(
       res.on('data', (chunk) => {
         total += chunk.length;
         if (total > MARKETPLACE_MAX_BODY_BYTES) {
-          req.destroy();
+          req?.destroy();
           done(null);
           return;
         }
@@ -178,10 +185,17 @@ function fetchUrl(
       });
       res.on('end', () => done(Buffer.concat(chunks).toString()));
       res.on('error', () => done(null));
-    });
+    };
+
+    try {
+      req = client.get(url, { headers }, onResponse);
+    } catch {
+      done(null);
+      return;
+    }
     req.on('error', () => done(null));
     req.setTimeout(MARKETPLACE_FETCH_TIMEOUT_MS, () => {
-      req.destroy();
+      req?.destroy();
       done(null);
     });
   });
@@ -266,6 +280,7 @@ export async function loadMarketplaceConfigFromSource(
   source: string,
 ): Promise<ClaudeMarketplaceConfig | null> {
   const trimmed = source.trim();
+  const lowerTrimmed = trimmed.toLowerCase();
 
   // Priority 1: local path (directory with .claude-plugin/marketplace.json,
   // or a direct marketplace.json file).
@@ -287,7 +302,10 @@ export async function loadMarketplaceConfigFromSource(
   }
 
   // Priority 2: http(s) URL — try GitHub repo first, then a direct JSON doc.
-  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+  if (
+    lowerTrimmed.startsWith('http://') ||
+    lowerTrimmed.startsWith('https://')
+  ) {
     try {
       const { owner, repo } = parseGitHubRepoForReleases(trimmed);
       const ghConfig = await fetchGitHubMarketplaceConfig(owner, repo);
@@ -309,11 +327,11 @@ export async function loadMarketplaceConfigFromSource(
   }
 
   // Priority 3: ssh/sso git URLs -> resolve owner/repo via github.
-  if (trimmed.startsWith('git@') || trimmed.startsWith('sso://')) {
+  if (lowerTrimmed.startsWith('git@') || lowerTrimmed.startsWith('sso://')) {
     // `git@github.com:owner/repo(.git)` isn't a parseable URL, so extract
     // owner/repo directly before falling back to the URL-based parser.
     const sshMatch = trimmed.match(
-      /^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/,
+      /^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/i,
     );
     if (sshMatch) {
       return fetchGitHubMarketplaceConfig(sshMatch[1], sshMatch[2]);

--- a/packages/core/src/extension/npm.ts
+++ b/packages/core/src/extension/npm.ts
@@ -5,13 +5,12 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import * as https from 'node:https';
-import * as http from 'node:http';
 import * as tar from 'tar';
 import type { ExtensionInstallMetadata } from '../config/config.js';
 import { ExtensionUpdateState } from './extensionManager.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { redactUrlCredentials } from './redaction.js';
+import { clientForUrl } from './http-client.js';
 
 const debugLogger = createDebugLogger('EXT_NPM');
 
@@ -177,20 +176,6 @@ function getNpmAuthToken(registryUrl: string): string | undefined {
   }
 
   return undefined;
-}
-
-/**
- * Fetch JSON from a URL, handling both https and http.
- */
-function clientForUrl(url: string): typeof https | typeof http {
-  const protocol = new URL(url).protocol.toLowerCase();
-  if (protocol === 'https:') {
-    return https;
-  }
-  if (protocol === 'http:') {
-    return http;
-  }
-  throw new Error(`Unsupported npm registry URL protocol: ${protocol}`);
 }
 
 function fetchNpmJson<T>(url: string, authToken?: string): Promise<T> {

--- a/packages/core/src/extension/sourceRegistry.test.ts
+++ b/packages/core/src/extension/sourceRegistry.test.ts
@@ -29,9 +29,12 @@ describe('parseExtensionSourceType', () => {
   it.each([
     ['anthropics/skills', 'github'],
     ['https://github.com/owner/repo', 'github'],
+    ['HTTPS://github.com/owner/repo', 'github'],
     ['git@github.com:owner/repo.git', 'git'],
     ['sso://team/repo', 'git'],
     ['https://example.com/marketplace.json', 'http'],
+    ['HTTPS://example.com/marketplace.json', 'http'],
+    ['HTTP://example.com/marketplace.json', 'http'],
     ['./local/marketplace', 'local'],
     ['/abs/path/marketplace', 'local'],
   ] as const)('classifies %s as %s', (input, expected) => {

--- a/packages/core/src/extension/sourceRegistry.ts
+++ b/packages/core/src/extension/sourceRegistry.ts
@@ -125,10 +125,11 @@ function pluginInstalls(
  */
 export function parseExtensionSourceType(source: string): ExtensionSourceType {
   const trimmed = source.trim();
-  if (trimmed.startsWith('git@') || trimmed.startsWith('sso://')) {
+  const lower = trimmed.toLowerCase();
+  if (lower.startsWith('git@') || lower.startsWith('sso://')) {
     return 'git';
   }
-  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+  if (lower.startsWith('http://') || lower.startsWith('https://')) {
     return isGitHubHost(trimmed) ? 'github' : 'http';
   }
   if (isOwnerRepoShorthand(trimmed)) {


### PR DESCRIPTION
## What this PR does

Accepts uppercase `HTTP://` / `HTTPS://` schemes in the extension marketplace paths that were still doing case-sensitive prefix checks. The source registry, marketplace config loader, and Claude marketplace plugin string-source resolver now lowercase only for scheme comparison while preserving the original source string for parsing, fetching, and install metadata.

It also makes marketplace direct-JSON fetches reuse the shared `clientForUrl()` helper introduced for npm registry URLs, so marketplace and npm extension downloads now choose `http.get` vs `https.get` from one parsed-URL protocol helper instead of carrying duplicate client-selection logic.

## Why it's needed

URL schemes are case-insensitive. #5429 fixed this for extension install sources, but marketplace sources still misclassified `HTTPS://...` as local and skipped the remote loading path. The same gap existed for string `source` entries inside Claude marketplace plugins.

## Reviewer Test Plan

### How to verify

Run the focused extension tests and core validation commands below. The important regression cases are uppercase GitHub marketplace sources, uppercase direct JSON marketplace sources, uppercase HTTP direct JSON marketplace sources, uppercase marketplace plugin string sources, and uppercase npm registry/tarball URLs continuing to use the shared helper.

### Evidence (Before & After)

Before: the new uppercase scheme tests failed because `HTTPS://...` was classified as local or skipped the HTTP(S) loader. `HTTP://...` could also enter a remote path that still called `https.get`, and npm/marketplace carried separate protocol-to-client helpers.

After: `npx vitest run packages/core/src/extension/npm.test.ts packages/core/src/extension/marketplace.test.ts packages/core/src/extension/sourceRegistry.test.ts packages/core/src/extension/claude-converter.test.ts` passes with 120 tests.

Additional local checks passed:

```text
npm run typecheck --workspace=packages/core
npm run lint --workspace=packages/core
npm run build --workspace=packages/core
git diff --check
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js v26.3.0, npm 11.16.0.

## Risk & Scope

- Main risk or tradeoff: `http://` direct marketplace JSON sources now use the HTTP client instead of accidentally going through the HTTPS client path; npm and marketplace now share one URL-client helper.
- Not validated / out of scope: end-to-end interactive `/extensions` TUI testing; this is covered at the core parser/loader level.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5434

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 extension marketplace 相关路径接受大写 `HTTP://` / `HTTPS://` scheme。source registry、marketplace config loader、Claude marketplace 插件里的字符串 `source` 解析，现在只在比较 scheme 时做 lowercase，后续解析、请求和安装 metadata 仍保留用户输入的原始字符串。

同时，marketplace direct-JSON fetch 复用 npm registry URL 已引入的共享 `clientForUrl()` helper，让 marketplace 和 npm extension download 都通过同一个 parsed-URL protocol helper 选择 `http.get` 或 `https.get`，避免重复实现 client-selection 逻辑。

## 为什么需要

URL scheme 按规范是大小写不敏感的。#5429 已经修了 extension install source，但 marketplace source 仍会把 `HTTPS://...` 误判成本地路径，从而跳过远程加载。Claude marketplace 插件内部的字符串 `source` 也有同类问题。

## Reviewer Test Plan

### 如何验证

运行上面的 focused extension tests 和 core validation commands。关键回归用例覆盖大写 GitHub marketplace source、大写 direct JSON marketplace source、大写 HTTP direct JSON marketplace source、大写 marketplace plugin string source，以及大写 npm registry/tarball URL 继续使用共享 helper。

### 证据（Before & After）

Before：新增的大写 scheme 测试失败，因为 `HTTPS://...` 会被归类为 local 或跳过 HTTP(S) loader。`HTTP://...` 也可能进入远程路径后仍调用 `https.get`，并且 npm/marketplace 各自有一份 protocol-to-client helper。

After：`npx vitest run packages/core/src/extension/npm.test.ts packages/core/src/extension/marketplace.test.ts packages/core/src/extension/sourceRegistry.test.ts packages/core/src/extension/claude-converter.test.ts` 通过，共 120 个测试。

额外本地检查也已通过：

```text
npm run typecheck --workspace=packages/core
npm run lint --workspace=packages/core
npm run build --workspace=packages/core
git diff --check
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js v26.3.0, npm 11.16.0.

## 风险和范围

- 主要风险或取舍：`http://` direct marketplace JSON source 现在会使用 HTTP client，而不是误走 HTTPS client；npm 和 marketplace 现在共用一个 URL-client helper。
- 未验证 / 不在范围内：未做 `/extensions` TUI 端到端交互验证；本 PR 在 core parser/loader 层覆盖。
- Breaking changes / migration notes：无。

## Linked Issues

Fixes #5434

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
