### PR TITLE
feat(channels): register Telegram bot command menu

### DIFF
--- a/packages/channels/base/src/BlockStreamer.test.ts
+++ b/packages/channels/base/src/BlockStreamer.test.ts
@@ -135,6 +135,18 @@ describe('BlockStreamer', () => {
     expect(s.blockCount).toBe(0);
   });
 
+  it('stop clears the idle timer and drops buffered text', async () => {
+    const s = createStreamer({ minChars: 5, idleMs: 500 });
+    s.push('Hello world');
+
+    s.stop();
+    vi.advanceTimersByTime(500);
+    await s.flush();
+
+    expect(sent).toEqual([]);
+    expect(s.blockCount).toBe(0);
+  });
+
   it('trims whitespace from emitted blocks', async () => {
     const s = createStreamer({ minChars: 5 });
     s.push('  \n  Hello world  \n\n  Next  ');

--- a/packages/channels/base/src/BlockStreamer.ts
+++ b/packages/channels/base/src/BlockStreamer.ts
@@ -60,6 +60,12 @@ export class BlockStreamer {
     await this.sending;
   }
 
+  /** Drop buffered text and cancel future idle emission. */
+  stop(): void {
+    this.clearIdleTimer();
+    this.buffer = '';
+  }
+
   // ---------------------------------------------------------------------------
   // Internal
   // ---------------------------------------------------------------------------

--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -27,6 +27,10 @@ class TestChannel extends ChannelBase {
     this.connected = false;
   }
 
+  enableCancelCommand(): void {
+    this.registerCancelCommand();
+  }
+
   protected override onPromptStart(
     chatId: string,
     sessionId: string,
@@ -51,6 +55,7 @@ function createBridge(): AcpBridge {
     newSession: vi.fn().mockImplementation(() => `s-${++sessionCounter}`),
     loadSession: vi.fn(),
     prompt: vi.fn().mockResolvedValue('agent response'),
+    cancelSession: vi.fn().mockResolvedValue(undefined),
     stop: vi.fn(),
     start: vi.fn(),
     isConnected: true,
@@ -147,6 +152,7 @@ describe('ChannelBase', () => {
       expect(ch.sent).toHaveLength(1);
       expect(ch.sent[0]!.text).toContain('/help');
       expect(ch.sent[0]!.text).toContain('/clear');
+      expect(ch.sent[0]!.text).not.toContain('/cancel');
       expect(bridge.prompt).not.toHaveBeenCalled();
     });
 
@@ -193,6 +199,256 @@ describe('ChannelBase', () => {
       ch.sent = [];
       await ch.handleInbound(envelope({ text: '/status' }));
       expect(ch.sent[0]!.text).toContain('Session: active');
+    });
+
+    it('/cancel reports when no request is running', async () => {
+      const ch = createChannel();
+      ch.enableCancelCommand();
+      await ch.handleInbound(envelope({ text: '/cancel' }));
+      expect(ch.sent).toHaveLength(1);
+      expect(ch.sent[0]!.text).toContain('No request is currently running');
+      expect(bridge.prompt).not.toHaveBeenCalled();
+      expect(bridge.cancelSession).not.toHaveBeenCalled();
+    });
+
+    it('/cancel aborts the active request without sending its response', async () => {
+      let resolvePrompt!: (v: string) => void;
+      const pendingPrompt = new Promise<string>((resolve) => {
+        resolvePrompt = resolve;
+      });
+      (bridge.prompt as ReturnType<typeof vi.fn>).mockReturnValue(
+        pendingPrompt,
+      );
+      (bridge.cancelSession as ReturnType<typeof vi.fn>).mockImplementation(
+        async () => {
+          resolvePrompt('late response');
+        },
+      );
+
+      const ch = createChannel();
+      ch.enableCancelCommand();
+      const prompt = ch.handleInbound(envelope({ text: 'long task' }));
+      await new Promise((r) => setTimeout(r, 10));
+
+      await ch.handleInbound(envelope({ text: '/cancel' }));
+      await prompt;
+
+      expect(bridge.cancelSession).toHaveBeenCalledWith('s-1');
+      expect(ch.sent).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ text: 'Cancelled current request.' }),
+        ]),
+      );
+      expect(ch.sent).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ text: 'late response' }),
+        ]),
+      );
+    });
+
+    it('/cancel reports failure without suppressing the active response', async () => {
+      let resolvePrompt!: (v: string) => void;
+      const pendingPrompt = new Promise<string>((resolve) => {
+        resolvePrompt = resolve;
+      });
+      (bridge.prompt as ReturnType<typeof vi.fn>).mockReturnValue(
+        pendingPrompt,
+      );
+      (bridge.cancelSession as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('session not found'),
+      );
+      vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+      const ch = createChannel();
+      ch.enableCancelCommand();
+      const prompt = ch.handleInbound(envelope({ text: 'long task' }));
+      await new Promise((r) => setTimeout(r, 10));
+
+      await ch.handleInbound(envelope({ text: '/cancel' }));
+      resolvePrompt('agent response');
+      await prompt;
+
+      expect(bridge.cancelSession).toHaveBeenCalledWith('s-1');
+      expect(ch.sent).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            text: 'Failed to cancel current request.',
+          }),
+          expect.objectContaining({ text: 'agent response' }),
+        ]),
+      );
+      expect(ch.sent).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ text: 'Cancelled current request.' }),
+        ]),
+      );
+    });
+
+    it('/cancel retries after a failed cancellation while the prompt is still active', async () => {
+      let resolvePrompt!: (v: string) => void;
+      const pendingPrompt = new Promise<string>((resolve) => {
+        resolvePrompt = resolve;
+      });
+      (bridge.prompt as ReturnType<typeof vi.fn>).mockReturnValue(
+        pendingPrompt,
+      );
+      (bridge.cancelSession as ReturnType<typeof vi.fn>)
+        .mockRejectedValueOnce(new Error('temporary failure'))
+        .mockImplementationOnce(async () => {
+          resolvePrompt('late response');
+        });
+      vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+      const ch = createChannel();
+      ch.enableCancelCommand();
+      const prompt = ch.handleInbound(envelope({ text: 'long task' }));
+      await new Promise((r) => setTimeout(r, 10));
+
+      await ch.handleInbound(envelope({ text: '/cancel' }));
+      await ch.handleInbound(envelope({ text: '/cancel' }));
+      resolvePrompt('late response');
+      await prompt;
+
+      expect(bridge.cancelSession).toHaveBeenCalledTimes(2);
+      expect(ch.sent).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            text: 'Failed to cancel current request.',
+          }),
+          expect.objectContaining({ text: 'Cancelled current request.' }),
+        ]),
+      );
+      expect(ch.sent).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ text: 'late response' }),
+        ]),
+      );
+    });
+
+    it('/cancel reuses an in-flight cancellation request', async () => {
+      let resolvePrompt!: (v: string) => void;
+      let resolveCancel!: () => void;
+      const pendingPrompt = new Promise<string>((resolve) => {
+        resolvePrompt = resolve;
+      });
+      const pendingCancel = new Promise<void>((resolve) => {
+        resolveCancel = resolve;
+      });
+      (bridge.prompt as ReturnType<typeof vi.fn>).mockReturnValue(
+        pendingPrompt,
+      );
+      (bridge.cancelSession as ReturnType<typeof vi.fn>).mockReturnValue(
+        pendingCancel,
+      );
+
+      const ch = createChannel();
+      ch.enableCancelCommand();
+      const prompt = ch.handleInbound(envelope({ text: 'long task' }));
+      await new Promise((r) => setTimeout(r, 10));
+
+      const firstCancel = ch.handleInbound(envelope({ text: '/cancel' }));
+      const secondCancel = ch.handleInbound(envelope({ text: '/cancel' }));
+
+      expect(bridge.cancelSession).toHaveBeenCalledTimes(1);
+      resolveCancel();
+      await Promise.all([firstCancel, secondCancel]);
+      resolvePrompt('late response');
+      await prompt;
+
+      expect(ch.sent).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ text: 'Cancelled current request.' }),
+        ]),
+      );
+      expect(ch.sent).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ text: 'late response' }),
+        ]),
+      );
+    });
+
+    it('/cancel follows single session scope', async () => {
+      let resolvePrompt!: (v: string) => void;
+      const pendingPrompt = new Promise<string>((resolve) => {
+        resolvePrompt = resolve;
+      });
+      (bridge.prompt as ReturnType<typeof vi.fn>).mockReturnValue(
+        pendingPrompt,
+      );
+      (bridge.cancelSession as ReturnType<typeof vi.fn>).mockImplementation(
+        async () => {
+          resolvePrompt('late response');
+        },
+      );
+
+      const ch = createChannel({ sessionScope: 'single' });
+      ch.enableCancelCommand();
+      const prompt = ch.handleInbound(
+        envelope({ senderId: 'alice', chatId: 'chat-a', text: 'long task' }),
+      );
+      await new Promise((r) => setTimeout(r, 10));
+
+      await ch.handleInbound(
+        envelope({ senderId: 'bob', chatId: 'chat-b', text: '/cancel' }),
+      );
+      await prompt;
+
+      expect(bridge.cancelSession).toHaveBeenCalledWith('s-1');
+      expect(ch.sent).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            chatId: 'chat-b',
+            text: 'Cancelled current request.',
+          }),
+        ]),
+      );
+    });
+
+    it('/cancel follows thread session scope', async () => {
+      let resolvePrompt!: (v: string) => void;
+      const pendingPrompt = new Promise<string>((resolve) => {
+        resolvePrompt = resolve;
+      });
+      (bridge.prompt as ReturnType<typeof vi.fn>).mockReturnValue(
+        pendingPrompt,
+      );
+      (bridge.cancelSession as ReturnType<typeof vi.fn>).mockImplementation(
+        async () => {
+          resolvePrompt('late response');
+        },
+      );
+
+      const ch = createChannel({ sessionScope: 'thread' });
+      ch.enableCancelCommand();
+      const prompt = ch.handleInbound(
+        envelope({
+          senderId: 'alice',
+          chatId: 'chat-a',
+          threadId: 'topic-1',
+          text: 'long task',
+        }),
+      );
+      await new Promise((r) => setTimeout(r, 10));
+
+      await ch.handleInbound(
+        envelope({
+          senderId: 'bob',
+          chatId: 'chat-a',
+          threadId: 'topic-1',
+          text: '/cancel',
+        }),
+      );
+      await prompt;
+
+      expect(bridge.cancelSession).toHaveBeenCalledWith('s-1');
+      expect(ch.sent).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            chatId: 'chat-a',
+            text: 'Cancelled current request.',
+          }),
+        ]),
+      );
     });
 
     it('handles /command@botname format', async () => {
@@ -376,6 +632,82 @@ describe('ChannelBase', () => {
       await ch.handleInbound(envelope());
       // BlockStreamer flush should have sent the accumulated text
       expect(ch.sent.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('does not emit buffered stream text after cancellation', async () => {
+      vi.useFakeTimers();
+      try {
+        let resolvePrompt!: (v: string) => void;
+        let resolveCancel!: () => void;
+        const pendingPrompt = new Promise<string>((resolve) => {
+          resolvePrompt = resolve;
+        });
+        const pendingCancel = new Promise<void>((resolve) => {
+          resolveCancel = resolve;
+        });
+        (bridge.prompt as ReturnType<typeof vi.fn>).mockImplementation(
+          (sid: string) => {
+            (bridge as unknown as EventEmitter).emit(
+              'textChunk',
+              sid,
+              'partial response that should not leak',
+            );
+            return pendingPrompt;
+          },
+        );
+        (bridge.cancelSession as ReturnType<typeof vi.fn>).mockReturnValue(
+          pendingCancel,
+        );
+
+        const ch = createChannel({
+          blockStreaming: 'on',
+          blockStreamingChunk: { minChars: 5, maxChars: 1000 },
+          blockStreamingCoalesce: { idleMs: 500 },
+        });
+        ch.enableCancelCommand();
+        const prompt = ch.handleInbound(envelope({ text: 'long task' }));
+        for (let i = 0; i < 10 && ch.promptStarts.length === 0; i++) {
+          await Promise.resolve();
+        }
+        expect(ch.promptStarts).toHaveLength(1);
+
+        const cancel = ch.handleInbound(envelope({ text: '/cancel' }));
+        await Promise.resolve();
+        resolveCancel();
+        await cancel;
+
+        (bridge as unknown as EventEmitter).emit(
+          'textChunk',
+          's-1',
+          'late chunk after cancel',
+        );
+        await vi.advanceTimersByTimeAsync(500);
+
+        resolvePrompt('late full response');
+        await prompt;
+
+        expect(ch.sent).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ text: 'Cancelled current request.' }),
+          ]),
+        );
+        expect(ch.sent).not.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              text: 'partial response that should not leak',
+            }),
+          ]),
+        );
+        expect(ch.sent).not.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              text: 'late chunk after cancel',
+            }),
+          ]),
+        );
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 
@@ -743,6 +1075,11 @@ describe('ChannelBase', () => {
       expect((ch as any).isLocalCommand('/help')).toBe(true);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((ch as any).isLocalCommand('/clear')).toBe(true);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((ch as any).isLocalCommand('/cancel')).toBe(false);
+      ch.enableCancelCommand();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((ch as any).isLocalCommand('/cancel')).toBe(true);
     });
 
     it('returns false for non-commands', () => {

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -13,6 +13,13 @@ export interface ChannelBaseOptions {
 
 /** Handler for a slash command. Return true if handled, false to forward to agent. */
 type CommandHandler = (envelope: Envelope, args: string) => Promise<boolean>;
+type ActivePrompt = {
+  cancelled: boolean;
+  cancelRequested?: Promise<boolean>;
+  done: Promise<void>;
+  resolve: () => void;
+  stopStreaming?: () => void;
+};
 
 export abstract class ChannelBase {
   protected config: ChannelConfig;
@@ -29,10 +36,7 @@ export abstract class ChannelBase {
   private sessionQueues: Map<string, Promise<void>> = new Map();
 
   /** Per-session active prompt tracking for dispatch modes. */
-  private activePrompts: Map<
-    string,
-    { cancelled: boolean; done: Promise<void>; resolve: () => void }
-  > = new Map();
+  private activePrompts: Map<string, ActivePrompt> = new Map();
   /** Per-session message buffer for collect mode. */
   private collectBuffers: Map<
     string,
@@ -142,6 +146,57 @@ export abstract class ChannelBase {
     this.commands.set(name.toLowerCase(), handler);
   }
 
+  protected registerCancelCommand(name = 'cancel'): void {
+    this.registerCommand(name, async (envelope) => {
+      const activeSessionId = this.findActiveSessionId(envelope);
+      if (!activeSessionId) {
+        await this.sendMessage(
+          envelope.chatId,
+          'No request is currently running.',
+        );
+        return true;
+      }
+
+      const active = this.activePrompts.get(activeSessionId);
+      if (!active) {
+        await this.sendMessage(
+          envelope.chatId,
+          'No request is currently running.',
+        );
+        return true;
+      }
+
+      const cancelRequested =
+        active.cancelRequested ??
+        this.bridge.cancelSession(activeSessionId).then(
+          () => true,
+          (err) => {
+            process.stderr.write(
+              `[${this.name}] cancelSession failed for session=${activeSessionId}: ${err instanceof Error ? err.message : err}\n`,
+            );
+            active.cancelRequested = undefined;
+            return false;
+          },
+        );
+      active.cancelRequested = cancelRequested;
+
+      const cancelSucceeded = await cancelRequested;
+      if (!cancelSucceeded) {
+        await this.sendMessage(
+          envelope.chatId,
+          'Failed to cancel current request.',
+        );
+        return true;
+      }
+
+      active.cancelled = true;
+      active.stopStreaming?.();
+      this.collectBuffers.delete(activeSessionId);
+      await this.sendMessage(envelope.chatId, 'Cancelled current request.');
+      return true;
+    });
+  }
+
   /** Register shared slash commands. Called from constructor. */
   private registerSharedCommands(): void {
     const clearHandler: CommandHandler = async (envelope) => {
@@ -221,6 +276,18 @@ export abstract class ChannelBase {
   protected isLocalCommand(text: string): boolean {
     const parsed = this.parseCommand(text);
     return parsed !== null && this.commands.has(parsed.command);
+  }
+
+  private findActiveSessionId(envelope: Envelope): string | undefined {
+    const sessionId = this.router.getSession(
+      this.name,
+      envelope.senderId,
+      envelope.chatId,
+      envelope.threadId,
+    );
+    return sessionId && this.activePrompts.has(sessionId)
+      ? sessionId
+      : undefined;
   }
 
   /**
@@ -399,7 +466,11 @@ export abstract class ChannelBase {
       const done = new Promise<void>((r) => {
         doneResolve = r;
       });
-      const promptState = { cancelled: false, done, resolve: doneResolve };
+      const promptState: ActivePrompt = {
+        cancelled: false,
+        done,
+        resolve: doneResolve,
+      };
       this.activePrompts.set(sessionId, promptState);
 
       this.onPromptStart(envelope.chatId, sessionId, envelope.messageId);
@@ -412,9 +483,10 @@ export abstract class ChannelBase {
             send: (text) => this.sendMessage(envelope.chatId, text),
           })
         : null;
+      promptState.stopStreaming = () => streamer?.stop();
 
       const onChunk = (sid: string, chunk: string) => {
-        if (sid === sessionId) {
+        if (sid === sessionId && !promptState.cancelled) {
           this.onResponseChunk(envelope.chatId, chunk, sessionId);
           streamer?.push(chunk);
         }
@@ -427,7 +499,11 @@ export abstract class ChannelBase {
           imageMimeType,
         });
 
-        // If cancelled (steer mode), skip sending the response
+        if (promptState.cancelRequested && !promptState.cancelled) {
+          promptState.cancelled = await promptState.cancelRequested;
+        }
+
+        // If cancelled, skip sending the response
         if (!promptState.cancelled && response) {
           if (streamer) {
             await streamer.flush();
@@ -437,6 +513,7 @@ export abstract class ChannelBase {
         }
       } finally {
         this.bridge.off('textChunk', onChunk);
+        streamer?.stop();
         this.onPromptEnd(envelope.chatId, sessionId, envelope.messageId);
         this.activePrompts.delete(sessionId);
         // Signal any steer waiter that we're done

--- a/packages/channels/base/src/SessionRouter.test.ts
+++ b/packages/channels/base/src/SessionRouter.test.ts
@@ -139,6 +139,28 @@ describe('SessionRouter', () => {
     });
   });
 
+  describe('getSession', () => {
+    it('returns the session for the configured scope without creating one', async () => {
+      const router = new SessionRouter(bridge, '/tmp', 'thread');
+      const sid = await router.resolve('ch', 'alice', 'chat1', 'thread1');
+
+      expect(router.getSession('ch', 'bob', 'chat1', 'thread1')).toBe(sid);
+      expect(
+        router.getSession('ch', 'bob', 'chat1', 'thread2'),
+      ).toBeUndefined();
+      expect(bridge.newSession).toHaveBeenCalledTimes(1);
+    });
+
+    it('respects per-channel single scope overrides', async () => {
+      const router = new SessionRouter(bridge, '/tmp');
+      router.setChannelScope('telegram', 'single');
+      const sid = await router.resolve('telegram', 'alice', 'chat1');
+
+      expect(router.getSession('telegram', 'bob', 'chat2')).toBe(sid);
+      expect(router.getSession('other', 'bob', 'chat2')).toBeUndefined();
+    });
+  });
+
   describe('hasSession', () => {
     it('returns true for existing session with chatId', async () => {
       const router = new SessionRouter(bridge, '/tmp');

--- a/packages/channels/base/src/SessionRouter.ts
+++ b/packages/channels/base/src/SessionRouter.ts
@@ -95,6 +95,17 @@ export class SessionRouter {
     return this.toTarget.get(sessionId);
   }
 
+  getSession(
+    channelName: string,
+    senderId: string,
+    chatId: string,
+    threadId?: string,
+  ): string | undefined {
+    return this.toSession.get(
+      this.routingKey(channelName, senderId, chatId, threadId),
+    );
+  }
+
   hasSession(channelName: string, senderId: string, chatId?: string): boolean {
     // If chatId is provided, do an exact lookup; otherwise prefix-scan for any
     // session belonging to this sender on this channel.

--- a/packages/channels/telegram/src/TelegramAdapter.test.ts
+++ b/packages/channels/telegram/src/TelegramAdapter.test.ts
@@ -1,10 +1,38 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TelegramChannel } from './TelegramAdapter.js';
-import type { AcpBridge, ChannelConfig } from '@qwen-code/channel-base';
+import type {
+  AcpBridge,
+  ChannelConfig,
+  Envelope,
+} from '@qwen-code/channel-base';
+
+type TestTelegramMessage = {
+  from: { id: number; first_name: string; last_name?: string };
+  chat: { id: number; type: string };
+  reply_to_message?: { from?: { id: number }; text?: string };
+};
+
+type TestTelegramEntity = { type: string; offset: number; length: number };
 
 class TestTelegramChannel extends TelegramChannel {
   startTyping(chatId: string): void {
     this.onPromptStart(chatId);
+  }
+
+  buildTestEnvelope(
+    msg: TestTelegramMessage,
+    text: string,
+    entities?: TestTelegramEntity[],
+  ): Envelope {
+    return (
+      this as unknown as {
+        buildEnvelope: (
+          msg: TestTelegramMessage,
+          text: string,
+          entities?: TestTelegramEntity[],
+        ) => Envelope;
+      }
+    ).buildEnvelope(msg, text, entities);
   }
 }
 
@@ -19,20 +47,56 @@ const config: ChannelConfig = {
   groups: {},
 };
 
-function createChannel(): TestTelegramChannel {
-  return new TestTelegramChannel('telegram', config, {} as AcpBridge, {
-    router: {} as never,
-  });
+function createChannel(
+  configOverrides: Partial<ChannelConfig> = {},
+  router: unknown = {},
+): TestTelegramChannel {
+  return new TestTelegramChannel(
+    'telegram',
+    { ...config, ...configOverrides },
+    {} as AcpBridge,
+    {
+      router: router as never,
+    },
+  );
+}
+
+function envelope(overrides: Partial<Envelope> = {}): Envelope {
+  return {
+    channelName: 'telegram',
+    senderId: 'user-1',
+    senderName: 'User 1',
+    chatId: 'chat-1',
+    text: 'hello',
+    isGroup: false,
+    isMentioned: false,
+    isReplyToBot: false,
+    ...overrides,
+  };
 }
 
 function installFakeBot(channel: TelegramChannel): {
-  api: { sendChatAction: ReturnType<typeof vi.fn> };
+  token: string;
+  api: {
+    getMe: ReturnType<typeof vi.fn>;
+    setMyCommands: ReturnType<typeof vi.fn>;
+    sendChatAction: ReturnType<typeof vi.fn>;
+    sendMessage: ReturnType<typeof vi.fn>;
+  };
+  on: ReturnType<typeof vi.fn>;
+  start: ReturnType<typeof vi.fn>;
   stop: ReturnType<typeof vi.fn>;
 } {
   const bot = {
+    token: 'token',
     api: {
+      getMe: vi.fn().mockResolvedValue({ id: 123, username: 'qwen_bot' }),
+      setMyCommands: vi.fn().mockResolvedValue(true),
       sendChatAction: vi.fn().mockResolvedValue(undefined),
+      sendMessage: vi.fn().mockResolvedValue(undefined),
     },
+    on: vi.fn(),
+    start: vi.fn().mockResolvedValue(undefined),
     stop: vi.fn(),
   };
   (channel as unknown as { bot: typeof bot }).bot = bot;
@@ -65,5 +129,135 @@ describe('TelegramChannel', () => {
 
     vi.advanceTimersByTime(4000);
     expect(bot.api.sendChatAction).toHaveBeenCalledTimes(2);
+  });
+
+  it('registers the Telegram command menu before polling starts', async () => {
+    const channel = createChannel();
+    const bot = installFakeBot(channel);
+    const processOnceSpy = vi.spyOn(process, 'once').mockReturnValue(process);
+
+    await channel.connect();
+
+    expect(bot.api.setMyCommands).toHaveBeenCalledWith([
+      { command: 'start', description: 'Show quick-start help' },
+      { command: 'help', description: 'Show available commands' },
+      { command: 'new', description: 'Start a fresh conversation' },
+      { command: 'cancel', description: 'Cancel the running request' },
+      { command: 'status', description: 'Show session info' },
+    ]);
+    expect(bot.start).toHaveBeenCalledWith({ drop_pending_updates: true });
+    expect(bot.api.setMyCommands.mock.invocationCallOrder[0]).toBeLessThan(
+      bot.start.mock.invocationCallOrder[0],
+    );
+    expect(processOnceSpy).toHaveBeenCalled();
+  });
+
+  it('continues startup when Telegram command menu registration fails', async () => {
+    const channel = createChannel();
+    const bot = installFakeBot(channel);
+    bot.api.setMyCommands.mockRejectedValue(new Error('bot api down'));
+    vi.spyOn(process, 'once').mockReturnValue(process);
+    const stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+
+    await channel.connect();
+
+    expect(bot.start).toHaveBeenCalledWith({ drop_pending_updates: true });
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to register bot commands'),
+    );
+  });
+
+  it('handles /start locally', async () => {
+    const channel = createChannel();
+    const bot = installFakeBot(channel);
+
+    await channel.handleInbound(envelope({ text: '/start' }));
+
+    expect(bot.api.sendMessage).toHaveBeenCalledWith(
+      'chat-1',
+      expect.stringContaining('Qwen Code Telegram bot'),
+      { parse_mode: 'HTML' },
+    );
+  });
+
+  it('only treats addressed Telegram bot commands as mentions in groups', () => {
+    const channel = createChannel();
+    installFakeBot(channel);
+    (channel as unknown as { botUsername: string }).botUsername = 'qwen_bot';
+
+    const directCommand = channel.buildTestEnvelope(
+      {
+        from: { id: 1, first_name: 'User' },
+        chat: { id: 2, type: 'group' },
+      },
+      '/cancel',
+      [{ type: 'bot_command', offset: 0, length: 7 }],
+    );
+    const addressedCommand = channel.buildTestEnvelope(
+      {
+        from: { id: 1, first_name: 'User' },
+        chat: { id: 2, type: 'group' },
+      },
+      '/cancel@qwen_bot',
+      [{ type: 'bot_command', offset: 0, length: 16 }],
+    );
+    const otherBotCommand = channel.buildTestEnvelope(
+      {
+        from: { id: 1, first_name: 'User' },
+        chat: { id: 2, type: 'group' },
+      },
+      '/cancel@other_bot',
+      [{ type: 'bot_command', offset: 0, length: 17 }],
+    );
+
+    expect(directCommand.isMentioned).toBe(false);
+    expect(addressedCommand.isMentioned).toBe(true);
+    expect(otherBotCommand.isMentioned).toBe(false);
+  });
+
+  it('does not let bare bot commands pass mention-gated groups', async () => {
+    const router = { getSession: vi.fn().mockReturnValue(undefined) };
+    const channel = createChannel(
+      {
+        groupPolicy: 'open',
+        groups: { '*': { requireMention: true } },
+      },
+      router,
+    );
+    const bot = installFakeBot(channel);
+    (channel as unknown as { botUsername: string }).botUsername = 'qwen_bot';
+    const groupMessage = {
+      from: { id: 1, first_name: 'User' },
+      chat: { id: 2, type: 'group' },
+    };
+
+    await channel.handleInbound(
+      channel.buildTestEnvelope(groupMessage, '/cancel', [
+        { type: 'bot_command', offset: 0, length: 7 },
+      ]),
+    );
+
+    expect(router.getSession).not.toHaveBeenCalled();
+    expect(bot.api.sendMessage).not.toHaveBeenCalled();
+
+    await channel.handleInbound(
+      channel.buildTestEnvelope(groupMessage, '/cancel@qwen_bot', [
+        { type: 'bot_command', offset: 0, length: 16 },
+      ]),
+    );
+
+    expect(router.getSession).toHaveBeenCalledWith(
+      'telegram',
+      '1',
+      '2',
+      undefined,
+    );
+    expect(bot.api.sendMessage).toHaveBeenCalledWith(
+      '2',
+      'No request is currently running.',
+      { parse_mode: 'HTML' },
+    );
   });
 });

--- a/packages/channels/telegram/src/TelegramAdapter.ts
+++ b/packages/channels/telegram/src/TelegramAdapter.ts
@@ -16,6 +16,23 @@ import type {
   AcpBridge,
 } from '@qwen-code/channel-base';
 
+const TELEGRAM_BOT_COMMANDS = [
+  { command: 'start', description: 'Show quick-start help' },
+  { command: 'help', description: 'Show available commands' },
+  { command: 'new', description: 'Start a fresh conversation' },
+  { command: 'cancel', description: 'Cancel the running request' },
+  { command: 'status', description: 'Show session info' },
+] as const;
+
+const TELEGRAM_START_MESSAGE = [
+  'Qwen Code Telegram bot',
+  '',
+  'Send any message to chat with Qwen Code.',
+  'Use /new to start a fresh conversation.',
+  'Use /cancel to stop a running request.',
+  'Use /help to see available commands.',
+].join('\n');
+
 export class TelegramChannel extends ChannelBase {
   private bot: Bot;
   private botId: number = 0;
@@ -36,6 +53,11 @@ export class TelegramChannel extends ChannelBase {
         }
       : undefined;
     this.bot = new Bot(config.token, botConfig);
+    this.registerCommand('start', async (envelope) => {
+      await this.sendMessage(envelope.chatId, TELEGRAM_START_MESSAGE);
+      return true;
+    });
+    this.registerCancelCommand();
   }
 
   private getFileUrl(filePath: string): string {
@@ -46,6 +68,7 @@ export class TelegramChannel extends ChannelBase {
     const botInfo = await this.bot.api.getMe();
     this.botId = botInfo.id;
     this.botUsername = botInfo.username ?? '';
+    await this.registerBotCommands();
     // All messages (including slash commands) go through handleInbound
     // where ChannelBase dispatches shared commands (/help, /clear, /status, etc.)
     this.bot.on('message:text', async (ctx) => {
@@ -218,6 +241,16 @@ export class TelegramChannel extends ChannelBase {
     process.once('SIGTERM', () => this.bot.stop());
   }
 
+  private async registerBotCommands(): Promise<void> {
+    try {
+      await this.bot.api.setMyCommands(TELEGRAM_BOT_COMMANDS);
+    } catch (err) {
+      process.stderr.write(
+        `[Telegram:${this.name}] Failed to register bot commands: ${err instanceof Error ? err.message : err}\n`,
+      );
+    }
+  }
+
   /** Per-chat typing interval — repeats every 4s since Telegram expires it after 5s. */
   private typingIntervals = new Map<string, ReturnType<typeof setInterval>>();
 
@@ -275,13 +308,21 @@ export class TelegramChannel extends ChannelBase {
     const isGroup = msg.chat.type === 'group' || msg.chat.type === 'supergroup';
 
     const isMentioned =
-      entities?.some(
-        (e) =>
-          e.type === 'mention' &&
-          this.botUsername &&
-          text.slice(e.offset, e.offset + e.length).toLowerCase() ===
-            `@${this.botUsername.toLowerCase()}`,
-      ) ?? false;
+      entities?.some((e) => {
+        if (!this.botUsername) return false;
+        const value = text.slice(e.offset, e.offset + e.length).toLowerCase();
+        const username = this.botUsername.toLowerCase();
+        if (e.type === 'mention') {
+          return value === `@${username}`;
+        }
+        if (e.type === 'bot_command') {
+          const mentionIndex = value.indexOf('@');
+          return (
+            mentionIndex !== -1 && value.slice(mentionIndex + 1) === username
+          );
+        }
+        return false;
+      }) ?? false;
 
     const isReplyToBot = msg.reply_to_message?.from?.id === this.botId;
 


### PR DESCRIPTION
## What this PR does

Registers the CLI Telegram bot command menu with Telegram's `setMyCommands` API, adds a Telegram-local `/start` response, and adds a shared `/cancel` command for channel adapters so the menu only advertises commands that are actually handled locally.

The new `/cancel` command reuses `SessionRouter` scope resolution instead of manually matching sender/chat fields, so it works with the existing `user`, `thread`, and `single` session scopes. Telegram command entities such as `/cancel@botname` are also treated as a bot mention in groups, which lets menu commands pass the existing group mention gate.

## Why it's needed

Part of #5907. The Telegram channel already parses slash commands server-side, but it never registers the command menu with Telegram. That leaves the bot menu out of sync with the commands users can actually run.

This PR covers the first small slice of the tracking issue: menu registration plus the core `/start`, `/help`, `/cancel`, `/new`, and `/status` commands for the CLI Telegram channel. Desktop gateway command alignment and larger session/model workflows stay out of scope for follow-up PRs.

## Reviewer Test Plan

### How to verify

Run the focused channel tests and confirm the Telegram adapter registers `start`, `help`, `new`, `cancel`, and `status` before polling starts, continues startup if menu registration fails, handles `/start` locally, and treats Telegram `bot_command` entities as mentions in groups. Also confirm `/cancel` cancels the active request and follows `user`, `thread`, and `single` session scope semantics.

Commands run locally:

```bash
npx vitest run packages/channels/base/src/SessionRouter.test.ts packages/channels/base/src/ChannelBase.test.ts packages/channels/telegram/src/TelegramAdapter.test.ts --coverage=false
npx eslint packages/channels/base/src/SessionRouter.ts packages/channels/base/src/SessionRouter.test.ts packages/channels/base/src/ChannelBase.ts packages/channels/base/src/ChannelBase.test.ts packages/channels/telegram/src/TelegramAdapter.ts packages/channels/telegram/src/TelegramAdapter.test.ts
npx prettier --check packages/channels/base/src/SessionRouter.ts packages/channels/base/src/SessionRouter.test.ts packages/channels/base/src/ChannelBase.ts packages/channels/base/src/ChannelBase.test.ts packages/channels/telegram/src/TelegramAdapter.ts packages/channels/telegram/src/TelegramAdapter.test.ts
npm run typecheck
npm run build
git diff --check
```

### Evidence (Before & After)

Before: the CLI Telegram adapter did not call `setMyCommands`, did not handle `/start` locally, and the shared channel command set did not include `/cancel`.

After: focused tests pass with 76 tests across `SessionRouter`, `ChannelBase`, and `TelegramAdapter`; `npm run typecheck`, focused lint/format checks, `npm run build`, and `git diff --check` pass locally. The full build still prints existing chunk-size, Browserslist, and VSCode companion curly warnings, but exits successfully.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local npm workspace on macOS.

## Risk & Scope

- Main risk or tradeoff: `/cancel` is now shared by channel adapters, so tests cover both the default user scope and the broader thread/single scopes to keep cancellation aligned with existing routing behavior.
- Not validated / out of scope: real Telegram Bot API manual testing, Desktop messaging gateway command alignment, session listing/switching, model/agent/language/token commands.
- Breaking changes / migration notes: none expected.

## Linked Issues

Part of #5907.

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 为 CLI Telegram bot 通过 Telegram 的 `setMyCommands` API 注册命令菜单，增加 Telegram 本地的 `/start` 响应，并在共享 channel 适配层增加 `/cancel` 命令，确保菜单只展示本地确实能处理的命令。

新的 `/cancel` 命令复用 `SessionRouter` 的 scope 解析，而不是手动匹配 sender/chat 字段，所以它能遵循现有的 `user`、`thread`、`single` session scope。Telegram 群聊里的 `/cancel@botname` 这类 `bot_command` entity 也会被视为对 bot 的 mention，从而通过现有的 group mention gate。

## Why it's needed

属于 #5907 的一部分。Telegram channel 已经会在服务端解析 slash command，但之前没有向 Telegram 注册命令菜单，导致 bot 菜单和用户实际能运行的命令不一致。

这个 PR 只覆盖 tracking issue 的第一个小切片：CLI Telegram channel 的命令菜单注册，以及核心 `/start`、`/help`、`/cancel`、`/new`、`/status` 命令。Desktop gateway 的命令对齐，以及更大的 session/model 工作流都留给后续 PR。

## Reviewer Test Plan

### How to verify

运行聚焦的 channel 测试，确认 Telegram adapter 会在 polling 启动前注册 `start`、`help`、`new`、`cancel`、`status`，即使命令菜单注册失败也继续启动，能本地处理 `/start`，并且会把 Telegram 的 `bot_command` entity 视作群聊里的 mention。同时确认 `/cancel` 会取消当前运行请求，并遵循 `user`、`thread`、`single` session scope 语义。

本地运行过的命令：

```bash
npx vitest run packages/channels/base/src/SessionRouter.test.ts packages/channels/base/src/ChannelBase.test.ts packages/channels/telegram/src/TelegramAdapter.test.ts --coverage=false
npx eslint packages/channels/base/src/SessionRouter.ts packages/channels/base/src/SessionRouter.test.ts packages/channels/base/src/ChannelBase.ts packages/channels/base/src/ChannelBase.test.ts packages/channels/telegram/src/TelegramAdapter.ts packages/channels/telegram/src/TelegramAdapter.test.ts
npx prettier --check packages/channels/base/src/SessionRouter.ts packages/channels/base/src/SessionRouter.test.ts packages/channels/base/src/ChannelBase.ts packages/channels/base/src/ChannelBase.test.ts packages/channels/telegram/src/TelegramAdapter.ts packages/channels/telegram/src/TelegramAdapter.test.ts
npm run typecheck
npm run build
git diff --check
```

### Evidence (Before & After)

Before：CLI Telegram adapter 没有调用 `setMyCommands`，没有本地处理 `/start`，共享 channel 命令集也没有 `/cancel`。

After：`SessionRouter`、`ChannelBase`、`TelegramAdapter` 三个聚焦测试文件共 76 个测试通过；`npm run typecheck`、聚焦 lint/format 检查、`npm run build` 和 `git diff --check` 都在本地通过。完整 build 仍会打印已有的 chunk-size、Browserslist 和 VSCode companion curly warnings，但命令成功退出。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 本地 npm workspace。

## Risk & Scope

- Main risk or tradeoff: `/cancel` 现在由 channel adapter 共享，因此测试覆盖了默认 user scope 以及更宽的 thread/single scopes，确保取消逻辑和现有 routing 行为一致。
- Not validated / out of scope: 真实 Telegram Bot API 手动测试、Desktop messaging gateway 命令对齐、session 列表/切换、model/agent/language/token 命令。
- Breaking changes / migration notes: 预期没有。

## Linked Issues

Part of #5907.

## AI Assistance Disclosure

我使用 Codex 审查改动、对照现有模式做 sanity check，并帮助发现潜在边界情况。

</details>
