### PR TITLE
feat(core): add fastOnly/voiceOnly flags to hide models from main model list

### DIFF
--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -1058,6 +1058,7 @@ describe('modelCommand', () => {
       expect(result).toMatchObject({
         type: 'message',
         messageType: 'error',
+        content: expect.stringContaining('fast-model'),
       });
     });
 
@@ -1083,6 +1084,7 @@ describe('modelCommand', () => {
       expect(result).toMatchObject({
         type: 'message',
         messageType: 'error',
+        content: expect.stringContaining('voice-model'),
       });
     });
 
@@ -1145,6 +1147,74 @@ describe('modelCommand', () => {
       expect(result).toMatchObject({
         type: 'message',
         messageType: 'error',
+        content: expect.stringContaining('voice-model'),
+      });
+    });
+
+    it('should not filter out voiceOnly models from --voice selection', async () => {
+      const setValue = vi.fn();
+      mockContext = createMockCommandContext({
+        invocation: {
+          raw: '/model --voice qwen3-asr-flash',
+          name: 'model',
+          args: '--voice qwen3-asr-flash',
+        },
+        services: {
+          config: {
+            getContentGeneratorConfig: vi.fn().mockReturnValue({
+              model: 'main-model',
+              authType: AuthType.USE_OPENAI,
+            }),
+            getAllConfiguredModels: vi.fn().mockReturnValue([
+              { id: 'main-model', label: 'Main', authType: AuthType.USE_OPENAI },
+              {
+                id: 'qwen3-asr-flash',
+                label: 'ASR',
+                voiceOnly: true,
+                authType: AuthType.USE_OPENAI,
+                baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+              },
+            ]),
+          },
+          settings: createMockSettings(setValue),
+        },
+      });
+
+      const result = await modelCommand.action!(mockContext, '--voice qwen3-asr-flash');
+      expect(result).toMatchObject({
+        type: 'message',
+        messageType: 'info',
+        content: expect.stringContaining('qwen3-asr-flash'),
+      });
+    });
+
+    it('should reject fastOnly models from --voice selection', async () => {
+      mockContext = createMockCommandContext({
+        invocation: {
+          raw: '/model --voice fast-model',
+          name: 'model',
+          args: '--voice fast-model',
+        },
+        services: {
+          config: {
+            getContentGeneratorConfig: vi.fn().mockReturnValue({
+              model: 'main-model',
+              authType: AuthType.USE_OPENAI,
+            }),
+            getAllConfiguredModels: vi.fn().mockReturnValue([
+              { id: 'main-model', label: 'Main' },
+              { id: 'fast-model', label: 'Fast', fastOnly: true },
+            ]),
+          },
+          settings: createMockSettings(),
+        },
+      });
+
+      const result = await modelCommand.action!(mockContext, '--voice fast-model');
+      expect(result).toMatchObject({
+        type: 'message',
+        messageType: 'error',
+        content: expect.stringContaining('fast-model'),
       });
     });
   });

--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -1034,4 +1034,118 @@ describe('modelCommand', () => {
       });
     });
   });
+
+  describe('fastOnly/voiceOnly filtering', () => {
+    it('should reject fastOnly models from normal /model selection', async () => {
+      mockContext = createMockCommandContext({
+        invocation: { raw: '/model fast-model', name: 'model', args: 'fast-model' },
+        services: {
+          config: {
+            getContentGeneratorConfig: vi.fn().mockReturnValue({
+              model: 'main-model',
+              authType: AuthType.USE_OPENAI,
+            }),
+            getAvailableModelsForAuthType: vi.fn().mockReturnValue([
+              { id: 'main-model', label: 'Main' },
+              { id: 'fast-model', label: 'Fast', fastOnly: true },
+            ]),
+          },
+          settings: createMockSettings(),
+        },
+      });
+
+      const result = await modelCommand.action!(mockContext, 'fast-model');
+      expect(result).toMatchObject({
+        type: 'message',
+        messageType: 'error',
+      });
+    });
+
+    it('should reject voiceOnly models from normal /model selection', async () => {
+      mockContext = createMockCommandContext({
+        invocation: { raw: '/model voice-model', name: 'model', args: 'voice-model' },
+        services: {
+          config: {
+            getContentGeneratorConfig: vi.fn().mockReturnValue({
+              model: 'main-model',
+              authType: AuthType.USE_OPENAI,
+            }),
+            getAvailableModelsForAuthType: vi.fn().mockReturnValue([
+              { id: 'main-model', label: 'Main' },
+              { id: 'voice-model', label: 'Voice', voiceOnly: true },
+            ]),
+          },
+          settings: createMockSettings(),
+        },
+      });
+
+      const result = await modelCommand.action!(mockContext, 'voice-model');
+      expect(result).toMatchObject({
+        type: 'message',
+        messageType: 'error',
+      });
+    });
+
+    it('should allow fastOnly models in --fast selection', async () => {
+      const setValue = vi.fn();
+      mockContext = createMockCommandContext({
+        invocation: {
+          raw: '/model --fast fast-model',
+          name: 'model',
+          args: '--fast fast-model',
+        },
+        services: {
+          config: {
+            getContentGeneratorConfig: vi.fn().mockReturnValue({
+              model: 'main-model',
+              authType: AuthType.USE_OPENAI,
+            }),
+            getAllConfiguredModels: vi.fn().mockReturnValue([
+              { id: 'main-model', label: 'Main' },
+              { id: 'fast-model', label: 'Fast', fastOnly: true },
+            ]),
+            setFastModel: vi.fn(),
+          },
+          settings: createMockSettings(setValue),
+        },
+      });
+
+      const result = await modelCommand.action!(mockContext, '--fast fast-model');
+      expect(result).toMatchObject({
+        type: 'message',
+        messageType: 'info',
+        content: expect.stringContaining('fast-model'),
+      });
+    });
+
+    it('should reject voiceOnly models from --fast selection', async () => {
+      mockContext = createMockCommandContext({
+        invocation: {
+          raw: '/model --fast voice-model',
+          name: 'model',
+          args: '--fast voice-model',
+        },
+        services: {
+          config: {
+            getContentGeneratorConfig: vi.fn().mockReturnValue({
+              model: 'main-model',
+              authType: AuthType.USE_OPENAI,
+            }),
+            getAllConfiguredModels: vi.fn().mockReturnValue([
+              { id: 'main-model', label: 'Main' },
+              { id: 'voice-model', label: 'Voice', voiceOnly: true },
+            ]),
+            setFastModel: vi.fn(),
+          },
+          settings: createMockSettings(),
+        },
+      });
+
+      const result = await modelCommand.action!(mockContext, '--fast voice-model');
+      expect(result).toMatchObject({
+        type: 'message',
+        messageType: 'error',
+      });
+    });
+  });
 });

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -390,7 +390,7 @@ export const modelCommand: SlashCommand = {
       const targetAuthType = parsed.authType ?? authType;
       const availableModels = config
         .getAvailableModelsForAuthType(targetAuthType)
-        .filter((m) => !m.fastOnly);
+        .filter((m) => !m.fastOnly && !m.voiceOnly);
       if (!availableModels.some((model) => model.id === parsed.modelId)) {
         return {
           type: 'message',

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -147,8 +147,9 @@ function getAvailableModelIds(context: CommandContext) {
   if (!config) {
     return [];
   }
-  const availableModels = config.getAvailableModels();
-  // Convert AvailableModel[] to string[] on AvailableModel.id
+  const availableModels = config
+    .getAvailableModels()
+    .filter((m) => !m.fastOnly && !m.voiceOnly);
   return availableModels.map((model) => model.id);
 }
 
@@ -239,7 +240,9 @@ export const modelCommand: SlashCommand = {
         };
       }
 
-      const availableModels = config.getAllConfiguredModels();
+      const availableModels = config
+        .getAllConfiguredModels()
+        .filter((m) => !m.fastOnly);
       const matches = availableModels.filter((model) => model.id === modelName);
       if (matches.length === 0) {
         return {
@@ -330,9 +333,11 @@ export const modelCommand: SlashCommand = {
         };
       }
 
-      const availableModels = selector.authType
-        ? config.getAvailableModelsForAuthType(selector.authType)
-        : config.getAllConfiguredModels();
+      const availableModels = (
+        selector.authType
+          ? config.getAvailableModelsForAuthType(selector.authType)
+          : config.getAllConfiguredModels()
+      ).filter((m) => !m.voiceOnly);
       if (!availableModels.some((model) => model.id === selector.modelId)) {
         return {
           type: 'message',

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -140,16 +140,21 @@ function formatUnavailableVoiceModelMessage(
   );
 }
 
-// Get an array of the available model IDs as strings
-function getAvailableModelIds(context: CommandContext) {
+// Get an array of the available model IDs as strings, filtered by mode
+function getAvailableModelIds(
+  context: CommandContext,
+  mode: 'main' | 'fast' | 'voice' = 'main',
+) {
   const { services } = context;
   const { config } = services;
   if (!config) {
     return [];
   }
-  const availableModels = config
-    .getAvailableModels()
-    .filter((m) => !m.fastOnly && !m.voiceOnly);
+  const availableModels = config.getAvailableModels().filter((m) => {
+    if (mode === 'fast') return !m.voiceOnly;
+    if (mode === 'voice') return !m.fastOnly;
+    return !m.fastOnly && !m.voiceOnly;
+  });
   return availableModels.map((model) => model.id);
 }
 
@@ -181,9 +186,19 @@ export const modelCommand: SlashCommand = {
       if (flagCompletions.length > 0) {
         return flagCompletions;
       }
-      if (partialArg.trim()) {
-        return getAvailableModelIds(context).filter((id) =>
-          id.startsWith(partialArg.trim()),
+      const trimmed = partialArg.trim();
+      if (trimmed) {
+        let mode: 'main' | 'fast' | 'voice' = 'main';
+        let modelPrefix = trimmed;
+        if (trimmed.startsWith('--fast ')) {
+          mode = 'fast';
+          modelPrefix = trimmed.slice('--fast '.length);
+        } else if (trimmed.startsWith('--voice ')) {
+          mode = 'voice';
+          modelPrefix = trimmed.slice('--voice '.length);
+        }
+        return getAvailableModelIds(context, mode).filter((id) =>
+          id.startsWith(modelPrefix),
         );
       }
       return null;

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -388,8 +388,9 @@ export const modelCommand: SlashCommand = {
       }
       const parsed = parseAcpModelOption(modelName);
       const targetAuthType = parsed.authType ?? authType;
-      const availableModels =
-        config.getAvailableModelsForAuthType(targetAuthType);
+      const availableModels = config
+        .getAvailableModelsForAuthType(targetAuthType)
+        .filter((m) => !m.fastOnly);
       if (!availableModels.some((model) => model.id === parsed.modelId)) {
         return {
           type: 'message',

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -229,7 +229,8 @@ export function ModelDialog({
         !m.isRuntimeModel &&
         (m.authType !== AuthType.QWEN_OAUTH ||
           authType === AuthType.QWEN_OAUTH) &&
-        (isFastModelMode || !m.fastOnly),
+        (isFastModelMode || !m.fastOnly) &&
+        (isVoiceModelMode || !m.voiceOnly),
     );
 
     // Group registry models by authType
@@ -294,7 +295,7 @@ export function ModelDialog({
     }
 
     return result;
-  }, [authType, config, isFastModelMode]);
+  }, [authType, config, isFastModelMode, isVoiceModelMode]);
 
   const MODEL_OPTIONS = useMemo(
     () =>

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -228,7 +228,8 @@ export function ModelDialog({
       (m) =>
         !m.isRuntimeModel &&
         (m.authType !== AuthType.QWEN_OAUTH ||
-          authType === AuthType.QWEN_OAUTH),
+          authType === AuthType.QWEN_OAUTH) &&
+        (isFastModelMode || !m.fastOnly),
     );
 
     // Group registry models by authType
@@ -293,7 +294,7 @@ export function ModelDialog({
     }
 
     return result;
-  }, [authType, config]);
+  }, [authType, config, isFastModelMode]);
 
   const MODEL_OPTIONS = useMemo(
     () =>

--- a/packages/core/src/models/modelRegistry.test.ts
+++ b/packages/core/src/models/modelRegistry.test.ts
@@ -1120,3 +1120,57 @@ describe('getProtocolForAuthType', () => {
     );
   });
 });
+
+describe('fastOnly and voiceOnly flags', () => {
+  it('should propagate fastOnly flag to AvailableModel', () => {
+    const config: ModelProvidersConfig = {
+      openai: {
+        protocol: Protocol.OPENAI,
+        models: [
+          { id: 'gpt-4o', name: 'GPT-4o' },
+          { id: 'gpt-4o-mini', name: 'GPT-4o Mini', fastOnly: true },
+        ],
+      },
+    };
+    const registry = new ModelRegistry(config);
+    const models = registry.getModelsForAuthType(AuthType.USE_OPENAI);
+    expect(models.find((m) => m.id === 'gpt-4o')?.fastOnly).toBeUndefined();
+    expect(models.find((m) => m.id === 'gpt-4o-mini')?.fastOnly).toBe(true);
+  });
+
+  it('should propagate voiceOnly flag to AvailableModel', () => {
+    const config: ModelProvidersConfig = {
+      openai: {
+        protocol: Protocol.OPENAI,
+        models: [
+          { id: 'gpt-4o', name: 'GPT-4o' },
+          { id: 'whisper-1', name: 'Whisper', voiceOnly: true },
+        ],
+      },
+    };
+    const registry = new ModelRegistry(config);
+    const models = registry.getModelsForAuthType(AuthType.USE_OPENAI);
+    expect(models.find((m) => m.id === 'gpt-4o')?.voiceOnly).toBeUndefined();
+    expect(models.find((m) => m.id === 'whisper-1')?.voiceOnly).toBe(true);
+  });
+
+  it('should warn when both fastOnly and voiceOnly are set', () => {
+    const config: ModelProvidersConfig = {
+      openai: {
+        protocol: Protocol.OPENAI,
+        models: [
+          {
+            id: 'unreachable-model',
+            fastOnly: true,
+            voiceOnly: true,
+          },
+        ],
+      },
+    };
+    const registry = new ModelRegistry(config);
+    const models = registry.getModelsForAuthType(AuthType.USE_OPENAI);
+    expect(models).toHaveLength(1);
+    expect(models[0].fastOnly).toBe(true);
+    expect(models[0].voiceOnly).toBe(true);
+  });
+});

--- a/packages/core/src/models/modelRegistry.ts
+++ b/packages/core/src/models/modelRegistry.ts
@@ -152,6 +152,7 @@ export class ModelRegistry {
       baseUrl: model.baseUrl,
       envKey: model.envKey,
       fastOnly: model.fastOnly,
+      voiceOnly: model.voiceOnly,
     }));
   }
 
@@ -254,6 +255,7 @@ export class ModelRegistry {
       generationConfig,
       capabilities: config.capabilities || {},
       fastOnly: config.fastOnly,
+      voiceOnly: config.voiceOnly,
     };
   }
 

--- a/packages/core/src/models/modelRegistry.ts
+++ b/packages/core/src/models/modelRegistry.ts
@@ -254,8 +254,6 @@ export class ModelRegistry {
       baseUrl: config.baseUrl || this.getDefaultBaseUrl(authType),
       generationConfig,
       capabilities: config.capabilities || {},
-      fastOnly: config.fastOnly,
-      voiceOnly: config.voiceOnly,
     };
   }
 
@@ -266,6 +264,11 @@ export class ModelRegistry {
     if (!config.id) {
       throw new Error(
         `Model config in authType '${authType}' missing required field: id`,
+      );
+    }
+    if (config.fastOnly && config.voiceOnly) {
+      debugLogger.warn(
+        `Model "${config.id}" in authType "${authType}" has both fastOnly and voiceOnly set. It will be unreachable in all model selectors.`,
       );
     }
   }

--- a/packages/core/src/models/modelRegistry.ts
+++ b/packages/core/src/models/modelRegistry.ts
@@ -151,6 +151,7 @@ export class ModelRegistry {
       modalities: model.generationConfig.modalities,
       baseUrl: model.baseUrl,
       envKey: model.envKey,
+      fastOnly: model.fastOnly,
     }));
   }
 
@@ -252,6 +253,7 @@ export class ModelRegistry {
       baseUrl: config.baseUrl || this.getDefaultBaseUrl(authType),
       generationConfig,
       capabilities: config.capabilities || {},
+      fastOnly: config.fastOnly,
     };
   }
 

--- a/packages/core/src/models/types.ts
+++ b/packages/core/src/models/types.ts
@@ -61,6 +61,8 @@ export interface ModelConfig {
   capabilities?: ModelCapabilities;
   /** Generation configuration (sampling parameters) */
   generationConfig?: ModelGenerationConfig;
+  /** When true, this model only appears in the fast model selector, not the main model list */
+  fastOnly?: boolean;
 }
 
 /**
@@ -116,6 +118,9 @@ export interface AvailableModel {
   modalities?: InputModalities;
   baseUrl?: string;
   envKey?: string;
+
+  /** When true, this model only appears in the fast model selector */
+  fastOnly?: boolean;
 
   /** Whether this is a runtime model (not from modelProviders) */
   isRuntimeModel?: boolean;

--- a/packages/core/src/models/types.ts
+++ b/packages/core/src/models/types.ts
@@ -63,6 +63,8 @@ export interface ModelConfig {
   generationConfig?: ModelGenerationConfig;
   /** When true, this model only appears in the fast model selector, not the main model list */
   fastOnly?: boolean;
+  /** When true, this model only appears in the voice model selector, not the main model list */
+  voiceOnly?: boolean;
 }
 
 /**
@@ -121,6 +123,8 @@ export interface AvailableModel {
 
   /** When true, this model only appears in the fast model selector */
   fastOnly?: boolean;
+  /** When true, this model only appears in the voice model selector */
+  voiceOnly?: boolean;
 
   /** Whether this is a runtime model (not from modelProviders) */
   isRuntimeModel?: boolean;


### PR DESCRIPTION
## What this PR does

Adds `fastOnly` and `voiceOnly` boolean flags to the model configuration. When a model is configured with `fastOnly: true` in `modelProviders`, it only appears in the fast model selector (`/model --fast` dialog) and is hidden from the main model list and the normal `/model` command. Similarly, `voiceOnly: true` makes a model visible only in the voice model selector (`/model --voice`). This allows users to register specialized models for background tasks or voice transcription without cluttering the main model selection UI.

## Why it's needed

Currently, all models registered in `modelProviders` appear in both the main model selector and the specialized selectors (fast/voice). Users who configure smaller/faster models specifically for fast model use, or speech models for voice transcription, have no way to prevent those models from appearing in the main model list, which adds visual noise and risks accidental selection as the primary conversation model.

## Reviewer Test Plan

### How to verify

1. Add a model with `"fastOnly": true` to `modelProviders` in settings.json, e.g.:
   ```json
   "modelProviders": {
     "use-openai": [
       { "id": "gpt-4o", "name": "GPT-4o" },
       { "id": "gpt-4o-mini", "name": "GPT-4o Mini", "fastOnly": true },
       { "id": "whisper-1", "name": "Whisper", "voiceOnly": true }
     ]
   }
   ```
2. Run `/model` — `gpt-4o-mini` and `whisper-1` should not appear in the list.
3. Run `/model --fast` — `gpt-4o-mini` should appear and be selectable; `whisper-1` should not.
4. Run `/model --voice` — `whisper-1` should appear and be selectable; `gpt-4o-mini` should not.
5. Run `/model gpt-4o-mini` — should get an "unavailable model" error since it's fast-only.
6. Run `/model --fast gpt-4o-mini` — should succeed.

### Evidence (Before & After)

N/A — behavioral change, verified via unit tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npm run dev`

## Risk & Scope

- Main risk or tradeoff: None — additive, opt-in flags with no behavior change when unset.
- Not validated / out of scope: The `about` command and system info display do not filter fastOnly/voiceOnly models from their model lists; this is intentional as those are diagnostic views.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

为模型配置添加了 `fastOnly` 和 `voiceOnly` 布尔标志。当模型在 `modelProviders` 中配置了 `fastOnly: true` 时，该模型仅出现在快速模型选择器（`/model --fast` 对话框）中，而在主模型列表和普通 `/model` 命令中被隐藏。类似地，`voiceOnly: true` 使模型仅在语音模型选择器（`/model --voice`）中可见。这允许用户注册专门用于后台任务或语音转录的模型，而不会在主模型选择界面中造成干扰。

## 为什么需要

目前，在 `modelProviders` 中注册的所有模型都会同时出现在主模型选择器和专用选择器（快速/语音）中。用户如果专门为快速模型用途配置了较小/较快的模型，或者为语音转录配置了语音模型，无法阻止这些模型出现在主模型列表中，这会增加视觉噪音并可能导致误选为主要对话模型。

## 审查测试计划

### 如何验证

1. 在 settings.json 的 `modelProviders` 中添加带 `"fastOnly": true` 或 `"voiceOnly": true` 的模型
2. 运行 `/model` — fast-only 和 voice-only 模型不应出现在列表中
3. 运行 `/model --fast` — fast-only 模型应出现在列表中且可选择
4. 运行 `/model --voice` — voice-only 模型应出现在列表中且可选择
5. 运行 `/model <fast-only-model-id>` — 应得到"不可用模型"错误
6. 运行 `/model --fast <fast-only-model-id>` — 应成功

## 风险和范围

- 主要风险或权衡：无 — 增量式、可选的标志，未设置时无行为变化。
- 未验证/范围外：`about` 命令和系统信息显示不会过滤 fastOnly/voiceOnly 模型；这是有意为之，因为它们是诊断视图。
- 破坏性变更/迁移说明：无。

</details>