### PR TITLE
fix(cli): replace emoji thinking/summary icons with Unicode text symbols

### DIFF
--- a/packages/cli/src/ui/components/messages/ConversationMessages.tsx
+++ b/packages/cli/src/ui/components/messages/ConversationMessages.tsx
@@ -20,11 +20,7 @@ import { t } from '../../../i18n/index.js';
 import { getCachedStringWidth } from '../../utils/textUtils.js';
 import { formatDuration } from '../../utils/displayUtils.js';
 
-const isUtf8 = /utf-?8/i.test(
-  process.env['LANG'] || process.env['LC_ALL'] || '',
-);
-export const THINKING_ICON =
-  !process.env['CI'] && isUtf8 ? '💡 ' : isUtf8 ? '⟡ ' : '';
+export const THINKING_ICON = '∴ ';
 
 interface UserMessageProps {
   text: string;

--- a/packages/cli/src/ui/components/messages/SummaryMessage.tsx
+++ b/packages/cli/src/ui/components/messages/SummaryMessage.tsx
@@ -44,7 +44,7 @@ export const SummaryMessage: React.FC<SummaryDisplayProps> = ({ summary }) => {
     if (summary.isPending) {
       return <Spinner type="dots" />;
     }
-    return <Text color={Colors.AccentGreen}>✅</Text>;
+    return <Text color={Colors.AccentGreen}>✓</Text>;
   };
 
   return (


### PR DESCRIPTION
## What this PR does

The Qwen Code TUI is built on a consistent vocabulary of width-1 Unicode text glyphs — `>` for user messages, `✦` for assistant replies, `●`/`○`/`◐` for todo and selection states, `✓` for success, `↓`/`↑` for token flow, and braille `⠋⠙⠹` frames for the spinner. Every one of these is a narrow text symbol that renders predictably across terminals, fonts, and CI logs. Two status indicators broke this consistency with emoji, and this PR replaces them with text symbols from the same family: the thinking block icon `💡` → `∴` (U+2234 THEREFORE), and the summary success icon `✅` → `✓` (matching `ToolMessage`'s existing success glyph).

## Why it's needed

Emoji are not just a style mismatch — they have real technical downsides in a TUI. They render at width=2 (e.g. `💡` = 2 columns) while every other glyph is width=1, so indented blocks drift depending on which code path rendered them. The thinking icon already encoded this pain: it branched into three different outputs (`💡 ` / `⟡ ` / empty) based on `CI` and `LANG`, so the same thinking line occupied a different number of columns depending on where it ran. The `∴` replacement is width=1 and renders identically everywhere, which lets us delete the entire `isUtf8`/`CI` branch and collapse `THINKING_ICON` to a single constant. The `✅` → `✓` change removes a redundant emoji variant of a glyph the project already standardized on — `ToolMessage` uses `✓` in success color for the exact same "operation succeeded" meaning.

## Reviewer Test Plan

### How to verify

- Run `npm run dev`, send any prompt that triggers model reasoning → the thinking block header should read `∴ Thinking…` (and `∴ Thought for Ns` when collapsed), replacing the old `💡`.
- Run `/chat summary` → on success the checkmark should be `✓` (green), matching `ToolMessage`'s success state, instead of `✅`.
- Confirm the thinking line no longer changes width between local and CI logs — the old `CI`/`LANG` branch is gone.

### Evidence (Before & After)

Rendered the real `ThinkMessage` and `SummaryMessage` components via `ink-testing-library`, captured with `tmux capture-pane` (120×40 viewport). Same props on both sides — only the icon constant differs.

**BEFORE — `main`**

```
💡 Thinking…
  Analyzing the request and planning the implementation steps carefully before w
  riting any code.

💡 Thought for 12s (alt+t to expand)

✅ Project summary generated and saved successfully! Saved to: /tmp/project-summary.md
```

**AFTER — this branch**

```
∴ Thinking…
  Analyzing the request and planning the implementation steps carefully before w
  riting any code.

∴ Thought for 12s (alt+t to expand)

✓ Project summary generated and saved successfully! Saved to: /tmp/project-summary.md
```

Note `💡` is width=2 — the thinking header and the wrapped streaming text sit one column to the right of `∴` (width=1). On `main` this drift varied by environment (`CI`/`LANG`); after this PR the thinking line is width=1 everywhere.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

Windows/Linux not tested locally, but the change is pure glyph replacement (`∴` U+2234 and `✓` U+2713 are common math/check symbols present in all mainstream monospace fonts). No platform-specific rendering logic.

### Environment

`npm run dev` (tsx, direct source) on macOS. Component render verified via `ink-testing-library`. Related unit tests: `ConversationMessages.test.tsx` (10), `SessionPreview.test.tsx` (7), `HistoryItemDisplay.test.tsx` (25) — all passing.

## Risk & Scope

- Main risk or tradeoff: Very low. Pure string-constant replacement, no logic change. `∴` (U+2234) verified width=1 via `string-width`; renders in SF Mono / Menlo / JetBrains Mono / Fira Code.
- Not validated / out of scope: Did not visually verify on Windows/Linux terminals (glyph coverage expected but not confirmed). The remaining 30+ emoji across the repo (McpStatus, Footer, ideCommand, loading phrases, i18n copy, core agent-stats) are tracked in #5787 as subsequent batches — intentionally out of scope here to keep the PR focused.
- Breaking changes / migration notes: None. `THINKING_ICON` is still an exported string constant; consumers (`ThinkingViewer.tsx`) import it unchanged. The only behavioral difference is the glyph and the removal of the environment-dependent width drift.

## Linked Issues

Closes #5787 (first batch).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

Qwen Code 的 TUI 建立在一套统一的 width-1 Unicode 文本符号体系上——`>` 用户消息、`✦` 助手回复、`●`/`○`/`◐` todo 与选择态、`✓` 成功、`↓`/`↑` token 流向、盲文 `⠋⠙⠹` spinner 帧。这些符号宽度都是 1，在各终端、字体、CI 日志里渲染一致。两处状态指示器用 emoji 破坏了这一致性，本 PR 用同族文本符号替换：thinking 图标 `💡` → `∴`（U+2234 数学"所以"），summary 成功图标 `✅` → `✓`（对齐 ToolMessage 已有的成功符号）。

## 为什么需要

emoji 不仅是风格不匹配，在 TUI 里有真实技术缺陷：渲染宽度为 2（如 `💡` 占 2 列），而其他符号都是 1，导致缩进块在不同代码路径下漂移。thinking 图标已经反映了这个痛点——它根据 `CI`/`LANG` 分支成三套输出（`💡 `/`⟡ `/空），同一条 thinking 行在不同环境占不同列宽。`∴` 替换是 width=1，各环境渲染一致，因此可以删除整个 `isUtf8`/`CI` 分支，把 `THINKING_ICON` 收敛成单常量。`✅` → `✓` 移除了一个多余的 emoji 变体——项目已有 `✓`（ToolMessage 成功态用），`✅` 是重复。

## 验证方法

- `npm run dev`，发任意触发模型推理的 prompt → thinking 标题应显示 `∴ Thinking…`（折叠态 `∴ Thought for Ns`），替代旧的 `💡`。
- 运行 `/chat summary` → 成功后勾选符应为 `✓`（绿色），与 ToolMessage 成功态一致，替代 `✅`。
- 确认 thinking 行在本地和 CI 日志里宽度不再变化——旧的 `CI`/`LANG` 分支已删除。

### 证据（Before & After）

用 ink-testing-library 渲染真实的 ThinkMessage / SummaryMessage 组件，tmux capture-pane 截取（120×40 视口）。两侧 props 一致，只有 icon 常量不同。

改动前（main）：`💡 Thinking…` / `💡 Thought for 12s` / `✅ Project summary...`
改动后（本分支）：`∴ Thinking…` / `∴ Thought for 12s` / `✓ Project summary...`

注意 `💡` 占 width=2，thinking 标题及换行文本比 `∴`（width=1）多偏移一列。main 上这个偏移随环境变化（CI/LANG）；本 PR 后 thinking 行在所有环境都是 width=1。

### 测试环境

macOS 本地验证（npm run dev + ink-testing-library）。Windows/Linux 未本地测试，但改动是纯字符替换（`∴` U+2234、`✓` U+2713 是主流等宽字体均含的常见数学/勾选符号），无平台特定渲染逻辑。相关单元测试全过（ConversationMessages 10 + SessionPreview 7 + HistoryItemDisplay 25）。

## 风险与范围

- 主要风险：极低。纯字符串常量替换，无逻辑改动。`∴`（U+2234）已验证 width=1。
- 未验证/范围外：未在 Windows/Linux 终端实测字体覆盖（预期支持但未确认）。仓库其余 30+ 处 emoji（McpStatus、Footer、ideCommand、loading 文案、i18n、core agent-stats）见 #5787 后续批次，本次刻意不在范围内以保持 PR 聚焦。
- 破坏性变更：无。`THINKING_ICON` 仍是导出的字符串常量，消费方（ThinkingViewer.tsx）import 不变。唯一行为差异是字符本身及环境相关的宽度漂移被消除。

## 关联 Issue

Closes #5787（第一批）。

</details>
