### PR TITLE
fix(core): reject fractional computer-use integer strings

### DIFF
--- a/packages/core/src/tools/computer-use/tool.test.ts
+++ b/packages/core/src/tools/computer-use/tool.test.ts
@@ -139,6 +139,7 @@ describe('coerceTypes', () => {
     properties: {
       x: { type: 'number' },
       y: { type: 'number' },
+      element_index: { type: 'integer' },
       label: { type: 'string' },
       app: { type: 'string' },
     },
@@ -151,6 +152,22 @@ describe('coerceTypes', () => {
     expect(result['y']).toBe(920);
     expect(typeof result['x']).toBe('number');
     expect(typeof result['y']).toBe('number');
+  });
+
+  it('coerces integer strings to numbers (schema type: integer)', () => {
+    const result = coerceTypes({ app: 'X', element_index: '11' }, schema);
+    expect(result['element_index']).toBe(11);
+    expect(typeof result['element_index']).toBe('number');
+  });
+
+  it('does not truncate fractional strings for integer fields', () => {
+    const result = coerceTypes({ app: 'X', element_index: '11.5' }, schema);
+    expect(result['element_index']).toBe('11.5');
+  });
+
+  it('continues to coerce fractional strings for number fields', () => {
+    const result = coerceTypes({ app: 'X', x: '11.5' }, schema);
+    expect(result['x']).toBe(11.5);
   });
 
   // Direction 2: number → string (schema wants string, model sent number)

--- a/packages/core/src/tools/computer-use/tool.ts
+++ b/packages/core/src/tools/computer-use/tool.ts
@@ -375,7 +375,11 @@ export function coerceTypes(
     ) {
       const trimmed = value.trim();
       // Only coerce if the string is a clean numeric — don't swallow garbage.
-      if (/^-?\d+(\.\d+)?$/.test(trimmed)) {
+      const matchesType =
+        fieldType === 'integer'
+          ? /^-?\d+$/.test(trimmed)
+          : /^-?\d+(\.\d+)?$/.test(trimmed);
+      if (matchesType) {
         const parsed =
           fieldType === 'integer' ? parseInt(trimmed, 10) : parseFloat(trimmed);
         if (Number.isFinite(parsed)) {


### PR DESCRIPTION
## What this PR does

This PR tightens computer-use argument coercion for integer fields so numeric strings like `"1.5"` are rejected instead of being truncated to `1`. Decimal coercion remains allowed for schema fields that are actually `number`.

## Why it's needed

Computer-use integer parameters are used for pixel coordinates and other count-like values. Accepting a fractional string and silently truncating it hides malformed model output, which can make tool calls behave differently from the schema contract.

## Reviewer Test Plan

### How to verify

Run the focused computer-use tool tests and confirm integer schema fields reject fractional numeric strings while number schema fields still accept decimal numeric strings.

### Evidence (Before & After)

Before: an integer field value such as `"1.5"` passed validation and was coerced with `parseInt`, becoming `1`.

After: integer fields reject fractional numeric strings; existing number fields still coerce values like `"1.5"` to `1.5`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested locally with focused unit test |
| 🪟 Windows | ✅ CI passed |
|  🐧 Linux  | ✅ CI passed |

### Environment (optional)

Local validation used the package test runner against `packages/core/src/tools/computer-use/tool.test.ts`.

## Risk & Scope

- Main risk or tradeoff: strict integer parsing may reject malformed model output that previously happened to work after truncation.
- Not validated / out of scope: no end-to-end browser/computer-use run; this is covered at the tool coercion unit layer.
- Breaking changes / migration notes: no migration; behavior now matches the integer schema contract.

## Linked Issues

Fixes #5499

## Testing

- npm --workspace packages/core run test -- src/tools/computer-use/tool.test.ts --coverage.enabled=false
- npx prettier --check packages/core/src/tools/computer-use/tool.ts packages/core/src/tools/computer-use/tool.test.ts
- npm run typecheck
- npm run lint:ci
- npm run check:lockfile
- git diff --check

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 收紧了 computer-use 参数里整数类型字段的强制转换逻辑，让 `"1.5"` 这类数字字符串被拒绝，而不是被截断成 `1`。真正声明为 `number` 的字段仍然允许小数转换。

## 为什么需要

computer-use 的整数参数会用于像素坐标和其他计数类值。把小数字符串静默截断会掩盖不符合 schema 的模型输出，也会让工具调用行为偏离 schema 合约。

## Reviewer 测试计划

### 如何验证

运行聚焦的 computer-use tool 测试，确认 integer schema 字段会拒绝小数字符串，同时 number schema 字段仍然接受小数字符串。

### 前后证据

之前：integer 字段传入 `"1.5"` 会通过验证，并被 `parseInt` 转成 `1`。

之后：integer 字段会拒绝小数字符串；已有 number 字段仍会把 `"1.5"` 转成 `1.5`。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ 本地聚焦单测已验证 |
| 🪟 Windows | ✅ CI 已通过 |
|  🐧 Linux  | ✅ CI 已通过 |

### 环境

本地验证使用 package test runner，目标测试文件是 `packages/core/src/tools/computer-use/tool.test.ts`。

## 风险与范围

- 主要风险或取舍：更严格的 integer 解析会拒绝以前被截断后“碰巧可用”的畸形模型输出。
- 未验证 / 不在范围内：没有跑浏览器或 computer-use 的端到端测试；本 PR 在 tool coercion 单测层覆盖。
- 破坏性变更 / 迁移说明：无需迁移；行为现在与 integer schema 合约一致。

## 关联 Issue

Fixes #5499

## 测试

- npm --workspace packages/core run test -- src/tools/computer-use/tool.test.ts --coverage.enabled=false
- npx prettier --check packages/core/src/tools/computer-use/tool.ts packages/core/src/tools/computer-use/tool.test.ts
- npm run typecheck
- npm run lint:ci
- npm run check:lockfile
- git diff --check

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
