### PR TITLE
fix(serve): reject fractional max connections

### DIFF
--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -1158,14 +1158,15 @@ export async function runQwenServe(
   // promise instead of escaping as an uncaught exception inside the
   // listen callback (which fires from the `listening` event after the
   // outer promise has already resolved). Silent fail-OPEN on NaN /
-  // negative would weaken the DoS/FD-exhaustion guard the cap exists
-  // for.
+  // negative / fractional values would weaken or blur the
+  // DoS/FD-exhaustion guard the cap exists for.
   if (
     opts.maxConnections !== undefined &&
-    (Number.isNaN(opts.maxConnections) || opts.maxConnections < 0)
+    !isNonNegativeIntegerOrInfinity(opts.maxConnections)
   ) {
     throw new TypeError(
-      `Invalid maxConnections: ${opts.maxConnections}. Must be >= 0 ` +
+      `Invalid maxConnections: ${opts.maxConnections}. ` +
+        `Must be a non-negative integer ` +
         `(0 / Infinity = unlimited).`,
     );
   }
@@ -1190,7 +1191,7 @@ export async function runQwenServe(
       // with `SocketError: other side closed`). Treat 0 / Infinity
       // as "leave the property unset" so the documented disable
       // path actually disables instead of silently bricking the
-      // daemon. NaN / negative are rejected upstream so
+      // daemon. NaN / negative / fractional values are rejected upstream so
       // they never reach here.
       const cap = opts.maxConnections ?? 256;
       if (cap > 0 && Number.isFinite(cap)) {

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -8970,7 +8970,7 @@ describe('runQwenServe', () => {
     // Node 22 `server.maxConnections = 0` causes the listener to
     // refuse EVERY connection. An operator following the documented
     // disable path got a daemon that booted cleanly but silently
-    // bricked every request. Fix treats 0 / Infinity / non-finite as
+    // bricked every request. Fix treats 0 / Infinity as
     // "leave the property unset" so Node's default (no cap) actually
     // applies.
     handle = await runQwenServe({
@@ -9012,7 +9012,11 @@ describe('runQwenServe', () => {
     expect(handle.server.maxConnections).toBe(100);
   });
 
-  it('--max-connections NaN/negative throws at boot (BUF9-)', async () => {
+  it.each([
+    ['NaN', NaN],
+    ['negative', -5],
+    ['fractional', 1.5],
+  ])('--max-connections %s throws at boot (BUF9-)', async (_label, value) => {
     // Silent fail-OPEN on a CLI typo would weaken the DoS guard.
     // Boot-loud is the right behavior for an unparseable cap.
     await expect(
@@ -9020,17 +9024,9 @@ describe('runQwenServe', () => {
         hostname: '127.0.0.1',
         port: 0,
         mode: 'http-bridge',
-        maxConnections: NaN,
+        maxConnections: value,
       }),
-    ).rejects.toThrow(/maxConnections: NaN/);
-    await expect(
-      runQwenServe({
-        hostname: '127.0.0.1',
-        port: 0,
-        mode: 'http-bridge',
-        maxConnections: -5,
-      }),
-    ).rejects.toThrow(/maxConnections: -5/);
+    ).rejects.toThrow(/maxConnections/);
   });
 
   it('case-insensitive loopback: --hostname Localhost / LOCALHOST does NOT require a token (BQ92B)', async () => {


### PR DESCRIPTION
## What this PR does

Rejects fractional `maxConnections` values in `runQwenServe` before the daemon listener starts.

The existing default behavior is unchanged, and `0` / `Infinity` still keep the documented unlimited behavior by leaving `server.maxConnections` unset.

## Why it's needed

`maxConnections` is a listener connection count cap. Fractional values like `1.5` are not meaningful for a socket count limit, but they were accepted and could be forwarded to Node's `server.maxConnections`.

Failing at boot keeps the cap deterministic and matches the surrounding validation style for count-based serve options.

## Reviewer Test Plan

### How to verify

Run `npm test --workspace=packages/cli -- serve/server.test.ts -t max-connections` and confirm the focused max-connections tests pass.

Review `runQwenServe` validation and confirm fractional `maxConnections` values now throw while `0`, `Infinity`, and positive integers keep their existing behavior.

### Evidence (Before & After)

Before: `runQwenServe({ maxConnections: 1.5 })` passed validation and forwarded a fractional connection cap toward the Node server.

After: fractional `maxConnections` throws during boot. Tests cover `0`, `Infinity`, a valid integer, `NaN`, a negative value, and a fractional value.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local validation on macOS:

- `npm test --workspace=packages/cli -- serve/server.test.ts -t max-connections` ✅
- `npx prettier --check packages/cli/src/serve/run-qwen-serve.ts packages/cli/src/serve/server.test.ts` ✅
- `npm run lint --workspace=packages/cli --if-present` ✅
- `git diff --check` ✅
- `npm run typecheck --workspace=packages/cli --if-present` ⚠️ still fails on existing unrelated `src/ui/components/BaseTextInput.tsx` imports from `ink/dom` and `ink/components/CursorContext`

## Risk & Scope

- Main risk or tradeoff: embedded callers that passed fractional `maxConnections` will now fail fast instead of relying on Node's handling of a fractional cap.
- Not validated / out of scope: no changes to connection handling, auth, session limits, or WebSocket/SSE behavior beyond rejecting invalid listener cap values.
- Breaking changes / migration notes: valid integer values, `0`, `Infinity`, and the default behavior are unchanged.

## Linked Issues

Fixes #5706

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 会在 daemon listener 启动前，在 `runQwenServe` 中拒绝小数形式的 `maxConnections`。

现有默认行为保持不变，`0` / `Infinity` 仍然保留文档中的无限制语义，也就是不设置 `server.maxConnections`。

## Why it's needed

`maxConnections` 是 listener 的连接数量上限。像 `1.5` 这样的小数对于 socket 数量限制没有意义，但之前会被接受，并可能继续传给 Node 的 `server.maxConnections`。

启动时直接失败能让这个 cap 的行为更确定，也和周围基于数量的 serve 选项校验风格一致。

## Reviewer Test Plan

### How to verify

运行 `npm test --workspace=packages/cli -- serve/server.test.ts -t max-connections`，确认 max-connections 的 focused tests 通过。

检查 `runQwenServe` 校验逻辑，确认小数 `maxConnections` 现在会抛错，同时 `0`、`Infinity` 和正整数保留现有行为。

### Evidence (Before & After)

Before：`runQwenServe({ maxConnections: 1.5 })` 可以通过校验，并把小数形式的连接 cap 继续传向 Node server。

After：小数 `maxConnections` 会在启动阶段抛错。测试覆盖了 `0`、`Infinity`、合法整数、`NaN`、负数和小数。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 macOS 验证：

- `npm test --workspace=packages/cli -- serve/server.test.ts -t max-connections` ✅
- `npx prettier --check packages/cli/src/serve/run-qwen-serve.ts packages/cli/src/serve/server.test.ts` ✅
- `npm run lint --workspace=packages/cli --if-present` ✅
- `git diff --check` ✅
- `npm run typecheck --workspace=packages/cli --if-present` ⚠️ 仍然因为既有的无关问题失败，位置是 `src/ui/components/BaseTextInput.tsx` 对 `ink/dom` 和 `ink/components/CursorContext` 的导入

## Risk & Scope

- Main risk or tradeoff：传入小数 `maxConnections` 的 embedded caller 现在会快速失败，不再依赖 Node 对小数 cap 的处理。
- Not validated / out of scope：不修改 connection handling、auth、session limits 或 WebSocket/SSE 行为，只拒绝无效 listener cap 值。
- Breaking changes / migration notes：合法整数、`0`、`Infinity` 和默认行为都保持不变。

## Linked Issues

Fixes #5706

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
