### PR TITLE
fix(core): require integer inline media byte limit

### DIFF
--- a/packages/core/src/core/inlineMediaLimit.test.ts
+++ b/packages/core/src/core/inlineMediaLimit.test.ts
@@ -60,6 +60,14 @@ describe('getMaxInlineMediaBytes', () => {
     process.env[ENV_KEY] = '0';
     expect(getMaxInlineMediaBytes()).toBe(DEFAULT_MAX_INLINE_MEDIA_BYTES);
   });
+
+  it('ignores fractional env overrides', () => {
+    process.env[ENV_KEY] = '0.5';
+    expect(getMaxInlineMediaBytes()).toBe(DEFAULT_MAX_INLINE_MEDIA_BYTES);
+
+    process.env[ENV_KEY] = '1024.9';
+    expect(getMaxInlineMediaBytes()).toBe(DEFAULT_MAX_INLINE_MEDIA_BYTES);
+  });
 });
 
 describe('clampInlineMediaPart', () => {

--- a/packages/core/src/core/inlineMediaLimit.ts
+++ b/packages/core/src/core/inlineMediaLimit.ts
@@ -17,7 +17,7 @@ export const DEFAULT_MAX_INLINE_MEDIA_BYTES = 10 * 1024 * 1024;
 /**
  * Resolve the inline-media byte ceiling, allowing override via the
  * `QWEN_CODE_MAX_INLINE_MEDIA_BYTES` env var. Falls back to the default for
- * missing, non-numeric, or non-positive values.
+ * missing, non-numeric, non-integer, or non-positive values.
  */
 export function getMaxInlineMediaBytes(): number {
   const raw = process.env['QWEN_CODE_MAX_INLINE_MEDIA_BYTES'];
@@ -25,8 +25,8 @@ export function getMaxInlineMediaBytes(): number {
     return DEFAULT_MAX_INLINE_MEDIA_BYTES;
   }
   const parsed = Number(raw);
-  return Number.isFinite(parsed) && parsed > 0
-    ? Math.floor(parsed)
+  return Number.isInteger(parsed) && parsed > 0
+    ? parsed
     : DEFAULT_MAX_INLINE_MEDIA_BYTES;
 }
 


### PR DESCRIPTION
## What this PR does

Requires `QWEN_CODE_MAX_INLINE_MEDIA_BYTES` to be a positive integer.

- Fractional env values now fall back to `DEFAULT_MAX_INLINE_MEDIA_BYTES`.
- Valid positive integer env values keep working as before.
- The inline-media clamp no longer silently floors byte limits.

## Why it's needed

`QWEN_CODE_MAX_INLINE_MEDIA_BYTES` is a byte-count limit, but fractional values were previously accepted and floored.

The sharpest case is `QWEN_CODE_MAX_INLINE_MEDIA_BYTES=0.5`: it passed the `> 0` check, then `Math.floor(0.5)` returned `0`. That made every non-empty inline media payload exceed the limit and get replaced with the placeholder.

Larger fractional values were also silently changed, for example `1024.9` became `1024`.

## Reviewer Test Plan

### How to verify

1. Set `QWEN_CODE_MAX_INLINE_MEDIA_BYTES=0.5` and confirm `getMaxInlineMediaBytes()` falls back to `DEFAULT_MAX_INLINE_MEDIA_BYTES`.
2. Set `QWEN_CODE_MAX_INLINE_MEDIA_BYTES=1024.9` and confirm it also falls back to the default.
3. Confirm a valid integer value such as `1024` still resolves to `1024`.

### Evidence (Before & After)

Before:

- `QWEN_CODE_MAX_INLINE_MEDIA_BYTES=0.5` resolved to `0`.
- `QWEN_CODE_MAX_INLINE_MEDIA_BYTES=1024.9` resolved to `1024`.

After:

- Fractional env values fall back to `DEFAULT_MAX_INLINE_MEDIA_BYTES`.
- Positive integer env values are still honored.

Commands run:

- `npm test --workspace=packages/core -- core/inlineMediaLimit.test.ts`
- `npm run lint --workspace=packages/core --if-present`
- `npm run typecheck --workspace=packages/core --if-present`
- `npm run build --workspace=packages/core --if-present`
- `npx prettier --check packages/core/src/core/inlineMediaLimit.ts packages/core/src/core/inlineMediaLimit.test.ts`
- `git diff --check`

### Tested on

| OS | Version | Arch |
| --- | --- | --- |
| macOS | 26.4.1 | arm64 |

## Risk & Scope

Risk is low. This only changes env override validation for the inline-media byte ceiling.

Out of scope:

- Changing the default inline-media byte limit.
- Changing inline media clamping behavior for valid integer limits.
- Adding a new upper bound for the env override.

Breaking changes:

- Fractional `QWEN_CODE_MAX_INLINE_MEDIA_BYTES` values are no longer accepted. They now fall back to the default limit.

## Linked Issues

Fixes #5669

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 要求 `QWEN_CODE_MAX_INLINE_MEDIA_BYTES` 必须是正整数。

- 小数 env 值现在会回退到 `DEFAULT_MAX_INLINE_MEDIA_BYTES`。
- 合法正整数 env 值保持原有行为。
- inline-media clamp 不再静默向下取整 byte limit。

## 为什么需要

`QWEN_CODE_MAX_INLINE_MEDIA_BYTES` 是按字节计数的限制，但之前小数值会被接受并向下取整。

最明显的问题是 `QWEN_CODE_MAX_INLINE_MEDIA_BYTES=0.5`：它会通过 `> 0` 检查，然后 `Math.floor(0.5)` 变成 `0`。这样所有非空 inline media 都会超过限制，被替换成 placeholder。

更大的小数值也会被静默改写，比如 `1024.9` 会变成 `1024`。

## Reviewer 测试计划

### 如何验证

1. 设置 `QWEN_CODE_MAX_INLINE_MEDIA_BYTES=0.5`，确认 `getMaxInlineMediaBytes()` 回退到 `DEFAULT_MAX_INLINE_MEDIA_BYTES`。
2. 设置 `QWEN_CODE_MAX_INLINE_MEDIA_BYTES=1024.9`，确认同样回退到默认值。
3. 确认 `1024` 这样的合法整数仍然解析为 `1024`。

### 前后对比证据

修改前：

- `QWEN_CODE_MAX_INLINE_MEDIA_BYTES=0.5` 解析为 `0`。
- `QWEN_CODE_MAX_INLINE_MEDIA_BYTES=1024.9` 解析为 `1024`。

修改后：

- 小数 env 值会回退到 `DEFAULT_MAX_INLINE_MEDIA_BYTES`。
- 正整数 env 值仍然生效。

已运行命令：

- `npm test --workspace=packages/core -- core/inlineMediaLimit.test.ts`
- `npm run lint --workspace=packages/core --if-present`
- `npm run typecheck --workspace=packages/core --if-present`
- `npm run build --workspace=packages/core --if-present`
- `npx prettier --check packages/core/src/core/inlineMediaLimit.ts packages/core/src/core/inlineMediaLimit.test.ts`
- `git diff --check`

### 测试环境

| OS | Version | Arch |
| --- | --- | --- |
| macOS | 26.4.1 | arm64 |

## 风险和范围

风险较低。这个改动只影响 inline-media byte ceiling 的 env override 校验。

不在范围内：

- 修改默认 inline-media byte limit。
- 修改合法整数 limit 下的 inline media clamp 行为。
- 给 env override 新增上限。

破坏性变化：

- 小数 `QWEN_CODE_MAX_INLINE_MEDIA_BYTES` 不再被接受，现在会回退到默认 limit。

## 关联 Issue

Fixes #5669

## AI 辅助披露

我使用 Codex 审查改动、对照现有模式做 sanity check，并帮助发现潜在边界情况。

</details>
