### PR TITLE
feat(cli): support @extension mention in input autocomplete

### DIFF
--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -533,7 +533,7 @@ export async function resolveAtCommandQuery({
             );
             return null;
           }
-          return fs.readFile(resolved, 'utf-8');
+          return fs.readFile(resolved, { encoding: 'utf-8', signal });
         }),
       );
 

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -244,6 +244,11 @@ export async function resolveAtCommandQuery({
         atPathToResolvedSpecMap.set(originalAtPath, pathName);
         continue;
       }
+      onDebugMessage(
+        `Extension "${extRef.name}" not found among active extensions. ` +
+          `Available: ${activeExtensions.map((e) => e.name).join(', ') || '(none)'}`,
+      );
+      continue;
     }
 
     // MCP resource reference (`@server:uri`): detected BEFORE filesystem

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -7,7 +7,7 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import type { Part, PartListUnion } from '@google/genai';
-import type { Config } from '@qwen-code/qwen-code-core';
+import type { Config, Extension } from '@qwen-code/qwen-code-core';
 import {
   getErrorMessage,
   isNodeError,
@@ -27,6 +27,11 @@ import type {
 } from '../types.js';
 import { ToolCallStatus } from '../types.js';
 import { matchMcpServerPrefix } from './mcpResourceRef.js';
+import {
+  parseExtensionRef,
+  matchExtensionByRef,
+  buildExtensionContextText,
+} from './extension-mention-ref.js';
 
 export interface ResolveAtCommandParams {
   query: string;
@@ -205,6 +210,13 @@ export async function resolveAtCommandQuery({
     uri: string;
   }> = [];
 
+  // Extension references (`@ext:<name>`) collected during the loop.
+  const activeExtensions = config.getActiveExtensions?.() ?? [];
+  const extensionMentions: Array<{
+    originalAtPath: string;
+    extension: Extension;
+  }> = [];
+
   for (const atPathPart of atPathCommandParts) {
     const originalAtPath = atPathPart.content; // e.g., "@file.txt" or "@"
 
@@ -216,6 +228,19 @@ export async function resolveAtCommandQuery({
     }
 
     const pathName = originalAtPath.substring(1);
+
+    // Extension reference (`@ext:<name>`): detected BEFORE MCP/filesystem
+    // resolution. Only matches when the path starts with `ext:` and the name
+    // corresponds to an active extension.
+    const extRef = parseExtensionRef(pathName);
+    if (extRef) {
+      const extension = matchExtensionByRef(extRef.name, activeExtensions);
+      if (extension) {
+        extensionMentions.push({ originalAtPath, extension });
+        atPathToResolvedSpecMap.set(originalAtPath, pathName);
+        continue;
+      }
+    }
 
     // MCP resource reference (`@server:uri`): detected BEFORE filesystem
     // resolution so a resource URI containing ':' / '//' isn't mistaken for
@@ -444,8 +469,12 @@ export async function resolveAtCommandQuery({
 
   // Fallback for lone "@" or completely invalid @-commands resulting in empty
   // initialQueryText — only when there is nothing to read at all (no valid
-  // file paths AND no resource references).
-  if (pathSpecsToRead.length === 0 && mcpResourceRefs.length === 0) {
+  // file paths, resource references, or extension mentions).
+  if (
+    pathSpecsToRead.length === 0 &&
+    mcpResourceRefs.length === 0 &&
+    extensionMentions.length === 0
+  ) {
     onDebugMessage('No valid file paths found in @ commands to read.');
     if (initialQueryText === '@' && query.trim() === '@') {
       // If the only thing was a lone @, pass original query (which might have spaces)
@@ -530,6 +559,50 @@ export async function resolveAtCommandQuery({
     }
   }
 
+  // Build extension context parts and display cards for @-mentioned extensions.
+  const extensionParts: Part[] = [];
+  const extensionDisplays: IndividualToolCallDisplay[] = [];
+  const extensionLabels: string[] = [];
+  for (let i = 0; i < extensionMentions.length; i++) {
+    const { extension } = extensionMentions[i];
+    const displayName = extension.displayName || extension.name;
+    const callId = `client-extension-${userMessageTimestamp}-${i}`;
+
+    // Build context text describing the extension's capabilities.
+    let contextText = buildExtensionContextText(extension);
+
+    // Read extension context files (e.g., QWEN.md bundled with the extension)
+    // and append their content to the injection block.
+    if (extension.contextFiles && extension.contextFiles.length > 0) {
+      for (const contextFilePath of extension.contextFiles) {
+        try {
+          const content = await fs.readFile(contextFilePath, 'utf-8');
+          if (content.trim()) {
+            // Cap at 50KB per context file to avoid blowing up the context
+            const cappedContent =
+              content.length > 50_000
+                ? content.slice(0, 50_000) + '\n... (truncated)'
+                : content;
+            contextText += `\n\n${cappedContent}`;
+          }
+        } catch {
+          // Skip unreadable context files silently
+        }
+      }
+    }
+
+    extensionParts.push({ text: contextText });
+    extensionLabels.push(`ext:${extension.name}`);
+    extensionDisplays.push({
+      callId,
+      name: 'Activate Extension',
+      description: `Activated extension ${displayName}`,
+      status: ToolCallStatus.Success,
+      resultDisplay: undefined,
+      confirmationDetails: undefined,
+    });
+  }
+
   // File and resource content are grouped by type, NOT interleaved by their
   // position in the user's query. The model correlates each @-reference with
   // its content block via the "--- Content from ... ---" delimiter labels (and
@@ -537,15 +610,20 @@ export async function resolveAtCommandQuery({
   // positional alignment, so grouping is safe.
   const processedQueryParts: PartListUnion = [
     { text: initialQueryText },
+    ...extensionParts,
     ...fileParts,
     ...resourceParts,
   ];
-  const allLabels = [...contentLabelsForDisplay, ...resourceLabels];
+  const allLabels = [
+    ...extensionLabels,
+    ...contentLabelsForDisplay,
+    ...resourceLabels,
+  ];
 
   return {
     processedQuery: processedQueryParts,
     shouldProceed: true,
-    toolDisplays: [...fileDisplays, ...resourceDisplays],
+    toolDisplays: [...extensionDisplays, ...fileDisplays, ...resourceDisplays],
     filesRead: allLabels,
     recording: {
       filesRead: allLabels,

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -494,76 +494,10 @@ export async function resolveAtCommandQuery({
     };
   }
 
-  // Read files (if any). A hard read error aborts the turn, as before — but
-  // any resource tool-cards already gathered are still surfaced.
-  const fileParts: Part[] = [];
-  let fileDisplays: IndividualToolCallDisplay[] = [];
-  if (pathSpecsToRead.length > 0) {
-    try {
-      const result = await readManyFiles(config, {
-        paths: pathSpecsToRead,
-        signal,
-        preserveUnsupportedImageForBridge: shouldRunVisionBridge(config),
-      });
-
-      const parts = Array.isArray(result.contentParts)
-        ? result.contentParts
-        : [result.contentParts];
-
-      // Create individual tool call displays for each file read
-      fileDisplays = result.files.map((file, index) => ({
-        callId: `client-read-${userMessageTimestamp}-${index}`,
-        name: file.isDirectory ? 'Read Directory' : 'Read File',
-        description: file.isDirectory
-          ? `Read directory ${path.basename(file.filePath)}`
-          : `Read file ${path.basename(file.filePath)}`,
-        status: file.error ? ToolCallStatus.Error : ToolCallStatus.Success,
-        resultDisplay: file.error
-          ? `Failed to read ${path.basename(file.filePath)}: ${file.error}`
-          : undefined,
-        confirmationDetails: undefined,
-      }));
-
-      if (parts.length > 0 && !result.error) {
-        // readManyFiles now returns properly formatted parts with headers and prefixes
-        for (const part of parts) {
-          fileParts.push(typeof part === 'string' ? { text: part } : part);
-        }
-      } else {
-        onDebugMessage('readManyFiles returned no content or empty content.');
-      }
-    } catch (error: unknown) {
-      const errorToolCallDisplay: IndividualToolCallDisplay = {
-        callId: `client-read-${userMessageTimestamp}`,
-        name: 'Read File(s)',
-        description: 'Error attempting to read files',
-        status: ToolCallStatus.Error,
-        resultDisplay: `Error reading files (${contentLabelsForDisplay.join(', ')}): ${getErrorMessage(error)}`,
-        confirmationDetails: undefined,
-      };
-      const errorMessage =
-        typeof errorToolCallDisplay.resultDisplay === 'string'
-          ? errorToolCallDisplay.resultDisplay
-          : undefined;
-      // Resource labels are merged in too: a resource may have been read
-      // successfully before the file read failed, and its card is already in
-      // `resourceDisplays` above — the audit trail must not drop it.
-      const labelsOnError = [...contentLabelsForDisplay, ...resourceLabels];
-      return {
-        processedQuery: null,
-        shouldProceed: false,
-        toolDisplays: [...resourceDisplays, errorToolCallDisplay],
-        filesRead: labelsOnError,
-        recording: {
-          filesRead: labelsOnError,
-          status: 'error',
-          message: errorMessage,
-        },
-      };
-    }
-  }
-
   // Build extension context parts and display cards for @-mentioned extensions.
+  // Processed BEFORE file reads so that extension labels/displays are available
+  // in the file-read error path (mirroring how resourceDisplays/resourceLabels
+  // are already built before the file read).
   // Aggregate cap across all extensions to prevent unbounded context injection.
   const EXTENSION_CONTEXT_BUDGET = 200_000; // 200KB total
   const PER_FILE_CAP = 50_000; // 50KB per context file
@@ -631,6 +565,78 @@ export async function resolveAtCommandQuery({
       resultDisplay: undefined,
       confirmationDetails: undefined,
     });
+  }
+
+  // Read files (if any). A hard read error aborts the turn, as before — but
+  // any extension/resource tool-cards already gathered are still surfaced.
+  const fileParts: Part[] = [];
+  let fileDisplays: IndividualToolCallDisplay[] = [];
+  if (pathSpecsToRead.length > 0) {
+    try {
+      const result = await readManyFiles(config, {
+        paths: pathSpecsToRead,
+        signal,
+        preserveUnsupportedImageForBridge: shouldRunVisionBridge(config),
+      });
+
+      const parts = Array.isArray(result.contentParts)
+        ? result.contentParts
+        : [result.contentParts];
+
+      fileDisplays = result.files.map((file, index) => ({
+        callId: `client-read-${userMessageTimestamp}-${index}`,
+        name: file.isDirectory ? 'Read Directory' : 'Read File',
+        description: file.isDirectory
+          ? `Read directory ${path.basename(file.filePath)}`
+          : `Read file ${path.basename(file.filePath)}`,
+        status: file.error ? ToolCallStatus.Error : ToolCallStatus.Success,
+        resultDisplay: file.error
+          ? `Failed to read ${path.basename(file.filePath)}: ${file.error}`
+          : undefined,
+        confirmationDetails: undefined,
+      }));
+
+      if (parts.length > 0 && !result.error) {
+        for (const part of parts) {
+          fileParts.push(typeof part === 'string' ? { text: part } : part);
+        }
+      } else {
+        onDebugMessage('readManyFiles returned no content or empty content.');
+      }
+    } catch (error: unknown) {
+      const errorToolCallDisplay: IndividualToolCallDisplay = {
+        callId: `client-read-${userMessageTimestamp}`,
+        name: 'Read File(s)',
+        description: 'Error attempting to read files',
+        status: ToolCallStatus.Error,
+        resultDisplay: `Error reading files (${contentLabelsForDisplay.join(', ')}): ${getErrorMessage(error)}`,
+        confirmationDetails: undefined,
+      };
+      const errorMessage =
+        typeof errorToolCallDisplay.resultDisplay === 'string'
+          ? errorToolCallDisplay.resultDisplay
+          : undefined;
+      const labelsOnError = [
+        ...extensionLabels,
+        ...contentLabelsForDisplay,
+        ...resourceLabels,
+      ];
+      return {
+        processedQuery: null,
+        shouldProceed: false,
+        toolDisplays: [
+          ...extensionDisplays,
+          ...resourceDisplays,
+          errorToolCallDisplay,
+        ],
+        filesRead: labelsOnError,
+        recording: {
+          filesRead: labelsOnError,
+          status: 'error',
+          message: errorMessage,
+        },
+      };
+    }
   }
 
   // File and resource content are grouped by type, NOT interleaved by their

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -236,7 +236,11 @@ export async function resolveAtCommandQuery({
     if (extRef) {
       const extension = matchExtensionByRef(extRef.name, activeExtensions);
       if (extension) {
-        extensionMentions.push({ originalAtPath, extension });
+        if (
+          !extensionMentions.some((m) => m.extension.name === extension.name)
+        ) {
+          extensionMentions.push({ originalAtPath, extension });
+        }
         atPathToResolvedSpecMap.set(originalAtPath, pathName);
         continue;
       }
@@ -560,6 +564,11 @@ export async function resolveAtCommandQuery({
   }
 
   // Build extension context parts and display cards for @-mentioned extensions.
+  // Aggregate cap across all extensions to prevent unbounded context injection.
+  const EXTENSION_CONTEXT_BUDGET = 200_000; // 200KB total
+  const PER_FILE_CAP = 50_000; // 50KB per context file
+  let extensionContextBudgetRemaining = EXTENSION_CONTEXT_BUDGET;
+
   const extensionParts: Part[] = [];
   const extensionDisplays: IndividualToolCallDisplay[] = [];
   const extensionLabels: string[] = [];
@@ -568,26 +577,47 @@ export async function resolveAtCommandQuery({
     const displayName = extension.displayName || extension.name;
     const callId = `client-extension-${userMessageTimestamp}-${i}`;
 
-    // Build context text describing the extension's capabilities.
     let contextText = buildExtensionContextText(extension);
 
-    // Read extension context files (e.g., QWEN.md bundled with the extension)
-    // and append their content to the injection block.
+    // Read extension context files in parallel, with path traversal and
+    // budget checks.
     if (extension.contextFiles && extension.contextFiles.length > 0) {
-      for (const contextFilePath of extension.contextFiles) {
-        try {
-          const content = await fs.readFile(contextFilePath, 'utf-8');
-          if (content.trim()) {
-            // Cap at 50KB per context file to avoid blowing up the context
-            const cappedContent =
-              content.length > 50_000
-                ? content.slice(0, 50_000) + '\n... (truncated)'
-                : content;
-            contextText += `\n\n${cappedContent}`;
+      const fileReads = await Promise.allSettled(
+        extension.contextFiles.map(async (contextFilePath) => {
+          const resolved = path.resolve(contextFilePath);
+          if (!isSubpath(extension.path, resolved)) {
+            onDebugMessage(
+              `Skipping context file outside extension directory: ${contextFilePath}`,
+            );
+            return null;
           }
-        } catch {
-          // Skip unreadable context files silently
+          return fs.readFile(resolved, 'utf-8');
+        }),
+      );
+
+      for (let j = 0; j < fileReads.length; j++) {
+        const outcome = fileReads[j];
+        if (outcome.status === 'rejected') {
+          onDebugMessage(
+            `Failed to read extension context file ${extension.contextFiles[j]}: ${getErrorMessage(outcome.reason)}`,
+          );
+          continue;
         }
+        const content = outcome.value;
+        if (!content || !content.trim()) continue;
+        if (extensionContextBudgetRemaining <= 0) {
+          onDebugMessage(
+            `Extension context budget exhausted, skipping remaining files.`,
+          );
+          break;
+        }
+        const cap = Math.min(PER_FILE_CAP, extensionContextBudgetRemaining);
+        const cappedContent =
+          content.length > cap
+            ? content.slice(0, cap) + '\n... (truncated)'
+            : content;
+        contextText += `\n\n${cappedContent}`;
+        extensionContextBudgetRemaining -= cappedContent.length;
       }
     }
 

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -19,6 +19,7 @@ import {
   emptyMcpResourceText,
   formatMcpResourceContents,
   summarizeMcpResource,
+  stripTerminalControlSequences,
 } from '@qwen-code/qwen-code-core';
 import type {
   HistoryItemToolGroup,
@@ -513,7 +514,9 @@ export async function resolveAtCommandQuery({
   const extensionLabels: string[] = [];
   for (let i = 0; i < extensionMentions.length; i++) {
     const { extension } = extensionMentions[i];
-    const displayName = extension.displayName || extension.name;
+    const displayName = stripTerminalControlSequences(
+      extension.displayName || extension.name,
+    );
     const callId = `client-extension-${userMessageTimestamp}-${i}`;
 
     let contextText = buildExtensionContextText(extension);

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -31,6 +31,7 @@ import {
   parseExtensionRef,
   matchExtensionByRef,
   buildExtensionContextText,
+  buildExtensionRef,
   sanitizeDisplayText,
 } from './extension-mention-ref.js';
 
@@ -521,19 +522,31 @@ export async function resolveAtCommandQuery({
 
     let contextText = buildExtensionContextText(extension);
 
-    // Read extension context files in parallel, with path traversal and
-    // budget checks.
+    // Read extension context files in parallel, with symlink-aware path
+    // traversal and budget checks.
     if (extension.contextFiles && extension.contextFiles.length > 0) {
       const fileReads = await Promise.allSettled(
         extension.contextFiles.map(async (contextFilePath) => {
-          const resolved = path.resolve(contextFilePath);
-          if (!isSubpath(extension.path, resolved)) {
+          // Resolve symlinks to prevent path traversal via symlinks within
+          // the extension directory (e.g., context.md -> ~/.ssh/id_rsa).
+          let realPath: string;
+          let realExtPath: string;
+          try {
+            realPath = await fs.realpath(contextFilePath);
+            realExtPath = await fs.realpath(extension.path);
+          } catch {
+            onDebugMessage(
+              `Skipping unreadable context file: ${contextFilePath}`,
+            );
+            return null;
+          }
+          if (!isSubpath(realExtPath, realPath)) {
             onDebugMessage(
               `Skipping context file outside extension directory: ${contextFilePath}`,
             );
             return null;
           }
-          return fs.readFile(resolved, { encoding: 'utf-8', signal });
+          return fs.readFile(realPath, { encoding: 'utf-8', signal });
         }),
       );
 
@@ -564,7 +577,7 @@ export async function resolveAtCommandQuery({
     }
 
     extensionParts.push({ text: contextText });
-    extensionLabels.push(`ext:${extension.name}`);
+    extensionLabels.push(buildExtensionRef(extension.name));
     extensionDisplays.push({
       callId,
       name: 'Activate Extension',

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -19,7 +19,6 @@ import {
   emptyMcpResourceText,
   formatMcpResourceContents,
   summarizeMcpResource,
-  stripTerminalControlSequences,
 } from '@qwen-code/qwen-code-core';
 import type {
   HistoryItemToolGroup,
@@ -32,6 +31,7 @@ import {
   parseExtensionRef,
   matchExtensionByRef,
   buildExtensionContextText,
+  sanitizeDisplayText,
 } from './extension-mention-ref.js';
 
 export interface ResolveAtCommandParams {
@@ -514,9 +514,9 @@ export async function resolveAtCommandQuery({
   const extensionLabels: string[] = [];
   for (let i = 0; i < extensionMentions.length; i++) {
     const { extension } = extensionMentions[i];
-    const displayName = stripTerminalControlSequences(
-      extension.displayName || extension.name,
-    );
+    const displayName =
+      sanitizeDisplayText(extension.displayName || extension.name) ||
+      extension.name;
     const callId = `client-extension-${userMessageTimestamp}-${i}`;
 
     let contextText = buildExtensionContextText(extension);

--- a/packages/cli/src/ui/hooks/extension-mention-ref.test.ts
+++ b/packages/cli/src/ui/hooks/extension-mention-ref.test.ts
@@ -13,6 +13,7 @@ import {
   buildExtensionContextText,
   EXTENSION_REF_PREFIX,
 } from './extension-mention-ref.js';
+import { MAX_SUGGESTIONS_TO_SHOW } from '../components/SuggestionsDisplay.js';
 import type {
   Config,
   Extension,
@@ -186,6 +187,58 @@ describe('getExtensionSuggestions', () => {
     expect(suggestions[0]!.sourceBadge).toBe('Extension');
     expect(suggestions[0]!.description).toBe('Test description');
     expect(suggestions[0]!.isDirectory).toBe(false);
+  });
+
+  it('returns empty when folder is not trusted', () => {
+    const config = {
+      isTrustedFolder: () => false,
+      getActiveExtensions: () => [makeExtension({ name: 'browser' })],
+    } as unknown as Config;
+    expect(getExtensionSuggestions(config, '')).toEqual([]);
+  });
+
+  it('caps results at MAX_SUGGESTIONS_TO_SHOW', () => {
+    const many = Array.from({ length: 12 }, (_, i) =>
+      makeExtension({ name: `ext-${String(i).padStart(2, '0')}` }),
+    );
+    const config = {
+      getActiveExtensions: () => many,
+    } as unknown as Config;
+    const suggestions = getExtensionSuggestions(config, '');
+    expect(suggestions).toHaveLength(MAX_SUGGESTIONS_TO_SHOW);
+  });
+
+  it('filters by displayName when name does not match', () => {
+    const config = {
+      getActiveExtensions: () => [
+        makeExtension({
+          name: 'code-ast',
+          displayName: 'Code Assistant',
+        }),
+      ],
+    } as unknown as Config;
+    const suggestions = getExtensionSuggestions(config, 'assist');
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]!.value).toBe('ext:code-ast');
+  });
+
+  it('strips terminal control sequences from label and description', () => {
+    const config = {
+      getActiveExtensions: () => [
+        makeExtension({
+          name: 'evil',
+          displayName: '\x1b[31mEvil\x1b[0m',
+          config: {
+            name: 'evil',
+            version: '1.0.0',
+            description: '\x1b[1mBad desc\x1b[0m',
+          },
+        }),
+      ],
+    } as unknown as Config;
+    const suggestions = getExtensionSuggestions(config, '');
+    expect(suggestions[0]!.label).not.toContain('\x1b');
+    expect(suggestions[0]!.description).not.toContain('\x1b');
   });
 });
 

--- a/packages/cli/src/ui/hooks/extension-mention-ref.test.ts
+++ b/packages/cli/src/ui/hooks/extension-mention-ref.test.ts
@@ -1,0 +1,245 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseExtensionRef,
+  buildExtensionRef,
+  matchExtensionByRef,
+  getExtensionSuggestions,
+  buildExtensionContextText,
+  EXTENSION_REF_PREFIX,
+} from './extension-mention-ref.js';
+import type {
+  Config,
+  Extension,
+  SkillConfig,
+  SubagentConfig,
+  MCPServerConfig,
+} from '@qwen-code/qwen-code-core';
+
+function makeExtension(overrides: Partial<Extension> = {}): Extension {
+  return {
+    id: 'test-ext',
+    name: 'test-ext',
+    version: '1.0.0',
+    isActive: true,
+    path: '/extensions/test-ext',
+    config: {
+      name: 'test-ext',
+      version: '1.0.0',
+      description: 'A test extension',
+    },
+    contextFiles: [],
+    ...overrides,
+  } as Extension;
+}
+
+describe('parseExtensionRef', () => {
+  it('returns null for non-ext: input', () => {
+    expect(parseExtensionRef('file.txt')).toBeNull();
+    expect(parseExtensionRef('server:resource')).toBeNull();
+    expect(parseExtensionRef('')).toBeNull();
+  });
+
+  it('returns null for bare ext: without name', () => {
+    expect(parseExtensionRef('ext:')).toBeNull();
+  });
+
+  it('returns name for valid ext: ref', () => {
+    expect(parseExtensionRef('ext:browser')).toEqual({ name: 'browser' });
+    expect(parseExtensionRef('ext:my-extension')).toEqual({
+      name: 'my-extension',
+    });
+  });
+
+  it('is case-sensitive on the prefix', () => {
+    expect(parseExtensionRef('EXT:browser')).toBeNull();
+    expect(parseExtensionRef('Ext:browser')).toBeNull();
+  });
+});
+
+describe('buildExtensionRef', () => {
+  it('produces ext:<name>', () => {
+    expect(buildExtensionRef('browser')).toBe('ext:browser');
+    expect(buildExtensionRef('my-ext')).toBe('ext:my-ext');
+  });
+
+  it('uses the EXTENSION_REF_PREFIX constant', () => {
+    expect(buildExtensionRef('foo').startsWith(EXTENSION_REF_PREFIX)).toBe(
+      true,
+    );
+  });
+});
+
+describe('matchExtensionByRef', () => {
+  const extensions = [
+    makeExtension({
+      name: 'browser',
+      config: { name: 'browser', version: '1.0.0' },
+    }),
+    makeExtension({
+      name: 'github',
+      config: { name: 'github', version: '1.0.0' },
+    }),
+  ];
+
+  it('matches case-insensitively by name', () => {
+    expect(matchExtensionByRef('Browser', extensions)?.name).toBe('browser');
+    expect(matchExtensionByRef('GITHUB', extensions)?.name).toBe('github');
+  });
+
+  it('matches by config.name', () => {
+    expect(matchExtensionByRef('browser', extensions)?.name).toBe('browser');
+  });
+
+  it('returns undefined for no match', () => {
+    expect(matchExtensionByRef('nonexistent', extensions)).toBeUndefined();
+  });
+
+  it('does not match by displayName (intentionally excluded)', () => {
+    const exts = [
+      makeExtension({
+        name: 'code-assist',
+        displayName: 'Code Assistant',
+        config: { name: 'code-assist', version: '1.0.0' },
+      }),
+    ];
+    expect(matchExtensionByRef('Code Assistant', exts)).toBeUndefined();
+    expect(matchExtensionByRef('code-assist', exts)?.name).toBe('code-assist');
+  });
+});
+
+describe('getExtensionSuggestions', () => {
+  it('returns empty for undefined config', () => {
+    expect(getExtensionSuggestions(undefined, '')).toEqual([]);
+  });
+
+  it('returns empty when no active extensions', () => {
+    const config = {
+      getActiveExtensions: () => [],
+    } as unknown as Config;
+    expect(getExtensionSuggestions(config, '')).toEqual([]);
+  });
+
+  it('returns all extensions on empty pattern', () => {
+    const config = {
+      getActiveExtensions: () => [
+        makeExtension({ name: 'alpha' }),
+        makeExtension({ name: 'beta' }),
+      ],
+    } as unknown as Config;
+    const suggestions = getExtensionSuggestions(config, '');
+    expect(suggestions).toHaveLength(2);
+    expect(suggestions[0]!.value).toBe('ext:alpha');
+    expect(suggestions[1]!.value).toBe('ext:beta');
+  });
+
+  it('filters by substring match', () => {
+    const config = {
+      getActiveExtensions: () => [
+        makeExtension({ name: 'browser' }),
+        makeExtension({ name: 'github' }),
+        makeExtension({ name: 'pdf' }),
+      ],
+    } as unknown as Config;
+    const suggestions = getExtensionSuggestions(config, 'bro');
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]!.value).toBe('ext:browser');
+  });
+
+  it('prefers prefix matches in sort order', () => {
+    const config = {
+      getActiveExtensions: () => [
+        makeExtension({
+          name: 'sub-browser',
+          displayName: 'Sub Browser',
+        }),
+        makeExtension({
+          name: 'browser',
+          displayName: 'Browser',
+        }),
+      ],
+    } as unknown as Config;
+    const suggestions = getExtensionSuggestions(config, 'bro');
+    expect(suggestions[0]!.value).toBe('ext:browser');
+    expect(suggestions[1]!.value).toBe('ext:sub-browser');
+  });
+
+  it('includes sourceBadge and description', () => {
+    const config = {
+      getActiveExtensions: () => [
+        makeExtension({
+          name: 'test',
+          config: {
+            name: 'test',
+            version: '1.0.0',
+            description: 'Test description',
+          },
+        }),
+      ],
+    } as unknown as Config;
+    const suggestions = getExtensionSuggestions(config, '');
+    expect(suggestions[0]!.sourceBadge).toBe('Extension');
+    expect(suggestions[0]!.description).toBe('Test description');
+    expect(suggestions[0]!.isDirectory).toBe(false);
+  });
+});
+
+describe('buildExtensionContextText', () => {
+  it('produces a context block for a minimal extension', () => {
+    const ext = makeExtension({
+      name: 'minimal',
+      config: { name: 'minimal', version: '1.0.0' },
+    });
+    const text = buildExtensionContextText(ext);
+    expect(text).toContain(
+      '--- Extension: minimal (untrusted third-party content) ---',
+    );
+    expect(text).toContain('--- End Extension: minimal ---');
+    expect(text).not.toContain('Available capabilities');
+  });
+
+  it('includes description when present', () => {
+    const ext = makeExtension({
+      config: { name: 'test', version: '1.0.0', description: 'My description' },
+    });
+    const text = buildExtensionContextText(ext);
+    expect(text).toContain('My description');
+  });
+
+  it('lists skills, MCP servers, and agents', () => {
+    const ext = makeExtension({
+      name: 'full',
+      displayName: 'Full Extension',
+      config: { name: 'full', version: '1.0.0', description: 'Full' },
+      skills: [
+        { name: 'skill-a' } as SkillConfig,
+        { name: 'skill-b' } as SkillConfig,
+      ],
+      mcpServers: {
+        'server-1': {} as MCPServerConfig,
+        'server-2': {} as MCPServerConfig,
+      },
+      agents: [{ name: 'agent-x' } as SubagentConfig],
+    });
+    const text = buildExtensionContextText(ext);
+    expect(text).toContain('Available capabilities');
+    expect(text).toContain('Skills: skill-a, skill-b');
+    expect(text).toContain('MCP Servers: server-1, server-2');
+    expect(text).toContain('Agents: agent-x');
+  });
+
+  it('uses displayName when available', () => {
+    const ext = makeExtension({
+      name: 'test',
+      displayName: 'My Test Extension',
+      config: { name: 'test', version: '1.0.0' },
+    });
+    const text = buildExtensionContextText(ext);
+    expect(text).toContain('Extension: My Test Extension');
+  });
+});

--- a/packages/cli/src/ui/hooks/extension-mention-ref.ts
+++ b/packages/cli/src/ui/hooks/extension-mention-ref.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Config, Extension } from '@qwen-code/qwen-code-core';
+import {
+  type Config,
+  type Extension,
+  stripTerminalControlSequences,
+} from '@qwen-code/qwen-code-core';
 import type { Suggestion } from '../components/SuggestionsDisplay.js';
 import { MAX_SUGGESTIONS_TO_SHOW } from '../components/SuggestionsDisplay.js';
 import { t } from '../../i18n/index.js';
@@ -84,9 +88,11 @@ export function getExtensionSuggestions(
     })
     .slice(0, MAX_SUGGESTIONS_TO_SHOW)
     .map((ext) => ({
-      label: ext.displayName || ext.name,
+      label: stripTerminalControlSequences(ext.displayName || ext.name),
       value: buildExtensionRef(ext.name),
-      description: ext.config.description,
+      description: ext.config.description
+        ? stripTerminalControlSequences(ext.config.description)
+        : undefined,
       sourceBadge: t('Extension'),
       isDirectory: false,
     }));
@@ -114,9 +120,7 @@ export function buildExtensionContextText(extension: Extension): string {
   // Skills
   if (extension.skills && extension.skills.length > 0) {
     const skillNames = extension.skills.map((s) => s.name).join(', ');
-    capabilities.push(
-      `- Skills: ${skillNames} (invoke via /${extension.name}:<skill-name>)`,
-    );
+    capabilities.push(`- Skills: ${skillNames} (invoke via /<skill-name>)`);
   }
 
   // MCP Servers

--- a/packages/cli/src/ui/hooks/extension-mention-ref.ts
+++ b/packages/cli/src/ui/hooks/extension-mention-ref.ts
@@ -58,6 +58,25 @@ export function matchExtensionByRef(
 }
 
 /**
+ * Regex matching Unicode bidi override/isolate/mark characters that
+ * `stripTerminalControlSequences` leaves intact.
+ */
+const BIDI_CONTROL_RE = /[‎‏؜⁦⁧⁨⁩‪‫‬‭‮]/g;
+
+/**
+ * Normalizes an untrusted display string for safe UI rendering. Strips
+ * terminal control sequences and bidi overrides, collapses/trims whitespace,
+ * and returns `null` when no safe text remains.
+ */
+export function sanitizeDisplayText(raw: string): string | null {
+  const stripped = stripTerminalControlSequences(raw)
+    .replace(BIDI_CONTROL_RE, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return stripped.length > 0 ? stripped : null;
+}
+
+/**
  * Returns autocomplete suggestions for extensions matching the given pattern.
  * Unlike MCP server suggestions (which require a non-empty pattern to avoid
  * flooding), extensions show on bare `@` because their count is typically small.
@@ -73,25 +92,29 @@ export function getExtensionSuggestions(
 
   const query = pattern.toLowerCase();
   return extensions
-    .filter((ext) => {
-      const displayName = (ext.displayName || ext.name).toLowerCase();
+    .map((ext) => ({
+      ext,
+      safeLabel: sanitizeDisplayText(ext.displayName || ext.name) || ext.name,
+    }))
+    .filter(({ safeLabel, ext }) => {
+      const label = safeLabel.toLowerCase();
       const name = ext.name.toLowerCase();
-      return displayName.includes(query) || name.includes(query);
+      return label.includes(query) || name.includes(query);
     })
     .sort((a, b) => {
-      const aName = (a.displayName || a.name).toLowerCase();
-      const bName = (b.displayName || b.name).toLowerCase();
+      const aName = a.safeLabel.toLowerCase();
+      const bName = b.safeLabel.toLowerCase();
       const aPrefix = aName.startsWith(query) ? 0 : 1;
       const bPrefix = bName.startsWith(query) ? 0 : 1;
       if (aPrefix !== bPrefix) return aPrefix - bPrefix;
       return aName.localeCompare(bName);
     })
     .slice(0, MAX_SUGGESTIONS_TO_SHOW)
-    .map((ext) => ({
-      label: stripTerminalControlSequences(ext.displayName || ext.name),
+    .map(({ ext, safeLabel }) => ({
+      label: safeLabel,
       value: buildExtensionRef(ext.name),
       description: ext.config.description
-        ? stripTerminalControlSequences(ext.config.description)
+        ? (sanitizeDisplayText(ext.config.description) ?? undefined)
         : undefined,
       sourceBadge: t('Extension'),
       isDirectory: false,
@@ -104,38 +127,41 @@ export function getExtensionSuggestions(
  * knows about the extension's capabilities.
  */
 export function buildExtensionContextText(extension: Extension): string {
-  const displayName = stripTerminalControlSequences(
-    extension.displayName || extension.name,
-  );
+  const displayName =
+    sanitizeDisplayText(extension.displayName || extension.name) ||
+    extension.name;
   const lines: string[] = [];
 
   lines.push(
     `--- Extension: ${displayName} (untrusted third-party content) ---`,
   );
   if (extension.config.description) {
-    lines.push(stripTerminalControlSequences(extension.config.description));
-    lines.push('');
+    const desc = sanitizeDisplayText(extension.config.description);
+    if (desc) {
+      lines.push(desc);
+      lines.push('');
+    }
   }
 
   const capabilities: string[] = [];
 
   if (extension.skills && extension.skills.length > 0) {
     const skillNames = extension.skills
-      .map((s) => stripTerminalControlSequences(s.name))
+      .map((s) => sanitizeDisplayText(s.name) || s.name)
       .join(', ');
     capabilities.push(`- Skills: ${skillNames} (invoke via /<skill-name>)`);
   }
 
   if (extension.mcpServers && Object.keys(extension.mcpServers).length > 0) {
     const serverNames = Object.keys(extension.mcpServers)
-      .map((n) => stripTerminalControlSequences(n))
+      .map((n) => sanitizeDisplayText(n) || n)
       .join(', ');
     capabilities.push(`- MCP Servers: ${serverNames}`);
   }
 
   if (extension.agents && extension.agents.length > 0) {
     const agentNames = extension.agents
-      .map((a) => stripTerminalControlSequences(a.name))
+      .map((a) => sanitizeDisplayText(a.name) || a.name)
       .join(', ');
     capabilities.push(`- Agents: ${agentNames}`);
   }

--- a/packages/cli/src/ui/hooks/extension-mention-ref.ts
+++ b/packages/cli/src/ui/hooks/extension-mention-ref.ts
@@ -104,34 +104,39 @@ export function getExtensionSuggestions(
  * knows about the extension's capabilities.
  */
 export function buildExtensionContextText(extension: Extension): string {
-  const displayName = extension.displayName || extension.name;
+  const displayName = stripTerminalControlSequences(
+    extension.displayName || extension.name,
+  );
   const lines: string[] = [];
 
   lines.push(
     `--- Extension: ${displayName} (untrusted third-party content) ---`,
   );
   if (extension.config.description) {
-    lines.push(extension.config.description);
+    lines.push(stripTerminalControlSequences(extension.config.description));
     lines.push('');
   }
 
   const capabilities: string[] = [];
 
-  // Skills
   if (extension.skills && extension.skills.length > 0) {
-    const skillNames = extension.skills.map((s) => s.name).join(', ');
+    const skillNames = extension.skills
+      .map((s) => stripTerminalControlSequences(s.name))
+      .join(', ');
     capabilities.push(`- Skills: ${skillNames} (invoke via /<skill-name>)`);
   }
 
-  // MCP Servers
   if (extension.mcpServers && Object.keys(extension.mcpServers).length > 0) {
-    const serverNames = Object.keys(extension.mcpServers).join(', ');
+    const serverNames = Object.keys(extension.mcpServers)
+      .map((n) => stripTerminalControlSequences(n))
+      .join(', ');
     capabilities.push(`- MCP Servers: ${serverNames}`);
   }
 
-  // Agents
   if (extension.agents && extension.agents.length > 0) {
-    const agentNames = extension.agents.map((a) => a.name).join(', ');
+    const agentNames = extension.agents
+      .map((a) => stripTerminalControlSequences(a.name))
+      .join(', ');
     capabilities.push(`- Agents: ${agentNames}`);
   }
 

--- a/packages/cli/src/ui/hooks/extension-mention-ref.ts
+++ b/packages/cli/src/ui/hooks/extension-mention-ref.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config, Extension } from '@qwen-code/qwen-code-core';
+import type { Suggestion } from '../components/SuggestionsDisplay.js';
+import { t } from '../../i18n/index.js';
+
+/**
+ * Prefix used for extension mention references. When the user selects an
+ * extension from the `@` autocomplete, the inserted value is `ext:<name>`.
+ * This prefix disambiguates extension mentions from file paths and MCP
+ * resource references at parse time.
+ */
+export const EXTENSION_REF_PREFIX = 'ext:';
+
+/**
+ * Parses an `ext:<name>` reference string. Returns the extension name
+ * portion if the input starts with the extension prefix, or `null` otherwise.
+ */
+export function parseExtensionRef(pathName: string): { name: string } | null {
+  if (!pathName.startsWith(EXTENSION_REF_PREFIX)) return null;
+  const name = pathName.slice(EXTENSION_REF_PREFIX.length);
+  if (!name) return null;
+  return { name };
+}
+
+/**
+ * Builds the canonical `ext:<name>` reference string for an extension.
+ */
+export function buildExtensionRef(extensionName: string): string {
+  return `${EXTENSION_REF_PREFIX}${extensionName}`;
+}
+
+/**
+ * Case-insensitive match of an extension name against a list of extensions.
+ * Matches against both `extension.name` and `extension.displayName`.
+ */
+export function matchExtensionByRef(
+  name: string,
+  extensions: Extension[],
+): Extension | undefined {
+  const lower = name.toLowerCase();
+  return extensions.find(
+    (ext) =>
+      ext.name.toLowerCase() === lower ||
+      ext.config.name.toLowerCase() === lower ||
+      (ext.displayName && ext.displayName.toLowerCase() === lower),
+  );
+}
+
+/**
+ * Returns autocomplete suggestions for extensions matching the given pattern.
+ * Unlike MCP server suggestions (which require a non-empty pattern to avoid
+ * flooding), extensions show on bare `@` because their count is typically small.
+ */
+export function getExtensionSuggestions(
+  config: Config | undefined,
+  pattern: string,
+): Suggestion[] {
+  if (!config) return [];
+  const extensions = config.getActiveExtensions?.() ?? [];
+  if (extensions.length === 0) return [];
+
+  const query = pattern.toLowerCase();
+  return extensions
+    .filter((ext) => {
+      const displayName = (ext.displayName || ext.name).toLowerCase();
+      const name = ext.name.toLowerCase();
+      return (
+        displayName.startsWith(query) ||
+        name.startsWith(query) ||
+        displayName.includes(query) ||
+        name.includes(query)
+      );
+    })
+    .sort((a, b) => {
+      const aName = (a.displayName || a.name).toLowerCase();
+      const bName = (b.displayName || b.name).toLowerCase();
+      // Prefer prefix match over substring match
+      const aPrefix = aName.startsWith(query) ? 0 : 1;
+      const bPrefix = bName.startsWith(query) ? 0 : 1;
+      if (aPrefix !== bPrefix) return aPrefix - bPrefix;
+      return aName.localeCompare(bName);
+    })
+    .map((ext) => ({
+      label: ext.displayName || ext.name,
+      value: buildExtensionRef(ext.name),
+      description: ext.config.description,
+      sourceBadge: t('Extension'),
+      isDirectory: false,
+    }));
+}
+
+/**
+ * Builds a structured context text block for an extension that has been
+ * @-mentioned. This text is injected into the user message so the model
+ * knows about the extension's capabilities.
+ */
+export function buildExtensionContextText(extension: Extension): string {
+  const displayName = extension.displayName || extension.name;
+  const lines: string[] = [];
+
+  lines.push(`--- Extension: ${displayName} ---`);
+  if (extension.config.description) {
+    lines.push(extension.config.description);
+    lines.push('');
+  }
+
+  const capabilities: string[] = [];
+
+  // Skills
+  if (extension.skills && extension.skills.length > 0) {
+    const skillNames = extension.skills.map((s) => s.name).join(', ');
+    capabilities.push(
+      `- Skills: ${skillNames} (invoke via /${extension.name}:<skill-name>)`,
+    );
+  }
+
+  // MCP Servers
+  if (extension.mcpServers && Object.keys(extension.mcpServers).length > 0) {
+    const serverNames = Object.keys(extension.mcpServers).join(', ');
+    capabilities.push(`- MCP Servers: ${serverNames}`);
+  }
+
+  // Agents
+  if (extension.agents && extension.agents.length > 0) {
+    const agentNames = extension.agents.map((a) => a.name).join(', ');
+    capabilities.push(`- Agents: ${agentNames}`);
+  }
+
+  if (capabilities.length > 0) {
+    lines.push('Available capabilities from this extension:');
+    lines.push(...capabilities);
+    lines.push('');
+  }
+
+  lines.push(`--- End Extension: ${displayName} ---`);
+
+  return lines.join('\n');
+}

--- a/packages/cli/src/ui/hooks/extension-mention-ref.ts
+++ b/packages/cli/src/ui/hooks/extension-mention-ref.ts
@@ -6,6 +6,7 @@
 
 import type { Config, Extension } from '@qwen-code/qwen-code-core';
 import type { Suggestion } from '../components/SuggestionsDisplay.js';
+import { MAX_SUGGESTIONS_TO_SHOW } from '../components/SuggestionsDisplay.js';
 import { t } from '../../i18n/index.js';
 
 /**
@@ -36,7 +37,9 @@ export function buildExtensionRef(extensionName: string): string {
 
 /**
  * Case-insensitive match of an extension name against a list of extensions.
- * Matches against both `extension.name` and `extension.displayName`.
+ * Matches against `extension.name` and `extension.config.name` (the canonical
+ * slugs). `displayName` is intentionally excluded: it often contains spaces
+ * which the `@`-path parser truncates at, so matching would be unreliable.
  */
 export function matchExtensionByRef(
   name: string,
@@ -46,8 +49,7 @@ export function matchExtensionByRef(
   return extensions.find(
     (ext) =>
       ext.name.toLowerCase() === lower ||
-      ext.config.name.toLowerCase() === lower ||
-      (ext.displayName && ext.displayName.toLowerCase() === lower),
+      ext.config.name.toLowerCase() === lower,
   );
 }
 
@@ -69,22 +71,17 @@ export function getExtensionSuggestions(
     .filter((ext) => {
       const displayName = (ext.displayName || ext.name).toLowerCase();
       const name = ext.name.toLowerCase();
-      return (
-        displayName.startsWith(query) ||
-        name.startsWith(query) ||
-        displayName.includes(query) ||
-        name.includes(query)
-      );
+      return displayName.includes(query) || name.includes(query);
     })
     .sort((a, b) => {
       const aName = (a.displayName || a.name).toLowerCase();
       const bName = (b.displayName || b.name).toLowerCase();
-      // Prefer prefix match over substring match
       const aPrefix = aName.startsWith(query) ? 0 : 1;
       const bPrefix = bName.startsWith(query) ? 0 : 1;
       if (aPrefix !== bPrefix) return aPrefix - bPrefix;
       return aName.localeCompare(bName);
     })
+    .slice(0, MAX_SUGGESTIONS_TO_SHOW)
     .map((ext) => ({
       label: ext.displayName || ext.name,
       value: buildExtensionRef(ext.name),
@@ -103,7 +100,9 @@ export function buildExtensionContextText(extension: Extension): string {
   const displayName = extension.displayName || extension.name;
   const lines: string[] = [];
 
-  lines.push(`--- Extension: ${displayName} ---`);
+  lines.push(
+    `--- Extension: ${displayName} (untrusted third-party content) ---`,
+  );
   if (extension.config.description) {
     lines.push(extension.config.description);
     lines.push('');

--- a/packages/cli/src/ui/hooks/extension-mention-ref.ts
+++ b/packages/cli/src/ui/hooks/extension-mention-ref.ts
@@ -63,6 +63,7 @@ export function getExtensionSuggestions(
   pattern: string,
 ): Suggestion[] {
   if (!config) return [];
+  if (config.isTrustedFolder?.() === false) return [];
   const extensions = config.getActiveExtensions?.() ?? [];
   if (extensions.length === 0) return [];
 

--- a/packages/cli/src/ui/hooks/useAtCompletion.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.ts
@@ -400,10 +400,9 @@ export function useAtCompletion(props: UseAtCompletionProps): void {
         if (slowSearchTimer.current) {
           clearTimeout(slowSearchTimer.current);
         }
-        dispatch({
-          type: 'SEARCH_SUCCESS',
-          payload: [...extensionSuggestions, ...resourceSuggestions],
-        });
+        // When drilling into a specific server's resources (`@server:partial`),
+        // extension suggestions are noise — only show resource results here.
+        dispatch({ type: 'SEARCH_SUCCESS', payload: resourceSuggestions });
         return;
       }
 

--- a/packages/cli/src/ui/hooks/useAtCompletion.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.ts
@@ -10,6 +10,7 @@ import { FileSearchFactory, escapePath } from '@qwen-code/qwen-code-core';
 import type { Suggestion } from '../components/SuggestionsDisplay.js';
 import { MAX_SUGGESTIONS_TO_SHOW } from '../components/SuggestionsDisplay.js';
 import { matchMcpServerPrefix, buildMcpResourceRef } from './mcpResourceRef.js';
+import { getExtensionSuggestions } from './extension-mention-ref.js';
 import { t } from '../../i18n/index.js';
 
 /**
@@ -379,6 +380,15 @@ export function useAtCompletion(props: UseAtCompletionProps): void {
         return;
       }
 
+      // Extension suggestions are computed synchronously from in-memory data.
+      // Unlike MCP servers, they show even on bare `@` (empty pattern) since
+      // the extension count is typically small and immediate discoverability
+      // matters.
+      const extensionSuggestions = getExtensionSuggestions(
+        config,
+        state.pattern,
+      );
+
       // `@server:uri` MCP resource completion short-circuits filesystem
       // search. Synchronous (in-memory registry), so no abort/slow-timer
       // machinery is needed.
@@ -390,7 +400,10 @@ export function useAtCompletion(props: UseAtCompletionProps): void {
         if (slowSearchTimer.current) {
           clearTimeout(slowSearchTimer.current);
         }
-        dispatch({ type: 'SEARCH_SUCCESS', payload: resourceSuggestions });
+        dispatch({
+          type: 'SEARCH_SUCCESS',
+          payload: [...extensionSuggestions, ...resourceSuggestions],
+        });
         return;
       }
 
@@ -405,6 +418,7 @@ export function useAtCompletion(props: UseAtCompletionProps): void {
         state.pattern,
       );
       const mcpSuggestions = [
+        ...extensionSuggestions,
         ...serverSuggestions,
         ...globalResourceSuggestions,
       ];

--- a/packages/cli/src/ui/utils/highlight.ts
+++ b/packages/cli/src/ui/utils/highlight.ts
@@ -14,7 +14,7 @@ export type HighlightToken = {
 };
 
 const HIGHLIGHT_REGEX =
-  /(^\/[a-zA-Z][a-zA-Z0-9:_-]*)|((?<=\s)\/[a-zA-Z][a-zA-Z0-9:_-]*)|(@(?:\\ |[a-zA-Z0-9_./-])+)/g;
+  /(^\/[a-zA-Z][a-zA-Z0-9:_-]*)|((?<=\s)\/[a-zA-Z][a-zA-Z0-9:_-]*)|(@(?:\\ |[a-zA-Z0-9_.:/-])+)/g;
 
 export function parseInputForHighlighting(
   text: string,


### PR DESCRIPTION
## What this PR does

Adds Codex-style `@extension` mention support in the CLI input. When typing `@`, installed and active extensions now appear in the autocomplete dropdown alongside files and MCP resources, each showing its display name, description, and an "Extension" badge. After selecting an extension (e.g., `@ext:browser`), its capabilities — skills, MCP servers, agents, and context files — are injected into the message context for that turn, giving the model awareness of what the extension provides.

## Why it's needed

Extensions already provide skills, MCP servers, agents, and context files, but there is no way to explicitly activate or reference an extension from the input prompt. Codex supports `@plugin` mentions that let users signal which plugin's capabilities should be prioritized for a given turn. This PR brings the same discoverability and activation UX to qwen-code extensions, making extensions first-class citizens in the `@` mention system.

## Reviewer Test Plan

### How to verify

1. Install at least one extension (e.g., `qwen-code /extensions install <url>`)
2. In the CLI input, type `@` — active extensions should appear at the top of the autocomplete dropdown with their name, description, and "Extension" badge
3. Type a partial name (e.g., `@bro`) to filter extensions
4. Press Tab/Enter to select — `@ext:extension-name` is inserted into the input, highlighted in accent color
5. Submit a message with `@ext:name` — the model receives extension context (capabilities + context files)
6. Verify mixed usage: `@ext:foo @src/main.ts` resolves both the extension and the file
7. Verify multiple extensions: `@ext:foo @ext:bar` injects both contexts

### Evidence (Before & After)

N/A — new feature, no prior behavior to compare against. The `@` autocomplete previously showed only files and MCP resources; now it additionally shows extensions.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Local development with `npm run dev`.

## Risk & Scope

- Main risk or tradeoff: Extensions with large context files could inflate message size; mitigated by a 50KB cap per context file.
- Not validated / out of scope: Desktop/WebUI `@` mention systems (this PR only covers CLI); extension marketplace discovery UX.
- Breaking changes / migration notes: None. Purely additive — existing `@file` and `@server:uri` behavior is unchanged.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 CLI 输入中添加了类似 Codex 的 `@extension` 提及支持。当输入 `@` 时，已安装并激活的扩展会和文件、MCP 资源一起出现在自动补全下拉列表中，每个扩展显示其名称、描述和 "Extension" 标签。选择扩展后（如 `@ext:browser`），其能力（skills、MCP 服务器、agents、上下文文件）会被注入到该轮消息上下文中，让模型了解该扩展提供的功能。

## 为什么需要

扩展已经可以提供 skills、MCP 服务器、agents 和上下文文件，但目前没有办法在输入提示中显式激活或引用扩展。Codex 支持 `@plugin` 提及，让用户可以指定某个 plugin 的能力应在当前轮次中优先使用。本 PR 为 qwen-code 扩展带来了相同的可发现性和激活体验，使扩展成为 `@` 提及系统中的一等公民。

## 审查测试计划

1. 安装至少一个扩展
2. 在 CLI 输入中输入 `@` — 活跃扩展应出现在自动补全下拉列表顶部
3. 输入部分名称进行过滤
4. 按 Tab/Enter 选择 — `@ext:extension-name` 被插入输入并高亮显示
5. 提交带有 `@ext:name` 的消息 — 模型收到扩展上下文
6. 验证混合使用：`@ext:foo @src/main.ts` 同时解析扩展和文件
7. 验证多扩展：`@ext:foo @ext:bar` 注入两个扩展的上下文

## 风险与范围

- 主要风险：扩展的大上下文文件可能增大消息体积；已通过每文件 50KB 上限缓解
- 未验证/超出范围：Desktop/WebUI 的 `@` 提及系统（本 PR 仅覆盖 CLI）
- 破坏性变更：无。纯增量修改，现有 `@file` 和 `@server:uri` 行为不受影响

</details>