### PR TITLE
fix(desktop): validate credential cache source slugs

### DIFF
--- a/packages/desktop/packages/session-mcp-server/src/credential-cache.test.ts
+++ b/packages/desktop/packages/session-mcp-server/src/credential-cache.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  getCredentialCachePath,
+  readCredentialCache,
+} from './credential-cache';
+
+let workspaceRoot: string | undefined;
+
+function makeWorkspace(): string {
+  workspaceRoot = mkdtempSync(join(tmpdir(), 'session-credential-cache-'));
+  return workspaceRoot;
+}
+
+function writeCredentialCache(root: string, sourceSlug: string, content: string): void {
+  const sourceDir = join(root, 'sources', sourceSlug);
+  mkdirSync(sourceDir, { recursive: true });
+  writeFileSync(join(sourceDir, '.credential-cache.json'), content);
+}
+
+afterEach(() => {
+  if (workspaceRoot) {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+    workspaceRoot = undefined;
+  }
+});
+
+describe('credential cache path validation', () => {
+  it('resolves cache paths through the validated source directory helper', () => {
+    const root = '/tmp/workspace';
+
+    expect(getCredentialCachePath(root, 'craft-kb')).toBe(
+      join(root, 'sources', 'craft-kb', '.credential-cache.json')
+    );
+  });
+
+  it('rejects unsafe source slugs before reading from the filesystem', () => {
+    const root = makeWorkspace();
+    const escapedDir = join(root, 'sessions');
+    mkdirSync(escapedDir, { recursive: true });
+    writeFileSync(
+      join(escapedDir, '.credential-cache.json'),
+      JSON.stringify({ value: 'escaped-token' })
+    );
+
+    expect(() => getCredentialCachePath(root, '../sessions')).toThrow(
+      'Invalid source slug: "../sessions"'
+    );
+    expect(() => readCredentialCache(root, '../sessions')).toThrow(
+      'Invalid source slug: "../sessions"'
+    );
+  });
+
+  it('reads valid, unexpired credential cache entries', () => {
+    const root = makeWorkspace();
+    writeCredentialCache(root, 'github', JSON.stringify({ value: 'token' }));
+
+    expect(readCredentialCache(root, 'github')).toBe('token');
+  });
+
+  it('returns null for missing, expired, or empty cache entries without logging misses', () => {
+    const root = makeWorkspace();
+    const messages: string[] = [];
+    writeCredentialCache(
+      root,
+      'expired',
+      JSON.stringify({ value: 'old-token', expiresAt: Date.now() - 1000 })
+    );
+    writeCredentialCache(root, 'empty', JSON.stringify({ value: '' }));
+
+    expect(readCredentialCache(root, 'missing', (message) => messages.push(message))).toBeNull();
+    expect(readCredentialCache(root, 'expired')).toBeNull();
+    expect(readCredentialCache(root, 'empty')).toBeNull();
+    expect(messages).toEqual([]);
+  });
+
+  it('logs unreadable cache content without swallowing slug validation errors', () => {
+    const root = makeWorkspace();
+    const messages: string[] = [];
+    writeCredentialCache(root, 'github', '{not-json');
+
+    expect(readCredentialCache(root, 'github', (message) => messages.push(message))).toBeNull();
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain('Failed to read credential cache for source "github"');
+  });
+});

--- a/packages/desktop/packages/session-mcp-server/src/credential-cache.ts
+++ b/packages/desktop/packages/session-mcp-server/src/credential-cache.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getSourcePath } from '@craft-agent/session-tools-core';
+
+/**
+ * Credential cache entry format (matches main process format).
+ * Written by Electron main process, read by this server.
+ */
+interface CredentialCacheEntry {
+  value: string;
+  expiresAt?: number;
+}
+
+export type CredentialCacheReadErrorLogger = (message: string) => void;
+
+function isMissingFileError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === 'ENOENT'
+  );
+}
+
+/**
+ * Get the path to a source's credential cache file.
+ * The main process writes decrypted credentials to these files.
+ */
+export function getCredentialCachePath(workspaceRootPath: string, sourceSlug: string): string {
+  return join(getSourcePath(workspaceRootPath, sourceSlug), '.credential-cache.json');
+}
+
+/**
+ * Read credentials from the cache file for a source.
+ * Returns null if the cache doesn't exist, is unreadable, or is expired.
+ *
+ * Invalid source slugs throw before any filesystem access. That keeps slug
+ * validation failures distinct from ordinary cache misses or corrupt JSON.
+ */
+export function readCredentialCache(
+  workspaceRootPath: string,
+  sourceSlug: string,
+  onReadError?: CredentialCacheReadErrorLogger,
+): string | null {
+  const cachePath = getCredentialCachePath(workspaceRootPath, sourceSlug);
+
+  try {
+    const content = readFileSync(cachePath, 'utf-8');
+    const cache = JSON.parse(content) as CredentialCacheEntry;
+
+    if (cache.expiresAt && Date.now() > cache.expiresAt) {
+      return null;
+    }
+
+    return cache.value || null;
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return null;
+    }
+
+    onReadError?.(
+      `Failed to read credential cache for source ${JSON.stringify(sourceSlug)}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    return null;
+  }
+}

--- a/packages/desktop/packages/session-mcp-server/src/index.ts
+++ b/packages/desktop/packages/session-mcp-server/src/index.ts
@@ -33,6 +33,7 @@ import {
 import { existsSync, readFileSync, readdirSync, statSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { isDeveloperFeedbackEnabled } from '@craft-agent/shared/feature-flags';
+import { readCredentialCache } from './credential-cache';
 // Import from session-tools-core
 import {
   type SessionToolContext,
@@ -75,66 +76,31 @@ function sendCallback(callback: CallbackMessage): void {
   console.error(`__CALLBACK__${JSON.stringify(callback)}`);
 }
 
-// ============================================================
-// Credential Cache Access
-// ============================================================
-
-/**
- * Credential cache entry format (matches main process format).
- * Written by Electron main process, read by this server.
- */
-interface CredentialCacheEntry {
-  value: string;
-  expiresAt?: number;
-}
-
-/**
- * Get the path to a source's credential cache file.
- * The main process writes decrypted credentials to these files.
- */
-function getCredentialCachePath(workspaceRootPath: string, sourceSlug: string): string {
-  return join(workspaceRootPath, 'sources', sourceSlug, '.credential-cache.json');
-}
-
-/**
- * Read credentials from the cache file for a source.
- * Returns null if the cache doesn't exist or is expired.
- */
-function readCredentialCache(workspaceRootPath: string, sourceSlug: string): string | null {
-  const cachePath = getCredentialCachePath(workspaceRootPath, sourceSlug);
-
-  try {
-    if (!existsSync(cachePath)) {
-      return null;
-    }
-
-    const content = readFileSync(cachePath, 'utf-8');
-    const cache = JSON.parse(content) as CredentialCacheEntry;
-
-    // Check expiry if set
-    if (cache.expiresAt && Date.now() > cache.expiresAt) {
-      return null;
-    }
-
-    return cache.value || null;
-  } catch {
-    return null;
-  }
-}
-
 /**
  * Create a credential manager that reads from credential cache files.
  * This allows the session-mcp-server to access credentials without keychain access.
  */
 function createCredentialManager(workspaceRootPath: string): CredentialManagerInterface {
+  const logCredentialCacheReadError = (message: string) => {
+    console.error(message);
+  };
+
   return {
     hasValidCredentials: async (source: LoadedSource): Promise<boolean> => {
-      const token = readCredentialCache(workspaceRootPath, source.config.slug);
+      const token = readCredentialCache(
+        workspaceRootPath,
+        source.config.slug,
+        logCredentialCacheReadError,
+      );
       return token !== null;
     },
 
     getToken: async (source: LoadedSource): Promise<string | null> => {
-      return readCredentialCache(workspaceRootPath, source.config.slug);
+      return readCredentialCache(
+        workspaceRootPath,
+        source.config.slug,
+        logCredentialCacheReadError,
+      );
     },
 
     refresh: async (_source: LoadedSource): Promise<string | null> => {


### PR DESCRIPTION
## What this PR does

Routes the session MCP server's credential-cache path construction through the existing validated source-directory helper, so unsafe source slugs are rejected before any credential-cache filesystem access.

It also keeps ordinary cache misses quiet while logging corrupt or otherwise unreadable cache files, and adds focused tests for the valid, missing, expired, unreadable, and traversal-slug cases.

## Why it's needed

#5909 identified one remaining source-slug-to-path call site in the credential cache reader. The old path construction joined the workspace root, `sources`, and `sourceSlug` directly, which left this subprocess path out of sync with the validated source helpers used elsewhere.

Invalid slug failures should not look the same as "no cached credential". This PR lets slug validation fail before the cache-read catch block, while preserving the existing null-return behavior for normal cache misses and expired entries.

## Reviewer Test Plan

### How to verify

From `packages/desktop/packages/session-mcp-server`:

```bash
bun test src/credential-cache.test.ts
bun run build
bunx tsc -p tsconfig.json --noEmit --allowImportingTsExtensions
```

From the repository root:

```bash
git diff --check HEAD
```

### Evidence (Before & After)

Before: credential-cache paths were built by directly joining `sourceSlug`, so a malformed slug like `../sessions` could be resolved before any slug validation.

After: `../sessions` throws `Invalid source slug: "../sessions"` before filesystem access; missing cache files still return `null`; corrupt cache JSON returns `null` with a diagnostic log. The focused Bun test covers these outcomes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 26.5.1, Bun 1.3.14.

## Risk & Scope

- Main risk or tradeoff: Invalid source slugs now surface as validation errors from credential-cache reads instead of being treated as cache misses. That is intentional so unsafe slugs cannot silently proceed through the credential cache path.
- Not validated / out of scope: This PR is scoped to the session MCP server credential-cache path and diagnostics slice. Shared config validator error wording is being handled separately in #5911; the broader test-isolation note in #5909 is not changed here.
- Breaking changes / migration notes: None expected for valid source slugs. Existing missing, expired, and empty cache behavior stays `null`.

## Linked Issues

Refs #5909

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让 session MCP server 的 credential-cache 路径构造复用已有的、带 source slug 校验的 source-directory helper，因此不安全的 source slug 会在任何 credential-cache 文件访问前被拒绝。

同时，它保留普通 cache miss 的静默行为，但会为损坏或其它不可读的 cache 文件记录诊断日志，并补充了覆盖有效 cache、缺失 cache、过期 cache、不可读 cache 和路径遍历 slug 的 focused tests。

## Why it's needed

#5909 指出了 credential cache reader 里还存在一个 source-slug-to-path 调用点。旧实现直接拼接 workspace root、`sources` 和 `sourceSlug`，导致这个 subprocess 路径没有和其它地方使用的已校验 source helper 保持一致。

非法 slug 失败不应该和“没有缓存凭证”表现得一样。这个 PR 让 slug 校验在 cache-read catch 块之前失败，同时保留普通 cache miss 和过期 cache 返回 `null` 的现有行为。

## Reviewer Test Plan

### How to verify

在 `packages/desktop/packages/session-mcp-server` 下运行：

```bash
bun test src/credential-cache.test.ts
bun run build
bunx tsc -p tsconfig.json --noEmit --allowImportingTsExtensions
```

在仓库根目录运行：

```bash
git diff --check HEAD
```

### Evidence (Before & After)

Before：credential-cache 路径直接拼接 `sourceSlug`，因此像 `../sessions` 这样的异常 slug 可能在任何 slug 校验前被解析成路径。

After：`../sessions` 会在文件系统访问前抛出 `Invalid source slug: "../sessions"`；缺失的 cache 文件仍返回 `null`；损坏的 cache JSON 返回 `null` 并记录诊断日志。focused Bun test 覆盖了这些结果。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 26.5.1，Bun 1.3.14。

## Risk & Scope

- Main risk or tradeoff：非法 source slug 现在会从 credential-cache 读取中表现为校验错误，而不是被当成 cache miss。这是有意的，避免不安全 slug 静默进入 credential cache 路径。
- Not validated / out of scope：这个 PR 只覆盖 session MCP server credential-cache 路径和诊断这一块。shared config validator 的错误文案由 #5911 单独处理；#5909 中更宽的 test-isolation 事项不在本 PR 范围内。
- Breaking changes / migration notes：对合法 source slug 没有预期破坏性变化。缺失、过期、空 cache 仍保持返回 `null` 的现有行为。

## Linked Issues

Refs #5909

## AI Assistance Disclosure

我使用 Codex 审查改动、按现有模式做 sanity-check，并辅助发现潜在边界情况。

</details>
