### PR TITLE
fix(core): add missing Token Plan models (qwen3.7-plus, glm-5.2, kimi-k2.7-code)

### DIFF
--- a/packages/core/src/core/modalityDefaults.ts
+++ b/packages/core/src/core/modalityDefaults.ts
@@ -77,7 +77,7 @@ const MODALITY_PATTERNS: Array<[RegExp, InputModalities]> = [
   // -------------------
   // Moonshot / Kimi
   // -------------------
-  [/^kimi-k2\.5/, { image: true, video: true }],
+  [/^kimi-k2\./, { image: true, video: true }],
   [/^kimi-/, {}],
 
   // -------------------

--- a/packages/core/src/providers/__tests__/presets/alibaba-token-plan.test.ts
+++ b/packages/core/src/providers/__tests__/presets/alibaba-token-plan.test.ts
@@ -31,14 +31,17 @@ describe('token plan provider', () => {
     });
 
     expect(template.map((model) => model.id)).toEqual([
+      'qwen3.7-plus',
       'qwen3.6-plus',
       'qwen3.7-max',
       'qwen3.6-flash',
       'deepseek-v4-pro',
       'deepseek-v4-flash',
       'deepseek-v3.2',
+      'kimi-k2.7-code',
       'kimi-k2.6',
       'kimi-k2.5',
+      'glm-5.2',
       'glm-5.1',
       'glm-5',
       'MiniMax-M2.5',

--- a/packages/core/src/providers/presets/alibaba-token-plan.ts
+++ b/packages/core/src/providers/presets/alibaba-token-plan.ts
@@ -17,6 +17,12 @@ export const TOKEN_PLAN_BASE_URL =
 
 const TOKEN_PLAN_MODELS: ModelSpec[] = [
   {
+    id: 'qwen3.7-plus',
+    contextWindowSize: 1000000,
+    enableThinking: true,
+    modalities: { image: true, video: true },
+  },
+  {
     id: 'qwen3.6-plus',
     contextWindowSize: 1000000,
     enableThinking: true,
@@ -32,6 +38,12 @@ const TOKEN_PLAN_MODELS: ModelSpec[] = [
   { id: 'deepseek-v4-flash', contextWindowSize: 1000000 },
   { id: 'deepseek-v3.2', contextWindowSize: 131072 },
   {
+    id: 'kimi-k2.7-code',
+    contextWindowSize: 262144,
+    enableThinking: true,
+    modalities: { image: true, video: true },
+  },
+  {
     id: 'kimi-k2.6',
     contextWindowSize: 262144,
     enableThinking: true,
@@ -42,6 +54,7 @@ const TOKEN_PLAN_MODELS: ModelSpec[] = [
     enableThinking: true,
     modalities: { image: true, video: true },
   },
+  { id: 'glm-5.2', contextWindowSize: 1000000, enableThinking: true },
   { id: 'glm-5.1', contextWindowSize: 202752, enableThinking: true },
   { id: 'glm-5', contextWindowSize: 202752, enableThinking: true },
   { id: 'MiniMax-M2.5', contextWindowSize: 196608 },

--- a/packages/vscode-ide-companion/src/services/subscriptionPlanDefinitions.test.ts
+++ b/packages/vscode-ide-companion/src/services/subscriptionPlanDefinitions.test.ts
@@ -14,14 +14,17 @@ describe('subscription plan definitions', () => {
     const codingPlan = getSubscriptionPlanConfig('coding');
 
     expect(tokenPlan.template.map((model) => model.id)).toEqual([
+      'qwen3.7-plus',
       'qwen3.6-plus',
       'qwen3.7-max',
       'qwen3.6-flash',
       'deepseek-v4-pro',
       'deepseek-v4-flash',
       'deepseek-v3.2',
+      'kimi-k2.7-code',
       'kimi-k2.6',
       'kimi-k2.5',
+      'glm-5.2',
       'glm-5.1',
       'glm-5',
       'MiniMax-M2.5',

--- a/packages/vscode-ide-companion/src/services/subscriptionPlanDefinitions.ts
+++ b/packages/vscode-ide-companion/src/services/subscriptionPlanDefinitions.ts
@@ -108,14 +108,17 @@ const ALIBABA_SUBSCRIPTION_MODELS = [
 ] as const satisfies readonly SubscriptionPlanModelSpec[];
 
 const BAILIAN_TOKEN_PLAN_MODELS = [
+  { id: 'qwen3.7-plus', contextWindowSize: 1000000, enableThinking: true },
   { id: 'qwen3.6-plus', contextWindowSize: 1000000, enableThinking: true },
   { id: 'qwen3.7-max', contextWindowSize: 1000000, enableThinking: true },
   { id: 'qwen3.6-flash', contextWindowSize: 1000000, enableThinking: true },
   { id: 'deepseek-v4-pro', contextWindowSize: 1000000 },
   { id: 'deepseek-v4-flash', contextWindowSize: 1000000 },
   { id: 'deepseek-v3.2', contextWindowSize: 131072 },
+  { id: 'kimi-k2.7-code', contextWindowSize: 262144, enableThinking: true },
   { id: 'kimi-k2.6', contextWindowSize: 262144, enableThinking: true },
   { id: 'kimi-k2.5', contextWindowSize: 262144, enableThinking: true },
+  { id: 'glm-5.2', contextWindowSize: 1000000, enableThinking: true },
   { id: 'glm-5.1', contextWindowSize: 202752, enableThinking: true },
   { id: 'glm-5', contextWindowSize: 202752, enableThinking: true },
   { id: 'MiniMax-M2.5', contextWindowSize: 196608 },


### PR DESCRIPTION
## What this PR does

Adds three models that are available on the ModelStudio Token Plan endpoint but were missing from the Token Plan preset: `qwen3.7-plus`, `glm-5.2`, and `kimi-k2.7-code`. Also widens the Kimi multimodal detection pattern so all `kimi-k2.*` models are correctly recognized as supporting image+video input, matching their documented capabilities.

## Why it's needed

Users who had these models in their local config (e.g. carried over from a previous setup or added manually) would see a "Built-in Provider Update" prompt offering to **remove** them, because the built-in Token Plan template didn't include them. Selecting "Update all" would silently delete working models and force-switch to a fallback.

- `qwen3.7-plus` was already in the Coding Plan preset but absent from Token Plan
- `glm-5.2` was already in the Z.AI preset but absent from both Alibaba plan presets
- `kimi-k2.7-code` is a new Kimi coding model (always-on thinking, multimodal) not present in any preset
- The Kimi modality pattern only covered `kimi-k2.5`, but per the Kimi documentation, `kimi-k2.5`, `kimi-k2.6`, and `kimi-k2.7-code` all support image+video input. The pattern is widened to cover the whole `kimi-k2.*` family

## Reviewer Test Plan

### How to verify

Check [doc](https://platform.qianwenai.com/docs/token-plan/overview) for supported models.

1. Run the Token Plan preset test and confirm all three new models appear in the template:
   ```bash
   cd packages/core && npx vitest run src/providers/__tests__/presets/alibaba-token-plan.test.ts
   ```
2. Run the VS Code companion catalog test and confirm it is in sync:
   ```bash
   cd packages/vscode-ide-companion && npx vitest run src/services/subscriptionPlanDefinitions.test.ts
   ```
3. Run the modality defaults test:
   ```bash
   cd packages/core && npx vitest run src/core/modalityDefaults.test.ts
   ```

### Evidence (Before & After)

N/A — no user-visible TUI change (preset/model-list only).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |   N/A   |
|  🐧 Linux  |   N/A   |

### Environment (optional)

N/A — only unit tests.

## Risk & Scope

- Main risk or tradeoff: the widened Kimi modality pattern (`/^kimi-k2\./` instead of `/^kimi-k2\.5/`) affects all providers globally, not just Token Plan. This is correct per the Kimi documentation (k2.5, k2.6, k2.7 all support image+video), but if a future kimi-k2.x model drops multimodal support, the pattern would need narrowing.
- Not validated / out of scope: DashScope-specific output token limits for kimi-k2.6/k2.7-code are not added to the global output-token-limit table, because those are provider-specific caps rather than model-level limits (following the convention established by PR #5397 for GLM output limits).
- Breaking changes / migration notes: none. Existing users with these models already installed will no longer see the false "model being removed" update prompt.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

向 Token Plan 预设中添加了三个在百炼 Token Plan 端点可用但缺失的模型：`qwen3.7-plus`、`glm-5.2` 和 `kimi-k2.7-code`。同时拓宽了 Kimi 多模态检测正则，使所有 `kimi-k2.*` 模型都能被正确识别为支持图文+视频输入，与文档一致。

## 为什么需要

用户本地配置中已有这些模型时（如从旧版本迁移或手动添加），会看到"内置提供商更新"提示，要求**移除**这些模型——因为内置模板里没有它们。选择"全部更新"会静默删除可用的模型并强制切换到回退模型。

- `qwen3.7-plus` 已在 Coding Plan 预设中，但 Token Plan 缺失
- `glm-5.2` 已在 Z.AI 预设中，但两个阿里云计划预设都缺失
- `kimi-k2.7-code` 是新的 Kimi 编程模型（始终开启思考、多模态），未出现在任何预设中
- Kimi 多模态正则此前仅覆盖 `kimi-k2.5`，但根据 Kimi 文档，`kimi-k2.5`、`kimi-k2.6`、`kimi-k2.7-code` 均支持图文+视频输入。已拓宽正则以覆盖整个 `kimi-k2.*` 系列

## 审阅者测试计划

### 如何验证

1. 运行 Token Plan 预设测试，确认三个新模型出现在模板中：
   ```bash
   cd packages/core && npx vitest run src/providers/__tests__/presets/alibaba-token-plan.test.ts
   ```
2. 运行 VS Code 伴侣目录测试，确认同步：
   ```bash
   cd packages/vscode-ide-companion && npx vitest run src/services/subscriptionPlanDefinitions.test.ts
   ```
3. 运行多模态默认值测试：
   ```bash
   cd packages/core && npx vitest run src/core/modalityDefaults.test.ts
   ```

### 证据（前后对比）

N/A — 无用户可见 TUI 变化（仅预设/模型列表）。

### 测试环境

|     OS     | 状态  |
| :--------: | :---: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A  |
|  🐧 Linux  |  N/A  |

### 环境（可选）

N/A — 仅单元测试。

## 风险与范围

- 主要风险或权衡：拓宽后的 Kimi 多模态正则（`/^kimi-k2\./` 替代 `/^kimi-k2\.5/`）全局影响所有提供商，而非仅 Token Plan。根据 Kimi 文档这是正确的（k2.5、k2.6、k2.7 均支持图文+视频），但若未来某个 kimi-k2.x 模型取消多模态支持，需重新收窄正则。
- 未验证/超出范围：kimi-k2.6/k2.7-code 的 DashScope 特定输出 token 限制未添加到全局输出限制表中，因为这些是提供商级别的限制而非模型级别的限制（遵循 PR #5397 对 GLM 输出限制确立的惯例）。
- 破坏性变更/迁移说明：无。已安装这些模型的用户将不再看到错误的"模型被移除"更新提示。

## 关联 Issue

N/A
</details>
