### PR TITLE
feat(telemetry): wire recordApiRequestBreakdown into endLLMRequestSpan (Phase 4c)

### DIFF
--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
@@ -337,6 +337,7 @@ export class LoggingContentGenerator implements ContentGenerator {
         thoughtsTokenCount: response.usageMetadata?.thoughtsTokenCount,
         subagentName: subagentNameContext.getStore() || undefined,
         ...retrySnapshot,
+        config: this.config,
       });
       return response;
     } catch (error) {
@@ -357,6 +358,7 @@ export class LoggingContentGenerator implements ContentGenerator {
         errorStatusCode: getErrorStatus(error),
         subagentName: subagentNameContext.getStore() || undefined,
         ...retrySnapshot,
+        config: this.config,
       });
       await context.with(spanContext, async () => {
         this.safelyLogApiError('', durationMs, error, req.model, userPromptId);
@@ -449,6 +451,7 @@ export class LoggingContentGenerator implements ContentGenerator {
         errorStatusCode: getErrorStatus(error),
         subagentName: subagentNameContext.getStore() || undefined,
         ...retrySnapshot,
+        config: this.config,
       });
       try {
         await this.safelyLogOpenAIInteraction(
@@ -583,6 +586,7 @@ export class LoggingContentGenerator implements ContentGenerator {
               responseId: firstResponseId || undefined,
               subagentName: subagentName || undefined,
               ...retrySnapshot,
+              config: this.config,
             });
             spanEndedByTimeout = true;
           }, STREAM_IDLE_TIMEOUT_MS);
@@ -730,6 +734,7 @@ export class LoggingContentGenerator implements ContentGenerator {
           errorType: lastError ? getErrorType(lastError) : undefined,
           errorStatusCode: lastError ? getErrorStatus(lastError) : undefined,
           ...retrySnapshot,
+          config: this.config,
         });
       }
     }

--- a/packages/core/src/telemetry/session-tracing.test.ts
+++ b/packages/core/src/telemetry/session-tracing.test.ts
@@ -19,8 +19,22 @@ const mockState = vi.hoisted(() => ({
   activeOtelSpan: undefined as unknown,
 }));
 
+const mockMetrics = vi.hoisted(() => ({
+  recordApiRequestBreakdown: vi.fn(),
+}));
+
 vi.mock('./sdk.js', () => ({
   isTelemetrySdkInitialized: () => mockState.sdkInitialized,
+}));
+
+vi.mock('./metrics.js', () => ({
+  recordApiRequestBreakdown: mockMetrics.recordApiRequestBreakdown,
+  ApiRequestPhase: {
+    REQUEST_PREPARATION: 'request_preparation',
+    NETWORK_LATENCY: 'network_latency',
+    RESPONSE_PROCESSING: 'response_processing',
+    TOKEN_PROCESSING: 'token_processing',
+  },
 }));
 
 interface MockSpanRecord {
@@ -864,6 +878,106 @@ describe('session-tracing', () => {
       expect(attrs['subagent_name']).toBe('code-reviewer');
       expect(attrs['input_tokens']).toBe(500);
       expect(attrs['output_tokens']).toBe(100);
+    });
+  });
+
+  describe('LLM request spans — Phase 4c (recordApiRequestBreakdown wiring)', () => {
+    beforeEach(() => {
+      mockMetrics.recordApiRequestBreakdown.mockClear();
+    });
+
+    it('records all 3 phases when config + ttftMs + requestSetupMs are present', () => {
+      const span = startLLMRequestSpan('test-model', 'p');
+      const config = createMockConfig();
+      endLLMRequestSpan(span, {
+        success: true,
+        durationMs: 1000,
+        ttftMs: 200,
+        requestSetupMs: 50,
+        config,
+      });
+
+      expect(mockMetrics.recordApiRequestBreakdown).toHaveBeenCalledTimes(3);
+      expect(mockMetrics.recordApiRequestBreakdown).toHaveBeenCalledWith(
+        config,
+        50,
+        { model: 'test-model', phase: 'request_preparation' },
+      );
+      expect(mockMetrics.recordApiRequestBreakdown).toHaveBeenCalledWith(
+        config,
+        200,
+        { model: 'test-model', phase: 'network_latency' },
+      );
+      expect(mockMetrics.recordApiRequestBreakdown).toHaveBeenCalledWith(
+        config,
+        800,
+        { model: 'test-model', phase: 'response_processing' },
+      );
+    });
+
+    it('skips metric recording when config is absent', () => {
+      const span = startLLMRequestSpan('test-model', 'p');
+      endLLMRequestSpan(span, {
+        success: true,
+        durationMs: 1000,
+        ttftMs: 200,
+        requestSetupMs: 50,
+      });
+
+      expect(mockMetrics.recordApiRequestBreakdown).not.toHaveBeenCalled();
+    });
+
+    it('records only REQUEST_PREPARATION when ttftMs is absent', () => {
+      const span = startLLMRequestSpan('test-model', 'p');
+      const config = createMockConfig();
+      endLLMRequestSpan(span, {
+        success: true,
+        durationMs: 1000,
+        requestSetupMs: 50,
+        config,
+      });
+
+      expect(mockMetrics.recordApiRequestBreakdown).toHaveBeenCalledTimes(1);
+      expect(mockMetrics.recordApiRequestBreakdown).toHaveBeenCalledWith(
+        config,
+        50,
+        { model: 'test-model', phase: 'request_preparation' },
+      );
+    });
+
+    it('skips RESPONSE_PROCESSING when samplingMs is 0 (ttftMs == duration)', () => {
+      const span = startLLMRequestSpan('test-model', 'p');
+      const config = createMockConfig();
+      endLLMRequestSpan(span, {
+        success: true,
+        durationMs: 500,
+        ttftMs: 500,
+        config,
+      });
+
+      const calls = mockMetrics.recordApiRequestBreakdown.mock.calls;
+      const phases = calls.map(
+        (c: unknown[]) => (c[2] as { phase: string }).phase,
+      );
+      expect(phases).toContain('network_latency');
+      expect(phases).not.toContain('response_processing');
+    });
+
+    it('idempotency — second endLLMRequestSpan call does not record again', () => {
+      const span = startLLMRequestSpan('test-model', 'p');
+      const config = createMockConfig();
+      const metadata = {
+        success: true,
+        durationMs: 1000,
+        ttftMs: 200,
+        requestSetupMs: 50,
+        config,
+      };
+      endLLMRequestSpan(span, metadata);
+      endLLMRequestSpan(span, metadata);
+
+      // Only first call records (3 phases), second is short-circuited.
+      expect(mockMetrics.recordApiRequestBreakdown).toHaveBeenCalledTimes(3);
     });
   });
 

--- a/packages/core/src/telemetry/session-tracing.test.ts
+++ b/packages/core/src/telemetry/session-tracing.test.ts
@@ -927,6 +927,20 @@ describe('session-tracing', () => {
       expect(mockMetrics.recordApiRequestBreakdown).not.toHaveBeenCalled();
     });
 
+    it('skips metric recording when request failed (success=false)', () => {
+      const span = startLLMRequestSpan('test-model', 'p');
+      const config = createMockConfig();
+      endLLMRequestSpan(span, {
+        success: false,
+        durationMs: 1000,
+        ttftMs: 200,
+        requestSetupMs: 50,
+        config,
+      });
+
+      expect(mockMetrics.recordApiRequestBreakdown).not.toHaveBeenCalled();
+    });
+
     it('records only REQUEST_PREPARATION when ttftMs is absent', () => {
       const span = startLLMRequestSpan('test-model', 'p');
       const config = createMockConfig();

--- a/packages/core/src/telemetry/session-tracing.ts
+++ b/packages/core/src/telemetry/session-tracing.ts
@@ -27,6 +27,7 @@ import {
   SPAN_TOOL_EXECUTION,
 } from './constants.js';
 import { clearDetailedSpanState } from './detailed-span-attributes.js';
+import { ApiRequestPhase, recordApiRequestBreakdown } from './metrics.js';
 import { isTelemetrySdkInitialized } from './sdk.js';
 import { getCurrentSessionId, setSessionContext } from './session-context.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
@@ -113,6 +114,8 @@ export interface LLMRequestMetadata {
   errorType?: string;
   /** HTTP status code from the provider error response. */
   errorStatusCode?: number;
+  /** Config reference for Phase 4c metric recording (recordApiRequestBreakdown). */
+  config?: Config;
 }
 
 export interface ToolSpanMetadata {
@@ -711,6 +714,33 @@ export function endLLMRequestSpan(
     }
 
     spanCtx.span.setAttributes(endAttributes);
+
+    // Phase 4c: record per-phase breakdown histogram.
+    if (metadata?.config) {
+      const model = String(spanCtx.attributes['qwen-code.model'] ?? '');
+      if (metadata.requestSetupMs !== undefined) {
+        recordApiRequestBreakdown(metadata.config, metadata.requestSetupMs, {
+          model,
+          phase: ApiRequestPhase.REQUEST_PREPARATION,
+        });
+      }
+      if (metadata.ttftMs !== undefined) {
+        recordApiRequestBreakdown(metadata.config, metadata.ttftMs, {
+          model,
+          phase: ApiRequestPhase.NETWORK_LATENCY,
+        });
+      }
+      const breakdownSamplingMs =
+        metadata.ttftMs !== undefined
+          ? Math.max(0, duration - metadata.ttftMs)
+          : undefined;
+      if (breakdownSamplingMs !== undefined && breakdownSamplingMs > 0) {
+        recordApiRequestBreakdown(metadata.config, breakdownSamplingMs, {
+          model,
+          phase: ApiRequestPhase.RESPONSE_PROCESSING,
+        });
+      }
+    }
 
     if (metadata === undefined || metadata.success) {
       spanCtx.span.setStatus({ code: SpanStatusCode.OK });

--- a/packages/core/src/telemetry/session-tracing.ts
+++ b/packages/core/src/telemetry/session-tracing.ts
@@ -716,30 +716,37 @@ export function endLLMRequestSpan(
     spanCtx.span.setAttributes(endAttributes);
 
     // Phase 4c: record per-phase breakdown histogram.
-    if (metadata?.config) {
-      const model = String(spanCtx.attributes['qwen-code.model'] ?? '');
-      if (metadata.requestSetupMs !== undefined) {
-        recordApiRequestBreakdown(metadata.config, metadata.requestSetupMs, {
-          model,
-          phase: ApiRequestPhase.REQUEST_PREPARATION,
-        });
+    // Isolated in its own try/catch so metric failures cannot affect span status.
+    try {
+      if (metadata?.config && metadata.success) {
+        const model = String(spanCtx.attributes['qwen-code.model'] ?? '');
+        if (metadata.requestSetupMs !== undefined) {
+          recordApiRequestBreakdown(metadata.config, metadata.requestSetupMs, {
+            model,
+            phase: ApiRequestPhase.REQUEST_PREPARATION,
+          });
+        }
+        if (metadata.ttftMs !== undefined) {
+          recordApiRequestBreakdown(metadata.config, metadata.ttftMs, {
+            model,
+            phase: ApiRequestPhase.NETWORK_LATENCY,
+          });
+        }
+        const breakdownSamplingMs =
+          metadata.ttftMs !== undefined
+            ? Math.max(0, duration - metadata.ttftMs)
+            : undefined;
+        if (breakdownSamplingMs !== undefined && breakdownSamplingMs > 0) {
+          recordApiRequestBreakdown(metadata.config, breakdownSamplingMs, {
+            model,
+            phase: ApiRequestPhase.RESPONSE_PROCESSING,
+          });
+        }
       }
-      if (metadata.ttftMs !== undefined) {
-        recordApiRequestBreakdown(metadata.config, metadata.ttftMs, {
-          model,
-          phase: ApiRequestPhase.NETWORK_LATENCY,
-        });
-      }
-      const breakdownSamplingMs =
-        metadata.ttftMs !== undefined
-          ? Math.max(0, duration - metadata.ttftMs)
-          : undefined;
-      if (breakdownSamplingMs !== undefined && breakdownSamplingMs > 0) {
-        recordApiRequestBreakdown(metadata.config, breakdownSamplingMs, {
-          model,
-          phase: ApiRequestPhase.RESPONSE_PROCESSING,
-        });
-      }
+    } catch (error) {
+      debugLogger.warn(
+        `Failed to record API request breakdown histogram: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
 
     if (metadata === undefined || metadata.success) {


### PR DESCRIPTION
## What this PR does

Activates the pre-existing `recordApiRequestBreakdown` histogram metric by calling it from `endLLMRequestSpan`. Each LLM request now records up to 3 phase durations as separate histogram data points: REQUEST_PREPARATION (retry/setup overhead), NETWORK_LATENCY (time to first token), and RESPONSE_PROCESSING (output streaming time).

## Why it's needed

Phase 4c of the telemetry LLM request timing design (#3731). The infrastructure (`recordApiRequestBreakdown` function, `ApiRequestPhase` enum, `apiRequestBreakdownHistogram`) was implemented in earlier phases but had zero production callers. This PR completes the wiring so operators can analyze where LLM request latency is spent via the `qwen-code.api.request.breakdown` metric.

## Reviewer Test Plan

### How to verify

1. Run unit tests: `cd packages/core && npx vitest run src/telemetry/session-tracing.test.ts` — all 125 tests pass including 5 new Phase 4c tests.
2. Run metrics tests to confirm no regression: `cd packages/core && npx vitest run src/telemetry/metrics.test.ts` — 40 tests pass.
3. Run LoggingContentGenerator tests: `cd packages/core && npx vitest run src/core/loggingContentGenerator/loggingContentGenerator.test.ts` — 58 tests pass (existing assertions unchanged).
4. Type check: `cd packages/core && npx tsc --noEmit` — no errors in modified files.

### Evidence (Before & After)

N/A — non-user-visible metrics plumbing change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Unit tests only.

## Risk & Scope

- Main risk or tradeoff: If `recordApiRequestBreakdown` throws unexpectedly (extremely unlikely given internal guards), span status won't be set — but span.end() still runs so no leak.
- Not validated / out of scope: Actual histogram export to an OTLP backend (covered by existing SDK integration tests).
- Breaking changes / migration notes: None. The new `config?` field on `LLMRequestMetadata` is optional.

## Linked Issues

Closes #3731 (Phase 4c)

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将已有的 `recordApiRequestBreakdown` 直方图指标接入 `endLLMRequestSpan`，使每次 LLM 请求按阶段记录耗时分布：REQUEST_PREPARATION（重试/准备开销）、NETWORK_LATENCY（首 token 时间）、RESPONSE_PROCESSING（输出流式处理时间）。

## 为什么需要

这是 telemetry LLM 请求计时设计的 Phase 4c（#3731）。基础设施已在早期阶段实现但无生产调用方。本 PR 完成最后的接线，使运维人员能通过 `qwen-code.api.request.breakdown` 指标分析 LLM 请求延迟的时间分布。

## 风险与范围

- 主要风险：如果 `recordApiRequestBreakdown` 意外抛出异常，span status 不会设置——但 span.end() 仍然执行，不会泄漏。
- 未验证：到 OTLP 后端的实际直方图导出（由已有 SDK 集成测试覆盖）。
- 破坏性变更：无。`LLMRequestMetadata` 上新增的 `config?` 字段是可选的。

</details>