### PR TITLE
fix(test): isolate ACP integration agents via QWEN_HOME to end parallel-settings race

### DIFF
--- a/integration-tests/cli/acp-integration.test.ts
+++ b/integration-tests/cli/acp-integration.test.ts
@@ -5,7 +5,8 @@
  */
 
 import { spawn } from 'node:child_process';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { createInterface } from 'node:readline';
 import { setTimeout as delay } from 'node:timers/promises';
 import { describe, expect, it } from 'vitest';
@@ -101,12 +102,30 @@ function setupAcpTest(
   const acpFlag =
     options?.useNewFlag !== false ? '--acp' : '--experimental-acp';
 
+  // Isolate this agent's GLOBAL (User-scope) qwen config dir via QWEN_HOME.
+  // `globalSetup` does not sandbox HOME, so every integration test shares the
+  // real `$HOME/.qwen`, and `vitest.config.ts` runs test files with
+  // `fileParallelism: true` (up to 4 at once). The ACP `authenticate` /
+  // `setModel` handlers persist `security.auth.selectedType` (and `model.name`)
+  // to User scope, so a concurrent test (e.g. `system-control`'s
+  // `setModel('qwen3-...')`) can clobber the persisted auth type in the window
+  // between this agent's `authenticate({ methodId: 'openai' })` and its
+  // `session/new`. When that happens the new session config resolves a
+  // non-openai auth, the openai runtime model is never captured, and it drops
+  // out of `availableModels` — flaking `expect(openaiModel).toBeDefined()` in
+  // the `set_config_option` test (acp-integration.test.ts:516). A per-agent
+  // QWEN_HOME redirects `getGlobalQwenDir()` so the authenticate -> session/new
+  // round-trip reads back exactly what this agent wrote.
+  const qwenHome = join(rig.testDir!, '.qwen-home');
+  mkdirSync(qwenHome, { recursive: true });
+
   const agent = spawn(
     'node',
     [rig.bundlePath, acpFlag, '--no-chat-recording'],
     {
       cwd: rig.testDir!,
       stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, QWEN_HOME: qwenHome },
     },
   );
 


### PR DESCRIPTION
## What this PR does

Spawns each ACP integration-test agent (`setupAcpTest` in `acp-integration.test.ts`) with a per-agent `QWEN_HOME` so its global (User-scope) qwen config dir is isolated from every other test. Test-only change; no runtime/production code is touched.

## Why it's needed

The ACP test `supports session/set_config_option for mode and model` flakes in CI at `acp-integration.test.ts:516` (`expect(openaiModel).toBeDefined()`), which fails the **Integration Tests (No Sandbox)** job and gates **Publish Release**. My previous PR #5721 restored the original `availableModels.find(m => m.modelId.includes('openai'))` form believing the assertion shape was the problem — but the very run triggered by that merge (run [27989509217](https://github.com/QwenLM/qwen-code/actions/runs/27989509217/job/82838650755)) failed again at line 516. The assertion shape was never the real cause.

Real root cause: `integration-tests/globalSetup.ts` does not sandbox `HOME`, so every integration test shares the real `$HOME/.qwen`, and `integration-tests/vitest.config.ts` sets `fileParallelism: true` (up to 4 test files at once). The ACP `authenticate` and `setModel` handlers persist `security.auth.selectedType` (and `model.name`) to **User scope** (`$HOME/.qwen/settings.json`). A concurrent test file — e.g. `sdk-typescript/system-control.test.ts` calling `setModel('qwen3-vl-plus')` / `setModel('qwen3-turbo')` — clobbers the persisted auth type in the window between this agent's `authenticate({ methodId: 'openai' })` and its `session/new`. The new per-session `Config` reads the clobbered settings from disk, resolves a non-openai auth, never captures the openai runtime-model snapshot, and the openai model drops out of `availableModels`. Because `formatAcpModelId` always appends `(openai)`, `find(...includes('openai'))` then returns `undefined` and the assertion fails. (#5676's `availableModels.some(m => m.modelId === currentValue)` form failed at the same line for the same underlying reason — the current model is also absent from the list.)

Setting a per-agent `QWEN_HOME` redirects `Storage.getGlobalQwenDir()` (which honors `QWEN_HOME` first) to an isolated directory, so the `authenticate` -> `session/new` round-trip reads back exactly what this agent wrote, immune to any concurrent writer. This is the same isolation mechanism already used by `qwen-config-dir.test.ts`.

## Reviewer Test Plan

### How to verify

1. Build the bundle: `npm run bundle`.
2. Run the previously-flaky test against the bundle with openai env (fake creds are fine — `set_config_option` performs no inference):

```
cd integration-tests && OPENAI_API_KEY=sk-fake OPENAI_BASE_URL=https://api.openai.com/v1 OPENAI_MODEL=gpt-4o-mini-fake QWEN_SANDBOX=false \
  npx vitest run cli/acp-integration.test.ts -t "config_option"
```

Expected: `supports session/set_config_option for mode and model` and `returns error for invalid configId in set_config_option` both pass.

Mechanism evidence (driving the bundled ACP agent directly):
- With a per-agent `QWEN_HOME` **and** a deliberately hostile shared `$HOME/.qwen/settings.json` (`selectedType: 'qwen-oauth'`, `model.name: 'qwen3-turbo'`), `session/new` still returns `availableModels` containing `$runtime|openai|<model>(openai)` — the openai model survives → test passes.
- Without isolation, overwriting the shared `$HOME/.qwen/settings.json` to `selectedType: 'qwen-oauth'` in the window between `authenticate` and `session/new` breaks the flow (the session resolves qwen-oauth and either drops the openai model or rejects with auth-required) — reproducing the CI symptom family.
- Control: the `returns internal error details when model auth is required` test (which skips `authenticate` and expects a `qwen-oauth` model in the list) still passes under isolation — `coder-model(qwen-oauth)` remains present.

### Evidence (Before & After)

N/A (test-only change, not user-visible). Before: under parallel CI load the shared `$HOME/.qwen` auth type is clobbered between `authenticate` and `session/new` → no openai model in `availableModels` → `acp-integration.test.ts:516` fails → No-Sandbox job exits 1 → Publish Release skipped. After: each ACP agent owns an isolated `QWEN_HOME`, so its persisted auth type cannot be clobbered by a concurrent test → the openai runtime model is reliably enumerated.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

macOS: built the bundle and ran `supports session/set_config_option for mode and model`, `returns error for invalid configId in set_config_option`, and `returns internal error details when model auth is required` locally — all pass. Windows/Linux not run locally; the authoritative check is the CI No-Sandbox job.

### Environment (optional)

Local: `npm run bundle` + `vitest run --root ./integration-tests` with fake `OPENAI_*` env, `QWEN_SANDBOX=false`.

## Risk & Scope

- Main risk or tradeoff: None for production — the change only adds `QWEN_HOME` to the test-spawned agent's env. Isolation matches the existing `qwen-config-dir.test.ts` pattern.
- Not validated / out of scope: Inference-driven ACP tests (smoke test, plan-mode, usage-metadata) were not re-run locally (need real provider auth); they only become more deterministic under isolation. Sibling ACP files (`acp-cron.test.ts`) share the same latent shared-`$HOME` fragility and could adopt the same isolation in a follow-up.
- Breaking changes / migration notes: None.

## Linked Issues

Refs failing run https://github.com/QwenLM/qwen-code/actions/runs/27989509217/job/82838650755. Follow-up to #5721 (which addressed the assertion shape but not the underlying shared-settings race).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让每个 ACP 集成测试 agent（`acp-integration.test.ts` 里的 `setupAcpTest`）在 spawn 时带上各自独立的 `QWEN_HOME`，从而把它的全局（User 级）qwen 配置目录与其他测试隔离开。仅改测试代码，不涉及任何运行时/生产代码。

## 为什么需要

ACP 测试 `supports session/set_config_option for mode and model` 在 CI 的 `acp-integration.test.ts:516`（`expect(openaiModel).toBeDefined()`）随机失败，会让 **Integration Tests (No Sandbox)** job 失败，而它 gating **Publish Release**。我上一个 PR #5721 把断言恢复成原始的 `availableModels.find(m => m.modelId.includes('openai'))` 写法，以为问题出在断言形态——但那次合并触发的 run（[27989509217](https://github.com/QwenLM/qwen-code/actions/runs/27989509217/job/82838650755)）依然在 516 行失败。断言形态从来不是真正的根因。

真正的根因：`integration-tests/globalSetup.ts` 没有隔离 `HOME`，所有集成测试共享真实的 `$HOME/.qwen`；而 `integration-tests/vitest.config.ts` 设了 `fileParallelism: true`（最多 4 个测试文件并行）。ACP 的 `authenticate` 和 `setModel` handler 会把 `security.auth.selectedType`（以及 `model.name`）持久化到 **User 级** 的 `$HOME/.qwen/settings.json`。某个并行的测试文件——例如 `sdk-typescript/system-control.test.ts` 调用 `setModel('qwen3-vl-plus')` / `setModel('qwen3-turbo')`——会在本测试 `authenticate({ methodId: 'openai' })` 与 `session/new` 之间的窗口里把持久化的 auth type 改掉。新建会话的 `Config` 从磁盘读到被改写的设置，解析成非 openai 鉴权，于是 openai 运行时模型快照根本没被捕获，openai 模型也就从 `availableModels` 里消失。由于 `formatAcpModelId` 总是拼上 `(openai)`，`find(...includes('openai'))` 返回 `undefined`，断言失败。（#5676 的 `availableModels.some(m => m.modelId === currentValue)` 写法在同一行失败，根因相同——当前模型同样不在列表里。）

给每个 agent 设置独立的 `QWEN_HOME`，会让 `Storage.getGlobalQwenDir()`（它优先读取 `QWEN_HOME`）指向一个隔离目录，于是 `authenticate` -> `session/new` 的往返读到的就是这个 agent 自己写入的内容，不受任何并发写入者影响。这正是 `qwen-config-dir.test.ts` 已经在用的隔离手段。

## 评审验证

### 如何验证

1. 构建 bundle：`npm run bundle`。
2. 用 openai 环境变量（假 key 即可，`set_config_option` 不做任何推理）对着 bundle 跑之前易挂的用例：

```
cd integration-tests && OPENAI_API_KEY=sk-fake OPENAI_BASE_URL=https://api.openai.com/v1 OPENAI_MODEL=gpt-4o-mini-fake QWEN_SANDBOX=false \
  npx vitest run cli/acp-integration.test.ts -t "config_option"
```

预期：`supports session/set_config_option for mode and model` 与 `returns error for invalid configId in set_config_option` 均通过。

机制佐证（直接驱动打包后的 ACP agent）：
- 设了独立 `QWEN_HOME`，**并且**故意把共享的 `$HOME/.qwen/settings.json` 写成敌对值（`selectedType: 'qwen-oauth'`、`model.name: 'qwen3-turbo'`）时，`session/new` 返回的 `availableModels` 里仍然包含 `$runtime|openai|<model>(openai)`——openai 模型存活 → 用例通过。
- 不做隔离、在 `authenticate` 与 `session/new` 之间把共享的 `$HOME/.qwen/settings.json` 覆写成 `selectedType: 'qwen-oauth'`，整个流程就坏掉（会话解析成 qwen-oauth，要么丢掉 openai 模型，要么直接以 auth-required 报错）——复现了 CI 故障所属的同一类。
- 对照：`returns internal error details when model auth is required` 用例（不调用 `authenticate`，期望列表里有 qwen-oauth 模型）在隔离下依然通过——`coder-model(qwen-oauth)` 仍在列表中。

### 证据（Before & After）

N/A（仅改测试，无用户可见变化）。Before：并行 CI 负载下，共享的 `$HOME/.qwen` auth type 在 `authenticate` 与 `session/new` 之间被改掉 → `availableModels` 里没有 openai 模型 → `acp-integration.test.ts:516` 失败 → No-Sandbox job 退出码 1 → Publish Release 被跳过。After：每个 ACP agent 拥有独立 `QWEN_HOME`，持久化的 auth type 不会被并发测试改写 → openai 运行时模型稳定出现在列表里。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS：构建 bundle 后本地跑了 `supports session/set_config_option for mode and model`、`returns error for invalid configId in set_config_option`、`returns internal error details when model auth is required`，全部通过。Windows/Linux 未在本地运行；以 CI 的 No-Sandbox job 为权威校验。

### 运行环境（可选）

本地：`npm run bundle` + `vitest run --root ./integration-tests`，使用假的 `OPENAI_*` 环境变量、`QWEN_SANDBOX=false`。

## 风险与范围

- 主要风险/取舍：对生产代码零风险——只在测试 spawn 的 agent env 里加了 `QWEN_HOME`，隔离方式与现有的 `qwen-config-dir.test.ts` 一致。
- 未验证/范围外：依赖推理的 ACP 用例（smoke test、plan-mode、usage-metadata）未在本地重跑（需真实 provider 鉴权），它们在隔离下只会更稳定。同类 ACP 文件（`acp-cron.test.ts`）有同样潜在的共享 `$HOME` 脆弱性，可在后续 PR 采用相同隔离。
- 破坏性变更：无。

## 关联

关联失败 run https://github.com/QwenLM/qwen-code/actions/runs/27989509217/job/82838650755。是 #5721 的后续（#5721 只动了断言形态，没解决底层的共享设置竞态）。

</details>
