### PR TITLE
ci(audio-capture): cross-compile darwin-x64 prebuild on arm64, drop macos-13 runner

### DIFF
--- a/.github/workflows/audio-capture-prebuilds.yml
+++ b/.github/workflows/audio-capture-prebuilds.yml
@@ -34,12 +34,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # arm64 runner; also cross-compiles the x64 slice (see Build step) to
+          # avoid the scarce macos-13 Intel runner that queues 20+ min (#5642).
           - os: 'macos-14'
             runner: 'macos-14'
             arch: 'arm64'
-          - os: 'macos-13'
-            runner: 'macos-13'
-            arch: 'x64'
           - os: 'ubuntu-latest'
             runner: 'ubuntu-latest'
             arch: 'x64'
@@ -59,7 +58,14 @@ jobs:
       - name: 'Install build deps'
         run: 'npm install --no-workspaces --ignore-scripts --no-audit --no-fund'
       - name: 'Build prebuild'
-        run: 'npm run prebuildify'
+        shell: 'bash'
+        run: |
+          npm run prebuildify
+          # Cross-compile the Intel (x64) slice on this arm64 runner instead of
+          # a separate macos-13 runner (frameworks are universal). See #5642.
+          if [ "$RUNNER_OS" = 'macOS' ]; then
+            npm run prebuildify -- --arch x64
+          fi
       - name: 'Upload prebuild'
         uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' # v7.0.1
         with:


### PR DESCRIPTION
## What

The `macos-13` (Intel x64) audio prebuild job routinely stalls in the GitHub-hosted runner queue for 20+ min — the Intel pool is scarce and on GitHub's deprecation path — while every other platform finishes in under a minute. It blocks the dependent `collect` job and the Release run that calls this workflow. See #5642 for evidence (the job sits `queued` with no runner assigned and 0 steps started, even after the rest of the run completes).

This drops the `macos-13` matrix entry and cross-compiles the `darwin-x64` slice on the existing `macos-14` (arm64) runner instead.

## Why it works

`binding.gyp` links only universal macOS frameworks (CoreAudio / AudioToolbox / AVFoundation / ...) with no hardcoded architecture, so `clang -arch x86_64` cross-compiles cleanly. The Build step now runs `prebuildify` for the native arm64 slice and, on macOS only, again with `--arch x64`.

## Verification

Locally on Apple Silicon:

```
$ npm run prebuildify -- --arch x64
$ file prebuilds/darwin-x64/@qwen-code+audio-capture.node
prebuilds/darwin-x64/@qwen-code+audio-capture.node: Mach-O 64-bit bundle x86_64
$ file prebuilds/darwin-arm64/@qwen-code+audio-capture.node
prebuilds/darwin-arm64/@qwen-code+audio-capture.node: Mach-O 64-bit bundle arm64
```

Both slices build in one ~40s job.

## Downstream safety

- `create-standalone-package.js` gates on the **file** `prebuilds/darwin-x64/*.node` existing (`hasNativePrebuild`), not on runner or artifact names — the cross-compiled slice satisfies it.
- `collect` merges every per-platform artifact via the `prebuilds-*` glob with `merge-multiple`, so the x64 slice (now inside the `macos-14` artifact) is still collected.
- No other workflow or script references `macos-13`.

Closes #5642
