### PR TITLE
fix(cli): validate sessions list limit

### DIFF
--- a/packages/cli/src/commands/sessions/list.test.ts
+++ b/packages/cli/src/commands/sessions/list.test.ts
@@ -5,7 +5,14 @@
  */
 
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { handleList, SESSION_COL, TIME_COL, TITLE_COL } from './list.js';
+import yargs, { type Argv } from 'yargs';
+import {
+  handleList,
+  listCommand,
+  SESSION_COL,
+  TIME_COL,
+  TITLE_COL,
+} from './list.js';
 
 const mockWriteStdoutLine = vi.hoisted(() => vi.fn());
 const mockWriteStderrLine = vi.hoisted(() => vi.fn());
@@ -38,6 +45,12 @@ const sampleSession = {
   customTitle: 'React 组件开发',
   titleSource: 'auto',
 };
+
+function buildParser(): Argv {
+  return (listCommand.builder as (argv: Argv) => Argv)(
+    yargs([]).exitProcess(false).fail(false).locale('en'),
+  );
+}
 
 describe('sessions list command', () => {
   beforeEach(() => {
@@ -201,6 +214,24 @@ describe('sessions list command', () => {
     expect(mockListSessions).toHaveBeenCalledWith({
       size: 20,
     });
+  });
+
+  it('parses --limit as a positive integer', () => {
+    const argv = buildParser().parseSync('--limit 10');
+
+    expect(argv['limit']).toBe(10);
+  });
+
+  it('defaults --limit to 20 in the parser', () => {
+    const argv = buildParser().parseSync('');
+
+    expect(argv['limit']).toBe(20);
+  });
+
+  it.each(['0', '-1', '1.5'])('rejects invalid --limit value %s', (value) => {
+    expect(() => buildParser().parseSync(`--limit ${value}`)).toThrow(
+      '--limit must be a positive integer.',
+    );
   });
 
   it('should yield JSON without header for multiple sessions', async () => {

--- a/packages/cli/src/commands/sessions/list.ts
+++ b/packages/cli/src/commands/sessions/list.ts
@@ -215,7 +215,12 @@ export const listCommand: CommandModule<unknown, ListArgs> = {
         type: 'number',
         describe: 'Maximum number of sessions to show',
         default: 20,
-        coerce: (v) => (Number.isInteger(v) && v > 0 ? v : 20),
+        coerce: (v) => {
+          if (Number.isInteger(v) && v > 0) {
+            return v;
+          }
+          throw new Error('--limit must be a positive integer.');
+        },
       }),
   handler: async (argv) => {
     await handleList(argv);


### PR DESCRIPTION
## What this PR does

Makes `qwen sessions list --limit` reject invalid explicit values instead of silently falling back to the default.

Valid positive integer values still pass through unchanged, and omitting `--limit` still defaults to 20.

## Why it's needed

Before this change, values such as `--limit 0`, `--limit -1`, or `--limit 1.5` were accepted by the parser and quietly coerced to 20. That hides user input mistakes and makes the command behave differently from what was requested.

The command should fail fast with a clear argument error when the user supplies an invalid limit.

## Reviewer Test Plan

### How to verify

Run the focused sessions-list test and CLI checks:

```bash
npm test --workspace=packages/cli -- commands/sessions/list.test.ts
npx prettier --check packages/cli/src/commands/sessions/list.ts packages/cli/src/commands/sessions/list.test.ts
npm run lint --workspace=packages/cli --if-present
npm run typecheck --workspace=packages/cli --if-present
git diff --check
```

### Evidence (Before & After)

Before:
- `--limit 0`, `--limit -1`, and `--limit 1.5` were silently coerced to the default value 20.

After:
- Invalid explicit `--limit` values fail parser validation with `--limit must be a positive integer.`
- `--limit 10` still parses as 10.
- Omitting `--limit` still defaults to 20.
- Local focused test passed: `commands/sessions/list.test.ts` — 30 tests passed.
- Prettier, lint, and `git diff --check` passed.
- CLI typecheck was run, but it is currently blocked by existing unrelated `BaseTextInput.tsx` / `ink/dom` type resolution errors.
- Read-only sub-agent review found no blocking issues.

### Tested on

| OS | Status | Notes |
| --- | --- | --- |
| macOS | Pass | Focused test, prettier, lint, and diff check passed locally |
| Linux | Not run | Covered by CI |
| Windows | Not run | Covered by CI |

## Risk & Scope

Risk is low. This only changes parser handling for invalid explicit `--limit` values.

Out of scope:
- Changing sessions listing behavior
- Changing default limit
- Adding new filters or output fields

Breaking changes: scripts passing invalid `--limit` values now get a clear argument error instead of a silent default fallback.

## Linked Issues

Fixes #5700

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 `qwen sessions list --limit` 在用户显式传入无效值时直接报错，而不是静默回退到默认值。

合法的正整数仍会原样传递；不传 `--limit` 时仍默认使用 20。

## 为什么需要

修改前，`--limit 0`、`--limit -1` 或 `--limit 1.5` 这类值会被 parser 接受，并静默转成 20。这样会隐藏用户输入错误，也会让命令行为和用户请求不一致。

当用户传入无效 limit 时，命令应该尽早给出清晰的参数错误。

## Reviewer Test Plan

### 如何验证

运行聚焦的 sessions-list 测试和 CLI 检查：

```bash
npm test --workspace=packages/cli -- commands/sessions/list.test.ts
npx prettier --check packages/cli/src/commands/sessions/list.ts packages/cli/src/commands/sessions/list.test.ts
npm run lint --workspace=packages/cli --if-present
npm run typecheck --workspace=packages/cli --if-present
git diff --check
```

### 证据（修改前 / 修改后）

修改前：
- `--limit 0`、`--limit -1` 和 `--limit 1.5` 会被静默转成默认值 20。

修改后：
- 无效的显式 `--limit` 值会在 parser 校验阶段失败，并提示 `--limit must be a positive integer.`
- `--limit 10` 仍解析为 10。
- 不传 `--limit` 时仍默认使用 20。
- 本地聚焦测试通过：`commands/sessions/list.test.ts` — 30 个测试通过。
- Prettier、lint 和 `git diff --check` 通过。
- 已运行 CLI typecheck，但目前被既有的无关 `BaseTextInput.tsx` / `ink/dom` 类型解析错误阻塞。
- 只读子代理审查未发现阻塞问题。

### 测试环境

| OS | 状态 | 备注 |
| --- | --- | --- |
| macOS | 通过 | 本地 focused test、prettier、lint 和 diff check 通过 |
| Linux | 未本地运行 | 由 CI 覆盖 |
| Windows | 未本地运行 | 由 CI 覆盖 |

## 风险与范围

风险较低。这里只改变显式无效 `--limit` 值的 parser 行为。

不在范围内：
- 修改 sessions list 行为
- 修改默认 limit
- 添加新的筛选或输出字段

破坏性变更：传入无效 `--limit` 的脚本现在会得到清晰的参数错误，而不是静默使用默认值。

## 关联 Issue

Fixes #5700

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
