### PR TITLE
ci: isolate per-run agent state for triage and PR review

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -326,12 +326,20 @@ jobs:
       pull-requests: 'write'
       issues: 'write'
     steps:
-      # Self-hosted runners reuse the workspace, so an interrupted review can
-      # leave a stale `.qwen/tmp/review-pr-*` worktree or `qwen-review/*` branch
-      # that trips the checkout below. Prune defensively; never fail the job.
-      - name: 'Clean stale review worktrees'
+      # Self-hosted runners reuse $HOME, /tmp and the workspace, so a prior run
+      # can bleed into this one: its agent session/memory (under QWEN_HOME),
+      # leftover draft comments (/tmp/stage-*.md, which survive `git clean`), or
+      # a stale `.qwen/tmp/review-pr-*` worktree / `qwen-review/*` branch from an
+      # interrupted review. Reset all three per run; never fail the job.
+      - name: 'Clean stale agent state'
         run: |-
           set -uo pipefail
+          # Fresh per-run agent home (must match QWEN_HOME on the Qwen step
+          # below) + drop any leftover stage drafts.
+          QWEN_HOME="${RUNNER_TEMP:?}/qwen-home"
+          rm -rf "$QWEN_HOME" 2>/dev/null || true
+          mkdir -p "$QWEN_HOME"
+          rm -f /tmp/stage-*.md 2>/dev/null || true
           # `.git` is a directory in a normal checkout but a gitlink file in a
           # worktree; -e covers both, and a missing .git (first run) too.
           if [ ! -e .git ]; then
@@ -409,6 +417,10 @@ jobs:
           PR_NUMBER: '${{ steps.context.outputs.pr_number }}'
           REVIEW_MODE: '${{ steps.context.outputs.review_mode }}'
           TIMEOUT_MINUTES: '${{ steps.context.outputs.timeout_minutes }}'
+          # Per-run agent home so this review's session/memory cannot leak into
+          # the next on the reused self-hosted workspace (reset in "Clean stale
+          # agent state"). Must match the QWEN_HOME computed there.
+          QWEN_HOME: '${{ runner.temp }}/qwen-home'
         run: |-
           set -euo pipefail
           fail() {

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -195,13 +195,21 @@ jobs:
             -f content='eyes' > /dev/null ||
             echo "Failed to add triage acknowledgement reaction; continuing." >&2
 
-      # Self-hosted ECS runners reuse the workspace between runs, so an
-      # interrupted triage (its agent has enter_worktree/exit_worktree) can
-      # leave a stale `.qwen/tmp/*` worktree that trips the checkout below.
-      # Prune defensively; never fail the job. No-op on a fresh hosted runner.
-      - name: 'Clean stale triage worktrees'
+      # Self-hosted ECS runners reuse $HOME, /tmp and the workspace between runs,
+      # so a prior run can bleed into this one: its agent session/memory (under
+      # QWEN_HOME), leftover draft comments (/tmp/stage-*.md, which survive
+      # `git clean`), or a stale `.qwen/tmp/*` worktree from an interrupted
+      # triage (its agent has enter_worktree/exit_worktree). Reset all three
+      # per run; never fail the job. No-op on a fresh hosted runner.
+      - name: 'Clean stale agent state'
         run: |-
           set -uo pipefail
+          # Fresh per-run agent home (must match QWEN_HOME on the Qwen step
+          # below) + drop any leftover stage drafts.
+          QWEN_HOME="${RUNNER_TEMP:?}/qwen-home"
+          rm -rf "$QWEN_HOME" 2>/dev/null || true
+          mkdir -p "$QWEN_HOME"
+          rm -f /tmp/stage-*.md 2>/dev/null || true
           # `.git` is a directory in a normal checkout but a gitlink file in a
           # worktree; -e covers both, and a missing .git (first run) too.
           if [ ! -e .git ]; then
@@ -210,7 +218,7 @@ jobs:
           fi
           rm -rf .qwen/tmp/* 2>/dev/null || true
           git worktree prune -v || true
-          echo "stale triage worktrees cleaned"
+          echo "stale agent state cleaned"
 
       - name: 'Checkout repo'
         uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
@@ -234,6 +242,10 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.QWEN_CODE_BOT_TOKEN || secrets.CI_BOT_PAT }}'
           GH_TOKEN: '${{ secrets.QWEN_CODE_BOT_TOKEN || secrets.CI_BOT_PAT }}'
           REPOSITORY: '${{ github.repository }}'
+          # Per-run agent home so this run's session/memory cannot leak into the
+          # next on the reused self-hosted workspace (reset in "Clean stale
+          # agent state"). Must match the QWEN_HOME computed there.
+          QWEN_HOME: '${{ runner.temp }}/qwen-home'
         with:
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
           OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'


### PR DESCRIPTION
## What this PR does

Gives the triage job (`qwen-triage.yml`) and the PR-review job (`qwen-code-pr-review.yml`) a fresh, per-run home for the qwen agent, and scrubs leftover draft files before each run. Both jobs run the agent directly on the persistent self-hosted ECS pool, where `$HOME`, `/tmp` and the workspace are reused between runs — so without isolation one run's state can bleed into the next.

Each job now points `QWEN_HOME` at `${RUNNER_TEMP}/qwen-home` on the step that runs qwen, and resets that directory (plus `/tmp/stage-*.md`) in the existing pre-run cleanup step. `QWEN_HOME` relocates the entire global qwen dir (sessions, memory, settings, temp — see `packages/core/src/config/storage.ts`), so this isolates agent state without touching `$HOME` and disturbing git/npm/gh. The already container-isolated `tmux-testing` job is unchanged.

## Why it's needed

On #5874 (`perf(cli): skip spawnSync wrapper`, author @doudouOUC) the triage bot posted three comments whose content belonged entirely to a different PR, #5872 (`fix(cli): make alt+t expand thinking on macOS…`, author @chiga0) — wrong author, wrong approver, wrong diff.

It was not a wrong-PR-id bug. The run resolved the number correctly (`number=5874`, `prompt: /triage 5874`, `PR_AUTHOR: doudouOUC`), and the same run's internal Stage 2 actually exercised #5874 (tmux-tested `qwen serve`, `/health` ok). But all three posted stages carried #5872's analysis — including the tell "matches my independent proposal exactly" — because the agent's session/memory from a prior run persisted on the reused self-hosted home. The same exposure exists in the PR-review job, which is worse since it casts an actual review verdict.

## Reviewer Test Plan

### How to verify

This is a CI-only change to two workflow files; the effect is observable on the self-hosted runner, not locally.

1. YAML parses and `actionlint` reports no new findings (the two pre-existing warnings — `environment.deployment` and an SC2016 in an unrelated script — are untouched).
2. On the next triage / review run, the "Clean stale agent state" step logs the reset, and the qwen step runs with `QWEN_HOME=$RUNNER_TEMP/qwen-home` — confirm via the run log that `~/.qwen` is no longer used.
3. Regression check: trigger triage on two different PRs back-to-back on the same runner and confirm each comments only on its own PR.

### Evidence (Before & After)

N/A — CI workflow change, no user-visible behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ⚠️   |

Linux is where these jobs run (self-hosted ECS); verification happens on the next live triage/review run.

### Environment (optional)

N/A — no local runtime; validated with `actionlint` + YAML parse.

## Risk & Scope

- Main risk or tradeoff: if `QwenLM/qwen-code-action` ever sets its own `QWEN_HOME`, the step-level value here takes precedence — intended. The `${RUNNER_TEMP:?}` guard fails the cleanup loudly rather than running `rm -rf` on an empty path.
- Not validated / out of scope: the triage skill still writes drafts to literal `/tmp/stage-*.md`; this PR scrubs them per run rather than relocating them. Moving the skill's draft path under `$QWEN_HOME` is a sensible follow-up but out of scope here.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5882

<details>
<summary>中文说明</summary>

## 做了什么

给 triage job(`qwen-triage.yml`)和 PR-review job(`qwen-code-pr-review.yml`)的 qwen agent 每次运行一个全新的 home,并在每次运行前清掉残留草稿文件。这两个 job 都直接跑在常驻的自建 ECS 机器上,`$HOME`、`/tmp` 和 workspace 在多次运行间复用 —— 不隔离的话,一次运行的状态会漏到下一次。

现在每个 job 在跑 qwen 的那一步把 `QWEN_HOME` 指向 `${RUNNER_TEMP}/qwen-home`,并在已有的运行前清理步骤里重置该目录(外加 `/tmp/stage-*.md`)。`QWEN_HOME` 会重定位整个全局 qwen 目录(session、memory、settings、temp —— 见 `packages/core/src/config/storage.ts`),因此隔离了 agent 状态,又不改 `$HOME`、不影响 git/npm/gh。已经用容器隔离的 `tmux-testing` job 不动。

## 为什么需要

在 #5874(`perf(cli): skip spawnSync wrapper`,作者 @doudouOUC)上,triage bot 发的三条评论内容完全属于另一个 PR #5872(`fix(cli): make alt+t…`,作者 @chiga0)—— 作者错、批准人错、diff 错。

这不是传错 PR id。运行时号是对的(`number=5874`、`prompt: /triage 5874`、`PR_AUTHOR: doudouOUC`),而且同一次运行的内部 Stage 2 确实测了 #5874(tmux 跑了 `qwen serve`,`/health` 正常)。但三条评论都带的是 #5872 的分析(包括 "matches my independent proposal exactly" 这句铁证),因为上一轮的 agent session/memory 残留在复用的自建 home 里。PR-review job 有同样的暴露,而且它会真的下评审结论,更糟。

## 风险

- 主要权衡:若 `QwenLM/qwen-code-action` 自己设了 `QWEN_HOME`,这里的 step 级取值会覆盖它 —— 符合预期。`${RUNNER_TEMP:?}` 守卫会在路径为空时直接报错,而不是对空路径 `rm -rf`。
- 范围外:triage skill 仍把草稿写到字面量 `/tmp/stage-*.md`;本 PR 是每次运行清掉它们,而非改写路径。把草稿路径挪到 `$QWEN_HOME` 下是合理的后续,不在本 PR 范围。
- 无 breaking change。

</details>
