### PR TITLE
test(desktop): update blocked scheme open-url assertion

### DIFF
--- a/packages/desktop/packages/server-core/src/handlers/rpc/system.open-url.test.ts
+++ b/packages/desktop/packages/server-core/src/handlers/rpc/system.open-url.test.ts
@@ -117,11 +117,12 @@ describe('registerSystemCoreHandlers OPEN_URL', () => {
     })
   })
 
-  it('rejects unsupported protocols', async () => {
-    const { openUrl, ctx } = createTestHarness()
+  it('rejects blocked URL schemes', async () => {
+    const { openUrl, ctx, invokeClientCalls } = createTestHarness()
 
     await expect(openUrl(ctx, 'file:///tmp/test.txt')).rejects.toThrow(
-      'Failed to open URL: Only http, https, mailto, craftdocs, craftagents URLs are allowed'
+      'Failed to open URL: Refused to open URL with blocked scheme: file:'
     )
+    expect(invokeClientCalls).toHaveLength(0)
   })
 })


### PR DESCRIPTION
Fixes #5528

## Summary

- update the OPEN_URL blocked-scheme test to match the current error message
- assert blocked file: URLs are not forwarded to the client openExternal path

## Validation

- bun test packages/desktop/packages/server-core/src/handlers/rpc/system.open-url.test.ts
- bun test packages/desktop/packages/server-core/src
- cd packages/desktop/packages/server-core && bun run typecheck
- npx prettier --check packages/desktop/packages/server-core/src/handlers/rpc/system.open-url.test.ts
- git diff --check

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.