### PR TITLE
feat(core): decouple /remember from auto-extract, stop writing to QWEN.md

### DIFF
--- a/packages/cli/src/services/BuiltinCommandLoader.test.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.test.ts
@@ -131,7 +131,7 @@ describe('BuiltinCommandLoader', () => {
       getFolderTrust: vi.fn().mockReturnValue(true),
       getUseModelRouter: () => false,
       getDisableAllHooks: vi.fn().mockReturnValue(false),
-      getManagedAutoMemoryEnabled: vi.fn().mockReturnValue(true),
+      isManagedMemoryAvailable: vi.fn().mockReturnValue(true),
       isLspEnabled: vi.fn().mockReturnValue(false),
       isWorkflowsEnabled: vi.fn().mockReturnValue(false),
     } as unknown as Config;

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -139,7 +139,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       initCommand,
       languageCommand,
       mcpCommand,
-      ...(this.config?.getManagedAutoMemoryEnabled()
+      ...(this.config?.isManagedMemoryAvailable()
         ? [dreamCommand, forgetCommand]
         : []),
       goalCommand,

--- a/packages/cli/src/ui/commands/rememberCommand.test.ts
+++ b/packages/cli/src/ui/commands/rememberCommand.test.ts
@@ -29,11 +29,11 @@ describe('rememberCommand', () => {
     });
   });
 
-  it('returns submit_prompt for managed auto-memory', () => {
+  it('routes to managed memory when available', () => {
     const context = createMockCommandContext({
       services: {
         config: {
-          getManagedAutoMemoryEnabled: vi.fn().mockReturnValue(true),
+          isManagedMemoryAvailable: vi.fn().mockReturnValue(true),
           getProjectRoot: vi.fn().mockReturnValue('/tmp/test-project'),
         },
       },
@@ -45,11 +45,11 @@ describe('rememberCommand', () => {
     });
   });
 
-  it('returns submit_prompt for non-managed memory (QWEN.md fallback)', () => {
+  it('falls back to QWEN.md in bare mode', () => {
     const context = createMockCommandContext({
       services: {
         config: {
-          getManagedAutoMemoryEnabled: vi.fn().mockReturnValue(false),
+          isManagedMemoryAvailable: vi.fn().mockReturnValue(false),
           getProjectRoot: vi.fn().mockReturnValue('/tmp/test-project'),
         },
       },

--- a/packages/cli/src/ui/commands/rememberCommand.test.ts
+++ b/packages/cli/src/ui/commands/rememberCommand.test.ts
@@ -43,6 +43,7 @@ describe('rememberCommand', () => {
       type: 'submit_prompt',
       content: expect.stringContaining('user prefers dark mode'),
     });
+    expect((result as { content: string }).content).toContain('memory system');
   });
 
   it('falls back to QWEN.md in bare mode', () => {
@@ -59,6 +60,7 @@ describe('rememberCommand', () => {
       type: 'submit_prompt',
       content: expect.stringContaining('some fact'),
     });
+    expect((result as { content: string }).content).toContain('QWEN.md');
   });
 
   it('declares acp in supportedModes', () => {

--- a/packages/cli/src/ui/commands/rememberCommand.ts
+++ b/packages/cli/src/ui/commands/rememberCommand.ts
@@ -43,15 +43,16 @@ export const rememberCommand: SlashCommand = {
       };
     }
 
-    const useManagedMemory = config?.getManagedAutoMemoryEnabled() ?? false;
+    const useManagedMemory = config?.isManagedMemoryAvailable() ?? false;
 
     if (useManagedMemory) {
-      // In managed auto-memory mode the save_memory tool is not registered.
-      // Submit a prompt so the main agent writes the per-entry file directly,
-      // choosing the appropriate type (user / feedback / project / reference)
-      // AND the appropriate scope (user-level for cross-project facts,
-      // project-level for this-project-only facts) based on the content,
-      // following the per-type `<scope>` guidance in buildManagedAutoMemoryPrompt.
+      // The save_memory tool was removed; submit a prompt so the main
+      // agent writes the per-entry file directly, choosing the
+      // appropriate type (user / feedback / project / reference) AND
+      // the appropriate scope (user-level for cross-project facts,
+      // project-level for this-project-only facts) based on the
+      // content, following the per-type `<scope>` guidance in
+      // buildManagedAutoMemoryPrompt.
       const projectDir = config
         ? getAutoMemoryRoot(config.getProjectRoot())
         : undefined;
@@ -66,9 +67,8 @@ export const rememberCommand: SlashCommand = {
       };
     }
 
-    // Managed auto-memory is disabled: ask the agent to save to QWEN.md
-    // using its native file tools. We do not call save_memory because that
-    // tool was removed.
+    // --bare mode: ask the agent to save to QWEN.md using its native
+    // file tools.
     return {
       type: 'submit_prompt',
       content: `Please save the following fact to memory (e.g. append to QWEN.md in the project root):\n\n${fact}`,

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -2347,6 +2347,27 @@ describe('Server Config (config.ts)', () => {
     expect(config.getUserMemory()).not.toContain('# auto memory');
   });
 
+  describe('isManagedMemoryAvailable', () => {
+    it('returns true when bareMode is false', () => {
+      const config = new Config({ ...baseParams, bareMode: false });
+      expect(config.isManagedMemoryAvailable()).toBe(true);
+    });
+
+    it('returns false when bareMode is true', () => {
+      const config = new Config({ ...baseParams, bareMode: true });
+      expect(config.isManagedMemoryAvailable()).toBe(false);
+    });
+
+    it('returns true even when enableManagedAutoMemory is false', () => {
+      const config = new Config({
+        ...baseParams,
+        enableManagedAutoMemory: false,
+        bareMode: false,
+      });
+      expect(config.isManagedMemoryAvailable()).toBe(true);
+    });
+  });
+
   it('refreshHierarchicalMemory should exclude implicit cwd from bare include-directories', async () => {
     const explicitDir = '/tmp/explicit';
     const config = new Config({

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1937,7 +1937,7 @@ describe('Server Config (config.ts)', () => {
   it('refreshHierarchicalMemory should not warn for small always-loaded context', async () => {
     const config = new Config({
       ...baseParams,
-      enableManagedAutoMemory: false,
+      bareMode: true,
       generationConfig: { contextWindowSize: 1000 },
     });
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2172,7 +2172,7 @@ export class Config {
           ),
         },
       );
-    if (this.getManagedAutoMemoryEnabled()) {
+    if (this.isManagedMemoryAvailable()) {
       // User-level read is best-effort — an EACCES on
       // `~/.qwen/memories/MEMORY.md` must not strip the whole managed-memory
       // section out of the system prompt. Project-level read still bubbles
@@ -4263,6 +4263,10 @@ export class Config {
 
   getManagedAutoMemoryEnabled(): boolean {
     return this.enableManagedAutoMemory && !this.getBareMode();
+  }
+
+  isManagedMemoryAvailable(): boolean {
+    return !this.getBareMode();
   }
 
   getManagedAutoDreamEnabled(): boolean {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -511,6 +511,7 @@ describe('Gemini Client (client.ts)', () => {
       getResumedSessionData: vi.fn().mockReturnValue(undefined),
       getArenaAgentClient: vi.fn().mockReturnValue(null),
       getManagedAutoMemoryEnabled: vi.fn().mockReturnValue(true),
+      isManagedMemoryAvailable: vi.fn().mockReturnValue(true),
       getMemoryManager: vi.fn().mockReturnValue(mockMemoryManager),
       getAutoSkillEnabled: vi.fn().mockReturnValue(false),
       getAutoSkillConfirmEnabled: vi.fn().mockReturnValue(true),
@@ -4500,10 +4501,8 @@ hello
       expect(client['pendingMemoryPrefetch']).not.toBeUndefined();
     });
 
-    it('should proceed without auto-memory when managed auto-memory is disabled', async () => {
-      // When getManagedAutoMemoryEnabled returns false, no recall is initiated
-      // and sendMessageStream completes without memory content
-      vi.mocked(mockConfig.getManagedAutoMemoryEnabled).mockReturnValue(false);
+    it('should skip recall when managed memory is unavailable', async () => {
+      vi.mocked(mockConfig.isManagedMemoryAvailable).mockReturnValue(false);
 
       const mockStream = (async function* () {
         yield { type: 'content', value: 'Hello' };
@@ -4538,8 +4537,7 @@ hello
         expect.any(AbortSignal),
       );
 
-      // Restore default
-      vi.mocked(mockConfig.getManagedAutoMemoryEnabled).mockReturnValue(true);
+      vi.mocked(mockConfig.isManagedMemoryAvailable).mockReturnValue(true);
     });
 
     it('should proceed normally when recall rejects', async () => {
@@ -8289,6 +8287,7 @@ function makeMockConfigForShutdown(
     getSessionId: vi.fn().mockReturnValue('session-1'),
     getMemoryManager: vi.fn().mockReturnValue(mgr),
     getManagedAutoMemoryEnabled: vi.fn().mockReturnValue(true),
+    getBareMode: vi.fn().mockReturnValue(false),
     getManagedAutoDreamEnabled: vi.fn().mockReturnValue(true),
     getAutoSkillEnabled: vi.fn().mockReturnValue(false),
     getModel: vi.fn().mockReturnValue('test-model'),

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -1773,7 +1773,7 @@ export class GeminiClient {
         messageType === SendMessageType.UserQuery ||
         messageType === SendMessageType.Cron
       ) {
-        if (this.config.getManagedAutoMemoryEnabled()) {
+        if (this.config.isManagedMemoryAvailable()) {
           // A previous recall may still be pending (slow side-query, new user
           // turn arrived before it settled). Abort it before installing the
           // new handle so the orphan doesn't keep running indefinitely.


### PR DESCRIPTION
## What this PR does

Narrows the scope of `enableManagedAutoMemory` from a master switch that gates six behaviors to a control that only governs background auto-extraction. Introduces `isManagedMemoryAvailable()` (`!getBareMode()`) as the gate for the other four behaviors: `/remember` routing, `/dream` and `/forget` command registration, managed memory prompt injection, and recall prefetch. These now remain available even when auto-extraction is off. Only `--bare` mode disables them.

## Why it's needed

### Problem: `/remember` pollutes QWEN.md

When `enableManagedAutoMemory` is `false`, `/remember` falls back to asking the LLM to append to QWEN.md — the user's manually maintained instruction file. QWEN.md should be fully user-controlled (like Codex's AGENTS.md and Claude Code's CLAUDE.md). No automated or semi-automated flow should write to it.

### Problem: one switch controls six behaviors

`enableManagedAutoMemory` currently acts as a master switch gating all of:

1. Background auto-extraction (the only thing it should control)
2. `/remember` routing (falls back to QWEN.md when off)
3. `/dream` and `/forget` command registration (hidden when off)
4. Managed memory prompt injection (memories invisible when off)
5. Recall prefetch (memory retrieval disabled when off)

This forces an all-or-nothing choice: users who want to reduce cost/noise by disabling auto-extraction also lose the ability to manually manage memories.

### Competitive analysis: Codex's orthogonal controls

Codex (OpenAI) has three independent switches that demonstrate the right granularity:

| Control | Codex | Qwen Code (before) | Qwen Code (after) |
|---------|-------|--------------------|--------------------|
| Auto-extract on/off | `generate_memories` (write pipeline only) | `enableManagedAutoMemory` (**master switch**) | `enableManagedAutoMemory` (**auto-extract only**) |
| Memory reading on/off | `use_memories` (independent) | Tied to master switch | **Always on** (unless `--bare`) |
| Memory tools on/off | `dedicated_tools` (independent) | Tied to master switch | **Always on** (unless `--bare`) |

In Codex, setting `generate_memories: false` disables background extraction but the `ad_hoc_note` tool remains available — users can still manually save memories. This PR brings the same decoupling to Qwen Code.

### Design decision: follow existing memory flow

An earlier design considered creating a separate `user-notes/` directory (mirroring Codex's `extensions/ad_hoc/notes/`). This was abandoned because Qwen Code's existing flow — LLM chooses among 4 memory types (user/feedback/project/reference) and writes topic files — already works well. The only change needed is the gate condition, not the write path.

## Reviewer Test Plan

### How to verify

1. Set `memory.enableManagedAutoMemory: false` in settings
2. Run `/remember test fact` → should route to managed memory (LLM writes topic files), NOT fall back to QWEN.md
3. Run `/dream` → should be available (was previously hidden)
4. Run `/forget` → should be available (was previously hidden)
5. Start a new session → managed memory content should appear in system prompt
6. With `--bare` flag → `/remember` falls back to QWEN.md, `/dream` `/forget` hidden

### Evidence (Before & After)

N/A — behavioral change verified via unit tests. The gate condition change is mechanical.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests via `npx vitest run`.

## Risk & Scope

- Main risk or tradeoff: Users who explicitly set `enableManagedAutoMemory: false` expecting full managed-memory opt-out will now get read-side features (prompt injection, recall, commands). This is intentional — the setting narrows from "master switch" to "auto-extract toggle." No migration needed since the change is strictly additive.
- Not validated / out of scope: daemon API (`POST /workspace/memory`) and ACP `workspace/memory/write` still write to QWEN.md — these are external SDK endpoints, separate from the `/remember` path.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

将 `enableManagedAutoMemory` 的语义从控制六种行为的主开关缩窄为仅控制后台自动提取。新增 `isManagedMemoryAvailable()`（`!getBareMode()`）作为其余四种行为的门控。

## 为什么需要

### 问题一：`/remember` 污染 QWEN.md

当 `enableManagedAutoMemory` 为 `false` 时，`/remember` 回退到让 LLM 写入 QWEN.md — 用户手动维护的指令文件。QWEN.md 应该完全由用户控制（如同 Codex 的 AGENTS.md、Claude Code 的 CLAUDE.md），任何自动化流程都不应写入它。

### 问题二：一个开关控制六种行为

`enableManagedAutoMemory` 当前是一个主开关，同时控制：后台自动提取、`/remember` 路由、`/dream` `/forget` 注册、managed memory prompt 注入、recall 预取。这迫使用户做全有或全无的选择。

### 竞品分析：Codex 的正交控制

Codex 有三个独立开关（`generate_memories`、`use_memories`、`dedicated_tools`）。关闭 `generate_memories` 只禁用后台提取，`ad_hoc_note` 工具仍可用，用户仍可手动记忆。本 PR 将同样的解耦引入 Qwen Code。

### 设计决策：复用现有记忆流程

早期方案考虑过新建 `user-notes/` 目录（模仿 Codex 的 `extensions/ad_hoc/notes/`），但放弃了。Qwen Code 现有的 LLM 自选 type + scope 写入 topic 文件的流程已经足够好，唯一需要改的是门控条件。

## 风险和范围

- 主要风险：设置 `enableManagedAutoMemory: false` 的用户现在会获得读侧功能。这是有意为之。
- 未验证：daemon API 和 ACP 仍写入 QWEN.md（外部 SDK 端点，与 `/remember` 路径无关）。
- 破坏性变更：无。

</details>