### PR TITLE
feat(tui): add thinking block viewer with Alt+T expand/collapse

### DIFF
--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -77,8 +77,8 @@ export enum Command {
   EXPAND_SUGGESTION = 'expandSuggestion',
   COLLAPSE_SUGGESTION = 'collapseSuggestion',
 
-  // Thinking viewer
-  OPEN_THINKING_VIEWER = 'openThinkingViewer',
+  // Thinking expansion
+  TOGGLE_THINKING_EXPANDED = 'toggleThinkingExpanded',
 
   // Scroll commands
   SCROLL_UP = 'scrollUp',
@@ -240,8 +240,8 @@ export const defaultKeyBindings: KeyBindingConfig = {
   [Command.EXPAND_SUGGESTION]: [{ key: 'right' }],
   [Command.COLLAPSE_SUGGESTION]: [{ key: 'left' }],
 
-  // Thinking viewer
-  [Command.OPEN_THINKING_VIEWER]: [{ key: 't', meta: true }],
+  // Thinking expansion
+  [Command.TOGGLE_THINKING_EXPANDED]: [{ key: 't', meta: true }],
 
   // Scroll commands
   [Command.SCROLL_UP]: [{ key: 'up', shift: true }],

--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -77,6 +77,9 @@ export enum Command {
   EXPAND_SUGGESTION = 'expandSuggestion',
   COLLAPSE_SUGGESTION = 'collapseSuggestion',
 
+  // Thinking viewer
+  OPEN_THINKING_VIEWER = 'openThinkingViewer',
+
   // Scroll commands
   SCROLL_UP = 'scrollUp',
   SCROLL_DOWN = 'scrollDown',
@@ -236,6 +239,9 @@ export const defaultKeyBindings: KeyBindingConfig = {
   // Suggestion expansion
   [Command.EXPAND_SUGGESTION]: [{ key: 'right' }],
   [Command.COLLAPSE_SUGGESTION]: [{ key: 'left' }],
+
+  // Thinking viewer
+  [Command.OPEN_THINKING_VIEWER]: [{ key: 't', meta: true }],
 
   // Scroll commands
   [Command.SCROLL_UP]: [{ key: 'up', shift: true }],

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -1247,6 +1247,7 @@ describe('startInteractiveUI', () => {
     expect(options).toEqual({
       exitOnCtrlC: false,
       isScreenReaderEnabled: false,
+      alternateScreen: false,
     });
 
     // Verify React element structure is valid (but don't deep dive into JSX internals)

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -48,10 +48,7 @@ import {
   type InitializationResult,
 } from './core/initializer.js';
 import { handleList as handleListExtensions } from './commands/extensions/list.js';
-import {
-  initializeI18n,
-  resolveLanguageSetting,
-} from './i18n/index.js';
+import { initializeI18n, resolveLanguageSetting } from './i18n/index.js';
 import { runNonInteractive } from './nonInteractiveCli.js';
 import {
   setupStartupWorktree,
@@ -367,6 +364,7 @@ export async function startInteractiveUI(
     );
   };
 
+  const useVP = settings.merged.ui?.useTerminalBuffer ?? false;
   const instance = render(
     process.env['DEBUG'] ? (
       <React.StrictMode>
@@ -378,6 +376,7 @@ export async function startInteractiveUI(
     {
       exitOnCtrlC: false,
       isScreenReaderEnabled: config.getScreenReader(),
+      alternateScreen: useVP,
     },
   );
   // Records the moment Ink's `render()` call has returned, which is

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -3116,12 +3116,14 @@ export const AppContainer = (props: AppContainerProps) => {
         debugLogger.debug('[DEBUG] Keystroke:', JSON.stringify(key));
       }
 
-      // ThinkingViewer owns all input while open; only ESC passes through
+      // ThinkingViewer owns all input while open.
+      // Ctrl+C / Ctrl+D close the viewer and fall through to quit/exit.
       if (thinkingViewerData) {
-        if (keyMatchers[Command.ESCAPE](key)) {
+        if (keyMatchers[Command.QUIT](key) || keyMatchers[Command.EXIT](key)) {
           closeThinkingViewer();
+        } else {
+          return;
         }
-        return;
       }
 
       if (keyMatchers[Command.QUIT](key)) {

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -134,6 +134,7 @@ import {
   useVimModeActions,
 } from './contexts/VimModeContext.js';
 import { CompactModeProvider } from './contexts/CompactModeContext.js';
+import { ThoughtExpandedProvider } from './contexts/ThoughtExpandedContext.js';
 import { useTerminalSize } from './hooks/useTerminalSize.js';
 import { calculatePromptWidths } from './components/InputPrompt.js';
 import { useStdin, useStdout } from 'ink';
@@ -487,6 +488,9 @@ export const AppContainer = (props: AppContainerProps) => {
   const closeThinkingViewer = useCallback(() => {
     setThinkingViewerData(null);
   }, []);
+
+  // Alt+T inline expansion toggle for thinking blocks
+  const [thoughtExpanded, setThoughtExpanded] = useState(false);
 
   // Terminal and layout hooks
   const { columns: terminalWidth, rows: terminalHeight } = useTerminalSize();
@@ -3126,6 +3130,13 @@ export const AppContainer = (props: AppContainerProps) => {
         }
       }
 
+      // Alt+T: toggle inline expansion of thinking blocks.
+      if (keyMatchers[Command.OPEN_THINKING_VIEWER](key)) {
+        setThoughtExpanded((prev) => !prev);
+        refreshStatic();
+        return;
+      }
+
       if (keyMatchers[Command.QUIT](key)) {
         if (isAuthenticating) {
           return;
@@ -3388,6 +3399,7 @@ export const AppContainer = (props: AppContainerProps) => {
       vimMode,
       thinkingViewerData,
       closeThinkingViewer,
+      setThoughtExpanded,
     ],
   );
 
@@ -3943,22 +3955,24 @@ export const AppContainer = (props: AppContainerProps) => {
             }}
           >
             <CompactModeProvider value={compactModeValue}>
-              <RenderModeProvider value={renderModeValue}>
-                <TerminalOutputProvider value={writeRaw}>
-                  <ThinkingViewerProvider value={thinkingViewerValue}>
-                    <ShellFocusContext.Provider value={isFocused}>
-                      {thinkingViewerData ? (
-                        <ThinkingViewer
-                          data={thinkingViewerData}
-                          onClose={closeThinkingViewer}
-                        />
-                      ) : (
-                        <App />
-                      )}
-                    </ShellFocusContext.Provider>
-                  </ThinkingViewerProvider>
-                </TerminalOutputProvider>
-              </RenderModeProvider>
+              <ThoughtExpandedProvider value={thoughtExpanded}>
+                <RenderModeProvider value={renderModeValue}>
+                  <TerminalOutputProvider value={writeRaw}>
+                    <ThinkingViewerProvider value={thinkingViewerValue}>
+                      <ShellFocusContext.Provider value={isFocused}>
+                        {thinkingViewerData ? (
+                          <ThinkingViewer
+                            data={thinkingViewerData}
+                            onClose={closeThinkingViewer}
+                          />
+                        ) : (
+                          <App />
+                        )}
+                      </ShellFocusContext.Provider>
+                    </ThinkingViewerProvider>
+                  </TerminalOutputProvider>
+                </RenderModeProvider>
+              </ThoughtExpandedProvider>
             </CompactModeProvider>
           </AppContext.Provider>
         </ConfigContext.Provider>

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -3116,6 +3116,14 @@ export const AppContainer = (props: AppContainerProps) => {
         debugLogger.debug('[DEBUG] Keystroke:', JSON.stringify(key));
       }
 
+      // ThinkingViewer owns all input while open; only ESC passes through
+      if (thinkingViewerData) {
+        if (keyMatchers[Command.ESCAPE](key)) {
+          closeThinkingViewer();
+        }
+        return;
+      }
+
       if (keyMatchers[Command.QUIT](key)) {
         if (isAuthenticating) {
           return;
@@ -3145,12 +3153,6 @@ export const AppContainer = (props: AppContainerProps) => {
         handleExit(ctrlDPressedOnce, setCtrlDPressedOnce, ctrlDTimerRef);
         return;
       } else if (keyMatchers[Command.ESCAPE](key)) {
-        // Close thinking viewer overlay first if open
-        if (thinkingViewerData) {
-          closeThinkingViewer();
-          return;
-        }
-
         // In vim INSERT mode, let vim's own handler (in InputPrompt) consume
         // the Esc to switch to NORMAL mode. Without this guard, both handlers
         // fire on the same keypress — vim switches mode AND AppContainer
@@ -3943,12 +3945,13 @@ export const AppContainer = (props: AppContainerProps) => {
                 <TerminalOutputProvider value={writeRaw}>
                   <ThinkingViewerProvider value={thinkingViewerValue}>
                     <ShellFocusContext.Provider value={isFocused}>
-                      <App />
-                      {thinkingViewerData && (
+                      {thinkingViewerData ? (
                         <ThinkingViewer
                           data={thinkingViewerData}
                           onClose={closeThinkingViewer}
                         />
+                      ) : (
+                        <App />
                       )}
                     </ShellFocusContext.Provider>
                   </ThinkingViewerProvider>

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -3131,7 +3131,7 @@ export const AppContainer = (props: AppContainerProps) => {
       }
 
       // Alt+T: toggle inline expansion of thinking blocks.
-      if (keyMatchers[Command.OPEN_THINKING_VIEWER](key)) {
+      if (keyMatchers[Command.TOGGLE_THINKING_EXPANDED](key)) {
         setThoughtExpanded((prev) => !prev);
         refreshStatic();
         return;

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -3964,6 +3964,7 @@ export const AppContainer = (props: AppContainerProps) => {
                           <ThinkingViewer
                             data={thinkingViewerData}
                             onClose={closeThinkingViewer}
+                            useAlternateScreen={!useTerminalBuffer}
                           />
                         ) : (
                           <App />

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -197,6 +197,11 @@ import {
   type RenderMode,
 } from './contexts/RenderModeContext.js';
 import { TerminalOutputProvider } from './contexts/TerminalOutputContext.js';
+import {
+  ThinkingViewerProvider,
+  type ThinkingViewerData,
+} from './contexts/ThinkingViewerContext.js';
+import { ThinkingViewer } from './components/ThinkingViewer.js';
 import { useAgentViewState } from './contexts/AgentViewContext.js';
 import {
   useBackgroundTaskViewState,
@@ -472,6 +477,16 @@ export const AppContainer = (props: AppContainerProps) => {
   const [isConfigInitialized, setConfigInitialized] = useState(false);
 
   const [userMessages, setUserMessages] = useState<string[]>([]);
+
+  // Thinking viewer overlay state
+  const [thinkingViewerData, setThinkingViewerData] =
+    useState<ThinkingViewerData | null>(null);
+  const openThinkingViewer = useCallback((data: ThinkingViewerData) => {
+    setThinkingViewerData(data);
+  }, []);
+  const closeThinkingViewer = useCallback(() => {
+    setThinkingViewerData(null);
+  }, []);
 
   // Terminal and layout hooks
   const { columns: terminalWidth, rows: terminalHeight } = useTerminalSize();
@@ -3130,6 +3145,12 @@ export const AppContainer = (props: AppContainerProps) => {
         handleExit(ctrlDPressedOnce, setCtrlDPressedOnce, ctrlDTimerRef);
         return;
       } else if (keyMatchers[Command.ESCAPE](key)) {
+        // Close thinking viewer overlay first if open
+        if (thinkingViewerData) {
+          closeThinkingViewer();
+          return;
+        }
+
         // In vim INSERT mode, let vim's own handler (in InputPrompt) consume
         // the Esc to switch to NORMAL mode. Without this guard, both handlers
         // fire on the same keypress — vim switches mode AND AppContainer
@@ -3361,6 +3382,8 @@ export const AppContainer = (props: AppContainerProps) => {
       handleDoubleEscRewind,
       vimEnabled,
       vimMode,
+      thinkingViewerData,
+      closeThinkingViewer,
     ],
   );
 
@@ -3900,6 +3923,11 @@ export const AppContainer = (props: AppContainerProps) => {
     [renderMode, setRenderMode],
   );
 
+  const thinkingViewerValue = useMemo(
+    () => ({ openThinkingViewer }),
+    [openThinkingViewer],
+  );
+
   return (
     <UIStateContext.Provider value={uiState}>
       <UIActionsContext.Provider value={uiActions}>
@@ -3913,9 +3941,17 @@ export const AppContainer = (props: AppContainerProps) => {
             <CompactModeProvider value={compactModeValue}>
               <RenderModeProvider value={renderModeValue}>
                 <TerminalOutputProvider value={writeRaw}>
-                  <ShellFocusContext.Provider value={isFocused}>
-                    <App />
-                  </ShellFocusContext.Provider>
+                  <ThinkingViewerProvider value={thinkingViewerValue}>
+                    <ShellFocusContext.Provider value={isFocused}>
+                      <App />
+                      {thinkingViewerData && (
+                        <ThinkingViewer
+                          data={thinkingViewerData}
+                          onClose={closeThinkingViewer}
+                        />
+                      )}
+                    </ShellFocusContext.Provider>
+                  </ThinkingViewerProvider>
                 </TerminalOutputProvider>
               </RenderModeProvider>
             </CompactModeProvider>

--- a/packages/cli/src/ui/components/AlternateScreen.tsx
+++ b/packages/cli/src/ui/components/AlternateScreen.tsx
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { FC, ReactNode } from 'react';
+import { useEffect } from 'react';
+import { Box } from 'ink';
+import { useTerminalOutput } from '../contexts/TerminalOutputContext.js';
+import { useTerminalSize } from '../hooks/useTerminalSize.js';
+
+const ENTER_ALT_SCREEN = '\x1b[?1049h';
+const EXIT_ALT_SCREEN = '\x1b[?1049l';
+const CLEAR_SCREEN = '\x1b[2J\x1b[H';
+const HIDE_CURSOR = '\x1b[?25l';
+const SHOW_CURSOR = '\x1b[?25h';
+
+interface AlternateScreenProps {
+  children: ReactNode;
+}
+
+export const AlternateScreen: FC<AlternateScreenProps> = ({ children }) => {
+  const writeRaw = useTerminalOutput();
+  const { rows } = useTerminalSize();
+
+  useEffect(() => {
+    writeRaw(ENTER_ALT_SCREEN + CLEAR_SCREEN + HIDE_CURSOR);
+    return () => {
+      writeRaw(SHOW_CURSOR + EXIT_ALT_SCREEN);
+    };
+  }, [writeRaw]);
+
+  return (
+    <Box flexDirection="column" height={rows}>
+      {children}
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/components/AlternateScreen.tsx
+++ b/packages/cli/src/ui/components/AlternateScreen.tsx
@@ -26,7 +26,10 @@ export const AlternateScreen: FC<AlternateScreenProps> = ({ children }) => {
 
   useEffect(() => {
     writeRaw(ENTER_ALT_SCREEN + CLEAR_SCREEN + HIDE_CURSOR);
+    const onExit = () => writeRaw(SHOW_CURSOR + EXIT_ALT_SCREEN);
+    process.on('exit', onExit);
     return () => {
+      process.removeListener('exit', onExit);
       writeRaw(SHOW_CURSOR + EXIT_ALT_SCREEN);
     };
   }, [writeRaw]);

--- a/packages/cli/src/ui/components/AlternateScreen.tsx
+++ b/packages/cli/src/ui/components/AlternateScreen.tsx
@@ -18,13 +18,19 @@ const SHOW_CURSOR = '\x1b[?25h';
 
 interface AlternateScreenProps {
   children: ReactNode;
+  /** Skip escape writes when the root Ink renderer already owns the alt screen (VP mode). */
+  disabled?: boolean;
 }
 
-export const AlternateScreen: FC<AlternateScreenProps> = ({ children }) => {
+export const AlternateScreen: FC<AlternateScreenProps> = ({
+  children,
+  disabled,
+}) => {
   const writeRaw = useTerminalOutput();
   const { rows } = useTerminalSize();
 
   useEffect(() => {
+    if (disabled) return;
     writeRaw(ENTER_ALT_SCREEN + CLEAR_SCREEN + HIDE_CURSOR);
     const onExit = () => writeRaw(SHOW_CURSOR + EXIT_ALT_SCREEN);
     process.on('exit', onExit);
@@ -32,7 +38,7 @@ export const AlternateScreen: FC<AlternateScreenProps> = ({ children }) => {
       process.removeListener('exit', onExit);
       writeRaw(SHOW_CURSOR + EXIT_ALT_SCREEN);
     };
-  }, [writeRaw]);
+  }, [writeRaw, disabled]);
 
   return (
     <Box flexDirection="column" height={rows}>

--- a/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
@@ -357,7 +357,7 @@ describe('<HistoryItemDisplay />', () => {
 
     const output = lastFrame() ?? '';
     expect(output).toContain('Thought for');
-    expect(output).toContain('click to view');
+    expect(output).toContain('alt+t to expand');
     expect(output).not.toContain('Inspecting the repository');
   });
 
@@ -393,7 +393,7 @@ describe('<HistoryItemDisplay />', () => {
 
     const output = lastFrame() ?? '';
     expect(output).toContain('Thought for');
-    expect(output).toContain('click to view');
+    expect(output).toContain('alt+t to expand');
     expect(output).not.toContain('Inspecting the repository');
   });
 

--- a/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
@@ -24,6 +24,10 @@ vi.mock('./messages/ToolGroupMessage.js', () => ({
   ToolGroupMessage: vi.fn(() => <div />),
 }));
 
+vi.mock('../hooks/useMouseEvents.js', () => ({
+  useMouseEvents: vi.fn(),
+}));
+
 describe('<HistoryItemDisplay />', () => {
   const mockConfig = {
     getChatRecordingService: () => undefined,
@@ -337,7 +341,7 @@ describe('<HistoryItemDisplay />', () => {
     expect(lastFrame()).toContain('●');
   });
 
-  it('renders committed thinking text in full transcript mode', () => {
+  it('renders committed thinking collapsed by default', () => {
     const item: HistoryItem = {
       id: 1,
       type: 'gemini_thought',
@@ -353,10 +357,11 @@ describe('<HistoryItemDisplay />', () => {
 
     const output = lastFrame() ?? '';
     expect(output).toContain('Thought for');
-    expect(output).toContain('Inspecting the repository');
+    expect(output).toContain('click to view');
+    expect(output).not.toContain('Inspecting the repository');
   });
 
-  it('renders committed thinking continuations in full transcript mode', () => {
+  it('renders committed thinking continuations hidden by default', () => {
     const item: HistoryItem = {
       id: 1,
       type: 'gemini_thought_content',
@@ -369,10 +374,10 @@ describe('<HistoryItemDisplay />', () => {
       </CompactModeProvider>,
     );
 
-    expect(lastFrame()).toContain('Continuing the reasoning');
+    expect(lastFrame()).not.toContain('Continuing the reasoning');
   });
 
-  it('keeps committed thinking collapsed in compact mode', () => {
+  it('keeps committed thinking collapsed in compact mode too', () => {
     const item: HistoryItem = {
       id: 1,
       type: 'gemini_thought',
@@ -388,7 +393,7 @@ describe('<HistoryItemDisplay />', () => {
 
     const output = lastFrame() ?? '';
     expect(output).toContain('Thought for');
-    expect(output).toContain('ctrl+o to expand');
+    expect(output).toContain('click to view');
     expect(output).not.toContain('Inspecting the repository');
   });
 

--- a/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
@@ -18,6 +18,7 @@ import { renderWithProviders } from '../../test-utils/render.js';
 import { LoadedSettings } from '../../config/settings.js';
 import { ConfigContext } from '../contexts/ConfigContext.js';
 import { CompactModeProvider } from '../contexts/CompactModeContext.js';
+import { ThoughtExpandedProvider } from '../contexts/ThoughtExpandedContext.js';
 
 // Mock child components
 vi.mock('./messages/ToolGroupMessage.js', () => ({
@@ -395,6 +396,26 @@ describe('<HistoryItemDisplay />', () => {
     expect(output).toContain('Thought for');
     expect(output).toContain('alt+t to expand');
     expect(output).not.toContain('Inspecting the repository');
+  });
+
+  it('renders committed thinking expanded when ThoughtExpandedProvider is true', () => {
+    const item: HistoryItem = {
+      id: 1,
+      type: 'gemini_thought',
+      text: 'Inspecting the repository',
+      durationMs: 1200,
+    };
+
+    const { lastFrame } = renderWithProviders(
+      <ThoughtExpandedProvider value={true}>
+        <HistoryItemDisplay item={item} terminalWidth={100} isPending={false} />
+      </ThoughtExpandedProvider>,
+    );
+
+    const output = lastFrame() ?? '';
+    expect(output).toContain('Thought for');
+    expect(output).toContain('alt+t to collapse');
+    expect(output).toContain('Inspecting the repository');
   });
 
   it('keeps committed thinking continuations hidden in compact mode', () => {

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -91,6 +91,8 @@ interface HistoryItemDisplayProps {
    */
   summaryAbsorbed?: boolean;
   sourceCopyIndexOffsets?: MarkdownSourceCopyIndexOffsets;
+  /** Force thinking blocks expanded (e.g. in SessionPreview). */
+  thoughtExpanded?: boolean;
 }
 
 function getHistoryItemMarginTop(item: HistoryItem): number {
@@ -139,6 +141,7 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
   compactLabel,
   summaryAbsorbed = false,
   sourceCopyIndexOffsets,
+  thoughtExpanded = false,
 }) => {
   const marginTop = getHistoryItemMarginTop(item);
 
@@ -185,7 +188,7 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
       },
       [openThinkingViewer, thoughtText, thoughtDurationMs],
     ),
-    { isActive: isCommittedThought },
+    { isActive: isCommittedThought && !thoughtExpanded },
   );
 
   return (
@@ -244,7 +247,7 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
           <ThinkMessage
             text={itemForDisplay.text.trimEnd()}
             isPending={isPending}
-            expanded={false}
+            expanded={thoughtExpanded}
             availableTerminalHeight={
               availableTerminalHeightGemini ?? availableTerminalHeight
             }
@@ -258,7 +261,7 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
           <ThinkMessageContent
             text={itemForDisplay.text.trimEnd()}
             isPending={isPending}
-            expanded={false}
+            expanded={thoughtExpanded}
             availableTerminalHeight={
               availableTerminalHeightGemini ?? availableTerminalHeight
             }

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -122,6 +122,10 @@ const ClickableThinkMessage: React.FC<{
   const ref = useRef<DOMElement>(null);
   const { openThinkingViewer } = useThinkingViewer();
   const isActive = !isPending && !expanded;
+  const sanitizedViewerText = useMemo(
+    () => escapeAnsiCtrlCodes(viewerText),
+    [viewerText],
+  );
 
   useMouseEvents(
     useCallback(
@@ -136,10 +140,10 @@ const ClickableThinkMessage: React.FC<{
           row >= metrics.y &&
           row < metrics.y + metrics.height
         ) {
-          openThinkingViewer({ text: viewerText, durationMs });
+          openThinkingViewer({ text: sanitizedViewerText, durationMs });
         }
       },
-      [openThinkingViewer, viewerText, durationMs],
+      [openThinkingViewer, sanitizedViewerText, durationMs],
     ),
     { isActive },
   );

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -59,6 +59,7 @@ import { DiffStatsDisplay } from './messages/DiffStatsDisplay.js';
 import { GoalStatusMessage } from './messages/GoalStatusMessage.js';
 import { useCompactMode } from '../contexts/CompactModeContext.js';
 import { useSettings } from '../contexts/SettingsContext.js';
+import { useThoughtExpanded } from '../contexts/ThoughtExpandedContext.js';
 import { useThinkingViewer } from '../contexts/ThinkingViewerContext.js';
 import { useMouseEvents } from '../hooks/useMouseEvents.js';
 import type { MouseEvent } from '../utils/mouse.js';
@@ -165,9 +166,9 @@ const ClickableThinkMessage: React.FC<{
 function getHistoryItemMarginTop(item: HistoryItem): number {
   switch (item.type) {
     case 'gemini':
+    case 'gemini_thought':
       return 1;
     case 'gemini_content':
-    case 'gemini_thought':
     case 'gemini_thought_content':
     case 'info':
     case 'success':
@@ -208,12 +209,14 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
   compactLabel,
   summaryAbsorbed = false,
   sourceCopyIndexOffsets,
-  thoughtExpanded = false,
+  thoughtExpanded,
   thinkingFullText,
 }) => {
   const marginTop = getHistoryItemMarginTop(item);
 
   const { compactMode } = useCompactMode();
+  const contextThoughtExpanded = useThoughtExpanded();
+  const resolvedThoughtExpanded = thoughtExpanded ?? contextThoughtExpanded;
   const settings = useSettings();
   const showTimestamps = settings.merged.output?.showTimestamps === true;
 
@@ -277,7 +280,7 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
           text={itemForDisplay.text.trimEnd()}
           viewerText={(thinkingFullText || itemForDisplay.text).trimEnd()}
           isPending={isPending}
-          expanded={thoughtExpanded}
+          expanded={resolvedThoughtExpanded}
           availableTerminalHeight={
             availableTerminalHeightGemini ?? availableTerminalHeight
           }
@@ -289,7 +292,7 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
         <ThinkMessageContent
           text={itemForDisplay.text.trimEnd()}
           isPending={isPending}
-          expanded={thoughtExpanded}
+          expanded={resolvedThoughtExpanded}
           availableTerminalHeight={
             availableTerminalHeightGemini ?? availableTerminalHeight
           }

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -5,7 +5,8 @@
  */
 
 import type React from 'react';
-import { useMemo } from 'react';
+import { useMemo, useRef, useCallback } from 'react';
+import type { DOMElement } from 'ink';
 import {
   escapeAnsiCtrlCodes,
   sanitizeSensitiveText,
@@ -58,6 +59,10 @@ import { DiffStatsDisplay } from './messages/DiffStatsDisplay.js';
 import { GoalStatusMessage } from './messages/GoalStatusMessage.js';
 import { useCompactMode } from '../contexts/CompactModeContext.js';
 import { useSettings } from '../contexts/SettingsContext.js';
+import { useThinkingViewer } from '../contexts/ThinkingViewerContext.js';
+import { useMouseEvents } from '../hooks/useMouseEvents.js';
+import type { MouseEvent } from '../utils/mouse.js';
+import { measureElementPosition } from '../utils/measure-element-position.js';
 
 interface HistoryItemDisplayProps {
   item: HistoryItem;
@@ -140,10 +145,48 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
   const { compactMode } = useCompactMode();
   const settings = useSettings();
   const showTimestamps = settings.merged.output?.showTimestamps === true;
+  const { openThinkingViewer } = useThinkingViewer();
 
   const itemForDisplay = useMemo(() => escapeAnsiCtrlCodes(item), [item]);
   const contentWidth = terminalWidth - 4;
   const boxWidth = mainAreaWidth || contentWidth;
+
+  const thoughtRef = useRef<DOMElement>(null);
+  const isCommittedThought =
+    !isPending &&
+    (itemForDisplay.type === 'gemini_thought' ||
+      itemForDisplay.type === 'gemini_thought_content');
+
+  const thoughtText =
+    isCommittedThought && 'text' in itemForDisplay
+      ? (itemForDisplay as { text: string }).text
+      : '';
+  const thoughtDurationMs =
+    itemForDisplay.type === 'gemini_thought'
+      ? itemForDisplay.durationMs
+      : undefined;
+
+  useMouseEvents(
+    useCallback(
+      (event: MouseEvent) => {
+        if (event.name !== 'left-press' || !thoughtRef.current) return;
+        const metrics = measureElementPosition(thoughtRef.current);
+        if (
+          event.col >= metrics.x &&
+          event.col < metrics.x + metrics.width &&
+          event.row >= metrics.y &&
+          event.row < metrics.y + metrics.height
+        ) {
+          openThinkingViewer({
+            text: thoughtText,
+            durationMs: thoughtDurationMs,
+          });
+        }
+      },
+      [openThinkingViewer, thoughtText, thoughtDurationMs],
+    ),
+    { isActive: isCommittedThought },
+  );
 
   return (
     <Box
@@ -197,27 +240,31 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
         />
       )}
       {itemForDisplay.type === 'gemini_thought' && (
-        <ThinkMessage
-          text={itemForDisplay.text.trimEnd()}
-          isPending={isPending}
-          expanded={!compactMode}
-          availableTerminalHeight={
-            availableTerminalHeightGemini ?? availableTerminalHeight
-          }
-          contentWidth={contentWidth}
-          durationMs={itemForDisplay.durationMs}
-        />
+        <Box ref={isCommittedThought ? thoughtRef : undefined}>
+          <ThinkMessage
+            text={itemForDisplay.text.trimEnd()}
+            isPending={isPending}
+            expanded={false}
+            availableTerminalHeight={
+              availableTerminalHeightGemini ?? availableTerminalHeight
+            }
+            contentWidth={contentWidth}
+            durationMs={itemForDisplay.durationMs}
+          />
+        </Box>
       )}
       {itemForDisplay.type === 'gemini_thought_content' && (
-        <ThinkMessageContent
-          text={itemForDisplay.text.trimEnd()}
-          isPending={isPending}
-          expanded={!compactMode}
-          availableTerminalHeight={
-            availableTerminalHeightGemini ?? availableTerminalHeight
-          }
-          contentWidth={contentWidth}
-        />
+        <Box ref={isCommittedThought ? thoughtRef : undefined}>
+          <ThinkMessageContent
+            text={itemForDisplay.text.trimEnd()}
+            isPending={isPending}
+            expanded={false}
+            availableTerminalHeight={
+              availableTerminalHeightGemini ?? availableTerminalHeight
+            }
+            contentWidth={contentWidth}
+          />
+        </Box>
       )}
       {itemForDisplay.type === 'info' && (
         <InfoMessage

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -93,6 +93,8 @@ interface HistoryItemDisplayProps {
   sourceCopyIndexOffsets?: MarkdownSourceCopyIndexOffsets;
   /** Force thinking blocks expanded (e.g. in SessionPreview). */
   thoughtExpanded?: boolean;
+  /** Aggregated text from this thought + its continuation items. */
+  thinkingFullText?: string;
 }
 
 function getHistoryItemMarginTop(item: HistoryItem): number {
@@ -142,6 +144,7 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
   summaryAbsorbed = false,
   sourceCopyIndexOffsets,
   thoughtExpanded = false,
+  thinkingFullText,
 }) => {
   const marginTop = getHistoryItemMarginTop(item);
 
@@ -158,7 +161,9 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
   const isClickableThought =
     !isPending && !thoughtExpanded && itemForDisplay.type === 'gemini_thought';
 
-  const thoughtText = isClickableThought ? itemForDisplay.text : '';
+  const thoughtText = isClickableThought
+    ? thinkingFullText || itemForDisplay.text
+    : '';
   const thoughtDurationMs = isClickableThought
     ? itemForDisplay.durationMs
     : undefined;

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -155,30 +155,27 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
   const boxWidth = mainAreaWidth || contentWidth;
 
   const thoughtRef = useRef<DOMElement>(null);
-  const isCommittedThought =
-    !isPending &&
-    (itemForDisplay.type === 'gemini_thought' ||
-      itemForDisplay.type === 'gemini_thought_content');
+  const isClickableThought =
+    !isPending && !thoughtExpanded && itemForDisplay.type === 'gemini_thought';
 
-  const thoughtText =
-    isCommittedThought && 'text' in itemForDisplay
-      ? (itemForDisplay as { text: string }).text
-      : '';
-  const thoughtDurationMs =
-    itemForDisplay.type === 'gemini_thought'
-      ? itemForDisplay.durationMs
-      : undefined;
+  const thoughtText = isClickableThought ? itemForDisplay.text : '';
+  const thoughtDurationMs = isClickableThought
+    ? itemForDisplay.durationMs
+    : undefined;
 
   useMouseEvents(
     useCallback(
       (event: MouseEvent) => {
         if (event.name !== 'left-press' || !thoughtRef.current) return;
         const metrics = measureElementPosition(thoughtRef.current);
+        // SGR mouse coordinates are 1-based; yoga layout is 0-based
+        const col = event.col - 1;
+        const row = event.row - 1;
         if (
-          event.col >= metrics.x &&
-          event.col < metrics.x + metrics.width &&
-          event.row >= metrics.y &&
-          event.row < metrics.y + metrics.height
+          col >= metrics.x &&
+          col < metrics.x + metrics.width &&
+          row >= metrics.y &&
+          row < metrics.y + metrics.height
         ) {
           openThinkingViewer({
             text: thoughtText,
@@ -188,7 +185,7 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
       },
       [openThinkingViewer, thoughtText, thoughtDurationMs],
     ),
-    { isActive: isCommittedThought && !thoughtExpanded },
+    { isActive: isClickableThought },
   );
 
   return (
@@ -243,7 +240,7 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
         />
       )}
       {itemForDisplay.type === 'gemini_thought' && (
-        <Box ref={isCommittedThought ? thoughtRef : undefined}>
+        <Box ref={isClickableThought ? thoughtRef : undefined}>
           <ThinkMessage
             text={itemForDisplay.text.trimEnd()}
             isPending={isPending}
@@ -257,17 +254,15 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
         </Box>
       )}
       {itemForDisplay.type === 'gemini_thought_content' && (
-        <Box ref={isCommittedThought ? thoughtRef : undefined}>
-          <ThinkMessageContent
-            text={itemForDisplay.text.trimEnd()}
-            isPending={isPending}
-            expanded={thoughtExpanded}
-            availableTerminalHeight={
-              availableTerminalHeightGemini ?? availableTerminalHeight
-            }
-            contentWidth={contentWidth}
-          />
-        </Box>
+        <ThinkMessageContent
+          text={itemForDisplay.text.trimEnd()}
+          isPending={isPending}
+          expanded={thoughtExpanded}
+          availableTerminalHeight={
+            availableTerminalHeightGemini ?? availableTerminalHeight
+          }
+          contentWidth={contentWidth}
+        />
       )}
       {itemForDisplay.type === 'info' && (
         <InfoMessage

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -97,6 +97,67 @@ interface HistoryItemDisplayProps {
   thinkingFullText?: string;
 }
 
+/**
+ * Wraps ThinkMessage with mouse click-to-open handling.
+ * Extracted so that non-thought HistoryItemDisplay instances
+ * don't pay the useMouseEvents/useRef/useCallback hook cost.
+ */
+const ClickableThinkMessage: React.FC<{
+  text: string;
+  viewerText: string;
+  isPending: boolean;
+  expanded: boolean;
+  availableTerminalHeight?: number;
+  contentWidth: number;
+  durationMs?: number;
+}> = ({
+  text,
+  viewerText,
+  isPending,
+  expanded,
+  availableTerminalHeight,
+  contentWidth,
+  durationMs,
+}) => {
+  const ref = useRef<DOMElement>(null);
+  const { openThinkingViewer } = useThinkingViewer();
+  const isActive = !isPending && !expanded;
+
+  useMouseEvents(
+    useCallback(
+      (event: MouseEvent) => {
+        if (event.name !== 'left-press' || !ref.current) return;
+        const metrics = measureElementPosition(ref.current);
+        const col = event.col - 1;
+        const row = event.row - 1;
+        if (
+          col >= metrics.x &&
+          col < metrics.x + metrics.width &&
+          row >= metrics.y &&
+          row < metrics.y + metrics.height
+        ) {
+          openThinkingViewer({ text: viewerText, durationMs });
+        }
+      },
+      [openThinkingViewer, viewerText, durationMs],
+    ),
+    { isActive },
+  );
+
+  return (
+    <Box ref={isActive ? ref : undefined}>
+      <ThinkMessage
+        text={text}
+        isPending={isPending}
+        expanded={expanded}
+        availableTerminalHeight={availableTerminalHeight}
+        contentWidth={contentWidth}
+        durationMs={durationMs}
+      />
+    </Box>
+  );
+};
+
 function getHistoryItemMarginTop(item: HistoryItem): number {
   switch (item.type) {
     case 'gemini':
@@ -151,47 +212,10 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
   const { compactMode } = useCompactMode();
   const settings = useSettings();
   const showTimestamps = settings.merged.output?.showTimestamps === true;
-  const { openThinkingViewer } = useThinkingViewer();
 
   const itemForDisplay = useMemo(() => escapeAnsiCtrlCodes(item), [item]);
   const contentWidth = terminalWidth - 4;
   const boxWidth = mainAreaWidth || contentWidth;
-
-  const thoughtRef = useRef<DOMElement>(null);
-  const isClickableThought =
-    !isPending && !thoughtExpanded && itemForDisplay.type === 'gemini_thought';
-
-  const thoughtText = isClickableThought
-    ? thinkingFullText || itemForDisplay.text
-    : '';
-  const thoughtDurationMs = isClickableThought
-    ? itemForDisplay.durationMs
-    : undefined;
-
-  useMouseEvents(
-    useCallback(
-      (event: MouseEvent) => {
-        if (event.name !== 'left-press' || !thoughtRef.current) return;
-        const metrics = measureElementPosition(thoughtRef.current);
-        // SGR mouse coordinates are 1-based; yoga layout is 0-based
-        const col = event.col - 1;
-        const row = event.row - 1;
-        if (
-          col >= metrics.x &&
-          col < metrics.x + metrics.width &&
-          row >= metrics.y &&
-          row < metrics.y + metrics.height
-        ) {
-          openThinkingViewer({
-            text: thoughtText,
-            durationMs: thoughtDurationMs,
-          });
-        }
-      },
-      [openThinkingViewer, thoughtText, thoughtDurationMs],
-    ),
-    { isActive: isClickableThought },
-  );
 
   return (
     <Box
@@ -245,18 +269,17 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
         />
       )}
       {itemForDisplay.type === 'gemini_thought' && (
-        <Box ref={isClickableThought ? thoughtRef : undefined}>
-          <ThinkMessage
-            text={itemForDisplay.text.trimEnd()}
-            isPending={isPending}
-            expanded={thoughtExpanded}
-            availableTerminalHeight={
-              availableTerminalHeightGemini ?? availableTerminalHeight
-            }
-            contentWidth={contentWidth}
-            durationMs={itemForDisplay.durationMs}
-          />
-        </Box>
+        <ClickableThinkMessage
+          text={itemForDisplay.text.trimEnd()}
+          viewerText={(thinkingFullText || itemForDisplay.text).trimEnd()}
+          isPending={isPending}
+          expanded={thoughtExpanded}
+          availableTerminalHeight={
+            availableTerminalHeightGemini ?? availableTerminalHeight
+          }
+          contentWidth={contentWidth}
+          durationMs={itemForDisplay.durationMs}
+        />
       )}
       {itemForDisplay.type === 'gemini_thought_content' && (
         <ThinkMessageContent

--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -25,6 +25,7 @@ import {
   isForceExpandGroup,
   mergeCompactToolGroups,
 } from '../utils/mergeCompactToolGroups.js';
+import { buildThinkingFullTextMap } from '../utils/historyUtils.js';
 import { ScrollableList, SCROLL_TO_ITEM_END } from './shared/ScrollableList.js';
 
 // Limit Gemini messages to a very high number of lines to mitigate performance
@@ -487,27 +488,10 @@ export const MainContent = () => {
     return map;
   }, [historyItemsWithSourceCopyOffsets]);
 
-  // Aggregate continuation text for each gemini_thought item so the
-  // thinking viewer can show the full reasoning (header + continuations).
-  const thinkingFullTextByItem = useMemo(() => {
-    const map = new Map<HistoryItem, string>();
-    for (let i = 0; i < mergedHistory.length; i++) {
-      const item = mergedHistory[i]!;
-      if (item.type !== 'gemini_thought') continue;
-      let fullText = item.text;
-      let hasContinuation = false;
-      for (let j = i + 1; j < mergedHistory.length; j++) {
-        const next = mergedHistory[j]!;
-        if (next.type !== 'gemini_thought_content') break;
-        fullText += '\n' + next.text;
-        hasContinuation = true;
-      }
-      if (hasContinuation) {
-        map.set(item, fullText);
-      }
-    }
-    return map;
-  }, [mergedHistory]);
+  const thinkingFullTextByItem = useMemo(
+    () => buildThinkingFullTextMap(mergedHistory),
+    [mergedHistory],
+  );
   const thinkingFullTextByItemRef = useRef(thinkingFullTextByItem);
   thinkingFullTextByItemRef.current = thinkingFullTextByItem;
 

--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -487,6 +487,30 @@ export const MainContent = () => {
     return map;
   }, [historyItemsWithSourceCopyOffsets]);
 
+  // Aggregate continuation text for each gemini_thought item so the
+  // thinking viewer can show the full reasoning (header + continuations).
+  const thinkingFullTextByItem = useMemo(() => {
+    const map = new Map<HistoryItem, string>();
+    for (let i = 0; i < mergedHistory.length; i++) {
+      const item = mergedHistory[i]!;
+      if (item.type !== 'gemini_thought') continue;
+      let fullText = item.text;
+      let hasContinuation = false;
+      for (let j = i + 1; j < mergedHistory.length; j++) {
+        const next = mergedHistory[j]!;
+        if (next.type !== 'gemini_thought_content') break;
+        fullText += '\n' + next.text;
+        hasContinuation = true;
+      }
+      if (hasContinuation) {
+        map.set(item, fullText);
+      }
+    }
+    return map;
+  }, [mergedHistory]);
+  const thinkingFullTextByItemRef = useRef(thinkingFullTextByItem);
+  thinkingFullTextByItemRef.current = thinkingFullTextByItem;
+
   const pendingSourceCopyOffsetsByIndex = useMemo(
     () =>
       pendingHistoryItemsWithSourceCopyOffsets.map(
@@ -567,6 +591,7 @@ export const MainContent = () => {
           compactLabel={getCompactLabel(item)}
           summaryAbsorbed={isSummaryAbsorbed(item)}
           sourceCopyIndexOffsets={sourceCopyIndexOffsets}
+          thinkingFullText={thinkingFullTextByItemRef.current.get(item)}
         />
       );
     },
@@ -641,6 +666,7 @@ export const MainContent = () => {
                 compactLabel={getCompactLabel(h)}
                 summaryAbsorbed={isSummaryAbsorbed(h)}
                 sourceCopyIndexOffsets={sourceCopyIndexOffsets}
+                thinkingFullText={thinkingFullTextByItem.get(h)}
               />
             ),
           ),

--- a/packages/cli/src/ui/components/SessionPreview.tsx
+++ b/packages/cli/src/ui/components/SessionPreview.tsx
@@ -170,6 +170,7 @@ export function SessionPreview(props: SessionPreviewProps) {
                 item={item}
                 terminalWidth={boxWidth}
                 isPending={false}
+                thoughtExpanded={true}
               />
             )),
             footerSeparator,

--- a/packages/cli/src/ui/components/ThinkingViewer.tsx
+++ b/packages/cli/src/ui/components/ThinkingViewer.tsx
@@ -17,22 +17,13 @@ import { t } from '../../i18n/index.js';
 import { AlternateScreen } from './AlternateScreen.js';
 import type { ThinkingViewerData } from '../contexts/ThinkingViewerContext.js';
 import { THINKING_ICON } from './messages/ConversationMessages.js';
+import { formatDuration } from '../utils/displayUtils.js';
 
 interface ThinkingViewerProps {
   data: ThinkingViewerData;
   onClose: () => void;
   /** When true, Ink already owns the alternate screen (VP mode) — skip escape writes. */
   useAlternateScreen?: boolean;
-}
-
-function formatDuration(ms: number): string {
-  const totalSeconds = Math.round(ms / 1000);
-  if (totalSeconds < 60) {
-    return `${totalSeconds}s`;
-  }
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
 }
 
 const WHEEL_LINES = 3;

--- a/packages/cli/src/ui/components/ThinkingViewer.tsx
+++ b/packages/cli/src/ui/components/ThinkingViewer.tsx
@@ -119,7 +119,8 @@ export const ThinkingViewer: FC<ThinkingViewerProps> = ({ data, onClose }) => {
       >
         <Box>
           <Text color={theme.text.accent} bold>
-            {THINKING_ICON} {title}
+            {THINKING_ICON}
+            {title}
           </Text>
           <Text dimColor>{scrollIndicator}</Text>
         </Box>

--- a/packages/cli/src/ui/components/ThinkingViewer.tsx
+++ b/packages/cli/src/ui/components/ThinkingViewer.tsx
@@ -5,7 +5,7 @@
  */
 
 import type { FC } from 'react';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { Box, Text } from 'ink';
 import { useTerminalSize } from '../hooks/useTerminalSize.js';
 import { useKeypress, type Key } from '../hooks/useKeypress.js';
@@ -44,6 +44,10 @@ export const ThinkingViewer: FC<ThinkingViewerProps> = ({ data, onClose }) => {
 
   const lines = data.text.split('\n');
   const maxScroll = Math.max(0, lines.length - contentHeight);
+
+  useEffect(() => {
+    setScrollOffset((prev) => Math.min(prev, maxScroll));
+  }, [maxScroll]);
 
   const scrollBy = useCallback(
     (delta: number) => {

--- a/packages/cli/src/ui/components/ThinkingViewer.tsx
+++ b/packages/cli/src/ui/components/ThinkingViewer.tsx
@@ -21,6 +21,8 @@ import { THINKING_ICON } from './messages/ConversationMessages.js';
 interface ThinkingViewerProps {
   data: ThinkingViewerData;
   onClose: () => void;
+  /** When true, Ink already owns the alternate screen (VP mode) — skip escape writes. */
+  useAlternateScreen?: boolean;
 }
 
 function formatDuration(ms: number): string {
@@ -35,7 +37,11 @@ function formatDuration(ms: number): string {
 
 const WHEEL_LINES = 3;
 
-export const ThinkingViewer: FC<ThinkingViewerProps> = ({ data, onClose }) => {
+export const ThinkingViewer: FC<ThinkingViewerProps> = ({
+  data,
+  onClose,
+  useAlternateScreen = true,
+}) => {
   const { rows } = useTerminalSize();
   const [scrollOffset, setScrollOffset] = useState(0);
 
@@ -109,7 +115,7 @@ export const ThinkingViewer: FC<ThinkingViewerProps> = ({ data, onClose }) => {
   const scrollIndicator = maxScroll > 0 ? ` (${scrollPercent}%)` : '';
 
   return (
-    <AlternateScreen>
+    <AlternateScreen disabled={!useAlternateScreen}>
       <Box
         flexDirection="column"
         borderStyle="round"

--- a/packages/cli/src/ui/components/ThinkingViewer.tsx
+++ b/packages/cli/src/ui/components/ThinkingViewer.tsx
@@ -125,7 +125,7 @@ export const ThinkingViewer: FC<ThinkingViewerProps> = ({ data, onClose }) => {
         </Box>
         <Box flexDirection="column" flexGrow={1}>
           {visibleLines.map((line, i) => (
-            <Text key={scrollOffset + i} dimColor wrap="truncate-end">
+            <Text key={i} dimColor wrap="truncate-end">
               {line || ' '}
             </Text>
           ))}

--- a/packages/cli/src/ui/components/ThinkingViewer.tsx
+++ b/packages/cli/src/ui/components/ThinkingViewer.tsx
@@ -1,0 +1,138 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { FC } from 'react';
+import { useState, useCallback } from 'react';
+import { Box, Text } from 'ink';
+import { useTerminalSize } from '../hooks/useTerminalSize.js';
+import { useKeypress, type Key } from '../hooks/useKeypress.js';
+import { useMouseEvents } from '../hooks/useMouseEvents.js';
+import type { MouseEvent } from '../utils/mouse.js';
+import { keyMatchers, Command } from '../keyMatchers.js';
+import { theme } from '../semantic-colors.js';
+import { t } from '../../i18n/index.js';
+import { AlternateScreen } from './AlternateScreen.js';
+import type { ThinkingViewerData } from '../contexts/ThinkingViewerContext.js';
+
+interface ThinkingViewerProps {
+  data: ThinkingViewerData;
+  onClose: () => void;
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`;
+  }
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+}
+
+const WHEEL_LINES = 3;
+
+export const ThinkingViewer: FC<ThinkingViewerProps> = ({ data, onClose }) => {
+  const { rows } = useTerminalSize();
+  const [scrollOffset, setScrollOffset] = useState(0);
+
+  const headerHeight = 2;
+  const footerHeight = 2;
+  const contentHeight = Math.max(rows - headerHeight - footerHeight, 1);
+
+  const lines = data.text.split('\n');
+  const maxScroll = Math.max(0, lines.length - contentHeight);
+
+  const scrollBy = useCallback(
+    (delta: number) => {
+      setScrollOffset((prev) => Math.max(0, Math.min(maxScroll, prev + delta)));
+    },
+    [maxScroll],
+  );
+
+  useKeypress(
+    useCallback(
+      (key: Key) => {
+        if (keyMatchers[Command.ESCAPE](key)) {
+          onClose();
+        } else if (keyMatchers[Command.SCROLL_UP](key) || key.name === 'up') {
+          scrollBy(-1);
+        } else if (
+          keyMatchers[Command.SCROLL_DOWN](key) ||
+          key.name === 'down'
+        ) {
+          scrollBy(1);
+        } else if (keyMatchers[Command.PAGE_UP](key)) {
+          scrollBy(-contentHeight);
+        } else if (keyMatchers[Command.PAGE_DOWN](key)) {
+          scrollBy(contentHeight);
+        } else if (keyMatchers[Command.SCROLL_HOME](key)) {
+          setScrollOffset(0);
+        } else if (keyMatchers[Command.SCROLL_END](key)) {
+          setScrollOffset(maxScroll);
+        }
+      },
+      [onClose, scrollBy, contentHeight, maxScroll],
+    ),
+    { isActive: true },
+  );
+
+  useMouseEvents(
+    useCallback(
+      (event: MouseEvent) => {
+        if (event.name === 'scroll-up') {
+          scrollBy(-WHEEL_LINES);
+        } else if (event.name === 'scroll-down') {
+          scrollBy(WHEEL_LINES);
+        }
+      },
+      [scrollBy],
+    ),
+    { isActive: true },
+  );
+
+  const title =
+    data.durationMs != null
+      ? `${t('Thought for')} ${formatDuration(data.durationMs)}`
+      : t('Thinking');
+
+  const visibleLines = lines.slice(scrollOffset, scrollOffset + contentHeight);
+  const scrollPercent =
+    maxScroll > 0 ? Math.round((scrollOffset / maxScroll) * 100) : 0;
+  const scrollIndicator = maxScroll > 0 ? ` (${scrollPercent}%)` : '';
+
+  return (
+    <AlternateScreen>
+      <Box
+        flexDirection="column"
+        borderStyle="round"
+        borderColor={theme.text.secondary}
+        paddingX={1}
+        height={rows}
+      >
+        <Box>
+          <Text color={theme.text.accent} bold>
+            {'⟡ '}
+            {title}
+          </Text>
+          <Text dimColor>{scrollIndicator}</Text>
+        </Box>
+        <Box flexDirection="column" flexGrow={1}>
+          {visibleLines.map((line, i) => (
+            <Text key={scrollOffset + i} dimColor wrap="truncate-end">
+              {line || ' '}
+            </Text>
+          ))}
+        </Box>
+        <Box justifyContent="center">
+          <Text dimColor italic>
+            ESC {t('to close')} {'  '}↑↓ {t('to scroll')} {'  '}PgUp/PgDn{' '}
+            Home/End
+          </Text>
+        </Box>
+      </Box>
+    </AlternateScreen>
+  );
+};

--- a/packages/cli/src/ui/components/ThinkingViewer.tsx
+++ b/packages/cli/src/ui/components/ThinkingViewer.tsx
@@ -5,7 +5,7 @@
  */
 
 import type { FC } from 'react';
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import { Box, Text } from 'ink';
 import { useTerminalSize } from '../hooks/useTerminalSize.js';
 import { useKeypress, type Key } from '../hooks/useKeypress.js';
@@ -43,7 +43,7 @@ export const ThinkingViewer: FC<ThinkingViewerProps> = ({ data, onClose }) => {
   const footerHeight = 2;
   const contentHeight = Math.max(rows - headerHeight - footerHeight, 1);
 
-  const lines = data.text.split('\n');
+  const lines = useMemo(() => data.text.split('\n'), [data.text]);
   const maxScroll = Math.max(0, lines.length - contentHeight);
 
   useEffect(() => {

--- a/packages/cli/src/ui/components/ThinkingViewer.tsx
+++ b/packages/cli/src/ui/components/ThinkingViewer.tsx
@@ -16,6 +16,7 @@ import { theme } from '../semantic-colors.js';
 import { t } from '../../i18n/index.js';
 import { AlternateScreen } from './AlternateScreen.js';
 import type { ThinkingViewerData } from '../contexts/ThinkingViewerContext.js';
+import { THINKING_ICON } from './messages/ConversationMessages.js';
 
 interface ThinkingViewerProps {
   data: ThinkingViewerData;
@@ -118,8 +119,7 @@ export const ThinkingViewer: FC<ThinkingViewerProps> = ({ data, onClose }) => {
       >
         <Box>
           <Text color={theme.text.accent} bold>
-            {'⟡ '}
-            {title}
+            {THINKING_ICON} {title}
           </Text>
           <Text dimColor>{scrollIndicator}</Text>
         </Box>

--- a/packages/cli/src/ui/components/ThinkingViewer.tsx
+++ b/packages/cli/src/ui/components/ThinkingViewer.tsx
@@ -134,7 +134,7 @@ export const ThinkingViewer: FC<ThinkingViewerProps> = ({ data, onClose }) => {
         <Box justifyContent="center">
           <Text dimColor italic>
             ESC {t('to close')} {'  '}↑↓ {t('to scroll')} {'  '}PgUp/PgDn{' '}
-            Home/End
+            Ctrl+Home/End
           </Text>
         </Box>
       </Box>

--- a/packages/cli/src/ui/components/agent-view/AgentChatContent.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentChatContent.tsx
@@ -25,6 +25,7 @@ import { useTerminalSize } from '../../hooks/useTerminalSize.js';
 import { useKeypress } from '../../hooks/useKeypress.js';
 import { useAgentViewActions } from '../../contexts/AgentViewContext.js';
 import { HistoryItemDisplay } from '../HistoryItemDisplay.js';
+import type { HistoryItem } from '../../types.js';
 import { ToolCallStatus } from '../../types.js';
 import { theme } from '../../semantic-colors.js';
 import { GeminiRespondingSpinner } from '../GeminiRespondingSpinner.js';
@@ -198,6 +199,26 @@ export const AgentChatContent = ({
   const committedItems = allItems.slice(0, splitIndex);
   const pendingItems = allItems.slice(splitIndex);
 
+  const thinkingFullTextByItem = useMemo(() => {
+    const map = new Map<HistoryItem, string>();
+    for (let i = 0; i < allItems.length; i++) {
+      const item = allItems[i]!;
+      if (item.type !== 'gemini_thought') continue;
+      let fullText = item.text;
+      let hasContinuation = false;
+      for (let j = i + 1; j < allItems.length; j++) {
+        const next = allItems[j]!;
+        if (next.type !== 'gemini_thought_content') break;
+        fullText += '\n' + next.text;
+        hasContinuation = true;
+      }
+      if (hasContinuation) {
+        map.set(item, fullText);
+      }
+    }
+    return map;
+  }, [allItems]);
+
   const agentWorkingDir = core.runtimeContext.getTargetDir() ?? '';
   // Cache the branch — it won't change during the agent's lifetime and
   // getGitBranch uses synchronous execSync which blocks the render loop.
@@ -232,6 +253,7 @@ export const AgentChatContent = ({
               isPending={false}
               terminalWidth={terminalWidth}
               mainAreaWidth={contentWidth}
+              thinkingFullText={thinkingFullTextByItem.get(item)}
             />
           )),
         ]}

--- a/packages/cli/src/ui/components/agent-view/AgentChatContent.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentChatContent.tsx
@@ -25,12 +25,12 @@ import { useTerminalSize } from '../../hooks/useTerminalSize.js';
 import { useKeypress } from '../../hooks/useKeypress.js';
 import { useAgentViewActions } from '../../contexts/AgentViewContext.js';
 import { HistoryItemDisplay } from '../HistoryItemDisplay.js';
-import type { HistoryItem } from '../../types.js';
 import { ToolCallStatus } from '../../types.js';
 import { theme } from '../../semantic-colors.js';
 import { GeminiRespondingSpinner } from '../GeminiRespondingSpinner.js';
 import { agentMessagesToHistoryItems } from './agentHistoryAdapter.js';
 import { AgentHeader } from './AgentHeader.js';
+import { buildThinkingFullTextMap } from '../../utils/historyUtils.js';
 
 export interface AgentChatContentProps {
   /** The agent's AgentCore — the source of truth for transcript state. */
@@ -199,25 +199,10 @@ export const AgentChatContent = ({
   const committedItems = allItems.slice(0, splitIndex);
   const pendingItems = allItems.slice(splitIndex);
 
-  const thinkingFullTextByItem = useMemo(() => {
-    const map = new Map<HistoryItem, string>();
-    for (let i = 0; i < allItems.length; i++) {
-      const item = allItems[i]!;
-      if (item.type !== 'gemini_thought') continue;
-      let fullText = item.text;
-      let hasContinuation = false;
-      for (let j = i + 1; j < allItems.length; j++) {
-        const next = allItems[j]!;
-        if (next.type !== 'gemini_thought_content') break;
-        fullText += '\n' + next.text;
-        hasContinuation = true;
-      }
-      if (hasContinuation) {
-        map.set(item, fullText);
-      }
-    }
-    return map;
-  }, [allItems]);
+  const thinkingFullTextByItem = useMemo(
+    () => buildThinkingFullTextMap(allItems),
+    [allItems],
+  );
 
   const agentWorkingDir = core.runtimeContext.getTargetDir() ?? '';
   // Cache the branch — it won't change during the agent's lifetime and

--- a/packages/cli/src/ui/components/messages/ConversationMessages.test.tsx
+++ b/packages/cli/src/ui/components/messages/ConversationMessages.test.tsx
@@ -19,7 +19,7 @@ describe('<ThinkMessage />', () => {
     );
     const output = lastFrame();
     expect(output).toContain('Thinking');
-    expect(output).not.toContain('click to view');
+    expect(output).not.toContain('alt+t to expand');
   });
 
   it('should render collapsed line when committed and not expanded', () => {
@@ -28,7 +28,7 @@ describe('<ThinkMessage />', () => {
     );
     const output = lastFrame();
     expect(output).toContain('Thinking');
-    expect(output).toContain('click to view');
+    expect(output).toContain('alt+t to expand');
     expect(output).not.toContain('Analyzing the code structure');
   });
 
@@ -45,7 +45,7 @@ describe('<ThinkMessage />', () => {
       <ThinkMessage {...defaultProps} isPending={false} />,
     );
     const output = lastFrame();
-    expect(output).toContain('click to view');
+    expect(output).toContain('alt+t to expand');
     expect(output).not.toContain('Analyzing the code structure');
   });
 
@@ -61,7 +61,7 @@ describe('<ThinkMessage />', () => {
     const output = lastFrame();
     expect(output).toContain('Thought for');
     expect(output).toContain('15s');
-    expect(output).toContain('click to view');
+    expect(output).toContain('alt+t to expand');
   });
 
   it('should show present-tense duration while pending (streaming)', () => {

--- a/packages/cli/src/ui/components/messages/ConversationMessages.test.tsx
+++ b/packages/cli/src/ui/components/messages/ConversationMessages.test.tsx
@@ -19,7 +19,7 @@ describe('<ThinkMessage />', () => {
     );
     const output = lastFrame();
     expect(output).toContain('Thinking');
-    expect(output).not.toContain('ctrl+o to expand');
+    expect(output).not.toContain('click to view');
   });
 
   it('should render collapsed line when committed and not expanded', () => {
@@ -28,7 +28,7 @@ describe('<ThinkMessage />', () => {
     );
     const output = lastFrame();
     expect(output).toContain('Thinking');
-    expect(output).toContain('ctrl+o to expand');
+    expect(output).toContain('click to view');
     expect(output).not.toContain('Analyzing the code structure');
   });
 
@@ -45,7 +45,7 @@ describe('<ThinkMessage />', () => {
       <ThinkMessage {...defaultProps} isPending={false} />,
     );
     const output = lastFrame();
-    expect(output).toContain('ctrl+o to expand');
+    expect(output).toContain('click to view');
     expect(output).not.toContain('Analyzing the code structure');
   });
 
@@ -61,7 +61,7 @@ describe('<ThinkMessage />', () => {
     const output = lastFrame();
     expect(output).toContain('Thought for');
     expect(output).toContain('15s');
-    expect(output).toContain('ctrl+o to expand');
+    expect(output).toContain('click to view');
   });
 
   it('should show present-tense duration while pending (streaming)', () => {

--- a/packages/cli/src/ui/components/messages/ConversationMessages.tsx
+++ b/packages/cli/src/ui/components/messages/ConversationMessages.tsx
@@ -24,11 +24,11 @@ import {
 import { t } from '../../../i18n/index.js';
 import { getCachedStringWidth } from '../../utils/textUtils.js';
 
-// Prefer emoji lightbulb; fall back to ⟡ in CI or non-UTF-8 locales.
-const supportsEmoji =
-  !process.env['CI'] &&
-  /utf-?8/i.test(process.env['LANG'] || process.env['LC_ALL'] || '');
-export const THINKING_ICON = supportsEmoji ? '💡' : '⟡';
+const isUtf8 = /utf-?8/i.test(
+  process.env['LANG'] || process.env['LC_ALL'] || '',
+);
+export const THINKING_ICON =
+  !process.env['CI'] && isUtf8 ? '💡 ' : isUtf8 ? '⟡ ' : '';
 
 interface UserMessageProps {
   text: string;
@@ -394,7 +394,8 @@ export const ThinkMessage: React.FC<ThinkMessageProps> = ({
         : t('Thinking');
     return (
       <Text dimColor italic>
-        {THINKING_ICON} {label} {t('(click to view)')}
+        {THINKING_ICON}
+        {label} {t('(alt+t to expand)')}
       </Text>
     );
   }
@@ -415,7 +416,8 @@ export const ThinkMessage: React.FC<ThinkMessageProps> = ({
     return (
       <Box flexDirection="column">
         <Text dimColor italic>
-          {THINKING_ICON} {t('Thinking')}…{durationSuffix}
+          {THINKING_ICON}
+          {t('Thinking')}…{durationSuffix}
         </Text>
         <Box paddingLeft={2}>
           <Text dimColor wrap="truncate">
@@ -433,7 +435,8 @@ export const ThinkMessage: React.FC<ThinkMessageProps> = ({
   return (
     <Box flexDirection="column">
       <Text dimColor italic>
-        {THINKING_ICON} {expandedLabel}
+        {THINKING_ICON}
+        {expandedLabel} {t('(alt+t to collapse)')}
       </Text>
       <Box paddingLeft={2} flexDirection="column">
         <MarkdownDisplay

--- a/packages/cli/src/ui/components/messages/ConversationMessages.tsx
+++ b/packages/cli/src/ui/components/messages/ConversationMessages.tsx
@@ -24,6 +24,12 @@ import {
 import { t } from '../../../i18n/index.js';
 import { getCachedStringWidth } from '../../utils/textUtils.js';
 
+// Prefer emoji lightbulb; fall back to ⟡ in CI or non-UTF-8 locales.
+const supportsEmoji =
+  !process.env['CI'] &&
+  /utf-?8/i.test(process.env['LANG'] || process.env['LC_ALL'] || '');
+export const THINKING_ICON = supportsEmoji ? '💡' : '⟡';
+
 interface UserMessageProps {
   text: string;
   width?: number;
@@ -388,7 +394,7 @@ export const ThinkMessage: React.FC<ThinkMessageProps> = ({
         : t('Thinking');
     return (
       <Text dimColor italic>
-        {label} {t('(click to view)')}
+        {THINKING_ICON} {label} {t('(click to view)')}
       </Text>
     );
   }
@@ -409,7 +415,7 @@ export const ThinkMessage: React.FC<ThinkMessageProps> = ({
     return (
       <Box flexDirection="column">
         <Text dimColor italic>
-          ⟡ {t('Thinking')}…{durationSuffix}
+          {THINKING_ICON} {t('Thinking')}…{durationSuffix}
         </Text>
         <Box paddingLeft={2}>
           <Text dimColor wrap="truncate">
@@ -427,7 +433,7 @@ export const ThinkMessage: React.FC<ThinkMessageProps> = ({
   return (
     <Box flexDirection="column">
       <Text dimColor italic>
-        {expandedLabel}
+        {THINKING_ICON} {expandedLabel}
       </Text>
       <Box paddingLeft={2} flexDirection="column">
         <MarkdownDisplay

--- a/packages/cli/src/ui/components/messages/ConversationMessages.tsx
+++ b/packages/cli/src/ui/components/messages/ConversationMessages.tsx
@@ -388,7 +388,7 @@ export const ThinkMessage: React.FC<ThinkMessageProps> = ({
         : t('Thinking');
     return (
       <Text dimColor italic>
-        {label} {t('(ctrl+o to expand)')}
+        {label} {t('(click to view)')}
       </Text>
     );
   }

--- a/packages/cli/src/ui/components/messages/ConversationMessages.tsx
+++ b/packages/cli/src/ui/components/messages/ConversationMessages.tsx
@@ -23,6 +23,7 @@ import {
 } from '../../themes/color-utils.js';
 import { t } from '../../../i18n/index.js';
 import { getCachedStringWidth } from '../../utils/textUtils.js';
+import { formatDuration } from '../../utils/displayUtils.js';
 
 const isUtf8 = /utf-?8/i.test(
   process.env['LANG'] || process.env['LC_ALL'] || '',
@@ -364,16 +365,6 @@ function tailVisualLines(
   }
   const lines = wrapToVisualLines(text.slice(sliceStart), width);
   return lines.slice(-maxLines).join('\n');
-}
-
-function formatDuration(ms: number): string {
-  const totalSeconds = Math.round(ms / 1000);
-  if (totalSeconds < 60) {
-    return `${totalSeconds}s`;
-  }
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
 }
 
 export const ThinkMessage: React.FC<ThinkMessageProps> = ({

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -23,6 +23,10 @@ import readline from 'node:readline';
 import { PassThrough } from 'node:stream';
 import { noteInteraction } from '../../utils/housekeeping/lastInteractionAt.js';
 import {
+  parseSGRMouseEvent,
+  type MouseEvent as SgrMouseEvent,
+} from '../utils/mouse.js';
+import {
   BACKSLASH_ENTER_DETECTION_WINDOW_MS,
   CHAR_CODE_ESC,
   KITTY_CTRL_C,
@@ -110,10 +114,13 @@ export interface Key {
 }
 
 export type KeypressHandler = (key: Key) => void;
+export type MouseHandler = (event: SgrMouseEvent) => void;
 
 interface KeypressContextValue {
   subscribe: (handler: KeypressHandler) => void;
   unsubscribe: (handler: KeypressHandler) => void;
+  subscribeMouse: (handler: MouseHandler) => void;
+  unsubscribeMouse: (handler: MouseHandler) => void;
   pasteWorkaround: boolean;
 }
 
@@ -149,6 +156,7 @@ export function KeypressProvider({
 }) {
   const { stdin, setRawMode } = useStdin();
   const subscribers = useRef<Set<KeypressHandler>>(new Set()).current;
+  const mouseSubscribers = useRef<Set<MouseHandler>>(new Set()).current;
 
   const subscribe = useCallback(
     (handler: KeypressHandler) => {
@@ -162,6 +170,20 @@ export function KeypressProvider({
       subscribers.delete(handler);
     },
     [subscribers],
+  );
+
+  const subscribeMouse = useCallback(
+    (handler: MouseHandler) => {
+      mouseSubscribers.add(handler);
+    },
+    [mouseSubscribers],
+  );
+
+  const unsubscribeMouse = useCallback(
+    (handler: MouseHandler) => {
+      mouseSubscribers.delete(handler);
+    },
+    [mouseSubscribers],
   );
 
   useEffect(() => {
@@ -194,6 +216,7 @@ export function KeypressProvider({
     let rawDataBuffer = Buffer.alloc(0);
     let rawFlushTimeout: NodeJS.Timeout | null = null;
     let swallowingSgrMouse = false;
+    let sgrMouseBuffer = '';
     let sgrMouseTimeout: NodeJS.Timeout | null = null;
 
     const updateKittyBuffer = (value: string) => {
@@ -677,37 +700,47 @@ export function KeypressProvider({
         return;
       }
 
-      // SGR mouse sequences (\x1b[<...M or \x1b[<...m) are handled by
-      // useMouseEvents via ink's useInput pipeline. readline's CSI parser
-      // treats the `<` parameter byte as a final byte, splitting the
-      // sequence into a CSI event (\x1b[<) followed by individual character
-      // events (digits, semicolons, M/m). Without this filter, those
-      // trailing characters would appear as typed text in the input box.
+      // SGR mouse sequences (\x1b[<...M or \x1b[<...m): readline's CSI
+      // parser treats `<` as a final byte, splitting the sequence into
+      // \x1b[< followed by individual character events. We buffer the
+      // fragments, reconstruct the full sequence, parse it, and forward
+      // to registered mouse handlers.
       if (swallowingSgrMouse) {
         if (key.ctrl && key.name === 'c') {
           swallowingSgrMouse = false;
+          sgrMouseBuffer = '';
           if (sgrMouseTimeout) {
             clearTimeout(sgrMouseTimeout);
             sgrMouseTimeout = null;
           }
         } else {
+          sgrMouseBuffer += key.sequence;
           if (key.name === 'm' || key.sequence === 'M') {
             swallowingSgrMouse = false;
             if (sgrMouseTimeout) {
               clearTimeout(sgrMouseTimeout);
               sgrMouseTimeout = null;
             }
+            const parsed = parseSGRMouseEvent(sgrMouseBuffer);
+            if (parsed) {
+              for (const handler of mouseSubscribers) {
+                handler(parsed.event);
+              }
+            }
+            sgrMouseBuffer = '';
           }
           return;
         }
       }
       if (key.sequence === `${ESC}[<`) {
         swallowingSgrMouse = true;
+        sgrMouseBuffer = `${ESC}[<`;
         if (sgrMouseTimeout) {
           clearTimeout(sgrMouseTimeout);
         }
         sgrMouseTimeout = setTimeout(() => {
           swallowingSgrMouse = false;
+          sgrMouseBuffer = '';
           sgrMouseTimeout = null;
         }, KITTY_SEQUENCE_TIMEOUT_MS);
         return;
@@ -1198,6 +1231,7 @@ export function KeypressProvider({
         sgrMouseTimeout = null;
       }
       swallowingSgrMouse = false;
+      sgrMouseBuffer = '';
 
       if (rawFlushTimeout) {
         clearTimeout(rawFlushTimeout);
@@ -1225,12 +1259,19 @@ export function KeypressProvider({
     pasteWorkaround,
     config,
     subscribers,
+    mouseSubscribers,
     initialCapturedInput,
   ]);
 
   return (
     <KeypressContext.Provider
-      value={{ subscribe, unsubscribe, pasteWorkaround }}
+      value={{
+        subscribe,
+        unsubscribe,
+        subscribeMouse,
+        unsubscribeMouse,
+        pasteWorkaround,
+      }}
     >
       {children}
     </KeypressContext.Provider>

--- a/packages/cli/src/ui/contexts/ThinkingViewerContext.tsx
+++ b/packages/cli/src/ui/contexts/ThinkingViewerContext.tsx
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createContext, useContext } from 'react';
+
+export interface ThinkingViewerData {
+  text: string;
+  durationMs?: number;
+}
+
+export interface ThinkingViewerContextType {
+  openThinkingViewer: (data: ThinkingViewerData) => void;
+}
+
+const ThinkingViewerContext = createContext<ThinkingViewerContextType>({
+  openThinkingViewer: () => {},
+});
+
+export const useThinkingViewer = (): ThinkingViewerContextType =>
+  useContext(ThinkingViewerContext);
+
+export const ThinkingViewerProvider = ThinkingViewerContext.Provider;

--- a/packages/cli/src/ui/contexts/ThoughtExpandedContext.tsx
+++ b/packages/cli/src/ui/contexts/ThoughtExpandedContext.tsx
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createContext, useContext } from 'react';
+
+const ThoughtExpandedContext = createContext(false);
+
+export const useThoughtExpanded = (): boolean =>
+  useContext(ThoughtExpandedContext);
+
+export const ThoughtExpandedProvider = ThoughtExpandedContext.Provider;

--- a/packages/cli/src/ui/hooks/useMouseEvents.ts
+++ b/packages/cli/src/ui/hooks/useMouseEvents.ts
@@ -5,22 +5,18 @@
  *
  * Inspired by gemini-cli's MouseContext (Google LLC, Apache-2.0) but
  * collapsed for our single-consumer case: enable SGR mouse mode on
- * mount, parse mouse sequences out of ink's input pipeline, call the
- * handler, restore on unmount.
+ * mount, parse mouse sequences out of the KeypressContext pipeline,
+ * call the handler, restore on unmount.
  */
 
-import { useEffect, useRef } from 'react';
-import { useStdin, useStdout, useInput } from 'ink';
+import { useEffect, useRef, useCallback } from 'react';
+import { useStdin, useStdout } from 'ink';
 import {
   enableMouseEvents,
   disableMouseEvents,
-  parseSGRMouseEvent,
   type MouseEvent,
 } from '../utils/mouse.js';
-
-// Use the `\x1b` escape so the source survives transports that strip raw
-// 0x1B bytes (terminal copies, code review tools, some linters).
-const ESC = '\x1b';
+import { useKeypressContext } from '../contexts/KeypressContext.js';
 
 export type MouseHandler = (event: MouseEvent) => void;
 
@@ -28,28 +24,17 @@ export type MouseHandler = (event: MouseEvent) => void;
  * Subscribes to SGR mouse events while `isActive` is true.
  *
  * On activation: writes `?1002h ?1006h` to enable button-event tracking and
- * SGR coordinates, then parses mouse sequences delivered through ink's own
- * input pipeline. On cleanup (or when `isActive` flips false): writes
- * `?1006l ?1002l` to restore the terminal.
+ * SGR coordinates. KeypressContext's readline pipeline receives the SGR
+ * fragments, reconstructs the full sequence, parses it, and forwards the
+ * parsed MouseEvent to subscribers registered via `subscribeMouse`. On
+ * cleanup (or when `isActive` flips false): writes `?1006l ?1002l` to
+ * restore the terminal.
  *
- * Why not a dedicated `stdin.on('data')` listener: attaching a `data`
- * listener switches stdin into flowing mode, which drains the buffer before
- * ink's `readable` + `stdin.read()` reader (App.js) can consume it — every
- * keystroke routed through `useInput` would be silently starved while mouse
- * mode is active. Instead we hook ink's `useInput`, which already owns the
- * single stdin reader. ink's input parser captures a full SGR sequence
- * (`ESC [ < … M/m`) as one CSI event and hands it to the handler with the
- * leading ESC stripped (use-input strips a leading `\x1b`), so we re-prepend
- * it before parsing. Non-mouse input does not match and is ignored; ink
- * still routes the same input to the app's other `useInput` handlers, so
- * keyboard navigation is unaffected.
- *
- * Note: only SGR mode (`?1006h`, which we enable) is parsed via this path —
- * we call `parseSGRMouseEvent` directly rather than `parseMouseEvent` (which
- * also tries the X11 fallback). X11 is unwanted here: ink's CSI parser
- * mangles a real `ESC [ M` + 3-byte sequence anyway, and a literal X11 prefix
- * arriving via pasted text could otherwise misfire a spurious mouse event.
- * SGR is the encoding modern terminals emit once `?1006h` is set.
+ * Earlier versions used ink's `useInput` to receive mouse events, but
+ * readline's `emitKeypressEvents` drains stdin in flowing mode before
+ * ink's `readable` + `stdin.read()` reader can consume it — useInput
+ * never fires when KeypressContext is active. The current approach routes
+ * mouse events through the same readline pipeline as keyboard input.
  *
  * The handler is stored in a ref so callers don't need to memoize it.
  */
@@ -59,6 +44,7 @@ export function useMouseEvents(
 ): void {
   const { isRawModeSupported } = useStdin();
   const { stdout } = useStdout();
+  const { subscribeMouse, unsubscribeMouse } = useKeypressContext();
 
   const handlerRef = useRef(handler);
   handlerRef.current = handler;
@@ -70,13 +56,6 @@ export function useMouseEvents(
 
     enableMouseEvents(stdout);
 
-    // Belt-and-braces: if the process exits without React unmounting us
-    // (Ctrl+C → exit, SIGTERM, parent killed), the React cleanup below
-    // never runs and the terminal stays in SGR mouse-tracking mode after
-    // qwen exits — wheel events would be echoed as literal escape
-    // sequences. Hook `exit` to write the disable seq one more time as
-    // a fallback. Node never throws from an `exit` listener, so even if
-    // stdout is broken (EPIPE) the process still terminates cleanly.
     const onExit = () => {
       disableMouseEvents(stdout);
     };
@@ -88,18 +67,14 @@ export function useMouseEvents(
     };
   }, [enabled, stdout]);
 
-  useInput(
-    (input) => {
-      // ink hands us one escape sequence per call, with the leading ESC
-      // stripped — re-prepend it so the SGR mouse regex matches.
-      let buffer = input.startsWith(ESC) ? input : ESC + input;
-      while (buffer.length > 0) {
-        const parsed = parseSGRMouseEvent(buffer);
-        if (!parsed) break;
-        handlerRef.current(parsed.event);
-        buffer = buffer.slice(parsed.length);
-      }
-    },
-    { isActive: enabled },
-  );
+  const mouseCallback = useCallback((event: MouseEvent) => {
+    handlerRef.current(event);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    subscribeMouse(mouseCallback);
+    return () => unsubscribeMouse(mouseCallback);
+  }, [enabled, subscribeMouse, unsubscribeMouse, mouseCallback]);
 }

--- a/packages/cli/src/ui/keyMatchers.test.ts
+++ b/packages/cli/src/ui/keyMatchers.test.ts
@@ -92,7 +92,8 @@ describe('keyMatchers', () => {
     [Command.PAGE_DOWN]: (key: Key) => key.name === 'pagedown',
     [Command.SCROLL_HOME]: (key: Key) => key.ctrl && key.name === 'home',
     [Command.SCROLL_END]: (key: Key) => key.ctrl && key.name === 'end',
-    [Command.OPEN_THINKING_VIEWER]: (key: Key) => key.meta && key.name === 't',
+    [Command.TOGGLE_THINKING_EXPANDED]: (key: Key) =>
+      key.meta && key.name === 't',
   };
 
   // Test data for each command with positive and negative test cases
@@ -413,7 +414,7 @@ describe('keyMatchers', () => {
       negative: [createKey('end'), createKey('end', { shift: true })],
     },
     {
-      command: Command.OPEN_THINKING_VIEWER,
+      command: Command.TOGGLE_THINKING_EXPANDED,
       positive: [createKey('t', { meta: true })],
       negative: [createKey('t'), createKey('t', { ctrl: true })],
     },

--- a/packages/cli/src/ui/keyMatchers.test.ts
+++ b/packages/cli/src/ui/keyMatchers.test.ts
@@ -92,6 +92,7 @@ describe('keyMatchers', () => {
     [Command.PAGE_DOWN]: (key: Key) => key.name === 'pagedown',
     [Command.SCROLL_HOME]: (key: Key) => key.ctrl && key.name === 'home',
     [Command.SCROLL_END]: (key: Key) => key.ctrl && key.name === 'end',
+    [Command.OPEN_THINKING_VIEWER]: (key: Key) => key.meta && key.name === 't',
   };
 
   // Test data for each command with positive and negative test cases
@@ -410,6 +411,11 @@ describe('keyMatchers', () => {
       command: Command.SCROLL_END,
       positive: [createKey('end', { ctrl: true })],
       negative: [createKey('end'), createKey('end', { shift: true })],
+    },
+    {
+      command: Command.OPEN_THINKING_VIEWER,
+      positive: [createKey('t', { meta: true })],
+      negative: [createKey('t'), createKey('t', { ctrl: true })],
     },
   ];
 

--- a/packages/cli/src/ui/utils/displayUtils.ts
+++ b/packages/cli/src/ui/utils/displayUtils.ts
@@ -61,3 +61,13 @@ export const getStatusColor = (
   }
   return options.defaultColor ?? theme.status.error;
 };
+
+export function formatDuration(ms: number): string {
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`;
+  }
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+}

--- a/packages/cli/src/ui/utils/historyUtils.test.ts
+++ b/packages/cli/src/ui/utils/historyUtils.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect } from 'vitest';
 import type { HistoryItem } from '../types.js';
 import { ToolCallStatus } from '../types.js';
 import {
+  buildThinkingFullTextMap,
   findLastUserItemIndex,
   isSyntheticHistoryItem,
   itemsAfterAreOnlySynthetic,
@@ -118,6 +119,51 @@ describe('itemsAfterAreOnlySynthetic', () => {
       ),
     ];
     expect(itemsAfterAreOnlySynthetic(h, 0)).toBe(false);
+  });
+});
+
+describe('buildThinkingFullTextMap', () => {
+  it('returns empty map when no gemini_thought items exist', () => {
+    const h: HistoryItem[] = [
+      mk({ type: 'user', text: 'hi' }, 1),
+      mk({ type: 'gemini_content', text: 'hello' }, 2),
+    ];
+    expect(buildThinkingFullTextMap(h).size).toBe(0);
+  });
+
+  it('omits thought items with no continuations', () => {
+    const h: HistoryItem[] = [
+      mk({ type: 'gemini_thought', text: 'thinking...' }, 1),
+      mk({ type: 'gemini_content', text: 'answer' }, 2),
+    ];
+    expect(buildThinkingFullTextMap(h).size).toBe(0);
+  });
+
+  it('aggregates consecutive gemini_thought_content into the preceding thought', () => {
+    const thought = mk({ type: 'gemini_thought', text: 'header' }, 1);
+    const h: HistoryItem[] = [
+      thought,
+      mk({ type: 'gemini_thought_content', text: 'part1' }, 2),
+      mk({ type: 'gemini_thought_content', text: 'part2' }, 3),
+      mk({ type: 'gemini_content', text: 'answer' }, 4),
+    ];
+    const map = buildThinkingFullTextMap(h);
+    expect(map.get(thought)).toBe('header\npart1\npart2');
+  });
+
+  it('stops aggregation at the first non-continuation item', () => {
+    const thought1 = mk({ type: 'gemini_thought', text: 't1' }, 1);
+    const thought2 = mk({ type: 'gemini_thought', text: 't2' }, 4);
+    const h: HistoryItem[] = [
+      thought1,
+      mk({ type: 'gemini_thought_content', text: 'c1' }, 2),
+      mk({ type: 'gemini_content', text: 'answer' }, 3),
+      thought2,
+      mk({ type: 'gemini_thought_content', text: 'c2' }, 5),
+    ];
+    const map = buildThinkingFullTextMap(h);
+    expect(map.get(thought1)).toBe('t1\nc1');
+    expect(map.get(thought2)).toBe('t2\nc2');
   });
 });
 

--- a/packages/cli/src/ui/utils/historyUtils.ts
+++ b/packages/cli/src/ui/utils/historyUtils.ts
@@ -124,3 +124,32 @@ export function findLastUserItemIndex(history: readonly HistoryItem[]): number {
   }
   return -1;
 }
+
+/**
+ * For each `gemini_thought` item that is immediately followed by one or
+ * more `gemini_thought_content` continuations, build the concatenated
+ * full text (header + continuations joined by newlines).  Items with no
+ * continuation are omitted from the result — callers fall back to
+ * `item.text` in that case.
+ */
+export function buildThinkingFullTextMap(
+  items: readonly HistoryItem[],
+): Map<HistoryItem, string> {
+  const map = new Map<HistoryItem, string>();
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]!;
+    if (item.type !== 'gemini_thought') continue;
+    let fullText = item.text;
+    let hasContinuation = false;
+    for (let j = i + 1; j < items.length; j++) {
+      const next = items[j]!;
+      if (next.type !== 'gemini_thought_content') break;
+      fullText += '\n' + next.text;
+      hasContinuation = true;
+    }
+    if (hasContinuation) {
+      map.set(item, fullText);
+    }
+  }
+  return map;
+}

--- a/packages/cli/src/ui/utils/measure-element-position.test.tsx
+++ b/packages/cli/src/ui/utils/measure-element-position.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect, useRef } from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, Box, Text, type DOMElement } from 'ink';
+import { measureElementPosition } from './measure-element-position.js';
+
+function createTestStdout() {
+  const stdout = Object.create(process.stdout, {
+    columns: { value: 80 },
+    rows: { value: 24 },
+    write: {
+      value() {
+        return true;
+      },
+    },
+  });
+  return { stdout };
+}
+
+describe('measureElementPosition', () => {
+  it('should return {0,0} for root-level element', async () => {
+    const { stdout } = createTestStdout();
+    let result: ReturnType<typeof measureElementPosition> | null = null;
+
+    function Test() {
+      const ref = useRef<DOMElement>(null);
+      useEffect(() => {
+        if (ref.current) {
+          result = measureElementPosition(ref.current);
+        }
+      }, []);
+      return (
+        <Box ref={ref}>
+          <Text>hello</Text>
+        </Box>
+      );
+    }
+
+    const app = render(<Test />, {
+      stdout,
+      patchConsole: false,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+    app.unmount();
+
+    expect(result).not.toBeNull();
+    expect(result!.x).toBe(0);
+    expect(result!.y).toBe(0);
+    expect(result!.width).toBeGreaterThan(0);
+    expect(result!.height).toBeGreaterThan(0);
+  });
+
+  it('should accumulate parent padding/margin offsets', async () => {
+    const { stdout } = createTestStdout();
+    let result: ReturnType<typeof measureElementPosition> | null = null;
+
+    function Test() {
+      const ref = useRef<DOMElement>(null);
+      useEffect(() => {
+        if (ref.current) {
+          result = measureElementPosition(ref.current);
+        }
+      }, []);
+      return (
+        <Box paddingLeft={3} paddingTop={2}>
+          <Box ref={ref}>
+            <Text>nested</Text>
+          </Box>
+        </Box>
+      );
+    }
+
+    const app = render(<Test />, {
+      stdout,
+      patchConsole: false,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+    app.unmount();
+
+    expect(result).not.toBeNull();
+    expect(result!.x).toBe(3);
+    expect(result!.y).toBe(2);
+  });
+
+  it('should account for sibling offset', async () => {
+    const { stdout } = createTestStdout();
+    let result: ReturnType<typeof measureElementPosition> | null = null;
+
+    function Test() {
+      const ref = useRef<DOMElement>(null);
+      useEffect(() => {
+        if (ref.current) {
+          result = measureElementPosition(ref.current);
+        }
+      }, []);
+      return (
+        <Box flexDirection="column">
+          <Box height={3}>
+            <Text>sibling above</Text>
+          </Box>
+          <Box ref={ref}>
+            <Text>target</Text>
+          </Box>
+        </Box>
+      );
+    }
+
+    const app = render(<Test />, {
+      stdout,
+      patchConsole: false,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+    app.unmount();
+
+    expect(result).not.toBeNull();
+    expect(result!.y).toBe(3);
+  });
+
+  it('should return zeroes for unmounted node', () => {
+    const fakeNode = {
+      yogaNode: undefined,
+      parentNode: undefined,
+    } as unknown as DOMElement;
+    const result = measureElementPosition(fakeNode);
+    expect(result).toEqual({ x: 0, y: 0, width: 0, height: 0 });
+  });
+});

--- a/packages/cli/src/ui/utils/measure-element-position.ts
+++ b/packages/cli/src/ui/utils/measure-element-position.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Shim for ink PR #968 (vadimdemedes/ink#968): extends measureElement()
+ * to return {x, y, width, height}. Once the upstream PR is merged and
+ * ink is upgraded, replace usages with `measureElement` from 'ink'
+ * and delete this file.
+ */
+
+import { type DOMElement } from 'ink';
+
+export interface ElementMetrics {
+  /** Horizontal position (0-based column) within the live layout region. */
+  x: number;
+  /** Vertical position (0-based row) within the live layout region. */
+  y: number;
+  /** Element width in columns. */
+  width: number;
+  /** Element height in rows. */
+  height: number;
+}
+
+/**
+ * Measure the layout metrics of a `<Box>` element, including its position
+ * within the live layout region.
+ *
+ * Coordinates are computed by walking up the yoga parent chain and
+ * accumulating each ancestor's offset. In alternate-screen mode these
+ * equal viewport coordinates directly; in inline mode callers must
+ * subtract the live region's viewport anchor from mouse event rows.
+ *
+ * Must be called from post-render code (useEffect, useLayoutEffect,
+ * input handlers, timer callbacks) — returns zeroes during render.
+ */
+export function measureElementPosition(node: DOMElement): ElementMetrics {
+  const { yogaNode } = node;
+
+  if (!yogaNode) {
+    return { x: 0, y: 0, width: 0, height: 0 };
+  }
+
+  let x = yogaNode.getComputedLeft();
+  let y = yogaNode.getComputedTop();
+
+  let current = node.parentNode;
+  while (current) {
+    if (current.yogaNode) {
+      x += current.yogaNode.getComputedLeft();
+      y += current.yogaNode.getComputedTop();
+    }
+    current = current.parentNode;
+  }
+
+  return {
+    x,
+    y,
+    width: yogaNode.getComputedWidth(),
+    height: yogaNode.getComputedHeight(),
+  };
+}


### PR DESCRIPTION
## What this PR does

Adds thinking block display improvements in two layers:

### Layer 1 — Regression fix + Alt+T expand/collapse (core)

- **Fix regression from PR #5354**: thinking blocks were always expanded because `expanded={!compactMode}` evaluates to `true` when `compactMode` defaults to `false`. Changed to `expanded={false}` so thinking blocks are always collapsed after completion.
- **Alt+T keyboard shortcut**: toggles inline expansion/collapse of all thinking blocks — works in both virtual-scroll and legacy Static render paths. This is the **primary** way users interact with thinking blocks.
- **Three-tier thinking icon**: `💡` (emoji-capable UTF-8, non-CI) → `⟡` (UTF-8, CI or non-emoji) → empty string (non-UTF-8).
- **Shared utility**: extracted duplicated `thinkingFullTextByItem` aggregation loop into `buildThinkingFullTextMap()` in `historyUtils.ts` with unit tests.

### Layer 2 — Overlay viewer via mouse click + AlternateScreen (supplementary)

> **Note**: This layer provides a full-screen thinking text viewer opened by clicking on collapsed thinking blocks. It works correctly in **virtual-scroll mode** (components stay mounted in `ScrollableList`), but click-to-view is **non-functional in legacy `<Static>` mode** due to Ink unmounting components after commit. The Alt+T shortcut (Layer 1) covers both render paths and is the recommended interaction.

- **`AlternateScreen.tsx`**: DEC 1049 alternate screen buffer wrapper with `process.on('exit')` safety guard.
- **`ThinkingViewer.tsx`**: full-screen scrollable viewer with keyboard navigation (↑↓, PgUp/PgDn, Ctrl+Home/End) and mouse wheel.
- **`ThinkingViewerContext.tsx`**: `openThinkingViewer` React context.
- **`ClickableThinkMessage`** in `HistoryItemDisplay.tsx`: per-item `useMouseEvents` + `measureElementPosition` hit-test.
- **VP mode fix** (`55ef6518`): enables alternate screen mouse scroll support in virtual-scroll mode.

## Why it's needed

After PR #5354 landed thinking block support, the blocks were always shown expanded — cluttering the conversation history with potentially long reasoning text. Users need a way to collapse completed thinking blocks by default and expand them on demand to inspect the model's reasoning process.

## GIF
<img width="803" height="716" alt="demo" src="https://github.com/user-attachments/assets/1fc91757-091d-457a-9e3a-11fa67614dd1" />


## Reviewer Test Plan

### How to verify

1. Start a conversation with a model that produces reasoning output (e.g. `reasoning_content` in the streaming response).
2. After the model responds, the thinking block should appear **collapsed** as a single line with the thinking icon and duration.
3. Press **Alt+T** to expand all thinking blocks inline — press again to collapse.
4. The hint text updates: `(alt+t to expand)` ↔ `(alt+t to collapse)`.
5. *(Layer 2, VP mode only)* Click on a collapsed thinking block header — the overlay viewer should open. ESC closes, arrow keys scroll, PgUp/PgDn pages, Ctrl+Home/End jumps to start/end.

### Evidence (Before & After)

Before: thinking blocks always expanded after completion, no way to collapse.
After: thinking blocks collapsed by default, Alt+T toggles inline expansion.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local runtime: `npm run dev`

## Risk & Scope

- Main risk or tradeoff: Alt+T expands/collapses ALL thinking blocks globally — per-block toggle would require additional state tracking (follow-up).
- Not validated / out of scope: Layer 2 click-to-view is non-functional in `<Static>` render path (Ink architectural limitation). `ThinkingViewer` `wrap="truncate-end"` silently cuts wide content (follow-up). `THINKING_ICON` placement could move to a terminal-capabilities utility (follow-up).
- Breaking changes / migration notes: None.

## Linked Issues

Fixes the thinking block display regression introduced by #5354.

<details>
<summary>中文说明</summary>

思考块显示改进分两层：

### 第一层 — 回归修复 + Alt+T 展开/折叠（核心）

- **修复 PR #5354 的回归**：思考块因 `expanded={!compactMode}` 在 `compactMode` 默认为 `false` 时始终展开。改为 `expanded={false}` 使完成后的思考块始终折叠。
- **Alt+T 快捷键**：切换所有思考块的内联展开/折叠，在虚拟滚动和传统 Static 渲染路径下均可用。这是用户与思考块交互的**主要方式**。
- **三级思考图标**：`💡`（支持 emoji 的 UTF-8 非 CI）→ `⟡`（UTF-8 CI 或不支持 emoji）→ 空字符串（非 UTF-8）。
- **共享工具函数**：将重复的聚合逻辑提取到 `historyUtils.ts` 中的 `buildThinkingFullTextMap()`，并添加单元测试。

### 第二层 — 鼠标点击 + AlternateScreen Overlay 查看器（补充功能）

> **注意**：此层提供通过点击折叠的思考块打开全屏查看器的功能。在**虚拟滚动模式**下正常工作（组件保持挂载在 `ScrollableList` 中），但在**传统 `<Static>` 模式下点击不生效**（Ink 在提交后卸载组件的架构限制）。Alt+T 快捷键（第一层）覆盖两种渲染路径，是推荐的交互方式。

- **`AlternateScreen.tsx`**：DEC 1049 alternate screen buffer 封装，含 `process.on('exit')` 安全守卫。
- **`ThinkingViewer.tsx`**：全屏滚动查看器，支持键盘导航和鼠标滚轮。
- **`ClickableThinkMessage`**：基于 `useMouseEvents` + `measureElementPosition` 的点击交互。
- **VP 模式修复**（`55ef6518`）：在虚拟滚动模式下启用 alternate screen 鼠标滚轮支持。

风险：Alt+T 全局展开/折叠所有思考块，逐块切换需额外状态跟踪（后续跟进）。第二层的点击功能在 Static 模式下不可用（Ink 架构限制）。

</details>