### PR TITLE
fix(cli): enforce temp path boundaries for at-file

### DIFF
--- a/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
@@ -12,6 +12,7 @@ import {
   FileDiscoveryService,
   StandardFileSystemService,
   COMMON_IGNORE_PATTERNS,
+  Storage,
   // DEFAULT_FILE_EXCLUDES,
 } from '@qwen-code/qwen-code-core';
 import * as os from 'node:os';
@@ -150,6 +151,80 @@ describe('handleAtCommand', () => {
     expect(result.toolDisplays).toBeDefined();
     expect(result.toolDisplays).toHaveLength(1);
     expect(result.toolDisplays![0].status).toBe(ToolCallStatus.Success);
+  });
+
+  it('should only allow actual temp directory paths outside the workspace', async () => {
+    const tempParentDir = await fsPromises.mkdtemp(
+      path.join(os.tmpdir(), 'at-command-temp-'),
+    );
+    const projectTempDir = path.join(tempParentDir, 'tmp');
+    const tempSiblingDir = `${projectTempDir}-sibling`;
+    const tempFileContent = 'allowed temp content';
+    const siblingFileContent = 'sibling secret content';
+    const tempFilePath = await createTestFile(
+      path.join(projectTempDir, 'allowed.txt'),
+      tempFileContent,
+    );
+    const siblingFilePath = await createTestFile(
+      path.join(tempSiblingDir, 'secret.txt'),
+      siblingFileContent,
+    );
+    const tempDirSpy = vi
+      .spyOn(Storage, 'getGlobalTempDir')
+      .mockReturnValue(projectTempDir);
+    const isWithinWorkspace = (candidate: string) => {
+      const absoluteCandidate = path.isAbsolute(candidate)
+        ? candidate
+        : path.resolve(testRootDir, candidate);
+      const relative = path.relative(testRootDir, absoluteCandidate);
+      return (
+        relative === '' ||
+        (!relative.startsWith('..') && !path.isAbsolute(relative))
+      );
+    };
+    mockConfig = {
+      ...mockConfig,
+      getWorkspaceContext: () => ({
+        isPathWithinWorkspace: isWithinWorkspace,
+        getDirectories: () => [testRootDir],
+      }),
+    } as unknown as Config;
+
+    try {
+      const tempResult = await handleAtCommand({
+        query: `@${tempFilePath}`,
+        config: mockConfig,
+        onDebugMessage: mockOnDebugMessage,
+        messageId: 126,
+        signal: abortController.signal,
+      });
+
+      expect(tempResult.processedQuery).toContainEqual({
+        text: tempFileContent,
+      });
+
+      mockOnDebugMessage.mockClear();
+      const siblingResult = await handleAtCommand({
+        query: `@${siblingFilePath}`,
+        config: mockConfig,
+        onDebugMessage: mockOnDebugMessage,
+        messageId: 127,
+        signal: abortController.signal,
+      });
+
+      expect(siblingResult.processedQuery).toEqual([
+        { text: `@${siblingFilePath}` },
+      ]);
+      expect(JSON.stringify(siblingResult.processedQuery)).not.toContain(
+        siblingFileContent,
+      );
+      expect(mockOnDebugMessage).toHaveBeenCalledWith(
+        `Path ${siblingFilePath} is not in the workspace and will be skipped.`,
+      );
+    } finally {
+      tempDirSpy.mockRestore();
+      await fsPromises.rm(tempParentDir, { recursive: true, force: true });
+    }
   });
 
   it('should process a valid directory path', async () => {

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -12,6 +12,7 @@ import {
   getErrorMessage,
   isNodeError,
   Storage,
+  isSubpath,
   unescapePath,
   readManyFiles,
 } from '@qwen-code/qwen-code-core';
@@ -191,7 +192,7 @@ export async function resolveAtCommandQuery({
       : path.resolve(workspaceContext.getDirectories()[0] || '', pathName);
 
     if (
-      !absolutePathName.startsWith(projectTempDir) &&
+      !isSubpath(projectTempDir, absolutePathName) &&
       !workspaceContext.isPathWithinWorkspace(pathName)
     ) {
       onDebugMessage(


### PR DESCRIPTION
## What this PR does

Fixes the `@file` temp-directory exception so the referenced path must be the temp directory itself or a real child path inside it.

Previously the check used a raw string prefix match. A sibling path such as `/tmp/qwen/tmp-other/file.txt` could pass when the allowed temp directory was `/tmp/qwen/tmp`.

## Why it's needed

`@file` paths are intentionally restricted, with a narrow exception for files created in the process temp directory. A raw `startsWith` check can confuse siblings that share the same prefix with actual children of the temp directory. This makes the temp exception broader than intended.

## Reviewer Test Plan

### How to verify

- Review the `@file` regression tests for a temp-directory sibling path that shares the same prefix.
- Confirm exact temp directory paths and real children still pass.
- Confirm sibling paths such as `tmp-other` are rejected.
- Run `npx vitest run packages/cli/src/ui/hooks/atCommandProcessor.test.ts`.
- Run `npx eslint packages/cli/src/ui/hooks/atCommandProcessor.ts packages/cli/src/ui/hooks/atCommandProcessor.test.ts`.
- Run `npx prettier --check packages/cli/src/ui/hooks/atCommandProcessor.ts packages/cli/src/ui/hooks/atCommandProcessor.test.ts`.
- Run `git diff --check`.

### Evidence (Before & After)

Before: `/tmp/qwen/tmp-other/file.txt` could be accepted as temp-scoped when `/tmp/qwen/tmp` was the allowed temp directory, because it shared the same raw string prefix. After: the path must be equal to the temp directory or inside it with a real path separator boundary.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; CI passed |
|  🐧 Linux  | ⚠️ not tested locally; CI passed |

### Environment (optional)

Local CLI hook tests, eslint, prettier, and `git diff --check` on macOS.

## Risk & Scope

- Main risk or tradeoff: path boundary logic is security-sensitive; the change is intentionally limited to the `@file` temp-directory exception.
- Not validated / out of scope: changing general `@file` path policy outside the temp-directory exception.
- Breaking changes / migration notes: sibling-prefix temp paths that were previously accepted by mistake are now rejected.

## Linked Issues

Fixes #5444

<details>
<summary>中文说明</summary>

## What this PR does

修复 `@file` 的临时目录例外：被引用的路径必须是临时目录本身，或者是真正位于该临时目录内部的子路径。

之前的检查使用裸字符串前缀匹配。如果允许的临时目录是 `/tmp/qwen/tmp`，像 `/tmp/qwen/tmp-other/file.txt` 这样的兄弟路径也可能被放行。

## Why it's needed

`@file` 路径本来是受限的，只对进程临时目录里的文件开一个很窄的例外。裸 `startsWith` 检查会把共享前缀的兄弟路径误认为临时目录子路径，让这个例外比预期更宽。

## Reviewer Test Plan

### How to verify

- 查看 `@file` 回归测试中共享临时目录前缀的兄弟路径用例。
- 确认临时目录本身和真实子路径仍然通过。
- 确认 `tmp-other` 这类兄弟路径会被拒绝。
- 运行 `npx vitest run packages/cli/src/ui/hooks/atCommandProcessor.test.ts`。
- 运行 `npx eslint packages/cli/src/ui/hooks/atCommandProcessor.ts packages/cli/src/ui/hooks/atCommandProcessor.test.ts`。
- 运行 `npx prettier --check packages/cli/src/ui/hooks/atCommandProcessor.ts packages/cli/src/ui/hooks/atCommandProcessor.test.ts`。
- 运行 `git diff --check`。

### Evidence (Before & After)

修复前：当允许的临时目录是 `/tmp/qwen/tmp` 时，`/tmp/qwen/tmp-other/file.txt` 因为共享裸字符串前缀，可能被误认为在临时目录范围内。修复后：路径必须等于临时目录，或带真实路径分隔边界地位于临时目录内部。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; CI passed |
|  🐧 Linux  | ⚠️ not tested locally; CI passed |

### Environment (optional)

在 macOS 上运行了本地 CLI hook 测试、eslint、prettier 和 `git diff --check`。

## Risk & Scope

- 主要风险或取舍：路径边界逻辑涉及安全；本改动故意只限制在 `@file` 临时目录例外。
- 未验证 / 不在范围内：修改临时目录例外之外的通用 `@file` 路径策略。
- Breaking changes / migration notes：之前被错误接受的兄弟前缀临时路径现在会被拒绝。

## Linked Issues

Fixes #5444

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
