### PR TITLE
test(core): wait for cron lock probe takeover

### DIFF
--- a/packages/core/src/services/cronScheduler.test.ts
+++ b/packages/core/src/services/cronScheduler.test.ts
@@ -1056,14 +1056,16 @@ describe('CronScheduler', () => {
         vi.useRealTimers();
         usingFakeTimers = false;
 
-        // The probe acquired the lock and flipped this session to owner.
+        // The probe acquired the lock.
         await vi.waitFor(async () => {
           const raw = await fs.readFile(getLockFilePath(tmpDir), 'utf-8');
           expect(JSON.parse(raw).sessionId).toBe('session-1');
         });
-        // Now an owner, the durable job fires.
-        scheduler.tick(new Date(2025, 0, 15, 10, 31, 59));
-        expect(fired.map((j) => j.id)).toContain('probe-job');
+        // The lock write can be visible before the probe's .then flips isOwner.
+        await vi.waitFor(() => {
+          scheduler.tick(new Date(2025, 0, 15, 10, 31, 59));
+          expect(fired.map((j) => j.id)).toEqual(['probe-job']);
+        });
       } finally {
         if (usingFakeTimers) vi.useRealTimers();
       }


### PR DESCRIPTION
Fixes #5534

## Summary
- wait for the cron lock-probe takeover behavior before asserting that a durable job fires
- keep the lock-file assertion, but avoid treating the visible lock write as proof that the scheduler's owner state has settled
- assert that the probe job fires exactly once after takeover

## Test plan
- npm --workspace @qwen-code/qwen-code-core test -- src/services/cronScheduler.test.ts
- repeated the same target test 5 times locally
- npx prettier --check packages/core/src/services/cronScheduler.test.ts
- git diff --check

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.