### PR TITLE
ci: harden Linux CI reliability (shallow ECS checkout + CodeQL timeout)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,11 @@ jobs:
         uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
         with:
           ref: "${{ github.event.inputs.branch_ref || (github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number)) || github.ref }}"
-          fetch-depth: 0
+          # Shallow: nothing here walks git history (the verify guard below checks
+          # head.sha == HEAD, schema/tests touch only the working tree). On the
+          # in-repo ECS runner a full-history clone is the heaviest transfer and
+          # chokes the squid egress proxy, flaking checkout. depth 1 is enough.
+          fetch-depth: 1
 
       - name: 'Verify PR checkout includes head commit'
         if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && github.event_name == 'pull_request' }}"
@@ -372,6 +376,11 @@ jobs:
     needs: 'classify_pr'
     if: "${{ !cancelled() && needs.classify_pr.outputs.skip_ci != 'true' }}"
     runs-on: 'ubuntu-latest'
+    # Analysis normally finishes in ~7-9 min (22 min worst case observed). Without
+    # an explicit cap, a hosted runner that drops its heartbeat mid-analysis leaves
+    # the job "in_progress" for the default 6h, holding a scarce hosted Linux slot
+    # the whole time. 30 min reaps such an orphan fast while clearing real runs.
+    timeout-minutes: 30
     permissions:
       actions: 'read'
       contents: 'read'


### PR DESCRIPTION
## What this PR does

Two independent reliability fixes on the Linux CI path: the ECS-routed ubuntu `test` job now does a shallow checkout (`fetch-depth: 0` → `1`), and the `codeql` job gets an explicit `timeout-minutes: 30`.

## Why it's needed

The ubuntu `test` job is routed to the self-hosted ECS runner, which reaches GitHub through a squid egress proxy. A full-history clone is by far the heaviest transfer in the job and repeatedly chokes that proxy — checkout flakes with `Operation too slow (Less than 1000 bytes/sec)` and eventual `Failed to connect ... after 134585 ms`. Nothing in the job actually needs git history: the `Verify PR checkout includes head commit` guard only checks `git merge-base --is-ancestor head.sha HEAD` (which holds at depth 1 because checkout is `refs/pull/N/head`, so `HEAD == head.sha`), the schema/test steps touch only the working tree, and coverage diffing runs in a separate hosted `Post Coverage Comment` job that checks out on its own. So the full history is dead weight; depth 1 removes the flake's root cause. (`fetch-depth: 0` here is historical cruft carried over from the first CI workflow, never re-examined.)

The `codeql` job had no `timeout-minutes`, so it inherited GitHub's default 6h job cap. When a hosted runner drops its heartbeat mid-analysis, the job stays `in_progress` for the full 6h, pinning a scarce hosted Linux slot the whole time and starving the queue — observed live today (one orphaned run held a slot for ~4h with zero log output). Real CodeQL runs finish in ~7-9 min (22 min worst case observed), so a 30-min cap reaps such an orphan quickly without clipping legitimate runs.

## Reviewer Test Plan

### How to verify

- `actionlint .github/workflows/ci.yml` passes.
- depth=1 safety: confirm the only git-history consumer in the ubuntu `test` job is the `Verify PR checkout includes head commit` guard, and that it holds at depth 1 (checkout ref is `refs/pull/N/head`, so `HEAD` is the head commit and `merge-base --is-ancestor head.sha HEAD` is trivially true). After merge, ECS-routed in-repo PR runs should show checkout completing without the "Operation too slow" retries.
- timeout: any CodeQL run still completes (~7-9 min); a hung/orphaned run now fails at 30 min instead of 6h.

### Evidence (Before & After)

N/A — CI-config only, no user-visible change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A  |
| 🪟 Windows |  N/A  |
|  🐧 Linux  |  ⚠️ validated with actionlint; runtime effect observable only on CI runners post-merge  |

### Environment (optional)

N/A — workflow change, no local runtime.

## Risk & Scope

- Main risk: `depth=1` would break any step that walks git history. Audited — no such step exists in this job; if one is added later it must fetch base history explicitly (or revert this).
- CodeQL `timeout-minutes: 30`: a legitimately slow analysis (>30 min) would be cut. Worst observed is 22 min, so 30 leaves headroom; bump if a real run ever approaches it.
- Not validated: the live ECS-runner checkout improvement can only be observed post-merge on in-repo PRs (forks stay on hosted runners).
- Breaking changes: none.

## Linked Issues

CI-reliability follow-up to the ECS runner routing introduced in #5620. No issue to close.
