### PR TITLE
fix(cli): stop repeated duplicate provider responses

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -1938,6 +1938,170 @@ describe('Session', () => {
 
         expect(finishedSpy).toHaveBeenCalled();
       });
+
+      it('stops an ACP prompt after a repeated duplicate provider id without sending an empty follow-up', async () => {
+        mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.YOLO);
+        vi.mocked(mockChat.getHistoryFunctionResponseIds)
+          .mockReturnValueOnce(new Set<string>())
+          .mockReturnValue(new Set(['shell_1']));
+        const [duplicatePart] = core.normalizeModelToolCallIds(
+          [
+            {
+              functionCall: {
+                id: 'shell_1',
+                name: 'read_file',
+                args: { file_path: 'b.ts' },
+              },
+            },
+          ],
+          new Set(['shell_1']),
+          new Set<string>(),
+        );
+        const duplicateCall = duplicatePart.functionCall!;
+        const execute = vi.fn().mockResolvedValue({
+          llmContent: 'first result',
+          returnDisplay: 'first result',
+        });
+        mockToolRegistry.getTool.mockReturnValue({
+          name: 'read_file',
+          kind: core.Kind.Read,
+          displayName: 'Read File',
+          description: 'Read file',
+          build: vi.fn().mockReturnValue({
+            params: { file_path: 'a.ts' },
+            execute,
+            getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+            getDescription: vi.fn().mockReturnValue('Read file'),
+            toolLocations: vi.fn().mockReturnValue([]),
+          }),
+          canUpdateOutput: false,
+          isOutputMarkdown: true,
+        });
+
+        mockChat.sendMessageStream = vi
+          .fn()
+          .mockResolvedValueOnce(
+            createStreamWithChunks([
+              {
+                type: core.StreamEventType.CHUNK,
+                value: {
+                  functionCalls: [
+                    {
+                      id: 'shell_1',
+                      name: 'read_file',
+                      args: { file_path: 'a.ts' },
+                    },
+                  ],
+                },
+              },
+            ]),
+          )
+          .mockResolvedValueOnce(
+            createStreamWithChunks([
+              {
+                type: core.StreamEventType.CHUNK,
+                value: { functionCalls: [duplicateCall] },
+              },
+            ]),
+          )
+          .mockResolvedValueOnce(
+            createStreamWithChunks([
+              {
+                type: core.StreamEventType.CHUNK,
+                value: {
+                  functionCalls: [
+                    duplicateCall,
+                    {
+                      id: 'fresh_shell',
+                      name: 'read_file',
+                      args: { file_path: 'c.ts' },
+                    },
+                  ],
+                },
+              },
+            ]),
+          );
+
+        await session.prompt({
+          sessionId: 'test-session-id',
+          prompt: [{ type: 'text', text: 'read the file' }],
+        });
+
+        expect(mockChat.sendMessageStream).toHaveBeenCalledTimes(3);
+        expect(execute).toHaveBeenCalledTimes(1);
+        const duplicateFollowUp = vi.mocked(mockChat.sendMessageStream).mock
+          .calls[2][1] as { message: Part[] };
+        expect(duplicateFollowUp.message).toHaveLength(1);
+        expect(
+          duplicateFollowUp.message[0].functionResponse?.response?.['error'],
+        ).toContain('Duplicate provider tool call id "shell_1"');
+      });
+
+      it('clears duplicate provider id tracking between ACP prompts', async () => {
+        mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.YOLO);
+        vi.mocked(mockChat.getHistoryFunctionResponseIds).mockReturnValue(
+          new Set(['shell_1']),
+        );
+        const [duplicatePart] = core.normalizeModelToolCallIds(
+          [
+            {
+              functionCall: {
+                id: 'shell_1',
+                name: 'read_file',
+                args: { file_path: 'b.ts' },
+              },
+            },
+          ],
+          new Set(['shell_1']),
+          new Set<string>(),
+        );
+        const duplicateCall = duplicatePart.functionCall!;
+
+        mockChat.sendMessageStream = vi
+          .fn()
+          .mockResolvedValueOnce(
+            createStreamWithChunks([
+              {
+                type: core.StreamEventType.CHUNK,
+                value: { functionCalls: [duplicateCall] },
+              },
+            ]),
+          )
+          .mockResolvedValueOnce(createEmptyStream())
+          .mockResolvedValueOnce(
+            createStreamWithChunks([
+              {
+                type: core.StreamEventType.CHUNK,
+                value: { functionCalls: [duplicateCall] },
+              },
+            ]),
+          )
+          .mockResolvedValueOnce(createEmptyStream());
+
+        await session.prompt({
+          sessionId: 'test-session-id',
+          prompt: [{ type: 'text', text: 'first prompt' }],
+        });
+        await session.prompt({
+          sessionId: 'test-session-id',
+          prompt: [{ type: 'text', text: 'second prompt' }],
+        });
+
+        expect(mockChat.sendMessageStream).toHaveBeenCalledTimes(4);
+        const firstFollowUp = vi.mocked(mockChat.sendMessageStream).mock
+          .calls[1][1] as { message: Part[] };
+        const secondFollowUp = vi.mocked(mockChat.sendMessageStream).mock
+          .calls[3][1] as { message: Part[] };
+
+        expect(firstFollowUp.message).toHaveLength(1);
+        expect(secondFollowUp.message).toHaveLength(1);
+        expect(
+          firstFollowUp.message[0].functionResponse?.response?.['error'],
+        ).toContain('Duplicate provider tool call id "shell_1"');
+        expect(
+          secondFollowUp.message[0].functionResponse?.response?.['error'],
+        ).toContain('Duplicate provider tool call id "shell_1"');
+      });
     });
 
     describe('tool outcome telemetry (#4602 review)', () => {
@@ -6589,6 +6753,7 @@ describe('Session', () => {
       ) => Promise<{
         parts: Part[];
         stopAfterPermissionCancel: boolean;
+        repeatedDuplicateProviderToolCall?: boolean;
       }>;
     };
 
@@ -8122,6 +8287,77 @@ describe('Session', () => {
           }),
         }),
       );
+    });
+
+    it('drops repeated duplicate provider functionCall ids after the first synthetic response', async () => {
+      const execute = vi.fn().mockResolvedValue({
+        llmContent: 'should not run',
+        returnDisplay: 'should not run',
+      });
+      const build = vi.fn().mockReturnValue({
+        params: { file_path: 'b.ts' },
+        execute,
+        getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+        getDescription: vi.fn().mockReturnValue('Read file'),
+        toolLocations: vi.fn().mockReturnValue([]),
+      });
+      mockToolRegistry.getTool.mockReturnValue({
+        name: 'read_file',
+        kind: core.Kind.Read,
+        displayName: 'Read File',
+        description: 'Read file',
+        build,
+        canUpdateOutput: false,
+        isOutputMarkdown: true,
+      });
+      vi.mocked(mockChat.getHistoryFunctionResponseIds).mockReturnValue(
+        new Set(['shell_1']),
+      );
+      const [duplicatePart] = core.normalizeModelToolCallIds(
+        [
+          {
+            functionCall: {
+              id: 'shell_1',
+              name: 'read_file',
+              args: { file_path: 'b.ts' },
+            },
+          },
+        ],
+        new Set(['shell_1']),
+        new Set<string>(),
+      );
+      const duplicateCall = duplicatePart.functionCall!;
+
+      const firstResult = await (
+        session as unknown as ToolCallInternals
+      ).runToolCalls(new AbortController().signal, 'prompt-history-dup', [
+        duplicateCall,
+      ]);
+      const secondResult = await (
+        session as unknown as ToolCallInternals
+      ).runToolCalls(new AbortController().signal, 'prompt-history-dup', [
+        duplicateCall,
+        { id: 'fresh_shell', name: 'read_file', args: { file_path: 'c.ts' } },
+      ]);
+
+      expect(mockToolRegistry.getTool).not.toHaveBeenCalled();
+      expect(build).not.toHaveBeenCalled();
+      expect(execute).not.toHaveBeenCalled();
+      expect(firstResult.parts).toHaveLength(1);
+      expect(firstResult.parts[0].functionResponse?.id).toBe(
+        'shell_1__qwen_dup_2',
+      );
+      expect(firstResult.parts[0].functionResponse?.response).toEqual({
+        error: expect.stringContaining(
+          'Duplicate provider tool call id "shell_1"',
+        ),
+      });
+      expect(secondResult.parts).toHaveLength(0);
+      expect(secondResult.repeatedDuplicateProviderToolCall).toBe(true);
+      expect(mockChatRecordingService.recordToolResult).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(mockClient.sessionUpdate).toHaveBeenCalledTimes(1);
     });
 
     it('suppresses duplicate TodoWrite calls without emitting plan updates', async () => {

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -35,6 +35,8 @@ import {
   CompressionStatus,
   convertToFunctionResponse,
   createDuplicateProviderToolCallResponse,
+  findRepeatedDuplicateProviderToolCall,
+  markDuplicateProviderToolCallResponseSent,
   createDebugLogger,
   DiscoveredMCPTool,
   StreamEventType,
@@ -184,6 +186,7 @@ type AutoCompressionSendResult =
 type RunToolResult = {
   parts: Part[];
   stopAfterPermissionCancel: boolean;
+  repeatedDuplicateProviderToolCall?: boolean;
 };
 
 const PERMISSION_CANCEL_SKIP_MESSAGE =
@@ -670,6 +673,10 @@ export class Session implements SessionContext {
   private lastPromptTokenCountChat: GeminiChat | null = null;
   private midTurnDrainUnavailable = false;
   private midTurnDrainTimeoutStrikes = 0;
+  // ACP can continue one logical conversation through prompt, cron, and
+  // background loops, so keep this with the session instead of a single
+  // runToolCalls invocation.
+  private readonly duplicateProviderToolCallResponseIds = new Set<string>();
   // Messages from a drain that the daemon answered but we timed out waiting for
   // (the daemon already spliced + SSE-published them). Re-injected on the next
   // batch so a transient stall can't silently lose them. See
@@ -1114,6 +1121,8 @@ export class Session implements SessionContext {
     if (pendingSend.signal.aborted) {
       return { stopReason: 'cancelled' };
     }
+
+    this.duplicateProviderToolCallResponseIds.clear();
 
     // Track this prompt's completion for the next prompt to await
     let resolveCompletion!: () => void;
@@ -1591,15 +1600,10 @@ export class Session implements SessionContext {
                     );
                     return { stopReason: 'end_turn' };
                   }
-                  nextMessage = {
-                    role: 'user',
-                    parts: [
-                      ...toolRun.parts,
-                      ...(await this.#drainMidTurnUserMessages(
-                        pendingSend.signal,
-                      )),
-                    ],
-                  };
+                  nextMessage = await this.#buildNextMessageAfterToolRun(
+                    toolRun,
+                    pendingSend.signal,
+                  );
                 }
               }
 
@@ -1865,13 +1869,10 @@ export class Session implements SessionContext {
               );
               return { stopReason: 'end_turn' };
             }
-            nextMessage = {
-              role: 'user',
-              parts: [
-                ...toolRun.parts,
-                ...(await this.#drainMidTurnUserMessages(pendingSend.signal)),
-              ],
-            };
+            nextMessage = await this.#buildNextMessageAfterToolRun(
+              toolRun,
+              pendingSend.signal,
+            );
           }
         }
 
@@ -2047,6 +2048,23 @@ export class Session implements SessionContext {
       true,
     );
     await this.messageRewriter?.waitForPendingRewrites();
+  }
+
+  async #buildNextMessageAfterToolRun(
+    toolRun: RunToolResult,
+    abortSignal: AbortSignal,
+  ): Promise<Content | null> {
+    if (toolRun.repeatedDuplicateProviderToolCall) {
+      debugLogger.debug(
+        'Stopping ACP turn after dropping repeated duplicate provider tool-call response.',
+      );
+      return null;
+    }
+    const parts = [
+      ...toolRun.parts,
+      ...(await this.#drainMidTurnUserMessages(abortSignal)),
+    ];
+    return { role: 'user', parts };
   }
 
   #recordCompressionTokenCount(info: ChatCompressionInfo): void {
@@ -2563,13 +2581,10 @@ export class Session implements SessionContext {
                     );
                     return;
                   }
-                  nextMessage = {
-                    role: 'user',
-                    parts: [
-                      ...toolRun.parts,
-                      ...(await this.#drainMidTurnUserMessages(ac.signal)),
-                    ],
-                  };
+                  nextMessage = await this.#buildNextMessageAfterToolRun(
+                    toolRun,
+                    ac.signal,
+                  );
                 }
               }
             } catch (error) {
@@ -2882,13 +2897,10 @@ export class Session implements SessionContext {
                 await this.#emitBackgroundNotificationEndTurn('end_turn');
                 return;
               }
-              nextMessage = {
-                role: 'user',
-                parts: [
-                  ...toolRun.parts,
-                  ...(await this.#drainMidTurnUserMessages(ac.signal)),
-                ],
-              };
+              nextMessage = await this.#buildNextMessageAfterToolRun(
+                toolRun,
+                ac.signal,
+              );
             }
           }
 
@@ -3246,12 +3258,38 @@ export class Session implements SessionContext {
     const handledProviderToolCallIds = new Set(
       this.#getCurrentChat().getHistoryFunctionResponseIds(),
     );
+    const repeatedDuplicateCall = findRepeatedDuplicateProviderToolCall(
+      dedupedFunctionCalls,
+      (fc) => getProviderToolCallId(fc) ?? fc.id,
+      handledProviderToolCallIds,
+      this.duplicateProviderToolCallResponseIds,
+    );
+    if (repeatedDuplicateCall) {
+      const providerCallId =
+        getProviderToolCallId(repeatedDuplicateCall) ??
+        repeatedDuplicateCall.id;
+      debugLogger.debug(
+        `[Session.runToolCalls] Dropping batch after repeated duplicate provider tool-call id: ` +
+          `${providerCallId} (tool: ${repeatedDuplicateCall.name ?? 'unknown_tool'})`,
+      );
+      return {
+        parts: [],
+        stopAfterPermissionCancel: false,
+        repeatedDuplicateProviderToolCall: true,
+      };
+    }
 
     const pushDuplicateBatch = (request: ToolCallRequestInfo): void => {
+      const providerCallId = request.providerCallId ?? request.callId;
+      markDuplicateProviderToolCallResponseSent(
+        providerCallId,
+        this.duplicateProviderToolCallResponseIds,
+      );
+
       const response = createDuplicateProviderToolCallResponse(request);
       debugLogger.debug(
         `[Session.runToolCalls] Suppressing duplicate provider tool-call id: ` +
-          `${request.providerCallId} (tool: ${request.name})`,
+          `${providerCallId} (tool: ${request.name})`,
       );
       batches.push({ kind: 'duplicate', request, response });
     };
@@ -3457,7 +3495,11 @@ export class Session implements SessionContext {
         }
         if (shouldStop) {
           await appendSkippedAfter(parts, batch.calls[batch.calls.length - 1]);
-          return { parts, stopAfterPermissionCancel: true };
+          return {
+            parts,
+            stopAfterPermissionCancel: true,
+            repeatedDuplicateProviderToolCall: false,
+          };
         }
       } else {
         for (const fc of batch.calls) {
@@ -3465,12 +3507,20 @@ export class Session implements SessionContext {
           parts.push(...r.parts);
           if (r.stopAfterPermissionCancel) {
             await appendSkippedAfter(parts, fc);
-            return { parts, stopAfterPermissionCancel: true };
+            return {
+              parts,
+              stopAfterPermissionCancel: true,
+              repeatedDuplicateProviderToolCall: false,
+            };
           }
         }
       }
     }
-    return { parts, stopAfterPermissionCancel: false };
+    return {
+      parts,
+      stopAfterPermissionCancel: false,
+      repeatedDuplicateProviderToolCall: false,
+    };
   }
 
   /**

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -477,7 +477,7 @@ describe('runNonInteractive', () => {
       toolCallEvent,
       {
         type: GeminiEventType.LoopDetected,
-        value: { loopType: LoopType.GLOBAL_TOOL_CALL_DUPLICATE },
+        value: { loopType: LoopType.REPETITIVE_THOUGHTS },
       },
     ];
     mockGeminiClient.sendMessageStream.mockReturnValue(
@@ -665,6 +665,159 @@ describe('runNonInteractive', () => {
       'Duplicate provider tool call id "tool-1"',
     );
     expect(processStdoutSpy).toHaveBeenCalledWith('Final answer\n');
+  });
+
+  it('should stop repeated duplicate provider tool-call responses', async () => {
+    setupMetricsMock();
+    vi.mocked(mockConfig.getMaxToolCalls).mockReturnValue(1);
+    const toolCallEvent: ServerGeminiStreamEvent = {
+      type: GeminiEventType.ToolCallRequest,
+      value: {
+        callId: 'tool-1',
+        providerCallId: 'tool-1',
+        name: 'testTool',
+        args: { arg1: 'value1' },
+        isClientInitiated: false,
+        prompt_id: 'prompt-id-dup-loop',
+      },
+    };
+    const freshToolCallEvent: ServerGeminiStreamEvent = {
+      type: GeminiEventType.ToolCallRequest,
+      value: {
+        callId: 'tool-2',
+        providerCallId: 'tool-2',
+        name: 'testTool',
+        args: { arg1: 'value2' },
+        isClientInitiated: false,
+        prompt_id: 'prompt-id-dup-loop',
+      },
+    };
+    mockCoreExecuteToolCall.mockResolvedValue({
+      responseParts: [{ text: 'Tool response' }],
+    });
+
+    mockGeminiClient.sendMessageStream
+      .mockReturnValueOnce(createStreamFromEvents([toolCallEvent]))
+      .mockReturnValueOnce(createStreamFromEvents([toolCallEvent]))
+      .mockReturnValueOnce(
+        createStreamFromEvents([toolCallEvent, freshToolCallEvent]),
+      );
+
+    const exitCode = await runNonInteractive(
+      mockConfig,
+      mockSettings,
+      'Use a tool',
+      'prompt-id-dup-loop',
+    );
+
+    expect(exitCode).toBe(1);
+    expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(3);
+    expect(mockCoreExecuteToolCall).toHaveBeenCalledTimes(1);
+    expect(mockGeminiClient.recordCompletedToolCall).toHaveBeenCalledTimes(1);
+
+    const duplicateParts = mockGeminiClient.sendMessageStream.mock.calls[2][0];
+    expect(duplicateParts[0].functionResponse?.response?.['error']).toContain(
+      'Duplicate provider tool call id "tool-1"',
+    );
+    expect(processStderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining(LoopType.GLOBAL_TOOL_CALL_DUPLICATE),
+    );
+    expect(processStderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'always-on guard and cannot be disabled via `model.skipLoopDetection`',
+      ),
+    );
+    expect(processStderrSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Set the `model.skipLoopDetection` setting to true',
+      ),
+    );
+  });
+
+  it('should stop repeated duplicate provider tool-call responses from drain items', async () => {
+    setupMetricsMock();
+    mockGeminiClient.getHistoryFunctionResponseIds.mockReturnValue(
+      new Set(['tool-drain']),
+    );
+
+    const notificationXml =
+      '<task-notification>\n' +
+      '<task-id>mon_1</task-id>\n' +
+      '<kind>monitor</kind>\n' +
+      '<status>running</status>\n' +
+      '<summary>Monitor emitted event #1.</summary>\n' +
+      '<result>ready</result>\n' +
+      '</task-notification>';
+    mockMonitorRegistry.setNotificationCallback.mockImplementation((cb) => {
+      if (!cb) return;
+      cb('Monitor "logs" event #1: ready', notificationXml, {
+        monitorId: 'mon_1',
+        toolUseId: 'tool_mon_1',
+        status: 'running',
+        eventCount: 1,
+      });
+    });
+
+    const duplicateToolCallEvent: ServerGeminiStreamEvent = {
+      type: GeminiEventType.ToolCallRequest,
+      value: {
+        callId: 'tool-drain__qwen_dup_2',
+        providerCallId: 'tool-drain',
+        name: 'testTool',
+        args: { arg1: 'value1' },
+        isClientInitiated: false,
+        prompt_id: 'prompt-id-drain-dup-loop',
+      },
+    };
+    const freshToolCallEvent: ServerGeminiStreamEvent = {
+      type: GeminiEventType.ToolCallRequest,
+      value: {
+        callId: 'tool-fresh',
+        providerCallId: 'tool-fresh',
+        name: 'testTool',
+        args: { arg1: 'value2' },
+        isClientInitiated: false,
+        prompt_id: 'prompt-id-drain-dup-loop',
+      },
+    };
+
+    mockGeminiClient.sendMessageStream
+      .mockReturnValueOnce(
+        createStreamFromEvents([
+          { type: GeminiEventType.Content, value: 'Monitor launched.' },
+          {
+            type: GeminiEventType.Finished,
+            value: {
+              reason: undefined,
+              usageMetadata: { totalTokenCount: 2 },
+            },
+          },
+        ]),
+      )
+      .mockReturnValueOnce(createStreamFromEvents([duplicateToolCallEvent]))
+      .mockReturnValueOnce(
+        createStreamFromEvents([duplicateToolCallEvent, freshToolCallEvent]),
+      );
+
+    const exitCode = await runNonInteractive(
+      mockConfig,
+      mockSettings,
+      'Watch the logs',
+      'prompt-id-drain-dup-loop',
+    );
+
+    expect(exitCode).toBe(1);
+    expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(3);
+    expect(mockCoreExecuteToolCall).not.toHaveBeenCalled();
+
+    const duplicateParts = mockGeminiClient.sendMessageStream.mock
+      .calls[2][0] as Part[];
+    expect(duplicateParts[0].functionResponse?.response?.['error']).toContain(
+      'Duplicate provider tool call id "tool-drain"',
+    );
+    expect(processStderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining(LoopType.GLOBAL_TOOL_CALL_DUPLICATE),
+    );
   });
 
   it('should ignore duplicate provider tool-call ids already present in chat history', async () => {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -31,6 +31,8 @@ import {
   ApprovalMode,
   ToolConfirmationOutcome,
   createDuplicateProviderToolCallResponse,
+  markDuplicateProviderToolCallResponseSent,
+  findRepeatedDuplicateProviderToolCall,
 } from '@qwen-code/qwen-code-core';
 import type { Content, Part, PartListUnion } from '@google/genai';
 import type { CLIUserMessage, PermissionMode } from './nonInteractive/types.js';
@@ -126,7 +128,8 @@ function formatLoopDetectedMessage(loopType: LoopType | undefined): string {
   // it for those always-on loop types.
   const isAlwaysOn =
     loopType === LoopType.TURN_TOOL_CALL_CAP ||
-    loopType === LoopType.CONSECUTIVE_IDENTICAL_TOOL_CALLS;
+    loopType === LoopType.CONSECUTIVE_IDENTICAL_TOOL_CALLS ||
+    loopType === LoopType.GLOBAL_TOOL_CALL_DUPLICATE;
   const hint = isAlwaysOn
     ? ' This is an always-on guard and cannot be disabled via `model.skipLoopDetection`.'
     : ' Set the `model.skipLoopDetection` setting to true to disable.';
@@ -796,15 +799,29 @@ export async function runNonInteractive(
        */
       const handledProviderToolCallIds =
         geminiClient.getHistoryFunctionResponseIds();
+      // Tracks duplicate-error responses emitted during this headless run.
+      // Once a provider id reaches this set, seeing it again is terminal for
+      // the current tool batch so we do not send partial tool responses.
+      const duplicateProviderToolCallResponseIds = new Set<string>();
+
+      type ToolCallBatchResult = {
+        responseParts: Part[];
+        repeatedDuplicateProviderToolCall: boolean;
+      };
 
       const processToolCallBatch = async (
         batchRequests: ToolCallRequestInfo[],
         setModelOverride: (override: string | undefined) => void,
-      ): Promise<Part[]> => {
+      ): Promise<ToolCallBatchResult> => {
         const toolResponseParts: Part[] = [];
         const structuredOutputActive =
           config.getJsonSchema() &&
           batchRequests.some((r) => r.name === ToolNames.STRUCTURED_OUTPUT);
+        const getProviderResponseId = (
+          request: ToolCallRequestInfo,
+        ): string | undefined =>
+          request.providerCallId ??
+          (structuredOutputActive ? undefined : request.callId || undefined);
         const seenBatchCallIds = new Set<string>();
         const duplicateBatchRequests: ToolCallRequestInfo[] = [];
         const uniqueBatchRequests = batchRequests.filter((request) => {
@@ -826,26 +843,51 @@ export async function runNonInteractive(
           }
           return true;
         });
+        const repeatedDuplicateRequest = findRepeatedDuplicateProviderToolCall(
+          [...uniqueBatchRequests, ...duplicateBatchRequests],
+          getProviderResponseId,
+          handledProviderToolCallIds,
+          duplicateProviderToolCallResponseIds,
+        );
+        if (repeatedDuplicateRequest) {
+          const providerCallId =
+            repeatedDuplicateRequest.providerCallId ??
+            repeatedDuplicateRequest.callId;
+          debugLogger.debug(
+            `[runNonInteractive] Dropping batch after repeated duplicate provider tool-call id: ${providerCallId} (tool: ${repeatedDuplicateRequest.name})`,
+          );
+          return {
+            responseParts: [],
+            repeatedDuplicateProviderToolCall: true,
+          };
+        }
+
         const respondedRequests = new Set<ToolCallRequestInfo>();
         const executableBatchRequests: ToolCallRequestInfo[] = [];
         const duplicatePendingResponses: Part[] = [];
 
         for (const requestInfo of uniqueBatchRequests) {
-          if (!requestInfo.providerCallId) {
+          const providerCallId = getProviderResponseId(requestInfo);
+          if (!providerCallId) {
             executableBatchRequests.push(requestInfo);
             continue;
           }
 
-          if (!handledProviderToolCallIds.has(requestInfo.providerCallId)) {
-            handledProviderToolCallIds.add(requestInfo.providerCallId);
+          if (!handledProviderToolCallIds.has(providerCallId)) {
+            handledProviderToolCallIds.add(providerCallId);
             executableBatchRequests.push(requestInfo);
             continue;
           }
+
+          markDuplicateProviderToolCallResponseSent(
+            providerCallId,
+            duplicateProviderToolCallResponseIds,
+          );
 
           const toolResponse =
             createDuplicateProviderToolCallResponse(requestInfo);
           debugLogger.debug(
-            `[runNonInteractive] Suppressing duplicate provider tool-call id: ${requestInfo.providerCallId} (tool: ${requestInfo.name})`,
+            `[runNonInteractive] Suppressing duplicate provider tool-call id: ${providerCallId} (tool: ${requestInfo.name})`,
           );
           respondedRequests.add(requestInfo);
           adapter.emitToolResult(requestInfo, toolResponse);
@@ -1028,13 +1070,23 @@ export async function runNonInteractive(
         }
 
         for (const requestInfo of duplicateBatchRequests) {
+          const providerCallId = getProviderResponseId(requestInfo);
+          if (!providerCallId) continue;
+          markDuplicateProviderToolCallResponseSent(
+            providerCallId,
+            duplicateProviderToolCallResponseIds,
+          );
+
           const toolResponse =
             createDuplicateProviderToolCallResponse(requestInfo);
           adapter.emitToolResult(requestInfo, toolResponse);
           toolResponseParts.push(...toolResponse.responseParts);
         }
 
-        return toolResponseParts;
+        return {
+          responseParts: toolResponseParts,
+          repeatedDuplicateProviderToolCall: false,
+        };
       };
 
       while (true) {
@@ -1175,12 +1227,12 @@ export async function runNonInteractive(
           // `modelOverride` so the next turn's sendMessageStream sees
           // it; the drain turn updates a per-item `itemModelOverride`
           // scoped to that drain item.
-          const toolResponseParts = await processToolCallBatch(
-            toolCallRequests,
-            (override) => {
-              modelOverride = override;
-            },
-          );
+          const {
+            responseParts: toolResponseParts,
+            repeatedDuplicateProviderToolCall,
+          } = await processToolCallBatch(toolCallRequests, (override) => {
+            modelOverride = override;
+          });
 
           if (structuredSubmission !== undefined) {
             // Single-shot terminal contract; aborts in-flight background
@@ -1189,6 +1241,16 @@ export async function runNonInteractive(
             // structured success envelope. Same helper as the drain-turn
             // post-loop branch — see emitStructuredSuccess above.
             return emitStructuredSuccess();
+          }
+          if (
+            repeatedDuplicateProviderToolCall &&
+            toolResponseParts.length === 0
+          ) {
+            loopDetectedMessage = emitLoopDetectedMessage(
+              config,
+              LoopType.GLOBAL_TOOL_CALL_DUPLICATE,
+            );
+            return emitLoopDetectedResult();
           }
           currentMessages = [{ role: 'user', parts: toolResponseParts }];
           hasUnsentToolResponse = true;
@@ -1401,7 +1463,10 @@ export async function runNonInteractive(
                 // sendMessageStream picks up the per-item override),
                 // while the main loop binds to the session-scoped
                 // `modelOverride`.
-                const itemToolResponseParts = await processToolCallBatch(
+                const {
+                  responseParts: itemToolResponseParts,
+                  repeatedDuplicateProviderToolCall,
+                } = await processToolCallBatch(
                   itemToolCallRequests,
                   (override) => {
                     itemModelOverride = override;
@@ -1411,6 +1476,17 @@ export async function runNonInteractive(
                 if (structuredSubmission !== undefined) {
                   // Stop processing further turns for this drain item;
                   // the post-drain code will emit the terminal result.
+                  return;
+                }
+                if (
+                  repeatedDuplicateProviderToolCall &&
+                  itemToolResponseParts.length === 0
+                ) {
+                  loopDetectedMessage = emitLoopDetectedMessage(
+                    config,
+                    LoopType.GLOBAL_TOOL_CALL_DUPLICATE,
+                  );
+                  loopDetected = true;
                   return;
                 }
                 itemMessages = [{ role: 'user', parts: itemToolResponseParts }];

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -2592,6 +2592,80 @@ describe('useGeminiStream', () => {
     expect(client.recordCompletedToolCall).not.toHaveBeenCalled();
   });
 
+  it('drops repeated history-paired duplicate provider ids after the first synthetic response', async () => {
+    const client = new MockedGeminiClientClass(mockConfig);
+    client.getHistoryFunctionResponseIds = vi
+      .fn()
+      .mockReturnValue(new Set(['tool-history']));
+
+    mockSendMessageStream
+      .mockReturnValueOnce(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.ToolCallRequest,
+            value: {
+              callId: 'tool-history',
+              providerCallId: 'tool-history',
+              name: 'shell',
+              args: { command: 'echo duplicate' },
+              isClientInitiated: false,
+              prompt_id: 'prompt-tui-history-loop',
+            },
+          };
+        })(),
+      )
+      .mockReturnValueOnce(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.ToolCallRequest,
+            value: {
+              callId: 'tool-history',
+              providerCallId: 'tool-history',
+              name: 'shell',
+              args: { command: 'echo duplicate again' },
+              isClientInitiated: false,
+              prompt_id: 'prompt-tui-history-loop',
+            },
+          };
+          yield {
+            type: ServerGeminiEventType.ToolCallRequest,
+            value: {
+              callId: 'tool-fresh',
+              providerCallId: 'tool-fresh',
+              name: 'shell',
+              args: { command: 'echo fresh' },
+              isClientInitiated: false,
+              prompt_id: 'prompt-tui-history-loop',
+            },
+          };
+          yield {
+            type: ServerGeminiEventType.Finished,
+            value: { reason: undefined, usageMetadata: { totalTokenCount: 1 } },
+          };
+        })(),
+      );
+
+    const { result } = renderTestHook([], client);
+
+    await act(async () => {
+      await result.current.submitQuery('run shell');
+    });
+
+    await waitFor(() => {
+      expect(result.current.streamingState).toBe(StreamingState.Idle);
+    });
+
+    expect(mockScheduleToolCalls).not.toHaveBeenCalled();
+    expect(mockSendMessageStream).toHaveBeenCalledTimes(2);
+    const toolResultParts = mockSendMessageStream.mock.calls[1][0] as Part[];
+    expect(toolResultParts).toHaveLength(1);
+    expect(toolResultParts[0].functionResponse?.id).toBe('tool-history');
+    expect(toolResultParts[0].functionResponse?.response?.['error']).toContain(
+      'Duplicate provider tool call id "tool-history"',
+    );
+    expect(client.recordCompletedToolCall).not.toHaveBeenCalled();
+  });
+
   it('does not deduplicate tool calls without provider ids in the TUI stream', async () => {
     mockSendMessageStream.mockReturnValueOnce(
       (async function* () {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -60,6 +60,8 @@ import {
   setActiveGoal,
   clearActiveGoal,
   createDuplicateProviderToolCallResponse,
+  markDuplicateProviderToolCallResponseSent,
+  findRepeatedDuplicateProviderToolCall,
 } from '@qwen-code/qwen-code-core';
 import { type Part, type PartListUnion, FinishReason } from '@google/genai';
 import type {
@@ -513,6 +515,11 @@ export const useGeminiStream = (
   const submitPromptOnCompleteRef = useRef<(() => Promise<void>) | null>(null);
   const modelOverrideRef = useRef<string | undefined>(undefined);
   const handledProviderToolCallIdsRef = useRef<Set<string>>(new Set());
+  // Scoped to a top-level submit and cleared below before a new user prompt.
+  // Repeated duplicate provider ids within that submit are terminal/drop-only.
+  const duplicateProviderToolCallResponseIdsRef = useRef<Set<string>>(
+    new Set(),
+  );
   const pendingDuplicateToolResponsesRef = useRef<
     PendingDuplicateToolResponses[]
   >([]);
@@ -1994,6 +2001,23 @@ export const useGeminiStream = (
         const historyCallIdsWithResponse: Set<string> = geminiClient
           ? geminiClient.getHistoryFunctionResponseIds()
           : new Set<string>();
+        const handledProviderIds = new Set([
+          ...handledProviderToolCallIdsRef.current,
+          ...historyCallIdsWithResponse,
+        ]);
+        const repeatedDuplicateRequest = findRepeatedDuplicateProviderToolCall(
+          toolCallRequests,
+          (request) => request.providerCallId,
+          handledProviderIds,
+          duplicateProviderToolCallResponseIdsRef.current,
+        );
+        if (repeatedDuplicateRequest?.providerCallId) {
+          debugLogger.debug(
+            `[processGeminiStreamEvents] Dropping batch after repeated duplicate provider tool-call id: ${repeatedDuplicateRequest.providerCallId} (tool: ${repeatedDuplicateRequest.name})`,
+          );
+          loopDetectedRef.current = true;
+          return StreamProcessingStatus.Completed;
+        }
 
         for (const request of toolCallRequests) {
           const providerCallId = request.providerCallId;
@@ -2006,6 +2030,11 @@ export const useGeminiStream = (
             handledProviderToolCallIdsRef.current.has(providerCallId) ||
             historyCallIdsWithResponse.has(providerCallId)
           ) {
+            markDuplicateProviderToolCallResponseSent(
+              providerCallId,
+              duplicateProviderToolCallResponseIdsRef.current,
+            );
+
             const response = createDuplicateProviderToolCallResponse(request);
             debugLogger.debug(
               `[processGeminiStreamEvents] Suppressing duplicate provider tool-call id: ${providerCallId} (tool: ${request.name})`,
@@ -2133,6 +2162,7 @@ export const useGeminiStream = (
         lastTurnUserItemRef.current = null;
         turnSawContentEventRef.current = false;
         handledProviderToolCallIdsRef.current.clear();
+        duplicateProviderToolCallResponseIdsRef.current.clear();
         pendingDuplicateToolResponsesRef.current = [];
         immediateDuplicateToolResponsesRef.current = null;
       }

--- a/packages/core/src/agents/runtime/agent-core.ts
+++ b/packages/core/src/agents/runtime/agent-core.ts
@@ -30,6 +30,8 @@ import {
 } from './agent-context.js';
 import {
   createDuplicateProviderToolCallResponse,
+  findRepeatedDuplicateProviderToolCall,
+  markDuplicateProviderToolCallResponseSent,
   type ToolCallRequestInfo,
 } from '../../core/turn.js';
 import {
@@ -662,6 +664,9 @@ export class AgentCore {
     let finalText = '';
     let terminateMode: AgentTerminateMode | null = null;
     const handledProviderToolCallIds = chat.getHistoryFunctionResponseIds();
+    // Scoped to this reasoning loop. A second duplicate response for the same
+    // provider id would keep deterministic providers in a tool-result loop.
+    const duplicateProviderToolCallResponseIds = new Set<string>();
     let stickyMaxOutputTokens: number | undefined;
 
     while (true) {
@@ -822,7 +827,7 @@ export class AgentCore {
         }
 
         if (functionCalls.length > 0) {
-          currentMessages = await this.processFunctionCalls(
+          const toolCallResult = await this.processFunctionCalls(
             functionCalls,
             roundAbortController,
             promptId,
@@ -831,7 +836,13 @@ export class AgentCore {
             currentResponseId,
             wasOutputTruncated,
             handledProviderToolCallIds,
+            duplicateProviderToolCallResponseIds,
           );
+          if (toolCallResult.repeatedDuplicateProviderToolCall) {
+            terminateMode = AgentTerminateMode.LOOP_DETECTED;
+            break;
+          }
+          currentMessages = toolCallResult.messages;
 
           const externalInputs = this.drainExternalInputs(options);
           if (externalInputs.length > 0) {
@@ -847,6 +858,10 @@ export class AgentCore {
             // user-role record. The framing prefix is stripped — the prefix
             // is a model-facing detail, not part of the original message.
             this.emitExternalInputEvents(externalInputs);
+          }
+          if ((currentMessages[0]?.parts?.length ?? 0) === 0) {
+            terminateMode = AgentTerminateMode.ERROR;
+            break;
           }
         } else {
           const immediateExternalInputs = this.drainExternalInputs(options);
@@ -1149,12 +1164,36 @@ export class AgentCore {
     responseId?: string,
     wasOutputTruncated = false,
     handledProviderToolCallIds = new Set<string>(),
-  ): Promise<Content[]> {
+    duplicateProviderToolCallResponseIds = new Set<string>(),
+  ): Promise<{
+    messages: Content[];
+    repeatedDuplicateProviderToolCall: boolean;
+  }> {
     const toolResponseParts: Part[] = [];
     const uniqueFunctionCalls = dedupeToolCallsById(functionCalls);
 
     // Build allowed tool names set for filtering
     const allowedToolNames = new Set(toolsList.map((t) => t.name));
+    const repeatedDuplicateCall = findRepeatedDuplicateProviderToolCall(
+      uniqueFunctionCalls,
+      (fc) => getProviderToolCallId(fc) ?? fc.id,
+      handledProviderToolCallIds,
+      duplicateProviderToolCallResponseIds,
+    );
+    if (repeatedDuplicateCall) {
+      const providerCallId =
+        getProviderToolCallId(repeatedDuplicateCall) ??
+        repeatedDuplicateCall.id;
+      this.runtimeContext
+        .getDebugLogger()
+        ?.debug(
+          `[processFunctionCalls] Dropping batch after repeated duplicate provider tool-call id: ${providerCallId} (tool: ${String(repeatedDuplicateCall.name)}, round: ${currentRound})`,
+        );
+      return {
+        messages: [{ role: 'user', parts: [] }],
+        repeatedDuplicateProviderToolCall: true,
+      };
+    }
 
     // Filter unauthorized tool calls before scheduling
     const authorizedCalls: FunctionCall[] = [];
@@ -1191,6 +1230,11 @@ export class AgentCore {
 
       if (providerCallId) {
         if (handledProviderToolCallIds.has(providerCallId)) {
+          markDuplicateProviderToolCallResponseSent(
+            providerCallId,
+            duplicateProviderToolCallResponseIds,
+          );
+
           const request: ToolCallRequestInfo = {
             callId,
             providerCallId,
@@ -1523,7 +1567,10 @@ export class AgentCore {
       });
     }
 
-    return [{ role: 'user', parts: toolResponseParts }];
+    return {
+      messages: [{ role: 'user', parts: toolResponseParts }],
+      repeatedDuplicateProviderToolCall: false,
+    };
   }
 
   // ─── Observable state accessors ────────────────────────────

--- a/packages/core/src/agents/runtime/agent-headless.test.ts
+++ b/packages/core/src/agents/runtime/agent-headless.test.ts
@@ -1147,6 +1147,115 @@ describe('subagent.ts', () => {
         expect(scope.getTerminateMode()).toBe(AgentTerminateMode.GOAL);
       });
 
+      it('should stop repeated duplicate provider tool-call responses', async () => {
+        const listFilesToolDef: FunctionDeclaration = {
+          name: 'list_files',
+          description: 'Lists files',
+          parameters: { type: Type.OBJECT, properties: {} },
+        };
+
+        const { config } = await createMockConfig({
+          getFunctionDeclarationsFiltered: vi
+            .fn()
+            .mockReturnValue([listFilesToolDef]),
+          getTool: vi.fn().mockReturnValue(undefined),
+        });
+        const toolConfig: ToolConfig = { tools: ['list_files'] };
+        const [duplicateNormalizedPart] = normalizeModelToolCallIds(
+          [
+            {
+              functionCall: {
+                id: 'call_1',
+                name: 'list_files',
+                args: { path: '.' },
+              },
+            },
+          ],
+          new Set(['call_1']),
+          new Set<string>(),
+        );
+
+        mockSendMessageStream.mockImplementation(
+          createMockStream([
+            [
+              {
+                id: 'call_1',
+                name: 'list_files',
+                args: { path: '.' },
+              },
+            ],
+            [duplicateNormalizedPart!.functionCall!],
+            [
+              duplicateNormalizedPart!.functionCall!,
+              {
+                id: 'call_2',
+                name: 'list_files',
+                args: { path: './fresh' },
+              },
+            ],
+          ]),
+        );
+
+        const listFilesInvocation = {
+          params: { path: '.' },
+          getDescription: vi.fn().mockReturnValue('List files'),
+          toolLocations: vi.fn().mockReturnValue([]),
+          getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+          execute: vi.fn().mockResolvedValue({
+            llmContent: 'file1.txt\nfile2.ts',
+            returnDisplay: 'Listed 2 files',
+          }),
+        };
+        const listFilesTool = {
+          name: 'list_files',
+          displayName: 'List Files',
+          description: 'List files in directory',
+          kind: 'READ' as const,
+          schema: listFilesToolDef,
+          build: vi.fn().mockImplementation(() => listFilesInvocation),
+          canUpdateOutput: false,
+          isOutputMarkdown: true,
+        } as unknown as AnyDeclarativeTool;
+        vi.mocked(
+          (config.getToolRegistry() as unknown as ToolRegistry).getTool,
+        ).mockImplementation((name: string) =>
+          name === 'list_files' ? listFilesTool : undefined,
+        );
+
+        const toolResultEvents: AgentToolResultEvent[] = [];
+        const eventEmitter = new AgentEventEmitter();
+        eventEmitter.on(AgentEventType.TOOL_RESULT, (event: unknown) => {
+          toolResultEvents.push(event as AgentToolResultEvent);
+        });
+
+        const scope = await AgentHeadless.create(
+          'test-agent',
+          config,
+          promptConfig,
+          defaultModelConfig,
+          defaultRunConfig,
+          toolConfig,
+          eventEmitter,
+        );
+
+        await scope.execute(new ContextState());
+
+        expect(listFilesInvocation.execute).toHaveBeenCalledTimes(1);
+        expect(mockSendMessageStream).toHaveBeenCalledTimes(3);
+        expect(toolResultEvents).toHaveLength(2);
+        expect(toolResultEvents[1].error).toContain(
+          'Duplicate provider tool call id "call_1"',
+        );
+
+        const thirdCallArgs = mockSendMessageStream.mock.calls[2][1];
+        const parts = thirdCallArgs.message as Part[];
+        expect(parts[0].functionResponse?.id).toBe('call_1__qwen_dup_2');
+        expect(parts[0].functionResponse?.response?.['error']).toContain(
+          'Duplicate provider tool call id "call_1"',
+        );
+        expect(scope.getTerminateMode()).toBe(AgentTerminateMode.LOOP_DETECTED);
+      });
+
       it('should ignore duplicate provider tool-call ids already present in chat history', async () => {
         const listFilesToolDef: FunctionDeclaration = {
           name: 'list_files',

--- a/packages/core/src/agents/runtime/agent-interactive.ts
+++ b/packages/core/src/agents/runtime/agent-interactive.ts
@@ -481,6 +481,11 @@ function terminateModeMessage(
       return { text: 'Agent stopped: time limit reached.', level: 'warning' };
     case AgentTerminateMode.ERROR:
       return { text: 'Agent stopped due to an error.', level: 'error' };
+    case AgentTerminateMode.LOOP_DETECTED:
+      return {
+        text: 'Agent stopped: duplicate tool-call loop detected.',
+        level: 'error',
+      };
     case AgentTerminateMode.CANCELLED:
     case AgentTerminateMode.SHUTDOWN:
       return null;

--- a/packages/core/src/agents/runtime/agent-types.ts
+++ b/packages/core/src/agents/runtime/agent-types.ts
@@ -107,6 +107,8 @@ export enum AgentTerminateMode {
   GOAL = 'GOAL',
   /** The agent's execution terminated because it exceeded the maximum number of turns. */
   MAX_TURNS = 'MAX_TURNS',
+  /** The agent's execution terminated after detecting a tool-call loop. */
+  LOOP_DETECTED = 'LOOP_DETECTED',
   /** The agent's execution was cancelled via an abort signal. */
   CANCELLED = 'CANCELLED',
   /** The agent was gracefully shut down (e.g., arena/team session ended). */

--- a/packages/core/src/core/turn.test.ts
+++ b/packages/core/src/core/turn.test.ts
@@ -9,7 +9,12 @@ import type {
   ServerGeminiToolCallRequestEvent,
   ServerGeminiErrorEvent,
 } from './turn.js';
-import { CompressionStatus, Turn, GeminiEventType } from './turn.js';
+import {
+  CompressionStatus,
+  Turn,
+  GeminiEventType,
+  findRepeatedDuplicateProviderToolCall,
+} from './turn.js';
 import type { GenerateContentResponse, Part, Content } from '@google/genai';
 import { reportError } from '../utils/errorReporting.js';
 import type { GeminiChat } from './geminiChat.js';
@@ -36,6 +41,54 @@ vi.mock('@google/genai', async (importOriginal) => {
 vi.mock('../utils/errorReporting', () => ({
   reportError: vi.fn(),
 }));
+
+describe('findRepeatedDuplicateProviderToolCall', () => {
+  const getProviderCallId = (item: { providerCallId?: string }) =>
+    item.providerCallId;
+
+  it('finds a handled provider id that already received a synthetic response', () => {
+    const items = [{ providerCallId: 'fresh' }, { providerCallId: 'handled' }];
+
+    expect(
+      findRepeatedDuplicateProviderToolCall(
+        items,
+        getProviderCallId,
+        new Set(['handled']),
+        new Set(['handled']),
+      ),
+    ).toBe(items[1]);
+  });
+
+  it('finds a handled provider id repeated within the same batch', () => {
+    const items = [
+      { providerCallId: 'handled' },
+      { providerCallId: 'fresh' },
+      { providerCallId: 'handled' },
+    ];
+
+    expect(
+      findRepeatedDuplicateProviderToolCall(
+        items,
+        getProviderCallId,
+        new Set(['handled']),
+        new Set<string>(),
+      ),
+    ).toBe(items[0]);
+  });
+
+  it('ignores unhandled repeated ids', () => {
+    const items = [{ providerCallId: 'fresh' }, { providerCallId: 'fresh' }];
+
+    expect(
+      findRepeatedDuplicateProviderToolCall(
+        items,
+        getProviderCallId,
+        new Set(['handled']),
+        new Set<string>(),
+      ),
+    ).toBeUndefined();
+  });
+});
 
 describe('Turn', () => {
   let turn: Turn;

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -149,6 +149,42 @@ export function createDuplicateProviderToolCallResponse(
   };
 }
 
+export function markDuplicateProviderToolCallResponseSent(
+  providerCallId: string,
+  duplicateProviderToolCallResponseIds: Set<string>,
+): void {
+  duplicateProviderToolCallResponseIds.add(providerCallId);
+}
+
+export function findRepeatedDuplicateProviderToolCall<T>(
+  items: readonly T[],
+  getProviderCallId: (item: T) => string | undefined,
+  handledProviderToolCallIds: ReadonlySet<string>,
+  duplicateProviderToolCallResponseIds: ReadonlySet<string>,
+): T | undefined {
+  const repeatedProviderIds = new Map<string, number>();
+  for (const item of items) {
+    const providerCallId = getProviderCallId(item);
+    if (!providerCallId || !handledProviderToolCallIds.has(providerCallId)) {
+      continue;
+    }
+    repeatedProviderIds.set(
+      providerCallId,
+      (repeatedProviderIds.get(providerCallId) ?? 0) + 1,
+    );
+  }
+
+  return items.find((item) => {
+    const providerCallId = getProviderCallId(item);
+    return (
+      providerCallId !== undefined &&
+      handledProviderToolCallIds.has(providerCallId) &&
+      (duplicateProviderToolCallResponseIds.has(providerCallId) ||
+        (repeatedProviderIds.get(providerCallId) ?? 0) > 1)
+    );
+  });
+}
+
 export interface ServerToolCallConfirmationDetails {
   request: ToolCallRequestInfo;
   details: ToolCallConfirmationDetails;


### PR DESCRIPTION
## What this PR does

Stops repeated duplicate provider tool-call responses from keeping Qwen Code in a tool-result loop. The first duplicate provider tool-call id still gets a synthetic duplicate-error function response so the provider's replayed tool call is paired. If the same provider id repeats again within the same prompt, the current batch is treated as terminal/drop-only before any fresh sibling tool call is executed or scheduled.

Applies the same guard to the non-interactive CLI, TUI stream handling, AgentCore, and ACP session tool execution paths. The repeated-duplicate detection is now shared through `findRepeatedDuplicateProviderToolCall`, so the four entry points use one consistent branch for both "already sent a synthetic duplicate response" and "same handled provider id appears more than once in one batch".

AgentCore now terminates this case with `AgentTerminateMode.LOOP_DETECTED` instead of a generic error. Interactive agent runs surface that as `Agent stopped: duplicate tool-call loop detected.`, making this loop class visible to users and callers instead of looking like an arbitrary failure.

This revision also clears ACP duplicate-response tracking at the start of each new user prompt. ACP sessions are long-lived, but the repeated-duplicate circuit breaker is a per-prompt guard; a provider id seen in prompt N should not poison prompt N+1.

## Why it's needed

Fixes a deterministic loop where an OpenAI-compatible provider can replay an already-completed tool-call id, receive another synthetic duplicate tool result, and then replay the same id again. On the current npm release this can lead to repeated tool-result submissions until a session/turn limit stops the run.

The fix keeps the existing duplicate suppression behavior for the first replay, but adds a circuit breaker for repeated duplicate responses so Qwen Code does not send partial or repeated tool responses back to the provider.

The explicit AgentCore termination mode is needed because otherwise the headless/interactive agent path stops correctly but reports the stop as a generic error. Review feedback called out that the user-facing path should identify the duplicate tool-call loop.

The ACP reset is needed because `Session` instances survive across prompts. Without clearing the duplicate-response Set per prompt, a legitimate same provider id in a later ACP prompt could be dropped immediately because an earlier prompt had already received a synthetic duplicate response for that id.

## Reviewer Test Plan

### How to verify

Run the focused duplicate-provider-id tests for the affected entry points. The regression cases cover repeated duplicate ids mixed with a fresh sibling tool call, the shared repeated-duplicate helper, AgentCore's visible loop termination mode, the TUI/non-interactive paths, and ACP prompt-to-prompt Set clearing.

Commands run locally after rebasing onto `upstream/main`:

```bash
cd packages/core
npx vitest run src/core/turn.test.ts src/agents/runtime/agent-headless.test.ts src/agents/runtime/agent-interactive.test.ts -t 'findRepeatedDuplicateProviderToolCall|duplicate provider|terminate|stopped'

cd ../cli
npx vitest run src/nonInteractiveCli.test.ts src/ui/hooks/useGeminiStream.test.tsx src/acp-integration/session/Session.test.ts -t 'duplicate provider'

cd ../..
npx prettier --check packages/cli/src/acp-integration/session/Session.ts packages/cli/src/acp-integration/session/Session.test.ts packages/cli/src/nonInteractiveCli.ts packages/cli/src/nonInteractiveCli.test.ts packages/cli/src/ui/hooks/useGeminiStream.ts packages/cli/src/ui/hooks/useGeminiStream.test.tsx packages/core/src/agents/runtime/agent-core.ts packages/core/src/agents/runtime/agent-headless.test.ts packages/core/src/agents/runtime/agent-interactive.ts packages/core/src/agents/runtime/agent-types.ts packages/core/src/core/turn.ts packages/core/src/core/turn.test.ts
npx eslint packages/cli/src/acp-integration/session/Session.ts packages/cli/src/acp-integration/session/Session.test.ts packages/cli/src/nonInteractiveCli.ts packages/cli/src/nonInteractiveCli.test.ts packages/cli/src/ui/hooks/useGeminiStream.ts packages/cli/src/ui/hooks/useGeminiStream.test.tsx packages/core/src/agents/runtime/agent-core.ts packages/core/src/agents/runtime/agent-headless.test.ts packages/core/src/agents/runtime/agent-interactive.ts packages/core/src/agents/runtime/agent-types.ts packages/core/src/core/turn.ts packages/core/src/core/turn.test.ts --max-warnings 0
git diff --check
npm run typecheck
npm run build
```

### Evidence (Before & After)

Before: a provider that replayed the same completed provider tool-call id could receive a synthetic duplicate tool result on every round, keeping Qwen Code in a duplicate tool-result loop.

Before, in ACP specifically: once a long-lived `Session` recorded that a provider id had already received a synthetic duplicate response, that Set was never cleared between user prompts.

Before, in AgentCore: the repeated duplicate guard stopped the run as a generic error, so users and callers could not distinguish this loop class from unrelated failures.

After: the first replay still gets a synthetic duplicate-error function response; the next replay of the same provider id in that prompt terminates/drops the batch before any fresh sibling tool response is sent. ACP clears this per-prompt guard before starting the next user prompt. AgentCore reports `LOOP_DETECTED`, and the interactive runner shows a duplicate-loop-specific stop message.

Local results:

- ✅ core focused tests: 2 files passed, 1 file skipped, 12 tests passed
- ✅ CLI focused tests: 3 files passed, 13 tests passed, including the drain-item repeated-duplicate path
- ✅ all PR touched-file Prettier checks passed
- ✅ all PR touched-file ESLint checks passed with `--max-warnings 0`
- ✅ `git diff --check` passed
- ✅ `npm run typecheck` passed
- ✅ `npm run build` passed
- ⚠️ Build still reports existing VS Code companion `curly` lint warnings plus existing Browserslist and chunk-size warnings; exit code was 0 and none are from touched files.
- ✅ Read-only sub-agent review found no blocking issues in the ACP clear placement, helper semantics, or regression test coverage.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS workspace, Node.js `v26.3.0`, focused Vitest suites plus repo-level typecheck/build.

## Risk & Scope

- Main risk or tradeoff: a malformed provider turn that repeats an already-answered provider id together with fresh sibling tool calls is now dropped as a batch, so the fresh sibling is not executed. This is intentional to avoid sending partial tool responses that could violate OpenAI-compatible tool-call pairing.
- AgentCore scope: duplicate-loop termination is now observable as `LOOP_DETECTED`; existing cancellation, shutdown, max-turn, and generic-error modes are unchanged.
- ACP scope: duplicate-response tracking is now prompt-scoped, matching the non-interactive, TUI, and AgentCore lifetimes. It still persists across multiple tool-call rounds within one prompt.
- Not validated / out of scope: full end-to-end replay against the external reproducer and broader loop-detection heuristics.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5641

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

阻止重复的 provider tool-call 响应让 Qwen Code 陷入 tool-result 循环。第一次重复的 provider tool-call id 仍会收到一个 synthetic duplicate-error function response，用来配对 provider 重放的 tool call。如果同一个 provider id 在同一个 prompt 内再次重复，当前 batch 会在执行或调度任何 fresh sibling tool call 之前被视为终止/仅丢弃。

这个保护覆盖 non-interactive CLI、TUI stream handling、AgentCore 和 ACP session tool execution 路径。repeated-duplicate 检测现在通过 `findRepeatedDuplicateProviderToolCall` 共享，因此四个入口对“已经发过 synthetic duplicate response”和“同批内同一个已处理 provider id 出现多次”使用同一套判断。

AgentCore 现在会用 `AgentTerminateMode.LOOP_DETECTED` 终止这种情况，而不是泛化成普通 error。interactive agent run 会展示 `Agent stopped: duplicate tool-call loop detected.`，让用户和调用方能明确看到这是 duplicate tool-call loop，而不是任意失败。

这一版也会在每个新的用户 prompt 开始时清理 ACP duplicate-response tracking。ACP session 是长生命周期对象，但 repeated-duplicate circuit breaker 是 per-prompt guard；prompt N 里见过的 provider id 不应该污染 prompt N+1。

## Why it's needed

修复一个确定性的循环：OpenAI-compatible provider 可以重放已经完成的 tool-call id，收到另一个 synthetic duplicate tool result，然后再次重放同一个 id。在当前 npm release 上，这可能导致重复提交 tool-result，直到 session/turn 限制中止运行。

这个修复保留第一次 replay 时已有的 duplicate suppression 行为，同时为 repeated duplicate response 增加断路器，避免 Qwen Code 再向 provider 发送 partial 或重复的 tool response。

显式的 AgentCore termination mode 是必要的，因为否则 headless/interactive agent 路径虽然会正确停止，但会把这个停止报告成普通 error。review feedback 已指出 user-facing 路径应该能识别 duplicate tool-call loop。

ACP reset 是必要的，因为 `Session` 实例会跨 prompt 存活。如果不按 prompt 清理 duplicate-response Set，后续 ACP prompt 里合法出现的相同 provider id 可能会因为早先 prompt 已经给该 id 发过 synthetic duplicate response 而被直接丢弃。

## Reviewer Test Plan

### How to verify

运行受影响入口的 focused duplicate-provider-id 测试。回归用例覆盖 repeated duplicate id 和 fresh sibling tool call 混在同一批、共享 repeated-duplicate helper、AgentCore 的 visible loop termination mode、TUI/non-interactive 路径，以及 ACP prompt 间 Set 清理。

在 rebase 到 `upstream/main` 后本地运行的命令：

```bash
cd packages/core
npx vitest run src/core/turn.test.ts src/agents/runtime/agent-headless.test.ts src/agents/runtime/agent-interactive.test.ts -t 'findRepeatedDuplicateProviderToolCall|duplicate provider|terminate|stopped'

cd ../cli
npx vitest run src/nonInteractiveCli.test.ts src/ui/hooks/useGeminiStream.test.tsx src/acp-integration/session/Session.test.ts -t 'duplicate provider'

cd ../..
npx prettier --check packages/cli/src/acp-integration/session/Session.ts packages/cli/src/acp-integration/session/Session.test.ts packages/cli/src/nonInteractiveCli.ts packages/cli/src/nonInteractiveCli.test.ts packages/cli/src/ui/hooks/useGeminiStream.ts packages/cli/src/ui/hooks/useGeminiStream.test.tsx packages/core/src/agents/runtime/agent-core.ts packages/core/src/agents/runtime/agent-headless.test.ts packages/core/src/agents/runtime/agent-interactive.ts packages/core/src/agents/runtime/agent-types.ts packages/core/src/core/turn.ts packages/core/src/core/turn.test.ts
npx eslint packages/cli/src/acp-integration/session/Session.ts packages/cli/src/acp-integration/session/Session.test.ts packages/cli/src/nonInteractiveCli.ts packages/cli/src/nonInteractiveCli.test.ts packages/cli/src/ui/hooks/useGeminiStream.ts packages/cli/src/ui/hooks/useGeminiStream.test.tsx packages/core/src/agents/runtime/agent-core.ts packages/core/src/agents/runtime/agent-headless.test.ts packages/core/src/agents/runtime/agent-interactive.ts packages/core/src/agents/runtime/agent-types.ts packages/core/src/core/turn.ts packages/core/src/core/turn.test.ts --max-warnings 0
git diff --check
npm run typecheck
npm run build
```

### Evidence (Before & After)

修复前：如果 provider 重放同一个已经完成的 provider tool-call id，每一轮都可能收到 synthetic duplicate tool result，让 Qwen Code 留在 duplicate tool-result 循环里。

修复前，在 ACP 路径里还有一个额外问题：长生命周期 `Session` 一旦记录某个 provider id 已经收到 synthetic duplicate response，这个 Set 在用户 prompt 之间不会清理。

修复前，在 AgentCore 路径里 repeated duplicate guard 会把运行作为普通 error 停止，因此用户和调用方无法把这个循环和其他失败区分开。

修复后：第一次 replay 仍会收到 synthetic duplicate-error function response；同一个 provider id 在该 prompt 内下一次 replay 会在发送任何 fresh sibling tool response 之前终止/丢弃当前 batch。ACP 会在下一个用户 prompt 开始前清理这个 per-prompt guard。AgentCore 会报告 `LOOP_DETECTED`，interactive runner 会显示 duplicate-loop-specific stop message。

本地结果：

- ✅ core focused tests：2 个文件通过，1 个文件 skipped，12 个测试通过
- ✅ CLI focused tests：3 个文件通过，13 个测试通过，包含 drain item repeated-duplicate 路径
- ✅ 所有 PR touched-file Prettier checks 通过
- ✅ 所有 PR touched-file ESLint checks 以 `--max-warnings 0` 通过
- ✅ `git diff --check` 通过
- ✅ `npm run typecheck` 通过
- ✅ `npm run build` 通过
- ⚠️ build 仍会报告既有 VS Code companion `curly` lint warnings，以及既有 Browserslist 和 chunk-size warnings；退出码为 0，且都不来自本 PR 修改文件
- ✅ 只读子代理复审没有发现 ACP clear 位置、helper 语义或回归测试覆盖方面的阻塞问题

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 macOS workspace，Node.js `v26.3.0`，运行 focused Vitest suites 以及 repo-level typecheck/build。

## Risk & Scope

- Main risk or tradeoff: 如果格式异常的 provider turn 同时包含已经回答过的重复 provider id 和 fresh sibling tool calls，现在会按 batch 丢弃，因此 fresh sibling 不会执行。这是有意为之，用来避免发送可能违反 OpenAI-compatible tool-call pairing 的 partial tool responses。
- AgentCore scope: duplicate-loop termination 现在可作为 `LOOP_DETECTED` 被观察到；现有 cancellation、shutdown、max-turn 和 generic-error modes 不变。
- ACP scope: duplicate-response tracking 现在是 prompt-scoped，与 non-interactive、TUI 和 AgentCore 的生命周期一致。它仍然会在同一个 prompt 的多轮 tool-call round 之间保留。
- Not validated / out of scope: 没有运行外部 reproducer 的完整端到端 replay；也不改更广泛的 loop-detection heuristics。
- Breaking changes / migration notes: 无。

## Linked Issues

Fixes #5641

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
