### PR TITLE
fix(test): make ACP set_config_option test use a deterministic openai provider model

### DIFF
--- a/integration-tests/cli/acp-integration.test.ts
+++ b/integration-tests/cli/acp-integration.test.ts
@@ -467,7 +467,31 @@ function setupAcpTest(
 
   it('supports session/set_config_option for mode and model', async () => {
     const rig = new TestRig();
-    rig.setup('acp set config option');
+    // Inject a deterministic openai provider model so `availableModels` always
+    // contains a settable openai entry. The previous version relied on the
+    // env-driven OPENAI_MODEL being captured as a runtime-model snapshot and
+    // enumerated, which is environment-sensitive and flaked in CI (the openai
+    // model could be absent from `availableModels`, failing the assertion
+    // below). A registry model configured via `modelProviders` is always
+    // enumerated and switchable without inference, making this test
+    // deterministic regardless of how the ambient openai credentials resolve.
+    rig.setup('acp set config option', {
+      settings: {
+        modelProviders: {
+          openai: {
+            protocol: 'openai',
+            models: [
+              {
+                id: 'e2e-set-config-option-model',
+                name: 'E2E Set Config Option Model',
+                baseUrl: 'https://api.openai.com/v1',
+                envKey: 'OPENAI_API_KEY',
+              },
+            ],
+          },
+        },
+      },
+    });
 
     const { sendRequest, cleanup, stderr } = setupAcpTest(rig);
 
@@ -528,9 +552,10 @@ function setupAcpTest(
       expect(modelOption!.currentValue).toBeTruthy();
 
       // Test: Set model using set_config_option
-      // Use openai model to avoid auth issues
+      // Target the deterministic openai provider model injected via settings
+      // above (avoids auth issues and is always present in `availableModels`).
       const openaiModel = newSession.models.availableModels.find((model) =>
-        model.modelId.includes('openai'),
+        model.modelId.includes('e2e-set-config-option-model'),
       );
       expect(openaiModel).toBeDefined();
 


### PR DESCRIPTION
## What this PR does

Makes the ACP integration test `supports session/set_config_option for mode and model` inject a deterministic openai provider model via `modelProviders` in the test's settings, and target that specific model when exercising `session/set_config_option`. Test-only change.

## Why it's needed

The test asserted that an openai model appears in the session's `availableModels` (`expect(openaiModel).toBeDefined()`). That entry only exists if the ambient `OPENAI_MODEL` is captured as a runtime-model snapshot and enumerated at `session/new` — a path that is environment-sensitive. In CI the openai model was absent from `availableModels`, so the assertion failed at `acp-integration.test.ts:535`, which fails the **Integration Tests (No Sandbox)** job and gates **Publish Release**. This persisted across the previous two attempts: #5721 (restored the assertion shape) and #5724 (isolated `QWEN_HOME` per agent) — neither addressed the dependency on env-driven runtime-model capture.

A model declared via `modelProviders` is a registry entry: it is always enumerated in `availableModels` and is switchable via `set_config_option` without any inference. Targeting an injected provider model removes the dependency on the fragile runtime-capture path, so the test is deterministic regardless of how the ambient openai credentials resolve in a given environment.

## Reviewer Test Plan

### How to verify

1. `npm run bundle`
2. Run the test against the bundle:

```
cd integration-tests && OPENAI_API_KEY=sk-fake OPENAI_BASE_URL=https://api.openai.com/v1 OPENAI_MODEL=qwen3.7-max QWEN_SANDBOX=false \
  npx vitest run cli/acp-integration.test.ts -t "for mode and model"
```

Expected: pass. It also passes **without** `OPENAI_MODEL` set — proving the assertion no longer depends on env-driven runtime-model enumeration:

```
cd integration-tests && OPENAI_API_KEY=sk-fake OPENAI_BASE_URL=https://api.openai.com/v1 QWEN_SANDBOX=false \
  npx vitest run cli/acp-integration.test.ts -t "for mode and model"
```

The sibling tests (`returns error for invalid configId in set_config_option`, `returns internal error details when model auth is required`) are untouched and still pass.

### Evidence (Before & After)

N/A (test-only). Before: `availableModels` contained no openai entry in CI → `expect(openaiModel).toBeDefined()` failed → No-Sandbox job exited 1 → Publish Release skipped. After: an injected openai registry model is always present and switchable, so the find + set + round-trip assertions are deterministic.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS: built the bundle and ran the target test both with and without `OPENAI_MODEL` (pass), plus the two sibling tests (pass). Windows/Linux not run locally; the authoritative check is the CI No-Sandbox job.

### Environment (optional)

`npm run bundle` + `vitest run --root ./integration-tests` with fake `OPENAI_*` env, `QWEN_SANDBOX=false`.

## Risk & Scope

- Main risk or tradeoff: None for production — the change only adds a `modelProviders` entry to one test's settings and narrows the model it targets. The test still exercises the real `session/set_config_option` model round-trip.
- Not validated / out of scope: The exact CI-environment condition under which the env-driven runtime openai model fails to enumerate was not reproduced locally (it reproduces only in CI); this change makes the test independent of that condition rather than diagnosing it. Inference-driven ACP tests were not re-run (need real provider auth).
- Breaking changes / migration notes: None.

## Linked Issues

Refs the failing No-Sandbox runs at `acp-integration.test.ts:535`. Follow-up to #5721 and #5724.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 ACP 集成测试 `supports session/set_config_option for mode and model` 通过测试 settings 里的 `modelProviders` 注入一个确定性的 openai provider 模型,并在跑 `session/set_config_option` 时精确针对这个模型。仅改测试。

## 为什么需要

该测试断言会话的 `availableModels` 里存在一个 openai 模型(`expect(openaiModel).toBeDefined()`)。这个条目只有在环境变量 `OPENAI_MODEL` 被捕获为 runtime-model 快照并在 `session/new` 时枚举出来才存在——而这条路径对环境很敏感。在 CI 里 openai 模型不在 `availableModels` 中,断言在 `acp-integration.test.ts:535` 失败,从而让 **Integration Tests (No Sandbox)** job 失败,而它 gating **Publish Release**。前两次尝试都没解决:#5721(恢复断言形态)和 #5724(给每个 agent 隔离 `QWEN_HOME`)都没触及"依赖 env 驱动的 runtime 模型捕获"这个根本点。

通过 `modelProviders` 声明的模型是 registry 条目:它一定会出现在 `availableModels` 里,并且能在不做任何推理的情况下通过 `set_config_option` 切换。针对一个注入的 provider 模型,就把测试从脆弱的 runtime 捕获路径上解耦出来,使它不受环境里 openai 凭证如何解析的影响,变得确定。

## 评审验证

1. `npm run bundle`
2. 对着 bundle 跑测试:

```
cd integration-tests && OPENAI_API_KEY=sk-fake OPENAI_BASE_URL=https://api.openai.com/v1 OPENAI_MODEL=qwen3.7-max QWEN_SANDBOX=false \
  npx vitest run cli/acp-integration.test.ts -t "for mode and model"
```

预期通过。在**不设** `OPENAI_MODEL` 时也通过——证明断言不再依赖 env 驱动的 runtime 模型枚举:

```
cd integration-tests && OPENAI_API_KEY=sk-fake OPENAI_BASE_URL=https://api.openai.com/v1 QWEN_SANDBOX=false \
  npx vitest run cli/acp-integration.test.ts -t "for mode and model"
```

同文件的另外两个用例(`returns error for invalid configId in set_config_option`、`returns internal error details when model auth is required`)未改动,仍通过。

### 证据(Before & After)

N/A(仅改测试)。Before:CI 里 `availableModels` 无 openai 条目 → `expect(openaiModel).toBeDefined()` 失败 → No-Sandbox job 退出码 1 → Publish Release 被跳过。After:注入的 openai registry 模型一定存在且可切换,find + set + 往返断言都确定。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS:构建 bundle 后,对目标用例分别在设/不设 `OPENAI_MODEL` 下各跑一次(通过),外加两个同文件用例(通过)。Windows/Linux 未在本地运行;以 CI 的 No-Sandbox job 为权威校验。

## 风险与范围

- 主要风险:对生产代码零风险——只在一个测试的 settings 里加了一个 `modelProviders` 条目并收窄了它针对的模型。测试仍然走真实的 `session/set_config_option` 模型往返。
- 未验证/范围外:env 驱动的 runtime openai 模型在何种 CI 环境条件下枚举失败,未在本地复现(只在 CI 复现);本改动是让测试不依赖该条件,而非诊断它。依赖推理的 ACP 用例未重跑(需真实 provider 鉴权)。
- 破坏性变更:无。

## 关联

关联 `acp-integration.test.ts:535` 的 No-Sandbox 失败。是 #5721 与 #5724 的后续。

</details>
