### PR TITLE
fix(vscode): clamp open file positions

### DIFF
--- a/packages/vscode-ide-companion/src/webview/handlers/FileMessageHandler.test.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/FileMessageHandler.test.ts
@@ -30,8 +30,42 @@ const vscodeMock = vi.hoisted(() => {
     }
   }
 
+  class Position {
+    line: number;
+    character: number;
+    constructor(line: number, character: number) {
+      if (line < 0 || character < 0) {
+        throw new Error('Position line and character must be non-negative');
+      }
+      this.line = line;
+      this.character = character;
+    }
+  }
+
+  class Selection {
+    anchor: Position;
+    active: Position;
+    constructor(anchor: Position, active: Position) {
+      this.anchor = anchor;
+      this.active = active;
+    }
+  }
+
+  class Range {
+    start: Position;
+    end: Position;
+    constructor(start: Position, end: Position) {
+      this.start = start;
+      this.end = end;
+    }
+  }
+
   return {
     Uri,
+    Position,
+    Selection,
+    Range,
+    TextEditorRevealType: { InCenter: 2 },
     ViewColumn: { One: 1, Two: 2, Three: 3, Beside: -2 },
     workspace: {
       findFiles: vi.fn(),
@@ -50,6 +84,7 @@ const vscodeMock = vi.hoisted(() => {
     window: {
       activeTextEditor: undefined,
       showTextDocument: vi.fn(),
+      showErrorMessage: vi.fn(),
       tabGroups: {
         all: [] as Array<{
           tabs: Array<{ input: unknown }>;
@@ -249,6 +284,42 @@ describe('FileMessageHandler', () => {
 
     expect(vscodeMock.workspace.openTextDocument).toHaveBeenCalledWith(
       expect.objectContaining({ fsPath: '\\\\server\\share\\app.ts' }),
+    );
+  });
+
+  it('openFile clamps zero line and column values to the file start', async () => {
+    vscodeMock.workspace.workspaceFolders = [
+      { uri: vscode.Uri.file('/workspace'), name: 'workspace', index: 0 },
+    ];
+    vscodeMock.workspace.openTextDocument.mockResolvedValue({
+      uri: vscode.Uri.file('/workspace/src/app.ts'),
+    });
+    const editor = { selection: undefined, revealRange: vi.fn() };
+    vscodeMock.window.showTextDocument.mockResolvedValue(editor);
+
+    const handler = new FileMessageHandler(
+      {} as QwenAgentManager,
+      {} as ConversationStore,
+      null,
+      vi.fn(),
+    );
+
+    await handler.handle({
+      type: 'openFile',
+      data: { path: 'src/app.ts:0:0' },
+    });
+
+    expect(vscodeMock.window.showErrorMessage).not.toHaveBeenCalled();
+    expect(editor.selection).toMatchObject({
+      anchor: { line: 0, character: 0 },
+      active: { line: 0, character: 0 },
+    });
+    expect(editor.revealRange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        start: { line: 0, character: 0 },
+        end: { line: 0, character: 0 },
+      }),
+      vscodeMock.TextEditorRevealType.InCenter,
     );
   });
 

--- a/packages/vscode-ide-companion/src/webview/handlers/FileMessageHandler.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/FileMessageHandler.ts
@@ -123,6 +123,13 @@ export class FileMessageHandler extends BaseMessageHandler {
     );
   }
 
+  private toZeroBasedEditorPosition(value: string | undefined): number {
+    if (!value) {
+      return 0;
+    }
+    return Math.max(0, parseInt(value, 10) - 1);
+  }
+
   private createWatcherForFolder(folder: vscode.WorkspaceFolder): void {
     const rootPath = folder.uri.fsPath;
 
@@ -554,8 +561,8 @@ export class FileMessageHandler extends BaseMessageHandler {
       }
 
       const [, path, lineStr, columnStr] = match;
-      const lineNumber = lineStr ? parseInt(lineStr, 10) - 1 : 0; // VS Code uses 0-based line numbers
-      const columnNumber = columnStr ? parseInt(columnStr, 10) - 1 : 0; // VS Code uses 0-based column numbers
+      const lineNumber = this.toZeroBasedEditorPosition(lineStr);
+      const columnNumber = this.toZeroBasedEditorPosition(columnStr);
 
       // Convert to absolute path if relative
       let absolutePath = path;


### PR DESCRIPTION
## What this PR does

This PR normalizes VS Code companion `openFile` line and column suffixes so zero values such as `src/app.ts:0:0` resolve to the start of the file instead of producing negative editor positions.

It also extends the `FileMessageHandler` test mock with the VS Code position/range APIs used by the open-file path and adds a regression test for the zero line/column case.

## Why it's needed

The web UI can emit file links with a zero-based line value. The VS Code companion treats incoming line/column suffixes as one-based values and subtracts one before creating `vscode.Position`. When the incoming value is `0`, the handler can try to create `vscode.Position(-1, -1)`, which makes the open-file request fail instead of opening the file.

Clamping the converted position keeps the existing one-based behavior for normal `:line:column` links while making zero-valued links safe.

## Reviewer Test Plan

### How to verify

Run `npm test --workspace=packages/vscode-ide-companion -- FileMessageHandler.test.ts` and confirm the new `openFile clamps zero line and column values to the file start` test passes. Reviewers can also confirm that `src/app.ts:0:0` opens `src/app.ts` and selects line 0 / column 0 in the mocked VS Code editor instead of surfacing an open-file error.

### Evidence (Before & After)

Before: `src/app.ts:0:0` was converted by subtracting one directly, producing negative VS Code editor positions.

After: `src/app.ts:0:0` is clamped to line 0 / column 0, and the regression test asserts that no error is shown and the editor selection/reveal range point at the file start.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local workspace tests on macOS with the repository npm workspace setup.

Commands run:

```sh
npm test --workspace=packages/vscode-ide-companion -- FileMessageHandler.test.ts
npx prettier --check packages/vscode-ide-companion/src/webview/handlers/FileMessageHandler.ts packages/vscode-ide-companion/src/webview/handlers/FileMessageHandler.test.ts
npx eslint packages/vscode-ide-companion/src/webview/handlers/FileMessageHandler.ts packages/vscode-ide-companion/src/webview/handlers/FileMessageHandler.test.ts
npm run check-types --workspace=packages/vscode-ide-companion
git diff --check
```

Sub-agent review: no blocking issues found.

## Risk & Scope

- Main risk or tradeoff: A malformed `:0` or `:0:0` location now opens at the file start rather than failing the open-file request.
- Not validated / out of scope: Negative suffixes such as `src/app.ts:-1:0` are not treated as line/column suffixes by the existing parser and are unchanged.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5710

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 会规范 VS Code companion 的 `openFile` 行号和列号后缀解析，让 `src/app.ts:0:0` 这样的零值位置打开到文件开头，而不是产生负数编辑器位置。

同时，测试里的 VS Code mock 补上了 open-file 路径实际用到的 position/range API，并增加了零行号/零列号的回归测试。

## Why it's needed

Web UI 可能发出带零基行号的文件链接。VS Code companion 会把收到的行号/列号后缀当作一基值处理，并在创建 `vscode.Position` 前减一。当传入值是 `0` 时，handler 可能会创建 `vscode.Position(-1, -1)`，导致打开文件请求失败，而不是正常打开文件。

转换后做下限 clamp 可以保留普通 `:line:column` 链接的一基行为，同时让零值链接安全落到文件开头。

## Reviewer Test Plan

### How to verify

运行 `npm test --workspace=packages/vscode-ide-companion -- FileMessageHandler.test.ts`，确认新增的 `openFile clamps zero line and column values to the file start` 测试通过。Reviewer 也可以确认 `src/app.ts:0:0` 会打开 `src/app.ts`，并在 mock 的 VS Code editor 中选择 line 0 / column 0，而不是显示打开文件错误。

### Evidence (Before & After)

Before: `src/app.ts:0:0` 会被直接减一转换，产生负数 VS Code 编辑器位置。

After: `src/app.ts:0:0` 会被 clamp 到 line 0 / column 0，回归测试断言不会显示错误，并且 editor selection/reveal range 指向文件开头。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

在 macOS 上使用仓库 npm workspace 进行本地测试。

已运行命令：

```sh
npm test --workspace=packages/vscode-ide-companion -- FileMessageHandler.test.ts
npx prettier --check packages/vscode-ide-companion/src/webview/handlers/FileMessageHandler.ts packages/vscode-ide-companion/src/webview/handlers/FileMessageHandler.test.ts
npx eslint packages/vscode-ide-companion/src/webview/handlers/FileMessageHandler.ts packages/vscode-ide-companion/src/webview/handlers/FileMessageHandler.test.ts
npm run check-types --workspace=packages/vscode-ide-companion
git diff --check
```

子代理审查：未发现阻塞问题。

## Risk & Scope

- Main risk or tradeoff: 格式异常的 `:0` 或 `:0:0` 位置现在会打开到文件开头，而不是让打开文件请求失败。
- Not validated / out of scope: `src/app.ts:-1:0` 这类负数后缀不会被现有 parser 当作行号/列号后缀处理，本 PR 不改变这部分行为。
- Breaking changes / migration notes: 无。

## Linked Issues

Fixes #5710

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
