### PR TITLE
fix(cli): reject invalid session list cursors

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -5387,7 +5387,14 @@ describe('QwenAgent unstable_listSessions cursor parsing', () => {
     const { agent, agentPromise } = await bootAgent();
 
     try {
-      for (const cursor of ['abc', 'Infinity', '-Infinity']) {
+      for (const cursor of [
+        'abc',
+        'Infinity',
+        '-Infinity',
+        '-1',
+        '9007199254740992',
+        '   ',
+      ]) {
         await expect(
           agent.unstable_listSessions({ cwd: '/tmp/project', cursor }),
         ).rejects.toThrow(
@@ -5517,7 +5524,7 @@ describe('QwenAgent unstable_listSessions cursor parsing', () => {
     }
   });
 
-  it('passes a finite cursor through to SessionService', async () => {
+  it('passes a finite non-negative cursor through to SessionService', async () => {
     const listSessions = vi.fn().mockResolvedValue({
       items: [
         {
@@ -5542,7 +5549,7 @@ describe('QwenAgent unstable_listSessions cursor parsing', () => {
       await expect(
         agent.unstable_listSessions({
           cwd: '/tmp/project',
-          cursor: '1797860000000',
+          cursor: '1797860000000.5',
           _meta: { size: 2 },
         }),
       ).resolves.toEqual({
@@ -5563,7 +5570,7 @@ describe('QwenAgent unstable_listSessions cursor parsing', () => {
       });
       expect(SessionService).toHaveBeenCalledWith('/tmp/project');
       expect(listSessions).toHaveBeenCalledWith({
-        cursor: 1_797_860_000_000,
+        cursor: 1_797_860_000_000.5,
         size: 2,
       });
     } finally {

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -2554,6 +2554,26 @@ function normalizeAcpSessionListSize(value: unknown): number | undefined {
   return Math.min(Math.max(value, 1), MAX_ACP_SESSION_PAGE_SIZE);
 }
 
+function parseAcpSessionListCursor(
+  value: string | null | undefined,
+): number | undefined {
+  if (value == null || value === '') return undefined;
+  const trimmed = value.trim();
+  const parsedCursor = Number(trimmed);
+  if (
+    trimmed === '' ||
+    !Number.isFinite(parsedCursor) ||
+    parsedCursor < 0 ||
+    parsedCursor > Number.MAX_SAFE_INTEGER
+  ) {
+    throw RequestError.invalidParams(
+      undefined,
+      `Invalid cursor: "${value}" is not a valid numeric cursor`,
+    );
+  }
+  return parsedCursor;
+}
+
 class QwenAgent implements Agent {
   private sessions: Map<string, Session> = new Map();
   private clientCapabilities: ClientCapabilities | undefined;
@@ -2913,17 +2933,7 @@ class QwenAgent implements Agent {
     params: ListSessionsRequest,
   ): Promise<ListSessionsResponse> {
     const cwd = params.cwd || process.cwd();
-    let numericCursor: number | undefined;
-    if (params.cursor != null && params.cursor !== '') {
-      const parsedCursor = Number(params.cursor);
-      if (!Number.isFinite(parsedCursor)) {
-        throw RequestError.invalidParams(
-          undefined,
-          `Invalid cursor: "${params.cursor}" is not a valid numeric cursor`,
-        );
-      }
-      numericCursor = parsedCursor;
-    }
+    const numericCursor = parseAcpSessionListCursor(params.cursor);
 
     // The ACP spec's ListSessionsRequest doesn't include a page-size field,
     // so the SDK's zod validator strips any top-level `size` the client sends

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -5449,7 +5449,34 @@ describe('createServeApp', () => {
       expect(cursoredIds).not.toContain('live-only');
     });
 
-    it('400 invalid_cursor when cursor is not a valid number', async () => {
+    it.each(['abc', '-1', 'Infinity', '9007199254740992', '   '])(
+      '400 invalid_cursor when cursor is not valid: %s',
+      async (cursor) => {
+        const bridge = fakeBridge();
+        const app = createServeApp(
+          { ...baseOpts, workspace: WS_BOUND },
+          undefined,
+          { bridge, boundWorkspace: WS_BOUND },
+        );
+        const res = await request(app)
+          .get(
+            `/workspace/${encodeURIComponent(WS_BOUND)}/sessions?cursor=${encodeURIComponent(cursor)}`,
+          )
+          .set('Host', `127.0.0.1:${baseOpts.port}`);
+        expect(res.status).toBe(400);
+        expect(res.body.code).toBe('invalid_cursor');
+      },
+    );
+
+    it('accepts fractional mtime cursor values', async () => {
+      const id = '550e8400-e29b-41d4-a716-446655440000';
+      await writeStoredSession({
+        sessionId: id,
+        cwd: WS_BOUND,
+        timestamp: '1970-01-01T00:16:39.000Z',
+        prompt: 'stored prompt',
+        mtime: new Date('1970-01-01T00:16:39.000Z'),
+      });
       const bridge = fakeBridge();
       const app = createServeApp(
         { ...baseOpts, workspace: WS_BOUND },
@@ -5457,10 +5484,36 @@ describe('createServeApp', () => {
         { bridge, boundWorkspace: WS_BOUND },
       );
       const res = await request(app)
-        .get(`/workspace/${encodeURIComponent(WS_BOUND)}/sessions?cursor=abc`)
+        .get(
+          `/workspace/${encodeURIComponent(WS_BOUND)}/sessions?cursor=1000123.456`,
+        )
         .set('Host', `127.0.0.1:${baseOpts.port}`);
-      expect(res.status).toBe(400);
-      expect(res.body.code).toBe('invalid_cursor');
+      expect(res.status).toBe(200);
+      expect(res.body.sessions).toHaveLength(1);
+      expect(res.body.sessions[0].sessionId).toBe(id);
+    });
+
+    it('passes fractional cursor values to SessionService without truncating', async () => {
+      const listSessionsSpy = vi
+        .spyOn(SessionService.prototype, 'listSessions')
+        .mockResolvedValue({
+          items: [],
+          nextCursor: undefined,
+          hasMore: false,
+        });
+
+      try {
+        await listWorkspaceSessionsForResponse(fakeBridge(), WS_BOUND, {
+          cursor: '1000123.456',
+        });
+
+        expect(listSessionsSpy).toHaveBeenCalledWith({
+          cursor: 1000123.456,
+          size: 20,
+        });
+      } finally {
+        listSessionsSpy.mockRestore();
+      }
     });
 
     it('excludes live sessions from subsequent pages to prevent cross-page duplicates', async () => {

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -237,6 +237,21 @@ export class InvalidCursorError extends Error {
   }
 }
 
+function parseSessionCursor(cursor: string): number | undefined {
+  if (cursor === '') return undefined;
+  const trimmed = cursor.trim();
+  const parsed = Number(trimmed);
+  if (
+    trimmed === '' ||
+    !Number.isFinite(parsed) ||
+    parsed < 0 ||
+    parsed > Number.MAX_SAFE_INTEGER
+  ) {
+    throw new InvalidCursorError(cursor);
+  }
+  return parsed;
+}
+
 export async function listWorkspaceSessionsForResponse(
   bridge: AcpSessionBridge,
   workspaceCwd: string,
@@ -250,12 +265,8 @@ export async function listWorkspaceSessionsForResponse(
   const pageSize = Math.min(Math.max(requestedSize, 1), MAX_SESSION_PAGE_SIZE);
 
   let numericCursor: number | undefined;
-  if (options?.cursor) {
-    const parsed = Number(options.cursor);
-    if (!Number.isFinite(parsed)) {
-      throw new InvalidCursorError(options.cursor);
-    }
-    numericCursor = parsed;
+  if (options?.cursor != null) {
+    numericCursor = parseSessionCursor(options.cursor);
   }
   const isFirstPage = numericCursor === undefined;
 


### PR DESCRIPTION
## What this PR does

Tightens session-list cursor validation before calling `SessionService.listSessions`. REST / ACP HTTP and in-process ACP now reject negative cursor values, whitespace-only cursor strings, and values above `Number.MAX_SAFE_INTEGER` while preserving existing first-page handling for omitted or empty cursors.

The change keeps non-negative fractional cursors valid because session pagination cursors come from filesystem `mtimeMs`, which can include fractional milliseconds. Tests now cover the invalid edges and assert that fractional cursor values are forwarded without truncation.

## Why it's needed

Session-list cursors are generated by `SessionService.listSessions()` from file `mtimeMs` values. The current handlers already reject non-numeric and non-finite cursors, but still accept finite values like `-1` or `9007199254740992`. Those are not valid page cursors: negative cursors can produce empty persisted pages, and unsafe numeric values can lose precision before filtering.

Rejecting these values keeps the REST / ACP HTTP and in-process ACP paths aligned, while still accepting cursor tokens that can actually be returned by the service.

## Reviewer Test Plan

### How to verify

Run:

```bash
npm test --workspace=packages/cli -- serve/server.test.ts -t cursor --coverage.enabled=false
npm test --workspace=packages/cli -- acp-integration/acpAgent.test.ts -t unstable_listSessions --coverage.enabled=false
npx prettier --check packages/cli/src/serve/server.ts packages/cli/src/serve/server.test.ts packages/cli/src/acp-integration/acpAgent.ts packages/cli/src/acp-integration/acpAgent.test.ts
npx eslint packages/cli/src/serve/server.ts packages/cli/src/serve/server.test.ts packages/cli/src/acp-integration/acpAgent.ts packages/cli/src/acp-integration/acpAgent.test.ts
npm run lint --workspace=packages/cli --if-present
git diff --check
```

Expected behavior: REST session-list requests with invalid cursors such as `abc`, `-1`, `Infinity`, `9007199254740992`, or whitespace-only strings return `400 invalid_cursor`. In-process ACP rejects the same invalid cursor values before constructing `SessionService`. Non-negative fractional cursors such as `1000123.456` remain valid and are forwarded without truncation.

Known unrelated local check failure:

```bash
npm run typecheck --workspace=packages/cli --if-present
```

This still fails in `src/ui/components/BaseTextInput.tsx` because local TypeScript cannot resolve `ink/dom` and `ink/components/CursorContext`; those files are outside this PR.

### Evidence (Before & After)

N/A — non-UI API validation change. Unit tests cover the before/after behavior: invalid negative, unsafe, non-finite, non-numeric, and whitespace-only cursors are rejected; omitted and empty cursors keep first-page behavior; valid fractional `mtimeMs` cursors are preserved.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Local Node/npm workspace. I ran focused Vitest, Prettier check, targeted ESLint, workspace lint, and `git diff --check`. CLI typecheck has the unrelated `ink/dom` resolution failure noted above.

## Risk & Scope

- Main risk or tradeoff: Clients that send malformed finite cursors now receive validation errors instead of empty or imprecise pages. Cursor values returned by the service remain accepted, including fractional `mtimeMs` values.
- Not validated / out of scope: Changing the cursor token format or adding a shared exported parser across packages.
- Breaking changes / migration notes: None expected for valid clients. Omitted and empty cursors continue to mean first page.

## Linked Issues

Fixes #5708

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在调用 `SessionService.listSessions` 之前收紧 session-list cursor 校验。REST / ACP HTTP 和 in-process ACP 现在会拒绝负数 cursor、仅包含空白的 cursor 字符串，以及超过 `Number.MAX_SAFE_INTEGER` 的值；省略 cursor 或传空字符串时，仍保持原有的首页行为。

这个改动保留非负小数 cursor 的合法性，因为 session 分页 cursor 来自文件系统 `mtimeMs`，它可能包含小数毫秒。测试现在覆盖非法边界，并断言小数 cursor 会原样转发、不被截断。

## 为什么需要

Session-list cursor 由 `SessionService.listSessions()` 基于文件 `mtimeMs` 生成。当前 handler 已经拒绝非数字和非有限 cursor，但仍会接受 `-1` 或 `9007199254740992` 这类有限数值。它们不是有效的分页 cursor：负数 cursor 可能产生空的持久化页面，unsafe 数值在过滤前可能发生精度丢失。

拒绝这些值可以让 REST / ACP HTTP 与 in-process ACP 路径保持一致，同时继续接受 service 实际可能返回的 cursor token。

## 审核测试计划

### 如何验证

运行：

```bash
npm test --workspace=packages/cli -- serve/server.test.ts -t cursor --coverage.enabled=false
npm test --workspace=packages/cli -- acp-integration/acpAgent.test.ts -t unstable_listSessions --coverage.enabled=false
npx prettier --check packages/cli/src/serve/server.ts packages/cli/src/serve/server.test.ts packages/cli/src/acp-integration/acpAgent.ts packages/cli/src/acp-integration/acpAgent.test.ts
npx eslint packages/cli/src/serve/server.ts packages/cli/src/serve/server.test.ts packages/cli/src/acp-integration/acpAgent.ts packages/cli/src/acp-integration/acpAgent.test.ts
npm run lint --workspace=packages/cli --if-present
git diff --check
```

预期行为：带有 `abc`、`-1`、`Infinity`、`9007199254740992` 或仅空白字符串等非法 cursor 的 REST session-list 请求返回 `400 invalid_cursor`。In-process ACP 会在构造 `SessionService` 前拒绝相同的非法 cursor。`1000123.456` 这类非负小数 cursor 仍然合法，并且不会被截断。

已知的无关本地检查失败：

```bash
npm run typecheck --workspace=packages/cli --if-present
```

该命令仍然在 `src/ui/components/BaseTextInput.tsx` 失败，因为本地 TypeScript 无法解析 `ink/dom` 和 `ink/components/CursorContext`；这些文件不在本 PR 范围内。

### 证据（修改前后）

N/A — 非 UI 的 API 校验变更。单元测试覆盖修改前后的行为：非法负数、unsafe、非有限、非数字和仅空白 cursor 会被拒绝；省略和空 cursor 仍然表示首页；合法的小数 `mtimeMs` cursor 会被保留。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### 环境（可选）

本地 Node/npm workspace。我运行了 focused Vitest、Prettier check、targeted ESLint、workspace lint 和 `git diff --check`。CLI typecheck 存在上面提到的无关 `ink/dom` 解析失败。

## 风险与范围

- 主要风险或取舍：发送格式错误但有限数值 cursor 的客户端，现在会收到校验错误，而不是空页面或精度不可靠的页面。service 返回的 cursor 值仍会被接受，包括小数 `mtimeMs` 值。
- 未验证 / 不在范围内：改变 cursor token 格式，或在 package 间新增共享导出的 parser。
- 破坏性变更 / 迁移说明：对有效客户端预计无影响。省略和空 cursor 会继续表示首页。

## 关联 Issue

Fixes #5708

## AI 辅助披露

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
