### PR TITLE
fix(cli): reject partial cpu profile durations

### DIFF
--- a/packages/cli/src/ui/commands/doctorCommand.test.ts
+++ b/packages/cli/src/ui/commands/doctorCommand.test.ts
@@ -10,11 +10,13 @@ import { type CommandContext } from './types.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 import * as doctorChecksModule from '../../utils/doctorChecks.js';
 import * as memoryDiagnosticsModule from '../../utils/memoryDiagnostics.js';
+import * as cpuProfilerModule from '../../utils/cpuProfiler.js';
 import { collectMemoryDiagnostics } from '@qwen-code/qwen-code-core';
 import type { DoctorCheckResult } from '../types.js';
 
 vi.mock('../../utils/doctorChecks.js');
 vi.mock('../../utils/memoryDiagnostics.js');
+vi.mock('../../utils/cpuProfiler.js');
 vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@qwen-code/qwen-code-core')>()),
   collectMemoryDiagnostics: vi.fn(),
@@ -109,6 +111,14 @@ describe('doctorCommand', () => {
 
     vi.mocked(doctorChecksModule.runDoctorChecks).mockResolvedValue(mockChecks);
     mockMemoryDiagnostics();
+    vi.mocked(cpuProfilerModule.isCpuProfileRecording).mockReturnValue(false);
+    vi.mocked(cpuProfilerModule.startCpuProfile).mockResolvedValue({
+      ok: true,
+    });
+    vi.mocked(cpuProfilerModule.stopCpuProfile).mockResolvedValue({
+      ok: true,
+      filePath: '/tmp/qwen-code.cpuprofile',
+    });
     vi.mocked(collectMemoryDiagnostics).mockResolvedValue({
       timestamp: '2026-05-01T10:00:00.000Z',
       uptimeSeconds: 60,
@@ -1060,5 +1070,38 @@ describe('doctorCommand', () => {
     expect(doctorCommand.argumentHint).toBe(
       '[memory|cpu-profile|rollback] [--sample] [--snapshot] [--duration]',
     );
+  });
+
+  it('should reject non-integer cpu profile durations before recording', async () => {
+    mockContext = createMockCommandContext({
+      executionMode: 'non_interactive',
+      ui: {
+        addItem: vi.fn(),
+        setPendingItem: vi.fn(),
+      },
+    } as unknown as CommandContext);
+
+    for (const duration of ['1.5', '2s']) {
+      vi.mocked(cpuProfilerModule.startCpuProfile).mockClear();
+
+      const result = await doctorCommand.action!(
+        mockContext,
+        `cpu-profile --duration ${duration}`,
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          type: 'message',
+          messageType: 'error',
+          content: expect.stringContaining(
+            'Usage: /doctor cpu-profile [--duration <seconds>]',
+          ),
+        }),
+      );
+      expect(result?.type === 'message' ? result.content : '').toContain(
+        'Duration must be between 1 and',
+      );
+      expect(cpuProfilerModule.startCpuProfile).not.toHaveBeenCalled();
+    }
   });
 });

--- a/packages/cli/src/ui/commands/doctorCommand.ts
+++ b/packages/cli/src/ui/commands/doctorCommand.ts
@@ -442,6 +442,13 @@ const CPU_PROFILE_USAGE_HINT = '/doctor cpu-profile [--duration <seconds>]';
 const DEFAULT_CPU_PROFILE_DURATION_SEC = 30;
 const MAX_CPU_PROFILE_DURATION_SEC = 300;
 
+function parseCpuProfileDuration(raw: string | undefined): number {
+  if (!raw || !/^\d+$/.test(raw)) {
+    return NaN;
+  }
+  return Number(raw);
+}
+
 async function cpuProfileDoctorAction(
   context: CommandContext,
   args = '',
@@ -462,7 +469,7 @@ async function cpuProfileDoctorAction(
   const durationIdx = tokens.indexOf('--duration');
   if (durationIdx !== -1) {
     const rawVal = tokens[durationIdx + 1];
-    const val = rawVal ? parseInt(rawVal, 10) : NaN;
+    const val = parseCpuProfileDuration(rawVal);
     if (
       !Number.isFinite(val) ||
       val < 1 ||


### PR DESCRIPTION
## What this PR does

Parses `/doctor cpu-profile --duration` with strict whole-token integer validation instead of `parseInt`.

Malformed values like `1.5` and `2s` are rejected before CPU profiling starts, while valid integer durations keep the existing 1 to 300 second range check.

## Why it's needed

`parseInt` accepts partial numeric tokens. That means `/doctor cpu-profile --duration 1.5` was treated as `1`, and `--duration 2s` was treated as `2`. Those values should be invalid user input, not silently truncated.

## Reviewer Test Plan

### How to verify

Review the duration parser and the doctor command regression test. Invalid partial numeric values should return the usage error and must not call `startCpuProfile`.

Run:

```bash
npm --workspace packages/cli test -- doctorCommand.test.ts --coverage.enabled=false
npx prettier --check packages/cli/src/ui/commands/doctorCommand.ts packages/cli/src/ui/commands/doctorCommand.test.ts
npx eslint packages/cli/src/ui/commands/doctorCommand.ts packages/cli/src/ui/commands/doctorCommand.test.ts
npm --workspace packages/cli run typecheck
npm run build -- --cli-only
```

### Evidence (Before & After)

Before: `parseInt('1.5', 10)` produced `1`, and `parseInt('2s', 10)` produced `2`, so both passed validation.

After: duration input must match a whole decimal token before conversion. Partial numeric values are rejected and the profiler is not started.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS     | tested |
|  Windows   | covered by CI |
|  Linux     | covered by CI |

### Environment (optional)

Local Node/npm CLI workspace tests.

## Risk & Scope

- Main risk or tradeoff: stricter parsing rejects values that were previously accepted by truncation.
- Not validated / out of scope: changing CPU profile recording behavior after a valid duration is accepted.
- Breaking changes / migration notes: malformed duration values now fail loudly instead of being truncated.

## Linked Issues

Fixes #5485

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 `/doctor cpu-profile --duration` 的解析从 `parseInt` 改成严格的完整整数 token 校验。

`1.5`、`2s` 这类格式错误的值会在 CPU profiling 启动前被拒绝；合法整数仍然沿用原来的 1 到 300 秒范围校验。

## 为什么需要

`parseInt` 会接受部分数字 token：`/doctor cpu-profile --duration 1.5` 会被当成 `1`，`--duration 2s` 会被当成 `2`。这些应该是无效输入，不应该被静默截断。

## Reviewer Test Plan

### How to verify

检查 duration parser 和 doctor command 回归测试：部分数字值应返回 usage error，并且不应调用 `startCpuProfile`。

### Evidence (Before & After)

修复前：`parseInt('1.5', 10)` 得到 `1`，`parseInt('2s', 10)` 得到 `2`，两者都会通过校验。

修复后：duration 必须先匹配完整十进制整数 token 才会转换；部分数字值会被拒绝，profiler 不会启动。

### Tested on

本地跑过 CLI workspace 相关 Node/npm 测试；Windows 和 Linux 由 CI 覆盖。

## Risk & Scope

主要变化是更严格地拒绝过去被截断接受的 duration 值。不改变合法 duration 通过后的 CPU profile 录制行为。格式错误的 duration 现在会明确失败，不再静默截断。

</details>
