### PR TITLE
fix(core): Disambiguate duplicate model display names

### DIFF
--- a/packages/core/src/models/modelsConfig.test.ts
+++ b/packages/core/src/models/modelsConfig.test.ts
@@ -2602,6 +2602,39 @@ describe('ModelsConfig', () => {
       expect(modelsConfig.getModelDisplayName('gpt-4o')).toBe('GPT-4o');
     });
 
+    it('should disambiguate duplicate model ids by current baseUrl', async () => {
+      const idealabBaseUrl = 'https://idealab.example.com/api/openai/v1';
+      const modelProvidersConfig: ModelProvidersConfig = {
+        openai: [
+          {
+            id: 'qwen3.7-max',
+            name: '[Token Plan] qwen3.7-max',
+            baseUrl: 'https://token-plan.example.com/v1',
+            envKey: 'TOKEN_PLAN_API_KEY',
+          },
+          {
+            id: 'qwen3.7-max',
+            name: '[Idealab] qwen3.7-max',
+            baseUrl: idealabBaseUrl,
+            envKey: 'IDEALAB_API_KEY',
+          },
+        ],
+      };
+
+      const modelsConfig = new ModelsConfig({
+        initialAuthType: AuthType.USE_OPENAI,
+        modelProvidersConfig,
+      });
+
+      await modelsConfig.switchModel(AuthType.USE_OPENAI, 'qwen3.7-max', {
+        baseUrl: idealabBaseUrl,
+      });
+
+      expect(modelsConfig.getModelDisplayName('qwen3.7-max')).toBe(
+        '[Idealab] qwen3.7-max',
+      );
+    });
+
     it('should return raw modelId when currentAuthType is falsy', () => {
       const modelsConfig = new ModelsConfig();
       // currentAuthType is undefined by default

--- a/packages/core/src/models/modelsConfig.ts
+++ b/packages/core/src/models/modelsConfig.ts
@@ -321,7 +321,12 @@ export class ModelsConfig {
    */
   getModelDisplayName(modelId: string): string {
     if (!this.currentAuthType) return modelId;
-    const resolved = this.modelRegistry.getModel(this.currentAuthType, modelId);
+    const resolved =
+      this.modelRegistry.getModel(
+        this.currentAuthType,
+        modelId,
+        this._generationConfig.baseUrl || undefined,
+      ) ?? this.modelRegistry.getModel(this.currentAuthType, modelId);
     return resolved?.name ?? modelId;
   }
 


### PR DESCRIPTION
## What this PR does

This PR makes the active model display resolve duplicate provider entries with the current resolved base URL before falling back to the existing id-only lookup. When multiple OpenAI-compatible providers use the same model id, the CLI now shows the provider label that matches the endpoint actually configured for the active session.

## Why it's needed

After selecting a non-first provider for a duplicated model id such as `qwen3.7-max`, the persisted configuration and runtime requests can correctly use that provider's base URL while the header and status line still show the first provider's label. That makes the selection look like it reverted after restart even though `/about` and the request route point at the selected provider.

## Reviewer Test Plan

### How to verify

Configure two `modelProviders.openai` entries with the same model id and different names/base URLs, select the non-first entry, restart the CLI, and confirm the header/status line label matches the same provider shown by `/about` Base URL. The regression test also exercises this state directly by switching to the second duplicate entry via base URL and checking that the displayed name follows that exact provider.

### Evidence (Before & After)

Before: on local `qwen 0.19.1`, selecting the IdeaLab `qwen3.7-max` entry made `/about` show `https://idealab.alibaba-inc.com/api/openai/v1`, but the header/status line still showed the first `[ModelStudio Token Plan] qwen3.7-max` entry. After: the new regression test covers this exact duplicate-id state and expects the displayed name to resolve to the provider selected by the active base URL. Source TUI capture was not completed because this checkout's dev CLI currently fails before render on an existing Ink subpath export issue unrelated to this change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js v22.22.3, npm 10.9.8, macOS Darwin 25.4.0 arm64. Validated with `npx vitest run src/models/modelsConfig.test.ts`, `npx vitest run src/config/config.test.ts -t "getModelDisplayName"`, `npm run build --workspace=packages/core`, and `npm run typecheck --workspace=packages/core`. Full root build was not used as the pass/fail signal because this checkout currently fails in the CLI package on an existing `ink/dom` and `ink/components/CursorContext` subpath/type issue unrelated to this PR.

## Risk & Scope

- Main risk or tradeoff: Low; this only changes display-name resolution and keeps the previous id-only lookup as the fallback when no exact base URL match is available.
- Not validated / out of scope: Source TUI after-capture is not included because the local dev CLI is blocked by the existing Ink subpath issue; ACP/OpenWork provider identity handling remains out of scope and should be handled separately.
- Breaking changes / migration notes: None.

## Linked Issues

Related to #5173. Does not address #4877.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让当前模型的展示名在回退到原有的仅按 id 查找之前，先使用当前解析出的 base URL 来匹配重复的 provider 配置。当多个 OpenAI-compatible provider 使用相同模型 id 时，CLI 现在会显示与当前会话实际配置 endpoint 一致的 provider 标签。

## Why it's needed

当用户为类似 `qwen3.7-max` 这种重复模型 id 选择非第一条 provider 后，持久化配置和运行时请求可能已经正确使用该 provider 的 base URL，但 header 和 status line 仍显示第一条 provider 的标签。这会让选择看起来像是在重启后回退了，即使 `/about` 和实际请求路由都指向用户选中的 provider。

## Reviewer Test Plan

### How to verify

配置两条 `modelProviders.openai`，让它们使用相同模型 id 但不同名称和 base URL，选择非第一条后重启 CLI，并确认 header/status line 的标签与 `/about` Base URL 显示的是同一个 provider。新增的回归测试也直接覆盖了这个状态：通过 base URL 切换到第二条重复配置，并检查展示名跟随该精确 provider。

### Evidence (Before & After)

Before：本地 `qwen 0.19.1` 中选择 IdeaLab 的 `qwen3.7-max` 后，`/about` 显示 `https://idealab.alibaba-inc.com/api/openai/v1`，但 header/status line 仍显示第一条 `[ModelStudio Token Plan] qwen3.7-max`。After：新增回归测试覆盖了这个重复 id 状态，并期望展示名解析到当前 active base URL 选中的 provider。由于当前 checkout 的 dev CLI 在渲染前会被一个既有 Ink subpath export 问题阻塞，所以没有完成源码版 TUI 截图验证；该问题与本次变更无关。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js v22.22.3、npm 10.9.8、macOS Darwin 25.4.0 arm64。已通过 `npx vitest run src/models/modelsConfig.test.ts`、`npx vitest run src/config/config.test.ts -t "getModelDisplayName"`、`npm run build --workspace=packages/core` 和 `npm run typecheck --workspace=packages/core` 验证。完整 root build 没有作为通过/失败信号，因为当前 checkout 在 CLI 包中会因为既有的 `ink/dom` 与 `ink/components/CursorContext` subpath/type 问题失败，该问题与本 PR 无关。

## Risk & Scope

- Main risk or tradeoff：风险较低；本 PR 只改变展示名解析，并在没有精确 base URL 匹配时保留原有的仅按 id 查找回退逻辑。
- Not validated / out of scope：由于本地 dev CLI 被既有 Ink subpath 问题阻塞，没有提供源码版 TUI 的 after 截图；ACP/OpenWork 的 provider identity 处理不在本 PR 范围内，应单独修复。
- Breaking changes / migration notes：无。

## Linked Issues

Related to #5173。Does not address #4877。

</details>
