### PR TITLE
feat(web-shell): add error boundaries so a render crash can't white-screen the embed

### DIFF
--- a/packages/web-shell/client/components/ErrorBoundary.test.tsx
+++ b/packages/web-shell/client/components/ErrorBoundary.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { ErrorBoundary } from './ErrorBoundary';
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+function render(node: React.ReactNode): HTMLElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(node));
+  mounted.push({ root, container });
+  return container;
+}
+
+afterEach(() => {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+  vi.restoreAllMocks();
+});
+
+function Boom({ explode }: { explode: boolean }): React.ReactElement {
+  if (explode) throw new Error('kaboom');
+  return <div data-testid="ok">healthy</div>;
+}
+
+describe('ErrorBoundary', () => {
+  it('renders children when nothing throws', () => {
+    const container = render(
+      <ErrorBoundary fallback={<div data-testid="fallback" />}>
+        <Boom explode={false} />
+      </ErrorBoundary>,
+    );
+    expect(container.querySelector('[data-testid="ok"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="fallback"]')).toBeNull();
+  });
+
+  it('renders the fallback when a child throws', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const container = render(
+      <ErrorBoundary fallback={<div data-testid="fallback">down</div>}>
+        <Boom explode={true} />
+      </ErrorBoundary>,
+    );
+    expect(container.querySelector('[data-testid="fallback"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="ok"]')).toBeNull();
+  });
+
+  it('passes the captured error to a render-prop fallback', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const container = render(
+      <ErrorBoundary
+        fallback={(error) => <div data-testid="fallback">{error.message}</div>}
+      >
+        <Boom explode={true} />
+      </ErrorBoundary>,
+    );
+    expect(
+      container.querySelector('[data-testid="fallback"]')?.textContent,
+    ).toBe('kaboom');
+  });
+
+  it('logs the error with the configured label prefix', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <ErrorBoundary label="message:assistant" fallback={<div />}>
+        <Boom explode={true} />
+      </ErrorBoundary>,
+    );
+    expect(
+      spy.mock.calls.some(
+        ([first]) =>
+          typeof first === 'string' &&
+          first.includes('[web-shell] message:assistant failed:'),
+      ),
+    ).toBe(true);
+  });
+
+  it('recovers when resetKeys change after an error', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    act(() =>
+      root.render(
+        <ErrorBoundary
+          resetKeys={[1]}
+          fallback={<div data-testid="fallback" />}
+        >
+          <Boom explode={true} />
+        </ErrorBoundary>,
+      ),
+    );
+    expect(container.querySelector('[data-testid="fallback"]')).not.toBeNull();
+
+    // Same key + now-healthy child: the boundary is still latched on the error,
+    // so the fallback persists until a reset key actually changes.
+    act(() =>
+      root.render(
+        <ErrorBoundary
+          resetKeys={[1]}
+          fallback={<div data-testid="fallback" />}
+        >
+          <Boom explode={false} />
+        </ErrorBoundary>,
+      ),
+    );
+    expect(container.querySelector('[data-testid="fallback"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="ok"]')).toBeNull();
+
+    // Changed key clears the error and re-mounts the (now healthy) child.
+    act(() =>
+      root.render(
+        <ErrorBoundary
+          resetKeys={[2]}
+          fallback={<div data-testid="fallback" />}
+        >
+          <Boom explode={false} />
+        </ErrorBoundary>,
+      ),
+    );
+    expect(container.querySelector('[data-testid="ok"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="fallback"]')).toBeNull();
+  });
+
+  it('keeps showing the fallback when a stable broken child never changes', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    const tree = (
+      <ErrorBoundary resetKeys={[1]} fallback={<div data-testid="fallback" />}>
+        <Boom explode={true} />
+      </ErrorBoundary>
+    );
+    act(() => root.render(tree));
+    act(() => root.render(tree));
+    expect(container.querySelector('[data-testid="fallback"]')).not.toBeNull();
+  });
+});

--- a/packages/web-shell/client/components/ErrorBoundary.tsx
+++ b/packages/web-shell/client/components/ErrorBoundary.tsx
@@ -1,0 +1,91 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+type FallbackRender = (error: Error, reset: () => void) => ReactNode;
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  /**
+   * Rendered in place of the children once one of them throws. A function form
+   * receives the captured error and a `reset` callback that clears the error
+   * and re-mounts the children (for an explicit "try again" affordance).
+   */
+  fallback: ReactNode | FallbackRender;
+  /**
+   * When any value here changes between renders, the boundary clears its error
+   * state and retries. Pass the rendered content's identity (e.g. a message
+   * object) so an edited/retried/streamed update recovers on its own instead of
+   * staying stuck on the fallback. A stable broken child keeps the fallback and
+   * never loops, since unchanged keys never trigger a reset.
+   */
+  resetKeys?: ReadonlyArray<unknown>;
+  /** Identifies the boundary in console diagnostics. */
+  label?: string;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+  resetKeys: ReadonlyArray<unknown>;
+}
+
+const EMPTY_KEYS: ReadonlyArray<unknown> = [];
+
+function resetKeysChanged(
+  prev: ReadonlyArray<unknown>,
+  next: ReadonlyArray<unknown>,
+): boolean {
+  if (prev === next) return false;
+  if (prev.length !== next.length) return true;
+  return prev.some((value, index) => !Object.is(value, next[index]));
+}
+
+/**
+ * Generic React error boundary. web-shell ships as an embeddable component, so
+ * a throw in any one subtree (Markdown, KaTeX, Mermaid, a tool panel) must not
+ * white-screen the host page. Wrap risky subtrees with this and supply a
+ * graceful fallback.
+ */
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = {
+    error: null,
+    resetKeys: this.props.resetKeys ?? EMPTY_KEYS,
+  };
+
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+    return { error };
+  }
+
+  static getDerivedStateFromProps(
+    props: ErrorBoundaryProps,
+    state: ErrorBoundaryState,
+  ): Partial<ErrorBoundaryState> | null {
+    const nextKeys = props.resetKeys ?? EMPTY_KEYS;
+    if (resetKeysChanged(state.resetKeys, nextKeys)) {
+      return { error: null, resetKeys: nextKeys };
+    }
+    return null;
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error(
+      `[web-shell] ${this.props.label ?? 'render'} failed:`,
+      error,
+      info.componentStack,
+    );
+  }
+
+  private readonly reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): ReactNode {
+    const { error } = this.state;
+    if (error === null) return this.props.children;
+    const { fallback } = this.props;
+    return typeof fallback === 'function'
+      ? fallback(error, this.reset)
+      : fallback;
+  }
+}

--- a/packages/web-shell/client/components/MessageItem.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageItem.dom.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { I18nProvider } from '../i18n';
+import type { Message } from '../adapters/types';
+
+// Stub the message body components so MessageItem's own wiring — not the bodies
+// — is under test. UserMessage/AssistantMessage throw on a sentinel so we can
+// drive the message-level ErrorBoundary (the real one, imported below); the
+// rest are inert. MessageTimestamp is a passthrough so its chrome doesn't
+// interfere with querying the fallback.
+vi.mock('./MessageTimestamp', async () => {
+  const React = await import('react');
+  return {
+    MessageTimestamp: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('div', null, children),
+    formatTimestamp: () => '',
+  };
+});
+vi.mock('./messages/UserMessage', async () => {
+  const React = await import('react');
+  return {
+    UserMessage: ({ content }: { content: string }) => {
+      if (content.includes('__BOOM__')) throw new Error('user boom');
+      return React.createElement('div', { 'data-testid': 'user-ok' }, content);
+    },
+  };
+});
+vi.mock('./messages/AssistantMessage', async () => {
+  const React = await import('react');
+  return {
+    AssistantMessage: ({ content }: { content: string }) => {
+      if (content.includes('__BOOM__')) throw new Error('assistant boom');
+      return React.createElement(
+        'div',
+        { 'data-testid': 'assistant-ok' },
+        content,
+      );
+    },
+    ThinkingMessage: () => null,
+  };
+});
+vi.mock('./messages/SystemMessage', () => ({ SystemMessage: () => null }));
+vi.mock('./messages/ToolGroup', () => ({ ToolGroup: () => null }));
+vi.mock('./messages/PlanMessage', () => ({ PlanMessage: () => null }));
+vi.mock('./messages/BtwMessage', () => ({ BtwMessage: () => null }));
+vi.mock('./messages/UserShellMessage', () => ({
+  UserShellMessage: () => null,
+}));
+vi.mock('./InsightProgress', () => ({ InsightProgress: () => null }));
+vi.mock('./InsightReady', () => ({ InsightReady: () => null }));
+
+const { MessageItem } = await import('./MessageItem');
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const RENDER_ERROR = 'This message could not be displayed.';
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+function render(node: React.ReactNode): HTMLElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(node));
+  mounted.push({ root, container });
+  return container;
+}
+
+afterEach(() => {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+  vi.restoreAllMocks();
+});
+
+const userMsg = (id: string, content: string): Message =>
+  ({ id, role: 'user', content, timestamp: 0 }) as Message;
+const assistantMsg = (id: string, content: string): Message =>
+  ({ id, role: 'assistant', content, timestamp: 0 }) as Message;
+
+function item(message: Message) {
+  return <MessageItem message={message} shellOutputMaxLines={50} />;
+}
+
+describe('MessageItem error isolation', () => {
+  it('renders a healthy message normally (no fallback)', () => {
+    const container = render(
+      <I18nProvider language="en">{item(userMsg('1', 'hello'))}</I18nProvider>,
+    );
+    expect(
+      container.querySelector('[data-testid="user-ok"]')?.textContent,
+    ).toBe('hello');
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('degrades a crashing message to an inline notice while a sibling survives', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const container = render(
+      <I18nProvider language="en">
+        {item(userMsg('ok', 'hello'))}
+        {item(userMsg('bad', '__BOOM__'))}
+      </I18nProvider>,
+    );
+    // The healthy sibling still renders — one bad message doesn't take down the
+    // transcript.
+    expect(
+      container.querySelector('[data-testid="user-ok"]')?.textContent,
+    ).toBe('hello');
+    // The crashing message degrades to the localized inline notice.
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      RENDER_ERROR,
+    );
+  });
+
+  it('right-aligns the fallback for a user message', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const container = render(
+      <I18nProvider language="en">
+        {item(userMsg('1', '__BOOM__'))}
+      </I18nProvider>,
+    );
+    const alert = container.querySelector('[role="alert"]') as HTMLElement;
+    expect(alert).not.toBeNull();
+    expect(alert.style.justifyContent).toBe('flex-end');
+  });
+
+  it('left-aligns the fallback for an assistant message', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const container = render(
+      <I18nProvider language="en">
+        {item(assistantMsg('1', '__BOOM__'))}
+      </I18nProvider>,
+    );
+    const alert = container.querySelector('[role="alert"]') as HTMLElement;
+    expect(alert).not.toBeNull();
+    expect(alert.style.justifyContent).toBe('flex-start');
+  });
+});

--- a/packages/web-shell/client/components/MessageItem.tsx
+++ b/packages/web-shell/client/components/MessageItem.tsx
@@ -5,6 +5,8 @@ import type {
   PermissionRequest,
   TodoItem,
 } from '../adapters/types';
+import { useI18n } from '../i18n';
+import { ErrorBoundary } from './ErrorBoundary';
 import { MessageTimestamp } from './MessageTimestamp';
 import { UserMessage } from './messages/UserMessage';
 import { AssistantMessage, ThinkingMessage } from './messages/AssistantMessage';
@@ -130,12 +132,31 @@ export const MessageItem = memo(function MessageItem({
 
   if (body === null) return null;
 
+  // Isolate each message's render: a throw in Markdown/KaTeX/Mermaid/a tool
+  // panel degrades to an inline notice rather than white-screening the whole
+  // (embeddable) transcript. `resetKeys={[message]}` lets a streamed/edited/
+  // retried update recover on its own; a stable broken message stays on the
+  // fallback without looping.
+  const safeBody = (
+    <ErrorBoundary
+      label={`message:${message.role}`}
+      resetKeys={[message]}
+      fallback={
+        <MessageRenderError align={message.role === 'user' ? 'end' : 'start'} />
+      }
+    >
+      {body}
+    </ErrorBoundary>
+  );
+
   if (message.role === 'assistant') {
     if (showAssistantActions) {
-      return body;
+      return safeBody;
     }
     return (
-      <MessageTimestamp timestamp={message.timestamp}>{body}</MessageTimestamp>
+      <MessageTimestamp timestamp={message.timestamp}>
+        {safeBody}
+      </MessageTimestamp>
     );
   }
 
@@ -146,10 +167,37 @@ export const MessageItem = memo(function MessageItem({
       copyText={message.role === 'user' ? message.content : undefined}
       copyTitle="Copy"
     >
-      {body}
+      {safeBody}
     </MessageTimestamp>
   );
 }, areMessageItemPropsEqual);
+
+// Aligns with the message it replaces: user messages are right-aligned bubbles,
+// so the notice sits on the right too and still reads as that user turn's prompt
+// (a left-aligned notice would look like it belongs to the previous turn's
+// output). Assistant and other rows are left-aligned, matching their layout.
+function MessageRenderError({ align }: { align: 'start' | 'end' }) {
+  const { t } = useI18n();
+  return (
+    <div
+      role="alert"
+      style={{
+        display: 'flex',
+        justifyContent: align === 'end' ? 'flex-end' : 'flex-start',
+      }}
+    >
+      <span
+        style={{
+          color: 'var(--error-color, #e06c75)',
+          fontSize: '0.85em',
+          opacity: 0.85,
+        }}
+      >
+        {t('message.renderError')}
+      </span>
+    </div>
+  );
+}
 
 function areMessageItemPropsEqual(
   prev: MessageItemProps,

--- a/packages/web-shell/client/components/RootErrorFallback.test.tsx
+++ b/packages/web-shell/client/components/RootErrorFallback.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { ErrorBoundary } from './ErrorBoundary';
+import { RootErrorFallback } from './RootErrorFallback';
+import type { WebShellLanguage } from '../i18n';
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+function mount(node: React.ReactNode): { container: HTMLElement; root: Root } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(node));
+  const entry = { container, root };
+  mounted.push(entry);
+  return entry;
+}
+
+afterEach(() => {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+// Mirror the top-level wiring in index.tsx / main.tsx: the boundary wraps the
+// whole App and renders RootErrorFallback (with retry) on a render-phase crash.
+function RootBoundary({
+  children,
+  language,
+}: {
+  children: React.ReactNode;
+  language?: WebShellLanguage;
+}) {
+  return (
+    <ErrorBoundary
+      label="web-shell-root"
+      fallback={(error, reset) => (
+        <RootErrorFallback error={error} onRetry={reset} language={language} />
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}
+
+describe('RootErrorFallback', () => {
+  it('renders English copy by default', () => {
+    const { container } = mount(
+      <RootErrorFallback error={new Error('boom detail')} onRetry={() => {}} />,
+    );
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert?.textContent).toContain('Something went wrong');
+    expect(alert?.textContent).toContain('Try again');
+  });
+
+  it('shows the raw error message only in dev, never in production', () => {
+    vi.stubEnv('DEV', true);
+    const dev = mount(
+      <RootErrorFallback error={new Error('boom detail')} onRetry={() => {}} />,
+    );
+    expect(dev.container.textContent).toContain('boom detail');
+
+    vi.stubEnv('DEV', false);
+    const prod = mount(
+      <RootErrorFallback error={new Error('boom detail')} onRetry={() => {}} />,
+    );
+    expect(prod.container.textContent).not.toContain('boom detail');
+    // The user-facing copy still renders in production.
+    expect(prod.container.textContent).toContain('Something went wrong');
+    expect(prod.container.textContent).toContain('Try again');
+  });
+
+  it('renders zh-CN copy when language is zh-CN', () => {
+    const { container } = mount(
+      <RootErrorFallback
+        error={new Error('x')}
+        onRetry={() => {}}
+        language="zh-CN"
+      />,
+    );
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      '出了点问题',
+    );
+  });
+
+  it('catches an App-level render crash instead of white-screening', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    function BrokenApp(): React.ReactElement {
+      throw new Error('app render exploded');
+    }
+    const { container } = mount(
+      <RootBoundary>
+        <BrokenApp />
+      </RootBoundary>,
+    );
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert).not.toBeNull();
+    expect(alert?.textContent).toContain('Something went wrong');
+    expect(alert?.textContent).toContain('app render exploded');
+  });
+
+  it('recovers when the user clicks "Try again" after the cause is gone', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    // External switch the child reads at render time. The boundary's reset()
+    // re-renders the children; flipping this before the click lets the now-
+    // healthy App mount.
+    let shouldThrow = true;
+    function FlakyApp(): React.ReactElement {
+      if (shouldThrow) throw new Error('transient');
+      return <div data-testid="app">recovered</div>;
+    }
+
+    const { container } = mount(
+      <RootBoundary>
+        <FlakyApp />
+      </RootBoundary>,
+    );
+    expect(container.querySelector('[role="alert"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="app"]')).toBeNull();
+
+    shouldThrow = false;
+    const retryButton = container.querySelector('button');
+    expect(retryButton).not.toBeNull();
+    act(() => {
+      retryButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.querySelector('[data-testid="app"]')?.textContent).toBe(
+      'recovered',
+    );
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+});

--- a/packages/web-shell/client/components/RootErrorFallback.tsx
+++ b/packages/web-shell/client/components/RootErrorFallback.tsx
@@ -1,0 +1,104 @@
+import type { CSSProperties } from 'react';
+import type { WebShellLanguage } from '../i18n';
+
+interface RootErrorFallbackProps {
+  error: Error;
+  onRetry: () => void;
+  /** Selects the fallback copy. Defaults to English when omitted. */
+  language?: WebShellLanguage;
+}
+
+interface FallbackCopy {
+  title: string;
+  body: string;
+  retry: string;
+}
+
+// This surface renders OUTSIDE the in-app I18nProvider (the boundary wraps the
+// whole App, which owns that provider), so it cannot call useI18n. It carries
+// its own minimal copy instead of pulling the full translation table.
+const COPY: Record<WebShellLanguage, FallbackCopy> = {
+  en: {
+    title: 'Something went wrong',
+    body: 'An unexpected error occurred and this content could not be displayed.',
+    retry: 'Try again',
+  },
+  'zh-CN': {
+    title: '出了点问题',
+    body: '发生意外错误，无法显示此内容。',
+    retry: '重试',
+  },
+};
+
+// The boundary wraps the whole App, so this surface renders when the themed
+// App container (which defines --text-primary etc.) never mounted. It therefore
+// cannot use app theme tokens. Inheriting the host's text color keeps it
+// readable on both light and dark hosts; opacity carries the hierarchy and a
+// neutral gray border reads acceptably on either background.
+const containerStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '0.75rem',
+  padding: '2rem',
+  minHeight: '8rem',
+  height: '100%',
+  textAlign: 'center',
+  color: 'inherit',
+};
+
+const titleStyle: CSSProperties = {
+  margin: 0,
+  fontSize: '1rem',
+  fontWeight: 600,
+};
+
+const bodyStyle: CSSProperties = {
+  margin: 0,
+  fontSize: '0.85rem',
+  opacity: 0.7,
+  maxWidth: '32rem',
+};
+
+const buttonStyle: CSSProperties = {
+  appearance: 'none',
+  cursor: 'pointer',
+  padding: '0.4rem 1rem',
+  fontSize: '0.85rem',
+  borderRadius: '6px',
+  border: '1px solid rgba(128, 128, 128, 0.4)',
+  background: 'transparent',
+  color: 'inherit',
+};
+
+/**
+ * Last-resort surface for the top-level boundary. Self-contained (no provider,
+ * theme-token, or i18n dependency) so it survives even when the whole App tree
+ * fails to mount. Offers a retry instead of forcing a host-page reload, which
+ * would be hostile in embedded integrations.
+ */
+export function RootErrorFallback({
+  error,
+  onRetry,
+  language = 'en',
+}: RootErrorFallbackProps) {
+  const copy = COPY[language] ?? COPY.en;
+  return (
+    <div role="alert" style={containerStyle} data-web-shell-error>
+      <p style={titleStyle}>{copy.title}</p>
+      <p style={bodyStyle}>{copy.body}</p>
+      {/* Dev-only: end users (and embedded hosts) shouldn't see raw internal
+          error text — it stays in console.error for everyone. In the published
+          lib build DEV is statically false, so this never ships to consumers. */}
+      {import.meta.env.DEV && error.message && (
+        <p style={{ ...bodyStyle, fontFamily: 'monospace', opacity: 0.55 }}>
+          {error.message}
+        </p>
+      )}
+      <button type="button" style={buttonStyle} onClick={onRetry}>
+        {copy.retry}
+      </button>
+    </div>
+  );
+}

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -1062,6 +1062,7 @@ const EN: Messages = {
     const n = v?.count ?? 0;
     return `${n} thought${n === 1 ? '' : 's'}`;
   },
+  'message.renderError': 'This message could not be displayed.',
   'tasks.title': 'Background tasks',
   'tasks.empty': 'No tasks currently running',
   'tasks.refreshStale': 'Task status may be stale; reconnecting...',
@@ -2209,6 +2210,7 @@ const ZH: Messages = {
   'turn.executionSteps': (v) => `${v?.count ?? 0} 步`,
   'turn.toolCalls': (v) => `工具 ${v?.count ?? 0} 次`,
   'turn.thinkingCount': (v) => `思考 ${v?.count ?? 0} 次`,
+  'message.renderError': '此消息无法显示。',
   'tasks.title': '后台任务',
   'tasks.empty': '当前没有运行中的任务',
   'tasks.refreshStale': '任务状态可能已过期，正在重连...',

--- a/packages/web-shell/client/index.test.tsx
+++ b/packages/web-shell/client/index.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+// Drive a render throw from inside DaemonWorkspaceProvider so we can prove the
+// top-level boundary sits *outside* the daemon providers (a boundary nested
+// under them couldn't catch their own throw).
+let workspaceShouldThrow = false;
+vi.mock('@qwen-code/webui/daemon-react-sdk', async () => {
+  const React = await import('react');
+  return {
+    DaemonWorkspaceProvider: ({ children }: { children: React.ReactNode }) => {
+      if (workspaceShouldThrow) throw new Error('provider boom');
+      return React.createElement(React.Fragment, null, children);
+    },
+    DaemonSessionProvider: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+vi.mock('./App', async () => {
+  const React = await import('react');
+  return {
+    App: () => React.createElement('div', { 'data-testid': 'app-ok' }, 'app'),
+  };
+});
+
+// Bare './index' resolves to the sibling index.ts barrel, which doesn't export
+// WebShellWithProviders (see the dual-entry note in the PR). A variable
+// specifier loads index.tsx at runtime without tripping tsc's ts-extension rule.
+const indexEntry = './index.tsx';
+const { WebShellWithProviders } = await import(indexEntry);
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+function render(node: React.ReactNode): HTMLElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(node));
+  mounted.push({ root, container });
+  return container;
+}
+
+afterEach(() => {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+  workspaceShouldThrow = false;
+  vi.restoreAllMocks();
+});
+
+describe('WebShellWithProviders top-level boundary', () => {
+  it('renders normally when the providers are healthy', () => {
+    const container = render(<WebShellWithProviders />);
+    expect(container.querySelector('[data-testid="app-ok"]')).not.toBeNull();
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('catches a daemon-provider render crash instead of white-screening', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    workspaceShouldThrow = true;
+    const container = render(<WebShellWithProviders />);
+    // The boundary is outside the providers, so the provider throw degrades to
+    // the recoverable fallback rather than unmounting the whole root.
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      'Something went wrong',
+    );
+    expect(container.querySelector('[data-testid="app-ok"]')).toBeNull();
+  });
+});

--- a/packages/web-shell/client/index.tsx
+++ b/packages/web-shell/client/index.tsx
@@ -1,8 +1,12 @@
+import type { ReactNode } from 'react';
 import {
   DaemonSessionProvider,
   DaemonWorkspaceProvider,
 } from '@qwen-code/webui/daemon-react-sdk';
 import { App, type WebShellProps } from './App';
+import { ErrorBoundary } from './components/ErrorBoundary';
+import { RootErrorFallback } from './components/RootErrorFallback';
+import { normalizeLanguage, type WebShellLanguage } from './i18n';
 
 export interface WebShellWithProvidersProps extends WebShellProps {
   /** Daemon API base URL. Defaults to the browser origin when omitted. */
@@ -22,10 +26,45 @@ function resolveBaseUrl(baseUrl: string | undefined): string {
 }
 
 /**
- * Low-level UI component. Requires ancestor `DaemonWorkspaceProvider` and
- * `DaemonSessionProvider` from `@qwen-code/webui/daemon-react-sdk`.
+ * Top-level boundary so a catastrophic render failure degrades to a recoverable
+ * fallback instead of taking down the host page. Place it at the outermost point
+ * each entry owns: a boundary nested *inside* the daemon providers can't catch a
+ * throw from the providers themselves, so the batteries-included paths wrap the
+ * providers too.
  */
-export { App as WebShell };
+function RootBoundary({
+  language,
+  children,
+}: {
+  language?: WebShellLanguage;
+  children: ReactNode;
+}) {
+  return (
+    <ErrorBoundary
+      label="web-shell-root"
+      fallback={(error, reset) => (
+        <RootErrorFallback error={error} onRetry={reset} language={language} />
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}
+
+/**
+ * Low-level UI component. Requires ancestor `DaemonWorkspaceProvider` and
+ * `DaemonSessionProvider` from `@qwen-code/webui/daemon-react-sdk`. The consumer
+ * owns those providers, so this boundary covers only what we render (`App`).
+ */
+export function WebShell(props: WebShellProps) {
+  return (
+    <RootBoundary
+      language={props.language ? normalizeLanguage(props.language) : undefined}
+    >
+      <App {...props} />
+    </RootBoundary>
+  );
+}
 
 /**
  * Batteries-included component for product integrations. It wraps WebShell
@@ -42,15 +81,23 @@ export function WebShellWithProviders({
   const resolvedBaseUrl = resolveBaseUrl(baseUrl);
 
   return (
-    <DaemonWorkspaceProvider baseUrl={resolvedBaseUrl} token={token}>
-      <DaemonSessionProvider
-        initialSessionId={initialSessionId}
-        clientId={clientId}
-        suppressOwnUserEcho
-      >
-        <App {...webShellProps} />
-      </DaemonSessionProvider>
-    </DaemonWorkspaceProvider>
+    <RootBoundary
+      language={
+        webShellProps.language
+          ? normalizeLanguage(webShellProps.language)
+          : undefined
+      }
+    >
+      <DaemonWorkspaceProvider baseUrl={resolvedBaseUrl} token={token}>
+        <DaemonSessionProvider
+          initialSessionId={initialSessionId}
+          clientId={clientId}
+          suppressOwnUserEcho
+        >
+          <App {...webShellProps} />
+        </DaemonSessionProvider>
+      </DaemonWorkspaceProvider>
+    </RootBoundary>
   );
 }
 

--- a/packages/web-shell/client/main.tsx
+++ b/packages/web-shell/client/main.tsx
@@ -6,6 +6,8 @@ import {
   DaemonSessionProvider,
 } from '@qwen-code/webui/daemon-react-sdk';
 import { App } from './App';
+import { ErrorBoundary } from './components/ErrorBoundary';
+import { RootErrorFallback } from './components/RootErrorFallback';
 import {
   getDaemonBaseUrl,
   getDaemonToken,
@@ -106,22 +108,29 @@ function StandaloneApp() {
   }, []);
 
   return (
-    <DaemonWorkspaceProvider baseUrl={baseUrl} token={DAEMON_TOKEN}>
-      <DaemonSessionProvider
-        key={sessionId ?? 'new'}
-        initialSessionId={sessionId}
-        suppressOwnUserEcho
-      >
-        <App
-          theme={theme}
-          onThemeChange={handleThemeChange}
-          language={language}
-          onLanguageChange={handleLanguageChange}
-          sidebar
-          compactThinking
-        />
-      </DaemonSessionProvider>
-    </DaemonWorkspaceProvider>
+    <ErrorBoundary
+      label="web-shell-root"
+      fallback={(error, reset) => (
+        <RootErrorFallback error={error} onRetry={reset} language={language} />
+      )}
+    >
+      <DaemonWorkspaceProvider baseUrl={baseUrl} token={DAEMON_TOKEN}>
+        <DaemonSessionProvider
+          key={sessionId ?? 'new'}
+          initialSessionId={sessionId}
+          suppressOwnUserEcho
+        >
+          <App
+            theme={theme}
+            onThemeChange={handleThemeChange}
+            language={language}
+            onLanguageChange={handleLanguageChange}
+            sidebar
+            compactThinking
+          />
+        </DaemonSessionProvider>
+      </DaemonWorkspaceProvider>
+    </ErrorBoundary>
   );
 }
 


### PR DESCRIPTION
## What this PR does

Adds React error boundaries to web-shell so that an uncaught render error in any one subtree degrades gracefully instead of unmounting the whole React root. There are three layers: a generic reusable `ErrorBoundary`; a message-level boundary around every `MessageItem` body, so one bad message becomes a small inline notice while the rest of the transcript keeps rendering; and a top-level boundary placed at the outermost point each entry controls (outside the daemon providers for the batteries-included `WebShellWithProviders` and the standalone app, around `App` for the low-level `WebShell` whose providers the consumer owns) that shows a self-contained, recoverable fallback with a retry. The boundary recovers automatically when its content changes (streamed/edited/retried updates) and logs every catch to the console for diagnostics.

## Why it's needed

web-shell ships as an embeddable React component, so an uncaught render error anywhere in the tree unmounts the entire root and white-screens the host page — taking down not just the bad message but the composer, header, and everything else. The codebase only had one narrow boundary (`EnhancedMarkdownTableBoundary`, tables only); a throw in Markdown, KaTeX, Mermaid, a tool panel, or the daemon providers had nothing to catch it. This was already called out during review of the streaming-highlight PR: code blocks "would crash the entire message view" because "there is no error boundary wrapping code blocks." This PR closes that class of failure for an embeddable component.

## Reviewer Test Plan

### How to verify

Unit/DOM tests cover the mechanism and each placement: the generic boundary (render/fallback/reset-on-key/stable-broken/label-logging), the message-level isolation (a crashing message degrades to the inline notice while a sibling still renders; role-aware alignment), the top-level fallback catching an App-level crash plus the retry recovering, the raw-error-detail being dev-only, and `WebShellWithProviders` catching a daemon-provider crash (which only holds because the boundary sits outside the providers). Expected: all green.

```
npm --workspace @qwen-code/web-shell run test          # 538 passed
npx tsc --noEmit -p packages/web-shell/tsconfig.json    # clean (after building @qwen-code/webui + @qwen-code/sdk)
```

Manual: run the standalone (`npm run dev:daemon`), temporarily make a message body throw → only that bubble shows "This message could not be displayed.", the rest of the UI survives; make `App` throw (or a provider) → the recoverable "Something went wrong" surface with a working retry, instead of a blank page.

### Evidence (Before & After)

Before (no boundary): a single bad message unmounts the whole root — blank page (composer/header/transcript all gone). After (boundary): the bad message degrades to an inline notice with siblings intact, App/provider crashes show the recoverable fallback, and retry restores the view.

<!-- Screenshots attached below. -->

#### Before
<img width="2886" height="1454" alt="6-WITHOUT-boundary-whitescreen" src="https://github.com/user-attachments/assets/f16c41dc-cdfb-413e-9b10-8b1e472d0db2" />

#### After
<img width="2886" height="1454" alt="5-assistant-reply-error" src="https://github.com/user-attachments/assets/98680cf9-3d8e-47ef-a639-2e5d75c21c46" />
<img width="2886" height="1454" alt="1-top-level-fallback" src="https://github.com/user-attachments/assets/aad4b74a-e736-46dc-918b-0e7f219f1241" />


### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local `npm run dev:daemon` (standalone) for manual verification; Vitest jsdom for the automated tests.

## Risk & Scope

- Main risk or tradeoff: every `MessageItem` body now renders inside a class error boundary. `MessageItem` stays memoized and the list is virtualized (~20 rows mounted), so the per-row overhead is negligible.
- Not validated / out of scope: the pre-existing dual entry files `client/index.ts` (raw `export { App as WebShell }`) and `client/index.tsx` (the wrapped component + `WebShellWithProviders`). The runtime lib bundle is built from `index.tsx`, so consumers get the boundary at runtime, but the emitted `dist/types/index.d.ts` is won by `index.ts`, so the published types do not reflect the wrapper or `WebShellWithProviders`. This predates this PR and is intentionally left out of scope here; consolidating to a single entry has packaging implications and should be discussed and handled in a separate follow-up PR.
- Breaking changes / migration notes: none. No public API removed; `WebShell` keeps the same props (now wrapped). The raw error message in the fallback is dev-only (`import.meta.env.DEV`), so production/embedded consumers never see internal error text.

## Linked Issues

<!-- none -->
