### PR TITLE
fix(serve): reject negative cleanupPeriodDays values

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -86,6 +86,8 @@ export interface SettingDefinition {
   options?: readonly SettingEnumOption[];
   /** Schema for array items when type is 'array' */
   items?: SettingItemDefinition;
+  /** Minimum value for number-type settings. */
+  minimum?: number;
   /**
    * Primitive shapes a field accepted before it was expanded to its current
    * type. The exported JSON Schema wraps the field in `anyOf` so values from
@@ -493,6 +495,7 @@ const SETTINGS_SCHEMA = {
         // surprised when a mid-session edit doesn't take effect immediately.
         requiresRestart: true,
         default: 30,
+        minimum: 0,
         description:
           'Number of days to retain ~/.qwen/file-history/ session backups used by /rewind and background subagent transcripts under <projectDir>/subagents/. Data older than this is removed by a background housekeeping pass that runs at most once per day. Set to 0 for minimum retention (~1 hour) — protects sessions touched in the last hour, plus the currently active session.',
         showInDialog: true,

--- a/packages/cli/src/serve/routes/workspace-settings.test.ts
+++ b/packages/cli/src/serve/routes/workspace-settings.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { registerWorkspaceSettingsRoutes } from './workspace-settings.js';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+
+  const persistSetting = vi.fn(async () => {});
+  const broadcastSettingsChanged = vi.fn();
+
+  registerWorkspaceSettingsRoutes(app, {
+    boundWorkspace: '/workspace',
+    mutate: () => (_req, _res, next) => next(),
+    safeBody: (req) =>
+      req.body && typeof req.body === 'object' ? req.body : {},
+    persistSetting,
+    broadcastSettingsChanged,
+    parseAndValidateClientId: () => undefined,
+  });
+
+  return { app, persistSetting, broadcastSettingsChanged };
+}
+
+describe('POST /workspace/settings', () => {
+  it('rejects negative general.cleanupPeriodDays values', async () => {
+    const { app, persistSetting, broadcastSettingsChanged } = makeApp();
+
+    for (const value of [-1, -5]) {
+      const res = await request(app).post('/workspace/settings').send({
+        scope: 'workspace',
+        key: 'general.cleanupPeriodDays',
+        value,
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        code: 'invalid_value',
+        error: 'Value must be >= 0',
+      });
+    }
+
+    expect(persistSetting).not.toHaveBeenCalled();
+    expect(broadcastSettingsChanged).not.toHaveBeenCalled();
+  });
+
+  it.each([0, 30])('accepts general.cleanupPeriodDays=%s', async (value) => {
+    const { app, persistSetting, broadcastSettingsChanged } = makeApp();
+
+    const res = await request(app).post('/workspace/settings').send({
+      scope: 'workspace',
+      key: 'general.cleanupPeriodDays',
+      value,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      key: 'general.cleanupPeriodDays',
+      scope: 'workspace',
+      value,
+      requiresRestart: true,
+    });
+    expect(persistSetting).toHaveBeenCalledWith(
+      '/workspace',
+      expect.any(String),
+      'general.cleanupPeriodDays',
+      value,
+    );
+    expect(broadcastSettingsChanged).toHaveBeenCalledWith(
+      'general.cleanupPeriodDays',
+      value,
+      'workspace',
+      undefined,
+    );
+  });
+});

--- a/packages/cli/src/serve/routes/workspace-settings.ts
+++ b/packages/cli/src/serve/routes/workspace-settings.ts
@@ -7,7 +7,6 @@
 import type { Application, Request, Response } from 'express';
 import { loadSettings, SettingScope } from '../../config/settings.js';
 import type {
-  SettingDefinition,
   SettingEnumOption,
   SettingsType,
   SettingsValue,
@@ -16,6 +15,7 @@ import {
   getDialogSettingKeys,
   getNestedProperty,
   getSettingDefinition,
+  validateSettingValue,
 } from '../../utils/settingsUtils.js';
 import { writeStderrLine } from '../../utils/stdioHelpers.js';
 
@@ -39,8 +39,6 @@ const TUI_ONLY_SETTINGS = new Set([
 const WEB_SHELL_SETTINGS = new Set(['ui.compactMode', 'voiceModel']);
 
 const VALID_WRITE_SCOPES = new Set(['workspace']);
-
-const MAX_STRING_VALUE_LENGTH = 1024;
 
 interface SettingDescriptor {
   key: string;
@@ -137,35 +135,6 @@ function buildSettingsResponse(
     ...(warnings.length ? { warnings } : {}),
     settings,
   };
-}
-
-function validateSettingValue(
-  def: SettingDefinition,
-  value: unknown,
-): string | undefined {
-  switch (def.type) {
-    case 'boolean':
-      if (typeof value !== 'boolean') return 'Value must be a boolean';
-      break;
-    case 'number':
-      if (typeof value !== 'number' || !Number.isFinite(value))
-        return 'Value must be a finite number';
-      break;
-    case 'string':
-      if (typeof value !== 'string') return 'Value must be a string';
-      if (value.length > MAX_STRING_VALUE_LENGTH)
-        return `Value exceeds ${MAX_STRING_VALUE_LENGTH}-character limit`;
-      break;
-    case 'enum':
-      if (!def.options?.some((opt) => opt.value === value)) {
-        const allowed = def.options?.map((o) => o.value).join(', ') ?? '';
-        return `Value must be one of: ${allowed}`;
-      }
-      break;
-    default:
-      return `Settings of type '${def.type}' cannot be modified via this API`;
-  }
-  return undefined;
 }
 
 const SCOPE_MAP: Record<string, SettingScope> = {

--- a/packages/cli/src/ui/components/SettingsDialog.test.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.test.tsx
@@ -171,6 +171,7 @@ vi.mock('../../utils/languageUtils.js', async () => {
   return {
     ...actual,
     updateOutputLanguageFile: vi.fn(),
+    writeOutputLanguageAndRegisterPath: vi.fn(),
   };
 });
 
@@ -520,6 +521,56 @@ describe('SettingsDialog', () => {
       expect(mockSetCompactMode).toHaveBeenCalledWith(true);
       // Verify refreshStatic was called to update rendered history
       expect(mockRefreshStatic).toHaveBeenCalled();
+
+      unmount();
+    });
+
+    it('should not save number settings below their configured minimum', async () => {
+      vi.mocked(saveModifiedSettings).mockClear();
+
+      const settings = createMockSettings();
+      const onSelect = vi.fn();
+      const component = (
+        <KeypressProvider kittyProtocolEnabled={false}>
+          <SettingsDialog settings={settings} onSelect={onSelect} />
+        </KeypressProvider>
+      );
+
+      const { stdin, unmount, lastFrame } = render(component);
+
+      await waitFor(() => {
+        expect(lastFrame()).toContain('Settings');
+      });
+
+      const cleanupPeriodIndex = getDialogSettingKeys().indexOf(
+        'general.cleanupPeriodDays',
+      );
+      expect(cleanupPeriodIndex).toBeGreaterThanOrEqual(0);
+
+      const press = async (key: string) => {
+        act(() => {
+          stdin.write(key);
+        });
+        await wait();
+      };
+
+      for (let i = 0; i < cleanupPeriodIndex; i++) {
+        await press(TerminalKeys.DOWN_ARROW as string);
+      }
+
+      await press(TerminalKeys.ENTER as string);
+      await press('-');
+      await press('1');
+      await press(TerminalKeys.ENTER as string);
+
+      await wait();
+
+      const cleanupPeriodCall = vi
+        .mocked(saveModifiedSettings)
+        .mock.calls.find((call) =>
+          (call[0] as Set<string>).has('general.cleanupPeriodDays'),
+        );
+      expect(cleanupPeriodCall).toBeUndefined();
 
       unmount();
     });

--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -26,6 +26,7 @@ import {
   setPendingSettingValueAny,
   getNestedValue,
   getEffectiveValue,
+  validateSettingValue,
 } from '../../utils/settingsUtils.js';
 import { writeOutputLanguageAndRegisterPath } from '../../utils/languageUtils.js';
 import {
@@ -322,6 +323,16 @@ export function SettingsDialog({
         parsed = trimmed === '' ? 'auto' : trimmed;
       } else {
         parsed = editBuffer;
+      }
+    }
+
+    if (definition) {
+      const validationError = validateSettingValue(definition, parsed);
+      if (validationError) {
+        setEditingKey(null);
+        setEditBuffer('');
+        setEditCursorPos(0);
+        return;
       }
     }
 

--- a/packages/cli/src/utils/settingsUtils.test.ts
+++ b/packages/cli/src/utils/settingsUtils.test.ts
@@ -36,6 +36,7 @@ import {
   getEffectiveDisplayValue,
   setNestedPropertySafe,
   setNestedPropertyForce,
+  validateSettingValue,
 } from './settingsUtils.js';
 import {
   getSettingsSchema,
@@ -77,6 +78,16 @@ describe('SettingsUtils', () => {
         requiresRestart: false,
         default: 'hello',
         description: 'A test field',
+        showInDialog: true,
+      },
+      numberWithMinimum: {
+        type: 'number',
+        label: 'Number With Minimum',
+        category: 'Basic',
+        requiresRestart: false,
+        default: 0,
+        minimum: 0,
+        description: 'A number field with a minimum.',
         showInDialog: true,
       },
       advanced: {
@@ -208,6 +219,25 @@ describe('SettingsUtils', () => {
       it('should return undefined for invalid setting', () => {
         const definition = getSettingDefinition('invalidSetting');
         expect(definition).toBeUndefined();
+      });
+    });
+
+    describe('validateSettingValue', () => {
+      it('accepts finite numbers at the configured minimum', () => {
+        const definition = getSettingDefinition('numberWithMinimum');
+        expect(definition).toBeDefined();
+
+        expect(validateSettingValue(definition!, 0)).toBeUndefined();
+        expect(validateSettingValue(definition!, 1)).toBeUndefined();
+      });
+
+      it('rejects numbers below the configured minimum', () => {
+        const definition = getSettingDefinition('numberWithMinimum');
+        expect(definition).toBeDefined();
+
+        expect(validateSettingValue(definition!, -1)).toBe(
+          'Value must be >= 0',
+        );
       });
     });
 

--- a/packages/cli/src/utils/settingsUtils.ts
+++ b/packages/cli/src/utils/settingsUtils.ts
@@ -309,6 +309,39 @@ const SETTINGS_DIALOG_ORDER: readonly string[] = [
   'privacy.usageStatisticsEnabled',
 ] as const;
 
+export const MAX_SETTING_STRING_VALUE_LENGTH = 1024;
+
+export function validateSettingValue(
+  def: SettingDefinition,
+  value: unknown,
+): string | undefined {
+  switch (def.type) {
+    case 'boolean':
+      if (typeof value !== 'boolean') return 'Value must be a boolean';
+      break;
+    case 'number':
+      if (typeof value !== 'number' || !Number.isFinite(value))
+        return 'Value must be a finite number';
+      if (def.minimum !== undefined && value < def.minimum)
+        return `Value must be >= ${def.minimum}`;
+      break;
+    case 'string':
+      if (typeof value !== 'string') return 'Value must be a string';
+      if (value.length > MAX_SETTING_STRING_VALUE_LENGTH)
+        return `Value exceeds ${MAX_SETTING_STRING_VALUE_LENGTH}-character limit`;
+      break;
+    case 'enum':
+      if (!def.options?.some((opt) => opt.value === value)) {
+        const allowed = def.options?.map((o) => o.value).join(', ') ?? '';
+        return `Value must be one of: ${allowed}`;
+      }
+      break;
+    default:
+      return `Settings of type '${def.type}' cannot be modified via this API`;
+  }
+  return undefined;
+}
+
 /**
  * Get all setting keys that should be shown in the dialog, sorted by display order
  */

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -101,7 +101,8 @@
         "cleanupPeriodDays": {
           "description": "Number of days to retain ~/.qwen/file-history/ session backups used by /rewind and background subagent transcripts under <projectDir>/subagents/. Data older than this is removed by a background housekeeping pass that runs at most once per day. Set to 0 for minimum retention (~1 hour) — protects sessions touched in the last hour, plus the currently active session.",
           "type": "number",
-          "default": 30
+          "default": 30,
+          "minimum": 0
         },
         "gitCoAuthor": {
           "description": "Attribution added to git commits and pull requests created through Qwen Code.",

--- a/scripts/generate-settings-schema.ts
+++ b/scripts/generate-settings-schema.ts
@@ -38,6 +38,7 @@ interface JsonSchemaProperty {
   items?: JsonSchemaProperty;
   enum?: (string | number)[];
   default?: unknown;
+  minimum?: number;
   additionalProperties?: boolean | JsonSchemaProperty;
   required?: string[];
   oneOf?: JsonSchemaProperty[];
@@ -182,6 +183,10 @@ function convertSettingToJsonSchema(
       // default value (e.g. `{commit: true, pr: true}` for gitCoAuthor).
       schema.default = defaultVal;
     }
+  }
+
+  if (setting.type === 'number' && setting.minimum !== undefined) {
+    schema.minimum = setting.minimum;
   }
 
   // If the field accepts a legacy primitive shape (e.g. a boolean that was


### PR DESCRIPTION
## What this PR does

Adds a `minimum?: number` field to `SettingDefinition` and applies `minimum: 0` to `general.cleanupPeriodDays` so negative retention periods are rejected consistently instead of being persisted and then silently clamped by the housekeeping runtime.

The validation is now enforced end to end across the first-party settings surfaces:

- `POST /workspace/settings` rejects values below the declared floor through the shared `validateSettingValue()` helper.
- The terminal `/settings` dialog reuses the same validator before saving edited number/string settings.
- `generate-settings-schema.ts` emits `minimum` into the generated VS Code settings JSON schema, and the committed schema includes `"minimum": 0` for `general.cleanupPeriodDays`.

## Why it's needed

The `cleanupPeriodDays` runtime (`getCutoffDate()`) already defends against negative inputs, but accepting and persisting those values at the settings boundary is misleading:

1. A user can save `-5` through a settings path.
2. The settings UI/schema may show `-5` as the configured value.
3. The housekeeping scheduler silently treats it as minimum retention instead.

This is the same class of schema-bypass issue as #5680: a settings entry accepts a value that the runtime later corrects. Declaring and enforcing `minimum` in the shared settings schema keeps API, TUI, generated editor schema, and runtime expectations aligned.

## Reviewer Test Plan

### How to verify

Run the focused tests from the repo root:

```bash
npm test --workspace=packages/cli -- utils/settingsUtils.test.ts --coverage.enabled=false
npm test --workspace=packages/cli -- routes/workspace-settings.test.ts --coverage.enabled=false
npm test --workspace=packages/cli -- ui/components/SettingsDialog.test.tsx --coverage.enabled=false
npm test --workspace=packages/cli -- utils/housekeeping/cleanup.test.ts --coverage.enabled=false
```

Regenerate the settings schema and confirm it stays in sync:

```bash
npm run generate:settings-schema
```

Manual API verification, if running a daemon:

```bash
# Should return 400
curl -X POST http://127.0.0.1:<port>/workspace/settings \
  -H "Content-Type: application/json" \
  -d '{"scope":"workspace","key":"general.cleanupPeriodDays","value":-5}'

# Should return 200
curl -X POST http://127.0.0.1:<port>/workspace/settings \
  -H "Content-Type: application/json" \
  -d '{"scope":"workspace","key":"general.cleanupPeriodDays","value":0}'

# Should return 200
curl -X POST http://127.0.0.1:<port>/workspace/settings \
  -H "Content-Type: application/json" \
  -d '{"scope":"workspace","key":"general.cleanupPeriodDays","value":30}'
```

A reviewer should also confirm the terminal `/settings` dialog does not persist a negative `general.cleanupPeriodDays` edit, and that the generated schema contains `"minimum": 0` for `general.cleanupPeriodDays`.

### Evidence (Before & After)

**Before:** `general.cleanupPeriodDays=-5` could be persisted through a settings path, while the runtime silently treated it as minimum retention.

**After:**

- `POST /workspace/settings` with `value: -5` returns `400 Bad Request` with `{"code":"invalid_value","error":"Value must be >= 0"}`.
- Terminal `/settings` uses the shared validator and does not save below-minimum numeric edits.
- Generated VS Code settings schema includes `"minimum": 0` for `general.cleanupPeriodDays`.

The tests cover:

- Shared validator accepts number settings without `minimum` unchanged and rejects below-minimum values when declared.
- Route rejects `general.cleanupPeriodDays=-1` and `-5` without calling `persistSetting` or broadcasting changes.
- Route accepts `general.cleanupPeriodDays=0` and `30`.
- TUI settings dialog does not save `general.cleanupPeriodDays=-1`.
- Existing housekeeping runtime tests still pass.

Local validation run:

```bash
npm test --workspace=packages/cli -- utils/settingsUtils.test.ts --coverage.enabled=false
npm test --workspace=packages/cli -- routes/workspace-settings.test.ts --coverage.enabled=false
npm test --workspace=packages/cli -- ui/components/SettingsDialog.test.tsx --coverage.enabled=false
npm test --workspace=packages/cli -- utils/housekeeping/cleanup.test.ts --coverage.enabled=false
npx prettier --check packages/cli/src/utils/settingsUtils.ts packages/cli/src/utils/settingsUtils.test.ts packages/cli/src/ui/components/SettingsDialog.tsx packages/cli/src/ui/components/SettingsDialog.test.tsx packages/cli/src/config/settingsSchema.ts packages/cli/src/serve/routes/workspace-settings.ts scripts/generate-settings-schema.ts
npm run generate:settings-schema
```

Maintainer local verification also reported all affected tests, typecheck, ESLint, Prettier, and settings-schema sync clean at PR head `e38a0c68e`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS  | tested |
| Windows | not tested |
|  Linux  | not tested |

## Risk & Scope

- **Risk:** Low. `minimum` is optional; number settings without it continue to accept any finite value, including negatives.
- **Scope:** 9 files changed, +219/-33. The broader scope is intentional: shared validator, API route reuse, TUI validation, schema generation, generated schema output, and focused regression tests.
- **Backward compatibility:** Preserved for all number settings that do not declare `minimum`. `cleanupPeriodDays < 0` was already not honored by the runtime, so rejecting it at the settings boundary makes the persisted value match actual behavior.
- **Breaking change:** None for valid `cleanupPeriodDays` values. Invalid negative values now fail validation instead of being saved and silently clamped.
- **Follow-up:** The TUI currently cancels invalid number edits without an inline error, consistent with its existing empty/NaN handling. A friendlier inline error could be added separately.

## Linked Issues

Fixes #5905
Related: #5680

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 `SettingDefinition` 中新增 `minimum?: number` 字段，并给 `general.cleanupPeriodDays` 设置 `minimum: 0`，让负数保留天数在设置边界被一致拒绝，而不是先持久化、再被 housekeeping 运行时静默 clamp。

现在该约束覆盖三个第一方设置入口：

- `POST /workspace/settings` 通过共享 `validateSettingValue()` 拒绝低于下限的值。
- terminal `/settings` 对话框在保存数字/字符串编辑前复用同一个 validator。
- `generate-settings-schema.ts` 会把 `minimum` 输出到生成的 VS Code settings JSON schema；已提交的 schema 中 `general.cleanupPeriodDays` 包含 `"minimum": 0`。

## 为什么需要

`cleanupPeriodDays` 的运行时逻辑（`getCutoffDate()`）已经防御负数，但在设置边界接受并持久化负数会造成误导：用户看到配置值是 `-5`，实际后台任务却按最小保留时间处理。

这和 #5680 属于同类 schema-bypass：设置入口接受了运行时会静默修正的值。把 `minimum` 声明在共享 schema 并在 API、TUI、generated editor schema 中保持一致，可以让持久化配置和真实运行行为对齐。

## Reviewer Test Plan

### 如何验证

从仓库根目录运行 focused tests：

```bash
npm test --workspace=packages/cli -- utils/settingsUtils.test.ts --coverage.enabled=false
npm test --workspace=packages/cli -- routes/workspace-settings.test.ts --coverage.enabled=false
npm test --workspace=packages/cli -- ui/components/SettingsDialog.test.tsx --coverage.enabled=false
npm test --workspace=packages/cli -- utils/housekeeping/cleanup.test.ts --coverage.enabled=false
```

重新生成 settings schema 并确认同步：

```bash
npm run generate:settings-schema
```

也可以手动验证 daemon API：`cleanupPeriodDays=-5` 应返回 `400 invalid_value`，`0` 和 `30` 应返回 `200`。同时确认 terminal `/settings` 不会持久化负数，生成的 schema 中 `general.cleanupPeriodDays` 带有 `"minimum": 0`。

### 证据（Before & After）

**Before：** `general.cleanupPeriodDays=-5` 可以被设置入口持久化，但运行时会静默按最小保留时间处理。

**After：**

- `POST /workspace/settings` 对 `value: -5` 返回 `400 Bad Request`。
- terminal `/settings` 使用共享 validator，不保存低于下限的数字编辑。
- 生成的 VS Code settings schema 对 `general.cleanupPeriodDays` 包含 `"minimum": 0`。

测试覆盖共享 validator、API route 拒绝/接受路径、TUI 设置对话框拒绝负数，以及既有 housekeeping runtime 回归测试。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  macOS  | 已测试 |
| Windows | 未测试 |
|  Linux  | 未测试 |

## 风险与范围

- **风险：** 低。`minimum` 是可选字段；没有声明 `minimum` 的 number 设置仍保持原行为，包括接受负数。
- **范围：** 9 个文件，+219/-33。范围扩大是有意的：共享 validator、API route 复用、TUI 校验、schema 生成、generated schema 输出和回归测试。
- **向后兼容：** 对所有未声明 `minimum` 的 number 设置保持兼容。`cleanupPeriodDays < 0` 本来就不会被运行时真实执行，现在只是在设置边界提前拒绝。
- **破坏性变更：** 对合法 `cleanupPeriodDays` 值无破坏性变化。非法负数现在校验失败，而不是被保存后静默 clamp。
- **后续改进：** TUI 目前对非法数字编辑是静默取消，和既有空值/NaN 行为一致。更友好的 inline error 可以作为后续改进。

## 关联 Issue

Fixes #5905
Related: #5680

</details>