### PR TITLE
feat(cli): tighten response timestamp consistency and tests

### DIFF
--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -250,6 +250,9 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
               [
               {new Date(itemForDisplay.timestamp).toLocaleTimeString('en-US', {
                 hour12: false,
+                hour: '2-digit',
+                minute: '2-digit',
+                second: '2-digit',
               })}
               ]
             </Text>

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -8370,6 +8370,79 @@ describe('useGeminiStream', () => {
       });
     });
   });
+
+  describe('timestamp attachment', () => {
+    it('attaches a numeric timestamp to gemini items via commitItem', async () => {
+      mockSendMessageStream.mockReturnValueOnce(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'Hello world',
+          };
+          yield {
+            type: ServerGeminiEventType.Finished,
+            value: {
+              reason: undefined,
+              usageMetadata: { totalTokenCount: 1 },
+            },
+          };
+        })(),
+      );
+
+      const { result } = renderTestHook();
+
+      await act(async () => {
+        await result.current.submitQuery('test');
+      });
+
+      await waitFor(() => {
+        expect(result.current.streamingState).toBe(StreamingState.Idle);
+      });
+
+      const geminiCalls = mockAddItem.mock.calls.filter(
+        (call: any[]) => call[0]?.type === 'gemini',
+      );
+      expect(geminiCalls.length).toBeGreaterThanOrEqual(1);
+      const geminiItem = geminiCalls[0][0];
+      expect(typeof geminiItem.timestamp).toBe('number');
+      expect(geminiItem.timestamp).toBeGreaterThan(0);
+    });
+
+    it('does not attach timestamp to user items', async () => {
+      mockSendMessageStream.mockReturnValueOnce(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'response',
+          };
+          yield {
+            type: ServerGeminiEventType.Finished,
+            value: {
+              reason: undefined,
+              usageMetadata: { totalTokenCount: 1 },
+            },
+          };
+        })(),
+      );
+
+      const { result } = renderTestHook();
+
+      await act(async () => {
+        await result.current.submitQuery('test');
+      });
+
+      await waitFor(() => {
+        expect(result.current.streamingState).toBe(StreamingState.Idle);
+      });
+
+      const userCalls = mockAddItem.mock.calls.filter(
+        (call: any[]) => call[0]?.type === 'user',
+      );
+      expect(userCalls.length).toBeGreaterThanOrEqual(1);
+      const userItem = userCalls[0][0];
+      expect(userItem).not.toHaveProperty('timestamp');
+    });
+  });
 });
 
 describe('classifyApiError', () => {

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -8408,7 +8408,7 @@ describe('useGeminiStream', () => {
       expect(geminiItem.timestamp).toBeGreaterThan(0);
     });
 
-    it('does not attach timestamp to user items', async () => {
+    it('does not attach timestamp to non-gemini items', async () => {
       mockSendMessageStream.mockReturnValueOnce(
         (async function* () {
           yield {
@@ -8435,12 +8435,13 @@ describe('useGeminiStream', () => {
         expect(result.current.streamingState).toBe(StreamingState.Idle);
       });
 
-      const userCalls = mockAddItem.mock.calls.filter(
-        (call: any[]) => call[0]?.type === 'user',
+      const nonGeminiCalls = mockAddItem.mock.calls.filter(
+        (call: any[]) => call[0]?.type !== 'gemini',
       );
-      expect(userCalls.length).toBeGreaterThanOrEqual(1);
-      const userItem = userCalls[0][0];
-      expect(userItem).not.toHaveProperty('timestamp');
+      expect(nonGeminiCalls.length).toBeGreaterThanOrEqual(1);
+      for (const call of nonGeminiCalls) {
+        expect(call[0]).not.toHaveProperty('timestamp');
+      }
     });
   });
 });

--- a/packages/cli/src/ui/utils/resumeHistoryUtils.test.ts
+++ b/packages/cli/src/ui/utils/resumeHistoryUtils.test.ts
@@ -52,6 +52,7 @@ describe('resumeHistoryUtils', () => {
         },
         {
           type: 'assistant',
+          timestamp: '2026-01-15T14:30:00.000Z',
           message: {
             parts: [
               { text: 'Hi there' } as Part,
@@ -89,7 +90,12 @@ describe('resumeHistoryUtils', () => {
 
     expect(items).toEqual([
       { id: baseTimestamp + 1, type: 'user', text: 'Hello' },
-      { id: baseTimestamp + 2, type: 'gemini', text: 'Hi there' },
+      {
+        id: baseTimestamp + 2,
+        type: 'gemini',
+        text: 'Hi there',
+        timestamp: new Date('2026-01-15T14:30:00.000Z').getTime(),
+      },
       {
         id: baseTimestamp + 3,
         type: 'tool_group',
@@ -155,6 +161,7 @@ describe('resumeHistoryUtils', () => {
       messages: [
         {
           type: 'assistant',
+          timestamp: '2026-01-15T15:00:00.000Z',
           message: {
             parts: [
               {
@@ -190,7 +197,12 @@ describe('resumeHistoryUtils', () => {
     const items = buildResumedHistoryItems(session, makeConfig({}));
 
     expect(items).toEqual([
-      { id: expect.any(Number), type: 'gemini', text: 'visible text' },
+      {
+        id: expect.any(Number),
+        type: 'gemini',
+        text: 'visible text',
+        timestamp: new Date('2026-01-15T15:00:00.000Z').getTime(),
+      },
       {
         id: expect.any(Number),
         type: 'tool_group',
@@ -213,6 +225,7 @@ describe('resumeHistoryUtils', () => {
       messages: [
         {
           type: 'assistant',
+          timestamp: '2026-01-15T16:00:00.000Z',
           message: {
             parts: [
               {
@@ -238,7 +251,12 @@ describe('resumeHistoryUtils', () => {
         type: 'gemini_thought',
         text: 'preview thought',
       },
-      { id: expect.any(Number), type: 'gemini', text: 'visible text' },
+      {
+        id: expect.any(Number),
+        type: 'gemini',
+        text: 'visible text',
+        timestamp: new Date('2026-01-15T16:00:00.000Z').getTime(),
+      },
     ]);
   });
 
@@ -337,6 +355,7 @@ describe('resumeHistoryUtils', () => {
         },
         {
           type: 'assistant',
+          timestamp: '2026-01-15T17:00:00.000Z',
           message: { parts: [{ text: 'Follow-up' } as Part] },
         },
       ],
@@ -355,7 +374,12 @@ describe('resumeHistoryUtils', () => {
         type: 'about',
         systemInfo: expect.objectContaining({ cliVersion: '1.2.3' }),
       },
-      { id: 8, type: 'gemini', text: 'Follow-up' },
+      {
+        id: 8,
+        type: 'gemini',
+        text: 'Follow-up',
+        timestamp: new Date('2026-01-15T17:00:00.000Z').getTime(),
+      },
     ]);
   });
 
@@ -373,6 +397,7 @@ describe('resumeHistoryUtils', () => {
         },
         {
           type: 'assistant',
+          timestamp: '2026-01-15T18:00:00.000Z',
           message: { parts: [{ text: 'Follow-up' } as Part] },
         },
       ],
@@ -386,7 +411,12 @@ describe('resumeHistoryUtils', () => {
 
     expect(items).toEqual([
       { id: 21, type: 'user', text: '/filecmd', sentToModel: true },
-      { id: 22, type: 'gemini', text: 'Follow-up' },
+      {
+        id: 22,
+        type: 'gemini',
+        text: 'Follow-up',
+        timestamp: new Date('2026-01-15T18:00:00.000Z').getTime(),
+      },
     ]);
   });
 

--- a/packages/cli/src/ui/utils/resumeHistoryUtils.ts
+++ b/packages/cli/src/ui/utils/resumeHistoryUtils.ts
@@ -382,7 +382,11 @@ function convertToHistoryItems(
             });
             currentToolGroup = [];
           }
-          items.push({ type: 'gemini', text });
+          items.push({
+            type: 'gemini',
+            text,
+            timestamp: new Date(record.timestamp).getTime(),
+          });
         }
 
         // Track function calls for pairing with results


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

Follow-up to PR #5001 (optional response timestamps). Three consistency and hardening items: (1) resumed assistant messages now carry their original conversation record timestamp so historical turns display `[HH:MM:SS]` consistently with newly streamed turns; (2) the time format now explicitly requests two-digit hour, minute, and second fields to guarantee `HH:MM:SS` across all ICU/runtime variants; (3) added positive stream tests that assert `useGeminiStream` attaches a numeric timestamp to `gemini` items and does not attach one to any non-gemini item type.

## Why it's needed

With `output.showTimestamps` enabled, old assistant turns from a restored session appeared without timestamps while newly streamed turns included them — a visible inconsistency. The `toLocaleTimeString` options also lacked explicit digit-width hints, which could produce single-digit hours on some ICU variants. The stream-level timestamp behavior had no dedicated test coverage.

## Reviewer Test Plan

### How to verify

```bash
cd packages/cli && npx vitest run src/ui/utils/resumeHistoryUtils.test.ts src/ui/hooks/useGeminiStream.test.tsx -t "timestamp"
```

1. Run `npm run dev`
2. Enable `output.showTimestamps` in `/settings`
3. Ask a question — verify `[HH:MM:SS]` appears before the response
4. Resume a previous session — verify historical assistant turns also show timestamps
5. Disable `showTimestamps` — next response should not have timestamp

### Evidence (Before & After)

**Before:** Resumed sessions showed timestamps only on newly streamed turns; historical turns had none. Time format could vary across ICU versions.

**After:** All assistant turns (new and resumed) show `[HH:MM:SS]` when the setting is enabled. Format is guaranteed two-digit across all platforms.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment

Node v22, macOS arm64, dev build (`npm run dev`).

## Risk & Scope

- **Main risk:** Minimal — `ChatRecord.timestamp` is always a valid ISO 8601 string, so `new Date().getTime()` is safe. The `timestamp` field on `HistoryItemGemini` is optional, maintaining backward compatibility.
- **Not validated:** Windows and Linux testing. Subagent responses (different rendering path). Non-interactive output modes.
- **Breaking changes:** None. The setting defaults to `false`.

## Linked Issues

Closes #5610

Refs #4899
Refs #5001

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

PR #5001（可选响应时间戳）的后续工作。三项一致性和加固改动：(1) 恢复的助手消息现在携带原始会话记录的时间戳，使历史 turn 与新流式 turn 一样显示 `[HH:MM:SS]`；(2) 时间格式现在显式请求两位小时、分钟和秒字段，确保在所有 ICU/运行时变体上保证 `HH:MM:SS`；(3) 添加了正向流测试，验证 `useGeminiStream` 为 `gemini` 类型 item 附加数字时间戳，不为任何非 gemini 类型 item 附加时间戳。

## 为什么需要

启用 `output.showTimestamps` 后，从恢复的会话中加载的旧助手 turn 没有时间戳，而新流式 turn 有时间戳——可见的不一致性。`toLocaleTimeString` 选项也缺少显式的数字宽度提示，在某些 ICU 变体上可能产生单位数小时。流级别的时间戳行为没有专门的测试覆盖。

## Reviewer Test Plan

```bash
cd packages/cli && npx vitest run src/ui/utils/resumeHistoryUtils.test.ts src/ui/hooks/useGeminiStream.test.tsx -t "timestamp"
```

1. 运行 `npm run dev`
2. 在 `/settings` 中启用 `output.showTimestamps`
3. 提问 — 验证响应前出现 `[HH:MM:SS]`
4. 恢复之前的会话 — 验证历史助手 turn 也显示时间戳
5. 禁用 `showTimestamps` — 下次回复不应有时间戳

## 风险与范围

- **主要风险：** 最小 — `ChatRecord.timestamp` 始终是有效的 ISO 8601 字符串。`HistoryItemGemini` 上的 `timestamp` 字段是可选的，保持向后兼容。
- **未验证：** Windows 和 Linux 测试。子代理响应（不同渲染路径）。非交互式输出模式。
- **破坏性更改：** 无。设置默认为 `false`。

## 关联 Issues

Closes #5610

Refs #4899
Refs #5001

</details>
