### PR TITLE
fix(ci): cover release integration regressions

### DIFF
--- a/integration-tests/cli/qwen-serve-client-mcp.test.ts
+++ b/integration-tests/cli/qwen-serve-client-mcp.test.ts
@@ -58,9 +58,9 @@ const REPO_ROOT = path.resolve(__dirname, '../..');
 // platform-agnostic, but daemon SIGTERM teardown is cleaner on POSIX. Keep it
 // running everywhere `ws` works.
 const SKIP = process.platform === 'win32';
-const SANDBOX_MODE = process.env['QWEN_SANDBOX']?.toLowerCase();
+const SANDBOX_MODE = process.env['QWEN_SANDBOX']?.toLowerCase().trim();
 const SKIP_PROMPTED_MODEL_TEST = Boolean(
-  SANDBOX_MODE && SANDBOX_MODE !== 'false',
+  SANDBOX_MODE && SANDBOX_MODE !== 'false' && SANDBOX_MODE !== '0',
 );
 const describeMaybe = SKIP ? describe.skip : describe;
 const itPromptedModelMaybe = SKIP_PROMPTED_MODEL_TEST ? it.skip : it;

--- a/integration-tests/cli/qwen-serve-client-mcp.test.ts
+++ b/integration-tests/cli/qwen-serve-client-mcp.test.ts
@@ -58,7 +58,12 @@ const REPO_ROOT = path.resolve(__dirname, '../..');
 // platform-agnostic, but daemon SIGTERM teardown is cleaner on POSIX. Keep it
 // running everywhere `ws` works.
 const SKIP = process.platform === 'win32';
+const SANDBOX_MODE = process.env['QWEN_SANDBOX']?.toLowerCase();
+const SKIP_PROMPTED_MODEL_TEST = Boolean(
+  SANDBOX_MODE && SANDBOX_MODE !== 'false',
+);
 const describeMaybe = SKIP ? describe.skip : describe;
+const itPromptedModelMaybe = SKIP_PROMPTED_MODEL_TEST ? it.skip : it;
 
 let daemon: ChildProcess;
 let port = 0;
@@ -417,7 +422,9 @@ describeMaybe('qwen serve — reverse tool channel (client-hosted MCP over WS)',
   //
   // This test does session/new THEN mcp_register (the "register after a session
   // already exists" timing), exercising the fan-out path specifically.
-  it('drives a model→agent tools/call of chrome_read_page over the reverse WS channel and consumes the result', async () => {
+  // Under container sandboxing, the ACP child cannot reach the host-loopback
+  // fake model server used below; keep the discovery-only test running there.
+  itPromptedModelMaybe('drives a model→agent tools/call of chrome_read_page over the reverse WS channel and consumes the result', async () => {
     const ws = new WebSocket(`ws://127.0.0.1:${port}/acp`, {
       headers: { Authorization: `Bearer ${TOKEN}` },
     });

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -24,12 +24,12 @@
     "README.md"
   ],
   "scripts": {
-    "dev": "EXTENSION_OUT_DIR=dist/extension node scripts/dev-watch.js",
+    "dev": "node scripts/dev-watch.js",
     "debug:mac": "./scripts/debug.sh",
     "sync:extension": "node scripts/sync-extension.js",
     "build:bg": "node scripts/sync-extension.js && node config/esbuild.background.config.js",
     "build:bg:watch": "node scripts/sync-extension.js && node config/esbuild.background.config.js --watch",
-    "build": "EXTENSION_OUT_DIR=dist/extension npm run clean && EXTENSION_OUT_DIR=dist/extension node scripts/sync-extension.js && EXTENSION_OUT_DIR=dist/extension node config/esbuild.background.config.js --production",
+    "build": "node scripts/sync-extension.js && node config/esbuild.background.config.js --production",
     "test": "vitest run --config vitest.config.ts",
     "test:ci": "vitest run --config vitest.config.ts",
     "dev:chrome": "open -a 'Google Chrome' --args --load-extension=$PWD/dist/extension --auto-open-devtools-for-tabs",

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -17,22 +17,6 @@ const YAMLLINT_VERSION = '1.35.1';
 
 const TEMP_DIR = join(tmpdir(), 'qwen-code-linters');
 
-function archiveInstaller(url, archivePath, extractCommand) {
-  return `
-      for attempt in 1 2 3 4 5; do
-        curl --fail --location --show-error --silent --retry 3 --retry-all-errors --retry-delay 2 --output "${archivePath}" "${url}" \\
-          && tar -tf "${archivePath}" >/dev/null \\
-          && break
-        rm -f "${archivePath}"
-        if [ "$attempt" -eq 5 ]; then
-          exit 1
-        fi
-        sleep "$((attempt * 2))"
-      done
-      ${extractCommand}
-    `;
-}
-
 function getPlatformArch() {
   const platform = process.platform;
   const arch = process.arch;
@@ -73,11 +57,11 @@ const platformArch = getPlatformArch();
 const LINTERS = {
   actionlint: {
     check: 'command -v actionlint',
-    installer: archiveInstaller(
-      `https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_${platformArch.actionlint}.tar.gz`,
-      `${TEMP_DIR}/.actionlint.tgz`,
-      `mkdir -p "${TEMP_DIR}/actionlint" && tar -xzf "${TEMP_DIR}/.actionlint.tgz" -C "${TEMP_DIR}/actionlint"`,
-    ),
+    installer: `
+      mkdir -p "${TEMP_DIR}/actionlint"
+      curl -sSLo "${TEMP_DIR}/.actionlint.tgz" "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_${platformArch.actionlint}.tar.gz"
+      tar -xzf "${TEMP_DIR}/.actionlint.tgz" -C "${TEMP_DIR}/actionlint"
+    `,
     run: `
       actionlint \
         -color \
@@ -89,11 +73,11 @@ const LINTERS = {
   },
   shellcheck: {
     check: 'command -v shellcheck',
-    installer: archiveInstaller(
-      `https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.${platformArch.shellcheck}.tar.xz`,
-      `${TEMP_DIR}/.shellcheck.txz`,
-      `mkdir -p "${TEMP_DIR}/shellcheck" && tar -xf "${TEMP_DIR}/.shellcheck.txz" -C "${TEMP_DIR}/shellcheck" --strip-components=1`,
-    ),
+    installer: `
+      mkdir -p "${TEMP_DIR}/shellcheck"
+      curl -sSLo "${TEMP_DIR}/.shellcheck.txz" "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.${platformArch.shellcheck}.tar.xz"
+      tar -xf "${TEMP_DIR}/.shellcheck.txz" -C "${TEMP_DIR}/shellcheck" --strip-components=1
+    `,
     run: `
       git ls-files | grep -v '^integration-tests/terminal-bench/' | grep -E '^([^.]+|.*\\.(sh|zsh|bash))' | xargs file --mime-type \
         | grep "text/x-shellscript" | awk '{ print substr($1, 1, length($1)-1) }' \

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -17,6 +17,22 @@ const YAMLLINT_VERSION = '1.35.1';
 
 const TEMP_DIR = join(tmpdir(), 'qwen-code-linters');
 
+function archiveInstaller(url, archivePath, extractCommand) {
+  return `
+      for attempt in 1 2 3 4 5; do
+        curl --fail --location --show-error --silent --retry 3 --retry-all-errors --retry-delay 2 --output "${archivePath}" "${url}" \\
+          && tar -tf "${archivePath}" >/dev/null \\
+          && break
+        rm -f "${archivePath}"
+        if [ "$attempt" -eq 5 ]; then
+          exit 1
+        fi
+        sleep "$((attempt * 2))"
+      done
+      ${extractCommand}
+    `;
+}
+
 function getPlatformArch() {
   const platform = process.platform;
   const arch = process.arch;
@@ -57,11 +73,11 @@ const platformArch = getPlatformArch();
 const LINTERS = {
   actionlint: {
     check: 'command -v actionlint',
-    installer: `
-      mkdir -p "${TEMP_DIR}/actionlint"
-      curl -sSLo "${TEMP_DIR}/.actionlint.tgz" "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_${platformArch.actionlint}.tar.gz"
-      tar -xzf "${TEMP_DIR}/.actionlint.tgz" -C "${TEMP_DIR}/actionlint"
-    `,
+    installer: archiveInstaller(
+      `https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_${platformArch.actionlint}.tar.gz`,
+      `${TEMP_DIR}/.actionlint.tgz`,
+      `mkdir -p "${TEMP_DIR}/actionlint" && tar -xzf "${TEMP_DIR}/.actionlint.tgz" -C "${TEMP_DIR}/actionlint"`,
+    ),
     run: `
       actionlint \
         -color \
@@ -73,11 +89,11 @@ const LINTERS = {
   },
   shellcheck: {
     check: 'command -v shellcheck',
-    installer: `
-      mkdir -p "${TEMP_DIR}/shellcheck"
-      curl -sSLo "${TEMP_DIR}/.shellcheck.txz" "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.${platformArch.shellcheck}.tar.xz"
-      tar -xf "${TEMP_DIR}/.shellcheck.txz" -C "${TEMP_DIR}/shellcheck" --strip-components=1
-    `,
+    installer: archiveInstaller(
+      `https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.${platformArch.shellcheck}.tar.xz`,
+      `${TEMP_DIR}/.shellcheck.txz`,
+      `mkdir -p "${TEMP_DIR}/shellcheck" && tar -xf "${TEMP_DIR}/.shellcheck.txz" -C "${TEMP_DIR}/shellcheck" --strip-components=1`,
+    ),
     run: `
       git ls-files | grep -v '^integration-tests/terminal-bench/' | grep -E '^([^.]+|.*\\.(sh|zsh|bash))' | xargs file --mime-type \
         | grep "text/x-shellscript" | awk '{ print substr($1, 1, length($1)-1) }' \

--- a/scripts/tests/chrome-extension-package.test.js
+++ b/scripts/tests/chrome-extension-package.test.js
@@ -24,8 +24,5 @@ describe('chrome extension package scripts', () => {
     expect(packageJson.scripts.build).not.toMatch(
       /(?:^|\s&&\s)[A-Za-z_][A-Za-z0-9_]*=/,
     );
-    expect(packageJson.scripts.build).not.toMatch(
-      /(?:^|\s&&\s)npm run clean(?:\s|$)/,
-    );
   });
 });

--- a/scripts/tests/chrome-extension-package.test.js
+++ b/scripts/tests/chrome-extension-package.test.js
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '../..');
+
+describe('chrome extension package scripts', () => {
+  it('keeps the build script portable for Windows npm lifecycle runs', () => {
+    const packageJson = JSON.parse(
+      readFileSync(
+        path.join(root, 'packages/chrome-extension/package.json'),
+        'utf8',
+      ),
+    );
+
+    expect(packageJson.scripts.build).not.toMatch(
+      /(?:^|\s&&\s)[A-Za-z_][A-Za-z0-9_]*=/,
+    );
+    expect(packageJson.scripts.build).not.toMatch(
+      /(?:^|\s&&\s)npm run clean(?:\s|$)/,
+    );
+  });
+});


### PR DESCRIPTION
## What this PR does

This PR fixes two release CI regressions. The Chrome extension build lifecycle now uses the package's existing Node-based defaults instead of POSIX inline environment assignment, and the client-hosted MCP integration coverage now separates the Docker-safe discovery path from the prompt-driven fake-model path. The discovery test still runs under Docker, while the prompt-driven fake-model scenario is skipped only when a container sandbox is actually active.

It also adds a regression guard for the extension build script so the Windows-incompatible POSIX environment-prefix form does not come back.

## Why it's needed

The Windows CI failure was caused by a POSIX inline environment assignment in an npm lifecycle script, which Windows `cmd.exe` does not understand during dependency installation.

The Release Docker integration failure was caused by a test setup mismatch: the model-side fake server listens on host `127.0.0.1`, but the sandboxed ACP child runs inside a container where that address points back to the container rather than the host. That made the prompt-driven test wait until timeout even though the client-hosted MCP discovery path itself can run in Docker.

## Reviewer Test Plan

### How to verify

Reviewers should confirm that dependency installation and extension packaging no longer rely on POSIX shell environment assignment on Windows, that Release Docker CLI integration no longer times out in the prompt-driven client-MCP fake-model scenario, and that the Docker-safe discovery path still executes and discovers the client-hosted tool. `QWEN_SANDBOX=0` should be treated as sandbox disabled and should still run the prompt-driven test.

### Evidence (Before & After)

Before: Windows CI failed during the extension build lifecycle because `EXTENSION_OUT_DIR=...` was interpreted by `cmd.exe` as an unknown command. Release Docker integration timed out in the prompt-driven client-MCP fake-model test because the sandboxed child could not reach the host-loopback fake model server.

After: `npx vitest run --config scripts/tests/vitest.config.ts scripts/tests/chrome-extension-package.test.js` passed. `QWEN_SANDBOX=0 DEBUG_CLIENT_MCP=1 npx vitest run --root ./integration-tests cli/qwen-serve-client-mcp.test.ts` passed with 2 tests run. `DOCKER_HOST=unix:///Users/jinjing/.colima/default/docker.sock QWEN_SANDBOX=docker DEBUG_CLIENT_MCP=1 npx vitest run --root ./integration-tests cli/qwen-serve-client-mcp.test.ts` passed with 1 passed / 1 skipped. `npm run build --workspace=packages/chrome-extension` passed. `git diff --check` passed.

N/A for screenshots or recordings because this is CI/test coverage only.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested locally |
| 🪟 Windows | ⚠️ not run locally; this PR removes the Windows-incompatible npm script form, and the Windows PR job is skipped outside merge queue |
|  🐧 Linux  | ✅ tested via the current-PR Docker sandbox image path on a macOS host with Colima; merge queue will re-run the Linux release jobs |

### Environment (optional)

macOS host with Colima Docker, Node 22, and `DOCKER_HOST=unix:///Users/jinjing/.colima/default/docker.sock` for Docker sandbox verification.

## Risk & Scope

- Main risk or tradeoff: The prompt-driven fake-model client-MCP test is skipped under an active container sandbox, but the Docker-safe discovery path still runs and validates the reverse client-hosted MCP registration path.
- Not validated / out of scope: Windows was not run locally. The transient merge-queue linter download failure is not addressed by this PR; it should be retried or handled separately if it repeats.
- Breaking changes / migration notes: None.

## Linked Issues

Related CI runs:

- Windows CI failure: https://github.com/QwenLM/qwen-code/actions/runs/28327803511/job/83920719777
- Release Docker integration failure: https://github.com/QwenLM/qwen-code/actions/runs/28350586794/job/83982792017

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 修复两个 release CI 回归问题。Chrome extension 的构建生命周期现在使用包内已有的 Node 默认值，不再依赖 POSIX inline 环境变量赋值；client-hosted MCP 集成测试现在把 Docker 下安全可跑的 discovery 路径和依赖 fake model 的 prompt-driven 路径拆开。discovery 测试仍然会在 Docker 下运行；只有容器 sandbox 确实启用时，才跳过依赖 host loopback 的 prompt-driven fake-model 场景。

同时增加了一个 package script 回归测试，避免 Windows 不兼容的 POSIX env-prefix 写法之后又被加回来。

## 为什么需要

Windows CI 失败是因为 npm lifecycle script 里用了 POSIX inline 环境变量赋值，Windows `cmd.exe` 在依赖安装期间无法识别这种写法。

Release Docker integration 失败是测试环境不匹配导致的：model 侧 fake server 监听 host 上的 `127.0.0.1`，但 sandboxed ACP child 运行在容器里，容器内的这个地址指向容器自身而不是 host。因此 prompt-driven 测试会一直等到超时，虽然 client-hosted MCP discovery 路径本身可以在 Docker 下运行。

## Reviewer Test Plan

### 如何验证

Reviewer 应确认依赖安装和 extension packaging 不再依赖 Windows 不支持的 POSIX shell 环境变量写法，确认 Release Docker CLI integration 不再卡在 prompt-driven client-MCP fake-model 场景，并确认 Docker 下安全的 discovery 路径仍会实际执行并发现 client-hosted tool。`QWEN_SANDBOX=0` 应被视为 sandbox disabled，并且仍应运行 prompt-driven 测试。

### Before/After 证据

Before：Windows CI 在 extension build lifecycle 阶段失败，因为 `EXTENSION_OUT_DIR=...` 被 `cmd.exe` 当成未知命令。Release Docker integration 在 prompt-driven client-MCP fake-model 测试中超时，因为 sandboxed child 无法访问 host-loopback fake model server。

After：`npx vitest run --config scripts/tests/vitest.config.ts scripts/tests/chrome-extension-package.test.js` 通过。`QWEN_SANDBOX=0 DEBUG_CLIENT_MCP=1 npx vitest run --root ./integration-tests cli/qwen-serve-client-mcp.test.ts` 通过，2 个测试都实际运行。`DOCKER_HOST=unix:///Users/jinjing/.colima/default/docker.sock QWEN_SANDBOX=docker DEBUG_CLIENT_MCP=1 npx vitest run --root ./integration-tests cli/qwen-serve-client-mcp.test.ts` 通过，结果为 1 passed / 1 skipped。`npm run build --workspace=packages/chrome-extension` 通过。`git diff --check` 通过。

截图或录屏不适用，因为这是 CI/test coverage 修复。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ 本地已验证 |
| 🪟 Windows | ⚠️ 本地未跑；此 PR 移除了 Windows 不兼容的 npm script 写法，且普通 PR workflow 不运行 Windows job |
|  🐧 Linux  | ✅ 在 macOS host + Colima 上通过当前 PR 的 Docker sandbox 路径验证；merge queue 会重新运行 Linux release jobs |

### Environment

本地使用 macOS host、Colima Docker、Node 22，并通过 `DOCKER_HOST=unix:///Users/jinjing/.colima/default/docker.sock` 执行 Docker sandbox 验证。

## 风险与范围

- 主要风险或取舍：container sandbox 启用时会跳过 prompt-driven fake-model client-MCP 测试，但 Docker-safe discovery 路径仍然运行，并覆盖 reverse client-hosted MCP registration 路径。
- 未验证或不在范围内：Windows 未在本地运行。merge queue 上 transient linter 下载失败不再由这个 PR 处理；如果重复出现，应该重跑或单独修。
- Breaking changes / migration notes：无。

## 关联问题

相关 CI runs：

- Windows CI failure: https://github.com/QwenLM/qwen-code/actions/runs/28327803511/job/83920719777
- Release Docker integration failure: https://github.com/QwenLM/qwen-code/actions/runs/28350586794/job/83982792017

</details>
