### PR TITLE
fix(cli): Avoid ACP runtime preload on serve fast path

### DIFF
--- a/packages/cli/src/serve/fast-path.test.ts
+++ b/packages/cli/src/serve/fast-path.test.ts
@@ -6,7 +6,9 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import yargs, { type Argv } from 'yargs';
+import { execFileSync } from 'node:child_process';
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -16,7 +18,8 @@ import {
   writeFileSync,
 } from 'node:fs';
 import * as os from 'node:os';
-import { join } from 'node:path';
+import { dirname, join, relative, resolve } from 'node:path';
+import * as ts from 'typescript';
 import { QWEN_DIR, Storage } from '@qwen-code/qwen-code-core';
 
 import {
@@ -66,6 +69,195 @@ const originalRateLimitPrompt = process.env['QWEN_SERVE_RATE_LIMIT_PROMPT'];
 const originalCloudShell = process.env['CLOUD_SHELL'];
 const originalGoogleCloudProject = process.env['GOOGLE_CLOUD_PROJECT'];
 const originalCwd = process.cwd();
+const cliPackageRoot = process.cwd();
+const repoRoot = resolve(cliPackageRoot, '../..');
+
+interface StaticSourceGraph {
+  localFiles: Set<string>;
+  externalValueImports: Set<string>;
+  unresolvedLocalImports: string[];
+}
+
+interface EsbuildMetafileOutput {
+  inputs?: Record<string, unknown>;
+  imports?: Array<{
+    path: string;
+    kind?: string;
+  }>;
+}
+
+interface EsbuildMetafile {
+  outputs: Record<string, EsbuildMetafileOutput>;
+}
+
+function normalizePathForTest(filePath: string): string {
+  return filePath.replace(/\\/g, '/');
+}
+
+function moduleSpecifierText(
+  specifier: ts.Expression | undefined,
+): string | undefined {
+  if (!specifier || !ts.isStringLiteral(specifier)) return undefined;
+  return specifier.text;
+}
+
+function importDeclarationHasRuntimeValue(node: ts.ImportDeclaration): boolean {
+  const clause = node.importClause;
+  if (!clause) return true;
+  if (clause.isTypeOnly) return false;
+  if (clause.name) return true;
+  const bindings = clause.namedBindings;
+  if (!bindings) return false;
+  if (ts.isNamespaceImport(bindings)) return true;
+  if (bindings.elements.length === 0) return true;
+  return bindings.elements.some((element) => !element.isTypeOnly);
+}
+
+function exportDeclarationHasRuntimeValue(node: ts.ExportDeclaration): boolean {
+  if (node.isTypeOnly) return false;
+  const clause = node.exportClause;
+  if (!clause) return true;
+  if (ts.isNamespaceExport(clause)) return true;
+  if (clause.elements.length === 0) return true;
+  return clause.elements.some((element) => !element.isTypeOnly);
+}
+
+function resolveLocalSourceImport(
+  importer: string,
+  specifier: string,
+): string | undefined {
+  const basePath = resolve(dirname(importer), specifier);
+  const candidates = specifier.endsWith('.js')
+    ? [`${basePath.slice(0, -3)}.ts`, `${basePath.slice(0, -3)}.tsx`]
+    : [
+        `${basePath}.ts`,
+        `${basePath}.tsx`,
+        join(basePath, 'index.ts'),
+        join(basePath, 'index.tsx'),
+      ];
+  return candidates.find((candidate) => existsSync(candidate));
+}
+
+function collectStaticSourceGraph(entryFile: string): StaticSourceGraph {
+  const visited = new Set<string>();
+  const localFiles = new Set<string>();
+  const externalValueImports = new Set<string>();
+  const unresolvedLocalImports: string[] = [];
+
+  function visit(filePath: string): void {
+    const normalizedFilePath = resolve(filePath);
+    if (visited.has(normalizedFilePath)) return;
+    visited.add(normalizedFilePath);
+    localFiles.add(
+      normalizePathForTest(relative(cliPackageRoot, normalizedFilePath)),
+    );
+
+    const sourceText = readFileSync(normalizedFilePath, 'utf8');
+    const sourceFile = ts.createSourceFile(
+      normalizedFilePath,
+      sourceText,
+      ts.ScriptTarget.Latest,
+      true,
+      normalizedFilePath.endsWith('.tsx')
+        ? ts.ScriptKind.TSX
+        : ts.ScriptKind.TS,
+    );
+
+    for (const statement of sourceFile.statements) {
+      let specifier: string | undefined;
+      let hasRuntimeValue = false;
+      if (ts.isImportDeclaration(statement)) {
+        specifier = moduleSpecifierText(statement.moduleSpecifier);
+        hasRuntimeValue = importDeclarationHasRuntimeValue(statement);
+      } else if (ts.isExportDeclaration(statement)) {
+        specifier = moduleSpecifierText(statement.moduleSpecifier);
+        hasRuntimeValue = exportDeclarationHasRuntimeValue(statement);
+      }
+      if (!specifier || !hasRuntimeValue) continue;
+      if (!specifier.startsWith('.')) {
+        externalValueImports.add(specifier);
+        continue;
+      }
+      const resolvedImport = resolveLocalSourceImport(
+        normalizedFilePath,
+        specifier,
+      );
+      if (!resolvedImport) {
+        unresolvedLocalImports.push(
+          `${normalizePathForTest(relative(cliPackageRoot, normalizedFilePath))} -> ${specifier}`,
+        );
+        continue;
+      }
+      visit(resolvedImport);
+    }
+  }
+
+  visit(entryFile);
+  return { localFiles, externalValueImports, unresolvedLocalImports };
+}
+
+function collectBundledRunServeStaticRuntimeOffenders(): string[] {
+  const metafilePath = resolve(repoRoot, 'dist/esbuild.json');
+  rmSync(metafilePath, { force: true });
+  execFileSync(process.execPath, [resolve(repoRoot, 'esbuild.config.js')], {
+    cwd: repoRoot,
+    env: { ...process.env, DEV: 'true' },
+    stdio: 'pipe',
+    timeout: 30_000,
+  });
+
+  expect(existsSync(metafilePath)).toBe(true);
+  const metafile = JSON.parse(
+    readFileSync(metafilePath, 'utf8'),
+  ) as EsbuildMetafile;
+  const outputs = new Map(
+    Object.entries(metafile.outputs).map(([outputPath, output]) => [
+      normalizePathForTest(outputPath),
+      output,
+    ]),
+  );
+  const runServeOutput = [...outputs.entries()].find(([, output]) =>
+    Object.keys(output.inputs ?? {}).some(
+      (input) =>
+        normalizePathForTest(input) ===
+        'packages/cli/src/serve/run-qwen-serve.ts',
+    ),
+  );
+  expect(runServeOutput).toBeDefined();
+  const queue = [runServeOutput![0]];
+  const staticClosure = new Set(queue);
+
+  for (let i = 0; i < queue.length; i++) {
+    const output = outputs.get(queue[i]);
+    for (const bundledImport of output?.imports ?? []) {
+      if (bundledImport.kind !== 'import-statement') continue;
+      const importedOutput = normalizePathForTest(bundledImport.path);
+      if (!outputs.has(importedOutput) || staticClosure.has(importedOutput)) {
+        continue;
+      }
+      staticClosure.add(importedOutput);
+      queue.push(importedOutput);
+    }
+  }
+
+  const forbiddenInputs = new Set([
+    'packages/cli/src/serve/acp-session-bridge.ts',
+    'packages/acp-bridge/src/bridge.ts',
+    'packages/acp-bridge/src/bridgeClient.ts',
+    'packages/acp-bridge/src/spawnChannel.ts',
+  ]);
+  const offenders: string[] = [];
+  for (const outputPath of staticClosure) {
+    const output = outputs.get(outputPath);
+    for (const input of Object.keys(output?.inputs ?? {})) {
+      const normalizedInput = normalizePathForTest(input);
+      if (forbiddenInputs.has(normalizedInput)) {
+        offenders.push(`${outputPath} -> ${normalizedInput}`);
+      }
+    }
+  }
+  return offenders;
+}
 
 function useTempQwenHome(): string {
   tempQwenHome = realpathSync(
@@ -297,6 +489,45 @@ describe('CLI entry import boundary', () => {
     expect(runServeSource).toContain("import('./server.js')");
     expect(runServeSource).toContain("import('@qwen-code/acp-bridge/bridge')");
   });
+
+  it('keeps the runQwenServe static source graph free of ACP runtime modules', () => {
+    const graph = collectStaticSourceGraph(
+      resolve(cliPackageRoot, 'src/serve/run-qwen-serve.ts'),
+    );
+
+    expect(graph.unresolvedLocalImports).toEqual([]);
+    const forbiddenLocalFiles = [...graph.localFiles].filter(
+      (filePath) => filePath === 'src/serve/acp-session-bridge.ts',
+    );
+    expect(
+      forbiddenLocalFiles,
+      `Unexpected static source graph files:\n${forbiddenLocalFiles.join('\n')}`,
+    ).toEqual([]);
+
+    const forbiddenExternalImports = [
+      '@qwen-code/acp-bridge',
+      '@qwen-code/acp-bridge/bridge',
+      '@qwen-code/acp-bridge/spawnChannel',
+      '@qwen-code/acp-bridge/bridgeClient',
+      '@qwen-code/acp-bridge/bridgeErrors',
+    ];
+    const forbiddenImports = [...graph.externalValueImports].filter(
+      (specifier) => forbiddenExternalImports.includes(specifier),
+    );
+    expect(
+      forbiddenImports,
+      `Unexpected ACP runtime imports:\n${forbiddenImports.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('keeps bundled runQwenServe static imports free of ACP runtime modules', () => {
+    const offenders = collectBundledRunServeStaticRuntimeOffenders();
+
+    expect(
+      offenders,
+      `Unexpected ACP runtime inputs in static bundle closure:\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  }, 30_000);
 });
 
 describe('serve fast path argument parsing', () => {

--- a/packages/cli/src/serve/server/request-helpers.ts
+++ b/packages/cli/src/serve/server/request-helpers.ts
@@ -6,11 +6,9 @@
 
 import * as path from 'node:path';
 import type { Request, Response } from 'express';
+import type { AcpSessionBridge } from '@qwen-code/acp-bridge/bridgeTypes';
+import { MAX_WORKSPACE_PATH_LENGTH } from '@qwen-code/acp-bridge/workspacePaths';
 import { writeStderrLine } from '../../utils/stdioHelpers.js';
-import {
-  MAX_WORKSPACE_PATH_LENGTH,
-  type AcpSessionBridge,
-} from '../acp-session-bridge.js';
 import type { WorkspaceRequestContext } from '../workspace-service/index.js';
 
 export function sendJsonBodyParserError(res: Response, err: unknown): boolean {


### PR DESCRIPTION
## What this PR does

This PR keeps `qwen serve`'s fast startup path from statically pulling in the ACP runtime before the daemon has reached its dynamic runtime boundary. It routes the request helper's bridge type and workspace path limit through lightweight ACP bridge subpaths, then adds regression coverage that checks both the source-level static import graph and the esbuild bundle metafile static closure.

The guards intentionally ignore type-only imports and dynamic imports, so the existing lazy boundary for the server runtime, bridge factory, and spawn channel remains intact while accidental static runtime imports fail fast in tests.

## Why it's needed

Issue #4748 tracks startup regressions where the serve fast path can preload heavy ACP runtime modules too early. A helper-level re-export import made the fast path transitively reachable to the compatibility bridge shim, which defeats the intended lazy runtime split and can regress daemon listen latency.

The new tests protect against this class of regression from both source changes and bundle chunking changes without changing CLI flags, HTTP/ACP protocol behavior, public types, or the compatibility shim.

## Reviewer Test Plan

A reviewer should confirm that the serve fast path still keeps ACP runtime modules behind dynamic imports, and that the new regression tests fail if the static source graph or bundled static closure reaches the ACP runtime again.

### How to verify

Run `cd packages/cli && npx vitest run src/serve/fast-path.test.ts` and confirm all 58 tests pass, including the source graph and bundle metafile guards. Run `npm run build`, `npm run typecheck`, and `DEV=true npm run bundle`; then inspect `dist/esbuild.json` and confirm the static import closure from the `run-qwen-serve` output does not include ACP runtime inputs while the lazy runtime chunks are still emitted through dynamic imports.

### Evidence (Before & After)

N/A — this is a non-UI startup import-boundary fix with regression coverage.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS worktree with repository npm scripts; validation used the repo's configured Node/npm toolchain.

## Risk & Scope

- Main risk or tradeoff: the bundle metafile guard invokes the repo esbuild config from the CLI package test, which adds a small amount of runtime to this focused test file and writes ignored bundle artifacts under `dist/`.
- Not validated / out of scope: this PR does not implement raw HTTP server work, change settings/version loading, remove the compatibility shim, or modify standalone install scripts.
- Breaking changes / migration notes: none; CLI arguments, HTTP/ACP behavior, public interfaces, and user-visible behavior are unchanged.

## Linked Issues

Refs #4748

<details>
<summary>中文说明</summary>

## What this PR does

本 PR 防止 `qwen serve` 的 fast startup path 在 daemon 到达动态 runtime 边界前静态拉入 ACP runtime。它把请求 helper 需要的 bridge 类型和 workspace path 上限改为从轻量 ACP bridge 子路径获取，并新增回归覆盖，同时检查源码级静态 import 图和 esbuild bundle metafile 的静态闭包。

这些 guard 会有意忽略 type-only import 和 dynamic import，因此现有的 server runtime、bridge factory、spawn channel 懒加载边界保持不变；如果后续误加静态 runtime import，测试会直接失败。

## Why it's needed

Issue #4748 跟踪的是 serve fast path 过早预加载较重 ACP runtime 模块导致的启动回归。一个 helper 层的 re-export import 让 fast path 可以传递到兼容 bridge shim，从而破坏预期的 lazy runtime split，并可能回归 daemon 监听前延迟。

新的测试同时从源码变更和 bundle chunking 变更两个层面保护这类回归，并且不改变 CLI 参数、HTTP/ACP 协议行为、公共类型或兼容 shim。

## Reviewer Test Plan

Reviewer 应确认 serve fast path 仍然把 ACP runtime 模块保留在 dynamic imports 之后，并确认当静态源码图或 bundle 静态闭包重新触达 ACP runtime 时，新的回归测试会失败。

### How to verify

运行 `cd packages/cli && npx vitest run src/serve/fast-path.test.ts`，确认全部 58 个测试通过，包括 source graph 和 bundle metafile guard。运行 `npm run build`、`npm run typecheck` 和 `DEV=true npm run bundle`；然后检查 `dist/esbuild.json`，确认从 `run-qwen-serve` 输出出发的静态 import closure 不包含 ACP runtime inputs，同时 lazy runtime chunks 仍然通过 dynamic imports 产出。

### Evidence (Before & After)

N/A — 这是非 UI 的启动 import 边界修复和回归覆盖。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 macOS worktree，使用仓库 npm scripts；验证使用仓库配置的 Node/npm 工具链。

## Risk & Scope

- Main risk or tradeoff: bundle metafile guard 会从 CLI package 测试里调用仓库的 esbuild config，这会让这个定向测试文件增加少量运行时间，并在 `dist/` 下写入 ignored bundle artifacts。
- Not validated / out of scope: 本 PR 不实现 raw HTTP server，不修改 settings/version loading，不删除兼容 shim，也不修改 standalone install scripts。
- Breaking changes / migration notes: 无；CLI 参数、HTTP/ACP 行为、公共接口和用户可见行为均不变。

## Linked Issues

Refs #4748

</details>
