### PR TITLE
feat(desktop): show file preview in a resizable side panel instead of fullscreen

### DIFF
--- a/packages/desktop/apps/electron/src/renderer/App.tsx
+++ b/packages/desktop/apps/electron/src/renderer/App.tsx
@@ -12,6 +12,7 @@ import { generateMessageId } from '../shared/types'
 import { useEventProcessor } from './event-processor'
 import type { AgentEvent, Effect } from './event-processor'
 import { AppShell } from '@/components/app-shell/AppShell'
+import { FilePreviewPanel } from '@/components/app-shell/FilePreviewPanel'
 import type { AppShellContextType } from '@/context/AppShellContext'
 import { OnboardingWizard, ReauthScreen } from '@/components/onboarding'
 import { WorkspacePicker } from '@/components/workspace'
@@ -2512,21 +2513,40 @@ export default function App() {
                 onRetry={handleReconnectTransport}
               />
             )}
-            <div className="flex-1 min-h-0">
-              {sessionLoadError ? (
-                <SessionLoadErrorScreen
-                  message={sessionLoadError}
-                  onRetry={() => { void loadSessionsFromServer() }}
-                />
-              ) : (
-                <AppShell
-                  contextValue={appShellContextValue}
-                  defaultLayout={[20, 32, 48]}
-                  menuNewChatTrigger={menuNewChatTrigger}
-                  isFocusedMode={isFocusedMode}
-                  isSessionListLoading={isActiveSessionListLoading}
-                  onProjectSessionSnapshotsReadyChange={setProjectSessionSnapshotsReady}
-                />
+            {/* Main content + docked file preview live side-by-side so opening a file keeps
+                the conversation and file tree visible (VS Code / Cursor style split layout). */}
+            <div className="flex-1 min-h-0 flex flex-row">
+              <div className="flex-1 min-w-0 h-full">
+                {sessionLoadError ? (
+                  <SessionLoadErrorScreen
+                    message={sessionLoadError}
+                    onRetry={() => { void loadSessionsFromServer() }}
+                  />
+                ) : (
+                  <AppShell
+                    contextValue={appShellContextValue}
+                    defaultLayout={[20, 32, 48]}
+                    menuNewChatTrigger={menuNewChatTrigger}
+                    isFocusedMode={isFocusedMode}
+                    isSessionListLoading={isActiveSessionListLoading}
+                    onProjectSessionSnapshotsReadyChange={setProjectSessionSnapshotsReady}
+                  />
+                )}
+              </div>
+
+              {/* File preview side panel — opened by the link interceptor when a previewable
+                  file is clicked. Rendered as a resizable docked panel rather than fullscreen. */}
+              {linkInterceptor.previewState && (
+                <FilePreviewPanel>
+                  <FilePreviewRenderer
+                    state={linkInterceptor.previewState}
+                    onClose={linkInterceptor.closePreview}
+                    loadDataUrl={linkInterceptor.readFileDataUrl}
+                    loadPdfData={linkInterceptor.readFileBinary}
+                    isDark={isDark}
+                    embedded
+                  />
+                </FilePreviewPanel>
               )}
             </div>
             <ResetConfirmationDialog
@@ -2535,17 +2555,6 @@ export default function App() {
               onCancel={() => setShowResetDialog(false)}
             />
           </div>
-
-          {/* File preview overlay — rendered by the link interceptor when a previewable file is clicked */}
-          {linkInterceptor.previewState && (
-            <FilePreviewRenderer
-              state={linkInterceptor.previewState}
-              onClose={linkInterceptor.closePreview}
-              loadDataUrl={linkInterceptor.readFileDataUrl}
-              loadPdfData={linkInterceptor.readFileBinary}
-              isDark={isDark}
-            />
-          )}
         </NavigationProvider>
         </TooltipProvider>
         </ModalProvider>
@@ -2585,12 +2594,15 @@ function FilePreviewRenderer({
   loadDataUrl,
   loadPdfData,
   isDark,
+  embedded = false,
 }: {
   state: FilePreviewState
   onClose: () => void
   loadDataUrl: (path: string) => Promise<string>
   loadPdfData: (path: string) => Promise<Uint8Array>
   isDark: boolean
+  /** Render inside the docked side panel instead of a fullscreen overlay */
+  embedded?: boolean
 }) {
   const theme = isDark ? 'dark' : 'light' as const
 
@@ -2603,6 +2615,7 @@ function FilePreviewRenderer({
           filePath={state.filePath}
           loadDataUrl={loadDataUrl}
           theme={theme}
+          embedded={embedded}
         />
       )
 
@@ -2614,6 +2627,7 @@ function FilePreviewRenderer({
           filePath={state.filePath}
           loadPdfData={loadPdfData}
           theme={theme}
+          embedded={embedded}
         />
       )
 
@@ -2629,6 +2643,7 @@ function FilePreviewRenderer({
           mode="read"
           theme={theme}
           error={state.error}
+          embedded={embedded}
         />
       )
 
@@ -2644,6 +2659,7 @@ function FilePreviewRenderer({
           content={state.content ?? ''}
           filePath={state.filePath}
           variant={isPlanFile ? 'plan' : 'response'}
+          embedded={embedded}
         />
       )
     }
@@ -2666,6 +2682,7 @@ function FilePreviewRenderer({
             mode="read"
             theme={theme}
             error={state.error}
+            embedded={embedded}
           />
         )
       }
@@ -2681,6 +2698,7 @@ function FilePreviewRenderer({
             mode="read"
             theme={theme}
             error={state.error}
+            embedded={embedded}
           />
         )
       }
@@ -2693,6 +2711,7 @@ function FilePreviewRenderer({
           data={parsedData}
           theme={theme}
           error={state.error}
+          embedded={embedded}
         />
       )
     }

--- a/packages/desktop/apps/electron/src/renderer/components/app-shell/FilePreviewPanel.tsx
+++ b/packages/desktop/apps/electron/src/renderer/components/app-shell/FilePreviewPanel.tsx
@@ -1,0 +1,91 @@
+/**
+ * FilePreviewPanel - Resizable, docked side panel that hosts the in-app file preview.
+ *
+ * Replaces the previous fullscreen file overlay: instead of taking over the whole window,
+ * a clicked file opens in this panel on the right while the conversation / file tree stays
+ * visible and interactive next to it (VS Code / Cursor style split layout).
+ *
+ * The panel width is user-adjustable via a drag handle on its left edge and is persisted
+ * to localStorage so it survives reloads. The preview content itself (rendered as children)
+ * uses each overlay's `embedded` mode to fill this panel.
+ */
+
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+import * as storage from '@/lib/local-storage'
+
+const MIN_WIDTH = 320
+const MAX_WIDTH = 900
+const DEFAULT_WIDTH = 460
+
+function clampWidth(width: number): number {
+  return Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, Math.round(width)))
+}
+
+export function FilePreviewPanel({ children }: { children: React.ReactNode }) {
+  const [width, setWidth] = React.useState(() =>
+    clampWidth(storage.get(storage.KEYS.filePreviewWidth, DEFAULT_WIDTH)),
+  )
+  const [isResizing, setIsResizing] = React.useState(false)
+
+  // Persist width changes (debounced via the natural render cadence is fine here).
+  React.useEffect(() => {
+    storage.set(storage.KEYS.filePreviewWidth, width)
+  }, [width])
+
+  const handleResizeStart = React.useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault()
+      const startX = event.clientX
+      const startWidth = width
+      setIsResizing(true)
+
+      const handleMove = (moveEvent: MouseEvent) => {
+        // The handle sits on the LEFT edge of the panel, so dragging left widens it.
+        const delta = startX - moveEvent.clientX
+        setWidth(clampWidth(startWidth + delta))
+      }
+
+      const handleUp = () => {
+        setIsResizing(false)
+        document.removeEventListener('mousemove', handleMove)
+        document.removeEventListener('mouseup', handleUp)
+        document.body.style.cursor = ''
+        document.body.style.userSelect = ''
+      }
+
+      document.addEventListener('mousemove', handleMove)
+      document.addEventListener('mouseup', handleUp)
+      document.body.style.cursor = 'col-resize'
+      document.body.style.userSelect = 'none'
+    },
+    [width],
+  )
+
+  return (
+    <div
+      className="relative h-full shrink-0 flex flex-col"
+      style={{ width }}
+      data-testid="file-preview-panel"
+    >
+      {/* Drag handle on the left edge — a thin line that thickens/tints on hover or while dragging. */}
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize file preview"
+        onMouseDown={handleResizeStart}
+        className="group absolute left-0 top-0 bottom-0 z-20 w-2 -translate-x-1/2 cursor-col-resize"
+      >
+        <div
+          className={cn(
+            'mx-auto h-full w-px transition-colors',
+            isResizing ? 'bg-accent' : 'bg-border group-hover:bg-accent/70',
+          )}
+        />
+      </div>
+
+      {/* Preview content fills the panel. min-h-0 lets inner scroll containers work. */}
+      <div className="flex-1 min-h-0 h-full pl-px">{children}</div>
+    </div>
+  )
+}

--- a/packages/desktop/apps/electron/src/renderer/lib/local-storage.ts
+++ b/packages/desktop/apps/electron/src/renderer/lib/local-storage.ts
@@ -29,6 +29,9 @@ export const KEYS = {
   // Session files panel state
   sessionFilesExpandedFolders: 'session-files-expanded', // Expanded folders in session files tree (keyed by sessionId)
 
+  // File preview side panel
+  filePreviewWidth: 'file-preview-width', // Width (px) of the docked file preview side panel
+
   // Theme
   theme: 'theme',
 

--- a/packages/desktop/packages/ui/src/components/markdown/__tests__/linkify.test.ts
+++ b/packages/desktop/packages/ui/src/components/markdown/__tests__/linkify.test.ts
@@ -62,6 +62,26 @@ describe('preprocessLinks', () => {
       expect(preprocessLinks(input)).toBe('Check out [example.com](http://example.com) for details')
     })
 
+    // Regression: bare filenames whose extension is also a TLD (.md=Moldova, .py=Paraguay,
+    // .sh=St. Helena) must be treated as file paths, not web domains. Otherwise clicking
+    // `readme.md` opens http://readme.md (a parked/ad domain) instead of the file preview.
+    it('treats a bare filename with a ccTLD extension as a file path, not a URL', () => {
+      expect(preprocessLinks('Open readme.md to start')).toBe('Open [readme.md](readme.md) to start')
+      expect(preprocessLinks('Run main.py now')).toBe('Run [main.py](main.py) now')
+
+      const link = detectLinks('readme.md')[0]
+      expect(link?.type).toBe('file')
+    })
+
+    // Regression: paths with non-ASCII (e.g. CJK) segments must still be detected.
+    // `\w`-based regexes only match ASCII, so a path like /Users/x/项目/笔记.md would
+    // not be linkified and could not be opened in the preview.
+    it('wraps absolute file paths containing non-ASCII (CJK) characters', () => {
+      const input = '查看 /Users/dragonzhang/项目/笔记.md 文件'
+      expect(preprocessLinks(input)).toBe('查看 [/Users/dragonzhang/项目/笔记.md](/Users/dragonzhang/项目/笔记.md) 文件')
+      expect(isFilePathTarget('/Users/dragonzhang/sessions/260623-测试预览/main.py')).toBe(true)
+    })
+
     it('wraps bare URL but preserves adjacent markdown link', () => {
       const input = 'See https://bare.example.com and [linked.example.com - Title](https://linked.example.com/page)'
       const result = preprocessLinks(input)

--- a/packages/desktop/packages/ui/src/components/markdown/linkify.ts
+++ b/packages/desktop/packages/ui/src/components/markdown/linkify.ts
@@ -11,18 +11,25 @@ import { FILE_EXTENSIONS_PATTERN } from '../../lib/file-classification'
 // Initialize linkify-it with default settings (fuzzy URLs, emails enabled)
 const linkify = new LinkifyIt()
 
+// Path character classes — Unicode-aware (note the `u` flag below) so paths containing
+// non-ASCII characters are detected. `\w` / [A-Za-z0-9_] only match ASCII, which would drop
+// any path with CJK or accented segments (e.g. /Users/me/项目/笔记.md, ~/Dokumente/Übung.md),
+// leaving the path un-linkified and therefore not clickable for preview.
+const PATH_START_CHAR = '[\\p{L}\\p{N}_]'
+const PATH_CHAR = '[\\p{L}\\p{N}_\\-./@]'
+
 // File path regex - detects absolute/home/explicit-relative/bare-relative paths with common extensions
-// Examples: /Users/foo.ts, ~/src/app.tsx, ./README.md, ../guide.md, apps/electron/src/main.ts
+// Examples: /Users/foo.ts, ~/src/app.tsx, ./README.md, ../guide.md, apps/electron/src/main.ts, /项目/笔记.md
 // Extensions derived from file-classification.ts to stay in sync with preview support
-const FILE_PATH_REGEX_SOURCE = `(?:^|[\\s([\\{<])((?:/|~/|\\./|\\.\\./|[A-Za-z0-9_][\\w\\-./@]*)[\\w\\-./@]*\\.(?:${FILE_EXTENSIONS_PATTERN}))(?=[\\s)\\]}\\.,:;!?>]|$)`
-const FILE_PATH_REGEX = new RegExp(FILE_PATH_REGEX_SOURCE, 'gi')
-const FILE_PATH_PRETEST_REGEX = new RegExp(FILE_PATH_REGEX_SOURCE, 'i')
+const FILE_PATH_REGEX_SOURCE = `(?:^|[\\s([\\{<])((?:/|~/|\\./|\\.\\./|${PATH_START_CHAR}${PATH_CHAR}*)${PATH_CHAR}*\\.(?:${FILE_EXTENSIONS_PATTERN}))(?=[\\s)\\]}\\.,:;!?>]|$)`
+const FILE_PATH_REGEX = new RegExp(FILE_PATH_REGEX_SOURCE, 'giu')
+const FILE_PATH_PRETEST_REGEX = new RegExp(FILE_PATH_REGEX_SOURCE, 'iu')
 
 // File-path regex for markdown anchor targets (entire href/text value)
 // Used by Markdown.tsx click handler to route file links to onFileClick.
 const FILE_PATH_TARGET_REGEX = new RegExp(
-  `^(?!https?://|mailto:|ftp://|data:)(?:/|~/|\./|\.\./|[A-Za-z0-9_][\\w\\-./@]*)[\\w\\-./@]*\\.(?:${FILE_EXTENSIONS_PATTERN})$`,
-  'i'
+  `^(?!https?://|mailto:|ftp://|data:)(?:/|~/|\\./|\\.\\./|${PATH_START_CHAR}${PATH_CHAR}*)${PATH_CHAR}*\\.(?:${FILE_EXTENSIONS_PATTERN})$`,
+  'iu'
 )
 
 interface DetectedLink {
@@ -130,6 +137,18 @@ export function detectLinks(text: string): DetectedLink[] {
   // Note: _ and ~ are valid URL chars so we only strip *
   const trailingMarkdownRe = /\*+$/
   for (const match of urlMatches) {
+    // Fuzzy (scheme-less) matches whose text is actually a local filename/path collide
+    // with TLDs that double as file extensions: .md (Moldova), .py (Paraguay),
+    // .sh (St. Helena), plus new gTLDs like .zip/.mov/.app. In a coding assistant these
+    // strings are overwhelmingly file paths, not web domains — so skip the URL match and
+    // let the file-path detector below claim them. Otherwise clicking a bare `readme.md`
+    // launches the browser to http://readme.md (a real, ad-serving parked domain) instead
+    // of opening the in-app file preview. Explicit `http(s)://readme.md` keeps its scheme
+    // and is left as a URL.
+    if (!match.schema && isFilePathTarget(match.text)) {
+      continue
+    }
+
     let matchText = match.text
     let matchUrl = match.url
     let matchEnd = match.lastIndex

--- a/packages/desktop/packages/ui/src/components/overlay/CodePreviewOverlay.tsx
+++ b/packages/desktop/packages/ui/src/components/overlay/CodePreviewOverlay.tsx
@@ -95,7 +95,9 @@ export function CodePreviewOverlay({
         </div>
       )}
 
-      <ContentFrame title={t('overlay.code')} fitContent minWidth={850}>
+      {/* Docked mode: let the card fill the (narrow) panel width instead of flooring at 850px,
+          which would force constant horizontal scrolling in a side panel. */}
+      <ContentFrame title={t('overlay.code')} fitContent={!embedded} minWidth={embedded ? undefined : 850}>
         <div>
           <ShikiCodeViewer
             code={content}

--- a/packages/desktop/packages/ui/src/components/overlay/DocumentFormattedMarkdownOverlay.tsx
+++ b/packages/desktop/packages/ui/src/components/overlay/DocumentFormattedMarkdownOverlay.tsx
@@ -56,6 +56,8 @@ export interface DocumentFormattedMarkdownOverlayProps {
   isStreaming?: boolean
   /** Optional external request to open a specific annotation */
   openAnnotationRequest?: ExternalOpenAnnotationRequest | null
+  /** Render inline inside a docked side panel instead of taking over the viewport */
+  embedded?: boolean
 }
 
 export function DocumentFormattedMarkdownOverlay({
@@ -77,6 +79,7 @@ export function DocumentFormattedMarkdownOverlay({
   sendMessageKey = 'enter',
   isStreaming = false,
   openAnnotationRequest,
+  embedded = false,
 }: DocumentFormattedMarkdownOverlayProps) {
   return (
     <FullscreenOverlayBase
@@ -86,10 +89,12 @@ export function DocumentFormattedMarkdownOverlay({
       typeBadge={typeBadge}
       copyContent={content}
       error={error ? { label: 'Write Failed', message: error } : undefined}
+      embedded={embedded}
     >
       {/* Content wrapper — min-h-full for vertical centering within FullscreenOverlayBase's scroll container.
-          Scrolling and gradient fade mask are handled by FullscreenOverlayBase. */}
-      <div className="min-h-full flex flex-col justify-center px-6 py-16">
+          Scrolling and gradient fade mask are handled by FullscreenOverlayBase. Docked mode uses tighter
+          padding so the document reads well in a narrow side panel. */}
+      <div className={embedded ? 'min-h-full flex flex-col justify-center px-3 py-6' : 'min-h-full flex flex-col justify-center px-6 py-16'}>
         {/* Content card - my-auto centers vertically when content is small, flows naturally when large */}
         <div className="bg-background rounded-[16px] shadow-strong w-full max-w-[960px] h-fit mx-auto my-auto">
           {/* Plan header (variant="plan" only) */}
@@ -101,7 +106,7 @@ export function DocumentFormattedMarkdownOverlay({
           )}
 
           {/* Content area */}
-          <div className="px-10 pt-8 pb-8">
+          <div className={embedded ? 'px-5 pt-6 pb-6' : 'px-10 pt-8 pb-8'}>
             <div className="text-sm">
               {messageId && onAddAnnotation ? (
                 <AnnotatableMarkdownDocument

--- a/packages/desktop/packages/ui/src/components/overlay/FullscreenOverlayBase.tsx
+++ b/packages/desktop/packages/ui/src/components/overlay/FullscreenOverlayBase.tsx
@@ -83,6 +83,17 @@ export interface FullscreenOverlayBaseProps {
 
   /** Optional error banner — rendered between header and children */
   error?: OverlayErrorBannerProps
+
+  /**
+   * Docked / embedded mode — render inline filling the parent container instead of
+   * taking over the viewport via a modal Dialog portal. Used to show the preview in a
+   * resizable side panel while the main UI stays visible and interactive.
+   *
+   * In this mode the component does NOT register a dismissible layer, does NOT hide the
+   * macOS traffic lights, and does NOT trap focus. Closing is driven entirely by the
+   * header close button (onClose).
+   */
+  embedded?: boolean
 }
 
 export function handleFullscreenEscapeWithStack(): boolean {
@@ -105,6 +116,7 @@ export function FullscreenOverlayBase({
   headerActions,
   copyContent,
   error,
+  embedded = false,
 }: FullscreenOverlayBaseProps) {
   const { onSetTrafficLightsVisible } = usePlatform()
 
@@ -114,7 +126,8 @@ export function FullscreenOverlayBase({
   const overlayIdRef = useRef(`fullscreen-overlay-${Math.random().toString(36).slice(2)}`)
 
   useEffect(() => {
-    if (!isOpen) return
+    // Docked mode is a persistent side panel, not a dismissible modal layer.
+    if (!isOpen || embedded) return
 
     const bridge = getDismissibleLayerBridge()
     if (!bridge) return
@@ -125,20 +138,83 @@ export function FullscreenOverlayBase({
       priority: 100,
       close: onClose,
     })
-  }, [isOpen, onClose])
+  }, [isOpen, onClose, embedded])
 
   // Hide macOS traffic lights when overlay opens, restore when it closes
-  // This prevents accidental clicks on window controls behind the fullscreen overlay
+  // This prevents accidental clicks on window controls behind the fullscreen overlay.
+  // Docked mode leaves the window chrome alone since it never covers it.
   useEffect(() => {
-    if (!isOpen) return
+    if (!isOpen || embedded) return
 
     onSetTrafficLightsVisible?.(false)
     return () => onSetTrafficLightsVisible?.(true)
-  }, [isOpen, onSetTrafficLightsVisible])
+  }, [isOpen, onSetTrafficLightsVisible, embedded])
 
   // Content padding clears the floating header at rest (when present).
   // Without a header, just the fade zone inset.
   const contentPaddingTop = hasHeader ? HEADER_HEIGHT + FADE_SIZE : FADE_SIZE
+
+  // Shared inner layout (masked scroll area + floating header) — identical structure for
+  // both fullscreen (inside Dialog.Content) and docked (inline) modes.
+  const overlayBody = (
+    <>
+      {/* Full-area masked scroll container — covers the entire surface including behind the header.
+          The CSS mask gradient fades content at both edges (starting from y=0).
+          Content padding clears the header at rest. */}
+      <div
+        className="absolute inset-0"
+        style={{ maskImage: FADE_MASK, WebkitMaskImage: FADE_MASK }}
+      >
+        <div
+          className="h-full overflow-y-auto"
+          style={{ paddingTop: contentPaddingTop, paddingBottom: FADE_SIZE, scrollPaddingTop: contentPaddingTop }}
+        >
+          {/* Centering wrapper — error + content move together as a unit. */}
+          <div className="min-h-full flex flex-col justify-center">
+            {error && (
+              <div className="px-6 pb-4">
+                <OverlayErrorBanner label={error.label} message={error.message} />
+              </div>
+            )}
+            {children}
+          </div>
+        </div>
+      </div>
+
+      {/* Floating header — rendered after the scroll area so it's visually on top (DOM order). */}
+      {hasHeader && (
+        <div className="absolute top-0 left-0 right-0 z-10">
+          <FullscreenOverlayBaseHeader
+            onClose={onClose}
+            typeBadge={typeBadge}
+            filePath={filePath}
+            title={title}
+            onTitleClick={onTitleClick}
+            subtitle={subtitle}
+            headerActions={headerActions}
+            copyContent={copyContent}
+          />
+        </div>
+      )}
+    </>
+  )
+
+  // Docked / embedded mode — render inline filling the parent container (e.g. a resizable
+  // side panel) without a modal portal, so the rest of the app stays visible and usable.
+  if (embedded) {
+    if (!isOpen) return null
+    return (
+      <div
+        className={cn(
+          'relative h-full w-full overflow-hidden outline-none',
+          'bg-foreground-3 fullscreen-overlay-background',
+          className
+        )}
+      >
+        {overlayBody}
+      </div>
+    )
+  }
 
   return (
     <Dialog.Root open={isOpen} onOpenChange={(open) => !open && onClose()}>
@@ -162,47 +238,7 @@ export function FullscreenOverlayBase({
           {/* Visually hidden title for accessibility - required by Radix Dialog */}
           <Dialog.Title className="sr-only">{accessibleTitle}</Dialog.Title>
 
-          {/* Full-viewport masked scroll area — covers the entire dialog including behind the header.
-              The CSS mask gradient fades content at both edges (starting from y=0).
-              Content padding clears the header at rest. */}
-          <div
-            className="absolute inset-0"
-            style={{ maskImage: FADE_MASK, WebkitMaskImage: FADE_MASK }}
-          >
-            <div
-              className="h-full overflow-y-auto"
-              style={{ paddingTop: contentPaddingTop, paddingBottom: FADE_SIZE, scrollPaddingTop: contentPaddingTop }}
-            >
-              {/* Centering wrapper — error + content move together as a unit.
-                  min-h-full ensures centering when content is small; content can grow beyond. */}
-              <div className="min-h-full flex flex-col justify-center">
-                {/* Error banner — inside centering flow, above content */}
-                {error && (
-                  <div className="px-6 pb-4">
-                    <OverlayErrorBanner label={error.label} message={error.message} />
-                  </div>
-                )}
-                {children}
-              </div>
-            </div>
-          </div>
-
-          {/* Floating header — rendered after scroll area so it's visually on top (DOM order).
-              Positioned absolutely at the top of the viewport, above the scroll content. */}
-          {hasHeader && (
-            <div className="absolute top-0 left-0 right-0 z-10">
-              <FullscreenOverlayBaseHeader
-                onClose={onClose}
-                typeBadge={typeBadge}
-                filePath={filePath}
-                title={title}
-                onTitleClick={onTitleClick}
-                subtitle={subtitle}
-                headerActions={headerActions}
-                copyContent={copyContent}
-              />
-            </div>
-          )}
+          {overlayBody}
         </Dialog.Content>
       </Dialog.Portal>
     </Dialog.Root>

--- a/packages/desktop/packages/ui/src/components/overlay/ImagePreviewOverlay.tsx
+++ b/packages/desktop/packages/ui/src/components/overlay/ImagePreviewOverlay.tsx
@@ -27,6 +27,8 @@ export interface ImagePreviewOverlayProps {
   title?: string
   loadDataUrl: (path: string) => Promise<string>
   theme?: 'light' | 'dark'
+  /** Render inline inside a docked side panel instead of taking over the viewport */
+  embedded?: boolean
 }
 
 export function ImagePreviewOverlay({
@@ -38,6 +40,7 @@ export function ImagePreviewOverlay({
   title,
   loadDataUrl,
   theme = 'light',
+  embedded,
 }: ImagePreviewOverlayProps) {
   const { t } = useTranslation()
   const resolvedItems = useMemo<PreviewItem[]>(() => {
@@ -162,6 +165,7 @@ export function ImagePreviewOverlay({
       title={title}
       error={error ? { label: 'Load Failed', message: error } : undefined}
       headerActions={headerActions}
+      embedded={embedded}
     >
       <div
         ref={containerRef}

--- a/packages/desktop/packages/ui/src/components/overlay/PDFPreviewOverlay.tsx
+++ b/packages/desktop/packages/ui/src/components/overlay/PDFPreviewOverlay.tsx
@@ -39,6 +39,8 @@ export interface PDFPreviewOverlayProps {
   /** Async loader that returns PDF data as Uint8Array */
   loadPdfData: (path: string) => Promise<Uint8Array>
   theme?: 'light' | 'dark'
+  /** Render inline inside a docked side panel instead of taking over the viewport */
+  embedded?: boolean
 }
 
 export function PDFPreviewOverlay({
@@ -49,6 +51,7 @@ export function PDFPreviewOverlay({
   initialIndex = 0,
   loadPdfData,
   theme = 'light',
+  embedded,
 }: PDFPreviewOverlayProps) {
   const { t } = useTranslation()
 
@@ -135,6 +138,7 @@ export function PDFPreviewOverlay({
       filePath={activeItem?.src || filePath}
       error={error ? { label: 'Load Failed', message: error } : undefined}
       headerActions={headerActions}
+      embedded={embedded}
     >
       <div className="h-full flex flex-col items-center overflow-auto">
         {isLoading && (


### PR DESCRIPTION
## What this PR does

In the desktop app, clicking a previewable file used to open it in a fullscreen overlay that took over the entire window. This PR makes file previews open in a docked, resizable panel on the right while the conversation and file tree stay visible and interactive beside it — a VS Code / Cursor style split layout. The panel can be resized by dragging its left edge (width is remembered across reloads) and closed with the header's close button. All existing preview types (code, text, markdown, JSON, image, PDF) render inside the panel via a new "embedded" render mode on the shared overlay components, so the fullscreen path is preserved unchanged for any other caller.

It also fixes two markdown link-detection issues that prevented file paths from opening in the preview at all, which surfaced while verifying the feature: bare filenames whose extension doubles as a TLD (`readme.md` → `.md` Moldova, `main.py` → `.py` Paraguay, `config.sh` → `.sh` St. Helena) were auto-linked as web URLs and opened a parked/ad domain in the browser; and absolute paths containing non-ASCII (e.g. CJK) segments like `/Users/me/项目/笔记.md` were never linkified because the path regex used ASCII-only `\w` classes, so they could not be clicked.

<img width="2684" height="1800" alt="image" src="https://github.com/user-attachments/assets/df61f2de-89bd-4e04-aa20-3b8f841b0a7b" />

## Why it's needed

The fullscreen file view is disruptive: it hides the conversation and file tree, feels out of place in a modern desktop app, and adds friction when reviewing multiple files. A collapsible, resizable side panel keeps context visible and matches what users expect from IDE-like tools (issue #4885). The link-detection fixes are required for the feature to actually be usable — clicking a file must reliably open the in-app preview rather than launching a browser or doing nothing.

## Reviewer Test Plan

### How to verify

1. Run the desktop app in dev mode and open a session.
2. Click a previewable file (a Read/Write tool result, a file badge, or a file path in a message). Expect: it opens in a resizable panel docked on the right; the conversation/file tree on the left stays visible and clickable (not a fullscreen takeover).
3. Drag the panel's left edge to resize; reload the app and confirm the width is preserved. Click the header X to close.
4. Exercise each type: code/text, markdown, JSON, image, PDF.
5. Link routing: a bare `readme.md` (or `main.py`) in a message now opens the in-app preview instead of a browser ad page; an absolute path containing Chinese characters (e.g. `/Users/.../sessions/260623-测试预览/readme.md`) renders as a clickable link and opens the preview.
6. Unit tests:

```
cd packages/desktop/packages/ui
bun test src/components/markdown/__tests__/linkify.test.ts        # 44 pass
bun test src/components/markdown/__tests__/markdown-link-routing.test.ts  # 13 pass
```

### Evidence (Before & After)

- Before: clicking a file opened a fullscreen overlay covering the whole window; a bare `readme.md` opened `http://readme.md` (an ad-serving parked domain) in the browser; paths with CJK characters were plain text and could not be opened.
- After: the file opens in a docked, resizable right-hand panel with the rest of the UI still visible; `readme.md` and CJK paths route to the in-app preview.

(Screenshots / recording to be attached — behavior verified locally via the dev app and unit tests.)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`bun run dev` (Electron) on macOS for the UI; `bun test` for the unit tests.

## Risk & Scope

- Main risk or tradeoff: the overlay base components are shared with the web UI; the docked mode is additive and opt-in (the `embedded` prop defaults to off), so the fullscreen behavior is unchanged for existing callers. The main change in `App.tsx` wraps `AppShell` and the preview in a horizontal split.
- Not validated / out of scope: Windows/Linux runtime; visual fine-tuning of code/markdown at very narrow panel widths; ESC no longer closes the (now non-modal) preview by design — closing is via the header button.
- Breaking changes / migration notes: none. New props are optional and the fullscreen render path is preserved.

## Linked Issues

Closes #4885

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

桌面端点击可预览文件时,以前会用一个占满整个窗口的全屏浮层打开。本 PR 改为在右侧的可调节停靠面板中打开文件预览,左侧的对话和文件树保持可见、可交互——类似 VS Code / Cursor 的分栏布局。面板可通过拖拽左缘调节宽度(宽度刷新后保留),并可通过头部关闭按钮关闭。所有现有预览类型(代码、文本、markdown、JSON、图片、PDF)都通过共享 overlay 组件上新增的 "embedded(停靠)" 渲染模式在面板内渲染,因此对其他调用方而言原有的全屏行为保持不变。

同时修复了两个导致文件路径根本无法打开预览的 markdown 链接识别问题(在验收功能时发现):后缀恰好是顶级域名的裸文件名(`readme.md` → `.md` 摩尔多瓦、`main.py` → `.py` 巴拉圭、`config.sh` → `.sh` 圣赫勒拿)被识别成网址,点击会在浏览器打开停放广告的域名;以及含非 ASCII(如中文)字符的绝对路径(如 `/Users/me/项目/笔记.md`)因路径正则只用了 ASCII 的 `\w` 字符类而完全无法识别成链接、无法点击。

## 为什么需要

全屏文件视图会打断工作流:遮挡对话和文件树,在现代桌面应用里显得格格不入,查看多个文件时切换摩擦大。可折叠、可调节的侧边面板能保留上下文,符合用户对 IDE 类工具的预期(issue #4885)。链接识别修复是该功能可用的前提——点击文件必须可靠地打开应用内预览,而不是打开浏览器或无反应。

## 验收方式

1. 以 dev 模式运行桌面应用并打开一个会话。
2. 点击一个可预览文件(Read/Write 工具结果、文件徽章,或消息中的文件路径)。预期:在右侧停靠的可调节面板中打开;左侧对话/文件树保持可见可点击(不再全屏覆盖)。
3. 拖拽面板左缘调宽;重启应用确认宽度保留;点击头部 X 关闭。
4. 分别验证:代码/文本、markdown、JSON、图片、PDF。
5. 链接路由:消息中裸写的 `readme.md`(或 `main.py`)现在打开应用内预览,而不是浏览器广告页;含中文字符的绝对路径(如 `/Users/.../sessions/260623-测试预览/readme.md`)渲染为可点击链接并打开预览。
6. 单元测试:`bun test src/components/markdown/__tests__/linkify.test.ts`(44 通过)、`markdown-link-routing.test.ts`(13 通过)。

## 风险与范围

- 主要风险:overlay 基础组件与 web UI 共享;停靠模式是附加且可选的(`embedded` 默认关闭),对现有调用方的全屏行为无影响。`App.tsx` 的主要改动是把 `AppShell` 和预览面板包进水平分栏。
- 未验证/范围外:Windows/Linux 运行时;极窄宽度下代码/markdown 的视觉微调;停靠面板为非模态,按设计 ESC 不再关闭它,改由头部按钮关闭。
- 破坏性变更:无。新增属性均为可选,全屏渲染路径保持不变。

## 关联 Issue

Closes #4885

</details>
