### PR TITLE
fix(cli): make alt+t expand thinking on macOS Option-compose terminals

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -122,6 +122,96 @@ describe('KeypressContext - Kitty Protocol', () => {
       );
     });
 
+    it('rewrites macOS composed Option+t glyph "†" to Alt+t', () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', {
+        value: 'darwin',
+        configurable: true,
+        writable: true,
+      });
+      try {
+        const keyHandler = vi.fn();
+
+        const { result } = renderHook(() => useKeypressContext(), {
+          wrapper,
+        });
+
+        act(() => {
+          result.current.subscribe(keyHandler);
+        });
+
+        act(() => {
+          stdin.pressKey({
+            name: '',
+            ctrl: false,
+            meta: false,
+            shift: false,
+            paste: false,
+            sequence: '†',
+          });
+        });
+
+        expect(keyHandler).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 't',
+            meta: true,
+            sequence: '†',
+          }),
+        );
+      } finally {
+        Object.defineProperty(process, 'platform', {
+          value: originalPlatform,
+          configurable: true,
+          writable: true,
+        });
+      }
+    });
+
+    it('leaves "†" untouched on non-macOS platforms', () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', {
+        value: 'linux',
+        configurable: true,
+        writable: true,
+      });
+      try {
+        const keyHandler = vi.fn();
+
+        const { result } = renderHook(() => useKeypressContext(), {
+          wrapper,
+        });
+
+        act(() => {
+          result.current.subscribe(keyHandler);
+        });
+
+        act(() => {
+          stdin.pressKey({
+            name: '',
+            ctrl: false,
+            meta: false,
+            shift: false,
+            paste: false,
+            sequence: '†',
+          });
+        });
+
+        expect(keyHandler).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: '',
+            meta: false,
+            sequence: '†',
+          }),
+        );
+      } finally {
+        Object.defineProperty(process, 'platform', {
+          value: originalPlatform,
+          configurable: true,
+          writable: true,
+        });
+      }
+    });
+
     it('should recognize regular enter key (keycode 13) in kitty protocol', async () => {
       const keyHandler = vi.fn();
 

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -46,6 +46,15 @@ import { clipboardHasImage } from '../utils/clipboardUtils.js';
 import { FOCUS_IN, FOCUS_OUT } from '../hooks/useFocus.js';
 
 const ESC = '\u001B';
+// On macOS, when the terminal's Option key is in its default "compose
+// character" mode (iTerm2 "Normal", VS Code without macOptionIsMeta), Option+t
+// is delivered to the app as the dagger glyph "†" (U+2020) with no modifier
+// metadata — so there is no way to tell Option was held. Terminals that speak
+// the Kitty keyboard protocol (e.g. Ghostty) instead report a real Alt+t event,
+// which is why the shortcut already works there. We treat a lone "†" as Alt+t so
+// the "expand thinking" shortcut works everywhere without requiring users to
+// reconfigure their terminal. See handleKeypress for where this is applied.
+const OPTION_T_COMPOSED_GLYPH = '†';
 export const PASTE_MODE_PREFIX = `${ESC}[200~`;
 export const PASTE_MODE_SUFFIX = `${ESC}[201~`;
 export const DRAG_COMPLETION_TIMEOUT_MS = 100; // Broadcast full path after 100ms if no more input
@@ -1048,6 +1057,22 @@ export function KeypressProvider({
       if (key.name === 'return' && key.sequence === `${ESC}\r`) {
         key.meta = true;
       }
+
+      // macOS "Option as compose character" terminals turn Option+t into the
+      // bare glyph "†" (U+2020) with no modifier metadata. Rewrite it to a
+      // synthetic Alt+t so the "expand thinking" shortcut fires; the meta flag
+      // also stops the glyph from being inserted into the input buffer (the
+      // text buffer skips printable input when meta/ctrl is set), so it looks
+      // exactly like Alt was pressed.
+      if (
+        process.platform === 'darwin' &&
+        !isPaste &&
+        key.sequence === OPTION_T_COMPOSED_GLYPH
+      ) {
+        key.name = 't';
+        key.meta = true;
+      }
+
       broadcast({ ...key, paste: isPaste });
     };
 


### PR DESCRIPTION
## What this PR does

Fixes the "expand thinking" shortcut (`Alt+t`) on macOS terminals that use the default "Option as compose character" mode — specifically iTerm2 (Normal mode) and VS Code's integrated terminal (without `macOptionIsMeta`). These terminals deliver `Option+t` as the dagger glyph `†` (U+2020) with no modifier metadata, so the app can't tell Option was held — the shortcut silently typed `†` into the prompt instead of toggling the thinking summary. The fix rewrites a lone `†` to a synthetic `Alt+t` in the keypress pipeline, scoped to `darwin` only. Terminals that speak the Kitty keyboard protocol (e.g. Ghostty) already report a real `Alt+t` event and are unaffected.

## Why it's needed

The thinking summary UI shows `(alt+t to expand)` but the shortcut only worked in Ghostty and terminals configured with "Option as Meta". Most macOS users on iTerm2 or VS Code — the two most popular terminals — would press `Alt+t` and get a `†` inserted into their prompt instead. This makes the shortcut work everywhere without requiring users to reconfigure their terminal's Option key behavior.

## Reviewer Test Plan

### How to verify

1. Open iTerm2 with default settings (Option key = Normal) or VS Code integrated terminal.
2. Run `qwen` and trigger a response that shows the thinking summary (`∴ Thought for Xs (alt+t to expand)`).
3. Press `Option+t` — the thinking block should expand/collapse. Previously it typed `†` into the prompt.
4. Confirm the same shortcut still works in Ghostty (no regression on Kitty protocol path).

### Evidence (Before & After)

**Before:** `Option+t` in iTerm2/VS Code inserts `†` into the prompt; thinking summary does not expand.
**After:** `Option+t` in iTerm2/VS Code toggles the thinking summary, matching Ghostty behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

iTerm2 (default Option=Normal), VS Code integrated terminal, Ghostty — all on macOS.

## Risk & Scope

- Main risk or tradeoff: A legitimate `†` character typed via other means on macOS would also be rewritten to `Alt+t`. This is extremely unlikely in practice since `†` is rarely typed in a terminal coding context.
- Not validated / out of scope: Non-macOS platforms (the fix is scoped to `darwin`).
- Breaking changes / migration notes: None.

## Linked Issues

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修复了 macOS 终端在默认"Option 作为组合字符"模式下（iTerm2 的 Normal 模式和 VS Code 集成终端未开启 `macOptionIsMeta` 时），`Alt+t` 展开思考摘要快捷键无效的问题。这些终端将 `Option+t` 转换为匕首符号 `†`（U+2020），且不携带修饰键信息，导致应用无法识别 Option 键被按下——快捷键会静默地将 `†` 输入到提示符中，而非展开思考摘要。修复方案是在按键管道中将单独的 `†` 重写为合成的 `Alt+t`，仅在 `darwin` 平台生效。使用 Kitty 键盘协议的终端（如 Ghostty）已经上报真实的 `Alt+t` 事件，不受影响。

## 为什么需要这个改动

思考摘要 UI 显示了 `(alt+t to expand)` 提示，但该快捷键只在 Ghostty 和配置了"Option as Meta"的终端中有效。大多数 macOS 用户使用 iTerm2 或 VS Code——这两个最流行的终端——按下 `Alt+t` 后只会在提示符中插入 `†`。此修复让快捷键在所有终端中都能正常工作，无需用户修改终端的 Option 键配置。

## 审阅者测试计划

1. 打开 iTerm2（默认设置，Option 键 = Normal）或 VS Code 集成终端。
2. 运行 `qwen`，触发一个包含思考摘要的响应（`∴ Thought for Xs (alt+t to expand)`）。
3. 按 `Option+t`——思考块应展开/折叠。此前会输入 `†` 到提示符中。
4. 确认 Ghostty 中快捷键仍然正常（Kitty 协议路径无回归）。

### 测试环境

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS    |  ✅  |
| 🪟 Windows   | N/A  |
|  🐧 Linux    | N/A  |

## 风险与范围

- 主要风险：在 macOS 上通过其他方式输入的合法 `†` 字符也会被重写为 `Alt+t`。实际风险极低，因为终端编码场景中几乎不会输入 `†`。
- 未验证/不在范围内：非 macOS 平台（修复仅限于 `darwin`）。
- 破坏性变更/迁移说明：无。

</details>
