### PR TITLE
fix(desktop): enforce session plans path boundary

### DIFF
--- a/packages/desktop/packages/session-tools-core/src/handlers/submit-plan.test.ts
+++ b/packages/desktop/packages/session-tools-core/src/handlers/submit-plan.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'bun:test';
+import { join } from 'node:path';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { handleSubmitPlan } from './submit-plan.ts';
+import type { SessionToolContext } from '../context.ts';
+
+function createCtx(
+  plansFolderPath: string,
+  opts: {
+    exists?: boolean;
+    readFile?: string;
+    onRead?: (path: string) => void;
+    onSubmitted?: (path: string) => void;
+  } = {}
+): SessionToolContext {
+  return {
+    sessionId: 'session-123',
+    workspacePath: join('/tmp', 'workspace'),
+    get sourcesPath() {
+      return join(this.workspacePath, 'sources');
+    },
+    get skillsPath() {
+      return join(this.workspacePath, 'skills');
+    },
+    plansFolderPath,
+    callbacks: {
+      onPlanSubmitted: (path: string) => opts.onSubmitted?.(path),
+      onAuthRequest: () => {},
+    },
+    fs: {
+      exists: () => opts.exists ?? true,
+      readFile: (path: string) => {
+        opts.onRead?.(path);
+        return opts.readFile ?? '# Plan';
+      },
+      readFileBuffer: () => Buffer.from(opts.readFile ?? '# Plan'),
+      writeFile: () => {},
+      isDirectory: () => false,
+      readdir: () => [],
+      stat: () => ({ size: 0, isDirectory: () => false }),
+    },
+    loadSourceConfig: () => null,
+  };
+}
+
+describe('handleSubmitPlan', () => {
+  const plansFolderPath = join('/tmp', 'workspace', 'sessions', 'session-123', 'plans');
+
+  it('submits a plan inside the session plans directory', async () => {
+    const submitted: string[] = [];
+    const planPath = join(plansFolderPath, 'plan.md');
+    const ctx = createCtx(plansFolderPath, {
+      onSubmitted: (path) => submitted.push(path),
+    });
+
+    const result = await handleSubmitPlan(ctx, { planPath });
+
+    expect(result.isError).toBe(false);
+    expect(submitted).toEqual([planPath]);
+  });
+
+  it('rejects sibling paths that share the plans directory prefix', async () => {
+    const readAttempts: string[] = [];
+    const submitted: string[] = [];
+    const siblingPlanPath = join(`${plansFolderPath}-other`, 'plan.md');
+    const ctx = createCtx(plansFolderPath, {
+      onRead: (path) => readAttempts.push(path),
+      onSubmitted: (path) => submitted.push(path),
+    });
+
+    const result = await handleSubmitPlan(ctx, { planPath: siblingPlanPath });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('session plans directory');
+    expect(readAttempts).toEqual([]);
+    expect(submitted).toEqual([]);
+  });
+
+  it('rejects paths that escape the plans directory through a symlink', async () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
+    const rootDir = mkdtempSync(join(tmpdir(), 'submit-plan-boundary-'));
+    try {
+      const realPlansDir = join(rootDir, 'plans');
+      const outsideDir = join(rootDir, 'outside');
+      mkdirSync(realPlansDir, { recursive: true });
+      mkdirSync(outsideDir, { recursive: true });
+      writeFileSync(join(outsideDir, 'plan.md'), '# outside');
+      symlinkSync(outsideDir, join(realPlansDir, 'escape-link'), 'dir');
+
+      const readAttempts: string[] = [];
+      const submitted: string[] = [];
+      const ctx = createCtx(realPlansDir, {
+        onRead: (path) => readAttempts.push(path),
+        onSubmitted: (path) => submitted.push(path),
+      });
+
+      const result = await handleSubmitPlan(ctx, {
+        planPath: join(realPlansDir, 'escape-link', 'plan.md'),
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('session plans directory');
+      expect(readAttempts).toEqual([]);
+      expect(submitted).toEqual([]);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/desktop/packages/session-tools-core/src/handlers/submit-plan.ts
+++ b/packages/desktop/packages/session-tools-core/src/handlers/submit-plan.ts
@@ -8,6 +8,7 @@
 import type { SessionToolContext } from '../context.ts';
 import type { ToolResult } from '../types.ts';
 import { successResponse, errorResponse } from '../response.ts';
+import { isPathWithinDirectory } from '../runtime/path-security.ts';
 
 export interface SubmitPlanArgs {
   planPath: string;
@@ -26,6 +27,12 @@ export async function handleSubmitPlan(
   args: SubmitPlanArgs
 ): Promise<ToolResult> {
   const { planPath } = args;
+
+  if (!isPathWithinDirectory(planPath, ctx.plansFolderPath)) {
+    return errorResponse(
+      `Plan file must be inside the session plans directory: ${ctx.plansFolderPath}`
+    );
+  }
 
   // Verify the file exists
   if (!ctx.fs.exists(planPath)) {

--- a/packages/desktop/packages/shared/src/agent/__tests__/session-scoped-tools-path-boundary.test.ts
+++ b/packages/desktop/packages/shared/src/agent/__tests__/session-scoped-tools-path-boundary.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'bun:test';
+import { join } from 'node:path';
+import {
+  getSessionPlansDir,
+  isPathInPlansDir,
+} from '../session-scoped-tools.ts';
+
+describe('session-scoped plan path helpers', () => {
+  const workspacePath = join('/tmp', 'workspace');
+  const sessionId = 'session-123';
+
+  it('allows the plans directory itself', () => {
+    const plansDir = getSessionPlansDir(workspacePath, sessionId);
+
+    expect(isPathInPlansDir(plansDir, workspacePath, sessionId)).toBe(true);
+  });
+
+  it('allows child paths inside the plans directory', () => {
+    const plansDir = getSessionPlansDir(workspacePath, sessionId);
+    const planPath = join(plansDir, 'plan.md');
+
+    expect(isPathInPlansDir(planPath, workspacePath, sessionId)).toBe(true);
+  });
+
+  it('rejects sibling paths that share the plans directory prefix', () => {
+    const plansDir = getSessionPlansDir(workspacePath, sessionId);
+    const siblingPlanPath = join(`${plansDir}-other`, 'plan.md');
+
+    expect(isPathInPlansDir(siblingPlanPath, workspacePath, sessionId)).toBe(false);
+  });
+});

--- a/packages/desktop/packages/shared/src/agent/session-scoped-tools.ts
+++ b/packages/desktop/packages/shared/src/agent/session-scoped-tools.ts
@@ -17,7 +17,7 @@
 
 import { getSessionPlansPath, getSessionPath } from '../sessions/storage.ts';
 import { DOC_REFS } from '../docs/index.ts';
-import { basename } from 'node:path';
+import { basename, isAbsolute, relative, sep } from 'node:path';
 import { createLocalMcpServer, localTool, type LocalTool } from '../mcp/local-tools.ts';
 
 // Import from session-tools-core: registry + schemas + base descriptions
@@ -140,7 +140,13 @@ export function getSessionPlansDir(workspacePath: string, sessionId: string): st
  */
 export function isPathInPlansDir(path: string, workspacePath: string, sessionId: string): boolean {
   const plansDir = getSessionPlansDir(workspacePath, sessionId);
-  return path.startsWith(plansDir);
+  const relativePath = relative(plansDir, path);
+  return (
+    relativePath === '' ||
+    (!relativePath.startsWith(`..${sep}`) &&
+      relativePath !== '..' &&
+      !isAbsolute(relativePath))
+  );
 }
 
 // ============================================================


### PR DESCRIPTION
## What this PR does

- Rejects `SubmitPlan` paths unless the submitted file is inside the current session's plans directory after path and symlink resolution.
- Updates the exported desktop shared `isPathInPlansDir` helper to use a real path-boundary check instead of a raw string prefix check.
- Adds regression coverage for both the `SubmitPlan` handler and the shared helper.

## Why it's needed

The old checks could treat a sibling path as being inside the plans directory if it shared the same string prefix. For example, `/tmp/workspace/sessions/session-123/plans-other/plan.md` starts with `/tmp/workspace/sessions/session-123/plans`, but it is not actually inside the plans directory. `SubmitPlan` should not read or submit that file.

## Reviewer Test Plan

### How to verify

- Review `handleSubmitPlan`: it should reject paths outside `ctx.plansFolderPath` before checking file existence or reading file contents, including symlink escapes from inside the plans directory.
- Review `isPathInPlansDir`: it should allow the plans directory itself and real children, but reject sibling-prefix paths such as `plans-other`.
- Run `bun test ./src/handlers/submit-plan.test.ts` from `packages/desktop/packages/session-tools-core`.
- Run `bun test ./src/agent/__tests__/session-scoped-tools-path-boundary.test.ts` from `packages/desktop/packages/shared`.
- Run `bun run typecheck` from `packages/desktop/packages/session-tools-core`.
- Run `bun run typecheck:shared` from `packages/desktop`.
- Run `npx prettier --check packages/desktop/packages/session-tools-core/src/handlers/submit-plan.ts packages/desktop/packages/session-tools-core/src/handlers/submit-plan.test.ts packages/desktop/packages/shared/src/agent/session-scoped-tools.ts packages/desktop/packages/shared/src/agent/__tests__/session-scoped-tools-path-boundary.test.ts`.

### Evidence (Before & After)

Before: a sibling path like `plans-other/plan.md` could pass the raw prefix check and be read/submitted as a plan path. After: `SubmitPlan` uses the existing symlink-aware path-security helper, and `isPathInPlansDir` uses a path-relative boundary check, so sibling prefixes are rejected and symlink escapes are not read.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; covered by CI/path semantics |
|  🐧 Linux  | ⚠️ not tested locally; covered by CI |

### Environment (optional)

Local Bun desktop workspace after `bun install --cwd packages/desktop --frozen-lockfile`.

## Risk & Scope

- Main risk or tradeoff: `SubmitPlan` now requires the plan file path to be inside the session plans folder before it will read the file, including after symlink resolution.
- Not validated / out of scope: changing where plan files are written or changing the plan approval UI.
- Breaking changes / migration notes: none for valid plans written to the session plans directory.

## Linked Issues

Fixes #5506

<details>
<summary>中文说明</summary>

## What this PR does

- 拒绝路径解析和软链解析后不在当前 session plans 目录内的 `SubmitPlan` 路径。
- 将 desktop shared 导出的 `isPathInPlansDir` helper 从裸字符串前缀判断改成真实路径边界判断。
- 为 `SubmitPlan` handler 和 shared helper 增加回归测试。

## Why it's needed

旧检查会把共享字符串前缀的兄弟路径误认为 plans 目录内部路径。例如 `/tmp/workspace/sessions/session-123/plans-other/plan.md` 以 `/tmp/workspace/sessions/session-123/plans` 开头，但它并不在 plans 目录内。`SubmitPlan` 不应该读取或提交这个文件。

## Reviewer Test Plan

### How to verify

- 检查 `handleSubmitPlan`：它应该在检查文件是否存在或读取文件内容之前，拒绝 `ctx.plansFolderPath` 外部的路径，包括从 plans 目录内部软链逃逸到外部的路径。
- 检查 `isPathInPlansDir`：它应该允许 plans 目录本身和真实子路径，但拒绝 `plans-other` 这样的兄弟前缀路径。
- 在 `packages/desktop/packages/session-tools-core` 下运行 `bun test ./src/handlers/submit-plan.test.ts`。
- 在 `packages/desktop/packages/shared` 下运行 `bun test ./src/agent/__tests__/session-scoped-tools-path-boundary.test.ts`。
- 在 `packages/desktop/packages/session-tools-core` 下运行 `bun run typecheck`。
- 在 `packages/desktop` 下运行 `bun run typecheck:shared`。
- 运行上面英文部分列出的 prettier 检查命令。

### Evidence (Before & After)

修复前：`plans-other/plan.md` 这类兄弟路径可能通过裸前缀检查，并被读取/提交为 plan path。修复后：`SubmitPlan` 复用现有的 symlink-aware path-security helper，`isPathInPlansDir` 使用 path-relative 边界检查，因此兄弟前缀会被拒绝，软链逃逸也不会被读取。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; covered by CI/path semantics |
|  🐧 Linux  | ⚠️ not tested locally; covered by CI |

### Environment (optional)

本地 Bun desktop workspace，先运行过 `bun install --cwd packages/desktop --frozen-lockfile`。

## Risk & Scope

- 主要风险或取舍：`SubmitPlan` 现在会要求 plan 文件路径在软链解析后仍必须位于 session plans folder 内，才会读取文件。
- 未验证 / 不在范围内：修改 plan 文件写入位置或 plan approval UI。
- Breaking changes / migration notes：对写入 session plans 目录的合法 plan 没有破坏性变更。

## Linked Issues

Fixes #5506

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
