### PR TITLE
[codex] fix daemon specialized model filtering

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -2037,6 +2037,62 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
+  it('provider status filters fastOnly and voiceOnly models', async () => {
+    mockConfig = {
+      ...mockConfig,
+      getTargetDir: vi.fn().mockReturnValue('/work/status'),
+      getAuthType: vi.fn().mockReturnValue('qwen'),
+      getActiveRuntimeModelSnapshot: vi.fn().mockReturnValue(undefined),
+      getModel: vi.fn().mockReturnValue('qwen-plus'),
+      getAllConfiguredModels: vi.fn().mockReturnValue([
+        {
+          id: 'qwen-plus',
+          label: 'Qwen Plus',
+          authType: 'qwen',
+        },
+        {
+          id: 'qwen-flash',
+          label: 'Qwen Flash',
+          authType: 'qwen',
+          fastOnly: true,
+        },
+        {
+          id: 'qwen-asr',
+          label: 'Qwen ASR',
+          authType: 'qwen',
+          voiceOnly: true,
+        },
+      ]),
+    } as unknown as Config;
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    const status = await agent.extMethod(
+      SERVE_STATUS_EXT_METHODS.workspaceProviders,
+      {},
+    );
+
+    expect(
+      (status['providers'] as Array<{ models: Array<{ modelId: string }> }>)
+        .flatMap((provider) => provider.models)
+        .map((model) => model.modelId),
+    ).toEqual(['qwen-plus(qwen)']);
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it('provider status uses runtime model ids for base id and token limit', async () => {
     mockConfig = {
       ...mockConfig,
@@ -2092,6 +2148,79 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       ],
     });
     expect(vi.mocked(tokenLimit)).toHaveBeenCalledWith('runtime-qwen-plus');
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('session model selectors filter fastOnly and voiceOnly models', async () => {
+    const sessionId = '11111111-1111-1111-1111-111111111111';
+    const innerConfig = await setupSessionMocks(sessionId);
+    Object.assign(innerConfig, {
+      getModel: vi.fn().mockReturnValue('main-model'),
+      getAuthType: vi.fn().mockReturnValue('api-key'),
+      getAllConfiguredModels: vi.fn().mockReturnValue([
+        {
+          id: 'main-model',
+          label: 'Main Model',
+          authType: 'api-key',
+        },
+        {
+          id: 'fast-model',
+          label: 'Fast Model',
+          authType: 'api-key',
+          fastOnly: true,
+        },
+        {
+          id: 'voice-model',
+          label: 'Voice Model',
+          authType: 'api-key',
+          voiceOnly: true,
+        },
+      ]),
+    });
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    const session = (await agent.newSession({
+      cwd: '/tmp',
+      mcpServers: [],
+    })) as {
+      models: { availableModels: Array<{ modelId: string }> };
+      configOptions: Array<{
+        id: string;
+        options: Array<{ value: string }>;
+      }>;
+    };
+    const context = (await agent.extMethod(
+      SERVE_STATUS_EXT_METHODS.sessionContext,
+      { sessionId },
+    )) as {
+      state: { models: { availableModels: Array<{ modelId: string }> } };
+    };
+
+    expect(
+      session.models.availableModels.map((model) => model.modelId),
+    ).toEqual(['main-model(api-key)']);
+    expect(
+      session.configOptions
+        .find((option) => option.id === 'model')
+        ?.options.map((option) => option.value),
+    ).toEqual(['main-model(api-key)']);
+    expect(
+      context.state.models.availableModels.map((model) => model.modelId),
+    ).toEqual(['main-model(api-key)']);
 
     mockConnectionState.resolve();
     await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -3905,7 +3905,9 @@ class QwenAgent implements Agent {
           : currentModelId || undefined;
       const providers = new Map<string, ServeWorkspaceProviderStatus>();
 
-      for (const model of config.getAllConfiguredModels()) {
+      for (const model of config
+        .getAllConfiguredModels()
+        .filter(isMainSelectableModel)) {
         const authType = String(model.authType);
         let provider = providers.get(authType);
         if (!provider) {
@@ -7688,7 +7690,9 @@ class QwenAgent implements Agent {
       ''
     ).trim();
     const currentAuthType = config.getAuthType();
-    const allConfiguredModels = config.getAllConfiguredModels();
+    const allConfiguredModels = config
+      .getAllConfiguredModels()
+      .filter(isMainSelectableModel);
 
     const activeRuntimeSnapshot = config.getActiveRuntimeModelSnapshot?.();
     const currentModelId = activeRuntimeSnapshot
@@ -7737,7 +7741,9 @@ class QwenAgent implements Agent {
 
   private buildConfigOptions(config: Config): SessionConfigOption[] {
     const currentApprovalMode = config.getApprovalMode();
-    const allConfiguredModels = config.getAllConfiguredModels();
+    const allConfiguredModels = config
+      .getAllConfiguredModels()
+      .filter(isMainSelectableModel);
     const rawCurrentModelId = (config.getModel() || '').trim();
     const currentAuthType = config.getAuthType?.();
 
@@ -7797,6 +7803,13 @@ class QwenAgent implements Agent {
     if (!baseModelId) return baseModelId;
     return authType ? formatAcpModelId(baseModelId, authType) : baseModelId;
   }
+}
+
+function isMainSelectableModel(model: {
+  fastOnly?: boolean;
+  voiceOnly?: boolean;
+}): boolean {
+  return model.fastOnly !== true && model.voiceOnly !== true;
 }
 
 function diffSettingsKeys(

--- a/packages/cli/src/serve/workspace-providers-status.test.ts
+++ b/packages/cli/src/serve/workspace-providers-status.test.ts
@@ -158,6 +158,30 @@ describe('createWorkspaceProvidersStatusProvider', () => {
     ).toBe(true);
   });
 
+  it('filters fastOnly and voiceOnly models from the workspace provider catalog', async () => {
+    const provider = createWorkspaceProvidersStatusProvider({ env: {} });
+    await writeUserSettings({
+      security: { auth: { selectedType: 'openai' } },
+      model: { name: 'main-model' },
+      modelProviders: {
+        openai: [
+          { id: 'main-model', name: 'Main Model' },
+          { id: 'fast-model', name: 'Fast Model', fastOnly: true },
+          { id: 'voice-model', name: 'Voice Model', voiceOnly: true },
+        ],
+      },
+    });
+
+    const result = await provider(workspace, false);
+    const modelIds = result.providers.flatMap((p) =>
+      p.models.map((m) => m.modelId),
+    );
+
+    expect(modelIds).toContain('main-model(openai)');
+    expect(modelIds).not.toContain('fast-model(openai)');
+    expect(modelIds).not.toContain('voice-model(openai)');
+  });
+
   it('reports custom providerProtocol models under their resolved auth type', async () => {
     const provider = createWorkspaceProvidersStatusProvider({ env: {} });
     await writeUserSettings({

--- a/packages/cli/src/serve/workspace-providers-status.ts
+++ b/packages/cli/src/serve/workspace-providers-status.ts
@@ -103,7 +103,9 @@ function buildWorkspaceProvidersStatus(
       settings.providerProtocol,
     );
 
-    for (const model of modelsConfig.getAllConfiguredModels()) {
+    for (const model of modelsConfig
+      .getAllConfiguredModels()
+      .filter(isMainSelectableModel)) {
       if (model.isRuntimeModel) continue;
       const authType = String(model.authType);
       let provider = providers.get(authType);
@@ -196,6 +198,13 @@ function buildWorkspaceProvidersStatus(
       ],
     };
   }
+}
+
+function isMainSelectableModel(model: {
+  fastOnly?: boolean;
+  voiceOnly?: boolean;
+}): boolean {
+  return model.fastOnly !== true && model.voiceOnly !== true;
 }
 
 function matchesCurrentModel(


### PR DESCRIPTION
## What this PR does

Extends the specialized model filtering from #5632 into daemon-backed model surfaces. Models marked `fastOnly` or `voiceOnly` are no longer advertised as normal selectable conversation models through daemon workspace provider status, ACP workspace provider status, ACP session model state, or ACP model config options.

## Why it's needed

#5632 hid fast-only and voice-only models from the CLI's normal `/model` picker, but daemon-backed clients can build their model selector from daemon provider/session metadata instead of the Ink picker. Without filtering at those daemon seams, Web chat and other daemon clients could still show specialized background or voice models in the normal model list.

## Reviewer Test Plan

### How to verify

Configure `modelProviders` with one normal model, one `fastOnly: true` model, and one `voiceOnly: true` model, then read daemon workspace provider status or create/load a daemon ACP session. The normal model should remain selectable, while the fast-only and voice-only models should not appear in the normal daemon model catalog or ACP session model options.

### Evidence (Before & After)

N/A — non-visual daemon metadata behavior covered by unit tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js v22.17.0. Verified with `cd packages/cli && npx vitest run src/serve/workspace-providers-status.test.ts src/acp-integration/acpAgent.test.ts` and `npm run typecheck`. `npm install` was run to restore the missing local `@types/chrome` dependency before the final typecheck.

## Risk & Scope

- Main risk or tradeoff: Daemon clients now share the CLI normal-model filtering behavior, so specialized models are intentionally absent from normal daemon model selectors.
- Not validated / out of scope: Fast-model and voice-model dedicated selector behavior is unchanged; this PR does not add a dedicated daemon fast/voice picker.
- Breaking changes / migration notes: None for users without `fastOnly` or `voiceOnly` model flags.

## Linked Issues

Related to #5632.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 #5632 的专用模型过滤扩展到 daemon 支持的模型数据面。标记为 `fastOnly` 或 `voiceOnly` 的模型不会再通过 daemon workspace provider status、ACP workspace provider status、ACP session model state 或 ACP model config options 作为普通对话模型候选暴露出去。

## 为什么需要

#5632 已经让 CLI 普通 `/model` 选择器隐藏 fast-only 和 voice-only 模型，但 daemon 客户端可能从 daemon provider/session metadata 构建模型选择器，而不是走 Ink 选择器。如果这些 daemon 数据面不做过滤，Web chat 和其他 daemon 客户端仍然可能在普通模型列表中展示后台任务模型或语音模型。

## 审查测试计划

### 如何验证

在 `modelProviders` 中配置一个普通模型、一个 `fastOnly: true` 模型和一个 `voiceOnly: true` 模型，然后读取 daemon workspace provider status 或创建/加载 daemon ACP session。普通模型应继续可选，fast-only 和 voice-only 模型不应出现在普通 daemon 模型目录或 ACP session 模型选项里。

### Evidence (Before & After)

N/A — 非视觉 daemon metadata 行为已由单元测试覆盖。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js v22.17.0。已通过 `cd packages/cli && npx vitest run src/serve/workspace-providers-status.test.ts src/acp-integration/acpAgent.test.ts` 和 `npm run typecheck` 验证。最终 typecheck 前运行了 `npm install`，用于恢复本地缺失的 `@types/chrome` 依赖。

## 风险和范围

- 主要风险或权衡：daemon 客户端现在与 CLI 普通模型选择器共享同样过滤语义，因此专用模型会被有意从普通 daemon 模型选择器中移除。
- 未验证/范围外：专用 fast-model 和 voice-model 选择器行为未改变；本 PR 不新增 daemon 专用 fast/voice picker。
- 破坏性变更/迁移说明：未使用 `fastOnly` 或 `voiceOnly` 标记的用户没有行为变化。

## 关联问题

关联 #5632。

</details>