### PR TITLE
fix(core): preserve reasoning_content when merging assistant turns

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -4389,6 +4389,41 @@ describe('OpenAIContentConverter', () => {
   });
 
   describe('mergeConsecutiveAssistantMessages', () => {
+    it('should preserve reasoning_content from every merged assistant turn', () => {
+      const request: GenerateContentParameters = {
+        model: 'models/test',
+        contents: [
+          {
+            role: 'model',
+            parts: [
+              { text: 'First reasoning.', thought: true },
+              { text: 'First answer.' },
+            ],
+          },
+          {
+            role: 'model',
+            parts: [
+              { text: 'Second reasoning.', thought: true },
+              { text: 'Second answer.' },
+            ],
+          },
+        ],
+      };
+
+      const messages = converter.convertGeminiRequestToOpenAI(
+        request,
+        requestContext,
+      );
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0].role).toBe('assistant');
+      expect(messages[0].content).toBe('First answer.Second answer.');
+      // The reasoning of the merged-away turn must not be silently dropped.
+      expect(
+        (messages[0] as { reasoning_content?: string }).reasoning_content,
+      ).toBe('First reasoning.Second reasoning.');
+    });
+
     it('should merge two consecutive assistant messages with string content', () => {
       const request: GenerateContentParameters = {
         model: 'models/test',

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -1718,6 +1718,24 @@ function mergeConsecutiveAssistantMessages(
           ).tool_calls = combinedToolCalls;
         }
 
+        // Combine reasoning_content the same way content is combined. Otherwise
+        // the merged-away turn's reasoning is silently dropped, while
+        // cleanOrphanedToolCalls (which also merges assistant turns) keeps it.
+        const lastReasoning = (
+          lastMessage as ExtendedChatCompletionAssistantMessageParam
+        ).reasoning_content;
+        const currentReasoning = (
+          message as ExtendedChatCompletionAssistantMessageParam
+        ).reasoning_content;
+        const combinedReasoning = [lastReasoning, currentReasoning]
+          .filter(Boolean)
+          .join('');
+        if (combinedReasoning) {
+          (
+            lastMessage as ExtendedChatCompletionAssistantMessageParam
+          ).reasoning_content = combinedReasoning;
+        }
+
         continue; // Skip adding the current message since it's been merged
       }
     }


### PR DESCRIPTION
## What this PR does

When two assistant turns end up next to each other, `mergeConsecutiveAssistantMessages` folds them into one. It already concatenates their text content and joins their tool calls, but it keeps only the reasoning of the first turn and throws away the reasoning of the one it merges in. This change concatenates `reasoning_content` from both turns the same way the visible content is concatenated, so nothing is lost when the turns collapse.

## Why it's needed

`reasoning_content` is a real field we put on the request: when a model turn carries thoughts but no visible text we deliberately set `content: ""` (not `null`) so OpenAI-compatible providers like Ollama don't reject the request with HTTP 400 while `reasoning_content` is present. The sibling helper `cleanOrphanedToolCalls` is careful to carry `reasoning_content` over when it rewrites assistant turns, and the merge step runs right after it (and again after orphan cleanup can make two assistant turns adjacent). So the merge path is the one place that silently drops chain-of-thought that the rest of the pipeline goes out of its way to preserve. After this change the two paths agree.

## Reviewer Test Plan

### How to verify

Added a unit test under the existing `mergeConsecutiveAssistantMessages` describe block: two consecutive `model` turns, each with a `thought: true` part plus visible text. Expected after merge — `content` is `"First answer.Second answer."` and `reasoning_content` is `"First reasoning.Second reasoning."`. On `main` the test fails with the second turn's reasoning missing (`"First reasoning."`); with the fix it passes. The whole `converter.test.ts` file (135 tests) stays green.

```
cd packages/core
npx vitest run src/core/openaiContentGenerator/converter.test.ts
```

### Evidence (Before & After)

N/A — not a user-visible / TUI change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only (vitest), no runtime/sandbox needed.

## Risk & Scope

- Main risk or tradeoff: very low. The new branch only runs when two assistant messages merge and at least one carries `reasoning_content`; it sets the field only when the combined string is non-empty, so messages without reasoning are byte-for-byte unchanged.
- Not validated / out of scope: no change to how `reasoning_content` is produced or consumed elsewhere — purely the merge step.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

当两个 assistant 回合相邻时，`mergeConsecutiveAssistantMessages` 会把它们合成一个。它已经会拼接文本 content、合并 tool calls，但只保留了第一个回合的 reasoning，把被合并进来的那个回合的 reasoning 丢掉了。这里把两个回合的 `reasoning_content` 按照合并 content 同样的方式拼接起来，合并时不再丢东西。

## 为什么需要

`reasoning_content` 是我们真正会放进请求里的字段：当一个 model 回合只有思考、没有可见文本时，我们故意把 `content` 设成 `""` 而不是 `null`，这样 Ollama 这类 OpenAI 兼容 provider 在带着 `reasoning_content` 时不会返回 HTTP 400。兄弟函数 `cleanOrphanedToolCalls` 在改写 assistant 回合时会特意保留 `reasoning_content`，而合并这一步紧跟在它后面跑（orphan 清理可能让两个 assistant 回合变相邻，之后还会再跑一次合并）。所以合并这一步是整条流水线里唯一会悄悄丢掉思维链的地方。改完之后两条路径就一致了。

## 如何验证

在已有的 `mergeConsecutiveAssistantMessages` describe 块里加了一个单测：两个连续的 `model` 回合，每个都带一个 `thought: true` 部分加可见文本。合并后期望 `content` 为 `"First answer.Second answer."`、`reasoning_content` 为 `"First reasoning.Second reasoning."`。在 `main` 上这个测试会失败，第二个回合的 reasoning 丢失（只剩 `"First reasoning."`）；带上修复后通过。整个 `converter.test.ts`（135 个测试）保持全绿。

## 风险

极低。新分支只在两个 assistant 消息合并、且至少一个带 `reasoning_content` 时才执行，并且只在拼出的字符串非空时才写该字段，所以没有 reasoning 的消息一字节都不变。无破坏性改动。

</details>
