### PR TITLE
docs: add provider preset governance policy to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,22 @@ Your PR should have a clear, descriptive title and a detailed description of the
 
 In the PR description, explain the "why" behind your changes and link to the relevant issue (e.g., `Fixes #123`).
 
+### Adding a Provider Preset
+
+A built-in preset is an **endorsement**, not just a convenience. Users route API keys and full prompt data through these endpoints, so the bar is high.
+
+**Tier 1 — Built-in Preset** requires all of the following:
+
+- **Affiliation Disclosure** — PR author must disclose any relationship with the provider.
+- **Operational Maturity** — publicly operational with demonstrated uptime; public SLA or status page preferred.
+- **Organic User Demand** — evidence of community demand (issues, discussions), not just a self-listing.
+- **Data and Security Transparency** — provider's data handling practices must be publicly documented.
+- **Maintenance Commitment** — provider team commits to tracking Qwen Code protocol changes.
+
+**Default Path — Custom Provider**: for providers that don't meet Tier 1, users connect via the built-in custom-provider flow (`/auth` or `/model` → Custom Provider). No code change or project endorsement needed.
+
+**If a Tier 1 preset is approved**, the PR should follow the existing `openrouter.ts` / `requesty.ts` pattern: use `customHeaders` for attribution, implement `ownsModel` with a dual-gate (env key + hostname), and add the env key to `SECRET_ENV_VARS` in `packages/cli/src/serve/envSnapshot.ts` with corresponding test assertions in `auth.test.ts` and `provider-config.test.ts`.
+
 ## Development Setup and Workflow
 
 This section guides contributors on how to build, modify, and understand the development setup of this project.


### PR DESCRIPTION
## What this PR does

Adds a "Adding a Provider Preset" section to CONTRIBUTING.md with two paths:

- **Tier 1 — Built-in Preset**: affiliation disclosure, operational maturity, organic user demand, data/security transparency, maintenance commitment.
- **Default Path — Custom Provider**: for providers that don't meet Tier 1, users connect via the existing custom-provider flow — no code change, no endorsement.

Also documents the technical checklist for approved Tier 1 PRs.

## Why it's needed

Two recent third-party gateway PRs (#5060, #5625) raised the same question: should any OpenAI-compatible gateway get a built-in preset on request? A built-in preset is an endorsement — users route API keys and full prompt data through these endpoints. This policy was already applied in review comments; formalizing it lets contributors self-check before opening a PR.

## Reviewer Test Plan

### How to verify

Read the added section in CONTRIBUTING.md. Confirm the criteria and custom-provider path are clear.

### Evidence (Before & After)

N/A — documentation-only.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

## Risk & Scope

- Main risk: None — documentation-only.
- Breaking changes: None.

## Linked Issues

Related: #5060, #5625

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 CONTRIBUTING.md 新增 "Adding a Provider Preset" 章节，定义两条路径：

- **Tier 1 — 内置预设**：利益关系披露、运营成熟度、有机用户需求、数据/安全透明度、维护承诺。
- **默认路径 — Custom Provider**：不满足 Tier 1 的 provider，用户通过 custom-provider 流程接入，无需代码变更、无需项目背书。

同时记录了获批 Tier 1 PR 的技术 checklist。

## 为什么需要

最近两个第三方网关 PR（#5060、#5625）提出了同一问题：是否任何 OpenAI 兼容网关都应获得内置预设？内置预设是一种背书——用户会通过这些端点路由 API key 和完整 prompt 数据。该政策此前已在 review 评论中非正式应用，正式写入可让贡献者提前自检。

## 风险与范围

- 主要风险：无——仅文档变更。
- 破坏性变更：无。

</details>
