### PR TITLE
fix(core): prevent GLM on DashScope from dropping web_fetch content

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
@@ -817,6 +817,227 @@ describe('DashScopeOpenAICompatibleProvider', () => {
       });
     });
 
+    // glm-* on DashScope drop array-form content on tool-less ("plain") chat
+    // requests. For glm models with no function-calling context the provider
+    // skips cache control and collapses text content to plain strings, so
+    // side-queries like web_fetch aren't silently emptied. Other models and
+    // tool-bearing requests keep the existing cache-control path untouched.
+    describe('glm array-drop fix (plain-text flatten)', () => {
+      it('should flatten system and user text content to strings for a glm tool-less request', () => {
+        const request: OpenAI.Chat.ChatCompletionCreateParams = {
+          model: 'glm-5.2',
+          stream: false,
+          messages: [
+            { role: 'system', content: 'You are a helpful assistant.' },
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'Summarize this page.' }],
+            },
+          ],
+        };
+
+        const result = provider.buildRequest(request, 'test-prompt-id');
+
+        // No cache_control is applied; both messages become plain strings.
+        expect(result.messages[0].content).toBe('You are a helpful assistant.');
+        expect(result.messages[1].content).toBe('Summarize this page.');
+      });
+
+      it('should join multi-part text-only array content with blank lines', () => {
+        const request: OpenAI.Chat.ChatCompletionCreateParams = {
+          model: 'glm-5.2',
+          stream: false,
+          messages: [
+            {
+              role: 'user',
+              content: [
+                { type: 'text', text: 'First block' },
+                { type: 'text', text: 'Second block' },
+              ],
+            },
+          ],
+        };
+
+        const result = provider.buildRequest(request, 'test-prompt-id');
+
+        expect(result.messages[0].content).toBe('First block\n\nSecond block');
+      });
+
+      it('should flatten the streamed last message too for a glm tool-less request', () => {
+        const request: OpenAI.Chat.ChatCompletionCreateParams = {
+          model: 'glm-5.2',
+          stream: true,
+          messages: [
+            { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+          ],
+        };
+
+        const result = provider.buildRequest(request, 'test-prompt-id');
+
+        expect(result.messages[0].content).toBe('Hello');
+      });
+
+      it('should NOT flatten array content that contains a non-text (media) part', () => {
+        const request: OpenAI.Chat.ChatCompletionCreateParams = {
+          model: 'glm-5.2',
+          stream: false,
+          messages: [
+            {
+              role: 'user',
+              content: [
+                { type: 'text', text: 'What is this?' },
+                {
+                  type: 'image_url',
+                  image_url: { url: 'https://example.com/x.jpg' },
+                },
+              ],
+            },
+          ],
+        };
+
+        const result = provider.buildRequest(request, 'test-prompt-id');
+
+        // The whole message is left untouched (cannot be a plain string).
+        expect(result.messages[0].content).toEqual([
+          { type: 'text', text: 'What is this?' },
+          {
+            type: 'image_url',
+            image_url: { url: 'https://example.com/x.jpg' },
+          },
+        ]);
+      });
+
+      it('should leave an empty content array unchanged for a glm tool-less request', () => {
+        const request: OpenAI.Chat.ChatCompletionCreateParams = {
+          model: 'glm-5.2',
+          stream: false,
+          messages: [{ role: 'user', content: [] }],
+        };
+
+        const result = provider.buildRequest(request, 'test-prompt-id');
+
+        expect(result.messages[0].content).toEqual([]);
+      });
+
+      it('should flatten glm content even when cache control is disabled', () => {
+        (
+          mockCliConfig.getContentGeneratorConfig as MockedFunction<
+            typeof mockCliConfig.getContentGeneratorConfig
+          >
+        ).mockReturnValue({
+          model: 'glm-5.2',
+          enableCacheControl: false,
+        });
+
+        const request: OpenAI.Chat.ChatCompletionCreateParams = {
+          model: 'glm-5.2',
+          stream: false,
+          messages: [
+            { role: 'system', content: [{ type: 'text', text: 'Sys' }] },
+            { role: 'user', content: [{ type: 'text', text: 'Hi' }] },
+          ],
+        };
+
+        const result = provider.buildRequest(request, 'test-prompt-id');
+
+        expect(result.messages[0].content).toBe('Sys');
+        expect(result.messages[1].content).toBe('Hi');
+      });
+
+      // Any function-calling signal (a tools field, an assistant tool_call, or a
+      // tool result in history) keeps glm out of the flatten path: cache control
+      // is applied and array content is preserved.
+      const functionCallingCases: Array<{
+        name: string;
+        extraMessages: OpenAI.Chat.ChatCompletionMessageParam[];
+        tools?: OpenAI.Chat.ChatCompletionTool[];
+        userIndex: number;
+      }> = [
+        {
+          name: 'declares tools',
+          extraMessages: [],
+          tools: [
+            {
+              type: 'function',
+              function: {
+                name: 'noop',
+                parameters: { type: 'object', properties: {} },
+              },
+            },
+          ],
+          userIndex: 1,
+        },
+        {
+          name: 'has an assistant turn with tool_calls',
+          extraMessages: [
+            {
+              role: 'assistant',
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_1',
+                  type: 'function',
+                  function: { name: 'noop', arguments: '{}' },
+                },
+              ],
+            },
+          ],
+          userIndex: 2,
+        },
+        {
+          name: 'has tool-result history',
+          extraMessages: [
+            { role: 'tool', content: 'tool result', tool_call_id: 'call_1' },
+          ],
+          userIndex: 2,
+        },
+      ];
+
+      it.each(functionCallingCases)(
+        'should keep cache control and array content for a glm request that $name',
+        ({ extraMessages, tools, userIndex }) => {
+          const request: OpenAI.Chat.ChatCompletionCreateParams = {
+            model: 'glm-5.2',
+            stream: false,
+            messages: [
+              { role: 'system', content: 'Sys' },
+              ...extraMessages,
+              { role: 'user', content: [{ type: 'text', text: 'Hi' }] },
+            ],
+            ...(tools ? { tools } : {}),
+          };
+
+          const result = provider.buildRequest(request, 'test-prompt-id');
+
+          expect(result.messages[0].content).toEqual([
+            { type: 'text', text: 'Sys', cache_control: { type: 'ephemeral' } },
+          ]);
+          expect(Array.isArray(result.messages[userIndex].content)).toBe(true);
+        },
+      );
+
+      it('should NOT flatten content for a non-glm tool-less request', () => {
+        const request: OpenAI.Chat.ChatCompletionCreateParams = {
+          model: 'qwen-max',
+          stream: false,
+          messages: [
+            { role: 'system', content: 'Sys' },
+            { role: 'user', content: [{ type: 'text', text: 'Hi' }] },
+          ],
+        };
+
+        const result = provider.buildRequest(request, 'test-prompt-id');
+
+        // Non-glm: existing behavior — system cached as array, user untouched.
+        expect(result.messages[0].content).toEqual([
+          { type: 'text', text: 'Sys', cache_control: { type: 'ephemeral' } },
+        ]);
+        expect(result.messages[1].content).toEqual([
+          { type: 'text', text: 'Hi' },
+        ]);
+      });
+    });
+
     it('should handle empty messages array', () => {
       const emptyRequest: OpenAI.Chat.ChatCompletionCreateParams = {
         model: 'qwen-max',

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
@@ -178,8 +178,24 @@ export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatiblePr
     let messages = request.messages;
     let tools = request.tools;
 
-    // Apply DashScope cache control if enabled (default is enabled).
-    if (this.shouldEnableCacheControl()) {
+    // glm-* models served via DashScope only parse structured "content parts"
+    // arrays when the request is in function-calling mode. A tool-less request
+    // (e.g. web_fetch's side-query: system + user, no tools, no tool messages)
+    // with array content has its prompt silently dropped server-side —
+    // prompt_tokens collapses and the model answers from an empty prompt. This
+    // is glm-specific; other DashScope models read array content fine. Caching
+    // is also moot for these one-shot side-queries, so for glm tool-less
+    // requests we skip cache control and collapse content to plain strings (the
+    // only form glm reliably reads here). Every other case keeps the existing
+    // cache-control path unchanged.
+    const flattenPlainTextForGlm =
+      this.isGlmModel(request.model) &&
+      !this.hasFunctionCallingContext(request);
+
+    if (flattenPlainTextForGlm) {
+      messages = this.flattenTextContent(messages);
+    } else if (this.shouldEnableCacheControl()) {
+      // Apply DashScope cache control if enabled (default is enabled).
       const { messages: updatedMessages, tools: updatedTools } =
         this.addDashScopeCacheControl(
           request,
@@ -348,6 +364,70 @@ export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatiblePr
     } as ChatCompletionContentPartTextWithCache;
 
     return contentArray;
+  }
+
+  /**
+   * True for glm-* models (e.g. glm-4.5, glm-5.2). Uses the same `^glm-` prefix
+   * convention as the GLM matchers in tokenLimits.ts, keeping model detection
+   * consistent across the codebase.
+   */
+  private isGlmModel(model: string | undefined): boolean {
+    return !!model && model.toLowerCase().startsWith('glm-');
+  }
+
+  /**
+   * Whether the request is in "function-calling mode" — it declares `tools`, or
+   * its history already contains a tool result / assistant tool_call. glm needs
+   * one of these present to parse structured content-part arrays.
+   */
+  private hasFunctionCallingContext(
+    request: OpenAI.Chat.ChatCompletionCreateParams,
+  ): boolean {
+    if (request.tools && request.tools.length > 0) {
+      return true;
+    }
+    return request.messages.some((message) => {
+      if (message.role === 'tool') {
+        return true;
+      }
+      if (message.role === 'assistant') {
+        const toolCalls = (message as { tool_calls?: unknown[] }).tool_calls;
+        return Array.isArray(toolCalls) && toolCalls.length > 0;
+      }
+      return false;
+    });
+  }
+
+  /**
+   * Collapse text-only content arrays back to a plain string, leaving
+   * media-bearing parts (image/audio/...) as arrays. Used for glm tool-less
+   * requests, where the array form would otherwise be dropped server-side.
+   * Multiple text parts are joined with a blank line, matching the DeepSeek
+   * provider's flattening (separate parts read as separate blocks).
+   * Only called on the flatten branch, which skips cache control, so no part
+   * here carries a `cache_control` marker.
+   */
+  private flattenTextContent(
+    messages: OpenAI.Chat.ChatCompletionMessageParam[],
+  ): OpenAI.Chat.ChatCompletionMessageParam[] {
+    return messages.map((message) => {
+      if (!('content' in message) || !Array.isArray(message.content)) {
+        return message;
+      }
+      const parts = message.content as Array<{ type?: string; text?: string }>;
+      if (parts.length === 0) {
+        return message;
+      }
+      const isTextOnly = parts.every((part) => part && part.type === 'text');
+      if (!isTextOnly) {
+        return message;
+      }
+      const text = parts.map((part) => part.text ?? '').join('\n\n');
+      return {
+        ...message,
+        content: text,
+      } as OpenAI.Chat.ChatCompletionMessageParam;
+    });
   }
 
   /**


### PR DESCRIPTION

<!-- PR body below — follows .github/pull_request_template.md. Paragraphs are single long lines on purpose (GitHub renders newlines as <br>). -->

## What this PR does

- When the active model is a GLM model on DashScope, the assistant's built-in helper requests (the step behind `web_fetch`, and other internal side-queries) now send their prompt as plain text so GLM actually reads it.
- Previously these requests sent their content in a structured form that GLM silently discards unless the request is also in tool-calling mode — so the model received an effectively empty prompt and made up an answer.
- The change is scoped to GLM models that have no tools in the request; every other model, and any request that already uses tools, is left exactly as before.

## Why it's needed

- Users on a GLM model would run something like `web_fetch` on a page and get a confident answer that had nothing to do with the page — or a reply claiming the message was blank.
- GLM on DashScope only reads structured request content when the request also offers it tools. The helper requests behind features like `web_fetch` don't use tools, so GLM ignored the page content entirely and answered from nothing.
- This made `web_fetch` (and similar helper-backed features) effectively unusable on GLM, with no error — just wrong answers.

## Reviewer Test Plan

### How to verify

- Configure a GLM model on DashScope as your model (e.g. `glm-4.x` / `glm-5.x`).
- Run a fetch and ask something answerable only from the page: `qwen --approval-mode yolo -p "Use the web_fetch tool to fetch https://example.com and quote the page's H1 heading verbatim."`
- Before this PR: the reply is unrelated to the page (e.g. it talks about something else, or says your message looked empty / got cut off).
- After this PR: the reply is grounded in the page — e.g. it returns "Example Domain".
- Sanity check that nothing else regresses: the same prompt on a non-GLM DashScope model (e.g. a Qwen or DeepSeek model) still works, and normal tool-using turns on GLM still work.

### Evidence (Before & After)

`web_fetch https://example.com` on a GLM model, asked to quote the page heading:

| | Before | After |
| --- | --- | --- |
| Model's answer | Unrelated / "your message appears to be empty" (page content never reached the model) | "Example Domain" — quotes the actual page |
| Prompt tokens reported by the API | ~13 (content discarded) | ~300+ (full prompt ingested) |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

- Local `npm run dev` against a real GLM model (`glm-5.2`) on DashScope.

## Risk & Scope

- Main risk or tradeoff: GLM tool-less helper requests no longer get prompt-cache markers. These are one-shot requests with no repeated prefix, so the caching was already providing ~nothing; in exchange the prompt is actually read.
- Not validated / out of scope: this is a client-side workaround for DashScope/GLM server behavior, not a server fix; verified locally on macOS only (CI covers the other platforms).
- Breaking changes / migration notes: none. Non-GLM models and tool-using requests are unchanged.

## Linked Issues

None — found during internal testing.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

- 当前模型为 DashScope 上的 GLM 模型时，助手内部的辅助请求（`web_fetch` 背后的那一步，以及其他内部 side-query）现在会以纯文本形式发送提示词，确保 GLM 能真正读到内容。
- 此前这些请求以结构化形式发送内容，而 GLM 只有在请求同时处于工具调用（tool-calling）模式时才会解析该结构，否则会静默丢弃——模型实际上收到了一个空提示词，于是凭空编造答案。
- 改动仅作用于「不带 tools 的 GLM 请求」；其他任何模型、以及任何已经带 tools 的请求都保持原样。

## 为什么需要

- 使用 GLM 模型的用户在对某个页面运行 `web_fetch` 时，会得到一个与页面毫不相关却很自信的答案，或者收到「消息为空」之类的回复。
- DashScope 上的 GLM 只有在请求同时提供 tools 时才会读取结构化内容。`web_fetch` 等功能背后的辅助请求并不使用 tools，因此 GLM 完全忽略了页面内容，凭空作答。
- 这让 `web_fetch`（以及其他依赖辅助请求的功能）在 GLM 上实际不可用，而且没有任何报错——只是答案是错的。

## 复核测试方案

### 如何验证

- 将 DashScope 上的某个 GLM 模型设为当前模型（如 `glm-4.x` / `glm-5.x`）。
- 运行一次抓取，并提出只有读到页面才能回答的问题：`qwen --approval-mode yolo -p "Use the web_fetch tool to fetch https://example.com and quote the page's H1 heading verbatim."`
- 本 PR 之前：回复与页面无关（谈论别的内容，或声称消息为空 / 被截断）。
- 本 PR 之后：回复基于页面内容——例如返回 "Example Domain"。
- 顺便确认无回归：同样的提示词在非 GLM 的 DashScope 模型（如 Qwen 或 DeepSeek）上依然正常，GLM 上正常的工具调用回合也依然正常。

### 证据（前 / 后）

在 GLM 模型上对 `web_fetch https://example.com` 请求引用页面标题：

| | 之前 | 之后 |
| --- | --- | --- |
| 模型回答 | 与页面无关 / 「消息似乎为空」（页面内容从未到达模型） | "Example Domain"——引用了真实页面 |
| API 报告的 prompt tokens | ~13（内容被丢弃） | ~300+（完整提示词被读取） |

### 测试平台

- 🍏 macOS：✅ 已测试；🪟 Windows：⚠️ 未测试；🐧 Linux：⚠️ 未测试（CI 覆盖其余平台）。

### 运行环境（可选）

- 本地 `npm run dev`，对接 DashScope 上真实的 GLM 模型（`glm-5.2`）。

## 风险与范围

- 主要风险 / 取舍：GLM 的无工具辅助请求不再附带 prompt 缓存标记。这些是一次性、无重复前缀的请求，缓存本就几乎没有收益；作为交换，提示词得以被真正读取。
- 未验证 / 范围之外：这是针对 DashScope/GLM 服务端行为的客户端规避方案，并非服务端修复；仅在 macOS 本地验证（其余平台由 CI 覆盖）。
- 破坏性变更 / 迁移说明：无。非 GLM 模型与使用工具的请求均不受影响。

## 关联 Issue

无——在内部测试中发现。

</details>
