### PR TITLE
fix(cli): source /context token total from the per-session chat

### DIFF
--- a/packages/cli/src/ui/commands/contextCommand.test.ts
+++ b/packages/cli/src/ui/commands/contextCommand.test.ts
@@ -90,6 +90,48 @@ describe('collectContextData (contextCommand)', () => {
     expect(getFunctionDeclarationsSpy).toHaveBeenCalledWith();
   });
 
+  it('reads the per-session chat token count, not the process-global singleton (#5763)', async () => {
+    // uiTelemetryService is a module-level singleton shared by every session
+    // in a `serve` daemon. Reading it here would report whichever session most
+    // recently completed a turn. The active chat carries the correct
+    // per-session value and must win.
+    mockGetLastPromptTokenCount.mockReturnValue(999_000); // wrong session's global value
+    const getLastPromptTokenCount = vi.fn().mockReturnValue(50_000);
+    const config = {
+      ...makeMockConfig(200_000),
+      getGeminiClient: vi.fn().mockReturnValue({
+        isInitialized: vi.fn().mockReturnValue(true),
+        getChat: vi.fn().mockReturnValue({ getLastPromptTokenCount }),
+      }),
+    } as unknown as Config;
+
+    const data = await collectContextData(config, false);
+
+    expect(getLastPromptTokenCount).toHaveBeenCalled();
+    expect(data.totalTokens).toBe(50_000);
+    // 50K < warn(147K); if the 999K global had leaked through it would be `hard`.
+    expect(data.breakdown.currentTier).toBe('safe');
+  });
+
+  it('falls back to the global singleton when the session chat is not initialized', async () => {
+    // First /context or --continue resume before any send: getChat() would
+    // throw, so collectContextData must use the global value instead.
+    mockGetLastPromptTokenCount.mockReturnValue(60_000);
+    const config = {
+      ...makeMockConfig(200_000),
+      getGeminiClient: vi.fn().mockReturnValue({
+        isInitialized: vi.fn().mockReturnValue(false),
+        getChat: vi.fn(() => {
+          throw new Error('Chat not initialized');
+        }),
+      }),
+    } as unknown as Config;
+
+    const data = await collectContextData(config, false);
+
+    expect(data.totalTokens).toBe(60_000);
+  });
+
   it('excludes deferred-but-not-revealed tools from the per-tool breakdown (#4508)', async () => {
     // Regression: /context used to surface every deferred tool (MCP tools,
     // plus low-frequency built-ins like web_fetch / monitor / cron_*) even

--- a/packages/cli/src/ui/commands/contextCommand.ts
+++ b/packages/cli/src/ui/commands/contextCommand.ts
@@ -108,7 +108,19 @@ export async function collectContextData(
   const contextWindowSize =
     contentGeneratorConfig.contextWindowSize ?? DEFAULT_TOKEN_LIMIT;
 
-  const apiTotalTokens = uiTelemetryService.getLastPromptTokenCount();
+  // Prefer the per-session chat's API-reported count. `uiTelemetryService` is
+  // a process-global singleton shared by every session in a `serve` daemon, so
+  // reading it here reports whichever session most recently completed a turn
+  // (#5763). The active chat carries the correct per-session value; fall back
+  // to the global singleton only when no chat exists yet (first /context,
+  // --continue resume before any send).
+  const geminiClient = config.getGeminiClient?.();
+  const apiTotalTokens = geminiClient?.isInitialized?.()
+    ? geminiClient.getChat().getLastPromptTokenCount()
+    : uiTelemetryService.getLastPromptTokenCount();
+  // Cached-content tokens have no per-chat mirror today (only the global
+  // singleton is written, geminiChat.ts), so this read stays global. It only
+  // refines the messages-vs-cache split, not the headline total or tier.
   const apiCachedTokens = uiTelemetryService.getLastCachedContentTokenCount();
 
   const systemPromptText = getCoreSystemPrompt(undefined, modelName);


### PR DESCRIPTION
## What this PR does

`collectContextData`, which powers both CLI `/context` and the serve `GET /session/:id/context-usage` route, now reads the prompt token total from the current session's `GeminiChat` instead of the process-global `uiTelemetryService` singleton. It still falls back to the singleton when no chat is initialized yet.

## Why it's needed

In a `qwen serve` daemon, multiple sessions share one process. The global telemetry singleton stores only the last completed turn across that process, so every session's `/context-usage` could report the same prompt-token total: whichever session most recently completed a turn. The per-session chat already tracks the correct value.

## Reviewer Test Plan

### How to verify

1. Start `qwen serve` and create two sessions.
2. Send a materially different prompt in each session so their context token totals diverge.
3. Call `GET /session/:id/context-usage` for both sessions.
4. Confirm each response reports that session's own prompt-token total rather than the most recent global total.
5. In the CLI, run `/context` in a single active session and confirm the reported total remains unchanged from existing behavior.

### Evidence (Before & After)

Before: `collectContextData` read `uiTelemetryService.getLastPromptTokenCount()`, a process-global value shared by all serve sessions.

After: it prefers `config.getGeminiClient().getChat().getLastPromptTokenCount()` when the session chat is initialized, with tests covering both the per-session path and the uninitialized fallback path.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS     | tested |
|  Windows   | not tested |
|  Linux     | not tested |

### Environment (optional)

Focused context data tests and existing context command / ACP agent suites.

## Risk & Scope

- Main risk or tradeoff: the headline prompt-token total now comes from the session chat when available, so serve sessions no longer share a stale cross-session value.
- Cached-content token accounting remains on the global singleton because there is no per-chat mirror today; this only affects the messages-vs-cache split, not the headline total or tier.
- Single-session CLI `/context` should be behaviorally unchanged because the global value and that session's chat value coincide there.
- Breaking changes / migration notes: none expected.

## Linked Issues

Closes #5763

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

`collectContextData` 同时支撑 CLI `/context` 和 serve 的 `GET /session/:id/context-usage`。它现在优先从当前 session 的 `GeminiChat` 读取 prompt token 总数，而不是读取进程级全局 `uiTelemetryService` 单例；当 chat 尚未初始化时仍回退到全局值。

## 为什么需要

`qwen serve` daemon 里多个 session 共享同一个进程。全局 telemetry 单例只保存整个进程最近一次完成 turn 的 token 数，因此不同 session 的 `/context-usage` 可能都显示同一个值：最后完成 turn 的那个 session 的值。每个 session 自己的 chat 已经保存了正确值。

## 评审验证步骤

1. 启动 `qwen serve` 并创建两个 session。
2. 在两个 session 中分别发送明显不同长度的 prompt，让 context token 总数不同。
3. 分别调用两个 session 的 `GET /session/:id/context-usage`。
4. 确认每个响应返回各自 session 的 prompt-token 总数，而不是最近一次全局值。
5. 在单个 CLI session 中运行 `/context`，确认输出与既有行为一致。

## 风险与范围

- 主要风险或取舍：headline prompt-token 总数现在在可用时来自 session chat，因此 serve session 不再共享过期的跨 session 值。
- cached-content token 仍使用全局单例，因为当前没有 per-chat 镜像；这只影响 messages-vs-cache 拆分，不影响 headline total 或 tier。
- 单 session CLI `/context` 行为应保持不变，因为全局值与该 session chat 值一致。
- 破坏性变更：无。

</details>
