### PR TITLE
fix(release): skip dist/node_modules when building standalone archives

### DIFF
--- a/scripts/create-standalone-package.js
+++ b/scripts/create-standalone-package.js
@@ -264,7 +264,15 @@ function copyRuntimeAssets(packageRoot, outDir) {
   fs.mkdirSync(libDir, { recursive: true });
 
   for (const entry of fs.readdirSync(distDir)) {
-    if (entry === skippedDistEntry || entry === '.DS_Store') {
+    // prepare-package.js stages the audio-capture addon into dist/node_modules
+    // for the npm package, but standalone rebuilds a clean, target-trimmed
+    // lib/node_modules via copyNativeAddon(). Copying dist/node_modules here
+    // would drag in every platform's prebuild and collide with that — skip it.
+    if (
+      entry === skippedDistEntry ||
+      entry === '.DS_Store' ||
+      entry === 'node_modules'
+    ) {
       continue;
     }
     if (!isAllowedDistEntry(entry)) {


### PR DESCRIPTION
## What this PR does

Makes the standalone-archive packaging step ignore a `dist/node_modules` directory if one is present, instead of treating it as an unexpected asset and aborting. The standalone packager already rebuilds a clean, target-trimmed `lib/node_modules` itself (via `copyNativeAddon`), so it simply skips the staged copy the same way it already skips `.DS_Store`.

## Why it's needed

The nightly Release run is failing at the "Build Standalone Archives" step with:

```
Error: Unexpected dist asset: .../dist/node_modules
```

`#5747` (bundle audio capture for mirror installs) made `prepare-package.js` stage the `@qwen-code/audio-capture` native addon into `dist/node_modules` for the npm/mirror package. But `create-standalone-package.js` validates every top-level `dist/` entry against an allowlist and fails on anything it doesn't recognize — so the newly-added `dist/node_modules` aborts the build. Copying it into the standalone archive would also be wrong: it would drag in every platform's prebuild and collide with the clean per-target `lib/node_modules` that `copyNativeAddon` builds. Skipping it is the intended behavior.

## Reviewer Test Plan

### How to verify

- `npm run bundle && npm run prepare:package` so `dist/node_modules/@qwen-code/audio-capture` exists.
- `npm run package:standalone:release -- --version 0.0.0-test --out-dir dist/standalone`.
- Expected before this change: fails with `Unexpected dist asset: .../dist/node_modules`.
- Expected after this change: packaging completes; the standalone archive contains `lib/node_modules/@qwen-code/audio-capture` (the per-target copy from `copyNativeAddon`), not a verbatim copy of `dist/node_modules`.

### Evidence (Before & After)

N/A (release-pipeline packaging script; not user-visible). Failing run: https://github.com/QwenLM/qwen-code/actions/runs/28208998731/job/83568730397

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️ not tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

N/A

## Risk & Scope

- Main risk or tradeoff: none meaningful — narrows the loop to skip a directory the standalone packager already reconstructs itself; the existing allowlist still rejects any other unexpected `dist/` entry.
- Not validated / out of scope: did not run the full release pipeline locally (heavy: per-target Node runtime download + full bundle); change is a one-line guard verified by reading both code paths and `node --check`.
- Breaking changes / migration notes: none.

## Linked Issues

Closes #5877

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 standalone 归档打包步骤在 `dist/node_modules` 目录存在时跳过它，而不是把它当成未知资产并报错中断。standalone 打包脚本本身已经会重建一份干净的、按 target 裁剪的 `lib/node_modules`（通过 `copyNativeAddon`），所以这里直接跳过这个已暂存的目录，处理方式和已有的跳过 `.DS_Store` 一致。

## 为什么需要

nightly Release 在 "Build Standalone Archives" 步骤失败：

```
Error: Unexpected dist asset: .../dist/node_modules
```

`#5747`（为镜像安装打包 audio capture）让 `prepare-package.js` 把 `@qwen-code/audio-capture` 原生插件暂存到 `dist/node_modules`，用于 npm/镜像包。但 `create-standalone-package.js` 会用白名单校验 `dist/` 下每个顶层条目，遇到不认识的就中断——于是新加的 `dist/node_modules` 把构建打断了。把它拷进 standalone 归档也是错的：会把所有平台的 prebuild 都带进来，并和 `copyNativeAddon` 构建的、按 target 裁剪的 `lib/node_modules` 冲突。跳过它才是预期行为。

## 如何验证

- `npm run bundle && npm run prepare:package`，使 `dist/node_modules/@qwen-code/audio-capture` 存在。
- `npm run package:standalone:release -- --version 0.0.0-test --out-dir dist/standalone`。
- 改动前：报错 `Unexpected dist asset: .../dist/node_modules`。
- 改动后：打包成功；standalone 归档里是 `lib/node_modules/@qwen-code/audio-capture`（来自 `copyNativeAddon` 的按 target 拷贝），而非原样拷贝的 `dist/node_modules`。

关联失败构建：https://github.com/QwenLM/qwen-code/actions/runs/28208998731/job/83568730397

</details>
