### PR TITLE
fix(cli): detect USE_OPENAI auth when the model is set via QWEN_MODEL

### DIFF
--- a/packages/cli/src/utils/modelConfigUtils.test.ts
+++ b/packages/cli/src/utils/modelConfigUtils.test.ts
@@ -55,6 +55,17 @@ describe('modelConfigUtils', () => {
       expect(getAuthTypeFromEnv()).toBe(AuthType.USE_OPENAI);
     });
 
+    it('should return USE_OPENAI when the model is given via QWEN_MODEL', () => {
+      // QWEN_MODEL is a valid USE_OPENAI model var (see AUTH_ENV_MODEL_VARS),
+      // so a config that sets it instead of OPENAI_MODEL must still resolve.
+      process.env['OPENAI_API_KEY'] = 'test-key';
+      process.env['QWEN_MODEL'] = 'qwen3-coder-plus';
+      process.env['OPENAI_BASE_URL'] =
+        'https://dashscope.aliyuncs.com/compatible-mode/v1';
+
+      expect(getAuthTypeFromEnv()).toBe(AuthType.USE_OPENAI);
+    });
+
     it('should return undefined when OpenAI env vars are incomplete', () => {
       process.env['OPENAI_API_KEY'] = 'test-key';
       process.env['OPENAI_MODEL'] = 'gpt-4';

--- a/packages/cli/src/utils/modelConfigUtils.ts
+++ b/packages/cli/src/utils/modelConfigUtils.ts
@@ -102,7 +102,7 @@ export function getAuthTypeFromEnv(): AuthType | undefined {
 
   if (
     process.env['OPENAI_API_KEY'] &&
-    process.env['OPENAI_MODEL'] &&
+    (process.env['OPENAI_MODEL'] || process.env['QWEN_MODEL']) &&
     process.env['OPENAI_BASE_URL']
   ) {
     return AuthType.USE_OPENAI;


### PR DESCRIPTION
## What this PR does

Lets `getAuthTypeFromEnv()` recognize `QWEN_MODEL` (not only `OPENAI_MODEL`) as the model env var that, together with `OPENAI_API_KEY` and `OPENAI_BASE_URL`, resolves to `USE_OPENAI`.

## Why it's needed

`QWEN_MODEL` is already a first-class `USE_OPENAI` model variable everywhere else in `modelConfigUtils.ts`: it's listed in `AUTH_ENV_MODEL_VARS[USE_OPENAI]` (`['OPENAI_MODEL', 'QWEN_MODEL']`), documented in the function's own doc comment, and honored by the model-resolution loop. Only `getAuthTypeFromEnv()` was inconsistent, checking `OPENAI_MODEL` alone.

So a perfectly valid OpenAI-compatible config that sets `OPENAI_API_KEY` + `QWEN_MODEL` + `OPENAI_BASE_URL` (without `OPENAI_MODEL`) failed auth-type detection and returned `undefined`, even though model resolution would have accepted it. That's a natural setup for Qwen/DashScope users.

## Reviewer Test Plan

### How to verify

```
npx vitest run packages/cli/src/utils/modelConfigUtils.test.ts
```

Expected: the new test `getAuthTypeFromEnv > should return USE_OPENAI when the model is given via QWEN_MODEL` passes, and all existing tests still pass. Before the fix the new test fails with `getAuthTypeFromEnv()` returning `undefined`.

### Evidence (Before & After)

N/A (non-user-visible env-detection logic; covered by the unit test above). Verified locally: `1 file, 54 tests passed`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   N/A  |

Verified locally on Windows via `vitest run packages/cli/src/utils/modelConfigUtils.test.ts`.

## Risk & Scope

- Main risk or tradeoff: very low. The condition is only broadened to also accept `QWEN_MODEL`, which is already a sanctioned `USE_OPENAI` model var; behavior is unchanged when `OPENAI_MODEL` is set.
- Not validated / out of scope: other auth types are untouched.
- Breaking changes / migration notes: none.
