### PR TITLE
fix(test): raise timeout for cold-import suites to stop CI flake

### DIFF
--- a/packages/core/src/config/config-session-env.test.ts
+++ b/packages/core/src/config/config-session-env.test.ts
@@ -103,6 +103,13 @@ const baseParams: ConfigParameters = {
   overrideExtensions: [],
 };
 
+// Each test re-imports config.js's full transitive module graph cold
+// (afterEach calls vi.resetModules() so the module-level sessionEnvClaimed
+// flag resets). That cold transform+evaluate runs several seconds and, under
+// a contended CI runner, crosses the 5s default — a flaky timeout, not a hang.
+// The reset is load-bearing for what these tests check, so give them headroom.
+vi.setConfig({ testTimeout: 30_000 });
+
 describe('Config sessionEnvClaimed guard', () => {
   let originalEnv: string | undefined;
 

--- a/packages/core/src/skills/skill-activation.test.ts
+++ b/packages/core/src/skills/skill-activation.test.ts
@@ -5,13 +5,19 @@
  */
 
 import * as path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   SkillActivationRegistry,
   resolveProjectRelativePath,
   splitConditionalSkills,
 } from './skill-activation.js';
 import type { SkillConfig } from './types.js';
+
+// The integration tests below `await import('../core/coreToolScheduler.js')`
+// just to reach one pure helper, but that drags in the whole scheduler module
+// graph cold. The first such import runs a few seconds and, under a contended
+// CI runner, crosses the 5s default — a flaky timeout, not a hang.
+vi.setConfig({ testTimeout: 30_000 });
 
 function makeSkill(overrides: Partial<SkillConfig>): SkillConfig {
   return {


### PR DESCRIPTION
## What this PR does

Raises the per-test timeout to 30s for two `packages/core` test suites whose tests cold-import a large module graph, so a slow-but-correct import under CI load stops being reported as a 5s timeout. No test logic changes.

## Why it's needed

The CI / merge-queue Test job intermittently fails with two `Test timed out in 5000ms` errors, and because it runs in the merge queue it kicks unrelated PRs out (e.g. #5878 was dropped twice by exactly these two failures).

Neither test touches the network or an LLM — they mock or avoid it. The cost is the cold transform + evaluate of a big dependency graph measured against the 5s per-test budget:

- `config-session-env.test.ts`: `afterEach` calls `vi.resetModules()` (load-bearing — these tests check a module-level `sessionEnvClaimed` flag), so every test re-imports `config.js`'s full transitive graph cold. A passing sibling already runs ~4.3s, right at the 5s edge.
- `skill-activation.test.ts`: the integration test does `await import('../core/coreToolScheduler.js')` just to reach one pure helper, dragging in the whole scheduler graph cold on first import.

On a contended self-hosted runner these cross 5000ms → flaky timeout, not a hang.

## Reviewer Test Plan

### How to verify

- `npx vitest run packages/core/src/config/config-session-env.test.ts packages/core/src/skills/skill-activation.test.ts` → both green (23 tests).
- The diff only adds `vi.setConfig({ testTimeout: 30_000 })` to each file (plus a `vi` import in the skills file). No assertions or mocks changed.

Before: intermittent `Test timed out in 5000ms` on the two named tests under CI load.
After: the import-heavy suites have headroom; a genuine hang still trips at 30s.

### Evidence (Before & After)

N/A (CI reliability, not user-visible). Example failing run: https://github.com/QwenLM/qwen-code/actions/runs/28213047069/job/83578267928

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ ran the two files locally   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

## Risk & Scope

- Main risk or tradeoff: none meaningful — only widens a timeout for two suites; a real hang still fails at 30s.
- Not validated / out of scope: the underlying reason these modules take seconds to import (the `config.js` / `coreToolScheduler.js` graph size). Shrinking that is a separate refactor, not a flake fix.
- Breaking changes / migration notes: none.

## Linked Issues

None. Referencing the failing run above rather than a closing keyword.

<details>
<summary>中文说明</summary>

把 `packages/core` 两个测试套件的单测超时从默认 5s 提到 30s。这俩测试在 5s 预算内**冷加载了一个巨大的模块图**,在 CI runner 负载高时偶发超时——不是真卡死,也没有任何 LLM/网络调用(都被 mock 或绕开了)。

- `config-session-env.test.ts`:`afterEach` 里的 `vi.resetModules()` 是必需的(测的就是模块级 `sessionEnvClaimed` 标志),导致每个用例都要把 `config.js` 的完整依赖图冷加载一遍;同文件一个通过的兄弟用例已经跑到 ~4.3s,贴着 5s 边缘。
- `skill-activation.test.ts`:集成用例 `await import('../core/coreToolScheduler.js')` 只是为了拿一个纯函数,却把整个 scheduler 模块图冷加载进来。

它会在 merge queue 里把无辜的 PR 踢出去(#5878 就被这两个失败踢了两次)。验证:`npx vitest run` 跑这两个文件即可,23 个用例全绿。改动只是给每个文件加一行 `vi.setConfig({ testTimeout: 30_000 })`,不动任何测试逻辑;真卡死仍会在 30s 失败。

</details>
