### PR TITLE
fix(core): improve cron tool search intents

### DIFF
--- a/packages/core/src/tools/cron-delete.ts
+++ b/packages/core/src/tools/cron-delete.ts
@@ -82,7 +82,7 @@ export class CronDeleteTool extends BaseDeclarativeTool<
     super(
       CronDeleteTool.Name,
       ToolDisplayNames.CRON_DELETE,
-      'Cancel a cron job previously scheduled with CronCreate, or a pending ' +
+      'Stop or cancel a cron job previously scheduled with CronCreate, or a pending ' +
         'loop wakeup scheduled with LoopWakeup. Removes cron jobs from the ' +
         `in-memory session store or from ${CRON_TASKS_DISPLAY_PATH} ` +
         '(durable jobs).',
@@ -102,7 +102,7 @@ export class CronDeleteTool extends BaseDeclarativeTool<
       false, // canUpdateOutput
       true, // shouldDefer — only needed after CronCreate/CronList
       false, // alwaysLoad
-      'cron delete cancel remove',
+      'cron delete cancel remove stop clear scheduled task loop wakeup',
     );
   }
 

--- a/packages/core/src/tools/cron-list.ts
+++ b/packages/core/src/tools/cron-list.ts
@@ -142,7 +142,7 @@ export class CronListTool extends BaseDeclarativeTool<
       false, // canUpdateOutput
       true, // shouldDefer — low-frequency inspection tool
       false, // alwaysLoad
-      'cron list scheduled jobs',
+      'cron list show active scheduled tasks loop jobs wakeups',
     );
   }
 

--- a/packages/core/src/tools/tool-search.test.ts
+++ b/packages/core/src/tools/tool-search.test.ts
@@ -12,6 +12,10 @@ import { ToolRegistry } from './tool-registry.js';
 import { DiscoveredMCPTool } from './mcp-tool.js';
 import { MockTool } from '../test-utils/mock-tool.js';
 import { ToolSearchTool, scoreTool, tokenize } from './tool-search.js';
+import { CronCreateTool } from './cron-create.js';
+import { CronDeleteTool } from './cron-delete.js';
+import { CronListTool } from './cron-list.js';
+import { LoopWakeupTool } from './loop-wakeup.js';
 
 const baseConfigParams: ConfigParameters = {
   cwd: '/tmp',
@@ -52,6 +56,12 @@ describe('tokenize', () => {
 
   it('filters empty tokens', () => {
     expect(tokenize('   foo    bar  ')).toEqual(['foo', 'bar']);
+  });
+
+  it('drops natural-language filler words and trailing punctuation', () => {
+    expect(tokenize('How do I stop this cron?')).toEqual(['stop', 'cron']);
+    expect(tokenize('please +cron, tasks!')).toEqual(['+cron', 'tasks']);
+    expect(tokenize('C++ C# search')).toEqual(['c++', 'c#', 'search']);
   });
 });
 
@@ -126,6 +136,32 @@ describe('scoreTool', () => {
       description: 'this tool does slack things',
     });
     expect(scoreTool(tool, ['slack'])).toBe(2); // SCORE_DESC_BUILTIN
+  });
+
+  it.each([
+    ['cancel', 'cron_delete'],
+    ['clear', 'cron_delete'],
+    ['delete', 'cron_remove'],
+    ['remove', 'cron_delete'],
+    ['stop', 'cron_delete'],
+  ])('bridges action alias "%s" to %s', (term, toolName) => {
+    const tool = new MockTool({
+      name: toolName,
+      description: 'scheduled task',
+      searchHint: 'cron task',
+    });
+
+    expect(scoreTool(tool, [term])).toBe(16);
+  });
+
+  it('does not add the alias bonus for a direct action-term match', () => {
+    const tool = new MockTool({
+      name: 'cron_stop',
+      description: 'scheduled task',
+      searchHint: 'cron task',
+    });
+
+    expect(scoreTool(tool, ['stop'])).toBe(10);
   });
 
   it('returns 0 when no term matches', () => {
@@ -246,6 +282,76 @@ describe('ToolSearchTool', () => {
     // Unrelated tools should not surface on a 'schedule' query.
     expect(content).not.toContain('"name":"lsp"');
     expect(content).not.toContain('"name":"ask_user_question"');
+  });
+
+  it('finds the cron delete tool for natural-language stop requests', async () => {
+    registry.registerTool(new CronCreateTool(config));
+    registry.registerTool(new CronListTool(config));
+    registry.registerTool(new CronDeleteTool(config));
+    registry.registerTool(new LoopWakeupTool(config));
+
+    const tool = new ToolSearchTool(config);
+    const result = await tool
+      .build({
+        query: 'how do I stop this cron or loop wakeup?',
+        max_results: 1,
+      })
+      .execute(new AbortController().signal);
+
+    const content = String(result.llmContent);
+    expect(content).toContain('"name":"cron_delete"');
+    expect(content).not.toContain('"name":"cron_create"');
+  });
+
+  it('matches required action aliases when filtering candidates', async () => {
+    registry.registerTool(new CronCreateTool(config));
+    registry.registerTool(new CronListTool(config));
+    registry.registerTool(new CronDeleteTool(config));
+    registry.registerTool(new LoopWakeupTool(config));
+
+    const tool = new ToolSearchTool(config);
+    const result = await tool
+      .build({
+        query: '+stop cron',
+        max_results: 1,
+      })
+      .execute(new AbortController().signal);
+
+    const content = String(result.llmContent);
+    expect(content).toContain('"name":"cron_delete"');
+    expect(content).not.toContain('No tools found');
+  });
+
+  it('finds the cron list tool for natural-language task visibility requests', async () => {
+    registry.registerTool(new CronCreateTool(config));
+    registry.registerTool(new CronListTool(config));
+    registry.registerTool(new CronDeleteTool(config));
+    registry.registerTool(new LoopWakeupTool(config));
+
+    const tool = new ToolSearchTool(config);
+    const result = await tool
+      .build({ query: 'show active loop tasks', max_results: 1 })
+      .execute(new AbortController().signal);
+
+    const content = String(result.llmContent);
+    expect(content).toContain('"name":"cron_list"');
+    expect(content).not.toContain('"name":"cron_create"');
+  });
+
+  it('still finds the loop wakeup tool for scheduling loop wakeups', async () => {
+    registry.registerTool(new CronCreateTool(config));
+    registry.registerTool(new CronListTool(config));
+    registry.registerTool(new CronDeleteTool(config));
+    registry.registerTool(new LoopWakeupTool(config));
+
+    const tool = new ToolSearchTool(config);
+    const result = await tool
+      .build({ query: 'schedule loop wakeup', max_results: 1 })
+      .execute(new AbortController().signal);
+
+    const content = String(result.llmContent);
+    expect(content).toContain('"name":"loop_wakeup"');
+    expect(content).not.toContain('"name":"cron_delete"');
   });
 
   it('returns a friendly message when nothing matches', async () => {

--- a/packages/core/src/tools/tool-search.ts
+++ b/packages/core/src/tools/tool-search.ts
@@ -50,6 +50,56 @@ const SCORE_HINT_BUILTIN = 4;
 const SCORE_DESC_BUILTIN = 2;
 const SCORE_NAME_EXACT_MCP = 12;
 const SCORE_NAME_SUBSTR_MCP = 6;
+const SCORE_ACTION_ALIAS_BUILTIN = 6;
+
+const TOOL_SEARCH_STOP_WORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'are',
+  'at',
+  'be',
+  'can',
+  'could',
+  'did',
+  'do',
+  'does',
+  'for',
+  'from',
+  'how',
+  'i',
+  'in',
+  'is',
+  'it',
+  'me',
+  'my',
+  'of',
+  'on',
+  'or',
+  'please',
+  'should',
+  'that',
+  'the',
+  'these',
+  'this',
+  'those',
+  'to',
+  'was',
+  'were',
+  'what',
+  'which',
+  'with',
+  'would',
+  'you',
+]);
+
+const ACTION_TERM_ALIASES = new Map<string, string[]>([
+  ['cancel', ['cancel', 'delete', 'remove', 'stop', 'clear']],
+  ['clear', ['clear', 'delete', 'remove', 'cancel', 'stop']],
+  ['delete', ['delete', 'remove', 'cancel', 'stop', 'clear']],
+  ['remove', ['remove', 'delete', 'cancel', 'stop', 'clear']],
+  ['stop', ['stop', 'cancel', 'delete', 'remove', 'clear']],
+]);
 
 interface ScoredTool {
   tool: AnyDeclarativeTool;
@@ -453,8 +503,23 @@ export function tokenize(query: string): string[] {
   return query
     .toLowerCase()
     .split(/\s+/g)
-    .map((t) => t.trim())
-    .filter((t) => t.length > 0);
+    .map(normalizeSearchTerm)
+    .filter((t): t is string => t !== null);
+}
+
+function normalizeSearchTerm(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const required = trimmed.startsWith('+');
+  const body = required ? trimmed.slice(1) : trimmed;
+  const normalized = body.replace(
+    /^[^\p{L}\p{N}_.+#-]+|[^\p{L}\p{N}_.+#-]+$/gu,
+    '',
+  );
+  if (normalized.length < 2 || TOOL_SEARCH_STOP_WORDS.has(normalized)) {
+    return null;
+  }
+  return required ? `+${normalized}` : normalized;
 }
 
 function clamp(n: number, lo: number, hi: number): number {
@@ -485,7 +550,9 @@ function candidateMatchesRequired(
 ): boolean {
   if (requiredTerms.length === 0) return true;
   const nameLower = tool.name.toLowerCase();
-  return requiredTerms.every((t) => nameLower.includes(t));
+  return requiredTerms.every((t) =>
+    getSearchTermVariants(t).some((variant) => nameLower.includes(variant)),
+  );
 }
 
 /**
@@ -502,22 +569,48 @@ export function scoreTool(tool: AnyDeclarativeTool, terms: string[]): number {
   let total = 0;
   for (const term of terms) {
     if (term.length === 0) continue;
-    if (
-      nameLower === term ||
-      nameLower.endsWith('_' + term) ||
-      nameLower.endsWith('.' + term)
-    ) {
-      total += isMcp ? SCORE_NAME_EXACT_MCP : SCORE_NAME_EXACT_BUILTIN;
-    } else if (nameLower.includes(term)) {
-      total += isMcp ? SCORE_NAME_SUBSTR_MCP : SCORE_NAME_SUBSTR_BUILTIN;
+    const variants = getSearchTermVariants(term);
+    let nameScore = 0;
+    for (const variant of variants) {
+      if (
+        nameLower === variant ||
+        nameLower.endsWith('_' + variant) ||
+        nameLower.endsWith('.' + variant)
+      ) {
+        nameScore = Math.max(
+          nameScore,
+          isMcp ? SCORE_NAME_EXACT_MCP : SCORE_NAME_EXACT_BUILTIN,
+        );
+      } else if (nameLower.includes(variant)) {
+        nameScore = Math.max(
+          nameScore,
+          isMcp ? SCORE_NAME_SUBSTR_MCP : SCORE_NAME_SUBSTR_BUILTIN,
+        );
+      }
     }
+    total += nameScore;
     // Hint matches are per-word, mirroring Claude's "word boundary" rule.
-    if (hintParts.some((p) => p === term)) {
+    if (hintParts.some((p) => variants.includes(p))) {
       total += SCORE_HINT_BUILTIN;
     }
-    if (descLower.includes(term)) {
+    if (variants.some((variant) => descLower.includes(variant))) {
       total += SCORE_DESC_BUILTIN;
+    }
+    if (
+      ACTION_TERM_ALIASES.has(term) &&
+      variants
+        .filter((variant) => variant !== term)
+        .some(
+          (variant) =>
+            nameLower.includes(variant) || hintParts.some((p) => p === variant),
+        )
+    ) {
+      total += SCORE_ACTION_ALIAS_BUILTIN;
     }
   }
   return total;
+}
+
+function getSearchTermVariants(term: string): string[] {
+  return ACTION_TERM_ALIASES.get(term) ?? [term];
 }


### PR DESCRIPTION
## What this PR does

Improves `tool_search` ranking for natural-language scheduled-task management requests. Queries like "how do I stop this cron?" or "stop this loop wakeup" now surface `cron_delete` ahead of creation/scheduling tools, while visibility queries surface `cron_list`.

This keeps the existing cron management implementation intact. The PR only tightens search tokenization/scoring and expands the cron tools' search hints so the model can discover the already-registered management tools from user wording.

## Why it's needed

Issue #5823 reports that users can end up with hidden `/loop` or cron tasks and the model may not know how to list or stop them. Current `main` already has `cron_list` and `cron_delete`, including support for durable jobs and pending loop wakeups, but those tools are deferred behind `tool_search`.

Before this change, a natural stop query could rank `cron_create` or `loop_wakeup` above `cron_delete` because the search scorer treated filler words and action verbs as plain substring matches and did not understand that "stop/cancel/remove/clear" should map to delete-style tools.

## Reviewer Test Plan

### How to verify

Run the focused tool tests:

```sh
npx vitest run packages/core/src/tools/tool-search.test.ts packages/core/src/tools/cron-list.test.ts packages/core/src/tools/cron-delete.test.ts packages/core/src/tools/loop-wakeup.test.ts --coverage=false
```

Run lint, formatting, and whitespace checks for the touched files:

```sh
npx eslint packages/core/src/tools/tool-search.ts packages/core/src/tools/cron-list.ts packages/core/src/tools/cron-delete.ts packages/core/src/tools/tool-search.test.ts
npx prettier --check packages/core/src/tools/tool-search.ts packages/core/src/tools/cron-list.ts packages/core/src/tools/cron-delete.ts packages/core/src/tools/tool-search.test.ts
git diff --check
```

Run the core package checks:

```sh
npm run typecheck --workspace=packages/core
npm run build --workspace=packages/core
```

### Evidence (Before & After)

Before: scoring `how do I stop this cron?` could rank `cron_create` at or above the management tool because filler words and generic description matches polluted the score. With `loop_wakeup` in the real candidate set, `cancel loop wakeup` ranked `loop_wakeup` above `cron_delete`.

After: focused regression tests register the real `cron_create`, `cron_list`, `cron_delete`, and `loop_wakeup` tools together. They assert that stop/cancel requests reveal `cron_delete`, visibility requests reveal `cron_list`, and scheduling requests still reveal `loop_wakeup`. This covers a non-cron deferred-tool competitor (`loop_wakeup`) so the action-alias scoring does not simply bias every loop-related query toward cron deletion. Tokenization tests also verify filler-word removal while preserving non-cron language-like terms such as `C++` and `C#`.

Local validation passed: 72 focused tests, ESLint, Prettier check, `git diff --check`, core typecheck, and core build.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

macOS arm64 (`Darwin 25.5.0`), Node `v26.3.0`, npm `11.16.0`.

## Risk & Scope

- Main risk or tradeoff: `tool_search` tokenization now drops common English filler words and maps cancellation verbs to delete/remove/stop tool terms. This should improve intent ranking, but it can affect deferred-tool search ordering outside cron tools.
- Not validated / out of scope: this does not redesign `/loop`, add a new UI panel, or make slash commands directly callable as tools. The PR only improves discovery of existing deferred tools.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #5823.

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

改进 `tool_search` 对自然语言定时任务管理请求的排序。像 "how do I stop this cron?" 或 "stop this loop wakeup" 这样的查询现在会优先找到 `cron_delete`，而不是创建/调度类工具；查询可见性时会优先找到 `cron_list`。

这个改动不改现有的 cron 管理实现。PR 只收紧搜索分词/评分，并扩展 cron 工具的搜索 hint，让模型能从用户自然表达里发现已经注册的管理工具。

## 为什么需要

#5823 反馈用户可能留下隐藏的 `/loop` 或 cron 任务，而模型不知道如何列出或停止它们。当前 `main` 已经有 `cron_list` 和 `cron_delete`，并且支持 durable jobs 与 pending loop wakeups，但这些工具是 deferred tools，需要通过 `tool_search` 发现。

改动前，自然语言的停止请求可能把 `cron_create` 或 `loop_wakeup` 排在 `cron_delete` 前面，因为搜索评分把填充词和普通描述 substring 都当成信号，也不理解 "stop/cancel/remove/clear" 应该映射到 delete 类工具。

## Reviewer Test Plan

### How to verify

运行聚焦工具测试：

```sh
npx vitest run packages/core/src/tools/tool-search.test.ts packages/core/src/tools/cron-list.test.ts packages/core/src/tools/cron-delete.test.ts packages/core/src/tools/loop-wakeup.test.ts --coverage=false
```

运行 touched files 的 lint、格式和空白检查：

```sh
npx eslint packages/core/src/tools/tool-search.ts packages/core/src/tools/cron-list.ts packages/core/src/tools/cron-delete.ts packages/core/src/tools/tool-search.test.ts
npx prettier --check packages/core/src/tools/tool-search.ts packages/core/src/tools/cron-list.ts packages/core/src/tools/cron-delete.ts packages/core/src/tools/tool-search.test.ts
git diff --check
```

运行 core 包检查：

```sh
npm run typecheck --workspace=packages/core
npm run build --workspace=packages/core
```

### Evidence (Before & After)

Before：`how do I stop this cron?` 的评分可能让 `cron_create` 与管理工具持平或更靠前，因为填充词和泛化描述匹配污染了分数。在真实候选集合包含 `loop_wakeup` 时，`cancel loop wakeup` 会把 `loop_wakeup` 排在 `cron_delete` 前面。

After：聚焦回归测试同时注册真实的 `cron_create`、`cron_list`、`cron_delete` 和 `loop_wakeup` 工具。测试断言 stop/cancel 请求会 reveal `cron_delete`，可见性请求会 reveal `cron_list`，调度请求仍会 reveal `loop_wakeup`。这覆盖了一个非 cron 的 deferred-tool 竞争者（`loop_wakeup`），证明 action-alias scoring 不会把所有 loop 相关查询都偏向 cron deletion。分词测试也验证了移除填充词的同时，会保留 `C++` 和 `C#` 这类非 cron 的语言式 token。

本地验证已通过：72 个聚焦测试、ESLint、Prettier check、`git diff --check`、core typecheck、core build。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

macOS arm64 (`Darwin 25.5.0`), Node `v26.3.0`, npm `11.16.0`。

## Risk & Scope

- 主要风险或权衡：`tool_search` 分词现在会丢弃常见英文填充词，并把取消类动词映射到 delete/remove/stop 工具词。这应该改善意图排序，但也可能影响 cron 工具之外 deferred tool search 的排序。
- 未验证 / 范围外：这个 PR 不重构 `/loop`，不新增 UI 面板，也不把 slash command 直接暴露成工具。它只改进现有 deferred tools 的发现。
- 破坏性变更 / 迁移说明：无。

## Linked Issues

Refs #5823.

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

</details>
