### PR TITLE
ci(autofix): gate fast path on trusted label

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -124,7 +124,7 @@ jobs:
       REPO: '${{ github.repository }}'
       WORKDIR: '/tmp/autofix'
       BUG_LABEL: 'type/bug'
-      READY_FOR_AGENT_LABEL: 'status/ready-for-agent'
+      AUTOFIX_READY_LABEL: 'autofix/ready'
       AUTOFIX_ISSUE_EXCLUDES: 'no:assignee -linked:pr -label:autofix/skip -label:autofix/in-progress -label:status/need-information -label:status/need-retesting sort:created-desc'
       # Comments from these accounts (triage/followup bots and the autofix bot's
       # own qwen-code-dev-bot identity) do not count as human engagement when
@@ -188,12 +188,13 @@ jobs:
                 "${WORKDIR}/scan.json" > "${WORKDIR}/candidates.json"
             }
 
-            echo "🔍 Scanning for ready-for-agent bugs (newest first)..."
-            # ready-for-agent is an explicit triage signal, so tier-1 takes
-            # candidates directly and skips the unattended filter — no need to
-            # fetch comments here (tier-2 below still fetches them for its filter).
+            echo "🔍 Scanning for autofix-ready bugs (newest first)..."
+            # autofix/ready is the explicit fast-path signal for scheduled
+            # autofix. Unlike status/ready-for-agent, it is not applied by the
+            # LLM triage path, so untrusted issue text cannot promote itself
+            # into tier-1. Tier-2 below still handles ordinary unattended bugs.
             gh issue list --repo "${REPO}" \
-              --search "is:open is:issue label:${BUG_LABEL} label:${READY_FOR_AGENT_LABEL} ${AUTOFIX_ISSUE_EXCLUDES}" \
+              --search "is:open is:issue label:${BUG_LABEL} label:${AUTOFIX_READY_LABEL} ${AUTOFIX_ISSUE_EXCLUDES}" \
               --limit 30 --json number,title,body,labels,createdAt,url \
               > "${WORKDIR}/scan.json"
             jq -c '.[0:10]' \

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -52,7 +52,16 @@ jobs:
        (github.event_name == 'workflow_dispatch' &&
         github.event.inputs.tmux_pr != ''))
     # Same-repo guard: this job loads CI_BOT_PAT, so fork-triggered runs stay on hosted (ephemeral); only in-repo PR events use the persistent ECS runner.
-    runs-on: "${{ (vars.MAINTAINER_ECS_RUNNER_DISABLED != 'true' && github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('[\"self-hosted\", \"linux\", \"x64\", \"ecs-qwen\"]') || fromJSON('[\"ubuntu-latest\"]') }}"
+    runs-on: >-
+      ${{
+        (
+          vars.MAINTAINER_ECS_RUNNER_DISABLED != 'true' &&
+          github.event.pull_request &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        ) &&
+        fromJSON('["self-hosted", "linux", "x64", "ecs-qwen"]') ||
+        fromJSON('["ubuntu-latest"]')
+      }}
     timeout-minutes: 5
     permissions:
       contents: 'read'
@@ -227,6 +236,17 @@ jobs:
               "sandbox": false
             }
           prompt: '/triage ${{ steps.resolve.outputs.number }} --repo ${{ github.repository }}'
+
+      - name: 'Drop autofix fast-path label from untrusted issue triage'
+        if: "always() && github.event_name == 'issues' && steps.resolve.outputs.number != ''"
+        env:
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          NUMBER: '${{ steps.resolve.outputs.number }}'
+        run: |-
+          # Newly opened issues are triaged from untrusted user text. Keep the
+          # scheduled autofix fast path limited to maintainer/workflow labels.
+          gh issue edit "${NUMBER}" --repo "${GITHUB_REPOSITORY}" \
+            --remove-label 'autofix/ready' 2> /dev/null || true
 
   # On-demand real-user testing: a write-permission user comments
   # `@qwen-code /tmux` on a PR to launch the changed app in a tmux TUI and

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -583,6 +583,7 @@ jobs:
           DETAILS_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
           BUG_LABEL: 'type/bug'
           READY_FOR_AGENT_LABEL: 'status/ready-for-agent'
+          AUTOFIX_READY_LABEL: 'autofix/ready'
           PREPARE_RESULT: '${{ needs.prepare.result }}'
           QUALITY_RESULT: '${{ needs.quality.result }}'
           INTEGRATION_NONE_RESULT: '${{ needs.integration_none.result }}'
@@ -606,6 +607,10 @@ jobs:
           if [[ -z "${failed_jobs}" ]]; then
             failed_jobs='- unknown'
           fi
+
+          gh label create "${AUTOFIX_READY_LABEL}" --repo "${GH_REPO}" \
+            --description 'Approved for scheduled autofix fast path' \
+            --color '0e8a16' 2> /dev/null || true
 
           body_file="$(mktemp)"
           cat > "${body_file}" <<BODY
@@ -661,10 +666,10 @@ jobs:
                 exit 0
               fi
               # Ensure the fallback labels are present so that, if the dispatch
-              # below fails, the scheduled ready-for-agent scan can still find it.
+              # below fails, the scheduled autofix/ready scan can still find it.
               gh issue edit "${issue_number}" --repo "${GH_REPO}" \
-                --add-label "${BUG_LABEL},${READY_FOR_AGENT_LABEL}" \
-                || echo "::warning::Failed to ensure ${BUG_LABEL}/${READY_FOR_AGENT_LABEL} on issue #${issue_number}."
+                --add-label "${BUG_LABEL},${READY_FOR_AGENT_LABEL},${AUTOFIX_READY_LABEL}" \
+                || echo "::warning::Failed to ensure ${BUG_LABEL}/${READY_FOR_AGENT_LABEL}/${AUTOFIX_READY_LABEL} on issue #${issue_number}."
             fi
           fi
 
@@ -673,7 +678,8 @@ jobs:
               --title "Release Failed for ${RELEASE_TAG} on $(date -u +'%Y-%m-%d')" \
               --body-file "${body_file}" \
               --label "${BUG_LABEL}" \
-              --label "${READY_FOR_AGENT_LABEL}")"
+              --label "${READY_FOR_AGENT_LABEL}" \
+              --label "${AUTOFIX_READY_LABEL}")"
             issue_number="${issue_url##*/}"
           fi
 

--- a/scripts/tests/autofix-workflow.test.js
+++ b/scripts/tests/autofix-workflow.test.js
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(import.meta.dirname, '../..');
+
+const autofixWorkflow = readFileSync(
+  path.join(ROOT, '.github/workflows/qwen-autofix.yml'),
+  'utf8',
+);
+const releaseWorkflow = readFileSync(
+  path.join(ROOT, '.github/workflows/release.yml'),
+  'utf8',
+);
+const triageWorkflow = readFileSync(
+  path.join(ROOT, '.github/workflows/qwen-triage.yml'),
+  'utf8',
+);
+
+describe('autofix workflow trust gates', () => {
+  it('does not use the LLM-applied ready-for-agent label for tier-1 issue scans', () => {
+    expect(autofixWorkflow).toContain("AUTOFIX_READY_LABEL: 'autofix/ready'");
+    expect(autofixWorkflow).not.toContain('READY_FOR_AGENT_LABEL');
+    expect(autofixWorkflow).toContain('label:${AUTOFIX_READY_LABEL}');
+    expect(autofixWorkflow).not.toContain('label:${READY_FOR_AGENT_LABEL}');
+    expect(autofixWorkflow).toContain(
+      'it is not applied by the\n            # LLM triage path',
+    );
+  });
+
+  it('marks workflow-owned release failure issues as autofix-ready for fallback scans', () => {
+    expect(releaseWorkflow).toContain("AUTOFIX_READY_LABEL: 'autofix/ready'");
+    expect(releaseWorkflow).toContain(
+      'gh label create "${AUTOFIX_READY_LABEL}"',
+    );
+    expect(releaseWorkflow).toContain(
+      '--add-label "${BUG_LABEL},${READY_FOR_AGENT_LABEL},${AUTOFIX_READY_LABEL}"',
+    );
+    expect(releaseWorkflow).toContain('--label "${AUTOFIX_READY_LABEL}"');
+  });
+
+  it('removes autofix-ready labels after untrusted issue-opened triage', () => {
+    const triageIndex = triageWorkflow.indexOf("- name: 'Run Qwen Triage'");
+    const guardIndex = triageWorkflow.indexOf(
+      "- name: 'Drop autofix fast-path label from untrusted issue triage'",
+    );
+
+    expect(guardIndex).toBeGreaterThan(triageIndex);
+    expect(triageWorkflow).toContain("github.event_name == 'issues'");
+    expect(triageWorkflow).toContain("--remove-label 'autofix/ready'");
+    expect(triageWorkflow).toContain(
+      'scheduled autofix fast path limited to maintainer/workflow labels',
+    );
+  });
+});


### PR DESCRIPTION
## What this PR does

This PR changes the scheduled autofix tier-1 issue scan to require a dedicated `autofix/ready` label instead of `status/ready-for-agent`. The release failure workflow now creates and applies `autofix/ready` to release-owned failure issues so the scheduled fallback scan can still pick them up if the direct autofix dispatch fails.

It also adds a post-triage guard for newly opened issues: if the LLM triage path adds `autofix/ready` while processing untrusted issue text, the workflow removes that label before the run finishes. The new workflow test locks the fast-path label, release fallback labels, and issue-opened guard.

## Why it's needed

`status/ready-for-agent` can be applied by the LLM-driven triage workflow after reading issue text. That makes it the wrong trust boundary for an autonomous fast path, because a crafted issue could try to influence triage into promoting itself.

The fast path now requires a label that is applied by maintainers or trusted workflows, while the existing ordinary unattended scan remains available for normal bugs.

## Reviewer Test Plan

### How to verify

Review the workflow diff and confirm that scheduled tier-1 issue scans search for `label:${AUTOFIX_READY_LABEL}`, not `label:${READY_FOR_AGENT_LABEL}`. Confirm that release failure issues are created or updated with `autofix/ready`, and that issue-opened triage removes `autofix/ready` after the LLM step.

Commands run locally:

```sh
npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/autofix-workflow.test.js scripts/tests/qwen-triage-workflow.test.js scripts/tests/install-script.test.js --testNamePattern 'autofix workflow trust gates|qwen-triage tmux workflow|syncs standalone and hosted installation assets during release'
npx prettier --check .github/workflows/qwen-autofix.yml .github/workflows/release.yml .github/workflows/qwen-triage.yml scripts/tests/autofix-workflow.test.js
npx eslint scripts/tests/autofix-workflow.test.js scripts/tests/qwen-triage-workflow.test.js scripts/tests/install-script.test.js
git diff --cached --check && git diff --check
```

`actionlint` was not run locally because neither `actionlint` nor `go` is available in this environment.

### Evidence (Before & After)

Before: the scheduled tier-1 autofix scan used `type/bug` plus `status/ready-for-agent`, and `status/ready-for-agent` can be applied by LLM triage from issue text.

After: the scheduled tier-1 autofix scan uses `type/bug` plus `autofix/ready`; release failure issues get `autofix/ready` explicitly from the release workflow; newly opened issue triage removes `autofix/ready` after the LLM step.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

N/A; this is a GitHub Actions workflow change covered by workflow text tests and local lint/format checks.

## Risk & Scope

- Main risk or tradeoff: `autofix/ready` must remain reserved for maintainers or trusted workflows. If the release failure workflow later changes from `GITHUB_TOKEN` to a PAT or GitHub App token, the issue-opened triage guard should be revisited because release-created issues could trigger triage and lose the fallback label.
- Not validated / out of scope: no live scheduled autofix workflow run was executed; old disabled triage workflows are not changed.
- Breaking changes / migration notes: no user-facing breaking changes.

## Linked Issues

Fixes #5634

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

这个 PR 将 scheduled autofix 的 tier-1 issue 扫描从 `status/ready-for-agent` 改为要求专用的 `autofix/ready` 标签。release failure workflow 现在会创建并给它自己管理的 release failure issue 添加 `autofix/ready`，这样直接 dispatch autofix 失败时，scheduled fallback scan 仍然可以找到这些 issue。

它还给新建 issue 的 triage 增加了一个后置保护：如果 LLM triage 在处理不可信 issue 文本时添加了 `autofix/ready`，workflow 会在本次运行结束前移除这个标签。新增的 workflow 测试锁住了 fast-path 标签、release fallback 标签，以及 issue-opened guard。

## 为什么需要

`status/ready-for-agent` 可以由 LLM 驱动的 triage workflow 在读取 issue 文本后添加。它不适合作为自主 fast path 的信任边界，因为恶意构造的 issue 可以尝试诱导 triage 把自己提升到 ready 状态。

fast path 现在要求一个由维护者或可信 workflow 添加的标签，同时现有的普通 unattended scan 仍然可以处理正常 bug。

## Reviewer Test Plan

### 如何验证

查看 workflow diff，确认 scheduled tier-1 issue scan 搜索的是 `label:${AUTOFIX_READY_LABEL}`，而不是 `label:${READY_FOR_AGENT_LABEL}`。确认 release failure issue 在创建或更新时会带上 `autofix/ready`，并且 issue-opened triage 会在 LLM 步骤之后移除 `autofix/ready`。

本地运行过的命令：

```sh
npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/autofix-workflow.test.js scripts/tests/qwen-triage-workflow.test.js scripts/tests/install-script.test.js --testNamePattern 'autofix workflow trust gates|qwen-triage tmux workflow|syncs standalone and hosted installation assets during release'
npx prettier --check .github/workflows/qwen-autofix.yml .github/workflows/release.yml .github/workflows/qwen-triage.yml scripts/tests/autofix-workflow.test.js
npx eslint scripts/tests/autofix-workflow.test.js scripts/tests/qwen-triage-workflow.test.js scripts/tests/install-script.test.js
git diff --cached --check && git diff --check
```

本地没有运行 `actionlint`，因为当前环境没有 `actionlint` 或 `go`。

### Evidence (Before & After)

Before：scheduled tier-1 autofix scan 使用 `type/bug` 加 `status/ready-for-agent`，而 `status/ready-for-agent` 可能由 LLM triage 根据 issue 文本添加。

After：scheduled tier-1 autofix scan 使用 `type/bug` 加 `autofix/ready`；release failure issue 会由 release workflow 显式添加 `autofix/ready`；新建 issue 的 triage 会在 LLM 步骤之后移除 `autofix/ready`。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

N/A；这是 GitHub Actions workflow 变更，已通过 workflow 文本测试和本地 lint/format 检查覆盖。

## Risk & Scope

- 主要风险或取舍：`autofix/ready` 必须继续保留给维护者或可信 workflow 使用。如果 release failure workflow 以后从 `GITHUB_TOKEN` 改成 PAT 或 GitHub App token，需要重新检查 issue-opened triage guard，因为 release 创建的 issue 可能会触发 triage 并丢失 fallback label。
- 未验证 / 不在范围内：没有执行真实的 scheduled autofix workflow run；没有修改旧的 disabled triage workflows。
- 破坏性变更 / 迁移说明：没有用户可见的破坏性变更。

## Linked Issues

Fixes #5634

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
