### PR TITLE
fix(cli): respect installation path boundaries

### DIFF
--- a/packages/cli/src/utils/installationInfo.test.ts
+++ b/packages/cli/src/utils/installationInfo.test.ts
@@ -576,6 +576,51 @@ describe('getInstallationInfo', () => {
     expect(info.isGlobal).toBe(false);
   });
 
+  it('should not detect a sibling directory as the local git clone', () => {
+    const siblingPath = `${projectRoot}-other/packages/cli/dist/index.js`;
+    process.argv[1] = siblingPath;
+    mockedRealPathSync.mockReturnValue(siblingPath);
+    mockedIsGitRepository.mockReturnValue(true);
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('Command failed');
+    });
+
+    const info = getInstallationInfo(projectRoot, false);
+
+    expect(info.updateMessage).not.toContain('local git clone');
+    expect(info.isGlobal).toBe(true);
+  });
+
+  it('should not detect a Windows sibling directory as the local git clone', () => {
+    const windowsRoot = 'C:/repo/app';
+    const siblingPath = 'C:\\repo\\app-other\\packages\\cli\\dist\\index.js';
+    process.argv[1] = siblingPath;
+    mockedRealPathSync.mockReturnValue(siblingPath);
+    mockedIsGitRepository.mockReturnValue(true);
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('Command failed');
+    });
+
+    const info = getInstallationInfo(windowsRoot, false);
+
+    expect(info.updateMessage).not.toContain('local git clone');
+    expect(info.isGlobal).toBe(true);
+  });
+
+  it('should not detect a node_modules-prefixed sibling directory as local install', () => {
+    const siblingPath = `${projectRoot}/node_modules-backup/.bin/gemini`;
+    process.argv[1] = siblingPath;
+    mockedRealPathSync.mockReturnValue(siblingPath);
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('Command failed');
+    });
+
+    const info = getInstallationInfo(projectRoot, false);
+
+    expect(info.updateMessage).not.toContain('Locally installed');
+    expect(info.isGlobal).toBe(true);
+  });
+
   it('should default to global npm installation for unrecognized paths', () => {
     const globalPath = `/usr/local/bin/gemini`;
     process.argv[1] = globalPath;

--- a/packages/cli/src/utils/installationInfo.ts
+++ b/packages/cli/src/utils/installationInfo.ts
@@ -56,7 +56,7 @@ export function getInstallationInfo(
     if (
       isGit &&
       normalizedProjectRoot &&
-      realPath.startsWith(normalizedProjectRoot) &&
+      isSamePathOrInside(realPath, normalizedProjectRoot) &&
       !realPath.includes('/node_modules/')
     ) {
       return {
@@ -158,7 +158,7 @@ export function getInstallationInfo(
     // Check for local install
     if (
       normalizedProjectRoot &&
-      realPath.startsWith(`${normalizedProjectRoot}/node_modules`)
+      isSamePathOrInside(realPath, `${normalizedProjectRoot}/node_modules`)
     ) {
       let pm = PackageManager.NPM;
       if (fs.existsSync(path.join(projectRoot, 'yarn.lock'))) {
@@ -215,6 +215,22 @@ export function getInstallationInfo(
     debugLogger.error('Failed to detect installation info:', error);
     return { packageManager: PackageManager.UNKNOWN, isGlobal: false };
   }
+}
+
+function stripTrailingSlashes(value: string): string {
+  return value.replace(/\/+$/, '') || '/';
+}
+
+function isSamePathOrInside(candidate: string, parent: string): boolean {
+  const normalizedCandidate = stripTrailingSlashes(candidate);
+  const normalizedParent = stripTrailingSlashes(parent);
+  if (normalizedParent === '/') {
+    return normalizedCandidate === '/' || normalizedCandidate.startsWith('/');
+  }
+  return (
+    normalizedCandidate === normalizedParent ||
+    normalizedCandidate.startsWith(`${normalizedParent}/`)
+  );
 }
 
 function getStandaloneInstallInfo(


### PR DESCRIPTION
## What this PR does

Fixes installation detection so the current CLI entrypoint must be an exact path match or a real child path before it is treated as a local git clone or project `node_modules` install.

This avoids false positives for sibling paths like `/repo/app-other` and `node_modules`-prefixed directories like `/repo/app/node_modules-backup`.

## Why it's needed

The previous detection used raw prefix checks. That can misclassify a globally installed or sibling CLI entrypoint as running from the current project just because the paths share the same string prefix. The resulting install/update guidance can be wrong for users.

## Reviewer Test Plan

### How to verify

- Review the installation info regression tests for sibling project roots and `node_modules`-prefixed sibling directories.
- Confirm genuine project-child and real `node_modules` paths are still detected.
- Run `npx vitest run packages/cli/src/utils/installationInfo.test.ts`.
- Run `npx eslint packages/cli/src/utils/installationInfo.ts packages/cli/src/utils/installationInfo.test.ts`.
- Run `npx prettier --check packages/cli/src/utils/installationInfo.ts packages/cli/src/utils/installationInfo.test.ts`.
- Run `git diff --check`.

### Evidence (Before & After)

Before: an entrypoint under `/repo/app-other` could be detected as being inside `/repo/app`, and `/repo/app/node_modules-backup` could be detected as a local `node_modules` install. After: installation detection requires exact path equality or a real path separator boundary.

Local validation note: `npm run typecheck --workspace=packages/cli` and `npm run build --workspace=packages/cli` were blocked in my checkout by existing workspace generated/dist preconditions unrelated to this patch.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; CI passed |
|  🐧 Linux  | ⚠️ not tested locally; CI passed |

### Environment (optional)

Local CLI utility tests, eslint, prettier, and `git diff --check` on macOS.

## Risk & Scope

- Main risk or tradeoff: installation classification affects user-facing update/install guidance, so the helper keeps exact-path and real-child matches valid while rejecting sibling-prefix matches.
- Not validated / out of scope: changing update-notifier behavior or installation messages beyond the path-boundary check.
- Breaking changes / migration notes: none for valid local clone or project `node_modules` installs.

## Linked Issues

Fixes #5440

<details>
<summary>中文说明</summary>

## What this PR does

修复安装来源检测逻辑：当前 CLI entrypoint 必须和目标路径完全相同，或是真正位于其子路径内，才会被识别为本地 git clone 或项目 `node_modules` 安装。

这避免了 `/repo/app-other` 这类兄弟路径，以及 `/repo/app/node_modules-backup` 这类 `node_modules` 前缀目录造成误判。

## Why it's needed

旧检测使用裸前缀判断。只要路径字符串前缀相同，就可能把全局安装或兄弟目录里的 CLI entrypoint 误认为来自当前项目，导致展示给用户的安装/更新提示不准确。

## Reviewer Test Plan

### How to verify

- 查看 installation info 回归测试中项目根目录兄弟路径和 `node_modules` 前缀兄弟目录的用例。
- 确认真正位于项目内的路径和真实 `node_modules` 路径仍然能被检测出来。
- 运行 `npx vitest run packages/cli/src/utils/installationInfo.test.ts`。
- 运行 `npx eslint packages/cli/src/utils/installationInfo.ts packages/cli/src/utils/installationInfo.test.ts`。
- 运行 `npx prettier --check packages/cli/src/utils/installationInfo.ts packages/cli/src/utils/installationInfo.test.ts`。
- 运行 `git diff --check`。

### Evidence (Before & After)

修复前：`/repo/app-other` 下的 entrypoint 可能被误判为位于 `/repo/app` 内，`/repo/app/node_modules-backup` 也可能被误判为本地 `node_modules` 安装。修复后：安装检测需要路径完全相同，或存在真实路径分隔边界。

本地验证说明：`npm run typecheck --workspace=packages/cli` 和 `npm run build --workspace=packages/cli` 在我的 checkout 里被既有 workspace generated/dist 前置条件挡住，和此 patch 无关。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; CI passed |
|  🐧 Linux  | ⚠️ not tested locally; CI passed |

### Environment (optional)

在 macOS 上运行了本地 CLI utility 测试、eslint、prettier 和 `git diff --check`。

## Risk & Scope

- 主要风险或取舍：安装分类会影响面向用户的更新/安装提示，所以 helper 保留完全相同路径和真实子路径匹配，同时拒绝兄弟前缀误判。
- 未验证 / 不在范围内：修改 update-notifier 行为或路径边界检查之外的安装提示文案。
- Breaking changes / migration notes：对合法的本地 clone 或项目 `node_modules` 安装没有破坏性变更。

## Linked Issues

Fixes #5440

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
