### PR TITLE
fix(webui): stop auto-recreating session on user-initiated delete

### DIFF
--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -22,6 +22,7 @@ import {
   useDaemonConnection,
   useDaemonSessionNotices,
   useDaemonPendingPermissions,
+  useDaemonPromptStatus,
   useDaemonStreamingState,
   useDaemonTranscriptBlocks,
   useDaemonTranscriptState,
@@ -4084,6 +4085,309 @@ describe('DaemonSessionProvider', () => {
         code: 'daemon.session_died',
       },
     ]);
+  });
+
+  it('stops reconnect loop on session_closed (user deleted session) even when autoReconnect is true', async () => {
+    // When the user deletes a running session, the server publishes
+    // session_closed on SSE. The provider must NOT auto-reconnect and
+    // create a new session — that would undo the user's delete action.
+    const session = createMockSession({
+      events: async function* sessionClosedEvents(
+        opts: { signal?: AbortSignal } = {},
+      ) {
+        yield {
+          id: 1,
+          v: 1,
+          type: 'session_closed',
+          data: { reason: 'client_close' },
+        };
+        if (opts.signal?.aborted) return;
+      },
+    });
+    sdkMocks.sessions.push(session);
+
+    let connection: DaemonConnectionState | undefined;
+    function Harness() {
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      autoReconnect: true,
+      reconnectDelayMs: 1,
+      maxReconnectDelayMs: 1,
+    });
+
+    await act(async () => {
+      await flushPromises();
+    });
+    // Give any potential reconnect timer a window to fire and
+    // React state updates to flush.
+    await act(async () => {
+      await wait(100);
+      await flushPromises();
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+
+    // createOrAttach called exactly once (initial), never again.
+    // This proves the reconnect loop stopped and no new session was
+    // auto-created after the user deleted the running one.
+    expect(
+      sdkMocks.MockDaemonSessionClient.createOrAttach,
+    ).toHaveBeenCalledTimes(1);
+    // Connection should be disconnected with no sessionId.
+    expect(connection?.status).toBe('disconnected');
+    expect(connection?.sessionId).toBeUndefined();
+  });
+
+  it('aborts in-flight prompt when session_closed arrives mid-stream', async () => {
+    // Exercises the most complex new code path: session_closed with
+    // reason 'client_close' arriving while a prompt is actively streaming.
+    // Verifies the abort path fires, the prompt rejects, and no
+    // auto-recreate happens.
+    const promptBlocked = createDeferred<void>();
+    const session = createMockSession({
+      prompt: vi.fn(
+        (_req: unknown, signal?: AbortSignal) =>
+          new Promise<PromptResult>((_resolve, reject) => {
+            signal?.addEventListener(
+              'abort',
+              () => reject(createAbortError()),
+              {
+                once: true,
+              },
+            );
+            promptBlocked.resolve();
+          }),
+      ),
+      events: async function* midStreamCloseEvents(
+        opts: { signal?: AbortSignal } = {},
+      ) {
+        // Wait for the prompt to start, then yield session_closed
+        await promptBlocked.promise;
+        yield {
+          id: 1,
+          v: 1,
+          type: 'session_closed',
+          data: { reason: 'client_close' },
+        };
+        if (opts.signal?.aborted) return;
+      },
+    });
+    sdkMocks.sessions.push(session);
+
+    let actions: DaemonUiSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+    let promptStatus: string | undefined;
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      promptStatus = useDaemonPromptStatus();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      autoReconnect: true,
+      reconnectDelayMs: 1,
+      maxReconnectDelayMs: 1,
+    });
+    const providerActions = requireActions(actions);
+
+    // Fire a prompt — it will block until abort
+    let promptResult: Promise<unknown> | undefined;
+    await act(async () => {
+      promptResult = providerActions.sendPrompt('long task');
+      await flushPromises();
+    });
+
+    // Wait for the session_closed event to arrive and be processed
+    await act(async () => {
+      await flushPromises();
+    });
+    await act(async () => {
+      await wait(100);
+      await flushPromises();
+    });
+
+    // The prompt should have been aborted
+    await expect(promptResult).resolves.toEqual({ stopReason: 'cancelled' });
+    // createOrAttach called exactly once — no auto-recreate
+    expect(
+      sdkMocks.MockDaemonSessionClient.createOrAttach,
+    ).toHaveBeenCalledTimes(1);
+    expect(connection?.status).toBe('disconnected');
+    expect(connection?.sessionId).toBeUndefined();
+    // Teardown set promptStatus to 'idle' — without the explicit
+    // setPromptStatus('idle') in the userDeletedSession block, this
+    // would remain 'waiting' (sendPrompt's own handler is blocked
+    // because sessionRef.current was cleared before the catch runs).
+    expect(promptStatus).toBe('idle');
+  });
+
+  it('stops reconnect on session_closed during epoch replay', async () => {
+    // Verifies the epoch replay path also handles session_closed
+    // with client_close correctly. If the user deletes a session
+    // while epoch replay is in progress, the provider must still
+    // exit the reconnect loop instead of auto-recreating.
+    const epochResetDelivered = createDeferred<void>();
+    const session = createMockSession({
+      events: async function* epochReplayThenClose(
+        opts: { signal?: AbortSignal } = {},
+      ) {
+        // Trigger epoch reset
+        yield {
+          v: 1,
+          type: 'state_resync_required',
+          data: {
+            reason: 'epoch_reset',
+            lastDeliveredId: 50,
+            earliestAvailableId: 1,
+          },
+        };
+        epochResetDelivered.resolve();
+        // During replay, send session_closed with client_close
+        yield {
+          id: 1,
+          v: 1,
+          type: 'session_closed',
+          data: { reason: 'client_close' },
+        };
+        if (opts.signal?.aborted) return;
+      },
+    });
+    sdkMocks.sessions.push(session);
+
+    let connection: DaemonConnectionState | undefined;
+    function Harness() {
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      autoReconnect: true,
+      reconnectDelayMs: 1,
+      maxReconnectDelayMs: 1,
+    });
+
+    await act(async () => {
+      await epochResetDelivered.promise;
+      await flushPromises();
+    });
+
+    // Give any potential reconnect timer a window to fire
+    await act(async () => {
+      await wait(100);
+      await flushPromises();
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+
+    // createOrAttach called exactly once — no auto-recreate
+    expect(
+      sdkMocks.MockDaemonSessionClient.createOrAttach,
+    ).toHaveBeenCalledTimes(1);
+    expect(connection?.status).toBe('disconnected');
+    expect(connection?.sessionId).toBeUndefined();
+  });
+
+  it.each(['idle_timeout', 'last_client_detached'] as const)(
+    'does NOT stop reconnect on session_closed with reason "%s"',
+    async (reason) => {
+      // session_closed with idle_timeout or last_client_detached should
+      // NOT prevent reconnection — these are server-initiated closes,
+      // not user deletions. The provider should preserve the session
+      // handle and attempt to resume on the next iteration.
+      const session = createMockSession({
+        events: async function* nonClientCloseEvents(
+          opts: { signal?: AbortSignal } = {},
+        ) {
+          yield {
+            id: 1,
+            v: 1,
+            type: 'session_closed',
+            data: { reason },
+          };
+          if (opts.signal?.aborted) return;
+        },
+      });
+      sdkMocks.sessions.push(session);
+
+      let connection: DaemonConnectionState | undefined;
+      function Harness() {
+        connection = useDaemonConnection();
+        return null;
+      }
+
+      await renderWithProvider(<Harness />, {
+        autoConnect: true,
+        autoReconnect: true,
+        reconnectDelayMs: 1,
+        maxReconnectDelayMs: 1,
+      });
+
+      await act(async () => {
+        await flushPromises();
+      });
+      await act(async () => {
+        await wait(50);
+        await flushPromises();
+      });
+
+      // Connection should still have the original sessionId — the
+      // provider did NOT exit the loop, it preserved the session
+      // for delta resume.
+      expect(connection?.sessionId).toBe('session-1');
+    },
+  );
+
+  it('does NOT stop reconnect on session_closed without reason field', async () => {
+    // Defensive: if the server sends session_closed without a reason
+    // field (older daemon versions), treat it as non-client_close and
+    // let the normal reconnect path handle it.
+    const session = createMockSession({
+      events: async function* noReasonEvents(
+        opts: { signal?: AbortSignal } = {},
+      ) {
+        yield {
+          id: 1,
+          v: 1,
+          type: 'session_closed',
+          data: {},
+        };
+        if (opts.signal?.aborted) return;
+      },
+    });
+    sdkMocks.sessions.push(session);
+
+    let connection: DaemonConnectionState | undefined;
+    function Harness() {
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      autoReconnect: true,
+      reconnectDelayMs: 1,
+      maxReconnectDelayMs: 1,
+    });
+
+    await act(async () => {
+      await flushPromises();
+    });
+    await act(async () => {
+      await wait(50);
+      await flushPromises();
+    });
+
+    // Session preserved — not treated as user deletion.
+    expect(connection?.sessionId).toBe('session-1');
   });
 
   it('routes stream_error to notices with connection category', async () => {

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -281,6 +281,12 @@ export function DaemonSessionProvider({
       let reconnectSessionId = restoreSessionId;
       let shouldCreateFreshSession = !restoreSessionId && newSessionNonce > 0;
       let reconnectAttempt = 0;
+      // Set when the user explicitly deletes the session (server
+      // publishes session_closed with reason 'client_close').
+      // Reconnecting would auto-create a new session, undoing the
+      // user's delete. Other session_closed reasons (idle_timeout,
+      // last_client_detached) fall through to normal reconnect.
+      let userDeletedSession = false;
 
       while (!disposed && !abort.signal.aborted) {
         try {
@@ -762,6 +768,23 @@ export function DaemonSessionProvider({
                   }
                   setConnection((c) => ({ ...c, catchingUp: undefined }));
                 }
+
+                // session_closed with client_close during epoch replay
+                if (
+                  event.type === 'session_closed' &&
+                  (event.data as Record<string, unknown> | undefined)
+                    ?.reason === 'client_close'
+                ) {
+                  userDeletedSession = true;
+                  const closedSessionId = activeSession.sessionId;
+                  const active = activePromptsRef.current.get(closedSessionId);
+                  active?.controller.abort();
+                  activePromptsRef.current.delete(closedSessionId);
+                  session = undefined;
+                  sessionRef.current = undefined;
+                  break;
+                }
+
                 continue;
               }
               bumpWorkspaceEventSignals(uiEvents, setWorkspaceEventSignals);
@@ -883,6 +906,27 @@ export function DaemonSessionProvider({
                   break;
                 }
               }
+              // session_closed with reason 'client_close' means the
+              // user explicitly deleted the session. Stop the
+              // reconnect loop — without this, the next iteration
+              // would call createOrAttach and auto-create a new
+              // session, undoing the user's delete action.
+              // Other reasons (idle_timeout, last_client_detached)
+              // fall through to the normal reconnect path.
+              if (
+                event.type === 'session_closed' &&
+                (event.data as Record<string, unknown> | undefined)?.reason ===
+                  'client_close'
+              ) {
+                userDeletedSession = true;
+                const closedSessionId = activeSession.sessionId;
+                const active = activePromptsRef.current.get(closedSessionId);
+                active?.controller.abort();
+                activePromptsRef.current.delete(closedSessionId);
+                session = undefined;
+                sessionRef.current = undefined;
+                break;
+              }
             } catch (error) {
               const message =
                 error instanceof Error ? error.message : String(error);
@@ -900,6 +944,24 @@ export function DaemonSessionProvider({
                 error,
               );
             }
+          }
+          if (userDeletedSession) {
+            // Session was explicitly closed (user deleted it). Do NOT
+            // reconnect — doing so would auto-create a new session.
+            // Note: we intentionally do NOT call setRestoreSessionId(undefined)
+            // here because restoreSessionId is in the useEffect dependency
+            // array — changing it would trigger an effect re-run that could
+            // create a new session via createOrAttach.
+            store.dispatch({ type: 'assistant.done', reason: 'cancelled' });
+            setPromptStatus('idle');
+            clearPassiveAssistantDoneTimer(passiveAssistantDoneTimerRef);
+            setConnection((current) => ({
+              ...current,
+              status: 'disconnected',
+              sessionId: undefined,
+              error: undefined,
+            }));
+            return;
           }
           if (!disposed && !abort.signal.aborted && !resyncRequested) {
             // Keep the session handle after a normal SSE close so the next


### PR DESCRIPTION
## What this PR does

Fixes a bug where deleting a running session (one with an active model stream) from the session list causes a new session to be automatically created, undoing the user's delete action.

The fix adds detection for `session_closed` SSE events with `reason: 'client_close'` in `DaemonSessionProvider`. When this specific event is received, the provider exits the reconnect loop instead of calling `createOrAttach()` which would auto-create a new session.

The interception is scoped to `reason === 'client_close'` only — other `session_closed` reasons (`idle_timeout`, `last_client_detached`) and `session_died` events fall through to the normal reconnect path, preserving existing behavior.

## Why it's needed

When a user deletes a session from the WebUI session list while the model is still generating output:
1. The server calls `bridge.closeSession()` which publishes a `session_closed` event (with `reason: 'client_close'`) on SSE, then closes the event bus.
2. The `DaemonSessionProvider` reconnect loop received `session_closed` but treated it as a passive disconnect — the SSE stream ended normally, session handle was preserved.
3. On the next iteration, `activeSession.events()` would fail (session gone → 404), triggering `createOrAttach()` which auto-creates a new session.

This makes it impossible for users to delete running sessions — the session always comes back.

## Reviewer Test Plan

### How to verify

1. Start a daemon server: `npm run dev -- serve`
2. Open the WebUI and start a new session
3. Send a prompt that generates a long response (e.g. "write 500 words about quantum computing")
4. While the model is still streaming output, delete this session from the session list
5. **Expected**: The session is deleted and no new session appears
6. **Before fix**: A new session would be automatically created after deletion

Unit test coverage:
- `session_closed` with `reason: 'client_close'` → stops reconnect, `createOrAttach` called exactly once
- `session_closed` with `reason: 'idle_timeout'` → does NOT stop reconnect
- `session_closed` with `reason: 'last_client_detached'` → does NOT stop reconnect
- `session_closed` without `reason` field → does NOT stop reconnect (old daemon compat)

### Evidence (Before & After)

N/A — no user-facing UI change. This is a behavioral fix in the SSE reconnect loop.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Verified against a real daemon server (`npm run dev -- serve`) on macOS. Both `POST /sessions/delete` and `DELETE /session/:id` APIs confirmed to emit `session_closed` with `reason: 'client_close'`.

## Risk & Scope

- Main risk: Over-interception of `session_closed` events — mitigated by checking `reason === 'client_close'` precisely. Reverse tests confirm `idle_timeout` and `last_client_detached` still allow reconnection.
- Not validated: Windows/Linux daemon behavior (SSE protocol is platform-independent, so risk is low).
- Breaking changes: None. Existing reconnect behavior for all non-user-delete scenarios is preserved.

## Linked Issues

No linked issue. This was discovered during manual testing of session deletion in the WebUI.

<details>
<summary>中文说明</summary>

## 修复内容

修复了一个 bug：用户在会话列表中删除一个正在运行（模型正在输出）的会话时，被删除的会话会被自动重新创建。

修复方式：在 `DaemonSessionProvider` 的 SSE 事件循环中，检测 `session_closed` 事件且 `reason: 'client_close'` 时，退出重连循环，阻止调用 `createOrAttach()` 自动创建新会话。

拦截范围仅限于 `reason === 'client_close'`（用户主动删除），其他原因（`idle_timeout` 超时回收、`last_client_detached` 无客户端自动关闭）和 `session_died`（进程崩溃）保持原有重连行为不变。

## 为什么需要

用户在 WebUI 中删除一个正在运行的会话时：
1. 服务端调用 `bridge.closeSession()` 发布 `session_closed` 事件（`reason: 'client_close'`），然后关闭事件总线
2. `DaemonSessionProvider` 收到 `session_closed` 但将其视为被动断连——SSE 流正常结束，session 句柄被保留
3. 下一轮迭代中 `activeSession.events()` 失败（session 已删除→404），触发 `createOrAttach()` 自动创建了新会话

这导致用户无法删除正在运行的会话——会话总是会被重新创建回来。

</details>