### PR TITLE
fix(core): don't treat an empty-parts message as a function call/response

### DIFF
--- a/packages/core/src/utils/messageInspectors.test.ts
+++ b/packages/core/src/utils/messageInspectors.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Content } from '@google/genai';
+import { describe, expect, it } from 'vitest';
+import { isFunctionCall, isFunctionResponse } from './messageInspectors.js';
+
+describe('isFunctionResponse', () => {
+  it('is true when every user part is a function response', () => {
+    const content: Content = {
+      role: 'user',
+      parts: [{ functionResponse: { name: 'f', response: {} } }],
+    };
+    expect(isFunctionResponse(content)).toBe(true);
+  });
+
+  it('is false when a user part is not a function response', () => {
+    const content: Content = { role: 'user', parts: [{ text: 'hi' }] };
+    expect(isFunctionResponse(content)).toBe(false);
+  });
+
+  it('is false for a user message with no parts', () => {
+    // [].every(...) is vacuously true, so an empty user turn would otherwise be
+    // misread as a function-response turn — it carries no function responses.
+    expect(isFunctionResponse({ role: 'user', parts: [] })).toBe(false);
+  });
+});
+
+describe('isFunctionCall', () => {
+  it('is true when every model part is a function call', () => {
+    const content: Content = {
+      role: 'model',
+      parts: [{ functionCall: { name: 'f', args: {} } }],
+    };
+    expect(isFunctionCall(content)).toBe(true);
+  });
+
+  it('is false for a model message with no parts', () => {
+    expect(isFunctionCall({ role: 'model', parts: [] })).toBe(false);
+  });
+});

--- a/packages/core/src/utils/messageInspectors.ts
+++ b/packages/core/src/utils/messageInspectors.ts
@@ -10,6 +10,7 @@ export function isFunctionResponse(content: Content): boolean {
   return (
     content.role === 'user' &&
     !!content.parts &&
+    content.parts.length > 0 &&
     content.parts.every((part) => !!part.functionResponse)
   );
 }
@@ -18,6 +19,7 @@ export function isFunctionCall(content: Content): boolean {
   return (
     content.role === 'model' &&
     !!content.parts &&
+    content.parts.length > 0 &&
     content.parts.every((part) => !!part.functionCall)
   );
 }


### PR DESCRIPTION
## What

`isFunctionResponse` and `isFunctionCall` (`packages/core/src/utils/messageInspectors.ts`) now require at least one part before the `parts.every(...)` check, so a message with `parts: []` is no longer reported as an all-function-responses / all-function-calls turn.

## Why

`[].every(...)` is vacuously `true`, so a user (or model) message with an empty parts array passed both inspectors. In `checkNextSpeaker`, an empty user turn then matched `isFunctionResponse(...)` and handed the next turn to the model with the reasoning "the last message was a function response" — which it wasn't. The model-with-empty-parts case is already special-cased just below that branch, but a user message with empty parts fell into the function-response branch first.

## Test Plan

Added `messageInspectors.test.ts`: `parts: []` returns `false` for both inspectors, while a real function-response / function-call part still returns `true` and a plain text part returns `false`. `vitest run packages/core/src/utils/messageInspectors.test.ts` passes, and the two empty-parts cases fail without the fix. `tsc` (typecheck) and `eslint --max-warnings 0` are clean.

## Risk

Low. The change only narrows two predicates to exclude empty-parts messages that previously slipped through a vacuous `every()`. No call site relied on the empty-parts case returning `true`.
