### PR TITLE
fix(cli): wrap tool call descriptions instead of truncating

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -802,10 +802,7 @@ const ToolInfo: React.FC<ToolInfo> = ({
   }, [emphasis]);
   return (
     <Box flexGrow={1}>
-      <Text
-        wrap="truncate-end"
-        strikethrough={status === ToolCallStatus.Canceled}
-      >
+      <Text wrap="wrap" strikethrough={status === ToolCallStatus.Canceled}>
         <Text color={nameColor} bold>
           {localizeToolDisplayName(name)}
         </Text>{' '}


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

Changes the tool call description text wrapping behavior from `truncate-end` to `wrap`, allowing long descriptions (shell commands, file paths, etc.) to wrap onto multiple lines instead of being cut off.

## Why it's needed

Tool call descriptions were truncated at the line width, making it impossible to see the full command or file path once the output scrolled out of view. The ANSI echo shows the command during execution but disappears from the viewport afterward, hindering session review and debugging. Wrapping keeps the full description visible in the message header for later reference.

## Reviewer Test Plan

### How to verify

Run a tool with a long description (e.g. a long shell command chain or a deep file path) and confirm the full text wraps to multiple lines instead of being truncated with no way to see the rest.

### Evidence (Before & After)

Before: Long commands are truncated at line width, tail hidden (`truncate-end`).
After: Long commands wrap to the next line, fully visible (`wrap`).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  ⚠️   |
|  🐧 Linux  |  ⚠️   |

### Environment (optional)

`npm run dev`

## Risk & Scope

- Main risk or trade-off: Very long descriptions will consume multiple terminal rows, slightly reducing visible message count per screen.
- Not validated / out of scope: N/A
- Breaking changes / migration notes: N/A

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

将工具调用描述的文本换行行为从 `truncate-end`（截断）改为 `wrap`（换行），使长描述（shell 命令、文件路径等）可以换行显示完整内容，而不是被截断。

## 为什么需要

工具调用描述在行宽处被截断，输出滚出视口后无法看到完整命令或路径。ANSI 回显在执行期间显示命令，但滚动后消失，不利于会话回顾和调试。换行显示使完整描述保留在消息头部，方便后期复盘。

## 评审测试计划

### 如何验证

运行一个带有长描述的工具（如长 shell 命令链或深层文件路径），确认完整文本换行到多行显示，而不是被截断且无法查看剩余部分。

### 证据（前后对比）

之前：长命令在行宽处截断，尾部不可见（`truncate-end`）。
之后：长命令换行到下一行，完整可见（`wrap`）。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

`npm run dev`

## 风险与范围

- 主要风险或权衡：超长描述将占用多行终端空间，略微减少每屏可见的消息数量。
- 未验证 / 超出范围：N/A
- 破坏性变更 / 迁移说明：N/A

## 关联 Issue

N/A

</details>
