### PR TITLE
fix(desktop): parse NO_PROXY ports strictly

### DIFF
--- a/packages/desktop/apps/electron/src/main/__tests__/network-proxy.test.ts
+++ b/packages/desktop/apps/electron/src/main/__tests__/network-proxy.test.ts
@@ -30,7 +30,18 @@ describe('parseNoProxyRules', () => {
 
   it('parses host:port', () => {
     const rules = parseNoProxyRules('example.com:8080');
-    expect(rules).toEqual([{ host: 'example.com', port: 8080, wildcard: false }]);
+    expect(rules).toEqual([
+      { host: 'example.com', port: 8080, wildcard: false },
+    ]);
+  });
+
+  it('does not parse malformed port suffixes', () => {
+    expect(parseNoProxyRules('example.com:443abc')).toEqual([
+      { host: 'example.com:443abc', wildcard: false },
+    ]);
+    expect(parseNoProxyRules('[::1]:abc')).toEqual([
+      { host: '[::1]:abc', wildcard: false },
+    ]);
   });
 });
 
@@ -55,7 +66,9 @@ describe('shouldBypassProxy', () => {
   it('respects port-scoped rules', () => {
     const rules = parseNoProxyRules('example.com:8080');
     expect(shouldBypassProxy('http://example.com:8080/path', rules)).toBe(true);
-    expect(shouldBypassProxy('http://example.com:9090/path', rules)).toBe(false);
+    expect(shouldBypassProxy('http://example.com:9090/path', rules)).toBe(
+      false,
+    );
   });
 
   it('matches implicit default ports', () => {
@@ -71,7 +84,9 @@ describe('shouldBypassProxy', () => {
 
     // Explicit port that differs from rule should not match
     const rules8080 = parseNoProxyRules('example.com:8080');
-    expect(shouldBypassProxy('https://example.com/path', rules8080)).toBe(false);
+    expect(shouldBypassProxy('https://example.com/path', rules8080)).toBe(
+      false,
+    );
   });
 
   it('wildcard bypasses everything', () => {
@@ -82,6 +97,27 @@ describe('shouldBypassProxy', () => {
   it('handles IPv6 literal', () => {
     const rules = parseNoProxyRules('[::1]');
     expect(shouldBypassProxy('http://[::1]:3000/path', rules)).toBe(true);
+  });
+
+  it('respects IPv6 port-scoped rules', () => {
+    const rules = parseNoProxyRules('[::1]:3000');
+    expect(shouldBypassProxy('http://[::1]:3000/path', rules)).toBe(true);
+    expect(shouldBypassProxy('http://[::1]:3001/path', rules)).toBe(false);
+  });
+
+  it('does not bypass for malformed port suffixes', () => {
+    expect(
+      shouldBypassProxy(
+        'https://example.com/path',
+        parseNoProxyRules('example.com:443abc'),
+      ),
+    ).toBe(false);
+    expect(
+      shouldBypassProxy(
+        'http://[::1]:3000/path',
+        parseNoProxyRules('[::1]:abc'),
+      ),
+    ).toBe(false);
   });
 
   it('matches exact IP literal', () => {

--- a/packages/desktop/apps/electron/src/main/network-proxy-utils.ts
+++ b/packages/desktop/apps/electron/src/main/network-proxy-utils.ts
@@ -7,7 +7,10 @@
 /** Split a comma-separated string into trimmed, non-empty entries. */
 export function splitCommaSeparated(str: string | undefined): string[] {
   if (!str) return [];
-  return str.split(',').map(s => s.trim()).filter(Boolean);
+  return str
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
 }
 
 export interface NoProxyRule {
@@ -17,6 +20,14 @@ export interface NoProxyRule {
   port?: number;
   /** If true, matches any hostname (wildcard `*`). */
   wildcard: boolean;
+}
+
+function parsePort(raw: string): number | undefined {
+  if (!/^\d+$/.test(raw)) return undefined;
+  const port = Number(raw);
+  return Number.isInteger(port) && port >= 0 && port <= 65535
+    ? port
+    : undefined;
 }
 
 /**
@@ -33,8 +44,8 @@ export function parseNoProxyRules(noProxy: string | undefined): NoProxyRule[] {
   if (!noProxy) return [];
 
   return splitCommaSeparated(noProxy)
-    .map(entry => entry.toLowerCase())
-    .map(entry => {
+    .map((entry) => entry.toLowerCase())
+    .map((entry) => {
       if (entry === '*') {
         return { host: '*', wildcard: true };
       }
@@ -49,12 +60,15 @@ export function parseNoProxyRules(noProxy: string | undefined): NoProxyRule[] {
           const ipv6Host = cleaned.slice(1, closeBracket);
           const afterBracket = cleaned.slice(closeBracket + 1);
           if (afterBracket.startsWith(':')) {
-            const port = parseInt(afterBracket.slice(1), 10);
-            if (!isNaN(port)) {
+            const port = parsePort(afterBracket.slice(1));
+            if (port !== undefined) {
               return { host: ipv6Host, port, wildcard: false };
             }
           }
-          return { host: ipv6Host, wildcard: false };
+          if (afterBracket === '') {
+            return { host: ipv6Host, wildcard: false };
+          }
+          return { host: cleaned, wildcard: false };
         }
       }
 
@@ -62,8 +76,8 @@ export function parseNoProxyRules(noProxy: string | undefined): NoProxyRule[] {
       const lastColon = cleaned.lastIndexOf(':');
       if (lastColon > 0) {
         const host = cleaned.slice(0, lastColon);
-        const port = parseInt(cleaned.slice(lastColon + 1), 10);
-        if (!isNaN(port)) {
+        const port = parsePort(cleaned.slice(lastColon + 1));
+        if (port !== undefined) {
           return { host, port, wildcard: false };
         }
       }
@@ -78,14 +92,19 @@ export function parseNoProxyRules(noProxy: string | undefined): NoProxyRule[] {
 /** Default ports by protocol, used when URL omits an explicit port. */
 const DEFAULT_PORTS: Record<string, number> = { 'http:': 80, 'https:': 443 };
 
-export function shouldBypassProxy(url: string | URL, rules: NoProxyRule[]): boolean {
+export function shouldBypassProxy(
+  url: string | URL,
+  rules: NoProxyRule[],
+): boolean {
   if (rules.length === 0) return false;
 
   const parsed = typeof url === 'string' ? new URL(url) : url;
   const hostname = parsed.hostname.toLowerCase();
   // Strip brackets from IPv6
   const host = hostname.startsWith('[') ? hostname.slice(1, -1) : hostname;
-  const port = parsed.port ? parseInt(parsed.port, 10) : DEFAULT_PORTS[parsed.protocol];
+  const port = parsed.port
+    ? parseInt(parsed.port, 10)
+    : DEFAULT_PORTS[parsed.protocol];
 
   for (const rule of rules) {
     if (rule.wildcard) return true;


### PR DESCRIPTION
## What this PR does

Tightens desktop `NO_PROXY` port parsing so only clean decimal port suffixes become port-scoped bypass rules. Malformed entries like `example.com:443abc` or `[::1]:abc` no longer create active proxy bypasses, while valid host:port and bracketed IPv6 port rules still work.

## Why it's needed

The previous parser used `parseInt`, so `example.com:443abc` became a valid `example.com:443` bypass. Bracketed IPv6 had a second failure mode: `[::1]:abc` fell through as a host-only rule and bypassed every `::1` port.

## Reviewer Test Plan

### How to verify

Run the focused desktop proxy test and confirm malformed port suffixes do not bypass while valid IPv6 port rules still match.

Commands run locally:

- `bun test apps/electron/src/main/__tests__/network-proxy.test.ts` from `packages/desktop`
- `bunx prettier --check apps/electron/src/main/network-proxy-utils.ts apps/electron/src/main/__tests__/network-proxy.test.ts` from `packages/desktop`
- `bunx eslint --config eslint.config.mjs src/main/network-proxy-utils.ts src/main/__tests__/network-proxy.test.ts` from `packages/desktop/apps/electron`
- `git diff --check`

### Evidence (Before & After)

Before: `example.com:443abc` parsed as port `443` and bypassed `https://example.com`; `[::1]:abc` degraded into an all-ports `::1` bypass.

After: the same malformed rules stay non-matching, while `[::1]:3000` still matches only port `3000`.

### Tested on

| OS | Status |
| :-- | :-- |
| macOS | tested |
| Windows | not tested |
| Linux | not tested |

### Environment (optional)

macOS local checkout, Bun desktop workspace tests.

## Risk & Scope

- Main risk or tradeoff: malformed `NO_PROXY` entries that previously matched accidentally will stop bypassing the proxy.
- Not validated / out of scope: full desktop app build and full desktop typecheck/lint. Those currently fail on unrelated existing files outside this patch.
- Breaking changes / migration notes: valid decimal port rules keep the same behavior.

## Linked Issues

Fixes #5497

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

收紧 desktop `NO_PROXY` 端口解析，只有干净的十进制端口后缀才会变成带端口限制的绕过规则。`example.com:443abc` 或 `[::1]:abc` 这类畸形条目不再创建有效 proxy bypass；合法的 host:port 和方括号 IPv6 端口规则仍然可用。

## 为什么需要

之前的解析逻辑用了 `parseInt`，所以 `example.com:443abc` 会变成合法的 `example.com:443` 绕过规则。方括号 IPv6 还有第二个失败模式：`[::1]:abc` 会退化成 host-only 规则，从而绕过所有 `::1` 端口。

## Reviewer Test Plan

### 如何验证

运行 focused desktop proxy test，确认畸形端口后缀不会 bypass，同时合法 IPv6 端口规则仍然匹配。

本地执行过的命令：

- `bun test apps/electron/src/main/__tests__/network-proxy.test.ts`，目录为 `packages/desktop`
- `bunx prettier --check apps/electron/src/main/network-proxy-utils.ts apps/electron/src/main/__tests__/network-proxy.test.ts`，目录为 `packages/desktop`
- `bunx eslint --config eslint.config.mjs src/main/network-proxy-utils.ts src/main/__tests__/network-proxy.test.ts`，目录为 `packages/desktop/apps/electron`
- `git diff --check`

### 前后证据

Before：`example.com:443abc` 被解析成端口 `443`，会绕过 `https://example.com`；`[::1]:abc` 会退化成所有端口的 `::1` 绕过。

After：同样的畸形规则不会匹配；`[::1]:3000` 仍然只匹配端口 `3000`。

### 测试平台

| OS | 状态 |
| :-- | :-- |
| macOS | 已测试 |
| Windows | 未测试 |
| Linux | 未测试 |

### 环境

macOS 本地 checkout，Bun desktop workspace tests。

## 风险和范围

- 主要风险或取舍：以前因解析宽松而意外匹配的畸形 `NO_PROXY` 条目，现在不会再绕过代理。
- 未验证 / 不在范围内：完整 desktop app build 和完整 desktop typecheck/lint；它们目前被本补丁外的既有文件问题阻塞。
- 破坏性变更 / 迁移说明：合法十进制端口规则保持原行为。

## 关联 Issue

Fixes #5497

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.