### PR TITLE
fix(vscode): keep UNC paths absolute

### DIFF
--- a/packages/vscode-ide-companion/src/commands/index.test.ts
+++ b/packages/vscode-ide-companion/src/commands/index.test.ts
@@ -10,6 +10,7 @@ import {
   focusChatCommand,
   openNewChatTabCommand,
   registerNewCommands,
+  showDiffCommand,
 } from './index.js';
 
 const {
@@ -17,6 +18,8 @@ const {
   executeCommand,
   showWarningMessage,
   showInformationMessage,
+  joinPath,
+  workspaceMock,
 } = vi.hoisted(() => ({
   registerCommand: vi.fn(
     (_id: string, handler: (...args: unknown[]) => unknown) => ({
@@ -27,6 +30,16 @@ const {
   executeCommand: vi.fn(),
   showWarningMessage: vi.fn(),
   showInformationMessage: vi.fn(),
+  joinPath: vi.fn((base: { fsPath: string }, filePath: string) => ({
+    fsPath: `${base.fsPath}/${filePath}`,
+  })),
+  workspaceMock: {
+    workspaceFolders: [] as Array<{
+      uri: { fsPath: string };
+      name: string;
+      index: number;
+    }>,
+  },
 }));
 
 vi.mock('vscode', () => ({
@@ -38,11 +51,10 @@ vi.mock('vscode', () => ({
     showWarningMessage,
     showInformationMessage,
   },
-  workspace: {
-    workspaceFolders: [],
-  },
+  workspace: workspaceMock,
   Uri: {
-    joinPath: vi.fn(),
+    file: (fsPath: string) => ({ fsPath }),
+    joinPath,
   },
 }));
 
@@ -65,6 +77,10 @@ describe('registerNewCommands', () => {
     executeCommand.mockClear();
     showWarningMessage.mockClear();
     showInformationMessage.mockClear();
+    joinPath.mockClear();
+    diffManager.showDiff.mockClear();
+    log.mockClear();
+    workspaceMock.workspaceFolders = [];
   });
 
   it('openNewChatTab opens a new provider without creating a second session explicitly', async () => {
@@ -146,6 +162,63 @@ describe('registerNewCommands', () => {
 
     expect(executeCommand).toHaveBeenCalledWith(
       'qwen-code.chatView.sidebar.focus',
+    );
+  });
+
+  it('showDiff resolves relative paths against the workspace', async () => {
+    workspaceMock.workspaceFolders = [
+      { uri: { fsPath: '/workspace' }, name: 'workspace', index: 0 },
+    ];
+
+    registerNewCommands(
+      context as never,
+      log,
+      diffManager as never,
+      () => [],
+      vi.fn() as never,
+    );
+
+    await getRegisteredHandler(showDiffCommand)({
+      path: 'src/app.ts',
+      oldText: 'old',
+      newText: 'new',
+    });
+
+    expect(joinPath).toHaveBeenCalledWith(
+      { fsPath: '/workspace' },
+      'src/app.ts',
+    );
+    expect(diffManager.showDiff).toHaveBeenCalledWith(
+      '/workspace/src/app.ts',
+      'old',
+      'new',
+    );
+  });
+
+  it('showDiff keeps UNC paths absolute', async () => {
+    workspaceMock.workspaceFolders = [
+      { uri: { fsPath: '/workspace' }, name: 'workspace', index: 0 },
+    ];
+
+    registerNewCommands(
+      context as never,
+      log,
+      diffManager as never,
+      () => [],
+      vi.fn() as never,
+    );
+
+    await getRegisteredHandler(showDiffCommand)({
+      path: '\\\\server\\share\\app.ts',
+      oldText: 'old',
+      newText: 'new',
+    });
+
+    expect(joinPath).not.toHaveBeenCalled();
+    expect(diffManager.showDiff).toHaveBeenCalledWith(
+      '\\\\server\\share\\app.ts',
+      'old',
+      'new',
     );
   });
 });

--- a/packages/vscode-ide-companion/src/commands/index.ts
+++ b/packages/vscode-ide-companion/src/commands/index.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import type { DiffManager } from '../diff-manager.js';
 import type { WebViewProvider } from '../webview/providers/WebViewProvider.js';
 import { getErrorMessage } from '../utils/errorMessage.js';
+import { shouldResolveAgainstWorkspace } from '../utils/file-path.js';
 import {
   CHAT_VIEW_ID_SIDEBAR,
   CHAT_VIEW_ID_SECONDARY,
@@ -68,7 +69,7 @@ export function registerNewCommands(
       async (args: { path: string; oldText: string; newText: string }) => {
         try {
           let absolutePath = args.path;
-          if (!args.path.startsWith('/') && !args.path.match(/^[a-zA-Z]:/)) {
+          if (shouldResolveAgainstWorkspace(args.path)) {
             const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
             if (workspaceFolder) {
               absolutePath = vscode.Uri.joinPath(

--- a/packages/vscode-ide-companion/src/utils/file-path.test.ts
+++ b/packages/vscode-ide-companion/src/utils/file-path.test.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { shouldResolveAgainstWorkspace } from './file-path.js';
+
+describe('shouldResolveAgainstWorkspace', () => {
+  it('returns true for relative paths', () => {
+    expect(shouldResolveAgainstWorkspace('src/app.ts')).toBe(true);
+    expect(shouldResolveAgainstWorkspace('nested/folder/file.ts')).toBe(true);
+  });
+
+  it('returns false for POSIX absolute paths', () => {
+    expect(shouldResolveAgainstWorkspace('/workspace/src/app.ts')).toBe(false);
+  });
+
+  it('returns false for Windows drive-letter paths', () => {
+    expect(shouldResolveAgainstWorkspace('C:\\workspace\\src\\app.ts')).toBe(
+      false,
+    );
+    expect(shouldResolveAgainstWorkspace('C:/workspace/src/app.ts')).toBe(
+      false,
+    );
+  });
+
+  it('returns false for Windows UNC paths', () => {
+    expect(shouldResolveAgainstWorkspace('\\\\server\\share\\app.ts')).toBe(
+      false,
+    );
+  });
+});

--- a/packages/vscode-ide-companion/src/utils/file-path.ts
+++ b/packages/vscode-ide-companion/src/utils/file-path.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import path from 'node:path';
+
+export function shouldResolveAgainstWorkspace(filePath: string): boolean {
+  return !path.posix.isAbsolute(filePath) && !path.win32.isAbsolute(filePath);
+}

--- a/packages/vscode-ide-companion/src/webview/handlers/FileMessageHandler.test.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/FileMessageHandler.test.ts
@@ -200,6 +200,58 @@ describe('FileMessageHandler', () => {
     expect(payload.data.requestId).toBe(7);
   });
 
+  it('openFile resolves relative paths against the workspace', async () => {
+    vscodeMock.workspace.workspaceFolders = [
+      { uri: vscode.Uri.file('/workspace'), name: 'workspace', index: 0 },
+    ];
+    vscodeMock.workspace.openTextDocument.mockResolvedValue({
+      uri: vscode.Uri.file('/workspace/src/app.ts'),
+    });
+    vscodeMock.window.showTextDocument.mockResolvedValue({});
+
+    const handler = new FileMessageHandler(
+      {} as QwenAgentManager,
+      {} as ConversationStore,
+      null,
+      vi.fn(),
+    );
+
+    await handler.handle({
+      type: 'openFile',
+      data: { path: 'src/app.ts' },
+    });
+
+    expect(vscodeMock.workspace.openTextDocument).toHaveBeenCalledWith(
+      expect.objectContaining({ fsPath: '/workspace/src/app.ts' }),
+    );
+  });
+
+  it('openFile keeps UNC paths absolute', async () => {
+    vscodeMock.workspace.workspaceFolders = [
+      { uri: vscode.Uri.file('/workspace'), name: 'workspace', index: 0 },
+    ];
+    vscodeMock.workspace.openTextDocument.mockResolvedValue({
+      uri: vscode.Uri.file('\\\\server\\share\\app.ts'),
+    });
+    vscodeMock.window.showTextDocument.mockResolvedValue({});
+
+    const handler = new FileMessageHandler(
+      {} as QwenAgentManager,
+      {} as ConversationStore,
+      null,
+      vi.fn(),
+    );
+
+    await handler.handle({
+      type: 'openFile',
+      data: { path: '\\\\server\\share\\app.ts' },
+    });
+
+    expect(vscodeMock.workspace.openTextDocument).toHaveBeenCalledWith(
+      expect.objectContaining({ fsPath: '\\\\server\\share\\app.ts' }),
+    );
+  });
+
   describe('createAndOpenTempFile viewColumn selection', () => {
     const chatViewType = 'mainThreadWebview-qwenCode.chat';
 

--- a/packages/vscode-ide-companion/src/webview/handlers/FileMessageHandler.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/FileMessageHandler.ts
@@ -20,6 +20,7 @@ import {
   type FileSearch,
 } from '@qwen-code/qwen-code-core';
 import { getErrorMessage } from '../../utils/errorMessage.js';
+import { shouldResolveAgainstWorkspace } from '../../utils/file-path.js';
 
 /**
  * File message handler
@@ -558,7 +559,7 @@ export class FileMessageHandler extends BaseMessageHandler {
 
       // Convert to absolute path if relative
       let absolutePath = path;
-      if (!path.startsWith('/') && !path.match(/^[a-zA-Z]:/)) {
+      if (shouldResolveAgainstWorkspace(path)) {
         // Relative path - resolve against workspace
         const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
         if (workspaceFolder) {


### PR DESCRIPTION
## What this PR does

This updates the VS Code companion path handling used by `openFile` messages and the `showDiff` command so UNC paths are treated as absolute paths instead of workspace-relative paths.

It adds a shared `shouldResolveAgainstWorkspace()` helper that checks both POSIX and Windows path semantics, then uses it in both affected call sites.

## Why it's needed

The previous checks only recognized POSIX absolute paths and Windows drive-letter paths. A UNC path like `\\server\share\app.ts` did not match either check, so the extension joined it under the first workspace folder before opening the file or showing a diff.

That breaks access to SMB/network share files from the VS Code companion on Windows.

## Reviewer Test Plan

### How to verify

Run the targeted VS Code companion tests and confirm relative paths still resolve against the workspace while UNC paths are passed through unchanged.

### Evidence (Before & After)

Before: `\\server\share\app.ts` could be treated as relative and resolved under the first workspace folder.

After: `npm run test --workspace=packages/vscode-ide-companion -- src/utils/file-path.test.ts src/webview/handlers/FileMessageHandler.test.ts src/commands/index.test.ts` passes with regression coverage for UNC paths in both `openFile` and `showDiff`.

Additional checks run:

- `npm run check-types --workspace=packages/vscode-ide-companion`
- `npm run lint --workspace=packages/vscode-ide-companion` (0 errors; existing warnings in unrelated files)
- `npx prettier --check packages/vscode-ide-companion/src/utils/file-path.ts packages/vscode-ide-companion/src/utils/file-path.test.ts packages/vscode-ide-companion/src/commands/index.ts packages/vscode-ide-companion/src/commands/index.test.ts packages/vscode-ide-companion/src/webview/handlers/FileMessageHandler.ts packages/vscode-ide-companion/src/webview/handlers/FileMessageHandler.test.ts`
- `git diff --check upstream/main...HEAD`

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; Windows path cases covered by unit tests |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS checkout with Node/npm workspace commands.

## Risk & Scope

- Main risk or tradeoff: low; the change is limited to deciding whether a VS Code companion path should be resolved against the workspace.
- Not validated / out of scope: manual VS Code session on Windows with a real UNC share.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5538

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

更新 VS Code companion 中 `openFile` 消息与 `showDiff` 命令使用的路径处理,使 UNC 路径被当作绝对路径,而不是相对于 workspace 的路径。

新增一个共享的 `shouldResolveAgainstWorkspace()` helper,同时检查 POSIX 与 Windows 的路径语义,并在两个受影响的调用点复用它。

## 为什么需要

之前的检查只识别 POSIX 绝对路径和 Windows 盘符路径。像 `\\server\share\app.ts` 这样的 UNC 路径两种检查都不匹配,于是扩展在打开文件或显示 diff 前,会把它拼接到第一个 workspace 文件夹下。

这会导致在 Windows 上无法通过 VS Code companion 访问 SMB/网络共享文件。

## Reviewer Test Plan

### 如何验证

运行针对性的 VS Code companion 测试,确认相对路径仍相对 workspace 解析,而 UNC 路径原样透传、保持不变。

### 证据(Before & After)

Before:`\\server\share\app.ts` 可能被当作相对路径,解析到第一个 workspace 文件夹下。

After:`npm run test --workspace=packages/vscode-ide-companion -- src/utils/file-path.test.ts src/webview/handlers/FileMessageHandler.test.ts src/commands/index.test.ts` 通过,并对 `openFile` 和 `showDiff` 两处的 UNC 路径都加了回归覆盖。

额外执行的检查:

- `npm run check-types --workspace=packages/vscode-ide-companion`
- `npm run lint --workspace=packages/vscode-ide-companion`(0 errors;无关文件存在既有 warning)
- `npx prettier --check`(上面列出的 6 个文件)
- `git diff --check upstream/main...HEAD`

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测 |
| 🪟 Windows | ⚠️ 未本地测;Windows 路径用例由单测覆盖 |
|  🐧 Linux  | ⚠️ 未测 |

### 环境(可选)

macOS 本地 checkout,使用 Node/npm workspace 命令。

## 风险与范围

- 主要风险或取舍:低;改动仅限于判断某个 VS Code companion 路径是否应相对 workspace 解析。
- 未验证 / 不在范围内:在 Windows 上用真实 UNC 共享做手动 VS Code 会话验证。
- Breaking changes / 迁移说明:无。

## 关联 Issue

Fixes #5538

## AI 协助声明

我使用 Codex 审查改动、对照既有模式做合理性检查,并帮助发现潜在的边界情况。

</details>
