### PR TITLE
fix(core): parse API timeout env strictly

### DIFF
--- a/packages/core/src/models/modelConfigResolver.test.ts
+++ b/packages/core/src/models/modelConfigResolver.test.ts
@@ -237,6 +237,7 @@ describe('modelConfigResolver', () => {
         });
 
         expect(result.config.timeout).toBeUndefined();
+        expect(result.sources['timeout']).toBeUndefined();
       });
 
       it('negative QWEN_CODE_API_TIMEOUT_MS ignored in OAuth path', () => {
@@ -265,7 +266,7 @@ describe('modelConfigResolver', () => {
         expect(result.config.timeout).toBeUndefined();
       });
 
-      it('QWEN_CODE_API_TIMEOUT_MS works with float value in OAuth', () => {
+      it('fractional QWEN_CODE_API_TIMEOUT_MS ignored in OAuth', () => {
         const result = resolveModelConfig({
           authType: AuthType.QWEN_OAUTH,
           cli: {},
@@ -275,7 +276,7 @@ describe('modelConfigResolver', () => {
           },
         });
 
-        expect(result.config.timeout).toBe(12345);
+        expect(result.config.timeout).toBeUndefined();
       });
 
       it('QWEN_CODE_API_TIMEOUT_MS works with proxy in OAuth path', () => {
@@ -573,7 +574,6 @@ describe('modelConfigResolver', () => {
           },
         });
 
-        // Number() implicitly trims whitespace, so this should parse correctly
         expect(result.config.timeout).toBe(300000);
         expect(result.sources['timeout'].kind).toBe('env');
       });
@@ -782,34 +782,24 @@ describe('modelConfigResolver', () => {
   });
 
   describe('[Additional] timeout env override edge cases', () => {
-    it('handles scientific notation in QWEN_CODE_API_TIMEOUT_MS', () => {
-      const result = resolveModelConfig({
-        authType: AuthType.USE_OPENAI,
-        cli: {},
-        settings: { apiKey: 'key' },
-        env: {
-          OPENAI_API_KEY: 'key',
-          QWEN_CODE_API_TIMEOUT_MS: '1.5e5',
-        },
-      });
-
-      expect(result.config.timeout).toBe(150000);
-      expect(result.sources['timeout'].kind).toBe('env');
-    });
-
-    it('handles hex values in QWEN_CODE_API_TIMEOUT_MS', () => {
+    it.each([
+      ['scientific notation', '1.5e5'],
+      ['hex values', '0x2BF20'],
+      ['fractional values', '12345.67'],
+      ['unsafe integers', String(Number.MAX_SAFE_INTEGER + 1)],
+    ])('ignores %s in QWEN_CODE_API_TIMEOUT_MS', (_label, value) => {
       const result = resolveModelConfig({
         authType: AuthType.USE_OPENAI,
         cli: {},
         settings: { apiKey: 'key', generationConfig: { timeout: 30000 } },
         env: {
           OPENAI_API_KEY: 'key',
-          QWEN_CODE_API_TIMEOUT_MS: '0x2BF20', // 180000 in hex
+          QWEN_CODE_API_TIMEOUT_MS: value,
         },
       });
 
-      expect(result.config.timeout).toBe(180000);
-      expect(result.sources['timeout'].kind).toBe('env');
+      expect(result.config.timeout).toBe(30000);
+      expect(result.sources['timeout'].kind).toBe('settings');
     });
 
     it('ignores empty string QWEN_CODE_API_TIMEOUT_MS', () => {

--- a/packages/core/src/models/modelConfigResolver.ts
+++ b/packages/core/src/models/modelConfigResolver.ts
@@ -36,6 +36,7 @@ import {
   type ConfigSources,
   type ConfigLayer,
 } from '../utils/configResolver.js';
+import { parsePositiveIntegerEnv } from '../utils/env.js';
 import {
   AUTH_ENV_MAPPINGS,
   DEFAULT_MODELS,
@@ -122,9 +123,9 @@ function applyTimeoutEnvOverride(
   const raw = env['QWEN_CODE_API_TIMEOUT_MS'];
   if (raw === undefined) return;
 
-  const parsed = Number(raw);
-  if (Number.isFinite(parsed) && parsed > 0) {
-    generationConfig.timeout = Math.floor(parsed);
+  const parsed = parsePositiveIntegerEnv(raw, 0);
+  if (parsed > 0) {
+    generationConfig.timeout = parsed;
     sources['timeout'] = {
       kind: 'env',
       envKey: 'QWEN_CODE_API_TIMEOUT_MS',


### PR DESCRIPTION
## What this PR does

This PR makes `QWEN_CODE_API_TIMEOUT_MS` use the same strict positive-integer env parsing rule as the newer shared env parser. Decimal positive integer values still override the lower-priority timeout, while malformed values are ignored.

It also updates the timeout env override tests so fractional, scientific-notation, hex, and unsafe-integer values fall back to the existing settings timeout instead of being coerced.

## Why it's needed

The previous parser used JavaScript number coercion, so values like `1.5e5`, `0x2BF20`, and `12345.67` were accepted as valid millisecond timeouts. That is surprising for a `*_MS` env var and inconsistent with the stricter env parsing now used by nearby configuration knobs.

Keeping timeout env parsing strict avoids silently changing user intent while preserving the current precedence order: model provider config wins, then env, then settings/defaults.

## Reviewer Test Plan

### How to verify

Reviewers can confirm that `QWEN_CODE_API_TIMEOUT_MS` accepts decimal positive integers such as `300000`, still trims surrounding whitespace, and ignores malformed values such as `1.5e5`, `0x2BF20`, `12345.67`, and unsafe integers.

Commands run locally:

```sh
(cd packages/core && npx vitest run src/models/modelConfigResolver.test.ts)
npx prettier --check packages/core/src/models/modelConfigResolver.ts packages/core/src/models/modelConfigResolver.test.ts
npx eslint packages/core/src/models/modelConfigResolver.ts packages/core/src/models/modelConfigResolver.test.ts
npm run build --workspace @qwen-code/qwen-code-core
npm run typecheck --workspace @qwen-code/qwen-code-core
git diff --check
```

### Evidence (Before & After)

Before: `QWEN_CODE_API_TIMEOUT_MS=1.5e5`, `QWEN_CODE_API_TIMEOUT_MS=0x2BF20`, and `QWEN_CODE_API_TIMEOUT_MS=12345.67` were accepted/coerced as env timeouts.

After: those malformed values are ignored and the lower-priority configured timeout is preserved. This is covered by the updated `modelConfigResolver` unit tests.

No UI/TUI evidence is attached because this is a config parsing change covered by unit tests.

### Tested on

|     OS     |   Status    |
| :--------: | :---------: |
|  🍏 macOS  |  ✅ tested  |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local Node/npm workspace on macOS. `npm install` completed successfully before running the focused validation commands.

## Risk & Scope

- Main risk or tradeoff: users who intentionally used scientific notation, hex, fractional, or unsafe integer timeout env values will need to switch to decimal positive integer milliseconds.
- Not validated / out of scope: no end-to-end model request was run; the behavior is covered at the shared model config resolver layer.
- Breaking changes / migration notes: malformed `QWEN_CODE_API_TIMEOUT_MS` values are now ignored instead of coerced.

## Linked Issues

Fixes #5596

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让 `QWEN_CODE_API_TIMEOUT_MS` 使用和较新的共享 env parser 一致的严格正整数解析规则。十进制正整数仍然会覆盖低优先级 timeout，格式不合法的值会被忽略。

同时更新了 timeout env override 的测试，确保小数、科学计数法、十六进制和不安全整数会回退到已有 settings timeout，而不是被静默转换。

## Why it's needed

之前的解析逻辑使用 JavaScript number coercion，因此 `1.5e5`、`0x2BF20`、`12345.67` 这类值都会被当成有效毫秒 timeout。对于一个 `*_MS` env var 来说这比较意外，也和附近配置项现在采用的严格 env 解析不一致。

把 timeout env 解析收紧可以避免静默改变用户意图，同时保留当前优先级顺序：model provider 配置优先，其次是 env，然后是 settings/defaults。

## Reviewer Test Plan

### How to verify

Reviewer 可以确认 `QWEN_CODE_API_TIMEOUT_MS` 仍然接受 `300000` 这样的十进制正整数，也仍然会 trim 前后空白；同时会忽略 `1.5e5`、`0x2BF20`、`12345.67` 和不安全整数。

本地已运行命令：

```sh
(cd packages/core && npx vitest run src/models/modelConfigResolver.test.ts)
npx prettier --check packages/core/src/models/modelConfigResolver.ts packages/core/src/models/modelConfigResolver.test.ts
npx eslint packages/core/src/models/modelConfigResolver.ts packages/core/src/models/modelConfigResolver.test.ts
npm run build --workspace @qwen-code/qwen-code-core
npm run typecheck --workspace @qwen-code/qwen-code-core
git diff --check
```

### Evidence (Before & After)

Before：`QWEN_CODE_API_TIMEOUT_MS=1.5e5`、`QWEN_CODE_API_TIMEOUT_MS=0x2BF20` 和 `QWEN_CODE_API_TIMEOUT_MS=12345.67` 会被接受/转换成 env timeout。

After：这些格式不合法的值会被忽略，并保留低优先级的已配置 timeout。这个行为已由更新后的 `modelConfigResolver` 单元测试覆盖。

这里没有附 UI/TUI 证据，因为这是配置解析变更，已由单元测试覆盖。

### Tested on

|     OS     |   Status    |
| :--------: | :---------: |
|  🍏 macOS  |  ✅ tested  |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 macOS Node/npm workspace。运行 focused validation commands 前，`npm install` 已成功完成。

## Risk & Scope

- Main risk or tradeoff：如果用户有意使用科学计数法、十六进制、小数或不安全整数作为 timeout env 值，需要改成十进制正整数毫秒。
- Not validated / out of scope：没有跑端到端模型请求；行为已在共享 model config resolver 层通过测试覆盖。
- Breaking changes / migration notes：格式不合法的 `QWEN_CODE_API_TIMEOUT_MS` 现在会被忽略，而不是被转换。

## Linked Issues

Fixes #5596

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
