### PR TITLE
fix(desktop): accept uppercase icon URL schemes

### DIFF
--- a/packages/desktop/apps/electron/src/renderer/hooks/useWorkspaceIcon.ts
+++ b/packages/desktop/apps/electron/src/renderer/hooks/useWorkspaceIcon.ts
@@ -8,8 +8,9 @@
  * Used by settings pages that display workspace icons.
  */
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import type { Workspace } from '../../shared/types'
+import { isIconUrl } from '@craft-agent/shared/utils/icon-constants'
 
 // Module-level cache to avoid redundant fetches across component instances
 // Key: workspaceId, Value: { dataUrl, sourceUrl }
@@ -26,83 +27,86 @@ const iconCache = new Map<string, { dataUrl: string; sourceUrl: string }>()
  * @returns Data URL or remote URL for the icon, or undefined
  */
 export function useWorkspaceIcon(workspace: Workspace | undefined): string | undefined {
+  const workspaceId = workspace?.id
+  const workspaceIconUrl = workspace?.iconUrl
+
   const [iconUrl, setIconUrl] = useState<string | undefined>(() => {
-    if (!workspace?.iconUrl) return undefined
+    if (!workspaceId || !workspaceIconUrl) return undefined
 
     // Remote URLs can be used directly
-    if (workspace.iconUrl.startsWith('http://') || workspace.iconUrl.startsWith('https://')) {
-      return workspace.iconUrl
+    if (isIconUrl(workspaceIconUrl)) {
+      return workspaceIconUrl
     }
 
     // Check cache for file:// URLs
-    const cached = iconCache.get(workspace.id)
-    if (cached && cached.sourceUrl === workspace.iconUrl) {
+    const cached = iconCache.get(workspaceId)
+    if (cached && cached.sourceUrl === workspaceIconUrl) {
       return cached.dataUrl
     }
 
     return undefined
   })
 
-  // Track the workspace to detect changes
-  const workspaceRef = useRef(workspace)
-
   useEffect(() => {
-    if (!workspace?.iconUrl) {
+    if (!workspaceId || !workspaceIconUrl) {
       setIconUrl(undefined)
       return
     }
 
     // Remote URLs - use directly
-    if (workspace.iconUrl.startsWith('http://') || workspace.iconUrl.startsWith('https://')) {
-      setIconUrl(workspace.iconUrl)
+    if (isIconUrl(workspaceIconUrl)) {
+      setIconUrl(workspaceIconUrl)
       return
     }
 
     // Not a file:// URL - skip
-    if (!workspace.iconUrl.startsWith('file://')) {
+    if (!workspaceIconUrl.startsWith('file://')) {
       setIconUrl(undefined)
       return
     }
 
     // Check if already cached with same source URL
-    const cached = iconCache.get(workspace.id)
-    if (cached && cached.sourceUrl === workspace.iconUrl) {
+    const cached = iconCache.get(workspaceId)
+    if (cached && cached.sourceUrl === workspaceIconUrl) {
       setIconUrl(cached.dataUrl)
       return
     }
 
     // Extract icon filename from file:// URL
     // e.g., "file:///path/to/icon.png?t=123" -> "icon.png"
-    const urlWithoutQuery = workspace.iconUrl.split('?')[0]
+    const urlWithoutQuery = workspaceIconUrl.split('?')[0]
     const iconFilename = urlWithoutQuery.split('/').pop()
     if (!iconFilename) {
       setIconUrl(undefined)
       return
     }
+    const id = workspaceId
+    const sourceUrl = workspaceIconUrl
+    const filename = iconFilename
 
     // Fetch via IPC and convert to data URL
     let cancelled = false
 
     async function fetchIcon() {
       try {
-        const result = await window.electronAPI.readWorkspaceImage(workspace!.id, iconFilename!)
+        const result = await window.electronAPI.readWorkspaceImage(id, filename)
         if (cancelled) return
 
         if (result) {
           // readWorkspaceImage returns raw SVG for .svg files, data URL for others
           let dataUrl = result
-          if (iconFilename!.endsWith('.svg')) {
+          if (filename.endsWith('.svg')) {
             dataUrl = `data:image/svg+xml;base64,${btoa(result)}`
           }
 
           // Cache the result
-          iconCache.set(workspace!.id, { dataUrl, sourceUrl: workspace!.iconUrl! })
+          iconCache.set(id, { dataUrl, sourceUrl })
           setIconUrl(dataUrl)
         } else {
           setIconUrl(undefined)
         }
       } catch (error) {
-        console.error(`Failed to load icon for workspace ${workspace!.id}:`, error)
+        console.error(`Failed to load icon for workspace ${id}:`, error)
         if (!cancelled) {
           setIconUrl(undefined)
         }
@@ -114,7 +118,7 @@ export function useWorkspaceIcon(workspace: Workspace | undefined): string | und
     return () => {
       cancelled = true
     }
-  }, [workspace?.id, workspace?.iconUrl])
+  }, [workspaceId, workspaceIconUrl])
 
   return iconUrl
 }
@@ -133,7 +137,7 @@ export function useWorkspaceIcons(workspaces: Workspace[]): Map<string, string> 
       if (!ws.iconUrl) continue
 
       // Remote URLs
-      if (ws.iconUrl.startsWith('http://') || ws.iconUrl.startsWith('https://')) {
+      if (isIconUrl(ws.iconUrl)) {
         map.set(ws.id, ws.iconUrl)
         continue
       }
@@ -157,7 +161,7 @@ export function useWorkspaceIcons(workspaces: Workspace[]): Map<string, string> 
         if (!workspace.iconUrl) continue
 
         // Remote URLs - use directly
-        if (workspace.iconUrl.startsWith('http://') || workspace.iconUrl.startsWith('https://')) {
+        if (isIconUrl(workspace.iconUrl)) {
           newMap.set(workspace.id, workspace.iconUrl)
           continue
         }

--- a/packages/desktop/apps/electron/src/renderer/lib/__tests__/icon-cache.test.ts
+++ b/packages/desktop/apps/electron/src/renderer/lib/__tests__/icon-cache.test.ts
@@ -102,6 +102,46 @@ describe('icon-cache null handling', () => {
   })
 })
 
+describe('remote icon URLs', () => {
+  it('returns source icon URLs with uppercase schemes directly', async () => {
+    const { clearIconCaches, loadSourceIcon } = await import('../icon-cache')
+    clearIconCaches()
+
+    const icon = 'HTTPS://cdn.example.com/source.svg'
+
+    await expect(
+      loadSourceIcon({
+        workspaceId: 'workspace-id',
+        config: {
+          slug: 'source',
+          name: 'Source',
+          type: 'api',
+          icon,
+        },
+      }),
+    ).resolves.toBe(icon)
+    expect(mockReadWorkspaceImage).not.toHaveBeenCalled()
+  })
+
+  it('returns skill icon URLs with uppercase schemes directly', async () => {
+    const { clearIconCaches, loadSkillIcon } = await import('../icon-cache')
+    clearIconCaches()
+
+    const icon = 'HTTP://cdn.example.com/skill.svg'
+
+    await expect(
+      loadSkillIcon(
+        {
+          slug: 'skill',
+          metadata: { icon },
+        },
+        'workspace-id',
+      ),
+    ).resolves.toBe(icon)
+    expect(mockReadWorkspaceImage).not.toHaveBeenCalled()
+  })
+})
+
 // ============================================================================
 // Pure Function Tests for Null Guards
 // ============================================================================

--- a/packages/desktop/apps/electron/src/renderer/lib/icon-cache.ts
+++ b/packages/desktop/apps/electron/src/renderer/lib/icon-cache.ts
@@ -20,7 +20,7 @@
  */
 
 import { useState, useEffect, useMemo } from 'react'
-import { isEmoji } from '@craft-agent/shared/utils/icon-constants'
+import { isEmoji, isIconUrl } from '@craft-agent/shared/utils/icon-constants'
 import type { ResolvedEntityIcon } from '@craft-agent/shared/icons'
 
 // ============================================================================
@@ -201,7 +201,7 @@ export async function loadSourceIcon(
 
   // Priority 3: URL in config.icon - return URL directly
   // Config URL takes precedence over auto-discovered local files
-  if (icon && (icon.startsWith('http://') || icon.startsWith('https://'))) {
+  if (icon && isIconUrl(icon)) {
     sourceIconCache.set(cacheKey, icon)
     return icon
   }
@@ -320,7 +320,7 @@ export async function loadSkillIcon(
   }
 
   // Priority 2: URL in metadata - return URL directly
-  if (iconValue && (iconValue.startsWith('http://') || iconValue.startsWith('https://'))) {
+  if (iconValue && isIconUrl(iconValue)) {
     skillIconCache.set(cacheKey, iconValue)
     return iconValue
   }
@@ -538,7 +538,7 @@ export function useEntityIcon(opts: UseEntityIconOptions): ResolvedEntityIcon {
     // Guard against non-string values (can happen with malformed config data)
     if (!iconValue || typeof iconValue !== 'string') return null
     if (isEmoji(iconValue)) return { type: 'emoji' as const, value: iconValue }
-    if (iconValue.startsWith('http://') || iconValue.startsWith('https://')) {
+    if (isIconUrl(iconValue)) {
       return { type: 'url' as const, value: iconValue }
     }
     return null

--- a/packages/desktop/apps/electron/src/renderer/pages/SourceInfoPage.tsx
+++ b/packages/desktop/apps/electron/src/renderer/pages/SourceInfoPage.tsx
@@ -29,6 +29,7 @@ import {
 } from '@/components/info'
 import type { LoadedSource, McpToolWithPermission } from '../../shared/types'
 import type { PermissionsConfigFile } from '@craft-agent/shared/agent/modes'
+import { isIconUrl } from '@craft-agent/shared/utils/icon-constants'
 
 interface SourceInfoPageProps {
   sourceSlug: string
@@ -318,7 +319,7 @@ export default function SourceInfoPage({ sourceSlug, workspaceId, onDelete }: So
   const handleOpenUrl = useCallback(async () => {
     if (!source || !sourceUrl) return
     if (window.electronAPI) {
-      if (sourceUrl.startsWith('http://') || sourceUrl.startsWith('https://')) {
+      if (isIconUrl(sourceUrl)) {
         await window.electronAPI.openUrl(sourceUrl)
       } else {
         await window.electronAPI.showInFolder(sourceUrl)

--- a/packages/desktop/packages/shared/src/config/__tests__/workspace-icon-url.test.ts
+++ b/packages/desktop/packages/shared/src/config/__tests__/workspace-icon-url.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'bun:test'
+import { mkdirSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { pathToFileURL } from 'url'
+
+const STORAGE_MODULE_PATH = pathToFileURL(join(import.meta.dir, '..', 'storage.ts')).href
+
+function setupConfigDir(iconUrl: string) {
+  const configDir = join(tmpdir(), `qwen-workspace-icon-${crypto.randomUUID()}`)
+  const workspaceRoot = join(configDir, 'workspace')
+  mkdirSync(workspaceRoot, { recursive: true })
+  writeFileSync(join(workspaceRoot, 'icon.svg'), '<svg />', 'utf-8')
+  writeFileSync(
+    join(configDir, 'config-defaults.json'),
+    JSON.stringify({
+      version: 'test',
+      description: 'test defaults',
+      defaults: {
+        notificationsEnabled: true,
+        colorTheme: 'default',
+        autoCapitalisation: true,
+        sendMessageKey: 'enter',
+        spellCheck: false,
+        keepAwakeWhileRunning: false,
+        richToolDescriptions: true,
+      },
+      workspaceDefaults: {
+        permissionMode: 'safe',
+        cyclablePermissionModes: ['safe', 'allow-all'],
+        localMcpServers: { enabled: true },
+      },
+    }),
+    'utf-8',
+  )
+  writeFileSync(
+    join(configDir, 'config.json'),
+    JSON.stringify({
+      workspaces: [
+        {
+          id: 'ws-a',
+          name: 'A',
+          slug: 'a',
+          rootPath: workspaceRoot,
+          iconUrl,
+          createdAt: 1,
+        },
+      ],
+      activeWorkspaceId: 'ws-a',
+      activeSessionId: null,
+    }),
+    'utf-8',
+  )
+  return configDir
+}
+
+function readWorkspaceIconUrl(configDir: string): string {
+  const run = Bun.spawnSync([
+    process.execPath,
+    '--eval',
+    `import { getWorkspaces } from '${STORAGE_MODULE_PATH}'; console.log(getWorkspaces()[0].iconUrl);`,
+  ], {
+    env: { ...process.env, CRAFT_CONFIG_DIR: configDir },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  if (run.exitCode !== 0) {
+    throw new Error(`subprocess failed (exit ${run.exitCode})\nstdout:\n${run.stdout.toString()}\nstderr:\n${run.stderr.toString()}`)
+  }
+
+  return run.stdout.toString().trim()
+}
+
+describe('workspace icon URLs', () => {
+  it('preserves uppercase remote icon URL schemes instead of falling back to local icons', () => {
+    const iconUrl = 'HTTPS://cdn.example.com/workspace.svg'
+    const configDir = setupConfigDir(iconUrl)
+
+    expect(readWorkspaceIconUrl(configDir)).toBe(iconUrl)
+  })
+})

--- a/packages/desktop/packages/shared/src/config/storage.ts
+++ b/packages/desktop/packages/shared/src/config/storage.ts
@@ -14,7 +14,7 @@ import {
   createWorkspaceAtPath,
   isValidWorkspace,
 } from '../workspaces/storage.ts';
-import { findIconFile } from '../utils/icon.ts';
+import { findIconFile, isIconUrl } from '../utils/icon.ts';
 import { extractWorkspaceSlugFromPath } from '../utils/workspace-slug.ts';
 import { initializeDocs } from '../docs/index.ts';
 import { expandPath, toPortablePath, getBundledAssetsDir } from '../utils/paths.ts';
@@ -869,7 +869,7 @@ export function getWorkspaces(): Workspace[] {
     // If workspace has a stored iconUrl that's a remote URL, use it
     // Otherwise check for local icon file
     let iconUrl = w.iconUrl;
-    if (!iconUrl || (!iconUrl.startsWith('http://') && !iconUrl.startsWith('https://'))) {
+    if (!iconUrl || !isIconUrl(iconUrl)) {
       const localIcon = findWorkspaceIcon(w.rootPath);
       if (localIcon) {
         // Convert absolute path to file:// URL for Electron renderer

--- a/packages/desktop/packages/shared/src/utils/__tests__/icon-constants.test.ts
+++ b/packages/desktop/packages/shared/src/utils/__tests__/icon-constants.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'bun:test'
+
+import { isIconUrl } from '../icon-constants.ts'
+import { validateIconValue } from '../icon.ts'
+
+describe('icon URL detection', () => {
+  it('treats http and https schemes as case-insensitive', () => {
+    expect(isIconUrl('HTTP://cdn.example.com/icon.svg')).toBe(true)
+    expect(isIconUrl('HTTPS://cdn.example.com/icon.svg')).toBe(true)
+    expect(validateIconValue('HTTPS://cdn.example.com/icon.svg')).toBe(
+      'HTTPS://cdn.example.com/icon.svg',
+    )
+  })
+
+  it('rejects non-http icon URLs', () => {
+    expect(isIconUrl('ftp://cdn.example.com/icon.svg')).toBe(false)
+    expect(isIconUrl('data:image/svg+xml;base64,abc')).toBe(false)
+  })
+})

--- a/packages/desktop/packages/shared/src/utils/icon-constants.ts
+++ b/packages/desktop/packages/shared/src/utils/icon-constants.ts
@@ -42,7 +42,7 @@ export function isEmoji(str: string | undefined): boolean {
  * Check if a string is a valid icon URL (http or https).
  */
 export function isIconUrl(str: string): boolean {
-  return str.startsWith('http://') || str.startsWith('https://');
+  return /^https?:\/\//i.test(str);
 }
 
 /**


### PR DESCRIPTION
## What this PR does

- Makes desktop icon URL detection treat `http://` and `https://` schemes case-insensitively.
- Reuses the shared icon URL predicate for workspace icon fallback resolution, source/skill/status icon rendering, and source URL opening.
- Adds regression coverage for uppercase icon URL schemes and workspace icon fallback behavior.

## Why it's needed

Desktop icon handling currently checks for lowercase `http`/`https` schemes in several places. URLs such as `HTTPS://example.com/icon.png` are valid, but they can be treated as non-URL icon values and fall back incorrectly. Centralizing the check also keeps the desktop call sites consistent.

## Reviewer Test Plan

### How to verify

- Confirm that uppercase `HTTP://` and `HTTPS://` icon URLs are accepted by the shared predicate and by workspace icon fallback logic.
- Confirm that non-URL values such as emoji are still handled by the existing fallback paths.
- Run `bun test packages/desktop/packages/shared/src/utils/__tests__/icon-constants.test.ts packages/desktop/packages/shared/src/config/__tests__/workspace-icon-url.test.ts packages/desktop/apps/electron/src/renderer/lib/__tests__/icon-cache.test.ts`.
- Run `bun run typecheck:shared`.
- Run `npx prettier --check packages/desktop/packages/shared/src/utils/icon-constants.ts packages/desktop/packages/shared/src/utils/__tests__/icon-constants.test.ts packages/desktop/packages/shared/src/config/storage.ts packages/desktop/packages/shared/src/config/__tests__/workspace-icon-url.test.ts packages/desktop/apps/electron/src/renderer/hooks/useWorkspaceIcon.ts packages/desktop/apps/electron/src/renderer/lib/icon-cache.ts packages/desktop/apps/electron/src/renderer/lib/__tests__/icon-cache.test.ts packages/desktop/apps/electron/src/renderer/pages/SourceInfoPage.tsx`.
- Run `bun x eslint src/renderer/hooks/useWorkspaceIcon.ts src/renderer/lib/icon-cache.ts src/renderer/lib/__tests__/icon-cache.test.ts src/renderer/pages/SourceInfoPage.tsx` from `packages/desktop/apps/electron`.
- Run `bun x eslint src/utils/icon-constants.ts src/utils/__tests__/icon-constants.test.ts src/config/storage.ts src/config/__tests__/workspace-icon-url.test.ts` from `packages/desktop/packages/shared`.
- Run `git diff --check`.

### Evidence (Before & After)

Before: uppercase HTTP(S) icon URLs were not consistently recognized by lowercase-only `startsWith` checks and could fall through to non-URL icon handling. After: the shared predicate uses case-insensitive scheme matching, and the regression tests cover uppercase URL schemes in the shared predicate, workspace icon fallback, and icon cache paths.

Known local validation note: `bun run typecheck:electron` still fails on pre-existing `auto-update.ts` and `settings-default-thinking.test.ts` type errors unrelated to this PR.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; CI passed |
|  🐧 Linux  | ⚠️ not tested locally; CI passed |

### Environment (optional)

Local package tests, typecheck, prettier, eslint, and `git diff --check` on macOS.

## Risk & Scope

- Main risk or tradeoff: `isIconUrl` is now shared across more desktop URL-handling paths, so future icon-specific behavior should avoid making the predicate narrower than generic HTTP(S) icon/source URL detection needs.
- Not validated / out of scope: manually opening the desktop UI on Windows/Linux; those platforms are covered by CI only.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5469

<details>
<summary>中文说明</summary>

## What this PR does

- 让 desktop 的图标 URL 判断对 `http://` 和 `https://` 协议大小写不敏感。
- 在 workspace 图标 fallback、source/skill/status 图标渲染、source URL 打开逻辑里复用同一个共享判断函数。
- 增加大写图标 URL 协议和 workspace 图标 fallback 行为的回归测试。

## Why it's needed

desktop 里有多处只检查小写 `http`/`https` 协议。`HTTPS://example.com/icon.png` 这类 URL 是合法的，但之前可能被当成非 URL 图标值处理并错误 fallback。把判断集中到共享函数里，也能让 desktop 相关调用点保持一致。

## Reviewer Test Plan

### How to verify

- 确认大写 `HTTP://` 和 `HTTPS://` 图标 URL 会被共享判断函数和 workspace 图标 fallback 逻辑接受。
- 确认 emoji 等非 URL 值仍然走既有 fallback 路径。
- 运行 `bun test packages/desktop/packages/shared/src/utils/__tests__/icon-constants.test.ts packages/desktop/packages/shared/src/config/__tests__/workspace-icon-url.test.ts packages/desktop/apps/electron/src/renderer/lib/__tests__/icon-cache.test.ts`。
- 运行 `bun run typecheck:shared`。
- 运行上面英文部分列出的 prettier、eslint 和 `git diff --check` 命令。

### Evidence (Before & After)

修复前：大写 HTTP(S) 图标 URL 不能被小写限定的 `startsWith` 检查稳定识别，可能落到非 URL 图标处理逻辑。修复后：共享判断函数使用大小写不敏感的协议匹配，回归测试覆盖了共享判断函数、workspace 图标 fallback 和 icon cache 路径里的大写 URL 协议。

本地验证说明：`bun run typecheck:electron` 仍会因为既有的 `auto-update.ts` 和 `settings-default-thinking.test.ts` 类型错误失败，和这个 PR 无关。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; CI passed |
|  🐧 Linux  | ⚠️ not tested locally; CI passed |

### Environment (optional)

在 macOS 上运行了本地 package tests、typecheck、prettier、eslint 和 `git diff --check`。

## Risk & Scope

- 主要风险或取舍：`isIconUrl` 现在被更多 desktop URL 处理路径复用，后续如果增加图标专属校验，需要避免把它收窄到影响通用 HTTP(S) 图标/source URL 判断。
- 未验证 / 不在范围内：没有在 Windows/Linux 上手动打开 desktop UI；这些平台仅由 CI 覆盖。
- Breaking changes / migration notes：无。

## Linked Issues

Fixes #5469

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
