### PR TITLE
fix(ui): use Static in SessionPreview to fix thinking block truncation on resume

### DIFF
--- a/packages/cli/src/ui/components/SessionPreview.tsx
+++ b/packages/cli/src/ui/components/SessionPreview.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Box, Text } from 'ink';
+import { Box, Static, Text } from 'ink';
 import { useEffect, useMemo, useState } from 'react';
 import type {
   ResumedSessionData,
@@ -150,16 +150,16 @@ export function SessionPreview(props: SessionPreviewProps) {
           </Text>
         </Box>
       ) : (
-        <Box flexDirection="column">
-          {items.map((item) => (
+        <Static items={items}>
+          {(item) => (
             <HistoryItemDisplay
               key={item.id}
               item={item}
               terminalWidth={boxWidth}
               isPending={false}
             />
-          ))}
-        </Box>
+          )}
+        </Static>
       )}
 
       {/* Footer */}


### PR DESCRIPTION
## What this PR does

Replaces `<Box flexDirection="column">` with `<Static>` in `SessionPreview.tsx` for rendering history items, and adapts the render function signature to match `<Static>`'s API.

## Why it's needed

Ink holds `<Box>` content in its in-memory diff buffer, which terminals clip at viewport height. Long thinking blocks in session preview get truncated. `<Static>` writes directly to the terminal's permanent scrollback buffer, making overflow scrollable. `MainContent.tsx` already uses `<Static>` for this purpose — `SessionPreview` was missing it.

## Reviewer Test Plan

### How to verify

1. Run a session that produces a long thinking block.
2. Exit and run `qwen --resume`.
3. Press Space to open the session preview.
4. Scroll up — the full thinking block should be accessible.

### Evidence (Before & After)

Before: thinking block truncates mid-content in session preview, no way to scroll to the rest.

After: full thinking block is accessible via terminal scrollback.

## Tested on

| OS | Status |
|---|---|
| 🍏 macOS | Not validated |
| 🪟 Windows | Tested and passing |
| 🐧 Linux | Not validated |

## Risk & Scope

Main risk or tradeoff: `<Static>` renders each item once and never re-renders. Fine here because preview content is loaded once and immutable.

Not validated / out of scope: macOS and Linux behavior.

Breaking changes / migration notes: None.

## Linked Issues

Fixes #5555

## 中文说明

将 `SessionPreview.tsx` 中渲染历史消息的 `<Box>` 替换为 `<Static>`。Ink 将 `<Box>` 内容保存在内存 diff buffer 中，终端在 viewport 高度处截断溢出内容，导致 thinking block 显示不完整。`<Static>` 将内容写入终端永久 scrollback buffer，溢出内容可滚动查看。`MainContent.tsx` 已使用此方案，`SessionPreview` 漏了。改动两行，数据链路不变。