### PR TITLE
fix(desktop): handle Windows file mentions

### DIFF
--- a/packages/desktop/packages/shared/src/mentions/__tests__/resolve-file-mentions.test.ts
+++ b/packages/desktop/packages/shared/src/mentions/__tests__/resolve-file-mentions.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect } from 'bun:test'
 import { resolveFileMentions } from '../index.ts'
 
 const WORK_DIR = '/Users/me/project'
+const WINDOWS_WORK_DIR = 'C:\\Users\\me\\workspace'
 
 describe('resolveFileMentions', () => {
   describe('file mentions', () => {
@@ -24,6 +25,33 @@ describe('resolveFileMentions', () => {
     it('wraps home-relative file path in semantic marker', () => {
       expect(resolveFileMentions('[file:~/docs/notes.md] read this', WORK_DIR))
         .toBe('[Mentioned file: notes.md (at ~/docs/notes.md)] read this')
+    })
+
+    it('wraps Windows absolute file path in semantic marker', () => {
+      expect(
+        resolveFileMentions(
+          '[file:C:\\Users\\me\\project\\README.md] check this',
+          WINDOWS_WORK_DIR
+        )
+      ).toBe('[Mentioned file: README.md (at C:\\Users\\me\\project\\README.md)] check this')
+    })
+
+    it('wraps Windows forward-slash absolute file path in semantic marker', () => {
+      expect(
+        resolveFileMentions(
+          '[file:C:/Users/me/project/README.md] check this',
+          WINDOWS_WORK_DIR
+        )
+      ).toBe('[Mentioned file: README.md (at C:/Users/me/project/README.md)] check this')
+    })
+
+    it('wraps Windows UNC file path in semantic marker', () => {
+      expect(
+        resolveFileMentions(
+          '[file:\\\\server\\share\\project\\README.md] check this',
+          WINDOWS_WORK_DIR
+        )
+      ).toBe('[Mentioned file: README.md (at \\\\server\\share\\project\\README.md)] check this')
     })
 
     it('handles file at root of working directory', () => {
@@ -54,6 +82,15 @@ describe('resolveFileMentions', () => {
     it('wraps absolute folder path in semantic marker', () => {
       expect(resolveFileMentions('[folder:/tmp/output] list files', WORK_DIR))
         .toBe('[Mentioned folder: output (at /tmp/output)] list files')
+    })
+
+    it('wraps Windows absolute folder path in semantic marker', () => {
+      expect(
+        resolveFileMentions(
+          '[folder:C:\\Users\\me\\project\\src] explore',
+          WINDOWS_WORK_DIR
+        )
+      ).toBe('[Mentioned folder: src (at C:\\Users\\me\\project\\src)] explore')
     })
   })
 

--- a/packages/desktop/packages/shared/src/mentions/index.ts
+++ b/packages/desktop/packages/shared/src/mentions/index.ts
@@ -18,6 +18,19 @@ function joinPath(base: string, relative: string): string {
   return base.endsWith(sep) ? base + relative : base + sep + relative
 }
 
+function isAbsoluteMentionPath(path: string): boolean {
+  return (
+    path.startsWith('/') ||
+    path.startsWith('~') ||
+    /^[A-Za-z]:[\\/]/.test(path) ||
+    path.startsWith('\\\\')
+  )
+}
+
+function getPathBasename(path: string): string {
+  return path.split(/[\\/]/).pop() || path
+}
+
 // ============================================================================
 // Constants
 // ============================================================================
@@ -196,17 +209,17 @@ export function resolveSourceMentions(text: string): string {
 export function resolveFileMentions(text: string, workingDirectory: string): string {
   return text
     .replace(/\[file:([^\]]+)\]/g, (_match, filePath: string) => {
-      const resolved = filePath.startsWith('/') || filePath.startsWith('~')
+      const resolved = isAbsoluteMentionPath(filePath)
         ? filePath
         : joinPath(workingDirectory, filePath)
-      const name = filePath.split('/').pop() || filePath
+      const name = getPathBasename(filePath)
       return `[Mentioned file: ${name} (at ${resolved})]`
     })
     .replace(/\[folder:([^\]]+)\]/g, (_match, folderPath: string) => {
-      const resolved = folderPath.startsWith('/') || folderPath.startsWith('~')
+      const resolved = isAbsoluteMentionPath(folderPath)
         ? folderPath
         : joinPath(workingDirectory, folderPath)
-      const name = folderPath.split('/').pop() || folderPath
+      const name = getPathBasename(folderPath)
       return `[Mentioned folder: ${name} (at ${resolved})]`
     })
 }


### PR DESCRIPTION
Fixes #5522

## What this PR does

This makes desktop file and folder mention resolution recognize Windows drive-letter paths and UNC paths as absolute paths, even when running the tests on macOS.

It also uses slash/backslash-aware basename extraction so Windows-style mention display names are not treated as one long POSIX filename.

## Why it's needed

The old mention resolver only relied on POSIX-style path behavior in this code path, so Windows absolute paths could be treated like relative workspace paths and display names could include the full backslash path.

## Reviewer Test Plan

### How to verify

Run the file mention resolver tests and confirm Windows drive-letter, forward-slash drive-letter, UNC file path, and Windows folder path cases are handled as absolute mentions.

### Evidence (Before & After)

Before: Windows-style absolute paths could be resolved through the workspace-relative branch and shown with incorrect basenames.

After: `bun test packages/desktop/packages/shared/src/mentions/__tests__/resolve-file-mentions.test.ts` passes with regression coverage for drive-letter and UNC paths.

Additional checks run:

- `cd packages/desktop && bun run typecheck:shared`
- `cd packages/desktop/packages/shared && npx eslint src/mentions/index.ts src/mentions/__tests__/resolve-file-mentions.test.ts`
- `npx prettier --check packages/desktop/packages/shared/src/mentions/index.ts packages/desktop/packages/shared/src/mentions/__tests__/resolve-file-mentions.test.ts`
- `git diff --check`

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; Windows path cases covered by unit tests |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS checkout with Bun and Node test commands.

## Risk & Scope

- Main risk or tradeoff: low; scoped to desktop mention path classification and display-name extraction.
- Not validated / out of scope: manual Windows desktop session; covered by cross-platform path string regression tests.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5522

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让 desktop 文件 / 文件夹 mention 解析能识别 Windows drive-letter 路径和 UNC 路径为绝对路径，即使测试运行在 macOS 上也能覆盖这些字符串语义。

它也改用同时理解 slash/backslash 的 basename 提取，避免 Windows 风格 mention display name 被当作一个很长的 POSIX 文件名。

## Why it's needed

旧的 mention resolver 在这条路径上主要依赖 POSIX 风格路径行为，所以 Windows 绝对路径可能被当成 workspace-relative 路径，display name 也可能包含完整反斜杠路径。

## Reviewer Test Plan

### How to verify

运行 file mention resolver 测试，确认 Windows drive-letter、forward-slash drive-letter、UNC 文件路径和 Windows 文件夹路径都按绝对 mention 处理。

### Evidence (Before & After)

Before：Windows 风格绝对路径可能走 workspace-relative 分支，并显示错误 basename。

After：`bun test packages/desktop/packages/shared/src/mentions/__tests__/resolve-file-mentions.test.ts` 通过，并覆盖 drive-letter 与 UNC 路径回归。

另外还运行了上面列出的 typecheck、eslint、prettier 和 `git diff --check`。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; Windows path cases covered by unit tests |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 macOS checkout，使用 Bun 和 Node 测试命令。

## Risk & Scope

- 主要风险或取舍：低；范围限于 desktop mention path 分类和 display-name 提取。
- 未验证 / 不在范围内：手动 Windows desktop session；已用跨平台路径字符串回归测试覆盖。
- Breaking changes / migration notes：无。

</details>
