### PR TITLE
ci(audio-capture): add win32-arm64, musl, and older-glibc prebuild targets

### DIFF
--- a/.github/workflows/audio-capture-prebuilds.yml
+++ b/.github/workflows/audio-capture-prebuilds.yml
@@ -40,15 +40,16 @@ jobs:
           - os: 'macos-13'
             runner: 'macos-13'
             arch: 'x64'
-          - os: 'ubuntu-latest'
-            runner: 'ubuntu-latest'
-            arch: 'x64'
-          - os: 'ubuntu-24.04-arm'
-            runner: 'ubuntu-24.04-arm'
-            arch: 'arm64'
           - os: 'windows-latest'
             runner: 'windows-2022'
             arch: 'x64'
+          # CLI ships win32-arm64 for its other native deps (node-pty, clipboard);
+          # build a matching audio-capture prebuild so ARM Windows isn't forced
+          # onto the SoX fallback. NOTE: validate via workflow_dispatch — the
+          # windows-11-arm runner + native toolchain are unverified locally.
+          - os: 'windows-11-arm'
+            runner: 'windows-11-arm'
+            arch: 'arm64'
     steps:
       - uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
       - uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # v6.4.0
@@ -67,9 +68,60 @@ jobs:
           path: 'packages/audio-capture/prebuilds/'
           if-no-files-found: 'error'
 
+  # Linux prebuilds build in containers: an older-glibc base (Debian 11, glibc
+  # 2.31) so the .node loads on Debian 11 / RHEL 8, plus a musl/Alpine build so
+  # Alpine users get a native prebuild instead of the SoX fallback.
+  # DRAFT: container builds are unverified locally — validate via
+  # workflow_dispatch before relying on these.
+  build-linux:
+    name: 'prebuild ${{ matrix.os }} (${{ matrix.arch }})'
+    runs-on: '${{ matrix.runner }}'
+    container: '${{ matrix.container }}'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: 'linux-glibc'
+            runner: 'ubuntu-latest'
+            arch: 'x64'
+            container: 'node:22-bullseye'
+          - os: 'linux-glibc'
+            runner: 'ubuntu-24.04-arm'
+            arch: 'arm64'
+            container: 'node:22-bullseye'
+          - os: 'linux-musl'
+            runner: 'ubuntu-latest'
+            arch: 'x64'
+            container: 'node:22-alpine'
+    steps:
+      # Install git + C toolchain BEFORE checkout: the Alpine image ships
+      # neither and actions/checkout needs git. working-directory is overridden
+      # to '/' since the repo isn't checked out yet. The container's own
+      # (musl/glibc) Node is used — setup-node would pull glibc Node that can't
+      # run on musl.
+      - name: 'Install Alpine build toolchain'
+        if: "${{ matrix.container == 'node:22-alpine' }}"
+        working-directory: '/'
+        run: 'apk add --no-cache build-base python3 git'
+      - name: 'Install Debian build toolchain'
+        if: "${{ matrix.container == 'node:22-bullseye' }}"
+        working-directory: '/'
+        run: 'apt-get update && apt-get install -y --no-install-recommends python3 make g++ git'
+      - uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
+      - name: 'Install build deps'
+        run: 'npm install --no-workspaces --ignore-scripts --no-audit --no-fund'
+      - name: 'Build prebuild'
+        run: 'npm run prebuildify'
+      - name: 'Upload prebuild'
+        uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' # v7.0.1
+        with:
+          name: 'prebuilds-${{ matrix.os }}-${{ matrix.arch }}'
+          path: 'packages/audio-capture/prebuilds/'
+          if-no-files-found: 'error'
+
   collect:
     name: 'collect prebuilds'
-    needs: 'build'
+    needs: ['build', 'build-linux']
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Merge per-platform prebuilds'

--- a/.github/workflows/audio-capture-prebuilds.yml
+++ b/.github/workflows/audio-capture-prebuilds.yml
@@ -111,7 +111,7 @@ jobs:
       - name: 'Install build deps'
         run: 'npm install --no-workspaces --ignore-scripts --no-audit --no-fund'
       - name: 'Build prebuild'
-        run: 'npm run prebuildify'
+        run: 'npx prebuildify --napi --strip --tag-libc'
       - name: 'Upload prebuild'
         uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' # v7.0.1
         with:
@@ -132,6 +132,19 @@ jobs:
           path: 'packages/audio-capture/prebuilds'
       - name: 'List collected prebuilds'
         run: 'find prebuilds -type f'
+      - name: 'Verify all prebuilds are present'
+        run: |
+          for file in \
+            prebuilds/darwin-arm64/node.napi.node \
+            prebuilds/darwin-x64/node.napi.node \
+            prebuilds/win32-x64/node.napi.node \
+            prebuilds/win32-arm64/node.napi.node \
+            prebuilds/linux-x64/node.napi.glibc.node \
+            prebuilds/linux-x64/node.napi.musl.node \
+            prebuilds/linux-arm64/node.napi.glibc.node
+          do
+            test -f "$file" || (echo "::error::Missing: $file" && exit 1)
+          done
       - name: 'Upload combined prebuilds'
         uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' # v7.0.1
         with:

--- a/.github/workflows/audio-capture-prebuilds.yml
+++ b/.github/workflows/audio-capture-prebuilds.yml
@@ -33,6 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Keep in sync with build-linux.matrix and the collect verification list.
         include:
           - os: 'macos-14'
             runner: 'macos-14'
@@ -80,19 +81,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Keep in sync with build.matrix and the collect verification list.
         include:
           - os: 'linux-glibc'
             runner: 'ubuntu-latest'
             arch: 'x64'
-            container: 'node:22-bullseye'
+            container: 'node:22-bullseye@sha256:55e1d290257108ca0bbd3b206d5ac2e8754b70e4ecbad2d9306fde8821cc30a3'
           - os: 'linux-glibc'
             runner: 'ubuntu-24.04-arm'
             arch: 'arm64'
-            container: 'node:22-bullseye'
+            container: 'node:22-bullseye@sha256:55e1d290257108ca0bbd3b206d5ac2e8754b70e4ecbad2d9306fde8821cc30a3'
           - os: 'linux-musl'
             runner: 'ubuntu-latest'
             arch: 'x64'
-            container: 'node:22-alpine'
+            container: 'node:22-alpine@sha256:ab07539e0988b63558ff621f5fbe1077054c39d9809112974fb79993949d41cd'
     steps:
       # Install git + C toolchain BEFORE checkout: the Alpine image ships
       # neither and actions/checkout needs git. working-directory is overridden
@@ -100,11 +102,11 @@ jobs:
       # (musl/glibc) Node is used — setup-node would pull glibc Node that can't
       # run on musl.
       - name: 'Install Alpine build toolchain'
-        if: "${{ matrix.container == 'node:22-alpine' }}"
+        if: "${{ startsWith(matrix.container, 'node:22-alpine') }}"
         working-directory: '/'
         run: 'apk add --no-cache build-base python3 git'
       - name: 'Install Debian build toolchain'
-        if: "${{ matrix.container == 'node:22-bullseye' }}"
+        if: "${{ startsWith(matrix.container, 'node:22-bullseye') }}"
         working-directory: '/'
         run: 'apt-get update && apt-get install -y --no-install-recommends python3 make g++ git'
       - uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
@@ -131,17 +133,18 @@ jobs:
           merge-multiple: true
           path: 'packages/audio-capture/prebuilds'
       - name: 'List collected prebuilds'
-        run: 'find prebuilds -type f'
+        run: 'find packages/audio-capture/prebuilds -type f'
       - name: 'Verify all prebuilds are present'
         run: |
+          # Keep in sync with the build and build-linux matrices above.
           for file in \
-            prebuilds/darwin-arm64/@qwen-code+audio-capture.node \
-            prebuilds/darwin-x64/@qwen-code+audio-capture.node \
-            prebuilds/win32-x64/@qwen-code+audio-capture.node \
-            prebuilds/win32-arm64/@qwen-code+audio-capture.node \
-            prebuilds/linux-x64/@qwen-code+audio-capture.glibc.node \
-            prebuilds/linux-x64/@qwen-code+audio-capture.musl.node \
-            prebuilds/linux-arm64/@qwen-code+audio-capture.glibc.node
+            packages/audio-capture/prebuilds/darwin-arm64/node.napi.node \
+            packages/audio-capture/prebuilds/darwin-x64/node.napi.node \
+            packages/audio-capture/prebuilds/win32-x64/node.napi.node \
+            packages/audio-capture/prebuilds/win32-arm64/node.napi.node \
+            packages/audio-capture/prebuilds/linux-x64/node.napi.glibc.node \
+            packages/audio-capture/prebuilds/linux-x64/node.napi.musl.node \
+            packages/audio-capture/prebuilds/linux-arm64/node.napi.glibc.node
           do
             test -f "$file" || (echo "::error::Missing: $file" && exit 1)
           done

--- a/.github/workflows/audio-capture-prebuilds.yml
+++ b/.github/workflows/audio-capture-prebuilds.yml
@@ -133,18 +133,18 @@ jobs:
           merge-multiple: true
           path: 'packages/audio-capture/prebuilds'
       - name: 'List collected prebuilds'
-        run: 'find packages/audio-capture/prebuilds -type f'
+        run: 'find prebuilds -type f'
       - name: 'Verify all prebuilds are present'
         run: |
           # Keep in sync with the build and build-linux matrices above.
           for file in \
-            packages/audio-capture/prebuilds/darwin-arm64/node.napi.node \
-            packages/audio-capture/prebuilds/darwin-x64/node.napi.node \
-            packages/audio-capture/prebuilds/win32-x64/node.napi.node \
-            packages/audio-capture/prebuilds/win32-arm64/node.napi.node \
-            packages/audio-capture/prebuilds/linux-x64/node.napi.glibc.node \
-            packages/audio-capture/prebuilds/linux-x64/node.napi.musl.node \
-            packages/audio-capture/prebuilds/linux-arm64/node.napi.glibc.node
+            prebuilds/darwin-arm64/node.napi.node \
+            prebuilds/darwin-x64/node.napi.node \
+            prebuilds/win32-x64/node.napi.node \
+            prebuilds/win32-arm64/node.napi.node \
+            prebuilds/linux-x64/node.napi.glibc.node \
+            prebuilds/linux-x64/node.napi.musl.node \
+            prebuilds/linux-arm64/node.napi.glibc.node
           do
             test -f "$file" || (echo "::error::Missing: $file" && exit 1)
           done

--- a/.github/workflows/audio-capture-prebuilds.yml
+++ b/.github/workflows/audio-capture-prebuilds.yml
@@ -72,8 +72,6 @@ jobs:
   # Linux prebuilds build in containers: an older-glibc base (Debian 11, glibc
   # 2.31) so the .node loads on Debian 11 / RHEL 8, plus a musl/Alpine build so
   # Alpine users get a native prebuild instead of the SoX fallback.
-  # DRAFT: container builds are unverified locally — validate via
-  # workflow_dispatch before relying on these.
   build-linux:
     name: 'prebuild ${{ matrix.os }} (${{ matrix.arch }})'
     runs-on: '${{ matrix.runner }}'
@@ -86,14 +84,17 @@ jobs:
           - os: 'linux-glibc'
             runner: 'ubuntu-latest'
             arch: 'x64'
+            libc: 'glibc'
             container: 'node:22-bullseye@sha256:55e1d290257108ca0bbd3b206d5ac2e8754b70e4ecbad2d9306fde8821cc30a3'
           - os: 'linux-glibc'
             runner: 'ubuntu-24.04-arm'
             arch: 'arm64'
+            libc: 'glibc'
             container: 'node:22-bullseye@sha256:55e1d290257108ca0bbd3b206d5ac2e8754b70e4ecbad2d9306fde8821cc30a3'
           - os: 'linux-musl'
             runner: 'ubuntu-latest'
             arch: 'x64'
+            libc: 'musl'
             container: 'node:22-alpine@sha256:ab07539e0988b63558ff621f5fbe1077054c39d9809112974fb79993949d41cd'
     steps:
       # Install git + C toolchain BEFORE checkout: the Alpine image ships
@@ -102,18 +103,18 @@ jobs:
       # (musl/glibc) Node is used — setup-node would pull glibc Node that can't
       # run on musl.
       - name: 'Install Alpine build toolchain'
-        if: "${{ startsWith(matrix.container, 'node:22-alpine') }}"
+        if: "${{ matrix.libc == 'musl' }}"
         working-directory: '/'
         run: 'apk add --no-cache build-base python3 git'
       - name: 'Install Debian build toolchain'
-        if: "${{ startsWith(matrix.container, 'node:22-bullseye') }}"
+        if: "${{ matrix.libc == 'glibc' }}"
         working-directory: '/'
         run: 'apt-get update && apt-get install -y --no-install-recommends python3 make g++ git'
       - uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
       - name: 'Install build deps'
         run: 'npm install --no-workspaces --ignore-scripts --no-audit --no-fund'
       - name: 'Build prebuild'
-        run: 'npm run prebuildify'
+        run: 'npx prebuildify --napi --strip --tag-libc'
       - name: 'Upload prebuild'
         uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' # v7.0.1
         with:
@@ -138,13 +139,13 @@ jobs:
         run: |
           # Keep in sync with the build and build-linux matrices above.
           for file in \
-            prebuilds/darwin-arm64/node.napi.node \
-            prebuilds/darwin-x64/node.napi.node \
-            prebuilds/win32-x64/node.napi.node \
-            prebuilds/win32-arm64/node.napi.node \
-            prebuilds/linux-x64/node.napi.glibc.node \
-            prebuilds/linux-x64/node.napi.musl.node \
-            prebuilds/linux-arm64/node.napi.glibc.node
+            prebuilds/darwin-arm64/@qwen-code+audio-capture.node \
+            prebuilds/darwin-x64/@qwen-code+audio-capture.node \
+            prebuilds/win32-x64/@qwen-code+audio-capture.node \
+            prebuilds/win32-arm64/@qwen-code+audio-capture.node \
+            prebuilds/linux-x64/@qwen-code+audio-capture.glibc.node \
+            prebuilds/linux-x64/@qwen-code+audio-capture.musl.node \
+            prebuilds/linux-arm64/@qwen-code+audio-capture.glibc.node
           do
             test -f "$file" || (echo "::error::Missing: $file" && exit 1)
           done

--- a/.github/workflows/audio-capture-prebuilds.yml
+++ b/.github/workflows/audio-capture-prebuilds.yml
@@ -111,7 +111,7 @@ jobs:
       - name: 'Install build deps'
         run: 'npm install --no-workspaces --ignore-scripts --no-audit --no-fund'
       - name: 'Build prebuild'
-        run: 'npx prebuildify --napi --strip --tag-libc'
+        run: 'npm run prebuildify'
       - name: 'Upload prebuild'
         uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' # v7.0.1
         with:

--- a/.github/workflows/audio-capture-prebuilds.yml
+++ b/.github/workflows/audio-capture-prebuilds.yml
@@ -135,13 +135,13 @@ jobs:
       - name: 'Verify all prebuilds are present'
         run: |
           for file in \
-            prebuilds/darwin-arm64/node.napi.node \
-            prebuilds/darwin-x64/node.napi.node \
-            prebuilds/win32-x64/node.napi.node \
-            prebuilds/win32-arm64/node.napi.node \
-            prebuilds/linux-x64/node.napi.glibc.node \
-            prebuilds/linux-x64/node.napi.musl.node \
-            prebuilds/linux-arm64/node.napi.glibc.node
+            prebuilds/darwin-arm64/@qwen-code+audio-capture.node \
+            prebuilds/darwin-x64/@qwen-code+audio-capture.node \
+            prebuilds/win32-x64/@qwen-code+audio-capture.node \
+            prebuilds/win32-arm64/@qwen-code+audio-capture.node \
+            prebuilds/linux-x64/@qwen-code+audio-capture.glibc.node \
+            prebuilds/linux-x64/@qwen-code+audio-capture.musl.node \
+            prebuilds/linux-arm64/@qwen-code+audio-capture.glibc.node
           do
             test -f "$file" || (echo "::error::Missing: $file" && exit 1)
           done

--- a/packages/audio-capture/package.json
+++ b/packages/audio-capture/package.json
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "install": "node install.js",
-    "prebuildify": "prebuildify --napi --strip --tag-libc",
+    "prebuildify": "prebuildify --napi --strip",
     "build": "node-gyp rebuild && tsc --build",
     "build:ts": "tsc --build",
     "test": "vitest run",

--- a/packages/audio-capture/package.json
+++ b/packages/audio-capture/package.json
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "install": "node install.js",
-    "prebuildify": "prebuildify --napi --strip",
+    "prebuildify": "prebuildify --napi --strip --tag-libc",
     "build": "node-gyp rebuild && tsc --build",
     "build:ts": "tsc --build",
     "test": "vitest run",


### PR DESCRIPTION
## What this PR does

This PR extends the audio-capture native prebuild matrix so additional supported platforms can load a bundled native addon instead of falling back to SoX or arecord.

It adds win32-arm64, linux musl/Alpine, and linux glibc builds on an older Debian 11 / glibc 2.31 baseline. macOS and Windows host builds stay on the existing runner path, while Linux prebuilds use pinned Node container images so the glibc and musl targets are built in the right runtime environment.

It also verifies the collected prebuild artifact contains the expected files, keeps glibc/musl output names distinct, and preserves package filenames that `node-gyp-build` can select at runtime.

## Why it's needed

Voice dictation depends on the `@qwen-code/audio-capture` native addon. Without these prebuilds, Windows ARM64 and Alpine users, plus users on older glibc distributions such as Debian 11 or RHEL 8, are more likely to miss the native addon and fall back to external audio tools.

The CLI already ships other native dependencies for Windows ARM64, so audio capture should have the same target coverage. Building Linux glibc in an older container also avoids producing a binary that only works on newer GitHub-hosted runners.

## Reviewer Test Plan

### How to verify

Review the `audio-capture-prebuilds.yml` workflow and confirm the host build matrix covers darwin arm64/x64 and win32 x64/arm64, the Linux container matrix covers glibc x64/arm64 and musl x64, and the collect job verifies the exact package-name prebuild filenames under `prebuilds/<platform>-<arch>/`.

Trigger `audio-capture-prebuilds.yml` with `workflow_dispatch` and confirm each build job uploads a per-platform artifact, the collect job downloads them into `packages/audio-capture/prebuilds`, `find prebuilds -type f` lists the expected files from the package working directory, and the combined `audio-capture-prebuilds` artifact uploads successfully.

### Evidence (Before & After)

Before: the prebuild workflow covered macOS arm64/x64, Linux x64/arm64 on hosted runners, and Windows x64; Windows ARM64, Linux musl, and older-glibc container builds were not covered.

After: a fork `workflow_dispatch` run validated that the added `windows-11-arm`, `linux-musl`, and `linux-glibc` build jobs can compile and upload their per-platform artifacts. The pre-existing `macos-13` job did not get a GitHub-hosted runner in that run, so the collect job was not fully exercised there.

Follow-up review fixes were verified locally by inspecting `prebuildify@6.0.1` filename generation, running `git diff --check`, parsing the collect shell block with `bash -n`, and simulating the collect job's expected file checks with the corrected filenames.

### Tested on

|     OS     |    Status     |
| :--------: | :-----------: |
|  🍏 macOS  | ✅ tested via static/local workflow checks |
| 🪟 Windows | ✅ tested via fork workflow build job |
|  🐧 Linux  | ✅ tested via fork workflow build jobs and local collect-path simulation |

### Environment (optional)

Local workflow validation on macOS with Node.js available in the repo worktree. Fork workflow run: https://github.com/qqqys/qwen-code/actions/runs/27935860165

## Risk & Scope

- Main risk or tradeoff: this changes release artifact production for audio-capture prebuilds, so incorrect filenames or missing artifacts would block the collect job instead of silently publishing an incomplete bundle.
- Not validated / out of scope: the final post-review collect job should still be confirmed by a fresh `workflow_dispatch` run because the earlier fork run did not complete collect after one pre-existing macOS runner did not start.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #5502, #5590.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 扩展了 audio-capture 原生 prebuild 矩阵，让更多受支持平台可以加载随包发布的原生 addon，而不是回退到 SoX 或 arecord。

它新增了 win32-arm64、linux musl/Alpine，以及基于 Debian 11 / glibc 2.31 的 older-glibc 构建。macOS 和 Windows host build 继续走现有 runner 路径，Linux prebuild 使用固定 digest 的 Node 容器镜像，确保 glibc 和 musl 目标在正确运行环境中构建。

它还会校验汇总后的 prebuild artifact 是否包含预期文件，确保 glibc/musl 输出文件名不会互相覆盖，并保留 `node-gyp-build` 运行时可以选择的 package-name 文件名。

## Why it's needed

Voice dictation 依赖 `@qwen-code/audio-capture` 原生 addon。没有这些 prebuild 时，Windows ARM64、Alpine 用户，以及 Debian 11 或 RHEL 8 这类旧 glibc 发行版用户，更容易缺失原生 addon 并回退到外部音频工具。

CLI 已经为 Windows ARM64 发布其它 native dependency，所以 audio capture 也应该覆盖同样的目标。Linux glibc 在更旧容器中构建，也可以避免产物只适用于较新的 GitHub-hosted runner。

## Reviewer Test Plan

### How to verify

检查 `audio-capture-prebuilds.yml` workflow：host build matrix 覆盖 darwin arm64/x64 和 win32 x64/arm64，Linux container matrix 覆盖 glibc x64/arm64 和 musl x64，collect job 校验 `prebuilds/<platform>-<arch>/` 下精确的 package-name prebuild 文件名。

通过 `workflow_dispatch` 触发 `audio-capture-prebuilds.yml`，确认每个 build job 上传 per-platform artifact，collect job 将它们下载到 `packages/audio-capture/prebuilds`，`find prebuilds -type f` 从 package working directory 列出预期文件，并成功上传合并后的 `audio-capture-prebuilds` artifact。

### Evidence (Before & After)

Before：prebuild workflow 覆盖 macOS arm64/x64、hosted runner 上的 Linux x64/arm64，以及 Windows x64；没有覆盖 Windows ARM64、Linux musl 和 older-glibc 容器构建。

After：fork 上的 `workflow_dispatch` run 验证了新增的 `windows-11-arm`、`linux-musl` 和 `linux-glibc` build job 可以编译并上传各自的 per-platform artifact。该 run 中既有的 `macos-13` job 没有拿到 GitHub-hosted runner，所以 collect job 没有在那次 run 中完整执行。

后续 review 修复通过本地检查验证：检查 `prebuildify@6.0.1` 文件名生成逻辑，运行 `git diff --check`，用 `bash -n` 解析 collect shell block，并用修正后的文件名模拟 collect job 的文件校验。

### Tested on

|     OS     |    Status     |
| :--------: | :-----------: |
|  🍏 macOS  | ✅ tested via static/local workflow checks |
| 🪟 Windows | ✅ tested via fork workflow build job |
|  🐧 Linux  | ✅ tested via fork workflow build jobs and local collect-path simulation |

### Environment (optional)

本地 workflow 校验在 macOS repo worktree 中完成，环境中可用 Node.js。Fork workflow run: https://github.com/qqqys/qwen-code/actions/runs/27935860165

## Risk & Scope

- Main risk or tradeoff: 这个改动会影响 audio-capture prebuild 的 release artifact 生产；如果文件名不正确或 artifact 缺失，collect job 会失败，而不是静默发布不完整 bundle。
- Not validated / out of scope: 最终的 post-review collect job 仍建议通过一次新的 `workflow_dispatch` run 确认，因为早前 fork run 中一个既有 macOS runner 没有启动，导致 collect 没有完整执行。
- Breaking changes / migration notes: 无。

## Linked Issues

Refs #5502, #5590.

</details>
