### PR TITLE
fix(cli): promote pasted image paths to attachments

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -7,7 +7,7 @@
 import { renderWithProviders } from '../../test-utils/render.js';
 import { waitFor, act } from '@testing-library/react';
 import type { InputPromptProps } from './InputPrompt.js';
-import { InputPrompt } from './InputPrompt.js';
+import { InputPrompt, classifyPastedImagePaths } from './InputPrompt.js';
 import { useTextBuffer, type TextBuffer } from './shared/text-buffer.js';
 import type { Config } from '@qwen-code/qwen-code-core';
 import { ApprovalMode } from '@qwen-code/qwen-code-core';
@@ -5170,3 +5170,42 @@ function clean(str: string | undefined): string {
   // Remove ANSI escape codes and trim whitespace
   return stripAnsi(str).trim();
 }
+
+describe('classifyPastedImagePaths', () => {
+  it('treats a lone @-prefixed image path (terminal Cmd+V injection) as all-image', () => {
+    const result = classifyPastedImagePaths(
+      '@/var/folders/12/T/clipboard-2026-06-24-124142-18EC6DC9.png',
+    );
+    expect(result.allImages).toBe(true);
+    expect(result.imagePaths).toEqual([
+      '/var/folders/12/T/clipboard-2026-06-24-124142-18EC6DC9.png',
+    ]);
+  });
+
+  it('splits multiple space- and newline-separated image paths', () => {
+    const result = classifyPastedImagePaths(
+      '/a/one.png /b/two.jpg\n/c/three.webp',
+    );
+    expect(result.allImages).toBe(true);
+    expect(result.imagePaths).toEqual([
+      '/a/one.png',
+      '/b/two.jpg',
+      '/c/three.webp',
+    ]);
+  });
+
+  it('unwraps surrounding quotes and shell-escaped spaces', () => {
+    const result = classifyPastedImagePaths('"/a/my image.png"');
+    expect(result.allImages).toBe(true);
+    expect(result.imagePaths).toEqual(['/a/my image.png']);
+  });
+
+  it('does not treat plain text or non-image paths as image paste', () => {
+    expect(classifyPastedImagePaths('just some text').allImages).toBe(false);
+    expect(classifyPastedImagePaths('/src/index.ts').imagePaths).toEqual([]);
+    // A path followed by free text is left for normal text handling.
+    expect(
+      classifyPastedImagePaths('@/a/img.png describe this').allImages,
+    ).toBe(false);
+  });
+});

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -43,6 +43,7 @@ import {
   cleanupOldClipboardImages,
 } from '../utils/clipboardUtils.js';
 import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
 import { SCREEN_READER_USER_PREFIX } from '../textConstants.js';
 import { useShellFocusState } from '../contexts/ShellFocusContext.js';
 import { useUIState } from '../contexts/UIStateContext.js';
@@ -86,6 +87,48 @@ export interface Attachment {
   id: string; // Unique identifier (timestamp)
   path: string; // Full file path
   filename: string; // Filename only (for display)
+}
+
+const PASTED_IMAGE_EXTENSIONS = /\.(png|jpe?g|gif|webp|bmp)$/i;
+
+/**
+ * Classify a pasted blob as image-file-path(s).
+ *
+ * Some terminals and clipboard helpers handle an image paste by injecting the
+ * saved file path as text (optionally prefixed with `@`, shell-escaped, or
+ * space/newline-separated for multiple files) instead of routing through our
+ * own Ctrl+V handler. Recognizing those lets Cmd+V (terminal-driven) converge
+ * on the same attachment UX as Ctrl+V. Mirrors Claude Code's usePasteHandler:
+ * split on newlines and on spaces that precede an absolute path (spaces inside
+ * a path are shell-escaped), then normalize each token.
+ *
+ * @returns `imagePaths` (normalized tokens with an image extension) and
+ *   `allImages` (true only when every token is such a path), so the caller can
+ *   promote a pure image-path paste without swallowing mixed text.
+ */
+export function classifyPastedImagePaths(pasted: string): {
+  imagePaths: string[];
+  allImages: boolean;
+} {
+  const tokens = pasted
+    .split(/ (?=@?\/|@?[A-Za-z]:\\)/)
+    .flatMap((part) => part.split('\n'))
+    .map((token) => token.trim())
+    .filter(Boolean);
+  const imagePaths: string[] = [];
+  let allImages = tokens.length > 0;
+  for (const token of tokens) {
+    const normalized = token
+      .replace(/^@/, '') // strip the `@` reference prefix
+      .replace(/^["']|["']$/g, '') // strip surrounding quotes
+      .replace(/\\ /g, ' '); // unescape shell-escaped spaces
+    if (PASTED_IMAGE_EXTENSIONS.test(normalized)) {
+      imagePaths.push(normalized);
+    } else {
+      allImages = false;
+    }
+  }
+  return { imagePaths, allImages };
 }
 
 const debugLogger = createDebugLogger('INPUT_PROMPT');
@@ -642,6 +685,52 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     }
   }, []);
 
+  // Promote a paste that is purely image-file path(s) (e.g. a terminal/clipboard
+  // helper that injects `@<path>` text on Cmd+V) into attachment chips, so the
+  // interaction matches Ctrl+V. Each source image is copied into the global temp
+  // dir (the same place Ctrl+V saves to) so it resolves under the workspace
+  // boundary on submit regardless of where it originally lived. If none of the
+  // candidate paths resolve, the original text is inserted unchanged.
+  const promotePastedImagePaths = useCallback(
+    async (imagePaths: string[], originalPasted: string) => {
+      const cwd = config.getTargetDir();
+      const clipboardDir = path.join(Storage.getGlobalTempDir(), 'clipboard');
+      const attachments: Attachment[] = [];
+      for (const imagePath of imagePaths) {
+        const sourcePath = path.isAbsolute(imagePath)
+          ? imagePath
+          : path.resolve(cwd, imagePath);
+        try {
+          const stats = await fs.stat(sourcePath);
+          if (!stats.isFile()) continue;
+          await fs.mkdir(clipboardDir, { recursive: true });
+          const destPath = path.join(
+            clipboardDir,
+            `clipboard-${Date.now()}-${attachments.length}${path.extname(sourcePath)}`,
+          );
+          await fs.copyFile(sourcePath, destPath);
+          attachments.push({
+            id: `${Date.now()}-${attachments.length}`,
+            path: destPath,
+            filename: path.basename(destPath),
+          });
+        } catch {
+          // Source missing or copy failed — skip this token.
+        }
+      }
+      if (attachments.length > 0) {
+        cleanupOldClipboardImages(Storage.getGlobalTempDir()).catch(() => {
+          // Ignore cleanup errors
+        });
+        setAttachments((prev) => [...prev, ...attachments]);
+      } else {
+        // Looked like image paths but none resolved — keep the original as text.
+        buffer.insert(originalPasted, { paste: false });
+      }
+    },
+    [config, buffer],
+  );
+
   // Handle deletion of an attachment from the list
   const handleAttachmentDelete = useCallback((index: number) => {
     setAttachments((prev) => {
@@ -849,8 +938,16 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         const lineCount = pasted.split('\n').length;
 
         // Ensure we never accidentally interpret paste as regular input.
+        const pastedImagePaths = classifyPastedImagePaths(pasted);
         if (key.pasteImage) {
           handleClipboardImage(true);
+        } else if (
+          pastedImagePaths.allImages &&
+          pastedImagePaths.imagePaths.length > 0
+        ) {
+          // Pasted text is purely image path(s) — promote to attachment chips
+          // so Cmd+V (terminal-injected path) matches the Ctrl+V experience.
+          void promotePastedImagePaths(pastedImagePaths.imagePaths, pasted);
         } else if (
           charCount > LARGE_PASTE_CHAR_THRESHOLD ||
           lineCount > LARGE_PASTE_LINE_THRESHOLD
@@ -1580,6 +1677,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       shellHistory,
       reverseSearchCompletion,
       handleClipboardImage,
+      promotePastedImagePaths,
       resetCompletionState,
       dismissCompletion,
       escPressCount,


### PR DESCRIPTION
## What this PR does

Some terminals and clipboard helpers deliver an image paste (e.g. Cmd+V) by saving the image to a temp file and injecting an `@<path>` text reference into the input, instead of going through the native Ctrl+V clipboard read. This PR detects a paste that is purely image-file path(s), copies each image into the global temp dir (the same place Ctrl+V already saves to), and shows it as an attachment chip. Pastes that aren't image paths, or whose paths don't exist on disk, fall through to normal text paste unchanged.

## Why it's needed

Before this change the same action produced two different results: Ctrl+V (native clipboard read) created an attachment chip, while Cmd+V (a terminal-injected `@<path>` text paste) left a raw `@<path>` link sitting in the input. After this change both converge on the attachment-chip experience and resolve identically on submit, since the image now always lands in the global temp dir under the workspace boundary.

## Reviewer Test Plan

### How to verify

1. Run a build where pasting an image via the terminal injects an `@<path>` text reference (any terminal/clipboard helper that saves the image to a temp file and types the path).
2. Copy an image, paste it into the prompt.
3. Expected: an attachment chip appears (e.g. `[clipboard-….png]`), not a raw `@/path/to/clipboard.png` link. Submit, and the image resolves the same way a Ctrl+V paste does.
4. Paste plain text, or an `@path` that isn't an existing image: behavior is unchanged (inserted as text).

### Evidence (Before & After)

- Before: pasting via the terminal-injected path left `@/var/folders/.../clipboard-….png` as literal text in the input.
- After: the same paste shows an attachment chip, matching Ctrl+V:

<img width="1084" alt="pasted image path becomes an attachment chip" src="https://github.com/user-attachments/assets/1075bf7e-6493-405c-981d-6536db6159e3" />

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment

Local build: `node packages/cli/dist/index.js`. Unit tests via `vitest`.

## Risk & Scope

- Main risk or tradeoff: a paste the user intended as literal text could be promoted to an attachment. Mitigated by only promoting when every token is an image-extension path **and** the file actually exists on disk; anything else falls through to text.
- Not validated / out of scope: the chip label still shows the full temp filename — compact `[Image #N]`-style labels and multi-attachment layout are a follow-up. Not tested on Windows/Linux locally.
- Breaking changes / migration notes: none.

## Linked Issues

Related (not auto-closing): #3518 — unified image-paste handling.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

部分终端和剪贴板工具在粘贴图片(如 Cmd+V)时,是把图片存到临时文件、再往输入框注入一段 `@<路径>` 文本,而不是走原生 Ctrl+V 的剪贴板读取。本 PR 会识别「整段粘贴都是图片文件路径」的情况,把每个图片拷贝到全局临时目录(Ctrl+V 落盘的同一处),并显示为附件 chip。非图片粘贴、或路径在磁盘上不存在时,维持原有的文本粘贴行为。

## 为什么需要

改之前,同一个动作有两种结果:Ctrl+V(原生剪贴板读取)生成附件 chip,而 Cmd+V(终端注入的 `@<路径>` 文本粘贴)只在输入框留下一段裸 `@<路径>` 链接。改之后两者统一为附件 chip,提交时也走同一条解析路径——因为图片现在总是落到 workspace 边界内的全局临时目录。

## Reviewer Test Plan

### 如何验证

1. 用一个「终端粘贴图片会注入 `@<路径>` 文本」的构建(任何把图片存临时文件、再敲路径的终端/剪贴板工具)。
2. 复制一张图,粘贴进输入框。
3. 预期:出现附件 chip(如 `[clipboard-….png]`),而不是裸 `@/path/to/clipboard.png` 链接。提交后,图片解析方式与 Ctrl+V 一致。
4. 粘贴纯文本、或一个不存在的 `@path`:行为不变(按文本插入)。

### 证据(前后对比)

- 改前:终端注入路径后,输入框留下 `@/var/folders/.../clipboard-….png` 文本。
- 改后:同样的粘贴显示附件 chip,与 Ctrl+V 一致(见上图)。

## 风险与范围

- 主要风险:用户本想当文本粘贴的内容可能被识别成附件。已通过「每个 token 都是图片扩展名路径 **且** 文件真实存在」来限制,其余一律退回文本。
- 未验证 / 范围外:chip 标签仍显示完整临时文件名——紧凑的 `[Image #N]` 标签与多附件排版作为后续。Windows/Linux 未本地验证。
- 破坏性变更:无。

</details>
