### PR TITLE
fix(core): require integer LSP maxRestarts

### DIFF
--- a/docs/users/features/lsp.md
+++ b/docs/users/features/lsp.md
@@ -122,7 +122,7 @@ Example:
 | `startupTimeout`        | number   | `10000`   | Startup timeout in milliseconds                         |
 | `shutdownTimeout`       | number   | `5000`    | Shutdown timeout in milliseconds                        |
 | `restartOnCrash`        | boolean  | `false`   | Auto-restart on crash                                   |
-| `maxRestarts`           | number   | `3`       | Maximum restart attempts                                |
+| `maxRestarts`           | integer  | `3`       | Maximum restart attempts (non-negative)                 |
 | `trustRequired`         | boolean  | `true`    | Require trusted workspace                               |
 
 ### TCP/Socket Transport

--- a/packages/core/src/lsp/LspConfigLoader.test.ts
+++ b/packages/core/src/lsp/LspConfigLoader.test.ts
@@ -154,6 +154,44 @@ describe('LspConfigLoader config-driven behavior', () => {
       mock.restore();
     }
   });
+
+  it('rejects fractional maxRestarts from .lsp.json', async () => {
+    mock({
+      [workspaceRoot]: {
+        '.lsp.json': JSON.stringify({
+          typescript: {
+            command: 'typescript-language-server',
+            maxRestarts: 1.5,
+          },
+        }),
+      },
+    });
+
+    const loader = new LspConfigLoader(workspaceRoot);
+    const configs = await loader.loadUserConfigs();
+
+    expect(configs).toHaveLength(1);
+    expect(configs[0]?.maxRestarts).toBeUndefined();
+  });
+
+  it('accepts integer maxRestarts from .lsp.json', async () => {
+    mock({
+      [workspaceRoot]: {
+        '.lsp.json': JSON.stringify({
+          typescript: {
+            command: 'typescript-language-server',
+            maxRestarts: 2,
+          },
+        }),
+      },
+    });
+
+    const loader = new LspConfigLoader(workspaceRoot);
+    const configs = await loader.loadUserConfigs();
+
+    expect(configs).toHaveLength(1);
+    expect(configs[0]?.maxRestarts).toBe(2);
+  });
 });
 
 describe('LspConfigLoader extension configs', () => {

--- a/packages/core/src/lsp/LspConfigLoader.ts
+++ b/packages/core/src/lsp/LspConfigLoader.ts
@@ -363,7 +363,7 @@ export class LspConfigLoader {
     if (typeof value !== 'number') {
       return undefined;
     }
-    if (!Number.isFinite(value) || value < 0) {
+    if (!Number.isSafeInteger(value) || value < 0) {
       return undefined;
     }
     return value;


### PR DESCRIPTION
## What this PR does

Updates LSP config normalization so `maxRestarts` is only accepted when it is a non-negative safe integer. Fractional values now fall back to the default restart limit path instead of being preserved as a configured restart count.

This also adds loader tests for rejecting `maxRestarts: 1.5`, preserving integer values such as `maxRestarts: 2`, and updates the user docs to describe `maxRestarts` as a non-negative integer.

## Why it's needed

`maxRestarts` represents a count of restart attempts. The runtime checks `restartAttempts >= maxRestarts`, so a fractional value like `1.5` effectively allows two restart attempts. Accepting fractional restart counts is ambiguous and can make the server restart more times than the config appears to allow.

## Reviewer Test Plan

### How to verify

Review the new loader tests or run the commands below. The important behavior is that `maxRestarts: 1.5` is ignored by config normalization, while valid integer values such as `0` and `2` remain allowed.

- `npm test --workspace=packages/core -- lsp/LspConfigLoader.test.ts`
- `npm test --workspace=packages/core -- lsp`
- `npm run lint --workspace=packages/core --if-present`
- `npm run typecheck --workspace=packages/core --if-present`
- `npx prettier --check packages/core/src/lsp/LspConfigLoader.ts packages/core/src/lsp/LspConfigLoader.test.ts docs/users/features/lsp.md`
- `git diff --check`

### Evidence (Before & After)

N/A for UI evidence.

Before: `.lsp.json` could preserve a fractional value such as `maxRestarts: 1.5`, which made the runtime threshold ambiguous.

After: fractional `maxRestarts` values are normalized away, while non-negative integer values are preserved. This is covered by the focused loader test and the broader core LSP test run.

### Tested on

|     OS     | Status        |
| :--------: | :-----------: |
|  🍏 macOS  | ✅ tested     |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS workspace with the repository npm toolchain.

## Risk & Scope

- Main risk or tradeoff: A previously accepted fractional `maxRestarts` value is now ignored and falls back to the default behavior. That is intentional because fractional restart attempts do not have a clear meaning.
- Not validated / out of scope: I did not manually launch an LSP server process for this change; the normalization behavior is covered at the loader layer.
- Breaking changes / migration notes: No expected breaking change for valid configs. Users with fractional `maxRestarts` should change it to a non-negative integer.

## Linked Issues

Fixes #5690

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

更新 LSP 配置归一化逻辑，使 `maxRestarts` 只有在非负安全整数时才会被接受。小数值现在会回退到默认重启次数路径，而不是被保留为已配置的重启次数。

同时新增 loader 测试，覆盖拒绝 `maxRestarts: 1.5`、保留 `maxRestarts: 2` 等整数值，并更新用户文档，将 `maxRestarts` 描述为非负整数。

## 为什么需要

`maxRestarts` 表示重启尝试次数。运行时使用 `restartAttempts >= maxRestarts` 做判断，因此像 `1.5` 这样的小数值实际会允许两次重启尝试。接受小数重启次数语义不清晰，也可能让服务器重启次数超过配置看起来允许的次数。

## Reviewer Test Plan

### How to verify

查看新增的 loader 测试，或运行下面的命令。关键行为是：`maxRestarts: 1.5` 会被配置归一化忽略，而 `0`、`2` 等合法整数值仍然允许。

- `npm test --workspace=packages/core -- lsp/LspConfigLoader.test.ts`
- `npm test --workspace=packages/core -- lsp`
- `npm run lint --workspace=packages/core --if-present`
- `npm run typecheck --workspace=packages/core --if-present`
- `npx prettier --check packages/core/src/lsp/LspConfigLoader.ts packages/core/src/lsp/LspConfigLoader.test.ts docs/users/features/lsp.md`
- `git diff --check`

### Evidence (Before & After)

UI 证据不适用。

修改前：`.lsp.json` 可以保留 `maxRestarts: 1.5` 这样的小数值，导致运行时阈值语义不清晰。

修改后：小数 `maxRestarts` 会被归一化移除，非负整数值仍会保留。这个行为已由聚焦的 loader 测试和更宽的 core LSP 测试覆盖。

### Tested on

|     OS     | Status        |
| :--------: | :-----------: |
|  🍏 macOS  | ✅ tested     |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 macOS 工作区，使用仓库的 npm 工具链。

## Risk & Scope

- 主要风险或取舍：之前被接受的小数 `maxRestarts` 现在会被忽略并回退到默认行为。这是有意的，因为小数重启次数没有清晰含义。
- 未验证 / 不在范围内：本次修改没有手动启动 LSP server 进程；归一化行为已在 loader 层覆盖。
- 破坏性变更 / 迁移说明：对合法配置没有预期破坏性变更。使用小数 `maxRestarts` 的用户应改为非负整数。

## Linked Issues

修复 #5690

## AI Assistance Disclosure

我使用 Codex 审查改动、对照现有模式做 sanity-check，并帮助发现潜在边界情况。

</details>
