### PR TITLE
fix(serve): reject non-positive sessionRecapAwayThresholdMinutes values

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -484,6 +484,7 @@ const SETTINGS_SCHEMA = {
         category: 'General',
         requiresRestart: false,
         default: 5,
+        minimum: 1,
         description:
           "How many minutes the terminal must be blurred before an auto-recap fires on the next focus-in. Matches Claude Code's default of 5 minutes; raise if you briefly alt-tab and do not want recaps to pile up.",
         showInDialog: true,

--- a/packages/cli/src/serve/routes/workspace-settings.test.ts
+++ b/packages/cli/src/serve/routes/workspace-settings.test.ts
@@ -80,4 +80,58 @@ describe('POST /workspace/settings', () => {
       undefined,
     );
   });
+
+  it('rejects non-positive general.sessionRecapAwayThresholdMinutes values', async () => {
+    const { app, persistSetting, broadcastSettingsChanged } = makeApp();
+
+    for (const value of [0, -1]) {
+      const res = await request(app).post('/workspace/settings').send({
+        scope: 'workspace',
+        key: 'general.sessionRecapAwayThresholdMinutes',
+        value,
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        code: 'invalid_value',
+        error: 'Value must be >= 1',
+      });
+    }
+
+    expect(persistSetting).not.toHaveBeenCalled();
+    expect(broadcastSettingsChanged).not.toHaveBeenCalled();
+  });
+
+  it.each([1, 5])(
+    'accepts general.sessionRecapAwayThresholdMinutes=%s',
+    async (value) => {
+      const { app, persistSetting, broadcastSettingsChanged } = makeApp();
+
+      const res = await request(app).post('/workspace/settings').send({
+        scope: 'workspace',
+        key: 'general.sessionRecapAwayThresholdMinutes',
+        value,
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        key: 'general.sessionRecapAwayThresholdMinutes',
+        scope: 'workspace',
+        value,
+        requiresRestart: false,
+      });
+      expect(persistSetting).toHaveBeenCalledWith(
+        '/workspace',
+        expect.any(String),
+        'general.sessionRecapAwayThresholdMinutes',
+        value,
+      );
+      expect(broadcastSettingsChanged).toHaveBeenCalledWith(
+        'general.sessionRecapAwayThresholdMinutes',
+        value,
+        'workspace',
+        undefined,
+      );
+    },
+  );
 });

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -96,7 +96,8 @@
         "sessionRecapAwayThresholdMinutes": {
           "description": "How many minutes the terminal must be blurred before an auto-recap fires on the next focus-in. Matches Claude Code's default of 5 minutes; raise if you briefly alt-tab and do not want recaps to pile up.",
           "type": "number",
-          "default": 5
+          "default": 5,
+          "minimum": 1
         },
         "cleanupPeriodDays": {
           "description": "Number of days to retain ~/.qwen/file-history/ session backups used by /rewind and background subagent transcripts under <projectDir>/subagents/. Data older than this is removed by a background housekeeping pass that runs at most once per day. Set to 0 for minimum retention (~1 hour) — protects sessions touched in the last hour, plus the currently active session.",


### PR DESCRIPTION
## What this PR does

Add a `minimum: 1` bound to the `general.sessionRecapAwayThresholdMinutes` setting so the workspace settings API rejects non-positive values instead of silently persisting them. A `POST /workspace/settings` request that sets the threshold to `0` or a negative number now returns `400 invalid_value` rather than `200`, and nothing is persisted or broadcast.

## Why it's needed

The away-threshold is a duration in minutes, so a value of `0` or below is meaningless and is effectively ignored at runtime — which means the value stored in settings silently diverges from the value that actually takes effect, and the user sees their setting "saved" while it does nothing. The ACP schema already constrains this field to `min: 1`, but the CLI settings schema had no lower bound, so the two schemas disagreed. This brings the CLI schema in line and mirrors #5906, which added a `minimum` bound to `cleanupPeriodDays` for the same class of issue.

## Reviewer Test Plan

### How to verify

```
npx vitest run packages/cli/src/serve/routes/workspace-settings.test.ts
```

New cases in `workspace-settings.test.ts`: a `POST /workspace/settings` with `general.sessionRecapAwayThresholdMinutes` set to `0` or `-1` returns `400 invalid_value` (`Value must be >= 1`) and calls neither `persistSetting` nor `broadcastSettingsChanged`; the same field set to `1` or `5` returns `200` and is persisted and broadcast. Expected: all 6 tests pass — non-positive values are rejected before any persistence, valid values are unchanged.

### Evidence (Before & After)

N/A — non–user-visible change (a settings-schema validation bound plus tests; no TUI surface).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   ⚠️   |

Ran the vitest suite above locally on Windows (6 passed); macOS and Linux are covered by CI.

### Environment (optional)

N/A — unit tests only.

## Risk & Scope

- Main risk or tradeoff: minimal — one schema bound plus tests, behavior is unchanged for valid (`>= 1`) values, and the default stays `5`.
- Not validated / out of scope: no change to the runtime consumption of the setting; this only tightens write-side validation so the persisted value can't drift from what runtime honors.
- Breaking changes / migration notes: none — a previously-accepted `0`/negative value was already a no-op at runtime, so such a request now fails fast instead of silently storing a dead value.

## Linked Issues

Fixes #5680

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

给 `general.sessionRecapAwayThresholdMinutes` 设置项加上 `minimum: 1` 约束，让 workspace settings API 拒绝非正数值，而不是默默把它存下来。现在 `POST /workspace/settings` 把该阈值设成 `0` 或负数会返回 `400 invalid_value`，不再是 `200`，也不会写入或广播。

## 为什么需要

这个 away 阈值以分钟为单位，`0` 或负数没有意义、运行时实际上会被忽略，于是存进设置里的值和真正生效的值悄悄对不上——用户以为设置"保存成功"了，实际不起任何作用。ACP schema 早已把该字段约束为 `min: 1`，但 CLI 的 settings schema 没有下界，两边 schema 不一致。这个改动让 CLI schema 对齐，和 #5906 给 `cleanupPeriodDays` 加 `minimum` 下界属于同一类问题。

## Reviewer Test Plan

### 如何验证

```
npx vitest run packages/cli/src/serve/routes/workspace-settings.test.ts
```

`workspace-settings.test.ts` 中的新用例：`POST /workspace/settings` 把 `general.sessionRecapAwayThresholdMinutes` 设为 `0` 或 `-1`，返回 `400 invalid_value`（`Value must be >= 1`），且 `persistSetting` 和 `broadcastSettingsChanged` 都不会被调用；同一字段设为 `1` 或 `5`，返回 `200`，正常写入并广播。预期：6 个测试全部通过——非正数在任何写入前就被拒绝，合法值行为不变。

### 证据（修改前后）

N/A —— 非用户可见改动（一个设置 schema 校验下界加测试，没有 TUI 层面变化）。

### 测试平台

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   ⚠️   |

本机在 Windows 上跑了上面的 vitest（6 个通过）；macOS 和 Linux 由 CI 覆盖。

### 运行环境（可选）

N/A —— 仅单元测试。

## 风险与范围

- 主要风险或权衡：极小——一个 schema 下界加测试，合法值（`>= 1`）行为不变，默认值仍是 `5`。
- 未验证/范围外：没有改运行时对该设置的消费逻辑；只收紧写入侧校验，让存下来的值不会和运行时实际生效的值漂移。
- 破坏性变更/迁移说明：无——之前能存进去的 `0`/负数本来在运行时就是空操作，现在这类请求会快速失败，而不是默默存一个无效值。

</details>
