### PR TITLE
docs(triage): Add reuse-before-new-code review check

### DIFF
--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -147,6 +147,15 @@ Now read the diff. Compare the PR's approach against your independent proposal:
 - Are there correctness bugs, security holes, or regressions your approach would have avoided?
 - Does the implementation follow the project's conventions, or does it over-abstract / duplicate code / put logic in the wrong package?
 
+**Reuse-before-new-code check:** for new non-trivial logic, run a small
+reuse ladder: is there an existing shared function/module/API in this repo? Does
+the standard library or platform API cover it? Does an already-installed
+dependency cover it? Prefer reusing or extending a compatible implementation
+instead of adding a parallel utility or per-file helper. Comment only when you
+can name the reusable implementation/API/dependency, or when the same
+non-trivial logic is repeated across changed files. Do not flag trivial
+one-liners, different semantics, or speculative extraction.
+
 Keep it tight — only flag two kinds of issues:
 
 - **Critical blockers** — correctness bugs, security holes, regressions.


### PR DESCRIPTION
## What this PR does

Adds a reuse-before-new-code check to the triage PR review workflow so reviewers look for existing shared functions/modules, standard library/platform APIs, or installed dependencies before accepting new non-trivial utility logic.

## Why it's needed

This makes the triage prompt better at catching duplicated helper-style logic without turning the review into a broad "extract helpers everywhere" rule.

## Reviewer Test Plan

### How to verify

Review the PR diff and confirm Stage 2 code review now asks for the reuse ladder before accepting new non-trivial logic, while only allowing comments when a concrete reusable implementation/API/dependency can be named or repeated non-trivial logic is clear.

### Evidence (Before & After)

N/A for runtime behavior; this is a prompt/workflow instruction update. Local checks: `git diff --check main...HEAD` passed for the local commit; GitHub compare API shows one file changed with 9 additions and 0 deletions. `quick_validate.py .qwen/skills/triage` was run and still fails on pre-existing `SKILL.md` frontmatter keys (`allowedTools`, `argument-hint`) that this PR does not change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

N/A; documentation/skill workflow change only.

## Risk & Scope

- Main risk or tradeoff: The new check could create noisy review comments if applied too broadly, so the wording limits it to named reusable implementations or clearly repeated non-trivial logic.
- Not validated / out of scope: No runtime product tests were run because this only changes triage skill guidance; existing skill frontmatter validation failures were not changed.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在 triage 的 PR review workflow 里增加 reuse-before-new-code 检查，要求 reviewer 在接受新的非平凡工具逻辑前，先看仓库里已有共享函数/模块、标准库/平台 API 或已安装依赖是否能覆盖。

## 为什么需要

这样可以让 triage prompt 更容易发现重复的 helper/utility 逻辑，同时不会变成“所有地方都必须抽 helper”的宽泛规则。

## Reviewer Test Plan

### 如何验证

查看 PR diff，确认 Stage 2 code review 现在会在接受新的非平凡逻辑前执行 reuse ladder，并且只有在能点名可复用实现/API/依赖，或跨文件重复逻辑很明确时才评论。

### 证据（Before & After）

运行时行为不适用；这是 prompt/workflow 指令更新。本地检查：`git diff --check main...HEAD` 通过；GitHub compare API 显示只改 1 个文件，新增 9 行、删除 0 行。已运行 `quick_validate.py .qwen/skills/triage`，它仍因既有 `SKILL.md` frontmatter 键 `allowedTools`、`argument-hint` 失败，本 PR 不修改这些键。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### 环境（可选）

N/A；仅文档/skill workflow 变更。

## 风险和范围

- 主要风险或权衡：如果执行过宽，新检查可能增加 review 噪音，所以文案限制为必须能点名可复用实现，或明确存在重复的非平凡逻辑。
- 未验证 / 范围外：没有运行产品运行时测试，因为这里只改变 triage skill 指引；既有 skill frontmatter 校验失败不在本 PR 范围内。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

N/A

</details>