### PR TITLE
fix(cli): enforce custom theme home boundary

### DIFF
--- a/packages/cli/src/ui/themes/theme-manager.test.ts
+++ b/packages/cli/src/ui/themes/theme-manager.test.ts
@@ -240,5 +240,18 @@ describe('ThemeManager', () => {
       expect(result).toBe(false);
       expect(themeManager.getActiveTheme().name).toBe(DEFAULT_THEME.name);
     });
+
+    it('should not load a theme from a sibling path with the same home prefix', () => {
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+      vi.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify(mockTheme));
+
+      const result = themeManager.setActiveTheme(
+        '/home/user-evil/my-theme.json',
+      );
+
+      expect(result).toBe(false);
+      expect(fs.readFileSync).not.toHaveBeenCalled();
+      expect(themeManager.getActiveTheme().name).toBe(DEFAULT_THEME.name);
+    });
   });
 });

--- a/packages/cli/src/ui/themes/theme-manager.ts
+++ b/packages/cli/src/ui/themes/theme-manager.ts
@@ -44,6 +44,16 @@ export interface ThemeDisplay {
 export const DEFAULT_THEME: Theme = QwenDark;
 export const AUTO_THEME_NAME = 'auto';
 
+function isPathWithinDirectory(parent: string, child: string): boolean {
+  const relativePath = path.relative(parent, child);
+  return (
+    relativePath === '' ||
+    (!relativePath.startsWith(`..${path.sep}`) &&
+      relativePath !== '..' &&
+      !path.isAbsolute(relativePath))
+  );
+}
+
 class ThemeManager {
   private readonly availableThemes: Theme[];
   private activeTheme: Theme;
@@ -307,7 +317,7 @@ class ThemeManager {
 
       // 2. Perform security check.
       const homeDir = path.resolve(os.homedir());
-      if (!canonicalPath.startsWith(homeDir)) {
+      if (!isPathWithinDirectory(homeDir, canonicalPath)) {
         debugLogger.warn(
           `Theme file at "${themePath}" is outside your home directory. ` +
             `Only load themes from trusted sources.`,


### PR DESCRIPTION
## What this PR does

Hardens custom theme loading so a path must be inside the user home directory by path boundary, not just by raw string prefix.

## Why it's needed

A sibling directory such as `/home/user-evil` shares the string prefix `/home/user`. The previous `startsWith(homeDir)` check could treat a theme in that sibling directory as trusted. The fix uses a real path-relative boundary check after canonicalizing the path.

## Reviewer Test Plan

### How to verify

Review the new theme-manager regression test for a sibling directory that shares the home prefix. It should reject before reading the theme file. Existing inside-home theme cases should continue to load.

Run:

```bash
npm --workspace packages/cli test -- theme-manager.test.ts --coverage.enabled=false
npx prettier --check packages/cli/src/ui/themes/theme-manager.ts packages/cli/src/ui/themes/theme-manager.test.ts
npx eslint packages/cli/src/ui/themes/theme-manager.ts packages/cli/src/ui/themes/theme-manager.test.ts
npm --workspace packages/cli run typecheck
```

### Evidence (Before & After)

Before: a canonical path under a sibling like `/home/user-evil/theme.json` passed the raw prefix check.

After: only the home directory itself or paths with a real path separator boundary under home pass. Sibling prefixes and symlink escapes stay blocked.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested locally; covered by CI/path tests   |
|  🐧 Linux  |   ⚠️ not tested locally; covered by CI   |

### Environment (optional)

Local Node/npm workspace tests.

## Risk & Scope

- Main risk or tradeoff: path-boundary logic is security-sensitive; the change is intentionally limited to custom theme file trust checks.
- Not validated / out of scope: changing theme schema validation or theme discovery behavior.
- Breaking changes / migration notes: themes outside the home directory that only matched by string prefix are now rejected as intended.

## Linked Issues

Fixes #5455

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

加固自定义主题加载逻辑：主题路径必须在用户 home 目录的真实路径边界内，而不是只做原始字符串前缀判断。

## 为什么需要

像 `/home/user-evil` 这样的兄弟目录会共享 `/home/user` 字符串前缀。旧的 `startsWith(homeDir)` 检查可能把这个兄弟目录里的主题误当成可信。修复后会在路径规范化之后用真实相对路径边界判断。

## Reviewer Test Plan

### 如何验证

查看新增的 theme-manager 回归测试：共享 home 前缀的兄弟目录应在读取主题文件前被拒绝。已有的 home 内主题加载用例应继续通过。

运行：

```bash
npm --workspace packages/cli test -- theme-manager.test.ts --coverage.enabled=false
npx prettier --check packages/cli/src/ui/themes/theme-manager.ts packages/cli/src/ui/themes/theme-manager.test.ts
npx eslint packages/cli/src/ui/themes/theme-manager.ts packages/cli/src/ui/themes/theme-manager.test.ts
npm --workspace packages/cli run typecheck
```

### 改动前后证据

改动前：`/home/user-evil/theme.json` 这类规范化路径会通过裸字符串前缀检查。

改动后：只有 home 目录本身或有真实路径分隔边界的 home 子路径会通过。兄弟目录前缀和软链逃逸仍被阻止。

### 本地测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ 已测试   |
| 🪟 Windows |   ⚠️ 本地未测；由 CI/路径测试覆盖   |
|  🐧 Linux  |   ⚠️ 本地未测；由 CI 覆盖   |

### 环境

本地 Node/npm workspace 测试。

## 风险与范围

- 主要风险或取舍：路径边界逻辑涉及安全；本改动故意只限制在自定义主题文件信任检查。
- 未验证 / 不在范围内：修改主题 schema 校验或主题发现行为。
- 破坏性变更 / 迁移说明：位于 home 目录外、只是字符串前缀碰巧匹配的主题现在会按预期被拒绝。

## 关联 Issue

Fixes #5455

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>