### PR TITLE
fix(core): reject non-decimal QWEN_CODE_API_TIMEOUT_MS values

### DIFF
--- a/packages/core/src/models/modelConfigResolver.test.ts
+++ b/packages/core/src/models/modelConfigResolver.test.ts
@@ -265,7 +265,7 @@ describe('modelConfigResolver', () => {
         expect(result.config.timeout).toBeUndefined();
       });
 
-      it('QWEN_CODE_API_TIMEOUT_MS works with float value in OAuth', () => {
+      it('ignores float QWEN_CODE_API_TIMEOUT_MS in OAuth (not a decimal integer)', () => {
         const result = resolveModelConfig({
           authType: AuthType.QWEN_OAUTH,
           cli: {},
@@ -275,7 +275,10 @@ describe('modelConfigResolver', () => {
           },
         });
 
-        expect(result.config.timeout).toBe(12345);
+        // Floats are not strict positive decimal integers — ignored, so the
+        // lower-priority layer applies (here: undefined / provider default).
+        expect(result.config.timeout).toBeUndefined();
+        expect(result.sources['timeout']).toBeUndefined();
       });
 
       it('QWEN_CODE_API_TIMEOUT_MS works with proxy in OAuth path', () => {
@@ -782,22 +785,24 @@ describe('modelConfigResolver', () => {
   });
 
   describe('[Additional] timeout env override edge cases', () => {
-    it('handles scientific notation in QWEN_CODE_API_TIMEOUT_MS', () => {
+    it('ignores scientific notation in QWEN_CODE_API_TIMEOUT_MS', () => {
       const result = resolveModelConfig({
         authType: AuthType.USE_OPENAI,
         cli: {},
-        settings: { apiKey: 'key' },
+        settings: { apiKey: 'key', generationConfig: { timeout: 30000 } },
         env: {
           OPENAI_API_KEY: 'key',
           QWEN_CODE_API_TIMEOUT_MS: '1.5e5',
         },
       });
 
-      expect(result.config.timeout).toBe(150000);
-      expect(result.sources['timeout'].kind).toBe('env');
+      // `1.5e5` is not a strict positive decimal integer — ignored, so the
+      // lower-priority settings value applies.
+      expect(result.config.timeout).toBe(30000);
+      expect(result.sources['timeout'].kind).toBe('settings');
     });
 
-    it('handles hex values in QWEN_CODE_API_TIMEOUT_MS', () => {
+    it('ignores hex values in QWEN_CODE_API_TIMEOUT_MS', () => {
       const result = resolveModelConfig({
         authType: AuthType.USE_OPENAI,
         cli: {},
@@ -808,8 +813,25 @@ describe('modelConfigResolver', () => {
         },
       });
 
-      expect(result.config.timeout).toBe(180000);
-      expect(result.sources['timeout'].kind).toBe('env');
+      // Hex literals are not decimal integers — ignored, settings value applies.
+      expect(result.config.timeout).toBe(30000);
+      expect(result.sources['timeout'].kind).toBe('settings');
+    });
+
+    it('ignores unsafe-integer QWEN_CODE_API_TIMEOUT_MS', () => {
+      const result = resolveModelConfig({
+        authType: AuthType.USE_OPENAI,
+        cli: {},
+        settings: { apiKey: 'key', generationConfig: { timeout: 30000 } },
+        env: {
+          OPENAI_API_KEY: 'key',
+          // 2^53 — beyond Number.MAX_SAFE_INTEGER, rejected by the strict parser.
+          QWEN_CODE_API_TIMEOUT_MS: '9007199254740993',
+        },
+      });
+
+      expect(result.config.timeout).toBe(30000);
+      expect(result.sources['timeout'].kind).toBe('settings');
     });
 
     it('ignores empty string QWEN_CODE_API_TIMEOUT_MS', () => {

--- a/packages/core/src/models/modelConfigResolver.ts
+++ b/packages/core/src/models/modelConfigResolver.ts
@@ -42,6 +42,7 @@ import {
   QWEN_OAUTH_ALLOWED_MODELS,
   MODEL_GENERATION_CONFIG_FIELDS,
 } from './constants.js';
+import { parsePositiveIntegerEnv } from '../utils/env.js';
 import type { ModelConfig as ModelProviderConfig } from './types.js';
 export {
   validateModelConfig,
@@ -122,9 +123,18 @@ function applyTimeoutEnvOverride(
   const raw = env['QWEN_CODE_API_TIMEOUT_MS'];
   if (raw === undefined) return;
 
-  const parsed = Number(raw);
-  if (Number.isFinite(parsed) && parsed > 0) {
-    generationConfig.timeout = Math.floor(parsed);
+  // For a `*_MS` knob, only accept strict positive decimal integers — the same
+  // rule `parsePositiveIntegerEnv` already applies to the other env knobs. This
+  // rejects floats, scientific notation (`1.5e5`), hex (`0x2BF20`), and unsafe
+  // integers that `Number()` would otherwise silently coerce. Malformed values
+  // are ignored so the lower-priority layer applies (modelProvider > env >
+  // settings > default). The INVALID sentinel distinguishes a genuine override
+  // from a malformed value, so we never mis-attribute a settings-derived timeout
+  // to the env source.
+  const INVALID = -1;
+  const parsed = parsePositiveIntegerEnv(raw, INVALID);
+  if (parsed !== INVALID) {
+    generationConfig.timeout = parsed;
     sources['timeout'] = {
       kind: 'env',
       envKey: 'QWEN_CODE_API_TIMEOUT_MS',


### PR DESCRIPTION
## Summary

`QWEN_CODE_API_TIMEOUT_MS` was parsed in `applyTimeoutEnvOverride()` with `Number(raw)` + `Math.floor()`, guarded only by `Number.isFinite(parsed) && parsed > 0`. That silently coerced and accepted JS number formats the shared strict env parser rejects:

- `1.5e5` → `150000`
- `0x2BF20` → `180000`
- `12345.67` → `12345` (floored)

For a `*_MS` knob the safe behavior is the same rule already applied to the other env knobs in #5491/#5496: accept only strict positive decimal integers, and ignore malformed values so the lower-priority layer applies.

## Changes

- `applyTimeoutEnvOverride()` now uses `parsePositiveIntegerEnv` (`packages/core/src/utils/env.ts`) instead of `Number()` + `Math.floor()`. This rejects floats, scientific notation, hex, empty strings, zero, negatives, and unsafe integers.
- Precedence is unchanged: `modelProvider > env > settings > default`. Malformed env values are silently ignored, falling back to settings/default.
- An `INVALID` sentinel distinguishes a genuine override from a malformed value, so a settings-derived timeout is never mis-attributed to the `env` source (`sources['timeout'].kind`).

## Tests

- Updated the three tests that previously encoded the buggy behavior (float / scientific notation / hex) to assert the values are now ignored and the lower-priority layer applies.
- Added an unsafe-integer (`2^53 + 1`) edge case.
- Whitespace-padded and plain decimal integers still apply as before.
- All 50 tests in `modelConfigResolver.test.ts` pass; the broader models + `env.test.ts` suites (197 tests) stay green.

Fixes #5596