### PR TITLE
fix(cli): avoid duplicate ACP write BOM

### DIFF
--- a/packages/cli/src/acp-integration/service/filesystem.test.ts
+++ b/packages/cli/src/acp-integration/service/filesystem.test.ts
@@ -127,4 +127,114 @@ describe('AcpFileSystemService', () => {
       expect(client.readTextFile).not.toHaveBeenCalled();
     });
   });
+
+  describe('writeTextFile', () => {
+    it('writes through ACP with the session id', async () => {
+      const client = {
+        writeTextFile: vi.fn().mockResolvedValue(undefined),
+      } as unknown as AgentSideConnection;
+
+      const svc = new AcpFileSystemService(
+        client,
+        'session-4',
+        { readTextFile: true, writeTextFile: true },
+        createFallback(),
+      );
+
+      const result = await svc.writeTextFile({
+        path: '/some/file.txt',
+        content: 'hello',
+      });
+
+      expect(result).toEqual({ _meta: undefined });
+      expect(client.writeTextFile).toHaveBeenCalledWith({
+        path: '/some/file.txt',
+        content: 'hello',
+        sessionId: 'session-4',
+      });
+    });
+
+    it('preserves a UTF-8 BOM without duplicating an existing marker', async () => {
+      const client = {
+        writeTextFile: vi.fn().mockResolvedValue(undefined),
+      } as unknown as AgentSideConnection;
+
+      const svc = new AcpFileSystemService(
+        client,
+        'session-5',
+        { readTextFile: true, writeTextFile: true },
+        createFallback(),
+      );
+
+      await svc.writeTextFile({
+        path: '/some/file.txt',
+        content: '\uFEFFHello',
+        _meta: { bom: true },
+      });
+
+      expect(client.writeTextFile).toHaveBeenCalledWith({
+        path: '/some/file.txt',
+        content: '\uFEFFHello',
+        _meta: { bom: true },
+        sessionId: 'session-5',
+      });
+    });
+
+    it('adds a UTF-8 BOM marker when requested and missing', async () => {
+      const client = {
+        writeTextFile: vi.fn().mockResolvedValue(undefined),
+      } as unknown as AgentSideConnection;
+
+      const svc = new AcpFileSystemService(
+        client,
+        'session-6',
+        { readTextFile: true, writeTextFile: true },
+        createFallback(),
+      );
+
+      await svc.writeTextFile({
+        path: '/some/file.txt',
+        content: 'Hello',
+        _meta: { bom: true },
+      });
+
+      expect(client.writeTextFile).toHaveBeenCalledWith({
+        path: '/some/file.txt',
+        content: '\uFEFFHello',
+        _meta: { bom: true },
+        sessionId: 'session-6',
+      });
+    });
+
+    it('uses fallback when writeTextFile capability is disabled', async () => {
+      const client = {
+        writeTextFile: vi.fn(),
+      } as unknown as AgentSideConnection;
+      const fallback = createFallback();
+      (fallback.writeTextFile as ReturnType<typeof vi.fn>).mockResolvedValue({
+        _meta: { bom: true },
+      });
+
+      const svc = new AcpFileSystemService(
+        client,
+        'session-7',
+        { readTextFile: true, writeTextFile: false },
+        fallback,
+      );
+
+      const result = await svc.writeTextFile({
+        path: '/some/file.txt',
+        content: '\uFEFFHello',
+        _meta: { bom: true },
+      });
+
+      expect(result).toEqual({ _meta: { bom: true } });
+      expect(fallback.writeTextFile).toHaveBeenCalledWith({
+        path: '/some/file.txt',
+        content: '\uFEFFHello',
+        _meta: { bom: true },
+      });
+      expect(client.writeTextFile).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/cli/src/acp-integration/service/filesystem.ts
+++ b/packages/cli/src/acp-integration/service/filesystem.ts
@@ -80,9 +80,10 @@ export class AcpFileSystemService implements FileSystemService {
       return this.fallback.writeTextFile(params);
     }
 
-    const finalContent = params._meta?.['bom']
-      ? '\uFEFF' + params.content
-      : params.content;
+    const finalContent =
+      params._meta?.['bom'] && params.content.charCodeAt(0) !== 0xfeff
+        ? '\uFEFF' + params.content
+        : params.content;
 
     await this.connection.writeTextFile({
       ...params,


### PR DESCRIPTION
## What this PR does

Updates `AcpFileSystemService.writeTextFile()` so ACP file writes preserve a UTF-8 BOM without duplicating it when the content already starts with the BOM marker.

Adds write-path tests for ACP forwarding, BOM insertion, existing BOM preservation, and fallback behavior when the ACP write capability is disabled.

## Why it's needed

Before this change, the ACP adapter prepended `\uFEFF` whenever `_meta.bom` was true. If the content already started with `\uFEFF`, the adapter forwarded two BOM characters to the ACP client.

The local file system service already avoids this duplication when writing UTF-8 BOM files. This change keeps the ACP adapter consistent with that behavior.

## Reviewer Test Plan

### How to verify

Call `AcpFileSystemService.writeTextFile()` with `_meta: { bom: true }` and content that already starts with `\uFEFF`. Confirm the forwarded ACP `writeTextFile` request contains exactly one leading BOM marker.

Call it with `_meta: { bom: true }` and content without a BOM marker. Confirm the forwarded content gains one leading BOM marker.

Disable the ACP `writeTextFile` capability and confirm the fallback file system receives the original params unchanged.

### Evidence (Before & After)

Before: `_meta.bom: true` plus content starting with `\uFEFF` produced forwarded content starting with two BOM markers.

After: `npm test --workspace=packages/cli -- acp-integration/service/filesystem.test.ts` passes with 8 tests, including existing-BOM preservation and missing-BOM insertion coverage.

After: `npm test --workspace=packages/cli -- acp-integration/service acp-integration/acpAgent.test.ts` passes with 2 test files and 141 tests. The run emits existing EventEmitter max-listener warnings from the ACP agent test harness but all tests pass.

After: `npm run lint --workspace=packages/cli --if-present` passes.

After: `npx prettier --experimental-cli --check packages/cli/src/acp-integration/service/filesystem.ts packages/cli/src/acp-integration/service/filesystem.test.ts` passes.

After: `git diff --check` passes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS workspace with the repository npm dependencies installed.

## Risk & Scope

- Main risk or tradeoff: This only changes the ACP write adapter's BOM normalization when `_meta.bom` is true; fallback and non-BOM writes are unchanged.
- Not validated / out of scope: Local Windows and Linux runs; non-UTF-8 encoding behavior is owned by the underlying file system implementation and is not changed here.
- Breaking changes / migration notes: No migration. Existing duplicated BOM content already written to disk is not rewritten by this PR.

## Linked Issues

Fixes #5687

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

更新 `AcpFileSystemService.writeTextFile()`，让 ACP 文件写入在保留 UTF-8 BOM 时，如果内容已经以 BOM marker 开头，不再重复添加 BOM。

新增 write path 测试，覆盖 ACP 转发、BOM 插入、已有 BOM 保留，以及 ACP write capability 关闭时的 fallback 行为。

## Why it's needed

在这个改动之前，只要 `_meta.bom` 为 true，ACP adapter 就会 prepend `\uFEFF`。如果内容本身已经以 `\uFEFF` 开头，adapter 会向 ACP client 转发两个 BOM 字符。

本地 file system service 写 UTF-8 BOM 文件时已经避免了这种重复。本改动让 ACP adapter 与本地行为保持一致。

## Reviewer Test Plan

### How to verify

用 `_meta: { bom: true }` 且内容已经以 `\uFEFF` 开头调用 `AcpFileSystemService.writeTextFile()`。确认转发给 ACP `writeTextFile` 的请求只包含一个 leading BOM marker。

用 `_meta: { bom: true }` 且内容不带 BOM marker 调用它。确认转发内容会增加一个 leading BOM marker。

关闭 ACP `writeTextFile` capability，确认 fallback file system 收到的 params 保持原样。

### Evidence (Before & After)

Before：`_meta.bom: true` 加上以 `\uFEFF` 开头的内容，会产生以两个 BOM marker 开头的转发内容。

After：`npm test --workspace=packages/cli -- acp-integration/service/filesystem.test.ts` 通过，8 个测试覆盖已有 BOM 保留和缺失 BOM 插入。

After：`npm test --workspace=packages/cli -- acp-integration/service acp-integration/acpAgent.test.ts` 通过，2 个测试文件共 141 个测试。运行中会出现 ACP agent 测试 harness 里已有的 EventEmitter max-listener warning，但所有测试通过。

After：`npm run lint --workspace=packages/cli --if-present` 通过。

After：`npx prettier --experimental-cli --check packages/cli/src/acp-integration/service/filesystem.ts packages/cli/src/acp-integration/service/filesystem.test.ts` 通过。

After：`git diff --check` 通过。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 macOS 工作区，已安装仓库 npm 依赖。

## Risk & Scope

- Main risk or tradeoff：仅在 `_meta.bom` 为 true 时调整 ACP write adapter 的 BOM normalization；fallback 和非 BOM 写入不变。
- Not validated / out of scope：未在本地跑 Windows 和 Linux；非 UTF-8 编码行为由底层 file system implementation 负责，本 PR 不改动。
- Breaking changes / migration notes：没有迁移逻辑。已经写入磁盘的重复 BOM 内容不会被本 PR 重写。

## Linked Issues

Fixes #5687

## AI Assistance Disclosure

我使用 Codex 来审查改动、对照现有模式做 sanity check，并帮助发现潜在边界情况。

</details>
