### PR TITLE
fix(desktop): preserve uppercase favicon URLs

### DIFF
--- a/packages/desktop/packages/shared/src/utils/__tests__/logo.test.ts
+++ b/packages/desktop/packages/shared/src/utils/__tests__/logo.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { getHighQualityLogoUrl } from '../logo.ts';
+
+describe('getHighQualityLogoUrl', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('keeps uppercase absolute favicon hrefs from HTML', async () => {
+    const iconUrl = 'HTTPS://cdn.example.com/icon.svg';
+    const fetchMock = mock(
+      (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+        const url = String(input);
+
+        if (init?.method === 'GET' && url === 'https://example.com') {
+          return Promise.resolve(
+            new Response(
+              `<html><head><link rel="icon" href="${iconUrl}" sizes="any"></head></html>`,
+              { status: 200 },
+            ),
+          );
+        }
+
+        if (init?.method === 'HEAD' && url === iconUrl) {
+          return Promise.resolve(
+            new Response(null, {
+              status: 200,
+              headers: { 'content-type': 'image/svg+xml' },
+            }),
+          );
+        }
+
+        return Promise.resolve(new Response(null, { status: 404 }));
+      },
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(getHighQualityLogoUrl('https://example.com')).resolves.toBe(
+      iconUrl,
+    );
+  });
+});

--- a/packages/desktop/packages/shared/src/utils/logo.ts
+++ b/packages/desktop/packages/shared/src/utils/logo.ts
@@ -231,7 +231,7 @@ async function parseFaviconsFromHtml(url: string): Promise<Array<{href: string, 
       } else if (href.startsWith('/')) {
         const origin = new URL(url).origin;
         href = `${origin}${href}`;
-      } else if (!href.startsWith('http')) {
+      } else if (!/^https?:\/\//i.test(href)) {
         const baseUrl = new URL(url);
         href = `${baseUrl.origin}/${href}`;
       }


### PR DESCRIPTION
## Summary

- preserve absolute favicon hrefs with uppercase HTTP(S) schemes when parsing HTML
- add a Bun regression test for uppercase favicon links returned from page `<head>` parsing

Fixes #5462

## Test Plan

- `bun test packages/shared/src/utils/__tests__/logo.test.ts`
- `bun test packages/shared/src/utils/__tests__`
- `bun run typecheck:shared`

Note: `bun run lint:shared` currently fails on unrelated existing shared lint/config issues (`import/no-internal-modules` rule missing and an existing `resource-bundle.test.ts` auth-check rule violation), not in the touched files.

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
