### PR TITLE
fix(cli): fail non-interactive runs on loop detection

### DIFF
--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -21,6 +21,7 @@ import {
   FatalInputError,
   ApprovalMode,
   SendMessageType,
+  LoopType,
 } from '@qwen-code/qwen-code-core';
 import type { Part } from '@google/genai';
 import { runNonInteractive } from './nonInteractiveCli.js';
@@ -368,6 +369,83 @@ describe('runNonInteractive', () => {
     await runNonInteractive(mockConfig, mockSettings, 'test', 'p1');
 
     expect(stdoutDestroySpy).toHaveBeenCalled();
+  });
+
+  it('returns non-zero and skips pending tool calls after loop detection', async () => {
+    setupMetricsMock();
+    const toolCallEvent: ServerGeminiStreamEvent = {
+      type: GeminiEventType.ToolCallRequest,
+      value: {
+        callId: 'tool-1',
+        name: 'testTool',
+        args: { arg1: 'value1' },
+        isClientInitiated: false,
+        prompt_id: 'prompt-id-loop-detected',
+      },
+    };
+    const events: ServerGeminiStreamEvent[] = [
+      toolCallEvent,
+      {
+        type: GeminiEventType.LoopDetected,
+        value: { loopType: LoopType.TURN_TOOL_CALL_CAP },
+      },
+    ];
+    mockGeminiClient.sendMessageStream.mockReturnValue(
+      createStreamFromEvents(events),
+    );
+
+    const exitCode = await runNonInteractive(
+      mockConfig,
+      mockSettings,
+      'Use a tool',
+      'prompt-id-loop-detected',
+    );
+
+    expect(exitCode).toBe(1);
+    expect(mockCoreExecuteToolCall).not.toHaveBeenCalled();
+    expect(processStdoutSpy).not.toHaveBeenCalled();
+    expect(processStderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Loop detection halted the run'),
+    );
+  });
+
+  it('marks JSON output as an error when loop detection halts the run', async () => {
+    (mockConfig.getOutputFormat as Mock).mockReturnValue(OutputFormat.JSON);
+    setupMetricsMock();
+    const events: ServerGeminiStreamEvent[] = [
+      { type: GeminiEventType.Content, value: 'Partial work' },
+      {
+        type: GeminiEventType.LoopDetected,
+        value: { loopType: LoopType.TURN_TOOL_CALL_CAP },
+      },
+    ];
+    mockGeminiClient.sendMessageStream.mockReturnValue(
+      createStreamFromEvents(events),
+    );
+
+    const exitCode = await runNonInteractive(
+      mockConfig,
+      mockSettings,
+      'Test input',
+      'prompt-id-loop-json',
+    );
+
+    expect(exitCode).toBe(1);
+    const outputCalls = processStdoutSpy.mock.calls.filter(
+      (call) => typeof call[0] === 'string',
+    );
+    const lastOutput = outputCalls.at(-1)?.[0];
+    expect(typeof lastOutput).toBe('string');
+    const parsed = JSON.parse(lastOutput as string) as Array<{
+      type?: string;
+      is_error?: boolean;
+      error?: { message?: string };
+    }>;
+    const resultMessage = parsed.find((msg) => msg.type === 'result');
+    expect(resultMessage?.is_error).toBe(true);
+    expect(resultMessage?.error?.message).toContain(
+      'Loop detection halted the run',
+    );
   });
 
   it('should handle a single tool call and respond', async () => {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -118,15 +118,7 @@ const LOOP_TYPE_LABELS: Record<LoopType, string> = {
     'the model exceeded the maximum number of tool calls allowed in a single turn',
 };
 
-function emitLoopDetectedMessage(
-  config: Config,
-  loopType: LoopType | undefined,
-): void {
-  // In TEXT mode the adapter swallows LoopDetected, so we print here. In
-  // JSON modes the adapter emits a structured result, which is enough.
-  if (config.getOutputFormat() !== OutputFormat.TEXT) {
-    return;
-  }
+function formatLoopDetectedMessage(loopType: LoopType | undefined): string {
   const reason = loopType ? LOOP_TYPE_LABELS[loopType] : undefined;
   const detail = reason ? ` (${loopType}: ${reason})` : '';
   // The turn cap runs before the skipLoopDetection gate, so that setting can't
@@ -135,7 +127,21 @@ function emitLoopDetectedMessage(
     loopType === LoopType.TURN_TOOL_CALL_CAP
       ? ' This is an always-on per-turn tool-call cap and cannot be disabled via `model.skipLoopDetection`.'
       : ' Set the `model.skipLoopDetection` setting to true to disable.';
-  process.stderr.write(`Loop detection halted the run${detail}.${hint}\n`);
+  return `Loop detection halted the run${detail}.${hint}`;
+}
+
+function emitLoopDetectedMessage(
+  config: Config,
+  loopType: LoopType | undefined,
+): string {
+  const message = formatLoopDetectedMessage(loopType);
+  // In TEXT mode the adapter swallows LoopDetected, so we print here. In
+  // JSON modes the adapter emits a structured result, which is enough.
+  if (config.getOutputFormat() !== OutputFormat.TEXT) {
+    return message;
+  }
+  process.stderr.write(`${message}\n`);
+  return message;
 }
 
 /**
@@ -689,6 +695,8 @@ export async function runNonInteractive(
       // actually said instead of a static, context-free message.
       let plainTextPreview = '';
       const PLAIN_TEXT_PREVIEW_LIMIT = 200;
+      let loopDetected = false;
+      let loopDetectedMessage = formatLoopDetectedMessage(undefined);
 
       // Shared terminal block for the structured-output success
       // contract. Both the main-turn loop and the drain-turn post-loop
@@ -734,6 +742,33 @@ export async function runNonInteractive(
           structuredResult: structuredSubmission,
         });
         return 0;
+      };
+
+      const emitLoopDetectedResult = (): 1 => {
+        registry.abortAll();
+        flushQueuedNotificationsToSdk(localQueue);
+        finalizeOneShotMonitors();
+
+        if (outputFormat === OutputFormat.TEXT) {
+          return 1;
+        }
+
+        const metrics = uiTelemetryService.getMetrics();
+        const usage = computeUsageFromMetrics(metrics);
+        const stats =
+          outputFormat === OutputFormat.JSON
+            ? uiTelemetryService.getMetrics()
+            : undefined;
+        adapter.emitResult({
+          isError: true,
+          durationMs: Date.now() - startTime,
+          apiDurationMs: totalApiDurationMs,
+          numTurns: turnCount,
+          errorMessage: loopDetectedMessage,
+          usage,
+          stats,
+        });
+        return 1;
       };
 
       /**
@@ -1092,7 +1127,13 @@ export async function runNonInteractive(
             plainTextPreview += String(event.value).slice(0, remaining);
           }
           if (event.type === GeminiEventType.LoopDetected) {
-            emitLoopDetectedMessage(config, event.value?.loopType);
+            if (!loopDetected) {
+              loopDetectedMessage = emitLoopDetectedMessage(
+                config,
+                event.value?.loopType,
+              );
+            }
+            loopDetected = true;
           }
           if (
             outputFormat === OutputFormat.TEXT &&
@@ -1114,6 +1155,10 @@ export async function runNonInteractive(
         // Finalize assistant message
         adapter.finalizeAssistantMessage();
         totalApiDurationMs += Date.now() - apiStartTime;
+
+        if (loopDetected) {
+          return emitLoopDetectedResult();
+        }
 
         if (toolCallRequests.length > 0) {
           // Dispatch the per-turn tool-call batch through the shared
@@ -1315,7 +1360,13 @@ export async function runNonInteractive(
                   itemToolCallRequests.push(event.value);
                 }
                 if (event.type === GeminiEventType.LoopDetected) {
-                  emitLoopDetectedMessage(config, event.value?.loopType);
+                  if (!loopDetected) {
+                    loopDetectedMessage = emitLoopDetectedMessage(
+                      config,
+                      event.value?.loopType,
+                    );
+                  }
+                  loopDetected = true;
                 }
                 if (
                   outputFormat === OutputFormat.TEXT &&
@@ -1335,6 +1386,10 @@ export async function runNonInteractive(
 
               adapter.finalizeAssistantMessage();
               totalApiDurationMs += Date.now() - itemApiStartTime;
+
+              if (loopDetected) {
+                return;
+              }
 
               if (itemToolCallRequests.length > 0) {
                 // Same shared dispatch as the main-turn loop. The only
@@ -1374,6 +1429,7 @@ export async function runNonInteractive(
             if (drainPromise) return drainPromise;
             const p = (async () => {
               while (localQueue.length > 0) {
+                if (loopDetected) return;
                 // Stop draining once a queued item's structured_output
                 // call captured the terminal contract — no point running
                 // more queued prompts that can't influence the result.
@@ -1428,6 +1484,12 @@ export async function runNonInteractive(
               });
 
               const checkCronDone = () => {
+                if (loopDetected) {
+                  abortController.signal.removeEventListener('abort', onAbort);
+                  scheduler.stop();
+                  resolve();
+                  return;
+                }
                 // A drain-turn structured_output makes the rest of the
                 // cron schedule moot: we already have a terminal result
                 // and the post-drain emit is about to fire. Stop the
@@ -1489,6 +1551,7 @@ export async function runNonInteractive(
             // through the model, but later monitor output is SDK-only.
             captureMonitorTurnsInLocalQueue = false;
             await drainLocalQueue();
+            if (loopDetected) return emitLoopDetectedResult();
             // A drain-turn structured_output captured the terminal
             // contract — bail out of the holdback loop early and let the
             // post-loop code emit the success result.


### PR DESCRIPTION
## What this PR does

This makes non-interactive CLI runs treat loop detection as a failure instead of a successful completion. When the model emits a loop-detected event, pending tool calls are skipped, text output still shows the loop message, and JSON output is marked as an error.

## Why it's needed

In CI/non-interactive mode, loop detection means the run could not complete the requested task. Exiting with status 0 and publishing a successful JSON result can make automation report false success.

## Reviewer Test Plan

### How to verify

Run the focused CLI regression test and confirm loop detection exits with code 1 and does not execute queued tool calls.

### Evidence (Before & After)

Before: a loop-detected non-interactive run could exit 0 and JSON output could report `isError: false`.

After: the new regression covers loop detection returning exit code 1, skipping pending tool calls, and setting `isError: true` / `is_error: true` in JSON output.

Commands run locally:

```bash
npm ci --ignore-scripts
npm run generate
cd packages/cli && npx vitest run src/nonInteractiveCli.test.ts
cd packages/cli && npx eslint src/nonInteractiveCli.ts src/nonInteractiveCli.test.ts
npm run lint --workspace=packages/cli
npx prettier --check packages/cli/src/nonInteractiveCli.ts packages/cli/src/nonInteractiveCli.test.ts
git diff --check HEAD~1..HEAD
```

`npm run typecheck --workspace=packages/cli` and `npm run build` currently fail in this checkout on existing Ink import/type errors in `packages/cli/src/ui/components/shared/BaseTextInput.tsx` (`ink/dom`, `ink/components/CursorContext`, and `cursorCtx` unknown); this PR does not touch that surface.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️ not tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ✅ tested   |

### Environment (optional)

Linux cron container, Node/npm from the repository environment.

## Risk & Scope

- Main risk or tradeoff: non-interactive loop detection now fails fast before queued tool calls, matching the error semantics expected by automation.
- Not validated / out of scope: unrelated CLI typecheck/build failures in `BaseTextInput.tsx` were not changed here.
- Breaking changes / migration notes: none expected beyond correcting the exit status for a failed loop-detected run.

## Linked Issues

Fixes #5554

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

此 PR 让非交互式 CLI 在检测到循环时按失败处理，而不是成功完成。模型发出循环检测事件后，会跳过待执行的工具调用，文本输出仍显示循环提示，并且 JSON 输出会标记为错误。

## 为什么需要

在 CI/非交互模式下，循环检测表示本次任务没有完成。如果仍以状态码 0 退出并发布成功的 JSON 结果，自动化流程会误报成功。

## Reviewer Test Plan

### 如何验证

运行聚焦的 CLI 回归测试，确认循环检测会返回退出码 1，并且不会执行排队中的工具调用。

### 证据（修改前后）

修改前：检测到循环的非交互式运行可能以 0 退出，并且 JSON 输出可能报告 `isError: false`。

修改后：新增回归测试覆盖循环检测返回退出码 1、跳过待执行工具调用，并在 JSON 输出中设置 `isError: true` / `is_error: true`。

本地运行命令：见英文部分命令列表。

`npm run typecheck --workspace=packages/cli` 和 `npm run build` 当前在此检出中因为 `packages/cli/src/ui/components/shared/BaseTextInput.tsx` 里既有的 Ink 导入/类型错误失败（`ink/dom`、`ink/components/CursorContext`、以及 `cursorCtx` 为 unknown）；此 PR 不修改该范围。

### 测试平台

Linux 已测试；macOS 和 Windows 未本地测试。

### 环境（可选）

Linux cron 容器，使用仓库环境中的 Node/npm。

## 风险与范围

- 主要风险或取舍：非交互式循环检测现在会在执行排队工具调用前失败退出，符合自动化场景对错误语义的预期。
- 未验证 / 不在范围内：未修改与本 PR 无关的 `BaseTextInput.tsx` 类型检查/构建失败。
- 破坏性变更 / 迁移说明：除修正循环检测失败时的退出状态外，预计没有破坏性变更。

## 关联 Issue

Fixes #5554

</details>
