### PR TITLE
fix(core): reject userinfo URLs in WebFetch validation

### DIFF
--- a/packages/core/src/tools/web-fetch.test.ts
+++ b/packages/core/src/tools/web-fetch.test.ts
@@ -64,12 +64,27 @@ describe('WebFetchTool', () => {
       },
     );
 
-    it.each(['ftp://example.com', 'http:example.com', 'http:/example.com'])(
-      'should reject invalid or unsupported url schemes: %s',
-      (url) => {
+    it.each([
+      [
+        'ftp://example.com',
+        "The 'url' must be a valid URL starting with http:// or https://.",
+      ],
+      [
+        'http:example.com',
+        "The 'url' must be a valid URL starting with http:// or https://.",
+      ],
+      [
+        'http:/example.com',
+        "The 'url' must be a valid URL starting with http:// or https://.",
+      ],
+      ['https://', "The 'url' is malformed and could not be parsed."],
+      ['http://[::1', "The 'url' is malformed and could not be parsed."],
+    ])(
+      'should reject invalid or unsupported urls: %s',
+      (url, expectedError) => {
         const tool = new WebFetchTool(mockConfig);
         expect(() => tool.build({ url, prompt: 'summarize this' })).toThrow(
-          "The 'url' must be a valid URL starting with http:// or https://.",
+          expectedError,
         );
       },
     );

--- a/packages/core/src/tools/web-fetch.test.ts
+++ b/packages/core/src/tools/web-fetch.test.ts
@@ -74,6 +74,18 @@ describe('WebFetchTool', () => {
       },
     );
 
+    it.each([
+      'https://user:secret@example.com/page',
+      'http://user@example.com/page',
+      'https://:secret@example.com/page',
+      'https://%75ser@example.com/page',
+    ])('should reject URLs containing credentials: %s', (url) => {
+      const tool = new WebFetchTool(mockConfig);
+      expect(() => tool.build({ url, prompt: 'summarize this' })).toThrow(
+        "The 'url' must not include credentials.",
+      );
+    });
+
     it('should return WEB_FETCH_FALLBACK_FAILED on fetch failure', async () => {
       vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(true);
       vi.spyOn(fetchUtils, 'fetchWithTimeout').mockRejectedValue(

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -305,8 +305,17 @@ export class WebFetchTool extends BaseDeclarativeTool<
     if (!params.url || params.url.trim() === '') {
       return "The 'url' parameter cannot be empty.";
     }
+    // Regex rejects non-http(s) schemes and malformed authority that new URL() normalizes away.
     if (!/^https?:\/\//i.test(params.url)) {
       return "The 'url' must be a valid URL starting with http:// or https://.";
+    }
+    try {
+      const parsedUrl = new URL(params.url);
+      if (parsedUrl.username || parsedUrl.password) {
+        return "The 'url' must not include credentials.";
+      }
+    } catch {
+      return "The 'url' is malformed and could not be parsed.";
     }
     if (!params.prompt || params.prompt.trim() === '') {
       return "The 'prompt' parameter cannot be empty.";


### PR DESCRIPTION
## What this PR does

This PR hardens WebFetch URL validation so `http` and `https` URLs with embedded userinfo are rejected before the tool invocation continues. Normal URLs such as `https://example.com/page` remain valid, while inputs such as `https://user:pass@example.com/page`, `http://user@example.com/page`, and encoded userinfo variants are treated as invalid.

## Why it's needed

Embedded credentials in URLs are not needed for normal WebFetch usage and can expose sensitive values through validation, confirmation, logging, diagnostic, or error-reporting surfaces. Issue #5782 was accepted as a small, focused credential-security hardening change, and the maintainer bot specifically welcomed rejecting URLs where the parsed username or password component is present, with focused unit coverage.

## Reviewer Test Plan

### How to verify

Confirm that WebFetch still accepts normal `http` and `https` URLs without userinfo.

Confirm that WebFetch rejects URLs containing a username, password, or both before the request proceeds.

Run:

`cd packages/core && npx vitest run src/tools/web-fetch.test.ts`

`cd packages/core && npm run typecheck`

### Evidence (Before & After)

Before: issue #5782 reports that the existing validation accepts URLs with embedded userinfo as long as they start with `http://` or `https://`.

After: WebFetch rejects userinfo URLs during validation. Local focused test coverage now includes `https://user:secret@example.com/page`, `http://user@example.com/page`, `https://:secret@example.com/page`, and `https://%75ser@example.com/page`.

Console validation, Windows:

```text
=== Windows validation: WebFetch userinfo URL hardening ===
Scope: focused unit validation and package typecheck; no network fetch is performed.
OS: Microsoft Windows 11 Professional Workstation 10.0.26200
Node: v24.15.0
npm: 11.12.1
Branch: codex/webfetch-userinfo-url
Commit: d464833
Command: cd packages/core; npx vitest run src/tools/web-fetch.test.ts
Test Files: 1 passed
Tests: 22 passed
Focused test exit code: 0
Command: cd packages/core; npm run typecheck
Typecheck exit code: 0
```

Console validation, WSL:

```text
Distro: Ubuntu 22.04.5 LTS
Kernel: Linux 6.6.114.1-microsoft-standard-WSL2 x86_64 GNU/Linux
Node: v24.15.0
npm: 11.12.1
Branch: codex/webfetch-userinfo-url
Commit: d464833
Command: cd packages/core; npx vitest run src/tools/web-fetch.test.ts
Test Files: 1 passed
Tests: 22 passed
Command: cd packages/core; npm run typecheck
tsc --noEmit passed
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS     | not tested |
| Windows    | tested |
| Linux / WSL | tested |

### Environment (optional)

Windows 11 Professional Workstation 10.0.26200 with Node.js v24.15.0 and npm 11.12.1. WSL validation used Ubuntu 22.04.5 LTS on WSL2 with Linux 6.6.114.1-microsoft-standard-WSL2, Node.js v24.15.0, and npm 11.12.1.

## Risk & Scope

- Main risk or tradeoff: Low. This intentionally rejects a URL form that can carry credentials and is not needed for normal WebFetch usage.
- Not validated / out of scope: Full `npm run preflight` and macOS validation have not been run locally.
- Breaking changes / migration notes: Users who attempted to pass credentials through URL userinfo will need to use a safer supported mechanism instead.
- Documentation: No docs update appears needed because this is a validation hardening change rather than a new user-facing command, flag, or workflow.

## Linked Issues

Fixes #5782

中文说明

## What this PR does

该 PR 加强了 WebFetch 的 URL 校验，使包含嵌入式 userinfo 的 `http` 和 `https` URL 在工具调用继续之前被拒绝。普通 URL（例如 `https://example.com/page`）仍然有效，而 `https://user:pass@example.com/page`、`http://user@example.com/page` 以及编码后的 userinfo 变体会被视为无效。

## Why it's needed

URL 中嵌入的凭据并不是正常 WebFetch 使用所必需的，并且可能通过校验、确认、日志、诊断或错误报告等表面暴露敏感值。Issue #5782 已被接受为一个小型、聚焦的凭据安全加固改动，维护者机器人也明确欢迎在解析出的用户名或密码组件存在时拒绝该 URL，并补充聚焦的单元测试覆盖。

## Reviewer Test Plan

### How to verify

确认 WebFetch 仍然接受不包含 userinfo 的普通 `http` 或 `https` URL。

确认 WebFetch 会在请求继续之前拒绝包含用户名、密码或二者皆有的 URL。

运行：

`cd packages/core && npx vitest run src/tools/web-fetch.test.ts`

`cd packages/core && npm run typecheck`

### Evidence (Before & After)

Before：issue #5782 报告称，现有校验只要 URL 以 `http://` 或 `https://` 开头，就会接受包含嵌入式 userinfo 的 URL。

After：WebFetch 会在校验阶段拒绝 userinfo URL。本地聚焦测试覆盖了 `https://user:secret@example.com/page`、`http://user@example.com/page`、`https://:secret@example.com/page` 和 `https://%75ser@example.com/page`。Windows 与 WSL 控制台验证均已通过。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS     | not tested |
| Windows    | tested |
| Linux / WSL | tested |

### Environment (optional)

Windows 11 Professional Workstation 10.0.26200，Node.js v24.15.0，npm 11.12.1。WSL 验证使用 Ubuntu 22.04.5 LTS / WSL2，Linux 6.6.114.1-microsoft-standard-WSL2，Node.js v24.15.0，npm 11.12.1。

## Risk & Scope

- Main risk or tradeoff：风险较低。该 PR 有意拒绝一种可携带凭据、且正常 WebFetch 使用不需要的 URL 形式。
- Not validated / out of scope：尚未在本地运行完整 `npm run preflight` 和 macOS 验证。
- Breaking changes / migration notes：曾尝试通过 URL userinfo 传递凭据的用户，需要改用更安全且受支持的机制。
- Documentation：该改动是校验加固，不是新的用户可见命令、参数或工作流，因此看起来不需要更新文档。

## Linked Issues

Fixes #5782