### PR TITLE
fix(cli): stabilize extension list spacing

### DIFF
--- a/packages/cli/src/ui/components/extensions/steps/ExtensionListStep.tsx
+++ b/packages/cli/src/ui/components/extensions/steps/ExtensionListStep.tsx
@@ -174,7 +174,11 @@ export const ExtensionListStep = ({
       : [];
 
     return (
-      <Box key={extension.name} flexDirection="column" marginBottom={descLines.length > 0 ? 1 : 0}>
+      <Box
+        key={extension.name}
+        flexDirection="column"
+        marginBottom={descLines.length > 0 ? 1 : 0}
+      >
         <Box alignItems="center">
           <Box minWidth={2} flexShrink={0}>
             <Text color={isSelected ? theme.text.accent : theme.text.primary}>
@@ -189,15 +193,17 @@ export const ExtensionListStep = ({
               {getExtensionDisplayName(extension, locale)}
             </Text>
           </Box>
-          <Box width={maxStatusWidth + 4} flexShrink={0}>
-            <Text color={activeColor}>  ({activeString})</Text>
+          <Box marginLeft={2} width={maxStatusWidth + 2} flexShrink={0}>
+            <Text color={activeColor}>({activeString})</Text>
           </Box>
           {stateText && <Text color={stateColor}>[{stateText}]</Text>}
         </Box>
         {descLines.length > 0 && (
           <Box paddingLeft={2} flexDirection="column">
             {descLines.map((line, i) => (
-              <Text key={i} color={theme.text.secondary}>{line}</Text>
+              <Text key={i} color={theme.text.secondary}>
+                {line}
+              </Text>
             ))}
           </Box>
         )}


### PR DESCRIPTION
## What this PR does

This PR keeps the extension list's visible alignment the same while moving the status-column spacing from literal leading text spaces into Ink layout spacing.

## Why it's needed

The scheduled Release workflow failed in Quality Checks because the extension list snapshot rendered one fewer leading space before status labels on CI than the committed snapshot expected. Using layout spacing avoids relying on renderer-specific preservation of leading whitespace inside text nodes.

## Reviewer Test Plan

### How to verify

Confirm that installed-extension rows still render with the same aligned status column, and that the extension list snapshot test remains stable. The related failed run was https://github.com/QwenLM/qwen-code/actions/runs/27854449183.

### Evidence (Before & After)

Before: the scheduled Release run on 2026-06-20 failed in Workspace Tests with snapshot mismatches around the spaces before `(active)` and `(disabled)` labels. After: `npx vitest run src/ui/components/extensions/steps/ExtensionListStep.test.tsx` passed with 5 tests, `npx prettier --check packages/cli/src/ui/components/extensions/steps/ExtensionListStep.tsx` passed, `npm run lint` passed, `npm run typecheck` passed, and `npm run build` passed. The build still reports pre-existing vscode companion curly warnings and Browserslist freshness notices, but exits successfully.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested locally; covered by CI after PR   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

Node.js v22.22.0, npm 10.9.4.

## Risk & Scope

- Main risk or tradeoff: very low; this is a layout-only change intended to preserve the same visible output.
- Not validated / out of scope: manual TUI screenshots on Windows and Linux.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5425
Fixes #5371

Related Actions runs: https://github.com/QwenLM/qwen-code/actions/runs/27854449183 and https://github.com/QwenLM/qwen-code/actions/runs/27797790330

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 保持扩展列表的可见对齐不变，但把状态列前面的间距从文本节点里的前导空格改成 Ink 布局间距。

## Why it's needed

定时 Release workflow 在 Quality Checks 里失败，因为 CI 上扩展列表 snapshot 在状态标签前少渲染了一个空格，和已提交 snapshot 不一致。使用布局间距可以避免依赖文本节点前导空格在不同渲染环境里的保留行为。

## Reviewer Test Plan

### How to verify

确认已安装扩展列表行仍然以同样的状态列对齐方式渲染，并确认扩展列表 snapshot 测试保持稳定。相关失败 run 是 https://github.com/QwenLM/qwen-code/actions/runs/27854449183。

### Evidence (Before & After)

Before: 2026-06-20 的定时 Release run 在 Workspace Tests 中失败，失败点是 `(active)` 和 `(disabled)` 标签前空格数量的 snapshot mismatch。After: `npx vitest run src/ui/components/extensions/steps/ExtensionListStep.test.tsx` 通过 5 个测试，`npx prettier --check packages/cli/src/ui/components/extensions/steps/ExtensionListStep.tsx` 通过，`npm run lint` 通过，`npm run typecheck` 通过，`npm run build` 通过。build 仍会报告既有的 vscode companion curly warning 和 Browserslist 数据提示，但命令成功退出。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested locally; covered by CI after PR   |

### Environment (optional)

Node.js v22.22.0, npm 10.9.4.

## Risk & Scope

- Main risk or tradeoff: 风险很低；这是布局层面的改动，目标是保持同样的可见输出。
- Not validated / out of scope: 未在 Windows 和 Linux 上做手动 TUI 截图验证。
- Breaking changes / migration notes: 无。

## Linked Issues

Fixes #5425
Fixes #5371

相关 Actions runs: https://github.com/QwenLM/qwen-code/actions/runs/27854449183 和 https://github.com/QwenLM/qwen-code/actions/runs/27797790330

</details>
