### PR TITLE
feat(providers): add PleumRouter provider preset

### DIFF
--- a/packages/core/src/providers/__tests__/presets/pleumrouter.test.ts
+++ b/packages/core/src/providers/__tests__/presets/pleumrouter.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+// Re-import via the relative source path so the new ownsModel envKey gate
+// is exercised even before dist/ is rebuilt (the @qwen-code/qwen-code-core
+// package resolves to dist/ on a fresh branch).
+import {
+  pleumRouterProvider,
+  PLEUMROUTER_ENV_KEY,
+} from '../../presets/pleumrouter.js';
+
+describe('pleumRouterProvider', () => {
+  it('owns models that match BOTH our envKey and a router.pleum.ai host', () => {
+    expect(
+      pleumRouterProvider.ownsModel?.({
+        id: 'gpt-5.5',
+        baseUrl: 'https://router.pleum.ai/v1',
+        envKey: PLEUMROUTER_ENV_KEY,
+      }),
+    ).toBe(true);
+  });
+
+  it('refuses ownership over a different envKey on the same host (user-added entry)', () => {
+    expect(
+      pleumRouterProvider.ownsModel?.({
+        id: 'user-added',
+        baseUrl: 'https://router.pleum.ai/v1',
+        envKey: 'MY_PRIVATE_GATEWAY_KEY',
+      }),
+    ).toBe(false);
+  });
+
+  it('refuses ownership over an unrelated host even with our envKey', () => {
+    expect(
+      pleumRouterProvider.ownsModel?.({
+        id: 'other-model',
+        baseUrl: 'https://api.example.com/v1',
+        envKey: PLEUMROUTER_ENV_KEY,
+      }),
+    ).toBe(false);
+  });
+
+  it('refuses ownership when baseUrl is missing or malformed', () => {
+    expect(
+      pleumRouterProvider.ownsModel?.({
+        id: 'no-url',
+        envKey: PLEUMROUTER_ENV_KEY,
+      }),
+    ).toBe(false);
+    expect(
+      pleumRouterProvider.ownsModel?.({
+        id: 'bad-url',
+        baseUrl: 'not a url',
+        envKey: PLEUMROUTER_ENV_KEY,
+      }),
+    ).toBe(false);
+  });
+
+  it('declares customHeaders for attribution', () => {
+    expect(pleumRouterProvider.customHeaders).toEqual({
+      'HTTP-Referer': 'https://github.com/QwenLM/qwen-code.git',
+      'X-Title': 'Qwen Code',
+    });
+  });
+});

--- a/packages/core/src/providers/all-providers.ts
+++ b/packages/core/src/providers/all-providers.ts
@@ -14,6 +14,7 @@ import { tokenPlanProvider } from './presets/alibaba-token-plan.js';
 import { alibabaStandardProvider } from './presets/alibaba-standard.js';
 import { openRouterProvider } from './presets/openrouter.js';
 import { requestyProvider } from './presets/requesty.js';
+import { pleumRouterProvider } from './presets/pleumrouter.js';
 import { deepseekProvider } from './presets/deepseek.js';
 import { minimaxProvider } from './presets/minimax.js';
 import { zaiProvider } from './presets/zai.js';
@@ -28,6 +29,7 @@ export {
   alibabaStandardProvider,
   openRouterProvider,
   requestyProvider,
+  pleumRouterProvider,
   deepseekProvider,
   minimaxProvider,
   zaiProvider,
@@ -56,6 +58,7 @@ export const ALL_PROVIDERS: readonly ProviderConfig[] = [
   modelscopeProvider,
   openRouterProvider,
   requestyProvider,
+  pleumRouterProvider,
   customProvider,
 ];
 

--- a/packages/core/src/providers/presets/pleumrouter.ts
+++ b/packages/core/src/providers/presets/pleumrouter.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AuthType } from '../../core/contentGenerator.js';
+import type { ProviderConfig } from '../types.js';
+
+export const PLEUMROUTER_ENV_KEY = 'PLEUMROUTER_API_KEY';
+export const PLEUMROUTER_BASE_URL = 'https://router.pleum.ai/v1';
+
+export const pleumRouterProvider: ProviderConfig = {
+  id: 'pleumrouter',
+  label: 'PleumRouter',
+  description:
+    'Connect with a PleumRouter API key (get one from router.pleum.ai). ' +
+    'Korea-region OpenAI-compatible multi-provider LLM gateway.',
+  protocol: AuthType.USE_OPENAI,
+  baseUrl: PLEUMROUTER_BASE_URL,
+  envKey: PLEUMROUTER_ENV_KEY,
+  models: [
+    { id: 'gpt-5.5', contextWindowSize: 1050000 },
+    { id: 'claude-opus-4-8', contextWindowSize: 1000000 },
+  ],
+  modelsEditable: true,
+  modelNamePrefix: 'PleumRouter',
+  ownsModel: (model) => {
+    if (model.envKey !== PLEUMROUTER_ENV_KEY) return false;
+    try {
+      const host = new URL(model.baseUrl ?? '').hostname;
+      return host === 'router.pleum.ai' || host.endsWith('.pleum.ai');
+    } catch {
+      return false;
+    }
+  },
+  customHeaders: {
+    'HTTP-Referer': 'https://github.com/QwenLM/qwen-code.git',
+    'X-Title': 'Qwen Code',
+  },
+  documentationUrl: 'https://router.pleum.ai/docs',
+  uiGroup: 'third-party',
+};


### PR DESCRIPTION
## What this PR does

Adds PleumRouter as a first-class provider preset. PleumRouter is a Korea-region, OpenAI-compatible multi-provider LLM gateway (one API key reaches many providers). Because it speaks the OpenAI protocol, it is registered exactly like the existing Requesty and OpenRouter gateway presets — a `ProviderConfig` in `presets/pleumrouter.ts`, wired into `all-providers.ts`, with an `ownsModel` host gate so user-added entries with a different env key are preserved on re-install.

## Why it's needed

PleumRouter users currently have to hand-configure a custom OpenAI-compatible endpoint. A built-in preset lets them pick "PleumRouter" directly (model list fetched from its public `GET /v1/models`), matching the first-class experience already given to Requesty/OpenRouter.

## Reviewer Test Plan

### How to verify

1. `export PLEUMROUTER_API_KEY=plm_...` (key from router.pleum.ai).
2. Start qwen-code, open the provider picker — "PleumRouter" appears under third-party providers; models load from `https://router.pleum.ai/v1/models`.
3. Unit: the added `__tests__/presets/pleumrouter.test.ts` covers the `ownsModel` env-key + host gate, mirroring `requesty.test.ts`.

### Evidence (Before & After)

N/A — non-UI provider registration. Behavior mirrors the existing Requesty/OpenRouter presets.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️ not run locally (heavy monorepo); relies on CI    |
| 🪟 Windows |   ⚠️    |
|  🐧 Linux  |   ⚠️    |

The change is a pure additive preset mirroring `presets/requesty.ts` + its test mirrors `requesty.test.ts`; CI validates lint/typecheck/tests.

### Environment (optional)

N/A — unit tests only.

## Risk & Scope

- Main risk or tradeoff: none functional; additive preset. `defaultModelId`/featured models can be tuned.
- Not validated / out of scope: did not run the full monorepo test suite locally.
- Breaking changes / migration notes: none.

## Linked Issues

No linked issue — new provider preset following the existing Requesty/OpenRouter pattern.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

新增 PleumRouter 作为一级 provider 预设。PleumRouter 是面向韩国区域、兼容 OpenAI 协议的多 provider LLM 网关（一个 API key 即可访问多个 provider）。由于它使用 OpenAI 协议，其注册方式与现有的 Requesty、OpenRouter 网关预设完全一致——在 `presets/pleumrouter.ts` 中定义 `ProviderConfig`，在 `all-providers.ts` 中接入，并通过 `ownsModel` 主机校验，使得用户用不同环境变量自行添加的条目在重新安装时不会被删除。

## 为什么需要

PleumRouter 用户目前必须手动配置自定义 OpenAI 兼容端点。内置预设让他们可以直接选择 "PleumRouter"（模型列表从其公开的 `GET /v1/models` 获取），与 Requesty/OpenRouter 已有的一级体验一致。

## 审阅测试计划

1. `export PLEUMROUTER_API_KEY=plm_...`（从 router.pleum.ai 获取 key）。
2. 启动 qwen-code，打开 provider 选择器——"PleumRouter" 出现在第三方 provider 中；模型从 `https://router.pleum.ai/v1/models` 加载。
3. 单元测试：新增的 `__tests__/presets/pleumrouter.test.ts` 覆盖 `ownsModel` 的环境变量与主机校验，对应 `requesty.test.ts`。

## 风险与范围

- 主要风险/权衡：无功能性风险；纯新增预设。
- 未验证/范围之外：未在本地运行完整 monorepo 测试套件。
- 破坏性变更/迁移说明：无。

</details>
