### PR TITLE
fix(serve): validate readText line limits

### DIFF
--- a/packages/cli/src/serve/fs/workspace-file-system.test.ts
+++ b/packages/cli/src/serve/fs/workspace-file-system.test.ts
@@ -768,6 +768,27 @@ describe('WorkspaceFileSystem - write/edit', () => {
     }
   });
 
+  it('rejects non-positive-integer opts.limit with parse_error', async () => {
+    const target = path.join(h.workspace, 'v.txt');
+    await fsp.writeFile(target, 'a\nb\nc\n');
+    const r = await h.fs.resolve('v.txt', 'read');
+    for (const bad of [
+      Infinity,
+      -Infinity,
+      Number.MAX_SAFE_INTEGER + 1,
+      0,
+      -1,
+      1.5,
+      NaN,
+    ]) {
+      const err = await h.fs
+        .readText(r, { limit: bad })
+        .catch((e: unknown) => e);
+      expect(isFsError(err)).toBe(true);
+      expect((err as { kind: string }).kind).toBe('parse_error');
+    }
+  });
+
   it('records matchedIgnore on edit() audit (parity with readText/writeText)', async () => {
     const ignore = new Ignore().add(['*.log']);
     h = await makeHarness({ ignore });

--- a/packages/cli/src/serve/fs/workspace-file-system.ts
+++ b/packages/cli/src/serve/fs/workspace-file-system.ts
@@ -391,6 +391,15 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
           `line must be a positive integer, got ${opts.line}`,
         );
       }
+      if (
+        opts.limit !== undefined &&
+        (!Number.isSafeInteger(opts.limit) || opts.limit < 1)
+      ) {
+        throw new FsError(
+          'parse_error',
+          `limit must be a positive integer, got ${opts.limit}`,
+        );
+      }
       const snapshot = await readTextSnapshotFromResolvedFile(p, opts);
       const ignoreVerdict = shouldIgnore(
         p,


### PR DESCRIPTION
## What this PR does

Rejects invalid `readText` `limit` values at the `WorkspaceFileSystem` boundary, matching the existing validation for `line`. When `limit` is provided, it must now be a positive safe integer; `0`, negatives, fractions, `NaN`, infinities, and unsafe integers return `parse_error`.

## Why it's needed

`readText` already documents and enforces `line` as a positive integer, but `limit` could still reach the lower-level slicing logic unchecked when called directly from the filesystem service. That made the shared boundary less predictable for internal callers and left edge cases such as `Infinity`, `NaN`, floats, and unsafe integers to degrade into implementation-specific truncation behavior.

## Reviewer Test Plan

### How to verify

Confirm that `WorkspaceFileSystem.readText` rejects invalid `opts.limit` values with `parse_error`, while the existing `opts.line` behavior remains covered by the same test file.

Commands run locally:

```sh
npx vitest run src/serve/fs/workspace-file-system.test.ts --coverage.enabled=false
npx prettier --check packages/cli/src/serve/fs/workspace-file-system.ts packages/cli/src/serve/fs/workspace-file-system.test.ts
npx eslint packages/cli/src/serve/fs/workspace-file-system.ts packages/cli/src/serve/fs/workspace-file-system.test.ts
git diff --check
npm run build --workspace @qwen-code/qwen-code-core
npm run build --workspace @qwen-code/acp-bridge
npm run build --workspace @qwen-code/qwen-code
npm run typecheck --workspace @qwen-code/qwen-code
```

### Evidence (Before & After)

Before: `readText(r, { limit: bad })` accepted invalid `limit` values at the service boundary and passed them to the lower-level read/slice path. After: invalid `limit` values return an `FsError` with `kind === 'parse_error'`. This is covered by the new unit test for `Infinity`, `-Infinity`, `Number.MAX_SAFE_INTEGER + 1`, `0`, `-1`, `1.5`, and `NaN`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS arm64, Node.js v26.3.0.

## Risk & Scope

- Main risk or tradeoff: Low; this only tightens invalid `limit` inputs at the shared filesystem service boundary and mirrors existing `line` validation.
- Not validated / out of scope: Windows and Linux were not tested locally; CI should cover those platforms.
- Breaking changes / migration notes: No expected breaking change for valid callers. Direct internal callers passing invalid `limit` values now receive `parse_error` instead of undefined slicing behavior.

## Linked Issues

Fixes #5623

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 在 `WorkspaceFileSystem` 边界拒绝非法的 `readText` `limit` 值，和现有的 `line` 校验保持一致。现在只要传入 `limit`，它就必须是正的安全整数；`0`、负数、小数、`NaN`、正负无穷以及不安全整数都会返回 `parse_error`。

## Why it's needed

`readText` 已经把 `line` 记录并校验为正整数，但直接从文件系统服务调用时，`limit` 仍然可以绕过校验进入更底层的切片逻辑。这会让共享边界对内部调用方不够可预测，也会让 `Infinity`、`NaN`、小数和不安全整数这类边界值退化成依赖实现细节的截断行为。

## Reviewer Test Plan

### How to verify

确认 `WorkspaceFileSystem.readText` 会对非法的 `opts.limit` 返回 `parse_error`，同时现有的 `opts.line` 行为仍由同一个测试文件覆盖。

本地运行过的命令：

```sh
npx vitest run src/serve/fs/workspace-file-system.test.ts --coverage.enabled=false
npx prettier --check packages/cli/src/serve/fs/workspace-file-system.ts packages/cli/src/serve/fs/workspace-file-system.test.ts
npx eslint packages/cli/src/serve/fs/workspace-file-system.ts packages/cli/src/serve/fs/workspace-file-system.test.ts
git diff --check
npm run build --workspace @qwen-code/qwen-code-core
npm run build --workspace @qwen-code/acp-bridge
npm run build --workspace @qwen-code/qwen-code
npm run typecheck --workspace @qwen-code/qwen-code
```

### Evidence (Before & After)

修复前：`readText(r, { limit: bad })` 会在服务边界接受非法的 `limit` 值，并继续传给更底层的读取和切片路径。修复后：非法的 `limit` 值会返回 `kind === 'parse_error'` 的 `FsError`。新增单元测试覆盖了 `Infinity`、`-Infinity`、`Number.MAX_SAFE_INTEGER + 1`、`0`、`-1`、`1.5` 和 `NaN`。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地环境为 macOS arm64，Node.js v26.3.0。

## Risk & Scope

- 主要风险或取舍：风险较低；这只是在共享文件系统服务边界收紧非法 `limit` 输入，并与现有 `line` 校验保持一致。
- 未验证或不在范围内：本地没有测试 Windows 和 Linux；这些平台交给 CI 覆盖。
- 破坏性变更或迁移说明：对合法调用方没有预期破坏性影响。直接传入非法 `limit` 的内部调用方现在会收到 `parse_error`，而不是进入未定义的切片行为。

## Linked Issues

Fixes #5623

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
