### PR TITLE
feat(cli): Show model thinking intent in loading indicator

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -2962,6 +2962,7 @@ export const AppContainer = (props: AppContainerProps) => {
     settings.merged.ui?.customWittyPhrases,
     responseCandidateTokens,
     streamingResponseLengthRef.current,
+    thought,
   );
 
   useAttentionNotifications({

--- a/packages/cli/src/ui/hooks/useLoadingIndicator.test.ts
+++ b/packages/cli/src/ui/hooks/useLoadingIndicator.test.ts
@@ -317,6 +317,20 @@ describe('useLoadingIndicator', () => {
       expect(result.current.currentLoadingPhrase).toBe('some reasoning');
     });
 
+    it('should use only first line of multiline description when subject is empty', () => {
+      const { result } = renderHook(() =>
+        useLoadingIndicator(
+          StreamingState.Responding,
+          undefined,
+          undefined,
+          undefined,
+          { subject: '', description: 'first line\nsecond line\nthird line' },
+        ),
+      );
+
+      expect(result.current.currentLoadingPhrase).toBe('first line');
+    });
+
     it('should truncate long thought subjects', () => {
       const longSubject = 'A'.repeat(120);
       const { result } = renderHook(() =>

--- a/packages/cli/src/ui/hooks/useLoadingIndicator.test.ts
+++ b/packages/cli/src/ui/hooks/useLoadingIndicator.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useLoadingIndicator } from './useLoadingIndicator.js';
 import { StreamingState } from '../types.js';
+import type { ThoughtSummary } from '../types.js';
 import { PHRASE_CHANGE_INTERVAL_MS } from './usePhraseCycler.js';
 import * as i18n from '../../i18n/index.js';
 
@@ -265,6 +266,171 @@ describe('useLoadingIndicator', () => {
 
       expect(result.current.taskStartTokens).toBe(500);
       expect(result.current.taskStartStreamingChars).toBe(2000);
+    });
+  });
+
+  describe('thinking-intent-driven phrase', () => {
+    const thoughtWithSubject: ThoughtSummary = {
+      subject: 'Analyzing auth flow',
+      description: 'Checking how sessions are managed',
+    };
+
+    it('should show thought subject during Responding', () => {
+      const { result } = renderHook(() =>
+        useLoadingIndicator(
+          StreamingState.Responding,
+          undefined,
+          undefined,
+          undefined,
+          thoughtWithSubject,
+        ),
+      );
+
+      expect(result.current.currentLoadingPhrase).toBe('Analyzing auth flow');
+    });
+
+    it('should fall back to witty phrase when thought is null', () => {
+      const { result } = renderHook(() =>
+        useLoadingIndicator(
+          StreamingState.Responding,
+          undefined,
+          undefined,
+          undefined,
+          null,
+        ),
+      );
+
+      expect(MOCK_WITTY_PHRASES).toContain(result.current.currentLoadingPhrase);
+    });
+
+    it('should fall back to description when thought subject is empty', () => {
+      const { result } = renderHook(() =>
+        useLoadingIndicator(
+          StreamingState.Responding,
+          undefined,
+          undefined,
+          undefined,
+          { subject: '', description: 'some reasoning' },
+        ),
+      );
+
+      expect(result.current.currentLoadingPhrase).toBe('some reasoning');
+    });
+
+    it('should truncate long thought subjects', () => {
+      const longSubject = 'A'.repeat(120);
+      const { result } = renderHook(() =>
+        useLoadingIndicator(
+          StreamingState.Responding,
+          undefined,
+          undefined,
+          undefined,
+          { subject: longSubject, description: '' },
+        ),
+      );
+
+      expect(result.current.currentLoadingPhrase).toBe('A'.repeat(79) + '…');
+      expect(result.current.currentLoadingPhrase.length).toBe(80);
+    });
+
+    it('should not use thought subject during WaitingForConfirmation', () => {
+      const { result } = renderHook(() =>
+        useLoadingIndicator(
+          StreamingState.WaitingForConfirmation,
+          undefined,
+          undefined,
+          undefined,
+          thoughtWithSubject,
+        ),
+      );
+
+      expect(result.current.currentLoadingPhrase).toBe(
+        'Waiting for user confirmation...',
+      );
+    });
+
+    it('should not use thought subject during Idle', () => {
+      const { result } = renderHook(() =>
+        useLoadingIndicator(
+          StreamingState.Idle,
+          undefined,
+          undefined,
+          undefined,
+          thoughtWithSubject,
+        ),
+      );
+
+      expect(MOCK_WITTY_PHRASES).toContain(result.current.currentLoadingPhrase);
+    });
+
+    it('should switch from witty phrase to thought subject when thought arrives', () => {
+      const { result, rerender } = renderHook(
+        ({ thought }) =>
+          useLoadingIndicator(
+            StreamingState.Responding,
+            undefined,
+            undefined,
+            undefined,
+            thought,
+          ),
+        { initialProps: { thought: null as ThoughtSummary | null } },
+      );
+
+      expect(MOCK_WITTY_PHRASES).toContain(result.current.currentLoadingPhrase);
+
+      rerender({ thought: thoughtWithSubject });
+
+      expect(result.current.currentLoadingPhrase).toBe('Analyzing auth flow');
+    });
+
+    it('should retain thought subject after thought is cleared (content/toolcall)', () => {
+      const { result, rerender } = renderHook(
+        ({ thought }) =>
+          useLoadingIndicator(
+            StreamingState.Responding,
+            undefined,
+            undefined,
+            undefined,
+            thought,
+          ),
+        {
+          initialProps: {
+            thought: thoughtWithSubject as ThoughtSummary | null,
+          },
+        },
+      );
+
+      expect(result.current.currentLoadingPhrase).toBe('Analyzing auth flow');
+
+      // Simulate useGeminiStream clearing thought on content/toolcall
+      rerender({ thought: null });
+
+      expect(result.current.currentLoadingPhrase).toBe('Analyzing auth flow');
+    });
+
+    it('should clear retained thought subject on Idle', () => {
+      const { result, rerender } = renderHook(
+        ({ streamingState, thought }) =>
+          useLoadingIndicator(
+            streamingState,
+            undefined,
+            undefined,
+            undefined,
+            thought,
+          ),
+        {
+          initialProps: {
+            streamingState: StreamingState.Responding,
+            thought: thoughtWithSubject as ThoughtSummary | null,
+          },
+        },
+      );
+
+      expect(result.current.currentLoadingPhrase).toBe('Analyzing auth flow');
+
+      rerender({ streamingState: StreamingState.Idle, thought: null });
+
+      expect(MOCK_WITTY_PHRASES).toContain(result.current.currentLoadingPhrase);
     });
   });
 });

--- a/packages/cli/src/ui/hooks/useLoadingIndicator.ts
+++ b/packages/cli/src/ui/hooks/useLoadingIndicator.ts
@@ -5,15 +5,24 @@
  */
 
 import { StreamingState } from '../types.js';
+import type { ThoughtSummary } from '../types.js';
 import { useTimer } from './useTimer.js';
 import { usePhraseCycler } from './usePhraseCycler.js';
 import { useState, useEffect, useRef } from 'react';
+
+const MAX_LOADING_PHRASE_LENGTH = 80;
+
+function truncateLoadingPhrase(phrase: string): string {
+  if (phrase.length <= MAX_LOADING_PHRASE_LENGTH) return phrase;
+  return phrase.slice(0, MAX_LOADING_PHRASE_LENGTH - 1).trimEnd() + '…';
+}
 
 export const useLoadingIndicator = (
   streamingState: StreamingState,
   customWittyPhrases?: string[],
   currentCandidatesTokens?: number,
   currentStreamingChars?: number,
+  thought?: ThoughtSummary | null,
 ) => {
   const [timerResetKey, setTimerResetKey] = useState(0);
   const isTimerActive = streamingState === StreamingState.Responding;
@@ -68,12 +77,33 @@ export const useLoadingIndicator = (
     currentStreamingChars,
   ]);
 
+  // thought is transient — useGeminiStream clears it when content or tool
+  // calls arrive, often in the same React batch as the setThought(value).
+  // A ref captures the subject synchronously during render, surviving the
+  // batch so the loading indicator keeps showing the model's intent
+  // throughout the rest of the turn.
+  // Falls back to description (first line) when subject is absent — many
+  // models don't emit **bold** subjects in their thinking.
+  const thoughtText =
+    thought?.subject?.trim() ||
+    thought?.description?.trim().split('\n')[0] ||
+    '';
+  const retainedThoughtRef = useRef<string | null>(null);
+  if (thoughtText) retainedThoughtRef.current = thoughtText;
+  if (streamingState === StreamingState.Idle) retainedThoughtRef.current = null;
+
+  const activeThoughtPhrase = thoughtText || retainedThoughtRef.current;
+  const loadingPhrase =
+    streamingState === StreamingState.Responding && activeThoughtPhrase
+      ? truncateLoadingPhrase(activeThoughtPhrase)
+      : currentLoadingPhrase;
+
   return {
     elapsedTime:
       streamingState === StreamingState.WaitingForConfirmation
         ? retainedElapsedTime
         : elapsedTimeFromTimer,
-    currentLoadingPhrase,
+    currentLoadingPhrase: loadingPhrase,
     taskStartTokens,
     taskStartStreamingChars,
   };

--- a/packages/cli/src/ui/hooks/useLoadingIndicator.ts
+++ b/packages/cli/src/ui/hooks/useLoadingIndicator.ts
@@ -9,6 +9,7 @@ import type { ThoughtSummary } from '../types.js';
 import { useTimer } from './useTimer.js';
 import { usePhraseCycler } from './usePhraseCycler.js';
 import { useState, useEffect, useRef } from 'react';
+import { escapeAnsiCtrlCodes } from '../utils/textUtils.js';
 
 const MAX_LOADING_PHRASE_LENGTH = 80;
 
@@ -84,10 +85,11 @@ export const useLoadingIndicator = (
   // throughout the rest of the turn.
   // Falls back to description (first line) when subject is absent — many
   // models don't emit **bold** subjects in their thinking.
-  const thoughtText =
+  const thoughtText = escapeAnsiCtrlCodes(
     thought?.subject?.trim() ||
-    thought?.description?.trim().split('\n')[0] ||
-    '';
+      thought?.description?.trim().split('\n')[0] ||
+      '',
+  );
   const retainedThoughtRef = useRef<string | null>(null);
   if (thoughtText) retainedThoughtRef.current = thoughtText;
   if (streamingState === StreamingState.Idle) retainedThoughtRef.current = null;


### PR DESCRIPTION
## What this PR does

Replaces random witty loading phrases ("I'm Feeling Lucky", "加载的是字节，承载是对技术的热爱...") with the model's real-time thinking text. When the model is thinking, its `ThoughtSummary` subject (or description first-line fallback) is shown in the loading indicator instead of a random phrase. The thinking content persists through tool execution via a `useRef` latch, clearing only when the turn ends (Idle).

## Why it's needed

The loading indicator is the user's primary "what's happening now" signal during agent loops. Random witty phrases carry zero information — they tell the user nothing about what the model is actually doing. The model's thinking text is already flowing through `UIStateContext` but was never consumed by the loading indicator. This change wires it up with minimal code — the data was already there, it just wasn't being displayed.

Discussed in #5656 with a full analysis of why the previous summary-based approach (past tense, 1-turn lag, fast-model cost) was semantically mismatched with a present-tense loading slot.

## Reviewer Test Plan

### How to verify

1. `npm run dev` and send a prompt that triggers thinking + tool calls (e.g. "帮我找一下 auth 相关的代码")
2. During the thinking phase, the loading indicator should show the model's thinking text (e.g. "让我搜索 auth 相关的代码文件") instead of a random witty phrase
3. During tool execution (after thinking is committed), the indicator should retain the last thought text — not revert to a witty phrase
4. When the turn ends (Idle), the phrase should reset to normal
5. Run unit tests: `cd packages/cli && npx vitest run src/ui/hooks/useLoadingIndicator.test.ts`

### Evidence (Before & After)

**Before (main branch)** — loading shows a random witty phrase during thinking + tool execution:

> `..  加载的是字节，承载是对技术的热爱... (14s · ↓ 23 tokens · esc to cancel)`

The phrase has no relation to what the model is actually doing.

**After (this PR)** — loading shows the model's real-time thinking text:

During thinking:
> `..  现在让我继续读取更多关键文件来理解完整的架构： (12s · ↓ 149 tokens · esc to cancel)`

During tool execution (thought retained via ref, not reverted to witty phrase):
> `..  让我继续查找 AuthType 的定义和 ProviderConfig 的定义，以及 SharedTokenManager 等… (29s · ↑ 519 tokens · esc to cancel)`

The indicator now reflects the model's intent — what it's trying to accomplish — rather than a decorative phrase.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  ⚠️   |
|  🐧 Linux  |  ⚠️   |

### Environment

`npm run dev` with ModelStudio Standard API key, qwen3.7-plus model. tmux 120x40 terminal.

## Risk & Scope

- Main risk or tradeoff: Models that don't emit thinking events will see no change (falls back to witty phrase). The `description` fallback (first line) may occasionally show technical reasoning rather than user-facing intent — acceptable since it's still more informative than a random phrase.
- Not validated / out of scope: AgentComposer (agent view) still hardcodes "Thinking..." — can be updated in a follow-up. Windows/Linux not tested locally.
- Breaking changes / migration notes: None. `enableLoadingPhrases === false` still suppresses the phrase at the Composer level.

## Linked Issues

#5656

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将 loading 指示器中的随机机智短语（"I'm Feeling Lucky"、"加载的是字节，承载是对技术的热爱..."）替换为模型的实时 thinking 文本。当模型在思考时，loading 指示器显示 `ThoughtSummary` 的 subject（或 description 第一行 fallback）而非随机短语。thinking 文本通过 `useRef` 在工具执行期间保留，直到 turn 结束（Idle）才清除。

## 为什么需要

Loading 指示器是用户在 agent loop 中感知"正在做什么"的主要信号。随机机智短语信息量为零——不告诉用户模型在做什么。模型的 thinking 文本已经通过 `UIStateContext` 流转，但 loading 指示器从未消费它。本改动以最小代码量接上这个连接——数据已存在，只是没被显示。

Issue #5656 中有完整分析，说明之前基于 summary 的方案（过去式、1 turn 滞后、fast-model 成本）与 loading 进行时槽位语义不匹配。

## 验证方法

1. `npm run dev`，发送触发 thinking + 工具调用的 prompt（如"帮我找一下 auth 相关的代码"）
2. thinking 阶段，loading 应显示模型的思考文本（如"让我搜索 auth 相关的代码文件"）而非随机短语
3. 工具执行期间（thinking 已提交），loading 应保留上一个 thinking 文本——不回退到随机短语
4. turn 结束（Idle）时，短语应恢复正常
5. 单元测试：`cd packages/cli && npx vitest run src/ui/hooks/useLoadingIndicator.test.ts`

## 风险与范围

- 主要风险/权衡：不输出 thinking 事件的模型无变化（回退到机智短语）。`description` fallback（第一行）偶尔可能显示技术推理而非面向用户的意图——可接受，因为仍比随机短语有信息量。
- 未验证/超出范围：AgentComposer（agent 视图）仍硬编码 "Thinking..."——可在后续 PR 更新。Windows/Linux 未本地测试。
- 破坏性变更/迁移说明：无。`enableLoadingPhrases === false` 仍在 Composer 层抑制短语。

## 关联 Issue

#5656

</details>
