### PR TITLE
fix(cli): correctly map Claude MCP server transport types on import and in .mcp.json

### DIFF
--- a/packages/cli/src/config/claudeMcpImport.test.ts
+++ b/packages/cli/src/config/claudeMcpImport.test.ts
@@ -141,13 +141,60 @@ describe('claude MCP import', () => {
       homeDir,
     });
 
+    // Claude's `type` discriminator is dropped on every transport (qwen reserves
+    // `type` for 'sdk'): http→httpUrl, sse→url, stdio keeps command only.
     expect(settings.setValue).toHaveBeenCalledWith(
       SettingScope.User,
       'mcpServers',
       {
         httpServer: { httpUrl: 'https://example.com/mcp' },
         sseServer: { url: 'https://example.com/sse' },
-        stdioServer: { type: 'stdio', command: 'node', args: ['s.js'] },
+        stdioServer: { command: 'node', args: ['s.js'] },
+      },
+    );
+  });
+
+  it('preserves non-transport fields through normalization', () => {
+    writeJson(path.join(homeDir, '.claude.json'), {
+      mcpServers: {
+        httpServer: {
+          type: 'http',
+          url: 'https://example.com/mcp',
+          headers: { Authorization: 'Bearer x' },
+          timeout: 5000,
+        },
+        stdioServer: {
+          type: 'stdio',
+          command: 'node',
+          args: ['s.js'],
+          env: { API_KEY: 'secret' },
+        },
+      },
+    });
+
+    const settings = createSettings();
+    importClaudeMcpServers({
+      source: 'claude-code',
+      scope: 'user',
+      settings,
+      cwd: projectDir,
+      homeDir,
+    });
+
+    expect(settings.setValue).toHaveBeenCalledWith(
+      SettingScope.User,
+      'mcpServers',
+      {
+        httpServer: {
+          httpUrl: 'https://example.com/mcp',
+          headers: { Authorization: 'Bearer x' },
+          timeout: 5000,
+        },
+        stdioServer: {
+          command: 'node',
+          args: ['s.js'],
+          env: { API_KEY: 'secret' },
+        },
       },
     );
   });

--- a/packages/cli/src/config/claudeMcpImport.test.ts
+++ b/packages/cli/src/config/claudeMcpImport.test.ts
@@ -123,6 +123,35 @@ describe('claude MCP import', () => {
     );
   });
 
+  it('normalizes Claude transport types into Qwen URL fields', () => {
+    writeJson(path.join(homeDir, '.claude.json'), {
+      mcpServers: {
+        httpServer: { type: 'http', url: 'https://example.com/mcp' },
+        sseServer: { type: 'sse', url: 'https://example.com/sse' },
+        stdioServer: { type: 'stdio', command: 'node', args: ['s.js'] },
+      },
+    });
+
+    const settings = createSettings();
+    importClaudeMcpServers({
+      source: 'claude-code',
+      scope: 'user',
+      settings,
+      cwd: projectDir,
+      homeDir,
+    });
+
+    expect(settings.setValue).toHaveBeenCalledWith(
+      SettingScope.User,
+      'mcpServers',
+      {
+        httpServer: { httpUrl: 'https://example.com/mcp' },
+        sseServer: { url: 'https://example.com/sse' },
+        stdioServer: { type: 'stdio', command: 'node', args: ['s.js'] },
+      },
+    );
+  });
+
   it('imports Claude Code current-project MCP servers into project scope', () => {
     writeJson(path.join(homeDir, '.claude.json'), {
       mcpServers: {

--- a/packages/cli/src/config/claudeMcpImport.ts
+++ b/packages/cli/src/config/claudeMcpImport.ts
@@ -7,7 +7,10 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import type { MCPServerConfig } from '@qwen-code/qwen-code-core';
+import {
+  type MCPServerConfig,
+  normalizeClaudeMcpServer,
+} from '@qwen-code/qwen-code-core';
 import stripJsonComments from 'strip-json-comments';
 import { SettingScope, type LoadedSettings } from './settings.js';
 
@@ -139,7 +142,10 @@ function copyMcpServers(
       errors.push(`${sourcePath}: server "${name}" is not an object - skipped`);
       continue;
     }
-    servers[name] = serverConfig as MCPServerConfig;
+    // Claude keys transport off a `type` field; Qwen keys off which URL field is
+    // set. Normalize so a Claude `type: 'http'` server connects over streamable
+    // HTTP instead of being mistaken for SSE.
+    servers[name] = normalizeClaudeMcpServer(serverConfig as MCPServerConfig);
   }
 }
 

--- a/packages/cli/src/config/mcpJson.test.ts
+++ b/packages/cli/src/config/mcpJson.test.ts
@@ -64,6 +64,34 @@ describe('loadProjectMcpServers', () => {
     });
   });
 
+  it('normalizes Claude-style type-based transports (.mcp.json is a Claude convention)', () => {
+    write(
+      JSON.stringify({
+        mcpServers: {
+          httpServer: { type: 'http', url: 'https://example.test/mcp' },
+          sseServer: { type: 'sse', url: 'https://example.test/sse' },
+          stdioServer: { type: 'stdio', command: 'node', args: ['s.js'] },
+        },
+      }),
+    );
+    const { servers, errors } = loadProjectMcpServers(dir);
+    expect(errors).toEqual([]);
+
+    expect(servers['httpServer']).toEqual({
+      httpUrl: 'https://example.test/mcp',
+      scope: 'project',
+    });
+    expect(servers['sseServer']).toEqual({
+      url: 'https://example.test/sse',
+      scope: 'project',
+    });
+    expect(servers['stdioServer']).toEqual({
+      command: 'node',
+      args: ['s.js'],
+      scope: 'project',
+    });
+  });
+
   it('forces .mcp.json server scope to project', () => {
     write(
       JSON.stringify({

--- a/packages/cli/src/config/mcpJson.ts
+++ b/packages/cli/src/config/mcpJson.ts
@@ -6,7 +6,10 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import type { MCPServerConfig } from '@qwen-code/qwen-code-core';
+import {
+  type MCPServerConfig,
+  normalizeClaudeMcpServer,
+} from '@qwen-code/qwen-code-core';
 import stripJsonComments from 'strip-json-comments';
 
 /** Project-scoped MCP config filename, read from the workspace root. */
@@ -81,8 +84,10 @@ export function loadProjectMcpServers(
       errors.push(`${filePath}: server "${name}" is not an object — skipped`);
       continue;
     }
+    // `.mcp.json` is the Claude Code convention, so entries may use Claude's
+    // `type`-based transport shape; normalize them to Qwen's field-based shape.
     servers[name] = {
-      ...(value as MCPServerConfig),
+      ...normalizeClaudeMcpServer(value as MCPServerConfig),
       scope: 'project',
     };
   }

--- a/packages/core/src/extension/claude-converter.test.ts
+++ b/packages/core/src/extension/claude-converter.test.ts
@@ -15,6 +15,7 @@ import {
   isClaudePluginConfig,
   convertClaudePluginPackage,
   convertClaudePluginStandalone,
+  normalizeClaudeMcpServer,
   type ClaudePluginConfig,
   type ClaudeMarketplacePluginConfig,
   type ClaudeMarketplaceConfig,
@@ -1452,5 +1453,85 @@ describe('convertClaudePluginPackage — string URL source', () => {
     expect(vi.mocked(downloadFromGitHubRelease)).toHaveBeenCalled();
 
     fs.rmSync(result.convertedDir, { recursive: true, force: true });
+  });
+});
+
+describe('normalizeClaudeMcpServer', () => {
+  // Cast helpers: inputs may carry Claude-only fields (`type:'http'` etc.) that
+  // aren't on MCPServerConfig, and outputs are inspected as plain records.
+  const norm = (raw: Record<string, unknown>): Record<string, unknown> =>
+    normalizeClaudeMcpServer(raw as never) as unknown as Record<
+      string,
+      unknown
+    >;
+
+  it('maps Claude type:http (url) to httpUrl and drops type/url', () => {
+    expect(norm({ type: 'http', url: 'https://example.com/mcp' })).toEqual({
+      httpUrl: 'https://example.com/mcp',
+    });
+  });
+
+  it('maps Claude type:sse (url) to url and drops type', () => {
+    expect(norm({ type: 'sse', url: 'https://example.com/sse' })).toEqual({
+      url: 'https://example.com/sse',
+    });
+  });
+
+  it('drops type from a Claude stdio server, keeping command', () => {
+    expect(norm({ type: 'stdio', command: 'node', args: ['s.js'] })).toEqual({
+      command: 'node',
+      args: ['s.js'],
+    });
+  });
+
+  it("preserves type:'sdk' (isSdkMcpServerConfig depends on it)", () => {
+    // sdk standalone, and sdk alongside a command — both must keep type:'sdk'.
+    expect(norm({ type: 'sdk', description: 'in-process' })).toEqual({
+      type: 'sdk',
+      description: 'in-process',
+    });
+    expect(norm({ type: 'sdk', command: 'node' })).toEqual({
+      type: 'sdk',
+      command: 'node',
+    });
+  });
+
+  it('drops a bogus non-sdk type from a websocket (tcp) config', () => {
+    // qwen reserves `type` for 'sdk' and selects websocket via the `tcp` field;
+    // any stray non-sdk `type` is meaningless and is removed.
+    expect(norm({ type: 'tcp', tcp: 'localhost:8000' })).toEqual({
+      tcp: 'localhost:8000',
+    });
+  });
+
+  it('preserves non-transport fields (headers, env, timeout)', () => {
+    expect(
+      norm({
+        type: 'http',
+        url: 'https://example.com/mcp',
+        headers: { Authorization: 'Bearer x' },
+        timeout: 5000,
+      }),
+    ).toEqual({
+      httpUrl: 'https://example.com/mcp',
+      headers: { Authorization: 'Bearer x' },
+      timeout: 5000,
+    });
+  });
+
+  it('passes through an already-Qwen-shaped config unchanged', () => {
+    expect(norm({ httpUrl: 'https://example.com/mcp' })).toEqual({
+      httpUrl: 'https://example.com/mcp',
+    });
+    expect(norm({ command: 'node', args: ['s.js'] })).toEqual({
+      command: 'node',
+      args: ['s.js'],
+    });
+  });
+
+  it('leaves a transport-less config untouched', () => {
+    expect(norm({ description: 'metadata only' })).toEqual({
+      description: 'metadata only',
+    });
   });
 });

--- a/packages/core/src/extension/claude-converter.ts
+++ b/packages/core/src/extension/claude-converter.ts
@@ -334,21 +334,31 @@ ${systemPrompt}
  * Maps a single Claude `.mcp.json` server entry to Qwen's MCPServerConfig shape.
  * Claude discriminates transport with a `type` field (`http`/`sse`/`stdio`),
  * whereas Qwen keys off which field is set: `httpUrl` (streamable HTTP),
- * `url` (SSE) or `command` (stdio). A Claude `type: 'http'` entry therefore
- * has to move its `url` to `httpUrl`, and the now-meaningless `type` is dropped.
+ * `url` (SSE) or `command` (stdio). A Claude `type: 'http'` entry therefore has
+ * to move its `url` to `httpUrl`. Qwen reserves `type` for `'sdk'`, so any other
+ * `type` value (Claude's transport discriminator) is dropped while `'sdk'` —
+ * which `isSdkMcpServerConfig` depends on — is always preserved.
  */
 export function normalizeClaudeMcpServer(
   raw: MCPServerConfig,
 ): MCPServerConfig {
   const server = raw as unknown as Record<string, unknown>;
-  // stdio / already-Qwen-shaped configs pass through unchanged.
+  // stdio / already-Qwen-shaped configs pass through; only a non-sdk `type`
+  // (Claude's transport discriminator) is stripped.
   if (server['command'] || server['httpUrl'] || server['tcp']) {
-    return raw;
+    if (server['type'] === undefined || server['type'] === 'sdk') {
+      return raw;
+    }
+    const rest = { ...server };
+    delete rest['type'];
+    return rest as unknown as MCPServerConfig;
   }
   if (typeof server['url'] === 'string') {
     const rest = { ...server };
-    delete rest['type'];
     delete rest['url'];
+    if (rest['type'] !== 'sdk') {
+      delete rest['type'];
+    }
     return {
       ...rest,
       ...(server['type'] === 'http'

--- a/packages/core/src/extension/claude-converter.ts
+++ b/packages/core/src/extension/claude-converter.ts
@@ -331,36 +331,44 @@ ${systemPrompt}
 }
 
 /**
- * Maps Claude `.mcp.json` server entries to Qwen's MCPServerConfig shape.
+ * Maps a single Claude `.mcp.json` server entry to Qwen's MCPServerConfig shape.
  * Claude discriminates transport with a `type` field (`http`/`sse`/`stdio`),
  * whereas Qwen keys off which field is set: `httpUrl` (streamable HTTP),
  * `url` (SSE) or `command` (stdio). A Claude `type: 'http'` entry therefore
  * has to move its `url` to `httpUrl`, and the now-meaningless `type` is dropped.
+ */
+export function normalizeClaudeMcpServer(
+  raw: MCPServerConfig,
+): MCPServerConfig {
+  const server = raw as unknown as Record<string, unknown>;
+  // stdio / already-Qwen-shaped configs pass through unchanged.
+  if (server['command'] || server['httpUrl'] || server['tcp']) {
+    return raw;
+  }
+  if (typeof server['url'] === 'string') {
+    const rest = { ...server };
+    delete rest['type'];
+    delete rest['url'];
+    return {
+      ...rest,
+      ...(server['type'] === 'http'
+        ? { httpUrl: server['url'] }
+        : { url: server['url'] }),
+    } as unknown as MCPServerConfig;
+  }
+  return raw;
+}
+
+/**
+ * Maps Claude `.mcp.json` server entries to Qwen's MCPServerConfig shape.
+ * @see normalizeClaudeMcpServer for the per-server transport mapping.
  */
 function normalizeClaudeMcpServers(
   servers: Record<string, MCPServerConfig>,
 ): Record<string, MCPServerConfig> {
   const normalized: Record<string, MCPServerConfig> = {};
   for (const [name, raw] of Object.entries(servers)) {
-    const server = raw as unknown as Record<string, unknown>;
-    // stdio / already-Qwen-shaped configs pass through unchanged.
-    if (server['command'] || server['httpUrl'] || server['tcp']) {
-      normalized[name] = raw;
-      continue;
-    }
-    if (typeof server['url'] === 'string') {
-      const rest = { ...server };
-      delete rest['type'];
-      delete rest['url'];
-      normalized[name] = {
-        ...rest,
-        ...(server['type'] === 'http'
-          ? { httpUrl: server['url'] }
-          : { url: server['url'] }),
-      } as unknown as MCPServerConfig;
-      continue;
-    }
-    normalized[name] = raw;
+    normalized[name] = normalizeClaudeMcpServer(raw);
   }
   return normalized;
 }


### PR DESCRIPTION
## What this PR does

Qwen Code can ingest MCP server definitions that were authored for Claude — through the `/import-config` migration, through installed extensions and plugins, and through a project's `.mcp.json` file. Claude describes a server's transport with a `type` field (`http`, `sse`, or `stdio`), whereas Qwen Code infers the transport from which connection field is present (`httpUrl` for streamable HTTP, `url` for SSE, `command` for stdio, `tcp` for websocket) and reserves `type` exclusively for the in-process `sdk` kind. Until now the import path and the `.mcp.json` loader copied Claude-shaped entries verbatim, so a Claude streamable-HTTP server — declared with `type: "http"` and a `url` — was stored with only a `url` and then connected as SSE instead of HTTP. This change normalizes Claude-shaped server definitions into Qwen Code's field-based shape at every ingestion point, so an imported or project-declared server connects over the transport its author intended. The leftover Claude `type` discriminator is now stripped from every normalized server, while a genuine `sdk` type is always preserved so in-process server detection is unaffected.

## Why it's needed

People migrating from Claude Code, or sharing a single `.mcp.json` across both tools, would silently get the wrong transport for HTTP servers: the connection was attempted as SSE and failed with no obvious cause. Extension installs already normalized these definitions correctly, which made the inconsistency between entry points especially confusing. This aligns all three ingestion routes so they behave identically and honor the server author's declared intent.

## Reviewer Test Plan

### How to verify

- Create a `.mcp.json` in a project root with a server declared the Claude way, for example `{ "mcpServers": { "demo": { "type": "http", "url": "https://example.com/mcp" } } }`, and confirm Qwen Code treats it as a streamable-HTTP server — the effective configuration exposes `httpUrl` (not `url`) — instead of attempting an SSE connection.
- Run `/import-config` against a Claude configuration that defines `type: "http"`, `type: "sse"`, and `type: "stdio"` servers, and confirm the imported entries end up using `httpUrl`, `url`, and `command` respectively, with the Claude `type` field removed and a real `sdk` server left untouched.
- Automated coverage: the affected unit suites all pass (transport mapping, the `sdk` preservation invariant, non-transport field preservation, and `.mcp.json` normalization).

```
✓ |@qwen-code/qwen-code-core| src/extension/claude-converter.test.ts (50 tests)
✓ |@qwen-code/qwen-code|      src/config/claudeMcpImport.test.ts (14 tests)
✓ |@qwen-code/qwen-code|      src/config/mcpJson.test.ts (11 tests)
Test Files  3 passed (3)
     Tests  75 passed (75)
```

### Evidence (Before & After)

N/A — this is not a user-visible or TUI change; it affects MCP configuration ingestion only. Verified through the unit output above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested locally · ⚠️ relying on CI · N/A -->

### Environment (optional)

N/A — unit tests only.

## Risk & Scope

- Main risk or tradeoff: normalization now also strips a stray Claude `type` value (e.g. `type: "stdio"`) from servers that already carry a connection field; `type: "sdk"` is explicitly preserved, so SDK detection is unchanged. Behavior for well-formed configurations is otherwise identical to before.
- Not validated / out of scope: making the transport selector itself honor a Claude `type` field for configs hand-written directly into Qwen settings (settings are field-based by design); the typed SDK control-protocol entry point, which accepts a Qwen-native shape by contract. A contradictory, hand-corrupted entry that sets both a `command` and a `url` keeps its pre-existing behavior.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

Qwen Code 可以从多个入口摄取为 Claude 编写的 MCP server 定义——`/import-config` 迁移、已安装的扩展与插件、以及项目根目录的 `.mcp.json` 文件。Claude 用 `type` 字段（`http`、`sse`、`stdio`）来标识 server 的传输方式，而 Qwen Code 是根据"哪个连接字段被设置"来推断传输方式（`httpUrl` 表示 streamable HTTP，`url` 表示 SSE，`command` 表示 stdio，`tcp` 表示 websocket），并且把 `type` 字段专门保留给进程内的 `sdk` 类型。此前，import 路径和 `.mcp.json` 加载器都是原样拷贝 Claude 形态的条目，因此一个 Claude 的 streamable-HTTP server（用 `type: "http"` 加 `url` 声明）会被存成只有 `url`，进而被当作 SSE 连接，而不是 HTTP。本次改动在所有摄取入口都把 Claude 形态的 server 定义归一化为 Qwen Code 基于字段的形态，使得导入或在项目中声明的 server 按作者期望的传输方式连接。归一化后会从每个 server 上移除遗留的 Claude `type` 判别字段，同时始终保留真正的 `sdk` 类型，从而不影响进程内 server 的识别。

## 为什么需要它

从 Claude Code 迁移过来、或在两个工具间共享同一份 `.mcp.json` 的用户，对 HTTP server 会悄悄得到错误的传输方式：连接以 SSE 发起并失败，且原因不明显。而扩展安装路径本来就已经正确归一化，这让各入口之间的不一致更令人困惑。本次改动让三条摄取路径行为一致，并尊重 server 作者声明的意图。

## 审查者验证计划

### 如何验证

- 在项目根目录创建一个用 Claude 写法声明的 `.mcp.json`，例如 `{ "mcpServers": { "demo": { "type": "http", "url": "https://example.com/mcp" } } }`，确认 Qwen Code 把它当作 streamable-HTTP server——其生效配置暴露的是 `httpUrl`（而非 `url`）——而不是发起 SSE 连接。
- 对一份同时定义了 `type: "http"`、`type: "sse"`、`type: "stdio"` 的 Claude 配置运行 `/import-config`，确认导入后的条目分别使用 `httpUrl`、`url`、`command`，Claude 的 `type` 字段被移除，且真正的 `sdk` server 保持不变。
- 自动化覆盖：相关单元测试全部通过（传输映射、`sdk` 保留不变量、非传输字段保留、以及 `.mcp.json` 归一化），共 75 个测试。

### 证据（前后对比）

N/A——这不是用户可见或 TUI 的改动，只影响 MCP 配置的摄取；通过上面的单元测试输出验证。

### 测试平台

macOS 本地已验证；Windows / Linux 依赖 CI。

### 环境（可选）

N/A——仅单元测试。

## 风险与范围

- 主要风险或取舍：归一化现在也会从已带连接字段的 server 上剥离遗留的 Claude `type` 值（例如 `type: "stdio"`）；`type: "sdk"` 会被显式保留，因此 SDK 识别不受影响。对格式正确的配置，行为与之前完全一致。
- 未验证 / 不在范围内：让传输选择器本身去识别直接手写进 Qwen 设置里的 Claude `type` 字段（设置按设计就是基于字段的）；以及类型化的 SDK 控制协议入口（按契约接收 Qwen 原生形态）。一个同时设置了 `command` 和 `url` 的矛盾、被手工损坏的条目，保持其原有行为。
- 破坏性改动 / 迁移说明：无。

## 关联 Issue

N/A

</details>
