### PR TITLE
fix(cli): use high-contrast software cursor

### DIFF
--- a/packages/cli/src/ui/components/BaseTextInput.test.tsx
+++ b/packages/cli/src/ui/components/BaseTextInput.test.tsx
@@ -6,10 +6,11 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from 'ink-testing-library';
-import { BaseTextInput } from './BaseTextInput.js';
+import { BaseTextInput, defaultRenderLine } from './BaseTextInput.js';
 import { useKeypress } from '../hooks/useKeypress.js';
 import type { Key } from '../hooks/useKeypress.js';
 import type { TextBuffer } from './shared/text-buffer.js';
+import { renderSoftwareCursor } from '../utils/software-cursor.js';
 
 vi.mock('../hooks/useKeypress.js', () => ({
   useKeypress: vi.fn(),
@@ -93,5 +94,43 @@ describe('BaseTextInput', () => {
     handler(typedKey);
 
     expect(buffer.handleInput).toHaveBeenCalledWith(typedKey);
+  });
+
+  it('renders the software cursor on the current character', () => {
+    const { lastFrame } = render(
+      <>
+        {defaultRenderLine({
+          lineText: 'hello',
+          isOnCursorLine: true,
+          cursorCol: 2,
+          showCursor: true,
+          visualLineIndex: 0,
+          absoluteVisualIndex: 0,
+          buffer: createBuffer(),
+          scrollVisualRow: 0,
+        })}
+      </>,
+    );
+
+    expect(lastFrame()).toContain(`he${renderSoftwareCursor('l')}lo`);
+  });
+
+  it('renders the software cursor as a trailing space', () => {
+    const { lastFrame } = render(
+      <>
+        {defaultRenderLine({
+          lineText: 'hello',
+          isOnCursorLine: true,
+          cursorCol: 5,
+          showCursor: true,
+          visualLineIndex: 0,
+          absoluteVisualIndex: 0,
+          buffer: createBuffer(),
+          scrollVisualRow: 0,
+        })}
+      </>,
+    );
+
+    expect(lastFrame()).toContain(`hello${renderSoftwareCursor(' ')}`);
   });
 });

--- a/packages/cli/src/ui/components/BaseTextInput.tsx
+++ b/packages/cli/src/ui/components/BaseTextInput.tsx
@@ -24,7 +24,6 @@ import { useCallback, useContext, useEffect, useRef } from 'react';
 import { Box, Text } from 'ink';
 import { addLayoutListener, type DOMElement } from 'ink/dom';
 import CursorContext from 'ink/components/CursorContext';
-import chalk from 'chalk';
 import type { TextBuffer } from './shared/text-buffer.js';
 import type { Key } from '../hooks/useKeypress.js';
 import { useKeypress } from '../hooks/useKeypress.js';
@@ -32,6 +31,7 @@ import { keyMatchers, Command } from '../keyMatchers.js';
 import stringWidth from 'string-width';
 import { cpSlice, cpLen } from '../utils/textUtils.js';
 import { theme } from '../semantic-colors.js';
+import { renderSoftwareCursor } from '../utils/software-cursor.js';
 
 // ─── Types ──────────────────────────────────────────────────
 
@@ -88,7 +88,7 @@ export interface BaseTextInputProps {
 // ─── Default line renderer ──────────────────────────────────
 
 /**
- * Renders a single visual line with an inverse-video block cursor.
+ * Renders a single visual line with a high-contrast block cursor.
  * Uses codepoint-aware string operations for Unicode/emoji safety.
  */
 export function defaultRenderLine({
@@ -103,12 +103,12 @@ export function defaultRenderLine({
 
   const len = cpLen(lineText);
 
-  // Cursor past end of line — append inverse space
+  // Cursor past end of line — append cursor space
   if (cursorCol >= len) {
     return (
       <Text>
         {lineText}
-        {chalk.inverse(' ') + '\u200B'}
+        {renderSoftwareCursor(' ') + '\u200B'}
       </Text>
     );
   }
@@ -120,7 +120,7 @@ export function defaultRenderLine({
   return (
     <Text>
       {before}
-      {chalk.inverse(cursorChar)}
+      {renderSoftwareCursor(cursorChar)}
       {after}
     </Text>
   );
@@ -378,7 +378,7 @@ export const BaseTextInput = ({
           {buffer.text.length === 0 && placeholder ? (
             showCursor ? (
               <Text>
-                {chalk.inverse(placeholder.slice(0, 1))}
+                {renderSoftwareCursor(placeholder.slice(0, 1))}
                 <Text color={theme.text.secondary}>{placeholder.slice(1)}</Text>
               </Text>
             ) : (

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -30,7 +30,7 @@ import { useVoiceInput } from '../hooks/use-voice-input.js';
 import * as clipboardUtils from '../utils/clipboardUtils.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 import stripAnsi from 'strip-ansi';
-import chalk from 'chalk';
+import { renderSoftwareCursor } from '../utils/software-cursor.js';
 import { useUIState } from '../contexts/UIStateContext.js';
 import { useUIActions } from '../contexts/UIActionsContext.js';
 import {
@@ -3019,8 +3019,8 @@ describe('InputPrompt', () => {
       await wait();
 
       const frame = stdout.lastFrame();
-      // The component will render the text with the character at the cursor inverted.
-      expect(frame).toContain(`hel${chalk.inverse('l')}o world`);
+      // The component will render the text with the character at the cursor styled.
+      expect(frame).toContain(`hel${renderSoftwareCursor('l')}o world`);
       unmount();
     });
 
@@ -3036,11 +3036,11 @@ describe('InputPrompt', () => {
       await wait();
 
       const frame = stdout.lastFrame();
-      expect(frame).toContain(`${chalk.inverse('h')}ello`);
+      expect(frame).toContain(`${renderSoftwareCursor('h')}ello`);
       unmount();
     });
 
-    it('should display cursor at the end of the line as an inverted space', async () => {
+    it('should display cursor at the end of the line as a styled space', async () => {
       mockBuffer.text = 'hello';
       mockBuffer.lines = ['hello'];
       mockBuffer.viewportVisualLines = ['hello'];
@@ -3052,7 +3052,7 @@ describe('InputPrompt', () => {
       await wait();
 
       const frame = stdout.lastFrame();
-      expect(frame).toContain(`hello${chalk.inverse(' ')}`);
+      expect(frame).toContain(`hello${renderSoftwareCursor(' ')}`);
       unmount();
     });
 
@@ -3069,7 +3069,7 @@ describe('InputPrompt', () => {
 
       const frame = stdout.lastFrame();
       // The token '@path/to/file' is colored, and the cursor highlights one char inside it.
-      expect(frame).toContain(`@path/${chalk.inverse('t')}o/file`);
+      expect(frame).toContain(`@path/${renderSoftwareCursor('t')}o/file`);
       unmount();
     });
 
@@ -3086,7 +3086,7 @@ describe('InputPrompt', () => {
       await wait();
 
       const frame = stdout.lastFrame();
-      expect(frame).toContain(`hello ${chalk.inverse('👍')} world`);
+      expect(frame).toContain(`hello ${renderSoftwareCursor('👍')} world`);
       unmount();
     });
 
@@ -3103,7 +3103,7 @@ describe('InputPrompt', () => {
       await wait();
 
       const frame = stdout.lastFrame();
-      expect(frame).toContain(`hello 👍${chalk.inverse(' ')}`);
+      expect(frame).toContain(`hello 👍${renderSoftwareCursor(' ')}`);
       unmount();
     });
 
@@ -3119,7 +3119,7 @@ describe('InputPrompt', () => {
       await wait();
 
       const frame = stdout.lastFrame();
-      expect(frame).toContain(chalk.inverse(' '));
+      expect(frame).toContain(renderSoftwareCursor(' '));
       unmount();
     });
 
@@ -3135,7 +3135,7 @@ describe('InputPrompt', () => {
       await wait();
 
       const frame = stdout.lastFrame();
-      expect(frame).toContain(`hello${chalk.inverse(' ')}world`);
+      expect(frame).toContain(`hello${renderSoftwareCursor(' ')}world`);
       unmount();
     });
 
@@ -3157,7 +3157,7 @@ describe('InputPrompt', () => {
       await wait();
 
       const frame = stdout.lastFrame();
-      expect(frame).toContain(`sec${chalk.inverse('o')}nd line`);
+      expect(frame).toContain(`sec${renderSoftwareCursor('o')}nd line`);
       unmount();
     });
 
@@ -3178,7 +3178,7 @@ describe('InputPrompt', () => {
       await wait();
 
       const frame = stdout.lastFrame();
-      expect(frame).toContain(`${chalk.inverse('s')}econd line`);
+      expect(frame).toContain(`${renderSoftwareCursor('s')}econd line`);
       unmount();
     });
 
@@ -3199,7 +3199,7 @@ describe('InputPrompt', () => {
       await wait();
 
       const frame = stdout.lastFrame();
-      expect(frame).toContain(`first line${chalk.inverse(' ')}`);
+      expect(frame).toContain(`first line${renderSoftwareCursor(' ')}`);
       unmount();
     });
 
@@ -3222,9 +3222,9 @@ describe('InputPrompt', () => {
 
       const frame = stdout.lastFrame();
       const lines = frame!.split('\n');
-      // The line with the cursor should just be an inverted space inside the box border
+      // The line with the cursor should just be a styled space inside the box border
       expect(
-        lines.find((l) => l.includes(chalk.inverse(' '))),
+        lines.find((l) => l.includes(renderSoftwareCursor(' '))),
       ).not.toBeUndefined();
       unmount();
     });
@@ -3254,7 +3254,7 @@ describe('InputPrompt', () => {
       // Check that all lines, including the empty one, are rendered.
       // This implicitly tests that the Box wrapper provides height for the empty line.
       expect(frame).toContain('hello');
-      expect(frame).toContain(`world${chalk.inverse(' ')}`);
+      expect(frame).toContain(`world${renderSoftwareCursor(' ')}`);
 
       const outputLines = frame!.split('\n');
       // The number of lines should be 2 for the border plus 3 for the content.
@@ -3992,9 +3992,9 @@ describe('InputPrompt', () => {
         <InputPrompt {...props} />,
       );
       await wait();
-      expect(stdout.lastFrame()).not.toContain(`{chalk.inverse(' ')}`);
+      expect(stdout.lastFrame()).not.toContain(`{renderSoftwareCursor(' ')}`);
       // This snapshot is good to make sure there was an input prompt but does
-      // not show the inverted cursor because snapshots do not show colors.
+      // not show the software cursor because snapshots do not show colors.
       expect(stdout.lastFrame()).toMatchSnapshot();
       unmount();
     });
@@ -4938,7 +4938,9 @@ describe('InputPrompt', () => {
       mockBuffer.setText('');
       mockBuffer.visualCursor = [0, 0];
 
-      const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+      const { stdin, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
       await wait();
 
       stdin.write('[B'); // Down arrow at the bottom edge

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -14,7 +14,7 @@ import { useInputHistory } from '../hooks/useInputHistory.js';
 import type { TextBuffer } from './shared/text-buffer.js';
 import { logicalPosToOffset } from './shared/text-buffer.js';
 import { cpSlice, cpLen } from '../utils/textUtils.js';
-import chalk from 'chalk';
+import { renderSoftwareCursor } from '../utils/software-cursor.js';
 import { useShellHistory } from '../hooks/useShellHistory.js';
 import { useReverseSearchCompletion } from '../hooks/useReverseSearchCompletion.js';
 import {
@@ -1677,7 +1677,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
               cursorVisualColAbsolute - segStart + 1,
             );
             const highlighted = showCursorOpt
-              ? chalk.inverse(charToHighlight)
+              ? renderSoftwareCursor(charToHighlight)
               : charToHighlight;
             display =
               cpSlice(seg.text, 0, cursorVisualColAbsolute - segStart) +
@@ -1705,7 +1705,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         if (ghostText && showCursorOpt && ghostText.text.length > 0) {
           if (ghostText.showCursorBeforeText) {
             renderedLine.push(
-              <Text key="ghost-cursor">{chalk.inverse(' ')}</Text>,
+              <Text key="ghost-cursor">{renderSoftwareCursor(' ')}</Text>,
             );
             renderedLine.push(
               <Text key="ghost-rest" color={theme.text.secondary}>
@@ -1713,11 +1713,11 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
               </Text>,
             );
           } else {
-            // First ghost char: inverted (as cursor). Rest: dimmed gray.
+            // First ghost char: software cursor. Rest: dimmed gray.
             const firstChar = ghostText.text[0]!;
             const rest = ghostText.text.slice(firstChar.length);
             renderedLine.push(
-              <Text key="ghost-cursor">{chalk.inverse(firstChar)}</Text>,
+              <Text key="ghost-cursor">{renderSoftwareCursor(firstChar)}</Text>,
             );
             if (rest.length > 0) {
               renderedLine.push(
@@ -1732,7 +1732,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           // Add zero-width space after cursor to prevent Ink from trimming trailing whitespace
           renderedLine.push(
             <Text key={`cursor-end-${cursorVisualColAbsolute}`}>
-              {showCursorOpt ? chalk.inverse(' ') + '\u200B' : ' \u200B'}
+              {showCursorOpt ? renderSoftwareCursor(' ') + '\u200B' : ' \u200B'}
             </Text>,
           );
         }

--- a/packages/cli/src/ui/components/SettingInputPrompt.tsx
+++ b/packages/cli/src/ui/components/SettingInputPrompt.tsx
@@ -10,7 +10,7 @@ import { theme } from '../semantic-colors.js';
 import { TextInput } from './shared/TextInput.js';
 import { t } from '../../i18n/index.js';
 import { useKeypress, type Key } from '../hooks/useKeypress.js';
-import chalk from 'chalk';
+import { renderSoftwareCursor } from '../utils/software-cursor.js';
 
 type SettingInputPromptProps = {
   settingName: string;
@@ -69,7 +69,7 @@ const PasswordInput = ({
 
   const maskedValue = '*'.repeat(value.length);
   const displayValue = maskedValue || '';
-  const cursorChar = chalk.inverse(' ');
+  const cursorChar = renderSoftwareCursor(' ');
 
   return (
     <Box>

--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -37,8 +37,8 @@ import { useUIActions } from '../contexts/UIActionsContext.js';
 import { createDebugLogger, type Config } from '@qwen-code/qwen-code-core';
 import { useKeypress } from '../hooks/useKeypress.js';
 import { keyMatchers, Command } from '../keyMatchers.js';
-import chalk from 'chalk';
 import { cpSlice, cpLen, stripUnsafeCharacters } from '../utils/textUtils.js';
+import { renderSoftwareCursor } from '../utils/software-cursor.js';
 import {
   type SettingsValue,
   TOGGLE_TYPES,
@@ -821,10 +821,10 @@ export function SettingsDialog({
                 );
                 const afterCursor = cpSlice(editBuffer, editCursorPos + 1);
                 displayValue =
-                  beforeCursor + chalk.inverse(atCursor) + afterCursor;
+                  beforeCursor + renderSoftwareCursor(atCursor) + afterCursor;
               } else if (cursorVisible && editCursorPos >= cpLen(editBuffer)) {
-                // Cursor is at the end - show inverted space
-                displayValue = editBuffer + chalk.inverse(' ');
+                // Cursor is at the end - show software cursor space
+                displayValue = editBuffer + renderSoftwareCursor(' ');
               } else {
                 // Cursor not visible
                 displayValue = editBuffer;

--- a/packages/cli/src/ui/components/shared/TextInput.test.tsx
+++ b/packages/cli/src/ui/components/shared/TextInput.test.tsx
@@ -19,6 +19,7 @@ vi.mock('../../hooks/usePreferredEditor.js');
 vi.mock('../../semantic-colors.js', () => ({
   theme: {
     text: { accent: 'cyan' },
+    background: { primary: '#1E1E1E' },
     status: { error: 'red' },
   },
 }));

--- a/packages/cli/src/ui/components/shared/TextInput.tsx
+++ b/packages/cli/src/ui/components/shared/TextInput.tsx
@@ -5,7 +5,6 @@
  */
 
 import { Box, Text, useStdin } from 'ink';
-import chalk from 'chalk';
 import stringWidth from 'string-width';
 import { useTextBuffer } from './text-buffer.js';
 import { usePreferredEditor } from '../../hooks/usePreferredEditor.js';
@@ -16,6 +15,7 @@ import { theme } from '../../semantic-colors.js';
 import { Colors } from '../../colors.js';
 import type { Key } from '../../hooks/useKeypress.js';
 import { useCallback, useRef, useEffect, useState } from 'react';
+import { renderSoftwareCursor } from '../../utils/software-cursor.js';
 
 export interface TextInputProps {
   value: string;
@@ -197,7 +197,7 @@ export function TextInput({
           {buffer.text.length === 0 && placeholder ? (
             shouldRenderCursor ? (
               <Text>
-                {chalk.inverse(placeholder.slice(0, 1))}
+                {renderSoftwareCursor(placeholder.slice(0, 1))}
                 <Text color={Colors.Gray}>{placeholder.slice(1)}</Text>
               </Text>
             ) : (
@@ -227,7 +227,7 @@ export function TextInput({
                         relativeVisualColForHighlight,
                         relativeVisualColForHighlight + 1,
                       ) || ' ';
-                    const highlighted = chalk.inverse(charToHighlight);
+                    const highlighted = renderSoftwareCursor(charToHighlight);
                     display =
                       cpSlice(display, 0, relativeVisualColForHighlight) +
                       highlighted +
@@ -236,7 +236,7 @@ export function TextInput({
                     relativeVisualColForHighlight === cpLen(display) &&
                     cpLen(display) === inputWidth
                   ) {
-                    display = display + chalk.inverse(' ');
+                    display = display + renderSoftwareCursor(' ');
                   }
                 }
               }

--- a/packages/cli/src/ui/utils/software-cursor.test.ts
+++ b/packages/cli/src/ui/utils/software-cursor.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  getSoftwareCursorBackground,
+  renderSoftwareCursor,
+} from './software-cursor.js';
+
+describe('renderSoftwareCursor', () => {
+  it('uses a dark cursor background on light themes', () => {
+    expect(getSoftwareCursorBackground('#FAFAFA')).toBe('#3A3A3A');
+  });
+
+  it('uses a light cursor background on dark themes', () => {
+    expect(getSoftwareCursorBackground('#002b36')).toBe('#D4D4D4');
+  });
+
+  it('handles named ANSI theme background colors', () => {
+    expect(getSoftwareCursorBackground('white')).toBe('#3A3A3A');
+    expect(getSoftwareCursorBackground('black')).toBe('#D4D4D4');
+  });
+
+  it('falls back to a light cursor background when the theme background is unknown', () => {
+    expect(getSoftwareCursorBackground('')).toBe('#D4D4D4');
+  });
+
+  it('uses an explicit background instead of reverse-video styling', () => {
+    const rendered = renderSoftwareCursor('x');
+
+    expect(rendered).toContain('x');
+    expect(rendered).not.toContain('\u001b[7m');
+  });
+
+  it('does not reset the surrounding foreground color', () => {
+    const rendered = renderSoftwareCursor('x');
+
+    expect(rendered).not.toContain('\u001b[39m');
+  });
+
+  it('renders an empty cursor cell as a space', () => {
+    expect(renderSoftwareCursor('')).toContain(' ');
+  });
+});

--- a/packages/cli/src/ui/utils/software-cursor.ts
+++ b/packages/cli/src/ui/utils/software-cursor.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import chalk from 'chalk';
+import { theme } from '../semantic-colors.js';
+import { resolveColor } from '../themes/color-utils.js';
+
+const LIGHT_CURSOR_BACKGROUND = '#D4D4D4';
+const DARK_CURSOR_BACKGROUND = '#3A3A3A';
+const INK_NAME_TO_HEX: Readonly<Record<string, string>> = {
+  black: '#000000',
+  red: '#ff0000',
+  green: '#00ff00',
+  yellow: '#ffff00',
+  blue: '#0000ff',
+  cyan: '#00ffff',
+  magenta: '#ff00ff',
+  white: '#ffffff',
+  gray: '#808080',
+  grey: '#808080',
+  blackbright: '#808080',
+  redbright: '#ff8080',
+  greenbright: '#80ff80',
+  yellowbright: '#ffff80',
+  bluebright: '#8080ff',
+  cyanbright: '#80ffff',
+  magentabright: '#ff80ff',
+  whitebright: '#ffffff',
+};
+
+function toHex(color: string): string | undefined {
+  const resolved = resolveColor(color) ?? color;
+  const lower = resolved.toLowerCase();
+
+  if (/^#[0-9a-f]{3}$/.test(lower)) {
+    return `#${lower
+      .slice(1)
+      .split('')
+      .map((c) => c + c)
+      .join('')}`;
+  }
+
+  if (/^#[0-9a-f]{6}$/.test(lower)) {
+    return lower;
+  }
+
+  return INK_NAME_TO_HEX[lower];
+}
+
+export function getSoftwareCursorBackground(
+  backgroundColor = theme.background?.primary ?? '',
+): string {
+  const hex = backgroundColor ? toHex(backgroundColor) : undefined;
+  if (!hex) {
+    return LIGHT_CURSOR_BACKGROUND;
+  }
+
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  const luminance = (r * 299 + g * 587 + b * 114) / 1000;
+
+  return luminance >= 128 ? DARK_CURSOR_BACKGROUND : LIGHT_CURSOR_BACKGROUND;
+}
+
+export function renderSoftwareCursor(text: string): string {
+  return chalk.bgHex(getSoftwareCursorBackground())(text || ' ');
+}


### PR DESCRIPTION
## What this PR does

Replaces the input software cursor's terminal-dependent reverse-video styling with a shared high-contrast cursor renderer. The renderer chooses a light or dark cursor background from the active theme background, so dark themes such as Solarized/Alacritty get a visible light cursor while light themes get a visible dark cursor.

The shared renderer is used by the main prompt, the base text input, the legacy shared text input, the sensitive setting prompt, and the settings dialog edit buffer. Existing line-end zero-width-space behavior is preserved so trailing cursor spaces are not trimmed by Ink.

## Why it's needed

Some terminals and color palettes render `chalk.inverse()` with very low contrast. In the reported Alacritty setup, the cursor becomes semi-invisible because reverse video depends on how the terminal swaps the current foreground and background colors.

Using an explicit, theme-aware cursor background makes the software cursor visible without adding terminal-specific branches.

## Reviewer Test Plan

### How to verify

1. Open Qwen Code in a terminal/theme where the input cursor was hard to see, such as Alacritty with a dark Solarized-style palette.
2. Focus the main input prompt and move the cursor through normal text, token-highlighted text, Unicode text, and the end of a line.
3. Confirm the cursor is a visible block in those positions and that typing/navigation behavior is unchanged.
4. Optionally switch to a light theme and confirm the cursor remains visible there too.

### Evidence (Before & After)

Before: the software cursor used `chalk.inverse()`, which emits reverse-video styling and can be low-contrast in Alacritty palettes.

After: cursor rendering uses `renderSoftwareCursor()`, which emits an explicit theme-aware background and unit tests assert it does not use SGR 7 reverse video or reset surrounding foreground color.

Local validation:

```console
$ npm test --workspace=packages/cli -- ui/utils/software-cursor.test.ts ui/components/InputPrompt.test.tsx ui/components/BaseTextInput.test.tsx ui/components/shared/TextInput.test.tsx ui/components/SettingInputPrompt.test.tsx --coverage.enabled=false
Test Files  5 passed (5)
Tests  202 passed (202)

$ npx eslint packages/cli/src/ui/utils/software-cursor.ts packages/cli/src/ui/utils/software-cursor.test.ts packages/cli/src/ui/components/BaseTextInput.tsx packages/cli/src/ui/components/BaseTextInput.test.tsx packages/cli/src/ui/components/InputPrompt.tsx packages/cli/src/ui/components/InputPrompt.test.tsx packages/cli/src/ui/components/SettingInputPrompt.tsx packages/cli/src/ui/components/SettingsDialog.tsx packages/cli/src/ui/components/shared/TextInput.tsx packages/cli/src/ui/components/shared/TextInput.test.tsx

$ npx prettier --check packages/cli/src/ui/utils/software-cursor.ts packages/cli/src/ui/utils/software-cursor.test.ts packages/cli/src/ui/components/BaseTextInput.tsx packages/cli/src/ui/components/BaseTextInput.test.tsx packages/cli/src/ui/components/InputPrompt.tsx packages/cli/src/ui/components/InputPrompt.test.tsx packages/cli/src/ui/components/SettingInputPrompt.tsx packages/cli/src/ui/components/SettingsDialog.tsx packages/cli/src/ui/components/shared/TextInput.tsx packages/cli/src/ui/components/shared/TextInput.test.tsx
All matched files use Prettier code style!

$ npm run typecheck --workspace=packages/cli --if-present
tsc --noEmit

$ git diff --check upstream/main..HEAD
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested locally   |
|  🐧 Linux  |   ⚠️ not tested locally   |

### Environment (optional)

Local validation used Node v26.3.0 and npm 11.16.0.

## Risk & Scope

- Main risk or tradeoff: the cursor now uses an explicit background color instead of terminal reverse video, so it may look slightly different from the previous terminal-native inverse style.
- Not validated / out of scope: I did not run a live Alacritty capture locally; the change is validated with focused rendering tests and the reported root cause.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5713

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 将输入框的软件光标从依赖终端反色视频的样式，改为共享的高对比光标渲染器。渲染器会根据当前主题背景选择浅色或深色光标背景，因此像 Solarized/Alacritty 这类深色主题会得到可见的浅色光标，浅色主题会得到可见的深色光标。

共享渲染器用于主输入框、基础文本输入框、旧的共享文本输入框、敏感设置输入框，以及设置对话框的编辑缓冲区。已有的行尾零宽空格行为保持不变，避免 Ink 裁掉行尾光标空格。

## Why it's needed

某些终端和配色方案会把 `chalk.inverse()` 渲染成很低的对比度。在本 issue 报告的 Alacritty 配置里，光标会变得半透明/不明显，因为反色视频依赖终端如何交换当前前景色和背景色。

使用明确的、跟随主题背景选择的光标背景，可以让软件光标保持可见，同时不需要加入终端特定分支。

## Reviewer Test Plan

### How to verify

1. 在之前光标不明显的终端/主题中打开 Qwen Code，例如使用深色 Solarized 风格配色的 Alacritty。
2. 聚焦主输入框，并把光标移动到普通文本、带 token 高亮的文本、Unicode 文本以及行尾。
3. 确认这些位置的光标都是可见的块状光标，并且输入/导航行为没有变化。
4. 可选：切换到浅色主题，确认光标仍然可见。

### Evidence (Before & After)

Before：软件光标使用 `chalk.inverse()`，会发出反色视频样式，在 Alacritty 配色下可能低对比。

After：光标渲染改为 `renderSoftwareCursor()`，它会发出明确的、跟随主题选择的背景色；单元测试断言它不会使用 SGR 7 反色视频，也不会重置外层前景色。

本地验证：

```console
$ npm test --workspace=packages/cli -- ui/utils/software-cursor.test.ts ui/components/InputPrompt.test.tsx ui/components/BaseTextInput.test.tsx ui/components/shared/TextInput.test.tsx ui/components/SettingInputPrompt.test.tsx --coverage.enabled=false
Test Files  5 passed (5)
Tests  202 passed (202)

$ npx eslint packages/cli/src/ui/utils/software-cursor.ts packages/cli/src/ui/utils/software-cursor.test.ts packages/cli/src/ui/components/BaseTextInput.tsx packages/cli/src/ui/components/BaseTextInput.test.tsx packages/cli/src/ui/components/InputPrompt.tsx packages/cli/src/ui/components/InputPrompt.test.tsx packages/cli/src/ui/components/SettingInputPrompt.tsx packages/cli/src/ui/components/SettingsDialog.tsx packages/cli/src/ui/components/shared/TextInput.tsx packages/cli/src/ui/components/shared/TextInput.test.tsx

$ npx prettier --check packages/cli/src/ui/utils/software-cursor.ts packages/cli/src/ui/utils/software-cursor.test.ts packages/cli/src/ui/components/BaseTextInput.tsx packages/cli/src/ui/components/BaseTextInput.test.tsx packages/cli/src/ui/components/InputPrompt.tsx packages/cli/src/ui/components/InputPrompt.test.tsx packages/cli/src/ui/components/SettingInputPrompt.tsx packages/cli/src/ui/components/SettingsDialog.tsx packages/cli/src/ui/components/shared/TextInput.tsx packages/cli/src/ui/components/shared/TextInput.test.tsx
All matched files use Prettier code style!

$ npm run typecheck --workspace=packages/cli --if-present
tsc --noEmit

$ git diff --check upstream/main..HEAD
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested locally   |
|  🐧 Linux  |   ⚠️ not tested locally   |

### Environment (optional)

本地验证使用 Node v26.3.0 和 npm 11.16.0。

## Risk & Scope

- 主要风险或取舍：光标现在使用明确的背景色，而不是终端反色视频，因此视觉上可能和之前的终端原生反色略有不同。
- 未验证 / 不在范围内：我没有在本地录制 Alacritty 实机画面；这个改动通过聚焦的渲染测试和已确认的根因来验证。
- 破坏性变更 / 迁移说明：无。

## Linked Issues

Fixes #5713

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
