### PR TITLE
fix(desktop): normalize bundle restore target paths

### DIFF
--- a/packages/desktop/packages/shared/src/utils/__tests__/bundle-files.test.ts
+++ b/packages/desktop/packages/shared/src/utils/__tests__/bundle-files.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
 import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'fs'
-import { join } from 'path'
+import { join, sep } from 'path'
 import { tmpdir } from 'os'
 import {
   collectDirectoryFiles,
@@ -222,6 +222,21 @@ describe('bundle-files', () => {
       const target = join(tmpDir, 'target')
       mkdirSync(target)
       restoreFiles(target, files)
+
+      expect(readFileSync(join(target, 'test.txt'), 'utf-8')).toBe('restored content')
+    })
+
+    it('restores files when target directory has a trailing separator', () => {
+      const content = Buffer.from('restored content')
+      const files: BundleFile[] = [{
+        relativePath: 'test.txt',
+        contentBase64: content.toString('base64'),
+        size: content.length,
+      }]
+
+      const target = join(tmpDir, 'target')
+      mkdirSync(target)
+      restoreFiles(`${target}${sep}`, files)
 
       expect(readFileSync(join(target, 'test.txt'), 'utf-8')).toBe('restored content')
     })

--- a/packages/desktop/packages/shared/src/utils/bundle-files.ts
+++ b/packages/desktop/packages/shared/src/utils/bundle-files.ts
@@ -8,7 +8,7 @@
  */
 
 import { existsSync, readdirSync, readFileSync, statSync, mkdirSync, writeFileSync } from 'fs'
-import { join, relative, dirname, sep } from 'path'
+import { join, relative, dirname, sep, resolve, isAbsolute } from 'path'
 import { debug } from './debug.ts'
 
 /**
@@ -175,6 +175,8 @@ export function collectDirectoryFiles(dir: string, options?: CollectOptions): Bu
  * @throws Error if any file fails path validation (path traversal, absolute path, etc.)
  */
 export function restoreFiles(targetDir: string, files: BundleFile[]): void {
+  const resolvedTargetDir = resolve(targetDir)
+
   for (const file of files) {
     const error = validateBundleFile(file)
     if (error) {
@@ -182,10 +184,15 @@ export function restoreFiles(targetDir: string, files: BundleFile[]): void {
     }
 
     const nativePath = fromPortableRelPath(file.relativePath)
-    const fullPath = join(targetDir, nativePath)
+    const fullPath = resolve(resolvedTargetDir, nativePath)
 
     // Safety: ensure resolved path is inside target dir
-    if (!fullPath.startsWith(targetDir + sep) && fullPath !== targetDir) {
+    const relativeFromTarget = relative(resolvedTargetDir, fullPath)
+    if (
+      relativeFromTarget === '..' ||
+      relativeFromTarget.startsWith(`..${sep}`) ||
+      isAbsolute(relativeFromTarget)
+    ) {
       throw new Error(`Path escapes target directory: ${file.relativePath}`)
     }
 


### PR DESCRIPTION
## What this PR does

Makes `restoreFiles()` normalize its target directory before validating restore boundaries. The target path is now resolved with `path.resolve()`, and the containment check uses `path.relative()` (rejecting results that are `..`, start with `..` + separator, or are absolute) instead of the previous fragile `fullPath.startsWith(targetDir + sep)` comparison. As a result, target directories that include a trailing path separator are accepted and restored correctly, while path-traversal protection is preserved. Adds regression coverage for the trailing-separator restore case.

## Why it's needed

The previous boundary check compared the resolved file path against the raw `targetDir` string. When the caller passed a target directory with a trailing path separator (or an otherwise non-normalized form), the `startsWith(targetDir + sep)` comparison failed and a valid restore was incorrectly rejected as escaping the target directory. Normalizing both sides before comparison fixes this false positive without weakening the traversal guard. See #5518.

## Reviewer Test Plan

### How to verify

- `bun test packages/desktop/packages/shared/src/utils/__tests__/bundle-files.test.ts`
- `bun run typecheck:shared` in `packages/desktop`
- `npx eslint src/utils/bundle-files.ts src/utils/__tests__/bundle-files.test.ts` in `packages/desktop/packages/shared`
- `npx prettier --check packages/desktop/packages/shared/src/utils/bundle-files.ts packages/desktop/packages/shared/src/utils/__tests__/bundle-files.test.ts`
- `git diff --check`

### Evidence (Before & After)

N/A — internal logic change covered by unit tests. New regression test asserts that `restoreFiles()` succeeds when the target directory has a trailing separator.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; covered by CI |
|  🐧 Linux  | ⚠️ not tested locally; covered by CI |

### Environment (optional)

Local macOS workspace; unit tests via npm/vitest.

## Risk & Scope

- Main risk or tradeoff: low; scope-limited to `restoreFiles()` path normalization and its boundary check.
- Not validated / out of scope: manual e2e of the desktop bundle restore flow.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5518

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 `restoreFiles()` 在校验恢复边界之前先对目标目录进行归一化。现在目标路径会通过 `path.resolve()` 解析，并且包含性检查改用 `path.relative()`（拒绝结果为 `..`、以 `..` + 分隔符开头、或为绝对路径的情况），取代之前脆弱的 `fullPath.startsWith(targetDir + sep)` 比较。因此，带有结尾路径分隔符的目标目录现在能够被正确接受并完成恢复，同时仍然保留了防止路径穿越（path traversal）的保护。新增了针对结尾分隔符恢复场景的回归测试覆盖。

## 为什么需要

之前的边界检查是把解析后的文件路径与原始的 `targetDir` 字符串做比较。当调用方传入带有结尾路径分隔符（或其他未归一化形式）的目标目录时，`startsWith(targetDir + sep)` 比较会失败，导致一次合法的恢复被错误地判定为越出目标目录而遭拒绝。在比较前对两边都进行归一化即可修复这一误报，且不会削弱穿越保护。详见 #5518。

## 评审测试计划

### 如何验证

- `bun test packages/desktop/packages/shared/src/utils/__tests__/bundle-files.test.ts`
- 在 `packages/desktop` 中执行 `bun run typecheck:shared`
- 在 `packages/desktop/packages/shared` 中执行 `npx eslint src/utils/bundle-files.ts src/utils/__tests__/bundle-files.test.ts`
- `npx prettier --check packages/desktop/packages/shared/src/utils/bundle-files.ts packages/desktop/packages/shared/src/utils/__tests__/bundle-files.test.ts`
- `git diff --check`

### 证据（前后对比）

N/A —— 这是内部逻辑改动，已由单元测试覆盖。新增的回归测试断言：当目标目录带有结尾分隔符时，`restoreFiles()` 能够成功执行。

### 测试平台

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 本地未测试；由 CI 覆盖 |
|  🐧 Linux  | ⚠️ 本地未测试；由 CI 覆盖 |

### 环境（可选）

本地 macOS 工作区；通过 npm/vitest 运行单元测试。

## 风险与范围

- 主要风险或权衡：低；范围仅限于 `restoreFiles()` 的路径归一化及其边界检查。
- 未验证 / 范围之外：桌面端 bundle 恢复流程的手动端到端测试。
- 破坏性改动 / 迁移说明：无。

## 关联 Issue

Fixes #5518

## AI 协助声明

我使用了 Codex 来评审这些改动、对照既有模式核对实现，并帮助发现潜在的边界情况。

</details>
