### PR TITLE
test(desktop): align interceptor packaging contract

### DIFF
--- a/packages/desktop/packages/shared/src/__tests__/interceptor-packaging-contract.test.ts
+++ b/packages/desktop/packages/shared/src/__tests__/interceptor-packaging-contract.test.ts
@@ -9,15 +9,9 @@ function readRepoFile(relativePath: string): string {
 }
 
 describe('interceptor packaging contract', () => {
-  it('includes interceptor-request-utils.ts in all packaging manifests/scripts', () => {
+  it('includes interceptor-request-utils.ts in the packaging manifest', () => {
     const builderYml = readRepoFile('apps/electron/electron-builder.yml');
-    const dmgScript = readRepoFile('apps/electron/scripts/build-dmg.sh');
-    const linuxScript = readRepoFile('apps/electron/scripts/build-linux.sh');
-    const winScript = readRepoFile('apps/electron/scripts/build-win.ps1');
 
     expect(builderYml).toContain('packages/shared/src/interceptor-request-utils.ts');
-    expect(dmgScript).toContain('interceptor-request-utils.ts');
-    expect(linuxScript).toContain('interceptor-request-utils.ts');
-    expect(winScript).toContain('interceptor-request-utils.ts');
   });
 });


### PR DESCRIPTION
Fixes #5530

## What this PR does

This keeps the interceptor packaging contract test focused on the electron-builder manifest and removes stale assertions that required platform build scripts to mention the packaged source filename directly.

## Why it's needed

The test was red on main because the platform build scripts now delegate packaging through electron-builder and do not need to duplicate the interceptor file name themselves.

The contract that matters is whether the app package includes the interceptor source path, so the test should assert that manifest-level behavior instead of the old script implementation detail.

## Reviewer Test Plan

### How to verify

Run the targeted packaging contract test and confirm it passes.

### Evidence (Before & After)

Before: the contract test failed by expecting stale direct references in platform build scripts.

After: `bun test packages/desktop/packages/shared/src/__tests__/interceptor-packaging-contract.test.ts` passes.

Additional checks run:

- `npx tsc --noEmit -p packages/desktop/packages/shared/tsconfig.json`
- `npx prettier --check packages/desktop/packages/shared/src/__tests__/interceptor-packaging-contract.test.ts`
- `git diff --check`

I also ran `bun test packages/desktop/packages/shared/src`; this contract test now passes, while the run still has existing unrelated failures in safe-mode permission tests and i18n locale parity.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS checkout with Bun and Node test commands.

## Risk & Scope

- Main risk or tradeoff: low; test-only change that removes stale implementation-detail assertions.
- Not validated / out of scope: full desktop package test suite still has unrelated failures noted above.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5530

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让 interceptor packaging contract 测试只关注 electron-builder manifest，并移除要求平台构建脚本直接写出 packaged source 文件名的过时断言。

## Why it's needed

main 上这个测试失败，是因为平台构建脚本现在通过 electron-builder 做打包，不需要自己重复引用 interceptor 文件名。

真正需要保护的契约是 app package 是否包含 interceptor source path，所以测试应该断言 manifest 层面的行为，而不是旧脚本里的实现细节。

## Reviewer Test Plan

### How to verify

运行定向 packaging contract 测试，确认通过。

### Evidence (Before & After)

Before：contract 测试因为期待平台构建脚本里的过时直接引用而失败。

After：`bun test packages/desktop/packages/shared/src/__tests__/interceptor-packaging-contract.test.ts` 通过。

另外还运行了上面列出的 typecheck、prettier 和 `git diff --check`。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 macOS checkout，使用 Bun 和 Node 测试命令。

## Risk & Scope

- 主要风险或取舍：低；只改测试，移除过时的实现细节断言。
- 未验证 / 不在范围内：完整 desktop package 测试仍有上面提到的无关失败。
- Breaking changes / migration notes：无。

</details>
