### PR TITLE
fix(cli): skip unusable A2UI configs

### DIFF
--- a/packages/cli/src/serve/routes/a2ui-action.test.ts
+++ b/packages/cli/src/serve/routes/a2ui-action.test.ts
@@ -177,6 +177,50 @@ describe('POST /session/:id/a2ui-action', () => {
     expect(configs[0]).toEqual(STDIO_SERVER.config);
   });
 
+  it('skips unusable runtime configs and uses a later valid server', async () => {
+    const badConnected: McpServerCell = {
+      name: 'a2ui-bad',
+      mcpStatus: 'connected',
+      config: { httpUrl: 'not a url' },
+    };
+    const goodListed: McpServerCell = {
+      name: 'a2ui-good',
+      config: { command: 'node', args: ['good.mjs'] },
+    };
+    const { app, configs } = makeApp({
+      servers: [badConnected, goodListed],
+    });
+
+    await request(app)
+      .post('/session/s1/a2ui-action')
+      .send({ name: 'go' })
+      .expect(200);
+
+    expect(configs[0]).toEqual(goodListed.config);
+  });
+
+  it('skips mixed runtime configs with invalid httpUrl before stdio fallback', async () => {
+    const badMixed: McpServerCell = {
+      name: 'a2ui-bad-mixed',
+      mcpStatus: 'connected',
+      config: { command: 'node', httpUrl: 'not a url' },
+    };
+    const goodListed: McpServerCell = {
+      name: 'a2ui-good',
+      config: { command: 'node', args: ['good.mjs'] },
+    };
+    const { app, configs } = makeApp({
+      servers: [badMixed, goodListed],
+    });
+
+    await request(app)
+      .post('/session/s1/a2ui-action')
+      .send({ name: 'go' })
+      .expect(200);
+
+    expect(configs[0]).toEqual(goodListed.config);
+  });
+
   it('falls back to workspace settings when daemon status is unavailable', async () => {
     const ws = await fsp.mkdtemp(path.join(os.tmpdir(), 'a2ui-action-test-'));
     await fsp.mkdir(path.join(ws, '.qwen'), { recursive: true });
@@ -193,6 +237,30 @@ describe('POST /session/:id/a2ui-action', () => {
         .send({ name: 'go' })
         .expect(200);
       expect(configs[0]).toEqual({ command: 'node', args: ['x.mjs'] });
+    } finally {
+      await fsp.rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  it('skips unusable workspace settings configs during fallback', async () => {
+    const ws = await fsp.mkdtemp(path.join(os.tmpdir(), 'a2ui-action-test-'));
+    await fsp.mkdir(path.join(ws, '.qwen'), { recursive: true });
+    await fsp.writeFile(
+      path.join(ws, '.qwen', 'settings.json'),
+      JSON.stringify({
+        mcpServers: {
+          'bad-a2ui': { command: '' },
+          'good-a2ui': { httpUrl: 'https://example.com/mcp' },
+        },
+      }),
+    );
+    try {
+      const { app, configs } = makeApp({ serversError: true, workspace: ws });
+      await request(app)
+        .post('/session/s1/a2ui-action')
+        .send({ name: 'go' })
+        .expect(200);
+      expect(configs[0]).toEqual({ httpUrl: 'https://example.com/mcp' });
     } finally {
       await fsp.rm(ws, { recursive: true, force: true });
     }
@@ -322,7 +390,15 @@ describe('helpers', () => {
 
   it('usableServerConfig accepts stdio or streamable-http shapes only', () => {
     expect(usableServerConfig({ command: 'node' })).toBe(true);
+    expect(usableServerConfig({ command: '' })).toBe(false);
+    expect(usableServerConfig({ command: '   ' })).toBe(false);
+    expect(usableServerConfig({ httpUrl: 'http://x/mcp' })).toBe(true);
     expect(usableServerConfig({ httpUrl: 'https://x/mcp' })).toBe(true);
+    expect(usableServerConfig({ httpUrl: 'not a url' })).toBe(false);
+    expect(usableServerConfig({ httpUrl: 'ftp://x/mcp' })).toBe(false);
+    expect(usableServerConfig({ command: 'node', httpUrl: 'not a url' })).toBe(
+      false,
+    );
     expect(usableServerConfig({})).toBe(false);
     expect(usableServerConfig(undefined)).toBe(false);
   });

--- a/packages/cli/src/serve/routes/a2ui-action.ts
+++ b/packages/cli/src/serve/routes/a2ui-action.ts
@@ -90,10 +90,16 @@ interface RegisterA2uiActionRoutesOptions {
 
 /** Exported for unit testing. */
 export function usableServerConfig(cfg?: McpServerConfigLike): boolean {
-  return (
-    !!cfg &&
-    (typeof cfg.command === 'string' || typeof cfg.httpUrl === 'string')
-  );
+  if (!cfg) return false;
+  if (typeof cfg.httpUrl === 'string') {
+    try {
+      const parsed = new URL(cfg.httpUrl);
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    } catch {
+      return false;
+    }
+  }
+  return typeof cfg.command === 'string' && cfg.command.trim().length > 0;
 }
 
 /**


### PR DESCRIPTION
## What this PR does

Makes A2UI MCP server discovery skip unusable server configs before selecting a candidate for `POST /session/:id/a2ui-action`.

A config is now considered usable only when it has either a non-empty stdio `command` or a valid `http:` / `https:` streamable HTTP `httpUrl`. When `httpUrl` is present, discovery validates it the same way `buildTransport()` will use it, so mixed configs with an invalid `httpUrl` do not get selected just because they also include a `command`.

## Why it's needed

Before this change, discovery treated any string `httpUrl` or any string `command` as usable. A bad A2UI server entry such as `{ "httpUrl": "not a url" }`, `{ "command": "" }`, or `{ "command": "node", "httpUrl": "not a url" }` could be selected ahead of a later valid A2UI server. The route would then fail in the proxy path with `502` instead of skipping the unusable candidate.

This makes runtime MCP status discovery and workspace settings fallback more robust when stale or partially edited A2UI server configs exist.

## Reviewer Test Plan

### How to verify

Create a runtime A2UI server list where an unusable A2UI config appears before a valid one, then call `POST /session/:id/a2ui-action`. Confirm the route skips the bad candidate and uses the later valid config.

Repeat through the workspace settings fallback path by making daemon MCP status unavailable and placing a bad A2UI config before a valid one in `.qwen/settings.json`.

Confirm helper-level behavior: empty stdio commands, invalid URLs, non-http(s) URLs, and mixed `command` plus invalid `httpUrl` all return unusable.

### Evidence (Before & After)

Before: A bad A2UI config could be selected and cause `502`, even when a later valid A2UI server was available.

After: `npm test --workspace=packages/cli -- serve/routes/a2ui-action.test.ts` passes with 19 tests, including runtime discovery, settings fallback, and mixed invalid `httpUrl` regression coverage.

After: `npm test --workspace=packages/cli -- serve/routes` passes with 3 test files and 60 tests.

After: `npm run lint --workspace=packages/cli --if-present` passes.

After: `npx prettier --experimental-cli --check packages/cli/src/serve/routes/a2ui-action.ts packages/cli/src/serve/routes/a2ui-action.test.ts` passes.

After: `git diff --check` passes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS workspace with the repository npm dependencies installed.

## Risk & Scope

- Main risk or tradeoff: A2UI configs with an invalid `httpUrl` are now skipped even if they also contain a valid stdio `command`, because `buildTransport()` gives `httpUrl` precedence and would fail the same config at call time.
- Not validated / out of scope: Local Windows and Linux runs; no changes to legacy SSE `url` support, which remains intentionally unsupported in this route.
- Breaking changes / migration notes: No migration. Stale unusable A2UI configs are ignored during discovery instead of being selected and failing the request.

## Linked Issues

Fixes #5682

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

让 A2UI MCP server discovery 在为 `POST /session/:id/a2ui-action` 选择候选 server 之前跳过不可用的 server 配置。

现在只有包含非空 stdio `command`，或合法 `http:` / `https:` streamable HTTP `httpUrl` 的配置才会被视为可用。如果配置里存在 `httpUrl`，discovery 会按 `buildTransport()` 实际使用它的方式先校验它，因此带有无效 `httpUrl` 的混合配置不会因为同时有 `command` 就被选中。

## Why it's needed

在这个改动之前，discovery 会把任意字符串 `httpUrl` 或任意字符串 `command` 视为可用。像 `{ "httpUrl": "not a url" }`、`{ "command": "" }`，或者 `{ "command": "node", "httpUrl": "not a url" }` 这样的坏 A2UI server entry 可能会排在后续有效 A2UI server 前面并被选中。随后 route 会在 proxy path 中返回 `502`，而不是跳过这个不可用候选。

这个改动让 runtime MCP status discovery 和 workspace settings fallback 在存在过期或编辑到一半的 A2UI server 配置时更稳健。

## Reviewer Test Plan

### How to verify

构造一个 runtime A2UI server 列表，让不可用的 A2UI 配置排在有效配置之前，然后调用 `POST /session/:id/a2ui-action`。确认 route 会跳过坏候选并使用后面的有效配置。

通过 workspace settings fallback 路径重复验证：让 daemon MCP status 不可用，并在 `.qwen/settings.json` 中把坏 A2UI 配置放在有效配置前面。

确认 helper 层行为：空 stdio command、无效 URL、非 http(s) URL，以及 `command` 加无效 `httpUrl` 的混合配置都会被判断为不可用。

### Evidence (Before & After)

Before：坏 A2UI config 可能被选中并导致 `502`，即使后面还有有效 A2UI server。

After：`npm test --workspace=packages/cli -- serve/routes/a2ui-action.test.ts` 通过，19 个测试覆盖 runtime discovery、settings fallback，以及 mixed invalid `httpUrl` 回归场景。

After：`npm test --workspace=packages/cli -- serve/routes` 通过，3 个测试文件共 60 个测试。

After：`npm run lint --workspace=packages/cli --if-present` 通过。

After：`npx prettier --experimental-cli --check packages/cli/src/serve/routes/a2ui-action.ts packages/cli/src/serve/routes/a2ui-action.test.ts` 通过。

After：`git diff --check` 通过。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 macOS 工作区，已安装仓库 npm 依赖。

## Risk & Scope

- Main risk or tradeoff：带有无效 `httpUrl` 的 A2UI 配置现在会被跳过，即使它同时包含有效 stdio `command`；这是因为 `buildTransport()` 会优先使用 `httpUrl`，同一个配置在调用时也会失败。
- Not validated / out of scope：未在本地跑 Windows 和 Linux；没有改变 legacy SSE `url` 支持，该 route 仍然有意不支持它。
- Breaking changes / migration notes：没有迁移逻辑。过期的不可用 A2UI 配置会在 discovery 时被忽略，而不是被选中并让请求失败。

## Linked Issues

Fixes #5682

## AI Assistance Disclosure

我使用 Codex 来审查改动、对照现有模式做 sanity check，并帮助发现潜在边界情况。

</details>
