### PR TITLE
fix(core): silence unknown schema format warnings

### DIFF
--- a/packages/core/src/utils/schemaValidator.test.ts
+++ b/packages/core/src/utils/schemaValidator.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { SchemaValidator } from './schemaValidator.js';
 
 describe('SchemaValidator', () => {
@@ -65,6 +65,7 @@ describe('SchemaValidator', () => {
   });
 
   it('allows custom format values', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const schema = {
       type: 'object',
       properties: {
@@ -88,7 +89,12 @@ describe('SchemaValidator', () => {
       mask: 'foo.bar,biz.baz',
       foo: 'some value',
     };
-    expect(SchemaValidator.validate(schema, params)).toBeNull();
+    try {
+      expect(SchemaValidator.validate(schema, params)).toBeNull();
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it('allows valid values for known formats', () => {

--- a/packages/core/src/utils/schemaValidator.ts
+++ b/packages/core/src/utils/schemaValidator.ts
@@ -24,10 +24,26 @@ const ajvOptions = {
   // strictSchema defaults to true and prevents use of JSON schemas that
   // include unrecognized keywords. The JSON schema spec specifically allows
   // for the use of non-standard keywords and the spec-compliant behavior
-  // is to ignore those keywords. Note that setting this to false also
-  // allows use of non-standard or custom formats (the unknown format value
-  // will be logged but the schema will still be considered valid).
+  // is to ignore those keywords.
   strictSchema: false,
+  // Ajv still validates known formats, but MCP/OpenAPI schemas often include
+  // annotation-only formats like uint64 that would otherwise spam stderr.
+  logger: {
+    // eslint-disable-next-line no-console
+    log: (...args: unknown[]) => console.log(...args),
+    warn: (...args: unknown[]) => {
+      if (
+        typeof args[0] === 'string' &&
+        args[0].startsWith('unknown format ')
+      ) {
+        return;
+      }
+      // eslint-disable-next-line no-console
+      console.warn(...args);
+    },
+    // eslint-disable-next-line no-console
+    error: (...args: unknown[]) => console.error(...args),
+  },
 };
 
 // Draft-07 validator (default)


### PR DESCRIPTION
## What this PR does

Silences Ajv's repeated `unknown format "... " ignored in schema` warnings in the lenient runtime schema validator used for tool schemas.

The validator still accepts custom MCP/OpenAPI formats as annotations, and it still validates known formats such as `date`. The fix uses a narrow Ajv logger filter instead of disabling format validation globally.

## Why it's needed

Some MCP servers expose OpenAPI-style schema formats such as `uint64`. Ajv treats those unknown formats as valid when `strictSchema: false`, but it still writes a warning to `console.warn`. In the CLI that warning goes to stderr and pollutes the TUI repeatedly on startup and refresh, as reported in #5897.

Using `validateFormats: false` would silence the warning, but it also disables validation for known formats. This PR keeps the existing validation behavior for known formats and only suppresses the non-actionable unknown-format warning.

## Reviewer Test Plan

### How to verify

From `packages/core`:

```bash
npx vitest run src/utils/schemaValidator.test.ts -t "allows custom format values|rejects invalid values for known formats"
npx vitest run src/utils/schemaValidator.test.ts
```

From the repository root:

```bash
npm run typecheck --workspace=packages/core
npx eslint packages/core/src/utils/schemaValidator.ts packages/core/src/utils/schemaValidator.test.ts --max-warnings 0
npx prettier --check packages/core/src/utils/schemaValidator.ts packages/core/src/utils/schemaValidator.test.ts
npm run build --workspace=packages/core
git diff --check
```

### Evidence (Before & After)

Before: `SchemaValidator.validate()` accepted custom formats, but Ajv called `console.warn` for each unknown format, e.g. `unknown format "google-duration" ignored in schema at path "#/properties/duration"`.

After: the same custom-format schema still validates successfully and no `console.warn` is emitted for unknown formats. The existing known-format regression test still rejects an invalid `format: "date"` value.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 26.5.1, Node.js v26.3.0, npm 11.16.0.

## Risk & Scope

- Main risk or tradeoff: The filter depends on Ajv's current unknown-format warning prefix. Other Ajv warnings and errors are still forwarded to the console.
- Not validated / out of scope: I did not stand up a BigQuery MCP server locally; the regression test reproduces the same Ajv warning path with custom formats.
- Breaking changes / migration notes: None expected. Runtime schema validation behavior is unchanged for valid data, invalid data, and known formats.

## Linked Issues

Fixes #5897

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 会静默运行时 lenient schema validator 中 Ajv 反复输出的 `unknown format "... " ignored in schema` 警告。

validator 仍然会把自定义 MCP/OpenAPI format 当作 annotation 接受，也仍然会校验 `date` 这类已知 format。本修复使用精确的 Ajv logger 过滤，而不是全局关闭 format 校验。

## Why it's needed

一些 MCP server 会暴露 `uint64` 这类 OpenAPI 风格的 schema format。`strictSchema: false` 时 Ajv 会把这些 unknown format 视为有效，但仍然写一条 `console.warn`。在 CLI 中这会进入 stderr，并在启动或刷新时反复污染 TUI，正是 #5897 报告的问题。

使用 `validateFormats: false` 也能消除警告，但会同时关闭已知 format 的校验。这个 PR 保留已知 format 的既有校验行为，只压掉不可操作的 unknown-format 警告。

## Reviewer Test Plan

### How to verify

在 `packages/core` 下运行：

```bash
npx vitest run src/utils/schemaValidator.test.ts -t "allows custom format values|rejects invalid values for known formats"
npx vitest run src/utils/schemaValidator.test.ts
```

在仓库根目录运行：

```bash
npm run typecheck --workspace=packages/core
npx eslint packages/core/src/utils/schemaValidator.ts packages/core/src/utils/schemaValidator.test.ts --max-warnings 0
npx prettier --check packages/core/src/utils/schemaValidator.ts packages/core/src/utils/schemaValidator.test.ts
npm run build --workspace=packages/core
git diff --check
```

### Evidence (Before & After)

Before：`SchemaValidator.validate()` 会接受自定义 format，但 Ajv 会对每个 unknown format 调用 `console.warn`，例如 `unknown format "google-duration" ignored in schema at path "#/properties/duration"`。

After：同一个自定义 format schema 仍能成功校验，并且不会为 unknown format 触发 `console.warn`。现有的已知 format 回归测试仍然会拒绝非法的 `format: "date"` 值。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 26.5.1，Node.js v26.3.0，npm 11.16.0。

## Risk & Scope

- Main risk or tradeoff：过滤逻辑依赖 Ajv 当前 unknown-format warning 的前缀。其它 Ajv warning 和 error 仍会转发到 console。
- Not validated / out of scope：我没有在本地启动 BigQuery MCP server；回归测试用自定义 format 复现了同一条 Ajv warning 路径。
- Breaking changes / migration notes：预期没有破坏性变化。对合法数据、非法数据以及已知 format 的运行时 schema 校验行为不变。

## Linked Issues

Fixes #5897

## AI Assistance Disclosure

我使用 Codex 审查改动、按现有模式做 sanity-check，并辅助发现潜在边界情况。

</details>
