### PR TITLE
fix(desktop): reject fractional transfer sizes

### DIFF
--- a/packages/desktop/packages/server-core/src/handlers/rpc/transfer.test.ts
+++ b/packages/desktop/packages/server-core/src/handlers/rpc/transfer.test.ts
@@ -65,6 +65,34 @@ afterEach(() => {
 })
 
 describe('chunked transfer handlers', () => {
+  it('rejects fractional chunk counts', async () => {
+    const { start } = createHarness()
+
+    setTransferableHandler('test:echo', async (_ctx, _placeholder, body) => body)
+
+    await expect(start(ctx('client-1'), {
+      totalBytes: 10,
+      chunkCount: 1.5,
+      channel: 'test:echo',
+      args: [null, null],
+      largeArgIndex: 1,
+    })).rejects.toThrow('Invalid chunkCount')
+  })
+
+  it('rejects fractional total byte counts', async () => {
+    const { start } = createHarness()
+
+    setTransferableHandler('test:echo', async (_ctx, _placeholder, body) => body)
+
+    await expect(start(ctx('client-1'), {
+      totalBytes: 10.5,
+      chunkCount: 1,
+      channel: 'test:echo',
+      args: [null, null],
+      largeArgIndex: 1,
+    })).rejects.toThrow('Invalid totalBytes')
+  })
+
   it('rejects chunk uploads from a different client', async () => {
     const { start, chunk } = createHarness()
     const payload = encodeParts({ hello: 'world' })

--- a/packages/desktop/packages/server-core/src/handlers/rpc/transfer.ts
+++ b/packages/desktop/packages/server-core/src/handlers/rpc/transfer.ts
@@ -98,10 +98,10 @@ export function registerTransferHandlers(server: RpcServer): void {
     largeArgIndex: number
     checksum?: string
   }) => {
-    if (!opts || typeof opts.chunkCount !== 'number' || opts.chunkCount < 1) {
+    if (!opts || !Number.isInteger(opts.chunkCount) || opts.chunkCount < 1) {
       throw new Error('Invalid chunkCount')
     }
-    if (typeof opts.totalBytes !== 'number' || opts.totalBytes < 0) {
+    if (!Number.isInteger(opts.totalBytes) || opts.totalBytes < 0) {
       throw new Error('Invalid totalBytes')
     }
     if (!opts.channel || typeof opts.channel !== 'string') {


### PR DESCRIPTION
## What this PR does

Hardens the `transfer:start` RPC handler in the desktop server-core so that it rejects fractional `chunkCount` and `totalBytes` values. The metadata validation now requires both fields to be integers (via `Number.isInteger`) instead of merely being of type `number`, so invalid transfer metadata is rejected before any transfer state is allocated. Adds regression tests covering fractional chunk counts and fractional byte counts.

## Why it's needed

The previous validation only checked `typeof opts.chunkCount === 'number'` / `typeof opts.totalBytes === 'number'`, which accepts fractional values such as `1.5` or `10.5`. Non-integer chunk counts and byte counts are not valid transfer metadata and could lead to allocating transfer state from malformed input. Requiring integers rejects these bad values up front.

## Reviewer Test Plan

### How to verify

- `bun test packages/desktop/packages/server-core/src/handlers/rpc/transfer.test.ts`
- `cd packages/desktop/packages/server-core && bun run typecheck`
- `npx prettier --check packages/desktop/packages/server-core/src/handlers/rpc/transfer.ts packages/desktop/packages/server-core/src/handlers/rpc/transfer.test.ts`
- `git diff --check`

Also ran `bun test packages/desktop/packages/server-core/src`; transfer coverage passed, but the full package currently has an unrelated existing failure in `system.open-url.test.ts` where the expected unsupported-protocol error text does not match the current blocked-scheme message.

### Evidence (Before & After)

N/A — internal logic change covered by unit tests. Before: fractional `chunkCount` / `totalBytes` passed validation. After: they are rejected with `Invalid chunkCount` / `Invalid totalBytes`, verified by the new regression tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; covered by CI |
|  🐧 Linux  | ⚠️ not tested locally; covered by CI |

### Environment (optional)

Local macOS workspace; unit tests via bun.

## Risk & Scope

- Main risk or tradeoff: low; scope-limited to input validation in the `transfer:start` handler.
- Not validated / out of scope: manual end-to-end transfer flow.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5526

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

加固 desktop server-core 中的 `transfer:start` RPC 处理器，使其拒绝分数（非整数）的 `chunkCount` 和 `totalBytes` 值。元数据校验现在要求这两个字段都是整数（通过 `Number.isInteger`），而不仅仅是 `number` 类型，因此无效的传输元数据会在分配任何传输状态之前就被拒绝。新增了针对分数 chunk 数和分数字节数的回归测试。

## 为什么需要

此前的校验只检查 `typeof opts.chunkCount === 'number'` / `typeof opts.totalBytes === 'number'`，这会接受诸如 `1.5` 或 `10.5` 之类的分数值。非整数的 chunk 数和字节数不是合法的传输元数据，可能导致基于畸形输入分配传输状态。要求整数可以在前期就拒绝这些非法值。

## 审阅者测试计划

### 如何验证

- `bun test packages/desktop/packages/server-core/src/handlers/rpc/transfer.test.ts`
- `cd packages/desktop/packages/server-core && bun run typecheck`
- `npx prettier --check packages/desktop/packages/server-core/src/handlers/rpc/transfer.ts packages/desktop/packages/server-core/src/handlers/rpc/transfer.test.ts`
- `git diff --check`

同时运行了 `bun test packages/desktop/packages/server-core/src`；传输相关的测试通过，但整个包目前存在一个与本次改动无关的既有失败：`system.open-url.test.ts` 中期望的「不支持协议」错误文本与当前的「被屏蔽 scheme」消息不匹配。

### 证据（前后对比）

N/A —— 内部逻辑改动，已由单元测试覆盖。改动前：分数的 `chunkCount` / `totalBytes` 能通过校验。改动后：它们会被拒绝并抛出 `Invalid chunkCount` / `Invalid totalBytes`，由新增的回归测试验证。

### 测试平台

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 本地未测试；由 CI 覆盖 |
|  🐧 Linux  | ⚠️ 本地未测试；由 CI 覆盖 |

### 环境（可选）

本地 macOS 工作区；通过 bun 运行单元测试。

## 风险与范围

- 主要风险或取舍：低；范围限定于 `transfer:start` 处理器的输入校验。
- 未验证 / 范围之外：手动端到端传输流程。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #5526

## AI 协助声明

我使用 Codex 来审查改动、对照既有模式核对实现，并帮助发现潜在的边界情况。

</details>
