### PR TITLE
fix(cli): restore saved custom model IDs when re-entering the auth wizard

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -206,6 +206,42 @@ vi.mock('@qwen-code/qwen-code-core', () => ({
       provider.ownsModel ??
       ((model: { envKey?: string }) => model.envKey === provider.envKey),
   ),
+  findExistingProviderModels: vi.fn(
+    (
+      provider: {
+        envKey?: string | ((...args: unknown[]) => string);
+        protocol: string;
+        protocolOptions?: string[];
+        ownsModel?: (model: { envKey?: string }) => boolean;
+      },
+      modelProviders: Record<string, unknown> | undefined,
+    ) => {
+      const ownsModel =
+        provider.ownsModel ??
+        (typeof provider.envKey === 'string'
+          ? (model: { envKey?: string }) => model.envKey === provider.envKey
+          : undefined);
+      if (!ownsModel || !modelProviders) return undefined;
+      const protocols =
+        provider.protocolOptions && provider.protocolOptions.length > 0
+          ? provider.protocolOptions
+          : [provider.protocol];
+      for (const protocol of protocols) {
+        const raw = modelProviders[protocol];
+        if (!Array.isArray(raw)) continue;
+        const models = raw
+          .filter(
+            (m): m is { id: string; envKey?: string } =>
+              typeof m === 'object' &&
+              m !== null &&
+              typeof (m as { id?: unknown }).id === 'string',
+          )
+          .filter(ownsModel);
+        if (models.length > 0) return { protocol, models };
+      }
+      return undefined;
+    },
+  ),
   ExtensionManager: vi.fn().mockImplementation(() => ({
     refreshCache: mockExtensionManagerState.refreshCache,
     getLoadedExtensions: vi.fn(() => mockExtensionManagerState.extensions),

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -39,7 +39,7 @@ import {
   MCPServerStatus,
   McpTransportPool,
   POOLED_TRANSPORTS_DEFAULT,
-  resolveOwnsModel,
+  findExistingProviderModels,
   ExtensionManager,
   ExtensionSettingScope,
   HookEventName,
@@ -1431,11 +1431,6 @@ function resolveProviderDocumentationUrl(
   return undefined;
 }
 
-function isProviderModelConfig(value: unknown): value is ProviderModelConfig {
-  const record = toRecord(value);
-  return typeof record['id'] === 'string';
-}
-
 function readSettingsEnv(
   settings: LoadedSettings,
   envKey: string | undefined,
@@ -1444,35 +1439,6 @@ function readSettingsEnv(
   const env = toRecord((settings.merged as Record<string, unknown>)['env']);
   const value = env[envKey];
   return typeof value === 'string' && value.length > 0 ? value : undefined;
-}
-
-function readProviderModels(
-  settings: LoadedSettings,
-  protocol: string,
-): ProviderModelConfig[] {
-  const modelProviders = toRecord(
-    (settings.merged as Record<string, unknown>)['modelProviders'],
-  );
-  const models = modelProviders[protocol];
-  return Array.isArray(models) ? models.filter(isProviderModelConfig) : [];
-}
-
-function findExistingProviderModels(
-  config: ProviderConfig,
-  settings: LoadedSettings,
-):
-  | { protocol: ProviderConfig['protocol']; models: ProviderModelConfig[] }
-  | undefined {
-  const ownsModel = resolveOwnsModel(config);
-  if (!ownsModel) return undefined;
-  const protocols = config.protocolOptions?.length
-    ? config.protocolOptions
-    : [config.protocol];
-  for (const protocol of protocols) {
-    const models = readProviderModels(settings, protocol).filter(ownsModel);
-    if (models.length > 0) return { protocol, models };
-  }
-  return undefined;
 }
 
 function resolveProviderEnvKey(
@@ -1508,7 +1474,10 @@ function readExistingProviderConfig(
   config: ProviderConfig,
   settings: LoadedSettings,
 ): Record<string, unknown> | undefined {
-  const existing = findExistingProviderModels(config, settings);
+  const existing = findExistingProviderModels(
+    config,
+    toRecord((settings.merged as Record<string, unknown>)['modelProviders']),
+  );
   const firstModel = existing?.models[0];
   const protocol = existing?.protocol ?? config.protocol;
   const baseUrl =

--- a/packages/cli/src/ui/auth/AuthDialog.test.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.test.tsx
@@ -1256,6 +1256,78 @@ describe('AuthDialog', { timeout: 15000 }, () => {
   );
 
   itWhenTuiInputReliable(
+    'should pre-fill the Model IDs step with previously saved custom model IDs',
+    async () => {
+      // User previously saved a custom model ID for Token Plan in settings.
+      const savedSettings = {
+        security: { auth: { selectedType: undefined } },
+        ui: { customThemes: {} },
+        mcpServers: {},
+        modelProviders: {
+          openai: [
+            {
+              id: 'my-custom-token-model',
+              name: '[ModelStudio Token Plan] my-custom-token-model',
+              baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+              envKey: 'BAILIAN_TOKEN_PLAN_API_KEY',
+            },
+          ],
+        },
+      };
+      const settings: LoadedSettings = new LoadedSettings(
+        {
+          settings: { ui: { customThemes: {} }, mcpServers: {} },
+          originalSettings: { ui: { customThemes: {} }, mcpServers: {} },
+          path: '',
+        },
+        {
+          settings: {},
+          originalSettings: {},
+          path: '',
+        },
+        {
+          settings: savedSettings,
+          originalSettings: savedSettings,
+          path: '',
+        },
+        {
+          settings: { ui: { customThemes: {} }, mcpServers: {} },
+          originalSettings: { ui: { customThemes: {} }, mcpServers: {} },
+          path: '',
+        },
+        true,
+        new Set(),
+      );
+
+      const { stdin, lastFrame, unmount } = renderAuthDialog(settings);
+
+      await waitForSelectedOption(lastFrame, 'Alibaba ModelStudio');
+      stdin.write('\r');
+      await waitForSelectedOption(lastFrame, 'Coding Plan');
+      await moveDownAndWaitForSelection(stdin, lastFrame, 'Token Plan');
+      await pressEnterAndWaitFor(
+        stdin,
+        lastFrame,
+        'Alibaba ModelStudio · Step 1/2 · API Key',
+      );
+
+      await typeText(stdin, 'sk-token-plan');
+
+      await pressEnterAndWaitFor(
+        stdin,
+        lastFrame,
+        'Alibaba ModelStudio · Step 2/2 · Model IDs',
+      );
+
+      // The Model IDs input is pre-filled with the saved custom model id
+      // (which only exists in settings, never among the built-in defaults).
+      expect(lastFrame()).toContain('my-custom-token-model');
+
+      unmount();
+    },
+  );
+
+  itWhenTuiInputReliable(
     'should return from Token Plan API key input to Token Plan selection',
     async () => {
       const settings: LoadedSettings = new LoadedSettings(

--- a/packages/cli/src/ui/auth/AuthDialog.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.tsx
@@ -19,6 +19,7 @@ import { t } from '../../i18n/index.js';
 import {
   findProviderById,
   findProviderByCredentials,
+  findExistingProviderModels,
   customProvider,
   ALIBABA_PROVIDERS,
   THIRD_PARTY_PROVIDERS,
@@ -171,11 +172,25 @@ export function AuthDialog(): React.JSX.Element {
 
   const existingEnv = (settings.merged.env ?? {}) as Record<string, string>;
 
+  // Model IDs already saved for this provider in settings.json (including any
+  // custom ones), so re-entering the wizard pre-fills them instead of resetting
+  // to the built-in defaults and overwriting them on submit.
+  const existingModelIds = (providerConfig: ProviderConfig): string[] =>
+    findExistingProviderModels(
+      providerConfig,
+      settings.merged.modelProviders as Record<string, unknown> | undefined,
+    )?.models.map((model) => model.id) ?? [];
+
   const handleProviderSelect = (providerId: string) => {
     clearErrors();
     const providerConfig = findProviderById(providerId);
     if (!providerConfig) return;
-    setupFlow.start(providerConfig, undefined, existingEnv);
+    setupFlow.start(
+      providerConfig,
+      undefined,
+      existingEnv,
+      existingModelIds(providerConfig),
+    );
     pushView('provider-setup');
   };
 
@@ -228,7 +243,12 @@ export function AuthDialog(): React.JSX.Element {
         pushView('thirdparty-select');
         break;
       case 'CUSTOM_PROVIDER':
-        setupFlow.start(customProvider, undefined, existingEnv);
+        setupFlow.start(
+          customProvider,
+          undefined,
+          existingEnv,
+          existingModelIds(customProvider),
+        );
         pushView('provider-setup');
         break;
       default:

--- a/packages/cli/src/ui/auth/useProviderSetupFlow.ts
+++ b/packages/cli/src/ui/auth/useProviderSetupFlow.ts
@@ -130,6 +130,7 @@ export function useProviderSetupFlow(
       config: ProviderConfig,
       initialProtocol?: AuthType,
       existingEnv?: Record<string, string>,
+      existingModelIds?: string[],
     ) => {
       setProvider(config);
       const steps = getVisibleSteps(config);
@@ -160,7 +161,14 @@ export function useProviderSetupFlow(
       setApiKey(prefillKey);
 
       setApiKeyError(null);
-      setModelIds(getDefaultModelIds(config).join(', '));
+      // Pre-fill with the user's previously saved model IDs (including custom
+      // ones) when present, so re-entering the wizard doesn't reset to — and
+      // later overwrite with — the provider's built-in defaults.
+      const initialModelIds =
+        existingModelIds && existingModelIds.length > 0
+          ? existingModelIds
+          : getDefaultModelIds(config);
+      setModelIds(initialModelIds.join(', '));
       setModelIdsError(null);
       setThinkingEnabled(false);
       setModalityEnabled(false);

--- a/packages/core/src/providers/__tests__/provider-config.test.ts
+++ b/packages/core/src/providers/__tests__/provider-config.test.ts
@@ -10,6 +10,7 @@ import {
   buildInstallPlan,
   buildProviderTemplate,
   computeModelListVersion,
+  findExistingProviderModels,
   findProviderByCredentials,
   getAllProviderBaseUrls,
   getDefaultModelIds,
@@ -362,6 +363,68 @@ describe('getDefaultModelIds', () => {
   it('returns empty array when no models', () => {
     const config = makeConfig({ models: undefined });
     expect(getDefaultModelIds(config)).toEqual([]);
+  });
+});
+
+describe('findExistingProviderModels', () => {
+  const config = makeConfig({ modelNamePrefix: '', envKey: 'TEST_API_KEY' });
+
+  it('returns the user-saved models owned by the provider', () => {
+    const result = findExistingProviderModels(config, {
+      [AuthType.USE_OPENAI]: [
+        { id: 'custom-model', envKey: 'TEST_API_KEY' },
+        { id: 'default-model', envKey: 'TEST_API_KEY' },
+        { id: 'other-provider-model', envKey: 'OTHER_API_KEY' },
+      ],
+    });
+    expect(result).toEqual({
+      protocol: AuthType.USE_OPENAI,
+      models: [
+        { id: 'custom-model', envKey: 'TEST_API_KEY' },
+        { id: 'default-model', envKey: 'TEST_API_KEY' },
+      ],
+    });
+  });
+
+  it('returns undefined when no saved models are owned by the provider', () => {
+    expect(
+      findExistingProviderModels(config, {
+        [AuthType.USE_OPENAI]: [{ id: 'x', envKey: 'OTHER_API_KEY' }],
+      }),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when modelProviders is empty or missing', () => {
+    expect(findExistingProviderModels(config, {})).toBeUndefined();
+    expect(findExistingProviderModels(config, undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when ownership cannot be resolved (function envKey)', () => {
+    const customConfig = makeConfig({
+      envKey: () => 'DYNAMIC_KEY',
+      modelNamePrefix: '',
+    });
+    expect(
+      findExistingProviderModels(customConfig, {
+        [AuthType.USE_OPENAI]: [{ id: 'x', envKey: 'DYNAMIC_KEY' }],
+      }),
+    ).toBeUndefined();
+  });
+
+  it('scans protocolOptions in order and picks the first with owned models', () => {
+    const multiProtocol = makeConfig({
+      modelNamePrefix: '',
+      envKey: 'TEST_API_KEY',
+      protocolOptions: [AuthType.USE_ANTHROPIC, AuthType.USE_OPENAI],
+    });
+    const result = findExistingProviderModels(multiProtocol, {
+      [AuthType.USE_OPENAI]: [{ id: 'openai-model', envKey: 'TEST_API_KEY' }],
+      [AuthType.USE_ANTHROPIC]: [
+        { id: 'anthropic-model', envKey: 'TEST_API_KEY' },
+      ],
+    });
+    expect(result?.protocol).toBe(AuthType.USE_ANTHROPIC);
+    expect(result?.models.map((m) => m.id)).toEqual(['anthropic-model']);
   });
 });
 

--- a/packages/core/src/providers/index.ts
+++ b/packages/core/src/providers/index.ts
@@ -23,6 +23,7 @@ export {
   buildInstallPlan,
   buildProviderTemplate,
   computeModelListVersion,
+  findExistingProviderModels,
   getDefaultBaseUrlForProtocol,
   getDefaultModelIds,
   providerMatchesCredentials,

--- a/packages/core/src/providers/provider-config.ts
+++ b/packages/core/src/providers/provider-config.ts
@@ -355,6 +355,41 @@ export function getDefaultModelIds(config: ProviderConfig): string[] {
   return config.models?.map((s) => s.id) ?? [];
 }
 
+function isProviderModelConfig(value: unknown): value is ProviderModelConfig {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { id?: unknown }).id === 'string'
+  );
+}
+
+/**
+ * Find the model entries a user has already saved for `config` under the
+ * `modelProviders` map in settings. Returns the first protocol (in the
+ * provider's own preference order) that owns stored models, or `undefined`
+ * when none are saved. Used to pre-fill the auth wizard / connect form with
+ * existing model IDs instead of resetting to the provider's built-in defaults.
+ */
+export function findExistingProviderModels(
+  config: ProviderConfig,
+  modelProviders: Record<string, unknown> | undefined,
+):
+  | { protocol: ProviderConfig['protocol']; models: ProviderModelConfig[] }
+  | undefined {
+  const ownsModel = resolveOwnsModel(config);
+  if (!ownsModel || !modelProviders) return undefined;
+  const protocols = config.protocolOptions?.length
+    ? config.protocolOptions
+    : [config.protocol];
+  for (const protocol of protocols) {
+    const raw = modelProviders[protocol];
+    if (!Array.isArray(raw)) continue;
+    const models = raw.filter(isProviderModelConfig).filter(ownsModel);
+    if (models.length > 0) return { protocol, models };
+  }
+  return undefined;
+}
+
 // ---------------------------------------------------------------------------
 // Check if a step should be shown in the UI
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this PR does

Re-entering the provider auth wizard for an Alibaba ModelStudio provider now pre-fills the Model IDs step with the model IDs already saved in settings — including any custom ones the user added — instead of resetting to the provider's built-in defaults. The API key step already restored the saved key; the model IDs now restore the same way, and the shared lookup logic is reused from the desktop/ACP path so both surfaces behave identically.

## Why it's needed

Previously the Model IDs step always started from the provider's built-in default list and ignored what the user had already saved. So when a user who had added custom model IDs re-opened the wizard for the same provider, their custom entries were gone from the step, and completing the wizard overwrote the saved custom models with the defaults — silent data loss. The desktop app already restored saved model IDs when re-opening the provider form; this brings the CLI wizard to parity.

## Reviewer Test Plan

### How to verify

1. Through `/auth`, set up an Alibaba ModelStudio provider (Standard API Key / Coding Plan / Token Plan) and add a custom model ID, then finish the wizard so it is saved to settings.
2. Re-open `/auth` and walk to the same provider's Model IDs step (Step 2/2).
3. Expected: the step is pre-filled with your previously saved model IDs (custom ones included), not the built-in defaults; finishing the wizard keeps them instead of overwriting with defaults. When nothing is saved yet, it still shows the built-in defaults as before.

Verified locally by launching the real CLI in tmux against a settings file that already contained a custom Token Plan model, walking `/auth → Alibaba ModelStudio → Token Plan → Model IDs`, and confirming the saved custom model appears in the input. Unit and component tests were added and pass alongside the existing suites.

### Evidence (Before & After)

**Before** — the Model IDs input is empty and the built-in defaults are all checked (`◉`), so submitting overwrites the saved custom model:

```
│ Alibaba ModelStudio · Step 2/2 · Model IDs                                  │
│ Enter model IDs directly. Use commas to configure multiple models.         │
│ > model-id                                                                 │
│ Recommended models                                                         │
│ ◉   qwen3.7-plus       1,000,000 tokens, thinking, text/image/video        │
│ ◉   qwen3.6-plus       1,000,000 tokens, thinking, text/image/video        │
│ ◉   qwen3.7-max        1,000,000 tokens, thinking, text                    │
│ ...  (saved "my-custom-token-model" is nowhere on this screen)             │
```

**After** — the input is pre-filled with the saved custom model and the defaults are unchecked (`○`):

```
│ Alibaba ModelStudio · Step 2/2 · Model IDs                                  │
│ Enter model IDs directly. Use commas to configure multiple models.         │
│ > my-custom-token-model                                                    │
│ Recommended models                                                         │
│ ○   qwen3.7-plus       1,000,000 tokens, thinking, text/image/video        │
│ ○   qwen3.6-plus       1,000,000 tokens, thinking, text/image/video        │
│ ○   qwen3.7-max        1,000,000 tokens, thinking, text                    │
│ ...  (saved custom model restored; defaults stay unselected)               │
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Real dev CLI launched in tmux with an isolated HOME and a fake API key. Core/CLI unit and component tests run via vitest.

## Risk & Scope

- Main risk or tradeoff: low — this only changes the initial value of the Model IDs step. When no saved models are found it falls back to the existing default list, so first-time setup is unchanged. Providers whose ownership cannot be resolved (e.g. the fully custom provider) are unaffected.
- Not validated / out of scope: Windows and Linux were not exercised locally (covered by CI).
- Breaking changes / migration notes: none.

## Linked Issues

Closes #5636

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

重新进入 Alibaba ModelStudio provider 的 auth 向导时，Model IDs 步骤现在会用 settings 中已保存的 model ID（包括用户添加的自定义项）预填，而不是重置为 provider 的内置默认值。API Key 步骤本就会恢复已保存的 key，现在 model ID 也以同样的方式恢复，并且复用了桌面端 / ACP 路径里共享的查找逻辑，让两端行为一致。

## 为什么需要

此前 Model IDs 步骤总是从 provider 的内置默认列表开始，忽略用户已经保存的内容。于是当用户重新打开同一个 provider 的向导时，之前添加的自定义条目就不见了，走完向导会用默认值覆盖已保存的自定义 model —— 造成静默的数据丢失。桌面应用在重新打开 provider 表单时已经会恢复已保存的 model ID，本 PR 让 CLI 向导与之对齐。

## 评审测试计划

### 如何验证

1. 通过 `/auth` 配置一个 Alibaba ModelStudio provider（Standard API Key / Coding Plan / Token Plan），添加一个自定义 model ID，走完向导保存到 settings。
2. 重新打开 `/auth`，走到同一个 provider 的 Model IDs 步骤（Step 2/2）。
3. 预期：该步骤预填你之前保存的 model ID（含自定义项），而非内置默认值；走完向导会保留它们，而不是用默认值覆盖。当尚无保存内容时，仍像以前一样显示内置默认值。

本地验证方式：在 tmux 中针对一个已包含自定义 Token Plan model 的 settings 启动真实 CLI，走 `/auth → Alibaba ModelStudio → Token Plan → Model IDs`，确认输入框出现已保存的自定义 model。新增了单元与组件测试，并与既有测试套件一同通过。

### 证据（Before & After）

**修复前** —— Model IDs 输入框为空，内置默认项全部选中（`◉`），提交会覆盖已保存的自定义 model：

```
│ > model-id                                                                 │
│ ◉   qwen3.7-plus  ...  （已保存的 "my-custom-token-model" 不在此屏任何位置）│
```

**修复后** —— 输入框预填已保存的自定义 model，默认项未选中（`○`）：

```
│ > my-custom-token-model                                                    │
│ ○   qwen3.7-plus  ...  （自定义 model 已恢复；默认项保持未选）              │
```

### 测试平台

仅在 macOS 本地验证；Windows、Linux 未本地测试（由 CI 覆盖）。

## 风险与范围

- 主要风险 / 取舍：低 —— 仅改变 Model IDs 步骤的初始值。找不到已保存的 model 时回退到原有默认列表，首次配置行为不变。无法解析归属的 provider（如完全自定义 provider）不受影响。
- 未验证 / 超出范围：Windows 与 Linux 未本地验证（由 CI 覆盖）。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Closes #5636

</details>
