### PR TITLE
fix(packaging): bundle audio capture for mirror installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -400,6 +400,8 @@ jobs:
           path: 'packages/audio-capture/prebuilds'
 
       - name: 'Build Bundle and Prepare Package'
+        env:
+          QWEN_REQUIRE_AUDIO_CAPTURE_PREBUILD: "${{ github.repository == 'QwenLM/qwen-code' && '1' || '' }}"
         run: |-
           npm run bundle
           npm run prepare:package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -391,11 +391,6 @@ jobs:
             echo "Dry run enabled. Skipping push."
           fi
 
-      - name: 'Build Bundle and Prepare Package'
-        run: |-
-          npm run bundle
-          npm run prepare:package
-
       - name: 'Download audio capture prebuilds'
         if: |-
           ${{ github.repository == 'QwenLM/qwen-code' }}
@@ -403,6 +398,11 @@ jobs:
         with:
           name: 'audio-capture-prebuilds'
           path: 'packages/audio-capture/prebuilds'
+
+      - name: 'Build Bundle and Prepare Package'
+        run: |-
+          npm run bundle
+          npm run prepare:package
 
       - name: 'Build Standalone Archives'
         env:

--- a/packages/cli/src/ui/voice/native-audio-recorder.test.ts
+++ b/packages/cli/src/ui/voice/native-audio-recorder.test.ts
@@ -173,6 +173,27 @@ describe('createNativeAudioRecorder', () => {
     await expect(recorder.start()).rejects.toThrow(/@qwen-code\/audio-capture/);
   });
 
+  it('does not explain native start failures as missing packages', async () => {
+    const startError = new Error(
+      "Cannot find package '@qwen-code/audio-capture' while starting",
+    );
+    const backend = {
+      startRecording: vi.fn(() => {
+        throw startError;
+      }),
+      stopRecording: vi.fn(() => new Uint8Array([1])),
+      isRecording: vi.fn(() => false),
+      microphoneAuthorizationStatus: vi.fn(() => 'unknown' as const),
+    };
+    const recorder = createNativeAudioRecorder({
+      loadBackend: () => backend,
+    });
+
+    await expect(recorder.start()).rejects.toBe(startError);
+
+    expect(backend.startRecording).toHaveBeenCalledTimes(1);
+  });
+
   it('allows retry after native stop throws', async () => {
     const backend = {
       startRecording: vi.fn(),

--- a/packages/cli/src/ui/voice/native-audio-recorder.test.ts
+++ b/packages/cli/src/ui/voice/native-audio-recorder.test.ts
@@ -158,6 +158,21 @@ describe('createNativeAudioRecorder', () => {
     expect(backend.startRecording).toHaveBeenCalledTimes(1);
   });
 
+  it('explains mirror registry installs when the native package is missing', async () => {
+    const recorder = createNativeAudioRecorder({
+      loadBackend: () => {
+        throw new Error(
+          "Cannot find package '@qwen-code/audio-capture' imported from /qwen/dist/cli.js",
+        );
+      },
+    });
+
+    await expect(recorder.start()).rejects.toThrow(
+      /mirror or private registry/,
+    );
+    await expect(recorder.start()).rejects.toThrow(/@qwen-code\/audio-capture/);
+  });
+
   it('allows retry after native stop throws', async () => {
     const backend = {
       startRecording: vi.fn(),

--- a/packages/cli/src/ui/voice/native-audio-recorder.test.ts
+++ b/packages/cli/src/ui/voice/native-audio-recorder.test.ts
@@ -173,6 +173,28 @@ describe('createNativeAudioRecorder', () => {
     await expect(recorder.start()).rejects.toThrow(/@qwen-code\/audio-capture/);
   });
 
+  it.each(['ERR_MODULE_NOT_FOUND', 'MODULE_NOT_FOUND'])(
+    'explains mirror registry installs for %s native package errors',
+    async (code) => {
+      const error = Object.assign(
+        new Error('missing @qwen-code/audio-capture dependency'),
+        { code },
+      );
+      const recorder = createNativeAudioRecorder({
+        loadBackend: () => {
+          throw error;
+        },
+      });
+
+      await expect(recorder.start()).rejects.toThrow(
+        /mirror or private registry/,
+      );
+      await expect(recorder.start()).rejects.toThrow(
+        /@qwen-code\/audio-capture/,
+      );
+    },
+  );
+
   it('does not explain native start failures as missing packages', async () => {
     const startError = new Error(
       "Cannot find package '@qwen-code/audio-capture' while starting",

--- a/packages/cli/src/ui/voice/native-audio-recorder.test.ts
+++ b/packages/cli/src/ui/voice/native-audio-recorder.test.ts
@@ -195,6 +195,19 @@ describe('createNativeAudioRecorder', () => {
     },
   );
 
+  it('does not rewrite wrapped native addon load failures as missing packages', async () => {
+    const loadError = new Error(
+      "Native audio capture addon could not be loaded. Reinstall @qwen-code/audio-capture, or use the SoX fallback. (Cannot find module 'node-gyp-build')",
+    );
+    const recorder = createNativeAudioRecorder({
+      loadBackend: () => {
+        throw loadError;
+      },
+    });
+
+    await expect(recorder.start()).rejects.toBe(loadError);
+  });
+
   it('does not explain native start failures as missing packages', async () => {
     const startError = new Error(
       "Cannot find package '@qwen-code/audio-capture' while starting",

--- a/packages/cli/src/ui/voice/native-audio-recorder.ts
+++ b/packages/cli/src/ui/voice/native-audio-recorder.ts
@@ -15,6 +15,7 @@ import type {
 // Native silence detection sets a flag we poll for; older addons lack it.
 const SILENCE_POLL_INTERVAL_MS = 200;
 const debugLogger = createDebugLogger('VOICE_NATIVE_RECORDER');
+const AUDIO_CAPTURE_PACKAGE = '@qwen-code/audio-capture';
 
 interface NativeAudioRecorderOptions {
   loadBackend?: () =>
@@ -101,7 +102,7 @@ class NativeAudioRecorder implements VoiceRecorder {
       }
     } catch (error) {
       this.starting = false;
-      throw error;
+      throw explainMissingNativePackage(error);
     }
   }
 
@@ -128,6 +129,31 @@ async function loadDefaultBackend(): Promise<NativeAudioCaptureBackend> {
     '@qwen-code/audio-capture'
   );
   return createNativeAudioCaptureBackend();
+}
+
+function explainMissingNativePackage(error: unknown): unknown {
+  if (!(error instanceof Error) || !isMissingNativePackageError(error)) {
+    return error;
+  }
+
+  return new Error(
+    `Native voice capture package '${AUDIO_CAPTURE_PACKAGE}' is missing. ` +
+      'If Qwen Code was installed from a mirror or private registry, the ' +
+      'registry may not have synced this optional package. Reinstall from ' +
+      'https://registry.npmjs.org or make sure the configured registry ' +
+      `provides ${AUDIO_CAPTURE_PACKAGE}. (${error.message})`,
+    { cause: error },
+  );
+}
+
+function isMissingNativePackageError(error: Error): boolean {
+  return (
+    error.message.includes(AUDIO_CAPTURE_PACKAGE) &&
+    (error.message.includes('Cannot find package') ||
+      error.message.includes('Cannot find module') ||
+      (error as NodeJS.ErrnoException).code === 'ERR_MODULE_NOT_FOUND' ||
+      (error as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND')
+  );
 }
 
 export function createNativeAudioRecorder(

--- a/packages/cli/src/ui/voice/native-audio-recorder.ts
+++ b/packages/cli/src/ui/voice/native-audio-recorder.ts
@@ -106,7 +106,7 @@ class NativeAudioRecorder implements VoiceRecorder {
       }
     } catch (error) {
       this.starting = false;
-      throw explainMissingNativePackage(error);
+      throw error;
     }
   }
 

--- a/packages/cli/src/ui/voice/native-audio-recorder.ts
+++ b/packages/cli/src/ui/voice/native-audio-recorder.ts
@@ -72,7 +72,11 @@ class NativeAudioRecorder implements VoiceRecorder {
     this.starting = true;
     let backend: NativeAudioCaptureBackend;
     try {
-      backend = await this.loadBackend();
+      try {
+        backend = await this.loadBackend();
+      } catch (loadError) {
+        throw explainMissingNativePackage(loadError);
+      }
       const silenceDetection = options.silenceDetection === true;
       backend.startRecording({
         sampleRate: 16000,
@@ -136,6 +140,11 @@ function explainMissingNativePackage(error: unknown): unknown {
     return error;
   }
 
+  debugLogger.warn(
+    '[voice] native package missing:',
+    error.message,
+    (error as NodeJS.ErrnoException).code,
+  );
   return new Error(
     `Native voice capture package '${AUDIO_CAPTURE_PACKAGE}' is missing. ` +
       'If Qwen Code was installed from a mirror or private registry, the ' +

--- a/packages/cli/src/ui/voice/native-audio-recorder.ts
+++ b/packages/cli/src/ui/voice/native-audio-recorder.ts
@@ -156,12 +156,15 @@ function explainMissingNativePackage(error: unknown): unknown {
 }
 
 function isMissingNativePackageError(error: Error): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  if (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') {
+    return error.message.includes(AUDIO_CAPTURE_PACKAGE);
+  }
+
   return (
     error.message.includes(AUDIO_CAPTURE_PACKAGE) &&
-    (error.message.includes('Cannot find package') ||
-      error.message.includes('Cannot find module') ||
-      (error as NodeJS.ErrnoException).code === 'ERR_MODULE_NOT_FOUND' ||
-      (error as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND')
+    (error.message.startsWith('Cannot find package') ||
+      error.message.startsWith('Cannot find module'))
   );
 }
 

--- a/scripts/prepare-package.js
+++ b/scripts/prepare-package.js
@@ -211,7 +211,7 @@ function copyNativeAudioCapturePackage(rootDir, distDir, { required } = {}) {
   );
   fs.cpSync(path.join(addonSrc, 'dist'), path.join(addonDest, 'dist'), {
     ...copyOpts,
-    filter: (src) => !/\.test\.(d\.)?[mc]?[jt]s(\.map)?$/.test(src),
+    filter: (src) => !/\.(test|spec)\.(d\.)?[mc]?[jt]s(\.map)?$/.test(src),
   });
   fs.cpSync(
     path.join(addonSrc, 'prebuilds'),

--- a/scripts/prepare-package.js
+++ b/scripts/prepare-package.js
@@ -160,24 +160,40 @@ function copyNativeAudioCapturePackage(rootDir, distDir) {
     }
   }
 
-  fs.rmSync(addonDest, { recursive: true, force: true });
-  fs.mkdirSync(addonDest, { recursive: true });
-
   const addonPkg = JSON.parse(
     fs.readFileSync(path.join(addonSrc, 'package.json'), 'utf8'),
   );
+  const dependencySources = [];
+  for (const dependencyName of Object.keys(addonPkg.dependencies ?? {})) {
+    try {
+      dependencySources.push([
+        dependencyName,
+        path.dirname(nodeRequire.resolve(`${dependencyName}/package.json`)),
+      ]);
+    } catch {
+      console.warn(
+        `Warning: audio capture dependency not resolvable: ${dependencyName}`,
+      );
+      return false;
+    }
+  }
+
   delete addonPkg.scripts;
   delete addonPkg.devDependencies;
-  fs.writeFileSync(
-    path.join(addonDest, 'package.json'),
-    JSON.stringify(addonPkg, null, 2) + '\n',
-  );
 
   const copyOpts = {
     recursive: true,
     dereference: true,
     verbatimSymlinks: false,
   };
+
+  fs.rmSync(addonDest, { recursive: true, force: true });
+  fs.mkdirSync(addonDest, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(addonDest, 'package.json'),
+    JSON.stringify(addonPkg, null, 2) + '\n',
+  );
   fs.cpSync(path.join(addonSrc, 'dist'), path.join(addonDest, 'dist'), {
     ...copyOpts,
     filter: (src) => !/\.test\.(d\.)?[mc]?[jt]s(\.map)?$/.test(src),
@@ -188,14 +204,13 @@ function copyNativeAudioCapturePackage(rootDir, distDir) {
     copyOpts,
   );
 
-  const nodeGypBuildSrc = path.dirname(
-    nodeRequire.resolve('node-gyp-build/package.json'),
-  );
-  fs.cpSync(
-    nodeGypBuildSrc,
-    path.join(addonDest, 'node_modules', 'node-gyp-build'),
-    copyOpts,
-  );
+  for (const [dependencyName, dependencySrc] of dependencySources) {
+    fs.cpSync(
+      dependencySrc,
+      path.join(addonDest, 'node_modules', dependencyName),
+      copyOpts,
+    );
+  }
 
   console.log('Copied native audio capture package');
   return true;

--- a/scripts/prepare-package.js
+++ b/scripts/prepare-package.js
@@ -18,7 +18,7 @@ import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const defaultRootDir = path.resolve(__dirname, '..');
-const nodeRequire = createRequire(import.meta.url);
+const TEST_FILE_RE = /\.(test|spec)\.(d\.)?[mc]?[jt]s(\.map)?$/;
 
 export function preparePackage({
   rootDir = defaultRootDir,
@@ -156,6 +156,8 @@ function copyNativeAudioCapturePackage(rootDir, distDir, { required } = {}) {
     path.join(addonSrc, 'package.json'),
   ];
 
+  fs.rmSync(addonDest, { recursive: true, force: true });
+
   for (const requiredPath of requiredPaths) {
     if (!fs.existsSync(requiredPath)) {
       const message = `audio capture package artifact not found at ${requiredPath}`;
@@ -173,9 +175,7 @@ function copyNativeAudioCapturePackage(rootDir, distDir, { required } = {}) {
     [
       path.join(addonSrc, 'dist'),
       'runtime JS',
-      (filePath) =>
-        /\.[cm]?js$/.test(filePath) &&
-        !/\.(test|spec)\.(d\.)?[mc]?[jt]s(\.map)?$/.test(filePath),
+      (filePath) => /\.[cm]?js$/.test(filePath) && !TEST_FILE_RE.test(filePath),
     ],
     [
       path.join(addonSrc, 'prebuilds'),
@@ -216,11 +216,12 @@ function copyNativeAudioCapturePackage(rootDir, distDir, { required } = {}) {
     return false;
   }
   const dependencySources = [];
+  const addonRequire = createRequire(path.join(addonSrc, 'package.json'));
   for (const dependencyName of Object.keys(addonPkg.dependencies ?? {})) {
     try {
       dependencySources.push([
         dependencyName,
-        path.dirname(nodeRequire.resolve(`${dependencyName}/package.json`)),
+        path.dirname(addonRequire.resolve(`${dependencyName}/package.json`)),
       ]);
     } catch {
       const message = `audio capture dependency not resolvable: ${dependencyName}`;
@@ -244,7 +245,6 @@ function copyNativeAudioCapturePackage(rootDir, distDir, { required } = {}) {
     verbatimSymlinks: false,
   };
 
-  fs.rmSync(addonDest, { recursive: true, force: true });
   fs.mkdirSync(addonDest, { recursive: true });
 
   fs.writeFileSync(
@@ -253,12 +253,18 @@ function copyNativeAudioCapturePackage(rootDir, distDir, { required } = {}) {
   );
   fs.cpSync(path.join(addonSrc, 'dist'), path.join(addonDest, 'dist'), {
     ...copyOpts,
-    filter: (src) => !/\.(test|spec)\.(d\.)?[mc]?[jt]s(\.map)?$/.test(src),
+    filter: (src) => !TEST_FILE_RE.test(src),
   });
   fs.cpSync(
     path.join(addonSrc, 'prebuilds'),
     path.join(addonDest, 'prebuilds'),
-    copyOpts,
+    {
+      ...copyOpts,
+      filter: (src) => {
+        const stat = fs.statSync(src);
+        return stat.isDirectory() || src.endsWith('.node');
+      },
+    },
   );
 
   for (const [dependencyName, dependencySrc] of dependencySources) {
@@ -276,9 +282,10 @@ function copyNativeAudioCapturePackage(rootDir, distDir, { required } = {}) {
 function hasFileMatching(dir, predicate) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const entryPath = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
+    const stat = fs.statSync(entryPath);
+    if (stat.isDirectory()) {
       if (hasFileMatching(entryPath, predicate)) return true;
-    } else if (entry.isFile() && predicate(entryPath)) {
+    } else if (stat.isFile() && predicate(entryPath)) {
       return true;
     }
   }

--- a/scripts/prepare-package.js
+++ b/scripts/prepare-package.js
@@ -20,7 +20,11 @@ const __dirname = path.dirname(__filename);
 const defaultRootDir = path.resolve(__dirname, '..');
 const nodeRequire = createRequire(import.meta.url);
 
-export function preparePackage({ rootDir = defaultRootDir } = {}) {
+export function preparePackage({
+  rootDir = defaultRootDir,
+  requireNativeAudioCapture = process.env
+    .QWEN_REQUIRE_AUDIO_CAPTURE_PREBUILD === '1',
+} = {}) {
   const distDir = path.join(rootDir, 'dist');
 
   verifyBundleArtifacts(rootDir, distDir);
@@ -30,6 +34,7 @@ export function preparePackage({ rootDir = defaultRootDir } = {}) {
   const bundleNativeAudioCapture = copyNativeAudioCapturePackage(
     rootDir,
     distDir,
+    { required: requireNativeAudioCapture },
   );
   writeDistPackageJson(rootDir, distDir, { bundleNativeAudioCapture });
   printPackageStructure(distDir);
@@ -135,7 +140,7 @@ function copyExtensionExamples(rootDir, distDir) {
   }
 }
 
-function copyNativeAudioCapturePackage(rootDir, distDir) {
+function copyNativeAudioCapturePackage(rootDir, distDir, { required } = {}) {
   console.log('Copying native audio capture package...');
 
   const addonSrc = path.join(rootDir, 'packages', 'audio-capture');
@@ -153,10 +158,15 @@ function copyNativeAudioCapturePackage(rootDir, distDir) {
 
   for (const requiredPath of requiredPaths) {
     if (!fs.existsSync(requiredPath)) {
-      throw new Error(
-        `Required audio capture artifact missing: ${requiredPath}. ` +
-          'Cannot publish package without native voice capture.',
-      );
+      const message = `audio capture package artifact not found at ${requiredPath}`;
+      if (required) {
+        throw new Error(
+          `Required ${message}. ` +
+            'Cannot publish package without native voice capture.',
+        );
+      }
+      console.warn(`Warning: ${message}`);
+      return false;
     }
   }
 

--- a/scripts/prepare-package.js
+++ b/scripts/prepare-package.js
@@ -181,10 +181,15 @@ function copyNativeAudioCapturePackage(rootDir, distDir, { required } = {}) {
         path.dirname(nodeRequire.resolve(`${dependencyName}/package.json`)),
       ]);
     } catch {
-      throw new Error(
-        `Required audio capture dependency not resolvable: ${dependencyName}. ` +
-          'Cannot publish package without native voice capture.',
-      );
+      const message = `audio capture dependency not resolvable: ${dependencyName}`;
+      if (required) {
+        throw new Error(
+          `Required ${message}. ` +
+            'Cannot publish package without native voice capture.',
+        );
+      }
+      console.warn(`Warning: ${message}`);
+      return false;
     }
   }
 

--- a/scripts/prepare-package.js
+++ b/scripts/prepare-package.js
@@ -11,12 +11,14 @@
  */
 
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const defaultRootDir = path.resolve(__dirname, '..');
+const nodeRequire = createRequire(import.meta.url);
 
 export function preparePackage({ rootDir = defaultRootDir } = {}) {
   const distDir = path.join(rootDir, 'dist');
@@ -25,7 +27,11 @@ export function preparePackage({ rootDir = defaultRootDir } = {}) {
   copyDocumentationFiles(rootDir, distDir);
   copyLocales(rootDir, distDir);
   copyExtensionExamples(rootDir, distDir);
-  writeDistPackageJson(rootDir, distDir);
+  const bundleNativeAudioCapture = copyNativeAudioCapturePackage(
+    rootDir,
+    distDir,
+  );
+  writeDistPackageJson(rootDir, distDir, { bundleNativeAudioCapture });
   printPackageStructure(distDir);
 }
 
@@ -129,7 +135,77 @@ function copyExtensionExamples(rootDir, distDir) {
   }
 }
 
-function writeDistPackageJson(rootDir, distDir) {
+function copyNativeAudioCapturePackage(rootDir, distDir) {
+  console.log('Copying native audio capture package...');
+
+  const addonSrc = path.join(rootDir, 'packages', 'audio-capture');
+  const addonDest = path.join(
+    distDir,
+    'node_modules',
+    '@qwen-code',
+    'audio-capture',
+  );
+  const requiredPaths = [
+    path.join(addonSrc, 'dist'),
+    path.join(addonSrc, 'prebuilds'),
+    path.join(addonSrc, 'package.json'),
+  ];
+
+  for (const requiredPath of requiredPaths) {
+    if (!fs.existsSync(requiredPath)) {
+      console.warn(
+        `Warning: audio capture package artifact not found at ${requiredPath}`,
+      );
+      return false;
+    }
+  }
+
+  fs.rmSync(addonDest, { recursive: true, force: true });
+  fs.mkdirSync(addonDest, { recursive: true });
+
+  const addonPkg = JSON.parse(
+    fs.readFileSync(path.join(addonSrc, 'package.json'), 'utf8'),
+  );
+  delete addonPkg.scripts;
+  delete addonPkg.devDependencies;
+  fs.writeFileSync(
+    path.join(addonDest, 'package.json'),
+    JSON.stringify(addonPkg, null, 2) + '\n',
+  );
+
+  const copyOpts = {
+    recursive: true,
+    dereference: true,
+    verbatimSymlinks: false,
+  };
+  fs.cpSync(path.join(addonSrc, 'dist'), path.join(addonDest, 'dist'), {
+    ...copyOpts,
+    filter: (src) => !/\.test\.(d\.)?[mc]?[jt]s(\.map)?$/.test(src),
+  });
+  fs.cpSync(
+    path.join(addonSrc, 'prebuilds'),
+    path.join(addonDest, 'prebuilds'),
+    copyOpts,
+  );
+
+  const nodeGypBuildSrc = path.dirname(
+    nodeRequire.resolve('node-gyp-build/package.json'),
+  );
+  fs.cpSync(
+    nodeGypBuildSrc,
+    path.join(addonDest, 'node_modules', 'node-gyp-build'),
+    copyOpts,
+  );
+
+  console.log('Copied native audio capture package');
+  return true;
+}
+
+function writeDistPackageJson(
+  rootDir,
+  distDir,
+  { bundleNativeAudioCapture = false } = {},
+) {
   console.log('Creating package.json for distribution...');
 
   const cliEntryContent = `#!/usr/bin/env node
@@ -190,6 +266,9 @@ if (result.signal) {
       'bundled',
       'web-shell',
     ],
+    ...(bundleNativeAudioCapture
+      ? { bundledDependencies: ['@qwen-code/audio-capture'] }
+      : {}),
     config: rootPackageJson.config,
     dependencies: {},
     optionalDependencies: {

--- a/scripts/prepare-package.js
+++ b/scripts/prepare-package.js
@@ -196,9 +196,25 @@ function copyNativeAudioCapturePackage(rootDir, distDir, { required } = {}) {
     }
   }
 
-  const addonPkg = JSON.parse(
-    fs.readFileSync(path.join(addonSrc, 'package.json'), 'utf8'),
-  );
+  let addonPkg;
+  try {
+    addonPkg = JSON.parse(
+      fs.readFileSync(path.join(addonSrc, 'package.json'), 'utf8'),
+    );
+  } catch {
+    const message = `audio capture package.json is not valid JSON at ${path.join(
+      addonSrc,
+      'package.json',
+    )}`;
+    if (required) {
+      throw new Error(
+        `Required ${message}. ` +
+          'Cannot publish package without native voice capture.',
+      );
+    }
+    console.warn(`Warning: ${message}`);
+    return false;
+  }
   const dependencySources = [];
   for (const dependencyName of Object.keys(addonPkg.dependencies ?? {})) {
     try {

--- a/scripts/prepare-package.js
+++ b/scripts/prepare-package.js
@@ -153,10 +153,10 @@ function copyNativeAudioCapturePackage(rootDir, distDir) {
 
   for (const requiredPath of requiredPaths) {
     if (!fs.existsSync(requiredPath)) {
-      console.warn(
-        `Warning: audio capture package artifact not found at ${requiredPath}`,
+      throw new Error(
+        `Required audio capture artifact missing: ${requiredPath}. ` +
+          'Cannot publish package without native voice capture.',
       );
-      return false;
     }
   }
 
@@ -171,10 +171,10 @@ function copyNativeAudioCapturePackage(rootDir, distDir) {
         path.dirname(nodeRequire.resolve(`${dependencyName}/package.json`)),
       ]);
     } catch {
-      console.warn(
-        `Warning: audio capture dependency not resolvable: ${dependencyName}`,
+      throw new Error(
+        `Required audio capture dependency not resolvable: ${dependencyName}. ` +
+          'Cannot publish package without native voice capture.',
       );
-      return false;
     }
   }
 

--- a/scripts/prepare-package.js
+++ b/scripts/prepare-package.js
@@ -169,6 +169,32 @@ function copyNativeAudioCapturePackage(rootDir, distDir, { required } = {}) {
       return false;
     }
   }
+  for (const [artifactPath, description, predicate] of [
+    [
+      path.join(addonSrc, 'dist'),
+      'runtime JS',
+      (filePath) =>
+        /\.[cm]?js$/.test(filePath) &&
+        !/\.(test|spec)\.(d\.)?[mc]?[jt]s(\.map)?$/.test(filePath),
+    ],
+    [
+      path.join(addonSrc, 'prebuilds'),
+      'native prebuild',
+      (filePath) => filePath.endsWith('.node'),
+    ],
+  ]) {
+    if (!hasFileMatching(artifactPath, predicate)) {
+      const message = `audio capture package artifact has no ${description}: ${artifactPath}`;
+      if (required) {
+        throw new Error(
+          `Required ${message}. ` +
+            'Cannot publish package without native voice capture.',
+        );
+      }
+      console.warn(`Warning: ${message}`);
+      return false;
+    }
+  }
 
   const addonPkg = JSON.parse(
     fs.readFileSync(path.join(addonSrc, 'package.json'), 'utf8'),
@@ -229,6 +255,18 @@ function copyNativeAudioCapturePackage(rootDir, distDir, { required } = {}) {
 
   console.log('Copied native audio capture package');
   return true;
+}
+
+function hasFileMatching(dir, predicate) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (hasFileMatching(entryPath, predicate)) return true;
+    } else if (entry.isFile() && predicate(entryPath)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function writeDistPackageJson(

--- a/scripts/tests/package-assets.test.js
+++ b/scripts/tests/package-assets.test.js
@@ -188,6 +188,39 @@ describe('package asset scripts', () => {
     ).toThrow(/Required audio capture package artifact not found at/);
   });
 
+  it('omits bundledDependencies when audio-capture dependencies are missing and not required', () => {
+    const rootDir = createFixtureRoot();
+    const audioPackagePath = path.join(
+      rootDir,
+      'packages',
+      'audio-capture',
+      'package.json',
+    );
+    const audioPackageJson = JSON.parse(readFileSync(audioPackagePath, 'utf8'));
+    audioPackageJson.dependencies['missing-audio-runtime'] = '1.0.0';
+    writeFileSync(audioPackagePath, JSON.stringify(audioPackageJson, null, 2));
+    createBundleArtifacts(rootDir);
+    stubConsole();
+
+    preparePackage({ rootDir });
+
+    const distPackageJson = JSON.parse(
+      readFileSync(path.join(rootDir, 'dist', 'package.json'), 'utf8'),
+    );
+    expect(distPackageJson.bundledDependencies).toBeUndefined();
+    expect(
+      existsSync(
+        path.join(
+          rootDir,
+          'dist',
+          'node_modules',
+          '@qwen-code',
+          'audio-capture',
+        ),
+      ),
+    ).toBe(false);
+  });
+
   function createFixtureRoot() {
     const rootDir = mkdtempSync(path.join(tmpdir(), 'qwen-package-assets-'));
     tempDirs.push(rootDir);

--- a/scripts/tests/package-assets.test.js
+++ b/scripts/tests/package-assets.test.js
@@ -83,6 +83,20 @@ describe('package asset scripts', () => {
         ),
       ),
     ).toBe(true);
+    expect(
+      existsSync(
+        path.join(
+          rootDir,
+          'dist',
+          'node_modules',
+          '@qwen-code',
+          'audio-capture',
+          'prebuilds',
+          'darwin-arm64',
+          '@qwen-code+audio-capture.node',
+        ),
+      ),
+    ).toBe(true);
     const distAudioPackageJson = JSON.parse(
       readFileSync(
         path.join(
@@ -132,7 +146,7 @@ describe('package asset scripts', () => {
     ).toBe(true);
   });
 
-  it('fails packaging when audio-capture artifacts are missing', () => {
+  it('omits bundledDependencies when audio-capture artifacts are missing', () => {
     const rootDir = createFixtureRoot();
     rmSync(path.join(rootDir, 'packages', 'audio-capture', 'prebuilds'), {
       recursive: true,
@@ -141,9 +155,12 @@ describe('package asset scripts', () => {
     createBundleArtifacts(rootDir);
     stubConsole();
 
-    expect(() => preparePackage({ rootDir })).toThrow(
-      /Required audio capture artifact missing:/,
+    preparePackage({ rootDir });
+
+    const distPackageJson = JSON.parse(
+      readFileSync(path.join(rootDir, 'dist', 'package.json'), 'utf8'),
     );
+    expect(distPackageJson.bundledDependencies).toBeUndefined();
     expect(
       existsSync(
         path.join(
@@ -155,6 +172,20 @@ describe('package asset scripts', () => {
         ),
       ),
     ).toBe(false);
+  });
+
+  it('fails packaging when required audio-capture artifacts are missing', () => {
+    const rootDir = createFixtureRoot();
+    rmSync(path.join(rootDir, 'packages', 'audio-capture', 'prebuilds'), {
+      recursive: true,
+      force: true,
+    });
+    createBundleArtifacts(rootDir);
+    stubConsole();
+
+    expect(() =>
+      preparePackage({ rootDir, requireNativeAudioCapture: true }),
+    ).toThrow(/Required audio capture package artifact not found at/);
   });
 
   function createFixtureRoot() {

--- a/scripts/tests/package-assets.test.js
+++ b/scripts/tests/package-assets.test.js
@@ -64,9 +64,39 @@ describe('package asset scripts', () => {
     );
 
     expect(distPackageJson.files).toContain('examples');
+    expect(distPackageJson.bundledDependencies).toContain(
+      '@qwen-code/audio-capture',
+    );
     expect(distPackageJson.optionalDependencies).toMatchObject({
       '@qwen-code/audio-capture': rootPackageJson.version,
     });
+    expect(
+      existsSync(
+        path.join(
+          rootDir,
+          'dist',
+          'node_modules',
+          '@qwen-code',
+          'audio-capture',
+          'dist',
+          'index.js',
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      existsSync(
+        path.join(
+          rootDir,
+          'dist',
+          'node_modules',
+          '@qwen-code',
+          'audio-capture',
+          'node_modules',
+          'node-gyp-build',
+          'package.json',
+        ),
+      ),
+    ).toBe(true);
     expect(
       existsSync(
         path.join(rootDir, 'dist', 'examples', 'mcp-server', 'package.json'),
@@ -106,6 +136,40 @@ describe('package asset scripts', () => {
       rootDir,
       'packages/cli/src/i18n/locales/en.json',
       '{"hello":"world"}\n',
+    );
+    writeFile(
+      rootDir,
+      'packages/audio-capture/package.json',
+      JSON.stringify(
+        {
+          name: '@qwen-code/audio-capture',
+          version: '0.17.0',
+          type: 'module',
+          main: 'dist/index.js',
+          dependencies: {
+            'node-gyp-build': '^4.8.4',
+          },
+          scripts: {
+            install: 'node install.js',
+          },
+          devDependencies: {
+            typescript: '^5.3.3',
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    writeFile(rootDir, 'packages/audio-capture/dist/index.js', '');
+    writeFile(
+      rootDir,
+      'packages/audio-capture/dist/index.test.js',
+      'throw new Error("should not copy tests");\n',
+    );
+    writeFile(
+      rootDir,
+      'packages/audio-capture/prebuilds/darwin-arm64/@qwen-code+audio-capture.node',
+      'fake native addon\n',
     );
 
     for (const template of [

--- a/scripts/tests/package-assets.test.js
+++ b/scripts/tests/package-assets.test.js
@@ -284,6 +284,42 @@ describe('package asset scripts', () => {
     ).toThrow(/Required audio capture dependency not resolvable/);
   });
 
+  it('omits bundledDependencies when audio-capture package JSON is invalid and not required', () => {
+    const rootDir = createFixtureRoot();
+    writeFile(rootDir, 'packages/audio-capture/package.json', '{ invalid json');
+    createBundleArtifacts(rootDir);
+    stubConsole();
+
+    preparePackage({ rootDir });
+
+    const distPackageJson = JSON.parse(
+      readFileSync(path.join(rootDir, 'dist', 'package.json'), 'utf8'),
+    );
+    expect(distPackageJson.bundledDependencies).toBeUndefined();
+    expect(
+      existsSync(
+        path.join(
+          rootDir,
+          'dist',
+          'node_modules',
+          '@qwen-code',
+          'audio-capture',
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it('fails packaging when required audio-capture package JSON is invalid', () => {
+    const rootDir = createFixtureRoot();
+    writeFile(rootDir, 'packages/audio-capture/package.json', '{ invalid json');
+    createBundleArtifacts(rootDir);
+    stubConsole();
+
+    expect(() =>
+      preparePackage({ rootDir, requireNativeAudioCapture: true }),
+    ).toThrow(/Required audio capture package\.json is not valid JSON/);
+  });
+
   function createFixtureRoot() {
     const rootDir = mkdtempSync(path.join(tmpdir(), 'qwen-package-assets-'));
     tempDirs.push(rootDir);

--- a/scripts/tests/package-assets.test.js
+++ b/scripts/tests/package-assets.test.js
@@ -54,7 +54,7 @@ describe('package asset scripts', () => {
     createBundleArtifacts(rootDir);
     stubConsole();
 
-    preparePackage({ rootDir });
+    preparePackage({ rootDir, requireNativeAudioCapture: false });
 
     const distPackageJson = JSON.parse(
       readFileSync(path.join(rootDir, 'dist', 'package.json'), 'utf8'),
@@ -83,6 +83,20 @@ describe('package asset scripts', () => {
         ),
       ),
     ).toBe(true);
+    expect(
+      existsSync(
+        path.join(
+          rootDir,
+          'dist',
+          'node_modules',
+          '@qwen-code',
+          'audio-capture',
+          'prebuilds',
+          'darwin-arm64',
+          'debug.log',
+        ),
+      ),
+    ).toBe(false);
     expect(
       existsSync(
         path.join(
@@ -168,7 +182,37 @@ describe('package asset scripts', () => {
     createBundleArtifacts(rootDir);
     stubConsole();
 
-    preparePackage({ rootDir });
+    preparePackage({ rootDir, requireNativeAudioCapture: false });
+
+    const distPackageJson = JSON.parse(
+      readFileSync(path.join(rootDir, 'dist', 'package.json'), 'utf8'),
+    );
+    expect(distPackageJson.bundledDependencies).toBeUndefined();
+    expect(
+      existsSync(
+        path.join(
+          rootDir,
+          'dist',
+          'node_modules',
+          '@qwen-code',
+          'audio-capture',
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it('removes stale bundled audio-capture files when artifacts are missing', () => {
+    const rootDir = createFixtureRoot();
+    createBundleArtifacts(rootDir);
+    stubConsole();
+
+    preparePackage({ rootDir, requireNativeAudioCapture: false });
+    rmSync(path.join(rootDir, 'packages', 'audio-capture', 'prebuilds'), {
+      recursive: true,
+      force: true,
+    });
+
+    preparePackage({ rootDir, requireNativeAudioCapture: false });
 
     const distPackageJson = JSON.parse(
       readFileSync(path.join(rootDir, 'dist', 'package.json'), 'utf8'),
@@ -246,7 +290,7 @@ describe('package asset scripts', () => {
     createBundleArtifacts(rootDir);
     stubConsole();
 
-    preparePackage({ rootDir });
+    preparePackage({ rootDir, requireNativeAudioCapture: false });
 
     const distPackageJson = JSON.parse(
       readFileSync(path.join(rootDir, 'dist', 'package.json'), 'utf8'),
@@ -290,7 +334,7 @@ describe('package asset scripts', () => {
     createBundleArtifacts(rootDir);
     stubConsole();
 
-    preparePackage({ rootDir });
+    preparePackage({ rootDir, requireNativeAudioCapture: false });
 
     const distPackageJson = JSON.parse(
       readFileSync(path.join(rootDir, 'dist', 'package.json'), 'utf8'),
@@ -391,6 +435,21 @@ describe('package asset scripts', () => {
       rootDir,
       'packages/audio-capture/prebuilds/darwin-arm64/@qwen-code+audio-capture.node',
       'fake native addon\n',
+    );
+    writeFile(
+      rootDir,
+      'packages/audio-capture/prebuilds/darwin-arm64/debug.log',
+      'should not ship\n',
+    );
+    writeFile(
+      rootDir,
+      'packages/audio-capture/node_modules/node-gyp-build/package.json',
+      '{"name":"node-gyp-build","version":"4.8.4"}\n',
+    );
+    writeFile(
+      rootDir,
+      'packages/audio-capture/node_modules/node-gyp-build/index.js',
+      '',
     );
 
     for (const template of [

--- a/scripts/tests/package-assets.test.js
+++ b/scripts/tests/package-assets.test.js
@@ -117,6 +117,34 @@ describe('package asset scripts', () => {
     ).toBe(true);
   });
 
+  it('omits bundledDependencies when audio-capture artifacts are missing', () => {
+    const rootDir = createFixtureRoot();
+    rmSync(path.join(rootDir, 'packages', 'audio-capture', 'prebuilds'), {
+      recursive: true,
+      force: true,
+    });
+    createBundleArtifacts(rootDir);
+    stubConsole();
+
+    preparePackage({ rootDir });
+
+    const distPackageJson = JSON.parse(
+      readFileSync(path.join(rootDir, 'dist', 'package.json'), 'utf8'),
+    );
+    expect(distPackageJson.bundledDependencies).toBeUndefined();
+    expect(
+      existsSync(
+        path.join(
+          rootDir,
+          'dist',
+          'node_modules',
+          '@qwen-code',
+          'audio-capture',
+        ),
+      ),
+    ).toBe(false);
+  });
+
   function createFixtureRoot() {
     const rootDir = mkdtempSync(path.join(tmpdir(), 'qwen-package-assets-'));
     tempDirs.push(rootDir);

--- a/scripts/tests/package-assets.test.js
+++ b/scripts/tests/package-assets.test.js
@@ -83,6 +83,21 @@ describe('package asset scripts', () => {
         ),
       ),
     ).toBe(true);
+    const distAudioPackageJson = JSON.parse(
+      readFileSync(
+        path.join(
+          rootDir,
+          'dist',
+          'node_modules',
+          '@qwen-code',
+          'audio-capture',
+          'package.json',
+        ),
+        'utf8',
+      ),
+    );
+    expect(distAudioPackageJson.scripts).toBeUndefined();
+    expect(distAudioPackageJson.devDependencies).toBeUndefined();
     expect(
       existsSync(
         path.join(
@@ -117,7 +132,7 @@ describe('package asset scripts', () => {
     ).toBe(true);
   });
 
-  it('omits bundledDependencies when audio-capture artifacts are missing', () => {
+  it('fails packaging when audio-capture artifacts are missing', () => {
     const rootDir = createFixtureRoot();
     rmSync(path.join(rootDir, 'packages', 'audio-capture', 'prebuilds'), {
       recursive: true,
@@ -126,12 +141,9 @@ describe('package asset scripts', () => {
     createBundleArtifacts(rootDir);
     stubConsole();
 
-    preparePackage({ rootDir });
-
-    const distPackageJson = JSON.parse(
-      readFileSync(path.join(rootDir, 'dist', 'package.json'), 'utf8'),
+    expect(() => preparePackage({ rootDir })).toThrow(
+      /Required audio capture artifact missing:/,
     );
-    expect(distPackageJson.bundledDependencies).toBeUndefined();
     expect(
       existsSync(
         path.join(

--- a/scripts/tests/package-assets.test.js
+++ b/scripts/tests/package-assets.test.js
@@ -201,6 +201,37 @@ describe('package asset scripts', () => {
     ).toThrow(/Required audio capture package artifact not found at/);
   });
 
+  it('fails packaging when required audio-capture runtime output is empty', () => {
+    const rootDir = createFixtureRoot();
+    rmSync(path.join(rootDir, 'packages', 'audio-capture', 'dist', 'index.js'));
+    createBundleArtifacts(rootDir);
+    stubConsole();
+
+    expect(() =>
+      preparePackage({ rootDir, requireNativeAudioCapture: true }),
+    ).toThrow(/Required audio capture package artifact has no runtime JS/);
+  });
+
+  it('fails packaging when required audio-capture prebuilds are empty', () => {
+    const rootDir = createFixtureRoot();
+    rmSync(
+      path.join(
+        rootDir,
+        'packages',
+        'audio-capture',
+        'prebuilds',
+        'darwin-arm64',
+        '@qwen-code+audio-capture.node',
+      ),
+    );
+    createBundleArtifacts(rootDir);
+    stubConsole();
+
+    expect(() =>
+      preparePackage({ rootDir, requireNativeAudioCapture: true }),
+    ).toThrow(/Required audio capture package artifact has no native prebuild/);
+  });
+
   it('omits bundledDependencies when audio-capture dependencies are missing and not required', () => {
     const rootDir = createFixtureRoot();
     const audioPackagePath = path.join(

--- a/scripts/tests/package-assets.test.js
+++ b/scripts/tests/package-assets.test.js
@@ -99,6 +99,19 @@ describe('package asset scripts', () => {
     ).toBe(true);
     expect(
       existsSync(
+        path.join(
+          rootDir,
+          'dist',
+          'node_modules',
+          '@qwen-code',
+          'audio-capture',
+          'dist',
+          'index.test.js',
+        ),
+      ),
+    ).toBe(false);
+    expect(
+      existsSync(
         path.join(rootDir, 'dist', 'examples', 'mcp-server', 'package.json'),
       ),
     ).toBe(true);

--- a/scripts/tests/package-assets.test.js
+++ b/scripts/tests/package-assets.test.js
@@ -141,6 +141,19 @@ describe('package asset scripts', () => {
     ).toBe(false);
     expect(
       existsSync(
+        path.join(
+          rootDir,
+          'dist',
+          'node_modules',
+          '@qwen-code',
+          'audio-capture',
+          'dist',
+          'index.spec.js',
+        ),
+      ),
+    ).toBe(false);
+    expect(
+      existsSync(
         path.join(rootDir, 'dist', 'examples', 'mcp-server', 'package.json'),
       ),
     ).toBe(true);
@@ -221,6 +234,25 @@ describe('package asset scripts', () => {
     ).toBe(false);
   });
 
+  it('fails packaging when required audio-capture dependencies are missing', () => {
+    const rootDir = createFixtureRoot();
+    const audioPackagePath = path.join(
+      rootDir,
+      'packages',
+      'audio-capture',
+      'package.json',
+    );
+    const audioPackageJson = JSON.parse(readFileSync(audioPackagePath, 'utf8'));
+    audioPackageJson.dependencies['missing-audio-runtime'] = '1.0.0';
+    writeFileSync(audioPackagePath, JSON.stringify(audioPackageJson, null, 2));
+    createBundleArtifacts(rootDir);
+    stubConsole();
+
+    expect(() =>
+      preparePackage({ rootDir, requireNativeAudioCapture: true }),
+    ).toThrow(/Required audio capture dependency not resolvable/);
+  });
+
   function createFixtureRoot() {
     const rootDir = mkdtempSync(path.join(tmpdir(), 'qwen-package-assets-'));
     tempDirs.push(rootDir);
@@ -282,6 +314,11 @@ describe('package asset scripts', () => {
       rootDir,
       'packages/audio-capture/dist/index.test.js',
       'throw new Error("should not copy tests");\n',
+    );
+    writeFile(
+      rootDir,
+      'packages/audio-capture/dist/index.spec.js',
+      'throw new Error("should not copy specs");\n',
     );
     writeFile(
       rootDir,


### PR DESCRIPTION
## What this PR does

Bundles the native voice capture package into the prepared npm package when its build artifacts are available, so the published CLI package can carry the native recorder instead of relying on mirror registries to resolve the package separately. It also rewrites missing native package errors into an actionable message that points users at mirror/private registry optional dependency sync issues.

## Why it's needed

A mirror registry can make the main CLI package available before `@qwen-code/audio-capture` is synced. Since the native package is optional, npm can complete the install while skipping it, leaving `/voice` to fail at runtime and then fall back to SoX. Bundling the package with the main publish artifact makes mirror installs more reliable, and the improved error text makes the remaining failure mode clear.

## Reviewer Test Plan

### How to verify

Confirm that preparing a publish package with native audio capture artifacts copies the native package into the package's bundled dependencies and keeps its runtime `node-gyp-build` dependency available. Confirm that a missing `@qwen-code/audio-capture` import reports a mirror/private registry install hint instead of only returning Node's generic package resolution error.

### Evidence (Before & After)

Before: the prepared package only referenced `@qwen-code/audio-capture` as an optional dependency, so mirrors that had the main package but not the native package could produce successful installs with broken native voice capture. Missing native package errors surfaced as generic `Cannot find package '@qwen-code/audio-capture'` messages.

After: focused tests verify the prepared package declares and copies the native capture package when artifacts are present, including `node-gyp-build`, and verify the native recorder explains the mirror/private registry failure mode when the package is missing.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Local macOS worktree with Node.js/npm workspace install.

## Risk & Scope

- Main risk or tradeoff: npm package size increases when native capture artifacts are available because the native package is carried inside the main publish artifact.
- Not validated / out of scope: a full release publish with real downloaded prebuild artifacts on every platform; CI/release jobs should cover the release matrix.
- Breaking changes / migration notes: none expected.

## Linked Issues

Fixes #5742

<details>
<summary>中文说明</summary>

## What this PR does

当 native 语音采集构建产物存在时，把 native 语音采集包打进准备发布的 npm 包里，让 CLI 主包自己携带 native recorder，而不是依赖镜像源再单独解析这个包。同时，把 native 包缺失错误改写成可操作的提示，明确指出镜像源或私有 registry 可能没有同步 optional dependency。

## Why it's needed

镜像源可能先同步 CLI 主包，但还没有同步 `@qwen-code/audio-capture`。因为 native 包是 optional dependency，npm 可能跳过它但仍然安装成功，导致 `/voice` 运行时失败并回退到 SoX。把 native 包随主发布产物一起携带，可以让镜像安装更可靠；改进错误文案也能让剩余失败模式更容易定位。

## Reviewer Test Plan

### How to verify

确认在存在 native audio capture 构建产物时，准备发布包会把 native 包复制进 bundled dependencies，并保留它运行时需要的 `node-gyp-build`。确认当 `@qwen-code/audio-capture` import 缺失时，错误会提示镜像源或私有 registry 同步问题，而不是只返回 Node 的通用包解析错误。

### Evidence (Before & After)

Before：准备发布的包只把 `@qwen-code/audio-capture` 作为 optional dependency 引用。如果镜像源有主包但没有 native 包，安装会成功但 native 语音采集会坏。缺少 native 包时，错误只是通用的 `Cannot find package '@qwen-code/audio-capture'`。

After：聚焦测试验证准备发布包会在产物存在时声明并复制 native capture 包，包括 `node-gyp-build`；同时验证 native recorder 在包缺失时会解释镜像源或私有 registry 的失败模式。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

本地 macOS worktree，使用 Node.js/npm workspace install。

## Risk & Scope

- Main risk or tradeoff：当 native capture 产物存在时，npm 主包会因为携带 native 包而变大。
- Not validated / out of scope：没有执行带真实全平台 prebuild 下载产物的完整 release publish；这部分应由 CI/release job 覆盖。
- Breaking changes / migration notes：预计没有。

## Linked Issues

Fixes #5742

</details>
