### PR TITLE
fix(core): require integer compaction counts

### DIFF
--- a/packages/core/src/services/compactionInputSlimming.test.ts
+++ b/packages/core/src/services/compactionInputSlimming.test.ts
@@ -123,6 +123,69 @@ describe('compactionInputSlimming', () => {
       expect(t.screenshotTriggerThreshold).toBe(99);
     });
 
+    it('rejects fractional count-like env values', () => {
+      const cases = [
+        {
+          envKey: 'QWEN_COMPACT_MAX_RECENT_FILES',
+          value: '1.5',
+          settings: { maxRecentFilesToRetain: 4 },
+          get: (t: ReturnType<typeof resolveCompactionTuning>) =>
+            t.maxRecentFiles,
+          expected: 4,
+        },
+        {
+          envKey: 'QWEN_COMPACT_MAX_RECENT_IMAGES',
+          value: '2.5',
+          settings: { maxRecentImagesToRetain: 5 },
+          get: (t: ReturnType<typeof resolveCompactionTuning>) =>
+            t.maxRecentImages,
+          expected: 5,
+        },
+        {
+          envKey: 'QWEN_COMPACT_SCREENSHOT_THRESHOLD',
+          value: '9007199254740990.5',
+          settings: { screenshotTriggerThreshold: 6 },
+          get: (t: ReturnType<typeof resolveCompactionTuning>) =>
+            t.screenshotTriggerThreshold,
+          expected: 6,
+        },
+      ] as const;
+
+      for (const c of cases) {
+        for (const k of COMPACTION_ENV_KEYS) delete process.env[k];
+        process.env[c.envKey] = c.value;
+        expect(c.get(resolveCompactionTuning(c.settings))).toBe(c.expected);
+      }
+    });
+
+    it('rejects fractional count-like settings values', () => {
+      const t = resolveCompactionTuning({
+        maxRecentFilesToRetain: 1.5,
+        maxRecentImagesToRetain: 2.5,
+        screenshotTriggerThreshold: 3.5,
+      });
+      expect(t.maxRecentFiles).toBe(DEFAULT_MAX_RECENT_FILES);
+      expect(t.maxRecentImages).toBe(DEFAULT_MAX_RECENT_IMAGES);
+      expect(t.screenshotTriggerThreshold).toBe(
+        DEFAULT_SCREENSHOT_TRIGGER_THRESHOLD,
+      );
+    });
+
+    it('rejects unsafe integer count-like values', () => {
+      process.env['QWEN_COMPACT_MAX_RECENT_FILES'] = String(
+        Number.MAX_SAFE_INTEGER + 1,
+      );
+      const envFallback = resolveCompactionTuning({
+        maxRecentFilesToRetain: 4,
+      });
+      expect(envFallback.maxRecentFiles).toBe(4);
+
+      const settingsFallback = resolveCompactionTuning({
+        maxRecentImagesToRetain: Number.MAX_SAFE_INTEGER + 1,
+      });
+      expect(settingsFallback.maxRecentImages).toBe(DEFAULT_MAX_RECENT_IMAGES);
+    });
+
     it('parses the boolean env both ways and ignores typos', () => {
       process.env['QWEN_COMPACT_SCREENSHOT_TRIGGER'] = 'false';
       expect(resolveCompactionTuning(undefined).enableScreenshotTrigger).toBe(

--- a/packages/core/src/services/compactionInputSlimming.ts
+++ b/packages/core/src/services/compactionInputSlimming.ts
@@ -80,19 +80,29 @@ function resolveNumber(
   envValue: string | undefined,
   settingsValue: number | undefined,
   defaultValue: number,
-  { minInclusive }: { minInclusive: number },
+  {
+    integer = false,
+    minInclusive,
+  }: { integer?: boolean; minInclusive: number },
 ): number {
+  const isValid = (value: number) =>
+    Number.isFinite(value) &&
+    (!integer || Number.isSafeInteger(value)) &&
+    value >= minInclusive;
+
   if (envValue !== undefined && envValue !== '') {
-    const parsed = Number(envValue);
-    if (Number.isFinite(parsed) && parsed >= minInclusive) {
+    const trimmed = envValue.trim();
+    if (integer && !/^\d+$/.test(trimmed)) {
+      return settingsValue !== undefined && isValid(settingsValue)
+        ? settingsValue
+        : defaultValue;
+    }
+    const parsed = Number(trimmed);
+    if (isValid(parsed)) {
       return parsed;
     }
   }
-  if (
-    settingsValue !== undefined &&
-    Number.isFinite(settingsValue) &&
-    settingsValue >= minInclusive
-  ) {
+  if (settingsValue !== undefined && isValid(settingsValue)) {
     return settingsValue;
   }
   return defaultValue;
@@ -116,8 +126,9 @@ export interface ResolvedCompactionTuning {
 
 /**
  * Resolves the post-compact retention + screenshot-trigger knobs in
- * priority order env > settings > default, reusing the same validation
- * rules as `resolveSlimmingConfig`.
+ * priority order env > settings > default. Count-like fields require
+ * integer values because downstream collectors compare against integer
+ * lengths.
  *
  * The screenshot trigger counts only images nested in
  * `functionResponse.parts` (tool results). Compaction replaces those with
@@ -134,13 +145,13 @@ export function resolveCompactionTuning(
       process.env['QWEN_COMPACT_MAX_RECENT_FILES'],
       settings?.maxRecentFilesToRetain,
       DEFAULT_MAX_RECENT_FILES,
-      { minInclusive: 0 },
+      { integer: true, minInclusive: 0 },
     ),
     maxRecentImages: resolveNumber(
       process.env['QWEN_COMPACT_MAX_RECENT_IMAGES'],
       settings?.maxRecentImagesToRetain,
       DEFAULT_MAX_RECENT_IMAGES,
-      { minInclusive: 0 },
+      { integer: true, minInclusive: 0 },
     ),
     enableScreenshotTrigger: resolveBoolean(
       process.env['QWEN_COMPACT_SCREENSHOT_TRIGGER'],
@@ -151,7 +162,7 @@ export function resolveCompactionTuning(
       process.env['QWEN_COMPACT_SCREENSHOT_THRESHOLD'],
       settings?.screenshotTriggerThreshold,
       DEFAULT_SCREENSHOT_TRIGGER_THRESHOLD,
-      { minInclusive: 1 },
+      { integer: true, minInclusive: 1 },
     ),
   };
 }


### PR DESCRIPTION
## What this PR does

Requires integer values for compaction tuning knobs that are used as counts: recent file retention, recent image retention, and the screenshot trigger threshold. Fractional and unsafe integer values now fall through to the next source in the normal env > settings > default order.

## Why it's needed

These knobs are documented and consumed as counts, but `resolveCompactionTuning` previously accepted any finite number above the minimum. A value like `1.5` could therefore reach collectors that compare against integer lengths, effectively retaining 2 items instead of rejecting the invalid count. Env strings also need a lexical integer check before numeric conversion so huge fractional values cannot be rounded into an apparently safe integer.

## Reviewer Test Plan

### How to verify

Confirm that `resolveCompactionTuning` accepts valid integer values, rejects fractional count-like env/settings values, rejects unsafe integers, and still preserves the existing fallback order from env to settings to defaults.

Commands run locally:

```sh
npx vitest run src/services/compactionInputSlimming.test.ts --coverage.enabled=false
npx prettier --check packages/core/src/services/compactionInputSlimming.ts packages/core/src/services/compactionInputSlimming.test.ts
npx eslint packages/core/src/services/compactionInputSlimming.ts packages/core/src/services/compactionInputSlimming.test.ts
git diff --check
npm run build --workspace @qwen-code/qwen-code-core
npm run typecheck --workspace @qwen-code/qwen-code-core
```

### Evidence (Before & After)

Before: fractional values such as `1.5` were accepted for count-like compaction tuning and could change the effective retention count. After: fractional and unsafe integer values are treated as invalid and fall through to settings/defaults. The new tests cover fractional env values for all three count-like knobs, a huge fractional env value that would otherwise be rounded by `Number()`, fractional settings values, and unsafe integers.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS arm64, Node.js v26.3.0.

## Risk & Scope

- Main risk or tradeoff: Low; this only tightens invalid count-like tuning values and keeps valid integer values unchanged.
- Not validated / out of scope: Windows and Linux were not tested locally; CI should cover those platforms.
- Breaking changes / migration notes: No expected breaking change for valid configs. Fractional count values now fall back instead of being accepted.

## Linked Issues

Fixes #5640

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 要求用于“计数”的 compaction tuning 必须是整数，包括最近文件保留数量、最近图片保留数量，以及截图触发阈值。小数和不安全整数现在会按正常的 env > settings > default 顺序回落到下一个来源。

## Why it's needed

这些配置项在文档和下游逻辑里都是作为数量使用的，但之前 `resolveCompactionTuning` 会接受任何大于等于下限的有限数字。因此像 `1.5` 这样的值可以进入和整数长度比较的 collector，实际效果会变成保留 2 个条目，而不是拒绝这个非法数量。env 字符串也需要在数字转换前先做整数字面量校验，避免超大的小数字符串被 `Number()` 舍入成看起来安全的整数。

## Reviewer Test Plan

### How to verify

确认 `resolveCompactionTuning` 会接受合法整数，拒绝 count-like env/settings 小数，拒绝不安全整数，并保留现有 env 到 settings 再到默认值的回落顺序。

本地运行过的命令：

```sh
npx vitest run src/services/compactionInputSlimming.test.ts --coverage.enabled=false
npx prettier --check packages/core/src/services/compactionInputSlimming.ts packages/core/src/services/compactionInputSlimming.test.ts
npx eslint packages/core/src/services/compactionInputSlimming.ts packages/core/src/services/compactionInputSlimming.test.ts
git diff --check
npm run build --workspace @qwen-code/qwen-code-core
npm run typecheck --workspace @qwen-code/qwen-code-core
```

### Evidence (Before & After)

修复前：`1.5` 这类小数会被 count-like compaction tuning 接受，并可能改变实际保留数量。修复后：小数和不安全整数都会被视为非法值，并回落到 settings/defaults。新增测试覆盖了三个 count-like 配置项的小数 env 值、一个会被 `Number()` 舍入的超大小数 env 值、小数 settings 值，以及不安全整数。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地环境为 macOS arm64，Node.js v26.3.0。

## Risk & Scope

- 主要风险或取舍：风险较低；这个 PR 只收紧非法的 count-like tuning 值，合法整数值保持不变。
- 未验证或不在范围内：本地没有测试 Windows 和 Linux；这些平台交给 CI 覆盖。
- 破坏性变更或迁移说明：对合法配置没有预期破坏性影响。小数 count 值现在会回落，而不是被接受。

## Linked Issues

Fixes #5640

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
