### PR TITLE
fix(core): halt repeated shell inspection variants

### DIFF
--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -112,6 +112,8 @@ const LOOP_TYPE_LABELS: Record<LoopType, string> = {
     'the model spent too many consecutive calls reading files without making progress',
   [LoopType.ACTION_STAGNATION]:
     'the model kept calling the same tool without making progress',
+  [LoopType.SHELL_COMMAND_STAGNATION]:
+    'the model repeated similar shell inspection commands without making progress',
   [LoopType.GLOBAL_TOOL_CALL_DUPLICATE]:
     'the model repeated the same tool call across the turn, even when not back-to-back',
   [LoopType.ALTERNATING_TOOL_CALL_PATTERN]:
@@ -129,6 +131,7 @@ function formatLoopDetectedMessage(loopType: LoopType | undefined): string {
   const isAlwaysOn =
     loopType === LoopType.TURN_TOOL_CALL_CAP ||
     loopType === LoopType.CONSECUTIVE_IDENTICAL_TOOL_CALLS ||
+    loopType === LoopType.SHELL_COMMAND_STAGNATION ||
     loopType === LoopType.GLOBAL_TOOL_CALL_DUPLICATE;
   const hint = isAlwaysOn
     ? ' This is an always-on guard and cannot be disabled via `model.skipLoopDetection`.'

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -2176,9 +2176,10 @@ export class GeminiClient {
         // interruptions. Only the historically false-positive-prone heuristics
         // (content/thought repetition, read-file and action stagnation,
         // global-duplicate and alternating tool-call patterns) sit behind this
-        // flag. The precise consecutive-identical guard and the per-turn cap
-        // run unconditionally in checkAlwaysOnSafeties above, so the documented
-        // escape hatch only relaxes the heuristics (see nonInteractiveCli.ts).
+        // flag. The precise consecutive-identical guard, shell inspection
+        // stagnation guard, and per-turn cap run unconditionally in
+        // checkAlwaysOnSafeties above, so the documented escape hatch only
+        // relaxes the heuristics (see nonInteractiveCli.ts).
         const skipLoopDetection = this.config.getSkipLoopDetection();
         const heuristicLoop =
           !skipLoopDetection &&

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -2143,9 +2143,10 @@ export class GeminiClient {
           didUpdateIdeContextState = true;
         }
 
-        // Always-on safety checks (consecutive-identical tool-call guard +
-        // per-turn tool-call cap). These fire before the skipLoopDetection
-        // gate so they cannot be bypassed by configuration.
+        // Always-on safety checks (consecutive-identical tool-call guard,
+        // shell inspection stagnation, and per-turn tool-call cap). These fire
+        // before the skipLoopDetection gate so they cannot be bypassed by
+        // configuration.
         const alwaysOnLoop = this.loopDetector.checkAlwaysOnSafeties(event);
         if (alwaysOnLoop) {
           // Drop every tool call collected before the guard fired so the run

--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -332,8 +332,7 @@ describe('LoopDetectionService', () => {
       expect(
         service.checkAlwaysOnSafeties({
           type: GeminiEventType.Retry,
-          value: {},
-        }),
+        } as ServerGeminiStreamEvent),
       ).toBe(false);
 
       for (const command of variants) {
@@ -417,6 +416,56 @@ describe('LoopDetectionService', () => {
       expect(service.getLastLoopType()).not.toBe(
         LoopType.SHELL_COMMAND_STAGNATION,
       );
+    });
+
+    it('does not halt repeated non-git shell commands', () => {
+      for (let i = 0; i < SHELL_COMMAND_STAGNATION_THRESHOLD + 2; i++) {
+        expect(
+          service.checkAlwaysOnSafeties(
+            createToolCallRequestEvent('run_shell_command', {
+              command: `npm test -- --runInBand=${i}`,
+              description: 'Run tests',
+            }),
+          ),
+        ).toBe(false);
+      }
+      expect(service.getLastLoopType()).not.toBe(
+        LoopType.SHELL_COMMAND_STAGNATION,
+      );
+    });
+
+    it('halts newline-separated git inspection command variants', () => {
+      const commands = [
+        'git diff --stat\ngit status --short',
+        'git diff --name-only HEAD\ngit ls-files --modified',
+        'git --no-pager diff --stat\ngit status --porcelain=v1',
+        'git diff --stat HEAD\ngit ls-files --others',
+        'git diff --name-only\ngit status --short',
+        'git diff --stat\ngit -C . status --short',
+        'git --no-pager diff --stat\ngit ls-files --modified',
+        'git diff --name-only HEAD\ngit status --short',
+      ];
+
+      for (const command of commands.slice(0, -1)) {
+        expect(
+          service.checkAlwaysOnSafeties(
+            createToolCallRequestEvent('run_shell_command', {
+              command,
+              description: 'Inspect repository changes',
+            }),
+          ),
+        ).toBe(false);
+      }
+
+      expect(
+        service.checkAlwaysOnSafeties(
+          createToolCallRequestEvent('run_shell_command', {
+            command: commands.at(-1),
+            description: 'Inspect repository changes',
+          }),
+        ),
+      ).toBe(true);
+      expect(service.getLastLoopType()).toBe(LoopType.SHELL_COMMAND_STAGNATION);
     });
 
     it('does not halt file-specific git diff review commands', () => {

--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -306,6 +306,26 @@ describe('LoopDetectionService', () => {
         LoopType.SHELL_COMMAND_STAGNATION,
       );
     });
+
+    it('does not bucket compound commands that also write to the repository', () => {
+      // Each chain stages and commits real work; the embedded `git status` must
+      // not classify the whole command as stagnant read-only inspection. Vary
+      // the path so the consecutive-identical guard never fires, isolating the
+      // shell-stagnation guard under test.
+      for (let i = 0; i < SHELL_COMMAND_STAGNATION_THRESHOLD; i++) {
+        expect(
+          service.checkAlwaysOnSafeties(
+            createToolCallRequestEvent('run_shell_command', {
+              command: `git add file-${i}.txt && git status --short && git commit -m progress-${i}`,
+              description: 'Stage, inspect, and commit progress',
+            }),
+          ),
+        ).toBe(false);
+      }
+      expect(service.getLastLoopType()).not.toBe(
+        LoopType.SHELL_COMMAND_STAGNATION,
+      );
+    });
   });
 
   describe('Content Loop Detection', () => {

--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -356,6 +356,36 @@ describe('LoopDetectionService', () => {
         }),
       );
     });
+
+    it('does not halt file-specific git diff review commands without -- separator', () => {
+      const commands = [
+        'git status --short',
+        'git diff --stat',
+        'git diff src/a.ts',
+        'git diff src/b.ts',
+        'git diff src/c.ts',
+        'git diff src/d.ts',
+        'git diff src/e.ts',
+        'git diff src/f.ts',
+      ];
+
+      for (const command of commands) {
+        expect(
+          service.checkAlwaysOnSafeties(
+            createToolCallRequestEvent('run_shell_command', {
+              command,
+              description: 'Inspect repository changes',
+            }),
+          ),
+        ).toBe(false);
+      }
+      expect(loggers.logLoopDetected).not.toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          loop_type: 'shell_command_stagnation',
+        }),
+      );
+    });
   });
 
   describe('Content Loop Detection', () => {

--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -29,6 +29,7 @@ const CONTENT_CHUNK_SIZE = 50;
 // self-describing and failures point to the constant that changed.
 const FILE_READ_WINDOW = 15;
 const GLOBAL_DUPLICATE_THRESHOLD = 6;
+const SHELL_COMMAND_STAGNATION_THRESHOLD = 8;
 const ALTERNATING_PATTERN_CYCLES = 3;
 const TURN_TOOL_CALL_CAP = 100;
 
@@ -259,6 +260,50 @@ describe('LoopDetectionService', () => {
         expect.objectContaining({
           loop_type: 'shell_command_stagnation',
         }),
+      );
+    });
+
+    it('resets the streak when a non-inspection tool call interrupts the run', () => {
+      // Vary the command text so the consecutive-identical guard (threshold 5)
+      // never fires and only the shell-stagnation bucket accumulates.
+      const variants = [
+        'git status --short',
+        'git diff --stat',
+        'git ls-files --modified',
+        'git status --porcelain=v1',
+        'git diff --name-only HEAD',
+        'git -C . status --short',
+        'git --no-pager diff --stat',
+      ];
+      const gitInspect = (i: number) =>
+        service.checkAlwaysOnSafeties(
+          createToolCallRequestEvent('run_shell_command', {
+            command: variants[i % variants.length],
+            description: 'Inspect repository changes',
+          }),
+        );
+
+      // One short of the threshold, so the next inspection alone would trip.
+      for (let i = 0; i < SHELL_COMMAND_STAGNATION_THRESHOLD - 1; i++) {
+        expect(gitInspect(i)).toBe(false);
+      }
+
+      // A non-inspection tool call must reset the streak to zero.
+      expect(
+        service.checkAlwaysOnSafeties(
+          createToolCallRequestEvent('read_file', {
+            absolute_path: '/repo/README.md',
+          }),
+        ),
+      ).toBe(false);
+
+      // Counting restarts from zero: a full threshold-minus-one run of git
+      // inspections still does not trip, proving the streak did not carry over.
+      for (let i = 0; i < SHELL_COMMAND_STAGNATION_THRESHOLD - 1; i++) {
+        expect(gitInspect(i)).toBe(false);
+      }
+      expect(service.getLastLoopType()).not.toBe(
+        LoopType.SHELL_COMMAND_STAGNATION,
       );
     });
   });

--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -221,6 +221,48 @@ describe('LoopDetectionService', () => {
     });
   });
 
+  describe('Shell Command Stagnation (Always-On Circuit Breaker)', () => {
+    it('halts repeated git inspection command variants via the always-on guard', () => {
+      const commands = [
+        'git status --short',
+        'git status --short && git diff --stat',
+        'git diff --name-only HEAD',
+        'git status --porcelain=v1',
+        'git diff --stat HEAD',
+        'git -C . status --short',
+        'git --no-pager diff --stat',
+        'git ls-files --modified',
+      ];
+
+      for (const command of commands.slice(0, -1)) {
+        expect(
+          service.checkAlwaysOnSafeties(
+            createToolCallRequestEvent('run_shell_command', {
+              command,
+              description: 'Inspect repository changes',
+            }),
+          ),
+        ).toBe(false);
+      }
+
+      expect(
+        service.checkAlwaysOnSafeties(
+          createToolCallRequestEvent('run_shell_command', {
+            command: commands.at(-1),
+            description: 'Inspect repository changes',
+          }),
+        ),
+      ).toBe(true);
+      expect(service.getLastLoopType()).toBe(LoopType.SHELL_COMMAND_STAGNATION);
+      expect(loggers.logLoopDetected).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          loop_type: 'shell_command_stagnation',
+        }),
+      );
+    });
+  });
+
   describe('Content Loop Detection', () => {
     const generateRandomString = (length: number) => {
       let result = '';

--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -221,6 +221,78 @@ describe('LoopDetectionService', () => {
     });
   });
 
+  describe('Shell Command Stagnation (Always-On Circuit Breaker)', () => {
+    it('halts repeated git inspection command variants via the always-on guard', () => {
+      const commands = [
+        'git status --short',
+        'git status --short && git diff --stat',
+        'git diff --name-only HEAD',
+        'git status --porcelain=v1',
+        'git diff --stat HEAD',
+        'git -C . status --short',
+        'git --no-pager diff --stat',
+        'git ls-files --modified',
+      ];
+
+      for (const command of commands.slice(0, -1)) {
+        expect(
+          service.checkAlwaysOnSafeties(
+            createToolCallRequestEvent('run_shell_command', {
+              command,
+              description: 'Inspect repository changes',
+            }),
+          ),
+        ).toBe(false);
+      }
+
+      expect(
+        service.checkAlwaysOnSafeties(
+          createToolCallRequestEvent('run_shell_command', {
+            command: commands.at(-1),
+            description: 'Inspect repository changes',
+          }),
+        ),
+      ).toBe(true);
+      expect(service.getLastLoopType()).toBe(LoopType.SHELL_COMMAND_STAGNATION);
+      expect(loggers.logLoopDetected).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          loop_type: 'shell_command_stagnation',
+        }),
+      );
+    });
+
+    it('does not halt file-specific git diff review commands', () => {
+      const commands = [
+        'git status --short',
+        'git diff --stat',
+        'git diff -- src/a.ts',
+        'git diff -- src/b.ts',
+        'git diff -- src/c.ts',
+        'git diff -- src/d.ts',
+        'git diff -- src/e.ts',
+        'git diff -- src/f.ts',
+      ];
+
+      for (const command of commands) {
+        expect(
+          service.checkAlwaysOnSafeties(
+            createToolCallRequestEvent('run_shell_command', {
+              command,
+              description: 'Inspect repository changes',
+            }),
+          ),
+        ).toBe(false);
+      }
+      expect(loggers.logLoopDetected).not.toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          loop_type: 'shell_command_stagnation',
+        }),
+      );
+    });
+  });
+
   describe('Content Loop Detection', () => {
     const generateRandomString = (length: number) => {
       let result = '';

--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -307,6 +307,82 @@ describe('LoopDetectionService', () => {
       );
     });
 
+    it('resets the streak when a retry replays shell inspections', () => {
+      const variants = [
+        'git status --short',
+        'git diff --stat',
+        'git ls-files --modified',
+        'git status --porcelain=v1',
+        'git diff --name-only HEAD',
+        'git -C . status --short',
+        'git --no-pager diff --stat',
+      ];
+
+      for (const command of variants) {
+        expect(
+          service.checkAlwaysOnSafeties(
+            createToolCallRequestEvent('run_shell_command', {
+              command,
+              description: 'Inspect repository changes',
+            }),
+          ),
+        ).toBe(false);
+      }
+
+      expect(
+        service.checkAlwaysOnSafeties({
+          type: GeminiEventType.Retry,
+          value: {},
+        }),
+      ).toBe(false);
+
+      for (const command of variants) {
+        expect(
+          service.checkAlwaysOnSafeties(
+            createToolCallRequestEvent('run_shell_command', {
+              command,
+              description: 'Inspect repository changes',
+            }),
+          ),
+        ).toBe(false);
+      }
+      expect(service.getLastLoopType()).not.toBe(
+        LoopType.SHELL_COMMAND_STAGNATION,
+      );
+    });
+
+    it('honors an in-session disable for shell inspection stagnation', () => {
+      service.disableForSession();
+
+      const variants = [
+        'git status --short',
+        'git diff --stat',
+        'git ls-files --modified',
+        'git status --porcelain=v1',
+        'git diff --name-only HEAD',
+        'git -C . status --short',
+        'git --no-pager diff --stat',
+        'git ls-files --others',
+      ];
+
+      for (const command of variants) {
+        expect(
+          service.checkAlwaysOnSafeties(
+            createToolCallRequestEvent('run_shell_command', {
+              command,
+              description: 'Inspect repository changes',
+            }),
+          ),
+        ).toBe(false);
+      }
+      expect(loggers.logLoopDetected).not.toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          loop_type: 'shell_command_stagnation',
+        }),
+      );
+    });
+
     it('does not bucket compound commands that also write to the repository', () => {
       // Each chain stages and commits real work; the embedded `git status` must
       // not classify the whole command as stagnant read-only inspection. Vary
@@ -318,6 +394,22 @@ describe('LoopDetectionService', () => {
             createToolCallRequestEvent('run_shell_command', {
               command: `git add file-${i}.txt && git status --short && git commit -m progress-${i}`,
               description: 'Stage, inspect, and commit progress',
+            }),
+          ),
+        ).toBe(false);
+      }
+      expect(service.getLastLoopType()).not.toBe(
+        LoopType.SHELL_COMMAND_STAGNATION,
+      );
+    });
+
+    it('does not bucket shell chains that include non-git commands', () => {
+      for (let i = 0; i < SHELL_COMMAND_STAGNATION_THRESHOLD; i++) {
+        expect(
+          service.checkAlwaysOnSafeties(
+            createToolCallRequestEvent('run_shell_command', {
+              command: `git status --short && npm test -- --runInBand=${i}`,
+              description: 'Inspect repository changes and run tests',
             }),
           ),
         ).toBe(false);

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -50,6 +50,12 @@ const FILE_READ_WINDOW = 15;
 // Action stagnation tracking
 const STAGNATION_THRESHOLD = 8;
 
+// Similar shell inspection commands are precise enough to guard always-on
+// when the model keeps rewriting read-only repository checks instead of
+// making progress. Use the same threshold as the heuristic action-stagnation
+// guard to leave room for legitimate branch-review inspection.
+const SHELL_COMMAND_STAGNATION_THRESHOLD = STAGNATION_THRESHOLD;
+
 // Global tool call duplicate tracking: how many times the same (tool, args)
 // pair must appear across the entire turn (not necessarily consecutively)
 // before it is treated as a loop.
@@ -98,6 +104,12 @@ export class LoopDetectionService {
   // the model keeps calling one tool with varying arguments.
   private sameNameStreak = 0;
   private lastSeenToolName: string | null = null;
+
+  // Always-on shell inspection stagnation tracking. This is narrower than
+  // action stagnation: it only covers read-only git inspection commands that
+  // are semantically equivalent even when the shell text varies.
+  private lastShellInspectionKey: string | null = null;
+  private shellInspectionStreak = 0;
 
   // Cold-start gate for READ_FILE_LOOP: the opening exploration of a prompt
   // is almost always read-heavy (list + parallel reads). Until at least one
@@ -285,6 +297,14 @@ export class LoopDetectionService {
       return true;
     }
 
+    if (
+      !this.disabledForSession &&
+      this.checkShellCommandStagnation(event.value)
+    ) {
+      this.loopDetected = true;
+      return true;
+    }
+
     if (this.checkTurnToolCallCap()) {
       this.loopDetected = true;
       return true;
@@ -312,6 +332,60 @@ export class LoopDetectionService {
       return true;
     }
     return false;
+  }
+
+  private checkShellCommandStagnation(toolCall: {
+    name: string;
+    args: object;
+  }): boolean {
+    const key = this.getShellInspectionKey(toolCall);
+    if (!key) {
+      this.lastShellInspectionKey = null;
+      this.shellInspectionStreak = 0;
+      return false;
+    }
+
+    if (this.lastShellInspectionKey === key) {
+      this.shellInspectionStreak++;
+    } else {
+      this.lastShellInspectionKey = key;
+      this.shellInspectionStreak = 1;
+    }
+
+    if (this.shellInspectionStreak >= SHELL_COMMAND_STAGNATION_THRESHOLD) {
+      this.lastLoopType = LoopType.SHELL_COMMAND_STAGNATION;
+      logLoopDetected(
+        this.config,
+        new LoopDetectedEvent(LoopType.SHELL_COMMAND_STAGNATION, this.promptId),
+      );
+      return true;
+    }
+
+    return false;
+  }
+
+  private getShellInspectionKey(toolCall: {
+    name: string;
+    args: object;
+  }): string | null {
+    if (toolCall.name !== 'run_shell_command') {
+      return null;
+    }
+
+    const command = (toolCall.args as { command?: unknown }).command;
+    if (typeof command !== 'string') {
+      return null;
+    }
+
+    return this.isGitInspectionCommand(command)
+      ? 'run_shell_command:git-inspection'
+      : null;
+  }
+
+  private isGitInspectionCommand(command: string): boolean {
+    return /(?:^|[;&|]\s*)git(?:\s+(?:-C\s+\S+|--no-pager))*\s+(?:status|diff|ls-files)\b/i.test(
+      command,
+    );
   }
 
   /**
@@ -752,6 +826,8 @@ export class LoopDetectionService {
   private resetToolCallCount(): void {
     this.lastToolCallKey = null;
     this.toolCallRepetitionCount = 0;
+    this.lastShellInspectionKey = null;
+    this.shellInspectionStreak = 0;
   }
 
   private resetContentTracking(resetHistory = true): void {

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -250,9 +250,10 @@ export class LoopDetectionService {
 
   /**
    * Always-on safety checks that fire regardless of the `skipLoopDetection`
-   * config default. Enforces two guards: the consecutive-identical tool-call
-   * loop and the per-turn tool-call cap. Call this before the gated heuristic
-   * checks so neither guard can be bypassed by configuration.
+   * config default. Enforces three guards: the consecutive-identical tool-call
+   * loop, the shell inspection-command stagnation loop, and the per-turn
+   * tool-call cap. Call this before the gated heuristic checks so none of the
+   * guards can be bypassed by configuration.
    */
   checkAlwaysOnSafeties(event: ServerGeminiStreamEvent): boolean {
     if (this.loopDetected) {

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -384,8 +384,23 @@ export class LoopDetectionService {
   }
 
   private isGitInspectionCommand(command: string): boolean {
-    return /(?:^|[;&|]\s*)git(?:\s+(?:-C\s+\S+|--no-pager))*\s+(?:status|diff|ls-files)\b/i.test(
-      command,
+    // Only classify a command as read-only inspection when *every* segment of
+    // the shell chain is a git status/diff/ls-files. A chain that also stages,
+    // commits, or runs another tool (e.g. `git add . && git status`) is making
+    // progress, so it must not share the stagnation bucket and trip a false
+    // halt. Failing open (treating mixed chains as non-inspection) is the safe
+    // direction for an always-on guard.
+    const segments = command
+      .split(/&&|\|\||[;&|]/)
+      .map((segment) => segment.trim())
+      .filter(Boolean);
+    if (segments.length === 0) {
+      return false;
+    }
+    return segments.every((segment) =>
+      /^git(?:\s+(?:-C\s+\S+|--no-pager))*\s+(?:status|diff|ls-files)\b/i.test(
+        segment,
+      ),
     );
   }
 

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -227,7 +227,7 @@ export class LoopDetectionService {
         // to avoid firing on a duplicated replay — e.g. 3 identical calls +
         // Retry + 3 more would otherwise hit the global-duplicate threshold of
         // 6. The always-on guards reset their own counters in
-        // checkAlwaysOnSafeties' Retry branch (cap rollback + consecutive
+        // checkAlwaysOnSafeties' Retry branch (cap rollback + always-on
         // streak reset).
         this.globalToolCallCounts.clear();
         this.recentToolCallKeys = [];
@@ -404,8 +404,41 @@ export class LoopDetectionService {
       if (!match) {
         return false;
       }
-      return match[1]?.toLowerCase() !== 'diff' || !/\s--\s+\S/.test(segment);
+      return (
+        match[1]?.toLowerCase() !== 'diff' ||
+        this.isOverviewGitDiff(segment.slice(match[0].length))
+      );
     });
+  }
+
+  private isOverviewGitDiff(args: string): boolean {
+    const trimmedArgs = args.trim();
+    if (!trimmedArgs) {
+      return true;
+    }
+
+    const tokens = trimmedArgs.split(/\s+/);
+    const pathspecSeparatorIndex = tokens.indexOf('--');
+    if (
+      pathspecSeparatorIndex !== -1 &&
+      pathspecSeparatorIndex < tokens.length - 1
+    ) {
+      return false;
+    }
+
+    return tokens.every(
+      (token) => token.startsWith('-') || this.isGitRevisionToken(token),
+    );
+  }
+
+  private isGitRevisionToken(token: string): boolean {
+    return (
+      token === 'HEAD' ||
+      token === '@' ||
+      /^(?:HEAD|@)(?:[~^]\d*)+$/.test(token) ||
+      /^[0-9a-f]{7,40}$/i.test(token) ||
+      /^[^\s]+\.{2,3}[^\s]+$/.test(token)
+    );
   }
 
   /**

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -390,7 +390,7 @@ export class LoopDetectionService {
     // making progress, so it must not share the stagnation bucket and trip a
     // false halt. Failing open is the safe direction for an always-on guard.
     const segments = command
-      .split(/&&|\|\||[;&|]/)
+      .split(/&&|\|\||[;&|\n]/)
       .map((segment) => segment.trim())
       .filter(Boolean);
     if (segments.length === 0) {

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -178,12 +178,13 @@ export class LoopDetectionService {
 
   /**
    * Convenience aggregate that runs every tier in order: the always-on
-   * safeties (consecutive-identical guard + per-turn cap) followed by the
-   * opt-in heuristics. Intended as a single "check everything" entry point for
-   * unit tests. Production code (client.ts) intentionally calls the tiers
-   * separately so the `skipLoopDetection` gate can sit between them — a new
-   * guard added here will NOT take effect in production unless it is also
-   * wired into checkAlwaysOnSafeties or addAndCheckHeuristicLoops.
+   * safeties (consecutive-identical guard, shell inspection-command
+   * stagnation guard, and per-turn cap) followed by the opt-in heuristics.
+   * Intended as a single "check everything" entry point for unit tests.
+   * Production code (client.ts) intentionally calls the tiers separately so
+   * the `skipLoopDetection` gate can sit between them — a new guard added here
+   * will NOT take effect in production unless it is also wired into
+   * checkAlwaysOnSafeties or addAndCheckHeuristicLoops.
    * @param event - The stream event to process
    * @returns true if any tier detects a loop, false otherwise
    */

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -50,6 +50,12 @@ const FILE_READ_WINDOW = 15;
 // Action stagnation tracking
 const STAGNATION_THRESHOLD = 8;
 
+// Similar shell inspection commands are precise enough to guard always-on
+// when the model keeps rewriting overview-style repository checks instead of
+// making progress. Use the same threshold as the heuristic action-stagnation
+// guard to leave room for legitimate branch-review inspection.
+const SHELL_COMMAND_STAGNATION_THRESHOLD = STAGNATION_THRESHOLD;
+
 // Global tool call duplicate tracking: how many times the same (tool, args)
 // pair must appear across the entire turn (not necessarily consecutively)
 // before it is treated as a loop.
@@ -98,6 +104,12 @@ export class LoopDetectionService {
   // the model keeps calling one tool with varying arguments.
   private sameNameStreak = 0;
   private lastSeenToolName: string | null = null;
+
+  // Always-on shell inspection stagnation tracking. This is narrower than
+  // action stagnation: it only covers overview-style git inspection commands
+  // and excludes file-specific diffs that are normal during code review.
+  private lastShellInspectionKey: string | null = null;
+  private shellInspectionStreak = 0;
 
   // Cold-start gate for READ_FILE_LOOP: the opening exploration of a prompt
   // is almost always read-heavy (list + parallel reads). Until at least one
@@ -285,6 +297,14 @@ export class LoopDetectionService {
       return true;
     }
 
+    if (
+      !this.disabledForSession &&
+      this.checkShellCommandStagnation(event.value)
+    ) {
+      this.loopDetected = true;
+      return true;
+    }
+
     if (this.checkTurnToolCallCap()) {
       this.loopDetected = true;
       return true;
@@ -312,6 +332,84 @@ export class LoopDetectionService {
       return true;
     }
     return false;
+  }
+
+  private checkShellCommandStagnation(toolCall: {
+    name: string;
+    args: object;
+  }): boolean {
+    const key = this.getShellInspectionKey(toolCall);
+    if (!key) {
+      this.lastShellInspectionKey = null;
+      this.shellInspectionStreak = 0;
+      return false;
+    }
+
+    if (this.lastShellInspectionKey === key) {
+      this.shellInspectionStreak++;
+    } else {
+      this.lastShellInspectionKey = key;
+      this.shellInspectionStreak = 1;
+    }
+
+    if (this.shellInspectionStreak >= SHELL_COMMAND_STAGNATION_THRESHOLD) {
+      this.lastLoopType = LoopType.SHELL_COMMAND_STAGNATION;
+      logLoopDetected(
+        this.config,
+        new LoopDetectedEvent(LoopType.SHELL_COMMAND_STAGNATION, this.promptId),
+      );
+      return true;
+    }
+
+    return false;
+  }
+
+  private getShellInspectionKey(toolCall: {
+    name: string;
+    args: object;
+  }): string | null {
+    if (toolCall.name !== 'run_shell_command') {
+      return null;
+    }
+
+    const command = (toolCall.args as { command?: unknown }).command;
+    if (typeof command !== 'string') {
+      return null;
+    }
+
+    return this.isGitOverviewInspectionCommand(command)
+      ? 'run_shell_command:git-inspection'
+      : null;
+  }
+
+  private isGitOverviewInspectionCommand(command: string): boolean {
+    const segments = command
+      .split(/\s*(?:&&|\|\||[;|])\s*/)
+      .map((segment) => segment.trim())
+      .filter(Boolean);
+    let hasGitInspection = false;
+
+    for (const segment of segments) {
+      if (/^echo\b/i.test(segment)) {
+        continue;
+      }
+
+      const match =
+        /^git(?:\s+(?:-C\s+\S+|--no-pager))*\s+(status|diff|ls-files)\b/i.exec(
+          segment,
+        );
+      if (!match) {
+        return false;
+      }
+
+      if (match[1]?.toLowerCase() === 'diff' && /\s--\s+\S/.test(segment)) {
+        return false;
+      }
+
+      hasGitInspection = true;
+    }
+
+    return hasGitInspection;
   }
 
   /**
@@ -752,6 +850,8 @@ export class LoopDetectionService {
   private resetToolCallCount(): void {
     this.lastToolCallKey = null;
     this.toolCallRepetitionCount = 0;
+    this.lastShellInspectionKey = null;
+    this.shellInspectionStreak = 0;
   }
 
   private resetContentTracking(resetHistory = true): void {

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -435,6 +435,8 @@ export enum LoopType {
   REPETITIVE_THOUGHTS = 'repetitive_thoughts',
   READ_FILE_LOOP = 'read_file_loop',
   ACTION_STAGNATION = 'action_stagnation',
+  /** Similar read-only shell inspection commands repeat with varied args. */
+  SHELL_COMMAND_STAGNATION = 'shell_command_stagnation',
   /** Same (tool, args) pair appears N times across the entire turn, not necessarily consecutively. */
   GLOBAL_TOOL_CALL_DUPLICATE = 'global_tool_call_duplicate',
   /** Two tools alternating in a fixed pattern (A B A B A B ...). */


### PR DESCRIPTION
## What this PR does

Adds an always-on loop guard for repeated shell-based git overview inspection variants. When the model keeps calling `run_shell_command` with semantically similar read-only repository overview commands such as `git status`, overview-style `git diff`, or `git ls-files`, Qwen Code now halts the run with `shell_command_stagnation` before it can churn until the per-turn hard cap.

The guard intentionally fails open for broader shell activity: file-specific diffs such as `git diff -- src/file.ts` and `git diff src/file.ts` are not bucketed, compound commands that stage or commit work are not bucketed, and a non-inspection tool call resets the streak. This keeps the always-on detector narrow enough for a core loop-detection service while still covering the issue's repeated shell inspection pattern.

## Why it's needed

Issue #4695 reports a long-context DeepSeek-compatible session where the model repeatedly called shell tools while varying the command text, so the exact repeated-call guard did not catch the loop. The default `model.skipLoopDetection` setting can skip heuristic stagnation detection, leaving only the exact-call guard and the 100-tool hard cap. This change adds targeted always-on protection for the observed git inspection variant loop.

## Reviewer Test Plan

### How to verify

Ask an OpenAI-compatible endpoint to repeatedly return `run_shell_command` calls that vary between overview `git status`, `git diff`, and `git ls-files` inspections. The run should execute the first seven tool results, then halt on the eighth request with `shell_command_stagnation`; it should not continue until `--max-tool-calls` or the 100-call hard cap.

Also verify the negative cases: a legitimate sequence of file-specific `git diff -- <path>` review commands should not halt, compound shell commands that write to the repo should not be bucketed as read-only inspection, and any non-inspection tool call should reset the shell-inspection streak.

### Evidence (Before & After)

Before: the regression test failed because the eighth similar git inspection variant did not trip any always-on guard.

After: the regression tests pass, including the false-positive cases added during review, and a tmux-driven E2E run against the bundled CLI halted with `Loop detection halted the run (shell_command_stagnation: the model repeated similar shell inspection commands without making progress). This is an always-on guard and cannot be disabled via \`model.skipLoopDetection\`.`

Local verification after the final pushed commit:

- `cd packages/core && npx vitest run src/services/loopDetectionService.test.ts` passed: 72 tests.
- `cd packages/cli && npx vitest run src/nonInteractiveCli.test.ts` passed: 57 passed, 1 skipped.
- `npm run lint` passed.
- `npm run typecheck` passed.
- `npm run build` passed; existing vscode companion curly warnings and frontend bundle-size/browserslist warnings were present, with exit code 0.
- `npm run bundle` passed.
- tmux E2E passed: real bundled `dist/cli.js`, local fake OpenAI-compatible endpoint, 8 chat completion requests served, 7 tool uses emitted before halt, 7 tool results executed before halt, final loop type `shell_command_stagnation`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js local workspace build using `dist/cli.js`; tmux E2E used a temporary git repository under `/private/tmp` and a local fake OpenAI-compatible streaming endpoint to deterministically return the repeated tool-call sequence.

## Risk & Scope

- Main risk or tradeoff: Any always-on guard in `LoopDetectionService` affects all runs, so this is intentionally scoped to overview-style `run_shell_command` git inspections only. It excludes file-specific diffs, write-bearing compound chains, and interrupted streaks.
- Not validated / out of scope: Windows and Linux local runs were not performed; the tmux E2E used an OpenAI-compatible fake endpoint rather than a live DeepSeek endpoint so the tool-call sequence is deterministic.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #4695

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

新增一个 always-on 循环保护，用于拦截重复的 shell git 概览检查变体。当模型持续调用 `run_shell_command`，并在 `git status`、概览类 `git diff`、`git ls-files` 这类语义相近的只读仓库概览命令之间变换时，Qwen Code 现在会在达到 per-turn 硬上限前以 `shell_command_stagnation` 中止运行。

这个保护刻意 fail open：`git diff -- src/file.ts` 这类文件级 review 命令不入桶，包含 `git add` / `git commit` 等写操作的复合 shell 命令不入桶，夹杂非检查工具调用时也会重置 streak。这样可以在覆盖 issue 里的重复 shell 检查模式时，尽量降低 core loop detector 的误伤面。

## 为什么需要

#4695 报告了一个长上下文 DeepSeek-compatible 会话：模型不断调用 shell 工具，但会变换命令文本，因此完全相同工具调用保护无法命中。默认 `model.skipLoopDetection` 可能让启发式 stagnation 检测不运行，实际只剩完全相同调用保护和 100 次工具调用硬上限。这个改动为已观察到的 git 检查变体循环增加了一个有针对性的 always-on 保护。

## Reviewer Test Plan

### How to verify

让一个 OpenAI-compatible endpoint 连续返回在概览类 `git status`、`git diff`、`git ls-files` 之间变化的 `run_shell_command` 调用。运行应执行前七个工具结果，并在第八次请求时以 `shell_command_stagnation` 中止；不应继续跑到 `--max-tool-calls` 或 100 次硬上限。

同时验证负向场景：连续的文件级 `git diff -- <path>` review 命令不应中止，包含写入仓库行为的复合 shell 命令不应被当作只读检查入桶，非检查工具调用应重置 shell-inspection streak。

### Evidence (Before & After)

Before：新增回归测试失败，因为第八个相似 git 检查变体没有触发任何 always-on guard。

After：回归测试通过；复核时补充的误伤测试也通过；tmux 驱动的真实 bundle CLI E2E 运行以 `Loop detection halted the run (shell_command_stagnation: the model repeated similar shell inspection commands without making progress). This is an always-on guard and cannot be disabled via \`model.skipLoopDetection\`.` 中止。

最终推送 commit 后的本地验证：

- `cd packages/core && npx vitest run src/services/loopDetectionService.test.ts` 通过：72 个测试。
- `cd packages/cli && npx vitest run src/nonInteractiveCli.test.ts` 通过：57 个通过，1 个跳过。
- `npm run lint` 通过。
- `npm run typecheck` 通过。
- `npm run build` 通过；存在既有 vscode companion curly warnings 和前端 bundle-size/browserslist warnings，退出码为 0。
- `npm run bundle` 通过。
- tmux E2E 通过：使用真实打包后的 `dist/cli.js`、本地 fake OpenAI-compatible endpoint，服务端收到 8 次 chat completion 请求，中止前发出 7 次 tool use，真实执行 7 个 tool result，最终 loop type 为 `shell_command_stagnation`。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js 本地 workspace build，使用 `dist/cli.js`；tmux E2E 在 `/private/tmp` 下创建临时 git 仓库，并使用本地 fake OpenAI-compatible streaming endpoint 稳定返回重复工具调用序列。

## Risk & Scope

- Main risk or tradeoff：`LoopDetectionService` 的 always-on guard 会影响所有运行，所以这次刻意只覆盖 `run_shell_command` 里的概览类 git inspection。文件级 diff（包括 `git diff -- path` 和 `git diff path`）、带写操作的复合命令、被非检查工具打断的 streak 都被排除。
- Not validated / out of scope：未在 Windows 和 Linux 本地运行；tmux E2E 使用 OpenAI-compatible fake endpoint，而不是 live DeepSeek endpoint，以便稳定产生工具调用序列。
- Breaking changes / migration notes：无。

## Linked Issues

Fixes #4695

</details>




