### PR TITLE
fix(cli): stabilize VP mouse interactions

### DIFF
--- a/packages/cli/src/ui/components/shared/ScrollableList.test.tsx
+++ b/packages/cli/src/ui/components/shared/ScrollableList.test.tsx
@@ -5,13 +5,17 @@
  */
 
 import type React from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render } from 'ink-testing-library';
 import { act } from '@testing-library/react';
 import { Text } from 'ink';
 import { ScrollableList } from './ScrollableList.js';
 import { SCROLL_TO_ITEM_END } from './VirtualizedList.js';
 import { KeypressProvider } from '../../contexts/KeypressContext.js';
+
+vi.mock('../../utils/measure-element-position.js', () => ({
+  measureElementPosition: () => ({ x: 0, y: 0, width: 40, height: 5 }),
+}));
 
 type Item = { id: number; label: string };
 
@@ -30,8 +34,11 @@ const estimatedItemHeight = () => 1;
 const ESC = '\x1b';
 const wheelUp = (col = 1, row = 1) => `${ESC}[<64;${col};${row}M`;
 const wheelDown = (col = 1, row = 1) => `${ESC}[<65;${col};${row}M`;
+const leftPress = (col: number, row: number) => `${ESC}[<0;${col};${row}M`;
+const leftDrag = (col: number, row: number) => `${ESC}[<32;${col};${row}M`;
+const leftRelease = (col: number, row: number) => `${ESC}[<0;${col};${row}m`;
 
-describe('<ScrollableList /> mouse wheel', () => {
+describe('<ScrollableList /> mouse scrolling', () => {
   it('routes wheel SGR events to viewport scroll (window shifts)', async () => {
     // When scrolled to top, item-0 is in the visible window; after enough
     // wheel-down events it should be scrolled out; wheel-up brings it back.
@@ -95,7 +102,7 @@ describe('<ScrollableList /> mouse wheel', () => {
     }).not.toThrow();
   });
 
-  it('does not move the rendered window on non-wheel mouse events', async () => {
+  it('does not move the rendered window on content-area clicks', async () => {
     const renderItem = ({ item }: { item: Item }) => <Text>{item.label}</Text>;
     const Wrapper = () => (
       <ScrollableList<Item>
@@ -117,11 +124,139 @@ describe('<ScrollableList /> mouse wheel', () => {
     const before = lastFrame();
 
     await act(async () => {
-      stdin.write(`${ESC}[<0;5;5M`); // left-press
-      stdin.write(`${ESC}[<32;5;6M`); // drag
-      stdin.write(`${ESC}[<0;5;6m`); // left-release
+      stdin.write(leftPress(5, 5));
+      stdin.write(leftDrag(5, 6));
+      stdin.write(leftRelease(5, 6));
     });
     await act(async () => {});
+    expect(lastFrame()).toBe(before);
+  });
+
+  it('drags the scrollbar to scroll the viewport', async () => {
+    const renderItem = ({ item }: { item: Item }) => <Text>{item.label}</Text>;
+    const Wrapper = () => (
+      <ScrollableList<Item>
+        hasFocus
+        data={makeItems(50)}
+        renderItem={renderItem}
+        estimatedItemHeight={estimatedItemHeight}
+        keyExtractor={keyExtractor}
+        initialScrollIndex={0}
+        containerHeight={5}
+        width={40}
+        showScrollbar
+      />
+    );
+
+    const { stdin, lastFrame, rerender } = render(withKeypress(<Wrapper />));
+    rerender(withKeypress(<Wrapper />));
+    await act(async () => {});
+    expect(lastFrame()).toContain('item-0');
+
+    await act(async () => {
+      stdin.write(leftPress(40, 1));
+      stdin.write(leftDrag(40, 5));
+      stdin.write(leftRelease(40, 5));
+    });
+    await act(async () => {});
+
+    expect(lastFrame()).not.toContain('item-0');
+    expect(lastFrame()).toContain('item-49');
+  });
+
+  it('drags the scrollbar to an intermediate viewport position', async () => {
+    const renderItem = ({ item }: { item: Item }) => <Text>{item.label}</Text>;
+    const Wrapper = () => (
+      <ScrollableList<Item>
+        hasFocus
+        data={makeItems(50)}
+        renderItem={renderItem}
+        estimatedItemHeight={estimatedItemHeight}
+        keyExtractor={keyExtractor}
+        initialScrollIndex={0}
+        containerHeight={5}
+        width={40}
+        showScrollbar
+      />
+    );
+
+    const { stdin, lastFrame, rerender } = render(withKeypress(<Wrapper />));
+    rerender(withKeypress(<Wrapper />));
+    await act(async () => {});
+    expect(lastFrame()).toContain('item-0');
+
+    await act(async () => {
+      stdin.write(leftPress(40, 1));
+      stdin.write(leftDrag(40, 3));
+      stdin.write(leftRelease(40, 3));
+    });
+    await act(async () => {});
+
+    expect(lastFrame()).not.toContain('item-0');
+    expect(lastFrame()).toContain('item-23');
+    expect(lastFrame()).not.toContain('item-49');
+  });
+
+  it('keeps dragging after the pointer leaves the scrollbar column', async () => {
+    const renderItem = ({ item }: { item: Item }) => <Text>{item.label}</Text>;
+    const Wrapper = () => (
+      <ScrollableList<Item>
+        hasFocus
+        data={makeItems(50)}
+        renderItem={renderItem}
+        estimatedItemHeight={estimatedItemHeight}
+        keyExtractor={keyExtractor}
+        initialScrollIndex={0}
+        containerHeight={5}
+        width={40}
+        showScrollbar
+      />
+    );
+
+    const { stdin, lastFrame, rerender } = render(withKeypress(<Wrapper />));
+    rerender(withKeypress(<Wrapper />));
+    await act(async () => {});
+    expect(lastFrame()).toContain('item-0');
+
+    await act(async () => {
+      stdin.write(leftPress(40, 1));
+      stdin.write(leftDrag(35, 5));
+      stdin.write(leftRelease(35, 5));
+    });
+    await act(async () => {});
+
+    expect(lastFrame()).not.toContain('item-0');
+    expect(lastFrame()).toContain('item-49');
+  });
+
+  it('does not start a scrollbar drag when content fits the viewport', async () => {
+    const renderItem = ({ item }: { item: Item }) => <Text>{item.label}</Text>;
+    const Wrapper = () => (
+      <ScrollableList<Item>
+        hasFocus
+        data={makeItems(3)}
+        renderItem={renderItem}
+        estimatedItemHeight={estimatedItemHeight}
+        keyExtractor={keyExtractor}
+        initialScrollIndex={0}
+        containerHeight={5}
+        width={40}
+        showScrollbar
+      />
+    );
+
+    const { stdin, lastFrame, rerender } = render(withKeypress(<Wrapper />));
+    rerender(withKeypress(<Wrapper />));
+    await act(async () => {});
+    const before = lastFrame();
+
+    await act(async () => {
+      stdin.write(leftPress(40, 1));
+      stdin.write(leftDrag(40, 5));
+      stdin.write(leftRelease(40, 5));
+    });
+    await act(async () => {});
+
     expect(lastFrame()).toBe(before);
   });
 });

--- a/packages/cli/src/ui/components/shared/ScrollableList.tsx
+++ b/packages/cli/src/ui/components/shared/ScrollableList.tsx
@@ -37,6 +37,7 @@ function ScrollableList<T>(
   // latent name collision if VirtualizedList ever adds the same prop.
   const { hasFocus, ...virtualizedListProps } = props;
   const virtualizedListRef = useRef<VirtualizedListRef<T>>(null);
+  const isDraggingScrollbar = useRef(false);
 
   useImperativeHandle(
     ref,
@@ -48,6 +49,10 @@ function ScrollableList<T>(
         virtualizedListRef.current?.scrollToIndex(params),
       scrollToItem: (params) =>
         virtualizedListRef.current?.scrollToItem(params),
+      hitTestScrollbar: (location) =>
+        virtualizedListRef.current?.hitTestScrollbar(location) ?? false,
+      scrollToScrollbarRow: (row) =>
+        virtualizedListRef.current?.scrollToScrollbarRow(row),
       getScrollIndex: () => virtualizedListRef.current?.getScrollIndex() ?? 0,
       getScrollState: () =>
         virtualizedListRef.current?.getScrollState() ?? {
@@ -95,22 +100,28 @@ function ScrollableList<T>(
     { isActive: hasFocus },
   );
 
-  // Mouse wheel scrolling. Legacy `<Static>` mode let the host terminal
-  // handle wheel events (they scrolled the native scrollback); in VP mode
-  // we own the visible region, so the terminal hands wheel events to us
-  // via SGR mouse protocol. Without this, opening the VP gate would cost
-  // users the most-felt mouse interaction.
-  //
-  // Hit-testing is intentionally absent: the ScrollableList occupies the
-  // conversation pane between the (small) pinned header and the (small)
-  // input prompt, so any wheel event the terminal forwards is overwhelm-
-  // ingly aimed at scrolling history. Precise per-pane hit-testing (and
-  // scrollbar drag) needs screen-absolute element coordinates which the
-  // stock ink 7 `useBoxMetrics` hook reports relative to the parent — see
-  // V.4 follow-up.
+  // Mouse scrolling. Legacy `<Static>` mode let the host terminal scroll its
+  // native scrollback. In VP mode the list owns the visible region, so route
+  // wheel ticks and scrollbar drags to the virtualized viewport.
   const WHEEL_LINES_PER_TICK = 3;
   const handleMouseEvent = useCallback((event: MouseEvent) => {
     if (!virtualizedListRef.current) return;
+    if (event.name === 'left-release') {
+      isDraggingScrollbar.current = false;
+      return;
+    }
+    if (event.name === 'left-press') {
+      isDraggingScrollbar.current =
+        virtualizedListRef.current.hitTestScrollbar(event);
+      if (isDraggingScrollbar.current) {
+        virtualizedListRef.current.scrollToScrollbarRow(event.row);
+      }
+      return;
+    }
+    if (event.name === 'move' && isDraggingScrollbar.current) {
+      virtualizedListRef.current.scrollToScrollbarRow(event.row);
+      return;
+    }
     if (event.name === 'scroll-up') {
       virtualizedListRef.current.scrollBy(-WHEEL_LINES_PER_TICK);
     } else if (event.name === 'scroll-down') {

--- a/packages/cli/src/ui/components/shared/VirtualizedList.tsx
+++ b/packages/cli/src/ui/components/shared/VirtualizedList.tsx
@@ -20,6 +20,7 @@ import { useAnimatedScrollbar } from '../../hooks/useAnimatedScrollbar.js';
 import { StaticRender } from './StaticRender.js';
 import { type DOMElement, Box, Text, useBoxMetrics } from 'ink';
 import { createDebugLogger } from '@qwen-code/qwen-code-core';
+import { measureElementPosition } from '../../utils/measure-element-position.js';
 
 const debugLogger = createDebugLogger('VIRTUALIZED_LIST');
 
@@ -55,6 +56,8 @@ export type VirtualizedListRef<T> = {
     viewPosition?: number;
   }) => void;
   getScrollIndex: () => number;
+  hitTestScrollbar: (location: { col: number; row: number }) => boolean;
+  scrollToScrollbarRow: (row: number) => void;
   getScrollState: () => {
     scrollTop: number;
     scrollHeight: number;
@@ -193,6 +196,7 @@ function VirtualizedList<T>(
   });
 
   const containerRef = useRef<DOMElement>(null);
+  const rootRef = useRef<DOMElement>(null);
 
   const { width: measuredContainerWidth, height: measuredContainerHeight } =
     useBoxMetrics(containerRef as React.RefObject<DOMElement>);
@@ -579,6 +583,79 @@ function VirtualizedList<T>(
     maxScroll,
   );
 
+  const getScrollbarGeometry = useCallback(() => {
+    const shouldShowScrollbar = (props.showScrollbar ?? true) && maxScroll > 0;
+    if (
+      !shouldShowScrollbar ||
+      !rootRef.current ||
+      scrollableContainerHeight <= 0
+    ) {
+      return null;
+    }
+
+    const metrics = measureElementPosition(rootRef.current);
+    if (metrics.width <= 0 || metrics.height <= 0) return null;
+
+    return {
+      col: metrics.x + metrics.width - 1,
+      top: metrics.y,
+      height: scrollableContainerHeight,
+    };
+  }, [props.showScrollbar, maxScroll, scrollableContainerHeight]);
+
+  const hitTestScrollbar = useCallback(
+    ({ col, row }: { col: number; row: number }) => {
+      const geometry = getScrollbarGeometry();
+      if (!geometry) return false;
+
+      const zeroBasedCol = col - 1;
+      const zeroBasedRow = row - 1;
+      return (
+        zeroBasedCol === geometry.col &&
+        zeroBasedRow >= geometry.top &&
+        zeroBasedRow < geometry.top + geometry.height
+      );
+    },
+    [getScrollbarGeometry],
+  );
+
+  const scrollToScrollbarRow = useCallback(
+    (row: number) => {
+      const geometry = getScrollbarGeometry();
+      if (!geometry) return;
+
+      const zeroBasedRow = row - 1;
+      const rowInTrack = Math.max(
+        0,
+        Math.min(geometry.height - 1, zeroBasedRow - geometry.top),
+      );
+      const scrollRatio = rowInTrack / Math.max(1, geometry.height - 1);
+      const newScrollTop = Math.round(scrollRatio * maxScroll);
+      if (newScrollTop >= maxScroll) {
+        setIsStickingToBottom(true);
+        setPendingScrollTop(Number.MAX_SAFE_INTEGER);
+        if (data.length > 0) {
+          setScrollAnchor({
+            index: data.length - 1,
+            offset: SCROLL_TO_ITEM_END,
+          });
+        }
+      } else {
+        setIsStickingToBottom(false);
+        setPendingScrollTop(newScrollTop);
+        setScrollAnchor(getAnchorForScrollTop(newScrollTop, offsets));
+      }
+    },
+    [
+      data.length,
+      getAnchorForScrollTop,
+      getScrollbarGeometry,
+      maxScroll,
+      offsets,
+      setPendingScrollTop,
+    ],
+  );
+
   useImperativeHandle(
     ref,
     () => ({
@@ -694,6 +771,8 @@ function VirtualizedList<T>(
           }
         }
       },
+      hitTestScrollbar,
+      scrollToScrollbarRow,
       getScrollIndex: () => scrollAnchor.index,
       getScrollState: () => {
         const maxScroll = Math.max(0, totalHeight - scrollableContainerHeight);
@@ -713,6 +792,8 @@ function VirtualizedList<T>(
       scrollableContainerHeight,
       getScrollTop,
       setPendingScrollTop,
+      hitTestScrollbar,
+      scrollToScrollbarRow,
     ],
   );
 
@@ -775,6 +856,7 @@ function VirtualizedList<T>(
 
   return (
     <Box
+      ref={rootRef}
       width="100%"
       height={
         props.containerHeight !== undefined ? props.containerHeight : '100%'

--- a/packages/cli/src/ui/hooks/useMouseEvents.test.tsx
+++ b/packages/cli/src/ui/hooks/useMouseEvents.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { EventEmitter } from 'node:events';
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useStdin, useStdout } from 'ink';
+import { KeypressProvider } from '../contexts/KeypressContext.js';
+import { useMouseEvents } from './useMouseEvents.js';
+
+vi.mock('ink', async (importOriginal) => {
+  const original = await importOriginal<typeof import('ink')>();
+  return {
+    ...original,
+    useStdin: vi.fn(),
+    useStdout: vi.fn(),
+  };
+});
+
+const mockedUseStdin = vi.mocked(useStdin);
+const mockedUseStdout = vi.mocked(useStdout);
+
+const ENABLE_MOUSE = '\x1b[?1002h\x1b[?1006h';
+const DISABLE_MOUSE = '\x1b[?1006l\x1b[?1002l';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <KeypressProvider kittyProtocolEnabled={false}>{children}</KeypressProvider>
+);
+
+function useTwoMouseSubscribers(firstActive: boolean, secondActive: boolean) {
+  useMouseEvents(() => {}, { isActive: firstActive });
+  useMouseEvents(() => {}, { isActive: secondActive });
+}
+
+describe('useMouseEvents', () => {
+  let stdin: EventEmitter & {
+    isTTY: boolean;
+    setRawMode: ReturnType<typeof vi.fn>;
+    resume: ReturnType<typeof vi.fn>;
+    pause: ReturnType<typeof vi.fn>;
+  };
+  let stdout: { write: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    stdin = Object.assign(new EventEmitter(), {
+      isTTY: true,
+      setRawMode: vi.fn(),
+      resume: vi.fn(),
+      pause: vi.fn(),
+    });
+    stdout = { write: vi.fn() };
+    mockedUseStdin.mockReturnValue({
+      stdin,
+      setRawMode: vi.fn(),
+      isRawModeSupported: true,
+    } as unknown as ReturnType<typeof useStdin>);
+    mockedUseStdout.mockReturnValue({ stdout } as unknown as ReturnType<
+      typeof useStdout
+    >);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    stdin.removeAllListeners();
+  });
+
+  it('keeps terminal mouse mode enabled until all subscribers are inactive', () => {
+    const { rerender, unmount } = renderHook(
+      ({ firstActive, secondActive }) =>
+        useTwoMouseSubscribers(firstActive, secondActive),
+      {
+        initialProps: { firstActive: true, secondActive: true },
+        wrapper,
+      },
+    );
+
+    expect(stdout.write).toHaveBeenCalledTimes(1);
+    expect(stdout.write).toHaveBeenCalledWith(ENABLE_MOUSE);
+
+    stdout.write.mockClear();
+    rerender({ firstActive: false, secondActive: true });
+    expect(stdout.write).not.toHaveBeenCalledWith(DISABLE_MOUSE);
+
+    rerender({ firstActive: false, secondActive: false });
+    expect(stdout.write).toHaveBeenCalledTimes(1);
+    expect(stdout.write).toHaveBeenCalledWith(DISABLE_MOUSE);
+
+    stdout.write.mockClear();
+    unmount();
+    expect(stdout.write).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/ui/hooks/useMouseEvents.ts
+++ b/packages/cli/src/ui/hooks/useMouseEvents.ts
@@ -3,10 +3,9 @@
  * Copyright 2025 Qwen
  * SPDX-License-Identifier: Apache-2.0
  *
- * Inspired by gemini-cli's MouseContext (Google LLC, Apache-2.0) but
- * collapsed for our single-consumer case: enable SGR mouse mode on
- * mount, parse mouse sequences out of the KeypressContext pipeline,
- * call the handler, restore on unmount.
+ * Inspired by gemini-cli's MouseContext (Google LLC, Apache-2.0): enable SGR
+ * mouse mode while at least one subscriber is active, parse mouse sequences
+ * out of the KeypressContext pipeline, call each handler, restore on cleanup.
  */
 
 import { useEffect, useRef, useCallback } from 'react';
@@ -19,6 +18,47 @@ import {
 import { useKeypressContext } from '../contexts/KeypressContext.js';
 
 export type MouseHandler = (event: MouseEvent) => void;
+
+type MouseModeEntry = {
+  refs: number;
+};
+
+const mouseModeRefs = new Map<NodeJS.WriteStream, MouseModeEntry>();
+
+const disableAllMouseModes = () => {
+  for (const stdout of mouseModeRefs.keys()) {
+    disableMouseEvents(stdout);
+  }
+  mouseModeRefs.clear();
+};
+
+function acquireMouseMode(stdout: NodeJS.WriteStream): void {
+  const entry = mouseModeRefs.get(stdout);
+  if (entry) {
+    entry.refs += 1;
+    return;
+  }
+
+  enableMouseEvents(stdout);
+  if (mouseModeRefs.size === 0) {
+    process.on('exit', disableAllMouseModes);
+  }
+  mouseModeRefs.set(stdout, { refs: 1 });
+}
+
+function releaseMouseMode(stdout: NodeJS.WriteStream): void {
+  const entry = mouseModeRefs.get(stdout);
+  if (!entry) return;
+
+  entry.refs -= 1;
+  if (entry.refs <= 0) {
+    mouseModeRefs.delete(stdout);
+    disableMouseEvents(stdout);
+    if (mouseModeRefs.size === 0) {
+      process.removeListener('exit', disableAllMouseModes);
+    }
+  }
+}
 
 /**
  * Subscribes to SGR mouse events while `isActive` is true.
@@ -54,16 +94,10 @@ export function useMouseEvents(
   useEffect(() => {
     if (!enabled) return;
 
-    enableMouseEvents(stdout);
-
-    const onExit = () => {
-      disableMouseEvents(stdout);
-    };
-    process.on('exit', onExit);
+    acquireMouseMode(stdout);
 
     return () => {
-      process.removeListener('exit', onExit);
-      disableMouseEvents(stdout);
+      releaseMouseMode(stdout);
     };
   }, [enabled, stdout]);
 


### PR DESCRIPTION
## What this PR does

This PR stabilizes mouse interactions in the virtualized terminal viewport. It keeps terminal mouse tracking enabled until every active mouse subscriber has been cleaned up, so a collapsed thinking block or overlay can no longer disable mouse reporting while the viewport still needs wheel or click events. It also adds scrollbar hit-testing for the virtualized list so users can click and drag the in-app scrollbar to move through long output.

## Why it's needed

Virtualized viewport mode is the path that avoids terminal scrollback redraw flicker, but it needs to preserve expected terminal interactions before it can be considered safe as a default. Maintainer feedback on #5738 called out two blockers: mouse scrolling / scrollbar dragging did not work reliably, and collapsed thinking blocks could fail to open with mouse clicks. The underlying issue was that mouse mode was managed per component even though it is a global terminal setting, and scrollbar dragging had not been implemented.

## Reviewer Test Plan

### How to verify

Run the focused viewport mouse tests and confirm they pass. Reviewers can also run the CLI with `ui.useTerminalBuffer` enabled, produce enough output to show the in-app scrollbar, then verify that the mouse wheel scrolls the viewport, dragging the scrollbar moves to the expected portion of history, and clicking a collapsed thinking line opens the thinking viewer.

### Evidence (Before & After)

Before: the new regression tests fail because deactivating one mouse subscriber writes the terminal mouse-disable sequence while another subscriber remains active, and scrollbar press / drag events do not move the rendered viewport. After: the regression tests pass, along with adjacent virtualized list, history item, and mouse parser tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Local macOS development environment with Node.js 22 workspace dependencies.

## Risk & Scope

- Main risk or tradeoff: scrollbar dragging now depends on measured viewport coordinates; the behavior is limited to the existing scrollbar column and returns false for content-area clicks.
- Not validated / out of scope: this does not change the default value of `ui.useTerminalBuffer`; it only fixes VP mouse interaction blockers.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #5738 maintainer feedback.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 稳定了虚拟终端视口里的鼠标交互。它会等所有活跃的鼠标订阅者都清理完之后，才关闭终端鼠标追踪，因此 collapsed thinking block 或 overlay 不会再在 viewport 仍然需要滚轮/点击事件时误关鼠标上报。它还为虚拟列表增加了滚动条 hit-test，让用户可以点击并拖动应用内滚动条浏览长输出。

## Why it's needed

虚拟视口模式是避免 terminal scrollback 重绘闪屏的路径，但在考虑默认开启之前，需要先保留用户期望的终端交互。#5738 的 maintainer 反馈指出两个 blocker：鼠标滚动/滚动条拖拽不可靠，以及 collapsed thinking block 可能无法通过鼠标点击打开。根因是鼠标模式虽然是全局终端设置，却按组件单独开关；同时滚动条拖拽之前没有实现。

## Reviewer Test Plan

### How to verify

运行聚焦的 viewport mouse 测试并确认通过。Reviewer 也可以启用 `ui.useTerminalBuffer` 运行 CLI，产生足够长的输出让应用内滚动条出现，然后确认鼠标滚轮可以滚动 viewport，拖动滚动条可以移动到预期的历史位置，点击 collapsed thinking 行可以打开 thinking viewer。

### Evidence (Before & After)

Before：新增回归测试会失败，因为一个鼠标订阅者失活时会写入终端鼠标关闭序列，即使另一个订阅者仍然活跃；同时滚动条按下/拖拽事件不会移动渲染窗口。After：这些回归测试通过，相邻的 virtualized list、history item 和 mouse parser 测试也通过。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

本地 macOS 开发环境，使用 Node.js 22 workspace dependencies。

## Risk & Scope

- Main risk or tradeoff：滚动条拖拽现在依赖测量到的 viewport 坐标；行为限制在现有滚动条列内，内容区点击会返回 false。
- Not validated / out of scope：这次不修改 `ui.useTerminalBuffer` 的默认值，只修复 VP 鼠标交互 blocker。
- Breaking changes / migration notes：无。

## Linked Issues

跟进 #5738 的 maintainer 反馈。

</details>
