### PR TITLE
fix(cli): match @ MCP resources by any URL substring, and stop label wrapping

### DIFF
--- a/packages/cli/src/ui/components/SuggestionsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.test.tsx
@@ -97,6 +97,37 @@ describe('SuggestionsDisplay', () => {
     expect(output).toContain('First line of the skill description.');
     expect(output).toContain('- bullet one - bullet two');
   });
+
+  it('keeps a reverse-mode label on one line when the row has a description', () => {
+    // Regression: an MCP server/resource suggestion (label + description) in
+    // `@` completion used to let the description column squeeze the label so it
+    // wrapped mid-string — the trailing `:` of `server:` landed on its own line.
+    const { lastFrame } = render(
+      <SuggestionsDisplay
+        suggestions={[
+          {
+            label: 'asys-mcp-http:',
+            value: 'asys-mcp-http:',
+            description: 'MCP resource server',
+            isDirectory: true,
+          },
+        ]}
+        activeIndex={0}
+        isLoading={false}
+        width={100}
+        scrollOffset={0}
+        userInput="asys-mcp"
+        mode="reverse"
+      />,
+    );
+
+    const output = lastFrame() ?? '';
+    // The whole label (colon included) sits on a single line, before the desc.
+    expect(output).toContain('asys-mcp-http:  MCP resource server');
+    // And the label is not split across lines.
+    expect(output).not.toMatch(/asys-mcp-http\n/);
+    expect(output.split('\n').length).toBe(1);
+  });
 });
 
 describe('normalizeDescription', () => {

--- a/packages/cli/src/ui/components/SuggestionsDisplay.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.tsx
@@ -135,7 +135,17 @@ export function SuggestionsDisplay({
             <Box
               {...(mode === 'slash'
                 ? { width: commandColumnWidth, flexShrink: 0 as const }
-                : { flexShrink: 1 as const })}
+                : // In reverse (`@`) mode a row with a description (e.g. an MCP
+                  // resource/server suggestion) must not let the greedy
+                  // description column shrink the label — otherwise the label
+                  // wraps mid-string (e.g. the trailing `:` of `server:` lands
+                  // on its own line). Pin the label (`flexShrink: 0`) so the
+                  // description column absorbs the shrink and truncates instead.
+                  // Description-less rows (plain files) keep the old shrink
+                  // behaviour so a long path can still wrap rather than overflow.
+                  {
+                    flexShrink: suggestion.description ? 0 : 1,
+                  })}
             >
               <Box>
                 {labelElement}

--- a/packages/cli/src/ui/hooks/useAtCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.test.ts
@@ -959,4 +959,141 @@ describe('useAtCompletion', () => {
       expect(values).toContain('my-notes.txt');
     });
   });
+
+  describe('MCP resource discovery (bare @<partial>)', () => {
+    const twoServerRegistry = () => {
+      const all = [
+        {
+          uri: 'asight://skills/analyze_ppu_op',
+          name: 'analyze_ppu_op',
+          title: 'Analyze PPU operator performance',
+          serverName: 'asys-mcp-http',
+        },
+        {
+          uri: 'asight://skills/analyze_ppu_bubble',
+          name: 'analyze_ppu_bubble',
+          serverName: 'asys-mcp-http',
+        },
+        {
+          uri: 'db://users/schema',
+          name: 'user schema',
+          serverName: 'other',
+        },
+      ];
+      return {
+        getAllResources: () => all,
+        getResourcesByServer: (name: string) =>
+          all.filter((r) => r.serverName === name),
+      };
+    };
+
+    const discoveryConfig = (overrides = {}) =>
+      ({
+        ...mockConfig,
+        getMcpServers: () => ({ 'asys-mcp-http': {}, other: {} }),
+        getResourceRegistry: twoServerRegistry,
+        ...overrides,
+      }) as unknown as Config;
+
+    // NOTE: the config object is created ONCE per test and held in a stable
+    // `const` before renderHook. Building it inside the render thunk would make
+    // a new reference every render, re-firing the hook's `[config]` effect in a
+    // RESET → re-init → re-render loop that spins up FileSearch workers forever.
+    it('matches a resource by any substring of its URI, not just a prefix', async () => {
+      testRootDir = await createTmpDir({ 'unrelated.txt': '' });
+      // `analyze` appears mid-URI (after `asight://skills/`), and there is no
+      // server named `analyze` — the old prefix-only path returned nothing.
+      const config = discoveryConfig();
+      const { result } = renderHook(() =>
+        useTestHarnessForAtCompletion(true, 'analyze', config, testRootDir),
+      );
+
+      await waitFor(() => {
+        expect(result.current.suggestions.length).toBeGreaterThan(0);
+      });
+      const values = result.current.suggestions.map((s) => s.value);
+      expect(values).toContain('asys-mcp-http:asight://skills/analyze_ppu_op');
+      expect(values).toContain(
+        'asys-mcp-http:asight://skills/analyze_ppu_bubble',
+      );
+    });
+
+    it('matches resources across all servers (no server prefix needed)', async () => {
+      testRootDir = await createTmpDir({ 'unrelated.txt': '' });
+      // `://` is in every URI here; both servers' resources should surface.
+      const config = discoveryConfig();
+      const { result } = renderHook(() =>
+        useTestHarnessForAtCompletion(true, '://', config, testRootDir),
+      );
+
+      await waitFor(() => {
+        expect(result.current.suggestions.length).toBeGreaterThan(0);
+      });
+      const values = result.current.suggestions.map((s) => s.value);
+      expect(values).toContain('asys-mcp-http:asight://skills/analyze_ppu_op');
+      expect(values).toContain('other:db://users/schema');
+    });
+
+    it('matches a resource by a substring of its friendly name/title', async () => {
+      testRootDir = await createTmpDir({ 'unrelated.txt': '' });
+      // `schema` is only in the name, not the URI scheme path.
+      const config = discoveryConfig();
+      const { result } = renderHook(() =>
+        useTestHarnessForAtCompletion(true, 'schema', config, testRootDir),
+      );
+
+      await waitFor(() => {
+        expect(result.current.suggestions.length).toBeGreaterThan(0);
+      });
+      expect(result.current.suggestions.map((s) => s.value)).toContain(
+        'other:db://users/schema',
+      );
+    });
+
+    it('surfaces resources ALONGSIDE files without hiding them', async () => {
+      testRootDir = await createTmpDir({ 'analyze_local.txt': '' });
+      const config = discoveryConfig();
+      const { result } = renderHook(() =>
+        useTestHarnessForAtCompletion(true, 'analyze', config, testRootDir),
+      );
+
+      await waitFor(() => {
+        expect(result.current.suggestions.length).toBeGreaterThan(0);
+      });
+      const values = result.current.suggestions.map((s) => s.value);
+      // Both the MCP resource and the matching file are present.
+      expect(values).toContain('asys-mcp-http:asight://skills/analyze_ppu_op');
+      expect(values).toContain('analyze_local.txt');
+    });
+
+    it('does not surface resources for the empty @ trigger (files only)', async () => {
+      testRootDir = await createTmpDir({ 'file.txt': '' });
+      const config = discoveryConfig();
+      const { result } = renderHook(() =>
+        useTestHarnessForAtCompletion(true, '', config, testRootDir),
+      );
+
+      await waitFor(() => {
+        expect(result.current.suggestions.length).toBeGreaterThan(0);
+      });
+      const values = result.current.suggestions.map((s) => s.value);
+      expect(values).toContain('file.txt');
+      expect(values.some((v) => v.includes('asight://'))).toBe(false);
+    });
+
+    it('does not surface resources in an untrusted folder', async () => {
+      testRootDir = await createTmpDir({ 'analyze_local.txt': '' });
+      const config = discoveryConfig({ isTrustedFolder: () => false });
+      const { result } = renderHook(() =>
+        useTestHarnessForAtCompletion(true, 'analyze', config, testRootDir),
+      );
+
+      await waitFor(() => {
+        expect(result.current.suggestions.length).toBeGreaterThan(0);
+      });
+      const values = result.current.suggestions.map((s) => s.value);
+      expect(values.some((v) => v.includes('asight://'))).toBe(false);
+      expect(values).toContain('analyze_local.txt');
+    });
+  });
 });

--- a/packages/cli/src/ui/hooks/useAtCompletion.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.ts
@@ -132,6 +132,77 @@ function getMcpServerSuggestions(
     }));
 }
 
+/**
+ * `@<partial>` MCP resource discovery. BEFORE any `<server>:` has been typed,
+ * match the partial — case-INsensitively, as a SUBSTRING (any part of the
+ * reference, not just a prefix) — against every discovered resource's
+ * canonical `@server:uri` reference AND its friendly name/title, across ALL
+ * configured servers. This lets a user who remembers only a fragment of a
+ * resource URI (or its human-readable name) jump straight to it without first
+ * drilling into the owning server via `@server:`.
+ *
+ * Returns `[]` (never `null`): like {@link getMcpServerSuggestions}, these are
+ * PREPENDED to the filesystem results so resources surface ALONGSIDE files and
+ * never hide them. The bare `@` trigger (empty partial) stays files-only —
+ * every string `.includes('')`, so an empty partial would otherwise match
+ * every resource. A `<server>:` drill-in is skipped here because
+ * {@link getMcpResourceSuggestions} already owns that path (and short-circuits
+ * before this runs), so resources are never double-surfaced.
+ *
+ * Ranking, best first: reference prefix, then name/title prefix, then
+ * reference substring, then name/title substring; ties break alphabetically by
+ * reference for a stable order. Each suggestion's `value` is the canonical
+ * `@server:uri` reference, so accepting it injects a directly-readable ref.
+ */
+function getMcpResourceDiscoverySuggestions(
+  config: Config | undefined,
+  pattern: string,
+): Suggestion[] {
+  if (!config) return [];
+  if (config.isTrustedFolder?.() === false) return [];
+  if (pattern.length === 0) return [];
+  // A `<server>:` drill-in is handled by getMcpResourceSuggestions; don't
+  // double-surface those resources here.
+  const mcpServers = config.getMcpServers?.() || {};
+  if (matchMcpServerPrefix(pattern, Object.keys(mcpServers))) return [];
+  const registry = config.getResourceRegistry?.();
+  if (!registry) return [];
+  const query = pattern.toLowerCase();
+
+  // Lower rank = better match; `Infinity` means no match and is filtered out.
+  const rankOf = (ref: string, friendly: string): number => {
+    if (ref.startsWith(query)) return 0;
+    if (friendly.startsWith(query)) return 1;
+    if (ref.includes(query)) return 2;
+    if (friendly.includes(query)) return 3;
+    return Infinity;
+  };
+
+  return (registry.getAllResources?.() ?? [])
+    .map((resource) => {
+      const ref = buildMcpResourceRef(resource.serverName, resource.uri);
+      const friendly = resource.title || resource.name || '';
+      return {
+        resource,
+        ref,
+        friendly,
+        rank: rankOf(ref.toLowerCase(), friendly.toLowerCase()),
+      };
+    })
+    .filter((m) => m.rank !== Infinity)
+    .sort((a, b) => a.rank - b.rank || a.ref.localeCompare(b.ref))
+    .slice(0, MAX_SUGGESTIONS_TO_SHOW * 3)
+    .map((m) => ({
+      label: m.ref,
+      value: m.ref,
+      // Only surface the friendly name when it adds information beyond the URI
+      // (mirrors getMcpResourceSuggestions and the `/mcp` resource list).
+      description:
+        m.friendly && m.friendly !== m.resource.uri ? m.friendly : undefined,
+      isDirectory: false,
+    }));
+}
+
 export enum AtCompletionStatus {
   IDLE = 'idle',
   INITIALIZING = 'initializing',
@@ -344,20 +415,31 @@ export function useAtCompletion(props: UseAtCompletionProps): void {
         return;
       }
 
-      // No `<server>:` selected yet — offer matching MCP servers (that expose
-      // resources) ALONGSIDE the filesystem results so the user can discover a
-      // server without knowing a resource URI up front. Computed synchronously
-      // and prepended below; never hides files.
+      // No `<server>:` selected yet — offer MCP discovery ALONGSIDE the
+      // filesystem results so the user can find a server OR a resource without
+      // knowing the full URI up front. Two complementary sources, both computed
+      // synchronously and prepended below (never hides files):
+      //   1. matching server names (drill-in entries: `@server:`)
+      //   2. resources across ALL servers matched by any substring of their
+      //      `@server:uri` reference or friendly name.
       const serverSuggestions = getMcpServerSuggestions(config, state.pattern);
+      const resourceDiscoverySuggestions = getMcpResourceDiscoverySuggestions(
+        config,
+        state.pattern,
+      );
+      const discoverySuggestions = [
+        ...serverSuggestions,
+        ...resourceDiscoverySuggestions,
+      ];
 
       if (!fileSearch.current) {
-        // File index not ready yet; still surface any server matches so
+        // File index not ready yet; still surface any MCP matches so
         // discovery doesn't have to wait on the crawler.
-        if (serverSuggestions.length > 0) {
+        if (discoverySuggestions.length > 0) {
           if (slowSearchTimer.current) {
             clearTimeout(slowSearchTimer.current);
           }
-          dispatch({ type: 'SEARCH_SUCCESS', payload: serverSuggestions });
+          dispatch({ type: 'SEARCH_SUCCESS', payload: discoverySuggestions });
         }
         return;
       }
@@ -397,14 +479,14 @@ export function useAtCompletion(props: UseAtCompletionProps): void {
         }));
         dispatch({
           type: 'SEARCH_SUCCESS',
-          payload: [...serverSuggestions, ...fileSuggestions],
+          payload: [...discoverySuggestions, ...fileSuggestions],
         });
       } catch (error) {
         if (!(error instanceof Error && error.name === 'AbortError')) {
-          // A file-search failure shouldn't swallow server matches we already
+          // A file-search failure shouldn't swallow MCP matches we already
           // have; show those rather than dropping to an error state.
-          if (serverSuggestions.length > 0) {
-            dispatch({ type: 'SEARCH_SUCCESS', payload: serverSuggestions });
+          if (discoverySuggestions.length > 0) {
+            dispatch({ type: 'SEARCH_SUCCESS', payload: discoverySuggestions });
           } else {
             dispatch({ type: 'ERROR' });
           }


### PR DESCRIPTION
## What this PR does

Two fixes to `@` completion for MCP resources, both surfaced by #5733.

The main behavior change: typing a bare `@<fragment>` now matches MCP resources by **any substring** of their `@server:uri` reference or friendly name, across all configured servers — not just server names by prefix. So `@analyze`, `@asight`, `@bubble` all reach a resource whose URI contains that fragment, mixed in with file results, without first typing the full `@server:` prefix.

The second fix is layout: in `@` mode a suggestion row that has a description (MCP server/resource entries) no longer wraps its label mid-string.

## Why it's needed

#5733 added "match MCP resource completions by name and discover servers", but discovery before the colon only matched server *names* by prefix. A user who remembers a fragment of a resource URI (the common case) got nothing: `@analyze` returned "no match" even though `asys-mcp-http:asight://skills/analyze_ppu_op` exists. Reaching a resource required knowing and typing the exact server name first.

Separately, #5733 was the first time `@` suggestions carried a description. That exposed a layout bug: the description column claimed nearly the full row width, squeezing the label so it wrapped — the `:` of a `server:` entry rendered on its own line.

## Reviewer Test Plan

### How to verify

Configure any MCP server that exposes resources whose URIs contain a recognizable mid-string (e.g. `asight://skills/analyze_ppu_op`), then in the TUI:

1. Type `@analyze` — **Before:** "no match". **After:** the matching resources appear (`asys-mcp-http:asight://skills/analyze_ppu_op`, `…/analyze_ppu_bubble`).
2. Type `@asys-mcp` — **Before:** the `asys-mcp-http:` server entry's `:` wraps to the next line. **After:** label + description on one line, resources also listed directly.
3. Confirm any substring works: `@asight` (scheme), `@skill` (mid-URI, mixes with `.qwen/skills/` files), `@bubble` (tail), `@schema` (a different `db://` resource).
4. Accept a suggestion — it injects the canonical `@server:uri` reference.

### Evidence (Before & After)

Verified live in tmux against a real stdio MCP server (`asys-mcp-http`, `/mcp` shows ✓ connected), 120-col terminal.

**Before** (from the original report):
- `@asys-mcp` → server entry rendered with the `:` wrapped onto a second line.
- `@analyze` → `无匹配` / no match.

**After:**

```
> @asys-mcp
  asys-mcp-http:  MCP resource server                          <- colon on one line
  asys-mcp-http:asight://reports/latest_trace      The most recently loaded trace report.
  asys-mcp-http:asight://skills/analyze_ppu_bubble Analyze PPU bubble (idle time) ...
  asys-mcp-http:asight://skills/analyze_ppu_op     Analyze PPU operator performance ...
  asys-mcp-http:db://users/schema                  Database schema for the users table.

> @analyze
  asys-mcp-http:asight://skills/analyze_ppu_bubble Analyze PPU bubble (idle time) ...
  asys-mcp-http:asight://skills/analyze_ppu_op     Analyze PPU operator performance ...

> @skill
  asys-mcp-http:asight://skills/analyze_ppu_bubble Analyze PPU bubble (idle time) ...
  asys-mcp-http:asight://skills/analyze_ppu_op     Analyze PPU operator performance ...
  .qwen/skills/
  .qwen/skills/asys_mcp_desync_analysis/
  .qwen/skills/auto-skill-hggc_graph_topology/SKILL.md

> @bubble
  asys-mcp-http:asight://skills/analyze_ppu_bubble Analyze PPU bubble (idle time) ...
```

Unit coverage: `useAtCompletion.test.ts` (substring across servers, name/title match, mixed-with-files, empty-`@` stays files-only, untrusted folder) and `SuggestionsDisplay.test.tsx` (reverse-mode label stays on one line). 38 passing across the two suites; lint + typecheck clean.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local build (`npm run build`), running `packages/cli/dist/index.js` against a stdio MCP server. Windows/Linux not exercised locally — left to CI.

## Risk & Scope

- Main risk or tradeoff: the cross-server resource scan runs on each `@` keystroke. It is synchronous over the in-memory `ResourceRegistry` and capped at `MAX_SUGGESTIONS_TO_SHOW * 3`, so it is cheap; very large registries would do more substring work per keystroke.
- Not validated / out of scope: matching stays plain case-insensitive substring (not fuzzy/subsequence) to match the existing `getMcpResourceSuggestions` behavior and avoid a new dependency. A very long reference in a very narrow terminal may overflow rather than wrap (mirrors the prior long-label truncation path).
- Breaking changes / migration notes: none. Empty `@` stays files-only; untrusted folders still surface no resources; the `@server:` drill-in path is unchanged.

## Linked Issues

No linked issue — reported directly. Follows up on #5733, which introduced `@` MCP resource completion.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

针对 MCP resource 的 `@` 补全修两个由 #5733 暴露的问题。

主要行为变化：现在输入裸 `@<片段>`，会用该片段去**子串**匹配所有已配置 server 的资源（匹配其 `@server:uri` 全引用或友好名），而不再只按前缀匹配 server 名。于是 `@analyze`、`@asight`、`@bubble` 都能匹配到 URI 含该片段的资源，并与文件结果混排，不需要先打出完整的 `@server:` 前缀。

第二个修复是布局：`@` 模式下带 description 的建议行（MCP server/resource 项）不再把标签从中间折行。

## 为什么需要

#5733 加了「按名匹配 MCP 资源补全并发现 server」，但冒号之前的发现只按前缀匹配 server *名字*。只记得资源 URI 片段的用户（最常见的情况）什么都得不到：`@analyze` 返回「无匹配」，尽管 `asys-mcp-http:asight://skills/analyze_ppu_op` 是存在的。要够到资源必须先知道并打出准确的 server 名。

另外，#5733 是 `@` 建议第一次带 description，由此暴露一个布局 bug：description 列几乎吃满整行宽度，把标签挤到折行 —— `server:` 项的 `:` 被甩到了下一行。

## Reviewer Test Plan

### 如何验证

配置任意一个暴露资源、且资源 URI 含可辨识中段（如 `asight://skills/analyze_ppu_op`）的 MCP server，然后在 TUI 中：

1. 输入 `@analyze` —— **修复前：**「无匹配」。**修复后：**命中相关资源。
2. 输入 `@asys-mcp` —— **修复前：** `asys-mcp-http:` server 项的 `:` 折到下一行。**修复后：** 标签和描述同一行，资源也直接列出。
3. 确认任意子串都行：`@asight`（scheme）、`@skill`（URI 中段，且与 `.qwen/skills/` 文件混排）、`@bubble`（末尾）、`@schema`（另一个 `db://` 资源）。
4. 选中某条建议 —— 注入规范的 `@server:uri` 引用。

### 证据（前 / 后）

在真实 stdio MCP server（`asys-mcp-http`，`/mcp` 显示 ✓ 已连接）、120 列终端下 tmux 实测。英文正文中的终端输出即为「修复后」实况；「修复前」为原始报告中的两种坏状态（冒号折行、`@analyze` 无匹配）。

单测覆盖：`useAtCompletion.test.ts`（跨 server 子串、名/标题匹配、与文件混排、空 `@` 仍只出文件、不信任目录不出资源）与 `SuggestionsDisplay.test.tsx`（reverse 模式标签不折行）。两套件 38 项通过；lint + typecheck 干净。

### 风险与范围

- 主要权衡：跨 server 资源扫描在每次 `@` 按键时执行，但它是对内存中 `ResourceRegistry` 的同步遍历，并按 `MAX_SUGGESTIONS_TO_SHOW * 3` 截断，开销很小。
- 未覆盖 / 范围外：匹配保持普通大小写不敏感子串（非模糊/子序列），与现有 `getMcpResourceSuggestions` 行为一致，且不引入新依赖。极窄终端下的超长引用可能溢出而非折行（沿用原有长标签截断路径）。
- 破坏性变更：无。空 `@` 仍只出文件；不信任目录仍不出资源；`@server:` 下钻路径不变。

</details>
