### PR TITLE
fix(voice): surface native recorder fallback so missing prebuilds aren't silent

### DIFF
--- a/packages/cli/src/ui/voice/voice-recorder.test.ts
+++ b/packages/cli/src/ui/voice/voice-recorder.test.ts
@@ -71,6 +71,32 @@ describe('createVoiceRecorder', () => {
     expect(soxRecorder.stop).toHaveBeenCalledTimes(1);
   });
 
+  it('logs the native backend failure when degrading to the fallback (#5583)', async () => {
+    const nativeRecorder = recorder({
+      start: vi
+        .fn()
+        .mockRejectedValue(
+          new Error('Native audio capture addon could not be loaded.'),
+        ),
+    });
+    const soxRecorder = recorder();
+
+    const voiceRecorder = createVoiceRecorder({
+      createNativeRecorder: vi.fn(() => nativeRecorder),
+      createSoxRecorder: vi.fn(() => soxRecorder),
+      platform: 'darwin',
+    });
+
+    await voiceRecorder.start();
+
+    expect(debugLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Native audio capture addon could not be loaded.',
+      ),
+    );
+    expect(soxRecorder.start).toHaveBeenCalledTimes(1);
+  });
+
   it('prefers sox before arecord on Linux so tap mode can auto-stop on silence', async () => {
     const nativeRecorder = recorder({
       start: vi.fn().mockRejectedValue(new Error('native unavailable')),

--- a/packages/cli/src/ui/voice/voice-recorder.ts
+++ b/packages/cli/src/ui/voice/voice-recorder.ts
@@ -49,7 +49,14 @@ class FallbackVoiceRecorder implements VoiceRecorder {
         this.activeRecorder = recorder;
         return;
       } catch (error) {
-        errors.push(error instanceof Error ? error.message : String(error));
+        const message = error instanceof Error ? error.message : String(error);
+        errors.push(message);
+        // Surface each backend failure so a missing native prebuild — which
+        // otherwise silently degrades to the SoX/arecord fallback — is
+        // diagnosable in debug logs instead of invisible. See #5583.
+        debugLogger.warn(
+          `[voice] recorder backend unavailable, trying fallback: ${message}`,
+        );
       }
     }
 


### PR DESCRIPTION
Follow-up to #5502 (voice dictation) — P0 observability (tracked in #5590).

`FallbackVoiceRecorder.start()` silently fell through to the SoX/arecord backend when the native addon failed to load, so a missing/failed prebuild was invisible. This logs each backend failure at the fallback point (debug level, matching the existing `warmup()` log) so the degrade is diagnosable.

- `packages/cli/src/ui/voice/voice-recorder.ts`: log per-backend failures in `start()`.
- Regression test added; `voice-recorder.test.ts` passes 8/8.

Refs #5502, #5590.
