### PR TITLE
fix(core): remove redundant reportSuggestionUsage causing double-counted stats

### DIFF
--- a/packages/core/src/followup/suggestionGenerator.test.ts
+++ b/packages/core/src/followup/suggestionGenerator.test.ts
@@ -8,13 +8,10 @@ import type { Content } from '@google/genai';
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 import type { Config } from '../config/config.js';
 
-const { mockGetCacheSafeParams, mockRunForkedAgent, mockAddEvent } = vi.hoisted(
-  () => ({
-    mockGetCacheSafeParams: vi.fn(),
-    mockRunForkedAgent: vi.fn(),
-    mockAddEvent: vi.fn(),
-  }),
-);
+const { mockGetCacheSafeParams, mockRunForkedAgent } = vi.hoisted(() => ({
+  mockGetCacheSafeParams: vi.fn(),
+  mockRunForkedAgent: vi.fn(),
+}));
 
 vi.mock('../utils/forkedAgent.js', async (importOriginal) => {
   const actual =
@@ -23,17 +20,6 @@ vi.mock('../utils/forkedAgent.js', async (importOriginal) => {
     ...actual,
     getCacheSafeParams: mockGetCacheSafeParams,
     runForkedAgent: mockRunForkedAgent,
-  };
-});
-
-vi.mock('../telemetry/uiTelemetry.js', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('../telemetry/uiTelemetry.js')>();
-  return {
-    ...actual,
-    uiTelemetryService: {
-      addEvent: mockAddEvent,
-    },
   };
 });
 
@@ -54,7 +40,6 @@ describe('generatePromptSuggestion', () => {
   beforeEach(() => {
     mockGetCacheSafeParams.mockReset();
     mockRunForkedAgent.mockReset();
-    mockAddEvent.mockReset();
   });
 
   it('passes cache-safe model in cache mode when no explicit or fast model exists', async () => {

--- a/packages/core/src/followup/suggestionGenerator.ts
+++ b/packages/core/src/followup/suggestionGenerator.ts
@@ -13,11 +13,6 @@ import type { Content } from '@google/genai';
 import type { Config } from '../config/config.js';
 import { getCacheSafeParams, runForkedAgent } from '../utils/forkedAgent.js';
 import { runSideQuery } from '../utils/sideQuery.js';
-import {
-  uiTelemetryService,
-  EVENT_API_RESPONSE,
-} from '../telemetry/uiTelemetry.js';
-import { ApiResponseEvent } from '../telemetry/types.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 
 const debugLogger = createDebugLogger('FOLLOWUP');
@@ -155,7 +150,6 @@ async function generateViaForkedQuery(
   const cacheSafeParams = getCacheSafeParams();
   if (!cacheSafeParams) return null;
   const model = modelOverride ?? config.getFastModel() ?? cacheSafeParams.model;
-  const startTime = Date.now();
   const result = await runForkedAgent({
     config,
     userMessage: SUGGESTION_PROMPT,
@@ -163,22 +157,6 @@ async function generateViaForkedQuery(
     jsonSchema: SUGGESTION_SCHEMA,
     model,
   });
-  const durationMs = Date.now() - startTime;
-
-  // Report usage to session stats
-  if (result.usage) {
-    reportSuggestionUsage(
-      config,
-      model,
-      {
-        promptTokenCount: result.usage.inputTokens,
-        candidatesTokenCount: result.usage.outputTokens,
-        totalTokenCount: result.usage.inputTokens + result.usage.outputTokens,
-        cachedContentTokenCount: result.usage.cacheHitTokens,
-      },
-      durationMs,
-    );
-  }
 
   if (result.jsonResult) {
     const raw = result.jsonResult['suggestion'];
@@ -213,7 +191,6 @@ async function generateViaBaseLlm(
     { role: 'user', parts: [{ text: SUGGESTION_PROMPT }] },
   ];
 
-  const startTime = Date.now();
   const result = await runSideQuery(config, {
     purpose: 'prompt-suggestion',
     contents,
@@ -223,12 +200,6 @@ async function generateViaBaseLlm(
     // the user shouldn't pay 7× the latency for a hint they may ignore.
     maxAttempts: 1,
   });
-  const durationMs = Date.now() - startTime;
-
-  // Report usage to session stats so /stats tracks suggestion model tokens
-  if (result.usage) {
-    reportSuggestionUsage(config, model, result.usage, durationMs);
-  }
 
   const text = result.text;
   if (text) {
@@ -355,39 +326,4 @@ export function getFilterReason(suggestion: string): string | null {
  */
 export function shouldFilterSuggestion(suggestion: string): boolean {
   return getFilterReason(suggestion) !== null;
-}
-
-/**
- * Report suggestion API usage to the UI telemetry service so it appears in /stats.
- */
-function reportSuggestionUsage(
-  config: Config,
-  model: string,
-  usage: {
-    promptTokenCount?: number;
-    candidatesTokenCount?: number;
-    totalTokenCount?: number;
-    cachedContentTokenCount?: number;
-    thoughtsTokenCount?: number;
-  },
-  durationMs: number,
-): void {
-  const event = new ApiResponseEvent(
-    'suggestion-' + Date.now(),
-    model,
-    durationMs,
-    'prompt_suggestion',
-    undefined,
-    {
-      promptTokenCount: usage.promptTokenCount ?? 0,
-      candidatesTokenCount: usage.candidatesTokenCount ?? 0,
-      totalTokenCount: usage.totalTokenCount ?? 0,
-      cachedContentTokenCount: usage.cachedContentTokenCount ?? 0,
-      thoughtsTokenCount: usage.thoughtsTokenCount ?? 0,
-    },
-  );
-  const uiEvent = Object.assign(event, {
-    'event.name': EVENT_API_RESPONSE as typeof EVENT_API_RESPONSE,
-  });
-  uiTelemetryService.addEvent(uiEvent, config.getSessionId());
 }


### PR DESCRIPTION
## What this PR does

Removes the `reportSuggestionUsage` function from the prompt suggestion generator. This function was creating a synthetic `ApiResponseEvent` and adding it directly to the UI telemetry service after each successful suggestion API call, using the raw `config.getFastModel()` value (e.g. `openai:qwen3.6-flash`) as the model name.

## Why it's needed

PR #3775 routed all side-query LLM calls — including prompt suggestions — through `runSideQuery` → `BaseLlmClient` → `LoggingContentGenerator`, which calls `logApiResponse()` → `uiTelemetryService.addEvent()` for every API response. This unified path already records suggestion usage in `/stats`, using the resolved model ID (e.g. `qwen3.6-flash` — without the authType prefix).

The older `reportSuggestionUsage` was never cleaned up. As a result, each successful suggestion call produced **two** entries in session metrics:

- `qwen3.6-flash` — from `logApiResponse` (resolved model ID, prefix stripped by `BaseLlmClient.resolveForModel()`)
- `openai:qwen3.6-flash` — from `reportSuggestionUsage` (raw `config.getFastModel()` value, prefix intact)

Both entries had identical token counts but different model name keys, inflating perceived request counts and splitting token attribution across two rows.

Verified with OpenAI interaction logs and live `/stats` output in a real session: the two rows shared the exact same token totals (e.g. 98,162 tokens each across 3 successful suggestion calls), confirming they were duplicate recordings of the same API calls.

## Reviewer Test Plan

### How to verify

1. Configure a `fastModel` with an authType prefix in `settings.json`, e.g. `"fastModel": "openai:qwen3.6-flash"`
2. Start a session, have at least 2 assistant turns (the minimum for suggestions to trigger)
3. Wait for a suggestion to appear in the input placeholder
4. Run `/stats` and check the model usage table
5. **Before this PR**: two separate rows appear for the same model — `qwen3.6-flash` and `openai:qwen3.6-flash` — with identical token counts
6. **After this PR**: only one row (`qwen3.6-flash`) appears, with the correct token count

### Evidence (Before & After)

**Before** (from a real session, `fastModel: "openai:qwen3.6-flash"` — suggestion call counted twice with different model names):

```
  模型使用情况                           请求  输入 token 数  输出 token 数
  ─────────────────────────────────────────────────────────────────────────
  glm-5.2 (main)                           72      4,105,722         16,656
  qwen3.6-flash (main)                      4         36,738             42
  qwen3.6-flash (Explore)                  33      2,248,994          5,470
  openai:qwen3.6-flash (main)               2         35,605              6
```

`qwen3.6-flash (main)` and `openai:qwen3.6-flash (main)` share the same suggestion API calls — verified via OpenAI interaction logs that token counts match exactly (14,861 + 20,744 = 35,605 input for the `openai:` row, same tokens counted again under `qwen3.6-flash`).

**After** (`npm run dev` with the fix, same `fastModel` config — only one row, no duplicate):

3 successful model turns (✦ 2, ✦ 4, ✦ 6), suggestion triggered (input placeholder shows `what is 4+4?`):

```
  指标                        glm-5.2                 qwen3.6-flash
  ──────────────────────────────────────────────────────────────────────────
  API
  请求数                      3                       3
  错误数                      0 (0.0%)                1 (33.3%)
  平均延迟                    1m 21s                  220ms

  Token
  总计                        68,724                  6,253
    ↳ 提示                    68,712                  6,217
    ↳ 缓存                    64,620 (94.0%)          965 (15.5%)
    ↳ 输出                    12                      36
```

Only `qwen3.6-flash` appears — no `openai:qwen3.6-flash` row. The 3 `qwen3.6-flash` requests are 1 session-title + 2 suggestion calls (1 succeeded, 1 failed). A follow-up suggestion ("what is 4+4?") is visible in the input placeholder, confirming suggestions were triggered.

<details>
<summary>Full tmux output</summary>

```
   ▄▄▄▄▄▄  ▄▄     ▄▄ ▄▄▄▄▄▄▄ ▄▄▄    ▄▄   ┌──────────────────────────────────────────────────────────┐
  ██╔═══██╗██║    ██║██╔════╝████╗  ██║  │ >_ Qwen Code (vdev)                                      │
  ██║   ██║██║ █╗ ██║█████╗  ██╔██╗ ██║  │                                                          │
  ██║▄▄ ██║██║███╗██║██╔══╝  ██║╚██╗██║  │ Token Plan | [ModelStudio Token Plan] glm-5.2            │
  ╚██████╔╝╚███╔███╔╝███████╗██║ ╚████║  │ ~/source/qwen-code                                       │
   ╚══▀▀═╝  ╚══╝╚══╝ ╚══════╝╚═╝  ╚═══╝  └──────────────────────────────────────────────────────────┘

  提示： 试试 /insight，从聊天记录中生成个性化洞察。
  ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
  > what is 1+1?
  ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀

  ✦ 2
  ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
  > what is 2+2?
  ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀

  ✦ 4
  ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
  > what is 3+3?
  ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀

  ✦ 6
  ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
  > /stats model
  ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀

  ╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
  │                                                                                                  │
  │  模型统计（技术细节）                                                                            │
  │                                                                                                  │
  │  指标                        glm-5.2                 qwen3.6-flash                               │
  │  ──────────────────────────────────────────────────────────────────────────────────────────────  │
  │  API                                                                                             │
  │  请求数                      3                       3                                           │
  │  错误数                      0 (0.0%)                1 (33.3%)                                   │
  │  平均延迟                    1m 21s                  220ms                                       │
  │                                                                                                  │
  │  Token                                                                                           │
  │  总计                        68,724                  6,253                                       │
  │    ↳ 提示                    68,712                  6,217                                       │
  │    ↳ 缓存                    64,620 (94.0%)          965 (15.5%)                                 │
  │    ↳ 输出                    12                      36                                          │
  │                                                                                                  │
  ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 回答简单数学问题 ──
* what is 4+4?
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  YOLO 模式 (Shift + Tab 切换)                                                                                                           2.3% 上下文已用
```

</details>

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |   N/A   |
|  🐧 Linux  |   N/A   |

### Environment

`npm run dev -- --approval-mode yolo` with custom model providers (OpenAI auth type, Token Plan base URL, `fastModel: "openai:qwen3.6-flash"`). Unit tests pass (`vitest run src/followup/suggestionGenerator.test.ts`).

## Risk & Scope

- Main risk or tradeoff: Suggestion token usage will no longer be reported via a synthetic event. It is still tracked through the standard `logApiResponse` path, which is the same mechanism used by all other API calls. No data is lost.
- Not validated / out of scope: Suggestion stats still disappear after session reload because `recordUiTelemetryEvent` is guarded by `isInternalPromptId` in `logApiResponse`. This is a separate issue that requires removing the guard and has broader implications for all internal prompts (session-title, auto-memory, etc.). A follow-up PR will address this.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5670

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

移除了 prompt suggestion 生成器中的 `reportSuggestionUsage` 函数。该函数在每次成功的 suggestion API 调用后，创建一个合成的 `ApiResponseEvent` 并直接添加到 UI telemetry 服务中，使用 `config.getFastModel()` 的原始值（如 `openai:qwen3.6-flash`）作为模型名。

## 为什么需要

PR #3775 将所有 side-query LLM 调用（包括 prompt suggestion）统一路由到 `runSideQuery` → `BaseLlmClient` → `LoggingContentGenerator`，后者通过 `logApiResponse()` → `uiTelemetryService.addEvent()` 记录每个 API 响应。这条统一路径已经用解析后的模型 ID（如 `qwen3.6-flash`，不含 authType 前缀）记录了 suggestion 的使用情况。

旧的 `reportSuggestionUsage` 未被清理。因此每次成功的 suggestion 调用在会话指标中产生**两条**记录：`qwen3.6-flash`（来自 `logApiResponse`）和 `openai:qwen3.6-flash`（来自 `reportSuggestionUsage`），token 数完全相同但模型名不同，导致请求数虚增、token 归属被拆分到两行。

通过 OpenAI 交互日志和实际会话的 `/stats` 输出验证：两行的 token 总数完全一致，确认是同一批 API 调用的重复记录。

## 验证步骤

1. 在 `settings.json` 中配置带 authType 前缀的 `fastModel`，如 `"fastModel": "openai:qwen3.6-flash"`
2. 启动会话，至少有 2 轮 assistant 回复（suggestion 触发的最低轮数）
3. 等待 suggestion 出现在输入框占位符中
4. 运行 `/stats` 检查模型使用表
5. **修改前**：同一模型出现两行——`qwen3.6-flash` 和 `openai:qwen3.6-flash`——token 数相同
6. **修改后**：只有一行 `qwen3.6-flash`，token 数正确

## 风险与范围

- 主要风险/权衡：suggestion 的 token 使用不再通过合成事件报告，但仍通过标准 `logApiResponse` 路径记录（与其他所有 API 调用相同）。不会丢失数据。
- 未验证/范围外：suggestion 统计在会话重载后仍会消失，因为 `logApiResponse` 中的 `recordUiTelemetryEvent` 受 `isInternalPromptId` 守卫。这是另一个问题，需要移除守卫并影响所有内部 prompt。后续 PR 将处理。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Fixes #5670

</details>
