### PR TITLE
fix(core): stop computer use driver when idle

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1953,6 +1953,7 @@ export async function loadCliConfig(
     computerUseEnabled: settings.tools?.computerUse?.enabled ?? true,
     computerUseMaxImageDimension:
       settings.tools?.computerUse?.maxImageDimension,
+    computerUseIdleTimeoutMs: settings.tools?.computerUse?.idleTimeoutMs,
     emitToolUseSummaries: settings.experimental?.emitToolUseSummaries ?? true,
     listExtensions: argv.listExtensions || false,
     locale: resolveLocaleForExtensions(settings),

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -88,6 +88,8 @@ export interface SettingDefinition {
   items?: SettingItemDefinition;
   /** Minimum value for number-type settings. */
   minimum?: number;
+  /** Maximum value for number-type settings. */
+  maximum?: number;
   /**
    * Primitive shapes a field accepted before it was expanded to its current
    * type. The exported JSON Schema wraps the field in `anyOf` so values from
@@ -2235,8 +2237,20 @@ const SETTINGS_SCHEMA = {
             requiresRestart: true,
             default: true,
             description:
-              'When enabled (default), the cua-driver computer_use__* tools are registered as deferred built-ins.',
+              'When enabled (default), the cua-driver computer_use__* tools are registered as deferred built-ins. Set to false to prevent the driver from being downloaded or spawned.',
             showInDialog: true,
+          },
+          idleTimeoutMs: {
+            type: 'number',
+            label: 'Idle Timeout',
+            category: 'Tools',
+            requiresRestart: true,
+            default: 300000,
+            minimum: 0,
+            maximum: 2147483647,
+            description:
+              'Milliseconds to keep the cua-driver process alive after the last computer_use__* call. The default is 300000 (5 minutes). Set to 0 to keep it running until qwen-code exits.',
+            showInDialog: false,
           },
           maxImageDimension: {
             type: 'number',

--- a/packages/cli/src/utils/settingsUtils.test.ts
+++ b/packages/cli/src/utils/settingsUtils.test.ts
@@ -90,6 +90,16 @@ describe('SettingsUtils', () => {
         description: 'A number field with a minimum.',
         showInDialog: true,
       },
+      numberWithMaximum: {
+        type: 'number',
+        label: 'Number With Maximum',
+        category: 'Basic',
+        requiresRestart: false,
+        default: 10,
+        maximum: 10,
+        description: 'A number field with a maximum.',
+        showInDialog: true,
+      },
       advanced: {
         type: 'object',
         label: 'Advanced',
@@ -237,6 +247,15 @@ describe('SettingsUtils', () => {
 
         expect(validateSettingValue(definition!, -1)).toBe(
           'Value must be >= 0',
+        );
+      });
+
+      it('rejects numbers above the configured maximum', () => {
+        const definition = getSettingDefinition('numberWithMaximum');
+        expect(definition).toBeDefined();
+
+        expect(validateSettingValue(definition!, 11)).toBe(
+          'Value must be <= 10',
         );
       });
     });

--- a/packages/cli/src/utils/settingsUtils.ts
+++ b/packages/cli/src/utils/settingsUtils.ts
@@ -324,6 +324,8 @@ export function validateSettingValue(
         return 'Value must be a finite number';
       if (def.minimum !== undefined && value < def.minimum)
         return `Value must be >= ${def.minimum}`;
+      if (def.maximum !== undefined && value > def.maximum)
+        return `Value must be <= ${def.maximum}`;
       break;
     case 'string':
       if (typeof value !== 'string') return 'Value must be a string';

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -4676,6 +4676,28 @@ describe('disabledTools runtime sync (#4282 fold-in 5 P2-2 / #4297 fold-in 5)', 
   });
 });
 
+describe('computer use settings', () => {
+  const baseParams: ConfigParameters = {
+    targetDir: '.',
+    debugMode: false,
+    model: 'test-model',
+    cwd: '.',
+  };
+
+  it('exposes the configured idle timeout', () => {
+    const config = new Config({
+      ...baseParams,
+      computerUseIdleTimeoutMs: 12_345,
+    });
+    expect(config.getComputerUseIdleTimeoutMs()).toBe(12_345);
+  });
+
+  it('leaves the idle timeout undefined when not configured', () => {
+    const config = new Config(baseParams);
+    expect(config.getComputerUseIdleTimeoutMs()).toBeUndefined();
+  });
+});
+
 describe('BaseLlmClient Lifecycle', () => {
   const MODEL = 'gemini-pro';
   const SANDBOX: SandboxConfig = {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -879,6 +879,7 @@ export interface ConfigParameters {
   skipWorkflowUsageWarning?: boolean;
   computerUseEnabled?: boolean;
   computerUseMaxImageDimension?: number;
+  computerUseIdleTimeoutMs?: number;
   emitToolUseSummaries?: boolean;
   listExtensions?: boolean;
   overrideExtensions?: string[];
@@ -1386,6 +1387,7 @@ export class Config {
   private readonly skipWorkflowUsageWarning: boolean = false;
   private readonly computerUseEnabled: boolean = true;
   private readonly computerUseMaxImageDimension?: number;
+  private readonly computerUseIdleTimeoutMs?: number;
   private readonly emitToolUseSummaries: boolean = true;
   private readonly chatRecordingEnabled: boolean;
   private readonly loadMemoryFromIncludeDirectories: boolean = false;
@@ -1604,6 +1606,7 @@ export class Config {
     this.skipWorkflowUsageWarning = params.skipWorkflowUsageWarning ?? false;
     this.computerUseEnabled = params.computerUseEnabled ?? true;
     this.computerUseMaxImageDimension = params.computerUseMaxImageDimension;
+    this.computerUseIdleTimeoutMs = params.computerUseIdleTimeoutMs;
     this.emitToolUseSummaries = params.emitToolUseSummaries ?? true;
     this.listExtensions = params.listExtensions ?? false;
     this.overrideExtensions = params.overrideExtensions;
@@ -4447,6 +4450,10 @@ export class Config {
    */
   getComputerUseMaxImageDimension(): number | undefined {
     return this.computerUseMaxImageDimension;
+  }
+
+  getComputerUseIdleTimeoutMs(): number | undefined {
+    return this.computerUseIdleTimeoutMs;
   }
 
   /**

--- a/packages/core/src/tools/computer-use/client.test.ts
+++ b/packages/core/src/tools/computer-use/client.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect, vi } from 'vitest';
-import { ComputerUseClient, isTransportClosedError } from './client.js';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import {
+  ComputerUseClient,
+  DEFAULT_COMPUTER_USE_IDLE_TIMEOUT_MS,
+  isTransportClosedError,
+  MAX_COMPUTER_USE_IDLE_TIMEOUT_MS,
+} from './client.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 describe('ComputerUseClient', () => {
@@ -97,6 +102,201 @@ describe('applyRuntimeConfig (set_config on connect)', () => {
     expect(progress).toHaveBeenCalledWith(
       expect.stringContaining('max_image_dimension=800'),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Idle shutdown
+// ---------------------------------------------------------------------------
+
+describe('idle shutdown', () => {
+  type FakeInner = {
+    callTool: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+  };
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const installInner = (c: ComputerUseClient, inner: FakeInner): void => {
+    (c as unknown as { client: FakeInner }).client = inner;
+  };
+
+  const makeInner = (): FakeInner => ({
+    callTool: vi.fn().mockResolvedValue(successResult),
+    close: vi.fn().mockResolvedValue(undefined),
+  });
+
+  it('defaults to a 5 minute idle timeout', async () => {
+    vi.useFakeTimers();
+    const c = new ComputerUseClient({ binary: '/fake/cua-driver' });
+    const inner = makeInner();
+    installInner(c, inner);
+
+    await c.callTool('list_windows', {});
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_COMPUTER_USE_IDLE_TIMEOUT_MS - 1);
+    expect(inner.close).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(inner.close).toHaveBeenCalledTimes(1);
+    expect(c.isStarted()).toBe(false);
+  });
+
+  it('treats negative idle timeouts as invalid and falls back to the default', async () => {
+    vi.useFakeTimers();
+    const c = new ComputerUseClient({
+      binary: '/fake/cua-driver',
+      idleTimeoutMs: -1,
+    });
+    const inner = makeInner();
+    installInner(c, inner);
+
+    await c.callTool('list_windows', {});
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_COMPUTER_USE_IDLE_TIMEOUT_MS - 1);
+    expect(inner.close).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(inner.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the configured idle timeout after the last tool call', async () => {
+    vi.useFakeTimers();
+    const c = new ComputerUseClient({
+      binary: '/fake/cua-driver',
+      idleTimeoutMs: 25,
+    });
+    const inner = makeInner();
+    installInner(c, inner);
+
+    await c.callTool('get_app_state', {});
+
+    await vi.advanceTimersByTimeAsync(24);
+    expect(inner.close).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(inner.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not stop while another tool call is still active', async () => {
+    vi.useFakeTimers();
+    let releaseFirst!: (result: CallToolResult) => void;
+    const c = new ComputerUseClient({
+      binary: '/fake/cua-driver',
+      idleTimeoutMs: 25,
+    });
+    const inner: FakeInner = {
+      callTool: vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise<CallToolResult>((resolve) => {
+              releaseFirst = resolve;
+            }),
+        )
+        .mockResolvedValueOnce(successResult),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    installInner(c, inner);
+
+    const first = c.callTool('get_window_state', {});
+    await Promise.resolve();
+    const second = c.callTool('click', {});
+    await second;
+
+    await vi.advanceTimersByTimeAsync(25);
+    expect(inner.close).not.toHaveBeenCalled();
+
+    releaseFirst(successResult);
+    await first;
+    await vi.advanceTimersByTimeAsync(25);
+    expect(inner.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables idle shutdown when configured as 0', async () => {
+    vi.useFakeTimers();
+    const c = new ComputerUseClient({
+      binary: '/fake/cua-driver',
+      idleTimeoutMs: 0,
+    });
+    const inner = makeInner();
+    installInner(c, inner);
+
+    await c.callTool('list_windows', {});
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+
+    expect(inner.close).not.toHaveBeenCalled();
+    expect(c.isStarted()).toBe(true);
+  });
+
+  it('reschedules the idle timer when setIdleTimeoutMs is called while pending', async () => {
+    vi.useFakeTimers();
+    const c = new ComputerUseClient({
+      binary: '/fake/cua-driver',
+      idleTimeoutMs: 25,
+    });
+    const inner = makeInner();
+    installInner(c, inner);
+
+    await c.callTool('list_windows', {});
+    await vi.advanceTimersByTimeAsync(20);
+    c.setIdleTimeoutMs(100);
+    await vi.advanceTimersByTimeAsync(5);
+    expect(inner.close).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(95);
+    expect(inner.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels the pending idle timer when stop() is called explicitly', async () => {
+    vi.useFakeTimers();
+    const c = new ComputerUseClient({
+      binary: '/fake/cua-driver',
+      idleTimeoutMs: 25,
+    });
+    const inner = makeInner();
+    installInner(c, inner);
+
+    await c.callTool('list_windows', {});
+    await c.stop();
+    expect(inner.close).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(inner.close).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([NaN, Infinity, -Infinity])(
+    'treats %p as invalid and falls back to the default',
+    async (value) => {
+      vi.useFakeTimers();
+      const c = new ComputerUseClient({
+        binary: '/fake/cua-driver',
+        idleTimeoutMs: value,
+      });
+      const inner = makeInner();
+      installInner(c, inner);
+
+      await c.callTool('list_windows', {});
+      await vi.advanceTimersByTimeAsync(
+        DEFAULT_COMPUTER_USE_IDLE_TIMEOUT_MS - 1,
+      );
+      expect(inner.close).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(inner.close).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('treats idle timeouts above the setTimeout safe range as invalid', async () => {
+    vi.useFakeTimers();
+    const c = new ComputerUseClient({
+      binary: '/fake/cua-driver',
+      idleTimeoutMs: MAX_COMPUTER_USE_IDLE_TIMEOUT_MS + 1,
+    });
+    const inner = makeInner();
+    installInner(c, inner);
+
+    await c.callTool('list_windows', {});
+    await vi.advanceTimersByTimeAsync(DEFAULT_COMPUTER_USE_IDLE_TIMEOUT_MS - 1);
+    expect(inner.close).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(inner.close).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/core/src/tools/computer-use/client.ts
+++ b/packages/core/src/tools/computer-use/client.ts
@@ -13,6 +13,9 @@ import type {
 import { homedir } from 'node:os';
 import { binaryPath } from './constants.js';
 
+export const DEFAULT_COMPUTER_USE_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+export const MAX_COMPUTER_USE_IDLE_TIMEOUT_MS = 2_147_483_647;
+
 /**
  * Singleton stdio MCP client for the cua-driver binary.
  *
@@ -21,11 +24,11 @@ import { binaryPath } from './constants.js';
  * downloads + verifies it before the first spawn). Spawns are sub-second
  * — there is no npx/download cost on this path anymore.
  *
- * Lifecycle: lazy spawn on first `callTool` invocation. The process
- * stays alive until `stop()` or qwen-code exits. State (element_index
- * map per window) lives in the process — if the process restarts, the
- * model must call `get_window_state` again before any element-targeted
- * action.
+ * Lifecycle: lazy spawn on first `callTool` invocation. The process is
+ * stopped by `stop()`, qwen-code exit, or the idle timeout after the last
+ * tool call. State (element_index map per window) lives in the process — if
+ * the process restarts, the model must call `get_window_state` again before
+ * any element-targeted action.
  */
 export interface ComputerUseClientOptions {
   /** Absolute path to the spawnable `cua-driver` binary. */
@@ -38,6 +41,11 @@ export interface ComputerUseClientOptions {
    * (1568) untouched; `0` disables resizing. See {@link resolveMaxImageDimension}.
    */
   maxImageDimension?: number;
+  /**
+   * How long an idle cua-driver client stays alive after the last tool call.
+   * `0` disables automatic idle shutdown.
+   */
+  idleTimeoutMs?: number;
 }
 
 export class ComputerUseClient {
@@ -46,13 +54,17 @@ export class ComputerUseClient {
   private readonly binary: string;
   private readonly onProgress: (message: string) => void;
   private maxImageDimension: number | undefined;
+  private idleTimeoutMs: number;
   private client: Client | undefined;
   private startPromise: Promise<void> | undefined;
+  private activeCalls = 0;
+  private idleStopTimer: ReturnType<typeof setTimeout> | undefined;
 
   constructor(options: ComputerUseClientOptions) {
     this.binary = options.binary;
     this.onProgress = options.onProgress ?? (() => {});
     this.maxImageDimension = options.maxImageDimension;
+    this.idleTimeoutMs = normalizeIdleTimeoutMs(options.idleTimeoutMs);
   }
 
   /**
@@ -63,6 +75,11 @@ export class ComputerUseClient {
    */
   setMaxImageDimension(value: number | undefined): void {
     this.maxImageDimension = value;
+  }
+
+  setIdleTimeoutMs(value: number | undefined): void {
+    this.idleTimeoutMs = normalizeIdleTimeoutMs(value);
+    this.scheduleIdleStop();
   }
 
   /**
@@ -104,12 +121,20 @@ export class ComputerUseClient {
    * responsible for mapping the throw into user-facing UX.
    */
   async start(onProgress?: (message: string) => void): Promise<void> {
-    if (this.client) return;
+    this.clearIdleStopTimer();
+    if (this.client) {
+      this.scheduleIdleStop();
+      return;
+    }
     if (this.startPromise) return this.startPromise;
 
-    this.startPromise = this.doStart(onProgress).finally(() => {
-      this.startPromise = undefined;
-    });
+    this.startPromise = this.doStart(onProgress)
+      .then(() => {
+        this.scheduleIdleStop();
+      })
+      .finally(() => {
+        this.startPromise = undefined;
+      });
     return this.startPromise;
   }
 
@@ -178,58 +203,67 @@ export class ComputerUseClient {
    *
    * On transport-closed errors (e.g. macOS kills the upstream binary after
    * the user grants Screen Recording permission), this method transparently
-   * tears down the stale connection, reconnects, and retries the call once.
-   * If the retry also fails, the error is re-thrown without further
-   * reconnect attempts.
+   * tears down the stale connection, reconnects, and retries with a bounded
+   * backoff loop. If the retries also fail, the last error is re-thrown.
    */
   async callTool(
     name: string,
     args: Record<string, unknown>,
   ): Promise<CallToolResult> {
     if (!this.client) throw new Error('ComputerUseClient not started');
+    this.activeCalls++;
+    this.clearIdleStopTimer();
     try {
-      return (await this.client.callTool({
-        name,
-        arguments: args,
-      })) as CallToolResult;
-    } catch (err) {
-      if (!isTransportClosedError(err)) throw err;
-      // The connection died. Two recoverable causes, both fixed by respawning
-      // the proxy (which relaunches the cua-driver daemon):
-      //   1. stdio "Connection closed" — the `cua-driver mcp` child was killed.
-      //   2. "daemon transport error … Connection refused" — the CuaDriver
-      //      DAEMON behind the proxy restarted. macOS forces a restart right
-      //      after the Screen Recording grant, so the proxy's Unix socket to
-      //      the daemon goes dead and every subsequent tool fails. This is the
-      //      first-use failure mode (grant SR → restart → all tools error).
-      //
-      // Respawn + retry, with a few attempts to absorb the daemon's restart /
-      // startup window (a single retry can land before the new daemon is up).
-      // Element-index state is lost across the restart; the model re-snapshots
-      // via get_window_state on a stale-index error.
-      let lastErr: unknown = err;
-      for (let attempt = 0; attempt < 3; attempt++) {
-        await this.stop();
-        await this.start();
-        if (!this.client) throw new Error('ComputerUseClient reconnect failed');
-        try {
-          return (await this.client.callTool({
-            name,
-            arguments: args,
-          })) as CallToolResult;
-        } catch (retryErr) {
-          if (!isTransportClosedError(retryErr)) throw retryErr;
-          lastErr = retryErr;
-          // Daemon may still be coming up after a restart — back off, retry.
-          await new Promise((r) => setTimeout(r, 1000));
+      try {
+        return (await this.client.callTool({
+          name,
+          arguments: args,
+        })) as CallToolResult;
+      } catch (err) {
+        if (!isTransportClosedError(err)) throw err;
+        // The connection died. Two recoverable causes, both fixed by respawning
+        // the proxy (which relaunches the cua-driver daemon):
+        //   1. stdio "Connection closed" — the `cua-driver mcp` child was killed.
+        //   2. "daemon transport error … Connection refused" — the CuaDriver
+        //      DAEMON behind the proxy restarted. macOS forces a restart right
+        //      after the Screen Recording grant, so the proxy's Unix socket to
+        //      the daemon goes dead and every subsequent tool fails. This is the
+        //      first-use failure mode (grant SR → restart → all tools error).
+        //
+        // Respawn + retry, with a few attempts to absorb the daemon's restart /
+        // startup window (a single retry can land before the new daemon is up).
+        // Element-index state is lost across the restart; the model re-snapshots
+        // via get_window_state on a stale-index error.
+        let lastErr: unknown = err;
+        for (let attempt = 0; attempt < 3; attempt++) {
+          await this.stop();
+          await this.start();
+          if (!this.client) {
+            throw new Error('ComputerUseClient reconnect failed');
+          }
+          try {
+            return (await this.client.callTool({
+              name,
+              arguments: args,
+            })) as CallToolResult;
+          } catch (retryErr) {
+            if (!isTransportClosedError(retryErr)) throw retryErr;
+            lastErr = retryErr;
+            // Daemon may still be coming up after a restart — back off, retry.
+            await new Promise((r) => setTimeout(r, 1000));
+          }
         }
+        throw lastErr;
       }
-      throw lastErr;
+    } finally {
+      this.activeCalls--;
+      this.scheduleIdleStop();
     }
   }
 
   /** Tear down the child process. Safe to call multiple times. */
   async stop(): Promise<void> {
+    this.clearIdleStopTimer();
     const client = this.client;
     this.client = undefined;
     if (client) {
@@ -240,6 +274,36 @@ export class ComputerUseClient {
       }
     }
   }
+
+  private scheduleIdleStop(): void {
+    this.clearIdleStopTimer();
+    if (!this.client || this.activeCalls > 0 || this.idleTimeoutMs <= 0) {
+      return;
+    }
+
+    this.idleStopTimer = setTimeout(() => {
+      this.idleStopTimer = undefined;
+      if (this.activeCalls > 0) return;
+      void this.stop();
+    }, this.idleTimeoutMs);
+    this.idleStopTimer.unref?.();
+  }
+
+  private clearIdleStopTimer(): void {
+    if (!this.idleStopTimer) return;
+    clearTimeout(this.idleStopTimer);
+    this.idleStopTimer = undefined;
+  }
+}
+
+function normalizeIdleTimeoutMs(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_COMPUTER_USE_IDLE_TIMEOUT_MS;
+  if (!Number.isFinite(value)) return DEFAULT_COMPUTER_USE_IDLE_TIMEOUT_MS;
+  if (value < 0) return DEFAULT_COMPUTER_USE_IDLE_TIMEOUT_MS;
+  if (value > MAX_COMPUTER_USE_IDLE_TIMEOUT_MS) {
+    return DEFAULT_COMPUTER_USE_IDLE_TIMEOUT_MS;
+  }
+  return value;
 }
 
 /**

--- a/packages/core/src/tools/computer-use/tool.test.ts
+++ b/packages/core/src/tools/computer-use/tool.test.ts
@@ -30,6 +30,7 @@ function makeFakeClient(
     callTool: vi.fn(callToolImpl),
     stop: vi.fn(async () => {}),
     setMaxImageDimension: vi.fn(),
+    setIdleTimeoutMs: vi.fn(),
   };
   return fake as unknown as ComputerUseClient;
 }
@@ -92,6 +93,7 @@ describe('ComputerUseTool', () => {
 
       const config = {
         getComputerUseMaxImageDimension: () => 1280,
+        getComputerUseIdleTimeoutMs: () => 30_000,
       } as unknown as Config;
       const tool = new ComputerUseTool(
         'list_apps',
@@ -101,6 +103,7 @@ describe('ComputerUseTool', () => {
       await tool.build({}).execute(new AbortController().signal);
 
       expect(fake.setMaxImageDimension).toHaveBeenCalledWith(1280);
+      expect(fake.setIdleTimeoutMs).toHaveBeenCalledWith(30_000);
     } finally {
       if (prev === undefined) {
         delete process.env['QWEN_COMPUTER_USE_MAX_IMAGE_DIMENSION'];

--- a/packages/core/src/tools/computer-use/tool.ts
+++ b/packages/core/src/tools/computer-use/tool.ts
@@ -221,6 +221,7 @@ class ComputerUseInvocation extends BaseToolInvocation<
     client.setMaxImageDimension(
       resolveMaxImageDimension(this.config?.getComputerUseMaxImageDimension()),
     );
+    client.setIdleTimeoutMs(this.config?.getComputerUseIdleTimeoutMs());
 
     // If the user confirmed through the pre-execution dialog, the install state
     // was already written by onConfirm — runBootstrap will skip promptInstallApproval.

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -1047,9 +1047,16 @@
           "type": "object",
           "properties": {
             "enabled": {
-              "description": "When enabled (default), the cua-driver computer_use__* tools are registered as deferred built-ins.",
+              "description": "When enabled (default), the cua-driver computer_use__* tools are registered as deferred built-ins. Set to false to prevent the driver from being downloaded or spawned.",
               "type": "boolean",
               "default": true
+            },
+            "idleTimeoutMs": {
+              "description": "Milliseconds to keep the cua-driver process alive after the last computer_use__* call. The default is 300000 (5 minutes). Set to 0 to keep it running until qwen-code exits.",
+              "type": "number",
+              "default": 300000,
+              "minimum": 0,
+              "maximum": 2147483647
             },
             "maxImageDimension": {
               "description": "Longest-edge pixel cap applied to cua-driver screenshots (via set_config's max_image_dimension). -1 (default) keeps cua-driver's built-in default (1568); 0 disables resizing (full resolution); a positive value caps the longest edge. Lower caps cut vision-token cost at the expense of fine detail. Overridable via the QWEN_COMPUTER_USE_MAX_IMAGE_DIMENSION env var.",

--- a/scripts/generate-settings-schema.ts
+++ b/scripts/generate-settings-schema.ts
@@ -39,6 +39,7 @@ interface JsonSchemaProperty {
   enum?: (string | number)[];
   default?: unknown;
   minimum?: number;
+  maximum?: number;
   additionalProperties?: boolean | JsonSchemaProperty;
   required?: string[];
   oneOf?: JsonSchemaProperty[];
@@ -187,6 +188,9 @@ function convertSettingToJsonSchema(
 
   if (setting.type === 'number' && setting.minimum !== undefined) {
     schema.minimum = setting.minimum;
+  }
+  if (setting.type === 'number' && setting.maximum !== undefined) {
+    schema.maximum = setting.maximum;
   }
 
   // If the field accepts a legacy primitive shape (e.g. a boolean that was


### PR DESCRIPTION
## What this PR does

This PR stops the shared Computer Use `cua-driver` client after it has been idle for a configurable timeout. The default timeout is 5 minutes after the last `computer_use__*` call. Users who need the driver to stay alive for the whole qwen-code session can set `tools.computerUse.idleTimeoutMs` to `0`, and users who want to disable Computer Use entirely can continue to set `tools.computerUse.enabled` to `false`.

It also threads the new setting through CLI config, updates the generated VS Code settings schema, and keeps the existing screenshot dimension runtime config behavior unchanged.

## Why it's needed

`cua-driver.exe` can keep running as a persistent child process after a Computer Use task has finished. On Windows, issue #5922 reports that the process continues consuming CPU while qwen-code is otherwise idle. Since every `computer_use__*` tool call goes through the shared `ComputerUseClient`, the lifecycle fix belongs there instead of in each individual tool wrapper.

## Reviewer Test Plan

### How to verify

Reviewers can verify that `ComputerUseClient` schedules an idle stop after the last tool call, does not stop while another call is still active, treats `0` as disabling idle shutdown, and treats negative timeout values as invalid by falling back to the default 5 minute timeout. Also verify that `ComputerUseTool.execute()` forwards `tools.computerUse.idleTimeoutMs` to the shared client and that the generated settings schema includes the new setting.

Commands run locally:

- `npx vitest run packages/core/src/tools/computer-use/tool.test.ts packages/core/src/tools/computer-use/client.test.ts packages/core/src/config/config.test.ts --coverage=false`
- `npx vitest run packages/cli/src/config/settingsSchema.test.ts --coverage=false`
- `npm run generate:settings-schema`
- `npx eslint packages/core/src/tools/computer-use/client.ts packages/core/src/tools/computer-use/client.test.ts packages/core/src/tools/computer-use/tool.ts packages/core/src/tools/computer-use/tool.test.ts packages/core/src/config/config.ts packages/core/src/config/config.test.ts packages/cli/src/config/config.ts packages/cli/src/config/settingsSchema.ts`
- `npx prettier --check packages/core/src/tools/computer-use/client.ts packages/core/src/tools/computer-use/client.test.ts packages/core/src/tools/computer-use/tool.ts packages/core/src/tools/computer-use/tool.test.ts packages/core/src/config/config.ts packages/core/src/config/config.test.ts packages/cli/src/config/config.ts packages/cli/src/config/settingsSchema.ts packages/vscode-ide-companion/schemas/settings.schema.json`
- `git diff --check`
- `npm run typecheck --workspace=packages/core`
- `npm run build --workspace=packages/core`
- `npm run build --workspace=packages/cli`
- `npm run typecheck --workspace=packages/cli`

### Evidence (Before & After)

Before: once started, the shared Computer Use client only stopped on explicit `stop()` / reconnect / qwen-code process exit, so the driver could remain alive for the full session even after the last `computer_use__*` call.

After: unit tests cover the default 5 minute idle stop, custom timeout, no stop while a concurrent call is still active, `0` disabling idle shutdown, and negative values falling back to the default. `tool.test.ts` also verifies that the configured timeout is forwarded through the tool wrapper.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS development environment with Node/npm from this checkout. I did not run a real Windows `cua-driver.exe`; the process lifecycle is covered with fake-timer unit tests around the shared client.

## Risk & Scope

- Main risk or tradeoff: stopping the driver after an idle timeout clears cua-driver's in-process element/window state, so a later action may need a fresh `get_window_state`. This already happens after reconnects and process exits; users can set `tools.computerUse.idleTimeoutMs` to `0` if they prefer the old long-lived behavior.
- Not validated / out of scope: real Windows Task Manager CPU verification and upstream `cua-driver-rs` idle polling changes.
- Breaking changes / migration notes: no config migration required. Default behavior now stops the Computer Use driver after 5 minutes of Computer Use inactivity.

## Linked Issues

Fixes #5922

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 会在共享的 Computer Use `cua-driver` client 空闲达到可配置超时时间后自动停止它。默认超时时间是最后一次 `computer_use__*` 调用后的 5 分钟。需要让驱动在整个 qwen-code 会话中保持运行的用户可以把 `tools.computerUse.idleTimeoutMs` 设为 `0`；想完全禁用 Computer Use 的用户仍然可以把 `tools.computerUse.enabled` 设为 `false`。

同时，这个 PR 也把新设置接入 CLI config，更新生成的 VS Code settings schema，并保持现有截图尺寸运行时配置行为不变。

## Why it's needed

`cua-driver.exe` 在 Computer Use 任务结束后仍可能作为持久子进程继续运行。#5922 在 Windows 上报告了 qwen-code 已经空闲时该进程仍持续消耗 CPU。由于所有 `computer_use__*` 工具调用都会经过共享的 `ComputerUseClient`，生命周期修复应该放在这里，而不是分散到每个工具 wrapper。

## Reviewer Test Plan

### How to verify

Reviewer 可以确认 `ComputerUseClient` 会在最后一次工具调用后安排 idle stop，不会在还有另一个调用进行中时停止，`0` 会禁用 idle shutdown，负数超时值会被视为无效并回退到默认 5 分钟。同时确认 `ComputerUseTool.execute()` 会把 `tools.computerUse.idleTimeoutMs` 传给共享 client，生成的 settings schema 也包含这个新设置。

本地运行过的命令：

- `npx vitest run packages/core/src/tools/computer-use/tool.test.ts packages/core/src/tools/computer-use/client.test.ts packages/core/src/config/config.test.ts --coverage=false`
- `npx vitest run packages/cli/src/config/settingsSchema.test.ts --coverage=false`
- `npm run generate:settings-schema`
- `npx eslint packages/core/src/tools/computer-use/client.ts packages/core/src/tools/computer-use/client.test.ts packages/core/src/tools/computer-use/tool.ts packages/core/src/tools/computer-use/tool.test.ts packages/core/src/config/config.ts packages/core/src/config/config.test.ts packages/cli/src/config/config.ts packages/cli/src/config/settingsSchema.ts`
- `npx prettier --check packages/core/src/tools/computer-use/client.ts packages/core/src/tools/computer-use/client.test.ts packages/core/src/tools/computer-use/tool.ts packages/core/src/tools/computer-use/tool.test.ts packages/core/src/config/config.ts packages/core/src/config/config.test.ts packages/cli/src/config/config.ts packages/cli/src/config/settingsSchema.ts packages/vscode-ide-companion/schemas/settings.schema.json`
- `git diff --check`
- `npm run typecheck --workspace=packages/core`
- `npm run build --workspace=packages/core`
- `npm run build --workspace=packages/cli`
- `npm run typecheck --workspace=packages/cli`

### Evidence (Before & After)

Before：共享 Computer Use client 一旦启动，只会在显式 `stop()`、重连或 qwen-code 进程退出时停止，所以最后一次 `computer_use__*` 调用结束后，driver 仍可能在整个会话期间保持运行。

After：单元测试覆盖了默认 5 分钟 idle stop、自定义超时、并发调用仍在进行中时不停止、`0` 禁用 idle shutdown，以及负数值回退默认。`tool.test.ts` 也验证了工具 wrapper 会传递配置的 timeout。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 macOS 开发环境，使用当前 checkout 的 Node/npm。没有运行真实 Windows `cua-driver.exe`；进程生命周期通过共享 client 的 fake-timer 单元测试覆盖。

## Risk & Scope

- 主要风险或取舍：idle timeout 后停止 driver 会清掉 cua-driver 进程内的 element/window 状态，因此后续动作可能需要重新调用 `get_window_state`。这和重连、进程退出后的行为一致；如果用户希望保持旧的长生命周期，可以把 `tools.computerUse.idleTimeoutMs` 设为 `0`。
- 未验证 / 范围外：真实 Windows Task Manager CPU 验证，以及上游 `cua-driver-rs` idle polling 的修改。
- 破坏性变更 / 迁移说明：不需要 config migration。默认行为现在会在 Computer Use 空闲 5 分钟后停止驱动。

## Linked Issues

Fixes #5922

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
