### PR TITLE
ci(release): trigger CI from release branch pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,9 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
         with:
+          # Persist the bot PAT for release-branch pushes so downstream CI
+          # workflows are triggered.
+          token: '${{ secrets.CI_BOT_PAT }}'
           ref: '${{ github.event.inputs.ref || github.sha }}'
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,9 +59,6 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
         with:
-          # Persist the bot PAT for release-branch pushes so downstream CI
-          # workflows are triggered.
-          token: '${{ secrets.CI_BOT_PAT }}'
           ref: '${{ github.event.inputs.ref || github.sha }}'
           fetch-depth: 0
 
@@ -322,6 +319,9 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
         with:
+          # Persist the bot PAT for release-branch pushes so downstream CI
+          # workflows are triggered.
+          token: '${{ secrets.CI_BOT_PAT }}'
           ref: '${{ github.event.inputs.ref || github.sha }}'
           fetch-depth: 0
 


### PR DESCRIPTION
## What this PR does

Uses the release bot PAT as the persisted checkout credential in the release publish job, so release branch pushes are authored with credentials that can trigger downstream GitHub Actions workflows.

## Why it's needed

Stable release PRs can otherwise be created with required `Test (...)` checks missing from the PR head commit. The release job already creates the PR with the bot PAT, but the release branch commits are pushed with the default checkout credential, so GitHub can suppress the follow-up CI events. Persisting the same bot PAT for checkout lets the release branch push create the required CI contexts before auto-merge waits on them.

## Reviewer Test Plan

### How to verify

Run or inspect a stable release workflow and confirm the release branch push creates `Qwen Code CI` check runs on the release PR head SHA, including the required `Test (ubuntu-latest, Node 22.x)`, `Test (macos-latest, Node 22.x)`, and `Test (windows-latest, Node 22.x)` contexts. For this fix, workflow syntax was validated locally with `node scripts/lint.js --actionlint` and `node scripts/lint.js --yamllint`.

### Evidence (Before & After)

Before: release PR #5464 was blocked because the PR head SHA had only triage/review checks and no `Qwen Code CI` required test contexts. After: manually dispatching `Qwen Code CI` on `release/v0.18.4` created the required test jobs on the same head SHA; this PR makes future release branch pushes trigger that CI path automatically.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

Local workflow validation on macOS with Node.js 22.20.0. `yamllint` was run from a temporary Python virtual environment because the system Python environment is externally managed.

## Risk & Scope

- Main risk or tradeoff: the release publish checkout now requires `CI_BOT_PAT`, which the same job already requires for release creation, PR creation, approval, and auto-merge.
- Not validated / out of scope: a full production release dry run was not executed for this one-line credential change.
- Breaking changes / migration notes: none.

## Linked Issues

References #5464.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 release publish job 的 checkout 中持久化使用 release bot 的 PAT，这样 release 分支 push 会使用可以触发后续 GitHub Actions workflow 的凭据。

## 为什么需要

稳定版 release PR 可能会卡在缺少 required `Test (...)` checks 的状态。release job 已经用 bot PAT 创建 PR，但 release 分支 commit 的 push 仍使用默认 checkout credential，GitHub 可能会抑制后续 CI 事件。让 checkout 持久化同一个 bot PAT 后，release 分支 push 会自动创建 required CI contexts，auto-merge 就不会一直等待不存在的 checks。

## Reviewer Test Plan

### 如何验证

运行或检查一次稳定版 release workflow，确认 release 分支 push 会在 release PR 的 head SHA 上创建 `Qwen Code CI` check runs，包括 required `Test (ubuntu-latest, Node 22.x)`、`Test (macos-latest, Node 22.x)` 和 `Test (windows-latest, Node 22.x)` contexts。本次修复本地用 `node scripts/lint.js --actionlint` 和 `node scripts/lint.js --yamllint` 验证了 workflow 语法。

### 证据（前后对比）

Before：release PR #5464 被阻塞，因为 PR head SHA 上只有 triage/review checks，没有 `Qwen Code CI` 的 required test contexts。After：手动对 `release/v0.18.4` dispatch `Qwen Code CI` 后，同一个 head SHA 上创建了 required test jobs；本 PR 让未来 release 分支 push 自动触发这条 CI 路径。

### 测试环境

本地在 macOS + Node.js 22.20.0 上验证 workflow。由于系统 Python 是 externally managed，`yamllint` 通过临时 Python virtual environment 运行。

## 风险与范围

- 主要风险或取舍：release publish checkout 现在依赖 `CI_BOT_PAT`，而同一个 job 已经在创建 release、创建 PR、审批和 auto-merge 时依赖这个 secret。
- 未验证 / 不在范围内：没有为了这个凭据改动执行完整生产 release dry run。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

References #5464.

</details>
