### PR TITLE
fix(cli): validate channel credential types

### DIFF
--- a/packages/cli/src/commands/channel/config-utils.test.ts
+++ b/packages/cli/src/commands/channel/config-utils.test.ts
@@ -69,6 +69,29 @@ describe('parseChannelConfig', () => {
     ).rejects.toThrow('requires "token"');
   });
 
+  it('throws a clear error when token is not a string', async () => {
+    await expect(
+      parseChannelConfig('bot', { type: 'telegram', token: 123 }),
+    ).rejects.toThrow('Channel "bot" field "token" must be a string.');
+  });
+
+  it('throws a clear error when dingtalk credentials are not strings', async () => {
+    await expect(
+      parseChannelConfig('bot', {
+        type: 'dingtalk',
+        clientId: 123,
+        clientSecret: 'secret',
+      }),
+    ).rejects.toThrow('Channel "bot" field "clientId" must be a string.');
+    await expect(
+      parseChannelConfig('bot', {
+        type: 'dingtalk',
+        clientId: 'client-id',
+        clientSecret: false,
+      }),
+    ).rejects.toThrow('Channel "bot" field "clientSecret" must be a string.');
+  });
+
   it('parses minimal valid config with defaults', async () => {
     const result = await parseChannelConfig('bot', {
       type: 'bare',

--- a/packages/cli/src/commands/channel/config-utils.ts
+++ b/packages/cli/src/commands/channel/config-utils.ts
@@ -25,6 +25,23 @@ export function findCliEntryPath(): string {
   throw new Error('Cannot determine CLI entry path');
 }
 
+function resolveOptionalStringField(
+  channelName: string,
+  rawConfig: Record<string, unknown>,
+  field: 'token' | 'clientId' | 'clientSecret',
+): string | undefined {
+  const value = rawConfig[field];
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+  if (typeof value !== 'string') {
+    throw new Error(
+      `Channel "${channelName}" field "${field}" must be a string.`,
+    );
+  }
+  return resolveEnvVars(value);
+}
+
 export async function parseChannelConfig(
   name: string,
   rawConfig: Record<string, unknown>,
@@ -44,7 +61,8 @@ export async function parseChannelConfig(
 
   // Validate plugin-required fields
   for (const field of plugin.requiredConfigFields ?? []) {
-    if (!rawConfig[field]) {
+    const value = rawConfig[field];
+    if (value === undefined || value === null || value === '') {
       throw new Error(
         `Channel "${name}" (${channelType}) requires "${field}".`,
       );
@@ -52,15 +70,13 @@ export async function parseChannelConfig(
   }
 
   // Resolve env vars for known credential fields
-  const token = rawConfig['token']
-    ? resolveEnvVars(rawConfig['token'] as string)
-    : '';
-  const clientId = rawConfig['clientId']
-    ? resolveEnvVars(rawConfig['clientId'] as string)
-    : undefined;
-  const clientSecret = rawConfig['clientSecret']
-    ? resolveEnvVars(rawConfig['clientSecret'] as string)
-    : undefined;
+  const token = resolveOptionalStringField(name, rawConfig, 'token') ?? '';
+  const clientId = resolveOptionalStringField(name, rawConfig, 'clientId');
+  const clientSecret = resolveOptionalStringField(
+    name,
+    rawConfig,
+    'clientSecret',
+  );
 
   return {
     ...rawConfig,


### PR DESCRIPTION
## What this PR does

This PR validates channel credential fields before resolving environment variables. `token`, `clientId`, and `clientSecret` now must be strings when present.

It also separates missing required credential fields from wrong-typed fields, so values such as `false` or `123` produce a field-specific type error instead of being reported as missing or falling through to an internal `startsWith` TypeError.

## Why it's needed

Channel settings are stored as a broad object, so invalid JSON types can reach `parseChannelConfig()`. The previous parser cast truthy credential values to `string` before calling `resolveEnvVars()`. A config like `{ "type": "telegram", "token": 123 }` could therefore fail with an internal `value.startsWith is not a function` error.

Clear configuration errors make it obvious which channel field is invalid.

## Reviewer Test Plan

### How to verify

Run the focused channel config tests and confirm non-string `token`, `clientId`, and `clientSecret` values are rejected with clear field-specific messages.

### Evidence (Before & After)

Before: non-string credential values could throw internal TypeErrors from env-var resolution, and falsy non-string required values could be reported as missing.

After: non-string credential values fail with messages like `Channel "bot" field "token" must be a string.`, while missing values still use the existing required-field error.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local workspace tests on macOS with the repository npm workspace setup.

Commands run:

```sh
npm test --workspace=packages/cli -- commands/channel/config-utils.test.ts --coverage.enabled=false
npx prettier --check packages/cli/src/commands/channel/config-utils.ts packages/cli/src/commands/channel/config-utils.test.ts
npx eslint packages/cli/src/commands/channel/config-utils.ts packages/cli/src/commands/channel/config-utils.test.ts
git diff --check
```

Also run:

```sh
npm run typecheck --workspace=packages/cli --if-present
```

This currently fails on unrelated existing `BaseTextInput.tsx` / `ink` type resolution errors:

```text
src/ui/components/BaseTextInput.tsx(25,52): error TS2307: Cannot find module 'ink/dom' or its corresponding type declarations.
src/ui/components/BaseTextInput.tsx(26,27): error TS2307: Cannot find module 'ink/components/CursorContext' or its corresponding type declarations.
src/ui/components/BaseTextInput.tsx(310,9): error TS18046: 'cursorCtx' is of type 'unknown'.
src/ui/components/BaseTextInput.tsx(334,7): error TS18046: 'cursorCtx' is of type 'unknown'.
src/ui/components/BaseTextInput.tsx(341,7): error TS18046: 'cursorCtx' is of type 'unknown'.
```

Sub-agent review: no blocking issues found.

## Risk & Scope

- Main risk or tradeoff: Existing invalid channel configs with non-string credential values now fail earlier with a configuration error.
- Not validated / out of scope: This PR does not validate unrelated channel settings such as `allowedUsers`, `groups`, or `senderPolicy`.
- Breaking changes / migration notes: None for valid configs.

## Linked Issues

Fixes #5717

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 会在解析环境变量之前校验 channel credential 字段。`token`、`clientId` 和 `clientSecret` 在出现时现在必须是字符串。

同时，它把缺失的必填 credential 字段和类型错误字段区分开来，因此 `false` 或 `123` 这类值会得到明确的字段类型错误，而不是被报成 missing 或继续进入内部 `startsWith` TypeError。

## Why it's needed

Channel settings 是宽泛 object，错误的 JSON 类型可能进入 `parseChannelConfig()`。之前的 parser 会在调用 `resolveEnvVars()` 前把 truthy credential 值强转成 `string`。因此 `{ "type": "telegram", "token": 123 }` 这样的配置可能以内部 `value.startsWith is not a function` 错误失败。

清晰的配置错误能让用户直接知道哪个 channel 字段无效。

## Reviewer Test Plan

### How to verify

运行 focused channel config tests，确认非字符串的 `token`、`clientId` 和 `clientSecret` 会被清晰的字段级错误拒绝。

### Evidence (Before & After)

Before: 非字符串 credential 值可能从 env-var resolution 抛内部 TypeError；falsy 的非字符串必填值也可能被误报为 missing。

After: 非字符串 credential 值会以类似 `Channel "bot" field "token" must be a string.` 的消息失败；缺失值仍使用已有 required-field 错误。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

在 macOS 上使用仓库 npm workspace 进行本地测试。

已运行命令：

```sh
npm test --workspace=packages/cli -- commands/channel/config-utils.test.ts --coverage.enabled=false
npx prettier --check packages/cli/src/commands/channel/config-utils.ts packages/cli/src/commands/channel/config-utils.test.ts
npx eslint packages/cli/src/commands/channel/config-utils.ts packages/cli/src/commands/channel/config-utils.test.ts
git diff --check
```

也运行了：

```sh
npm run typecheck --workspace=packages/cli --if-present
```

该命令目前因既有且无关的 `BaseTextInput.tsx` / `ink` 类型解析错误失败：

```text
src/ui/components/BaseTextInput.tsx(25,52): error TS2307: Cannot find module 'ink/dom' or its corresponding type declarations.
src/ui/components/BaseTextInput.tsx(26,27): error TS2307: Cannot find module 'ink/components/CursorContext' or its corresponding type declarations.
src/ui/components/BaseTextInput.tsx(310,9): error TS18046: 'cursorCtx' is of type 'unknown'.
src/ui/components/BaseTextInput.tsx(334,7): error TS18046: 'cursorCtx' is of type 'unknown'.
src/ui/components/BaseTextInput.tsx(341,7): error TS18046: 'cursorCtx' is of type 'unknown'.
```

子代理审查：未发现阻塞问题。

## Risk & Scope

- Main risk or tradeoff: credential 字段为非字符串的无效 channel config 现在会更早以配置错误失败。
- Not validated / out of scope: 本 PR 不校验 `allowedUsers`、`groups` 或 `senderPolicy` 等其他 channel settings。
- Breaking changes / migration notes: 对有效配置无影响。

## Linked Issues

Fixes #5717

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
