### PR TITLE
fix(desktop): harden remaining source path validation

### DIFF
--- a/packages/desktop/packages/server-core/src/handlers/rpc/sources.test.ts
+++ b/packages/desktop/packages/server-core/src/handlers/rpc/sources.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, mock } from 'bun:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { RPC_CHANNELS } from '@craft-agent/shared/protocol'
+import type { HandlerFn, RpcServer } from '@craft-agent/server-core/transport'
+import type { HandlerDeps } from '../handler-deps'
+
+let workspaceRoot = ''
+
+mock.module('@craft-agent/shared/config', () => ({
+  getWorkspaceByNameOrId: () => ({
+    id: 'workspace-1',
+    name: 'Workspace',
+    rootPath: workspaceRoot,
+  }),
+}))
+
+await import('@craft-agent/shared/agent')
+const { registerSourcesHandlers } = await import('./sources')
+
+function createSourcesHandlers() {
+  const handlers = new Map<string, HandlerFn>()
+  const warnings: unknown[][] = []
+  const errors: unknown[][] = []
+  const server: RpcServer = {
+    handle(channel, handler) {
+      handlers.set(channel, handler)
+    },
+    push() {},
+    async invokeClient() {
+      return undefined
+    },
+  }
+
+  const deps: HandlerDeps = {
+    sessionManager: {} as HandlerDeps['sessionManager'],
+    oauthFlowStore: {} as HandlerDeps['oauthFlowStore'],
+    platform: {
+      appRootPath: '/',
+      resourcesPath: '/',
+      isPackaged: false,
+      appVersion: '0.0.0-test',
+      isDebugMode: true,
+      logger: {
+        info: () => {},
+        warn: (...args: unknown[]) => warnings.push(args),
+        error: (...args: unknown[]) => errors.push(args),
+        debug: () => {},
+      },
+      imageProcessor: {
+        getMetadata: async () => null,
+        process: async (buffer: Buffer) => buffer,
+      },
+    },
+  }
+
+  registerSourcesHandlers(server, deps)
+
+  const getPermissions = handlers.get(RPC_CHANNELS.sources.GET_PERMISSIONS)
+  if (!getPermissions) {
+    throw new Error('GET_PERMISSIONS handler not registered')
+  }
+
+  return { getPermissions, warnings, errors }
+}
+
+describe('source permissions RPC diagnostics', () => {
+  it('logs invalid source slugs separately from permissions file read errors', async () => {
+    workspaceRoot = mkdtempSync(join(tmpdir(), 'source-rpc-permissions-'))
+    try {
+      const { getPermissions, warnings, errors } = createSourcesHandlers()
+
+      const result = await getPermissions(
+        { clientId: 'c1', workspaceId: null, webContentsId: null },
+        'workspace-1',
+        '../sessions',
+      )
+
+      expect(result).toBeNull()
+      expect(errors).toHaveLength(0)
+      expect(warnings).toHaveLength(1)
+      expect(String(warnings[0]?.[0])).toBe('Invalid source slug for permissions:')
+      expect(String(warnings[0]?.[1])).toBe('Invalid source slug: "../sessions"')
+    } finally {
+      rmSync(workspaceRoot, { recursive: true, force: true })
+      workspaceRoot = ''
+    }
+  })
+})

--- a/packages/desktop/packages/server-core/src/handlers/rpc/sources.ts
+++ b/packages/desktop/packages/server-core/src/handlers/rpc/sources.ts
@@ -6,6 +6,10 @@ import { getCredentialManager } from '@craft-agent/shared/credentials'
 import type { RpcServer } from '@craft-agent/server-core/transport'
 import type { HandlerDeps } from '../handler-deps'
 
+function isInvalidSourceSlugError(error: unknown): boolean {
+  return error instanceof Error && error.message.startsWith('Invalid source slug:')
+}
+
 export const HANDLED_CHANNELS = [
   RPC_CHANNELS.sources.GET,
   RPC_CHANNELS.sources.CREATE,
@@ -105,7 +109,11 @@ export function registerSourcesHandlers(server: RpcServer, deps: HandlerDeps): v
       const content = readFileSync(path, 'utf-8')
       return safeJsonParse(content)
     } catch (error) {
-      log.error('Error reading permissions config:', error)
+      if (isInvalidSourceSlugError(error)) {
+        log.warn('Invalid source slug for permissions:', error instanceof Error ? error.message : error)
+      } else {
+        log.error('Error reading permissions config:', error)
+      }
       return null
     }
   })

--- a/packages/desktop/packages/session-mcp-server/src/credential-cache.test.ts
+++ b/packages/desktop/packages/session-mcp-server/src/credential-cache.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getCredentialCachePath, readCredentialCache } from './credential-cache';
+
+describe('credential cache source slug validation', () => {
+  it('resolves valid source slugs under the workspace sources directory', () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'credential-cache-'));
+
+    expect(getCredentialCachePath(workspaceRoot, 'valid-source')).toBe(
+      join(workspaceRoot, 'sources', 'valid-source', '.credential-cache.json')
+    );
+  });
+
+  it('rejects traversal source slugs before constructing credential cache paths', () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'credential-cache-'));
+
+    expect(() => getCredentialCachePath(workspaceRoot, '../sessions')).toThrow(
+      'Invalid source slug: "../sessions"'
+    );
+  });
+
+  it('returns null for invalid source slugs instead of reading neighboring cache files', () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'credential-cache-'));
+    const sessionsDir = join(workspaceRoot, 'sessions');
+    mkdirSync(sessionsDir, { recursive: true });
+    writeFileSync(join(sessionsDir, '.credential-cache.json'), JSON.stringify({ value: 'secret-token' }));
+
+    expect(readCredentialCache(workspaceRoot, '../sessions')).toBeNull();
+  });
+});

--- a/packages/desktop/packages/session-mcp-server/src/credential-cache.ts
+++ b/packages/desktop/packages/session-mcp-server/src/credential-cache.ts
@@ -1,0 +1,45 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { assertValidSourceSlug } from '@craft-agent/session-tools-core';
+
+/**
+ * Credential cache entry format (matches main process format).
+ * Written by Electron main process, read by this server.
+ */
+interface CredentialCacheEntry {
+  value: string;
+  expiresAt?: number;
+}
+
+/**
+ * Get the path to a source's credential cache file.
+ * The main process writes decrypted credentials to these files.
+ */
+export function getCredentialCachePath(workspaceRootPath: string, sourceSlug: string): string {
+  assertValidSourceSlug(sourceSlug);
+  return join(workspaceRootPath, 'sources', sourceSlug, '.credential-cache.json');
+}
+
+/**
+ * Read credentials from the cache file for a source.
+ * Returns null if the cache doesn't exist, the slug is invalid, or the cache is expired.
+ */
+export function readCredentialCache(workspaceRootPath: string, sourceSlug: string): string | null {
+  try {
+    const cachePath = getCredentialCachePath(workspaceRootPath, sourceSlug);
+    if (!existsSync(cachePath)) {
+      return null;
+    }
+
+    const content = readFileSync(cachePath, 'utf-8');
+    const cache = JSON.parse(content) as CredentialCacheEntry;
+
+    if (cache.expiresAt && Date.now() > cache.expiresAt) {
+      return null;
+    }
+
+    return cache.value || null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/desktop/packages/session-mcp-server/src/index.ts
+++ b/packages/desktop/packages/session-mcp-server/src/index.ts
@@ -33,6 +33,7 @@ import {
 import { existsSync, readFileSync, readdirSync, statSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { isDeveloperFeedbackEnabled } from '@craft-agent/shared/feature-flags';
+import { readCredentialCache } from './credential-cache';
 // Import from session-tools-core
 import {
   type SessionToolContext,
@@ -78,49 +79,6 @@ function sendCallback(callback: CallbackMessage): void {
 // ============================================================
 // Credential Cache Access
 // ============================================================
-
-/**
- * Credential cache entry format (matches main process format).
- * Written by Electron main process, read by this server.
- */
-interface CredentialCacheEntry {
-  value: string;
-  expiresAt?: number;
-}
-
-/**
- * Get the path to a source's credential cache file.
- * The main process writes decrypted credentials to these files.
- */
-function getCredentialCachePath(workspaceRootPath: string, sourceSlug: string): string {
-  return join(workspaceRootPath, 'sources', sourceSlug, '.credential-cache.json');
-}
-
-/**
- * Read credentials from the cache file for a source.
- * Returns null if the cache doesn't exist or is expired.
- */
-function readCredentialCache(workspaceRootPath: string, sourceSlug: string): string | null {
-  const cachePath = getCredentialCachePath(workspaceRootPath, sourceSlug);
-
-  try {
-    if (!existsSync(cachePath)) {
-      return null;
-    }
-
-    const content = readFileSync(cachePath, 'utf-8');
-    const cache = JSON.parse(content) as CredentialCacheEntry;
-
-    // Check expiry if set
-    if (cache.expiresAt && Date.now() > cache.expiresAt) {
-      return null;
-    }
-
-    return cache.value || null;
-  } catch {
-    return null;
-  }
-}
 
 /**
  * Create a credential manager that reads from credential cache files.

--- a/packages/desktop/packages/shared/src/agent/permissions-config.ts
+++ b/packages/desktop/packages/shared/src/agent/permissions-config.ts
@@ -514,7 +514,8 @@ export function loadRawSourcePermissions(workspaceRootPath: string, sourceSlug: 
     const json = safeJsonParse(content);
     const result = PermissionsConfigSchema.safeParse(json);
     return result.success ? result.data : null;
-  } catch {
+  } catch (error) {
+    debug('[Permissions] Error loading raw source permissions:', error);
     return null;
   }
 }

--- a/packages/desktop/packages/shared/src/config/__tests__/source-slug-validation.test.ts
+++ b/packages/desktop/packages/shared/src/config/__tests__/source-slug-validation.test.ts
@@ -11,6 +11,7 @@ describe('source slug validation in config validators', () => {
     const result = validateSource(workspaceRoot, '../sessions');
 
     expect(result.valid).toBe(false);
+    expect(result.errors[0]?.file).toBe('sources/<invalid>/config.json');
     expect(result.errors[0]?.message).toBe('Invalid source slug: "../sessions"');
   });
 
@@ -39,7 +40,7 @@ describe('source slug validation in config validators', () => {
     const result = validateSourcePermissions(workspaceRoot, 'legacy-source-');
 
     expect(result.valid).toBe(false);
-    expect(result.errors[0]?.file).toBe('sources/legacy-source-/permissions.json');
+    expect(result.errors[0]?.file).toBe('sources/<invalid>/permissions.json');
     expect(result.errors[0]?.message).toBe('Invalid source slug: "legacy-source-"');
   });
 });

--- a/packages/desktop/packages/shared/src/config/validators.ts
+++ b/packages/desktop/packages/shared/src/config/validators.ts
@@ -377,6 +377,24 @@ export function assertValidSourceSlug(sourceSlug: string): void {
   }
 }
 
+function getSourceValidationFile(slug: string): string {
+  try {
+    assertValidSourceSlug(slug);
+    return `sources/${slug}/config.json`;
+  } catch {
+    return 'sources/<invalid>/config.json';
+  }
+}
+
+function getSourcePermissionsValidationFile(sourceSlug: string): string {
+  try {
+    assertValidSourceSlug(sourceSlug);
+    return `sources/${sourceSlug}/permissions.json`;
+  } catch {
+    return 'sources/<invalid>/permissions.json';
+  }
+}
+
 // MCP source supports two transport types:
 // - HTTP/SSE: requires url and authType
 // - Stdio: requires command (and optional args, env)
@@ -534,7 +552,7 @@ export function validateSourceConfigContent(jsonString: string): ValidationResul
  */
 export function validateSource(workspaceId: string, slug: string): ValidationResult {
   const sourcesDir = getWorkspaceSourcesPath(workspaceId);
-  const file = `sources/${slug}/config.json`;
+  const file = getSourceValidationFile(slug);
 
   try {
     assertValidSourceSlug(slug);
@@ -1482,6 +1500,7 @@ export function validateWorkspacePermissions(workspaceRoot: string): ValidationR
  * @param sourceSlug - Source slug
  */
 export function validateSourcePermissions(workspaceRoot: string, sourceSlug: string): ValidationResult {
+  const file = getSourcePermissionsValidationFile(sourceSlug);
   let permissionsPath: string;
   try {
     permissionsPath = getSourcePermissionsPath(workspaceRoot, sourceSlug);
@@ -1489,7 +1508,7 @@ export function validateSourcePermissions(workspaceRoot: string, sourceSlug: str
     return {
       valid: false,
       errors: [{
-        file: `sources/${sourceSlug}/permissions.json`,
+        file,
         path: '',
         message: error instanceof Error ? error.message : 'Invalid source slug',
         severity: 'error',
@@ -1498,7 +1517,7 @@ export function validateSourcePermissions(workspaceRoot: string, sourceSlug: str
     };
   }
 
-  return validatePermissionsFile(permissionsPath, `sources/${sourceSlug}/permissions.json`);
+  return validatePermissionsFile(permissionsPath, file);
 }
 
 /**

--- a/packages/desktop/packages/shared/src/sources/__tests__/credential-manager-renew.test.ts
+++ b/packages/desktop/packages/shared/src/sources/__tests__/credential-manager-renew.test.ts
@@ -9,13 +9,6 @@ import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
 import { SourceCredentialManager } from '../credential-manager.ts';
 import type { FolderSourceConfig } from '../types.ts';
 
-// Mock storage module to prevent disk I/O
-mock.module('../storage.ts', () => ({
-  markSourceAuthenticated: mock(() => true),
-  loadSourceConfig: mock(() => null),
-  saveSourceConfig: mock(() => {}),
-}));
-
 // Mock credentials module — track set() calls to verify saves
 let setCalls: unknown[][] = [];
 const mockGet = mock(() => Promise.resolve(null as unknown));


### PR DESCRIPTION
This PR hardens the remaining desktop source slug-to-path edges from #5909 without relaxing the source slug guard introduced by #5829 or duplicating the validation/RPC behavior normalization in #5911.

## What this PR does

- Validates source slugs before the session MCP server resolves a source credential cache path, so path-like inputs such as `../sessions` cannot be joined into `sources/../sessions/.credential-cache.json`.
- Keeps credential cache reads graceful: invalid slugs, missing cache files, expired cache entries, and malformed cache contents still return `null` instead of surfacing a hard tool failure.
- Sanitizes validation result `file` fields for invalid source slugs by using placeholders such as `sources/<invalid>/config.json` and `sources/<invalid>/permissions.json` instead of echoing unsafe slug-derived paths.
- Adds debug logging for raw source permission load failures, matching the nearby normalized source permission loader behavior.
- Separates invalid source slug diagnostics from source permissions file I/O failures in the source permissions RPC handler.
- Removes an unnecessary source storage module mock from the renew-endpoint credential tests so it no longer leaks into later source storage slug tests in the same Bun process.

## Why it's needed

This is a follow-up to #5829 and #5911. #5829 added the core path traversal guard for source deletion by rejecting path-like source slugs before filesystem path construction. #5911 normalizes several validation and RPC boundary behaviors around invalid or legacy source slugs.

A few remaining defensive edges still needed cleanup. The session MCP credential cache helper directly joined `sourceSlug` into a filesystem path, making it the last reviewed source-slug-to-path construction site that did not explicitly run the slug guard first. Some diagnostics also made invalid slug failures harder to interpret: validation results could display paths derived from the unsafe slug itself, the raw permissions loader silently swallowed failures, and the source permissions RPC handler logged invalid slug assertions as generic permissions file read errors.

This PR keeps the same strict slug regex and focuses on the remaining API boundaries: source slugs are validated before credential cache path construction, invalid slug diagnostics are classified as caller input issues rather than disk I/O, unsafe display paths are redacted, and the local test pair that previously depended on run order is deterministic again.

## Possible call chain / impact

The affected paths are session MCP credential cache reads, source validation diagnostics, source permissions RPC diagnostics, raw permissions loading, and local test isolation:

```text
Session MCP tool execution
  -> createCredentialManager(workspaceRootPath)
    -> hasValidCredentials(...) / getToken(...)
      -> readCredentialCache(workspaceRootPath, source.config.slug)
        -> getCredentialCachePath(workspaceRootPath, sourceSlug)
          -> assertValidSourceSlug(sourceSlug)
          -> workspaceRootPath/sources/<slug>/.credential-cache.json
```

Before this PR, the credential cache path was constructed directly from `sourceSlug`. A path-like slug such as `../sessions` could resolve toward `sources/../sessions/.credential-cache.json` before the read failed or returned data. This PR validates the slug before joining the cache path; invalid cache slugs still return `null` through the credential manager, preserving the existing missing-credential behavior.

```text
Validation call: validateSource(workspaceRoot, sourceSlug)
  -> getSourceValidationFile(sourceSlug)
    -> assertValidSourceSlug(sourceSlug)
    -> sources/<invalid>/config.json for invalid input
```

Before this PR, invalid input such as `../sessions` could be reflected in the validation result as `sources/../sessions/config.json`. This PR keeps the validation error message but uses a sanitized display path so validation output does not look like a resolved workspace path.

```text
Source permissions UI/RPC request
  -> RPC sources:getPermissions
    -> getSourcePermissionsPath(workspace.rootPath, sourceSlug)
      -> getSourcePath(...)
        -> assertValidSourceSlug(...)
```

Before this PR, an invalid slug assertion in this path was logged as `Error reading permissions config`, which points maintainers toward filesystem or JSON problems. This PR logs invalid slug failures with a warning specific to source slug validation while preserving the existing `null` return contract.

```text
Bun test run
  -> credential-manager-renew.test.ts
    -> unnecessary mock.module('../storage.ts')
  -> storage-source-slug.test.ts
    -> imports source storage helpers
```

Before this PR, running the renew-endpoint credential tests before the storage source slug tests in one Bun process could leave the storage module mocked, causing the later storage test to list no real sources. This PR removes the unused storage mock so the focused pair is order-independent.

This PR only changes these remaining hardening and diagnostics paths. It does not relax the source slug regex, change source creation or deletion behavior, alter source config parsing, change guide parsing, modify source connection tests, or duplicate the `config_validate`, `source_test`, `validateAllSources`, and source delete RPC behavior changes handled in #5911.

## Reviewer Test Plan

### How to verify

Confirm that:

- A session MCP credential cache read for `sourceSlug: "../sessions"` returns `null` and does not read `sessions/.credential-cache.json` outside the source directory.
- Invalid source validation results report `sources/<invalid>/config.json` or `sources/<invalid>/permissions.json` while preserving the underlying `Invalid source slug` error message.
- Source permissions RPC reads return `null` for invalid slugs and log `Invalid source slug for permissions:` as a warning instead of logging a generic permissions file read error.
- Running `credential-manager-renew.test.ts` before `storage-source-slug.test.ts` no longer leaves source storage mocked for the second file.

Commands run:
- `cd packages/desktop && bun test packages/session-mcp-server/src/credential-cache.test.ts packages/shared/src/config/__tests__/source-slug-validation.test.ts packages/shared/src/agent/__tests__/permissions-config-source-slug.test.ts packages/server-core/src/handlers/rpc/sources.test.ts` -> 8 pass, 0 fail
- `cd packages/desktop && bun test packages/shared/src/sources/__tests__/credential-manager-renew.test.ts packages/shared/src/sources/__tests__/storage-source-slug.test.ts` -> 14 pass, 0 fail
- `cd packages/desktop/packages/shared && bun run tsc --noEmit` -> pass
- `cd packages/desktop/packages/server-core && bun run tsc --noEmit` -> pass
- `cd packages/desktop/packages/session-mcp-server && bun run build` -> pass
- `cd packages/desktop/packages/session-mcp-server && bun run tsc --noEmit` -> fails in existing `../session-tools-core/src/**` `.ts` import extension configuration errors; no errors are reported for this PR's changed session MCP files after the new local imports were switched to extensionless form
- JD-Cloud Linux (`Ubuntu 24.04.2 LTS`, `Linux 6.8.0-53-generic`, `Node v22.23.1`, `Bun 1.3.14`): `cd packages/desktop && ELECTRON_SKIP_BINARY_DOWNLOAD=1 bun install` -> pass
- JD-Cloud Linux: `cd packages/desktop && bun test packages/session-mcp-server/src/credential-cache.test.ts packages/shared/src/config/__tests__/source-slug-validation.test.ts packages/shared/src/agent/__tests__/permissions-config-source-slug.test.ts packages/server-core/src/handlers/rpc/sources.test.ts` -> 8 pass, 0 fail
- JD-Cloud Linux: `cd packages/desktop && bun test packages/shared/src/sources/__tests__/credential-manager-renew.test.ts packages/shared/src/sources/__tests__/storage-source-slug.test.ts` -> 14 pass, 0 fail
- JD-Cloud Linux: `cd packages/desktop/packages/shared && bun run tsc --noEmit` -> pass
- JD-Cloud Linux: `cd packages/desktop/packages/server-core && bun run tsc --noEmit` -> pass
- JD-Cloud Linux: `cd packages/desktop/packages/session-mcp-server && bun run build` -> pass
- JD-Cloud Linux: `cd packages/desktop/packages/session-mcp-server && bun run tsc --noEmit` -> reproduces the existing `../session-tools-core/src/**` `.ts` import extension configuration errors only; no changed session MCP files are reported

### Evidence (Before & After)

No UI evidence; this is non-UI path handling, diagnostics, and test isolation behavior covered by focused regression tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ✅ tested on JD-Cloud |

### Environment (optional)

Windows PowerShell, Bun 1.3.12, Node v22.22.3. JD-Cloud Ubuntu 24.04.2 LTS (`Linux 6.8.0-53-generic`), Bun 1.3.14, Node v22.23.1.

## Risk & Scope

- Main risk or tradeoff: invalid credential cache slugs now return `null` before path construction, which is intentionally the same observable result as a missing or unusable credential cache.
- Not validated / out of scope: the behavior normalization work in #5911, broader source creation semantics, source config parsing, guide parsing, connection testing, and unrelated desktop-wide typecheck failures.
- Breaking changes / migration notes: None expected; strict source slug validation is preserved and no valid source slug path changes.

## Linked Issues

Closes #5909

<details>
<summary>中文说明</summary>

本 PR 加固 #5909 中剩余的桌面端 source slug 到文件系统路径的边界，同时不放宽 #5829 引入的 source slug guard，也不重复 #5911 已处理的 validation / RPC 行为归一化。

## What this PR does

- 在 session MCP server 解析 source credential cache 路径前先验证 source slug，因此 `../sessions` 这类 path-like 输入不能被拼成 `sources/../sessions/.credential-cache.json`。
- 保持 credential cache read 的宽容返回：无效 slug、cache 不存在、cache 过期、cache 内容损坏都会继续返回 `null`，不会变成硬失败。
- 对 invalid source slug 的 validation result `file` 字段做脱敏，使用 `sources/<invalid>/config.json` 和 `sources/<invalid>/permissions.json` 这类占位路径，而不是回显由不安全 slug 拼出来的路径。
- 给 raw source permissions load failure 增加 debug 日志，与旁边的 normalized source permissions loader 行为保持一致。
- 在 source permissions RPC handler 中区分 invalid source slug 诊断和 source permissions 文件 I/O 失败。
- 移除 renew-endpoint credential 测试中不必要的 source storage module mock，避免它泄漏到同一个 Bun 进程后续运行的 source storage slug 测试里。

## Why it's needed

这是 #5829 和 #5911 的后续。#5829 已经通过在文件系统路径构造前拒绝 path-like source slug，修复了 source deletion 的核心路径穿越防护。#5911 则统一了若干 invalid / legacy source slug 在 validation 和 RPC 边界上的行为。

剩余的一些防御性边界仍需要收尾。session MCP credential cache helper 会直接把 `sourceSlug` 拼进文件系统路径，它是本轮 review 中剩余的、没有显式先走 slug guard 的 source-slug-to-path 构造点。部分诊断也会让 invalid slug 失败更难排查：validation result 可能展示由不安全 slug 拼出来的路径，raw permissions loader 会静默吞掉失败，source permissions RPC handler 会把 invalid slug assertion 记录成泛化的 permissions file read error。

本 PR 保留相同的严格 slug regex，并只聚焦剩余 API 边界：credential cache 路径构造前先验证 source slug，invalid slug 诊断被归类为调用方输入问题而不是磁盘 I/O，unsafe display path 被占位符替代，本地测试组合也不再依赖运行顺序。

## Possible call chain / impact

受影响路径是 session MCP credential cache read、source validation diagnostics、source permissions RPC diagnostics、raw permissions loading 以及本地测试隔离：

```text
Session MCP tool execution
  -> createCredentialManager(workspaceRootPath)
    -> hasValidCredentials(...) / getToken(...)
      -> readCredentialCache(workspaceRootPath, source.config.slug)
        -> getCredentialCachePath(workspaceRootPath, sourceSlug)
          -> assertValidSourceSlug(sourceSlug)
          -> workspaceRootPath/sources/<slug>/.credential-cache.json
```

在本 PR 之前，credential cache path 直接由 `sourceSlug` 构造。`../sessions` 这类 path-like slug 可能在读取失败或返回数据前，先被解析到 `sources/../sessions/.credential-cache.json`。本 PR 在 join cache path 前验证 slug；无效 cache slug 仍然通过 credential manager 返回 `null`，保持原有 missing credential 语义。

```text
Validation call: validateSource(workspaceRoot, sourceSlug)
  -> getSourceValidationFile(sourceSlug)
    -> assertValidSourceSlug(sourceSlug)
    -> sources/<invalid>/config.json for invalid input
```

在本 PR 之前，`../sessions` 这类 invalid input 可能在 validation result 里显示为 `sources/../sessions/config.json`。本 PR 保留 validation error message，但使用脱敏 display path，避免验证输出看起来像一个被解析过的 workspace path。

```text
Source permissions UI/RPC request
  -> RPC sources:getPermissions
    -> getSourcePermissionsPath(workspace.rootPath, sourceSlug)
      -> getSourcePath(...)
        -> assertValidSourceSlug(...)
```

在本 PR 之前，这条路径里的 invalid slug assertion 会被记录成 `Error reading permissions config`，容易让维护者误判成文件系统或 JSON 问题。本 PR 对 invalid slug 使用专门 warning，同时保留原有 `null` 返回契约。

```text
Bun test run
  -> credential-manager-renew.test.ts
    -> unnecessary mock.module('../storage.ts')
  -> storage-source-slug.test.ts
    -> imports source storage helpers
```

在本 PR 之前，如果 renew-endpoint credential tests 先于 storage source slug tests 在同一个 Bun 进程里运行，storage module mock 可能残留，导致后一个 storage test 列不出真实 source。本 PR 移除未使用的 storage mock，让这个聚焦测试组合不再依赖运行顺序。

本 PR 只改变这些剩余 hardening 和 diagnostics 路径。它不会放宽 source slug regex，不会改变 source 创建或删除行为，不会改变 source config parsing，不会改变 guide parsing，不会修改 source connection tests，也不重复 #5911 中已处理的 `config_validate`、`source_test`、`validateAllSources` 和 source delete RPC 行为变更。

## Reviewer Test Plan

### How to verify

确认：

- session MCP credential cache 对 `sourceSlug: "../sessions"` 返回 `null`，并且不会读取 source 目录外的 `sessions/.credential-cache.json`。
- invalid source validation result 会报告 `sources/<invalid>/config.json` 或 `sources/<invalid>/permissions.json`，同时保留底层 `Invalid source slug` 错误信息。
- Source permissions RPC 对 invalid slug 返回 `null`，并以 `Invalid source slug for permissions:` 记录 warning，而不是泛化 permissions file read error。
- `credential-manager-renew.test.ts` 在 `storage-source-slug.test.ts` 前运行时，不再把 source storage mock 泄漏给第二个测试文件。

已运行命令：
- `cd packages/desktop && bun test packages/session-mcp-server/src/credential-cache.test.ts packages/shared/src/config/__tests__/source-slug-validation.test.ts packages/shared/src/agent/__tests__/permissions-config-source-slug.test.ts packages/server-core/src/handlers/rpc/sources.test.ts` -> 8 pass, 0 fail
- `cd packages/desktop && bun test packages/shared/src/sources/__tests__/credential-manager-renew.test.ts packages/shared/src/sources/__tests__/storage-source-slug.test.ts` -> 14 pass, 0 fail
- `cd packages/desktop/packages/shared && bun run tsc --noEmit` -> pass
- `cd packages/desktop/packages/server-core && bun run tsc --noEmit` -> pass
- `cd packages/desktop/packages/session-mcp-server && bun run build` -> pass
- `cd packages/desktop/packages/session-mcp-server && bun run tsc --noEmit` -> 因既有 `../session-tools-core/src/**` `.ts` import extension 配置错误失败；新增 local import 改成 extensionless 之后，本 PR 改动的 session MCP 文件没有报错
- JD-Cloud Linux（`Ubuntu 24.04.2 LTS`、`Linux 6.8.0-53-generic`、`Node v22.23.1`、`Bun 1.3.14`）：`cd packages/desktop && ELECTRON_SKIP_BINARY_DOWNLOAD=1 bun install` -> pass
- JD-Cloud Linux：`cd packages/desktop && bun test packages/session-mcp-server/src/credential-cache.test.ts packages/shared/src/config/__tests__/source-slug-validation.test.ts packages/shared/src/agent/__tests__/permissions-config-source-slug.test.ts packages/server-core/src/handlers/rpc/sources.test.ts` -> 8 pass, 0 fail
- JD-Cloud Linux：`cd packages/desktop && bun test packages/shared/src/sources/__tests__/credential-manager-renew.test.ts packages/shared/src/sources/__tests__/storage-source-slug.test.ts` -> 14 pass, 0 fail
- JD-Cloud Linux：`cd packages/desktop/packages/shared && bun run tsc --noEmit` -> pass
- JD-Cloud Linux：`cd packages/desktop/packages/server-core && bun run tsc --noEmit` -> pass
- JD-Cloud Linux：`cd packages/desktop/packages/session-mcp-server && bun run build` -> pass
- JD-Cloud Linux：`cd packages/desktop/packages/session-mcp-server && bun run tsc --noEmit` -> 仅复现既有 `../session-tools-core/src/**` `.ts` import extension 配置错误；未报告本 PR 改动的 session MCP 文件错误

### Evidence (Before & After)

无 UI 证据；这是非 UI 的 path handling、diagnostics 和 test isolation 行为，已由聚焦回归测试覆盖。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ✅ tested on JD-Cloud |

### Environment (optional)

Windows PowerShell, Bun 1.3.12, Node v22.22.3. JD-Cloud Ubuntu 24.04.2 LTS（`Linux 6.8.0-53-generic`）、Bun 1.3.14、Node v22.23.1。

## Risk & Scope

- Main risk or tradeoff: invalid credential cache slug 现在会在 path construction 之前返回 `null`，这与 missing / unusable credential cache 的可观察结果一致，是有意保持的行为。
- Not validated / out of scope: #5911 中的行为归一化、更广泛 source creation 语义、source config parsing、guide parsing、connection testing，以及无关的 desktop-wide typecheck 失败。
- Breaking changes / migration notes: 预期没有破坏性变更；严格 source slug validation 保持不变，有效 source slug 的路径行为不变。

## Linked Issues

Closes #5909

</details>