### PR TITLE
docs(qc-helper): add daemon mode docs and fix system settings path

### DIFF
--- a/packages/core/src/skills/bundled/qc-helper/SKILL.md
+++ b/packages/core/src/skills/bundled/qc-helper/SKILL.md
@@ -75,6 +75,13 @@ Use this index to locate the right document for the user's question. Load only t
 | Contextual tips                             | `docs/features/tips.md`                 |
 | Channels (Telegram/WeChat/DingTalk/etc.)    | `docs/features/channels/overview.md`    |
 
+### Daemon Mode
+
+| Topic                             | Doc Path                          |
+| --------------------------------- | --------------------------------- |
+| qwen serve (daemon mode overview) | `docs/qwen-serve.md`              |
+| Local launch templates            | `docs/qwen-serve-deploy-local.md` |
+
 ### IDE Integration
 
 | Topic                   | Doc Path                                     |
@@ -115,7 +122,7 @@ When the user asks about configuration, the primary reference is `docs/configura
 | ------- | ------------------------------------------------------------ | -------------------------------------- |
 | User    | `~/.qwen/settings.json`                                      | Personal global config                 |
 | Project | `<project>/.qwen/settings.json`                              | Project-specific, overrides user level |
-| System  | macOS: `/Library/Application Support/QwenCode/settings.json` | Admin-level config                     |
+| System  | Linux: `/etc/qwen-code/settings.json`<br>Windows: `C:\ProgramData\qwen-code\settings.json`<br>macOS: `/Library/Application Support/QwenCode/settings.json` | Admin-level config                     |
 
 **Priority** (highest to lowest): CLI args > env vars > system settings > project settings > user settings > defaults
 


### PR DESCRIPTION
## What this PR does

Fixes two gaps in the `/qc-helper` bundled skill's documentation index (`packages/core/src/skills/bundled/qc-helper/SKILL.md`):

1. **Adds a "Daemon Mode" section** with entries for `docs/qwen-serve.md` and `docs/qwen-serve-deploy-local.md`. These pages exist in `docs/users/` and appear in `docs/users/_meta.ts` but were absent from the qc-helper's index, meaning `/qc-helper how does qwen serve work?` would silently find nothing.
2. **Expands the system settings path** in the Config File Locations quick reference from macOS-only to all three platforms (Linux, Windows, macOS), matching what `docs/users/configuration/settings.md` already documents.

No changes to source code, tests, or user-facing docs pages. Only the bundled skill's index table is touched.

## Why it's needed

The qc-helper skill ships with the CLI and uses its hardcoded documentation index at runtime to locate docs for `/qc-helper` invocations. Stale or missing entries cause the skill to miss the right documentation. `qwen serve` is a prominently documented feature (it has two pages and a top-level nav entry) but wasn't reachable via `/qc-helper`. The incomplete system path would give Linux and Windows admins wrong information when asking about system-wide settings.

## Reviewer Test Plan

### How to verify

- Build the CLI and run `/qc-helper how do I run qwen serve?` — the skill should now read `qwen-serve.md` and answer accurately.
- Run `/qc-helper where is the system settings file on Linux?` — the skill's quick reference now includes `/etc/qwen-code/settings.json`.

### Evidence (Before & After)

N/A — docs-only change (skill index table).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A

## Risk & Scope

- Main risk or tradeoff: None — additive change to an index table; no logic changes.
- Not validated / out of scope: Channel-specific docs (telegram.md, feishu.md, etc.) are also absent from the index but the existing `channels/overview.md` entry covers the primary use case; adding all channel sub-pages would be a follow-up.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

修复了 `/qc-helper` 内置技能文档索引（`packages/core/src/skills/bundled/qc-helper/SKILL.md`）中的两处缺漏：

1. **新增"守护进程模式"章节**，添加了 `docs/qwen-serve.md` 和 `docs/qwen-serve-deploy-local.md` 两个条目。这两个文档已存在于 `docs/users/` 目录并在 `docs/users/_meta.ts` 中注册，但未出现在 qc-helper 的索引中，导致用户通过 `/qc-helper how does qwen serve work?` 无法找到相关文档。
2. **补全系统设置文件路径**：将配置文件位置快速参考表中的系统路径从仅显示 macOS 扩展为同时包含 Linux、Windows 和 macOS 三个平台，与 `docs/users/configuration/settings.md` 的现有描述保持一致。

本次更改仅涉及内置技能的索引表，不影响源代码、测试或用户文档页面。

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_014xYwTpwyfQ2gKmifZgGLCB)_