### PR TITLE
fix(release): use relative postinstall patch dir

### DIFF
--- a/scripts/prepare-package.js
+++ b/scripts/prepare-package.js
@@ -394,10 +394,11 @@ if (chromeDevtoolsMcpPackageJson) {
   if (!installRoot || !existsSync(patchDir)) {
     process.exit(0);
   }
+  const relativePatchDir = path.relative(installRoot, patchDir) || '.';
   const patchPackageBin = require.resolve('patch-package/index.js');
   const result = spawnSync(
     process.execPath,
-    [patchPackageBin, '--patch-dir', patchDir, '--error-on-fail'],
+    [patchPackageBin, '--patch-dir', relativePatchDir, '--error-on-fail'],
     { cwd: installRoot, stdio: 'inherit' },
   );
   if (result.signal) {

--- a/scripts/tests/package-assets.test.js
+++ b/scripts/tests/package-assets.test.js
@@ -229,11 +229,7 @@ describe('package asset scripts', () => {
 
     const realDistDir = realpathSync(distDir);
     expect(JSON.parse(readFileSync(markerPath, 'utf8'))).toEqual({
-      argv: [
-        '--patch-dir',
-        path.join(realDistDir, 'patches'),
-        '--error-on-fail',
-      ],
+      argv: ['--patch-dir', 'patches', '--error-on-fail'],
       cwd: realDistDir,
     });
   });


### PR DESCRIPTION
## What this PR does

This change makes the published CLI postinstall patch step pass a patch directory relative to the package install root instead of an absolute path.

## Why it's needed

The release Docker sandbox build installs the packed CLI globally before running Docker integration tests. The new postinstall patching path passed an absolute directory to `patch-package`, but `patch-package` rejects absolute `--patch-dir` values. That caused the sandbox image build to fail before the Docker integration tests could start.

## Reviewer Test Plan

### How to verify

Run the package asset script test and confirm the postinstall regression case records `--patch-dir patches` while the full package asset suite passes.

### Evidence (Before & After)

Before: the regression test failed because the generated postinstall command passed an absolute patch directory. After: `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/package-assets.test.js` passes with 12 tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Node.js local script tests via Vitest.

## Risk & Scope

- Main risk or tradeoff: Low; the change only affects the generated postinstall patch invocation and keeps the working directory unchanged.
- Not validated / out of scope: Full Docker sandbox image build was not run locally because the local Docker daemon is unavailable.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5969

<details>
<summary>中文说明</summary>

## What this PR does

这个改动让发布后的 CLI postinstall 补丁步骤传入相对于安装根目录的 patch 目录，而不是绝对路径。

## Why it's needed

Release 的 Docker sandbox 构建会先全局安装打包后的 CLI，再运行 Docker 集成测试。新的 postinstall 补丁逻辑把绝对目录传给了 `patch-package`，但 `patch-package` 会拒绝绝对 `--patch-dir`，导致 sandbox 镜像构建在 Docker 集成测试开始前失败。

## Reviewer Test Plan

### How to verify

运行 package asset 脚本测试，确认 postinstall 回归用例记录到的是 `--patch-dir patches`，并且整个 package asset 测试文件通过。

### Evidence (Before & After)

Before：回归测试失败，因为生成的 postinstall 命令传入了绝对 patch 目录。After：`npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/package-assets.test.js` 通过，共 12 个测试。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

通过 Vitest 运行 Node.js 本地脚本测试。

## Risk & Scope

- Main risk or tradeoff：风险较低；改动只影响生成的 postinstall 补丁调用方式，并保持工作目录不变。
- Not validated / out of scope：本地 Docker daemon 不可用，因此没有运行完整 Docker sandbox 镜像构建。
- Breaking changes / migration notes：无。

## Linked Issues

Fixes #5969

</details>
