### PR TITLE
ci(release): Auto-publish VSCode companion after stable releases

### DIFF
--- a/.github/workflows/release-vscode-companion.yml
+++ b/.github/workflows/release-vscode-companion.yml
@@ -1,6 +1,8 @@
 name: 'Release VSCode IDE Companion'
 
 on:
+  release:
+    types: ['published']
   workflow_dispatch:
     inputs:
       version:
@@ -37,7 +39,16 @@ jobs:
   prepare:
     runs-on: 'ubuntu-latest'
     if: |-
-      ${{ github.repository == 'QwenLM/qwen-code' }}
+      ${{
+        github.repository == 'QwenLM/qwen-code' &&
+        (
+          github.event_name != 'release' ||
+          (
+            startsWith(github.event.release.tag_name, 'v') &&
+            github.event.release.prerelease == false
+          )
+        )
+      }}
     permissions:
       contents: 'read'
     outputs:
@@ -49,9 +60,9 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
         with:
-          ref: '${{ github.event.inputs.ref || github.sha }}'
+          ref: '${{ github.event.release.tag_name || github.event.inputs.ref || github.sha }}'
           fetch-depth: 0
 
       - name: 'Set booleans for simplified logic'
@@ -73,7 +84,7 @@ jobs:
           echo "is_dry_run=${is_dry_run}" >> "${GITHUB_OUTPUT}"
 
       - name: 'Setup Node.js'
-        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e'  # v6.4.0
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -112,9 +123,11 @@ jobs:
 
             RELEASE_TAG="${PREVIEW_VERSION}"
 
-            echo "RELEASE_TAG=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
-            echo "RELEASE_VERSION=${PREVIEW_VERSION}" >> "$GITHUB_OUTPUT"
-            echo "VSCODE_TAG=preview" >> "$GITHUB_OUTPUT"
+            {
+              echo "RELEASE_TAG=${RELEASE_TAG}"
+              echo "RELEASE_VERSION=${PREVIEW_VERSION}"
+              echo "VSCODE_TAG=preview"
+            } >> "$GITHUB_OUTPUT"
           else
             # Use specified version or get from package.json
             if [[ -n "${MANUAL_VERSION}" ]]; then
@@ -125,9 +138,11 @@ jobs:
               RELEASE_TAG="${BASE_VERSION}"
             fi
 
-            echo "RELEASE_TAG=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
-            echo "RELEASE_VERSION=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
-            echo "VSCODE_TAG=latest" >> "$GITHUB_OUTPUT"
+            {
+              echo "RELEASE_TAG=${RELEASE_TAG}"
+              echo "RELEASE_VERSION=${RELEASE_VERSION}"
+              echo "VSCODE_TAG=latest"
+            } >> "$GITHUB_OUTPUT"
           fi
         env:
           IS_PREVIEW: '${{ steps.vars.outputs.is_preview }}'
@@ -185,13 +200,13 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
         with:
-          ref: '${{ github.event.inputs.ref || github.sha }}'
+          ref: '${{ github.event.release.tag_name || github.event.inputs.ref || github.sha }}'
           fetch-depth: 0
 
       - name: 'Setup Node.js'
-        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e'  # v6.4.0
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -249,7 +264,7 @@ jobs:
         shell: 'bash'
 
       - name: 'Upload VSIX Artifact'
-        uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a'  # v7.0.1
+        uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' # v7.0.1
         with:
           name: "vsix-${{ matrix.target || 'universal' }}"
           path: 'qwen-code-vscode-companion-${{ needs.prepare.outputs.release_version }}-*.vsix'
@@ -270,12 +285,12 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
         with:
-          ref: '${{ github.event.inputs.ref || github.sha }}'
+          ref: '${{ github.event.release.tag_name || github.event.inputs.ref || github.sha }}'
 
       - name: 'Download all VSIX artifacts'
-        uses: 'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c'  # v8.0.1
+        uses: 'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c' # v8.0.1
         with:
           pattern: 'vsix-*'
           path: 'vsix-artifacts'
@@ -319,7 +334,7 @@ jobs:
 
       - name: 'Upload all VSIXes as release artifacts (dry run)'
         if: "${{ needs.prepare.outputs.is_dry_run == 'true' }}"
-        uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a'  # v7.0.1
+        uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' # v7.0.1
         with:
           name: 'all-vsix-packages-${{ needs.prepare.outputs.release_version }}'
           path: 'vsix-artifacts/*.vsix'

--- a/scripts/tests/install-script.test.js
+++ b/scripts/tests/install-script.test.js
@@ -1962,6 +1962,25 @@ describe('standalone release packaging', () => {
     );
   });
 
+  it('automatically publishes the VSCode companion after stable CLI releases', () => {
+    const workflow = readScript(
+      '.github/workflows/release-vscode-companion.yml',
+    );
+
+    expect(workflow).toContain("release:\n    types: ['published']");
+    expect(workflow).toContain('workflow_dispatch:');
+    expect(workflow).toContain("github.event_name != 'release'");
+    expect(workflow).toContain(
+      "startsWith(github.event.release.tag_name, 'v')",
+    );
+    expect(workflow).toContain('github.event.release.prerelease == false');
+    expect(
+      workflow.match(
+        /github\.event\.release\.tag_name \|\| github\.event\.inputs\.ref \|\| github\.sha/g,
+      ) || [],
+    ).toHaveLength(3);
+  });
+
   it('does not whitelist internal planning documents in gitignore', () => {
     const gitignore = readScript('.gitignore');
 


### PR DESCRIPTION
## What this PR does

Adds a published-release trigger to the VSCode companion publishing workflow so stable CLI GitHub Releases automatically enqueue the VSIX publish path. The manual workflow dispatch path remains available, and release-triggered runs check out the release tag before preparing, building, and publishing packages.

## Why it's needed

The CLI release process already creates the GitHub Release, but the VSCode companion publish step stayed manual and was easy to miss. Connecting stable release publication to the existing companion workflow keeps the two publish steps aligned while preserving manual recovery and dry-run workflows.

## Reviewer Test Plan

### How to verify

Confirm that a non-prerelease GitHub Release with a `v*` tag is eligible to run the VSCode companion workflow from `release.published`, while prereleases and non-`v*` tags are stopped by the prepare guard. Confirm that `workflow_dispatch` remains available for manual publishes and dry runs.

Local validation run for this PR:

- `actionlint .github/workflows/release-vscode-companion.yml`
- `npx prettier --check .github/workflows/release-vscode-companion.yml scripts/tests/install-script.test.js`
- `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/install-script.test.js`
- `npm run typecheck`
- `npm run build`

### Evidence (Before & After)

Before: publishing the CLI GitHub Release did not enqueue the VSCode companion publishing workflow, so the extension publish step still depended on a manual dispatch.

After: stable `v*` GitHub Release publication can trigger the VSCode companion publishing workflow, the job checks out the release tag, and manual dispatch remains supported.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local Node.js workspace on macOS; GitHub Actions workflow validated statically with `actionlint`.

## Risk & Scope

- Main risk or tradeoff: an incorrectly published stable `v*` GitHub Release can now enqueue the VSCode companion publish workflow automatically; the automatic path is restricted to `QwenLM/qwen-code`, non-prerelease releases, and `v*` tags.
- Not validated / out of scope: live Marketplace publishing and an actual GitHub Actions release-event run were not performed locally.
- Breaking changes / migration notes: None.

## Linked Issues

Resolves #5570

<details>
<summary>中文说明</summary>

## What this PR does

为 VSCode companion 发布 workflow 增加 GitHub Release published 触发器，使稳定版 CLI GitHub Release 发布后可以自动进入 VSIX 发布流程。手动 workflow dispatch 仍然保留，release 触发时会先 checkout 对应 release tag，再执行准备、构建和发布。

## Why it's needed

CLI release 流程已经会创建 GitHub Release，但 VSCode companion 的发布步骤仍然依赖手动触发，容易漏掉。把稳定版 release 发布事件接到现有 companion workflow 后，可以让两个发布步骤保持一致，同时保留手动恢复和 dry run 流程。

## Reviewer Test Plan

### How to verify

确认带 `v*` tag 的非 prerelease GitHub Release 可以通过 `release.published` 触发 VSCode companion workflow；同时确认 prerelease 或非 `v*` tag 会被 prepare guard 拦住。确认 `workflow_dispatch` 仍然可用于手动发布和 dry run。

本 PR 已执行的本地验证：

- `actionlint .github/workflows/release-vscode-companion.yml`
- `npx prettier --check .github/workflows/release-vscode-companion.yml scripts/tests/install-script.test.js`
- `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/install-script.test.js`
- `npm run typecheck`
- `npm run build`

### Evidence (Before & After)

Before：CLI GitHub Release 发布后不会排队执行 VSCode companion 发布 workflow，因此插件发布仍然依赖手动 dispatch。

After：稳定版 `v*` GitHub Release 发布后可以触发 VSCode companion 发布 workflow，job 会 checkout release tag，并且手动 dispatch 仍然可用。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 本地 Node.js workspace；GitHub Actions workflow 已通过 `actionlint` 做静态校验。

## Risk & Scope

- Main risk or tradeoff：如果误发布稳定版 `v*` GitHub Release，现在会自动排队执行 VSCode companion 发布 workflow；自动路径已限制在 `QwenLM/qwen-code`、非 prerelease release 和 `v*` tag。
- Not validated / out of scope：没有在本地执行真实 Marketplace 发布，也没有实际触发一次 GitHub Actions release-event run。
- Breaking changes / migration notes：无。

## Linked Issues

Resolves #5570

</details>
