### PR TITLE
fix(serve): validate list maxEntries as a positive integer

### DIFF
--- a/packages/cli/src/serve/fs/workspace-file-system.test.ts
+++ b/packages/cli/src/serve/fs/workspace-file-system.test.ts
@@ -262,6 +262,25 @@ describe('WorkspaceFileSystem - list', () => {
     });
     expect(entries).toHaveLength(2);
   });
+
+  it('rejects a non-positive-integer maxEntries with parse_error', async () => {
+    const r = await h.fs.resolve('.', 'list');
+    // Infinity/NaN make `entries.length >= maxEntries` silently never break;
+    // floats / 0 / negatives are equally meaningless. Reject them up front,
+    // matching how readText() guards its `limit` / `line`.
+    for (const bad of [
+      Infinity,
+      NaN,
+      0,
+      -1,
+      1.5,
+      Number.MAX_SAFE_INTEGER + 1,
+    ]) {
+      const err = await h.fs.list(r, { maxEntries: bad }).catch((e) => e);
+      expect(isFsError(err)).toBe(true);
+      expect(String(err)).toContain('maxEntries');
+    }
+  });
 });
 
 describe('WorkspaceFileSystem - glob', () => {

--- a/packages/cli/src/serve/fs/workspace-file-system.ts
+++ b/packages/cli/src/serve/fs/workspace-file-system.ts
@@ -520,6 +520,18 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
     const start = performance.now();
     try {
       assertTrustedForIntent(this.deps.trusted, 'list');
+      // Reject malformed caps the same way readText() guards `limit`/`line`:
+      // an unvalidated Infinity/NaN/float/0/negative makes the
+      // `entries.length >= opts.maxEntries` break check silently wrong.
+      if (
+        opts.maxEntries !== undefined &&
+        (!Number.isSafeInteger(opts.maxEntries) || opts.maxEntries < 1)
+      ) {
+        throw new FsError(
+          'parse_error',
+          `maxEntries must be a positive integer, got ${opts.maxEntries}`,
+        );
+      }
       const entries: FsEntry[] = [];
       const dir = await fsp.opendir(p as string);
       for await (const d of dir) {


### PR DESCRIPTION
## What this PR does

Validates the `maxEntries` option of the workspace file-system `list()` as a positive integer, rejecting `Infinity` / `NaN` / floats / `0` / negatives with a `parse_error` — the same guard `readText()` already applies to its `limit` and `line` options in the same file.

## Why it's needed

`list()` caps results with `if (entries.length >= opts.maxEntries) break`. With an unvalidated `maxEntries` of `Infinity` or `NaN`, that comparison is always false, so the cap is silently ignored and the entire directory is returned; a float, `0`, or a negative is equally meaningless. `readText()` in the same file already rejects bad `limit` / `line` values this way (#5639), so this closes the same validation gap for `list()`'s `maxEntries` and keeps the two entry points consistent.

## Reviewer Test Plan

### How to verify

Run the workspace file-system suite: `npx vitest run packages/cli/src/serve/fs/workspace-file-system.test.ts`. The new test `rejects a non-positive-integer maxEntries with parse_error` exercises `Infinity`, `NaN`, `0`, `-1`, `1.5`, and `Number.MAX_SAFE_INTEGER + 1`, asserting each is rejected with an `FsError` of kind `parse_error`. Expected: 77 passed. Stashing only the source guard makes that one test fail (the bad value is no longer rejected), which confirms the test reproduces the gap; restoring the guard makes it pass again. Valid positive-integer `maxEntries` is unchanged.

### Evidence (Before & After)

N/A — non–user-visible change in the serve layer (input validation), no TUI surface. Verified by unit test (see above): 1 failed without the guard, 77 passed with it.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A — macOS/Linux covered by CI -->

### Environment (optional)

Unit tests only (`vitest`); no runtime / sandbox needed.

## Risk & Scope

- Main risk or tradeoff: Low — a previously-accepted-but-meaningless `maxEntries` (e.g. `Infinity`, a float, `0`, a negative) now throws `parse_error` instead of silently returning the whole directory. Any caller relying on that silent no-cap behavior would now see an error, but that path was already broken (the cap was ignored).
- Not validated / out of scope: Only `list()`'s `maxEntries` is touched; the other `list()` options and the rest of the file are unchanged.
- Breaking changes / migration notes: None for valid input. Callers must pass a positive integer (or omit `maxEntries`), which matches `readText()`'s existing contract.

## Linked Issues

No issue; mirrors the validation added for `readText()` in #5639.

<details>
<summary>中文说明</summary>

`list()` 用 `if (entries.length >= opts.maxEntries) break` 来限制返回条数，但没有校验 `maxEntries`。传入 `Infinity` / `NaN` 时这个比较恒为 false，上限被静默忽略、整目录被返回；浮点数、`0`、负数同样没有意义。同文件的 `readText()` 早已对 `limit` / `line` 做了同样的校验（#5639），这个 PR 给 `list()` 的 `maxEntries` 补上一致的「正整数」校验，非法值抛 `parse_error`。新增测试覆盖 `Infinity`/`NaN`/`0`/`-1`/`1.5`/超安全整数；去掉修复后该测试失败、加回后 77 通过。合法的正整数行为不变。

</details>
