### PR TITLE
fix(cli): require integer Mermaid render timeout

### DIFF
--- a/packages/cli/src/ui/utils/mermaidImageRenderer.test.ts
+++ b/packages/cli/src/ui/utils/mermaidImageRenderer.test.ts
@@ -358,6 +358,35 @@ describe('mermaid image renderer', () => {
     expect(result.kind === 'terminal-image' && result.protocol).toBe('iterm2');
   });
 
+  it('falls back to the default render timeout when configured timeout is fractional', async () => {
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'qwen-mmdc-'));
+    tempDirs.push(binDir);
+    createFakeMmdc(binDir, [
+      'setTimeout(() => {',
+      '  const fs = require("node:fs");',
+      '  const out = process.argv[process.argv.indexOf("-o") + 1];',
+      `  fs.writeFileSync(out, Buffer.from("${PNG_1X1.toString(
+        'base64',
+      )}", "base64"));`,
+      '}, 20);',
+    ]);
+
+    const result = await renderMermaidImageAsync({
+      source: 'flowchart TD\n  A[Start] --> B[End fractional timeout]',
+      contentWidth: 80,
+      availableTerminalHeight: 20,
+      env: {
+        PATH: `${binDir}${path.delimiter}${process.env['PATH'] ?? ''}`,
+        QWEN_CODE_MERMAID_IMAGE_RENDERING: '1',
+        QWEN_CODE_MERMAID_IMAGE_PROTOCOL: 'kitty',
+        QWEN_CODE_MERMAID_RENDER_TIMEOUT_MS: '0.4',
+      },
+    });
+
+    expect(result.kind).toBe('terminal-image');
+    expect(result.kind === 'terminal-image' && result.protocol).toBe('kitty');
+  });
+
   it('renders Mermaid through chafa when terminal images are unavailable', () => {
     const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'qwen-chafa-'));
     tempDirs.push(binDir);

--- a/packages/cli/src/ui/utils/mermaidImageRenderer.ts
+++ b/packages/cli/src/ui/utils/mermaidImageRenderer.ts
@@ -1063,8 +1063,8 @@ function getMermaidRenderWidth(env: NodeJS.ProcessEnv): number {
 
 function getMermaidRenderTimeout(env: NodeJS.ProcessEnv): number {
   const configuredTimeout = Number(env['QWEN_CODE_MERMAID_RENDER_TIMEOUT_MS']);
-  if (Number.isFinite(configuredTimeout) && configuredTimeout > 0) {
-    return Math.min(Math.round(configuredTimeout), MAX_RENDER_TIMEOUT_MS);
+  if (Number.isInteger(configuredTimeout) && configuredTimeout > 0) {
+    return Math.min(configuredTimeout, MAX_RENDER_TIMEOUT_MS);
   }
   return DEFAULT_RENDER_TIMEOUT_MS;
 }


### PR DESCRIPTION
## What this PR does

Requires `QWEN_CODE_MERMAID_RENDER_TIMEOUT_MS` to be a positive integer.

- Fractional timeout env values now fall back to the default Mermaid render timeout.
- Valid positive integer timeout values keep working as before.
- The renderer no longer rounds fractional millisecond values before passing them to `spawnSync` / `setTimeout`.

## Why it's needed

`QWEN_CODE_MERMAID_RENDER_TIMEOUT_MS` is a millisecond timeout, but fractional values were previously accepted and rounded.

The sharpest case is `QWEN_CODE_MERMAID_RENDER_TIMEOUT_MS=0.4`: it passed the `> 0` check, then `Math.round(0.4)` returned `0`. In the async renderer, that value is passed to `setTimeout(..., 0)`, so the Mermaid CLI process can be killed immediately instead of using the default timeout.

Fractional timeout values should be treated like other invalid env values instead of being silently rounded.

## Reviewer Test Plan

### How to verify

1. Set `QWEN_CODE_MERMAID_RENDER_TIMEOUT_MS=0.4`.
2. Render a Mermaid diagram through the async renderer with a fake `mmdc` that writes the PNG after a short delay.
3. Confirm rendering succeeds by falling back to the default timeout instead of timing out immediately.
4. Confirm valid positive integer timeout values still work.

### Evidence (Before & After)

Before:

- `QWEN_CODE_MERMAID_RENDER_TIMEOUT_MS=0.4` resolved to `0`.
- The async renderer could schedule `setTimeout(..., 0)` and terminate the renderer immediately.

After:

- Fractional timeout env values fall back to `DEFAULT_RENDER_TIMEOUT_MS`.
- The regression test with a delayed fake `mmdc` succeeds under `QWEN_CODE_MERMAID_RENDER_TIMEOUT_MS=0.4`.

Commands run:

- `npm test --workspace=packages/cli -- ui/utils/mermaidImageRenderer.test.ts`
- `npm run lint --workspace=packages/cli --if-present`
- `npx prettier --check packages/cli/src/ui/utils/mermaidImageRenderer.ts packages/cli/src/ui/utils/mermaidImageRenderer.test.ts`
- `git diff --check`

Attempted but blocked by existing unrelated local failures:

- `npm run typecheck --workspace=packages/cli --if-present`
  - Fails in `src/ui/components/BaseTextInput.tsx` because `ink/dom` and `ink/components/CursorContext` type declarations are not resolved, followed by `cursorCtx` unknown-type errors.
- `npm run build --workspace=packages/cli --if-present`
  - Fails before this diff is involved with existing `packages/core/dist/**/*.d.ts` TS5055 overwrite errors, then the same `BaseTextInput.tsx` `ink/dom` type errors.

### Tested on

| OS | Version | Arch |
| --- | --- | --- |
| macOS | 26.4.1 | arm64 |

## Risk & Scope

Risk is low. This only changes env override validation for the Mermaid renderer timeout.

Out of scope:

- Changing the default Mermaid render timeout.
- Changing timeout behavior for valid positive integer env values.
- Changing Mermaid render width parsing.

Breaking changes:

- Fractional `QWEN_CODE_MERMAID_RENDER_TIMEOUT_MS` values are no longer accepted. They now fall back to the default timeout.

## Linked Issues

Fixes #5672

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 要求 `QWEN_CODE_MERMAID_RENDER_TIMEOUT_MS` 必须是正整数。

- 小数 timeout env 值现在会回退到默认 Mermaid render timeout。
- 合法正整数 timeout 值保持原有行为。
- renderer 不再把小数毫秒值 round 之后传给 `spawnSync` / `setTimeout`。

## 为什么需要

`QWEN_CODE_MERMAID_RENDER_TIMEOUT_MS` 是毫秒级 timeout，但之前小数值会被接受并四舍五入。

最明显的问题是 `QWEN_CODE_MERMAID_RENDER_TIMEOUT_MS=0.4`：它会通过 `> 0` 检查，然后 `Math.round(0.4)` 返回 `0`。在 async renderer 里，这个值会传给 `setTimeout(..., 0)`，导致 Mermaid CLI 进程可能立刻被终止，而不是使用默认 timeout。

小数 timeout 应该像其他无效 env 值一样回退，而不是被静默 round。

## Reviewer 测试计划

### 如何验证

1. 设置 `QWEN_CODE_MERMAID_RENDER_TIMEOUT_MS=0.4`。
2. 用 async renderer 渲染 Mermaid diagram，fake `mmdc` 延迟很短时间后写出 PNG。
3. 确认渲染成功，说明它回退到了默认 timeout，而不是立即 timeout。
4. 确认合法正整数 timeout 值仍然有效。

### 前后对比证据

修改前：

- `QWEN_CODE_MERMAID_RENDER_TIMEOUT_MS=0.4` 解析为 `0`。
- async renderer 可能调度 `setTimeout(..., 0)`，立刻终止 renderer。

修改后：

- 小数 timeout env 值会回退到 `DEFAULT_RENDER_TIMEOUT_MS`。
- 使用 `QWEN_CODE_MERMAID_RENDER_TIMEOUT_MS=0.4` 和延迟 fake `mmdc` 的回归测试可以正常通过。

已运行命令：

- `npm test --workspace=packages/cli -- ui/utils/mermaidImageRenderer.test.ts`
- `npm run lint --workspace=packages/cli --if-present`
- `npx prettier --check packages/cli/src/ui/utils/mermaidImageRenderer.ts packages/cli/src/ui/utils/mermaidImageRenderer.test.ts`
- `git diff --check`

已尝试但被本地既有无关失败挡住：

- `npm run typecheck --workspace=packages/cli --if-present`
  - 失败点在 `src/ui/components/BaseTextInput.tsx`，原因是 `ink/dom` 和 `ink/components/CursorContext` 类型声明没有解析到，随后出现 `cursorCtx` unknown-type 错误。
- `npm run build --workspace=packages/cli --if-present`
  - 在触及本次 diff 之前失败：先出现既有的 `packages/core/dist/**/*.d.ts` TS5055 overwrite errors，然后是同一组 `BaseTextInput.tsx` / `ink/dom` 类型错误。

### 测试环境

| OS | Version | Arch |
| --- | --- | --- |
| macOS | 26.4.1 | arm64 |

## 风险和范围

风险较低。这个改动只影响 Mermaid renderer timeout 的 env override 校验。

不在范围内：

- 修改默认 Mermaid render timeout。
- 修改合法正整数 env 值下的 timeout 行为。
- 修改 Mermaid render width 解析。

破坏性变化：

- 小数 `QWEN_CODE_MERMAID_RENDER_TIMEOUT_MS` 不再被接受，现在会回退到默认 timeout。

## 关联 Issue

Fixes #5672

## AI 辅助披露

我使用 Codex 审查改动、对照现有模式做 sanity check，并帮助发现潜在边界情况。

</details>
