### PR TITLE
fix(core): validate lsp socket ports

### DIFF
--- a/packages/core/src/lsp/LspConfigLoader.test.ts
+++ b/packages/core/src/lsp/LspConfigLoader.test.ts
@@ -12,6 +12,10 @@ import type { Extension } from '../extension/extensionManager.js';
 describe('LspConfigLoader config-driven behavior', () => {
   const workspaceRoot = '/workspace';
 
+  afterEach(() => {
+    mock.restore();
+  });
+
   it('does not generate any presets when no user or extension config provided', () => {
     const loader = new LspConfigLoader(workspaceRoot);
     // Even if languages are detected, no built-in presets should be generated
@@ -104,6 +108,51 @@ describe('LspConfigLoader config-driven behavior', () => {
     expect(configs).toHaveLength(1);
     expect(configs[0]?.command).toBe('/custom/path/jdtls');
     expect(configs[0]?.args).toEqual(['--custom-flag']);
+  });
+
+  it('accepts valid string socket ports from .lsp.json', async () => {
+    mock({
+      [workspaceRoot]: {
+        '.lsp.json': JSON.stringify({
+          typescript: {
+            transport: 'tcp',
+            host: '127.0.0.1',
+            port: '1234',
+          },
+        }),
+      },
+    });
+
+    const loader = new LspConfigLoader(workspaceRoot);
+    const configs = await loader.loadUserConfigs();
+
+    expect(configs).toHaveLength(1);
+    expect(configs[0]?.socket).toEqual({
+      host: '127.0.0.1',
+      port: 1234,
+    });
+  });
+
+  it('rejects malformed socket ports from .lsp.json', async () => {
+    for (const port of ['1.5', '0x10', 1.5, 0, 65_536]) {
+      mock({
+        [workspaceRoot]: {
+          '.lsp.json': JSON.stringify({
+            typescript: {
+              transport: 'tcp',
+              host: '127.0.0.1',
+              port,
+            },
+          }),
+        },
+      });
+
+      const loader = new LspConfigLoader(workspaceRoot);
+      const configs = await loader.loadUserConfigs();
+
+      expect(configs, `port ${JSON.stringify(port)}`).toHaveLength(0);
+      mock.restore();
+    }
   });
 });
 

--- a/packages/core/src/lsp/LspConfigLoader.ts
+++ b/packages/core/src/lsp/LspConfigLoader.ts
@@ -20,6 +20,7 @@ import type {
 import { createDebugLogger } from '../utils/debugLogger.js';
 
 const debugLogger = createDebugLogger('LSP');
+const MAX_TCP_PORT = 65_535;
 
 export class LspConfigLoader {
   constructor(private readonly workspaceRoot: string) {}
@@ -368,6 +369,26 @@ export class LspConfigLoader {
     return value;
   }
 
+  private normalizePort(value: unknown): number | undefined {
+    let port: number;
+    if (typeof value === 'number') {
+      port = value;
+    } else if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (!/^\d+$/.test(trimmed)) {
+        return undefined;
+      }
+      port = Number(trimmed);
+    } else {
+      return undefined;
+    }
+
+    if (!Number.isSafeInteger(port) || port < 1 || port > MAX_TCP_PORT) {
+      return undefined;
+    }
+    return port;
+  }
+
   private normalizeSocketOptions(
     value: Record<string, unknown>,
   ): LspSocketOptions | undefined {
@@ -387,20 +408,14 @@ export class LspConfigLoader {
         : typeof source['socketPath'] === 'string'
           ? (source['socketPath'] as string)
           : undefined;
-    const portValue = source['port'];
-    const port =
-      typeof portValue === 'number'
-        ? portValue
-        : typeof portValue === 'string'
-          ? Number(portValue)
-          : undefined;
+    const port = this.normalizePort(source['port']);
 
     const socket: LspSocketOptions = {};
     if (host) {
       socket.host = host;
     }
-    if (Number.isFinite(port) && (port as number) > 0) {
-      socket.port = port as number;
+    if (port !== undefined) {
+      socket.port = port;
     }
     if (pathValue) {
       socket.path = pathValue;


### PR DESCRIPTION
## What this PR does

Validates LSP socket/tcp ports while loading user and extension LSP configs. Ports are now accepted only when they are safe integers in the TCP range `1..65535`; malformed or out-of-range values make the socket config invalid instead of carrying a bad port into the connection layer.

## Why it's needed

The loader previously parsed string ports with `Number(...)` and only checked finite/>0. That allowed values like `"1.5"` and `"0x10"`, and it also allowed values above `65535`. Bad values should be rejected at config load time, matching the existing behavior for non-stdio configs with missing socket info.

## Reviewer Test Plan

### How to verify

Load a `.lsp.json` tcp config with `port: "1234"` and confirm it produces `socket.port === 1234`. Load tcp configs with malformed values such as `"1.5"`, `"0x10"`, `1.5`, `0`, or `65536` and confirm the config is dropped as invalid.

### Evidence (Before & After)

N/A. This is a non-UI config parsing fix covered by unit tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local Node/npm workspace on macOS.

## Risk & Scope

- Main risk or tradeoff: malformed port values that were previously accepted accidentally are now rejected.
- Not validated / out of scope: full cross-platform CI; no Windows or Linux local run.
- Breaking changes / migration notes: configs using non-decimal, fractional, zero, or out-of-range port values will no longer load as valid socket configs.

## Linked Issues

Fixes #5492

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 在加载用户和扩展的 LSP 配置时校验 socket/tcp 端口。现在只有 `1..65535` 范围内的安全整数会被接受；格式错误或超出范围的值会让 socket 配置变成无效，而不是把坏端口继续传到连接层。

## Why it's needed

之前 loader 对字符串端口使用 `Number(...)`，并且只判断 finite/>0。这会接受 `"1.5"`、`"0x10"` 这类值，也会接受大于 `65535` 的值。坏值应该在配置加载阶段就被拒绝，这和现有非 stdio 配置缺少 socket info 时直接丢弃配置的行为一致。

## Reviewer Test Plan

### How to verify

加载一个 `.lsp.json` tcp 配置，设置 `port: "1234"`，确认得到 `socket.port === 1234`。再加载端口为 `"1.5"`、`"0x10"`、`1.5`、`0` 或 `65536` 的 tcp 配置，确认这些配置会按无效配置丢弃。

### Evidence (Before & After)

N/A。这是非 UI 的配置解析修复，已用单测覆盖。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 本地 Node/npm workspace。

## Risk & Scope

- Main risk or tradeoff: 以前被意外接受的格式错误端口现在会被拒绝。
- Not validated / out of scope: 没有在本地跑完整跨平台 CI，也没有本地 Windows/Linux 验证。
- Breaking changes / migration notes: 使用非十进制、小数、0 或超范围端口的配置，将不再作为有效 socket 配置加载。

## Linked Issues

Fixes #5492

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
