### PR TITLE
feat(cli): simplify auto mode startup text and remove emoji (#4584)

### DIFF
--- a/packages/cli/src/ui/hooks/useAutoAcceptIndicator.ts
+++ b/packages/cli/src/ui/hooks/useAutoAcceptIndicator.ts
@@ -16,11 +16,9 @@ import { MessageType } from '../types.js';
 import { type LoadedSettings, SettingScope } from '../../config/settings.js';
 
 const AUTO_MODE_FIRST_TIME_MESSAGE =
-  '✨ Auto mode enabled.\n' +
-  '   An LLM classifier evaluates each tool call and auto-approves safe actions,\n' +
-  '   blocks risky ones. Most read-only operations and in-cwd edits skip the\n' +
-  '   classifier for speed. To exit: Shift+Tab or /approval-mode default.\n' +
-  '   (This notice will not appear again.)';
+  'Auto mode enabled.\n' +
+  '   An LLM classifier evaluates each tool call — safe actions auto-approve,\n' +
+  '   risky ones are blocked. Exit: Shift+Tab or /approval-mode default.';
 
 export interface UseAutoAcceptIndicatorArgs {
   config: Config;


### PR DESCRIPTION
<!--
Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

Removes the ✨ emoji prefix from the Auto mode first-time startup message and simplifies the copy from 5 lines to 3 lines. The message now reads: "Auto mode enabled. An LLM classifier evaluates each tool call — safe actions auto-approve, risky ones are blocked. Exit: Shift+Tab or /approval-mode default."

## Why it's needed

The emoji icon in front of the auto mode startup text looked visually redundant, and the original copy was unnecessarily verbose. This simplifies the text to be more concise and professional while preserving all essential information (what auto mode does, how to exit).

Resolves #4584.

## Reviewer Test Plan

### How to verify

```bash
cd packages/cli && npx vitest run src/ui/hooks/useAutoAcceptIndicator
```

Manually: start the CLI with `--approval-mode auto` on a fresh config (no `ui.autoModeAcknowledged` set) and confirm the message appears without an emoji prefix and with shortened text.

### Evidence (Before & After)

**Before:**
```
✨ Auto mode enabled.
   An LLM classifier evaluates each tool call and auto-approves safe actions,
   blocks risky ones. Most read-only operations and in-cwd edits skip the
   classifier for speed. To exit: Shift+Tab or /approval-mode default.
   (This notice will not appear again.)
```

**After:**
```
Auto mode enabled.
   An LLM classifier evaluates each tool call — safe actions auto-approve,
   risky ones are blocked. Exit: Shift+Tab or /approval-mode default.
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

## Risk & Scope

- Purely cosmetic text change — no logic modified
- **Breaking changes:** None

## Linked Issues

Closes #4584

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

移除 Auto 模式首次启动提示文字前的 ✨ emoji，并将文案从 5 行精简为 3 行。新文案为："Auto mode enabled. An LLM classifier evaluates each tool call — safe actions auto-approve, risky ones are blocked. Exit: Shift+Tab or /approval-mode default."

## 为什么需要

原有的 emoji 图标在文字前面显得多余，原始文案也过于冗长。简化后更加简洁专业，同时保留了所有关键信息（auto 模式的作用、退出方式）。

解决 #4584。

## Reviewer Test Plan

手动验证：用 `--approval-mode auto` 启动 CLI（清除 `ui.autoModeAcknowledged` 设置），确认消息无 emoji 前缀且文案已缩短。

## 风险与范围

- 纯文案变更，无逻辑修改
- **破坏性变更：** 无

## 关联 Issues

Closes #4584

</details>