### PR TITLE
fix(standalone): Route serve shim through cli-entry

### DIFF
--- a/scripts/create-standalone-package.js
+++ b/scripts/create-standalone-package.js
@@ -50,14 +50,15 @@ const TARGET_PREBUILD_DIR = new Map([
 
 const DIST_REQUIRED_PATHS = [
   'cli.js',
+  'cli-entry.js',
   'chunks',
   'vendor',
   'bundled/qc-helper/docs',
 ];
 const DIST_ALLOWED_ENTRIES = new Set([
   'cli.js',
-  // bin wrapper emitted by prepare-package.js that re-spawns `node --expose-gc
-  // cli.js`; ships in dist/ as the package `bin` entry (#4914).
+  // bin wrapper emitted by prepare-package.js. Standalone shims use it for
+  // `qwen serve` so daemon startup gets the same fast path as npm installs.
   'cli-entry.js',
   // fzf fuzzy-search worker; esbuild emits it as a standalone entry that must
   // sit next to cli.js so `new URL('./fzfWorker.js', ...)` resolves at runtime.
@@ -79,6 +80,7 @@ const DIST_ALLOWED_ENTRIES = new Set([
 const DIST_ALLOWED_ENTRY_PATTERNS = [
   /^sandbox-macos-(permissive|restrictive)-(open|closed|proxied)\.sb$/,
 ];
+const DIST_NPM_PACKAGE_ONLY_ENTRIES = new Set(['postinstall.js', 'patches']);
 const ROOT_REQUIRED_PATHS = ['README.md', 'LICENSE'];
 
 if (isMainModule()) {
@@ -240,7 +242,10 @@ function assertRequiredInputs() {
   for (const relativePath of DIST_REQUIRED_PATHS) {
     const fullPath = path.join(distDir, relativePath);
     if (!fs.existsSync(fullPath)) {
-      fail(`Required dist asset missing: ${fullPath}`);
+      fail(
+        `Required dist asset missing: ${fullPath}. ` +
+          'Run "npm run bundle" and "npm run prepare:package" first.',
+      );
     }
   }
 
@@ -271,7 +276,8 @@ function copyRuntimeAssets(packageRoot, outDir) {
     if (
       entry === skippedDistEntry ||
       entry === '.DS_Store' ||
-      entry === 'node_modules'
+      entry === 'node_modules' ||
+      DIST_NPM_PACKAGE_ONLY_ENTRIES.has(entry)
     ) {
       continue;
     }
@@ -599,6 +605,9 @@ function writeShims(packageRoot) {
   const unixShim = `#!/usr/bin/env sh
 set -e
 ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+if [ "\${1:-}" = "serve" ]; then
+  exec "$ROOT/node/bin/node" "$ROOT/lib/cli-entry.js" "$@"
+fi
 exec "$ROOT/node/bin/node" --expose-gc "$ROOT/lib/cli.js" "$@"
 `;
   const unixShimPath = path.join(binDir, 'qwen');
@@ -608,7 +617,13 @@ exec "$ROOT/node/bin/node" --expose-gc "$ROOT/lib/cli.js" "$@"
   const windowsShim = `@echo off
 setlocal
 set "ROOT=%~dp0.."
+if "%~1"=="serve" goto serve
 "%ROOT%\\node\\node.exe" --expose-gc "%ROOT%\\lib\\cli.js" %*
+exit /b %ERRORLEVEL%
+
+:serve
+"%ROOT%\\node\\node.exe" "%ROOT%\\lib\\cli-entry.js" %*
+exit /b %ERRORLEVEL%
 `;
   fs.writeFileSync(path.join(binDir, 'qwen.cmd'), windowsShim);
 }

--- a/scripts/create-standalone-package.js
+++ b/scripts/create-standalone-package.js
@@ -80,6 +80,8 @@ const DIST_ALLOWED_ENTRIES = new Set([
 const DIST_ALLOWED_ENTRY_PATTERNS = [
   /^sandbox-macos-(permissive|restrictive)-(open|closed|proxied)\.sb$/,
 ];
+// Emitted into dist/ by prepare-package.js for npm publishing only;
+// standalone archives must not copy them into lib/.
 const DIST_NPM_PACKAGE_ONLY_ENTRIES = new Set(['postinstall.js', 'patches']);
 const ROOT_REQUIRED_PATHS = ['README.md', 'LICENSE'];
 

--- a/scripts/tests/install-script.test.js
+++ b/scripts/tests/install-script.test.js
@@ -1723,6 +1723,7 @@ describe('standalone release packaging', () => {
       expect(shim).toContain(
         '"%ROOT%\\node\\node.exe" "%ROOT%\\lib\\cli-entry.js" %*',
       );
+      expect((shim.match(/exit \/b %ERRORLEVEL%/g) || []).length).toBe(2);
       expect(readScript(path.join(outDir, 'SHA256SUMS'))).toContain(
         'qwen-code-win-x64.zip',
       );

--- a/scripts/tests/install-script.test.js
+++ b/scripts/tests/install-script.test.js
@@ -1646,6 +1646,36 @@ describe('standalone release packaging', () => {
     }
   });
 
+  it('requires the standalone cli-entry wrapper in dist', () => {
+    const createdDist = ensureMinimalDist({ includeCliEntry: false });
+    const tmpDir = mkdtempSync(path.join(tmpdir(), 'qwen-package-test-'));
+
+    try {
+      expect(() =>
+        execFileSync(
+          'node',
+          [
+            'scripts/create-standalone-package.js',
+            '--target',
+            'win-x64',
+            '--node-archive',
+            createFakeWindowsNodeArchive(tmpDir),
+            '--out-dir',
+            path.join(tmpDir, 'out'),
+            '--version',
+            '0.0.0-test',
+          ],
+          { stdio: 'pipe' },
+        ),
+      ).toThrow(
+        /Required dist asset missing: .*cli-entry\.js[\s\S]*npm run prepare:package/,
+      );
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+      restoreMinimalDist(createdDist);
+    }
+  });
+
   it('packages a win-x64 standalone archive', () => {
     const createdDist = ensureMinimalDist();
     const tmpDir = mkdtempSync(path.join(tmpdir(), 'qwen-package-test-'));
@@ -1678,11 +1708,67 @@ describe('standalone release packaging', () => {
         existsSync(path.join(extractDir, 'qwen-code', 'bin', 'qwen.cmd')),
       ).toBe(true);
       expect(
+        existsSync(path.join(extractDir, 'qwen-code', 'lib', 'cli-entry.js')),
+      ).toBe(true);
+      expect(
         existsSync(path.join(extractDir, 'qwen-code', 'node', 'node.exe')),
       ).toBe(true);
+      const shim = readScript(
+        path.join(extractDir, 'qwen-code', 'bin', 'qwen.cmd'),
+      );
+      expect(shim).toContain('if "%~1"=="serve" goto serve');
+      expect(shim).toContain(
+        '"%ROOT%\\node\\node.exe" --expose-gc "%ROOT%\\lib\\cli.js" %*',
+      );
+      expect(shim).toContain(
+        '"%ROOT%\\node\\node.exe" "%ROOT%\\lib\\cli-entry.js" %*',
+      );
       expect(readScript(path.join(outDir, 'SHA256SUMS'))).toContain(
         'qwen-code-win-x64.zip',
       );
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+      restoreMinimalDist(createdDist);
+    }
+  }, 30_000);
+
+  it('skips npm-only artifacts staged in dist', () => {
+    const createdDist = ensureMinimalDist({
+      includeNpmPackageArtifacts: true,
+    });
+    const tmpDir = mkdtempSync(path.join(tmpdir(), 'qwen-package-test-'));
+
+    try {
+      const outDir = path.join(tmpDir, 'out');
+      execFileSync(
+        'node',
+        [
+          'scripts/create-standalone-package.js',
+          '--target',
+          'win-x64',
+          '--node-archive',
+          createFakeWindowsNodeArchive(tmpDir),
+          '--out-dir',
+          outDir,
+          '--version',
+          '0.0.0-test',
+        ],
+        { stdio: 'pipe' },
+      );
+
+      const extractDir = path.join(tmpDir, 'extract');
+      mkdirSync(extractDir, { recursive: true });
+      extractZipForTest(path.join(outDir, 'qwen-code-win-x64.zip'), extractDir);
+
+      expect(
+        existsSync(path.join(extractDir, 'qwen-code', 'lib', 'cli-entry.js')),
+      ).toBe(true);
+      expect(
+        existsSync(path.join(extractDir, 'qwen-code', 'lib', 'postinstall.js')),
+      ).toBe(false);
+      expect(
+        existsSync(path.join(extractDir, 'qwen-code', 'lib', 'patches')),
+      ).toBe(false);
     } finally {
       rmSync(tmpDir, { recursive: true, force: true });
       restoreMinimalDist(createdDist);
@@ -1780,6 +1866,37 @@ describe('standalone release packaging', () => {
       }
       rmSync(tmpDir, { recursive: true, force: true });
       restoreMinimalDist(createdDist);
+    }
+  });
+
+  itOnUnix('packages a Unix standalone archive with a serve fast path shim', () => {
+    const createdDist = ensureMinimalDist();
+    const tmpDir = mkdtempSync(path.join(tmpdir(), 'qwen-package-test-'));
+
+    try {
+      const archive = packageFakeStandalone(tmpDir);
+      const extractDir = path.join(tmpDir, 'extract');
+      mkdirSync(extractDir, { recursive: true });
+      execFileSync('tar', ['-xzf', archive, '-C', extractDir], {
+        stdio: 'ignore',
+      });
+
+      expect(
+        existsSync(path.join(extractDir, 'qwen-code', 'lib', 'cli-entry.js')),
+      ).toBe(true);
+      const shim = readScript(
+        path.join(extractDir, 'qwen-code', 'bin', 'qwen'),
+      );
+      expect(shim).toContain('if [ "${1:-}" = "serve" ]; then');
+      expect(shim).toContain(
+        'exec "$ROOT/node/bin/node" "$ROOT/lib/cli-entry.js" "$@"',
+      );
+      expect(shim).toContain(
+        'exec "$ROOT/node/bin/node" --expose-gc "$ROOT/lib/cli.js" "$@"',
+      );
+    } finally {
+      restoreMinimalDist(createdDist);
+      rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 
@@ -3979,7 +4096,10 @@ describe('Windows PowerShell uninstaller end-to-end', () => {
   });
 });
 
-function ensureMinimalDist() {
+function ensureMinimalDist({
+  includeCliEntry = true,
+  includeNpmPackageArtifacts = false,
+} = {}) {
   const distPath = path.resolve('dist');
   const backupPath = existsSync(distPath)
     ? path.join(
@@ -3999,6 +4119,20 @@ function ensureMinimalDist() {
     recursive: true,
   });
   writeFileSync(path.join(distPath, 'cli.js'), 'console.log("qwen");\n');
+  if (includeCliEntry) {
+    writeFileSync(path.join(distPath, 'cli-entry.js'), 'import "./cli.js";\n');
+  }
+  if (includeNpmPackageArtifacts) {
+    writeFileSync(
+      path.join(distPath, 'postinstall.js'),
+      'console.log("postinstall");\n',
+    );
+    mkdirSync(path.join(distPath, 'patches'), { recursive: true });
+    writeFileSync(
+      path.join(distPath, 'patches', 'dependency.patch'),
+      'patch\n',
+    );
+  }
   writeFileSync(path.join(distPath, 'chunks/index.js'), 'export {};\n');
   writeFileSync(
     path.join(distPath, 'package.json'),


### PR DESCRIPTION
## What this PR does

Standalone archives now route `qwen serve` through the packaged CLI entry wrapper while keeping other standalone commands on the existing direct `node --expose-gc lib/cli.js` path. The standalone package builder also treats the entry wrapper as a required runtime artifact so release archives cannot be produced without the file that the serve fast path needs. When `prepare:package` has staged npm-only artifacts in `dist/`, standalone packaging now skips those artifacts instead of failing or copying them into the archive.

## Why it's needed

Recent daemon startup work optimized the npm-installed `cli-entry.js` path, but the standalone `bin/qwen` and `bin/qwen.cmd` shims still invoked `lib/cli.js` directly with `--expose-gc`. That bypassed the compile-cache and serve fast-path behavior for standalone users, leaving daemon startup slower in the installation mode used by hosted standalone releases. Requiring `cli-entry.js` also needs to work with the documented `bundle -> prepare:package -> package:standalone` flow, where `prepare:package` writes npm package-only files that standalone archives should not ship.

## Reviewer Test Plan

### How to verify

Build a standalone archive and inspect the generated launchers. `qwen serve` should execute `lib/cli-entry.js`, while non-serve commands should still execute `node --expose-gc lib/cli.js`. The package builder should fail if `dist/cli-entry.js` is missing, and it should still package successfully when `dist/` contains npm-only `postinstall.js` and `patches` artifacts from `prepare:package` without copying those artifacts into `lib/`.

### Evidence (Before & After)

N/A - non-UI packaging fix. The regression coverage asserts the generated Unix and Windows archive shims, the missing-entry failure path, and the prepared `dist/` case with npm-only artifacts.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️ not tested locally; Windows archive content is covered by script tests |
|  🐧 Linux  |   ⚠️ not tested locally; Unix archive content is covered by script tests |

### Environment (optional)

macOS local worktree with Node.js v26.0.0. Dependencies installed with `npm ci --ignore-scripts --no-audit --progress=false` in a clean worktree before validation.

## Risk & Scope

- Main risk or tradeoff: The serve fast path only matches `qwen serve`, so commands with flags before the subcommand continue to use the existing fallback behavior. Standalone archives intentionally skip npm-only postinstall artifacts because no npm install lifecycle runs inside the archive.
- Not validated / out of scope: This PR does not move `getCliVersion()` after listen and does not change ACP bridge import timing; those remain separate startup follow-ups.
- Breaking changes / migration notes: None. Non-serve standalone commands keep the existing `--expose-gc` path.

## Linked Issues

Relates to #4748

<details>
<summary>中文说明</summary>

## What this PR does

Standalone 包现在让 `qwen serve` 通过打包进去的 CLI entry wrapper 启动，同时保持其它 standalone 命令继续走现有的直接 `node --expose-gc lib/cli.js` 路径。standalone 打包脚本也把这个 entry wrapper 设为必需运行时产物，避免生成缺少 serve fast path 入口文件的发布包。当 `prepare:package` 已经在 `dist/` 中放入 npm-only artifacts 时，standalone 打包现在会跳过这些文件，而不是失败或把它们复制进 archive。

## Why it's needed

近期 daemon 启动优化已经覆盖 npm 安装的 `cli-entry.js` 路径，但 standalone 的 `bin/qwen` 和 `bin/qwen.cmd` 仍然直接带 `--expose-gc` 调用 `lib/cli.js`。这会让 standalone 用户绕过 compile cache 和 serve fast path，导致 hosted standalone release 使用的安装方式里 daemon 启动仍然偏慢。把 `cli-entry.js` 设为必需文件后，也需要兼容文档里的 `bundle -> prepare:package -> package:standalone` 流程，因为 `prepare:package` 会写入 standalone archive 不应该携带的 npm package-only 文件。

## Reviewer Test Plan

### How to verify

构建 standalone archive 并检查生成的启动脚本。`qwen serve` 应该执行 `lib/cli-entry.js`，非 serve 命令应该仍然执行 `node --expose-gc lib/cli.js`。如果缺少 `dist/cli-entry.js`，打包脚本应该失败；当 `dist/` 中含有 `prepare:package` 生成的 npm-only `postinstall.js` 和 `patches` artifacts 时，打包应该仍然成功，并且这些 artifacts 不会被复制进 `lib/`。

### Evidence (Before & After)

N/A - 非 UI 的打包修复。回归测试会断言生成的 Unix 和 Windows archive shim 内容、缺失 entry wrapper 时的失败路径，以及准备过的 `dist/` 中含 npm-only artifacts 的场景。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️ 本地未测试；Windows archive 内容由脚本测试覆盖 |
|  🐧 Linux  |   ⚠️ 本地未测试；Unix archive 内容由脚本测试覆盖 |

### Environment (optional)

macOS 本地干净 worktree，Node.js v26.0.0。验证前在干净 worktree 里使用 `npm ci --ignore-scripts --no-audit --progress=false` 安装依赖。

## Risk & Scope

- Main risk or tradeoff: serve fast path 只匹配 `qwen serve`，所以子命令前带 flag 的调用会继续使用现有 fallback 行为。standalone archive 会有意跳过 npm-only postinstall artifacts，因为 archive 内部不会运行 npm install lifecycle。
- Not validated / out of scope: 这个 PR 不把 `getCliVersion()` 移到 listen 之后，也不修改 ACP bridge 的导入时机；这些仍是独立的启动优化后续项。
- Breaking changes / migration notes: 无。非 serve standalone 命令保留现有 `--expose-gc` 路径。

## Linked Issues

Relates to #4748

</details>
