### PR TITLE
fix(cli): reject unsupported extension scopes

### DIFF
--- a/packages/cli/src/commands/extensions/disable.test.ts
+++ b/packages/cli/src/commands/extensions/disable.test.ts
@@ -13,11 +13,15 @@ const mockDisableExtension = vi.hoisted(() => vi.fn());
 const mockWriteStdoutLine = vi.hoisted(() => vi.fn());
 const mockWriteStderrLine = vi.hoisted(() => vi.fn());
 
-vi.mock('./utils.js', () => ({
-  getExtensionManager: vi.fn().mockResolvedValue({
-    disableExtension: mockDisableExtension,
-  }),
-}));
+vi.mock('./utils.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./utils.js')>();
+  return {
+    ...actual,
+    getExtensionManager: vi.fn().mockResolvedValue({
+      disableExtension: mockDisableExtension,
+    }),
+  };
+});
 
 vi.mock('../../utils/errors.js', () => ({
   getErrorMessage: vi.fn((error: Error) => error.message),
@@ -30,31 +34,37 @@ vi.mock('../../utils/stdioHelpers.js', () => ({
 }));
 
 describe('extensions disable command', () => {
+  const parseDisableCommand = (command: string) =>
+    yargs([]).command(disableCommand).fail(false).locale('en').parse(command);
+
   it('should fail if no name is provided', () => {
-    const validationParser = yargs([])
-      .command(disableCommand)
-      .fail(false)
-      .locale('en');
-    expect(() => validationParser.parse('disable')).toThrow(
+    expect(() => parseDisableCommand('disable')).toThrow(
       'Not enough non-option arguments: got 0, need at least 1',
     );
   });
 
   it('should fail if invalid scope is provided', () => {
-    const validationParser = yargs([])
-      .command(disableCommand)
-      .fail(false)
-      .locale('en');
     expect(() =>
-      validationParser.parse('disable test-extension --scope=invalid'),
+      parseDisableCommand('disable test-extension --scope=invalid'),
     ).toThrow(/Invalid scope: invalid/);
   });
 
+  it('should fail if unsupported system scopes are provided', () => {
+    expect(() =>
+      parseDisableCommand('disable test-extension --scope=system'),
+    ).toThrow(/Invalid scope: system/);
+    expect(() =>
+      parseDisableCommand('disable test-extension --scope=systemdefaults'),
+    ).toThrow(/Invalid scope: systemdefaults/);
+  });
+
   it('should accept valid scope values', () => {
-    const parser = yargs([]).command(disableCommand).fail(false).locale('en');
     // Just check that the scope option is recognized, actual execution needs name first
     expect(() =>
-      parser.parse('disable my-extension --scope=user'),
+      parseDisableCommand('disable my-extension --scope=user'),
+    ).not.toThrow();
+    expect(() =>
+      parseDisableCommand('disable my-extension --scope=workspace'),
     ).not.toThrow();
   });
 });
@@ -123,14 +133,31 @@ describe('handleDisable', () => {
     processExitSpy.mockRestore();
   });
 
+  it('should reject unsupported system scopes without disabling at user scope', async () => {
+    const processExitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+
+    await handleDisable({
+      name: 'test-extension',
+      scope: 'system',
+    });
+
+    expect(mockDisableExtension).not.toHaveBeenCalled();
+    expect(mockWriteStderrLine).toHaveBeenCalledWith(
+      expect.stringMatching(/Invalid scope: system/),
+    );
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+
+    processExitSpy.mockRestore();
+  });
+
   it('should handle errors and exit with code 1', async () => {
     const processExitSpy = vi
       .spyOn(process, 'exit')
       .mockImplementation(() => undefined as never);
 
-    mockDisableExtension.mockImplementationOnce(() => {
-      throw new Error('Disable failed');
-    });
+    mockDisableExtension.mockRejectedValueOnce(new Error('Disable failed'));
 
     await handleDisable({
       name: 'test-extension',

--- a/packages/cli/src/commands/extensions/disable.ts
+++ b/packages/cli/src/commands/extensions/disable.ts
@@ -8,7 +8,7 @@ import { type CommandModule } from 'yargs';
 import { SettingScope } from '../../config/settings.js';
 import { getErrorMessage } from '../../utils/errors.js';
 import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
-import { getExtensionManager } from './utils.js';
+import { getExtensionManager, resolveExtensionCommandScope } from './utils.js';
 import { t } from '../../i18n/index.js';
 
 interface DisableArgs {
@@ -19,11 +19,8 @@ interface DisableArgs {
 export async function handleDisable(args: DisableArgs) {
   const extensionManager = await getExtensionManager();
   try {
-    if (args.scope?.toLowerCase() === 'workspace') {
-      extensionManager.disableExtension(args.name, SettingScope.Workspace);
-    } else {
-      extensionManager.disableExtension(args.name, SettingScope.User);
-    }
+    const scope = resolveExtensionCommandScope(args.scope);
+    await extensionManager.disableExtension(args.name, scope);
     writeStdoutLine(
       t('Extension "{{name}}" successfully disabled for scope "{{scope}}".', {
         name: args.name,
@@ -51,21 +48,7 @@ export const disableCommand: CommandModule = {
         default: SettingScope.User,
       })
       .check((argv) => {
-        if (
-          argv.scope &&
-          !Object.values(SettingScope)
-            .map((s) => s.toLowerCase())
-            .includes((argv.scope as string).toLowerCase())
-        ) {
-          throw new Error(
-            t('Invalid scope: {{scope}}. Please use one of {{scopes}}.', {
-              scope: argv.scope as string,
-              scopes: Object.values(SettingScope)
-                .map((s) => s.toLowerCase())
-                .join(', '),
-            }),
-          );
-        }
+        resolveExtensionCommandScope(argv.scope as string | undefined);
         return true;
       }),
   handler: async (argv) => {

--- a/packages/cli/src/commands/extensions/enable.test.ts
+++ b/packages/cli/src/commands/extensions/enable.test.ts
@@ -12,11 +12,15 @@ import { SettingScope } from '../../config/settings.js';
 const mockEnableExtension = vi.hoisted(() => vi.fn());
 const mockWriteStdoutLine = vi.hoisted(() => vi.fn());
 
-vi.mock('./utils.js', () => ({
-  getExtensionManager: vi.fn().mockResolvedValue({
-    enableExtension: mockEnableExtension,
-  }),
-}));
+vi.mock('./utils.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./utils.js')>();
+  return {
+    ...actual,
+    getExtensionManager: vi.fn().mockResolvedValue({
+      enableExtension: mockEnableExtension,
+    }),
+  };
+});
 
 vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
   const actual =
@@ -40,31 +44,37 @@ vi.mock('../../utils/stdioHelpers.js', () => ({
 }));
 
 describe('extensions enable command', () => {
+  const parseEnableCommand = (command: string) =>
+    yargs([]).command(enableCommand).fail(false).locale('en').parse(command);
+
   it('should fail if no name is provided', () => {
-    const validationParser = yargs([])
-      .command(enableCommand)
-      .fail(false)
-      .locale('en');
-    expect(() => validationParser.parse('enable')).toThrow(
+    expect(() => parseEnableCommand('enable')).toThrow(
       'Not enough non-option arguments: got 0, need at least 1',
     );
   });
 
   it('should fail if invalid scope is provided', () => {
-    const validationParser = yargs([])
-      .command(enableCommand)
-      .fail(false)
-      .locale('en');
     expect(() =>
-      validationParser.parse('enable test-extension --scope=invalid'),
+      parseEnableCommand('enable test-extension --scope=invalid'),
     ).toThrow(/Invalid scope: invalid/);
   });
 
+  it('should fail if unsupported system scopes are provided', () => {
+    expect(() =>
+      parseEnableCommand('enable test-extension --scope=system'),
+    ).toThrow(/Invalid scope: system/);
+    expect(() =>
+      parseEnableCommand('enable test-extension --scope=systemdefaults'),
+    ).toThrow(/Invalid scope: systemdefaults/);
+  });
+
   it('should accept valid scope values', () => {
-    const parser = yargs([]).command(enableCommand).fail(false).locale('en');
     // Just check that the scope option is recognized, actual execution needs name first
     expect(() =>
-      parser.parse('enable my-extension --scope=user'),
+      parseEnableCommand('enable my-extension --scope=user'),
+    ).not.toThrow();
+    expect(() =>
+      parseEnableCommand('enable my-extension --scope=workspace'),
     ).not.toThrow();
   });
 });
@@ -118,10 +128,19 @@ describe('handleEnable', () => {
     );
   });
 
+  it('should reject unsupported system scopes without enabling at user scope', async () => {
+    await expect(
+      handleEnable({
+        name: 'test-extension',
+        scope: 'system',
+      }),
+    ).rejects.toThrow(/Invalid scope: system/);
+
+    expect(mockEnableExtension).not.toHaveBeenCalled();
+  });
+
   it('should throw FatalConfigError when enable fails', async () => {
-    mockEnableExtension.mockImplementationOnce(() => {
-      throw new Error('Enable failed');
-    });
+    mockEnableExtension.mockRejectedValueOnce(new Error('Enable failed'));
 
     await expect(
       handleEnable({

--- a/packages/cli/src/commands/extensions/enable.ts
+++ b/packages/cli/src/commands/extensions/enable.ts
@@ -6,9 +6,8 @@
 
 import { type CommandModule } from 'yargs';
 import { FatalConfigError, getErrorMessage } from '@qwen-code/qwen-code-core';
-import { SettingScope } from '../../config/settings.js';
 import { writeStdoutLine } from '../../utils/stdioHelpers.js';
-import { getExtensionManager } from './utils.js';
+import { getExtensionManager, resolveExtensionCommandScope } from './utils.js';
 import { t } from '../../i18n/index.js';
 
 interface EnableArgs {
@@ -20,11 +19,8 @@ export async function handleEnable(args: EnableArgs) {
   const extensionManager = await getExtensionManager();
 
   try {
-    if (args.scope?.toLowerCase() === 'workspace') {
-      extensionManager.enableExtension(args.name, SettingScope.Workspace);
-    } else {
-      extensionManager.enableExtension(args.name, SettingScope.User);
-    }
+    const scope = resolveExtensionCommandScope(args.scope);
+    await extensionManager.enableExtension(args.name, scope);
     if (args.scope) {
       writeStdoutLine(
         t('Extension "{{name}}" successfully enabled for scope "{{scope}}".', {
@@ -60,21 +56,7 @@ export const enableCommand: CommandModule = {
         type: 'string',
       })
       .check((argv) => {
-        if (
-          argv.scope &&
-          !Object.values(SettingScope)
-            .map((s) => s.toLowerCase())
-            .includes((argv.scope as string).toLowerCase())
-        ) {
-          throw new Error(
-            t('Invalid scope: {{scope}}. Please use one of {{scopes}}.', {
-              scope: argv.scope as string,
-              scopes: Object.values(SettingScope)
-                .map((s) => s.toLowerCase())
-                .join(', '),
-            }),
-          );
-        }
+        resolveExtensionCommandScope(argv.scope as string | undefined);
         return true;
       }),
   handler: async (argv) => {

--- a/packages/cli/src/commands/extensions/utils.test.ts
+++ b/packages/cli/src/commands/extensions/utils.test.ts
@@ -25,6 +25,12 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
 });
 
 vi.mock('../../config/settings.js', () => ({
+  SettingScope: {
+    User: 'User',
+    Workspace: 'Workspace',
+    System: 'System',
+    SystemDefaults: 'SystemDefaults',
+  },
   loadSettings: vi.fn().mockReturnValue({
     merged: {},
   }),

--- a/packages/cli/src/commands/extensions/utils.ts
+++ b/packages/cli/src/commands/extensions/utils.ts
@@ -11,7 +11,7 @@ import {
   getExtensionDescription,
   type Extension,
 } from '@qwen-code/qwen-code-core';
-import { loadSettings } from '../../config/settings.js';
+import { loadSettings, SettingScope } from '../../config/settings.js';
 import {
   requestConsentOrFail,
   requestConsentNonInteractive,
@@ -38,6 +38,35 @@ export async function getExtensionManager(): Promise<ExtensionManager> {
   });
   await extensionManager.refreshCache();
   return extensionManager;
+}
+
+const EXTENSION_COMMAND_SCOPES = [SettingScope.User, SettingScope.Workspace];
+
+function extensionCommandScopesList(): string {
+  return EXTENSION_COMMAND_SCOPES.map((s) => s.toLowerCase()).join(', ');
+}
+
+export function resolveExtensionCommandScope(
+  scope: string | undefined,
+): SettingScope {
+  if (!scope) {
+    return SettingScope.User;
+  }
+
+  const normalized = scope.toLowerCase();
+  const matched = EXTENSION_COMMAND_SCOPES.find(
+    (candidate) => candidate.toLowerCase() === normalized,
+  );
+  if (matched) {
+    return matched;
+  }
+
+  throw new Error(
+    t('Invalid scope: {{scope}}. Please use one of {{scopes}}.', {
+      scope,
+      scopes: extensionCommandScopesList(),
+    }),
+  );
 }
 
 export function extensionToOutputString(


### PR DESCRIPTION
## What this PR does

This PR narrows `qwen extensions enable --scope` and `qwen extensions disable --scope` to the scopes that extension enablement actually supports: `user` and `workspace`.

It also awaits the async extension manager enable/disable calls so rejected manager failures are handled by the existing command error paths instead of printing success before an unhandled rejection.

## Why it's needed

The commands previously validated `--scope` against every `SettingScope` value, including `system` and `systemdefaults`. The handlers only special-cased `workspace`, so any other accepted scope was sent to the extension manager as `User`. That made commands like `qwen extensions enable my-extension --scope=system` report success for `system` while writing user-scope enablement config.

Rejecting unsupported scopes at command validation and handler level keeps CLI output aligned with the actual persisted scope.

## Reviewer Test Plan

### How to verify

Run the focused extension command tests and confirm that `system` / `systemdefaults` are rejected for both enable and disable, while `user` and `workspace` continue to pass.

### Evidence (Before & After)

Before: `--scope=system` and `--scope=systemdefaults` passed yargs validation and were mapped to user-scope manager calls.

After: those unsupported scopes fail validation with `Invalid scope`, and direct handler calls do not invoke the manager with user scope. Async manager rejections are also covered by tests using rejected promises.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local workspace tests on macOS with the repository npm workspace setup.

Commands run:

```sh
npm test --workspace=packages/cli -- commands/extensions/enable.test.ts commands/extensions/disable.test.ts --coverage.enabled=false
npx prettier --check packages/cli/src/commands/extensions/utils.ts packages/cli/src/commands/extensions/enable.ts packages/cli/src/commands/extensions/disable.ts packages/cli/src/commands/extensions/enable.test.ts packages/cli/src/commands/extensions/disable.test.ts
npx eslint packages/cli/src/commands/extensions/utils.ts packages/cli/src/commands/extensions/enable.ts packages/cli/src/commands/extensions/disable.ts packages/cli/src/commands/extensions/enable.test.ts packages/cli/src/commands/extensions/disable.test.ts
git diff --check
```

Also run:

```sh
npm run typecheck --workspace=packages/cli --if-present
```

This currently fails on unrelated existing `BaseTextInput.tsx` / `ink` type resolution errors:

```text
src/ui/components/BaseTextInput.tsx(25,52): error TS2307: Cannot find module 'ink/dom' or its corresponding type declarations.
src/ui/components/BaseTextInput.tsx(26,27): error TS2307: Cannot find module 'ink/components/CursorContext' or its corresponding type declarations.
src/ui/components/BaseTextInput.tsx(310,9): error TS18046: 'cursorCtx' is of type 'unknown'.
src/ui/components/BaseTextInput.tsx(334,7): error TS18046: 'cursorCtx' is of type 'unknown'.
src/ui/components/BaseTextInput.tsx(341,7): error TS18046: 'cursorCtx' is of type 'unknown'.
```

Sub-agent review: initial async-error finding was addressed; follow-up review found no blocking issues.

## Risk & Scope

- Main risk or tradeoff: Users who previously passed `system` or `systemdefaults` now get a validation error instead of silently writing user-scope enablement config.
- Not validated / out of scope: System-level extension enablement support is not added here; this PR only rejects unsupported scopes.
- Breaking changes / migration notes: None. The affected scope values did not work as requested before.

## Linked Issues

Fixes #5712

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 将 `qwen extensions enable --scope` 和 `qwen extensions disable --scope` 收窄到 extension enablement 实际支持的范围：`user` 和 `workspace`。

同时，handler 现在会 `await` async 的 extension manager enable/disable 调用，让 manager 的 rejected failure 进入现有命令错误路径，而不是先打印成功再出现未处理 rejection。

## Why it's needed

这些命令之前会用所有 `SettingScope` 值校验 `--scope`，包括 `system` 和 `systemdefaults`。但 handler 只特殊处理 `workspace`，其他已通过校验的 scope 都会被当成 `User` 传给 extension manager。这样 `qwen extensions enable my-extension --scope=system` 会报告 system scope 成功，但实际写入 user-scope enablement config。

在命令校验和 handler 层拒绝不支持的 scope，可以让 CLI 输出和真实持久化 scope 保持一致。

## Reviewer Test Plan

### How to verify

运行 focused extension command tests，确认 enable 和 disable 都会拒绝 `system` / `systemdefaults`，同时 `user` 和 `workspace` 仍然通过。

### Evidence (Before & After)

Before: `--scope=system` 和 `--scope=systemdefaults` 可以通过 yargs 校验，并被映射成 user-scope manager 调用。

After: 这些不支持的 scope 会以 `Invalid scope` 校验失败，直接调用 handler 时也不会再用 user scope 调 manager。async manager rejection 也用 rejected promise 测试覆盖。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

在 macOS 上使用仓库 npm workspace 进行本地测试。

已运行命令：

```sh
npm test --workspace=packages/cli -- commands/extensions/enable.test.ts commands/extensions/disable.test.ts --coverage.enabled=false
npx prettier --check packages/cli/src/commands/extensions/utils.ts packages/cli/src/commands/extensions/enable.ts packages/cli/src/commands/extensions/disable.ts packages/cli/src/commands/extensions/enable.test.ts packages/cli/src/commands/extensions/disable.test.ts
npx eslint packages/cli/src/commands/extensions/utils.ts packages/cli/src/commands/extensions/enable.ts packages/cli/src/commands/extensions/disable.ts packages/cli/src/commands/extensions/enable.test.ts packages/cli/src/commands/extensions/disable.test.ts
git diff --check
```

也运行了：

```sh
npm run typecheck --workspace=packages/cli --if-present
```

该命令目前因既有且无关的 `BaseTextInput.tsx` / `ink` 类型解析错误失败：

```text
src/ui/components/BaseTextInput.tsx(25,52): error TS2307: Cannot find module 'ink/dom' or its corresponding type declarations.
src/ui/components/BaseTextInput.tsx(26,27): error TS2307: Cannot find module 'ink/components/CursorContext' or its corresponding type declarations.
src/ui/components/BaseTextInput.tsx(310,9): error TS18046: 'cursorCtx' is of type 'unknown'.
src/ui/components/BaseTextInput.tsx(334,7): error TS18046: 'cursorCtx' is of type 'unknown'.
src/ui/components/BaseTextInput.tsx(341,7): error TS18046: 'cursorCtx' is of type 'unknown'.
```

子代理审查：首次审查发现的 async error handling 问题已修复；复核未发现阻塞问题。

## Risk & Scope

- Main risk or tradeoff: 之前传入 `system` 或 `systemdefaults` 的用户现在会收到校验错误，而不是静默写入 user-scope enablement config。
- Not validated / out of scope: 本 PR 不新增 system-level extension enablement 支持，只拒绝当前不支持的 scope。
- Breaking changes / migration notes: 无。这些 scope 值之前也没有按请求的 scope 生效。

## Linked Issues

Fixes #5712

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
