### PR TITLE
Fix native voice recorder retry after stop errors

### DIFF
--- a/packages/cli/src/ui/voice/native-audio-recorder.test.ts
+++ b/packages/cli/src/ui/voice/native-audio-recorder.test.ts
@@ -157,4 +157,29 @@ describe('createNativeAudioRecorder', () => {
     expect(loadBackend).toHaveBeenCalledTimes(2);
     expect(backend.startRecording).toHaveBeenCalledTimes(1);
   });
+
+  it('allows retry after native stop throws', async () => {
+    const backend = {
+      startRecording: vi.fn(),
+      stopRecording: vi
+        .fn()
+        .mockImplementationOnce(() => {
+          throw new Error('Native audio capture produced empty audio.');
+        })
+        .mockReturnValueOnce(new Uint8Array([1])),
+      isRecording: vi.fn(() => false),
+      microphoneAuthorizationStatus: vi.fn(() => 'unknown' as const),
+    };
+    const recorder = createNativeAudioRecorder({
+      loadBackend: () => backend,
+    });
+
+    await recorder.start();
+    await expect(recorder.stop()).rejects.toThrow(/empty audio/);
+    await recorder.start();
+    await recorder.stop();
+
+    expect(backend.startRecording).toHaveBeenCalledTimes(2);
+    expect(backend.stopRecording).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/cli/src/ui/voice/native-audio-recorder.ts
+++ b/packages/cli/src/ui/voice/native-audio-recorder.ts
@@ -111,12 +111,15 @@ class NativeAudioRecorder implements VoiceRecorder {
       throw new Error('Native voice recorder was not started.');
     }
 
-    const data = this.backend.stopRecording();
-    this.backend = null;
-    return {
-      data,
-      mimeType: 'audio/wav',
-    };
+    try {
+      const data = this.backend.stopRecording();
+      return {
+        data,
+        mimeType: 'audio/wav',
+      };
+    } finally {
+      this.backend = null;
+    }
   }
 }
 


### PR DESCRIPTION
## What this PR does

This PR makes native voice dictation release its active recorder state whenever stopping is attempted, even if the native backend reports an empty final buffer.

## Why it\s needed

Realtime voice dictation drains audio while recording. At stop time, the native backend can have no buffered audio left and report an empty capture after the device has already been stopped. The JavaScript recorder wrapper kept its active backend reference in that error path, so the next voice attempt incorrectly failed as already recording and then fell through to the SoX fallback.

## Reviewer Test Plan

### How to verify

Use a realtime voice model, record once, let the session finish, then record again in the same CLI process. The second recording should start through native capture instead of reporting that the native recorder is already recording.

### Evidence (Before & After)

Before: the new regression test failed with `Native voice recorder is already recording.` when starting again after a native stop error. After: the same test passes and confirms the recorder can start and stop again.

Commands run: `cd packages/cli && npx vitest run src/ui/voice/native-audio-recorder.test.ts` passed with 7 tests. `npm run build && npm run typecheck` completed with exit 0. The build still prints existing Browserslist and VS Code companion lint warnings, but no errors.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node v24.14.1 on macOS arm64, local linked worktree.

## Risk & Scope

- Main risk or tradeoff: a stop error no longer keeps the wrapper in a recording state, which matches the native backend behavior after it has already attempted to stop the device.
- Not validated / out of scope: manual microphone verification on Windows and Linux.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让原生语音听写在尝试停止录音后一定释放活跃录音器状态，即使原生后端报告最终缓冲区为空。

## Why it\s needed

实时语音听写会在录音过程中持续 drain 音频。停止时，原生后端可能已经没有剩余缓冲，并在设备已停止后报告空音频。此前 JavaScript 录音器包装层在这个错误路径里保留了活跃后端引用，导致下一次语音输入被误判为仍在录音，然后降级到 SoX fallback。

## Reviewer Test Plan

### How to verify

使用 realtime 语音模型，完成一次录音后，在同一个 CLI 进程里再次录音。第二次录音应该通过原生采集正常开始，而不是报告原生录音器仍在录音。

### Evidence (Before & After)

Before：新增回归测试在原生停止错误后再次开始录音时失败，错误为 `Native voice recorder is already recording.`。After：同一个测试通过，并确认录音器可以再次开始和停止。

执行命令：`cd packages/cli && npx vitest run src/ui/voice/native-audio-recorder.test.ts` 通过，共 7 个测试。`npm run build && npm run typecheck` 以 exit 0 完成。build 仍会打印现有 Browserslist 和 VS Code companion lint warning，但没有错误。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS arm64，Node v24.14.1，本地 linked worktree。

## Risk & Scope

- Main risk or tradeoff：stop 出错后不再让包装层保持录音中状态，这和原生后端已经尝试停止设备后的行为一致。
- Not validated / out of scope：Windows 和 Linux 上的手动麦克风验证。
- Breaking changes / migration notes：无。

## Linked Issues

N/A

</details>