### PR TITLE
test(desktop): enable feedback flag in permission tests

### DIFF
--- a/packages/desktop/packages/shared/src/agent/__tests__/send-developer-feedback-permissions.test.ts
+++ b/packages/desktop/packages/shared/src/agent/__tests__/send-developer-feedback-permissions.test.ts
@@ -1,37 +1,60 @@
 /**
  * Tests for send_developer_feedback tool permission handling across permission modes.
  *
- * send_developer_feedback is a session-scoped MCP tool that should be allowed
- * in ALL permission modes, including safe/Explore, so product issues can be
- * reported without requiring mode switches.
+ * send_developer_feedback is a feature-gated session-scoped MCP tool that
+ * should be allowed in ALL permission modes when enabled, including
+ * safe/Explore, so product issues can be reported without requiring mode
+ * switches.
  */
 import { describe, it, expect } from 'bun:test';
 import { shouldAllowToolInMode } from '../../agent/mode-manager.ts';
+
+function withDeveloperFeedbackEnabled(run: () => void) {
+  const previousFlag = process.env.CRAFT_FEATURE_DEVELOPER_FEEDBACK;
+  process.env.CRAFT_FEATURE_DEVELOPER_FEEDBACK = '1';
+  try {
+    run();
+  } finally {
+    if (previousFlag === undefined) {
+      delete process.env.CRAFT_FEATURE_DEVELOPER_FEEDBACK;
+    } else {
+      process.env.CRAFT_FEATURE_DEVELOPER_FEEDBACK = previousFlag;
+    }
+  }
+}
 
 describe('send_developer_feedback permission mode handling', () => {
   const toolName = 'mcp__session__send_developer_feedback';
   const input = { message: 'Feedback content' };
 
   it('is allowed in safe (Explore) mode', () => {
-    const result = shouldAllowToolInMode(toolName, input, 'safe');
-    expect(result.allowed).toBe(true);
+    withDeveloperFeedbackEnabled(() => {
+      const result = shouldAllowToolInMode(toolName, input, 'safe');
+      expect(result.allowed).toBe(true);
+    });
   });
 
   it('is allowed in ask mode', () => {
-    const result = shouldAllowToolInMode(toolName, input, 'ask');
-    expect(result.allowed).toBe(true);
+    withDeveloperFeedbackEnabled(() => {
+      const result = shouldAllowToolInMode(toolName, input, 'ask');
+      expect(result.allowed).toBe(true);
+    });
   });
 
   it('is allowed in allow-all (Execute) mode', () => {
-    const result = shouldAllowToolInMode(toolName, input, 'allow-all');
-    expect(result.allowed).toBe(true);
+    withDeveloperFeedbackEnabled(() => {
+      const result = shouldAllowToolInMode(toolName, input, 'allow-all');
+      expect(result.allowed).toBe(true);
+    });
   });
 
   it('does not require permission prompt in ask mode', () => {
-    const result = shouldAllowToolInMode(toolName, input, 'ask');
-    expect(result.allowed).toBe(true);
-    if (result.allowed) {
-      expect(result.requiresPermission).toBeFalsy();
-    }
+    withDeveloperFeedbackEnabled(() => {
+      const result = shouldAllowToolInMode(toolName, input, 'ask');
+      expect(result.allowed).toBe(true);
+      if (result.allowed) {
+        expect(result.requiresPermission).toBeFalsy();
+      }
+    });
   });
 });

--- a/packages/desktop/packages/shared/src/agent/__tests__/session-tool-safe-mode-permissions.test.ts
+++ b/packages/desktop/packages/shared/src/agent/__tests__/session-tool-safe-mode-permissions.test.ts
@@ -4,10 +4,23 @@
 import { describe, it, expect } from 'bun:test';
 import { shouldAllowToolInMode } from '../../agent/mode-manager.ts';
 
+function withDeveloperFeedbackEnabled(run: () => void) {
+  const previousFlag = process.env.CRAFT_FEATURE_DEVELOPER_FEEDBACK;
+  process.env.CRAFT_FEATURE_DEVELOPER_FEEDBACK = '1';
+  try {
+    run();
+  } finally {
+    if (previousFlag === undefined) {
+      delete process.env.CRAFT_FEATURE_DEVELOPER_FEEDBACK;
+    } else {
+      process.env.CRAFT_FEATURE_DEVELOPER_FEEDBACK = previousFlag;
+    }
+  }
+}
+
 describe('session tool safe-mode classification', () => {
   it('allows read-only session tools in safe mode', () => {
     const allowedTools = [
-      'mcp__session__send_developer_feedback',
       'mcp__session__call_llm',
       'mcp__session__browser_tool',
       'mcp__session__script_sandbox',
@@ -17,6 +30,18 @@ describe('session tool safe-mode classification', () => {
       const result = shouldAllowToolInMode(toolName, {}, 'safe');
       expect(result.allowed).toBe(true);
     }
+  });
+
+  it('allows developer feedback in safe mode when the feature is enabled', () => {
+    withDeveloperFeedbackEnabled(() => {
+      const result = shouldAllowToolInMode(
+        'mcp__session__send_developer_feedback',
+        {},
+        'safe'
+      );
+
+      expect(result.allowed).toBe(true);
+    });
   });
 
   it('blocks mutating/auth session tools in safe mode', () => {


### PR DESCRIPTION
Fixes #5532

## What this PR does

This makes the developer feedback permission tests explicitly enable `CRAFT_FEATURE_DEVELOPER_FEEDBACK` for the assertions that depend on that feature-gated session tool.

It also separates the developer-feedback tool assertion from the always-visible read-only session tool allowlist, so the safe-mode test no longer assumes the feedback feature is globally enabled.

## Why it's needed

The tests were failing when `CRAFT_FEATURE_DEVELOPER_FEEDBACK` was unset because the permission assertions expected a tool that is intentionally hidden unless that flag is enabled.

Making the flag setup local to these tests keeps the production behavior unchanged and makes the expected permission surface explicit.

## Reviewer Test Plan

### How to verify

Run the targeted permission tests with the feedback flag removed from the parent environment and confirm they pass.

### Evidence (Before & After)

Before: the safe-mode permission coverage depended on the ambient `CRAFT_FEATURE_DEVELOPER_FEEDBACK` value.

After: `env -u CRAFT_FEATURE_DEVELOPER_FEEDBACK bun test packages/desktop/packages/shared/src/agent/__tests__/session-tool-safe-mode-permissions.test.ts packages/desktop/packages/shared/src/agent/__tests__/send-developer-feedback-permissions.test.ts` passes.

Additional checks run:

- `bun test packages/desktop/packages/shared/src/__tests__/feature-flags.test.ts packages/desktop/packages/session-tools-core/src/tool-defs-filtering.test.ts packages/desktop/packages/shared/src/agent/__tests__/session-tool-safe-mode-permissions.test.ts packages/desktop/packages/shared/src/agent/__tests__/send-developer-feedback-permissions.test.ts`
- `npx tsc --noEmit -p packages/desktop/packages/shared/tsconfig.json`
- `npx prettier --check packages/desktop/packages/shared/src/agent/__tests__/session-tool-safe-mode-permissions.test.ts packages/desktop/packages/shared/src/agent/__tests__/send-developer-feedback-permissions.test.ts`
- `git diff --check`

I also ran `bun test packages/desktop/packages/shared/src`; these safe-mode failures are gone. The run still has existing unrelated failures in the interceptor packaging contract and i18n locale parity.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS checkout with Bun and Node test commands.

## Risk & Scope

- Main risk or tradeoff: low; test-only change, scoped to permission assertions.
- Not validated / out of scope: full desktop package test suite still has unrelated failures noted above.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5532

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让 developer feedback 权限测试在依赖 `CRAFT_FEATURE_DEVELOPER_FEEDBACK` 的断言里显式打开这个 feature flag。

它也把 developer-feedback 工具断言从始终可见的只读 session tool allowlist 里拆出来，这样 safe-mode 测试不再假设 feedback 功能默认全局开启。

## Why it's needed

当 `CRAFT_FEATURE_DEVELOPER_FEEDBACK` 没有设置时，测试会期待一个本来应该被隐藏的 feature-gated tool，导致测试失败。

把 flag 设置限制在这些测试内部，可以保持生产行为不变，同时让预期的权限面更明确。

## Reviewer Test Plan

### How to verify

在父环境移除 feedback flag 后运行定向权限测试，确认测试通过。

### Evidence (Before & After)

Before：safe-mode 权限覆盖依赖外部环境里的 `CRAFT_FEATURE_DEVELOPER_FEEDBACK` 值。

After：`env -u CRAFT_FEATURE_DEVELOPER_FEEDBACK bun test packages/desktop/packages/shared/src/agent/__tests__/session-tool-safe-mode-permissions.test.ts packages/desktop/packages/shared/src/agent/__tests__/send-developer-feedback-permissions.test.ts` 通过。

另外还运行了上面列出的定向测试、typecheck、prettier 和 `git diff --check`。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 macOS checkout，使用 Bun 和 Node 测试命令。

## Risk & Scope

- 主要风险或取舍：低；只改测试，范围限于权限断言。
- 未验证 / 不在范围内：完整 desktop package 测试仍有上面提到的无关失败。
- Breaking changes / migration notes：无。

</details>
