### PR TITLE
fix(sdk): raise browser daemon bundle budget to 126 KiB

### DIFF
--- a/packages/sdk-typescript/scripts/build.js
+++ b/packages/sdk-typescript/scripts/build.js
@@ -29,7 +29,9 @@ const rootDir = join(__dirname, '..');
 // (install/update/enable/disable/uninstall/refresh/check update endpoints).
 // Bumped from 122KB to 124KB for daemon fork-session APIs/events.
 // Bumped from 124KB to 125KB for rewind/branch transcript/session APIs.
-const MAX_DAEMON_BROWSER_BUNDLE_BYTES = 125 * 1024;
+// Bumped from 125KB to 126KB for the workspace permissions rules API
+// (workspacePermissions + set/add/remove rule methods + types, ~718 bytes).
+const MAX_DAEMON_BROWSER_BUNDLE_BYTES = 126 * 1024;
 
 rmSync(join(rootDir, 'dist'), { recursive: true, force: true });
 mkdirSync(join(rootDir, 'dist'), { recursive: true });


### PR DESCRIPTION
## Summary

`main` is red on the **E2E Tests** workflow — every job fails in *Install dependencies* at the SDK build step:

```
Error: Browser daemon SDK bundle is 128651 bytes; expected <= 128000
    at assertBrowserSafeBundle (packages/sdk-typescript/scripts/build.js:164)
```

### Root cause

The browser-facing daemon SDK bundle has a hard size budget, `MAX_DAEMON_BROWSER_BUNDLE_BYTES`, currently 125 KiB (128000 bytes). The **workspace permissions rules API** (#5743) added `workspacePermissions` and the `set`/`add`/`remove` rule methods plus their types to `DaemonClient` (~718 bytes minified) but did not raise the budget. #5775 had just set the budget to 125 KiB while adding its own surface; #5743 was cut from an earlier base and stayed green on its own CI, so the two only combined over the budget once both landed on `main`. The bundle is now 128651 bytes — 651 over.

The voice-dictation merge (#5755) that the failing run points at did not touch `sdk-typescript` at all; it was simply the first push afterward to run the build and surface the pre-existing breakage.

### Fix

Raise `MAX_DAEMON_BROWSER_BUNDLE_BYTES` one notch to 126 KiB (129024 bytes), following the established per-feature bump pattern documented in the same file. The permissions methods are public class methods on `DaemonClient` and are not tree-shakeable, so the bytes ship regardless of consumers — trimming is not an option without splitting the client.

### Verification

- Reproduced the failure locally (esbuild 0.25.12): the bundle builds to **128651 bytes**, byte-identical to CI.
- Isolated the cause: removing only the permissions API drops the bundle to 127933 bytes (under the old cap); an esbuild metafile confirms the delta is purely those methods and that unrelated branch diffs (e.g. `src/types/types.ts`) are not in the bundle.
- With the raised cap, `npm run build --workspace=packages/sdk-typescript` passes (bundle 128651 ≤ 129024, 373 bytes headroom).

<details>
<summary>中文说明</summary>

## 概述

`main` 分支的 **E2E Tests** 工作流全部失败，每个 job 都在 *Install dependencies* 的 SDK 构建步骤报错：

```
Error: Browser daemon SDK bundle is 128651 bytes; expected <= 128000
    at assertBrowserSafeBundle (packages/sdk-typescript/scripts/build.js:164)
```

### 根因

面向浏览器的 daemon SDK bundle 有一个硬性体积上限 `MAX_DAEMON_BROWSER_BUNDLE_BYTES`，当前为 125 KiB（128000 字节）。**workspace permissions rules API**（#5743）向 `DaemonClient` 新增了 `workspacePermissions` 以及 `set`/`add`/`remove` 规则方法和相关类型（压缩后约 718 字节），但没有同步上调上限。#5775 在加入自身代码时刚把上限设为 125 KiB；而 #5743 基于更早的分支，单独跑 CI 时是绿的，两者各自合入后在 `main` 上叠加才超出预算。当前 bundle 为 128651 字节，超出 651 字节。

报错那次构建指向的语音听写合并（#5755）根本没有改动 `sdk-typescript`，它只是之后第一个触发构建、从而暴露这个既有问题的 push。

### 修复

按文件中既有的「每个功能上调一档」惯例，将 `MAX_DAEMON_BROWSER_BUNDLE_BYTES` 上调一档到 126 KiB（129024 字节）。这些 permissions 方法是 `DaemonClient` 上的 public 类方法，无法被 tree-shaking 移除，无论是否有调用方都会进入 bundle —— 不拆分 client 就无法削减。

### 验证

- 本地复现（esbuild 0.25.12）：bundle 构建为 **128651 字节**，与 CI 完全一致。
- 定位根因：仅移除 permissions API 后 bundle 降至 127933 字节（在旧上限之内）；esbuild metafile 确认增量完全来自这些方法，且分支中无关的改动（如 `src/types/types.ts`）并不在 bundle 内。
- 上调上限后，`npm run build --workspace=packages/sdk-typescript` 通过（bundle 128651 ≤ 129024，余量 373 字节）。

</details>
