### PR TITLE
feat(cli): Add skill usage stats

### DIFF
--- a/docs/developers/daemon/08-session-lifecycle.md
+++ b/docs/developers/daemon/08-session-lifecycle.md
@@ -217,7 +217,9 @@ closes bridge sessions, and deletes transcript files. It uses
 
 `GET /session/:id/stats` returns usage statistics: model metrics
 (input/output tokens, cache reads/writes, total cost), per-tool call counts and
-latencies, and file edit counts.
+latencies, file edit counts, and per-skill invocation counts for the live
+session. The `skills` block reflects skill body loads and skill slash commands
+within this session only; it is not a cross-session activity aggregate.
 
 ### Session Tasks (`session_tasks` capability tag)
 

--- a/docs/users/features/commands.md
+++ b/docs/users/features/commands.md
@@ -38,22 +38,22 @@ These commands help you save, restore, and summarize work progress.
 
 Commands for adjusting interface appearance and work environment.
 
-| Command              | Description                                                                                                                                                                       | Usage Examples                          |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
-| `/clear`             | Clear terminal screen content                                                                                                                                                     | `/clear` (shortcut: `Ctrl+L`)           |
-| `/context`           | Show context window usage breakdown                                                                                                                                               | `/context`                              |
-| → `detail`           | Show per-item context usage breakdown                                                                                                                                             | `/context detail`                       |
-| `/history`           | Control history display preferences and visibility                                                                                                                               | `/history collapse-on-resume`, `/history expand-on-resume`, `/history expand-now` |
-| `/diff`              | Open an interactive diff viewer showing uncommitted changes and per-turn diffs. Use ←/→ to switch between current git diff and individual conversation turns, ↑/↓ to browse files | `/diff`                                 |
-| `/theme`             | Change Qwen Code visual theme                                                                                                                                                     | `/theme`                                |
-| `/vim`               | Turn input area Vim editing mode on/off                                                                                                                                           | `/vim`                                  |
-| `/voice`             | Toggle voice dictation input                                                                                                                                                      | `/voice`, `/voice status`               |
-| `/directory`         | Manage multi-directory support workspace                                                                                                                                          | `/dir add ./src,./tests`                |
-| `/cd`                | Move this session to a new working directory                                                                                                                                      | `/cd ../other-project`                  |
-| `/editor`            | Open dialog to select supported editor                                                                                                                                            | `/editor`                               |
-| `/statusline`        | Open interactive [status line](./status-line.md) preset dialog                                                                                                                    | `/statusline`                           |
-| `/statusline <text>` | Generate a command-mode [status line](./status-line.md) via agent                                                                                                                 | `/statusline show model and git branch` |
-| `/terminal-setup`    | Configure terminal keybindings for multiline input                                                                                                                                | `/terminal-setup`                       |
+| Command              | Description                                                                                                                                                                       | Usage Examples                                                                    |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `/clear`             | Clear terminal screen content                                                                                                                                                     | `/clear` (shortcut: `Ctrl+L`)                                                     |
+| `/context`           | Show context window usage breakdown                                                                                                                                               | `/context`                                                                        |
+| → `detail`           | Show per-item context usage breakdown                                                                                                                                             | `/context detail`                                                                 |
+| `/history`           | Control history display preferences and visibility                                                                                                                                | `/history collapse-on-resume`, `/history expand-on-resume`, `/history expand-now` |
+| `/diff`              | Open an interactive diff viewer showing uncommitted changes and per-turn diffs. Use ←/→ to switch between current git diff and individual conversation turns, ↑/↓ to browse files | `/diff`                                                                           |
+| `/theme`             | Change Qwen Code visual theme                                                                                                                                                     | `/theme`                                                                          |
+| `/vim`               | Turn input area Vim editing mode on/off                                                                                                                                           | `/vim`                                                                            |
+| `/voice`             | Toggle voice dictation input                                                                                                                                                      | `/voice`, `/voice status`                                                         |
+| `/directory`         | Manage multi-directory support workspace                                                                                                                                          | `/dir add ./src,./tests`                                                          |
+| `/cd`                | Move this session to a new working directory                                                                                                                                      | `/cd ../other-project`                                                            |
+| `/editor`            | Open dialog to select supported editor                                                                                                                                            | `/editor`                                                                         |
+| `/statusline`        | Open interactive [status line](./status-line.md) preset dialog                                                                                                                    | `/statusline`                                                                     |
+| `/statusline <text>` | Generate a command-mode [status line](./status-line.md) via agent                                                                                                                 | `/statusline show model and git branch`                                           |
+| `/terminal-setup`    | Configure terminal keybindings for multiline input                                                                                                                                | `/terminal-setup`                                                                 |
 
 ### 1.3 Language Settings
 
@@ -72,36 +72,36 @@ Commands specifically for controlling interface and output language.
 
 Commands for managing AI tools and models.
 
-| Command          | Description                                   | Usage Examples                                |
-| ---------------- | --------------------------------------------- | --------------------------------------------- |
-| `/mcp`           | List configured MCP servers and tools         | `/mcp`, `/mcp desc`                           |
-| `/import-config` | Import MCP servers from Claude configs         | `/import-config claude-code`, `/import-config claude-desktop --scope project` |
-| `/tools`         | Display currently available tool list         | `/tools`, `/tools desc`                       |
-| `/skills`        | List and run available skills                 | `/skills`, `/skills <name>`                   |
-| `/plan`          | Switch to plan mode or exit plan mode         | `/plan`, `/plan <task>`, `/plan exit`         |
-| `/approval-mode` | Change approval mode for tool usage           | `/approval-mode <mode (auto-edit)> --project` |
-| →`plan`          | Analysis only, no execution                   | Secure review                                 |
-| →`default`       | Require approval for edits                    | Daily use                                     |
-| →`auto-edit`     | Automatically approve edits                   | Trusted environment                           |
-| →`auto`          | Classifier-evaluated approval                 | Autonomous sessions with safety guardrails    |
-| →`yolo`          | Automatically approve all                     | Quick prototyping                             |
-| `/model`         | Switch model used in current session          | `/model`, `/model <model-id>` (switch immediately) |
-| `/model --fast`  | Set a lighter model for prompt suggestions    | `/model --fast qwen3-coder-flash`             |
-| `/model --voice` | Set the model used for voice transcription    | `/model --voice <model-id>`                   |
-| `/extensions`    | List all active extensions in current session | `/extensions`                                 |
-| `/memory`        | Open the Memory Manager dialog                | `/memory`                                     |
-| `/remember`      | Save a durable memory                         | `/remember Prefer terse responses`            |
-| `/forget`        | Remove matching entries from auto-memory      | `/forget <query>`                             |
-| `/dream`         | Manually run auto-memory consolidation        | `/dream`                                      |
-| `/hooks`         | Manage Qwen Code hooks                        | `/hooks`, `/hooks list`                       |
-| `/permissions`   | Manage permission rules                       | `/permissions`                                |
-| `/agents`        | Manage subagents                              | `/agents manage`, `/agents create`            |
-| `/arena`         | Manage Arena sessions                         | `/arena start`, `/arena status`               |
-| `/goal`          | Set a goal — keep working until condition met | `/goal <condition>`, `/goal clear`            |
-| `/tasks`         | List background tasks                         | `/tasks`                                      |
-| `/workflows`     | Inspect workflow runs                         | `/workflows`, `/workflows <runId>`            |
-| `/lsp`           | Show LSP server status                        | `/lsp`                                        |
-| `/trust`         | Manage folder trust settings                  | `/trust`                                      |
+| Command          | Description                                   | Usage Examples                                                                |
+| ---------------- | --------------------------------------------- | ----------------------------------------------------------------------------- |
+| `/mcp`           | List configured MCP servers and tools         | `/mcp`, `/mcp desc`                                                           |
+| `/import-config` | Import MCP servers from Claude configs        | `/import-config claude-code`, `/import-config claude-desktop --scope project` |
+| `/tools`         | Display currently available tool list         | `/tools`, `/tools desc`                                                       |
+| `/skills`        | List and run available skills                 | `/skills`, `/skills <name>`                                                   |
+| `/plan`          | Switch to plan mode or exit plan mode         | `/plan`, `/plan <task>`, `/plan exit`                                         |
+| `/approval-mode` | Change approval mode for tool usage           | `/approval-mode <mode (auto-edit)> --project`                                 |
+| →`plan`          | Analysis only, no execution                   | Secure review                                                                 |
+| →`default`       | Require approval for edits                    | Daily use                                                                     |
+| →`auto-edit`     | Automatically approve edits                   | Trusted environment                                                           |
+| →`auto`          | Classifier-evaluated approval                 | Autonomous sessions with safety guardrails                                    |
+| →`yolo`          | Automatically approve all                     | Quick prototyping                                                             |
+| `/model`         | Switch model used in current session          | `/model`, `/model <model-id>` (switch immediately)                            |
+| `/model --fast`  | Set a lighter model for prompt suggestions    | `/model --fast qwen3-coder-flash`                                             |
+| `/model --voice` | Set the model used for voice transcription    | `/model --voice <model-id>`                                                   |
+| `/extensions`    | List all active extensions in current session | `/extensions`                                                                 |
+| `/memory`        | Open the Memory Manager dialog                | `/memory`                                                                     |
+| `/remember`      | Save a durable memory                         | `/remember Prefer terse responses`                                            |
+| `/forget`        | Remove matching entries from auto-memory      | `/forget <query>`                                                             |
+| `/dream`         | Manually run auto-memory consolidation        | `/dream`                                                                      |
+| `/hooks`         | Manage Qwen Code hooks                        | `/hooks`, `/hooks list`                                                       |
+| `/permissions`   | Manage permission rules                       | `/permissions`                                                                |
+| `/agents`        | Manage subagents                              | `/agents manage`, `/agents create`                                            |
+| `/arena`         | Manage Arena sessions                         | `/arena start`, `/arena status`                                               |
+| `/goal`          | Set a goal — keep working until condition met | `/goal <condition>`, `/goal clear`                                            |
+| `/tasks`         | List background tasks                         | `/tasks`                                                                      |
+| `/workflows`     | Inspect workflow runs                         | `/workflows`, `/workflows <runId>`                                            |
+| `/lsp`           | Show LSP server status                        | `/lsp`                                                                        |
+| `/trust`         | Manage folder trust settings                  | `/trust`                                                                      |
 
 ### 1.5 Built-in Skills
 
@@ -299,6 +299,7 @@ Commands for obtaining information and performing system settings.
 | `/stats`        | Open interactive usage statistics dashboard with three tabs: Session (live metrics), Activity (heatmap, token trend, project ranking), and Efficiency (cache rate, tool leaderboard, model comparison). Use `tab` to switch tabs, `r` to cycle time ranges, `←→` to pan months, `esc` to close. | `/stats`                         |
 | `/stats model`  | Show per-model token breakdown and estimated cost                                                                                                                                                                                                                                               | `/stats model`                   |
 | `/stats tools`  | Show per-tool call counts                                                                                                                                                                                                                                                                       | `/stats tools`                   |
+| `/stats skills` | Show per-skill call counts for the current live session. This does not include cross-session daily/monthly activity.                                                                                                                                                                            | `/stats skills`                  |
 | `/settings`     | Open settings editor                                                                                                                                                                                                                                                                            | `/settings`                      |
 | `/auth`         | Change authentication method                                                                                                                                                                                                                                                                    | `/auth`                          |
 | `/doctor`       | Run installation and environment diagnostics                                                                                                                                                                                                                                                    | `/doctor`, `/doctor memory`      |

--- a/packages/acp-bridge/src/status.ts
+++ b/packages/acp-bridge/src/status.ts
@@ -587,6 +587,12 @@ export interface ServeSessionStatsToolByName {
   };
 }
 
+export interface ServeSessionStatsSkillByName {
+  count: number;
+  success: number;
+  fail: number;
+}
+
 export interface ServeSessionStatsStatus {
   v: typeof STATUS_SCHEMA_VERSION;
   sessionId: string;
@@ -605,6 +611,12 @@ export interface ServeSessionStatsStatus {
   files: {
     totalLinesAdded: number;
     totalLinesRemoved: number;
+  };
+  skills: {
+    totalCalls: number;
+    totalSuccess: number;
+    totalFail: number;
+    byName: Record<string, ServeSessionStatsSkillByName>;
   };
 }
 

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -4255,6 +4255,26 @@ class QwenAgent implements Agent {
       };
     }
 
+    const skillMetrics = metrics.skills ?? {
+      totalCalls: 0,
+      totalSuccess: 0,
+      totalFail: 0,
+      byName: {},
+    };
+    const skillsByName: ServeSessionStatsStatus['skills']['byName'] = {};
+    for (const [name, skill] of Object.entries(skillMetrics.byName)) {
+      Object.defineProperty(skillsByName, name, {
+        value: {
+          count: skill.count,
+          success: skill.success,
+          fail: skill.fail,
+        },
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    }
+
     return {
       v: STATUS_SCHEMA_VERSION,
       sessionId,
@@ -4273,6 +4293,12 @@ class QwenAgent implements Agent {
       files: {
         totalLinesAdded: metrics.files.totalLinesAdded,
         totalLinesRemoved: metrics.files.totalLinesRemoved,
+      },
+      skills: {
+        totalCalls: skillMetrics.totalCalls,
+        totalSuccess: skillMetrics.totalSuccess,
+        totalFail: skillMetrics.totalFail,
+        byName: skillsByName,
       },
     };
   }

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -1883,6 +1883,7 @@ export default {
     'Tip: For a full token breakdown, run `/stats model`.',
   'Model Stats For Nerds': 'Model Stats For Nerds',
   'Tool Stats For Nerds': 'Tool Stats For Nerds',
+  'Skill Stats For Nerds': 'Skill Stats For Nerds',
   Metric: 'Metric',
   API: 'API',
   Requests: 'Requests',
@@ -1897,6 +1898,7 @@ export default {
   'No API calls have been made in this session.':
     'No API calls have been made in this session.',
   'Tool Name': 'Tool Name',
+  'Skill Name': 'Skill Name',
   Calls: 'Calls',
   'Success Rate': 'Success Rate',
   'Avg Duration': 'Avg Duration',
@@ -1908,6 +1910,8 @@ export default {
   ' Overall Agreement Rate:': ' Overall Agreement Rate:',
   'No tool calls have been made in this session.':
     'No tool calls have been made in this session.',
+  'No skill calls have been made in this session.':
+    'No skill calls have been made in this session.',
   'Session start time is unavailable, cannot calculate stats.':
     'Session start time is unavailable, cannot calculate stats.',
 
@@ -2425,6 +2429,10 @@ export default {
     'Tokens — prompt: {{prompt}}, output: {{output}}',
   'Tool calls: {{total}} ({{success}} ok, {{fail}} fail)':
     'Tool calls: {{total}} ({{success}} ok, {{fail}} fail)',
+  'Skill calls: {{total}} ({{success}} ok, {{fail}} fail)':
+    'Skill calls: {{total}} ({{success}} ok, {{fail}} fail)',
+  '  {{name}}: {{count}} ({{success}} ok, {{fail}} fail)':
+    '  {{name}}: {{count}} ({{success}} ok, {{fail}} fail)',
   'Files: +{{added}} / -{{removed}} lines':
     'Files: +{{added}} / -{{removed}} lines',
   prompt: 'prompt',
@@ -2433,6 +2441,7 @@ export default {
   'Estimated cost: ${{cost}}': 'Estimated cost: ${{cost}}',
   'No model usage data yet.': 'No model usage data yet.',
   'No tool usage data yet.': 'No tool usage data yet.',
+  'No skill usage data yet.': 'No skill usage data yet.',
 
   // StatsDialog
   Models: 'Models',

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -725,6 +725,8 @@ export default {
     'Show model-specific usage statistics.',
   'Show tool-specific usage statistics.':
     'Show tool-specific usage statistics.',
+  'Show skill-specific usage statistics.':
+    'Show skill-specific usage statistics.',
   'Show daily token usage statistics.': 'Show daily token usage statistics.',
   'Show monthly token usage statistics.':
     'Show monthly token usage statistics.',

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -651,6 +651,7 @@ export default {
   'toggle vim mode on/off': '切換 vim 模式開關',
   'Show model-specific usage statistics.': '顯示模型相關的使用統計資訊',
   'Show tool-specific usage statistics.': '顯示工具相關的使用統計資訊',
+  'Show skill-specific usage statistics.': '顯示技能相關的使用統計資訊',
   'Show daily token usage statistics.': '顯示每日 token 使用統計資訊',
   'Show monthly token usage statistics.': '顯示每月 token 使用統計資訊',
   'Export token usage statistics to CSV or JSON.':

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -1611,6 +1611,7 @@ export default {
     '提示：要查看完整的 token 明細，請運行 `/stats model`',
   'Model Stats For Nerds': '模型統計（技術細節）',
   'Tool Stats For Nerds': '工具統計（技術細節）',
+  'Skill Stats For Nerds': '技能統計（技術細節）',
   Metric: '指標',
   API: 'API',
   Session: '會話',
@@ -1645,6 +1646,7 @@ export default {
   'No API calls have been made in this session.':
     '本次會話中未進行任何 API 調用',
   'Tool Name': '工具名稱',
+  'Skill Name': '技能名稱',
   'Success Rate': '成功率',
   'Avg Duration': '平均耗時',
   'User Decision Summary': '用戶決策摘要',
@@ -1655,6 +1657,8 @@ export default {
   ' Overall Agreement Rate:': ' 總體同意率：',
   'No tool calls have been made in this session.':
     '本次會話中未進行任何工具調用',
+  'No skill calls have been made in this session.':
+    '本次會話中未進行任何技能調用',
   'Session start time is unavailable, cannot calculate stats.':
     '會話開始時間不可用，無法計算統計信息',
   'Command Format Migration': '命令格式遷移',
@@ -2053,6 +2057,7 @@ export default {
   Name: '名稱',
   'No model usage data yet.': '尚無模型使用資料。',
   'No tool usage data yet.': '尚無工具使用資料。',
+  'No skill usage data yet.': '尚無技能使用資料。',
   'Prompts: {{count}}': '提示：{{count}}',
   'Session duration: {{duration}}': '會話時長：{{duration}}',
   'Tokens \u2014 prompt: {{prompt}}, output: {{output}}':
@@ -2060,6 +2065,10 @@ export default {
   'Tool calls': '工具呼叫',
   'Tool calls: {{total}} ({{success}} ok, {{fail}} fail)':
     '工具呼叫：{{total}}（{{success}} 成功，{{fail}} 失敗）',
+  'Skill calls: {{total}} ({{success}} ok, {{fail}} fail)':
+    '技能呼叫：{{total}}（{{success}} 成功，{{fail}} 失敗）',
+  '  {{name}}: {{count}} ({{success}} ok, {{fail}} fail)':
+    '  {{name}}：{{count}}（{{success}} 成功，{{fail}} 失敗）',
   cached: '快取',
   days: '天',
   output: '輸出',

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -695,6 +695,7 @@ export default {
   'Show usage statistics dashboard.': '显示使用统计面板。',
   'Show model-specific usage statistics.': '显示模型相关的使用统计信息',
   'Show tool-specific usage statistics.': '显示工具相关的使用统计信息',
+  'Show skill-specific usage statistics.': '显示技能相关的使用统计信息',
   'Show daily token usage statistics.': '显示每日 token 使用统计信息',
   'Show monthly token usage statistics.': '显示每月 token 使用统计信息',
   'Export token usage statistics to CSV or JSON.':

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -1774,6 +1774,7 @@ export default {
     '提示：要查看完整的 token 明细，请运行 `/stats model`',
   'Model Stats For Nerds': '模型统计（技术细节）',
   'Tool Stats For Nerds': '工具统计（技术细节）',
+  'Skill Stats For Nerds': '技能统计（技术细节）',
   Metric: '指标',
   API: 'API',
   Session: '会话',
@@ -1808,6 +1809,7 @@ export default {
   'No API calls have been made in this session.':
     '本次会话中未进行任何 API 调用',
   'Tool Name': '工具名称',
+  'Skill Name': '技能名称',
   'Success Rate': '成功率',
   'Avg Duration': '平均耗时',
   'User Decision Summary': '用户决策摘要',
@@ -1818,6 +1820,8 @@ export default {
   ' Overall Agreement Rate:': ' 总体同意率：',
   'No tool calls have been made in this session.':
     '本次会话中未进行任何工具调用',
+  'No skill calls have been made in this session.':
+    '本次会话中未进行任何技能调用',
   'Session start time is unavailable, cannot calculate stats.':
     '会话开始时间不可用，无法计算统计信息',
 
@@ -2215,6 +2219,10 @@ export default {
     'Tokens — 输入：{{prompt}}，输出：{{output}}',
   'Tool calls: {{total}} ({{success}} ok, {{fail}} fail)':
     '工具调用：{{total}}（{{success}} 成功，{{fail}} 失败）',
+  'Skill calls: {{total}} ({{success}} ok, {{fail}} fail)':
+    '技能调用：{{total}}（{{success}} 成功，{{fail}} 失败）',
+  '  {{name}}: {{count}} ({{success}} ok, {{fail}} fail)':
+    '  {{name}}：{{count}}（{{success}} 成功，{{fail}} 失败）',
   'Files: +{{added}} / -{{removed}} lines':
     '文件：+{{added}} / -{{removed}} 行',
   prompt: '输入',
@@ -2223,6 +2231,7 @@ export default {
   'Estimated cost: ${{cost}}': '预估费用：${{cost}}',
   'No model usage data yet.': '暂无模型使用数据。',
   'No tool usage data yet.': '暂无工具使用数据。',
+  'No skill usage data yet.': '暂无技能使用数据。',
 
   // StatsDialog
   Models: '模型',

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -284,6 +284,12 @@ describe('runNonInteractive', () => {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
       },
+      skills: {
+        totalCalls: 0,
+        totalSuccess: 0,
+        totalFail: 0,
+        byName: {},
+      },
       ...overrides,
     };
   }

--- a/packages/cli/src/nonInteractiveCliCommands.test.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.test.ts
@@ -443,6 +443,31 @@ describe('handleSlashCommand', () => {
     });
   });
 
+  it('records failed SKILL commands when action throws', async () => {
+    const mockSkillCommand = {
+      name: 'review',
+      description: 'Review code',
+      kind: CommandKind.SKILL,
+      action: vi.fn().mockRejectedValue(new Error('boom')),
+    };
+    mockGetCommands.mockReturnValue([mockSkillCommand]);
+
+    await expect(
+      handleSlashCommand('/review', abortController, mockConfig, mockSettings),
+    ).rejects.toThrow('boom');
+
+    expect(
+      uiTelemetryService.getMetricsForSession('test-session').skills,
+    ).toEqual({
+      totalCalls: 1,
+      totalSuccess: 0,
+      totalFail: 1,
+      byName: {
+        review: { count: 1, success: 0, fail: 1 },
+      },
+    });
+  });
+
   it('records blocked SKILL submit_prompt commands as failures', async () => {
     mockFireUserPromptExpansionEvent.mockResolvedValue({
       getBlockingError: () => ({
@@ -470,6 +495,37 @@ describe('handleSlashCommand', () => {
     );
 
     expect(result.type).toBe('message');
+    expect(
+      uiTelemetryService.getMetricsForSession('test-session').skills,
+    ).toEqual({
+      totalCalls: 1,
+      totalSuccess: 0,
+      totalFail: 1,
+      byName: {
+        review: { count: 1, success: 0, fail: 1 },
+      },
+    });
+  });
+
+  it('records SKILL submit_prompt commands as failures when hooks throw', async () => {
+    mockFireUserPromptExpansionEvent.mockRejectedValue(
+      new Error('hook crash'),
+    );
+    const mockSkillCommand = {
+      name: 'review',
+      description: 'Review code',
+      kind: CommandKind.SKILL,
+      action: vi.fn().mockResolvedValue({
+        type: 'submit_prompt',
+        content: 'Review prompt',
+      }),
+    };
+    mockGetCommands.mockReturnValue([mockSkillCommand]);
+
+    await expect(
+      handleSlashCommand('/review', abortController, mockConfig, mockSettings),
+    ).rejects.toThrow('hook crash');
+
     expect(
       uiTelemetryService.getMetricsForSession('test-session').skills,
     ).toEqual({

--- a/packages/cli/src/nonInteractiveCliCommands.test.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   __resetActiveGoalStoreForTests,
   type Config,
+  uiTelemetryService,
 } from '@qwen-code/qwen-code-core';
 import type { LoadedSettings } from './config/settings.js';
 import { CommandKind, type ExecutionMode } from './ui/commands/types.js';
@@ -37,6 +38,7 @@ describe('handleSlashCommand', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    uiTelemetryService.reset();
     __resetActiveGoalStoreForTests();
     // getCommandsForMode applies real mode filtering on top of getCommands()
     mockGetCommandsForMode.mockImplementation((mode: ExecutionMode) =>
@@ -87,6 +89,7 @@ describe('handleSlashCommand', () => {
   });
 
   afterEach(() => {
+    uiTelemetryService.reset();
     __resetActiveGoalStoreForTests();
   });
 
@@ -371,6 +374,142 @@ describe('handleSlashCommand', () => {
     if (result.type === 'submit_prompt') {
       expect(result.content).toEqual([{ text: 'Custom prompt' }]);
     }
+  });
+
+  it('records successful SKILL submit_prompt commands in session metrics', async () => {
+    const mockSkillCommand = {
+      name: 'review',
+      description: 'Review code',
+      kind: CommandKind.SKILL,
+      skillDetail: { name: 'review-skill' },
+      action: vi.fn().mockResolvedValue({
+        type: 'submit_prompt',
+        content: [{ text: 'Review prompt' }],
+      }),
+    };
+    mockGetCommands.mockReturnValue([mockSkillCommand]);
+
+    const result = await handleSlashCommand(
+      '/review',
+      abortController,
+      mockConfig,
+      mockSettings,
+    );
+
+    expect(result.type).toBe('submit_prompt');
+    expect(
+      uiTelemetryService.getMetricsForSession('test-session').skills,
+    ).toEqual({
+      totalCalls: 1,
+      totalSuccess: 1,
+      totalFail: 0,
+      byName: {
+        'review-skill': { count: 1, success: 1, fail: 0 },
+      },
+    });
+  });
+
+  it('records ACP SKILL submit_prompt commands in session metrics', async () => {
+    vi.mocked(mockConfig.getExperimentalZedIntegration).mockReturnValue(true);
+    const mockSkillCommand = {
+      name: 'review',
+      description: 'Review code',
+      kind: CommandKind.SKILL,
+      supportedModes: ['acp'] as const,
+      action: vi.fn().mockResolvedValue({
+        type: 'submit_prompt',
+        content: [{ text: 'Review prompt' }],
+      }),
+    };
+    mockGetCommands.mockReturnValue([mockSkillCommand]);
+
+    const result = await handleSlashCommand(
+      '/review',
+      abortController,
+      mockConfig,
+      mockSettings,
+    );
+
+    expect(result.type).toBe('submit_prompt');
+    expect(
+      uiTelemetryService.getMetricsForSession('test-session').skills,
+    ).toEqual({
+      totalCalls: 1,
+      totalSuccess: 1,
+      totalFail: 0,
+      byName: {
+        review: { count: 1, success: 1, fail: 0 },
+      },
+    });
+  });
+
+  it('records blocked SKILL submit_prompt commands as failures', async () => {
+    mockFireUserPromptExpansionEvent.mockResolvedValue({
+      getBlockingError: () => ({
+        blocked: true,
+        reason: 'Blocked by policy',
+      }),
+      shouldStopExecution: () => false,
+    });
+    const mockSkillCommand = {
+      name: 'review',
+      description: 'Review code',
+      kind: CommandKind.SKILL,
+      action: vi.fn().mockResolvedValue({
+        type: 'submit_prompt',
+        content: 'Review prompt',
+      }),
+    };
+    mockGetCommands.mockReturnValue([mockSkillCommand]);
+
+    const result = await handleSlashCommand(
+      '/review',
+      abortController,
+      mockConfig,
+      mockSettings,
+    );
+
+    expect(result.type).toBe('message');
+    expect(
+      uiTelemetryService.getMetricsForSession('test-session').skills,
+    ).toEqual({
+      totalCalls: 1,
+      totalSuccess: 0,
+      totalFail: 1,
+      byName: {
+        review: { count: 1, success: 0, fail: 1 },
+      },
+    });
+  });
+
+  it('does not record FILE submit_prompt commands as skill metrics', async () => {
+    const mockFileCommand = {
+      name: 'custom',
+      description: 'Custom file command',
+      kind: CommandKind.FILE,
+      action: vi.fn().mockResolvedValue({
+        type: 'submit_prompt',
+        content: [{ text: 'Custom prompt' }],
+      }),
+    };
+    mockGetCommands.mockReturnValue([mockFileCommand]);
+
+    const result = await handleSlashCommand(
+      '/custom',
+      abortController,
+      mockConfig,
+      mockSettings,
+    );
+
+    expect(result.type).toBe('submit_prompt');
+    expect(
+      uiTelemetryService.getMetricsForSession('test-session').skills,
+    ).toEqual({
+      totalCalls: 0,
+      totalSuccess: 0,
+      totalFail: 0,
+      byName: {},
+    });
   });
 
   it('should fire UserPromptExpansion hooks for submit_prompt commands', async () => {

--- a/packages/cli/src/nonInteractiveCliCommands.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.ts
@@ -11,6 +11,7 @@ import {
   uiTelemetryService,
   type Config,
   createDebugLogger,
+  recordSkillInvocation,
 } from '@qwen-code/qwen-code-core';
 import { CommandService } from './services/CommandService.js';
 import { BuiltinCommandLoader } from './services/BuiltinCommandLoader.js';
@@ -21,6 +22,7 @@ import { McpPromptLoader } from './services/McpPromptLoader.js';
 import { SkillCommandLoader } from './services/SkillCommandLoader.js';
 import {
   type CommandContext,
+  CommandKind,
   type SlashCommand,
   type SlashCommandActionReturn,
   type ExecutionMode,
@@ -39,6 +41,10 @@ import {
 const debugLogger = createDebugLogger('NON_INTERACTIVE_COMMANDS');
 
 type CommandServiceInstance = Awaited<ReturnType<typeof CommandService.create>>;
+
+function getSkillCommandName(command: SlashCommand): string {
+  return command.skillDetail?.name ?? command.name;
+}
 
 /**
  * Result of handling a slash command in non-interactive mode.
@@ -465,7 +471,26 @@ export const handleSlashCommand = async (
     },
   };
 
-  const result = await commandToExecute.action(context, args);
+  const isSkillCommand = commandToExecute.kind === CommandKind.SKILL;
+  let skillInvocationRecorded = false;
+  const recordSkillCommandInvocation = (success: boolean) => {
+    if (!isSkillCommand || skillInvocationRecorded) {
+      return;
+    }
+    recordSkillInvocation(config, {
+      skillName: getSkillCommandName(commandToExecute),
+      success,
+    });
+    skillInvocationRecorded = true;
+  };
+
+  let result: SlashCommandActionReturn | void;
+  try {
+    result = await commandToExecute.action(context, args);
+  } catch (error) {
+    recordSkillCommandInvocation(false);
+    throw error;
+  }
 
   if (!result) {
     // Command executed but returned no result (e.g., void return)
@@ -477,16 +502,24 @@ export const handleSlashCommand = async (
   }
 
   if (result.type === 'submit_prompt') {
-    const hookResult = await fireUserPromptExpansionHook(
-      config,
-      commandToExecute.name,
-      args,
-      result.content,
-      abortController.signal,
-    );
+    let hookResult: Awaited<ReturnType<typeof fireUserPromptExpansionHook>>;
+    try {
+      hookResult = await fireUserPromptExpansionHook(
+        config,
+        commandToExecute.name,
+        args,
+        result.content,
+        abortController.signal,
+      );
+    } catch (error) {
+      recordSkillCommandInvocation(false);
+      throw error;
+    }
     if (hookResult.blockedResult) {
+      recordSkillCommandInvocation(false);
       return hookResult.blockedResult;
     }
+    recordSkillCommandInvocation(true);
     return handleCommandResult(
       { ...result, content: hookResult.content },
       outputHistoryItems,

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -87,6 +87,7 @@ import type {
   ServeSessionContextUsageStatus,
   ServeSessionHooksStatus,
   ServeSessionLspStatus,
+  ServeSessionStatsStatus,
   ServeSessionSupportedCommandsStatus,
   ServeSessionTasksStatus,
   ServeWorkspaceEnvStatus,
@@ -364,6 +365,7 @@ interface FakeBridgeOpts {
   sessionSupportedCommandsImpl?: (
     sessionId: string,
   ) => Promise<ServeSessionSupportedCommandsStatus>;
+  sessionStatsImpl?: (sessionId: string) => Promise<ServeSessionStatsStatus>;
   sessionTasksImpl?: (sessionId: string) => Promise<ServeSessionTasksStatus>;
   sessionLspImpl?: (sessionId: string) => Promise<ServeSessionLspStatus>;
   cancelSessionTaskImpl?: (
@@ -545,6 +547,7 @@ interface FakeBridge extends AcpSessionBridge {
   sessionContextCalls: string[];
   sessionContextUsageCalls: string[];
   sessionSupportedCommandsCalls: string[];
+  sessionStatsCalls: string[];
   sessionTasksCalls: string[];
   sessionLspCalls: string[];
   cancelSessionTaskCalls: Array<{
@@ -654,6 +657,7 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
   const extensionEvents: FakeBridge['extensionEvents'] = [];
   const sessionContextCalls: string[] = [];
   const sessionSupportedCommandsCalls: string[] = [];
+  const sessionStatsCalls: string[] = [];
   const sessionTasksCalls: string[] = [];
   const sessionLspCalls: string[] = [];
   const cancelSessionTaskCalls: FakeBridge['cancelSessionTaskCalls'] = [];
@@ -820,6 +824,34 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
       sessionId,
       availableCommands: [],
       availableSkills: [],
+    }));
+  const sessionStatsImpl =
+    opts.sessionStatsImpl ??
+    (async (sessionId) => ({
+      v: 1 as const,
+      sessionId,
+      workspaceCwd: WS_BOUND,
+      sessionStartTimeMs: 1_700_000_000_000,
+      durationMs: 0,
+      promptCount: 0,
+      models: {},
+      tools: {
+        totalCalls: 0,
+        totalSuccess: 0,
+        totalFail: 0,
+        totalDurationMs: 0,
+        byName: {},
+      },
+      files: {
+        totalLinesAdded: 0,
+        totalLinesRemoved: 0,
+      },
+      skills: {
+        totalCalls: 0,
+        totalSuccess: 0,
+        totalFail: 0,
+        byName: {},
+      },
     }));
   const sessionTasksImpl =
     opts.sessionTasksImpl ??
@@ -1010,6 +1042,7 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
     sessionContextCalls,
     sessionContextUsageCalls,
     sessionSupportedCommandsCalls,
+    sessionStatsCalls,
     sessionTasksCalls,
     sessionLspCalls,
     cancelSessionTaskCalls,
@@ -1199,6 +1232,10 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
     async getSessionSupportedCommandsStatus(sessionId) {
       sessionSupportedCommandsCalls.push(sessionId);
       return sessionSupportedCommandsImpl(sessionId);
+    },
+    async getSessionStatsStatus(sessionId) {
+      sessionStatsCalls.push(sessionId);
+      return sessionStatsImpl(sessionId);
     },
     async getSessionTasksStatus(sessionId) {
       sessionTasksCalls.push(sessionId);
@@ -4193,6 +4230,35 @@ describe('createServeApp', () => {
         ],
         availableSkills: ['review'],
       };
+      const stats: ServeSessionStatsStatus = {
+        v: 1,
+        sessionId: 's-1',
+        workspaceCwd: WS_BOUND,
+        sessionStartTimeMs: 1_700_000_000_000,
+        durationMs: 1200,
+        promptCount: 2,
+        models: {},
+        tools: {
+          totalCalls: 0,
+          totalSuccess: 0,
+          totalFail: 0,
+          totalDurationMs: 0,
+          byName: {},
+        },
+        files: {
+          totalLinesAdded: 0,
+          totalLinesRemoved: 0,
+        },
+        skills: {
+          totalCalls: 3,
+          totalSuccess: 2,
+          totalFail: 1,
+          byName: {
+            review: { count: 2, success: 1, fail: 1 },
+            testing: { count: 1, success: 1, fail: 0 },
+          },
+        },
+      };
       const tasks: ServeSessionTasksStatus = {
         v: 1,
         sessionId: 's-1',
@@ -4236,6 +4302,7 @@ describe('createServeApp', () => {
       const bridge = fakeBridge({
         sessionContextImpl: async () => context,
         sessionSupportedCommandsImpl: async () => commands,
+        sessionStatsImpl: async () => stats,
         sessionTasksImpl: async () => tasks,
         sessionLspImpl: async () => lsp,
       });
@@ -4251,6 +4318,9 @@ describe('createServeApp', () => {
       const commandsRes = await request(app)
         .get('/session/s-1/supported-commands')
         .set('Host', `127.0.0.1:${baseOpts.port}`);
+      const statsRes = await request(app)
+        .get('/session/s-1/stats')
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
       const tasksRes = await request(app)
         .get('/session/s-1/tasks')
         .set('Host', `127.0.0.1:${baseOpts.port}`);
@@ -4262,12 +4332,15 @@ describe('createServeApp', () => {
       expect(contextRes.body).toEqual(context);
       expect(commandsRes.status).toBe(200);
       expect(commandsRes.body).toEqual(commands);
+      expect(statsRes.status).toBe(200);
+      expect(statsRes.body).toEqual(stats);
       expect(tasksRes.status).toBe(200);
       expect(tasksRes.body).toEqual(tasks);
       expect(lspRes.status).toBe(200);
       expect(lspRes.body).toEqual(lsp);
       expect(bridge.sessionContextCalls).toEqual(['s-1']);
       expect(bridge.sessionSupportedCommandsCalls).toEqual(['s-1']);
+      expect(bridge.sessionStatsCalls).toEqual(['s-1']);
       expect(bridge.sessionTasksCalls).toEqual(['s-1']);
       expect(bridge.sessionLspCalls).toEqual(['s-1']);
     });
@@ -4370,6 +4443,9 @@ describe('createServeApp', () => {
         sessionSupportedCommandsImpl: async (sessionId) => {
           throw new SessionNotFoundError(sessionId);
         },
+        sessionStatsImpl: async (sessionId) => {
+          throw new SessionNotFoundError(sessionId);
+        },
         sessionTasksImpl: async (sessionId) => {
           throw new SessionNotFoundError(sessionId);
         },
@@ -4389,6 +4465,9 @@ describe('createServeApp', () => {
       const commandsRes = await request(app)
         .get('/session/missing/supported-commands')
         .set('Host', `127.0.0.1:${baseOpts.port}`);
+      const statsRes = await request(app)
+        .get('/session/missing/stats')
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
       const tasksRes = await request(app)
         .get('/session/missing/tasks')
         .set('Host', `127.0.0.1:${baseOpts.port}`);
@@ -4400,6 +4479,8 @@ describe('createServeApp', () => {
       expect(contextRes.body.sessionId).toBe('missing');
       expect(commandsRes.status).toBe(404);
       expect(commandsRes.body.sessionId).toBe('missing');
+      expect(statsRes.status).toBe(404);
+      expect(statsRes.body.sessionId).toBe('missing');
       expect(tasksRes.status).toBe(404);
       expect(tasksRes.body.sessionId).toBe('missing');
       expect(lspRes.status).toBe(404);

--- a/packages/cli/src/test-utils/mockCommandContext.ts
+++ b/packages/cli/src/test-utils/mockCommandContext.ts
@@ -92,6 +92,12 @@ export const createMockCommandContext = (
             byName: {},
           },
           files: { totalLinesAdded: 0, totalLinesRemoved: 0 },
+          skills: {
+            totalCalls: 0,
+            totalSuccess: 0,
+            totalFail: 0,
+            byName: {},
+          },
         },
         promptCount: 0,
       } as SessionStatsState,

--- a/packages/cli/src/ui/commands/statsCommand.test.ts
+++ b/packages/cli/src/ui/commands/statsCommand.test.ts
@@ -187,6 +187,22 @@ describe('statsCommand', () => {
     );
   });
 
+  it('should display skill stats when using the "skills" subcommand', () => {
+    const skillsSubCommand = statsCommand.subCommands?.find(
+      (sc) => sc.name === 'skills',
+    );
+    if (!skillsSubCommand?.action) throw new Error('Subcommand has no action');
+
+    skillsSubCommand.action(mockContext, '');
+
+    expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+      {
+        type: MessageType.SKILL_STATS,
+      },
+      expect.any(Number),
+    );
+  });
+
   describe('non-interactive mode', () => {
     let nonInteractiveContext: ReturnType<typeof createMockCommandContext>;
 
@@ -211,6 +227,38 @@ describe('statsCommand', () => {
       expect(result.content).toContain('Session duration');
       expect(result.content).toContain('Prompts');
       expect(nonInteractiveContext.ui.addItem).not.toHaveBeenCalled();
+    });
+
+    it('should return skill stats in text mode', async () => {
+      const skillsSubCommand = statsCommand.subCommands?.find(
+        (sc) => sc.name === 'skills',
+      );
+      if (!skillsSubCommand?.action)
+        throw new Error('Subcommand has no action');
+      nonInteractiveContext.session.stats.metrics.skills = {
+        totalCalls: 3,
+        totalSuccess: 2,
+        totalFail: 1,
+        byName: {
+          review: { count: 2, success: 1, fail: 1 },
+          testing: { count: 1, success: 1, fail: 0 },
+        },
+      };
+
+      const result = (await skillsSubCommand.action(
+        nonInteractiveContext,
+        '',
+      )) as {
+        type: string;
+        messageType: string;
+        content: string;
+      };
+
+      expect(result.type).toBe('message');
+      expect(result.messageType).toBe('info');
+      expect(result.content).toContain('Skill calls: 3 (2 ok, 1 fail)');
+      expect(result.content).toContain('review');
+      expect(result.content).toContain('testing');
     });
 
     it('should return info with zero duration if sessionStartTime is not available', async () => {

--- a/packages/cli/src/ui/commands/statsCommand.ts
+++ b/packages/cli/src/ui/commands/statsCommand.ts
@@ -23,6 +23,7 @@ import {
   formatTokenUsageSummaryAsJson,
   isSubpath,
   queryTokenUsage,
+  type SkillMetrics,
   type TokenUsageExportFormat,
   type TokenUsageGroupSummary,
   type TokenUsagePeriod,
@@ -30,6 +31,13 @@ import {
 } from '@qwen-code/qwen-code-core';
 
 const VALID_EXPORT_FORMATS = new Set<TokenUsageExportFormat>(['csv', 'json']);
+
+const EMPTY_SKILL_METRICS: SkillMetrics = {
+  totalCalls: 0,
+  totalSuccess: 0,
+  totalFail: 0,
+  byName: {},
+};
 
 type ParsedStatsExportArgs = {
   period: TokenUsagePeriod;
@@ -63,6 +71,34 @@ function formatGroupLines(
       })}`;
     }),
   ];
+}
+
+function formatSkillStats(skills: SkillMetrics): string {
+  const skillNames = Object.keys(skills.byName).sort((a, b) => {
+    const countDelta = skills.byName[b]!.count - skills.byName[a]!.count;
+    return countDelta !== 0 ? countDelta : a.localeCompare(b);
+  });
+
+  if (skillNames.length === 0) {
+    return t('No skill usage data yet.');
+  }
+
+  return [
+    t('Skill calls: {{total}} ({{success}} ok, {{fail}} fail)', {
+      total: String(skills.totalCalls),
+      success: String(skills.totalSuccess),
+      fail: String(skills.totalFail),
+    }),
+    ...skillNames.map((name) => {
+      const stats = skills.byName[name]!;
+      return t('  {{name}}: {{count}} ({{success}} ok, {{fail}} fail)', {
+        name,
+        count: String(stats.count),
+        success: String(stats.success),
+        fail: String(stats.fail),
+      });
+    }),
+  ].join('\n');
 }
 
 function formatTokenUsageSummary(summary: TokenUsageSummary): string {
@@ -636,7 +672,7 @@ export const statsCommand: SlashCommand = {
   get description() {
     return t('Show usage statistics dashboard.');
   },
-  argumentHint: '[model|tools|daily|monthly|export]',
+  argumentHint: '[model|tools|skills|daily|monthly|export]',
   kind: CommandKind.BUILT_IN,
   supportedModes: ['interactive', 'non_interactive', 'acp'] as const,
   action: (
@@ -760,6 +796,31 @@ export const statsCommand: SlashCommand = {
         context.ui.addItem(
           {
             type: MessageType.TOOL_STATS,
+          },
+          Date.now(),
+        );
+      },
+    },
+    {
+      name: 'skills',
+      get description() {
+        return t('Show skill-specific usage statistics.');
+      },
+      kind: CommandKind.BUILT_IN,
+      supportedModes: ['interactive', 'non_interactive', 'acp'] as const,
+      action: (context: CommandContext): MessageActionReturn | void => {
+        if (context.executionMode !== 'interactive') {
+          const skills =
+            context.session.stats.metrics.skills ?? EMPTY_SKILL_METRICS;
+          return {
+            type: 'message',
+            messageType: 'info',
+            content: formatSkillStats(skills),
+          };
+        }
+        context.ui.addItem(
+          {
+            type: MessageType.SKILL_STATS,
           },
           Date.now(),
         );

--- a/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
@@ -167,6 +167,21 @@ describe('<HistoryItemDisplay />', () => {
     );
   });
 
+  it('renders SkillStatsDisplay for "skill_stats" type', () => {
+    const item: HistoryItem = {
+      ...baseItem,
+      type: 'skill_stats',
+    };
+    const { lastFrame } = renderWithProviders(
+      <SessionStatsProvider>
+        <HistoryItemDisplay {...baseItem} item={item} />
+      </SessionStatsProvider>,
+    );
+    expect(lastFrame()).toContain(
+      'No skill calls have been made in this session.',
+    );
+  });
+
   it('renders SessionSummaryDisplay for "quit" type', () => {
     const item: HistoryItem = {
       ...baseItem,

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -41,6 +41,7 @@ import { AboutBox } from './AboutBox.js';
 import { StatsDisplay } from './StatsDisplay.js';
 import { ModelStatsDisplay } from './ModelStatsDisplay.js';
 import { ToolStatsDisplay } from './ToolStatsDisplay.js';
+import { SkillStatsDisplay } from './SkillStatsDisplay.js';
 import { SessionSummaryDisplay } from './SessionSummaryDisplay.js';
 import { Help } from './Help.js';
 import type { SlashCommand } from '../commands/types.js';
@@ -335,6 +336,9 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
       )}
       {itemForDisplay.type === 'tool_stats' && (
         <ToolStatsDisplay width={boxWidth} />
+      )}
+      {itemForDisplay.type === 'skill_stats' && (
+        <SkillStatsDisplay width={boxWidth} />
       )}
       {itemForDisplay.type === 'quit' && (
         <SessionSummaryDisplay

--- a/packages/cli/src/ui/components/SkillStatsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/SkillStatsDisplay.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render } from 'ink-testing-library';
+import { describe, expect, it, vi } from 'vitest';
+import { SkillStatsDisplay } from './SkillStatsDisplay.js';
+import * as SessionContext from '../contexts/SessionContext.js';
+import type { SessionMetrics } from '../contexts/SessionContext.js';
+
+vi.mock('../contexts/SessionContext.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof SessionContext>();
+  return {
+    ...actual,
+    useSessionStats: vi.fn(),
+  };
+});
+
+const useSessionStatsMock = vi.mocked(SessionContext.useSessionStats);
+
+function renderWithMockedStats(metrics: SessionMetrics) {
+  useSessionStatsMock.mockReturnValue({
+    stats: {
+      sessionId: 'session-1',
+      sessionStartTime: new Date(),
+      metrics,
+      lastPromptTokenCount: 0,
+      promptCount: 5,
+    },
+    getPromptCount: () => 5,
+    startNewPrompt: vi.fn(),
+    seedPromptCount: vi.fn(),
+    startNewSession: vi.fn(),
+  });
+
+  return render(<SkillStatsDisplay />);
+}
+
+function createMetrics(skills: SessionMetrics['skills']): SessionMetrics {
+  return {
+    models: {},
+    tools: {
+      totalCalls: 0,
+      totalSuccess: 0,
+      totalFail: 0,
+      totalDurationMs: 0,
+      totalDecisions: {
+        accept: 0,
+        reject: 0,
+        modify: 0,
+        auto_accept: 0,
+      },
+      byName: {},
+    },
+    files: {
+      totalLinesAdded: 0,
+      totalLinesRemoved: 0,
+    },
+    skills,
+  };
+}
+
+describe('<SkillStatsDisplay />', () => {
+  it('renders an empty state when no skills have been called', () => {
+    const { lastFrame } = renderWithMockedStats(
+      createMetrics({
+        totalCalls: 0,
+        totalSuccess: 0,
+        totalFail: 0,
+        byName: {},
+      }),
+    );
+
+    expect(lastFrame()).toContain(
+      'No skill calls have been made in this session.',
+    );
+  });
+
+  it('renders per-skill call counts and outcomes', () => {
+    const { lastFrame } = renderWithMockedStats(
+      createMetrics({
+        totalCalls: 3,
+        totalSuccess: 2,
+        totalFail: 1,
+        byName: {
+          review: { count: 2, success: 1, fail: 1 },
+          testing: { count: 1, success: 1, fail: 0 },
+        },
+      }),
+    );
+
+    const output = lastFrame();
+    expect(output).toContain('Skill Stats For Nerds');
+    expect(output).toContain('review');
+    expect(output).toContain('testing');
+    expect(output).toContain('50.0%');
+    expect(output).toContain('100.0%');
+  });
+});

--- a/packages/cli/src/ui/components/SkillStatsDisplay.tsx
+++ b/packages/cli/src/ui/components/SkillStatsDisplay.tsx
@@ -1,0 +1,152 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { Box, Text } from 'ink';
+import type { SkillCallStats } from '@qwen-code/qwen-code-core';
+import { t } from '../../i18n/index.js';
+import { useSessionStats } from '../contexts/SessionContext.js';
+import { theme } from '../semantic-colors.js';
+import {
+  getStatusColor,
+  TOOL_SUCCESS_RATE_HIGH,
+  TOOL_SUCCESS_RATE_MEDIUM,
+} from '../utils/displayUtils.js';
+
+const SKILL_NAME_COL_WIDTH = 30;
+const CALLS_COL_WIDTH = 8;
+const SUCCESS_COL_WIDTH = 8;
+const FAIL_COL_WIDTH = 8;
+const SUCCESS_RATE_COL_WIDTH = 15;
+
+const StatRow: React.FC<{
+  name: string;
+  stats: SkillCallStats;
+}> = ({ name, stats }) => {
+  const successRate = stats.count > 0 ? (stats.success / stats.count) * 100 : 0;
+  const successColor = getStatusColor(successRate, {
+    green: TOOL_SUCCESS_RATE_HIGH,
+    yellow: TOOL_SUCCESS_RATE_MEDIUM,
+  });
+
+  return (
+    <Box>
+      <Box width={SKILL_NAME_COL_WIDTH}>
+        <Text color={theme.text.link}>{name}</Text>
+      </Box>
+      <Box width={CALLS_COL_WIDTH} justifyContent="flex-end">
+        <Text color={theme.text.primary}>{stats.count}</Text>
+      </Box>
+      <Box width={SUCCESS_COL_WIDTH} justifyContent="flex-end">
+        <Text color={theme.status.success}>{stats.success}</Text>
+      </Box>
+      <Box width={FAIL_COL_WIDTH} justifyContent="flex-end">
+        <Text color={stats.fail > 0 ? theme.status.error : theme.text.primary}>
+          {stats.fail}
+        </Text>
+      </Box>
+      <Box width={SUCCESS_RATE_COL_WIDTH} justifyContent="flex-end">
+        <Text color={successColor}>{successRate.toFixed(1)}%</Text>
+      </Box>
+    </Box>
+  );
+};
+
+interface SkillStatsDisplayProps {
+  width?: number;
+}
+
+export const SkillStatsDisplay: React.FC<SkillStatsDisplayProps> = ({
+  width,
+}) => {
+  const { stats } = useSessionStats();
+  const skills = stats.metrics.skills ?? {
+    totalCalls: 0,
+    totalSuccess: 0,
+    totalFail: 0,
+    byName: {},
+  };
+  const activeSkills = Object.entries(skills.byName)
+    .filter(([, metrics]) => metrics.count > 0)
+    .sort(([leftName, left], [rightName, right]) => {
+      const countDelta = right.count - left.count;
+      return countDelta !== 0 ? countDelta : leftName.localeCompare(rightName);
+    });
+
+  if (activeSkills.length === 0) {
+    return (
+      <Box
+        borderStyle="round"
+        borderColor={theme.border.default}
+        paddingY={1}
+        paddingX={2}
+        width={width}
+      >
+        <Text color={theme.text.primary}>
+          {t('No skill calls have been made in this session.')}
+        </Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      borderStyle="round"
+      borderColor={theme.border.default}
+      flexDirection="column"
+      paddingY={1}
+      paddingX={2}
+      width={width}
+    >
+      <Text bold color={theme.text.accent}>
+        {t('Skill Stats For Nerds')}
+      </Text>
+      <Box height={1} />
+
+      <Box>
+        <Box width={SKILL_NAME_COL_WIDTH}>
+          <Text bold color={theme.text.primary}>
+            {t('Skill Name')}
+          </Text>
+        </Box>
+        <Box width={CALLS_COL_WIDTH} justifyContent="flex-end">
+          <Text bold color={theme.text.primary}>
+            {t('Calls')}
+          </Text>
+        </Box>
+        <Box width={SUCCESS_COL_WIDTH} justifyContent="flex-end">
+          <Text bold color={theme.text.primary}>
+            {t('OK')}
+          </Text>
+        </Box>
+        <Box width={FAIL_COL_WIDTH} justifyContent="flex-end">
+          <Text bold color={theme.text.primary}>
+            {t('Fail')}
+          </Text>
+        </Box>
+        <Box width={SUCCESS_RATE_COL_WIDTH} justifyContent="flex-end">
+          <Text bold color={theme.text.primary}>
+            {t('Success Rate')}
+          </Text>
+        </Box>
+      </Box>
+
+      <Box
+        borderStyle="single"
+        borderBottom={true}
+        borderTop={false}
+        borderLeft={false}
+        borderRight={false}
+        borderColor={theme.border.default}
+        width="100%"
+      />
+
+      {activeSkills.map(([name, skillStats]) => (
+        <StatRow key={name} name={name} stats={skillStats} />
+      ))}
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/contexts/SessionContext.test.tsx
+++ b/packages/cli/src/ui/contexts/SessionContext.test.tsx
@@ -205,6 +205,70 @@ describe('SessionStatsContext', () => {
     expect(renderCount).toBe(3);
   });
 
+  it('should read metrics for the provided session id', () => {
+    uiTelemetryService.reset();
+    const contextRef: MutableRefObject<
+      ReturnType<typeof useSessionStats> | undefined
+    > = { current: undefined };
+
+    uiTelemetryService.recordSkillInvocation('review', true, 'session-a');
+    uiTelemetryService.recordSkillInvocation('testing', true, 'session-b');
+
+    render(
+      <SessionStatsProvider sessionId="session-a">
+        <TestHarness contextRef={contextRef} />
+      </SessionStatsProvider>,
+    );
+
+    expect(contextRef.current?.stats.metrics.skills).toEqual({
+      totalCalls: 1,
+      totalSuccess: 1,
+      totalFail: 0,
+      byName: {
+        review: { count: 1, success: 1, fail: 0 },
+      },
+    });
+
+    uiTelemetryService.reset();
+  });
+
+  it('should update when skill metrics are mutated in place', () => {
+    uiTelemetryService.reset();
+    const contextRef: MutableRefObject<
+      ReturnType<typeof useSessionStats> | undefined
+    > = { current: undefined };
+
+    let renderCount = 0;
+    const CountingTestHarness = () => {
+      contextRef.current = useSessionStats();
+      renderCount++;
+      return null;
+    };
+
+    render(
+      <SessionStatsProvider sessionId="session-a">
+        <CountingTestHarness />
+      </SessionStatsProvider>,
+    );
+    const initialRenderCount = renderCount;
+
+    act(() => {
+      uiTelemetryService.recordSkillInvocation('review', true, 'session-a');
+    });
+
+    expect(renderCount).toBeGreaterThan(initialRenderCount);
+    expect(contextRef.current?.stats.metrics.skills).toEqual({
+      totalCalls: 1,
+      totalSuccess: 1,
+      totalFail: 0,
+      byName: {
+        review: { count: 1, success: 1, fail: 0 },
+      },
+    });
+
+    uiTelemetryService.reset();
+  });
+
   it('should throw an error when useSessionStats is used outside of a provider', () => {
     // Suppress console.error for this test since we expect an error
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/packages/cli/src/ui/contexts/SessionContext.tsx
+++ b/packages/cli/src/ui/contexts/SessionContext.tsx
@@ -19,8 +19,17 @@ import type {
   ModelMetrics,
   ModelMetricsCore,
   ToolCallStats,
+  SkillCallStats,
+  SkillMetrics,
 } from '@qwen-code/qwen-code-core';
 import { uiTelemetryService } from '@qwen-code/qwen-code-core';
+
+const EMPTY_SKILL_METRICS: SkillMetrics = {
+  totalCalls: 0,
+  totalSuccess: 0,
+  totalFail: 0,
+  byName: {},
+};
 
 export enum ToolCallDecision {
   ACCEPT = 'accept',
@@ -93,6 +102,34 @@ function areToolCallStatsEqual(a: ToolCallStats, b: ToolCallStats): boolean {
   return true;
 }
 
+function areSkillCallStatsEqual(a: SkillCallStats, b: SkillCallStats): boolean {
+  return a.count === b.count && a.success === b.success && a.fail === b.fail;
+}
+
+function areSkillMetricsEqual(a: SkillMetrics, b: SkillMetrics): boolean {
+  if (
+    a.totalCalls !== b.totalCalls ||
+    a.totalSuccess !== b.totalSuccess ||
+    a.totalFail !== b.totalFail
+  ) {
+    return false;
+  }
+
+  const aKeys = Object.keys(a.byName);
+  const bKeys = Object.keys(b.byName);
+  if (aKeys.length !== bKeys.length) return false;
+
+  for (const key of aKeys) {
+    const skillA = a.byName[key];
+    const skillB = b.byName[key];
+    if (!skillB || !areSkillCallStatsEqual(skillA, skillB)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 function areMetricsEqual(a: SessionMetrics, b: SessionMetrics): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
@@ -142,6 +179,15 @@ function areMetricsEqual(a: SessionMetrics, b: SessionMetrics): boolean {
     if (!toolB || !areToolCallStatsEqual(toolA, toolB)) {
       return false;
     }
+  }
+
+  if (
+    !areSkillMetricsEqual(
+      a.skills ?? EMPTY_SKILL_METRICS,
+      b.skills ?? EMPTY_SKILL_METRICS,
+    )
+  ) {
+    return false;
   }
 
   // Compare models
@@ -194,6 +240,79 @@ interface SessionStatsContextValue {
   seedPromptCount: (count: number) => void;
 }
 
+function cloneSessionMetrics(metrics: SessionMetrics): SessionMetrics {
+  return {
+    models: Object.fromEntries(
+      Object.entries(metrics.models).map(([name, model]) => [
+        name,
+        {
+          api: { ...model.api },
+          tokens: { ...model.tokens },
+          bySource: Object.fromEntries(
+            Object.entries(model.bySource).map(([source, sourceMetrics]) => [
+              source,
+              {
+                api: { ...sourceMetrics.api },
+                tokens: { ...sourceMetrics.tokens },
+              },
+            ]),
+          ),
+        },
+      ]),
+    ),
+    tools: {
+      totalCalls: metrics.tools.totalCalls,
+      totalSuccess: metrics.tools.totalSuccess,
+      totalFail: metrics.tools.totalFail,
+      totalDurationMs: metrics.tools.totalDurationMs,
+      totalDecisions: { ...metrics.tools.totalDecisions },
+      byName: Object.fromEntries(
+        Object.entries(metrics.tools.byName).map(([name, stats]) => [
+          name,
+          {
+            count: stats.count,
+            success: stats.success,
+            fail: stats.fail,
+            durationMs: stats.durationMs,
+            decisions: { ...stats.decisions },
+          },
+        ]),
+      ),
+    },
+    files: {
+      totalLinesAdded: metrics.files.totalLinesAdded,
+      totalLinesRemoved: metrics.files.totalLinesRemoved,
+    },
+    ...(metrics.skills
+      ? {
+          skills: {
+            totalCalls: metrics.skills.totalCalls,
+            totalSuccess: metrics.skills.totalSuccess,
+            totalFail: metrics.skills.totalFail,
+            byName: Object.fromEntries(
+              Object.entries(metrics.skills.byName).map(([name, stats]) => [
+                name,
+                {
+                  count: stats.count,
+                  success: stats.success,
+                  fail: stats.fail,
+                },
+              ]),
+            ),
+          },
+        }
+      : {}),
+  };
+}
+
+function getMetricsForDisplay(sessionId: string): SessionMetrics {
+  return cloneSessionMetrics(
+    sessionId
+      ? uiTelemetryService.getMetricsForSession(sessionId)
+      : uiTelemetryService.getMetrics(),
+  );
+}
+
 // --- Context Definition ---
 
 const SessionStatsContext = createContext<SessionStatsContextValue | undefined>(
@@ -203,7 +322,7 @@ const SessionStatsContext = createContext<SessionStatsContextValue | undefined>(
 const createDefaultStats = (sessionId: string = ''): SessionStatsState => ({
   sessionId,
   sessionStartTime: new Date(),
-  metrics: uiTelemetryService.getMetrics(),
+  metrics: getMetricsForDisplay(sessionId),
   lastPromptTokenCount: 0,
   promptCount: 0,
 });
@@ -227,15 +346,18 @@ export const SessionStatsProvider: React.FC<{
       lastPromptTokenCount: number;
     }) => {
       setStats((prevState) => {
+        const nextMetrics = prevState.sessionId
+          ? getMetricsForDisplay(prevState.sessionId)
+          : cloneSessionMetrics(metrics);
         if (
           prevState.lastPromptTokenCount === lastPromptTokenCount &&
-          areMetricsEqual(prevState.metrics, metrics)
+          areMetricsEqual(prevState.metrics, nextMetrics)
         ) {
           return prevState;
         }
         return {
           ...prevState,
-          metrics,
+          metrics: nextMetrics,
           lastPromptTokenCount,
         };
       });

--- a/packages/cli/src/ui/contexts/SessionContext.tsx
+++ b/packages/cli/src/ui/contexts/SessionContext.tsx
@@ -241,68 +241,7 @@ interface SessionStatsContextValue {
 }
 
 function cloneSessionMetrics(metrics: SessionMetrics): SessionMetrics {
-  return {
-    models: Object.fromEntries(
-      Object.entries(metrics.models).map(([name, model]) => [
-        name,
-        {
-          api: { ...model.api },
-          tokens: { ...model.tokens },
-          bySource: Object.fromEntries(
-            Object.entries(model.bySource).map(([source, sourceMetrics]) => [
-              source,
-              {
-                api: { ...sourceMetrics.api },
-                tokens: { ...sourceMetrics.tokens },
-              },
-            ]),
-          ),
-        },
-      ]),
-    ),
-    tools: {
-      totalCalls: metrics.tools.totalCalls,
-      totalSuccess: metrics.tools.totalSuccess,
-      totalFail: metrics.tools.totalFail,
-      totalDurationMs: metrics.tools.totalDurationMs,
-      totalDecisions: { ...metrics.tools.totalDecisions },
-      byName: Object.fromEntries(
-        Object.entries(metrics.tools.byName).map(([name, stats]) => [
-          name,
-          {
-            count: stats.count,
-            success: stats.success,
-            fail: stats.fail,
-            durationMs: stats.durationMs,
-            decisions: { ...stats.decisions },
-          },
-        ]),
-      ),
-    },
-    files: {
-      totalLinesAdded: metrics.files.totalLinesAdded,
-      totalLinesRemoved: metrics.files.totalLinesRemoved,
-    },
-    ...(metrics.skills
-      ? {
-          skills: {
-            totalCalls: metrics.skills.totalCalls,
-            totalSuccess: metrics.skills.totalSuccess,
-            totalFail: metrics.skills.totalFail,
-            byName: Object.fromEntries(
-              Object.entries(metrics.skills.byName).map(([name, stats]) => [
-                name,
-                {
-                  count: stats.count,
-                  success: stats.success,
-                  fail: stats.fail,
-                },
-              ]),
-            ),
-          },
-        }
-      : {}),
-  };
+  return structuredClone(metrics);
 }
 
 function getMetricsForDisplay(sessionId: string): SessionMetrics {

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -30,17 +30,20 @@ import {
   makeFakeConfig,
   MCPServerStatus,
   updateMCPServerStatus,
+  recordSkillInvocation,
 } from '@qwen-code/qwen-code-core';
 
-const { logSlashCommand, debugLoggerMock } = vi.hoisted(() => ({
-  logSlashCommand: vi.fn(),
-  debugLoggerMock: {
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  },
-}));
+const { logSlashCommand, recordSkillInvocationMock, debugLoggerMock } =
+  vi.hoisted(() => ({
+    logSlashCommand: vi.fn(),
+    recordSkillInvocationMock: vi.fn(),
+    debugLoggerMock: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  }));
 
 vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
   const original =
@@ -48,6 +51,7 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
   return {
     ...original,
     logSlashCommand,
+    recordSkillInvocation: recordSkillInvocationMock,
     createDebugLogger: () => debugLoggerMock,
     getIdeInstaller: vi.fn().mockReturnValue(null),
   };
@@ -1977,6 +1981,7 @@ describe('useSlashCommandProcessor', () => {
     beforeEach(() => {
       mockCommandAction.mockClear();
       vi.mocked(logSlashCommand).mockClear();
+      vi.mocked(recordSkillInvocation).mockClear();
     });
 
     it('should log a simple slash command', async () => {
@@ -2061,6 +2066,156 @@ describe('useSlashCommandProcessor', () => {
           command: 'logalias',
         }),
       );
+    });
+
+    it('records successful skill slash commands when they submit a prompt', async () => {
+      const skillCmd = createTestCommand(
+        {
+          name: 'review-skill',
+          action: vi.fn().mockResolvedValue({
+            type: 'submit_prompt',
+            content: [{ text: 'skill body' }],
+          }),
+        },
+        CommandKind.SKILL,
+      );
+      const result = setupProcessorHook([skillCmd]);
+      await waitFor(() =>
+        expect(result.current.slashCommands.length).toBeGreaterThan(0),
+      );
+
+      await act(async () => {
+        await result.current.handleSlashCommand('/review-skill');
+      });
+
+      expect(recordSkillInvocation).toHaveBeenCalledWith(mockConfig, {
+        skillName: 'review-skill',
+        success: true,
+      });
+    });
+
+    it('records failed skill slash commands when the action throws', async () => {
+      const skillCmd = createTestCommand(
+        {
+          name: 'review-skill',
+          action: vi.fn().mockRejectedValue(new Error('skill failed')),
+        },
+        CommandKind.SKILL,
+      );
+      const result = setupProcessorHook([skillCmd]);
+      await waitFor(() =>
+        expect(result.current.slashCommands.length).toBeGreaterThan(0),
+      );
+
+      await act(async () => {
+        await result.current.handleSlashCommand('/review-skill');
+      });
+
+      expect(recordSkillInvocation).toHaveBeenCalledWith(mockConfig, {
+        skillName: 'review-skill',
+        success: false,
+      });
+    });
+
+    it('records blocked skill slash commands as failures', async () => {
+      mockFireUserPromptExpansionEvent.mockResolvedValue({
+        getBlockingError: () => ({
+          blocked: true,
+          reason: 'Blocked by policy',
+        }),
+        shouldStopExecution: () => false,
+      });
+      const skillCmd = createTestCommand(
+        {
+          name: 'review-skill',
+          action: vi.fn().mockResolvedValue({
+            type: 'submit_prompt',
+            content: [{ text: 'skill body' }],
+          }),
+        },
+        CommandKind.SKILL,
+      );
+      const result = setupProcessorHook([skillCmd]);
+      await waitFor(() =>
+        expect(result.current.slashCommands.length).toBeGreaterThan(0),
+      );
+
+      await act(async () => {
+        await result.current.handleSlashCommand('/review-skill');
+      });
+
+      expect(recordSkillInvocation).toHaveBeenCalledWith(mockConfig, {
+        skillName: 'review-skill',
+        success: false,
+      });
+    });
+
+    it('records confirmed skill slash commands only once', async () => {
+      const action = vi
+        .fn()
+        .mockResolvedValueOnce({
+          type: 'confirm_action',
+          prompt: 'Run skill?',
+          originalInvocation: { raw: '/review-skill' },
+        } as ConfirmActionReturn)
+        .mockResolvedValueOnce({
+          type: 'submit_prompt',
+          content: [{ text: 'skill body' }],
+        });
+      const skillCmd = createTestCommand(
+        {
+          name: 'review-skill',
+          action,
+        },
+        CommandKind.SKILL,
+      );
+      const result = setupProcessorHook([skillCmd]);
+      await waitFor(() =>
+        expect(result.current.slashCommands.length).toBeGreaterThan(0),
+      );
+
+      act(() => {
+        void result.current.handleSlashCommand('/review-skill');
+      });
+      await waitFor(() => {
+        expect(result.current.confirmationRequest).not.toBeNull();
+      });
+
+      await act(async () => {
+        result.current.confirmationRequest?.onConfirm(true);
+      });
+
+      await waitFor(() => {
+        expect(action).toHaveBeenCalledTimes(2);
+      });
+      expect(recordSkillInvocation).toHaveBeenCalledTimes(1);
+      expect(recordSkillInvocation).toHaveBeenCalledWith(mockConfig, {
+        skillName: 'review-skill',
+        success: true,
+      });
+    });
+
+    it('does not record non-skill submit-prompt slash commands as skills', async () => {
+      const fileCmd = createTestCommand(
+        {
+          name: 'filecmd',
+          action: vi.fn().mockResolvedValue({
+            type: 'submit_prompt',
+            content: [{ text: 'custom prompt' }],
+          }),
+        },
+        CommandKind.FILE,
+      );
+      const result = setupProcessorHook([], [fileCmd]);
+      await waitFor(() =>
+        expect(result.current.slashCommands.length).toBeGreaterThan(0),
+      );
+
+      await act(async () => {
+        await result.current.handleSlashCommand('/filecmd');
+      });
+
+      expect(recordSkillInvocation).not.toHaveBeenCalled();
     });
 
     it('should not log for unknown commands', async () => {

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -29,6 +29,7 @@ import {
   addMCPStatusChangeListener,
   removeMCPStatusChangeListener,
   MCPServerStatus,
+  recordSkillInvocation,
 } from '@qwen-code/qwen-code-core';
 import { useSessionStats } from '../contexts/SessionContext.js';
 import type {
@@ -41,7 +42,11 @@ import type {
 } from '../types.js';
 import { MessageType } from '../types.js';
 import type { LoadedSettings } from '../../config/settings.js';
-import { type CommandContext, type SlashCommand } from '../commands/types.js';
+import {
+  CommandKind,
+  type CommandContext,
+  type SlashCommand,
+} from '../commands/types.js';
 import type { RecentSlashCommand } from './useSlashCompletion.js';
 import { CommandService } from '../../services/CommandService.js';
 import { BuiltinCommandLoader } from '../../services/BuiltinCommandLoader.js';
@@ -100,6 +105,10 @@ const SLASH_COMMANDS_SKIP_RECORDING = new Set([
   'btw',
   'history',
 ]);
+
+function getSkillCommandName(command: SlashCommand): string {
+  return command.skillDetail?.name ?? command.name;
+}
 
 export interface SlashCommandProcessorActions {
   openAuthDialog: () => void;
@@ -300,6 +309,10 @@ export const useSlashCommandProcessor = (
       } else if (message.type === MessageType.TOOL_STATS) {
         historyItemContent = {
           type: 'tool_stats',
+        };
+      } else if (message.type === MessageType.SKILL_STATS) {
+        historyItemContent = {
+          type: 'skill_stats',
         };
       } else if (message.type === MessageType.QUIT) {
         historyItemContent = {
@@ -664,6 +677,23 @@ export const useSlashCommandProcessor = (
         resolvedCommandPath.length > 1
           ? resolvedCommandPath.slice(1).join(' ')
           : undefined;
+      const isSkillCommand = commandToExecute?.kind === CommandKind.SKILL;
+      let skillInvocationRecorded = false;
+      const recordSkillCommandInvocation = (success: boolean) => {
+        if (
+          !config ||
+          !commandToExecute ||
+          !isSkillCommand ||
+          skillInvocationRecorded
+        ) {
+          return;
+        }
+        recordSkillInvocation(config, {
+          skillName: getSkillCommandName(commandToExecute),
+          success,
+        });
+        skillInvocationRecorded = true;
+      };
 
       try {
         if (commandToExecute) {
@@ -897,6 +927,7 @@ export const useSlashCommandProcessor = (
                     const blockingError = output.getBlockingError();
                     if (blockingError.blocked || output.shouldStopExecution()) {
                       hasError = true;
+                      recordSkillCommandInvocation(false);
                       addMessage({
                         type: MessageType.ERROR,
                         content: formatUserPromptExpansionBlockedMessage(
@@ -923,6 +954,7 @@ export const useSlashCommandProcessor = (
                     // consumers observe it after state has rendered.
                     updateItem(invocationItemId, { sentToModel: true });
                   }
+                  recordSkillCommandInvocation(true);
                   return {
                     type: 'submit_prompt',
                     content,
@@ -1047,6 +1079,7 @@ export const useSlashCommandProcessor = (
           return { type: 'handled' };
         }
         hasError = true;
+        recordSkillCommandInvocation(false);
         if (config) {
           const event = makeSlashCommandEvent({
             command: resolvedCommandPath[0],

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -247,6 +247,10 @@ export type HistoryItemToolStats = HistoryItemBase & {
   type: 'tool_stats';
 };
 
+export type HistoryItemSkillStats = HistoryItemBase & {
+  type: 'skill_stats';
+};
+
 export type HistoryItemQuit = HistoryItemBase & {
   type: 'quit';
   duration: string;
@@ -609,6 +613,7 @@ export type HistoryItemWithoutId =
   | HistoryItemStats
   | HistoryItemModelStats
   | HistoryItemToolStats
+  | HistoryItemSkillStats
   | HistoryItemQuit
   | HistoryItemCompression
   | HistoryItemSummary
@@ -645,6 +650,7 @@ export enum MessageType {
   STATS = 'stats',
   MODEL_STATS = 'model_stats',
   TOOL_STATS = 'tool_stats',
+  SKILL_STATS = 'skill_stats',
   QUIT = 'quit',
   GEMINI = 'gemini',
   COMPRESSION = 'compression',
@@ -722,6 +728,11 @@ export type Message =
     }
   | {
       type: MessageType.TOOL_STATS;
+      timestamp: Date;
+      content?: string;
+    }
+  | {
+      type: MessageType.SKILL_STATS;
       timestamp: Date;
       content?: string;
     }

--- a/packages/cli/src/ui/utils/historyUtils.ts
+++ b/packages/cli/src/ui/utils/historyUtils.ts
@@ -71,6 +71,7 @@ export function isSyntheticHistoryItem(
     case 'stats':
     case 'model_stats':
     case 'tool_stats':
+    case 'skill_stats':
     case 'quit':
     case 'compression':
     case 'summary':

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -49,6 +49,7 @@ export {
   logNextSpeakerCheck,
   logAuth,
   logSkillLaunch,
+  recordSkillInvocation,
   logUserFeedback,
   logArenaSessionStarted,
   logArenaAgentCompleted,

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -1017,6 +1017,17 @@ export function logSkillLaunch(config: Config, event: SkillLaunchEvent): void {
   logger.emit(logRecord);
 }
 
+export function recordSkillInvocation(
+  config: Config,
+  event: { skillName: string; success: boolean },
+): void {
+  uiTelemetryService.recordSkillInvocation(
+    event.skillName,
+    event.success,
+    config.getSessionId(),
+  );
+}
+
 export function logUserFeedback(
   config: Config,
   event: UserFeedbackEvent,

--- a/packages/core/src/telemetry/uiTelemetry.test.ts
+++ b/packages/core/src/telemetry/uiTelemetry.test.ts
@@ -142,6 +142,12 @@ describe('UiTelemetryService', () => {
         totalLinesAdded: 0,
         totalLinesRemoved: 0,
       },
+      skills: {
+        totalCalls: 0,
+        totalSuccess: 0,
+        totalFail: 0,
+        byName: {},
+      },
     });
     expect(service.getLastPromptTokenCount()).toBe(0);
   });
@@ -798,6 +804,40 @@ describe('UiTelemetryService', () => {
     });
   });
 
+  describe('Skill Invocation Metrics', () => {
+    it('aggregates successful and failed skill invocations by name', () => {
+      service.recordSkillInvocation('review', true);
+      service.recordSkillInvocation('review', false);
+      service.recordSkillInvocation('testing', true);
+
+      expect(service.getMetrics().skills).toEqual({
+        totalCalls: 3,
+        totalSuccess: 2,
+        totalFail: 1,
+        byName: {
+          review: { count: 2, success: 1, fail: 1 },
+          testing: { count: 1, success: 1, fail: 0 },
+        },
+      });
+    });
+
+    it('handles skill names that collide with object prototype keys', () => {
+      service.recordSkillInvocation('constructor', true);
+      service.recordSkillInvocation('__proto__', false);
+
+      expect(service.getMetrics().skills?.byName['constructor']).toEqual({
+        count: 1,
+        success: 1,
+        fail: 0,
+      });
+      expect(service.getMetrics().skills?.byName['__proto__']).toEqual({
+        count: 1,
+        success: 0,
+        fail: 1,
+      });
+    });
+  });
+
   describe('resetLastPromptTokenCount', () => {
     it('should reset the last prompt token count to 0', () => {
       // First, set up some initial token count
@@ -1096,6 +1136,52 @@ describe('UiTelemetryService', () => {
       expect(metricsB.tools.totalCalls).toBe(2);
       expect(metricsB.tools.byName['Write']?.count).toBe(1);
       expect(metricsB.tools.byName['Read']?.count).toBe(1);
+    });
+
+    it('should isolate skill invocation metrics by session', () => {
+      service.recordSkillInvocation('review', true, SESSION_A);
+      service.recordSkillInvocation('review', false, SESSION_B);
+      service.recordSkillInvocation('testing', true, SESSION_B);
+
+      const metricsA = service.getMetricsForSession(SESSION_A);
+      const metricsB = service.getMetricsForSession(SESSION_B);
+
+      expect(metricsA.skills).toEqual({
+        totalCalls: 1,
+        totalSuccess: 1,
+        totalFail: 0,
+        byName: {
+          review: { count: 1, success: 1, fail: 0 },
+        },
+      });
+      expect(metricsB.skills).toEqual({
+        totalCalls: 2,
+        totalSuccess: 1,
+        totalFail: 1,
+        byName: {
+          review: { count: 1, success: 0, fail: 1 },
+          testing: { count: 1, success: 1, fail: 0 },
+        },
+      });
+    });
+
+    it('removeSession should prevent late skill metrics from recreating bucket', () => {
+      service.recordSkillInvocation('review', true, SESSION_A);
+      service.removeSession(SESSION_A);
+
+      service.recordSkillInvocation('review', false, SESSION_A);
+
+      expect(service.getMetricsForSession(SESSION_A).skills).toEqual({
+        totalCalls: 0,
+        totalSuccess: 0,
+        totalFail: 0,
+        byName: {},
+      });
+      expect(service.getMetrics().skills?.byName['review']).toEqual({
+        count: 2,
+        success: 1,
+        fail: 1,
+      });
     });
 
     it('resetSession should not clear global metrics (replay scenario)', () => {

--- a/packages/core/src/telemetry/uiTelemetry.ts
+++ b/packages/core/src/telemetry/uiTelemetry.ts
@@ -45,6 +45,19 @@ export interface ToolCallStats {
   };
 }
 
+export interface SkillCallStats {
+  count: number;
+  success: number;
+  fail: number;
+}
+
+export interface SkillMetrics {
+  totalCalls: number;
+  totalSuccess: number;
+  totalFail: number;
+  byName: Record<string, SkillCallStats>;
+}
+
 /**
  * Per-model counters without the nested source breakdown. Used both as the
  * aggregate `ModelMetrics` shape (via extension) and as the value type of the
@@ -94,6 +107,7 @@ export interface SessionMetrics {
     totalLinesAdded: number;
     totalLinesRemoved: number;
   };
+  skills?: SkillMetrics;
 }
 
 const createInitialModelMetricsCore = (): ModelMetricsCore => ({
@@ -121,6 +135,13 @@ const createInitialModelMetrics = (): ModelMetrics => ({
   bySource: Object.create(null) as Record<string, ModelMetricsCore>,
 });
 
+const createInitialSkillMetrics = (): SkillMetrics => ({
+  totalCalls: 0,
+  totalSuccess: 0,
+  totalFail: 0,
+  byName: {},
+});
+
 const createInitialMetrics = (): SessionMetrics => ({
   models: {},
   tools: {
@@ -140,6 +161,7 @@ const createInitialMetrics = (): SessionMetrics => ({
     totalLinesAdded: 0,
     totalLinesRemoved: 0,
   },
+  skills: createInitialSkillMetrics(),
 });
 
 export class UiTelemetryService extends EventEmitter {
@@ -173,6 +195,30 @@ export class UiTelemetryService extends EventEmitter {
 
   getMetricsForSession(sessionId: string): SessionMetrics {
     return this.#sessionMetrics.get(sessionId) ?? createInitialMetrics();
+  }
+
+  recordSkillInvocation(
+    skillName: string,
+    success: boolean,
+    sessionId?: string,
+  ): void {
+    this.#accumulateSkillInvocation(this.#metrics, skillName, success);
+
+    if (sessionId && !this.#closedSessions.has(sessionId)) {
+      if (!this.#sessionMetrics.has(sessionId)) {
+        this.#sessionMetrics.set(sessionId, createInitialMetrics());
+      }
+      this.#accumulateSkillInvocation(
+        this.#sessionMetrics.get(sessionId)!,
+        skillName,
+        success,
+      );
+    }
+
+    this.emit('update', {
+      metrics: this.#metrics,
+      lastPromptTokenCount: this.#lastPromptTokenCount,
+    });
   }
 
   getLastPromptTokenCount(): number {
@@ -328,6 +374,46 @@ export class UiTelemetryService extends EventEmitter {
       if (event.metadata['model_removed_lines'] !== undefined) {
         files.totalLinesRemoved += event.metadata['model_removed_lines'];
       }
+    }
+  }
+
+  #accumulateSkillInvocation(
+    metrics: SessionMetrics,
+    skillName: string,
+    success: boolean,
+  ): void {
+    const skills = metrics.skills ?? createInitialSkillMetrics();
+    metrics.skills = skills;
+
+    skills.totalCalls++;
+    if (success) {
+      skills.totalSuccess++;
+    } else {
+      skills.totalFail++;
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(skills.byName, skillName)) {
+      Object.defineProperty(skills.byName, skillName, {
+        value: {
+          count: 0,
+          success: 0,
+          fail: 0,
+        },
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    }
+
+    const skillStats = skills.byName[skillName];
+    if (!skillStats) {
+      return;
+    }
+    skillStats.count++;
+    if (success) {
+      skillStats.success++;
+    } else {
+      skillStats.fail++;
     }
   }
 

--- a/packages/core/src/tools/skill.test.ts
+++ b/packages/core/src/tools/skill.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { logSkillLaunch } from '../telemetry/index.js';
+import { logSkillLaunch, recordSkillInvocation } from '../telemetry/index.js';
 import { SkillTool, type SkillParams } from './skill.js';
 import type { PartListUnion } from '@google/genai';
 import type { ToolResultDisplay } from './tools.js';
@@ -38,6 +38,7 @@ type SkillToolWithProtectedMethods = SkillTool & {
 vi.mock('../skills/skill-manager.js');
 vi.mock('../telemetry/index.js', () => ({
   logSkillLaunch: vi.fn(),
+  recordSkillInvocation: vi.fn(),
   SkillLaunchEvent: class {
     constructor(
       public skill_name: string,
@@ -79,6 +80,7 @@ describe('SkillTool', () => {
     vi.useFakeTimers();
 
     mockAddSessionAllowRule = vi.fn();
+    vi.mocked(recordSkillInvocation).mockClear();
 
     // Create mock config
     config = {
@@ -609,6 +611,10 @@ describe('SkillTool', () => {
       expect(result.returnDisplay).toBe(
         'Specialized skill for reviewing code quality',
       );
+      expect(recordSkillInvocation).toHaveBeenCalledWith(config, {
+        skillName: 'code-review',
+        success: true,
+      });
     });
 
     it('should include allowedTools in result when present', async () => {
@@ -680,6 +686,10 @@ describe('SkillTool', () => {
 
       const llmText = partToString(result.llmContent);
       expect(llmText).toContain('Skill "non-existent" not found');
+      expect(recordSkillInvocation).toHaveBeenCalledWith(config, {
+        skillName: 'non-existent',
+        success: false,
+      });
     });
 
     it('should handle execution errors gracefully', async () => {
@@ -699,6 +709,10 @@ describe('SkillTool', () => {
       const llmText = partToString(result.llmContent);
       expect(llmText).toContain('Failed to load skill');
       expect(llmText).toContain('Loading failed');
+      expect(recordSkillInvocation).toHaveBeenCalledWith(config, {
+        skillName: 'code-review',
+        success: false,
+      });
     });
 
     it("L3 default is 'ask' so AUTO mode routes through the classifier", async () => {
@@ -828,6 +842,7 @@ describe('SkillTool', () => {
           prompt_id: 'prompt-via-executor',
         }),
       );
+      expect(recordSkillInvocation).not.toHaveBeenCalled();
     });
 
     it('returns the executor error from the disabled-skill delegation path', async () => {
@@ -1136,6 +1151,24 @@ describe('SkillTool', () => {
       expect(result.returnDisplay).toBe(
         'UserPromptExpansion blocked: Blocked by policy',
       );
+      expect(recordSkillInvocation).not.toHaveBeenCalled();
+    });
+
+    it('does not record skill stats when commandExecutor throws', async () => {
+      const executor = vi.fn().mockRejectedValue(new Error('MCP timeout'));
+      vi.mocked(config.getModelInvocableCommandsExecutor).mockReturnValue(
+        executor,
+      );
+      vi.mocked(mockSkillManager.loadSkillForRuntime).mockResolvedValue(null);
+
+      const invocation = (
+        skillTool as SkillToolWithProtectedMethods
+      ).createInvocation({ skill: 'mcp-prompt-a' });
+      const result = await invocation.execute();
+
+      expect(executor).toHaveBeenCalledWith('mcp-prompt-a', '');
+      expect(partToString(result.llmContent)).toContain('MCP timeout');
+      expect(recordSkillInvocation).not.toHaveBeenCalled();
     });
 
     it('logs prompt attribution when executor returns an error', async () => {
@@ -1231,6 +1264,7 @@ describe('SkillTool', () => {
       // distinguish a disabled-skill→command pass-through from a real
       // skill execution. See comment in skill.ts execute().
       expect(result.returnDisplay).toBe('Delegated to command: mytool');
+      expect(recordSkillInvocation).not.toHaveBeenCalled();
     });
 
     it('returns the disabled-specific error when no command alternative exists', async () => {
@@ -1250,6 +1284,10 @@ describe('SkillTool', () => {
       const llmText = partToString(result.llmContent);
       expect(llmText).toMatch(/is disabled/);
       expect(llmText).toMatch(/skills manage|skills\.disabled/);
+      expect(recordSkillInvocation).toHaveBeenCalledWith(config, {
+        skillName: 'testing',
+        success: false,
+      });
     });
 
     it('returns the disabled-specific error when the executor returns null', async () => {
@@ -1272,6 +1310,7 @@ describe('SkillTool', () => {
       expect(mockSkillManager.loadSkillForRuntime).not.toHaveBeenCalled();
       const llmText = partToString(result.llmContent);
       expect(llmText).toMatch(/is disabled/);
+      expect(recordSkillInvocation).not.toHaveBeenCalled();
     });
 
     it('returns command executor errors for disabled skill command alternatives', async () => {

--- a/packages/core/src/tools/skill.test.ts
+++ b/packages/core/src/tools/skill.test.ts
@@ -686,10 +686,7 @@ describe('SkillTool', () => {
 
       const llmText = partToString(result.llmContent);
       expect(llmText).toContain('Skill "non-existent" not found');
-      expect(recordSkillInvocation).toHaveBeenCalledWith(config, {
-        skillName: 'non-existent',
-        success: false,
-      });
+      expect(recordSkillInvocation).not.toHaveBeenCalled();
     });
 
     it('should handle execution errors gracefully', async () => {
@@ -1284,10 +1281,7 @@ describe('SkillTool', () => {
       const llmText = partToString(result.llmContent);
       expect(llmText).toMatch(/is disabled/);
       expect(llmText).toMatch(/skills manage|skills\.disabled/);
-      expect(recordSkillInvocation).toHaveBeenCalledWith(config, {
-        skillName: 'testing',
-        success: false,
-      });
+      expect(recordSkillInvocation).not.toHaveBeenCalled();
     });
 
     it('returns the disabled-specific error when the executor returns null', async () => {

--- a/packages/core/src/tools/skill.ts
+++ b/packages/core/src/tools/skill.ts
@@ -14,7 +14,11 @@ import type {
 import type { PermissionDecision } from '../permissions/types.js';
 import type { SkillManager } from '../skills/skill-manager.js';
 import type { SkillConfig } from '../skills/types.js';
-import { logSkillLaunch, SkillLaunchEvent } from '../telemetry/index.js';
+import {
+  logSkillLaunch,
+  recordSkillInvocation,
+  SkillLaunchEvent,
+} from '../telemetry/index.js';
 import path from 'path';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { registerSkillHooks } from '../hooks/registerSkillHooks.js';
@@ -345,7 +349,9 @@ class SkillToolInvocation extends BaseToolInvocation<SkillParams, ToolResult> {
       .getDisabledSkillNames()
       .has(this.params.skill.toLowerCase());
     if (disabled) {
+      let disabledCommandFallbackAttempted = false;
       if (this.commandExecutor) {
+        disabledCommandFallbackAttempted = true;
         // Wrap in try/catch matching the non-disabled path's graceful
         // degradation: if the MCP server throws
         // (network error, timeout, protocol violation), fall through to
@@ -382,9 +388,17 @@ class SkillToolInvocation extends BaseToolInvocation<SkillParams, ToolResult> {
         this.config,
         new SkillLaunchEvent(this.params.skill, false, this.promptId),
       );
+      if (!disabledCommandFallbackAttempted) {
+        recordSkillInvocation(this.config, {
+          skillName: this.params.skill,
+          success: false,
+        });
+      }
       const msg = `Skill "${this.params.skill}" is disabled. Re-enable it via /skills or remove it from skills.disabled.`;
       return { llmContent: msg, returnDisplay: msg };
     }
+
+    let commandFallbackAttempted = false;
 
     try {
       // Load the skill with runtime config (includes additional files)
@@ -395,6 +409,7 @@ class SkillToolInvocation extends BaseToolInvocation<SkillParams, ToolResult> {
       if (!skill) {
         // Try model-invocable command executor (e.g. MCP prompts)
         if (this.commandExecutor) {
+          commandFallbackAttempted = true;
           const commandResult = await this.commandExecutor(
             this.params.skill,
             this.params.args ?? '',
@@ -431,6 +446,12 @@ class SkillToolInvocation extends BaseToolInvocation<SkillParams, ToolResult> {
           this.config,
           new SkillLaunchEvent(this.params.skill, false, this.promptId),
         );
+        if (!commandFallbackAttempted) {
+          recordSkillInvocation(this.config, {
+            skillName: this.params.skill,
+            success: false,
+          });
+        }
 
         // Get parse errors if any
         const parseErrors = this.skillManager.getParseErrors();
@@ -504,6 +525,10 @@ class SkillToolInvocation extends BaseToolInvocation<SkillParams, ToolResult> {
 
       const baseDir = path.dirname(skill.filePath);
       const llmContent = buildSkillLlmContent(baseDir, skill.body);
+      recordSkillInvocation(this.config, {
+        skillName: this.params.skill,
+        success: true,
+      });
 
       return {
         llmContent: [{ text: llmContent }],
@@ -520,6 +545,12 @@ class SkillToolInvocation extends BaseToolInvocation<SkillParams, ToolResult> {
         this.config,
         new SkillLaunchEvent(this.params.skill, false, this.promptId),
       );
+      if (!commandFallbackAttempted) {
+        recordSkillInvocation(this.config, {
+          skillName: this.params.skill,
+          success: false,
+        });
+      }
 
       return {
         llmContent: `Failed to load skill "${this.params.skill}": ${errorMessage}`,

--- a/packages/core/src/tools/skill.ts
+++ b/packages/core/src/tools/skill.ts
@@ -349,9 +349,7 @@ class SkillToolInvocation extends BaseToolInvocation<SkillParams, ToolResult> {
       .getDisabledSkillNames()
       .has(this.params.skill.toLowerCase());
     if (disabled) {
-      let disabledCommandFallbackAttempted = false;
       if (this.commandExecutor) {
-        disabledCommandFallbackAttempted = true;
         // Wrap in try/catch matching the non-disabled path's graceful
         // degradation: if the MCP server throws
         // (network error, timeout, protocol violation), fall through to
@@ -388,12 +386,6 @@ class SkillToolInvocation extends BaseToolInvocation<SkillParams, ToolResult> {
         this.config,
         new SkillLaunchEvent(this.params.skill, false, this.promptId),
       );
-      if (!disabledCommandFallbackAttempted) {
-        recordSkillInvocation(this.config, {
-          skillName: this.params.skill,
-          success: false,
-        });
-      }
       const msg = `Skill "${this.params.skill}" is disabled. Re-enable it via /skills or remove it from skills.disabled.`;
       return { llmContent: msg, returnDisplay: msg };
     }
@@ -446,12 +438,6 @@ class SkillToolInvocation extends BaseToolInvocation<SkillParams, ToolResult> {
           this.config,
           new SkillLaunchEvent(this.params.skill, false, this.promptId),
         );
-        if (!commandFallbackAttempted) {
-          recordSkillInvocation(this.config, {
-            skillName: this.params.skill,
-            success: false,
-          });
-        }
 
         // Get parse errors if any
         const parseErrors = this.skillManager.getParseErrors();

--- a/packages/sdk-typescript/src/daemon/types.ts
+++ b/packages/sdk-typescript/src/daemon/types.ts
@@ -988,6 +988,12 @@ export interface DaemonSessionStatsToolByName {
   };
 }
 
+export interface DaemonSessionStatsSkillByName {
+  count: number;
+  success: number;
+  fail: number;
+}
+
 /** Returned from `GET /session/:id/stats`. */
 export interface DaemonSessionStatsStatus {
   v: 1;
@@ -1007,6 +1013,12 @@ export interface DaemonSessionStatsStatus {
   files: {
     totalLinesAdded: number;
     totalLinesRemoved: number;
+  };
+  skills?: {
+    totalCalls: number;
+    totalSuccess: number;
+    totalFail: number;
+    byName: Record<string, DaemonSessionStatsSkillByName>;
   };
 }
 


### PR DESCRIPTION
## What this PR does

This PR adds live per-session skill invocation statistics to daemon session stats and exposes them through `/stats skills`. It tracks real skill body loads through the Skill tool and skill slash commands across interactive, non-interactive, and ACP execution, while excluding MCP prompt and file-command fallbacks so available command entries do not inflate skill usage.

## Why it's needed

Users can already inspect model, tool, and file activity for a live session, but skill usage was invisible. This makes `/session/:id/stats` and `/stats skills` reflect which skills were actually invoked, whether they succeeded or failed, and how often each skill was used without changing daily, monthly, or export aggregation semantics.

## Reviewer Test Plan

### How to verify

Run the targeted core telemetry and SkillTool tests and confirm skill success/fail aggregation is session-scoped, disabled/not-found real skill failures are counted, and commandExecutor fallback paths are not counted. Run the CLI targeted tests and confirm `/stats skills` produces a `skill_stats` history item in interactive mode, text output in non-interactive and ACP paths, skill command hook failures are counted as failures, confirmation recursion counts once, and non-skill commands do not increment skill metrics. Run `npm run build && npm run typecheck` from the repository root and confirm it exits successfully.

### Evidence (Before & After)

Before: `GET /session/:id/stats` had no `skills` block and `/stats skills` was not available. After: daemon stats includes `skills.totalCalls`, `skills.totalSuccess`, `skills.totalFail`, and `skills.byName`; `/stats skills` renders the interactive skill stats display or non-interactive lines such as `Skill calls: 3 (2 ok, 1 fail)` with per-skill counts. Targeted tests cover empty and multi-skill display states.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js v22.22.3, npm 10.9.8. Local validation used package-scoped Vitest commands plus root `npm run build && npm run typecheck`.

## Risk & Scope

- Main risk or tradeoff: The live UI stats provider now clones session metrics snapshots to avoid stale renders from mutable telemetry objects; this adds small per-update copy cost proportional to the live metrics size.
- Not validated / out of scope: Cross-session daily, monthly, and export stats intentionally do not include skills; no manual TUI screenshot was captured.
- Breaking changes / migration notes: The current daemon always returns the required `skills` block through ACP status, while the TypeScript SDK keeps the field optional for compatibility with older daemon versions.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

本 PR 为 daemon session stats 增加实时的按会话 skill 调用统计，并通过 `/stats skills` 展示。统计范围包括 Skill tool 真实加载 skill body，以及 interactive、non-interactive、ACP 执行路径中的 skill slash command；同时排除 MCP prompt 和 file command fallback，避免把 available command 条目错误计入 skill 使用量。

## Why it's needed

用户已经可以查看当前 live session 的 model、tool 和 file 活动，但 skill 使用情况之前不可见。这个改动让 `/session/:id/stats` 和 `/stats skills` 能展示实际调用过哪些 skills、成功或失败次数，以及每个 skill 的调用次数，同时不改变 daily、monthly、export 聚合语义。

## Reviewer Test Plan

### How to verify

运行 core telemetry 和 SkillTool 的定向测试，确认 skill success/fail 聚合按 session 隔离，disabled/not-found 的真实 skill 失败会被计数，commandExecutor fallback 路径不会被计数。运行 CLI 定向测试，确认 `/stats skills` 在 interactive 模式产生 `skill_stats` history item，在 non-interactive 和 ACP 路径输出文本，skill command hook 失败按失败计数，确认递归只计一次，非 skill command 不增加 skill metrics。在仓库根目录运行 `npm run build && npm run typecheck` 并确认成功退出。

### Evidence (Before & After)

Before：`GET /session/:id/stats` 没有 `skills` block，`/stats skills` 不可用。After：daemon stats 包含 `skills.totalCalls`、`skills.totalSuccess`、`skills.totalFail` 和 `skills.byName`；`/stats skills` 会渲染 interactive skill stats display，或在 non-interactive 输出类似 `Skill calls: 3 (2 ok, 1 fail)` 的总数和按 skill 统计。定向测试覆盖了空状态和多 skill 展示状态。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js v22.22.3，npm 10.9.8。本地验证使用 package-scoped Vitest 命令，以及根目录 `npm run build && npm run typecheck`。

## Risk & Scope

- Main risk or tradeoff：live UI stats provider 现在会 clone session metrics snapshot，以避免 mutable telemetry object 导致 UI 不刷新；这会带来与 live metrics 大小成比例的小额 per-update copy 成本。
- Not validated / out of scope：跨 session 的 daily、monthly、export stats 按设计暂不包含 skills；没有捕获手动 TUI 截图。
- Breaking changes / migration notes：当前 daemon 会通过 ACP status 始终返回必填 `skills` block；TypeScript SDK 为兼容旧 daemon，仍将该字段保持 optional。

## Linked Issues

N/A

</details>
