### PR TITLE
ci(triage): run triage on the self-hosted ECS pool instead of GitHub-hosted

### DIFF
--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -153,7 +153,16 @@ jobs:
              startsWith(github.event.comment.body, '@qwen-code /triage'))) &&
            needs.authorize.outputs.should_run == 'true')
         }}
-    runs-on: 'ubuntu-latest'
+    # Triage is the read-only analysis agent (same security profile as
+    # review-pr in qwen-code-pr-review.yml): it checks out the trusted base
+    # repo, never executes PR code, and reaches the PR/issue only via the API.
+    # Run it on the self-hosted ECS pool like review-pr — not GitHub-hosted —
+    # so it stops queueing behind the hosted CI/e2e/macOS/Windows concurrency
+    # cap while the ECS pool sits idle. Falls back to ubuntu-latest when ECS is
+    # disabled. The upstream `authorize` job deliberately stays on hosted: it is
+    # secret-bearing and runs before the permission gate, so it must stay
+    # ephemeral.
+    runs-on: "${{ vars.MAINTAINER_ECS_RUNNER_DISABLED != 'true' && fromJSON('[\"self-hosted\", \"linux\", \"x64\", \"ecs-qwen\"]') || fromJSON('[\"ubuntu-latest\"]') }}"
     # startsWith (not contains) prevents false triggers from comments that
     # mention the phrase in quoted text or mid-sentence descriptions.
     # always() so the job still evaluates when the upstream `authorize` job is
@@ -185,6 +194,23 @@ jobs:
             "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}/reactions" \
             -f content='eyes' > /dev/null ||
             echo "Failed to add triage acknowledgement reaction; continuing." >&2
+
+      # Self-hosted ECS runners reuse the workspace between runs, so an
+      # interrupted triage (its agent has enter_worktree/exit_worktree) can
+      # leave a stale `.qwen/tmp/*` worktree that trips the checkout below.
+      # Prune defensively; never fail the job. No-op on a fresh hosted runner.
+      - name: 'Clean stale triage worktrees'
+        run: |-
+          set -uo pipefail
+          # `.git` is a directory in a normal checkout but a gitlink file in a
+          # worktree; -e covers both, and a missing .git (first run) too.
+          if [ ! -e .git ]; then
+            echo "no prior workspace; nothing to clean"
+            exit 0
+          fi
+          rm -rf .qwen/tmp/* 2>/dev/null || true
+          git worktree prune -v || true
+          echo "stale triage worktrees cleaned"
 
       - name: 'Checkout repo'
         uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2


### PR DESCRIPTION
## What this PR does

Routes the `triage` job in `qwen-triage.yml` to the self-hosted ECS runner pool (`[self-hosted, linux, x64, ecs-qwen]`), with a fallback to `ubuntu-latest` when `MAINTAINER_ECS_RUNNER_DISABLED` is set — exactly mirroring how the `review-pr` job in `qwen-code-pr-review.yml` is already routed.

## Why it's needed

`@qwen-code /triage` (and the `pull_request_target` / `issues` triage paths) were pinned to `ubuntu-latest`, so they competed for the **GitHub-hosted runner concurrency cap**. That cap is routinely saturated by the jobs that *must* run hosted — the CI **macOS/Windows matrix** and **e2e** — so triage runs sit `queued` for many minutes.

Meanwhile the **31-runner self-hosted ECS pool sits almost entirely idle** (observed: 27/31 idle while a triage run waited ~15 min). Comment-triggered triage never reached ECS because the only ECS routing in the workflow keys on `github.event.pull_request`, which is **null on `issue_comment` events**, so it always fell through to `ubuntu-latest`.

Concretely, a `/triage` on #5793 was created at `07:11:01` and was still `queued` (its `authorize` job never even allocated a runner) ~15 minutes later, stuck behind a backlog of hosted CI / review / e2e jobs.

## Reviewer Test Plan

### How to verify

- Confirm the `triage` job's `runs-on` now resolves to `[self-hosted, linux, x64, ecs-qwen]` (and to `ubuntu-latest` when `MAINTAINER_ECS_RUNNER_DISABLED == 'true'`). The expression is copied verbatim from the already-live `review-config` / `ack-review-request` jobs in `qwen-code-pr-review.yml`.
- Trigger `@qwen-code /triage <n>` and confirm the run picks up an ECS runner instead of waiting in the hosted queue.
- Confirm the new `Clean stale triage worktrees` step runs before checkout and is a no-op on a fresh runner (`no prior workspace; nothing to clean`).

### Evidence (Before & After)

Before: `runs-on: 'ubuntu-latest'` — triage queues behind the saturated hosted concurrency cap; ECS pool idle.
After: triage runs on the idle ECS pool (same as `review-pr`); hosted capacity is freed for the jobs that can only run hosted.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested locally (CI-config change) |
| 🪟 Windows | ⚠️ not tested locally (CI-config change) |
|  🐧 Linux  | ✅ YAML validated; runs-on expression identical to live ECS jobs |

## Risk & Scope

- **Main risk / tradeoff:** the triage agent (`run_shell_command`, `write_file`, `enter_worktree`, `sandbox: false`) now runs on a *persistent* runner. This is the same posture already accepted for `review-pr`. Mitigated by: (a) triage only ever checks out the **trusted base repo** and never executes PR code, (b) it is gated behind `authorize` (commenter/author has write+), and (c) a defensive stale-worktree cleanup runs before checkout, mirroring `review-pr`.
- **Deliberately unchanged:** the `authorize` job stays on a hosted runner — it is secret-bearing (`CI_BOT_PAT`) and runs *before* the permission gate, so it must remain ephemeral. Only the gated, post-authorize `triage` job moves. `tmux-testing` (executes PR code, already ECS + container) and `publish-tmux` (hosted, isolated write PAT) are untouched.
- **Breaking changes / migration:** none. Behavior is identical when `MAINTAINER_ECS_RUNNER_DISABLED == 'true'`.

## Linked Issues

N/A — operational fix surfaced while triaging #5793.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 `qwen-triage.yml` 里的 `triage` job 路由到自托管 ECS runner 池（`[self-hosted, linux, x64, ecs-qwen]`），并在 `MAINTAINER_ECS_RUNNER_DISABLED` 置位时回退到 `ubuntu-latest` —— 与 `qwen-code-pr-review.yml` 中 `review-pr` 的现有路由方式完全一致。

## 为什么需要

`@qwen-code /triage`（以及 `pull_request_target` / `issues` 触发的 triage）此前被写死在 `ubuntu-latest`，因此要去抢 **GitHub 托管 runner 的并发额度**。而这个额度经常被那些**只能跑在托管上**的任务占满 —— CI 的 **macOS/Windows 矩阵**和 **e2e** —— 导致 triage 长时间 `queued`。

与此同时，**31 台自托管 ECS runner 几乎全空闲**（实测：一个 triage 等了约 15 分钟时，27/31 空闲）。评论触发的 triage 永远到不了 ECS，因为 workflow 里唯一的 ECS 路由判断依赖 `github.event.pull_request`，而它在 `issue_comment` 事件里是 null，于是总是落回 `ubuntu-latest`。

具体例子：#5793 上的一次 `/triage` 在 `07:11:01` 创建，约 15 分钟后仍是 `queued`（连 `authorize` job 都没分配到 runner），卡在一堆托管的 CI / review / e2e 任务后面。

## 风险与范围

- **主要风险/取舍：** triage agent（`run_shell_command`、`write_file`、`enter_worktree`、`sandbox: false`）现在跑在*持久* runner 上。这与 `review-pr` 已经采用的姿态一致。缓解：(a) triage 只 checkout **受信任的 base 仓库**、从不执行 PR 代码；(b) 它在 `authorize` 之后才运行（评论者/作者具备 write+ 权限）；(c) checkout 前有一个防御性的 stale-worktree 清理步骤，照搬自 `review-pr`。
- **刻意不动：** `authorize` job 继续留在托管 runner —— 它携带密钥（`CI_BOT_PAT`）且在权限门之前运行，必须保持 ephemeral。只有在权限门之后、已授权的 `triage` job 被迁移。`tmux-testing`（执行 PR 代码，已是 ECS + 容器）和 `publish-tmux`（托管、隔离写 PAT）均不改动。
- **破坏性变更/迁移：** 无。当 `MAINTAINER_ECS_RUNNER_DISABLED == 'true'` 时行为完全一致。

</details>