### PR TITLE
fix(core): respect zero OpenAI log file limit

### DIFF
--- a/packages/core/src/utils/openaiLogger.test.ts
+++ b/packages/core/src/utils/openaiLogger.test.ts
@@ -458,6 +458,16 @@ describe('OpenAILogger', () => {
       expect(limitedFiles.length).toBe(3);
     });
 
+    it('should respect a zero limit', async () => {
+      const logger = new OpenAILogger(testTempDir);
+      await logger.initialize();
+
+      await logger.logInteraction({ test: 'request' }, { test: 'response' });
+
+      const files = await logger.getLogFiles(0);
+      expect(files).toEqual([]);
+    });
+
     it('should return files sorted by most recent first', async () => {
       const logger = new OpenAILogger(testTempDir);
       await logger.initialize();

--- a/packages/core/src/utils/openaiLogger.ts
+++ b/packages/core/src/utils/openaiLogger.ts
@@ -217,7 +217,7 @@ export class OpenAILogger {
         .sort()
         .reverse();
 
-      return limit ? logFiles.slice(0, limit) : logFiles;
+      return limit === undefined ? logFiles : logFiles.slice(0, limit);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
         return [];


### PR DESCRIPTION
## What this PR does

Fixes `OpenAILogger.getLogFiles(0)` so a zero limit returns no log files instead of being treated as an unlimited request.

The previous implementation used a truthy check:

```ts
return limit ? logFiles.slice(0, limit) : logFiles;
```

Because `0` is falsy, `getLogFiles(0)` returned the full `logFiles` array. This PR changes the branch to check `limit === undefined`, preserving the existing unlimited behavior when no limit is provided while allowing `0` to behave like a real limit.

## Why it's needed

`getLogFiles(limit)` takes an optional number of log files to return. Positive limits already work, but the boundary value `0` was ignored. This can surprise callers that pass a computed limit and expect zero results when the computed limit is zero.

## Reviewer Test Plan

### How to verify

From the repo root, run:

```bash
npm exec --workspace=packages/core vitest run src/utils/openaiLogger.test.ts
git diff --check
```

### Evidence (Before & After)

Before the implementation change, the new regression test failed:

```text
OpenAILogger > getLogFiles > should respect a zero limit
expected [ Array(1) ] to deeply equal []
```

After the fix:

```text
✓ src/utils/openaiLogger.test.ts (38 tests)
Test Files  1 passed (1)
Tests  38 passed (38)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS  | tested |
| Windows | not tested |
|  Linux  | not tested |

## Risk & Scope

- Main risk or tradeoff: low. The change only affects the boundary case where `limit` is explicitly `0`.
- Existing behavior preserved: `undefined` still returns all log files, and positive limits still slice the log list.
- Not validated / out of scope: full `npm run preflight` was not run locally. Focused unit tests and `git diff --check` were run.
- Breaking changes / migration notes: none expected.

## Linked Issues

Fixes #5567

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复 `OpenAILogger.getLogFiles(0)` 的边界行为。之前代码使用 truthy 判断：

```ts
return limit ? logFiles.slice(0, limit) : logFiles;
```

因为 `0` 是 falsy，传入 `0` 时会走“无限制”分支，返回全部日志文件。现在改为判断 `limit === undefined`，只有未传 limit 时才返回全部文件；传入 `0` 时会返回空数组。

## 为什么需要

`limit` 表示最多返回多少个日志文件。正数 limit 已经能正常工作，但 `0` 这个边界值之前被忽略。对于使用计算结果作为 limit 的调用方来说，`0` 应该表示返回 0 个文件，而不是返回全部文件。

## Reviewer Test Plan

### 如何验证

从仓库根目录运行：

```bash
npm exec --workspace=packages/core vitest run src/utils/openaiLogger.test.ts
git diff --check
```

### 证据（Before & After）

修复前，新增回归测试失败，`getLogFiles(0)` 会返回已有日志文件。

修复后：

```text
✓ src/utils/openaiLogger.test.ts (38 tests)
Test Files  1 passed (1)
Tests  38 passed (38)
```

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  macOS  | 已测试 |
| Windows | 未测试 |
|  Linux  | 未测试 |

## 风险与范围

- 主要风险：低。只影响显式传入 `limit = 0` 的边界情况。
- 保留行为：未传 `limit` 仍然返回全部日志文件，正数 limit 行为不变。
- 未验证 / 范围外：本地没有运行完整 `npm run preflight`；已运行 focused unit test 和 `git diff --check`。
- 破坏性变更 / 迁移说明：预计无。

## 关联 Issue

Fixes #5567

</details>