### PR TITLE
Fix mid-input skill command completion

### DIFF
--- a/packages/cli/src/ui/components/SuggestionsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.test.tsx
@@ -143,6 +143,32 @@ describe('SuggestionsDisplay', () => {
     expect(output).toContain('First line of the skill description.');
     expect(output).toContain('- bullet one - bullet two');
   });
+
+  it('renders a visible marker for the active suggestion', () => {
+    const { lastFrame } = render(
+      <SuggestionsDisplay
+        suggestions={[
+          { label: 'pr', value: 'pr', description: 'Pull request helper' },
+          {
+            label: 'issue-to-pr',
+            value: 'issue-to-pr',
+            description: 'Issue helper',
+          },
+        ]}
+        activeIndex={1}
+        isLoading={false}
+        width={80}
+        scrollOffset={0}
+        userInput="/pr"
+        mode="slash"
+      />,
+    );
+
+    const lines = (lastFrame() ?? '').split('\n');
+
+    expect(lines[0]).toMatch(/^  pr/);
+    expect(lines[1]).toMatch(/^> issue-to-pr/);
+  });
 });
 
 describe('normalizeDescription', () => {

--- a/packages/cli/src/ui/components/SuggestionsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.test.tsx
@@ -166,7 +166,7 @@ describe('SuggestionsDisplay', () => {
 
     const lines = (lastFrame() ?? '').split('\n');
 
-    expect(lines[0]).toMatch(/^  pr/);
+    expect(lines[0]).toMatch(/^ {2}pr/);
     expect(lines[1]).toMatch(/^> issue-to-pr/);
   });
 });

--- a/packages/cli/src/ui/components/SuggestionsDisplay.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.tsx
@@ -61,6 +61,7 @@ export { MAX_WIDTH };
  * shrink the description away entirely.
  */
 const MIN_DESCRIPTION_WIDTH = 12;
+const ACTIVE_MARKER_WIDTH = 2;
 
 /**
  * Collapse all runs of whitespace (including newlines from multi-line
@@ -118,13 +119,14 @@ export function SuggestionsDisplay({
   const describedLabelLengths = suggestions
     .filter((s) => s.description)
     .map((s) => getFullLabel(s).length);
+  const contentWidth = Math.max(width - ACTIVE_MARKER_WIDTH, 1);
   const labelColumnWidth =
     mode === 'slash'
-      ? Math.min(maxLabelLength, Math.floor(width * 0.5))
+      ? Math.min(maxLabelLength, Math.floor(contentWidth * 0.5))
       : describedLabelLengths.length > 0
         ? Math.min(
             Math.max(...describedLabelLengths),
-            Math.max(width - MIN_DESCRIPTION_WIDTH - 2, 1),
+            Math.max(contentWidth - MIN_DESCRIPTION_WIDTH - 2, 1),
           )
         : 0;
 
@@ -141,7 +143,7 @@ export function SuggestionsDisplay({
         const isLong = displayLabel.length >= MAX_WIDTH;
         const expansionIndicatorWidth = isActive && isLong ? 3 : 0;
         const descriptionColumnWidth = Math.max(
-          width - labelColumnWidth - 2 - expansionIndicatorWidth,
+          contentWidth - labelColumnWidth - 2 - expansionIndicatorWidth,
           1,
         );
         const labelElement = (
@@ -156,6 +158,9 @@ export function SuggestionsDisplay({
 
         return (
           <Box key={`${suggestion.value}-${originalIndex}`} flexDirection="row">
+            <Box width={ACTIVE_MARKER_WIDTH} flexShrink={0}>
+              <Text color={textColor}>{isActive ? '> ' : '  '}</Text>
+            </Box>
             <Box
               {...(mode === 'slash' || suggestion.description
                 ? { width: labelColumnWidth, flexShrink: 0 as const }

--- a/packages/cli/src/ui/components/__snapshots__/InputPrompt.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/InputPrompt.test.tsx.snap
@@ -4,31 +4,32 @@ exports[`InputPrompt > command search (Ctrl+R when not in shell) > expands and c
 "────────────────────────────────────────────────────────────────────────────────
 (r:)    Type your message or @path/to/file
 ────────────────────────────────────────────────────────────────────────────────────────────────────
-  lllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll →
-  lllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll..."
+  > lllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll →
+    lllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll
+    ..."
 `;
 
 exports[`InputPrompt > command search (Ctrl+R when not in shell) > expands and collapses long suggestion via Right/Left arrows > command-search-expanded-match 1`] = `
 "────────────────────────────────────────────────────────────────────────────────
 (r:)    Type your message or @path/to/file
 ────────────────────────────────────────────────────────────────────────────────────────────────────
-  lllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll ←
-  lllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll
-  llllllllllllllllllllllllllllllllllllllllllllll"
+  > lllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll ←
+    lllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll
+    llllllllllllllllllllllllllllllllllllllllllllllllll"
 `;
 
 exports[`InputPrompt > command search (Ctrl+R when not in shell) > renders match window and expanded view (snapshots) > command-search-collapsed-match 1`] = `
 "────────────────────────────────────────────────────────────────────────────────
 (r:)  commit ​
 ────────────────────────────────────────────────────────────────────────────────────────────────────
-  git commit -m "feat: add search" in src/app"
+  > git commit -m "feat: add search" in src/app"
 `;
 
 exports[`InputPrompt > command search (Ctrl+R when not in shell) > renders match window and expanded view (snapshots) > command-search-expanded-match 1`] = `
 "────────────────────────────────────────────────────────────────────────────────
 (r:)  commit ​
 ────────────────────────────────────────────────────────────────────────────────────────────────────
-  git commit -m "feat: add search" in src/app"
+  > git commit -m "feat: add search" in src/app"
 `;
 
 exports[`InputPrompt > snapshots > should not show inverted cursor when shell is focused 1`] = `

--- a/packages/cli/src/ui/hooks/useCommandCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.test.ts
@@ -505,6 +505,50 @@ describe('useCommandCompletion', () => {
       });
     });
 
+    it('should use slash completion for mid-input model-invocable commands', async () => {
+      const skillCommand: SlashCommand = {
+        name: 'front-end-store-rules',
+        description: 'Store rules',
+        kind: CommandKind.SKILL,
+        modelInvocable: true,
+      };
+      const builtInCommand: SlashCommand = {
+        name: 'clear',
+        description: 'Clear conversation',
+        kind: CommandKind.BUILT_IN,
+        modelInvocable: false,
+      };
+
+      setupMocks({
+        slashSuggestions: [
+          { label: 'front-end-store-rules', value: 'front-end-store-rules' },
+        ],
+      });
+
+      const { result } = renderHook(() =>
+        useCommandCompletion(
+          useTextBufferForTest('please /store'),
+          testRootDir,
+          [skillCommand, builtInCommand],
+          mockCommandContext,
+          false,
+          mockConfig,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(result.current.showSuggestions).toBe(true);
+      });
+
+      expect(useSlashCompletion).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          enabled: true,
+          query: '/store',
+          slashCommands: [skillCommand],
+        }),
+      );
+    });
+
     it('should complete a file path when @ appears after a slash command', async () => {
       setupMocks({
         atSuggestions: [{ label: 'src/index.ts', value: 'src/index.ts' }],
@@ -565,6 +609,47 @@ describe('useCommandCompletion', () => {
       });
 
       expect(result.current.textBuffer.text).toBe('/memory ');
+    });
+
+    it('should complete the mid-input slash token at the cursor', async () => {
+      setupMocks({
+        slashSuggestions: [
+          { label: 'front-end-store-rules', value: 'front-end-store-rules' },
+        ],
+        slashCompletionRange: { completionStart: 1, completionEnd: 4 },
+      });
+
+      const { result } = renderHook(() => {
+        const textBuffer = useTextBufferForTest('please /review /sto');
+        const completion = useCommandCompletion(
+          textBuffer,
+          testRootDir,
+          [
+            {
+              name: 'front-end-store-rules',
+              description: 'Store rules',
+              kind: CommandKind.SKILL,
+              modelInvocable: true,
+            },
+          ],
+          mockCommandContext,
+          false,
+          mockConfig,
+        );
+        return { ...completion, textBuffer };
+      });
+
+      await waitFor(() => {
+        expect(result.current.suggestions.length).toBe(1);
+      });
+
+      act(() => {
+        result.current.handleAutocomplete(0);
+      });
+
+      expect(result.current.textBuffer.text).toBe(
+        'please /review /front-end-store-rules ',
+      );
     });
 
     it('should complete a file path', async () => {
@@ -735,7 +820,7 @@ describe('useCommandCompletion', () => {
       });
     });
 
-    it('shows mid-input ghost text for model-invocable commands', () => {
+    it('does not show ghost text while dropdown handles partial mid-input commands', () => {
       const slashCommands: SlashCommand[] = [
         {
           name: 'review',
@@ -764,12 +849,7 @@ describe('useCommandCompletion', () => {
         return completion;
       });
 
-      expect(result.current.midInputGhostText).toEqual({
-        text: 'iew',
-        insertPosition: 'please /rev'.length,
-        acceptText: 'iew',
-        showCursorBeforeText: false,
-      });
+      expect(result.current.midInputGhostText).toBeNull();
     });
 
     it('shows argumentHint for a complete mid-input model-invocable command', () => {

--- a/packages/cli/src/ui/hooks/useCommandCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.test.ts
@@ -652,6 +652,43 @@ describe('useCommandCompletion', () => {
       );
     });
 
+    it('should complete a bare mid-input slash without inserting a space', async () => {
+      setupMocks({
+        slashSuggestions: [{ label: 'review', value: 'review' }],
+        slashCompletionRange: { completionStart: 1, completionEnd: 1 },
+      });
+
+      const { result } = renderHook(() => {
+        const textBuffer = useTextBufferForTest('please /');
+        const completion = useCommandCompletion(
+          textBuffer,
+          testRootDir,
+          [
+            {
+              name: 'review',
+              description: 'Review PR',
+              kind: CommandKind.BUILT_IN,
+              modelInvocable: true,
+            },
+          ],
+          mockCommandContext,
+          false,
+          mockConfig,
+        );
+        return { ...completion, textBuffer };
+      });
+
+      await waitFor(() => {
+        expect(result.current.suggestions.length).toBe(1);
+      });
+
+      act(() => {
+        result.current.handleAutocomplete(0);
+      });
+
+      expect(result.current.textBuffer.text).toBe('please /review ');
+    });
+
     it('should complete a file path', async () => {
       setupMocks({
         atSuggestions: [{ label: 'src/file1.txt', value: 'src/file1.txt' }],

--- a/packages/cli/src/ui/hooks/useCommandCompletion.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.tsx
@@ -283,7 +283,8 @@ export function useCommandCompletion(
         if (
           start === end &&
           start > 1 &&
-          (buffer.lines[cursorRow] || '')[start - 1] !== ' '
+          (buffer.lines[cursorRow] || '')[start - 1] !== ' ' &&
+          (buffer.lines[cursorRow] || '')[start - 1] !== '/'
         ) {
           suggestionText = ' ' + suggestionText;
         }

--- a/packages/cli/src/ui/hooks/useCommandCompletion.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.tsx
@@ -13,6 +13,7 @@ import {
   isSlashCommand,
   findMidInputSlashCommand,
   getBestSlashCommandMatch,
+  isMidInputCompletableCommand,
 } from '../utils/commandUtils.js';
 import { toCodePoints } from '../utils/textUtils.js';
 import { useAtCompletion } from './useAtCompletion.js';
@@ -35,14 +36,12 @@ function isExactMidInputModelInvocableCommand(
   slashCommands: readonly SlashCommand[],
 ): boolean {
   const query = partialCommand.toLowerCase();
+  // Match canonical names only. The ghost-text fallback (getBestSlashCommandMatch)
+  // matches names too, so an exact altName routes through the dropdown instead —
+  // fzf surfaces altNames there, avoiding a no-feedback dead zone.
   return slashCommands.some(
     (cmd) =>
-      cmd.modelInvocable === true &&
-      !cmd.hidden &&
-      (cmd.name.toLowerCase() === query ||
-        (cmd.altNames ?? []).some(
-          (altName) => altName.toLowerCase() === query,
-        )),
+      isMidInputCompletableCommand(cmd) && cmd.name.toLowerCase() === query,
   );
 }
 
@@ -178,7 +177,7 @@ export function useCommandCompletion(
   const slashCommandsForCompletion = useMemo(
     () =>
       isMidInputSlashCompletion
-        ? slashCommands.filter((cmd) => cmd.modelInvocable === true)
+        ? slashCommands.filter(isMidInputCompletableCommand)
         : slashCommands,
     [isMidInputSlashCompletion, slashCommands],
   );

--- a/packages/cli/src/ui/hooks/useCommandCompletion.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.tsx
@@ -30,6 +30,22 @@ export enum CompletionMode {
   SLASH = 'SLASH',
 }
 
+function isExactMidInputModelInvocableCommand(
+  partialCommand: string,
+  slashCommands: readonly SlashCommand[],
+): boolean {
+  const query = partialCommand.toLowerCase();
+  return slashCommands.some(
+    (cmd) =>
+      cmd.modelInvocable === true &&
+      !cmd.hidden &&
+      (cmd.name.toLowerCase() === query ||
+        (cmd.altNames ?? []).some(
+          (altName) => altName.toLowerCase() === query,
+        )),
+  );
+}
+
 export interface UseCommandCompletionReturn {
   suggestions: Suggestion[];
   activeSuggestionIndex: number;
@@ -68,66 +84,104 @@ export function useCommandCompletion(
   const cursorRow = buffer.cursor[0];
   const cursorCol = buffer.cursor[1];
 
-  const { completionMode, query, completionStart, completionEnd } =
-    useMemo(() => {
-      const currentLine = buffer.lines[cursorRow] || '';
+  const {
+    completionMode,
+    query,
+    completionStart,
+    completionEnd,
+    isMidInputSlashCompletion,
+  } = useMemo(() => {
+    const currentLine = buffer.lines[cursorRow] || '';
 
-      // Check for @ completion first, so that typing @ after a slash command
-      // still triggers file search (see #2518).
-      const codePoints = toCodePoints(currentLine);
-      for (let i = cursorCol - 1; i >= 0; i--) {
-        const char = codePoints[i];
+    // Check for @ completion first, so that typing @ after a slash command
+    // still triggers file search (see #2518).
+    const codePoints = toCodePoints(currentLine);
+    for (let i = cursorCol - 1; i >= 0; i--) {
+      const char = codePoints[i];
 
-        if (char === ' ') {
-          let backslashCount = 0;
-          for (let j = i - 1; j >= 0 && codePoints[j] === '\\'; j--) {
-            backslashCount++;
-          }
-          if (backslashCount % 2 === 0) {
-            break;
-          }
-        } else if (char === '@' && (i === 0 || /\s/.test(codePoints[i - 1]))) {
-          let end = codePoints.length;
-          for (let i = cursorCol; i < codePoints.length; i++) {
-            if (codePoints[i] === ' ') {
-              let backslashCount = 0;
-              for (let j = i - 1; j >= 0 && codePoints[j] === '\\'; j--) {
-                backslashCount++;
-              }
+      if (char === ' ') {
+        let backslashCount = 0;
+        for (let j = i - 1; j >= 0 && codePoints[j] === '\\'; j--) {
+          backslashCount++;
+        }
+        if (backslashCount % 2 === 0) {
+          break;
+        }
+      } else if (char === '@' && (i === 0 || /\s/.test(codePoints[i - 1]))) {
+        let end = codePoints.length;
+        for (let i = cursorCol; i < codePoints.length; i++) {
+          if (codePoints[i] === ' ') {
+            let backslashCount = 0;
+            for (let j = i - 1; j >= 0 && codePoints[j] === '\\'; j--) {
+              backslashCount++;
+            }
 
-              if (backslashCount % 2 === 0) {
-                end = i;
-                break;
-              }
+            if (backslashCount % 2 === 0) {
+              end = i;
+              break;
             }
           }
-          const pathStart = i + 1;
-          const partialPath = currentLine.substring(pathStart, end);
-          return {
-            completionMode: CompletionMode.AT,
-            query: partialPath,
-            completionStart: pathStart,
-            completionEnd: end,
-          };
         }
-      }
-
-      if (cursorRow === 0 && isSlashCommand(currentLine.trim())) {
+        const pathStart = i + 1;
+        const partialPath = currentLine.substring(pathStart, end);
         return {
-          completionMode: CompletionMode.SLASH,
-          query: currentLine,
-          completionStart: 0,
-          completionEnd: currentLine.length,
+          completionMode: CompletionMode.AT,
+          query: partialPath,
+          completionStart: pathStart,
+          completionEnd: end,
+          isMidInputSlashCompletion: false,
         };
       }
+    }
 
+    if (cursorRow === 0 && isSlashCommand(currentLine.trim())) {
       return {
-        completionMode: CompletionMode.IDLE,
-        query: null,
-        completionStart: -1,
-        completionEnd: -1,
+        completionMode: CompletionMode.SLASH,
+        query: currentLine,
+        completionStart: 0,
+        completionEnd: currentLine.length,
+        isMidInputSlashCompletion: false,
       };
-    }, [cursorRow, cursorCol, buffer.lines]);
+    }
+
+    const cursorOffset = logicalPosToOffset(buffer.lines, cursorRow, cursorCol);
+    const midCmd = findMidInputSlashCommand(buffer.text, cursorOffset);
+    if (
+      midCmd &&
+      !isExactMidInputModelInvocableCommand(
+        midCmd.partialCommand,
+        slashCommands,
+      )
+    ) {
+      const lineStartOffset = logicalPosToOffset(buffer.lines, cursorRow, 0);
+      const startOnLine = midCmd.startPos - lineStartOffset;
+      if (startOnLine >= 0) {
+        return {
+          completionMode: CompletionMode.SLASH,
+          query: midCmd.token,
+          completionStart: startOnLine,
+          completionEnd: startOnLine + midCmd.token.length,
+          isMidInputSlashCompletion: true,
+        };
+      }
+    }
+
+    return {
+      completionMode: CompletionMode.IDLE,
+      query: null,
+      completionStart: -1,
+      completionEnd: -1,
+      isMidInputSlashCompletion: false,
+    };
+  }, [cursorRow, cursorCol, buffer.lines, buffer.text, slashCommands]);
+
+  const slashCommandsForCompletion = useMemo(
+    () =>
+      isMidInputSlashCompletion
+        ? slashCommands.filter((cmd) => cmd.modelInvocable === true)
+        : slashCommands,
+    [isMidInputSlashCompletion, slashCommands],
+  );
 
   const {
     suggestions,
@@ -163,7 +217,7 @@ export function useCommandCompletion(
   const slashCompletionRange = useSlashCompletion({
     enabled: completionMode === CompletionMode.SLASH,
     query,
-    slashCommands,
+    slashCommands: slashCommandsForCompletion,
     commandContext,
     recentCommands,
     setSuggestions,
@@ -275,6 +329,7 @@ export function useCommandCompletion(
     const cursorOffset = logicalPosToOffset(buffer.lines, cursorRow, cursorCol);
     const midCmd = findMidInputSlashCommand(buffer.text, cursorOffset);
     if (midCmd) {
+      if (isMidInputSlashCompletion) return null;
       const match = getBestSlashCommandMatch(
         midCmd.partialCommand,
         slashCommands,
@@ -320,6 +375,7 @@ export function useCommandCompletion(
     active,
     reverseSearchActive,
     recentCommands,
+    isMidInputSlashCompletion,
   ]);
 
   return {

--- a/packages/cli/src/ui/utils/commandUtils.test.ts
+++ b/packages/cli/src/ui/utils/commandUtils.test.ts
@@ -685,6 +685,21 @@ describe('findMidInputSlashCommand', () => {
     // "hello/review", no space before slash
     expect(findMidInputSlashCommand('hello/review', 12)).toBeNull();
   });
+
+  it('handles a non-BMP prefix before the token (code-point offsets)', () => {
+    // "please 👍 /sto": 👍 is one code point but two UTF-16 units, so the
+    // code-point cursor offset (13) is one short of the UTF-16 offset (14).
+    // A UTF-16-based implementation slices one char early and returns null.
+    const input = 'please 👍 /sto';
+    const cursorOffset = [...input].length; // 13 code points, cursor at end
+    expect(cursorOffset).toBe(13);
+    const result = findMidInputSlashCommand(input, cursorOffset);
+    expect(result).toEqual({
+      token: '/sto',
+      startPos: 9, // code-point index of "/"
+      partialCommand: 'sto',
+    });
+  });
 });
 
 describe('findSlashCommandTokens', () => {

--- a/packages/cli/src/ui/utils/commandUtils.ts
+++ b/packages/cli/src/ui/utils/commandUtils.ts
@@ -10,6 +10,7 @@ import { createDebugLogger } from '@qwen-code/qwen-code-core';
 import type { SlashCommand } from '../commands/types.js';
 import type { RecentSlashCommands } from '../hooks/useSlashCompletion.js';
 import { writeOsc52 } from './clipboardUtils.js';
+import { toCodePoints } from './textUtils.js';
 
 /**
  * Common Windows console code pages (CP) used for encoding conversions.
@@ -226,11 +227,25 @@ export type MidInputSlashCommand = {
 };
 
 /**
+ * A slash command is completable mid-input (not at the start of the line) only
+ * when it is model-invocable and not hidden: built-in commands typed in the
+ * middle of text won't be executed, and hidden commands shouldn't surface.
+ * Shared so the dropdown filter, ghost-text fallback, and exact-match suppressor
+ * all agree on which commands qualify.
+ */
+export function isMidInputCompletableCommand(cmd: SlashCommand): boolean {
+  return cmd.modelInvocable === true && !cmd.hidden;
+}
+
+/**
  * Finds a slash command token that appears mid-input (not at position 0).
  * Only triggers when the "/" is preceded by whitespace and the cursor is
  * right at or within the partial command (no text between cursor and slash).
  *
  * Returns null when input starts with "/" (handled by start-of-line completion).
+ *
+ * `cursorOffset` and all returned positions are code-point offsets, so non-BMP
+ * characters before the token (e.g. "please 👍 /sto") don't skew the result.
  */
 export function findMidInputSlashCommand(
   input: string,
@@ -239,17 +254,22 @@ export function findMidInputSlashCommand(
   // Start-of-line slash handled by existing dropdown completion
   if (input.startsWith('/')) return null;
 
-  const beforeCursor = input.slice(0, cursorOffset);
+  // Work in code points. The slash and command chars are always BMP, so once we
+  // anchor on the slash, lengths map 1:1 to UTF-16 — only the prefix can drift.
+  const codePoints = toCodePoints(input);
+  const beforeCursor = codePoints.slice(0, cursorOffset).join('');
 
   // Match: whitespace then "/" then optional command chars, anchored at end
   // Capture whitespace instead of lookbehind to avoid JSC JIT regression
   const match = beforeCursor.match(/\s\/([a-zA-Z0-9_:-]*)$/);
-  if (!match || match.index === undefined) return null;
+  if (!match) return null;
 
-  const slashPos = match.index + 1; // +1 to skip the captured whitespace char
-  const textAfterSlash = input.slice(slashPos + 1);
+  // Command chars before the cursor; slash sits one code point ahead of them.
+  const partialCommand = match[1];
+  const slashPos = cursorOffset - 1 - partialCommand.length;
 
   // Extend to next space (or end of input) to find the full command name
+  const textAfterSlash = codePoints.slice(slashPos + 1).join('');
   const commandMatch = textAfterSlash.match(/^[a-zA-Z0-9_:-]*/);
   const fullCommand = commandMatch ? commandMatch[0] : '';
 
@@ -260,7 +280,7 @@ export function findMidInputSlashCommand(
   return {
     token: '/' + fullCommand,
     startPos: slashPos,
-    partialCommand: input.slice(slashPos + 1, cursorOffset),
+    partialCommand,
   };
 }
 
@@ -285,9 +305,7 @@ export function getBestSlashCommandMatch(
 
   const matches = commands
     .filter((cmd) => {
-      // Only suggest model-invocable commands for mid-input completion,
-      // since built-in commands typed in the middle of text won't be executed.
-      if (!cmd.modelInvocable) return false;
+      if (!isMidInputCompletableCommand(cmd)) return false;
       const name = cmd.name.toLowerCase();
       return name.startsWith(query) && (name !== query || !!cmd.argumentHint);
     })


### PR DESCRIPTION
## What this PR does

Makes slash-command mentions typed after other prompt text use the same suggestion menu as line-start slash commands. Mid-input skill mentions now get fuzzy matching, menu navigation, and token replacement for the slash token under the cursor. Fully typed mid-input commands still keep the inline argument hint behavior.

## Why it is needed

Issue #5875 showed that `/store` works when typed at the start of the prompt, but the same skill mention after existing text falls back to shadow text and behaves inconsistently. The second skill mention in the same prompt could also miss the expected completion path. Reusing the existing slash suggestion path keeps line-start and mid-input skill discovery consistent.

## Reviewer Test Plan

### How to verify

Type text followed by a model-invocable skill mention such as `please /store`; the regular slash suggestion menu should open and should include matching commands by a middle segment. Accepting a suggestion in a prompt with an earlier mention, such as `please /review /sto`, should replace only the slash token at the cursor and preserve the earlier mention.

Focused checks run locally:
- `npx vitest run src/ui/hooks/useCommandCompletion.test.ts src/ui/hooks/useSlashCompletion.test.ts src/ui/hooks/useSlashCompletion.integration.test.ts` — 61 tests passed
- `npx eslint src/ui/hooks/useCommandCompletion.tsx src/ui/hooks/useCommandCompletion.test.ts` — passed
- `npx prettier --check packages/cli/src/ui/hooks/useCommandCompletion.tsx packages/cli/src/ui/hooks/useCommandCompletion.test.ts` — passed
- `npm run build` — passed, with existing warnings from VS Code companion lint plus Browserslist and chunk-size warnings
- `npm -w packages/cli run typecheck` — passed

### Evidence (Before & After)

Before: line-start `/store` used fuzzy menu matching, but mid-input `/store` used inline shadow completion and did not show the same candidate list. A second mid-input slash mention could fail to complete through the menu path.

After: mid-input partial skill mentions use the slash suggestion menu, filter to model-invocable commands, and replace only the slash token at the cursor. This is covered by focused hook tests for `please /store` and `please /review /sto`.

<img width="1812" height="874" alt="image" src="https://github.com/user-attachments/assets/7740eb61-40e0-4c2d-9c0f-153dbd0e7278" />


### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Clean worktree based on latest `origin/main`, Node.js 22.22.0, dependencies installed with `npm install --ignore-scripts`.

## Risk & Scope

- Main risk or tradeoff: Mid-input slash suggestions now open the full menu for partial model-invocable commands, so this changes the UI from ghost-text-only to menu-based completion for that case.
- Not validated / out of scope: Manual TUI screenshots on Windows and Linux.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5875

<details>
<summary>中文说明</summary>

## What this PR does

让 prompt 中已有文本后面的 slash 命令提及使用和行首 slash 命令相同的候选菜单。中间位置的 skill mention 现在支持模糊匹配、菜单导航，并且接受候选时只替换光标所在的 slash token。已经完整输入的中间命令仍保留参数提示的 ghost text 行为。

## Why it is needed

Issue #5875 显示，`/store` 在 prompt 开头输入时可以正常走模糊候选菜单，但同一个 skill mention 出现在已有文本之后时，会退回到 shadow text，并表现得不一致。同一个 prompt 里的第二个 skill mention 也可能没有走到预期的补全路径。复用现有 slash suggestion 路径可以让行首和中间位置的 skill 查找行为保持一致。

## Reviewer Test Plan

### How to verify

输入一段文本后接一个 model-invocable skill mention，例如 `please /store`；常规 slash 候选菜单应该打开，并且可以通过名称中间片段匹配候选。在已有一个 mention 的 prompt 里接受另一个候选，例如 `please /review /sto`，应该只替换光标所在的 slash token，并保留前面的 mention。

本地已运行的聚焦检查：
- `npx vitest run src/ui/hooks/useCommandCompletion.test.ts src/ui/hooks/useSlashCompletion.test.ts src/ui/hooks/useSlashCompletion.integration.test.ts` — 61 tests passed
- `npx eslint src/ui/hooks/useCommandCompletion.tsx src/ui/hooks/useCommandCompletion.test.ts` — passed
- `npx prettier --check packages/cli/src/ui/hooks/useCommandCompletion.tsx packages/cli/src/ui/hooks/useCommandCompletion.test.ts` — passed
- `npm run build` — passed，但有 VS Code companion lint、Browserslist 和 chunk-size 的既有 warning
- `npm -w packages/cli run typecheck` — passed

### Evidence (Before & After)

Before：行首 `/store` 会使用 fuzzy menu matching，但中间位置的 `/store` 使用 inline shadow completion，不显示同一套候选列表。第二个中间位置的 slash mention 也可能无法通过菜单路径完成补全。

After：中间位置的 partial skill mention 使用 slash suggestion menu，只展示 model-invocable 命令，并且只替换光标所在的 slash token。`please /store` 和 `please /review /sto` 的聚焦 hook 测试覆盖了这个行为。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

基于最新 `origin/main` 的干净 worktree，Node.js 22.22.0，依赖通过 `npm install --ignore-scripts` 安装。

## Risk & Scope

- Main risk or tradeoff：中间位置的 partial slash suggestion 现在会打开完整候选菜单，这会把该场景从仅 ghost text 改为 menu-based completion。
- Not validated / out of scope：没有在 Windows 和 Linux 上做手工 TUI 截图验证。
- Breaking changes / migration notes：无。

## Linked Issues

Fixes #5875

</details>