### PR TITLE
fix(cli): reject non-positive recap thresholds

### DIFF
--- a/packages/cli/src/serve/routes/workspace-settings.test.ts
+++ b/packages/cli/src/serve/routes/workspace-settings.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it, vi } from 'vitest';
+import { SettingScope } from '../../config/settings.js';
+import { registerWorkspaceSettingsRoutes } from './workspace-settings.js';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+
+  const persistSetting = vi.fn().mockResolvedValue(undefined);
+  const broadcastSettingsChanged = vi.fn();
+
+  registerWorkspaceSettingsRoutes(app, {
+    boundWorkspace: '/tmp/qwen-workspace-settings-test',
+    mutate: () => (_req, _res, next) => next(),
+    safeBody: (req) =>
+      req.body && typeof req.body === 'object' ? req.body : {},
+    persistSetting,
+    broadcastSettingsChanged,
+    parseAndValidateClientId: () => undefined,
+  });
+
+  return { app, persistSetting, broadcastSettingsChanged };
+}
+
+function recapThresholdBody(value: number) {
+  return {
+    scope: 'workspace',
+    key: 'general.sessionRecapAwayThresholdMinutes',
+    value,
+  };
+}
+
+describe('POST /workspace/settings', () => {
+  it.each([0, -5])(
+    'rejects non-positive session recap away threshold %s',
+    async (value) => {
+      const { app, persistSetting, broadcastSettingsChanged } = makeApp();
+
+      const res = await request(app)
+        .post('/workspace/settings')
+        .send(recapThresholdBody(value));
+
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        code: 'invalid_value',
+        error: 'Value must be greater than 0',
+      });
+      expect(persistSetting).not.toHaveBeenCalled();
+      expect(broadcastSettingsChanged).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([0.1, 5])(
+    'accepts positive session recap away threshold %s',
+    async (value) => {
+      const { app, persistSetting, broadcastSettingsChanged } = makeApp();
+
+      const res = await request(app)
+        .post('/workspace/settings')
+        .send(recapThresholdBody(value));
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        key: 'general.sessionRecapAwayThresholdMinutes',
+        scope: 'workspace',
+        value,
+      });
+      expect(persistSetting).toHaveBeenCalledWith(
+        '/tmp/qwen-workspace-settings-test',
+        SettingScope.Workspace,
+        'general.sessionRecapAwayThresholdMinutes',
+        value,
+      );
+      expect(broadcastSettingsChanged).toHaveBeenCalledWith(
+        'general.sessionRecapAwayThresholdMinutes',
+        value,
+        'workspace',
+        undefined,
+      );
+    },
+  );
+});

--- a/packages/cli/src/serve/routes/workspace-settings.ts
+++ b/packages/cli/src/serve/routes/workspace-settings.ts
@@ -65,6 +65,9 @@ interface SettingsResponse {
 }
 
 const SECURITY_SENSITIVE_SETTINGS = new Set(['tools.approvalMode']);
+const POSITIVE_NUMBER_SETTINGS = new Set([
+  'general.sessionRecapAwayThresholdMinutes',
+]);
 
 function getAllowedKeys(): Set<string> {
   const keys = new Set(
@@ -147,6 +150,9 @@ function validateSettingValue(
     case 'number':
       if (typeof value !== 'number' || !Number.isFinite(value))
         return 'Value must be a finite number';
+      if (def.key && POSITIVE_NUMBER_SETTINGS.has(def.key) && value <= 0) {
+        return 'Value must be greater than 0';
+      }
       break;
     case 'string':
       if (typeof value !== 'string') return 'Value must be a string';


### PR DESCRIPTION
## What this PR does

Rejects non-positive `general.sessionRecapAwayThresholdMinutes` values when web or daemon clients update the setting through `POST /workspace/settings`.

Adds focused route coverage for `0` and negative values returning `400 invalid_value`, while positive fractional and integer values still persist and broadcast normally.

## Why it's needed

Before this change, the REST workspace settings route could persist values such as `0` or `-5`, but the runtime recap hook only uses the configured threshold when it is greater than zero. Those stored values were ignored at runtime and silently fell back to the default threshold, so the web-visible setting could say one thing while the app did another.

This keeps the REST settings API aligned with the runtime behavior: only positive thresholds are accepted.

## Reviewer Test Plan

### How to verify

Send `POST /workspace/settings` for `general.sessionRecapAwayThresholdMinutes` with `0` or `-5` and confirm the route returns `400` with `code: "invalid_value"` and does not persist the value.

Send the same request with `0.1` or `5` and confirm the route returns `200`, persists the value, and broadcasts the settings change.

Run the focused route tests and the existing serve route test group.

### Evidence (Before & After)

Before: `POST /workspace/settings` accepted and persisted non-positive session recap thresholds even though the runtime ignored them.

After: `npm test --workspace=packages/cli -- serve/routes/workspace-settings.test.ts` passes with 4 tests covering rejected `0` / `-5` and accepted `0.1` / `5`.

After: `npm test --workspace=packages/cli -- serve/routes` passes with 4 test files and 61 tests.

After: `npm run lint --workspace=packages/cli --if-present` passes.

After: `npx prettier --experimental-cli --check packages/cli/src/serve/routes/workspace-settings.ts packages/cli/src/serve/routes/workspace-settings.test.ts` passes.

After: `git diff --check` passes.

Note: `npm run typecheck --workspace=packages/cli --if-present` is currently blocked locally by existing `BaseTextInput.tsx` `ink/dom` type-resolution errors unrelated to this route change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS workspace with the repository npm dependencies installed.

## Risk & Scope

- Main risk or tradeoff: Clients that try to store `0` or negative recap thresholds through the REST settings API now receive `400`; those values were already ignored by the runtime, so this makes the API fail earlier instead of storing ineffective config.
- Not validated / out of scope: Local Windows and Linux runs; the full CLI typecheck is blocked in this checkout by unrelated Ink type-resolution errors.
- Breaking changes / migration notes: No migration. Existing invalid stored values are not rewritten by this PR.

## Linked Issues

Fixes #5680

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

当 web 或 daemon 客户端通过 `POST /workspace/settings` 更新 `general.sessionRecapAwayThresholdMinutes` 时，拒绝非正数值。

新增了聚焦的 route 测试，覆盖 `0` 和负数返回 `400 invalid_value`，同时确保正的小数和整数仍然可以正常持久化并广播变更。

## Why it's needed

在这个改动之前，REST workspace settings route 可以持久化 `0` 或 `-5` 这样的值，但运行时 recap hook 只有在阈值大于 0 时才会使用配置值。这些已存储的值运行时会被忽略，并静默回退到默认阈值，导致 web 上看到的设置和应用实际行为不一致。

这个改动让 REST settings API 和运行时行为保持一致：只接受正数阈值。

## Reviewer Test Plan

### How to verify

用 `0` 或 `-5` 调用 `POST /workspace/settings` 更新 `general.sessionRecapAwayThresholdMinutes`，确认 route 返回 `400`，响应中包含 `code: "invalid_value"`，并且不会持久化该值。

用 `0.1` 或 `5` 发送同样的请求，确认 route 返回 `200`，会持久化该值，并广播 settings 变更。

运行聚焦 route 测试和现有 serve route 测试组。

### Evidence (Before & After)

Before：`POST /workspace/settings` 会接受并持久化非正数 session recap 阈值，但运行时会忽略这些值。

After：`npm test --workspace=packages/cli -- serve/routes/workspace-settings.test.ts` 通过，4 个测试覆盖拒绝 `0` / `-5` 以及接受 `0.1` / `5`。

After：`npm test --workspace=packages/cli -- serve/routes` 通过，4 个测试文件共 61 个测试。

After：`npm run lint --workspace=packages/cli --if-present` 通过。

After：`npx prettier --experimental-cli --check packages/cli/src/serve/routes/workspace-settings.ts packages/cli/src/serve/routes/workspace-settings.test.ts` 通过。

After：`git diff --check` 通过。

说明：`npm run typecheck --workspace=packages/cli --if-present` 当前在本地被已有的 `BaseTextInput.tsx` `ink/dom` 类型解析错误阻塞，这和本次 route 改动无关。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 macOS 工作区，已安装仓库 npm 依赖。

## Risk & Scope

- Main risk or tradeoff：尝试通过 REST settings API 写入 `0` 或负数 recap 阈值的客户端现在会收到 `400`；这些值本来就会被运行时忽略，所以这个改动是在 API 层更早失败，而不是保存无效配置。
- Not validated / out of scope：未在本地跑 Windows 和 Linux；完整 CLI typecheck 在当前 checkout 中被无关的 Ink 类型解析错误阻塞。
- Breaking changes / migration notes：没有迁移逻辑。本 PR 不会重写已经存在的无效已存储值。

## Linked Issues

Fixes #5680

## AI Assistance Disclosure

我使用 Codex 来审查改动、对照现有模式做 sanity check，并帮助发现潜在边界情况。

</details>
