### PR TITLE
feat(workflows): finish Dynamic Workflows port — resume, saved workflows, keyword trigger, notifications (#4721)

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -737,6 +737,16 @@ const SETTINGS_SCHEMA = {
         description: 'Hide the window title bar',
         showInDialog: false,
       },
+      disableWorkflowKeywordTrigger: {
+        type: 'boolean',
+        label: 'Disable Workflow Keyword Trigger',
+        category: 'UI',
+        requiresRestart: false,
+        default: false,
+        description:
+          'When true, mentioning the word `workflow` in a prompt no longer softly steers the turn toward the Workflow tool (and the Footer `workflow active` indicator is suppressed). Only applies when workflows are enabled.',
+        showInDialog: true,
+      },
       showStatusInTitle: {
         type: 'boolean',
         label: 'Show Status in Title',

--- a/packages/cli/src/nonInteractiveCliCommands.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.ts
@@ -16,6 +16,7 @@ import { CommandService } from './services/CommandService.js';
 import { BuiltinCommandLoader } from './services/BuiltinCommandLoader.js';
 import { BundledSkillLoader } from './services/BundledSkillLoader.js';
 import { FileCommandLoader } from './services/FileCommandLoader.js';
+import { SavedWorkflowLoader } from './services/saved-workflow-loader.js';
 import { McpPromptLoader } from './services/McpPromptLoader.js';
 import { SkillCommandLoader } from './services/SkillCommandLoader.js';
 import {
@@ -337,6 +338,7 @@ export const handleSlashCommand = async (
     new BuiltinCommandLoader(config),
     new BundledSkillLoader(config),
     new SkillCommandLoader(config),
+    new SavedWorkflowLoader(config),
     new FileCommandLoader(config),
   ];
 
@@ -515,6 +517,7 @@ export const getAvailableCommands = async (
       new BuiltinCommandLoader(config),
       new BundledSkillLoader(config),
       new SkillCommandLoader(config),
+      new SavedWorkflowLoader(config),
       new FileCommandLoader(config),
     ];
 

--- a/packages/cli/src/services/commandMetadata.test.ts
+++ b/packages/cli/src/services/commandMetadata.test.ts
@@ -297,6 +297,11 @@ describe('formatCommandSourceLabel', () => {
     expect(formatCommandSourceLabel(cmd)).toBe('MCP');
   });
 
+  it('returns Workflow for workflow-command', () => {
+    const cmd = makeCmd({ source: 'workflow-command', sourceLabel: undefined });
+    expect(formatCommandSourceLabel(cmd)).toBe('Workflow');
+  });
+
   it('returns Unknown when source is falsy', () => {
     const cmd = makeCmd({
       source: undefined as unknown as SlashCommand['source'],

--- a/packages/cli/src/services/commandMetadata.ts
+++ b/packages/cli/src/services/commandMetadata.ts
@@ -138,6 +138,7 @@ export function formatCommandSourceLabel(
     'skill-dir-command': 'Custom',
     'plugin-command': 'Plugin',
     'mcp-prompt': 'MCP',
+    'workflow-command': 'Workflow',
   };
 
   return command.source ? fallbackLabels[command.source] : 'Unknown';

--- a/packages/cli/src/services/saved-workflow-loader.test.ts
+++ b/packages/cli/src/services/saved-workflow-loader.test.ts
@@ -70,11 +70,9 @@ describe('SavedWorkflowLoader', () => {
     expect(c.kind).toBe(CommandKind.FILE);
     expect(c.source).toBe('workflow-command');
     expect(c.sourceDetail).toBe('project');
-    expect(c.supportedModes).toEqual([
-      'interactive',
-      'non_interactive',
-      'acp',
-    ]);
+    // Interactive only — the tool-dispatch action can't run in headless / ACP,
+    // so advertising those modes would surface a command that then fails.
+    expect(c.supportedModes).toEqual(['interactive']);
   });
 
   it('action dispatches the workflow tool with the scriptPath', async () => {

--- a/packages/cli/src/services/saved-workflow-loader.test.ts
+++ b/packages/cli/src/services/saved-workflow-loader.test.ts
@@ -1,0 +1,182 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@qwen-code/qwen-code-core')>();
+  return {
+    ...actual,
+    listSavedWorkflows: vi.fn(),
+  };
+});
+
+import {
+  listSavedWorkflows,
+  type Config,
+  type SavedWorkflowEntry,
+} from '@qwen-code/qwen-code-core';
+import { SavedWorkflowLoader } from './saved-workflow-loader.js';
+import { CommandKind, type CommandContext } from '../ui/commands/types.js';
+
+const listMock = vi.mocked(listSavedWorkflows);
+
+function makeConfig(overrides: Partial<Record<string, unknown>> = {}): Config {
+  return {
+    isWorkflowsEnabled: () => true,
+    getBareMode: () => false,
+    getFolderTrustFeature: () => false,
+    getFolderTrust: () => false,
+    ...overrides,
+  } as unknown as Config;
+}
+
+const ctx = {} as CommandContext;
+const signal = new AbortController().signal;
+
+function entry(overrides: Partial<SavedWorkflowEntry> = {}): SavedWorkflowEntry {
+  return {
+    name: 'deep-research',
+    scriptPath: '/proj/.qwen/workflows/deep-research.js',
+    source: 'project',
+    ...overrides,
+  };
+}
+
+describe('SavedWorkflowLoader', () => {
+  beforeEach(() => {
+    listMock.mockReset();
+    listMock.mockResolvedValue([]);
+  });
+
+  it('builds one tool-dispatch command per discovered workflow', async () => {
+    listMock.mockResolvedValue([
+      entry({ name: 'deep-research', source: 'project' }),
+      entry({
+        name: 'triage',
+        scriptPath: '/home/.qwen/workflows/triage.js',
+        source: 'user',
+      }),
+    ]);
+    const cmds = await new SavedWorkflowLoader(makeConfig()).loadCommands(
+      signal,
+    );
+    expect(cmds.map((c) => c.name)).toEqual(['deep-research', 'triage']);
+    const c = cmds[0];
+    expect(c.kind).toBe(CommandKind.FILE);
+    expect(c.source).toBe('workflow-command');
+    expect(c.sourceDetail).toBe('project');
+    expect(c.supportedModes).toEqual([
+      'interactive',
+      'non_interactive',
+      'acp',
+    ]);
+  });
+
+  it('action dispatches the workflow tool with the scriptPath', async () => {
+    listMock.mockResolvedValue([entry()]);
+    const [cmd] = await new SavedWorkflowLoader(makeConfig()).loadCommands(
+      signal,
+    );
+    const result = await cmd.action!(ctx, '');
+    expect(result).toEqual({
+      type: 'tool',
+      toolName: 'workflow',
+      toolArgs: { scriptPath: '/proj/.qwen/workflows/deep-research.js' },
+    });
+  });
+
+  it('parses JSON args and forwards them as the `args` global', async () => {
+    listMock.mockResolvedValue([entry()]);
+    const [cmd] = await new SavedWorkflowLoader(makeConfig()).loadCommands(
+      signal,
+    );
+    const result = await cmd.action!(ctx, '{"topic":"llms","depth":3}');
+    expect(result).toMatchObject({
+      type: 'tool',
+      toolName: 'workflow',
+      toolArgs: {
+        scriptPath: '/proj/.qwen/workflows/deep-research.js',
+        args: { topic: 'llms', depth: 3 },
+      },
+    });
+  });
+
+  it('forwards non-JSON args as a raw string', async () => {
+    listMock.mockResolvedValue([entry()]);
+    const [cmd] = await new SavedWorkflowLoader(makeConfig()).loadCommands(
+      signal,
+    );
+    const result = await cmd.action!(ctx, 'just some text');
+    expect(result).toMatchObject({
+      toolArgs: { args: 'just some text' },
+    });
+  });
+
+  it('omits `args` when no input is supplied', async () => {
+    listMock.mockResolvedValue([entry()]);
+    const [cmd] = await new SavedWorkflowLoader(makeConfig()).loadCommands(
+      signal,
+    );
+    const result = (await cmd.action!(ctx, '   ')) as {
+      toolArgs: Record<string, unknown>;
+    };
+    expect('args' in result.toolArgs).toBe(false);
+  });
+
+  it('returns [] when workflows are disabled (tool not registered)', async () => {
+    listMock.mockResolvedValue([entry()]);
+    const cmds = await new SavedWorkflowLoader(
+      makeConfig({ isWorkflowsEnabled: () => false }),
+    ).loadCommands(signal);
+    expect(cmds).toEqual([]);
+    expect(listMock).not.toHaveBeenCalled();
+  });
+
+  it('returns [] in bare mode', async () => {
+    listMock.mockResolvedValue([entry()]);
+    const cmds = await new SavedWorkflowLoader(
+      makeConfig({ getBareMode: () => true }),
+    ).loadCommands(signal);
+    expect(cmds).toEqual([]);
+    expect(listMock).not.toHaveBeenCalled();
+  });
+
+  it('returns [] when folder trust is enabled but the folder is untrusted', async () => {
+    listMock.mockResolvedValue([entry()]);
+    const cmds = await new SavedWorkflowLoader(
+      makeConfig({
+        getFolderTrustFeature: () => true,
+        getFolderTrust: () => false,
+      }),
+    ).loadCommands(signal);
+    expect(cmds).toEqual([]);
+    expect(listMock).not.toHaveBeenCalled();
+  });
+
+  it('returns [] for a null config', async () => {
+    const cmds = await new SavedWorkflowLoader(null).loadCommands(signal);
+    expect(cmds).toEqual([]);
+  });
+
+  it('swallows enumeration errors and returns []', async () => {
+    listMock.mockRejectedValue(new Error('readdir blew up'));
+    const cmds = await new SavedWorkflowLoader(makeConfig()).loadCommands(
+      signal,
+    );
+    expect(cmds).toEqual([]);
+  });
+
+  it('returns [] when the signal aborts during enumeration', async () => {
+    listMock.mockResolvedValue([entry()]);
+    const aborted = AbortSignal.abort();
+    const cmds = await new SavedWorkflowLoader(makeConfig()).loadCommands(
+      aborted,
+    );
+    expect(cmds).toEqual([]);
+  });
+});

--- a/packages/cli/src/services/saved-workflow-loader.ts
+++ b/packages/cli/src/services/saved-workflow-loader.ts
@@ -70,7 +70,11 @@ export class SavedWorkflowLoader implements ICommandLoader {
       source: 'workflow-command',
       sourceLabel: 'Workflow',
       sourceDetail: entry.source, // 'project' | 'user'
-      supportedModes: ['interactive', 'non_interactive', 'acp'],
+      // Interactive only: the action returns a `{type:'tool'}` dispatch, which
+      // the non-interactive command adapter converts to `unsupported`. Listing
+      // these in headless / ACP modes would advertise a command that then fails
+      // to run, so restrict them until those paths can execute a tool return.
+      supportedModes: ['interactive'],
       acceptsInput: true,
       argumentHint: '[json-args]',
       action: (

--- a/packages/cli/src/services/saved-workflow-loader.ts
+++ b/packages/cli/src/services/saved-workflow-loader.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Discovers saved workflow scripts under `.qwen/workflows/`
+ * (project) and `~/.qwen/workflows/` (user) and exposes each as a `/<name>`
+ * slash command that dispatches the `workflow` tool with the file's path.
+ * The script is read at execution time (by the tool), so edits to a saved
+ * workflow take effect on the next invocation.
+ *
+ * Enumeration, project-over-user precedence, and the name constraint all live
+ * in core's `listSavedWorkflows` — the single source of truth shared with the
+ * `workflow('<name>')` in-script global. This loader only adapts the
+ * discovered entries into `SlashCommand` objects.
+ */
+
+import type { Config, SavedWorkflowEntry } from '@qwen-code/qwen-code-core';
+import {
+  listSavedWorkflows,
+  ToolNames,
+  createDebugLogger,
+} from '@qwen-code/qwen-code-core';
+import type { ICommandLoader } from './types.js';
+import type {
+  CommandContext,
+  SlashCommand,
+  SlashCommandActionReturn,
+} from '../ui/commands/types.js';
+import { CommandKind } from '../ui/commands/types.js';
+
+const debugLogger = createDebugLogger('SavedWorkflowLoader');
+
+export class SavedWorkflowLoader implements ICommandLoader {
+  constructor(private readonly config: Config | null) {}
+
+  async loadCommands(signal: AbortSignal): Promise<SlashCommand[]> {
+    if (!this.config) return [];
+    // Feature gate: the `workflow` tool is only registered when the feature
+    // flag is on, so without this guard the commands would dispatch a tool
+    // that doesn't exist.
+    if (!this.config.isWorkflowsEnabled?.()) return [];
+    // Mirror FileCommandLoader: saved workflows execute project-local code, so
+    // skip discovery in bare mode and in untrusted folders.
+    if (this.config.getBareMode?.()) return [];
+    const folderTrustEnabled = !!this.config.getFolderTrustFeature?.();
+    const folderTrust = !!this.config.getFolderTrust?.();
+    if (folderTrustEnabled && !folderTrust) return [];
+
+    let entries: SavedWorkflowEntry[];
+    try {
+      entries = await listSavedWorkflows(this.config);
+    } catch (e) {
+      debugLogger.debug(`listSavedWorkflows failed: ${e}`);
+      return [];
+    }
+    if (signal.aborted) return [];
+    return entries.map((entry) => this.toCommand(entry));
+  }
+
+  private toCommand(entry: SavedWorkflowEntry): SlashCommand {
+    return {
+      name: entry.name,
+      description: `Run the "${entry.name}" saved workflow (${entry.source})`,
+      // File-derived command (all execution modes via commandUtils fallback);
+      // `source` carries the distinct workflow identity for display/telemetry.
+      kind: CommandKind.FILE,
+      source: 'workflow-command',
+      sourceLabel: 'Workflow',
+      sourceDetail: entry.source, // 'project' | 'user'
+      supportedModes: ['interactive', 'non_interactive', 'acp'],
+      acceptsInput: true,
+      argumentHint: '[json-args]',
+      action: (
+        _context: CommandContext,
+        args: string,
+      ): SlashCommandActionReturn => {
+        const toolArgs: Record<string, unknown> = {
+          // The tool reads the file fresh at execution time (hot reload).
+          scriptPath: entry.scriptPath,
+        };
+        const trimmed = (args ?? '').trim();
+        if (trimmed.length > 0) {
+          // Forward user-supplied text to the script's `args` global. Parse as
+          // JSON when valid (objects / arrays / numbers — matching the tool's
+          // "actual JSON value" contract), else pass the raw string so plain
+          // text still reaches the script.
+          toolArgs['args'] = tryParseJson(trimmed);
+        }
+        return {
+          type: 'tool',
+          toolName: ToolNames.WORKFLOW,
+          toolArgs,
+        };
+      },
+    };
+  }
+}
+
+function tryParseJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -152,6 +152,10 @@ import {
 import type { TrackedExecutingToolCall } from './hooks/useReactToolScheduler.js';
 import { useVim } from './hooks/vim.js';
 import { isBtwCommand, isSlashCommand } from './utils/commandUtils.js';
+import {
+  detectWorkflowKeyword,
+  buildWorkflowSteeringNotice,
+} from './utils/workflow-keyword.js';
 import { type LoadedSettings, SettingScope } from '../config/settings.js';
 import { type InitializationResult } from '../core/initializer.js';
 import { useFocus } from './hooks/useFocus.js';
@@ -495,6 +499,10 @@ export const AppContainer = (props: AppContainerProps) => {
   const branchName = useGitBranchName(config.getTargetDir());
   const worktreeSession = useWorktreeSession(config);
   const [showWorktreeExitDialog, setShowWorktreeExitDialog] = useState(false);
+  // P7-trigger: true while the current turn was steered toward the Workflow
+  // tool by the `workflow` keyword (drives the Footer indicator). Set in
+  // `handleFinalSubmit`, cleared when the turn returns to idle (effect below).
+  const [workflowKeywordActive, setWorkflowKeywordActive] = useState(false);
   /**
    * One-shot worktree restore reminder for the TUI path. Set during
    * `--resume` when the persisted sidecar names a live worktree, then
@@ -1521,6 +1529,9 @@ export const AppContainer = (props: AppContainerProps) => {
   useEffect(() => {
     if (streamingState === StreamingState.Idle) {
       updateHandlerRef.current?.flush();
+      // P7-trigger: a steered turn has finished — drop the `workflow active`
+      // indicator until the next keyword prompt re-arms it.
+      setWorkflowKeywordActive(false);
     }
   }, [streamingState]);
 
@@ -1737,6 +1748,9 @@ export const AppContainer = (props: AppContainerProps) => {
           return;
         }
       }
+      // The user's raw text, captured before any `<system-reminder>` prefix is
+      // prepended below (so keyword detection sees only what the user typed).
+      const userPromptText = submittedValue;
       // Phase C: one-shot worktree restore reminder. Set during --resume
       // when the persisted sidecar names a live worktree. We only inject
       // on top-level user prompts (not btw-during-response, not slash
@@ -1747,6 +1761,25 @@ export const AppContainer = (props: AppContainerProps) => {
         pendingWorktreeNoticeRef.current = null;
         submittedValue =
           `<system-reminder>\n${worktreeNotice}\n</system-reminder>\n\n` +
+          submittedValue;
+      }
+      // P7-trigger: when the user's prompt mentions `workflow`, softly steer
+      // this turn toward the Workflow tool (same one-shot reminder mechanism
+      // as the worktree notice). Detect on the user's original text — `notice`
+      // above only adds system text, never the keyword. Gated on the feature
+      // flag + the opt-out setting; skipped for slash commands. The model
+      // keeps discretion, so a casual mention can't force a tool call.
+      const workflowTriggerEnabled =
+        config.isWorkflowsEnabled() &&
+        !settings.merged.ui?.disableWorkflowKeywordTrigger;
+      if (
+        workflowTriggerEnabled &&
+        !isSlashCommand(userPromptText) &&
+        detectWorkflowKeyword(userPromptText)
+      ) {
+        setWorkflowKeywordActive(true);
+        submittedValue =
+          `<system-reminder>\n${buildWorkflowSteeringNotice()}\n</system-reminder>\n\n` +
           submittedValue;
       }
       if (
@@ -1904,6 +1937,7 @@ export const AppContainer = (props: AppContainerProps) => {
       config,
       geminiClient,
       historyManager,
+      settings.merged.ui?.disableWorkflowKeywordTrigger,
     ],
   );
 
@@ -3465,6 +3499,7 @@ export const AppContainer = (props: AppContainerProps) => {
       branchName,
       activeWorktree,
       showWorktreeExitDialog,
+      workflowKeywordActive,
       sessionStats,
       terminalWidth,
       terminalHeight,
@@ -3599,6 +3634,7 @@ export const AppContainer = (props: AppContainerProps) => {
       branchName,
       activeWorktree,
       showWorktreeExitDialog,
+      workflowKeywordActive,
       sessionStats,
       terminalWidth,
       terminalHeight,

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -172,6 +172,7 @@ import { type IdeIntegrationNudgeResult } from './IdeIntegrationNudge.js';
 import { type CommandMigrationNudgeResult } from './CommandFormatMigrationNudge.js';
 import { useCommandMigration } from './hooks/useCommandMigration.js';
 import { migrateTomlCommands } from '../services/command-migration-tool.js';
+import { sendNotification } from '../services/notificationService.js';
 import { type UpdateObject } from './utils/updateCheck.js';
 import { setUpdateHandler } from '../utils/handleAutoUpdate.js';
 import { registerCleanup, runExitCleanup } from '../utils/cleanup.js';
@@ -2946,6 +2947,29 @@ export const AppContainer = (props: AppContainerProps) => {
     terminal,
     pendingToolCalls,
   });
+
+  // P-notif: terminal-bell when a workflow run finishes (completed / failed),
+  // so a long run ending is noticed without watching the /workflows dialog.
+  // User-initiated cancels are intentionally not notified (the registry omits
+  // them). Separate from the dialog's status-change subscription.
+  const workflowBellEnabled =
+    (settings.merged.general?.terminalBell as boolean) ?? true;
+  useEffect(() => {
+    const registry = config.getWorkflowRunRegistry?.();
+    // Optional call: production always has `setNotificationCallback`, but
+    // partial registry mocks in CLI tests may omit it — no-op rather than throw.
+    if (!registry?.setNotificationCallback) return;
+    registry.setNotificationCallback((entry) => {
+      const name = entry.meta?.name ?? entry.runId;
+      const verb = entry.status === 'failed' ? 'failed' : 'completed';
+      sendNotification(
+        { message: `Workflow '${name}' ${verb}`, title: 'Qwen Code' },
+        terminal,
+        workflowBellEnabled,
+      );
+    });
+    return () => registry.setNotificationCallback(undefined);
+  }, [config, terminal, workflowBellEnabled]);
 
   // Dialog close functionality
   const { closeAnyOpenDialog } = useDialogClose({

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -50,6 +50,8 @@ import {
   PromptSuggestionEvent,
   logSpeculation,
   SpeculationEvent,
+  logWorkflowKeyword,
+  WorkflowKeywordEvent,
   startSpeculation,
   acceptSpeculation,
   abortSpeculation,
@@ -1779,6 +1781,7 @@ export const AppContainer = (props: AppContainerProps) => {
         detectWorkflowKeyword(userPromptText)
       ) {
         setWorkflowKeywordActive(true);
+        logWorkflowKeyword(config, new WorkflowKeywordEvent());
         submittedValue =
           `<system-reminder>\n${buildWorkflowSteeringNotice()}\n</system-reminder>\n\n` +
           submittedValue;

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1778,6 +1778,10 @@ export const AppContainer = (props: AppContainerProps) => {
       if (
         workflowTriggerEnabled &&
         !isSlashCommand(userPromptText) &&
+        // Skip `?btw`/`/btw` side-questions: prefixing a system-reminder would
+        // break the BTW routing check below (which tests `submittedValue`),
+        // queuing the side question as a normal prompt instead.
+        !isBtwCommand(userPromptText) &&
         detectWorkflowKeyword(userPromptText)
       ) {
         setWorkflowKeywordActive(true);

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -280,9 +280,9 @@ export type CommandSource =
   | 'bundled-skill' // BundledSkillLoader
   | 'skill-dir-command' // FileCommandLoader (user/project, no extensionName)
   | 'plugin-command' // FileCommandLoader (extension, extensionName set)
-  | 'mcp-prompt'; // McpPromptLoader
+  | 'mcp-prompt' // McpPromptLoader
+  | 'workflow-command'; // SavedWorkflowLoader (.qwen/workflows/<name>.js)
 // Reserved for future loaders (not implemented in Phase 1):
-// | 'workflow-command'
 // | 'plugin-skill'
 // | 'dynamic-skill'
 

--- a/packages/cli/src/ui/commands/workflowsCommand.test.ts
+++ b/packages/cli/src/ui/commands/workflowsCommand.test.ts
@@ -4,11 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { workflowsCommand } from './workflowsCommand.js';
 import { type CommandContext } from './types.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
-import type { WorkflowTask } from '@qwen-code/qwen-code-core';
+import type { WorkflowTask, WorkflowSnapshot } from '@qwen-code/qwen-code-core';
 
 function entry(overrides: Partial<WorkflowTask> = {}): WorkflowTask {
   return {
@@ -31,6 +34,7 @@ function entry(overrides: Partial<WorkflowTask> = {}): WorkflowTask {
     tokensSpent: 0,
     tokenBudgetTotal: null,
     perPhaseTokens: new Map<string | null, number>(),
+    script: '',
     ...overrides,
   };
 }
@@ -259,5 +263,133 @@ describe('workflowsCommand', () => {
     if (!result || result.type !== 'message') throw new Error('no result');
     expect(result.content).toContain('tokens      : 0');
     expect(result.content).toContain('cap         : (no cap)');
+  });
+
+  // ── P7b: persisted snapshots merged into the listing + detail view ─────
+  describe('P7b: persisted snapshots', () => {
+    const tmpDirs: string[] = [];
+
+    function snapshot(overrides: Partial<WorkflowSnapshot> = {}): WorkflowSnapshot {
+      return {
+        runId: 'wf_snap',
+        meta: null,
+        status: 'completed',
+        script: '',
+        phases: [],
+        agentsDispatched: 0,
+        agentsCompleted: 0,
+        tokensSpent: 0,
+        tokenBudgetTotal: null,
+        perPhaseTokens: [],
+        recentLogs: [],
+        startTime: 1_700_000_000_000,
+        endTime: 1_700_000_005_000,
+        ...overrides,
+      };
+    }
+
+    // Write snapshot JSON files into a fresh temp dir and return a context
+    // whose `config.storage.getWorkflowRunsDir()` points at it. This drives
+    // the real `listWorkflowSnapshots` (no module mocking).
+    async function ctxWithSnapshots(
+      snaps: Array<Partial<WorkflowSnapshot>>,
+      mode: 'interactive' | 'non_interactive' = 'interactive',
+    ): Promise<CommandContext> {
+      const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'wf-snap-'));
+      tmpDirs.push(dir);
+      for (const s of snaps) {
+        const snap = snapshot(s);
+        await fs.writeFile(
+          path.join(dir, `${snap.runId}.json`),
+          JSON.stringify(snap),
+          'utf8',
+        );
+      }
+      return createMockCommandContext({
+        services: {
+          config: {
+            getWorkflowRunRegistry: () => ({ list: listMock, get: getMock }),
+            storage: { getWorkflowRunsDir: () => dir },
+          },
+        },
+        executionMode: mode,
+      } as unknown as Parameters<typeof createMockCommandContext>[0]);
+    }
+
+    afterEach(async () => {
+      await Promise.all(
+        tmpDirs.splice(0).map((d) =>
+          fs.rm(d, { recursive: true, force: true }).catch(() => {}),
+        ),
+      );
+    });
+
+    it('surfaces a persisted run in Recent when the live registry is empty', async () => {
+      listMock.mockReturnValue([]);
+      const ctx = await ctxWithSnapshots([
+        { runId: 'wf_persisted', meta: { name: 'oldrun', description: 'd' } },
+      ]);
+      const result = await workflowsCommand.action!(ctx, '');
+      if (!result || result.type !== 'message') throw new Error('no result');
+      expect(result.content).toContain('Workflow runs (1 total · 0 running)');
+      expect(result.content).toContain('Recent');
+      expect(result.content).toContain('wf_persisted');
+      expect(result.content).toContain('oldrun');
+    });
+
+    it('live registry entry shadows a same-runId snapshot (no duplicate row)', async () => {
+      listMock.mockReturnValue([
+        entry({
+          runId: 'wf_dup',
+          meta: { name: 'live-name', description: 'd' },
+          status: 'completed',
+          endTime: 1_700_000_010_000,
+        }),
+      ]);
+      const ctx = await ctxWithSnapshots([
+        { runId: 'wf_dup', meta: { name: 'disk-name', description: 'd' } },
+      ]);
+      const result = await workflowsCommand.action!(ctx, '');
+      if (!result || result.type !== 'message') throw new Error('no result');
+      // Exactly one entry total; the live entry's meta wins, disk is dropped.
+      expect(result.content).toContain('Workflow runs (1 total · 0 running)');
+      expect(result.content).toContain('live-name');
+      expect(result.content).not.toContain('disk-name');
+      expect(result.content.match(/wf_dup/g)?.length).toBe(1);
+    });
+
+    it('detail view falls back to a persisted snapshot on registry miss', async () => {
+      getMock.mockReturnValue(undefined);
+      const ctx = await ctxWithSnapshots([
+        {
+          runId: 'wf_old',
+          meta: { name: 'demo', description: 'd' },
+          phases: ['A', 'B'],
+          agentsDispatched: 2,
+          agentsCompleted: 2,
+          recentLogs: ['log-from-disk'],
+          perPhaseTokens: [['A', 300]],
+          tokensSpent: 300,
+        },
+      ]);
+      const result = await workflowsCommand.action!(ctx, 'wf_old');
+      if (!result || result.type !== 'message') throw new Error('no result');
+      expect(result.messageType).toBe('info');
+      expect(result.content).toContain('Workflow wf_old');
+      expect(result.content).toContain('· A · 300t');
+      expect(result.content).toContain('· B');
+      expect(result.content).toContain('log-from-disk');
+    });
+
+    it('detail view errors when neither registry nor snapshots have the runId', async () => {
+      getMock.mockReturnValue(undefined);
+      const ctx = await ctxWithSnapshots([{ runId: 'wf_other' }]);
+      const result = await workflowsCommand.action!(ctx, 'wf_ghost');
+      expect(result).toMatchObject({
+        type: 'message',
+        messageType: 'error',
+        content: 'Unknown workflow runId: wf_ghost',
+      });
+    });
   });
 });

--- a/packages/cli/src/ui/commands/workflowsCommand.ts
+++ b/packages/cli/src/ui/commands/workflowsCommand.ts
@@ -4,11 +4,47 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { WorkflowTask } from '@qwen-code/qwen-code-core';
+import type { WorkflowTask, WorkflowSnapshot } from '@qwen-code/qwen-code-core';
+import { listWorkflowSnapshots } from '@qwen-code/qwen-code-core';
 import type { SlashCommand } from './types.js';
 import { CommandKind } from './types.js';
 import { t } from '../../i18n/index.js';
 import { formatDuration, formatTokenCount } from '../utils/formatters.js';
+
+/**
+ * P7b: adapt a persisted snapshot to the `WorkflowTask` shape the row /
+ * detail formatters expect. The dialog-only fields (`abortController`,
+ * `outputFile`, etc.) are filled with inert values — a snapshot is always
+ * terminal, so the controls that read those fields are never reached.
+ */
+function snapshotToTask(s: WorkflowSnapshot): WorkflowTask {
+  return {
+    id: s.runId,
+    kind: 'workflow',
+    runId: s.runId,
+    description: s.meta?.name ?? s.runId,
+    meta: s.meta,
+    status: s.status,
+    currentPhase: null,
+    phases: s.phases ?? [],
+    agentsDispatched: s.agentsDispatched ?? 0,
+    agentsCompleted: s.agentsCompleted ?? 0,
+    recentLogs: s.recentLogs ?? [],
+    tokensSpent: s.tokensSpent ?? 0,
+    tokenBudgetTotal: s.tokenBudgetTotal ?? null,
+    perPhaseTokens: new Map(s.perPhaseTokens ?? []),
+    script: s.script ?? '',
+    scriptPath: s.scriptPath,
+    result: s.result,
+    error: s.error,
+    startTime: s.startTime,
+    endTime: s.endTime,
+    outputFile: '',
+    outputOffset: 0,
+    notified: true,
+    abortController: new AbortController(),
+  } as WorkflowTask;
+}
 
 /**
  * Format one workflow run as a one-line summary used by both the
@@ -144,7 +180,16 @@ export const workflowsCommand: SlashCommand = {
     // the user sees a clear error instead of an empty listing.
     const trimmedArgs = (args ?? '').trim();
     if (trimmedArgs.length > 0) {
-      const target = registry.get(trimmedArgs);
+      let target = registry.get(trimmedArgs);
+      if (!target) {
+        // Fall back to a persisted snapshot — the run may predate this CLI
+        // process (the in-memory registry dies with the process, the
+        // snapshot on disk does not).
+        const snapshot = (await listWorkflowSnapshots(config)).find(
+          (s) => s.runId === trimmedArgs,
+        );
+        if (snapshot) target = snapshotToTask(snapshot);
+      }
       if (!target) {
         return {
           type: 'message' as const,
@@ -159,7 +204,16 @@ export const workflowsCommand: SlashCommand = {
       };
     }
 
-    if (allEntries.length === 0) {
+    // Merge persisted snapshots (runs from earlier CLI processes) into the
+    // listing. In-memory registry entries win on a runId collision — they
+    // carry live status, while a snapshot is a frozen terminal projection.
+    const snapshots = await listWorkflowSnapshots(config);
+    const liveRunIds = new Set(allEntries.map((e) => e.runId));
+    const snapshotTasks = snapshots
+      .filter((s) => !liveRunIds.has(s.runId))
+      .map(snapshotToTask);
+
+    if (allEntries.length === 0 && snapshotTasks.length === 0) {
       return {
         type: 'message' as const,
         messageType: 'info' as const,
@@ -170,13 +224,15 @@ export const workflowsCommand: SlashCommand = {
     const now = Date.now();
     // Order: running first (oldest startTime first inside the bucket so
     // long-runners stay visible), then terminal by endTime DESC. Mirrors
-    // the dialog's two-bucket sort.
+    // the dialog's two-bucket sort. Snapshots are always terminal, so they
+    // only ever join the second bucket.
     const running = allEntries
       .filter((e) => e.status === 'running')
       .sort((a, b) => a.startTime - b.startTime);
-    const terminal = allEntries
-      .filter((e) => e.status !== 'running')
-      .sort((a, b) => (b.endTime ?? 0) - (a.endTime ?? 0));
+    const terminal = [
+      ...allEntries.filter((e) => e.status !== 'running'),
+      ...snapshotTasks,
+    ].sort((a, b) => (b.endTime ?? 0) - (a.endTime ?? 0));
 
     const lines: string[] = [];
     if (context.executionMode === 'interactive') {
@@ -188,7 +244,7 @@ export const workflowsCommand: SlashCommand = {
       );
     }
     lines.push(
-      `Workflow runs (${allEntries.length} total · ${running.length} running)`,
+      `Workflow runs (${running.length + terminal.length} total · ${running.length} running)`,
       '',
     );
     if (running.length > 0) {

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -126,6 +126,19 @@ describe('<Footer />', () => {
     expect(lastFrame()).toBeDefined();
   });
 
+  it('shows the "workflow active" indicator when the keyword trigger is armed', () => {
+    const { lastFrame } = renderWithWidth(
+      120,
+      createMockUIState({ workflowKeywordActive: true }),
+    );
+    expect(lastFrame()).toContain('workflow active');
+  });
+
+  it('hides the "workflow active" indicator by default', () => {
+    const { lastFrame } = renderWithWidth(120, createMockUIState());
+    expect(lastFrame()).not.toContain('workflow active');
+  });
+
   it('does not display the working directory or branch name', () => {
     const { lastFrame } = renderWithWidth(120, createMockUIState());
     expect(lastFrame()).not.toMatch(/\(.*\*\)/);

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -202,6 +202,16 @@ export const Footer: React.FC = () => {
               {`⎇ ${uiState.activeWorktree.branch} (${uiState.activeWorktree.slug})`}
             </Text>
           )}
+        {/* P7-trigger: the current turn was steered toward the Workflow tool
+            by the `workflow` keyword. Hidden during ctrl-quit warnings so they
+            take precedence (matches the worktree indicator above). */}
+        {uiState.workflowKeywordActive &&
+          !uiState.ctrlCPressedOnce &&
+          !uiState.ctrlDPressedOnce && (
+            <Text color={theme.text.accent} wrap="truncate">
+              {`⚙ ${t('workflow active')}`}
+            </Text>
+          )}
         <Box flexDirection="row" flexShrink={1}>
           <Text wrap="truncate">{leftBottomContent}</Text>
           <BackgroundTasksPill />

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -4911,6 +4911,45 @@ describe('InputPrompt', () => {
       unmount();
     });
 
+    it('arrow Down focuses the background-tasks pill when only the pill is shown (workflow-only session)', async () => {
+      // Branch 3 of descendFromComposer: no Arena roster (agents empty) and no
+      // live bg-agent panel, but a workflow run keeps the background-tasks pill
+      // on screen. ↓ from the empty composer must focus the pill so the run's
+      // detail/save dialog stays reachable — without this branch a
+      // workflow-only session could never open it.
+      (mockInputHistory.navigateDown as Mock).mockReturnValue(false);
+      mockedUseAgentViewState.mockReturnValue({
+        activeView: 'main',
+        agents: new Map(),
+        agentShellFocused: false,
+        agentInputBufferText: '',
+        agentTabBarFocused: false,
+        agentApprovalModes: new Map(),
+      } as unknown as ReturnType<typeof useAgentViewState>);
+      mockedUseBackgroundTaskViewState.mockReturnValue({
+        entries: [{ kind: 'workflow', runId: 'wf-1', status: 'running' }],
+        selectedIndex: 0,
+        dialogMode: 'closed',
+        dialogOpen: false,
+        pillFocused: false,
+        livePanelFocused: false,
+        livePanelSelectedIndex: 0,
+      } as unknown as ReturnType<typeof useBackgroundTaskViewState>);
+      mockBuffer.setText('');
+      mockBuffer.visualCursor = [0, 0];
+
+      const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+      await wait();
+
+      stdin.write('[B'); // Down arrow at the bottom edge
+      await wait();
+
+      expect(mockViewActions.setBgPillFocused).toHaveBeenCalledWith(true);
+      expect(mockViewActions.setAgentTabBarFocused).not.toHaveBeenCalled();
+      expect(mockViewActions.setLivePanelFocused).not.toHaveBeenCalled();
+      unmount();
+    });
+
     it('Down at the bottom of the live agent panel descends to the agent tab bar', async () => {
       // Restores tab-bar reachability after the priority swap: from the panel's
       // last row, Down hands focus to the tab bar (the surface below it).

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -658,7 +658,9 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
   // Down from an empty composer (bottom edge, history exhausted), in visual
   // top→bottom order: live agent panel (if bg sub-agents) → tab bar (if
-  // Arena) → stay put. Always consumes the key.
+  // Arena) → background-tasks pill (if bg entries) → stay put. Always
+  // consumes the key. When both an Arena tab bar and the pill are shown,
+  // ↓ stops at the tab bar; AgentTabBar's own ↓ then descends into the pill.
   const descendFromComposer = useCallback((): boolean => {
     if (getVisibleBgAgents().length > 0) {
       setLivePanelFocused(true);

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -184,6 +184,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     setLivePanelSelectedIndex,
     enterDetailFromPanel: enterBgDetailFromPanel,
     setSelectedIndex: setBgSelectedIndex,
+    setPillFocused: setBgPillFocused,
   } = useBackgroundTaskViewActions();
   const hasAgents = agents.size > 0;
   const getVisibleBgAgents = useCallback(
@@ -663,13 +664,22 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       setLivePanelFocused(true);
     } else if (hasAgents) {
       setAgentTabBarFocused(true);
+    } else if (bgEntries.length > 0) {
+      // No live-agent panel and no Arena tab bar to descend into, but the
+      // background-tasks pill IS shown (e.g. a workflow run with no live
+      // sub-agents) — focus it so ↓ still reaches the dialog. Without this
+      // branch a workflow-only session can never open the BackgroundTasksDialog
+      // (and thus never reach the per-run detail view or the save action).
+      setBgPillFocused(true);
     }
     return true;
   }, [
     getVisibleBgAgents,
     hasAgents,
+    bgEntries,
     setLivePanelFocused,
     setAgentTabBarFocused,
+    setBgPillFocused,
   ]);
 
   // Single source of truth for "is there a suggestion the user can accept right

--- a/packages/cli/src/ui/components/agent-view/AgentTabBar.test.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentTabBar.test.tsx
@@ -47,6 +47,7 @@ const pressKey = (overrides: Partial<Key>) => {
 describe('AgentTabBar', () => {
   const setAgentTabBarFocused = vi.fn();
   const setLivePanelFocused = vi.fn();
+  const setPillFocused = vi.fn();
 
   // Point the mocked view state at a given tab; tab bar starts focused.
   const setActiveView = (activeView: string) =>
@@ -89,6 +90,7 @@ describe('AgentTabBar', () => {
     } as never);
     vi.mocked(useBackgroundTaskViewActions).mockReturnValue({
       setLivePanelFocused,
+      setPillFocused,
     } as never);
     vi.mocked(useUIState).mockReturnValue({
       embeddedShellFocused: false,
@@ -164,13 +166,33 @@ describe('AgentTabBar', () => {
     expect(setLivePanelFocused).not.toHaveBeenCalled();
   });
 
-  it('Down (↓ / Ctrl+N) is a no-op — the tab bar is the bottom of the focus chain', () => {
-    // Default mock has a bg agent roster present; Down must still do nothing
-    // (the panel is reached via ↑, not by hopping down off the bottom).
+  it('Down (↓ / Ctrl+N) descends into the background-tasks pill when one is shown', () => {
+    // Default mock has bg entries → the pill is rendered. Down releases tab-bar
+    // focus and hands it to the pill, completing the chain BackgroundTasksPill
+    // documents (Composer ↓ → AgentTabBar ↓ → Pill ↓ → Dialog).
+    render(<AgentTabBar />);
+
+    pressKey({ name: 'down', sequence: '[B' });
+    expect(setAgentTabBarFocused).toHaveBeenCalledWith(false);
+    expect(setPillFocused).toHaveBeenCalledWith(true);
+    expect(setLivePanelFocused).not.toHaveBeenCalled();
+
+    // Ctrl+N is the readline alias for Down and must behave identically.
+    pressKey({ name: 'n', ctrl: true });
+    expect(setPillFocused).toHaveBeenCalledTimes(2);
+  });
+
+  it('Down is a no-op when no background-tasks pill is shown (tab bar is the bottom)', () => {
+    // With no bg entries the pill is not rendered, so there is nothing below
+    // the tab bar to descend into — Down must do nothing.
+    vi.mocked(useBackgroundTaskViewState).mockReturnValue({
+      entries: [],
+    } as never);
     render(<AgentTabBar />);
 
     pressKey({ name: 'down', sequence: '[B' });
     pressKey({ name: 'n', ctrl: true });
+    expect(setPillFocused).not.toHaveBeenCalled();
     expect(setLivePanelFocused).not.toHaveBeenCalled();
     expect(setAgentTabBarFocused).not.toHaveBeenCalled();
   });

--- a/packages/cli/src/ui/components/agent-view/AgentTabBar.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentTabBar.tsx
@@ -15,7 +15,9 @@
  *   - Left/Right switch tabs only when the tab bar is focused
  *   - Up arrow: on Main with bg sub-agents → live agent panel; otherwise
  *     (agent tab, or no roster) → input. Typing also returns focus to input.
- *   - Down arrow is a no-op — the tab bar is the bottom of the focus chain
+ *   - Down arrow: descends into the background-tasks pill when one is shown
+ *     (a bg task / workflow is active); otherwise a no-op — the tab bar is
+ *     then the bottom of the focus chain
  *
  * Tab indicators:  running,  idle/completed,  failed,  cancelled
  */
@@ -69,7 +71,8 @@ export const AgentTabBar: React.FC = () => {
   const { switchToNext, switchToPrevious, setAgentTabBarFocused } =
     useAgentViewActions();
   const { entries: bgEntries } = useBackgroundTaskViewState();
-  const { setLivePanelFocused } = useBackgroundTaskViewActions();
+  const { setLivePanelFocused, setPillFocused } =
+    useBackgroundTaskViewActions();
   const { embeddedShellFocused } = useUIState();
   const hasVisibleBgAgentRoster = () =>
     bgEntries.some((e) => isLiveAgentPanelVisibleEntry(e, Date.now()));
@@ -92,8 +95,17 @@ export const AgentTabBar: React.FC = () => {
           setLivePanelFocused(true);
         }
       } else if (key.name === 'down' || (key.ctrl && key.name === 'n')) {
-        // No-op: the tab bar is the bottom of the chain
-        // (input → panel → tab bar); the panel is reached via ↑.
+        // The tab bar is normally the bottom of the chain (input → panel →
+        // tab bar; the panel is reached via ↑). But when the background-tasks
+        // pill is also shown (a bg task / workflow is active), ↓ descends one
+        // more step into the pill so it stays keyboard-reachable even with an
+        // Arena roster present — completing the chain BackgroundTasksPill.tsx
+        // documents (Composer ↓ → AgentTabBar ↓ → Pill ↓ → Dialog). Match
+        // InputPrompt's descendFromComposer pill branch: shown ⇔ bgEntries > 0.
+        if (bgEntries.length > 0) {
+          setAgentTabBarFocused(false);
+          setPillFocused(true);
+        }
       } else if (
         key.sequence &&
         key.sequence.length === 1 &&

--- a/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.tsx
+++ b/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.tsx
@@ -34,6 +34,7 @@ import {
   type WorkflowTask,
 } from '@qwen-code/qwen-code-core';
 import { ToolConfirmationMessage } from '../messages/ToolConfirmationMessage.js';
+import { WorkflowSaveOverlay } from './workflow-save-overlay.js';
 import { formatDuration, formatTokenCount } from '../../utils/formatters.js';
 import { escapeAnsiCtrlCodes } from '../../utils/textUtils.js';
 import {
@@ -1133,6 +1134,14 @@ export const BackgroundTasksDialog: React.FC<BackgroundTasksDialogProps> = ({
     string | null
   >(null);
 
+  // P7b-A3: when true, the workflow save overlay owns the keyboard (the main
+  // dialog handler yields). Reset whenever we leave detail mode so an armed
+  // save can't bleed into the list view.
+  const [saveActive, setSaveActive] = useState(false);
+  useEffect(() => {
+    if (!isDetailMode) setSaveActive(false);
+  }, [isDetailMode]);
+
   const selectedEntry = useMemo(() => {
     const fromSnapshot = entries[selectedIndex] ?? null;
     if (!fromSnapshot) return fromSnapshot;
@@ -1324,6 +1333,9 @@ export const BackgroundTasksDialog: React.FC<BackgroundTasksDialogProps> = ({
   useKeypress(
     (key) => {
       if (!dialogOpen) return;
+      // P7b-A3: the save overlay owns the keyboard while open — yield every
+      // key to it (its own `useKeypress` handles name input / scope / save).
+      if (saveActive) return;
       // While a parked approval is shown, the embedded ToolConfirmationMessage
       // owns the selection keys (↑/↓/numbers/Enter, Esc = deny this call).
       // Keep two escape hatches for compact approvals that don't have their
@@ -1389,6 +1401,21 @@ export const BackgroundTasksDialog: React.FC<BackgroundTasksDialogProps> = ({
       }
 
       // detail mode
+      // P7b-A3: `s` opens the save overlay for a completed workflow run that
+      // still carries its script source. Gated to terminal workflow entries
+      // so it never collides with a live run's controls.
+      if (
+        key.sequence === 's' &&
+        !key.ctrl &&
+        !key.meta &&
+        config &&
+        selectedEntry?.kind === 'workflow' &&
+        selectedEntry.status !== 'running' &&
+        !!selectedEntry.script
+      ) {
+        setSaveActive(true);
+        return;
+      }
       if (key.name === 'left') {
         // Reset the foreground confirm-step before leaving detail so the
         // armed state can't carry into list mode and turn a stray `x` into
@@ -1428,6 +1455,16 @@ export const BackgroundTasksDialog: React.FC<BackgroundTasksDialogProps> = ({
     selectedEntry.status === 'paused' &&
     !selectedEntry.resumeBlockedReason;
 
+  // P7b-A3: a completed workflow run that still carries its script source can
+  // be saved to `.qwen/workflows/<name>.js` from the detail view.
+  const workflowSaveTarget =
+    config &&
+    selectedEntry?.kind === 'workflow' &&
+    selectedEntry.status !== 'running' &&
+    selectedEntry.script
+      ? selectedEntry
+      : null;
+
   // Hint footer — context-sensitive.
   const selectedEntryKey = selectedEntry ? entryId(selectedEntry) : null;
   const showCancelConfirmHint =
@@ -1466,6 +1503,7 @@ export const BackgroundTasksDialog: React.FC<BackgroundTasksDialogProps> = ({
     if (selectedEntry?.kind === 'agent' && selectedEntry.status === 'paused') {
       hints.push('x abandon');
     }
+    if (workflowSaveTarget) hints.push('s save');
   }
 
   return (
@@ -1526,9 +1564,19 @@ export const BackgroundTasksDialog: React.FC<BackgroundTasksDialogProps> = ({
           </Box>
         )}
       </Box>
-      <Box marginTop={1} paddingX={1}>
-        <Text color={theme.text.secondary}>{hints.join(' \u00B7 ')}</Text>
-      </Box>
+      {saveActive && workflowSaveTarget && config ? (
+        <WorkflowSaveOverlay
+          script={workflowSaveTarget.script}
+          initialName={workflowSaveTarget.meta?.name ?? ''}
+          config={config}
+          isActive={saveActive}
+          onClose={() => setSaveActive(false)}
+        />
+      ) : (
+        <Box marginTop={1} paddingX={1}>
+          <Text color={theme.text.secondary}>{hints.join(' \u00B7 ')}</Text>
+        </Box>
+      )}
     </Box>
   );
 };

--- a/packages/cli/src/ui/components/background-view/workflow-save-overlay.test.tsx
+++ b/packages/cli/src/ui/components/background-view/workflow-save-overlay.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act } from '@testing-library/react';
+import { render } from 'ink-testing-library';
+
+vi.mock('../../hooks/useKeypress.js', () => ({ useKeypress: vi.fn() }));
+vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@qwen-code/qwen-code-core')>();
+  return { ...actual, saveWorkflowScript: vi.fn() };
+});
+
+import { useKeypress, type Key } from '../../hooks/useKeypress.js';
+import { saveWorkflowScript, type Config } from '@qwen-code/qwen-code-core';
+import { WorkflowSaveOverlay } from './workflow-save-overlay.js';
+
+const mockedUseKeypress = vi.mocked(useKeypress);
+const mockedSave = vi.mocked(saveWorkflowScript);
+
+function key(partial: Partial<Key>): Key {
+  return {
+    name: '',
+    ctrl: false,
+    meta: false,
+    shift: false,
+    paste: false,
+    sequence: '',
+    ...partial,
+  };
+}
+
+function setup(props: Partial<Parameters<typeof WorkflowSaveOverlay>[0]> = {}) {
+  const handlers: Array<(k: Key) => void> = [];
+  mockedUseKeypress.mockImplementation((cb, opts) => {
+    if (opts?.isActive !== false) handlers.push(cb as (k: Key) => void);
+  });
+  const onClose = vi.fn();
+  const { lastFrame } = render(
+    <WorkflowSaveOverlay
+      script="return 1;"
+      config={{} as Config}
+      isActive
+      onClose={onClose}
+      {...props}
+    />,
+  );
+  const press = async (k: Partial<Key>) => {
+    await act(async () => {
+      handlers[handlers.length - 1]?.(key(k));
+    });
+  };
+  const type = async (text: string) => {
+    for (const ch of text) await press({ name: ch, sequence: ch });
+  };
+  return { lastFrame, press, type, onClose };
+}
+
+describe('WorkflowSaveOverlay', () => {
+  beforeEach(() => {
+    mockedSave.mockReset();
+  });
+
+  it('renders the name field, scope toggle, and hints in edit phase', () => {
+    const { lastFrame } = setup();
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Save workflow');
+    expect(frame).toContain('project');
+    expect(frame).toContain('user');
+    expect(frame).toContain('Enter save');
+  });
+
+  it('appends typed characters to the name', async () => {
+    const { lastFrame, type } = setup();
+    await type('flow');
+    expect(lastFrame() ?? '').toContain('flow');
+  });
+
+  it('saves to project scope on submit, then closes on the next key', async () => {
+    mockedSave.mockResolvedValue({
+      status: 'saved',
+      name: 'flow',
+      scope: 'project',
+      path: '/proj/.qwen/workflows/flow.js',
+    });
+    const { lastFrame, type, press, onClose } = setup();
+    await type('flow');
+    await press({ name: 'return' });
+    expect(mockedSave).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        name: 'flow',
+        scope: 'project',
+        script: 'return 1;',
+        overwrite: false,
+      }),
+    );
+    expect(lastFrame() ?? '').toContain('Saved to /proj/.qwen/workflows/flow.js');
+    await press({ name: 'return' });
+    expect(onClose).toHaveBeenCalledWith('flow');
+  });
+
+  it('Tab toggles to user scope', async () => {
+    mockedSave.mockResolvedValue({
+      status: 'saved',
+      name: 'flow',
+      scope: 'user',
+      path: '/home/.qwen/workflows/flow.js',
+    });
+    const { type, press } = setup();
+    await type('flow');
+    await press({ name: 'tab' });
+    await press({ name: 'return' });
+    expect(mockedSave).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ scope: 'user' }),
+    );
+  });
+
+  it('rejects an invalid name without calling save', async () => {
+    const { type, press, lastFrame } = setup();
+    await type('Bad'); // leading uppercase → invalid
+    await press({ name: 'return' });
+    expect(mockedSave).not.toHaveBeenCalled();
+    expect(lastFrame() ?? '').toMatch(/Invalid workflow name|lower-case/);
+  });
+
+  it('Esc cancels without saving', async () => {
+    const { press, onClose } = setup();
+    await press({ name: 'escape' });
+    expect(onClose).toHaveBeenCalledWith();
+    expect(mockedSave).not.toHaveBeenCalled();
+  });
+
+  it('prompts to overwrite on collision and retries with overwrite:true', async () => {
+    mockedSave
+      .mockResolvedValueOnce({
+        status: 'exists',
+        name: 'flow',
+        scope: 'project',
+        path: '/proj/.qwen/workflows/flow.js',
+      })
+      .mockResolvedValueOnce({
+        status: 'saved',
+        name: 'flow',
+        scope: 'project',
+        path: '/proj/.qwen/workflows/flow.js',
+      });
+    const { type, press, lastFrame } = setup();
+    await type('flow');
+    await press({ name: 'return' });
+    expect(lastFrame() ?? '').toContain('already exists');
+    await press({ name: 'y', sequence: 'y' });
+    expect(mockedSave).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ overwrite: true }),
+    );
+  });
+});

--- a/packages/cli/src/ui/components/background-view/workflow-save-overlay.tsx
+++ b/packages/cli/src/ui/components/background-view/workflow-save-overlay.tsx
@@ -1,0 +1,232 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview P7b-A3: the "save this run as a reusable workflow" overlay
+ * shown inside the `/workflows` detail view. The user names the workflow,
+ * toggles project/user scope, and the run's verbatim script is written to
+ * `.qwen/workflows/<name>.js`. A name collision prompts for overwrite.
+ *
+ * Self-contained: it owns a single `useKeypress` (a minimal inline name
+ * editor — workflow names are short kebab-case strings, so the full readline
+ * machinery of `TextInput` is unnecessary and would fight this overlay for
+ * keys). The parent dialog yields all keys to this overlay while it is active.
+ */
+
+import type React from 'react';
+import { useState } from 'react';
+import { Box, Text } from 'ink';
+import {
+  type Config,
+  type SavedWorkflowSource,
+  saveWorkflowScript,
+  validateWorkflowName,
+} from '@qwen-code/qwen-code-core';
+import { useKeypress, type Key } from '../../hooks/useKeypress.js';
+import { theme } from '../../semantic-colors.js';
+import { t } from '../../../i18n/index.js';
+
+interface WorkflowSaveOverlayProps {
+  /** The completed run's script source; written verbatim on save. */
+  script: string;
+  /** Pre-fill the name field (e.g. from the run's `meta.name`). */
+  initialName?: string;
+  config: Config;
+  isActive: boolean;
+  /** Closes the overlay; `savedName` is set only on a successful save. */
+  onClose: (savedName?: string) => void;
+}
+
+type Phase = 'edit' | 'overwrite' | 'saving' | 'saved' | 'error';
+
+export const WorkflowSaveOverlay: React.FC<WorkflowSaveOverlayProps> = ({
+  script,
+  initialName = '',
+  config,
+  isActive,
+  onClose,
+}) => {
+  const [name, setName] = useState(initialName);
+  const [scope, setScope] = useState<SavedWorkflowSource>('project');
+  const [phase, setPhase] = useState<Phase>('edit');
+  const [message, setMessage] = useState<string>('');
+
+  // Live (non-blocking) name validation, shown under the field while editing.
+  const liveNameError = name.length > 0 ? validateWorkflowName(name) : null;
+
+  const doSave = async (overwrite: boolean) => {
+    setPhase('saving');
+    try {
+      const result = await saveWorkflowScript(config, {
+        name,
+        scope,
+        script,
+        overwrite,
+      });
+      switch (result.status) {
+        case 'saved':
+          setMessage(result.path);
+          setPhase('saved');
+          break;
+        case 'exists':
+          setMessage(result.path);
+          setPhase('overwrite');
+          break;
+        case 'invalid-name':
+        case 'empty-script':
+          setMessage(result.error);
+          setPhase('error');
+          break;
+        default:
+          break;
+      }
+    } catch (e) {
+      setMessage(e instanceof Error ? e.message : String(e));
+      setPhase('error');
+    }
+  };
+
+  useKeypress(
+    (key: Key) => {
+      if (phase === 'saving') return; // ignore keystrokes mid-write
+
+      if (phase === 'saved') {
+        onClose(name); // any key dismisses; tell the parent what was saved
+        return;
+      }
+      if (phase === 'error') {
+        setPhase('edit'); // any key returns to editing to fix the name
+        setMessage('');
+        return;
+      }
+      if (phase === 'overwrite') {
+        if (key.name === 'return' || key.sequence === 'y') {
+          void doSave(true);
+          return;
+        }
+        setPhase('edit'); // Esc / n / anything else backs out
+        return;
+      }
+
+      // phase === 'edit'
+      if (key.name === 'escape') {
+        onClose();
+        return;
+      }
+      if (key.name === 'return') {
+        const err = !name ? 'Workflow name is required.' : validateWorkflowName(name);
+        if (err) {
+          setMessage(err);
+          setPhase('error');
+          return;
+        }
+        void doSave(false);
+        return;
+      }
+      if (key.name === 'tab') {
+        setScope((s) => (s === 'project' ? 'user' : 'project'));
+        return;
+      }
+      if (key.name === 'backspace' || key.name === 'delete') {
+        setName((n) => n.slice(0, -1));
+        return;
+      }
+      if (key.ctrl && key.name === 'u') {
+        setName('');
+        return;
+      }
+      // Printable single char → append. Out-of-range chars are accepted but
+      // surface the live validation hint; submission re-validates.
+      if (
+        !key.ctrl &&
+        !key.meta &&
+        key.sequence.length === 1 &&
+        key.sequence >= ' '
+      ) {
+        setName((n) => n + key.sequence);
+      }
+    },
+    { isActive },
+  );
+
+  return (
+    <Box flexDirection="column" marginTop={1} paddingX={1}>
+      <Text bold color={theme.text.accent}>
+        {t('Save workflow')}
+      </Text>
+
+      {phase === 'overwrite' ? (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={theme.status.warning}>
+            {t('{{name}}.js already exists in {{scope}} scope.', { name, scope })}
+          </Text>
+          <Text color={theme.text.secondary}>
+            {t('Overwrite? Enter / y to confirm · any other key cancels')}
+          </Text>
+        </Box>
+      ) : phase === 'saved' ? (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={theme.status.success}>
+            {t('Saved to {{path}}', { path: message })}
+          </Text>
+          <Text color={theme.text.secondary}>
+            {t('Available as /{{name}} on the next session · press any key', {
+              name,
+            })}
+          </Text>
+        </Box>
+      ) : phase === 'error' ? (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={theme.status.error}>{message}</Text>
+          <Text color={theme.text.secondary}>
+            {t('Press any key to edit the name')}
+          </Text>
+        </Box>
+      ) : (
+        <Box flexDirection="column" marginTop={1}>
+          <Text>
+            {t('name')}
+            {'  : '}
+            {name}
+            <Text color={theme.text.accent}>{'█'}</Text>
+            {!name && (
+              <Text color={theme.text.secondary}>{t('(type a name)')}</Text>
+            )}
+          </Text>
+          <Text>
+            {t('scope')}
+            {' : '}
+            <Text
+              bold={scope === 'project'}
+              color={
+                scope === 'project'
+                  ? theme.text.accent
+                  : theme.text.secondary
+              }
+            >
+              {t('project')}
+            </Text>
+            {'   '}
+            <Text
+              bold={scope === 'user'}
+              color={
+                scope === 'user' ? theme.text.accent : theme.text.secondary
+              }
+            >
+              {t('user')}
+            </Text>
+          </Text>
+          {liveNameError && (
+            <Text color={theme.status.error}>{liveNameError}</Text>
+          )}
+          <Text color={theme.text.secondary}>
+            {t('Enter save · Tab scope · Esc cancel')}
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -143,6 +143,12 @@ export interface UIState {
   } | null;
   /** Visibility of WorktreeExitDialog (only shown when activeWorktree != null). */
   showWorktreeExitDialog: boolean;
+  /**
+   * P7-trigger: true while the current turn was steered toward the Workflow
+   * tool by the `workflow` keyword. Drives the Footer `workflow active`
+   * indicator; cleared when the turn returns to idle.
+   */
+  workflowKeywordActive: boolean;
   sessionStats: SessionStatsState;
   terminalWidth: number;
   terminalHeight: number;

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -47,6 +47,7 @@ import { CommandService } from '../../services/CommandService.js';
 import { BuiltinCommandLoader } from '../../services/BuiltinCommandLoader.js';
 import { BundledSkillLoader } from '../../services/BundledSkillLoader.js';
 import { FileCommandLoader } from '../../services/FileCommandLoader.js';
+import { SavedWorkflowLoader } from '../../services/saved-workflow-loader.js';
 import { McpPromptLoader } from '../../services/McpPromptLoader.js';
 import { SkillCommandLoader } from '../../services/SkillCommandLoader.js';
 import { parseSlashCommand } from '../../utils/commands.js';
@@ -497,6 +498,7 @@ export const useSlashCommandProcessor = (
           new BuiltinCommandLoader(config),
           new BundledSkillLoader(config),
           new SkillCommandLoader(config),
+          new SavedWorkflowLoader(config),
           new FileCommandLoader(config),
         ];
         const disabled = config?.getDisabledSlashCommands() ?? [];

--- a/packages/cli/src/ui/utils/workflow-keyword.test.ts
+++ b/packages/cli/src/ui/utils/workflow-keyword.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  detectWorkflowKeyword,
+  buildWorkflowSteeringNotice,
+} from './workflow-keyword.js';
+
+describe('detectWorkflowKeyword', () => {
+  it.each([
+    ['build me a workflow for this', true],
+    ['Workflow this please', true],
+    ['can you run a workflow?', true],
+    ['WORKFLOW', true],
+    ['the workflow.', true],
+  ])('matches the standalone word: %s', (text, expected) => {
+    expect(detectWorkflowKeyword(text)).toBe(expected);
+  });
+
+  it.each([
+    ['fix the workflows list', false], // plural — not the bare word
+    ['this is a dataflow problem', false], // substring, not a word
+    ['my-workflow-runner crashed', false], // hyphen-joined
+    ['just a normal request', false],
+    ['', false],
+  ])('does not over-match: %s', (text, expected) => {
+    expect(detectWorkflowKeyword(text)).toBe(expected);
+  });
+});
+
+describe('buildWorkflowSteeringNotice', () => {
+  it('names the Workflow tool and stays a soft nudge', () => {
+    const notice = buildWorkflowSteeringNotice();
+    expect(notice).toContain('Workflow tool');
+    expect(notice).toContain('workflow');
+    // Soft, not forced — the model keeps discretion.
+    expect(notice).toMatch(/proceed normally/i);
+  });
+});

--- a/packages/cli/src/ui/utils/workflow-keyword.ts
+++ b/packages/cli/src/ui/utils/workflow-keyword.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview P7-trigger: the `workflow` keyword trigger. When a user's
+ * prompt mentions `workflow` (as a whole word), the turn is softly steered
+ * toward the Workflow tool by prepending a system reminder. This is the
+ * qwen-code analogue of upstream's keyword opt-in — deliberately keyed on the
+ * plain word `workflow` (never any other marker).
+ */
+
+/**
+ * Edge punctuation stripped from a token before the keyword comparison, so
+ * `workflow.` / `workflow?` / `(workflow)` still count. Deliberately excludes
+ * hyphens and digits so compound identifiers (`my-workflow-runner`,
+ * `workflow2`) do NOT trigger.
+ */
+const STRIP_EDGE_PUNCT = /^[.,!?;:'"()[\]{}<>]+|[.,!?;:'"()[\]{}<>]+$/g;
+
+/**
+ * True when `text` contains `workflow` as a standalone word (case-insensitive).
+ * Tokenizes on whitespace and strips edge punctuation, so `Workflow` and
+ * `a workflow.` match while `workflows`, `dataflow`, and `my-workflow-runner`
+ * do not — a stricter notion of "word" than `\bworkflow\b` (which treats
+ * hyphens as boundaries and would over-match compound identifiers).
+ */
+export function detectWorkflowKeyword(text: string): boolean {
+  return text
+    .toLowerCase()
+    .split(/\s+/)
+    .some((token) => token.replace(STRIP_EDGE_PUNCT, '') === 'workflow');
+}
+
+/**
+ * The steering note injected into a triggered turn. A soft nudge, not a
+ * forced tool call — the model keeps discretion so a casual mention of
+ * "workflow" doesn't derail an unrelated request.
+ */
+export function buildWorkflowSteeringNotice(): string {
+  return (
+    'The user\'s message includes the "workflow" keyword. If this request ' +
+    'benefits from orchestrating multiple steps or subagents, strongly prefer ' +
+    'the Workflow tool — author a script using phase(), log(), agent(), and ' +
+    'parallel()/pipeline() — over ad-hoc sequential tool calls. If a workflow ' +
+    'is not a good fit for this request, proceed normally.'
+  );
+}

--- a/packages/core/src/agents/runtime/workflow-journal.test.ts
+++ b/packages/core/src/agents/runtime/workflow-journal.test.ts
@@ -11,6 +11,7 @@ import * as path from 'node:path';
 import {
   canonicalizeAgentOpts,
   deriveAgentKey,
+  deriveArgsSeed,
   buildReplay,
   WorkflowJournal,
   JOURNAL_KEY_VERSION,
@@ -125,5 +126,21 @@ describe('WorkflowJournal', () => {
     const replay = await j.load();
     expect(replay.results.size).toBe(0);
     expect(replay.started.size).toBe(0);
+  });
+});
+
+// #7: the resume prefix chain is seeded with the run's args, so a resume with
+// different args yields a disjoint key space (cache misses → live re-run).
+describe('deriveArgsSeed', () => {
+  it('is deterministic for equal args and differs for different args', () => {
+    expect(deriveArgsSeed({ a: 1 })).toBe(deriveArgsSeed({ a: 1 }));
+    expect(deriveArgsSeed({ a: 1 })).not.toBe(deriveArgsSeed({ a: 2 }));
+    expect(deriveArgsSeed(undefined)).toBe(deriveArgsSeed(null));
+  });
+
+  it('changes the first agent key when args change', () => {
+    const k1 = deriveAgentKey(deriveArgsSeed({ topic: 'a' }), 'do x', {});
+    const k2 = deriveAgentKey(deriveArgsSeed({ topic: 'b' }), 'do x', {});
+    expect(k1).not.toBe(k2); // same prompt+opts, different args → different key
   });
 });

--- a/packages/core/src/agents/runtime/workflow-journal.test.ts
+++ b/packages/core/src/agents/runtime/workflow-journal.test.ts
@@ -42,7 +42,8 @@ describe('canonicalizeAgentOpts', () => {
   it('drops function-valued opts', () => {
     const c = canonicalizeAgentOpts({
       model: 'm',
-      // @ts-expect-error — testing the runtime function-strip
+      // A function is structurally an `object`, so this needs no type
+      // suppression — the test asserts the *runtime* strip of callable values.
       schema: () => {},
     });
     expect(c).toBe(JSON.stringify({ model: 'm' }));

--- a/packages/core/src/agents/runtime/workflow-journal.test.ts
+++ b/packages/core/src/agents/runtime/workflow-journal.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  canonicalizeAgentOpts,
+  deriveAgentKey,
+  buildReplay,
+  WorkflowJournal,
+  JOURNAL_KEY_VERSION,
+  type JournalEntry,
+} from './workflow-journal.js';
+
+describe('canonicalizeAgentOpts', () => {
+  it('keeps only dispatch-affecting opts', () => {
+    const c = canonicalizeAgentOpts({
+      label: 'ignored',
+      phase: 'ignored',
+      stallMs: 1234,
+      model: 'm1',
+      agentType: 'a1',
+    });
+    expect(c).toBe(JSON.stringify({ agentType: 'a1', model: 'm1' }));
+  });
+
+  it('sorts object keys deeply so reordered schemas hash the same', () => {
+    const a = canonicalizeAgentOpts({
+      schema: { type: 'object', properties: { b: 1, a: 2 } },
+    });
+    const b = canonicalizeAgentOpts({
+      schema: { properties: { a: 2, b: 1 }, type: 'object' },
+    });
+    expect(a).toBe(b);
+  });
+
+  it('drops function-valued opts', () => {
+    const c = canonicalizeAgentOpts({
+      model: 'm',
+      // @ts-expect-error — testing the runtime function-strip
+      schema: () => {},
+    });
+    expect(c).toBe(JSON.stringify({ model: 'm' }));
+  });
+
+  it('empty opts → {}', () => {
+    expect(canonicalizeAgentOpts({})).toBe('{}');
+  });
+});
+
+describe('deriveAgentKey', () => {
+  it('is deterministic for the same inputs', () => {
+    const k1 = deriveAgentKey('', 'do x', { model: 'm' });
+    const k2 = deriveAgentKey('', 'do x', { model: 'm' });
+    expect(k1).toBe(k2);
+    expect(k1).toMatch(new RegExp(`^${JOURNAL_KEY_VERSION}:[0-9a-f]{64}$`));
+  });
+
+  it('changes when the prompt changes', () => {
+    expect(deriveAgentKey('', 'a', {})).not.toBe(deriveAgentKey('', 'b', {}));
+  });
+
+  it('changes when an opt changes', () => {
+    expect(deriveAgentKey('', 'x', { model: 'm1' })).not.toBe(
+      deriveAgentKey('', 'x', { model: 'm2' }),
+    );
+  });
+
+  it('does NOT change when only a cosmetic opt (label) changes', () => {
+    expect(deriveAgentKey('', 'x', { label: 'a' })).toBe(
+      deriveAgentKey('', 'x', { label: 'b' }),
+    );
+  });
+
+  it('changes when the prefix hash changes (chaining)', () => {
+    expect(deriveAgentKey('prefA', 'x', {})).not.toBe(
+      deriveAgentKey('prefB', 'x', {}),
+    );
+  });
+});
+
+describe('buildReplay', () => {
+  it('results last-write-wins; started entries accumulate', () => {
+    const entries: JournalEntry[] = [
+      { type: 'started', key: 'k1', agentId: '1' },
+      { type: 'result', key: 'k1', agentId: '1', result: 'first' },
+      { type: 'started', key: 'k1', agentId: '2' }, // respawn
+      { type: 'result', key: 'k1', agentId: '2', result: 'second' },
+      { type: 'started', key: 'k2', agentId: '3' },
+    ];
+    const replay = buildReplay(entries);
+    expect(replay.results.get('k1')?.result).toBe('second');
+    expect(replay.started.get('k1')).toHaveLength(2);
+    expect(replay.started.get('k2')).toHaveLength(1);
+    expect(replay.results.has('k2')).toBe(false); // started but never resulted
+  });
+});
+
+describe('WorkflowJournal', () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'wf-journal-'));
+  });
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('append then load round-trips entries', async () => {
+    const j = new WorkflowJournal(path.join(dir, 'sub', 'journal.jsonl'));
+    await j.append({ type: 'started', key: 'k1', agentId: '1' });
+    await j.append({ type: 'result', key: 'k1', agentId: '1', result: { v: 9 } });
+    const replay = await j.load();
+    expect(replay.results.get('k1')?.result).toEqual({ v: 9 });
+    expect(replay.started.get('k1')).toHaveLength(1);
+  });
+
+  it('load on a missing file returns empty maps', async () => {
+    const j = new WorkflowJournal(path.join(dir, 'nope.jsonl'));
+    const replay = await j.load();
+    expect(replay.results.size).toBe(0);
+    expect(replay.started.size).toBe(0);
+  });
+});

--- a/packages/core/src/agents/runtime/workflow-journal.ts
+++ b/packages/core/src/agents/runtime/workflow-journal.ts
@@ -1,0 +1,167 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Same-session workflow resume via a JSONL journal. Every
+ * `agent()` dispatch in a run appends a `started` then a `result` line to
+ * `<projectDir>/workflows/<runId>/journal.jsonl`. Re-running the workflow
+ * with `Workflow({resumeFromRunId})` loads the journal and serves cached
+ * results for the longest UNCHANGED PREFIX of `agent()` calls — the first
+ * call whose (rolling prefix + prompt + opts) hash diverges, or that has no
+ * journaled result, runs live, and every call after it runs live too.
+ *
+ * Key derivation (matches upstream `v2`): each dispatch's key is
+ * `v2:sha256(prefixHash ‖ prompt ‖ canonicalOpts)`, where `prefixHash` is
+ * the PREVIOUS dispatch's key (rolling chain, empty for the first call).
+ * Chaining is what gives "longest unchanged prefix" semantics: editing
+ * call #3 changes its key, which changes #4's prefix, which changes #4's
+ * key, and so on — so the cache naturally invalidates from the edit point.
+ *
+ * The `canonicalOpts` projection keeps only the dispatch-affecting opts
+ * (`schema`, `model`, `isolation`, `agentType`) with object keys sorted, so
+ * cosmetic opt differences (a re-ordered schema, a `label` change) don't
+ * bust the cache.
+ *
+ * Determinism requirement: workflow scripts are deterministic (`Date.now`
+ * / `Math.random` throw in the sandbox), so the sequence of `agent()`
+ * calls — and therefore the key chain — is stable across runs. That is the
+ * precondition that makes prefix-hash caching correct.
+ */
+
+import { createHash } from 'node:crypto';
+import { read, writeLine } from '../../utils/jsonl-utils.js';
+import { createDebugLogger } from '../../utils/debugLogger.js';
+import type { WorkflowAgentOpts } from './workflow-sandbox.js';
+
+const debugLogger = createDebugLogger('WORKFLOW_JOURNAL');
+
+/** Journal-format version tag, prefixed onto every key. */
+export const JOURNAL_KEY_VERSION = 'v2';
+
+export interface JournalStartedEntry {
+  type: 'started';
+  key: string;
+  agentId: string;
+}
+
+export interface JournalResultEntry {
+  type: 'result';
+  key: string;
+  agentId: string;
+  result: unknown;
+}
+
+export type JournalEntry = JournalStartedEntry | JournalResultEntry;
+
+/** Parsed journal: completed results + started-but-maybe-incomplete markers. */
+export interface JournalReplay {
+  /** key → the completed result entry (last write wins). */
+  results: Map<string, JournalResultEntry>;
+  /** key → all `started` entries seen (length > 1 ⇒ prior respawns). */
+  started: Map<string, JournalStartedEntry[]>;
+}
+
+/**
+ * Project the dispatch-affecting opts into a stable canonical string. Only
+ * `schema` / `model` / `isolation` / `agentType` change what the dispatch
+ * does; `label` / `phase` / `stallMs` are cosmetic or operational and must
+ * NOT bust the cache. Object keys are sorted recursively so a re-serialized
+ * schema with reordered keys hashes the same.
+ */
+export function canonicalizeAgentOpts(opts: WorkflowAgentOpts): string {
+  const projected: Record<string, unknown> = {};
+  for (const k of ['schema', 'model', 'isolation', 'agentType'] as const) {
+    const v = opts[k];
+    if (v === undefined || typeof v === 'function') continue;
+    projected[k] = v;
+  }
+  const sortDeep = (val: unknown): unknown => {
+    if (typeof val === 'function') return undefined;
+    if (Array.isArray(val)) return val.map(sortDeep);
+    if (val && typeof val === 'object') {
+      const out: Record<string, unknown> = {};
+      for (const key of Object.keys(val as Record<string, unknown>).sort()) {
+        if (key === '__proto__') continue;
+        out[key] = sortDeep((val as Record<string, unknown>)[key]);
+      }
+      return out;
+    }
+    return val;
+  };
+  try {
+    return JSON.stringify(sortDeep(projected));
+  } catch {
+    // A non-serializable opt (shouldn't happen — opts are JSON-revived
+    // before crossing the vm boundary) falls back to an empty projection
+    // so the dispatch still gets a stable (prompt-only) key.
+    return '{}';
+  }
+}
+
+/**
+ * Derive a dispatch's resume key from the rolling prefix hash, the prompt,
+ * and the canonical opts. Returns `{key}`; the caller chains by setting the
+ * next `prefixHash = key`.
+ */
+export function deriveAgentKey(
+  prefixHash: string,
+  prompt: string,
+  opts: WorkflowAgentOpts,
+): string {
+  const hash = createHash('sha256');
+  hash.update(prefixHash);
+  hash.update('\0');
+  hash.update(prompt);
+  hash.update('\0');
+  hash.update(canonicalizeAgentOpts(opts));
+  return `${JOURNAL_KEY_VERSION}:${hash.digest('hex')}`;
+}
+
+/**
+ * Build the replay maps from a flat list of journal entries. `result`
+ * entries win last-write; `started` entries accumulate (so a key started
+ * N times surfaces N prior attempts for the respawn telemetry).
+ */
+export function buildReplay(entries: JournalEntry[]): JournalReplay {
+  const results = new Map<string, JournalResultEntry>();
+  const started = new Map<string, JournalStartedEntry[]>();
+  for (const e of entries) {
+    if (e.type === 'result') {
+      results.set(e.key, e);
+    } else if (e.type === 'started') {
+      const list = started.get(e.key);
+      if (list) list.push(e);
+      else started.set(e.key, [e]);
+    }
+  }
+  return { results, started };
+}
+
+/**
+ * Append-only JSONL journal for one workflow run. Reads tolerate a missing
+ * file (fresh run); appends are fire-and-forget at the call site (the
+ * orchestrator does not await them on the hot path — a journal write
+ * failure must not fail the dispatch).
+ */
+export class WorkflowJournal {
+  constructor(readonly path: string) {}
+
+  /** Load + parse all entries into replay maps. Empty maps if no file. */
+  async load(): Promise<JournalReplay> {
+    try {
+      const entries = await read<JournalEntry>(this.path);
+      return buildReplay(entries);
+    } catch (e) {
+      debugLogger.warn(`WorkflowJournal.load failed for ${this.path}: ${e}`);
+      return { results: new Map(), started: new Map() };
+    }
+  }
+
+  /** Append one entry. Rejects only on I/O error (callers `.catch`). */
+  append(entry: JournalEntry): Promise<void> {
+    return writeLine(this.path, entry);
+  }
+}

--- a/packages/core/src/agents/runtime/workflow-journal.ts
+++ b/packages/core/src/agents/runtime/workflow-journal.ts
@@ -121,6 +121,27 @@ export function deriveAgentKey(
 }
 
 /**
+ * Seed for the resume prefix-hash chain, derived from the run's `args`. Folding
+ * `args` into the chain root means a resume with DIFFERENT args produces a
+ * disjoint key space: every `agent()` call misses the journal and re-runs live
+ * instead of silently replaying the previous run's results. (The tool documents
+ * "pass the same args" as a user obligation; this enforces it.)
+ */
+export function deriveArgsSeed(args: unknown): string {
+  const hash = createHash('sha256');
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(args ?? null) ?? 'null';
+  } catch {
+    // `args` is contractually JSON; a non-serializable value (cycle/BigInt)
+    // hashes to a stable sentinel so the chain stays deterministic.
+    serialized = 'non-serializable-args';
+  }
+  hash.update(serialized);
+  return `${JOURNAL_KEY_VERSION}:${hash.digest('hex')}`;
+}
+
+/**
  * Build the replay maps from a flat list of journal entries. `result`
  * entries win last-write; `started` entries accumulate (so a key started
  * N times surfaces N prior attempts for the respawn telemetry).

--- a/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
@@ -910,19 +910,28 @@ describe('createProductionDispatch', () => {
   // FIX-C4 (TST-2-C2): the previous test only asserted no-crash. This one
   // actually captures the signal in the mock and asserts identity, so a
   // regression that drops the second arg of subagent.execute() would fail.
-  it('threads abort signal through to subagent.execute', async () => {
+  // P-stall: the stall wrapper now interposes a per-attempt AbortController
+  // between the caller's signal and `subagent.execute()`, so the subagent
+  // receives a per-attempt signal (chained to the parent), not the caller's
+  // exact object. The behavioural parent-abort-propagates contract is
+  // covered by workflow-stall.test.ts where timing is controllable; here we
+  // assert the subagent always receives a live (non-aborted) signal.
+  it('threads a per-attempt abort signal through to subagent.execute', async () => {
     const controller = new AbortController();
     const dispatch = createProductionDispatch(fakeConfig(), controller.signal);
     await dispatch('hello', { label: 'h1' });
     expect(created.length).toBe(1);
-    expect(created[0]!.signal).toBe(controller.signal);
+    expect(created[0]!.signal).toBeDefined();
   });
 
-  it('passes undefined signal when none provided', async () => {
+  it('provides a per-attempt signal even when no caller signal is given', async () => {
     const dispatch = createProductionDispatch(fakeConfig());
     await dispatch('hello', { label: 'h1' });
     expect(created.length).toBe(1);
-    expect(created[0]!.signal).toBeUndefined();
+    // The stall wrapper always supplies a per-attempt signal (so the
+    // watchdog can abort it); it just isn't chained to any parent.
+    expect(created[0]!.signal).toBeDefined();
+    expect(created[0]!.signal!.aborted).toBe(false);
   });
 
   // FIX-C2 (UP-2-C1): the subagent system prompt must include the binary's

--- a/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
@@ -887,6 +887,181 @@ describe('WorkflowOrchestrator', () => {
     });
     expect(outcome.result).toMatch(/caught:.*no workflow with that name/);
   });
+
+  // ── P6: resume journal ────────────────────────────────────────────────
+
+  it('P6: a normal run journals a started+result per agent() call', async () => {
+    const { buildReplay } = await import('./workflow-journal.js');
+    const entries: import('./workflow-journal.js').JournalEntry[] = [];
+    const journal = {
+      path: 'mem',
+      append: (e: import('./workflow-journal.js').JournalEntry) => {
+        entries.push(e);
+        return Promise.resolve();
+      },
+      load: () => Promise.resolve(buildReplay(entries)),
+    } as unknown as import('./workflow-journal.js').WorkflowJournal;
+
+    const orchestrator = new WorkflowOrchestrator(
+      async (prompt) => `r:${prompt}`,
+    );
+    await orchestrator.run({
+      script: `await agent('a'); await agent('b'); return 'done';`,
+      args: undefined,
+      journal,
+    });
+    // 2 agents → 2 started + 2 result.
+    expect(entries.filter((e) => e.type === 'started')).toHaveLength(2);
+    const results = entries.filter((e) => e.type === 'result');
+    expect(results).toHaveLength(2);
+    expect((results[0] as { result: unknown }).result).toBe('r:a');
+    expect((results[1] as { result: unknown }).result).toBe('r:b');
+  });
+
+  it('P6: resume serves the cached prefix without re-dispatching', async () => {
+    const { buildReplay } = await import('./workflow-journal.js');
+    // Run 1: record the journal.
+    const entries: import('./workflow-journal.js').JournalEntry[] = [];
+    const journal1 = {
+      append: (e: import('./workflow-journal.js').JournalEntry) => {
+        entries.push(e);
+        return Promise.resolve();
+      },
+    } as unknown as import('./workflow-journal.js').WorkflowJournal;
+    const orch1 = new WorkflowOrchestrator(async (prompt) => `r:${prompt}`);
+    await orch1.run({
+      script: `await agent('a'); await agent('b'); return 'done';`,
+      args: undefined,
+      journal: journal1,
+    });
+
+    // Run 2 (resume): same script. The dispatch counter must stay 0 because
+    // both agents are cached.
+    let dispatchCalls = 0;
+    const orch2 = new WorkflowOrchestrator(async (prompt) => {
+      dispatchCalls += 1;
+      return `LIVE:${prompt}`;
+    });
+    const journal2 = {
+      append: () => Promise.resolve(),
+    } as unknown as import('./workflow-journal.js').WorkflowJournal;
+    const outcome = await orch2.run({
+      script: `const a = await agent('a'); const b = await agent('b'); return a + '|' + b;`,
+      args: undefined,
+      journal: journal2,
+      resumeReplay: buildReplay(entries),
+    });
+    expect(dispatchCalls).toBe(0); // fully cached
+    expect(outcome.result).toBe('r:a|r:b'); // cached values, not LIVE
+  });
+
+  it('P6: first miss runs live and the suffix goes live (first-miss invalidates suffix)', async () => {
+    const { buildReplay } = await import('./workflow-journal.js');
+    // Run 1 journaled agents a, b, c.
+    const entries: import('./workflow-journal.js').JournalEntry[] = [];
+    const journal1 = {
+      append: (e: import('./workflow-journal.js').JournalEntry) => {
+        entries.push(e);
+        return Promise.resolve();
+      },
+    } as unknown as import('./workflow-journal.js').WorkflowJournal;
+    const orch1 = new WorkflowOrchestrator(async (prompt) => `r:${prompt}`);
+    await orch1.run({
+      script: `await agent('a'); await agent('b'); await agent('c'); return 1;`,
+      args: undefined,
+      journal: journal1,
+    });
+
+    // Run 2: change agent #2's prompt ('b' → 'B'). #1 ('a') is cached; #2
+    // ('B') misses → live; #3 ('c') must ALSO run live even though 'c' was
+    // journaled (first-miss invalidates suffix + the prefix-hash chain from
+    // #2's new prompt changes #3's key anyway).
+    const dispatched: string[] = [];
+    const orch2 = new WorkflowOrchestrator(async (prompt) => {
+      dispatched.push(prompt);
+      return `LIVE:${prompt}`;
+    });
+    const outcome = await orch2.run({
+      script: `const a = await agent('a');
+               const b = await agent('B');
+               const c = await agent('c');
+               return [a, b, c].join('|');`,
+      args: undefined,
+      journal: { append: () => Promise.resolve() } as never,
+      resumeReplay: buildReplay(entries),
+    });
+    // 'a' cached; 'B' and 'c' live.
+    expect(dispatched).toEqual(['B', 'c']);
+    expect(outcome.result).toBe('r:a|LIVE:B|LIVE:c');
+  });
+
+  it('P6: cache hit advances the registry counters (agentDispatched + agentCompleted)', async () => {
+    const { buildReplay } = await import('./workflow-journal.js');
+    const entries: import('./workflow-journal.js').JournalEntry[] = [];
+    const journal1 = {
+      append: (e: import('./workflow-journal.js').JournalEntry) => {
+        entries.push(e);
+        return Promise.resolve();
+      },
+    } as unknown as import('./workflow-journal.js').WorkflowJournal;
+    const orch1 = new WorkflowOrchestrator(async () => 'cached');
+    await orch1.run({
+      script: `await agent('a'); return 1;`,
+      args: undefined,
+      journal: journal1,
+    });
+
+    const events: string[] = [];
+    const orch2 = new WorkflowOrchestrator(async () => 'LIVE');
+    await orch2.run({
+      script: `await agent('a'); return 1;`,
+      args: undefined,
+      journal: { append: () => Promise.resolve() } as never,
+      resumeReplay: buildReplay(entries),
+      emitter: {
+        agentDispatched: () => events.push('dispatched'),
+        agentCompleted: () => events.push('completed'),
+      },
+    });
+    expect(events).toEqual(['dispatched', 'completed']);
+  });
+
+  it('P6: cached dispatches do NOT consume the agent-count cap', async () => {
+    const prev = process.env['QWEN_CODE_MAX_WORKFLOW_AGENTS'];
+    process.env['QWEN_CODE_MAX_WORKFLOW_AGENTS'] = '2';
+    try {
+      const { buildReplay } = await import('./workflow-journal.js');
+      const entries: import('./workflow-journal.js').JournalEntry[] = [];
+      const journal1 = {
+        append: (e: import('./workflow-journal.js').JournalEntry) => {
+          entries.push(e);
+          return Promise.resolve();
+        },
+      } as unknown as import('./workflow-journal.js').WorkflowJournal;
+      // Run 1 with a larger cap to record 3 agents.
+      process.env['QWEN_CODE_MAX_WORKFLOW_AGENTS'] = '10';
+      const orch1 = new WorkflowOrchestrator(async (p) => `r:${p}`);
+      await orch1.run({
+        script: `await agent('a'); await agent('b'); await agent('c'); return 1;`,
+        args: undefined,
+        journal: journal1,
+      });
+      // Run 2 (resume) with cap=2: all 3 are cached, so the cap (which
+      // counts only LIVE dispatches) is never hit.
+      process.env['QWEN_CODE_MAX_WORKFLOW_AGENTS'] = '2';
+      const orch2 = new WorkflowOrchestrator(async () => 'LIVE');
+      const outcome = await orch2.run({
+        script: `await agent('a'); await agent('b'); await agent('c'); return 'ok';`,
+        args: undefined,
+        journal: { append: () => Promise.resolve() } as never,
+        resumeReplay: buildReplay(entries),
+      });
+      expect(outcome.result).toBe('ok'); // no cap error despite 3 > 2
+    } finally {
+      if (prev === undefined) delete process.env['QWEN_CODE_MAX_WORKFLOW_AGENTS'];
+      else process.env['QWEN_CODE_MAX_WORKFLOW_AGENTS'] = prev;
+    }
+  });
 });
 
 describe('createProductionDispatch', () => {

--- a/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
@@ -745,6 +745,148 @@ describe('WorkflowOrchestrator', () => {
     });
     expect(outcome.result).toBe('done');
   });
+
+  // ── P-nested: workflow() global ───────────────────────────────────────
+
+  it('P-nested: workflow(name) resolves via injected resolver and returns nested result', async () => {
+    const orchestrator = new WorkflowOrchestrator(
+      async (prompt) => `agent:${prompt}`,
+    );
+    const resolveSavedWorkflow = async (
+      ref: string | { scriptPath: string },
+    ) => {
+      expect(ref).toBe('child');
+      return { script: `return 'nested-' + (await agent('inner'));`, name: 'child' };
+    };
+    const outcome = await orchestrator.run({
+      script: `const r = await workflow('child'); return 'parent:' + r;`,
+      args: undefined,
+      resolveSavedWorkflow,
+    });
+    expect(outcome.result).toBe('parent:nested-agent:inner');
+  });
+
+  it('P-nested: nested args are passed to the child script', async () => {
+    const orchestrator = new WorkflowOrchestrator(async () => 'unused');
+    const resolveSavedWorkflow = async () => ({
+      script: `return args.x * 2;`,
+    });
+    const outcome = await orchestrator.run({
+      script: `return await workflow('child', { x: 21 });`,
+      args: undefined,
+      resolveSavedWorkflow,
+    });
+    expect(outcome.result).toBe(42);
+  });
+
+  it('P-nested: nested agents share the parent agent-count cap', async () => {
+    // Cap is read from env; set a tiny cap so parent(1) + nested(2) trips it.
+    const prev = process.env['QWEN_CODE_MAX_WORKFLOW_AGENTS'];
+    process.env['QWEN_CODE_MAX_WORKFLOW_AGENTS'] = '2';
+    try {
+      let dispatchCalls = 0;
+      const orchestrator = new WorkflowOrchestrator(async () => {
+        dispatchCalls += 1;
+        return 'ok';
+      });
+      const resolveSavedWorkflow = async () => ({
+        // nested fires 2 agents; with parent's 1 already spent and cap=2,
+        // the 2nd nested agent (3rd overall) must throw the cap error.
+        script: `await agent('n1'); await agent('n2'); return 'done';`,
+      });
+      let caught: unknown;
+      try {
+        await orchestrator.run({
+          script: `await agent('p1'); return await workflow('child');`,
+          args: undefined,
+          resolveSavedWorkflow,
+        });
+      } catch (e) {
+        caught = e;
+      }
+      // parent p1 (1) + nested n1 (2) pass; nested n2 (3) trips the cap.
+      expect(dispatchCalls).toBe(2);
+      expect(String(caught)).toMatch(/exceeded the maximum of 2 agent/);
+    } finally {
+      if (prev === undefined) delete process.env['QWEN_CODE_MAX_WORKFLOW_AGENTS'];
+      else process.env['QWEN_CODE_MAX_WORKFLOW_AGENTS'] = prev;
+    }
+  });
+
+  it('P-nested: nested agents share the parent token budget', async () => {
+    const { WorkflowBudgetImpl } = await import('./workflow-budget.js');
+    const budget = new WorkflowBudgetImpl(100);
+    const orchestrator = new WorkflowOrchestrator(async () => {
+      budget.recordSpent(60); // each agent burns 60 → 2 agents = 120 > 100
+      return 'ok';
+    });
+    const resolveSavedWorkflow = async () => ({
+      script: `await agent('n1'); await agent('n2'); return 'done';`,
+    });
+    let caught: unknown;
+    try {
+      await orchestrator.run({
+        script: `await agent('p1'); return await workflow('child');`,
+        args: undefined,
+        budget,
+        resolveSavedWorkflow,
+      });
+    } catch (e) {
+      caught = e;
+    }
+    // parent p1 spends 60; nested n1 spends 60 (total 120); nested n2 gated.
+    expect(String(caught)).toMatch(/exceeded the token budget/);
+    expect(budget.spent()).toBe(120);
+  });
+
+  it('P-nested: single-level limit — a nested workflow() call throws', async () => {
+    const orchestrator = new WorkflowOrchestrator(async () => 'ok');
+    const resolveSavedWorkflow = async () => ({
+      // The nested script tries to nest again — must throw.
+      script: `return await workflow('grandchild');`,
+    });
+    let caught: unknown;
+    try {
+      await orchestrator.run({
+        script: `return await workflow('child');`,
+        args: undefined,
+        resolveSavedWorkflow,
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(String(caught)).toMatch(/workflow\(\) is unavailable here/);
+    expect(String(caught)).toMatch(/single level/);
+  });
+
+  it('P-nested: workflow() throws when no resolver is wired', async () => {
+    const orchestrator = new WorkflowOrchestrator(async () => 'ok');
+    let caught: unknown;
+    try {
+      await orchestrator.run({
+        script: `return await workflow('child');`,
+        args: undefined,
+        // resolveSavedWorkflow omitted
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(String(caught)).toMatch(/workflow\(\) is unavailable here/);
+  });
+
+  it('P-nested: resolver rejection (workflow not found) surfaces to the parent script', async () => {
+    const orchestrator = new WorkflowOrchestrator(async () => 'ok');
+    const resolveSavedWorkflow = async () => {
+      throw new Error(`workflow('child'): no workflow with that name.`);
+    };
+    const outcome = await orchestrator.run({
+      script: `try { await workflow('child'); return 'no-throw'; }
+               catch (e) { return 'caught:' + e.message; }`,
+      args: undefined,
+      resolveSavedWorkflow,
+    });
+    expect(outcome.result).toMatch(/caught:.*no workflow with that name/);
+  });
 });
 
 describe('createProductionDispatch', () => {

--- a/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
@@ -892,7 +892,7 @@ describe('WorkflowOrchestrator', () => {
 
   it('P6: a normal run journals a started+result per agent() call', async () => {
     const { buildReplay } = await import('./workflow-journal.js');
-    const entries: import('./workflow-journal.js').JournalEntry[] = [];
+    const entries: Array<import('./workflow-journal.js').JournalEntry> = [];
     const journal = {
       path: 'mem',
       append: (e: import('./workflow-journal.js').JournalEntry) => {
@@ -921,7 +921,7 @@ describe('WorkflowOrchestrator', () => {
   it('P6: resume serves the cached prefix without re-dispatching', async () => {
     const { buildReplay } = await import('./workflow-journal.js');
     // Run 1: record the journal.
-    const entries: import('./workflow-journal.js').JournalEntry[] = [];
+    const entries: Array<import('./workflow-journal.js').JournalEntry> = [];
     const journal1 = {
       append: (e: import('./workflow-journal.js').JournalEntry) => {
         entries.push(e);
@@ -958,7 +958,7 @@ describe('WorkflowOrchestrator', () => {
   it('P6: first miss runs live and the suffix goes live (first-miss invalidates suffix)', async () => {
     const { buildReplay } = await import('./workflow-journal.js');
     // Run 1 journaled agents a, b, c.
-    const entries: import('./workflow-journal.js').JournalEntry[] = [];
+    const entries: Array<import('./workflow-journal.js').JournalEntry> = [];
     const journal1 = {
       append: (e: import('./workflow-journal.js').JournalEntry) => {
         entries.push(e);
@@ -997,7 +997,7 @@ describe('WorkflowOrchestrator', () => {
 
   it('P6: cache hit advances the registry counters (agentDispatched + agentCompleted)', async () => {
     const { buildReplay } = await import('./workflow-journal.js');
-    const entries: import('./workflow-journal.js').JournalEntry[] = [];
+    const entries: Array<import('./workflow-journal.js').JournalEntry> = [];
     const journal1 = {
       append: (e: import('./workflow-journal.js').JournalEntry) => {
         entries.push(e);
@@ -1031,7 +1031,7 @@ describe('WorkflowOrchestrator', () => {
     process.env['QWEN_CODE_MAX_WORKFLOW_AGENTS'] = '2';
     try {
       const { buildReplay } = await import('./workflow-journal.js');
-      const entries: import('./workflow-journal.js').JournalEntry[] = [];
+      const entries: Array<import('./workflow-journal.js').JournalEntry> = [];
       const journal1 = {
         append: (e: import('./workflow-journal.js').JournalEntry) => {
           entries.push(e);

--- a/packages/core/src/agents/runtime/workflow-orchestrator.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.ts
@@ -17,6 +17,8 @@ import type {
 } from './workflow-sandbox.js';
 import { WorkflowBudgetExceededError } from './workflow-budget.js';
 import { resolveStallMs, runStallResilient } from './workflow-stall.js';
+import { deriveAgentKey } from './workflow-journal.js';
+import type { WorkflowJournal, JournalReplay } from './workflow-journal.js';
 import {
   WORKFLOW_SUBAGENT_SYSTEM_PROMPT,
   WORKFLOW_SUBAGENT_SYSTEM_PROMPT_WITH_SCHEMA,
@@ -257,6 +259,20 @@ export interface WorkflowRunRequest {
   resolveSavedWorkflow?: (
     nameOrRef: string | { scriptPath: string },
   ) => Promise<{ script: string; scriptPath?: string; name?: string }>;
+  /**
+   * P6: append-only resume journal for THIS run. When provided, every live
+   * `agent()` dispatch appends a `started` then a `result` line keyed by the
+   * rolling prefix-hash. Always set by the production caller (`WorkflowTool`)
+   * so any run is resumable; omitted by tests that don't exercise resume.
+   */
+  journal?: WorkflowJournal;
+  /**
+   * P6: replay maps loaded from a prior run's journal. Present only when
+   * resuming (`Workflow({resumeFromRunId})`). Cached results are served for
+   * the longest unchanged prefix; the first cache miss flips the run to
+   * live for the remainder ("first miss invalidates the suffix").
+   */
+  resumeReplay?: JournalReplay;
 }
 
 export interface WorkflowRunOutcome {
@@ -1278,7 +1294,70 @@ export class WorkflowOrchestrator {
     let agentCount = 0;
     const emitter = req.emitter;
     const budget = req.budget;
+
+    // P6: resume journal state. `prefixHash` chains across sequential
+    // agent() calls; `hadMiss` enforces the "first miss invalidates the
+    // suffix" invariant (once any dispatch runs live, no later dispatch
+    // trusts the cache). `journalAgentId` numbers journal entries.
+    const journal = req.journal;
+    const replay = req.resumeReplay;
+    let prefixHash = '';
+    let hadMiss = false;
+    let journalAgentId = 0;
+
     const countedDispatch: WorkflowAgentDispatch = (prompt, opts) => {
+      // P6: journal cache lookup — runs BEFORE the budget gate + agent
+      // counter so a cached result is free (no token spend, no agent-cap
+      // slot, no live dispatch). The key is computed SYNCHRONOUSLY here so
+      // the rolling prefix chains in deterministic call order even under
+      // parallel()/pipeline() fan-out (the thunks' synchronous prefixes run
+      // in array/microtask order).
+      let journalKey: string | undefined;
+      // Captured per-dispatch (NOT read from the shared counter later) so a
+      // concurrent dispatch can't clobber the id used in the result append.
+      let journalEntryId: string | undefined;
+      if (journal) {
+        journalKey = deriveAgentKey(prefixHash, prompt, opts);
+        prefixHash = journalKey;
+        if (!hadMiss && replay) {
+          const cached = replay.results.get(journalKey);
+          if (cached !== undefined) {
+            // Cache hit: surface dispatch + completion to the registry so
+            // the UI counters advance, then return the cached result. A
+            // prior `started`-without-`result` for this key means the agent
+            // was respawned in an earlier resume — log it for diagnostics.
+            const respawns = replay.started.get(journalKey);
+            if (respawns && respawns.length > 0) {
+              debugLogger.info(
+                `[Workflow] resume cache hit after ${respawns.length} prior ` +
+                  `respawn(s) for runId=${runId}.`,
+              );
+            }
+            const label = typeof opts.label === 'string' ? opts.label : undefined;
+            try {
+              emitter?.agentDispatched?.(label);
+            } catch (e) {
+              debugLogger.warn('emitter.agentDispatched threw:', e);
+            }
+            try {
+              emitter?.agentCompleted?.(label);
+            } catch (e) {
+              debugLogger.warn('emitter.agentCompleted threw:', e);
+            }
+            return Promise.resolve(cached.result as WorkflowAgentResult);
+          }
+        }
+        // First miss → suffix goes live; append a `started` marker so an
+        // interrupted run leaves a trace for the next resume.
+        hadMiss = true;
+        journalEntryId = String((journalAgentId += 1));
+        journal
+          .append({ type: 'started', key: journalKey, agentId: journalEntryId })
+          .catch((e) =>
+            debugLogger.warn(`journal started-append failed: ${e}`),
+          );
+      }
+
       // P5 R3 (wenshao #7): budget gate runs BEFORE `agentCount += 1`
       // so budget-rejected dispatches don't consume agent-cap slots.
       // Previously the order was reversed: budget exhaustion incremented
@@ -1364,6 +1443,23 @@ export class WorkflowOrchestrator {
               emitter?.agentCompleted?.(label);
             } catch (e) {
               debugLogger.warn('emitter.agentCompleted threw:', e);
+            }
+            // P6: append the live result to the journal so a later resume
+            // serves it from cache. Only JSON-serializable results are
+            // resumable; a non-serializable result is skipped (the next
+            // resume re-runs that dispatch live). Fire-and-forget — a
+            // journal write failure must not fail the dispatch.
+            if (journal && journalKey !== undefined) {
+              journal
+                .append({
+                  type: 'result',
+                  key: journalKey,
+                  agentId: journalEntryId ?? '',
+                  result,
+                })
+                .catch((e) =>
+                  debugLogger.warn(`journal result-append failed: ${e}`),
+                );
             }
             // P5: re-snapshot the budget after successful completion so the
             // registry sees the cumulative spent. The dispatch's onTokens

--- a/packages/core/src/agents/runtime/workflow-orchestrator.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.ts
@@ -16,6 +16,7 @@ import type {
   WorkflowOrchestratorEmitter,
 } from './workflow-sandbox.js';
 import { WorkflowBudgetExceededError } from './workflow-budget.js';
+import { resolveStallMs, runStallResilient } from './workflow-stall.js';
 import {
   WORKFLOW_SUBAGENT_SYSTEM_PROMPT,
   WORKFLOW_SUBAGENT_SYSTEM_PROMPT_WITH_SCHEMA,
@@ -339,67 +340,108 @@ export function createProductionDispatch(
   onTokens?: (outputTokens: number, opts: WorkflowAgentOpts) => void,
 ): WorkflowAgentDispatch {
   return async (prompt, opts) => {
-    const { AgentHeadless, ContextState } = await import('./agent-headless.js');
-    const ctx = new ContextState();
-    ctx.set('task_prompt', prompt);
-
-    if (
-      opts.agentType === undefined &&
-      opts.model === undefined &&
-      opts.isolation === undefined &&
-      opts.schema === undefined
-    ) {
-      const subagent = await AgentHeadless.create(
-        opts.label ?? 'workflow-agent',
-        config,
-        {
-          systemPrompt: WORKFLOW_SUBAGENT_SYSTEM_PROMPT,
-          initialMessages: [],
-        },
-        {},
-        // T11 (PR #4732 R1): bound resource ceiling so a single agent() call
-        // cannot loop the model indefinitely. Without this, runConfig was {}
-        // and the loop guards never tripped — combined with the cancellation
-        // bug below, workflows were effectively unkillable.
-        {
-          max_turns: WORKFLOW_SUBAGENT_MAX_TURNS,
-          max_time_minutes: WORKFLOW_SUBAGENT_MAX_TIME_MINUTES,
-        },
-        // T11 (PR #4732 R1): disallow SendMessage / ExitPlanMode to align with
-        // upstream Tg8 — closes the back-channel that would let a subagent
-        // deliver its answer via user message instead of the script's read.
-        { tools: ['*'], disallowedTools: WORKFLOW_SUBAGENT_DISALLOWED_TOOLS },
-      );
-      // P5 R3 (wenshao #6): wrap `execute()` in try/finally so tokens
-      // are reported even when `subagent.execute()` THROWS. R1 #3 moved
-      // `reportTokens` before the terminate-mode check but kept it on
-      // the line AFTER `await subagent.execute(...)` — so the production
-      // ERROR path (AgentHeadless's catch arm re-throws after setting
-      // terminateMode=ERROR, see agent-headless.ts:287-294) skipped
-      // recording, leaking the dispatch's tokens. `getExecutionSummary()`
-      // is valid inside the throw path because AgentHeadless's own
-      // outer `finally` finalizes stats before propagating the error.
-      try {
-        await subagent.execute(ctx, signal);
-      } finally {
-        reportTokens(subagent, opts, onTokens);
-      }
-      // T10 (PR #4732 R1): runReasoningLoop does NOT throw on abort / turn /
-      // time limit — it returns with terminateMode = CANCELLED|MAX_TURNS|
-      // TIMEOUT|ERROR and getFinalText() = '' or partial. Without this check,
-      // `await agent(...)` would resolve to '' on user cancel and the script
-      // would happily loop on empty results.
-      const mode = subagent.getTerminateMode();
-      if (mode !== AgentTerminateMode.GOAL) {
-        throw new Error(
-          `Workflow subagent did not complete (terminate mode: ${mode}).`,
-        );
-      }
-      return subagent.getFinalText();
-    }
-
-    return runOverridePath(config, ctx, opts, signal, onTokens);
+    // P-stall: wrap the single-attempt dispatch in the stall watchdog +
+    // retry loop. The wrapper owns the per-attempt AbortController +
+    // AgentEventEmitter; it chains the caller's `signal` into the
+    // per-attempt controller and hands both into `runSingleDispatch`. A
+    // stall fires `controller.abort('stalled')`, the attempt returns
+    // CANCELLED, runSingleDispatch throws its "did not complete" terminal,
+    // and the wrapper retries (up to 3) when `watchdog.stalled()` is set
+    // and the parent signal is NOT aborted.
+    const stallMs = resolveStallMs(
+      typeof opts.stallMs === 'number' ? opts.stallMs : undefined,
+    );
+    return runStallResilient(
+      (attemptSignal, emitter) =>
+        runSingleDispatch(config, prompt, opts, attemptSignal, emitter, onTokens),
+      {
+        stallMs,
+        signal,
+        label: typeof opts.label === 'string' ? opts.label : undefined,
+      },
+    );
   };
+}
+
+/**
+ * One single-attempt production dispatch. Receives the per-attempt abort
+ * signal (the stall wrapper chains the parent signal into it + the watchdog
+ * aborts it on stall) and the per-attempt event emitter (the stall watchdog
+ * is already attached; the override/schema path additionally attaches its
+ * `structured_output` capture listeners to the same emitter). Returns the
+ * agent result on success; throws on any non-success terminal.
+ */
+async function runSingleDispatch(
+  config: Config,
+  prompt: string,
+  opts: WorkflowAgentOpts,
+  attemptSignal: AbortSignal,
+  emitter: AgentEventEmitter,
+  onTokens?: (outputTokens: number, opts: WorkflowAgentOpts) => void,
+): Promise<WorkflowAgentResult> {
+  const { AgentHeadless, ContextState } = await import('./agent-headless.js');
+  const ctx = new ContextState();
+  ctx.set('task_prompt', prompt);
+
+  if (
+    opts.agentType === undefined &&
+    opts.model === undefined &&
+    opts.isolation === undefined &&
+    opts.schema === undefined
+  ) {
+    const subagent = await AgentHeadless.create(
+      opts.label ?? 'workflow-agent',
+      config,
+      {
+        systemPrompt: WORKFLOW_SUBAGENT_SYSTEM_PROMPT,
+        initialMessages: [],
+      },
+      {},
+      // T11 (PR #4732 R1): bound resource ceiling so a single agent() call
+      // cannot loop the model indefinitely. Without this, runConfig was {}
+      // and the loop guards never tripped — combined with the cancellation
+      // bug below, workflows were effectively unkillable.
+      {
+        max_turns: WORKFLOW_SUBAGENT_MAX_TURNS,
+        max_time_minutes: WORKFLOW_SUBAGENT_MAX_TIME_MINUTES,
+      },
+      // T11 (PR #4732 R1): disallow SendMessage / ExitPlanMode to align with
+      // upstream Tg8 — closes the back-channel that would let a subagent
+      // deliver its answer via user message instead of the script's read.
+      { tools: ['*'], disallowedTools: WORKFLOW_SUBAGENT_DISALLOWED_TOOLS },
+      // P-stall: the stall-watchdog emitter observes reasoning-loop events
+      // (round/tool/usage) to detect a hang and abort `attemptSignal`.
+      emitter,
+    );
+    // P5 R3 (wenshao #6): wrap `execute()` in try/finally so tokens
+    // are reported even when `subagent.execute()` THROWS. R1 #3 moved
+    // `reportTokens` before the terminate-mode check but kept it on
+    // the line AFTER `await subagent.execute(...)` — so the production
+    // ERROR path (AgentHeadless's catch arm re-throws after setting
+    // terminateMode=ERROR, see agent-headless.ts:287-294) skipped
+    // recording, leaking the dispatch's tokens. `getExecutionSummary()`
+    // is valid inside the throw path because AgentHeadless's own
+    // outer `finally` finalizes stats before propagating the error.
+    try {
+      await subagent.execute(ctx, attemptSignal);
+    } finally {
+      reportTokens(subagent, opts, onTokens);
+    }
+    // T10 (PR #4732 R1): runReasoningLoop does NOT throw on abort / turn /
+    // time limit — it returns with terminateMode = CANCELLED|MAX_TURNS|
+    // TIMEOUT|ERROR and getFinalText() = '' or partial. Without this check,
+    // `await agent(...)` would resolve to '' on user cancel and the script
+    // would happily loop on empty results.
+    const mode = subagent.getTerminateMode();
+    if (mode !== AgentTerminateMode.GOAL) {
+      throw new Error(
+        `Workflow subagent did not complete (terminate mode: ${mode}).`,
+      );
+    }
+    return subagent.getFinalText();
+  }
+
+  return runOverridePath(config, ctx, opts, attemptSignal, onTokens, emitter);
 }
 
 /**
@@ -476,6 +518,13 @@ async function runOverridePath(
    * so the token report site is identical.
    */
   onTokens?: (outputTokens: number, opts: WorkflowAgentOpts) => void,
+  /**
+   * P-stall: the per-attempt event emitter with the stall watchdog already
+   * attached. The schema path additionally attaches its `structured_output`
+   * capture listeners to this SAME emitter (rather than creating its own),
+   * so the watchdog and schema capture observe the one subagent's events.
+   */
+  emitter?: AgentEventEmitter,
 ): Promise<WorkflowAgentResult> {
   if (opts.isolation === 'remote') {
     // Error message verbatim from upstream Claude Code 2.1.168 strings.
@@ -640,9 +689,16 @@ async function runOverridePath(
       dispatchSignal = child.signal;
     }
 
-    const eventEmitter = schemaState
-      ? createSchemaEventEmitter(schemaState)
-      : undefined;
+    // P-stall: use the stall-watchdog emitter the wrapper handed us. The
+    // schema path attaches its `structured_output` capture listeners to the
+    // SAME emitter so both concerns observe the one subagent's events. When
+    // no emitter was passed (legacy / direct callers), fall back to a fresh
+    // emitter only in schema mode (the watchdog is then absent, matching the
+    // pre-P-stall behaviour for direct override-path callers).
+    const eventEmitter = emitter ?? (schemaState ? new AgentEventEmitter() : undefined);
+    if (schemaState && eventEmitter) {
+      attachSchemaListeners(eventEmitter, schemaState);
+    }
 
     const { subagent, dispose } = await subagentMgr.createAgentHeadless(
       augmented,
@@ -1116,8 +1172,10 @@ function createSchemaModeState(): SchemaModeState {
  *     signal into this state's controller, so a caller cancellation
  *     propagates straight to the subagent.
  */
-function createSchemaEventEmitter(state: SchemaModeState): AgentEventEmitter {
-  const emitter = new AgentEventEmitter();
+function attachSchemaListeners(
+  emitter: AgentEventEmitter,
+  state: SchemaModeState,
+): void {
   const targetTool = ToolNames.STRUCTURED_OUTPUT;
   emitter.on(AgentEventType.TOOL_CALL, (evt: AgentToolCallEvent) => {
     if (evt.name !== targetTool) return;
@@ -1142,7 +1200,6 @@ function createSchemaEventEmitter(state: SchemaModeState): AgentEventEmitter {
       state.abortController.abort();
     }
   });
-  return emitter;
 }
 
 /**

--- a/packages/core/src/agents/runtime/workflow-orchestrator.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.ts
@@ -1507,6 +1507,9 @@ export class WorkflowOrchestrator {
 async function settleToNullArray(
   thunks: Array<() => Promise<unknown>>,
   signal?: AbortSignal,
+  // P5 R3 Gap-3: which fan-out primitive is calling, for the budget-drop
+  // summary log. Defaults to 'parallel'.
+  kind: 'parallel' | 'pipeline' = 'parallel',
 ): Promise<unknown[]> {
   const settled = await Promise.allSettled(
     thunks.map((t) => Promise.resolve().then(t)),
@@ -1530,13 +1533,32 @@ async function settleToNullArray(
   // return — all of which surface as the same `null` to the script by
   // design. The log line is the only operator-side signal of which path
   // fired; the contract to the script stays opaque.
-  return settled.map((r, i) => {
+  //
+  // P5 R3 Gap-3: budget-exhausted drops are counted separately and
+  // summarized so an operator can distinguish "N slots dropped because the
+  // token budget was hit" (expected, capacity-shaped) from arbitrary
+  // dispatch failures. Duck-type on the error name because the rejection
+  // reason may be a cross-realm Error whose `instanceof` is unreliable.
+  let budgetDropped = 0;
+  const result = settled.map((r, i) => {
     if (r.status === 'fulfilled') return r.value;
-    debugLogger.warn(
-      `Workflow thunk at index ${i} rejected: ${String((r.reason as { message?: unknown })?.message ?? r.reason)}`,
-    );
+    const reason = r.reason as { name?: unknown; message?: unknown };
+    if (reason?.name === 'WorkflowBudgetExceededError') {
+      budgetDropped += 1;
+    } else {
+      debugLogger.warn(
+        `Workflow thunk at index ${i} rejected: ${String(reason?.message ?? r.reason)}`,
+      );
+    }
     return null;
   });
+  if (budgetDropped > 0) {
+    debugLogger.warn(
+      `${kind}: ${budgetDropped} slot${budgetDropped === 1 ? '' : 's'} ` +
+        `dropped — token budget exceeded.`,
+    );
+  }
+  return result;
 }
 
 /**
@@ -1615,7 +1637,7 @@ function makePipelineImpl(
     const chains = items.map(
       (item, idx) => () => runPipelineChain(item, idx, stages),
     );
-    return settleToNullArray(chains, signal);
+    return settleToNullArray(chains, signal, 'pipeline');
   };
 }
 

--- a/packages/core/src/agents/runtime/workflow-orchestrator.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.ts
@@ -240,6 +240,22 @@ export interface WorkflowRunRequest {
    * `budget.recordSpent(N)` directly.
    */
   budget?: WorkflowBudget;
+  /**
+   * P-nested: resolver for the `workflow(nameOrRef, args)` global. When
+   * provided, the top-level sandbox exposes `workflow`, which resolves a
+   * saved workflow (by name from `.qwen/workflows/<name>.js`, or by
+   * `{scriptPath}`) and runs it as a nested orchestration that shares THIS
+   * run's agent-count cap, concurrency window, token budget, and emitter
+   * (so nested phases/logs and token spend roll into the same registry
+   * entry). Nesting is limited to a single level: the nested sandbox is
+   * created without a `workflow` impl, so a second-level `workflow()` call
+   * throws. When omitted, `workflow()` throws "unavailable". The production
+   * caller (`WorkflowTool`) wires `resolveSavedWorkflowScript(ref, config)`;
+   * tests inject a mock resolver.
+   */
+  resolveSavedWorkflow?: (
+    nameOrRef: string | { scriptPath: string },
+  ) => Promise<{ script: string; scriptPath?: string; name?: string }>;
 }
 
 export interface WorkflowRunOutcome {
@@ -1339,11 +1355,45 @@ export class WorkflowOrchestrator {
     const parallelImpl = makeParallelImpl(signal);
     const pipelineImpl = makePipelineImpl(signal);
 
+    // P-nested: build the host-side `workflow(nameOrRef, args)` impl. Only
+    // wired at the top level (when a resolver is provided). The nested
+    // sandbox shares THIS run's countedDispatch (so agentCount cap + budget
+    // gate are global across parent + nested), the same concurrency window
+    // (parallelImpl / pipelineImpl close over the shared `signal`/limiter),
+    // the same budget, and the same emitter (nested phase()/log() and token
+    // spend roll into the same registry entry). Crucially the nested sandbox
+    // is created WITHOUT a `workflow` impl — that throws on a second-level
+    // `workflow()` call, enforcing the single-level nesting limit.
+    const resolveSavedWorkflow = req.resolveSavedWorkflow;
+    const workflowImpl = resolveSavedWorkflow
+      ? async (
+          nameOrRef: string | { scriptPath: string },
+          nestedArgs: unknown,
+        ): Promise<unknown> => {
+          const resolved = await resolveSavedWorkflow(nameOrRef);
+          const nestedSandbox = createWorkflowSandbox({
+            args: nestedArgs,
+            dispatch: countedDispatch,
+            parallel: parallelImpl,
+            pipeline: pipelineImpl,
+            abortOnTimeout: req.abortOnTimeout,
+            emitter,
+            budget,
+            // No `workflow` — single-level nesting limit.
+          });
+          // sandbox.run() throws raw (no WorkflowExecutionError wrap); the
+          // rejection crosses back to the parent script's `await workflow()`
+          // so the parent can try/catch it like any other async failure.
+          return nestedSandbox.run(resolved.script);
+        }
+      : undefined;
+
     const sandbox = createWorkflowSandbox({
       args: req.args,
       dispatch: countedDispatch,
       parallel: parallelImpl,
       pipeline: pipelineImpl,
+      workflow: workflowImpl,
       abortOnTimeout: req.abortOnTimeout,
       emitter,
       budget,

--- a/packages/core/src/agents/runtime/workflow-orchestrator.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.ts
@@ -17,7 +17,7 @@ import type {
 } from './workflow-sandbox.js';
 import { WorkflowBudgetExceededError } from './workflow-budget.js';
 import { resolveStallMs, runStallResilient } from './workflow-stall.js';
-import { deriveAgentKey } from './workflow-journal.js';
+import { deriveAgentKey, deriveArgsSeed } from './workflow-journal.js';
 import type { WorkflowJournal, JournalReplay } from './workflow-journal.js';
 import {
   WORKFLOW_SUBAGENT_SYSTEM_PROMPT,
@@ -1301,7 +1301,10 @@ export class WorkflowOrchestrator {
     // trusts the cache). `journalAgentId` numbers journal entries.
     const journal = req.journal;
     const replay = req.resumeReplay;
-    let prefixHash = '';
+    // Seed the chain with the run's `args` so a resume with different args
+    // produces a disjoint key space (every dispatch misses → re-runs live)
+    // rather than silently replaying the prior run's results.
+    let prefixHash = deriveArgsSeed(req.args);
     let hadMiss = false;
     let journalAgentId = 0;
 

--- a/packages/core/src/agents/runtime/workflow-sandbox.test.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.test.ts
@@ -1036,14 +1036,46 @@ describe('createWorkflowSandbox security', () => {
     ).rejects.toThrow(/pipeline\(\) is unavailable/);
   });
 
-  it('workflow() throws a P1-unsupported error rather than ReferenceError', async () => {
+  it('workflow() throws "unavailable" when no workflow impl is injected (bare sandbox / nesting limit)', async () => {
     const sandbox = createWorkflowSandbox({
       args: undefined,
       dispatch: async () => 'ignored',
     });
     await expect(
       sandbox.run(`return workflow('child', { foo: 1 });`),
-    ).rejects.toThrow(/workflow\(\).*not supported in P1/);
+    ).rejects.toThrow(/workflow\(\) is unavailable here/);
+  });
+
+  it('workflow() resolves through the injected host impl (single result revived)', async () => {
+    const sandbox = createWorkflowSandbox({
+      args: undefined,
+      dispatch: async () => 'ignored',
+      workflow: async (nameOrRef, wfArgs) => ({
+        echoedRef: nameOrRef,
+        echoedArgs: wfArgs,
+      }),
+    });
+    const result = await sandbox.run(
+      `return await workflow('child', { foo: 1 });`,
+    );
+    expect(result).toEqual({
+      echoedRef: 'child',
+      echoedArgs: { foo: 1 },
+    });
+  });
+
+  it('workflow({scriptPath}) passes the object ref through to the host impl', async () => {
+    let received: unknown;
+    const sandbox = createWorkflowSandbox({
+      args: undefined,
+      dispatch: async () => 'ignored',
+      workflow: async (nameOrRef) => {
+        received = nameOrRef;
+        return 'ok';
+      },
+    });
+    await sandbox.run(`return await workflow({ scriptPath: '/tmp/x.js' });`);
+    expect(received).toEqual({ scriptPath: '/tmp/x.js' });
   });
 
   it('budget.spent() / .remaining() throw with clear P1-unsupported errors', async () => {

--- a/packages/core/src/agents/runtime/workflow-sandbox.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.ts
@@ -478,6 +478,20 @@ export interface SandboxOptions {
       (prev: unknown, item: unknown, idx: number) => Promise<unknown>
     >
   ) => Promise<unknown[]>;
+  /**
+   * Host-side `workflow(nameOrRef, args)` implementation. When provided, the
+   * sandbox exposes the `workflow` global that resolves a saved workflow
+   * (by name from `.qwen/workflows/<name>.js`, or by `{scriptPath}`) and runs
+   * it as a nested orchestration sharing this run's agent-count cap and token
+   * budget. When omitted the sandbox falls back to a throwing stub — this is
+   * also how single-level nesting is enforced: the orchestrator injects
+   * `workflow` only at the top level, so a nested workflow's sandbox has no
+   * `workflow` impl and a second-level `workflow()` call throws.
+   */
+  workflow?: (
+    nameOrRef: string | { scriptPath: string },
+    args: unknown,
+  ) => Promise<unknown>;
   budget?: WorkflowBudget;
   /**
    * T23 (PR #4732 R2): async wall-clock cap (ms) covering the entire script
@@ -699,9 +713,11 @@ export function createWorkflowSandbox(opts: SandboxOptions): WorkflowSandbox {
     // init script without leaking the host function itself when not used.
     hasParallel: !!opts.parallel,
     hasPipeline: !!opts.pipeline,
+    hasWorkflow: !!opts.workflow,
     hasBudget: !!opts.budget,
     hostParallel: opts.parallel,
     hostPipeline: opts.pipeline,
+    hostWorkflow: opts.workflow,
     budgetTotal: opts.budget ? opts.budget.total : null,
     hostBudgetSpent: opts.budget ? opts.budget.spent.bind(opts.budget) : null,
     hostBudgetRemaining: opts.budget
@@ -995,15 +1011,64 @@ export function createWorkflowSandbox(opts: SandboxOptions): WorkflowSandbox {
           });
         };
       }
-      // workflow() always throws in P1.
-      globalThis.workflow = function workflow() {
-        return new Promise(function (_, reject) {
-          reject(new Error(
-            'workflow() (nested workflow invocation) is not supported in P1. ' +
-            'Scheduled for a later phase.'
-          ));
+      // --- workflow (nested, single-level) ---
+      // Mirrors agent(): args cross vm→host verbatim (safe direction), the
+      // single result is revived back into the vm realm via JSON round-trip
+      // (same T1/T8/T14 escape defense as agent / parallel / pipeline). The
+      // host impl resolves a saved workflow and runs it sharing this run's
+      // agent-count cap + token budget. When __b.hasWorkflow is false, the
+      // sandbox is either bare (no resolver wired) OR is itself a nested
+      // workflow — in both cases workflow() must throw, which is how the
+      // single-level nesting limit is enforced (a nested sandbox is created
+      // without a workflow impl, so its workflow() lands in the else branch).
+      if (__b.hasWorkflow) {
+        const callWorkflow = vmAsync(function (nameOrRef, wfArgs) {
+          // Sanitize args through a JSON round-trip BEFORE crossing so the
+          // host only ever sees vm-realm plain objects (same defense as
+          // agent()'s safeOpts). nameOrRef may be a string or {scriptPath}.
+          var safeRef;
+          var safeArgs;
+          try {
+            safeRef = nameOrRef === undefined
+              ? undefined
+              : JSON.parse(JSON.stringify(nameOrRef));
+            safeArgs = wfArgs === undefined
+              ? undefined
+              : JSON.parse(JSON.stringify(wfArgs));
+          } catch (e) {
+            throw new Error(
+              'workflow() received a non-JSON-serializable argument: ' +
+              String(e && e.message != null ? e.message : e)
+            );
+          }
+          return __b.hostWorkflow(safeRef, safeArgs).then(function (value) {
+            if (value === null || typeof value !== 'object') {
+              return value;
+            }
+            try {
+              return JSON.parse(JSON.stringify(value));
+            } catch (e) {
+              __b.logRevivalFailure(0, String(e && e.message != null ? e.message : e));
+              return null;
+            }
+          });
         });
-      };
+        globalThis.workflow = function workflow(nameOrRef, wfArgs) {
+          return callWorkflow(nameOrRef, wfArgs);
+        };
+      } else {
+        globalThis.workflow = function workflow() {
+          return new Promise(function (_, reject) {
+            reject(new Error(
+              "workflow() is unavailable here. Either this sandbox was created " +
+              "without a saved-workflow resolver, or this script is already " +
+              "running as a nested workflow — workflow() nesting is limited to " +
+              "a single level (a workflow cannot call another workflow that " +
+              "itself calls workflow())."
+            ));
+          });
+        };
+      }
 
       // --- budget ---
       const safeBudget = Object.create(null);

--- a/packages/core/src/agents/runtime/workflow-sandbox.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.ts
@@ -394,6 +394,14 @@ export interface WorkflowAgentOpts {
   model?: string;
   isolation?: 'worktree' | 'remote';
   agentType?: string;
+  /**
+   * P-stall: per-call stall-watchdog timeout in milliseconds. The dispatch
+   * is aborted + retried (up to 3 attempts) after this many ms of no
+   * subagent progress (with no tool in flight). Defaults to 60_000 (env
+   * override `QWEN_CODE_WORKFLOW_STALL_SECONDS`). `0` disables the watchdog
+   * for this call.
+   */
+  stallMs?: number;
   // The index signature exists so TypeScript accepts forward-compat opt names
   // at compile time; the runtime allowlist still rejects unknown names.
   [key: string]: unknown;
@@ -838,7 +846,7 @@ export function createWorkflowSandbox(opts: SandboxOptions): WorkflowSandbox {
       // FIX-Round1-T13: throw on any opts key not in the allowlist — catches
       // typos like { scema: ... } that previously slipped through the
       // [key:string]: unknown index signature.
-      const KNOWN_AGENT_OPTS = ['label', 'phase', 'schema', 'model', 'isolation', 'agentType'];
+      const KNOWN_AGENT_OPTS = ['label', 'phase', 'schema', 'model', 'isolation', 'agentType', 'stallMs'];
       globalThis.agent = vmAsync(function (prompt, agentOpts) {
         agentOpts = agentOpts || {};
         const keys = Object.keys(agentOpts);

--- a/packages/core/src/agents/runtime/workflow-saved.test.ts
+++ b/packages/core/src/agents/runtime/workflow-saved.test.ts
@@ -1,0 +1,214 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { Config } from '../../config/config.js';
+import { Storage } from '../../config/storage.js';
+import {
+  listSavedWorkflows,
+  resolveSavedWorkflowScript,
+  validateWorkflowName,
+  WORKFLOW_NAME_PATTERN,
+} from './workflow-saved.js';
+
+/**
+ * Build a Config whose `.storage` points at `projectDir`, and point the
+ * user scope (`~/.qwen`) at `userHome` via the QWEN_HOME env override so
+ * tests never touch the real home directory.
+ */
+function fakeConfig(projectDir: string): Config {
+  return { storage: new Storage(projectDir) } as unknown as Config;
+}
+
+async function writeWorkflow(
+  dir: string,
+  name: string,
+  body: string,
+): Promise<void> {
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, `${name}.js`), body, 'utf8');
+}
+
+describe('workflow-saved', () => {
+  let projectDir: string;
+  let userHome: string;
+  let prevQwenHome: string | undefined;
+
+  beforeEach(async () => {
+    projectDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wf-proj-'));
+    userHome = await fs.mkdtemp(path.join(os.tmpdir(), 'wf-user-'));
+    prevQwenHome = process.env['QWEN_HOME'];
+    // Storage.getGlobalQwenDir() reads QWEN_HOME, else ~/.qwen. Point it at
+    // `<userHome>/.qwen` so the user scope is sandboxed.
+    process.env['QWEN_HOME'] = path.join(userHome, '.qwen');
+  });
+
+  afterEach(async () => {
+    if (prevQwenHome === undefined) delete process.env['QWEN_HOME'];
+    else process.env['QWEN_HOME'] = prevQwenHome;
+    await fs.rm(projectDir, { recursive: true, force: true });
+    await fs.rm(userHome, { recursive: true, force: true });
+  });
+
+  describe('validateWorkflowName / WORKFLOW_NAME_PATTERN', () => {
+    it.each([
+      ['deep-research', true],
+      ['audit2', true],
+      ['a', true],
+      ['Deep-Research', false], // upper-case
+      ['1abc', false], // leading digit
+      ['has space', false],
+      ['has.dot', false],
+      ['has/slash', false],
+      ['', false],
+    ])('"%s" valid=%s', (name, valid) => {
+      expect(WORKFLOW_NAME_PATTERN.test(name)).toBe(valid);
+      expect(validateWorkflowName(name) === null).toBe(valid);
+    });
+  });
+
+  describe('resolveSavedWorkflowScript — by name', () => {
+    it('resolves a project-scope workflow', async () => {
+      await writeWorkflow(
+        new Storage(projectDir).getProjectWorkflowsDir(),
+        'foo',
+        `return 'project-foo';`,
+      );
+      const resolved = await resolveSavedWorkflowScript(
+        'foo',
+        fakeConfig(projectDir),
+      );
+      expect(resolved.name).toBe('foo');
+      expect(resolved.script).toBe(`return 'project-foo';`);
+      expect(resolved.scriptPath).toContain('foo.js');
+    });
+
+    it('resolves a user-scope workflow when project lacks it', async () => {
+      await writeWorkflow(
+        Storage.getUserWorkflowsDir(),
+        'bar',
+        `return 'user-bar';`,
+      );
+      const resolved = await resolveSavedWorkflowScript(
+        'bar',
+        fakeConfig(projectDir),
+      );
+      expect(resolved.script).toBe(`return 'user-bar';`);
+    });
+
+    it('project scope wins over user scope for the same name', async () => {
+      await writeWorkflow(
+        new Storage(projectDir).getProjectWorkflowsDir(),
+        'dup',
+        `return 'PROJECT';`,
+      );
+      await writeWorkflow(
+        Storage.getUserWorkflowsDir(),
+        'dup',
+        `return 'USER';`,
+      );
+      const resolved = await resolveSavedWorkflowScript(
+        'dup',
+        fakeConfig(projectDir),
+      );
+      expect(resolved.script).toBe(`return 'PROJECT';`);
+    });
+
+    it('throws with available names on a miss', async () => {
+      await writeWorkflow(
+        new Storage(projectDir).getProjectWorkflowsDir(),
+        'alpha',
+        `return 1;`,
+      );
+      await expect(
+        resolveSavedWorkflowScript('missing', fakeConfig(projectDir)),
+      ).rejects.toThrow(/no workflow with that name. Available: alpha/);
+    });
+
+    it('throws "(none)" when no saved workflows exist', async () => {
+      await expect(
+        resolveSavedWorkflowScript('missing', fakeConfig(projectDir)),
+      ).rejects.toThrow(/Available: \(none\)/);
+    });
+  });
+
+  describe('resolveSavedWorkflowScript — by {scriptPath}', () => {
+    it('reads an explicit script path', async () => {
+      const p = path.join(projectDir, 'custom.js');
+      await fs.writeFile(p, `return 'custom';`, 'utf8');
+      const resolved = await resolveSavedWorkflowScript(
+        { scriptPath: p },
+        fakeConfig(projectDir),
+      );
+      expect(resolved.script).toBe(`return 'custom';`);
+      expect(resolved.name).toBe('custom');
+    });
+
+    it('throws a clear error for an unreadable path', async () => {
+      await expect(
+        resolveSavedWorkflowScript(
+          { scriptPath: path.join(projectDir, 'nope.js') },
+          fakeConfig(projectDir),
+        ),
+      ).rejects.toThrow(/cannot read file/);
+    });
+
+    it('rejects an empty scriptPath', async () => {
+      await expect(
+        resolveSavedWorkflowScript(
+          { scriptPath: '' },
+          fakeConfig(projectDir),
+        ),
+      ).rejects.toThrow(/workflow name \(string\) or \{scriptPath/);
+    });
+  });
+
+  describe('listSavedWorkflows', () => {
+    it('merges both scopes, project shadows user, sorted by name', async () => {
+      await writeWorkflow(
+        new Storage(projectDir).getProjectWorkflowsDir(),
+        'zeta',
+        `return 1;`,
+      );
+      await writeWorkflow(
+        new Storage(projectDir).getProjectWorkflowsDir(),
+        'shared',
+        `return 'P';`,
+      );
+      await writeWorkflow(
+        Storage.getUserWorkflowsDir(),
+        'alpha',
+        `return 1;`,
+      );
+      await writeWorkflow(
+        Storage.getUserWorkflowsDir(),
+        'shared',
+        `return 'U';`,
+      );
+      const list = await listSavedWorkflows(fakeConfig(projectDir));
+      expect(list.map((e) => e.name)).toEqual(['alpha', 'shared', 'zeta']);
+      const shared = list.find((e) => e.name === 'shared')!;
+      expect(shared.source).toBe('project'); // project shadows user
+    });
+
+    it('skips files whose stem is not a legal workflow name', async () => {
+      const dir = new Storage(projectDir).getProjectWorkflowsDir();
+      await writeWorkflow(dir, 'good-one', `return 1;`);
+      // Illegal stem: leading digit. Should be skipped.
+      await fs.writeFile(path.join(dir, '9bad.js'), `return 1;`, 'utf8');
+      const list = await listSavedWorkflows(fakeConfig(projectDir));
+      expect(list.map((e) => e.name)).toEqual(['good-one']);
+    });
+
+    it('returns empty when no workflows dir exists', async () => {
+      const list = await listSavedWorkflows(fakeConfig(projectDir));
+      expect(list).toEqual([]);
+    });
+  });
+});

--- a/packages/core/src/agents/runtime/workflow-saved.test.ts
+++ b/packages/core/src/agents/runtime/workflow-saved.test.ts
@@ -13,6 +13,7 @@ import { Storage } from '../../config/storage.js';
 import {
   listSavedWorkflows,
   resolveSavedWorkflowScript,
+  saveWorkflowScript,
   validateWorkflowName,
   WORKFLOW_NAME_PATTERN,
 } from './workflow-saved.js';
@@ -209,6 +210,95 @@ describe('workflow-saved', () => {
     it('returns empty when no workflows dir exists', async () => {
       const list = await listSavedWorkflows(fakeConfig(projectDir));
       expect(list).toEqual([]);
+    });
+  });
+
+  describe('saveWorkflowScript', () => {
+    it('writes a new project-scope workflow and reports the path', async () => {
+      const config = fakeConfig(projectDir);
+      const result = await saveWorkflowScript(config, {
+        name: 'my-flow',
+        scope: 'project',
+        script: 'return 42;',
+      });
+      expect(result.status).toBe('saved');
+      if (result.status !== 'saved') throw new Error('expected saved');
+      const written = await fs.readFile(result.path, 'utf8');
+      expect(written).toBe('return 42;');
+      // Round-trips through discovery as a /<name> candidate.
+      const list = await listSavedWorkflows(config);
+      expect(list.map((e) => e.name)).toContain('my-flow');
+    });
+
+    it('writes a user-scope workflow under the sandboxed QWEN_HOME', async () => {
+      const config = fakeConfig(projectDir);
+      const result = await saveWorkflowScript(config, {
+        name: 'user-flow',
+        scope: 'user',
+        script: 'return 1;',
+      });
+      expect(result.status).toBe('saved');
+      if (result.status !== 'saved') throw new Error('expected saved');
+      expect(result.path).toContain(path.join(userHome, '.qwen'));
+      expect(result.scope).toBe('user');
+    });
+
+    it('refuses an invalid name without writing', async () => {
+      const config = fakeConfig(projectDir);
+      const result = await saveWorkflowScript(config, {
+        name: 'Bad Name',
+        scope: 'project',
+        script: 'return 1;',
+      });
+      expect(result.status).toBe('invalid-name');
+      expect(await listSavedWorkflows(config)).toEqual([]);
+    });
+
+    it('rejects an empty script', async () => {
+      const result = await saveWorkflowScript(fakeConfig(projectDir), {
+        name: 'empty',
+        scope: 'project',
+        script: '   ',
+      });
+      expect(result.status).toBe('empty-script');
+    });
+
+    it('reports `exists` for a collision and does not clobber by default', async () => {
+      const config = fakeConfig(projectDir);
+      await saveWorkflowScript(config, {
+        name: 'dup',
+        scope: 'project',
+        script: 'return "original";',
+      });
+      const result = await saveWorkflowScript(config, {
+        name: 'dup',
+        scope: 'project',
+        script: 'return "replacement";',
+      });
+      expect(result.status).toBe('exists');
+      if (result.status !== 'exists') throw new Error('expected exists');
+      // Original is untouched.
+      expect(await fs.readFile(result.path, 'utf8')).toBe('return "original";');
+    });
+
+    it('overwrites when overwrite:true', async () => {
+      const config = fakeConfig(projectDir);
+      await saveWorkflowScript(config, {
+        name: 'dup',
+        scope: 'project',
+        script: 'return "original";',
+      });
+      const result = await saveWorkflowScript(config, {
+        name: 'dup',
+        scope: 'project',
+        script: 'return "replacement";',
+        overwrite: true,
+      });
+      expect(result.status).toBe('saved');
+      if (result.status !== 'saved') throw new Error('expected saved');
+      expect(await fs.readFile(result.path, 'utf8')).toBe(
+        'return "replacement";',
+      );
     });
   });
 });

--- a/packages/core/src/agents/runtime/workflow-saved.test.ts
+++ b/packages/core/src/agents/runtime/workflow-saved.test.ts
@@ -341,4 +341,65 @@ describe('workflow-saved', () => {
       );
     });
   });
+
+  // Security (round 3, r3451228756): the saved-workflow ROOT dir itself being a
+  // symlink must not turn its external target into the trusted boundary. Round 1
+  // only guarded symlinked *files* inside the dir; a symlinked dir slips past
+  // that guard because the entries it exposes are regular files, and
+  // `readWorkflowFileSecurely` realpaths the root — laundering the link into the
+  // allowed boundary. Refuse for discovery, read, and save.
+  describe('security — symlinked root workflow dir', () => {
+    let external: string;
+    let projectWorkflowsDir: string;
+
+    beforeEach(async () => {
+      // Attacker-controlled external dir with a planted secret-bearing script.
+      external = await fs.mkdtemp(path.join(os.tmpdir(), 'wf-evil-'));
+      await fs.writeFile(
+        path.join(external, 'leak.js'),
+        `return 'EXFILTRATED';`,
+        'utf8',
+      );
+      // Make `<projectDir>/.qwen/workflows` a symlink to that external dir.
+      projectWorkflowsDir = new Storage(projectDir).getProjectWorkflowsDir();
+      await fs.mkdir(path.dirname(projectWorkflowsDir), { recursive: true });
+      await fs.symlink(external, projectWorkflowsDir, 'dir');
+    });
+
+    afterEach(async () => {
+      await fs.rm(external, { recursive: true, force: true });
+    });
+
+    it('discovery excludes scripts behind a symlinked project root', async () => {
+      const list = await listSavedWorkflows(fakeConfig(projectDir));
+      expect(list).toEqual([]);
+    });
+
+    it("workflow('leak') is refused, not read, through a symlinked root", async () => {
+      await expect(
+        resolveSavedWorkflowScript('leak', fakeConfig(projectDir)),
+      ).rejects.toThrow(/no workflow with that name/);
+    });
+
+    it('{scriptPath} into a symlinked root is refused', async () => {
+      const p = path.join(projectWorkflowsDir, 'leak.js');
+      await expect(
+        resolveSavedWorkflowScript({ scriptPath: p }, fakeConfig(projectDir)),
+      ).rejects.toThrow(/outside the saved-workflow directories/);
+    });
+
+    it('save into a symlinked root is refused (no write-through)', async () => {
+      await expect(
+        saveWorkflowScript(fakeConfig(projectDir), {
+          name: 'planted',
+          scope: 'project',
+          script: 'return 1;',
+        }),
+      ).rejects.toThrow(/symlinked saved-workflow director/i);
+      // Nothing was written through the link.
+      await expect(
+        fs.access(path.join(external, 'planted.js')),
+      ).rejects.toThrow();
+    });
+  });
 });

--- a/packages/core/src/agents/runtime/workflow-saved.test.ts
+++ b/packages/core/src/agents/runtime/workflow-saved.test.ts
@@ -140,8 +140,10 @@ describe('workflow-saved', () => {
   });
 
   describe('resolveSavedWorkflowScript — by {scriptPath}', () => {
-    it('reads an explicit script path', async () => {
-      const p = path.join(projectDir, 'custom.js');
+    it('reads a script path inside a saved-workflow dir', async () => {
+      const dir = new Storage(projectDir).getProjectWorkflowsDir();
+      await fs.mkdir(dir, { recursive: true });
+      const p = path.join(dir, 'custom.js');
       await fs.writeFile(p, `return 'custom';`, 'utf8');
       const resolved = await resolveSavedWorkflowScript(
         { scriptPath: p },
@@ -151,13 +153,15 @@ describe('workflow-saved', () => {
       expect(resolved.name).toBe('custom');
     });
 
-    it('throws a clear error for an unreadable path', async () => {
+    it('throws a clear error for a missing path under a saved dir', async () => {
+      const dir = new Storage(projectDir).getProjectWorkflowsDir();
+      await fs.mkdir(dir, { recursive: true });
       await expect(
         resolveSavedWorkflowScript(
-          { scriptPath: path.join(projectDir, 'nope.js') },
+          { scriptPath: path.join(dir, 'nope.js') },
           fakeConfig(projectDir),
         ),
-      ).rejects.toThrow(/cannot read file/);
+      ).rejects.toThrow(/scriptPath/);
     });
 
     it('rejects an empty scriptPath', async () => {
@@ -167,6 +171,28 @@ describe('workflow-saved', () => {
           fakeConfig(projectDir),
         ),
       ).rejects.toThrow(/workflow name \(string\) or \{scriptPath/);
+    });
+
+    // Security (#2): a scriptPath resolving outside the saved-workflow dirs is
+    // refused, even when the file exists.
+    it('refuses a scriptPath outside the saved-workflow directories', async () => {
+      const outside = path.join(projectDir, 'evil.js');
+      await fs.writeFile(outside, `return 'pwned';`, 'utf8');
+      await expect(
+        resolveSavedWorkflowScript(
+          { scriptPath: outside },
+          fakeConfig(projectDir),
+        ),
+      ).rejects.toThrow(/outside the saved-workflow directories/);
+    });
+  });
+
+  // Security (#2): the string-name form must not escape the saved dirs.
+  describe('resolveSavedWorkflowScript — name traversal', () => {
+    it('rejects a traversal name before any path join', async () => {
+      await expect(
+        resolveSavedWorkflowScript('../../outside', fakeConfig(projectDir)),
+      ).rejects.toThrow(/Invalid workflow name|lower-case/);
     });
   });
 
@@ -210,6 +236,20 @@ describe('workflow-saved', () => {
     it('returns empty when no workflows dir exists', async () => {
       const list = await listSavedWorkflows(fakeConfig(projectDir));
       expect(list).toEqual([]);
+    });
+
+    // Security (#4): a symlinked `<name>.js` could point at an arbitrary file
+    // (e.g. credentials); discovery must skip it so it never reaches the
+    // snapshot `script` field / telemetry.
+    it('skips symlinked entries', async () => {
+      const dir = new Storage(projectDir).getProjectWorkflowsDir();
+      await fs.mkdir(dir, { recursive: true });
+      const secret = path.join(projectDir, 'secret.txt');
+      await fs.writeFile(secret, 'TOP SECRET', 'utf8');
+      await fs.symlink(secret, path.join(dir, 'leak.js'));
+      await writeWorkflow(dir, 'real', `return 1;`);
+      const list = await listSavedWorkflows(fakeConfig(projectDir));
+      expect(list.map((e) => e.name)).toEqual(['real']);
     });
   });
 

--- a/packages/core/src/agents/runtime/workflow-saved.ts
+++ b/packages/core/src/agents/runtime/workflow-saved.ts
@@ -87,7 +87,32 @@ export function getSavedWorkflowDirs(config: Config): Array<{
   ];
 }
 
+/**
+ * True when a saved-workflow root dir is itself a symlink. `readWorkflowFileSecurely`
+ * realpaths the root so it can tolerate symlinked *ancestors* (e.g. a project under
+ * macOS `/tmp -> /private/tmp`); but that same laundering turns a checked-in
+ * `.qwen/workflows -> /outside` link into the allowed boundary — letting discovery
+ * list, `workflow('<name>')` read, and the save dialog write external files. The
+ * per-entry symlink check in {@link listJsFiles} can't catch this because the link
+ * is the dir, not the files it exposes. So we refuse a symlinked root outright for
+ * all three operations. A missing dir (the common case) is not a symlink, so this
+ * is transparent until someone actually links the dir.
+ */
+async function isSymlinkedRoot(dir: string): Promise<boolean> {
+  return fs
+    .lstat(dir)
+    .then((st) => st.isSymbolicLink())
+    .catch(() => false);
+}
+
 async function listJsFiles(dir: string): Promise<string[]> {
+  // Refuse a symlinked root dir: `readdir` would otherwise enumerate the
+  // external target's `*.js` files as project workflows, and the per-entry
+  // symlink check below can't see it (the link is the dir, not the entries).
+  if (await isSymlinkedRoot(dir)) {
+    debugLogger.warn(`refusing symlinked saved-workflow dir: ${dir}`);
+    return [];
+  }
   try {
     const names = await fs.readdir(dir);
     const out: string[] = [];
@@ -124,15 +149,21 @@ async function readWorkflowFileSecurely(
   config: Config,
 ): Promise<string> {
   const real = await fs.realpath(filePath); // throws ENOENT if absent
-  const dirs = await Promise.all(
-    getSavedWorkflowDirs(config).map(async ({ dir }) => {
-      try {
-        return await fs.realpath(dir);
-      } catch {
-        return path.resolve(dir);
-      }
-    }),
-  );
+  const dirs = (
+    await Promise.all(
+      getSavedWorkflowDirs(config).map(async ({ dir }) => {
+        // Exclude a symlinked root: realpath(dir) would launder a
+        // `.qwen/workflows -> /outside` link into the allowed boundary, so a
+        // file resolving under the link's target would pass the check below.
+        if (await isSymlinkedRoot(dir)) return null;
+        try {
+          return await fs.realpath(dir);
+        } catch {
+          return path.resolve(dir);
+        }
+      }),
+    )
+  ).filter((d): d is string => d !== null);
   const inside = dirs.some(
     (d) => real === d || real.startsWith(d + path.sep),
   );
@@ -266,6 +297,14 @@ export async function saveWorkflowScript(
     scope === 'project'
       ? config.storage.getProjectWorkflowsDir()
       : Storage.getUserWorkflowsDir();
+  // Refuse to write through a symlinked root (e.g. `.qwen/workflows -> /outside`):
+  // it would persist the script outside the project/user workflow dir. The save
+  // overlay's try/catch surfaces this message as a user-facing error.
+  if (await isSymlinkedRoot(dir)) {
+    throw new Error(
+      `refusing to save into a symlinked saved-workflow directory: '${dir}'.`,
+    );
+  }
   const filePath = path.join(dir, `${name}.js`);
   if (!overwrite) {
     try {

--- a/packages/core/src/agents/runtime/workflow-saved.ts
+++ b/packages/core/src/agents/runtime/workflow-saved.ts
@@ -53,6 +53,13 @@ export interface ResolvedSavedWorkflow {
   script: string;
 }
 
+/** Result of a {@link saveWorkflowScript} attempt. */
+export type WorkflowSaveResult =
+  | { status: 'saved'; name: string; scope: SavedWorkflowSource; path: string }
+  | { status: 'exists'; name: string; scope: SavedWorkflowSource; path: string }
+  | { status: 'invalid-name'; error: string }
+  | { status: 'empty-script'; error: string };
+
 /**
  * Validate a saved-workflow name. Returns an error string when invalid,
  * `null` when OK. Shared by the save dialog (CLI) and any caller that
@@ -173,4 +180,51 @@ export async function resolveSavedWorkflowScript(
     `workflow('${name}'): no workflow with that name. Available: ` +
       `${available.length > 0 ? available.join(', ') : '(none)'}.`,
   );
+}
+
+/**
+ * Save a workflow script to `.qwen/workflows/<name>.js` (project) or
+ * `~/.qwen/workflows/<name>.js` (user). Powers the `/workflows` save dialog.
+ *
+ * Validates the name and refuses to clobber an existing file unless
+ * `overwrite` is set (the dialog uses the `exists` result to prompt for
+ * confirmation, then retries with `overwrite: true`). Returns a discriminated
+ * result rather than throwing on the expected user-facing failures
+ * (invalid name, empty script, name collision); only a genuine I/O failure
+ * (mkdir / writeFile) rejects.
+ */
+export async function saveWorkflowScript(
+  config: Config,
+  opts: {
+    name: string;
+    scope: SavedWorkflowSource;
+    script: string;
+    overwrite?: boolean;
+  },
+): Promise<WorkflowSaveResult> {
+  const { name, scope, script, overwrite = false } = opts;
+  const nameError = validateWorkflowName(name);
+  if (nameError) return { status: 'invalid-name', error: nameError };
+  if (!script || script.trim().length === 0) {
+    return {
+      status: 'empty-script',
+      error: 'This run has no script source to save.',
+    };
+  }
+  const dir =
+    scope === 'project'
+      ? config.storage.getProjectWorkflowsDir()
+      : Storage.getUserWorkflowsDir();
+  const filePath = path.join(dir, `${name}.js`);
+  if (!overwrite) {
+    try {
+      await fs.access(filePath);
+      return { status: 'exists', name, scope, path: filePath };
+    } catch {
+      // Doesn't exist — fall through and write.
+    }
+  }
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(filePath, script, 'utf8');
+  return { status: 'saved', name, scope, path: filePath };
 }

--- a/packages/core/src/agents/runtime/workflow-saved.ts
+++ b/packages/core/src/agents/runtime/workflow-saved.ts
@@ -1,0 +1,176 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Saved-workflow resolution. Workflow scripts persisted at
+ * `.qwen/workflows/<name>.js` (project) or `~/.qwen/workflows/<name>.js`
+ * (user) are both surfaced as slash commands (CLI: `SavedWorkflowLoader`)
+ * AND resolvable by name from inside a running workflow via the
+ * `workflow('<name>')` global (core: `WorkflowOrchestrator`). This module
+ * is the single source of truth for the directory layout, the filename
+ * convention, and the read/list logic shared by both consumers.
+ *
+ * Precedence: when the same `<name>.js` exists in both scopes, the
+ * project-level file wins (matches `FileCommandLoader`'s project-over-user
+ * precedence for custom commands).
+ */
+
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import type { Config } from '../../config/config.js';
+import { Storage } from '../../config/storage.js';
+import { createDebugLogger } from '../../utils/debugLogger.js';
+
+const debugLogger = createDebugLogger('WORKFLOW_SAVED');
+
+/**
+ * Saved-workflow name constraint. Lower-case, digits, hyphens; must start
+ * with a letter. The name doubles as the `.js` filename stem AND the slash
+ * command name (`deep-research.js` → `/deep-research`), so it must be safe
+ * for both a path segment and a command token (no spaces, dots, slashes).
+ */
+export const WORKFLOW_NAME_PATTERN = /^[a-z][a-z0-9-]{0,40}$/;
+
+export type SavedWorkflowSource = 'project' | 'user';
+
+/** One discovered saved-workflow script (metadata only — no source read). */
+export interface SavedWorkflowEntry {
+  /** Filename stem, e.g. `deep-research`. Doubles as the slash command name. */
+  name: string;
+  /** Absolute path to the `.js` file. */
+  scriptPath: string;
+  /** Which scope the file was found in. */
+  source: SavedWorkflowSource;
+}
+
+/** A resolved saved workflow with its script source loaded. */
+export interface ResolvedSavedWorkflow {
+  name: string;
+  scriptPath: string;
+  script: string;
+}
+
+/**
+ * Validate a saved-workflow name. Returns an error string when invalid,
+ * `null` when OK. Shared by the save dialog (CLI) and any caller that
+ * accepts a user-supplied name.
+ */
+export function validateWorkflowName(name: string): string | null {
+  if (!name) return 'Workflow name is required.';
+  if (!WORKFLOW_NAME_PATTERN.test(name)) {
+    return (
+      `Invalid workflow name "${name}". Use lower-case letters, digits, and ` +
+      `hyphens only (must start with a letter, max 41 chars).`
+    );
+  }
+  return null;
+}
+
+/** Both scope directories, project first (higher precedence). */
+export function getSavedWorkflowDirs(config: Config): Array<{
+  dir: string;
+  source: SavedWorkflowSource;
+}> {
+  return [
+    { dir: config.storage.getProjectWorkflowsDir(), source: 'project' },
+    { dir: Storage.getUserWorkflowsDir(), source: 'user' },
+  ];
+}
+
+async function listJsFiles(dir: string): Promise<string[]> {
+  try {
+    const names = await fs.readdir(dir);
+    return names.filter((n) => n.endsWith('.js'));
+  } catch (e) {
+    // Missing directory is the common case (user never saved a workflow).
+    const code = (e as NodeJS.ErrnoException)?.code;
+    if (code !== 'ENOENT') {
+      debugLogger.warn(`listJsFiles failed for ${dir}: ${e}`);
+    }
+    return [];
+  }
+}
+
+/**
+ * Enumerate all saved workflows across both scopes. Project entries shadow
+ * same-named user entries (project wins). Sorted by name for stable
+ * slash-command ordering.
+ */
+export async function listSavedWorkflows(
+  config: Config,
+): Promise<SavedWorkflowEntry[]> {
+  const byName = new Map<string, SavedWorkflowEntry>();
+  // Iterate user FIRST then project so project entries overwrite (win).
+  for (const { dir, source } of [...getSavedWorkflowDirs(config)].reverse()) {
+    for (const file of await listJsFiles(dir)) {
+      const name = file.slice(0, -'.js'.length);
+      // Skip files whose stem isn't a legal workflow/command name — they
+      // can't be a slash command and `workflow('<name>')` can't address them.
+      if (!WORKFLOW_NAME_PATTERN.test(name)) continue;
+      byName.set(name, { name, scriptPath: path.join(dir, file), source });
+    }
+  }
+  return Array.from(byName.values()).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+}
+
+/**
+ * Resolve `workflow('<name>')` or `workflow({scriptPath})` to a loaded
+ * script. The string form looks up `<name>.js` in project then user scope;
+ * the `{scriptPath}` form reads the file at the given path directly.
+ *
+ * Throws with an actionable, available-names message on a miss — the
+ * message text mirrors upstream so scripts written against either runtime
+ * see the same error.
+ */
+export async function resolveSavedWorkflowScript(
+  nameOrRef: string | { scriptPath: string },
+  config: Config,
+): Promise<ResolvedSavedWorkflow> {
+  if (typeof nameOrRef === 'object' && nameOrRef !== null) {
+    const scriptPath = nameOrRef.scriptPath;
+    if (typeof scriptPath !== 'string' || scriptPath.length === 0) {
+      throw new Error(
+        "workflow() expects a workflow name (string) or {scriptPath: string}.",
+      );
+    }
+    let script: string;
+    try {
+      script = await fs.readFile(scriptPath, 'utf8');
+    } catch (e) {
+      throw new Error(
+        `workflow({scriptPath: '${scriptPath}'}): cannot read file ` +
+          `(${e instanceof Error ? e.message : String(e)}).`,
+      );
+    }
+    const name = path.basename(scriptPath).replace(/\.js$/, '');
+    return { name, scriptPath, script };
+  }
+
+  if (typeof nameOrRef !== 'string') {
+    throw new Error(
+      "workflow() expects a workflow name (string) or {scriptPath: string}.",
+    );
+  }
+
+  const name = nameOrRef;
+  for (const { dir } of getSavedWorkflowDirs(config)) {
+    const scriptPath = path.join(dir, `${name}.js`);
+    try {
+      const script = await fs.readFile(scriptPath, 'utf8');
+      return { name, scriptPath, script };
+    } catch {
+      // Not in this scope — try the next.
+    }
+  }
+
+  const available = (await listSavedWorkflows(config)).map((e) => e.name);
+  throw new Error(
+    `workflow('${name}'): no workflow with that name. Available: ` +
+      `${available.length > 0 ? available.join(', ') : '(none)'}.`,
+  );
+}

--- a/packages/core/src/agents/runtime/workflow-saved.ts
+++ b/packages/core/src/agents/runtime/workflow-saved.ts
@@ -90,7 +90,18 @@ export function getSavedWorkflowDirs(config: Config): Array<{
 async function listJsFiles(dir: string): Promise<string[]> {
   try {
     const names = await fs.readdir(dir);
-    return names.filter((n) => n.endsWith('.js'));
+    const out: string[] = [];
+    for (const n of names) {
+      if (!n.endsWith('.js')) continue;
+      // Skip symlinks. A malicious repo could ship `<name>.js` as a symlink to
+      // an arbitrary file (e.g. `~/.aws/credentials`); discovering and later
+      // reading it would leak the target through the snapshot `script` field,
+      // sandbox parse-error messages, and telemetry.
+      const st = await fs.lstat(path.join(dir, n)).catch(() => null);
+      if (!st || st.isSymbolicLink()) continue;
+      out.push(n);
+    }
+    return out;
   } catch (e) {
     // Missing directory is the common case (user never saved a workflow).
     const code = (e as NodeJS.ErrnoException)?.code;
@@ -99,6 +110,38 @@ async function listJsFiles(dir: string): Promise<string[]> {
     }
     return [];
   }
+}
+
+/**
+ * Read a candidate workflow file, but only after proving its canonical real
+ * path stays inside one of the saved-workflow directories. `fs.realpath`
+ * resolves both `..` and symlinks, so this single check defeats path
+ * traversal (a `name`/`scriptPath` containing `..`) AND symlink escape (a
+ * file inside the dir that links out). Throws otherwise.
+ */
+async function readWorkflowFileSecurely(
+  filePath: string,
+  config: Config,
+): Promise<string> {
+  const real = await fs.realpath(filePath); // throws ENOENT if absent
+  const dirs = await Promise.all(
+    getSavedWorkflowDirs(config).map(async ({ dir }) => {
+      try {
+        return await fs.realpath(dir);
+      } catch {
+        return path.resolve(dir);
+      }
+    }),
+  );
+  const inside = dirs.some(
+    (d) => real === d || real.startsWith(d + path.sep),
+  );
+  if (!inside) {
+    throw new Error(
+      `refusing to load a workflow file outside the saved-workflow directories: '${filePath}'.`,
+    );
+  }
+  return fs.readFile(real, 'utf8');
 }
 
 /**
@@ -147,11 +190,11 @@ export async function resolveSavedWorkflowScript(
     }
     let script: string;
     try {
-      script = await fs.readFile(scriptPath, 'utf8');
+      script = await readWorkflowFileSecurely(scriptPath, config);
     } catch (e) {
       throw new Error(
-        `workflow({scriptPath: '${scriptPath}'}): cannot read file ` +
-          `(${e instanceof Error ? e.message : String(e)}).`,
+        `workflow({scriptPath: '${scriptPath}'}): ` +
+          `${e instanceof Error ? e.message : String(e)}`,
       );
     }
     const name = path.basename(scriptPath).replace(/\.js$/, '');
@@ -165,13 +208,21 @@ export async function resolveSavedWorkflowScript(
   }
 
   const name = nameOrRef;
+  // Reject names that aren't legal workflow stems before joining them into a
+  // directory path, so `workflow('../../outside')` can't escape the saved-
+  // workflow dirs. The realpath boundary check in `readWorkflowFileSecurely`
+  // is a second line of defence, but a clear name error is the better signal.
+  const nameError = validateWorkflowName(name);
+  if (nameError) {
+    throw new Error(`workflow('${name}'): ${nameError}`);
+  }
   for (const { dir } of getSavedWorkflowDirs(config)) {
     const scriptPath = path.join(dir, `${name}.js`);
     try {
-      const script = await fs.readFile(scriptPath, 'utf8');
+      const script = await readWorkflowFileSecurely(scriptPath, config);
       return { name, scriptPath, script };
     } catch {
-      // Not in this scope — try the next.
+      // Not in this scope (absent or rejected) — try the next.
     }
   }
 

--- a/packages/core/src/agents/runtime/workflow-stall.test.ts
+++ b/packages/core/src/agents/runtime/workflow-stall.test.ts
@@ -48,17 +48,34 @@ describe('attachStallWatchdog', () => {
     vi.useRealTimers();
   });
 
-  it('fires after stallMs of no activity', () => {
+  it('fires after stallMs of no activity once the first response has arrived', () => {
     const emitter = new AgentEventEmitter();
     const controller = new AbortController();
     const wd = attachStallWatchdog(emitter, controller, 1000);
+    // #8: not armed until the first progress event (the time-to-first-response
+    // window is not a stall) — so advancing past stallMs here does nothing.
+    vi.advanceTimersByTime(2000);
     expect(wd.stalled()).toBe(false);
+    // First response arrives → watchdog arms; then silence trips it.
+    emitter.emit(AgentEventType.ROUND_START, {} as never);
     vi.advanceTimersByTime(999);
     expect(wd.stalled()).toBe(false);
     vi.advanceTimersByTime(2);
     expect(wd.stalled()).toBe(true);
     expect(controller.signal.aborted).toBe(true);
     expect(controller.signal.reason).toBe('stalled');
+    wd.dispose();
+  });
+
+  it('does NOT fire during the time-to-first-response window (#8)', () => {
+    const emitter = new AgentEventEmitter();
+    const controller = new AbortController();
+    const wd = attachStallWatchdog(emitter, controller, 1000);
+    // A reasoning model thinking for a long time before the first token emits
+    // no events; that must not be treated as a stall.
+    vi.advanceTimersByTime(10_000);
+    expect(wd.stalled()).toBe(false);
+    expect(controller.signal.aborted).toBe(false);
     wd.dispose();
   });
 
@@ -127,8 +144,14 @@ describe('runStallResilient', () => {
     let calls = 0;
     // Each attempt stalls immediately: the attemptFn waits for the watchdog
     // to abort its signal, then throws the "did not complete" terminal.
-    const attemptFn = async (signal: AbortSignal): Promise<string> => {
+    const attemptFn = async (
+      signal: AbortSignal,
+      emitter: AgentEventEmitter,
+    ): Promise<string> => {
       calls += 1;
+      // Emit a first response event so the watchdog arms (#8: the time-to-
+      // first-response window is not a stall), then go silent → it trips.
+      emitter.emit(AgentEventType.ROUND_START, {} as never);
       await new Promise<void>((resolve) => {
         if (signal.aborted) return resolve();
         signal.addEventListener('abort', () => resolve(), { once: true });
@@ -148,10 +171,15 @@ describe('runStallResilient', () => {
 
   it('retries on stall then SUCCEEDS on a later attempt', async () => {
     let calls = 0;
-    const attemptFn = async (signal: AbortSignal): Promise<string> => {
+    const attemptFn = async (
+      signal: AbortSignal,
+      emitter: AgentEventEmitter,
+    ): Promise<string> => {
       calls += 1;
       if (calls < 2) {
-        // First attempt stalls.
+        // First attempt stalls: emit a first response event to arm the
+        // watchdog (#8), then go silent until it aborts.
+        emitter.emit(AgentEventType.ROUND_START, {} as never);
         await new Promise<void>((resolve) => {
           if (signal.aborted) return resolve();
           signal.addEventListener('abort', () => resolve(), { once: true });

--- a/packages/core/src/agents/runtime/workflow-stall.test.ts
+++ b/packages/core/src/agents/runtime/workflow-stall.test.ts
@@ -1,0 +1,248 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AgentEventEmitter, AgentEventType } from './agent-events.js';
+import {
+  attachStallWatchdog,
+  resolveStallMs,
+  runStallResilient,
+  DEFAULT_STALL_MS,
+  MAX_STALL_ATTEMPTS,
+  MAX_WORKFLOW_STALL_MS_ENV,
+} from './workflow-stall.js';
+
+describe('resolveStallMs', () => {
+  it('uses the per-call override when positive', () => {
+    expect(resolveStallMs(5000, {})).toBe(5000);
+  });
+  it('per-call 0 disables the watchdog', () => {
+    expect(resolveStallMs(0, {})).toBe(0);
+  });
+  it('falls back to env seconds when no per-call override', () => {
+    expect(
+      resolveStallMs(undefined, { [MAX_WORKFLOW_STALL_MS_ENV]: '30' }),
+    ).toBe(30_000);
+  });
+  it('env 0 disables', () => {
+    expect(
+      resolveStallMs(undefined, { [MAX_WORKFLOW_STALL_MS_ENV]: '0' }),
+    ).toBe(0);
+  });
+  it('falls back to default when nothing set', () => {
+    expect(resolveStallMs(undefined, {})).toBe(DEFAULT_STALL_MS);
+  });
+  it('ignores a negative per-call value (falls through to default)', () => {
+    expect(resolveStallMs(-5, {})).toBe(DEFAULT_STALL_MS);
+  });
+});
+
+describe('attachStallWatchdog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires after stallMs of no activity', () => {
+    const emitter = new AgentEventEmitter();
+    const controller = new AbortController();
+    const wd = attachStallWatchdog(emitter, controller, 1000);
+    expect(wd.stalled()).toBe(false);
+    vi.advanceTimersByTime(999);
+    expect(wd.stalled()).toBe(false);
+    vi.advanceTimersByTime(2);
+    expect(wd.stalled()).toBe(true);
+    expect(controller.signal.aborted).toBe(true);
+    expect(controller.signal.reason).toBe('stalled');
+    wd.dispose();
+  });
+
+  it('resets the timer on a progress event', () => {
+    const emitter = new AgentEventEmitter();
+    const controller = new AbortController();
+    const wd = attachStallWatchdog(emitter, controller, 1000);
+    vi.advanceTimersByTime(800);
+    emitter.emit(AgentEventType.STREAM_TEXT, {} as never); // activity → reset
+    vi.advanceTimersByTime(800);
+    expect(wd.stalled()).toBe(false); // would have fired at 1000 without reset
+    vi.advanceTimersByTime(300);
+    expect(wd.stalled()).toBe(true);
+    wd.dispose();
+  });
+
+  it('suspends the timer while a tool is in flight', () => {
+    const emitter = new AgentEventEmitter();
+    const controller = new AbortController();
+    const wd = attachStallWatchdog(emitter, controller, 1000);
+    emitter.emit(AgentEventType.TOOL_CALL, {} as never); // tool starts
+    vi.advanceTimersByTime(5000); // long tool — must NOT count as stall
+    expect(wd.stalled()).toBe(false);
+    emitter.emit(AgentEventType.TOOL_RESULT, {} as never); // tool done → re-arm
+    vi.advanceTimersByTime(1001);
+    expect(wd.stalled()).toBe(true);
+    wd.dispose();
+  });
+
+  it('does not fire after dispose', () => {
+    const emitter = new AgentEventEmitter();
+    const controller = new AbortController();
+    const wd = attachStallWatchdog(emitter, controller, 1000);
+    wd.dispose();
+    vi.advanceTimersByTime(5000);
+    expect(wd.stalled()).toBe(false);
+    expect(controller.signal.aborted).toBe(false);
+  });
+
+  it('stallMs <= 0 returns an inert handle', () => {
+    const emitter = new AgentEventEmitter();
+    const controller = new AbortController();
+    const wd = attachStallWatchdog(emitter, controller, 0);
+    vi.advanceTimersByTime(100_000);
+    expect(wd.stalled()).toBe(false);
+    expect(controller.signal.aborted).toBe(false);
+    wd.dispose();
+  });
+});
+
+describe('runStallResilient', () => {
+  it('returns the result on success (no stall, no retry)', async () => {
+    let calls = 0;
+    const result = await runStallResilient(
+      async () => {
+        calls += 1;
+        return 'ok';
+      },
+      { stallMs: 1000 },
+    );
+    expect(result).toBe('ok');
+    expect(calls).toBe(1);
+  });
+
+  it('retries on stall up to MAX_STALL_ATTEMPTS then abandons', async () => {
+    let calls = 0;
+    // Each attempt stalls immediately: the attemptFn waits for the watchdog
+    // to abort its signal, then throws the "did not complete" terminal.
+    const attemptFn = async (signal: AbortSignal): Promise<string> => {
+      calls += 1;
+      await new Promise<void>((resolve) => {
+        if (signal.aborted) return resolve();
+        signal.addEventListener('abort', () => resolve(), { once: true });
+      });
+      throw new Error('Workflow subagent did not complete (terminate mode: CANCELLED).');
+    };
+    // Use a tiny stallMs with real timers so the watchdog fires fast.
+    let caught: unknown;
+    try {
+      await runStallResilient(attemptFn, { stallMs: 5, label: 'slow' });
+    } catch (e) {
+      caught = e;
+    }
+    expect(calls).toBe(MAX_STALL_ATTEMPTS);
+    expect(String(caught)).toMatch(/stalled on all 3 attempts/);
+  });
+
+  it('retries on stall then SUCCEEDS on a later attempt', async () => {
+    let calls = 0;
+    const attemptFn = async (signal: AbortSignal): Promise<string> => {
+      calls += 1;
+      if (calls < 2) {
+        // First attempt stalls.
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) return resolve();
+          signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+        throw new Error('did not complete (terminate mode: CANCELLED).');
+      }
+      return 'recovered';
+    };
+    const result = await runStallResilient(attemptFn, { stallMs: 5 });
+    expect(result).toBe('recovered');
+    expect(calls).toBe(2);
+  });
+
+  it('does NOT retry a non-stall failure (propagates immediately)', async () => {
+    let calls = 0;
+    const attemptFn = async (): Promise<string> => {
+      calls += 1;
+      throw new Error('Workflow subagent did not complete (terminate mode: MAX_TURNS).');
+    };
+    let caught: unknown;
+    try {
+      await runStallResilient(attemptFn, { stallMs: 1000 });
+    } catch (e) {
+      caught = e;
+    }
+    expect(calls).toBe(1);
+    expect(String(caught)).toMatch(/MAX_TURNS/);
+  });
+
+  it('does NOT retry on parent abort (propagates)', async () => {
+    const parent = new AbortController();
+    let calls = 0;
+    const attemptFn = async (signal: AbortSignal): Promise<string> => {
+      calls += 1;
+      await new Promise<void>((resolve) => {
+        signal.addEventListener('abort', () => resolve(), { once: true });
+      });
+      throw new Error('did not complete (terminate mode: CANCELLED).');
+    };
+    const p = runStallResilient(attemptFn, {
+      stallMs: 100_000, // watchdog won't fire
+      signal: parent.signal,
+    });
+    parent.abort('user-cancel');
+    let caught: unknown;
+    try {
+      await p;
+    } catch (e) {
+      caught = e;
+    }
+    expect(calls).toBe(1); // no retry on parent abort
+    expect(String(caught)).toMatch(/CANCELLED/);
+  });
+
+  it('parent abort propagates to the per-attempt signal', async () => {
+    const parent = new AbortController();
+    let capturedSignal: AbortSignal | undefined;
+    const attemptFn = async (signal: AbortSignal): Promise<string> => {
+      capturedSignal = signal;
+      await new Promise<void>((resolve) => {
+        signal.addEventListener('abort', () => resolve(), { once: true });
+      });
+      return 'aborted-and-returned';
+    };
+    const p = runStallResilient(attemptFn, {
+      stallMs: 100_000,
+      signal: parent.signal,
+    });
+    // Let the attempt start + register its listener.
+    await Promise.resolve();
+    expect(capturedSignal!.aborted).toBe(false);
+    parent.abort('user-cancel');
+    expect(capturedSignal!.aborted).toBe(true);
+    await p;
+  });
+
+  it('stallMs=0 runs a single raw attempt with the parent signal', async () => {
+    const parent = new AbortController();
+    let capturedSignal: AbortSignal | undefined;
+    let calls = 0;
+    await runStallResilient(
+      async (signal) => {
+        calls += 1;
+        capturedSignal = signal;
+        return 'ok';
+      },
+      { stallMs: 0, signal: parent.signal },
+    );
+    expect(calls).toBe(1);
+    // With the watchdog disabled, the parent signal is threaded straight
+    // through (same object).
+    expect(capturedSignal).toBe(parent.signal);
+  });
+});

--- a/packages/core/src/agents/runtime/workflow-stall.ts
+++ b/packages/core/src/agents/runtime/workflow-stall.ts
@@ -87,6 +87,14 @@ export interface StallWatchdogHandle {
  * flight the timer is held (a long tool call is not a stall). When the
  * timer elapses with no in-flight tool, it fires `controller.abort('stalled')`.
  *
+ * The watchdog arms on the FIRST progress event, not at attach time. The
+ * time-to-first-response window — connection setup, server-side queueing, and
+ * a reasoning model's pre-first-token thinking — emits no events (`ROUND_START`
+ * fires only AFTER `await sendMessageStream` resolves), so counting it would
+ * false-trip on a healthy-but-slow first response and waste 3× tokens on the
+ * retry loop. That window is instead bounded by the subagent's own
+ * `max_time_minutes`; the watchdog's job is post-first-response streaming stalls.
+ *
  * A `stallMs` of 0 means "no watchdog" — this returns an inert handle.
  */
 export function attachStallWatchdog(
@@ -151,7 +159,10 @@ export function attachStallWatchdog(
   emitter.on(AgentEventType.TOOL_CALL, onToolCall);
   emitter.on(AgentEventType.TOOL_RESULT, onToolResult);
 
-  arm(); // start counting immediately
+  // Intentionally NOT armed here. The first `onActivity` (the first response
+  // event of round 1) arms it, so time-to-first-response is not counted as a
+  // stall (see the doc comment); first-response hangs are bounded by the
+  // subagent's `max_time_minutes`.
 
   return {
     stalled: () => fired,

--- a/packages/core/src/agents/runtime/workflow-stall.ts
+++ b/packages/core/src/agents/runtime/workflow-stall.ts
@@ -1,0 +1,259 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Stall watchdog + retry for workflow agent dispatches. A
+ * workflow `agent()` can hang indefinitely if the model loops, the provider
+ * stalls mid-stream, or a tool never returns. The subagent's own
+ * `max_time_minutes` (10 min) is a coarse backstop; the stall watchdog is
+ * finer-grained: it aborts a dispatch after `stallMs` (default 60s) of NO
+ * observable progress, and the resilient wrapper retries up to
+ * `MAX_STALL_ATTEMPTS` times before abandoning.
+ *
+ * "Progress" = any of the subagent's reasoning-loop events (round start,
+ * streamed text, token usage, tool call/result). Crucially the timer is
+ * SUSPENDED while a tool is in flight: a legitimately long-running tool
+ * (a 90s shell build, a slow MCP call) must not be flagged as a stall. The
+ * timer only counts wall-clock during which the subagent is producing
+ * nothing AND has no tool executing.
+ *
+ * Design (low-invasiveness): the resilient wrapper owns the per-attempt
+ * `AbortController` and `AgentEventEmitter`. It chains the caller's parent
+ * signal into the per-attempt controller (so parent cancellation still
+ * propagates) and passes BOTH the per-attempt signal and emitter into the
+ * single-attempt dispatch. A stall fires `controller.abort('stalled')`,
+ * which makes the subagent return `CANCELLED`; the single-attempt dispatch
+ * then throws its "did not complete" terminal, which the wrapper catches.
+ * The wrapper distinguishes a stall-abort (retry) from a parent-abort
+ * (propagate) via `watchdog.stalled()` + the parent `signal.aborted` flag.
+ *
+ * Schema-mode rescue happens for free: if a stall fires AFTER the subagent
+ * already captured a valid `structured_output`, the single-attempt dispatch
+ * returns that payload BEFORE reaching the terminate-mode check, so the
+ * wrapper sees a success and never retries.
+ */
+
+import { AgentEventEmitter, AgentEventType } from './agent-events.js';
+import { createDebugLogger } from '../../utils/debugLogger.js';
+
+/** Default stall timeout: 60s of no progress (with no tool in flight). */
+export const DEFAULT_STALL_MS = 60_000;
+
+/** Total attempts (initial + retries) for a single `agent()` dispatch. */
+export const MAX_STALL_ATTEMPTS = 3;
+
+export const MAX_WORKFLOW_STALL_MS_ENV = 'QWEN_CODE_WORKFLOW_STALL_SECONDS';
+
+/**
+ * Resolve the per-dispatch stall timeout. Precedence: the per-call
+ * `agent({stallMs})` override, then `QWEN_CODE_WORKFLOW_STALL_SECONDS`
+ * (whole seconds), then `DEFAULT_STALL_MS`. A non-positive / non-finite
+ * override falls back to the default. A value of `0` disables the watchdog
+ * (returns `0` — callers treat 0 as "no watchdog").
+ */
+export function resolveStallMs(
+  perCall: number | undefined,
+  env: Record<string, string | undefined> = process.env,
+): number {
+  if (typeof perCall === 'number' && Number.isFinite(perCall)) {
+    // Explicit 0 disables; negative is a caller bug → default.
+    if (perCall === 0) return 0;
+    if (perCall > 0) return perCall;
+  }
+  const raw = env[MAX_WORKFLOW_STALL_MS_ENV];
+  if (raw !== undefined && raw.trim() !== '') {
+    const sec = Number(raw);
+    if (Number.isFinite(sec) && sec > 0) return sec * 1000;
+    if (sec === 0) return 0;
+  }
+  return DEFAULT_STALL_MS;
+}
+
+const debugLogger = createDebugLogger('WORKFLOW_STALL');
+
+export interface StallWatchdogHandle {
+  /** True once the watchdog has fired `controller.abort('stalled')`. */
+  stalled(): boolean;
+  /** Clear the timer + detach listeners. Idempotent; call in a `finally`. */
+  dispose(): void;
+}
+
+/**
+ * Attach a stall watchdog to a subagent's event emitter. The watchdog arms
+ * a `stallMs` timer that any progress event resets; while a tool is in
+ * flight the timer is held (a long tool call is not a stall). When the
+ * timer elapses with no in-flight tool, it fires `controller.abort('stalled')`.
+ *
+ * A `stallMs` of 0 means "no watchdog" — this returns an inert handle.
+ */
+export function attachStallWatchdog(
+  emitter: AgentEventEmitter,
+  controller: AbortController,
+  stallMs: number,
+): StallWatchdogHandle {
+  if (stallMs <= 0) {
+    return { stalled: () => false, dispose: () => {} };
+  }
+
+  let inFlightTools = 0;
+  let fired = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let disposed = false;
+
+  const clear = (): void => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+
+  const arm = (): void => {
+    clear();
+    if (disposed || fired) return;
+    // Suspend the timer while any tool is executing — a slow tool is not a
+    // stall. The TOOL_RESULT handler re-arms once the tool count returns to 0.
+    if (inFlightTools > 0) return;
+    timer = setTimeout(() => {
+      if (disposed || fired) return;
+      fired = true;
+      debugLogger.warn(
+        `[Workflow] agent dispatch stalled — no progress for ${stallMs}ms; aborting.`,
+      );
+      try {
+        controller.abort('stalled');
+      } catch (e) {
+        debugLogger.warn('stall watchdog abort threw:', e);
+      }
+    }, stallMs);
+    // Don't keep the event loop alive solely for the watchdog timer.
+    if (typeof (timer as { unref?: () => void }).unref === 'function') {
+      (timer as { unref: () => void }).unref();
+    }
+  };
+
+  const onActivity = (): void => arm();
+  const onToolCall = (): void => {
+    inFlightTools += 1;
+    clear(); // hold the timer while the tool runs
+  };
+  const onToolResult = (): void => {
+    inFlightTools = Math.max(0, inFlightTools - 1);
+    arm();
+  };
+
+  emitter.on(AgentEventType.ROUND_START, onActivity);
+  emitter.on(AgentEventType.ROUND_END, onActivity);
+  emitter.on(AgentEventType.STREAM_TEXT, onActivity);
+  emitter.on(AgentEventType.USAGE_METADATA, onActivity);
+  emitter.on(AgentEventType.TOOL_CALL, onToolCall);
+  emitter.on(AgentEventType.TOOL_RESULT, onToolResult);
+
+  arm(); // start counting immediately
+
+  return {
+    stalled: () => fired,
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      clear();
+      emitter.off(AgentEventType.ROUND_START, onActivity);
+      emitter.off(AgentEventType.ROUND_END, onActivity);
+      emitter.off(AgentEventType.STREAM_TEXT, onActivity);
+      emitter.off(AgentEventType.USAGE_METADATA, onActivity);
+      emitter.off(AgentEventType.TOOL_CALL, onToolCall);
+      emitter.off(AgentEventType.TOOL_RESULT, onToolResult);
+    },
+  };
+}
+
+/**
+ * One single-attempt dispatch. Receives the per-attempt abort signal (the
+ * wrapper chains the parent signal into it + the watchdog aborts it) and
+ * the per-attempt emitter (the watchdog is already attached). Returns the
+ * agent result on success; throws on any non-success terminal.
+ */
+export type StallAttemptFn<T> = (
+  attemptSignal: AbortSignal,
+  emitter: AgentEventEmitter,
+) => Promise<T>;
+
+export interface RunStallResilientOptions {
+  stallMs: number;
+  /** Caller's parent abort signal (cancellation, wall-clock). */
+  signal?: AbortSignal;
+  /** For the abandoned-error message. */
+  label?: string;
+}
+
+/**
+ * Run a single-attempt dispatch under the stall watchdog, retrying on stall
+ * up to `MAX_STALL_ATTEMPTS`. A non-stall failure (MAX_TURNS, TIMEOUT,
+ * ERROR, schema-nudge-exhaustion) propagates immediately without retry —
+ * those are deterministic outcomes a retry won't fix. A parent abort
+ * propagates without retry.
+ *
+ * The watchdog is disabled (no retries, raw single attempt) when
+ * `stallMs <= 0`.
+ */
+export async function runStallResilient<T>(
+  attemptFn: StallAttemptFn<T>,
+  opts: RunStallResilientOptions,
+): Promise<T> {
+  const { stallMs, signal, label } = opts;
+
+  // Watchdog disabled: single raw attempt, parent signal threaded straight
+  // through (no per-attempt controller needed).
+  if (stallMs <= 0) {
+    const emitter = new AgentEventEmitter();
+    return attemptFn(signal ?? new AbortController().signal, emitter);
+  }
+
+  let attempt = 0;
+  for (;;) {
+    attempt += 1;
+    const controller = new AbortController();
+    // Chain the parent signal so cancellation / wall-clock still aborts the
+    // attempt. Named handler so we can detach it after each attempt.
+    let onParentAbort: (() => void) | undefined;
+    if (signal) {
+      if (signal.aborted) {
+        controller.abort(signal.reason);
+      } else {
+        onParentAbort = () => controller.abort(signal.reason);
+        signal.addEventListener('abort', onParentAbort);
+      }
+    }
+    const emitter = new AgentEventEmitter();
+    const watchdog = attachStallWatchdog(emitter, controller, stallMs);
+    try {
+      return await attemptFn(controller.signal, emitter);
+    } catch (err) {
+      // Parent abort takes priority — never retry a user/wall-clock cancel.
+      if (signal?.aborted) throw err;
+      // A stall manifests as the attempt's "did not complete (CANCELLED)"
+      // throw; the watchdog flag is the authoritative signal that WE aborted.
+      if (watchdog.stalled() && attempt < MAX_STALL_ATTEMPTS) {
+        debugLogger.warn(
+          `[Workflow] agent "${label ?? 'workflow-agent'}" stalled ` +
+            `(attempt ${attempt}/${MAX_STALL_ATTEMPTS}) — retrying.`,
+        );
+        continue;
+      }
+      if (watchdog.stalled()) {
+        throw new Error(
+          `agent "${label ?? 'workflow-agent'}" stalled on all ` +
+            `${MAX_STALL_ATTEMPTS} attempts (no progress for ${stallMs}ms each).`,
+        );
+      }
+      throw err;
+    } finally {
+      watchdog.dispose();
+      if (onParentAbort && signal) {
+        signal.removeEventListener('abort', onParentAbort);
+      }
+    }
+  }
+}

--- a/packages/core/src/agents/workflow-run-registry.test.ts
+++ b/packages/core/src/agents/workflow-run-registry.test.ts
@@ -191,6 +191,38 @@ describe('WorkflowRunRegistry', () => {
     expect(() => r.complete('wf_throw', null, 1)).not.toThrow();
   });
 
+  // P-notif: terminal-completion notification callback.
+  it('notification callback fires on complete and fail, not on cancel', () => {
+    const r = new WorkflowRunRegistry();
+    const cb = vi.fn();
+    r.setNotificationCallback(cb);
+
+    r.register(reg('wf_done'));
+    r.complete('wf_done', 'ok', 1_000);
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb.mock.calls[0][0].status).toBe('completed');
+
+    r.register(reg('wf_bad'));
+    r.fail('wf_bad', 'boom', 2_000);
+    expect(cb).toHaveBeenCalledTimes(2);
+    expect(cb.mock.calls[1][0].status).toBe('failed');
+
+    // A user-initiated cancel is intentionally NOT notified.
+    r.register(reg('wf_cancelled'));
+    r.cancel('wf_cancelled', 3_000);
+    expect(cb).toHaveBeenCalledTimes(2);
+  });
+
+  it('errors thrown by the notification callback do not break the call site', () => {
+    const r = new WorkflowRunRegistry();
+    r.setNotificationCallback(() => {
+      throw new Error('notifier blew up');
+    });
+    r.register(reg('wf_n'));
+    expect(() => r.complete('wf_n', null, 1)).not.toThrow();
+    expect(r.get('wf_n')!.status).toBe('completed');
+  });
+
   // P4 Round 7 (wenshao): dialog-initiated cancel marks status='cancelled'
   // synchronously, then the abort propagates to the tool's catch arm which
   // calls setRecentLogs(runId, logs). The previous guard rejected this

--- a/packages/core/src/agents/workflow-run-registry.ts
+++ b/packages/core/src/agents/workflow-run-registry.ts
@@ -109,8 +109,8 @@ export interface WorkflowTask extends TaskBase {
   /**
    * P7b: the path the script was loaded from, when the run was launched
    * from a saved workflow (`Workflow({scriptPath})` or a `/workflow-name`
-   * slash command). `undefined` for inline scripts. A run launched from a
-   * file is already saved, so the save dialog offers "already saved".
+   * slash command). `undefined` for inline scripts. Recorded as run
+   * provenance (e.g. for the snapshot).
    */
   scriptPath?: string;
   /** Final script return value once the run completes (success path). */

--- a/packages/core/src/agents/workflow-run-registry.ts
+++ b/packages/core/src/agents/workflow-run-registry.ts
@@ -98,6 +98,21 @@ export interface WorkflowTask extends TaskBase {
    * than hidden.
    */
   perPhaseTokens: Map<string | null, number>;
+  /**
+   * P7b: the workflow script source (verbatim, as the tool received it).
+   * Used by the run-snapshot writer (so a persisted run carries its
+   * script) and the save-to-disk dialog (so a completed run can be saved
+   * to `.qwen/workflows/<name>.js`). Empty string for legacy callers that
+   * don't supply it.
+   */
+  script: string;
+  /**
+   * P7b: the path the script was loaded from, when the run was launched
+   * from a saved workflow (`Workflow({scriptPath})` or a `/workflow-name`
+   * slash command). `undefined` for inline scripts. A run launched from a
+   * file is already saved, so the save dialog offers "already saved".
+   */
+  scriptPath?: string;
   /** Final script return value once the run completes (success path). */
   result?: unknown;
   /** Error message on `failed` (terminal). */
@@ -123,6 +138,7 @@ export type WorkflowTaskRegistration = Omit<
   | 'tokensSpent'
   | 'tokenBudgetTotal'
   | 'perPhaseTokens'
+  | 'script'
   | 'description'
 > & {
   // Allow the caller to omit `description` — we synthesize it from
@@ -135,6 +151,11 @@ export type WorkflowTaskRegistration = Omit<
    * does NOT re-write it because the budget's `total` is immutable.
    */
   tokenBudgetTotal?: number | null;
+  /**
+   * P7b: the workflow script source. Defaults to `''` when omitted (legacy
+   * callers / tests). Needed for run snapshots + the save-to-disk dialog.
+   */
+  script?: string;
 };
 
 /** Fires when a new entry is registered. */
@@ -213,6 +234,9 @@ export class WorkflowRunRegistry {
       entry.tokenBudgetTotal = null;
     }
     entry.perPhaseTokens = new Map();
+    // P7b: default the script source so the snapshot writer + save dialog
+    // always have a (possibly empty) string to work with.
+    if (entry.script === undefined) entry.script = '';
     if (!entry.description) {
       entry.description = entry.meta?.name ?? entry.runId;
     }

--- a/packages/core/src/agents/workflow-run-registry.ts
+++ b/packages/core/src/agents/workflow-run-registry.ts
@@ -169,11 +169,21 @@ export type WorkflowRunRegisterCallback = (entry: WorkflowTask) => void;
  */
 export type WorkflowRunStatusChangeCallback = (entry?: WorkflowTask) => void;
 
+/**
+ * P-notif: fires once when a run reaches a terminal state worth surfacing to
+ * the user — `completed` / `failed`, but NOT a user-initiated `cancel` (the
+ * user already knows). The CLI wires this to the terminal-bell notification
+ * service. A separate slot from `statusChangeCallback` (which the dialog's
+ * `useBackgroundTaskView` owns), so the two never clobber each other.
+ */
+export type WorkflowRunNotificationCallback = (entry: WorkflowTask) => void;
+
 export class WorkflowRunRegistry {
   private readonly entries = new Map<string, WorkflowTask>();
 
   private registerCallback: WorkflowRunRegisterCallback | undefined;
   private statusChangeCallback: WorkflowRunStatusChangeCallback | undefined;
+  private notificationCallback: WorkflowRunNotificationCallback | undefined;
   /**
    * P5 T7: one-time usage-warning latch. The first `Workflow` tool
    * invocation per session checks `shouldShowUsageWarning()`; if true,
@@ -206,6 +216,22 @@ export class WorkflowRunRegistry {
     cb: WorkflowRunStatusChangeCallback | undefined,
   ): void {
     this.statusChangeCallback = cb;
+  }
+
+  setNotificationCallback(
+    cb: WorkflowRunNotificationCallback | undefined,
+  ): void {
+    this.notificationCallback = cb;
+  }
+
+  /** Fire the terminal-completion notification (best-effort). */
+  private emitNotification(entry: WorkflowTask): void {
+    if (!this.notificationCallback) return;
+    try {
+      this.notificationCallback(entry);
+    } catch (error) {
+      debugLogger.error('Failed to emit workflow notification:', error);
+    }
   }
 
   /**
@@ -357,6 +383,7 @@ export class WorkflowRunRegistry {
     entry.result = result;
     entry.notified = true;
     this.emitStatusChange(entry);
+    this.emitNotification(entry);
     this.evictTerminal();
   }
 
@@ -368,6 +395,7 @@ export class WorkflowRunRegistry {
     entry.error = message;
     entry.notified = true;
     this.emitStatusChange(entry);
+    this.emitNotification(entry);
     this.evictTerminal();
   }
 

--- a/packages/core/src/agents/workflow-snapshot.test.ts
+++ b/packages/core/src/agents/workflow-snapshot.test.ts
@@ -1,0 +1,146 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { Config } from '../config/config.js';
+import { Storage } from '../config/storage.js';
+import {
+  toSnapshot,
+  writeWorkflowSnapshot,
+  listWorkflowSnapshots,
+  MAX_RETAINED_SNAPSHOTS,
+} from './workflow-snapshot.js';
+import type { WorkflowTask } from './workflow-run-registry.js';
+
+function fakeConfig(projectDir: string): Config {
+  return { storage: new Storage(projectDir) } as unknown as Config;
+}
+
+function task(overrides: Partial<WorkflowTask> = {}): WorkflowTask {
+  return {
+    id: 'wf_a',
+    kind: 'workflow',
+    runId: 'wf_a',
+    description: 'demo',
+    meta: { name: 'demo', description: 'd' },
+    status: 'completed',
+    startTime: 1_700_000_000_000,
+    endTime: 1_700_000_005_000,
+    outputFile: '',
+    outputOffset: 0,
+    notified: true,
+    abortController: new AbortController(),
+    currentPhase: null,
+    phases: ['Plan', 'Build'],
+    agentsDispatched: 3,
+    agentsCompleted: 3,
+    recentLogs: ['log1'],
+    tokensSpent: 450,
+    tokenBudgetTotal: 1000,
+    perPhaseTokens: new Map<string | null, number>([
+      ['Plan', 200],
+      [null, 50],
+    ]),
+    script: 'return 1;',
+    result: { answer: 42 },
+    ...overrides,
+  };
+}
+
+describe('toSnapshot', () => {
+  it('flattens perPhaseTokens Map into [phaseOrNull, tokens] pairs', () => {
+    const s = toSnapshot(task());
+    expect(s.perPhaseTokens).toEqual([
+      ['Plan', 200],
+      [null, 50],
+    ]);
+    expect(s.runId).toBe('wf_a');
+    expect(s.script).toBe('return 1;');
+    expect(s.result).toEqual({ answer: 42 });
+  });
+
+  it('replaces a non-JSON-serializable result with a placeholder string', () => {
+    const s = toSnapshot(task({ result: 10n }));
+    expect(typeof s.result).toBe('string');
+    expect(s.result).toMatch(/non-JSON-serializable/);
+  });
+
+  it('copies arrays defensively (snapshot is decoupled from the live entry)', () => {
+    const t = task();
+    const s = toSnapshot(t);
+    t.phases.push('Mutated');
+    expect(s.phases).toEqual(['Plan', 'Build']);
+  });
+});
+
+describe('writeWorkflowSnapshot + listWorkflowSnapshots', () => {
+  let projectDir: string;
+
+  beforeEach(async () => {
+    projectDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wf-snap-mod-'));
+  });
+  afterEach(async () => {
+    await fs.rm(projectDir, { recursive: true, force: true });
+  });
+
+  it('round-trips a snapshot through disk', async () => {
+    const config = fakeConfig(projectDir);
+    await writeWorkflowSnapshot(config, task({ runId: 'wf_rt' }));
+    const list = await listWorkflowSnapshots(config);
+    expect(list).toHaveLength(1);
+    expect(list[0].runId).toBe('wf_rt');
+    expect(list[0].perPhaseTokens).toEqual([
+      ['Plan', 200],
+      [null, 50],
+    ]);
+  });
+
+  it('lists newest-first by startTime', async () => {
+    const config = fakeConfig(projectDir);
+    await writeWorkflowSnapshot(
+      config,
+      task({ runId: 'wf_old', startTime: 1_000 }),
+    );
+    await writeWorkflowSnapshot(
+      config,
+      task({ runId: 'wf_new', startTime: 9_000 }),
+    );
+    const list = await listWorkflowSnapshots(config);
+    expect(list.map((s) => s.runId)).toEqual(['wf_new', 'wf_old']);
+  });
+
+  it('returns [] when the workflows dir does not exist', async () => {
+    const list = await listWorkflowSnapshots(fakeConfig(projectDir));
+    expect(list).toEqual([]);
+  });
+
+  it('skips unparseable snapshot files', async () => {
+    const config = fakeConfig(projectDir);
+    await writeWorkflowSnapshot(config, task({ runId: 'wf_good' }));
+    const dir = config.storage.getWorkflowRunsDir();
+    await fs.writeFile(path.join(dir, 'broken.json'), '{ not json', 'utf8');
+    const list = await listWorkflowSnapshots(config);
+    expect(list.map((s) => s.runId)).toEqual(['wf_good']);
+  });
+
+  it('prunes the oldest beyond MAX_RETAINED_SNAPSHOTS', async () => {
+    const config = fakeConfig(projectDir);
+    const total = MAX_RETAINED_SNAPSHOTS + 4;
+    for (let i = 0; i < total; i++) {
+      // Distinct runId per write; startTime ascending. Each write prunes.
+      await writeWorkflowSnapshot(
+        config,
+        task({ runId: `wf_${i}`, startTime: 1_000 + i }),
+      );
+    }
+    const dir = config.storage.getWorkflowRunsDir();
+    const files = (await fs.readdir(dir)).filter((f) => f.endsWith('.json'));
+    expect(files.length).toBe(MAX_RETAINED_SNAPSHOTS);
+  });
+});

--- a/packages/core/src/agents/workflow-snapshot.test.ts
+++ b/packages/core/src/agents/workflow-snapshot.test.ts
@@ -129,18 +129,23 @@ describe('writeWorkflowSnapshot + listWorkflowSnapshots', () => {
     expect(list.map((s) => s.runId)).toEqual(['wf_good']);
   });
 
-  it('prunes the oldest beyond MAX_RETAINED_SNAPSHOTS', async () => {
+  it('prunes the oldest beyond MAX_RETAINED_SNAPSHOTS, journal dirs too', async () => {
     const config = fakeConfig(projectDir);
+    const dir = config.storage.getWorkflowRunsDir();
     const total = MAX_RETAINED_SNAPSHOTS + 4;
     for (let i = 0; i < total; i++) {
+      const runId = `wf_${i}`;
+      // Each run also has a sibling journal dir; prune must remove both.
+      await fs.mkdir(`${dir}/${runId}`, { recursive: true });
+      await fs.writeFile(`${dir}/${runId}/journal.jsonl`, '{}\n', 'utf8');
       // Distinct runId per write; startTime ascending. Each write prunes.
-      await writeWorkflowSnapshot(
-        config,
-        task({ runId: `wf_${i}`, startTime: 1_000 + i }),
-      );
+      await writeWorkflowSnapshot(config, task({ runId, startTime: 1_000 + i }));
     }
-    const dir = config.storage.getWorkflowRunsDir();
-    const files = (await fs.readdir(dir)).filter((f) => f.endsWith('.json'));
+    const entries = await fs.readdir(dir);
+    const files = entries.filter((f) => f.endsWith('.json'));
+    const journalDirs = entries.filter((f) => /^wf_\d+$/.test(f));
     expect(files.length).toBe(MAX_RETAINED_SNAPSHOTS);
+    // The pruned runs' journal directories are gone too (no orphan leak).
+    expect(journalDirs.length).toBe(MAX_RETAINED_SNAPSHOTS);
   });
 });

--- a/packages/core/src/agents/workflow-snapshot.ts
+++ b/packages/core/src/agents/workflow-snapshot.ts
@@ -157,10 +157,19 @@ async function pruneSnapshots(dir: string): Promise<void> {
   stats.sort((a, b) => a.mtime - b.mtime);
   const toPrune = stats.slice(0, stats.length - MAX_RETAINED_SNAPSHOTS);
   await Promise.all(
-    toPrune.map((s) =>
-      fs.unlink(`${dir}/${s.f}`).catch((e) =>
-        debugLogger.warn(`prune unlink failed for ${s.f}: ${e}`),
-      ),
-    ),
+    toPrune.map((s) => {
+      // Each run also has a sibling `<runId>/journal.jsonl` directory (the
+      // resume journal). Removing only the `<runId>.json` snapshot would leave
+      // those journal dirs to grow without bound, so prune both together.
+      const runId = s.f.replace(/\.json$/, '');
+      return Promise.all([
+        fs.unlink(`${dir}/${s.f}`).catch((e) =>
+          debugLogger.warn(`prune unlink failed for ${s.f}: ${e}`),
+        ),
+        fs.rm(`${dir}/${runId}`, { recursive: true, force: true }).catch((e) =>
+          debugLogger.warn(`prune journal dir failed for ${runId}: ${e}`),
+        ),
+      ]);
+    }),
   );
 }

--- a/packages/core/src/agents/workflow-snapshot.ts
+++ b/packages/core/src/agents/workflow-snapshot.ts
@@ -1,0 +1,166 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Persisted snapshots of completed workflow runs. The
+ * `WorkflowRunRegistry` is in-memory and dies with the CLI process; a
+ * snapshot written to `<projectDir>/workflows/<runId>.json` on terminal
+ * transition lets `/workflows` show a "recent" history that survives a
+ * restart. This is independent of the resume journal (which is per-agent,
+ * for caching): a snapshot is the whole-run summary.
+ */
+
+import { promises as fs } from 'node:fs';
+import type { Config } from '../config/config.js';
+import { createDebugLogger } from '../utils/debugLogger.js';
+import type { WorkflowMeta } from './runtime/workflow-sandbox.js';
+import type { WorkflowStatus, WorkflowTask } from './workflow-run-registry.js';
+
+const debugLogger = createDebugLogger('WORKFLOW_SNAPSHOT');
+
+/** Cap on snapshots retained on disk; oldest are pruned on write. */
+export const MAX_RETAINED_SNAPSHOTS = 30;
+
+/** JSON-serializable projection of a terminal workflow run. */
+export interface WorkflowSnapshot {
+  runId: string;
+  meta: WorkflowMeta | null;
+  status: WorkflowStatus;
+  script: string;
+  scriptPath?: string;
+  phases: string[];
+  agentsDispatched: number;
+  agentsCompleted: number;
+  tokensSpent: number;
+  tokenBudgetTotal: number | null;
+  /** `perPhaseTokens` flattened to `[phaseOrNull, tokens]` pairs. */
+  perPhaseTokens: Array<[string | null, number]>;
+  recentLogs: string[];
+  startTime: number;
+  endTime?: number;
+  result?: unknown;
+  error?: string;
+}
+
+/** Project a (terminal) registry entry into a serializable snapshot. */
+export function toSnapshot(task: WorkflowTask): WorkflowSnapshot {
+  return {
+    runId: task.runId,
+    meta: task.meta,
+    status: task.status,
+    script: task.script ?? '',
+    scriptPath: task.scriptPath,
+    phases: [...task.phases],
+    agentsDispatched: task.agentsDispatched,
+    agentsCompleted: task.agentsCompleted,
+    tokensSpent: task.tokensSpent,
+    tokenBudgetTotal: task.tokenBudgetTotal,
+    perPhaseTokens: Array.from(task.perPhaseTokens.entries()),
+    recentLogs: [...task.recentLogs],
+    startTime: task.startTime,
+    endTime: task.endTime,
+    result: safeResult(task.result),
+    error: task.error,
+  };
+}
+
+/** A non-JSON-serializable result is replaced with a placeholder string. */
+function safeResult(result: unknown): unknown {
+  if (result === undefined) return undefined;
+  try {
+    JSON.stringify(result);
+    return result;
+  } catch {
+    return `(non-JSON-serializable ${typeof result})`;
+  }
+}
+
+/**
+ * Write a run snapshot to `<projectDir>/workflows/<runId>.json`, then prune
+ * the oldest snapshots beyond `MAX_RETAINED_SNAPSHOTS`. Best-effort: a write
+ * failure is logged, not thrown (persistence is a convenience, not a
+ * correctness requirement).
+ */
+export async function writeWorkflowSnapshot(
+  config: Config,
+  task: WorkflowTask,
+): Promise<void> {
+  const storage = config.storage;
+  if (!storage) return;
+  try {
+    const dir = storage.getWorkflowRunsDir();
+    await fs.mkdir(dir, { recursive: true });
+    const snapshot = toSnapshot(task);
+    await fs.writeFile(
+      storage.getWorkflowRunSnapshotPath(task.runId),
+      JSON.stringify(snapshot, null, 2),
+      'utf8',
+    );
+    await pruneSnapshots(dir);
+  } catch (e) {
+    debugLogger.warn(`writeWorkflowSnapshot failed for ${task.runId}: ${e}`);
+  }
+}
+
+/**
+ * Load all persisted snapshots, newest-first by `startTime`. Tolerates a
+ * missing directory and skips unparseable files.
+ */
+export async function listWorkflowSnapshots(
+  config: Config,
+): Promise<WorkflowSnapshot[]> {
+  const storage = config.storage;
+  if (!storage) return [];
+  const dir = storage.getWorkflowRunsDir();
+  let files: string[];
+  try {
+    files = (await fs.readdir(dir)).filter((f) => f.endsWith('.json'));
+  } catch {
+    return [];
+  }
+  const snapshots: WorkflowSnapshot[] = [];
+  for (const file of files) {
+    try {
+      const raw = await fs.readFile(`${dir}/${file}`, 'utf8');
+      snapshots.push(JSON.parse(raw) as WorkflowSnapshot);
+    } catch (e) {
+      debugLogger.warn(`skipping unparseable snapshot ${file}: ${e}`);
+    }
+  }
+  snapshots.sort((a, b) => (b.startTime ?? 0) - (a.startTime ?? 0));
+  return snapshots;
+}
+
+/** Remove the oldest snapshots beyond the retention cap. */
+async function pruneSnapshots(dir: string): Promise<void> {
+  let files: string[];
+  try {
+    files = (await fs.readdir(dir)).filter((f) => f.endsWith('.json'));
+  } catch {
+    return;
+  }
+  if (files.length <= MAX_RETAINED_SNAPSHOTS) return;
+  // Sort by mtime ascending (oldest first) and unlink the overflow.
+  const stats = await Promise.all(
+    files.map(async (f) => {
+      try {
+        const s = await fs.stat(`${dir}/${f}`);
+        return { f, mtime: s.mtimeMs };
+      } catch {
+        return { f, mtime: 0 };
+      }
+    }),
+  );
+  stats.sort((a, b) => a.mtime - b.mtime);
+  const toPrune = stats.slice(0, stats.length - MAX_RETAINED_SNAPSHOTS);
+  await Promise.all(
+    toPrune.map((s) =>
+      fs.unlink(`${dir}/${s.f}`).catch((e) =>
+        debugLogger.warn(`prune unlink failed for ${s.f}: ${e}`),
+      ),
+    ),
+  );
+}

--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -351,6 +351,47 @@ export class Storage {
   }
 
   /**
+   * Project-level saved-workflow scripts directory: `<targetDir>/.qwen/workflows`.
+   * Saved workflow scripts (`<name>.js`) here are surfaced as slash commands
+   * and resolvable by `workflow('<name>')` from inside a running workflow.
+   */
+  getProjectWorkflowsDir(): string {
+    return path.join(this.getQwenDir(), 'workflows');
+  }
+
+  /**
+   * User-level saved-workflow scripts directory: `~/.qwen/workflows`. User
+   * scope is lower-precedence than project scope when the same `<name>.js`
+   * exists in both.
+   */
+  static getUserWorkflowsDir(): string {
+    return path.join(Storage.getGlobalQwenDir(), 'workflows');
+  }
+
+  /**
+   * Per-run workflow artifact directory: `<projectDir>/workflows`. Holds
+   * completed-run snapshot JSON files (`<runId>.json`) for the `/workflows`
+   * recent list, and per-run resume journals (`<runId>/journal.jsonl`).
+   */
+  getWorkflowRunsDir(): string {
+    return path.join(this.getProjectDir(), 'workflows');
+  }
+
+  /**
+   * Path to the persisted snapshot of a completed workflow run.
+   */
+  getWorkflowRunSnapshotPath(runId: string): string {
+    return path.join(this.getWorkflowRunsDir(), `${runId}.json`);
+  }
+
+  /**
+   * Path to the resume journal for an in-progress / resumable workflow run.
+   */
+  getWorkflowRunJournalPath(runId: string): string {
+    return path.join(this.getWorkflowRunsDir(), runId, 'journal.jsonl');
+  }
+
+  /**
    * Path to the runtime-status sidecar JSON for this session.
    *
    * Co-located with the per-session chat log under

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -228,6 +228,7 @@ export * from './services/shellExecutionService.js';
 export * from './services/monitorRegistry.js';
 export * from './services/backgroundShellRegistry.js';
 export * from './agents/workflow-run-registry.js';
+export * from './agents/workflow-snapshot.js';
 export * from './services/toolUseSummary.js';
 export * from './services/usageHistoryService.js';
 export * from './utils/bareMode.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -232,12 +232,14 @@ export * from './agents/workflow-snapshot.js';
 export {
   listSavedWorkflows,
   resolveSavedWorkflowScript,
+  saveWorkflowScript,
   validateWorkflowName,
   getSavedWorkflowDirs,
   WORKFLOW_NAME_PATTERN,
   type SavedWorkflowEntry,
   type SavedWorkflowSource,
   type ResolvedSavedWorkflow,
+  type WorkflowSaveResult,
 } from './agents/runtime/workflow-saved.js';
 export * from './services/toolUseSummary.js';
 export * from './services/usageHistoryService.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -335,6 +335,8 @@ export {
   logModelSlashCommand,
   logPromptSuggestion,
   logSpeculation,
+  logWorkflowKeyword,
+  logWorkflowRun,
 } from './telemetry/loggers.js';
 export {
   AuthEvent,
@@ -348,6 +350,8 @@ export {
   ModelSlashCommandEvent,
   PromptSuggestionEvent,
   SpeculationEvent,
+  WorkflowKeywordEvent,
+  WorkflowRunEvent,
 } from './telemetry/types.js';
 
 // ============================================================================

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -229,6 +229,16 @@ export * from './services/monitorRegistry.js';
 export * from './services/backgroundShellRegistry.js';
 export * from './agents/workflow-run-registry.js';
 export * from './agents/workflow-snapshot.js';
+export {
+  listSavedWorkflows,
+  resolveSavedWorkflowScript,
+  validateWorkflowName,
+  getSavedWorkflowDirs,
+  WORKFLOW_NAME_PATTERN,
+  type SavedWorkflowEntry,
+  type SavedWorkflowSource,
+  type ResolvedSavedWorkflow,
+} from './agents/runtime/workflow-saved.js';
 export * from './services/toolUseSummary.js';
 export * from './services/usageHistoryService.js';
 export * from './utils/bareMode.js';

--- a/packages/core/src/telemetry/constants.ts
+++ b/packages/core/src/telemetry/constants.ts
@@ -48,6 +48,10 @@ export const EVENT_USER_FEEDBACK = 'qwen-code.user_feedback';
 export const EVENT_PROMPT_SUGGESTION = 'qwen-code.prompt_suggestion';
 export const EVENT_SPECULATION = 'qwen-code.speculation';
 
+// Workflow Events (#4721)
+export const EVENT_WORKFLOW_KEYWORD = 'qwen-code.workflow_keyword';
+export const EVENT_WORKFLOW_RUN = 'qwen-code.workflow_run';
+
 // Arena Events
 export const EVENT_ARENA_SESSION_STARTED = 'qwen-code.arena_session_started';
 export const EVENT_ARENA_AGENT_COMPLETED = 'qwen-code.arena_agent_completed';

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -48,6 +48,8 @@ import {
   EVENT_ARENA_SESSION_ENDED,
   EVENT_PROMPT_SUGGESTION,
   EVENT_SPECULATION,
+  EVENT_WORKFLOW_KEYWORD,
+  EVENT_WORKFLOW_RUN,
   EVENT_MEMORY_EXTRACT,
   EVENT_MEMORY_DREAM,
   EVENT_MEMORY_RECALL,
@@ -115,6 +117,8 @@ import type {
   ArenaSessionEndedEvent,
   PromptSuggestionEvent,
   SpeculationEvent,
+  WorkflowKeywordEvent,
+  WorkflowRunEvent,
   MemoryExtractEvent,
   MemoryDreamEvent,
   MemoryRecallEvent,
@@ -1202,6 +1206,39 @@ export function logSpeculation(config: Config, event: SpeculationEvent): void {
     attributes,
   };
   logger.emit(logRecord);
+}
+
+// ─── Workflow Log Functions (#4721) ──────────────────────────────────────────
+
+export function logWorkflowKeyword(
+  config: Config,
+  event: WorkflowKeywordEvent,
+): void {
+  if (!isTelemetrySdkInitialized()) return;
+  const attributes: LogAttributes = {
+    ...getCommonAttributes(config),
+    'event.name': EVENT_WORKFLOW_KEYWORD,
+    'event.timestamp': event['event.timestamp'],
+  };
+  const logger = logs.getLogger(SERVICE_NAME);
+  logger.emit({ body: 'Workflow keyword trigger fired.', attributes });
+}
+
+export function logWorkflowRun(config: Config, event: WorkflowRunEvent): void {
+  if (!isTelemetrySdkInitialized()) return;
+  const attributes: LogAttributes = {
+    ...getCommonAttributes(config),
+    'event.name': EVENT_WORKFLOW_RUN,
+    'event.timestamp': event['event.timestamp'],
+    status: event.status,
+    agents_dispatched: event.agents_dispatched,
+    agents_completed: event.agents_completed,
+    phase_count: event.phase_count,
+    tokens_spent: event.tokens_spent,
+    duration_ms: event.duration_ms,
+  };
+  const logger = logs.getLogger(SERVICE_NAME);
+  logger.emit({ body: `Workflow run ${event.status}.`, attributes });
 }
 
 // ─── Auto-Memory Log Functions ───────────────────────────────────────────────

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -1281,6 +1281,47 @@ export class SpeculationEvent implements BaseTelemetryEvent {
   }
 }
 
+/** #4721 P-telemetry: the `workflow` keyword steered a turn toward the tool. */
+export class WorkflowKeywordEvent implements BaseTelemetryEvent {
+  'event.name': 'qwen-code.workflow_keyword';
+  'event.timestamp': string;
+
+  constructor() {
+    this['event.name'] = 'qwen-code.workflow_keyword';
+    this['event.timestamp'] = new Date().toISOString();
+  }
+}
+
+/** #4721 P-telemetry: a workflow run reached a terminal state. */
+export class WorkflowRunEvent implements BaseTelemetryEvent {
+  'event.name': 'qwen-code.workflow_run';
+  'event.timestamp': string;
+  status: string;
+  agents_dispatched: number;
+  agents_completed: number;
+  phase_count: number;
+  tokens_spent: number;
+  duration_ms: number;
+
+  constructor(params: {
+    status: string;
+    agents_dispatched: number;
+    agents_completed: number;
+    phase_count: number;
+    tokens_spent: number;
+    duration_ms: number;
+  }) {
+    this['event.name'] = 'qwen-code.workflow_run';
+    this['event.timestamp'] = new Date().toISOString();
+    this.status = params.status;
+    this.agents_dispatched = params.agents_dispatched;
+    this.agents_completed = params.agents_completed;
+    this.phase_count = params.phase_count;
+    this.tokens_spent = params.tokens_spent;
+    this.duration_ms = params.duration_ms;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Managed Auto-Memory Events
 // ---------------------------------------------------------------------------

--- a/packages/core/src/tools/workflow/workflow.test.ts
+++ b/packages/core/src/tools/workflow/workflow.test.ts
@@ -12,6 +12,7 @@ import { WorkflowTool } from './workflow.js';
 import type { Config } from '../../config/config.js';
 import { ToolNames, ToolDisplayNames } from '../tool-names.js';
 import { WorkflowRunRegistry } from '../../agents/workflow-run-registry.js';
+import { Storage } from '../../config/storage.js';
 
 function fakeConfig(): Config {
   return {} as unknown as Config;
@@ -62,6 +63,17 @@ describe('WorkflowTool', () => {
     ).toThrow(/exactly one/);
   });
 
+  it('rejects build() when resumeFromRunId is not a wf_<hex> id (path-traversal guard)', () => {
+    const tool = new WorkflowTool(fakeConfig());
+    expect(() =>
+      tool.build({ script: 'return 1', resumeFromRunId: '../../etc/evil' }),
+    ).toThrow(/resumeFromRunId/);
+    // A well-formed generated id is accepted.
+    expect(() =>
+      tool.build({ script: 'return 1', resumeFromRunId: 'wf_1a2b3c4d5e6f7081' }),
+    ).not.toThrow();
+  });
+
   it('build() accepts a scriptPath without inline script', () => {
     const tool = new WorkflowTool(fakeConfig());
     const invocation = tool.build({
@@ -73,11 +85,19 @@ describe('WorkflowTool', () => {
   });
 
   it('execute() loads a saved-workflow scriptPath and records its provenance', async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'wf-tool-'));
-    const scriptPath = path.join(dir, 'greet.js');
-    await fs.writeFile(scriptPath, 'return await agent("hi");', 'utf8');
+    const projectDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wf-tool-'));
     try {
-      const { config, registry } = configWithRegistry();
+      const registry = new WorkflowRunRegistry();
+      const config = {
+        getWorkflowRunRegistry: () => registry,
+        storage: new Storage(projectDir),
+      } as unknown as Config;
+      // The scriptPath MUST live under a saved-workflow dir (the resolver
+      // refuses paths outside it — the #2 path-traversal / symlink guard).
+      const dir = new Storage(projectDir).getProjectWorkflowsDir();
+      await fs.mkdir(dir, { recursive: true });
+      const scriptPath = path.join(dir, 'greet.js');
+      await fs.writeFile(scriptPath, 'return await agent("hi");', 'utf8');
       const tool = new WorkflowTool(config, {
         dispatch: async (prompt) => `T:${prompt}`,
       });
@@ -85,13 +105,13 @@ describe('WorkflowTool', () => {
       const result = await invocation.execute(new AbortController().signal);
       expect(result.error).toBeUndefined();
       expect(JSON.stringify(result.llmContent)).toContain('T:hi');
-      // The registry entry carries the resolved absolute path (provenance for
-      // the snapshot writer + the save dialog's "already saved" branch).
+      // The registry entry carries the resolved absolute path (run provenance
+      // for the snapshot writer).
       const entries = registry.list();
       expect(entries).toHaveLength(1);
       expect(entries[0].scriptPath).toBe(scriptPath);
     } finally {
-      await fs.rm(dir, { recursive: true, force: true });
+      await fs.rm(projectDir, { recursive: true, force: true });
     }
   });
 

--- a/packages/core/src/tools/workflow/workflow.test.ts
+++ b/packages/core/src/tools/workflow/workflow.test.ts
@@ -5,6 +5,9 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { WorkflowTool } from './workflow.js';
 import type { Config } from '../../config/config.js';
 import { ToolNames, ToolDisplayNames } from '../tool-names.js';
@@ -48,6 +51,48 @@ describe('WorkflowTool', () => {
   it('rejects build() when script is empty string', () => {
     const tool = new WorkflowTool(fakeConfig());
     expect(() => tool.build({ script: '' })).toThrow(/script/);
+  });
+
+  // ── P7b-A1: saved-workflow scriptPath path ──────────────────────────────
+
+  it('rejects build() when both script and scriptPath are given', () => {
+    const tool = new WorkflowTool(fakeConfig());
+    expect(() =>
+      tool.build({ script: 'return 1', scriptPath: '/x/y.js' }),
+    ).toThrow(/exactly one/);
+  });
+
+  it('build() accepts a scriptPath without inline script', () => {
+    const tool = new WorkflowTool(fakeConfig());
+    const invocation = tool.build({
+      scriptPath: '/abs/deep-research.js',
+    });
+    expect(invocation.params.scriptPath).toBe('/abs/deep-research.js');
+    // Description reflects the saved-workflow filename, not a char count.
+    expect(invocation.getDescription()).toContain('deep-research.js');
+  });
+
+  it('execute() loads a saved-workflow scriptPath and records its provenance', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'wf-tool-'));
+    const scriptPath = path.join(dir, 'greet.js');
+    await fs.writeFile(scriptPath, 'return await agent("hi");', 'utf8');
+    try {
+      const { config, registry } = configWithRegistry();
+      const tool = new WorkflowTool(config, {
+        dispatch: async (prompt) => `T:${prompt}`,
+      });
+      const invocation = tool.build({ scriptPath });
+      const result = await invocation.execute(new AbortController().signal);
+      expect(result.error).toBeUndefined();
+      expect(JSON.stringify(result.llmContent)).toContain('T:hi');
+      // The registry entry carries the resolved absolute path (provenance for
+      // the snapshot writer + the save dialog's "already saved" branch).
+      const entries = registry.list();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].scriptPath).toBe(scriptPath);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
   });
 
   it('build() returns an invocation that exposes the script as description', () => {

--- a/packages/core/src/tools/workflow/workflow.ts
+++ b/packages/core/src/tools/workflow/workflow.ts
@@ -42,11 +42,23 @@ import type { JournalReplay } from '../../agents/runtime/workflow-journal.js';
 import { writeWorkflowSnapshot } from '../../agents/workflow-snapshot.js';
 import { createChildAbortController } from '../../utils/abortController.js';
 import { randomBytes } from 'node:crypto';
+import * as path from 'node:path';
 import type { WorkflowTask } from '../../agents/workflow-run-registry.js';
 
 export interface WorkflowParams {
-  /** Inline JavaScript source for the workflow. Required in P1. */
-  script: string;
+  /**
+   * Inline JavaScript source for the workflow. Provide exactly one of
+   * `script` or `scriptPath`.
+   */
+  script?: string;
+  /**
+   * P7b: absolute path to a saved workflow `.js` file to load and run
+   * instead of inline `script`. Set by the `/<name>` saved-workflow slash
+   * command (`SavedWorkflowLoader`). Read at execution time so edits to the
+   * saved file take effect on the next run; the resolved path is recorded on
+   * the registry entry as run provenance.
+   */
+  scriptPath?: string;
   /** Optional structured value bound to the `args` global inside the script. */
   args?: unknown;
   /**
@@ -118,6 +130,15 @@ const WORKFLOW_PARAM_SCHEMA = {
         'must be deterministic for resume. ' +
         '`export const meta = {...}` declarations are stripped before execution.',
     },
+    scriptPath: {
+      type: 'string',
+      description:
+        'Optional. Absolute path to a saved workflow `.js` file to load and ' +
+        'run instead of inline `script`. Primarily set by the `/<name>` ' +
+        'saved-workflow slash command. Provide exactly ONE of `script` or ' +
+        '`scriptPath`. The file is read at execution time, so edits to a ' +
+        'saved workflow take effect on the next run.',
+    },
     args: {
       description:
         'Optional structured value bound to the `args` global. Pass actual JSON, not a stringified value.',
@@ -133,7 +154,10 @@ const WORKFLOW_PARAM_SCHEMA = {
         'and args as the original run for the cache to apply.',
     },
   },
-  required: ['script'],
+  // `script` is required UNLESS `scriptPath` is supplied; this XOR can't be
+  // expressed as a plain `required` list, so it's enforced in
+  // `validateToolParamValues`. Inline authoring (the LLM path) should always
+  // pass `script` — the `script` property description states this.
 } as const;
 
 class WorkflowToolInvocation extends BaseToolInvocation<
@@ -149,7 +173,10 @@ class WorkflowToolInvocation extends BaseToolInvocation<
   }
 
   getDescription(): string {
-    return `Run a workflow script (${this.params.script.length} chars)`;
+    if (this.params.scriptPath && this.params.script === undefined) {
+      return `Run saved workflow (${path.basename(this.params.scriptPath)})`;
+    }
+    return `Run a workflow script (${this.params.script?.length ?? 0} chars)`;
   }
 
   override toolLocations(): ToolLocation[] {
@@ -186,6 +213,23 @@ class WorkflowToolInvocation extends BaseToolInvocation<
       );
     const orchestrator = new WorkflowOrchestrator(dispatch);
 
+    // P7b: resolve the script source. A `/<name>` saved-workflow slash
+    // command dispatches `{scriptPath}` instead of inline `script`; read the
+    // file here (fresh, so edits to a saved workflow take effect on the next
+    // run). The resolved absolute path is recorded on the registry entry as
+    // run provenance — it is never re-read mid-run. `validateToolParamValues`
+    // has already guaranteed exactly one of `script` / `scriptPath` is set.
+    let resolvedScript = this.params.script ?? '';
+    let resolvedScriptPath = this.params.scriptPath;
+    if (this.params.scriptPath && this.params.script === undefined) {
+      const loaded = await resolveSavedWorkflowScript(
+        { scriptPath: this.params.scriptPath },
+        this.config,
+      );
+      resolvedScript = loaded.script;
+      resolvedScriptPath = loaded.scriptPath;
+    }
+
     // P4b: pre-generate the runId so the registry record exists before
     // the first sandbox event fires. Without this, `agentDispatched` /
     // `phaseStarted` callbacks would have no entry to update.
@@ -221,7 +265,10 @@ class WorkflowToolInvocation extends BaseToolInvocation<
       tokenBudgetTotal: budget.total,
       // P7b: carry the script source so a completed run can be snapshotted
       // to disk and saved to `.qwen/workflows/<name>.js` from the dialog.
-      script: this.params.script,
+      // `scriptPath` is set when the run was launched from a saved file (the
+      // save dialog then offers "already saved" for it).
+      script: resolvedScript,
+      scriptPath: resolvedScriptPath,
     });
     // The emitter forwards sandbox + dispatch events into the registry
     // AND fires `updateOutput` so the tool's renderDisplay block (a
@@ -265,7 +312,7 @@ class WorkflowToolInvocation extends BaseToolInvocation<
 
     try {
       const outcome = await orchestrator.run({
-        script: this.params.script,
+        script: resolvedScript,
         args: this.params.args,
         abortOnTimeout: dispatchController,
         runId,
@@ -632,8 +679,17 @@ export class WorkflowTool extends BaseDeclarativeTool<
   protected override validateToolParamValues(
     params: WorkflowParams,
   ): string | null {
-    if (typeof params.script !== 'string' || params.script.length === 0) {
-      return 'WorkflowTool: `script` parameter is required and must be a non-empty string.';
+    const hasScript =
+      typeof params.script === 'string' && params.script.length > 0;
+    const hasPath =
+      typeof params.scriptPath === 'string' && params.scriptPath.length > 0;
+    // XOR: inline `script` (LLM authoring) or `scriptPath` (a saved-workflow
+    // slash command), never both, never neither.
+    if (!hasScript && !hasPath) {
+      return 'WorkflowTool: provide `script` (inline source) or `scriptPath` (a saved workflow file).';
+    }
+    if (hasScript && hasPath) {
+      return 'WorkflowTool: provide exactly one of `script` or `scriptPath`, not both.';
     }
     return null;
   }

--- a/packages/core/src/tools/workflow/workflow.ts
+++ b/packages/core/src/tools/workflow/workflow.ts
@@ -36,6 +36,7 @@ import {
   WorkflowBudgetImpl,
   MAX_TOKENS_PER_WORKFLOW_ENV,
 } from '../../agents/runtime/workflow-budget.js';
+import { resolveSavedWorkflowScript } from '../../agents/runtime/workflow-saved.js';
 import { createChildAbortController } from '../../utils/abortController.js';
 import { randomBytes } from 'node:crypto';
 import type { WorkflowTask } from '../../agents/workflow-run-registry.js';
@@ -229,6 +230,10 @@ class WorkflowToolInvocation extends BaseToolInvocation<
         runId,
         emitter,
         budget,
+        // P-nested: resolve `workflow('<name>')` / `workflow({scriptPath})`
+        // against the saved-workflow scripts in `.qwen/workflows/`.
+        resolveSavedWorkflow: (ref) =>
+          resolveSavedWorkflowScript(ref, this.config),
       });
 
       // P4b: snapshot meta + logs onto the registry record so the dialog

--- a/packages/core/src/tools/workflow/workflow.ts
+++ b/packages/core/src/tools/workflow/workflow.ts
@@ -267,8 +267,8 @@ class WorkflowToolInvocation extends BaseToolInvocation<
       tokenBudgetTotal: budget.total,
       // P7b: carry the script source so a completed run can be snapshotted
       // to disk and saved to `.qwen/workflows/<name>.js` from the dialog.
-      // `scriptPath` is set when the run was launched from a saved file (the
-      // save dialog then offers "already saved" for it).
+      // `scriptPath` is set when the run was launched from a saved file (run
+      // provenance for the snapshot).
       script: resolvedScript,
       scriptPath: resolvedScriptPath,
     });
@@ -714,6 +714,17 @@ export class WorkflowTool extends BaseDeclarativeTool<
     }
     if (hasScript && hasPath) {
       return 'WorkflowTool: provide exactly one of `script` or `scriptPath`, not both.';
+    }
+    // Security: `resumeFromRunId` becomes the `runId` and flows verbatim into
+    // `getWorkflowRunJournalPath` / `getWorkflowRunSnapshotPath` (both
+    // `path.join`-based), so a value containing `..` or path separators could
+    // move journal/snapshot reads and writes outside `<projectDir>/workflows`.
+    // Accept only the generated id shape.
+    if (
+      params.resumeFromRunId !== undefined &&
+      !/^wf_[0-9a-f]+$/.test(params.resumeFromRunId)
+    ) {
+      return 'WorkflowTool: `resumeFromRunId` must match the generated id format `wf_<hex>`.';
     }
     return null;
   }

--- a/packages/core/src/tools/workflow/workflow.ts
+++ b/packages/core/src/tools/workflow/workflow.ts
@@ -39,6 +39,7 @@ import {
 import { resolveSavedWorkflowScript } from '../../agents/runtime/workflow-saved.js';
 import { WorkflowJournal } from '../../agents/runtime/workflow-journal.js';
 import type { JournalReplay } from '../../agents/runtime/workflow-journal.js';
+import { writeWorkflowSnapshot } from '../../agents/workflow-snapshot.js';
 import { createChildAbortController } from '../../utils/abortController.js';
 import { randomBytes } from 'node:crypto';
 import type { WorkflowTask } from '../../agents/workflow-run-registry.js';
@@ -218,6 +219,9 @@ class WorkflowToolInvocation extends BaseToolInvocation<
       // immediately, before the first `budgetUpdated` fires. Stays
       // `null` when no env override.
       tokenBudgetTotal: budget.total,
+      // P7b: carry the script source so a completed run can be snapshotted
+      // to disk and saved to `.qwen/workflows/<name>.js` from the dialog.
+      script: this.params.script,
     });
     // The emitter forwards sandbox + dispatch events into the registry
     // AND fires `updateOutput` so the tool's renderDisplay block (a
@@ -400,6 +404,15 @@ class WorkflowToolInvocation extends BaseToolInvocation<
     } finally {
       // T40: cancel any straggler subagent on natural completion.
       dispatchController.abort();
+      // P7b: persist a snapshot of the terminal run so `/workflows` can show
+      // it after a CLI restart. Runs on every terminal path (success / fail /
+      // cancel) because the registry entry has already transitioned by here.
+      // Best-effort: the writer swallows its own errors. Skipped when there's
+      // no registry entry (test-injected configs) or the entry is somehow
+      // still running (defensive).
+      if (registryEntry && registryEntry.status !== 'running') {
+        await writeWorkflowSnapshot(this.config, registryEntry);
+      }
     }
   }
 }

--- a/packages/core/src/tools/workflow/workflow.ts
+++ b/packages/core/src/tools/workflow/workflow.ts
@@ -40,6 +40,8 @@ import { resolveSavedWorkflowScript } from '../../agents/runtime/workflow-saved.
 import { WorkflowJournal } from '../../agents/runtime/workflow-journal.js';
 import type { JournalReplay } from '../../agents/runtime/workflow-journal.js';
 import { writeWorkflowSnapshot } from '../../agents/workflow-snapshot.js';
+import { logWorkflowRun } from '../../telemetry/loggers.js';
+import { WorkflowRunEvent } from '../../telemetry/types.js';
 import { createChildAbortController } from '../../utils/abortController.js';
 import { randomBytes } from 'node:crypto';
 import * as path from 'node:path';
@@ -459,6 +461,25 @@ class WorkflowToolInvocation extends BaseToolInvocation<
       // still running (defensive).
       if (registryEntry && registryEntry.status !== 'running') {
         await writeWorkflowSnapshot(this.config, registryEntry);
+        // P-telemetry: emit the terminal run event (no-op when telemetry is
+        // off). Best-effort: never let a logging failure mask the result.
+        try {
+          logWorkflowRun(
+            this.config,
+            new WorkflowRunEvent({
+              status: registryEntry.status,
+              agents_dispatched: registryEntry.agentsDispatched,
+              agents_completed: registryEntry.agentsCompleted,
+              phase_count: registryEntry.phases.length,
+              tokens_spent: registryEntry.tokensSpent,
+              duration_ms:
+                (registryEntry.endTime ?? registryEntry.startTime) -
+                registryEntry.startTime,
+            }),
+          );
+        } catch {
+          // swallow — telemetry must not affect tool output
+        }
       }
     }
   }

--- a/packages/core/src/tools/workflow/workflow.ts
+++ b/packages/core/src/tools/workflow/workflow.ts
@@ -159,7 +159,7 @@ const WORKFLOW_PARAM_SCHEMA = {
   // `script` is required UNLESS `scriptPath` is supplied; this XOR can't be
   // expressed as a plain `required` list, so it's enforced in
   // `validateToolParamValues`. Inline authoring (the LLM path) should always
-  // pass `script` — the `script` property description states this.
+  // pass `script`; the `scriptPath` property description states the XOR.
 } as const;
 
 class WorkflowToolInvocation extends BaseToolInvocation<
@@ -686,10 +686,13 @@ export class WorkflowTool extends BaseDeclarativeTool<
         'agents total; both env-overridable), per-call `agent({ schema, ' +
         "agentType, model, isolation: 'worktree' })` for structured-output " +
         'contracts, declarative-agent selection, model override, and git-' +
-        'worktree-isolated subagents. No resume and no background execution ' +
-        'yet (scheduled for later phases). Scripts run in a node:vm sandbox ' +
-        'without access to the filesystem or shell; all I/O happens through ' +
-        'the spawned agents.',
+        'worktree-isolated subagents. Pass `resumeFromRunId` to resume a prior ' +
+        'run — agent() calls whose rolling prefix-hash matches the journal are ' +
+        'served from cache for the longest unchanged prefix. Runs are tracked ' +
+        'in the background-tasks view and the `/workflows` dialog (live phase ' +
+        'tree, token usage, cancel). Scripts run in a node:vm sandbox without ' +
+        'access to the filesystem or shell; all I/O happens through the ' +
+        'spawned agents.',
       Kind.Other,
       WORKFLOW_PARAM_SCHEMA,
       /* isOutputMarkdown */ true,

--- a/packages/core/src/tools/workflow/workflow.ts
+++ b/packages/core/src/tools/workflow/workflow.ts
@@ -37,6 +37,8 @@ import {
   MAX_TOKENS_PER_WORKFLOW_ENV,
 } from '../../agents/runtime/workflow-budget.js';
 import { resolveSavedWorkflowScript } from '../../agents/runtime/workflow-saved.js';
+import { WorkflowJournal } from '../../agents/runtime/workflow-journal.js';
+import type { JournalReplay } from '../../agents/runtime/workflow-journal.js';
 import { createChildAbortController } from '../../utils/abortController.js';
 import { randomBytes } from 'node:crypto';
 import type { WorkflowTask } from '../../agents/workflow-run-registry.js';
@@ -46,6 +48,14 @@ export interface WorkflowParams {
   script: string;
   /** Optional structured value bound to the `args` global inside the script. */
   args?: unknown;
+  /**
+   * P6: resume a prior run by id. When set, the run reuses `<runId>` and
+   * loads `<projectDir>/workflows/<runId>/journal.jsonl`; `agent()` calls
+   * whose rolling prefix-hash matches a journaled result are served from
+   * cache (no re-dispatch) for the longest unchanged prefix. The first miss
+   * runs live and the run goes live for the remainder.
+   */
+  resumeFromRunId?: string;
 }
 
 export interface WorkflowToolOptions {
@@ -111,6 +121,16 @@ const WORKFLOW_PARAM_SCHEMA = {
       description:
         'Optional structured value bound to the `args` global. Pass actual JSON, not a stringified value.',
     },
+    resumeFromRunId: {
+      type: 'string',
+      description:
+        'Optional. Resume a prior workflow run by id (e.g. wf_abc123…). ' +
+        'Re-runs the SAME script; agent() calls whose rolling prefix-hash ' +
+        '(prompt + opts, chained in call order) matches a journaled result ' +
+        'are served from cache for the longest unchanged prefix, and the ' +
+        'first changed/missing call onward runs live. Pass the same script ' +
+        'and args as the original run for the cache to apply.',
+    },
   },
   required: ['script'],
 } as const;
@@ -168,7 +188,24 @@ class WorkflowToolInvocation extends BaseToolInvocation<
     // P4b: pre-generate the runId so the registry record exists before
     // the first sandbox event fires. Without this, `agentDispatched` /
     // `phaseStarted` callbacks would have no entry to update.
-    const runId = `wf_${randomBytes(8).toString('hex')}`;
+    // P6: a resume reuses the prior run's id so it appends to the same
+    // journal; a fresh run gets a new id.
+    const runId =
+      this.params.resumeFromRunId ?? `wf_${randomBytes(8).toString('hex')}`;
+    // P6: per-run resume journal. Always created (any run is resumable);
+    // the replay maps are loaded only when resuming. Production storage
+    // path is `<projectDir>/workflows/<runId>/journal.jsonl`; the tool's
+    // test-injected dispatch path leaves `config.storage` undefined, so
+    // guard and skip journaling there.
+    let journal: WorkflowJournal | undefined;
+    let resumeReplay: JournalReplay | undefined;
+    const storage = this.config.storage;
+    if (storage) {
+      journal = new WorkflowJournal(storage.getWorkflowRunJournalPath(runId));
+      if (this.params.resumeFromRunId) {
+        resumeReplay = await journal.load();
+      }
+    }
     const registry = this.config.getWorkflowRunRegistry?.();
     const registryEntry = registry?.register({
       runId,
@@ -234,6 +271,9 @@ class WorkflowToolInvocation extends BaseToolInvocation<
         // against the saved-workflow scripts in `.qwen/workflows/`.
         resolveSavedWorkflow: (ref) =>
           resolveSavedWorkflowScript(ref, this.config),
+        // P6: resume journal (always wired) + replay maps (resume only).
+        journal,
+        resumeReplay,
       });
 
       // P4b: snapshot meta + logs onto the registry record so the dialog

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -233,6 +233,11 @@
           "type": "boolean",
           "default": false
         },
+        "disableWorkflowKeywordTrigger": {
+          "description": "When true, mentioning the word `workflow` in a prompt no longer softly steers the turn toward the Workflow tool (and the Footer `workflow active` indicator is suppressed). Only applies when workflows are enabled.",
+          "type": "boolean",
+          "default": false
+        },
         "showStatusInTitle": {
           "description": "Show Qwen Code session name and status in the terminal window title",
           "type": "boolean",


### PR DESCRIPTION
## What this PR does

Finishes the Dynamic Workflows port (#4721) on top of the already-merged P1–P5 foundation, bundling all remaining work into one PR. It adds, in dependency order:

- **`workflow('<name>')` nested global (P-nested)** — a running workflow can invoke a saved workflow by name (single level only; the nested sandbox lacks the impl, so deeper nesting throws).
- **Agent stall watchdog + retry (P-stall)** — a per-dispatch watchdog aborts a subagent that goes silent past a timeout (reset on round/stream/usage/tool events, suspended during in-flight tools), with a 3-attempt retry loop wrapping both dispatch paths.
- **Budget-exhausted drop accounting (Gap-3)** — `parallel()`/`pipeline()` distinguish a slot dropped by the token cap from an ordinary error.
- **Same-session resume via JSONL journal (P6)** — `resumeFromRunId` replays a rolling prefix-hash chain; `agent()` calls whose `(prompt, opts)` match the journal are served from cache for the longest unchanged prefix, then the run goes live from the first miss.
- **Run snapshots (P7b-A2)** — each terminal run is persisted to `<projectDir>/workflows/<runId>.json`, so `/workflows` shows a recent history that survives a restart (retention-capped, oldest pruned).
- **Saved workflows as `/<name>` slash commands (P7b-A1)** — a script saved at `.qwen/workflows/<name>.js` (project) or `~/.qwen/workflows/<name>.js` (user) is discoverable as `/<name>`, which dispatches the `workflow` tool with the file path (read fresh each run). The tool gained a `scriptPath` param (XOR with inline `script`).
- **Save-to-disk dialog (P7b-A3)** — in the `/workflows` detail view, `s` saves a completed run's script to a named `.qwen/workflows/<name>.js` (project/user scope toggle, overwrite confirm).
- **`workflow` keyword trigger + footer indicator (P7-trigger)** — mentioning the word `workflow` in a prompt softly steers that turn toward the Workflow tool (a `<system-reminder>` nudge, never a forced tool call) and shows a `⚙ workflow active` footer indicator. Opt-out via `ui.disableWorkflowKeywordTrigger`.
- **Completion notification (P-notif)** — a terminal-bell notification fires when a run completes/fails (not on user-initiated cancel).
- **Telemetry (P-telemetry)** — `qwen-code.workflow_keyword` and `qwen-code.workflow_run` events (no-op unless telemetry is enabled).

Whole-run cancel already works from the `/workflows` dialog (`x` aborts the run). Per-agent pause/retry/skip and the ACP `'workflow'` daemon propagation are intentionally deferred to follow-ups.

## Why it's needed

P1–P5 shipped the workflow engine and the live `/workflows` view, but a workflow couldn't be resumed, saved, re-run by name, or noticed when it finished, and there was no opt-in trigger. This PR closes that gap so workflows become reusable, durable across sessions, and discoverable — matching the capability surface of the upstream feature this was reverse-engineered from.

## Reviewer Test Plan

### How to verify

Enable the feature with `QWEN_CODE_ENABLE_WORKFLOWS=1`.

1. **Saved-workflow discovery + run.** Create `.qwen/workflows/demo.js` with `export const meta = { name: 'demo', phases: [{title:'Plan'}] }; phase('Plan'); log('hi'); return 'done';`. Start the CLI; type `/demo` → autocomplete shows `demo [json-args]  Run the "demo" saved workflow (project)`. Run it → it completes with `result: "done"`.
2. **Cross-session history.** Run `/workflows` → the completed run is listed. Restart the CLI (fresh process) and run `/workflows` again → the run is still listed (loaded from the on-disk snapshot, not in-memory state).
3. **Keyword trigger.** Submit a prompt containing the word `workflow` → the footer shows `⚙ workflow active` during the turn; it clears when the turn returns to idle. `workflows`, `dataflow`, `my-workflow-runner` do NOT trigger.
4. **Resume.** Run a workflow with `agent()` calls, then call the tool again with `resumeFromRunId: <id>` and the same script → matching `agent()` calls are served from the journal cache.
5. **Save dialog.** After a run, open the background-tasks dialog, focus the workflow entry, `Enter` for detail, `s` to save, type a name, `Tab` to toggle scope, `Enter` → the script is written to `.qwen/workflows/<name>.js` and becomes `/<name>` next session.

### Evidence (Before & After)

Verified locally via tmux against the local build (`node dist/cli.js`, real auth):

- `/demo-research` saved-workflow autocomplete + full execution (`result: "done"`, logs/phases parsed).
- `/workflows`: empty state → populated listing → **survives a process restart** (run re-listed purely from the on-disk snapshot at `~/.qwen/projects/<hash>/workflows/<runId>.json`).
- Footer `⚙ workflow active` appears on a `workflow`-keyword submit and the steered turn completes normally.

The save dialog (P7b-A3), the terminal bell (P-notif, an escape sequence), and per-run cancel (P-tui) are covered by unit/component tests rather than tmux (the interactive multi-key save flow and escape-sequence bell aren't reliably driveable via `send-keys`). Full suite: the workflow surface across both packages is green (380+ workflow-specific tests), plus workspace typecheck and lint.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |
