### PR TITLE
fix(cli): validate ACP file read windows

### DIFF
--- a/packages/cli/src/serve/acpHttp/dispatch.ts
+++ b/packages/cli/src/serve/acpHttp/dispatch.ts
@@ -31,7 +31,10 @@ import {
 } from '@qwen-code/acp-bridge/bridgeErrors';
 import { writeStderrLine } from '../../utils/stdioHelpers.js';
 import { MAX_WORKSPACE_PATH_LENGTH } from '../fs/paths.js';
-import type { WorkspaceFileSystemFactory } from '../fs/index.js';
+import {
+  MAX_READ_BYTES,
+  type WorkspaceFileSystemFactory,
+} from '../fs/index.js';
 import type { DeviceFlowRegistry } from '../auth/deviceFlow.js';
 import { collectWorkspaceMemoryStatus } from '../workspaceMemory.js';
 import {
@@ -155,6 +158,7 @@ const CONN_ROUTED_METHODS = new Set<string>([
 const MAX_NAME_LENGTH = 256;
 const DEFAULT_FILE_GLOB_MAX_RESULTS = 5000;
 const MAX_FILE_GLOB_MAX_RESULTS = 50_000;
+const MAX_FILE_LINE_LIMIT = 2000;
 
 class AcpParamError extends Error {}
 
@@ -168,6 +172,23 @@ function parseOptionalPositiveInteger(
     typeof value !== 'number' ||
     !Number.isSafeInteger(value) ||
     value < 1 ||
+    value > max
+  ) {
+    return null;
+  }
+  return value;
+}
+
+function parseOptionalSafeIntegerInRange(
+  value: unknown,
+  min: number,
+  max: number,
+): number | null | undefined {
+  if (value === undefined) return undefined;
+  if (
+    typeof value !== 'number' ||
+    !Number.isSafeInteger(value) ||
+    value < min ||
     value > max
   ) {
     return null;
@@ -1500,17 +1521,56 @@ export class AcpDispatcher {
             originatorClientId: conn.clientId,
             route: `ACP ${method}`,
           });
+          const maxBytes = parseOptionalSafeIntegerInRange(
+            params['maxBytes'],
+            1,
+            MAX_READ_BYTES,
+          );
+          if (maxBytes === null) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(
+                  id,
+                  RPC.INVALID_PARAMS,
+                  `\`maxBytes\` must be a positive integer in [1, ${MAX_READ_BYTES}]`,
+                ),
+              );
+            return;
+          }
+          const line = parseOptionalSafeIntegerInRange(
+            params['line'],
+            1,
+            Number.MAX_SAFE_INTEGER,
+          );
+          if (line === null) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(
+                  id,
+                  RPC.INVALID_PARAMS,
+                  '`line` must be a positive integer',
+                ),
+              );
+            return;
+          }
+          const limit = parseOptionalSafeIntegerInRange(
+            params['limit'],
+            1,
+            MAX_FILE_LINE_LIMIT,
+          );
+          if (limit === null) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(
+                  id,
+                  RPC.INVALID_PARAMS,
+                  `\`limit\` must be a positive integer in [1, ${MAX_FILE_LINE_LIMIT}]`,
+                ),
+              );
+            return;
+          }
           const resolved = await fs.resolve(p, 'read');
-          const out = await fs.readText(resolved, {
-            maxBytes:
-              typeof params['maxBytes'] === 'number'
-                ? params['maxBytes']
-                : undefined,
-            line:
-              typeof params['line'] === 'number' ? params['line'] : undefined,
-            limit:
-              typeof params['limit'] === 'number' ? params['limit'] : undefined,
-          });
+          const out = await fs.readText(resolved, { maxBytes, line, limit });
           this.replyConn(conn, id, {
             path: p,
             content: out.content,
@@ -1537,17 +1597,40 @@ export class AcpDispatcher {
             originatorClientId: conn.clientId,
             route: `ACP ${method}`,
           });
+          const offset = parseOptionalSafeIntegerInRange(
+            params['offset'],
+            0,
+            Number.MAX_SAFE_INTEGER,
+          );
+          if (offset === null) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(
+                  id,
+                  RPC.INVALID_PARAMS,
+                  '`offset` must be a non-negative safe integer',
+                ),
+              );
+            return;
+          }
+          const maxBytes = parseOptionalSafeIntegerInRange(
+            params['maxBytes'],
+            1,
+            MAX_READ_BYTES,
+          );
+          if (maxBytes === null) {
+            if (id !== undefined)
+              conn.sendConn(
+                error(
+                  id,
+                  RPC.INVALID_PARAMS,
+                  `\`maxBytes\` must be a positive integer in [1, ${MAX_READ_BYTES}]`,
+                ),
+              );
+            return;
+          }
           const resolved = await fs.resolve(p, 'read');
-          const buf = await fs.readBytesWindow(resolved, {
-            offset:
-              typeof params['offset'] === 'number'
-                ? params['offset']
-                : undefined,
-            maxBytes:
-              typeof params['maxBytes'] === 'number'
-                ? params['maxBytes']
-                : undefined,
-          });
+          const buf = await fs.readBytesWindow(resolved, { offset, maxBytes });
           this.replyConn(conn, id, { path: p, ...buf } as unknown);
           return;
         }

--- a/packages/cli/src/serve/acpHttp/transport.test.ts
+++ b/packages/cli/src/serve/acpHttp/transport.test.ts
@@ -18,10 +18,11 @@ import {
   SessionShellDisabledError,
 } from '@qwen-code/acp-bridge/bridgeErrors';
 import { SessionService } from '@qwen-code/qwen-code-core';
-import type {
-  ResolvedPath,
-  WorkspaceFileSystem,
-  WorkspaceFileSystemFactory,
+import {
+  MAX_READ_BYTES,
+  type ResolvedPath,
+  type WorkspaceFileSystem,
+  type WorkspaceFileSystemFactory,
 } from '../fs/index.js';
 import type { DaemonWorkspaceService } from '../workspace-service/types.js';
 import { mountAcpHttp } from './index.js';
@@ -345,6 +346,18 @@ function makeGlobFsFactory(glob: WorkspaceFileSystem['glob']) {
 
 function resolvedPath(value: string): ResolvedPath {
   return value as ResolvedPath;
+}
+
+function makeFileFsFactory(
+  overrides: Partial<Record<keyof WorkspaceFileSystem, unknown>>,
+) {
+  return {
+    forRequest: () =>
+      ({
+        resolve: vi.fn(async (input: string) => resolvedPath(`/ws/${input}`)),
+        ...overrides,
+      }) as unknown as WorkspaceFileSystem,
+  } satisfies WorkspaceFileSystemFactory;
 }
 
 // ── SSE client helper ────────────────────────────────────────────────
@@ -2448,6 +2461,211 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
       const frames = await takeFrames(await streamRes, 1);
       expect(frames[0]).toMatchObject({ error: { code: -32602 } });
     });
+
+    it('_qwen/file/read forwards valid window parameters', async () => {
+      const readText = vi.fn(async () => ({
+        content: 'hello',
+        meta: { truncated: false },
+      }));
+      await restartServer({
+        fsFactory: makeFileFsFactory({ readText }),
+      });
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 92,
+        method: '_qwen/file/read',
+        params: { path: 'test.txt', maxBytes: 10, line: 2, limit: 1 },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({
+        result: { path: 'test.txt', content: 'hello', truncated: false },
+      });
+      expect(readText).toHaveBeenCalledWith(resolvedPath('/ws/test.txt'), {
+        maxBytes: 10,
+        line: 2,
+        limit: 1,
+      });
+    });
+
+    it('_qwen/file/read preserves defaults when window parameters are omitted', async () => {
+      const readText = vi.fn(async () => ({
+        content: 'hello',
+        meta: { truncated: false },
+      }));
+      await restartServer({
+        fsFactory: makeFileFsFactory({ readText }),
+      });
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 92,
+        method: '_qwen/file/read',
+        params: { path: 'test.txt' },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({
+        result: { path: 'test.txt', content: 'hello', truncated: false },
+      });
+      expect(readText).toHaveBeenCalledWith(resolvedPath('/ws/test.txt'), {
+        maxBytes: undefined,
+        line: undefined,
+        limit: undefined,
+      });
+    });
+
+    it.each([
+      { maxBytes: 0 },
+      { maxBytes: MAX_READ_BYTES + 1 },
+      { maxBytes: 1.5 },
+      { maxBytes: '1' },
+      { maxBytes: null },
+      { line: 0 },
+      { line: Number.MAX_SAFE_INTEGER + 1 },
+      { line: 1.5 },
+      { line: '2' },
+      { line: null },
+      { limit: 0 },
+      { limit: 2001 },
+      { limit: 1.5 },
+      { limit: '1' },
+      { limit: null },
+    ])('_qwen/file/read rejects invalid window params (%j)', async (params) => {
+      const readText = vi.fn(async () => ({
+        content: 'hello',
+        meta: { truncated: false },
+      }));
+      await restartServer({
+        fsFactory: makeFileFsFactory({ readText }),
+      });
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 92,
+        method: '_qwen/file/read',
+        params: { path: 'test.txt', ...params },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({ error: { code: -32602 } });
+      expect(readText).not.toHaveBeenCalled();
+    });
+
+    it('_qwen/file/read_bytes forwards valid window parameters', async () => {
+      const readBytesWindow = vi.fn(async () => ({
+        buffer: Buffer.from('ell'),
+        offset: 1,
+        sizeBytes: 5,
+        returnedBytes: 3,
+        truncated: true,
+      }));
+      await restartServer({
+        fsFactory: makeFileFsFactory({ readBytesWindow }),
+      });
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 93,
+        method: '_qwen/file/read_bytes',
+        params: { path: 'test.txt', offset: 1, maxBytes: 3 },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({
+        result: {
+          path: 'test.txt',
+          offset: 1,
+          sizeBytes: 5,
+          returnedBytes: 3,
+          truncated: true,
+        },
+      });
+      expect(readBytesWindow).toHaveBeenCalledWith(
+        resolvedPath('/ws/test.txt'),
+        { offset: 1, maxBytes: 3 },
+      );
+    });
+
+    it('_qwen/file/read_bytes preserves defaults when window parameters are omitted', async () => {
+      const readBytesWindow = vi.fn(async () => ({
+        buffer: Buffer.from('hello'),
+        offset: 0,
+        sizeBytes: 5,
+        returnedBytes: 5,
+        truncated: false,
+      }));
+      await restartServer({
+        fsFactory: makeFileFsFactory({ readBytesWindow }),
+      });
+      const connId = await initialize();
+      const streamRes = openStream(connId);
+      await new Promise((r) => setTimeout(r, 30));
+      await post(connId, {
+        jsonrpc: '2.0',
+        id: 93,
+        method: '_qwen/file/read_bytes',
+        params: { path: 'test.txt' },
+      });
+      const frames = await takeFrames(await streamRes, 1);
+      expect(frames[0]).toMatchObject({
+        result: {
+          path: 'test.txt',
+          offset: 0,
+          sizeBytes: 5,
+          returnedBytes: 5,
+          truncated: false,
+        },
+      });
+      expect(readBytesWindow).toHaveBeenCalledWith(
+        resolvedPath('/ws/test.txt'),
+        { offset: undefined, maxBytes: undefined },
+      );
+    });
+
+    it.each([
+      { offset: -1 },
+      { offset: Number.MAX_SAFE_INTEGER + 1 },
+      { offset: 1.5 },
+      { offset: '1' },
+      { offset: null },
+      { maxBytes: 0 },
+      { maxBytes: MAX_READ_BYTES + 1 },
+      { maxBytes: 1.5 },
+      { maxBytes: '1' },
+      { maxBytes: null },
+    ])(
+      '_qwen/file/read_bytes rejects invalid window params (%j)',
+      async (params) => {
+        const readBytesWindow = vi.fn(async () => ({
+          buffer: Buffer.from('hello'),
+          offset: 0,
+          sizeBytes: 5,
+          returnedBytes: 5,
+          truncated: false,
+        }));
+        await restartServer({
+          fsFactory: makeFileFsFactory({ readBytesWindow }),
+        });
+        const connId = await initialize();
+        const streamRes = openStream(connId);
+        await new Promise((r) => setTimeout(r, 30));
+        await post(connId, {
+          jsonrpc: '2.0',
+          id: 93,
+          method: '_qwen/file/read_bytes',
+          params: { path: 'test.txt', ...params },
+        });
+        const frames = await takeFrames(await streamRes, 1);
+        expect(frames[0]).toMatchObject({ error: { code: -32602 } });
+        expect(readBytesWindow).not.toHaveBeenCalled();
+      },
+    );
 
     it('_qwen/file/write rejects missing content', async () => {
       const connId = await initialize();


### PR DESCRIPTION
## What this PR does

This PR validates ACP `_qwen/file/read` window parameters before calling the file system, and validates `_qwen/file/read_bytes` offset and maxBytes parameters before byte reads. It adds transport coverage for valid params, omitted defaults, and invalid window values.

## Why it's needed

ACP file reads should reject malformed window values at the transport boundary instead of letting partial parses or invalid numeric values reach file-system logic. That keeps the method contract predictable for IDE and HTTP callers.

## Reviewer Test Plan

### How to verify

Run the focused ACP HTTP transport file-method tests. Confirm valid and omitted window params still work, while invalid `startLine`, `limit`, `offset`, or `maxBytes` values return validation errors before a file read is attempted.

### Evidence (Before & After)

Before: malformed ACP file-read window params could pass through to the file-system call path.

After: invalid window params are rejected at dispatch/transport validation; valid and omitted defaults continue to work.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested locally with focused unit tests |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Local validation used the CLI package test runner for `src/serve/acpHttp/transport.test.ts`.

## Risk & Scope

- Main risk or tradeoff: callers sending malformed numeric strings now receive validation errors instead of best-effort behavior.
- Not validated / out of scope: no real IDE client run; this is covered through ACP HTTP transport tests.
- Breaking changes / migration notes: valid requests keep the same behavior.

## Linked Issues

Fixes #5481

## Testing

- `npm --workspace packages/cli run test -- src/serve/acpHttp/transport.test.ts -t "file methods"`
- `npm --workspace packages/cli run test -- src/serve/acpHttp/transport.test.ts`
- `npx prettier --check packages/cli/src/serve/acpHttp/dispatch.ts packages/cli/src/serve/acpHttp/transport.test.ts`
- `npx eslint packages/cli/src/serve/acpHttp/dispatch.ts packages/cli/src/serve/acpHttp/transport.test.ts`
- `npm --workspace packages/cli run typecheck`
- `npm run build -- --cli-only`
- `git diff --check`

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 在调用文件系统前校验 ACP `_qwen/file/read` 的窗口参数，并在 byte read 前校验 `_qwen/file/read_bytes` 的 offset 和 maxBytes 参数。同时补充了 valid params、默认省略值和非法窗口参数的 transport 测试。

## 为什么需要

ACP 文件读取应该在 transport 边界拒绝畸形窗口值，而不是让部分解析或非法数字进入文件系统逻辑。这样 IDE 和 HTTP 调用方看到的方法合约更稳定。

## Reviewer 测试计划

### 如何验证

运行聚焦的 ACP HTTP transport file-method 测试。确认合法和省略的窗口参数仍然可用，非法 `startLine`、`limit`、`offset` 或 `maxBytes` 会在读取文件前返回校验错误。

### 前后证据

之前：畸形 ACP file-read 窗口参数可能进入文件系统调用路径。

之后：非法窗口参数会在 dispatch/transport 校验处被拒绝；合法值和省略默认值行为不变。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ 本地聚焦单测已验证 |
| 🪟 Windows | ⚠️ 未本地验证 |
|  🐧 Linux  | ⚠️ 未本地验证 |

### 环境

本地验证使用 CLI package test runner，目标测试为 `src/serve/acpHttp/transport.test.ts`。

## 风险与范围

- 主要风险或取舍：发送畸形数字字符串的调用方现在会收到校验错误，不再走 best-effort 行为。
- 未验证 / 不在范围内：没有跑真实 IDE client；本 PR 通过 ACP HTTP transport 测试覆盖。
- 破坏性变更 / 迁移说明：合法请求行为不变。

## 关联 Issue

Fixes #5481

## 测试

- `npm --workspace packages/cli run test -- src/serve/acpHttp/transport.test.ts -t "file methods"`
- `npm --workspace packages/cli run test -- src/serve/acpHttp/transport.test.ts`
- `npx prettier --check packages/cli/src/serve/acpHttp/dispatch.ts packages/cli/src/serve/acpHttp/transport.test.ts`
- `npx eslint packages/cli/src/serve/acpHttp/dispatch.ts packages/cli/src/serve/acpHttp/transport.test.ts`
- `npm --workspace packages/cli run typecheck`
- `npm run build -- --cli-only`
- `git diff --check`

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
