### PR TITLE
[codex] test(ci): cover post-merge review follow-ups

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -355,7 +355,7 @@ jobs:
                 fi
               done
           git worktree prune -v || true
-          echo "stale review worktrees cleaned"
+          echo "stale agent state cleaned"
 
       # SECURITY: checkout trusted base code; /review fetches PR diff context.
       - name: 'Checkout base branch'

--- a/packages/core/src/config/config-session-env.test.ts
+++ b/packages/core/src/config/config-session-env.test.ts
@@ -108,7 +108,7 @@ const baseParams: ConfigParameters = {
 // flag resets). That cold transform+evaluate runs several seconds and, under
 // a contended CI runner, crosses the 5s default — a flaky timeout, not a hang.
 // The reset is load-bearing for what these tests check, so give them headroom.
-vi.setConfig({ testTimeout: 30_000 });
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 describe('Config sessionEnvClaimed guard', () => {
   let originalEnv: string | undefined;

--- a/packages/core/src/skills/skill-activation.test.ts
+++ b/packages/core/src/skills/skill-activation.test.ts
@@ -5,7 +5,7 @@
  */
 
 import * as path from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
   SkillActivationRegistry,
   resolveProjectRelativePath,
@@ -245,7 +245,6 @@ describe('extractToolFilePaths → SkillActivationRegistry integration', () => {
   // These tests `await import('../core/coreToolScheduler.js')` just to reach
   // one pure helper, but that drags in the whole scheduler module graph cold.
   // Under a contended CI runner, that can cross the 5s default timeout.
-  vi.setConfig({ testTimeout: 30_000 });
 
   // Regression: feed the real candidate output for a `glob` call into
   // the registry and assert end-to-end activation. The earlier per-field
@@ -271,7 +270,7 @@ describe('extractToolFilePaths → SkillActivationRegistry integration', () => {
       for (const n of reg.matchAndConsume(c)) activated.add(n);
     }
     expect(Array.from(activated)).toEqual(['tsx-helper']);
-  });
+  }, 30_000);
 
   it('does NOT activate from external glob.path (project-root guard wins)', async () => {
     const { extractToolFilePaths } = await import(
@@ -290,5 +289,5 @@ describe('extractToolFilePaths → SkillActivationRegistry integration', () => {
       for (const n of reg.matchAndConsume(c)) activated.add(n);
     }
     expect(activated.size).toBe(0);
-  });
+  }, 30_000);
 });

--- a/packages/core/src/skills/skill-activation.test.ts
+++ b/packages/core/src/skills/skill-activation.test.ts
@@ -13,12 +13,6 @@ import {
 } from './skill-activation.js';
 import type { SkillConfig } from './types.js';
 
-// The integration tests below `await import('../core/coreToolScheduler.js')`
-// just to reach one pure helper, but that drags in the whole scheduler module
-// graph cold. The first such import runs a few seconds and, under a contended
-// CI runner, crosses the 5s default — a flaky timeout, not a hang.
-vi.setConfig({ testTimeout: 30_000 });
-
 function makeSkill(overrides: Partial<SkillConfig>): SkillConfig {
   return {
     name: overrides.name ?? 'test-skill',
@@ -248,6 +242,11 @@ describe('resolveProjectRelativePath', () => {
 });
 
 describe('extractToolFilePaths → SkillActivationRegistry integration', () => {
+  // These tests `await import('../core/coreToolScheduler.js')` just to reach
+  // one pure helper, but that drags in the whole scheduler module graph cold.
+  // Under a contended CI runner, that can cross the 5s default timeout.
+  vi.setConfig({ testTimeout: 30_000 });
+
   // Regression: feed the real candidate output for a `glob` call into
   // the registry and assert end-to-end activation. The earlier per-field
   // extraction (path + pattern as separate candidates) silently failed

--- a/scripts/tests/qwen-resolve-workflow.test.js
+++ b/scripts/tests/qwen-resolve-workflow.test.js
@@ -14,6 +14,31 @@ const repoRoot = path.resolve(
   '../..',
 );
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function job(workflow, name) {
+  const start = workflow.indexOf(`\n  ${name}:`);
+  if (start === -1) {
+    return '';
+  }
+  const nextJob = workflow.slice(start + 1).search(/\n {2}\S/);
+  return nextJob === -1
+    ? workflow.slice(start)
+    : workflow.slice(start, start + 1 + nextJob);
+}
+
+function step(section, name) {
+  const escaped = escapeRegExp(name);
+  const match = section.match(
+    new RegExp(
+      `\\n\\s+- name:\\s*(['"])${escaped}\\1[\\s\\S]*?(?=\\n\\s+- name:\\s*['"]|\\n\\s{2}[a-zA-Z0-9_-]+:|$)`,
+    ),
+  );
+  return match?.[0] ?? '';
+}
+
 describe('qwen resolve workflow', () => {
   const workflow = readFileSync(
     path.join(repoRoot, '.github/workflows/qwen-code-pr-review.yml'),
@@ -88,6 +113,18 @@ describe('qwen resolve workflow', () => {
     expect(workflow).not.toContain('qwen-fix-conflicts');
   });
 
+  it('isolates review agent state per run', () => {
+    const cleanStep = step(reviewJob, 'Clean stale agent state');
+    const agentStep = step(reviewJob, 'Run review');
+
+    expect(cleanStep).toContain('QWEN_HOME="${RUNNER_TEMP:?}/qwen-home"');
+    expect(cleanStep).toContain('rm -rf "$QWEN_HOME"');
+    expect(cleanStep).toContain('mkdir -p "$QWEN_HOME"');
+    expect(cleanStep).toContain('rm -f /tmp/stage-*.md');
+    expect(cleanStep).toContain('echo "stale agent state cleaned"');
+    expect(agentStep).toContain("QWEN_HOME: '${{ runner.temp }}/qwen-home'");
+  });
+
   // Whole-file `toContain` cannot tell which job a guard lives on. Slice the
   // resolve-pr job so these assertions fail if a future edit drops a guard
   // specifically from the credentialed conflict-resolution path. Bound the slice
@@ -101,6 +138,7 @@ describe('qwen resolve workflow', () => {
     nextJob === -1
       ? workflow.slice(resolveJobStart)
       : workflow.slice(resolveJobStart, resolveJobStart + 1 + nextJob);
+  const reviewJob = job(workflow, 'review-pr');
 
   it('keeps the authorization and scope guards on resolve-pr', () => {
     // /resolve must require write+ permission before any credentialed push.

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -54,6 +54,18 @@ describe('qwen-triage tmux workflow', () => {
     expect(runStep).toContain('"OPENAI_MODEL=$OPENAI_MODEL"');
   });
 
+  it('isolates agent state per run', () => {
+    const cleanStep = step('Clean stale agent state');
+    const runStep = step('Run Qwen Triage');
+
+    expect(cleanStep).toContain('QWEN_HOME="${RUNNER_TEMP:?}/qwen-home"');
+    expect(cleanStep).toContain('rm -rf "$QWEN_HOME"');
+    expect(cleanStep).toContain('mkdir -p "$QWEN_HOME"');
+    expect(cleanStep).toContain('rm -f /tmp/stage-*.md');
+    expect(cleanStep).toContain('echo "stale agent state cleaned"');
+    expect(runStep).toContain("QWEN_HOME: '${{ runner.temp }}/qwen-home'");
+  });
+
   it('reports timeout and infra-error without claiming the flow was exercised', () => {
     const postStep = step('Post tmux result comment');
 


### PR DESCRIPTION
## What this PR does

Adds regression coverage for the Qwen triage and PR review workflow agent-state isolation paths, including the per-run `QWEN_HOME` reset, `/tmp/stage-*.md` cleanup, and agent-step `QWEN_HOME` environment wiring. It also fixes the stale PR review workflow cleanup log message so both workflows report `stale agent state cleaned` consistently.

Narrows the cold-import timeout override in the skill activation suite to only the integration tests that import the scheduler graph, and adds a matching hook timeout to the config session-env suite.

## Why it's needed

Post-merge review on #5885 identified that the CI isolation logic was behaviorally important but not pinned by tests, so a future workflow edit could remove the cleanup or environment wiring without failing locally. Post-merge review on #5880 also pointed out that one timeout override was broader than necessary and another suite was missing the hook-timeout convention used by similar core tests.

## Reviewer Test Plan

### How to verify

Review the workflow test additions and confirm they fail if the `QWEN_HOME` cleanup, stage draft cleanup, agent-step `QWEN_HOME`, or cleanup echo is removed or changed. Confirm the skill activation suite applies the cold-import timeout only to the two integration tests, while the config session-env suite keeps file-level headroom and adds `hookTimeout`.

Commands run locally: `npm run test:scripts -- scripts/tests/qwen-triage-workflow.test.js scripts/tests/qwen-resolve-workflow.test.js`; `cd packages/core && npx vitest run src/skills/skill-activation.test.ts src/config/config-session-env.test.ts`; `npm run build`; `npm run typecheck`.

### Evidence (Before & After)

Before: the newly added PR review workflow test failed because the cleanup step still emitted `echo "stale review worktrees cleaned"`.

After: workflow tests passed with 21 tests; targeted core tests passed with 23 tests; full build and typecheck completed successfully. No tmux run was used because this change has no user-visible TUI behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node v22.22.0, npm 10.9.4, local clean worktree.

## Risk & Scope

- Main risk or tradeoff: the workflow tests intentionally pin string-level YAML behavior, which is a narrow but appropriate guard for this CI-only shell wiring.
- Not validated / out of scope: no live ECS runner execution and no tmux E2E, because this follow-up only changes workflow assertions, one cleanup log line, and Vitest timeout configuration.
- Breaking changes / migration notes: none.

## Linked Issues

References #5885 and #5880.

<details>
<summary>中文说明</summary>

## What this PR does

为 Qwen triage 和 PR review workflow 的 agent 状态隔离路径补回归测试，覆盖每次运行的 `QWEN_HOME` reset、`/tmp/stage-*.md` 清理，以及 agent step 上的 `QWEN_HOME` 环境变量传递。同时修正 PR review workflow 清理步骤的旧日志文案，让两个 workflow 都一致输出 `stale agent state cleaned`。

把 skill activation 测试里的冷导入超时设置收窄到真正导入 scheduler graph 的两个 integration 用例，并为 config session-env 测试补上与类似 core 测试一致的 hook timeout。

## Why it's needed

#5885 的合并后 review 指出 CI 隔离逻辑很关键但没有被测试 pin 住，后续有人改 workflow 时可能删掉 cleanup 或环境变量传递而本地不失败。#5880 的合并后 review 也指出一个 timeout override 范围过宽，另一个测试文件缺少同类 core 测试使用的 hook-timeout 配置。

## Reviewer Test Plan

### How to verify

检查新增 workflow 测试，确认如果移除或修改 `QWEN_HOME` cleanup、stage draft cleanup、agent step 的 `QWEN_HOME` 或 cleanup echo，测试会失败。确认 skill activation 测试的冷导入 timeout 只作用于两个 integration 用例，config session-env 测试仍保留文件级 headroom 并增加 `hookTimeout`。

本地运行过的命令：`npm run test:scripts -- scripts/tests/qwen-triage-workflow.test.js scripts/tests/qwen-resolve-workflow.test.js`；`cd packages/core && npx vitest run src/skills/skill-activation.test.ts src/config/config-session-env.test.ts`；`npm run build`；`npm run typecheck`。

### Evidence (Before & After)

Before：新增的 PR review workflow 测试失败，因为 cleanup step 仍输出 `echo "stale review worktrees cleaned"`。

After：workflow tests 21 个通过；targeted core tests 23 个通过；完整 build 和 typecheck 成功。没有跑 tmux，因为这个 follow-up 没有用户可见的 TUI 行为。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node v22.22.0，npm 10.9.4，本地 clean worktree。

## Risk & Scope

- Main risk or tradeoff：workflow tests 有意 pin 住 YAML 字符串级行为；对这类 CI-only shell wiring 来说范围窄但合适。
- Not validated / out of scope：没有做 live ECS runner 执行，也没有跑 tmux E2E，因为本 follow-up 只改 workflow 断言、一个 cleanup 日志，以及 Vitest timeout 配置。
- Breaking changes / migration notes：无。

## Linked Issues

References #5885 and #5880.

</details>