### PR TITLE
feat(core): warn before foreground shell timeout

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -3276,6 +3276,67 @@ describe('AppContainer State Management', () => {
       expect(reason).toEqual({ kind: 'background' });
     });
 
+    it('Ctrl+B does NOT promote when multiple foreground shell tool calls are executing', () => {
+      const promoteAc1 = new AbortController();
+      const promoteAc2 = new AbortController();
+      const abortSpy1 = vi.spyOn(promoteAc1, 'abort');
+      const abortSpy2 = vi.spyOn(promoteAc2, 'abort');
+      mockedUseGeminiStream.mockReturnValue({
+        streamingState: 'responding',
+        submitQuery: vi.fn(),
+        initError: null,
+        pendingHistoryItems: [],
+        pendingToolCalls: [
+          {
+            status: 'executing',
+            request: { callId: 'call-shell-1', name: 'run_shell_command' },
+            promoteAbortController: promoteAc1,
+          },
+          {
+            status: 'executing',
+            request: { callId: 'call-shell-2', name: 'run_shell_command' },
+            promoteAbortController: promoteAc2,
+          },
+        ],
+        thought: null,
+        cancelOngoingRequest: vi.fn(),
+        retryLastPrompt: vi.fn(),
+        streamingResponseLengthRef: { current: 0 },
+        isReceivingContent: false,
+      });
+
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      const handleKeypress = mockedUseKeypress.mock.calls
+        .map((call) => call[0])
+        .reverse()
+        .find(
+          (handler): handler is (key: Key) => void =>
+            typeof handler === 'function' &&
+            handler.toString().includes('PROMOTE_SHELL_TO_BACKGROUND'),
+        ) as ((key: Key) => void) | undefined;
+      expect(handleKeypress).toBeDefined();
+
+      handleKeypress!({
+        name: 'b',
+        ctrl: true,
+        meta: false,
+        shift: false,
+        paste: false,
+        sequence: '\x02',
+      });
+
+      expect(abortSpy1).not.toHaveBeenCalled();
+      expect(abortSpy2).not.toHaveBeenCalled();
+    });
+
     it('Ctrl+B is a no-op when no foreground shell is currently executing', () => {
       // Pin the safety contract: pressing Ctrl+B mid-prompt with no
       // pending tool calls must NOT throw — falls through to the input

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -3456,8 +3456,12 @@ export const AppContainer = (props: AppContainerProps) => {
         // character left if the prompt has focus. Cosmetic; tracked
         // for a follow-up that introduces a `consumed` return value
         // on KeypressHandler so global handlers can swallow keys.
-        const executingShell = pendingToolCallsRef.current.find(
-          (tc) =>
+        const promotableShells = pendingToolCallsRef.current.filter(
+          (
+            tc,
+          ): tc is TrackedExecutingToolCall & {
+            promoteAbortController: AbortController;
+          } =>
             tc.status === 'executing' &&
             // Defense-in-depth: also gate on the tool name. Today only
             // the shell tool's invocation wires `promoteAbortController`,
@@ -3467,8 +3471,9 @@ export const AppContainer = (props: AppContainerProps) => {
             // whose service has no promote-handoff handler.
             tc.request.name === ToolNames.SHELL &&
             tc.promoteAbortController !== undefined,
-        ) as TrackedExecutingToolCall | undefined;
-        if (executingShell?.promoteAbortController) {
+        );
+        if (promotableShells.length === 1) {
+          const executingShell = promotableShells[0];
           debugLogger.debug(
             `Ctrl+B promote: matched executing shell tool call ${executingShell.request.callId}`,
           );
@@ -3478,9 +3483,10 @@ export const AppContainer = (props: AppContainerProps) => {
           return;
         }
         debugLogger.debug(
-          `Ctrl+B promote: no executing shell tool call; falling through ` +
+          `Ctrl+B promote: expected exactly one executing shell tool call; falling through ` +
             `(streamingState=${streamingState}, ` +
-            `pendingToolCalls=${pendingToolCallsRef.current.length})`,
+            `pendingToolCalls=${pendingToolCallsRef.current.length}, ` +
+            `promotableShells=${promotableShells.length})`,
         );
       }
     },

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -3234,12 +3234,25 @@ export class CoreToolScheduler {
           );
           this.notifyToolCallsUpdate();
         };
+        const canPromoteForegroundShell = () => {
+          const promotableShells = this.toolCalls.filter(
+            (tc) =>
+              tc.status === 'executing' &&
+              tc.request.name === ToolNames.SHELL &&
+              tc.promoteAbortController !== undefined,
+          );
+          return (
+            promotableShells.length === 1 &&
+            promotableShells[0]?.request.callId === callId
+          );
+        };
         promise = invocation.execute(
           signal,
           liveOutputCallback,
           shellExecutionConfig,
           setPidCallback,
           setPromoteAbortControllerCallback,
+          canPromoteForegroundShell,
         );
       } else {
         promise = invocation.execute(

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -1907,6 +1907,7 @@ describe('ShellTool', () => {
           undefined,
           undefined,
           setPromoteAbortController,
+          () => true,
         );
         await Promise.resolve();
         expect(setPromoteAbortController).toHaveBeenCalledOnce();
@@ -1946,6 +1947,188 @@ describe('ShellTool', () => {
         await promise;
       });
 
+      it('should append the foreground timeout warning to ANSI output', async () => {
+        const setPromoteAbortController = vi.fn();
+        const invocation = shellTool.build({
+          command: 'ansi-slow-build',
+          is_background: false,
+          timeout: 20_000,
+        }) as ShellToolInvocation;
+        const promise = invocation.execute(
+          mockAbortSignal,
+          updateOutputMock,
+          undefined,
+          undefined,
+          setPromoteAbortController,
+          () => true,
+        );
+        await Promise.resolve();
+        expect(setPromoteAbortController).toHaveBeenCalledOnce();
+
+        const ansiChunk: import('../utils/terminalSerializer.js').AnsiOutput = [
+          [
+            {
+              text: 'still running',
+              bold: false,
+              italic: false,
+              dim: false,
+              underline: false,
+              inverse: false,
+              fg: '',
+              bg: '',
+            },
+          ],
+        ];
+        mockShellOutputCallback({ type: 'data', chunk: ansiChunk });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+
+        await vi.advanceTimersByTimeAsync(5_000);
+
+        expect(updateOutputMock).toHaveBeenCalledTimes(2);
+        const warningFrame = updateOutputMock.mock.calls.at(-1)?.[0] as {
+          ansiOutput: import('../utils/terminalSerializer.js').AnsiOutput;
+        };
+        const warningToken = warningFrame.ansiOutput.at(-1)?.[0];
+        expect(warningToken).toMatchObject({
+          text: expect.stringContaining('about to time out'),
+          bold: true,
+          fg: '#ff5555',
+        });
+
+        resolveExecutionPromise({
+          rawOutput: Buffer.from('still running'),
+          output: 'still running',
+          exitCode: 0,
+          signal: null,
+          error: null,
+          aborted: false,
+          pid: 12345,
+          executionMethod: 'child_process',
+        });
+        await promise;
+      });
+
+      it('should not show the Ctrl+B warning when promotion is ambiguous', async () => {
+        const setPromoteAbortController = vi.fn();
+        const invocation = shellTool.build({
+          command: 'ambiguous-slow-build',
+          is_background: false,
+          timeout: 20_000,
+        }) as ShellToolInvocation;
+        const promise = invocation.execute(
+          mockAbortSignal,
+          updateOutputMock,
+          undefined,
+          undefined,
+          setPromoteAbortController,
+          () => false,
+        );
+        await Promise.resolve();
+        expect(setPromoteAbortController).toHaveBeenCalledOnce();
+
+        await vi.advanceTimersByTimeAsync(5_000);
+        expect(updateOutputMock).not.toHaveBeenCalled();
+
+        resolveExecutionPromise({
+          rawOutput: Buffer.from('done'),
+          output: 'done',
+          exitCode: 0,
+          signal: null,
+          error: null,
+          aborted: false,
+          pid: 12345,
+          executionMethod: 'child_process',
+        });
+        await promise;
+      });
+
+      it('should suppress a stale Ctrl+B warning if promotion becomes ambiguous before the timer fires', async () => {
+        let canPromote = true;
+        const setPromoteAbortController = vi.fn();
+        const invocation = shellTool.build({
+          command: 'stale-warning-slow-build',
+          is_background: false,
+          timeout: 20_000,
+        }) as ShellToolInvocation;
+        const promise = invocation.execute(
+          mockAbortSignal,
+          updateOutputMock,
+          undefined,
+          undefined,
+          setPromoteAbortController,
+          () => canPromote,
+        );
+        await Promise.resolve();
+        expect(setPromoteAbortController).toHaveBeenCalledOnce();
+
+        await vi.advanceTimersByTimeAsync(4_999);
+        canPromote = false;
+        await vi.advanceTimersByTimeAsync(1);
+        expect(updateOutputMock).not.toHaveBeenCalled();
+
+        resolveExecutionPromise({
+          rawOutput: Buffer.from('done'),
+          output: 'done',
+          exitCode: 0,
+          signal: null,
+          error: null,
+          aborted: false,
+          pid: 12345,
+          executionMethod: 'child_process',
+        });
+        await promise;
+      });
+
+      it('schedules the warning against the real timeout clock', async () => {
+        mockShellExecutionService.mockImplementationOnce(
+          (_cmd, _cwd, callback) => {
+            mockShellOutputCallback = callback;
+            vi.advanceTimersByTime(6_000);
+            return {
+              pid: 12345,
+              result: new Promise((resolve) => {
+                resolveExecutionPromise = resolve;
+              }),
+            };
+          },
+        );
+        const setPromoteAbortController = vi.fn();
+        const invocation = shellTool.build({
+          command: 'slow-spawn',
+          is_background: false,
+          timeout: 20_000,
+        }) as ShellToolInvocation;
+
+        const promise = invocation.execute(
+          mockAbortSignal,
+          updateOutputMock,
+          undefined,
+          undefined,
+          setPromoteAbortController,
+          () => true,
+        );
+        await Promise.resolve();
+        expect(setPromoteAbortController).toHaveBeenCalledOnce();
+
+        await vi.advanceTimersByTimeAsync(0);
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+        expect(updateOutputMock).toHaveBeenLastCalledWith(
+          expect.stringContaining('about to time out'),
+        );
+
+        resolveExecutionPromise({
+          rawOutput: Buffer.from('done'),
+          output: 'done',
+          exitCode: 0,
+          signal: null,
+          error: null,
+          aborted: false,
+          pid: 12345,
+          executionMethod: 'child_process',
+        });
+        await promise;
+      });
+
       it('should not show the Ctrl+B warning outside interactive mode', async () => {
         const interactiveMock = mockConfig as unknown as {
           isInteractive: Mock;
@@ -1962,6 +2145,7 @@ describe('ShellTool', () => {
           undefined,
           undefined,
           vi.fn(),
+          () => true,
         );
         await Promise.resolve();
 
@@ -2018,6 +2202,7 @@ describe('ShellTool', () => {
           undefined,
           undefined,
           vi.fn(),
+          () => true,
         );
         await Promise.resolve();
 
@@ -2064,6 +2249,7 @@ describe('ShellTool', () => {
           undefined,
           undefined,
           setPromoteAbortController,
+          () => true,
         );
 
         ac.abort();

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -133,6 +133,7 @@ describe('ShellTool', () => {
       getFileReadCache: vi.fn().mockReturnValue(mockFileReadCache),
       getFileReadCacheDisabled: vi.fn().mockReturnValue(false),
       getModel: vi.fn().mockReturnValue('qwen3-coder-plus'),
+      isInteractive: vi.fn().mockReturnValue(true),
       getGitCoAuthor: vi.fn().mockReturnValue({
         commit: true,
         pr: true,
@@ -1893,15 +1894,212 @@ describe('ShellTool', () => {
         expect(updateOutputMock).toHaveBeenCalledOnce();
       });
 
+      it('should warn shortly before a foreground command times out', async () => {
+        const setPromoteAbortController = vi.fn();
+        const invocation = shellTool.build({
+          command: 'slow-build',
+          is_background: false,
+          timeout: 20_000,
+        }) as ShellToolInvocation;
+        const promise = invocation.execute(
+          mockAbortSignal,
+          updateOutputMock,
+          undefined,
+          undefined,
+          setPromoteAbortController,
+        );
+        await Promise.resolve();
+        expect(setPromoteAbortController).toHaveBeenCalledOnce();
+
+        await vi.advanceTimersByTimeAsync(4_999);
+        expect(updateOutputMock).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+        expect(updateOutputMock).toHaveBeenLastCalledWith(
+          expect.stringContaining('about to time out'),
+        );
+        expect(updateOutputMock).toHaveBeenLastCalledWith(
+          expect.stringContaining('Ctrl+B'),
+        );
+
+        mockShellOutputCallback({ type: 'data', chunk: 'still running' });
+        await vi.advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS + 1);
+        expect(updateOutputMock).toHaveBeenCalledTimes(2);
+        expect(updateOutputMock).toHaveBeenLastCalledWith(
+          expect.stringContaining('still running'),
+        );
+        expect(updateOutputMock).toHaveBeenLastCalledWith(
+          expect.stringContaining('Ctrl+B'),
+        );
+
+        resolveExecutionPromise({
+          rawOutput: Buffer.from('still running'),
+          output: 'still running',
+          exitCode: 0,
+          signal: null,
+          error: null,
+          aborted: false,
+          pid: 12345,
+          executionMethod: 'child_process',
+        });
+        await promise;
+      });
+
+      it('should not show the Ctrl+B warning outside interactive mode', async () => {
+        const interactiveMock = mockConfig as unknown as {
+          isInteractive: Mock;
+        };
+        interactiveMock.isInteractive.mockReturnValue(false);
+        const invocation = shellTool.build({
+          command: 'headless-build',
+          is_background: false,
+          timeout: 20_000,
+        }) as ShellToolInvocation;
+        const promise = invocation.execute(
+          mockAbortSignal,
+          updateOutputMock,
+          undefined,
+          undefined,
+          vi.fn(),
+        );
+        await Promise.resolve();
+
+        await vi.advanceTimersByTimeAsync(5_000);
+        expect(updateOutputMock).not.toHaveBeenCalled();
+
+        resolveExecutionPromise({
+          rawOutput: Buffer.from('done'),
+          output: 'done',
+          exitCode: 0,
+          signal: null,
+          error: null,
+          aborted: false,
+          pid: 12345,
+          executionMethod: 'child_process',
+        });
+        await promise;
+      });
+
+      it('should not show the Ctrl+B warning when no promote callback is wired', async () => {
+        const invocation = shellTool.build({
+          command: 'direct-core-build',
+          is_background: false,
+          timeout: 20_000,
+        });
+        const promise = invocation.execute(mockAbortSignal, updateOutputMock);
+        await Promise.resolve();
+
+        await vi.advanceTimersByTimeAsync(5_000);
+        expect(updateOutputMock).not.toHaveBeenCalled();
+
+        resolveExecutionPromise({
+          rawOutput: Buffer.from('done'),
+          output: 'done',
+          exitCode: 0,
+          signal: null,
+          error: null,
+          aborted: false,
+          pid: 12345,
+          executionMethod: 'child_process',
+        });
+        await promise;
+      });
+
+      it('should cancel the near-timeout warning when the command completes early', async () => {
+        const invocation = shellTool.build({
+          command: 'quick-cmd',
+          is_background: false,
+          timeout: 20_000,
+        }) as ShellToolInvocation;
+        const promise = invocation.execute(
+          mockAbortSignal,
+          updateOutputMock,
+          undefined,
+          undefined,
+          vi.fn(),
+        );
+        await Promise.resolve();
+
+        await vi.advanceTimersByTimeAsync(1_000);
+        resolveExecutionPromise({
+          rawOutput: Buffer.from('done'),
+          output: 'done',
+          exitCode: 0,
+          signal: null,
+          error: null,
+          aborted: false,
+          pid: 12345,
+          executionMethod: 'child_process',
+        });
+        await promise;
+
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(updateOutputMock).not.toHaveBeenCalled();
+      });
+
+      it('should not arm the near-timeout warning after an abort that happens before the shell handle is ready', async () => {
+        const ac = new AbortController();
+        const setPromoteAbortController = vi.fn();
+        let resolveShellHandle: (handle: {
+          pid: number;
+          result: Promise<ShellExecutionResult>;
+        }) => void;
+        mockShellExecutionService.mockImplementationOnce(
+          (_cmd, _cwd, callback) => {
+            mockShellOutputCallback = callback;
+            return new Promise((resolve) => {
+              resolveShellHandle = resolve;
+            });
+          },
+        );
+        const invocation = shellTool.build({
+          command: 'slow-spawn',
+          is_background: false,
+          timeout: 20_000,
+        }) as ShellToolInvocation;
+        const promise = invocation.execute(
+          ac.signal,
+          updateOutputMock,
+          undefined,
+          undefined,
+          setPromoteAbortController,
+        );
+
+        ac.abort();
+        resolveShellHandle!({
+          pid: 12345,
+          result: new Promise((resolve) => {
+            resolveExecutionPromise = resolve;
+          }),
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(setPromoteAbortController).toHaveBeenCalledOnce();
+
+        await vi.advanceTimersByTimeAsync(5_000);
+        expect(updateOutputMock).not.toHaveBeenCalled();
+
+        resolveExecutionPromise({
+          rawOutput: Buffer.from('partial'),
+          output: 'partial',
+          exitCode: null,
+          signal: 15,
+          error: null,
+          aborted: true,
+          pid: 12345,
+          executionMethod: 'child_process',
+        });
+        await promise;
+      });
+
       it('should clean up a pending trailing flush if execute() rejects', async () => {
         // ShellExecutionService.execute() can throw before resolving
         // (e.g. PTY dynamic import failure). The tool must propagate the
         // error AND ensure no scheduled timer survives to fire a late
         // updateOutput call after the caller has already seen the error.
-        // (No chunks can arrive before execute() resolves, so the timer
-        // is never actually scheduled in this path. The contract we
-        // verify here is that the abort listener is torn down — which we
-        // observe indirectly via "no late update on subsequent abort".)
+        // No chunks can arrive before execute() resolves, and the
+        // near-timeout warning is not armed until a foreground handle exists.
         const ac = new AbortController();
         mockShellExecutionService.mockImplementationOnce(() => {
           throw new Error('pty-import-failed');
@@ -1910,6 +2108,7 @@ describe('ShellTool', () => {
         const invocation = shellTool.build({
           command: 'pty-cmd',
           is_background: false,
+          timeout: 20_000,
         });
 
         await expect(
@@ -1919,7 +2118,7 @@ describe('ShellTool', () => {
         // After rejection, aborting must not crash and must not produce
         // any updateOutput calls (no listener leak).
         ac.abort();
-        await vi.advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS * 2);
+        await vi.advanceTimersByTimeAsync(5_000);
         expect(updateOutputMock).not.toHaveBeenCalled();
       });
 

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -2057,6 +2057,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
     shellExecutionConfig?: ShellExecutionConfig,
     setPidCallback?: (pid: number) => void,
     setPromoteAbortControllerCallback?: (ac: AbortController) => void,
+    canPromoteForegroundShell?: () => boolean,
   ): Promise<ToolResult> {
     const strippedCommand = stripShellWrapper(this.params.command);
 
@@ -2087,7 +2088,9 @@ export class ShellToolInvocation extends BaseToolInvocation<
       signal,
       promoteAbortController.signal,
     ]);
+    let timeoutSignalStartedAt: number | null = null;
     if (effectiveTimeout) {
+      timeoutSignalStartedAt = Date.now();
       const timeoutSignal = AbortSignal.timeout(effectiveTimeout);
       combinedSignal = AbortSignal.any([
         signal,
@@ -2167,7 +2170,6 @@ export class ShellToolInvocation extends BaseToolInvocation<
     let trailingFlushTimer: ReturnType<typeof setTimeout> | null = null;
     let timeoutWarningTimer: ReturnType<typeof setTimeout> | null = null;
     let showTimeoutWarning = false;
-    const timeoutSignalStartedAt = Date.now();
 
     const cancelTrailingFlush = () => {
       if (trailingFlushTimer !== null) {
@@ -2222,7 +2224,9 @@ export class ShellToolInvocation extends BaseToolInvocation<
         !updateOutput ||
         combinedSignal.aborted ||
         !this.config.isInteractive() ||
-        setPromoteAbortControllerCallback === undefined
+        setPromoteAbortControllerCallback === undefined ||
+        canPromoteForegroundShell?.() !== true ||
+        timeoutSignalStartedAt === null
       ) {
         return;
       }
@@ -2235,6 +2239,9 @@ export class ShellToolInvocation extends BaseToolInvocation<
       }
       timeoutWarningTimer = setTimeout(() => {
         timeoutWarningTimer = null;
+        if (combinedSignal.aborted || canPromoteForegroundShell?.() !== true) {
+          return;
+        }
         showTimeoutWarning = true;
         doUpdate();
       }, warningDelay);

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -1010,6 +1010,50 @@ function longRunThresholdFor(effectiveTimeoutMs: number): number {
   );
 }
 
+const FOREGROUND_TIMEOUT_WARNING_LEAD_MS = 15_000;
+const FOREGROUND_TIMEOUT_WARNING =
+  'Warning: this command is about to time out. In the interactive TUI, press Ctrl+B to keep it running in the background.';
+
+function foregroundTimeoutWarningDelayFor(
+  effectiveTimeoutMs: number,
+  elapsedMs: number,
+): number | null {
+  if (effectiveTimeoutMs <= FOREGROUND_TIMEOUT_WARNING_LEAD_MS) {
+    return null;
+  }
+  const remainingMs = effectiveTimeoutMs - elapsedMs;
+  if (remainingMs <= 0) {
+    return null;
+  }
+  return Math.max(0, remainingMs - FOREGROUND_TIMEOUT_WARNING_LEAD_MS);
+}
+
+function appendForegroundTimeoutWarning(
+  output: string | AnsiOutput,
+): string | AnsiOutput {
+  if (typeof output === 'string') {
+    return output
+      ? `${output}\n\n${FOREGROUND_TIMEOUT_WARNING}`
+      : FOREGROUND_TIMEOUT_WARNING;
+  }
+
+  return [
+    ...output,
+    [
+      {
+        text: FOREGROUND_TIMEOUT_WARNING,
+        bold: true,
+        italic: false,
+        underline: false,
+        dim: false,
+        inverse: false,
+        fg: '#ff5555',
+        bg: '',
+      },
+    ],
+  ];
+}
+
 /**
  * Format the long-run advisory appended to long foreground commands.
  * Exported so tests and any future consumer (e.g. an alternative
@@ -2121,11 +2165,21 @@ export class ShellToolInvocation extends BaseToolInvocation<
     let totalLines = 0;
     let totalBytes = 0;
     let trailingFlushTimer: ReturnType<typeof setTimeout> | null = null;
+    let timeoutWarningTimer: ReturnType<typeof setTimeout> | null = null;
+    let showTimeoutWarning = false;
+    const timeoutSignalStartedAt = Date.now();
 
     const cancelTrailingFlush = () => {
       if (trailingFlushTimer !== null) {
         clearTimeout(trailingFlushTimer);
         trailingFlushTimer = null;
+      }
+    };
+
+    const cancelTimeoutWarning = () => {
+      if (timeoutWarningTimer !== null) {
+        clearTimeout(timeoutWarningTimer);
+        timeoutWarningTimer = null;
       }
     };
 
@@ -2137,11 +2191,14 @@ export class ShellToolInvocation extends BaseToolInvocation<
       cancelTrailingFlush();
       lastUpdateTime = Date.now();
       if (!updateOutput) return;
-      if (typeof cumulativeOutput === 'string') {
-        updateOutput(cumulativeOutput);
+      const displayOutput = showTimeoutWarning
+        ? appendForegroundTimeoutWarning(cumulativeOutput)
+        : cumulativeOutput;
+      if (typeof displayOutput === 'string') {
+        updateOutput(displayOutput);
       } else {
         updateOutput({
-          ansiOutput: cumulativeOutput,
+          ansiOutput: displayOutput,
           totalLines,
           totalBytes,
           ...(this.params.timeout != null && {
@@ -2156,8 +2213,32 @@ export class ShellToolInvocation extends BaseToolInvocation<
     // between the abort signal firing and the result promise settling.
     const onAbort = () => {
       cancelTrailingFlush();
+      cancelTimeoutWarning();
     };
     combinedSignal.addEventListener('abort', onAbort, { once: true });
+
+    const armTimeoutWarning = () => {
+      if (
+        !updateOutput ||
+        combinedSignal.aborted ||
+        !this.config.isInteractive() ||
+        setPromoteAbortControllerCallback === undefined
+      ) {
+        return;
+      }
+      const warningDelay = foregroundTimeoutWarningDelayFor(
+        effectiveTimeout,
+        Date.now() - timeoutSignalStartedAt,
+      );
+      if (warningDelay === null) {
+        return;
+      }
+      timeoutWarningTimer = setTimeout(() => {
+        timeoutWarningTimer = null;
+        showTimeoutWarning = true;
+        doUpdate();
+      }, warningDelay);
+    };
 
     const onShellOutputEvent = (event: ShellOutputEvent) => {
       let shouldUpdate = false;
@@ -2316,6 +2397,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
       // (theoretically) scheduled trailing flush so nothing fires after we
       // re-throw to the caller.
       cancelTrailingFlush();
+      cancelTimeoutWarning();
       combinedSignal.removeEventListener('abort', onAbort);
       throw err;
     }
@@ -2330,6 +2412,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
     // implement promote yet, but exposing it now means PR-3 doesn't
     // need to revisit shell.ts.
     setPromoteAbortControllerCallback?.(promoteAbortController);
+    armTimeoutWarning();
 
     // Bracket the spawn → settle wall-clock so the result builder below
     // can decide whether to append the long-run advisory. Captured AFTER
@@ -2358,6 +2441,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
       // fire a stale frame after we've returned. `finally` covers both the
       // happy path and the (theoretical) reject path so no timer leaks.
       cancelTrailingFlush();
+      cancelTimeoutWarning();
       combinedSignal.removeEventListener('abort', onAbort);
     }
 


### PR DESCRIPTION
## What this PR does

Adds a live near-timeout warning for interactive foreground shell commands. When a foreground command with a timeout longer than 15 seconds reaches its final 15 seconds, the live output shows a warning that the command is about to time out and that Ctrl+B can promote it to a background task in the interactive TUI.

The warning is live-display only. It does not change the final shell output, model-facing `llmContent`, timeout defaults, or the existing Ctrl+B promote behavior. It is also gated to interactive sessions with the promote callback wired, so direct core/headless live-output callers do not get a misleading Ctrl+B hint.

## Why it's needed

In #5838, the reporter clarified that the main pain is noticing too late that a foreground command is close to timing out. Ctrl+B already exists as the current workaround for keeping an in-flight foreground command running in the background, but the running shell UI did not surface that option near timeout. This makes the existing recovery path discoverable at the moment it matters.

## Reviewer Test Plan

### How to verify

From `packages/core`, run `npx vitest run src/tools/shell.test.ts --coverage=false`. The focused coverage verifies that the warning fires shortly before timeout, stays visible with later live output, is suppressed outside interactive mode, is suppressed when no promote callback is wired, is cancelled on early completion, and is not armed after an abort-before-handle race.

Optional manual check: in the interactive TUI, run a foreground shell command with a timeout over 15 seconds and let it approach the final 15 seconds. The live shell output should show the near-timeout Ctrl+B warning; pressing Ctrl+B should still promote the command through the existing background-task path.

### Evidence (Before & After)

Before: foreground shell live output could show elapsed/timeout state, but it did not emit a near-timeout Ctrl+B hint while the command was still running.

After: the new regression tests assert the live warning for a 20s foreground command at the 5s mark, assert that subsequent live output preserves the warning, and assert no stale or misleading warning for non-interactive, no-promote-callback, early-completion, and abort-before-arm paths.

Local validation passed:

- `npx vitest run src/tools/shell.test.ts --coverage=false` — 246 passed
- `npx eslint src/tools/shell.ts src/tools/shell.test.ts`
- `npx prettier --check src/tools/shell.ts src/tools/shell.test.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |  ⚠️ not tested  |
|  🐧 Linux  |  ⚠️ not tested  |

### Environment (optional)

Local package validation from `packages/core`; Node.js v26.3.0.

## Risk & Scope

- Main risk or tradeoff: this is a live-output user hint, so the main risk is showing it in a context where Ctrl+B is not available. The implementation gates it behind `config.isInteractive()` and the shell promote callback, and it arms only after the foreground handle/promotion path is exposed.
- Not validated / out of scope: this does not add an in-place timeout extension control, does not change default timeout settings, and does not alter background task behavior.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #5838

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

为交互式前台 shell 命令增加了临近超时的实时提示。当一个带有超过 15 秒 timeout 的前台命令进入最后 15 秒时，live output 会提示该命令即将超时，并说明在交互式 TUI 中可以按 Ctrl+B 将它提升为后台任务继续运行。

这个提示只影响 live display。它不会改变最终 shell 输出、面向模型的 `llmContent`、默认 timeout，也不会改变已有 Ctrl+B promote 行为。同时它只在交互式会话且 promote callback 已接入时显示，因此直接 core/headless live-output 调用方不会看到误导性的 Ctrl+B 提示。

## 为什么需要

在 #5838 中，报告者澄清主要痛点是前台命令快超时时才意识到已经来不及处理。Ctrl+B 已经是当前让运行中的前台命令转入后台继续运行的 workaround，但正在运行的 shell UI 没有在临近超时时提示这个选项。这个改动让已有恢复路径在真正需要的时候可被发现。

## Reviewer 测试计划

### 如何验证

在 `packages/core` 下运行 `npx vitest run src/tools/shell.test.ts --coverage=false`。重点覆盖会验证：提示会在超时前触发；后续 live output 仍保留提示；非交互模式不显示；没有 promote callback 时不显示；命令提前完成时会取消；以及 abort-before-handle 竞态下不会晚 arm 一个 stale warning。

可选手动验证：在交互式 TUI 中运行一个 timeout 超过 15 秒的前台 shell 命令，并让它进入最后 15 秒。live shell output 应显示临近超时的 Ctrl+B 提示；按 Ctrl+B 仍应通过已有后台任务路径提升命令。

### 证据（Before & After）

Before：前台 shell live output 可以展示 elapsed/timeout 状态，但命令仍在运行且临近超时时不会给出 Ctrl+B 提示。

After：新增回归测试断言 20 秒前台命令在第 5 秒触发 live warning，断言后续 live output 会保留 warning，并断言非交互、无 promote callback、提前完成、abort-before-arm 等路径不会出现 stale 或误导性 warning。

本地验证已通过：

- `npx vitest run src/tools/shell.test.ts --coverage=false` — 246 passed
- `npx eslint src/tools/shell.ts src/tools/shell.test.ts`
- `npx prettier --check src/tools/shell.ts src/tools/shell.test.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |  ⚠️ not tested  |
|  🐧 Linux  |  ⚠️ not tested  |

### 环境（可选）

在 `packages/core` 下做本地 package 验证；Node.js v26.3.0。

## 风险与范围

- 主要风险或取舍：这是 live-output 用户提示，主要风险是在 Ctrl+B 不可用的上下文显示提示。实现通过 `config.isInteractive()` 和 shell promote callback 做门禁，并且只在前台 handle / promote 路径暴露后才 arm。
- 未验证 / 不在范围内：不新增原地延长 timeout 的控制，不修改默认 timeout 设置，也不改变后台任务行为。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Refs #5838

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
