### PR TITLE
fix(cli): render full resume preview history

### DIFF
--- a/packages/cli/src/ui/components/SessionPreview.test.tsx
+++ b/packages/cli/src/ui/components/SessionPreview.test.tsx
@@ -35,7 +35,11 @@ function mockService(resolved: unknown) {
   } as never;
 }
 
-function fakeResumedData() {
+function fakeResumedData(
+  assistantParts: Array<{ text: string; thought?: boolean }> = [
+    { text: 'Hi from assistant REPLY-MARKER' },
+  ],
+) {
   return {
     conversation: {
       sessionId: 's1',
@@ -66,7 +70,7 @@ function fakeResumedData() {
           version: 'test',
           message: {
             role: 'model',
-            parts: [{ text: 'Hi from assistant REPLY-MARKER' }],
+            parts: assistantParts,
           },
         },
       ],
@@ -110,6 +114,39 @@ describe('SessionPreview', () => {
     const frame = lastFrame() ?? '';
     expect(frame).toContain('PREVIEW-MARKER');
     expect(frame).toContain('REPLY-MARKER');
+  });
+
+  it('renders full resumed thinking content after load', async () => {
+    const thinkingText = Array.from(
+      { length: 40 },
+      (_, index) => `RESUMED-THINKING-LINE-${index + 1}`,
+    ).join('\n');
+    const svc = mockService(
+      fakeResumedData([
+        { text: thinkingText, thought: true },
+        { text: 'FINAL-ANSWER-MARKER' },
+      ]),
+    );
+    const { lastFrame } = render(
+      <KeypressProvider kittyProtocolEnabled={false}>
+        <SessionPreview
+          sessionService={svc}
+          sessionId="s1"
+          sessionTitle="My session"
+          onExit={vi.fn()}
+          onResume={vi.fn()}
+        />
+      </KeypressProvider>,
+    );
+    await wait(100);
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Thinking…');
+    expect(frame).toContain('RESUMED-THINKING-LINE-1');
+    expect(frame).toContain('RESUMED-THINKING-LINE-40');
+    expect(frame).toContain('FINAL-ANSWER-MARKER');
+    expect(frame.indexOf('My session')).toBeLessThan(
+      frame.indexOf('RESUMED-THINKING-LINE-1'),
+    );
   });
 
   it('renders footer metadata (messageCount · time · branch)', async () => {

--- a/packages/cli/src/ui/components/SessionPreview.tsx
+++ b/packages/cli/src/ui/components/SessionPreview.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Box, Text } from 'ink';
+import { Box, Static, Text } from 'ink';
 import { useEffect, useMemo, useState } from 'react';
 import type {
   ResumedSessionData,
@@ -126,56 +126,86 @@ export function SessionPreview(props: SessionPreviewProps) {
   }
   const metaLine = metaParts.join(' · ');
 
+  const header = (
+    <Box key="header" paddingX={1}>
+      <Text bold color={theme.text.primary}>
+        {sessionTitle ?? t('Session Preview')}
+      </Text>
+    </Box>
+  );
+  const topSeparator = (
+    <Box key="top-separator">
+      <Text color={theme.border.default}>{'─'.repeat(separatorWidth)}</Text>
+    </Box>
+  );
+  const footerSeparator = (
+    <Box key="footer-separator">
+      <Text color={theme.border.default}>{'─'.repeat(separatorWidth)}</Text>
+    </Box>
+  );
+  const meta = metaLine ? (
+    <Box key="meta" paddingX={1}>
+      <Text color={theme.text.secondary}>{metaLine}</Text>
+    </Box>
+  ) : null;
+  const footer = (
+    <Box key="footer" paddingX={1}>
+      <Text color={theme.text.secondary}>
+        {t('Enter to resume · Esc to back')}
+      </Text>
+    </Box>
+  );
+
+  if (data && !error) {
+    return (
+      <Box flexDirection="column" width={boxWidth}>
+        <Static
+          key={sessionId}
+          items={[
+            header,
+            topSeparator,
+            ...items.map((item) => (
+              <HistoryItemDisplay
+                key={item.id}
+                item={item}
+                terminalWidth={boxWidth}
+                isPending={false}
+              />
+            )),
+            footerSeparator,
+            ...(meta ? [meta] : []),
+            footer,
+          ]}
+        >
+          {(item) => item}
+        </Static>
+      </Box>
+    );
+  }
+
   return (
     <Box flexDirection="column" width={boxWidth}>
       {/* Header */}
-      <Box paddingX={1}>
-        <Text bold color={theme.text.primary}>
-          {sessionTitle ?? t('Session Preview')}
-        </Text>
-      </Box>
-      <Box>
-        <Text color={theme.border.default}>{'─'.repeat(separatorWidth)}</Text>
-      </Box>
+      {header}
+      {topSeparator}
 
-      {/* Body: render all items, let the terminal's scrollback own overflow. */}
+      {/* Body */}
       {error ? (
         <Box paddingY={1} justifyContent="center">
           <Text color={theme.status.error}>{error}</Text>
         </Box>
-      ) : !data ? (
+      ) : (
         <Box paddingY={1} justifyContent="center">
           <Text color={theme.text.secondary}>
             {t('Loading session preview...')}
           </Text>
         </Box>
-      ) : (
-        <Box flexDirection="column">
-          {items.map((item) => (
-            <HistoryItemDisplay
-              key={item.id}
-              item={item}
-              terminalWidth={boxWidth}
-              isPending={false}
-            />
-          ))}
-        </Box>
       )}
 
       {/* Footer */}
-      <Box>
-        <Text color={theme.border.default}>{'─'.repeat(separatorWidth)}</Text>
-      </Box>
-      {metaLine && (
-        <Box paddingX={1}>
-          <Text color={theme.text.secondary}>{metaLine}</Text>
-        </Box>
-      )}
-      <Box paddingX={1}>
-        <Text color={theme.text.secondary}>
-          {t('Enter to resume · Esc to back')}
-        </Text>
-      </Box>
+      {footerSeparator}
+      {meta}
+      {footer}
     </Box>
   );
 }


### PR DESCRIPTION
## What this PR does

This updates the resume-session preview so loaded conversation history is rendered through Ink static output. Long resumed thinking blocks can then remain visible in terminal scrollback instead of being clipped out of the Space preview frame.

## Why it's needed

Issue #5555 reports that `qwen --resume` shows incomplete thinking content when pressing Space to preview a session. The resume data already contains the thinking text; the preview renderer was the limiting surface.

## Reviewer Test Plan

### How to verify

Open `qwen --resume`, select a session containing a long thinking block, press Space, and confirm the preview includes the full thinking block followed by the final response.

### Evidence (Before & After)

Before: long resumed thinking content could be truncated in the preview.

After: the added regression renders a 40-line thinking block and verifies the first line, last line, and final answer marker are all present in the preview output.

Commands run locally:

```bash
cd packages/cli && npx vitest run src/ui/components/SessionPreview.test.tsx
cd packages/cli && npx eslint src/ui/components/SessionPreview.tsx src/ui/components/SessionPreview.test.tsx
npx prettier --check packages/cli/src/ui/components/SessionPreview.tsx packages/cli/src/ui/components/SessionPreview.test.tsx
git diff --check
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️ not tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ✅ tested   |

### Environment (optional)

Linux cron container; focused component tests only.

## Risk & Scope

- Main risk or tradeoff: loaded preview history is now emitted as static Ink output once session data is loaded, matching the existing intent to let terminal scrollback own overflow.
- Not validated / out of scope: real terminal screenshot/video was not captured in this cron environment.
- Breaking changes / migration notes: none expected.

## Linked Issues

Fixes #5555

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

此 PR 更新了恢复会话预览的渲染方式，让已加载的会话历史通过 Ink static output 输出。这样较长的 resumed thinking block 可以保留在终端滚动历史中，而不是在按 Space 预览时被预览帧截断。

## 为什么需要

Issue #5555 报告 `qwen --resume` 中按 Space 预览会话时 thinking 内容显示不完整。恢复数据本身已经包含 thinking 文本；限制在预览渲染层。

## Reviewer Test Plan

### 如何验证

运行 `qwen --resume`，选择包含较长 thinking block 的会话，按 Space，确认预览中包含完整 thinking block，并且后续最终回复仍可见。

### 证据（修改前后）

修改前：较长的 resumed thinking 内容可能在预览中被截断。

修改后：新增回归测试渲染 40 行 thinking block，并验证第一行、最后一行和最终回复标记都存在于预览输出中。

本地运行命令：见英文部分命令列表。

### 测试平台

Linux 已测试；macOS 和 Windows 未本地测试。

### 环境（可选）

Linux cron 容器；仅运行了聚焦组件测试。

## 风险与范围

- 主要风险或取舍：会话数据加载完成后，预览历史现在通过 Ink static output 输出，符合现有“让终端滚动历史处理溢出”的意图。
- 未验证 / 不在范围内：此 cron 环境未捕获真实终端截图或视频。
- 破坏性变更 / 迁移说明：预计没有。

## 关联 Issue

Fixes #5555

</details>
