### PR TITLE
test(integration): align fake OpenAI tool responses

### DIFF
--- a/integration-tests/fake-openai-server.test.ts
+++ b/integration-tests/fake-openai-server.test.ts
@@ -25,10 +25,14 @@ describe('fake OpenAI server', () => {
         ? { content: 'hello from fake model' }
         : {
             toolCalls: [
-              fakeToolCall('write_file', {
-                file_path: '/tmp/fake.txt',
-                content: 'fake',
-              }),
+              fakeToolCall(
+                'write_file',
+                {
+                  file_path: '/tmp/fake.txt',
+                  content: 'fake',
+                },
+                'call_write_file',
+              ),
             ],
           },
     );
@@ -67,8 +71,66 @@ describe('fake OpenAI server', () => {
     const streamText = await streaming.text();
     expect(streamText).toContain('"tool_calls"');
     expect(streamText).toContain('"write_file"');
+    expect(streamText).toContain('"id":"call_write_file"');
+    expect(streamText).toContain('"function":{"name":"write_file"}');
+    expect(streamText).toContain(
+      '"function":{"arguments":"{\\"file_path\\":\\"/tmp/fake.txt\\",\\"content\\":\\"fake\\"}"}',
+    );
+    expect(streamText).not.toContain(
+      '"function":{"name":"write_file","arguments":',
+    );
     expect(streamText).toContain('data: [DONE]');
     expect(server.requests).toHaveLength(2);
+  });
+
+  it('serves non-streaming tool calls with null content', async () => {
+    server = await startFakeOpenAIServer(() => ({
+      toolCalls: [
+        fakeToolCall(
+          'write_file',
+          {
+            file_path: '/tmp/fake.txt',
+            content: 'fake',
+          },
+          'call_write_file',
+        ),
+      ],
+    }));
+
+    const response = await fetch(`${server.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        model: 'fake-model',
+        messages: [{ role: 'user', content: 'write' }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      choices: [
+        {
+          message: {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: 'call_write_file',
+                type: 'function',
+                function: {
+                  name: 'write_file',
+                  arguments: JSON.stringify({
+                    file_path: '/tmp/fake.txt',
+                    content: 'fake',
+                  }),
+                },
+              },
+            ],
+          },
+          finish_reason: 'tool_calls',
+        },
+      ],
+    });
   });
 
   it('returns 404 for wrong methods or paths', async () => {

--- a/integration-tests/fake-openai-server.ts
+++ b/integration-tests/fake-openai-server.ts
@@ -183,7 +183,7 @@ function writeNonStreamed(
           index: 0,
           message: {
             role: 'assistant',
-            content: message.content ?? '',
+            content: message.content ?? (message.toolCalls ? null : ''),
             ...(message.toolCalls ? { tool_calls: message.toolCalls } : {}),
           },
           finish_reason: finishReason(message),
@@ -235,11 +235,23 @@ function writeStreamed(
             index,
             id: toolCall.id,
             type: toolCall.type,
-            function: toolCall.function,
+            function: { name: toolCall.function.name },
           },
         ],
       }),
     );
+    if (toolCall.function.arguments) {
+      send(
+        chunk({
+          tool_calls: [
+            {
+              index,
+              function: { arguments: toolCall.function.arguments },
+            },
+          ],
+        }),
+      );
+    }
   }
   send(chunk({}, finishReason(message), message.usage ?? DEFAULT_USAGE));
   res.write('data: [DONE]\n\n');


### PR DESCRIPTION
## What this PR does

This PR brings the fake OpenAI chat completion test server closer to the real OpenAI tool-call contract. Non-streaming tool-call-only replies now use null assistant content, and streaming tool calls now send metadata before arguments deltas instead of putting the full function object in one chunk.

## Why it's needed

The fake server is reused by daemon and no-AK integration tests. Matching the real API shape keeps those tests from masking consumers that distinguish text responses from tool-call responses or that depend on incremental tool-call argument streaming.

## Reviewer Test Plan

### How to verify

Reviewers can run the fake server integration test and confirm it covers both non-streaming tool-call serialization and streamed tool-call deltas.

### Evidence (Before & After)

N/A, this is non-UI test infrastructure behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

`npx vitest run --root ./integration-tests fake-openai-server.test.ts`

## Risk & Scope

- Main risk or tradeoff: the fake server now emits one arguments delta per tool call, which is enough for current consumers but does not simulate every possible chunk split.
- Not validated / out of scope: full integration test matrix and real OpenAI network calls.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #5560.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让 fake OpenAI chat completion 测试服务器更接近真实 OpenAI tool-call 合同。非流式的纯 tool-call 回复现在使用 null assistant content，流式 tool call 现在先发送 metadata，再发送 arguments delta，而不是在一个 chunk 里放完整 function object。

## Why it's needed

这个 fake server 会被 daemon 和 no-AK integration tests 复用。保持真实 API 形态可以避免测试掩盖那些区分文本回复和 tool-call 回复、或依赖增量 tool-call arguments 的消费端问题。

## Reviewer Test Plan

### How to verify

Reviewer 可以运行 fake server integration test，并确认它覆盖了非流式 tool-call 序列化和流式 tool-call delta。

### Evidence (Before & After)

N/A，这是非 UI 的测试基础设施行为。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

`npx vitest run --root ./integration-tests fake-openai-server.test.ts`

## Risk & Scope

- Main risk or tradeoff: fake server 现在每个 tool call 发一个 arguments delta，足够覆盖当前消费者，但不模拟所有可能的 chunk split。
- Not validated / out of scope: 完整 integration test matrix 和真实 OpenAI 网络调用。
- Breaking changes / migration notes: 无。

## Linked Issues

#5560 的 follow-up。

</details>
