### PR TITLE
fix(web-shell): reword the Chinese tool-group summary (执行了 → 调用了)

### DIFF
--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -2219,7 +2219,7 @@ const ZH: Messages = {
   'tool.showFullLines': '▼ 显示完整行',
   'tool.linesTotal': (v) => `▼ 共 ${v?.count ?? 0} 行`,
   'toolGroup.moreKinds': (v) => ` +${v?.count ?? 0}`,
-  'toolGroup.summary': (v) => `执行了 ${v?.count ?? 0} 个工具`,
+  'toolGroup.summary': (v) => `调用了 ${v?.count ?? 0} 个工具`,
   'toolGroup.running': (v) =>
     `正在执行 ${v?.name ?? '工具'}${v?.duration ? ` ${v.duration}` : ''}${
       Number(v?.count ?? 0) > 1 ? ` · 共 ${v?.count ?? 0} 个工具` : ''


### PR DESCRIPTION
## What this PR does

Rewords the collapsed tool-group summary in the Web Shell's **Chinese** locale from `执行了 N 个工具` to `调用了 N 个工具`. The English locale (`Ran N tools`) is unchanged.

## Why it's needed

In Chinese a tool is **调用** (invoked/called), not **执行** (executed) — `执行` collocates more naturally with 操作/命令/任务, while a tool/function is something you 调用. The codebase already uses **工具调用** as the established term for "tool call" (e.g. the CLI locale's `{{count}} 个工具调用`). The previous `执行了 N 个工具` read like a literal machine translation; `调用了 N 个工具` is more idiomatic.

## Reviewer Test Plan

### How to verify

This is a single i18n display string (`toolGroup.summary` in the `ZH` message table). In the Web Shell with the Chinese locale, run a turn that triggers tool calls; once the tool group collapses, the summary now reads `调用了 N 个工具` (e.g. `调用了 3 个工具`). The English locale still shows `Ran N tools`.

- `npm test` in `packages/web-shell` → 471 passing.
- `npm run build` in `packages/web-shell` → succeeds; the built bundle contains `调用了 ${...} 个工具`.

### Evidence (Before & After)

|        | Chinese summary  |
| ------ | ---------------- |
| Before | `执行了 3 个工具` |
| After  | `调用了 3 个工具` |

English is unchanged (`Ran 3 tools`). This is a one-string wording swap with no layout or logic change, so there is no visual diff beyond the text itself.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

A locale string is platform-independent; verified on macOS via web-shell unit tests + production build.

### Environment (optional)

N/A — verified via `packages/web-shell` unit tests and `npm run build`.

## Risk & Scope

- Main risk or tradeoff: None functional — a single Chinese display string. Note the running-state summary still reads `正在执行 …`, so there is a minor 执行/调用 wording split between the in-progress and completed states; this PR intentionally scopes to the completed summary only.
- Not validated / out of scope: English wording (intentionally unchanged); the `正在执行` running-state string.
- Breaking changes / migration notes: None.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 Web Shell **中文**语言包里折叠后的工具组摘要从 `执行了 N 个工具` 改为 `调用了 N 个工具`。英文(`Ran N tools`)保持不变。

## 为什么需要

中文里工具是被**调用**的,不是被**执行**的——`执行` 更常搭配 操作/命令/任务,而工具/函数是「调用」。代码库里 "tool call" 的既有译法本就是**工具调用**(例如 CLI 语言包的 `{{count}} 个工具调用`)。原来的 `执行了 N 个工具` 读着像直译,`调用了 N 个工具` 更地道。

## 验证方式

这是单条 i18n 文案(`ZH` 文案表里的 `toolGroup.summary`)。在中文语言包下,跑一轮会触发工具调用的对话,工具组折叠后摘要显示 `调用了 N 个工具`(如 `调用了 3 个工具`);英文仍显示 `Ran N tools`。

- `packages/web-shell` 下 `npm test` → 471 通过。
- `packages/web-shell` 下 `npm run build` → 成功,产物包含 `调用了 ${...} 个工具`。

### 改动前后

|      | 中文摘要         |
| ---- | ---------------- |
| 改前 | `执行了 3 个工具` |
| 改后 | `调用了 3 个工具` |

英文不变(`Ran 3 tools`)。仅文案替换,无布局或逻辑改动。

## 风险与范围

- 主要风险/取舍:无功能影响——单条中文文案。注意进行中态摘要仍是 `正在执行 …`,因此进行中与完成态之间存在轻微的 执行/调用 用词不一致;本 PR 有意只改完成态摘要。
- 未验证/范围外:英文文案(有意不动);`正在执行` 进行中态文案。
- 破坏性变更/迁移说明:无。

</details>
