### PR TITLE
fix(desktop): consolidate path boundary checks

### DIFF
--- a/packages/desktop/bun.lock
+++ b/packages/desktop/bun.lock
@@ -268,6 +268,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@craft-agent/core": "workspace:*",
+        "@craft-agent/session-tools-core": "workspace:*",
         "@craft-agent/shared": "workspace:*",
         "jose": "^6.0.0",
         "sharp": "0.34.5",

--- a/packages/desktop/packages/server-core/package.json
+++ b/packages/desktop/packages/server-core/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@craft-agent/core": "workspace:*",
+    "@craft-agent/session-tools-core": "workspace:*",
     "@craft-agent/shared": "workspace:*",
     "jose": "^6.0.0",
     "ws": "^8.19.0",

--- a/packages/desktop/packages/server-core/src/handlers/rpc/workspace.image-path.test.ts
+++ b/packages/desktop/packages/server-core/src/handlers/rpc/workspace.image-path.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { RPC_CHANNELS } from '@craft-agent/shared/protocol'
+import type { HandlerFn, RpcServer } from '@craft-agent/server-core/transport'
+import type { HandlerDeps } from '../handler-deps'
+
+let workspaceRoot = ''
+
+mock.module('@craft-agent/shared/config', () => ({
+  getWorkspaceByNameOrId: () => ({
+    id: 'workspace-1',
+    name: 'Workspace',
+    rootPath: workspaceRoot,
+  }),
+  addWorkspace: mock(() => null),
+  setActiveWorkspace: mock(() => {}),
+  updateWorkspaceRemoteServer: mock(() => {}),
+}))
+
+const { registerWorkspaceCoreHandlers } = await import('./workspace')
+
+function createWorkspaceImageHandlers() {
+  const handlers = new Map<string, HandlerFn>()
+  const server: RpcServer = {
+    handle(channel, handler) {
+      handlers.set(channel, handler)
+    },
+    push() {},
+    async invokeClient() {
+      return undefined
+    },
+  }
+
+  const deps: HandlerDeps = {
+    sessionManager: {} as HandlerDeps['sessionManager'],
+    oauthFlowStore: {} as HandlerDeps['oauthFlowStore'],
+    platform: {
+      appRootPath: '/',
+      resourcesPath: '/',
+      isPackaged: false,
+      appVersion: '0.0.0-test',
+      isDebugMode: true,
+      logger: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
+      imageProcessor: {
+        getMetadata: async () => null,
+        process: async (buffer: Buffer) => buffer,
+      },
+    },
+  }
+
+  registerWorkspaceCoreHandlers(server, deps)
+
+  const readImage = handlers.get(RPC_CHANNELS.workspace.READ_IMAGE)
+  const writeImage = handlers.get(RPC_CHANNELS.workspace.WRITE_IMAGE)
+
+  if (!readImage || !writeImage) {
+    throw new Error('workspace image handlers not registered')
+  }
+
+  return { readImage, writeImage }
+}
+
+describe('workspace image path boundaries', () => {
+  let rootDir: string
+  let outsideDir: string
+
+  beforeEach(() => {
+    rootDir = mkdtempSync(join(tmpdir(), 'qwen-workspace-image-'))
+    workspaceRoot = join(rootDir, 'workspace')
+    outsideDir = join(rootDir, 'outside')
+    mkdirSync(workspaceRoot)
+    mkdirSync(outsideDir)
+  })
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true })
+    workspaceRoot = ''
+  })
+
+  it('returns null for missing optional images inside the workspace', async () => {
+    const { readImage } = createWorkspaceImageHandlers()
+
+    await expect(readImage({ clientId: 'c1', workspaceId: null, webContentsId: null }, 'workspace-1', 'missing.svg')).resolves.toBeNull()
+  })
+
+  it.skipIf(process.platform === 'win32')('rejects image reads that escape through a symlink', async () => {
+    const outsideImage = join(outsideDir, 'icon.svg')
+    writeFileSync(outsideImage, '<svg></svg>')
+    symlinkSync(outsideImage, join(workspaceRoot, 'icon.svg'), 'file')
+
+    const { readImage } = createWorkspaceImageHandlers()
+
+    await expect(readImage({ clientId: 'c1', workspaceId: null, webContentsId: null }, 'workspace-1', 'icon.svg')).rejects.toThrow(
+      'outside workspace directory',
+    )
+  })
+
+  it('rejects image writes that escape through a symlinked parent directory', async () => {
+    const outsideImage = join(outsideDir, 'icon.svg')
+    symlinkSync(outsideDir, join(workspaceRoot, 'linked-outside'), process.platform === 'win32' ? 'junction' : 'dir')
+
+    const { writeImage } = createWorkspaceImageHandlers()
+
+    await expect(
+      writeImage(
+        { clientId: 'c1', workspaceId: null, webContentsId: null },
+        'workspace-1',
+        'linked-outside/icon.svg',
+        Buffer.from('<svg></svg>').toString('base64'),
+        'image/svg+xml',
+      ),
+    ).rejects.toThrow('outside workspace directory')
+
+    expect(existsSync(outsideImage)).toBe(false)
+  })
+
+  it.skipIf(process.platform === 'win32')('rejects image writes through a broken final symlink', async () => {
+    const outsideImage = join(outsideDir, 'created.svg')
+    symlinkSync(outsideImage, join(workspaceRoot, 'icon.svg'), 'file')
+
+    const { writeImage } = createWorkspaceImageHandlers()
+
+    await expect(
+      writeImage(
+        { clientId: 'c1', workspaceId: null, webContentsId: null },
+        'workspace-1',
+        'icon.svg',
+        Buffer.from('<svg></svg>').toString('base64'),
+        'image/svg+xml',
+      ),
+    ).rejects.toThrow('outside workspace directory')
+
+    expect(existsSync(outsideImage)).toBe(false)
+  })
+
+  it('allows overwriting an image when the workspace root is a symlink', async () => {
+    const linkedWorkspaceRoot = join(rootDir, 'workspace-link')
+    symlinkSync(workspaceRoot, linkedWorkspaceRoot, process.platform === 'win32' ? 'junction' : 'dir')
+    workspaceRoot = linkedWorkspaceRoot
+
+    const realImage = join(rootDir, 'workspace', 'icon.svg')
+    writeFileSync(realImage, '<svg>old</svg>')
+
+    const { writeImage } = createWorkspaceImageHandlers()
+
+    await writeImage(
+      { clientId: 'c1', workspaceId: null, webContentsId: null },
+      'workspace-1',
+      'icon.svg',
+      Buffer.from('<svg>new</svg>').toString('base64'),
+      'image/svg+xml',
+    )
+
+    expect(readFileSync(realImage, 'utf8')).toBe('<svg>new</svg>')
+  })
+})

--- a/packages/desktop/packages/server-core/src/handlers/rpc/workspace.ts
+++ b/packages/desktop/packages/server-core/src/handlers/rpc/workspace.ts
@@ -4,6 +4,7 @@ import { mkdir, writeFile } from 'node:fs/promises'
 import { homedir } from 'os'
 import { dirname, join } from 'path'
 import { promisify } from 'node:util'
+import { isPathWithinDirectoryForCreation } from '@craft-agent/session-tools-core'
 import { RPC_CHANNELS } from '@craft-agent/shared/protocol'
 import { getWorkspaceByNameOrId, addWorkspace, setActiveWorkspace, updateWorkspaceRemoteServer } from '@craft-agent/shared/config'
 import { loadWorkspaceConfig } from '@craft-agent/shared/workspaces'
@@ -297,8 +298,8 @@ export function registerWorkspaceCoreHandlers(server: RpcServer, deps: HandlerDe
     // Resolve path relative to workspace root
     const absolutePath = normalize(join(workspace.rootPath, relativePath))
 
-    // Double-check the resolved path is still within workspace
-    if (!absolutePath.startsWith(workspace.rootPath)) {
+    // Double-check the resolved path is still within workspace, including symlink targets.
+    if (!isPathWithinDirectoryForCreation(absolutePath, workspace.rootPath)) {
       throw new Error('Invalid path: outside workspace directory')
     }
 
@@ -351,8 +352,8 @@ export function registerWorkspaceCoreHandlers(server: RpcServer, deps: HandlerDe
     // Resolve path relative to workspace root
     const absolutePath = normalize(join(workspace.rootPath, relativePath))
 
-    // Double-check the resolved path is still within workspace
-    if (!absolutePath.startsWith(workspace.rootPath)) {
+    // Double-check the resolved path is still within workspace, including symlink targets.
+    if (!isPathWithinDirectoryForCreation(absolutePath, workspace.rootPath)) {
       throw new Error('Invalid path: outside workspace directory')
     }
 

--- a/packages/desktop/packages/session-tools-core/src/handlers/submit-plan.test.ts
+++ b/packages/desktop/packages/session-tools-core/src/handlers/submit-plan.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'bun:test';
+import { join } from 'node:path';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { handleSubmitPlan } from './submit-plan.ts';
+import type { SessionToolContext } from '../context.ts';
+
+function createCtx(
+  plansFolderPath: string,
+  opts: {
+    exists?: boolean;
+    readFile?: string;
+    onRead?: (path: string) => void;
+    onSubmitted?: (path: string) => void;
+  } = {}
+): SessionToolContext {
+  return {
+    sessionId: 'session-123',
+    workspacePath: join('/tmp', 'workspace'),
+    get sourcesPath() {
+      return join(this.workspacePath, 'sources');
+    },
+    get skillsPath() {
+      return join(this.workspacePath, 'skills');
+    },
+    plansFolderPath,
+    callbacks: {
+      onPlanSubmitted: (path: string) => opts.onSubmitted?.(path),
+      onAuthRequest: () => {},
+    },
+    fs: {
+      exists: () => opts.exists ?? true,
+      readFile: (path: string) => {
+        opts.onRead?.(path);
+        return opts.readFile ?? '# Plan';
+      },
+      readFileBuffer: () => Buffer.from(opts.readFile ?? '# Plan'),
+      writeFile: () => {},
+      isDirectory: () => false,
+      readdir: () => [],
+      stat: () => ({ size: 0, isDirectory: () => false }),
+    },
+    loadSourceConfig: () => null,
+  };
+}
+
+describe('handleSubmitPlan', () => {
+  const plansFolderPath = join('/tmp', 'workspace', 'sessions', 'session-123', 'plans');
+
+  it('submits a plan inside the session plans directory', async () => {
+    const submitted: string[] = [];
+    const planPath = join(plansFolderPath, 'plan.md');
+    const ctx = createCtx(plansFolderPath, {
+      onSubmitted: (path) => submitted.push(path),
+    });
+
+    const result = await handleSubmitPlan(ctx, { planPath });
+
+    expect(result.isError).toBe(false);
+    expect(submitted).toEqual([planPath]);
+  });
+
+  it('rejects sibling paths that share the plans directory prefix', async () => {
+    const readAttempts: string[] = [];
+    const submitted: string[] = [];
+    const siblingPlanPath = join(`${plansFolderPath}-other`, 'plan.md');
+    const ctx = createCtx(plansFolderPath, {
+      onRead: (path) => readAttempts.push(path),
+      onSubmitted: (path) => submitted.push(path),
+    });
+
+    const result = await handleSubmitPlan(ctx, { planPath: siblingPlanPath });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('session plans directory');
+    expect(readAttempts).toEqual([]);
+    expect(submitted).toEqual([]);
+  });
+
+  it('rejects paths that escape the plans directory through a symlink', async () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
+    const rootDir = mkdtempSync(join(tmpdir(), 'submit-plan-boundary-'));
+    try {
+      const realPlansDir = join(rootDir, 'plans');
+      const outsideDir = join(rootDir, 'outside');
+      mkdirSync(realPlansDir, { recursive: true });
+      mkdirSync(outsideDir, { recursive: true });
+      writeFileSync(join(outsideDir, 'plan.md'), '# outside');
+      symlinkSync(outsideDir, join(realPlansDir, 'escape-link'), 'dir');
+
+      const readAttempts: string[] = [];
+      const submitted: string[] = [];
+      const ctx = createCtx(realPlansDir, {
+        onRead: (path) => readAttempts.push(path),
+        onSubmitted: (path) => submitted.push(path),
+      });
+
+      const result = await handleSubmitPlan(ctx, {
+        planPath: join(realPlansDir, 'escape-link', 'plan.md'),
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('session plans directory');
+      expect(readAttempts).toEqual([]);
+      expect(submitted).toEqual([]);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/desktop/packages/session-tools-core/src/handlers/submit-plan.ts
+++ b/packages/desktop/packages/session-tools-core/src/handlers/submit-plan.ts
@@ -8,6 +8,7 @@
 import type { SessionToolContext } from '../context.ts';
 import type { ToolResult } from '../types.ts';
 import { successResponse, errorResponse } from '../response.ts';
+import { isPathWithinDirectory } from '../runtime/path-security.ts';
 
 export interface SubmitPlanArgs {
   planPath: string;
@@ -26,6 +27,12 @@ export async function handleSubmitPlan(
   args: SubmitPlanArgs
 ): Promise<ToolResult> {
   const { planPath } = args;
+
+  if (!isPathWithinDirectory(planPath, ctx.plansFolderPath)) {
+    return errorResponse(
+      `Plan file must be inside the session plans directory: ${ctx.plansFolderPath}`
+    );
+  }
 
   // Verify the file exists
   if (!ctx.fs.exists(planPath)) {

--- a/packages/desktop/packages/session-tools-core/src/index.ts
+++ b/packages/desktop/packages/session-tools-core/src/index.ts
@@ -136,6 +136,13 @@ export type {
 
 export { createNodeFileSystem } from './context.ts';
 
+// Path security
+export {
+  isPathInsideOrEqual,
+  isPathWithinDirectory,
+  isPathWithinDirectoryForCreation,
+} from './runtime/path-security.ts';
+
 // Handlers
 export {
   // SubmitPlan

--- a/packages/desktop/packages/session-tools-core/src/runtime/path-security.test.ts
+++ b/packages/desktop/packages/session-tools-core/src/runtime/path-security.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { isPathWithinDirectory, isPathWithinDirectoryForCreation } from './path-security.ts';
+import {
+  isPathInsideOrEqual,
+  isPathWithinDirectory,
+  isPathWithinDirectoryForCreation,
+} from './path-security.ts';
 
 describe('path-security', () => {
   let rootDir: string;
@@ -30,6 +34,11 @@ describe('path-security', () => {
     expect(isPathWithinDirectoryForCreation(sibling, sessionDir)).toBe(false);
   });
 
+  it('allows child names that start with dots but are not parent-directory segments', () => {
+    expect(isPathInsideOrEqual(sessionDir, join(sessionDir, '..backup', 'file.txt'))).toBe(true);
+    expect(isPathInsideOrEqual(sessionDir, join(sessionDir, '..notes.md'))).toBe(true);
+  });
+
   it('blocks symlink escape for creation paths', () => {
     if (process.platform === 'win32') {
       // Symlink creation on Windows is permission-sensitive in CI/dev.
@@ -41,6 +50,32 @@ describe('path-security', () => {
 
     const escapedOutput = join(escapeLink, 'out.json');
     expect(isPathWithinDirectoryForCreation(escapedOutput, dataDir)).toBe(false);
+  });
+
+  it('blocks creation through a broken final symlink', () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
+    const outsideFile = join(outsideDir, 'created.txt');
+    const linkInSession = join(dataDir, 'created.txt');
+    symlinkSync(outsideFile, linkInSession, 'file');
+
+    expect(isPathWithinDirectoryForCreation(linkInSession, dataDir)).toBe(false);
+  });
+
+  it('allows paths inside a root directory that is itself a symlink', () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
+    const linkedSessionDir = join(rootDir, 'session-link');
+    symlinkSync(sessionDir, linkedSessionDir, 'dir');
+    const filePath = join(linkedSessionDir, 'data', 'file.txt');
+    writeFileSync(filePath, 'inside');
+
+    expect(isPathWithinDirectory(filePath, linkedSessionDir)).toBe(true);
+    expect(isPathWithinDirectoryForCreation(filePath, linkedSessionDir)).toBe(true);
   });
 
   it('blocks symlink escape for existing files', () => {

--- a/packages/desktop/packages/session-tools-core/src/runtime/path-security.ts
+++ b/packages/desktop/packages/session-tools-core/src/runtime/path-security.ts
@@ -1,19 +1,49 @@
-import { dirname, isAbsolute, relative, resolve } from 'node:path';
-import { existsSync, realpathSync } from 'node:fs';
+import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
+import { lstatSync, realpathSync } from 'node:fs';
 
-function normalizePath(path: string): string {
+function normalizePathForBoundary(path: string): string {
   return process.platform === 'win32' ? path.toLowerCase() : path;
 }
 
-function isWithin(base: string, target: string): boolean {
-  const normalizedBase = normalizePath(base);
-  const normalizedTarget = normalizePath(target);
-  const rel = relative(normalizedBase, normalizedTarget);
-  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+/**
+ * Check whether targetPath is baseDir or a child path of baseDir.
+ */
+export function isPathInsideOrEqual(baseDir: string, targetPath: string): boolean {
+  const resolvedBase = normalizePathForBoundary(resolve(baseDir));
+  const resolvedTarget = normalizePathForBoundary(resolve(targetPath));
+  const relativePath = relative(resolvedBase, resolvedTarget);
+
+  return (
+    relativePath === '' ||
+    (relativePath !== '..' &&
+      !relativePath.startsWith(`..${sep}`) &&
+      !isAbsolute(relativePath))
+  );
 }
 
-function realpathIfExists(path: string): string {
-  return existsSync(path) ? realpathSync.native(path) : resolve(path);
+function pathEntryExists(path: string): boolean {
+  try {
+    lstatSync(path);
+    return true;
+  } catch (error) {
+    const code =
+      error && typeof error === 'object'
+        ? (error as { code?: unknown }).code
+        : undefined;
+    return code !== 'ENOENT' && code !== 'ENOTDIR';
+  }
+}
+
+function realpathOrNull(path: string): string | null {
+  try {
+    return realpathSync.native(path);
+  } catch {
+    return null;
+  }
+}
+
+function realpathIfEntryExists(path: string): string | null {
+  return pathEntryExists(path) ? realpathOrNull(path) : resolve(path);
 }
 
 /**
@@ -23,13 +53,17 @@ export function isPathWithinDirectory(targetPath: string, baseDir: string): bool
   const resolvedTarget = resolve(targetPath);
   const resolvedBase = resolve(baseDir);
 
-  if (!isWithin(resolvedBase, resolvedTarget)) {
+  if (!isPathInsideOrEqual(resolvedBase, resolvedTarget)) {
     return false;
   }
 
-  const realBase = realpathIfExists(resolvedBase);
-  const realTarget = realpathIfExists(resolvedTarget);
-  return isWithin(realBase, realTarget);
+  const realBase = realpathIfEntryExists(resolvedBase);
+  const realTarget = realpathIfEntryExists(resolvedTarget);
+  if (!realBase || !realTarget) {
+    return false;
+  }
+
+  return isPathInsideOrEqual(realBase, realTarget);
 }
 
 /**
@@ -41,21 +75,24 @@ export function isPathWithinDirectoryForCreation(targetPath: string, baseDir: st
   const resolvedTarget = resolve(targetPath);
   const resolvedBase = resolve(baseDir);
 
-  if (!isWithin(resolvedBase, resolvedTarget)) {
+  if (!isPathInsideOrEqual(resolvedBase, resolvedTarget)) {
     return false;
   }
 
-  const realBase = realpathIfExists(resolvedBase);
+  const realBase = realpathIfEntryExists(resolvedBase);
+  if (!realBase) {
+    return false;
+  }
 
-  if (existsSync(resolvedTarget)) {
-    return isPathWithinDirectory(resolvedTarget, realBase);
+  if (pathEntryExists(resolvedTarget)) {
+    return isPathWithinDirectory(resolvedTarget, resolvedBase);
   }
 
   let current = dirname(resolvedTarget);
   while (true) {
-    if (existsSync(current)) {
-      const realCurrent = realpathSync.native(current);
-      return isWithin(realBase, realCurrent);
+    if (pathEntryExists(current)) {
+      const realCurrent = realpathOrNull(current);
+      return !!realCurrent && isPathInsideOrEqual(realBase, realCurrent);
     }
     const parent = dirname(current);
     if (parent === current) {

--- a/packages/desktop/packages/shared/src/agent/__tests__/session-scoped-tools-path-boundary.test.ts
+++ b/packages/desktop/packages/shared/src/agent/__tests__/session-scoped-tools-path-boundary.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'bun:test';
+import { join } from 'node:path';
+import {
+  getSessionPlansDir,
+  isPathInPlansDir,
+} from '../session-scoped-tools.ts';
+
+describe('session-scoped plan path helpers', () => {
+  const workspacePath = join('/tmp', 'workspace');
+  const sessionId = 'session-123';
+
+  it('allows the plans directory itself', () => {
+    const plansDir = getSessionPlansDir(workspacePath, sessionId);
+
+    expect(isPathInPlansDir(plansDir, workspacePath, sessionId)).toBe(true);
+  });
+
+  it('allows child paths inside the plans directory', () => {
+    const plansDir = getSessionPlansDir(workspacePath, sessionId);
+    const planPath = join(plansDir, 'plan.md');
+
+    expect(isPathInPlansDir(planPath, workspacePath, sessionId)).toBe(true);
+  });
+
+  it('rejects sibling paths that share the plans directory prefix', () => {
+    const plansDir = getSessionPlansDir(workspacePath, sessionId);
+    const siblingPlanPath = join(`${plansDir}-other`, 'plan.md');
+
+    expect(isPathInPlansDir(siblingPlanPath, workspacePath, sessionId)).toBe(false);
+  });
+});

--- a/packages/desktop/packages/shared/src/agent/session-scoped-tools.ts
+++ b/packages/desktop/packages/shared/src/agent/session-scoped-tools.ts
@@ -25,6 +25,7 @@ import {
   SESSION_BACKEND_TOOL_NAMES,
   SESSION_TOOL_REGISTRY,
   getSessionToolDefs,
+  isPathInsideOrEqual,
   TOOL_DESCRIPTIONS as BASE_DESCRIPTIONS,
   // Types
   type ToolResult,
@@ -140,7 +141,7 @@ export function getSessionPlansDir(workspacePath: string, sessionId: string): st
  */
 export function isPathInPlansDir(path: string, workspacePath: string, sessionId: string): boolean {
   const plansDir = getSessionPlansDir(workspacePath, sessionId);
-  return path.startsWith(plansDir);
+  return isPathInsideOrEqual(plansDir, path);
 }
 
 // ============================================================

--- a/packages/desktop/packages/shared/src/utils/__tests__/bundle-files.test.ts
+++ b/packages/desktop/packages/shared/src/utils/__tests__/bundle-files.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
-import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'fs'
-import { join } from 'path'
+import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync, symlinkSync } from 'fs'
+import { join, sep } from 'path'
 import { tmpdir } from 'os'
 import {
   collectDirectoryFiles,
@@ -245,6 +245,21 @@ describe('bundle-files', () => {
       expect(readFileSync(join(target, 'test.txt'), 'utf-8')).toBe('restored content')
     })
 
+    it('restores files when target directory has a trailing separator', () => {
+      const content = Buffer.from('restored content')
+      const files: BundleFile[] = [{
+        relativePath: 'test.txt',
+        contentBase64: content.toString('base64'),
+        size: content.length,
+      }]
+
+      const target = join(tmpDir, 'target')
+      mkdirSync(target)
+      restoreFiles(`${target}${sep}`, files)
+
+      expect(readFileSync(join(target, 'test.txt'), 'utf-8')).toBe('restored content')
+    })
+
     it('creates subdirectories as needed', () => {
       const content = Buffer.from('nested')
       const files: BundleFile[] = [{
@@ -282,6 +297,50 @@ describe('bundle-files', () => {
       const target = join(tmpDir, 'target')
       mkdirSync(target)
       expect(() => restoreFiles(target, files)).toThrow('Invalid bundle file')
+    })
+
+    it('rejects writes through a symlinked parent directory', () => {
+      if (process.platform === 'win32') {
+        return
+      }
+
+      const content = Buffer.from('x')
+      const files: BundleFile[] = [{
+        relativePath: 'link/pwn.txt',
+        contentBase64: content.toString('base64'),
+        size: content.length,
+      }]
+
+      const target = join(tmpDir, 'target')
+      const outside = join(tmpDir, 'outside')
+      mkdirSync(target)
+      mkdirSync(outside)
+      symlinkSync(outside, join(target, 'link'), 'dir')
+
+      expect(() => restoreFiles(target, files)).toThrow('Path escapes target directory')
+      expect(existsSync(join(outside, 'pwn.txt'))).toBe(false)
+    })
+
+    it('rejects writes through a broken final symlink', () => {
+      if (process.platform === 'win32') {
+        return
+      }
+
+      const content = Buffer.from('x')
+      const files: BundleFile[] = [{
+        relativePath: 'link.txt',
+        contentBase64: content.toString('base64'),
+        size: content.length,
+      }]
+
+      const target = join(tmpDir, 'target')
+      const outside = join(tmpDir, 'outside')
+      mkdirSync(target)
+      mkdirSync(outside)
+      symlinkSync(join(outside, 'created.txt'), join(target, 'link.txt'), 'file')
+
+      expect(() => restoreFiles(target, files)).toThrow('Path escapes target directory')
+      expect(existsSync(join(outside, 'created.txt'))).toBe(false)
     })
 
     it('round-trips with collectDirectoryFiles', () => {

--- a/packages/desktop/packages/shared/src/utils/bundle-files.ts
+++ b/packages/desktop/packages/shared/src/utils/bundle-files.ts
@@ -8,7 +8,8 @@
  */
 
 import { existsSync, readdirSync, readFileSync, statSync, mkdirSync, writeFileSync } from 'fs'
-import { join, relative, dirname, sep } from 'path'
+import { join, relative, dirname, sep, resolve } from 'path'
+import { isPathWithinDirectoryForCreation } from '@craft-agent/session-tools-core'
 import { debug } from './debug.ts'
 
 /**
@@ -179,6 +180,8 @@ export function collectDirectoryFiles(dir: string, options?: CollectOptions): Bu
  * @throws Error if any file fails path validation (path traversal, absolute path, etc.)
  */
 export function restoreFiles(targetDir: string, files: BundleFile[]): void {
+  const resolvedTargetDir = resolve(targetDir)
+
   for (const file of files) {
     const error = validateBundleFile(file)
     if (error) {
@@ -186,10 +189,10 @@ export function restoreFiles(targetDir: string, files: BundleFile[]): void {
     }
 
     const nativePath = fromPortableRelPath(file.relativePath)
-    const fullPath = join(targetDir, nativePath)
+    const fullPath = resolve(resolvedTargetDir, nativePath)
 
     // Safety: ensure resolved path is inside target dir
-    if (!fullPath.startsWith(targetDir + sep) && fullPath !== targetDir) {
+    if (!isPathWithinDirectoryForCreation(fullPath, resolvedTargetDir)) {
       throw new Error(`Path escapes target directory: ${file.relativePath}`)
     }
 

--- a/packages/desktop/packages/shared/src/utils/files.ts
+++ b/packages/desktop/packages/shared/src/utils/files.ts
@@ -1,7 +1,8 @@
 import { existsSync, readFileSync, statSync, writeFileSync, unlinkSync, mkdtempSync, renameSync } from 'fs';
-import { extname, basename, resolve, join, relative, isAbsolute, sep } from 'path';
+import { extname, basename, resolve, join, relative } from 'path';
 import { execSync } from 'child_process';
 import { tmpdir } from 'os';
+import { isPathInsideOrEqual } from '@craft-agent/session-tools-core';
 
 /**
  * Strip UTF-8 BOM (Byte Order Mark) from a string.
@@ -832,12 +833,7 @@ export function formatSinglePathToRelative(absolutePath: string, cwd?: string): 
   const targetPath = resolve(absolutePath);
   const relativePath = relative(basePath, targetPath);
 
-  if (
-    relativePath &&
-    relativePath !== '..' &&
-    !relativePath.startsWith(`..${sep}`) &&
-    !isAbsolute(relativePath)
-  ) {
+  if (relativePath && isPathInsideOrEqual(basePath, targetPath)) {
     return './' + relativePath;
   }
 


### PR DESCRIPTION
## What this PR does

Consolidates the remaining desktop path-boundary fixes for session plans, workspace image RPCs, and bundle restore, and routes the already-merged path formatter boundary check through the same shared desktop helper. The shared helper now handles exact-directory containment without sibling-prefix matches, keeps `..name` path segments valid, handles trailing separators, and supports symlink-aware checks for existing and creation paths.

## Why it's needed

The separate fixes in #5507, #5513, #5519, and the formatter work from #5517 all addressed the same class of bug: raw prefix checks accepted sibling paths or duplicated slightly different boundary logic. This PR folds the remaining fixes together and makes the formatter use the same helper, so the desktop packages do not carry per-file containment checks.

## Reviewer Test Plan

### How to verify

Run the targeted desktop tests for the affected surfaces: session plan submission, workspace image read/write paths, session-scoped plan helpers, path formatting, and bundle file restore. Confirm that sibling-prefix paths are rejected, symlink escapes are rejected, paths under a symlinked workspace/root still work, `..name` entries inside the root still work, and bundle restore accepts target directories with a trailing separator while rejecting symlink-parent and broken-final-symlink writes.

### Evidence (Before & After)

Before: these call sites used raw prefix checks or local one-off containment checks, so siblings such as `plans-other`, workspace image symlink escapes, sibling project paths, and trailing-separator restore targets were handled inconsistently.

After: the tests cover those cases directly. Local results after rebasing onto latest `upstream/main`:

`bun test ./src/runtime/path-security.test.ts ./src/handlers/submit-plan.test.ts` in `packages/desktop/packages/session-tools-core`: 9 pass / 0 fail

`bun test ./src/handlers/rpc/workspace.image-path.test.ts` in `packages/desktop/packages/server-core`: 5 pass / 0 fail

`bun test ./src/agent/__tests__/session-scoped-tools-path-boundary.test.ts ./src/utils/__tests__/bundle-files.test.ts ./src/utils/__tests__/files.test.ts` in `packages/desktop/packages/shared`: 34 pass / 0 fail

`bun run typecheck:shared` in `packages/desktop`: pass

`bun run typecheck` in `packages/desktop/packages/server-core`: pass

`bunx prettier --check` on touched desktop files: pass

`git diff --check`: pass

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Bun 1.3.14, Node 22.22.2, local macOS worktree.

## Risk & Scope

- Main risk or tradeoff: the shared helper is now used by multiple desktop packages, so a containment semantic mistake would affect several path-sensitive call sites.
- Not validated / out of scope: full desktop app runtime flow, local Windows/Linux runs.
- Breaking changes / migration notes: none expected.

## Linked Issues

Fixes #5506
Fixes #5512
Fixes #5518
Refs #5516

Supersedes #5507, #5513, and #5519. Follows up #5517 by routing its formatter boundary check through the shared helper.

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

将 desktop 里剩余的 session plans、workspace image RPC、bundle restore 路径边界修复合并到一个 PR，并把已经合入的 path formatter 边界判断也接到同一个共享 desktop helper 上。共享 helper 现在可以正确处理目录包含关系，不会把共享字符串前缀的兄弟路径当成子路径；同时保留 `..name` 这类合法路径段，支持尾部分隔符，并为已存在路径和创建路径提供 symlink-aware 检查。

## Why it's needed

#5507、#5513、#5519 这些独立修复，以及 #5517 中的 formatter 修复，处理的是同一类问题：原来的 raw prefix check 会接受兄弟路径，或者在不同文件里重复实现略有差异的边界判断。本 PR 将剩余修复合并，并让 formatter 使用同一个 helper，这样 desktop packages 不再保留每个文件自己的 containment check。

## Reviewer Test Plan

### How to verify

运行受影响面的目标 desktop 测试：session plan submit、workspace image read/write path、session-scoped plan helper、path formatting、bundle file restore。确认共享前缀的兄弟路径会被拒绝，symlink escape 会被拒绝，位于 symlink workspace/root 下的正常路径仍可用，root 内部的 `..name` 路径仍可用，并且 bundle restore 接受带尾部分隔符的 target directory，同时拒绝 symlink parent 和 broken final symlink 写入。

### Evidence (Before & After)

Before：这些调用点使用 raw prefix check 或本地一次性 containment check，导致 `plans-other` 这类 sibling path、workspace image symlink escape、兄弟 project path、以及带尾部分隔符的 restore target 行为不一致。

After：测试直接覆盖这些场景。rebase 到最新 `upstream/main` 后的本地结果：

`bun test ./src/runtime/path-security.test.ts ./src/handlers/submit-plan.test.ts` in `packages/desktop/packages/session-tools-core`: 9 pass / 0 fail

`bun test ./src/handlers/rpc/workspace.image-path.test.ts` in `packages/desktop/packages/server-core`: 5 pass / 0 fail

`bun test ./src/agent/__tests__/session-scoped-tools-path-boundary.test.ts ./src/utils/__tests__/bundle-files.test.ts ./src/utils/__tests__/files.test.ts` in `packages/desktop/packages/shared`: 34 pass / 0 fail

`bun run typecheck:shared` in `packages/desktop`: pass

`bun run typecheck` in `packages/desktop/packages/server-core`: pass

`bunx prettier --check` on touched desktop files: pass

`git diff --check`: pass

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Bun 1.3.14，Node 22.22.2，本地 macOS worktree。

## Risk & Scope

- 主要风险或取舍：共享 helper 现在被多个 desktop package 使用，如果 containment 语义有误，会影响多个路径敏感调用点。
- 未验证 / 不在范围内：完整 desktop app runtime flow、本地 Windows/Linux 测试。
- 破坏性变更 / 迁移说明：预期没有。

## Linked Issues

Fixes #5506
Fixes #5512
Fixes #5518
Refs #5516

Supersedes #5507, #5513, and #5519. 作为 #5517 的后续，本 PR 将 formatter 的边界判断接到共享 helper。

## AI Assistance Disclosure

我使用 Codex 审查改动、对照现有模式做 sanity-check，并帮助发现潜在边界情况。

</details>
