### PR TITLE
feat(web-shell): add manual toggle for enhanced markdown tables

### DIFF
--- a/packages/web-shell/client/components/messages/AssistantMessage.test.tsx
+++ b/packages/web-shell/client/components/messages/AssistantMessage.test.tsx
@@ -69,6 +69,17 @@ describe('AssistantMessage markdown tables', () => {
   it('enhances completed assistant tables', () => {
     const container = render(<AssistantMessage content={tableMarkdown} />);
 
+    expect(container.querySelector('table')).not.toBeNull();
+    expect(container.textContent).not.toContain('Quick copy');
+
+    const toggle = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Switch to advanced table"]',
+    );
+    expect(toggle).not.toBeNull();
+    act(() => {
+      toggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
     expect(container.textContent).toContain('Quick copy');
     expect(container.textContent).toContain('Details');
   });

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.module.css
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.module.css
@@ -44,6 +44,10 @@
   cursor: pointer;
 }
 
+.copyCheck {
+  margin-right: 4px;
+}
+
 .copyButton,
 .secondaryButton {
   background: var(--card);

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
@@ -648,6 +648,31 @@ describe('EnhancedMarkdownTable', () => {
     expect(container.textContent).toContain('Quick copy');
   });
 
+  it('shows checkmark feedback after copying a selection', async () => {
+    vi.useFakeTimers();
+    mockClipboard();
+    const container = renderTable();
+
+    dragCells(dataCell(container, 0, 0), dataCell(container, 0, 0));
+
+    await act(async () => {
+      textButton(container, 'Copy TSV').click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('✓');
+    expect(container.textContent).toContain('Copied!');
+    expect(container.textContent).not.toContain('Copy TSV');
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(container.textContent).not.toContain('✓');
+    expect(container.textContent).toContain('Copy TSV');
+  });
+
   it('resets interactive state when table columns change', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
@@ -179,6 +179,27 @@ function mockClipboardRejecting() {
   return writeText;
 }
 
+function mockClipboardDelayed() {
+  let resolveCopy: (() => void) | undefined;
+  const writeText = vi.fn(
+    () =>
+      new Promise<void>((resolve) => {
+        resolveCopy = resolve;
+      }),
+  );
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText },
+  });
+  return {
+    writeText,
+    resolveCopy: () => {
+      expect(resolveCopy).toBeDefined();
+      resolveCopy?.();
+    },
+  };
+}
+
 function button(container: HTMLElement, label: string): HTMLButtonElement {
   const el = container.querySelector<HTMLButtonElement>(
     `button[aria-label="${label}"]`,
@@ -751,6 +772,49 @@ describe('EnhancedMarkdownTable', () => {
     expect(container.textContent).toContain('Copied!');
 
     click(button(container, 'Sort by Score'));
+
+    expect(container.textContent).not.toContain('Copied!');
+    expect(container.textContent).toContain('Quick copy');
+  });
+
+  it('ignores stale quick copy feedback after visible data changes', async () => {
+    const clipboard = mockClipboardDelayed();
+    const container = renderTable();
+
+    act(() => {
+      textButton(container, 'Quick copy').click();
+    });
+    click(button(container, 'Sort by Score'));
+
+    await act(async () => {
+      clipboard.resolveCopy();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).not.toContain('Copied!');
+    expect(container.textContent).toContain('Quick copy');
+  });
+
+  it('resets quick copy feedback when filters change visible rows', async () => {
+    vi.useFakeTimers();
+    mockClipboard();
+    const container = renderTable();
+
+    await act(async () => {
+      textButton(container, 'Quick copy').click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('Copied!');
+
+    click(button(container, 'Filter Team'));
+    const beta = container.querySelector<HTMLInputElement>(
+      'input[name="markdown-table-filter-option-0-1"]',
+    );
+    expect(beta).not.toBeNull();
+    click(beta!);
+    click(textButton(container, 'Confirm'));
 
     expect(container.textContent).not.toContain('Copied!');
     expect(container.textContent).toContain('Quick copy');

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
@@ -18,6 +18,7 @@ afterEach(() => {
     container.remove();
   }
   vi.restoreAllMocks();
+  vi.useRealTimers();
   document.getSelection()?.removeAllRanges();
   if (originalElementFromPoint) {
     Object.defineProperty(document, 'elementFromPoint', {
@@ -622,6 +623,29 @@ describe('EnhancedMarkdownTable', () => {
     expect(writeText).toHaveBeenCalledWith(
       ['Score', '10', '2', '30'].join('\n'),
     );
+  });
+
+  it('shows checkmark feedback after quick copy', async () => {
+    vi.useFakeTimers();
+    mockClipboard();
+    const container = renderTable();
+
+    await act(async () => {
+      textButton(container, 'Quick copy').click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('✓');
+    expect(container.textContent).toContain('Copied!');
+    expect(container.textContent).not.toContain('Quick copy');
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(container.textContent).not.toContain('✓');
+    expect(container.textContent).toContain('Quick copy');
   });
 
   it('resets interactive state when table columns change', () => {

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
@@ -882,6 +882,25 @@ describe('EnhancedMarkdownTable', () => {
     expect(container.textContent).toContain('Copy TSV');
   });
 
+  it('ignores stale selection copy feedback after selection changes', async () => {
+    const clipboard = mockClipboardDelayed();
+    const container = renderTable();
+
+    dragCells(dataCell(container, 0, 0), dataCell(container, 0, 0));
+    act(() => {
+      textButton(container, 'Copy TSV').click();
+    });
+    dragCells(dataCell(container, 1, 0), dataCell(container, 1, 0));
+
+    await act(async () => {
+      clipboard.resolveCopy();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).not.toContain('Copied!');
+    expect(container.textContent).toContain('Copy TSV');
+  });
+
   it('resets interactive state when table columns change', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
@@ -150,8 +150,28 @@ function textButton(container: HTMLElement, text: string): HTMLButtonElement {
   return el!;
 }
 
+function textButtonContaining(
+  container: HTMLElement,
+  text: string,
+): HTMLButtonElement {
+  const el = [...container.querySelectorAll('button')].find((button) =>
+    button.textContent?.includes(text),
+  );
+  expect(el).not.toBeNull();
+  return el!;
+}
+
 function mockClipboard() {
   const writeText = vi.fn(() => Promise.resolve());
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText },
+  });
+  return writeText;
+}
+
+function mockClipboardRejecting() {
+  const writeText = vi.fn(() => Promise.reject(new Error('copy failed')));
   Object.defineProperty(navigator, 'clipboard', {
     configurable: true,
     value: { writeText },
@@ -648,6 +668,74 @@ describe('EnhancedMarkdownTable', () => {
     expect(container.textContent).toContain('Quick copy');
   });
 
+  it('keeps quick copy feedback visible for the latest click', async () => {
+    vi.useFakeTimers();
+    mockClipboard();
+    const container = renderTable();
+
+    await act(async () => {
+      textButton(container, 'Quick copy').click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+      textButtonContaining(container, 'Copied!').click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(container.textContent).toContain('Copied!');
+    expect(container.textContent).not.toContain('Quick copy');
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(container.textContent).not.toContain('Copied!');
+    expect(container.textContent).toContain('Quick copy');
+  });
+
+  it('resets quick copy feedback when visible table data changes', async () => {
+    vi.useFakeTimers();
+    mockClipboard();
+    const container = renderTable();
+
+    await act(async () => {
+      textButton(container, 'Quick copy').click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('Copied!');
+
+    click(button(container, 'Sort by Score'));
+
+    expect(container.textContent).not.toContain('Copied!');
+    expect(container.textContent).toContain('Quick copy');
+  });
+
+  it('does not show copied feedback when clipboard write fails', async () => {
+    mockClipboardRejecting();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const container = renderTable();
+
+    await act(async () => {
+      textButton(container, 'Quick copy').click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(warn).toHaveBeenCalled();
+    expect(container.textContent).not.toContain('Copied!');
+    expect(container.textContent).toContain('Quick copy');
+  });
+
   it('shows checkmark feedback after copying a selection', async () => {
     vi.useFakeTimers();
     mockClipboard();
@@ -670,6 +758,27 @@ describe('EnhancedMarkdownTable', () => {
     });
 
     expect(container.textContent).not.toContain('✓');
+    expect(container.textContent).toContain('Copy TSV');
+  });
+
+  it('resets selection copy feedback when the selection changes', async () => {
+    vi.useFakeTimers();
+    mockClipboard();
+    const container = renderTable();
+
+    dragCells(dataCell(container, 0, 0), dataCell(container, 0, 0));
+
+    await act(async () => {
+      textButton(container, 'Copy TSV').click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('Copied!');
+
+    dragCells(dataCell(container, 1, 0), dataCell(container, 1, 0));
+
+    expect(container.textContent).not.toContain('Copied!');
     expect(container.textContent).toContain('Copy TSV');
   });
 

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { act, type ReactNode } from 'react';
+import { StrictMode, act, type ReactNode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { I18nProvider, type WebShellLanguage } from '../../i18n';
 import { EnhancedMarkdownTable } from './EnhancedMarkdownTable';
@@ -666,6 +666,42 @@ describe('EnhancedMarkdownTable', () => {
 
     expect(container.textContent).not.toContain('✓');
     expect(container.textContent).toContain('Quick copy');
+  });
+
+  it('keeps copy feedback working under StrictMode effect replay', async () => {
+    mockClipboard();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <StrictMode>
+          <I18nProvider language="en">
+            <EnhancedMarkdownTable>
+              <thead>
+                <tr>
+                  <th>Team</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Alpha</td>
+                </tr>
+              </tbody>
+            </EnhancedMarkdownTable>
+          </I18nProvider>
+        </StrictMode>,
+      );
+    });
+    mounted.push({ root, container });
+
+    await act(async () => {
+      textButton(container, 'Quick copy').click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('Copied!');
   });
 
   it('keeps quick copy feedback visible for the latest click', async () => {

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
@@ -1064,6 +1064,12 @@ function InteractiveMarkdownTable({
   const [copiedVisible, setCopiedVisible] = useState(false);
   const [copiedSelection, setCopiedSelection] = useState(false);
   const draggingRef = useRef(false);
+  const copiedVisibleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const copiedSelectionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   const shellRef = useRef<HTMLDivElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const filterMenuRef = useRef<HTMLDivElement | null>(null);
@@ -1154,6 +1160,18 @@ function InteractiveMarkdownTable({
     draggingRef.current = false;
     setIsDragging(false);
   }, [tableStructureKey]);
+
+  useEffect(
+    () => () => {
+      if (copiedVisibleTimerRef.current) {
+        clearTimeout(copiedVisibleTimerRef.current);
+      }
+      if (copiedSelectionTimerRef.current) {
+        clearTimeout(copiedSelectionTimerRef.current);
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!openFilterMenu) return;
@@ -1462,8 +1480,14 @@ function InteractiveMarkdownTable({
     void navigator.clipboard
       .writeText(text)
       .then(() => {
+        if (copiedSelectionTimerRef.current) {
+          clearTimeout(copiedSelectionTimerRef.current);
+        }
         setCopiedSelection(true);
-        setTimeout(() => setCopiedSelection(false), 2000);
+        copiedSelectionTimerRef.current = setTimeout(
+          () => setCopiedSelection(false),
+          2000,
+        );
       })
       .catch((error: unknown) =>
         console.warn('[web-shell] clipboard write failed:', error),
@@ -1480,8 +1504,14 @@ function InteractiveMarkdownTable({
     void navigator.clipboard
       .writeText(text)
       .then(() => {
+        if (copiedVisibleTimerRef.current) {
+          clearTimeout(copiedVisibleTimerRef.current);
+        }
         setCopiedVisible(true);
-        setTimeout(() => setCopiedVisible(false), 2000);
+        copiedVisibleTimerRef.current = setTimeout(
+          () => setCopiedVisible(false),
+          2000,
+        );
       })
       .catch((error: unknown) =>
         console.warn('[web-shell] clipboard write failed:', error),

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
@@ -1070,6 +1070,7 @@ function InteractiveMarkdownTable({
   const copiedSelectionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+  const mountedRef = useRef(true);
   const shellRef = useRef<HTMLDivElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const filterMenuRef = useRef<HTMLDivElement | null>(null);
@@ -1102,6 +1103,22 @@ function InteractiveMarkdownTable({
     setOpenFilterMenu(null);
     focusFilterTrigger();
   }, [focusFilterTrigger]);
+
+  const resetCopiedVisible = useCallback(() => {
+    if (copiedVisibleTimerRef.current) {
+      clearTimeout(copiedVisibleTimerRef.current);
+      copiedVisibleTimerRef.current = null;
+    }
+    setCopiedVisible(false);
+  }, []);
+
+  const resetCopiedSelection = useCallback(() => {
+    if (copiedSelectionTimerRef.current) {
+      clearTimeout(copiedSelectionTimerRef.current);
+      copiedSelectionTimerRef.current = null;
+    }
+    setCopiedSelection(false);
+  }, []);
 
   const flushPendingSelection = useCallback(() => {
     if (selectionFrameRef.current) {
@@ -1157,17 +1174,26 @@ function InteractiveMarkdownTable({
     setOpenFilterMenu(null);
     setHiddenColumns(new Set());
     setDetailRowKey(null);
+    resetCopiedVisible();
+    resetCopiedSelection();
     draggingRef.current = false;
     setIsDragging(false);
-  }, [tableStructureKey]);
+  }, [resetCopiedSelection, resetCopiedVisible, tableStructureKey]);
+
+  useEffect(() => {
+    resetCopiedSelection();
+  }, [resetCopiedSelection, selection]);
 
   useEffect(
     () => () => {
+      mountedRef.current = false;
       if (copiedVisibleTimerRef.current) {
         clearTimeout(copiedVisibleTimerRef.current);
+        copiedVisibleTimerRef.current = null;
       }
       if (copiedSelectionTimerRef.current) {
         clearTimeout(copiedSelectionTimerRef.current);
+        copiedSelectionTimerRef.current = null;
       }
     },
     [],
@@ -1266,6 +1292,10 @@ function InteractiveMarkdownTable({
         .filter((index) => !hiddenColumns.has(index)),
     [hiddenColumns, table.headers],
   );
+
+  useEffect(() => {
+    resetCopiedVisible();
+  }, [resetCopiedVisible, visibleColumnIndexes, visibleRows]);
 
   useEffect(() => {
     if (detailRowKey && !visibleRows.some((row) => row.key === detailRowKey)) {
@@ -1480,6 +1510,7 @@ function InteractiveMarkdownTable({
     void navigator.clipboard
       .writeText(text)
       .then(() => {
+        if (!mountedRef.current) return;
         if (copiedSelectionTimerRef.current) {
           clearTimeout(copiedSelectionTimerRef.current);
         }
@@ -1504,6 +1535,7 @@ function InteractiveMarkdownTable({
     void navigator.clipboard
       .writeText(text)
       .then(() => {
+        if (!mountedRef.current) return;
         if (copiedVisibleTimerRef.current) {
           clearTimeout(copiedVisibleTimerRef.current);
         }

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
@@ -1189,6 +1189,8 @@ function InteractiveMarkdownTable({
   }, [resetCopiedSelection, selection]);
 
   useEffect(() => {
+    // StrictMode simulates an unmount/remount without re-running useRef's
+    // initializer, so restore this before clipboard callbacks can run.
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
@@ -1184,8 +1184,9 @@ function InteractiveMarkdownTable({
     resetCopiedSelection();
   }, [resetCopiedSelection, selection]);
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
       mountedRef.current = false;
       if (copiedVisibleTimerRef.current) {
         clearTimeout(copiedVisibleTimerRef.current);
@@ -1195,9 +1196,8 @@ function InteractiveMarkdownTable({
         clearTimeout(copiedSelectionTimerRef.current);
         copiedSelectionTimerRef.current = null;
       }
-    },
-    [],
-  );
+    };
+  }, []);
 
   useEffect(() => {
     if (!openFilterMenu) return;

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
@@ -1012,11 +1012,13 @@ function ColumnFilterMenu({
 interface EnhancedMarkdownTableProps {
   children?: ReactNode;
   fallback?: ReactNode;
+  toolbarExtra?: ReactNode;
 }
 
 export function EnhancedMarkdownTable({
   children,
   fallback,
+  toolbarExtra,
 }: EnhancedMarkdownTableProps) {
   const { t } = useI18n();
   const table = useMemo(
@@ -1036,10 +1038,16 @@ export function EnhancedMarkdownTable({
     return <>{fallback ?? <table>{children}</table>}</>;
   }
 
-  return <InteractiveMarkdownTable table={table} />;
+  return <InteractiveMarkdownTable table={table} toolbarExtra={toolbarExtra} />;
 }
 
-function InteractiveMarkdownTable({ table }: { table: ParsedTable }) {
+function InteractiveMarkdownTable({
+  table,
+  toolbarExtra,
+}: {
+  table: ParsedTable;
+  toolbarExtra?: ReactNode;
+}) {
   const { t } = useI18n();
   const tableId = useId();
   const [sort, setSort] = useState<SortState | null>(null);
@@ -1053,6 +1061,8 @@ function InteractiveMarkdownTable({ table }: { table: ParsedTable }) {
   );
   const [detailRowKey, setDetailRowKey] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
+  const [copiedVisible, setCopiedVisible] = useState(false);
+  const [copiedSelection, setCopiedSelection] = useState(false);
   const draggingRef = useRef(false);
   const shellRef = useRef<HTMLDivElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -1451,6 +1461,10 @@ function InteractiveMarkdownTable({ table }: { table: ParsedTable }) {
     if (!text || !navigator.clipboard) return;
     void navigator.clipboard
       .writeText(text)
+      .then(() => {
+        setCopiedSelection(true);
+        setTimeout(() => setCopiedSelection(false), 2000);
+      })
       .catch((error: unknown) =>
         console.warn('[web-shell] clipboard write failed:', error),
       );
@@ -1465,6 +1479,10 @@ function InteractiveMarkdownTable({ table }: { table: ParsedTable }) {
     if (!text || !navigator.clipboard) return;
     void navigator.clipboard
       .writeText(text)
+      .then(() => {
+        setCopiedVisible(true);
+        setTimeout(() => setCopiedVisible(false), 2000);
+      })
       .catch((error: unknown) =>
         console.warn('[web-shell] clipboard write failed:', error),
       );
@@ -1511,7 +1529,14 @@ function InteractiveMarkdownTable({ table }: { table: ParsedTable }) {
           type="button"
           onClick={copyVisibleTable}
         >
-          {t('markdownTable.copyVisible')}
+          {copiedVisible ? (
+            <>
+              <span className={styles.copyCheck}>✓</span>
+              {t('code.copied')}
+            </>
+          ) : (
+            t('markdownTable.copyVisible')
+          )}
         </button>
         {hiddenColumns.size > 0 && (
           <button
@@ -1539,10 +1564,18 @@ function InteractiveMarkdownTable({ table }: { table: ParsedTable }) {
               type="button"
               onClick={copySelection}
             >
-              {t('markdownTable.copyTsv')}
+              {copiedSelection ? (
+                <>
+                  <span className={styles.copyCheck}>✓</span>
+                  {t('code.copied')}
+                </>
+              ) : (
+                t('markdownTable.copyTsv')
+              )}
             </button>
           </>
         )}
+        {toolbarExtra}
       </div>
       <div
         ref={containerRef}

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
@@ -1070,6 +1070,8 @@ function InteractiveMarkdownTable({
   const copiedSelectionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+  const copiedVisibleGenRef = useRef(0);
+  const copiedSelectionGenRef = useRef(0);
   const mountedRef = useRef(true);
   const shellRef = useRef<HTMLDivElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -1105,6 +1107,7 @@ function InteractiveMarkdownTable({
   }, [focusFilterTrigger]);
 
   const resetCopiedVisible = useCallback(() => {
+    copiedVisibleGenRef.current += 1;
     if (copiedVisibleTimerRef.current) {
       clearTimeout(copiedVisibleTimerRef.current);
       copiedVisibleTimerRef.current = null;
@@ -1113,6 +1116,7 @@ function InteractiveMarkdownTable({
   }, []);
 
   const resetCopiedSelection = useCallback(() => {
+    copiedSelectionGenRef.current += 1;
     if (copiedSelectionTimerRef.current) {
       clearTimeout(copiedSelectionTimerRef.current);
       copiedSelectionTimerRef.current = null;
@@ -1507,10 +1511,12 @@ function InteractiveMarkdownTable({
   const copySelection = () => {
     const text = getSelectionText(selection, visibleRows, visibleColumnIndexes);
     if (!text || !navigator.clipboard) return;
+    const copyGeneration = copiedSelectionGenRef.current;
     void navigator.clipboard
       .writeText(text)
       .then(() => {
         if (!mountedRef.current) return;
+        if (copiedSelectionGenRef.current !== copyGeneration) return;
         if (copiedSelectionTimerRef.current) {
           clearTimeout(copiedSelectionTimerRef.current);
         }
@@ -1532,10 +1538,12 @@ function InteractiveMarkdownTable({
       visibleColumnIndexes,
     );
     if (!text || !navigator.clipboard) return;
+    const copyGeneration = copiedVisibleGenRef.current;
     void navigator.clipboard
       .writeText(text)
       .then(() => {
         if (!mountedRef.current) return;
+        if (copiedVisibleGenRef.current !== copyGeneration) return;
         if (copiedVisibleTimerRef.current) {
           clearTimeout(copiedVisibleTimerRef.current);
         }

--- a/packages/web-shell/client/components/messages/Markdown.module.css
+++ b/packages/web-shell/client/components/messages/Markdown.module.css
@@ -95,7 +95,10 @@
   background: var(--subtle-bg);
   color: var(--muted-foreground);
   cursor: pointer;
-  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  transition:
+    background 0.15s,
+    color 0.15s,
+    border-color 0.15s;
 }
 
 .tableToggle svg {
@@ -138,8 +141,8 @@
   text-align: left;
 }
 
-.table th:last-child,
-.table td:last-child {
+.tableWrapper:has(.tableToggle) .table th:last-child,
+.tableWrapper:has(.tableToggle) .table td:last-child {
   padding-right: 40px;
 }
 

--- a/packages/web-shell/client/components/messages/Markdown.module.css
+++ b/packages/web-shell/client/components/messages/Markdown.module.css
@@ -74,8 +74,55 @@
 }
 
 .tableWrapper {
+  position: relative;
   overflow-x: auto;
   margin: 6px 0;
+}
+
+.tableToggle {
+  position: absolute;
+  right: 8px;
+  top: 4px;
+  z-index: 4;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--subtle-bg);
+  color: var(--muted-foreground);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.tableToggle svg {
+  display: block;
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+}
+
+.tableToggle:not(.tableToggleActive):hover {
+  color: var(--foreground);
+  background: var(--subtle-bg-strong);
+}
+
+.tableToggleInline {
+  position: static;
+  margin-left: auto;
+}
+
+.tableToggleActive {
+  background: var(--agent-blue-500);
+  color: var(--card);
+  border-color: var(--agent-blue-500);
+}
+
+.tableToggleActive:hover {
+  filter: brightness(1.08);
 }
 
 .table {
@@ -89,6 +136,11 @@
   border: 1px solid var(--border);
   padding: 4px 8px;
   text-align: left;
+}
+
+.table th:last-child,
+.table td:last-child {
+  padding-right: 40px;
 }
 
 .table th {

--- a/packages/web-shell/client/components/messages/Markdown.test.ts
+++ b/packages/web-shell/client/components/messages/Markdown.test.ts
@@ -125,6 +125,14 @@ describe('Markdown enhanced tables', () => {
       );
     });
 
+    const toggle = container.querySelector('button');
+    expect(toggle).not.toBeNull();
+    expect(toggle?.getAttribute('aria-label')).toContain('advanced');
+
+    act(() => {
+      toggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
     expect(container.textContent).toContain('Quick copy');
     expect(container.textContent).toContain('Details');
 
@@ -167,6 +175,11 @@ describe('Markdown enhanced tables', () => {
           ),
         ),
       );
+    });
+
+    const toggle = container.querySelector('button');
+    act(() => {
+      toggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
     expect(container.textContent).toContain('Quick copy');
@@ -227,6 +240,11 @@ describe('Markdown enhanced tables', () => {
           }),
         ),
       );
+    });
+
+    const toggle = container.querySelector('button');
+    act(() => {
+      toggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
     const table = container.querySelector('table');

--- a/packages/web-shell/client/components/messages/Markdown.test.ts
+++ b/packages/web-shell/client/components/messages/Markdown.test.ts
@@ -136,6 +136,20 @@ describe('Markdown enhanced tables', () => {
     expect(container.textContent).toContain('Quick copy');
     expect(container.textContent).toContain('Details');
 
+    const toggleOff = container.querySelector(
+      'button[aria-label="Switch to basic table"]',
+    );
+    expect(toggleOff).not.toBeNull();
+    act(() => {
+      toggleOff?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.textContent).not.toContain('Quick copy');
+    expect(container.querySelector('table')).not.toBeNull();
+    expect(
+      container.querySelector('button[aria-label="Switch to advanced table"]'),
+    ).not.toBeNull();
+
     act(() => root.unmount());
     container.remove();
   });

--- a/packages/web-shell/client/components/messages/Markdown.tsx
+++ b/packages/web-shell/client/components/messages/Markdown.tsx
@@ -332,11 +332,107 @@ function InlineCode({ children }: { children: ReactNode }) {
   return <code className={styles.inlineCode}>{children}</code>;
 }
 
-function PlainMarkdownTable({ children }: { children?: ReactNode }) {
+function PlainMarkdownTable({
+  children,
+  toggle,
+}: {
+  children?: ReactNode;
+  toggle?: ReactNode;
+}) {
   return (
     <div className={styles.tableWrapper}>
+      {toggle}
       <table className={styles.table}>{children}</table>
     </div>
+  );
+}
+
+function TableBasicIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="6" y="6" width="12" height="12" rx="1" />
+      <path d="M6 10h12" />
+      <path d="M6 14h12" />
+      <path d="M12 6v12" />
+    </svg>
+  );
+}
+
+const TableAdvancedIcon = TableBasicIcon;
+
+function ToggleableMarkdownTable({
+  children,
+  tableResetKey,
+}: {
+  children?: ReactNode;
+  tableResetKey: string;
+}) {
+  const [enhanced, setEnhanced] = useState(false);
+  const { t } = useI18n();
+
+  if (enhanced) {
+    const fallbackToggle = (
+      <button
+        className={`${styles.tableToggle} ${styles.tableToggleActive}`}
+        type="button"
+        onClick={() => setEnhanced(false)}
+        title={t('markdownTable.toggleBasic')}
+        aria-label={t('markdownTable.toggleBasic')}
+      >
+        <TableBasicIcon />
+      </button>
+    );
+    const fallback = (
+      <PlainMarkdownTable toggle={fallbackToggle}>
+        {children}
+      </PlainMarkdownTable>
+    );
+    const toolbarToggle = (
+      <button
+        className={`${styles.tableToggle} ${styles.tableToggleInline} ${styles.tableToggleActive}`}
+        type="button"
+        onClick={() => setEnhanced(false)}
+        title={t('markdownTable.toggleBasic')}
+        aria-label={t('markdownTable.toggleBasic')}
+      >
+        <TableBasicIcon />
+      </button>
+    );
+    return (
+      <EnhancedMarkdownTableBoundary
+        fallback={fallback}
+        resetKey={tableResetKey}
+      >
+        <EnhancedMarkdownTable fallback={fallback} toolbarExtra={toolbarToggle}>
+          {children}
+        </EnhancedMarkdownTable>
+      </EnhancedMarkdownTableBoundary>
+    );
+  }
+
+  const toggleButton = (
+    <button
+      className={styles.tableToggle}
+      type="button"
+      onClick={() => setEnhanced(true)}
+      title={t('markdownTable.toggleAdvanced')}
+      aria-label={t('markdownTable.toggleAdvanced')}
+    >
+      <TableAdvancedIcon />
+    </button>
+  );
+  return (
+    <PlainMarkdownTable toggle={toggleButton}>{children}</PlainMarkdownTable>
   );
 }
 
@@ -416,20 +512,14 @@ function createComponents(
       );
     },
     table({ children }: { children?: ReactNode }) {
-      const fallback = <PlainMarkdownTable>{children}</PlainMarkdownTable>;
       if (enhanceTables) {
         return (
-          <EnhancedMarkdownTableBoundary
-            fallback={fallback}
-            resetKey={tableResetKey}
-          >
-            <EnhancedMarkdownTable fallback={fallback}>
-              {children}
-            </EnhancedMarkdownTable>
-          </EnhancedMarkdownTableBoundary>
+          <ToggleableMarkdownTable tableResetKey={tableResetKey}>
+            {children}
+          </ToggleableMarkdownTable>
         );
       }
-      return fallback;
+      return <PlainMarkdownTable>{children}</PlainMarkdownTable>;
     },
     img({ src, alt }: { src?: string; alt?: string }) {
       const safeSrc = isSafeImageSrc(src) ? src : undefined;

--- a/packages/web-shell/client/components/messages/Markdown.tsx
+++ b/packages/web-shell/client/components/messages/Markdown.tsx
@@ -388,6 +388,7 @@ function ToggleableMarkdownTable({
         onClick={() => setEnhanced(false)}
         title={t('markdownTable.toggleBasic')}
         aria-label={t('markdownTable.toggleBasic')}
+        aria-pressed={true}
       >
         <TableBasicIcon />
       </button>
@@ -404,16 +405,21 @@ function ToggleableMarkdownTable({
         onClick={() => setEnhanced(false)}
         title={t('markdownTable.toggleBasic')}
         aria-label={t('markdownTable.toggleBasic')}
+        aria-pressed={true}
       >
         <TableBasicIcon />
       </button>
     );
+    const plainFallback = <PlainMarkdownTable>{children}</PlainMarkdownTable>;
     return (
       <EnhancedMarkdownTableBoundary
         fallback={fallback}
         resetKey={tableResetKey}
       >
-        <EnhancedMarkdownTable fallback={fallback} toolbarExtra={toolbarToggle}>
+        <EnhancedMarkdownTable
+          fallback={plainFallback}
+          toolbarExtra={toolbarToggle}
+        >
           {children}
         </EnhancedMarkdownTable>
       </EnhancedMarkdownTableBoundary>
@@ -427,6 +433,7 @@ function ToggleableMarkdownTable({
       onClick={() => setEnhanced(true)}
       title={t('markdownTable.toggleAdvanced')}
       aria-label={t('markdownTable.toggleAdvanced')}
+      aria-pressed={false}
     >
       <TableAdvancedIcon />
     </button>

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -215,6 +215,8 @@ const EN: Messages = {
   'code.copy': 'Copy',
   'code.copied': 'Copied!',
   'markdownTable.blank': '(blank)',
+  'markdownTable.toggleAdvanced': 'Switch to advanced table',
+  'markdownTable.toggleBasic': 'Switch to basic table',
   'markdownTable.column': (v) => `Column ${v?.index ?? ''}`,
   'markdownTable.rows': (v) => {
     const count = Number(v?.count ?? 0);
@@ -1401,6 +1403,8 @@ const ZH: Messages = {
   'code.copy': '复制',
   'code.copied': '已复制！',
   'markdownTable.blank': '(空白)',
+  'markdownTable.toggleAdvanced': '切换到高级表格',
+  'markdownTable.toggleBasic': '切换到基础表格',
   'markdownTable.column': (v) => `第 ${v?.index ?? ''} 列`,
   'markdownTable.rows': (v) => `${v?.count ?? 0} 行`,
   'markdownTable.rowsFiltered': (v) => `${v?.visible ?? 0}/${v?.total ?? 0} 行`,


### PR DESCRIPTION
## What this PR does

Currently, when `enhanceTables` is enabled, all markdown tables are automatically replaced with the enhanced interactive table. This PR changes the behavior to manual toggle: tables render as plain tables by default with a small icon button in the top-right corner. Users can click the icon to switch to the enhanced table (with sorting, filtering, cell selection, etc.) and switch back at any time.

Additionally, the "Quick copy" and "Copy TSV" buttons in the enhanced table now show a `✓ Copied!` feedback for 2 seconds after a successful copy, giving users visual confirmation.

## Why it's needed

The automatic table replacement can be jarring — users may want to see the simple table layout first and opt into the enhanced view only when needed (e.g. large datasets requiring sorting/filtering). A manual toggle gives users control over their reading experience without removing the enhanced features.

The copy feedback addresses a minor UX gap where users had no confirmation that clipboard operations succeeded.

## Reviewer Test Plan

### How to verify

1. Run `npm run dev` and open the web-shell
2. Send a message that produces a markdown table response
3. Confirm the table renders as a plain table with a small grid icon button in the top-right corner
4. Click the icon — the table should switch to the enhanced interactive table with toolbar
5. In the enhanced table toolbar, click the grid icon again to switch back to the plain table
6. Click "Quick copy" in the enhanced table — confirm `✓ Copied!` appears for ~2 seconds then reverts
7. Select cells and click "Copy TSV" — confirm the same `✓ Copied!` feedback

### Evidence (Before & After)

Before: Tables automatically render as enhanced interactive tables. No copy feedback.

After: Tables render as plain tables with a toggle icon. Copy buttons show `✓ Copied!` for 2 seconds.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npm run dev` on macOS

## Risk & Scope

- Main risk or tradeoff: Users who prefer always-enhanced tables need one extra click to opt in
- Not validated / out of scope: Windows/Linux visual testing
- Breaking changes / migration notes: None — the `enhanceTables` prop still gates the feature; this only changes the default rendering within it

## Linked Issues
默认情况下是普通表格，右上角增加切换到高级表格的入口

<img width="2058" height="270" alt="image" src="https://github.com/user-attachments/assets/c5c08c34-39d0-4caf-9d6f-d6345898b81a" />
<img width="2046" height="402" alt="image" src="https://github.com/user-attachments/assets/c3b3bd13-a574-4103-9115-d197e9f39c65" />

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当前 `enhanceTables` 启用时，所有 markdown 表格会自动替换为增强交互表格。本 PR 将其改为手动切换：默认渲染为普通表格，右上角显示一个小网格图标按钮，用户点击后可切换到增强表格（支持排序、筛选、单元格选择等），也可以随时切换回来。

此外，增强表格的「快捷复制」和「复制 TSV」按钮在复制成功后会显示 `✓ 已复制！` 反馈 2 秒，给用户视觉确认。

## 为什么需要这个改动

自动替换表格可能影响阅读体验——用户可能希望先看到简洁的表格布局，仅在需要排序/筛选时再手动启用增强视图。手动切换让用户可以自主选择，同时保留了增强功能。

复制反馈解决了一个小 UX 问题：用户之前无法确认剪贴板操作是否成功。

## 风险和范围

- 主要风险：偏好始终使用增强表格的用户需要多一次点击
- 未验证/超出范围：Windows/Linux 视觉测试
- 破坏性变更/迁移说明：无——`enhanceTables` 属性仍然控制是否启用此功能

</details>
