### PR TITLE
ci: move macOS/Windows tests and CodeQL off the per-PR path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,12 @@ jobs:
   test_platforms:
     name: 'Test (${{ matrix.os }}, Node ${{ matrix.node-version }})'
     needs: 'classify_pr'
-    if: '${{ !cancelled() }}'
+    # macOS/Windows are the slowest, costliest runners and platform-specific
+    # regressions are rare per push, so rerunning them on every review iteration
+    # is mostly wasted. Skip on PR pushes; they still run on push to `main` (and
+    # in the merge queue, once enabled), catching platform breakage before it
+    # ships without sitting on every PR's critical path.
+    if: "${{ !cancelled() && github.event_name != 'pull_request' }}"
     runs-on: '${{ fromJSON(matrix.runner) }}'
     permissions:
       contents: 'read'
@@ -374,7 +379,10 @@ jobs:
   codeql:
     name: 'CodeQL'
     needs: 'classify_pr'
-    if: "${{ !cancelled() && needs.classify_pr.outputs.skip_ci != 'true' }}"
+    # Security findings rarely change push-to-push, so a slow scan on every PR
+    # push is poor value. Skip on PR pushes; CodeQL still runs on push to `main`
+    # (and in the merge queue, once enabled) as the pre-/post-merge backstop.
+    if: "${{ !cancelled() && needs.classify_pr.outputs.skip_ci != 'true' && github.event_name != 'pull_request' }}"
     runs-on: 'ubuntu-latest'
     # Analysis normally finishes in ~7-9 min (22 min worst case observed). Without
     # an explicit cap, a hosted runner that drops its heartbeat mid-analysis leaves


### PR DESCRIPTION
## What this PR does

Gates the `test_platforms` (macOS + Windows) and `codeql` jobs off the `pull_request` event. They no longer run on every PR push; they keep running on push to `main` (and in the merge queue, once it is enabled). No GitHub settings change here — this is the workflow half only.

## Why it's needed

Both jobs reran on every PR push but rarely caught push-to-push regressions. macOS/Windows are the slowest and costliest runners, and platform breakage is rare per review iteration — a PR pushed ten times during review paid for ten macOS+Windows runs. CodeQL findings seldom change between pushes, so a slow scan on each one is poor value.

Moving them off the per-PR path trims the critical path a reviewer waits on (PR pushes now run the ubuntu `Test` job, coverage, and the no-AK smoke) and eases hosted-runner pressure. The checks still gate before code ships: push to `main` runs them post-merge today, and once the merge queue is enabled they run pre-merge against the merge group.

This is the per-PR-speed half of moving to a merge queue. Enabling the queue and marking the `merge_group` jobs (e.g. `Integration Tests (CLI, No Sandbox)`) as required are separate, settings-only steps and are intentionally not in this PR.

## Reviewer Test Plan

### How to verify

- `actionlint .github/workflows/ci.yml` passes.
- The only required status check, `Test (ubuntu-latest, Node 22.x)`, is untouched and still runs on `pull_request` — so no PR gets stuck waiting on a check that no longer runs. (Branch protection currently requires only that one check.)
- After merge: a PR push shows `Test (...)`, coverage, and CodeQL/macOS/Windows **not** running; a push to `main` shows macOS, Windows, and CodeQL running.

### Evidence (Before & After)

N/A — CI-config only, no user-visible change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A  |
| 🪟 Windows |  N/A  |
|  🐧 Linux  |  ⚠️ actionlint only; runtime effect observable on CI runners post-merge  |

### Environment (optional)

N/A — workflow change, no local runtime.

## Risk & Scope

- Main risk / tradeoff: until the merge queue is enabled, macOS/Windows/CodeQL regressions are caught post-merge on `main` rather than pre-merge. Worst case is a brief red `main` + revert; enabling the merge queue restores pre-merge gating.
- Not validated / out of scope: enabling the merge queue and required-check changes (settings only); the post-merge runtime effect is observable only on CI after merge.
- Breaking changes: none.

## Linked Issues

CI-throughput follow-up to the ECS runner routing (#5620) and the Linux CI reliability fixes (#5810). No issue to close.

<details>
<summary>中文说明</summary>

把 `test_platforms`(macOS + Windows)和 `codeql` 两个 job 从 `pull_request` 事件上摘掉:它们不再每次 PR push 都跑,改为在 push 到 `main` 时跑(以及 merge queue 启用后在合并队列里跑)。本 PR 只改 workflow,不动任何 GitHub 设置。

原因:这两个 job 每次 PR push 都重跑,但很少抓到逐 push 的回归。macOS/Windows 是最慢最贵的 runner,平台问题逐次迭代很罕见——一个评审期间 push 十次的 PR 就白跑十次 mac+win;CodeQL 的安全发现也很少在 push 之间变化。把它们移出 PR 关键路径,缩短评审等待、缓解托管 runner 压力,同时合并前仍有把关:push 到 `main` 会在合并后跑,merge queue 启用后会在合并前对 merge group 跑。

这是迁移到 merge queue 的「PR 提速」那一半。启用队列、把 `merge_group` 的 job(如 `Integration Tests (CLI, No Sandbox)`)设为 required 是纯设置改动,故意不放进本 PR。

唯一的 required check 是 `Test (ubuntu-latest, Node 22.x)`,本 PR 没动它,PR 上照常跑,所以不会有 PR 卡在「等一个不再跑的 required check」。
</details>
