### PR TITLE
fix(web-shell): prefer raw file diffs in tool output

### DIFF
--- a/packages/web-shell/client/components/messages/ToolGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.test.tsx
@@ -13,6 +13,7 @@ vi.mock('../../App', async () => {
 
 const {
   buildUnifiedDiff,
+  extractDiff,
   formatToolGroupSummary,
   getActiveTool,
   getRawFileDiff,
@@ -182,6 +183,32 @@ describe('tool output logic', () => {
         }),
       ),
     ).toBe('');
+  });
+
+  it('prefers raw fileDiff over content old/new text', () => {
+    const fileDiff =
+      'Index: file.ts\n@@ -10,1 +10,2 @@\n old context\n+precise line';
+
+    expect(
+      extractDiff(
+        makeTool({
+          toolName: 'edit',
+          content: [
+            {
+              type: 'diff',
+              oldText: 'full old text',
+              newText: 'full new text',
+            },
+          ],
+          rawOutput: {
+            fileDiff,
+            fileName: 'file.ts',
+            originalContent: 'full old text',
+            newContent: 'full new text',
+          },
+        }),
+      ),
+    ).toBe(fileDiff);
   });
 
   it('builds a unified diff for changed content blocks', () => {

--- a/packages/web-shell/client/components/messages/ToolGroup.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.tsx
@@ -110,14 +110,18 @@ function hasEditContent(tool: ACPToolCall): boolean {
   return hasDiffContent(tool) || !!extractText(tool);
 }
 
-function extractDiff(tool: ACPToolCall): string {
+export function extractDiff(tool: ACPToolCall): string {
+  const rawFileDiff = getRawFileDiff(tool);
+  if (rawFileDiff) return rawFileDiff;
+
   if (tool.content) {
     const diffBlock = tool.content.find((b) => b.type === 'diff');
     if (diffBlock && diffBlock.type === 'diff') {
       return buildUnifiedDiff(diffBlock.oldText || '', diffBlock.newText || '');
     }
   }
-  return getRawFileDiff(tool);
+
+  return '';
 }
 
 export function getRawFileDiff(tool: ACPToolCall): string {


### PR DESCRIPTION
## What this PR does

This PR updates the web-shell tool output renderer to prefer the raw file diff produced by the daemon/tool result when both a structured old/new content diff and a precomputed file diff are available. It keeps the existing structured old/new diff rendering as the fallback for cases where no raw file diff is present.

It also adds a focused logic test that covers the mixed payload shape where an edit tool call contains both full old/new text and a precise file diff.

## Why it's needed

Some edit tool updates include full `oldText`/`newText` content in the structured diff block and also include a precise `fileDiff` in the raw output. The previous web-shell priority chose the full old/new content first, which made the UI recompute the diff from large complete file contents and could show a broad, noisy diff instead of the precise hunk returned by the tool.

Preferring the raw file diff preserves the backend-generated hunk locations and makes expanded edit output show the relevant changed lines instead of a large block of unchanged surrounding content.

## Reviewer Test Plan

### How to verify

Create or inspect an edit tool update payload that contains both structured `content: [{ type: 'diff', oldText, newText }]` and `rawOutput.fileDiff`. Expand the tool output in web-shell. The displayed diff should match the precise `rawOutput.fileDiff` hunk rather than a recomputed diff from the full old/new text.

Local verification: `cd packages/web-shell && npx vitest run client/components/messages/ToolGroup.test.tsx`

Output: `Test Files 1 passed (1)`, `Tests 11 passed (11)`.

### Evidence (Before & After)

Before: web-shell chose the structured old/new block first, so an edit payload with full file contents could render a large recomputed diff even though `rawOutput.fileDiff` already contained the precise hunk.

After: web-shell chooses `rawOutput.fileDiff` first, so the expanded edit output renders the precise tool-provided hunk. If no raw file diff exists, the existing structured old/new fallback is unchanged.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Node 22 workspace, targeted web-shell vitest logic test.

## Risk & Scope

- Main risk or tradeoff: The selected display source changes only when both raw `fileDiff` and structured old/new diff are present; this intentionally trusts the tool-generated diff as the more precise representation.
- Not validated / out of scope: Browser visual regression testing and full repository typecheck/build.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<img width="2202" height="1048" alt="image" src="https://github.com/user-attachments/assets/53d6d3b0-11d1-4b21-bba8-b9cee79fdb02" />


<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 调整了 web-shell 工具输出的 diff 选择顺序：当同一个工具结果里同时存在结构化 old/new diff 和 daemon/tool 生成好的原始 file diff 时，优先展示原始 file diff。没有原始 file diff 的情况下，继续使用已有的结构化 old/new diff fallback。

同时补充了一个聚焦的逻辑测试，覆盖 edit 工具结果同时包含完整 old/new 文本和精准 file diff 的数据形态。

## 为什么需要

有些 edit 工具更新会同时包含 `content: [{ type: 'diff', oldText, newText }]` 和 `rawOutput.fileDiff`。之前 web-shell 优先选择完整 old/new 内容，导致 UI 会基于完整文件内容重新计算 diff，在文件较大时容易展示一大段噪声内容，而不是工具已经返回的精准 hunk。

优先使用原始 file diff 可以保留后端生成好的 hunk 位置信息，让展开后的 edit 输出显示真正相关的变更行，而不是大段未变化上下文。

## Reviewer Test Plan

### 如何验证

构造或检查一个 edit 工具更新 payload，其中同时包含结构化 `content: [{ type: 'diff', oldText, newText }]` 和 `rawOutput.fileDiff`。在 web-shell 中展开工具输出。展示的 diff 应匹配精准的 `rawOutput.fileDiff` hunk，而不是从完整 old/new 文本重新计算出来的 diff。

本地验证：`cd packages/web-shell && npx vitest run client/components/messages/ToolGroup.test.tsx`

输出：`Test Files 1 passed (1)`，`Tests 11 passed (11)`。

### 前后对比证据

Before：web-shell 优先选择结构化 old/new block，因此包含完整文件内容的 edit payload 即使已经有精准 `rawOutput.fileDiff`，也可能渲染出大段重新计算的 diff。

After：web-shell 优先选择 `rawOutput.fileDiff`，展开 edit 输出时展示工具提供的精准 hunk。没有 raw file diff 时，原有结构化 old/new fallback 保持不变。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Node 22 workspace，定向运行 web-shell vitest 逻辑测试。

## 风险和范围

- 主要风险或取舍：只有当 raw `fileDiff` 和结构化 old/new diff 同时存在时，展示来源会发生变化；这是有意信任工具生成的 diff，因为它更精准。
- 未验证 / 不在范围内：浏览器视觉回归测试和全仓库 typecheck/build。
- Breaking changes / 迁移说明：无。

## Linked Issues

N/A

</details>
