### PR TITLE
feat(web-shell): show duration on finished thinking summary

### DIFF
--- a/packages/web-shell/client/components/messages/AssistantMessage.tsx
+++ b/packages/web-shell/client/components/messages/AssistantMessage.tsx
@@ -233,7 +233,7 @@ export const ThinkingMessage = memo(function ThinkingMessage({
                 }
               >
                 {t(thinkingSummaryKey, {
-                  duration: thinkingActive ? thinkingDuration : '',
+                  duration: thinkingDuration,
                 })}
               </span>
               <span

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -1119,7 +1119,7 @@ const EN: Messages = {
   'thinking.collapse': 'Collapse thinking',
   'thinking.running': (v) => `Thinking${v?.duration ? ` ${v.duration}` : ''}`,
   'thinking.done': (v) =>
-    `Finished thinking${v?.duration ? ` ${v.duration}` : ''}`,
+    v?.duration ? `Thought for ${v.duration}` : 'Done thinking',
   'settings.title': 'Settings',
   'settings.loading': 'Loading settings...',
   'settings.empty': 'No settings available.',
@@ -2227,7 +2227,7 @@ const ZH: Messages = {
   'thinking.expand': '展开思考',
   'thinking.collapse': '收起思考',
   'thinking.running': (v) => `正在思考${v?.duration ? ` ${v.duration}` : ''}`,
-  'thinking.done': (v) => `已完成思考${v?.duration ? ` ${v.duration}` : ''}`,
+  'thinking.done': (v) => (v?.duration ? `已思考 ${v.duration}` : '思考完成'),
   'welcome.changeModel': '(/model 切换)',
   'welcome.defaultModel': '未知模型',
   'settings.title': '设置',


### PR DESCRIPTION
## What this PR does

Keeps the elapsed time visible on the collapsed thinking summary after thinking finishes, and refines the finished-state wording in the web shell. Previously the summary showed the running timer (e.g. "Thinking 5s") but dropped the duration the moment thinking finished, collapsing to a bare "Finished thinking" / "已完成思考". Now the finished summary reads "Thought for 5s" / "已思考 5s" when the duration is known, and falls back to "Done thinking" / "思考完成" when it is not (e.g. history messages restored on reload, where the original duration was never observed).

## Why it's needed

Dropping the duration on completion makes the finished state show *less* information than while it was running, which feels like a regression and is inconsistent with the streaming state and with common reasoning-trace conventions (ChatGPT/Claude "Thought for Xs", DeepSeek/Kimi "已深度思考（用时 X 秒）"). The previous Chinese label "已完成思考" also reads as an action sentence ("has finished thinking") rather than a concise status; "已思考 5s" / "思考完成" are tighter and stay symmetric with the running label "正在思考".

## Reviewer Test Plan

### How to verify

1. Run the web shell (`npm run dev` in `packages/web-shell`) and send a prompt to a model that emits a thinking/reasoning trace.
2. While streaming, the collapsed summary shows the live timer "Thinking 5s" / "正在思考 5s" (unchanged).
3. After thinking finishes in the same live session, the summary now keeps the duration: "Thought for 5s" / "已思考 5s".
4. Reload the page so the message is restored from history (no duration observed this session): the summary falls back to "Done thinking" / "思考完成".

Expected: the finished summary never loses information relative to the running state when a duration is known, and degrades gracefully to a duration-less label otherwise.

### Evidence (Before & After)

Rendered summary string by state:

| State | Before | After |
| --- | --- | --- |
| Thinking (streaming) | `Thinking 5s` / `正在思考 5s` | `Thinking 5s` / `正在思考 5s` (unchanged) |
| Finished, live session | `Finished thinking` / `已完成思考` (duration dropped) | `Thought for 5s` / `已思考 5s` |
| Finished, history (no duration) | `Finished thinking` / `已完成思考` | `Done thinking` / `思考完成` |

Implementation: `AssistantMessage.tsx` now always forwards the computed `thinkingDuration` (it is already `''` for history messages with no observed duration), and the `thinking.done` i18n entries branch on whether a duration is present.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS: `vitest run` (471 tests pass, incl. `AssistantMessage.test.tsx`), `tsc --noEmit` clean, `prettier --check` clean on both touched files. Windows/Linux: not tested locally — covered by CI.

### Environment (optional)

Node/vitest unit tests + `tsc` typecheck in `packages/web-shell`. No live model required to run the test suite.

## Risk & Scope

- Main risk or tradeoff: purely an i18n wording / display change for two locales (en, zh-CN); no logic or data-flow change beyond always forwarding an already-computed duration string.
- Not validated / out of scope: no real-browser screenshot captured (string-level before/after provided instead); other locales are not defined in the web shell (only en and zh-CN exist).
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 web shell 中折叠的"思考"摘要在思考结束后继续显示耗时，并优化完成态文案。之前摘要在思考进行时显示实时计时（如 "Thinking 5s"），但一旦思考结束就丢掉耗时，退化成单纯的 "Finished thinking" / "已完成思考"。现在已知耗时时，完成态显示 "Thought for 5s" / "已思考 5s"；未知耗时时（如刷新后从历史记录恢复的消息，本会话从未观测到耗时）回退为 "Done thinking" / "思考完成"。

## 为什么需要

完成时丢掉耗时，会让完成态显示的信息反而比运行时更少，像一种倒退，也与运行态以及业界主流的推理轨迹惯例不一致（ChatGPT/Claude "Thought for Xs"、DeepSeek/Kimi "已深度思考（用时 X 秒）"）。原中文文案 "已完成思考" 读起来像动作句（"已经完成了思考"）而非简洁的状态标签；"已思考 5s" / "思考完成" 更紧凑，并与运行态 "正在思考" 保持对称。

## 审阅者验证计划

### 如何验证

1. 运行 web shell（在 `packages/web-shell` 执行 `npm run dev`），向会输出思考/推理轨迹的模型发送一个 prompt。
2. 流式进行时，折叠摘要显示实时计时 "Thinking 5s" / "正在思考 5s"（不变）。
3. 同一 live 会话内思考结束后，摘要现在保留耗时："Thought for 5s" / "已思考 5s"。
4. 刷新页面，使该消息从历史记录恢复（本会话未观测到耗时）：摘要回退为 "Done thinking" / "思考完成"。

预期：已知耗时时，完成态相对运行态不再丢失信息；未知耗时时优雅降级为不带耗时的文案。

### 证据（前后对比）

各状态下渲染出的摘要字符串：

| 状态 | 改前 | 改后 |
| --- | --- | --- |
| 思考中（流式）| `Thinking 5s` / `正在思考 5s` | `Thinking 5s` / `正在思考 5s`（不变）|
| 完成 · live 会话 | `Finished thinking` / `已完成思考`（丢耗时）| `Thought for 5s` / `已思考 5s` |
| 完成 · 历史（无耗时）| `Finished thinking` / `已完成思考` | `Done thinking` / `思考完成` |

实现：`AssistantMessage.tsx` 现在始终透传已计算好的 `thinkingDuration`（对历史消息它本就是 `''`），`thinking.done` 的 i18n 条目根据是否存在耗时分支。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS：`vitest run`（471 个测试通过，含 `AssistantMessage.test.tsx`）、`tsc --noEmit` 通过、两个改动文件 `prettier --check` 通过。Windows/Linux：本地未测试，交由 CI 覆盖。

### 运行环境（可选）

`packages/web-shell` 内的 Node/vitest 单测 + `tsc` 类型检查。运行测试套件不需要真实模型。

## 风险与范围

- 主要风险/取舍：纯 i18n 文案/显示改动，覆盖两个 locale（en、zh-CN）；除"始终透传一个已算好的耗时字符串"外无逻辑或数据流改动。
- 未验证/范围外：未截取真实浏览器截图（改为提供字符串级前后对比）；web shell 仅定义了 en 与 zh-CN 两个 locale。
- 破坏性改动/迁移说明：无。

## 关联 Issue

N/A

</details>
