### PR TITLE
ci: take CodeQL and E2E off the per-merge push path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,10 @@
 name: 'Qwen Code CI'
 
 on:
-  push:
-    branches:
-      - 'main'
-      # No 'release/**' here: release.yml's commits to the release branch would
-      # fire a redundant full CI run that blocks the release PR's merge queue.
-      # Kept under pull_request below for backport PRs.
+  # No `push` trigger: every job here is gated to pull_request / merge_group, so
+  # a push to `main` ran nothing (CodeQL was the last push job and moved to its
+  # own scheduled codeql.yml). The merge queue validates the merged tree before
+  # it lands, so there is nothing left to run on the post-merge push.
   pull_request:
     branches:
       - 'main'
@@ -419,36 +417,6 @@ jobs:
           os: '${{ matrix.os }}'
           github_token: '${{ secrets.GITHUB_TOKEN }}'
 
-  codeql:
-    name: 'CodeQL'
-    needs: 'classify_pr'
-    # Security findings rarely change push-to-push, and a slow scan is poor value
-    # as a hard merge gate. Run CodeQL only on push to `main` (post-merge
-    # backstop) — not on PR pushes, and not in the merge queue where, being
-    # non-required, it would just burn a runner and lengthen the serial queue
-    # without blocking anything.
-    if: "${{ !cancelled() && needs.classify_pr.outputs.skip_ci != 'true' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}"
-    runs-on: 'ubuntu-latest'
-    # Analysis normally finishes in ~7-9 min (22 min worst case observed). Without
-    # an explicit cap, a hosted runner that drops its heartbeat mid-analysis leaves
-    # the job "in_progress" for the default 6h, holding a scarce hosted Linux slot
-    # the whole time. 30 min reaps such an orphan fast while clearing real runs.
-    timeout-minutes: 30
-    permissions:
-      actions: 'read'
-      contents: 'read'
-      security-events: 'write'
-    steps:
-      - name: 'Checkout'
-        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
-
-      - name: 'Initialize CodeQL'
-        uses: 'github/codeql-action/init@df559355d593797519d70b90fc8edd5db049e7a2' # ratchet:github/codeql-action/init@v3
-        with:
-          languages: 'javascript'
-
-      - name: 'Perform CodeQL Analysis'
-        uses: 'github/codeql-action/analyze@df559355d593797519d70b90fc8edd5db049e7a2' # ratchet:github/codeql-action/analyze@v3
 
   # Integration tests run only in the merge queue, not on every PR push.
   # They are the suite that previously ran *only* in the nightly Release

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: 'CodeQL'
+
+# CodeQL used to be a per-push job in ci.yml. Security findings rarely change
+# commit-to-commit and the scan is non-blocking (never a required check), so
+# running it on every merge to `main` just piled onto the scarce hosted Linux
+# pool. Run it on a nightly schedule (plus manual dispatch) instead; findings
+# still surface in the Security tab. If fresher results are wanted, add a
+# path-filtered `push` trigger for security-relevant sources.
+on:
+  schedule:
+    - cron: '0 3 * * *' # nightly (~03:00 UTC), staggered from the E2E nightly
+  workflow_dispatch:
+
+permissions:
+  actions: 'read'
+  contents: 'read'
+  security-events: 'write'
+
+concurrency:
+  group: 'codeql'
+  cancel-in-progress: false
+
+jobs:
+  codeql:
+    name: 'CodeQL'
+    runs-on: 'ubuntu-latest'
+    # Analysis normally finishes in ~7-9 min (22 min worst case observed). Cap it
+    # so a runner that drops its heartbeat mid-analysis can't hold a slot for the
+    # default 6h.
+    timeout-minutes: 30
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
+
+      - name: 'Initialize CodeQL'
+        uses: 'github/codeql-action/init@df559355d593797519d70b90fc8edd5db049e7a2' # ratchet:github/codeql-action/init@v3
+        with:
+          languages: 'javascript'
+
+      - name: 'Perform CodeQL Analysis'
+        uses: 'github/codeql-action/analyze@df559355d593797519d70b90fc8edd5db049e7a2' # ratchet:github/codeql-action/analyze@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,25 +1,30 @@
 name: 'E2E Tests'
 
 on:
-  # E2E runs post-merge on `main` (per-commit signal) only. It is intentionally
-  # NOT in the merge queue yet: it is slow and currently flaky, so gating the
-  # serial queue on it would stall every merge. Promote it to `merge_group` +
-  # required once it is reliable.
+  # E2E is slow and currently flaky, so it is NOT in the merge queue (gating the
+  # serial queue on it would stall every merge). It runs post-merge on `main`,
+  # plus a nightly full regression and on-demand. Promote it to `merge_group` +
+  # required once a stable subset is carved out.
   push:
     branches:
       - 'main'
       - 'feat/e2e/**'
+  schedule:
+    - cron: '0 4 * * *' # nightly full regression (~04:00 UTC), guaranteed signal
+  workflow_dispatch:
 
 concurrency:
-  # Key on the head ref so a `push` to a `feat/e2e/**` branch and a
-  # `pull_request` from that same branch share one group and cancel each
-  # other instead of running the matrix twice for the same change.
+  # Scope the group by event so back-to-back pushes to `main` cancel superseded
+  # runs (no pile-up when PRs merge in quick succession), without ever cancelling
+  # the nightly schedule or a manual dispatch — they share the ref but not the
+  # event. feat/e2e/** pushes still cancel their own superseded runs.
   group: |-
-    ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  # Cancel superseded feature-branch runs, but let every `main` commit finish
-  # (complete per-commit e2e signal, matching ci.yml).
+    ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
+  # Cancel superseded pushes (main included now — only the latest tree matters,
+  # and it covers every merged change). The nightly run always finishes, so a
+  # busy merge window that keeps cancelling the push run still gets a signal.
   cancel-in-progress: |-
-    ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
+    ${{ github.event_name == 'push' }}
 
 jobs:
   e2e-test-linux:


### PR DESCRIPTION
## What this PR does

Stop running CodeQL and the full E2E suite on every push to `main`, since that per-commit post-merge work was the main driver of the recent hosted-runner saturation.

- **CodeQL** moves to its own `codeql.yml` on a nightly `schedule` + `workflow_dispatch`, and is removed from `ci.yml`. As a result `ci.yml` loses its `push` trigger — every remaining job is gated to `pull_request` / `merge_group`, so a push to `main` ran nothing anyway.
- **E2E** keeps running on push to `main`, but with event-scoped concurrency so back-to-back merges cancel superseded runs instead of piling up, plus a **nightly full regression** as a guaranteed signal and `workflow_dispatch` for manual runs.

The `merge_group` gate (ubuntu + integration + mac + win) still validates every PR before it lands — this only touches the non-gating post-merge work.

## Why it's needed

After #5842, CodeQL + the three E2E jobs were the only things on every `push: main`. They never cancel-superseded, so a few back-to-back merges stacked ~30min CodeQL + ~25/36/36min E2E onto the scarce hosted Linux pool — a primary cause of the saturation incident. CodeQL was never a required check and its findings still surface in the Security tab, so per-commit scanning bought little; E2E only needs the latest `main` tree tested (it covers every merged change), with a nightly run so a busy merge window can't starve it.

## Reviewer Test Plan

### How to verify

- `actionlint .github/workflows/{ci,e2e,codeql}.yml` passes.
- `ci.yml` no longer has a `push` trigger or a `codeql` job.
- `codeql.yml` runs on `schedule` + `workflow_dispatch` only, with `security-events: write`.
- `e2e.yml` concurrency group is event-scoped (`...-${{ github.event_name }}-...`) and `cancel-in-progress` is true for `push`; nightly `schedule` + `workflow_dispatch` added.
- After merge: back-to-back merges to `main` cancel the older E2E run; the nightly E2E and nightly CodeQL show up on schedule; no `Qwen Code CI` runs are triggered by `push: main`.

### Evidence (Before & After)

N/A — CI-config only, no user-visible change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A  |
| 🪟 Windows |  N/A  |
|  🐧 Linux  |  ⚠️ actionlint only; scheduling/concurrency observable only on CI  |

### Environment (optional)

N/A — workflow change.

## Risk & Scope

- Main risk / tradeoff: CodeQL and E2E no longer run on every commit — CodeQL is nightly (findings delayed up to a day; Security tab still the source of truth), and a busy merge window can keep cancelling the push E2E so the **nightly** run becomes the signal there. The pre-merge `merge_group` gate is unchanged. Failure alerting for these unattended runs is a deliberate follow-up (a deduped `ci-failure` issue), not in this PR.
- Not validated / out of scope: doesn't change merge-queue settings, required checks, or the E2E job matrix (docker variant still runs on push; could move to nightly-only later); no DingTalk alerting yet.
- Breaking changes / migration notes: none.

## Linked Issues

Part of the merge-queue rollout in #4805; follow-up to #5842.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

不再让 CodeQL 和整套 E2E 在每次 push 到 `main` 时跑——那套“每个 commit 的合并后兜底”是最近 hosted runner 被打满的主因。

- **CodeQL** 抽到独立的 `codeql.yml`，改成 nightly `schedule` + `workflow_dispatch`，从 `ci.yml` 删掉。连带 `ci.yml` 的 `push` 触发器也去掉——其余 job 都 gated 到 `pull_request` / `merge_group`，push 到 `main` 本来就什么都不跑。
- **E2E** 仍在 push 到 `main` 跑，但改成 event-scoped concurrency，让连续合并时旧 run 被取消、不再堆积；另加 **nightly 全量回归**当保底信号 + `workflow_dispatch` 手动。

合并前的 `merge_group` 门（ubuntu + integration + mac + win）不变——这只动非 gating 的合并后工作。

## 为什么需要

#5842 之后，CodeQL + 3 个 E2E job 是 `push: main` 上仅剩的东西。它们从不 cancel-superseded，几个 PR 连着合就把 ~30min CodeQL + ~25/36/36min E2E 堆到稀缺的 hosted Linux 池上——saturation 事故主因。CodeQL 不是 required、发现也进 Security tab，每个 commit 扫价值不大；E2E 只需测最新 `main` 树（它覆盖所有已合改动），再加 nightly 防忙时被反复取消饿死。

## 验证方式

- `actionlint .github/workflows/{ci,e2e,codeql}.yml` 通过。
- `ci.yml` 不再有 `push` 触发器和 `codeql` job。
- `codeql.yml` 只在 `schedule` + `workflow_dispatch` 跑，带 `security-events: write`。
- `e2e.yml` concurrency group 含 `${{ github.event_name }}`，`cancel-in-progress` 对 `push` 为真；加了 nightly `schedule` + `workflow_dispatch`。
- 合并后：连续合并会取消较旧的 E2E run；nightly E2E / nightly CodeQL 按时出现；`push: main` 不再触发 `Qwen Code CI`。

### 证据（Before & After）

N/A —— 仅 CI 配置，无用户可见变化。

## 风险与范围

- 主要权衡：CodeQL/E2E 不再每个 commit 跑——CodeQL 改 nightly（发现最多延迟一天；Security tab 仍是准）；忙时 push 的 E2E 可能被反复取消，**nightly** 成为那段时间的信号。合并前的 `merge_group` 门不变。这些无人值守 run 的失败告警是有意拆出的后续（deduped `ci-failure` issue），不在本 PR。
- 未验证 / 范围外：不改 merge-queue 设置、required 列表、E2E 矩阵（docker 变体仍在 push 跑，以后可只留 nightly）；暂无钉钉告警。
- 破坏性变更 / 迁移：无。

## 关联 issue

属于 #4805 的 merge queue 推进；#5842 的后续。

</details>
