### PR TITLE
fix(core): declare integer tool params

### DIFF
--- a/packages/core/src/tools/monitor.test.ts
+++ b/packages/core/src/tools/monitor.test.ts
@@ -238,6 +238,17 @@ describe('MonitorTool', () => {
       }
     ).createInvocation(params);
 
+  describe('schema', () => {
+    it('declares integer-only auto-stop params as integers', () => {
+      const schema = monitorTool.schema.parametersJsonSchema as {
+        properties: Record<string, { type: string }>;
+      };
+
+      expect(schema.properties['max_events'].type).toBe('integer');
+      expect(schema.properties['idle_timeout_ms'].type).toBe('integer');
+    });
+  });
+
   describe('confirmation details', () => {
     it('includes command-scoped permission rules for monitor commands', async () => {
       const invocation = createInvocation({
@@ -499,6 +510,12 @@ describe('MonitorTool', () => {
       );
     });
 
+    it('rejects fractional max_events', () => {
+      expect(validate({ command: 'tail -f log', max_events: 1.5 })).toBe(
+        'max_events must be a positive integer.',
+      );
+    });
+
     it('rejects max_events over limit', () => {
       expect(validate({ command: 'tail -f log', max_events: 20000 })).toBe(
         'max_events cannot exceed 10000.',
@@ -509,6 +526,12 @@ describe('MonitorTool', () => {
       expect(validate({ command: 'tail -f log', idle_timeout_ms: -100 })).toBe(
         'idle_timeout_ms must be a positive integer.',
       );
+    });
+
+    it('rejects fractional idle_timeout_ms', () => {
+      expect(
+        validate({ command: 'tail -f log', idle_timeout_ms: 1000.5 }),
+      ).toBe('idle_timeout_ms must be a positive integer.');
     });
 
     it('rejects idle_timeout_ms over limit', () => {

--- a/packages/core/src/tools/monitor.ts
+++ b/packages/core/src/tools/monitor.ts
@@ -696,12 +696,12 @@ export class MonitorTool extends BaseDeclarativeTool<
               'Brief description of what this monitor watches (e.g., "webpack build output"). Truncated to 80 characters in display.',
           },
           max_events: {
-            type: 'number',
+            type: 'integer',
             description:
               'Stop the monitor after this many events. Default 1000. Max 10000.',
           },
           idle_timeout_ms: {
-            type: 'number',
+            type: 'integer',
             description:
               'Stop the monitor if no output for this many milliseconds. Default 300000 (5 min). Max 600000.',
           },

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -62,6 +62,9 @@ interface ShellToolParameterJsonSchema {
     command: {
       description: string;
     };
+    timeout: {
+      type: string;
+    };
   };
 }
 
@@ -6041,6 +6044,13 @@ describe('ShellTool', () => {
   });
 
   describe('timeout parameter', () => {
+    it('declares timeout as an integer in the tool schema', () => {
+      const schema = shellTool.schema
+        .parametersJsonSchema as ShellToolParameterJsonSchema;
+
+      expect(schema.properties.timeout.type).toBe('integer');
+    });
+
     it('should validate timeout parameter correctly', async () => {
       // Valid timeout
       expect(() => {
@@ -6087,23 +6097,23 @@ describe('ShellTool', () => {
         });
       }).toThrow('Timeout cannot exceed 600000ms (10 minutes).');
 
-      // Non-integer timeout
+      // Non-integer timeout (schema validation catches this first)
       expect(() => {
         shellTool.build({
           command: 'echo test',
           is_background: false,
           timeout: 5000.5,
         });
-      }).toThrow('Timeout must be an integer number of milliseconds.');
+      }).toThrow('params/timeout must be integer');
 
-      // Non-number timeout (schema validation catches this first)
+      // Non-number timeout
       expect(() => {
         shellTool.build({
           command: 'echo test',
           is_background: false,
           timeout: 'invalid' as unknown as number,
         });
-      }).toThrow('params/timeout must be number');
+      }).toThrow('params/timeout must be integer');
     });
 
     it('should include timeout in description for foreground commands', async () => {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -4736,7 +4736,7 @@ export class ShellTool extends BaseDeclarativeTool<
               'Optional: Whether to run the command in background. If not specified, defaults to false (foreground execution). Explicitly set to true for long-running processes like development servers, watchers, or daemons that should continue running without blocking further commands.',
           },
           timeout: {
-            type: 'number',
+            type: 'integer',
             description: 'Optional timeout in milliseconds (max 600000)',
           },
           description: {


### PR DESCRIPTION
## What this PR does

Declares integer-only tool parameters as JSON Schema `integer` values instead of generic `number` values:

- `run_shell_command.timeout`
- `monitor.max_events`
- `monitor.idle_timeout_ms`

The runtime validators already require these values to be integers. This PR aligns the public tool schemas with that contract and adds focused schema/fractional-value regression tests.

## Why it's needed

Before this change, the tool schemas advertised these fields as `number`, even though fractional values are rejected by runtime validation. That mismatch can lead model/tool clients to emit fractional values that are only rejected after a tool call is attempted.

Keeping the schema precise makes the tool contract clearer and catches invalid values earlier.

## Reviewer Test Plan

### How to verify

Run the focused core tool tests and package checks:

```bash
npm test --workspace=packages/core -- tools/monitor.test.ts tools/shell.test.ts
npx prettier --check packages/core/src/tools/monitor.ts packages/core/src/tools/monitor.test.ts packages/core/src/tools/shell.ts packages/core/src/tools/shell.test.ts
npm run lint --workspace=packages/core --if-present
npm run typecheck --workspace=packages/core --if-present
git diff --check
```

### Evidence (Before & After)

Before:
- `run_shell_command.timeout`, `monitor.max_events`, and `monitor.idle_timeout_ms` were declared as `type: 'number'` in tool schemas.
- Fractional values were only rejected by later runtime validation.

After:
- The three fields are declared as `type: 'integer'`.
- Focused tests assert the schema type and fractional-value rejection paths.
- Local verification passed: 318 focused tests passed across `monitor.test.ts` and `shell.test.ts`; prettier, lint, typecheck, and `git diff --check` passed.
- Read-only sub-agent review found no blocking issues.

### Tested on

| OS | Status | Notes |
| --- | --- | --- |
| macOS | Pass | Local focused tests and checks on macOS |
| Linux | Not run | Covered by CI |
| Windows | Not run | Covered by CI |

## Risk & Scope

Risk is low. This is a schema-contract tightening for fields that were already integer-only at runtime.

Out of scope:
- Changing timeout/event-count semantics
- Changing monitor or shell execution behavior
- Adding new tool parameters

Breaking changes: callers that send fractional values now fail schema validation earlier instead of reaching the custom runtime validator.

## Linked Issues

Fixes #5698

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

将仅接受整数的工具参数在 JSON Schema 中声明为 `integer`，不再声明为泛化的 `number`：

- `run_shell_command.timeout`
- `monitor.max_events`
- `monitor.idle_timeout_ms`

这些字段在运行时校验中本来就要求是整数。本 PR 让公开的工具 schema 与运行时契约一致，并补充了聚焦的 schema 和小数值回归测试。

## 为什么需要

修改前，这些工具 schema 把字段声明为 `number`，但运行时会拒绝小数值。这个不一致会让模型或工具客户端合理地产生小数参数，然后等到工具调用阶段才失败。

更精确的 schema 能让工具契约更清晰，也能更早拒绝无效值。

## Reviewer Test Plan

### 如何验证

运行聚焦的 core 工具测试和包级检查：

```bash
npm test --workspace=packages/core -- tools/monitor.test.ts tools/shell.test.ts
npx prettier --check packages/core/src/tools/monitor.ts packages/core/src/tools/monitor.test.ts packages/core/src/tools/shell.ts packages/core/src/tools/shell.test.ts
npm run lint --workspace=packages/core --if-present
npm run typecheck --workspace=packages/core --if-present
git diff --check
```

### 证据（修改前 / 修改后）

修改前：
- `run_shell_command.timeout`、`monitor.max_events` 和 `monitor.idle_timeout_ms` 在工具 schema 中声明为 `type: 'number'`。
- 小数值只会在后续运行时校验中被拒绝。

修改后：
- 这三个字段声明为 `type: 'integer'`。
- 聚焦测试覆盖了 schema 类型和小数值拒绝路径。
- 本地验证通过：`monitor.test.ts` 和 `shell.test.ts` 共 318 个聚焦测试通过；prettier、lint、typecheck 和 `git diff --check` 均通过。
- 只读子代理审查未发现阻塞问题。

### 测试环境

| OS | 状态 | 备注 |
| --- | --- | --- |
| macOS | 通过 | 本地运行聚焦测试和检查 |
| Linux | 未本地运行 | 由 CI 覆盖 |
| Windows | 未本地运行 | 由 CI 覆盖 |

## 风险与范围

风险较低。这是 schema 契约收紧，涉及的字段在运行时本来就只接受整数。

不在范围内：
- 修改 timeout 或事件数量语义
- 修改 monitor 或 shell 执行行为
- 添加新的工具参数

破坏性变更：发送小数值的调用方现在会更早在 schema 校验阶段失败，而不是进入自定义运行时校验。

## 关联 Issue

Fixes #5698

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
