### PR TITLE
fix(cli): harden ACP session list pagination params

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -5302,41 +5302,40 @@ describe('QwenAgent unstable_listSessions cursor parsing', () => {
     return { agent, agentPromise };
   }
 
-  it.each(['abc', 'Infinity', '-Infinity'])(
-    'rejects invalid cursor %s before listing sessions',
-    async (cursor) => {
-      const { agent, agentPromise } = await bootAgent();
+  it('rejects invalid cursors before listing sessions', async () => {
+    const { agent, agentPromise } = await bootAgent();
 
-      try {
+    try {
+      for (const cursor of ['abc', 'Infinity', '-Infinity']) {
         await expect(
           agent.unstable_listSessions({ cwd: '/tmp/project', cursor }),
         ).rejects.toThrow(
           `Invalid cursor: "${cursor}" is not a valid numeric cursor`,
         );
-        expect(SessionService).not.toHaveBeenCalled();
-      } finally {
-        mockConnectionState.resolve();
-        await agentPromise;
       }
-    },
-  );
+      expect(SessionService).not.toHaveBeenCalled();
+    } finally {
+      mockConnectionState.resolve();
+      await agentPromise;
+    }
+  });
 
-  it.each([undefined, null, ''])(
-    'treats %s cursor as absent',
-    async (cursor) => {
-      const listSessions = vi.fn().mockResolvedValue({
-        items: [],
-        nextCursor: undefined,
-      });
-      vi.mocked(SessionService).mockImplementation(
-        () =>
-          ({
-            listSessions,
-          }) as unknown as InstanceType<typeof SessionService>,
-      );
-      const { agent, agentPromise } = await bootAgent();
+  it('treats absent cursor values as no cursor', async () => {
+    const listSessions = vi.fn().mockResolvedValue({
+      items: [],
+      nextCursor: undefined,
+    });
+    vi.mocked(SessionService).mockImplementation(
+      () =>
+        ({
+          listSessions,
+        }) as unknown as InstanceType<typeof SessionService>,
+    );
+    const { agent, agentPromise } = await bootAgent();
 
-      try {
+    try {
+      for (const cursor of [undefined, null, '']) {
+        listSessions.mockClear();
         await expect(
           agent.unstable_listSessions({ cwd: '/tmp/project', cursor }),
         ).resolves.toEqual({
@@ -5347,12 +5346,95 @@ describe('QwenAgent unstable_listSessions cursor parsing', () => {
           cursor: undefined,
           size: undefined,
         });
-      } finally {
-        mockConnectionState.resolve();
-        await agentPromise;
       }
-    },
-  );
+    } finally {
+      mockConnectionState.resolve();
+      await agentPromise;
+    }
+  });
+
+  it('ignores invalid _meta.size values', async () => {
+    const listSessions = vi.fn().mockResolvedValue({
+      items: [],
+      nextCursor: undefined,
+    });
+    vi.mocked(SessionService).mockImplementation(
+      () =>
+        ({
+          listSessions,
+        }) as unknown as InstanceType<typeof SessionService>,
+    );
+    const { agent, agentPromise } = await bootAgent();
+
+    try {
+      for (const size of [
+        Number.POSITIVE_INFINITY,
+        Number.NEGATIVE_INFINITY,
+        Number.NaN,
+        0.5,
+        Number.MAX_SAFE_INTEGER + 1,
+        '2',
+      ]) {
+        listSessions.mockClear();
+        await expect(
+          agent.unstable_listSessions({
+            cwd: '/tmp/project',
+            _meta: { size },
+          }),
+        ).resolves.toEqual({
+          sessions: [],
+          nextCursor: undefined,
+        });
+        expect(listSessions).toHaveBeenCalledWith({
+          cursor: undefined,
+          size: undefined,
+        });
+      }
+    } finally {
+      mockConnectionState.resolve();
+      await agentPromise;
+    }
+  });
+
+  it('clamps _meta.size to the supported page range', async () => {
+    const listSessions = vi.fn().mockResolvedValue({
+      items: [],
+      nextCursor: undefined,
+    });
+    vi.mocked(SessionService).mockImplementation(
+      () =>
+        ({
+          listSessions,
+        }) as unknown as InstanceType<typeof SessionService>,
+    );
+    const { agent, agentPromise } = await bootAgent();
+
+    try {
+      for (const { input, expected } of [
+        { input: 0, expected: 1 },
+        { input: -5, expected: 1 },
+        { input: 200, expected: 100 },
+      ]) {
+        listSessions.mockClear();
+        await expect(
+          agent.unstable_listSessions({
+            cwd: '/tmp/project',
+            _meta: { size: input },
+          }),
+        ).resolves.toEqual({
+          sessions: [],
+          nextCursor: undefined,
+        });
+        expect(listSessions).toHaveBeenCalledWith({
+          cursor: undefined,
+          size: expected,
+        });
+      }
+    } finally {
+      mockConnectionState.resolve();
+      await agentPromise;
+    }
+  });
 
   it('passes a finite cursor through to SessionService', async () => {
     const listSessions = vi.fn().mockResolvedValue({

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -5231,6 +5231,185 @@ describe('QwenAgent extMethod renameSession routing', () => {
   });
 });
 
+describe('QwenAgent unstable_listSessions cursor parsing', () => {
+  let capturedAgentFactory:
+    | ((conn: { closed: Promise<void> }) => {
+        unstable_listSessions: (
+          args: Record<string, unknown>,
+        ) => Promise<unknown>;
+      })
+    | undefined;
+
+  let mockConfig: Config;
+  let processExitSpy: MockInstance<typeof process.exit>;
+  let stdinDestroySpy: MockInstance<typeof process.stdin.destroy>;
+  let stdoutDestroySpy: MockInstance<typeof process.stdout.destroy>;
+
+  const mockArgv = {} as CliArgs;
+  const mockSettings = { merged: { mcpServers: {} } } as LoadedSettings;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRunExitCleanup.mockResolvedValue(undefined);
+    mockConnectionState.reset();
+    capturedAgentFactory = undefined;
+
+    vi.mocked(AgentSideConnection).mockImplementation((factory: unknown) => {
+      capturedAgentFactory = factory as typeof capturedAgentFactory;
+      return {
+        get closed() {
+          return mockConnectionState.promise;
+        },
+      } as unknown as InstanceType<typeof AgentSideConnection>;
+    });
+
+    mockConfig = {
+      initialize: vi.fn().mockResolvedValue(undefined),
+      waitForMcpReady: vi.fn().mockResolvedValue(undefined),
+      getHookSystem: vi.fn().mockReturnValue(undefined),
+      getDisableAllHooks: vi.fn().mockReturnValue(false),
+      hasHooksForEvent: vi.fn().mockReturnValue(false),
+      getModel: vi.fn().mockReturnValue('test-model'),
+      getWorkspaceContext: vi.fn().mockReturnValue({}),
+      getDebugMode: vi.fn().mockReturnValue(false),
+    } as unknown as Config;
+
+    processExitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as unknown as typeof process.exit);
+    stdinDestroySpy = vi
+      .spyOn(process.stdin, 'destroy')
+      .mockImplementation(() => process.stdin);
+    stdoutDestroySpy = vi
+      .spyOn(process.stdout, 'destroy')
+      .mockImplementation(() => process.stdout);
+  });
+
+  afterEach(() => {
+    processExitSpy.mockRestore();
+    stdinDestroySpy.mockRestore();
+    stdoutDestroySpy.mockRestore();
+  });
+
+  async function bootAgent() {
+    const agentPromise = runAcpAgent(mockConfig, mockSettings, mockArgv);
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    });
+    return { agent, agentPromise };
+  }
+
+  it.each(['abc', 'Infinity', '-Infinity'])(
+    'rejects invalid cursor %s before listing sessions',
+    async (cursor) => {
+      const { agent, agentPromise } = await bootAgent();
+
+      try {
+        await expect(
+          agent.unstable_listSessions({ cwd: '/tmp/project', cursor }),
+        ).rejects.toThrow(
+          `Invalid cursor: "${cursor}" is not a valid numeric cursor`,
+        );
+        expect(SessionService).not.toHaveBeenCalled();
+      } finally {
+        mockConnectionState.resolve();
+        await agentPromise;
+      }
+    },
+  );
+
+  it.each([undefined, null, ''])(
+    'treats %s cursor as absent',
+    async (cursor) => {
+      const listSessions = vi.fn().mockResolvedValue({
+        items: [],
+        nextCursor: undefined,
+      });
+      vi.mocked(SessionService).mockImplementation(
+        () =>
+          ({
+            listSessions,
+          }) as unknown as InstanceType<typeof SessionService>,
+      );
+      const { agent, agentPromise } = await bootAgent();
+
+      try {
+        await expect(
+          agent.unstable_listSessions({ cwd: '/tmp/project', cursor }),
+        ).resolves.toEqual({
+          sessions: [],
+          nextCursor: undefined,
+        });
+        expect(listSessions).toHaveBeenCalledWith({
+          cursor: undefined,
+          size: undefined,
+        });
+      } finally {
+        mockConnectionState.resolve();
+        await agentPromise;
+      }
+    },
+  );
+
+  it('passes a finite cursor through to SessionService', async () => {
+    const listSessions = vi.fn().mockResolvedValue({
+      items: [
+        {
+          sessionId: 'session-1',
+          cwd: '/tmp/project',
+          startTime: '2026-06-22T01:00:00.000Z',
+          prompt: 'hello',
+          mtime: 1_797_860_000_000,
+        },
+      ],
+      nextCursor: 1_797_859_999_000,
+    });
+    vi.mocked(SessionService).mockImplementation(
+      () =>
+        ({
+          listSessions,
+        }) as unknown as InstanceType<typeof SessionService>,
+    );
+    const { agent, agentPromise } = await bootAgent();
+
+    try {
+      await expect(
+        agent.unstable_listSessions({
+          cwd: '/tmp/project',
+          cursor: '1797860000000',
+          _meta: { size: 2 },
+        }),
+      ).resolves.toEqual({
+        sessions: [
+          {
+            _meta: {
+              createdAt: '2026-06-22T01:00:00.000Z',
+              startTime: '2026-06-22T01:00:00.000Z',
+              preview: 'hello',
+            },
+            cwd: '/tmp/project',
+            sessionId: 'session-1',
+            title: 'hello',
+            updatedAt: '2026-12-21T13:33:20.000Z',
+          },
+        ],
+        nextCursor: '1797859999000',
+      });
+      expect(SessionService).toHaveBeenCalledWith('/tmp/project');
+      expect(listSessions).toHaveBeenCalledWith({
+        cursor: 1_797_860_000_000,
+        size: 2,
+      });
+    } finally {
+      mockConnectionState.resolve();
+      await agentPromise;
+    }
+  });
+});
+
 // Tests for QwenAgent.loadSession() and QwenAgent.unstable_resumeSession()
 // — locks the session-existence guard, the resourceNotFound error contract,
 // and the resume-vs-load semantic difference (load replays UI history,

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -2506,6 +2506,16 @@ function createWorkspaceMcpBudget(
   });
 }
 
+const MAX_ACP_SESSION_PAGE_SIZE = 100;
+
+function normalizeAcpSessionListSize(value: unknown): number | undefined {
+  if (value == null) return undefined;
+  if (typeof value !== 'number' || !Number.isSafeInteger(value)) {
+    return undefined;
+  }
+  return Math.min(Math.max(value, 1), MAX_ACP_SESSION_PAGE_SIZE);
+}
+
 class QwenAgent implements Agent {
   private sessions: Map<string, Session> = new Map();
   private clientCapabilities: ClientCapabilities | undefined;
@@ -2881,11 +2891,7 @@ class QwenAgent implements Agent {
     // so the SDK's zod validator strips any top-level `size` the client sends
     // before it reaches this handler. Carry page size through `_meta.size`
     // (same pattern filesystem.ts uses for `_meta.bom` / `_meta.encoding`).
-    const metaSize = params._meta?.['size'];
-    const size =
-      typeof metaSize === 'number' && metaSize > 0
-        ? Math.floor(metaSize)
-        : undefined;
+    const size = normalizeAcpSessionListSize(params._meta?.['size']);
 
     const result = await runWithAcpRuntimeOutputDir(this.settings, cwd, () => {
       const sessionService = new SessionService(cwd);

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -2865,7 +2865,17 @@ class QwenAgent implements Agent {
     params: ListSessionsRequest,
   ): Promise<ListSessionsResponse> {
     const cwd = params.cwd || process.cwd();
-    const numericCursor = params.cursor ? Number(params.cursor) : undefined;
+    let numericCursor: number | undefined;
+    if (params.cursor != null && params.cursor !== '') {
+      const parsedCursor = Number(params.cursor);
+      if (!Number.isFinite(parsedCursor)) {
+        throw RequestError.invalidParams(
+          undefined,
+          `Invalid cursor: "${params.cursor}" is not a valid numeric cursor`,
+        );
+      }
+      numericCursor = parsedCursor;
+    }
 
     // The ACP spec's ListSessionsRequest doesn't include a page-size field,
     // so the SDK's zod validator strips any top-level `size` the client sends
@@ -2880,7 +2890,7 @@ class QwenAgent implements Agent {
     const result = await runWithAcpRuntimeOutputDir(this.settings, cwd, () => {
       const sessionService = new SessionService(cwd);
       return sessionService.listSessions({
-        cursor: Number.isNaN(numericCursor) ? undefined : numericCursor,
+        cursor: numericCursor,
         size,
       });
     });


### PR DESCRIPTION
## What this PR does

Hardens in-process ACP `session/list` pagination parameter parsing before calling `SessionService.listSessions`.

Invalid cursor values such as `Infinity`, `-Infinity`, and malformed strings now return ACP invalid params instead of being forwarded or silently treated as a missing cursor. Absent cursor values (`undefined`, `null`, and empty string) still mean "first page".

The PR also normalizes `_meta.size` to match the daemon session-list path: non-numeric, non-safe integer, fractional, and non-finite values are ignored, while valid integers are clamped to the supported `1..100` page-size range.

## Why it's needed

The daemon session-listing path already rejects non-finite cursors and clamps valid page sizes. The in-process ACP path had two inconsistent edges: it only checked `Number.isNaN` for cursors, so `Infinity` could reach the session service, and it accepted any numeric `_meta.size > 0`, so `Infinity` could become an unbounded page size and fractional values like `0.5` could become `0`.

## Reviewer Test Plan

### How to verify

Run:

```bash
npx vitest run src/acp-integration/acpAgent.test.ts -t "unstable_listSessions cursor parsing" --coverage.enabled=false
npx prettier --check packages/cli/src/acp-integration/acpAgent.ts packages/cli/src/acp-integration/acpAgent.test.ts
npx eslint packages/cli/src/acp-integration/acpAgent.ts packages/cli/src/acp-integration/acpAgent.test.ts
npm run build --workspace @qwen-code/qwen-code-core
npm run build --workspace @qwen-code/qwen-code
npm run typecheck --workspace @qwen-code/qwen-code
git diff --check
```

The focused test should cover invalid cursor rejection, absent cursor passthrough as `undefined`, invalid `_meta.size` falling back to the default path, page-size clamping, and finite cursor forwarding with `_meta.size`.

### Evidence (Before & After)

N/A — non-UI API validation change. Unit tests cover the before/after behavior: invalid cursor values are rejected before `SessionService` is constructed; `undefined`, `null`, and empty cursor still list the first page; invalid `_meta.size` values do not reach `SessionService`; and valid page sizes are clamped to `1..100`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Local Node/npm workspace. I ran focused Vitest, Prettier check, ESLint, core build, CLI build, CLI typecheck, and `git diff --check`.

## Risk & Scope

- Main risk or tradeoff: ACP clients that sent malformed/non-finite pagination parameters now get daemon-aligned validation behavior instead of silently inconsistent results.
- Not validated / out of scope: REST/daemon cursor and size handling, which already perform these bounds; broader whitespace cursor normalization across transports.
- Breaking changes / migration notes: None expected for valid clients. Omitted, `null`, and empty cursors continue to mean "first page"; valid integer sizes keep working within the supported page range.

## Linked Issues

Fixes #5614
Fixes #5619

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在调用 `SessionService.listSessions` 之前，强化 in-process ACP `session/list` 的分页参数解析。

`Infinity`、`-Infinity` 和格式错误的字符串等非法 cursor 现在会返回 ACP invalid params，而不是继续传给 session service 或被静默当成没有 cursor。缺省 cursor 值（`undefined`、`null` 和空字符串）仍然表示“第一页”。

这个 PR 也把 `_meta.size` 规范化为和 daemon session-list 路径一致：非数字、非安全整数、小数和非有限数字会被忽略；合法整数会被 clamp 到支持的 `1..100` page-size 范围。

## 为什么需要

daemon session-list 路径已经会拒绝非有限数字 cursor，并 clamp 合法 page size。in-process ACP 路径有两个不一致边界：它之前只用 `Number.isNaN` 检查 cursor，所以 `Infinity` 可能传到 session service；同时它接受任何 `> 0` 的数字 `_meta.size`，所以 `Infinity` 可能变成无界 page size，`0.5` 这类小数也可能变成 `0`。

## 审核测试计划

### 如何验证

运行：

```bash
npx vitest run src/acp-integration/acpAgent.test.ts -t "unstable_listSessions cursor parsing" --coverage.enabled=false
npx prettier --check packages/cli/src/acp-integration/acpAgent.ts packages/cli/src/acp-integration/acpAgent.test.ts
npx eslint packages/cli/src/acp-integration/acpAgent.ts packages/cli/src/acp-integration/acpAgent.test.ts
npm run build --workspace @qwen-code/qwen-code-core
npm run build --workspace @qwen-code/qwen-code
npm run typecheck --workspace @qwen-code/qwen-code
git diff --check
```

focused test 应覆盖非法 cursor 拒绝、缺省 cursor 按 `undefined` 传递、非法 `_meta.size` 回退到默认路径、page-size clamp，以及有限数字 cursor 携带 `_meta.size` 正常转发。

### 证据（修改前后）

N/A — 非 UI 的 API 校验变更。单元测试覆盖修改前后的行为：非法 cursor 会在构造 `SessionService` 前被拒绝；`undefined`、`null` 和空 cursor 仍然列出第一页；非法 `_meta.size` 不会传到 `SessionService`；合法 page size 会被 clamp 到 `1..100`。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### 环境（可选）

本地 Node/npm workspace。我运行了 focused Vitest、Prettier check、ESLint、core build、CLI build、CLI typecheck 和 `git diff --check`。

## 风险与范围

- 主要风险或取舍：发送格式错误或非有限数字分页参数的 ACP 客户端，现在会得到与 daemon 对齐的校验行为，而不是静默的不一致结果。
- 未验证 / 不在范围内：REST/daemon cursor 和 size 处理，它们已经执行这些边界校验；跨 transport 的空白字符串 cursor 统一规范化。
- 破坏性变更 / 迁移说明：对有效客户端预计无影响。省略 cursor、`null` 和空 cursor 仍然表示“第一页”；合法整数 size 在支持的页面范围内继续可用。

## 关联 Issue

Fixes #5614
Fixes #5619

## AI 辅助披露

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
