### PR TITLE
Use VS Code theme tokens for companion scrollbar

### DIFF
--- a/packages/vscode-ide-companion/src/webview/App.tsx
+++ b/packages/vscode-ide-companion/src/webview/App.tsx
@@ -1532,7 +1532,7 @@ export const App: React.FC = () => {
 
       <div
         ref={messagesContainerRef}
-        className="chat-messages messages-container flex-1 overflow-y-auto overflow-x-hidden pt-5 pr-5 pl-5 pb-[140px] flex flex-col relative min-w-0 focus:outline-none [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-white/20 [&::-webkit-scrollbar-thumb]:rounded-sm [&::-webkit-scrollbar-thumb]:hover:bg-white/30 [&>*]:flex [&>*]:gap-0 [&>*]:items-start [&>*]:text-left [&>*]:py-2 [&>*:not(:last-child)]:pb-[8px] [&>*]:flex-col [&>*]:relative [&>*]:animate-[fadeIn_0.2s_ease-in]"
+        className="chat-messages messages-container flex-1 overflow-y-auto overflow-x-hidden pt-5 pr-5 pl-5 pb-[140px] flex flex-col relative min-w-0 focus:outline-none [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-sm [&>*]:flex [&>*]:gap-0 [&>*]:items-start [&>*]:text-left [&>*]:py-2 [&>*:not(:last-child)]:pb-[8px] [&>*]:flex-col [&>*]:relative [&>*]:animate-[fadeIn_0.2s_ease-in]"
         data-vscode-context={
           hasContent ? '{"webviewSection": "chat-messages"}' : undefined
         }

--- a/packages/vscode-ide-companion/src/webview/styles/App.css
+++ b/packages/vscode-ide-companion/src/webview/styles/App.css
@@ -93,6 +93,16 @@
   --app-list-border-radius: 4px;
   --app-list-gap: 2px;
 
+  /* Scrollbars - VSCode tokens */
+  --app-scrollbar-thumb: var(
+    --vscode-scrollbarSlider-background,
+    rgba(128, 128, 128, 0.35)
+  );
+  --app-scrollbar-thumb-hover: var(
+    --vscode-scrollbarSlider-hoverBackground,
+    rgba(128, 128, 128, 0.5)
+  );
+
   /* Buttons - VSCode tokens */
   --app-ghost-button-hover-background: var(--vscode-toolbar-hoverBackground);
   --app-button-foreground: var(
@@ -175,4 +185,13 @@ button {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+}
+
+.messages-container::-webkit-scrollbar-thumb {
+  background: var(--app-scrollbar-thumb);
+  border-radius: var(--corner-radius-small);
+}
+
+.messages-container::-webkit-scrollbar-thumb:hover {
+  background: var(--app-scrollbar-thumb-hover);
 }


### PR DESCRIPTION
## What this PR does

I just couldn't see the scrollbar without hunting with my mouse pointer up & down the height of the scroll area (unless the chat session was all the way at the start, or all the way at the end, in which case I 'knew where to hunt').

So to try to make scrollbar visible with a light theme:

- replace hardcoded white scrollbar thumb colors in the VS Code IDE companion chat view
- map the scrollbar thumb and hover colors to VS Code `scrollbarSlider` theme tokens
- keep the existing scrollbar width, track, and rounded thumb styling unchanged

## Why it's needed

In light themes, the companion webview scrollbar can be effectively invisible until hover because the thumb color is hardcoded as translucent white in `App.tsx`. This is especially noticeable in customized light themes where the secondary sidebar background is close to the thumb color.

This patch moves the scrollbar thumb colors to `App.css` and sources them from VS Code theme tokens:
- `--vscode-scrollbarSlider-background`
- `--vscode-scrollbarSlider-hoverBackground`

Fallback values are included so the webview still renders reasonably if those tokens are unavailable.

## User-visible result
The idle scrollbar now tracks the active VS Code theme instead of staying hardcoded, so it remains visible in light themes and still behaves correctly on hover.

## Reviewer Test Plan (with How to verify, Before & After evidence, and Tested on table)

### How to verify:

Open VS Code with a light theme (e.g. “Light+” or “GitHub Light”)
Open the Companion chat panel (any chat session)
Observe the scrollbar thumb in the chat message area — it should be visibly distinct from the track/background
Scroll up and down — the hover state should also be visible
Switch to a dark theme (e.g. “Dark+” or “GitHub Dark”) — scrollbar should still be visible and consistent with the theme

### Before & After:

Before: scrollbar thumb is hardcoded translucent white — effectively invisible against light theme backgrounds until hovered
After: scrollbar thumb uses --vscode-scrollbarSlider-background / --vscode-scrollbarSlider-hoverBackground — adapts to the active theme, visible in both light and dark themes

### Tested on:

Environment	Result
VS Code (light theme, e.g. Light+)	 visible
VS Code (dark theme, e.g. Dark+)	 visible
VS Code (custom light theme)	 adapts via tokens

VScode:

Version: 1.125.1
Commit: fcf604774b9f2674b473065736ee75077e256353
Date: 2026-06-19T08:39:34Z
Electron: 42.2.0
ElectronBuildId: 14159160
Chromium: 148.0.7778.97
Node.js: 24.15.0
V8: 14.8.178.14-electron.0
OS: Linux x64 6.17.0-35-generic

Qwen Code Companion:

Identifier
qwenlm.qwen-code-vscode-ide-companion
Version
0.18.4

VScode Themes:

GrayJack’s Gruvbox Dark
GrayJack’s Gruvbox Light

## Risk & Scope

- Scope: CSS-only change in the companion webview’s scrollbar styling. No JS logic, no API, no build changes.
- Risk: Low. The only behavioral change is visual — scrollbar thumb color now derives from VS Code theme tokens instead of being hardcoded. Fallback values ensure graceful degradation if tokens are unavailable.
- No regressions expected in functionality, performance, or other UI components.

## Linked Issues

Fixes the invisible scrollbar issue in light themes for the Companion chat view.

## Chinese summary section

<details>
<summary>中文摘要</summary>

此 PR 将 VS Code IDE 伴侣聊天视图中的滚动条颜色从硬编码的半透明白色改为使用 VS Code 主题令牌（--vscode-scrollbarSlider-background 和 --vscode-scrollbarSlider-hoverBackground）。在浅色主题下，硬编码的白色滚动条几乎不可见。修复后，滚动条颜色会跟随当前 VS Code 主题，确保在浅色和深色主题下都可见。

</details>