### PR TITLE
fix(core): validate IDE server port env

### DIFF
--- a/packages/core/src/ide/ide-client.test.ts
+++ b/packages/core/src/ide/ide-client.test.ts
@@ -237,29 +237,50 @@ describe('IdeClient', () => {
       delete process.env['QWEN_CODE_IDE_SERVER_PORT'];
     });
 
-    it('should connect using HTTP when port is provided in environment variables', async () => {
-      vi.mocked(fs.promises.readFile).mockRejectedValue(
-        new Error('File not found'),
-      );
-      (
-        vi.mocked(fs.promises.readdir) as Mock<
-          (path: fs.PathLike) => Promise<string[]>
-        >
-      ).mockResolvedValue([]);
-      process.env['QWEN_CODE_IDE_SERVER_PORT'] = '9090';
+    it.each(['1', '9090', '65535'])(
+      'should connect using HTTP when port %s is provided in environment variables',
+      async (port) => {
+        vi.mocked(fs.promises.readFile).mockRejectedValue(
+          new Error('File not found'),
+        );
+        (
+          vi.mocked(fs.promises.readdir) as Mock<
+            (path: fs.PathLike) => Promise<string[]>
+          >
+        ).mockResolvedValue([]);
+        process.env['QWEN_CODE_IDE_SERVER_PORT'] = port;
 
-      const ideClient = await IdeClient.getInstance();
-      await ideClient.connect();
+        const ideClient = await IdeClient.getInstance();
+        await ideClient.connect();
 
-      expect(StreamableHTTPClientTransport).toHaveBeenCalledWith(
-        new URL('http://127.0.0.1:9090/mcp'),
-        expect.any(Object),
-      );
-      expect(mockClient.connect).toHaveBeenCalledWith(mockHttpTransport);
-      expect(ideClient.getConnectionStatus().status).toBe(
-        IDEConnectionStatus.Connected,
-      );
-    });
+        expect(StreamableHTTPClientTransport).toHaveBeenCalledWith(
+          new URL(`http://127.0.0.1:${port}/mcp`),
+          expect.any(Object),
+        );
+        expect(mockClient.connect).toHaveBeenCalledWith(mockHttpTransport);
+        expect(ideClient.getConnectionStatus().status).toBe(
+          IDEConnectionStatus.Connected,
+        );
+      },
+    );
+
+    it.each(['0', '65536', '9090abc'])(
+      'should ignore invalid HTTP port %s from environment variables',
+      async (port) => {
+        vi.mocked(Client).mockClear();
+        vi.mocked(StreamableHTTPClientTransport).mockClear();
+        process.env['QWEN_CODE_IDE_SERVER_PORT'] = port;
+
+        const ideClient = await IdeClient.getInstance();
+        await ideClient.connect();
+
+        expect(Client).not.toHaveBeenCalled();
+        expect(StreamableHTTPClientTransport).not.toHaveBeenCalled();
+        expect(ideClient.getConnectionStatus().status).toBe(
+          IDEConnectionStatus.Disconnected,
+        );
+      },
+    );
 
     it('should fall back to host.docker.internal when localhost fails in container', async () => {
       process.env['QWEN_CODE_IDE_SERVER_PORT'] = '9090';
@@ -500,6 +521,39 @@ describe('IdeClient', () => {
 
       expect(result).toEqual(config);
       expect(fs.promises.readdir).not.toHaveBeenCalled();
+      delete process.env['QWEN_CODE_IDE_SERVER_PORT'];
+    });
+
+    it('should ignore invalid env port while resolving lock files', async () => {
+      process.env['QWEN_CODE_IDE_SERVER_PORT'] = '../evil';
+      vi.mocked(fs.promises.readFile).mockClear();
+      vi.mocked(fs.promises.readdir).mockClear();
+      vi.mocked(fs.promises.readFile).mockRejectedValue(new Error('not found'));
+      (
+        vi.mocked(fs.promises.readdir) as Mock<
+          (path: fs.PathLike) => Promise<string[]>
+        >
+      ).mockResolvedValue([]);
+
+      const ideClient = await IdeClient.getInstance();
+      const result = await (
+        ideClient as unknown as {
+          getConnectionConfigFromFile: () => Promise<unknown>;
+        }
+      ).getConnectionConfigFromFile();
+
+      expect(result).toBeUndefined();
+      expect(fs.promises.readFile).not.toHaveBeenCalledWith(
+        path.join('/home/test', '.qwen', 'evil.lock'),
+        'utf8',
+      );
+      expect(fs.promises.readFile).not.toHaveBeenCalledWith(
+        path.join('/tmp', 'qwen-code-ide-server-../evil.json'),
+        'utf8',
+      );
+      expect(fs.promises.readdir).toHaveBeenCalledWith(
+        path.join('/home/test', '.qwen', 'ide'),
+      );
       delete process.env['QWEN_CODE_IDE_SERVER_PORT'];
     });
 

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -75,6 +75,15 @@ type ParsedConnectionLockFile = {
   parsed: IdeConnectionConfig;
 };
 
+function isValidIdeServerPort(port: string): boolean {
+  if (!/^\d+$/.test(port)) {
+    return false;
+  }
+
+  const portNumber = Number(port);
+  return portNumber >= 1 && portNumber <= 65535;
+}
+
 function getRealPath(path: string): string {
   try {
     return fs.realpathSync(path);
@@ -546,6 +555,10 @@ export class IdeClient {
   private getPortFromEnv(): string | undefined {
     const port = process.env['QWEN_CODE_IDE_SERVER_PORT'];
     if (!port) {
+      return undefined;
+    }
+    if (!isValidIdeServerPort(port)) {
+      debugLogger.debug('Ignoring invalid QWEN_CODE_IDE_SERVER_PORT:', port);
       return undefined;
     }
     return port;


### PR DESCRIPTION
## What this PR does

Validates `QWEN_CODE_IDE_SERVER_PORT` before the IDE client uses it. The env var is now accepted only when it is a decimal TCP port in the `1..65535` range; invalid values are ignored so normal IDE discovery can continue.

This also adds regression coverage for valid boundary ports, invalid numeric ports, malformed port strings, and path-segment values such as `../evil`.

## Why it's needed

The IDE client previously trusted the env var as a raw string. That value was used to build the HTTP URL and to choose the env-specific IDE lock file path, so a malformed value could make the CLI probe paths outside `.qwen/ide` or attempt an invalid HTTP URL.

Rejecting invalid values keeps the env override useful for real ports while preventing malformed values from changing lock file discovery.

## Reviewer Test Plan

### How to verify

Run the core IDE client tests and confirm invalid `QWEN_CODE_IDE_SERVER_PORT` values are ignored while valid boundary ports still connect through HTTP.

Commands used locally:

```bash
npm test --workspace=packages/core -- ide/ide-client.test.ts
npm test --workspace=packages/core -- ide
npm run lint --workspace=packages/core --if-present
npm run typecheck --workspace=packages/core --if-present
npx prettier --check packages/core/src/ide/ide-client.ts packages/core/src/ide/ide-client.test.ts
git diff --check
```

### Evidence (Before & After)

Before: `QWEN_CODE_IDE_SERVER_PORT=../evil` could make the env lock file lookup target `.qwen/evil.lock` instead of staying under `.qwen/ide`.

After: the new regression test verifies `../evil` is ignored, `.qwen/evil.lock` is not read, the legacy temp path using that invalid value is not read, and normal lock-directory scanning continues. The same test file also verifies `0`, `65536`, and `9090abc` are ignored while `1`, `9090`, and `65535` remain valid.

Local results:

```text
src/ide/ide-client.test.ts: 39 tests passed
vitest run ide: 33 test files, 480 tests passed
core lint: passed
core typecheck: passed
Prettier check: passed
git diff --check: passed
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Node.js `v26.3.0`, npm `11.16.0`, macOS `26.4.1`.

## Risk & Scope

- Main risk or tradeoff: setups relying on malformed IDE port values will now fall back to discovery instead of using those values directly.
- Not validated / out of scope: real VS Code extension end-to-end connection on Windows/Linux; CI should cover platform-level regressions.
- Breaking changes / migration notes: none for valid decimal TCP ports.

## Linked Issues

Fixes #5675

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

在 IDE client 使用 `QWEN_CODE_IDE_SERVER_PORT` 前先校验它。现在只有 `1..65535` 范围内的十进制 TCP 端口会被接受；非法值会被忽略，让常规 IDE discovery 继续执行。

这次也补了回归测试，覆盖有效边界端口、非法数字端口、格式错误的端口字符串，以及 `../evil` 这种带路径片段的值。

## Why it's needed

之前 IDE client 会把这个 env var 当作原始字符串信任。这个值既会用来构造 HTTP URL，也会用来选择 env-specific IDE lock file 路径，所以格式错误的值可能让 CLI 探测 `.qwen/ide` 之外的路径，或者尝试构造非法 HTTP URL。

拒绝非法值可以保留真实端口 override 的能力，同时避免 malformed 值影响 lock file discovery。

## Reviewer Test Plan

### How to verify

运行 core IDE client 测试，确认非法的 `QWEN_CODE_IDE_SERVER_PORT` 会被忽略，同时有效边界端口仍然会通过 HTTP 连接。

本地执行的命令：

```bash
npm test --workspace=packages/core -- ide/ide-client.test.ts
npm test --workspace=packages/core -- ide
npm run lint --workspace=packages/core --if-present
npm run typecheck --workspace=packages/core --if-present
npx prettier --check packages/core/src/ide/ide-client.ts packages/core/src/ide/ide-client.test.ts
git diff --check
```

### Evidence (Before & After)

Before：`QWEN_CODE_IDE_SERVER_PORT=../evil` 会让 env lock file lookup 指向 `.qwen/evil.lock`，而不是停留在 `.qwen/ide` 目录下。

After：新的回归测试确认 `../evil` 会被忽略，不会读取 `.qwen/evil.lock`，也不会读取使用这个非法值拼出来的 legacy temp 路径，并且会继续走常规 lock-directory scanning。同一个测试文件还确认 `0`、`65536`、`9090abc` 会被忽略，而 `1`、`9090`、`65535` 仍然有效。

本地结果：

```text
src/ide/ide-client.test.ts：39 个测试通过
vitest run ide：33 个测试文件、480 个测试通过
core lint：通过
core typecheck：通过
Prettier check：通过
git diff --check：通过
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Node.js `v26.3.0`，npm `11.16.0`，macOS `26.4.1`。

## Risk & Scope

- Main risk or tradeoff：依赖 malformed IDE port 值的配置现在会回退到 discovery，而不是继续直接使用这些值。
- Not validated / out of scope：没有在 Windows/Linux 上做真实 VS Code extension 端到端连接；平台级回归交给 CI 覆盖。
- Breaking changes / migration notes：对合法十进制 TCP 端口没有破坏性变更。

## Linked Issues

Fixes #5675

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
