### PR TITLE
fix(cli): allow double dots in update archives

### DIFF
--- a/packages/cli/src/utils/standalone-update.test.ts
+++ b/packages/cli/src/utils/standalone-update.test.ts
@@ -13,6 +13,7 @@ import {
   ensureBinWrapper,
   ensurePathInShellRc,
   performStandaloneUpdate,
+  isSafeTarEntryPath,
 } from './standalone-update.js';
 
 describe('standalone-update', () => {
@@ -257,6 +258,25 @@ describe('standalone-update', () => {
 
       // Clean up lock
       fs.unlinkSync(lockPath);
+    });
+  });
+
+  describe('isSafeTarEntryPath', () => {
+    it('allows double dots inside a filename segment', () => {
+      expect(isSafeTarEntryPath('qwen-code/release..notes.md')).toBe(true);
+      expect(isSafeTarEntryPath('qwen-code/node/lib/foo..bar')).toBe(true);
+      expect(isSafeTarEntryPath('qwen-code/.../file.txt')).toBe(true);
+    });
+
+    it('rejects parent-directory segments and absolute paths', () => {
+      expect(isSafeTarEntryPath('../qwen-code/manifest.json')).toBe(false);
+      expect(isSafeTarEntryPath('qwen-code/../manifest.json')).toBe(false);
+      expect(isSafeTarEntryPath('qwen-code\\..\\manifest.json')).toBe(false);
+      expect(isSafeTarEntryPath('/tmp/qwen-code/manifest.json')).toBe(false);
+      expect(isSafeTarEntryPath('C:\\tmp\\qwen-code\\manifest.json')).toBe(
+        false,
+      );
+      expect(isSafeTarEntryPath('')).toBe(false);
     });
   });
 

--- a/packages/cli/src/utils/standalone-update.ts
+++ b/packages/cli/src/utils/standalone-update.ts
@@ -216,6 +216,14 @@ function validateExtractedPaths(resolvedDest: string): void {
   }
 }
 
+export function isSafeTarEntryPath(entryPath: string): boolean {
+  if (entryPath.length === 0) return false;
+  if (path.posix.isAbsolute(entryPath) || path.win32.isAbsolute(entryPath)) {
+    return false;
+  }
+  return !entryPath.split(/[\\/]+/).includes('..');
+}
+
 async function extractArchive(
   archivePath: string,
   destDir: string,
@@ -250,7 +258,7 @@ async function extractArchive(
       cwd: destDir,
       preservePaths: false,
       filter: (p, entry) => {
-        if (p.startsWith('/') || p.includes('..')) return false;
+        if (!isSafeTarEntryPath(p)) return false;
         if (
           'type' in entry &&
           entry.type === 'SymbolicLink' &&


### PR DESCRIPTION
## What this PR does

Refines the standalone updater's tar-extraction path filter so it no longer rejects safe filenames that merely contain consecutive dots. A new `isSafeTarEntryPath` helper replaces the old `p.startsWith('/') || p.includes('..')` check inside `extractArchive`. The helper:

- Rejects empty entry paths.
- Rejects absolute paths (both POSIX and Windows, via `path.posix.isAbsolute` / `path.win32.isAbsolute`).
- Splits the entry path on `/` or `\` separators and rejects it only when a whole segment is exactly `..` (a real parent-directory traversal).
- Allows `..` that appears inside a single filename segment (e.g. `qwen-code/release..notes.md`, `qwen-code/node/lib/foo..bar`, `qwen-code/.../file.txt`).

The function is exported so it can be unit-tested directly.

## Why it's needed

The previous filter rejected any archive entry whose path contained `..` anywhere. That blocked directory traversal, but it also dropped legitimate files whose names happen to contain consecutive dots (such as `qwen-code/release..notes.md` or `qwen-code/node/lib/foo..bar`), because the dots are part of a single path segment rather than a parent-directory segment. The desired behavior is to keep rejecting absolute paths and real `..` path segments while allowing safe filenames that merely contain consecutive dots.

## Reviewer Test Plan

### How to verify

- `npm run test --workspace=packages/cli -- standalone-update.test.ts`
- `npm run typecheck --workspace=packages/cli`
- `npm run build`
- `npx eslint packages/cli/src/utils/standalone-update.ts packages/cli/src/utils/standalone-update.test.ts`
- `npx prettier --check packages/cli/src/utils/standalone-update.ts packages/cli/src/utils/standalone-update.test.ts`
- `git diff --check`

### Evidence (Before & After)

N/A — internal logic change covered by unit tests. New `isSafeTarEntryPath` tests assert that double dots inside a filename segment are allowed while parent-directory segments and absolute paths (including backslash separators and `C:\...` drive paths) are rejected.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; covered by CI |
|  🐧 Linux  | ⚠️ not tested locally; covered by CI |

### Environment (optional)

Local macOS workspace; unit tests via npm/vitest.

## Risk & Scope

- Main risk or tradeoff: low; scope-limited to the tar-entry path filter in `packages/cli/src/utils/standalone-update.ts`. Traversal protection is preserved (absolute paths and real `..` segments are still rejected).
- Not validated / out of scope: manual end-to-end standalone update against a real release archive.
- Breaking changes / migration notes: none

## Linked Issues

Fixes #5520

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

优化独立更新器（standalone updater）的 tar 解压路径过滤逻辑，使其不再误拒仅仅包含连续点号的安全文件名。在 `extractArchive` 内部，用新的 `isSafeTarEntryPath` 辅助函数替换了原先的 `p.startsWith('/') || p.includes('..')` 判断。该辅助函数：

- 拒绝空的条目路径。
- 拒绝绝对路径（POSIX 与 Windows 两种，通过 `path.posix.isAbsolute` / `path.win32.isAbsolute` 判断）。
- 按 `/` 或 `\` 分隔符切分条目路径，仅当某个完整片段恰好为 `..`（真正的上级目录穿越）时才拒绝。
- 允许出现在单个文件名片段内部的 `..`（例如 `qwen-code/release..notes.md`、`qwen-code/node/lib/foo..bar`、`qwen-code/.../file.txt`）。

该函数被导出，以便可以直接进行单元测试。

## 为什么需要

之前的过滤器会拒绝任何路径中任意位置包含 `..` 的归档条目。这虽然阻止了目录穿越，但也丢弃了名字恰好包含连续点号的合法文件（例如 `qwen-code/release..notes.md` 或 `qwen-code/node/lib/foo..bar`），因为这些点号属于单个路径片段，而不是上级目录片段。期望的行为是：继续拒绝绝对路径和真正的 `..` 路径片段，同时允许仅仅包含连续点号的安全文件名。

## 审阅者测试计划

### 如何验证

- `npm run test --workspace=packages/cli -- standalone-update.test.ts`
- `npm run typecheck --workspace=packages/cli`
- `npm run build`
- `npx eslint packages/cli/src/utils/standalone-update.ts packages/cli/src/utils/standalone-update.test.ts`
- `npx prettier --check packages/cli/src/utils/standalone-update.ts packages/cli/src/utils/standalone-update.test.ts`
- `git diff --check`

### 证据（前后对比）

N/A — 属于内部逻辑改动，已由单元测试覆盖。新增的 `isSafeTarEntryPath` 测试断言：文件名片段内部的连续点号被允许，而上级目录片段和绝对路径（包括反斜杠分隔符以及 `C:\...` 盘符路径）被拒绝。

### 测试平台

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 本地未测试；由 CI 覆盖 |
|  🐧 Linux  | ⚠️ 本地未测试；由 CI 覆盖 |

### 环境（可选）

本地 macOS 工作区；通过 npm/vitest 运行单元测试。

## 风险与范围

- 主要风险或权衡：低；范围仅限于 `packages/cli/src/utils/standalone-update.ts` 中的 tar 条目路径过滤逻辑。穿越防护得以保留（绝对路径和真正的 `..` 片段仍被拒绝）。
- 未验证 / 范围之外：针对真实发布归档的手动端到端独立更新。
- 破坏性变更 / 迁移说明：无

## 关联 Issue

Fixes #5520

## AI 协助声明

我使用 Codex 审阅了这些改动，对照现有模式核对实现，并帮助发现潜在的边界情况。

</details>
