### PR TITLE
fix(cli): validate mcp add timeout

### DIFF
--- a/packages/cli/src/commands/mcp/add.test.ts
+++ b/packages/cli/src/commands/mcp/add.test.ts
@@ -58,7 +58,7 @@ describe('mcp add command', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
-    const yargsInstance = yargs([]).command(addCommand);
+    const yargsInstance = yargs([]).exitProcess(false).command(addCommand);
     parser = yargsInstance;
     mockSetValue = vi.fn();
     mockWriteStderrLine.mockClear();
@@ -94,6 +94,34 @@ describe('mcp add command', () => {
       }),
     });
   });
+
+  it('should persist positive integer timeout values', async () => {
+    await parser.parseAsync('add my-server /path/to/server --timeout 30000');
+
+    expect(mockSetValue).toHaveBeenCalledWith(SettingScope.User, 'mcpServers', {
+      'my-server': expect.objectContaining({
+        command: '/path/to/server',
+        timeout: 30000,
+      }),
+    });
+  });
+
+  it.each(['0', '-1', '1.5', 'abc'])(
+    'should reject invalid timeout value %s',
+    async (timeout) => {
+      await expect(async () => {
+        await parser.parseAsync([
+          'add',
+          'my-server',
+          '/path/to/server',
+          '--timeout',
+          timeout,
+        ]);
+      }).rejects.toThrow('--timeout must be a positive integer.');
+
+      expect(mockSetValue).not.toHaveBeenCalled();
+    },
+  );
 
   it('should auto-detect http transport when commandOrUrl is an https URL', async () => {
     await parser.parseAsync('add http-server https://example.com/mcp');

--- a/packages/cli/src/commands/mcp/add.ts
+++ b/packages/cli/src/commands/mcp/add.ts
@@ -246,6 +246,12 @@ export const addCommand: CommandModule = {
       .option('timeout', {
         describe: 'Set connection timeout in milliseconds',
         type: 'number',
+        coerce: (value: number) => {
+          if (!Number.isInteger(value) || value <= 0) {
+            throw new Error('--timeout must be a positive integer.');
+          }
+          return value;
+        },
       })
       .option('trust', {
         describe:


### PR DESCRIPTION
## What this PR does

Validates `qwen mcp add --timeout` as a positive integer before the command writes MCP server settings.

Invalid values now fail during argument parsing instead of being persisted into `mcpServers.<name>.timeout`.

## Why it's needed

`--timeout` is stored as the MCP request timeout in milliseconds. The command previously accepted values like `0`, negative numbers, fractional milliseconds, or non-numeric input, which could save unusable MCP server configuration.

Rejecting bad input at the CLI keeps the persisted settings valid and gives the user immediate feedback.

## Reviewer Test Plan

### How to verify

Run `npm test --workspace=packages/cli -- commands/mcp/add.test.ts` and confirm the `mcp add` parser tests pass.

Optionally run `qwen mcp add test-server echo --timeout 0` and confirm the command rejects the value with `--timeout must be a positive integer.`

### Evidence (Before & After)

Before: `qwen mcp add ... --timeout 0`, `--timeout -1`, `--timeout 1.5`, or `--timeout abc` could reach the settings write path.

After: those values are rejected before `settings.setValue` is called. The new tests cover a valid positive integer and invalid `0`, negative, fractional, and non-numeric values.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local validation on macOS:

- `npm test --workspace=packages/cli -- commands/mcp/add.test.ts` ✅
- `npx prettier --check packages/cli/src/commands/mcp/add.ts packages/cli/src/commands/mcp/add.test.ts` ✅
- `npm run lint --workspace=packages/cli --if-present` ✅
- `git diff --check` ✅
- `npm run typecheck --workspace=packages/cli --if-present` ⚠️ still fails on existing unrelated `src/ui/components/BaseTextInput.tsx` imports from `ink/dom` and `ink/components/CursorContext`

## Risk & Scope

- Main risk or tradeoff: users who previously saved invalid timeout values will now get a parse-time error.
- Not validated / out of scope: no changes to existing settings schema or MCP runtime timeout behavior.
- Breaking changes / migration notes: none for valid positive integer timeout values.

## Linked Issues

Fixes #5702

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 在 `qwen mcp add --timeout` 写入 MCP server settings 之前，先校验它必须是正整数。

无效值现在会在参数解析阶段失败，不会再被持久化到 `mcpServers.<name>.timeout`。

## Why it's needed

`--timeout` 会作为 MCP 请求超时时间保存，单位是毫秒。之前这个命令会接受 `0`、负数、小数毫秒或者非数字输入，导致保存出不可用的 MCP server 配置。

在 CLI 层拒绝错误输入，可以保持 settings 有效，并且让用户立刻看到明确反馈。

## Reviewer Test Plan

### How to verify

运行 `npm test --workspace=packages/cli -- commands/mcp/add.test.ts`，确认 `mcp add` parser 相关测试通过。

也可以手动运行 `qwen mcp add test-server echo --timeout 0`，确认命令用 `--timeout must be a positive integer.` 拒绝这个值。

### Evidence (Before & After)

Before：`qwen mcp add ... --timeout 0`、`--timeout -1`、`--timeout 1.5` 或 `--timeout abc` 可以进入 settings 写入路径。

After：这些值会在调用 `settings.setValue` 之前被拒绝。新增测试覆盖了合法正整数，以及 `0`、负数、小数和非数字这些无效值。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 macOS 验证：

- `npm test --workspace=packages/cli -- commands/mcp/add.test.ts` ✅
- `npx prettier --check packages/cli/src/commands/mcp/add.ts packages/cli/src/commands/mcp/add.test.ts` ✅
- `npm run lint --workspace=packages/cli --if-present` ✅
- `git diff --check` ✅
- `npm run typecheck --workspace=packages/cli --if-present` ⚠️ 仍然因为既有的无关问题失败，位置是 `src/ui/components/BaseTextInput.tsx` 对 `ink/dom` 和 `ink/components/CursorContext` 的导入

## Risk & Scope

- Main risk or tradeoff：之前能保存无效 timeout 的用户，现在会在解析参数时看到错误。
- Not validated / out of scope：不修改现有 settings schema，也不修改 MCP 运行时 timeout 行为。
- Breaking changes / migration notes：对合法正整数 timeout 值没有破坏性变更。

## Linked Issues

Fixes #5702

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
