### PR TITLE
fix(serve): validate session reaper timeouts

### DIFF
--- a/packages/cli/src/serve/runQwenServe.test.ts
+++ b/packages/cli/src/serve/runQwenServe.test.ts
@@ -316,6 +316,83 @@ describe('runQwenServe permissionResponseTimeoutMs validation', () => {
   });
 });
 
+describe('runQwenServe session reaper timeout validation', () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  function makeFakeBridge(): HttpAcpBridge {
+    return {
+      spawnOrAttach: vi.fn(),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+      killAllSync: vi.fn(),
+      getSession: vi.fn(),
+      getAllSessions: vi.fn().mockReturnValue([]),
+      publishWorkspaceEvent: vi.fn(),
+      getEventRing: vi.fn().mockReturnValue({ getAll: () => [] }),
+      resume: vi.fn(),
+      preheat: vi.fn().mockResolvedValue(undefined),
+    } as unknown as HttpAcpBridge;
+  }
+
+  async function runWithReaperOption(
+    optionName: 'sessionReapIntervalMs' | 'sessionIdleTimeoutMs',
+    value: number,
+  ) {
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'qws-rt-')));
+    const origEnv = process.env['QWEN_RUNTIME_DIR'];
+    process.env['QWEN_RUNTIME_DIR'] = tmpDir;
+    try {
+      return await runQwenServe(
+        {
+          port: 0,
+          hostname: '127.0.0.1',
+          mode: 'http-bridge',
+          workspace: tmpDir,
+          maxSessions: 1,
+          [optionName]: value,
+        },
+        { bridge: makeFakeBridge() },
+      );
+    } finally {
+      delete process.env['QWEN_RUNTIME_DIR'];
+      if (origEnv !== undefined) {
+        process.env['QWEN_RUNTIME_DIR'] = origEnv;
+      }
+    }
+  }
+
+  it.each([
+    ['sessionReapIntervalMs', -1],
+    ['sessionReapIntervalMs', 1.5],
+    ['sessionReapIntervalMs', Number.NaN],
+    ['sessionReapIntervalMs', Number.POSITIVE_INFINITY],
+    ['sessionIdleTimeoutMs', -1],
+    ['sessionIdleTimeoutMs', 1.5],
+    ['sessionIdleTimeoutMs', Number.NaN],
+    ['sessionIdleTimeoutMs', Number.POSITIVE_INFINITY],
+  ] as const)('rejects invalid %s=%s', async (optionName, value) => {
+    await expect(runWithReaperOption(optionName, value)).rejects.toThrow(
+      optionName,
+    );
+  });
+
+  it.each([
+    ['sessionReapIntervalMs', 0],
+    ['sessionIdleTimeoutMs', 0],
+  ] as const)(
+    'keeps %s=0 as the disabled sentinel',
+    async (optionName, value) => {
+      const handle = await runWithReaperOption(optionName, value);
+      await handle.close();
+    },
+  );
+});
+
 describe('runQwenServe Web Shell signals on RunHandle', () => {
   let tmpDir: string;
 

--- a/packages/cli/src/serve/runQwenServe.ts
+++ b/packages/cli/src/serve/runQwenServe.ts
@@ -94,6 +94,10 @@ function isNonNegativeIntegerOrInfinity(value: number): boolean {
   );
 }
 
+function isNonNegativeIntegerMs(value: number): boolean {
+  return Number.isFinite(value) && Number.isInteger(value) && value >= 0;
+}
+
 const MAX_TIMEOUT_MS = 2_147_483_647;
 
 function assertTimerDelayInRange(name: string, value: number): void {
@@ -696,6 +700,20 @@ export async function runQwenServe(
     ) {
       throw new TypeError(
         `Invalid channelIdleTimeoutMs: ${opts.channelIdleTimeoutMs}. Must be a non-negative integer (milliseconds, 0 = immediate kill).`,
+      );
+    }
+  }
+  if (opts.sessionReapIntervalMs !== undefined) {
+    if (!isNonNegativeIntegerMs(opts.sessionReapIntervalMs)) {
+      throw new TypeError(
+        `Invalid sessionReapIntervalMs: ${opts.sessionReapIntervalMs}. Must be a non-negative integer (milliseconds, 0 = disabled).`,
+      );
+    }
+  }
+  if (opts.sessionIdleTimeoutMs !== undefined) {
+    if (!isNonNegativeIntegerMs(opts.sessionIdleTimeoutMs)) {
+      throw new TypeError(
+        `Invalid sessionIdleTimeoutMs: ${opts.sessionIdleTimeoutMs}. Must be a non-negative integer (milliseconds, 0 = disabled).`,
       );
     }
   }


### PR DESCRIPTION
## Summary

- reject invalid `sessionReapIntervalMs` values at daemon boot
- reject invalid `sessionIdleTimeoutMs` values at daemon boot
- keep `0` as the documented disabled sentinel for both reaper options

Fixes #5483

## Test Plan

- `npm --workspace packages/cli run test -- src/serve/runQwenServe.test.ts -t "session reaper timeout validation"`
- `npm --workspace packages/cli run test -- src/serve/runQwenServe.test.ts`
- `npx prettier --check packages/cli/src/serve/runQwenServe.ts packages/cli/src/serve/runQwenServe.test.ts`
- `npx eslint packages/cli/src/serve/runQwenServe.ts packages/cli/src/serve/runQwenServe.test.ts`
- `npm --workspace packages/cli run typecheck`
- `npm run build -- --cli-only`
- `git diff --check`

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
