### PR TITLE
fix(core): subtract reserved output tokens from context window for compression thresholds

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -3094,14 +3094,14 @@ describe('Gemini Client (client.ts)', () => {
 
       await client.tryCompressChat('p1', true, signal);
 
-      // 5th arg is the `options` bag for `customInstructions` plumbing;
-      // omitted here means undefined which is the correct contract.
+      // 5th arg is the `options` bag — always includes reservedOutputTokens
+      // now; no customInstructions when omitted by the caller.
       expect(tryCompress).toHaveBeenCalledWith(
         'p1',
         'the-model',
         true,
         signal,
-        undefined,
+        { reservedOutputTokens: expect.any(Number) },
       );
     });
 
@@ -3124,7 +3124,10 @@ describe('Gemini Client (client.ts)', () => {
         'the-model',
         true,
         undefined,
-        { customInstructions: 'focus on auth bug' },
+        {
+          customInstructions: 'focus on auth bug',
+          reservedOutputTokens: expect.any(Number),
+        },
       );
     });
 

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -37,6 +37,7 @@ import { buildContextUsage } from '../hooks/context-usage.js';
 import {
   DEFAULT_TOKEN_LIMIT,
   ESCALATED_MAX_TOKENS,
+  parsePositiveIntegerEnvValue,
   tokenLimit,
 } from './tokenLimits.js';
 
@@ -2717,7 +2718,11 @@ export class GeminiClient {
         cgConfig?.samplingParams?.max_tokens !== null) ||
       !!process.env['QWEN_CODE_MAX_OUTPUT_TOKENS'];
     const reservedOutputTokens: number = hasUserMaxTokensOverride
-      ? (cgConfig?.samplingParams?.max_tokens ?? 0)
+      ? (cgConfig?.samplingParams?.max_tokens ??
+        parsePositiveIntegerEnvValue(
+          process.env['QWEN_CODE_MAX_OUTPUT_TOKENS'],
+        ) ??
+        0)
       : Math.max(ESCALATED_MAX_TOKENS, tokenLimit(model, 'output'));
 
     const previousSessionStartContext = this.lastSessionStartContext;

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -2713,16 +2713,15 @@ export class GeminiClient {
     // the real available input budget (issue #5950).
     const cgConfig = this.config.getContentGeneratorConfig();
     const model = this.config.getModel();
+    const parsedEnvMaxTokens = parsePositiveIntegerEnvValue(
+      process.env['QWEN_CODE_MAX_OUTPUT_TOKENS'],
+    );
     const hasUserMaxTokensOverride =
       (cgConfig?.samplingParams?.max_tokens !== undefined &&
         cgConfig?.samplingParams?.max_tokens !== null) ||
-      !!process.env['QWEN_CODE_MAX_OUTPUT_TOKENS'];
+      parsedEnvMaxTokens !== undefined;
     const reservedOutputTokens: number = hasUserMaxTokensOverride
-      ? (cgConfig?.samplingParams?.max_tokens ??
-        parsePositiveIntegerEnvValue(
-          process.env['QWEN_CODE_MAX_OUTPUT_TOKENS'],
-        ) ??
-        0)
+      ? (cgConfig?.samplingParams?.max_tokens ?? parsedEnvMaxTokens ?? 0)
       : Math.max(ESCALATED_MAX_TOKENS, tokenLimit(model, 'output'));
 
     const previousSessionStartContext = this.lastSessionStartContext;

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -34,7 +34,11 @@ import {
 import { abortGoalForStopHookCap } from '../goals/goalHook.js';
 import { formatStopHookBlockingCapWarning } from '../hooks/stopHookCap.js';
 import { buildContextUsage } from '../hooks/context-usage.js';
-import { DEFAULT_TOKEN_LIMIT } from './tokenLimits.js';
+import {
+  DEFAULT_TOKEN_LIMIT,
+  ESCALATED_MAX_TOKENS,
+  tokenLimit,
+} from './tokenLimits.js';
 
 const debugLogger = createDebugLogger('CLIENT');
 
@@ -2703,14 +2707,30 @@ export class GeminiClient {
     signal?: AbortSignal,
     customInstructions?: string,
   ): Promise<ChatCompressionInfo> {
+    // Compute reservedOutputTokens using the same fallback logic as
+    // GeminiChat.sendMessageStream so the cheap-gate thresholds align with
+    // the real available input budget (issue #5950).
+    const cgConfig = this.config.getContentGeneratorConfig();
+    const model = this.config.getModel();
+    const hasUserMaxTokensOverride =
+      (cgConfig?.samplingParams?.max_tokens !== undefined &&
+        cgConfig?.samplingParams?.max_tokens !== null) ||
+      !!process.env['QWEN_CODE_MAX_OUTPUT_TOKENS'];
+    const reservedOutputTokens: number = hasUserMaxTokensOverride
+      ? (cgConfig?.samplingParams?.max_tokens ?? 0)
+      : Math.max(ESCALATED_MAX_TOKENS, tokenLimit(model, 'output'));
+
     const previousSessionStartContext = this.lastSessionStartContext;
     const previousSessionStartSource = this.lastSessionStartSource;
     const info = await this.getChat().tryCompress(
       prompt_id,
-      this.config.getModel(),
+      model,
       force,
       signal,
-      customInstructions ? { customInstructions } : undefined,
+      {
+        ...(customInstructions ? { customInstructions } : undefined),
+        reservedOutputTokens,
+      },
     );
     if (info.compressionStatus === CompressionStatus.COMPRESSED) {
       const chat = this.getChat();

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -3855,6 +3855,69 @@ describe('GeminiChat', async () => {
       // service cheap-gate.
       expect(compressSpy.mock.calls[0][1].reservedOutputTokens).toBe(65_536);
     });
+
+    it('sources reservedOutputTokens from QWEN_CODE_MAX_OUTPUT_TOKENS env var when no config override is present', async () => {
+      // When QWEN_CODE_MAX_OUTPUT_TOKENS is set (32000) and there is no
+      // samplingParams.max_tokens nor params.config.maxOutputTokens, the env
+      // var value becomes effectiveReservedOutput.
+      // With 200K window: contextLimit = 200000 - 32000 = 168000
+      // computeThresholds(168000): effectiveWindow = 148000, hard = 145000
+      // Without the fix (raw 200K): hard = 177000, and 150K would NOT exceed.
+      // Setting lastPromptTokenCount to 150000 triggers hard-rescue ONLY when
+      // the env var budget is correctly subtracted.
+      process.env['QWEN_CODE_MAX_OUTPUT_TOKENS'] = '32000';
+      try {
+        vi.mocked(mockConfig.getContentGeneratorConfig).mockReturnValue({
+          authType: AuthType.USE_GEMINI,
+          model: 'test-model',
+          contextWindowSize: 200_000,
+        });
+
+        const compressSpy = vi
+          .spyOn(ChatCompressionService.prototype, 'compress')
+          .mockResolvedValueOnce({
+            newHistory: [
+              { role: 'user', parts: [{ text: 'summary' }] },
+              { role: 'model', parts: [{ text: 'ack' }] },
+            ],
+            info: {
+              originalTokenCount: 150_000,
+              newTokenCount: 40_000,
+              compressionStatus: CompressionStatus.COMPRESSED,
+            },
+          });
+        vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+          makeStreamResponse('after env-var rescue'),
+        );
+
+        const chatInstance = new GeminiChat(
+          mockConfig,
+          config,
+          [],
+          undefined,
+          uiTelemetryService,
+        );
+        chatInstance.setLastPromptTokenCount(150_000);
+
+        const stream = await chatInstance.sendMessageStream(
+          'test-model',
+          { message: 'hi' },
+          'prompt-env-var-output-budget',
+        );
+        for await (const _ of stream) {
+          /* consume */
+        }
+
+        // Compression must have been triggered with force=true (hard-rescue)
+        // proving that the adjusted threshold (145000) was used, not the raw
+        // threshold (177K) which 150K would NOT exceed.
+        expect(compressSpy).toHaveBeenCalledTimes(1);
+        expect(compressSpy.mock.calls[0][1].force).toBe(true);
+        expect(compressSpy.mock.calls[0][1].reservedOutputTokens).toBe(32_000);
+      } finally {
+        delete process.env['QWEN_CODE_MAX_OUTPUT_TOKENS'];
+      }
+    });
   });
 
   describe('addHistory', () => {

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1973,7 +1973,7 @@ describe('GeminiChat', async () => {
       vi.mocked(mockConfig.getContentGeneratorConfig).mockReturnValue({
         authType: AuthType.USE_GEMINI,
         model: 'test-model',
-        contextWindowSize: 200_000,
+        contextWindowSize: 264_000,
       });
       const subagentChat = new GeminiChat(mockConfig, config, [
         { role: 'user', parts: [{ text: 'inherited' }] },
@@ -2711,7 +2711,9 @@ describe('GeminiChat', async () => {
     }
 
     /**
-     * Default 200K window in our mocks; computeThresholds:
+     * 264K raw window in our mocks. With effectiveReservedOutput = 64K
+     * (max(ESCALATED_MAX_TOKENS, tokenLimit('test-model','output'))):
+     *   contextLimit    = 264K - 64K = 200K
      *   effectiveWindow = 200K - 20K (SUMMARY_RESERVE) = 180K
      *   hard            = max(180K - 3K, auto) = 177K
      * So lastPromptTokenCount=176K + a small user message tips over 177K.
@@ -2720,7 +2722,7 @@ describe('GeminiChat', async () => {
       vi.mocked(mockConfig.getContentGeneratorConfig).mockReturnValue({
         authType: AuthType.USE_GEMINI,
         model: 'test-model',
-        contextWindowSize: 200_000,
+        contextWindowSize: 264_000,
       });
     });
 
@@ -3789,6 +3791,69 @@ describe('GeminiChat', async () => {
 
       expect(compressSpy).toHaveBeenCalledTimes(1);
       expect(compressSpy.mock.calls[0][1].force).toBe(false);
+    });
+
+    it('sources reservedOutputTokens from model output limit when params.config.maxOutputTokens is absent (issue #5950)', async () => {
+      // Use claude-sonnet-4-6 which has a 65536 output limit in tokenLimits.ts.
+      // ESCALATED_MAX_TOKENS is 64000, so effectiveReservedOutput =
+      // max(64000, 65536) = 65536.
+      // With 200K window: contextLimit = 200000 - 65536 = 134464
+      // computeThresholds(134464): effectiveWindow = 114464, hard = 111464
+      // Without the fix: contextLimit = 200000, hard = 177000
+      // Setting lastPromptTokenCount to 112000 should trigger hard-rescue
+      // ONLY when the output budget is correctly reserved.
+      vi.mocked(mockConfig.getContentGeneratorConfig).mockReturnValue({
+        authType: AuthType.USE_GEMINI,
+        model: 'claude-sonnet-4-6',
+        contextWindowSize: 200_000,
+      });
+
+      const compressSpy = vi
+        .spyOn(ChatCompressionService.prototype, 'compress')
+        .mockResolvedValueOnce({
+          newHistory: [
+            { role: 'user', parts: [{ text: 'summary' }] },
+            { role: 'model', parts: [{ text: 'ack' }] },
+          ],
+          info: {
+            originalTokenCount: 112_000,
+            newTokenCount: 40_000,
+            compressionStatus: CompressionStatus.COMPRESSED,
+          },
+        });
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        makeStreamResponse('after output-budget rescue'),
+      );
+
+      const chatInstance = new GeminiChat(
+        mockConfig,
+        config,
+        [],
+        undefined,
+        uiTelemetryService,
+      );
+      chatInstance.setLastPromptTokenCount(112_000);
+
+      // Do NOT pass params.config.maxOutputTokens — exercises the real
+      // sourcing path where effectiveReservedOutput is computed from
+      // tokenLimit(model, 'output') / ESCALATED_MAX_TOKENS.
+      const stream = await chatInstance.sendMessageStream(
+        'claude-sonnet-4-6',
+        { message: 'hi' },
+        'prompt-output-budget-sourcing',
+      );
+      for await (const _ of stream) {
+        /* consume */
+      }
+
+      // Compression must have been triggered with force=true (hard-rescue)
+      // proving that the adjusted threshold (111464) was used, not the raw
+      // threshold (177K) which 112K would NOT exceed.
+      expect(compressSpy).toHaveBeenCalledTimes(1);
+      expect(compressSpy.mock.calls[0][1].force).toBe(true);
+      // Also verify reservedOutputTokens was threaded to the compression
+      // service cheap-gate.
+      expect(compressSpy.mock.calls[0][1].reservedOutputTokens).toBe(65_536);
     });
   });
 

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -1765,17 +1765,18 @@ export class GeminiChat {
     // Pre-reserving that space prevents the dead zone between the adjusted
     // auto threshold and an unadjusted hard threshold (issue #5950).
     const cgConfigForThresholds = this.config.getContentGeneratorConfig();
+    const parsedEnvMaxTokensForThreshold = parsePositiveIntegerEnvValue(
+      process.env['QWEN_CODE_MAX_OUTPUT_TOKENS'],
+    );
     const hasUserMaxTokensOverrideForThreshold =
       (cgConfigForThresholds?.samplingParams?.max_tokens !== undefined &&
         cgConfigForThresholds?.samplingParams?.max_tokens !== null) ||
-      !!process.env['QWEN_CODE_MAX_OUTPUT_TOKENS'];
+      parsedEnvMaxTokensForThreshold !== undefined;
     const effectiveReservedOutput: number =
       params.config?.maxOutputTokens ??
       (hasUserMaxTokensOverrideForThreshold
         ? (cgConfigForThresholds?.samplingParams?.max_tokens ??
-          parsePositiveIntegerEnvValue(
-            process.env['QWEN_CODE_MAX_OUTPUT_TOKENS'],
-          ) ??
+          parsedEnvMaxTokensForThreshold ??
           0)
         : Math.max(ESCALATED_MAX_TOKENS, tokenLimit(model, 'output')));
 
@@ -2032,10 +2033,13 @@ export class GeminiChat {
         // Max output tokens escalation: when no user/env override is set and
         // the model hits MAX_TOKENS, retry once with the escalated limit.
         let maxTokensEscalated = false;
+        const parsedEnvMaxTokens = parsePositiveIntegerEnvValue(
+          process.env['QWEN_CODE_MAX_OUTPUT_TOKENS'],
+        );
         const hasUserMaxTokensOverride =
           (cgConfig?.samplingParams?.max_tokens !== undefined &&
             cgConfig?.samplingParams?.max_tokens !== null) ||
-          !!process.env['QWEN_CODE_MAX_OUTPUT_TOKENS'];
+          parsedEnvMaxTokens !== undefined;
 
         let lastFinishReason: string | undefined;
 

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -292,6 +292,12 @@ interface TryCompressOptions {
    * on the user's stated concern.
    */
   customInstructions?: string;
+  /**
+   * Output tokens reserved by the model (e.g. max_tokens / escalated limit).
+   * Threaded to the compression service so the cheap-gate computes
+   * thresholds against the real available input budget.
+   */
+  reservedOutputTokens?: number;
 }
 
 const INVALID_CONTENT_RETRY_OPTIONS: ContentRetryOptions = {
@@ -1552,6 +1558,7 @@ export class GeminiChat {
       precomputedEffectiveTokens: options?.precomputedEffectiveTokens,
       trigger: options?.trigger,
       customInstructions: options?.customInstructions,
+      reservedOutputTokens: options?.reservedOutputTokens,
       signal,
     });
 
@@ -1746,6 +1753,27 @@ export class GeminiChat {
     let compressionInfo: ChatCompressionInfo;
     let requestContents: Content[];
     let userContentAdded = false;
+
+    // Compute the output budget the model can actually use. Declared at
+    // function level so the reactive-compression path inside the generator
+    // closure can also access it.
+    //
+    // The subagent path sets params.config.maxOutputTokens explicitly; the
+    // interactive path leaves it undefined but will escalate to
+    // max(ESCALATED_MAX_TOKENS, tokenLimit(model, 'output')) on MAX_TOKENS.
+    // Pre-reserving that space prevents the dead zone between the adjusted
+    // auto threshold and an unadjusted hard threshold (issue #5950).
+    const cgConfigForThresholds = this.config.getContentGeneratorConfig();
+    const hasUserMaxTokensOverrideForThreshold =
+      (cgConfigForThresholds?.samplingParams?.max_tokens !== undefined &&
+        cgConfigForThresholds?.samplingParams?.max_tokens !== null) ||
+      !!process.env['QWEN_CODE_MAX_OUTPUT_TOKENS'];
+    const effectiveReservedOutput: number =
+      params.config?.maxOutputTokens ??
+      (hasUserMaxTokensOverrideForThreshold
+        ? (cgConfigForThresholds?.samplingParams?.max_tokens ?? 0)
+        : Math.max(ESCALATED_MAX_TOKENS, tokenLimit(model, 'output')));
+
     try {
       // The send-lock above is held but the generator's `finally` (which
       // resolves it) has not run yet. Any setup error before returning the
@@ -1774,9 +1802,12 @@ export class GeminiChat {
       // force=true already bypasses that breaker, while hard-rescue itself is
       // bounded by hardRescueFailureCount so persistent pre-send rescue
       // failures fall through to reactive overflow after a few strikes.
-      const contextLimit =
-        this.config.getContentGeneratorConfig()?.contextWindowSize ??
-        DEFAULT_TOKEN_LIMIT;
+      const rawContextLimit =
+        cgConfigForThresholds?.contextWindowSize ?? DEFAULT_TOKEN_LIMIT;
+      const contextLimit = Math.max(
+        0,
+        rawContextLimit - effectiveReservedOutput,
+      );
       const { hard } = computeThresholds(
         contextLimit,
         this.config.getAutoCompactThreshold(),
@@ -1844,6 +1875,7 @@ export class GeminiChat {
             // classified correctly while the pending user message preserves
             // any active tool-call / response pairing.
             trigger: shouldForceFromHard ? 'auto' : undefined,
+            reservedOutputTokens: effectiveReservedOutput,
           },
         );
       }
@@ -2233,6 +2265,7 @@ export class GeminiChat {
                     {
                       originalTokenCountOverride: reactiveOriginalTokenCount,
                       trigger: 'auto',
+                      reservedOutputTokens: effectiveReservedOutput,
                     },
                   );
 

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -33,6 +33,7 @@ import type { Config } from '../config/config.js';
 import {
   DEFAULT_TOKEN_LIMIT,
   ESCALATED_MAX_TOKENS,
+  parsePositiveIntegerEnvValue,
   tokenLimit,
 } from './tokenLimits.js';
 import { hasCycleInSchema } from '../tools/tools.js';
@@ -1771,7 +1772,11 @@ export class GeminiChat {
     const effectiveReservedOutput: number =
       params.config?.maxOutputTokens ??
       (hasUserMaxTokensOverrideForThreshold
-        ? (cgConfigForThresholds?.samplingParams?.max_tokens ?? 0)
+        ? (cgConfigForThresholds?.samplingParams?.max_tokens ??
+          parsePositiveIntegerEnvValue(
+            process.env['QWEN_CODE_MAX_OUTPUT_TOKENS'],
+          ) ??
+          0)
         : Math.max(ESCALATED_MAX_TOKENS, tokenLimit(model, 'output')));
 
     try {

--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -2452,6 +2452,134 @@ describe('ChatCompressionService.compress cheap-gate uses computeThresholds.auto
   });
 });
 
+describe('ChatCompressionService.compress cheap-gate respects reservedOutputTokens', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function makeFakeChat(): GeminiChat {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'msg1' }] },
+      { role: 'model', parts: [{ text: 'msg2' }] },
+    ];
+    const getHistoryMock = vi.fn().mockReturnValue(history);
+    return {
+      getHistory: getHistoryMock,
+      getHistoryShallow: getHistoryMock,
+    } as unknown as GeminiChat;
+  }
+
+  function makeFakeConfig(opts: { contextWindowSize: number }): Config {
+    return {
+      getChatCompression: vi.fn(),
+      getAutoCompactThreshold: vi.fn(),
+      getBaseLlmClient: vi.fn(),
+      getContentGeneratorConfig: vi
+        .fn()
+        .mockReturnValue({ contextWindowSize: opts.contextWindowSize }),
+      getHookSystem: vi.fn().mockReturnValue({
+        fireSessionStartEvent: vi.fn().mockResolvedValue(undefined),
+        firePreCompactEvent: vi.fn().mockResolvedValue(undefined),
+        firePostCompactEvent: vi.fn().mockResolvedValue(undefined),
+      }),
+      getModel: () => 'test-model',
+      getApprovalMode: () => 'default',
+      getDebugLogger: () => ({ warn: vi.fn(), debug: vi.fn() }),
+      getTargetDir: () => '/tmp/test-workspace',
+    } as unknown as Config;
+  }
+
+  it('without reservedOutputTokens, 131K window NOOPs at 90K (auto ≈ 98K)', async () => {
+    const spy = vi
+      .spyOn(sideQueryModule, 'runSideQuery')
+      .mockResolvedValue({ text: 's', usage: {} } as never);
+
+    const result = await new ChatCompressionService().compress(makeFakeChat(), {
+      promptId: 'p',
+      force: false,
+      model: 'qwen-test',
+      config: makeFakeConfig({ contextWindowSize: 131_072 }),
+      consecutiveFailures: 0,
+      originalTokenCount: 90_000,
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(result.info.compressionStatus).toBe(CompressionStatus.NOOP);
+  });
+
+  it('with 64K reservedOutputTokens, 131K window triggers compression at 60K input', async () => {
+    // Without reservation: computeThresholds(131072).auto ≈ 98K → 60K < 98K → NOOP
+    // With 64K reservation: computeThresholds(131072 - 64000 = 67072).auto ≈ 47K → 60K > 47K → triggers
+    const spy = vi.spyOn(sideQueryModule, 'runSideQuery').mockResolvedValue({
+      text: '<state_snapshot>summary</state_snapshot>',
+      usage: {
+        promptTokenCount: 1000,
+        candidatesTokenCount: 500,
+        totalTokenCount: 1500,
+      },
+    } as never);
+
+    const result = await new ChatCompressionService().compress(makeFakeChat(), {
+      promptId: 'p',
+      force: false,
+      model: 'qwen-test',
+      config: makeFakeConfig({ contextWindowSize: 131_072 }),
+      consecutiveFailures: 0,
+      originalTokenCount: 60_000,
+      reservedOutputTokens: 64_000,
+    });
+
+    expect(spy).toHaveBeenCalled();
+    expect(result.info.compressionStatus).not.toBe(CompressionStatus.NOOP);
+  });
+
+  it('without reservedOutputTokens, behavior is unchanged (backward compat)', async () => {
+    const spy = vi
+      .spyOn(sideQueryModule, 'runSideQuery')
+      .mockResolvedValue({ text: 's', usage: {} } as never);
+
+    // computeThresholds(200_000).auto ≈ 167K; 160K < 167K → NOOP
+    const result = await new ChatCompressionService().compress(makeFakeChat(), {
+      promptId: 'p',
+      force: false,
+      model: 'qwen-test',
+      config: makeFakeConfig({ contextWindowSize: 200_000 }),
+      consecutiveFailures: 0,
+      originalTokenCount: 160_000,
+      // reservedOutputTokens is not provided
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(result.info.compressionStatus).toBe(CompressionStatus.NOOP);
+  });
+
+  it('reservedOutputTokens >= contextWindowSize clamps to zero (no crash)', async () => {
+    const spy = vi.spyOn(sideQueryModule, 'runSideQuery').mockResolvedValue({
+      text: '<state_snapshot>summary</state_snapshot>',
+      usage: {
+        promptTokenCount: 1000,
+        candidatesTokenCount: 500,
+        totalTokenCount: 1500,
+      },
+    } as never);
+
+    // reservedOutputTokens == contextWindowSize → effective window = 0
+    // computeThresholds(0).auto ≈ 0 → any tokens > 0 triggers compression
+    const result = await new ChatCompressionService().compress(makeFakeChat(), {
+      promptId: 'p',
+      force: false,
+      model: 'qwen-test',
+      config: makeFakeConfig({ contextWindowSize: 131_072 }),
+      consecutiveFailures: 0,
+      originalTokenCount: 1000,
+      reservedOutputTokens: 131_072,
+    });
+
+    expect(spy).toHaveBeenCalled();
+    expect(result.info.compressionStatus).not.toBe(CompressionStatus.NOOP);
+  });
+});
+
 describe('ChatCompressionService.compress — single-turn computer-use regression', () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -19,6 +19,7 @@ import { runSideQuery } from '../utils/sideQuery.js';
 import { logChatCompression } from '../telemetry/loggers.js';
 import { makeChatCompressionEvent } from '../telemetry/types.js';
 import { PreCompactTrigger, PostCompactTrigger } from '../hooks/types.js';
+import { createDebugLogger } from '../utils/debugLogger.js';
 import {
   estimateContentChars,
   resolveCompactionTuning,
@@ -38,6 +39,8 @@ import {
   stripAnalysisBlock,
   type SubagentSnapshot,
 } from './postCompactAttachments.js';
+
+const debugLogger = createDebugLogger('COMPRESSION');
 
 /**
  * Hard cap on the compression sideQuery output (summary text only, since
@@ -359,8 +362,10 @@ export class ChatCompressionService {
       const rawContextLimit =
         config.getContentGeneratorConfig()?.contextWindowSize ??
         DEFAULT_TOKEN_LIMIT;
-      const contextLimit =
-        Math.max(0, rawContextLimit - (opts.reservedOutputTokens ?? 0));
+      const contextLimit = Math.max(
+        0,
+        rawContextLimit - (opts.reservedOutputTokens ?? 0),
+      );
       const { auto } = computeThresholds(
         contextLimit,
         config.getAutoCompactThreshold(),
@@ -399,6 +404,12 @@ export class ChatCompressionService {
           countToolResponseImages(chat.getHistoryShallow(true)) >=
             tuning.screenshotTriggerThreshold;
         if (!screenshotOverflow) {
+          debugLogger.debug(
+            `[compaction] cheap-gate NOOP: effectiveTokens=${effectiveTokens}, ` +
+              `auto=${auto}, contextLimit=${contextLimit}, ` +
+              `rawContextLimit=${rawContextLimit}, ` +
+              `reservedOutputTokens=${opts.reservedOutputTokens ?? 0}`,
+          );
           return {
             newHistory: null,
             info: {

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -246,6 +246,13 @@ export interface CompressOptions {
    * first, hook text last (matches claude-code mergeHookInstructions).
    */
   customInstructions?: string;
+  /**
+   * Output tokens reserved by the model (e.g. max_tokens / escalated limit).
+   * When provided, the cheap-gate subtracts this from the context window
+   * before computing thresholds so auto-compression fires based on the
+   * real available input budget rather than the full window.
+   */
+  reservedOutputTokens?: number;
 }
 
 /**
@@ -349,9 +356,11 @@ export class ChatCompressionService {
     }
 
     if (!force) {
-      const contextLimit =
+      const rawContextLimit =
         config.getContentGeneratorConfig()?.contextWindowSize ??
         DEFAULT_TOKEN_LIMIT;
+      const contextLimit =
+        Math.max(0, rawContextLimit - (opts.reservedOutputTokens ?? 0));
       const { auto } = computeThresholds(
         contextLimit,
         config.getAutoCompactThreshold(),


### PR DESCRIPTION
## Summary

When `max_tokens` escalates to 64K (`ESCALATED_MAX_TOKENS`), the effective input budget drops to ~67K, but `computeThresholds()` was still called with the full 131K context window. This caused auto-compression to never fire before the API rejected the request with a 400 error (`requested about 135349 tokens`).

## Changes

- **`chatCompressionService.ts`**: Added optional `reservedOutputTokens` to `CompressOptions`. The cheap-gate now subtracts this from the context window before computing thresholds: `Math.max(0, rawContextLimit - reservedOutputTokens)`.
- **`geminiChat.ts`**: Added `reservedOutputTokens` to `TryCompressOptions`, threaded it through `tryCompress()`, and sourced it from `params.config?.maxOutputTokens` (or fallback to env var / model output limit) in `sendMessageStream()`.
- **`client.ts`**: Threaded `reservedOutputTokens` through `tryCompressChat()` for the ACP path.

The fix is backward compatible — when `reservedOutputTokens` is not provided, behavior is unchanged.

## Behavior Change (intentional)

The interactive path now reserves `max(ESCALATED_MAX_TOKENS, tokenLimit(model, 'output'))` on **every turn** (not only after escalation). On a 131K-context model with no user `max_tokens` override, auto-compaction now fires at ~47K input instead of ~98K (effective input window 67K vs 131K).

This is the **correct safety tradeoff** — it guarantees no 400 regardless of when output escalation happens. Without it, the first escalated turn after a long session would hit the API limit before compression had a chance to fire.

## Validation

- 4 new tests in `chatCompressionService.test.ts` (cheap-gate reservation)
- Hard-tier rescue test in `geminiChat.test.ts` (output-budget sourcing from model limit)
- Env-var sourcing test in `geminiChat.test.ts` (QWEN_CODE_MAX_OUTPUT_TOKENS)
- Client delegation tests updated in `client.test.ts`
- All existing + new tests pass (`npx vitest run`)
- `eslint` + `prettier` clean on all changed files
- Mutation-tested: 4/4 key mutations caught by the test suite

## Scope & Risk

- **3 files, ~160 lines added** (mostly tests)
- **Intentional earlier compaction for interactive sessions** — sessions now compact at ~47K input (vs ~98K previously) to prevent 400 errors when output escalation is in effect. This is a net improvement: shorter prompts compress faster and the model never hits the context ceiling.
- Forced compression (`force=true`) bypasses the cheap-gate entirely, so the budget adjustment only affects auto-compression decisions

Closes #5950