### PR TITLE
fix(dingtalk): skip uppercase webhook reaction targets

### DIFF
--- a/packages/channels/dingtalk/package.json
+++ b/packages/channels/dingtalk/package.json
@@ -15,7 +15,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --build"
+    "build": "tsc --build",
+    "test": "vitest run",
+    "test:ci": "vitest run"
   },
   "dependencies": {
     "@qwen-code/channel-base": "file:../base",

--- a/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('dingtalk-stream-sdk-nodejs', () => ({
+  DWClient: class {
+    disconnect = vi.fn();
+    getConfig = vi.fn(() => ({ access_token: 'token' }));
+    registerCallbackListener = vi.fn();
+    send = vi.fn();
+    connect = vi.fn();
+  },
+  TOPIC_ROBOT: 'robot',
+  EventAck: { SUCCESS: 'success' },
+}));
+
+vi.mock('@qwen-code/channel-base', () => ({
+  ChannelBase: class {
+    protected config: Record<string, unknown>;
+    protected name: string;
+
+    constructor(
+      name: string,
+      config: Record<string, unknown>,
+      _bridge: unknown,
+    ) {
+      this.name = name;
+      this.config = config;
+    }
+  },
+}));
+
+const { DingtalkChannel } = await import('./DingtalkAdapter.js');
+
+function createChannel(): DingtalkChannel {
+  return new DingtalkChannel(
+    'test-dingtalk',
+    {
+      type: 'dingtalk',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      senderPolicy: 'open',
+      allowedUsers: [],
+      sessionScope: 'user',
+      cwd: '/tmp',
+      groupPolicy: 'open',
+      groups: {},
+    },
+    {} as never,
+  );
+}
+
+function getPromptHook(
+  channel: DingtalkChannel,
+  hook: 'onPromptStart' | 'onPromptEnd',
+): (chatId: string, sessionId: string, messageId?: string) => void {
+  const fn = (channel as unknown as Record<string, unknown>)[hook] as (
+    chatId: string,
+    sessionId: string,
+    messageId?: string,
+  ) => void;
+  return fn.bind(channel);
+}
+
+describe('DingtalkChannel prompt reactions', () => {
+  it('skips uppercase webhook URLs when starting a prompt', () => {
+    const channel = createChannel();
+    const attachReaction = vi.fn().mockResolvedValue(undefined);
+    (
+      channel as unknown as { attachReaction: typeof attachReaction }
+    ).attachReaction = attachReaction;
+
+    getPromptHook(channel, 'onPromptStart')(
+      'HTTPS://oapi.dingtalk.com/robot/send?access_token=token',
+      'session-1',
+      'message-1',
+    );
+
+    expect(attachReaction).not.toHaveBeenCalled();
+  });
+
+  it('still attaches reactions for conversation IDs', () => {
+    const channel = createChannel();
+    const attachReaction = vi.fn().mockResolvedValue(undefined);
+    (
+      channel as unknown as { attachReaction: typeof attachReaction }
+    ).attachReaction = attachReaction;
+
+    getPromptHook(channel, 'onPromptStart')(
+      'cid-123',
+      'session-1',
+      'message-1',
+    );
+
+    expect(attachReaction).toHaveBeenCalledWith('message-1', 'cid-123');
+  });
+
+  it('skips uppercase webhook URLs when ending a prompt', () => {
+    const channel = createChannel();
+    const recallReaction = vi.fn().mockResolvedValue(undefined);
+    (
+      channel as unknown as { recallReaction: typeof recallReaction }
+    ).recallReaction = recallReaction;
+
+    getPromptHook(channel, 'onPromptEnd')(
+      'HTTPS://oapi.dingtalk.com/robot/send?access_token=token',
+      'session-1',
+      'message-1',
+    );
+
+    expect(recallReaction).not.toHaveBeenCalled();
+  });
+});

--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -244,7 +244,7 @@ export class DingtalkChannel extends ChannelBase {
    * conversation ID — skip the webhook-URL fallback case.
    */
   private isConversationId(chatId: string): boolean {
-    return !!chatId && !chatId.startsWith('http');
+    return !!chatId && !/^https?:\/\//i.test(chatId);
   }
 
   protected override onPromptStart(


### PR DESCRIPTION
## What this PR does

- Treats uppercase `HTTP://` and `HTTPS://` DingTalk webhook URLs as webhook fallback targets instead of conversation IDs.
- Adds prompt reaction regression tests for uppercase webhook handling on both prompt start and prompt end.
- Adds DingTalk package `test` and `test:ci` scripts so the adapter tests are included in the package test workflow.

## Why it's needed

The DingTalk adapter skips prompt reactions for webhook fallback targets, but the old `startsWith('http')` check only handled lowercase schemes. An uppercase webhook URL could be misclassified as a conversation ID and then used as `openConversationId` in DingTalk emotion API calls.

## Reviewer Test Plan

### How to verify

- Confirm that `onPromptStart` and `onPromptEnd` skip uppercase webhook URLs such as `HTTPS://oapi.dingtalk.com/robot/send?...`.
- Confirm that normal DingTalk conversation IDs still send reactions.
- Run `npm --workspace packages/channels/dingtalk run test`.
- Run `npm --workspace packages/channels/dingtalk run test:ci`.
- Run `npm --workspace packages/channels/dingtalk run build`.
- Run `npx prettier --check packages/channels/dingtalk/package.json packages/channels/dingtalk/src/DingtalkAdapter.ts packages/channels/dingtalk/src/DingtalkAdapter.test.ts`.
- Run `npx eslint packages/channels/dingtalk/src/DingtalkAdapter.ts packages/channels/dingtalk/src/DingtalkAdapter.test.ts`.

### Evidence (Before & After)

Before: `onPromptStart('HTTPS://...')` and `onPromptEnd('HTTPS://...')` could send DingTalk emotion `reply`/`recall` requests with the webhook URL incorrectly placed in `openConversationId`. After: uppercase webhook URLs are detected as webhook targets and skipped; real conversation IDs still send reactions. The new tests are revert-proof because the uppercase webhook cases fail against the old lowercase-only check.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; CI passed |
|  🐧 Linux  | ⚠️ not tested locally; CI passed |

### Environment (optional)

Local DingTalk package test/build/lint/prettier checks on macOS.

## Risk & Scope

- Main risk or tradeoff: the check now only skips real `http(s)://` webhook URLs, so a literal conversation ID beginning with `http` but not a URL would no longer be skipped.
- Not validated / out of scope: live DingTalk API calls against a real bot; the regression is covered at the adapter boundary.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5465

<details>
<summary>中文说明</summary>

## What this PR does

- 将大写 `HTTP://` 和 `HTTPS://` DingTalk webhook URL 识别为 webhook fallback 目标，而不是会话 ID。
- 为 prompt start 和 prompt end 两条路径增加大写 webhook 的 reaction 回归测试。
- 给 DingTalk package 增加 `test` 和 `test:ci` 脚本，让 adapter 测试进入 package 测试流程。

## Why it's needed

DingTalk adapter 会跳过 webhook fallback 目标的 prompt reaction，但旧的 `startsWith('http')` 只覆盖小写协议。大写 webhook URL 可能被误判成会话 ID，然后作为 `openConversationId` 传给 DingTalk emotion API。

## Reviewer Test Plan

### How to verify

- 确认 `onPromptStart` 和 `onPromptEnd` 会跳过 `HTTPS://oapi.dingtalk.com/robot/send?...` 这类大写 webhook URL。
- 确认普通 DingTalk conversation ID 仍然会发送 reaction。
- 运行 `npm --workspace packages/channels/dingtalk run test`。
- 运行 `npm --workspace packages/channels/dingtalk run test:ci`。
- 运行 `npm --workspace packages/channels/dingtalk run build`。
- 运行上面英文部分列出的 prettier 和 eslint 命令。

### Evidence (Before & After)

修复前：`onPromptStart('HTTPS://...')` 和 `onPromptEnd('HTTPS://...')` 可能发出 DingTalk emotion `reply`/`recall` 请求，并把 webhook URL 错误放进 `openConversationId`。修复后：大写 webhook URL 会被识别为 webhook 目标并跳过；真实 conversation ID 仍然会发送 reaction。新增测试是 revert-proof 的，因为大写 webhook 用例在旧的小写限定检查上会失败。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; CI passed |
|  🐧 Linux  | ⚠️ not tested locally; CI passed |

### Environment (optional)

在 macOS 上运行了 DingTalk package 的 test/build/lint/prettier 检查。

## Risk & Scope

- 主要风险或取舍：现在只会跳过真正的 `http(s)://` webhook URL，所以字面以 `http` 开头但不是 URL 的 conversation ID 不再被跳过。
- 未验证 / 不在范围内：没有对真实 bot 做 live DingTalk API 调用；回归已在 adapter 边界覆盖。
- Breaking changes / migration notes：无。

## Linked Issues

Fixes #5465

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
