### PR TITLE
fix(core): require integer stop hook cap

### DIFF
--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -175,6 +175,16 @@ describe('SettingsSchema', () => {
       expect(voiceModel.showInDialog).toBe(false);
     });
 
+    it('should define stopHookBlockingCap schema override as a positive integer', () => {
+      expect(
+        getSettingsSchema().stopHookBlockingCap.jsonSchemaOverride,
+      ).toEqual({
+        type: 'integer',
+        minimum: 1,
+        default: 8,
+      });
+    });
+
     it('should have voice dictation settings under general', () => {
       const voice =
         getSettingsSchema().general.properties.voice.properties ?? {};

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -2589,6 +2589,11 @@ const SETTINGS_SCHEMA = {
     // This is an advanced safety valve for runaway hook loops, not a common
     // interactive preference.
     showInDialog: false,
+    jsonSchemaOverride: {
+      type: 'integer',
+      minimum: 1,
+      default: DEFAULT_STOP_HOOK_BLOCK_CAP,
+    },
   },
 
   hooks: {

--- a/packages/core/src/hooks/stopHookCap.test.ts
+++ b/packages/core/src/hooks/stopHookCap.test.ts
@@ -31,12 +31,12 @@ describe('stop hook blocking cap', () => {
     );
   });
 
-  it('normalizes finite fractional values down to whole iterations', () => {
+  it('normalizes finite fractional config values down to whole iterations', () => {
     expect(normalizeStopHookBlockingCap(3.7)).toBe(3);
     expect(normalizeStopHookBlockingCap(100.9)).toBe(MAX_STOP_HOOK_BLOCK_CAP);
   });
 
-  it('caps large finite values to avoid unbounded recursive Stop loops', () => {
+  it('caps large integer values to avoid unbounded recursive Stop loops', () => {
     expect(normalizeStopHookBlockingCap(99999)).toBe(MAX_STOP_HOOK_BLOCK_CAP);
   });
 
@@ -44,6 +44,16 @@ describe('stop hook blocking cap', () => {
     process.env[STOP_HOOK_BLOCK_CAP_ENV] = '3';
 
     expect(resolveStopHookBlockingCap(12)).toBe(3);
+  });
+
+  it('rejects fractional environment overrides', () => {
+    process.env[STOP_HOOK_BLOCK_CAP_ENV] = '1.5';
+
+    expect(resolveStopHookBlockingCap(12)).toBe(DEFAULT_STOP_HOOK_BLOCK_CAP);
+  });
+
+  it('preserves legacy fractional config values when no environment override is set', () => {
+    expect(resolveStopHookBlockingCap(3.7)).toBe(3);
   });
 
   it('ignores an empty environment override', () => {

--- a/packages/core/src/hooks/stopHookCap.ts
+++ b/packages/core/src/hooks/stopHookCap.ts
@@ -19,11 +19,17 @@ export function normalizeStopHookBlockingCap(value: unknown): number {
     : DEFAULT_STOP_HOOK_BLOCK_CAP;
 }
 
+function parseStopHookBlockingCapEnv(value: string): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed)
+    ? normalizeStopHookBlockingCap(parsed)
+    : DEFAULT_STOP_HOOK_BLOCK_CAP;
+}
+
 export function resolveStopHookBlockingCap(configValue?: number): number {
   const envValue = process.env[STOP_HOOK_BLOCK_CAP_ENV];
   if (envValue !== undefined && envValue.trim() !== '') {
-    const parsed = Number(envValue);
-    return normalizeStopHookBlockingCap(parsed);
+    return parseStopHookBlockingCapEnv(envValue);
   }
 
   return normalizeStopHookBlockingCap(configValue);

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -1217,9 +1217,10 @@
       "default": false
     },
     "stopHookBlockingCap": {
-      "description": "Maximum consecutive blocking Stop/SubagentStop hook decisions before Qwen Code overrides the hook loop and ends the turn. Can be overridden by QWEN_CODE_STOP_HOOK_BLOCK_CAP.",
-      "type": "number",
-      "default": 8
+      "type": "integer",
+      "minimum": 1,
+      "default": 8,
+      "description": "Maximum consecutive blocking Stop/SubagentStop hook decisions before Qwen Code overrides the hook loop and ends the turn. Can be overridden by QWEN_CODE_STOP_HOOK_BLOCK_CAP."
     },
     "hooks": {
       "description": "Hook event configurations for extending CLI behavior at various lifecycle points.",


### PR DESCRIPTION
## What this PR does

Rejects fractional values for the Stop/SubagentStop hook blocking cap.

- Treats non-integer `stopHookBlockingCap` values as invalid and falls back to `DEFAULT_STOP_HOOK_BLOCK_CAP`.
- Applies the same behavior to `QWEN_CODE_STOP_HOOK_BLOCK_CAP`.
- Keeps valid positive integers and the existing max clamp unchanged.
- Updates the generated settings schema so editors validate this setting as an integer with `minimum: 1`.

## Why it's needed

`stopHookBlockingCap` is a count-like safety valve, but fractional values were previously accepted and floored. For example, `QWEN_CODE_STOP_HOOK_BLOCK_CAP=1.5` resolved to `1`, which can make Stop/SubagentStop hook loop protection fire earlier than the configured value suggests.

Fractional values should be treated like other invalid values instead of silently changing the cap.

## Reviewer Test Plan

### How to verify

1. Confirm fractional values now fall back to the default cap:
   - `normalizeStopHookBlockingCap(3.7)`
   - `QWEN_CODE_STOP_HOOK_BLOCK_CAP=1.5`
2. Confirm valid integer values still work and large integers are still clamped.
3. Confirm `packages/vscode-ide-companion/schemas/settings.schema.json` now marks `stopHookBlockingCap` as an integer.

### Evidence (Before & After)

Before:

- `normalizeStopHookBlockingCap(3.7)` returned `3`.
- `QWEN_CODE_STOP_HOOK_BLOCK_CAP=1.5` resolved to `1`.
- The generated settings schema used `"type": "number"` for `stopHookBlockingCap`.

After:

- Fractional direct settings values fall back to `DEFAULT_STOP_HOOK_BLOCK_CAP`.
- Fractional environment overrides fall back to `DEFAULT_STOP_HOOK_BLOCK_CAP`.
- The generated settings schema uses `"type": "integer"`, `"minimum": 1`, and `"default": 8`.

Commands run:

- `npm run generate:settings-schema`
- `npm test --workspace=packages/core -- hooks/stopHookCap.test.ts`
- `npm test --workspace=packages/cli -- src/config/settingsSchema.test.ts`
- `npm run lint --workspace=packages/core --if-present`
- `npm run lint --workspace=packages/cli --if-present`
- `npm run typecheck --workspace=packages/core --if-present`
- `npx prettier --check packages/core/src/hooks/stopHookCap.ts packages/core/src/hooks/stopHookCap.test.ts packages/cli/src/config/settingsSchema.ts packages/cli/src/config/settingsSchema.test.ts packages/vscode-ide-companion/schemas/settings.schema.json`
- `git diff --check`

### Tested on

| OS | Version | Arch |
| --- | --- | --- |
| macOS | 26.4.1 | arm64 |

## Risk & Scope

Risk is low. The change only affects validation/normalization for fractional cap values.

Out of scope:

- Changing the default cap.
- Changing Stop/SubagentStop hook loop behavior for valid integer caps.
- Migrating existing fractional settings.

Breaking changes:

- Fractional `stopHookBlockingCap` values are no longer accepted. They now fall back to the default, matching the invalid-value path.

## Linked Issues

Fixes #5664

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 拒绝 Stop/SubagentStop hook blocking cap 的小数值。

- 非整数的 `stopHookBlockingCap` 会被视为无效值，并回退到 `DEFAULT_STOP_HOOK_BLOCK_CAP`。
- `QWEN_CODE_STOP_HOOK_BLOCK_CAP` 走同样的规则。
- 合法正整数仍然有效，超大整数仍然沿用现有最大值 clamp。
- 更新生成出来的 settings schema，让编辑器把这个配置校验为 `minimum: 1` 的 integer。

## 为什么需要

`stopHookBlockingCap` 是计数类 safety valve，但之前小数会被接受并向下取整。比如 `QWEN_CODE_STOP_HOOK_BLOCK_CAP=1.5` 会解析成 `1`，这会让 Stop/SubagentStop hook loop protection 比配置看起来更早触发。

小数值应该像其他无效值一样回退，而不是被静默改写成另一个 cap。

## Reviewer 测试计划

### 如何验证

1. 确认小数值现在会回退到默认 cap：
   - `normalizeStopHookBlockingCap(3.7)`
   - `QWEN_CODE_STOP_HOOK_BLOCK_CAP=1.5`
2. 确认合法整数仍然有效，超大整数仍然会被 clamp。
3. 确认 `packages/vscode-ide-companion/schemas/settings.schema.json` 现在把 `stopHookBlockingCap` 标记为 integer。

### 前后对比证据

修改前：

- `normalizeStopHookBlockingCap(3.7)` 返回 `3`。
- `QWEN_CODE_STOP_HOOK_BLOCK_CAP=1.5` 解析为 `1`。
- 生成的 settings schema 对 `stopHookBlockingCap` 使用 `"type": "number"`。

修改后：

- 直接配置的小数值会回退到 `DEFAULT_STOP_HOOK_BLOCK_CAP`。
- 环境变量里的小数值会回退到 `DEFAULT_STOP_HOOK_BLOCK_CAP`。
- 生成的 settings schema 使用 `"type": "integer"`、`"minimum": 1` 和 `"default": 8`。

已运行命令：

- `npm run generate:settings-schema`
- `npm test --workspace=packages/core -- hooks/stopHookCap.test.ts`
- `npm test --workspace=packages/cli -- src/config/settingsSchema.test.ts`
- `npm run lint --workspace=packages/core --if-present`
- `npm run lint --workspace=packages/cli --if-present`
- `npm run typecheck --workspace=packages/core --if-present`
- `npx prettier --check packages/core/src/hooks/stopHookCap.ts packages/core/src/hooks/stopHookCap.test.ts packages/cli/src/config/settingsSchema.ts packages/cli/src/config/settingsSchema.test.ts packages/vscode-ide-companion/schemas/settings.schema.json`
- `git diff --check`

### 测试环境

| OS | Version | Arch |
| --- | --- | --- |
| macOS | 26.4.1 | arm64 |

## 风险和范围

风险较低。这个改动只影响小数 cap 值的校验和归一化。

不在范围内：

- 修改默认 cap。
- 修改合法整数 cap 下的 Stop/SubagentStop hook loop 行为。
- 迁移已有的小数配置。

破坏性变化：

- 小数 `stopHookBlockingCap` 不再被接受，现在会按无效值路径回退到默认值。

## 关联 Issue

Fixes #5664

## AI 辅助披露

我使用 Codex 审查改动、对照现有模式做 sanity check，并帮助发现潜在边界情况。

</details>
