### PR TITLE
feat(cli): match MCP resources globally on bare @ and show full references

### DIFF
--- a/packages/cli/src/ui/components/SuggestionsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.test.tsx
@@ -71,6 +71,52 @@ describe('SuggestionsDisplay', () => {
     expect(output.split('\n').length).toBeLessThanOrEqual(2);
   });
 
+  it('keeps the full MCP resource reference on one line and truncates its description (reverse mode)', () => {
+    // Two resources that share a long `server:scheme://` prefix and differ only
+    // in the tail — the discriminating part. The reference (label) must stay
+    // intact on a single line so the two rows are distinguishable; the
+    // description yields the width and truncates instead.
+    const a = 'asys-mcp-http:asight://skills/ppu_bubble_analysis';
+    const b = 'asys-mcp-http:asight://skills/ppu_operator_performance';
+    const { lastFrame } = render(
+      <SuggestionsDisplay
+        suggestions={[
+          {
+            label: a,
+            value: a,
+            description:
+              'Analyze PPU bubble (idle time) from a loaded trace report.',
+          },
+          {
+            label: b,
+            value: b,
+            description:
+              'Analyze PPU operator performance from a loaded trace report.',
+          },
+        ]}
+        activeIndex={0}
+        isLoading={false}
+        width={80}
+        scrollOffset={0}
+        userInput="asys-mcp-http:asight"
+        mode="reverse"
+      />,
+    );
+
+    const output = lastFrame() ?? '';
+    // Each full reference appears verbatim (the tail is NOT truncated away), so
+    // the two rows can be told apart.
+    expect(output).toContain(a);
+    expect(output).toContain(b);
+    // The description is what gets cut — its tail must be gone, ellipsized.
+    expect(output).toContain('…');
+    expect(output).not.toContain('loaded trace report.');
+    // One visible row per suggestion: the label is not wrapped onto extra lines.
+    expect(
+      output.split('\n').filter((l) => l.includes('asys-mcp-http:')),
+    ).toHaveLength(2);
+  });
+
   it('collapses newlines in multi-line descriptions so a row stays one line', () => {
     const description = [
       'First line of the skill description.',

--- a/packages/cli/src/ui/components/SuggestionsDisplay.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.tsx
@@ -56,6 +56,13 @@ export const MAX_SUGGESTIONS_TO_SHOW = 8;
 export { MAX_WIDTH };
 
 /**
+ * In @-mention mode a wide resource-reference column must still leave the row's
+ * description at least this many columns, so an unusually long reference can't
+ * shrink the description away entirely.
+ */
+const MIN_DESCRIPTION_WIDTH = 12;
+
+/**
  * Collapse all runs of whitespace (including newlines from multi-line
  * SKILL.md/command descriptions) into single spaces so a description renders
  * as a single logical line. Without this, frontmatter line breaks are
@@ -101,8 +108,25 @@ export function SuggestionsDisplay({
   const maxLabelLength = Math.max(
     ...suggestions.map((s) => getFullLabel(s).length),
   );
-  const commandColumnWidth =
-    mode === 'slash' ? Math.min(maxLabelLength, Math.floor(width * 0.5)) : 0;
+  // Width of the left label column. In slash mode every row shares one
+  // half-width command column. In @-mention (reverse) mode only rows WITH a
+  // description (MCP resources/servers) share a column — sized to the longest
+  // such reference so the references stay intact and their descriptions line
+  // up, capped so the description keeps a minimum readable width — while plain
+  // file rows (no description) keep the full row width. The reference takes
+  // priority over its description, which truncates.
+  const describedLabelLengths = suggestions
+    .filter((s) => s.description)
+    .map((s) => getFullLabel(s).length);
+  const labelColumnWidth =
+    mode === 'slash'
+      ? Math.min(maxLabelLength, Math.floor(width * 0.5))
+      : describedLabelLengths.length > 0
+        ? Math.min(
+            Math.max(...describedLabelLengths),
+            Math.max(width - MIN_DESCRIPTION_WIDTH - 2, 1),
+          )
+        : 0;
 
   return (
     <Box flexDirection="column" width={width}>
@@ -117,7 +141,7 @@ export function SuggestionsDisplay({
         const isLong = displayLabel.length >= MAX_WIDTH;
         const expansionIndicatorWidth = isActive && isLong ? 3 : 0;
         const descriptionColumnWidth = Math.max(
-          width - commandColumnWidth - 2 - expansionIndicatorWidth,
+          width - labelColumnWidth - 2 - expansionIndicatorWidth,
           1,
         );
         const labelElement = (
@@ -133,8 +157,8 @@ export function SuggestionsDisplay({
         return (
           <Box key={`${suggestion.value}-${originalIndex}`} flexDirection="row">
             <Box
-              {...(mode === 'slash'
-                ? { width: commandColumnWidth, flexShrink: 0 as const }
+              {...(mode === 'slash' || suggestion.description
+                ? { width: labelColumnWidth, flexShrink: 0 as const }
                 : { flexShrink: 1 as const })}
             >
               <Box>

--- a/packages/cli/src/ui/hooks/useAtCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.test.ts
@@ -959,4 +959,166 @@ describe('useAtCompletion', () => {
       expect(values).toContain('my-notes.txt');
     });
   });
+
+  describe('Global MCP resource completion', () => {
+    it('matches resources globally for a bare @<partial> with no server prefix', async () => {
+      testRootDir = await createTmpDir({ 'unrelated.txt': '' });
+      const resourceConfig = {
+        ...mockConfig,
+        getMcpServers: () => ({ 'asys-mcp-http': {} }),
+        getResourceRegistry: () => ({
+          getResourcesByServer: () => [],
+          getAllResources: () => [
+            {
+              uri: 'asight://skills/ppu_bubble',
+              name: 'bubble',
+              serverName: 'asys-mcp-http',
+            },
+            {
+              uri: 'asight://skills/ppu_op',
+              name: 'op',
+              serverName: 'asys-mcp-http',
+            },
+          ],
+        }),
+      } as unknown as Config;
+
+      const { result } = renderHook(() =>
+        useTestHarnessForAtCompletion(
+          true,
+          'asight',
+          resourceConfig,
+          testRootDir,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(result.current.suggestions.length).toBeGreaterThan(0);
+      });
+      // 'asight' is not a configured server name and carries no ':' — yet both
+      // resources match by URI prefix and are injected as @server:uri.
+      const values = result.current.suggestions.map((s) => s.value);
+      expect(values).toContain('asys-mcp-http:asight://skills/ppu_bubble');
+      expect(values).toContain('asys-mcp-http:asight://skills/ppu_op');
+    });
+
+    it('matches a resource globally by its friendly name/title', async () => {
+      testRootDir = await createTmpDir({ 'file.txt': '' });
+      const resourceConfig = {
+        ...mockConfig,
+        getMcpServers: () => ({ demo: {} }),
+        getResourceRegistry: () => ({
+          getResourcesByServer: () => [],
+          getAllResources: () => [
+            {
+              uri: 'file:///x/spec.md',
+              name: 'spec',
+              title: 'Project Spec',
+              serverName: 'demo',
+            },
+          ],
+        }),
+      } as unknown as Config;
+
+      const { result } = renderHook(() =>
+        useTestHarnessForAtCompletion(
+          true,
+          'Project',
+          resourceConfig,
+          testRootDir,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(result.current.suggestions.length).toBeGreaterThan(0);
+      });
+      expect(result.current.suggestions.map((s) => s.value)).toContain(
+        'demo:file:///x/spec.md',
+      );
+    });
+
+    it('prepends globally-matched resources before file results', async () => {
+      // A file AND a resource both match 'doc'.
+      testRootDir = await createTmpDir({ 'doc.txt': '' });
+      const resourceConfig = {
+        ...mockConfig,
+        getMcpServers: () => ({ demo: {} }),
+        getResourceRegistry: () => ({
+          getResourcesByServer: () => [],
+          getAllResources: () => [
+            { uri: 'doc://readme', name: 'r', serverName: 'demo' },
+          ],
+        }),
+      } as unknown as Config;
+
+      const { result } = renderHook(() =>
+        useTestHarnessForAtCompletion(true, 'doc', resourceConfig, testRootDir),
+      );
+
+      await waitFor(() => {
+        expect(result.current.suggestions.length).toBeGreaterThan(1);
+      });
+      const values = result.current.suggestions.map((s) => s.value);
+      const resIdx = values.indexOf('demo:doc://readme');
+      const fileIdx = values.indexOf('doc.txt');
+      expect(resIdx).toBeGreaterThanOrEqual(0);
+      expect(fileIdx).toBeGreaterThanOrEqual(0);
+      // Resources come first so a file flood can't bury them.
+      expect(resIdx).toBeLessThan(fileIdx);
+    });
+
+    it('does not surface global resources for the empty @ trigger (files only)', async () => {
+      testRootDir = await createTmpDir({ 'file.txt': '' });
+      const resourceConfig = {
+        ...mockConfig,
+        getMcpServers: () => ({ demo: {} }),
+        getResourceRegistry: () => ({
+          getResourcesByServer: () => [],
+          getAllResources: () => [
+            { uri: 'res://x', name: 'x', serverName: 'demo' },
+          ],
+        }),
+      } as unknown as Config;
+
+      const { result } = renderHook(() =>
+        useTestHarnessForAtCompletion(true, '', resourceConfig, testRootDir),
+      );
+
+      await waitFor(() => {
+        expect(result.current.suggestions.length).toBeGreaterThan(0);
+      });
+      const values = result.current.suggestions.map((s) => s.value);
+      expect(values).toContain('file.txt');
+      expect(values).not.toContain('demo:res://x');
+    });
+
+    it('does not surface global resources in an untrusted folder', async () => {
+      testRootDir = await createTmpDir({ 'file.txt': '' });
+      const resourceConfig = {
+        ...mockConfig,
+        isTrustedFolder: () => false,
+        getMcpServers: () => ({ demo: {} }),
+        getResourceRegistry: () => ({
+          getResourcesByServer: () => [],
+          getAllResources: () => [
+            { uri: 'asight://secret', name: 's', serverName: 'demo' },
+          ],
+        }),
+      } as unknown as Config;
+
+      const { result } = renderHook(() =>
+        useTestHarnessForAtCompletion(
+          true,
+          'asight',
+          resourceConfig,
+          testRootDir,
+        ),
+      );
+
+      await new Promise((r) => setTimeout(r, 300));
+      expect(result.current.suggestions.map((s) => s.value)).not.toContain(
+        'demo:asight://secret',
+      );
+    });
+  });
 });

--- a/packages/cli/src/ui/hooks/useAtCompletion.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.ts
@@ -13,24 +13,87 @@ import { matchMcpServerPrefix, buildMcpResourceRef } from './mcpResourceRef.js';
 import { t } from '../../i18n/index.js';
 
 /**
- * `@server:uri` MCP resource completion. Returns suggestions when `pattern`
- * is of the form `<server>:<partial>` and `<server>` is a configured MCP
- * server (so a plain file path containing ':' is never hijacked); returns
- * `null` otherwise to let the caller fall through to filesystem search.
+ * Resource → suggestion input shape. Structurally satisfied by core's
+ * `DiscoveredMCPResource` (typed locally to avoid a core import / rebuild).
+ */
+type CompletableResource = {
+  uri: string;
+  name?: string;
+  title?: string;
+  serverName: string;
+};
+
+/**
+ * Lower rank = better match; `Infinity` means no match (filtered out). Shared by
+ * the per-server and global resource paths so their ranking can't drift, best
+ * first: URI prefix, then friendly-name prefix, then URI substring, then name
+ * substring. `query` must already be lower-cased.
+ */
+function rankResourceMatch(
+  uri: string,
+  friendly: string,
+  query: string,
+): number {
+  if (uri.startsWith(query)) return 0;
+  if (friendly.startsWith(query)) return 1;
+  if (uri.includes(query)) return 2;
+  if (friendly.includes(query)) return 3;
+  return Infinity;
+}
+
+/**
+ * Rank `resources` against `query` (already lower-cased) and project the matches
+ * onto completion suggestions, best first (ties break by the canonical
+ * `@server:uri` reference for a stable order).
  *
- * The partial after the colon is matched case-INsensitively against each
- * resource's URI AND its friendly name/title (the same `title || name` the
- * `/mcp` dialog shows), so a user who only remembers the human-readable name —
- * not the URI — still gets completions. An empty partial matches every
- * resource (`''` is a prefix of every string). Ranking, best first: URI prefix,
- * then name/title prefix, then URI substring, then name/title substring; ties
- * break alphabetically by URI for a stable order.
+ * The partial is matched case-INsensitively against each resource's URI AND its
+ * friendly name/title (the same `title || name` the `/mcp` dialog shows), so a
+ * user who only remembers the human-readable name — not the URI — still gets
+ * completions. An empty `query` matches every resource (`''` is a substring of
+ * every string); callers gate that where it is unwanted.
  *
  * The injected `value` is always the canonical `@server:uri` reference (the
  * friendly name is not a referenceable identifier); the name rides along as the
- * suggestion `description` so a name-only match is self-explanatory. The
- * resource list comes from the post-discovery `ResourceRegistry`, so an empty
- * result before discovery completes simply shows no suggestions.
+ * suggestion `description` only when it adds information beyond the URI (mirrors
+ * the `/mcp` resource list, which dims a redundant name).
+ */
+function rankResourcesToSuggestions(
+  resources: CompletableResource[],
+  query: string,
+): Suggestion[] {
+  return resources
+    .map((resource) => {
+      const friendly = resource.title || resource.name || '';
+      return {
+        resource,
+        friendly,
+        ref: buildMcpResourceRef(resource.serverName, resource.uri),
+        rank: rankResourceMatch(
+          resource.uri.toLowerCase(),
+          friendly.toLowerCase(),
+          query,
+        ),
+      };
+    })
+    .filter((m) => m.rank !== Infinity)
+    .sort((a, b) => a.rank - b.rank || a.ref.localeCompare(b.ref))
+    .slice(0, MAX_SUGGESTIONS_TO_SHOW * 3)
+    .map((m) => ({
+      label: m.ref,
+      value: m.ref,
+      description:
+        m.friendly && m.friendly !== m.resource.uri ? m.friendly : undefined,
+      isDirectory: false,
+    }));
+}
+
+/**
+ * `@server:uri` per-server MCP resource completion. Returns suggestions when
+ * `pattern` is of the form `<server>:<partial>` and `<server>` is a configured
+ * MCP server (so a plain file path containing ':' is never hijacked); returns
+ * `null` otherwise to let the caller fall through to filesystem search (and the
+ * global path below). The resource list comes from the post-discovery
+ * `ResourceRegistry`, so an empty result before discovery simply shows nothing.
  */
 function getMcpResourceSuggestions(
   config: Config | undefined,
@@ -46,46 +109,33 @@ function getMcpResourceSuggestions(
   const mcpServers = config.getMcpServers?.() || {};
   const match = matchMcpServerPrefix(pattern, Object.keys(mcpServers));
   if (!match) return null;
-  const serverName = match.serverName;
-  const query = match.rest.toLowerCase();
-
-  // Lower rank = better match; `Infinity` means no match and is filtered out.
-  const rankOf = (uri: string, friendly: string): number => {
-    if (uri.startsWith(query)) return 0;
-    if (friendly.startsWith(query)) return 1;
-    if (uri.includes(query)) return 2;
-    if (friendly.includes(query)) return 3;
-    return Infinity;
-  };
-
   const resources =
-    config.getResourceRegistry?.()?.getResourcesByServer(serverName) ?? [];
-  const matches = resources
-    .map((resource) => {
-      const friendly = resource.title || resource.name || '';
-      return {
-        resource,
-        friendly,
-        rank: rankOf(resource.uri.toLowerCase(), friendly.toLowerCase()),
-      };
-    })
-    .filter((m) => m.rank !== Infinity)
-    .sort(
-      (a, b) => a.rank - b.rank || a.resource.uri.localeCompare(b.resource.uri),
-    );
+    config.getResourceRegistry?.()?.getResourcesByServer(match.serverName) ??
+    [];
+  return rankResourcesToSuggestions(resources, match.rest.toLowerCase());
+}
 
-  return matches.slice(0, MAX_SUGGESTIONS_TO_SHOW * 3).map((m) => {
-    const ref = buildMcpResourceRef(serverName, m.resource.uri);
-    return {
-      label: ref,
-      value: ref,
-      // Only surface the friendly name when it adds information beyond the URI
-      // (mirrors the `/mcp` resource list, which dims a redundant name).
-      description:
-        m.friendly && m.friendly !== m.resource.uri ? m.friendly : undefined,
-      isDirectory: false,
-    };
-  });
+/**
+ * Bare `@<partial>` GLOBAL MCP resource completion. When the partial carries no
+ * `<server>:` prefix (so `getMcpResourceSuggestions` doesn't apply), match it
+ * against EVERY discovered resource across all servers, so a user can pull up a
+ * resource by a memorable fragment of its URI/name without first recalling which
+ * server exposes it. The injected `value` is still the canonical `@server:uri`.
+ *
+ * Returns `[]` (never `null`): like `getMcpServerSuggestions`, these are
+ * surfaced ALONGSIDE the filesystem results, never replacing them. The empty
+ * partial (bare `@`) is intentionally excluded — every resource would otherwise
+ * match — keeping the bare `@` a files-only view.
+ */
+function getGlobalMcpResourceSuggestions(
+  config: Config | undefined,
+  pattern: string,
+): Suggestion[] {
+  if (!config) return [];
+  if (config.isTrustedFolder?.() === false) return [];
+  if (pattern.length === 0) return [];
+  const resources = config.getResourceRegistry?.()?.getAllResources?.() ?? [];
+  return rankResourcesToSuggestions(resources, pattern.toLowerCase());
 }
 
 /**
@@ -344,20 +394,29 @@ export function useAtCompletion(props: UseAtCompletionProps): void {
         return;
       }
 
-      // No `<server>:` selected yet — offer matching MCP servers (that expose
-      // resources) ALONGSIDE the filesystem results so the user can discover a
-      // server without knowing a resource URI up front. Computed synchronously
-      // and prepended below; never hides files.
+      // No `<server>:` prefix yet — offer, ALONGSIDE the filesystem results
+      // (never hiding files): matching MCP servers (discovery, so the user can
+      // drill in without knowing a URI) AND resources matched globally by
+      // URI/name across all servers. Both computed synchronously and prepended
+      // below.
       const serverSuggestions = getMcpServerSuggestions(config, state.pattern);
+      const globalResourceSuggestions = getGlobalMcpResourceSuggestions(
+        config,
+        state.pattern,
+      );
+      const mcpSuggestions = [
+        ...serverSuggestions,
+        ...globalResourceSuggestions,
+      ];
 
       if (!fileSearch.current) {
-        // File index not ready yet; still surface any server matches so
-        // discovery doesn't have to wait on the crawler.
-        if (serverSuggestions.length > 0) {
+        // File index not ready yet; still surface any MCP matches so they
+        // don't have to wait on the crawler.
+        if (mcpSuggestions.length > 0) {
           if (slowSearchTimer.current) {
             clearTimeout(slowSearchTimer.current);
           }
-          dispatch({ type: 'SEARCH_SUCCESS', payload: serverSuggestions });
+          dispatch({ type: 'SEARCH_SUCCESS', payload: mcpSuggestions });
         }
         return;
       }
@@ -397,14 +456,14 @@ export function useAtCompletion(props: UseAtCompletionProps): void {
         }));
         dispatch({
           type: 'SEARCH_SUCCESS',
-          payload: [...serverSuggestions, ...fileSuggestions],
+          payload: [...mcpSuggestions, ...fileSuggestions],
         });
       } catch (error) {
         if (!(error instanceof Error && error.name === 'AbortError')) {
-          // A file-search failure shouldn't swallow server matches we already
+          // A file-search failure shouldn't swallow MCP matches we already
           // have; show those rather than dropping to an error state.
-          if (serverSuggestions.length > 0) {
-            dispatch({ type: 'SEARCH_SUCCESS', payload: serverSuggestions });
+          if (mcpSuggestions.length > 0) {
+            dispatch({ type: 'SEARCH_SUCCESS', payload: mcpSuggestions });
           } else {
             dispatch({ type: 'ERROR' });
           }


### PR DESCRIPTION
## What this PR does

Two related improvements to `@`-mention completion for MCP resources.

1. **Global resource matching on a bare `@`.** Previously a resource URI only completed after you typed its server name and a colon (`@myserver:…`). Now a bare `@<partial>` with no `<server>:` prefix matches the partial (case-insensitively) against every discovered resource's URI and friendly name across all connected servers, surfaced alongside the file results and injected as the canonical `@server:uri` reference. Server-name discovery (`@<partial>` → `@server:`) and the per-server path are unchanged; global matches are prepended to the file list so they stay visible without hiding files, and the bare `@` (empty partial) remains a files-only view.

2. **Full, aligned resource references in the dropdown.** An MCP resource row now keeps its complete `server:uri` reference on a single line; the description column yields the width and truncates instead. References that share a long prefix (e.g. several `server:scheme://skills/…` URIs) are no longer cut down to an identical `…`, so they stay distinguishable and their descriptions line up.

## Why it's needed

Resource references are long (`server` + `scheme://path`), and the dropdown previously let the description column dominate the row width, wrapping or truncating the reference so that resources sharing a prefix rendered identically and couldn't be told apart. Separately, requiring the exact server name before any resource would complete made resources hard to discover when you remember a fragment of the URI but not which server hosts it.

## Reviewer Test Plan

### How to verify

Configure any MCP server that exposes resources — e.g. a small stdio server whose `resources/list` returns a few entries with long shared-prefix URIs and descriptions. Then in the input box:

- Type `@<servername>:` — every resource is listed with its full `server:uri` reference intact and the descriptions aligned.
- Type a bare `@<fragment>` that matches a resource URI/name but is not a server name (e.g. the URI scheme) — the resources appear (prepended above files) and insert as `@server:uri`.
- Confirm an unrelated `@<path>` still lists files, and a bare `@` alone still shows files only.

Expected: full references are shown (not truncated to `…`) and the description truncates instead; the bare fragment surfaces matching resources across servers.

### Evidence (Before & After)

Server `asys-mcp-http` exposing `asight://skills/…` resources.

Before — the `@server:` reference is forced to wrap onto a second line, and a bare `@asight` matched no resources at all:

```
asys-mcp-http:asight://skills/   Analyze PPU bubble (idle time) from a loaded t…
ppu_bubble_analysis
```

After — full references on one line with aligned descriptions, and a bare `@asight` (no server prefix) matches globally:

```
* @asys-mcp-http:
  asys-mcp-http:asight://skills/hbm_bandwidth_utilization  HBM bandwidth utilization
  asys-mcp-http:asight://skills/ppu_bubble_analysis        PPU bubble analysis
  asys-mcp-http:asight://skills/ppu_operator_performance   PPU operator performance

* @asight
  asys-mcp-http:asight://skills/hbm_bandwidth_utilization  HBM bandwidth utilization
  asys-mcp-http:asight://skills/ppu_bubble_analysis        PPU bubble analysis
  asys-mcp-http:asight://skills/ppu_operator_performance   PPU operator performance
```

Selecting a row inserts `@asys-mcp-http:asight://skills/hbm_bandwidth_utilization`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

Built bundle (`npm run bundle`) run as `node --expose-gc dist/cli.js`, against a throwaway stdio MCP server, driven in tmux. Logic covered by vitest unit tests.

## Risk & Scope

- Main risk or tradeoff: global matching scans all discovered resources (in-memory, capped at the slice already used for the per-server path) on each prefix-free `@<partial>` keystroke and prepends matches before file results, so a very generic short fragment can surface several resources above files. Resource counts are typically small. Ordering (resources before files) and substring-vs-prefix matching are isolated and easy to tune.
- Not validated / out of scope: Windows/Linux (covered by CI); the per-server `@server:` path and slash-command completion are behavior-unchanged.
- Breaking changes / migration notes: none. The injected reference format (`@server:uri`) is unchanged.

## Linked Issues

Follows #5733. Refs #5601.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

对 MCP 资源的 `@` 提及补全做了两处相关改进。

1. **裸 `@` 的全局资源匹配。** 之前资源 URI 只有在先打出服务器名加冒号（`@myserver:…`）之后才会补全。现在没有 `<server>:` 前缀的裸 `@<partial>` 会把这段（不区分大小写）匹配到所有已连接服务器中每个已发现资源的 URI 和友好名称，与文件结果一起呈现，并以规范的 `@server:uri` 引用注入。服务器名发现（`@<partial>` → `@server:`）与按服务器路径都保持不变；全局匹配前插到文件列表之前以保证可见、且不隐藏文件，裸 `@`（空 partial）仍然是只看文件的视图。

2. **下拉里完整、对齐的资源引用。** MCP 资源行现在把完整的 `server:uri` 引用保持在一行；改由描述列让出宽度并截断。共享长前缀的引用（例如多个 `server:scheme://skills/…` URI）不再被切成一模一样的 `…`，因此可以区分，描述也对齐。

## 为什么需要

资源引用很长（`server` + `scheme://path`），而下拉之前让描述列占据了行宽，把引用换行或截断，导致共享前缀的资源渲染得一模一样、无法区分。另外，要求先打出准确的服务器名才能补全任何资源，使得"只记得 URI 的一个片段、却不知道哪个服务器托管它"时很难发现资源。

## 评审测试计划

### 如何验证

配置任意一个暴露资源的 MCP 服务器——例如一个小的 stdio 服务器，其 `resources/list` 返回几条带长共享前缀 URI 和描述的条目。然后在输入框：

- 打 `@<servername>:` —— 每个资源都以完整的 `server:uri` 引用列出，描述对齐。
- 打一个匹配资源 URI/名称但不是服务器名的裸 `@<fragment>`（例如 URI scheme）—— 资源出现（前插在文件之前）并以 `@server:uri` 注入。
- 确认无关的 `@<path>` 仍然列文件，单独一个裸 `@` 仍然只显示文件。

预期：显示完整引用（不被截成 `…`），改为描述截断；裸片段能跨服务器召出匹配的资源。

### 证据（前后对比）

服务器 `asys-mcp-http` 暴露 `asight://skills/…` 资源。

之前 —— `@server:` 引用被迫换行到第二行，且裸 `@asight` 完全匹配不到资源：

```
asys-mcp-http:asight://skills/   Analyze PPU bubble (idle time) from a loaded t…
ppu_bubble_analysis
```

之后 —— 完整引用一行显示、描述对齐，且裸 `@asight`（无服务器前缀）能全局匹配：

```
* @asys-mcp-http:
  asys-mcp-http:asight://skills/hbm_bandwidth_utilization  HBM bandwidth utilization
  asys-mcp-http:asight://skills/ppu_bubble_analysis        PPU bubble analysis
  asys-mcp-http:asight://skills/ppu_operator_performance   PPU operator performance

* @asight
  asys-mcp-http:asight://skills/hbm_bandwidth_utilization  HBM bandwidth utilization
  asys-mcp-http:asight://skills/ppu_bubble_analysis        PPU bubble analysis
  asys-mcp-http:asight://skills/ppu_operator_performance   PPU operator performance
```

选中某一行会插入 `@asys-mcp-http:asight://skills/hbm_bandwidth_utilization`。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

构建后的 bundle（`npm run bundle`）以 `node --expose-gc dist/cli.js` 运行，对接一个临时 stdio MCP 服务器，在 tmux 中驱动。逻辑由 vitest 单测覆盖。

## 风险与范围

- 主要风险/取舍：全局匹配会在每次无前缀的 `@<partial>` 键入时扫描所有已发现资源（内存内，沿用按服务器路径已有的 slice 上限），并把匹配前插到文件之前，因此非常宽泛的短片段可能把若干资源排到文件上方。资源数量通常很少。顺序（资源排在文件前）与子串/前缀匹配都是隔离的、易于调整。
- 未验证/范围外：Windows/Linux（由 CI 覆盖）；按服务器的 `@server:` 路径与斜杠命令补全行为不变。
- 破坏性变更/迁移说明：无。注入的引用格式（`@server:uri`）不变。

## 关联 Issue

Follows #5733. Refs #5601.

</details>
