### PR TITLE
feat(web-shell): add 'voice' to ComposerToolbarAction for external visibility control

### DIFF
--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -40,7 +40,8 @@ export type ComposerToolbarAction =
   | 'model'
   | 'commands'
   | 'files'
-  | 'widthMode';
+  | 'widthMode'
+  | 'voice';
 
 interface ChatEditorProps {
   onSubmit: (
@@ -1535,15 +1536,17 @@ export const ChatEditor = memo(
                       </span>
                     </button>
                   )}
-                <VoiceButton
-                  disabled={disabled}
-                  onInsert={(text) => {
-                    const existing = core.getText();
-                    const sep = existing && !/\s$/.test(existing) ? ' ' : '';
-                    core.insertText(`${sep}${text} `);
-                    core.focus();
-                  }}
-                />
+                {showToolbarAction('voice') && (
+                  <VoiceButton
+                    disabled={disabled}
+                    onInsert={(text) => {
+                      const existing = core.getText();
+                      const sep = existing && !/\s$/.test(existing) ? ' ' : '';
+                      core.insertText(`${sep}${text} `);
+                      core.focus();
+                    }}
+                  />
+                )}
                 <button
                   className={
                     isRunning


### PR DESCRIPTION
## What this PR does

Adds `voice` as a new member of the `ComposerToolbarAction` union type and wraps the `VoiceButton` rendering with the existing `showToolbarAction()` gate. This allows external consumers of the web-shell component to control whether the voice dictation button is visible, using the same `composerToolbarActions` prop already used for other toolbar actions.

## Why it's needed

When embedding the web-shell as a component, external consumers currently have no way to hide the voice input button. The only existing visibility control is the daemon-side `voice_transcribe` capability check, which is not accessible from the embedding application. By adding `voice` to `ComposerToolbarAction`, consumers can now hide the voice button simply by omitting it from the `composerToolbarActions` array — consistent with how `approvalMode`, `model`, `commands`, `files`, and `widthMode` are already controlled.

## Reviewer Test Plan

### How to verify

1. Build the web-shell package: `npm run build`
2. Render `<WebShell />` without `composerToolbarActions` prop — voice button should still appear (backward compatible, default behavior unchanged)
3. Render `<WebShell composerToolbarActions={['approvalMode', 'model', 'commands', 'files']} />` — voice button should be hidden
4. Render `<WebShell composerToolbarActions={['voice']} />` — only voice button should appear in the toolbar area
5. Run VoiceButton unit tests: `cd packages/web-shell && npx vitest run client/voice/VoiceButton.test.tsx`

### Evidence (Before & After)

N/A — this is a programmatic API change; no visual difference unless the consumer explicitly excludes `voice`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

`npm run build` and `npx vitest run` on macOS.

## Risk & Scope

- Main risk or tradeoff: None — fully backward compatible. Omitting `composerToolbarActions` still shows all actions including voice.
- Not validated / out of scope: No changes to the daemon-side capability check.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在 `ComposerToolbarAction` 联合类型中新增 `voice` 成员，并用已有的 `showToolbarAction()` 门控包裹 `VoiceButton` 的渲染。这使得 web-shell 组件的外部消费者可以通过已有的 `composerToolbarActions` prop 来控制语音输入按钮的显隐。

## 为什么需要这个改动

当以组件形式嵌入 web-shell 时，外部消费者目前无法隐藏语音输入按钮。唯一的显隐控制是 daemon 端的 `voice_transcribe` capability 检查，嵌入方无法触达。将 `voice` 加入 `ComposerToolbarAction` 后，消费者只需在 `composerToolbarActions` 数组中省略它即可隐藏——与 `approvalMode`、`model`、`commands`、`files`、`widthMode` 的控制方式一致。

## 风险与范围

- 主要风险：无——完全向后兼容。不传 `composerToolbarActions` 时仍然显示所有操作按钮（包括语音）。
- 未验证/不在范围内：未修改 daemon 端的 capability 检查逻辑。
- 破坏性变更/迁移说明：无。

</details>
