### PR TITLE
fix(core): preserve rewind parents after resume

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -6256,9 +6256,11 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
   let lastSessionMock:
     | {
         getId: ReturnType<typeof vi.fn>;
+        getConfig: ReturnType<typeof vi.fn>;
         sendAvailableCommandsUpdate: ReturnType<typeof vi.fn>;
         replayHistory: ReturnType<typeof vi.fn>;
         installRewriter: ReturnType<typeof vi.fn>;
+        startCronScheduler: ReturnType<typeof vi.fn>;
         dispose: ReturnType<typeof vi.fn>;
       }
     | undefined;
@@ -6320,6 +6322,9 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
       resumedConversation?: { messages: unknown[] };
     } = {},
   ) {
+    const recording = {
+      rebuildTurnBoundaries: vi.fn(),
+    };
     return {
       initialize: vi.fn().mockResolvedValue(undefined),
       waitForMcpReady: vi.fn().mockResolvedValue(undefined),
@@ -6345,6 +6350,7 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
       getHookSystem: vi.fn().mockReturnValue(undefined),
       getDisableAllHooks: vi.fn().mockReturnValue(true),
       hasHooksForEvent: vi.fn().mockReturnValue(false),
+      getChatRecordingService: vi.fn().mockReturnValue(recording),
       // load path reads back the persisted conversation here and feeds
       // it to `session.replayHistory`. resume path doesn't read this.
       getResumedSessionData: vi
@@ -6433,10 +6439,11 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
   });
 
   it('loadSession returns LoadSessionResponse and replays history on the session', async () => {
+    const messages = [{ role: 'user', parts: [{ text: 'hi' }] }];
     bindRestoreMocks({
       sessionExists: true,
       resumedConversation: {
-        messages: [{ role: 'user', parts: [{ text: 'hi' }] }],
+        messages,
       },
     });
     const { agent, agentPromise } = await spawnAgent();
@@ -6454,9 +6461,10 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
     });
     // load semantic: history MUST be replayed so SSE subscribers see
     // the persisted turns.
-    expect(lastSessionMock?.replayHistory).toHaveBeenCalledWith([
-      { role: 'user', parts: [{ text: 'hi' }] },
-    ]);
+    expect(lastSessionMock?.replayHistory).toHaveBeenCalledWith(messages);
+
+    const recording = lastSessionMock?.getConfig().getChatRecordingService();
+    expect(recording?.rebuildTurnBoundaries).toHaveBeenCalledWith(messages);
 
     mockConnectionState.resolve();
     await agentPromise;
@@ -6539,10 +6547,11 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
   });
 
   it('unstable_resumeSession returns the response without replaying history', async () => {
+    const messages = [{ role: 'user', parts: [{ text: 'hi' }] }];
     bindRestoreMocks({
       sessionExists: true,
       resumedConversation: {
-        messages: [{ role: 'user', parts: [{ text: 'hi' }] }],
+        messages,
       },
     });
     const { agent, agentPromise } = await spawnAgent();
@@ -6562,6 +6571,8 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
     // the SSE stream stays clean for clients that already have the
     // history rendered.
     expect(lastSessionMock?.replayHistory).not.toHaveBeenCalled();
+    const recording = lastSessionMock?.getConfig().getChatRecordingService();
+    expect(recording?.rebuildTurnBoundaries).toHaveBeenCalledWith(messages);
 
     mockConnectionState.resolve();
     await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -7318,6 +7318,12 @@ class QwenAgent implements Agent {
         .restoreFromSnapshots(sessionData.fileHistorySnapshots);
     }
 
+    if (sessionData?.conversation.messages) {
+      config
+        .getChatRecordingService()
+        ?.rebuildTurnBoundaries(sessionData.conversation.messages);
+    }
+
     if (options.replayHistory !== false && sessionData?.conversation.messages) {
       await session.replayHistory(sessionData.conversation.messages);
     }

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -169,6 +169,47 @@ describe('ChatRecordingService', () => {
     });
   });
 
+  describe('rewindRecording', () => {
+    it('preserves a resumed user turn parent when rebuilding rewind boundaries', async () => {
+      vi.mocked(mockConfig.getResumedSessionData).mockReturnValue({
+        lastCompletedUuid: 'assistant-1',
+      } as unknown as ReturnType<Config['getResumedSessionData']>);
+      chatRecordingService = new ChatRecordingService(mockConfig);
+
+      chatRecordingService.rebuildTurnBoundaries([
+        {
+          uuid: 'user-1',
+          parentUuid: 'pre-resume-parent',
+          sessionId: 'test-session-id',
+          timestamp: '2026-06-27T00:00:00.000Z',
+          type: 'user',
+          cwd: '/test/project/root',
+          version: '1.0.0',
+          message: { role: 'user', parts: [{ text: 'first resumed turn' }] },
+        },
+        {
+          uuid: 'assistant-1',
+          parentUuid: 'user-1',
+          sessionId: 'test-session-id',
+          timestamp: '2026-06-27T00:00:01.000Z',
+          type: 'assistant',
+          cwd: '/test/project/root',
+          version: '1.0.0',
+          message: { role: 'model', parts: [{ text: 'response' }] },
+          model: 'gemini-pro',
+        },
+      ]);
+
+      chatRecordingService.rewindRecording(0, { truncatedCount: 2 });
+      await chatRecordingService.flush();
+
+      expect(jsonl.writeLine).toHaveBeenCalledTimes(1);
+      const rewind = vi.mocked(jsonl.writeLine).mock.calls[0][1] as ChatRecord;
+      expect(rewind.subtype).toBe('rewind');
+      expect(rewind.parentUuid).toBe('pre-resume-parent');
+    });
+  });
+
   describe('recordAtCommand', () => {
     it('should record @-command metadata as a system payload', async () => {
       const userParts: Part[] = [{ text: 'Hello, world!' }];

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -1230,10 +1230,6 @@ export class ChatRecordingService {
    */
   rebuildTurnBoundaries(messages: ChatRecord[]): void {
     this.turnParentUuids = [];
-    let prevUuid: string | null =
-      this.config.getResumedSessionData()?.lastCompletedUuid !== undefined
-        ? null
-        : this.lastRecordUuid;
 
     for (let i = 0; i < messages.length; i++) {
       const record = messages[i];
@@ -1243,9 +1239,10 @@ export class ChatRecordingService {
         record.subtype !== 'cron' &&
         record.subtype !== 'mid_turn_user_message'
       ) {
-        this.turnParentUuids.push(prevUuid);
+        // Reconstructed histories can start mid-chain; the persisted edge is
+        // the source of truth, not the previous item in this sliced list.
+        this.turnParentUuids.push(record.parentUuid ?? null);
       }
-      prevUuid = record.uuid;
     }
     // Ensure lastRecordUuid points to the end of the reconstructed chain.
     if (messages.length > 0) {


### PR DESCRIPTION
## What this PR does

Preserves persisted parent UUID edges when rebuilding rewind turn boundaries after a session resume. The CLI resume path already rebuilt those boundaries; this PR makes that rebuild use each resumed record's stored `parentUuid` instead of inferring from the adjacent item in the reconstructed list, and applies the same rebuild step to ACP session resume paths used by VS Code and daemon clients.

## Why it's needed

Issue #5920 reports resumed session history disappearing after an automatic rewind/edit flow. The recorder stores a tree of records, and the rewind marker must be attached to the record that was the parent of the target user turn. If the boundary is rebuilt as `null`, the next resume can stop walking the parent chain too early and drop earlier conversation history.

## Reviewer Test Plan

### How to verify

Run the focused tests and confirm that resumed rewind boundaries preserve the stored parent edge, and that both ACP resume entry points rebuild recorder boundaries from resumed conversation records.

Commands run locally:

```bash
npx vitest run packages/core/src/services/chatRecordingService.test.ts packages/cli/src/acp-integration/acpAgent.test.ts --coverage=false
npx eslint packages/core/src/services/chatRecordingService.ts packages/core/src/services/chatRecordingService.test.ts packages/cli/src/acp-integration/acpAgent.ts packages/cli/src/acp-integration/acpAgent.test.ts
npx prettier --check packages/core/src/services/chatRecordingService.ts packages/core/src/services/chatRecordingService.test.ts packages/cli/src/acp-integration/acpAgent.ts packages/cli/src/acp-integration/acpAgent.test.ts
git diff --check
npm run typecheck --workspace=packages/core
npm run build --workspace=packages/core
npm run build --workspace=packages/cli
npm run typecheck --workspace=packages/cli
```

### Evidence (Before & After)

Before: `rebuildTurnBoundaries()` inferred the first resumed user turn boundary from local list traversal, so a sliced reconstructed history could lose the persisted parent edge and a later rewind marker could be written with the wrong `parentUuid`.

After: `chatRecordingService.test.ts` verifies that a resumed user turn with a stored parent writes the rewind marker under that same parent. `acpAgent.test.ts` verifies that both `loadSession` and `unstable_resumeSession` rebuild recorder boundaries from resumed conversation records.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Local Node/npm workspace on macOS.

## Risk & Scope

- Main risk or tradeoff: this changes how rewind boundaries are rebuilt after resume, but uses the persisted tree edge already stored on each `ChatRecord` instead of deriving a new edge from list position.
- Not validated / out of scope: this does not change compression-aware rewind mapping or the broader `/rewind` UI/API model handled by #4242.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #5920

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 在 session resume 后重建 rewind turn boundaries 时保留持久化记录里的 parent UUID 边。CLI resume 路径之前已经会重建这些 boundaries；这个 PR 让重建逻辑使用每条 resumed record 自己保存的 `parentUuid`，而不是从 reconstructed list 中相邻元素推断，并且把同样的重建步骤应用到 VS Code 和 daemon clients 使用的 ACP session resume 路径。

## Why it's needed

#5920 报告了恢复会话后，自动 rewind/edit 流程导致历史消失的问题。recorder 存的是一棵 record tree，rewind marker 必须挂到目标 user turn 原本的 parent record 下。如果 boundary 被重建成 `null`，下一次 resume 沿 parent chain 回溯时可能过早停止，并丢失更早的对话历史。

## Reviewer Test Plan

### How to verify

运行聚焦测试，确认 resumed rewind boundaries 会保留存储的 parent edge，并确认两个 ACP resume 入口都会从 resumed conversation records 重建 recorder boundaries。

本地运行过的命令：

```bash
npx vitest run packages/core/src/services/chatRecordingService.test.ts packages/cli/src/acp-integration/acpAgent.test.ts --coverage=false
npx eslint packages/core/src/services/chatRecordingService.ts packages/core/src/services/chatRecordingService.test.ts packages/cli/src/acp-integration/acpAgent.ts packages/cli/src/acp-integration/acpAgent.test.ts
npx prettier --check packages/core/src/services/chatRecordingService.ts packages/core/src/services/chatRecordingService.test.ts packages/cli/src/acp-integration/acpAgent.ts packages/cli/src/acp-integration/acpAgent.test.ts
git diff --check
npm run typecheck --workspace=packages/core
npm run build --workspace=packages/core
npm run build --workspace=packages/cli
npm run typecheck --workspace=packages/cli
```

### Evidence (Before & After)

Before：`rebuildTurnBoundaries()` 会根据本地列表遍历推断第一个 resumed user turn 的 boundary；如果 reconstructed history 是一个被裁剪过的链，就可能丢失持久化的 parent edge，导致后续 rewind marker 写入错误的 `parentUuid`。

After：`chatRecordingService.test.ts` 验证带有已存储 parent 的 resumed user turn 会把 rewind marker 写到同一个 parent 下。`acpAgent.test.ts` 验证 `loadSession` 和 `unstable_resumeSession` 都会从 resumed conversation records 重建 recorder boundaries。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

macOS 上的本地 Node/npm workspace。

## Risk & Scope

- Main risk or tradeoff：这个 PR 改变了 resume 后 rewind boundaries 的重建方式，但它使用的是每条 `ChatRecord` 已经持久化保存的 tree edge，而不是根据列表位置重新推导 edge。
- Not validated / out of scope：这个 PR 不改 compression-aware rewind mapping，也不处理 #4242 覆盖的更大 `/rewind` UI/API 模型。
- Breaking changes / migration notes：无。

## Linked Issues

Fixes #5920

## AI Assistance Disclosure

我使用 Codex 审查变更、对照现有模式做 sanity check，并帮助发现潜在边界情况。

</details>
