### PR TITLE
fix(cli): fill content area background on wrapped input lines

### DIFF
--- a/packages/cli/src/ui/components/BaseTextInput.tsx
+++ b/packages/cli/src/ui/components/BaseTextInput.tsx
@@ -370,7 +370,7 @@ export const BaseTextInput = ({
         borderColor={resolvedBorderColor}
       >
         {resolvedPrefix}
-        <Box flexGrow={1} flexDirection="column">
+        <Box flexGrow={1} flexDirection="column" backgroundColor={theme.background.primary}>
           {buffer.text.length === 0 && placeholder ? (
             showCursor ? (
               <Text>


### PR DESCRIPTION
## What this PR does

Adds `backgroundColor={theme.background.primary}` to the input content container (`<Box flexGrow={1} flexDirection="column">`) in `BaseTextInput.tsx`, so the whole input area paints one continuous background — including the trailing empty cells that appear on wrapped or multi-line input.

## Why it's needed

Ink only paints the terminal cells that actually contain text. The content container `<Box>` had no `backgroundColor`, so the trailing empty cells on any wrapped/multi-line input fell through to the terminal's default background, leaving a visible gap in the input box. Setting a `backgroundColor` makes Ink flood-fill the box's entire computed layout area before drawing children, covering all empty cells regardless of wrap mode. Reported in #5562.

## Reviewer Test Plan

### How to verify

1. Launch the interactive TUI (`npm run dev`, or a built `qwen`).
2. In the bottom input box, type a single line long enough to soft-wrap, or paste multi-line text.
3. Observe the background of the input content area across every visual line.

Expected (after this PR): the background color fills the entire input area continuously, with no gaps on wrapped/extra lines. Before: trailing empty cells on wrapped lines show the terminal's default background, breaking the box visually.

### Evidence (Before & After)

**Before** — from #5562 (red arrows mark the discontinuity):

![before](https://github.com/user-attachments/assets/5789fa33-2c3d-4705-942a-7a63e0e55ea1)

**After** — author capture pending; expected result is the gap-free, continuously-filled input background described above. (Reformatted to the template by a maintainer — I did not run the TUI locally, so I'm not attaching a fabricated "after".)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A — maintainer reformat: original author @lcheng321 to confirm the platforms tested. For reference, the macOS CI `Test`, `Lint`, and `CodeQL` jobs are green for build + unit tests. -->

### Environment (optional)

N/A — a single rendering-prop change with no runtime/sandbox specifics.

## Risk & Scope

- Main risk or tradeoff: purely visual. The new `backgroundColor` reuses the existing `theme.background.primary` token (already used across components like `PermissionsDialog`, `StatsDialog`, `PrepareLabel`), so it tracks the active theme rather than hard-coding a color.
- Not validated / out of scope: local before/after visual capture across all three platforms (the Ink rendering path is platform-agnostic).
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5562

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 `BaseTextInput.tsx` 的输入内容容器（`<Box flexGrow={1} flexDirection="column">`）上增加 `backgroundColor={theme.background.primary}`，使整个输入区域绘制为连续的背景色 —— 包括换行或多行输入时出现的行尾空白单元格。

## 为什么需要它

Ink 只会绘制真正包含文字的终端单元格。内容容器 `<Box>` 此前没有设置 `backgroundColor`，因此换行/多行输入的行尾空白单元格会"漏"到终端默认背景，导致输入框出现可见的断裂。设置 `backgroundColor` 后，Ink 会在绘制子元素之前用该背景色铺满整个盒子的布局区域，无论是否换行都能覆盖所有空白单元格。问题见 #5562。

## Reviewer 验证步骤

### 如何验证

1. 启动交互式 TUI（`npm run dev`，或已构建的 `qwen`）。
2. 在底部输入框输入一段足够长、会自动软换行的单行文本，或粘贴多行内容。
3. 观察输入内容区域在每一行上的背景色。

期望（本 PR 之后）：背景色连续铺满整个输入区域，换行/多出来的行上没有空洞。修复前：换行行的行尾空白单元格显示为终端默认背景，视觉上割裂。

### 证据（前 & 后）

**修复前** —— 来自 #5562（红色箭头标出断裂处）：

![before](https://github.com/user-attachments/assets/5789fa33-2c3d-4705-942a-7a63e0e55ea1)

**修复后** —— 作者截图待补；预期是上文所述连续、无空洞的输入框背景。（描述由维护者按模板重排 —— 我没有在本地实跑 TUI，因此不附伪造的"修复后"截图。）

### 测试平台

|    系统    | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ⚠️  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

<!-- ✅ 已测 · ⚠️ 未测 · N/A —— 维护者重排：由原作者 @lcheng321 确认实测平台。供参考：macOS 的 CI `Test`、`Lint`、`CodeQL` 任务在 构建 + 单测 上均为绿色。 -->

### 运行环境（可选）

N/A —— 仅一处渲染属性改动，无运行时/沙箱相关。

## 风险与范围

- 主要风险或权衡：纯视觉改动。新增的 `backgroundColor` 复用既有的 `theme.background.primary` 主题令牌（`PermissionsDialog`、`StatsDialog`、`PrepareLabel` 等组件均已使用），因此跟随当前主题而非硬编码颜色。
- 未验证 / 范围之外：三个平台的本地前后视觉截图（Ink 渲染路径与平台无关）。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #5562

</details>
