### PR TITLE
fix(cli): restore saved custom model IDs when re-entering the auth wizard

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -206,6 +206,41 @@ vi.mock('@qwen-code/qwen-code-core', () => ({
       provider.ownsModel ??
       ((model: { envKey?: string }) => model.envKey === provider.envKey),
   ),
+  findExistingProviderModels: vi.fn(
+    (
+      provider: {
+        envKey?: string | ((...args: unknown[]) => string);
+        protocol: string;
+        protocolOptions?: string[];
+        ownsModel?: (model: { envKey?: string }) => boolean;
+      },
+      modelProviders: Record<string, unknown> | undefined,
+    ) => {
+      const ownsModel =
+        provider.ownsModel ??
+        (typeof provider.envKey === 'string'
+          ? (model: { envKey?: string }) => model.envKey === provider.envKey
+          : undefined);
+      if (!ownsModel || !modelProviders) return undefined;
+      const protocols =
+        provider.protocolOptions && provider.protocolOptions.length > 0
+          ? provider.protocolOptions
+          : [provider.protocol];
+      for (const protocol of protocols) {
+        const raw = modelProviders[protocol];
+        if (!Array.isArray(raw)) continue;
+        const models = raw.filter(
+          (m): m is { id: string; envKey?: string } =>
+            typeof m === 'object' &&
+            m !== null &&
+            typeof (m as { id?: unknown }).id === 'string' &&
+            ownsModel(m),
+        );
+        if (models.length > 0) return { protocol, models };
+      }
+      return undefined;
+    },
+  ),
   ExtensionManager: vi.fn().mockImplementation(() => ({
     refreshCache: mockExtensionManagerState.refreshCache,
     getLoadedExtensions: vi.fn(() => mockExtensionManagerState.extensions),

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -39,7 +39,7 @@ import {
   MCPServerStatus,
   McpTransportPool,
   POOLED_TRANSPORTS_DEFAULT,
-  resolveOwnsModel,
+  findExistingProviderModels,
   ExtensionManager,
   ExtensionSettingScope,
   HookEventName,
@@ -1414,11 +1414,6 @@ function resolveProviderDocumentationUrl(
   return undefined;
 }
 
-function isProviderModelConfig(value: unknown): value is ProviderModelConfig {
-  const record = toRecord(value);
-  return typeof record['id'] === 'string';
-}
-
 function readSettingsEnv(
   settings: LoadedSettings,
   envKey: string | undefined,
@@ -1427,35 +1422,6 @@ function readSettingsEnv(
   const env = toRecord((settings.merged as Record<string, unknown>)['env']);
   const value = env[envKey];
   return typeof value === 'string' && value.length > 0 ? value : undefined;
-}
-
-function readProviderModels(
-  settings: LoadedSettings,
-  protocol: string,
-): ProviderModelConfig[] {
-  const modelProviders = toRecord(
-    (settings.merged as Record<string, unknown>)['modelProviders'],
-  );
-  const models = modelProviders[protocol];
-  return Array.isArray(models) ? models.filter(isProviderModelConfig) : [];
-}
-
-function findExistingProviderModels(
-  config: ProviderConfig,
-  settings: LoadedSettings,
-):
-  | { protocol: ProviderConfig['protocol']; models: ProviderModelConfig[] }
-  | undefined {
-  const ownsModel = resolveOwnsModel(config);
-  if (!ownsModel) return undefined;
-  const protocols = config.protocolOptions?.length
-    ? config.protocolOptions
-    : [config.protocol];
-  for (const protocol of protocols) {
-    const models = readProviderModels(settings, protocol).filter(ownsModel);
-    if (models.length > 0) return { protocol, models };
-  }
-  return undefined;
 }
 
 function resolveProviderEnvKey(
@@ -1491,7 +1457,12 @@ function readExistingProviderConfig(
   config: ProviderConfig,
   settings: LoadedSettings,
 ): Record<string, unknown> | undefined {
-  const existing = findExistingProviderModels(config, settings);
+  const existing = findExistingProviderModels(
+    config,
+    (settings.merged as Record<string, unknown>)['modelProviders'] as
+      | Record<string, unknown>
+      | undefined,
+  );
   const firstModel = existing?.models[0];
   const protocol = existing?.protocol ?? config.protocol;
   const baseUrl =

--- a/packages/cli/src/ui/auth/AuthDialog.test.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.test.tsx
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { AuthDialog } from './AuthDialog.js';
 import { LoadedSettings } from '../../config/settings.js';
+import type { Settings } from '../../config/settingsSchema.js';
 import type { Config } from '@qwen-code/qwen-code-core';
 import { AuthType } from '@qwen-code/qwen-code-core';
 import { renderWithProviders } from '../../test-utils/render.js';
@@ -1250,6 +1251,78 @@ describe('AuthDialog', { timeout: 15000 }, () => {
         },
         { timeout: WAIT_FOR_TIMEOUT },
       );
+
+      unmount();
+    },
+  );
+
+  itWhenTuiInputReliable(
+    'should pre-fill the Model IDs step with previously saved custom model IDs',
+    async () => {
+      // User previously saved a custom model ID for Token Plan in settings.
+      const savedSettings = {
+        security: { auth: { selectedType: undefined } },
+        ui: { customThemes: {} },
+        mcpServers: {},
+        modelProviders: {
+          openai: [
+            {
+              id: 'my-custom-token-model',
+              name: '[ModelStudio Token Plan] my-custom-token-model',
+              baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+              envKey: 'BAILIAN_TOKEN_PLAN_API_KEY',
+            },
+          ],
+        },
+      } as unknown as Settings;
+      const settings: LoadedSettings = new LoadedSettings(
+        {
+          settings: { ui: { customThemes: {} }, mcpServers: {} },
+          originalSettings: { ui: { customThemes: {} }, mcpServers: {} },
+          path: '',
+        },
+        {
+          settings: {},
+          originalSettings: {},
+          path: '',
+        },
+        {
+          settings: savedSettings,
+          originalSettings: savedSettings,
+          path: '',
+        },
+        {
+          settings: { ui: { customThemes: {} }, mcpServers: {} },
+          originalSettings: { ui: { customThemes: {} }, mcpServers: {} },
+          path: '',
+        },
+        true,
+        new Set(),
+      );
+
+      const { stdin, lastFrame, unmount } = renderAuthDialog(settings);
+
+      await waitForSelectedOption(lastFrame, 'Alibaba ModelStudio');
+      stdin.write('\r');
+      await waitForSelectedOption(lastFrame, 'Coding Plan');
+      await moveDownAndWaitForSelection(stdin, lastFrame, 'Token Plan');
+      await pressEnterAndWaitFor(
+        stdin,
+        lastFrame,
+        'Alibaba ModelStudio · Step 1/2 · API Key',
+      );
+
+      await typeText(stdin, 'sk-token-plan');
+
+      await pressEnterAndWaitFor(
+        stdin,
+        lastFrame,
+        'Alibaba ModelStudio · Step 2/2 · Model IDs',
+      );
+
+      // The Model IDs input is pre-filled with the saved custom model id
+      // (which only exists in settings, never among the built-in defaults).
+      expect(lastFrame()).toContain('my-custom-token-model');
 
       unmount();
     },

--- a/packages/cli/src/ui/auth/AuthDialog.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.tsx
@@ -19,6 +19,8 @@ import { t } from '../../i18n/index.js';
 import {
   findProviderById,
   findProviderByCredentials,
+  findExistingProviderModels,
+  getDefaultModelIds,
   customProvider,
   ALIBABA_PROVIDERS,
   THIRD_PARTY_PROVIDERS,
@@ -171,11 +173,26 @@ export function AuthDialog(): React.JSX.Element {
 
   const existingEnv = (settings.merged.env ?? {}) as Record<string, string>;
 
+  const getExistingModelIds = (providerConfig: ProviderConfig): string[] => {
+    const saved = findExistingProviderModels(
+      providerConfig,
+      settings.merged.modelProviders as Record<string, unknown> | undefined,
+    );
+    if (!saved) return [];
+    const builtinIds = new Set(getDefaultModelIds(providerConfig));
+    return saved.models.map((m) => m.id).filter((id) => !builtinIds.has(id));
+  };
+
   const handleProviderSelect = (providerId: string) => {
     clearErrors();
     const providerConfig = findProviderById(providerId);
     if (!providerConfig) return;
-    setupFlow.start(providerConfig, undefined, existingEnv);
+    setupFlow.start(
+      providerConfig,
+      undefined,
+      existingEnv,
+      getExistingModelIds(providerConfig),
+    );
     pushView('provider-setup');
   };
 
@@ -228,7 +245,12 @@ export function AuthDialog(): React.JSX.Element {
         pushView('thirdparty-select');
         break;
       case 'CUSTOM_PROVIDER':
-        setupFlow.start(customProvider, undefined, existingEnv);
+        setupFlow.start(
+          customProvider,
+          undefined,
+          existingEnv,
+          getExistingModelIds(customProvider),
+        );
         pushView('provider-setup');
         break;
       default:

--- a/packages/cli/src/ui/auth/useProviderSetupFlow.ts
+++ b/packages/cli/src/ui/auth/useProviderSetupFlow.ts
@@ -130,6 +130,7 @@ export function useProviderSetupFlow(
       config: ProviderConfig,
       initialProtocol?: AuthType,
       existingEnv?: Record<string, string>,
+      existingModelIds?: string[],
     ) => {
       setProvider(config);
       const steps = getVisibleSteps(config);
@@ -160,7 +161,12 @@ export function useProviderSetupFlow(
       setApiKey(prefillKey);
 
       setApiKeyError(null);
-      setModelIds(getDefaultModelIds(config).join(', '));
+      // Built-in defaults go to the recommended list (checked), user-added
+      // custom IDs go to the input box. The ModelIdsStep component splits
+      // flow.state.modelIds automatically based on config.models.
+      const defaultIds = getDefaultModelIds(config);
+      const customIds = existingModelIds ?? [];
+      setModelIds([...defaultIds, ...customIds].join(', '));
       setModelIdsError(null);
       setThinkingEnabled(false);
       setModalityEnabled(false);

--- a/packages/cli/src/ui/hooks/useProviderUpdates.test.ts
+++ b/packages/cli/src/ui/hooks/useProviderUpdates.test.ts
@@ -138,8 +138,8 @@ describe('useProviderUpdates', () => {
     expect(entry?.diff.currentModelAffected).toBe(false);
   });
 
-  it('reports currentModelAffected when model is removed', async () => {
-    mockConfig.getModel.mockReturnValue('old-deprecated-model');
+  it('excludes user-added custom models from the diff', async () => {
+    mockConfig.getModel.mockReturnValue('my-custom-model');
     (mockSettings.merged[PROVIDER_METADATA_NS] as Record<string, unknown>)[
       METADATA_KEY
     ] = {
@@ -150,10 +150,10 @@ describe('useProviderUpdates', () => {
       [AuthType.USE_OPENAI]: [
         ...chinaTemplate,
         {
-          id: 'old-deprecated-model',
+          id: 'my-custom-model',
           baseUrl: CODING_PLAN_CHINA_BASE_URL,
           envKey: CODING_PLAN_ENV_KEY,
-          name: '[Coding Plan] old-deprecated-model',
+          name: '[Coding Plan] my-custom-model',
         },
       ],
     };
@@ -171,8 +171,8 @@ describe('useProviderUpdates', () => {
     });
 
     const entry = result.current.providerUpdateRequest?.entries[0];
-    expect(entry?.diff.currentModelAffected).toBe(true);
-    expect(entry?.diff.removed).toContain('old-deprecated-model');
+    expect(entry?.diff.removed).not.toContain('my-custom-model');
+    expect(entry?.diff.currentModelAffected).toBe(false);
   });
 
   it('executes update when user confirms with "update"', async () => {

--- a/packages/cli/src/ui/hooks/useProviderUpdates.test.ts
+++ b/packages/cli/src/ui/hooks/useProviderUpdates.test.ts
@@ -175,6 +175,80 @@ describe('useProviderUpdates', () => {
     expect(entry?.diff.currentModelAffected).toBe(false);
   });
 
+  it('detects newly added built-in models when the template grows', async () => {
+    // Simulate an older install that lacks the last built-in model.
+    const olderTemplate = chinaTemplate.slice(0, -1);
+    const addedModelId = chinaTemplate[chinaTemplate.length - 1]!.id;
+    (mockSettings.merged[PROVIDER_METADATA_NS] as Record<string, unknown>)[
+      METADATA_KEY
+    ] = {
+      baseUrl: CODING_PLAN_CHINA_BASE_URL,
+      version: 'old-version-hash',
+    };
+    mockSettings.merged['modelProviders'] = {
+      [AuthType.USE_OPENAI]: olderTemplate,
+    };
+
+    const { result } = renderHook(() =>
+      useProviderUpdates(
+        mockSettings as never,
+        mockConfig as never,
+        mockAddItem,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(result.current.providerUpdateRequest).toBeDefined();
+    });
+
+    const entry = result.current.providerUpdateRequest?.entries[0];
+    expect(entry?.diff.added).toContain(addedModelId);
+  });
+
+  it('preserves user-added custom models when executing an update', async () => {
+    const customModel = {
+      id: 'my-custom-model',
+      baseUrl: CODING_PLAN_CHINA_BASE_URL,
+      envKey: CODING_PLAN_ENV_KEY,
+      name: '[Coding Plan] my-custom-model',
+    };
+    (mockSettings.merged[PROVIDER_METADATA_NS] as Record<string, unknown>)[
+      METADATA_KEY
+    ] = {
+      baseUrl: CODING_PLAN_CHINA_BASE_URL,
+      version: 'old-version-hash',
+    };
+    mockSettings.merged['modelProviders'] = {
+      [AuthType.USE_OPENAI]: [...chinaTemplate, customModel],
+    };
+    mockConfig.refreshAuth.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() =>
+      useProviderUpdates(
+        mockSettings as never,
+        mockConfig as never,
+        mockAddItem,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(result.current.providerUpdateRequest).toBeDefined();
+    });
+
+    await result.current.providerUpdateRequest!.onConfirm('update');
+
+    await waitFor(() => {
+      expect(mockConfig.reloadModelProvidersConfig).toHaveBeenCalled();
+    });
+
+    const reloaded = mockConfig.reloadModelProvidersConfig.mock.calls[0][0];
+    expect(reloaded[AuthType.USE_OPENAI]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'my-custom-model' }),
+      ]),
+    );
+  });
+
   it('executes update when user confirms with "update"', async () => {
     (mockSettings.merged[PROVIDER_METADATA_NS] as Record<string, unknown>)[
       METADATA_KEY

--- a/packages/cli/src/ui/hooks/useProviderUpdates.ts
+++ b/packages/cli/src/ui/hooks/useProviderUpdates.ts
@@ -152,7 +152,7 @@ interface PendingUpdate {
   diff: ModelUpdateDiff;
 }
 
-function getInstalledOwnedModelIds(
+function readInstalledOwnedIds(
   settings: LoadedSettings,
   provider: ProviderConfig,
 ): string[] {
@@ -165,14 +165,22 @@ function getInstalledOwnedModelIds(
   if (!modelProviders) return [];
   const allModels: ProviderModelConfig[] = modelProviders[protocol] ?? [];
   const ownsFn = resolveOwnsModel(provider);
-  const installedIds = ownsFn
+  return ownsFn
     ? allModels.filter(ownsFn).map((m) => m.id)
     : allModels.map((m) => m.id);
+}
+
+function getInstalledOwnedModelIds(
+  settings: LoadedSettings,
+  provider: ProviderConfig,
+): string[] {
   // Only compare built-in model IDs — user-added custom models should not
   // appear as "removed" in the diff since they were never part of the
   // provider's built-in list.
   const builtinIds = new Set(getDefaultModelIds(provider));
-  return installedIds.filter((id) => builtinIds.has(id));
+  return readInstalledOwnedIds(settings, provider).filter((id) =>
+    builtinIds.has(id),
+  );
 }
 
 function findAllPendingUpdates(
@@ -228,10 +236,17 @@ export function useProviderUpdates(
     async (providerCfg: ProviderConfig, baseUrl?: string) => {
       try {
         const resolved = resolveBaseUrl(providerCfg, baseUrl);
+        // An update only refreshes built-in models — user-added custom IDs
+        // must be carried through so they are not deleted by the
+        // prepend-and-remove-owned merge.
+        const defaultIds = getDefaultModelIds(providerCfg);
+        const customIds = readInstalledOwnedIds(settings, providerCfg).filter(
+          (id) => !defaultIds.includes(id),
+        );
         const installPlan = buildInstallPlan(providerCfg, {
           baseUrl: resolved,
           apiKey: '',
-          modelIds: getDefaultModelIds(providerCfg),
+          modelIds: [...defaultIds, ...customIds],
         });
         delete installPlan.env;
         const previousModel = config.getModel();

--- a/packages/cli/src/ui/hooks/useProviderUpdates.ts
+++ b/packages/cli/src/ui/hooks/useProviderUpdates.ts
@@ -165,8 +165,14 @@ function getInstalledOwnedModelIds(
   if (!modelProviders) return [];
   const allModels: ProviderModelConfig[] = modelProviders[protocol] ?? [];
   const ownsFn = resolveOwnsModel(provider);
-  if (!ownsFn) return allModels.map((m) => m.id);
-  return allModels.filter(ownsFn).map((m) => m.id);
+  const installedIds = ownsFn
+    ? allModels.filter(ownsFn).map((m) => m.id)
+    : allModels.map((m) => m.id);
+  // Only compare built-in model IDs — user-added custom models should not
+  // appear as "removed" in the diff since they were never part of the
+  // provider's built-in list.
+  const builtinIds = new Set(getDefaultModelIds(provider));
+  return installedIds.filter((id) => builtinIds.has(id));
 }
 
 function findAllPendingUpdates(

--- a/packages/core/src/providers/__tests__/provider-config.test.ts
+++ b/packages/core/src/providers/__tests__/provider-config.test.ts
@@ -10,6 +10,7 @@ import {
   buildInstallPlan,
   buildProviderTemplate,
   computeModelListVersion,
+  findExistingProviderModels,
   findProviderByCredentials,
   getAllProviderBaseUrls,
   getDefaultModelIds,
@@ -362,6 +363,68 @@ describe('getDefaultModelIds', () => {
   it('returns empty array when no models', () => {
     const config = makeConfig({ models: undefined });
     expect(getDefaultModelIds(config)).toEqual([]);
+  });
+});
+
+describe('findExistingProviderModels', () => {
+  const config = makeConfig({ modelNamePrefix: '', envKey: 'TEST_API_KEY' });
+
+  it('returns the user-saved models owned by the provider', () => {
+    const result = findExistingProviderModels(config, {
+      [AuthType.USE_OPENAI]: [
+        { id: 'custom-model', envKey: 'TEST_API_KEY' },
+        { id: 'default-model', envKey: 'TEST_API_KEY' },
+        { id: 'other-provider-model', envKey: 'OTHER_API_KEY' },
+      ],
+    });
+    expect(result).toEqual({
+      protocol: AuthType.USE_OPENAI,
+      models: [
+        { id: 'custom-model', envKey: 'TEST_API_KEY' },
+        { id: 'default-model', envKey: 'TEST_API_KEY' },
+      ],
+    });
+  });
+
+  it('returns undefined when no saved models are owned by the provider', () => {
+    expect(
+      findExistingProviderModels(config, {
+        [AuthType.USE_OPENAI]: [{ id: 'x', envKey: 'OTHER_API_KEY' }],
+      }),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when modelProviders is empty or missing', () => {
+    expect(findExistingProviderModels(config, {})).toBeUndefined();
+    expect(findExistingProviderModels(config, undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when ownership cannot be resolved (function envKey)', () => {
+    const customConfig = makeConfig({
+      envKey: () => 'DYNAMIC_KEY',
+      modelNamePrefix: '',
+    });
+    expect(
+      findExistingProviderModels(customConfig, {
+        [AuthType.USE_OPENAI]: [{ id: 'x', envKey: 'DYNAMIC_KEY' }],
+      }),
+    ).toBeUndefined();
+  });
+
+  it('scans protocolOptions in order and picks the first with owned models', () => {
+    const multiProtocol = makeConfig({
+      modelNamePrefix: '',
+      envKey: 'TEST_API_KEY',
+      protocolOptions: [AuthType.USE_ANTHROPIC, AuthType.USE_OPENAI],
+    });
+    const result = findExistingProviderModels(multiProtocol, {
+      [AuthType.USE_OPENAI]: [{ id: 'openai-model', envKey: 'TEST_API_KEY' }],
+      [AuthType.USE_ANTHROPIC]: [
+        { id: 'anthropic-model', envKey: 'TEST_API_KEY' },
+      ],
+    });
+    expect(result?.protocol).toBe(AuthType.USE_ANTHROPIC);
+    expect(result?.models.map((m) => m.id)).toEqual(['anthropic-model']);
   });
 });
 

--- a/packages/core/src/providers/index.ts
+++ b/packages/core/src/providers/index.ts
@@ -23,6 +23,7 @@ export {
   buildInstallPlan,
   buildProviderTemplate,
   computeModelListVersion,
+  findExistingProviderModels,
   getDefaultBaseUrlForProtocol,
   getDefaultModelIds,
   providerMatchesCredentials,

--- a/packages/core/src/providers/provider-config.ts
+++ b/packages/core/src/providers/provider-config.ts
@@ -355,6 +355,44 @@ export function getDefaultModelIds(config: ProviderConfig): string[] {
   return config.models?.map((s) => s.id) ?? [];
 }
 
+function isProviderModelConfig(value: unknown): value is ProviderModelConfig {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { id?: unknown }).id === 'string'
+  );
+}
+
+/**
+ * Find the model entries a user has already saved for `config` under the
+ * `modelProviders` map in settings. Returns the first protocol (in the
+ * provider's own preference order) that owns stored models, or `undefined`
+ * when none are saved. Used to pre-fill the auth wizard / connect form with
+ * existing model IDs instead of resetting to the provider's built-in defaults.
+ */
+export function findExistingProviderModels(
+  config: ProviderConfig,
+  modelProviders: Record<string, unknown> | undefined,
+):
+  | { protocol: ProviderConfig['protocol']; models: ProviderModelConfig[] }
+  | undefined {
+  const ownsModel = resolveOwnsModel(config);
+  if (!ownsModel || !modelProviders) return undefined;
+  const protocols = config.protocolOptions?.length
+    ? config.protocolOptions
+    : [config.protocol];
+  for (const protocol of protocols) {
+    const raw = modelProviders[protocol];
+    if (!Array.isArray(raw)) continue;
+    const models = raw.filter(
+      (m): m is ProviderModelConfig =>
+        isProviderModelConfig(m) && ownsModel(m),
+    );
+    if (models.length > 0) return { protocol, models };
+  }
+  return undefined;
+}
+
 // ---------------------------------------------------------------------------
 // Check if a step should be shown in the UI
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this PR does

A user adds a custom model ID to a Coding Plan / Token Plan provider (e.g. `my-custom-model` alongside the built-in `qwen3-coder-plus`). Two things break:

1. **Re-opening `/auth` silently loses the custom model.** The Model IDs step always reset to built-in defaults, ignoring what was saved. Completing the wizard overwrote the user's custom entries — silent data loss.

2. **A spurious "provider update" diff appears on every restart.** The update detector compared *all* saved model IDs (including user-added ones) against the current built-in list. Since custom models are never in the built-in list, they showed up as "removed" on every launch — noise that trains users to ignore real updates.

Both bugs share one root cause: `ownsModel` determines *which provider* a model belongs to, but cannot distinguish **built-in defaults** from **user-added custom models** — both pass ownership checks because `buildModelConfigs` stamps custom models with the same `envKey` and `name` prefix as built-in ones.

This PR fixes both by splitting built-in vs custom at each call site, using `getDefaultModelIds(config)` as the discriminator:

- **`AuthDialog.getExistingModelIds`**: filters out built-in IDs from saved models, passes only custom IDs to the wizard.
- **`useProviderSetupFlow`**: pre-fills `[...getDefaultModelIds(config), ...customIds]`. The `ModelIdsStep` component auto-splits — built-in models go to the recommended list (checked), custom models go to the input box.
- **`useProviderUpdates.getInstalledOwnedModelIds`**: filters to only built-in IDs before diffing, so custom models never appear as "removed".
- **`findExistingProviderModels`** (shared core helper, extracted from cli): unchanged — still returns all saved owned models. Callers decide what to exclude.

## Reviewer Test Plan

### How to verify

Pre-seed an isolated settings file with a Coding Plan provider that has one built-in model and one custom model, plus a stale version hash:

```bash
TEST_HOME=/tmp/qc-pr5654-test
mkdir -p "$TEST_HOME/.qwen"
cat > "$TEST_HOME/.qwen/settings.json" << 'EOF'
{
  "env": { "BAILIAN_CODING_PLAN_API_KEY": "sk-sp-fake-key" },
  "modelProviders": {
    "openai": [
      { "id": "qwen3-coder-plus", "name": "[ModelStudio Coding Plan] qwen3-coder-plus", "baseUrl": "https://coding.dashscope.aliyuncs.com/v1", "envKey": "BAILIAN_CODING_PLAN_API_KEY" },
      { "id": "my-custom-test-model", "name": "[ModelStudio Coding Plan] my-custom-test-model", "baseUrl": "https://coding.dashscope.aliyuncs.com/v1", "envKey": "BAILIAN_CODING_PLAN_API_KEY" }
    ]
  },
  "providerMetadata": { "coding-plan": { "version": "old-hash", "baseUrl": "https://coding.dashscope.aliyuncs.com/v1" } }
}
EOF
HOME=$TEST_HOME npm run dev -- --approval-mode yolo
```

**Scene 1 — startup diff prompt: custom model is NOT listed**

```
Built-in Provider Update · Coding Plan

  + qwen3.5-plus
  + qwen3.6-plus
  + qwen3.7-plus
  + glm-5
  + kimi-k2.5
  + MiniMax-M2.5
  + qwen3-coder-next
  + qwen3-max-2026-01-23
  + glm-4.7
```

`my-custom-test-model` does not appear. Before the fix it was listed as "removed" on every restart.

**Scene 2 — `/auth` wizard, Model IDs step: custom in input, built-in in recommended**

Walk `/auth` → Alibaba ModelStudio → Coding Plan → China → submit API key → reach Model IDs:

```
Alibaba ModelStudio · Step 3/3 · Model IDs

Enter model IDs directly. Use commas to configure multiple models.

> my-custom-test-model

Recommended models
◉   qwen3.5-plus       1,000,000 tokens, thinking, text/image/video
◉   qwen3.6-plus       1,000,000 tokens, thinking, text/image/video
◉   qwen3.7-plus       1,000,000 tokens, thinking, text
◉   glm-5              202,752 tokens, thinking, text
◉   kimi-k2.5          262,144 tokens, thinking, text/image/video
◉   MiniMax-M2.5       196,608 tokens, thinking, text
◉   qwen3-coder-plus   1,000,000 tokens, text
◉   qwen3-coder-next   262,144 tokens, text
```

- Input box: `my-custom-test-model` (restored from saved settings, user can edit or remove)
- Recommended list: all built-in defaults checked, reflecting the latest provider config (note `qwen3-coder-next` which wasn't in the saved settings)
- API key step also pre-filled the saved key

### Tested on

| OS | Status |
| --- | --- |
| macOS | verified locally |
| Windows | CI only |
| Linux | CI only |

## Risk & Scope

- **Tradeoff**: when a provider *removes* a previously built-in model (e.g. `old-deprecated-model`), the diff detector can no longer flag it as "removed" because it is indistinguishable from a user-added custom model — both are absent from `getDefaultModelIds`. This is accepted as a rare case; the alternative (flagging every custom model as "removed") is worse.
- First-time setup (no saved models) is unchanged — the wizard shows built-in defaults as before.
- The fully custom provider (no `ownsModel` resolvable) is unaffected.

## Linked Issues

Closes #5636

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

用户给 Coding Plan / Token Plan provider 添加了自定义 model ID（比如在内置的 `qwen3-coder-plus` 之外加了 `my-custom-model`）。然后出现两个问题：

1. **重新打开 `/auth` 时自定义 model 静默丢失。** Model IDs 步骤总是重置为内置默认列表，忽略已保存的内容。走完向导会用默认值覆盖用户的自定义条目——静默数据丢失。

2. **每次重启都弹出虚假的"provider 更新"提醒。** 更新检测器把所有 saved model IDs（包括用户自定义的）和当前内置列表做 diff。自定义 model 从来不在内置列表里，所以每次启动都显示为"removed"——噪音让用户逐渐忽略真正的更新。

两个 bug 的根因相同：`ownsModel` 判断的是 model 属于哪个 provider，但无法区分**内置默认**和**用户自定义**——两者都通过归属检查，因为 `buildModelConfigs` 给自定义 model 打了和内置一样的 `envKey` 和 `name` prefix。

本 PR 在每个调用点用 `getDefaultModelIds(config)` 作为判据做拆分：

- **`AuthDialog.getExistingModelIds`**：从 saved models 中过滤掉内置 ID，只传自定义 ID 给 wizard
- **`useProviderSetupFlow`**：预填 `[...getDefaultModelIds(config), ...customIds]`。`ModelIdsStep` 组件自动拆分——内置去 recommended 列表（选中），自定义去 input 框
- **`useProviderUpdates.getInstalledOwnedModelIds`**：过滤为只含内置 ID 再做 diff，自定义 model 不会出现为 "removed"
- **`findExistingProviderModels`**（共享 core helper，从 cli 提取）：不变——仍返回全部 saved owned models，由调用方决定排除什么

## 评审测试计划

### 如何验证

预置隔离 settings 文件，包含一个内置 model + 一个自定义 model + 旧 version hash：

```bash
TEST_HOME=/tmp/qc-pr5654-test
mkdir -p "$TEST_HOME/.qwen"
cat > "$TEST_HOME/.qwen/settings.json" << 'EOF'
{
  "env": { "BAILIAN_CODING_PLAN_API_KEY": "sk-sp-fake-key" },
  "modelProviders": {
    "openai": [
      { "id": "qwen3-coder-plus", "name": "[ModelStudio Coding Plan] qwen3-coder-plus", "baseUrl": "https://coding.dashscope.aliyuncs.com/v1", "envKey": "BAILIAN_CODING_PLAN_API_KEY" },
      { "id": "my-custom-test-model", "name": "[ModelStudio Coding Plan] my-custom-test-model", "baseUrl": "https://coding.dashscope.aliyuncs.com/v1", "envKey": "BAILIAN_CODING_PLAN_API_KEY" }
    ]
  },
  "providerMetadata": { "coding-plan": { "version": "old-hash", "baseUrl": "https://coding.dashscope.aliyuncs.com/v1" } }
}
EOF
HOME=$TEST_HOME npm run dev -- --approval-mode yolo
```

**场景一 — 启动 diff 提醒：自定义 model 不在列表中**

`my-custom-test-model` 未出现。修复前每次启动都会被列为 "removed"。

**场景二 — `/auth` 向导 Model IDs 步骤：自定义在 input 框，内置在 recommended 列表**

- input 框：`my-custom-test-model`（从 saved 恢复，可编辑或删除）
- recommended 列表：内置默认全部选中，反映最新 provider 配置（注意 saved 里没有的 `qwen3-coder-next` 也出现了）
- API key 步骤也预填了已保存的 key

## 风险与范围

- **取舍**：当 provider 删除某个曾经内置的 model 时，diff 检测器无法再将其标记为 "removed"——因为它和用户自定义的 model 一样不在 `getDefaultModelIds` 里。这个罕见场景被接受；替代方案（每次把自定义 model 标为 "removed"）更差。
- 首次配置（无 saved models）行为不变——wizard 仍显示内置默认。
- 完全自定义 provider（无法解析 ownsModel）不受影响。

## 关联 Issue

Closes #5636

</details>