### PR TITLE
fix(core): parse max output token env strictly

### DIFF
--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -70,16 +70,20 @@ const importConverter = async (): Promise<{
 }> => import('./converter.js');
 
 describe('AnthropicContentGenerator', () => {
+  const MAX_OUTPUT_TOKENS_ENV = 'QWEN_CODE_MAX_OUTPUT_TOKENS';
   let mockConfig: Config;
   let anthropicState: {
     constructorOptions?: Record<string, unknown>;
     lastCreateArgs?: AnthropicCreateArgs;
     createImpl: ReturnType<typeof vi.fn>;
   };
+  let savedMaxOutputTokensEnv: string | undefined;
 
   beforeEach(async () => {
     vi.clearAllMocks();
     vi.resetModules();
+    savedMaxOutputTokensEnv = process.env[MAX_OUTPUT_TOKENS_ENV];
+    delete process.env[MAX_OUTPUT_TOKENS_ENV];
 
     mockTokenizer.calculateTokens.mockResolvedValue({
       totalTokens: 50,
@@ -106,6 +110,11 @@ describe('AnthropicContentGenerator', () => {
   });
 
   afterEach(() => {
+    if (savedMaxOutputTokensEnv === undefined) {
+      delete process.env[MAX_OUTPUT_TOKENS_ENV];
+    } else {
+      process.env[MAX_OUTPUT_TOKENS_ENV] = savedMaxOutputTokensEnv;
+    }
     vi.restoreAllMocks();
   });
 
@@ -1617,6 +1626,75 @@ describe('AnthropicContentGenerator', () => {
           anthropicState.lastCreateArgs as AnthropicCreateArgs;
         expect(anthropicRequest).toEqual(
           expect.objectContaining({ max_tokens: 8000 }),
+        );
+      });
+
+      it('ignores malformed QWEN_CODE_MAX_OUTPUT_TOKENS values', async () => {
+        const { AnthropicContentGenerator } = await importGenerator();
+
+        for (const envValue of ['1.5', '2k', 'abc']) {
+          process.env[MAX_OUTPUT_TOKENS_ENV] = envValue;
+          anthropicState.createImpl.mockResolvedValueOnce({
+            id: `anthropic-${envValue}`,
+            model: 'claude-sonnet-4',
+            content: [{ type: 'text', text: 'hi' }],
+          });
+
+          const generator = new AnthropicContentGenerator(
+            {
+              model: 'claude-sonnet-4',
+              apiKey: 'test-key',
+              timeout: 10_000,
+              maxRetries: 2,
+              samplingParams: {},
+              schemaCompliance: 'auto',
+            },
+            mockConfig,
+          );
+
+          await generator.generateContent({
+            model: 'models/ignored',
+            contents: 'Hello',
+          } as unknown as GenerateContentParameters);
+
+          const [anthropicRequest] =
+            anthropicState.lastCreateArgs as AnthropicCreateArgs;
+          expect(anthropicRequest).toEqual(
+            expect.objectContaining({ max_tokens: 8000 }),
+          );
+        }
+      });
+
+      it('respects a valid QWEN_CODE_MAX_OUTPUT_TOKENS value', async () => {
+        const { AnthropicContentGenerator } = await importGenerator();
+        process.env[MAX_OUTPUT_TOKENS_ENV] = '9000';
+        anthropicState.createImpl.mockResolvedValue({
+          id: 'anthropic-1',
+          model: 'claude-sonnet-4',
+          content: [{ type: 'text', text: 'hi' }],
+        });
+
+        const generator = new AnthropicContentGenerator(
+          {
+            model: 'claude-sonnet-4',
+            apiKey: 'test-key',
+            timeout: 10_000,
+            maxRetries: 2,
+            samplingParams: {},
+            schemaCompliance: 'auto',
+          },
+          mockConfig,
+        );
+
+        await generator.generateContent({
+          model: 'models/ignored',
+          contents: 'Hello',
+        } as unknown as GenerateContentParameters);
+
+        const [anthropicRequest] =
+          anthropicState.lastCreateArgs as AnthropicCreateArgs;
+        expect(anthropicRequest).toEqual(
+          expect.objectContaining({ max_tokens: 9000 }),
         );
       });
 

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -40,6 +40,7 @@ import {
   tokenLimit,
   CAPPED_DEFAULT_MAX_TOKENS,
   hasExplicitOutputLimit,
+  parsePositiveIntegerEnvValue,
 } from '../tokenLimits.js';
 
 const debugLogger = createDebugLogger('ANTHROPIC');
@@ -594,9 +595,10 @@ export class AnthropicContentGenerator implements ContentGenerator {
         : userMaxTokens;
     } else {
       // No explicit user config — check env var, then use capped default.
-      const envVal = process.env['QWEN_CODE_MAX_OUTPUT_TOKENS'];
-      const envMaxTokens = envVal ? parseInt(envVal, 10) : NaN;
-      if (!isNaN(envMaxTokens) && envMaxTokens > 0) {
+      const envMaxTokens = parsePositiveIntegerEnvValue(
+        process.env['QWEN_CODE_MAX_OUTPUT_TOKENS'],
+      );
+      if (envMaxTokens !== undefined) {
         maxTokens = isKnownModel
           ? Math.min(envMaxTokens, modelLimit)
           : envMaxTokens;

--- a/packages/core/src/core/openaiContentGenerator/provider/default.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/default.test.ts
@@ -10,6 +10,7 @@ import {
   expect,
   vi,
   beforeEach,
+  afterEach,
   type MockedFunction,
 } from 'vitest';
 import OpenAI from 'openai';
@@ -37,12 +38,16 @@ vi.mock('../../../utils/runtimeFetchOptions.js', () => ({
 }));
 
 describe('DefaultOpenAICompatibleProvider', () => {
+  const MAX_OUTPUT_TOKENS_ENV = 'QWEN_CODE_MAX_OUTPUT_TOKENS';
   let provider: DefaultOpenAICompatibleProvider;
   let mockContentGeneratorConfig: ContentGeneratorConfig;
   let mockCliConfig: Config;
+  let savedMaxOutputTokensEnv: string | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    savedMaxOutputTokensEnv = process.env[MAX_OUTPUT_TOKENS_ENV];
+    delete process.env[MAX_OUTPUT_TOKENS_ENV];
     const mockedBuildRuntimeFetchOptions =
       buildRuntimeFetchOptions as unknown as MockedFunction<
         (sdkType: 'openai', proxyUrl?: string) => OpenAIRuntimeFetchOptions
@@ -68,6 +73,14 @@ describe('DefaultOpenAICompatibleProvider', () => {
       mockContentGeneratorConfig,
       mockCliConfig,
     );
+  });
+
+  afterEach(() => {
+    if (savedMaxOutputTokensEnv === undefined) {
+      delete process.env[MAX_OUTPUT_TOKENS_ENV];
+    } else {
+      process.env[MAX_OUTPUT_TOKENS_ENV] = savedMaxOutputTokensEnv;
+    }
   });
 
   describe('constructor', () => {
@@ -207,6 +220,33 @@ describe('DefaultOpenAICompatibleProvider', () => {
       // Should set capped default (min of model limit and CAPPED_DEFAULT_MAX_TOKENS)
       // GPT-4 has 16K output limit, so min(16K, 8K) = 8K
       expect(result.max_tokens).toBe(8000);
+    });
+
+    it('should ignore malformed QWEN_CODE_MAX_OUTPUT_TOKENS values', () => {
+      const request: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: 'Hello' }],
+      };
+
+      for (const envValue of ['1.5', '2k', 'abc']) {
+        process.env[MAX_OUTPUT_TOKENS_ENV] = envValue;
+
+        const result = provider.buildRequest(request, 'prompt-id');
+
+        expect(result.max_tokens).toBe(8000);
+      }
+    });
+
+    it('should respect a valid QWEN_CODE_MAX_OUTPUT_TOKENS value', () => {
+      process.env[MAX_OUTPUT_TOKENS_ENV] = '9000';
+      const request: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: 'Hello' }],
+      };
+
+      const result = provider.buildRequest(request, 'prompt-id');
+
+      expect(result.max_tokens).toBe(9000);
     });
 
     it('should respect user max_tokens for unknown models (deployment aliases, self-hosted)', () => {

--- a/packages/core/src/core/openaiContentGenerator/provider/default.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/default.ts
@@ -9,6 +9,7 @@ import {
   tokenLimit,
   CAPPED_DEFAULT_MAX_TOKENS,
   hasExplicitOutputLimit,
+  parsePositiveIntegerEnvValue,
 } from '../../tokenLimits.js';
 
 type AssistantMessageWithReasoningFields =
@@ -187,9 +188,10 @@ export class DefaultOpenAICompatibleProvider
       // No explicit user config — check env var, then use capped default.
       // Capped default (8K) reduces GPU slot over-reservation by ~4×.
       // Requests hitting the cap get one clean retry at 64K (geminiChat.ts).
-      const envVal = process.env['QWEN_CODE_MAX_OUTPUT_TOKENS'];
-      const envMaxTokens = envVal ? parseInt(envVal, 10) : NaN;
-      if (!isNaN(envMaxTokens) && envMaxTokens > 0) {
+      const envMaxTokens = parsePositiveIntegerEnvValue(
+        process.env['QWEN_CODE_MAX_OUTPUT_TOKENS'],
+      );
+      if (envMaxTokens !== undefined) {
         effectiveMaxTokens = isKnownModel
           ? Math.min(envMaxTokens, modelLimit)
           : envMaxTokens;

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -18,6 +18,20 @@ export const DEFAULT_OUTPUT_TOKEN_LIMIT: TokenCount = 32_000; // 32K tokens
 export const CAPPED_DEFAULT_MAX_TOKENS: TokenCount = 8_000;
 export const ESCALATED_MAX_TOKENS: TokenCount = 64_000;
 
+export function parsePositiveIntegerEnvValue(
+  raw: string | undefined,
+): number | undefined {
+  if (raw === undefined) return undefined;
+
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) return undefined;
+
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) return undefined;
+
+  return parsed;
+}
+
 /**
  * Accurate numeric limits:
  * - power-of-two approximations (128K -> 131072, 256K -> 262144, etc.)


### PR DESCRIPTION
## What this PR does

Parses `QWEN_CODE_MAX_OUTPUT_TOKENS` as a strict positive integer for both OpenAI-compatible and Anthropic content generators, so malformed values no longer get accepted through `parseInt` partial parsing.

## Why it's needed

Before this change, values like `1.5` and `2k` were treated as `1` and `2`. That can silently override the intended capped default with a much smaller token budget. The env override should only apply when the value is a whole positive integer; malformed values should fall back to the existing default behavior.

## Reviewer Test Plan

### How to verify

Set `QWEN_CODE_MAX_OUTPUT_TOKENS` to malformed values such as `1.5`, `2k`, or `abc` and confirm OpenAI-compatible and Anthropic requests keep the capped default `8000`. Set it to a valid value such as `9000` and confirm both paths honor the override.

### Evidence (Before & After)

N/A. This is a non-UI parsing fix covered by unit tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local Node/npm workspace on macOS.

## Risk & Scope

- Main risk or tradeoff: stricter parsing rejects partially numeric env values that were previously accepted accidentally.
- Not validated / out of scope: full cross-platform CI; no Windows or Linux local run.
- Breaking changes / migration notes: users with malformed `QWEN_CODE_MAX_OUTPUT_TOKENS` values will now get the capped default instead of a partial parse.

## Linked Issues

Fixes #5490

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让 OpenAI-compatible 和 Anthropic 两条生成路径都严格按正整数解析 `QWEN_CODE_MAX_OUTPUT_TOKENS`，不再让 `parseInt` 接受半截数字。

## Why it's needed

改动前，`1.5` 会被当成 `1`，`2k` 会被当成 `2`。这会悄悄覆盖原本的 8000 capped default，导致输出 token 预算异常变小。这个环境变量只有在值是完整正整数时才应该生效；格式不对时应该回退到现有默认行为。

## Reviewer Test Plan

### How to verify

把 `QWEN_CODE_MAX_OUTPUT_TOKENS` 设成 `1.5`、`2k` 或 `abc` 这类非法值，确认 OpenAI-compatible 和 Anthropic 请求仍使用 capped default `8000`。再设成 `9000` 这类合法值，确认两条路径都正常使用覆盖值。

### Evidence (Before & After)

N/A。这是非 UI 解析修复，已用单测覆盖。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 本地 Node/npm workspace。

## Risk & Scope

- Main risk or tradeoff: 更严格的解析会拒绝以前因为 `parseInt` 而被意外接受的半截数字。
- Not validated / out of scope: 没有在本地跑完整跨平台 CI，也没有本地 Windows/Linux 验证。
- Breaking changes / migration notes: 如果用户配置了格式错误的 `QWEN_CODE_MAX_OUTPUT_TOKENS`，现在会回退到 capped default，不再使用半截解析出来的数字。

## Linked Issues

Fixes #5490

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
