### PR TITLE
test(cli): add daemon startup benchmark

### DIFF
--- a/integration-tests/cli/_daemon-benchmark-helpers.ts
+++ b/integration-tests/cli/_daemon-benchmark-helpers.ts
@@ -30,6 +30,7 @@ import {
   sleep,
   DEFAULT_CLI_BIN,
   DEFAULT_TOKEN,
+  LISTENING_LINE_RE,
   type SpawnDaemonOptions,
   type SpawnedDaemon,
 } from './_daemon-harness.js';
@@ -336,7 +337,6 @@ export async function spawnDaemonWithTime(
     stderrBuf.value += chunk.toString();
   });
 
-  const LISTENING_RE = /listening on http:\/\/127\.0\.0\.1:(\d+)/;
   const port = await new Promise<number>((resolve, reject) => {
     let settled = false;
     const cleanup = () => {
@@ -361,12 +361,12 @@ export async function spawnDaemonWithTime(
       );
     }, bootTimeoutMs);
     const onData = () => {
-      const m = stdoutBuf.value.match(LISTENING_RE);
-      if (m && !settled) {
-        settled = true;
-        cleanup();
-        resolve(Number(m[1]));
-      }
+      const matchedPort =
+        stdoutBuf.value.match(LISTENING_LINE_RE)?.groups?.['port'];
+      if (!matchedPort || settled) return;
+      settled = true;
+      cleanup();
+      resolve(Number(matchedPort));
     };
     const onExit = (code: number | null) => {
       fail(

--- a/integration-tests/cli/_daemon-harness.ts
+++ b/integration-tests/cli/_daemon-harness.ts
@@ -89,7 +89,8 @@ export interface SpawnedDaemon {
   dispose: () => Promise<void>;
 }
 
-const LISTENING_RE = /listening on http:\/\/127\.0\.0\.1:(\d+)/;
+export const LISTENING_LINE_RE =
+  /^(?<line>.*listening on http:\/\/127\.0\.0\.1:(?<port>\d+).*)$/m;
 const DISPOSE_GRACE_MS = 5_000;
 const MATCHED_DESCENDANT_DEPTH = 4;
 
@@ -160,13 +161,11 @@ export async function spawnDaemon(
       );
     }, bootTimeoutMs);
     const onData = (_chunk: Buffer) => {
-      const m = stdoutBuf.value.match(LISTENING_RE);
-      if (m) {
-        if (settled) return;
-        settled = true;
-        cleanup();
-        resolve(Number(m[1]));
-      }
+      const port = stdoutBuf.value.match(LISTENING_LINE_RE)?.groups?.['port'];
+      if (!port || settled) return;
+      settled = true;
+      cleanup();
+      resolve(Number(port));
     };
     const onExit = (code: number | null) => {
       fail(

--- a/integration-tests/cli/qwen-daemon-startup-benchmark.test.ts
+++ b/integration-tests/cli/qwen-daemon-startup-benchmark.test.ts
@@ -22,10 +22,14 @@ import * as path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { afterAll, describe, expect, it } from 'vitest';
 
-import type { DaemonStartupPreheatStatus } from '../../packages/cli/src/serve/daemon-status.js';
+import type {
+  DaemonStartupPreheatStatus,
+  DaemonStartupSnapshot,
+} from '../../packages/cli/src/serve/daemon-status.js';
 import {
   DEFAULT_REPO_ROOT,
   gitHead,
+  LISTENING_LINE_RE,
   makeTempWorkspace,
   percentiles,
   sleep,
@@ -57,6 +61,12 @@ const BOOT_TIMEOUT_MS = Number(
 const EXTERNAL_P99_MAX_MS = Number(
   process.env['BENCHMARK_DAEMON_STARTUP_P99_MAX_MS'] ?? 15_000,
 );
+const PROCESS_P99_MAX_MS = Number(
+  process.env['BENCHMARK_PROCESS_P99_MAX_MS'] ?? 5_000,
+);
+const RUN_SERVE_P99_MAX_MS = Number(
+  process.env['BENCHMARK_RUN_SERVE_P99_MAX_MS'] ?? 5_000,
+);
 const STATUS_FETCH_TIMEOUT_MS = Number(
   process.env['BENCHMARK_DAEMON_STATUS_TIMEOUT_MS'] ?? 5_000,
 );
@@ -84,21 +94,9 @@ const PREHEAT_STATUSES = Object.keys(
   PREHEAT_STATUS_SET,
 ) as DaemonStartupPreheatStatus[];
 
-interface DaemonStartupStatus {
-  processStartedAt: string;
-  listenerReadyAt?: string;
-  processToListenMs?: number;
-  runQwenServeToListenMs?: number;
-  preheat?: {
-    status?: DaemonStartupPreheatStatus;
-    durationMs?: number;
-    error?: string;
-  };
-}
-
 interface DaemonStatusResponse {
   daemon?: {
-    startup?: DaemonStartupStatus;
+    startup?: DaemonStartupSnapshot;
   };
 }
 
@@ -124,6 +122,8 @@ interface StartupBenchmarkSnapshot {
     warmupIterations: number;
     bootTimeoutMs: number;
     externalP99MaxMs: number;
+    processP99MaxMs: number;
+    runServeP99MaxMs: number;
     statusFetchTimeoutMs: number;
     stderrTimingTimeoutMs: number;
   };
@@ -145,6 +145,8 @@ const snapshot: StartupBenchmarkSnapshot = {
     warmupIterations: WARMUP_ITERATIONS,
     bootTimeoutMs: BOOT_TIMEOUT_MS,
     externalP99MaxMs: EXTERNAL_P99_MAX_MS,
+    processP99MaxMs: PROCESS_P99_MAX_MS,
+    runServeP99MaxMs: RUN_SERVE_P99_MAX_MS,
     statusFetchTimeoutMs: STATUS_FETCH_TIMEOUT_MS,
     stderrTimingTimeoutMs: STDERR_TIMING_TIMEOUT_MS,
   },
@@ -157,8 +159,6 @@ const snapshot: StartupBenchmarkSnapshot = {
   runs: [],
 };
 
-const LISTENING_RE =
-  /^(qwen serve listening on http:\/\/127\.0\.0\.1:(\d+) \(mode=.*\))$/m;
 const STDERR_TIMING_RE =
   /qwen serve: startup timing: processToListenMs=(\d+) runQwenServeToListenMs=(\d+)/;
 
@@ -281,13 +281,15 @@ async function runStartupIteration(
       };
       const onStdout = (chunk: Buffer) => {
         stdout += chunk.toString();
-        const match = stdout.match(LISTENING_RE);
-        if (!match) return;
+        const match = stdout.match(LISTENING_LINE_RE);
+        const line = match?.groups?.['line'];
+        const port = match?.groups?.['port'];
+        if (!line || !port) return;
         settled = true;
         cleanup();
         resolve({
-          line: match[1],
-          port: Number(match[2]),
+          line,
+          port: Number(port),
           externalCommandToListeningMs: Math.round(
             performance.now() - startedAt,
           ),
@@ -316,13 +318,11 @@ async function runStartupIteration(
     const timing = await waitForStderrTiming(() => stderr);
     let status: DaemonStatusResponse;
     try {
-      const res = await fetch(
-        `http://127.0.0.1:${listening.port}/daemon/status?detail=full`,
-        {
-          headers: { authorization: `Bearer ${TOKEN}` },
-          signal: AbortSignal.timeout(STATUS_FETCH_TIMEOUT_MS),
-        },
-      );
+      const statusUrl = `http://127.0.0.1:${listening.port}/daemon/status`;
+      const res = await fetch(statusUrl, {
+        headers: { authorization: `Bearer ${TOKEN}` },
+        signal: AbortSignal.timeout(STATUS_FETCH_TIMEOUT_MS),
+      });
       if (!res.ok) {
         throw new Error(`/daemon/status returned ${res.status}`);
       }
@@ -345,9 +345,8 @@ async function runStartupIteration(
       expect(startup?.listenerReadyAt).toEqual(expect.any(String));
       expect(processToListenMs).toEqual(Number(timing[1]));
       expect(runQwenServeToListenMs).toEqual(Number(timing[2]));
-      expect(processToListenMs).toEqual(expect.any(Number));
-      expect(runQwenServeToListenMs).toEqual(expect.any(Number));
       expect(processToListenMs).toBeGreaterThanOrEqual(runQwenServeToListenMs!);
+      expect(startup?.preheat).toEqual(expect.any(Object));
       expect(preheatStatus).toEqual(expect.any(String));
       expect(PREHEAT_STATUSES).toContain(preheatStatus);
     };
@@ -416,8 +415,16 @@ async function runStartupIteration(
         expect(snapshot.externalCommandToListening.p99).toBeLessThan(
           EXTERNAL_P99_MAX_MS,
         );
+        expect(snapshot.processToListen.p99).toBeLessThan(PROCESS_P99_MAX_MS);
+        expect(snapshot.runQwenServeToListen.p99).toBeLessThan(
+          RUN_SERVE_P99_MAX_MS,
+        );
       },
-      (WARMUP_ITERATIONS + ITERATIONS) * (BOOT_TIMEOUT_MS + 5_000),
+      (WARMUP_ITERATIONS + ITERATIONS) *
+        (BOOT_TIMEOUT_MS +
+          STDERR_TIMING_TIMEOUT_MS +
+          STATUS_FETCH_TIMEOUT_MS +
+          5_000),
     );
 
     afterAll(() => {

--- a/integration-tests/cli/qwen-daemon-startup-benchmark.test.ts
+++ b/integration-tests/cli/qwen-daemon-startup-benchmark.test.ts
@@ -58,6 +58,7 @@ const TOKEN = 'daemon-startup-benchmark-token';
 const CLI_BIN =
   process.env['TEST_CLI_PATH'] ??
   path.resolve(DEFAULT_REPO_ROOT, 'dist/cli.js');
+// Keep in sync with DaemonStartupPreheatStatus in daemon-status.ts.
 const PREHEAT_STATUSES = [
   'external_bridge',
   'not_scheduled',

--- a/integration-tests/cli/qwen-daemon-startup-benchmark.test.ts
+++ b/integration-tests/cli/qwen-daemon-startup-benchmark.test.ts
@@ -209,6 +209,9 @@ async function runStartupIteration(
   const { VITEST_WORKER_ID: _vitestWorkerId, ...childEnv } = process.env;
 
   try {
+    // Keep this separate from spawnDaemon(): the benchmark needs the wall
+    // clock to include Node process creation, raw stderr for the timing-line
+    // assertion, and tighter sample-to-sample teardown.
     child = spawn(
       process.execPath,
       [

--- a/integration-tests/cli/qwen-daemon-startup-benchmark.test.ts
+++ b/integration-tests/cli/qwen-daemon-startup-benchmark.test.ts
@@ -40,7 +40,10 @@ const SANDBOX_ENABLED = Boolean(
   process.env['QWEN_SANDBOX'] &&
     process.env['QWEN_SANDBOX'].toLowerCase() !== 'false',
 );
-const SKIP = process.env['QWEN_BENCHMARK_ENABLED'] !== '1' || SANDBOX_ENABLED;
+const SKIP =
+  process.env['QWEN_BENCHMARK_ENABLED'] !== '1' ||
+  SANDBOX_ENABLED ||
+  process.platform === 'win32';
 
 const ITERATIONS = Number(process.env['BENCHMARK_ITERATIONS'] ?? 5);
 const WARMUP_ITERATIONS = Number(
@@ -52,9 +55,18 @@ const BOOT_TIMEOUT_MS = Number(
 const EXTERNAL_P99_MAX_MS = Number(
   process.env['BENCHMARK_DAEMON_STARTUP_P99_MAX_MS'] ?? 15_000,
 );
+const STATUS_FETCH_TIMEOUT_MS = Number(
+  process.env['BENCHMARK_DAEMON_STATUS_TIMEOUT_MS'] ?? 5_000,
+);
+const STDERR_TIMING_TIMEOUT_MS = Number(
+  process.env['BENCHMARK_STDERR_TIMING_TIMEOUT_MS'] ??
+    Math.max(2_000, Math.ceil(BOOT_TIMEOUT_MS / 5)),
+);
 
 const OUTPUT_DIR = resolveOutputDir('daemon-startup');
 const TOKEN = 'daemon-startup-benchmark-token';
+// Prefer the bundled root CLI because this benchmark targets the packaged
+// `qwen serve` entrypoint; TEST_CLI_PATH can still override it.
 const CLI_BIN =
   process.env['TEST_CLI_PATH'] ??
   path.resolve(DEFAULT_REPO_ROOT, 'dist/cli.js');
@@ -110,6 +122,8 @@ interface StartupBenchmarkSnapshot {
     warmupIterations: number;
     bootTimeoutMs: number;
     externalP99MaxMs: number;
+    statusFetchTimeoutMs: number;
+    stderrTimingTimeoutMs: number;
   };
   notes: string[];
   runs: StartupRun[];
@@ -129,6 +143,8 @@ const snapshot: StartupBenchmarkSnapshot = {
     warmupIterations: WARMUP_ITERATIONS,
     bootTimeoutMs: BOOT_TIMEOUT_MS,
     externalP99MaxMs: EXTERNAL_P99_MAX_MS,
+    statusFetchTimeoutMs: STATUS_FETCH_TIMEOUT_MS,
+    stderrTimingTimeoutMs: STDERR_TIMING_TIMEOUT_MS,
   },
   notes: [
     'Measures built CLI `qwen serve` cold startup to the stdout listening line.',
@@ -184,7 +200,7 @@ async function terminate(child: ChildProcess): Promise<void> {
 async function waitForStderrTiming(
   stderr: () => string,
 ): Promise<RegExpMatchArray> {
-  const deadline = performance.now() + 1_000;
+  const deadline = performance.now() + STDERR_TIMING_TIMEOUT_MS;
   while (performance.now() < deadline) {
     const match = stderr().match(STDERR_TIMING_RE);
     if (match) return match;
@@ -192,7 +208,10 @@ async function waitForStderrTiming(
   }
   const match = stderr().match(STDERR_TIMING_RE);
   if (match) return match;
-  throw new Error(`startup timing line missing from stderr:\n${stderr()}`);
+  throw new Error(
+    `startup timing line missing from stderr after ` +
+      `${STDERR_TIMING_TIMEOUT_MS}ms:\n${stderr()}`,
+  );
 }
 
 async function runStartupIteration(
@@ -301,6 +320,7 @@ async function runStartupIteration(
       `http://127.0.0.1:${listening.port}/daemon/status?detail=full`,
       {
         headers: { authorization: `Bearer ${TOKEN}` },
+        signal: AbortSignal.timeout(STATUS_FETCH_TIMEOUT_MS),
       },
     ).then((res) => {
       if (!res.ok) {
@@ -314,15 +334,29 @@ async function runStartupIteration(
     const runQwenServeToListenMs = startup?.runQwenServeToListenMs;
     const preheatStatus = startup?.preheat?.status;
 
-    expect(startup?.processStartedAt).toEqual(expect.any(String));
-    expect(startup?.listenerReadyAt).toEqual(expect.any(String));
-    expect(processToListenMs).toEqual(Number(timing[1]));
-    expect(runQwenServeToListenMs).toEqual(Number(timing[2]));
-    expect(processToListenMs).toEqual(expect.any(Number));
-    expect(runQwenServeToListenMs).toEqual(expect.any(Number));
-    expect(processToListenMs).toBeGreaterThanOrEqual(runQwenServeToListenMs!);
-    expect(preheatStatus).toEqual(expect.any(String));
-    expect(PREHEAT_STATUSES).toContain(preheatStatus as PreheatStatus);
+    const validateStartupObservation = () => {
+      expect(startup?.processStartedAt).toEqual(expect.any(String));
+      expect(startup?.listenerReadyAt).toEqual(expect.any(String));
+      expect(processToListenMs).toEqual(Number(timing[1]));
+      expect(runQwenServeToListenMs).toEqual(Number(timing[2]));
+      expect(processToListenMs).toEqual(expect.any(Number));
+      expect(runQwenServeToListenMs).toEqual(expect.any(Number));
+      expect(processToListenMs).toBeGreaterThanOrEqual(runQwenServeToListenMs!);
+      expect(preheatStatus).toEqual(expect.any(String));
+      expect(PREHEAT_STATUSES).toContain(preheatStatus as PreheatStatus);
+    };
+    if (measured) {
+      validateStartupObservation();
+    } else {
+      try {
+        validateStartupObservation();
+      } catch (err) {
+        console.warn(
+          `[daemon-startup] warmup ${iteration}: startup validation failed: ` +
+            `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
 
     return {
       iteration,

--- a/integration-tests/cli/qwen-daemon-startup-benchmark.test.ts
+++ b/integration-tests/cli/qwen-daemon-startup-benchmark.test.ts
@@ -22,11 +22,13 @@ import * as path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { afterAll, describe, expect, it } from 'vitest';
 
+import type { DaemonStartupPreheatStatus } from '../../packages/cli/src/serve/daemon-status.js';
 import {
   DEFAULT_REPO_ROOT,
   gitHead,
   makeTempWorkspace,
   percentiles,
+  sleep,
   type Percentiles,
 } from './_daemon-harness.js';
 import {
@@ -70,17 +72,17 @@ const TOKEN = 'daemon-startup-benchmark-token';
 const CLI_BIN =
   process.env['TEST_CLI_PATH'] ??
   path.resolve(DEFAULT_REPO_ROOT, 'dist/cli.js');
-// Keep in sync with DaemonStartupPreheatStatus in daemon-status.ts.
-const PREHEAT_STATUSES = [
-  'external_bridge',
-  'not_scheduled',
-  'scheduled',
-  'running',
-  'succeeded',
-  'failed',
-] as const;
-
-type PreheatStatus = (typeof PREHEAT_STATUSES)[number];
+const PREHEAT_STATUS_SET: Record<DaemonStartupPreheatStatus, true> = {
+  external_bridge: true,
+  not_scheduled: true,
+  scheduled: true,
+  running: true,
+  succeeded: true,
+  failed: true,
+};
+const PREHEAT_STATUSES = Object.keys(
+  PREHEAT_STATUS_SET,
+) as DaemonStartupPreheatStatus[];
 
 interface DaemonStartupStatus {
   processStartedAt: string;
@@ -88,7 +90,7 @@ interface DaemonStartupStatus {
   processToListenMs?: number;
   runQwenServeToListenMs?: number;
   preheat?: {
-    status?: PreheatStatus;
+    status?: DaemonStartupPreheatStatus;
     durationMs?: number;
     error?: string;
   };
@@ -106,7 +108,7 @@ interface StartupRun {
   externalCommandToListeningMs: number;
   processToListenMs: number;
   runQwenServeToListenMs: number;
-  preheatStatus: PreheatStatus;
+  preheatStatus: DaemonStartupPreheatStatus;
   port: number;
   stdoutListeningLine: string;
 }
@@ -159,10 +161,6 @@ const LISTENING_RE =
   /^(qwen serve listening on http:\/\/127\.0\.0\.1:(\d+) \(mode=.*\))$/m;
 const STDERR_TIMING_RE =
   /qwen serve: startup timing: processToListenMs=(\d+) runQwenServeToListenMs=(\d+)/;
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 function signalChildTree(child: ChildProcess, signal: NodeJS.Signals): void {
   if (!child.pid) return;
@@ -316,18 +314,26 @@ async function runStartupIteration(
     });
 
     const timing = await waitForStderrTiming(() => stderr);
-    const status = (await fetch(
-      `http://127.0.0.1:${listening.port}/daemon/status?detail=full`,
-      {
-        headers: { authorization: `Bearer ${TOKEN}` },
-        signal: AbortSignal.timeout(STATUS_FETCH_TIMEOUT_MS),
-      },
-    ).then((res) => {
+    let status: DaemonStatusResponse;
+    try {
+      const res = await fetch(
+        `http://127.0.0.1:${listening.port}/daemon/status?detail=full`,
+        {
+          headers: { authorization: `Bearer ${TOKEN}` },
+          signal: AbortSignal.timeout(STATUS_FETCH_TIMEOUT_MS),
+        },
+      );
       if (!res.ok) {
         throw new Error(`/daemon/status returned ${res.status}`);
       }
-      return res.json();
-    })) as DaemonStatusResponse;
+      status = (await res.json()) as DaemonStatusResponse;
+    } catch (err) {
+      throw new Error(
+        `/daemon/status fetch failed on iteration ${iteration} ` +
+          `(port ${listening.port}): ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
 
     const startup = status.daemon?.startup;
     const processToListenMs = startup?.processToListenMs;
@@ -343,7 +349,7 @@ async function runStartupIteration(
       expect(runQwenServeToListenMs).toEqual(expect.any(Number));
       expect(processToListenMs).toBeGreaterThanOrEqual(runQwenServeToListenMs!);
       expect(preheatStatus).toEqual(expect.any(String));
-      expect(PREHEAT_STATUSES).toContain(preheatStatus as PreheatStatus);
+      expect(PREHEAT_STATUSES).toContain(preheatStatus);
     };
     if (measured) {
       validateStartupObservation();
@@ -362,9 +368,9 @@ async function runStartupIteration(
       iteration,
       measured,
       externalCommandToListeningMs: listening.externalCommandToListeningMs,
-      processToListenMs: processToListenMs!,
-      runQwenServeToListenMs: runQwenServeToListenMs!,
-      preheatStatus: preheatStatus!,
+      processToListenMs: processToListenMs ?? -1,
+      runQwenServeToListenMs: runQwenServeToListenMs ?? -1,
+      preheatStatus: preheatStatus ?? 'not_scheduled',
       port: listening.port,
       stdoutListeningLine: listening.line,
     };

--- a/integration-tests/cli/qwen-daemon-startup-benchmark.test.ts
+++ b/integration-tests/cli/qwen-daemon-startup-benchmark.test.ts
@@ -1,0 +1,453 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * qwen serve daemon startup benchmark.
+ *
+ * Measures only the cold path from spawning the built CLI to the HTTP
+ * listener-ready stdout line. It intentionally does not create a session, so
+ * ACP/runtime preheat cost remains observed but not part of the primary
+ * listener-ready latency.
+ *
+ * Gated by QWEN_BENCHMARK_ENABLED=1 and writes JSON/Markdown artifacts to the
+ * integration test output directory.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { afterAll, describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_REPO_ROOT,
+  gitHead,
+  makeTempWorkspace,
+  percentiles,
+  type Percentiles,
+} from './_daemon-harness.js';
+import {
+  collectPlatformInfo,
+  formatPercentiles,
+  resolveOutputDir,
+  writeSnapshotArtifacts,
+} from './_daemon-perf-report.js';
+
+const SANDBOX_ENABLED = Boolean(
+  process.env['QWEN_SANDBOX'] &&
+    process.env['QWEN_SANDBOX'].toLowerCase() !== 'false',
+);
+const SKIP = process.env['QWEN_BENCHMARK_ENABLED'] !== '1' || SANDBOX_ENABLED;
+
+const ITERATIONS = Number(process.env['BENCHMARK_ITERATIONS'] ?? 5);
+const WARMUP_ITERATIONS = Number(
+  process.env['BENCHMARK_WARMUP_ITERATIONS'] ?? 1,
+);
+const BOOT_TIMEOUT_MS = Number(
+  process.env['BENCHMARK_BOOT_TIMEOUT_MS'] ?? 15_000,
+);
+const EXTERNAL_P99_MAX_MS = Number(
+  process.env['BENCHMARK_DAEMON_STARTUP_P99_MAX_MS'] ?? 15_000,
+);
+
+const OUTPUT_DIR = resolveOutputDir('daemon-startup');
+const TOKEN = 'daemon-startup-benchmark-token';
+const CLI_BIN =
+  process.env['TEST_CLI_PATH'] ??
+  path.resolve(DEFAULT_REPO_ROOT, 'dist/cli.js');
+const PREHEAT_STATUSES = [
+  'external_bridge',
+  'not_scheduled',
+  'scheduled',
+  'running',
+  'succeeded',
+  'failed',
+] as const;
+
+type PreheatStatus = (typeof PREHEAT_STATUSES)[number];
+
+interface DaemonStartupStatus {
+  processStartedAt: string;
+  listenerReadyAt?: string;
+  processToListenMs?: number;
+  runQwenServeToListenMs?: number;
+  preheat?: {
+    status?: PreheatStatus;
+    durationMs?: number;
+    error?: string;
+  };
+}
+
+interface DaemonStatusResponse {
+  daemon?: {
+    startup?: DaemonStartupStatus;
+  };
+}
+
+interface StartupRun {
+  iteration: number;
+  measured: boolean;
+  externalCommandToListeningMs: number;
+  processToListenMs: number;
+  runQwenServeToListenMs: number;
+  preheatStatus: PreheatStatus;
+  port: number;
+  stdoutListeningLine: string;
+}
+
+interface StartupBenchmarkSnapshot {
+  version: 1;
+  capturedAt: string;
+  gitCommit: string | null;
+  platform: { os: string; arch: string; nodeVersion: string };
+  cliBin: string;
+  config: {
+    iterations: number;
+    warmupIterations: number;
+    bootTimeoutMs: number;
+    externalP99MaxMs: number;
+  };
+  notes: string[];
+  runs: StartupRun[];
+  externalCommandToListening?: Percentiles;
+  processToListen?: Percentiles;
+  runQwenServeToListen?: Percentiles;
+}
+
+const snapshot: StartupBenchmarkSnapshot = {
+  version: 1,
+  capturedAt: new Date().toISOString(),
+  gitCommit: gitHead(),
+  platform: collectPlatformInfo(),
+  cliBin: CLI_BIN,
+  config: {
+    iterations: ITERATIONS,
+    warmupIterations: WARMUP_ITERATIONS,
+    bootTimeoutMs: BOOT_TIMEOUT_MS,
+    externalP99MaxMs: EXTERNAL_P99_MAX_MS,
+  },
+  notes: [
+    'Measures built CLI `qwen serve` cold startup to the stdout listening line.',
+    'Runs the default daemon path except for ephemeral port, loopback host, explicit workspace, and --no-open.',
+    'Does not create a session; preheat state is recorded but not included in the primary listener-ready metric.',
+    'Validates stderr startup timing and /daemon/status startup fields for each run.',
+  ],
+  runs: [],
+};
+
+const LISTENING_RE =
+  /^(qwen serve listening on http:\/\/127\.0\.0\.1:(\d+) \(mode=.*\))$/m;
+const STDERR_TIMING_RE =
+  /qwen serve: startup timing: processToListenMs=(\d+) runQwenServeToListenMs=(\d+)/;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function signalChildTree(child: ChildProcess, signal: NodeJS.Signals): void {
+  if (!child.pid) return;
+  try {
+    process.kill(process.platform === 'win32' ? child.pid : -child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+function childHasExited(child: ChildProcess): boolean {
+  return child.exitCode !== null || child.signalCode !== null;
+}
+
+async function terminate(child: ChildProcess): Promise<void> {
+  const exited = new Promise<true>((resolve) => {
+    if (childHasExited(child)) {
+      resolve(true);
+      return;
+    }
+    child.once('exit', () => resolve(true));
+  });
+  signalChildTree(child, 'SIGTERM');
+  if (await Promise.race([exited, sleep(250).then(() => false)])) {
+    return;
+  }
+  signalChildTree(child, 'SIGKILL');
+  await Promise.race([exited, sleep(750)]);
+}
+
+async function waitForStderrTiming(
+  stderr: () => string,
+): Promise<RegExpMatchArray> {
+  const deadline = performance.now() + 1_000;
+  while (performance.now() < deadline) {
+    const match = stderr().match(STDERR_TIMING_RE);
+    if (match) return match;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  const match = stderr().match(STDERR_TIMING_RE);
+  if (match) return match;
+  throw new Error(`startup timing line missing from stderr:\n${stderr()}`);
+}
+
+async function runStartupIteration(
+  iteration: number,
+  measured: boolean,
+): Promise<StartupRun> {
+  const workspace = makeTempWorkspace(
+    `${iteration}`,
+    'qwen-daemon-startup-benchmark',
+  );
+  const startedAt = performance.now();
+  let stdout = '';
+  let stderr = '';
+  let child: ChildProcess | undefined;
+  const { VITEST_WORKER_ID: _vitestWorkerId, ...childEnv } = process.env;
+
+  try {
+    child = spawn(
+      process.execPath,
+      [
+        CLI_BIN,
+        'serve',
+        '--port',
+        '0',
+        '--hostname',
+        '127.0.0.1',
+        '--workspace',
+        workspace,
+        '--no-open',
+      ],
+      {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        detached: process.platform !== 'win32',
+        env: {
+          ...childEnv,
+          CI: '1',
+          NO_COLOR: '1',
+          QWEN_CODE_PROFILE_STARTUP: '0',
+          QWEN_CODE_PROFILE_STARTUP_OUTER: '0',
+          QWEN_CODE_SUPPRESS_YOLO_WARNING: '1',
+          QWEN_SERVER_TOKEN: TOKEN,
+        },
+      },
+    );
+
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    const listening = await new Promise<{
+      line: string;
+      port: number;
+      externalCommandToListeningMs: number;
+    }>((resolve, reject) => {
+      let settled = false;
+      const cleanup = () => {
+        child?.stdout?.off('data', onStdout);
+        child?.off('exit', onExit);
+        clearTimeout(timer);
+      };
+      const fail = (err: Error) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(err);
+      };
+      const onStdout = (chunk: Buffer) => {
+        stdout += chunk.toString();
+        const match = stdout.match(LISTENING_RE);
+        if (!match) return;
+        settled = true;
+        cleanup();
+        resolve({
+          line: match[1],
+          port: Number(match[2]),
+          externalCommandToListeningMs: Math.round(
+            performance.now() - startedAt,
+          ),
+        });
+      };
+      const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+        fail(
+          new Error(
+            `daemon exited before listening: code=${code} signal=${signal}\n` +
+              `stdout=${stdout}\nstderr=${stderr}`,
+          ),
+        );
+      };
+      const timer = setTimeout(() => {
+        fail(
+          new Error(
+            `daemon startup timed out after ${BOOT_TIMEOUT_MS}ms\n` +
+              `stdout=${stdout}\nstderr=${stderr}`,
+          ),
+        );
+      }, BOOT_TIMEOUT_MS);
+      child?.stdout?.on('data', onStdout);
+      child?.once('exit', onExit);
+    });
+
+    const timing = await waitForStderrTiming(() => stderr);
+    const status = (await fetch(
+      `http://127.0.0.1:${listening.port}/daemon/status?detail=full`,
+      {
+        headers: { authorization: `Bearer ${TOKEN}` },
+      },
+    ).then((res) => {
+      if (!res.ok) {
+        throw new Error(`/daemon/status returned ${res.status}`);
+      }
+      return res.json();
+    })) as DaemonStatusResponse;
+
+    const startup = status.daemon?.startup;
+    const processToListenMs = startup?.processToListenMs;
+    const runQwenServeToListenMs = startup?.runQwenServeToListenMs;
+    const preheatStatus = startup?.preheat?.status;
+
+    expect(startup?.processStartedAt).toEqual(expect.any(String));
+    expect(startup?.listenerReadyAt).toEqual(expect.any(String));
+    expect(processToListenMs).toEqual(Number(timing[1]));
+    expect(runQwenServeToListenMs).toEqual(Number(timing[2]));
+    expect(processToListenMs).toEqual(expect.any(Number));
+    expect(runQwenServeToListenMs).toEqual(expect.any(Number));
+    expect(processToListenMs).toBeGreaterThanOrEqual(runQwenServeToListenMs!);
+    expect(preheatStatus).toEqual(expect.any(String));
+    expect(PREHEAT_STATUSES).toContain(preheatStatus as PreheatStatus);
+
+    return {
+      iteration,
+      measured,
+      externalCommandToListeningMs: listening.externalCommandToListeningMs,
+      processToListenMs: processToListenMs!,
+      runQwenServeToListenMs: runQwenServeToListenMs!,
+      preheatStatus: preheatStatus!,
+      port: listening.port,
+      stdoutListeningLine: listening.line,
+    };
+  } finally {
+    if (child) await terminate(child);
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+}
+
+(SKIP ? describe.skip : describe)(
+  'qwen serve daemon startup benchmark',
+  { retry: 0 },
+  () => {
+    it(
+      'measures built CLI startup to listener readiness',
+      async () => {
+        const total = WARMUP_ITERATIONS + ITERATIONS;
+        for (let i = 0; i < total; i++) {
+          const measured = i >= WARMUP_ITERATIONS;
+          const run = await runStartupIteration(i, measured);
+          snapshot.runs.push(run);
+          console.log(
+            `[daemon-startup] ${measured ? 'run' : 'warmup'} ${i}: ` +
+              `external=${run.externalCommandToListeningMs}ms ` +
+              `process=${run.processToListenMs}ms ` +
+              `runQwenServe=${run.runQwenServeToListenMs}ms ` +
+              `preheat=${run.preheatStatus}`,
+          );
+        }
+
+        const measuredRuns = snapshot.runs.filter((run) => run.measured);
+        snapshot.externalCommandToListening = percentiles(
+          measuredRuns.map((run) => run.externalCommandToListeningMs),
+        );
+        snapshot.processToListen = percentiles(
+          measuredRuns.map((run) => run.processToListenMs),
+        );
+        snapshot.runQwenServeToListen = percentiles(
+          measuredRuns.map((run) => run.runQwenServeToListenMs),
+        );
+
+        expect(snapshot.externalCommandToListening.count).toBe(ITERATIONS);
+        expect(snapshot.externalCommandToListening.p99).toBeLessThan(
+          EXTERNAL_P99_MAX_MS,
+        );
+      },
+      (WARMUP_ITERATIONS + ITERATIONS) * (BOOT_TIMEOUT_MS + 5_000),
+    );
+
+    afterAll(() => {
+      if (SKIP || snapshot.runs.length === 0) return;
+
+      console.log('\n[daemon-startup] ---- summary ----');
+      console.log(
+        `  External command -> listening: ${formatPercentiles(
+          snapshot.externalCommandToListening,
+        )}`,
+      );
+      console.log(
+        `  process -> listening:          ${formatPercentiles(
+          snapshot.processToListen,
+        )}`,
+      );
+      console.log(
+        `  runQwenServe -> listening:     ${formatPercentiles(
+          snapshot.runQwenServeToListen,
+        )}`,
+      );
+      console.log('[daemon-startup] ---- end summary ----\n');
+
+      writeSnapshotArtifacts(
+        OUTPUT_DIR,
+        'daemon-startup-benchmark',
+        snapshot,
+        renderMarkdown(snapshot),
+        'daemon-startup',
+      );
+    });
+  },
+);
+
+function renderMarkdown(s: StartupBenchmarkSnapshot): string {
+  const lines = [
+    '# qwen serve daemon startup benchmark',
+    '',
+    `Captured: ${s.capturedAt}`,
+    `Git: ${s.gitCommit ?? 'unknown'}`,
+    `Platform: ${s.platform.os}/${s.platform.arch} node=${s.platform.nodeVersion}`,
+    `CLI: ${s.cliBin}`,
+    `Iterations: ${s.config.iterations}  Warmup: ${s.config.warmupIterations}`,
+    '',
+    `> ${s.notes.join(' ')}`,
+    '',
+    '## Summary',
+    '',
+    `- External command -> listening: ${formatPercentiles(
+      s.externalCommandToListening,
+    )}`,
+    `- process -> listening: ${formatPercentiles(s.processToListen)}`,
+    `- runQwenServe -> listening: ${formatPercentiles(s.runQwenServeToListen)}`,
+    '',
+    '## Runs',
+    '',
+    '| Iteration | Measured | External wall | processToListen | runQwenServeToListen | Preheat |',
+    '|---:|:---:|---:|---:|---:|---|',
+  ];
+
+  for (const run of s.runs) {
+    lines.push(
+      `| ${run.iteration} | ${run.measured ? 'yes' : 'warmup'} | ` +
+        `${run.externalCommandToListeningMs}ms | ${run.processToListenMs}ms | ` +
+        `${run.runQwenServeToListenMs}ms | ${run.preheatStatus} |`,
+    );
+  }
+
+  lines.push(
+    '',
+    '## Scope',
+    '',
+    'This benchmark stops at the stdout listening line and does not create a daemon session. It records the preheat state visible at listen time, but preheat completion is not part of the primary metric. Use `qwen-daemon-vs-cli-benchmark.test.ts` for first-session, memory, and prompt metrics.',
+    '',
+  );
+  return lines.join('\n');
+}


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

Adds a gated integration benchmark for daemon startup that measures the built CLI `qwen serve` cold path from process spawn to the stdout listening line. The benchmark records external wall time, validates the daemon's startup timing fields from stderr and `/daemon/status`, records the preheat state visible at listener readiness, and writes JSON/Markdown artifacts for comparison runs.

## Why it's needed

The daemon startup work now has a repeatable measurement for listener readiness that is separate from first-session ACP/runtime costs. This gives reviewers and future changes a focused way to verify whether startup changes affect the daemon becoming ready to accept HTTP traffic.

## Reviewer Test Plan

### How to verify

Run `npm run build && npm run bundle` so `dist/cli.js` reflects the current checkout, then run `npx vitest run --root ./integration-tests cli/qwen-daemon-startup-benchmark.test.ts` and confirm the benchmark is skipped by default. To measure daemon startup, run `QWEN_BENCHMARK_ENABLED=1 QWEN_SANDBOX=false TEST_CLI_PATH=$PWD/dist/cli.js npx vitest run --root ./integration-tests cli/qwen-daemon-startup-benchmark.test.ts` and confirm it starts `qwen serve`, validates stderr and `/daemon/status` startup fields, prints percentile summaries, and writes benchmark artifacts under `.integration-tests/`.

### Evidence (Before & After)

N/A for UI. Local benchmark run against `dist/cli.js` passed with 5 measured samples: external command -> listening p50=818ms, process -> listening p50=102ms, runQwenServe -> listening p50=26ms.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

macOS darwin/arm64, Node v22.22.3, local `dist/cli.js` bundle, `QWEN_SANDBOX=false` for the enabled benchmark run.

## Risk & Scope

- Main risk or tradeoff: timing benchmarks are environment-sensitive, so this benchmark is gated behind `QWEN_BENCHMARK_ENABLED=1` and uses a generous default threshold to avoid affecting normal CI.
- Not validated / out of scope: first `POST /session`, prompt latency, and preheat completion timing remain covered by the broader daemon benchmark rather than this startup-only test.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

新增一个带开关的 daemon 启动集成 benchmark，用打包后的 CLI 测量 `qwen serve` 从进程启动到 stdout listening 行出现的冷启动路径。该 benchmark 会记录外部 wall time，校验 stderr 和 `/daemon/status` 中的 daemon startup timing 字段，记录 listener ready 时可见的 preheat 状态，并输出 JSON/Markdown artifact 方便对比多次运行。

## Why it's needed

daemon 启动优化现在需要一个可重复的 listener readiness 测量方式，并且要和首个 session 的 ACP/runtime 成本分开。这样 review 和后续改动可以聚焦验证启动变更是否影响 daemon 到达可接受 HTTP 流量的时间。

## Reviewer Test Plan

### How to verify

先运行 `npm run build && npm run bundle`，确保 `dist/cli.js` 对应当前 checkout，然后运行 `npx vitest run --root ./integration-tests cli/qwen-daemon-startup-benchmark.test.ts`，确认 benchmark 默认会被跳过。要实际测量 daemon 启动，运行 `QWEN_BENCHMARK_ENABLED=1 QWEN_SANDBOX=false TEST_CLI_PATH=$PWD/dist/cli.js npx vitest run --root ./integration-tests cli/qwen-daemon-startup-benchmark.test.ts`，确认它会启动 `qwen serve`，校验 stderr 和 `/daemon/status` 的 startup 字段，打印 percentile summary，并在 `.integration-tests/` 下写出 benchmark artifacts。

### Evidence (Before & After)

UI 证据不适用。本地使用 `dist/cli.js` 运行 benchmark 通过，5 次 measured 样本结果为：external command -> listening p50=818ms，process -> listening p50=102ms，runQwenServe -> listening p50=26ms。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

macOS darwin/arm64，Node v22.22.3，本地 `dist/cli.js` bundle，启用 benchmark 时使用 `QWEN_SANDBOX=false`。

## Risk & Scope

- Main risk or tradeoff: timing benchmark 会受运行环境影响，因此该 benchmark 由 `QWEN_BENCHMARK_ENABLED=1` 显式开启，并使用宽松的默认阈值，避免影响常规 CI。
- Not validated / out of scope: 首个 `POST /session`、prompt latency 和 preheat 完成耗时仍由更完整的 daemon benchmark 覆盖，不放入这个 startup-only 测试。
- Breaking changes / migration notes: 无。

## Linked Issues

N/A

</details>
