### PR TITLE
fix(cli): only paint theme background when it matches the terminal

### DIFF
--- a/packages/cli/src/ui/components/BaseTextInput.tsx
+++ b/packages/cli/src/ui/components/BaseTextInput.tsx
@@ -32,6 +32,7 @@ import stringWidth from 'string-width';
 import { cpSlice, cpLen } from '../utils/textUtils.js';
 import { theme } from '../semantic-colors.js';
 import { renderSoftwareCursor } from '../utils/software-cursor.js';
+import { getInputBackgroundFill } from '../utils/theme-background.js';
 
 // ─── Types ──────────────────────────────────────────────────
 
@@ -373,7 +374,7 @@ export const BaseTextInput = ({
         <Box
           flexGrow={1}
           flexDirection="column"
-          backgroundColor={theme.background.primary}
+          backgroundColor={getInputBackgroundFill()}
         >
           {buffer.text.length === 0 && placeholder ? (
             showCursor ? (

--- a/packages/cli/src/ui/components/messages/ConversationMessages.tsx
+++ b/packages/cli/src/ui/components/messages/ConversationMessages.tsx
@@ -24,6 +24,7 @@ import {
 import { t } from '../../../i18n/index.js';
 import { getCachedStringWidth } from '../../utils/textUtils.js';
 import { formatDuration } from '../../utils/displayUtils.js';
+import { themeBackgroundMatchesTerminal } from '../../utils/theme-background.js';
 
 const isUtf8 = /utf-?8/i.test(
   process.env['LANG'] || process.env['LC_ALL'] || '',
@@ -212,6 +213,10 @@ export const UserMessage: React.FC<UserMessageProps> = ({ text, width }) => {
     width > 0 &&
     !isScreenReaderEnabled &&
     !!theme.background.primary &&
+    // The band paints the theme background behind every user message; only do
+    // so when it matches the terminal, else (e.g. a light theme forced onto a
+    // dark terminal) it renders as bright stripes fighting the surroundings.
+    themeBackgroundMatchesTerminal() &&
     supportsTrueColor();
 
   const fallback = (

--- a/packages/cli/src/ui/themes/theme-manager.ts
+++ b/packages/cli/src/ui/themes/theme-manager.ts
@@ -29,6 +29,7 @@ import { NoColorTheme } from './no-color.js';
 import process from 'node:process';
 import { createDebugLogger } from '@qwen-code/qwen-code-core';
 import {
+  type DetectedTheme,
   detectTerminalTheme,
   detectTerminalThemeAsync,
 } from './detect-terminal-theme.js';
@@ -156,6 +157,14 @@ class ThemeManager {
   private cachedAutoDetection: 'dark' | 'light' | undefined;
 
   /**
+   * Memoised synchronous detection of the terminal's background brightness,
+   * used when no async OSC 11 result is available (e.g. an explicitly
+   * configured theme, for which the startup probe never runs). Detected at
+   * most once per process.
+   */
+  private terminalBackground: DetectedTheme | undefined;
+
+  /**
    * Detects the terminal's dark/light preference (synchronous) and returns
    * the corresponding Qwen theme.
    * Used by the theme dialog for instant preview. Prefers the cached
@@ -178,6 +187,22 @@ class ThemeManager {
     this.cachedAutoDetection = detected;
     this.activeTheme = detected === 'light' ? QwenLight : QwenDark;
     debugLogger.info(`Auto-detected theme (async): ${this.activeTheme.name}`);
+  }
+
+  /**
+   * Returns the terminal's detected background brightness ('dark' | 'light').
+   *
+   * Prefers the accurate async OSC 11 result captured at startup (for 'auto'
+   * themes); otherwise falls back to a memoised synchronous heuristic
+   * (COLORFGBG → macOS appearance → default dark). Lets UI code decide whether
+   * the active theme's background matches the terminal without re-probing.
+   */
+  getTerminalBackgroundType(): DetectedTheme {
+    if (this.cachedAutoDetection) {
+      return this.cachedAutoDetection;
+    }
+    this.terminalBackground ??= detectTerminalTheme();
+    return this.terminalBackground;
   }
 
   /**

--- a/packages/cli/src/ui/utils/software-cursor.test.ts
+++ b/packages/cli/src/ui/utils/software-cursor.test.ts
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import {
   getSoftwareCursorBackground,
   renderSoftwareCursor,
 } from './software-cursor.js';
+import { themeManager } from '../themes/theme-manager.js';
 
 describe('renderSoftwareCursor', () => {
   it('uses a dark cursor background on light themes', () => {
@@ -43,5 +44,46 @@ describe('renderSoftwareCursor', () => {
 
   it('renders an empty cursor cell as a space', () => {
     expect(renderSoftwareCursor('')).toContain(' ');
+  });
+});
+
+describe('getSoftwareCursorBackground theme-derived default', () => {
+  function setDetectedTerminal(value: 'dark' | 'light') {
+    (
+      themeManager as unknown as { cachedAutoDetection: 'dark' | 'light' }
+    ).cachedAutoDetection = value;
+  }
+
+  beforeEach(() => {
+    (
+      themeManager as unknown as {
+        cachedAutoDetection: unknown;
+        terminalBackground: unknown;
+      }
+    ).cachedAutoDetection = undefined;
+    (
+      themeManager as unknown as { terminalBackground: unknown }
+    ).terminalBackground = undefined;
+  });
+
+  it('contrasts against the theme background when it matches the terminal', () => {
+    themeManager.setActiveTheme('Qwen Dark');
+    setDetectedTerminal('dark');
+    expect(getSoftwareCursorBackground()).toBe('#D4D4D4');
+  });
+
+  it('stays visible (light cursor) for a light theme forced onto a dark terminal', () => {
+    themeManager.setActiveTheme('Qwen Light');
+    setDetectedTerminal('dark');
+    // Without the terminal-aware default this would contrast against the light
+    // theme background and render a dark, near-invisible cursor on the dark
+    // terminal.
+    expect(getSoftwareCursorBackground()).toBe('#D4D4D4');
+  });
+
+  it('stays visible (dark cursor) for a dark theme forced onto a light terminal', () => {
+    themeManager.setActiveTheme('Qwen Dark');
+    setDetectedTerminal('light');
+    expect(getSoftwareCursorBackground()).toBe('#3A3A3A');
   });
 });

--- a/packages/cli/src/ui/utils/software-cursor.ts
+++ b/packages/cli/src/ui/utils/software-cursor.ts
@@ -5,8 +5,8 @@
  */
 
 import chalk from 'chalk';
-import { theme } from '../semantic-colors.js';
 import { resolveColor } from '../themes/color-utils.js';
+import { getEffectiveInputBackground } from './theme-background.js';
 
 const LIGHT_CURSOR_BACKGROUND = '#D4D4D4';
 const DARK_CURSOR_BACKGROUND = '#3A3A3A';
@@ -51,7 +51,7 @@ function toHex(color: string): string | undefined {
 }
 
 export function getSoftwareCursorBackground(
-  backgroundColor = theme.background?.primary ?? '',
+  backgroundColor = getEffectiveInputBackground(),
 ): string {
   const hex = backgroundColor ? toHex(backgroundColor) : undefined;
   if (!hex) {

--- a/packages/cli/src/ui/utils/theme-background.test.ts
+++ b/packages/cli/src/ui/utils/theme-background.test.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  getEffectiveInputBackground,
+  getInputBackgroundFill,
+  themeBackgroundMatchesTerminal,
+} from './theme-background.js';
+import { themeManager } from '../themes/theme-manager.js';
+import { theme } from '../semantic-colors.js';
+import type { CustomTheme } from '../themes/theme.js';
+
+const customTheme: CustomTheme = {
+  type: 'custom',
+  name: 'MyCustomTheme',
+  Background: '#102030',
+  Foreground: '#ffffff',
+  LightBlue: '#89BDCD',
+  AccentBlue: '#3B82F6',
+  AccentPurple: '#8B5CF6',
+  AccentCyan: '#06B6D4',
+  AccentGreen: '#3CA84B',
+  AccentYellow: 'yellow',
+  AccentRed: 'red',
+  DiffAdded: 'green',
+  DiffRemoved: 'red',
+  Comment: 'gray',
+  Gray: 'gray',
+};
+
+// Force the terminal background detection result without probing the real
+// terminal: cachedAutoDetection takes precedence in getTerminalBackgroundType.
+function setDetectedTerminal(value: 'dark' | 'light') {
+  (
+    themeManager as unknown as { cachedAutoDetection: 'dark' | 'light' }
+  ).cachedAutoDetection = value;
+}
+
+describe('theme-background', () => {
+  beforeEach(() => {
+    // themeManager is a module-level singleton; reset state so ordering is not
+    // load-bearing across tests.
+    themeManager.loadCustomThemes({});
+    (
+      themeManager as unknown as {
+        cachedAutoDetection: unknown;
+        terminalBackground: unknown;
+      }
+    ).cachedAutoDetection = undefined;
+    (
+      themeManager as unknown as { terminalBackground: unknown }
+    ).terminalBackground = undefined;
+  });
+
+  describe('themeBackgroundMatchesTerminal', () => {
+    it('matches when a light theme runs on a light terminal', () => {
+      themeManager.setActiveTheme('Qwen Light');
+      setDetectedTerminal('light');
+      expect(themeBackgroundMatchesTerminal()).toBe(true);
+    });
+
+    it('matches when a dark theme runs on a dark terminal', () => {
+      themeManager.setActiveTheme('Qwen Dark');
+      setDetectedTerminal('dark');
+      expect(themeBackgroundMatchesTerminal()).toBe(true);
+    });
+
+    it('does not match a light theme forced onto a dark terminal', () => {
+      themeManager.setActiveTheme('Qwen Light');
+      setDetectedTerminal('dark');
+      expect(themeBackgroundMatchesTerminal()).toBe(false);
+    });
+
+    it('does not match a dark theme forced onto a light terminal', () => {
+      themeManager.setActiveTheme('Qwen Dark');
+      setDetectedTerminal('light');
+      expect(themeBackgroundMatchesTerminal()).toBe(false);
+    });
+
+    it('treats custom themes as matching (brightness cannot be classified)', () => {
+      themeManager.loadCustomThemes({ MyCustomTheme: customTheme });
+      themeManager.setActiveTheme('MyCustomTheme');
+      setDetectedTerminal('light');
+      expect(themeBackgroundMatchesTerminal()).toBe(true);
+    });
+  });
+
+  describe('getInputBackgroundFill', () => {
+    it('fills with the theme background when it matches the terminal', () => {
+      themeManager.setActiveTheme('Qwen Light');
+      setDetectedTerminal('light');
+      expect(getInputBackgroundFill()).toBe(theme.background.primary);
+    });
+
+    it('leaves the box transparent when the theme fights the terminal', () => {
+      themeManager.setActiveTheme('Qwen Light');
+      setDetectedTerminal('dark');
+      expect(getInputBackgroundFill()).toBeUndefined();
+    });
+  });
+
+  describe('getEffectiveInputBackground', () => {
+    it('returns the theme background when it matches the terminal', () => {
+      themeManager.setActiveTheme('Qwen Dark');
+      setDetectedTerminal('dark');
+      expect(getEffectiveInputBackground()).toBe(theme.background.primary);
+    });
+
+    it('returns a dark stand-in for a light theme on a dark terminal', () => {
+      themeManager.setActiveTheme('Qwen Light');
+      setDetectedTerminal('dark');
+      expect(getEffectiveInputBackground()).toBe('#000000');
+    });
+
+    it('returns a light stand-in for a dark theme on a light terminal', () => {
+      themeManager.setActiveTheme('Qwen Dark');
+      setDetectedTerminal('light');
+      expect(getEffectiveInputBackground()).toBe('#ffffff');
+    });
+  });
+});

--- a/packages/cli/src/ui/utils/theme-background.ts
+++ b/packages/cli/src/ui/utils/theme-background.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { theme } from '../semantic-colors.js';
+import { themeManager } from '../themes/theme-manager.js';
+
+// Representative terminal background colours used only for luminance-based
+// decisions (e.g. software cursor contrast) when the active theme's background
+// does not match the terminal and therefore isn't painted. Only the
+// light/dark bucket matters, so pure black/white are the safest stand-ins.
+const DARK_TERMINAL_BACKGROUND = '#000000';
+const LIGHT_TERMINAL_BACKGROUND = '#ffffff';
+
+/**
+ * Whether the active theme's background brightness agrees with the terminal's
+ * detected background.
+ *
+ * The TUI paints no global background — almost everything relies on the
+ * terminal's own background. So a component may only flood itself with the
+ * theme background when that background actually matches the terminal;
+ * otherwise (e.g. a user forcing "Qwen Light" onto a dark terminal) the fill
+ * renders as a bright block fighting the dark surroundings.
+ *
+ * Themes whose type is 'ansi' or 'custom' can't be classified as light/dark,
+ * so they're treated as matching to preserve existing behaviour.
+ */
+export function themeBackgroundMatchesTerminal(): boolean {
+  const activeType = themeManager.getActiveTheme().type;
+  if (activeType !== 'light' && activeType !== 'dark') {
+    return true;
+  }
+  return activeType === themeManager.getTerminalBackgroundType();
+}
+
+/**
+ * The colour to flood-fill the input box content area with, or `undefined` to
+ * leave it transparent so it blends into the terminal when the active theme
+ * fights the terminal background.
+ */
+export function getInputBackgroundFill(): string | undefined {
+  return themeBackgroundMatchesTerminal()
+    ? theme.background?.primary
+    : undefined;
+}
+
+/**
+ * The brightness-representative colour the input area actually shows on screen:
+ * the theme background when it matches the terminal, otherwise a stand-in for
+ * the terminal's own background. Used for derived decisions such as software
+ * cursor contrast, which must stay correct even when no fill is painted.
+ */
+export function getEffectiveInputBackground(): string {
+  if (themeBackgroundMatchesTerminal()) {
+    return theme.background?.primary ?? '';
+  }
+  return themeManager.getTerminalBackgroundType() === 'light'
+    ? LIGHT_TERMINAL_BACKGROUND
+    : DARK_TERMINAL_BACKGROUND;
+}


### PR DESCRIPTION
## What this PR does

Makes the input box and the user-message highlight band paint the theme background **only when the active theme's brightness matches the terminal's**. When they don't match — for example a user setting `"ui": { "theme": "Qwen Light" }` while running in a dark terminal — those elements now stay transparent and blend into the terminal instead of rendering a bright block. A new `themeManager.getTerminalBackgroundType()` exposes the terminal's detected brightness, and the software cursor's contrast is derived from the same "effective background" so it stays visible even when no fill is painted.

## Why it's needed

The TUI paints no global background — almost the entire interface relies on the terminal's own background. The input box (since #5568, which fixed #5562's wrapped-line gaps) and the user-message band are the exceptions: they flood themselves with `theme.background.primary`. That only looks right when the chosen theme's background matches the terminal. Forcing a light theme onto a dark terminal (or vice-versa) therefore painted a near-white input box and bright bands behind every user message, clashing with the otherwise-dark UI. Simply removing the fill would re-introduce #5562 for matched setups and, because the software cursor's contrast is derived from the same colour, would make the cursor invisible on the mismatched terminal — so the fill and the cursor must be handled together.

## Reviewer Test Plan

### How to verify

1. Use a **dark** terminal.
2. Set `"ui": { "theme": "Qwen Light" }` in `settings.json` (an explicit light theme, not `auto`).
3. Launch the interactive TUI (`npm run dev`, or a built `qwen`).
4. Observe the bottom input box and any user message.

Expected after this PR: the input box and user-message bands share the terminal's dark background (no bright rectangle/stripes), and the text cursor stays visible. Before: the input box was filled near-white (`#f8f9fa`) and user-message bands were bright, fighting the dark surroundings. The matched case (e.g. Qwen Dark on a dark terminal, or any `auto` theme) is unchanged.

Automated checks, run locally and all green: `tsc --noEmit`, ESLint on every changed file, and `vitest` across the affected areas (567 passing). New unit tests in `theme-background.test.ts` and the additions to `software-cursor.test.ts` lock the decision: theme background when matched, transparent when not, and a still-visible (light) cursor in the light-theme-on-dark-terminal case.

### Evidence (Before & After)

This is gated behaviour on an existing render prop; the before/after is described above and locked by the new unit tests (the input fill returns `undefined`, and the cursor flips to a light block, in the light-on-dark case). A live tmux before/after capture can be added on request.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS ✅ = `tsc --noEmit` + ESLint + 567 vitest tests green locally. A live cross-terminal visual A/B has not yet been captured.

### Environment (optional)

N/A — local `vitest` / `tsc` / `eslint` only.

## Risk & Scope

- Main risk or tradeoff: purely visual. Matched setups — the common case, including every `auto` theme — render identically to today. `ansi`/`custom` themes can't be classified as light or dark and are treated as matching, so their behaviour is unchanged.
- Not validated / out of scope: a live cross-terminal visual capture. Modal dialogs (`PermissionsDialog`, `StatsDialog`, tab bars, …) deliberately keep painting `theme.background.primary` — a floating panel is meant to have a delineating background, unlike inline content, so they are intentionally left alone.
- Breaking changes / migration notes: none.

## Linked Issues

Refines #5568 / #5562 (the input-box background fill) rather than reverting them — no closing keyword.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让输入框和用户消息的高亮色带**只在当前主题亮度与终端一致时**才绘制主题背景。当二者不一致时——例如用户在深色终端里设置了 `"ui": { "theme": "Qwen Light" }`——这些元素现在保持透明、融入终端，而不是渲染成一个亮色块。新增的 `themeManager.getTerminalBackgroundType()` 暴露终端检测到的亮度；软光标的对比色也改为从同一个“有效背景”推导，因此即使不绘制填充，光标依然可见。

## 为什么需要它

这个 TUI 不绘制全局背景——几乎整个界面都依赖终端自身的背景色。输入框（自 #5568 起，该 PR 修了 #5562 的换行空洞）和用户消息色带是例外：它们用 `theme.background.primary` 给自己刷背景。这只有在所选主题的背景与终端一致时才好看。把亮色主题强加到深色终端上（或反之），就会把输入框刷成近白色、把每条用户消息后面的色带刷成亮色，与原本深色的界面冲突。单纯去掉填充会让一致场景重新出现 #5562 的空洞；而且由于软光标的对比色也来自同一个颜色，去掉填充会让光标在不一致的终端上变得不可见——所以填充和光标必须一起处理。

## Reviewer 验证步骤

### 如何验证

1. 使用**深色**终端。
2. 在 `settings.json` 中设置 `"ui": { "theme": "Qwen Light" }`（显式选亮色主题，而非 `auto`）。
3. 启动交互式 TUI（`npm run dev`，或已构建的 `qwen`）。
4. 观察底部输入框和任意一条用户消息。

本 PR 之后的期望：输入框与用户消息色带都与终端的深色背景一致（没有亮色矩形/条带），且文本光标保持可见。修复前：输入框被刷成近白色（`#f8f9fa`），用户消息色带为亮色，与深色环境冲突。一致场景（如深色终端 + Qwen Dark，或任意 `auto` 主题）行为不变。

本地自动化检查全部通过：`tsc --noEmit`、对所有改动文件跑 ESLint、以及在相关范围跑 `vitest`（567 项通过）。`theme-background.test.ts` 中的新单测与 `software-cursor.test.ts` 的新增用例锁定了该决策：一致时用主题背景、不一致时透明，且在“亮色主题 + 深色终端”场景下光标仍为可见的亮色。

### 证据（前 & 后）

这是在既有渲染属性上加的条件分支；前后差异已在上文描述，并由新单测锁定（不一致场景下输入填充返回 `undefined`、光标翻转为亮色块）。如有需要可补充真实 tmux 的前后对比截图。

### 测试平台

macOS ✅ = 本地 `tsc --noEmit` + ESLint + 567 项 vitest 通过。尚未做跨终端的真实视觉前后对比。

### 运行环境（可选）

N/A —— 仅本地 `vitest` / `tsc` / `eslint`。

## 风险与范围

- 主要风险或权衡：纯视觉改动。一致场景（常见情况，含所有 `auto` 主题）与当前完全一致。`ansi`/`custom` 主题无法判定明暗，按“一致”处理，行为不变。
- 未验证 / 范围之外：跨终端的真实视觉截图。模态对话框（`PermissionsDialog`、`StatsDialog`、标签栏等）有意继续绘制 `theme.background.primary`——浮层面板本就应有用于区隔的背景，与内联内容不同，因此刻意不动它们。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

是对 #5568 / #5562（输入框背景填充）的**改进**而非回退——不使用自动关闭关键字。

</details>
