### PR TITLE
fix(cli): reject partial session size values

### DIFF
--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -15,6 +15,7 @@ import { trace, type Span } from '@opentelemetry/api';
 import {
   createServeApp,
   detectFromLoopback,
+  listWorkspaceSessionsForResponse,
   PromptDeadlineExceededError,
   resolvePromptDeadlineMs,
 } from './server.js';
@@ -1726,9 +1727,13 @@ describe('createServeApp', () => {
     });
 
     it('does not mount the UI when serveWebShell is false', async () => {
-      const app = createServeApp({ ...baseOpts, serveWebShell: false }, undefined, {
-        webShellDir,
-      });
+      const app = createServeApp(
+        { ...baseOpts, serveWebShell: false },
+        undefined,
+        {
+          webShellDir,
+        },
+      );
       const res = await request(app)
         .get('/')
         .set('Host', host)
@@ -1771,7 +1776,12 @@ describe('createServeApp', () => {
       // bearerAuth (401), not receive the shell. Without the /health guard the
       // pre-auth fallback would return index.html instead.
       const app = createServeApp(
-        { ...baseOpts, hostname: '0.0.0.0', token: 'secret', requireAuth: true },
+        {
+          ...baseOpts,
+          hostname: '0.0.0.0',
+          token: 'secret',
+          requireAuth: true,
+        },
         undefined,
         { webShellDir },
       );
@@ -5070,6 +5080,21 @@ describe('createServeApp', () => {
       await fsp.utimes(filePath, input.mtime, input.mtime);
     }
 
+    async function writeStoredSessions(count: number): Promise<void> {
+      for (let i = 0; i < count; i++) {
+        const timestamp = new Date(
+          Date.UTC(2026, 4, 17, 12, i, 0),
+        ).toISOString();
+        await writeStoredSession({
+          sessionId: `550e8400-e29b-41d4-a716-44665544${String(i).padStart(4, '0')}`,
+          cwd: WS_BOUND,
+          timestamp,
+          prompt: `prompt ${i}`,
+          mtime: new Date(timestamp),
+        });
+      }
+    }
+
     it('returns the list returned by the bridge', async () => {
       // #3803 §02 (commit 0c6e963cd): the route now rejects
       // cross-workspace queries with 400 workspace_mismatch (so
@@ -5457,6 +5482,65 @@ describe('createServeApp', () => {
         .set('Host', `127.0.0.1:${baseOpts.port}`);
       expect(res.status).toBe(200);
       expect(res.body.sessions).toHaveLength(1);
+    });
+
+    it('ignores malformed size query values', async () => {
+      await writeStoredSessions(3);
+      const bridge = fakeBridge();
+      const app = createServeApp(
+        { ...baseOpts, workspace: WS_BOUND },
+        undefined,
+        { bridge, boundWorkspace: WS_BOUND },
+      );
+      for (const malformedSize of ['1abc', '1.5', '1e2', '0x10']) {
+        const res = await request(app)
+          .get(
+            `/workspace/${encodeURIComponent(WS_BOUND)}/sessions?size=${malformedSize}`,
+          )
+          .set('Host', `127.0.0.1:${baseOpts.port}`);
+        expect(res.status).toBe(200);
+        expect(res.body.sessions).toHaveLength(3);
+        expect(res.body.nextCursor).toBeUndefined();
+      }
+    });
+
+    it('clamps unsafe finite HTTP size values to the max page size', async () => {
+      await writeStoredSessions(21);
+      const bridge = fakeBridge();
+      const app = createServeApp(
+        { ...baseOpts, workspace: WS_BOUND },
+        undefined,
+        { bridge, boundWorkspace: WS_BOUND },
+      );
+      const res = await request(app)
+        .get(
+          `/workspace/${encodeURIComponent(WS_BOUND)}/sessions?size=9007199254740992`,
+        )
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.sessions).toHaveLength(21);
+      expect(res.body.nextCursor).toBeUndefined();
+    });
+
+    it('uses the default page size for invalid non-HTTP size values', async () => {
+      for (const invalidSize of [
+        1.5,
+        Number.MAX_SAFE_INTEGER + 1,
+        Number.POSITIVE_INFINITY,
+      ]) {
+        await fsp.rm(runtimeDir, { recursive: true, force: true });
+        await fsp.mkdir(runtimeDir, { recursive: true });
+        await writeStoredSessions(21);
+        const result = await listWorkspaceSessionsForResponse(
+          fakeBridge(),
+          WS_BOUND,
+          { size: invalidSize },
+        );
+
+        expect(result.sessions).toHaveLength(20);
+        expect(result.nextCursor).toBeDefined();
+      }
     });
 
     it('clamps size=200 to max page size', async () => {

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -239,10 +239,12 @@ export async function listWorkspaceSessionsForResponse(
   workspaceCwd: string,
   options?: ListWorkspaceSessionsOptions,
 ): Promise<ListWorkspaceSessionsResult> {
-  const pageSize = Math.min(
-    Math.max(options?.size ?? DEFAULT_SESSION_PAGE_SIZE, 1),
-    MAX_SESSION_PAGE_SIZE,
-  );
+  const rawSize = options?.size;
+  const requestedSize =
+    typeof rawSize === 'number' && Number.isSafeInteger(rawSize)
+      ? rawSize
+      : DEFAULT_SESSION_PAGE_SIZE;
+  const pageSize = Math.min(Math.max(requestedSize, 1), MAX_SESSION_PAGE_SIZE);
 
   let numericCursor: number | undefined;
   if (options?.cursor) {
@@ -309,6 +311,16 @@ export async function listWorkspaceSessionsForResponse(
     persisted.nextCursor != null ? String(persisted.nextCursor) : undefined;
 
   return { sessions, nextCursor };
+}
+
+function parseSessionPageSizeQuery(raw: unknown): number | undefined {
+  if (typeof raw !== 'string') return undefined;
+  const trimmed = raw.trim();
+  if (!/^[+-]?\d+$/.test(trimmed)) return undefined;
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed)) return undefined;
+  if (Number.isSafeInteger(parsed)) return parsed;
+  return trimmed.startsWith('-') ? 1 : MAX_SESSION_PAGE_SIZE;
 }
 
 const AUTH_PROVIDER_STEPS: ServeAuthProviderDescriptor['steps'] = [
@@ -3483,12 +3495,10 @@ export function createServeApp(
         typeof req.query['cursor'] === 'string'
           ? req.query['cursor']
           : undefined;
-      const sizeParam = req.query['size'];
-      const size =
-        typeof sizeParam === 'string' ? parseInt(sizeParam, 10) : undefined;
+      const size = parseSessionPageSizeQuery(req.query['size']);
       const result = await listWorkspaceSessionsForResponse(bridge, key, {
         cursor,
-        size: Number.isFinite(size) ? size : undefined,
+        size,
       });
       res.status(200).json({
         sessions: result.sessions,


### PR DESCRIPTION
## What this PR does

This PR parses `GET /workspace/:id/sessions?size=` only when the full query value is a decimal integer. Malformed values such as `1abc`, `1.5`, `1e2`, and `0x10` now stay on the default page-size path instead of being partially accepted. Valid oversized integers still use the existing HTTP clamp behavior, and fractional or non-safe numeric sizes from non-HTTP callers are ignored.

## Why it's needed

The sessions endpoint should not accept partial numeric query values. Partial parsing makes malformed inputs behave like valid sizes, which is surprising for callers and inconsistent with other stricter query parsing paths.

## Reviewer Test Plan

### How to verify

Run the focused server tests for `GET /workspace/:id/sessions`. Confirm malformed size query values use the default size, valid oversized integers are clamped, and non-HTTP fractional/non-safe numeric inputs are ignored.

### Evidence (Before & After)

Before: a query such as `?size=1abc` could be parsed as `1` by partial numeric parsing.

After: only complete decimal integer strings are accepted from HTTP query values; malformed strings use the default behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested locally with focused unit tests |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Local validation used the CLI package test runner for `server.test.ts`.

## Risk & Scope

- Main risk or tradeoff: callers sending malformed `size` values now get default page size behavior instead of accidental partial parsing.
- Not validated / out of scope: no browser UI run; this is route/helper validation behavior.
- Breaking changes / migration notes: valid integer query values keep the same behavior.

## Linked Issues

Fixes #5474

## Testing

- `npm --workspace packages/cli test -- server.test.ts -t "GET /workspace/:id/sessions" --coverage.enabled=false`
- `npx prettier --check packages/cli/src/serve/server.ts packages/cli/src/serve/server.test.ts`
- `npx eslint packages/cli/src/serve/server.ts packages/cli/src/serve/server.test.ts`
- `npm --workspace packages/cli run typecheck`
- `npm run build -- --cli-only`
- `git diff --check`

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 只在 `GET /workspace/:id/sessions?size=` 的完整 query 值是十进制整数时才解析它。`1abc`、`1.5`、`1e2`、`0x10` 这类畸形值会走默认 page-size 路径，不再被部分接受。合法但过大的整数仍保留现有 HTTP clamp 行为；非 HTTP 调用方传入的小数或非安全数字 size 会被忽略。

## 为什么需要

Sessions endpoint 不应该接受部分数字 query 值。部分解析会让畸形输入表现得像合法 size，这对调用方来说很意外，也和其他更严格的 query 解析路径不一致。

## Reviewer 测试计划

### 如何验证

运行 `GET /workspace/:id/sessions` 的聚焦 server 测试。确认畸形 size query 值会使用默认 size，合法超大整数会被 clamp，非 HTTP 的小数/非安全数字输入会被忽略。

### 前后证据

之前：`?size=1abc` 这类 query 可能通过部分数字解析变成 `1`。

之后：HTTP query 只接受完整十进制整数字符串；畸形字符串走默认行为。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ 本地聚焦单测已验证 |
| 🪟 Windows | ⚠️ 未本地验证 |
|  🐧 Linux  | ⚠️ 未本地验证 |

### 环境

本地验证使用 CLI package test runner，目标测试为 `server.test.ts`。

## 风险与范围

- 主要风险或取舍：发送畸形 `size` 值的调用方现在会得到默认 page size 行为，不再走意外的部分解析。
- 未验证 / 不在范围内：没有跑浏览器 UI；这是 route/helper 校验行为。
- 破坏性变更 / 迁移说明：合法整数 query 值行为不变。

## 关联 Issue

Fixes #5474

## 测试

- `npm --workspace packages/cli test -- server.test.ts -t "GET /workspace/:id/sessions" --coverage.enabled=false`
- `npx prettier --check packages/cli/src/serve/server.ts packages/cli/src/serve/server.test.ts`
- `npx eslint packages/cli/src/serve/server.ts packages/cli/src/serve/server.test.ts`
- `npm --workspace packages/cli run typecheck`
- `npm run build -- --cli-only`
- `git diff --check`

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
