### PR TITLE
ci: route merge-queue Linux jobs to the ECS runner pool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,12 @@ env:
 jobs:
   classify_pr:
     name: 'Classify PR'
-    if: "${{ github.event_name == 'pull_request' }}"
-    # Gate runs on ECS for in-repo PRs too, else a busy hosted pool delays it and blocks the ECS-bound jobs. The kill-switch is read here, so flipping it reverts everything to hosted.
-    runs-on: '${{ (vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && github.event.pull_request.head.repo.full_name == github.repository) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
+    if: "${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}"
+    # Gate runs on ECS for in-repo PRs and for the merge queue (which runs in the
+    # base-repo context), else a busy hosted pool delays it and blocks the
+    # ECS-bound jobs. The kill-switch is read here, so flipping it reverts
+    # everything to hosted.
+    runs-on: '${{ (vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == ''merge_group'')) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     continue-on-error: true
     outputs:
       skip_ci: '${{ steps.release_sync.outputs.skip_ci }}'
@@ -88,16 +91,18 @@ jobs:
           echo "skip_ci=${skip_ci}" >> "${GITHUB_OUTPUT}"
           echo "skip_ci=${skip_ci}"
 
-      # In-repo PR (head branch in this repo => author has write access) runs the
-      # Linux Test on ECS; forks stay hosted. Disable via repo var MAINTAINER_ECS_RUNNER_DISABLED=true.
+      # In-repo PR (head branch in this repo => author has write access) and the
+      # merge queue (base-repo context) run the Linux jobs on ECS; fork PRs stay
+      # hosted. Disable via repo var MAINTAINER_ECS_RUNNER_DISABLED=true.
       - name: 'Select Linux runner'
         id: 'pick_runner'
         env:
           SAME_REPO: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
           ECS_DISABLED: '${{ vars.MAINTAINER_ECS_RUNNER_DISABLED }}'
+          EVENT_NAME: '${{ github.event_name }}'
         run: |-
           ubuntu_runner='["ubuntu-latest"]'
-          if [[ "${ECS_DISABLED}" != "true" && "${SAME_REPO}" == "true" ]]; then
+          if [[ "${ECS_DISABLED}" != "true" && ( "${SAME_REPO}" == "true" || "${EVENT_NAME}" == "merge_group" ) ]]; then
             ubuntu_runner='["self-hosted", "linux", "x64", "ecs-qwen"]'
           fi
           echo "ubuntu_runner=${ubuntu_runner}" >> "${GITHUB_OUTPUT}"
@@ -463,8 +468,13 @@ jobs:
   # `test:integration:cli:sandbox:none` script from `release.yml`.
   integration_cli:
     name: 'Integration Tests (CLI, No Sandbox)'
-    if: "${{ github.event_name == 'merge_group' }}"
-    runs-on: 'ubuntu-latest'
+    needs: 'classify_pr'
+    # Same ECS routing as the Ubuntu gate (via classify_pr): the merge queue runs
+    # in the base-repo context, so use the self-hosted ECS pool and keep the
+    # scarce hosted Linux runners free. Falls back to hosted if classify_pr is
+    # skipped or the ECS kill-switch is set.
+    if: "${{ !cancelled() && github.event_name == 'merge_group' }}"
+    runs-on: '${{ fromJSON(needs.classify_pr.outputs.ubuntu_runner || ''["ubuntu-latest"]'') }}'
     permissions:
       contents: 'read'
     env:
@@ -475,12 +485,24 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
 
-      - name: 'Setup Node.js'
+      # Hosted downloads Node; self-hosted ECS reuses its pre-installed Node 22
+      # (it can't reach nodejs.org reliably). Mirrors the Ubuntu gate.
+      - name: 'Setup Node.js (hosted)'
+        if: "${{ runner.environment == 'github-hosted' }}"
         uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
           cache-dependency-path: 'package-lock.json'
+
+      - name: 'Use pre-installed Node.js (self-hosted)'
+        if: "${{ runner.environment == 'self-hosted' }}"
+        run: |-
+          if ! command -v node >/dev/null 2>&1; then
+            echo "::error::Node.js is not on PATH for this self-hosted runner. Provision Node 22.x or set the MAINTAINER_ECS_RUNNER_DISABLED repository variable to 'true' to route the merge queue back to hosted runners."
+            exit 1
+          fi
+          echo "Using pre-installed Node $(node -v) / npm $(npm -v)"
 
       - name: 'Install Dependencies'
         env:


### PR DESCRIPTION
## What this PR does

The merge queue (`merge_group`) skipped the `classify_pr` job — it was gated to `pull_request` — so the required `Test (ubuntu-latest)` gate and the `Integration Tests (CLI, No Sandbox)` job both fell back to hosted `ubuntu-latest`. Once the queue went live, every queue entry piled those Linux jobs onto the small hosted pool while the self-hosted ECS runners sat idle. The required gate then starved in `queued` for 30+ minutes and the queue stalled (no merges for hours).

This extends the existing ECS routing to `merge_group`:

- **`classify_pr`** now also runs for `merge_group` and emits the ECS runner label set (`["self-hosted", "linux", "x64", "ecs-qwen"]`). The merge queue runs in the trusted base-repo context, so this is safe. The required **`Test (ubuntu-latest)`** gate picks the runner up automatically through `classify_pr`'s `ubuntu_runner` output — no change needed in the gate job itself.
- **`integration_cli`** is routed through `classify_pr` the same way, with hosted/self-hosted Node handling mirroring the Ubuntu gate: ECS has Node 22 pre-installed and can't reach nodejs.org reliably, so on self-hosted it reuses the machine's Node instead of `actions/setup-node`.

macOS/Windows jobs stay on hosted runners (the ECS pool is Linux-only). The `MAINTAINER_ECS_RUNNER_DISABLED` repository-variable kill-switch still reverts everything back to hosted.

## Why it's needed

After #5842 the queue no longer runs CodeQL/E2E, but the required Linux gate still ran on hosted because `merge_group` never hit the ECS routing. Under load the hosted Linux pool saturates and the queue's required check sits unscheduled while ECS capacity is idle — exactly the stall this fixes. Routing the queue's Linux jobs to ECS keeps the gate unblocked and leaves the scarce hosted Linux runners free for fork PRs and the macOS/Windows jobs.

## Testing

- `actionlint` and `yamllint` pass (`node scripts/lint.js --actionlint --yamllint`).
- Reuses the exact ECS routing pattern already proven by the per-PR `Test` job and the ECS-based PR-review workflow (which calls the model API from ECS), so runner availability, Node provisioning (Node 22 / `.nvmrc`), and model egress are all known-good on the ECS pool.

## Out of scope

The runner label cleanup (16 `ecs-qwen-runner-N` carry only `ecs`, not `ecs-qwen`) and a `maximumEntriesToBuild` bump are runner-side / merge-queue-settings changes, not workflow code, so they are handled separately.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

合并队列(`merge_group`)会跳过 `classify_pr`(它的 `if` 只认 `pull_request`),导致必需门禁 `Test (ubuntu-latest)` 和 `Integration Tests (CLI, No Sandbox)` 都回落到 hosted `ubuntu-latest`。队列上线后,每个队列条目都把这些 Linux job 压到很小的 hosted 池,而自托管的 ECS runner 却闲置。必需门禁因此在 `queued` 里饿了 30+ 分钟,队列停摆(几个小时没有合并)。

本 PR 把已有的 ECS 路由扩展到 `merge_group`:

- **`classify_pr`** 现在也在 `merge_group` 下运行,并输出 ECS 标签集(`["self-hosted", "linux", "x64", "ecs-qwen"]`)。合并队列运行在受信任的 base-repo 上下文,所以这是安全的。必需门禁 **`Test (ubuntu-latest)`** 通过 `classify_pr` 的 `ubuntu_runner` 输出自动拿到 ECS runner——门禁 job 本身无需改动。
- **`integration_cli`** 以同样方式经由 `classify_pr` 路由,并加上与 Ubuntu 门禁一致的 hosted/self-hosted Node 处理:ECS 上预装了 Node 22 且无法稳定访问 nodejs.org,因此在自托管上复用机器自带的 Node,而不是 `actions/setup-node`。

macOS/Windows 仍跑在 hosted(ECS 池只有 Linux)。`MAINTAINER_ECS_RUNNER_DISABLED` 这个仓库变量的总开关依然能把一切切回 hosted。

## 为什么需要

#5842 之后队列已经不再跑 CodeQL/E2E,但必需的 Linux 门禁仍然跑在 hosted,因为 `merge_group` 从未命中 ECS 路由。负载一上来,hosted Linux 池就被占满,队列的必需检查排不上号,而 ECS 容量却闲着——正是本 PR 修复的停摆。把队列的 Linux job 路由到 ECS,门禁就不会再被堵,同时把稀缺的 hosted Linux runner 留给 fork PR 和 macOS/Windows job。

## 测试

- `actionlint` 与 `yamllint` 通过(`node scripts/lint.js --actionlint --yamllint`)。
- 复用了 per-PR `Test` job 以及基于 ECS 的 PR-review 工作流(它在 ECS 上调用模型 API)已经验证过的同一套 ECS 路由模式,因此 runner 可用性、Node 供给(Node 22 / `.nvmrc`)、模型出网在 ECS 池上都是已知可用的。

## 不在本 PR 范围内

runner 标签清理(16 台 `ecs-qwen-runner-N` 只带 `ecs`、缺 `ecs-qwen`)与调大 `maximumEntriesToBuild` 属于 runner 侧 / 合并队列设置的改动,不是工作流代码,单独处理。

</details>
