### PR TITLE
fix(core): match provider base URL slash variants

### DIFF
--- a/packages/core/src/providers/__tests__/provider-config.test.ts
+++ b/packages/core/src/providers/__tests__/provider-config.test.ts
@@ -594,6 +594,25 @@ describe('resolveBaseUrl edge cases', () => {
       'https://api.user.com/v1',
     );
   });
+
+  it('matches BaseUrlOption trailing-slash variants', () => {
+    const config = makeConfig({
+      baseUrl: [
+        { id: 'a', label: 'A', url: 'https://a.com/v1' },
+        { id: 'b', label: 'B', url: 'https://b.com/v1' },
+        { id: 'c', label: 'C', url: 'https://c.com/v1/' },
+      ],
+    });
+    expect(resolveBaseUrlSrc(config, 'https://b.com/v1/')).toBe(
+      'https://b.com/v1',
+    );
+    expect(resolveBaseUrlSrc(config, 'https://a.com/v1///')).toBe(
+      'https://a.com/v1',
+    );
+    expect(resolveBaseUrlSrc(config, 'https://c.com/v1')).toBe(
+      'https://c.com/v1/',
+    );
+  });
 });
 
 describe('providerMatchesCredentials with function envKey (custom provider)', () => {

--- a/packages/core/src/providers/provider-config.ts
+++ b/packages/core/src/providers/provider-config.ts
@@ -303,7 +303,12 @@ export function resolveBaseUrl(
     return config.baseUrl;
   }
   if (Array.isArray(config.baseUrl)) {
-    const match = config.baseUrl.find((opt) => opt.url === selectedBaseUrl);
+    const normalizedSelectedBaseUrl =
+      normalizeBaseUrlForMatching(selectedBaseUrl);
+    const match = config.baseUrl.find(
+      (opt) =>
+        normalizeBaseUrlForMatching(opt.url) === normalizedSelectedBaseUrl,
+    );
     if (match) return match.url;
     // Defensive: an empty baseUrl array would crash `config.baseUrl[0].url`
     // and bring down the install flow. Fall back to the caller-supplied
@@ -311,6 +316,15 @@ export function resolveBaseUrl(
     return config.baseUrl[0]?.url ?? selectedBaseUrl ?? '';
   }
   return selectedBaseUrl ?? '';
+}
+
+function normalizeBaseUrlForMatching(baseUrl: string | undefined): string {
+  if (baseUrl === undefined) return '';
+  let end = baseUrl.length;
+  while (end > 0 && baseUrl.charCodeAt(end - 1) === 47) {
+    end--;
+  }
+  return end === baseUrl.length ? baseUrl : baseUrl.slice(0, end);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this PR does

Makes `resolveBaseUrl()` match configured `BaseUrlOption` URLs even when the selected URL only differs by trailing slash count.

The returned URL still comes from the provider config, so callers keep the canonical configured endpoint.

## Why it's needed

Some configured provider base URLs and selected URLs can differ only by trailing slashes. The previous exact string comparison missed those matches and fell back to the selected URL path instead of returning the canonical configured option.

## Reviewer Test Plan

### How to verify

Review the base URL normalization test. A selected URL with trailing slash variation should resolve to the matching configured option; unknown URLs should keep the existing fallback behavior.

Run:

```bash
npx vitest run packages/core/src/providers/__tests__/provider-config.test.ts packages/core/src/providers/__tests__/presets/alibaba-coding-plan.test.ts
npx eslint packages/core/src/providers/provider-config.ts packages/core/src/providers/__tests__/provider-config.test.ts
npx prettier --check packages/core/src/providers/provider-config.ts packages/core/src/providers/__tests__/provider-config.test.ts
npm run typecheck --workspace=packages/core
```

### Evidence (Before & After)

Before: a configured URL and selected URL that only differed by trailing slashes did not match.

After: trailing slash variants match the configured `BaseUrlOption`, while unrelated URLs still fall back as before.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS     | tested |
|  Windows   | covered by CI |
|  Linux     | covered by CI |

### Environment (optional)

Local Node/npm workspace tests.

## Risk & Scope

- Main risk or tradeoff: URL comparison now normalizes trailing slashes for matching, but still returns the configured canonical URL.
- Not validated / out of scope: broader URL normalization such as query strings, casing, or path segment changes.
- Breaking changes / migration notes: none expected.

## Linked Issues

Fixes #5447

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 `resolveBaseUrl()` 在 selected URL 只和配置的 `BaseUrlOption` 差 trailing slash 数量时，也能正确匹配。

返回值仍然来自 provider config，因此调用方拿到的还是规范化的配置 endpoint。

## 为什么需要

部分 provider base URL 在配置值和选中值之间可能只差末尾斜杠。旧的精确字符串比较会漏掉这种匹配，转而走 fallback，返回 selected URL 而不是配置里的 canonical option。

## Reviewer Test Plan

### How to verify

检查 base URL normalization 测试：只有 trailing slash 差异的 selected URL 应解析到配置 option；未知 URL 应保持原有 fallback 行为。

### Evidence (Before & After)

修复前：配置 URL 和 selected URL 仅 trailing slash 不同也无法匹配。

修复后：trailing slash 变体能匹配配置的 `BaseUrlOption`；无关 URL 仍按原逻辑 fallback。

### Tested on

本地跑过相关 Node/npm 测试；Windows 和 Linux 由 CI 覆盖。

## Risk & Scope

改动只规范化 trailing slash 匹配，不做 query、大小写、path segment 等更广泛的 URL normalization，也没有预期破坏性变更。

</details>
