### PR TITLE
fix(core): parse tool concurrency env strictly

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -6008,6 +6008,115 @@ describe('Session', () => {
           .map((p) => p.functionResponse?.id);
         expect(ids).toEqual(['call-a', 'call-b']);
       });
+
+      it('ignores malformed QWEN_CODE_MAX_TOOL_CONCURRENCY values', async () => {
+        const previousMaxConcurrency =
+          process.env['QWEN_CODE_MAX_TOOL_CONCURRENCY'];
+        process.env['QWEN_CODE_MAX_TOOL_CONCURRENCY'] = '1abc';
+        try {
+          type Deferred<T> = {
+            promise: Promise<T>;
+            resolve: (v: T) => void;
+          };
+          const makeDeferred = <T>(): Deferred<T> => {
+            let resolve!: (v: T) => void;
+            const promise = new Promise<T>((r) => {
+              resolve = r;
+            });
+            return { promise, resolve };
+          };
+
+          const called: Record<string, Deferred<void>> = {
+            'call-a': makeDeferred<void>(),
+            'call-b': makeDeferred<void>(),
+          };
+          const result: Record<string, Deferred<core.ToolResult>> = {
+            'call-a': makeDeferred<core.ToolResult>(),
+            'call-b': makeDeferred<core.ToolResult>(),
+          };
+
+          const agentTool = {
+            name: core.ToolNames.AGENT,
+            kind: core.Kind.Think,
+            build: vi
+              .fn()
+              .mockImplementation((args: Record<string, unknown>) => {
+                const id = args['_test_id'] as string;
+                return {
+                  params: args,
+                  eventEmitter: undefined,
+                  getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+                  getDescription: vi.fn().mockReturnValue(`agent ${id}`),
+                  toolLocations: vi.fn().mockReturnValue([]),
+                  execute: vi.fn().mockImplementation(() => {
+                    called[id].resolve();
+                    return result[id].promise;
+                  }),
+                };
+              }),
+          };
+
+          mockToolRegistry.getTool.mockImplementation((name: string) =>
+            name === core.ToolNames.AGENT ? agentTool : undefined,
+          );
+          mockConfig.getApprovalMode = vi
+            .fn()
+            .mockReturnValue(ApprovalMode.DEFAULT);
+          mockConfig.getPermissionManager = vi.fn().mockReturnValue(null);
+          mockChat.sendMessageStream = vi
+            .fn()
+            .mockResolvedValueOnce(
+              createStreamWithChunks([
+                {
+                  type: core.StreamEventType.CHUNK,
+                  value: {
+                    functionCalls: [
+                      {
+                        id: 'call-a',
+                        name: core.ToolNames.AGENT,
+                        args: { _test_id: 'call-a', subagent_type: 'explore' },
+                      },
+                      {
+                        id: 'call-b',
+                        name: core.ToolNames.AGENT,
+                        args: { _test_id: 'call-b', subagent_type: 'explore' },
+                      },
+                    ],
+                  },
+                },
+              ]),
+            )
+            .mockResolvedValueOnce(createEmptyStream());
+
+          const promptPromise = session.prompt({
+            sessionId: 'test-session-id',
+            prompt: [{ type: 'text', text: 'spawn two agents' }],
+          });
+
+          await Promise.all([
+            called['call-a'].promise,
+            called['call-b'].promise,
+          ]);
+
+          result['call-a'].resolve({
+            llmContent: 'A-done',
+            returnDisplay: 'A',
+          });
+          result['call-b'].resolve({
+            llmContent: 'B-done',
+            returnDisplay: 'B',
+          });
+
+          await promptPromise;
+        } finally {
+          if (previousMaxConcurrency === undefined) {
+            delete process.env['QWEN_CODE_MAX_TOOL_CONCURRENCY'];
+          } else {
+            process.env['QWEN_CODE_MAX_TOOL_CONCURRENCY'] =
+              previousMaxConcurrency;
+          }
+        }
+      });
     });
 
     describe('system reminders', () => {

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -99,6 +99,7 @@ import {
   sessionIdContext,
   dedupeToolCallsById,
   getProviderToolCallId,
+  parsePositiveIntegerEnv,
 } from '@qwen-code/qwen-code-core';
 import { NOT_CURRENTLY_GENERATING_CANCEL_MESSAGE } from '@qwen-code/acp-bridge/bridgeErrors';
 // Single source of truth shared with the daemon-side answerer (BridgeClient),
@@ -3344,12 +3345,10 @@ export class Session implements SessionContext {
       onStopAfterPermissionCancel?: () => void,
       shouldSkipUnstarted?: () => boolean,
     ): Promise<RunToolResult[]> => {
-      const parsed = parseInt(
-        process.env['QWEN_CODE_MAX_TOOL_CONCURRENCY'] || '',
+      const maxConcurrency = parsePositiveIntegerEnv(
+        process.env['QWEN_CODE_MAX_TOOL_CONCURRENCY'],
         10,
       );
-      const maxConcurrency =
-        Number.isFinite(parsed) && parsed >= 1 ? parsed : 10;
       const results: RunToolResult[] = new Array(calls.length);
       const executing = new Set<Promise<void>>();
       for (let i = 0; i < calls.length; i++) {

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -8574,6 +8574,70 @@ describe('Fire hook functions integration', () => {
       expect(startIndices.every((i) => i < firstEnd)).toBe(true);
     });
 
+    it('ignores malformed QWEN_CODE_MAX_TOOL_CONCURRENCY values', async () => {
+      process.env['QWEN_CODE_MAX_TOOL_CONCURRENCY'] = '2abc';
+      const executionLog: string[] = [];
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+
+      const agentTool = new MockTool({
+        name: 'agent',
+        execute: async (params) => {
+          const id = (params as { id: string }).id;
+          executionLog.push(`start:${id}`);
+          await gate;
+          executionLog.push(`end:${id}`);
+          return {
+            llmContent: `Agent ${id} done`,
+            returnDisplay: `Agent ${id} done`,
+          };
+        },
+      });
+
+      const tools = new Map([['agent', agentTool]]);
+      const scheduler = createScheduler(tools, vi.fn(), vi.fn());
+      const abortController = new AbortController();
+      const schedulePromise = scheduler.schedule(
+        [
+          {
+            callId: '1',
+            name: 'agent',
+            args: { id: 'A' },
+            isClientInitiated: false,
+            prompt_id: 'p1',
+          },
+          {
+            callId: '2',
+            name: 'agent',
+            args: { id: 'B' },
+            isClientInitiated: false,
+            prompt_id: 'p1',
+          },
+          {
+            callId: '3',
+            name: 'agent',
+            args: { id: 'C' },
+            isClientInitiated: false,
+            prompt_id: 'p1',
+          },
+        ],
+        abortController.signal,
+      );
+
+      try {
+        await vi.waitFor(() => {
+          expect(
+            executionLog.filter((e) => e.startsWith('start:')),
+          ).toHaveLength(3);
+        });
+      } finally {
+        release();
+        await schedulePromise;
+      }
+    });
+
     it('should run concurrency-safe tools in parallel and unsafe tools sequentially', async () => {
       const executionLog: string[] = [];
 

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -66,6 +66,7 @@ import type { MemoryPressureMonitor } from '../services/memoryPressureMonitor.js
 import { CONCURRENCY_SAFE_KINDS } from '../tools/tools.js';
 import { isShellCommandReadOnly } from '../utils/shellReadOnlyChecker.js';
 import { stripShellWrapper } from '../utils/shell-utils.js';
+import { parsePositiveIntegerEnv } from '../utils/env.js';
 import {
   isAlreadyTruncated,
   persistAndTruncateToolResult,
@@ -2879,11 +2880,10 @@ export class CoreToolScheduler {
     calls: ScheduledToolCall[],
     signal: AbortSignal,
   ): Promise<void> {
-    const parsed = parseInt(
-      process.env['QWEN_CODE_MAX_TOOL_CONCURRENCY'] || '',
+    const maxConcurrency = parsePositiveIntegerEnv(
+      process.env['QWEN_CODE_MAX_TOOL_CONCURRENCY'],
       10,
     );
-    const maxConcurrency = Number.isFinite(parsed) && parsed >= 1 ? parsed : 10;
     const executing = new Set<Promise<void>>();
 
     for (const call of calls) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -355,6 +355,7 @@ export * from './utils/configResolver.js';
 export * from './utils/debugLogger.js';
 export * from './utils/editor.js';
 export * from './utils/environmentContext.js';
+export * from './utils/env.js';
 export * from './utils/errorParsing.js';
 export * from './utils/errors.js';
 export * from './utils/fileUtils.js';

--- a/packages/core/src/utils/env.test.ts
+++ b/packages/core/src/utils/env.test.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parsePositiveIntegerEnv } from './env.js';
+
+describe('parsePositiveIntegerEnv', () => {
+  it.each([
+    ['1', 1],
+    ['10', 10],
+    [' 3 ', 3],
+  ])('accepts positive integer value %j', (value, expected) => {
+    expect(parsePositiveIntegerEnv(value, 10)).toBe(expected);
+  });
+
+  it.each([
+    undefined,
+    '',
+    ' ',
+    '0',
+    '-1',
+    '2abc',
+    '2.5',
+    '0x10',
+    String(Number.MAX_SAFE_INTEGER + 1),
+  ])('falls back for malformed value %j', (value) => {
+    expect(parsePositiveIntegerEnv(value, 10)).toBe(10);
+  });
+});

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export function parsePositiveIntegerEnv(
+  value: string | undefined,
+  fallback: number,
+): number {
+  const trimmed = value?.trim();
+  if (!trimmed || !/^\d+$/.test(trimmed)) {
+    return fallback;
+  }
+
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}


### PR DESCRIPTION
## What this PR does

Parses `QWEN_CODE_MAX_TOOL_CONCURRENCY` with a strict positive-integer helper and uses it in both the core scheduler and ACP session execution path. Malformed values now fall back to the default concurrency cap of `10` instead of being partially accepted by `parseInt`.

## Why it's needed

`parseInt` accepts leading numeric prefixes, so values like `2abc` or `2.5` silently became `2`. That makes an operator typo change tool concurrency instead of falling back to the documented default.

## Reviewer Test Plan

### How to verify

Set `QWEN_CODE_MAX_TOOL_CONCURRENCY` to a malformed value such as `2abc` or `1abc` and confirm concurrency-safe tool calls still use the default cap rather than truncating to `2` or `1`. The added tests cover the parser directly, core scheduling, and ACP session execution.

### Evidence (Before & After)

N/A - no UI change.

### Tested on

| OS | Status |
| :-- | :-- |
| macOS | tested |
| Windows | not tested |
| Linux | not tested |

### Environment (optional)

macOS local checkout, Node.js workspace tests.

## Risk & Scope

- Main risk or tradeoff: malformed env values that previously truncated to a positive integer now fall back to `10`.
- Not validated / out of scope: full Windows and Linux local runs.
- Breaking changes / migration notes: only malformed env values change behavior; valid positive integers still work.

## Linked Issues

Fixes #5495

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

用严格的正整数解析逻辑处理 `QWEN_CODE_MAX_TOOL_CONCURRENCY`，并在 core scheduler 和 ACP session 两条执行路径里复用。畸形值现在会回退到默认并发上限 `10`，不会再被 `parseInt` 部分接受。

## 为什么需要

`parseInt` 会接受字符串开头的数字，所以 `2abc` 或 `2.5` 会被静默解析成 `2`。这会让一个环境变量拼写错误意外改变工具并发，而不是回退到默认值。

## Reviewer Test Plan

### 如何验证

把 `QWEN_CODE_MAX_TOOL_CONCURRENCY` 设成 `2abc` 或 `1abc` 这类畸形值，确认并发安全的工具调用仍使用默认上限，而不是截断成 `2` 或 `1`。新增测试覆盖了 parser 本身、core 调度器和 ACP session 执行路径。

### 前后证据

N/A - 没有 UI 改动。

### 测试平台

| OS | 状态 |
| :-- | :-- |
| macOS | 已测试 |
| Windows | 未测试 |
| Linux | 未测试 |

### 环境

macOS 本地 checkout，Node.js workspace tests。

## 风险和范围

- 主要风险或取舍：以前会被截断成正整数的畸形 env 值，现在会回退到 `10`。
- 未验证 / 不在范围内：Windows 和 Linux 本地完整运行。
- 破坏性变更 / 迁移说明：只有畸形 env 值行为改变；合法正整数仍保持原行为。

## 关联 Issue

Fixes #5495

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.