### PR TITLE
ci(release): drop --delete-branch from auto-merge to support merge queue

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -681,10 +681,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Omit --delete-branch: it is rejected when a merge queue is enabled;
+          # the repo's "automatically delete head branches" setting handles it.
           gh pr merge "$PR_URL" \
             --squash \
             --auto \
-            --delete-branch \
             --subject "chore(release): desktop ${RELEASE_TAG} [skip ci]"
 
   dry-run-summary:

--- a/.github/workflows/release-sdk-python.yml
+++ b/.github/workflows/release-sdk-python.yml
@@ -474,7 +474,9 @@ jobs:
           PR_URL: '${{ steps.pr.outputs.PR_URL }}'
         run: |
           set -euo pipefail
-          gh pr merge "${PR_URL}" --merge --auto --delete-branch
+          # Omit --delete-branch: it is rejected when a merge queue is enabled;
+          # the repo's "automatically delete head branches" setting handles it.
+          gh pr merge "${PR_URL}" --merge --auto
 
       - name: 'Create issue on failure'
         if: |-

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -417,10 +417,11 @@ jobs:
           # Keep [skip ci] only on the squash commit that lands on main. The
           # release branch commit and PR title intentionally omit it so tag-push
           # workflows and PR metadata stay unaffected.
+          # Omit --delete-branch: it is rejected when a merge queue is enabled;
+          # the repo's "automatically delete head branches" setting handles it.
           gh pr merge "${PR_URL}" \
             --squash \
             --auto \
-            --delete-branch \
             --subject "chore(release): sdk-typescript ${RELEASE_TAG} [skip ci]"
 
       - name: 'Create Issue on Failure'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -540,10 +540,11 @@ jobs:
           # Keep [skip ci] only on the squash commit that lands on main. The
           # release branch commit and PR title intentionally omit it so tag-push
           # workflows and PR metadata stay unaffected.
+          # Omit --delete-branch: it is rejected when a merge queue is enabled;
+          # the repo's "automatically delete head branches" setting handles it.
           gh pr merge "${PR_URL}" \
             --squash \
             --auto \
-            --delete-branch \
             --subject "chore(release): ${RELEASE_TAG} [skip ci]"
 
   notify_failure:


### PR DESCRIPTION
## What this PR does

Removes the `--delete-branch` flag from the `gh pr merge` call in the auto-merge step of all four release workflows (`release.yml`, `desktop-release.yml`, `release-sdk.yml`, `release-sdk-python.yml`), keeping `--auto` and the squash/merge settings unchanged. Branch cleanup now relies on the repository's "Automatically delete head branches" setting.

## Why it's needed

The latest `main` release run failed at the final **Enable auto-merge for release PR** step with `Cannot use -d or --delete-branch when merge queue enabled`. A merge queue is now enabled on `main`, and the GitHub CLI refuses `--delete-branch` (`-d`) together with `--auto` once the base branch has a queue. By the time this step ran the release was already complete — npm packages published, the `v0.19.2` tag and GitHub Release created, and the version-bump PR opened and approved — so only the housekeeping PR was left un-queued. Dropping the incompatible flag lets the auto-merge step queue the PR cleanly; the merge queue plus the repo's auto-delete-head-branch setting still removes the branch after merge.

## Reviewer Test Plan

### How to verify

This is a CI-only change to release workflows that cannot be exercised by a full local release. Verification:

- Read the diff: each workflow's `gh pr merge ... --auto` call no longer passes `--delete-branch`; `--squash`/`--merge`, `--auto`, and `--subject` are unchanged.
- Confirm the four YAML files still parse (validated locally with a YAML parser — all OK).
- Cross-check against the failing run log, which shows the exact error string `Cannot use -d or --delete-branch when merge queue enabled` from `gh pr merge --auto --delete-branch`.

Expected: the next release's auto-merge step queues the release PR without erroring; the head branch is still deleted after the queued merge via the repository setting.

### Evidence (Before & After)

N/A — non-user-visible CI workflow change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ (YAML parse only)   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

N/A — no local runtime; YAML syntax validated only. Real verification happens on the next release run in CI.

## Risk & Scope

- Main risk or tradeoff: the release branch is no longer deleted by `gh` directly; it relies on the repo's "Automatically delete head branches" setting. If that setting is off, stale `release/*` branches would accumulate.
- Not validated / out of scope: an end-to-end release run (cannot be triggered locally); whether the merge queue is enabled on every base branch these four workflows target.
- Breaking changes / migration notes: none.

## Linked Issues

Surfaced by release run https://github.com/QwenLM/qwen-code/actions/runs/28101728630 (no tracking issue).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把四个 release workflow(`release.yml`、`desktop-release.yml`、`release-sdk.yml`、`release-sdk-python.yml`)里 auto-merge 步骤的 `gh pr merge` 调用中的 `--delete-branch` 参数去掉,`--auto` 以及 squash/merge 等其余设置保持不变。分支清理改为依赖仓库的 "Automatically delete head branches" 设置。

## 为什么需要

最近一次 `main` 的 release 在最后一步 **Enable auto-merge for release PR** 失败,报错 `Cannot use -d or --delete-branch when merge queue enabled`。现在 `main` 启用了 merge queue(合并队列),GitHub CLI 在 base 分支有队列时不允许 `--delete-branch`(`-d`)和 `--auto` 一起用。这一步执行时 release 其实已经完成——npm 包已发布、`v0.19.2` tag 和 GitHub Release 已创建、版本回填 PR 已创建并 approve——只剩这个收尾 PR 没能进队列合并。去掉这个不兼容的参数后,auto-merge 步骤就能正常把 PR 加入队列;合并后分支仍由 merge queue 配合仓库的自动删除 head 分支设置清理。

## 验证方式

这是只动 release workflow 的 CI 改动,无法靠本地完整跑一遍 release 来验证。验证手段:

- 看 diff:每个 workflow 的 `gh pr merge ... --auto` 调用不再传 `--delete-branch`;`--squash`/`--merge`、`--auto`、`--subject` 均未变。
- 确认四个 YAML 文件仍能解析(已用本地 YAML 解析器验证,全部 OK)。
- 对照失败 run 的日志,其中正是 `gh pr merge --auto --delete-branch` 抛出的 `Cannot use -d or --delete-branch when merge queue enabled`。

预期:下次 release 的 auto-merge 步骤不再报错、能正常把 release PR 入队;合并后 head 分支仍由仓库设置删除。

## 证据(前后对比)

N/A —— 非用户可见的 CI workflow 改动。

## 测试平台

仅本地校验了 YAML 语法(macOS),Windows/Linux 未单独测试;真正的端到端验证发生在下一次 CI release 运行。

## 风险与范围

- 主要风险/取舍:release 分支不再由 `gh` 直接删除,改为依赖仓库的 "Automatically delete head branches" 设置;若该设置关闭,`release/*` 分支会堆积。
- 未验证/范围外:端到端 release 全流程(无法本地触发);这四个 workflow 各自的 base 分支是否都启用了 merge queue。
- 破坏性变更/迁移说明:无。

## 关联

由 release run https://github.com/QwenLM/qwen-code/actions/runs/28101728630 暴露(无跟踪 issue)。

</details>
