### PR TITLE
fix(triage): strengthen PR gate with batch detection, problem existence check, and red flag patterns

### DIFF
--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -58,22 +58,15 @@ If the same author has **3+ open PRs in 7 days** with similar patterns:
 - Mostly noise → close the batch with a single explanation.
 - A few have value → extract those, close the rest.
 
-### Stage 0b: Core Module Protection (HARD BLOCK — no exceptions, no judgment)
+### Stage 0b: Core Module Protection (two-tier check)
 
-**If the PR author is NOT a maintainer AND the PR touches core infrastructure → reject immediately. Do NOT evaluate. Do NOT proceed to Stage 1. No exceptions.**
+Core infrastructure: `packages/core/src/**`, auth, providers, models, config, tools, services, cross-package changes.
 
-Core infrastructure paths:
+**Tier 1 — Large-scope changes to core → HARD BLOCK.** If the PR touches 10+ files or 500+ lines in core paths → reject immediately. No evaluation, no Stage 1. Reply: "This change touches core infrastructure at scale. Core refactors must be maintainer-initiated — please open an issue to discuss the design first." Then **stop**. This is a wall, not a guideline.
 
-- `packages/core/src/**`
-- `packages/cli/src/config/auth.ts`, `packages/cli/src/ui/auth/**`
-- `packages/cli/src/serve/**`
-- Any PR spanning both `packages/core` and `packages/cli`
+**Tier 2 — Small-scope changes to core → evaluate with 100% confidence.** If the PR touches fewer files but still hits core paths, you MAY proceed to Stage 1 — but only if you are **100% confident** the change is correct and safe. If there is any doubt at all — "the direction looks correct" is NOT 100% confidence — escalate to maintainer before proceeding. You must be able to name every downstream consumer affected; if you cannot, escalate.
 
-Check the author: `gh pr view "$PR_NUMBER" --json author --jq '.author.login'`. If the author is not a maintainer, and any changed file matches the paths above → request changes with: "Core infrastructure changes must be maintainer-initiated. Please open an issue to discuss the design first." Then **stop**.
-
-**Do NOT try to evaluate whether the change "looks correct" or "seems safe."** You will be wrong. The gate cannot assess the blast radius of core refactors — that requires architectural context no PR review provides. "The direction looks correct" has caused real damage (see PR #5089: 75 files, core/auth/providers/models, approved by gate, design was wrong).
-
-**This rule is not a guideline. It is a wall. Do not think around it.**
+**Why two tiers:** A one-line bugfix in `packages/core/src/providers/install.ts` with a clear reproduction is different from a 75-file refactor of the provider system. The gate can handle the former; the latter requires maintainer architectural context. But for any core change, **when in doubt, escalate. Better to wrongly escalate than to wrongly approve.**
 
 ### Stage 1: Gate (Template + Direction + Solution Review)
 

--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -43,21 +43,6 @@ Never create duplicates.
 
 Default posture: **skepticism**. Burden of proof is on the author. Distinguish **observed failures** (linked issue, reproduction, before/after) from **theoretical hardening** ("could theoretically send X" with no evidence it ever has). Volume ≠ value — an AI bot can produce 20 plausible PRs in a day. If being "too strict" feels uncomfortable, that is the gate working correctly.
 
-### Stage 0: Batch Pattern Detection (run before Stage 1)
-
-Before evaluating any PR individually, check for batch patterns:
-
-```bash
-gh pr list --repo "$REPO" --author "<author>" --state open --limit 20 \
-  --json number,title,createdAt --jq '[.[] | select((.createdAt | fromdateiso8601) > (now - 604800))]'
-```
-
-If the same author has **3+ open PRs in 7 days** with similar patterns:
-
-- **Stop individual review.** Evaluate the batch as a group first.
-- Mostly noise → close the batch with a single explanation.
-- A few have value → extract those, close the rest.
-
 ### Stage 0b: Core Module Protection (two-tier check)
 
 Core infrastructure: `packages/core/src/**`, auth, providers, models, config, tools, services, cross-package changes.

--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -60,18 +60,15 @@ If the same author has **3+ open PRs in 7 days** with similar patterns:
 
 ### Stage 0b: Core Module Protection (MANDATORY — run after Stage 0, before Stage 1)
 
-**We do not accept community PRs that refactor core infrastructure. Period.**
+**The gate must honestly assess: do I truly understand this PR's full impact?**
 
-Check the PR's changed files. If the PR is a `refactor:` (or large structural change) touching any of these paths, **reject immediately** — do not proceed to Stage 1:
+Before proceeding, check the PR's changed files. For any PR touching core infrastructure (`packages/core/src/**`, auth, providers, models, config, tools, services, or cross-package refactors):
 
-- `packages/core/src/**`
-- `packages/cli/src/config/auth.ts`, `packages/cli/src/ui/auth/**`
-- `packages/cli/src/serve/**`
-- Cross-package changes spanning both `packages/core` and `packages/cli`
+1. **Can I name every downstream consumer that this change affects?** If not, you do not understand the blast radius — escalate to maintainer immediately.
+2. **Is this a `refactor:` or large structural change from a community contributor?** → Reject. Core refactors must be maintainer-initiated. Reply: "Core infrastructure refactors must be maintainer-initiated. Please open an issue to discuss the design first."
+3. **Am I 100% confident this change is safe?** If there is any doubt — "the direction looks correct" is NOT confidence — escalate to maintainer. Do not approve.
 
-Reply: "Core infrastructure refactors must be maintainer-initiated. Please open an issue to discuss the design first."
-
-**Why this is non-negotiable:** "The direction looks correct" is not enough. A community contributor lacks the architectural context to design core refactors — the blast radius, the downstream dependencies, the invariants that must hold. A bad core refactor costs months of breakage. A wrongly rejected one costs a polite comment. The asymmetry is enormous. **When in doubt, reject. Better to wrongly reject a valid PR than to wrongly accept a broken one.**
+**The meta-principle:** "The direction looks correct" is the most dangerous sentence in triage. It means the gate understood the intent but not the impact. A bad core refactor costs months of breakage. A wrongly rejected one costs a polite comment. **When in doubt, escalate. Better to wrongly reject a valid PR than to wrongly accept a broken one.**
 
 ### Stage 1: Gate (Template + Direction + Solution Review)
 

--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -41,29 +41,22 @@ Never create duplicates.
 
 ### Gate Philosophy
 
-The gate's job is to **say no**. A gate that approves everything is not a gate — it is a rubber stamp. The default posture is skepticism, not welcome. Every PR must earn its way in; the burden of proof is on the author, not the reviewer.
-
-This is especially critical for AI-bot-generated PRs. An AI bot can produce 20 plausible-sounding PRs in a day, each with perfect grammar and tests. Volume does not equal value. "Theoretically possible input" does not equal "real bug." The gate must distinguish **observed failures** from **theoretical hardening**, and treat them very differently.
-
-If the gate feels uncomfortable — if it feels like you are being "too strict" — that is the gate working correctly. Being a pushover is not kindness; it is negligence.
+Default posture: **skepticism**. Burden of proof is on the author. Distinguish **observed failures** (linked issue, reproduction, before/after) from **theoretical hardening** ("could theoretically send X" with no evidence it ever has). Volume ≠ value — an AI bot can produce 20 plausible PRs in a day. If being "too strict" feels uncomfortable, that is the gate working correctly.
 
 ### Stage 0: Batch Pattern Detection (run before Stage 1)
 
 Before evaluating any PR individually, check for batch patterns:
 
 ```bash
-gh pr list --repo "$REPO" --author "<author>" --state all --limit 20 \
-  --json number,title,createdAt --jq '.[] | select(.createdAt > "7 days ago")'
+gh pr list --repo "$REPO" --author "<author>" --state open --limit 20 \
+  --json number,title,createdAt --jq '[.[] | select((.createdAt | fromdateiso8601) > (now - 604800))]'
 ```
 
-If the same author has **3+ open PRs in 7 days** with similar patterns (e.g., multiple "add validation" / "reject X" / "require Y" PRs):
+If the same author has **3+ open PRs in 7 days** with similar patterns:
 
-- **Stop individual review.** Evaluate the batch as a group.
-- Ask: is this one consolidated change split into N PRs to inflate contribution metrics?
-- If the batch is mostly noise (validation hygiene, schema alignment, theoretical hardening): close the entire batch with a single explanation, not N individual reviews.
-- If a few PRs in the batch have genuine value: extract those, close the rest.
-
-**Why this matters:** reviewing each PR individually makes every single one look "fine" — small change, has tests, follows template. The problem only appears at batch scale. The gate must zoom out before zooming in.
+- **Stop individual review.** Evaluate the batch as a group first.
+- Mostly noise → close the batch with a single explanation.
+- A few have value → extract those, close the rest.
 
 ### Stage 1: Gate (Template + Direction + Solution Review)
 
@@ -85,22 +78,15 @@ PR body missing required headings from `.github/pull_request_template.md` (read 
 gh pr review "$PR_NUMBER" --repo "$REPO" --request-changes --body-file /tmp/pr-gate-template.md
 ```
 
-**1b. Problem existence check (MANDATORY — this is where most noise PRs get caught):**
+**1b. Problem existence check (MANDATORY):**
 
-Before asking "is the direction right?", ask **"does this problem actually exist?"**
+Before "is the direction right?", ask **"does this problem actually exist?"**
 
-- **Observed bug**: Is there a linked issue, user report, error log, or reproduction case? Does the PR show a before/after demonstrating the failure? → Legitimate fix, proceed.
-- **Theoretical hardening**: "The model could theoretically send `maxConnections: 1.5`" or "this env var could contain a non-integer" — with no evidence it ever has? → **Default to close.** Ask: "What scenario triggers this? Show me the before/after." If the author cannot answer, the PR is solving a non-problem.
-- **No reproduction = no fix.** A `fix:` PR without a reproduction case is not a fix — it is a hypothesis. Hypotheses belong in issues, not PRs.
+- **Observed bug** (linked issue, reproduction, before/after) → proceed.
+- **Theoretical hardening** ("could theoretically send X" with no evidence) → **request changes.** Ask for a reproduction. If the author cannot provide one, close.
+- **No reproduction = no fix.** A `fix:` PR without reproduction is a hypothesis — belongs in issues, not PRs.
 
-The key distinction: **"direction is correct" ≠ "problem exists."** "Rejecting fractional values for integer parameters" sounds reasonable as a direction. But if no one has ever passed a fractional value, and the runtime coerces it correctly anyway, there is no bug to fix — only code hygiene to perform. Code hygiene does not warrant a standalone PR, let alone 20 in a single day.
-
-Red flag phrases in PR descriptions that signal "no real problem":
-
-- "The runtime validators already require/enforce..." → the problem is already handled
-- "This aligns the schema with..." → documentation hygiene, not a behavioral fix
-- "Fractional values like 1.5 were accepted" → who sent 1.5? Why? What broke?
-- "Values such as 0 or -1 were accepted and quietly coerced" → coercion is often correct behavior
+**"direction is correct" ≠ "problem exists."** If the runtime already handles the case correctly, there is no bug — only code hygiene. Code hygiene does not warrant a PR.
 
 **1c. Product direction:**
 
@@ -173,8 +159,11 @@ Approach: <state your honest assessment — the scope feels right / feels like i
 — _Qwen Code · qwen3.7-max_
 ```
 
-Save this comment's ID. If direction is escalated → stop here. Template
-failures already stopped in Stage 1a.
+Save this comment's ID. Terminal exits — stop here if any applies:
+
+- Template failure → stopped in 1a.
+- Problem does not exist → request changes in 1b, do not proceed to Stage 2.
+- Direction escalated → stop here.
 
 ### Stage 2: Review + Test
 
@@ -281,7 +270,7 @@ Step back and look at the whole picture — the motivation, the implementation, 
 - If I had to maintain this in six months, would I curse the author or thank them?
 - Am I approving this because it's genuinely good, or because I ran out of reasons to say no?
 - **Did I verify the problem actually exists?** Or did I accept the PR's framing ("this value could be passed") without asking "has this ever happened?" If the PR has no before/after reproduction, I should not be this far in the pipeline.
-- **Is this part of a batch?** If the same author has 10+ similar PRs, am I evaluating each one on merit, or am I being worn down by volume? Step back: would I have accepted this as a single consolidated PR? If not, the batch is noise.
+- **Is this part of a batch?** If this PR met the Stage 0 batch threshold (3+ similar PRs from the same author), am I evaluating each one on merit, or being worn down by volume?
 - **Am I being a pushover?** If I feel "this is probably fine but I'm not sure it's needed" — that feeling IS the signal. The gate's job is to say no to things that are not clearly needed.
 
 If your independent proposal was materially simpler — say so. Not as a blocker, but as an honest question the contributor should think about.

--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -58,17 +58,22 @@ If the same author has **3+ open PRs in 7 days** with similar patterns:
 - Mostly noise → close the batch with a single explanation.
 - A few have value → extract those, close the rest.
 
-### Stage 0b: Core Module Protection (MANDATORY — run after Stage 0, before Stage 1)
+### Stage 0b: Core Module Protection (HARD BLOCK — no exceptions, no judgment)
 
-**The gate must honestly assess: do I truly understand this PR's full impact?**
+**If the PR author is NOT a maintainer AND the PR touches core infrastructure → reject immediately. Do NOT evaluate. Do NOT proceed to Stage 1. No exceptions.**
 
-Before proceeding, check the PR's changed files. For any PR touching core infrastructure (`packages/core/src/**`, auth, providers, models, config, tools, services, or cross-package refactors):
+Core infrastructure paths:
 
-1. **Can I name every downstream consumer that this change affects?** If not, you do not understand the blast radius — escalate to maintainer immediately.
-2. **Is this a `refactor:` or large structural change from a community contributor?** → Reject. Core refactors must be maintainer-initiated. Reply: "Core infrastructure refactors must be maintainer-initiated. Please open an issue to discuss the design first."
-3. **Am I 100% confident this change is safe?** If there is any doubt — "the direction looks correct" is NOT confidence — escalate to maintainer. Do not approve.
+- `packages/core/src/**`
+- `packages/cli/src/config/auth.ts`, `packages/cli/src/ui/auth/**`
+- `packages/cli/src/serve/**`
+- Any PR spanning both `packages/core` and `packages/cli`
 
-**The meta-principle:** "The direction looks correct" is the most dangerous sentence in triage. It means the gate understood the intent but not the impact. A bad core refactor costs months of breakage. A wrongly rejected one costs a polite comment. **When in doubt, escalate. Better to wrongly reject a valid PR than to wrongly accept a broken one.**
+Check the author: `gh pr view "$PR_NUMBER" --json author --jq '.author.login'`. If the author is not a maintainer, and any changed file matches the paths above → request changes with: "Core infrastructure changes must be maintainer-initiated. Please open an issue to discuss the design first." Then **stop**.
+
+**Do NOT try to evaluate whether the change "looks correct" or "seems safe."** You will be wrong. The gate cannot assess the blast radius of core refactors — that requires architectural context no PR review provides. "The direction looks correct" has caused real damage (see PR #5089: 75 files, core/auth/providers/models, approved by gate, design was wrong).
+
+**This rule is not a guideline. It is a wall. Do not think around it.**
 
 ### Stage 1: Gate (Template + Direction + Solution Review)
 

--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -39,6 +39,32 @@ Never create duplicates.
 
 **Approval:** the `gh pr review --approve` command is a separate step that runs **after** Stage 3 comment is posted. Comment first, then approve only when genuinely confident.
 
+### Gate Philosophy
+
+The gate's job is to **say no**. A gate that approves everything is not a gate — it is a rubber stamp. The default posture is skepticism, not welcome. Every PR must earn its way in; the burden of proof is on the author, not the reviewer.
+
+This is especially critical for AI-bot-generated PRs. An AI bot can produce 20 plausible-sounding PRs in a day, each with perfect grammar and tests. Volume does not equal value. "Theoretically possible input" does not equal "real bug." The gate must distinguish **observed failures** from **theoretical hardening**, and treat them very differently.
+
+If the gate feels uncomfortable — if it feels like you are being "too strict" — that is the gate working correctly. Being a pushover is not kindness; it is negligence.
+
+### Stage 0: Batch Pattern Detection (run before Stage 1)
+
+Before evaluating any PR individually, check for batch patterns:
+
+```bash
+gh pr list --repo "$REPO" --author "<author>" --state all --limit 20 \
+  --json number,title,createdAt --jq '.[] | select(.createdAt > "7 days ago")'
+```
+
+If the same author has **3+ open PRs in 7 days** with similar patterns (e.g., multiple "add validation" / "reject X" / "require Y" PRs):
+
+- **Stop individual review.** Evaluate the batch as a group.
+- Ask: is this one consolidated change split into N PRs to inflate contribution metrics?
+- If the batch is mostly noise (validation hygiene, schema alignment, theoretical hardening): close the entire batch with a single explanation, not N individual reviews.
+- If a few PRs in the batch have genuine value: extract those, close the rest.
+
+**Why this matters:** reviewing each PR individually makes every single one look "fine" — small change, has tests, follows template. The problem only appears at batch scale. The gate must zoom out before zooming in.
+
 ### Stage 1: Gate (Template + Direction + Solution Review)
 
 **⛔ Before anything else: create a worktree.** This is the #1 forgotten step.
@@ -59,7 +85,24 @@ PR body missing required headings from `.github/pull_request_template.md` (read 
 gh pr review "$PR_NUMBER" --repo "$REPO" --request-changes --body-file /tmp/pr-gate-template.md
 ```
 
-**1b. Product direction:**
+**1b. Problem existence check (MANDATORY — this is where most noise PRs get caught):**
+
+Before asking "is the direction right?", ask **"does this problem actually exist?"**
+
+- **Observed bug**: Is there a linked issue, user report, error log, or reproduction case? Does the PR show a before/after demonstrating the failure? → Legitimate fix, proceed.
+- **Theoretical hardening**: "The model could theoretically send `maxConnections: 1.5`" or "this env var could contain a non-integer" — with no evidence it ever has? → **Default to close.** Ask: "What scenario triggers this? Show me the before/after." If the author cannot answer, the PR is solving a non-problem.
+- **No reproduction = no fix.** A `fix:` PR without a reproduction case is not a fix — it is a hypothesis. Hypotheses belong in issues, not PRs.
+
+The key distinction: **"direction is correct" ≠ "problem exists."** "Rejecting fractional values for integer parameters" sounds reasonable as a direction. But if no one has ever passed a fractional value, and the runtime coerces it correctly anyway, there is no bug to fix — only code hygiene to perform. Code hygiene does not warrant a standalone PR, let alone 20 in a single day.
+
+Red flag phrases in PR descriptions that signal "no real problem":
+
+- "The runtime validators already require/enforce..." → the problem is already handled
+- "This aligns the schema with..." → documentation hygiene, not a behavioral fix
+- "Fractional values like 1.5 were accepted" → who sent 1.5? Why? What broke?
+- "Values such as 0 or -1 were accepted and quietly coerced" → coercion is often correct behavior
+
+**1c. Product direction:**
 
 Ask the hard questions before reading a single line of code:
 
@@ -78,7 +121,7 @@ curl -s https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.
 
 **Escalate to maintainer** (never auto-reject): touches auth/sandbox/model selection/telemetry/release/public contract, or direction is genuinely unclear.
 
-**1c. Solution review** (never skip — judge from the PR description and a skim of the diff structure, before reading code in detail):
+**1d. Solution review** (never skip — judge from the PR description and a skim of the diff structure, before reading code in detail):
 
 - If we cut 80% of the scope, would the remaining 20% already solve the problem?
 - Could we achieve the same goal by modifying something that already exists, instead of adding something new?
@@ -98,11 +141,14 @@ Thanks for the PR!
 
 Template looks good ✓
 
-On direction: <state your honest assessment — aligned and why, or concerns and why>. CHANGELOG <reference if found, or "no direct reference but the area is relevant">.
+Problem: <state whether the problem is an observed bug with evidence, or theoretical hardening without reproduction. If no reproduction exists, say so plainly: "No before/after reproduction is provided. What scenario triggers this issue?">
 
-On approach: <state your honest assessment — the scope feels right / feels like it could be much simpler / here's what I'd consider cutting>. <If you see a simpler path, name it: "Have you considered just X? It might cover most of the use case with a fraction of the complexity."> <If the diff carries unrelated changes or drive-by refactors, name them and suggest splitting them out.>
+Direction: <state your honest assessment — aligned and why, or concerns and why>. CHANGELOG <reference if found, or "no direct reference but the area is relevant">.
+
+Approach: <state your honest assessment — the scope feels right / feels like it could be much simpler / here's what I'd consider cutting>. <If you see a simpler path, name it: "Have you considered just X? It might cover most of the use case with a fraction of the complexity."> <If the diff carries unrelated changes or drive-by refactors, name them and suggest splitting them out.>
 
 <If passing:> Moving on to code review. 🔍
+<If problem does not exist:> Closing — no demonstrated failure. Feel free to reopen with a reproduction case.
 <If concerns:> Flagging these for discussion before diving deeper.
 
 <details>
@@ -112,11 +158,14 @@ On approach: <state your honest assessment — the scope feels right / feels lik
 
 模板完整 ✓
 
+问题：<说明问题是已观测到的 bug（有证据）还是理论性加固（无复现）。如果没有复现，直接说明："未提供 before/after 复现。什么场景会触发这个问题？">
+
 方向：<直接说判断——对齐的原因/担心的原因>。
 
 方案：<范围合理 / 感觉可以大幅简化 / 建议砍掉的部分>。<如果看到更简路径，点名：有没有考虑过直接 X？可能用很小的复杂度覆盖大部分场景。><如果 diff 夹带了无关改动或顺手重构，点名并建议拆成单独 PR。>
 
 <如果通过：> 进入代码审查 🔍
+<如果问题不存在：> 关闭——未展示实际故障。欢迎带上复现案例重新打开。
 <如果有顾虑：> 先提出来讨论，再深入看代码。
 
 </details>
@@ -231,6 +280,9 @@ Step back and look at the whole picture — the motivation, the implementation, 
 - After seeing it run, do the results match what the PR promised?
 - If I had to maintain this in six months, would I curse the author or thank them?
 - Am I approving this because it's genuinely good, or because I ran out of reasons to say no?
+- **Did I verify the problem actually exists?** Or did I accept the PR's framing ("this value could be passed") without asking "has this ever happened?" If the PR has no before/after reproduction, I should not be this far in the pipeline.
+- **Is this part of a batch?** If the same author has 10+ similar PRs, am I evaluating each one on merit, or am I being worn down by volume? Step back: would I have accepted this as a single consolidated PR? If not, the batch is noise.
+- **Am I being a pushover?** If I feel "this is probably fine but I'm not sure it's needed" — that feeling IS the signal. The gate's job is to say no to things that are not clearly needed.
 
 If your independent proposal was materially simpler — say so. Not as a blocker, but as an honest question the contributor should think about.
 

--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -58,6 +58,21 @@ If the same author has **3+ open PRs in 7 days** with similar patterns:
 - Mostly noise → close the batch with a single explanation.
 - A few have value → extract those, close the rest.
 
+### Stage 0b: Core Module Protection (MANDATORY — run after Stage 0, before Stage 1)
+
+**We do not accept community PRs that refactor core infrastructure. Period.**
+
+Check the PR's changed files. If the PR is a `refactor:` (or large structural change) touching any of these paths, **reject immediately** — do not proceed to Stage 1:
+
+- `packages/core/src/**`
+- `packages/cli/src/config/auth.ts`, `packages/cli/src/ui/auth/**`
+- `packages/cli/src/serve/**`
+- Cross-package changes spanning both `packages/core` and `packages/cli`
+
+Reply: "Core infrastructure refactors must be maintainer-initiated. Please open an issue to discuss the design first."
+
+**Why this is non-negotiable:** "The direction looks correct" is not enough. A community contributor lacks the architectural context to design core refactors — the blast radius, the downstream dependencies, the invariants that must hold. A bad core refactor costs months of breakage. A wrongly rejected one costs a polite comment. The asymmetry is enormous. **When in doubt, reject. Better to wrongly reject a valid PR than to wrongly accept a broken one.**
+
 ### Stage 1: Gate (Template + Direction + Solution Review)
 
 **⛔ Before anything else: create a worktree.** This is the #1 forgotten step.

--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -19,10 +19,10 @@ COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" -F body=@/tmp/stage
 | Stage 2 | Code review + test results (with screenshots) |
 | Stage 3 | Reflection + verdict                          |
 
-**Terminal gate exception:** if any terminal exit triggers (Stage 0b hard
-block, Stage 1a template failure, Stage 1b problem-does-not-exist, or
-direction escalation), submit exactly one `CHANGES_REQUESTED` review and
-stop. Do not also post or update a Stage 1 issue comment, and do not
+**Terminal gate exception:** if any terminal exit triggers (Stage 0 core
+module hard block, Stage 1a template failure, Stage 1b problem-does-not-exist,
+or Stage 1c direction escalation), submit exactly one `CHANGES_REQUESTED`
+review and stop. Do not also post or update a Stage 1 issue comment, and do not
 continue to Stage 2, Stage 3, or approval.
 
 **Re-runs:** if the triage runs again on the same PR, update each comment in place:
@@ -45,7 +45,7 @@ Never create duplicates.
 
 Default posture: **skepticism**. Burden of proof is on the author. Distinguish **observed failures** (linked issue, reproduction, before/after) from **theoretical hardening** ("could theoretically send X" with no evidence it ever has). Volume ≠ value — an AI bot can produce 20 plausible PRs in a day. If being "too strict" feels uncomfortable, that is the gate working correctly.
 
-### Stage 0b: Core Module Protection (two-tier check)
+### Stage 0: Core Module Protection (two-tier check)
 
 Core infrastructure: files matching `packages/core/src/**`, `packages/*/src/auth/**`, `packages/*/src/providers/**`, `packages/*/src/models/**`, `packages/*/src/config/**`, `packages/*/src/tools/**`, `packages/*/src/services/**`, or cross-package changes spanning multiple `packages/*/`.
 
@@ -86,7 +86,7 @@ gh pr review "$PR_NUMBER" --repo "$REPO" --request-changes --body-file /tmp/pr-g
 Before "is the direction right?", ask **"does this problem actually exist?"**
 
 - **Observed bug** (linked issue, reproduction, before/after) → proceed.
-- **Theoretical hardening** ("could theoretically send X" with no evidence) → **request changes.** Ask for a reproduction. If the author cannot provide one, close.
+- **Theoretical hardening** ("could theoretically send X" with no evidence) → **request changes.** Ask for a reproduction. If the author cannot provide one on re-run, leave for maintainer to decide.
 - **No reproduction = no fix.** A `fix:` PR without reproduction is a hypothesis — belongs in issues, not PRs.
 
 **"direction is correct" ≠ "problem exists."** If the runtime already handles the case correctly, there is no bug — only code hygiene. Code hygiene does not warrant a PR.
@@ -164,10 +164,10 @@ Approach: <state your honest assessment — the scope feels right / feels like i
 
 Save this comment's ID. Terminal exits — stop here if any applies:
 
-- Core module hard block (Stage 0b) → rejected, do not proceed.
-- Template failure → stopped in 1a.
-- Problem does not exist → request changes in 1b, do not proceed to Stage 2.
-- Direction escalated → stop here.
+- Core module hard block (Stage 0) → rejected, do not proceed.
+- Template failure (Stage 1a) → stopped.
+- Problem does not exist (Stage 1b) → request changes, do not proceed to Stage 2.
+- Direction escalated (Stage 1c) → stop here.
 
 ### Stage 2: Review + Test
 

--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -31,7 +31,19 @@ continue to Stage 2, Stage 3, or approval.
 gh api -X PATCH "/repos/$REPO/issues/comments/$COMMENT_ID" -F body=@/tmp/stage-N-updated.md
 ```
 
-Never create duplicates.
+Never create duplicates. For terminal-exit reviews (submitted via
+`gh pr review --request-changes`), the GitHub API does not support editing PR
+reviews. On re-run: check if a `CHANGES_REQUESTED` review from the bot already
+exists — if it does, skip re-submitting (the existing review already gates the
+PR). Only update issue comments, not PR reviews.
+
+```bash
+# Check for existing terminal-exit review before re-submitting
+EXISTING=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+  --jq '[.[] | select(.user.login=="qwen-code-ci-bot" and .state=="CHANGES_REQUESTED")] | length')
+# Only submit if no existing terminal review
+if [ "$EXISTING" -eq 0 ]; then gh pr review ... ; fi
+```
 
 **Signature:** every comment ends with:
 
@@ -59,7 +71,7 @@ Then **stop**. This is a wall, not a guideline.
 
 **Breadth ≠ size.** A uniform, low-risk sweep — renaming a symbol, updating an import path, a lint/format autofix, the same null-guard at many call sites — can touch **10+ files** while changing only a line or two each. Don't auto-reject on file count alone: **flag it for the maintainer's awareness**, and otherwise let it proceed to Stage 1 under Tier 2's 100%-confidence bar, judged on the actual diff rather than the file count. (A deep rewrite concentrated in a few files still trips the 500-line threshold above, so depth isn't ignored.)
 
-**Tier 2 — Small-scope changes to core → evaluate with 100% confidence.** If the PR touches fewer files but still hits core paths, you MAY proceed to Stage 1 — but only if you are **100% confident** the change is correct and safe. If there is any doubt at all — "the direction looks correct" is NOT 100% confidence — escalate to maintainer before proceeding. You must be able to name every downstream consumer affected; if you cannot, escalate.
+**Tier 2 — Changes to core below the 500-line threshold → evaluate with 100% confidence.** If the PR hits core paths but stays under Tier 1 (either few files, or a breadth-sweep flagged above), you MAY proceed to Stage 1 — but only if you are **100% confident** the change is correct and safe. If there is any doubt at all — "the direction looks correct" is NOT 100% confidence — escalate to maintainer before proceeding. You must be able to name every downstream consumer affected; if you cannot, escalate.
 
 **Why two tiers:** A one-line bugfix in `packages/core/src/providers/install.ts` with a clear reproduction is different from a 75-file refactor of the provider system. The gate can handle the former; the latter requires maintainer architectural context. But for any core change, **when in doubt, escalate. Better to wrongly escalate than to wrongly approve.**
 
@@ -88,7 +100,36 @@ gh pr review "$PR_NUMBER" --repo "$REPO" --request-changes --body-file /tmp/pr-g
 Before "is the direction right?", ask **"does this problem actually exist?"**
 
 - **Observed bug** (linked issue, reproduction, before/after) → proceed.
-- **Theoretical hardening** ("could theoretically send X" with no evidence) → **request changes.** Ask for a reproduction. If the author cannot provide one on re-run, escalate to the maintainer (use `$QWEN_MAINTAINER_HANDLE` if set) and stop — do not proceed to Stage 2.
+- **Theoretical hardening** ("could theoretically send X" with no evidence) → **request changes.** Ask for a reproduction:
+
+```bash
+cat > /tmp/stage-1b-reproduction.md <<'EOF'
+<!-- qwen-triage stage=1b -->
+
+This PR addresses a theoretical concern — "could theoretically send X" — but
+no reproduction demonstrates it has actually happened. Could you provide a
+before/after reproduction or link an issue where this was observed?
+
+Without a reproduction, this is a hypothesis that belongs in issues, not PRs.
+If the author cannot provide one on re-run, escalate to the maintainer and stop.
+
+<details>
+<summary>中文说明</summary>
+
+这个 PR 解决的是一个理论性的问题——"理论上可能发生 X"——但没有复现证明它
+实际发生过。能否提供一个 before/after 复现，或者关联一个观测到此现象的 issue？
+
+没有复现的 fix 只是一个假设——应该放在 issues 里，而不是 PR。
+如果作者在 re-run 时仍无法提供复现，请转交 maintainer 处理。
+
+</details>
+
+— _Qwen Code · qwen3.7-max_
+EOF
+gh pr review "$PR_NUMBER" --repo "$REPO" --request-changes --body-file /tmp/stage-1b-reproduction.md
+```
+
+If the author cannot provide a reproduction on re-run, escalate to the maintainer (use `$QWEN_MAINTAINER_HANDLE` if set) and stop — do not proceed to Stage 2.
 - **No reproduction = no fix.** A `fix:` PR without reproduction is a hypothesis — belongs in issues, not PRs.
 
 **"direction is correct" ≠ "problem exists."** If the runtime already handles the case correctly, there is no bug — only code hygiene. Code hygiene does not warrant a PR.

--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -57,7 +57,7 @@ gh pr review "$PR_NUMBER" --repo "$REPO" --request-changes --body "This change t
 
 Then **stop**. This is a wall, not a guideline.
 
-**Breadth ≠ size.** A uniform, low-risk sweep — renaming a symbol, updating an import path, a lint/format autofix, the same null-guard at many call sites — can touch **10+ files** while changing only a line or two each. Don't auto-reject on file count alone: **escalate to the maintainer**, and otherwise let it proceed to Stage 1 under Tier 2's 100%-confidence bar, judged on the actual diff rather than the file count. (A deep rewrite concentrated in a few files still trips the 500-line threshold above, so depth isn't ignored.)
+**Breadth ≠ size.** A uniform, low-risk sweep — renaming a symbol, updating an import path, a lint/format autofix, the same null-guard at many call sites — can touch **10+ files** while changing only a line or two each. Don't auto-reject on file count alone: **flag it for the maintainer's awareness**, and otherwise let it proceed to Stage 1 under Tier 2's 100%-confidence bar, judged on the actual diff rather than the file count. (A deep rewrite concentrated in a few files still trips the 500-line threshold above, so depth isn't ignored.)
 
 **Tier 2 — Small-scope changes to core → evaluate with 100% confidence.** If the PR touches fewer files but still hits core paths, you MAY proceed to Stage 1 — but only if you are **100% confident** the change is correct and safe. If there is any doubt at all — "the direction looks correct" is NOT 100% confidence — escalate to maintainer before proceeding. You must be able to name every downstream consumer affected; if you cannot, escalate.
 
@@ -139,7 +139,6 @@ Direction: <state your honest assessment — aligned and why, or concerns and wh
 Approach: <state your honest assessment — the scope feels right / feels like it could be much simpler / here's what I'd consider cutting>. <If you see a simpler path, name it: "Have you considered just X? It might cover most of the use case with a fraction of the complexity."> <If the diff carries unrelated changes or drive-by refactors, name them and suggest splitting them out.>
 
 <If passing:> Moving on to code review. 🔍
-<If problem does not exist:> Requesting changes — no demonstrated failure. Please provide a reproduction case to proceed.
 <If concerns:> Flagging these for discussion before diving deeper.
 
 <details>
@@ -156,7 +155,6 @@ Approach: <state your honest assessment — the scope feels right / feels like i
 方案：<范围合理 / 感觉可以大幅简化 / 建议砍掉的部分>。<如果看到更简路径，点名：有没有考虑过直接 X？可能用很小的复杂度覆盖大部分场景。><如果 diff 夹带了无关改动或顺手重构，点名并建议拆成单独 PR。>
 
 <如果通过：> 进入代码审查 🔍
-<如果问题不存在：> 请求修改——未展示实际故障。请提供复现案例后继续。
 <如果有顾虑：> 先提出来讨论，再深入看代码。
 
 </details>

--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -49,13 +49,15 @@ Default posture: **skepticism**. Burden of proof is on the author. Distinguish *
 
 Core infrastructure: files matching `packages/core/src/**`, `packages/*/src/auth/**`, `packages/*/src/providers/**`, `packages/*/src/models/**`, `packages/*/src/config/**`, `packages/*/src/tools/**`, `packages/*/src/services/**`, or cross-package changes spanning multiple `packages/*/`.
 
-**Tier 1 — Large-scope changes to core → HARD BLOCK.** Applies to non-maintainer PRs only (skip this check if the author is a known maintainer). If the PR touches 10+ files or 500+ lines (additions + deletions combined) in core paths → reject immediately. No evaluation, no Stage 1.
+**Tier 1 — Large-scope changes to core → HARD BLOCK.** Applies to non-maintainer PRs only (skip this check if the author is a known maintainer). Hard-block on _size_, not breadth: if a core-path change totals **500+ lines** (additions + deletions combined) → reject immediately. No evaluation, no Stage 1.
 
 ```bash
 gh pr review "$PR_NUMBER" --repo "$REPO" --request-changes --body "This change touches core infrastructure at scale. Core refactors must be maintainer-initiated — please open an issue to discuss the design first."
 ```
 
 Then **stop**. This is a wall, not a guideline.
+
+**Breadth ≠ size.** A uniform, low-risk sweep — renaming a symbol, updating an import path, a lint/format autofix, the same null-guard at many call sites — can touch **10+ files** while changing only a line or two each. Don't auto-reject on file count alone: **escalate to the maintainer**, and otherwise let it proceed to Stage 1 under Tier 2's 100%-confidence bar, judged on the actual diff rather than the file count. (A deep rewrite concentrated in a few files still trips the 500-line threshold above, so depth isn't ignored.)
 
 **Tier 2 — Small-scope changes to core → evaluate with 100% confidence.** If the PR touches fewer files but still hits core paths, you MAY proceed to Stage 1 — but only if you are **100% confident** the change is correct and safe. If there is any doubt at all — "the direction looks correct" is NOT 100% confidence — escalate to maintainer before proceeding. You must be able to name every downstream consumer affected; if you cannot, escalate.
 

--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -88,7 +88,7 @@ gh pr review "$PR_NUMBER" --repo "$REPO" --request-changes --body-file /tmp/pr-g
 Before "is the direction right?", ask **"does this problem actually exist?"**
 
 - **Observed bug** (linked issue, reproduction, before/after) → proceed.
-- **Theoretical hardening** ("could theoretically send X" with no evidence) → **request changes.** Ask for a reproduction. If the author cannot provide one on re-run, leave for maintainer to decide.
+- **Theoretical hardening** ("could theoretically send X" with no evidence) → **request changes.** Ask for a reproduction. If the author cannot provide one on re-run, escalate to the maintainer (use `$QWEN_MAINTAINER_HANDLE` if set) and stop — do not proceed to Stage 2.
 - **No reproduction = no fix.** A `fix:` PR without reproduction is a hypothesis — belongs in issues, not PRs.
 
 **"direction is correct" ≠ "problem exists."** If the runtime already handles the case correctly, there is no bug — only code hygiene. Code hygiene does not warrant a PR.

--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -19,9 +19,11 @@ COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" -F body=@/tmp/stage
 | Stage 2 | Code review + test results (with screenshots) |
 | Stage 3 | Reflection + verdict                          |
 
-**Terminal gate exception:** if Stage 1a template check fails, submit exactly
-one `CHANGES_REQUESTED` review and stop. Do not also post or update a Stage 1
-issue comment, and do not continue to Stage 2, Stage 3, or approval.
+**Terminal gate exception:** if any terminal exit triggers (Stage 0b hard
+block, Stage 1a template failure, Stage 1b problem-does-not-exist, or
+direction escalation), submit exactly one `CHANGES_REQUESTED` review and
+stop. Do not also post or update a Stage 1 issue comment, and do not
+continue to Stage 2, Stage 3, or approval.
 
 **Re-runs:** if the triage runs again on the same PR, update each comment in place:
 
@@ -45,9 +47,15 @@ Default posture: **skepticism**. Burden of proof is on the author. Distinguish *
 
 ### Stage 0b: Core Module Protection (two-tier check)
 
-Core infrastructure: `packages/core/src/**`, auth, providers, models, config, tools, services, cross-package changes.
+Core infrastructure: files matching `packages/core/src/**`, `packages/*/src/auth/**`, `packages/*/src/providers/**`, `packages/*/src/models/**`, `packages/*/src/config/**`, `packages/*/src/tools/**`, `packages/*/src/services/**`, or cross-package changes spanning multiple `packages/*/`.
 
-**Tier 1 — Large-scope changes to core → HARD BLOCK.** If the PR touches 10+ files or 500+ lines in core paths → reject immediately. No evaluation, no Stage 1. Reply: "This change touches core infrastructure at scale. Core refactors must be maintainer-initiated — please open an issue to discuss the design first." Then **stop**. This is a wall, not a guideline.
+**Tier 1 — Large-scope changes to core → HARD BLOCK.** Applies to non-maintainer PRs only (skip this check if the author is a known maintainer). If the PR touches 10+ files or 500+ lines (additions + deletions combined) in core paths → reject immediately. No evaluation, no Stage 1.
+
+```bash
+gh pr review "$PR_NUMBER" --repo "$REPO" --request-changes --body "This change touches core infrastructure at scale. Core refactors must be maintainer-initiated — please open an issue to discuss the design first."
+```
+
+Then **stop**. This is a wall, not a guideline.
 
 **Tier 2 — Small-scope changes to core → evaluate with 100% confidence.** If the PR touches fewer files but still hits core paths, you MAY proceed to Stage 1 — but only if you are **100% confident** the change is correct and safe. If there is any doubt at all — "the direction looks correct" is NOT 100% confidence — escalate to maintainer before proceeding. You must be able to name every downstream consumer affected; if you cannot, escalate.
 
@@ -129,7 +137,7 @@ Direction: <state your honest assessment — aligned and why, or concerns and wh
 Approach: <state your honest assessment — the scope feels right / feels like it could be much simpler / here's what I'd consider cutting>. <If you see a simpler path, name it: "Have you considered just X? It might cover most of the use case with a fraction of the complexity."> <If the diff carries unrelated changes or drive-by refactors, name them and suggest splitting them out.>
 
 <If passing:> Moving on to code review. 🔍
-<If problem does not exist:> Closing — no demonstrated failure. Feel free to reopen with a reproduction case.
+<If problem does not exist:> Requesting changes — no demonstrated failure. Please provide a reproduction case to proceed.
 <If concerns:> Flagging these for discussion before diving deeper.
 
 <details>
@@ -146,7 +154,7 @@ Approach: <state your honest assessment — the scope feels right / feels like i
 方案：<范围合理 / 感觉可以大幅简化 / 建议砍掉的部分>。<如果看到更简路径，点名：有没有考虑过直接 X？可能用很小的复杂度覆盖大部分场景。><如果 diff 夹带了无关改动或顺手重构，点名并建议拆成单独 PR。>
 
 <如果通过：> 进入代码审查 🔍
-<如果问题不存在：> 关闭——未展示实际故障。欢迎带上复现案例重新打开。
+<如果问题不存在：> 请求修改——未展示实际故障。请提供复现案例后继续。
 <如果有顾虑：> 先提出来讨论，再深入看代码。
 
 </details>
@@ -156,6 +164,7 @@ Approach: <state your honest assessment — the scope feels right / feels like i
 
 Save this comment's ID. Terminal exits — stop here if any applies:
 
+- Core module hard block (Stage 0b) → rejected, do not proceed.
 - Template failure → stopped in 1a.
 - Problem does not exist → request changes in 1b, do not proceed to Stage 2.
 - Direction escalated → stop here.
@@ -265,7 +274,7 @@ Step back and look at the whole picture — the motivation, the implementation, 
 - If I had to maintain this in six months, would I curse the author or thank them?
 - Am I approving this because it's genuinely good, or because I ran out of reasons to say no?
 - **Did I verify the problem actually exists?** Or did I accept the PR's framing ("this value could be passed") without asking "has this ever happened?" If the PR has no before/after reproduction, I should not be this far in the pipeline.
-- **Is this part of a batch?** If this PR met the Stage 0 batch threshold (3+ similar PRs from the same author), am I evaluating each one on merit, or being worn down by volume?
+- **Is this part of a pattern?** If the same author has multiple similar PRs open, am I evaluating each one on merit, or being worn down by volume?
 - **Am I being a pushover?** If I feel "this is probably fine but I'm not sure it's needed" — that feeling IS the signal. The gate's job is to say no to things that are not clearly needed.
 
 If your independent proposal was materially simpler — say so. Not as a blocker, but as an honest question the contributor should think about.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,18 +23,21 @@ _Adapted from Andrej Karpathy's [CLAUDE.md](https://github.com/multica-ai/andrej
 
 ### Core Infrastructure Is Maintainer-Only
 
-**We do not accept community PRs that refactor core infrastructure. Period.**
+**Before approving any PR touching core modules, the reviewer must honestly
+ask: do I truly understand this change's full impact?**
 
 Core modules — `packages/core/src/**`, auth, providers, models, config, tools,
-services — are the architectural backbone. A community contributor cannot
-understand the full blast radius of a core refactor. "The direction looks
-correct" is not enough; the design is likely wrong because the contributor
-lacks architectural context. A bad core refactor costs months of breakage; a
-wrongly rejected one costs a polite comment. **When in doubt, reject. Better
-to wrongly reject a valid PR than to wrongly accept a broken one.**
+services — are the architectural backbone. If the reviewer cannot name every
+downstream consumer affected by the change, they do not understand the blast
+radius — escalate to a maintainer. "The direction looks correct" is not
+confidence; it means the reviewer understood the intent but not the impact.
 
-Core refactors must be maintainer-initiated, with design discussion in an
-issue before any PR is opened.
+Community PRs that refactor core infrastructure are rejected by default. Core
+refactors must be maintainer-initiated, with design discussion in an issue
+before any PR is opened.
+
+**When in doubt, escalate. Better to wrongly reject a valid PR than to wrongly
+accept a broken one.**
 
 ## Common Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,19 +21,21 @@ simplify.
 
 _Adapted from Andrej Karpathy's [CLAUDE.md](https://github.com/multica-ai/andrej-karpathy-skills/blob/main/CLAUDE.md)._
 
-### Core Infrastructure Is Maintainer-Only
-
-**Non-maintainer PRs touching core infrastructure are rejected. No
-exceptions, no evaluation, no judgment.**
+### Core Infrastructure Is Maintainer-Only (two-tier rule)
 
 Core modules — `packages/core/src/**`, auth, providers, models, config, tools,
-services — are the architectural backbone. The gate cannot assess the blast
-radius of changes to these modules. "The direction looks correct" is not
-confidence; it is how bad refactors get approved (see PR #5089: 75 files
-across core/auth/providers/models, approved by gate, design was wrong).
+services — are the architectural backbone. PRs touching them face a two-tier
+gate:
 
-Core refactors must be maintainer-initiated, with design discussion in an
-issue before any PR is opened. **This is not a guideline. It is a wall.**
+1. **Large-scope changes (10+ files or 500+ lines in core) → hard block.**
+   No evaluation, no exceptions. Core refactors must be maintainer-initiated.
+2. **Small-scope changes → gate may evaluate, but must be 100% confident.**
+   Any doubt at all → escalate to maintainer. "The direction looks correct"
+   is not confidence. The gate must name every downstream consumer; if it
+   cannot, escalate.
+
+**When in doubt, escalate. Better to wrongly escalate than to wrongly
+approve.**
 
 ## Common Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,21 +23,17 @@ _Adapted from Andrej Karpathy's [CLAUDE.md](https://github.com/multica-ai/andrej
 
 ### Core Infrastructure Is Maintainer-Only
 
-**Before approving any PR touching core modules, the reviewer must honestly
-ask: do I truly understand this change's full impact?**
+**Non-maintainer PRs touching core infrastructure are rejected. No
+exceptions, no evaluation, no judgment.**
 
 Core modules — `packages/core/src/**`, auth, providers, models, config, tools,
-services — are the architectural backbone. If the reviewer cannot name every
-downstream consumer affected by the change, they do not understand the blast
-radius — escalate to a maintainer. "The direction looks correct" is not
-confidence; it means the reviewer understood the intent but not the impact.
+services — are the architectural backbone. The gate cannot assess the blast
+radius of changes to these modules. "The direction looks correct" is not
+confidence; it is how bad refactors get approved (see PR #5089: 75 files
+across core/auth/providers/models, approved by gate, design was wrong).
 
-Community PRs that refactor core infrastructure are rejected by default. Core
-refactors must be maintainer-initiated, with design discussion in an issue
-before any PR is opened.
-
-**When in doubt, escalate. Better to wrongly reject a valid PR than to wrongly
-accept a broken one.**
+Core refactors must be maintainer-initiated, with design discussion in an
+issue before any PR is opened. **This is not a guideline. It is a wall.**
 
 ## Common Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,21 @@ simplify.
 
 _Adapted from Andrej Karpathy's [CLAUDE.md](https://github.com/multica-ai/andrej-karpathy-skills/blob/main/CLAUDE.md)._
 
+### Core Infrastructure Is Maintainer-Only
+
+**We do not accept community PRs that refactor core infrastructure. Period.**
+
+Core modules — `packages/core/src/**`, auth, providers, models, config, tools,
+services — are the architectural backbone. A community contributor cannot
+understand the full blast radius of a core refactor. "The direction looks
+correct" is not enough; the design is likely wrong because the contributor
+lacks architectural context. A bad core refactor costs months of breakage; a
+wrongly rejected one costs a polite comment. **When in doubt, reject. Better
+to wrongly reject a valid PR than to wrongly accept a broken one.**
+
+Core refactors must be maintainer-initiated, with design discussion in an
+issue before any PR is opened.
+
 ## Common Commands
 
 ### Building

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,14 +21,18 @@ simplify.
 
 _Adapted from Andrej Karpathy's [CLAUDE.md](https://github.com/multica-ai/andrej-karpathy-skills/blob/main/CLAUDE.md)._
 
-### Core Infrastructure Is Maintainer-Only (two-tier rule)
+### Core Infrastructure Is Maintainer-Only (triage gate, two-tier rule)
 
-Core modules — `packages/core/src/**`, auth, providers, models, config, tools,
-services — are the architectural backbone. PRs touching them face a two-tier
-gate:
+Core modules — `packages/core/src/**`, `packages/*/src/auth/**`,
+`packages/*/src/providers/**`, `packages/*/src/models/**`,
+`packages/*/src/config/**`, `packages/*/src/tools/**`,
+`packages/*/src/services/**`, cross-package changes — are the architectural
+backbone. External PRs touching them face a two-tier gate (maintainer-authored
+PRs are exempt):
 
 1. **Large-scope changes (10+ files or 500+ lines in core) → hard block.**
-   No evaluation, no exceptions. Core refactors must be maintainer-initiated.
+   No evaluation, no exceptions. Large-scale core refactors must be
+   maintainer-initiated.
 2. **Small-scope changes → gate may evaluate, but must be 100% confident.**
    Any doubt at all → escalate to maintainer. "The direction looks correct"
    is not confidence. The gate must name every downstream consumer; if it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ PRs are exempt):
 
 1. **Large-scope changes (500+ changed lines in core, additions +
    deletions combined) → hard block.**
-   No evaluation, no exceptions. Large-scale core refactors must be
-   maintainer-initiated. Breadth alone is not size — a low-risk sweep that
+   Skip evaluation entirely — the maintainer exemption above is the sole
+   exception. Large-scale core refactors must be maintainer-initiated. Breadth alone is not size — a low-risk sweep that
    touches 10+ files but changes a line or two each is escalated to a
    maintainer for awareness and otherwise judged under Tier 2's
    100%-confidence bar, not auto-rejected on file count.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,8 @@ PRs are exempt):
    No evaluation, no exceptions. Large-scale core refactors must be
    maintainer-initiated. Breadth alone is not size — a low-risk sweep that
    touches 10+ files but changes a line or two each is escalated to a
-   maintainer, not auto-rejected on file count.
+   maintainer for awareness and otherwise judged under Tier 2's
+   100%-confidence bar, not auto-rejected on file count.
 2. **Small-scope changes → gate may evaluate, but must be 100% confident.**
    Any doubt at all → escalate to maintainer. "The direction looks correct"
    is not confidence. The gate must name every downstream consumer; if it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,8 @@ Core modules — `packages/core/src/**`, `packages/*/src/auth/**`,
 backbone. External PRs touching them face a two-tier gate (maintainer-authored
 PRs are exempt):
 
-1. **Large-scope changes (500+ changed lines in core) → hard block.**
+1. **Large-scope changes (500+ changed lines in core, additions +
+   deletions combined) → hard block.**
    No evaluation, no exceptions. Large-scale core refactors must be
    maintainer-initiated. Breadth alone is not size — a low-risk sweep that
    touches 10+ files but changes a line or two each is escalated to a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,9 +30,11 @@ Core modules — `packages/core/src/**`, `packages/*/src/auth/**`,
 backbone. External PRs touching them face a two-tier gate (maintainer-authored
 PRs are exempt):
 
-1. **Large-scope changes (10+ files or 500+ lines in core) → hard block.**
+1. **Large-scope changes (500+ changed lines in core) → hard block.**
    No evaluation, no exceptions. Large-scale core refactors must be
-   maintainer-initiated.
+   maintainer-initiated. Breadth alone is not size — a low-risk sweep that
+   touches 10+ files but changes a line or two each is escalated to a
+   maintainer, not auto-rejected on file count.
 2. **Small-scope changes → gate may evaluate, but must be 100% confident.**
    Any doubt at all → escalate to maintainer. "The direction looks correct"
    is not confidence. The gate must name every downstream consumer; if it


### PR DESCRIPTION
## What this PR does

Adds two new checks to the PR triage gate and fixes several control flow bugs in the gate prompt (`pr-workflow.md`):

- **Stage 0: Batch Pattern Detection** — before reviewing any PR individually, check if the same author has 3+ similar open PRs in 7 days. If so, evaluate the batch as a group instead of rubber-stamping each one.
- **Stage 1b: Problem Existence Check** — mandatory before direction review. Classifies the PR as observed bug (with reproduction) or theoretical hardening (without). Requests reproduction for the latter; closes if the author cannot provide one.
- **Gate Philosophy** — concise stance statement: the gate's default posture is skepticism, burden of proof is on the author.

Bug fixes from review feedback:
- Fixed broken jq date filter (`"7 days ago"` string comparison was always false) and `--state all` / `--state open` mismatch.
- Added missing terminal exit list after Stage 1 comment — the 1b "problem does not exist" path had no stop instruction, causing the agent to fall through into Stage 2.
- Aligned Stage 3 batch threshold (was 10+, now references Stage 0's 3+).
- Compressed Gate Philosophy, Stage 0, and 1b sections for conciseness (net -11 lines).

## Why it's needed

On 2026-06-22, a high-volume automated contributor submitted 20 PRs in a single day. 11 of them were validation noise — "reject fractional maxConnections", "require integer read_file ranges", "validate sessions list limit" — each individually plausible, each collectively a waste of maintainer attention. Our PR triage gate approved all of them.

The root cause: the gate asked "is the direction correct?" — a question every one of these PRs could pass, because "rejecting invalid values" sounds reasonable. It never asked the harder question: **"does this problem actually exist?"** Nobody ever passed `maxConnections: 1.5`. The runtime already coerced or rejected these values. The PRs were schema hygiene dressed up as bug fixes, and the gate waved them through.

This PR closes that gap: the gate now checks problem existence before direction, and detects batch patterns before individual review.

## Reviewer Test Plan

This is a prompt-only change (no code paths affected). Verification is by reading the modified `pr-workflow.md` and confirming the gate logic is correct.

### How to verify

- Read `.qwen/skills/triage/references/pr-workflow.md` and confirm the Stage 0 jq command returns correct results (the old `"7 days ago"` string comparison was always false).
- Confirm the terminal exit list after Stage 1 comment covers all three exits (template failure, problem does not exist, direction escalated).
- Confirm Stage 3 batch threshold references Stage 0's 3+ instead of the old 10+.

### Evidence (Before & After)

N/A — prompt-only change, no user-visible behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS  | N/A |
| Windows | N/A |
|  Linux  | N/A |

### Environment (optional)

N/A

## Risk & Scope

- Main risk or tradeoff: the problem-existence check may be overly aggressive for edge-case PRs (security hardening, race conditions) where reproduction is hard to provide. Mitigated by the fact that maintainers review outside this prompt flow and will recognize legitimate cases.
- Not validated / out of scope: no E2E test of the triage agent running the updated prompt against real PRs.
- Breaking changes / migration notes: none.

## Linked Issues

Related to the 2026-06-22 batch incident (no specific issue filed).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 PR triage gate 中新增两项检查，并修复 gate prompt（`pr-workflow.md`）中的多个控制流 bug：

- **Stage 0: 批量模式检测** — 在逐个 review 之前，先检查同一作者 7 天内是否有 3+ 个类似 open PR。如果有，改为批量评估，而不是逐个放行。
- **Stage 1b: 问题存在性检查** — 在方向 review 之前强制执行。将 PR 分类为已观测 bug（有复现）或理论性加固（无复现）。后者要求提供复现，无法提供则关闭。
- **Gate Philosophy** — 简洁的立场声明：gate 默认姿态是怀疑，举证责任在作者。

来自 review 反馈的 bug 修复：
- 修复了失效的 jq 日期过滤（`"7 days ago"` 字符串比较永远返回 false）以及 `--state all` / `--state open` 不一致。
- 补充了 Stage 1 comment 后缺失的终止出口列表——1b "问题不存在" 路径没有 stop 指令，导致 agent 会继续 fall through 到 Stage 2。
- 统一 Stage 3 批量阈值（原来写的 10+，改为引用 Stage 0 的 3+）。
- 压缩 Gate Philosophy、Stage 0 和 1b 段落以提升简洁度（净减 11 行）。

## 为什么需要

2026-06-22，一个高频自动贡献者在一天内提交了 20 个 PR。其中 11 个是验证噪音——"拒绝小数 maxConnections"、"要求整数 read_file 范围"、"验证 sessions list limit"——每个单独看都合理，合在一起是浪费 maintainer 时间。我们的 PR triage gate 全部放行。

根因：gate 问的是"方向对不对"——这些 PR 都能过，因为"拒绝非法值"听起来没毛病。但从未问更难的问题：**"这个问题实际存在吗？"** 没人传过 `maxConnections: 1.5`，运行时已经 coerce 或拒绝了这些值。这些 PR 是把 schema 洁癖包装成 bug fix，gate 全部放行。

这个 PR 补上了这个缺口：gate 现在在方向 review 之前检查问题存在性，在逐个 review 之前检测批量模式。

## Reviewer 测试计划

纯 prompt 改动（不影响代码路径）。验证方式是阅读修改后的 `pr-workflow.md` 确认 gate 逻辑正确。

### 如何验证

- 阅读 `.qwen/skills/triage/references/pr-workflow.md`，确认 Stage 0 的 jq 命令能返回正确结果（旧的 `"7 days ago"` 字符串比较永远返回 false）。
- 确认 Stage 1 comment 后的终止出口列表覆盖三种情况（模板不通过、问题不存在、方向需升级）。
- 确认 Stage 3 批量阈值引用 Stage 0 的 3+ 而非旧的 10+。

### 证据（改进前 vs 改进后）

N/A — 纯 prompt 改动，无用户可见行为变化。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  macOS  | N/A |
| Windows | N/A |
|  Linux  | N/A |

### 环境（可选）

N/A

## 风险与范围

- 主要风险或权衡：问题存在性检查对难以提供复现的 edge-case PR（安全加固、race condition）可能过于激进。缓解因素：maintainer 在这个 prompt 流程之外仍会 review，能识别合理的 case。
- 未验证 / 超出范围：没有对 triage agent 运行更新后 prompt 的 E2E 测试。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

关联 2026-06-22 批量事件（未单独建 issue）。

</details>


Refs #3957