### PR TITLE
fix(cli): Fail dangling replayed tool calls

### DIFF
--- a/packages/cli/src/acp-integration/session/HistoryReplayer.test.ts
+++ b/packages/cli/src/acp-integration/session/HistoryReplayer.test.ts
@@ -372,6 +372,102 @@ describe('HistoryReplayer', () => {
       });
     });
 
+    it('should fail dangling calls before rethrowing replay errors', async () => {
+      const danglingRecord: ChatRecord = {
+        ...createAssistantRecord(''),
+        message: {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'call-missing',
+                name: 'run_shell_command',
+                args: { command: 'sleep 10' },
+              },
+            },
+          ],
+        },
+      };
+      const failingRecord = createUserRecord('this send fails');
+      sendUpdateSpy.mockImplementation(
+        async (update: Record<string, unknown>) => {
+          if (update['sessionUpdate'] === 'user_message_chunk') {
+            throw new Error('replay failed');
+          }
+        },
+      );
+
+      await expect(
+        replayer.replay([danglingRecord, failingRecord]),
+      ).rejects.toThrow('replay failed');
+
+      const updates = sentUpdates();
+      expect(updates.map((update) => update['sessionUpdate'])).toEqual([
+        'tool_call',
+        'user_message_chunk',
+        'tool_call_update',
+      ]);
+      expect(updates[2]).toMatchObject({
+        toolCallId: 'call-missing',
+        status: 'failed',
+      });
+    });
+
+    it('should continue failing dangling calls after a synthetic update error', async () => {
+      const record: ChatRecord = {
+        ...createAssistantRecord(''),
+        message: {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'call-a',
+                name: 'read_file',
+                args: { path: 'a.ts' },
+              },
+            },
+            {
+              functionCall: {
+                id: 'call-b',
+                name: 'read_file',
+                args: { path: 'b.ts' },
+              },
+            },
+          ],
+        },
+      };
+      sendUpdateSpy.mockImplementation(
+        async (update: Record<string, unknown>) => {
+          if (
+            update['sessionUpdate'] === 'tool_call_update' &&
+            update['toolCallId'] === 'call-a'
+          ) {
+            throw new Error('first synthetic failure failed');
+          }
+        },
+      );
+
+      await expect(replayer.replay([record])).rejects.toThrow(
+        'first synthetic failure failed',
+      );
+
+      const updates = sentUpdates();
+      expect(updates.map((update) => update['sessionUpdate'])).toEqual([
+        'tool_call',
+        'tool_call',
+        'tool_call_update',
+        'tool_call_update',
+      ]);
+      expect(updates[2]).toMatchObject({
+        toolCallId: 'call-a',
+        status: 'failed',
+      });
+      expect(updates[3]).toMatchObject({
+        toolCallId: 'call-b',
+        status: 'failed',
+      });
+    });
+
     it('should not fail function calls that have matching tool results', async () => {
       const records: ChatRecord[] = [
         {

--- a/packages/cli/src/acp-integration/session/HistoryReplayer.test.ts
+++ b/packages/cli/src/acp-integration/session/HistoryReplayer.test.ts
@@ -291,6 +291,7 @@ describe('HistoryReplayer', () => {
           },
         }),
       );
+      expect(sendUpdateSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should use function call id as callId when available', async () => {
@@ -369,6 +370,38 @@ describe('HistoryReplayer', () => {
       expect(sentUpdateContexts[1]).toEqual({
         activeRecordId: record.uuid,
         activeRecordTimestamp: record.timestamp,
+      });
+    });
+
+    it('should not synthesize missing-result failures for calls without source ids', async () => {
+      const records: ChatRecord[] = [
+        {
+          ...createAssistantRecord(''),
+          message: {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  name: 'read_file',
+                  args: { path: 'test.ts' },
+                },
+              },
+            ],
+          },
+        },
+        createToolResultRecord('read_file', 'File contents here'),
+      ];
+
+      await replayer.replay(records);
+
+      const updates = sentUpdates();
+      expect(updates.map((update) => update['sessionUpdate'])).toEqual([
+        'tool_call',
+        'tool_call_update',
+      ]);
+      expect(updates[1]).toMatchObject({
+        toolCallId: 'call-123',
+        status: 'completed',
       });
     });
 

--- a/packages/cli/src/acp-integration/session/HistoryReplayer.test.ts
+++ b/packages/cli/src/acp-integration/session/HistoryReplayer.test.ts
@@ -5,7 +5,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { HistoryReplayer } from './HistoryReplayer.js';
+import {
+  HistoryReplayer,
+  MISSING_TOOL_RESULT_MESSAGE,
+} from './HistoryReplayer.js';
 import type { SessionContext } from './types.js';
 import type {
   Config,
@@ -54,9 +57,6 @@ describe('HistoryReplayer', () => {
   });
 
   const toEpochMs = (ts: string) => new Date(ts).getTime();
-  const missingToolResultMessage =
-    'Tool result missing from saved history; the previous run likely ended ' +
-    'before this tool completed.';
   const sentUpdates = () =>
     sendUpdateSpy.mock.calls.map(
       (call: unknown[]) => call[0] as Record<string, unknown>,
@@ -352,7 +352,7 @@ describe('HistoryReplayer', () => {
             type: 'content',
             content: {
               type: 'text',
-              text: missingToolResultMessage,
+              text: MISSING_TOOL_RESULT_MESSAGE,
             },
           },
         ],
@@ -413,7 +413,7 @@ describe('HistoryReplayer', () => {
       });
     });
 
-    it('should continue failing dangling calls after a synthetic update error', async () => {
+    it('should throw dangling errors and continue failing later dangling calls', async () => {
       const record: ChatRecord = {
         ...createAssistantRecord(''),
         message: {
@@ -466,6 +466,52 @@ describe('HistoryReplayer', () => {
         toolCallId: 'call-b',
         status: 'failed',
       });
+    });
+
+    it('should aggregate replay and dangling cleanup errors', async () => {
+      const danglingRecord: ChatRecord = {
+        ...createAssistantRecord(''),
+        message: {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'call-missing',
+                name: 'run_shell_command',
+                args: { command: 'sleep 10' },
+              },
+            },
+          ],
+        },
+      };
+      const failingRecord = createUserRecord('this send fails');
+      sendUpdateSpy.mockImplementation(
+        async (update: Record<string, unknown>) => {
+          if (update['sessionUpdate'] === 'user_message_chunk') {
+            throw new Error('replay failed');
+          }
+          if (update['sessionUpdate'] === 'tool_call_update') {
+            throw new Error('dangling cleanup failed');
+          }
+        },
+      );
+
+      let caughtError: unknown;
+      try {
+        await replayer.replay([danglingRecord, failingRecord]);
+      } catch (error) {
+        caughtError = error;
+      }
+
+      expect(caughtError).toBeInstanceOf(AggregateError);
+      expect((caughtError as AggregateError).message).toBe(
+        'Replay and dangling-cleanup both failed',
+      );
+      expect(
+        (caughtError as AggregateError).errors.map((error) =>
+          error instanceof Error ? error.message : String(error),
+        ),
+      ).toEqual(['replay failed', 'dangling cleanup failed']);
     });
 
     it('should not fail function calls that have matching tool results', async () => {

--- a/packages/cli/src/acp-integration/session/HistoryReplayer.test.ts
+++ b/packages/cli/src/acp-integration/session/HistoryReplayer.test.ts
@@ -18,10 +18,22 @@ import type {
 describe('HistoryReplayer', () => {
   let mockContext: SessionContext;
   let sendUpdateSpy: ReturnType<typeof vi.fn>;
+  let setActiveRecordIdSpy: ReturnType<typeof vi.fn>;
+  let sentUpdateContexts: Array<{
+    activeRecordId: string | null;
+    activeRecordTimestamp: string | undefined;
+  }>;
   let replayer: HistoryReplayer;
 
   beforeEach(() => {
+    let activeRecordId: string | null = null;
+    let activeRecordTimestamp: string | undefined;
+    sentUpdateContexts = [];
     sendUpdateSpy = vi.fn().mockResolvedValue(undefined);
+    setActiveRecordIdSpy = vi.fn((id: string | null, timestamp?: string) => {
+      activeRecordId = id;
+      activeRecordTimestamp = timestamp;
+    });
     const mockToolRegistry = {
       getTool: vi.fn().mockReturnValue(null),
     } as unknown as ToolRegistry;
@@ -31,13 +43,24 @@ describe('HistoryReplayer', () => {
       config: {
         getToolRegistry: () => mockToolRegistry,
       } as unknown as Config,
-      sendUpdate: sendUpdateSpy,
-    };
+      sendUpdate: vi.fn(async (update) => {
+        sentUpdateContexts.push({ activeRecordId, activeRecordTimestamp });
+        await sendUpdateSpy(update);
+      }),
+      setActiveRecordId: setActiveRecordIdSpy,
+    } as unknown as SessionContext;
 
     replayer = new HistoryReplayer(mockContext);
   });
 
   const toEpochMs = (ts: string) => new Date(ts).getTime();
+  const missingToolResultMessage =
+    'Tool result missing from saved history; the previous run likely ended ' +
+    'before this tool completed.';
+  const sentUpdates = () =>
+    sendUpdateSpy.mock.calls.map(
+      (call: unknown[]) => call[0] as Record<string, unknown>,
+    );
 
   const createUserRecord = (text: string): ChatRecord => ({
     uuid: 'user-uuid',
@@ -295,6 +318,160 @@ describe('HistoryReplayer', () => {
         }),
       );
     });
+
+    it('should fail dangling function calls after replay completes', async () => {
+      const record: ChatRecord = {
+        ...createAssistantRecord(''),
+        message: {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'call-missing',
+                name: 'run_shell_command',
+                args: { command: 'sleep 10' },
+              },
+            },
+          ],
+        },
+      };
+
+      await replayer.replay([record]);
+
+      const updates = sentUpdates();
+      expect(updates.map((update) => update['sessionUpdate'])).toEqual([
+        'tool_call',
+        'tool_call_update',
+      ]);
+      expect(updates[1]).toMatchObject({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'call-missing',
+        status: 'failed',
+        content: [
+          {
+            type: 'content',
+            content: {
+              type: 'text',
+              text: missingToolResultMessage,
+            },
+          },
+        ],
+        _meta: {
+          toolName: 'run_shell_command',
+          provenance: 'builtin',
+          timestamp: toEpochMs(record.timestamp),
+        },
+      });
+      expect(setActiveRecordIdSpy).toHaveBeenCalledWith(
+        record.uuid,
+        record.timestamp,
+      );
+      expect(sentUpdateContexts[1]).toEqual({
+        activeRecordId: record.uuid,
+        activeRecordTimestamp: record.timestamp,
+      });
+    });
+
+    it('should not fail function calls that have matching tool results', async () => {
+      const records: ChatRecord[] = [
+        {
+          ...createAssistantRecord(''),
+          message: {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'call-123',
+                  name: 'read_file',
+                  args: { path: 'test.ts' },
+                },
+              },
+            ],
+          },
+        },
+        createToolResultRecord('read_file', 'File contents here'),
+      ];
+
+      await replayer.replay(records);
+
+      const updates = sentUpdates();
+      expect(updates.map((update) => update['sessionUpdate'])).toEqual([
+        'tool_call',
+        'tool_call_update',
+      ]);
+      expect(updates[1]).toMatchObject({
+        toolCallId: 'call-123',
+        status: 'completed',
+      });
+    });
+
+    it('should only fail dangling calls when matched and dangling calls are mixed', async () => {
+      const records: ChatRecord[] = [
+        {
+          ...createAssistantRecord(''),
+          message: {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'call-123',
+                  name: 'read_file',
+                  args: { path: 'test.ts' },
+                },
+              },
+              {
+                functionCall: {
+                  id: 'call-missing',
+                  name: 'run_shell_command',
+                  args: { command: 'sleep 10' },
+                },
+              },
+            ],
+          },
+        },
+        createToolResultRecord('read_file', 'File contents here'),
+      ];
+
+      await replayer.replay(records);
+
+      const updates = sentUpdates();
+      expect(updates.map((update) => update['sessionUpdate'])).toEqual([
+        'tool_call',
+        'tool_call',
+        'tool_call_update',
+        'tool_call_update',
+      ]);
+      expect(updates[2]).toMatchObject({
+        toolCallId: 'call-123',
+        status: 'completed',
+      });
+      expect(updates[3]).toMatchObject({
+        toolCallId: 'call-missing',
+        status: 'failed',
+      });
+    });
+
+    it('should not track skipped TodoWrite starts as dangling tool calls', async () => {
+      const record: ChatRecord = {
+        ...createAssistantRecord(''),
+        message: {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'todo-call',
+                name: 'todo_write',
+                args: { todos: [] },
+              },
+            },
+          ],
+        },
+      };
+
+      await replayer.replay([record]);
+
+      expect(sendUpdateSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('tool result replay', () => {
@@ -393,6 +570,40 @@ describe('HistoryReplayer', () => {
         }),
       );
     });
+
+    it('should use functionResponse id as callId when toolCallResult.callId is missing', async () => {
+      const record: ChatRecord = {
+        ...createToolResultRecord('test_tool'),
+        uuid: 'fallback-uuid',
+        message: {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'response-call-id',
+                name: 'test_tool',
+                response: { result: 'ok' },
+              },
+            },
+          ],
+        },
+        toolCallResult: {
+          callId: undefined as unknown as string,
+          responseParts: [],
+          resultDisplay: 'Result',
+          error: undefined,
+          errorType: undefined,
+        },
+      };
+
+      await replayer.replay([record]);
+
+      expect(sendUpdateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolCallId: 'response-call-id',
+        }),
+      );
+    });
   });
 
   describe('system records', () => {
@@ -426,7 +637,7 @@ describe('HistoryReplayer', () => {
               { text: "I'll read that file for you.", thought: true },
               {
                 functionCall: {
-                  id: 'call-read',
+                  id: 'call-123',
                   name: 'read_file',
                   args: { path: 'test.ts' },
                 },

--- a/packages/cli/src/acp-integration/session/HistoryReplayer.ts
+++ b/packages/cli/src/acp-integration/session/HistoryReplayer.ts
@@ -18,7 +18,7 @@ import type { SessionContext } from './types.js';
 import { MessageEmitter } from './emitters/MessageEmitter.js';
 import { ToolCallEmitter } from './emitters/ToolCallEmitter.js';
 
-const MISSING_TOOL_RESULT_MESSAGE =
+export const MISSING_TOOL_RESULT_MESSAGE =
   'Tool result missing from saved history; the previous run likely ended ' +
   'before this tool completed.';
 
@@ -75,6 +75,12 @@ export class HistoryReplayer {
         danglingError = error;
       }
 
+      if (replayError && danglingError) {
+        throw new AggregateError(
+          [replayError, danglingError],
+          'Replay and dangling-cleanup both failed',
+        );
+      }
       if (replayError) {
         throw replayError;
       }

--- a/packages/cli/src/acp-integration/session/HistoryReplayer.ts
+++ b/packages/cli/src/acp-integration/session/HistoryReplayer.ts
@@ -59,10 +59,28 @@ export class HistoryReplayer {
   async replay(records: ChatRecord[]): Promise<void> {
     this.pendingReplayToolCalls.clear();
     try {
-      for (const record of records) {
-        await this.replayRecord(record);
+      let replayError: unknown;
+      try {
+        for (const record of records) {
+          await this.replayRecord(record);
+        }
+      } catch (error) {
+        replayError = error;
       }
-      await this.failDanglingToolCalls();
+
+      let danglingError: unknown;
+      try {
+        await this.failDanglingToolCalls();
+      } catch (error) {
+        danglingError = error;
+      }
+
+      if (replayError) {
+        throw replayError;
+      }
+      if (danglingError) {
+        throw danglingError;
+      }
     } finally {
       this.pendingReplayToolCalls.clear();
       this.setActiveRecordId(null);
@@ -258,6 +276,7 @@ export class HistoryReplayer {
   }
 
   private async failDanglingToolCalls(): Promise<void> {
+    let firstError: unknown;
     for (const pending of this.pendingReplayToolCalls.values()) {
       this.setActiveRecordId(pending.recordId, pending.timestamp);
       try {
@@ -269,9 +288,14 @@ export class HistoryReplayer {
           error: new Error(MISSING_TOOL_RESULT_MESSAGE),
           timestamp: pending.timestamp,
         });
+      } catch (error) {
+        firstError ??= error;
       } finally {
         this.setActiveRecordId(null);
       }
+    }
+    if (firstError) {
+      throw firstError;
     }
   }
 

--- a/packages/cli/src/acp-integration/session/HistoryReplayer.ts
+++ b/packages/cli/src/acp-integration/session/HistoryReplayer.ts
@@ -18,6 +18,17 @@ import type { SessionContext } from './types.js';
 import { MessageEmitter } from './emitters/MessageEmitter.js';
 import { ToolCallEmitter } from './emitters/ToolCallEmitter.js';
 
+const MISSING_TOOL_RESULT_MESSAGE =
+  'Tool result missing from saved history; the previous run likely ended ' +
+  'before this tool completed.';
+
+interface PendingReplayToolCall {
+  callId: string;
+  toolName: string;
+  timestamp?: string;
+  recordId: string;
+}
+
 /**
  * Handles replaying session history on session load.
  *
@@ -29,6 +40,10 @@ export class HistoryReplayer {
   private readonly ctx: SessionContext;
   private readonly messageEmitter: MessageEmitter;
   private readonly toolCallEmitter: ToolCallEmitter;
+  private readonly pendingReplayToolCalls = new Map<
+    string,
+    PendingReplayToolCall
+  >();
 
   constructor(ctx: SessionContext) {
     this.ctx = ctx;
@@ -42,8 +57,15 @@ export class HistoryReplayer {
    * @param records - Array of chat records to replay
    */
   async replay(records: ChatRecord[]): Promise<void> {
-    for (const record of records) {
-      await this.replayRecord(record);
+    this.pendingReplayToolCalls.clear();
+    try {
+      for (const record of records) {
+        await this.replayRecord(record);
+      }
+      await this.failDanglingToolCalls();
+    } finally {
+      this.pendingReplayToolCalls.clear();
+      this.setActiveRecordId(null);
     }
   }
 
@@ -52,70 +74,84 @@ export class HistoryReplayer {
    */
   private async replayRecord(record: ChatRecord): Promise<void> {
     this.setActiveRecordId(record.uuid, record.timestamp);
-    switch (record.type) {
-      case 'user':
-        // Notification/cron records hold raw XML/prompt the user never
-        // typed; replay the friendly displayText so the assistant's reply
-        // has an antecedent in the ACP transcript.
-        if (record.subtype === 'notification' || record.subtype === 'cron') {
-          const displayText = (
-            record.systemPayload as NotificationRecordPayload | undefined
-          )?.displayText;
-          if (displayText) {
-            await this.messageEmitter.emitUserMessage(
-              displayText,
+    try {
+      switch (record.type) {
+        case 'user':
+          // Notification/cron records hold raw XML/prompt the user never
+          // typed; replay the friendly displayText so the assistant's reply
+          // has an antecedent in the ACP transcript.
+          if (record.subtype === 'notification' || record.subtype === 'cron') {
+            const displayText = (
+              record.systemPayload as NotificationRecordPayload | undefined
+            )?.displayText;
+            if (displayText) {
+              await this.messageEmitter.emitUserMessage(
+                displayText,
+                record.timestamp,
+              );
+            }
+            break;
+          }
+          if (record.subtype === 'mid_turn_user_message') {
+            const displayText = (
+              record.systemPayload as NotificationRecordPayload | undefined
+            )?.displayText;
+            if (displayText) {
+              await this.messageEmitter.emitUserMessage(
+                displayText,
+                record.timestamp,
+              );
+            } else if (record.message) {
+              await this.replayContent(
+                record.message,
+                'user',
+                record.timestamp,
+                record.uuid,
+              );
+            }
+            break;
+          }
+          if (record.message) {
+            await this.replayContent(
+              record.message,
+              'user',
               record.timestamp,
+              record.uuid,
             );
           }
           break;
-        }
-        if (record.subtype === 'mid_turn_user_message') {
-          const displayText = (
-            record.systemPayload as NotificationRecordPayload | undefined
-          )?.displayText;
-          if (displayText) {
-            await this.messageEmitter.emitUserMessage(
-              displayText,
+
+        case 'assistant':
+          if (record.message) {
+            await this.replayContent(
+              record.message,
+              'assistant',
               record.timestamp,
+              record.uuid,
             );
-          } else if (record.message) {
-            await this.replayContent(record.message, 'user', record.timestamp);
+          }
+          if (record.usageMetadata) {
+            await this.replayUsageMetadata(record.usageMetadata);
           }
           break;
-        }
-        if (record.message) {
-          await this.replayContent(record.message, 'user', record.timestamp);
-        }
-        break;
 
-      case 'assistant':
-        if (record.message) {
-          await this.replayContent(
-            record.message,
-            'assistant',
-            record.timestamp,
-          );
-        }
-        if (record.usageMetadata) {
-          await this.replayUsageMetadata(record.usageMetadata);
-        }
-        break;
+        case 'tool_result':
+          await this.replayToolResult(record);
+          break;
 
-      case 'tool_result':
-        await this.replayToolResult(record);
-        break;
+        case 'system':
+          if (record.subtype === 'slash_command') {
+            await this.replaySlashCommandResult(record);
+          }
+          // Other system subtypes (compression, telemetry, at_command) are skipped.
+          break;
 
-      case 'system':
-        if (record.subtype === 'slash_command') {
-          await this.replaySlashCommandResult(record);
-        }
-        // Other system subtypes (compression, telemetry, at_command) are skipped.
-        break;
-
-      default:
-        break;
+        default:
+          break;
+      }
+    } finally {
+      this.setActiveRecordId(null);
     }
-    this.setActiveRecordId(null);
   }
 
   /**
@@ -130,6 +166,7 @@ export class HistoryReplayer {
     content: Content,
     role: 'user' | 'assistant',
     timestamp?: string,
+    recordId?: string,
   ): Promise<void> {
     for (const part of content.parts ?? []) {
       // Text content
@@ -148,13 +185,22 @@ export class HistoryReplayer {
         const functionName = part.functionCall.name ?? '';
         const callId = part.functionCall.id ?? `${functionName}-${Date.now()}`;
 
-        await this.toolCallEmitter.emitStart({
+        const emitted = await this.toolCallEmitter.emitStart({
           toolName: functionName,
           callId,
           args: part.functionCall.args as Record<string, unknown>,
           status: 'in_progress',
           timestamp,
         });
+
+        if (emitted && role === 'assistant' && recordId) {
+          this.pendingReplayToolCalls.set(callId, {
+            callId,
+            toolName: functionName,
+            timestamp,
+            recordId,
+          });
+        }
       }
     }
   }
@@ -179,7 +225,8 @@ export class HistoryReplayer {
     }
 
     const result = record.toolCallResult;
-    const callId = result?.callId ?? record.uuid;
+    const callId = this.getToolResultCallId(record);
+    this.pendingReplayToolCalls.delete(callId);
 
     // Extract tool name from the function response in message if available
     const toolName = this.extractToolNameFromRecord(record);
@@ -207,6 +254,24 @@ export class HistoryReplayer {
       await this.emitTaskUsageFromResultDisplay(
         resultDisplay as AgentResultDisplay,
       );
+    }
+  }
+
+  private async failDanglingToolCalls(): Promise<void> {
+    for (const pending of this.pendingReplayToolCalls.values()) {
+      this.setActiveRecordId(pending.recordId, pending.timestamp);
+      try {
+        await this.toolCallEmitter.emitResult({
+          toolName: pending.toolName,
+          callId: pending.callId,
+          success: false,
+          message: [],
+          error: new Error(MISSING_TOOL_RESULT_MESSAGE),
+          timestamp: pending.timestamp,
+        });
+      } finally {
+        this.setActiveRecordId(null);
+      }
     }
   }
 
@@ -281,6 +346,29 @@ export class HistoryReplayer {
       }
     }
     return '';
+  }
+
+  private getToolResultCallId(record: ChatRecord): string {
+    const resultCallId = record.toolCallResult?.callId;
+    if (typeof resultCallId === 'string' && resultCallId.length > 0) {
+      return resultCallId;
+    }
+    return this.extractFunctionResponseIdFromRecord(record) ?? record.uuid;
+  }
+
+  private extractFunctionResponseIdFromRecord(
+    record: ChatRecord,
+  ): string | undefined {
+    if (record.message?.parts) {
+      for (const part of record.message.parts) {
+        const id =
+          'functionResponse' in part ? part.functionResponse?.id : undefined;
+        if (typeof id === 'string' && id.length > 0) {
+          return id;
+        }
+      }
+    }
+    return undefined;
   }
 
   private setActiveRecordId(recordId: string | null, timestamp?: string): void {

--- a/packages/cli/src/acp-integration/session/HistoryReplayer.ts
+++ b/packages/cli/src/acp-integration/session/HistoryReplayer.ts
@@ -207,7 +207,8 @@ export class HistoryReplayer {
       // Function call (tool start)
       if ('functionCall' in part && part.functionCall) {
         const functionName = part.functionCall.name ?? '';
-        const callId = part.functionCall.id ?? `${functionName}-${Date.now()}`;
+        const sourceCallId = part.functionCall.id;
+        const callId = sourceCallId ?? `${functionName}-${Date.now()}`;
 
         const emitted = await this.toolCallEmitter.emitStart({
           toolName: functionName,
@@ -217,7 +218,7 @@ export class HistoryReplayer {
           timestamp,
         });
 
-        if (emitted && role === 'assistant' && recordId) {
+        if (emitted && role === 'assistant' && recordId && sourceCallId) {
           this.pendingReplayToolCalls.set(callId, {
             callId,
             toolName: functionName,

--- a/packages/webui/src/daemon/session/selectors.test.ts
+++ b/packages/webui/src/daemon/session/selectors.test.ts
@@ -221,6 +221,16 @@ describe('daemon selectors', () => {
         block({ kind: 'tool', status: 'in_progress' }),
       ]),
     ).toBe('responding');
+    expect(
+      selectDaemonTranscriptStreamingState([
+        block({ kind: 'tool', status: 'failed' }),
+      ]),
+    ).toBe('idle');
+    expect(
+      selectDaemonTranscriptStreamingState([
+        block({ kind: 'tool', status: 'completed' }),
+      ]),
+    ).toBe('idle');
   });
 
   it('falls back to prompt status when transcript is idle', () => {


### PR DESCRIPTION
## What this PR does

This PR makes history replay close tool calls that were saved with a start event but no matching result. During replay, emitted assistant tool starts are tracked by call ID, real tool results remove their matching pending entry, and any remaining pending calls are replayed as failed tool updates with a clear missing-result message. Tool result matching now also falls back from the saved result call ID to the first function response ID before using the record UUID, preserving older history behavior while covering the saved-history shape that triggered the stuck UI.

The replay change is intentionally limited to historical transcript reconstruction. It does not change REST, SDK, ACP protocol shapes, or live tool execution semantics. TodoWrite starts that are skipped by the existing emitter are not tracked as dangling calls.

## Why it's needed

Some saved sessions can contain assistant function calls without corresponding tool result records when the previous run ended before the tool completed or the history was otherwise incomplete. Replaying those sessions currently recreates an in-progress tool block but never emits a terminal update, so clients can continue showing the session as processing even though there is no backend work left.

Failing these dangling replay-only calls makes restored/exported transcripts terminal and prevents old incomplete history from keeping the UI in a responding state.

## Reviewer Test Plan

### How to verify

Run `cd packages/cli && npx vitest run src/acp-integration/session/HistoryReplayer.test.ts`; expect all 25 tests to pass, including dangling, matched, mixed, call ID fallback, and TodoWrite skip cases.

Run `cd packages/webui && npx vitest run src/daemon/session/selectors.test.ts`; expect all 7 tests to pass, including failed/completed tool blocks remaining idle.

Run `cd packages/cli && npx eslint src/acp-integration/session/HistoryReplayer.ts src/acp-integration/session/HistoryReplayer.test.ts` and `npx prettier --check packages/cli/src/acp-integration/session/HistoryReplayer.ts packages/cli/src/acp-integration/session/HistoryReplayer.test.ts packages/webui/src/daemon/session/selectors.test.ts`; both should pass.

I also ran `npm run build` and `npm run typecheck`. Both are currently blocked by existing `packages/cli/src/ui/components/BaseTextInput.tsx` errors resolving `ink/dom` and `ink/components/CursorContext`, plus related `cursorCtx` unknown-type errors; those files are outside this PR.

### Evidence (Before & After)

Before: replaying saved history with a function call but no saved tool result recreated an in-progress tool block with no terminal update, leaving the session visually stuck as processing.

After: the same replay emits the original `tool_call` followed by a `tool_call_update` with `status: failed` and the message `Tool result missing from saved history; the previous run likely ended before this tool completed.` Matched tool calls still complete normally and skipped TodoWrite starts do not produce synthetic failures.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS checkout, Node.js v26.0.0, gh 2.92.0. Focused Vitest, ESLint, Prettier, build, and typecheck commands were run locally; build/typecheck are blocked by the unrelated BaseTextInput Ink type errors noted above.

## Risk & Scope

- Main risk or tradeoff: A saved history that has a dangling tool start for an unusual reason will now show that replayed tool as failed instead of in progress, but this is limited to historical replay and uses the existing tool update path.
- Not validated / out of scope: Full build/typecheck cannot be validated until the unrelated BaseTextInput Ink type resolution errors are fixed; live tool execution and protocol schemas are intentionally unchanged.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让历史回放能够终结那些已保存了工具开始事件、但没有匹配工具结果的调用。回放过程中，已发出的 assistant 工具开始事件会按 call ID 进入 pending；真实工具结果会移除匹配项；回放结束后剩余的 pending 调用会被重放为 failed 工具更新，并带上明确的缺失结果说明。工具结果匹配现在也会在保存的结果 call ID 缺失时，先回退到第一个 function response ID，再回退到 record UUID；这样既保留老历史行为，也覆盖导致卡住 UI 的保存历史形态。

这个回放改动刻意限制在历史 transcript 重建层，不修改 REST、SDK、ACP 协议形态，也不改变 live 工具执行语义。现有 emitter 会跳过的 TodoWrite start 不会被记录为 dangling call。

## Why it's needed

部分已保存会话会在上一次运行于工具完成前结束、或历史不完整时，只包含 assistant function call，而没有对应的 tool result record。当前回放这些会话时会重新创建一个 in-progress 工具块，但永远不会发出终态更新，因此客户端可能持续显示会话仍在处理中，即使后端已经没有工作在运行。

把这些仅存在于 replay 阶段的悬空调用标记为 failed，可以让恢复和导出的 transcript 进入终态，并避免旧的不完整历史让 UI 一直保持 responding 状态。

## Reviewer Test Plan

### How to verify

运行 `cd packages/cli && npx vitest run src/acp-integration/session/HistoryReplayer.test.ts`；预期全部 25 个测试通过，包括 dangling、matched、mixed、call ID fallback 和 TodoWrite skip 场景。

运行 `cd packages/webui && npx vitest run src/daemon/session/selectors.test.ts`；预期全部 7 个测试通过，包括 failed/completed 工具块保持 idle 的回归断言。

运行 `cd packages/cli && npx eslint src/acp-integration/session/HistoryReplayer.ts src/acp-integration/session/HistoryReplayer.test.ts` 和 `npx prettier --check packages/cli/src/acp-integration/session/HistoryReplayer.ts packages/cli/src/acp-integration/session/HistoryReplayer.test.ts packages/webui/src/daemon/session/selectors.test.ts`；两者都应通过。

我也运行了 `npm run build` 和 `npm run typecheck`。两者目前都被既有的 `packages/cli/src/ui/components/BaseTextInput.tsx` 错误阻塞：无法解析 `ink/dom` 和 `ink/components/CursorContext`，并出现相关的 `cursorCtx` unknown 类型错误；这些文件不在本 PR 范围内。

### Evidence (Before & After)

Before：当已保存历史里有 function call 但没有保存的 tool result 时，回放会重新创建一个 in-progress 工具块，但没有终态更新，导致会话视觉上一直停留在处理中。

After：同样的回放会先发出原始 `tool_call`，随后发出 `tool_call_update`，其中 `status: failed`，并带有 `Tool result missing from saved history; the previous run likely ended before this tool completed.`。已匹配的工具调用仍会正常 completed，被跳过的 TodoWrite start 不会产生合成失败。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 macOS checkout，Node.js v26.0.0，gh 2.92.0。已在本地运行 focused Vitest、ESLint、Prettier、build 和 typecheck 命令；build/typecheck 被上面提到的无关 BaseTextInput Ink 类型错误阻塞。

## Risk & Scope

- Main risk or tradeoff: 如果某段保存历史因为少见原因存在悬空工具 start，现在回放时会显示为 failed，而不是继续保持 in progress；但影响范围仅限历史回放，并且复用了现有工具 update 路径。
- Not validated / out of scope: 在修复无关的 BaseTextInput Ink 类型解析错误前，无法完成 full build/typecheck 验证；live 工具执行和协议 schema 均刻意不变。
- Breaking changes / migration notes: 无。

## Linked Issues

N/A

</details>



