### PR TITLE
fix(core): backend-aware artifact publish confirmation + cancel handling

### DIFF
--- a/packages/core/src/tools/artifact/artifact-tool.test.ts
+++ b/packages/core/src/tools/artifact/artifact-tool.test.ts
@@ -292,7 +292,7 @@ describe('ArtifactTool', () => {
       openSpy as unknown as UrlOpener,
     );
     const res = await cancelTool.build({ file_path: file }).execute(signal);
-    expect(res.error?.type).toBe(ToolErrorType.EXECUTION_FAILED);
+    expect(res.error).toBeUndefined();
     expect(res.llmContent).toMatch(/cancelled/i);
     expect(openSpy).not.toHaveBeenCalled();
   });
@@ -313,7 +313,7 @@ describe('ArtifactTool', () => {
       openSpy as unknown as UrlOpener,
     );
     const res = await cancelTool.build({ file_path: file }).execute(signal);
-    expect(res.error?.type).toBe(ToolErrorType.EXECUTION_FAILED);
+    expect(res.error).toBeUndefined();
     expect(res.llmContent).toMatch(/cancelled/i);
     expect(openSpy).not.toHaveBeenCalled();
   });
@@ -335,7 +335,7 @@ describe('ArtifactTool', () => {
     const res = await cancelTool
       .build({ file_path: file })
       .execute(controller.signal);
-    expect(res.error?.type).toBe(ToolErrorType.EXECUTION_FAILED);
+    expect(res.error).toBeUndefined();
     expect(res.llmContent).toMatch(/cancelled/i);
     expect(openSpy).not.toHaveBeenCalled();
   });

--- a/packages/core/src/tools/artifact/artifact-tool.test.ts
+++ b/packages/core/src/tools/artifact/artifact-tool.test.ts
@@ -165,4 +165,45 @@ describe('ArtifactTool', () => {
     const html = await fs.readFile(res.resultFilePaths![0], 'utf8');
     expect(html).toContain('<title>release-notes</title>');
   });
+
+  it('tells the user a remote backend uploads, but a local one does not', async () => {
+    const file = path.join(workdir, 'p.html');
+    const remoteTool = new ArtifactTool(
+      makeConfig(),
+      { kind: 'oss', publish: async () => ({ id: 'x', url: 'https://h/x' }) },
+      openSpy as unknown as UrlOpener,
+    );
+    const remote = await remoteTool
+      .build({ file_path: file })
+      .getConfirmationDetails(signal);
+    expect((remote as { prompt: string }).prompt).toMatch(
+      /remote host \(oss\)/i,
+    );
+
+    const local = await tool
+      .build({ file_path: file })
+      .getConfirmationDetails(signal);
+    expect((local as { prompt: string }).prompt).not.toMatch(/remote/i);
+  });
+
+  it('reports a cancellation when the publisher aborts', async () => {
+    const file = await writeFragment('page.html', '<p>x</p>');
+    const abortErr = Object.assign(new Error('aborted'), {
+      name: 'AbortError',
+    });
+    const cancelTool = new ArtifactTool(
+      makeConfig(),
+      {
+        kind: 'oss',
+        publish: async () => {
+          throw abortErr;
+        },
+      },
+      openSpy as unknown as UrlOpener,
+    );
+    const res = await cancelTool.build({ file_path: file }).execute(signal);
+    expect(res.error?.type).toBe(ToolErrorType.EXECUTION_FAILED);
+    expect(res.llmContent).toMatch(/cancelled/i);
+    expect(openSpy).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/tools/artifact/artifact-tool.test.ts
+++ b/packages/core/src/tools/artifact/artifact-tool.test.ts
@@ -242,4 +242,26 @@ describe('ArtifactTool', () => {
     expect(res.llmContent).toMatch(/cancelled/i);
     expect(openSpy).not.toHaveBeenCalled();
   });
+
+  it('reports a cancellation when the signal is aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const file = await writeFragment('page.html', '<p>x</p>');
+    const cancelTool = new ArtifactTool(
+      makeConfig(),
+      {
+        kind: 'oss',
+        publish: async () => {
+          throw new Error('network failure');
+        },
+      },
+      openSpy as unknown as UrlOpener,
+    );
+    const res = await cancelTool
+      .build({ file_path: file })
+      .execute(controller.signal);
+    expect(res.error?.type).toBe(ToolErrorType.EXECUTION_FAILED);
+    expect(res.llmContent).toMatch(/cancelled/i);
+    expect(openSpy).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/tools/artifact/artifact-tool.test.ts
+++ b/packages/core/src/tools/artifact/artifact-tool.test.ts
@@ -122,7 +122,7 @@ describe('ArtifactTool', () => {
     const failingTool = new ArtifactTool(
       makeConfig(),
       {
-        kind: 'fail',
+        kind: 'oss',
         publish: async () => {
           throw new Error('network timeout');
         },
@@ -180,6 +180,21 @@ describe('ArtifactTool', () => {
       /remote host \(oss\)/i,
     );
 
+    const hostTool = new ArtifactTool(
+      makeConfig(),
+      {
+        kind: 'host',
+        publish: async () => ({ id: 'x', url: 'https://h/x' }),
+      },
+      openSpy as unknown as UrlOpener,
+    );
+    const host = await hostTool
+      .build({ file_path: file })
+      .getConfirmationDetails(signal);
+    expect((host as { prompt: string }).prompt).toMatch(
+      /remote host \(custom upload\)/i,
+    );
+
     const local = await tool
       .build({ file_path: file })
       .getConfirmationDetails(signal);
@@ -190,6 +205,27 @@ describe('ArtifactTool', () => {
     const file = await writeFragment('page.html', '<p>x</p>');
     const abortErr = Object.assign(new Error('aborted'), {
       name: 'AbortError',
+    });
+    const cancelTool = new ArtifactTool(
+      makeConfig(),
+      {
+        kind: 'oss',
+        publish: async () => {
+          throw abortErr;
+        },
+      },
+      openSpy as unknown as UrlOpener,
+    );
+    const res = await cancelTool.build({ file_path: file }).execute(signal);
+    expect(res.error?.type).toBe(ToolErrorType.EXECUTION_FAILED);
+    expect(res.llmContent).toMatch(/cancelled/i);
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('reports a cancellation for a Node abort error', async () => {
+    const file = await writeFragment('page.html', '<p>x</p>');
+    const abortErr = Object.assign(new Error('aborted'), {
+      code: 'ABORT_ERR',
     });
     const cancelTool = new ArtifactTool(
       makeConfig(),

--- a/packages/core/src/tools/artifact/artifact-tool.ts
+++ b/packages/core/src/tools/artifact/artifact-tool.ts
@@ -17,7 +17,11 @@ import type { PermissionDecision } from '../../permissions/types.js';
 import { ToolErrorType } from '../tool-error.js';
 import { ToolNames, ToolDisplayNames } from '../tool-names.js';
 import { makeRelative, shortenPath, unescapePath } from '../../utils/paths.js';
-import { getErrorMessage, isNodeError } from '../../utils/errors.js';
+import {
+  getErrorMessage,
+  isAbortError,
+  isNodeError,
+} from '../../utils/errors.js';
 import { openBrowserSecurely } from '../../utils/secure-browser-launcher.js';
 import { createDebugLogger } from '../../utils/debugLogger.js';
 import {
@@ -84,18 +88,22 @@ class ArtifactToolInvocation extends BaseToolInvocation<
     return Promise.resolve('ask');
   }
 
-  override getConfirmationDetails(): Promise<ToolCallConfirmationDetails> {
+  override getConfirmationDetails(
+    _abortSignal: AbortSignal,
+  ): Promise<ToolCallConfirmationDetails> {
     const relativePath = makeRelative(
       this.params.file_path,
       this.config.getTargetDir(),
     );
+    const backendLabel =
+      this.publisher.kind === 'host' ? 'custom upload' : this.publisher.kind;
     // Remote backends (host/oss) upload the HTML to a server and hand back a
     // shareable link — say so in the prompt so the user knows the page leaves
     // their machine before they approve.
     const prompt =
       this.publisher.kind === 'local'
         ? `Publish ${shortenPath(relativePath)} as an interactive Artifact and open it in your browser.`
-        : `Publish ${shortenPath(relativePath)} as an interactive Artifact. This uploads the page to a remote host (${this.publisher.kind}) and opens the shareable link in your browser.`;
+        : `Publish ${shortenPath(relativePath)} as an interactive Artifact. This uploads the page to a remote host (${backendLabel}) and opens the shareable link in your browser.`;
     const details: ToolInfoConfirmationDetails = {
       type: 'info',
       title: 'Publish Artifact',
@@ -173,10 +181,7 @@ class ArtifactToolInvocation extends BaseToolInvocation<
     } catch (err) {
       // A user-initiated cancel (Esc / aborted signal) is not a failure —
       // surface it as a cancellation rather than a publish error.
-      if (
-        signal.aborted ||
-        (err instanceof Error && err.name === 'AbortError')
-      ) {
+      if (signal.aborted || isAbortError(err)) {
         const message = 'Artifact publishing was cancelled.';
         return {
           llmContent: message,

--- a/packages/core/src/tools/artifact/artifact-tool.ts
+++ b/packages/core/src/tools/artifact/artifact-tool.ts
@@ -89,10 +89,17 @@ class ArtifactToolInvocation extends BaseToolInvocation<
       this.params.file_path,
       this.config.getTargetDir(),
     );
+    // Remote backends (host/oss) upload the HTML to a server and hand back a
+    // shareable link — say so in the prompt so the user knows the page leaves
+    // their machine before they approve.
+    const prompt =
+      this.publisher.kind === 'local'
+        ? `Publish ${shortenPath(relativePath)} as an interactive Artifact and open it in your browser.`
+        : `Publish ${shortenPath(relativePath)} as an interactive Artifact. This uploads the page to a remote host (${this.publisher.kind}) and opens the shareable link in your browser.`;
     const details: ToolInfoConfirmationDetails = {
       type: 'info',
       title: 'Publish Artifact',
-      prompt: `Publish ${shortenPath(relativePath)} as an interactive Artifact and open it in your browser.`,
+      prompt,
       onConfirm: async () => {
         // Persistence handled by coreToolScheduler via PM rules.
       },
@@ -164,6 +171,19 @@ class ArtifactToolInvocation extends BaseToolInvocation<
       url = published.url;
       filePath = published.filePath;
     } catch (err) {
+      // A user-initiated cancel (Esc / aborted signal) is not a failure —
+      // surface it as a cancellation rather than a publish error.
+      if (
+        signal.aborted ||
+        (err instanceof Error && err.name === 'AbortError')
+      ) {
+        const message = 'Artifact publishing was cancelled.';
+        return {
+          llmContent: message,
+          returnDisplay: message,
+          error: { message, type: ToolErrorType.EXECUTION_FAILED },
+        };
+      }
       const message = `Failed to publish artifact: ${getErrorMessage(err)}`;
       return {
         llmContent: message,
@@ -197,10 +217,9 @@ class ArtifactToolInvocation extends BaseToolInvocation<
 }
 
 /**
- * The Artifact tool (option B): publishes a self-contained HTML fragment as a
- * local interactive page and opens it. Backend is pluggable via
- * {@link ArtifactPublisher} so remote/shared publishing (option C) can drop in
- * later without changing the tool.
+ * The Artifact tool: publishes a self-contained HTML fragment as an interactive
+ * page and opens it. The backend is pluggable via {@link ArtifactPublisher}
+ * (local file://, a custom upload command, or native OSS).
  */
 export class ArtifactTool extends BaseDeclarativeTool<
   ArtifactToolParams,

--- a/packages/core/src/tools/artifact/artifact-tool.ts
+++ b/packages/core/src/tools/artifact/artifact-tool.ts
@@ -100,7 +100,9 @@ class ArtifactToolInvocation extends BaseToolInvocation<
     );
     const backendLabel =
       this.publisher.kind === 'host' ? 'custom upload' : this.publisher.kind;
-    const openSuffix = this.shouldAutoOpen ? ' and open it in your browser' : '';
+    const openSuffix = this.shouldAutoOpen
+      ? ' and open it in your browser'
+      : '';
     const remoteOpenSuffix = this.shouldAutoOpen
       ? ' and opens the shareable link in your browser'
       : '';
@@ -193,7 +195,6 @@ class ArtifactToolInvocation extends BaseToolInvocation<
         return {
           llmContent: message,
           returnDisplay: message,
-          error: { message, type: ToolErrorType.EXECUTION_FAILED },
         };
       }
       const message = `Failed to publish artifact: ${getErrorMessage(err)}`;

--- a/packages/core/src/tools/artifact/create-publisher.ts
+++ b/packages/core/src/tools/artifact/create-publisher.ts
@@ -11,9 +11,9 @@ import { HostPublisher } from './host-publisher.js';
 import { OssPublisher } from './oss-publisher.js';
 
 /**
- * Selects the artifact publisher from config: `oss` (option C, native Aliyun
- * OSS), `host` (option C, upload via a user command), or `local` (option B,
- * file:// on disk; the default). A misconfigured `host`/`oss` selection still
+ * Selects the artifact publisher from config: `oss` (native Aliyun OSS),
+ * `host` (upload via a user command), or `local` (file:// on disk, the
+ * default). A misconfigured `host`/`oss` selection still
  * returns the publisher, which throws an actionable error at publish time
  * rather than silently falling back.
  */

--- a/packages/core/src/tools/artifact/publisher.ts
+++ b/packages/core/src/tools/artifact/publisher.ts
@@ -9,8 +9,8 @@ import path from 'node:path';
 
 /**
  * Backend-agnostic contract for publishing an artifact. The local backend
- * (option B) writes to disk and returns a file:// URL; a future host backend
- * (option C) uploads to a user-configured static host and returns an https://
+ * writes to disk and returns a file:// URL; the host/oss backends upload to a
+ * configured destination and return an https://
  * link. The {@link ArtifactTool} depends only on this interface so backends are
  * swappable without touching the tool.
  */
@@ -47,7 +47,7 @@ export interface PublishedArtifact {
 }
 
 /**
- * Config for the host publisher (option C). The artifact is uploaded by running
+ * Config for the host publisher. The artifact is uploaded by running
  * a user-supplied command; `{file}` (the local HTML path) and `{key}` (the
  * remote object key) are substituted, and `urlTemplate`'s `{key}` yields the
  * shareable URL. Credentials live in the user's command/environment — qwen
@@ -63,7 +63,7 @@ export interface ArtifactHostConfig {
 }
 
 /**
- * Config for the native Aliyun OSS publisher (option C, zero-dependency). The
+ * Config for the native Aliyun OSS publisher (zero-dependency). The
  * artifact is uploaded with a self-signed PUT Object request. Credentials come
  * from the environment (OSS_* / ALIBABA_CLOUD_*), never from settings.
  */

--- a/packages/core/src/tools/artifact/publisher.ts
+++ b/packages/core/src/tools/artifact/publisher.ts
@@ -14,9 +14,11 @@ import path from 'node:path';
  * link. The {@link ArtifactTool} depends only on this interface so backends are
  * swappable without touching the tool.
  */
+export type ArtifactPublisherKind = 'local' | 'host' | 'oss';
+
 export interface ArtifactPublisher {
   /** Backend identifier, e.g. 'local'. */
-  readonly kind: string;
+  readonly kind: ArtifactPublisherKind;
   /**
    * Publishes (or redeploys) the document. Implementations MUST be idempotent
    * for a given {@link PublishArtifactInput.id}: the same id redeploys to the


### PR DESCRIPTION
Follow-up to #5557 (the Artifact tool). Three small fixes that were ready just after that PR merged:

- **Backend-aware confirmation** — the publish confirmation dialog now states that `host`/`oss` backends upload the page to a remote host, so the user knows it leaves their machine before approving. `local` stays local-only.
- **Cancellation handling** — a user-initiated cancel (aborted signal / `AbortError`) during publish is reported as a cancellation instead of a publish failure.
- **JSDoc cleanup** — drop internal "option B/C" design-doc references from public comments.

Tests: backend-aware prompt + cancellation cases added; full artifact suite green (96 tests), `tsc --noEmit` (core) and `eslint` clean.
