### PR TITLE
fix: accept uppercase endpoint URL schemes

### DIFF
--- a/packages/core/src/qwen/qwenContentGenerator.test.ts
+++ b/packages/core/src/qwen/qwenContentGenerator.test.ts
@@ -1226,6 +1226,14 @@ describe('QwenContentGenerator', () => {
           expected: 'https://api.example.com:443/v1',
         },
         {
+          input: 'HTTPS://api.example.com',
+          expected: 'HTTPS://api.example.com/v1',
+        },
+        {
+          input: 'HtTp://localhost:8080',
+          expected: 'HtTp://localhost:8080/v1',
+        },
+        {
           input: 'api.example.com:9000/api',
           expected: 'https://api.example.com:9000/api/v1',
         },

--- a/packages/core/src/qwen/qwenContentGenerator.ts
+++ b/packages/core/src/qwen/qwenContentGenerator.ts
@@ -61,7 +61,7 @@ export class QwenContentGenerator extends OpenAIContentGenerator {
     const suffix = '/v1';
 
     // Normalize the URL: add protocol if missing, ensure /v1 suffix
-    const normalizedUrl = baseEndpoint.startsWith('http')
+    const normalizedUrl = /^https?:\/\//i.test(baseEndpoint)
       ? baseEndpoint
       : `https://${baseEndpoint}`;
 

--- a/packages/core/src/telemetry/qwen-logger/qwen-logger.test.ts
+++ b/packages/core/src/telemetry/qwen-logger/qwen-logger.test.ts
@@ -138,6 +138,17 @@ describe('QwenLogger', () => {
     });
   });
 
+  describe('getProxyAgent', () => {
+    it('accepts uppercase proxy URL schemes', () => {
+      const config = makeFakeConfig({
+        getProxy: () => 'HTTPS://proxy.example.com:8080',
+      });
+      const logger = QwenLogger.getInstance(config)!;
+
+      expect(logger.getProxyAgent()).toBeDefined();
+    });
+  });
+
   describe('createRumPayload', () => {
     it('includes os metadata in payload', async () => {
       const logger = QwenLogger.getInstance(mockConfig)!;

--- a/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
+++ b/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
@@ -1070,7 +1070,7 @@ export class QwenLogger {
     if (!proxyUrl) return undefined;
     // undici which is widely used in the repo can only support http & https proxy protocol,
     // https://github.com/nodejs/undici/issues/2224
-    if (proxyUrl.startsWith('http')) {
+    if (/^https?:\/\//i.test(proxyUrl)) {
       return new HttpsProxyAgent(proxyUrl);
     } else {
       throw new Error('Unsupported proxy type');

--- a/packages/desktop/packages/shared/src/sources/__tests__/credential-manager-renew.test.ts
+++ b/packages/desktop/packages/shared/src/sources/__tests__/credential-manager-renew.test.ts
@@ -176,6 +176,24 @@ describe('refreshApiRenew via refresh()', () => {
     expect(fetchCalls[0]!.url).toBe('https://auth.example.com/oauth/token');
   });
 
+  test('handles absolute renew URL with uppercase scheme', async () => {
+    mockGet.mockImplementationOnce(() => Promise.resolve({
+      value: 'old-token', expiresAt: Date.now() - 60_000,
+    }));
+    mockFetch({ access_token: 'new-token', expires_in: 3600 });
+
+    const source = createRenewSource({
+      api: {
+        baseUrl: 'https://api.example.com',
+        authType: 'bearer',
+        renewEndpoint: { path: 'HTTPS://auth.example.com/oauth/token' },
+      },
+    });
+
+    await credManager.refresh(source);
+    expect(fetchCalls[0]!.url).toBe('HTTPS://auth.example.com/oauth/token');
+  });
+
   test('returns null on 401 response', async () => {
     mockGet.mockImplementationOnce(() => Promise.resolve({
       value: 'old-token', expiresAt: Date.now() - 60_000,

--- a/packages/desktop/packages/shared/src/sources/credential-manager.ts
+++ b/packages/desktop/packages/shared/src/sources/credential-manager.ts
@@ -975,7 +975,7 @@ export class SourceCredentialManager {
 
     try {
       // 1. Resolve URL
-      const url = renewConfig.path.startsWith('http')
+      const url = /^https?:\/\//i.test(renewConfig.path)
         ? renewConfig.path
         : new URL(renewConfig.path, baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`).toString();
 


### PR DESCRIPTION
## What this PR does

Fixes case-sensitive endpoint scheme checks so uppercase or mixed-case `HTTP://` / `HTTPS://` URLs are treated as absolute URLs instead of being prefixed again.

This covers the Qwen OAuth resource endpoint, desktop credential renew endpoints, and telemetry proxy URL handling.

## Why it's needed

URL schemes are case-insensitive. The previous checks used lowercase-only string tests, so uppercase absolute endpoint URLs could be treated as relative values and prefixed a second time.

## Reviewer Test Plan

### How to verify

Review the endpoint URL tests across core and desktop shared credential renewal. Uppercase and mixed-case HTTP(S) URLs should remain absolute; invalid lookalike schemes such as `httpx://` should not be accepted as HTTP(S).

Run:

```bash
npx vitest run packages/core/src/qwen/qwenContentGenerator.test.ts packages/core/src/telemetry/qwen-logger/qwen-logger.test.ts
bun install --cwd packages/desktop --frozen-lockfile
bun test packages/desktop/packages/shared/src/sources/__tests__/credential-manager-renew.test.ts
npx eslint packages/core/src/qwen/qwenContentGenerator.ts packages/core/src/qwen/qwenContentGenerator.test.ts packages/core/src/telemetry/qwen-logger/qwen-logger.ts packages/core/src/telemetry/qwen-logger/qwen-logger.test.ts
npx prettier --check packages/core/src/qwen/qwenContentGenerator.ts packages/core/src/qwen/qwenContentGenerator.test.ts packages/core/src/telemetry/qwen-logger/qwen-logger.ts packages/core/src/telemetry/qwen-logger/qwen-logger.test.ts packages/desktop/packages/shared/src/sources/credential-manager.ts packages/desktop/packages/shared/src/sources/__tests__/credential-manager-renew.test.ts
npm run typecheck --workspace=packages/core
```

### Evidence (Before & After)

Before: uppercase absolute `HTTP://` / `HTTPS://` endpoint values could be treated as non-absolute and prefixed again.

After: HTTP(S) scheme detection is case-insensitive and exact, so uppercase absolute URLs stay absolute while lookalike schemes remain rejected.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS     | tested |
|  Windows   | CI had an environment failure unrelated to this change |
|  Linux     | covered by CI |

### Environment (optional)

Local Node/npm workspace tests plus desktop shared package tests.

## Risk & Scope

- Main risk or tradeoff: scheme matching is stricter and case-insensitive; `httpx://` no longer passes as an HTTP-looking prefix.
- Not validated / out of scope: changing endpoint construction semantics beyond HTTP(S) absolute URL detection.
- Breaking changes / migration notes: none expected for valid HTTP(S) endpoint URLs.

## Linked Issues

Fixes #5442

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复 endpoint scheme 的大小写敏感判断，让大写或混合大小写的 `HTTP://` / `HTTPS://` URL 被当作绝对 URL，而不是被再次拼前缀。

覆盖范围包括 Qwen OAuth resource endpoint、desktop credential renew endpoint，以及 telemetry proxy URL。

## 为什么需要

URL scheme 本来就是大小写不敏感的。旧逻辑只检查小写字符串，因此大写绝对 endpoint URL 可能被误认为相对值，并被重复拼接前缀。

## Reviewer Test Plan

### How to verify

检查 core 和 desktop shared credential renewal 的 endpoint URL 测试：大写/混合大小写 HTTP(S) URL 应保持绝对 URL；`httpx://` 这类伪装 scheme 不应被当作 HTTP(S)。

### Evidence (Before & After)

修复前：大写绝对 `HTTP://` / `HTTPS://` endpoint 可能被当成非绝对值再次拼接。

修复后：HTTP(S) scheme 检测大小写不敏感且精确，大写绝对 URL 保持绝对，伪装 scheme 仍被拒绝。

### Tested on

本地跑过相关 Node/npm 测试和 desktop shared 测试；Linux 由 CI 覆盖；Windows CI 当时是环境问题。

## Risk & Scope

改动只影响 HTTP(S) 绝对 URL 检测，不改变其它 endpoint 构造语义。对合法 HTTP(S) endpoint 没有预期破坏性变更。

</details>
