### PR TITLE
fix(cli): validate ACP glob max results

### DIFF
--- a/packages/cli/src/serve/acpHttp/dispatch.ts
+++ b/packages/cli/src/serve/acpHttp/dispatch.ts
@@ -153,8 +153,27 @@ const CONN_ROUTED_METHODS = new Set<string>([
 // shared module to avoid churning the 2987-line server.ts near merge; a
 // follow-up may lift all three to a `serve/limits.ts`.)
 const MAX_NAME_LENGTH = 256;
+const DEFAULT_FILE_GLOB_MAX_RESULTS = 5000;
+const MAX_FILE_GLOB_MAX_RESULTS = 50_000;
 
 class AcpParamError extends Error {}
+
+function parseOptionalPositiveInteger(
+  value: unknown,
+  fallback: number,
+  max: number,
+): number | null {
+  if (value === undefined) return fallback;
+  if (
+    typeof value !== 'number' ||
+    !Number.isSafeInteger(value) ||
+    value < 1 ||
+    value > max
+  ) {
+    return null;
+  }
+  return value;
+}
 
 /**
  * Validate an optional `cwd` param the same way the REST `POST /session`
@@ -1607,14 +1626,22 @@ export class AcpDispatcher {
             originatorClientId: conn.clientId,
             route: `ACP ${method}`,
           });
-          const MAX_GLOB = 5000;
-          const maxResults =
-            typeof params['maxResults'] === 'number'
-              ? Math.max(
-                  1,
-                  Math.min(Number(params['maxResults']) || 5000, 50000),
-                )
-              : MAX_GLOB;
+          const maxResults = parseOptionalPositiveInteger(
+            params['maxResults'],
+            DEFAULT_FILE_GLOB_MAX_RESULTS,
+            MAX_FILE_GLOB_MAX_RESULTS,
+          );
+          if (maxResults === null) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(
+                  id,
+                  RPC.INVALID_PARAMS,
+                  '`maxResults` must be an integer between 1 and 50000',
+                ),
+              );
+            return;
+          }
           const matches = await fs.glob(pattern, {
             maxResults: maxResults + 1,
           });

--- a/packages/cli/src/serve/acpHttp/transport.test.ts
+++ b/packages/cli/src/serve/acpHttp/transport.test.ts
@@ -18,6 +18,11 @@ import {
   SessionShellDisabledError,
 } from '@qwen-code/acp-bridge/bridgeErrors';
 import { SessionService } from '@qwen-code/qwen-code-core';
+import type {
+  ResolvedPath,
+  WorkspaceFileSystem,
+  WorkspaceFileSystemFactory,
+} from '../fs/index.js';
 import type { DaemonWorkspaceService } from '../workspace-service/types.js';
 import { mountAcpHttp } from './index.js';
 
@@ -329,6 +334,19 @@ const fakeWorkspace = {
   },
 } as unknown as DaemonWorkspaceService;
 
+function makeGlobFsFactory(glob: WorkspaceFileSystem['glob']) {
+  return {
+    forRequest: () =>
+      ({
+        glob,
+      }) as unknown as WorkspaceFileSystem,
+  } satisfies WorkspaceFileSystemFactory;
+}
+
+function resolvedPath(value: string): ResolvedPath {
+  return value as ResolvedPath;
+}
+
 // ── SSE client helper ────────────────────────────────────────────────
 async function* readSse(
   res: Response,
@@ -443,6 +461,7 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
   async function restartServer(opts: {
     sessionShellCommandEnabled?: boolean;
     nextBridge?: FakeBridge;
+    fsFactory?: WorkspaceFileSystemFactory;
   }): Promise<void> {
     server.closeAllConnections?.();
     await new Promise<void>((r) => server.close(() => r()));
@@ -453,6 +472,7 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
       boundWorkspace: '/ws',
       workspace: fakeWorkspace,
       enabled: true,
+      fsFactory: opts.fsFactory,
       sessionShellCommandEnabled: opts.sessionShellCommandEnabled,
     });
     await new Promise<void>((resolve) => {
@@ -2470,6 +2490,76 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
       const frames = await takeFrames(await streamRes, 1);
       expect(frames[0]).toMatchObject({ error: { code: -32602 } });
     });
+
+    it('_qwen/file/glob honors a valid maxResults limit', async () => {
+      const glob = vi.fn(async () => [
+        resolvedPath('a'),
+        resolvedPath('b'),
+        resolvedPath('c'),
+      ]);
+      await restartServer({ fsFactory: makeGlobFsFactory(glob) });
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 95,
+        method: '_qwen/file/glob',
+        params: { pattern: '**/*', maxResults: 2 },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({
+        result: {
+          pattern: '**/*',
+          matches: ['a', 'b'],
+          truncated: true,
+        },
+      });
+      expect(glob).toHaveBeenCalledWith('**/*', { maxResults: 3 });
+    });
+
+    it('_qwen/file/glob defaults maxResults when omitted', async () => {
+      const glob = vi.fn(async () => []);
+      await restartServer({ fsFactory: makeGlobFsFactory(glob) });
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 95,
+        method: '_qwen/file/glob',
+        params: { pattern: '**/*' },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({
+        result: {
+          pattern: '**/*',
+          matches: [],
+          truncated: false,
+        },
+      });
+      expect(glob).toHaveBeenCalledWith('**/*', { maxResults: 5001 });
+    });
+
+    it.each([0, -1, 1.5, 50_001, '2', null])(
+      '_qwen/file/glob rejects invalid maxResults (%s)',
+      async (maxResults) => {
+        const glob = vi.fn(async () => []);
+        await restartServer({ fsFactory: makeGlobFsFactory(glob) });
+        const connId = await initialize();
+        const streamRes = openStream(connId);
+        await new Promise((r) => setTimeout(r, 30));
+        await post(connId, {
+          jsonrpc: '2.0',
+          id: 95,
+          method: '_qwen/file/glob',
+          params: { pattern: '**/*', maxResults },
+        });
+        const frames = await takeFrames(await streamRes, 1);
+        expect(frames[0]).toMatchObject({ error: { code: -32602 } });
+        expect(glob).not.toHaveBeenCalled();
+      },
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- validate `_qwen/file/glob` `maxResults` as a safe integer in the supported `1..50000` range
- keep omitted `maxResults` defaulting to 5000
- return JSON-RPC `INVALID_PARAMS` before calling `fs.glob` for invalid values

Fixes #5479

## Test Plan

- `npm --workspace packages/cli run test -- src/serve/acpHttp/transport.test.ts`
- `npx prettier --check packages/cli/src/serve/acpHttp/dispatch.ts packages/cli/src/serve/acpHttp/transport.test.ts`
- `npx eslint packages/cli/src/serve/acpHttp/dispatch.ts packages/cli/src/serve/acpHttp/transport.test.ts`
- `npm --workspace packages/cli run typecheck`
- `npm run build -- --cli-only`
- `git diff --check`

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.