### PR TITLE
test(integration): run no-AK smoke tests on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,6 +304,44 @@ jobs:
       - name: 'Perform CodeQL Analysis'
         uses: 'github/codeql-action/analyze@df559355d593797519d70b90fc8edd5db049e7a2' # ratchet:github/codeql-action/analyze@v3
 
+  # Fast PR-safe integration coverage. This job intentionally runs only the
+  # no-AK subset that uses local fakes or no model transport, so fork PRs get
+  # daemon/SSE smoke coverage without repository secrets.
+  integration_no_ak:
+    name: 'Integration Tests (No-AK Smoke)'
+    needs: 'classify_pr'
+    if: "${{ !cancelled() && github.event_name == 'pull_request' && needs.classify_pr.outputs.skip_ci != 'true' }}"
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: 'read'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
+
+      - name: 'Setup Node.js'
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: 'package-lock.json'
+
+      - name: 'Configure npm for rate limiting'
+        run: |-
+          npm config set fetch-retry-mintimeout 20000
+          npm config set fetch-retry-maxtimeout 120000
+          npm config set fetch-retries 5
+          npm config set fetch-timeout 300000
+
+      - name: 'Install Dependencies'
+        env:
+          NPM_CONFIG_PREFER_OFFLINE: 'true'
+        run: |-
+          npm ci --no-audit --progress=false
+
+      - name: 'Run no-AK integration smoke tests'
+        run: |-
+          npm run test:integration:no-ak:sandbox:none
+
   # Integration tests run only in the merge queue, not on every PR push.
   # They are the suite that previously ran *only* in the nightly Release
   # pipeline (`release.yml`), so regressions stayed hidden until release

--- a/docs/developers/qwen-serve-protocol.md
+++ b/docs/developers/qwen-serve-protocol.md
@@ -1663,24 +1663,23 @@ The connection then closes.
 
 ## Environment variables
 
-| Var                 | Purpose                                                                                                                                                             |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `QWEN_SERVER_TOKEN` | Bearer token. Stripped of leading/trailing whitespace at boot.                                                                                                      |
-| `SKIP_LLM_TESTS`    | Set to `1` to **skip** LLM-required integration tests in `integration-tests/cli/qwen-serve-streaming.test.ts` (default-on for CI envs that lack provider API keys). |
+| Var                 | Purpose                                                        |
+| ------------------- | -------------------------------------------------------------- |
+| `QWEN_SERVER_TOKEN` | Bearer token. Stripped of leading/trailing whitespace at boot. |
 
 ## Source layout
 
 | Path                                                 | Purpose                                                                                                    |
 | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
 | `packages/cli/src/commands/serve.ts`                 | yargs command + flag schema                                                                                |
-| `packages/cli/src/serve/run-qwen-serve.ts`             | listener lifecycle + signal handling                                                                       |
+| `packages/cli/src/serve/run-qwen-serve.ts`           | listener lifecycle + signal handling                                                                       |
 | `packages/cli/src/serve/server.ts`                   | Express routes + middleware                                                                                |
 | `packages/cli/src/serve/auth.ts`                     | bearer + Host allowlist + CORS deny                                                                        |
 | `packages/cli/src/serve/httpAcpBridge.ts`            | spawn-or-attach + per-session FIFO + permission registry                                                   |
 | `packages/cli/src/serve/status.ts`                   | read-only daemon status wire types + `ServeErrorKind` + `BridgeTimeoutError` + `mapDomainErrorToErrorKind` |
-| `packages/cli/src/serve/env-snapshot.ts`              | pure helper that builds `/workspace/env` payloads from `process.*` state, including credential redaction   |
-| `packages/acp-bridge/src/eventBus.ts`                 | bounded async queue + replay ring                                                                          |
+| `packages/cli/src/serve/env-snapshot.ts`             | pure helper that builds `/workspace/env` payloads from `process.*` state, including credential redaction   |
+| `packages/acp-bridge/src/eventBus.ts`                | bounded async queue + replay ring                                                                          |
 | `packages/sdk-typescript/src/daemon/DaemonClient.ts` | TS client                                                                                                  |
 | `packages/sdk-typescript/src/daemon/sse.ts`          | EventSource frame parser                                                                                   |
 | `integration-tests/cli/qwen-serve-routes.test.ts`    | 18 cases, no LLM                                                                                           |
-| `integration-tests/cli/qwen-serve-streaming.test.ts` | 3 cases, real `qwen --acp` child (skipped when `SKIP_LLM_TESTS=1`)                                         |
+| `integration-tests/cli/qwen-serve-streaming.test.ts` | 3 cases, real `qwen --acp` child backed by the local fake OpenAI server (POSIX only; skipped on Windows)   |

--- a/integration-tests/cli/qwen-serve-routes.test.ts
+++ b/integration-tests/cli/qwen-serve-routes.test.ts
@@ -9,18 +9,16 @@
  *
  * These exercise the daemon end-to-end without needing a working model
  * credential: they spawn a real `node packages/cli/dist/index.js serve`
- * (which itself spawns real `qwen --acp` children), then probe the HTTP
- * surface. The agent's `initialize` + `newSession` handshake works
- * without auth, so session creation, listing, cancellation, validation,
- * SSE wiring, the CORS guard, the bearer-auth guard and shutdown all
- * run here.
+ * with dummy OpenAI auth env, then probe the HTTP surface without issuing
+ * model calls. Session creation, listing, cancellation, validation, SSE
+ * wiring, the CORS guard, the bearer-auth guard and shutdown all run here.
  *
- * Tests that require an actual model call (streaming prompts, real
- * permission flows, Last-Event-ID resume across a real reconnect) live
- * in `qwen-serve-streaming.test.ts` and skip when no auth is set.
+ * Tests that require prompt streaming or real permission flows live in
+ * `qwen-serve-streaming.test.ts`, backed by the local fake OpenAI server.
  */
 import { spawn, type ChildProcess } from 'node:child_process';
-import { realpathSync } from 'node:fs';
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -45,11 +43,13 @@ const TOKEN = 'integration-test-token';
 const REPO_ROOT = path.resolve(__dirname, '../..');
 
 let daemon: ChildProcess;
+let homeDir = '';
 let port = 0;
 let base = '';
 let client: DaemonClient;
 
 beforeAll(async () => {
+  homeDir = mkdtempSync(path.join(tmpdir(), 'qwen-serve-routes-home-'));
   daemon = spawn(
     process.execPath,
     [
@@ -78,17 +78,25 @@ beforeAll(async () => {
       // capabilities baseline below assumes their default state; a
       // dev machine exporting any of these would otherwise fail the
       // exact-equality assertion.
-      env: Object.fromEntries(
-        Object.entries(process.env).filter(
-          ([k]) =>
-            ![
-              'QWEN_SERVE_PROMPT_DEADLINE_MS',
-              'QWEN_SERVE_WRITER_IDLE_TIMEOUT_MS',
-              'QWEN_SERVE_RATE_LIMIT',
-              'QWEN_SERVE_NO_MCP_POOL',
-            ].includes(k),
+      env: {
+        ...Object.fromEntries(
+          Object.entries(process.env).filter(
+            ([k]) =>
+              ![
+                'QWEN_SERVE_PROMPT_DEADLINE_MS',
+                'QWEN_SERVE_WRITER_IDLE_TIMEOUT_MS',
+                'QWEN_SERVE_RATE_LIMIT',
+                'QWEN_SERVE_NO_MCP_POOL',
+              ].includes(k),
+          ),
         ),
-      ),
+        HOME: homeDir,
+        QWEN_HOME: path.join(homeDir, '.qwen'),
+        OPENAI_API_KEY: 'fake-key',
+        OPENAI_BASE_URL: 'http://127.0.0.1:9/v1',
+        OPENAI_MODEL: 'fake-model',
+        QWEN_MODEL: 'fake-model',
+      },
     },
   );
   // Read stdout until we see the listening line + parse the port.
@@ -122,9 +130,15 @@ beforeAll(async () => {
 }, 30_000);
 
 afterAll(async () => {
-  if (!daemon || daemon.exitCode !== null) return;
-  daemon.kill('SIGTERM');
-  await new Promise((r) => daemon.once('exit', r));
+  try {
+    if (!daemon || daemon.exitCode !== null) return;
+    daemon.kill('SIGTERM');
+    await new Promise((r) => daemon.once('exit', r));
+  } finally {
+    if (homeDir) {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  }
 }, 15_000);
 
 describe('qwen serve — bearer auth (timing-safe compare)', () => {

--- a/integration-tests/fake-openai-server.test.ts
+++ b/integration-tests/fake-openai-server.test.ts
@@ -11,6 +11,24 @@ import {
   type FakeOpenAIServer,
 } from './fake-openai-server.js';
 
+type StreamToolCallDelta = {
+  index: number;
+  id?: string;
+  type?: string;
+  function?: {
+    name?: string;
+    arguments?: string;
+  };
+};
+
+type StreamChunk = {
+  choices: Array<{
+    delta: {
+      tool_calls?: StreamToolCallDelta[];
+    };
+  }>;
+};
+
 let server: FakeOpenAIServer | undefined;
 
 afterEach(async () => {
@@ -69,6 +87,85 @@ describe('fake OpenAI server', () => {
     expect(streamText).toContain('"write_file"');
     expect(streamText).toContain('data: [DONE]');
     expect(server.requests).toHaveLength(2);
+  });
+
+  it('serves non-streaming tool calls with null content', async () => {
+    server = await startFakeOpenAIServer(() => ({
+      toolCalls: [
+        fakeToolCall('write_file', {
+          file_path: '/tmp/fake.txt',
+          content: 'fake',
+        }),
+      ],
+    }));
+
+    const response = await fetch(`${server.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        model: 'fake-model',
+        messages: [{ role: 'user', content: 'use a tool' }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      choices: [
+        {
+          message: {
+            content: null,
+            tool_calls: [{ function: { name: 'write_file' } }],
+          },
+          finish_reason: 'tool_calls',
+        },
+      ],
+    });
+  });
+
+  it('streams tool call arguments as deltas', async () => {
+    server = await startFakeOpenAIServer(() => ({
+      toolCalls: [
+        fakeToolCall(
+          'write_file',
+          {
+            file_path: '/tmp/fake.txt',
+            content: 'fake',
+          },
+          'call_fixed',
+        ),
+      ],
+    }));
+
+    const response = await fetch(`${server.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        model: 'fake-model',
+        stream: true,
+        messages: [{ role: 'user', content: 'write' }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const toolCallDeltas = (await response.text())
+      .split('\n\n')
+      .filter((line) => line.startsWith('data: ') && line !== 'data: [DONE]')
+      .map((line) => JSON.parse(line.slice('data: '.length)) as StreamChunk)
+      .flatMap((chunk) => chunk.choices[0]?.delta.tool_calls ?? []);
+    expect(toolCallDeltas).toEqual([
+      {
+        index: 0,
+        id: 'call_fixed',
+        type: 'function',
+        function: { name: 'write_file', arguments: '' },
+      },
+      {
+        index: 0,
+        function: {
+          arguments: '{"file_path":"/tmp/fake.txt","content":"fake"}',
+        },
+      },
+    ]);
   });
 
   it('returns 404 for wrong methods or paths', async () => {

--- a/integration-tests/fake-openai-server.ts
+++ b/integration-tests/fake-openai-server.ts
@@ -183,7 +183,7 @@ function writeNonStreamed(
           index: 0,
           message: {
             role: 'assistant',
-            content: message.content ?? '',
+            content: message.content ?? null,
             ...(message.toolCalls ? { tool_calls: message.toolCalls } : {}),
           },
           finish_reason: finishReason(message),
@@ -235,11 +235,28 @@ function writeStreamed(
             index,
             id: toolCall.id,
             type: toolCall.type,
-            function: toolCall.function,
+            function: {
+              name: toolCall.function.name,
+              arguments: '',
+            },
           },
         ],
       }),
     );
+    if (toolCall.function.arguments) {
+      send(
+        chunk({
+          tool_calls: [
+            {
+              index,
+              function: {
+                arguments: toolCall.function.arguments,
+              },
+            },
+          ],
+        }),
+      );
+    }
   }
   send(chunk({}, finishReason(message), message.usage ?? DEFAULT_USAGE));
   res.write('data: [DONE]\n\n');

--- a/integration-tests/terminal-capture/subagent-flicker-regression.ts
+++ b/integration-tests/terminal-capture/subagent-flicker-regression.ts
@@ -68,16 +68,16 @@
  *   QWEN_TUI_E2E_SUBAGENT_TOOL_CALLS=5
  */
 
-import {
-  createServer,
-  type IncomingMessage,
-  type ServerResponse,
-} from 'node:http';
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { TerminalCapture } from './terminal-capture.js';
+import {
+  fakeToolCall,
+  startFakeOpenAIServer,
+  type FakeOpenAIResponse,
+} from '../fake-openai-server.js';
 
 const TERMINAL_COLS = 60;
 const TERMINAL_ROWS = 18;
@@ -94,12 +94,6 @@ type Counts = {
   clearScreenCodeCount: number;
   eraseLineCount: number;
   cursorUpCount: number;
-};
-
-type FakeServer = {
-  baseUrl: string;
-  getRequestCount: () => number;
-  close: () => Promise<void>;
 };
 
 type Summary = Counts & {
@@ -159,223 +153,88 @@ function captureCounts(raw: string): Counts {
   };
 }
 
-function chatCompletionId(suffix: string): string {
-  return `chatcmpl-qwen-tui-subagent-${suffix}-${Date.now()}`;
-}
-
-function sendJson(res: ServerResponse, body: unknown): void {
-  res.writeHead(200, { 'content-type': 'application/json' });
-  res.end(JSON.stringify(body));
-}
-
-function sendStream(res: ServerResponse, chunks: unknown[]): void {
-  res.writeHead(200, {
-    'content-type': 'text/event-stream; charset=utf-8',
-    'cache-control': 'no-cache, no-transform',
-    connection: 'keep-alive',
-  });
-  for (const chunk of chunks) {
-    res.write(`data: ${JSON.stringify(chunk)}\n\n`);
-  }
-  res.write('data: [DONE]\n\n');
-  res.end();
-}
-
-function streamWrap(
-  id: string,
-  delta: Record<string, unknown>,
-  finishReason: string | null,
-  usage?: Record<string, unknown>,
-) {
+function buildMainAgentToolCall(packageJsonPath: string): FakeOpenAIResponse {
   return {
-    id,
-    object: 'chat.completion.chunk',
-    created: Math.floor(Date.now() / 1000),
-    model: 'dummy',
-    choices: [{ index: 0, delta, finish_reason: finishReason }],
-    ...(usage ? { usage } : {}),
-  };
-}
-
-type ChatCompletionResponse = {
-  id: string;
-  choices: Array<{
-    message: {
-      role: string;
-      content: string | null;
-      tool_calls?: Array<{
-        id: string;
-        type: string;
-        function: { name: string; arguments: string };
-      }>;
-    };
-    finish_reason: string;
-  }>;
-  usage?: Record<string, unknown>;
-};
-
-function responseToStreamChunks(response: ChatCompletionResponse): unknown[] {
-  const id = response.id;
-  const choice = response.choices[0];
-  const message = choice.message;
-  const chunks: unknown[] = [];
-
-  chunks.push(streamWrap(id, { role: 'assistant' }, null));
-
-  if (message.content !== null && message.content !== undefined) {
-    chunks.push(streamWrap(id, { content: message.content }, null));
-  }
-
-  if (message.tool_calls) {
-    for (let i = 0; i < message.tool_calls.length; i += 1) {
-      const tc = message.tool_calls[i];
-      chunks.push(
-        streamWrap(
-          id,
-          {
-            tool_calls: [
-              {
-                index: i,
-                id: tc.id,
-                type: tc.type,
-                function: {
-                  name: tc.function.name,
-                  arguments: tc.function.arguments,
-                },
-              },
-            ],
-          },
-          null,
-        ),
-      );
-    }
-  }
-
-  chunks.push(streamWrap(id, {}, choice.finish_reason, response.usage));
-  return chunks;
-}
-
-function sendResponse(
-  res: ServerResponse,
-  body: ChatCompletionResponse,
-  isStream: boolean,
-): void {
-  if (isStream) {
-    sendStream(res, responseToStreamChunks(body));
-  } else {
-    sendJson(res, body);
-  }
-}
-
-function buildMainAgentToolCall(packageJsonPath: string) {
-  return {
-    id: 'chatcmpl-qwen-tui-subagent-dispatch',
-    object: 'chat.completion',
-    created: Math.floor(Date.now() / 1000),
-    model: 'dummy',
-    choices: [
-      {
-        index: 0,
-        message: {
-          role: 'assistant',
-          content: null,
-          tool_calls: [
-            {
-              id: 'call_dispatch_main',
-              type: 'function',
-              function: {
-                name: 'agent',
-                arguments: JSON.stringify({
-                  description: SUBAGENT_DESCRIPTION,
-                  prompt: `${SUBAGENT_PROMPT_MARKER}: read ${packageJsonPath} a few times to drive the SubAgent display, then reply with "${SUBAGENT_DONE_MARKER}"`,
-                  subagent_type: 'general-purpose',
-                }),
-              },
-            },
-          ],
+    toolCalls: [
+      fakeToolCall(
+        'agent',
+        {
+          description: SUBAGENT_DESCRIPTION,
+          prompt: `${SUBAGENT_PROMPT_MARKER}: read ${packageJsonPath} a few times to drive the SubAgent display, then reply with "${SUBAGENT_DONE_MARKER}"`,
+          subagent_type: 'general-purpose',
         },
-        finish_reason: 'tool_calls',
-      },
+        'call_dispatch_main',
+      ),
     ],
     usage: { prompt_tokens: 32, completion_tokens: 16, total_tokens: 48 },
   };
 }
 
-function buildSubagentSingleToolCall(packageJsonPath: string, index: number) {
+function buildSubagentSingleToolCall(
+  packageJsonPath: string,
+  index: number,
+): FakeOpenAIResponse {
   return {
-    id: chatCompletionId(`subagent-tool-${index}`),
-    object: 'chat.completion',
-    created: Math.floor(Date.now() / 1000),
-    model: 'dummy',
-    choices: [
-      {
-        index: 0,
-        message: {
-          role: 'assistant',
-          content: null,
-          tool_calls: [
-            {
-              id: `call_subagent_read_${index}`,
-              type: 'function',
-              function: {
-                name: 'read_file',
-                arguments: JSON.stringify({
-                  absolute_path: packageJsonPath,
-                  offset: index * 2,
-                  limit: 6,
-                }),
-              },
-            },
-          ],
+    toolCalls: [
+      fakeToolCall(
+        'read_file',
+        {
+          absolute_path: packageJsonPath,
+          offset: index * 2,
+          limit: 6,
         },
-        finish_reason: 'tool_calls',
-      },
+        `call_subagent_read_${index}`,
+      ),
     ],
     usage: { prompt_tokens: 50, completion_tokens: 12, total_tokens: 62 },
   };
 }
 
-function buildSubagentFinal() {
+function buildSubagentFinal(): FakeOpenAIResponse {
   return {
-    id: chatCompletionId('subagent-final'),
-    object: 'chat.completion',
-    created: Math.floor(Date.now() / 1000),
-    model: 'dummy',
-    choices: [
-      {
-        index: 0,
-        message: { role: 'assistant', content: SUBAGENT_DONE_MARKER },
-        finish_reason: 'stop',
-      },
-    ],
+    content: SUBAGENT_DONE_MARKER,
     usage: { prompt_tokens: 80, completion_tokens: 8, total_tokens: 88 },
   };
 }
 
-function buildMainFinal() {
+function buildMainFinal(): FakeOpenAIResponse {
   return {
-    id: chatCompletionId('main-final'),
-    object: 'chat.completion',
-    created: Math.floor(Date.now() / 1000),
-    model: 'dummy',
-    choices: [
-      {
-        index: 0,
-        message: { role: 'assistant', content: MAIN_DONE_MARKER },
-        finish_reason: 'stop',
-      },
-    ],
+    content: MAIN_DONE_MARKER,
     usage: { prompt_tokens: 100, completion_tokens: 4, total_tokens: 104 },
   };
 }
 
-async function startFakeOpenAIServer(
+function messageText(content: unknown): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+  return content === undefined ? '' : JSON.stringify(content);
+}
+
+function roleContentMessages(body: Record<string, unknown>): string {
+  const messages = body['messages'];
+  if (!Array.isArray(messages)) {
+    return '';
+  }
+
+  return messages
+    .filter(
+      (message): message is Record<string, unknown> =>
+        typeof message === 'object' && message !== null,
+    )
+    .filter(
+      (message) => message['role'] === 'system' || message['role'] === 'user',
+    )
+    .map((message) => messageText(message['content']))
+    .join('\n');
+}
+
+function startSubagentFakeOpenAIServer(
   packageJsonPath: string,
   subagentToolCalls: number,
-): Promise<FakeServer> {
+): ReturnType<typeof startFakeOpenAIServer> {
   let mainTurnCount = 0;
   let subagentTurnCount = 0;
-  let requestCount = 0;
 
   const verbose = process.env['QWEN_TUI_E2E_VERBOSE'] === '1';
   const log = (...args: unknown[]) => {
@@ -384,77 +243,39 @@ async function startFakeOpenAIServer(
     }
   };
 
-  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
-    requestCount += 1;
-    log('incoming', req.method, req.url);
-    if (req.method !== 'POST') {
-      res.writeHead(404).end();
-      return;
+  return startFakeOpenAIServer(({ body, requestIndex }) => {
+    const bodyText = JSON.stringify(body);
+    log('request', requestIndex + 1, 'first 200:', bodyText.slice(0, 200));
+    // SubAgent loop is identified by the marker we planted in the prompt.
+    // Main-loop tool-call arguments and tool results can also contain the
+    // marker, so only `system`/`user` content participates in this check.
+    const roleContent = roleContentMessages(body);
+    const isSubagentLoop =
+      roleContent.includes('general-purpose agent') &&
+      roleContent.includes(SUBAGENT_PROMPT_MARKER);
+
+    const isStream = body['stream'] === true;
+
+    if (isSubagentLoop) {
+      subagentTurnCount += 1;
+      log('subagent turn', subagentTurnCount, 'stream', isStream);
+      // Emit one tool_call per turn so the SubAgent display has to commit
+      // and re-render between roundtrips. Sending all tool_calls in a
+      // single response lets the CLI batch the renders and hides the
+      // streaming-flicker pattern we want to expose.
+      if (subagentTurnCount <= subagentToolCalls) {
+        return buildSubagentSingleToolCall(packageJsonPath, subagentTurnCount);
+      }
+      return buildSubagentFinal();
     }
 
-    let body = '';
-    req.on('data', (chunk: Buffer) => {
-      body += chunk.toString('utf8');
-    });
-    req.on('end', () => {
-      log('body bytes', body.length, 'first 200:', body.slice(0, 200));
-      // SubAgent loop is identified by the marker we planted in the prompt.
-      // Main-loop tool-call arguments also contain the marker (it's embedded
-      // in the assistant's tool_call we returned), so we additionally require
-      // the marker to appear as a `user` or `system` content — which only
-      // happens after the parent dispatched into the SubAgent loop.
-      const isSubagentLoop =
-        body.includes('"role":"system"') &&
-        body.includes('general-purpose agent') &&
-        body.includes(SUBAGENT_PROMPT_MARKER);
-
-      const isStream = body.includes('"stream":true');
-
-      if (isSubagentLoop) {
-        subagentTurnCount += 1;
-        log('subagent turn', subagentTurnCount, 'stream', isStream);
-        // Emit one tool_call per turn so the SubAgent display has to commit
-        // and re-render between roundtrips. Sending all tool_calls in a
-        // single response lets the CLI batch the renders and hides the
-        // streaming-flicker pattern we want to expose.
-        if (subagentTurnCount <= subagentToolCalls) {
-          sendResponse(
-            res,
-            buildSubagentSingleToolCall(packageJsonPath, subagentTurnCount),
-            isStream,
-          );
-          return;
-        }
-        sendResponse(res, buildSubagentFinal(), isStream);
-        return;
-      }
-
-      mainTurnCount += 1;
-      log('main turn', mainTurnCount, 'stream', isStream);
-      if (mainTurnCount === 1) {
-        sendResponse(res, buildMainAgentToolCall(packageJsonPath), isStream);
-        return;
-      }
-      sendResponse(res, buildMainFinal(), isStream);
-    });
+    mainTurnCount += 1;
+    log('main turn', mainTurnCount, 'stream', isStream);
+    if (mainTurnCount === 1) {
+      return buildMainAgentToolCall(packageJsonPath);
+    }
+    return buildMainFinal();
   });
-
-  await new Promise<void>((resolveListen) => {
-    server.listen(0, '127.0.0.1', resolveListen);
-  });
-  const address = server.address();
-  if (!address || typeof address === 'string') {
-    throw new Error('failed to start fake OpenAI server');
-  }
-
-  return {
-    baseUrl: `http://127.0.0.1:${address.port}/v1`,
-    getRequestCount: () => requestCount,
-    close: () =>
-      new Promise<void>((resolveClose) => {
-        server.close(() => resolveClose());
-      }),
-  };
 }
 
 function qwenArgs(baseUrl: string): string[] {
@@ -503,7 +324,7 @@ async function main(): Promise<void> {
   }
   mkdirSync(outputDir, { recursive: true });
 
-  const fakeServer = await startFakeOpenAIServer(
+  const fakeServer = await startSubagentFakeOpenAIServer(
     packageJsonPath,
     subagentToolCalls,
   );
@@ -602,7 +423,7 @@ async function main(): Promise<void> {
       ...counts,
       finalScreenLines: finalScreen.split('\n').length,
       subagentToolCalls,
-      requestCount: fakeServer.getRequestCount(),
+      requestCount: fakeServer.requests.length,
       limits: {
         maxClearTerminalPairs: maxClearPairs,
         maxClearScreen,

--- a/integration-tests/terminal-capture/table-inline-code-wrap-regression.ts
+++ b/integration-tests/terminal-capture/table-inline-code-wrap-regression.ts
@@ -5,17 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  createServer,
-  type IncomingMessage,
-  type ServerResponse,
-} from 'node:http';
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join, resolve } from 'node:path';
-import type { AddressInfo } from 'node:net';
 import { fileURLToPath } from 'node:url';
 import { TerminalCapture } from './terminal-capture.js';
+import { startFakeOpenAIServer } from '../fake-openai-server.js';
 
 const TERMINAL_COLS = 100;
 const TERMINAL_ROWS = 32;
@@ -33,12 +28,6 @@ const MARKDOWN_RESPONSE = [
   'REGRESSION_TABLE_DONE',
 ].join('\n');
 
-type FakeServer = {
-  baseUrl: string;
-  close: () => Promise<void>;
-  getRequestCount: () => number;
-};
-
 type Summary = {
   repoRoot: string;
   outputDir: string;
@@ -54,116 +43,6 @@ type Summary = {
   expectedPass: boolean;
   screenshots: string[];
 };
-
-function sendJson(res: ServerResponse, body: unknown): void {
-  res.writeHead(200, { 'content-type': 'application/json' });
-  res.end(JSON.stringify(body));
-}
-
-function sendStream(res: ServerResponse, chunks: unknown[]): void {
-  res.writeHead(200, {
-    'cache-control': 'no-cache, no-transform',
-    connection: 'keep-alive',
-    'content-type': 'text/event-stream; charset=utf-8',
-  });
-  for (const chunk of chunks) {
-    res.write(`data: ${JSON.stringify(chunk)}\n\n`);
-  }
-  res.write('data: [DONE]\n\n');
-  res.end();
-}
-
-function chatCompletionId(): string {
-  return `chatcmpl-table-wrap-${Date.now()}`;
-}
-
-function streamWrap(
-  id: string,
-  delta: Record<string, unknown>,
-  finishReason: string | null,
-  usage?: Record<string, unknown>,
-): Record<string, unknown> {
-  return {
-    id,
-    object: 'chat.completion.chunk',
-    created: Math.floor(Date.now() / 1000),
-    model: 'dummy',
-    choices: [{ index: 0, delta, finish_reason: finishReason }],
-    ...(usage ? { usage } : {}),
-  };
-}
-
-function readRequestBody(req: IncomingMessage): Promise<string> {
-  return new Promise((resolveRead, rejectRead) => {
-    const chunks: Buffer[] = [];
-    req.on('data', (chunk: Buffer) => chunks.push(chunk));
-    req.on('end', () => resolveRead(Buffer.concat(chunks).toString('utf8')));
-    req.on('error', rejectRead);
-  });
-}
-
-async function startFakeOpenAIServer(): Promise<FakeServer> {
-  let requestCount = 0;
-  const server = createServer(async (req, res) => {
-    if (req.method !== 'POST' || !req.url?.endsWith('/chat/completions')) {
-      res.writeHead(404);
-      res.end('not found');
-      return;
-    }
-
-    requestCount += 1;
-    const body = await readRequestBody(req);
-    const parsed = JSON.parse(body) as { stream?: boolean };
-    const id = chatCompletionId();
-    const usage = {
-      prompt_tokens: 24,
-      completion_tokens: 16,
-      total_tokens: 40,
-    };
-
-    if (parsed.stream) {
-      sendStream(res, [
-        streamWrap(id, { role: 'assistant' }, null),
-        streamWrap(id, { content: MARKDOWN_RESPONSE }, null),
-        streamWrap(id, {}, 'stop', usage),
-      ]);
-      return;
-    }
-
-    sendJson(res, {
-      id,
-      object: 'chat.completion',
-      created: Math.floor(Date.now() / 1000),
-      model: 'dummy',
-      choices: [
-        {
-          index: 0,
-          message: { role: 'assistant', content: MARKDOWN_RESPONSE },
-          finish_reason: 'stop',
-        },
-      ],
-      usage,
-    });
-  });
-
-  await new Promise<void>((resolveListen) => {
-    server.listen(0, '127.0.0.1', resolveListen);
-  });
-
-  const address = server.address() as AddressInfo | null;
-  if (!address) {
-    throw new Error('failed to start fake OpenAI server');
-  }
-
-  return {
-    baseUrl: `http://127.0.0.1:${address.port}/v1`,
-    close: () =>
-      new Promise<void>((resolveClose) => {
-        server.close(() => resolveClose());
-      }),
-    getRequestCount: () => requestCount,
-  };
-}
 
 function qwenArgs(baseUrl: string): string[] {
   return [
@@ -268,7 +147,14 @@ async function main(): Promise<void> {
   }
   mkdirSync(outputDir, { recursive: true });
 
-  const fakeServer = await startFakeOpenAIServer();
+  const fakeServer = await startFakeOpenAIServer(() => ({
+    content: MARKDOWN_RESPONSE,
+    usage: {
+      prompt_tokens: 24,
+      completion_tokens: 16,
+      total_tokens: 40,
+    },
+  }));
   const homeDir = join(outputDir, 'home');
   mkdirSync(homeDir, { recursive: true });
 
@@ -338,7 +224,7 @@ async function main(): Promise<void> {
       finalScreen.includes(TABLE_NAME_SUFFIX) &&
       !finalScreen.includes(TABLE_NAME);
     const pass =
-      fakeServer.getRequestCount() > 0 &&
+      fakeServer.requests.length > 0 &&
       finalScreenWrappedTableName &&
       foregrounds.length > 0 &&
       uncoloredContinuationOccurrences === 0;
@@ -349,7 +235,7 @@ async function main(): Promise<void> {
     const summary: Summary = {
       repoRoot,
       outputDir,
-      requestCount: fakeServer.getRequestCount(),
+      requestCount: fakeServer.requests.length,
       rawBytes: raw.length,
       finalScreenLines: finalScreen.split('\n').length,
       continuationOccurrences: foregrounds.length,

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "test:integration:sandbox:none": "cross-env QWEN_SANDBOX=false vitest run --root ./integration-tests",
     "test:integration:sandbox:docker": "cross-env QWEN_SANDBOX=docker npm run build:sandbox && QWEN_SANDBOX=docker vitest run --root ./integration-tests",
     "test:integration:sandbox:podman": "cross-env QWEN_SANDBOX=podman vitest run --root ./integration-tests",
+    "test:integration:no-ak:sandbox:none": "cross-env QWEN_SANDBOX=false vitest run --root ./integration-tests ./fake-openai-server.test.ts ./cli/qwen-serve-routes.test.ts ./cli/qwen-serve-streaming.test.ts",
     "test:integration:sdk:sandbox:none": "cross-env QWEN_SANDBOX=false vitest run --root ./integration-tests --poolOptions.threads.maxThreads 2 sdk-typescript",
     "test:integration:sdk:sandbox:docker": "cross-env QWEN_SANDBOX=docker npm run build:sandbox && QWEN_SANDBOX=docker vitest run --root ./integration-tests --poolOptions.threads.maxThreads 2 sdk-typescript",
     "test:sdk:python": "python3 -m pytest -c packages/sdk-python/pyproject.toml packages/sdk-python/tests -q",

--- a/scripts/tests/no-ak-integration-ci.test.js
+++ b/scripts/tests/no-ak-integration-ci.test.js
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(import.meta.dirname, '../..');
+const NO_AK_SCRIPT = 'test:integration:no-ak:sandbox:none';
+
+describe('no-AK integration CI wiring', () => {
+  it('defines a focused no-AK integration script', () => {
+    const packageJson = JSON.parse(
+      readFileSync(path.join(ROOT, 'package.json'), 'utf8'),
+    );
+
+    expect(packageJson.scripts[NO_AK_SCRIPT]).toBe(
+      [
+        'cross-env QWEN_SANDBOX=false vitest run --root ./integration-tests',
+        './fake-openai-server.test.ts',
+        './cli/qwen-serve-routes.test.ts',
+        './cli/qwen-serve-streaming.test.ts',
+      ].join(' '),
+    );
+  });
+
+  it('runs the no-AK integration script on pull requests without model secrets', () => {
+    const workflow = readFileSync(
+      path.join(ROOT, '.github/workflows/ci.yml'),
+      'utf8',
+    );
+    const job = workflow.slice(
+      workflow.indexOf('  integration_no_ak:'),
+      workflow.indexOf('  integration_cli:'),
+    );
+
+    expect(job).toContain("name: 'Integration Tests (No-AK Smoke)'");
+    expect(job).toContain("github.event_name == 'pull_request'");
+    expect(job).toContain(`npm run ${NO_AK_SCRIPT}`);
+    expect(job).not.toContain('secrets.OPENAI_API_KEY');
+    expect(job).not.toContain('secrets.OPENAI_BASE_URL');
+    expect(job).not.toContain('secrets.OPENAI_MODEL');
+  });
+});


### PR DESCRIPTION
## What this PR does

This adds PR-safe no-AK integration smoke coverage for the daemon and fake model path, so pull requests can exercise the serve routes and streaming flow without repository secrets or real provider credentials.

It also makes the local fake OpenAI responses closer to real chat completions for tool calls, including null assistant content for tool-call responses and streamed tool-call argument deltas. The terminal capture regressions now reuse the shared fake model helper instead of keeping separate inline fake servers.

## Why it's needed

Issue #5559 tracks moving replayable fake model responses into integration coverage so regressions are caught during PR validation rather than waiting for release or secret-backed jobs. PR #5560 added the first fake server foundation; this follow-up wires the no-AK subset into pull_request CI and adds guard coverage for that wiring.

## Reviewer Test Plan

### How to verify

Confirm that pull request CI includes the "Integration Tests (No-AK Smoke)" job and that the job does not reference model provider secrets. The expected behavior is that fake OpenAI server coverage, qwen serve route coverage, and qwen serve streaming coverage can all run from the focused no-AK integration script.

Local verification used:

- `npm run build`
- `npm run bundle`
- `npm run test:integration:no-ak:sandbox:none`
- `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/no-ak-integration-ci.test.js`
- `npm run typecheck`
- `actionlint -color -ignore 'SC2002:' -ignore 'SC2016:' -ignore 'SC2129:' -ignore 'label ".+" is unknown' .github/workflows/ci.yml`
- `git diff --check`

### Evidence (Before & After)

N/A for UI evidence. The new focused integration command passed locally with 3 test files and 36 tests, and the CI wiring guard passed with 2 tests.

### Tested on

|     OS     |     Status     |
| :--------: | :------------: |
|  🍏 macOS  |    ✅ tested    |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local worktree with `QWEN_SANDBOX=false`; the no-AK suite uses a local fake OpenAI server and does not require provider API keys.

## Risk & Scope

- Main risk or tradeoff: This adds a small PR CI job, so PR validation does a bit more work, but the scope is intentionally limited to fake/no-transport coverage.
- Not validated / out of scope: Full secret-backed integration coverage and Windows-local serve streaming are still outside this smoke job.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5559

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 增加了可以在 PR 阶段运行的 no-AK integration smoke 覆盖，用本地 fake model 跑 daemon 和 streaming 相关路径，因此 fork PR 不需要仓库 secrets 或真实模型凭证也能覆盖这部分行为。

它也让本地 fake OpenAI 响应更接近真实 chat completions 的 tool call 形态，包括 tool-call 响应里的 assistant content 为 null，以及流式 tool-call arguments 以 delta 形式输出。两个 terminal capture 回归脚本也改成复用共享 fake model helper，不再各自维护内联 fake server。

## Why it's needed

#5559 的目标是把可回放的 fake model responses 接入 integration coverage，让相关回归在 PR 阶段暴露，而不是等 release 或需要 secrets 的 job。#5560 已经补了第一阶段 fake server 基础；这个后续 PR 把 no-AK 子集接入 pull_request CI，并补了防止 CI wiring 退化的测试。

## Reviewer Test Plan

### How to verify

确认 pull request CI 里包含 "Integration Tests (No-AK Smoke)" job，并且这个 job 没有引用模型供应商 secrets。预期行为是 fake OpenAI server 覆盖、qwen serve routes 覆盖和 qwen serve streaming 覆盖都能通过新的 focused no-AK integration script 运行。

本地验证已运行：

- `npm run build`
- `npm run bundle`
- `npm run test:integration:no-ak:sandbox:none`
- `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/no-ak-integration-ci.test.js`
- `npm run typecheck`
- `actionlint -color -ignore 'SC2002:' -ignore 'SC2016:' -ignore 'SC2129:' -ignore 'label ".+" is unknown' .github/workflows/ci.yml`
- `git diff --check`

### Evidence (Before & After)

非 UI 改动，没有截图证据。新的 focused integration command 已在本地通过 3 个测试文件、36 个测试；CI wiring guard 已通过 2 个测试。

### Tested on

|     OS     |     Status     |
| :--------: | :------------: |
|  🍏 macOS  |    ✅ tested    |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 worktree，`QWEN_SANDBOX=false`；no-AK suite 使用本地 fake OpenAI server，不需要模型供应商 API key。

## Risk & Scope

- Main risk or tradeoff: PR CI 会多一个小型 job，但范围刻意限制在 fake/no-transport 覆盖。
- Not validated / out of scope: 完整 secret-backed integration 覆盖，以及 Windows 本地 serve streaming，仍不在这个 smoke job 范围内。
- Breaking changes / migration notes: 无。

## Linked Issues

Fixes #5559

</details>
