### PR TITLE
test(cli): raise i18n ToolMessage test timeout to 15s to stop merge-queue flake

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
@@ -995,7 +995,10 @@ describe('<ToolMessage /> localized badge', () => {
     const output = lastFrame() ?? '';
     expect(output).toContain('读取文件');
     expect(output).not.toContain('ReadFile');
-  });
+    // 15s timeout (not the 5s default): setLanguageAsync() loads locale
+    // resources lazily and intermittently exceeds 5s on the heavily
+    // parallelized macOS CI runner, flaking the merge queue.
+  }, 15000);
 
   it('keeps the English display name under the en locale', async () => {
     const { setLanguageAsync } = await import('../../../i18n/index.js');
@@ -1005,5 +1008,5 @@ describe('<ToolMessage /> localized badge', () => {
       StreamingState.Idle,
     );
     expect(lastFrame() ?? '').toContain('ReadFile');
-  });
+  }, 15000);
 });


### PR DESCRIPTION
## What this PR does

Raises the per-test timeout from the 5s default to 15s for the two `<ToolMessage /> localized badge` locale tests in `ToolMessage.test.tsx`.

## Why it's needed

Both tests `await setLanguageAsync()`, which loads locale resources lazily. On the heavily parallelized macOS CI runner that call intermittently takes longer than the 5s default and the test times out — even though nothing is actually broken. Because the failure only surfaces under merge-queue load (not at PR-check time, where the macOS job is skipped), it repeatedly kicks otherwise-passing PRs out of the merge queue. #5828 was bounced three times this way on an unrelated change; in the failing run the full CLI suite took 830s wall-clock, so a 5s budget for a lazy locale load is too tight under contention.

## Reviewer Test Plan

### How to verify

```
cd packages/cli && npx vitest run src/ui/components/messages/ToolMessage.test.tsx -t "localized badge"
```

Expected: both `zh` and `en` locale tests pass. The change only lifts the timeout ceiling; assertions are unchanged.

### Evidence (Before & After)

Before: `FAIL src/ui/components/messages/ToolMessage.test.tsx > <ToolMessage /> localized badge > shows the localized display name under the zh locale` — `Error: Test timed out in 5000ms.` ([failing merge-queue job](https://github.com/QwenLM/qwen-code/actions/runs/28150792806/job/83367783029))

After (local macOS):
```
 ✓ src/ui/components/messages/ToolMessage.test.tsx (42 tests | 40 skipped) 265ms
 Test Files  1 passed (1)
      Tests  2 passed | 40 skipped (42)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit test only.

## Risk & Scope

- Main risk or tradeoff: a genuinely-hung locale load would now take 15s to fail instead of 5s. Acceptable — the observed failure is a load-induced timeout, not a logic bug, so the assertions still guard correctness.
- Not validated / out of scope: the broader macOS CI suite slowness (830s collect-heavy run) is not addressed here; this only stops the flaky timeout from blocking the merge queue.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #5828 (the PR repeatedly evicted from the merge queue by this flake).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 `ToolMessage.test.tsx` 里两个 `<ToolMessage /> localized badge` 语言用例的单测超时从默认 5s 提到 15s。

## 为什么需要

这两个用例都会 `await setLanguageAsync()`，而该调用是惰性加载语言资源的。在高度并行的 macOS CI runner 上，这个调用偶尔会超过 5s 默认超时导致用例超时——其实并没有真正的功能问题。由于该失败只在 merge queue 阶段（macOS job 在 PR check 阶段是 skip 的）才暴露，它会反复把本来能通过的 PR 踢出合并队列。#5828 就因此在一个无关改动上被踢了三次；那趟失败的 run 里整个 CLI 套件跑了 830s，所以在高负载下给惰性语言加载只留 5s 预算太紧了。

## 如何验证

```
cd packages/cli && npx vitest run src/ui/components/messages/ToolMessage.test.tsx -t "localized badge"
```

预期：`zh` 和 `en` 两个语言用例都通过。本改动只抬高超时上限，断言未变。

## 风险与范围

- 主要风险：真正卡死的语言加载现在会等 15s 而不是 5s 才失败。可接受——观察到的失败是负载导致的超时而非逻辑 bug，断言仍然守住正确性。
- 不在范围内：更大范围的 macOS CI 套件慢（830s、collect 占大头）不在本 PR 处理；这里只是阻止这个 flaky 超时卡住合并队列。
- 破坏性变更：无。

</details>
