### PR TITLE
fix(core): parse workflow stall env as decimal seconds

### DIFF
--- a/packages/core/src/agents/runtime/workflow-stall.test.ts
+++ b/packages/core/src/agents/runtime/workflow-stall.test.ts
@@ -32,6 +32,14 @@ describe('resolveStallMs', () => {
       resolveStallMs(undefined, { [MAX_WORKFLOW_STALL_MS_ENV]: '0' }),
     ).toBe(0);
   });
+  it.each(['0x10', '1e3', '1.0', '2.5', '0x0'])(
+    'ignores malformed env seconds %j',
+    (value) => {
+      expect(
+        resolveStallMs(undefined, { [MAX_WORKFLOW_STALL_MS_ENV]: value }),
+      ).toBe(DEFAULT_STALL_MS);
+    },
+  );
   it('falls back to default when nothing set', () => {
     expect(resolveStallMs(undefined, {})).toBe(DEFAULT_STALL_MS);
   });

--- a/packages/core/src/agents/runtime/workflow-stall.ts
+++ b/packages/core/src/agents/runtime/workflow-stall.ts
@@ -38,6 +38,7 @@
 
 import { AgentEventEmitter, AgentEventType } from './agent-events.js';
 import { createDebugLogger } from '../../utils/debugLogger.js';
+import { parsePositiveIntegerEnv } from '../../utils/env.js';
 
 /** Default stall timeout: 60s of no progress (with no tool in flight). */
 export const DEFAULT_STALL_MS = 60_000;
@@ -64,10 +65,11 @@ export function resolveStallMs(
     if (perCall > 0) return perCall;
   }
   const raw = env[MAX_WORKFLOW_STALL_MS_ENV];
-  if (raw !== undefined && raw.trim() !== '') {
-    const sec = Number(raw);
-    if (Number.isFinite(sec) && sec > 0) return sec * 1000;
-    if (sec === 0) return 0;
+  const trimmed = raw?.trim();
+  if (trimmed) {
+    if (trimmed === '0') return 0;
+    const sec = parsePositiveIntegerEnv(trimmed, 0);
+    if (sec > 0) return sec * 1000;
   }
   return DEFAULT_STALL_MS;
 }


### PR DESCRIPTION
## What this PR does

Tightens `QWEN_CODE_WORKFLOW_STALL_SECONDS` parsing so the workflow stall watchdog only accepts plain decimal whole seconds from the environment. The exact value `0` still disables the watchdog, while malformed numeric forms fall back to the default timeout.

## Why it's needed

The env knob is documented as whole seconds, but it was parsed with `Number(raw)`, so values like `0x10`, `1e3`, `1.0`, and `0x0` were silently accepted. Nearby workflow env settings already use the shared strict integer parser, so this makes the stall watchdog consistent and avoids typo-shaped config changing workflow behavior.

## Reviewer Test Plan

### How to verify

Review `resolveStallMs` and confirm `QWEN_CODE_WORKFLOW_STALL_SECONDS=0` still disables the watchdog, valid decimal values like `30` still resolve to milliseconds, and malformed values such as `0x10`, `1e3`, `1.0`, `2.5`, and `0x0` fall back to `DEFAULT_STALL_MS`.

Run the focused test: `npx vitest run packages/core/src/agents/runtime/workflow-stall.test.ts --coverage=false`.

### Evidence (Before & After)

Before: `Number(raw)` accepted hex, scientific notation, decimal notation, and non-canonical zero values for a whole-seconds env knob.

After: the regression test `ignores malformed env seconds` covers `0x10`, `1e3`, `1.0`, `2.5`, and `0x0`; all now resolve to `DEFAULT_STALL_MS`, while the existing `env 0 disables` test still passes.

Local validation passed:

- `npx vitest run packages/core/src/agents/runtime/workflow-stall.test.ts --coverage=false` — 24 tests passed
- `npm exec prettier -- --check packages/core/src/agents/runtime/workflow-stall.ts packages/core/src/agents/runtime/workflow-stall.test.ts` — passed
- `npm exec eslint -- packages/core/src/agents/runtime/workflow-stall.ts packages/core/src/agents/runtime/workflow-stall.test.ts` — passed
- `npm run typecheck --workspace=packages/core` — passed
- `npm run build --workspace=packages/core` — passed
- `git diff --check` — passed

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS checkout, Node/npm workspace commands only.

## Risk & Scope

- Main risk or tradeoff: non-canonical values such as `1.0` or `00` no longer act as valid overrides; operators should use plain decimal whole seconds, with exact `0` for disabling the watchdog.
- Not validated / out of scope: changing the per-call `stallMs` override, changing the workflow sandbox timeout env parser, or changing stall retry behavior.
- Breaking changes / migration notes: no runtime migration; update any local env value to a plain decimal integer if it relied on JavaScript `Number()` coercion.

## Linked Issues

Fixes #5929

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.

<details>
<summary>中文说明</summary>

## What this PR does

收紧 `QWEN_CODE_WORKFLOW_STALL_SECONDS` 的解析逻辑，让 workflow stall watchdog 的环境变量只接受普通十进制整秒。精确的 `0` 仍然会禁用 watchdog，格式异常的数值会回退到默认超时时间。

## Why it's needed

这个环境变量文档里写的是整秒，但之前用 `Number(raw)` 解析，所以 `0x10`、`1e3`、`1.0`、`0x0` 这类值都会被静默接受。旁边的 workflow 环境变量已经在用共享的严格整数解析函数，这个改动让 stall watchdog 的行为保持一致，也避免 typo 形态的配置意外改变 workflow 行为。

## Reviewer Test Plan

### How to verify

检查 `resolveStallMs`，确认 `QWEN_CODE_WORKFLOW_STALL_SECONDS=0` 仍然会禁用 watchdog，`30` 这类合法十进制值仍然会转换为毫秒，`0x10`、`1e3`、`1.0`、`2.5`、`0x0` 这类异常值会回退到 `DEFAULT_STALL_MS`。

运行聚焦测试：`npx vitest run packages/core/src/agents/runtime/workflow-stall.test.ts --coverage=false`。

### Evidence (Before & After)

Before：`Number(raw)` 会让 whole-seconds 环境变量接受十六进制、科学计数法、小数表示和非标准零值。

After：回归测试 `ignores malformed env seconds` 覆盖了 `0x10`、`1e3`、`1.0`、`2.5`、`0x0`；这些值现在都会解析为 `DEFAULT_STALL_MS`，现有的 `env 0 disables` 测试也仍然通过。

本地验证已通过：

- `npx vitest run packages/core/src/agents/runtime/workflow-stall.test.ts --coverage=false` — 24 个测试通过
- `npm exec prettier -- --check packages/core/src/agents/runtime/workflow-stall.ts packages/core/src/agents/runtime/workflow-stall.test.ts` — 通过
- `npm exec eslint -- packages/core/src/agents/runtime/workflow-stall.ts packages/core/src/agents/runtime/workflow-stall.test.ts` — 通过
- `npm run typecheck --workspace=packages/core` — 通过
- `npm run build --workspace=packages/core` — 通过
- `git diff --check` — 通过

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 macOS checkout，只运行 Node/npm workspace 命令。

## Risk & Scope

- Main risk or tradeoff：`1.0` 或 `00` 这类非标准值不再作为有效 override；operator 应该使用普通十进制整秒，精确的 `0` 用于禁用 watchdog。
- Not validated / out of scope：不修改 per-call `stallMs` override，不修改 workflow sandbox timeout 环境变量解析，不修改 stall retry 行为。
- Breaking changes / migration notes：没有运行时迁移；如果本地环境变量依赖 JavaScript `Number()` coercion，请改成普通十进制整数。

## Linked Issues

Fixes #5929

## AI Assistance Disclosure

我使用 Codex 审查改动、对照现有模式做 sanity-check，并帮助发现潜在边界情况。

</details>