### PR TITLE
fix(core): require integer LSP tool positions

### DIFF
--- a/packages/core/src/tools/lsp.test.ts
+++ b/packages/core/src/tools/lsp.test.ts
@@ -210,6 +210,28 @@ describe('LspTool', () => {
         } as LspToolParams);
         expect(result).toBeNull();
       });
+
+      it('rejects fractional callHierarchyItem positions', () => {
+        const item: LspCallHierarchyItem = {
+          name: 'testFunc',
+          uri: 'file:///test.ts',
+          range: {
+            start: { line: 0.5, character: 0 },
+            end: { line: 0, character: 10 },
+          },
+          selectionRange: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 10 },
+          },
+        };
+        const result = tool.validateToolParams({
+          operation: 'incomingCalls',
+          callHierarchyItem: item,
+        } as LspToolParams);
+        expect(result).toBe(
+          'params/callHierarchyItem/range/start/line must be integer',
+        );
+      });
     });
 
     describe('numeric parameter validation', () => {
@@ -219,7 +241,7 @@ describe('LspTool', () => {
           filePath: 'src/app.ts',
           line: 0,
         } as LspToolParams);
-        expect(result).toBe('line must be a positive number.');
+        expect(result).toBe('line must be a positive integer.');
       });
 
       it('rejects negative line', () => {
@@ -228,7 +250,25 @@ describe('LspTool', () => {
           filePath: 'src/app.ts',
           line: -1,
         } as LspToolParams);
-        expect(result).toBe('line must be a positive number.');
+        expect(result).toBe('line must be a positive integer.');
+      });
+
+      it('rejects fractional line', () => {
+        const result = tool.validateToolParams({
+          operation: 'goToDefinition',
+          filePath: 'src/app.ts',
+          line: 1.5,
+        } as LspToolParams);
+        expect(result).toBe('params/line must be integer');
+      });
+
+      it('rejects unsafe integer line', () => {
+        const result = tool.validateToolParams({
+          operation: 'goToDefinition',
+          filePath: 'src/app.ts',
+          line: Number.MAX_SAFE_INTEGER + 1,
+        } as LspToolParams);
+        expect(result).toBe('line must be a positive integer.');
       });
 
       it('rejects non-positive character', () => {
@@ -238,7 +278,41 @@ describe('LspTool', () => {
           line: 1,
           character: 0,
         } as LspToolParams);
-        expect(result).toBe('character must be a positive number.');
+        expect(result).toBe('character must be a positive integer.');
+      });
+
+      it('rejects fractional character', () => {
+        const result = tool.validateToolParams({
+          operation: 'goToDefinition',
+          filePath: 'src/app.ts',
+          line: 1,
+          character: 1.5,
+        } as LspToolParams);
+        expect(result).toBe('params/character must be integer');
+      });
+
+      it('rejects fractional range end positions', () => {
+        const result = tool.validateToolParams({
+          operation: 'codeActions',
+          filePath: 'src/app.ts',
+          line: 1,
+          character: 1,
+          endLine: 2.5,
+          endCharacter: 3.5,
+        } as LspToolParams);
+        expect(result).toBe('params/endLine must be integer');
+      });
+
+      it('rejects fractional end character', () => {
+        const result = tool.validateToolParams({
+          operation: 'codeActions',
+          filePath: 'src/app.ts',
+          line: 1,
+          character: 1,
+          endLine: 2,
+          endCharacter: 3.5,
+        } as LspToolParams);
+        expect(result).toBe('params/endCharacter must be integer');
       });
 
       it('rejects non-positive limit', () => {
@@ -247,7 +321,16 @@ describe('LspTool', () => {
           filePath: 'src/app.ts',
           limit: 0,
         } as LspToolParams);
-        expect(result).toBe('limit must be a positive number.');
+        expect(result).toBe('limit must be a positive integer.');
+      });
+
+      it('rejects fractional limit', () => {
+        const result = tool.validateToolParams({
+          operation: 'documentSymbol',
+          filePath: 'src/app.ts',
+          limit: 2.5,
+        } as LspToolParams);
+        expect(result).toBe('params/limit must be integer');
       });
     });
 
@@ -913,27 +996,7 @@ describe('LspTool', () => {
     });
   });
 
-  describe('schema compatibility with Claude Code', () => {
-    /**
-     * Claude Code LSP tool schema reference:
-     * {
-     *   "name": "lsp",
-     *   "input_schema": {
-     *     "type": "object",
-     *     "properties": {
-     *       "operation": { "type": "string", "enum": [...] },
-     *       "filePath": { "type": "string" },
-     *       "line": { "type": "number" },
-     *       "character": { "type": "number" },
-     *       "includeDeclaration": { "type": "boolean" },
-     *       "query": { "type": "string" },
-     *       "callHierarchyItem": { ... }
-     *     },
-     *     "required": ["operation"]
-     *   }
-     * }
-     */
-
+  describe('schema shape', () => {
     it('has correct tool name', () => {
       const tool = createTool();
       expect(tool.schema.name).toBe('lsp');
@@ -1048,8 +1111,22 @@ describe('LspTool', () => {
           character?: { type?: string };
         };
       };
-      expect(schema.properties?.line?.type).toBe('number');
-      expect(schema.properties?.character?.type).toBe('number');
+      expect(schema.properties?.line?.type).toBe('integer');
+      expect(schema.properties?.character?.type).toBe('integer');
+    });
+
+    it('range and limit extension properties have integer type', () => {
+      const tool = createTool();
+      const schema = tool.schema.parametersJsonSchema as {
+        properties?: {
+          endLine?: { type?: string };
+          endCharacter?: { type?: string };
+          limit?: { type?: string };
+        };
+      };
+      expect(schema.properties?.endLine?.type).toBe('integer');
+      expect(schema.properties?.endCharacter?.type).toBe('integer');
+      expect(schema.properties?.limit?.type).toBe('integer');
     });
 
     it('includeDeclaration property has correct type', () => {
@@ -1121,8 +1198,8 @@ describe('LspTool', () => {
         const posDef = schema.definitions?.LspPosition;
         expect(posDef).toBeDefined();
         expect(posDef?.type).toBe('object');
-        expect(posDef?.properties?.line?.type).toBe('number');
-        expect(posDef?.properties?.character?.type).toBe('number');
+        expect(posDef?.properties?.line?.type).toBe('integer');
+        expect(posDef?.properties?.character?.type).toBe('integer');
         expect(posDef?.required).toEqual(['line', 'character']);
       });
 

--- a/packages/core/src/tools/lsp.ts
+++ b/packages/core/src/tools/lsp.ts
@@ -1047,20 +1047,20 @@ export class LspTool extends BaseDeclarativeTool<LspToolParams, ToolResult> {
             description: 'File path (absolute or workspace-relative).',
           },
           line: {
-            type: 'number',
+            type: 'integer',
             description: '1-based line number for the target location.',
           },
           character: {
-            type: 'number',
+            type: 'integer',
             description:
               '1-based character/column number for the target location.',
           },
           endLine: {
-            type: 'number',
+            type: 'integer',
             description: '1-based end line number for range-based operations.',
           },
           endCharacter: {
-            type: 'number',
+            type: 'integer',
             description: '1-based end character for range-based operations.',
           },
           includeDeclaration: {
@@ -1081,7 +1081,7 @@ export class LspTool extends BaseDeclarativeTool<LspToolParams, ToolResult> {
             description: 'Optional LSP server name to target.',
           },
           limit: {
-            type: 'number',
+            type: 'integer',
             description: 'Optional maximum number of results to return.',
           },
           diagnostics: {
@@ -1101,8 +1101,8 @@ export class LspTool extends BaseDeclarativeTool<LspToolParams, ToolResult> {
           LspPosition: {
             type: 'object',
             properties: {
-              line: { type: 'number' },
-              character: { type: 'number' },
+              line: { type: 'integer' },
+              character: { type: 'integer' },
             },
             required: ['line', 'character'],
           },
@@ -1200,20 +1200,35 @@ export class LspTool extends BaseDeclarativeTool<LspToolParams, ToolResult> {
       }
     }
 
-    if (params.line !== undefined && params.line < 1) {
-      return 'line must be a positive number.';
+    if (
+      params.line !== undefined &&
+      (!Number.isSafeInteger(params.line) || params.line < 1)
+    ) {
+      return 'line must be a positive integer.';
     }
-    if (params.character !== undefined && params.character < 1) {
-      return 'character must be a positive number.';
+    if (
+      params.character !== undefined &&
+      (!Number.isSafeInteger(params.character) || params.character < 1)
+    ) {
+      return 'character must be a positive integer.';
     }
-    if (params.endLine !== undefined && params.endLine < 1) {
-      return 'endLine must be a positive number.';
+    if (
+      params.endLine !== undefined &&
+      (!Number.isSafeInteger(params.endLine) || params.endLine < 1)
+    ) {
+      return 'endLine must be a positive integer.';
     }
-    if (params.endCharacter !== undefined && params.endCharacter < 1) {
-      return 'endCharacter must be a positive number.';
+    if (
+      params.endCharacter !== undefined &&
+      (!Number.isSafeInteger(params.endCharacter) || params.endCharacter < 1)
+    ) {
+      return 'endCharacter must be a positive integer.';
     }
-    if (params.limit !== undefined && params.limit <= 0) {
-      return 'limit must be a positive number.';
+    if (
+      params.limit !== undefined &&
+      (!Number.isSafeInteger(params.limit) || params.limit <= 0)
+    ) {
+      return 'limit must be a positive integer.';
     }
 
     return null;


### PR DESCRIPTION
## What this PR does

Tightens the LSP tool schema and validation so LSP positions and result limits use integer values instead of generic numbers.

Top-level `line`, `character`, `endLine`, `endCharacter`, and `limit` now use `integer` schema types. Nested `LspPosition` values used by call hierarchy items and diagnostics are also integer-typed. Tool-level validation now rejects unsafe integer values before they can reach LSP client calls or array slicing.

## Why it's needed

LSP positions and result counts are integer concepts. Before this change, fractional values such as `line: 1.5`, `endCharacter: 3.5`, or `limit: 2.5` could pass schema validation. Some paths floored those values, some passed them through to LSP ranges, and `limit` was also used with `slice(0, limit)`, making the behavior ambiguous.

## Reviewer Test Plan

### How to verify

Review the new `LspTool` validation tests or run the commands below. The key behavior is that fractional top-level positions, fractional nested `LspPosition` values, fractional limits, and unsafe integer positions are rejected before execution, while existing positive-integer calls remain valid.

- `npm test --workspace=packages/core -- tools/lsp.test.ts`
- `npm run lint --workspace=packages/core --if-present`
- `npm run typecheck --workspace=packages/core --if-present`
- `npx prettier --check packages/core/src/tools/lsp.ts packages/core/src/tools/lsp.test.ts`
- `git diff --check`

### Evidence (Before & After)

N/A for UI evidence.

Before: LSP position and limit fields were declared as `number`, so fractional values could validate and then be floored, passed to LSP ranges, or used as slice limits depending on the operation path.

After: LSP position and limit fields are declared as `integer`, fractional values fail schema validation, and unsafe integers fail tool value validation.

### Tested on

|     OS     | Status        |
| :--------: | :-----------: |
|  🍏 macOS  | ✅ tested     |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS workspace with the repository npm toolchain.

## Risk & Scope

- Main risk or tradeoff: Existing callers that send fractional LSP positions or limits will now receive a validation error. That is intentional because these fields are integer-only.
- Not validated / out of scope: I did not manually connect to a real language server; this is a schema and validation fix covered by focused LSP tool tests.
- Breaking changes / migration notes: No expected breaking change for valid LSP tool calls. Fractional position or limit values should be changed to integers.

## Linked Issues

Fixes #5694

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

收紧 LSP tool 的 schema 和校验，让 LSP 位置参数和结果数量使用整数，而不是普通 number。

顶层 `line`、`character`、`endLine`、`endCharacter` 和 `limit` 现在使用 `integer` schema 类型。call hierarchy item 和 diagnostics 中复用的嵌套 `LspPosition` 也改为 integer。工具层校验现在会拒绝不安全整数，避免这些值进入 LSP client 调用或数组 slice。

## 为什么需要

LSP 位置和结果数量本身都是整数概念。修改前，`line: 1.5`、`endCharacter: 3.5` 或 `limit: 2.5` 这样的小数值可以通过 schema 校验。有些路径会对这些值取 floor，有些路径会直接传给 LSP range，`limit` 还会用于 `slice(0, limit)`，行为不够明确。

## Reviewer Test Plan

### How to verify

查看新增的 `LspTool` 校验测试，或运行下面的命令。关键行为是：顶层位置参数、嵌套 `LspPosition`、`limit` 的小数值，以及不安全整数位置值都会在执行前被拒绝；已有的正整数调用仍然合法。

- `npm test --workspace=packages/core -- tools/lsp.test.ts`
- `npm run lint --workspace=packages/core --if-present`
- `npm run typecheck --workspace=packages/core --if-present`
- `npx prettier --check packages/core/src/tools/lsp.ts packages/core/src/tools/lsp.test.ts`
- `git diff --check`

### Evidence (Before & After)

UI 证据不适用。

修改前：LSP 位置和 limit 字段声明为 `number`，小数值可以通过校验，然后根据操作路径被取 floor、传给 LSP range，或作为 slice limit 使用。

修改后：LSP 位置和 limit 字段声明为 `integer`，小数值会在 schema 校验阶段失败，不安全整数会在工具值校验阶段失败。

### Tested on

|     OS     | Status        |
| :--------: | :-----------: |
|  🍏 macOS  | ✅ tested     |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 macOS 工作区，使用仓库的 npm 工具链。

## Risk & Scope

- 主要风险或取舍：现有调用方如果传入小数 LSP 位置或 limit，现在会得到校验错误。这是有意的，因为这些字段只能是整数。
- 未验证 / 不在范围内：没有手动连接真实 language server；这是 schema 和校验修复，已由聚焦的 LSP tool 测试覆盖。
- 破坏性变更 / 迁移说明：对合法的 LSP tool 调用没有预期破坏性变更。小数位置或 limit 值应改为整数。

## Linked Issues

修复 #5694

## AI Assistance Disclosure

我使用 Codex 审查改动、对照现有模式做 sanity-check，并帮助发现潜在边界情况。

</details>
