### PR TITLE
fix(desktop): validate generic oauth token responses

### DIFF
--- a/packages/desktop/packages/shared/src/auth/__tests__/generic-oauth.test.ts
+++ b/packages/desktop/packages/shared/src/auth/__tests__/generic-oauth.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { exchangeGenericOAuth, refreshGenericOAuthToken } from '../generic-oauth.ts';
+import type { OAuthExchangeParams } from '../oauth-flow-types.ts';
+
+const exchangeParams: OAuthExchangeParams = {
+  code: 'code-123',
+  codeVerifier: 'verifier-123',
+  tokenEndpoint: 'https://auth.example.com/oauth/token',
+  clientId: 'client-123',
+  clientSecret: 'secret-123',
+  redirectUri: 'https://app.example.com/callback',
+};
+
+function mockTokenResponse(body: unknown, contentType = 'application/json') {
+  globalThis.fetch = (async () =>
+    new Response(
+      typeof body === 'string' ? body : JSON.stringify(body),
+      { status: 200, headers: { 'Content-Type': contentType } },
+    )) as unknown as typeof globalThis.fetch;
+}
+
+describe('generic OAuth token responses', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('exchanges JSON token responses with numeric expires_in', async () => {
+    mockTokenResponse({
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      expires_in: 3600,
+    });
+
+    const result = await exchangeGenericOAuth(exchangeParams);
+
+    expect(result.success).toBe(true);
+    expect(result.accessToken).toBe('access-token');
+    expect(result.refreshToken).toBe('refresh-token');
+    expect(result.expiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it('exchanges form-encoded token responses with string expires_in', async () => {
+    mockTokenResponse(
+      'access_token=access-token&refresh_token=refresh-token&expires_in=3600',
+      'application/x-www-form-urlencoded',
+    );
+
+    const result = await exchangeGenericOAuth(exchangeParams);
+
+    expect(result.success).toBe(true);
+    expect(result.accessToken).toBe('access-token');
+    expect(result.refreshToken).toBe('refresh-token');
+    expect(result.expiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it('rejects exchange responses without access_token', async () => {
+    mockTokenResponse({ refresh_token: 'refresh-token', expires_in: 3600 });
+
+    const result = await exchangeGenericOAuth(exchangeParams);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('missing access_token');
+  });
+
+  it('rejects exchange responses with malformed expires_in', async () => {
+    mockTokenResponse({ access_token: 'access-token', expires_in: '3600abc' });
+
+    const result = await exchangeGenericOAuth(exchangeParams);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('invalid expires_in');
+  });
+
+  it('rejects unsafe JSON number expires_in values', async () => {
+    mockTokenResponse({ access_token: 'access-token', expires_in: Number.MAX_SAFE_INTEGER + 1 });
+
+    const result = await exchangeGenericOAuth(exchangeParams);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('invalid expires_in');
+  });
+
+  it('preserves zero-second expiries instead of treating them as missing', async () => {
+    mockTokenResponse({ access_token: 'access-token', expires_in: 0 });
+    const before = Date.now();
+
+    const result = await exchangeGenericOAuth(exchangeParams);
+
+    expect(result.success).toBe(true);
+    expect(result.expiresAt).toBeGreaterThanOrEqual(before);
+    expect(result.expiresAt).toBeLessThanOrEqual(Date.now());
+  });
+
+  it('rejects refresh responses without access_token', async () => {
+    mockTokenResponse({ refresh_token: 'refresh-token', expires_in: 3600 });
+
+    await expect(
+      refreshGenericOAuthToken(
+        'refresh-token',
+        'https://auth.example.com/oauth/token',
+        'client-123',
+        'secret-123',
+      ),
+    ).rejects.toThrow('missing access_token');
+  });
+
+  it('refreshes JSON token responses with refresh_token and numeric expires_in', async () => {
+    mockTokenResponse({
+      access_token: 'new-access-token',
+      refresh_token: 'new-refresh-token',
+      expires_in: 3600,
+    });
+
+    const result = await refreshGenericOAuthToken(
+      'old-refresh-token',
+      'https://auth.example.com/oauth/token',
+      'client-123',
+      'secret-123',
+    );
+
+    expect(result.accessToken).toBe('new-access-token');
+    expect(result.refreshToken).toBe('new-refresh-token');
+    expect(result.expiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it('preserves zero-second expiries on refresh responses', async () => {
+    mockTokenResponse({ access_token: 'new-access-token', expires_in: 0 });
+    const before = Date.now();
+
+    const result = await refreshGenericOAuthToken(
+      'old-refresh-token',
+      'https://auth.example.com/oauth/token',
+      'client-123',
+      'secret-123',
+    );
+
+    expect(result.accessToken).toBe('new-access-token');
+    expect(result.expiresAt).toBeGreaterThanOrEqual(before);
+    expect(result.expiresAt).toBeLessThanOrEqual(Date.now());
+  });
+
+  it('rejects refresh responses with malformed expires_in', async () => {
+    mockTokenResponse({ access_token: 'access-token', expires_in: '1e3' });
+
+    await expect(
+      refreshGenericOAuthToken(
+        'refresh-token',
+        'https://auth.example.com/oauth/token',
+        'client-123',
+        'secret-123',
+      ),
+    ).rejects.toThrow('invalid expires_in');
+  });
+});

--- a/packages/desktop/packages/shared/src/auth/generic-oauth.ts
+++ b/packages/desktop/packages/shared/src/auth/generic-oauth.ts
@@ -17,7 +17,7 @@ import { generatePKCE, generateState } from './pkce.ts';
  * GitHub (and some other providers) return form-encoded unless you send Accept: application/json.
  * We send Accept: application/json but tolerate form-encoded as a fallback.
  */
-function parseTokenResponse(body: string, contentType: string | null): Record<string, string> {
+function parseTokenResponse(body: string, contentType: string | null): Record<string, unknown> {
   if (contentType?.includes('application/json')) {
     return JSON.parse(body);
   }
@@ -29,6 +29,43 @@ function parseTokenResponse(body: string, contentType: string | null): Record<st
     // Not JSON — try form-urlencoded
   }
   return Object.fromEntries(new URLSearchParams(body));
+}
+
+function readStringField(data: Record<string, unknown>, field: string): string | undefined {
+  const value = data[field];
+  return typeof value === 'string' && value.length > 0
+    ? value
+    : undefined;
+}
+
+function readAccessToken(data: Record<string, unknown>): string | null {
+  return readStringField(data, 'access_token') ?? null;
+}
+
+function parseExpiresIn(data: Record<string, unknown>): number | undefined {
+  const raw = data.expires_in;
+  if (raw == null || raw === '') return undefined;
+
+  if (typeof raw === 'number') {
+    if (Number.isSafeInteger(raw) && raw >= 0) return raw;
+    throw new Error('Token response has invalid expires_in');
+  }
+
+  const trimmed = String(raw).trim();
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error('Token response has invalid expires_in');
+  }
+
+  const value = Number(trimmed);
+  if (!Number.isSafeInteger(value)) {
+    throw new Error('Token response has invalid expires_in');
+  }
+
+  return value;
+}
+
+function expiresAtFromSeconds(expiresIn: number | undefined): number | undefined {
+  return expiresIn == null ? undefined : Date.now() + expiresIn * 1000;
 }
 
 // ============================================================
@@ -123,16 +160,19 @@ export async function exchangeGenericOAuth(params: OAuthExchangeParams): Promise
     const data = parseTokenResponse(responseBody, response.headers.get('content-type'));
 
     if (data.error) {
-      return { success: false, error: `OAuth error: ${data.error} — ${data.error_description ?? ''}` };
+      return { success: false, error: `OAuth error: ${String(data.error)} — ${String(data.error_description ?? '')}` };
     }
 
-    const expiresIn = data.expires_in ? parseInt(data.expires_in, 10) : undefined;
+    const accessToken = readAccessToken(data);
+    if (!accessToken) {
+      return { success: false, error: 'Token exchange response missing access_token' };
+    }
 
     return {
       success: true,
-      accessToken: data.access_token,
-      refreshToken: data.refresh_token,
-      expiresAt: expiresIn ? Date.now() + expiresIn * 1000 : undefined,
+      accessToken,
+      refreshToken: readStringField(data, 'refresh_token'),
+      expiresAt: expiresAtFromSeconds(parseExpiresIn(data)),
       oauthClientId: params.clientId,
       oauthClientSecret: params.clientSecret,
     };
@@ -186,18 +226,17 @@ export async function refreshGenericOAuthToken(
   const data = parseTokenResponse(responseBody, response.headers.get('content-type'));
 
   if (data.error) {
-    throw new Error(`OAuth refresh error: ${data.error} — ${data.error_description ?? ''}`);
+    throw new Error(`OAuth refresh error: ${String(data.error)} — ${String(data.error_description ?? '')}`);
   }
 
-  if (!data.access_token) {
+  const accessToken = readAccessToken(data);
+  if (!accessToken) {
     throw new Error('Token refresh response missing access_token');
   }
 
-  const expiresIn = data.expires_in ? parseInt(data.expires_in, 10) : undefined;
-
   return {
-    accessToken: data.access_token,
-    refreshToken: data.refresh_token,
-    expiresAt: expiresIn ? Date.now() + expiresIn * 1000 : undefined,
+    accessToken,
+    refreshToken: readStringField(data, 'refresh_token'),
+    expiresAt: expiresAtFromSeconds(parseExpiresIn(data)),
   };
 }


### PR DESCRIPTION
## What this PR does

- Rejects generic OAuth exchange responses that do not include a non-empty `access_token`.
- Reuses the same non-empty `access_token` validation for generic OAuth refresh responses.
- Parses `expires_in` from JSON and form-encoded token responses without partial parsing.
- Preserves `expires_in: 0` as an immediate expiry instead of treating it as missing.
- Adds focused coverage for generic OAuth exchange and refresh token responses.

## Why it's needed

`SourceCredentialManager.exchangeAndStore()` saves `result.accessToken!` after a successful OAuth exchange. The generic OAuth exchange path could return `success: true` even when the token response was missing `access_token`, which could mark a source authenticated with an invalid credential.

The generic OAuth path also used `parseInt` for `expires_in`, so malformed values like `"3600abc"` were accepted as `3600`. Token lifetimes should only accept whole, safe, non-negative seconds.

## Reviewer Test Plan

### How to verify

- Review `exchangeGenericOAuth`: missing or empty `access_token` should return `success: false`.
- Review `refreshGenericOAuthToken`: missing or empty `access_token` should still throw.
- Review `expires_in` parsing: JSON numbers and form-encoded strings should be accepted only when they are safe non-negative integers.
- Review `expires_in: 0`: it should produce an immediate `expiresAt`, not `undefined`.
- Run `bun test packages/desktop/packages/shared/src/auth/__tests__/generic-oauth.test.ts` from the repo root.
- Run `bun run typecheck:shared` from `packages/desktop`.
- Run `npx prettier --check packages/desktop/packages/shared/src/auth/generic-oauth.ts packages/desktop/packages/shared/src/auth/__tests__/generic-oauth.test.ts`.
- Run `git diff --check`.

### Evidence (Before & After)

Before: a generic OAuth token exchange response like `{"refresh_token":"r"}` could be treated as successful, and `expires_in: "3600abc"` was accepted as `3600`. After: missing `access_token` fails exchange/refresh, malformed `expires_in` is rejected, and valid JSON/form-encoded token responses keep working.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; covered by CI |
|  🐧 Linux  | ⚠️ not tested locally; covered by CI |

### Environment (optional)

Local desktop workspace after `bun install --cwd packages/desktop --frozen-lockfile`; root `npm ci --ignore-scripts` was used for tooling.

## Risk & Scope

- Main risk or tradeoff: malformed generic OAuth token responses that were previously tolerated are now rejected.
- Not validated / out of scope: changing provider-specific Google, Slack, Microsoft, or MCP OAuth flows.
- Breaking changes / migration notes: generic OAuth providers must return a non-empty `access_token`; `expires_in`, when present, must be a whole non-negative second count.

## Linked Issues

Fixes #5510

<details>
<summary>中文说明</summary>

## What this PR does

- generic OAuth exchange response 缺少非空 `access_token` 时直接拒绝。
- generic OAuth refresh response 复用同一套非空 `access_token` 校验。
- 对 JSON 和 form-encoded token response 的 `expires_in` 做严格解析，不再部分解析。
- 保留 `expires_in: 0` 为立即过期，而不是当成缺失。
- 增加 generic OAuth exchange/refresh token response 的聚焦测试。

## Why it's needed

`SourceCredentialManager.exchangeAndStore()` 会在 OAuth exchange 成功后保存 `result.accessToken!`。generic OAuth exchange 路径以前即使 token response 缺少 `access_token`，也可能返回 `success: true`，从而把 source 标记为已认证并保存无效 credential。

generic OAuth 还用 `parseInt` 解析 `expires_in`，所以 `"3600abc"` 这类异常值会被当成 `3600`。token lifetime 应该只接受安全、非负、完整的秒数整数。

## Reviewer Test Plan

### How to verify

- 检查 `exchangeGenericOAuth`：缺少或为空的 `access_token` 应该返回 `success: false`。
- 检查 `refreshGenericOAuthToken`：缺少或为空的 `access_token` 仍应该抛错。
- 检查 `expires_in` 解析：JSON number 和 form-encoded string 只有在安全非负整数时才接受。
- 检查 `expires_in: 0`：应该生成立即过期的 `expiresAt`，而不是 `undefined`。
- 运行英文部分列出的测试、typecheck、prettier 和 `git diff --check`。

### Evidence (Before & After)

修复前：`{"refresh_token":"r"}` 这类 generic OAuth exchange response 可能被当作成功，`expires_in: "3600abc"` 会被当成 `3600`。修复后：缺少 `access_token` 的 exchange/refresh 会失败，格式错误的 `expires_in` 会被拒绝，合法 JSON/form-encoded token response 继续可用。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; covered by CI |
|  🐧 Linux  | ⚠️ not tested locally; covered by CI |

### Environment (optional)

本地 desktop workspace，已运行 `bun install --cwd packages/desktop --frozen-lockfile`；为了 tooling 也运行了 root `npm ci --ignore-scripts`。

## Risk & Scope

- 主要风险或取舍：以前被容忍的 malformed generic OAuth token response 现在会被拒绝。
- 未验证 / 不在范围内：修改 Google、Slack、Microsoft 或 MCP 这些 provider-specific OAuth flow。
- Breaking changes / migration notes：generic OAuth provider 必须返回非空 `access_token`；如果返回 `expires_in`，必须是完整的非负秒数整数。

## Linked Issues

Fixes #5510

</details>

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
