### PR TITLE
ci(qwen-resolve): run the /resolve job on a hosted runner

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -621,13 +621,14 @@ jobs:
           startsWith(github.event.comment.body, '@qwen-code /resolve ') ||
           startsWith(github.event.comment.body, format('@qwen-code /resolve{0}', '\n'))))
       )
-    # Prefer the self-hosted ECS pool, but honor the MAINTAINER_ECS_RUNNER_DISABLED
-    # kill-switch (like the review path): if ECS is toggled off, fall back to an
-    # ephemeral hosted runner so /resolve still works. NOTE: this job's verification
-    # gate runs the untrusted PR's build/typecheck/lint/test; on the reused ECS
-    # workspace the cleanup step below keeps stale per-run artifacts from leaking
-    # between PRs (hosted runners are ephemeral, so they need no such cleanup).
-    runs-on: "${{ vars.MAINTAINER_ECS_RUNNER_DISABLED != 'true' && fromJSON('[\"self-hosted\", \"linux\", \"x64\", \"ecs-qwen\"]') || fromJSON('[\"ubuntu-latest\"]') }}"
+    # Pinned to an ephemeral hosted runner. The conflict-resolution agent step
+    # runs with `sandbox: true`, which on Linux needs docker or podman to launch
+    # the sandbox; the self-hosted ECS pool ships no container runtime, so routing
+    # this job there fails the agent before it starts (exit 44, "failed to
+    # determine command for sandbox"). Hosted runners ship docker and are
+    # ephemeral, which also suits running the untrusted PR's build/typecheck/
+    # lint/test in the verification gate below.
+    runs-on: 'ubuntu-latest'
     timeout-minutes: 90
     concurrency:
       group: 'qwen-resolve-${{ github.event.issue.number || github.event.inputs.pr_number }}'
@@ -644,10 +645,10 @@ jobs:
       WORKDIR: '/tmp/qwen-resolve'
       DRY_RUN: '${{ github.event.inputs.dry_run || false }}'
     steps:
-      # Self-hosted runners reuse the workspace and /tmp across jobs. A prior
-      # /resolve can leave stale ${WORKDIR} reports (failure.md, no-action.md, ...)
-      # that the verification gate would misread as this run's outcome, plus stale
-      # git worktrees that trip the checkout. Clean defensively; never fail the job.
+      # Defensive cleanup. Hosted runners start clean so this is normally a no-op,
+      # but a stale ${WORKDIR} report (failure.md, no-action.md, ...) or leftover
+      # git worktree would make the verification gate or checkout misread this
+      # run's outcome. Clean before anything else; never fail the job.
       - name: 'Clean stale resolve workspace'
         run: |-
           set -uo pipefail
@@ -1133,9 +1134,11 @@ jobs:
               push_failed=true
               echo "::error::Push rejected; the branch was updated concurrently. Re-run /resolve."
             fi
-            # Scrub the PAT from .git/config: this job runs on a self-hosted ECS
-            # runner where .git/config persists between jobs, so a later job could
-            # otherwise read the token. Runs regardless of push outcome.
+            # Scrub the PAT from .git/config defensively. Hosted runners are
+            # ephemeral so .git/config does not persist, but scrubbing the token
+            # as soon as the push is done keeps it out of the workspace that the
+            # untrusted PR's build/lint/test step runs in. Runs regardless of
+            # push outcome.
             git remote set-url origin "https://github.com/${REPO}.git"
           fi
 


### PR DESCRIPTION
## What this PR does

Pins the maintainer-triggered `/resolve` conflict-resolution job to an ephemeral hosted runner (`ubuntu-latest`) instead of routing it onto the self-hosted ECS pool.

## Why it's needed

The job's agent step runs with `sandbox: true`, which on Linux launches the sandbox through docker or podman. The self-hosted ECS pool has no container runtime, so the agent step fails before doing any work — exit 44, `failed to determine command for sandbox` — and the run reports a generic "did not complete successfully" on the PR (e.g. run 28158417390 triggered on #4943). Hosted `ubuntu-latest` ships docker, so the sandbox can start; it is also ephemeral, which suits running the untrusted PR's build/typecheck/lint/test in the verification gate.

## Reviewer Test Plan

### How to verify

Static review of the `resolve-pr` job: `runs-on` is now `ubuntu-latest`, with no remaining self-hosted-only dependency — no `runner.*` gating, no hardcoded ECS paths, and the secrets it uses (`CI_BOT_PAT`, `CI_DEV_BOT_PAT`, `OPENAI_*`) are repo-level and available on hosted runners. The cleanup and PAT-scrub steps are unchanged and remain harmless defensive no-ops on an ephemeral runner; only their comments were updated to drop the stale "reused self-hosted workspace" assumption. `yamllint` on the workflow is clean.

End-to-end is intentionally deferred (see Out of scope): a follow-up dry-run on an in-repo conflicting PR should confirm the sandbox actually starts on hosted before relying on the command.

### Evidence (Before & After)

N/A (CI configuration change). Before: run 28158417390 — agent step exit 44, `QWEN_SANDBOX is true but failed to determine command for sandbox; install docker or podman`. After: the job targets `ubuntu-latest`, which ships docker.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

GitHub Actions; workflow-only change. Verified locally with `yamllint`.

## Risk & Scope

- Main risk or tradeoff: the job no longer honors the `MAINTAINER_ECS_RUNNER_DISABLED` kill-switch — it is now always hosted. This is intentional: the kill-switch existed to move work off ECS, and the docker-backed sandbox requirement means this job must stay off ECS until the pool gains a container runtime. Cost is hosted-runner minutes for a low-frequency, maintainer-triggered command.
- Not validated / out of scope: a live end-to-end `/resolve` run on hosted (sandbox start → verify gate → push). Fork-PR support and replacement-PR creation remain out of scope, as in #5779.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up fix to #5779.

<details>
<summary>中文说明</summary>

## What this PR does

把维护者触发的 `/resolve` 冲突解决 job 固定到临时 hosted runner（`ubuntu-latest`），不再路由到自建 ECS pool。

## Why it's needed

该 job 的 agent 步骤以 `sandbox: true` 运行，在 Linux 上要通过 docker 或 podman 启动 sandbox。自建 ECS pool 没有容器运行时，所以 agent 步骤在干活之前就失败了——exit 44、`failed to determine command for sandbox`——PR 上只显示笼统的 "did not complete successfully"（例如在 #4943 上触发的 run 28158417390）。Hosted `ubuntu-latest` 自带 docker，sandbox 能起；它还是临时的，适合在 verification gate 里跑不受信任 PR 的 build/typecheck/lint/test。

## Reviewer Test Plan

### How to verify

静态审查 `resolve-pr` job：`runs-on` 现在是 `ubuntu-latest`，没有残留的 self-hosted 专属依赖——没有 `runner.*` 门控、没有硬编码 ECS 路径，用到的 secrets（`CI_BOT_PAT`、`CI_DEV_BOT_PAT`、`OPENAI_*`）都是 repo 级、hosted runner 同样可用。cleanup 和 PAT-scrub 步骤逻辑没动，在临时 runner 上是无害的防御性 no-op，只更新了其注释里过时的「复用 self-hosted 工作区」假设。workflow 跑 `yamllint` 干净。

端到端验证有意推迟（见 Out of scope）：后续应在一个本仓库的冲突 PR 上 dry-run 一次，确认 hosted 上 sandbox 真能起来再依赖这个命令。

### Evidence (Before & After)

N/A（CI 配置改动）。Before：run 28158417390——agent 步骤 exit 44，`QWEN_SANDBOX is true but failed to determine command for sandbox; install docker or podman`。After：job 跑在自带 docker 的 `ubuntu-latest` 上。

### Tested on

见上表。

### Environment (optional)

GitHub Actions；纯 workflow 改动。本地用 `yamllint` 验证。

## Risk & Scope

- Main risk or tradeoff：该 job 不再响应 `MAINTAINER_ECS_RUNNER_DISABLED` kill-switch——现在恒定 hosted。这是有意的：kill-switch 本来就是用来把任务挪离 ECS，而 docker sandbox 的需求意味着在 ECS pool 装上容器运行时之前，这个 job 必须留在 ECS 之外。代价是这个低频、维护者触发的命令会消耗 hosted runner 分钟数。
- Not validated / out of scope：一次 hosted 上的真实端到端 `/resolve` 运行（sandbox 启动 → verify gate → push）。fork PR 支持与 replacement-PR 创建仍然 out of scope，与 #5779 一致。
- Breaking changes / migration notes：无。

## Linked Issues

#5779 的后续修复。

</details>
