### PR TITLE
fix(core): tree-kill PTY shell tree on Windows to stop pwsh leak (#5873)

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -1567,6 +1567,24 @@ describe('ShellExecutionService', () => {
       expect(mockPtyProcess.kill).toHaveBeenCalled();
     });
 
+    it('exit cleanup tree-kills child_process children via the absolute taskkill', () => {
+      mockPlatform.mockReturnValue('win32');
+      const childPid = 54321;
+      ShellExecutionService['activeChildProcesses'].add(childPid);
+
+      ShellExecutionService.cleanup();
+      ShellExecutionService['activeChildProcesses'].delete(childPid);
+
+      // Pins killChildProcesses on the absolute System32 path — a regression to
+      // the bare 'taskkill' name reopens the binary-planting hole. See #5873.
+      expect(mockSpawnSync).toHaveBeenCalledWith(TASKKILL, [
+        '/f',
+        '/t',
+        '/pid',
+        String(childPid),
+      ]);
+    });
+
     it('win32 taskkill is invoked by absolute System32 path, not the bare name', async () => {
       mockPlatform.mockReturnValue('win32');
 
@@ -1684,6 +1702,49 @@ describe('ShellExecutionService', () => {
         '/pid',
         String(mockPtyProcess.pid),
       ]);
+    });
+
+    it('win32 promoted shell skips the post-settle reap when the pty already exited', async () => {
+      mockPlatform.mockReturnValue('win32');
+
+      const { result } = await simulateExecution(
+        'long-running-command',
+        (_pty, ac) => {
+          ac.abort({
+            kind: 'background',
+            shellId: 'bg_5873_settle_esrch',
+          } satisfies ShellAbortReason);
+        },
+        shellExecutionConfig,
+        { postPromote: { onSettle: () => {} } },
+      );
+      // Promote succeeded while the shell was still alive (default liveness).
+      expect(result.promoted).toBe(true);
+
+      // Now the shell has exited: the post-settle liveness check fails (ESRCH),
+      // so the firePostSettle reap must be skipped (no taskkill against a
+      // possibly-reused pid). Mirrors the foreground finalizer's guard. See #5873.
+      mockProcessKill.mockImplementation(
+        (_pid: number, signal?: string | number) => {
+          if (signal === 0) {
+            throw new Error('ESRCH');
+          }
+          return true;
+        },
+      );
+      try {
+        const onExitRegistrations = mockPtyProcess.onExit.mock.calls;
+        const postPromoteExitHandler =
+          onExitRegistrations[onExitRegistrations.length - 1][0];
+        postPromoteExitHandler({ exitCode: 0, signal: undefined });
+
+        expect(mockCpSpawn).not.toHaveBeenCalledWith(
+          TASKKILL,
+          expect.anything(),
+        );
+      } finally {
+        mockProcessKill.mockImplementation(() => true);
+      }
     });
   });
 

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -38,6 +38,7 @@ const mockGetSystemEncoding = vi.hoisted(() =>
 );
 const mockPtySpawn = vi.hoisted(() => vi.fn());
 const mockCpSpawn = vi.hoisted(() => vi.fn());
+const mockSpawnSync = vi.hoisted(() => vi.fn());
 const mockIsBinary = vi.hoisted(() => vi.fn());
 const mockPlatform = vi.hoisted(() => vi.fn());
 const mockGetPty = vi.hoisted(() => vi.fn());
@@ -76,6 +77,7 @@ vi.mock('@lydell/node-pty', () => ({
 }));
 vi.mock('child_process', () => ({
   spawn: mockCpSpawn,
+  spawnSync: mockSpawnSync,
 }));
 vi.mock('../utils/textUtils.js', () => ({
   isBinary: mockIsBinary,
@@ -116,6 +118,11 @@ vi.mock('../utils/systemEncoding.js', () => ({
 const mockProcessKill = vi
   .spyOn(process, 'kill')
   .mockImplementation(() => true);
+
+// Production resolves taskkill by absolute System32 path (never the bare name)
+// to avoid PATH/CWD binary planting. Compute the expected path the same way so
+// assertions stay in sync across platforms (SystemRoot is unset off Windows).
+const TASKKILL = `${process.env['SystemRoot'] || 'C:\\Windows'}\\System32\\taskkill.exe`;
 
 const shellExecutionConfig = {
   terminalWidth: 80,
@@ -1280,6 +1287,406 @@ describe('ShellExecutionService', () => {
     });
   });
 
+  describe('Windows process cleanup (#5873)', () => {
+    // Under ConPTY, ptyProcess.kill() does not kill the pwsh process tree
+    // (microsoft/node-pty#333). These pin that the PTY paths now reap pwsh via
+    // taskkill on Windows — tree-kill on cancel, shell-pid-only on normal
+    // completion — so idle pwsh processes don't accumulate until OOM.
+
+    beforeEach(() => {
+      // windowsKillPid attaches an 'error' listener to the spawned taskkill
+      // child so a failed launch can't crash the CLI; the mock must therefore
+      // return something with .on(). The top-level beforeEach leaves
+      // mockCpSpawn returning undefined.
+      mockCpSpawn.mockReturnValue(new EventEmitter());
+      // The PTY cancel path now taskkills synchronously (spawnSync); default it
+      // to a clean exit so the result-inspecting logging doesn't fire.
+      mockSpawnSync.mockReturnValue({ status: 0 });
+    });
+
+    it('cancel on win32 tree-kills via taskkill, with a ptyProcess.kill fallback', async () => {
+      mockPlatform.mockReturnValue('win32');
+
+      const { result } = await simulateExecution(
+        'sleep 10',
+        (pty, abortController) => {
+          abortController.abort();
+          pty.onExit.mock.calls[0][0]({ exitCode: 1, signal: null });
+        },
+      );
+
+      expect(result.aborted).toBe(true);
+      // Cancel tree-kills (/t) SYNCHRONOUSLY (spawnSync) so taskkill enumerates
+      // the tree before ptyProcess.kill() fires ClosePseudoConsole. See #5873.
+      expect(mockSpawnSync).toHaveBeenCalledWith(TASKKILL, [
+        '/f',
+        '/t',
+        '/pid',
+        String(mockPtyProcess.pid),
+      ]);
+      // The finalizer reap (async cpSpawn via windowsKillPid) must ALSO
+      // tree-kill on cancel — positively asserted so removing the reap or
+      // forcing cancelKillDispatched=false fails here, not just trivially via
+      // the negative check below. See #5873.
+      expect(mockCpSpawn).toHaveBeenCalledWith(TASKKILL, [
+        '/f',
+        '/t',
+        '/pid',
+        String(mockPtyProcess.pid),
+      ]);
+      // ...and it must never downgrade to a shell-only (/f without /t) kill
+      // that could leave the abandoned descendant tree behind. See #5873.
+      expect(mockCpSpawn).not.toHaveBeenCalledWith(TASKKILL, [
+        '/f',
+        '/pid',
+        String(mockPtyProcess.pid),
+      ]);
+      // ...and still calls ptyProcess.kill() so that if taskkill cannot launch,
+      // the ConPTY host is torn down and onExit fires (the cancel can't hang).
+      // See #5873.
+      expect(mockPtyProcess.kill).toHaveBeenCalled();
+      // Ordering is the race fix: the sync taskkill must enumerate/kill the
+      // tree BEFORE ptyProcess.kill() fires ClosePseudoConsole. See #5873.
+      expect(mockSpawnSync.mock.invocationCallOrder[0]).toBeLessThan(
+        mockPtyProcess.kill.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('normal completion on win32 reaps a still-alive pty by shell pid only (no /t)', async () => {
+      mockPlatform.mockReturnValue('win32');
+      // isPtyActive -> process.kill(pid, 0) returns true (default mock):
+      // node-pty reported exit but the pwsh process is still alive.
+
+      const { result } = await simulateExecution('echo hi', (pty) => {
+        pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+      });
+
+      expect(result.exitCode).toBe(0);
+      // Reap kills only the shell pid — no /t — so a child the command
+      // intentionally detached (e.g. Start-Process) survives. See #5873.
+      expect(mockCpSpawn).toHaveBeenCalledWith(TASKKILL, [
+        '/f',
+        '/pid',
+        String(mockPtyProcess.pid),
+      ]);
+      expect(mockCpSpawn).not.toHaveBeenCalledWith(TASKKILL, [
+        '/f',
+        '/t',
+        '/pid',
+        String(mockPtyProcess.pid),
+      ]);
+    });
+
+    it('normal completion on win32 swallows a taskkill launch error (no crash)', async () => {
+      mockPlatform.mockReturnValue('win32');
+      // windowsKillPid attaches a no-op 'error' listener so a failed taskkill
+      // launch (reported as an async EventEmitter 'error' event, not a throw)
+      // can't crash the CLI from this cleanup path. See #5873.
+      const taskkillProc = new EventEmitter();
+      mockCpSpawn.mockReturnValue(taskkillProc);
+
+      const { result } = await simulateExecution('echo hi', (pty) => {
+        pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+      });
+
+      expect(result.exitCode).toBe(0);
+      // By now the finalizer reap has spawned taskkill (taskkillProc) and
+      // attached its 'error' listener; firing the launch error must be
+      // swallowed. Without the listener this emit would throw (EventEmitter
+      // re-raises an 'error' with no handler) — i.e. the production crash.
+      expect(() =>
+        taskkillProc.emit('error', new Error('spawn taskkill ENOENT')),
+      ).not.toThrow();
+    });
+
+    it('normal completion on win32 does NOT taskkill when the pty already exited', async () => {
+      mockPlatform.mockReturnValue('win32');
+      // isPtyActive -> process.kill(pid, 0) throws => the process is gone, so
+      // the reap is skipped (avoids killing a possibly-reused pid).
+      mockProcessKill.mockImplementation(
+        (_pid: number, signal?: string | number) => {
+          if (signal === 0) {
+            throw new Error('ESRCH');
+          }
+          return true;
+        },
+      );
+
+      try {
+        const { result } = await simulateExecution('echo hi', (pty) => {
+          pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(mockCpSpawn).not.toHaveBeenCalledWith(
+          TASKKILL,
+          expect.anything(),
+        );
+      } finally {
+        // clearAllMocks() resets calls but not implementations — restore the
+        // default liveness mock so later tests see isPtyActive === true.
+        mockProcessKill.mockImplementation(() => true);
+      }
+    });
+
+    it('normal completion on non-win32 never taskkills', async () => {
+      // Default platform is 'linux'.
+      const { result } = await simulateExecution('echo hi', (pty) => {
+        pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(mockCpSpawn).not.toHaveBeenCalledWith(TASKKILL, expect.anything());
+    });
+
+    it('exit cleanup on win32 tree-kills via taskkill and tears down the host', () => {
+      mockPlatform.mockReturnValue('win32');
+      mockSpawnSync.mockReturnValue({ error: undefined });
+      const pid = mockPtyProcess.pid;
+      ShellExecutionService['activePtys'].set(pid, {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ptyProcess: mockPtyProcess as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        headlessTerminal: { dispose: vi.fn() } as any,
+      });
+
+      ShellExecutionService.cleanup();
+      ShellExecutionService['activePtys'].delete(pid);
+
+      expect(mockSpawnSync).toHaveBeenCalledWith(TASKKILL, [
+        '/f',
+        '/t',
+        '/pid',
+        String(pid),
+      ]);
+      // The ConPTY host is torn down unconditionally, alongside the tree-kill.
+      expect(mockPtyProcess.kill).toHaveBeenCalled();
+    });
+
+    it('exit cleanup on win32 still tears down the host when taskkill exits non-zero', () => {
+      mockPlatform.mockReturnValue('win32');
+      // taskkill launched (no spawn error) but failed — e.g. access denied, or
+      // the pid was already gone. result.error is undefined, so we must not
+      // treat that as success and skip the host teardown.
+      mockSpawnSync.mockReturnValue({ status: 1, error: undefined });
+      const pid = mockPtyProcess.pid;
+      ShellExecutionService['activePtys'].set(pid, {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ptyProcess: mockPtyProcess as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        headlessTerminal: { dispose: vi.fn() } as any,
+      });
+
+      ShellExecutionService.cleanup();
+      ShellExecutionService['activePtys'].delete(pid);
+
+      expect(mockPtyProcess.kill).toHaveBeenCalled();
+    });
+
+    it('cancel on win32 still resolves when ptyProcess.kill throws', async () => {
+      mockPlatform.mockReturnValue('win32');
+      // The host-teardown fallback in performCancelKill is wrapped in try/catch;
+      // a throwing kill (pty already gone) must not break the cancel. See #5873.
+      mockPtyProcess.kill.mockImplementation(() => {
+        throw new Error('pty already gone');
+      });
+
+      const { result } = await simulateExecution(
+        'sleep 10',
+        (pty, abortController) => {
+          abortController.abort();
+          pty.onExit.mock.calls[0][0]({ exitCode: 1, signal: null });
+        },
+      );
+
+      expect(result.aborted).toBe(true);
+      expect(mockPtyProcess.kill).toHaveBeenCalled();
+    });
+
+    it('cancel on win32 with an already-dead shell skips the finalizer reap', async () => {
+      mockPlatform.mockReturnValue('win32');
+      // performCancelKill already killed the shell, so by the time the finalizer
+      // runs the liveness check fails (ESRCH) — the common cancel-on-healthy-
+      // ConPTY flow. The cancel still tree-kills (performCancelKill), and the
+      // finalizer adds no shell-only kill. See #5873.
+      mockProcessKill.mockImplementation(
+        (_pid: number, signal?: string | number) => {
+          if (signal === 0) {
+            throw new Error('ESRCH');
+          }
+          return true;
+        },
+      );
+
+      try {
+        const { result } = await simulateExecution(
+          'sleep 10',
+          (pty, abortController) => {
+            abortController.abort();
+            pty.onExit.mock.calls[0][0]({ exitCode: 1, signal: null });
+          },
+        );
+
+        expect(result.aborted).toBe(true);
+        // performCancelKill's sync tree-kill still runs...
+        expect(mockSpawnSync).toHaveBeenCalledWith(TASKKILL, [
+          '/f',
+          '/t',
+          '/pid',
+          String(mockPtyProcess.pid),
+        ]);
+        // ...but the finalizer reap is skipped (isPtyActive false via ESRCH),
+        // so no async taskkill fires there.
+        expect(mockCpSpawn).not.toHaveBeenCalledWith(
+          TASKKILL,
+          expect.anything(),
+        );
+      } finally {
+        mockProcessKill.mockImplementation(() => true);
+      }
+    });
+
+    it('exit cleanup falls back to ptyProcess.kill when taskkill spawnSync throws', () => {
+      mockPlatform.mockReturnValue('win32');
+      // spawnSync can throw on a synchronous arg/setup failure; the catch in
+      // killPty must swallow it and still tear down the host. See #5873.
+      mockSpawnSync.mockImplementationOnce(() => {
+        throw new Error('spawnSync EACCES');
+      });
+      const pid = mockPtyProcess.pid;
+      ShellExecutionService['activePtys'].set(pid, {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ptyProcess: mockPtyProcess as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        headlessTerminal: { dispose: vi.fn() } as any,
+      });
+
+      ShellExecutionService.cleanup();
+      ShellExecutionService['activePtys'].delete(pid);
+
+      expect(mockPtyProcess.kill).toHaveBeenCalled();
+    });
+
+    it('win32 taskkill is invoked by absolute System32 path, not the bare name', async () => {
+      mockPlatform.mockReturnValue('win32');
+
+      await simulateExecution('echo hi', (pty) => {
+        pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+      });
+
+      // The executable must be the trusted absolute System32 path — never the
+      // bare 'taskkill', which Windows spawn would resolve through PATH/CWD and
+      // could be hijacked by a planted taskkill.exe/.bat. See #5873.
+      const cmd = mockCpSpawn.mock.calls.find((c) =>
+        /taskkill/i.test(String(c[0])),
+      )?.[0];
+      expect(cmd).toBe(TASKKILL);
+      expect(cmd).toMatch(/^[A-Za-z]:\\.*\\System32\\taskkill\.exe$/i);
+      expect(cmd).not.toBe('taskkill');
+    });
+
+    it('a late abort after a normal exit does NOT tree-kill (no cancel retro-flag)', async () => {
+      mockPlatform.mockReturnValue('win32');
+
+      const { result } = await simulateExecution(
+        'echo hi',
+        (pty, abortController) => {
+          // Command exits normally FIRST...
+          pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+          // ...then an unrelated abort lands during the finalize window. The
+          // abort listener is already removed and performCancelKill never ran,
+          // so cancelKillDispatched stays false and the reap must stay
+          // shell-pid-only — detached children must not be tree-killed.
+          abortController.abort();
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(mockCpSpawn).toHaveBeenCalledWith(TASKKILL, [
+        '/f',
+        '/pid',
+        String(mockPtyProcess.pid),
+      ]);
+      expect(mockCpSpawn).not.toHaveBeenCalledWith(TASKKILL, [
+        '/f',
+        '/t',
+        '/pid',
+        String(mockPtyProcess.pid),
+      ]);
+    });
+
+    it('win32 promoted shell reaps its lingering pwsh on natural exit (shell-pid-only)', async () => {
+      mockPlatform.mockReturnValue('win32');
+      const settleCalls: ShellPostPromoteSettleInfo[] = [];
+
+      const { result } = await simulateExecution(
+        'long-running-command',
+        (_pty, ac) => {
+          ac.abort({
+            kind: 'background',
+            shellId: 'bg_5873_reap',
+          } satisfies ShellAbortReason);
+        },
+        shellExecutionConfig,
+        { postPromote: { onSettle: (info) => settleCalls.push(info) } },
+      );
+      expect(result.promoted).toBe(true);
+
+      // Drive the promoted PTY's natural exit. The post-promote settle path
+      // must reap the lingering ConPTY shell — shell-pid-only, since the
+      // command finished and any detached child should survive. Before this
+      // fix the reap only ran in the foreground finalizer, so backgrounded
+      // shells still leaked the pwsh process. See #5873.
+      const onExitRegistrations = mockPtyProcess.onExit.mock.calls;
+      const postPromoteExitHandler =
+        onExitRegistrations[onExitRegistrations.length - 1][0];
+      postPromoteExitHandler({ exitCode: 0, signal: undefined });
+
+      expect(settleCalls).toHaveLength(1);
+      expect(mockCpSpawn).toHaveBeenCalledWith(TASKKILL, [
+        '/f',
+        '/pid',
+        String(mockPtyProcess.pid),
+      ]);
+      expect(mockCpSpawn).not.toHaveBeenCalledWith(TASKKILL, [
+        '/f',
+        '/t',
+        '/pid',
+        String(mockPtyProcess.pid),
+      ]);
+    });
+
+    it('win32 promoted shell reaps on natural exit even with onData only (no onSettle)', async () => {
+      mockPlatform.mockReturnValue('win32');
+
+      const { result } = await simulateExecution(
+        'long-running-command',
+        (_pty, ac) => {
+          ac.abort({
+            kind: 'background',
+            shellId: 'bg_5873_ondata',
+          } satisfies ShellAbortReason);
+        },
+        shellExecutionConfig,
+        // onData only — the reap must fire BEFORE firePostSettle's
+        // `!postPromote?.onSettle` early return. See #5873.
+        { postPromote: { onData: () => {} } },
+      );
+      expect(result.promoted).toBe(true);
+
+      const onExitRegistrations = mockPtyProcess.onExit.mock.calls;
+      const postPromoteExitHandler =
+        onExitRegistrations[onExitRegistrations.length - 1][0];
+      postPromoteExitHandler({ exitCode: 0, signal: undefined });
+
+      expect(mockCpSpawn).toHaveBeenCalledWith(TASKKILL, [
+        '/f',
+        '/pid',
+        String(mockPtyProcess.pid),
+      ]);
+    });
+  });
+
   describe('Binary Output', () => {
     it('should detect binary output and switch to progress events', async () => {
       mockIsBinary.mockReturnValueOnce(true);
@@ -1929,7 +2336,7 @@ describe('ShellExecutionService child_process fallback', () => {
       },
       {
         platform: 'win32',
-        expectedCommand: 'taskkill',
+        expectedCommand: TASKKILL,
         expectedExit: { code: 1 },
       },
     ])(
@@ -1962,15 +2369,114 @@ describe('ShellExecutionService child_process fallback', () => {
             );
           } else {
             expect(mockCpSpawn).toHaveBeenCalledWith(expectedCommand, [
-              '/pid',
-              String(mockChildProcess.pid),
               '/f',
               '/t',
+              '/pid',
+              String(mockChildProcess.pid),
             ]);
           }
         });
       },
     );
+
+    it('win32 cancel falls back to child.kill when taskkill cannot launch', async () => {
+      mockPlatform.mockReturnValue('win32');
+      // The shell spawn returns mockChildProcess; the taskkill spawn returns a
+      // separate emitter so its launch 'error' can be fired in isolation
+      // (without also tripping the shell child's own 'error' handler).
+      const taskkillProc = new EventEmitter();
+      mockCpSpawn.mockReturnValueOnce(mockChildProcess); // shell
+      mockCpSpawn.mockReturnValueOnce(taskkillProc); // performCancelKill taskkill
+
+      const { result } = await simulateExecution(
+        'sleep 10',
+        (cp, abortController) => {
+          abortController.abort();
+          // taskkill could not launch -> async 'error' event (not a throw).
+          taskkillProc.emit('error', new Error('spawn taskkill ENOENT'));
+          // The child.kill() fallback makes the real child exit; settle it.
+          cp.emit('exit', 1, null);
+          cp.emit('close', 1, null);
+        },
+      );
+
+      expect(result.aborted).toBe(true);
+      // Without the fallback the abort would hang waiting for an exit that
+      // never comes. See #5873.
+      expect(mockChildProcess.kill).toHaveBeenCalledWith('SIGKILL');
+    });
+
+    it('win32 cancel falls back to child.kill when taskkill exits non-zero', async () => {
+      mockPlatform.mockReturnValue('win32');
+      const taskkillProc = new EventEmitter();
+      mockCpSpawn.mockReturnValueOnce(mockChildProcess); // shell
+      mockCpSpawn.mockReturnValueOnce(taskkillProc); // performCancelKill taskkill
+
+      const { result } = await simulateExecution(
+        'sleep 10',
+        (cp, abortController) => {
+          abortController.abort();
+          // taskkill launched but failed to kill the tree (e.g. access denied
+          // on an elevated child): non-zero exit, no 'error' event.
+          taskkillProc.emit('exit', 1);
+          // The child.kill() fallback makes the real child exit; settle it.
+          cp.emit('exit', 1, null);
+          cp.emit('close', 1, null);
+        },
+      );
+
+      expect(result.aborted).toBe(true);
+      // The 'exit' handler must fall back to child.kill on a non-zero taskkill
+      // exit, else the cancel hangs (no 'error', child still alive). See #5873.
+      expect(mockChildProcess.kill).toHaveBeenCalledWith('SIGKILL');
+    });
+
+    it('win32 cancel does NOT fall back to child.kill when taskkill exits 0', async () => {
+      mockPlatform.mockReturnValue('win32');
+      const taskkillProc = new EventEmitter();
+      mockCpSpawn.mockReturnValueOnce(mockChildProcess); // shell
+      mockCpSpawn.mockReturnValueOnce(taskkillProc); // performCancelKill taskkill
+
+      const { result } = await simulateExecution(
+        'sleep 10',
+        (cp, abortController) => {
+          abortController.abort();
+          // taskkill succeeded (exit 0): it killed the tree, so the fallback
+          // must NOT fire — pins the `if (code !== 0)` guard against removal
+          // or inversion.
+          taskkillProc.emit('exit', 0);
+          cp.emit('exit', 1, null);
+          cp.emit('close', 1, null);
+        },
+      );
+
+      expect(result.aborted).toBe(true);
+      expect(mockChildProcess.kill).not.toHaveBeenCalled();
+    });
+
+    it('win32 cancel does NOT fall back to child.kill when the child already exited', async () => {
+      mockPlatform.mockReturnValue('win32');
+      const taskkillProc = new EventEmitter();
+      mockCpSpawn.mockReturnValueOnce(mockChildProcess); // shell
+      mockCpSpawn.mockReturnValueOnce(taskkillProc); // performCancelKill taskkill
+
+      const { result } = await simulateExecution(
+        'sleep 10',
+        (cp, abortController) => {
+          abortController.abort();
+          // The child exits naturally BEFORE taskkill reports failure (taskkill
+          // can be slow to report). This sets `exited = true`...
+          cp.emit('exit', 0, null);
+          cp.emit('close', 0, null);
+          // ...so the late taskkill error must NOT fall back to child.kill on a
+          // dead (possibly pid-reused) child — pins the `if (!exited)` guard.
+          taskkillProc.emit('error', new Error('spawn taskkill ENOENT'));
+        },
+      );
+
+      expect(result.aborted).toBe(true);
+      expect(mockChildProcess.kill).not.toHaveBeenCalled();
+    });
 
     it('signal.reason = { kind: "cancel" } still tree-kills (same as default)', async () => {
       mockPlatform.mockReturnValue('linux');

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -477,9 +477,10 @@ interface ProcessCleanupStrategy {
  * A failed *launch* of taskkill (System32 off PATH, EMFILE, EACCES) is reported
  * via an async 'error' event, not a throw, so the try/catch below cannot see
  * it. Without a listener that 'error' would bubble up as an unhandled
- * EventEmitter error and crash the CLI from this cleanup path; attach a no-op
- * one. (Callers that need the kill to actually land must provide their own
- * fallback — see performCancelKill.) See #5873.
+ * EventEmitter error and crash the CLI from this cleanup path; the 'error' and
+ * 'exit' listeners below log the failure via debugLogger without re-throwing.
+ * Callers that need the kill to actually land must provide their own fallback —
+ * see performCancelKill. See #5873.
  */
 // Resolve taskkill by absolute System32 path, never the bare name. On Windows
 // child_process spawn resolves a bare command through the executable search

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -460,9 +460,94 @@ interface ProcessCleanupStrategy {
   killChildProcesses(pids: Set<number>): void;
 }
 
+/**
+ * Kills a PTY shell process on Windows via taskkill. Under ConPTY,
+ * `ptyProcess.kill()` only tears down the pseudo-console host, not the
+ * pwsh/powershell/cmd process (microsoft/node-pty#333), so idle shells pile up
+ * until OOM (#5873).
+ *
+ * `tree` sets the blast radius:
+ *  - `true` (`/t`): also kill descendants. Use for cancellation and app-exit
+ *    cleanup, where the user has abandoned the whole command.
+ *  - `false`: kill only the shell pid. Use for the normal-completion reap: the
+ *    leak is the idle shell itself, and a command that finished may have
+ *    intentionally detached a child (e.g. `Start-Process`) that should outlive
+ *    the shell — `/t` would take that child down too.
+ *
+ * A failed *launch* of taskkill (System32 off PATH, EMFILE, EACCES) is reported
+ * via an async 'error' event, not a throw, so the try/catch below cannot see
+ * it. Without a listener that 'error' would bubble up as an unhandled
+ * EventEmitter error and crash the CLI from this cleanup path; attach a no-op
+ * one. (Callers that need the kill to actually land must provide their own
+ * fallback — see performCancelKill.) See #5873.
+ */
+// Resolve taskkill by absolute System32 path, never the bare name. On Windows
+// child_process spawn resolves a bare command through the executable search
+// path AND the current directory, so a taskkill.exe/.bat planted in the
+// workspace or on PATH could run from these cleanup paths with the CLI's
+// environment — arbitrary code execution out of a benign teardown. See #5873.
+const WINDOWS_TASKKILL = `${process.env['SystemRoot'] || 'C:\\Windows'}\\System32\\taskkill.exe`;
+
+const windowsKillPid = (pid: number, tree: boolean): void => {
+  try {
+    // Flags-first, matching windowsStrategy.killPty / killChildProcesses so
+    // every taskkill invocation greps the same way (taskkill is order-agnostic).
+    const args = tree
+      ? ['/f', '/t', '/pid', pid.toString()]
+      : ['/f', '/pid', pid.toString()];
+    const killer = cpSpawn(WINDOWS_TASKKILL, args);
+    // Log (don't crash on) a failed launch: silently swallowing it would let
+    // the #5873 pwsh leak quietly return with no diagnostic trail under
+    // enterprise lockdown / EMFILE / antivirus interception.
+    killer.on('error', (e) => {
+      debugLogger.warn(
+        `windowsKillPid: taskkill failed to launch for pid ${pid}: ${e.message}`,
+      );
+    });
+    // Also observe a launch that succeeds but exits non-zero (e.g. access
+    // denied after launch) — otherwise a reap / post-promote taskkill could
+    // still fail silently. These callers run at runtime (not the process
+    // 'exit' handler), so the async debug write flushes. Logging only; the
+    // shell-only/tree-kill behavior is unchanged.
+    killer.on('exit', (code, signal) => {
+      if (code !== 0 || signal) {
+        debugLogger.warn(
+          `windowsKillPid: taskkill exited non-zero for pid ${pid}: ${signal ? `signal ${signal}` : `exit ${code}`}`,
+        );
+      }
+    });
+  } catch (e) {
+    debugLogger.warn(
+      `windowsKillPid: taskkill spawn threw for pid ${pid}: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+};
+
 const windowsStrategy: ProcessCleanupStrategy = {
-  killPty: (_pid, pty) => {
-    pty.ptyProcess.kill();
+  killPty: (pid, pty) => {
+    // Sync because this runs from the process 'exit' cleanup() handler, where
+    // an async spawn would not get a chance to run before the process dies.
+    // Mirrors the sibling killChildProcesses taskkill below.
+    try {
+      // No diagnostic logging here: killPty runs only from the process 'exit'
+      // handler, where debugLogger's async fs.appendFile would never flush
+      // before the process dies (and a sync stderr write would be exit-time
+      // noise). The unconditional ptyProcess.kill() below is the mitigation;
+      // the runtime reap paths (windowsKillPid), which DO flush, keep logging.
+      spawnSync(WINDOWS_TASKKILL, ['/f', '/t', '/pid', pid.toString()]);
+    } catch {
+      // ignore
+    }
+    // Always also tear down the ConPTY host (the pre-#5873 behavior): taskkill
+    // owns the pwsh tree, this owns the pseudo-console host. Doing both
+    // unconditionally avoids depending on taskkill's launch/exit status — it
+    // may fail to launch, or exit non-zero on access-denied or an already-gone
+    // pid — and matches performCancelKill. Harmless once the process is dead.
+    try {
+      pty.ptyProcess.kill();
+    } catch {
+      // already gone
+    }
   },
   killChildProcesses: (pids) => {
     if (pids.size > 0) {
@@ -471,7 +556,9 @@ const windowsStrategy: ProcessCleanupStrategy = {
         for (const pid of pids) {
           args.push('/pid', pid.toString());
         }
-        spawnSync('taskkill', args);
+        // No logging — like killPty, this runs only from the 'exit' handler
+        // where an async debug write can't flush before the process dies.
+        spawnSync(WINDOWS_TASKKILL, args);
       } catch {
         // ignore
       }
@@ -1143,7 +1230,41 @@ export class ShellExecutionService {
         const performCancelKill = async (): Promise<void> => {
           if (!child.pid || exited) return;
           if (isWindows) {
-            cpSpawn('taskkill', ['/pid', child.pid.toString(), '/f', '/t']);
+            const killer = cpSpawn(WINDOWS_TASKKILL, [
+              '/f',
+              '/t',
+              '/pid',
+              child.pid.toString(),
+            ]);
+            // taskkill can fail two ways, and either would otherwise hang the
+            // cancel (the abort waits for a child exit that never comes), so
+            // fall back to killing the child directly in both:
+            //  - a failed *launch* surfaces as an async 'error' event, not a
+            //    throw (swallowing it also avoids crashing the CLI on an
+            //    unhandled EventEmitter error);
+            //  - a successful launch that *exits non-zero* (e.g. access-denied
+            //    on an elevated child) means taskkill ran but did not kill the
+            //    tree, and no 'error' fires.
+            // Mirrors the POSIX branch's child.kill below and the PTY cancel's
+            // ptyProcess.kill fallback. See #5873.
+            const killChildFallback = (why: string) => {
+              debugLogger.warn(
+                `performCancelKill (child_process): taskkill ${why} for pid ${child.pid}; falling back to child.kill`,
+              );
+              if (!exited) {
+                try {
+                  child.kill('SIGKILL');
+                } catch {
+                  // already gone
+                }
+              }
+            };
+            killer.on('error', (e) =>
+              killChildFallback(`failed to launch (${e.message})`),
+            );
+            killer.on('exit', (code) => {
+              if (code !== 0) killChildFallback(`exited ${code}`);
+            });
           } else {
             try {
               process.kill(-child.pid, 'SIGTERM');
@@ -1305,6 +1426,11 @@ export class ShellExecutionService {
         const sniffChunks: Buffer[] = [];
         const error: Error | null = null;
         let exited = false;
+        // Set the moment performCancelKill actually proceeds (a cancel reached
+        // us before the shell exited). The finalizer reads THIS, not a late
+        // abortSignal.aborted check, to decide tree-kill vs shell-pid-only — an
+        // abort that arrives after a normal exit must not retro-flag the reap.
+        let cancelKillDispatched = false;
 
         let isStreamingRawContent = true;
         const MAX_SNIFF_SIZE = 4096;
@@ -1585,6 +1711,38 @@ export class ShellExecutionService {
               `headlessTerminal.dispose() threw during PTY cleanup: ${e instanceof Error ? e.message : String(e)}`,
             );
           }
+          // Windows: node-pty (ConPTY) fires onExit when it believes the shell
+          // exited, but the pwsh/powershell/cmd process can linger
+          // (microsoft/node-pty#333). We delete from activePtys just below, so
+          // the process-exit cleanup() can never reap it — do it here. The
+          // isPtyActive guard skips the taskkill when the shell exited cleanly
+          // (the healthy case).
+          //
+          // Blast radius depends on why we're exiting. On a *cancel* the user
+          // abandoned the whole command, so tree-kill: performCancelKill's own
+          // taskkill /t may still be in flight or have failed to launch, and a
+          // shell-only reap here could otherwise race it down to killing just
+          // the shell while its descendant tree survives. On cancel this can
+          // therefore fire taskkill a second time (performCancelKill fired the
+          // first) — deliberate, not a redundancy to "optimize away": the
+          // isPtyActive guard means it only runs while the shell is genuinely
+          // still alive, so it is a no-op once the tree is dead and a real
+          // retry when performCancelKill's taskkill never launched. On a
+          // *normal completion* kill only the shell pid, so a child the command
+          // intentionally detached (e.g. Start-Process) outlives it. We use
+          // cancelKillDispatched (set inside performCancelKill, before the shell
+          // exited), NOT a late abortSignal.aborted check — an abort that lands
+          // after a normal exit, during the async finalize window, must not
+          // retro-flag this reap into a tree-kill of detached children.
+          // Background-promote never reaches this finalizer (it disposes
+          // exitDisposable and reaps on its own settle path), so a backgrounded
+          // process is never reaped here. See #5873.
+          if (
+            os.platform() === 'win32' &&
+            ShellExecutionService.isPtyActive(ptyProcess.pid)
+          ) {
+            windowsKillPid(ptyProcess.pid, cancelKillDispatched);
+          }
           this.activePtys.delete(ptyProcess.pid);
         };
 
@@ -1832,6 +1990,20 @@ export class ShellExecutionService {
             // delay could recover them but would complicate the
             // single-fire latch.
             disposePostPromoteListeners();
+            // Windows: a promoted shell can leave its ConPTY pwsh/powershell/cmd
+            // process behind after it settles (microsoft/node-pty#333) — the
+            // same #5873 leak as the foreground path, but the background
+            // lifecycle never reaches disposeForegroundPtyResources. Reap it
+            // here, shell-pid-only: the command has finished (natural exit or
+            // error), so a child it intentionally detached should outlive it.
+            // (Runs before the onSettle early-return so it fires even without an
+            // onSettle handler.) See #5873.
+            if (
+              os.platform() === 'win32' &&
+              ShellExecutionService.isPtyActive(ptyProcess.pid)
+            ) {
+              windowsKillPid(ptyProcess.pid, false);
+            }
             if (!postPromote?.onSettle) return;
             try {
               postPromote.onSettle(info);
@@ -2014,8 +2186,43 @@ export class ShellExecutionService {
 
         const performCancelKill = async (): Promise<void> => {
           if (!ptyProcess.pid || exited) return;
+          // Record that a cancel — not a natural exit — drove this teardown, so
+          // the finalizer reap tree-kills. Guarded by `exited` above, so a late
+          // abort after a normal exit returns early and never sets this.
+          cancelKillDispatched = true;
           if (os.platform() === 'win32') {
-            ptyProcess.kill();
+            // Tree-kill SYNCHRONOUSLY (spawnSync, like windowsStrategy.killPty):
+            // taskkill must enumerate and kill the process tree BEFORE
+            // ptyProcess.kill() below fires ClosePseudoConsole — an async
+            // taskkill could still be launching when the resulting CTRL_CLOSE
+            // exit orphans the descendants, leaking them (the #5873 leak on the
+            // cancel path). ptyProcess.kill() alone doesn't tree-kill under
+            // ConPTY (microsoft/node-pty#333).
+            try {
+              const r = spawnSync(WINDOWS_TASKKILL, [
+                '/f',
+                '/t',
+                '/pid',
+                ptyProcess.pid.toString(),
+              ]);
+              if (r.error || (typeof r.status === 'number' && r.status !== 0)) {
+                debugLogger.warn(
+                  `performCancelKill: taskkill failed for pid ${ptyProcess.pid}: ${r.error?.message ?? `exit ${r.status}`}`,
+                );
+              }
+            } catch (e) {
+              debugLogger.warn(
+                `performCancelKill: taskkill spawn threw for pid ${ptyProcess.pid}: ${e instanceof Error ? e.message : String(e)}`,
+              );
+            }
+            // Then tear down the ConPTY host so onExit fires and the cancel
+            // resolves even if taskkill couldn't kill the tree. Harmless once
+            // the tree is already dead. Mirrors the POSIX branch's kill fallback.
+            try {
+              ptyProcess.kill();
+            } catch {
+              // already gone
+            }
           } else {
             try {
               // Send SIGTERM first to allow graceful shutdown


### PR DESCRIPTION
## What this PR does

On Windows, qwen-code defaults to the interactive-shell PTY path (node-pty / ConPTY), and every tool call spawned a shell whose process tree was never reaped: `ptyProcess.kill()` only tears down the pseudo-console host, not the `pwsh`/`powershell`/`cmd` tree (microsoft/node-pty#333). This change aligns every Windows teardown path on the same tree-kill the child_process fallback already used (`taskkill /f /t`), and adds a guarded reap on normal command completion so a ConPTY-lingering shell is cleaned up regardless of which path it leaked through. Each teardown also gains a fallback so a `taskkill` that cannot launch (or exits non-zero) can neither crash the CLI via an unhandled `'error'` event nor leave a cancel hanging, and the normal-completion reap kills only the shell pid so a process the command intentionally detached (e.g. `Start-Process`) still outlives it.

## Why it's needed

On Windows 11 (ConPTY) every tool call left one idle `pwsh` behind, accumulating until the machine ran out of memory (100% reproducible, v0.19.2). The PTY teardown used a bare `ptyProcess.kill()` that does not tree-kill under ConPTY, while only the child_process fallback tree-killed correctly — so PTY-spawned shells piled up until OOM. Workaround until this ships: `tools.shell.enableInteractiveShell: false` (routes to the child_process path, which already tree-kills).

## Reviewer Test Plan

### How to verify

Automated: `npx vitest run packages/core/src/services/shellExecutionService.test.ts` — 107 tests pass, including new win32 coverage for every taskkill path: cancel tree-kills (with a `ptyProcess.kill` fallback and never a shell-only downgrade); normal completion reaps shell-pid-only (no `/t`); no reap once the shell already exited; non-win32 never taskkills; process-exit cleanup tree-kills and tears down the host (including when taskkill exits non-zero); and the child_process cancel falls back to `child.kill('SIGKILL')` when taskkill cannot launch.

Manual (Windows — I could not reproduce this on macOS, so it needs a Windows verifier): with default settings (interactive shell on), run ~20 tool calls and watch Task Manager — the `pwsh` count should return to baseline instead of climbing. Start a long command (`Start-Sleep 60`) and cancel with Esc; its `pwsh` tree should disappear with no orphan. Quit qwen while a command runs; confirm no leftover `pwsh`. Sanity: a backgrounded command keeps running (the promote path is intentionally not reaped).

### Evidence (Before & After)

The user-visible signal is the Windows `pwsh` process count across a session: Before — climbs by one per tool call without bound (until OOM); After — returns to baseline. Capturing this needs a Windows host and is left for Windows verification; the decision logic is covered by the unit tests above. Non-Windows: N/A — all changes are win32-only branches and the POSIX paths are untouched.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

macOS: unit tests pass. Windows: runtime ConPTY behavior needs a Windows verifier. Linux: not run locally (win32-only branches; non-win32 paths unchanged and exercised by the unit tests).

### Environment (optional)

Unit tests only (`vitest`); no local app runtime.

## Risk & Scope

- Main risk or tradeoff: the normal-completion reap fires only when `isPtyActive(pid)` (a `process.kill(pid, 0)` liveness check) reports the shell still alive, so a healthy node-pty that reaps correctly never triggers an extra `taskkill`. There is a tiny pid-reuse window during the ≤200ms output flush before dispose — the same risk class the existing child_process `taskkill`-by-pid path already accepts.
- Not validated / out of scope: real Windows runtime verification (see Test Plan); no change to PTY defaulting or `tools.shell.enableInteractiveShell`.
- Breaking changes / migration notes: none. All changes are Windows-only teardown branches; POSIX paths and default behavior are unchanged.

## Linked Issues

Fixes #5873

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

Windows 上 qwen-code 默认走交互式 shell 的 PTY 路径（node-pty / ConPTY），每次工具调用起的 shell 进程树从未被回收：`ptyProcess.kill()` 在 ConPTY 下只拆伪终端宿主，杀不掉 `pwsh`/`powershell`/`cmd` 进程树（microsoft/node-pty#333）。本 PR 把 Windows 上所有 teardown 路径都对齐到 child_process 兜底路径早已使用的树杀（`taskkill /f /t`），并在命令正常完成时加一个有守卫的回收，使得无论从哪条路径泄漏的滞留 shell 都能被清理。每个 teardown 还都加了兜底：当 `taskkill` 起不来（或非 0 退出）时，既不会因未处理的 `'error'` 事件崩溃 CLI，也不会让取消操作卡死；而正常完成的回收只杀 shell 自身 pid，所以命令故意 detach 的进程（如 `Start-Process`）仍能存活。

## 为什么需要

Windows 11（ConPTY）下每次工具调用都残留一个 idle `pwsh`，不断累积直到机器内存耗尽（100% 复现，v0.19.2）。PTY 的清理用的是裸 `ptyProcess.kill()`，在 ConPTY 下不树杀；只有 child_process 兜底路径正确树杀——于是 PTY 起的 shell 一直堆积到 OOM。发布前的临时规避：`tools.shell.enableInteractiveShell: false`（回退到能正确树杀的 child_process 路径）。

## 验证方式

自动化：`npx vitest run packages/core/src/services/shellExecutionService.test.ts` —— 107 个测试通过，新增覆盖了全部 win32 taskkill 路径：取消树杀（带 `ptyProcess.kill` 兜底、且绝不降级为 shell-only）；正常完成只杀 shell pid（不带 `/t`）；shell 已退出则不回收；非 win32 永不 taskkill；进程退出清理树杀并拆 host（含 taskkill 非 0 退出）；child_process 取消在 taskkill 起不来时回退 `child.kill('SIGKILL')`。

手工（Windows —— 我在 macOS 上无法复现，需 Windows 验证）：默认设置（交互式 shell 开）下连续跑约 20 次工具调用，看任务管理器 `pwsh` 数应回落而非攀升；`Start-Sleep 60` 后按 Esc 取消，其 `pwsh` 树应消失、无残留；命令运行时退出 qwen，确认无残留 `pwsh`；同时确认后台化的命令仍存活（promote 路径有意不回收）。

## 风险与范围

- 主要风险：正常完成的回收仅在 `isPtyActive(pid)`（`process.kill(pid, 0)` 存活检查）报告 shell 仍存活时才触发，因此健康的 node-pty 永不会多跑一次 `taskkill`。在 dispose 前 ≤200ms 的输出 flush 期间有一个极小的 pid 复用窗口——与既有 child_process `taskkill`-by-pid 路径承担的是同一类风险。
- 未验证 / 范围外：真实 Windows 运行时验证（见测试计划）；不改 PTY 默认开关与 `tools.shell.enableInteractiveShell`。
- 破坏性变更：无。全部为 Windows-only teardown 分支；POSIX 路径与默认行为不变。

## 关联 Issue

Fixes #5873

</details>
