### PR TITLE
fix(desktop): keep workspace image paths in root

### DIFF
--- a/packages/desktop/packages/server-core/src/handlers/rpc/workspace.image-path.test.ts
+++ b/packages/desktop/packages/server-core/src/handlers/rpc/workspace.image-path.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { RPC_CHANNELS } from '@craft-agent/shared/protocol'
+import type { HandlerFn, RpcServer } from '@craft-agent/server-core/transport'
+import type { HandlerDeps } from '../handler-deps'
+
+let workspaceRoot = ''
+
+mock.module('@craft-agent/shared/config', () => ({
+  getWorkspaceByNameOrId: () => ({
+    id: 'workspace-1',
+    name: 'Workspace',
+    rootPath: workspaceRoot,
+  }),
+  addWorkspace: mock(() => null),
+  setActiveWorkspace: mock(() => {}),
+  updateWorkspaceRemoteServer: mock(() => {}),
+}))
+
+const { registerWorkspaceCoreHandlers } = await import('./workspace')
+
+function createWorkspaceImageHandlers() {
+  const handlers = new Map<string, HandlerFn>()
+  const server: RpcServer = {
+    handle(channel, handler) {
+      handlers.set(channel, handler)
+    },
+    push() {},
+    async invokeClient() {
+      return undefined
+    },
+  }
+
+  const deps: HandlerDeps = {
+    sessionManager: {} as HandlerDeps['sessionManager'],
+    oauthFlowStore: {} as HandlerDeps['oauthFlowStore'],
+    platform: {
+      appRootPath: '/',
+      resourcesPath: '/',
+      isPackaged: false,
+      appVersion: '0.0.0-test',
+      isDebugMode: true,
+      logger: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
+      imageProcessor: {
+        getMetadata: async () => null,
+        process: async (buffer: Buffer) => buffer,
+      },
+    },
+  }
+
+  registerWorkspaceCoreHandlers(server, deps)
+
+  const readImage = handlers.get(RPC_CHANNELS.workspace.READ_IMAGE)
+  const writeImage = handlers.get(RPC_CHANNELS.workspace.WRITE_IMAGE)
+
+  if (!readImage || !writeImage) {
+    throw new Error('workspace image handlers not registered')
+  }
+
+  return { readImage, writeImage }
+}
+
+describe('workspace image path boundaries', () => {
+  let rootDir: string
+  let outsideDir: string
+
+  beforeEach(() => {
+    rootDir = mkdtempSync(join(tmpdir(), 'qwen-workspace-image-'))
+    workspaceRoot = join(rootDir, 'workspace')
+    outsideDir = join(rootDir, 'outside')
+    mkdirSync(workspaceRoot)
+    mkdirSync(outsideDir)
+  })
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true })
+    workspaceRoot = ''
+  })
+
+  it('returns null for missing optional images inside the workspace', async () => {
+    const { readImage } = createWorkspaceImageHandlers()
+
+    await expect(readImage({ clientId: 'c1', workspaceId: null, webContentsId: null }, 'workspace-1', 'missing.svg')).resolves.toBeNull()
+  })
+
+  it.skipIf(process.platform === 'win32')('rejects image reads that escape through a symlink', async () => {
+    const outsideImage = join(outsideDir, 'icon.svg')
+    writeFileSync(outsideImage, '<svg></svg>')
+    symlinkSync(outsideImage, join(workspaceRoot, 'icon.svg'), 'file')
+
+    const { readImage } = createWorkspaceImageHandlers()
+
+    await expect(readImage({ clientId: 'c1', workspaceId: null, webContentsId: null }, 'workspace-1', 'icon.svg')).rejects.toThrow(
+      'outside workspace directory',
+    )
+  })
+
+  it('rejects image writes that escape through a symlinked parent directory', async () => {
+    const outsideImage = join(outsideDir, 'icon.svg')
+    symlinkSync(outsideDir, join(workspaceRoot, 'linked-outside'), process.platform === 'win32' ? 'junction' : 'dir')
+
+    const { writeImage } = createWorkspaceImageHandlers()
+
+    await expect(
+      writeImage(
+        { clientId: 'c1', workspaceId: null, webContentsId: null },
+        'workspace-1',
+        'linked-outside/icon.svg',
+        Buffer.from('<svg></svg>').toString('base64'),
+        'image/svg+xml',
+      ),
+    ).rejects.toThrow('outside workspace directory')
+
+    expect(existsSync(outsideImage)).toBe(false)
+  })
+
+  it.skipIf(process.platform === 'win32')('rejects image writes through a broken final symlink', async () => {
+    const outsideImage = join(outsideDir, 'created.svg')
+    symlinkSync(outsideImage, join(workspaceRoot, 'icon.svg'), 'file')
+
+    const { writeImage } = createWorkspaceImageHandlers()
+
+    await expect(
+      writeImage(
+        { clientId: 'c1', workspaceId: null, webContentsId: null },
+        'workspace-1',
+        'icon.svg',
+        Buffer.from('<svg></svg>').toString('base64'),
+        'image/svg+xml',
+      ),
+    ).rejects.toThrow('outside workspace directory')
+
+    expect(existsSync(outsideImage)).toBe(false)
+  })
+
+  it('allows overwriting an image when the workspace root is a symlink', async () => {
+    const linkedWorkspaceRoot = join(rootDir, 'workspace-link')
+    symlinkSync(workspaceRoot, linkedWorkspaceRoot, process.platform === 'win32' ? 'junction' : 'dir')
+    workspaceRoot = linkedWorkspaceRoot
+
+    const realImage = join(rootDir, 'workspace', 'icon.svg')
+    writeFileSync(realImage, '<svg>old</svg>')
+
+    const { writeImage } = createWorkspaceImageHandlers()
+
+    await writeImage(
+      { clientId: 'c1', workspaceId: null, webContentsId: null },
+      'workspace-1',
+      'icon.svg',
+      Buffer.from('<svg>new</svg>').toString('base64'),
+      'image/svg+xml',
+    )
+
+    expect(readFileSync(realImage, 'utf8')).toBe('<svg>new</svg>')
+  })
+})

--- a/packages/desktop/packages/server-core/src/handlers/rpc/workspace.ts
+++ b/packages/desktop/packages/server-core/src/handlers/rpc/workspace.ts
@@ -1,8 +1,8 @@
 import { execFile } from 'node:child_process'
-import { existsSync } from 'node:fs'
+import { existsSync, lstatSync, realpathSync } from 'node:fs'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { homedir } from 'os'
-import { dirname, join } from 'path'
+import { dirname, isAbsolute, join, relative, resolve } from 'path'
 import { promisify } from 'node:util'
 import { RPC_CHANNELS } from '@craft-agent/shared/protocol'
 import { getWorkspaceByNameOrId, addWorkspace, setActiveWorkspace, updateWorkspaceRemoteServer } from '@craft-agent/shared/config'
@@ -43,6 +43,67 @@ function getWorktreeDirName(branchName: string): string {
     .replace(/[^a-zA-Z0-9._-]+/g, '-')
     .replace(/-+/g, '-')
     .replace(/^[.-]+|[.-]+$/g, '') || 'worktree'
+}
+
+function isPathWithinDirectory(baseDir: string, targetPath: string): boolean {
+  const relativePath = relative(baseDir, targetPath)
+  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath))
+}
+
+function pathEntryExists(path: string): boolean {
+  try {
+    lstatSync(path)
+    return true
+  } catch (error) {
+    const code = error && typeof error === 'object' ? (error as { code?: unknown }).code : undefined
+    return code !== 'ENOENT' && code !== 'ENOTDIR'
+  }
+}
+
+function realpathOrNull(path: string): string | null {
+  try {
+    return realpathSync.native(path)
+  } catch {
+    return null
+  }
+}
+
+function isExistingWorkspacePath(workspaceRoot: string, targetPath: string): boolean {
+  const resolvedRoot = resolve(workspaceRoot)
+  const resolvedTarget = resolve(targetPath)
+
+  if (!isPathWithinDirectory(resolvedRoot, resolvedTarget)) return false
+
+  const realRoot = realpathOrNull(resolvedRoot)
+  const realTarget = realpathOrNull(resolvedTarget)
+  if (!realRoot || !realTarget) return false
+
+  return isPathWithinDirectory(realRoot, realTarget)
+}
+
+function isWorkspacePathAllowingMissingTarget(workspaceRoot: string, targetPath: string): boolean {
+  const resolvedRoot = resolve(workspaceRoot)
+  const resolvedTarget = resolve(targetPath)
+
+  if (!isPathWithinDirectory(resolvedRoot, resolvedTarget)) return false
+
+  const realRoot = realpathOrNull(resolvedRoot)
+  if (!realRoot) return false
+
+  if (pathEntryExists(resolvedTarget)) {
+    return isExistingWorkspacePath(workspaceRoot, resolvedTarget)
+  }
+
+  let current = dirname(resolvedTarget)
+  while (true) {
+    if (pathEntryExists(current)) {
+      const realCurrent = realpathOrNull(current)
+      return !!realCurrent && isPathWithinDirectory(realRoot, realCurrent)
+    }
+    const parent = dirname(current)
+    if (parent === current) return false
+    current = parent
+  }
 }
 
 async function localBranchExists(repoRoot: string, branchName: string): Promise<boolean> {
@@ -297,8 +358,8 @@ export function registerWorkspaceCoreHandlers(server: RpcServer, deps: HandlerDe
     // Resolve path relative to workspace root
     const absolutePath = normalize(join(workspace.rootPath, relativePath))
 
-    // Double-check the resolved path is still within workspace
-    if (!absolutePath.startsWith(workspace.rootPath)) {
+    // Double-check the resolved path is still within workspace, including symlink targets.
+    if (!isWorkspacePathAllowingMissingTarget(workspace.rootPath, absolutePath)) {
       throw new Error('Invalid path: outside workspace directory')
     }
 
@@ -351,8 +412,8 @@ export function registerWorkspaceCoreHandlers(server: RpcServer, deps: HandlerDe
     // Resolve path relative to workspace root
     const absolutePath = normalize(join(workspace.rootPath, relativePath))
 
-    // Double-check the resolved path is still within workspace
-    if (!absolutePath.startsWith(workspace.rootPath)) {
+    // Double-check the resolved path is still within workspace, including symlink targets.
+    if (!isWorkspacePathAllowingMissingTarget(workspace.rootPath, absolutePath)) {
       throw new Error('Invalid path: outside workspace directory')
     }
 


### PR DESCRIPTION
## What this PR does

This PR hardens the workspace image RPC handlers (`READ_IMAGE` / `WRITE_IMAGE`) so that resolved image paths cannot escape the workspace root via symlinks. The previous boundary check relied only on a string `startsWith(workspace.rootPath)` comparison on the joined path, which can be bypassed when an entry inside the workspace is a symlink (or has a symlinked parent directory) that points outside the root.

The new logic resolves the real path of both the workspace root and the target via `realpathSync.native`, and verifies containment with a proper `path.relative` based check (`isPathWithinDirectory`) instead of a raw string prefix match. For writes to a not-yet-existing file, it walks up to the nearest existing ancestor and validates that ancestor's real path is still inside the workspace, so a symlinked parent directory or a broken final symlink is rejected before any file is written. Reads of a missing optional image continue to return `null` rather than throwing, preserving existing behavior. Legitimate cases — including a workspace whose root itself is a symlink — are still allowed.

A new focused test file adds coverage for these read/write image path boundaries.

## Why it's needed

Without resolving symlinks, the `startsWith` containment check could be tricked into reading or writing files outside the workspace directory (a path-traversal / symlink-escape issue). This fixes that boundary while keeping the existing "missing optional image returns null" behavior intact. See the linked issue for the reported problem.

## Reviewer Test Plan

### How to verify

- `bun test packages/desktop/packages/server-core/src/handlers/rpc/workspace.image-path.test.ts`
- `bun run typecheck` in `packages/desktop/packages/server-core`
- `npx prettier --check packages/desktop/packages/server-core/src/handlers/rpc/workspace.ts packages/desktop/packages/server-core/src/handlers/rpc/workspace.image-path.test.ts`
- `git diff --check`

### Evidence (Before & After)

N/A — internal logic change covered by unit tests. The new `workspace.image-path.test.ts` asserts: missing optional images return `null`; reads/writes that escape via a symlink or symlinked parent throw `outside workspace directory` and create no outside file; and overwriting an image works when the workspace root is itself a symlink.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested locally; covered by CI |
| 🪟 Windows | ⚠️ not tested locally; covered by CI |
|  🐧 Linux  | ⚠️ not tested locally; covered by CI |

### Environment (optional)

Local macOS workspace; unit tests via npm/vitest (desktop server-core uses bun:test, so the test command above is run via bun).

## Risk & Scope

- Main risk or tradeoff: low; scope-limited to the workspace image `READ_IMAGE` / `WRITE_IMAGE` path-containment check. The symlink-aware checks add `realpathSync`/`lstatSync` calls, but only on the image read/write paths.
- Not validated / out of scope: manual end-to-end run in the packaged desktop app.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5512

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

本 PR 加固了工作区图片的 RPC 处理器（`READ_IMAGE` / `WRITE_IMAGE`），使得解析后的图片路径无法通过符号链接（symlink）逃逸出工作区根目录。此前的边界检查只是对拼接后的路径做字符串 `startsWith(workspace.rootPath)` 比较，当工作区内的某个条目是指向根目录之外的符号链接（或其父目录是符号链接）时，这种检查可以被绕过。

新逻辑通过 `realpathSync.native` 解析工作区根目录和目标路径的真实路径，并使用基于 `path.relative` 的正确包含性检查（`isPathWithinDirectory`）来替代原始的字符串前缀匹配。对于写入尚不存在的文件，它会向上查找最近的已存在祖先目录，并校验该祖先目录的真实路径仍位于工作区内，因此在写入任何文件之前，符号链接的父目录或损坏的末端符号链接都会被拒绝。读取缺失的可选图片仍然返回 `null` 而非抛错，保持了既有行为。合法场景——包括工作区根目录本身就是符号链接的情况——依然被允许。

新增了一个专门的测试文件来覆盖这些读/写图片路径的边界。

## 为什么需要

如果不解析符号链接，`startsWith` 包含性检查可能被欺骗，从而读取或写入工作区目录之外的文件（一种路径穿越 / 符号链接逃逸问题）。本 PR 修复了该边界，同时保持了"缺失的可选图片返回 null"这一既有行为。具体问题见关联 Issue。

## Reviewer Test Plan（评审测试计划）

### 如何验证

- `bun test packages/desktop/packages/server-core/src/handlers/rpc/workspace.image-path.test.ts`
- 在 `packages/desktop/packages/server-core` 中执行 `bun run typecheck`
- `npx prettier --check packages/desktop/packages/server-core/src/handlers/rpc/workspace.ts packages/desktop/packages/server-core/src/handlers/rpc/workspace.image-path.test.ts`
- `git diff --check`

### 证据（前后对比）

不适用 —— 这是内部逻辑改动，已由单元测试覆盖。新增的 `workspace.image-path.test.ts` 断言：缺失的可选图片返回 `null`；通过符号链接或符号链接父目录逃逸的读/写会抛出 `outside workspace directory` 且不会在外部创建任何文件；当工作区根目录本身是符号链接时，覆盖写入图片可以正常工作。

### 测试平台

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ 本地未测试；由 CI 覆盖 |
| 🪟 Windows | ⚠️ 本地未测试；由 CI 覆盖 |
|  🐧 Linux  | ⚠️ 本地未测试；由 CI 覆盖 |

### 环境（可选）

本地 macOS 工作区；单元测试通过 npm/vitest 运行（desktop server-core 使用 bun:test，因此上述测试命令通过 bun 运行）。

## 风险与范围

- 主要风险或权衡：低；范围仅限于工作区图片 `READ_IMAGE` / `WRITE_IMAGE` 的路径包含性检查。符号链接感知的检查增加了 `realpathSync`/`lstatSync` 调用，但仅作用于图片读/写路径。
- 未验证 / 范围之外：在打包后的桌面应用中进行手动端到端运行。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #5512

## AI 协助声明

我使用了 Codex 来评审改动、对照既有模式核查实现，并帮助发现潜在的边界情况。

</details>
