### PR TITLE
fix(core): isolate Anthropic SDK abort listener leak with per-request child controllers

### DIFF
--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { getEventListeners } from 'node:events';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   CountTokensParameters,
@@ -1099,6 +1100,94 @@ describe('AnthropicContentGenerator', () => {
       ).rejects.toThrow('connect ECONNREFUSED <redacted>@proxy.local:8080');
     });
 
+    it('does not leak abort listeners onto the caller signal across non-streaming requests', async () => {
+      const { AnthropicContentGenerator } = await importGenerator();
+
+      // Reproduce the SDK leak (see the generateContentStream test): the client
+      // registers a non-removed 'abort' listener on whatever signal it gets.
+      anthropicState.createImpl.mockImplementation(
+        (_req: unknown, opts: { signal?: AbortSignal }) => {
+          opts.signal?.addEventListener('abort', () => {});
+          return {
+            id: 'anthropic-1',
+            model: 'claude-test',
+            content: [{ type: 'text', text: 'Hello' }],
+          };
+        },
+      );
+
+      const generator = new AnthropicContentGenerator(
+        {
+          model: 'claude-test',
+          apiKey: 'test-key',
+          timeout: 10_000,
+          maxRetries: 2,
+          samplingParams: { max_tokens: 100 },
+          schemaCompliance: 'auto',
+        },
+        mockConfig,
+      );
+
+      const callerAc = new AbortController();
+      for (let i = 0; i < 5; i++) {
+        await generator.generateContent({
+          model: 'models/ignored',
+          contents: 'Hello',
+          config: { abortSignal: callerAc.signal },
+        } as unknown as GenerateContentParameters);
+      }
+
+      expect(getEventListeners(callerAc.signal, 'abort')).toHaveLength(0);
+      const passedSignal = (
+        anthropicState.lastCreateArgs?.[1] as { signal?: AbortSignal }
+      )?.signal;
+      expect(passedSignal).toBeDefined();
+      expect(passedSignal).not.toBe(callerAc.signal);
+    });
+
+    it('propagates a caller abort to the per-request child signal', async () => {
+      const { AnthropicContentGenerator } = await importGenerator();
+
+      const callerAc = new AbortController();
+      let capturedSignal: AbortSignal | undefined;
+      anthropicState.createImpl.mockImplementation(
+        (_req: unknown, opts: { signal?: AbortSignal }) => {
+          capturedSignal = opts.signal;
+          // The caller aborts while the request is in flight.
+          callerAc.abort();
+          return {
+            id: 'anthropic-1',
+            model: 'claude-test',
+            content: [{ type: 'text', text: 'hi' }],
+          };
+        },
+      );
+
+      const generator = new AnthropicContentGenerator(
+        {
+          model: 'claude-test',
+          apiKey: 'test-key',
+          timeout: 10_000,
+          maxRetries: 2,
+          samplingParams: { max_tokens: 100 },
+          schemaCompliance: 'auto',
+        },
+        mockConfig,
+      );
+
+      await generator.generateContent({
+        model: 'models/ignored',
+        contents: 'Hello',
+        config: { abortSignal: callerAc.signal },
+      } as unknown as GenerateContentParameters);
+
+      // The SDK is handed a child, and the caller's abort still reaches it, so
+      // cancellation behaviour is preserved.
+      expect(capturedSignal).toBeDefined();
+      expect(capturedSignal).not.toBe(callerAc.signal);
+      expect(capturedSignal!.aborted).toBe(true);
+    });
+
     it('builds request with config sampling params (config overrides request) and thinking budget', async () => {
       const { AnthropicContentConverter } = await importConverter();
       const { AnthropicContentGenerator } = await importGenerator();
@@ -1161,7 +1250,11 @@ describe('AnthropicContentGenerator', () => {
       const [anthropicRequest, options] =
         anthropicState.lastCreateArgs as AnthropicCreateArgs;
 
-      expect(options?.signal).toBe(abortController.signal);
+      // The generator wraps the caller's signal in a per-request child to
+      // isolate the SDK's abort-listener leak, so the SDK sees the child rather
+      // than the caller's signal.
+      expect(options?.signal).toBeDefined();
+      expect(options?.signal).not.toBe(abortController.signal);
 
       expect(anthropicRequest).toEqual(
         expect.objectContaining({
@@ -2256,6 +2349,71 @@ describe('AnthropicContentGenerator', () => {
           contents: 'Hello',
         } as unknown as GenerateContentParameters),
       ).rejects.toThrow('407 via http://<redacted>@proxy.local');
+    });
+
+    it('does not leak abort listeners onto the caller signal across streamed requests', async () => {
+      const { AnthropicContentGenerator } = await importGenerator();
+
+      // Reproduce the Anthropic SDK's listener leak: core.mjs fetchWithTimeout
+      // registers an 'abort' listener on whatever signal it is handed and never
+      // removes it. Whichever signal the generator passes to the client is
+      // where that listener accumulates.
+      anthropicState.createImpl.mockImplementation(
+        (_req: unknown, opts: { signal?: AbortSignal }) => {
+          opts.signal?.addEventListener('abort', () => {});
+          return (async function* () {
+            yield {
+              type: 'content_block_start',
+              index: 0,
+              content_block: { type: 'text' },
+            };
+            yield {
+              type: 'content_block_delta',
+              index: 0,
+              delta: { type: 'text_delta', text: 'Hello' },
+            };
+            yield { type: 'content_block_stop', index: 0 };
+          })();
+        },
+      );
+
+      const generator = new AnthropicContentGenerator(
+        {
+          model: 'claude-test',
+          apiKey: 'test-key',
+          timeout: 10_000,
+          maxRetries: 2,
+          samplingParams: { max_tokens: 100 },
+          schemaCompliance: 'auto',
+        },
+        mockConfig,
+      );
+
+      // A single long-lived caller signal reused across many requests, as a
+      // session/turn-scoped AbortController would be.
+      const callerAc = new AbortController();
+
+      for (let i = 0; i < 5; i++) {
+        const stream = await generator.generateContentStream({
+          model: 'models/ignored',
+          contents: 'Hello',
+          config: { abortSignal: callerAc.signal },
+        } as unknown as GenerateContentParameters);
+        for await (const _chunk of stream) {
+          // drain
+        }
+      }
+
+      // The SDK's per-request listeners must land on short-lived child signals
+      // (aborted once the stream drains), not pile up on the caller's signal.
+      expect(getEventListeners(callerAc.signal, 'abort')).toHaveLength(0);
+
+      // And the generator must not hand the caller signal straight to the SDK.
+      const passedSignal = (
+        anthropicState.lastCreateArgs?.[1] as { signal?: AbortSignal }
+      )?.signal;
+      expect(passedSignal).toBeDefined();
+      expect(passedSignal).not.toBe(callerAc.signal);
     });
 
     it('redacts proxy credentials from stream iteration errors', async () => {

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -36,6 +36,7 @@ import {
 import { DEFAULT_TIMEOUT } from '../openaiContentGenerator/constants.js';
 import { createDebugLogger } from '../../utils/debugLogger.js';
 import { runtimeDiagnostics } from '../../utils/runtimeDiagnostics.js';
+import { createChildAbortController } from '../../utils/abortController.js';
 import {
   tokenLimit,
   hasExplicitOutputLimit,
@@ -225,16 +226,26 @@ export class AnthropicContentGenerator implements ContentGenerator {
     request: GenerateContentParameters,
   ): Promise<GenerateContentResponse> {
     let response: Message;
+    // Wrap the caller's signal in a per-request child for the same reason as
+    // generateContentStream: the Anthropic SDK leaks an abort listener onto
+    // whatever signal it is handed, so keep that on a short-lived signal rather
+    // than the caller's long-lived round signal.
+    const parentSignal = request.config?.abortSignal;
+    const perRequestAc = parentSignal
+      ? createChildAbortController(parentSignal)
+      : undefined;
     try {
       const anthropicRequest = await this.buildRequest(request);
       runtimeDiagnostics.recordAnthropicWireRequest(anthropicRequest);
       const headers = this.buildPerRequestHeaders(anthropicRequest);
       response = (await this.client.messages.create(anthropicRequest, {
-        signal: request.config?.abortSignal,
+        signal: perRequestAc?.signal,
         ...(headers ? { headers } : {}),
       })) as Message;
     } catch (error) {
       throw redactProxyError(error);
+    } finally {
+      perRequestAc?.abort();
     }
 
     return this.converter.convertAnthropicResponseToGemini(response);
@@ -253,25 +264,46 @@ export class AnthropicContentGenerator implements ContentGenerator {
     };
     runtimeDiagnostics.recordAnthropicWireRequest(streamingRequest);
 
+    // Wrap the caller's signal in a per-request child so the Anthropic SDK's
+    // leaked abort listener (core.mjs fetchWithTimeout registers one with no
+    // { once: true } and never removes it) lands on a short-lived signal
+    // instead of piling up on the caller's long-lived round signal. The
+    // OpenAI pipeline wraps its stream the same way for the identical leak.
+    const perRequestAc = createChildAbortController(
+      request.config?.abortSignal,
+    );
+
     let stream: AsyncIterable<RawMessageStreamEvent>;
     try {
       stream = (await this.client.messages.create(
         streamingRequest as MessageCreateParamsStreaming,
         {
-          signal: request.config?.abortSignal,
+          signal: perRequestAc.signal,
           ...(headers ? { headers } : {}),
         },
       )) as AsyncIterable<RawMessageStreamEvent>;
     } catch (error) {
+      perRequestAc.abort();
       throw redactProxyError(error);
     }
 
-    return this.processStreamWithEmptyFallback(
+    const inner = this.processStreamWithEmptyFallback(
       this.redactStreamErrors(stream),
       anthropicRequest,
-      request.config?.abortSignal,
+      perRequestAc.signal,
       headers,
     );
+    // Abort the child once the stream is fully drained or abandoned; this
+    // releases the SDK request and detaches the child's listener from the
+    // caller's signal.
+    async function* drainThenCleanup(): AsyncGenerator<GenerateContentResponse> {
+      try {
+        yield* inner;
+      } finally {
+        perRequestAc.abort();
+      }
+    }
+    return drainThenCleanup();
   }
 
   async countTokens(


### PR DESCRIPTION
## What this PR does

The Anthropic content generator now wraps the caller's abort signal in a per-request child controller before handing it to the SDK, on both the non-streaming (`generateContent`) and streaming (`generateContentStream`) paths, and aborts that child once the request completes or the stream is drained. This mirrors the per-request isolation that #4810 introduced for the OpenAI generator (`execute` and `executeStream`), applied to the Anthropic generator that was left out.

## Why it's needed

The Anthropic SDK's `fetchWithTimeout` (in `@anthropic-ai/sdk` `core.mjs`) registers an `'abort'` listener on the signal it is given and never removes it: it uses neither `{ once: true }` nor `removeEventListener`. Both Anthropic paths passed `request.config?.abortSignal` straight to `client.messages.create` (the streaming path also passes it to the empty-stream fallback probe). That signal is typically a long-lived session/turn-scoped `AbortController`, so every request left a dead listener behind and they accumulated over the life of the session, eventually tripping Node's `MaxListenersExceededWarning` and holding references the request no longer needs. This is the exact leak #4810 isolated for the OpenAI generator; the Anthropic generator has the identical SDK behavior and was simply not covered.

The fix wraps the caller's signal in a child via the existing `createChildAbortController` helper, passes the child to the SDK and the fallback probe, and aborts the child once the request is done (in a `finally` for the non-streaming path, and after the stream is consumed for the streaming path). The SDK's leaked listener then lands on a short-lived child instead of the caller's signal, and the child's own listener on the parent is removed on cleanup, so nothing accumulates on the long-lived signal. Parent-to-child abort propagation is preserved, so cancellation still works.

## Reviewer Test Plan

### How to verify

Run the core unit tests for the Anthropic generator:

`node_modules/.bin/vitest run packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts`

Three tests cover the change: `does not leak abort listeners onto the caller signal across streamed requests` and its non-streaming twin each drive five requests over one long-lived caller signal and assert that `getEventListeners(callerSignal, 'abort')` is empty afterward and that the signal passed to the SDK is not the caller's signal; `propagates a caller abort to the per-request child signal` confirms a caller abort still reaches the child, so cancellation is preserved.

Failing-first check: revert only the source change and these tests fail (the leak tests with `expected [...] to have a length of +0 but got 5`, one leaked listener per request); restore it and all 72 tests in the file pass.

### Evidence (Before & After)

N/A: non-user-visible change, covered by the unit tests above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

N/A: unit tests only.

## Risk & Scope

- Main risk or tradeoff: Very low. The change is confined to the signal plumbing in `generateContent` and `generateContentStream`; it reuses the same `createChildAbortController` helper and cleanup shape already proven on the OpenAI path. Abort propagation is unchanged (a parent abort still cancels the request).
- Not validated / out of scope: The other SDKs are untouched. The Anthropic SDK's leak itself is upstream and not addressed here; this isolates our usage from it, exactly as #4810 did for OpenAI.
- Breaking changes / migration notes: None.

## Linked Issues

Follows up #4810, which isolated the same SDK abort-listener leak for the OpenAI generator. No issue to close.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

Anthropic 内容生成器现在会先把调用方传入的 abort signal 包成一个 per-request 子控制器再交给 SDK，非流式（`generateContent`）和流式（`generateContentStream`）两条路径都是如此，并在请求结束或流被读完后 abort 这个子控制器。这与 #4810 给 OpenAI 生成器（`execute` 和 `executeStream`）引入的 per-request 隔离一致，补上了当时漏掉的 Anthropic 生成器。

## 为什么需要

Anthropic SDK 的 `fetchWithTimeout`（位于 `@anthropic-ai/sdk` 的 `core.mjs`）会在拿到的 signal 上注册一个 `'abort'` 监听器，却既不用 `{ once: true }` 也不 `removeEventListener`，永远不会移除它。Anthropic 的两条路径都把 `request.config?.abortSignal` 直接传给了 `client.messages.create`（流式路径还会传给空流回退探测）。而这个 signal 通常是一个会话/回合级、生命周期很长的 `AbortController`，于是每次请求都会在它上面留下一个死监听器，并随会话不断累积，最终触发 Node 的 `MaxListenersExceededWarning`，也会一直持有请求其实已不再需要的引用。这正是 #4810 给 OpenAI 生成器隔离掉的那个泄漏；Anthropic 生成器有完全相同的 SDK 行为，只是当时没被覆盖到。

修复用现有的 `createChildAbortController` helper 把调用方的 signal 包成子 signal，把子 signal 传给 SDK 和回退探测，并在请求完成后 abort 该子控制器（非流式在 `finally` 中、流式在流被消费完后）。这样 SDK 泄漏的监听器就落在一个短命的子 signal 上，而不是调用方的长寿 signal；同时子控制器注册在父 signal 上的那个监听器也会在清理时被移除，长寿 signal 上不再有任何累积。父到子的 abort 传播保持不变，取消功能照常工作。

## 复审测试计划

### 如何验证

运行 Anthropic 生成器的核心单测：

`node_modules/.bin/vitest run packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts`

三个测试覆盖了本改动：`does not leak abort listeners onto the caller signal across streamed requests` 及其非流式版本，各自在同一个长寿调用方 signal 上连发五次请求，然后断言事后 `getEventListeners(callerSignal, 'abort')` 为空、且传给 SDK 的 signal 不是调用方那个 signal；`propagates a caller abort to the per-request child signal` 确认调用方 abort 仍能传到子 signal，取消功能得以保留。

失败优先验证：只回退源码改动，这些测试就会失败（两个泄漏测试报 `expected [...] to have a length of +0 but got 5`，即每次请求泄漏一个监听器）；恢复改动后，该文件 72 个测试全部通过。

### 证据（前后对比）

N/A：非用户可见改动，由上面的单测覆盖。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

N/A：仅单元测试。

## 风险与范围

- 主要风险或权衡：非常低。改动仅限于 `generateContent` 和 `generateContentStream` 的 signal 传递，复用了已在 OpenAI 路径上验证过的同一个 `createChildAbortController` helper 和清理写法。abort 传播保持不变（父 abort 仍会取消请求）。
- 未验证 / 范围外：其它 SDK 未改动。Anthropic SDK 自身的泄漏属于上游、本 PR 不处理，本 PR 只是把我们的用法与它隔离开，正如 #4810 对 OpenAI 所做。
- 破坏性变更 / 迁移说明：无。

## 关联 issue

承接 #4810，本 PR 用同样的方式隔离 OpenAI 之外、Anthropic 生成器上的同一个 SDK abort 监听器泄漏。没有需要关闭的 issue。

</details>
