### PR TITLE
fix(core): preserve the selected model when re-applying a provider install plan

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -4001,7 +4001,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       (settings as Record<string, unknown>)['getValue'] = vi.fn((key: string) =>
         key === 'model.name' ? 'deepseek-flash' : undefined,
       );
-      return settings;
+      return settings as unknown as ReturnType<typeof createLoadedSettingsAdapter>;
     });
 
     const settings = makeSessionSettings();

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -594,6 +594,7 @@ import {
   MAX_PERMISSION_RULES_COUNT,
 } from '../config/permission-settings.js';
 import { loadCliConfig } from '../config/config.js';
+import { createLoadedSettingsAdapter } from '../config/loadedSettingsAdapter.js';
 import { Session, buildAvailableCommandsSnapshot } from './session/Session.js';
 import {
   SERVE_STATUS_EXT_METHODS,
@@ -3990,6 +3991,37 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       expect.objectContaining({ providerId: 'deepseek' }),
       expect.objectContaining({ settings }),
     );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('qwen/providers/connect returns preserved model when adapter getValue returns a non-empty string', async () => {
+    vi.mocked(createLoadedSettingsAdapter).mockImplementationOnce((settings: unknown) => {
+      (settings as Record<string, unknown>)['getValue'] = vi.fn((key: string) =>
+        key === 'model.name' ? 'deepseek-flash' : undefined,
+      );
+      return settings;
+    });
+
+    const settings = makeSessionSettings();
+    const agentPromise = runAcpAgent(mockConfig, settings, mockArgv);
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+
+    const agent = capturedAgentFactory!({
+      get closed() { return mockConnectionState.promise; },
+    }) as AgentLike;
+
+    await expect(
+      agent.extMethod('qwen/providers/connect', {
+        providerId: 'deepseek',
+        apiKey: 'sk-test',
+        modelIds: ['deepseek-chat'],
+      }),
+    ).resolves.toMatchObject({
+      success: true,
+      modelId: 'deepseek-flash',
+    });
 
     mockConnectionState.resolve();
     await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -474,8 +474,9 @@ vi.mock('../config/settings.js', () => ({
 }));
 vi.mock('../config/loadedSettingsAdapter.js', () => ({
   createLoadedSettingsAdapter: vi.fn((settings: unknown) => {
-  (settings as Record<string, unknown>)['getValue'] = vi.fn();
-  return settings;}),
+    (settings as Record<string, unknown>)['getValue'] = vi.fn();
+    return settings;
+  }),
 }));
 vi.mock('../config/config.js', () => ({
   loadCliConfig: vi.fn(),
@@ -3997,19 +3998,26 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
   });
 
   it('qwen/providers/connect returns preserved model when adapter getValue returns a non-empty string', async () => {
-    vi.mocked(createLoadedSettingsAdapter).mockImplementationOnce((settings: unknown) => {
-      (settings as Record<string, unknown>)['getValue'] = vi.fn((key: string) =>
-        key === 'model.name' ? 'deepseek-flash' : undefined,
-      );
-      return settings as unknown as ReturnType<typeof createLoadedSettingsAdapter>;
-    });
+    vi.mocked(createLoadedSettingsAdapter).mockImplementationOnce(
+      (settings: unknown) => {
+        (settings as Record<string, unknown>)['getValue'] = vi.fn(
+          (key: string) =>
+            key === 'model.name' ? 'deepseek-flash' : undefined,
+        );
+        return settings as unknown as ReturnType<
+          typeof createLoadedSettingsAdapter
+        >;
+      },
+    );
 
     const settings = makeSessionSettings();
     const agentPromise = runAcpAgent(mockConfig, settings, mockArgv);
     await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
 
     const agent = capturedAgentFactory!({
-      get closed() { return mockConnectionState.promise; },
+      get closed() {
+        return mockConnectionState.promise;
+      },
     }) as AgentLike;
 
     await expect(

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -473,7 +473,10 @@ vi.mock('../config/settings.js', () => ({
   reloadEnvironment: vi.fn(() => ({ updatedKeys: [], removedKeys: [] })),
 }));
 vi.mock('../config/loadedSettingsAdapter.js', () => ({
-  createLoadedSettingsAdapter: vi.fn((settings: unknown) => settings),
+  createLoadedSettingsAdapter: vi.fn((settings: unknown) => ({
+  ...(settings as object),
+  getValue: vi.fn(),
+  })),
 }));
 vi.mock('../config/config.js', () => ({
   loadCliConfig: vi.fn(),

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -473,10 +473,9 @@ vi.mock('../config/settings.js', () => ({
   reloadEnvironment: vi.fn(() => ({ updatedKeys: [], removedKeys: [] })),
 }));
 vi.mock('../config/loadedSettingsAdapter.js', () => ({
-  createLoadedSettingsAdapter: vi.fn((settings: unknown) => ({
-  ...(settings as object),
-  getValue: vi.fn(),
-  })),
+  createLoadedSettingsAdapter: vi.fn((settings: unknown) => {
+  (settings as Record<string, unknown>)['getValue'] = vi.fn();
+  return settings;}),
 }));
 vi.mock('../config/config.js', () => ({
   loadCliConfig: vi.fn(),

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -4886,15 +4886,16 @@ class QwenAgent implements Agent {
         const effectiveModelId =
           (adapter.getValue('model.name') as string | undefined) ??
           plan.modelSelection?.modelId;
+        const effectiveBaseUrl = 
+          (adapter.getValue('model.baseUrl') as string | undefined) ??
+          plan.modelSelection?.baseUrl;
         return {
           success: true,
           providerId: providerConfig.id,
           providerLabel: providerConfig.label,
           authType: plan.authType,
           ...(effectiveModelId ? { modelId: effectiveModelId } : {}),
-          ...(plan.modelSelection?.baseUrl
-            ? { baseUrl: plan.modelSelection.baseUrl }
-            : {}),
+          ...(effectiveBaseUrl ? { baseUrl: effectiveBaseUrl } : {}),
         };
       }
       case 'qwen/skills/install': {

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -4872,8 +4872,9 @@ class QwenAgent implements Agent {
         );
         const persistScope = readProviderConnectScope(params['scope']);
         const plan = buildInstallPlan(providerConfig, inputs);
+        const adapter = createLoadedSettingsAdapter(this.settings, persistScope);
         await applyProviderInstallPlan(plan, {
-          settings: createLoadedSettingsAdapter(this.settings, persistScope),
+          settings: adapter,
           reloadModelProviders: (modelProviders) =>
             this.config.reloadModelProvidersConfig(modelProviders),
           syncAuthState: (authType, modelId, baseUrl) =>
@@ -4882,13 +4883,15 @@ class QwenAgent implements Agent {
               .syncAfterAuthRefresh(authType, modelId, baseUrl),
           refreshAuth: (authType) => this.config.refreshAuth(authType),
         });
-
+        const effectiveModelId =
+          (adapter.getValue('model.name') as string | undefined) ??
+          plan.modelSelection?.modelId;
         return {
           success: true,
           providerId: providerConfig.id,
           providerLabel: providerConfig.label,
           authType: plan.authType,
-          modelId: plan.modelSelection?.modelId,
+          ...(effectiveModelId ? { modelId: effectiveModelId } : {}),
           ...(plan.modelSelection?.baseUrl
             ? { baseUrl: plan.modelSelection.baseUrl }
             : {}),

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -4872,7 +4872,10 @@ class QwenAgent implements Agent {
         );
         const persistScope = readProviderConnectScope(params['scope']);
         const plan = buildInstallPlan(providerConfig, inputs);
-        const adapter = createLoadedSettingsAdapter(this.settings, persistScope);
+        const adapter = createLoadedSettingsAdapter(
+          this.settings,
+          persistScope,
+        );
         await applyProviderInstallPlan(plan, {
           settings: adapter,
           reloadModelProviders: (modelProviders) =>
@@ -4886,7 +4889,7 @@ class QwenAgent implements Agent {
         const effectiveModelId =
           (adapter.getValue('model.name') as string | undefined) ??
           plan.modelSelection?.modelId;
-        const effectiveBaseUrl = 
+        const effectiveBaseUrl =
           (adapter.getValue('model.baseUrl') as string | undefined) ??
           plan.modelSelection?.baseUrl;
         return {

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -1798,7 +1798,7 @@ export async function runQwenServe(
               ...(inputs.baseUrl ? { baseUrl: inputs.baseUrl } : {}),
               message: `Successfully configured ${provider.label}. Use /model to switch models.`,
             };
-            },
+          },
         ),
     });
     return { app, bridge };

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -1777,7 +1777,10 @@ export async function runQwenServe(
             });
             const plan = core.buildInstallPlan(provider, inputs);
             const fresh = settingsRuntime.settings.loadSettings(boundWorkspace);
-            const adapter = settingsRuntime.loadedSettingsAdapter.createLoadedSettingsAdapter(fresh);
+            const adapter =
+              settingsRuntime.loadedSettingsAdapter.createLoadedSettingsAdapter(
+                fresh,
+              );
             await core.applyProviderInstallPlan(plan, {
               settings: adapter,
               doRefreshAuth: false,
@@ -1789,13 +1792,17 @@ export async function runQwenServe(
             const effectiveModelId =
               (adapter.getValue('model.name') as string | undefined) ??
               plan.modelSelection?.modelId;
+            const effectiveBaseUrl =
+              (adapter.getValue('model.baseUrl') as string | undefined) ??
+              plan.modelSelection?.baseUrl ??
+              inputs.baseUrl;
             return {
               v: 1,
               providerId: provider.id,
               providerLabel: provider.label,
               authType: plan.authType,
               ...(effectiveModelId ? { modelId: effectiveModelId } : {}),
-              ...(inputs.baseUrl ? { baseUrl: inputs.baseUrl } : {}),
+              ...(effectiveBaseUrl ? { baseUrl: effectiveBaseUrl } : {}),
               message: `Successfully configured ${provider.label}. Use /model to switch models.`,
             };
           },

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -1777,28 +1777,23 @@ export async function runQwenServe(
             });
             const plan = core.buildInstallPlan(provider, inputs);
             const fresh = settingsRuntime.settings.loadSettings(boundWorkspace);
-            await core.applyProviderInstallPlan(plan, {
-              settings:
-                settingsRuntime.loadedSettingsAdapter.createLoadedSettingsAdapter(
-                  fresh,
-                ),
-              doRefreshAuth: false,
-            });
-            core.emitDaemonLog('Auth provider installed.', {
-              'qwen-code.daemon.auth.provider_id': provider.id,
-              'qwen-code.daemon.auth.auth_type': plan.authType,
-            });
-            return {
-              v: 1,
-              providerId: provider.id,
-              providerLabel: provider.label,
-              authType: plan.authType,
-              ...(plan.modelSelection?.modelId
-                ? { modelId: plan.modelSelection.modelId }
-                : {}),
-              ...(inputs.baseUrl ? { baseUrl: inputs.baseUrl } : {}),
-              message: `Successfully configured ${provider.label}. Use /model to switch models.`,
-            };
+            const adapter = settingsRuntime.loadedSettingsAdapter.createLoadedSettingsAdapter(fresh);
+          await core.applyProviderInstallPlan(plan, {
+            settings: adapter,
+            doRefreshAuth: false,
+          });
+          const effectiveModelId =
+            (adapter.getValue('model.name') as string | undefined) ??
+            plan.modelSelection?.modelId;
+          return {
+            v: 1,
+            providerId: provider.id,
+            providerLabel: provider.label,
+            authType: plan.authType,
+            ...(effectiveModelId ? { modelId: effectiveModelId } : {}),
+            ...(inputs.baseUrl ? { baseUrl: inputs.baseUrl } : {}),
+            message: `Successfully configured ${provider.label}. Use /model to switch models.`,
+          };
           },
         ),
     });

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -1778,23 +1778,27 @@ export async function runQwenServe(
             const plan = core.buildInstallPlan(provider, inputs);
             const fresh = settingsRuntime.settings.loadSettings(boundWorkspace);
             const adapter = settingsRuntime.loadedSettingsAdapter.createLoadedSettingsAdapter(fresh);
-          await core.applyProviderInstallPlan(plan, {
-            settings: adapter,
-            doRefreshAuth: false,
-          });
-          const effectiveModelId =
-            (adapter.getValue('model.name') as string | undefined) ??
-            plan.modelSelection?.modelId;
-          return {
-            v: 1,
-            providerId: provider.id,
-            providerLabel: provider.label,
-            authType: plan.authType,
-            ...(effectiveModelId ? { modelId: effectiveModelId } : {}),
-            ...(inputs.baseUrl ? { baseUrl: inputs.baseUrl } : {}),
-            message: `Successfully configured ${provider.label}. Use /model to switch models.`,
-          };
-          },
+            await core.applyProviderInstallPlan(plan, {
+              settings: adapter,
+              doRefreshAuth: false,
+            });
+            core.emitDaemonLog('Auth provider installed.', {
+              'qwen-code.daemon.auth.provider_id': provider.id,
+              'qwen-code.daemon.auth.auth_type': plan.authType,
+            });
+            const effectiveModelId =
+              (adapter.getValue('model.name') as string | undefined) ??
+              plan.modelSelection?.modelId;
+            return {
+              v: 1,
+              providerId: provider.id,
+              providerLabel: provider.label,
+              authType: plan.authType,
+              ...(effectiveModelId ? { modelId: effectiveModelId } : {}),
+              ...(inputs.baseUrl ? { baseUrl: inputs.baseUrl } : {}),
+              message: `Successfully configured ${provider.label}. Use /model to switch models.`,
+            };
+            },
         ),
     });
     return { app, bridge };

--- a/packages/cli/src/ui/auth/useAuth.test.ts
+++ b/packages/cli/src/ui/auth/useAuth.test.ts
@@ -31,7 +31,8 @@ vi.mock('../hooks/useQwenAuth.js', () => ({
 }));
 
 vi.mock('../../utils/settingsUtils.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../utils/settingsUtils.js')>();
+  const actual =
+    await importOriginal<typeof import('../../utils/settingsUtils.js')>();
   return {
     ...actual,
     backupSettingsFile: vi.fn(),

--- a/packages/cli/src/ui/auth/useAuth.test.ts
+++ b/packages/cli/src/ui/auth/useAuth.test.ts
@@ -30,20 +30,15 @@ vi.mock('../hooks/useQwenAuth.js', () => ({
   })),
 }));
 
-vi.mock('../../utils/settingsUtils.js', () => ({
-  backupSettingsFile: vi.fn(),
-  restoreSettingsFromBackup: vi.fn(),
-  cleanupSettingsBackup: vi.fn(),
-  getNestedProperty: vi.fn((obj, key) => {
-    if (!obj || !key) return undefined;
-    return String(key)
-      .split('.')
-      .reduce((acc, part) => {
-        if (acc === null || acc === undefined) return undefined;
-        return acc[part];
-      }, obj);
-  }),
-}));
+vi.mock('../../utils/settingsUtils.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/settingsUtils.js')>();
+  return {
+    ...actual,
+    backupSettingsFile: vi.fn(),
+    restoreSettingsFromBackup: vi.fn(),
+    cleanupSettingsBackup: vi.fn(),
+  };
+});
 
 vi.mock('../../config/modelProvidersScope.js', () => ({
   getPersistScopeForModelSelection: vi.fn(() => 'user'),

--- a/packages/cli/src/ui/auth/useAuth.test.ts
+++ b/packages/cli/src/ui/auth/useAuth.test.ts
@@ -41,9 +41,8 @@ vi.mock('../../config/modelProvidersScope.js', () => ({
 }));
 
 const createSettings = () => ({
-  merged: {
-    modelProviders: {},
-  },
+  merged: { modelProviders: {} },
+  getValue: vi.fn().mockReturnValue(undefined),
   setValue: vi.fn(),
   recomputeMerged: vi.fn(),
   forScope: vi.fn(() => ({

--- a/packages/cli/src/ui/auth/useAuth.test.ts
+++ b/packages/cli/src/ui/auth/useAuth.test.ts
@@ -34,6 +34,15 @@ vi.mock('../../utils/settingsUtils.js', () => ({
   backupSettingsFile: vi.fn(),
   restoreSettingsFromBackup: vi.fn(),
   cleanupSettingsBackup: vi.fn(),
+  getNestedProperty: vi.fn((obj, key) => {
+    if (!obj || !key) return undefined;
+    return String(key)
+      .split('.')
+      .reduce((acc, part) => {
+        if (acc === null || acc === undefined) return undefined;
+        return acc[part];
+      }, obj);
+  }),
 }));
 
 vi.mock('../../config/modelProvidersScope.js', () => ({
@@ -41,8 +50,9 @@ vi.mock('../../config/modelProvidersScope.js', () => ({
 }));
 
 const createSettings = () => ({
-  merged: { modelProviders: {} },
-  getValue: vi.fn().mockReturnValue(undefined),
+  merged: {
+    modelProviders: {},
+  },
   setValue: vi.fn(),
   recomputeMerged: vi.fn(),
   forScope: vi.fn(() => ({

--- a/packages/cli/src/ui/hooks/useProviderUpdates.test.ts
+++ b/packages/cli/src/ui/hooks/useProviderUpdates.test.ts
@@ -19,20 +19,15 @@ import {
 } from '@qwen-code/qwen-code-core';
 import { useProviderUpdates } from './useProviderUpdates.js';
 
-vi.mock('../../utils/settingsUtils.js', () => ({
-  backupSettingsFile: vi.fn(),
-  restoreSettingsFromBackup: vi.fn(),
-  cleanupSettingsBackup: vi.fn(),
-  getNestedProperty: vi.fn((obj, key) => {
-    if (!obj || !key) return undefined;
-    return String(key)
-      .split('.')
-      .reduce((acc, part) => {
-        if (acc === null || acc === undefined) return undefined;
-        return acc[part];
-      }, obj);
-  }),
-}));
+vi.mock('../../utils/settingsUtils.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/settingsUtils.js')>();
+  return {
+    ...actual,
+    backupSettingsFile: vi.fn(),
+    restoreSettingsFromBackup: vi.fn(),
+    cleanupSettingsBackup: vi.fn(),
+  };
+});
 
 const chinaTemplate = buildProviderTemplate(
   codingPlanProvider,

--- a/packages/cli/src/ui/hooks/useProviderUpdates.test.ts
+++ b/packages/cli/src/ui/hooks/useProviderUpdates.test.ts
@@ -23,6 +23,15 @@ vi.mock('../../utils/settingsUtils.js', () => ({
   backupSettingsFile: vi.fn(),
   restoreSettingsFromBackup: vi.fn(),
   cleanupSettingsBackup: vi.fn(),
+  getNestedProperty: vi.fn((obj, key) => {
+    if (!obj || !key) return undefined;
+    return String(key)
+      .split('.')
+      .reduce((acc, part) => {
+        if (acc === null || acc === undefined) return undefined;
+        return acc[part];
+      }, obj);
+  }),
 }));
 
 const chinaTemplate = buildProviderTemplate(
@@ -46,7 +55,6 @@ describe('useProviderUpdates', () => {
       modelProviders: {} as Record<string, unknown>,
       [PROVIDER_METADATA_NS]: {} as Record<string, unknown>,
     } as Record<string, unknown>,
-    getValue: vi.fn().mockReturnValue(undefined),
     setValue: vi.fn(),
     forScope: vi.fn(() => ({ path: '/tmp/settings.json' })),
     isTrusted: true,

--- a/packages/cli/src/ui/hooks/useProviderUpdates.test.ts
+++ b/packages/cli/src/ui/hooks/useProviderUpdates.test.ts
@@ -20,7 +20,8 @@ import {
 import { useProviderUpdates } from './useProviderUpdates.js';
 
 vi.mock('../../utils/settingsUtils.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../utils/settingsUtils.js')>();
+  const actual =
+    await importOriginal<typeof import('../../utils/settingsUtils.js')>();
   return {
     ...actual,
     backupSettingsFile: vi.fn(),

--- a/packages/cli/src/ui/hooks/useProviderUpdates.test.ts
+++ b/packages/cli/src/ui/hooks/useProviderUpdates.test.ts
@@ -46,6 +46,7 @@ describe('useProviderUpdates', () => {
       modelProviders: {} as Record<string, unknown>,
       [PROVIDER_METADATA_NS]: {} as Record<string, unknown>,
     } as Record<string, unknown>,
+    getValue: vi.fn().mockReturnValue(undefined),
     setValue: vi.fn(),
     forScope: vi.fn(() => ({ path: '/tmp/settings.json' })),
     isTrusted: true,

--- a/packages/core/src/providers/install.ts
+++ b/packages/core/src/providers/install.ts
@@ -232,11 +232,6 @@ export async function applyProviderInstallPlan(
           ),
         );
       if (planOffersCurrentModel) {
-        if (plan.modelSelection?.baseUrl) {
-          settings.setValue('model.baseUrl', plan.modelSelection.baseUrl);
-        } else {
-          settings.setValue('model.baseUrl', '');
-        }
         effectiveModelSelection = undefined;
       }
     }

--- a/packages/core/src/providers/install.ts
+++ b/packages/core/src/providers/install.ts
@@ -226,6 +226,11 @@ export async function applyProviderInstallPlan(
           patch.models.some((model) => model.id === currentModelId),
         );
       if (planOffersCurrentModel) {
+        if (plan.modelSelection?.baseUrl) {
+          settings.setValue('model.baseUrl', plan.modelSelection.baseUrl);
+        } else {
+          settings.setValue('model.baseUrl', '');
+        }
         effectiveModelSelection = undefined;
       }
     }

--- a/packages/core/src/providers/install.ts
+++ b/packages/core/src/providers/install.ts
@@ -211,11 +211,28 @@ export async function applyProviderInstallPlan(
     }
 
     // Model selection
+    // Re-applying a plan (manual /auth, ACP reconnect, token refresh, or an
+    // upgrade that reordered the model list) must not silently move the user
+    // off a model they chose. If the plan still offers the current model, keep
+    // it; a genuine first-time setup still adopts the provider default. (#5819)
     currentStep = 'modelSelection';
-    if (plan.modelSelection?.modelId) {
-      settings.setValue('model.name', plan.modelSelection.modelId);
-      if (plan.modelSelection.baseUrl) {
-        settings.setValue('model.baseUrl', plan.modelSelection.baseUrl);
+    let effectiveModelSelection = plan.modelSelection;
+    if (effectiveModelSelection?.modelId) {
+      const currentModelId = settings.getValue('model.name');
+      const planOffersCurrentModel =
+        typeof currentModelId === 'string' &&
+        currentModelId.length > 0 &&
+        (plan.modelProviders ?? []).some((patch) =>
+          patch.models.some((model) => model.id === currentModelId),
+        );
+      if (planOffersCurrentModel) {
+        effectiveModelSelection = undefined;
+      }
+    }
+    if (effectiveModelSelection?.modelId) {
+      settings.setValue('model.name', effectiveModelSelection.modelId);
+      if (effectiveModelSelection.baseUrl) {
+        settings.setValue('model.baseUrl', effectiveModelSelection.baseUrl);
       } else {
         // The plan selects by model id only, so clear any baseUrl disambiguator
         // left by a previous model-picker selection — otherwise the next launch
@@ -241,12 +258,12 @@ export async function applyProviderInstallPlan(
     // Reload runtime config
     currentStep = 'reloadModelProviders';
     reloadModelProviders?.(updatedModelProviders);
-    if (plan.modelSelection?.modelId) {
+    if (effectiveModelSelection?.modelId) {
       currentStep = 'syncAuthState';
       syncAuthState?.(
         plan.authType,
-        plan.modelSelection.modelId,
-        plan.modelSelection.baseUrl,
+        effectiveModelSelection.modelId,
+        effectiveModelSelection.baseUrl,
       );
     }
     if (doRefreshAuth && refreshAuth) {

--- a/packages/core/src/providers/install.ts
+++ b/packages/core/src/providers/install.ts
@@ -219,11 +219,17 @@ export async function applyProviderInstallPlan(
     let effectiveModelSelection = plan.modelSelection;
     if (effectiveModelSelection?.modelId) {
       const currentModelId = settings.getValue('model.name');
+      const currentBaseUrl = settings.getValue('model.baseUrl') as string | undefined;
       const planOffersCurrentModel =
         typeof currentModelId === 'string' &&
         currentModelId.length > 0 &&
         (plan.modelProviders ?? []).some((patch) =>
-          patch.models.some((model) => model.id === currentModelId),
+          patch.models.some((model) =>
+            isSameModelIdentity(
+              { id: currentModelId, baseUrl: currentBaseUrl },
+              model,
+            ),
+          ),
         );
       if (planOffersCurrentModel) {
         if (plan.modelSelection?.baseUrl) {

--- a/packages/core/src/providers/install.ts
+++ b/packages/core/src/providers/install.ts
@@ -219,16 +219,20 @@ export async function applyProviderInstallPlan(
     let effectiveModelSelection = plan.modelSelection;
     if (effectiveModelSelection?.modelId) {
       const currentModelId = settings.getValue('model.name');
-      const currentBaseUrl = settings.getValue('model.baseUrl') as string | undefined;
+      const currentBaseUrl = settings.getValue('model.baseUrl') as
+        | string
+        | undefined;
       const planOffersCurrentModel =
         typeof currentModelId === 'string' &&
         currentModelId.length > 0 &&
         (plan.modelProviders ?? []).some((patch) =>
           patch.models.some((model) =>
-            isSameModelIdentity(
-              { id: currentModelId, baseUrl: currentBaseUrl },
-              model,
-            ),
+            currentBaseUrl === '' || currentBaseUrl === undefined
+              ? model.id === currentModelId
+              : isSameModelIdentity(
+                  { id: currentModelId, baseUrl: currentBaseUrl },
+                  model,
+                ),
           ),
         );
       if (planOffersCurrentModel) {


### PR DESCRIPTION
## What this PR does

Re-running provider setup no longer changes which model is active. Any flow that re-applies a provider's install plan — re-authenticating, reconnecting over ACP, refreshing an expired token, or upgrading to a version that reordered a provider's model list — used to reset the active model to that provider's first/default model. With this change the active model is kept whenever the provider still offers it, and the provider default is adopted only on a genuine first-time setup or when the previously selected model is no longer available.

The second commit fixes two CLI test mocks broken by the new `settings.getValue()` call in `install.ts`. The call routes through `createLoadedSettingsAdapter`, which calls `getNestedProperty` from `settingsUtils.js`. That function was missing from the `vi.mock('../../utils/settingsUtils.js')` stubs in both test files, causing a TypeError that swallowed the `model.name` write and the `syncAuthState` call.

### Changes

- **`packages/core/src/providers/install.ts`** — introduce `effectiveModelSelection`; read `settings.getValue('model.name')` and skip the write when the plan still offers that model; thread `effectiveModelSelection` through to `syncAuthState`
- **`packages/cli/src/acp-integration/acpAgent.ts`** — store the adapter before calling `applyProviderInstallPlan`; read `adapter.getValue('model.name')` and `adapter.getValue('model.baseUrl')` for the response instead of `plan.modelSelection`
- **`packages/cli/src/acp-integration/acpAgent.test.ts`** — add `getValue` stub to the `createLoadedSettingsAdapter` mock; add a test verifying the preserved model appears in the ACP response
- **`packages/cli/src/serve/run-qwen-serve.ts`** — same adapter read-back pattern as `acpAgent.ts`: store the adapter, read `adapter.getValue('model.name')` for the response `modelId`
- **`packages/cli/src/ui/auth/useAuth.test.ts`** — replace hand-rolled `getNestedProperty` stub with `importOriginal` pattern
- **`packages/cli/src/ui/hooks/useProviderUpdates.test.ts`** — replace hand-rolled `getNestedProperty` stub with `importOriginal` pattern

## Why it's needed

Users who deliberately picked a cheaper or faster model were silently switched onto a different, often pricier, model after routine actions, with no indication that anything had changed — quietly burning extra tokens and credits. In the reported case an upgrade reordered a provider's model list and users sitting on the cheaper model were moved onto the pricier default on their next provider action. A deliberate model choice should be sticky: the model should change only when the user changes it, or when their chosen model genuinely no longer exists.

## Reviewer Test Plan

### How to verify

Manual reproduction (no test harness needed): configure a provider and select a model other than the provider's first/default model — the DeepSeek preset lists the pricier "pro" model first and the cheaper "flash" model second, so selecting "flash" reproduces the report. Then trigger a re-application of that provider's install plan, for example by re-running the provider authentication flow. Before this change the active model recorded in the user settings (the `model.name` value) is overwritten back to the provider's first model; after this change it stays on the model you selected. Also confirm the cases that must still switch: a first-time setup with no prior model, and a previously selected model the provider no longer lists — both should still adopt the provider default.

I verified this locally with a focused unit test against the affected function, reproduced as a drop-in at the end of this section (intentionally not part of this PR's diff). A reviewer who prefers automated confirmation can drop that file into `packages/core/src/providers/__tests__/` and run the command below: all five cases pass on this branch, and reverting only the production change (keeping the test) makes the two "preserve" cases fail, reproducing the bug.

```bash
npx vitest run packages/core/src/providers/__tests__/install-preserve-user-model.test.ts
```

<details>
<summary>Drop-in regression test used to verify (not included in this PR's diff)</summary>

```ts
/**
 * @license
 * Copyright 2025 Qwen Team
 * SPDX-License-Identifier: Apache-2.0
 */

import { beforeEach, describe, expect, it, vi } from 'vitest';
import { AuthType } from '../../core/contentGenerator.js';
import type { ModelProvidersConfig } from '../../models/types.js';
import {
  applyProviderInstallPlan,
  type ProviderInstallPlan,
  type ProviderSettingsAdapter,
} from '../index.js';

function adapterWithCurrentModel(
  currentModel: string | undefined,
  modelProviders: ModelProvidersConfig = {},
): ProviderSettingsAdapter & {
  getValue: ReturnType<typeof vi.fn>;
  setValue: ReturnType<typeof vi.fn>;
} {
  return {
    getValue: vi.fn((key: string) =>
      key === 'model.name' ? currentModel : undefined,
    ),
    setValue: vi.fn(),
    getModelProviders: vi.fn(() => modelProviders),
    persist: vi.fn(),
    backup: vi.fn(),
    restore: vi.fn(),
    cleanupBackup: vi.fn(),
  };
}

const reorderedDeepseekPlan: ProviderInstallPlan = {
  providerId: 'deepseek',
  authType: AuthType.USE_OPENAI,
  env: { DEEPSEEK_API_KEY: 'sk-deepseek' },
  modelSelection: { modelId: 'deepseek-v4-pro' },
  modelProviders: [
    {
      authType: AuthType.USE_OPENAI,
      models: [
        { id: 'deepseek-v4-pro', envKey: 'DEEPSEEK_API_KEY' },
        { id: 'deepseek-v4-flash', envKey: 'DEEPSEEK_API_KEY' },
      ],
      mergeStrategy: 'prepend-and-remove-owned',
    },
  ],
};

describe('applyProviderInstallPlan — preserves the user-selected model (#5819)', () => {
  beforeEach(() => {
    vi.clearAllMocks();
    delete process.env['DEEPSEEK_API_KEY'];
  });

  it('does NOT rewrite model.name when the plan still offers the current model', async () => {
    const adapter = adapterWithCurrentModel('deepseek-v4-flash');
    await applyProviderInstallPlan(reorderedDeepseekPlan, { settings: adapter });
    expect(adapter.setValue).not.toHaveBeenCalledWith('model.name', expect.anything());
    expect(adapter.setValue).not.toHaveBeenCalledWith('model.baseUrl', expect.anything());
    expect(adapter.setValue).toHaveBeenCalledWith('env.DEEPSEEK_API_KEY', 'sk-deepseek');
    expect(adapter.setValue).toHaveBeenCalledWith('security.auth.selectedType', AuthType.USE_OPENAI);
  });

  it('does NOT sync auth state to the unselected default when preserving the model', async () => {
    const adapter = adapterWithCurrentModel('deepseek-v4-flash');
    const syncAuthState = vi.fn();
    await applyProviderInstallPlan(reorderedDeepseekPlan, { settings: adapter, syncAuthState });
    const syncedToPro = syncAuthState.mock.calls.some((args) => args[1] === 'deepseek-v4-pro');
    expect(syncedToPro).toBe(false);
  });

  it('falls back to the plan default when the current model was removed', async () => {
    const adapter = adapterWithCurrentModel('deepseek-v3-legacy');
    await applyProviderInstallPlan(reorderedDeepseekPlan, { settings: adapter });
    expect(adapter.setValue).toHaveBeenCalledWith('model.name', 'deepseek-v4-pro');
  });

  it('selects the default on a first-time setup (no current model)', async () => {
    const adapter = adapterWithCurrentModel(undefined);
    await applyProviderInstallPlan(reorderedDeepseekPlan, { settings: adapter });
    expect(adapter.setValue).toHaveBeenCalledWith('model.name', 'deepseek-v4-pro');
  });

  it('switches when the current model belongs to a different provider', async () => {
    const adapter = adapterWithCurrentModel('gpt-4o');
    await applyProviderInstallPlan(reorderedDeepseekPlan, { settings: adapter });
    expect(adapter.setValue).toHaveBeenCalledWith('model.name', 'deepseek-v4-pro');
  });
});
```

</details>

### Evidence (Before & After)

The evidence is the drop-in regression test above, run locally with and without the production fix (the test itself is not committed in this PR).

Before — production change reverted, test kept:
<img width="794" height="556" alt="before" src="https://github.com/user-attachments/assets/349f4145-5f4f-49b1-9cf2-2b87ea30bbae" />

```text
× does NOT rewrite model.name when the plan still offers the current model
× does NOT sync auth state to the unselected default when preserving the model
✓ falls back to the plan default when the current model was removed
✓ selects the default on a first-time setup (no current model)
✓ switches when the current model belongs to a different provider
Tests  2 failed | 3 passed (5)
```

After — with the fix:
<img width="778" height="378" alt="after" src="https://github.com/user-attachments/assets/5b271e43-00f1-44a9-99ca-046298bed8cb" />

```text
✓ does NOT rewrite model.name when the plan still offers the current model
✓ does NOT sync auth state to the unselected default when preserving the model
✓ falls back to the plan default when the current model was removed
✓ selects the default on a first-time setup (no current model)
✓ switches when the current model belongs to a different provider
Tests  5 passed (5)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

N/A — verified with a single focused unit test, no dev server or sandbox involved.

## Risk & Scope

## Linked Issues

Closes #5819

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

重新运行 provider 配置时不再改变当前正在使用的模型。任何会重新应用 provider 安装计划的流程——重新认证、通过 ACP 重连、刷新过期 token,或升级到一个重排了 provider 模型列表的版本——以前都会把当前模型重置成该 provider 的第一个/默认模型。改动之后,只要 provider 仍然提供用户当前的模型就保留它,只有在真正首次配置、或之前所选模型已不存在时才采用 provider 的默认模型。

第二个 commit 修复了两个被本次 `install.ts` 新增的 `settings.getValue()` 调用所破坏的 CLI 测试 mock。该调用经由 `createLoadedSettingsAdapter` 转发，最终调用 `settingsUtils.js` 中的 `getNestedProperty`。两个测试文件的 `vi.mock('../../utils/settingsUtils.js')` stub 中缺少该函数，导致 TypeError 吞掉了 `model.name` 的写入和 `syncAuthState` 的调用。

### 改动内容

- **`packages/core/src/providers/install.ts`** — 引入 `effectiveModelSelection`；读取 `settings.getValue('model.name')`，若 plan 仍包含该模型则跳过写入；将 `effectiveModelSelection` 传入 `syncAuthState`
- **`packages/cli/src/acp-integration/acpAgent.ts`** — 在调用 `applyProviderInstallPlan` 前保存 adapter 引用；通过 `adapter.getValue('model.name')` 和 `adapter.getValue('model.baseUrl')` 读取实际生效的模型，而非 `plan.modelSelection`
- **`packages/cli/src/acp-integration/acpAgent.test.ts`** — 在 `createLoadedSettingsAdapter` mock 中补充 `getValue` stub；新增测试用例，验证 ACP 响应中包含的是保留的模型
- **`packages/cli/src/serve/run-qwen-serve.ts`** — 与 `acpAgent.ts` 相同的读回模式：保存 adapter，通过 `adapter.getValue('model.name')` 读取响应中的 `modelId`
- **`packages/cli/src/ui/auth/useAuth.test.ts`** — 用 `importOriginal` 模式替换手写的 `getNestedProperty` stub
- **`packages/cli/src/ui/hooks/useProviderUpdates.test.ts`** — 用 `importOriginal` 模式替换手写的 `getNestedProperty` stub

## 为什么需要

那些特意选了更便宜或更快模型的用户,在一些常规操作后会被悄悄切到另一个(往往更贵的)模型,且没有任何提示,白白多烧 token 和额度。在被报告的场景里,一次升级重排了 provider 的模型列表,原本停留在便宜模型上的用户在下一次 provider 操作时被切到了更贵的默认模型。用户的主动选择应当是"粘性"的:模型只应在用户自己更改、或所选模型确实不存在时才改变。

## 评审测试计划

### 如何验证

手动复现(不需要测试脚手架):配置一个 provider,选一个**非**该 provider 第一个/默认的模型——DeepSeek 预设把更贵的 "pro" 模型排在第一、把更便宜的 "flash" 排在第二,所以选 "flash" 即可复现该报告。然后触发该 provider 安装计划的重新应用,例如重新走一遍该 provider 的认证流程。改动前,用户设置里记录的当前模型(`model.name` 字段)会被改回该 provider 的第一个模型;改动后则保持在你所选的模型上。同时确认那些**本就应该切换**的情况:没有历史模型的首次配置,以及 provider 已不再列出的旧模型——两者都仍应采用 provider 默认模型。

我在本地用一个针对该函数的聚焦单元测试做了验证,完整代码见上方英文部分的折叠块(该测试**有意不**进本 PR 的 diff)。需要自动化确认的 reviewer 可以把该文件放进 `packages/core/src/providers/__tests__/` 并运行上面的命令:本分支上五个用例全部通过;只还原生产代码改动(保留测试)会让其中两个"保留模型"用例失败,从而复现 bug。

### 证据(修改前 & 修改后)

证据是上方折叠块里的 drop-in 回归测试,在有/没有生产修复时分别本地运行的结果(该测试本身未提交进本 PR),即英文部分给出的 `2 failed | 3 passed` 与 `5 passed` 两段输出。

### 测试平台

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   ⚠️   |

### 环境(可选)

N/A——仅用一个聚焦单元测试验证,不涉及 dev server 或沙箱。

## 风险与范围

## 关联 Issue

Closes #5819

</details>