### PR TITLE
fix(extensions): handle uppercase npm registry schemes

### DIFF
--- a/packages/core/src/extension/npm.test.ts
+++ b/packages/core/src/extension/npm.test.ts
@@ -166,8 +166,14 @@ vi.mock('node:http', () => ({
   get: vi.fn(),
 }));
 
+vi.mock('tar', () => ({
+  x: vi.fn(),
+}));
+
 // We need to import https after mocking
 const https = await import('node:https');
+const http = await import('node:http');
+const tar = await import('tar');
 
 function mockNpmRegistryResponse(data: object) {
   vi.mocked(https.get).mockImplementation(
@@ -210,6 +216,16 @@ function mockNpmRegistryStatus(statusCode: number) {
 describe('downloadFromNpmRegistry', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.createWriteStream).mockReturnValue({
+      on: vi.fn((event: string, handler: () => void) => {
+        if (event === 'finish') {
+          handler();
+        }
+      }),
+      close: vi.fn((callback: () => void) => callback()),
+    } as never);
+    vi.mocked(tar.x).mockResolvedValue(undefined);
   });
 
   it('redacts credentialed registry URLs in metadata request errors', async () => {
@@ -227,6 +243,70 @@ describe('downloadFromNpmRegistry', () => {
     ).rejects.toThrow(
       'npm registry request failed with status 404: https://***REDACTED***@registry.example.com/@scope%2fpkg',
     );
+  });
+
+  it('uses the HTTPS client for uppercase HTTPS tarball URLs', async () => {
+    let requestCount = 0;
+    vi.mocked(http.get).mockImplementation(() => {
+      throw new Error('wrong client');
+    });
+    vi.mocked(https.get).mockImplementation(
+      (_url: unknown, _options: unknown, callback: unknown) => {
+        requestCount += 1;
+        const mockRes =
+          requestCount === 1
+            ? {
+                statusCode: 200,
+                headers: {},
+                on: vi.fn(
+                  (event: string, handler: (data?: Buffer) => void) => {
+                    if (event === 'data') {
+                      handler(
+                        Buffer.from(
+                          JSON.stringify({
+                            'dist-tags': { latest: '1.0.0' },
+                            versions: {
+                              '1.0.0': {
+                                dist: {
+                                  tarball:
+                                    'HTTPS://registry.example.com/@scope/pkg/-/pkg-1.0.0.tgz',
+                                },
+                              },
+                            },
+                          }),
+                        ),
+                      );
+                    }
+                    if (event === 'end') {
+                      handler();
+                    }
+                  },
+                ),
+              }
+            : {
+                statusCode: 200,
+                headers: {},
+                pipe: vi.fn(),
+              };
+        if (typeof callback === 'function') {
+          callback(mockRes as never);
+        }
+        return { on: vi.fn() } as never;
+      },
+    );
+
+    await expect(
+      downloadFromNpmRegistry(
+        {
+          source: '@scope/pkg',
+          type: 'npm',
+          registryUrl: 'HTTPS://registry.example.com',
+        },
+        '/tmp/qwen-extension',
+      ),
+    ).resolves.toEqual({ version: '1.0.0', type: 'npm' });
+    expect(https.get).toHaveBeenCalledTimes(2);
+    expect(http.get).not.toHaveBeenCalled();
   });
 });
 
@@ -257,6 +337,29 @@ describe('checkNpmUpdate', () => {
 
     const result = await checkNpmUpdate(metadata);
     expect(result).toBe(ExtensionUpdateState.UPDATE_AVAILABLE);
+  });
+
+  it('uses the HTTPS client for uppercase HTTPS registry URLs', async () => {
+    vi.mocked(http.get).mockImplementation(() => {
+      throw new Error('wrong client');
+    });
+    mockNpmRegistryResponse({
+      'dist-tags': { latest: '1.0.0' },
+      versions: { '1.0.0': { dist: { tarball: '' } } },
+    });
+
+    const metadata: ExtensionInstallMetadata = {
+      source: '@scope/pkg',
+      type: 'npm',
+      releaseTag: '1.0.0',
+      registryUrl: 'HTTPS://registry.npmjs.org',
+    };
+
+    const result = await checkNpmUpdate(metadata);
+
+    expect(result).toBe(ExtensionUpdateState.UP_TO_DATE);
+    expect(https.get).toHaveBeenCalled();
+    expect(http.get).not.toHaveBeenCalled();
   });
 
   it('should report UP_TO_DATE when latest matches', async () => {

--- a/packages/core/src/extension/npm.ts
+++ b/packages/core/src/extension/npm.ts
@@ -182,6 +182,17 @@ function getNpmAuthToken(registryUrl: string): string | undefined {
 /**
  * Fetch JSON from a URL, handling both https and http.
  */
+function clientForUrl(url: string): typeof https | typeof http {
+  const protocol = new URL(url).protocol.toLowerCase();
+  if (protocol === 'https:') {
+    return https;
+  }
+  if (protocol === 'http:') {
+    return http;
+  }
+  throw new Error(`Unsupported npm registry URL protocol: ${protocol}`);
+}
+
 function fetchNpmJson<T>(url: string, authToken?: string): Promise<T> {
   const headers: Record<string, string> = {
     Accept: 'application/json',
@@ -190,7 +201,7 @@ function fetchNpmJson<T>(url: string, authToken?: string): Promise<T> {
     headers['Authorization'] = `Bearer ${authToken}`;
   }
 
-  const client = url.startsWith('https://') ? https : http;
+  const client = clientForUrl(url);
 
   return new Promise((resolve, reject) => {
     client
@@ -242,7 +253,7 @@ function downloadNpmFile(
     headers['Authorization'] = `Bearer ${authToken}`;
   }
 
-  const client = url.startsWith('https://') ? https : http;
+  const client = clientForUrl(url);
 
   return new Promise((resolve, reject) => {
     client


### PR DESCRIPTION
## What this PR does

Makes npm extension registry requests choose the HTTP client from the parsed URL protocol instead of checking for a lowercase `https://` prefix. This keeps uppercase HTTPS registry and tarball URLs on the HTTPS client.

## Why it is needed

URL schemes are case-insensitive, but the npm extension path used a case-sensitive string prefix check. A registry URL like `HTTPS://registry.npmjs.org` could be misrouted to `http.get`, and the same issue applied when downloading tarballs from uppercase HTTPS tarball URLs.

## Reviewer Test Plan

### How to verify

Run `npx vitest run packages/core/src/extension/npm.test.ts`, `npm run typecheck --workspace=packages/core`, `npm run lint --workspace=packages/core`, `npm run build --workspace=packages/core`, and `git diff --check`. The new tests assert uppercase HTTPS registry metadata and tarball URLs use `https.get` and never call `http.get`.

### Evidence (Before & After)

N/A

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local npm workspace on macOS.

## Risk & Scope

- Main risk or tradeoff: Low. This only changes client selection for npm registry URLs and now rejects unsupported URL protocols instead of accidentally sending them through the HTTP client.
- Not validated / out of scope: Manual install against every possible registry service; Windows and Linux local runs.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5436

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 npm extension registry 请求根据解析后的 URL protocol 选择 HTTP client，而不是检查小写 `https://` 前缀。这样 uppercase HTTPS registry 和 tarball URL 都会继续走 HTTPS client。

## 为什么需要

URL scheme 本身是大小写不敏感的，但 npm extension 路径之前用了大小写敏感的字符串前缀判断。像 `HTTPS://registry.npmjs.org` 这样的 registry URL 可能会被错误转到 `http.get`，下载 uppercase HTTPS tarball URL 时也有同样问题。

## Reviewer Test Plan

### 如何验证

运行 `npx vitest run packages/core/src/extension/npm.test.ts`、`npm run typecheck --workspace=packages/core`、`npm run lint --workspace=packages/core`、`npm run build --workspace=packages/core` 和 `git diff --check`。新增测试会断言 uppercase HTTPS registry metadata 和 tarball URL 都使用 `https.get`，不会调用 `http.get`。

### Before & After 证据

N/A

### Tested on

macOS 已本地验证；Windows 和 Linux 未本地验证，交给 CI 覆盖。

### Environment

macOS 本地 npm workspace。

## Risk & Scope

- 主要风险或取舍：低。改动只影响 npm registry URL 的 client 选择，并且现在会拒绝 unsupported URL protocol，而不是意外交给 HTTP client。
- 未验证 / 不在范围内：没有手动覆盖每一种 registry 服务；Windows 和 Linux 未本地跑。
- Breaking changes / migration notes：无。

## Linked Issues

Fixes #5436

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>