### PR TITLE
fix(weixin): handle uppercase CDN upload schemes

### DIFF
--- a/packages/channels/weixin/src/api.test.ts
+++ b/packages/channels/weixin/src/api.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { uploadToCdn } from './api.js';
+
+describe('uploadToCdn', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it.each([
+    'HTTPS://novac2c.cdn.weixin.qq.com/c2c/upload?encrypted_query_param=abc',
+    'HtTpS://novac2c.cdn.weixin.qq.com/c2c/upload?encrypted_query_param=abc',
+  ])('accepts %s CDN upload URLs', async (uploadUrl) => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: {
+        get: vi.fn((name: string) =>
+          name.toLowerCase() === 'x-encrypted-param' ? 'cdn-param' : null,
+        ),
+      },
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      uploadToCdn(uploadUrl, 'filekey-123', Buffer.from('encrypted')),
+    ).resolves.toBe('cdn-param');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      uploadUrl,
+      expect.objectContaining({
+        method: 'POST',
+        body: Buffer.from('encrypted'),
+      }),
+    );
+  });
+
+  it('rejects uppercase HTTP CDN upload URLs', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      uploadToCdn(
+        'HTTP://novac2c.cdn.weixin.qq.com/c2c/upload?encrypted_query_param=abc',
+        'filekey-123',
+        Buffer.from('encrypted'),
+      ),
+    ).rejects.toThrow('CDN upload URL must use HTTPS');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/channels/weixin/src/api.ts
+++ b/packages/channels/weixin/src/api.ts
@@ -343,13 +343,14 @@ export async function uploadToCdn(
   const CDN_HOST = 'novac2c.cdn.weixin.qq.com';
 
   let url: string;
-  if (urlOrParam.startsWith('https://')) {
+  const lowerUrlOrParam = urlOrParam.toLowerCase();
+  if (lowerUrlOrParam.startsWith('https://')) {
     const parsed = new URL(urlOrParam);
     if (parsed.hostname !== CDN_HOST) {
       throw new Error(`CDN upload URL has unexpected host: ${parsed.hostname}`);
     }
     url = urlOrParam;
-  } else if (urlOrParam.startsWith('http://')) {
+  } else if (lowerUrlOrParam.startsWith('http://')) {
     throw new Error('CDN upload URL must use HTTPS');
   } else {
     url = `https://${CDN_HOST}/c2c/upload?encrypted_query_param=${encodeURIComponent(urlOrParam)}&filekey=${encodeURIComponent(filekey)}`;


### PR DESCRIPTION
## What this PR does

Makes Weixin CDN upload URL handling compare HTTP(S) schemes case-insensitively. Full CDN upload URLs with `HTTPS://` or mixed-case `HtTpS://` now stay on the direct upload URL path, while uppercase `HTTP://` is rejected like lowercase `http://`.

## Why it is needed

URL schemes are case-insensitive, but `uploadToCdn()` used case-sensitive `startsWith()` checks. That meant uppercase HTTPS upload URLs could be treated as raw upload params and embedded into `encrypted_query_param`, producing malformed CDN requests.

## Reviewer Test Plan

### How to verify

Run the Weixin channel tests and build. The new regression tests cover uppercase and mixed-case HTTPS CDN URLs, plus uppercase HTTP rejection.

Commands run locally:
- `npx vitest run packages/channels/weixin/src/api.test.ts`
- `npx vitest run --config vitest.config.ts` from `packages/channels/weixin`
- `npx eslint packages/channels/weixin/src/api.ts packages/channels/weixin/src/api.test.ts`
- `npx prettier --check packages/channels/weixin/src/api.ts packages/channels/weixin/src/api.test.ts`
- `npm run build --workspace=packages/channels/weixin`
- `git diff --check`

### Evidence (Before & After)

N/A

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local npm workspace on macOS.

## Risk & Scope

- Main risk or tradeoff: Low. The change only normalizes the scheme comparison before the existing branch, and the direct URL path still enforces the exact Weixin CDN hostname.
- Not validated / out of scope: Real Weixin CDN upload with a live channel session; Windows and Linux local runs.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5438

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 Weixin CDN 上传 URL 的 HTTP(S) scheme 判断变成大小写不敏感。`HTTPS://` 或混合大小写 `HtTpS://` 的完整 CDN 上传 URL 现在会继续走直接上传 URL 分支；大写 `HTTP://` 会像小写 `http://` 一样被拒绝。

## 为什么需要

URL scheme 本身大小写不敏感，但 `uploadToCdn()` 之前用了大小写敏感的 `startsWith()`。这会让大写 HTTPS 上传 URL 被当成原始 upload param，并嵌入 `encrypted_query_param`，最终生成错误的 CDN 请求。

## Reviewer Test Plan

### 如何验证

运行 Weixin channel 测试和 build。新增回归测试覆盖大写 HTTPS、混合大小写 HTTPS，以及大写 HTTP 拒绝。

本地运行过的命令：
- `npx vitest run packages/channels/weixin/src/api.test.ts`
- 在 `packages/channels/weixin` 下运行 `npx vitest run --config vitest.config.ts`
- `npx eslint packages/channels/weixin/src/api.ts packages/channels/weixin/src/api.test.ts`
- `npx prettier --check packages/channels/weixin/src/api.ts packages/channels/weixin/src/api.test.ts`
- `npm run build --workspace=packages/channels/weixin`
- `git diff --check`

### Before & After 证据

N/A

### Tested on

macOS 已本地验证；Windows 和 Linux 未本地验证，交给 CI 覆盖。

### Environment

macOS 本地 npm workspace。

## Risk & Scope

- 主要风险或取舍：低。改动只在现有分支判断前规范化 scheme 比较；直接 URL 分支仍然保留精确 Weixin CDN hostname 校验。
- 未验证 / 不在范围内：没有用真实 Weixin channel session 做 CDN 上传；Windows 和 Linux 未本地跑。
- Breaking changes / migration notes：无。

## Linked Issues

Fixes #5438

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>