### PR TITLE
fix(test): restore openai model selection in ACP set_config_option test

### DIFF
--- a/integration-tests/cli/acp-integration.test.ts
+++ b/integration-tests/cli/acp-integration.test.ts
@@ -508,17 +508,17 @@ function setupAcpTest(
       expect(modelOption).toBeDefined();
       expect(modelOption!.currentValue).toBeTruthy();
 
-      const modelId = modelOption!.currentValue;
-      expect(
-        newSession.models.availableModels.some(
-          (model) => model.modelId === modelId,
-        ),
-      ).toBe(true);
+      // Test: Set model using set_config_option
+      // Use openai model to avoid auth issues
+      const openaiModel = newSession.models.availableModels.find((model) =>
+        model.modelId.includes('openai'),
+      );
+      expect(openaiModel).toBeDefined();
 
       const setModelResult = (await sendRequest('session/set_config_option', {
         sessionId: newSession.sessionId,
         configId: 'model',
-        value: modelId,
+        value: openaiModel!.modelId,
       })) as {
         configOptions: Array<{
           id: string;
@@ -535,7 +535,7 @@ function setupAcpTest(
         (opt) => opt.id === 'model',
       );
       expect(updatedModelOption).toBeDefined();
-      expect(updatedModelOption!.currentValue).toBe(modelId);
+      expect(updatedModelOption!.currentValue).toBe(openaiModel!.modelId);
     } catch (e) {
       if (stderr.length) {
         console.error('Agent stderr:', stderr.join(''));


### PR DESCRIPTION
## What this PR does

Restores the ACP integration test `supports session/set_config_option for mode and model` to explicitly select an `openai` model from the session's `availableModels` list before setting it, instead of asserting that the session's *current* model already appears in `availableModels`.

## Why it's needed

PR #5676 (an unrelated v5 settings-migration fix) inadvertently reverted this test's model-selection block back to a flaky form:

```js
const modelId = modelOption!.currentValue;
expect(
  newSession.models.availableModels.some((model) => model.modelId === modelId),
).toBe(true);
```

In CI without real authentication, the session's default *current* model is not present in `availableModels`, so this assertion fails with `expected false to be true`. That fails the Release workflow's **Integration Tests (No Sandbox)** job, which gates **Publish Release** — so the last several releases never published (e.g. run [27971498894](https://github.com/QwenLM/qwen-code/actions/runs/27971498894/job/82779732247), failing at `acp-integration.test.ts:516`).

The restored form explicitly picks an `openai` model (the test authenticates with `methodId: 'openai'` earlier) and sets that, avoiding the auth-dependent current-model mismatch. This is the exact form that shipped in every successful release from late March until #5676, including the last green release `6bc3f853e`.

## Reviewer Test Plan

### How to verify

- The change is a pure revert of the test-only hunk introduced by #5676. Confirm `git show <this-commit> -- integration-tests/cli/acp-integration.test.ts` is the inverse of #5676's change to the same file.
- The restored block is byte-for-byte identical to the last successful Release commit `6bc3f853e`; the next No-Sandbox integration run should pass `supports session/set_config_option for mode and model` again.
- No production/runtime code is touched — test file only.

### Evidence (Before & After)

N/A (test-only change, not user-visible). Before: assertion `availableModels.some(m => m.modelId === currentValue)` → `false` in CI → job exits 1 → Publish Release skipped. After: test selects an `openai` model already present in `availableModels` and sets it, matching the long-standing passing behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

The live ACP integration test requires provider auth + network, so it was not re-run locally. Verified locally: `prettier --check` passes, no dangling references, and the restored region is byte-identical to the last green release. The authoritative check is the CI No-Sandbox job.

### Environment (optional)

N/A

## Risk & Scope

- Main risk or tradeoff: None for production code — test-file only. Risk is limited to the integration test itself; restoring a version proven across many prior releases.
- Not validated / out of scope: Live integration run was not executed locally (needs auth); relies on CI. The root-cause stale-branch revert in #5676's merge is out of scope here.
- Breaking changes / migration notes: None.

## Linked Issues

Refs failing Release run https://github.com/QwenLM/qwen-code/actions/runs/27971498894 (No Sandbox integration job). Restores behavior regressed by #5676.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 ACP 集成测试 `supports session/set_config_option for mode and model` 恢复为：先从会话的 `availableModels` 列表里显式挑选一个 `openai` 模型再设置，而不是断言"会话当前模型已经存在于 `availableModels` 中"。

## 为什么需要

PR #5676（一个不相干的 v5 settings 迁移修复）在合并时意外把这段模型选择代码回退成了 flaky 写法：

```js
const modelId = modelOption!.currentValue;
expect(
  newSession.models.availableModels.some((model) => model.modelId === modelId),
).toBe(true);
```

在没有真实鉴权的 CI 环境里，会话默认的"当前模型"并不在 `availableModels` 列表中，于是该断言报 `expected false to be true`。这会让 Release 工作流的 **Integration Tests (No Sandbox)** job 失败，而 **Publish Release** 依赖它通过 —— 导致最近几次发布都没真正发出去（例如失败 run [27971498894](https://github.com/QwenLM/qwen-code/actions/runs/27971498894/job/82779732247)，挂在 `acp-integration.test.ts:516`）。

恢复后的写法显式选取一个 `openai` 模型（测试前面已用 `methodId: 'openai'` 鉴权）再设置，规避了依赖鉴权的"当前模型不匹配"问题。这正是从 3 月底到 #5676 之前、每次成功发布（含最后一次绿色发布 `6bc3f853e`）所采用的版本。

## 评审验证

- 本改动是对 #5676 在该测试文件那段 hunk 的纯逆向恢复。可用 `git show <本提交> -- integration-tests/cli/acp-integration.test.ts` 确认它与 #5676 对同一文件的改动互为逆操作。
- 恢复后的代码块与上次成功 Release 提交 `6bc3f853e` 逐字节一致；下一次 No-Sandbox 集成测试应重新通过该用例。
- 不涉及任何生产/运行时代码，仅改测试文件。

## 风险与范围

- 主要风险：对生产代码无风险，仅测试文件；恢复的是历经多次发布验证的版本。
- 未验证/范围外：未在本地跑实测集成用例（需鉴权），依赖 CI；#5676 合并时的陈旧分支误回退根因不在本 PR 范围内。
- 破坏性变更：无。

## 测试情况

实测 ACP 集成用例需要 provider 鉴权 + 网络，未在本地重跑。本地已验证：`prettier --check` 通过、无悬空引用、恢复区域与上次绿色发布逐字节一致。权威校验以 CI 的 No-Sandbox job 为准。

</details>
