### PR TITLE
chore(cli): drop redundant home-directory startup warning

### DIFF
--- a/packages/cli/src/utils/userStartupWarnings.test.ts
+++ b/packages/cli/src/utils/userStartupWarnings.test.ts
@@ -4,24 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { getUserStartupWarnings } from './userStartupWarnings.js';
 import * as os from 'node:os';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-// Mock os.homedir to control the home directory in tests
-vi.mock('os', async (importOriginal) => {
-  const actualOs = await importOriginal<typeof os>();
-  return {
-    ...actualOs,
-    homedir: vi.fn(),
-  };
-});
-
 describe('getUserStartupWarnings', () => {
   let testRootDir: string;
-  let homeDir: string;
   let startupOptions: {
     workspaceRoot: string;
     useRipgrep: boolean;
@@ -30,9 +20,6 @@ describe('getUserStartupWarnings', () => {
 
   beforeEach(async () => {
     testRootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'warnings-test-'));
-    homeDir = path.join(testRootDir, 'home');
-    await fs.mkdir(homeDir, { recursive: true });
-    vi.mocked(os.homedir).mockReturnValue(homeDir);
     startupOptions = {
       workspaceRoot: testRootDir,
       useRipgrep: true,
@@ -42,31 +29,6 @@ describe('getUserStartupWarnings', () => {
 
   afterEach(async () => {
     await fs.rm(testRootDir, { recursive: true, force: true });
-    vi.clearAllMocks();
-  });
-
-  describe('home directory check', () => {
-    it('should return a warning when running in home directory', async () => {
-      const warnings = await getUserStartupWarnings({
-        ...startupOptions,
-        workspaceRoot: homeDir,
-      });
-      expect(warnings).toContainEqual(
-        expect.stringContaining('home directory'),
-      );
-    });
-
-    it('should not return a warning when running in a project directory', async () => {
-      const projectDir = path.join(testRootDir, 'project');
-      await fs.mkdir(projectDir);
-      const warnings = await getUserStartupWarnings({
-        ...startupOptions,
-        workspaceRoot: projectDir,
-      });
-      expect(warnings).not.toContainEqual(
-        expect.stringContaining('home directory'),
-      );
-    });
   });
 
   describe('root directory check', () => {
@@ -106,7 +68,7 @@ describe('getUserStartupWarnings', () => {
       });
       const expectedWarning =
         'Could not verify the current directory due to a file system error.';
-      expect(warnings).toEqual([expectedWarning, expectedWarning]);
+      expect(warnings).toEqual([expectedWarning]);
     });
   });
 });

--- a/packages/cli/src/utils/userStartupWarnings.ts
+++ b/packages/cli/src/utils/userStartupWarnings.ts
@@ -5,7 +5,6 @@
  */
 
 import fs from 'node:fs/promises';
-import * as os from 'node:os';
 import path from 'node:path';
 import { canUseRipgrep } from '@qwen-code/qwen-code-core';
 
@@ -21,25 +20,6 @@ type WarningCheck = {
 };
 
 // Individual warning checks
-const homeDirectoryCheck: WarningCheck = {
-  id: 'home-directory',
-  check: async (options: WarningCheckOptions) => {
-    try {
-      const [workspaceRealPath, homeRealPath] = await Promise.all([
-        fs.realpath(options.workspaceRoot),
-        fs.realpath(os.homedir()),
-      ]);
-
-      if (workspaceRealPath === homeRealPath) {
-        return 'You are running Qwen Code in your home directory. It is recommended to run in a project-specific directory.';
-      }
-      return null;
-    } catch (_err: unknown) {
-      return 'Could not verify the current directory due to a file system error.';
-    }
-  },
-};
-
 const rootDirectoryCheck: WarningCheck = {
   id: 'root-directory',
   check: async (options: WarningCheckOptions) => {
@@ -81,7 +61,6 @@ const ripgrepAvailabilityCheck: WarningCheck = {
 
 // All warning checks
 const WARNING_CHECKS: readonly WarningCheck[] = [
-  homeDirectoryCheck,
   rootDirectoryCheck,
   ripgrepAvailabilityCheck,
 ];


### PR DESCRIPTION
## What this PR does

Removes the "You are running Qwen Code in your home directory" startup warning. When the workspace root equals the user's home directory, Qwen Code no longer prints the advisory message at startup. The root-directory and ripgrep-availability warnings are untouched.

## Why it's needed

Running in `$HOME` is already handled correctly by the memory layer — when `cwd === home`, an empty effective cwd is passed so the workspace memory search is skipped. In other words, the home directory is a fully supported working directory, not a degraded state.

The warning was pure noise: it never told the user what to do about it, and co-working from the home directory (e.g. managing `~/.qwen` configs, cross-project scratch work) is a legitimate use case that peer coding agents like Claude Code also allow without complaint. Removing it eliminates a false-alarm prompt that added no functional value.

## Reviewer Test Plan

### How to verify

1. Check out the branch and run `cd packages/cli && npx vitest run src/utils/userStartupWarnings.test.ts` — all 3 tests pass.
2. Run `npm run typecheck` and `npx eslint packages/cli/src/utils/userStartupWarnings.ts packages/cli/src/utils/userStartupWarnings.test.ts` — both clean.
3. (Optional, behavioral) From the repo run `cd ~ && npm run dev` and confirm no "home directory" warning appears at startup; the root-directory warning still fires under `/`.

### Evidence (Before & After)

Non-UI change (warning text removal). Before: launching in `~` printed "You are running Qwen Code in your home directory. It is recommended to run in a project-specific directory." After: no message is printed. N/A for screenshots.

### Tested on

| OS | Status |
| :-- | :----: |
| macOS | tested |
| Windows | N/A |
| Linux | N/A |

### Environment

Local unit tests + typecheck/lint only. No sandbox or runtime involved.

## Risk & Scope

- Main risk or tradeoff: A user who launches in `$HOME` and encounters slow file searches no longer gets a hint pointing them toward a project directory. Mitigated by the fact that the memory layer already special-cases `$HOME`, so search behavior is bounded.
- Not validated / out of scope: Windows/Linux runtime not tested locally; relying on CI.
- Breaking changes / migration notes: None. Pure removal of a startup message; no config or API change.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

移除了 "You are running Qwen Code in your home directory" 启动提醒。当工作区根目录等于用户 home 目录时，Qwen Code 不再在启动时打印这条提示。根目录和 ripgrep 可用性的提醒保持不变。

## 为什么需要

在 `$HOME` 下运行已经由 memory 层正确处理——当 `cwd === home` 时，会传入空的 effective cwd 以跳过 workspace memory 搜索。也就是说，home 目录是完全支持的工作目录，不是降级状态。

这条提醒纯属噪音：它从未告诉用户该怎么处理，而从 home 目录协同工作（如管理 `~/.qwen` 配置、跨项目草稿）是合理的使用场景，同类编码 agent 如 Claude Code 在 home 下运行也不会报错。移除它消除了一个没有功能价值的误报提示。

## 评审测试计划

### 如何验证

1. 检出分支，运行 `cd packages/cli && npx vitest run src/utils/userStartupWarnings.test.ts`——3 个测试全部通过。
2. 运行 `npm run typecheck` 和 `npx eslint packages/cli/src/utils/userStartupWarnings.ts packages/cli/src/utils/userStartupWarnings.test.ts`——均无报错。
3. （可选，行为验证）在仓库中执行 `cd ~ && npm run dev`，确认启动时不再出现 "home directory" 提醒；根目录下 `/` 仍会触发根目录提醒。

### 证据（前后对比）

非 UI 改动（移除提示文字）。之前：在 `~` 下启动会打印 "You are running Qwen Code in your home directory. It is recommended to run in a project-specific directory."。之后：不再打印。截图 N/A。

### 测试环境

| OS | 状态 |
| :-- | :----: |
| macOS | tested |
| Windows | N/A |
| Linux | N/A |

### 环境

仅本地单测 + typecheck/lint。未使用沙箱或运行时。

## 风险与范围

- 主要风险/权衡：在 `$HOME` 下启动并遇到慢速文件搜索的用户不再获得指向项目目录的提示。由于 memory 层已对 `$HOME` 做特殊处理，搜索行为是有边界的，风险可控。
- 未验证/范围外：Windows/Linux 运行时未在本地测试，依赖 CI。
- 破坏性变更/迁移说明：无。仅移除启动提示，无配置或 API 变更。

## 关联 Issue

无
</details>
