### PR TITLE
fix(telegram): clear typing intervals on disconnect

### DIFF
--- a/packages/channels/telegram/package.json
+++ b/packages/channels/telegram/package.json
@@ -15,7 +15,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --build"
+    "build": "tsc --build",
+    "test": "vitest run",
+    "test:ci": "vitest run"
   },
   "dependencies": {
     "@qwen-code/channel-base": "file:../base",

--- a/packages/channels/telegram/src/TelegramAdapter.test.ts
+++ b/packages/channels/telegram/src/TelegramAdapter.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TelegramChannel } from './TelegramAdapter.js';
+import type { AcpBridge, ChannelConfig } from '@qwen-code/channel-base';
+
+class TestTelegramChannel extends TelegramChannel {
+  startTyping(chatId: string): void {
+    this.onPromptStart(chatId);
+  }
+}
+
+const config: ChannelConfig = {
+  type: 'telegram',
+  token: 'token',
+  senderPolicy: 'open',
+  allowedUsers: [],
+  sessionScope: 'user',
+  cwd: process.cwd(),
+  groupPolicy: 'disabled',
+  groups: {},
+};
+
+function createChannel(): TestTelegramChannel {
+  return new TestTelegramChannel('telegram', config, {} as AcpBridge, {
+    router: {} as never,
+  });
+}
+
+function installFakeBot(channel: TelegramChannel): {
+  api: { sendChatAction: ReturnType<typeof vi.fn> };
+  stop: ReturnType<typeof vi.fn>;
+} {
+  const bot = {
+    api: {
+      sendChatAction: vi.fn().mockResolvedValue(undefined),
+    },
+    stop: vi.fn(),
+  };
+  (channel as unknown as { bot: typeof bot }).bot = bot;
+  return bot;
+}
+
+describe('TelegramChannel', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('clears active typing intervals on disconnect', () => {
+    const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
+    const channel = createChannel();
+    const bot = installFakeBot(channel);
+
+    channel.startTyping('chat-1');
+    channel.startTyping('chat-2');
+    expect(bot.api.sendChatAction).toHaveBeenCalledTimes(2);
+
+    channel.disconnect();
+
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(2);
+    expect(bot.stop).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(4000);
+    expect(bot.api.sendChatAction).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/channels/telegram/src/TelegramAdapter.ts
+++ b/packages/channels/telegram/src/TelegramAdapter.ts
@@ -256,6 +256,10 @@ export class TelegramChannel extends ChannelBase {
   }
 
   disconnect(): void {
+    for (const interval of this.typingIntervals.values()) {
+      clearInterval(interval);
+    }
+    this.typingIntervals.clear();
     this.bot.stop();
   }
 


### PR DESCRIPTION
## What this PR does

This PR clears all active Telegram typing intervals when the channel disconnects. It also adds Telegram adapter coverage for disconnecting while typing indicators are active, and adds Telegram workspace test scripts so the adapter tests run from root test jobs.

## Why it's needed

Typing timers are background intervals. If the Telegram channel disconnects while a typing indicator is active, those intervals can keep running after the adapter is no longer connected.

## Reviewer Test Plan

### How to verify

Run the Telegram channel tests and confirm disconnect clears active typing intervals. The focused adapter test covers a disconnect while typing indicators are active.

### Evidence (Before & After)

Before: a disconnect could leave typing intervals alive after the Telegram adapter disconnected.

After: disconnect clears the active typing interval set, so no typing timers remain after disconnect.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested locally with Telegram package tests |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Local validation used the Telegram channel package test/build scripts.

## Risk & Scope

- Main risk or tradeoff: low risk; the change only runs on Telegram disconnect and clears timers that should not outlive the connection.
- Not validated / out of scope: no live Telegram bot connection was used.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5476

## Testing

- npm --workspace packages/channels/telegram run test:ci
- npm --workspace packages/channels/telegram run build
- npx eslint packages/channels/telegram/src/TelegramAdapter.ts packages/channels/telegram/src/TelegramAdapter.test.ts
- npx prettier --check packages/channels/telegram/package.json packages/channels/telegram/src/TelegramAdapter.ts packages/channels/telegram/src/TelegramAdapter.test.ts
- git diff --check

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 在 Telegram channel 断开连接时清理所有活跃的 typing intervals。它还补充了 Telegram adapter 在 typing indicator 活跃时断开连接的测试，并添加 Telegram workspace test scripts，让 root test jobs 能跑到 adapter 测试。

## 为什么需要

Typing timers 是后台 interval。如果 Telegram channel 在 typing indicator 活跃时断开，这些 interval 可能会在 adapter 断开后继续运行。

## Reviewer 测试计划

### 如何验证

运行 Telegram channel 测试，确认 disconnect 会清理活跃 typing intervals。聚焦的 adapter 测试覆盖了 typing indicator 活跃时断开连接的场景。

### 前后证据

之前：disconnect 可能让 typing intervals 在 Telegram adapter 断开后继续存活。

之后：disconnect 会清空活跃 typing interval 集合，因此断开后不会残留 typing timers。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ 本地 Telegram package 测试已验证 |
| 🪟 Windows | ⚠️ 未本地验证 |
|  🐧 Linux  | ⚠️ 未本地验证 |

### 环境

本地验证使用 Telegram channel package 的 test/build scripts。

## 风险与范围

- 主要风险或取舍：低风险；改动只在 Telegram disconnect 路径执行，并清理不应长于连接生命周期的 timer。
- 未验证 / 不在范围内：没有使用真实 Telegram bot 连接。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #5476

## 测试

- npm --workspace packages/channels/telegram run test:ci
- npm --workspace packages/channels/telegram run build
- npx eslint packages/channels/telegram/src/TelegramAdapter.ts packages/channels/telegram/src/TelegramAdapter.test.ts
- npx prettier --check packages/channels/telegram/package.json packages/channels/telegram/src/TelegramAdapter.ts packages/channels/telegram/src/TelegramAdapter.test.ts
- git diff --check

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
