### PR TITLE
feat(core): add Requesty provider

### DIFF
--- a/docs/users/configuration/auth.md
+++ b/docs/users/configuration/auth.md
@@ -101,7 +101,7 @@ If you prefer to skip the interactive `/auth` flow, add the following to `~/.qwe
 
 ## 🚀 Option 3: API Key (flexible)
 
-Use this if you want to connect to third-party providers such as OpenAI, Anthropic, Google, Azure OpenAI, OpenRouter, ModelScope, or a self-hosted endpoint. Supports multiple protocols and providers.
+Use this if you want to connect to third-party providers such as OpenAI, Anthropic, Google, Azure OpenAI, OpenRouter, Requesty, ModelScope, or a self-hosted endpoint. Supports multiple protocols and providers.
 
 ### Recommended: One-file setup via `settings.json`
 
@@ -153,11 +153,11 @@ The key concept is **Model Providers** (`modelProviders`): Qwen Code supports mu
 
 #### Supported protocols
 
-| Protocol          | `modelProviders` key | Environment variables                                        | Providers                                                                                   |
-| ----------------- | -------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
-| OpenAI-compatible | `openai`             | `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `OPENAI_MODEL`          | OpenAI, Azure OpenAI, OpenRouter, ModelScope, Alibaba Cloud, any OpenAI-compatible endpoint |
-| Anthropic         | `anthropic`          | `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_MODEL` | Anthropic Claude                                                                            |
-| Google GenAI      | `gemini`             | `GEMINI_API_KEY`, `GEMINI_MODEL`                             | Google Gemini                                                                               |
+| Protocol          | `modelProviders` key | Environment variables                                        | Providers                                                                                             |
+| ----------------- | -------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| OpenAI-compatible | `openai`             | `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `OPENAI_MODEL`          | OpenAI, Azure OpenAI, OpenRouter, Requesty, ModelScope, Alibaba Cloud, any OpenAI-compatible endpoint |
+| Anthropic         | `anthropic`          | `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_MODEL` | Anthropic Claude                                                                                      |
+| Google GenAI      | `gemini`             | `GEMINI_API_KEY`, `GEMINI_MODEL`                             | Google Gemini                                                                                         |
 
 #### Step 1: Configure models and providers in `~/.qwen/settings.json`
 
@@ -315,6 +315,7 @@ The standalone `qwen auth` CLI command has been removed. Use these replacements 
 | Interactive authentication setup | Run `qwen`, then use `/auth`                                                                |
 | Coding Plan setup                | Use `/auth`, or set `BAILIAN_CODING_PLAN_API_KEY` with the Coding Plan base URL             |
 | OpenRouter setup                 | Use `/auth`, or set `OPENROUTER_API_KEY` and `OPENAI_BASE_URL=https://openrouter.ai/api/v1` |
+| Requesty setup                   | Use `/auth`, or set `REQUESTY_API_KEY` and `OPENAI_BASE_URL=https://router.requesty.ai/v1`  |
 | API-key or custom provider setup | Configure `~/.qwen/settings.json`, `.env`, or provider-specific environment variables       |
 | Check current authentication     | Run `/doctor` inside Qwen Code                                                              |
 | OAuth browser flow               | Run `qwen` interactively and use `/auth`; OAuth cannot be configured with env vars alone    |

--- a/docs/users/configuration/model-providers.md
+++ b/docs/users/configuration/model-providers.md
@@ -47,13 +47,14 @@ This means the `baseUrl` you configure should be compatible with the correspondi
 
 ### OpenAI-compatible providers (`openai`)
 
-This auth type supports not only OpenAI's official API but also any OpenAI-compatible endpoint, including aggregated model providers like OpenRouter.
+This auth type supports not only OpenAI's official API but also any OpenAI-compatible endpoint, including aggregated model providers like OpenRouter and Requesty.
 
 ```json
 {
   "env": {
     "OPENAI_API_KEY": "sk-your-actual-openai-key-here",
-    "OPENROUTER_API_KEY": "sk-or-your-actual-openrouter-key-here"
+    "OPENROUTER_API_KEY": "sk-or-your-actual-openrouter-key-here",
+    "REQUESTY_API_KEY": "sk-your-actual-requesty-key-here"
   },
   "modelProviders": {
     "openai": [
@@ -104,6 +105,19 @@ This auth type supports not only OpenAI's official API but also any OpenAI-compa
         "name": "GPT-4o (via OpenRouter)",
         "envKey": "OPENROUTER_API_KEY",
         "baseUrl": "https://openrouter.ai/api/v1",
+        "generationConfig": {
+          "timeout": 120000,
+          "maxRetries": 3,
+          "samplingParams": {
+            "temperature": 0.7
+          }
+        }
+      },
+      {
+        "id": "openai/gpt-4o-mini",
+        "name": "GPT-4o Mini (via Requesty)",
+        "envKey": "REQUESTY_API_KEY",
+        "baseUrl": "https://router.requesty.ai/v1",
         "generationConfig": {
           "timeout": 120000,
           "maxRetries": 3,

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -28,6 +28,7 @@ export const buildRemovalNotice = (): string =>
     `                     ${t('China: https://coding.dashscope.aliyuncs.com/v1')}`,
     `                     ${t('International: https://coding-intl.dashscope.aliyuncs.com/v1')}`,
     `  ${cyan(t('OpenRouter'))}    →  ${t('set OPENROUTER_API_KEY and OPENAI_BASE_URL=https://openrouter.ai/api/v1')}`,
+    `  ${cyan(t('Requesty'))}      →  ${t('set REQUESTY_API_KEY and OPENAI_BASE_URL=https://router.requesty.ai/v1')}`,
     `  ${cyan(t('Qwen OAuth'))}    →  ${t('run qwen interactively and use /auth; OAuth cannot be configured with env vars alone')}`,
     `  ${cyan(t('Scripted'))}      →  ${t('edit ~/.qwen/settings.json, or run qwen interactively once')}`,
     '',
@@ -43,6 +44,7 @@ const legacySubcommands = [
   'status',
   'coding-plan',
   'openrouter',
+  'requesty',
   'api-key',
   'qwen-oauth',
 ];

--- a/packages/core/src/core/openaiContentGenerator/index.ts
+++ b/packages/core/src/core/openaiContentGenerator/index.ts
@@ -18,6 +18,7 @@ import {
   MiniMaxOpenAICompatibleProvider,
   MistralOpenAICompatibleProvider,
   OpenRouterOpenAICompatibleProvider,
+  RequestyOpenAICompatibleProvider,
   type OpenAICompatibleProvider,
   DefaultOpenAICompatibleProvider,
 } from './provider/index.js';
@@ -34,6 +35,7 @@ export {
   MiniMaxOpenAICompatibleProvider,
   MistralOpenAICompatibleProvider,
   OpenRouterOpenAICompatibleProvider,
+  RequestyOpenAICompatibleProvider,
 } from './provider/index.js';
 
 export { OpenAIContentConverter } from './converter.js';
@@ -85,6 +87,14 @@ export function determineProvider(
   // Check for OpenRouter provider
   if (OpenRouterOpenAICompatibleProvider.isOpenRouterProvider(config)) {
     return new OpenRouterOpenAICompatibleProvider(
+      contentGeneratorConfig,
+      cliConfig,
+    );
+  }
+
+  // Check for Requesty provider
+  if (RequestyOpenAICompatibleProvider.isRequestyProvider(config)) {
+    return new RequestyOpenAICompatibleProvider(
       contentGeneratorConfig,
       cliConfig,
     );

--- a/packages/core/src/core/openaiContentGenerator/provider/README.md
+++ b/packages/core/src/core/openaiContentGenerator/provider/README.md
@@ -9,6 +9,7 @@ This folder contains the different provider implementations for the Qwen Code re
 - `default.ts` - Default provider for standard OpenAI-compatible APIs
 - `dashscope.ts` - DashScope (Qwen) specific provider implementation
 - `openrouter.ts` - OpenRouter specific provider implementation
+- `requesty.ts` - Requesty specific provider implementation
 - `index.ts` - Main export file for all providers
 
 ## Provider Types
@@ -24,6 +25,10 @@ The `DashScopeOpenAICompatibleProvider` handles DashScope (Qwen) specific featur
 ### OpenRouter Provider
 
 The `OpenRouterOpenAICompatibleProvider` handles OpenRouter specific headers and configurations.
+
+### Requesty Provider
+
+The `RequestyOpenAICompatibleProvider` handles Requesty specific attribution headers and configurations.
 
 ## Adding a New Provider
 

--- a/packages/core/src/core/openaiContentGenerator/provider/index.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/index.ts
@@ -2,6 +2,7 @@ export { ModelScopeOpenAICompatibleProvider } from './modelscope.js';
 export { DashScopeOpenAICompatibleProvider } from './dashscope.js';
 export { DeepSeekOpenAICompatibleProvider } from './deepseek.js';
 export { OpenRouterOpenAICompatibleProvider } from './openrouter.js';
+export { RequestyOpenAICompatibleProvider } from './requesty.js';
 export { MiniMaxOpenAICompatibleProvider } from './minimax.js';
 export { MistralOpenAICompatibleProvider } from './mistral.js';
 export { MiMoOpenAICompatibleProvider } from './mimo.js';

--- a/packages/core/src/core/openaiContentGenerator/provider/requesty.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/requesty.test.ts
@@ -1,0 +1,220 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type OpenAI from 'openai';
+import { RequestyOpenAICompatibleProvider } from './requesty.js';
+import { DefaultOpenAICompatibleProvider } from './default.js';
+import type { Config } from '../../../config/config.js';
+import type { ContentGeneratorConfig } from '../../contentGenerator.js';
+
+describe('RequestyOpenAICompatibleProvider', () => {
+  let provider: RequestyOpenAICompatibleProvider;
+  let mockContentGeneratorConfig: ContentGeneratorConfig;
+  let mockCliConfig: Config;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Mock ContentGeneratorConfig
+    mockContentGeneratorConfig = {
+      apiKey: 'test-api-key',
+      baseUrl: 'https://router.requesty.ai/v1',
+      timeout: 60000,
+      maxRetries: 2,
+      model: 'openai/gpt-4o-mini',
+    } as ContentGeneratorConfig;
+
+    // Mock Config
+    mockCliConfig = {
+      getCliVersion: vi.fn().mockReturnValue('1.0.0'),
+    } as unknown as Config;
+
+    provider = new RequestyOpenAICompatibleProvider(
+      mockContentGeneratorConfig,
+      mockCliConfig,
+    );
+  });
+
+  describe('constructor', () => {
+    it('should extend DefaultOpenAICompatibleProvider', () => {
+      expect(provider).toBeInstanceOf(DefaultOpenAICompatibleProvider);
+      expect(provider).toBeInstanceOf(RequestyOpenAICompatibleProvider);
+    });
+  });
+
+  describe('isRequestyProvider', () => {
+    it('should return true for router.requesty.ai URLs', () => {
+      const configs = [
+        { baseUrl: 'https://router.requesty.ai/v1' },
+        { baseUrl: 'https://router.requesty.ai' },
+        { baseUrl: 'http://router.requesty.ai/v1' },
+      ];
+
+      configs.forEach((config) => {
+        const result = RequestyOpenAICompatibleProvider.isRequestyProvider(
+          config as ContentGeneratorConfig,
+        );
+        expect(result).toBe(true);
+      });
+    });
+
+    it('should return false for non-requesty URLs', () => {
+      const configs = [
+        { baseUrl: 'https://api.openai.com/v1' },
+        { baseUrl: 'https://api.anthropic.com/v1' },
+        { baseUrl: 'https://openrouter.ai/api/v1' },
+        { baseUrl: 'https://example.com/api/v1' }, // different domain
+        { baseUrl: '' },
+        { baseUrl: undefined },
+      ];
+
+      configs.forEach((config) => {
+        const result = RequestyOpenAICompatibleProvider.isRequestyProvider(
+          config as ContentGeneratorConfig,
+        );
+        expect(result).toBe(false);
+      });
+    });
+
+    it('should handle missing baseUrl gracefully', () => {
+      const config = {} as ContentGeneratorConfig;
+      const result =
+        RequestyOpenAICompatibleProvider.isRequestyProvider(config);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('buildHeaders', () => {
+    it('should include base headers from parent class', () => {
+      const headers = provider.buildHeaders();
+
+      // Should include User-Agent from parent
+      expect(headers['User-Agent']).toBe(
+        `QwenCode/1.0.0 (${process.platform}; ${process.arch})`,
+      );
+    });
+
+    it('should add Requesty-specific headers', () => {
+      const headers = provider.buildHeaders();
+
+      expect(headers).toEqual({
+        'User-Agent': `QwenCode/1.0.0 (${process.platform}; ${process.arch})`,
+        'HTTP-Referer': 'https://github.com/QwenLM/qwen-code.git',
+        'X-Title': 'Qwen Code',
+      });
+    });
+
+    it('should override parent headers if there are conflicts', () => {
+      // Mock parent to return conflicting headers
+      const parentBuildHeaders = vi.spyOn(
+        DefaultOpenAICompatibleProvider.prototype,
+        'buildHeaders',
+      );
+      parentBuildHeaders.mockReturnValue({
+        'User-Agent': 'ParentAgent/1.0.0',
+        'HTTP-Referer': 'https://parent.com',
+      });
+
+      const headers = provider.buildHeaders();
+
+      expect(headers).toEqual({
+        'User-Agent': 'ParentAgent/1.0.0',
+        'HTTP-Referer': 'https://github.com/QwenLM/qwen-code.git', // Requesty-specific value should override
+        'X-Title': 'Qwen Code',
+      });
+
+      parentBuildHeaders.mockRestore();
+    });
+
+    it('should handle unknown CLI version from parent', () => {
+      vi.mocked(mockCliConfig.getCliVersion).mockReturnValue(undefined);
+
+      const headers = provider.buildHeaders();
+
+      expect(headers['User-Agent']).toBe(
+        `QwenCode/unknown (${process.platform}; ${process.arch})`,
+      );
+      expect(headers['HTTP-Referer']).toBe(
+        'https://github.com/QwenLM/qwen-code.git',
+      );
+      expect(headers['X-Title']).toBe('Qwen Code');
+    });
+  });
+
+  describe('buildClient', () => {
+    it('should inherit buildClient behavior from parent', () => {
+      // Mock the parent's buildClient method
+      const mockClient = { test: 'client' };
+      const parentBuildClient = vi.spyOn(
+        DefaultOpenAICompatibleProvider.prototype,
+        'buildClient',
+      );
+      parentBuildClient.mockReturnValue(mockClient as unknown as OpenAI);
+
+      const result = provider.buildClient();
+
+      expect(parentBuildClient).toHaveBeenCalled();
+      expect(result).toBe(mockClient);
+
+      parentBuildClient.mockRestore();
+    });
+  });
+
+  describe('buildRequest', () => {
+    it('should inherit buildRequest behavior from parent', () => {
+      const mockRequest: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'openai/gpt-4o-mini',
+        messages: [{ role: 'user', content: 'Hello' }],
+      };
+      const mockUserPromptId = 'test-prompt-id';
+      const mockResult = { ...mockRequest, modified: true };
+
+      // Mock the parent's buildRequest method
+      const parentBuildRequest = vi.spyOn(
+        DefaultOpenAICompatibleProvider.prototype,
+        'buildRequest',
+      );
+      parentBuildRequest.mockReturnValue(mockResult);
+
+      const result = provider.buildRequest(mockRequest, mockUserPromptId);
+
+      expect(parentBuildRequest).toHaveBeenCalledWith(
+        mockRequest,
+        mockUserPromptId,
+      );
+      expect(result).toBe(mockResult);
+
+      parentBuildRequest.mockRestore();
+    });
+  });
+
+  describe('integration with parent class', () => {
+    it('should properly call parent constructor', () => {
+      const newProvider = new RequestyOpenAICompatibleProvider(
+        mockContentGeneratorConfig,
+        mockCliConfig,
+      );
+
+      // Verify that parent properties are accessible
+      expect(newProvider).toHaveProperty('buildHeaders');
+      expect(newProvider).toHaveProperty('buildClient');
+      expect(newProvider).toHaveProperty('buildRequest');
+    });
+
+    it('should maintain parent functionality while adding Requesty specifics', () => {
+      // Test that the provider can perform all parent operations
+      const headers = provider.buildHeaders();
+
+      // Should have both parent and Requesty-specific headers
+      expect(headers['User-Agent']).toBeDefined(); // From parent
+      expect(headers['HTTP-Referer']).toBe(
+        'https://github.com/QwenLM/qwen-code.git',
+      ); // Requesty-specific
+      expect(headers['X-Title']).toBe('Qwen Code'); // Requesty-specific
+    });
+  });
+});

--- a/packages/core/src/core/openaiContentGenerator/provider/requesty.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/requesty.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type OpenAI from 'openai';
 import { RequestyOpenAICompatibleProvider } from './requesty.js';
 import { DefaultOpenAICompatibleProvider } from './default.js';
+import { determineProvider } from '../index.js';
 import type { Config } from '../../../config/config.js';
 import type { ContentGeneratorConfig } from '../../contentGenerator.js';
 
@@ -85,6 +86,48 @@ describe('RequestyOpenAICompatibleProvider', () => {
       const result =
         RequestyOpenAICompatibleProvider.isRequestyProvider(config);
       expect(result).toBe(false);
+    });
+
+    it('should reject hostile hostnames containing router.requesty.ai', () => {
+      const configs = [
+        { baseUrl: 'https://router.requesty.ai.evil.example/v1' },
+        { baseUrl: 'https://fake-router.requesty.ai.attacker.com/v1' },
+        { baseUrl: 'https://router.requesty.ai@evil.example/v1' },
+        { baseUrl: 'not-a-url' },
+      ];
+
+      configs.forEach((config) => {
+        const result = RequestyOpenAICompatibleProvider.isRequestyProvider(
+          config as ContentGeneratorConfig,
+        );
+        expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('determineProvider dispatch', () => {
+    it('routes router.requesty.ai configs to RequestyOpenAICompatibleProvider', () => {
+      const provider = determineProvider(
+        {
+          apiKey: 'key',
+          baseUrl: 'https://router.requesty.ai/v1',
+          model: 'openai/gpt-4o-mini',
+        } as ContentGeneratorConfig,
+        mockCliConfig,
+      );
+      expect(provider).toBeInstanceOf(RequestyOpenAICompatibleProvider);
+    });
+
+    it('does not route hostile hostnames to RequestyOpenAICompatibleProvider', () => {
+      const provider = determineProvider(
+        {
+          apiKey: 'key',
+          baseUrl: 'https://router.requesty.ai.evil.example/v1',
+          model: 'openai/gpt-4o-mini',
+        } as ContentGeneratorConfig,
+        mockCliConfig,
+      );
+      expect(provider).not.toBeInstanceOf(RequestyOpenAICompatibleProvider);
     });
   });
 

--- a/packages/core/src/core/openaiContentGenerator/provider/requesty.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/requesty.ts
@@ -1,0 +1,31 @@
+import type { Config } from '../../../config/config.js';
+import type { ContentGeneratorConfig } from '../../contentGenerator.js';
+import { DefaultOpenAICompatibleProvider } from './default.js';
+
+export class RequestyOpenAICompatibleProvider extends DefaultOpenAICompatibleProvider {
+  constructor(
+    contentGeneratorConfig: ContentGeneratorConfig,
+    cliConfig: Config,
+  ) {
+    super(contentGeneratorConfig, cliConfig);
+  }
+
+  static isRequestyProvider(
+    contentGeneratorConfig: ContentGeneratorConfig,
+  ): boolean {
+    const baseURL = contentGeneratorConfig.baseUrl || '';
+    return baseURL.includes('router.requesty.ai');
+  }
+
+  override buildHeaders(): Record<string, string | undefined> {
+    // Get base headers from parent class
+    const baseHeaders = super.buildHeaders();
+
+    // Add Requesty-specific attribution headers
+    return {
+      ...baseHeaders,
+      'HTTP-Referer': 'https://github.com/QwenLM/qwen-code.git',
+      'X-Title': 'Qwen Code',
+    };
+  }
+}

--- a/packages/core/src/core/openaiContentGenerator/provider/requesty.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/requesty.ts
@@ -14,7 +14,13 @@ export class RequestyOpenAICompatibleProvider extends DefaultOpenAICompatiblePro
     contentGeneratorConfig: ContentGeneratorConfig,
   ): boolean {
     const baseURL = contentGeneratorConfig.baseUrl || '';
-    return baseURL.includes('router.requesty.ai');
+    if (!baseURL) return false;
+    try {
+      const host = new URL(baseURL).hostname.toLowerCase();
+      return host === 'router.requesty.ai' || host.endsWith('.requesty.ai');
+    } catch {
+      return false;
+    }
   }
 
   override buildHeaders(): Record<string, string | undefined> {

--- a/packages/core/src/providers/__tests__/presets/requesty.test.ts
+++ b/packages/core/src/providers/__tests__/presets/requesty.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+// Re-import via the relative source path so the new ownsModel envKey gate
+// is exercised even before dist/ is rebuilt (the @qwen-code/qwen-code-core
+// package resolves to dist/ on a fresh branch).
+import { requestyProvider, REQUESTY_ENV_KEY } from '../../presets/requesty.js';
+
+describe('requestyProvider', () => {
+  it('owns models that match BOTH our envKey and a router.requesty.ai host', () => {
+    expect(
+      requestyProvider.ownsModel?.({
+        id: 'requesty-model',
+        baseUrl: 'https://router.requesty.ai/v1',
+        envKey: REQUESTY_ENV_KEY,
+      }),
+    ).toBe(true);
+  });
+
+  it('refuses ownership over a different envKey on the same host (user-added entry)', () => {
+    // A user wired their own gateway through router.requesty.ai with a custom
+    // env var — re-install must not silently delete their model entry.
+    expect(
+      requestyProvider.ownsModel?.({
+        id: 'user-added',
+        baseUrl: 'https://router.requesty.ai/v1',
+        envKey: 'MY_PRIVATE_GATEWAY_KEY',
+      }),
+    ).toBe(false);
+  });
+
+  it('refuses ownership over an unrelated host even with our envKey', () => {
+    expect(
+      requestyProvider.ownsModel?.({
+        id: 'other-model',
+        baseUrl: 'https://api.example.com/v1',
+        envKey: REQUESTY_ENV_KEY,
+      }),
+    ).toBe(false);
+  });
+
+  it('refuses ownership when baseUrl is missing or malformed', () => {
+    expect(
+      requestyProvider.ownsModel?.({
+        id: 'no-url',
+        envKey: REQUESTY_ENV_KEY,
+      }),
+    ).toBe(false);
+    expect(
+      requestyProvider.ownsModel?.({
+        id: 'bad-url',
+        baseUrl: 'not a url',
+        envKey: REQUESTY_ENV_KEY,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/core/src/providers/all-providers.ts
+++ b/packages/core/src/providers/all-providers.ts
@@ -13,6 +13,7 @@ import { codingPlanProvider } from './presets/alibaba-coding-plan.js';
 import { tokenPlanProvider } from './presets/alibaba-token-plan.js';
 import { alibabaStandardProvider } from './presets/alibaba-standard.js';
 import { openRouterProvider } from './presets/openrouter.js';
+import { requestyProvider } from './presets/requesty.js';
 import { deepseekProvider } from './presets/deepseek.js';
 import { minimaxProvider } from './presets/minimax.js';
 import { zaiProvider } from './presets/zai.js';
@@ -26,6 +27,7 @@ export {
   tokenPlanProvider,
   alibabaStandardProvider,
   openRouterProvider,
+  requestyProvider,
   deepseekProvider,
   minimaxProvider,
   zaiProvider,
@@ -53,6 +55,7 @@ export const ALL_PROVIDERS: readonly ProviderConfig[] = [
   idealabProvider,
   modelscopeProvider,
   openRouterProvider,
+  requestyProvider,
   customProvider,
 ];
 

--- a/packages/core/src/providers/index.ts
+++ b/packages/core/src/providers/index.ts
@@ -50,6 +50,7 @@ export {
   minimaxProvider,
   modelscopeProvider,
   openRouterProvider,
+  requestyProvider,
   THIRD_PARTY_PROVIDERS,
   tokenPlanProvider,
   zaiProvider,
@@ -69,6 +70,7 @@ export {
   OPENROUTER_BASE_URL,
   OPENROUTER_ENV_KEY,
 } from './presets/openrouter.js';
+export { REQUESTY_BASE_URL, REQUESTY_ENV_KEY } from './presets/requesty.js';
 
 // Install logic
 export {

--- a/packages/core/src/providers/presets/requesty.ts
+++ b/packages/core/src/providers/presets/requesty.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AuthType } from '../../core/contentGenerator.js';
+import type { ProviderConfig } from '../types.js';
+
+export const REQUESTY_ENV_KEY = 'REQUESTY_API_KEY';
+export const REQUESTY_BASE_URL = 'https://router.requesty.ai/v1';
+
+export const requestyProvider: ProviderConfig = {
+  id: 'requesty',
+  label: 'Requesty',
+  description:
+    'Connect with a Requesty API key (get one from app.requesty.ai/api-keys)',
+  protocol: AuthType.USE_OPENAI,
+  baseUrl: REQUESTY_BASE_URL,
+  envKey: REQUESTY_ENV_KEY,
+  models: [
+    { id: 'openai/gpt-4o-mini', contextWindowSize: 128000 },
+    { id: 'openai/gpt-4o', contextWindowSize: 128000 },
+  ],
+  modelsEditable: true,
+  modelNamePrefix: 'Requesty',
+  ownsModel: (model) => {
+    // A user who manually added a Requesty-routed model under a custom
+    // envKey (e.g. their own gateway) shouldn't have their entry silently
+    // removed on re-install — require BOTH the hostname *and* our envKey to
+    // claim ownership.
+    if (model.envKey !== REQUESTY_ENV_KEY) return false;
+    try {
+      const host = new URL(model.baseUrl ?? '').hostname;
+      return host === 'router.requesty.ai' || host.endsWith('.requesty.ai');
+    } catch {
+      return false;
+    }
+  },
+  documentationUrl: 'https://docs.requesty.ai',
+  uiGroup: 'third-party',
+};


### PR DESCRIPTION
## What this PR does

Adds [Requesty](https://requesty.ai) as a first-class model provider alongside the existing OpenAI / OpenRouter / Fireworks providers. Requesty is an OpenAI-compatible model gateway that uses the same `provider/model` identifier format as OpenRouter, so it is implemented by mirroring the existing OpenRouter provider as closely as possible: a `RequestyOpenAICompatibleProvider` with URL-hostname-based detection and Requesty attribution headers, a first-class provider preset (env key, base URL, `ownsModel` gate, third-party UI group), dispatch-chain registration, a legacy auth-migration entry, and user docs. Only the base URL (`https://router.requesty.ai/v1`) and env var (`REQUESTY_API_KEY`) differ from the shared OpenAI-compatible path.

## Why it's needed

Requesty users currently have to configure it by hand as a generic OpenAI-compatible endpoint, which skips the attribution headers, the onboarding/auth flow, and the model preset that every other bundled gateway gets. Making it first-class gives Requesty users the same one-step onboarding and model-picker experience as OpenRouter, with a key from https://app.requesty.ai/api-keys and the model list at https://app.requesty.ai/router/list.

## Reviewer Test Plan

### How to verify

1. `npm run typecheck --workspace @qwen-code/qwen-code-core` — clean. 2. Run the provider + preset suites: `npx vitest run packages/core/src/core/openaiContentGenerator/provider/requesty.test.ts packages/core/src/providers/__tests__/presets/requesty.test.ts` — 19 pass (provider 15 + preset 4), including hostile-hostname rejection and `determineProvider` dispatch routing. 3. Confirm no OpenRouter regression: `npx vitest run packages/core/src/core/openaiContentGenerator/provider/openrouter.test.ts` — 12 pass. 4. Optional live check: a POST to `https://router.requesty.ai/v1/chat/completions` with `model: openai/gpt-4o-mini` returns HTTP 200 with a real completion; GET `/v1/models` returns 200.

Expected: configs whose `baseUrl` hostname is `router.requesty.ai` (or `*.requesty.ai`) route to `RequestyOpenAICompatibleProvider`; crafted hosts like `https://router.requesty.ai.evil.example/v1` do not.

### Evidence (Before & After)

Non-user-visible (new provider wiring + types + tests). N/A for screenshots; see the test output in How to verify.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node v22.22.0, Vitest 3.2.4, macOS. Unit tests + typecheck + a real HTTP round-trip to `router.requesty.ai`.

## Risk & Scope

- Main risk or tradeoff: provider detection must not over-claim configs. Addressed by URL-hostname matching (exact `router.requesty.ai` or `.requesty.ai` suffix), matching the `ownsModel` preset gate and the MiMo/MiniMax/Mistral providers.
- Not validated / out of scope: only the changed surface was typechecked/tested, not a full monorepo build; image/audio/embedding modalities are out of scope (text inference only).
- Breaking changes / migration notes: none. Purely additive; existing providers and dispatch are unchanged (OpenRouter regression suite still green).

## Linked Issues

N/A (new provider).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

新增 [Requesty](https://requesty.ai) 作为一等模型提供方，与现有的 OpenAI / OpenRouter / Fireworks 等并列。Requesty 是一个兼容 OpenAI 的模型网关，使用与 OpenRouter 相同的 `provider/model` 标识格式，因此实现方式尽量参照现有的 OpenRouter 提供方：一个基于 URL 主机名检测并带 Requesty 归因请求头的 `RequestyOpenAICompatibleProvider`、一个一等的提供方预设（环境变量、base URL、`ownsModel` 判定、third-party 分组）、分发链注册、旧版认证迁移入口，以及用户文档。与共享的 OpenAI 兼容路径相比，仅 base URL（`https://router.requesty.ai/v1`）与环境变量（`REQUESTY_API_KEY`）不同。

## 为什么需要

目前 Requesty 用户只能手动把它配置成通用的 OpenAI 兼容端点，从而错过归因请求头、引导/认证流程，以及其他网关都有的模型预设。将其设为一等提供方后，Requesty 用户可获得与 OpenRouter 相同的一步式引导与模型选择体验，API key 见 https://app.requesty.ai/api-keys ，模型列表见 https://app.requesty.ai/router/list 。

## 审阅测试计划

1. `npm run typecheck --workspace @qwen-code/qwen-code-core`——通过。2. 运行提供方与预设测试：`npx vitest run packages/core/src/core/openaiContentGenerator/provider/requesty.test.ts packages/core/src/providers/__tests__/presets/requesty.test.ts`——19 个通过（provider 15 + preset 4），含恶意主机名拒绝与 `determineProvider` 分发路由。3. 确认 OpenRouter 无回归：`npx vitest run .../openrouter.test.ts`——12 个通过。预期：主机名为 `router.requesty.ai`（或 `*.requesty.ai`）的配置路由到 `RequestyOpenAICompatibleProvider`；像 `https://router.requesty.ai.evil.example/v1` 这样的伪造主机名不会被匹配。

## 风险与范围

- 主要风险：提供方检测不能错误匹配其他配置。已通过 URL 主机名匹配（精确 `router.requesty.ai` 或 `.requesty.ai` 后缀）解决，与 `ownsModel` 预设判定及 MiMo/MiniMax/Mistral 提供方一致。
- 不在范围内：仅对改动面做了类型检查/测试，未做整库构建；仅文本推理，图像/音频/嵌入模态不在范围内。
- 破坏性变更：无。纯新增，现有提供方与分发逻辑不变（OpenRouter 回归测试仍全部通过）。

## 披露

我在 Requesty 工作。本 PR 尽量参照现有的 OpenRouter 提供方实现。乐意调整命名/位置，或在不合适时关闭。

</details>
