### PR TITLE
fix(desktop): separate transform data output lines

### DIFF
--- a/packages/desktop/packages/session-tools-core/src/handlers/transform-data.test.ts
+++ b/packages/desktop/packages/session-tools-core/src/handlers/transform-data.test.ts
@@ -106,13 +106,17 @@ describe('transform_data path containment', () => {
   it('allows valid descendant paths and writes output', async () => {
     const result = await handleTransformData(ctx(), {
       language: 'node',
-      script: "const fs=require('node:fs');fs.writeFileSync(process.argv.at(-1), JSON.stringify({ok:true}));",
+      script: "const fs=require('node:fs');console.log('made output');fs.writeFileSync(process.argv.at(-1), JSON.stringify({ok:true}));",
       inputFiles: ['in.txt'],
       outputFile: 'out.json',
     });
 
     expect(result.isError).toBe(false);
     expect(existsSync(join(dataDir, 'out.json'))).toBe(true);
+    const text = result.content[0]?.text ?? '';
+    expect(text).toContain('out.json\nRuntime:');
+    expect(text).toContain('\n\nUse this absolute path as the "src" value');
+    expect(text).toContain('\n\nStdout:\nmade output');
   });
 
   it('allows input files from skills directory (absolute path)', async () => {

--- a/packages/desktop/packages/session-tools-core/src/handlers/transform-data.ts
+++ b/packages/desktop/packages/session-tools-core/src/handlers/transform-data.ts
@@ -153,12 +153,14 @@ export async function handleTransformData(
     // Return the absolute path for use in preview/table block "src" fields
     const lines = [`Output written to: ${resolvedOutput}`];
     lines.push(`Runtime: ${cmd} (source: ${runtime.source})`);
-    lines.push(`\nUse this absolute path as the "src" value in your datatable, spreadsheet, html-preview, pdf-preview, or image-preview block.`);
+    lines.push('');
+    lines.push('Use this absolute path as the "src" value in your datatable, spreadsheet, html-preview, pdf-preview, or image-preview block.');
     if (result.stdout.trim()) {
-      lines.push(`\nStdout:\n${result.stdout.slice(0, 500)}`);
+      lines.push('');
+      lines.push(`Stdout:\n${result.stdout.slice(0, 500)}`);
     }
 
-    return successResponse(lines.join(''));
+    return successResponse(lines.join('\n'));
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     return errorResponse(`Error running script: ${msg}`);


### PR DESCRIPTION
Fixes #5524

## What this PR does

This formats successful `transform_data` results as newline-separated sections so the output path, runtime, usage hint, and stdout are readable instead of being squeezed together.

It also adds regression coverage for the output path/runtime split and stdout section spacing.

## Why it's needed

The previous success message could join independent pieces of information on the same line, making the generated file path and runtime metadata harder to scan in the desktop tool output.

## Reviewer Test Plan

### How to verify

Run the targeted `transform_data` tests and confirm the success output includes distinct lines for the output path, runtime, next-step hint, and stdout section.

### Evidence (Before & After)

Before: success output could concatenate the saved path, runtime, and stdout labels into a dense line.

After: `bun test packages/desktop/packages/session-tools-core/src/handlers/transform-data.test.ts` passes with regression assertions for newline-separated sections.

Additional checks run:

- `bun test packages/desktop/packages/session-tools-core/src`
- `cd packages/desktop/packages/session-tools-core && bun run typecheck`
- `npx prettier --check packages/desktop/packages/session-tools-core/src/handlers/transform-data.ts packages/desktop/packages/session-tools-core/src/handlers/transform-data.test.ts`
- `git diff --check`

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS checkout with Bun and Node test commands.

## Risk & Scope

- Main risk or tradeoff: low; output formatting only, no change to transform execution or generated data.
- Not validated / out of scope: visual desktop screenshot; this is covered by string-level handler tests.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5524

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 把成功的 `transform_data` 结果格式化为按行分隔的几个部分，让输出路径、运行时间、使用提示和 stdout 更容易阅读，而不是挤在同一行里。

它也为输出路径 / 运行时间分隔，以及 stdout 区块间距增加了回归测试。

## Why it's needed

之前的成功消息可能把不同信息拼到同一行，导致 desktop tool output 里的生成文件路径和运行信息不容易扫读。

## Reviewer Test Plan

### How to verify

运行定向 `transform_data` 测试，确认成功输出里有独立的输出路径、运行时间、下一步提示和 stdout 区块。

### Evidence (Before & After)

Before：成功输出可能把保存路径、运行时间和 stdout 标签拼成一行。

After：`bun test packages/desktop/packages/session-tools-core/src/handlers/transform-data.test.ts` 通过，并覆盖了按行分隔的回归断言。

另外还运行了上面列出的 package 测试、typecheck、prettier 和 `git diff --check`。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 macOS checkout，使用 Bun 和 Node 测试命令。

## Risk & Scope

- 主要风险或取舍：低；只调整输出格式，不改变 transform 执行或生成数据。
- 未验证 / 不在范围内：desktop 可视截图；这里由 handler 字符串测试覆盖。
- Breaking changes / migration notes：无。

</details>
