### PR TITLE
fix(cli): parse serve rate limit env strictly

### DIFF
--- a/packages/cli/src/commands/serve.test.ts
+++ b/packages/cli/src/commands/serve.test.ts
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import yargs, { type Argv } from 'yargs';
 import { serveCommand, maybeOpenWebShellBrowser } from './serve.js';
 
 const mockOpenBrowserSecurely = vi.hoisted(() => vi.fn());
 const mockShouldLaunchBrowser = vi.hoisted(() => vi.fn(() => true));
+const mockRunQwenServe = vi.hoisted(() => vi.fn());
 vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
   const actual =
     await importOriginal<typeof import('@qwen-code/qwen-code-core')>();
@@ -19,6 +20,9 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
     shouldLaunchBrowser: mockShouldLaunchBrowser,
   };
 });
+vi.mock('../serve/index.js', () => ({
+  runQwenServe: mockRunQwenServe,
+}));
 
 function buildParser(): Argv {
   return (serveCommand.builder as (argv: Argv) => Argv)(
@@ -57,6 +61,77 @@ describe('serve command args', () => {
   it('parses --open (default false)', () => {
     expect(buildParser().parseSync('')['open']).toBe(false);
     expect(buildParser().parseSync('--open')['open']).toBe(true);
+  });
+});
+
+describe('serve rate limit env parsing', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv, QWEN_CODE_SUPPRESS_YOLO_WARNING: '1' };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  async function invokeServeHandler() {
+    const handler = serveCommand.handler;
+    if (!handler) throw new Error('serve handler missing');
+    const argv = buildParser().parseSync('--rate-limit --no-web');
+    await handler(argv as Parameters<typeof handler>[0]);
+  }
+
+  async function startServeHandler() {
+    const handler = serveCommand.handler;
+    if (!handler) throw new Error('serve handler missing');
+    const argv = buildParser().parseSync('--rate-limit --no-web');
+    void handler(argv as Parameters<typeof handler>[0]);
+    await vi.waitFor(() => {
+      expect(mockRunQwenServe).toHaveBeenCalled();
+    });
+  }
+
+  it.each([
+    ['QWEN_SERVE_RATE_LIMIT_PROMPT', '0x10'],
+    ['QWEN_SERVE_RATE_LIMIT_MUTATION', '1e3'],
+    ['QWEN_SERVE_RATE_LIMIT_READ', '2.5'],
+    ['QWEN_SERVE_RATE_LIMIT_WINDOW_MS', '0x3e8'],
+  ])('rejects non-decimal %s=%s', async (key, value) => {
+    process.env[key] = value;
+    vi.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`process.exit(${code}) called`);
+    });
+
+    await expect(invokeServeHandler()).rejects.toThrow(
+      'process.exit(1) called',
+    );
+    expect(mockRunQwenServe).not.toHaveBeenCalled();
+  });
+
+  it('passes decimal env values to runQwenServe', async () => {
+    process.env['QWEN_SERVE_RATE_LIMIT_PROMPT'] = '11';
+    process.env['QWEN_SERVE_RATE_LIMIT_MUTATION'] = ' 31 ';
+    process.env['QWEN_SERVE_RATE_LIMIT_READ'] = '121';
+    process.env['QWEN_SERVE_RATE_LIMIT_WINDOW_MS'] = '60000';
+    mockRunQwenServe.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:4170/',
+      webShellMounted: false,
+    });
+
+    await startServeHandler();
+
+    expect(mockRunQwenServe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rateLimit: true,
+        rateLimitPrompt: 11,
+        rateLimitMutation: 31,
+        rateLimitRead: 121,
+        rateLimitWindowMs: 60000,
+      }),
+    );
   });
 });
 

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -16,6 +16,7 @@ import {
   ApprovalMode,
   MCP_BUDGET_WARN_FRACTION,
   openBrowserSecurely,
+  parsePositiveIntegerEnv,
   shouldLaunchBrowser,
 } from '@qwen-code/qwen-code-core';
 import { loadSettings } from '../config/settings.js';
@@ -426,8 +427,9 @@ export const serveCommand: CommandModule<unknown, ServeArgs> = {
     let rateLimitWindowMs: number | undefined;
     if (rateLimit) {
       const envInt = (key: string): number | undefined => {
-        const v = process.env[key];
-        return v ? Number(v) : undefined;
+        const raw = process.env[key];
+        if (raw === undefined || raw === '') return undefined;
+        return parsePositiveIntegerEnv(raw, Number.NaN);
       };
       rateLimitPrompt =
         argv['rate-limit-prompt'] ?? envInt('QWEN_SERVE_RATE_LIMIT_PROMPT');


### PR DESCRIPTION
## What this PR does

This PR makes the `qwen serve` rate-limit env vars use strict positive-integer parsing. `QWEN_SERVE_RATE_LIMIT_PROMPT`, `QWEN_SERVE_RATE_LIMIT_MUTATION`, `QWEN_SERVE_RATE_LIMIT_READ`, and `QWEN_SERVE_RATE_LIMIT_WINDOW_MS` now reject non-decimal values instead of accepting JavaScript number coercions.

It also adds focused handler coverage to confirm malformed env values fail before the daemon startup path is reached.

## Why it's needed

The previous parser used `Number(v)`, so values like `0x10`, `1e3`, and `0x3e8` passed the later integer checks as valid rate-limit settings. These env vars are documented and described as integer counts or millisecond windows, so silently accepting non-decimal formats is surprising and inconsistent with the shared strict env parser used elsewhere.

The change keeps valid decimal values working while making malformed non-empty env values fail startup through the existing validation errors.

## Reviewer Test Plan

### How to verify

Reviewers can confirm that decimal positive integers are passed through to `runQwenServe`, while non-decimal values such as `0x10`, `1e3`, `2.5`, and `0x3e8` are rejected before `runQwenServe` is called.

Commands run locally:

```sh
npm run build --workspace @qwen-code/acp-bridge
(cd packages/cli && npx vitest run src/commands/serve.test.ts --coverage.enabled=false)
npx prettier --check packages/cli/src/commands/serve.ts packages/cli/src/commands/serve.test.ts
npx eslint packages/cli/src/commands/serve.ts packages/cli/src/commands/serve.test.ts
npm run build --workspace @qwen-code/qwen-code
npm run typecheck --workspace @qwen-code/qwen-code
git diff --check
```

### Evidence (Before & After)

Before: `QWEN_SERVE_RATE_LIMIT_PROMPT=0x10` was accepted as `16`, `QWEN_SERVE_RATE_LIMIT_MUTATION=1e3` was accepted as `1000`, and `QWEN_SERVE_RATE_LIMIT_WINDOW_MS=0x3e8` was accepted as `1000`.

After: those malformed values fail validation and the serve daemon is not started. This is covered by the updated `serve` command unit tests.

No UI/TUI evidence is attached because this is a CLI configuration parsing change covered by unit tests.

### Tested on

|     OS     |   Status    |
| :--------: | :---------: |
|  🍏 macOS  |  ✅ tested  |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local Node/npm workspace on macOS. The local install used `npm install --ignore-scripts`; `npx patch-package` was run before build/typecheck so the local workspace matched the normal patched dependency state.

## Risk & Scope

- Main risk or tradeoff: users who intentionally used hex, scientific notation, or fractional values in `QWEN_SERVE_RATE_LIMIT_*` env vars need to switch to decimal positive integers.
- Not validated / out of scope: no end-to-end daemon process was started; this is covered at the command handler validation layer.
- Breaking changes / migration notes: malformed non-empty rate-limit env values now fail startup instead of being coerced.

## Linked Issues

Fixes #5603

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让 `qwen serve` 的 rate-limit env vars 使用严格正整数解析。`QWEN_SERVE_RATE_LIMIT_PROMPT`、`QWEN_SERVE_RATE_LIMIT_MUTATION`、`QWEN_SERVE_RATE_LIMIT_READ` 和 `QWEN_SERVE_RATE_LIMIT_WINDOW_MS` 现在会拒绝非十进制值，而不是接受 JavaScript number coercion。

同时增加了 focused handler 测试，确认格式不合法的 env 值会在进入 daemon 启动路径前失败。

## Why it's needed

之前的解析逻辑使用 `Number(v)`，所以 `0x10`、`1e3`、`0x3e8` 这类值会通过后续整数校验，被当作有效 rate-limit 配置。这些 env vars 在语义上是整数次数或毫秒窗口，静默接受非十进制格式比较意外，也和项目里其他位置使用的共享严格 env parser 不一致。

这个改动保留合法十进制值的现有行为，同时让格式不合法的非空 env 值通过已有 validation error 让启动失败。

## Reviewer Test Plan

### How to verify

Reviewer 可以确认十进制正整数会传给 `runQwenServe`，而 `0x10`、`1e3`、`2.5`、`0x3e8` 这类非十进制值会在调用 `runQwenServe` 之前被拒绝。

本地已运行命令：

```sh
npm run build --workspace @qwen-code/acp-bridge
(cd packages/cli && npx vitest run src/commands/serve.test.ts --coverage.enabled=false)
npx prettier --check packages/cli/src/commands/serve.ts packages/cli/src/commands/serve.test.ts
npx eslint packages/cli/src/commands/serve.ts packages/cli/src/commands/serve.test.ts
npm run build --workspace @qwen-code/qwen-code
npm run typecheck --workspace @qwen-code/qwen-code
git diff --check
```

### Evidence (Before & After)

Before：`QWEN_SERVE_RATE_LIMIT_PROMPT=0x10` 会被接受为 `16`，`QWEN_SERVE_RATE_LIMIT_MUTATION=1e3` 会被接受为 `1000`，`QWEN_SERVE_RATE_LIMIT_WINDOW_MS=0x3e8` 会被接受为 `1000`。

After：这些格式不合法的值会触发 validation，serve daemon 不会启动。这个行为已由更新后的 `serve` command 单元测试覆盖。

这里没有附 UI/TUI 证据，因为这是 CLI 配置解析变更，已由单元测试覆盖。

### Tested on

|     OS     |   Status    |
| :--------: | :---------: |
|  🍏 macOS  |  ✅ tested  |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 macOS Node/npm workspace。本地安装使用了 `npm install --ignore-scripts`；在 build/typecheck 前运行了 `npx patch-package`，确保本地 workspace 与正常安装后的 patched dependency 状态一致。

## Risk & Scope

- Main risk or tradeoff：如果用户有意在 `QWEN_SERVE_RATE_LIMIT_*` env vars 中使用十六进制、科学计数法或小数，需要改成十进制正整数。
- Not validated / out of scope：没有启动端到端 daemon 进程；这个变更在 command handler validation 层通过测试覆盖。
- Breaking changes / migration notes：格式不合法的非空 rate-limit env 值现在会导致启动失败，而不是被转换。

## Linked Issues

Fixes #5603

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
