### PR TITLE
fix(cli): allow dotfile paths in Web Shell sendFile

### DIFF
--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -1799,6 +1799,32 @@ describe('createServeApp', () => {
       expect(res.status).toBe(500);
     });
 
+    it('serves the shell when webShellDir is under a dotfile path (e.g. ~/.nvm)', async () => {
+      // Regression: the send library defaults to dotfiles:'ignore', which
+      // returns 404 for any path containing a segment starting with '.'.
+      // Users who installed qwen via nvm have the package under
+      // ~/.nvm/.../web-shell/index.html.
+      const dotParent = await fsp.mkdtemp(path.join(os.tmpdir(), '.fake-nvm-'));
+      const nestedShellDir = path.join(dotParent, 'web-shell');
+      await fsp.mkdir(nestedShellDir, { recursive: true });
+      await fsp.writeFile(path.join(nestedShellDir, 'index.html'), INDEX_HTML);
+      await fsp.mkdir(path.join(nestedShellDir, 'assets'));
+      await fsp.writeFile(
+        path.join(nestedShellDir, 'assets', 'app.js'),
+        'export const x = 1;\n',
+      );
+      try {
+        const app = createServeApp(baseOpts, undefined, {
+          webShellDir: nestedShellDir,
+        });
+        const res = await request(app).get('/').set('Host', host);
+        expect(res.status).toBe(200);
+        expect(res.text).toContain('<div id="root">');
+      } finally {
+        await fsp.rm(dotParent, { recursive: true, force: true });
+      }
+    });
+
     it('isDocumentNavigation recognizes each navigation signal', () => {
       const nav = (headers: Record<string, string>) =>
         isDocumentNavigation({ headers } as never);

--- a/packages/cli/src/serve/webShellStatic.ts
+++ b/packages/cli/src/serve/webShellStatic.ts
@@ -120,24 +120,33 @@ function createSendIndex(webShellDir: string): (res: Response) => void {
         'camera=(), microphone=(), geolocation=(), payment=()',
       )
       .set('Cache-Control', 'no-cache');
-    res.sendFile(indexPath, { cacheControl: false }, (err) => {
-      if (!err) return;
-      // Only 5xx path in the serve app that would otherwise emit nothing —
-      // log it like the sibling /demo handler so an operator can see why the
-      // shell stopped loading (EACCES/ESTALE on a network mount, a perms
-      // change, a partial deploy).
-      writeStderrLine(
-        `qwen serve: Web Shell index send failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      if (!res.headersSent) {
-        res.status(500).type('text/plain').send('Failed to load Web Shell');
-      } else {
-        // Failed mid-stream (truncated/corrupt index.html): end the
-        // half-written response instead of leaving the client on a 200 with a
-        // partial body.
-        res.end();
-      }
-    });
+    // `dotfiles: 'allow'` is required because the resolved path may pass
+    // through a dotfile directory (e.g. ~/.nvm/.../web-shell/index.html).
+    // The `send` library defaults to 'ignore' which returns a 404 for any
+    // path containing a segment starting with '.', breaking users who
+    // installed qwen via nvm.
+    res.sendFile(
+      indexPath,
+      { cacheControl: false, dotfiles: 'allow' },
+      (err) => {
+        if (!err) return;
+        // Only 5xx path in the serve app that would otherwise emit nothing —
+        // log it like the sibling /demo handler so an operator can see why the
+        // shell stopped loading (EACCES/ESTALE on a network mount, a perms
+        // change, a partial deploy).
+        writeStderrLine(
+          `qwen serve: Web Shell index send failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        if (!res.headersSent) {
+          res.status(500).type('text/plain').send('Failed to load Web Shell');
+        } else {
+          // Failed mid-stream (truncated/corrupt index.html): end the
+          // half-written response instead of leaving the client on a 200 with a
+          // partial body.
+          res.end();
+        }
+      },
+    );
   };
 }
 


### PR DESCRIPTION
## Problem

When qwen is installed via nvm (or volta/asdf), the global package path contains a dotfile directory segment (e.g. `~/.nvm/versions/node/v22.22.2/lib/node_modules/@qwen-code/qwen-code/web-shell/index.html`). Running `qwen serve --open` opens the browser to a page that shows **"Failed to load Web Shell"** instead of the Web Shell UI.

## Root Cause

`res.sendFile()` is backed by the [`send`](https://www.npmjs.com/package/send) library, which defaults to `dotfiles: 'ignore'`. This causes a silent **404 "Not Found"** for any file whose resolved path contains a segment starting with `.` — even if the file exists and is readable. The `.nvm` directory in the installation path triggers this behavior, so `index.html` is never served.

## Fix

Pass `dotfiles: 'allow'` to the `sendFile` options in `createSendIndex`. The index.html is a static shell with no secrets — all API routes remain protected by bearer auth regardless.

## How to verify

1. `npm run build && npm run bundle`
2. Install globally: `npm install -g . --ignore-scripts` (or `cp dist/cli.js "$(npm root -g)/@qwen-code/qwen-code/cli.js"`)
3. Run `qwen serve --open`
4. Browser should load the Web Shell UI (200 + `<div id="root">`), not "Failed to load Web Shell"

**Before:** `GET /` → 500 "Failed to load Web Shell"
**After:** `GET /` → 200 + HTML with `<div id="root">`