### PR TITLE
feat(cli): match MCP resource completions by name and discover servers

### DIFF
--- a/docs/users/features/mcp.md
+++ b/docs/users/features/mcp.md
@@ -190,8 +190,12 @@ syntax — type `@`, then the server name, a colon, and the resource URI:
 summarize @myserver:file:///docs/spec.md and list the open questions
 ```
 
-Typing `@myserver:` shows an autocomplete list of that server's resource
-URIs. On submit, the referenced resource is read and its contents are
+Typing `@myserver:` shows an autocomplete list of that server's resources;
+keep typing to filter, matching (case-insensitively) either the resource URI
+or its friendly name/title. You don't have to know a URI by heart — before
+you reach the colon, typing part of a server name also suggests matching
+servers that expose resources, so you can pick one and drill straight into
+its resource list. On submit, the referenced resource is read and its contents are
 appended to your message (text inline, binary blobs as attachments); the
 `@server:uri` reference is preserved in the prompt so the model knows what
 it is looking at. The `server` prefix must match a configured MCP server —

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -1386,6 +1386,7 @@ export default {
   'Size:': 'Size:',
   '{{count}} bytes': '{{count}} bytes',
   'Reference in chat': 'Reference in chat',
+  'MCP resource server': 'MCP resource server',
 
   // Invalid tool related translations
   '{{count}} invalid tools': '{{count}} invalid tools',

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -1193,6 +1193,7 @@ export default {
   'Size:': '大小：',
   '{{count}} bytes': '{{count}} 位元組',
   'Reference in chat': '在對話中引用',
+  'MCP resource server': 'MCP 資源伺服器',
   '{{count}} invalid tools': '{{count}} 個無效工具',
   invalid: '無效',
   'invalid: {{reason}}': '無效：{{reason}}',

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -1298,6 +1298,7 @@ export default {
   'Size:': '大小：',
   '{{count}} bytes': '{{count}} 字节',
   'Reference in chat': '在对话中引用',
+  'MCP resource server': 'MCP 资源服务器',
 
   // Invalid tool related translations
   '{{count}} invalid tools': '{{count}} 个无效工具',

--- a/packages/cli/src/ui/hooks/useAtCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.test.ts
@@ -678,5 +678,244 @@ describe('useAtCompletion', () => {
         'my:server:res://doc',
       ]);
     });
+
+    it('matches a resource by its friendly name/title, not just the URI', async () => {
+      testRootDir = await createTmpDir({ 'file.txt': '' });
+      const resourceConfig = {
+        ...mockConfig,
+        getMcpServers: () => ({ demo: {} }),
+        getResourceRegistry: () => ({
+          getResourcesByServer: (name: string) =>
+            name === 'demo'
+              ? [
+                  {
+                    uri: 'file:///docs/spec.md',
+                    name: 'spec',
+                    title: 'Project Spec',
+                    serverName: 'demo',
+                  },
+                ]
+              : [],
+        }),
+      } as unknown as Config;
+
+      const { result } = renderHook(() =>
+        useTestHarnessForAtCompletion(
+          true,
+          'demo:Project',
+          resourceConfig,
+          testRootDir,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(result.current.suggestions.length).toBeGreaterThan(0);
+      });
+      // 'Project' matches only the title 'Project Spec', not the URI; the
+      // injected value is still the canonical URI reference.
+      expect(result.current.suggestions.map((s) => s.value)).toEqual([
+        'demo:file:///docs/spec.md',
+      ]);
+    });
+
+    it('matches the URI case-insensitively', async () => {
+      testRootDir = await createTmpDir({ 'file.txt': '' });
+      const resourceConfig = {
+        ...mockConfig,
+        getMcpServers: () => ({ demo: {} }),
+        getResourceRegistry: () => ({
+          getResourcesByServer: () => [
+            { uri: 'file:///docs/Spec.md', name: 's', serverName: 'demo' },
+          ],
+        }),
+      } as unknown as Config;
+
+      const { result } = renderHook(() =>
+        useTestHarnessForAtCompletion(
+          true,
+          'demo:spec',
+          resourceConfig,
+          testRootDir,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(result.current.suggestions.length).toBeGreaterThan(0);
+      });
+      // Lowercase 'spec' still matches 'file:///docs/Spec.md'.
+      expect(result.current.suggestions.map((s) => s.value)).toEqual([
+        'demo:file:///docs/Spec.md',
+      ]);
+    });
+
+    it('ranks prefix above substring and URI above name across both fields', async () => {
+      testRootDir = await createTmpDir({ 'file.txt': '' });
+      const resourceConfig = {
+        ...mockConfig,
+        getMcpServers: () => ({ demo: {} }),
+        getResourceRegistry: () => ({
+          getResourcesByServer: () => [
+            { uri: 'y', name: 'my doc', serverName: 'demo' }, // name substring → rank 3
+            { uri: 'api/doc', name: 'zzz', serverName: 'demo' }, // uri substring → rank 2
+            { uri: 'x', name: 'doc-notes', serverName: 'demo' }, // name prefix → rank 1
+            { uri: 'doc/a', name: 'zzz', serverName: 'demo' }, // uri prefix → rank 0
+          ],
+        }),
+      } as unknown as Config;
+
+      const { result } = renderHook(() =>
+        useTestHarnessForAtCompletion(
+          true,
+          'demo:doc',
+          resourceConfig,
+          testRootDir,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(result.current.suggestions.length).toBeGreaterThan(0);
+      });
+      expect(result.current.suggestions.map((s) => s.value)).toEqual([
+        'demo:doc/a',
+        'demo:x',
+        'demo:api/doc',
+        'demo:y',
+      ]);
+    });
+
+    it('surfaces the friendly name as the suggestion description', async () => {
+      testRootDir = await createTmpDir({ 'file.txt': '' });
+      const resourceConfig = {
+        ...mockConfig,
+        getMcpServers: () => ({ demo: {} }),
+        getResourceRegistry: () => ({
+          getResourcesByServer: () => [
+            {
+              uri: 'file:///docs/spec.md',
+              name: 'spec',
+              title: 'Project Spec',
+              serverName: 'demo',
+            },
+          ],
+        }),
+      } as unknown as Config;
+
+      const { result } = renderHook(() =>
+        useTestHarnessForAtCompletion(
+          true,
+          'demo:spec',
+          resourceConfig,
+          testRootDir,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(result.current.suggestions.length).toBeGreaterThan(0);
+      });
+      expect(result.current.suggestions[0].description).toBe('Project Spec');
+    });
+  });
+
+  describe('MCP server discovery', () => {
+    it('suggests matching servers (with resources) alongside files for a bare @<partial>', async () => {
+      testRootDir = await createTmpDir({ 'my-notes.txt': '' });
+      const resourceConfig = {
+        ...mockConfig,
+        getMcpServers: () => ({ myserver: {} }),
+        getResourceRegistry: () => ({
+          getResourcesByServer: (name: string) =>
+            name === 'myserver'
+              ? [{ uri: 'res://x', name: 'x', serverName: 'myserver' }]
+              : [],
+        }),
+      } as unknown as Config;
+
+      const { result } = renderHook(() =>
+        useTestHarnessForAtCompletion(true, 'my', resourceConfig, testRootDir),
+      );
+
+      await waitFor(() => {
+        expect(result.current.suggestions.length).toBeGreaterThan(0);
+      });
+      const values = result.current.suggestions.map((s) => s.value);
+      // Server entry is prepended (before files) and expands to `@myserver:`.
+      expect(values[0]).toBe('myserver:');
+      expect(values).toContain('my-notes.txt');
+      const serverSug = result.current.suggestions.find(
+        (s) => s.value === 'myserver:',
+      );
+      // `isDirectory` => no trailing space => completion re-triggers into the
+      // resource list once `@myserver:` is inserted.
+      expect(serverSug?.isDirectory).toBe(true);
+    });
+
+    it('does not suggest servers for the empty @ trigger (files only)', async () => {
+      testRootDir = await createTmpDir({ 'file.txt': '' });
+      const resourceConfig = {
+        ...mockConfig,
+        getMcpServers: () => ({ myserver: {} }),
+        getResourceRegistry: () => ({
+          getResourcesByServer: () => [
+            { uri: 'res://x', name: 'x', serverName: 'myserver' },
+          ],
+        }),
+      } as unknown as Config;
+
+      const { result } = renderHook(() =>
+        useTestHarnessForAtCompletion(true, '', resourceConfig, testRootDir),
+      );
+
+      await waitFor(() => {
+        expect(result.current.suggestions.length).toBeGreaterThan(0);
+      });
+      const values = result.current.suggestions.map((s) => s.value);
+      expect(values).toContain('file.txt');
+      expect(values).not.toContain('myserver:');
+    });
+
+    it('does not suggest servers that expose no resources', async () => {
+      testRootDir = await createTmpDir({ 'my-notes.txt': '' });
+      const resourceConfig = {
+        ...mockConfig,
+        getMcpServers: () => ({ myserver: {} }),
+        getResourceRegistry: () => ({ getResourcesByServer: () => [] }),
+      } as unknown as Config;
+
+      const { result } = renderHook(() =>
+        useTestHarnessForAtCompletion(true, 'my', resourceConfig, testRootDir),
+      );
+
+      await waitFor(() => {
+        expect(result.current.suggestions.length).toBeGreaterThan(0);
+      });
+      const values = result.current.suggestions.map((s) => s.value);
+      expect(values).not.toContain('myserver:');
+      expect(values).toContain('my-notes.txt');
+    });
+
+    it('does not suggest servers in an untrusted folder', async () => {
+      testRootDir = await createTmpDir({ 'my-notes.txt': '' });
+      const resourceConfig = {
+        ...mockConfig,
+        isTrustedFolder: () => false,
+        getMcpServers: () => ({ myserver: {} }),
+        getResourceRegistry: () => ({
+          getResourcesByServer: () => [
+            { uri: 'res://x', name: 'x', serverName: 'myserver' },
+          ],
+        }),
+      } as unknown as Config;
+
+      const { result } = renderHook(() =>
+        useTestHarnessForAtCompletion(true, 'my', resourceConfig, testRootDir),
+      );
+
+      await waitFor(() => {
+        expect(result.current.suggestions.length).toBeGreaterThan(0);
+      });
+      const values = result.current.suggestions.map((s) => s.value);
+      expect(values).not.toContain('myserver:');
+      expect(values).toContain('my-notes.txt');
+    });
   });
 });

--- a/packages/cli/src/ui/hooks/useAtCompletion.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.ts
@@ -10,6 +10,7 @@ import { FileSearchFactory, escapePath } from '@qwen-code/qwen-code-core';
 import type { Suggestion } from '../components/SuggestionsDisplay.js';
 import { MAX_SUGGESTIONS_TO_SHOW } from '../components/SuggestionsDisplay.js';
 import { matchMcpServerPrefix, buildMcpResourceRef } from './mcpResourceRef.js';
+import { t } from '../../i18n/index.js';
 
 /**
  * `@server:uri` MCP resource completion. Returns suggestions when `pattern`
@@ -17,11 +18,19 @@ import { matchMcpServerPrefix, buildMcpResourceRef } from './mcpResourceRef.js';
  * server (so a plain file path containing ':' is never hijacked); returns
  * `null` otherwise to let the caller fall through to filesystem search.
  *
- * Matching is a case-sensitive substring on the URI (an empty partial matches
- * every resource — `'x'.includes('')` is `true`), with prefix matches ranked
- * above mid-string matches. The resource list comes from the post-discovery
- * `ResourceRegistry`, so an empty result before discovery completes simply
- * shows no suggestions.
+ * The partial after the colon is matched case-INsensitively against each
+ * resource's URI AND its friendly name/title (the same `title || name` the
+ * `/mcp` dialog shows), so a user who only remembers the human-readable name —
+ * not the URI — still gets completions. An empty partial matches every
+ * resource (`''` is a prefix of every string). Ranking, best first: URI prefix,
+ * then name/title prefix, then URI substring, then name/title substring; ties
+ * break alphabetically by URI for a stable order.
+ *
+ * The injected `value` is always the canonical `@server:uri` reference (the
+ * friendly name is not a referenceable identifier); the name rides along as the
+ * suggestion `description` so a name-only match is self-explanatory. The
+ * resource list comes from the post-discovery `ResourceRegistry`, so an empty
+ * result before discovery completes simply shows no suggestions.
  */
 function getMcpResourceSuggestions(
   config: Config | undefined,
@@ -38,26 +47,89 @@ function getMcpResourceSuggestions(
   const match = matchMcpServerPrefix(pattern, Object.keys(mcpServers));
   if (!match) return null;
   const serverName = match.serverName;
-  const partialUri = match.rest;
+  const query = match.rest.toLowerCase();
+
+  // Lower rank = better match; `Infinity` means no match and is filtered out.
+  const rankOf = (uri: string, friendly: string): number => {
+    if (uri.startsWith(query)) return 0;
+    if (friendly.startsWith(query)) return 1;
+    if (uri.includes(query)) return 2;
+    if (friendly.includes(query)) return 3;
+    return Infinity;
+  };
+
   const resources =
     config.getResourceRegistry?.()?.getResourcesByServer(serverName) ?? [];
   const matches = resources
-    .filter((r) => r.uri.includes(partialUri))
-    .sort((a, b) => {
-      // Rank URIs that start with the partial above mid-string matches,
-      // then alphabetically for a stable order.
-      const aPrefix = a.uri.startsWith(partialUri) ? 0 : 1;
-      const bPrefix = b.uri.startsWith(partialUri) ? 0 : 1;
-      return aPrefix - bPrefix || a.uri.localeCompare(b.uri);
-    });
-  return matches.slice(0, MAX_SUGGESTIONS_TO_SHOW * 3).map((r) => {
-    const ref = buildMcpResourceRef(serverName, r.uri);
+    .map((resource) => {
+      const friendly = resource.title || resource.name || '';
+      return {
+        resource,
+        friendly,
+        rank: rankOf(resource.uri.toLowerCase(), friendly.toLowerCase()),
+      };
+    })
+    .filter((m) => m.rank !== Infinity)
+    .sort(
+      (a, b) => a.rank - b.rank || a.resource.uri.localeCompare(b.resource.uri),
+    );
+
+  return matches.slice(0, MAX_SUGGESTIONS_TO_SHOW * 3).map((m) => {
+    const ref = buildMcpResourceRef(serverName, m.resource.uri);
     return {
       label: ref,
       value: ref,
+      // Only surface the friendly name when it adds information beyond the URI
+      // (mirrors the `/mcp` resource list, which dims a redundant name).
+      description:
+        m.friendly && m.friendly !== m.resource.uri ? m.friendly : undefined,
       isDirectory: false,
     };
   });
+}
+
+/**
+ * `@<partial>` MCP server discovery. BEFORE any `<server>:` has been typed,
+ * surface configured MCP servers that (a) expose at least one resource and
+ * (b) whose name starts (case-insensitively) with the partial, so a user who
+ * doesn't know a resource URI can drill in without first memorizing the exact
+ * server name.
+ *
+ * Returns `[]` (never `null`): these are PREPENDED to the filesystem results
+ * rather than replacing them, so typing `@<partial>` never hides files. The
+ * bare `@` trigger (empty partial) is intentionally left as a files-only view
+ * — both to keep the common case unchanged and because every name
+ * `.startsWith('')`, so an empty partial would otherwise match every server.
+ *
+ * Each suggestion expands to `@<server>:` and is flagged `isDirectory` so
+ * `handleAutocomplete` appends no trailing space, letting completion re-trigger
+ * straight into that server's resource list (the `getMcpResourceSuggestions`
+ * path above).
+ */
+function getMcpServerSuggestions(
+  config: Config | undefined,
+  pattern: string,
+): Suggestion[] {
+  if (!config) return [];
+  if (config.isTrustedFolder?.() === false) return [];
+  if (pattern.length === 0) return [];
+  const registry = config.getResourceRegistry?.();
+  if (!registry) return [];
+  const mcpServers = config.getMcpServers?.() || {};
+  const query = pattern.toLowerCase();
+  return Object.keys(mcpServers)
+    .filter(
+      (name) =>
+        name.toLowerCase().startsWith(query) &&
+        (registry.getResourcesByServer(name)?.length ?? 0) > 0,
+    )
+    .sort((a, b) => a.localeCompare(b))
+    .map((name) => ({
+      label: `${name}:`,
+      value: `${name}:`,
+      description: t('MCP resource server'),
+      isDirectory: true,
+    }));
 }
 
 export enum AtCompletionStatus {
@@ -270,7 +342,21 @@ export function useAtCompletion(props: UseAtCompletionProps): void {
         return;
       }
 
+      // No `<server>:` selected yet — offer matching MCP servers (that expose
+      // resources) ALONGSIDE the filesystem results so the user can discover a
+      // server without knowing a resource URI up front. Computed synchronously
+      // and prepended below; never hides files.
+      const serverSuggestions = getMcpServerSuggestions(config, state.pattern);
+
       if (!fileSearch.current) {
+        // File index not ready yet; still surface any server matches so
+        // discovery doesn't have to wait on the crawler.
+        if (serverSuggestions.length > 0) {
+          if (slowSearchTimer.current) {
+            clearTimeout(slowSearchTimer.current);
+          }
+          dispatch({ type: 'SEARCH_SUCCESS', payload: serverSuggestions });
+        }
         return;
       }
 
@@ -302,15 +388,24 @@ export function useAtCompletion(props: UseAtCompletionProps): void {
         // isDirectory relies on crawler.ts in @qwen-code/qwen-code-core
         // always normalizing paths with posix '/' via fdir.withPathSeparator('/').
         // If the crawler ever switches to path.sep, this check must be updated.
-        const suggestions = results.map((p) => ({
+        const fileSuggestions = results.map((p) => ({
           label: p,
           value: escapePath(p),
           isDirectory: p.endsWith('/'),
         }));
-        dispatch({ type: 'SEARCH_SUCCESS', payload: suggestions });
+        dispatch({
+          type: 'SEARCH_SUCCESS',
+          payload: [...serverSuggestions, ...fileSuggestions],
+        });
       } catch (error) {
         if (!(error instanceof Error && error.name === 'AbortError')) {
-          dispatch({ type: 'ERROR' });
+          // A file-search failure shouldn't swallow server matches we already
+          // have; show those rather than dropping to an error state.
+          if (serverSuggestions.length > 0) {
+            dispatch({ type: 'SEARCH_SUCCESS', payload: serverSuggestions });
+          } else {
+            dispatch({ type: 'ERROR' });
+          }
         }
       }
     };


### PR DESCRIPTION
## What this PR does

Improves the in-chat `@server:uri` MCP resource completion (shipped in #5544, surfaced in the `/mcp` dialog by #5635) so it behaves like a normal fuzzy mention picker:

1. **Match by friendly name, case-insensitively.** The partial after the colon now matches (case-insensitively) each resource's friendly **name/title** — the same `title || name` the `/mcp` dialog shows — in addition to its URI. The matched name is shown as the suggestion's description so a name-only hit is self-explanatory. The injected `value` is still the canonical `@server:uri` reference. Ranking, best first: URI prefix → name prefix → URI substring → name substring.
2. **Discover servers before the colon.** Typing `@<partial>` (no colon yet) now also suggests configured MCP servers that expose at least one resource and whose name prefixes the input, **prepended to** (never replacing) the filesystem results. Selecting one expands to `@server:` and drills straight into that server's resource list — it reuses the existing `isDirectory` directory-continuation, so **Tab** drills in and **Enter** inserts-and-closes, identical to picking a folder. The bare `@` trigger is intentionally left files-only.

## Why it's needed

After #5635 a user can *browse* a server's resources in the `/mcp` dialog, but the in-chat `@` completion only matched the **URI**, **case-sensitively**, and only once the full `@server:` prefix was typed. So a user who remembered a resource by its human name ("Project Spec"), typed a different case, or didn't recall the exact server name couldn't complete it — the discoverability #5635 added in the dialog didn't carry over to the place you actually type the reference. This closes that gap.

## Reviewer Test Plan

### How to verify

1. Configure a stdio MCP server that advertises resources via `resources/list` with friendly `title`/`name` (e.g. `uri: file:///docs/spec.md`, `title: "Project Spec"`).
2. Run `qwen` in a trusted folder; wait for MCP discovery to settle.
3. `@demo:Project` → completes `@demo:file:///docs/spec.md` (matched the **title**), shown with description `Project Spec`.
4. `@demo:SPEC` (uppercase) → same match (case-insensitive on the URI).
5. `@dem` → a `demo:` entry (labeled `MCP resource server`) appears **above** the file matches; pressing **Tab** drills into the resource list.

### Evidence — real-TUI A/B

Built the bundle and drove the real TUI in tmux against a live stdio MCP server exposing two resources (`file:///docs/spec.md` "Project Spec", `file:///config/app.json` "App Config"), in a workspace also containing `demo-notes.txt` / `readme.md`:

| Input | Before | After |
| --- | --- | --- |
| `@demo:Project` (title match) | *(no suggestions)* | `demo:file:///docs/spec.md` · `Project Spec` |
| `@demo:SPEC` (uppercase URI) | *(no suggestions)* | `demo:file:///docs/spec.md` · `Project Spec` |
| `@dem` (server discovery) | `demo-notes.txt`, `readme.md` *(files only)* | `demo:` · `MCP resource server` **+** `demo-notes.txt`, `readme.md` |
| `@dem` then `Tab` | n/a | expands to `@demo:` → lists both resources |
| `@demo:` (list) | URIs only | URIs **+** `App Config` / `Project Spec` descriptions |

Unit tests: `npx vitest run --root packages/cli src/ui/hooks/useAtCompletion.test.ts` → **26 passing** (8 new: name match, case-insensitivity, 4-level ranking, description, server discovery, empty-`@` files-only, no-resource server excluded, untrusted folder). `useCommandCompletion` **26 passing** (no regression). `tsc --noEmit`, `eslint`, `prettier --check`, and `check-i18n` all green.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

Windows/Linux not run manually — covered by the cross-platform CI unit tests.

## Risk & Scope

- **Main risk / tradeoff:** UI-only change, almost entirely in one hook (`useAtCompletion.ts`), plus 3 i18n keys and a docs note. No change to MCP discovery, the resource read/inject path, or core.
- Server suggestions are gated to servers that actually expose ≥1 resource and are suppressed in untrusted folders (the same gate as resource URIs); the bare `@` menu stays files-only, so the most common case is unchanged. The `getResourcesByServer` membership check is `&&`-short-circuited behind a name-prefix test, so it runs only for prefix-matching servers (normally 0–1 per keystroke).
- **Breaking changes / migration:** none.

## Linked Issues

Refs #5601, follows #5635.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把对话框里的 `@server:uri` MCP 资源补全(#5544 实现,#5635 在 `/mcp` 面板里暴露)改成更像普通的模糊提及选择器:

1. **按友好名称匹配,且大小写不敏感。** 冒号后的输入现在除了匹配 URI,还会(大小写不敏感地)匹配资源的友好**名称/标题**(即 `/mcp` 面板显示的 `title || name`)。命中的名称作为候选项的描述显示,这样"按名字命中"时一目了然。注入的 `value` 仍然是规范的 `@server:uri` 引用。排序优先级:URI 前缀 → 名称前缀 → URI 子串 → 名称子串。
2. **冒号前发现 server。** 还没敲冒号时,输入 `@<partial>` 会把"暴露了资源、且名称以输入为前缀"的 MCP server 作为候选项**前插**到文件结果里(不替换、不隐藏文件)。选中后展开成 `@server:` 并直接钻入该 server 的资源列表——复用已有的 `isDirectory` 目录续接机制,所以 **Tab** 钻入、**Enter** 插入并关闭,和选文件夹完全一致。裸 `@` 有意保持只列文件。

## 为什么需要

#5635 之后用户可以在 `/mcp` 面板里**浏览**资源,但对话框里的 `@` 补全只匹配 **URI**、**区分大小写**,而且必须先敲完整的 `@server:` 前缀。于是按人类名称("Project Spec")记忆、大小写不符、或记不住确切 server 名的用户都补不出来——#5635 在面板里加的可发现性没有延续到真正输入引用的地方。本 PR 补上这一环。

## 评审验证计划

### 如何验证

1. 配一个通过 `resources/list` 暴露带友好 `title`/`name` 资源的 stdio MCP server(如 `uri: file:///docs/spec.md`、`title: "Project Spec"`)。
2. 在受信任目录运行 `qwen`,等 MCP 发现完成。
3. `@demo:Project` → 补全 `@demo:file:///docs/spec.md`(命中**标题**),并显示描述 `Project Spec`。
4. `@demo:SPEC`(大写)→ 同样命中(URI 大小写不敏感)。
5. `@dem` → `demo:` 项(标 `MCP resource server`)出现在文件匹配**上方**;按 **Tab** 钻入资源列表。

### 证据 — 真实 TUI A/B

构建 bundle 后用 tmux 驱动真实 TUI,对接一个暴露两个资源(`file:///docs/spec.md` "Project Spec"、`file:///config/app.json` "App Config")的真实 stdio MCP server,工作区另含 `demo-notes.txt` / `readme.md`。结果见上方英文表格:`@demo:Project`、`@demo:SPEC` 在改前**无候选**、改后命中;`@dem` 改前**只有文件**、改后 `demo:` 前插且文件仍在;`@dem`+Tab 钻入资源列表;`@demo:` 改前只有 URI、改后带友好名称描述。

单测:`useAtCompletion` 26 通过(8 个新增),`useCommandCompletion` 26 通过(无回归);`tsc` / `eslint` / `prettier --check` / `check-i18n` 全绿。

### 测试平台

macOS ✅;Windows ⚠️ 未手动测试;Linux ⚠️ 未手动测试(均由跨平台 CI 单测覆盖)。

## 风险与范围

- 主要风险/取舍:纯 UI 改动,几乎全在一个 hook(`useAtCompletion.ts`)里,外加 3 个 i18n key 和一处文档。不改 MCP 发现、资源读取/注入路径,也不动 core。
- server 候选项只针对"确实暴露 ≥1 个资源"的 server,且在不可信目录里被抑制(与资源 URI 同一道门);裸 `@` 仍只列文件,最常见场景不变。`getResourcesByServer` 的"是否有资源"检查在名称前缀判断后用 `&&` 短路,只对前缀匹配的 server 触发(正常每次按键 0~1 个)。
- 破坏性变更/迁移:无。

## 关联 Issue

Refs #5601,follows #5635。

</details>
