### PR TITLE
fix(core): keep active runtime model in default getAllConfiguredModels listing

### DIFF
--- a/packages/core/src/models/modelsConfig.test.ts
+++ b/packages/core/src/models/modelsConfig.test.ts
@@ -1889,6 +1889,71 @@ describe('ModelsConfig', () => {
           .every((m) => m.authType === AuthType.QWEN_OAUTH),
       ).toBe(true);
     });
+
+    it('should include an active runtime model whose authType has no registry models', () => {
+      // Regression for #5089: an OPENAI_*-derived runtime model (no registry
+      // entry) used to drop out of the default listing because the iteration
+      // was limited to `modelRegistry.getAuthTypes()`, which only knows about
+      // authTypes that have registry models. The runtime model can be the
+      // *current* model, so it must still appear in availableModels.
+      const modelsConfig = new ModelsConfig({
+        initialAuthType: AuthType.USE_OPENAI,
+        generationConfig: {
+          model: 'my-openai-model',
+          apiKey: 'sk-test-key',
+          baseUrl: 'https://api.example.com/v1',
+        },
+        generationConfigSources: {
+          model: { kind: 'env', envKey: 'OPENAI_MODEL' },
+          apiKey: { kind: 'env', envKey: 'OPENAI_API_KEY' },
+          baseUrl: { kind: 'env', envKey: 'OPENAI_BASE_URL' },
+        },
+      });
+
+      const snapshotId = modelsConfig.detectAndCaptureRuntimeModel();
+      expect(snapshotId).toBe('$runtime|openai|my-openai-model');
+
+      // Default call (no explicit authTypes) — the openai runtime model must
+      // be present even though openai has no registry models.
+      const allModels = modelsConfig.getAllConfiguredModels();
+      const openaiModel = allModels.find(
+        (m) => m.authType === AuthType.USE_OPENAI,
+      );
+      expect(openaiModel).toBeDefined();
+      expect(openaiModel?.id).toBe('my-openai-model');
+      expect(openaiModel?.isRuntimeModel).toBe(true);
+
+      // qwen-oauth registry models still come first and are still listed.
+      expect(allModels.some((m) => m.authType === AuthType.QWEN_OAUTH)).toBe(
+        true,
+      );
+    });
+
+    it('should not inject the runtime model when an explicit authType filter excludes it', () => {
+      // The runtime-model injection is scoped to the default listing; an
+      // explicit filter must return exactly the requested authType set.
+      const modelsConfig = new ModelsConfig({
+        initialAuthType: AuthType.USE_OPENAI,
+        generationConfig: {
+          model: 'my-openai-model',
+          apiKey: 'sk-test-key',
+          baseUrl: 'https://api.example.com/v1',
+        },
+        generationConfigSources: {
+          model: { kind: 'env', envKey: 'OPENAI_MODEL' },
+          apiKey: { kind: 'env', envKey: 'OPENAI_API_KEY' },
+          baseUrl: { kind: 'env', envKey: 'OPENAI_BASE_URL' },
+        },
+      });
+      modelsConfig.detectAndCaptureRuntimeModel();
+
+      const qwenOnly = modelsConfig.getAllConfiguredModels([
+        AuthType.QWEN_OAUTH,
+      ]);
+      expect(qwenOnly.every((m) => m.authType === AuthType.QWEN_OAUTH)).toBe(
+        true,
+      );
+    });
   });
 
   describe('Runtime Model Snapshot', () => {

--- a/packages/core/src/models/modelsConfig.ts
+++ b/packages/core/src/models/modelsConfig.ts
@@ -260,10 +260,13 @@ export class ModelsConfig {
    * - Runtime model option (if active) is included before registry models of the same authType.
    */
   getAllConfiguredModels(authTypes?: AuthType[]): AvailableModel[] {
-    const inputAuthTypes =
-      authTypes && authTypes.length > 0
-        ? authTypes
-        : this.modelRegistry.getAuthTypes();
+    const hasExplicitAuthTypes = !!authTypes && authTypes.length > 0;
+    const inputAuthTypes = hasExplicitAuthTypes
+      ? authTypes!
+      : this.modelRegistry.getAuthTypes();
+
+    // Get runtime model option
+    const runtimeOption = this.getRuntimeModelOption();
 
     // De-duplicate while preserving the original order.
     const seen = new Set<AuthType>();
@@ -273,6 +276,21 @@ export class ModelsConfig {
         seen.add(authType);
         uniqueAuthTypes.push(authType);
       }
+    }
+
+    // A runtime model (e.g. an OPENAI_*-derived env/CLI override) can use an
+    // authType that has no registry models, so `modelRegistry.getAuthTypes()`
+    // omits it. Without this, the active runtime model — which may be the
+    // *current* model — would be dropped from the default listing. Only inject
+    // when no explicit authType filter was requested so callers asking for a
+    // specific authType still get exactly that set.
+    if (
+      !hasExplicitAuthTypes &&
+      runtimeOption &&
+      !seen.has(runtimeOption.authType)
+    ) {
+      seen.add(runtimeOption.authType);
+      uniqueAuthTypes.push(runtimeOption.authType);
     }
 
     // Force qwen-oauth to the front (if requested / defaulted in).
@@ -285,9 +303,6 @@ export class ModelsConfig {
         orderedAuthTypes.push(authType);
       }
     }
-
-    // Get runtime model option
-    const runtimeOption = this.getRuntimeModelOption();
 
     const allModels: AvailableModel[] = [];
     for (const authType of orderedAuthTypes) {


### PR DESCRIPTION
## What this PR does

Fixes a core regression where an **active runtime model** is dropped from `ModelsConfig.getAllConfiguredModels()` when its `authType` has no registry models. In the default (no explicit `authTypes` filter) case the method now includes the active runtime model's `authType` in the iteration, so it is enumerated alongside registry models. Callers that pass an explicit `authTypes` filter are unchanged — they still get exactly the requested set (a matching runtime model was, and remains, included by the existing loop).

## Why it's needed

#5089 changed the default branch of `getAllConfiguredModels` from `Object.values(AuthType)` to `this.modelRegistry.getAuthTypes()`, which only returns auth types that have **registry** models. A runtime model resolved purely from env/CLI overrides — e.g. `OPENAI_API_KEY` / `OPENAI_BASE_URL` / `OPENAI_MODEL` with no `modelProviders` entry — has `authType: 'openai'`, which has no registry models, so `'openai'` is absent from the iteration and the runtime model is never emitted. This happens **even when the runtime model is the current/active model**: `currentModelId` points at `$runtime|openai|…(openai)` while `availableModels` contains only `coder-model(qwen-oauth)`.

User-facing impact: ACP clients (Zed / VSCode companion) cannot see or re-select the active openai model; the interactive `/model` picker (`modelCommand.ts` calls `getAllConfiguredModels()` with no filter) omits it too; and the ACP integration test `supports session/set_config_option for mode and model` fails `expect(openaiModel).toBeDefined()` on every `main` run since #5089. The failure is **deterministic**, not a parallel-settings race — which is why #5721 (assertion shape) and #5724 (`QWEN_HOME` isolation) did not fix it.

## Reviewer Test Plan

### How to verify

1. New core unit regression test in `packages/core/src/models/modelsConfig.test.ts` captures a runtime openai model (no `modelProviders`) and asserts it appears in `getAllConfiguredModels()`; a second test asserts an explicit `authTypes` filter does **not** inject it. Run: `npx vitest run packages/core/src/models/modelsConfig.test.ts`.
2. The previously failing integration test passes locally against the bundle with fake creds:

```
npm run bundle
QWEN_SANDBOX=false OPENAI_API_KEY=sk-dummy OPENAI_BASE_URL=https://example.invalid/v1 OPENAI_MODEL=my-openai-model \
  npx vitest run --root ./integration-tests cli/acp-integration -t "supports session/set_config_option for mode and model"
```

Expected: pass — `availableModels` now contains the `…(openai)` runtime model that the test looks for.

### Evidence (Before & After)

Non-UI change (core model-listing logic). Observed via a script driving the real ACP protocol (`initialize` → `authenticate openai` → `session/new`) with `OPENAI_*` set:

**Before** — runtime model is the current model but missing from the list:

```
currentModelId: "$runtime|openai|my-openai-model(openai)"
availableModels:  [ "coder-model(qwen-oauth)" ]          # openai runtime model dropped
```

**After** — runtime model is enumerated:

```
availableModels:  [ "coder-model(qwen-oauth)", "$runtime|openai|my-openai-model(openai)" ]
```

The new unit test fails with `expected undefined to be defined` (the exact CI error) before the fix and passes after. Historically, the pre-#5089 E2E run had all 11 `acp-integration` tests green; every run since fails this one assertion.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

Linux: ran the new unit tests, the target integration test (against the bundle, fake `OPENAI_*`), plus `tsc` / `prettier` / `eslint` — all green. macOS / Windows not run locally; the authoritative check is CI.

### Environment (optional)

`npm run bundle` + `vitest run --root ./integration-tests` with fake `OPENAI_*` env and `QWEN_SANDBOX=false`. Core unit tests via `vitest run` at repo root. No real provider auth needed (the assertions exercise model enumeration, not inference).

## Risk & Scope

- Main risk or tradeoff: None expected. The behavior change is limited to the default listing — it adds the active runtime model when it would otherwise be missing. Registry models and ordering (qwen-oauth first) are unchanged, and explicit-filter callers (`getFastModel`, etc.) are unaffected.
- Not validated / out of scope: macOS/Windows not run locally (covered by CI). Inference-driven ACP tests not re-run (need real provider auth).
- Breaking changes / migration notes: None. No production dependency changes.

## Linked Issues

Fixes the deterministic ACP `set_config_option` failure introduced by #5089. Follow-up to the prior attempts #5721 and #5724 (which addressed the symptom, not the cause). Complementary to #5728: that PR hardens the test by injecting an openai `modelProviders` entry (giving openai a registry model, which sidesteps the symptom); this PR fixes the underlying product bug, so the original assertion and real env-only-auth users work without any injection. The two do not conflict.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复一个核心回归:当**当前激活的 runtime 模型**所属的 `authType` 没有 registry 模型时,它会被 `ModelsConfig.getAllConfiguredModels()` 丢弃。现在在默认分支(未显式传 `authTypes` 过滤)里,会把当前激活 runtime 模型的 `authType` 也纳入遍历,使其与 registry 模型一起被枚举。显式传 `authTypes` 的调用方行为不变——仍然只得到所请求的集合(匹配的 runtime 模型本来就由原有循环包含)。

## 为什么需要

#5089 把 `getAllConfiguredModels` 的默认分支从 `Object.values(AuthType)` 改成了 `this.modelRegistry.getAuthTypes()`,而后者只返回**有 registry 模型**的 authType。一个仅由环境变量 / CLI 覆盖解析出来的 runtime 模型(例如只设了 `OPENAI_API_KEY` / `OPENAI_BASE_URL` / `OPENAI_MODEL`、没有 `modelProviders` 配置)的 `authType` 是 `'openai'`,而 openai 没有 registry 模型,于是 `'openai'` 不在遍历集合里,这个 runtime 模型就永远不会被输出。**即使它就是当前激活模型**也一样:`currentModelId` 指向 `$runtime|openai|…(openai)`,而 `availableModels` 里只有 `coder-model(qwen-oauth)`。

用户可见影响:ACP 客户端(Zed / VSCode companion)看不到、也无法重新选中当前激活的 openai 模型;交互式 `/model` 选择器(`modelCommand.ts` 无参调用 `getAllConfiguredModels()`)同样漏掉它;ACP 集成测试 `supports session/set_config_option for mode and model` 自 #5089 起在每次 `main` 跑都会在 `expect(openaiModel).toBeDefined()` 失败。这是**确定性**失败,不是并发 settings 竞争——所以 #5721(改断言形态)和 #5724(隔离 `QWEN_HOME`)都没修好。

## 评审验证

### 如何验证

1. 在 `packages/core/src/models/modelsConfig.test.ts` 新增核心单测回归:捕获一个 runtime openai 模型(无 `modelProviders`),断言它出现在 `getAllConfiguredModels()` 里;另一个用例断言显式 `authTypes` 过滤**不会**注入它。运行:`npx vitest run packages/core/src/models/modelsConfig.test.ts`。
2. 之前失败的集成测试现在用 fake 凭证对着 bundle 本地通过:

```
npm run bundle
QWEN_SANDBOX=false OPENAI_API_KEY=sk-dummy OPENAI_BASE_URL=https://example.invalid/v1 OPENAI_MODEL=my-openai-model \
  npx vitest run --root ./integration-tests cli/acp-integration -t "supports session/set_config_option for mode and model"
```

预期通过——`availableModels` 现在包含测试要找的 `…(openai)` runtime 模型。

### 证据(Before & After)

非 UI 改动(核心模型列表逻辑)。通过一个驱动真实 ACP 协议的脚本观察(`initialize` → `authenticate openai` → `session/new`),并设置了 `OPENAI_*`:

**Before**——runtime 模型是当前模型,却不在列表里:

```
currentModelId: "$runtime|openai|my-openai-model(openai)"
availableModels:  [ "coder-model(qwen-oauth)" ]          # openai runtime 模型被丢弃
```

**After**——runtime 模型被枚举出来:

```
availableModels:  [ "coder-model(qwen-oauth)", "$runtime|openai|my-openai-model(openai)" ]
```

新单测在修复前以 `expected undefined to be defined`(即 CI 的报错)失败,修复后通过。历史上 #5089 之前的 E2E 跑里 11 个 `acp-integration` 用例全绿;自 #5089 起每次都挂在这一条断言上。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

<!-- ✅ 已测 · ⚠️ 未测 · N/A -->

Linux:跑了新单测、目标集成测试(对着 bundle、fake `OPENAI_*`),以及 `tsc` / `prettier` / `eslint`,全部通过。macOS / Windows 未本地运行;以 CI 为权威校验。

### 运行环境(可选)

`npm run bundle` + `vitest run --root ./integration-tests`,fake `OPENAI_*` 环境变量、`QWEN_SANDBOX=false`。核心单测在仓库根用 `vitest run` 跑。无需真实 provider 鉴权(断言验证的是模型枚举,不是推理)。

## 风险与范围

- 主要风险 / 取舍:预计无。行为变化仅限于默认列表——在本应缺失时补上当前激活的 runtime 模型。registry 模型和排序(qwen-oauth 在前)均不变,显式过滤的调用方(`getFastModel` 等)不受影响。
- 未验证 / 范围外:macOS/Windows 未本地运行(由 CI 覆盖);依赖推理的 ACP 用例未重跑(需真实 provider 鉴权)。
- 破坏性变更 / 迁移说明:无。不涉及生产依赖变更。

## 关联 Issue

修复 #5089 引入的、确定性的 ACP `set_config_option` 失败。是此前两次尝试 #5721、#5724 的后续(那两次处理的是症状,不是根因)。与 #5728 互补:#5728 通过注入一个 openai `modelProviders` 条目来加固测试(给 openai 造了个 registry 模型,从而绕开症状);本 PR 修的是底层产品 bug,因此原断言以及真实的纯 env 认证用户无需任何注入即可正常工作。两者不冲突。

</details>
