### PR TITLE
fix(core): require integer read_file ranges

### DIFF
--- a/docs/developers/tools/file-system.md
+++ b/docs/developers/tools/file-system.md
@@ -31,8 +31,8 @@ Qwen Code provides a comprehensive suite of tools for interacting with the local
 - **File:** `read-file.ts`
 - **Parameters:**
   - `path` (string, required): The absolute path to the file to read.
-  - `offset` (number, optional): For text files, the 0-based line number to start reading from. Requires `limit` to be set.
-  - `limit` (number, optional): For text files, the maximum number of lines to read. If omitted, reads a default maximum (e.g., 2000 lines) or the entire file if feasible.
+  - `offset` (integer, optional): For text files, the 0-based line number to start reading from. Requires `limit` to be set.
+  - `limit` (integer, optional): For text files, the maximum number of lines to read. If omitted, reads a default maximum (e.g., 2000 lines) or the entire file if feasible.
 - **Behavior:**
   - For text files: Returns the content. If `offset` and `limit` are used, returns only that slice of lines. Indicates if content was truncated due to line limits or line length limits.
   - For media files (images, PDFs, audio, video): If the current model supports the file's modality, returns the file content as a base64-encoded `inlineData` object. If the model does not support the modality, returns an error message with guidance (e.g., suggesting skills or external tools).

--- a/packages/core/src/tools/read-file.test.ts
+++ b/packages/core/src/tools/read-file.test.ts
@@ -145,7 +145,25 @@ describe('ReadFileTool', () => {
         offset: -1,
       };
       expect(() => tool.build(params)).toThrow(
-        'Offset must be a non-negative number',
+        'Offset must be a non-negative integer',
+      );
+    });
+
+    it('should throw error if offset is fractional', () => {
+      const params: ReadFileToolParams = {
+        file_path: path.join(tempRootDir, 'test.txt'),
+        offset: 1.5,
+      };
+      expect(() => tool.build(params)).toThrow('params/offset must be integer');
+    });
+
+    it('should throw error if offset exceeds the safe integer range', () => {
+      const params: ReadFileToolParams = {
+        file_path: path.join(tempRootDir, 'test.txt'),
+        offset: Number.MAX_SAFE_INTEGER + 1,
+      };
+      expect(() => tool.build(params)).toThrow(
+        'Offset must be a non-negative integer',
       );
     });
 
@@ -155,7 +173,25 @@ describe('ReadFileTool', () => {
         limit: 0,
       };
       expect(() => tool.build(params)).toThrow(
-        'Limit must be a positive number',
+        'Limit must be a positive integer',
+      );
+    });
+
+    it('should throw error if limit is fractional', () => {
+      const params: ReadFileToolParams = {
+        file_path: path.join(tempRootDir, 'test.txt'),
+        limit: 2.5,
+      };
+      expect(() => tool.build(params)).toThrow('params/limit must be integer');
+    });
+
+    it('should throw error if limit exceeds the safe integer range', () => {
+      const params: ReadFileToolParams = {
+        file_path: path.join(tempRootDir, 'test.txt'),
+        limit: Number.MAX_SAFE_INTEGER + 1,
+      };
+      expect(() => tool.build(params)).toThrow(
+        'Limit must be a positive integer',
       );
     });
 

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -404,12 +404,12 @@ export class ReadFileTool extends BaseDeclarativeTool<
           offset: {
             description:
               "Optional: For text files, the 0-based line number to start reading from. Requires 'limit' to be set. Use for paginating through large files.",
-            type: 'number',
+            type: 'integer',
           },
           limit: {
             description:
               "Optional: For text files, maximum number of lines to read. Use with 'offset' to paginate through large files. If omitted, reads the entire file (if feasible, up to a default limit).",
-            type: 'number',
+            type: 'integer',
           },
           pages: {
             description:
@@ -439,11 +439,17 @@ export class ReadFileTool extends BaseDeclarativeTool<
       return `File path must be absolute, but was relative: ${filePath}. You must provide an absolute path.`;
     }
 
-    if (params.offset !== undefined && params.offset < 0) {
-      return 'Offset must be a non-negative number';
+    if (
+      params.offset !== undefined &&
+      (!Number.isSafeInteger(params.offset) || params.offset < 0)
+    ) {
+      return 'Offset must be a non-negative integer';
     }
-    if (params.limit !== undefined && params.limit <= 0) {
-      return 'Limit must be a positive number';
+    if (
+      params.limit !== undefined &&
+      (!Number.isSafeInteger(params.limit) || params.limit <= 0)
+    ) {
+      return 'Limit must be a positive integer';
     }
 
     if (params.pages !== undefined) {


### PR DESCRIPTION
## What this PR does

Tightens `read_file` range parameters so `offset` and `limit` are treated as integer line indexes/counts instead of generic numbers.

The tool schema now declares both fields as `integer`, the value validation rejects unsafe integers, and the developer tool docs now describe both parameters as integers. Focused tests cover fractional values, unsafe integer values, and the existing negative/zero validation paths.

## Why it's needed

`offset` is a 0-based line number and `limit` is a line count. Before this change, fractional values such as `offset: 1.5` or `limit: 2.5` could pass the tool-level validation and reach the file-reading path. JavaScript array slicing coerces those fractional indexes internally, which can make the actual lines read disagree with the tool description and location metadata.

## Reviewer Test Plan

### How to verify

Review the new `ReadFileTool` tests or run the commands below. The important behavior is that fractional `offset` / `limit` values are rejected before execution, valid integer pagination still works, and unsafe integer values do not reach the underlying slice logic.

- `npm test --workspace=packages/core -- tools/read-file.test.ts`
- `npm test --workspace=packages/core -- tools/read-file.test.ts services/fileSystemService.test.ts`
- `npm run lint --workspace=packages/core --if-present`
- `npm run typecheck --workspace=packages/core --if-present`
- `npx prettier --check packages/core/src/tools/read-file.ts packages/core/src/tools/read-file.test.ts docs/developers/tools/file-system.md`
- `git diff --check`

### Evidence (Before & After)

N/A for UI evidence.

Before: `read_file` accepted fractional range values as schema-valid numbers, and those values could reach the lower-level file slicing path.

After: `read_file` declares `offset` and `limit` as integer schema fields, rejects fractional values during schema validation, and also rejects unsafe integers in tool validation.

### Tested on

|     OS     | Status        |
| :--------: | :-----------: |
|  🍏 macOS  | ✅ tested     |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS workspace with the repository npm toolchain.

## Risk & Scope

- Main risk or tradeoff: Existing callers that pass fractional `offset` or `limit` values will now get a validation error. That is intentional because line ranges are integer-only.
- Not validated / out of scope: I did not run a full repository test suite; validation focused on `read_file`, the file system service, and core lint/typecheck.
- Breaking changes / migration notes: No expected breaking change for valid `read_file` calls. Fractional range parameters should be changed to integers.

## Linked Issues

Fixes #5692

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

收紧 `read_file` 的范围参数，让 `offset` 和 `limit` 按整数行号 / 行数处理，而不是普通 number。

工具 schema 现在把这两个字段声明为 `integer`，值校验会拒绝不安全整数，开发者工具文档也把这两个参数描述为整数。聚焦测试覆盖了小数值、不安全整数，以及已有的负数 / 零值校验路径。

## 为什么需要

`offset` 是 0-based 行号，`limit` 是行数。修改前，`offset: 1.5` 或 `limit: 2.5` 这样的小数值可以通过工具层校验并进入文件读取路径。JavaScript 的数组 slice 会在内部转换这些小数索引，导致实际读取的行可能和工具描述、位置元数据不一致。

## Reviewer Test Plan

### How to verify

查看新增的 `ReadFileTool` 测试，或运行下面的命令。关键行为是：小数 `offset` / `limit` 会在执行前被拒绝，合法整数分页仍然正常工作，不安全整数不会进入底层 slice 逻辑。

- `npm test --workspace=packages/core -- tools/read-file.test.ts`
- `npm test --workspace=packages/core -- tools/read-file.test.ts services/fileSystemService.test.ts`
- `npm run lint --workspace=packages/core --if-present`
- `npm run typecheck --workspace=packages/core --if-present`
- `npx prettier --check packages/core/src/tools/read-file.ts packages/core/src/tools/read-file.test.ts docs/developers/tools/file-system.md`
- `git diff --check`

### Evidence (Before & After)

UI 证据不适用。

修改前：`read_file` 会把小数范围值作为 schema 合法的 number 接受，这些值可能进入更底层的文件切片路径。

修改后：`read_file` 把 `offset` 和 `limit` 声明为 integer schema 字段，在 schema 校验阶段拒绝小数，并在工具值校验中拒绝不安全整数。

### Tested on

|     OS     | Status        |
| :--------: | :-----------: |
|  🍏 macOS  | ✅ tested     |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 macOS 工作区，使用仓库的 npm 工具链。

## Risk & Scope

- 主要风险或取舍：现有调用方如果传入小数 `offset` 或 `limit`，现在会得到校验错误。这是有意的，因为行范围只能是整数。
- 未验证 / 不在范围内：没有运行完整仓库测试；验证聚焦在 `read_file`、file system service，以及 core lint/typecheck。
- 破坏性变更 / 迁移说明：对合法的 `read_file` 调用没有预期破坏性变更。小数范围参数应改为整数。

## Linked Issues

修复 #5692

## AI Assistance Disclosure

我使用 Codex 审查改动、对照现有模式做 sanity-check，并帮助发现潜在边界情况。

</details>
