### PR TITLE
feat(cli): Show tool-use summaries in loading indicator instead of conversation

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -227,6 +227,7 @@ import {
 import { compactToggleHasVisualEffect } from './utils/mergeCompactToolGroups.js';
 import {
   findLastUserItemIndex,
+  getLatestToolUseSummary,
   isSyntheticHistoryItem,
   itemsAfterAreOnlySynthetic,
 } from './utils/historyUtils.js';
@@ -2945,6 +2946,22 @@ export const AppContainer = (props: AppContainerProps) => {
     streamingResponseLengthRef.current,
   );
 
+  // Surface the latest fast-model tool-use summary in the loading indicator
+  // instead of a generic witty phrase. Falls back to the phrase cycler when
+  // no summary is available (no fast-model configured, or a fresh user turn).
+  const latestToolUseSummary = useMemo(
+    () =>
+      getLatestToolUseSummary([
+        ...historyManager.history,
+        ...pendingHistoryItems,
+      ]),
+    [historyManager.history, pendingHistoryItems],
+  );
+  const loadingPhrase =
+    streamingState === StreamingState.Responding && latestToolUseSummary
+      ? latestToolUseSummary
+      : currentLoadingPhrase;
+
   useAttentionNotifications({
     isFocused,
     streamingState,
@@ -3509,7 +3526,7 @@ export const AppContainer = (props: AppContainerProps) => {
       showEscapePrompt,
       isFocused,
       elapsedTime,
-      currentLoadingPhrase,
+      currentLoadingPhrase: loadingPhrase,
       historyRemountKey,
       messageQueue,
       showAutoAcceptIndicator,
@@ -3645,7 +3662,7 @@ export const AppContainer = (props: AppContainerProps) => {
       showEscapePrompt,
       isFocused,
       elapsedTime,
-      currentLoadingPhrase,
+      loadingPhrase,
       historyRemountKey,
       messageQueue,
       showAutoAcceptIndicator,

--- a/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
@@ -75,7 +75,7 @@ describe('<HistoryItemDisplay />', () => {
     expect(output).toContain('✦ Hello');
   });
 
-  it('renders tool summaries without a leading spacer row', () => {
+  it('renders nothing for tool_use_summary (moved to loading indicator)', () => {
     const item: HistoryItem = {
       id: 1,
       type: 'tool_use_summary',
@@ -87,8 +87,8 @@ describe('<HistoryItemDisplay />', () => {
     );
 
     const output = lastFrame() ?? '';
-    expect(output.startsWith('\n')).toBe(false);
-    expect(output).toContain('Read txt files');
+    expect(output).not.toContain('Read txt files');
+    expect(output).not.toContain('●');
   });
 
   it('renders StatsDisplay for "stats" type', () => {
@@ -318,7 +318,7 @@ describe('<HistoryItemDisplay />', () => {
     expect(lastFrame()).toMatchSnapshot();
   });
 
-  it('renders tool_use_summary as a dim badge line in full mode', () => {
+  it('renders nothing for tool_use_summary in full mode (moved to loading indicator)', () => {
     const item: HistoryItem = {
       id: 1,
       type: 'tool_use_summary',
@@ -333,8 +333,9 @@ describe('<HistoryItemDisplay />', () => {
         terminalWidth={80}
       />,
     );
-    expect(lastFrame()).toContain('Read txt files');
-    expect(lastFrame()).toContain('●');
+    const output = lastFrame() ?? '';
+    expect(output).not.toContain('Read txt files');
+    expect(output).not.toContain('●');
   });
 
   it('renders committed thinking text in full transcript mode', () => {

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -132,7 +132,6 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
   embeddedShellFocused,
   availableTerminalHeightGemini,
   compactLabel,
-  summaryAbsorbed = false,
   sourceCopyIndexOffsets,
 }) => {
   const marginTop = getHistoryItemMarginTop(item);
@@ -278,30 +277,8 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
           compactLabel={compactLabel}
         />
       )}
-      {/*
-        `tool_use_summary` as a standalone inline item.
-
-        In full mode (`compactMode=false`), the label arrives via the fast-model
-        call AFTER the tool_group has been committed to Ink's append-only
-        <Static>, so we cannot update the tool_group's header retroactively.
-        Rendering a standalone `● <label>` line appends cleanly.
-
-        In compact mode, the label is normally absorbed into the merged
-        tool_group's header (via `compactLabel` prop to CompactToolGroupDisplay),
-        and `summaryAbsorbed=true` is set so this block does nothing. But when
-        the sibling tool_group is force-expanded (errors, confirmations,
-        user-initiated, focused shell), the full-expand path ignores
-        `compactLabel`, and `MainContent` leaves `summaryAbsorbed=false` —
-        the standalone line below is then the label's only route to the UI,
-        which is exactly the case where a summary is most diagnostically
-        useful ("Fixed NPE in UserService" on an errored batch).
-      */}
-      {itemForDisplay.type === 'tool_use_summary' &&
-        (!compactMode || !summaryAbsorbed) && (
-          <Box paddingLeft={1}>
-            <Text dimColor>● {itemForDisplay.summary}</Text>
-          </Box>
-        )}
+      {/* Tool-use summaries are now shown in the loading indicator instead
+          of as standalone lines in the conversation. See #5656. */}
       {itemForDisplay.type === 'compression' && (
         <CompressionMessage compression={itemForDisplay.compression} />
       )}

--- a/packages/cli/src/ui/components/MainContent.test.tsx
+++ b/packages/cli/src/ui/components/MainContent.test.tsx
@@ -692,9 +692,9 @@ describe('<MainContent />', () => {
       historyItemDisplayPropsSpy.mockClear();
 
       // History with a tool_group followed by its tool_use_summary, then another tool_group.
-      // When merge is skipped (Static mode), absorbedCallIds returns EMPTY_ABSORBED_CALL_IDS
-      // so isSummaryAbsorbed returns false — the summary MUST pass through as a standalone
-      // item and render as `● <label>` line in HistoryItemDisplay.
+      // The tool_use_summary item is still passed through to HistoryItemDisplay (it
+      // feeds the compact-mode label and the loading-indicator summary), but
+      // HistoryItemDisplay no longer renders a standalone `● <label>` line.
       const history = [
         {
           id: 1,

--- a/packages/cli/src/ui/utils/historyUtils.test.ts
+++ b/packages/cli/src/ui/utils/historyUtils.test.ts
@@ -9,6 +9,7 @@ import type { HistoryItem } from '../types.js';
 import { ToolCallStatus } from '../types.js';
 import {
   findLastUserItemIndex,
+  getLatestToolUseSummary,
   isSyntheticHistoryItem,
   itemsAfterAreOnlySynthetic,
 } from './historyUtils.js';
@@ -136,5 +137,51 @@ describe('findLastUserItemIndex', () => {
       mk({ type: 'info', text: 'Request cancelled.' }, 4),
     ];
     expect(findLastUserItemIndex(h)).toBe(2);
+  });
+});
+
+describe('getLatestToolUseSummary', () => {
+  const summary = (text: string, id: number): HistoryItem =>
+    mk({ type: 'tool_use_summary', summary: text } as never, id);
+
+  it('returns the summary when it is the last item', () => {
+    const h: HistoryItem[] = [
+      mk({ type: 'user', text: 'fix the bug' }, 1),
+      mk({ type: 'tool_group', tools: [] } as never, 2),
+      summary('Fixed NPE in UserService', 3),
+    ];
+    expect(getLatestToolUseSummary(h)).toBe('Fixed NPE in UserService');
+  });
+
+  it('returns the latest summary when multiple exist in one turn', () => {
+    const h: HistoryItem[] = [
+      mk({ type: 'user', text: 'refactor' }, 1),
+      summary('Searched in auth/', 2),
+      mk({ type: 'gemini_content', text: '...' }, 3),
+      summary('Fixed NPE in UserService', 4),
+    ];
+    expect(getLatestToolUseSummary(h)).toBe('Fixed NPE in UserService');
+  });
+
+  it('returns undefined when a user message follows (new turn)', () => {
+    const h: HistoryItem[] = [
+      mk({ type: 'user', text: 'first' }, 1),
+      summary('Searched in auth/', 2),
+      mk({ type: 'user', text: 'second' }, 3),
+      mk({ type: 'gemini_content', text: 'streaming...' }, 4),
+    ];
+    expect(getLatestToolUseSummary(h)).toBeUndefined();
+  });
+
+  it('returns undefined when no summary exists', () => {
+    const h: HistoryItem[] = [
+      mk({ type: 'user', text: 'hello' }, 1),
+      mk({ type: 'gemini_content', text: 'hi' }, 2),
+    ];
+    expect(getLatestToolUseSummary(h)).toBeUndefined();
+  });
+
+  it('returns undefined on empty history', () => {
+    expect(getLatestToolUseSummary([])).toBeUndefined();
   });
 });

--- a/packages/cli/src/ui/utils/historyUtils.ts
+++ b/packages/cli/src/ui/utils/historyUtils.ts
@@ -124,3 +124,26 @@ export function findLastUserItemIndex(history: readonly HistoryItem[]): number {
   }
   return -1;
 }
+
+/**
+ * Returns the summary text of the most recent `tool_use_summary` in the
+ * current turn (after the last user message), or `undefined` when none
+ * exists. Used by the loading indicator to show a contextual summary
+ * instead of a generic witty phrase when a fast-model summary is available.
+ */
+export function getLatestToolUseSummary(
+  history: ReadonlyArray<HistoryItem | HistoryItemWithoutId>,
+): string | undefined {
+  for (let i = history.length - 1; i >= 0; i--) {
+    const item = history[i];
+    if (item.type === 'tool_use_summary') {
+      return item.summary;
+    }
+    // A user message marks the start of a new turn — any summary before
+    // it belongs to a previous turn and is stale.
+    if (item.type === 'user') {
+      return undefined;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
## What this PR does

When a fast-model is configured, Qwen Code generates a short summary label after each tool call completes (e.g., "Searched in auth/", "Fixed NPE in UserService"). Previously, this summary appeared as a standalone `● <label>` line in the conversation history — a transient piece of information that persisted in the transcript without lasting value.

This PR moves the summary into the **loading indicator area** — the transient text zone where generic witty phrases (e.g., "Searching files...", "Analyzing code...") are displayed during model streaming. Now, when a summary is available, the loading indicator shows it instead of a random phrase, making the wait feel more transparent and informative. The standalone summary line is removed from the conversation history.

When no fast-model is configured (and thus no summary is available), the loading indicator falls back to the existing witty loading phrases — no behavior change.

The implementation is intentionally minimal:

- A new utility function searches backwards through the current turn's history items to find the latest tool-use summary (stopping at a user message so summaries from previous turns don't leak into a new conversation turn).
- In the app container, this summary overrides the loading phrase during the `Responding` streaming state. During `WaitingForConfirmation`, the existing "Waiting for user confirmation..." text is preserved.
- The standalone `● <label>` rendering block is removed from the history item display. The compact-mode collapsed header label is kept unchanged — it serves as the collapsed tool group's title, not a standalone summary display.

## Why it's needed

The loading indicator was underutilized. It showed generic, rotating phrases that didn't reflect what the model just did, while the fast-model summary — already being generated in parallel — provided exactly the contextual information that would make the wait more transparent. At the same time, the summary appearing as a separate line in the conversation history added noise without lasting value: it was a transient label (what the tool just accomplished), most useful in the moment while the user is waiting for the next response.

Combining the two solves both problems: the loading text becomes meaningful, and the conversation history stays clean. See #5656 for the original feature request.

## Reviewer Test Plan

### How to verify

1. Configure a fast-model: `/model --fast <model-id>` (or set `"fastModel"` in settings.json).
2. Ask the model to do something that involves tool calls (e.g., "search for all TypeScript files in this project").
3. While the model is streaming its response after the tool call completes, observe the loading indicator — it should show the tool-use summary (e.g., "Searched in src/") instead of a witty phrase.
4. Verify the conversation history no longer has a standalone `● <label>` line after the tool group.
5. In compact mode, verify the collapsed tool group header still shows the summary label (e.g., "Searched 3 files · 3 tools") — this is unchanged.
6. Remove the fast-model config and repeat — the loading indicator should fall back to witty phrases, and no summary line appears in the conversation.
7. Start a new conversation turn (send a new user message) — the loading indicator should show witty phrases, not a stale summary from the previous turn.

### Evidence (Before & After)

**Before:** The tool-use summary appears as a standalone `● <label>` line in the conversation history after each tool group, and the loading indicator shows generic witty phrases.

```
⠏ Searching files... (5s · ↓ 1,234 tokens · esc to cancel)
...
● Searched in auth/
```

**After:** The summary is shown in the loading indicator, and no standalone line appears in the conversation history.

```
⠏ Searched in auth/ (5s · ↓ 1,234 tokens · esc to cancel)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |   ⚠️    |
|  🐧 Linux  |   ⚠️    |

### Environment

`npm run dev` on macOS. Unit tests pass for all affected packages. Build and typecheck pass.

## Risk & Scope

- Main risk or tradeoff: In compact mode with force-expanded tool groups (errors, confirmations), the standalone summary line no longer appears in the conversation. The tool group itself (with its tool calls and results) is still visible, so the user can see what happened — only the one-line label is gone. The compact-mode collapsed header label is unaffected.
- Not validated / out of scope: Windows and Linux not manually tested (logic is platform-agnostic, unit tests cover the core behavior).
- Breaking changes / migration notes: None. The `summaryAbsorbed` prop on `HistoryItemDisplay` is retained in the interface for backward compatibility but no longer used internally.


<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

当配置了 fast-model 后，Qwen Code 会在每次工具调用结束后生成一个简短的摘要标签（如 "Searched in auth/"、"Fixed NPE in UserService"）。此前这个摘要作为独立的 `● <标签>` 行出现在对话历史中——一个持久留在转录中的瞬时信息，没有持久价值。

本 PR 将摘要移至 **loading 指示器区域**——也就是模型流式输出期间显示通用短语（如 "Searching files..."、"Analyzing code..."）的临时文本区。现在，当摘要可用时，loading 指示器会显示它而非随机短语，让等待过程更透明、更有信息量。对话历史中的独立摘要行被移除。

当未配置 fast-model（因此没有摘要）时，loading 指示器回退到现有的机智短语——行为不变。

实现刻意保持最小化：

- 新增一个工具函数，在当前轮次的历史条目中向后搜索最新的 tool-use summary（遇到 user 消息即停止，防止上一轮的摘要泄漏到新轮次）。
- 在 App 容器中，此摘要在 `Responding` 流式状态下覆盖 loading 短语。在 `WaitingForConfirmation` 状态下，保留现有的 "Waiting for user confirmation..." 文本。
- 从历史条目展示中移除独立的 `● <标签>` 渲染块。compact 模式下折叠工具组的标题标签保持不变——它是折叠组的标题，不是独立的摘要展示。

## 为什么需要

loading 指示器未被充分利用。它显示的通用短语不能反映模型刚刚做了什么，而 fast-model 摘要——已经在并行生成——恰好提供了能让等待更透明的上下文信息。同时，摘要作为独立行出现在对话历史中增加了噪音而无持久价值：它是一个瞬时标签（工具刚完成了什么），在用户等待下一条回复时最有用。

两者结合同时解决了两个问题：loading 文案变得有意义，对话历史保持干净。详见 #5656。

## 风险与范围

- 主要风险/取舍：在 compact 模式下展开的工具组（错误、确认），独立摘要行不再出现在对话中。工具组本身（含工具调用和结果）仍然可见，用户可以看到发生了什么——只少了一行标签。compact 模式折叠标题标签不受影响。
- 未验证/超出范围：Windows 和 Linux 未手动测试（逻辑与平台无关，单元测试覆盖核心行为）。
- 破坏性变更/迁移说明：无。`HistoryItemDisplay` 的 `summaryAbsorbed` prop 在接口中保留以向后兼容，但内部不再使用。


</details>
