### PR TITLE
fix(cli): enable /lsp in ACP mode

### DIFF
--- a/packages/cli/src/ui/commands/lspCommand.test.ts
+++ b/packages/cli/src/ui/commands/lspCommand.test.ts
@@ -22,6 +22,14 @@ const createConfig = ({
 });
 
 describe('lspCommand', () => {
+  it('declares ACP support for the status-only path', () => {
+    expect(lspCommand.supportedModes).toEqual([
+      'interactive',
+      'non_interactive',
+      'acp',
+    ]);
+  });
+
   it('returns an error when config is unavailable in non-interactive mode', async () => {
     if (!lspCommand.action) {
       throw new Error('lspCommand must have an action');
@@ -171,6 +179,40 @@ describe('lspCommand', () => {
       '| pyright | `pyright-langserver` | python | FAILED - startup failed |',
     );
     expect(result.content).not.toMatch(/[✅⏳❌⚪❓]/u);
+    expect(context.ui.addItem).not.toHaveBeenCalled();
+  });
+
+  it('returns server status as a message in ACP mode', async () => {
+    if (!lspCommand.action) {
+      throw new Error('lspCommand must have an action');
+    }
+    const context = createMockCommandContext({
+      executionMode: 'acp',
+      services: {
+        config: createConfig({
+          client: {
+            getServerStatus: vi.fn().mockReturnValue([
+              {
+                name: 'tsserver',
+                status: 'READY',
+                command: 'typescript-language-server',
+                languages: ['typescript'],
+              },
+            ]),
+          },
+        }) as unknown as never,
+      },
+    });
+
+    const result = await lspCommand.action(context, '');
+
+    expect(result).toMatchObject({
+      type: 'message',
+      messageType: 'info',
+      content: expect.stringContaining(
+        '| tsserver | `typescript-language-server` | typescript | READY |',
+      ),
+    });
     expect(context.ui.addItem).not.toHaveBeenCalled();
   });
 

--- a/packages/cli/src/ui/commands/lspCommand.ts
+++ b/packages/cli/src/ui/commands/lspCommand.ts
@@ -41,7 +41,7 @@ export const lspCommand: SlashCommand = {
     return t('Show LSP server status. Usage: /lsp [status]');
   },
   kind: CommandKind.BUILT_IN,
-  supportedModes: ['interactive', 'non_interactive'] as const,
+  supportedModes: ['interactive', 'non_interactive', 'acp'] as const,
   action: async (
     context: CommandContext,
     _args?: string,


### PR DESCRIPTION
## What this PR does

Adds ACP mode support to the existing status-only `/lsp` slash command by including `acp` in its `supportedModes`. The command already returns a message result outside interactive mode, so ACP can reuse the same non-UI status path.

Adds focused tests for the `/lsp` command mode contract and for the ACP execution path returning a message instead of writing to interactive UI history.

## Why it's needed

#5677 tracks several daemon/ACP slash-command gaps, and the triage there calls out `/lsp` as the narrow quick fix: the command already supports non-interactive status output, but ACP filtering rejects it because `acp` is missing from `supportedModes`.

With this change, remote/ACP clients can request LSP server status through `/lsp` instead of receiving an unsupported slash-command result.

## Reviewer Test Plan

### How to verify

Confirm `/lsp` is available to ACP command filtering when LSP is enabled, and that executing the command in ACP mode returns a `message` result without touching interactive UI history.

```bash
npm test --workspace=packages/cli -- ui/commands/lspCommand.test.ts
npm test --workspace=packages/cli -- services/BuiltinCommandLoader.test.ts
npm test --workspace=packages/cli -- nonInteractiveCliCommands.test.ts
npm run lint --workspace=packages/cli --if-present
npx prettier --check packages/cli/src/ui/commands/lspCommand.ts packages/cli/src/ui/commands/lspCommand.test.ts
git diff --check HEAD^..HEAD
```

I also ran:

```bash
npm run typecheck --workspace=packages/cli --if-present
```

That still fails on the existing unrelated `BaseTextInput.tsx` `ink/dom` type-resolution errors:

```text
src/ui/components/BaseTextInput.tsx(25,52): error TS2307: Cannot find module 'ink/dom' or its corresponding type declarations.
src/ui/components/BaseTextInput.tsx(26,27): error TS2307: Cannot find module 'ink/components/CursorContext' or its corresponding type declarations.
src/ui/components/BaseTextInput.tsx(310,9): error TS18046: 'cursorCtx' is of type 'unknown'.
src/ui/components/BaseTextInput.tsx(334,7): error TS18046: 'cursorCtx' is of type 'unknown'.
src/ui/components/BaseTextInput.tsx(341,7): error TS18046: 'cursorCtx' is of type 'unknown'.
```

### Evidence (Before & After)

Before: `/lsp` declared only `interactive` and `non_interactive`, so ACP slash-command filtering excluded it and ACP requests were rejected as unsupported.

After: `/lsp` declares `interactive`, `non_interactive`, and `acp`; the ACP-mode unit test verifies it returns LSP status as a message result and does not write through the interactive UI path.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️ not tested locally |
|  🐧 Linux  |   ⚠️ not tested locally |

### Environment (optional)

Local validation used the repository npm workspace scripts on macOS. Vitest coverage output is not safe to run concurrently in this workspace, so focused Vitest commands were rerun sequentially after an initial concurrent coverage-file race.

## Risk & Scope

- Main risk or tradeoff: Low; this only exposes an existing status-only command to ACP, and the command already uses a non-interactive message return path for non-UI modes.
- Not validated / out of scope: This does not add a structured LSP HTTP endpoint and does not address the other #5677 commands (`/cd`, `/permissions`, `/trust`, `/setup-github`). Full ACP session integration is left to CI; local coverage focused on command behavior and slash-command filtering.
- Breaking changes / migration notes: None.

## Linked Issues

Refs #5677

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

给现有的状态查询型 `/lsp` slash command 增加 ACP mode 支持，在 `supportedModes` 中加入 `acp`。该命令在非 interactive 模式下本来就会返回 message result，因此 ACP 可以复用同一条非 UI 的状态输出路径。

为 `/lsp` 命令的 mode 合同和 ACP 执行路径增加了聚焦测试，确认它在 ACP 下返回 message，而不是写入 interactive UI history。

## 为什么需要

#5677 跟踪了几个 daemon/ACP slash-command 缺口，其中 triage 明确指出 `/lsp` 是一个窄范围 quick fix：该命令已经支持 non-interactive 状态输出，但因为 `supportedModes` 缺少 `acp`，会被 ACP filtering 拒绝。

这个改动后，remote/ACP 客户端可以通过 `/lsp` 请求 LSP server status，而不是收到 unsupported slash-command result。

## Reviewer Test Plan

### How to verify

确认在启用 LSP 时 `/lsp` 能被 ACP command filtering 看到，并且在 ACP mode 执行时返回 `message` result，不会触碰 interactive UI history。

```bash
npm test --workspace=packages/cli -- ui/commands/lspCommand.test.ts
npm test --workspace=packages/cli -- services/BuiltinCommandLoader.test.ts
npm test --workspace=packages/cli -- nonInteractiveCliCommands.test.ts
npm run lint --workspace=packages/cli --if-present
npx prettier --check packages/cli/src/ui/commands/lspCommand.ts packages/cli/src/ui/commands/lspCommand.test.ts
git diff --check HEAD^..HEAD
```

我也运行了：

```bash
npm run typecheck --workspace=packages/cli --if-present
```

该命令仍然因为既有、无关的 `BaseTextInput.tsx` `ink/dom` 类型解析问题失败：

```text
src/ui/components/BaseTextInput.tsx(25,52): error TS2307: Cannot find module 'ink/dom' or its corresponding type declarations.
src/ui/components/BaseTextInput.tsx(26,27): error TS2307: Cannot find module 'ink/components/CursorContext' or its corresponding type declarations.
src/ui/components/BaseTextInput.tsx(310,9): error TS18046: 'cursorCtx' is of type 'unknown'.
src/ui/components/BaseTextInput.tsx(334,7): error TS18046: 'cursorCtx' is of type 'unknown'.
src/ui/components/BaseTextInput.tsx(341,7): error TS18046: 'cursorCtx' is of type 'unknown'.
```

### Evidence (Before & After)

Before：`/lsp` 只声明了 `interactive` 和 `non_interactive`，因此 ACP slash-command filtering 会排除它，ACP 请求会被拒绝为 unsupported。

After：`/lsp` 声明了 `interactive`、`non_interactive` 和 `acp`；ACP-mode 单测验证它会把 LSP status 作为 message result 返回，并且不会走 interactive UI 写入路径。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️ not tested locally |
|  🐧 Linux  |   ⚠️ not tested locally |

### Environment (optional)

本地验证使用 macOS 上的仓库 npm workspace scripts。这个 workspace 的 Vitest coverage 输出不能安全并发运行，所以最初遇到 coverage file race 后，focused Vitest 命令都已顺序重跑。

## Risk & Scope

- Main risk or tradeoff：低；本 PR 只是把一个现有的状态查询命令暴露给 ACP，并且该命令已经为非 UI 模式使用 message return path。
- Not validated / out of scope：本 PR 不新增结构化 LSP HTTP endpoint，也不处理 #5677 中的其他命令（`/cd`、`/permissions`、`/trust`、`/setup-github`）。完整 ACP session integration 留给 CI；本地验证聚焦在 command behavior 和 slash-command filtering。
- Breaking changes / migration notes：无。

## Linked Issues

Refs #5677

## AI Assistance Disclosure

我使用 Codex 审查改动、对照现有模式做 sanity check，并帮助发现潜在边界情况。

</details>
