### PR TITLE
fix(core): detect providers by hostname

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/provider/modelscope.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/modelscope.test.ts
@@ -35,22 +35,38 @@ describe('ModelScopeOpenAICompatibleProvider', () => {
   });
 
   describe('isModelScopeProvider', () => {
-    it('should return true if baseUrl includes "modelscope"', () => {
-      const config = { baseUrl: 'https://api.modelscope.cn/v1' };
-      expect(
-        ModelScopeOpenAICompatibleProvider.isModelScopeProvider(
-          config as ContentGeneratorConfig,
-        ),
-      ).toBe(true);
+    it('should return true for ModelScope hostnames', () => {
+      const configs = [
+        { baseUrl: 'https://api-inference.modelscope.cn/v1' },
+        { baseUrl: 'https://api.modelscope.cn/v1' },
+        { baseUrl: 'https://modelscope.cn/v1' },
+      ];
+
+      configs.forEach((config) => {
+        expect(
+          ModelScopeOpenAICompatibleProvider.isModelScopeProvider(
+            config as ContentGeneratorConfig,
+          ),
+        ).toBe(true);
+      });
     });
 
-    it('should return false if baseUrl does not include "modelscope"', () => {
-      const config = { baseUrl: 'https://api.openai.com/v1' };
-      expect(
-        ModelScopeOpenAICompatibleProvider.isModelScopeProvider(
-          config as ContentGeneratorConfig,
-        ),
-      ).toBe(false);
+    it('should return false for non-ModelScope hostnames', () => {
+      const configs = [
+        { baseUrl: 'https://api.openai.com/v1' },
+        { baseUrl: 'https://example.com/modelscope/v1' },
+        { baseUrl: 'https://modelscope.cn.evil.example/v1' },
+        { baseUrl: 'not a url with modelscope' },
+        { baseUrl: undefined },
+      ];
+
+      configs.forEach((config) => {
+        expect(
+          ModelScopeOpenAICompatibleProvider.isModelScopeProvider(
+            config as ContentGeneratorConfig,
+          ),
+        ).toBe(false);
+      });
     });
   });
 

--- a/packages/core/src/core/openaiContentGenerator/provider/modelscope.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/modelscope.ts
@@ -10,7 +10,16 @@ export class ModelScopeOpenAICompatibleProvider extends DefaultOpenAICompatibleP
    * Checks if the configuration is for ModelScope.
    */
   static isModelScopeProvider(config: ContentGeneratorConfig): boolean {
-    return !!config.baseUrl?.includes('modelscope');
+    const baseUrl = config.baseUrl ?? '';
+    if (!baseUrl) return false;
+    try {
+      const hostname = new URL(baseUrl).hostname.toLowerCase();
+      return (
+        hostname === 'modelscope.cn' || hostname.endsWith('.modelscope.cn')
+      );
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/packages/core/src/core/openaiContentGenerator/provider/openrouter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/openrouter.test.ts
@@ -69,6 +69,8 @@ describe('OpenRouterOpenAICompatibleProvider', () => {
         { baseUrl: 'https://api.anthropic.com/v1' },
         { baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1' },
         { baseUrl: 'https://example.com/api/v1' }, // different domain
+        { baseUrl: 'https://example.com/openrouter.ai/v1' },
+        { baseUrl: 'https://openrouter.ai.evil.example/v1' },
         { baseUrl: '' },
         { baseUrl: undefined },
       ];

--- a/packages/core/src/core/openaiContentGenerator/provider/openrouter.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/openrouter.ts
@@ -13,8 +13,16 @@ export class OpenRouterOpenAICompatibleProvider extends DefaultOpenAICompatibleP
   static isOpenRouterProvider(
     contentGeneratorConfig: ContentGeneratorConfig,
   ): boolean {
-    const baseURL = contentGeneratorConfig.baseUrl || '';
-    return baseURL.includes('openrouter.ai');
+    const baseURL = contentGeneratorConfig.baseUrl ?? '';
+    if (!baseURL) return false;
+    try {
+      const hostname = new URL(baseURL).hostname.toLowerCase();
+      return (
+        hostname === 'openrouter.ai' || hostname.endsWith('.openrouter.ai')
+      );
+    } catch {
+      return false;
+    }
   }
 
   override buildHeaders(): Record<string, string | undefined> {


### PR DESCRIPTION
## What this PR does

Tightens ModelScope and OpenRouter provider detection so it matches provider-owned hostnames instead of searching for provider strings anywhere in the full URL.

Official root hosts and subdomains still match; unrelated hosts, path-only matches, suffix spoofing, and userinfo spoofing do not.

## Why it's needed

The previous substring checks could treat URLs such as `https://example.com/modelscope/v1` or `https://openrouter.ai.evil.example/v1` as provider-owned endpoints. That can apply provider-specific behavior to a URL that only happens to contain the provider name.

## Reviewer Test Plan

### How to verify

Review the hostname helper and the provider tests. Confirm official provider hosts still take the provider-specific path, while spoofed path/suffix/userinfo URLs do not.

Run:

```bash
npx vitest run packages/core/src/core/openaiContentGenerator/provider/modelscope.test.ts packages/core/src/core/openaiContentGenerator/provider/openrouter.test.ts packages/core/src/providers/__tests__/presets/openrouter.test.ts packages/core/src/providers/__tests__/presets/modelscope.test.ts
npx eslint packages/core/src/core/openaiContentGenerator/provider/modelscope.ts packages/core/src/core/openaiContentGenerator/provider/modelscope.test.ts packages/core/src/core/openaiContentGenerator/provider/openrouter.ts packages/core/src/core/openaiContentGenerator/provider/openrouter.test.ts
npx prettier --check packages/core/src/core/openaiContentGenerator/provider/modelscope.ts packages/core/src/core/openaiContentGenerator/provider/modelscope.test.ts packages/core/src/core/openaiContentGenerator/provider/openrouter.ts packages/core/src/core/openaiContentGenerator/provider/openrouter.test.ts
npm run typecheck --workspace=packages/core
```

### Evidence (Before & After)

Before: provider detection could match `modelscope` or `openrouter.ai` inside a URL path or an attacker-controlled hostname suffix.

After: detection parses the URL and checks the hostname boundary, so only the provider host or its subdomains match.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS     | tested |
|  Windows   | covered by CI |
|  Linux     | covered by CI |

### Environment (optional)

Local Node/npm workspace tests.

## Risk & Scope

- Main risk or tradeoff: stricter detection may stop treating unofficial lookalike URLs as ModelScope/OpenRouter endpoints.
- Not validated / out of scope: changing provider behavior for unrelated providers.
- Breaking changes / migration notes: none expected for official provider endpoints.

## Linked Issues

Fixes #5449

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

收紧 ModelScope 和 OpenRouter 的 provider 检测逻辑：不再在完整 URL 字符串里做子串搜索，而是匹配 provider 自有 hostname。

官方根域名和子域名仍然匹配；无关 host、路径里的 provider 名称、后缀伪装、userinfo 伪装都不会匹配。

## 为什么需要

旧逻辑会把 `https://example.com/modelscope/v1` 或 `https://openrouter.ai.evil.example/v1` 这类 URL 误判成 provider 自有 endpoint，导致 provider-specific 行为被应用到并不属于该 provider 的 URL 上。

## Reviewer Test Plan

### How to verify

检查 hostname helper 和 provider 测试：官方 provider host 应继续走 provider-specific 路径；路径、后缀和 userinfo 伪装都应被拒绝。

### Evidence (Before & After)

修复前：URL 路径或攻击者控制的 hostname 后缀里只要包含 provider 字符串，就可能误匹配。

修复后：先解析 URL，再按 hostname 边界匹配，只允许 provider host 或其子域名。

### Tested on

本地跑过相关 Node/npm 测试；Windows 和 Linux 由 CI 覆盖。

## Risk & Scope

改动会让非官方的 lookalike URL 不再被当成 ModelScope/OpenRouter endpoint。不会改其它 provider，也没有预期破坏性变更。

</details>
