### PR TITLE
ci: allow longer PR review timeout retries

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -319,7 +319,7 @@ jobs:
          startsWith(github.event.review.body, '@qwen-code /review ') ||
          startsWith(github.event.review.body, format('@qwen-code /review{0}', '\n'))) &&
         needs.authorize.outputs.should_review == 'true'))
-    timeout-minutes: 120
+    timeout-minutes: 200
     runs-on: ['self-hosted', 'linux', 'x64', 'ecs-qwen']
     permissions:
       contents: 'read'
@@ -370,11 +370,14 @@ jobs:
           TRIGGER_BODY: "${{ github.event.comment.body || github.event.review.body || '' }}"
         run: |-
           set -euo pipefail
+          DEFAULT_TIMEOUT_MINUTES=120
+          TIMEOUT_MINUTES="$DEFAULT_TIMEOUT_MINUTES"
           TRIGGER_COMMAND="${TRIGGER_BODY%%$'\n'*}"
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             PR_NUMBER="${{ github.event.inputs.pr_number }}"
             REVIEW_MODE="${{ github.event.inputs.review_mode }}"
+            TIMEOUT_MINUTES="${{ github.event.inputs.timeout_minutes || '120' }}"
           elif [ "${{ github.event_name }}" = "issue_comment" ]; then
             if ! printf '%s\n' "$TRIGGER_COMMAND" | grep -Eq '^@qwen-code[[:space:]]+/review([[:space:]]|$)'; then
               echo "should_run=false" >> "$GITHUB_OUTPUT"
@@ -397,7 +400,20 @@ jobs:
             exit 1
           fi
 
-          TIMEOUT_MINUTES="${{ github.event.inputs.timeout_minutes || '120' }}"
+          if [ -n "$TRIGGER_COMMAND" ]; then
+            set -f
+            for token in $TRIGGER_COMMAND; do
+              case "$token" in
+                --timeout=*)
+                  TIMEOUT_MINUTES="${token#--timeout=}"
+                  ;;
+                timeout=*)
+                  TIMEOUT_MINUTES="${token#timeout=}"
+                  ;;
+              esac
+            done
+            set +f
+          fi
 
           {
             echo "should_run=true"
@@ -426,8 +442,12 @@ jobs:
           fail() {
             local message="$1"
             local code="${2:-1}"
+            local kind="${3:-}"
             echo "$message" >&2
             echo "failure_reason=$message" >> "$GITHUB_OUTPUT"
+            if [ -n "$kind" ]; then
+              echo "failure_kind=$kind" >> "$GITHUB_OUTPUT"
+            fi
             echo "$message" >> "$GITHUB_STEP_SUMMARY"
             exit "$code"
           }
@@ -524,11 +544,14 @@ jobs:
               fail "Invalid timeout_minutes: ${TIMEOUT_MINUTES}"
               ;;
           esac
+          if [ "${#TIMEOUT_MINUTES}" -gt 3 ]; then
+            fail "Invalid timeout_minutes: ${TIMEOUT_MINUTES}"
+          fi
           if [ "$TIMEOUT_MINUTES" -le 5 ]; then
             fail "timeout_minutes must be greater than 5"
           fi
-          if [ "$TIMEOUT_MINUTES" -gt 120 ]; then
-            fail "timeout_minutes must not exceed the 120 minute job timeout"
+          if [ "$TIMEOUT_MINUTES" -gt 180 ]; then
+            fail "timeout_minutes must not exceed 180 minutes"
           fi
 
           if ! PR_STATE="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state --jq '.state')"; then
@@ -549,7 +572,7 @@ jobs:
             MODEL_ARGS=(--model "$OPENAI_MODEL")
           fi
 
-          QWEN_TIMEOUT=$((TIMEOUT_MINUTES - 5))
+          QWEN_TIMEOUT="$TIMEOUT_MINUTES"
           set +e
           # GNU timeout times out command children unless --foreground is used.
           timeout --kill-after=10s "${QWEN_TIMEOUT}m" qwen \
@@ -567,8 +590,9 @@ jobs:
           if [ "$tee_status" -ne 0 ]; then
             fail "Failed to write qwen review log."
           fi
-          if [ "$qwen_status" -eq 124 ]; then
-            fail "Qwen review timed out after ${QWEN_TIMEOUT} minutes."
+          # GNU timeout may report 137 if --kill-after escalates to SIGKILL.
+          if [ "$qwen_status" -eq 124 ] || [ "$qwen_status" -eq 137 ]; then
+            fail "Qwen review timed out after ${QWEN_TIMEOUT} minutes." 1 "timeout"
           fi
           if [ "$qwen_status" -ne 0 ]; then
             fail "Qwen review exited with status ${qwen_status}."
@@ -609,13 +633,24 @@ jobs:
           steps.context.outputs.pr_number != ''
         env:
           GH_TOKEN: '${{ secrets.CI_BOT_PAT }}'
+          FAILURE_KIND: "${{ steps.review.outputs.failure_kind || '' }}"
           FAILURE_REASON: "${{ steps.review.outputs.failure_reason || 'Run review failed. See workflow logs for details.' }}"
           PR_NUMBER: '${{ steps.context.outputs.pr_number }}'
           RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          TIMEOUT_MINUTES: '${{ steps.context.outputs.timeout_minutes }}'
         run: |-
+          if [ "$FAILURE_KIND" = "timeout" ]; then
+            if [ "$TIMEOUT_MINUTES" -lt 180 ]; then
+              body="**Qwen Code review timed out.** ${FAILURE_REASON} For large PRs, retry with a longer timeout by commenting: \`@qwen-code /review --timeout=180\`. See [workflow logs](${RUN_URL})."
+            else
+              body="**Qwen Code review timed out.** ${FAILURE_REASON} This run already used the maximum 180 minute timeout. See [workflow logs](${RUN_URL})."
+            fi
+          else
+            body="**Qwen Code review did not complete successfully.** ${FAILURE_REASON} See [workflow logs](${RUN_URL})."
+          fi
           gh pr comment "$PR_NUMBER" \
             --repo "$GITHUB_REPOSITORY" \
-            --body "_Qwen Code review did not complete successfully: ${FAILURE_REASON} See [workflow logs](${RUN_URL})._"
+            --body "$body"
 
   resolve-pr:
     needs: ['authorize']

--- a/scripts/tests/qwen-resolve-workflow.test.js
+++ b/scripts/tests/qwen-resolve-workflow.test.js
@@ -125,6 +125,44 @@ describe('qwen resolve workflow', () => {
     expect(agentStep).toContain("QWEN_HOME: '${{ runner.temp }}/qwen-home'");
   });
 
+  it('allows maintainers to extend review timeout from /review comments', () => {
+    const contextStep = step(reviewJob, 'Resolve PR context');
+    const runStep = step(reviewJob, 'Run review');
+
+    expect(reviewJob).toContain('timeout-minutes: 200');
+    expect(contextStep).toContain('DEFAULT_TIMEOUT_MINUTES=120');
+    expect(contextStep).toContain('case "$token" in');
+    expect(contextStep).toContain('--timeout=*)');
+    expect(contextStep).toContain('TIMEOUT_MINUTES="${token#--timeout=}"');
+    expect(contextStep).toContain('timeout=*)');
+    expect(contextStep).toContain('TIMEOUT_MINUTES="${token#timeout=}"');
+    expect(runStep).toContain('if [ "${#TIMEOUT_MINUTES}" -gt 3 ]; then');
+    expect(runStep).toContain('timeout_minutes must not exceed 180 minutes');
+    expect(runStep).toContain('QWEN_TIMEOUT="$TIMEOUT_MINUTES"');
+    expect(runStep).not.toContain('QWEN_TIMEOUT=$((TIMEOUT_MINUTES - 5))');
+  });
+
+  it('tells maintainers how to retry timed-out reviews with more time', () => {
+    const runStep = step(reviewJob, 'Run review');
+    const fallbackStep = step(reviewJob, 'Post fallback comment on failure');
+
+    expect(runStep).toContain('failure_kind=$kind');
+    expect(runStep).toContain(
+      'fail "Qwen review timed out after ${QWEN_TIMEOUT} minutes." 1 "timeout"',
+    );
+    expect(runStep).toContain('[ "$qwen_status" -eq 137 ]');
+    expect(fallbackStep).toContain('FAILURE_KIND:');
+    expect(fallbackStep).toContain('TIMEOUT_MINUTES:');
+    expect(fallbackStep).toContain('@qwen-code /review --timeout=180');
+    expect(fallbackStep).toContain(
+      'This run already used the maximum 180 minute timeout.',
+    );
+    expect(fallbackStep).toContain('**Qwen Code review timed out.**');
+    expect(fallbackStep).not.toContain(
+      '_Qwen Code review did not complete successfully:',
+    );
+  });
+
   // Whole-file `toContain` cannot tell which job a guard lives on. Slice the
   // resolve-pr job so these assertions fail if a future edit drops a guard
   // specifically from the credentialed conflict-resolution path. Bound the slice


### PR DESCRIPTION
## What this PR does

Adds an explicit timeout override for maintainer-triggered `@qwen-code /review` comments. Maintainers can now retry a large PR review with `@qwen-code /review --timeout=180` or `@qwen-code /review timeout=180`, while the default review timeout stays at 120 minutes.

When a review times out, the fallback PR comment now uses a clearer bold heading and tells maintainers exactly how to rerun the review with a longer timeout. Non-timeout failures still get a generic failure comment without suggesting that more time will help.

## Why it's needed

Large PRs can exceed the normal review budget. The current fallback only says the review timed out, which leaves maintainers to infer the next action. This keeps automatic reviews bounded by default while giving maintainers an explicit, auditable way to spend more runner time when a large PR is worth another pass.

## Reviewer Test Plan

### How to verify

Comment `@qwen-code /review --timeout=180` on an open PR and confirm the review step accepts `timeout_minutes=180`, giving Qwen 180 minutes while the GitHub Actions job is capped at 200 minutes to leave fallback-comment time. To verify fallback behavior, force the review step to hit the timeout path and confirm the PR comment includes `@qwen-code /review --timeout=180`.

### Evidence (Before & After)

Before: timed-out reviews posted a generic italic fallback comment with no retry command. After: timed-out reviews post a bold timeout heading and include the longer-timeout retry command.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

`npx vitest run scripts/tests/qwen-resolve-workflow.test.js --config scripts/tests/vitest.config.ts` passed. `npx prettier --check scripts/tests/qwen-resolve-workflow.test.js` passed. `git diff --check` passed. Local `actionlint .github/workflows/qwen-code-pr-review.yml` still reports the existing `environment.deployment: false` key on current main, so it was not used as a passing signal for this change.

### Manual timeout verification

A workflow_dispatch dry-run was dispatched on PR head SHA `885309cdfa59c797e13d192775c7cbc5e3a35b9d` with `timeout_minutes=121`: https://github.com/QwenLM/qwen-code/actions/runs/28325897701. Result: the run completed `Resolve PR context` and reached `review-pr / Run review`, staying in the actual review step for more than 8 minutes instead of failing the previous 120-minute timeout validation. This verifies that the manual timeout override path accepts a maintainer-provided value above the default 120 minutes; the full dry-run conclusion remains available in the linked run.


## Risk & Scope

- Main risk or tradeoff: maintainers can intentionally occupy the review runner longer when they request `--timeout=180`.
- Not validated / out of scope: automatically sizing review time from PR line counts.
- Breaking changes / migration notes: none.

## Linked Issues

- Related PR: #5777
- Related PR: #5959

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

为 maintainer 通过 `@qwen-code /review` 评论触发的评审增加显式超时参数。现在可以用 `@qwen-code /review --timeout=180` 或 `@qwen-code /review timeout=180` 重新触发大 PR 评审，默认 review 超时时间仍保持 120 分钟。

当评审超时时，fallback PR 评论会使用更清晰的加粗标题，并明确告诉 maintainer 如何用更长超时时间重新触发。非超时失败仍然只显示通用失败信息，不误导用户以为增加时间一定有帮助。

## 为什么需要

大 PR 可能超过默认评审预算。现有 fallback 只说明评审超时，maintainer 需要自己推断下一步怎么做。这个改动保持自动评审默认受限，同时给 maintainer 一个明确、可审计的方式，在确实值得重跑的大 PR 上投入更多 runner 时间。

## Reviewer Test Plan

### 如何验证

在打开的 PR 上评论 `@qwen-code /review --timeout=180`，确认 review step 接受 `timeout_minutes=180`，也就是 Qwen 可以跑 180 分钟，同时 GitHub Actions job 上限是 200 分钟，保留 fallback 评论收尾时间。要验证 fallback 行为，可以强制 review step 进入 timeout 路径，并确认 PR 评论包含 `@qwen-code /review --timeout=180`。

### 证据（Before & After）

Before：评审超时后只发布一条通用斜体 fallback 评论，没有重跑命令。After：评审超时后发布加粗 timeout 标题，并包含更长超时时间的重跑命令。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### 环境

`npx vitest run scripts/tests/qwen-resolve-workflow.test.js --config scripts/tests/vitest.config.ts` 通过。`npx prettier --check scripts/tests/qwen-resolve-workflow.test.js` 通过。`git diff --check` 通过。本地 `actionlint .github/workflows/qwen-code-pr-review.yml` 仍会报告当前 main 已存在的 `environment.deployment: false` key，因此没有把它作为本次变更的通过信号。

### 手动 timeout 验证

已在 PR head SHA `885309cdfa59c797e13d192775c7cbc5e3a35b9d` 上 dispatch 一次 workflow_dispatch dry-run，传入 `timeout_minutes=121`：https://github.com/QwenLM/qwen-code/actions/runs/28325897701。结果：run 已成功完成 `Resolve PR context` 并进入 `review-pr / Run review`，在真实 review step 中持续运行超过 8 分钟，而不是被旧的 120 分钟上限校验挡掉。这验证了手动 timeout override 路径可以接受高于默认 120 分钟的 maintainer 指定值；完整 dry-run conclusion 可在链接的 workflow run 中查看。


## 风险和范围

- 主要风险或取舍：maintainer 显式请求 `--timeout=180` 时，review runner 会被占用更久。
- 未验证 / 不在范围内：根据 PR 行数自动调整评审时间。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

- 相关 PR：#5777
- 相关 PR：#5959

</details>


