### PR TITLE
fix(desktop): keep sibling paths absolute

### DIFF
--- a/packages/desktop/packages/shared/src/utils/__tests__/files.test.ts
+++ b/packages/desktop/packages/shared/src/utils/__tests__/files.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'bun:test'
+import { join, relative } from 'node:path'
+import { tmpdir } from 'node:os'
+import { formatSinglePathToRelative } from '../files.ts'
+
+describe('formatSinglePathToRelative', () => {
+  it('formats paths inside cwd as relative paths', () => {
+    const cwd = join(tmpdir(), 'qwen-format-path-project')
+    const filePath = join(cwd, 'src', 'index.ts')
+
+    expect(formatSinglePathToRelative(filePath, cwd)).toBe(
+      `./${relative(cwd, filePath)}`,
+    )
+  })
+
+  it('keeps sibling directories with the same prefix absolute', () => {
+    const cwd = join(tmpdir(), 'qwen-format-path-project')
+    const siblingPath = join(`${cwd}-other`, 'src', 'index.ts')
+
+    expect(formatSinglePathToRelative(siblingPath, cwd)).toBe(siblingPath)
+  })
+
+  it('formats paths whose segment starts with double dots but stays inside cwd', () => {
+    const cwd = join(tmpdir(), 'qwen-format-path-project')
+    const filePath = join(cwd, '..notes.md')
+
+    expect(formatSinglePathToRelative(filePath, cwd)).toBe(
+      `./${relative(cwd, filePath)}`,
+    )
+  })
+})

--- a/packages/desktop/packages/shared/src/utils/files.ts
+++ b/packages/desktop/packages/shared/src/utils/files.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, statSync, writeFileSync, unlinkSync, mkdtempSync, renameSync } from 'fs';
-import { extname, basename, resolve, join, relative } from 'path';
+import { extname, basename, resolve, join, relative, isAbsolute, sep } from 'path';
 import { execSync } from 'child_process';
 import { tmpdir } from 'os';
 
@@ -828,15 +828,19 @@ function readImageFile(tempFile: string): FileAttachment | null {
  * @returns Relative path prefixed with ./ or original path if outside cwd
  */
 export function formatSinglePathToRelative(absolutePath: string, cwd?: string): string {
-  const basePath = cwd || process.cwd();
+  const basePath = resolve(cwd || process.cwd());
+  const targetPath = resolve(absolutePath);
+  const relativePath = relative(basePath, targetPath);
 
-  if (absolutePath.startsWith(basePath)) {
-    const relativePath = relative(basePath, absolutePath);
-    if (relativePath && !relativePath.startsWith('..') && !relativePath.startsWith('./')) {
-      return './' + relativePath;
-    }
-    return relativePath || absolutePath;
+  if (
+    relativePath &&
+    relativePath !== '..' &&
+    !relativePath.startsWith(`..${sep}`) &&
+    !isAbsolute(relativePath)
+  ) {
+    return './' + relativePath;
   }
+
   return absolutePath;
 }
 


### PR DESCRIPTION
## What this PR does

This PR fixes how `formatSinglePathToRelative()` decides whether an absolute path lives inside the current working directory before rewriting it to a `./...` relative form.

- It replaces the raw string prefix check (`absolutePath.startsWith(basePath)`) with a real relative-path boundary check based on `relative()`, `isAbsolute()`, and the platform path separator (`sep`).
- Both the base directory and the target path are now normalized via `resolve()` before comparison.
- A path is rewritten to `./...` only when the computed relative path is non-empty, is not `..`, does not start with `..${sep}`, and is not itself absolute; otherwise the original absolute path is returned unchanged.
- This keeps sibling directories that merely share the same string prefix (for example `/tmp/project` vs `/tmp/project-other`) as absolute paths, while still correctly handling file names whose first segment starts with double dots but remain inside cwd (for example `..notes.md`).
- It adds focused regression coverage for three cases: paths inside cwd, sibling paths with the same prefix, and `..`-prefixed file names inside cwd.

## Why it's needed

`formatSinglePathToRelative()` previously tested membership in `cwd` with a raw string prefix. That misclassifies sibling directories that share the same prefix: with `cwd=/tmp/project`, the path `/tmp/project-other/file.txt` passes the prefix check and then gets formatted as `../project-other/file.txt`. Because this helper feeds tool input/output formatting via `formatToolInputPaths()`, an outside absolute path could be made to look like a relative path from the workspace. Only paths actually inside `cwd` should be rewritten to `./...`; sibling paths must stay absolute.

## Reviewer Test Plan

### How to verify

- `bun test packages/desktop/packages/shared/src/utils/__tests__/files.test.ts`
- `bun run typecheck:shared` in `packages/desktop`
- `npx eslint src/utils/files.ts src/utils/__tests__/files.test.ts` in `packages/desktop/packages/shared`
- `npx prettier --check packages/desktop/packages/shared/src/utils/files.ts packages/desktop/packages/shared/src/utils/__tests__/files.test.ts`
- `git diff --check`

### Evidence (Before & After)

N/A — internal logic change covered by unit tests. Before: `formatSinglePathToRelative('/tmp/project-other/file.txt', '/tmp/project')` returned `../project-other/file.txt`. After: it returns the original absolute path `/tmp/project-other/file.txt`, while paths actually inside cwd are still rewritten to `./...`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested locally; covered by CI |
| 🪟 Windows | ⚠️ not tested locally; covered by CI |
|  🐧 Linux  | ⚠️ not tested locally; covered by CI |

### Environment (optional)

Local macOS workspace; unit tests via npm/vitest.

## Risk & Scope

- Main risk or tradeoff: low; scope-limited to a single path-formatting helper in the desktop shared package.
- Not validated / out of scope: manual end-to-end verification through the desktop UI.
- Breaking changes / migration notes: none

## Linked Issues

Fixes #5516

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

本 PR 修复了 `formatSinglePathToRelative()` 在把绝对路径改写为 `./...` 相对形式之前，判断该路径是否位于当前工作目录内的逻辑。

- 用基于 `relative()`、`isAbsolute()` 和平台路径分隔符（`sep`）的真正相对路径边界检查，替换了原先的原始字符串前缀检查（`absolutePath.startsWith(basePath)`）。
- 现在在比较之前，会先通过 `resolve()` 对基准目录和目标路径分别做归一化。
- 只有当计算出的相对路径非空、不等于 `..`、不以 `..${sep}` 开头、且本身不是绝对路径时，才会改写为 `./...`；否则原样返回绝对路径。
- 这样可以让仅仅共享相同字符串前缀的兄弟目录（例如 `/tmp/project` 与 `/tmp/project-other`）保持为绝对路径，同时仍能正确处理首段以双点开头但实际位于 cwd 内的文件名（例如 `..notes.md`）。
- 新增了针对三种情况的回归测试覆盖：位于 cwd 内的路径、具有相同前缀的兄弟路径，以及位于 cwd 内的以 `..` 开头的文件名。

## 为什么需要它

`formatSinglePathToRelative()` 此前用原始字符串前缀来判断路径是否属于 `cwd`。这会错误地把共享相同前缀的兄弟目录归类进来：当 `cwd=/tmp/project` 时，路径 `/tmp/project-other/file.txt` 会通过前缀检查，然后被格式化成 `../project-other/file.txt`。由于该辅助函数会通过 `formatToolInputPaths()` 参与工具输入/输出的路径格式化，外部的绝对路径可能被伪装成相对于工作区的相对路径。只有真正位于 `cwd` 内的路径才应被改写为 `./...`；兄弟路径必须保持为绝对路径。

## 审阅者测试计划

### 如何验证

- `bun test packages/desktop/packages/shared/src/utils/__tests__/files.test.ts`
- 在 `packages/desktop` 下执行 `bun run typecheck:shared`
- 在 `packages/desktop/packages/shared` 下执行 `npx eslint src/utils/files.ts src/utils/__tests__/files.test.ts`
- `npx prettier --check packages/desktop/packages/shared/src/utils/files.ts packages/desktop/packages/shared/src/utils/__tests__/files.test.ts`
- `git diff --check`

### 证据（前后对比）

N/A — 属于内部逻辑变更，已由单元测试覆盖。修复前：`formatSinglePathToRelative('/tmp/project-other/file.txt', '/tmp/project')` 返回 `../project-other/file.txt`。修复后：它返回原始绝对路径 `/tmp/project-other/file.txt`，同时真正位于 cwd 内的路径仍会被改写为 `./...`。

### 测试平台

|    操作系统    |   状态   |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ 本地未测试；由 CI 覆盖 |
| 🪟 Windows | ⚠️ 本地未测试；由 CI 覆盖 |
|  🐧 Linux  | ⚠️ 本地未测试；由 CI 覆盖 |

### 环境（可选）

本地 macOS 工作区；通过 npm/vitest 运行单元测试。

## 风险与范围

- 主要风险或取舍：低；范围仅限于 desktop shared 包中的单个路径格式化辅助函数。
- 未验证 / 范围之外：通过 desktop UI 的手动端到端验证。
- 破坏性变更 / 迁移说明：无

## 关联 Issue

Fixes #5516

## AI 协助声明

我使用 Codex 来审阅改动、对照现有模式核对实现，并帮助发现潜在的边界情况。

</details>
