### PR TITLE
fix(core): clear tool display after completion errors

### DIFF
--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -2541,6 +2541,52 @@ describe('CoreToolScheduler', () => {
     });
   });
 
+  it('clears displayed tool calls when completion finalization throws', async () => {
+    const execute = vi.fn().mockResolvedValue({
+      llmContent: 'alpha output',
+      returnDisplay: 'alpha output',
+    });
+    const toolsByName = new Map<string, MockTool>([
+      [
+        'alpha',
+        new MockTool({
+          name: 'alpha',
+          kind: Kind.Read,
+          execute,
+        }),
+      ],
+    ]);
+    const onAllToolCallsComplete = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('completion failed'));
+    const onToolCallsUpdate = vi.fn();
+    const { scheduler } = createSchedulerForLegacyToolTests({
+      toolsByName,
+      onAllToolCallsComplete,
+      onToolCallsUpdate,
+    });
+
+    await scheduler.schedule(
+      [
+        {
+          callId: 'call-alpha',
+          name: 'alpha',
+          args: { value: 'a' },
+          isClientInitiated: false,
+          prompt_id: 'prompt-finalization-throws',
+        },
+      ],
+      new AbortController().signal,
+    );
+
+    await vi.waitFor(() => {
+      expect(onAllToolCallsComplete).toHaveBeenCalled();
+    });
+    await vi.waitFor(() => {
+      expect(onToolCallsUpdate.mock.calls.at(-1)?.[0]).toEqual([]);
+    });
+  });
+
   it('applies PostToolBatch stop decisions and preserves additional context', async () => {
     const executeA = vi.fn().mockResolvedValue({
       llmContent: 'alpha output',

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -3934,15 +3934,18 @@ export class CoreToolScheduler {
         if (this.onAllToolCallsComplete) {
           await this.onAllToolCallsComplete(completedCalls);
         }
-        this.notifyToolCallsUpdate();
       } finally {
-        this.isFinalizingToolCalls = false;
-        // Always drain the queue, even if completion callbacks throw.
-        if (this.requestQueue.length > 0) {
-          const next = this.requestQueue.shift()!;
-          this._schedule(next.request, next.signal)
-            .then(next.resolve)
-            .catch(next.reject);
+        try {
+          this.notifyToolCallsUpdate();
+        } finally {
+          this.isFinalizingToolCalls = false;
+          // Always drain the queue, even if completion callbacks throw.
+          if (this.requestQueue.length > 0) {
+            const next = this.requestQueue.shift()!;
+            this._schedule(next.request, next.signal)
+              .then(next.resolve)
+              .catch(next.reject);
+          }
         }
       }
     }


### PR DESCRIPTION
## What this PR does

Ensures completed tool calls are cleared from the interactive display even when the completion finalization callback fails.

The scheduler already clears its internal completed-call state before invoking the completion callback. This change makes the display update run during finalization cleanup too, so the UI still receives the empty tool-call state if the callback throws.

## Why it's needed

Fixes a bug where an edit tool result summary could stay visible and be appended to every later response after completion finalization failed. In that failure path, the scheduler state was already empty, but the React display state never received the clearing update.

## Reviewer Test Plan

### How to verify

Review the regression test that mocks a failing completion callback and asserts the last tool-call display update is an empty array. The adjacent queue-drain regression still verifies that queued tool batches continue after a finalization error.

Commands run locally:

```sh
cd packages/core
npx vitest run src/core/coreToolScheduler.test.ts -t "clears displayed tool calls when completion finalization throws|drains queued tool calls when completion finalization throws"
npx vitest run src/core/coreToolScheduler.test.ts
npm run typecheck
npx eslint src/core/coreToolScheduler.ts src/core/coreToolScheduler.test.ts
npx prettier --check src/core/coreToolScheduler.ts src/core/coreToolScheduler.test.ts
npm run build
cd ../..
git diff --check
```

### Evidence (Before & After)

Before: the new regression test failed because the final `onToolCallsUpdate` payload still contained the completed `success` tool call after `onAllToolCallsComplete` rejected.

After: the focused regression tests pass, and the full `coreToolScheduler.test.ts` file passes with 221 tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Local Node.js/npm workspace, package-local Vitest/TypeScript/ESLint/Prettier checks in `packages/core`.

## Risk & Scope

- Main risk or tradeoff: low; this only changes cleanup ordering for a completed tool batch after `this.toolCalls` has already been cleared.
- Not validated / out of scope: manual TUI reproduction and platform-specific UI checks were not run locally; CI should cover Linux/Windows/macOS package checks.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5894

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

确保即使 completion finalization callback 失败，已经完成的工具调用也会从交互式显示中清空。

调度器在调用 completion callback 之前已经会清空内部的已完成调用状态。这个改动让显示更新也在 finalization cleanup 阶段执行，因此如果 callback 抛错，UI 仍然会收到空的 tool-call 状态。

## Why it's needed

修复一个 bug：当 completion finalization 失败后，edit 工具的结果摘要可能会一直留在界面上，并被追加到之后的每个响应里。在这个失败路径中，调度器内部状态已经是空的，但 React display state 没有收到清空更新。

## Reviewer Test Plan

### How to verify

请查看新增的回归测试：它 mock 了失败的 completion callback，并断言最后一次 tool-call display update 是空数组。相邻的 queue-drain 回归测试仍然验证 finalization error 后排队的工具批次会继续执行。

本地运行过的命令：

```sh
cd packages/core
npx vitest run src/core/coreToolScheduler.test.ts -t "clears displayed tool calls when completion finalization throws|drains queued tool calls when completion finalization throws"
npx vitest run src/core/coreToolScheduler.test.ts
npm run typecheck
npx eslint src/core/coreToolScheduler.ts src/core/coreToolScheduler.test.ts
npx prettier --check src/core/coreToolScheduler.ts src/core/coreToolScheduler.test.ts
npm run build
cd ../..
git diff --check
```

### Evidence (Before & After)

Before：新增回归测试失败，因为 `onAllToolCallsComplete` reject 后，最后一次 `onToolCallsUpdate` payload 仍然包含已完成的 `success` tool call。

After：聚焦回归测试通过，完整的 `coreToolScheduler.test.ts` 文件也通过，共 221 个测试。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

本地 Node.js/npm workspace，在 `packages/core` 内运行 package-local 的 Vitest、TypeScript、ESLint、Prettier 检查。

## Risk & Scope

- Main risk or tradeoff: 风险较低；这个改动只调整 completed tool batch 在 `this.toolCalls` 已经清空后的 cleanup 顺序。
- Not validated / out of scope: 本地没有跑手动 TUI 复现和特定平台 UI 检查；Linux/Windows/macOS 的 package checks 交给 CI 覆盖。
- Breaking changes / migration notes: 无。

## Linked Issues

Fixes #5894

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
