### PR TITLE
fix(web-shell): defer transcript-appending local commands while a turn streams

### DIFF
--- a/packages/web-shell/client/App.module.css
+++ b/packages/web-shell/client/App.module.css
@@ -307,6 +307,15 @@
   color: var(--text-primary);
 }
 
+.queuedPromptAction:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.queuedPromptAction:disabled:hover {
+  color: var(--text-secondary);
+}
+
 .queuedHint {
   font-style: italic;
 }

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -94,6 +94,7 @@ import {
 } from './utils/copyCommand';
 import type { SkillInfo } from './completions/slashCompletion';
 import { collectSystemInfo } from './utils/systemInfo';
+import { appendOrDeferLocalUserMessage } from './utils/localCommandQueue';
 import {
   TasksStatusMessage,
   type SerializedTasksMessage,
@@ -1538,6 +1539,24 @@ export function App({
     [],
   );
 
+  // Echo a local command into the transcript, or defer it to the queue when a
+  // turn is streaming so the injected user row can't split the active turn (see
+  // appendOrDeferLocalUserMessage). Returns true when deferred — callers must
+  // then stop and not run the command's inline side effects.
+  const echoOrDeferLocalCommand = useCallback(
+    (text: string, images?: PromptImage[]): boolean =>
+      appendOrDeferLocalUserMessage(
+        streamingStateRef.current !== 'idle',
+        text,
+        images,
+        {
+          append: (value: string) => store.appendLocalUserMessage(value),
+          enqueue: enqueuePrompt,
+        },
+      ),
+    [enqueuePrompt, store],
+  );
+
   // When the turn settles, abort any still-in-flight explicit insert so it can't
   // arrive during the next turn (see midTurnEnqueueAbortRef). If aborted, the
   // message remains in queuedPrompts.
@@ -2011,7 +2030,9 @@ export function App({
   // is revealed even when the click comes while scrolled up.
   const showContextUsage = useCallback(
     (commandText: string, detail: boolean) => {
-      store.appendLocalUserMessage(commandText);
+      // Self-guard so every entry point (keyboard, status-bar button, in-chat
+      // "context detail" click) defers mid-turn instead of splitting the turn.
+      if (echoOrDeferLocalCommand(commandText)) return;
       sessionActions
         .getContextUsage({ detail })
         .then((result) => {
@@ -2027,7 +2048,13 @@ export function App({
           reportError(error, 'Failed to load context usage');
         });
     },
-    [store, sessionActions, reportError, resumeChatBottomFollow],
+    [
+      echoOrDeferLocalCommand,
+      store,
+      sessionActions,
+      reportError,
+      resumeChatBottomFollow,
+    ],
   );
 
   // Stable reference: this travels through the memoized MessageList →
@@ -2392,7 +2419,7 @@ export function App({
               return true;
             }
             if (modelArg === '--voice') {
-              store.appendLocalUserMessage(text);
+              if (echoOrDeferLocalCommand(text, images)) return true;
               workspaceActions
                 .loadProviders()
                 .then((status) => {
@@ -2492,7 +2519,7 @@ export function App({
                 reportError(error, 'Failed to send /skills command'),
               );
             } else {
-              store.appendLocalUserMessage(text);
+              if (echoOrDeferLocalCommand(text, images)) return true;
               workspaceActions
                 .loadSkillsStatus()
                 .then((status) => {
@@ -2529,7 +2556,7 @@ export function App({
             if (toolsArg === 'desc' || toolsArg === 'descriptions') {
               setShowToolsDialog(true);
             } else {
-              store.appendLocalUserMessage(text);
+              if (echoOrDeferLocalCommand(text, images)) return true;
               workspaceActions
                 .loadToolsStatus()
                 .then((status) => {
@@ -2618,6 +2645,10 @@ export function App({
               return true;
             }
             if (subCommand === 'install') {
+              // Install echoes into the transcript (and its error/usage replies
+              // do too); defer the whole command mid-turn so it can't split the
+              // active turn. It re-dispatches here once the turn settles.
+              if (promptBlocked) return enqueuePrompt(text, images);
               const tokens = args.slice('install'.length).trim().split(/\s+/);
               let source = '';
               let ref: string | undefined;
@@ -2676,16 +2707,6 @@ export function App({
                 ]);
                 return true;
               }
-              if (promptBlocked) {
-                store.appendLocalUserMessage(text);
-                store.dispatch([
-                  {
-                    type: 'error',
-                    text: t('extensions.install.waitForTurn'),
-                  },
-                ]);
-                return true;
-              }
               const clientId = connectionRef.current.clientId;
               if (!clientId) {
                 store.appendLocalUserMessage(text);
@@ -2724,7 +2745,7 @@ export function App({
                 });
               return true;
             }
-            store.appendLocalUserMessage(text);
+            if (echoOrDeferLocalCommand(text, images)) return true;
             store.dispatch([
               {
                 type: 'error',
@@ -2794,7 +2815,7 @@ export function App({
             let statsView: StatsView = 'overview';
             if (statsArg === 'model') statsView = 'model';
             else if (statsArg === 'tools') statsView = 'tools';
-            store.appendLocalUserMessage(text);
+            if (echoOrDeferLocalCommand(text, images)) return true;
             sessionActions
               .getStats()
               .then((result) => {
@@ -2810,7 +2831,7 @@ export function App({
             return true;
           }
           if (cmd === 'status' || cmd === 'about') {
-            store.appendLocalUserMessage(text);
+            if (echoOrDeferLocalCommand(text, images)) return true;
             Promise.all([
               workspaceActions.loadPreflight().catch(() => null),
               workspaceActions.loadProviders().catch(() => null),
@@ -2876,7 +2897,7 @@ export function App({
           }
           if (cmd === 'bug') {
             const bugTitle = text.slice(match[0].length).trim();
-            store.appendLocalUserMessage(text);
+            if (echoOrDeferLocalCommand(text, images)) return true;
             Promise.all([
               workspaceActions.loadPreflight().catch(() => null),
               workspaceActions.loadEnv().catch(() => null),
@@ -2954,6 +2975,7 @@ export function App({
       sessionActions,
       store,
       enqueuePrompt,
+      echoOrDeferLocalCommand,
       branchCurrentSession,
       createNewSession,
       handleBusyGoalClear,

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -94,7 +94,10 @@ import {
 } from './utils/copyCommand';
 import type { SkillInfo } from './completions/slashCompletion';
 import { collectSystemInfo } from './utils/systemInfo';
-import { appendOrDeferLocalUserMessage } from './utils/localCommandQueue';
+import {
+  appendOrDeferLocalUserMessage,
+  isCommandPrompt,
+} from './utils/localCommandQueue';
 import {
   TasksStatusMessage,
   type SerializedTasksMessage,
@@ -758,6 +761,10 @@ function QueuedPromptDisplay({
             ? `${normalizedPreview.slice(0, MAX_QUEUED_PROMPT_PREVIEW_CHARS)}...`
             : normalizedPreview;
         const imageCount = prompt.images?.length ?? 0;
+        // A command (/… or !…) can't be inserted into the running turn — insert
+        // injects raw text the model would see literally, never running the
+        // command. Show the action disabled so it stays visible but inert.
+        const isCommand = isCommandPrompt(prompt.text);
         return (
           <div key={prompt.id} className={styles.queuedPrompt}>
             <span className={styles.queuedPromptText}>
@@ -788,6 +795,10 @@ function QueuedPromptDisplay({
                   type="button"
                   className={styles.queuedPromptAction}
                   onClick={() => onInsert(prompt.id)}
+                  disabled={isCommand}
+                  title={
+                    isCommand ? t('queue.insertCommandDisabled') : undefined
+                  }
                 >
                   <svg viewBox="0 0 16 16" aria-hidden="true">
                     <path
@@ -1602,6 +1613,9 @@ export function App({
     async (id: number) => {
       const prompt = queuedPromptsRef.current.find((item) => item.id === id);
       if (!prompt || (prompt.images?.length ?? 0) > 0) return;
+      // Commands can't be inserted into the running turn (the model would see
+      // the raw text and never run them); they re-dispatch on drain instead.
+      if (isCommandPrompt(prompt.text)) return;
       let abort = midTurnEnqueueAbortRef.current;
       if (!abort) {
         abort = new AbortController();

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -359,6 +359,8 @@ const EN: Messages = {
   'queue.delete': 'Delete',
   'queue.edit': 'Edit',
   'queue.insert': 'Insert',
+  'queue.insertCommandDisabled':
+    "Commands can't be inserted into the running turn; they run after it finishes.",
   'queue.insertFailed': 'Failed to insert queued message',
   'queue.footer':
     'Press ↑ to edit the latest queued message · Esc to clear queue',
@@ -1450,6 +1452,7 @@ const ZH: Messages = {
   'queue.delete': '删除',
   'queue.edit': '编辑',
   'queue.insert': '插入',
+  'queue.insertCommandDisabled': '命令无法插入当前回合，会在回合结束后执行。',
   'queue.insertFailed': '插入排队消息失败',
   'queue.footer': '按 ↑ 编辑最后一条排队消息 · Esc 清空队列',
   'queue.imageCount': (v) => `（+${v?.count ?? 0} 张图片）`,

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -599,8 +599,6 @@ const EN: Messages = {
   'extensions.install.usage': 'Usage: /extensions manage|install <source>',
   'extensions.install.waitForSession':
     'Wait for the session to connect before installing an extension.',
-  'extensions.install.waitForTurn':
-    'Wait for the current turn to finish before installing an extension.',
   'local.tools': 'List available tools. Usage: /tools [desc]',
   'loadWarning.commands':
     'Failed to load command list; slash commands may be incomplete.',
@@ -1679,7 +1677,6 @@ const ZH: Messages = {
   'extensions.install.unknownOption': (v) => `未知选项 ${v?.option ?? ''}`,
   'extensions.install.usage': '用法: /extensions manage|install <source>',
   'extensions.install.waitForSession': '等待会话连接后再安装扩展。',
-  'extensions.install.waitForTurn': '等待当前回合结束后再安装扩展。',
   'local.tools': '列出可用工具。用法: /tools [desc]',
   'loadWarning.commands': '命令列表加载失败，斜杠命令可能不完整。',
   'loadWarning.context': '会话上下文加载失败，当前模式可能不准确。',

--- a/packages/web-shell/client/utils/localCommandQueue.test.ts
+++ b/packages/web-shell/client/utils/localCommandQueue.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { appendOrDeferLocalUserMessage } from './localCommandQueue';
+import {
+  appendOrDeferLocalUserMessage,
+  isCommandPrompt,
+} from './localCommandQueue';
 
 describe('appendOrDeferLocalUserMessage', () => {
   it('appends and returns false when no turn is streaming', () => {
@@ -48,5 +51,20 @@ describe('appendOrDeferLocalUserMessage', () => {
     appendOrDeferLocalUserMessage(true, '/stats', images, { append, enqueue });
 
     expect(enqueue).toHaveBeenCalledExactlyOnceWith('/stats', images);
+  });
+});
+
+describe('isCommandPrompt', () => {
+  it('treats slash and shell prefixes as commands', () => {
+    expect(isCommandPrompt('/context detail')).toBe(true);
+    expect(isCommandPrompt('/stats')).toBe(true);
+    expect(isCommandPrompt('!ls -la')).toBe(true);
+    expect(isCommandPrompt('  /context')).toBe(true); // leading whitespace
+  });
+
+  it('treats prose as not a command', () => {
+    expect(isCommandPrompt('summarize the project structure')).toBe(false);
+    expect(isCommandPrompt('what does this do?')).toBe(false);
+    expect(isCommandPrompt('')).toBe(false);
   });
 });

--- a/packages/web-shell/client/utils/localCommandQueue.test.ts
+++ b/packages/web-shell/client/utils/localCommandQueue.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import { appendOrDeferLocalUserMessage } from './localCommandQueue';
+
+describe('appendOrDeferLocalUserMessage', () => {
+  it('appends and returns false when no turn is streaming', () => {
+    const append = vi.fn();
+    const enqueue = vi.fn();
+
+    const deferred = appendOrDeferLocalUserMessage(
+      false,
+      '/context',
+      undefined,
+      {
+        append,
+        enqueue,
+      },
+    );
+
+    expect(deferred).toBe(false);
+    expect(append).toHaveBeenCalledExactlyOnceWith('/context');
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('defers to the queue and returns true while a turn is streaming', () => {
+    const append = vi.fn();
+    const enqueue = vi.fn();
+
+    const deferred = appendOrDeferLocalUserMessage(
+      true,
+      '/context',
+      undefined,
+      {
+        append,
+        enqueue,
+      },
+    );
+
+    expect(deferred).toBe(true);
+    expect(enqueue).toHaveBeenCalledExactlyOnceWith('/context', undefined);
+    expect(append).not.toHaveBeenCalled();
+  });
+
+  it('forwards images to the queue when deferring', () => {
+    const append = vi.fn();
+    const enqueue = vi.fn();
+    const images = [{ data: 'base64xx', media_type: 'image/png' }];
+
+    appendOrDeferLocalUserMessage(true, '/stats', images, { append, enqueue });
+
+    expect(enqueue).toHaveBeenCalledExactlyOnceWith('/stats', images);
+  });
+});

--- a/packages/web-shell/client/utils/localCommandQueue.ts
+++ b/packages/web-shell/client/utils/localCommandQueue.ts
@@ -1,0 +1,50 @@
+import type { PromptImage } from '../adapters/promptTypes';
+
+/**
+ * Single choke point for echoing a local slash command into the transcript.
+ *
+ * Some local commands "echo": they append a local user message
+ * (`store.appendLocalUserMessage`) and render their result inline. If one runs
+ * while a turn is streaming, the injected user row acts as a turn boundary in
+ * `applyTurnCollapse` (a turn spans one user message up to the next) and splits
+ * the active turn into two — its tool/thinking/token counters are then computed
+ * per fragment and come out wrong.
+ *
+ * Routing every echo through this helper means a command can never append to the
+ * transcript mid-turn: while a turn is in flight it is deferred to the prompt
+ * queue instead, which re-dispatches it through `handleSubmit` once the turn
+ * settles so it runs as its own clean turn. This covers every entry point —
+ * keyboard submit and UI affordances (e.g. the status-bar context button) — as
+ * long as they funnel through here rather than calling `append` directly.
+ *
+ * The only call sites that should bypass this and append mid-stream are the
+ * deliberate "busy acknowledgement" paths (e.g. clearing a goal while a turn
+ * runs), which opt in by calling `append` directly.
+ */
+export interface LocalEchoSink {
+  /** Append the command as a local user message (renders inline immediately). */
+  append: (text: string) => void;
+  /** Defer the command to the prompt queue for re-dispatch when the turn settles. */
+  enqueue: (text: string, images?: PromptImage[]) => void;
+}
+
+/**
+ * Append a local command's echo, or defer it to the queue if a turn is streaming.
+ *
+ * @returns `true` if the command was deferred — the caller must stop and not run
+ *   its inline side effects (they will run on re-dispatch). `false` if it was
+ *   appended and the caller should proceed.
+ */
+export function appendOrDeferLocalUserMessage(
+  isStreaming: boolean,
+  text: string,
+  images: PromptImage[] | undefined,
+  sink: LocalEchoSink,
+): boolean {
+  if (isStreaming) {
+    sink.enqueue(text, images);
+    return true;
+  }
+  sink.append(text);
+  return false;
+}

--- a/packages/web-shell/client/utils/localCommandQueue.ts
+++ b/packages/web-shell/client/utils/localCommandQueue.ts
@@ -48,3 +48,19 @@ export function appendOrDeferLocalUserMessage(
   sink.append(text);
   return false;
 }
+
+/**
+ * Whether a queued prompt is a slash (`/…`) or shell (`!…`) command rather than
+ * model-facing prose.
+ *
+ * The queue's "insert" action injects the raw text into the running turn via
+ * `enqueueMidTurnMessage` — it is NOT re-dispatched as a command, so a command
+ * inserted this way reaches the model as the literal string "/context …" and
+ * never runs. Callers use this to disable "insert" for command entries; they
+ * still run correctly when the queue drains and re-dispatches them through
+ * `handleSubmit`.
+ */
+export function isCommandPrompt(text: string): boolean {
+  const trimmed = text.trimStart();
+  return trimmed.startsWith('/') || trimmed.startsWith('!');
+}


### PR DESCRIPTION
## What this PR does

Makes local slash commands that "echo" into the transcript behave correctly with respect to the streaming turn, in two parts.

First, it routes those commands (`/context`, `/stats`, `/status`, `/about`, `/bug`, `/model --voice`, `/skills`, `/tools`, `/extensions`) through a single choke point so that, while a turn is streaming, they defer to the prompt queue instead of appending a user message into the middle of the running turn. When the turn settles, the queue re-dispatches them and they run as their own clean turn. `showContextUsage` self-guards so all three `/context` entry points — keyboard submit, the status-bar context button, and the in-chat "context detail" link — are covered, not just the keyboard. `/extensions install` defers via a top-of-branch guard, which replaces its bespoke "wait for turn" message (the now-unused `extensions.install.waitForTurn` i18n key is removed). Dialog/overlay commands (`/help`, `/theme`, `/settings`, `/memory`, `/agents`) and the deliberate busy-acknowledgement paths (e.g. clearing a goal mid-turn) are unaffected.

Second, it disables the queue's "insert" action for command entries. "Insert" injects a queued message's raw text into the running turn via `enqueueMidTurnMessage` for the model to consume; that is meaningless for a slash/shell command, since the model would only see the literal string "/context …" and the command would never run. Command entries (text starting with `/` or `!`) now show the insert action greyed out with an explanatory tooltip, and the handler guards against it defensively. Plain prompts remain insertable, and the deferred commands still run correctly when the queue drains.

## Why it's needed

`applyTurnCollapse` defines a turn as spanning one user message up to the next, so every user-role row is a turn boundary. When an echoing command ran while a turn was still streaming, it appended a user row into the active turn and split it in two — the tool/thinking/token counters were then computed per fragment and rendered incorrectly (for example a single turn showed up as "tools 4" + "tools 5" instead of "tools 9"). On top of that, some commands deferred and others ran immediately, so the transcript ordering was inconsistent. Centralizing the decision fixes the whole class at once and removes the per-command drift. The "insert" change closes the matching gap on the queue side: once these commands sit in the queue, offering to splice them into the live turn was misleading, because insertion sends raw text the model can't act on as a command.

## Reviewer Test Plan

### How to verify

1. Start the web shell: `npm run dev:daemon`. 2. Send a prompt that triggers a multi-step tool turn (e.g. "summarize this project's structure"). 3. While it is still streaming, run `/context detail` — or click the status-bar context button, or the in-chat "context detail" link.

Expected (after this PR): the command is queued (visible in the queued-prompts area) and runs as its own turn after the current one finishes; the active turn keeps a single collapse header with correct tool/thinking/token counts. Before this PR it appended mid-stream and split the turn into two headers with wrong counts. Also confirm `/stats`, `/status`, and `/extensions foo` defer the same way, while dialog commands (`/help`, `/theme`, `/settings`) stay instant. In the queued-prompts list, the "insert" action is greyed out (with a tooltip) for these command entries but stays active for a plain text prompt.

Automated: `cd packages/web-shell && npx vitest run` (all pass; unit tests added for the new helpers), `npx tsc --noEmit -p tsconfig.json` (clean), and `npx eslint` on the changed files (clean).

### Evidence (Before & After)

Before: running `/context detail` during a streaming turn split the turn into two collapse headers ("tools 4 · thinking 3" + "12s … tools 5 · thinking 3") with the usage stamped only on the second fragment. After: `/context detail` is queued during streaming and renders as its own clean turn once the original turn completes; the original turn stays a single header with correct counts, and the queued command's "insert" action is greyed out. 
<img width="2092" height="1210" alt="image" src="https://github.com/user-attachments/assets/b8a4019b-ce18-40d9-ab4e-2ac066b0ccc2" />
<img width="2116" height="1150" alt="image" src="https://github.com/user-attachments/assets/11b12020-860a-4e98-b618-b5d44a183136" />


### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local: `npm run dev:daemon` (daemon + Vite web shell), plus `vitest`, `tsc --noEmit`, and `eslint`.

## Risk & Scope

- Main risk or tradeoff: behavior change — echoing commands now queue when invoked mid-turn instead of running immediately; in particular `/extensions install` mid-turn now silently queues (and runs after the turn) instead of showing a "wait for turn" message. The queued command is visible in the queued-prompts UI, so feedback is retained. The "insert" action is now disabled for any queued entry starting with `/` or `!`; a plain prompt that literally begins with `/` (e.g. a path) is treated as a command for this purpose, consistent with how the web-shell already classifies such input elsewhere.
- Not validated / out of scope: Windows/Linux verified only via CI; no end-to-end automated test for the full `handleSubmit` queue round-trip (covered by helper unit tests plus manual verification). The dedicated permission/approval rendering is untouched.
- Breaking changes / migration notes: none. Removes the now-unused `extensions.install.waitForTurn` translation key.
- Validation timing (deferral is whole-command, not just execution): for a command typed mid-turn, argument parsing/validation is deferred along with execution, because a parse error is itself transcript output — running validation before the deferral check would re-introduce the turn-splitting bug this PR fixes (the error would render in the middle of the streaming turn). An invalid command (e.g. `/extensions install --bad-flag`) therefore queues silently and its error surfaces when the queue drains and re-runs validation, rather than at the mid-turn keystroke. This is intentional; the queued entry is visible in the queued-prompts UI so the command is not lost.

## Linked Issues

<!-- none -->

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让会"回显"进会话流的本地斜杠命令在流式回合下表现正确,分两部分。

第一,把这些命令(`/context`、`/stats`、`/status`、`/about`、`/bug`、`/model --voice`、`/skills`、`/tools`、`/extensions`)统一收敛到一个入口控制点:当某个回合正在流式输出时,它们改为进入提示队列延迟执行,而不是把一条用户消息插入到正在进行的回合中间。等该回合结束后,队列会重新分发它们,各自作为一个独立、干净的回合运行。`showContextUsage` 自带守卫,因此 `/context` 的三个入口——键盘提交、状态栏的上下文按钮、会话流内的 "context detail" 链接——全部被覆盖,而不只是键盘。`/extensions install` 通过分支顶部的守卫来延迟,替代了它原本特有的"等待回合结束"提示(已无引用的 `extensions.install.waitForTurn` i18n 键被删除)。弹窗/浮层类命令(`/help`、`/theme`、`/settings`、`/memory`、`/agents`)以及有意为之的"忙时确认"路径(例如回合进行中清除目标)不受影响。

第二,禁用队列对命令类条目的"插入"操作。"插入"会通过 `enqueueMidTurnMessage` 把排队消息的原始文本注入正在进行的回合供模型消费;但对斜杠/shell 命令而言这毫无意义,因为模型只会看到字面字符串 "/context …",命令根本不会执行。命令类条目(以 `/` 或 `!` 开头的文本)的"插入"操作现在置灰,并带有说明性的悬停提示,处理函数也做了防御性守卫。普通 prompt 仍可插入,延迟的命令在队列排空时仍会正确执行。

## 为什么需要

`applyTurnCollapse` 把一个回合定义为"从一条用户消息延伸到下一条用户消息",因此每一行用户消息都是回合边界。当一个会回显的命令在回合仍在流式输出时执行,它会往正在进行的回合里插入一行用户消息,把回合劈成两段——工具/思考/token 的计数随后按片段分别统计、渲染错误(例如一个回合显示成"工具 4 次" + "工具 5 次",而非"工具 9 次")。此外,部分命令会延迟、部分会立即执行,导致会话流顺序不一致。把决策集中化可一次性修复这一整类问题,并消除各命令各自为政的漂移。"插入"这部分则补上了队列侧对应的缺口:一旦这些命令进入队列,再提供把它们拼接进实时回合的操作就具有误导性,因为插入发送的是模型无法当作命令执行的原始文本。

## 复审测试计划

### 如何验证

1. 启动 web shell:`npm run dev:daemon`。2. 发送一个会触发多步工具调用的提示(例如"帮我看下这个项目的结构")。3. 在它仍在流式输出时,执行 `/context detail`——或点击状态栏的上下文按钮、或会话流内的 "context detail" 链接。

预期(本 PR 之后):该命令进入队列(在队列区可见),并在当前回合结束后作为独立回合运行;正在进行的回合保持单一折叠头、计数正确。本 PR 之前它会在流式中插入并把回合劈成两个折叠头、计数错误。另外确认 `/stats`、`/status`、`/extensions foo` 也同样延迟,而弹窗命令(`/help`、`/theme`、`/settings`)仍即时弹出。在队列列表中,这些命令类条目的"插入"操作被置灰(带提示),而普通文字 prompt 的"插入"仍可用。

自动化:`cd packages/web-shell && npx vitest run`(全部通过;为新增 helper 加了单元测试)、`npx tsc --noEmit -p tsconfig.json`(无错误)、对改动文件运行 `npx eslint`(无警告)。

### 证据(前 & 后)

之前:在流式回合中执行 `/context detail` 会把回合劈成两个折叠头("工具 4 次 · 思考 3 次" + "12s … 工具 5 次 · 思考 3 次"),用量只盖在第二段上。之后:`/context detail` 在流式中被排队,等原回合结束后作为独立、干净的回合渲染;原回合保持单一折叠头、计数正确,且该排队命令的"插入"操作被置灰。(截图已附。)

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境(可选)

本地:`npm run dev:daemon`(daemon + Vite web shell),以及 `vitest`、`tsc --noEmit`、`eslint`。

## 风险与范围

- 主要风险/取舍:行为变更——会回显的命令在回合进行中被调用时,现在会排队而非立即执行;特别是 `/extensions install` 在回合中现在静默排队(回合结束后执行),而非显示"等待回合结束"提示。排队的命令在队列 UI 中可见,因此反馈未丢失。"插入"操作现在对任何以 `/` 或 `!` 开头的排队条目禁用;一个字面以 `/` 开头的普通 prompt(例如路径)在此处会被当作命令处理,这与 web-shell 其他地方对此类输入的归类方式一致。
- 未验证/范围外:Windows/Linux 仅通过 CI 验证;没有针对完整 `handleSubmit` 队列往返的端到端自动化测试(由 helper 单元测试 + 手动验证覆盖)。专用的权限/审批渲染未触及。
- 破坏性变更/迁移说明:无。删除了已无引用的 `extensions.install.waitForTurn` 翻译键。
- 校验时机(整条命令延迟,而非仅延迟执行):对于回合进行中输入的命令,参数解析/校验会随执行一起延迟,因为 parse
  错误本身就是一条会话流输出——若在延迟判断之前先跑校验,会重新引入本 PR 所修复的回合切断问题(错误会渲染在流式回合中间)。因此非法命令(如 `/extensions install --bad-flag`)会静默排队,其错误在队列排空、重新跑校验时才出现,而非在 mid-turn 的那次输入时。这是有意为之;排队条目在队列 UI 中可见,命令不会丢失。

</details>
