### PR TITLE
fix(core): stream chat-compression side-query to survive gateway timeout

### DIFF
--- a/packages/core/src/core/baseLlmClient.test.ts
+++ b/packages/core/src/core/baseLlmClient.test.ts
@@ -644,6 +644,54 @@ describe('BaseLlmClient', () => {
       expect(mockGenerateContentStream).not.toHaveBeenCalled();
       expect(result.text).toBe('plain');
     });
+
+    it('propagates a mid-stream error and never returns the partial text', async () => {
+      async function* failingStream(): AsyncGenerator<GenerateContentResponse> {
+        yield createMockTextResponse('partial');
+        throw new Error('connection reset');
+      }
+      mockGenerateContentStream.mockImplementation(async () => failingStream());
+
+      // A failure after some deltas have arrived rejects the whole call — the
+      // accumulated 'partial' text is never surfaced as a success — and, since
+      // the signal isn't aborted, the error is reported like the non-streaming
+      // path. This is the gateway-timeout-mid-inference scenario the PR targets.
+      await expect(
+        client.generateText({
+          contents: [{ role: 'user', parts: [{ text: 'hi' }] }],
+          model: 'test-model',
+          abortSignal: abortController.signal,
+          promptId: 'p',
+          stream: true,
+        }),
+      ).rejects.toThrow('connection reset');
+      expect(vi.mocked(reportError)).toHaveBeenCalled();
+    });
+
+    it('surfaces an abort that fires mid-stream and skips error reporting', async () => {
+      async function* abortingStream(): AsyncGenerator<GenerateContentResponse> {
+        yield createMockTextResponse('chunk');
+        abortController.abort();
+        throw new DOMException('The operation was aborted.', 'AbortError');
+      }
+      mockGenerateContentStream.mockImplementation(async () =>
+        abortingStream(),
+      );
+
+      // The `abortSignal.aborted` guard in the catch block rethrows the original
+      // error unwrapped and skips reportError, so a user-initiated cancellation
+      // mid-stream surfaces verbatim and is not logged as an API failure.
+      await expect(
+        client.generateText({
+          contents: [{ role: 'user', parts: [{ text: 'hi' }] }],
+          model: 'test-model',
+          abortSignal: abortController.signal,
+          promptId: 'p',
+          stream: true,
+        }),
+      ).rejects.toThrow('The operation was aborted.');
+      expect(vi.mocked(reportError)).not.toHaveBeenCalled();
+    });
   });
 
   describe('per-model resolution', () => {

--- a/packages/core/src/core/baseLlmClient.test.ts
+++ b/packages/core/src/core/baseLlmClient.test.ts
@@ -677,7 +677,14 @@ describe('BaseLlmClient', () => {
           stream: true,
         }),
       ).rejects.toThrow('connection reset');
-      expect(vi.mocked(reportError)).toHaveBeenCalled();
+      // The streaming failure is reported with the `[streaming]` marker so an
+      // oncall can tell it apart from the original non-streaming 504 (#5861).
+      expect(vi.mocked(reportError)).toHaveBeenCalledWith(
+        expect.any(Error),
+        'Error generating text content via API [streaming].',
+        expect.anything(),
+        'generateText-api',
+      );
     });
 
     it('surfaces an abort that fires mid-stream and skips error reporting', async () => {

--- a/packages/core/src/core/baseLlmClient.test.ts
+++ b/packages/core/src/core/baseLlmClient.test.ts
@@ -692,6 +692,26 @@ describe('BaseLlmClient', () => {
       ).rejects.toThrow('The operation was aborted.');
       expect(vi.mocked(reportError)).not.toHaveBeenCalled();
     });
+
+    it('returns an empty result for a stream that yields no chunks', async () => {
+      // A stream that closes immediately (no content, no usage) must resolve to
+      // an empty string rather than throw — the boundary the streaming branch
+      // introduces. mockTextStream([]) yields nothing.
+      mockGenerateContentStream.mockImplementation(async () =>
+        mockTextStream([]),
+      );
+
+      const result = await client.generateText({
+        contents: [{ role: 'user', parts: [{ text: 'hi' }] }],
+        model: 'test-model',
+        abortSignal: abortController.signal,
+        promptId: 'p',
+        stream: true,
+      });
+
+      expect(result.text).toBe('');
+      expect(result.usage).toBeUndefined();
+    });
   });
 
   describe('per-model resolution', () => {

--- a/packages/core/src/core/baseLlmClient.test.ts
+++ b/packages/core/src/core/baseLlmClient.test.ts
@@ -591,6 +591,18 @@ describe('BaseLlmClient', () => {
       });
 
       expect(mockGenerateContentStream).toHaveBeenCalledTimes(1);
+      // The streaming branch builds the same request object as the non-stream
+      // path: resolved model, contents, and a config carrying the abortSignal.
+      expect(mockGenerateContentStream).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'test-model',
+          contents: [{ role: 'user', parts: [{ text: 'hi' }] }],
+          config: expect.objectContaining({
+            abortSignal: abortController.signal,
+          }),
+        }),
+        'p',
+      );
       expect(mockGenerateContent).not.toHaveBeenCalled();
       // Deltas are concatenated, then trimmed once at the end.
       expect(result.text).toBe('Hello, world');
@@ -888,6 +900,17 @@ describe('BaseLlmClient', () => {
       });
 
       expect(fastGenerateContentStream).toHaveBeenCalledTimes(1);
+      // Streamed against the resolved per-model identity, not the main model.
+      expect(fastGenerateContentStream).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: fastModel,
+          contents: [{ role: 'user', parts: [{ text: 'hi' }] }],
+          config: expect.objectContaining({
+            abortSignal: abortController.signal,
+          }),
+        }),
+        'p',
+      );
       // The constructor-injected default generator must not be touched.
       expect(mockGenerateContentStream).not.toHaveBeenCalled();
       expect(result.text).toBe('fast stream');

--- a/packages/core/src/core/baseLlmClient.test.ts
+++ b/packages/core/src/core/baseLlmClient.test.ts
@@ -60,10 +60,12 @@ vi.mock('../models/content-generator-config.js', () => ({
 }));
 
 const mockGenerateContent = vi.fn();
+const mockGenerateContentStream = vi.fn();
 const mockEmbedContent = vi.fn();
 
 const mockContentGenerator = {
   generateContent: mockGenerateContent,
+  generateContentStream: mockGenerateContentStream,
   embedContent: mockEmbedContent,
 } as unknown as Mocked<ContentGenerator>;
 
@@ -129,6 +131,21 @@ const createMockTextResponse = (text: string): GenerateContentResponse =>
       },
     ],
   }) as GenerateContentResponse;
+
+// Builds an async generator that yields one response per text delta, then an
+// optional trailing usage-only chunk — mirroring how the streaming pipeline
+// emits content deltas followed by a final chunk carrying usageMetadata.
+async function* mockTextStream(
+  chunks: string[],
+  usage?: GenerateContentResponse['usageMetadata'],
+): AsyncGenerator<GenerateContentResponse> {
+  for (const text of chunks) {
+    yield createMockTextResponse(text);
+  }
+  if (usage) {
+    yield { usageMetadata: usage } as GenerateContentResponse;
+  }
+}
 
 describe('BaseLlmClient', () => {
   let client: BaseLlmClient;
@@ -551,6 +568,81 @@ describe('BaseLlmClient', () => {
       await expect(client.generateEmbedding(texts)).rejects.toThrow(
         'API Failure',
       );
+    });
+  });
+
+  describe('generateText - streaming', () => {
+    it('routes through generateContentStream, concatenates deltas, trims once, and captures final-chunk usage', async () => {
+      const usage = {
+        promptTokenCount: 11,
+        candidatesTokenCount: 7,
+        totalTokenCount: 18,
+      };
+      mockGenerateContentStream.mockImplementation(async () =>
+        mockTextStream(['  Hello', ', ', 'world  '], usage),
+      );
+
+      const result = await client.generateText({
+        contents: [{ role: 'user', parts: [{ text: 'hi' }] }],
+        model: 'test-model',
+        abortSignal: abortController.signal,
+        promptId: 'p',
+        stream: true,
+      });
+
+      expect(mockGenerateContentStream).toHaveBeenCalledTimes(1);
+      expect(mockGenerateContent).not.toHaveBeenCalled();
+      // Deltas are concatenated, then trimmed once at the end.
+      expect(result.text).toBe('Hello, world');
+      expect(result.usage).toEqual(usage);
+    });
+
+    it('drops thought parts and tolerates a stream that omits usage', async () => {
+      async function* streamWithThought(): AsyncGenerator<GenerateContentResponse> {
+        yield createMockTextResponse('answer');
+        yield {
+          candidates: [
+            {
+              content: {
+                role: 'model',
+                parts: [{ text: 'reasoning', thought: true }],
+              },
+              index: 0,
+            },
+          ],
+        } as unknown as GenerateContentResponse;
+      }
+      mockGenerateContentStream.mockImplementation(async () =>
+        streamWithThought(),
+      );
+
+      const result = await client.generateText({
+        contents: [{ role: 'user', parts: [{ text: 'hi' }] }],
+        model: 'test-model',
+        abortSignal: abortController.signal,
+        promptId: 'p',
+        stream: true,
+      });
+
+      expect(result.text).toBe('answer');
+      expect(result.usage).toBeUndefined();
+    });
+
+    it('does not stream when stream is omitted (non-streaming path, still trimmed)', async () => {
+      mockGenerateContent.mockResolvedValue(
+        createMockTextResponse('  plain  '),
+      );
+
+      const result = await client.generateText({
+        contents: [{ role: 'user', parts: [{ text: 'hi' }] }],
+        model: 'test-model',
+        abortSignal: abortController.signal,
+        promptId: 'p',
+      });
+
+      expect(mockGenerateContent).toHaveBeenCalledTimes(1);
+      expect(mockGenerateContentStream).not.toHaveBeenCalled();
+      expect(result.text).toBe('plain');
     });
   });
 

--- a/packages/core/src/core/baseLlmClient.test.ts
+++ b/packages/core/src/core/baseLlmClient.test.ts
@@ -712,13 +712,46 @@ describe('BaseLlmClient', () => {
       expect(result.text).toBe('');
       expect(result.usage).toBeUndefined();
     });
+
+    it('captures usage that rides the final content-bearing chunk', async () => {
+      // Realistic Gemini/OpenAI shape: usageMetadata arrives on the last chunk
+      // that *also* carries a text delta. Text and usage are read independently
+      // per chunk, so the trailing text must not be dropped when usage is read.
+      const usage = {
+        promptTokenCount: 5,
+        candidatesTokenCount: 3,
+        totalTokenCount: 8,
+      };
+      async function* usageOnTextChunk(): AsyncGenerator<GenerateContentResponse> {
+        yield createMockTextResponse('Hello, ');
+        const finalChunk = createMockTextResponse('world');
+        finalChunk.usageMetadata = usage;
+        yield finalChunk;
+      }
+      mockGenerateContentStream.mockImplementation(async () =>
+        usageOnTextChunk(),
+      );
+
+      const result = await client.generateText({
+        contents: [{ role: 'user', parts: [{ text: 'hi' }] }],
+        model: 'test-model',
+        abortSignal: abortController.signal,
+        promptId: 'p',
+        stream: true,
+      });
+
+      expect(result.text).toBe('Hello, world');
+      expect(result.usage).toEqual(usage);
+    });
   });
 
   describe('per-model resolution', () => {
     const fastModel = 'fast-model';
     const fastGenerateContent = vi.fn();
+    const fastGenerateContentStream = vi.fn();
     const fastContentGenerator = {
       generateContent: fastGenerateContent,
+      generateContentStream: fastGenerateContentStream,
       embedContent: vi.fn(),
     } as unknown as Mocked<ContentGenerator>;
 
@@ -730,6 +763,7 @@ describe('BaseLlmClient', () => {
         async (fn) => await (fn as () => Promise<unknown>)(),
       );
       fastGenerateContent.mockReset();
+      fastGenerateContentStream.mockReset();
       mockCreateContentGenerator.mockReset();
       mockBuildAgentContentGeneratorConfig.mockReset();
       getResolvedModel.mockReset();
@@ -825,6 +859,39 @@ describe('BaseLlmClient', () => {
         }),
       );
       expect(mockCreateContentGenerator).toHaveBeenCalledTimes(1);
+    });
+
+    it('streams through a per-model generator resolved by model (compression path)', async () => {
+      // chatCompressionService passes both `model` and `stream: true`, so the
+      // streaming branch must run on the resolveForModel-selected generator,
+      // not the constructor-injected default.
+      getResolvedModel.mockReturnValue({
+        authType: AuthType.USE_ANTHROPIC,
+        envKey: 'ANTHROPIC_API_KEY',
+      });
+      const usage = {
+        promptTokenCount: 2,
+        candidatesTokenCount: 2,
+        totalTokenCount: 4,
+      };
+      fastGenerateContentStream.mockImplementation(async () =>
+        mockTextStream(['fast ', 'stream'], usage),
+      );
+
+      const c = new BaseLlmClient(mockContentGenerator, crossProviderConfig);
+      const result = await c.generateText({
+        contents: [{ role: 'user', parts: [{ text: 'hi' }] }],
+        model: fastModel,
+        abortSignal: abortController.signal,
+        promptId: 'p',
+        stream: true,
+      });
+
+      expect(fastGenerateContentStream).toHaveBeenCalledTimes(1);
+      // The constructor-injected default generator must not be touched.
+      expect(mockGenerateContentStream).not.toHaveBeenCalled();
+      expect(result.text).toBe('fast stream');
+      expect(result.usage).toEqual(usage);
     });
 
     it('caches the per-model generator across resolveForModel calls', async () => {

--- a/packages/core/src/core/baseLlmClient.ts
+++ b/packages/core/src/core/baseLlmClient.ts
@@ -86,7 +86,7 @@ export interface GenerateTextOptions {
   maxAttempts?: number;
   /**
    * Stream the response instead of awaiting the whole non-streaming body.
-   * Defaults to falsy (unchanged non-streaming behavior). Opt in to keep the
+   * Defaults to `false` (unchanged non-streaming behavior). Opt in to keep the
    * HTTP connection alive against BFF gateways whose `proxy_read_timeout` would
    * otherwise kill a slow inference before the first byte arrives. The streamed
    * deltas are collected into the same `{ text, usage }` result.

--- a/packages/core/src/core/baseLlmClient.ts
+++ b/packages/core/src/core/baseLlmClient.ts
@@ -84,6 +84,14 @@ export interface GenerateTextOptions {
    * The maximum number of attempts for the request.
    */
   maxAttempts?: number;
+  /**
+   * Stream the response instead of awaiting the whole non-streaming body.
+   * Defaults to falsy (unchanged non-streaming behavior). Opt in to keep the
+   * HTTP connection alive against BFF gateways whose `proxy_read_timeout` would
+   * otherwise kill a slow inference before the first byte arrives. The streamed
+   * deltas are collected into the same `{ text, usage }` result.
+   */
+  stream?: boolean;
 }
 
 /**
@@ -325,6 +333,7 @@ export class BaseLlmClient {
       systemInstruction,
       promptId,
       maxAttempts,
+      stream,
     } = options;
 
     const requestConfig: GenerateContentConfig = {
@@ -341,15 +350,46 @@ export class BaseLlmClient {
     } = await this.resolveForModel(model);
 
     try {
-      const apiCall = () =>
-        contentGenerator.generateContent(
-          {
-            model: requestModel,
-            config: requestConfig,
-            contents,
-          },
-          promptId ?? '',
-        );
+      const request = {
+        model: requestModel,
+        config: requestConfig,
+        contents,
+      };
+
+      // Both branches resolve to the same `{ text, usage }` shape so a single
+      // retryWithBackoff governs the whole request (a mid-stream failure retries
+      // the entire call — side queries are idempotent). Streaming keeps the HTTP
+      // connection alive so a slow inference can't be killed by a gateway's
+      // `proxy_read_timeout`; non-streaming is the unchanged default.
+      const apiCall: () => Promise<GenerateTextResult> = stream
+        ? async () => {
+            const responseStream = await contentGenerator.generateContentStream(
+              request,
+              promptId ?? '',
+            );
+            // Chunks are deltas, not cumulative snapshots, so concatenate.
+            // getResponseText already drops thought parts; usageMetadata rides
+            // the final chunk (last one wins), matching the non-streaming read.
+            let text = '';
+            let usage: GenerateContentResponseUsageMetadata | undefined;
+            for await (const chunk of responseStream) {
+              text += getResponseText(chunk) ?? '';
+              if (chunk.usageMetadata) {
+                usage = chunk.usageMetadata;
+              }
+            }
+            return { text, usage };
+          }
+        : async () => {
+            const result = await contentGenerator.generateContent(
+              request,
+              promptId ?? '',
+            );
+            return {
+              text: getResponseText(result) ?? '',
+              usage: result.usageMetadata,
+            };
+          };
 
       const result = await retryWithBackoff(apiCall, {
         maxAttempts: maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
@@ -379,8 +419,8 @@ export class BaseLlmClient {
       });
 
       return {
-        text: (getResponseText(result) ?? '').trim(),
-        usage: result.usageMetadata,
+        text: result.text.trim(),
+        usage: result.usage,
       };
     } catch (error) {
       if (abortSignal.aborted) {

--- a/packages/core/src/core/baseLlmClient.ts
+++ b/packages/core/src/core/baseLlmClient.ts
@@ -429,7 +429,9 @@ export class BaseLlmClient {
 
       await reportError(
         error,
-        'Error generating text content via API.',
+        // Mark streaming failures so an oncall can tell a mid-stream error
+        // apart from the original non-streaming gateway timeout (#5861).
+        `Error generating text content via API${stream ? ' [streaming]' : ''}.`,
         contents,
         'generateText-api',
       );

--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -282,6 +282,12 @@ describe('ChatCompressionService', () => {
 
       expect(result.info.compressionStatus).toBe(CompressionStatus.COMPRESSED);
       expect(generateText).toHaveBeenCalled();
+      // Compression opts into streaming so a slow inference keeps the HTTP
+      // connection alive behind a BFF gateway whose proxy_read_timeout would
+      // otherwise kill the non-streaming request (issue #5861).
+      expect(generateText).toHaveBeenCalledWith(
+        expect.objectContaining({ stream: true }),
+      );
       // Screenshot trigger → reason must be image_overflow (not token_limit)
       // so the UI notice is accurate when it fired below the token threshold.
       expect(result.info.triggerReason).toBe('image_overflow');

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -479,6 +479,12 @@ export class ChatCompressionService {
       purpose: 'chat-compression',
       skipOutputLanguagePreference: true,
       model,
+      // Stream so a slow compression inference keeps the HTTP connection alive.
+      // Non-streaming returns no bytes until the whole summary is generated, so
+      // behind a BFF gateway with a short `proxy_read_timeout` a long inference
+      // is killed with a 504 (surfaced as a 422) mid-compression, breaking the
+      // session. See https://github.com/QwenLM/qwen-code/issues/5861.
+      stream: true,
       // Best-effort: failures fall back to NOOP and the next turn re-triggers
       // compression anyway, so don't burn 7 retries blocking the user mid-turn.
       maxAttempts: 1,

--- a/packages/core/src/utils/sideQuery.test.ts
+++ b/packages/core/src/utils/sideQuery.test.ts
@@ -345,6 +345,35 @@ describe('runSideQuery', () => {
       );
     });
 
+    it('forwards stream:true to generateText when opted in', async () => {
+      mockTextResult('streamed');
+
+      await runSideQuery(mockConfig, {
+        purpose: 'chat-compression',
+        contents: [{ role: 'user', parts: [{ text: 'summarize' }] }],
+        abortSignal: abortController.signal,
+        stream: true,
+      });
+
+      expect(mockBaseLlmClient.generateText).toHaveBeenCalledWith(
+        expect.objectContaining({ stream: true }),
+      );
+    });
+
+    it('omits stream from the generateText call when not set (backward-compat)', async () => {
+      mockTextResult('ok');
+
+      await runSideQuery(mockConfig, {
+        purpose: 'p',
+        contents: [{ role: 'user', parts: [{ text: 'q' }] }],
+        abortSignal: abortController.signal,
+      });
+
+      const callArg = vi.mocked(mockBaseLlmClient.generateText).mock
+        .calls[0][0];
+      expect(callArg).not.toHaveProperty('stream');
+    });
+
     it('prefers fastModel when available', async () => {
       vi.mocked(mockConfig.getFastModel).mockReturnValue('fast-model');
       mockTextResult('ok');

--- a/packages/core/src/utils/sideQuery.ts
+++ b/packages/core/src/utils/sideQuery.ts
@@ -100,12 +100,10 @@ export interface SideQueryTextOptions {
    */
   skipOutputLanguagePreference?: boolean;
   /**
-   * Stream the response instead of awaiting the whole non-streaming body.
-   * Defaults to false. Opt in to keep the HTTP connection alive against
-   * gateways whose `proxy_read_timeout` would kill a slow inference before the
-   * first byte arrives (e.g. chat compression behind a BFF). The streamed
-   * deltas are collected into the same `{ text, usage }` result, so only
-   * callers at real timeout risk need to set this.
+   * Opt in to stream the response so a slow inference keeps its HTTP connection
+   * alive against gateways that would time out the non-streaming request (e.g.
+   * chat compression behind a BFF); see {@link GenerateTextOptions.stream} for
+   * the full rationale. Defaults to `false`.
    */
   stream?: boolean;
   validate?: (text: string) => string | null;

--- a/packages/core/src/utils/sideQuery.ts
+++ b/packages/core/src/utils/sideQuery.ts
@@ -99,6 +99,15 @@ export interface SideQueryTextOptions {
    * new user-visible side queries honor the preference automatically.
    */
   skipOutputLanguagePreference?: boolean;
+  /**
+   * Stream the response instead of awaiting the whole non-streaming body.
+   * Defaults to false. Opt in to keep the HTTP connection alive against
+   * gateways whose `proxy_read_timeout` would kill a slow inference before the
+   * first byte arrives (e.g. chat compression behind a BFF). The streamed
+   * deltas are collected into the same `{ text, usage }` result, so only
+   * callers at real timeout risk need to set this.
+   */
+  stream?: boolean;
   validate?: (text: string) => string | null;
 }
 
@@ -248,6 +257,7 @@ export async function runSideQuery<TResponse>(
     ...(options.maxAttempts !== undefined && {
       maxAttempts: options.maxAttempts,
     }),
+    ...(options.stream !== undefined && { stream: options.stream }),
   });
 
   const customError = options.validate?.(result.text);


### PR DESCRIPTION
## What this PR does

Adds an opt-in streaming path to the text side-query so the context-compression summary request can keep its HTTP connection alive while the model is still thinking. A new `stream?: boolean` option flows from `ChatCompressionService.compress` through `runSideQuery` down to `BaseLlmClient.generateText`; when set, the call routes through the already-existing `generateContentStream` and the streamed deltas are collected back into the same `{ text, usage }` result the non-streaming path returns. Only the compression caller opts in — every other side-query keeps the unchanged non-streaming behaviour.

## Why it's needed

When the context window approaches capacity, compression fires a summarization side-query that today runs non-streaming, so the entire LLM inference must finish before the first HTTP byte arrives. Behind a BFF gateway (e.g. DataWorks ACP / DQ_AGENT) whose `proxy_read_timeout` is ~60s, a long compression inference — a real production trace measured ~1.9 minutes — is killed by the gateway at 60s with a `504 Gateway Timeout`, surfaced to qwen-code as `UnprocessableEntityError: 422`. Compression then fails, the turn errors out, and the session breaks even though the model itself would have succeeded. Streaming fixes this because the server returns HTTP 200 and an initial delta within seconds, which resets the gateway's read timeout on every chunk, so a slow inference can no longer trip the 60s ceiling.

## Reviewer Test Plan

### How to verify

Unit: `cd packages/core && npx vitest run src/core/baseLlmClient.test.ts src/utils/sideQuery.test.ts src/services/chatCompressionService.test.ts` — expect all green. New coverage asserts that `stream: true` routes through `generateContentStream`, concatenates multi-chunk deltas, trims, drops thought parts, and captures usage from the final chunk; that omitting `stream` still uses the non-streaming `generateContent`; that `runSideQuery` forwards the flag only when set; and that compression calls `generateText` with `stream: true`.

End-to-end (optional, needs a gateway): drive a long session against an OpenAI-compatible endpoint behind a ≤60s `proxy_read_timeout` proxy, force compression, and confirm the compression request now streams and completes where the non-streaming path previously failed with a 504/422.

### Evidence (Before & After)

Non-user-visible change (core inference plumbing), so no UI before/after. Local unit run: `Test Files 3 passed (3) · Tests 132 passed (132)`. Repo gates pass: `npm run typecheck` (all workspaces) and `npm run lint` both exit 0; the pre-commit hook (`prettier` + `eslint --max-warnings 0`) passed on the six changed files.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only (`vitest`), plus `npm run typecheck` / `npm run lint`. No runtime/sandbox needed.

## Risk & Scope

- Main risk or tradeoff: The motivating deployment (DataWorks ACP / DQ_AGENT is OpenAI-compatible, served by `OpenAIContentGenerator` / `QwenContentGenerator`) routes through the OpenAI pipeline, which already wraps the stream in a per-chunk inactivity watchdog (`withStreamInactivityTimeout`, tunable via `QWEN_STREAM_IDLE_TIMEOUT_MS` / `streamIdleTimeoutMs`, `0` disables) — so a stream that returns 200 then goes silent is bounded there, not the old all-or-nothing non-streaming wait. Native `USE_GEMINI` / `USE_ANTHROPIC` streams have no per-chunk idle timeout at the provider layer, but that is the exact contract the main chat loop already consumes for every turn (`geminiChat.ts` iterates the same raw `generateContentStream`), bounded by the SDK transport timeout plus `abortSignal`; this side-query reuses that existing invariant rather than introducing a new exposure. The whole stream is consumed inside `retryWithBackoff`, so a mid-stream failure retries the entire idempotent request, matching the non-streaming retry semantics. A provider-agnostic idle timeout for Gemini/Anthropic would belong at the `ContentGenerator` layer (so the main loop benefits too) and is out of scope here.
- Not validated / out of scope: The optional secondary improvements from the issue are intentionally not bundled here, to keep the change focused on the 504 root cause. "Disable thinking for compression" is already satisfied in current code — the compression call passes `thinkingConfig: { includeThoughts: false }` and `applyThinkingDefault` defaults every side-query to it (the issue's `thoughts_token_count=1` was from an older preview build). "Use the fast model for compression" is a summarization-quality / model-selection change unrelated to the timeout and is left as a possible follow-up (see the related #3760 for the broader fastModel-reasoning topic). The end-to-end gateway repro above was not run locally.
- Breaking changes / migration notes: None. `stream?: boolean` is an additive optional field defaulting to falsy; all existing text-mode `runSideQuery` callers omit it and keep the non-streaming path, and JSON-mode side-queries are untouched.

## Linked Issues

Closes #5861

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

为文本 side-query 增加一个可选的流式路径，使上下文压缩的摘要请求在模型仍在推理时也能保持 HTTP 连接存活。新增的 `stream?: boolean` 选项从 `ChatCompressionService.compress` 经 `runSideQuery` 一直传到 `BaseLlmClient.generateText`；开启后请求改走已存在的 `generateContentStream`，流式增量再被收集回与非流式路径相同的 `{ text, usage }` 结果。只有压缩这一个调用方 opt-in，其余 side-query 保持原有的非流式行为不变。

## 为什么需要

上下文窗口接近上限时，压缩会发起一个摘要 side-query，而它当前是非流式的，因此整个 LLM 推理必须全部完成后第一个 HTTP 字节才会返回。在 BFF 网关（如 DataWorks ACP / DQ_AGENT，`proxy_read_timeout` 约 60s）后面，较长的压缩推理（生产 trace 实测约 1.9 分钟）会在 60s 被网关以 `504 Gateway Timeout` 杀掉，到 qwen-code 侧表现为 `UnprocessableEntityError: 422`。于是压缩失败、本轮 turn 报错、会话中断——尽管模型本身其实会成功。流式能解决：服务端会在数秒内返回 HTTP 200 和首个增量 chunk，每个 chunk 都会重置网关的读超时，慢推理因此不再触发 60s 上限。

## Reviewer Test Plan

### 如何验证

单测：`cd packages/core && npx vitest run src/core/baseLlmClient.test.ts src/utils/sideQuery.test.ts src/services/chatCompressionService.test.ts`，预期全绿。新增用例断言：`stream: true` 走 `generateContentStream`、拼接多 chunk 增量、trim、过滤 thought part、并从最后一个 chunk 取 usage；省略 `stream` 时仍走非流式 `generateContent`；`runSideQuery` 仅在设置时转发该 flag；压缩以 `stream: true` 调用 `generateText`。

端到端（可选，需要网关）：用 OpenAI 兼容端点 + 一个 `proxy_read_timeout` ≤60s 的代理跑一个长会话，强制触发压缩，确认压缩请求现在以流式完成，而此前非流式路径会以 504/422 失败。

### 证据（Before & After）

非用户可见改动（核心推理链路），无 UI before/after。本地单测：`Test Files 3 passed (3) · Tests 132 passed (132)`。仓库门禁通过：`npm run typecheck`（全 workspace）与 `npm run lint` 均 exit 0；pre-commit（`prettier` + `eslint --max-warnings 0`）在 6 个改动文件上通过。

### 测试平台

仅 macOS 本地验证；Windows / Linux 未本地测试，交由 CI 覆盖。

### 运行环境（可选）

仅单测（`vitest`）+ `npm run typecheck` / `npm run lint`，无需运行时/沙箱。

## 风险与范围

- 主要风险 / 取舍：本 PR 的目标部署（DataWorks ACP / DQ_AGENT 是 OpenAI 兼容协议，由 `OpenAIContentGenerator` / `QwenContentGenerator` 承接）走的是 OpenAI pipeline，该 pipeline 已把流包进按 chunk 计的空闲看门狗（`withStreamInactivityTimeout`，可经 `QWEN_STREAM_IDLE_TIMEOUT_MS` / `streamIdleTimeoutMs` 调节，`0` 关闭）——所以「返回 200 后转入静默」的流在那里是有界的，而非旧的「全有或全无」非流式等待。原生 `USE_GEMINI` / `USE_ANTHROPIC` 流在 provider 层没有按 chunk 的空闲超时，但这正是主对话循环每一轮已经在消费的同一契约（`geminiChat.ts` 迭代的是同一个原始 `generateContentStream`），由 SDK 传输超时 + `abortSignal` 兜底；本 side-query 复用了这个既有不变量，并未引入新的暴露面。整段流在 `retryWithBackoff` 内消费，中途失败会重试整个幂等请求，与非流式的重试语义一致。若要为 Gemini/Anthropic 加一个 provider 无关的空闲超时，应放在 `ContentGenerator` 层（这样主循环也受益），不在本 PR 范围内。
- 未验证 / 范围外：issue 中可选的次要改进刻意不在本 PR 捆绑，以聚焦 504 根因。「为压缩禁用 thinking」当前代码其实已满足——压缩调用已传 `thinkingConfig: { includeThoughts: false }`，且 `applyThinkingDefault` 把每个 side-query 默认设为该值（issue 里的 `thoughts_token_count=1` 来自较旧的 preview 构建）。「为压缩使用 fast model」是与超时无关的摘要质量 / 选模行为变更，留作可能的 follow-up（fastModel-reasoning 的更大话题见关联的 #3760）。上面的端到端网关复现未在本地执行。
- 破坏性变更 / 迁移说明：无。`stream?: boolean` 是默认 falsy 的新增可选字段；所有现有文本模式 `runSideQuery` 调用方都不传它、保持非流式路径，JSON 模式 side-query 不受影响。

## 关联 Issue

Closes #5861

</details>

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)
