### PR TITLE
fix(extensions): fetch http marketplaces with http client

### DIFF
--- a/packages/core/src/extension/marketplace.test.ts
+++ b/packages/core/src/extension/marketplace.test.ts
@@ -10,6 +10,7 @@ import {
   loadMarketplaceConfigFromSource,
 } from './marketplace.js';
 import * as fs from 'node:fs/promises';
+import * as http from 'node:http';
 import * as https from 'node:https';
 
 // Mock dependencies
@@ -24,6 +25,10 @@ vi.mock('node:fs', () => ({
 }));
 
 vi.mock('node:https', () => ({
+  get: vi.fn(),
+}));
+
+vi.mock('node:http', () => ({
   get: vi.fn(),
 }));
 
@@ -50,6 +55,17 @@ describe('parseInstallSource', () => {
         callback(mockRes as never);
       }
       return { on: vi.fn() } as never;
+    });
+    vi.mocked(http.get).mockImplementation((_url, _options, callback) => {
+      const mockRes = {
+        statusCode: 404,
+        resume: vi.fn(),
+        on: vi.fn(),
+      };
+      if (typeof callback === 'function') {
+        callback(mockRes as never);
+      }
+      return { on: vi.fn(), setTimeout: vi.fn(), destroy: vi.fn() } as never;
     });
   });
 
@@ -343,6 +359,45 @@ describe('parseInstallSource', () => {
   });
 
   describe('loadMarketplaceConfigFromSource', () => {
+    it('fetches direct HTTP marketplace JSON with the HTTP client', async () => {
+      vi.mocked(fs.stat).mockRejectedValueOnce(new Error('ENOENT'));
+      const cfg = {
+        name: 'http-marketplace',
+        owner: { name: 'Owner' },
+        plugins: [{ name: 'p1' }],
+      };
+      vi.mocked(http.get).mockImplementation((_url, _options, callback) => {
+        const mockRes = {
+          statusCode: 200,
+          resume: vi.fn(),
+          on: vi.fn((event, handler) => {
+            if (event === 'data') {
+              handler(Buffer.from(JSON.stringify(cfg)));
+            }
+            if (event === 'end') {
+              handler();
+            }
+          }),
+        };
+        if (typeof callback === 'function') {
+          callback(mockRes as never);
+        }
+        return { on: vi.fn(), setTimeout: vi.fn(), destroy: vi.fn() } as never;
+      });
+
+      const result = await loadMarketplaceConfigFromSource(
+        'http://example.com/marketplace.json',
+      );
+
+      expect(result).toEqual(cfg);
+      expect(http.get).toHaveBeenCalledWith(
+        'http://example.com/marketplace.json',
+        { headers: { 'User-Agent': 'qwen-code' } },
+        expect.any(Function),
+      );
+      expect(https.get).not.toHaveBeenCalled();
+    });
+
     it('resolves a marketplace from a git@ SSH source', async () => {
       vi.mocked(fs.stat).mockRejectedValueOnce(new Error('ENOENT'));
       const cfg = {

--- a/packages/core/src/extension/marketplace.ts
+++ b/packages/core/src/extension/marketplace.ts
@@ -9,6 +9,7 @@ import type { ExtensionInstallMetadata } from '../config/config.js';
 import type { ClaudeMarketplaceConfig } from './claude-converter.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import * as http from 'node:http';
 import * as https from 'node:https';
 import { stat } from 'node:fs/promises';
 import { parseGitHubRepoForReleases } from './github.js';
@@ -140,6 +141,9 @@ function fetchUrl(
   url: string,
   headers: Record<string, string>,
 ): Promise<string | null> {
+  const protocol = new URL(url).protocol;
+  const client = protocol === 'http:' ? http : https;
+
   return new Promise((resolve) => {
     let settled = false;
     const done = (value: string | null) => {
@@ -155,7 +159,7 @@ function fetchUrl(
       req.destroy();
       done(null);
     }, MARKETPLACE_FETCH_TIMEOUT_MS);
-    const req = https.get(url, { headers }, (res) => {
+    const req = client.get(url, { headers }, (res) => {
       if (res.statusCode !== 200) {
         res.resume(); // drain so the socket can be freed
         done(null);
@@ -254,7 +258,7 @@ async function readLocalMarketplaceConfig(
  * - Local directory containing `.claude-plugin/marketplace.json`
  * - Local path directly to a `marketplace.json` file
  * - `owner/repo`, `https://github.com/owner/repo`, `git@github.com:owner/repo.git`
- * - Arbitrary `https://host/.../marketplace.json` returning the JSON document
+ * - Arbitrary `http(s)://host/.../marketplace.json` returning the JSON document
  *
  * Returns `null` when no marketplace config can be resolved.
  */


### PR DESCRIPTION
## What this PR does

Uses the Node HTTP client for `http://` extension marketplace sources and the HTTPS client for `https://` sources.

The existing timeout, body-size limit, JSON parsing, and null-on-error behavior stay the same.

## Why it's needed

`loadMarketplaceConfigFromSource` accepts direct `http://.../marketplace.json` URLs, but the shared fetch helper always called `https.get`. Node rejects that client/protocol mismatch before making the request, so valid local or internal HTTP marketplace sources could not load.

## Reviewer Test Plan

### How to verify

Review `fetchUrl` and the marketplace tests. The `http://` case should go through `http.get`; HTTPS and GitHub-backed sources should continue to use `https.get`.

Run:

```bash
npx vitest run packages/core/src/extension/marketplace.test.ts
npx eslint packages/core/src/extension/marketplace.ts packages/core/src/extension/marketplace.test.ts
```

### Evidence (Before & After)

Before: `http://.../marketplace.json` failed with `Protocol "http:" not supported. Expected "https:"`.

After: HTTP marketplace URLs are fetched with the HTTP client, while HTTPS marketplace URLs keep the previous HTTPS path.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS     | tested |
|  Windows   | covered by CI |
|  Linux     | covered by CI |

### Environment (optional)

Local Node/npm workspace tests.

## Risk & Scope

- Main risk or tradeoff: direct marketplace fetching now branches on URL protocol; unsupported protocols still fail through URL/client handling.
- Not validated / out of scope: adding support for protocols other than HTTP and HTTPS.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5451

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 `http://` 扩展 marketplace 源使用 Node 的 HTTP client，让 `https://` 源继续使用 HTTPS client。

原有的超时、响应体大小限制、JSON 解析和出错返回 `null` 的行为不变。

## 为什么需要

`loadMarketplaceConfigFromSource` 支持直接传入 `http://.../marketplace.json`，但共享 fetch helper 之前总是调用 `https.get`。Node 会在发请求前拒绝这种 protocol/client 不匹配，因此本地或内网 HTTP marketplace 源无法加载。

## Reviewer Test Plan

### How to verify

检查 `fetchUrl` 和 marketplace 测试：`http://` 用例应走 `http.get`，HTTPS 和 GitHub 源应继续走 `https.get`。

### Evidence (Before & After)

修复前：`http://.../marketplace.json` 会报 `Protocol "http:" not supported. Expected "https:"`。

修复后：HTTP marketplace URL 使用 HTTP client；HTTPS URL 保持原来的 HTTPS 路径。

### Tested on

本地跑过相关 Node/npm 测试；Windows 和 Linux 由 CI 覆盖。

## Risk & Scope

改动只影响直接 marketplace URL 的协议选择。不新增 HTTP/HTTPS 以外的协议支持，也没有破坏性变更。

</details>
