### PR TITLE
fix(cli): align MCP dialog border

### DIFF
--- a/packages/cli/src/ui/components/mcp/MCPManagementDialog.test.tsx
+++ b/packages/cli/src/ui/components/mcp/MCPManagementDialog.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { Config } from '@qwen-code/qwen-code-core';
+import { MCPManagementDialog } from './MCPManagementDialog.js';
+import { renderWithProviders } from '../../../test-utils/render.js';
+
+vi.mock('../../../config/mcpApprovals.js', () => ({
+  loadMcpApprovals: vi.fn(() => ({
+    getState: vi.fn(() => 'approved'),
+  })),
+}));
+
+const createConfig = (): Config =>
+  ({
+    getMcpServers: () => ({}),
+    getToolRegistry: () => undefined,
+    getPromptRegistry: () => undefined,
+    getResourceRegistry: () => undefined,
+    getWorkingDir: () => process.cwd(),
+    isMcpServerDisabled: () => false,
+  }) as unknown as Config;
+
+describe('MCPManagementDialog', () => {
+  it('uses the same rounded outer border as other dialogs', () => {
+    const { lastFrame } = renderWithProviders(
+      <MCPManagementDialog onClose={vi.fn()} />,
+      { config: createConfig() },
+    );
+
+    expect(lastFrame()).toContain('╭');
+    expect(lastFrame()).toContain('╮');
+  });
+});

--- a/packages/cli/src/ui/components/mcp/MCPManagementDialog.tsx
+++ b/packages/cli/src/ui/components/mcp/MCPManagementDialog.tsx
@@ -43,7 +43,6 @@ import {
 import { loadSettings, SettingScope } from '../../../config/settings.js';
 import { loadMcpApprovals } from '../../../config/mcpApprovals.js';
 import { isToolValid, getToolInvalidReasons } from './utils.js';
-import { useTerminalSize } from '../../hooks/useTerminalSize.js';
 
 const debugLogger = createDebugLogger('MCP_DIALOG');
 
@@ -51,8 +50,6 @@ export const MCPManagementDialog: React.FC<MCPManagementDialogProps> = ({
   onClose,
 }) => {
   const config = useConfig();
-  const { columns: width } = useTerminalSize();
-  const boxWidth = width - 4;
 
   const [servers, setServers] = useState<MCPServerDisplayInfo[]>([]);
   const [selectedServerIndex, setSelectedServerIndex] = useState<number>(-1);
@@ -906,20 +903,17 @@ export const MCPManagementDialog: React.FC<MCPManagementDialogProps> = ({
   );
 
   return (
-    <Box flexDirection="column" width={boxWidth}>
-      <Box
-        borderStyle="single"
-        borderColor={theme.border.default}
-        flexDirection="column"
-        width={boxWidth}
-        gap={1}
-        paddingLeft={1}
-        paddingRight={1}
-      >
-        {renderStepHeader()}
-        {renderStepContent()}
-        {renderStepFooter()}
-      </Box>
+    <Box
+      borderStyle="round"
+      borderColor={theme.border.default}
+      flexDirection="column"
+      gap={1}
+      padding={1}
+      width="100%"
+    >
+      {renderStepHeader()}
+      {renderStepContent()}
+      {renderStepFooter()}
     </Box>
   );
 };


### PR DESCRIPTION
## What this PR does

This PR updates the `/mcp` management dialog so its outer border follows the same rounded, full-width dialog style used elsewhere in the CLI. It also adds a focused regression test that renders the dialog and checks the rounded border characters.

## Why it's needed

The MCP management dialog previously calculated its own width from terminal columns and used a single-line border, which could leave the right side of the border clipped or visually inconsistent with other dialogs. Letting the parent dialog area own the width keeps the border inside the available layout and makes `/mcp` match `/model`.

## Reviewer Test Plan

### How to verify

Run the interactive CLI on Windows, open `/mcp`, and confirm the outer border is rounded and complete on the right side. Compare with `/model`; both dialogs should now use the same outer border style. The regression test should pass and fail if the MCP dialog falls back to the old single-line border.

### Evidence (Before & After)

Before:

<img width="1261" height="352" alt="Before: MCP dialog right border clipped" src="https://github.com/user-attachments/assets/612c0ac3-8784-4008-82f8-df6d471706da" />

After:

<img width="1092" height="301" alt="After: MCP dialog border complete" src="https://github.com/user-attachments/assets/b39b16a5-66c9-41a9-9f3a-72f2f9d06f96" />

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍎 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local checks run on Windows: `cd packages/cli && npx vitest run src/ui/components/mcp/MCPManagementDialog.test.tsx`, `npm run build`, and `npm run typecheck`. Build completed with existing unrelated warnings in the VS Code companion package.

## Risk & Scope

- Main risk or tradeoff: This changes only the MCP dialog shell styling and relies on the existing parent dialog width instead of local terminal-width math.
- Not validated / out of scope: Manual verification on macOS and Linux terminal renderers.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5933

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 调整 `/mcp` 管理对话框，让它的外层边框使用 CLI 中其他对话框一致的圆角、全宽样式。同时增加了一个聚焦的回归测试，渲染该对话框并检查圆角边框字符。

## 为什么需要

MCP 管理对话框之前会根据终端列数自行计算宽度，并使用单线边框，这可能导致右侧边框被裁掉，或者与其他对话框显示不一致。改为由父级对话框区域控制宽度后，边框会保持在可用布局内，并且 `/mcp` 与 `/model` 的外层边框风格一致。

## 审查测试计划

### 如何验证

在 Windows 上运行交互式 CLI，打开 `/mcp`，确认外层边框是圆角且右侧完整显示。再与 `/model` 对比，两者应使用相同的外层边框风格。新增回归测试应通过，并且如果 MCP 对话框退回旧的单线边框，测试会失败。

### 证据（修复前后）

修复前后截图见上方 Evidence 区域。

### 已测试平台

Windows 已测试；macOS 和 Linux 未手动测试。

### 环境

本地在 Windows 上运行了 `cd packages/cli && npx vitest run src/ui/components/mcp/MCPManagementDialog.test.tsx`、`npm run build` 和 `npm run typecheck`。构建通过，但 VS Code companion 包仍有既有的无关 warning。

## 风险与范围

- 主要风险或取舍：只调整 MCP 对话框外壳样式，并依赖现有父级对话框宽度，而不是本地终端宽度计算。
- 未验证 / 范围外：macOS 和 Linux 终端渲染器的手动验证。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #5933

</details>