### PR TITLE
fix(core): allow dot-prefixed plans directories

### DIFF
--- a/packages/core/src/config/storage.test.ts
+++ b/packages/core/src/config/storage.test.ts
@@ -219,6 +219,12 @@ describe('Storage – getPlansDir', () => {
     );
   });
 
+  it('allows project subdirectories whose names start with two dots', () => {
+    expect(Storage.getPlansDir(projectRoot, './..plans')).toBe(
+      path.join(projectRoot, '..plans'),
+    );
+  });
+
   it('expands tilde in configured plansDirectory values', () => {
     const projectInHome = path.join(os.homedir(), 'workspace', 'project');
     expect(

--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -23,6 +23,16 @@ const PLANS_DIR_NAME = 'plans';
 const DEBUG_DIR_NAME = 'debug';
 const ARENA_DIR_NAME = 'arena';
 
+function isResolvedPathWithinDirectory(childPath: string, parentPath: string) {
+  const relativePath = path.relative(parentPath, childPath);
+  return (
+    relativePath === '' ||
+    (!relativePath.startsWith(`..${path.sep}`) &&
+      relativePath !== '..' &&
+      !path.isAbsolute(relativePath))
+  );
+}
+
 export class Storage {
   private readonly targetDir: string;
 
@@ -233,11 +243,7 @@ export class Storage {
     const realParent = Storage.resolvePathThroughExistingAncestor(parentPath);
     const realChild = Storage.resolvePathThroughExistingAncestor(childPath);
 
-    const relativePath = path.relative(realParent, realChild);
-    return (
-      relativePath === '' ||
-      (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))
-    );
+    return isResolvedPathWithinDirectory(realChild, realParent);
   }
 
   static assertPathWithinDirectory(


### PR DESCRIPTION
## What this PR does

Allows custom plans directories whose directory names start with dots, such as `..plans` or `...triple`, while keeping real parent-directory traversal rejected.

## Why it's needed

The old boundary check treated any `path.relative(...)` result starting with `..` as an escape. That accidentally rejected legitimate project subdirectories whose names merely begin with two dots. Users could not place plans in those directories even though they are still inside the project.

## Reviewer Test Plan

### How to verify

Review the new `Storage.getPlansDir()` regression coverage. The allowed case is a real project child named with a `..` prefix; traversal cases such as `..`, `../plans`, and paths that resolve outside the project should still throw.

Run:

```bash
npm --workspace packages/core test -- storage.test.ts --coverage.enabled=false
npx eslint packages/core/src/config/storage.ts packages/core/src/config/storage.test.ts
npm --workspace packages/core run typecheck
```

### Evidence (Before & After)

Before: `getPlansDir(projectRoot, "..plans")` threw because the relative path started with `..`.

After: dot-prefixed child directory names resolve, while actual traversal still fails.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested locally; covered by path-based unit expectations   |
|  🐧 Linux  |   ⚠️ not tested locally; covered by CI   |

### Environment (optional)

Local Node/npm workspace tests.

## Risk & Scope

- Main risk or tradeoff: path-boundary logic is security-sensitive, so the fix only narrows the false-positive `..` prefix check to actual parent segments.
- Not validated / out of scope: changing where plans are stored by default.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5459

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

允许使用目录名以点开头的自定义 plans 目录，例如 `..plans` 或 `...triple`，同时继续拒绝真正的父目录穿越。

## 为什么需要

旧的边界检查把所有 `path.relative(...)` 结果以 `..` 开头的路径都当作逃逸路径，导致项目内真实存在的 `..` 前缀子目录也被误拒绝。用户即使目录仍在项目内，也无法把 plans 放在那里。

## Reviewer Test Plan

### 如何验证

查看新增的 `Storage.getPlansDir()` 回归测试。允许的用例是项目内名为 `..` 前缀的真实子目录；`..`、`../plans` 以及解析到项目外的路径仍应抛错。

运行：

```bash
npm --workspace packages/core test -- storage.test.ts --coverage.enabled=false
npx eslint packages/core/src/config/storage.ts packages/core/src/config/storage.test.ts
npm --workspace packages/core run typecheck
```

### 改动前后证据

改动前：`getPlansDir(projectRoot, "..plans")` 会因为相对路径以 `..` 开头而抛错。

改动后：以点开头的子目录名可以正常解析，真正的路径穿越仍会失败。

### 本地测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ 已测试   |
| 🪟 Windows |   ⚠️ 本地未测；由路径单测覆盖   |
|  🐧 Linux  |   ⚠️ 本地未测；由 CI 覆盖   |

### 环境

本地 Node/npm workspace 测试。

## 风险与范围

- 主要风险或取舍：路径边界逻辑涉及安全，所以本修复只把误伤的 `..` 前缀检查收窄到真实父目录片段。
- 未验证 / 不在范围内：修改 plans 默认存储位置。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #5459

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>