### PR TITLE
ci: route the merge queue's Linux jobs onto ECS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,12 @@ env:
 jobs:
   classify_pr:
     name: 'Classify PR'
-    if: "${{ github.event_name == 'pull_request' }}"
-    # Gate runs on ECS for in-repo PRs too, else a busy hosted pool delays it and blocks the ECS-bound jobs. The kill-switch is read here, so flipping it reverts everything to hosted.
-    runs-on: '${{ (vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && github.event.pull_request.head.repo.full_name == github.repository) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
+    if: "${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}"
+    # Gate runs on ECS for in-repo PRs and for the merge queue (which runs in the
+    # base-repo context), else a busy hosted pool delays it and blocks the
+    # ECS-bound jobs. The kill-switch is read here, so flipping it reverts
+    # everything to hosted.
+    runs-on: '${{ (vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == ''merge_group'')) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     continue-on-error: true
     outputs:
       skip_ci: '${{ steps.release_sync.outputs.skip_ci }}'
@@ -88,16 +91,18 @@ jobs:
           echo "skip_ci=${skip_ci}" >> "${GITHUB_OUTPUT}"
           echo "skip_ci=${skip_ci}"
 
-      # In-repo PR (head branch in this repo => author has write access) runs the
-      # Linux Test on ECS; forks stay hosted. Disable via repo var MAINTAINER_ECS_RUNNER_DISABLED=true.
+      # In-repo PR (head branch in this repo => author has write access) and the
+      # merge queue (base-repo context) run the Linux jobs on ECS; fork PRs stay
+      # hosted. Disable via repo var MAINTAINER_ECS_RUNNER_DISABLED=true.
       - name: 'Select Linux runner'
         id: 'pick_runner'
         env:
           SAME_REPO: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
           ECS_DISABLED: '${{ vars.MAINTAINER_ECS_RUNNER_DISABLED }}'
+          EVENT_NAME: '${{ github.event_name }}'
         run: |-
           ubuntu_runner='["ubuntu-latest"]'
-          if [[ "${ECS_DISABLED}" != "true" && "${SAME_REPO}" == "true" ]]; then
+          if [[ "${ECS_DISABLED}" != "true" && ( "${SAME_REPO}" == "true" || "${EVENT_NAME}" == "merge_group" ) ]]; then
             ubuntu_runner='["self-hosted", "linux", "x64", "ecs-qwen"]'
           fi
           echo "ubuntu_runner=${ubuntu_runner}" >> "${GITHUB_OUTPUT}"
@@ -138,11 +143,17 @@ jobs:
           # chokes the squid egress proxy, flaking checkout. depth 1 is enough.
           fetch-depth: 1
 
-      - name: 'Verify PR checkout includes head commit'
-        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && github.event_name == 'pull_request' }}"
+      # Guard against a stale checkout (e.g. a caching egress proxy serving an old
+      # ref) silently testing the wrong tree. Cheap: one merge-base, sub-second.
+      # Also runs in the merge queue — now that the queue's Ubuntu checkout is on
+      # ECS/squid, a wrong-tree pass would merge bad code.
+      - name: 'Verify checkout includes expected head commit'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}"
+        env:
+          EXPECTED_SHA: "${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.event.pull_request.head.sha }}"
         run: |-
-          if ! git merge-base --is-ancestor '${{ github.event.pull_request.head.sha }}' HEAD; then
-            echo "::error::Checked out ref does not contain PR head ${{ github.event.pull_request.head.sha }}."
+          if ! git merge-base --is-ancestor "${EXPECTED_SHA}" HEAD; then
+            echo "::error::Checked out ref does not contain expected head ${EXPECTED_SHA}."
             git log --oneline --decorate -5
             exit 1
           fi
@@ -463,8 +474,13 @@ jobs:
   # `test:integration:cli:sandbox:none` script from `release.yml`.
   integration_cli:
     name: 'Integration Tests (CLI, No Sandbox)'
-    if: "${{ github.event_name == 'merge_group' }}"
-    runs-on: 'ubuntu-latest'
+    needs: 'classify_pr'
+    # Same ECS routing as the Ubuntu gate (via classify_pr): the merge queue runs
+    # in the base-repo context, so use the self-hosted ECS pool and keep the
+    # scarce hosted Linux runners free. Falls back to hosted if classify_pr is
+    # skipped or the ECS kill-switch is set.
+    if: "${{ !cancelled() && github.event_name == 'merge_group' }}"
+    runs-on: '${{ fromJSON(needs.classify_pr.outputs.ubuntu_runner || ''["ubuntu-latest"]'') }}'
     permissions:
       contents: 'read'
     env:
@@ -475,12 +491,24 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
 
-      - name: 'Setup Node.js'
+      # Hosted downloads Node; self-hosted ECS reuses its pre-installed Node 22
+      # (it can't reach nodejs.org reliably). Mirrors the Ubuntu gate.
+      - name: 'Setup Node.js (hosted)'
+        if: "${{ runner.environment == 'github-hosted' }}"
         uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
           cache-dependency-path: 'package-lock.json'
+
+      - name: 'Use pre-installed Node.js (self-hosted)'
+        if: "${{ runner.environment == 'self-hosted' }}"
+        run: |-
+          if ! command -v node >/dev/null 2>&1; then
+            echo "::error::Node.js is not on PATH for this self-hosted runner. Provision Node 22.x or set the MAINTAINER_ECS_RUNNER_DISABLED repository variable to 'true' to route the merge queue back to hosted runners."
+            exit 1
+          fi
+          echo "Using pre-installed Node $(node -v) / npm $(npm -v)"
 
       - name: 'Install Dependencies'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,6 +526,9 @@ jobs:
             exit 1
           fi
           echo "Using pre-installed Node $(node -v) / npm $(npm -v)"
+          if [[ "$(node -p 'process.versions.node.split(".")[0]')" != "22" ]]; then
+            echo "::warning::Expected Node 22.x but found $(node -v); integration tests will run against the runner's Node."
+          fi
 
       - name: 'Install Dependencies'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,6 +490,23 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
+        with:
+          # Shallow, mirroring the Ubuntu gate: nothing here walks git history,
+          # and a full-history clone is the heaviest transfer on the ECS runner.
+          fetch-depth: 1
+
+      # Same stale-checkout guard as the Ubuntu gate: this job now runs on ECS
+      # via classify_pr, so fail loud if the checkout lacks the merge-queue head
+      # rather than silently testing the wrong tree into a merge.
+      - name: 'Verify checkout includes expected head commit'
+        env:
+          EXPECTED_SHA: '${{ github.event.merge_group.head_sha }}'
+        run: |-
+          if ! git merge-base --is-ancestor "${EXPECTED_SHA}" HEAD; then
+            echo "::error::Checked out ref does not contain expected head ${EXPECTED_SHA}."
+            git log --oneline --decorate -5
+            exit 1
+          fi
 
       # Hosted downloads Node; self-hosted ECS reuses its pre-installed Node 22
       # (it can't reach nodejs.org reliably). Mirrors the Ubuntu gate.

--- a/scripts/tests/no-ak-integration-ci.test.js
+++ b/scripts/tests/no-ak-integration-ci.test.js
@@ -94,9 +94,10 @@ describe('no-AK integration CI wiring', () => {
       "name: 'Back off for stale merge ref to refresh'",
     );
 
-    // The cheap sanity guard stays: fail loud if HEAD lacks the PR head.
+    // The cheap sanity guard stays: fail loud if HEAD lacks the expected head
+    // (PR head, or the merge-queue head once this job also runs on merge_group).
     expect(ubuntuJob).toContain(
-      "name: 'Verify PR checkout includes head commit'",
+      "name: 'Verify checkout includes expected head commit'",
     );
     expect(ubuntuJob).toContain('git merge-base --is-ancestor');
     expect(ubuntuJob).toContain('github.event.pull_request.head.sha');


### PR DESCRIPTION
## What this PR does

Route the merge queue's Linux jobs onto the in-repo ECS runner pool. `classify_pr` now also runs on `merge_group` and emits the ECS runner, so the Ubuntu `Test` gate and `Integration Tests` reuse that output and run on ECS in the queue instead of falling back to the shared hosted pool. The `MAINTAINER_ECS_RUNNER_DISABLED` kill-switch and the hosted fallback are intact, and fork PRs are unaffected.

It also extends the checkout-verification guard to the merge queue (a one-line `merge-base` check) so a stale-ref checkout can't silently test the wrong tree there.

## Why it's needed

The merge queue runs in the base-repo context, but `classify_pr` was PR-only, so its `ubuntu_runner` output was empty in the queue and the Ubuntu + Integration jobs fell back to `ubuntu-latest`. That piles onto the scarce hosted Linux runners exactly when the queue is busiest — we just hit a saturation incident where queued merge groups couldn't get hosted runners. Routing these onto the idle ECS pool keeps the hosted Linux runners free; mac/win stay hosted (no ECS equivalent).

The verify guard matters more now: with the queue's Ubuntu checkout on ECS behind the squid egress proxy, a stale ref served from cache could test the wrong tree, and a wrong-tree pass in the queue would merge bad code.

## Reviewer Test Plan

### How to verify

- `actionlint .github/workflows/ci.yml` passes.
- `classify_pr` `if` now includes `merge_group`; its `runs-on` and `pick_runner` select ECS when `merge_group` (or in-repo PR) and the kill-switch is off.
- `integration_cli` now `needs: classify_pr`, uses `ubuntu_runner`, and has hosted/self-hosted Node setup mirroring the Ubuntu gate.
- The verify step runs on `pull_request` and `merge_group`, checking the right `EXPECTED_SHA` (`merge_group.head_sha` in the queue).
- After merge: a merge-queue run shows `Classify PR`, `Test (ubuntu)`, and `Integration Tests` on the `ecs-qwen` self-hosted runner; fork PRs and `MAINTAINER_ECS_RUNNER_DISABLED=true` still go hosted.

### Evidence (Before & After)

N/A — CI-config only, no user-visible change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A  |
| 🪟 Windows |  N/A  |
|  🐧 Linux  |  ⚠️ actionlint only; ECS routing observable only on CI post-merge  |

### Environment (optional)

N/A — workflow change.

## Risk & Scope

- Main risk or tradeoff: the queue's required Ubuntu + Integration checks now depend on ECS availability — if the ECS pool is unhealthy the queue could stall. Mitigated by the `MAINTAINER_ECS_RUNNER_DISABLED` kill-switch (reverts both to hosted) and the new checkout guard (catches a stale-ref checkout). mac/win remain hosted.
- Not validated / out of scope: doesn't touch mac/win (hosted-only) or the post-merge `push` jobs; ECS routing behaviour is only observable on CI after merge.
- Breaking changes / migration notes: none.

## Linked Issues

Part of the merge-queue rollout in #4805. Routing approach carried forward from #5853 by @wenshao (closed); this revives it with the merge-queue checkout guard added.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 merge queue 的 Linux 活路由到 in-repo 的 ECS runner 池。`classify_pr` 现在也在 `merge_group` 跑、输出 ECS runner，于是 ubuntu `Test` 门和 `Integration Tests` 复用该输出、在队列里跑 ECS，而不是回落到共享的 hosted 池。`MAINTAINER_ECS_RUNNER_DISABLED` kill-switch 和 hosted fallback 都保留，fork PR 不受影响。

同时把 checkout 校验守卫扩展到 merge queue（一个 `merge-base` 检查），防止队列里旧 ref 静默测错树。

## 为什么需要

merge queue 跑在 base-repo 上下文，但 `classify_pr` 之前只在 PR 跑，所以队列里它的 `ubuntu_runner` 输出为空、ubuntu+integration 回落 `ubuntu-latest`，在队列最忙时正好挤压稀缺的 hosted Linux runner——我们刚出过一次 saturation 事故，排队的 merge group 抢不到 hosted runner。把这些挪到空闲的 ECS 池能腾出 hosted；mac/win 没有 ECS 对应只能留 hosted。

verify 守卫现在更重要：队列的 ubuntu checkout 走 ECS、经 squid 代理，缓存的旧 ref 可能测错树，而队列里测错树的"通过"会把坏代码合进 main。

## 验证方式

- `actionlint .github/workflows/ci.yml` 通过。
- `classify_pr` 的 `if` 含 `merge_group`；`runs-on` 和 `pick_runner` 在 `merge_group`（或 in-repo PR）且 kill-switch 关时选 ECS。
- `integration_cli` 现在 `needs: classify_pr`、用 `ubuntu_runner`、有 hosted/self-hosted Node 处理（对齐 ubuntu 门）。
- verify 步骤在 `pull_request` 和 `merge_group` 都跑，校验正确的 `EXPECTED_SHA`（队列里用 `merge_group.head_sha`）。
- 合并后：merge-queue run 里 `Classify PR` / `Test (ubuntu)` / `Integration Tests` 跑在 `ecs-qwen` 自建 runner；fork PR 和 `MAINTAINER_ECS_RUNNER_DISABLED=true` 仍走 hosted。

### 证据（Before & After）

N/A —— 仅 CI 配置，无用户可见变化。

## 风险与范围

- 主要权衡：队列的 required ubuntu+integration 现在依赖 ECS 可用性——ECS 不健康时队列可能卡。靠 kill-switch（两者回落 hosted）+ 新的 checkout 守卫（抓旧 ref）兜底。mac/win 仍 hosted。
- 未验证 / 范围外：不动 mac/win（hosted-only）和 push 兜底 job；ECS 路由效果只能合并后在 CI 上看。
- 破坏性变更 / 迁移：无。

## 关联 issue

属于 #4805 的 merge queue 推进。路由方案来自 @wenshao 的 #5853（已关），本 PR 复活它并补上队列的 checkout 守卫。

</details>
