### PR TITLE
ci: split platform test matrix into named jobs so PRs can enter the merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,9 @@ on:
   push:
     branches:
       - 'main'
-      - 'release/**'
+      # No 'release/**' here: release.yml's commits to the release branch would
+      # fire a redundant full CI run that blocks the release PR's merge queue.
+      # Kept under pull_request below for backport PRs.
   pull_request:
     branches:
       - 'main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,28 +272,19 @@ jobs:
           name: 'coverage-reports-22.x-ubuntu-latest'
           path: 'packages/*/coverage'
 
-  test_platforms:
-    name: 'Test (${{ matrix.os }}, Node ${{ matrix.node-version }})'
+  # macOS/Windows: slowest/costliest runners, rare platform regressions — skip
+  # on PR, run on push to `main` and in the merge queue. Two named jobs, not a
+  # matrix: a skipped matrix job reports one collapsed check name, never the
+  # per-OS required contexts, so PRs would sit "Expected" forever and never
+  # enter the queue. A skipped named job reports under its exact name and
+  # satisfies the required check (same as the Integration Tests job).
+  test_macos:
+    name: 'Test (macos-latest, Node 22.x)'
     needs: 'classify_pr'
-    # macOS/Windows are the slowest, costliest runners and platform-specific
-    # regressions are rare per push, so rerunning them on every review iteration
-    # is mostly wasted. Skip on PR pushes; they still run on push to `main` (and
-    # in the merge queue, once enabled), catching platform breakage before it
-    # ships without sitting on every PR's critical path.
     if: "${{ !cancelled() && github.event_name != 'pull_request' }}"
-    runs-on: '${{ fromJSON(matrix.runner) }}'
+    runs-on: 'macos-latest'
     permissions:
       contents: 'read'
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: 'macos-latest'
-            runner: '["macos-latest"]'
-            node-version: '22.x'
-          - os: 'windows-latest'
-            runner: '["windows-2022"]'
-            node-version: '22.x'
     steps:
       # See the Ubuntu gate's checkout: on PRs use the immutable refs/pull/N/head
       # to avoid merge-ref rebuild lag; other events keep github.ref.
@@ -304,11 +295,57 @@ jobs:
         with:
           ref: "${{ github.event.inputs.branch_ref || (github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number)) || github.ref }}"
 
-      - name: 'Set up Node.js ${{ matrix.node-version }}'
+      - name: 'Set up Node.js 22.x'
         if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
         uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # v6.4.0
         with:
-          node-version: '${{ matrix.node-version }}'
+          node-version: '22.x'
+          cache: 'npm'
+          cache-dependency-path: 'package-lock.json'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: 'Configure npm for rate limiting'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
+        run: |-
+          npm config set fetch-retry-mintimeout 20000
+          npm config set fetch-retry-maxtimeout 120000
+          npm config set fetch-retries 5
+          npm config set fetch-timeout 300000
+
+      - name: 'Install dependencies'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
+        run: |-
+          npm ci --prefer-offline --no-audit --progress=false
+
+      - name: 'Run tests and generate reports'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
+        env:
+          NO_COLOR: true
+        run: 'npm run test:ci'
+
+  # Windows counterpart of test_macos (see that job's note). Runner is
+  # windows-2022; the check name keeps the windows-latest label so it matches
+  # the required-status-check context.
+  test_windows:
+    name: 'Test (windows-latest, Node 22.x)'
+    needs: 'classify_pr'
+    if: "${{ !cancelled() && github.event_name != 'pull_request' }}"
+    runs-on: 'windows-2022'
+    permissions:
+      contents: 'read'
+    steps:
+      - name: 'Checkout'
+        id: 'checkout'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
+        with:
+          ref: "${{ github.event.inputs.branch_ref || (github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number)) || github.ref }}"
+
+      - name: 'Set up Node.js 22.x'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # v6.4.0
+        with:
+          node-version: '22.x'
           cache: 'npm'
           cache-dependency-path: 'package-lock.json'
           registry-url: 'https://registry.npmjs.org/'

--- a/scripts/tests/no-ak-integration-ci.test.js
+++ b/scripts/tests/no-ak-integration-ci.test.js
@@ -47,7 +47,8 @@ describe('no-AK integration CI wiring', () => {
       'utf8',
     );
     const ubuntuJob = getWorkflowJob(workflow, 'test');
-    const platformJob = getWorkflowJob(workflow, 'test_platforms');
+    const macosJob = getWorkflowJob(workflow, 'test_macos');
+    const windowsJob = getWorkflowJob(workflow, 'test_windows');
 
     expect(workflow).not.toContain('  integration_no_ak:');
     expect(workflow.split(`npm run ${NO_AK_SCRIPT}`).length - 1).toBe(1);
@@ -59,7 +60,8 @@ describe('no-AK integration CI wiring', () => {
     expect(ubuntuJob).not.toContain('secrets.OPENAI_BASE_URL');
     expect(ubuntuJob).not.toContain('secrets.OPENAI_MODEL');
 
-    expect(platformJob).not.toContain(NO_AK_SCRIPT);
+    expect(macosJob).not.toContain(NO_AK_SCRIPT);
+    expect(windowsJob).not.toContain(NO_AK_SCRIPT);
   });
 
   it('checks out the immutable PR head ref instead of the lagging merge ref', () => {
@@ -68,12 +70,13 @@ describe('no-AK integration CI wiring', () => {
       'utf8',
     );
     const ubuntuJob = getWorkflowJob(workflow, 'test');
-    const platformJob = getWorkflowJob(workflow, 'test_platforms');
+    const macosJob = getWorkflowJob(workflow, 'test_macos');
+    const windowsJob = getWorkflowJob(workflow, 'test_windows');
 
-    // On PRs both gates check out refs/pull/N/head, which is published the
+    // On PRs every gate checks out refs/pull/N/head, which is published the
     // instant the branch is pushed, instead of the merge ref that GitHub
     // rebuilds asynchronously and can serve stale for minutes.
-    for (const job of [ubuntuJob, platformJob]) {
+    for (const job of [ubuntuJob, macosJob, windowsJob]) {
       expect(job).toContain(
         "format('refs/pull/{0}/head', github.event.pull_request.number)",
       );


### PR DESCRIPTION
## What this PR does

Unblocks `main`'s merge queue and removes a redundant release-branch CI run. Three changes:

1. **Splits the platform test matrix into two named jobs** — `Test (macos-latest, Node 22.x)` and `Test (windows-latest, Node 22.x)` — instead of one `test_platforms` matrix.
2. **Removes `release/**` from `ci.yml`'s `push` trigger** (kept under `pull_request` for backport PRs).
3. **Updates the `no-ak-integration-ci` structure test** to assert against the two new job names instead of the removed `test_platforms`.

## Why it's needed

**Merge queue is blocked for every PR.** The macOS/Windows tests are required status checks that only run in the merge queue (`if: github.event_name != 'pull_request'`). As a single matrix job, a *skipped* run collapses to one check named `Test (${{ matrix.os }}, Node ${{ matrix.node-version }})` — so the required contexts `Test (macos-latest, Node 22.x)` and `Test (windows-latest, Node 22.x)` are **never reported on the PR head** and sit `Expected — Waiting for status to be reported` forever. The PR is `MERGEABLE` but `mergeStateStatus: BLOCKED`, so it can't enter the queue (observed on #5830 and #5832).

A *skipped named job*, by contrast, reports a check run under its exact name with conclusion `skipped`, which satisfies the required check on the PR head — exactly how the merge-queue-only `Integration Tests (CLI, No Sandbox)` job already behaves and why it never blocked PRs. Splitting the matrix into two named jobs gives macOS/Windows the same property:

- **On a PR:** both jobs are skipped → no runner is spun up → but each reports under its exact required name → required checks satisfied → the PR can enter the queue.
- **In the merge queue (`merge_group`):** both jobs run for real → report under their exact names → gate the merge.

So platform tests still run exactly once (in the queue) and still gate the merge, with no PR-stage runner cost and **no branch-protection / ruleset change**.

**Redundant release-branch CI.** `release.yml` pushes version + changelog commits to the release branch; with `release/**` under the `push` trigger that fired a full push-event CI run (heavy jobs really run since `event != pull_request`), which blocked the release PR from the queue and double-ran the matrix. Nothing gates on it — release branches are unprotected and publish happens inside `release.yml`. (This change was split out of #5832.)

## Reviewer Test Plan

### How to verify

CI-config change — verify by inspection plus this PR's own run:

- `ci.yml` defines `test_macos` (`name: Test (macos-latest, Node 22.x)`, `runs-on: macos-latest`) and `test_windows` (`name: Test (windows-latest, Node 22.x)`, `runs-on: windows-2022`), both gated `if: !cancelled() && github.event_name != 'pull_request'`; the old `test_platforms` matrix is gone.
- On this PR, the checks `Test (macos-latest, Node 22.x)` and `Test (windows-latest, Node 22.x)` appear as **skipped** (not "Expected"), so the PR becomes mergeable and can enter the queue — where they run for real.
- `ci.yml`'s `push.branches` lists only `main`; `pull_request.branches` still includes `release/**`.
- The structure test passes against the new jobs: `npx vitest run --project scripts scripts/tests/no-ak-integration-ci.test.js` → 3 passed.
- YAML parses: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → OK.

### Evidence (Before & After)

Before: `Test (macos-latest, Node 22.x)` / `Test (windows-latest, Node 22.x)` are MISSING from the PR's status rollup (only the collapsed `Test (${{ matrix.os }}, Node ${{ matrix.node-version }})` skipped check exists) → PR BLOCKED.
After: both report as skipped under their exact names on this PR's own head → PR mergeable.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

<!-- Linux: ran the scripts structure test locally (3 passed) and inspected the rendered status rollup on this PR. macOS/Windows: config-only, the real runs happen in the merge queue / on push to main. -->

### Environment (optional)

N/A — workflow YAML plus one structure test.

## Risk & Scope

- Main risk or tradeoff: the two named jobs duplicate the same five steps (checkout / setup-node / npm config / npm ci / test). Accepted — a reusable workflow or composite action would be more machinery than the duplication it removes for two jobs. Behavior in the merge queue and on push to `main` is unchanged (same two OS legs run); only PR-head check reporting changes (collapsed matrix name → two exact names).
- Not validated / out of scope: the real macOS/Windows test runs only happen in the merge queue and on push to `main`, so they can't be exercised on this PR (they show as skipped here, by design).
- Breaking changes / migration notes: none. No branch-protection / ruleset change required — the existing required contexts now get satisfied correctly.

## Linked Issues

Relates to the merge-queue rollout (#4805). Unblocks #5832.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

解开 `main` 分支 merge queue 对所有 PR 的阻塞，并去掉一轮多余的 release 分支 CI。三处改动：

1. **把平台测试 matrix 拆成两个具名 job** —— `Test (macos-latest, Node 22.x)` 和 `Test (windows-latest, Node 22.x)`，不再用单个 `test_platforms` matrix。
2. **从 `ci.yml` 的 `push` 触发器里去掉 `release/**`**（`pull_request` 里保留，给 backport PR 用）。
3. **更新 `no-ak-integration-ci` 结构自检测试**，断言改成针对两个新 job 名，而非已删除的 `test_platforms`。

## 为什么需要

**merge queue 对每个 PR 都被卡住。** macOS/Windows 测试是 required status check，且只在 merge queue 里跑（`if: github.event_name != 'pull_request'`）。作为单个 matrix job，被跳过时会塌缩成一个名为 `Test (${{ matrix.os }}, Node ${{ matrix.node-version }})` 的 check —— 于是 required 要的 `Test (macos-latest, Node 22.x)` 和 `Test (windows-latest, Node 22.x)` 在 PR head 上**永远没人上报**，一直停在 `Expected — Waiting for status to be reported`。PR 状态是 `MERGEABLE` 但 `mergeStateStatus: BLOCKED`，进不了队列（在 #5830、#5832 上实测到）。

相对地，一个**被跳过的具名 job** 会按它的精确名上报一个 conclusion 为 `skipped` 的 check，这就满足了 PR head 上的 required check —— 这正是只在队列里跑的 `Integration Tests (CLI, No Sandbox)` job 一直以来的行为，也是它从不卡 PR 的原因。把 matrix 拆成两个具名 job，让 macOS/Windows 获得同样的属性：

- **在 PR 上：** 两个 job 都跳过 → 不拉起任何 runner → 但各自按精确 required 名上报 → required check 满足 → PR 能进队列。
- **在 merge queue（`merge_group`）里：** 两个 job 真跑 → 按精确名上报 → gate 合并。

所以平台测试仍然只跑一次（在队列里）、仍然 gate 合并，PR 阶段零 runner 开销，且**不需要改 branch protection / ruleset**。

**多余的 release 分支 CI。** `release.yml` 会往 release 分支推 version + changelog 提交；`release/**` 挂在 `push` 触发器下时，这会触发一整轮 push 事件 CI（重活在 `event != pull_request` 下真跑），既挡住 release PR 入队、又让 matrix 跑两遍。没有任何东西依赖它 —— release 分支没有保护、发布在 `release.yml` 内部就完成了。（此项从 #5832 拆出。）

## 评审验证计划

### 如何验证

CI 配置改动 —— 看代码 + 看本 PR 自身这轮：

- `ci.yml` 定义了 `test_macos`（`name: Test (macos-latest, Node 22.x)`，`runs-on: macos-latest`）和 `test_windows`（`name: Test (windows-latest, Node 22.x)`，`runs-on: windows-2022`），两者都 gate 在 `if: !cancelled() && github.event_name != 'pull_request'`；旧的 `test_platforms` matrix 已删除。
- 在本 PR 上，`Test (macos-latest, Node 22.x)` / `Test (windows-latest, Node 22.x)` 显示为 **skipped**（而非 "Expected"），所以 PR 变得可合并、能入队 —— 进队列后真跑。
- `ci.yml` 的 `push.branches` 只剩 `main`；`pull_request.branches` 仍含 `release/**`。
- 结构测试对新 job 通过：`npx vitest run --project scripts scripts/tests/no-ak-integration-ci.test.js` → 3 passed。
- YAML 可解析：`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → OK。

### 证据（前后对比）

之前：`Test (macos-latest, Node 22.x)` / `Test (windows-latest, Node 22.x)` 在 PR 的 status rollup 里缺席（只有塌缩的 `Test (${{ matrix.os }}, Node ${{ matrix.node-version }})` skipped check）→ PR BLOCKED。
之后：两者都在本 PR 自己的 head 上按精确名以 skipped 上报 → PR 可合并。

### 测试平台

仅改 workflow YAML + 一个结构测试。Linux 上本地跑过结构测试（3 passed）并核对了本 PR 渲染出的 status rollup；macOS/Windows 为纯配置项，真实跑发生在 merge queue / push to main。

### 运行环境（可选）

N/A —— 仅 workflow YAML 加一个结构测试。

## 风险与范围

- 主要风险 / 取舍：两个具名 job 复制了同样的五个 step（checkout / setup-node / npm config / npm ci / test）。已接受 —— 为两个 job 引入 reusable workflow 或 composite action，比这点重复更重。merge queue 里和 push to main 时行为不变（同样跑两个 OS leg），只有 PR head 的 check 上报方式变了（塌缩 matrix 名 → 两个精确名）。
- 未验证 / 范围之外：真实的 macOS/Windows 测试只在 merge queue 和 push to main 时跑，本 PR 上无法触发（按设计它们在这里显示 skipped）。
- 破坏性改动 / 迁移说明：无。不需要改 branch protection / ruleset —— 现有 required context 现在能被正确满足。

## 关联 Issue

关联 merge-queue 推进（#4805）。解开 #5832。

</details>
