### PR TITLE
feat(core): add --insecure flag to skip TLS verification for self-signed endpoints (#3535)

### DIFF
--- a/docs/users/support/troubleshooting.md
+++ b/docs/users/support/troubleshooting.md
@@ -20,6 +20,12 @@ This guide provides solutions to common issues and debugging tips, including top
   - **Solution:** Set the `NODE_EXTRA_CA_CERTS` environment variable to the absolute path of your corporate root CA certificate file.
     - Example: `export NODE_EXTRA_CA_CERTS=/path/to/your/corporate-ca.crt`
 
+- **Error: `Connection error. (cause: fetch failed)` against a self-signed endpoint**
+  - **Cause:** You are pointing Qwen Code at a self-hosted server (for example a local model behind `https://`) whose TLS certificate is self-signed, so Node.js rejects it.
+  - **Solution:** Prefer trusting the certificate via `NODE_EXTRA_CA_CERTS` (above). If that is not practical in a trusted lab/private network, skip verification with the `--insecure` flag (or `QWEN_TLS_INSECURE=1`):
+    - Example: `qwen --insecure --openaiBaseUrl https://192.168.1.10:8080 ...`
+    - **Warning:** Disabling verification removes protection against man-in-the-middle attacks. Only use it for endpoints you fully trust.
+
 - **Error: `Device authorization flow failed: fetch failed`**
   - **Cause:** Node.js could not reach Qwen OAuth endpoints (often a proxy or SSL/TLS trust issue). When available, Qwen Code will also print the underlying error cause (for example: `UNABLE_TO_VERIFY_LEAF_SIGNATURE`). Note: this error is specific to the legacy Qwen OAuth flow.
   - **Solution:**

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -969,6 +969,34 @@ describe('loadCliConfig', () => {
     expect(config.getPreventSystemSleepEnabled()).toBe(true);
   });
 
+  describe('--insecure flag', () => {
+    let savedInsecure: string | undefined;
+
+    beforeEach(() => {
+      savedInsecure = process.env['QWEN_TLS_INSECURE'];
+      delete process.env['QWEN_TLS_INSECURE'];
+    });
+
+    afterEach(() => {
+      if (savedInsecure === undefined) delete process.env['QWEN_TLS_INSECURE'];
+      else process.env['QWEN_TLS_INSECURE'] = savedInsecure;
+    });
+
+    it('sets QWEN_TLS_INSECURE=1 when --insecure is passed', async () => {
+      process.argv = ['node', 'script.js', '--insecure'];
+      const argv = await parseArguments();
+      await loadCliConfig({}, argv);
+      expect(process.env['QWEN_TLS_INSECURE']).toBe('1');
+    });
+
+    it('leaves QWEN_TLS_INSECURE unset without --insecure', async () => {
+      process.argv = ['node', 'script.js'];
+      const argv = await parseArguments();
+      await loadCliConfig({}, argv);
+      expect(process.env['QWEN_TLS_INSECURE']).toBeUndefined();
+    });
+  });
+
   it('should propagate runtime sleep prevention setting', async () => {
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments();

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -971,17 +971,19 @@ describe('loadCliConfig', () => {
 
   describe('--insecure flag', () => {
     const savedEnv: Record<string, string | undefined> = {};
+    let errorSpy: ReturnType<typeof vi.spyOn>;
 
     beforeEach(() => {
       for (const key of ['QWEN_TLS_INSECURE', 'NODE_TLS_REJECT_UNAUTHORIZED']) {
         savedEnv[key] = process.env[key];
         delete process.env[key];
       }
-      // Silence the intentional MITM warning loadCliConfig emits.
-      vi.spyOn(console, 'error').mockImplementation(() => {});
+      // Silence (and capture) the intentional MITM warning loadCliConfig emits.
+      errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     });
 
     afterEach(() => {
+      errorSpy.mockRestore();
       for (const [key, value] of Object.entries(savedEnv)) {
         if (value === undefined) delete process.env[key];
         else process.env[key] = value;
@@ -994,6 +996,7 @@ describe('loadCliConfig', () => {
       await loadCliConfig({}, argv);
       expect(process.env['QWEN_TLS_INSECURE']).toBe('1');
       expect(process.env['NODE_TLS_REJECT_UNAUTHORIZED']).toBe('0');
+      expect(errorSpy).toHaveBeenCalled();
     });
 
     it('leaves TLS env vars unset without --insecure', async () => {
@@ -1002,6 +1005,25 @@ describe('loadCliConfig', () => {
       await loadCliConfig({}, argv);
       expect(process.env['QWEN_TLS_INSECURE']).toBeUndefined();
       expect(process.env['NODE_TLS_REJECT_UNAUTHORIZED']).toBeUndefined();
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it('propagates a pre-set QWEN_TLS_INSECURE to NODE_TLS_REJECT_UNAUTHORIZED=0', async () => {
+      process.env['QWEN_TLS_INSECURE'] = '1';
+      process.argv = ['node', 'script.js'];
+      const argv = await parseArguments();
+      await loadCliConfig({}, argv);
+      expect(process.env['NODE_TLS_REJECT_UNAUTHORIZED']).toBe('0');
+      expect(errorSpy).toHaveBeenCalled();
+    });
+
+    it('skips re-assignment and warning when NODE_TLS_REJECT_UNAUTHORIZED is already 0', async () => {
+      process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
+      process.argv = ['node', 'script.js', '--insecure'];
+      const argv = await parseArguments();
+      await loadCliConfig({}, argv);
+      expect(process.env['NODE_TLS_REJECT_UNAUTHORIZED']).toBe('0');
+      expect(errorSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -281,6 +281,16 @@ describe('parseArguments', () => {
     expect(argv.prompt).toBeUndefined();
   });
 
+  it('parses --insecure as a boolean flag (default false)', async () => {
+    process.argv = ['node', 'script.js'];
+    const defaultArgv = await parseArguments();
+    expect(defaultArgv.insecure).toBe(false);
+
+    process.argv = ['node', 'script.js', '--insecure'];
+    const argv = await parseArguments();
+    expect(argv.insecure).toBe(true);
+  });
+
   it('rejects --json-schema combined with --acp', async () => {
     // ACP runs an independent turn loop (runAcpAgent) that doesn't honour
     // the synthetic structured_output terminal contract. The yargs check

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -970,30 +970,38 @@ describe('loadCliConfig', () => {
   });
 
   describe('--insecure flag', () => {
-    let savedInsecure: string | undefined;
+    const savedEnv: Record<string, string | undefined> = {};
 
     beforeEach(() => {
-      savedInsecure = process.env['QWEN_TLS_INSECURE'];
-      delete process.env['QWEN_TLS_INSECURE'];
+      for (const key of ['QWEN_TLS_INSECURE', 'NODE_TLS_REJECT_UNAUTHORIZED']) {
+        savedEnv[key] = process.env[key];
+        delete process.env[key];
+      }
+      // Silence the intentional MITM warning loadCliConfig emits.
+      vi.spyOn(console, 'error').mockImplementation(() => {});
     });
 
     afterEach(() => {
-      if (savedInsecure === undefined) delete process.env['QWEN_TLS_INSECURE'];
-      else process.env['QWEN_TLS_INSECURE'] = savedInsecure;
+      for (const [key, value] of Object.entries(savedEnv)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
     });
 
-    it('sets QWEN_TLS_INSECURE=1 when --insecure is passed', async () => {
+    it('sets QWEN_TLS_INSECURE=1 and NODE_TLS_REJECT_UNAUTHORIZED=0 when --insecure is passed', async () => {
       process.argv = ['node', 'script.js', '--insecure'];
       const argv = await parseArguments();
       await loadCliConfig({}, argv);
       expect(process.env['QWEN_TLS_INSECURE']).toBe('1');
+      expect(process.env['NODE_TLS_REJECT_UNAUTHORIZED']).toBe('0');
     });
 
-    it('leaves QWEN_TLS_INSECURE unset without --insecure', async () => {
+    it('leaves TLS env vars unset without --insecure', async () => {
       process.argv = ['node', 'script.js'];
       const argv = await parseArguments();
       await loadCliConfig({}, argv);
       expect(process.env['QWEN_TLS_INSECURE']).toBeUndefined();
+      expect(process.env['NODE_TLS_REJECT_UNAUTHORIZED']).toBeUndefined();
     });
   });
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1423,10 +1423,15 @@ export async function loadCliConfig(
     process.env['NODE_TLS_REJECT_UNAUTHORIZED'] !== '0'
   ) {
     process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
+    // The setting is process-wide, so the blast radius is every outbound HTTPS
+    // connection (model API, OAuth, MCP servers, and child processes that
+    // inherit the env), not just model calls. Log to the debug file too, so the
+    // state is discoverable after the terminal scrollback is gone.
+    const tlsWarning =
+      'TLS certificate verification is disabled (--insecure / QWEN_TLS_INSECURE). All HTTPS connections in this process (API calls, OAuth, MCP servers, child processes) are vulnerable to man-in-the-middle attacks.';
+    debugLogger.warn(tlsWarning);
     // eslint-disable-next-line no-console
-    console.error(
-      'WARNING: TLS certificate verification is disabled (--insecure / QWEN_TLS_INSECURE). API connections are vulnerable to man-in-the-middle attacks.',
-    );
+    console.error(`WARNING: ${tlsWarning}`);
   }
 
   // Set runtime output directory from settings (env var QWEN_RUNTIME_DIR

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -31,6 +31,7 @@ import {
   NativeLspService,
   isBareMode,
   isToolEnabled,
+  isTlsVerificationDisabled,
   SchemaValidator,
   type ConfigParameters,
   type MCPServerConfig,
@@ -1410,6 +1411,22 @@ export async function loadCliConfig(
   // with QWEN_TLS_INSECURE / NODE_TLS_REJECT_UNAUTHORIZED=0.
   if (argv.insecure) {
     process.env['QWEN_TLS_INSECURE'] = '1';
+  }
+  // When opting out of TLS verification, also set NODE_TLS_REJECT_UNAUTHORIZED
+  // process-wide. The custom undici dispatcher handles the Node path, but this
+  // makes the opt-out effective on runtimes/paths it does not cover (the Bun
+  // runtime, and the proxy-creation fallback that uses the built-in fetch), and
+  // surfaces a single explicit warning. Skipped when the user already set it,
+  // since Node emits its own warning in that case.
+  if (
+    isTlsVerificationDisabled() &&
+    process.env['NODE_TLS_REJECT_UNAUTHORIZED'] !== '0'
+  ) {
+    process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
+    // eslint-disable-next-line no-console
+    console.error(
+      'WARNING: TLS certificate verification is disabled (--insecure / QWEN_TLS_INSECURE). API connections are vulnerable to man-in-the-middle attacks.',
+    );
   }
 
   // Set runtime output directory from settings (env var QWEN_RUNTIME_DIR

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -165,6 +165,7 @@ export interface CliArgs {
   openaiBaseUrl: string | undefined;
   openaiLoggingDir: string | undefined;
   proxy: string | undefined;
+  insecure?: boolean | undefined;
   includeDirectories: string[] | undefined;
   screenReader: boolean | undefined;
   inputFormat?: string | undefined;
@@ -620,6 +621,12 @@ export async function parseArguments(): Promise<CliArgs> {
       'proxy',
       'Use the "proxy" setting in settings.json instead. This flag will be removed in a future version.',
     )
+    .option('insecure', {
+      type: 'boolean',
+      description:
+        'Skip TLS certificate verification for API connections (for self-signed certs in trusted/lab environments). Equivalent to setting QWEN_TLS_INSECURE=1. WARNING: removes protection against man-in-the-middle attacks.',
+      default: false,
+    })
     .option('chat-recording', {
       type: 'boolean',
       description:
@@ -1396,6 +1403,14 @@ export async function loadCliConfig(
 ): Promise<Config> {
   const debugMode = isDebugMode(argv);
   const bareMode = isBareMode(argv.bare);
+
+  // Surface `--insecure` as an env var so it reaches the undici dispatcher
+  // layer (which controls TLS verification) without threading a flag through
+  // every content generator and the preconnect path. Resolution there ORs this
+  // with QWEN_TLS_INSECURE / NODE_TLS_REJECT_UNAUTHORIZED=0.
+  if (argv.insecure) {
+    process.env['QWEN_TLS_INSECURE'] = '1';
+  }
 
   // Set runtime output directory from settings (env var QWEN_RUNTIME_DIR
   // is auto-detected inside getRuntimeBaseDir() at each call site).

--- a/packages/cli/src/config/shared-env-keys.test.ts
+++ b/packages/cli/src/config/shared-env-keys.test.ts
@@ -14,4 +14,13 @@ describe('PROJECT_ENV_HARDCODED_EXCLUSIONS', () => {
   it('excludes QWEN_TLS_INSECURE so a project .env cannot disable TLS', () => {
     expect(PROJECT_ENV_HARDCODED_EXCLUSIONS).toContain('QWEN_TLS_INSECURE');
   });
+
+  // isTlsVerificationDisabled() also honors NODE_TLS_REJECT_UNAUTHORIZED=0, and
+  // the initial .env load only consults this list, so it must be blocked here
+  // too — otherwise a project .env could bypass TLS via the Node-native var.
+  it('excludes NODE_TLS_REJECT_UNAUTHORIZED so a project .env cannot disable TLS', () => {
+    expect(PROJECT_ENV_HARDCODED_EXCLUSIONS).toContain(
+      'NODE_TLS_REJECT_UNAUTHORIZED',
+    );
+  });
 });

--- a/packages/cli/src/config/shared-env-keys.test.ts
+++ b/packages/cli/src/config/shared-env-keys.test.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PROJECT_ENV_HARDCODED_EXCLUSIONS } from './shared-env-keys.js';
+
+describe('PROJECT_ENV_HARDCODED_EXCLUSIONS', () => {
+  // Security guard: a project `.env` must never be able to disable TLS
+  // certificate verification. Removing this key would let an untrusted repo
+  // silently turn off MITM protection for all API connections.
+  it('excludes QWEN_TLS_INSECURE so a project .env cannot disable TLS', () => {
+    expect(PROJECT_ENV_HARDCODED_EXCLUSIONS).toContain('QWEN_TLS_INSECURE');
+  });
+});

--- a/packages/cli/src/config/shared-env-keys.ts
+++ b/packages/cli/src/config/shared-env-keys.ts
@@ -21,6 +21,12 @@ export const PROJECT_ENV_HARDCODED_EXCLUSIONS = [
   'QWEN_CODE_TRUSTED_FOLDERS_PATH',
   ENV_CORRUPTED_PATH,
   ENV_WAS_RECOVERED,
+  // QWEN_TLS_INSECURE disables TLS certificate verification for all outbound
+  // API connections. A project `.env` must never enable it — that would let an
+  // untrusted repo silently turn off MITM protection. Opt-in stays with the
+  // user via the `--insecure` flag, the shell environment, or a home `.env`.
+  // (Via RELOAD_EXCLUDED_KEYS below this also blocks it on reload.)
+  'QWEN_TLS_INSECURE',
 ];
 
 export const HOME_ENV_BOOTSTRAP_KEYS = [

--- a/packages/cli/src/config/shared-env-keys.ts
+++ b/packages/cli/src/config/shared-env-keys.ts
@@ -21,12 +21,15 @@ export const PROJECT_ENV_HARDCODED_EXCLUSIONS = [
   'QWEN_CODE_TRUSTED_FOLDERS_PATH',
   ENV_CORRUPTED_PATH,
   ENV_WAS_RECOVERED,
-  // QWEN_TLS_INSECURE disables TLS certificate verification for all outbound
-  // API connections. A project `.env` must never enable it — that would let an
-  // untrusted repo silently turn off MITM protection. Opt-in stays with the
-  // user via the `--insecure` flag, the shell environment, or a home `.env`.
-  // (Via RELOAD_EXCLUDED_KEYS below this also blocks it on reload.)
+  // QWEN_TLS_INSECURE (and NODE_TLS_REJECT_UNAUTHORIZED, which it mirrors)
+  // disable TLS certificate verification for all outbound API connections. A
+  // project `.env` must never enable either — that would let an untrusted repo
+  // silently turn off MITM protection. Opt-in stays with the user via the
+  // `--insecure` flag, the shell environment, or a home `.env`. The initial
+  // `.env` load only consults this list, so both keys must be here (not just
+  // RELOAD_EXCLUDED_KEYS, which only applies on reload).
   'QWEN_TLS_INSECURE',
+  'NODE_TLS_REJECT_UNAUTHORIZED',
 ];
 
 export const HOME_ENV_BOOTSTRAP_KEYS = [

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -445,6 +445,7 @@ export * from './utils/ripgrepUtils.js';
 export {
   detectRuntime,
   getOrCreateSharedDispatcher,
+  isTlsVerificationDisabled,
   redactProxyCredentials,
 } from './utils/runtimeFetchOptions.js';
 export * from './utils/runtimeStatus.js';

--- a/packages/core/src/utils/fetch.test.ts
+++ b/packages/core/src/utils/fetch.test.ts
@@ -4,21 +4,40 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { FetchError, formatFetchErrorForUser } from './fetch.js';
 
+function makeTlsError(): Error {
+  const tlsCause = new Error('unable to verify the first certificate');
+  (tlsCause as Error & { code?: string }).code =
+    'UNABLE_TO_VERIFY_LEAF_SIGNATURE';
+  const fetchError = new TypeError('fetch failed') as TypeError & {
+    cause?: unknown;
+  };
+  fetchError.cause = tlsCause;
+  return fetchError;
+}
+
 describe('formatFetchErrorForUser', () => {
+  const saved = {
+    QWEN_TLS_INSECURE: process.env['QWEN_TLS_INSECURE'],
+    NODE_TLS_REJECT_UNAUTHORIZED: process.env['NODE_TLS_REJECT_UNAUTHORIZED'],
+  };
+
+  beforeEach(() => {
+    delete process.env['QWEN_TLS_INSECURE'];
+    delete process.env['NODE_TLS_REJECT_UNAUTHORIZED'];
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
   it('includes troubleshooting hints for TLS errors', () => {
-    const tlsCause = new Error('unable to verify the first certificate');
-    (tlsCause as Error & { code?: string }).code =
-      'UNABLE_TO_VERIFY_LEAF_SIGNATURE';
-
-    const fetchError = new TypeError('fetch failed') as TypeError & {
-      cause?: unknown;
-    };
-    fetchError.cause = tlsCause;
-
-    const message = formatFetchErrorForUser(fetchError, {
+    const message = formatFetchErrorForUser(makeTlsError(), {
       url: 'https://chat.qwen.ai',
     });
 
@@ -28,6 +47,16 @@ describe('formatFetchErrorForUser', () => {
     expect(message).toContain('Confirm you can reach https://chat.qwen.ai');
     expect(message).toContain('--proxy');
     expect(message).toContain('NODE_EXTRA_CA_CERTS');
+    expect(message).toContain('--insecure');
+  });
+
+  it('omits the --insecure hint when verification is already disabled', () => {
+    process.env['QWEN_TLS_INSECURE'] = '1';
+    const message = formatFetchErrorForUser(makeTlsError());
+
+    expect(message).toContain('already disabled');
+    expect(message).not.toContain('NODE_EXTRA_CA_CERTS');
+    expect(message).not.toContain('pass `--insecure`');
   });
 
   it('includes troubleshooting hints for network codes', () => {

--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -188,6 +188,7 @@ export function formatFetchErrorForUser(
     ...(shouldShowTlsHint
       ? [
           '- If your network uses a corporate TLS inspection CA, set `NODE_EXTRA_CA_CERTS` to your CA bundle.',
+          '- For a trusted self-signed endpoint, pass `--insecure` (or set `QWEN_TLS_INSECURE=1`) to skip certificate verification.',
         ]
       : []),
   ];

--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -5,6 +5,7 @@
  */
 
 import { getErrorMessage, isNodeError } from './errors.js';
+import { isTlsVerificationDisabled } from './runtimeFetchOptions.js';
 import { URL } from 'node:url';
 
 const PRIVATE_IP_RANGES = [
@@ -186,10 +187,14 @@ export function formatFetchErrorForUser(
       : []),
     '- If you are behind a proxy, pass `--proxy <url>` (or set `proxy` in settings).',
     ...(shouldShowTlsHint
-      ? [
-          '- If your network uses a corporate TLS inspection CA, set `NODE_EXTRA_CA_CERTS` to your CA bundle.',
-          '- For a trusted self-signed endpoint, pass `--insecure` (or set `QWEN_TLS_INSECURE=1`) to skip certificate verification.',
-        ]
+      ? isTlsVerificationDisabled()
+        ? [
+            '- TLS verification is already disabled (`--insecure` / `QWEN_TLS_INSECURE`), so this is likely a network or protocol issue rather than a certificate trust problem.',
+          ]
+        : [
+            '- If your network uses a corporate TLS inspection CA, set `NODE_EXTRA_CA_CERTS` to your CA bundle.',
+            '- For a trusted self-signed endpoint, pass `--insecure` (or set `QWEN_TLS_INSECURE=1`) to skip certificate verification.',
+          ]
       : []),
   ];
 

--- a/packages/core/src/utils/runtimeFetchOptions.test.ts
+++ b/packages/core/src/utils/runtimeFetchOptions.test.ts
@@ -59,6 +59,7 @@ import {
   buildRuntimeFetchOptions,
   extractHostnameFromProxyUrl,
   getOrCreateSharedDispatcher,
+  isTlsVerificationDisabled,
   redactProxyCredentials,
   redactProxyError,
   resetDispatcherCache,
@@ -365,6 +366,38 @@ describe('TLS verification opt-out (insecure)', () => {
     process.env['QWEN_TLS_INSECURE'] = '1';
     const insecure = getOrCreateSharedDispatcher('http://proxy.local');
     expect(secure).not.toBe(insecure);
+  });
+
+  describe('isTlsVerificationDisabled', () => {
+    it.each(['1', 'true', 'TRUE', 'Yes', 'on', '  1  '])(
+      'treats QWEN_TLS_INSECURE=%j as enabled',
+      (value) => {
+        process.env['QWEN_TLS_INSECURE'] = value;
+        expect(isTlsVerificationDisabled()).toBe(true);
+      },
+    );
+
+    it.each(['0', 'false', 'no', 'off', '', 'enabled'])(
+      'treats QWEN_TLS_INSECURE=%j as disabled',
+      (value) => {
+        process.env['QWEN_TLS_INSECURE'] = value;
+        expect(isTlsVerificationDisabled()).toBe(false);
+      },
+    );
+
+    it('honors NODE_TLS_REJECT_UNAUTHORIZED=0', () => {
+      process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
+      expect(isTlsVerificationDisabled()).toBe(true);
+    });
+
+    it('ignores NODE_TLS_REJECT_UNAUTHORIZED values other than "0"', () => {
+      process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '1';
+      expect(isTlsVerificationDisabled()).toBe(false);
+    });
+
+    it('returns false when neither variable is set', () => {
+      expect(isTlsVerificationDisabled()).toBe(false);
+    });
   });
 });
 

--- a/packages/core/src/utils/runtimeFetchOptions.test.ts
+++ b/packages/core/src/utils/runtimeFetchOptions.test.ts
@@ -290,6 +290,84 @@ describe('getOrCreateSharedDispatcher', () => {
   });
 });
 
+describe('TLS verification opt-out (insecure)', () => {
+  const savedEnv = {
+    QWEN_TLS_INSECURE: process.env['QWEN_TLS_INSECURE'],
+    NODE_TLS_REJECT_UNAUTHORIZED: process.env['NODE_TLS_REJECT_UNAUTHORIZED'],
+  };
+
+  beforeEach(() => {
+    resetDispatcherCache();
+    delete process.env['QWEN_TLS_INSECURE'];
+    delete process.env['NODE_TLS_REJECT_UNAUTHORIZED'];
+  });
+
+  afterEach(() => {
+    if (savedEnv.QWEN_TLS_INSECURE === undefined) {
+      delete process.env['QWEN_TLS_INSECURE'];
+    } else {
+      process.env['QWEN_TLS_INSECURE'] = savedEnv.QWEN_TLS_INSECURE;
+    }
+    if (savedEnv.NODE_TLS_REJECT_UNAUTHORIZED === undefined) {
+      delete process.env['NODE_TLS_REJECT_UNAUTHORIZED'];
+    } else {
+      process.env['NODE_TLS_REJECT_UNAUTHORIZED'] =
+        savedEnv.NODE_TLS_REJECT_UNAUTHORIZED;
+    }
+  });
+
+  const getDispatcherOptions = (result: unknown): UndiciOptions | undefined =>
+    (
+      result as {
+        fetchOptions?: { dispatcher?: { options?: UndiciOptions } };
+      }
+    ).fetchOptions?.dispatcher?.options;
+
+  it('does not set connect options on the no-proxy Agent by default', () => {
+    const options = getDispatcherOptions(buildRuntimeFetchOptions('openai'));
+    expect(options?.['connect']).toBeUndefined();
+  });
+
+  it('disables verification on the no-proxy Agent via QWEN_TLS_INSECURE', () => {
+    process.env['QWEN_TLS_INSECURE'] = '1';
+    const options = getDispatcherOptions(buildRuntimeFetchOptions('openai'));
+    expect(options?.['connect']).toEqual({ rejectUnauthorized: false });
+  });
+
+  it('honors NODE_TLS_REJECT_UNAUTHORIZED=0 for parity', () => {
+    process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
+    const options = getDispatcherOptions(buildRuntimeFetchOptions('openai'));
+    expect(options?.['connect']).toEqual({ rejectUnauthorized: false });
+  });
+
+  it('ignores falsy QWEN_TLS_INSECURE values', () => {
+    process.env['QWEN_TLS_INSECURE'] = '0';
+    const options = getDispatcherOptions(buildRuntimeFetchOptions('openai'));
+    expect(options?.['connect']).toBeUndefined();
+  });
+
+  it('uses requestTls/proxyTls (not connect) for the ProxyAgent', () => {
+    process.env['QWEN_TLS_INSECURE'] = '1';
+    const dispatcher = getOrCreateSharedDispatcher(
+      'http://proxy.local',
+    ) as unknown as { options: UndiciOptions };
+    expect(dispatcher.options['requestTls']).toEqual({
+      rejectUnauthorized: false,
+    });
+    expect(dispatcher.options['proxyTls']).toEqual({
+      rejectUnauthorized: false,
+    });
+    expect(dispatcher.options['connect']).toBeUndefined();
+  });
+
+  it('keeps secure and insecure dispatchers in separate cache entries', () => {
+    const secure = getOrCreateSharedDispatcher('http://proxy.local');
+    process.env['QWEN_TLS_INSECURE'] = '1';
+    const insecure = getOrCreateSharedDispatcher('http://proxy.local');
+    expect(secure).not.toBe(insecure);
+  });
+});
+
 describe('redactProxyCredentials', () => {
   it('redacts credentials from a single proxy URL', () => {
     const msg = 'Failed to connect: http://user:secret@proxy.local';

--- a/packages/core/src/utils/runtimeFetchOptions.ts
+++ b/packages/core/src/utils/runtimeFetchOptions.ts
@@ -206,8 +206,10 @@ const NO_DISPATCHER_FALLBACK = {
  * @param proxyUrl - Proxy URL used to create a cached ProxyAgent
  * @returns A cached undici ProxyAgent dispatcher
  */
-export function getOrCreateSharedDispatcher(proxyUrl: string): Dispatcher {
-  const insecure = isTlsVerificationDisabled();
+export function getOrCreateSharedDispatcher(
+  proxyUrl: string,
+  insecure: boolean = isTlsVerificationDisabled(),
+): Dispatcher {
   // Secure and insecure dispatchers must not share a cache entry, otherwise a
   // preconnect warmed without the flag could hand a verifying dispatcher to a
   // client that expects verification disabled (or vice versa).
@@ -663,7 +665,7 @@ function buildFetchOptionsWithDispatcher(
   }
 
   try {
-    const dispatcher = getOrCreateSharedDispatcher(proxyUrl);
+    const dispatcher = getOrCreateSharedDispatcher(proxyUrl, insecure);
     // Pin fetch to undici's own implementation so the dispatcher and fetch
     // come from the same undici version. Node's bundled undici may differ in
     // major version from the project's bundled one (e.g. v8 vs v6), which

--- a/packages/core/src/utils/runtimeFetchOptions.ts
+++ b/packages/core/src/utils/runtimeFetchOptions.ts
@@ -21,6 +21,34 @@ const debugLogger = createDebugLogger('RUNTIME_FETCH');
 export type Runtime = 'node' | 'bun' | 'unknown';
 
 /**
+ * Determine whether TLS certificate verification should be disabled for
+ * outbound API connections.
+ *
+ * This is an opt-in escape hatch for self-hosted / lab environments that use
+ * self-signed certificates. Because Qwen Code installs its own undici
+ * dispatcher (to control timeouts), Node's global `NODE_TLS_REJECT_UNAUTHORIZED`
+ * is not automatically honored by that dispatcher — this helper feeds the
+ * setting back into the dispatcher's TLS connect options.
+ *
+ * Sources (any one enables it):
+ * - `QWEN_TLS_INSECURE` env var (`1`/`true`/`yes`/`on`, case-insensitive).
+ *   The `--insecure` CLI flag sets this.
+ * - `NODE_TLS_REJECT_UNAUTHORIZED=0` (Node convention, for parity)
+ *
+ * WARNING: disabling verification removes protection against
+ * man-in-the-middle attacks. Only use it for trusted, private endpoints.
+ *
+ * @returns true when certificate verification should be skipped
+ */
+export function isTlsVerificationDisabled(): boolean {
+  const flag = process.env['QWEN_TLS_INSECURE'];
+  if (flag !== undefined && /^(1|true|yes|on)$/i.test(flag.trim())) {
+    return true;
+  }
+  return process.env['NODE_TLS_REJECT_UNAUTHORIZED'] === '0';
+}
+
+/**
  * Detect the current JavaScript runtime
  */
 export function detectRuntime(): Runtime {
@@ -105,12 +133,15 @@ export function buildRuntimeFetchOptions(
 
   switch (runtime) {
     case 'bun': {
+      const insecure = isTlsVerificationDisabled();
       if (sdkType === 'openai') {
         // Bun: Disable built-in 300s timeout to let OpenAI SDK timeout control
         // This ensures user-configured timeout works as expected without interference
         return {
           fetchOptions: {
             timeout: false,
+            // Bun's fetch honors a `tls` option for per-request TLS settings.
+            ...(insecure ? { tls: { rejectUnauthorized: false } } : {}),
           },
         };
       } else {
@@ -126,6 +157,8 @@ export function buildRuntimeFetchOptions(
             ...init,
             // @ts-expect-error - Bun-specific timeout option
             timeout: false,
+            // Bun-specific TLS option; spread so the type stays RequestInit.
+            ...(insecure ? { tls: { rejectUnauthorized: false } } : {}),
           };
           return fetch(input, bunFetchOptions);
         };
@@ -179,7 +212,12 @@ const NO_DISPATCHER_FALLBACK = {
  * @returns A cached undici ProxyAgent dispatcher
  */
 export function getOrCreateSharedDispatcher(proxyUrl: string): Dispatcher {
-  const cached = dispatcherCache.get(proxyUrl);
+  const insecure = isTlsVerificationDisabled();
+  // Secure and insecure dispatchers must not share a cache entry, otherwise a
+  // preconnect warmed without the flag could hand a verifying dispatcher to a
+  // client that expects verification disabled (or vice versa).
+  const cacheKey = insecure ? `${proxyUrl}#insecure` : proxyUrl;
+  const cached = dispatcherCache.get(cacheKey);
   if (cached) {
     return cached;
   }
@@ -189,9 +227,18 @@ export function getOrCreateSharedDispatcher(proxyUrl: string): Dispatcher {
     headersTimeout: 0,
     bodyTimeout: 0,
     keepAliveTimeout: 60_000,
+    // For a ProxyAgent the upstream (origin) TLS handshake is governed by
+    // `requestTls`, not `connect`; `proxyTls` covers an HTTPS proxy whose own
+    // certificate is self-signed. Disable verification on both when opted in.
+    ...(insecure
+      ? {
+          requestTls: { rejectUnauthorized: false },
+          proxyTls: { rejectUnauthorized: false },
+        }
+      : {}),
   });
 
-  dispatcherCache.set(proxyUrl, dispatcher);
+  dispatcherCache.set(cacheKey, dispatcher);
   return dispatcher;
 }
 
@@ -597,19 +644,23 @@ function buildFetchOptionsWithDispatcher(
   sdkType: SDKType,
   proxyUrl?: string,
 ): OpenAIRuntimeFetchOptions | AnthropicRuntimeFetchOptions {
+  const insecure = isTlsVerificationDisabled();
   // When no proxy is configured, use a cached plain undici Agent with disabled
   // timeouts (headersTimeout: 0, bodyTimeout: 0). This prevents undici's 300s
   // default bodyTimeout from aborting long-running requests to local LLM
   // backends (LM Studio, Ollama, llama.cpp, MLX). The Agent is cached for
   // connection pool reuse, matching the proxy path's caching behavior.
   if (!proxyUrl) {
-    const NO_PROXY_KEY = '__no_proxy__';
+    const NO_PROXY_KEY = insecure ? '__no_proxy__#insecure' : '__no_proxy__';
     let dispatcher = dispatcherCache.get(NO_PROXY_KEY);
     if (!dispatcher) {
       dispatcher = new Agent({
         headersTimeout: 0,
         bodyTimeout: 0,
         keepAliveTimeout: 60_000,
+        // For a direct (non-proxy) Agent, `connect` options flow straight to
+        // the TLS connector, so this disables upstream cert verification.
+        ...(insecure ? { connect: { rejectUnauthorized: false } } : {}),
       });
       dispatcherCache.set(NO_PROXY_KEY, dispatcher);
     }

--- a/packages/core/src/utils/runtimeFetchOptions.ts
+++ b/packages/core/src/utils/runtimeFetchOptions.ts
@@ -133,15 +133,12 @@ export function buildRuntimeFetchOptions(
 
   switch (runtime) {
     case 'bun': {
-      const insecure = isTlsVerificationDisabled();
       if (sdkType === 'openai') {
         // Bun: Disable built-in 300s timeout to let OpenAI SDK timeout control
         // This ensures user-configured timeout works as expected without interference
         return {
           fetchOptions: {
             timeout: false,
-            // Bun's fetch honors a `tls` option for per-request TLS settings.
-            ...(insecure ? { tls: { rejectUnauthorized: false } } : {}),
           },
         };
       } else {
@@ -157,8 +154,6 @@ export function buildRuntimeFetchOptions(
             ...init,
             // @ts-expect-error - Bun-specific timeout option
             timeout: false,
-            // Bun-specific TLS option; spread so the type stays RequestInit.
-            ...(insecure ? { tls: { rejectUnauthorized: false } } : {}),
           };
           return fetch(input, bunFetchOptions);
         };


### PR DESCRIPTION
## What this PR does

Adds an opt-in way to skip TLS certificate verification for outbound model API connections, so Qwen Code can talk to self-hosted endpoints that use a self-signed certificate. It is enabled by a new `--insecure` CLI flag, the `QWEN_TLS_INSECURE` environment variable, or the Node convention `NODE_TLS_REJECT_UNAUTHORIZED=0`. When enabled, verification is disabled on the undici dispatcher that Qwen Code installs: a direct connection uses the connector's TLS options, and a proxied connection disables verification for the upstream origin (and for an HTTPS proxy whose own certificate is self-signed). When not enabled, behavior is unchanged.

## Why it's needed

Because Qwen Code installs its own undici dispatcher (to control request timeouts for local backends), Node's global `NODE_TLS_REJECT_UNAUTHORIZED=0` was not reliably honored for model API calls, so users pointing Qwen Code at a self-hosted server with a self-signed certificate hit `Connection error. (cause: fetch failed)` with no escape hatch — even though the same setting works elsewhere. This gives a clear, intentional opt-out for trusted lab / self-hosted environments, while keeping the safer `NODE_EXTRA_CA_CERTS` (trust the CA) as the recommended path. The flag carries an explicit man-in-the-middle warning in both `--help` and the troubleshooting docs.

## Reviewer Test Plan

### How to verify

1. Stand up (or point at) an HTTPS endpoint with a self-signed certificate, e.g. an OpenAI-compatible local server at `https://localhost:8443`.
2. Baseline: `qwen --auth-type openai --openaiBaseUrl https://localhost:8443 --openaiApiKey sk-x --prompt "2+2?"` → expect `Connection error. (cause: fetch failed)` and a troubleshooting hint mentioning `NODE_EXTRA_CA_CERTS` and `--insecure`.
3. With the flag: add `--insecure` to the same command → expect the request to reach the server (no TLS rejection). `QWEN_TLS_INSECURE=1 qwen ...` and `NODE_TLS_REJECT_UNAUTHORIZED=0 qwen ...` should behave the same.
4. Confirm the default is unchanged: without any of the three, verification still rejects the self-signed cert.

Unit coverage: `packages/core/src/utils/runtimeFetchOptions.test.ts` asserts the direct Agent uses `connect: { rejectUnauthorized: false }`, the ProxyAgent uses `requestTls`/`proxyTls` (not `connect`), falsy `QWEN_TLS_INSECURE` values are ignored, and secure/insecure dispatchers are cached separately. `packages/cli/src/config/config.test.ts` covers flag parsing.

### Evidence (Before & After)

N/A (non-TUI; network/TLS behavior). See test output below.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local unit tests (vitest) on macOS; repo-wide `lint` / `build` / `typecheck` green.

## Risk & Scope

- Main risk or tradeoff: disabling verification removes MITM protection; mitigated by being strictly opt-in, off by default, and warned about in `--help` and docs.
- Not validated / out of scope: MCP server transport (`EnvHttpProxyAgent`) and telemetry use independent paths and are intentionally left verifying; this PR scopes to model API connections, which is what the issue asks for.
- Breaking changes / migration notes: none — default behavior is unchanged.

## Linked Issues

Fixes #3535

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

新增一个可选项，用于在访问模型 API 时跳过 TLS 证书校验，使 Qwen Code 能连接使用自签名证书的自建服务。可通过新增的 `--insecure` 命令行参数、`QWEN_TLS_INSECURE` 环境变量，或 Node 习惯的 `NODE_TLS_REJECT_UNAUTHORIZED=0` 任一开启。开启后，会在 Qwen Code 自建的 undici dispatcher 上关闭校验：直连走连接器的 TLS 选项；走代理时关闭对上游源站的校验（以及自签名 HTTPS 代理自身证书的校验）。未开启时行为完全不变。

## 为什么需要

由于 Qwen Code 为控制本地后端的请求超时而自建了 undici dispatcher，Node 全局的 `NODE_TLS_REJECT_UNAUTHORIZED=0` 对模型 API 调用并不可靠生效，导致用户指向自签名证书的自建服务器时遇到 `Connection error. (cause: fetch failed)` 且没有任何逃生通道——尽管同样的设置在别处有效。本改动提供一个明确、需主动开启的开关，面向受信任的实验/自建环境，同时仍把更安全的 `NODE_EXTRA_CA_CERTS`（信任 CA）作为推荐方案。该参数在 `--help` 和排障文档中都带有中间人攻击风险提示。

## 审阅测试计划

### 如何验证

1. 准备一个使用自签名证书的 HTTPS 端点（例如本地 OpenAI 兼容服务 `https://localhost:8443`）。
2. 基线：`qwen --auth-type openai --openaiBaseUrl https://localhost:8443 --openaiApiKey sk-x --prompt "2+2?"` → 预期报 `Connection error. (cause: fetch failed)`，并提示 `NODE_EXTRA_CA_CERTS` 与 `--insecure`。
3. 加上参数：同样命令加 `--insecure` → 预期请求能到达服务器（不再被 TLS 拒绝）。`QWEN_TLS_INSECURE=1 qwen ...` 与 `NODE_TLS_REJECT_UNAUTHORIZED=0 qwen ...` 行为相同。
4. 确认默认不变：三者都不设置时，自签名证书仍被拒绝。

单测覆盖：`runtimeFetchOptions.test.ts` 断言直连 Agent 使用 `connect: { rejectUnauthorized: false }`、ProxyAgent 使用 `requestTls`/`proxyTls`（而非 `connect`）、忽略 `QWEN_TLS_INSECURE` 的假值、以及 secure/insecure dispatcher 分开缓存；`config.test.ts` 覆盖参数解析。

### 证据（前后对比）

N/A（非 TUI；属网络/TLS 行为），见测试输出。

### 测试平台

仅在 macOS 本地跑了单测；全仓 `lint` / `build` / `typecheck` 通过。

## 风险与范围

- 主要风险：关闭校验会失去中间人防护；通过严格可选、默认关闭、并在 `--help` 与文档中警告来缓解。
- 未验证/超出范围：MCP 传输（`EnvHttpProxyAgent`）与遥测走独立路径，本 PR 有意保持校验；范围限定为模型 API 连接，即 issue 的诉求。
- 破坏性变更：无，默认行为不变。

## 关联 Issue

Fixes #3535

</details>
