### PR TITLE
docs(mcp): correct mcp add scope default

### DIFF
--- a/docs/users/features/mcp.md
+++ b/docs/users/features/mcp.md
@@ -42,8 +42,8 @@ qwen mcp
 
 Most users only need these two scopes:
 
-- **Project scope (default)**: `.qwen/settings.json` in your project root
-- **User scope**: `~/.qwen/settings.json` across all projects on your machine
+- **User scope (default)**: `~/.qwen/settings.json` across all projects on your machine
+- **Project scope**: `.qwen/settings.json` in your project root
 
 Write to user scope:
 
@@ -94,7 +94,7 @@ JSON (`.qwen/settings.json`):
 }
 ```
 
-CLI (writes to project scope by default):
+CLI (writes to user scope by default):
 
 ```bash
 qwen mcp add pythonTools -e DATABASE_URL=$DB_CONNECTION_STRING -e API_KEY=$EXTERNAL_API_KEY \
@@ -447,7 +447,7 @@ qwen mcp add [options] <name> <commandOrUrl> [args...]
 | `<name>`                    | A unique name for the server.                                       | —                                      | `example-server`                                                   |
 | `<commandOrUrl>`            | The command to execute (for `stdio`) or the URL (for `http`/`sse`). | —                                      | `/usr/bin/python` or `http://localhost:8`                          |
 | `[args...]`                 | Optional arguments for a `stdio` command.                           | —                                      | `--port 5000`                                                      |
-| `-s`, `--scope`             | Configuration scope (user or project).                              | `project`                              | `-s user`                                                          |
+| `-s`, `--scope`             | Configuration scope (user or project).                              | `user`                                 | `-s user`                                                          |
 | `-t`, `--transport`         | Transport type (`stdio`, `sse`, `http`).                            | `stdio`                                | `-t sse`                                                           |
 | `-e`, `--env`               | Set environment variables.                                          | —                                      | `-e KEY=value`                                                     |
 | `-H`, `--header`            | Set HTTP headers for SSE and HTTP transports.                       | —                                      | `-H "X-Api-Key: abc123"`                                           |


### PR DESCRIPTION
## What this PR does

Updates `docs/users/features/mcp.md` so the documented `qwen mcp add --scope` default matches the CLI implementation:

- marks user scope as the default in the scope overview
- changes the CLI example note to say it writes to user scope by default
- changes the CLI reference table default for `--scope` from `project` to `user`

## Why it's needed

`qwen mcp add` has defaulted to `user` scope since commit `21e711469`, but the MCP documentation still described the default as `project`. That can lead users to look in the wrong `settings.json` file after adding an MCP server without an explicit `--scope`.

## Reviewer Test Plan

### How to verify

1. Compare `packages/cli/src/commands/mcp/add.ts` and confirm the `scope` option defaults to `user`.
2. Check `docs/users/features/mcp.md` and confirm all `qwen mcp add --scope` default references now say `user`.
3. Run:
   - `/Users/tushaokun/opse/qwen-code/node_modules/.bin/prettier --check docs/users/features/mcp.md`
   - `git diff --check`

### Evidence (Before & After)

Before: the MCP docs said `qwen mcp add` wrote to project scope by default and listed the `--scope` default as `project`.

After: the MCP docs consistently describe user scope as the default, matching the CLI's `default: 'user'`.

### Tested on

| OS | Tested | Notes |
| --- | --- | --- |
| macOS | Yes | Docs-only validation with Prettier and `git diff --check`. |
| Linux | No | Docs-only change. |
| Windows | No | Docs-only change. |

## Risk & Scope

Risk is low. This is a documentation-only correction and does not change CLI behavior.

Out of scope: changing the `mcp add` default, adding new scope behavior, or editing unrelated MCP docs.

Breaking changes: none.

## Linked Issues

Fixes #5563

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

更新 `docs/users/features/mcp.md`，让文档中的 `qwen mcp add --scope` 默认值与 CLI 实现一致：

- 在 scope 概览中标明 user scope 是默认值
- 将 CLI 示例说明改为默认写入 user scope
- 将 CLI 参考表格中 `--scope` 的默认值从 `project` 改为 `user`

## 为什么需要

从 commit `21e711469` 起，`qwen mcp add` 的默认 scope 已经是 `user`，但 MCP 文档仍写成 `project`。这会让用户在没有显式传 `--scope` 添加 MCP server 后，去错误的 `settings.json` 文件里查找配置。

## Reviewer Test Plan

### How to verify

1. 对照 `packages/cli/src/commands/mcp/add.ts`，确认 `scope` 选项默认值是 `user`。
2. 检查 `docs/users/features/mcp.md`，确认所有关于 `qwen mcp add --scope` 默认值的描述都改为 `user`。
3. 运行：
   - `/Users/tushaokun/opse/qwen-code/node_modules/.bin/prettier --check docs/users/features/mcp.md`
   - `git diff --check`

### Evidence (Before & After)

Before：MCP 文档写的是 `qwen mcp add` 默认写入 project scope，并在 `--scope` 表格中把默认值列为 `project`。

After：MCP 文档统一说明 user scope 是默认值，与 CLI 中的 `default: 'user'` 一致。

### Tested on

| OS | Tested | Notes |
| --- | --- | --- |
| macOS | Yes | 文档变更，仅做 Prettier 和 `git diff --check` 校验。 |
| Linux | No | 文档变更。 |
| Windows | No | 文档变更。 |

## Risk & Scope

风险低。本 PR 只修正文档，不改变 CLI 行为。

不在范围内：修改 `mcp add` 的默认值、增加新的 scope 行为、或编辑无关 MCP 文档。

破坏性变更：无。

## Linked Issues

Fixes #5563

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
