### PR TITLE
fix(core): enforce shell directory workspace boundary

### DIFF
--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -331,6 +331,29 @@ describe('ShellTool', () => {
       );
     });
 
+    it('should reject sibling-prefix directories outside the workspace', async () => {
+      const workspaceContext = createMockWorkspaceContext('/test/dir', [
+        '/tmp/project',
+      ]);
+      vi.mocked(workspaceContext.isPathWithinWorkspace).mockReturnValue(false);
+      (mockConfig.getWorkspaceContext as Mock).mockReturnValue(
+        workspaceContext,
+      );
+
+      expect(() =>
+        shellTool.build({
+          command: 'ls',
+          directory: '/tmp/project-other',
+          is_background: false,
+        }),
+      ).toThrow(
+        "Directory '/tmp/project-other' is not within any of the registered workspace directories.",
+      );
+      expect(workspaceContext.isPathWithinWorkspace).toHaveBeenCalledWith(
+        '/tmp/project-other',
+      );
+    });
+
     it('should throw an error for a directory within the user skills directory', async () => {
       expect(() =>
         shellTool.build({

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -4809,12 +4809,8 @@ export class ShellTool extends BaseDeclarativeTool<
         return `Explicitly running shell commands from within the user skills directory is not allowed. Please use absolute paths for command parameter instead.`;
       }
 
-      const workspaceDirs = this.config.getWorkspaceContext().getDirectories();
-      const isWithinWorkspace = workspaceDirs.some((wsDir) =>
-        params.directory!.startsWith(wsDir),
-      );
-
-      if (!isWithinWorkspace) {
+      const workspaceContext = this.config.getWorkspaceContext();
+      if (!workspaceContext.isPathWithinWorkspace(params.directory)) {
         return `Directory '${params.directory}' is not within any of the registered workspace directories.`;
       }
     }


### PR DESCRIPTION
## Summary

- use `WorkspaceContext.isPathWithinWorkspace` for shell `directory` validation
- add a regression test for sibling-prefix workspace paths such as `/tmp/project-other`

Fixes #5453

## Validation

- `npx vitest run packages/core/src/tools/shell.test.ts --testNamePattern "sibling-prefix"`
- `npx vitest run packages/core/src/tools/shell.test.ts`
- `npx eslint packages/core/src/tools/shell.ts packages/core/src/tools/shell.test.ts`
- `npx prettier --check packages/core/src/tools/shell.ts packages/core/src/tools/shell.test.ts && git diff --check`
- `npm run typecheck --workspace=packages/core`

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
