### PR TITLE
fix(core): enable loop detection by default and lower duplicate threshold

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1953,7 +1953,7 @@ export async function loadCliConfig(
     preventSystemSleep: settings.general?.preventSystemSleep ?? true,
     skipNextSpeakerCheck: settings.model?.skipNextSpeakerCheck,
     skipWorkflowUsageWarning: settings.model?.skipWorkflowUsageWarning ?? false,
-    skipLoopDetection: settings.model?.skipLoopDetection ?? true,
+    skipLoopDetection: settings.model?.skipLoopDetection ?? false,
     skipStartupContext: settings.model?.skipStartupContext ?? false,
     truncateToolOutputThreshold: settings.tools?.truncateToolOutputThreshold,
     truncateToolOutputLines: settings.tools?.truncateToolOutputLines,

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -47,7 +47,7 @@ const STAGNATION_THRESHOLD = 8;
 // Global tool call duplicate tracking: how many times the same (tool, args)
 // pair must appear across the entire turn (not necessarily consecutively)
 // before it is treated as a loop.
-const GLOBAL_DUPLICATE_THRESHOLD = 6;
+const GLOBAL_DUPLICATE_THRESHOLD = 4;
 
 // Alternating pattern detection: number of complete AB cycles needed to
 // trip the detector (3 cycles = 6 calls: A B A B A B).


### PR DESCRIPTION
Fixes #5019

## Root Cause

`skipLoopDetection` defaults to `true` in `loadCliConfig`, so `LoopDetectionService` never runs for users who haven't explicitly opted in. Only the always-on hard cap (`TURN_TOOL_CALL_CAP = 100`) stays active, which is far above the server threshold. The API fires `InternalError.Algo.InvalidParameter: Repetitive tool calls detected` before the client can intervene.

## Changes

`packages/cli/src/config/config.ts` — enable loop detection by default:

```diff
- skipLoopDetection: settings.model?.skipLoopDetection ?? true,
+ skipLoopDetection: settings.model?.skipLoopDetection ?? false,
```

`packages/core/src/services/loopDetectionService.ts` — lower global duplicate threshold so client fires before server:

```diff
- const GLOBAL_DUPLICATE_THRESHOLD = 6;
+ const GLOBAL_DUPLICATE_THRESHOLD = 4;
```

Users who want the old behavior can opt out via `settings.json`:

```json
{ "model": { "skipLoopDetection": true } }
```