### PR TITLE
fix(serve): reject fractional max sessions

### DIFF
--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -4692,14 +4692,18 @@ describe('createAcpSessionBridge', () => {
       );
     });
 
-    it('rejects NaN maxSessions (BRApy: silent fail-OPEN guard)', () => {
+    it.each([
+      ['NaN', Number.NaN],
+      ['negative', -5],
+      ['float', 1.5],
+    ])('rejects invalid maxSessions (%s)', (_label, value) => {
       // A typo / parse error in CLI / config that yields NaN must
       // NOT silently disable the daemon's resource cap. We fail
       // boot loud instead of serving unbounded.
-      expect(() => makeBridge({ maxSessions: NaN })).toThrow(
-        /maxSessions: NaN/,
-      );
-      expect(() => makeBridge({ maxSessions: -5 })).toThrow(/maxSessions: -5/);
+      expect(() => makeBridge({ maxSessions: value })).toThrow(/maxSessions/);
+    });
+
+    it('accepts disabled maxSessions sentinels', () => {
       // Explicit zero or Infinity remain valid "unlimited" sentinels.
       expect(() => makeBridge({ maxSessions: 0 })).not.toThrow();
       expect(() => makeBridge({ maxSessions: Infinity })).not.toThrow();

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -710,25 +710,25 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
   // `0` → explicitly unlimited (operator opt-out).
   // `Infinity` → unlimited (programmatic opt-out — accepted as a
   //              long-standing alias since the cap check is `>= max`).
-  // `NaN` / negative → throw. A typo / parse error in CLI/config
-  //                    silently disabling the daemon's only resource
-  //                    guard is fail-OPEN behavior — we'd rather fail
-  //                    boot than serve unbounded.
+  // non-integer / `NaN` / negative → throw. A typo / parse error in
+  //                    CLI/config silently disabling or rounding the
+  //                    daemon's only resource guard is fail-OPEN behavior —
+  //                    we'd rather fail boot than serve with the wrong cap.
   let maxSessions: number;
   if (opts.maxSessions === undefined) {
     maxSessions = DEFAULT_MAX_SESSIONS;
-  } else if (Number.isNaN(opts.maxSessions)) {
-    throw new TypeError(
-      `Invalid maxSessions: NaN. Must be a number >= 0 ` +
-        `(0 / Infinity = unlimited).`,
-    );
-  } else if (opts.maxSessions < 0) {
-    throw new TypeError(
-      `Invalid maxSessions: ${opts.maxSessions}. Must be >= 0 ` +
-        `(0 / Infinity = unlimited).`,
-    );
   } else if (opts.maxSessions === 0 || opts.maxSessions === Infinity) {
     maxSessions = Infinity;
+  } else if (
+    !Number.isFinite(opts.maxSessions) ||
+    !Number.isInteger(opts.maxSessions) ||
+    opts.maxSessions < 0
+  ) {
+    throw new TypeError(
+      `Invalid maxSessions: ${opts.maxSessions}. ` +
+        `Must be a non-negative integer ` +
+        `(0 / Infinity = unlimited).`,
+    );
   } else {
     maxSessions = opts.maxSessions;
   }


### PR DESCRIPTION
## What this PR does

Rejects fractional `maxSessions` values in the ACP session bridge.

The existing behavior for `undefined`, `0`, and `Infinity` is preserved: `undefined` keeps the default session cap, while `0` and `Infinity` still mean unlimited.

## Why it's needed

`maxSessions` is a count-based resource limit. Fractional values like `1.5` are not meaningful, but they were accepted and then used in a `current >= maxSessions` comparison.

That silently changes the effective limit. For example, `maxSessions: 1.5` behaves like allowing 2 sessions. Failing at bridge construction is clearer and matches the nearby integer validation for `maxPendingPromptsPerSession`.

## Reviewer Test Plan

### How to verify

Run `npm test --workspace=@qwen-code/acp-bridge -- bridge.test.ts` and confirm the bridge tests pass.

Review the updated `createAcpSessionBridge` validation and confirm fractional `maxSessions` values now throw while `0` and `Infinity` remain valid unlimited sentinels.

### Evidence (Before & After)

Before: `createAcpSessionBridge({ maxSessions: 1.5 })` constructed a bridge and effectively allowed 2 sessions.

After: fractional `maxSessions` throws during bridge construction. Tests cover `NaN`, negative, and fractional rejection, plus `0` and `Infinity` acceptance.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local validation on macOS:

- `npm test --workspace=@qwen-code/acp-bridge -- bridge.test.ts` ✅
- `npx prettier --check packages/acp-bridge/src/bridge.ts packages/acp-bridge/src/bridge.test.ts` ✅
- `npm run lint --workspace=@qwen-code/acp-bridge --if-present` ✅
- `npm run typecheck --workspace=@qwen-code/acp-bridge --if-present` ✅
- `git diff --check` ✅

## Risk & Scope

- Main risk or tradeoff: embedded callers that passed fractional `maxSessions` will now fail fast instead of getting an implicit rounded-up effective cap.
- Not validated / out of scope: no changes to session creation, reaping, or daemon HTTP route behavior beyond rejecting invalid bridge options.
- Breaking changes / migration notes: valid integer values, `0`, `Infinity`, and the default behavior are unchanged.

## Linked Issues

Fixes #5704

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 会在 ACP session bridge 中拒绝小数形式的 `maxSessions`。

原有的 `undefined`、`0` 和 `Infinity` 行为保持不变：`undefined` 使用默认 session 上限，`0` 和 `Infinity` 仍然表示无限制。

## Why it's needed

`maxSessions` 是基于数量的资源限制。像 `1.5` 这样的小数没有实际意义，但之前会被接受，并参与 `current >= maxSessions` 这样的比较。

这会静默改变实际限制。例如 `maxSessions: 1.5` 的效果接近允许 2 个 session。现在在 bridge 构造阶段直接失败更清晰，也和附近 `maxPendingPromptsPerSession` 的整数校验保持一致。

## Reviewer Test Plan

### How to verify

运行 `npm test --workspace=@qwen-code/acp-bridge -- bridge.test.ts`，确认 bridge 测试通过。

检查更新后的 `createAcpSessionBridge` 校验逻辑，确认小数 `maxSessions` 会抛错，同时 `0` 和 `Infinity` 仍然是合法的无限制哨兵值。

### Evidence (Before & After)

Before：`createAcpSessionBridge({ maxSessions: 1.5 })` 可以构造 bridge，并且实际效果接近允许 2 个 session。

After：小数 `maxSessions` 会在 bridge 构造阶段抛错。测试覆盖了 `NaN`、负数、小数拒绝，以及 `0` 和 `Infinity` 接受。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 macOS 验证：

- `npm test --workspace=@qwen-code/acp-bridge -- bridge.test.ts` ✅
- `npx prettier --check packages/acp-bridge/src/bridge.ts packages/acp-bridge/src/bridge.test.ts` ✅
- `npm run lint --workspace=@qwen-code/acp-bridge --if-present` ✅
- `npm run typecheck --workspace=@qwen-code/acp-bridge --if-present` ✅
- `git diff --check` ✅

## Risk & Scope

- Main risk or tradeoff：传入小数 `maxSessions` 的 embedded caller 现在会快速失败，而不是得到一个隐式向上取整效果的实际上限。
- Not validated / out of scope：不修改 session 创建、回收或 daemon HTTP route 行为，只拒绝无效 bridge options。
- Breaking changes / migration notes：合法整数、`0`、`Infinity` 和默认行为都保持不变。

## Linked Issues

Fixes #5704

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
