### PR TITLE
fix(desktop): parse server ports strictly

### DIFF
--- a/packages/desktop/apps/electron/src/main/index.ts
+++ b/packages/desktop/apps/electron/src/main/index.ts
@@ -88,7 +88,7 @@ import { registerCoreRpcHandlers, cleanupSessionFileWatchForClient } from '@craf
 import type { PlatformServices } from '../runtime/platform'
 import { createElectronPlatform } from './platform'
 import type { HandlerDeps } from './handlers/handler-deps'
-import { bootstrapServer, releaseServerLock } from '@craft-agent/server-core/bootstrap'
+import { bootstrapServer, releaseServerLock, parseServerPort } from '@craft-agent/server-core/bootstrap'
 import { createMessagingBootstrap, type MessagingBootstrapHandle } from '@craft-agent/messaging-gateway'
 import { getCredentialManager } from '@craft-agent/shared/credentials'
 import { initModelRefreshService, getModelRefreshService, setFetcherPlatform } from '@craft-agent/server-core/model-fetchers'
@@ -589,8 +589,9 @@ app.whenReady().then(async () => {
         : randomUUID()
       const rpcHost = process.env.CRAFT_RPC_HOST
         ?? (serverModeEnabled ? '0.0.0.0' : '127.0.0.1')
-      const rpcPort = process.env.CRAFT_RPC_PORT
-        ? parseInt(process.env.CRAFT_RPC_PORT, 10)
+      const envRpcPort = process.env.CRAFT_RPC_PORT
+      const rpcPort = envRpcPort
+        ? parseServerPort('CRAFT_RPC_PORT', envRpcPort, 9100)
         : (serverModeEnabled ? embeddedServerConfig.port : 0)
 
       // Load TLS certificates if configured

--- a/packages/desktop/packages/server-core/src/bootstrap/__tests__/server-port.test.ts
+++ b/packages/desktop/packages/server-core/src/bootstrap/__tests__/server-port.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'bun:test'
+import { parseServerPort } from '../headless-start'
+
+describe('parseServerPort', () => {
+  it('uses the default when the value is undefined', () => {
+    expect(parseServerPort('CRAFT_RPC_PORT', undefined, 9100)).toBe(9100)
+  })
+
+  it('accepts whole decimal ports', () => {
+    expect(parseServerPort('CRAFT_RPC_PORT', '0', 9100)).toBe(0)
+    expect(parseServerPort('CRAFT_RPC_PORT', '9100', 0)).toBe(9100)
+    expect(parseServerPort('CRAFT_RPC_PORT', '65535', 0)).toBe(65535)
+    expect(parseServerPort('CRAFT_RPC_PORT', ' 3000 ', 0)).toBe(3000)
+  })
+
+  it('accepts integer numeric ports from bootstrap options', () => {
+    expect(parseServerPort('rpcPort', 0, 9100)).toBe(0)
+    expect(parseServerPort('rpcPort', 3000, 0)).toBe(3000)
+  })
+
+  it('rejects partially parsed port strings', () => {
+    expect(() => parseServerPort('CRAFT_RPC_PORT', '9100abc', 9100)).toThrow(/Invalid CRAFT_RPC_PORT/)
+    expect(() => parseServerPort('CRAFT_RPC_PORT', '3000.5', 9100)).toThrow(/Invalid CRAFT_RPC_PORT/)
+    expect(() => parseServerPort('CRAFT_RPC_PORT', '1e3', 9100)).toThrow(/Invalid CRAFT_RPC_PORT/)
+  })
+
+  it('rejects out-of-range or non-integer ports', () => {
+    expect(() => parseServerPort('CRAFT_RPC_PORT', '-1', 9100)).toThrow(/Invalid CRAFT_RPC_PORT/)
+    expect(() => parseServerPort('CRAFT_RPC_PORT', '65536', 9100)).toThrow(/Invalid CRAFT_RPC_PORT/)
+    expect(() => parseServerPort('rpcPort', 3000.5, 9100)).toThrow(/Invalid rpcPort/)
+  })
+})

--- a/packages/desktop/packages/server-core/src/bootstrap/headless-start.ts
+++ b/packages/desktop/packages/server-core/src/bootstrap/headless-start.ts
@@ -109,6 +109,29 @@ export function generateServerToken(): string {
   return Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('')
 }
 
+const PORT_VALUE_PATTERN = /^\d+$/
+
+export function parseServerPort(name: string, value: string | number | undefined, defaultPort: number): number {
+  const raw = value ?? defaultPort
+  let port: number
+
+  if (typeof raw === 'number') {
+    port = raw
+  } else {
+    const trimmed = raw.trim()
+    if (!PORT_VALUE_PATTERN.test(trimmed)) {
+      throw new Error(`Invalid ${name}: expected an integer port between 0 and 65535, got ${JSON.stringify(raw)}`)
+    }
+    port = Number(trimmed)
+  }
+
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    throw new Error(`Invalid ${name}: expected an integer port between 0 and 65535, got ${String(raw)}`)
+  }
+
+  return port
+}
+
 // ---------------------------------------------------------------------------
 // Startup lock file
 // ---------------------------------------------------------------------------
@@ -284,11 +307,9 @@ export async function bootstrapServer<TSessionManager, THandlerDeps>(
   const sessionManager = options.createSessionManager()
 
   const rpcHost = options.rpcHost ?? process.env.CRAFT_RPC_HOST ?? '127.0.0.1'
-  const rpcPortRaw = options.rpcPort ?? parseInt(process.env.CRAFT_RPC_PORT ?? '9100', 10)
-  if (!Number.isFinite(rpcPortRaw) || rpcPortRaw < 0 || rpcPortRaw > 65535) {
-    throw new Error(`Invalid RPC port: ${rpcPortRaw}`)
-  }
-  const rpcPort = Math.trunc(rpcPortRaw)
+  const rpcPort = options.rpcPort != null
+    ? parseServerPort('rpcPort', options.rpcPort, 9100)
+    : parseServerPort('CRAFT_RPC_PORT', process.env.CRAFT_RPC_PORT, 9100)
 
   const wsServer = new WsRpcServer({
     host: rpcHost,

--- a/packages/desktop/packages/server/src/__tests__/smoke.test.ts
+++ b/packages/desktop/packages/server/src/__tests__/smoke.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, it, expect, afterEach } from 'bun:test'
 import { join } from 'node:path'
+import { tmpdir } from 'node:os'
 import type { Subprocess } from 'bun'
 import WebSocket from 'ws'
 
@@ -94,6 +95,61 @@ async function spawnTestServer(extraEnv?: Record<string, string>): Promise<Spawn
   })
 }
 
+async function readStream(stream: ReadableStream<Uint8Array> | null): Promise<string> {
+  if (!stream) return ''
+
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let output = ''
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    output += decoder.decode(value, { stream: true })
+  }
+
+  output += decoder.decode()
+  return output
+}
+
+async function runServerExpectingStartupFailure(extraEnv: Record<string, string>): Promise<{
+  exitCode: number | null
+  output: string
+}> {
+  const token = crypto.randomUUID() + crypto.randomUUID()
+  const proc = Bun.spawn(['bun', 'run', SERVER_ENTRY], {
+    env: {
+      ...process.env,
+      ...extraEnv,
+      CRAFT_SERVER_TOKEN: token,
+      CRAFT_RPC_HOST: '127.0.0.1',
+      CRAFT_SERVER_LOCK_FILE: join(tmpdir(), `qwen-code-server-test-${crypto.randomUUID()}.lock`),
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  const exitCode = await Promise.race([
+    proc.exited,
+    new Promise<never>((_, reject) => {
+      timeout = setTimeout(() => {
+        proc.kill()
+        reject(new Error('Server did not exit after invalid startup config'))
+      }, STARTUP_TIMEOUT)
+    }),
+  ]).finally(() => {
+    if (timeout) clearTimeout(timeout)
+  })
+
+  const [stdout, stderr] = await Promise.all([
+    readStream(proc.stdout),
+    readStream(proc.stderr),
+  ])
+
+  return { exitCode, output: `${stdout}\n${stderr}` }
+}
+
 function connectWs(url: string, token: string): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
     const ws = new WebSocket(url)
@@ -161,6 +217,29 @@ describe('headless server smoke test', () => {
 
     const exitCode = await proc.exited
     expect(exitCode).not.toBe(0)
+  }, TEST_TIMEOUT)
+
+  it('rejects partially parsed RPC ports at startup', async () => {
+    const result = await runServerExpectingStartupFailure({
+      CRAFT_RPC_PORT: '9100abc',
+      CRAFT_HEALTH_PORT: '0',
+    })
+
+    expect(result.exitCode).not.toBe(0)
+    expect(result.output).toContain('Invalid CRAFT_RPC_PORT')
+    expect(result.output).not.toContain('CRAFT_SERVER_URL=')
+  }, TEST_TIMEOUT)
+
+  it('rejects partially parsed health ports before starting', async () => {
+    const result = await runServerExpectingStartupFailure({
+      CRAFT_RPC_PORT: '0',
+      CRAFT_HEALTH_PORT: '3000abc',
+    })
+
+    expect(result.exitCode).not.toBe(0)
+    expect(result.output).toContain('Invalid CRAFT_HEALTH_PORT')
+    expect(result.output).not.toContain('Qwen Code server listening')
+    expect(result.output).not.toContain('CRAFT_SERVER_URL=')
   }, TEST_TIMEOUT)
 
   it('shuts down cleanly on SIGTERM', async () => {

--- a/packages/desktop/packages/server/src/index.ts
+++ b/packages/desktop/packages/server/src/index.ts
@@ -30,7 +30,7 @@ import { homedir } from 'node:os'
 import { readFileSync, existsSync } from 'node:fs'
 import { version as packageVersion } from '../package.json'
 import { enableDebug } from '@craft-agent/shared/utils/debug'
-import { bootstrapServer, startHealthHttpServer, generateServerToken } from '@craft-agent/server-core/bootstrap'
+import { bootstrapServer, startHealthHttpServer, generateServerToken, parseServerPort } from '@craft-agent/server-core/bootstrap'
 import { validateSession, createWebuiHandler, nodeHttpAdapter } from '@craft-agent/server-core/webui'
 import type { WebuiHandler } from '@craft-agent/server-core/webui'
 import { getCredentialManager } from '@craft-agent/shared/credentials'
@@ -90,6 +90,15 @@ function parseOptionalWebSocketUrl(name: string, value: string | undefined): str
   }
 }
 
+function parseServerPortOrExit(name: string, value: string | undefined, defaultPort: number): number {
+  try {
+    return parseServerPort(name, value, defaultPort)
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  }
+}
+
 // In dev (monorepo), bundled assets root is the repo root (4 levels up from this file).
 // In packaged mode, use CRAFT_BUNDLED_ASSETS_ROOT env or cwd.
 const bundledAssetsRoot = process.env.CRAFT_BUNDLED_ASSETS_ROOT
@@ -117,6 +126,7 @@ const webuiEnabled = webuiDir && existsSync(webuiDir)
 const webuiSecureCookies = parseOptionalBooleanEnv('CRAFT_WEBUI_SECURE_COOKIE', process.env.CRAFT_WEBUI_SECURE_COOKIE)
 const webuiWsUrl = parseOptionalWebSocketUrl('CRAFT_WEBUI_WS_URL', process.env.CRAFT_WEBUI_WS_URL)
 const serverToken = process.env.CRAFT_SERVER_TOKEN
+const healthPort = parseServerPortOrExit('CRAFT_HEALTH_PORT', process.env.CRAFT_HEALTH_PORT, 0)
 
 // ---------------------------------------------------------------------------
 // Create WebUI handler early so it can be embedded in the WsRpcServer.
@@ -132,7 +142,7 @@ let webuiNodeHandler: ReturnType<typeof nodeHttpAdapter> | undefined
 let healthCheckFn: (() => { status: string }) | null = null
 
 if (webuiEnabled && serverToken) {
-  const rpcPort = parseInt(process.env.CRAFT_RPC_PORT ?? '9100', 10)
+  const rpcPort = parseServerPortOrExit('CRAFT_RPC_PORT', process.env.CRAFT_RPC_PORT, 9100)
   const rpcProtocol = tls ? 'wss' as const : 'ws' as const
 
   webuiHandler = createWebuiHandler({
@@ -296,7 +306,6 @@ if (webuiHandler) {
 }
 
 // Start HTTP health endpoint if CRAFT_HEALTH_PORT is set
-const healthPort = parseInt(process.env.CRAFT_HEALTH_PORT ?? '0', 10)
 const healthServer = await startHealthHttpServer({
   port: healthPort,
   deps: { sessionManager: instance.sessionManager },


### PR DESCRIPTION
## What this PR does

- Adds a shared strict `parseServerPort` helper for desktop server bootstrap ports.
- Uses it for `CRAFT_RPC_PORT` in standalone server bootstrap, standalone WebUI setup, and Electron embedded server env overrides.
- Uses it for `CRAFT_HEALTH_PORT`, parsing the health port before starting the standalone server.
- Adds parser unit coverage and standalone server startup regression coverage.

## Why it's needed

`parseInt` accepts partial numbers. That means values like `CRAFT_RPC_PORT=9100abc` or `CRAFT_HEALTH_PORT=3000abc` could be treated as valid ports instead of failing fast. The server should only accept whole decimal TCP port numbers in the `0..65535` range.

## Reviewer Test Plan

### How to verify

- Review `parseServerPort`: it should accept whole decimal ports and reject trailing junk, fractions, exponent notation, negatives, and out-of-range values.
- Review standalone server startup: invalid `CRAFT_HEALTH_PORT` should be rejected before starting the WebSocket server.
- Review Electron embedded server startup: `CRAFT_RPC_PORT` env overrides should use the shared strict parser instead of `parseInt`.
- Run `bun test packages/desktop/packages/server-core/src/bootstrap/__tests__/server-port.test.ts` from the repo root.
- Run `bun test packages/desktop/packages/server/src/__tests__/smoke.test.ts` from the repo root.
- Run `bun run typecheck` from `packages/desktop/packages/server-core`.
- Run `bun run typecheck` from `packages/desktop/packages/server`.
- Run `bun run build:main` from `packages/desktop/apps/electron`.

### Evidence (Before & After)

Before: `parseInt('9100abc', 10)` returned `9100`, so malformed port env vars could silently bind a partially parsed port. After: `CRAFT_RPC_PORT=9100abc` and `CRAFT_HEALTH_PORT=3000abc` both exit non-zero with a clear invalid port error.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; covered by CI |
|  🐧 Linux  | ⚠️ not tested locally; covered by CI |

### Environment (optional)

Local desktop workspace after `bun install --cwd packages/desktop --frozen-lockfile` and root `npm ci --ignore-scripts` for tooling.

## Risk & Scope

- Main risk or tradeoff: env values that used to be partially accepted are now rejected. Valid integer ports are unchanged.
- Not validated / out of scope: full desktop `typecheck:all` still fails in existing Electron files unrelated to this PR (`src/main/auto-update.ts` and `src/main/handlers/__tests__/settings-default-thinking.test.ts`).
- Breaking changes / migration notes: configs like `9100abc`, `3000.5`, or `1e3` must be changed to plain decimal port numbers.

## Linked Issues

Fixes #5508

<details>
<summary>中文说明</summary>

## What this PR does

- 新增 desktop server bootstrap 端口专用的严格 `parseServerPort` helper。
- 将 standalone server bootstrap、standalone WebUI 配置、Electron embedded server env override 里的 `CRAFT_RPC_PORT` 改成复用严格解析。
- 将 `CRAFT_HEALTH_PORT` 改成严格解析，并提前到 standalone server 启动前解析。
- 增加 parser 单测和 standalone server 启动级回归测试。

## Why it's needed

`parseInt` 会接受部分数字。比如 `CRAFT_RPC_PORT=9100abc` 或 `CRAFT_HEALTH_PORT=3000abc` 可能被当成合法端口，而不是尽早失败。server 端口环境变量应该只接受 `0..65535` 范围内的完整十进制整数。

## Reviewer Test Plan

### How to verify

- 检查 `parseServerPort`：应接受完整十进制端口，拒绝尾随字符、小数、指数写法、负数和越界值。
- 检查 standalone server 启动：非法 `CRAFT_HEALTH_PORT` 应该在 WebSocket server 启动前被拒绝。
- 检查 Electron embedded server 启动：`CRAFT_RPC_PORT` env override 应该使用共享严格 parser，而不是 `parseInt`。
- 运行英文部分列出的测试和 typecheck/build 命令。

### Evidence (Before & After)

修复前：`parseInt('9100abc', 10)` 返回 `9100`，格式错误的端口环境变量可能被静默截断并绑定到部分解析出的端口。修复后：`CRAFT_RPC_PORT=9100abc` 和 `CRAFT_HEALTH_PORT=3000abc` 都会非零退出，并打印清晰的 invalid port 错误。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; covered by CI |
|  🐧 Linux  | ⚠️ not tested locally; covered by CI |

### Environment (optional)

本地 desktop workspace，已运行 `bun install --cwd packages/desktop --frozen-lockfile`；为了 tooling 也运行了 root `npm ci --ignore-scripts`。

## Risk & Scope

- 主要风险或取舍：以前会被部分接受的 env 值现在会被拒绝。合法整数端口不受影响。
- 未验证 / 不在范围内：完整 desktop `typecheck:all` 仍在本 PR 无关的既有 Electron 文件失败（`src/main/auto-update.ts` 和 `src/main/handlers/__tests__/settings-default-thinking.test.ts`）。
- Breaking changes / migration notes：`9100abc`、`3000.5`、`1e3` 这类配置需要改成普通十进制端口数字。

## Linked Issues

Fixes #5508

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
