### PR TITLE
fix(core): require confirmation when user manually enters plan mode

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -3385,6 +3385,41 @@ describe('setApprovalMode with folder trust', () => {
       config.setApprovalMode(ApprovalMode.PLAN);
       expect(config.getPrePlanMode()).toBe(ApprovalMode.YOLO);
     });
+
+    // Regression for #5574: the gate state records whether the model or the
+    // user entered plan mode, so exit_plan_mode can decide whether to gate.
+    it('marks the plan gate entry as user-initiated by default', () => {
+      const config = new Config(baseParams);
+      vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
+
+      config.setApprovalMode(ApprovalMode.PLAN);
+      expect(config.getPlanGateState()?.enteredByModel).toBe(false);
+    });
+
+    it('marks the plan gate entry as model-initiated when enter_plan_mode requests it', () => {
+      const config = new Config(baseParams);
+      vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
+
+      config.setApprovalMode(ApprovalMode.PLAN, { enteredByModel: true });
+      expect(config.getPlanGateState()?.enteredByModel).toBe(true);
+    });
+
+    it('records prePlanMode=yolo and enteredByModel=false for a Shift+Tab cycle into plan mode (#5574)', () => {
+      const config = new Config(baseParams);
+      vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
+
+      // Simulate the Shift+Tab cycle order:
+      // default → auto-edit → auto → yolo → plan
+      config.setApprovalMode(ApprovalMode.AUTO_EDIT);
+      config.setApprovalMode(ApprovalMode.AUTO);
+      config.setApprovalMode(ApprovalMode.YOLO);
+      config.setApprovalMode(ApprovalMode.PLAN);
+
+      // prePlanMode is yolo purely because it precedes plan in the cycle —
+      // it does NOT mean the user wants autonomous execution.
+      expect(config.getPrePlanMode()).toBe(ApprovalMode.YOLO);
+      expect(config.getPlanGateState()?.enteredByModel).toBe(false);
+    });
   });
 
   describe('AUTO mode', () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -3621,7 +3621,10 @@ export class Config {
     return this.planGateState;
   }
 
-  setApprovalMode(mode: ApprovalMode): void {
+  setApprovalMode(
+    mode: ApprovalMode,
+    options?: { enteredByModel?: boolean },
+  ): void {
     if (
       !this.isTrustedFolder() &&
       mode !== ApprovalMode.DEFAULT &&
@@ -3634,8 +3637,14 @@ export class Config {
     // Track the mode before entering plan mode so it can be restored later
     if (mode === ApprovalMode.PLAN && this.approvalMode !== ApprovalMode.PLAN) {
       this.prePlanMode = this.approvalMode;
-      // Begin a fresh Plan Mode Entry for the Plan Approval Gate.
-      this.planGateState = createPlanGateState(++this.planGateEntryCounter);
+      // Begin a fresh Plan Mode Entry for the Plan Approval Gate. Only the
+      // model's enter_plan_mode tool marks the entry as model-initiated; every
+      // user-driven entry (Shift+Tab, /plan, dialog) defaults to false so the
+      // user always gets the confirmation dialog on exit (issue #5574).
+      this.planGateState = createPlanGateState(
+        ++this.planGateEntryCounter,
+        options?.enteredByModel ?? false,
+      );
     } else if (
       mode !== ApprovalMode.PLAN &&
       this.approvalMode === ApprovalMode.PLAN

--- a/packages/core/src/plan-gate/state.ts
+++ b/packages/core/src/plan-gate/state.ts
@@ -33,6 +33,16 @@ export interface PlanGateState {
   /** Number of capped review rounds consumed so far. */
   reviewCount: number;
   gateMode: GateMode;
+  /**
+   * True when plan mode was entered by the model via `enter_plan_mode` (an
+   * autonomous flow that should be gated by the LLM reviewer). False when the
+   * user entered plan mode explicitly (Shift+Tab, `/plan`, the approval-mode
+   * dialog) — those entries always route through the user confirmation dialog,
+   * regardless of `prePlanMode`. See issue #5574: cycling Shift+Tab to PLAN
+   * always lands with `prePlanMode === 'yolo'` (it is the mode immediately
+   * before PLAN in the cycle), which must NOT auto-approve via the gate.
+   */
+  enteredByModel: boolean;
   /** Findings merged in the previous round, for the next Evidence Bundle. */
   lastFindings: MergedGateFinding[];
   /** Main model's resolution summary for the previous round's findings. */
@@ -43,11 +53,15 @@ export interface PlanGateState {
   needsUserPending: boolean;
 }
 
-export function createPlanGateState(entryId: number): PlanGateState {
+export function createPlanGateState(
+  entryId: number,
+  enteredByModel = false,
+): PlanGateState {
   return {
     entryId,
     reviewCount: 0,
     gateMode: 'capped',
+    enteredByModel,
     lastFindings: [],
     capEscalationPending: false,
     needsUserPending: false,

--- a/packages/core/src/tools/enterPlanMode.test.ts
+++ b/packages/core/src/tools/enterPlanMode.test.ts
@@ -91,6 +91,7 @@ describe('EnterPlanModeTool', () => {
 
       expect(mockConfig.setApprovalMode).toHaveBeenCalledWith(
         ApprovalMode.PLAN,
+        { enteredByModel: true },
       );
       expect(approvalMode).toBe(ApprovalMode.PLAN);
       expect(savedPrePlanMode).toBe(ApprovalMode.DEFAULT);
@@ -104,6 +105,7 @@ describe('EnterPlanModeTool', () => {
 
       expect(mockConfig.setApprovalMode).toHaveBeenCalledWith(
         ApprovalMode.PLAN,
+        { enteredByModel: true },
       );
       expect(savedPrePlanMode).toBe(ApprovalMode.AUTO_EDIT);
     });
@@ -115,6 +117,7 @@ describe('EnterPlanModeTool', () => {
 
       expect(mockConfig.setApprovalMode).toHaveBeenCalledWith(
         ApprovalMode.PLAN,
+        { enteredByModel: true },
       );
       expect(savedPrePlanMode).toBe(ApprovalMode.AUTO);
     });
@@ -126,6 +129,7 @@ describe('EnterPlanModeTool', () => {
 
       expect(mockConfig.setApprovalMode).toHaveBeenCalledWith(
         ApprovalMode.PLAN,
+        { enteredByModel: true },
       );
       expect(savedPrePlanMode).toBe(ApprovalMode.YOLO);
     });

--- a/packages/core/src/tools/enterPlanMode.ts
+++ b/packages/core/src/tools/enterPlanMode.ts
@@ -81,8 +81,13 @@ class EnterPlanModeToolInvocation extends BaseToolInvocation<
     try {
       // Idempotent: only switch when not already in plan mode so we never
       // overwrite the saved prePlanMode.
+      // Mark this entry as model-initiated so exit_plan_mode runs the Plan
+      // Approval Gate for AUTO/YOLO sessions. User-initiated entries (Shift+Tab,
+      // /plan) leave this false and always get the confirmation dialog (#5574).
       if (this.config.getApprovalMode() !== ApprovalMode.PLAN) {
-        this.config.setApprovalMode(ApprovalMode.PLAN);
+        this.config.setApprovalMode(ApprovalMode.PLAN, {
+          enteredByModel: true,
+        });
       }
     } catch (error) {
       const errorMessage =

--- a/packages/core/src/tools/exitPlanMode.test.ts
+++ b/packages/core/src/tools/exitPlanMode.test.ts
@@ -6,7 +6,11 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ExitPlanModeTool, type ExitPlanModeParams } from './exitPlanMode.js';
-import { ApprovalMode, type Config } from '../config/config.js';
+import {
+  ApprovalMode,
+  Config,
+  type ConfigParameters,
+} from '../config/config.js';
 import { ToolConfirmationOutcome } from './tools.js';
 import { runPlanApprovalGate } from '../plan-gate/planApprovalGate.js';
 import type { GateDecision, MergedGateFinding } from '../plan-gate/types.js';
@@ -404,6 +408,7 @@ describe('ExitPlanModeTool', () => {
           entryId: 1,
           reviewCount: 0,
           gateMode: 'user_override',
+          enteredByModel: true,
           lastFindings: [],
           capEscalationPending: false,
           needsUserPending: false,
@@ -424,7 +429,7 @@ describe('ExitPlanModeTool', () => {
       );
     });
 
-    it('should return allow from getDefaultPermission when prePlanMode is YOLO', async () => {
+    it('should return allow from getDefaultPermission when model entered plan mode in YOLO', async () => {
       approvalMode = ApprovalMode.PLAN;
       (mockConfig.getPrePlanMode as ReturnType<typeof vi.fn>).mockReturnValue(
         ApprovalMode.YOLO,
@@ -434,6 +439,7 @@ describe('ExitPlanModeTool', () => {
           entryId: 1,
           reviewCount: 0,
           gateMode: 'capped',
+          enteredByModel: true,
           lastFindings: [],
           capEscalationPending: false,
           needsUserPending: false,
@@ -444,6 +450,33 @@ describe('ExitPlanModeTool', () => {
       const invocation = tool.build(params);
       const permission = await invocation.getDefaultPermission();
       expect(permission).toBe('allow');
+    });
+
+    // Regression for #5574: cycling Shift+Tab to PLAN always lands with
+    // prePlanMode === 'yolo' (it is the mode right before PLAN in the cycle).
+    // A user-initiated entry must NOT auto-approve via the gate — it must show
+    // the confirmation dialog so the user can review the plan.
+    it('should return ask when the user entered plan mode in YOLO (not via the model)', async () => {
+      approvalMode = ApprovalMode.PLAN;
+      (mockConfig.getPrePlanMode as ReturnType<typeof vi.fn>).mockReturnValue(
+        ApprovalMode.YOLO,
+      );
+      (mockConfig.getPlanGateState as ReturnType<typeof vi.fn>).mockReturnValue(
+        {
+          entryId: 1,
+          reviewCount: 0,
+          gateMode: 'capped',
+          enteredByModel: false,
+          lastFindings: [],
+          capEscalationPending: false,
+          needsUserPending: false,
+        },
+      );
+
+      const params: ExitPlanModeParams = { plan: 'User Shift+Tab YOLO plan' };
+      const invocation = tool.build(params);
+      const permission = await invocation.getDefaultPermission();
+      expect(permission).toBe('ask');
     });
 
     it('should fall back to ask when no gateState even with YOLO prePlanMode', async () => {
@@ -507,6 +540,7 @@ describe('ExitPlanModeTool', () => {
           entryId: 1,
           reviewCount: 0,
           gateMode: 'capped' as const,
+          enteredByModel: true,
           lastFindings: [],
           capEscalationPending: false,
           needsUserPending: false,
@@ -556,6 +590,7 @@ describe('ExitPlanModeTool', () => {
         entryId: 1,
         reviewCount: 0,
         gateMode: 'capped' as const,
+        enteredByModel: true,
         lastFindings: [],
         capEscalationPending: false,
         needsUserPending: false,
@@ -594,6 +629,61 @@ describe('ExitPlanModeTool', () => {
         ApprovalMode.DEFAULT,
       );
       expect(mockConfig.savePlan).toHaveBeenCalledWith(params.plan);
+    });
+  });
+
+  // End-to-end regression for #5574 using a REAL Config (no mocks) wired to a
+  // REAL ExitPlanModeTool, exercising the exact production decision point the
+  // CoreToolScheduler consults (getDefaultPermission → needsConfirmation).
+  describe('issue #5574 — real Config + real tool, no mocks', () => {
+    const baseParams: ConfigParameters = {
+      targetDir: '.',
+      debugMode: false,
+      model: 'test-model',
+      cwd: '.',
+    };
+
+    function makeTrustedConfig(): Config {
+      const config = new Config(baseParams);
+      vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
+      return config;
+    }
+
+    it('user cycling Shift+Tab into plan mode (…→auto→yolo→plan) gets the confirmation dialog', async () => {
+      const config = makeTrustedConfig();
+
+      // Exact reproduction of the issue: the user presses Shift+Tab four times
+      // from DEFAULT, walking the real APPROVAL_MODES cycle into plan mode.
+      config.setApprovalMode(ApprovalMode.AUTO_EDIT);
+      config.setApprovalMode(ApprovalMode.AUTO);
+      config.setApprovalMode(ApprovalMode.YOLO);
+      config.setApprovalMode(ApprovalMode.PLAN);
+
+      // prePlanMode is yolo purely due to cycle order — NOT user intent.
+      expect(config.getPrePlanMode()).toBe(ApprovalMode.YOLO);
+      expect(config.getPlanGateState()?.enteredByModel).toBe(false);
+
+      const tool = new ExitPlanModeTool(config);
+      const invocation = tool.build({ plan: 'Refactor the parser.' });
+
+      // 'ask' → CoreToolScheduler shows the plan confirmation dialog.
+      await expect(invocation.getDefaultPermission()).resolves.toBe('ask');
+    });
+
+    it('model self-entering plan mode in a YOLO session still auto-runs the gate', async () => {
+      const config = makeTrustedConfig();
+      config.setApprovalMode(ApprovalMode.YOLO);
+      // This is what enter_plan_mode does under the hood.
+      config.setApprovalMode(ApprovalMode.PLAN, { enteredByModel: true });
+
+      expect(config.getPrePlanMode()).toBe(ApprovalMode.YOLO);
+      expect(config.getPlanGateState()?.enteredByModel).toBe(true);
+
+      const tool = new ExitPlanModeTool(config);
+      const invocation = tool.build({ plan: 'Autonomous plan.' });
+
+      // 'allow' → no user prompt; the gate runs inside execute() as designed.
+      await expect(invocation.getDefaultPermission()).resolves.toBe('allow');
     });
   });
 });

--- a/packages/core/src/tools/exitPlanMode.ts
+++ b/packages/core/src/tools/exitPlanMode.ts
@@ -106,10 +106,16 @@ class ExitPlanModeToolInvocation extends BaseToolInvocation<
   }
 
   /**
-   * For AUTO/YOLO pre-plan modes (without user takeover), the gate runs
-   * inside execute() and no user confirmation prompt is needed. For
-   * DEFAULT/AUTO_EDIT (or after user takeover), the existing confirmation
-   * UI handles approval.
+   * The Plan Approval Gate auto-approves (runs inside execute(), no user prompt)
+   * only when the model entered plan mode itself via enter_plan_mode while the
+   * session was AUTO/YOLO — an autonomous flow that should not be interrupted.
+   *
+   * When the user entered plan mode explicitly (Shift+Tab, /plan, the dialog),
+   * the confirmation UI always handles approval, even if prePlanMode happens to
+   * be AUTO/YOLO. Note the Shift+Tab cycle order (…→auto→yolo→plan) means a
+   * manual entry ALWAYS lands with prePlanMode === 'yolo', so prePlanMode alone
+   * cannot distinguish the two cases — `enteredByModel` is the discriminator
+   * (issue #5574).
    */
   override async getDefaultPermission(): Promise<PermissionDecision> {
     const prePlanMode = this.config.getPrePlanMode();
@@ -117,6 +123,7 @@ class ExitPlanModeToolInvocation extends BaseToolInvocation<
     if (
       isAutonomousPrePlanMode(prePlanMode) &&
       gateState &&
+      gateState.enteredByModel &&
       gateState.gateMode !== 'user_takeover'
     ) {
       return 'allow';
@@ -199,10 +206,11 @@ class ExitPlanModeToolInvocation extends BaseToolInvocation<
         return this.approveAndRestore(plan, prePlanMode, 'Gate user override');
       }
 
-      // ── Path B: AUTO/YOLO gate path (no takeover) ──────────────
+      // ── Path B: AUTO/YOLO gate path (model-initiated, no takeover) ──
       if (
         isAutonomousPrePlanMode(prePlanMode) &&
         gateState &&
+        gateState.enteredByModel &&
         gateState.gateMode !== 'user_takeover'
       ) {
         // Update the gate state with the latest resolution summary


### PR DESCRIPTION
## What this PR does

Fixes #5574. When a user enters Plan Mode by cycling **Shift+Tab**, `exit_plan_mode` no longer skips the confirmation dialog and silently runs the automated Plan Approval Gate. Auto-approval is now restricted to genuinely autonomous flows — i.e. the **model** self-entering plan mode via `enter_plan_mode` while the session is in AUTO/YOLO.

## Why it's needed

The Plan Approval Gate (introduced in #4853) auto-approves `exit_plan_mode` — skipping the user confirmation dialog and running an LLM reviewer instead — whenever `prePlanMode` is `AUTO`/`YOLO`.

The problem: the Shift+Tab cycle order is `…→ auto → yolo → plan` (`APPROVAL_MODES` in `config.ts`). **YOLO is the mode immediately before PLAN**, so a user cycling into plan mode *always* lands with `prePlanMode === 'yolo'`. As a result, **every** manual Shift+Tab entry into plan mode bypassed the confirmation dialog — the exact opposite of the user's intent when they deliberately enter plan mode to review a plan.

`prePlanMode` simply cannot distinguish "user manually cycled into plan mode" from "model self-entered plan mode during an AUTO/YOLO session".

## How it works

Track the **entry source** instead of inferring it from `prePlanMode`:

- `PlanGateState` gains a boolean `enteredByModel`.
- `setApprovalMode(mode, { enteredByModel })` records it; only the `enter_plan_mode` tool passes `true`. Every user-driven entry (Shift+Tab, `/plan`, the approval-mode dialog, ACP/web clients) leaves it `false`.
- `exit_plan_mode` auto-approves (runs the gate without a prompt) **only when `enteredByModel` is true AND `prePlanMode` is AUTO/YOLO**. This preserves the autonomous gate from #4853 untouched, while user-initiated plan entries always get the confirmation dialog.

## Reviewer Test Plan

### Real-scenario test report — real `Config` + real `ExitPlanModeTool`, no mocks

Exercises the exact production decision point the `CoreToolScheduler` consults (`getDefaultPermission()` → `needsConfirmation()`), walking the real `setApprovalMode` cycle. `allow` = no dialog (plan auto-runs via the gate); `ask` = user confirmation dialog shown.

**Before this PR (buggy):**
```
[USER  Shift+Tab → plan]  prePlanMode=yolo  enteredByModel=undefined
                          getDefaultPermission = allow  → NO dialog, plan auto-runs via gate   ❌ BUG
[MODEL enter_plan_mode  ]  prePlanMode=yolo  enteredByModel=undefined
                          getDefaultPermission = allow  → NO dialog, plan auto-runs via gate
```

**After this PR (fixed):**
```
[USER  Shift+Tab → plan]  prePlanMode=yolo  enteredByModel=false
                          getDefaultPermission = ask    → user confirmation dialog SHOWN        ✅ FIXED
[MODEL enter_plan_mode  ]  prePlanMode=yolo  enteredByModel=true
                          getDefaultPermission = allow  → NO dialog, plan auto-runs via gate    ✅ gate preserved
```

This before/after is encoded as a committed regression test (`exitPlanMode.test.ts` → `describe('issue #5574 — real Config + real tool, no mocks')`); it passes on this branch and fails on `main`.

### Unit / integration tests

```bash
cd packages/core && npx vitest run \
  src/tools/exitPlanMode.test.ts \
  src/tools/enterPlanMode.test.ts \
  src/plan-gate/planApprovalGate.test.ts \
  src/config/config.test.ts
```

- `exitPlanMode.test.ts`: user-initiated YOLO entry → `ask`; model-initiated YOLO entry → `allow`; plus the no-mock end-to-end pair above.
- `config.test.ts` → `prePlanMode tracking`: real `Config` walking `default→auto-edit→auto→yolo→plan` asserts `prePlanMode=yolo` **and** `enteredByModel=false`; `setApprovalMode(PLAN, {enteredByModel:true})` → `true`.
- All consumer suites green (`permissionFlow`, `coreToolScheduler`): 227/227.

### Manual (interactive) check

1. Start the CLI in DEFAULT mode.
2. Press Shift+Tab to cycle into Plan Mode (passes through yolo).
3. Ask for a plan; the model calls `exit_plan_mode`.
4. **Expected:** the plan confirmation dialog appears (approve / modify / reject) — no silent auto-execution.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

> Note: the interactive Shift+Tab path can't be exercised in headless E2E (modifier keys aren't reliably injectable via tmux), so verification is done with the real-`Config`/real-tool integration tests above, which hit the identical decision code path.

## Risk & Scope

- `setApprovalMode` gains an **optional** second argument — fully backward compatible; all existing callers and mocks pass a single argument.
- `PlanGateState.enteredByModel` defaults to `false` (user-initiated), so any path that forgets to pass it fails safe toward *showing* the confirmation dialog rather than skipping it.
- No change to the autonomous gate behaviour from #4853 for model-initiated plan entries.
