### PR TITLE
[codex] Support artifact auto-open setting

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -974,6 +974,21 @@ describe('loadCliConfig', () => {
     expect(config.getPreventSystemSleepEnabled()).toBe(false);
   });
 
+  it('should propagate artifact auto-open setting', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+    const config = await loadCliConfig(
+      {
+        artifact: {
+          autoOpen: false,
+        },
+      },
+      argv,
+    );
+
+    expect(config.shouldAutoOpenArtifact()).toBe(false);
+  });
+
   it('places session-injected (ACP/IDE) MCP servers at the top precedence tier', async () => {
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments();

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1922,6 +1922,7 @@ export async function loadCliConfig(
     cronEnabled: settings.experimental?.cron ?? true,
     agentTeamEnabled: settings.experimental?.agentTeam ?? false,
     artifactEnabled: settings.experimental?.artifact ?? false,
+    artifactAutoOpen: settings.artifact?.autoOpen ?? true,
     artifactPublisher: settings.artifact?.publisher ?? 'local',
     artifactHost: settings.artifact?.host
       ? {

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -2804,6 +2804,16 @@ const SETTINGS_SCHEMA = {
       'Configuration for the experimental Artifact tool (enable it via experimental.artifact). Selects the publish backend and, for the host backend, the upload command and shareable URL template.',
     showInDialog: false,
     properties: {
+      autoOpen: {
+        type: 'boolean',
+        label: 'Auto-open Artifacts',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: true,
+        description:
+          'Open published artifacts in the browser automatically. Set to false to publish without launching a browser. QWEN_ARTIFACT_NO_AUTO_OPEN=1 overrides this setting.',
+        showInDialog: false,
+      },
       publisher: {
         type: 'enum',
         label: 'Artifact Publisher',

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1033,17 +1033,35 @@ describe('Server Config (config.ts)', () => {
     });
 
     describe('shouldAutoOpenArtifact', () => {
-      const originalNoAutoOpen = process.env['QWEN_ARTIFACT_NO_AUTO_OPEN'];
+      const browserEnvKeys = [
+        'QWEN_ARTIFACT_NO_AUTO_OPEN',
+        'BROWSER',
+        'CI',
+        'DEBIAN_FRONTEND',
+        'SSH_CONNECTION',
+        'DISPLAY',
+        'WAYLAND_DISPLAY',
+        'MIR_SOCKET',
+      ] as const;
+      const originalEnv: Partial<
+        Record<(typeof browserEnvKeys)[number], string>
+      > = {};
 
       beforeEach(() => {
-        delete process.env['QWEN_ARTIFACT_NO_AUTO_OPEN'];
+        for (const key of browserEnvKeys) {
+          originalEnv[key] = process.env[key];
+          delete process.env[key];
+        }
+        process.env['DISPLAY'] = ':0';
       });
 
       afterEach(() => {
-        if (originalNoAutoOpen === undefined) {
-          delete process.env['QWEN_ARTIFACT_NO_AUTO_OPEN'];
-        } else {
-          process.env['QWEN_ARTIFACT_NO_AUTO_OPEN'] = originalNoAutoOpen;
+        for (const key of browserEnvKeys) {
+          if (originalEnv[key] === undefined) {
+            delete process.env[key];
+          } else {
+            process.env[key] = originalEnv[key];
+          }
         }
       });
 
@@ -1074,6 +1092,15 @@ describe('Server Config (config.ts)', () => {
           ...baseParams,
           artifactAutoOpen: true,
           noBrowser: true,
+        });
+        expect(config.shouldAutoOpenArtifact()).toBe(false);
+      });
+
+      it('honors CI browser launch suppression', () => {
+        process.env['CI'] = 'true';
+        const config = new Config({
+          ...baseParams,
+          artifactAutoOpen: true,
         });
         expect(config.shouldAutoOpenArtifact()).toBe(false);
       });

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1032,6 +1032,44 @@ describe('Server Config (config.ts)', () => {
       });
     });
 
+    describe('shouldAutoOpenArtifact', () => {
+      const originalNoAutoOpen = process.env['QWEN_ARTIFACT_NO_AUTO_OPEN'];
+
+      beforeEach(() => {
+        delete process.env['QWEN_ARTIFACT_NO_AUTO_OPEN'];
+      });
+
+      afterEach(() => {
+        if (originalNoAutoOpen === undefined) {
+          delete process.env['QWEN_ARTIFACT_NO_AUTO_OPEN'];
+        } else {
+          process.env['QWEN_ARTIFACT_NO_AUTO_OPEN'] = originalNoAutoOpen;
+        }
+      });
+
+      it('auto-opens artifacts by default', () => {
+        const config = new Config(baseParams);
+        expect(config.shouldAutoOpenArtifact()).toBe(true);
+      });
+
+      it('honors artifact.autoOpen=false from settings', () => {
+        const config = new Config({
+          ...baseParams,
+          artifactAutoOpen: false,
+        });
+        expect(config.shouldAutoOpenArtifact()).toBe(false);
+      });
+
+      it('lets QWEN_ARTIFACT_NO_AUTO_OPEN override settings', () => {
+        process.env['QWEN_ARTIFACT_NO_AUTO_OPEN'] = '1';
+        const config = new Config({
+          ...baseParams,
+          artifactAutoOpen: true,
+        });
+        expect(config.shouldAutoOpenArtifact()).toBe(false);
+      });
+    });
+
     it('skips inline MCP discovery by default (progressive availability)', async () => {
       const config = new Config({ ...baseParams });
       await config.initialize();

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1068,6 +1068,15 @@ describe('Server Config (config.ts)', () => {
         });
         expect(config.shouldAutoOpenArtifact()).toBe(false);
       });
+
+      it('honors global browser launch suppression', () => {
+        const config = new Config({
+          ...baseParams,
+          artifactAutoOpen: true,
+          noBrowser: true,
+        });
+        expect(config.shouldAutoOpenArtifact()).toBe(false);
+      });
     });
 
     it('skips inline MCP discovery by default (progressive availability)', async () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -4003,7 +4003,7 @@ export class Config {
 
   shouldAutoOpenArtifact(): boolean {
     if (process.env['QWEN_ARTIFACT_NO_AUTO_OPEN'] === '1') return false;
-    return this.artifactAutoOpen;
+    return this.artifactAutoOpen && !this.isBrowserLaunchSuppressed();
   }
 
   isWorkflowsEnabled(): boolean {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -829,6 +829,7 @@ export interface ConfigParameters {
   agentTeamEnabled?: boolean;
   workflowsEnabled?: boolean;
   artifactEnabled?: boolean;
+  artifactAutoOpen?: boolean;
   artifactPublisher?: 'local' | 'host' | 'oss';
   artifactHost?: ArtifactHostConfig;
   artifactOss?: ArtifactOssConfig;
@@ -1280,6 +1281,7 @@ export class Config {
   private readonly cronEnabled: boolean = true;
   private readonly agentTeamEnabled: boolean = false;
   private readonly artifactEnabled: boolean = false;
+  private readonly artifactAutoOpen: boolean = true;
   private readonly artifactPublisher: 'local' | 'host' | 'oss' = 'local';
   private readonly artifactHost?: ArtifactHostConfig;
   private readonly artifactOss?: ArtifactOssConfig;
@@ -1488,6 +1490,7 @@ export class Config {
     this.cronEnabled = params.cronEnabled ?? true;
     this.agentTeamEnabled = params.agentTeamEnabled ?? false;
     this.artifactEnabled = params.artifactEnabled ?? false;
+    this.artifactAutoOpen = params.artifactAutoOpen ?? true;
     this.artifactPublisher = params.artifactPublisher ?? 'local';
     this.artifactHost = params.artifactHost;
     this.artifactOss = params.artifactOss;
@@ -3996,6 +3999,11 @@ export class Config {
 
   getArtifactOssConfig(): ArtifactOssConfig | undefined {
     return this.artifactOss;
+  }
+
+  shouldAutoOpenArtifact(): boolean {
+    if (process.env['QWEN_ARTIFACT_NO_AUTO_OPEN'] === '1') return false;
+    return this.artifactAutoOpen;
   }
 
   isWorkflowsEnabled(): boolean {

--- a/packages/core/src/tools/artifact/artifact-tool.test.ts
+++ b/packages/core/src/tools/artifact/artifact-tool.test.ts
@@ -55,6 +55,11 @@ describe('ArtifactTool', () => {
     vi.restoreAllMocks();
   });
 
+  it('describes browser opening as settings-dependent', () => {
+    expect(tool.description).toContain('depending on settings');
+    expect(tool.description).not.toContain('and opens it in the browser');
+  });
+
   it('publishes a fragment, wraps it, and opens the url', async () => {
     const file = await writeFragment('page.html', '<h1>Report</h1>');
     const res = await tool
@@ -192,6 +197,35 @@ describe('ArtifactTool', () => {
       throw new Error(`Unexpected confirmation type: ${details.type}`);
     }
     expect(details.prompt).toBe('Publish p.html as an interactive Artifact.');
+  });
+
+  it('reuses the confirmation auto-open decision during execution', async () => {
+    const shouldAutoOpenArtifact = vi
+      .fn()
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false);
+    const consistentTool = new ArtifactTool(
+      {
+        ...makeConfig(),
+        shouldAutoOpenArtifact,
+      } as unknown as Config,
+      new LocalPublisher(outDir),
+      openSpy as unknown as UrlOpener,
+    );
+    const file = await writeFragment('p.html', '<p>x</p>');
+    const invocation = consistentTool.build({ file_path: file });
+
+    const details = await invocation.getConfirmationDetails(signal);
+    const res = await invocation.execute(signal);
+
+    expect(details.type).toBe('info');
+    if (details.type !== 'info') {
+      throw new Error(`Unexpected confirmation type: ${details.type}`);
+    }
+    expect(details.prompt).toContain('and open it in your browser');
+    expect(res.error).toBeUndefined();
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(shouldAutoOpenArtifact).toHaveBeenCalledTimes(1);
   });
 
   it('rejects a relative file_path at build time', () => {

--- a/packages/core/src/tools/artifact/artifact-tool.test.ts
+++ b/packages/core/src/tools/artifact/artifact-tool.test.ts
@@ -27,6 +27,8 @@ describe('ArtifactTool', () => {
     ({
       getFileSystemService: () => new StandardFileSystemService(),
       getTargetDir: () => workdir,
+      shouldAutoOpenArtifact: () =>
+        process.env['QWEN_ARTIFACT_NO_AUTO_OPEN'] !== '1',
     }) as unknown as Config;
 
   const writeFragment = async (name: string, content: string) => {
@@ -151,6 +153,45 @@ describe('ArtifactTool', () => {
     const res = await tool.build({ file_path: file }).execute(signal);
     expect(res.error).toBeUndefined();
     expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips auto-open when disabled by settings', async () => {
+    const file = await writeFragment('p.html', '<p>x</p>');
+    const noAutoOpenTool = new ArtifactTool(
+      {
+        ...makeConfig(),
+        shouldAutoOpenArtifact: () => false,
+      } as unknown as Config,
+      new LocalPublisher(outDir),
+      openSpy as unknown as UrlOpener,
+    );
+
+    const res = await noAutoOpenTool.build({ file_path: file }).execute(signal);
+
+    expect(res.error).toBeUndefined();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('omits browser launch from confirmation when auto-open is disabled', async () => {
+    const file = await writeFragment('p.html', '<p>x</p>');
+    const noAutoOpenTool = new ArtifactTool(
+      {
+        ...makeConfig(),
+        shouldAutoOpenArtifact: () => false,
+      } as unknown as Config,
+      new LocalPublisher(outDir),
+      openSpy as unknown as UrlOpener,
+    );
+
+    const details = await noAutoOpenTool
+      .build({ file_path: file })
+      .getConfirmationDetails(signal);
+
+    expect(details.type).toBe('info');
+    if (details.type !== 'info') {
+      throw new Error(`Unexpected confirmation type: ${details.type}`);
+    }
+    expect(details.prompt).toBe('Publish p.html as an interactive Artifact.');
   });
 
   it('rejects a relative file_path at build time', () => {

--- a/packages/core/src/tools/artifact/artifact-tool.ts
+++ b/packages/core/src/tools/artifact/artifact-tool.ts
@@ -43,7 +43,7 @@ export interface ArtifactToolParams {
   title?: string;
 }
 
-const DESCRIPTION = `Publishes a self-contained HTML page as an interactive Artifact and opens it in the browser (returning a shareable link when a remote host is configured). Use it to turn session output into a durable, interactive page — a PR walkthrough, an architecture tour, a project dashboard.
+const DESCRIPTION = `Publishes a self-contained HTML page as an interactive Artifact, optionally opens it in the browser depending on settings, and returns a shareable link when a remote host is configured. Use it to turn session output into a durable, interactive page — a PR walkthrough, an architecture tour, a project dashboard.
 
 Workflow:
 - Write the page to a file first (via Write/Edit), then call Artifact with that file's absolute path.
@@ -62,6 +62,8 @@ class ArtifactToolInvocation extends BaseToolInvocation<
   ArtifactToolParams,
   ToolResult
 > {
+  private readonly shouldAutoOpen: boolean;
+
   constructor(
     private readonly config: Config,
     private readonly publisher: ArtifactPublisher,
@@ -69,6 +71,7 @@ class ArtifactToolInvocation extends BaseToolInvocation<
     params: ArtifactToolParams,
   ) {
     super(params);
+    this.shouldAutoOpen = config.shouldAutoOpenArtifact();
   }
 
   override getDescription(): string {
@@ -89,12 +92,11 @@ class ArtifactToolInvocation extends BaseToolInvocation<
       this.params.file_path,
       this.config.getTargetDir(),
     );
-    const autoOpen = this.config.shouldAutoOpenArtifact();
     const details: ToolInfoConfirmationDetails = {
       type: 'info',
       title: 'Publish Artifact',
       prompt: `Publish ${shortenPath(relativePath)} as an interactive Artifact${
-        autoOpen ? ' and open it in your browser' : ''
+        this.shouldAutoOpen ? ' and open it in your browser' : ''
       }.`,
       onConfirm: async () => {
         // Persistence handled by coreToolScheduler via PM rules.
@@ -177,7 +179,7 @@ class ArtifactToolInvocation extends BaseToolInvocation<
 
     // Open in the browser unless disabled. Best-effort: never fail the publish
     // because the browser could not be launched.
-    if (this.config.shouldAutoOpenArtifact()) {
+    if (this.shouldAutoOpen) {
       try {
         await this.openUrl(url, {
           allowFile: true,

--- a/packages/core/src/tools/artifact/artifact-tool.ts
+++ b/packages/core/src/tools/artifact/artifact-tool.ts
@@ -54,7 +54,7 @@ Workflow:
 
 To update an artifact, call Artifact again with the SAME file path: it redeploys to the same URL. A different path creates a separate Artifact.
 
-Set QWEN_ARTIFACT_NO_AUTO_OPEN=1 to publish without launching a browser.`;
+Set artifact.autoOpen=false in settings.json, or QWEN_ARTIFACT_NO_AUTO_OPEN=1, to publish without launching a browser.`;
 
 const debugLogger = createDebugLogger('artifact');
 
@@ -79,7 +79,7 @@ class ArtifactToolInvocation extends BaseToolInvocation<
     return `Publishing artifact from ${shortenPath(relativePath)}`;
   }
 
-  /** Publishing writes outside the project and opens a browser — always ask. */
+  /** Publishing writes outside the project and may open a browser — always ask. */
   override getDefaultPermission(): Promise<PermissionDecision> {
     return Promise.resolve('ask');
   }
@@ -89,10 +89,13 @@ class ArtifactToolInvocation extends BaseToolInvocation<
       this.params.file_path,
       this.config.getTargetDir(),
     );
+    const autoOpen = this.config.shouldAutoOpenArtifact();
     const details: ToolInfoConfirmationDetails = {
       type: 'info',
       title: 'Publish Artifact',
-      prompt: `Publish ${shortenPath(relativePath)} as an interactive Artifact and open it in your browser.`,
+      prompt: `Publish ${shortenPath(relativePath)} as an interactive Artifact${
+        autoOpen ? ' and open it in your browser' : ''
+      }.`,
       onConfirm: async () => {
         // Persistence handled by coreToolScheduler via PM rules.
       },
@@ -174,7 +177,7 @@ class ArtifactToolInvocation extends BaseToolInvocation<
 
     // Open in the browser unless disabled. Best-effort: never fail the publish
     // because the browser could not be launched.
-    if (process.env['QWEN_ARTIFACT_NO_AUTO_OPEN'] !== '1') {
+    if (this.config.shouldAutoOpenArtifact()) {
       try {
         await this.openUrl(url, {
           allowFile: true,

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -2683,6 +2683,11 @@
       "description": "Configuration for the experimental Artifact tool (enable it via experimental.artifact). Selects the publish backend and, for the host backend, the upload command and shareable URL template.",
       "type": "object",
       "properties": {
+        "autoOpen": {
+          "description": "Open published artifacts in the browser automatically. Set to false to publish without launching a browser. QWEN_ARTIFACT_NO_AUTO_OPEN=1 overrides this setting.",
+          "type": "boolean",
+          "default": true
+        },
         "publisher": {
           "description": "Where artifacts are published: 'local' (a file:// page on disk, the default), 'host' (upload via artifact.host.uploadCommand and return a shareable link), or 'oss' (native Aliyun OSS upload). Options: local, host, oss",
           "enum": [


### PR DESCRIPTION
## What this PR does

Adds a settings.json option that lets users publish Artifacts without automatically launching a browser. The existing environment variable override continues to work and takes precedence over the setting.

The Artifact confirmation copy now reflects whether the publish will open the browser, and the generated settings schema includes the new option for editor validation and completion.

## Why it's needed

Artifact enablement can already be configured in settings.json, but suppressing browser launch required an environment variable. This makes the behavior configurable from the same settings surface as the rest of the Artifact feature.

## Reviewer Test Plan

### How to verify

Set `experimental.artifact` to `true` and `artifact.autoOpen` to `false`, then publish an Artifact. The Artifact should still be published successfully, but the browser should not launch. Set `QWEN_ARTIFACT_NO_AUTO_OPEN=1` and confirm it still suppresses browser launch regardless of the settings value.

Local checks run: `npx vitest run src/config/config.test.ts src/tools/artifact/artifact-tool.test.ts` from `packages/core`; `npx vitest run src/config/config.test.ts` from `packages/cli`; `npm run typecheck`; `npm run build`.

### Evidence (Before & After)

N/A for screenshots; this is a configuration and tool behavior change covered by unit tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local development checkout on macOS. `npm run build` completed successfully with existing VS Code companion curly-rule warnings and Browserslist freshness warnings.

## Risk & Scope

- Main risk or tradeoff: Low; this only changes Artifact auto-open gating and keeps the existing environment variable override.
- Not validated / out of scope: Manual browser launch behavior on Windows and Linux was not tested locally.
- Breaking changes / migration notes: None. Existing behavior remains the default because `artifact.autoOpen` defaults to `true`.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

新增一个 settings.json 配置项，让用户可以发布 Artifact 但不自动拉起浏览器。现有环境变量覆盖仍然保留，并且优先级高于 settings。

Artifact 的确认文案现在会根据是否自动打开浏览器调整，生成的 settings schema 也包含这个新配置，方便编辑器校验和补全。

## Why it's needed

Artifact 开关已经可以通过 settings.json 配置，但关闭发布后的浏览器自动打开仍然只能依赖环境变量。这个改动把相关行为补齐到同一个 settings 配置入口里。

## Reviewer Test Plan

### How to verify

把 `experimental.artifact` 设为 `true`，并把 `artifact.autoOpen` 设为 `false`，然后发布一个 Artifact。Artifact 应该正常发布，但浏览器不应自动打开。再设置 `QWEN_ARTIFACT_NO_AUTO_OPEN=1`，确认它仍然会无视 settings 值并阻止浏览器自动打开。

本地已运行检查：在 `packages/core` 下运行 `npx vitest run src/config/config.test.ts src/tools/artifact/artifact-tool.test.ts`；在 `packages/cli` 下运行 `npx vitest run src/config/config.test.ts`；运行 `npm run typecheck`；运行 `npm run build`。

### Evidence (Before & After)

无截图；这是配置和工具行为变更，已由单元测试覆盖。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 本地开发 checkout。`npm run build` 成功完成，过程中出现仓库已有的 VS Code companion curly-rule warnings 和 Browserslist freshness warnings。

## Risk & Scope

- Main risk or tradeoff: 风险较低；只调整 Artifact 自动打开浏览器的判断，并保留现有环境变量覆盖。
- Not validated / out of scope: 未在本地手动验证 Windows 和 Linux 上的浏览器打开行为。
- Breaking changes / migration notes: 无。`artifact.autoOpen` 默认值为 `true`，因此现有默认行为不变。

## Linked Issues

N/A

</details>
