### PR TITLE
ci: give each CI job one home in the merge-queue flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,9 @@ jobs:
     needs: 'classify_pr'
     # Stay running on release-sync PRs so the required Test contexts still
     # report; the per-step skip_ci guards below make them no-op (pass) there.
-    if: '${{ !cancelled() }}'
+    # Not on push: the merge queue already tested the merged tree, so a
+    # post-merge re-run on `main` would be redundant.
+    if: "${{ !cancelled() && github.event_name != 'push' }}"
     runs-on: '${{ fromJSON(needs.classify_pr.outputs.ubuntu_runner || ''["ubuntu-latest"]'') }}'
     permissions:
       contents: 'read'
@@ -272,16 +274,18 @@ jobs:
           name: 'coverage-reports-22.x-ubuntu-latest'
           path: 'packages/*/coverage'
 
-  # macOS/Windows: slowest/costliest runners, rare platform regressions — skip
-  # on PR, run on push to `main` and in the merge queue. Two named jobs, not a
-  # matrix: a skipped matrix job reports one collapsed check name, never the
-  # per-OS required contexts, so PRs would sit "Expected" forever and never
-  # enter the queue. A skipped named job reports under its exact name and
-  # satisfies the required check (same as the Integration Tests job).
+  # macOS/Windows: slowest/costliest runners, rare platform regressions — run
+  # only in the merge queue. Skipped on PR (ubuntu is the fast PR signal) and on
+  # push (the queue already tested the merged tree, so a post-merge re-run is
+  # redundant). Two named jobs, not a matrix: a skipped matrix job reports one
+  # collapsed check name, never the per-OS required contexts, so PRs would sit
+  # "Expected" forever and never enter the queue. A skipped named job reports
+  # under its exact name and satisfies the required check (same as the
+  # Integration Tests job).
   test_macos:
     name: 'Test (macos-latest, Node 22.x)'
     needs: 'classify_pr'
-    if: "${{ !cancelled() && github.event_name != 'pull_request' }}"
+    if: "${{ !cancelled() && github.event_name == 'merge_group' }}"
     runs-on: 'macos-latest'
     permissions:
       contents: 'read'
@@ -329,7 +333,7 @@ jobs:
   test_windows:
     name: 'Test (windows-latest, Node 22.x)'
     needs: 'classify_pr'
-    if: "${{ !cancelled() && github.event_name != 'pull_request' }}"
+    if: "${{ !cancelled() && github.event_name == 'merge_group' }}"
     runs-on: 'windows-2022'
     permissions:
       contents: 'read'
@@ -418,10 +422,12 @@ jobs:
   codeql:
     name: 'CodeQL'
     needs: 'classify_pr'
-    # Security findings rarely change push-to-push, so a slow scan on every PR
-    # push is poor value. Skip on PR pushes; CodeQL still runs on push to `main`
-    # (and in the merge queue, once enabled) as the pre-/post-merge backstop.
-    if: "${{ !cancelled() && needs.classify_pr.outputs.skip_ci != 'true' && github.event_name != 'pull_request' }}"
+    # Security findings rarely change push-to-push, and a slow scan is poor value
+    # as a hard merge gate. Run CodeQL only on push to `main` (post-merge
+    # backstop) — not on PR pushes, and not in the merge queue where, being
+    # non-required, it would just burn a runner and lengthen the serial queue
+    # without blocking anything.
+    if: "${{ !cancelled() && needs.classify_pr.outputs.skip_ci != 'true' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}"
     runs-on: 'ubuntu-latest'
     # Analysis normally finishes in ~7-9 min (22 min worst case observed). Without
     # an explicit cap, a hosted runner that drops its heartbeat mid-analysis leaves

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,11 +1,14 @@
 name: 'E2E Tests'
 
 on:
+  # E2E runs post-merge on `main` (per-commit signal) only. It is intentionally
+  # NOT in the merge queue yet: it is slow and currently flaky, so gating the
+  # serial queue on it would stall every merge. Promote it to `merge_group` +
+  # required once it is reliable.
   push:
     branches:
       - 'main'
       - 'feat/e2e/**'
-  merge_group:
 
 concurrency:
   # Key on the head ref so a `push` to a `feat/e2e/**` branch and a
@@ -13,11 +16,10 @@ concurrency:
   # other instead of running the matrix twice for the same change.
   group: |-
     ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  # Cancel superseded PR / feature-branch runs, but let every `main`
-  # commit finish (complete per-commit e2e signal, matching ci.yml) and
-  # never cancel merge-queue runs.
+  # Cancel superseded feature-branch runs, but let every `main` commit finish
+  # (complete per-commit e2e signal, matching ci.yml).
   cancel-in-progress: |-
-    ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/main') }}
+    ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
 
 jobs:
   e2e-test-linux:


### PR DESCRIPTION
## What this PR does

Now that the merge queue is live, make each CI job run in exactly one place instead of doubling up:

- CodeQL and E2E leave the merge queue (CodeQL gains a `merge_group` guard; E2E loses its `merge_group:` trigger). They keep running post-merge on push to `main`.
- macOS and Windows tests move to `merge_group` only (they were also running on push to `main`), and the ubuntu Test job stops running on push too.

Net: a PR runs ubuntu; the merge queue runs ubuntu + integration + mac + win (the gate); push to `main` runs CodeQL + E2E (the backstop). No job runs in two of those.

## Why it's needed

Two kinds of waste showed up once the queue was enabled:

- CodeQL and E2E aren't required checks, so they never gated a merge — yet both triggered on `merge_group`, so every merge group ran them for nothing. On recent queue runs (#5660, #5830) CodeQL ran ~30 min and got cancelled the instant the required checks passed and the PR merged; the three E2E jobs each burned ~25/36/36 min of hosted time. That's roughly half the queue's hosted compute, and the main driver of the merge-time spike on the hosted pool. E2E is also flaky, so it shouldn't gate the serial queue yet.
- The required gate jobs (ubuntu / macOS / Windows) ran in the merge queue *and* again on the post-merge push to `main`. The queue already tests the merged tree, so the push re-run is redundant.

Moving the backstop jobs out of the queue and the gate jobs out of push leaves a clean split with no job running twice.

## Reviewer Test Plan

### How to verify

- `actionlint .github/workflows/ci.yml .github/workflows/e2e.yml` passes.
- ci.yml: the `test` (ubuntu) `if` now excludes `push`; `test_macos` / `test_windows` run only on `merge_group`; `codeql` excludes both `pull_request` and `merge_group`.
- e2e.yml: `on:` no longer lists `merge_group`.
- The named mac/win jobs still report under their exact required-check names (skipped) on PRs, so PRs still enter the queue.
- After merge: a merge-queue run runs ubuntu + integration + mac + win and no CodeQL/E2E; a push to `main` runs CodeQL + E2E and not the gate jobs.

### Evidence (Before & After)

N/A — CI-config only, no user-visible change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A  |
| 🪟 Windows |  N/A  |
|  🐧 Linux  |  ⚠️ actionlint only; runtime effect observable on CI  |

### Environment (optional)

N/A — workflow change.

## Risk & Scope

- Main risk or tradeoff: the gate jobs (mac/win/ubuntu) no longer run on `push: main`, so a commit that lands without going through the queue wouldn't get a post-merge run from them — but the merge queue is required (enforce admins on), so that path is `--admin` only. CodeQL/E2E failures now surface on the post-merge `main` run rather than (non-blockingly) inside the queue; a notification on a red `main` is a sensible follow-up.
- Not validated / out of scope: no merge-queue setting or required-check list changes; E2E build-once-reuse and moving the docker variant to nightly are separate follow-ups.
- Breaking changes / migration notes: none.

## Linked Issues

Related to #4805 (merge-queue rollout); follow-up to #5813.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

队列上线后，让每个 CI job 只在一个地方跑，别再双跑：

- CodeQL 和 E2E 退出 merge queue（CodeQL 加 `merge_group` 守卫；E2E 删掉 `merge_group:` 触发），仍在合并后的 push to `main` 上跑。
- macOS / Windows 测试改成只在 `merge_group` 跑（之前也在 push to `main` 跑），ubuntu Test 也不再在 push 跑。

结果：PR 跑 ubuntu；队列跑 ubuntu + integration + mac + win（门）；push to `main` 跑 CodeQL + E2E（兜底）。没有 job 跑两次。

## 为什么需要

队列开了之后冒出两类浪费：

- CodeQL/E2E 不是 required check，拦不住合并，却都挂在 `merge_group` 上，每个 merge group 白跑一遍。最近的队列 run（#5660、#5830）实测：CodeQL 跑约 30 分钟、等 required 过、PR 一合并就被 cancel；三个 E2E job 各烧约 25/36/36 分钟托管时间。约等于队列里一半的托管算力，也是托管池合并尖峰的主因。E2E 还 flaky，更不该现在 gate 串行队列。
- required 的门 job（ubuntu / macOS / Windows）在队列里跑了一遍，合并后又在 push to `main` 上再跑一遍。队列已经测过合并后的树，push 这次是冗余。

把兜底类移出队列、把门类移出 push，就得到一个互不重复的干净划分。

## 验证方式

- `actionlint .github/workflows/ci.yml .github/workflows/e2e.yml` 通过。
- ci.yml：`test`(ubuntu) 的 `if` 排除 `push`；`test_macos`/`test_windows` 只在 `merge_group` 跑；`codeql` 同时排除 `pull_request` 和 `merge_group`。
- e2e.yml：`on:` 不再有 `merge_group`。
- 具名的 mac/win job 在 PR 上仍按精确的 required-check 名上报（skipped），所以 PR 照样能进队列。
- 合并后：merge-queue run 跑 ubuntu + integration + mac + win、无 CodeQL/E2E；push 到 `main` 跑 CodeQL + E2E、不跑门 job。

### 证据（Before & After）

N/A —— 仅 CI 配置，无用户可见变化。

## 风险与范围

- 主要权衡：门 job（mac/win/ubuntu）不再在 `push: main` 跑，所以不经队列直接落 main 的 commit 不会有它们的合并后兜底——但队列是强制的（enforce admins 开），那条路只剩 `--admin`。CodeQL/E2E 失败改为在合并后的 `main` run 上暴露，而非（非阻断地）在队列里；给红 `main` 加通知是合理后续。
- 未验证 / 范围外：不改 merge-queue 设置或 required 列表；E2E build 复用、docker 变体降级 nightly 是单独后续。
- 破坏性变更 / 迁移：无。

## 关联 issue

关联 #4805（merge queue 推进）；#5813 的后续。

</details>
