### PR TITLE
fix(cli): wire ACP model-invocable commands

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -841,6 +841,7 @@ describe('Session', () => {
         mockConfig,
         expect.any(AbortSignal),
         'acp',
+        mockSettings,
       );
       expect(mockClient.sessionUpdate).toHaveBeenCalledWith({
         sessionId: 'test-session-id',
@@ -884,6 +885,7 @@ describe('Session', () => {
         mockConfig,
         expect.any(AbortSignal),
         'acp',
+        mockSettings,
       );
       expect(mockClient.sessionUpdate).toHaveBeenCalledWith({
         sessionId: 'test-session-id',

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -531,8 +531,14 @@ export interface AvailableCommandsSnapshot {
 export async function buildAvailableCommandsSnapshot(
   config: Config,
   abortSignal: AbortSignal = AbortSignal.timeout(10_000),
+  settings?: LoadedSettings,
 ): Promise<AvailableCommandsSnapshot> {
-  const slashCommands = await getAvailableCommands(config, abortSignal, 'acp');
+  const slashCommands = await getAvailableCommands(
+    config,
+    abortSignal,
+    'acp',
+    settings,
+  );
 
   const availableCommands: AvailableCommand[] = slashCommands.map((cmd) => {
     const acceptsInput =
@@ -2960,7 +2966,11 @@ export class Session implements SessionContext {
   async sendAvailableCommandsUpdate(): Promise<void> {
     try {
       const { availableCommands, availableSkills, availableSkillDetails } =
-        await buildAvailableCommandsSnapshot(this.config);
+        await buildAvailableCommandsSnapshot(
+          this.config,
+          undefined,
+          this.settings,
+        );
 
       const update: SessionUpdate = {
         sessionUpdate: 'available_commands_update',

--- a/packages/cli/src/nonInteractiveCliCommands.test.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.test.ts
@@ -713,19 +713,83 @@ describe('handleSlashCommand', () => {
 
       expect(result.type).toBe('no_command');
     });
+
+    it('does not expose disabled model-invocable commands through SkillTool', async () => {
+      const modelInvocableCommand = {
+        name: 'custom',
+        description: 'Custom file command',
+        kind: CommandKind.FILE,
+        modelInvocable: true,
+        supportedModes: ['non_interactive'] as ExecutionMode[],
+        action: vi.fn().mockResolvedValue({
+          type: 'submit_prompt',
+          content: 'Expanded prompt',
+        }),
+      };
+      mockGetCommands.mockReturnValue([modelInvocableCommand]);
+      vi.mocked(mockConfig.getDisabledSlashCommands).mockReturnValue([
+        'custom',
+      ]);
+      mockCommandServiceCreate.mockImplementation(
+        async (_loaders, _signal, disabledNames?: ReadonlySet<string>) => {
+          const commands =
+            disabledNames?.has('custom') === true
+              ? []
+              : [modelInvocableCommand];
+          return {
+            getCommands: () => commands,
+            getCommandsForMode: (mode: ExecutionMode) =>
+              filterCommandsForMode(commands, mode),
+            getModelInvocableCommands: () =>
+              commands.filter((command) => command.modelInvocable === true),
+          };
+        },
+      );
+
+      const result = await handleSlashCommand(
+        '/custom',
+        abortController,
+        mockConfig,
+        mockSettings,
+      );
+
+      expect(result.type).toBe('unsupported');
+      if (result.type === 'unsupported') {
+        expect(result.reason).toContain('disabled');
+      }
+      const provider = vi.mocked(mockConfig.setModelInvocableCommandsProvider)
+        .mock.calls[0]?.[0];
+      expect(provider?.()).toEqual([]);
+      const executor = vi.mocked(mockConfig.setModelInvocableCommandsExecutor)
+        .mock.calls[0]?.[0];
+      await expect(executor?.('custom')).resolves.toBeNull();
+    });
   });
 });
 
 describe('getAvailableCommands', () => {
   let mockConfig: Config;
+  let notifyConfigChanged: ReturnType<typeof vi.fn>;
+  let fireUserPromptExpansionEvent: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetCommandsForMode.mockImplementation((mode: ExecutionMode) =>
+      filterCommandsForMode(mockGetCommands(), mode),
+    );
+    mockGetModelInvocableCommands.mockImplementation(() =>
+      mockGetCommands().filter(
+        (command: { modelInvocable?: boolean; hidden?: boolean }) =>
+          !command.hidden && command.modelInvocable === true,
+      ),
+    );
     mockCommandServiceCreate.mockResolvedValue({
       getCommands: mockGetCommands,
       getCommandsForMode: mockGetCommandsForMode,
       getModelInvocableCommands: mockGetModelInvocableCommands,
     });
+    notifyConfigChanged = vi.fn().mockResolvedValue(undefined);
+    fireUserPromptExpansionEvent = vi.fn().mockResolvedValue(undefined);
 
     mockConfig = {
       getExperimentalZedIntegration: vi.fn().mockReturnValue(false),
@@ -735,6 +799,14 @@ describe('getAvailableCommands', () => {
       getFolderTrust: vi.fn().mockReturnValue(false),
       getProjectRoot: vi.fn().mockReturnValue('/test/project'),
       getDisabledSlashCommands: vi.fn().mockReturnValue([]),
+      getDisableAllHooks: vi.fn().mockReturnValue(false),
+      hasHooksForEvent: vi.fn().mockReturnValue(false),
+      getHookSystem: vi.fn().mockReturnValue({
+        fireUserPromptExpansionEvent,
+      }),
+      setModelInvocableCommandsProvider: vi.fn(),
+      setModelInvocableCommandsExecutor: vi.fn(),
+      getSkillManager: vi.fn().mockReturnValue({ notifyConfigChanged }),
       storage: {},
     } as unknown as Config;
   });
@@ -755,5 +827,83 @@ describe('getAvailableCommands', () => {
     );
 
     expect(commands.map((command) => command.name)).toContain('export');
+  });
+
+  it('does not partially register model-invocable commands without settings', async () => {
+    mockGetCommands.mockReturnValue([
+      {
+        name: 'expand-prompt',
+        description: 'Expand prompt',
+        kind: CommandKind.FILE,
+        modelInvocable: true,
+        supportedModes: ['acp'] as const,
+      },
+    ]);
+
+    await getAvailableCommands(mockConfig, new AbortController().signal, 'acp');
+
+    expect(mockConfig.setModelInvocableCommandsProvider).not.toHaveBeenCalled();
+    expect(mockConfig.setModelInvocableCommandsExecutor).not.toHaveBeenCalled();
+    expect(notifyConfigChanged).not.toHaveBeenCalled();
+  });
+
+  it('registers model-invocable commands for ACP command snapshots', async () => {
+    const promptCommand = {
+      name: 'expand-prompt',
+      description: 'Fallback description',
+      modelDescription: 'Model-facing description',
+      kind: CommandKind.FILE,
+      modelInvocable: true,
+      supportedModes: ['acp'] as const,
+      action: vi.fn().mockResolvedValue({
+        type: 'submit_prompt',
+        content: 'expanded prompt',
+      }),
+    };
+    mockGetCommands.mockReturnValue([promptCommand]);
+    vi.mocked(mockConfig.hasHooksForEvent).mockReturnValue(true);
+    const expiredSnapshotSignal = new AbortController();
+    expiredSnapshotSignal.abort();
+
+    await getAvailableCommands(
+      mockConfig,
+      expiredSnapshotSignal.signal,
+      'acp',
+      {
+        system: { path: '', settings: {} },
+        systemDefaults: { path: '', settings: {} },
+        user: { path: '', settings: {} },
+        workspace: { path: '', settings: {} },
+      } as LoadedSettings,
+    );
+
+    const provider = vi.mocked(mockConfig.setModelInvocableCommandsProvider)
+      .mock.calls[0]?.[0];
+    expect(provider?.()).toEqual([
+      {
+        name: 'expand-prompt',
+        description: 'Model-facing description',
+      },
+    ]);
+
+    const executor = vi.mocked(mockConfig.setModelInvocableCommandsExecutor)
+      .mock.calls[0]?.[0];
+    await expect(executor?.('expand-prompt', 'with args')).resolves.toBe(
+      'expanded prompt',
+    );
+    expect(fireUserPromptExpansionEvent).toHaveBeenCalledTimes(1);
+    expect(fireUserPromptExpansionEvent.mock.calls[0]?.[3].aborted).toBe(false);
+    expect(promptCommand.action).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executionMode: 'acp',
+        invocation: {
+          raw: '/expand-prompt with args',
+          name: 'expand-prompt',
+          args: 'with args',
+        },
+      }),
+      'with args',
+    );
+    expect(notifyConfigChanged).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cli/src/nonInteractiveCliCommands.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.ts
@@ -37,6 +37,8 @@ import {
 
 const debugLogger = createDebugLogger('NON_INTERACTIVE_COMMANDS');
 
+type CommandServiceInstance = Awaited<ReturnType<typeof CommandService.create>>;
+
 /**
  * Result of handling a slash command in non-interactive mode.
  *
@@ -233,6 +235,72 @@ async function fireUserPromptExpansionHook(
   };
 }
 
+async function registerModelInvocableCommands(
+  commandService: CommandServiceInstance,
+  config: Config,
+  executionMode: ExecutionMode,
+  settings?: LoadedSettings,
+): Promise<void> {
+  if (!settings) {
+    return;
+  }
+
+  config.setModelInvocableCommandsProvider(() =>
+    commandService.getModelInvocableCommands().map((cmd) => ({
+      name: cmd.name,
+      description: cmd.modelDescription ?? cmd.description,
+    })),
+  );
+
+  config.setModelInvocableCommandsExecutor(
+    async (name: string, args: string = '') => {
+      const commands = commandService.getModelInvocableCommands();
+      const cmd = commands.find((c) => c.name === name);
+      if (!cmd?.action) return null;
+      const minimalContext = {
+        executionMode,
+        invocation: {
+          raw: args ? `/${name} ${args}` : `/${name}`,
+          name,
+          args,
+        },
+        services: { config, settings, logger: null },
+      } as unknown as CommandContext;
+      const result = await cmd.action(minimalContext, args);
+      if (!result || result.type !== 'submit_prompt') return null;
+      const hookSignal = new AbortController().signal;
+      const hookResult = await fireUserPromptExpansionHook(
+        config,
+        name,
+        args,
+        result.content,
+        hookSignal,
+      );
+      if (hookResult.blockedResult) {
+        return hookResult.blockedResult.type === 'message'
+          ? { error: hookResult.blockedResult.content }
+          : null;
+      }
+      const content = hookResult.content;
+      if (typeof content === 'string') return content;
+      if (Array.isArray(content)) {
+        return content
+          .map((p) =>
+            typeof p === 'string' ? p : ((p as { text?: string }).text ?? ''),
+          )
+          .join('');
+      }
+      return null;
+    },
+  );
+
+  const skillManager =
+    typeof config.getSkillManager === 'function'
+      ? config.getSkillManager()
+      : null;
+  await skillManager?.notifyConfigChanged();
+}
+
 /**
  * Processes a slash command in a non-interactive environment.
  *
@@ -287,61 +355,25 @@ export const handleSlashCommand = async (
   // fallback existence check below can distinguish a disabled command from a
   // truly unknown one. Without this, a disabled command would fall through to
   // `no_command` and be forwarded to the model as plain prompt text.
-  const commandService = await CommandService.create(
+  const allCommandService = await CommandService.create(
     allLoaders,
     abortController.signal,
   );
-  // Register model-invocable commands provider so the startup snapshot and
-  // per-turn drain include these in non-interactive / ACP mode.
-  config.setModelInvocableCommandsProvider(() =>
-    commandService.getModelInvocableCommands().map((cmd) => ({
-      name: cmd.name,
-      description: cmd.modelDescription ?? cmd.description,
-    })),
+  const commandService =
+    disabledNameSet.size > 0
+      ? await CommandService.create(
+          allLoaders,
+          abortController.signal,
+          disabledNameSet,
+        )
+      : allCommandService;
+  await registerModelInvocableCommands(
+    commandService,
+    config,
+    executionMode,
+    settings,
   );
-  // Register executor so SkillTool can invoke model-invocable commands
-  // (e.g. MCP prompts) that are not file-based skills.
-  config.setModelInvocableCommandsExecutor(
-    async (name: string, args: string = '') => {
-      const commands = commandService.getModelInvocableCommands();
-      const cmd = commands.find((c) => c.name === name);
-      if (!cmd?.action) return null;
-      const minimalContext = {
-        executionMode,
-        invocation: {
-          raw: args ? `/${name} ${args}` : `/${name}`,
-          name,
-          args,
-        },
-        services: { config, settings, logger: null },
-      } as unknown as CommandContext;
-      const result = await cmd.action(minimalContext, args);
-      if (!result || result.type !== 'submit_prompt') return null;
-      const hookResult = await fireUserPromptExpansionHook(
-        config,
-        name,
-        args,
-        result.content,
-        abortController.signal,
-      );
-      if (hookResult.blockedResult) {
-        return hookResult.blockedResult.type === 'message'
-          ? { error: hookResult.blockedResult.content }
-          : null;
-      }
-      const content = hookResult.content;
-      if (typeof content === 'string') return content;
-      if (Array.isArray(content)) {
-        return content
-          .map((p) =>
-            typeof p === 'string' ? p : ((p as { text?: string }).text ?? ''),
-          )
-          .join('');
-      }
-      return null;
-    },
-  );
-  const allCommands = commandService.getCommands();
+  const allCommands = allCommandService.getCommands();
   const filteredCommands = commandService
     .getCommandsForMode(executionMode)
     .filter((cmd) => !isDisabled(cmd));
@@ -475,6 +507,7 @@ export const getAvailableCommands = async (
   config: Config,
   abortSignal: AbortSignal,
   mode: ExecutionMode = 'acp',
+  settings?: LoadedSettings,
 ): Promise<SlashCommand[]> => {
   try {
     const loaders = [
@@ -492,6 +525,12 @@ export const getAvailableCommands = async (
       disabledSlashCommands.length > 0
         ? new Set(disabledSlashCommands)
         : undefined,
+    );
+    await registerModelInvocableCommands(
+      commandService,
+      config,
+      mode,
+      settings,
     );
     return commandService.getCommandsForMode(mode) as SlashCommand[];
   } catch (error) {


### PR DESCRIPTION
## What this PR does

- Registers the model-invocable command provider/executor when ACP builds command snapshots from session settings.
- Avoids partial registration when session settings are unavailable.
- Avoids retaining the snapshot timeout signal for later hook execution.
- Keeps disabled slash commands out of SkillTool's model-invocable command path.

## Why it's needed

ACP `available_commands_update` builds slash commands through `getAvailableCommands()`, but that path only returned the command list. It did not wire the model-invocable command provider/executor onto `Config`, so `SkillTool` could miss MCP prompts or file commands that the ACP command snapshot already knew about.

There was also a cancellation edge where a snapshot timeout signal could be captured by a long-lived executor. Later `UserPromptExpansion` hooks could then see an already-aborted signal.

## Reviewer Test Plan

### How to verify

- Review the ACP command snapshot path: it should register model-invocable commands when settings are available.
- Review disabled slash command handling: disabled commands should not become model-invocable commands.
- Review timeout handling: the snapshot timeout signal should not be retained for later hook execution.
- Run `npm test --workspace=packages/cli -- --coverage.enabled=false src/nonInteractiveCliCommands.test.ts`.
- Run `npm test --workspace=packages/cli -- --coverage.enabled=false src/acp-integration/session/Session.test.ts`.
- Run `npx eslint packages/cli/src/nonInteractiveCliCommands.ts packages/cli/src/nonInteractiveCliCommands.test.ts packages/cli/src/acp-integration/session/Session.ts packages/cli/src/acp-integration/session/Session.test.ts`.
- Run `npx prettier --check packages/cli/src/nonInteractiveCliCommands.ts packages/cli/src/nonInteractiveCliCommands.test.ts packages/cli/src/acp-integration/session/Session.ts packages/cli/src/acp-integration/session/Session.test.ts`.
- Run `git diff --check`.

### Evidence (Before & After)

Before: ACP snapshots could list commands without wiring the matching model-invocable provider/executor on `Config`, so later model-invocable command execution could miss commands the snapshot had advertised. After: the snapshot path registers the same model-invocable command surface when settings are available, and disabled commands remain excluded.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; covered by CI |
|  🐧 Linux  | ⚠️ not tested locally; covered by CI |

### Environment (optional)

Local npm workspace. `npm run typecheck --workspace=packages/cli` still fails on existing `BaseTextInput.tsx` `ink/dom` and `ink/components/CursorContext` type resolution.

## Risk & Scope

- Main risk or tradeoff: ACP command snapshot setup now also mutates the model-invocable command registration on `Config` when settings are available.
- Not validated / out of scope: changing command discovery semantics outside the ACP snapshot/model-invocable command path.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5503

<details>
<summary>中文说明</summary>

## What this PR does

- ACP 从 session settings 构建 command snapshot 时，同时注册 model-invocable command provider/executor。
- session settings 不可用时避免半注册状态。
- 避免把 snapshot timeout signal 保存给后续 hook 执行使用。
- 禁用的 slash command 不会进入 SkillTool 的 model-invocable command 路径。

## Why it's needed

ACP `available_commands_update` 通过 `getAvailableCommands()` 构建 slash commands，但旧路径只返回 command list，没有把 model-invocable command provider/executor 挂到 `Config` 上。因此 `SkillTool` 可能拿不到 ACP command snapshot 已经知道的 MCP prompts 或 file commands。

此外还有一个取消信号边界：snapshot timeout signal 如果被长期 executor 捕获，后续 `UserPromptExpansion` hooks 可能会看到一个已经 aborted 的 signal。

## Reviewer Test Plan

### How to verify

- 检查 ACP command snapshot 路径：settings 可用时应该注册 model-invocable commands。
- 检查禁用 slash command 的处理：disabled commands 不应该成为 model-invocable commands。
- 检查 timeout 处理：snapshot timeout signal 不应该被保存给后续 hook 执行。
- 运行英文部分列出的测试、eslint、prettier 和 `git diff --check` 命令。

### Evidence (Before & After)

修复前：ACP snapshot 可能列出 commands，但没有把对应 model-invocable provider/executor 注册到 `Config`，导致后续 model-invocable command execution 漏掉 snapshot 已经 advertised 的 commands。修复后：settings 可用时，snapshot 路径会注册同一套 model-invocable command surface，并继续排除 disabled commands。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; covered by CI |
|  🐧 Linux  | ⚠️ not tested locally; covered by CI |

### Environment (optional)

本地 npm workspace。`npm run typecheck --workspace=packages/cli` 仍在既有 `BaseTextInput.tsx` 的 `ink/dom` 和 `ink/components/CursorContext` 类型解析处失败。

## Risk & Scope

- 主要风险或取舍：ACP command snapshot setup 现在会在 settings 可用时同步更新 `Config` 上的 model-invocable command registration。
- 未验证 / 不在范围内：修改 ACP snapshot/model-invocable command 路径之外的 command discovery 语义。
- Breaking changes / migration notes：无。

## Linked Issues

Fixes #5503

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
