### PR TITLE
fix(daemon): Reject stale prompt client admission

### DIFF
--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -593,7 +593,7 @@ describe('createAcpSessionBridge', () => {
         { clientId: first.clientId },
       ),
     ).resolves.toMatchObject({ stopReason: 'end_turn' });
-    await expect(
+    expect(() =>
       bridge.sendPrompt(
         second.sessionId,
         {
@@ -603,7 +603,7 @@ describe('createAcpSessionBridge', () => {
         undefined,
         { clientId: second.clientId },
       ),
-    ).rejects.toBeInstanceOf(InvalidClientIdError);
+    ).toThrow(InvalidClientIdError);
 
     await bridge.shutdown();
   });
@@ -5338,7 +5338,7 @@ describe('createAcpSessionBridge', () => {
 
     it('rejects unregistered client ids on session-scoped requests', async () => {
       const { bridge, session } = await setup();
-      await expect(
+      expect(() =>
         bridge.sendPrompt(
           session.sessionId,
           {
@@ -5348,7 +5348,8 @@ describe('createAcpSessionBridge', () => {
           undefined,
           { clientId: 'client-not-issued' },
         ),
-      ).rejects.toBeInstanceOf(InvalidClientIdError);
+      ).toThrow(InvalidClientIdError);
+      expect(bridge.activePromptCount).toBe(0);
       await expect(
         bridge.cancelSession(session.sessionId, undefined, {
           clientId: 'client-not-issued',

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -604,6 +604,7 @@ describe('createAcpSessionBridge', () => {
         { clientId: second.clientId },
       ),
     ).toThrow(InvalidClientIdError);
+    expect(bridge.activePromptCount).toBe(0);
 
     await bridge.shutdown();
   });

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -2813,12 +2813,10 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       const queuedAt = Date.now();
       const entry = byId.get(sessionId);
       if (!entry) return Promise.reject(new SessionNotFoundError(sessionId));
-      let originatorClientId: string | undefined;
-      try {
-        originatorClientId = resolveTrustedClientId(entry, context?.clientId);
-      } catch (err) {
-        return Promise.reject(err);
-      }
+      const originatorClientId = resolveTrustedClientId(
+        entry,
+        context?.clientId,
+      );
       // Pre-aborted: skip the queue entirely. Without this the prompt
       // chains onto promptQueue, waits its turn, and the FIFO worker
       // checks `signal.aborted` only AFTER reaching the head — wasted

--- a/packages/acp-bridge/src/bridgeTypes.ts
+++ b/packages/acp-bridge/src/bridgeTypes.ts
@@ -304,10 +304,10 @@ export interface AcpSessionBridge {
    * session FIFO-serialize through a per-session queue.
    *
    * Admission contract: implementations must not be `async`. Admission
-   * failures such as `PromptQueueFullError` and pre-aborted signals throw
-   * synchronously so HTTP routes can reject before returning 202. Deferred
-   * failures such as `SessionNotFoundError` may be returned as rejected
-   * promises.
+   * failures such as `InvalidClientIdError`, `PromptQueueFullError`, and
+   * pre-aborted signals throw synchronously so HTTP routes can reject before
+   * returning 202. Deferred failures such as `SessionNotFoundError` may be
+   * returned as rejected promises.
    */
   sendPrompt(
     sessionId: string,

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -5321,6 +5321,28 @@ describe('createServeApp', () => {
       expect(res.body.promptId).toBeDefined();
     });
 
+    it('400 without promptId when bridge rejects invalid client admission synchronously', async () => {
+      const bridge = fakeBridge({
+        promptImpl: () => {
+          throw new InvalidClientIdError('session-A', 'client-stale');
+        },
+      });
+      const app = createServeApp(baseOpts, undefined, { bridge });
+      const res = await request(app)
+        .post('/session/session-A/prompt')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .set('X-Qwen-Client-Id', 'client-stale')
+        .send({ prompt: [{ type: 'text', text: 'hi' }] });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        code: 'invalid_client_id',
+        sessionId: 'session-A',
+        clientId: 'client-stale',
+      });
+      expect(res.body.promptId).toBeUndefined();
+    });
+
     it('503 without promptId when bridge rejects prompt admission synchronously', async () => {
       const bridge = fakeBridge({
         promptImpl: () => {

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -1084,6 +1084,7 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
       resumeCalls.push(req);
       return result;
     },
+    // Keep non-async so prompt admission failures can throw synchronously.
     sendPrompt(sessionId, req, signal, context) {
       promptCalls.push({
         sessionId,
@@ -5327,7 +5328,8 @@ describe('createServeApp', () => {
           throw new InvalidClientIdError('session-A', 'client-stale');
         },
       });
-      const app = createServeApp(baseOpts, undefined, { bridge });
+      const daemonLog = fakeDaemonLog();
+      const app = createServeApp(baseOpts, undefined, { bridge, daemonLog });
       const res = await request(app)
         .post('/session/session-A/prompt')
         .set('Host', `127.0.0.1:${baseOpts.port}`)
@@ -5341,6 +5343,13 @@ describe('createServeApp', () => {
         clientId: 'client-stale',
       });
       expect(res.body.promptId).toBeUndefined();
+      expect(daemonLog.warn).toHaveBeenCalledWith(
+        'prompt admission rejected: invalid client id',
+        expect.objectContaining({
+          sessionId: 'session-A',
+          clientId: 'client-stale',
+        }),
+      );
     });
 
     it('503 without promptId when bridge rejects prompt admission synchronously', async () => {

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -3436,6 +3436,13 @@ export function createServeApp(
           pendingCount: err.pendingCount,
         });
       }
+      if (daemonLog && err instanceof InvalidClientIdError) {
+        daemonLog.warn('prompt admission rejected: invalid client id', {
+          sessionId,
+          promptId,
+          ...(clientId !== undefined ? { clientId } : {}),
+        });
+      }
       sendBridgeError(res, err, {
         route: 'POST /session/:id/prompt',
         sessionId,

--- a/packages/sdk-typescript/test/unit/DaemonClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonClient.test.ts
@@ -1029,6 +1029,46 @@ describe('DaemonClient', () => {
       });
     });
 
+    it('maps invalid client id responses on non-blocking prompts', async () => {
+      const { fetch, calls } = recordingFetch((req) => {
+        if (req.url.endsWith('/session/s-1/prompt')) {
+          return jsonResponse(400, {
+            code: 'invalid_client_id',
+            error: 'unknown client',
+            sessionId: 's-1',
+            clientId: 'client-stale',
+          });
+        }
+        return jsonResponse(500, { error: `unexpected ${req.url}` });
+      });
+      const client = new DaemonClient({
+        baseUrl: 'http://daemon',
+        fetch,
+      });
+
+      const result = await client
+        .promptNonBlocking(
+          's-1',
+          {
+            prompt: [{ type: 'text', text: 'hi' }],
+          },
+          undefined,
+          'client-stale',
+        )
+        .catch((err: unknown) => err);
+
+      expect(result).toBeInstanceOf(DaemonHttpError);
+      expect(result).toMatchObject({
+        status: 400,
+        body: {
+          code: 'invalid_client_id',
+          sessionId: 's-1',
+          clientId: 'client-stale',
+        },
+      });
+      expect(calls[0]?.headers['x-qwen-client-id']).toBe('client-stale');
+    });
+
     it('does not reserve a local prompt slot for a pre-aborted signal', async () => {
       const { fetch, calls } = recordingFetch((req) => {
         if (req.url.endsWith('/session/s-1/prompt')) {

--- a/packages/sdk-typescript/test/unit/DaemonClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonClient.test.ts
@@ -1069,6 +1069,65 @@ describe('DaemonClient', () => {
       expect(calls[0]?.headers['x-qwen-client-id']).toBe('client-stale');
     });
 
+    it('releases the local prompt slot after invalid client id responses on blocking prompts', async () => {
+      let promptRequests = 0;
+      const { fetch, calls } = recordingFetch((req) => {
+        if (req.url.endsWith('/session/s-1/prompt')) {
+          promptRequests += 1;
+          if (promptRequests === 1) {
+            return jsonResponse(400, {
+              code: 'invalid_client_id',
+              error: 'unknown client',
+              sessionId: 's-1',
+              clientId: 'client-stale',
+            });
+          }
+          return jsonResponse(202, {
+            promptId: `p-${promptRequests}`,
+            lastEventId: 0,
+          });
+        }
+        if (req.url.endsWith('/session/s-1/events')) {
+          return sseResponse(
+            `id: 1\nevent: turn_complete\ndata: {"id":1,"v":1,"type":"turn_complete","data":{"promptId":"p-${promptRequests}","stopReason":"end_turn"}}\n\n`,
+          );
+        }
+        return jsonResponse(500, { error: `unexpected ${req.url}` });
+      });
+      const client = new DaemonClient({
+        baseUrl: 'http://daemon',
+        fetch,
+        maxPendingPromptsPerSession: 1,
+      });
+
+      const result = await client
+        .prompt(
+          's-1',
+          {
+            prompt: [{ type: 'text', text: 'hi' }],
+          },
+          undefined,
+          'client-stale',
+        )
+        .catch((err: unknown) => err);
+
+      expect(result).toBeInstanceOf(DaemonHttpError);
+      expect(result).toMatchObject({
+        status: 400,
+        body: {
+          code: 'invalid_client_id',
+          sessionId: 's-1',
+          clientId: 'client-stale',
+        },
+      });
+      await expect(
+        client.prompt('s-1', {
+          prompt: [{ type: 'text', text: 'after stale client' }],
+        }),
+      ).resolves.toEqual({ stopReason: 'end_turn' });
+      expect(calls.filter((c) => c.url.endsWith('/prompt'))).toHaveLength(2);
+    });
+
     it('does not reserve a local prompt slot for a pre-aborted signal', async () => {
       const { fetch, calls } = recordingFetch((req) => {
         if (req.url.endsWith('/session/s-1/prompt')) {


### PR DESCRIPTION
## What this PR does

This PR makes stale or unregistered prompt client ids fail during prompt admission instead of becoming asynchronous prompt failures after the HTTP route has already accepted the request. The bridge now treats invalid prompt client ids the same way it already treats queue-full and pre-aborted prompt admission failures, and the daemon route returns the existing `invalid_client_id` response shape without a `promptId`.

The tests cover the bridge admission contract, the daemon `/prompt` response shape, and the SDK non-blocking prompt error mapping.

## Why it's needed

A daemon restart or session reload can issue a new client id while a UI still has an older one. Before this change, `/prompt` could return `202 Accepted` for that stale client id, then the bridge would reject asynchronously before any turn was registered, so no `turn_complete` or `turn_error` event would ever arrive for the accepted prompt. Clients that rely on the returned `promptId` could stay in a processing state indefinitely.

Returning `400 invalid_client_id` before acceptance keeps the client out of the pending-prompt path and lets existing UI error handling clear the active prompt state.

## Reviewer Test Plan

### How to verify

Run the targeted prompt admission tests and confirm stale prompt client ids return `400 invalid_client_id` without a `promptId`, while true asynchronous prompt failures still return `202` and rely on turn events. Also confirm the bridge rejects unregistered prompt clients synchronously and the SDK maps the response to `DaemonHttpError` instead of creating an accepted non-blocking prompt.

### Evidence (Before & After)

Before: a stale prompt client id could be accepted with `202`, then fail asynchronously before any terminal turn event was emitted, leaving the client waiting on a prompt id that would never complete.

After: the route-level regression test verifies stale prompt client ids return `400 invalid_client_id` with no `promptId`, while the existing asynchronous failure test still verifies true turn failures remain on the `202` path.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js v22.22.3. Local targeted Vitest coverage was run for `packages/acp-bridge`, `packages/cli`, and `packages/sdk-typescript`.

## Risk & Scope

- Main risk or tradeoff: callers that directly invoked `sendPrompt` with an invalid client id and expected a rejected Promise now receive a synchronous admission throw, matching the documented non-async prompt admission contract.
- Not validated / out of scope: this PR does not persist client ids across daemon restarts or automatically retry prompts after a stale client id failure.
- Breaking changes / migration notes: no wire-shape migration; the daemon reuses the existing `invalid_client_id` response shape.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 将 stale 或未注册的 prompt client id 改为在 prompt admission 阶段失败，而不是在 HTTP 路由已经接受请求后再异步失败。bridge 现在把无效 prompt client id 视为和队列已满、预先 abort 的 prompt 一样的 admission failure，daemon 路由会返回既有的 `invalid_client_id` 响应，并且不返回 `promptId`。

测试覆盖了 bridge admission 契约、daemon `/prompt` 响应形状，以及 SDK 非阻塞 prompt 的错误映射。

## Why it's needed

daemon 重启或 session reload 后可能会签发新的 client id，而 UI 仍然持有旧 client id。修改前，`/prompt` 可能会对这个 stale client id 返回 `202 Accepted`，随后 bridge 在任何 turn 注册之前异步拒绝，因此这个已接受 prompt 不会收到 `turn_complete` 或 `turn_error` 事件。依赖返回 `promptId` 的客户端可能会一直停留在处理中状态。

在接受请求前返回 `400 invalid_client_id`，可以让客户端不进入 pending-prompt 路径，并让现有 UI 错误处理清理 active prompt 状态。

## Reviewer Test Plan

### How to verify

运行针对 prompt admission 的测试，确认 stale prompt client id 返回 `400 invalid_client_id` 且没有 `promptId`，同时真实的异步 prompt 失败仍然返回 `202` 并依赖 turn 事件。还需要确认 bridge 会同步拒绝未注册 prompt client，SDK 会把响应映射为 `DaemonHttpError`，而不是创建一个已接受的非阻塞 prompt。

### Evidence (Before & After)

Before：stale prompt client id 可能先被 `202` 接受，然后在任何终止 turn 事件发出前异步失败，导致客户端等待一个永远不会完成的 prompt id。

After：路由层回归测试验证 stale prompt client id 返回 `400 invalid_client_id` 且没有 `promptId`，同时已有异步失败测试仍验证真实 turn 失败保持在 `202` 路径。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js v22.22.3。本地针对 `packages/acp-bridge`、`packages/cli` 和 `packages/sdk-typescript` 运行了相关 Vitest 测试。

## Risk & Scope

- Main risk or tradeoff：如果有调用方直接用无效 client id 调用 `sendPrompt` 并期望拿到 rejected Promise，现在会收到同步 admission throw；这符合已文档化的非 async prompt admission 契约。
- Not validated / out of scope：这个 PR 不做跨 daemon 重启的 client id 持久化，也不会在 stale client id 失败后自动重试 prompt。
- Breaking changes / migration notes：没有 wire-shape 迁移；daemon 复用既有的 `invalid_client_id` 响应形状。

## Linked Issues

N/A

</details>
