### PR TITLE
fix(config): fall back to user env files

### DIFF
--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -62,9 +62,11 @@ import {
   SETTINGS_DIRECTORY_NAME, // This is from the original module, but used by the mock.
   type Settings,
   loadEnvironment,
+  reloadEnvironment,
   SETTINGS_VERSION,
   SETTINGS_VERSION_KEY,
   resetHomeEnvBootstrapForTesting,
+  resetEnvironmentTrackingForTesting,
   ENV_CORRUPTED_PATH,
   ENV_WAS_RECOVERED,
 } from './settings.js';
@@ -195,6 +197,7 @@ describe('Settings Loading and Merging', () => {
       source: 'file',
     });
     resetHomeEnvBootstrapForTesting();
+    resetEnvironmentTrackingForTesting();
     // Ensure the mock delegates to the real implementation by default
     // (set up in vi.mock factory above).
   });
@@ -3612,6 +3615,200 @@ describe('Settings Loading and Merging', () => {
       cwdSpy.mockRestore();
     });
 
+    it('uses user .qwen/.env as fallback when the project .env lacks an API key', () => {
+      delete process.env['OPENCODE_GO_API_KEY'];
+      delete process.env['PROJECT_ONLY_VAR'];
+      const cwdSpy = vi
+        .spyOn(process, 'cwd')
+        .mockReturnValue(MOCK_WORKSPACE_DIR);
+      const projectEnvPath = path.join(MOCK_WORKSPACE_DIR, '.env');
+      const userQwenEnvPath = path.join('/mock/home/user', QWEN_DIR, '.env');
+
+      vi.mocked(isWorkspaceTrusted).mockReturnValue({
+        isTrusted: true,
+        source: 'file',
+      });
+      (mockFsExistsSync as Mock).mockImplementation((p: fs.PathLike) =>
+        [projectEnvPath, userQwenEnvPath].includes(p.toString()),
+      );
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === projectEnvPath) return 'PROJECT_ONLY_VAR=from_project';
+          if (p === userQwenEnvPath)
+            return 'OPENCODE_GO_API_KEY=from_user_qwen_env';
+          return '{}';
+        },
+      );
+
+      const loaded = loadSettings(MOCK_WORKSPACE_DIR, {
+        skipLoadEnvironment: true,
+      });
+      loadEnvironment(loaded.merged);
+
+      expect(process.env['PROJECT_ONLY_VAR']).toEqual('from_project');
+      expect(process.env['OPENCODE_GO_API_KEY']).toEqual('from_user_qwen_env');
+
+      cwdSpy.mockRestore();
+    });
+
+    it('lets the project .env win over user .qwen/.env when both define the API key', () => {
+      delete process.env['OPENCODE_GO_API_KEY'];
+      const cwdSpy = vi
+        .spyOn(process, 'cwd')
+        .mockReturnValue(MOCK_WORKSPACE_DIR);
+      const projectEnvPath = path.join(MOCK_WORKSPACE_DIR, '.env');
+      const userQwenEnvPath = path.join('/mock/home/user', QWEN_DIR, '.env');
+
+      vi.mocked(isWorkspaceTrusted).mockReturnValue({
+        isTrusted: true,
+        source: 'file',
+      });
+      (mockFsExistsSync as Mock).mockImplementation((p: fs.PathLike) =>
+        [projectEnvPath, userQwenEnvPath].includes(p.toString()),
+      );
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === projectEnvPath)
+            return 'OPENCODE_GO_API_KEY=from_project_env';
+          if (p === userQwenEnvPath)
+            return 'OPENCODE_GO_API_KEY=from_user_qwen_env';
+          return '{}';
+        },
+      );
+
+      const loaded = loadSettings(MOCK_WORKSPACE_DIR, {
+        skipLoadEnvironment: true,
+      });
+      loadEnvironment(loaded.merged);
+
+      expect(process.env['OPENCODE_GO_API_KEY']).toEqual('from_project_env');
+
+      cwdSpy.mockRestore();
+    });
+
+    it('still loads user .qwen/.env fallback when the workspace is untrusted', () => {
+      delete process.env['OPENCODE_GO_API_KEY'];
+      delete process.env['PROJECT_ENV_VAR'];
+      const cwdSpy = vi
+        .spyOn(process, 'cwd')
+        .mockReturnValue(MOCK_WORKSPACE_DIR);
+      const projectEnvPath = path.join(MOCK_WORKSPACE_DIR, '.env');
+      const userQwenEnvPath = path.join('/mock/home/user', QWEN_DIR, '.env');
+
+      vi.mocked(isWorkspaceTrusted).mockReturnValue({
+        isTrusted: false,
+        source: 'file',
+      });
+      (mockFsExistsSync as Mock).mockImplementation((p: fs.PathLike) =>
+        [projectEnvPath, userQwenEnvPath].includes(p.toString()),
+      );
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === projectEnvPath) return 'PROJECT_ENV_VAR=from_project';
+          if (p === userQwenEnvPath)
+            return 'OPENCODE_GO_API_KEY=from_user_qwen_env';
+          return '{}';
+        },
+      );
+
+      const loaded = loadSettings(MOCK_WORKSPACE_DIR, {
+        skipLoadEnvironment: true,
+      });
+      loadEnvironment(loaded.merged);
+
+      expect(process.env['PROJECT_ENV_VAR']).toBeUndefined();
+      expect(process.env['OPENCODE_GO_API_KEY']).toEqual('from_user_qwen_env');
+
+      cwdSpy.mockRestore();
+    });
+
+    it('does not continue loading parent workspace .env files after finding the first workspace .env', () => {
+      delete process.env['OPENCODE_GO_API_KEY'];
+      delete process.env['FIRST_WORKSPACE_VAR'];
+      delete process.env['PARENT_WORKSPACE_VAR'];
+      const nestedWorkspaceDir = path.join(MOCK_WORKSPACE_DIR, 'project');
+      const cwdSpy = vi
+        .spyOn(process, 'cwd')
+        .mockReturnValue(path.join(nestedWorkspaceDir, 'nested'));
+      const firstWorkspaceEnvPath = path.join(nestedWorkspaceDir, '.env');
+      const parentWorkspaceEnvPath = path.join(MOCK_WORKSPACE_DIR, '.env');
+      const userQwenEnvPath = path.join('/mock/home/user', QWEN_DIR, '.env');
+
+      vi.mocked(isWorkspaceTrusted).mockReturnValue({
+        isTrusted: true,
+        source: 'file',
+      });
+      (mockFsExistsSync as Mock).mockImplementation((p: fs.PathLike) =>
+        [
+          firstWorkspaceEnvPath,
+          parentWorkspaceEnvPath,
+          userQwenEnvPath,
+        ].includes(p.toString()),
+      );
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === firstWorkspaceEnvPath)
+            return 'FIRST_WORKSPACE_VAR=from_first_workspace';
+          if (p === parentWorkspaceEnvPath)
+            return 'PARENT_WORKSPACE_VAR=from_parent_workspace';
+          if (p === userQwenEnvPath)
+            return 'OPENCODE_GO_API_KEY=from_user_qwen_env';
+          return '{}';
+        },
+      );
+
+      const loaded = loadSettings(nestedWorkspaceDir, {
+        skipLoadEnvironment: true,
+      });
+      loadEnvironment(loaded.merged);
+
+      expect(process.env['FIRST_WORKSPACE_VAR']).toEqual(
+        'from_first_workspace',
+      );
+      expect(process.env['PARENT_WORKSPACE_VAR']).toBeUndefined();
+      expect(process.env['OPENCODE_GO_API_KEY']).toEqual('from_user_qwen_env');
+
+      cwdSpy.mockRestore();
+    });
+
+    it('uses the same .env priority order for Cloud Shell GOOGLE_CLOUD_PROJECT', () => {
+      delete process.env['GOOGLE_CLOUD_PROJECT'];
+      process.env['CLOUD_SHELL'] = 'true';
+      const cwdSpy = vi
+        .spyOn(process, 'cwd')
+        .mockReturnValue(MOCK_WORKSPACE_DIR);
+      const projectEnvPath = path.join(MOCK_WORKSPACE_DIR, '.env');
+      const userQwenEnvPath = path.join('/mock/home/user', QWEN_DIR, '.env');
+
+      vi.mocked(isWorkspaceTrusted).mockReturnValue({
+        isTrusted: true,
+        source: 'file',
+      });
+      (mockFsExistsSync as Mock).mockImplementation((p: fs.PathLike) =>
+        [projectEnvPath, userQwenEnvPath].includes(p.toString()),
+      );
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === projectEnvPath)
+            return 'GOOGLE_CLOUD_PROJECT=from_project_env';
+          if (p === userQwenEnvPath)
+            return 'GOOGLE_CLOUD_PROJECT=from_user_qwen_env';
+          return '{}';
+        },
+      );
+
+      const loaded = loadSettings(MOCK_WORKSPACE_DIR, {
+        skipLoadEnvironment: true,
+      });
+      loadEnvironment(loaded.merged);
+
+      expect(process.env['GOOGLE_CLOUD_PROJECT']).toEqual('from_project_env');
+
+      delete process.env['CLOUD_SHELL'];
+      delete process.env['GOOGLE_CLOUD_PROJECT'];
+      cwdSpy.mockRestore();
+    });
+
     describe('settings.env field', () => {
       const originalEnv = { ...process.env };
 
@@ -4280,6 +4477,83 @@ describe('Settings Loading and Merging', () => {
         delete process.env['OPENAI_API_KEY'];
         cwdSpy.mockRestore();
       });
+    });
+  });
+
+  describe('reloadEnvironment', () => {
+    const normalizeFsPath = (
+      p: fs.PathLike | fs.PathOrFileDescriptor,
+    ): string => path.normalize(p.toString());
+
+    it('uses user .qwen/.env as fallback when the project .env lacks an API key', () => {
+      delete process.env['OPENCODE_GO_API_KEY'];
+      delete process.env['PROJECT_ONLY_VAR'];
+      const projectEnvPath = path.resolve(MOCK_WORKSPACE_DIR, '.env');
+      const userQwenEnvPath = path.normalize(
+        path.join('/mock/home/user', QWEN_DIR, '.env'),
+      );
+      const envPaths = new Set([projectEnvPath, userQwenEnvPath]);
+
+      vi.mocked(isWorkspaceTrusted).mockReturnValue({
+        isTrusted: true,
+        source: 'file',
+      });
+      (mockFsExistsSync as Mock).mockImplementation((p: fs.PathLike) =>
+        envPaths.has(normalizeFsPath(p)),
+      );
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          const filePath = normalizeFsPath(p);
+          if (filePath === projectEnvPath)
+            return 'PROJECT_ONLY_VAR=from_project';
+          if (filePath === userQwenEnvPath)
+            return 'OPENCODE_GO_API_KEY=from_user_qwen_env';
+          return '{}';
+        },
+      );
+
+      const result = reloadEnvironment({}, MOCK_WORKSPACE_DIR);
+
+      expect(process.env['PROJECT_ONLY_VAR']).toEqual('from_project');
+      expect(process.env['OPENCODE_GO_API_KEY']).toEqual('from_user_qwen_env');
+      expect(result.updatedKeys).toEqual([
+        'PROJECT_ONLY_VAR',
+        'OPENCODE_GO_API_KEY',
+      ]);
+      expect(result.removedKeys).toEqual([]);
+    });
+
+    it('keeps the project .env value during reload when user .qwen/.env also defines it', () => {
+      delete process.env['OPENCODE_GO_API_KEY'];
+      const projectEnvPath = path.resolve(MOCK_WORKSPACE_DIR, '.env');
+      const userQwenEnvPath = path.normalize(
+        path.join('/mock/home/user', QWEN_DIR, '.env'),
+      );
+      const envPaths = new Set([projectEnvPath, userQwenEnvPath]);
+
+      vi.mocked(isWorkspaceTrusted).mockReturnValue({
+        isTrusted: true,
+        source: 'file',
+      });
+      (mockFsExistsSync as Mock).mockImplementation((p: fs.PathLike) =>
+        envPaths.has(normalizeFsPath(p)),
+      );
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          const filePath = normalizeFsPath(p);
+          if (filePath === projectEnvPath)
+            return 'OPENCODE_GO_API_KEY=from_project_env';
+          if (filePath === userQwenEnvPath)
+            return 'OPENCODE_GO_API_KEY=from_user_qwen_env';
+          return '{}';
+        },
+      );
+
+      const result = reloadEnvironment({}, MOCK_WORKSPACE_DIR);
+
+      expect(process.env['OPENCODE_GO_API_KEY']).toEqual('from_project_env');
+      expect(result.updatedKeys).toEqual(['OPENCODE_GO_API_KEY']);
+      expect(result.removedKeys).toEqual([]);
     });
   });
 

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -717,6 +717,14 @@ export function resetHomeEnvBootstrapForTesting(): void {
   homeEnvBootstrapped = false;
 }
 
+/** Test-only: reset environment reload provenance between tests. */
+export function resetEnvironmentTrackingForTesting(): void {
+  dotEnvSourcedKeys.clear();
+  settingsEnvSourcedKeys.clear();
+  lastReloadSnapshot.clear();
+  lastReloadSnapshotSeeded = false;
+}
+
 /**
  * Collects environment variables from user-level `.env` files and returns
  * them as a plain dictionary **without** mutating `process.env`.
@@ -804,45 +812,58 @@ function detectQwenHomeRedirectWithoutMigration(
 }
 
 /**
- * Finds the .env file to load, respecting workspace trust settings.
+ * Finds the .env files to load, respecting workspace trust settings.
  *
  * When workspace is untrusted, only allow user-level .env files at:
  * - ~/.qwen/.env
  * - ~/.env
  * - <QWEN_HOME>/.env (when set)
  */
-function findEnvFile(
+function findEnvFiles(
   settings: Settings,
   startDir: string,
   userLevelPaths: Set<string> = getUserLevelEnvPaths(),
-): string | null {
+): string[] {
   const homeDir = homedir();
   const isTrusted = isWorkspaceTrusted(settings).isTrusted;
 
   const globalQwenDir = Storage.getGlobalQwenDir();
   const legacyQwenDir = path.normalize(path.join(homeDir, QWEN_DIR));
   const hasCustomConfigDir = path.normalize(globalQwenDir) !== legacyQwenDir;
+  const found: string[] = [];
+  const seen = new Set<string>();
 
   const canUseEnvFile = (filePath: string): boolean =>
     isTrusted !== false || userLevelPaths.has(path.normalize(filePath));
+
+  const pushCandidate = (filePath: string): boolean => {
+    const normalized = path.normalize(filePath);
+    if (
+      !seen.has(normalized) &&
+      fs.existsSync(filePath) &&
+      canUseEnvFile(filePath)
+    ) {
+      seen.add(normalized);
+      found.push(filePath);
+      return true;
+    }
+    return false;
+  };
 
   // Home-dir candidates in priority order: globalQwenDir/.env, then legacy
   // ~/.qwen/.env (only when QWEN_HOME redirects), then ~/.env.
   // Users who add `QWEN_HOME=` to an existing global env file shouldn't lose
   // credentials still in the legacy file; routing vars inside it are already
   // pinned by `preResolveHomeEnvOverrides` (no-override).
-  const findHomeCandidate = (): string | null => {
+  const pushHomeCandidates = (): void => {
     const candidates = [path.join(globalQwenDir, '.env')];
     if (hasCustomConfigDir) {
       candidates.push(path.join(legacyQwenDir, '.env'));
     }
     candidates.push(path.join(homeDir, '.env'));
     for (const candidate of candidates) {
-      if (fs.existsSync(candidate) && canUseEnvFile(candidate)) {
-        return candidate;
-      }
+      pushCandidate(candidate);
     }
-    return null;
   };
 
   let currentDir = path.resolve(startDir);
@@ -850,23 +871,28 @@ function findEnvFile(
   while (true) {
     if (currentDir === homeDir) {
       visitedHomeDir = true;
-      const found = findHomeCandidate();
-      if (found) return found;
+      pushHomeCandidates();
+      return found;
     } else {
       // Workspace step: prefer .qwen/.env, then plain .env.
       const geminiEnvPath = path.join(currentDir, QWEN_DIR, '.env');
-      if (fs.existsSync(geminiEnvPath) && canUseEnvFile(geminiEnvPath)) {
-        return geminiEnvPath;
+      if (pushCandidate(geminiEnvPath)) {
+        pushHomeCandidates();
+        return found;
       }
       const envPath = path.join(currentDir, '.env');
-      if (fs.existsSync(envPath) && canUseEnvFile(envPath)) {
-        return envPath;
+      if (pushCandidate(envPath)) {
+        pushHomeCandidates();
+        return found;
       }
     }
 
     const parentDir = path.dirname(currentDir);
     if (parentDir === currentDir || !parentDir) {
-      return visitedHomeDir ? null : findHomeCandidate();
+      if (!visitedHomeDir) {
+        pushHomeCandidates();
+      }
+      return found;
     }
     currentDir = parentDir;
   }
@@ -893,6 +919,23 @@ export function setUpCloudShellEnvironment(envFilePath: string | null): void {
     process.env['GOOGLE_CLOUD_PROJECT'] = 'cloudshell-gca';
   }
 }
+
+function setUpCloudShellEnvironmentFromFiles(envFilePaths: string[]): void {
+  for (const envFilePath of envFilePaths) {
+    if (!fs.existsSync(envFilePath)) {
+      continue;
+    }
+    const envFileContent = fs.readFileSync(envFilePath);
+    const parsedEnv = dotenv.parse(envFileContent);
+    if (parsedEnv['GOOGLE_CLOUD_PROJECT']) {
+      process.env['GOOGLE_CLOUD_PROJECT'] = parsedEnv['GOOGLE_CLOUD_PROJECT'];
+      return;
+    }
+  }
+
+  process.env['GOOGLE_CLOUD_PROJECT'] = 'cloudshell-gca';
+}
+
 /**
  * Loads environment variables from .env files and settings.env.
  *
@@ -905,16 +948,16 @@ export function setUpCloudShellEnvironment(envFilePath: string | null): void {
  */
 export function loadEnvironment(settings: Settings): void {
   const userLevelPaths = getUserLevelEnvPaths();
-  const envFilePath = findEnvFile(settings, process.cwd(), userLevelPaths);
+  const envFilePaths = findEnvFiles(settings, process.cwd(), userLevelPaths);
 
   // Cloud Shell environment variable handling
   if (process.env['CLOUD_SHELL'] === 'true') {
-    setUpCloudShellEnvironment(envFilePath);
+    setUpCloudShellEnvironmentFromFiles(envFilePaths);
   }
 
   // Step 1: Load from .env files (higher priority than settings.env)
   // Only set if not already present in process.env (no-override mode)
-  if (envFilePath) {
+  for (const envFilePath of envFilePaths) {
     try {
       const envFileContent = fs.readFileSync(envFilePath, 'utf-8');
       const parsedEnv = dotenv.parse(envFileContent);
@@ -949,7 +992,7 @@ export function loadEnvironment(settings: Settings): void {
           }
           // Seed snapshot with ALL parsed keys (not just written ones)
           // so child processes can detect deletions on first reload.
-          if (!lastReloadSnapshotSeeded) {
+          if (!lastReloadSnapshotSeeded && !lastReloadSnapshot.has(key)) {
             lastReloadSnapshot.set(key, parsedEnv[key]!);
           }
         }
@@ -998,10 +1041,10 @@ export function reloadEnvironment(
   workspaceCwd: string,
 ): EnvReloadResult {
   const userLevelPaths = getUserLevelEnvPaths();
-  const envFilePath = findEnvFile(settings, workspaceCwd, userLevelPaths);
+  const envFilePaths = findEnvFiles(settings, workspaceCwd, userLevelPaths);
 
   if (process.env['CLOUD_SHELL'] === 'true') {
-    setUpCloudShellEnvironment(envFilePath);
+    setUpCloudShellEnvironmentFromFiles(envFilePaths);
   }
 
   // Build the set of new keys from .env (higher priority) + settings.env
@@ -1009,7 +1052,7 @@ export function reloadEnvironment(
   const newDotEnvKeys = new Map<string, string>();
   const newSettingsEnvKeys = new Map<string, string>();
 
-  if (envFilePath) {
+  for (const envFilePath of envFilePaths) {
     try {
       const envFileContent = fs.readFileSync(envFilePath, 'utf-8');
       const parsedEnv = dotenv.parse(envFileContent);
@@ -1031,7 +1074,9 @@ export function reloadEnvironment(
           continue;
         }
         if (!isQwenScopedEnvFile && excludedVars.includes(key)) continue;
-        newDotEnvKeys.set(key, parsedEnv[key]!);
+        if (!newDotEnvKeys.has(key)) {
+          newDotEnvKeys.set(key, parsedEnv[key]!);
+        }
       }
     } catch {
       dotEnvReadFailed = true;


### PR DESCRIPTION
## What this PR does

This PR changes environment loading from a single selected `.env` file to a small priority chain: the first workspace `.env` file found by the existing walk-up behavior, followed by user-level `.env` files such as `~/.qwen/.env`, `<QWEN_HOME>/.env`, and `~/.env`.

The loader still uses no-override semantics, so an exported shell variable wins over all files, and a project `.env` value wins over the same key in user-level `.env` files. If the project `.env` exists but does not define the selected provider API key, user-level `.env` files can now fill in that missing key.

`reloadEnvironment()` now uses the same priority chain as initial startup loading, so daemon/ACP reload behavior stays consistent with `loadEnvironment()`. The change also keeps the existing trust boundary: untrusted workspaces still cannot load project `.env` files, but user-level `.env` files remain allowed.

## Why it's needed

Fixes a case where starting `qwen` in a directory with an empty project `.env`, or a project `.env` that lacks the active provider key, could make Qwen Code report a missing API key even when that key exists in `~/.qwen/.env`.

The old lookup stopped as soon as it found a project `.env`, so lower-priority user-level credentials were never considered. That made global user credentials fragile because any unrelated project `.env` could shadow them completely.

## Reviewer Test Plan

### How to verify

Review the new `settings.test.ts` cases covering:

- project `.env` missing `OPENCODE_GO_API_KEY` falls back to `~/.qwen/.env`
- project `.env` still wins when both files define the same key
- untrusted workspaces skip project `.env` but still load user-level `.env`
- parent workspace `.env` files are not loaded after the first workspace `.env` is found
- Cloud Shell `GOOGLE_CLOUD_PROJECT` follows the same priority order
- `reloadEnvironment()` follows the same fallback rules as `loadEnvironment()`

Commands run locally:

```sh
npm test --workspace=packages/cli -- config/settings.test.ts --coverage.enabled=false
npx prettier --check packages/cli/src/config/settings.ts packages/cli/src/config/settings.test.ts
npx eslint packages/cli/src/config/settings.ts packages/cli/src/config/settings.test.ts
npm run typecheck --workspace=packages/cli --if-present
git diff --check HEAD
```

### Evidence (Before & After)

Before: once the loader found a project `.env`, it loaded only that file. If that file was empty or missing the active provider key, `~/.qwen/.env` was ignored.

After: the loader reads the first workspace `.env` and then user-level fallback files in no-override order. Missing keys can be filled from user-level `.env`, while same-name project keys keep priority.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local Node/npm workspace; no external services required.

## Risk & Scope

- Main risk or tradeoff: this intentionally broadens `.env` loading from one file to one workspace file plus user-level fallback files, so missing keys can now come from user-level `.env` files.
- Not validated / out of scope: no interactive authentication flow was exercised; this is covered at the config loader unit-test level.
- Breaking changes / migration notes: none expected. Existing priority is preserved for shell env and project `.env` values.

## Linked Issues

Fixes #3877

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 将环境变量加载从“只加载一个选中的 `.env` 文件”改为一个较短的优先级链：先加载现有向上查找逻辑找到的第一个 workspace `.env`，然后加载用户级 `.env` 文件，例如 `~/.qwen/.env`、`<QWEN_HOME>/.env` 和 `~/.env`。

加载逻辑仍然保持 no-override 语义，所以 shell 中已经导出的环境变量优先级最高；如果 project `.env` 和用户级 `.env` 定义了同一个 key，project `.env` 仍然优先。现在如果 project `.env` 存在但没有定义当前 provider 需要的 API key，用户级 `.env` 可以补上这个缺失的 key。

`reloadEnvironment()` 现在也使用和启动加载相同的优先级链，保证 daemon/ACP reload 行为与 `loadEnvironment()` 一致。这个改动也保留了现有 trust 边界：不可信 workspace 仍然不能加载 project `.env`，但用户级 `.env` 仍然允许加载。

## Why it's needed

这个 PR 修复了一个问题：当在带有空 project `.env` 的目录中启动 `qwen`，或者 project `.env` 没有包含当前 provider key 时，即使 `~/.qwen/.env` 里存在这个 key，Qwen Code 也可能报缺少 API key。

旧逻辑一旦找到 project `.env` 就停止查找，因此优先级更低的用户级凭据完全不会被考虑。这让全局用户凭据变得很脆弱，因为任何无关的 project `.env` 都可能把它完全遮住。

## Reviewer Test Plan

### How to verify

请检查新增的 `settings.test.ts` 用例，覆盖：

- project `.env` 缺少 `OPENCODE_GO_API_KEY` 时回退到 `~/.qwen/.env`
- 当两个文件都定义同一个 key 时，project `.env` 仍然优先
- 不可信 workspace 会跳过 project `.env`，但仍然加载用户级 `.env`
- 找到第一个 workspace `.env` 后，不会继续加载父目录 workspace `.env`
- Cloud Shell 的 `GOOGLE_CLOUD_PROJECT` 使用相同优先级顺序
- `reloadEnvironment()` 使用和 `loadEnvironment()` 一致的 fallback 规则

本地已运行命令：

```sh
npm test --workspace=packages/cli -- config/settings.test.ts --coverage.enabled=false
npx prettier --check packages/cli/src/config/settings.ts packages/cli/src/config/settings.test.ts
npx eslint packages/cli/src/config/settings.ts packages/cli/src/config/settings.test.ts
npm run typecheck --workspace=packages/cli --if-present
git diff --check HEAD
```

### Evidence (Before & After)

Before：加载器一旦找到 project `.env`，就只加载这个文件。如果这个文件为空，或者缺少当前 provider key，`~/.qwen/.env` 会被忽略。

After：加载器会读取第一个 workspace `.env`，然后按 no-override 顺序读取用户级 fallback 文件。缺失的 key 可以由用户级 `.env` 补上，同名 project key 仍然保持更高优先级。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 Node/npm workspace；不需要外部服务。

## Risk & Scope

- Main risk or tradeoff: 这个改动有意将 `.env` 加载范围从一个文件扩展为一个 workspace 文件加用户级 fallback 文件，因此缺失的 key 现在可以来自用户级 `.env`。
- Not validated / out of scope: 没有跑交互式认证流程；这里通过 config loader 的单元测试覆盖。
- Breaking changes / migration notes: 预计没有。shell env 和 project `.env` 值的现有优先级保持不变。

## Linked Issues

Fixes #3877

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
