### PR TITLE
feat(cli): show scheduled task count in footer

### DIFF
--- a/packages/cli/src/ui/components/CronPill.test.tsx
+++ b/packages/cli/src/ui/components/CronPill.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../test-utils/render.js';
+import { CronPill } from './CronPill.js';
+
+describe('CronPill', () => {
+  it('renders nothing when there are no scheduled tasks', () => {
+    const { lastFrame, unmount } = renderWithProviders(<CronPill count={0} />);
+    expect(lastFrame()).toBe('');
+    unmount();
+  });
+
+  it('renders the active scheduled task count', () => {
+    const { lastFrame, unmount } = renderWithProviders(<CronPill count={2} />);
+    expect(lastFrame()).toContain('◎ 2 scheduled tasks');
+    unmount();
+  });
+});

--- a/packages/cli/src/ui/components/CronPill.tsx
+++ b/packages/cli/src/ui/components/CronPill.tsx
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { useEffect, useState } from 'react';
+import { Text } from 'ink';
+import type { Config } from '@qwen-code/qwen-code-core';
+import { useConfig } from '../contexts/ConfigContext.js';
+import { theme } from '../semantic-colors.js';
+
+const POLL_INTERVAL_MS = 1000;
+
+function getScheduledTaskCount(config: Config | undefined): number {
+  if (!config?.isCronEnabled?.()) return 0;
+  return config.getCronScheduler?.()?.size ?? 0;
+}
+
+function useScheduledTaskCount(config: Config | undefined): number {
+  const [count, setCount] = useState(() => getScheduledTaskCount(config));
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setCount(getScheduledTaskCount(config));
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [config]);
+
+  return count;
+}
+
+export function useFooterCronTaskCount(): number {
+  return useScheduledTaskCount(useConfig());
+}
+
+type CronPillProps = {
+  count: number;
+};
+
+export const CronPill: React.FC<CronPillProps> = ({ count }) => {
+  if (count <= 0) return null;
+
+  const noun = count === 1 ? 'scheduled task' : 'scheduled tasks';
+  return (
+    <Text color={theme.text.accent}>
+      ◎ {count} {noun}
+    </Text>
+  );
+};

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -5,6 +5,7 @@
  */
 
 import { render } from 'ink-testing-library';
+import { act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Footer } from './Footer.js';
 import * as useTerminalSize from '../hooks/useTerminalSize.js';
@@ -93,12 +94,18 @@ const createMockSettings = (): LoadedSettings =>
     },
   }) as LoadedSettings;
 
-const renderWithWidth = (width: number, uiState: UIState) => {
+const renderWithWidth = (
+  width: number,
+  uiState: UIState,
+  configOverrides = {},
+) => {
   useTerminalSizeMock.mockReturnValue({ columns: width, rows: 24 });
   const mockSettings = createMockSettings();
   return render(
     <SettingsContext.Provider value={mockSettings}>
-      <ConfigContext.Provider value={createMockConfig() as never}>
+      <ConfigContext.Provider
+        value={createMockConfig(configOverrides) as never}
+      >
         <KeypressProvider kittyProtocolEnabled={false}>
           <VimModeProvider settings={mockSettings}>
             <UIStateContext.Provider value={uiState}>
@@ -137,6 +144,49 @@ describe('<Footer />', () => {
   it('hides the "workflow active" indicator by default', () => {
     const { lastFrame } = renderWithWidth(120, createMockUIState());
     expect(lastFrame()).not.toContain('workflow active');
+  });
+
+  it('shows the active scheduled task count', () => {
+    const { lastFrame } = renderWithWidth(120, createMockUIState(), {
+      isCronEnabled: vi.fn(() => true),
+      getCronScheduler: vi.fn(() => ({ size: 2 })),
+    });
+    expect(lastFrame()).toContain('◎ 2 scheduled tasks');
+  });
+
+  it('refreshes the scheduled task count after mount', async () => {
+    vi.useFakeTimers();
+    let schedulerSize = 0;
+    let unmount: (() => void) | undefined;
+    const scheduler = {
+      get size() {
+        return schedulerSize;
+      },
+    };
+    try {
+      const renderResult = renderWithWidth(120, createMockUIState(), {
+        isCronEnabled: vi.fn(() => true),
+        getCronScheduler: vi.fn(() => scheduler),
+      });
+      unmount = renderResult.unmount;
+      const { lastFrame } = renderResult;
+      expect(lastFrame()).not.toContain('scheduled task');
+
+      schedulerSize = 1;
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(lastFrame()).toContain('◎ 1 scheduled task');
+
+      schedulerSize = 0;
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(lastFrame()).not.toContain('scheduled task');
+    } finally {
+      unmount?.();
+      vi.useRealTimers();
+    }
   });
 
   it('does not display the working directory or branch name', () => {

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -24,6 +24,7 @@ import { useVimModeState } from '../contexts/VimModeContext.js';
 import { ApprovalMode } from '@qwen-code/qwen-code-core';
 import { GeminiSpinner } from './GeminiRespondingSpinner.js';
 import { GoalPill, useFooterGoalState } from './GoalPill.js';
+import { CronPill, useFooterCronTaskCount } from './CronPill.js';
 import { t } from '../../i18n/index.js';
 
 export const Footer: React.FC = () => {
@@ -140,6 +141,10 @@ export const Footer: React.FC = () => {
   const goalActive = useFooterGoalState() !== undefined;
   if (goalActive) {
     rightItems.push({ key: 'goal', node: <GoalPill /> });
+  }
+  const cronTaskCount = useFooterCronTaskCount();
+  if (cronTaskCount > 0) {
+    rightItems.push({ key: 'cron', node: <CronPill count={cronTaskCount} /> });
   }
 
   // Layout matches upstream: left column has status line (top) + hints/mode


### PR DESCRIPTION
## What this PR does

Adds a compact footer pill that shows the number of active scheduled tasks when cron scheduling is enabled and the in-memory cron scheduler has pending entries. The pill reuses the existing footer indicator area and renders as `◎ 2 scheduled tasks`, with singular wording for one task.

## Why it's needed

Issue #5823 points out that `/loop` cron tasks can keep running silently after setup. This PR covers the small visibility slice: users now get an always-visible footer signal when scheduled tasks are active, without changing the broader `/loop` lifecycle or task-management commands.

## Reviewer Test Plan

### How to verify

Run the focused footer tests and confirm that the footer includes `◎ 2 scheduled tasks` when `getCronScheduler().size` returns `2`, and omits the pill when the count is `0`.

Commands run locally:

```bash
npx vitest run packages/cli/src/ui/components/CronPill.test.tsx packages/cli/src/ui/components/Footer.test.tsx --coverage=false
npx eslint packages/cli/src/ui/components/CronPill.tsx packages/cli/src/ui/components/CronPill.test.tsx packages/cli/src/ui/components/Footer.tsx packages/cli/src/ui/components/Footer.test.tsx
npx prettier --check packages/cli/src/ui/components/CronPill.tsx packages/cli/src/ui/components/CronPill.test.tsx packages/cli/src/ui/components/Footer.tsx packages/cli/src/ui/components/Footer.test.tsx
git diff --check
npm run typecheck --workspace=packages/cli
npm run build --workspace=packages/cli
```

### Evidence (Before & After)

Before: active cron scheduler entries did not surface in the footer, so scheduled `/loop` work had no persistent visual indicator.

After: `Footer.test.tsx` verifies that a scheduler size of `2` renders `◎ 2 scheduled tasks`; `CronPill.test.tsx` verifies that a count of `0` renders nothing and a positive count renders the pill text.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Local Node/npm workspace on macOS.

## Risk & Scope

- Main risk or tradeoff: the footer polls the cron scheduler once per second, matching the existing goal footer pill pattern; the scheduler lookup is in-memory and cheap.
- Not validated / out of scope: this does not add `/loop list`, `/loop stop`, session-start banners, model-visible status tools, or persistence changes.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #5823

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 增加了一个紧凑的 footer pill：当 cron scheduling 开启，并且内存中的 cron scheduler 有待执行任务时，会在 footer 中显示当前 active scheduled task 数量。这个 pill 复用现有 footer indicator 区域，显示形式类似 `◎ 2 scheduled tasks`，单个任务时会使用单数文案。

## Why it's needed

#5823 指出 `/loop` cron tasks 设置后可能持续静默运行。这个 PR 只覆盖其中一个小的可见性切片：当 scheduled tasks 处于 active 状态时，用户会在 footer 里看到持续可见的提示；它不改动更大的 `/loop` 生命周期或任务管理命令。

## Reviewer Test Plan

### How to verify

运行聚焦 footer 测试，确认当 `getCronScheduler().size` 返回 `2` 时 footer 包含 `◎ 2 scheduled tasks`，并确认 count 为 `0` 时不显示这个 pill。

本地运行过的命令：

```bash
npx vitest run packages/cli/src/ui/components/CronPill.test.tsx packages/cli/src/ui/components/Footer.test.tsx --coverage=false
npx eslint packages/cli/src/ui/components/CronPill.tsx packages/cli/src/ui/components/CronPill.test.tsx packages/cli/src/ui/components/Footer.tsx packages/cli/src/ui/components/Footer.test.tsx
npx prettier --check packages/cli/src/ui/components/CronPill.tsx packages/cli/src/ui/components/CronPill.test.tsx packages/cli/src/ui/components/Footer.tsx packages/cli/src/ui/components/Footer.test.tsx
git diff --check
npm run typecheck --workspace=packages/cli
npm run build --workspace=packages/cli
```

### Evidence (Before & After)

Before：active cron scheduler entries 不会显示在 footer 中，所以 scheduled `/loop` work 没有持久的视觉提示。

After：`Footer.test.tsx` 验证 scheduler size 为 `2` 时会渲染 `◎ 2 scheduled tasks`；`CronPill.test.tsx` 验证 count 为 `0` 时不渲染内容，正数 count 会渲染 pill 文案。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

macOS 上的本地 Node/npm workspace。

## Risk & Scope

- Main risk or tradeoff：footer 每秒 poll 一次 cron scheduler，和现有 goal footer pill 的模式一致；scheduler lookup 是内存操作，成本很低。
- Not validated / out of scope：这个 PR 不增加 `/loop list`、`/loop stop`、session-start banner、model-visible status tools 或持久化改动。
- Breaking changes / migration notes：无。

## Linked Issues

Refs #5823

## AI Assistance Disclosure

我使用 Codex 审查变更、对照现有模式做 sanity check，并帮助发现潜在边界情况。

</details>
