### PR TITLE
fix(core): reject blank cron prompts

### DIFF
--- a/packages/core/src/tools/cron-create.test.ts
+++ b/packages/core/src/tools/cron-create.test.ts
@@ -99,6 +99,30 @@ describe('CronCreateTool', () => {
     expect(tasks).toHaveLength(0);
   });
 
+  it.each(['', '   '])('rejects blank prompt %j', (prompt) => {
+    expect(() =>
+      tool.build({
+        cron: '*/5 * * * *',
+        prompt,
+      }),
+    ).toThrow('Parameter "prompt" must be a non-empty string.');
+    expect(config._scheduler.list()).toHaveLength(0);
+  });
+
+  it('trims the prompt before scheduling the job', async () => {
+    const invocation = tool.build({
+      cron: '*/5 * * * *',
+      prompt: '  check status  ',
+    });
+
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    const jobs = config._scheduler.list();
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]!.prompt).toBe('check status');
+  });
+
   it('returns error for invalid cron expression', async () => {
     const invocation = tool.build({
       cron: 'bad cron',

--- a/packages/core/src/tools/cron-create.ts
+++ b/packages/core/src/tools/cron-create.ts
@@ -49,6 +49,7 @@ class CronCreateInvocation extends BaseToolInvocation<
     const scheduler = this.config.getCronScheduler();
     const recurring = this.params.recurring !== false;
     const durable = this.params.durable === true;
+    const prompt = this.params.prompt.trim();
 
     try {
       // Validate cron expression before creating the job
@@ -59,12 +60,8 @@ class CronCreateInvocation extends BaseToolInvocation<
       nextFireTime(this.params.cron, new Date());
 
       const job = durable
-        ? await scheduler.createDurable(
-            this.params.cron,
-            this.params.prompt,
-            recurring,
-          )
-        : scheduler.create(this.params.cron, this.params.prompt, recurring);
+        ? await scheduler.createDurable(this.params.cron, prompt, recurring)
+        : scheduler.create(this.params.cron, prompt, recurring);
 
       const display = humanReadableCron(job.cronExpr);
       const returnDisplay = `Scheduled ${job.id} (${display})${durable ? ' [durable]' : ''}`;
@@ -163,6 +160,15 @@ export class CronCreateTool extends BaseDeclarativeTool<
     params: CronCreateParams,
   ): ToolInvocation<CronCreateParams, ToolResult> {
     return new CronCreateInvocation(this.config, params);
+  }
+
+  protected override validateToolParamValues(
+    params: CronCreateParams,
+  ): string | null {
+    if (!params.prompt || params.prompt.trim() === '') {
+      return 'Parameter "prompt" must be a non-empty string.';
+    }
+    return null;
   }
 
   /**


### PR DESCRIPTION
## What this PR does

This PR makes `cron_create` reject empty and whitespace-only prompts before a scheduled job is created.

It also trims accepted prompts before handing them to the cron scheduler, so durable and session-only jobs store the prompt that will actually be enqueued later.

## Why it's needed

`cron_create` schedules future agent input. A blank prompt creates a job that has no useful work to enqueue, and durable mode can persist that blank prompt to the scheduled tasks file.

Other prompt-driven tools already reject empty prompts. This change brings `cron_create` in line with that behavior and prevents meaningless future jobs.

## Reviewer Test Plan

### How to verify

Run the focused cron-create tests and confirm that blank prompts are rejected without creating scheduler jobs, while normal prompts still schedule successfully.

### Evidence (Before & After)

Before: `cron_create` accepted `prompt: ""` or `prompt: "   "` as long as the cron expression was valid, creating a scheduler job.

After: blank prompts fail parameter validation with `Parameter "prompt" must be a non-empty string.`, and the scheduler remains empty. A prompt with surrounding whitespace is trimmed before scheduling.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local workspace tests on macOS with the repository npm workspace setup.

Commands run:

```sh
npm test --workspace=packages/core -- tools/cron-create.test.ts --coverage.enabled=false
npx prettier --check packages/core/src/tools/cron-create.ts packages/core/src/tools/cron-create.test.ts
npx eslint packages/core/src/tools/cron-create.ts packages/core/src/tools/cron-create.test.ts
npm run typecheck --workspace=packages/core --if-present
git diff --check
```

Sub-agent review: no blocking issues found.

## Risk & Scope

- Main risk or tradeoff: Existing callers that pass blank cron prompts now receive a validation error instead of creating a no-op scheduled job.
- Not validated / out of scope: This PR does not change cron expression parsing or scheduler timing.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5715

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让 `cron_create` 在创建 scheduled job 之前拒绝空字符串和纯空白 prompt。

同时，已接受的 prompt 会先 trim 再交给 cron scheduler，因此 durable 和 session-only job 存储的是之后真正会入队执行的 prompt。

## Why it's needed

`cron_create` 会调度未来的 agent 输入。空白 prompt 会创建一个没有实际工作内容的 job，durable 模式还可能把这个空白 prompt 持久化到 scheduled tasks 文件。

其他 prompt-driven tools 已经会拒绝空 prompt。这个改动让 `cron_create` 和这些工具保持一致，避免创建无意义的未来任务。

## Reviewer Test Plan

### How to verify

运行 focused cron-create tests，确认空白 prompt 会被拒绝且不会创建 scheduler job，同时普通 prompt 仍然能正常创建计划任务。

### Evidence (Before & After)

Before: 只要 cron 表达式有效，`cron_create` 会接受 `prompt: ""` 或 `prompt: "   "` 并创建 scheduler job。

After: 空白 prompt 会以 `Parameter "prompt" must be a non-empty string.` 参数校验失败，scheduler 保持为空。带前后空白的 prompt 会在 scheduling 前被 trim。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

在 macOS 上使用仓库 npm workspace 进行本地测试。

已运行命令：

```sh
npm test --workspace=packages/core -- tools/cron-create.test.ts --coverage.enabled=false
npx prettier --check packages/core/src/tools/cron-create.ts packages/core/src/tools/cron-create.test.ts
npx eslint packages/core/src/tools/cron-create.ts packages/core/src/tools/cron-create.test.ts
npm run typecheck --workspace=packages/core --if-present
git diff --check
```

子代理审查：未发现阻塞问题。

## Risk & Scope

- Main risk or tradeoff: 现有调用方如果传入空白 cron prompt，现在会收到校验错误，而不是创建一个 no-op scheduled job。
- Not validated / out of scope: 本 PR 不改变 cron 表达式解析或 scheduler timing。
- Breaking changes / migration notes: 无。

## Linked Issues

Fixes #5715

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
