### PR TITLE
fix(core): keep bare fast model on current auth

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1291,7 +1291,7 @@ describe('Server Config (config.ts)', () => {
   });
 
   describe('model switching with different credentials (OpenAI)', () => {
-    it('returns undefined for bare Qwen OAuth fast models under OpenAI auth', () => {
+    it('returns undefined for bare Qwen OAuth fast models under active OpenAI auth', async () => {
       const config = new Config({
         ...baseParams,
         authType: AuthType.USE_OPENAI,
@@ -1308,6 +1308,8 @@ describe('Server Config (config.ts)', () => {
           ],
         },
       });
+
+      await config.refreshAuth(AuthType.USE_OPENAI);
 
       expect(config.getFastModel()).toBeUndefined();
     });

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1291,33 +1291,25 @@ describe('Server Config (config.ts)', () => {
   });
 
   describe('model switching with different credentials (OpenAI)', () => {
-    it('returns a bare fast model selector when the model is configured under another auth type', () => {
+    it('returns undefined for bare Qwen OAuth fast models under OpenAI auth', () => {
       const config = new Config({
         ...baseParams,
-        authType: AuthType.USE_ANTHROPIC,
-        model: 'claude-opus-4-7',
-        fastModel: 'deepseek-v4-flash',
+        authType: AuthType.USE_OPENAI,
+        model: 'qwen3.7-max',
+        fastModel: 'coder-model',
         modelProvidersConfig: {
           [AuthType.USE_OPENAI]: [
             {
-              id: 'deepseek-v4-flash',
-              name: 'deepseek-v4-flash',
+              id: 'qwen3.7-max',
+              name: 'qwen3.7-max',
               baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
               envKey: 'DASHSCOPE_API_KEY',
-            },
-          ],
-          [AuthType.USE_ANTHROPIC]: [
-            {
-              id: 'claude-opus-4-7',
-              name: 'claude-opus-4-7',
-              baseUrl: 'https://idealab.alibaba-inc.com/api/anthropic',
-              envKey: 'IDEALAB_OPUS_API_KEY',
             },
           ],
         },
       });
 
-      expect(config.getFastModel()).toBe('deepseek-v4-flash');
+      expect(config.getFastModel()).toBeUndefined();
     });
 
     it('returns an authType-qualified fast model selector', () => {
@@ -1347,6 +1339,27 @@ describe('Server Config (config.ts)', () => {
       });
 
       expect(config.getFastModel()).toBe('openai:shared-model');
+    });
+
+    it('allows authType-qualified fast models under Qwen OAuth', () => {
+      const config = new Config({
+        ...baseParams,
+        authType: AuthType.USE_OPENAI,
+        model: 'qwen3.7-max',
+        fastModel: 'qwen-oauth:coder-model',
+        modelProvidersConfig: {
+          [AuthType.USE_OPENAI]: [
+            {
+              id: 'qwen3.7-max',
+              name: 'qwen3.7-max',
+              baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+              envKey: 'DASHSCOPE_API_KEY',
+            },
+          ],
+        },
+      });
+
+      expect(config.getFastModel()).toBe('qwen-oauth:coder-model');
     });
 
     it('keeps authType-qualified selectors when the auth type matches the current auth type', () => {

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1343,7 +1343,7 @@ describe('Server Config (config.ts)', () => {
       expect(config.getFastModel()).toBe('openai:shared-model');
     });
 
-    it('allows authType-qualified fast models under Qwen OAuth', () => {
+    it('preserves authType-qualified fast model selectors across auth types', () => {
       const config = new Config({
         ...baseParams,
         authType: AuthType.USE_OPENAI,
@@ -1362,6 +1362,35 @@ describe('Server Config (config.ts)', () => {
       });
 
       expect(config.getFastModel()).toBe('qwen-oauth:coder-model');
+    });
+
+    it('resolves a bare fast model under the current auth type', async () => {
+      const config = new Config({
+        ...baseParams,
+        authType: AuthType.USE_OPENAI,
+        model: 'qwen3.7-max',
+        fastModel: 'fast-model',
+        modelProvidersConfig: {
+          [AuthType.USE_OPENAI]: [
+            {
+              id: 'qwen3.7-max',
+              name: 'qwen3.7-max',
+              baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+              envKey: 'DASHSCOPE_API_KEY',
+            },
+            {
+              id: 'fast-model',
+              name: 'fast-model',
+              baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+              envKey: 'DASHSCOPE_API_KEY',
+            },
+          ],
+        },
+      });
+
+      await config.refreshAuth(AuthType.USE_OPENAI);
+
+      expect(config.getFastModel()).toBe('fast-model');
     });
 
     it('keeps authType-qualified selectors when the auth type matches the current auth type', () => {
@@ -1416,7 +1445,7 @@ describe('Server Config (config.ts)', () => {
       expect(config.getFastModel()).toBe('openai:runtime-fast-model');
     });
 
-    it('returns undefined when the fast model is not configured for any auth type', () => {
+    it('returns undefined when no active auth type is available for a bare fast model', () => {
       const config = new Config({
         ...baseParams,
         authType: AuthType.USE_ANTHROPIC,
@@ -1433,6 +1462,29 @@ describe('Server Config (config.ts)', () => {
           ],
         },
       });
+
+      expect(config.getFastModel()).toBeUndefined();
+    });
+
+    it('returns undefined when the fast model is not configured for the current auth type', async () => {
+      const config = new Config({
+        ...baseParams,
+        authType: AuthType.USE_ANTHROPIC,
+        model: 'claude-opus-4-7',
+        fastModel: 'missing-fast-model',
+        modelProvidersConfig: {
+          [AuthType.USE_ANTHROPIC]: [
+            {
+              id: 'claude-opus-4-7',
+              name: 'claude-opus-4-7',
+              baseUrl: 'https://idealab.alibaba-inc.com/api/anthropic',
+              envKey: 'IDEALAB_OPUS_API_KEY',
+            },
+          ],
+        },
+      });
+
+      await config.refreshAuth(AuthType.USE_ANTHROPIC);
 
       expect(config.getFastModel()).toBeUndefined();
     });

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2588,10 +2588,17 @@ export class Config {
   private resolveFastModelSelector() {
     if (!this.fastModel) return undefined;
     try {
+      const rawSelector = resolveModelId(this.fastModel);
+      if (!rawSelector) return undefined;
+      if (rawSelector.authType) return rawSelector;
+
+      const currentAuthType = this.getContentGeneratorConfig()?.authType;
+      if (!currentAuthType) return undefined;
+
       return resolveModelId(this.fastModel, {
-        currentAuthType: this.getContentGeneratorConfig()?.authType,
+        currentAuthType,
         getAvailableModels: (authTypes) =>
-          this.getAllConfiguredModels(authTypes),
+          this.getAllConfiguredModels(authTypes ?? [currentAuthType]),
       });
     } catch {
       return undefined;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2593,12 +2593,17 @@ export class Config {
       if (rawSelector.authType) return rawSelector;
 
       const currentAuthType = this.getContentGeneratorConfig()?.authType;
-      if (!currentAuthType) return undefined;
+      if (!currentAuthType) {
+        this.debugLogger.debug(
+          'No active auth type; skipping bare fast model resolution',
+        );
+        return undefined;
+      }
 
       return resolveModelId(this.fastModel, {
         currentAuthType,
-        getAvailableModels: (authTypes) =>
-          this.getAllConfiguredModels(authTypes ?? [currentAuthType]),
+        getAvailableModels: () =>
+          this.getAllConfiguredModels([currentAuthType]),
       });
     } catch {
       return undefined;


### PR DESCRIPTION
## What this PR does

Keeps bare fast-model selectors scoped to the current authentication type while preserving explicit auth-qualified selectors such as `qwen-oauth:coder-model`.

## Why it's needed

A legacy bare `fastModel` value like `coder-model` can otherwise resolve to Qwen OAuth when the active model is using OpenAI-compatible auth. That can trigger an unexpected Qwen OAuth browser flow from background fast-model requests.

## Reviewer Test Plan

### How to verify

Configure OpenAI-compatible auth with a main model such as `qwen3.7-max` and a bare `fastModel` value of `coder-model`. Confirm that `config.getFastModel()` returns `undefined` after OpenAI auth is active instead of routing to Qwen OAuth. Also confirm that an explicit `qwen-oauth:coder-model` fast model still resolves.

### Evidence (Before & After)

Targeted test after the review follow-up:

```console
$ cd packages/core && npx vitest run src/config/config.test.ts
✓ src/config/config.test.ts (232 tests) 461ms
Test Files  1 passed (1)
Tests  232 passed (232)
```

Runtime tmux harness against the built core output:

```console
Qwen Code PR #5553 tmux runtime verification
Scenario: auth=openai, current provider models=[qwen3.7-max], qwen-oauth auto-registers coder-model
BEFORE old getFastModel equivalent:
  fastModel=coder-model => "coder-model"
  generic route => {"authType":"qwen-oauth","modelId":"coder-model"}
AFTER current Config.getFastModel():
  fastModel=coder-model => undefined
NON-REGRESSION current-auth bare model:
  fastModel=qwen3.7-max => "qwen3.7-max"
NON-REGRESSION explicit cross-auth selector:
  fastModel=qwen-oauth:coder-model => "qwen-oauth:coder-model"
```

Before: bare `fastModel: "coder-model"` could resolve through Qwen OAuth when the active OpenAI provider did not own that model.

After: bare fast-model resolution is limited to the current auth type after auth is active, while current-auth bare models remain supported, and explicit auth-qualified selectors continue to resolve only when intentionally configured.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Local worktree on macOS. Verified with `npx vitest run src/config/config.test.ts` from `packages/core`. The initial change was also verified with `npm run build && npm run typecheck` from the repository root; the follow-up commit only changes the regression test to activate auth before asserting.

## Risk & Scope

- Main risk or tradeoff: bare fast-model selectors no longer intentionally route across auth types; users who want cross-auth routing must use an explicit auth-qualified selector.
- Not validated / out of scope: manual interactive TUI browser-flow testing on Windows and Linux.
- Breaking changes / migration notes: none expected for explicit selectors.

## Linked Issues

Resolves #5552

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

将裸 `fastModel` 选择器限制在当前认证类型内解析，同时保留 `qwen-oauth:coder-model` 这类显式带认证类型的选择器。

## 为什么需要

当当前主模型使用 OpenAI-compatible auth 时，历史遗留的裸 `fastModel: "coder-model"` 可能解析到 Qwen OAuth 的硬编码模型，从而让后台 fast-model 请求意外触发 Qwen OAuth 浏览器登录流程。

## Reviewer Test Plan

### 如何验证

配置 OpenAI-compatible auth，主模型使用类似 `qwen3.7-max`，并设置裸 `fastModel: "coder-model"`。确认 OpenAI auth 激活后 `config.getFastModel()` 返回 `undefined`，不会路由到 Qwen OAuth。同时确认当前 auth 下的裸模型和显式 `qwen-oauth:coder-model` 仍然可以解析。

### 前后证据

Review follow-up 后的目标测试：

```console
$ cd packages/core && npx vitest run src/config/config.test.ts
✓ src/config/config.test.ts (232 tests) 461ms
Test Files  1 passed (1)
Tests  232 passed (232)
```

基于已构建 core 产物的 tmux runtime harness：

```console
Qwen Code PR #5553 tmux runtime verification
Scenario: auth=openai, current provider models=[qwen3.7-max], qwen-oauth auto-registers coder-model
BEFORE old getFastModel equivalent:
  fastModel=coder-model => "coder-model"
  generic route => {"authType":"qwen-oauth","modelId":"coder-model"}
AFTER current Config.getFastModel():
  fastModel=coder-model => undefined
NON-REGRESSION current-auth bare model:
  fastModel=qwen3.7-max => "qwen3.7-max"
NON-REGRESSION explicit cross-auth selector:
  fastModel=qwen-oauth:coder-model => "qwen-oauth:coder-model"
```

Before：裸 `fastModel: "coder-model"` 在当前 OpenAI provider 不拥有该模型时，可能跨到 Qwen OAuth。

After：auth 激活后，裸 fast model 只在当前 auth type 内解析；当前 auth 下的裸模型和显式带 auth type 的选择器仍会在用户有意配置时保留解析。

### 测试环境

macOS 本地 worktree。已运行 `packages/core` 下的 `npx vitest run src/config/config.test.ts`。初始改动也已运行仓库根目录的 `npm run build && npm run typecheck`；follow-up commit 只把回归测试改成先激活 auth 再断言。

</details>