### PR TITLE
fix(cli): cancel pending self-paced loop wakeups on user abort

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -4909,6 +4909,109 @@ describe('useGeminiStream', () => {
       );
     });
 
+    it('cancels pending self-paced loop wakeups and notifies on a tick-in-flight abort', async () => {
+      const cancelAllWakeups = vi.fn().mockReturnValue(2);
+      (mockConfig.getCronScheduler as unknown as Mock).mockReturnValue({
+        cancelAllWakeups,
+      });
+
+      const mockStream = (async function* () {
+        yield { type: 'content', value: 'Part 1' };
+        await new Promise(() => {}); // keep the tick open
+      })();
+      mockSendMessageStream.mockReturnValue(mockStream);
+
+      const { result } = renderTestHook();
+
+      await act(async () => {
+        result.current.submitQuery('keep checking the deploy');
+      });
+      expect(result.current.streamingState).toBe(StreamingState.Responding);
+
+      act(() => {
+        result.current.cancelOngoingRequest();
+      });
+
+      expect(cancelAllWakeups).toHaveBeenCalledTimes(1);
+      expect(mockAddItem).toHaveBeenCalledWith(
+        {
+          type: MessageType.INFO,
+          text: 'Stopped the self-paced loop: cancelled 2 pending wakeups.',
+        },
+        expect.any(Number),
+      );
+      // The count is annotated onto the abort telemetry (4th ctor arg).
+      expect(MockedApiCancelEvent.mock.calls.at(-1)?.[3]).toBe(2);
+    });
+
+    it('uses the singular form when exactly one wakeup was cancelled', async () => {
+      const cancelAllWakeups = vi.fn().mockReturnValue(1);
+      (mockConfig.getCronScheduler as unknown as Mock).mockReturnValue({
+        cancelAllWakeups,
+      });
+
+      const mockStream = (async function* () {
+        yield { type: 'content', value: 'Part 1' };
+        await new Promise(() => {}); // keep the tick open
+      })();
+      mockSendMessageStream.mockReturnValue(mockStream);
+
+      const { result } = renderTestHook();
+
+      await act(async () => {
+        result.current.submitQuery('keep checking the deploy');
+      });
+      expect(result.current.streamingState).toBe(StreamingState.Responding);
+
+      act(() => {
+        result.current.cancelOngoingRequest();
+      });
+
+      expect(mockAddItem).toHaveBeenCalledWith(
+        {
+          type: MessageType.INFO,
+          text: 'Stopped the self-paced loop: cancelled 1 pending wakeup.',
+        },
+        expect.any(Number),
+      );
+      expect(MockedApiCancelEvent.mock.calls.at(-1)?.[3]).toBe(1);
+    });
+
+    it('shows no loop notice when the abort cancelled no wakeups', async () => {
+      const cancelAllWakeups = vi.fn().mockReturnValue(0);
+      (mockConfig.getCronScheduler as unknown as Mock).mockReturnValue({
+        cancelAllWakeups,
+      });
+
+      const mockStream = (async function* () {
+        yield { type: 'content', value: 'Part 1' };
+        await new Promise(() => {}); // keep the tick open
+      })();
+      mockSendMessageStream.mockReturnValue(mockStream);
+
+      const { result } = renderTestHook();
+
+      await act(async () => {
+        result.current.submitQuery('ordinary request');
+      });
+      expect(result.current.streamingState).toBe(StreamingState.Responding);
+
+      act(() => {
+        result.current.cancelOngoingRequest();
+      });
+
+      // Always attempted; only the user-facing notice and the telemetry
+      // annotation are gated on a positive count.
+      expect(cancelAllWakeups).toHaveBeenCalledTimes(1);
+      expect(mockAddItem).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining('self-paced loop'),
+        }),
+        expect.any(Number),
+      );
+      expect(MockedApiCancelEvent.mock.calls.at(-1)?.[3]).toBeUndefined();
+    });
+
     it('should prevent further processing after cancellation', async () => {
       let continueStream: () => void;
       const streamPromise = new Promise<void>((resolve) => {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -775,6 +775,12 @@ export const useGeminiStream = (
     turnCancelledRef.current = true;
     isSubmittingQueryRef.current = false;
     abortControllerRef.current?.abort();
+    // Aborting a tick-in-flight ends any self-paced /loop: drop pending loop
+    // wakeups so the loop doesn't resume after the cancelled tick. Only clears
+    // session wakeups (never cron jobs); lazily-creating an empty scheduler
+    // here is inert.
+    const loopWakeupsCancelled =
+      config.getCronScheduler()?.cancelAllWakeups() ?? 0;
     // Cancel any in-flight auxiliary work so its Promise.then doesn't add
     // stale content after the user cancelled.
     for (const ac of auxiliaryAbortRefsRef.current) {
@@ -794,6 +800,7 @@ export const useGeminiStream = (
       config.getModel(),
       prompt_id,
       config.getContentGeneratorConfig()?.authType,
+      loopWakeupsCancelled > 0 ? loopWakeupsCancelled : undefined,
     );
     logApiCancel(config, cancellationEvent);
 
@@ -807,6 +814,17 @@ export const useGeminiStream = (
       },
       Date.now(),
     );
+    if (loopWakeupsCancelled > 0) {
+      addItem(
+        {
+          type: MessageType.INFO,
+          text: `Stopped the self-paced loop: cancelled ${loopWakeupsCancelled} pending wakeup${
+            loopWakeupsCancelled === 1 ? '' : 's'
+          }.`,
+        },
+        Date.now(),
+      );
+    }
     setPendingHistoryItem(null);
     clearRetryCountdown();
     // Wrap the consumer callback so a throw in AppContainer's cancel

--- a/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
+++ b/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
@@ -650,6 +650,7 @@ export class QwenLogger {
         model: event.model,
         prompt_id: event.prompt_id,
         auth_type: event.auth_type,
+        loop_wakeups_cancelled: event.loop_wakeups_cancelled,
       },
     });
 

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -327,13 +327,24 @@ export class ApiCancelEvent implements BaseTelemetryEvent {
   model: string;
   prompt_id: string;
   auth_type?: string;
+  // Pending self-paced /loop wakeups dropped by this abort, when any. Lets a
+  // user abort that ends a loop be told apart from an ordinary cancellation.
+  // Named for wakeups (not "loops") to avoid colliding with loop_type, the
+  // unrelated repetition-detection vocabulary in this file.
+  loop_wakeups_cancelled?: number;
 
-  constructor(model: string, prompt_id: string, auth_type?: string) {
+  constructor(
+    model: string,
+    prompt_id: string,
+    auth_type?: string,
+    loop_wakeups_cancelled?: number,
+  ) {
     this['event.name'] = 'api_cancel';
     this['event.timestamp'] = new Date().toISOString();
     this.model = model;
     this.prompt_id = prompt_id;
     this.auth_type = auth_type;
+    this.loop_wakeups_cancelled = loop_wakeups_cancelled;
   }
 }
 


### PR DESCRIPTION
## What this PR does

Aborting an in-flight self-paced `/loop` tick with Esc now also ends the loop: the pending one-shot loop wakeup is cancelled, so the loop no longer silently resumes at its next scheduled fire. When at least one wakeup is dropped, the user gets a short notice confirming the loop was stopped, and the cancellation telemetry records how many loop wakeups the abort cleared.

## Why it's needed

Self-paced `/loop` schedules a session-only one-shot wakeup at the end of each tick. Before this change, aborting a tick cancelled the current turn but left that wakeup armed, so the loop came back to life at the next fire against the user's intent — there was no way to stop a self-paced loop mid-tick. The primitive that drops pending wakeups already existed but was never wired to the abort path. The change is loop-scoped: only session loop wakeups are cleared; scheduled cron jobs are untouched.

## Reviewer Test Plan

### How to verify

Automated — `npm run test --workspace packages/cli -- src/ui/hooks/useGeminiStream.test.tsx`: the Cancellation block covers the new behavior (plural notice, singular notice, and the no-wakeup case where the notice is suppressed and the telemetry count is omitted). Core telemetry stays green: `npm run test --workspace packages/core -- src/telemetry`.

Manual — start a self-paced loop (`/loop <prompt>` with no interval); while a tick is responding, press Esc. Expected: the turn cancels AND a notice `Stopped the self-paced loop: cancelled N pending wakeup(s).` appears, and no further wakeup fires. Aborting an ordinary (non-loop) request shows only the usual `Request cancelled.` with no loop notice.

### Evidence (Before & After)

Before — Esc during a self-paced loop tick cancelled the turn, but the armed wakeup later fired and the loop resumed, with no indication the loop was still alive. After — Esc during the tick cancels the turn, drops the pending wakeup, prints `Stopped the self-paced loop: cancelled 1 pending wakeup.`, and the loop does not resume. Behavior verified via hook-level unit tests; no live TUI recording captured.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ unit tests |
| 🪟 Windows | ⚠️ not tested (CI) |
|  🐧 Linux  | ⚠️ not tested (CI) |

### Environment (optional)

Unit tests only (vitest); no live runtime needed.

## Risk & Scope

- Main risk or tradeoff: low — the cancel is a synchronous in-memory map clear behind optional chaining; it runs on every abort but is inert when no loop is active (empty scheduler → 0 → no notice, no telemetry field).
- Not validated / out of scope: live cross-platform TUI rendering of the notice (verified via unit tests); only the tick-in-flight case is handled — idle pending wakeups remain cancellable via `/loop clear`; a dedicated standalone cancel telemetry event is intentionally omitted (qwen self-paced wakeups are session-only one-shots with at most one pending, and there is no signal bus to host it).
- Breaking changes / migration notes: none — `ApiCancelEvent` gains one optional trailing constructor param/field (`loop_wakeups_cancelled`); the single existing call site and all consumers stay backward-compatible.

## Linked Issues

Closes #5806

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

用 Esc 中止进行中的自定步 `/loop` tick 现在会真正结束循环:那次 tick 末尾排定的一次性 loop wakeup 会被取消,循环不再在下次预定时间悄悄复活。当至少取消了一个 wakeup 时,用户会看到一条简短提示确认循环已停止,取消遥测也会记录这次中止清掉了多少个 loop wakeup。

## 为什么需要

自定步 `/loop` 在每个 tick 末尾排一个 session 级一次性 wakeup。改动前,中止 tick 只取消当前 turn,却把那个 wakeup 留着,于是循环在下次 fire 时违背用户意愿复活——没有办法在 tick 中途停掉自定步循环。取消 pending wakeup 的原语早已存在,只是从未接到 abort 路径上。本改动是 loop-scoped 的:只清 session loop wakeups,排定的 cron job 不动。

## Reviewer 验证计划

### 如何验证

自动——`npm run test --workspace packages/cli -- src/ui/hooks/useGeminiStream.test.tsx`:Cancellation 块覆盖了新行为(复数提示、单数提示,以及无 wakeup 时提示被抑制、遥测计数省略的情形)。core telemetry 保持全绿:`npm run test --workspace packages/core -- src/telemetry`。

手动——启动一个自定步循环(`/loop <prompt>`,不带间隔);在某个 tick responding 时按 Esc。预期:turn 取消,且出现提示 `Stopped the self-paced loop: cancelled N pending wakeup(s).`,之后不再有 wakeup fire。中止普通(非循环)请求只显示常规的 `Request cancelled.`,无循环提示。

### 证据(Before & After)

Before——自定步循环 tick 中按 Esc 取消了 turn,但已 armed 的 wakeup 之后照样 fire、循环复活,没有任何循环仍存活的提示。After——tick 中按 Esc 取消 turn、丢弃 pending wakeup、打印 `Stopped the self-paced loop: cancelled 1 pending wakeup.`,循环不再复活。行为经 hook 级单测验证;未录制实时 TUI。

### 测试平台

🍏 macOS ✅(单测)· 🪟 Windows ⚠️ 未测(CI)· 🐧 Linux ⚠️ 未测(CI)。

### 运行环境(可选)

仅单元测试(vitest),无需实时运行时。

## 风险与范围

- 主要风险/取舍:低——取消调用是可选链后的同步内存 map 清空;每次 abort 都跑,但无循环时是 inert(空 scheduler → 0 → 无提示、无遥测字段)。
- 未验证/超范围:提示在跨平台 TUI 的实时渲染(经单测验证);只处理 tick-in-flight,idle pending wakeup 仍靠 `/loop clear`;有意不做独立的取消遥测事件(qwen 自定步 wakeup 是 session 级一次性、至多一个 pending,且无 signal bus 承载)。
- 破坏性改动/迁移:无——`ApiCancelEvent` 只新增一个可选末尾构造参数/字段(`loop_wakeups_cancelled`);唯一现有调用点与所有消费者向后兼容。

</details>
