### PR TITLE
fix(triage): never auto-approve cross-repo refactor PRs

### DIFF
--- a/.qwen/skills/triage/SKILL.md
+++ b/.qwen/skills/triage/SKILL.md
@@ -38,6 +38,11 @@ gh label list --repo "$REPO" --limit 200
   or `gh api -F body=@FILE` when the response ID is needed. Never `--body @FILE`
   or `gh api -f body=@FILE` — those post the path literally.
 - Drafts: skip
+- **Approval guardrail**: never auto-approve a cross-repository (fork) PR whose
+  title is a `refactor` type (starts with `refactor` — `refactor:`,
+  `refactor(scope):`, `refactor(scope)!:`, case-insensitive). Review it as usual,
+  but escalate to the maintainer in place of approval. See `references/pr-workflow.md`
+  Stage 3 for the deterministic check.
 
 ## Duplicate Guard
 

--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -238,7 +238,16 @@ If your independent proposal was materially simpler — say so. Not as a blocker
 
 **Step 2: Act on the verdict.**
 
-All stages genuinely clean — approve:
+**⛔ Approval guardrail — check this BEFORE approving.** A cross-repository (fork) `refactor` PR must never be auto-approved: refactors touch structure broadly and a fork author is not a trusted committer, so these always need a human maintainer's eye (this rule exists because such a PR was wrongly auto-approved and merged). Decide it deterministically — do not eyeball it:
+
+```bash
+GUARD=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json isCrossRepository,title \
+  --jq 'if (.isCrossRepository and (.title | test("^\\s*refactor"; "i"))) then "block" else "ok" end')
+```
+
+If `GUARD` is `block`: do **not** run `gh pr review --approve` no matter how clean every stage looked. Escalate to the maintainer instead (the "Genuinely unsure" path below, using `$QWEN_MAINTAINER_HANDLE` if set), and only `--request-changes` if you actually found blocking issues. This overrides the "approve" path.
+
+All stages genuinely clean **and** `GUARD` is `ok` — approve:
 
 ```bash
 gh pr review "$PR_NUMBER" --repo "$REPO" --approve --body "LGTM, looks ready to ship. ✅"
@@ -250,4 +259,4 @@ Reflection shows it shouldn't merge — request changes immediately, citing the 
 gh pr review "$PR_NUMBER" --repo "$REPO" --request-changes --body "Needs some rethinking — see my notes above. 🙏"
 ```
 
-Genuinely unsure — **don't approve or reject**. Ask the maintainer to weigh in. Use `$QWEN_MAINTAINER_HANDLE` if set.
+Genuinely unsure, or `GUARD` blocked approval — **don't approve or reject**. Ask the maintainer to weigh in. Use `$QWEN_MAINTAINER_HANDLE` if set.


### PR DESCRIPTION
## What this PR does

Adds an approval guardrail to the `/triage` skill so it never auto-approves a cross-repository (fork) PR whose title is a `refactor` type. Right before the Stage 3 approve step, triage runs a deterministic check on the PR's `isCrossRepository` flag and its title; when both match it skips `gh pr review --approve` and escalates to the maintainer instead. Approval is now gated on a positive condition (the guard must explicitly return `ok`), so a blocked, failed, or empty check never results in an approval. The rule is also documented in the skill's global Rules section so it is visible at the skill entry point.

## Why it's needed

A fork `refactor` PR (#5089, `refactor(core): extract Protocol enum and decouple model identity from auth type`) was auto-approved by triage and merged without a human maintainer reviewing the structural changes. Refactors touch code broadly and a fork author is not a trusted committer, so this class of PR should always get a human decision rather than an automated LGTM. This adds that safety net for future triage runs — both the GitHub Action (`@qwen-code /triage`, PR-opened auto-triage) and local `/triage`.

## Reviewer Test Plan

### How to verify

The guard is the `jq` expression added to Stage 3 of the PR workflow. It returns `block` only when the PR is cross-repository **and** the title starts with `refactor` (case-insensitive). Run it against the motivating PR:

```bash
# Real data: fork + "refactor(core): ..." -> block
gh pr view 5089 --repo QwenLM/qwen-code --json isCrossRepository,title \
  --jq 'if (.isCrossRepository and (.title | test("^\\s*refactor"; "i"))) then "block" else "ok" end'
# => block
```

Expected results for synthetic metadata:

| isCrossRepository | title | result |
| :---: | :--- | :---: |
| true | `refactor(core): x` | block |
| true | `refactor!: x` | block |
| true | `Refactor the x` (no colon) | block |
| true | `feat: refactor the x` | ok |
| false | `refactor(core): x` | ok |
| true | `fix: a bug` | ok |

### Evidence (Before & After)

N/A — this is a skill documentation (prompt) change with no user-visible / TUI surface.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

Verified the guard expression against PR #5089 and 9 boundary cases on macOS. Windows/Linux marked N/A: this is a markdown-only skill doc and the check is plain `gh` + `jq`, which is platform-independent.

### Environment (optional)

Local `gh` + `jq`. No app runtime involved.

## Risk & Scope

- Main risk or tradeoff: the guard keys off the conventional-commit `refactor` title prefix, so a refactor mislabeled as `feat:` / `chore:` would not be caught. This is the known ceiling of a title-based, skill-level rule.
- Not validated / out of scope: hard enforcement at the GitHub Actions layer (e.g. auto-dismissing an approval that slips through) is intentionally not part of this PR.
- Breaking changes / migration notes: none. Only affects whether triage auto-approves; every other triage behavior is unchanged.

## Linked Issues

References #5089 as the motivating incident (no closing keyword — that PR is already merged).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

给 `/triage` skill 加了一道 approve 护栏:对来自 fork(跨仓库)且标题是 `refactor` 类型的 PR,绝不自动 approve。在 Stage 3 执行 approve 之前,triage 会对 PR 的 `isCrossRepository` 标志和标题做一次确定性判定;两者同时命中时跳过 `gh pr review --approve`,改为升级给维护者。现在 approve 是"正向条件"——护栏必须明确返回 `ok` 才批,因此判定被拦、失败或为空时都不会 approve。该规则同时写进 skill 的全局 Rules 区,确保在 skill 入口处就可见。

## 为什么需要

一个 fork 的 refactor PR(#5089,`refactor(core): extract Protocol enum and decouple model identity from auth type`)被 triage 自动 approve 并合入,期间没有维护者人工审查这些结构性改动。重构改动面广,而 fork 作者并非可信的提交者,所以这类 PR 应当始终交由人来决定,而不是自动 LGTM。本 PR 为未来的 triage(GitHub Action 的 `@qwen-code /triage`、PR 打开时的自动 triage,以及本地 `/triage`)补上这道保护。

## 审查测试计划

### 如何验证

护栏就是 PR workflow Stage 3 中新增的那段 `jq` 表达式:仅当 PR 来自跨仓库**且**标题以 `refactor` 开头(大小写不敏感)时返回 `block`。对触发本次问题的 PR 运行:

```bash
# 真实数据:fork + "refactor(core): ..." -> block
gh pr view 5089 --repo QwenLM/qwen-code --json isCrossRepository,title \
  --jq 'if (.isCrossRepository and (.title | test("^\\s*refactor"; "i"))) then "block" else "ok" end'
# => block
```

构造元数据的预期结果:

| isCrossRepository | title | 结果 |
| :---: | :--- | :---: |
| true | `refactor(core): x` | block |
| true | `refactor!: x` | block |
| true | `Refactor the x`(无冒号) | block |
| true | `feat: refactor the x` | ok |
| false | `refactor(core): x` | ok |
| true | `fix: a bug` | ok |

### 证据(改动前后)

N/A —— 这是 skill 文档(prompt)改动,无用户可见 / TUI 界面。

### 测试平台

仅在 macOS 上对 PR #5089 及 9 个边界用例验证了护栏表达式。Windows/Linux 标 N/A:纯 markdown 文档改动,判定只用 `gh` + `jq`,与平台无关。

### 环境(可选)

本地 `gh` + `jq`,不涉及应用运行时。

## 风险与范围

- 主要风险 / 取舍:护栏依据 conventional-commit 的 `refactor` 标题前缀判定,因此被误标成 `feat:` / `chore:` 的重构不会被拦——这是"基于标题、skill 层规则"方案的固有上限。
- 未验证 / 范围外:GitHub Actions 层的硬性兜底(例如自动 dismiss 漏网的 approve)有意不在本 PR 内。
- 破坏性改动 / 迁移说明:无。仅影响 triage 是否自动 approve,其余行为不变。

## 关联 Issue

引用 #5089 作为触发本次改动的事件(不带关闭关键字——该 PR 已合并)。

</details>
