### PR TITLE
fix(cli): Guard serve fast-path bundle closure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,10 @@ jobs:
           fi
           echo "Settings schema is up-to-date"
 
+      - name: 'Check serve fast-path bundle closure'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
+        run: 'npm run check:serve-fast-path-bundle'
+
       - name: 'Run tests and generate reports'
         id: 'unit_tests'
         if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
@@ -427,7 +431,6 @@ jobs:
           node_version: '${{ matrix.node-version }}'
           os: '${{ matrix.os }}'
           github_token: '${{ secrets.GITHUB_TOKEN }}'
-
 
   # Integration tests run only in the merge queue, not on every PR push.
   # They are the suite that previously ran *only* in the nightly Release

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "telemetry": "node scripts/telemetry.js",
     "check:lockfile": "node scripts/check-lockfile.js",
     "check:desktop-isolation": "node scripts/check-desktop-isolation.js",
+    "check:serve-fast-path-bundle": "npm run build -- --cli-only && cross-env DEV=true npm run bundle && node scripts/check-serve-fast-path-bundle.js",
     "desktop-openwork-sync": "bun run scripts/desktop-openwork-sync.ts",
     "clean": "node scripts/clean.js",
     "pre-commit": "node scripts/pre-commit.js"

--- a/packages/cli/src/serve/fast-path.test.ts
+++ b/packages/cli/src/serve/fast-path.test.ts
@@ -6,7 +6,6 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import yargs, { type Argv } from 'yargs';
-import { execFileSync } from 'node:child_process';
 import {
   existsSync,
   mkdirSync,
@@ -70,24 +69,11 @@ const originalCloudShell = process.env['CLOUD_SHELL'];
 const originalGoogleCloudProject = process.env['GOOGLE_CLOUD_PROJECT'];
 const originalCwd = process.cwd();
 const cliPackageRoot = process.cwd();
-const repoRoot = resolve(cliPackageRoot, '../..');
 
 interface StaticSourceGraph {
   localFiles: Set<string>;
   externalValueImports: Set<string>;
   unresolvedLocalImports: string[];
-}
-
-interface EsbuildMetafileOutput {
-  inputs?: Record<string, unknown>;
-  imports?: Array<{
-    path: string;
-    kind?: string;
-  }>;
-}
-
-interface EsbuildMetafile {
-  outputs: Record<string, EsbuildMetafileOutput>;
 }
 
 function normalizePathForTest(filePath: string): string {
@@ -194,69 +180,6 @@ function collectStaticSourceGraph(entryFile: string): StaticSourceGraph {
 
   visit(entryFile);
   return { localFiles, externalValueImports, unresolvedLocalImports };
-}
-
-function collectBundledRunServeStaticRuntimeOffenders(): string[] {
-  const metafilePath = resolve(repoRoot, 'dist/esbuild.json');
-  rmSync(metafilePath, { force: true });
-  execFileSync(process.execPath, [resolve(repoRoot, 'esbuild.config.js')], {
-    cwd: repoRoot,
-    env: { ...process.env, DEV: 'true' },
-    stdio: 'pipe',
-    timeout: 30_000,
-  });
-
-  expect(existsSync(metafilePath)).toBe(true);
-  const metafile = JSON.parse(
-    readFileSync(metafilePath, 'utf8'),
-  ) as EsbuildMetafile;
-  const outputs = new Map(
-    Object.entries(metafile.outputs).map(([outputPath, output]) => [
-      normalizePathForTest(outputPath),
-      output,
-    ]),
-  );
-  const runServeOutput = [...outputs.entries()].find(([, output]) =>
-    Object.keys(output.inputs ?? {}).some(
-      (input) =>
-        normalizePathForTest(input) ===
-        'packages/cli/src/serve/run-qwen-serve.ts',
-    ),
-  );
-  expect(runServeOutput).toBeDefined();
-  const queue = [runServeOutput![0]];
-  const staticClosure = new Set(queue);
-
-  for (let i = 0; i < queue.length; i++) {
-    const output = outputs.get(queue[i]);
-    for (const bundledImport of output?.imports ?? []) {
-      if (bundledImport.kind !== 'import-statement') continue;
-      const importedOutput = normalizePathForTest(bundledImport.path);
-      if (!outputs.has(importedOutput) || staticClosure.has(importedOutput)) {
-        continue;
-      }
-      staticClosure.add(importedOutput);
-      queue.push(importedOutput);
-    }
-  }
-
-  const forbiddenInputs = new Set([
-    'packages/cli/src/serve/acp-session-bridge.ts',
-    'packages/acp-bridge/src/bridge.ts',
-    'packages/acp-bridge/src/bridgeClient.ts',
-    'packages/acp-bridge/src/spawnChannel.ts',
-  ]);
-  const offenders: string[] = [];
-  for (const outputPath of staticClosure) {
-    const output = outputs.get(outputPath);
-    for (const input of Object.keys(output?.inputs ?? {})) {
-      const normalizedInput = normalizePathForTest(input);
-      if (forbiddenInputs.has(normalizedInput)) {
-        offenders.push(`${outputPath} -> ${normalizedInput}`);
-      }
-    }
-  }
-  return offenders;
 }
 
 function useTempQwenHome(): string {
@@ -490,6 +413,23 @@ describe('CLI entry import boundary', () => {
     expect(runServeSource).toContain("import('@qwen-code/acp-bridge/bridge')");
   });
 
+  it('keeps request helpers from value-importing the ACP compatibility shim', () => {
+    const requestHelpersSource = readFileSync(
+      'src/serve/server/request-helpers.ts',
+      'utf8',
+    );
+
+    expect(requestHelpersSource).not.toMatch(
+      /from ['"]\.\.\/acp-session-bridge\.js['"]/,
+    );
+    expect(requestHelpersSource).toContain(
+      "import type { AcpSessionBridge } from '@qwen-code/acp-bridge/bridgeTypes';",
+    );
+    expect(requestHelpersSource).toContain(
+      "import { MAX_WORKSPACE_PATH_LENGTH } from '@qwen-code/acp-bridge/workspacePaths';",
+    );
+  });
+
   it('keeps the runQwenServe static source graph free of ACP runtime modules', () => {
     const graph = collectStaticSourceGraph(
       resolve(cliPackageRoot, 'src/serve/run-qwen-serve.ts'),
@@ -519,15 +459,6 @@ describe('CLI entry import boundary', () => {
       `Unexpected ACP runtime imports:\n${forbiddenImports.join('\n')}`,
     ).toEqual([]);
   });
-
-  it('keeps bundled runQwenServe static imports free of ACP runtime modules', () => {
-    const offenders = collectBundledRunServeStaticRuntimeOffenders();
-
-    expect(
-      offenders,
-      `Unexpected ACP runtime inputs in static bundle closure:\n${offenders.join('\n')}`,
-    ).toEqual([]);
-  }, 30_000);
 });
 
 describe('serve fast path argument parsing', () => {

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -57,6 +57,10 @@ export default defineConfig({
         __dirname,
         '../acp-bridge/src/bridgeFileSystem.ts',
       ),
+      '@qwen-code/acp-bridge/eventBus': path.resolve(
+        __dirname,
+        '../acp-bridge/src/eventBus.ts',
+      ),
       '@qwen-code/acp-bridge/workspacePaths': path.resolve(
         __dirname,
         '../acp-bridge/src/workspacePaths.ts',

--- a/scripts/check-serve-fast-path-bundle.js
+++ b/scripts/check-serve-fast-path-bundle.js
@@ -10,36 +10,79 @@ import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const DEFAULT_METAFILE_PATH = resolve('dist/esbuild.json');
-const RUN_QWEN_SERVE_SOURCE = 'packages/cli/src/serve/run-qwen-serve.ts';
+const SERVE_PRE_LISTEN_ROOTS = [
+  {
+    label: 'serve fast path entry',
+    suffixes: [
+      'packages/cli/src/serve/fast-path.ts',
+      'packages/cli/dist/src/serve/fast-path.js',
+    ],
+  },
+  {
+    label: 'serve fast path settings',
+    suffixes: [
+      'packages/cli/src/serve/fast-path-settings.ts',
+      'packages/cli/dist/src/serve/fast-path-settings.js',
+    ],
+  },
+  {
+    label: 'run qwen serve entry',
+    suffixes: [
+      'packages/cli/src/serve/run-qwen-serve.ts',
+      'packages/cli/dist/src/serve/run-qwen-serve.js',
+    ],
+  },
+];
 
 const FORBIDDEN_SOURCE_INPUTS = [
   {
     label: 'Serve ACP compatibility shim',
-    suffix: 'packages/cli/src/serve/acp-session-bridge.ts',
+    suffixes: [
+      'packages/cli/src/serve/acp-session-bridge.ts',
+      'packages/cli/dist/src/serve/acp-session-bridge.js',
+    ],
   },
   {
     label: 'ACP bridge runtime',
-    suffix: 'packages/acp-bridge/src/bridge.ts',
+    suffixes: [
+      'packages/acp-bridge/src/bridge.ts',
+      'packages/acp-bridge/dist/bridge.js',
+    ],
   },
   {
     label: 'ACP bridge client runtime',
-    suffix: 'packages/acp-bridge/src/bridgeClient.ts',
+    suffixes: [
+      'packages/acp-bridge/src/bridgeClient.ts',
+      'packages/acp-bridge/dist/bridgeClient.js',
+    ],
   },
   {
     label: 'ACP spawnChannel runtime',
-    suffix: 'packages/acp-bridge/src/spawnChannel.ts',
+    suffixes: [
+      'packages/acp-bridge/src/spawnChannel.ts',
+      'packages/acp-bridge/dist/spawnChannel.js',
+    ],
   },
   {
     label: 'ACP permission mediator runtime',
-    suffix: 'packages/acp-bridge/src/permissionMediator.ts',
+    suffixes: [
+      'packages/acp-bridge/src/permissionMediator.ts',
+      'packages/acp-bridge/dist/permissionMediator.js',
+    ],
   },
   {
     label: 'ACP compaction engine runtime',
-    suffix: 'packages/acp-bridge/src/compactionEngine.ts',
+    suffixes: [
+      'packages/acp-bridge/src/compactionEngine.ts',
+      'packages/acp-bridge/dist/compactionEngine.js',
+    ],
   },
   {
     label: 'Core shell tool runtime',
-    suffix: 'packages/core/src/tools/shell.ts',
+    suffixes: [
+      'packages/core/src/tools/shell.ts',
+      'packages/core/dist/src/tools/shell.js',
+    ],
   },
 ];
 
@@ -57,6 +100,10 @@ export function normalizeMetafilePath(filePath) {
 function inputMatchesSuffix(input, suffix) {
   const normalizedInput = normalizeMetafilePath(input);
   return normalizedInput === suffix || normalizedInput.endsWith(`/${suffix}`);
+}
+
+function inputMatchesAnySuffix(input, suffixes) {
+  return suffixes.some((suffix) => inputMatchesSuffix(input, suffix));
 }
 
 function inputMatchesPackage(input, packageName) {
@@ -77,22 +124,42 @@ function normalizeOutputs(metafile) {
   );
 }
 
-function findRunQwenServeOutput(outputs) {
-  for (const [outputPath, output] of outputs) {
-    for (const input of Object.keys(output.inputs ?? {})) {
-      if (inputMatchesSuffix(input, RUN_QWEN_SERVE_SOURCE)) {
-        return outputPath;
+function findServePreListenRootOutputs(outputs) {
+  const rootOutputs = [];
+  const missingRoots = [];
+
+  for (const root of SERVE_PRE_LISTEN_ROOTS) {
+    let matchedOutput;
+    for (const [outputPath, output] of outputs) {
+      for (const input of Object.keys(output.inputs ?? {})) {
+        if (inputMatchesAnySuffix(input, root.suffixes)) {
+          matchedOutput = outputPath;
+          break;
+        }
       }
+      if (matchedOutput) break;
+    }
+
+    if (matchedOutput) {
+      rootOutputs.push(matchedOutput);
+    } else {
+      missingRoots.push(`${root.label} (${root.suffixes.join(' or ')})`);
     }
   }
-  throw new Error(
-    `Could not find bundled output for ${RUN_QWEN_SERVE_SOURCE}. ` +
-      'Run DEV=true npm run bundle before this check.',
-  );
+
+  if (missingRoots.length > 0) {
+    throw new Error(
+      'Could not find bundled outputs for serve pre-listen roots:\n' +
+        missingRoots.map((root) => `- ${root}`).join('\n') +
+        '\nRun DEV=true npm run bundle before this check.',
+    );
+  }
+
+  return [...new Set(rootOutputs)];
 }
 
-function collectStaticClosure(outputs, entryOutput) {
-  const queue = [entryOutput];
+function collectStaticClosure(outputs, entryOutputs) {
+  const queue = [...entryOutputs];
   const closure = new Set(queue);
   const parent = new Map();
 
@@ -117,10 +184,11 @@ function collectStaticClosure(outputs, entryOutput) {
   return { closure, parent };
 }
 
-function buildImportPath(entryOutput, outputPath, parent) {
+function buildImportPath(entryOutputs, outputPath, parent) {
+  const roots = new Set(entryOutputs);
   const reversed = [outputPath];
   let current = outputPath;
-  while (current !== entryOutput) {
+  while (!roots.has(current)) {
     current = parent.get(current);
     if (!current) break;
     reversed.push(current);
@@ -130,8 +198,8 @@ function buildImportPath(entryOutput, outputPath, parent) {
 
 export function findServeFastPathBundleOffenders(metafile) {
   const outputs = normalizeOutputs(metafile);
-  const entryOutput = findRunQwenServeOutput(outputs);
-  const { closure, parent } = collectStaticClosure(outputs, entryOutput);
+  const entryOutputs = findServePreListenRootOutputs(outputs);
+  const { closure, parent } = collectStaticClosure(outputs, entryOutputs);
   const offenders = [];
   const seen = new Set();
 
@@ -141,8 +209,8 @@ export function findServeFastPathBundleOffenders(metafile) {
 
     for (const input of inputs) {
       const normalizedInput = normalizeMetafilePath(input);
-      const sourceMatch = FORBIDDEN_SOURCE_INPUTS.find(({ suffix }) =>
-        inputMatchesSuffix(normalizedInput, suffix),
+      const sourceMatch = FORBIDDEN_SOURCE_INPUTS.find(({ suffixes }) =>
+        inputMatchesAnySuffix(normalizedInput, suffixes),
       );
       if (sourceMatch) {
         addOffender(sourceMatch.label, normalizedInput, outputPath);
@@ -168,7 +236,7 @@ export function findServeFastPathBundleOffenders(metafile) {
       matchedInput,
       outputPath,
       bytes: outputs.get(outputPath)?.bytes ?? 0,
-      importPath: buildImportPath(entryOutput, outputPath, parent),
+      importPath: buildImportPath(entryOutputs, outputPath, parent),
     });
   }
 }

--- a/scripts/check-serve-fast-path-bundle.js
+++ b/scripts/check-serve-fast-path-bundle.js
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_METAFILE_PATH = resolve('dist/esbuild.json');
+const RUN_QWEN_SERVE_SOURCE = 'packages/cli/src/serve/run-qwen-serve.ts';
+
+const FORBIDDEN_SOURCE_INPUTS = [
+  {
+    label: 'Serve ACP compatibility shim',
+    suffix: 'packages/cli/src/serve/acp-session-bridge.ts',
+  },
+  {
+    label: 'ACP bridge runtime',
+    suffix: 'packages/acp-bridge/src/bridge.ts',
+  },
+  {
+    label: 'ACP bridge client runtime',
+    suffix: 'packages/acp-bridge/src/bridgeClient.ts',
+  },
+  {
+    label: 'ACP spawnChannel runtime',
+    suffix: 'packages/acp-bridge/src/spawnChannel.ts',
+  },
+  {
+    label: 'ACP permission mediator runtime',
+    suffix: 'packages/acp-bridge/src/permissionMediator.ts',
+  },
+  {
+    label: 'ACP compaction engine runtime',
+    suffix: 'packages/acp-bridge/src/compactionEngine.ts',
+  },
+  {
+    label: 'Core shell tool runtime',
+    suffix: 'packages/core/src/tools/shell.ts',
+  },
+];
+
+const FORBIDDEN_VENDOR_PACKAGES = [
+  { label: 'glob vendor package', packageName: 'glob' },
+  { label: 'chokidar vendor package', packageName: 'chokidar' },
+  { label: '@iarna/toml vendor package', packageName: '@iarna/toml' },
+  { label: 'fzf vendor package', packageName: 'fzf' },
+];
+
+export function normalizeMetafilePath(filePath) {
+  return filePath.replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+function inputMatchesSuffix(input, suffix) {
+  const normalizedInput = normalizeMetafilePath(input);
+  return normalizedInput === suffix || normalizedInput.endsWith(`/${suffix}`);
+}
+
+function inputMatchesPackage(input, packageName) {
+  const normalizedInput = normalizeMetafilePath(input);
+  const marker = `node_modules/${packageName}/`;
+  return (
+    normalizedInput === `node_modules/${packageName}` ||
+    normalizedInput.includes(marker)
+  );
+}
+
+function normalizeOutputs(metafile) {
+  return new Map(
+    Object.entries(metafile.outputs ?? {}).map(([outputPath, output]) => [
+      normalizeMetafilePath(outputPath),
+      output,
+    ]),
+  );
+}
+
+function findRunQwenServeOutput(outputs) {
+  for (const [outputPath, output] of outputs) {
+    for (const input of Object.keys(output.inputs ?? {})) {
+      if (inputMatchesSuffix(input, RUN_QWEN_SERVE_SOURCE)) {
+        return outputPath;
+      }
+    }
+  }
+  throw new Error(
+    `Could not find bundled output for ${RUN_QWEN_SERVE_SOURCE}. ` +
+      'Run DEV=true npm run bundle before this check.',
+  );
+}
+
+function collectStaticClosure(outputs, entryOutput) {
+  const queue = [entryOutput];
+  const closure = new Set(queue);
+  const parent = new Map();
+
+  for (let i = 0; i < queue.length; i++) {
+    const outputPath = queue[i];
+    const output = outputs.get(outputPath);
+    for (const bundledImport of output?.imports ?? []) {
+      if (bundledImport.external) continue;
+      if (bundledImport.kind === 'dynamic-import') continue;
+
+      const importedOutput = normalizeMetafilePath(bundledImport.path);
+      if (!outputs.has(importedOutput) || closure.has(importedOutput)) {
+        continue;
+      }
+
+      closure.add(importedOutput);
+      parent.set(importedOutput, outputPath);
+      queue.push(importedOutput);
+    }
+  }
+
+  return { closure, parent };
+}
+
+function buildImportPath(entryOutput, outputPath, parent) {
+  const reversed = [outputPath];
+  let current = outputPath;
+  while (current !== entryOutput) {
+    current = parent.get(current);
+    if (!current) break;
+    reversed.push(current);
+  }
+  return reversed.reverse();
+}
+
+export function findServeFastPathBundleOffenders(metafile) {
+  const outputs = normalizeOutputs(metafile);
+  const entryOutput = findRunQwenServeOutput(outputs);
+  const { closure, parent } = collectStaticClosure(outputs, entryOutput);
+  const offenders = [];
+  const seen = new Set();
+
+  for (const outputPath of closure) {
+    const output = outputs.get(outputPath);
+    const inputs = Object.keys(output?.inputs ?? {});
+
+    for (const input of inputs) {
+      const normalizedInput = normalizeMetafilePath(input);
+      const sourceMatch = FORBIDDEN_SOURCE_INPUTS.find(({ suffix }) =>
+        inputMatchesSuffix(normalizedInput, suffix),
+      );
+      if (sourceMatch) {
+        addOffender(sourceMatch.label, normalizedInput, outputPath);
+      }
+
+      const vendorMatch = FORBIDDEN_VENDOR_PACKAGES.find(({ packageName }) =>
+        inputMatchesPackage(normalizedInput, packageName),
+      );
+      if (vendorMatch) {
+        addOffender(vendorMatch.label, normalizedInput, outputPath);
+      }
+    }
+  }
+
+  return offenders;
+
+  function addOffender(label, matchedInput, outputPath) {
+    const key = `${label}\0${outputPath}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    offenders.push({
+      label,
+      matchedInput,
+      outputPath,
+      bytes: outputs.get(outputPath)?.bytes ?? 0,
+      importPath: buildImportPath(entryOutput, outputPath, parent),
+    });
+  }
+}
+
+export function formatServeFastPathBundleOffenders(offenders) {
+  return offenders
+    .map((offender) => {
+      const importPath = offender.importPath.join(' -> ');
+      return [
+        `- ${offender.label}`,
+        `  input: ${offender.matchedInput}`,
+        `  output: ${offender.outputPath} (${offender.bytes} bytes)`,
+        `  static path: ${importPath}`,
+      ].join('\n');
+    })
+    .join('\n');
+}
+
+export function checkServeFastPathBundle({
+  metafilePath = DEFAULT_METAFILE_PATH,
+} = {}) {
+  if (!existsSync(metafilePath)) {
+    throw new Error(
+      `Missing esbuild metafile at ${metafilePath}. ` +
+        'Run `npm run check:serve-fast-path-bundle` to build one.',
+    );
+  }
+
+  const metafile = JSON.parse(readFileSync(metafilePath, 'utf8'));
+  const offenders = findServeFastPathBundleOffenders(metafile);
+  return { ok: offenders.length === 0, offenders };
+}
+
+function main() {
+  try {
+    const result = checkServeFastPathBundle();
+    if (result.ok) {
+      console.log('Serve fast-path bundle closure check passed.');
+      return;
+    }
+
+    console.error(
+      'Serve fast-path bundle closure includes pre-listen runtime modules:\n' +
+        formatServeFastPathBundleOffenders(result.offenders),
+    );
+    process.exitCode = 1;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}
+
+if (
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === resolve(process.argv[1])
+) {
+  main();
+}

--- a/scripts/check-serve-fast-path-bundle.js
+++ b/scripts/check-serve-fast-path-bundle.js
@@ -208,19 +208,26 @@ export function findServeFastPathBundleOffenders(metafile) {
     const inputs = Object.keys(output?.inputs ?? {});
 
     for (const input of inputs) {
-      const normalizedInput = normalizeMetafilePath(input);
       const sourceMatch = FORBIDDEN_SOURCE_INPUTS.find(({ suffixes }) =>
-        inputMatchesAnySuffix(normalizedInput, suffixes),
+        inputMatchesAnySuffix(input, suffixes),
       );
       if (sourceMatch) {
-        addOffender(sourceMatch.label, normalizedInput, outputPath);
+        addOffender(
+          sourceMatch.label,
+          normalizeMetafilePath(input),
+          outputPath,
+        );
       }
 
       const vendorMatch = FORBIDDEN_VENDOR_PACKAGES.find(({ packageName }) =>
-        inputMatchesPackage(normalizedInput, packageName),
+        inputMatchesPackage(input, packageName),
       );
       if (vendorMatch) {
-        addOffender(vendorMatch.label, normalizedInput, outputPath);
+        addOffender(
+          vendorMatch.label,
+          normalizeMetafilePath(input),
+          outputPath,
+        );
       }
     }
   }

--- a/scripts/check-serve-fast-path-bundle.js
+++ b/scripts/check-serve-fast-path-bundle.js
@@ -10,6 +10,8 @@ import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const DEFAULT_METAFILE_PATH = resolve('dist/esbuild.json');
+const METAFILE_BUILD_COMMAND =
+  'npm run build -- --cli-only && npx cross-env DEV=true npm run bundle';
 const SERVE_PRE_LISTEN_ROOTS = [
   {
     label: 'serve fast path entry',
@@ -151,7 +153,7 @@ function findServePreListenRootOutputs(outputs) {
     throw new Error(
       'Could not find bundled outputs for serve pre-listen roots:\n' +
         missingRoots.map((root) => `- ${root}`).join('\n') +
-        '\nRun DEV=true npm run bundle before this check.',
+        `\nRun \`${METAFILE_BUILD_COMMAND}\` to produce the metafile.`,
     );
   }
 
@@ -235,7 +237,7 @@ export function findServeFastPathBundleOffenders(metafile) {
   return offenders;
 
   function addOffender(label, matchedInput, outputPath) {
-    const key = `${label}\0${outputPath}`;
+    const key = `${label}\0${matchedInput}\0${outputPath}`;
     if (seen.has(key)) return;
     seen.add(key);
     offenders.push({
@@ -268,11 +270,20 @@ export function checkServeFastPathBundle({
   if (!existsSync(metafilePath)) {
     throw new Error(
       `Missing esbuild metafile at ${metafilePath}. ` +
-        'Run `npm run check:serve-fast-path-bundle` to build one.',
+        `Run \`${METAFILE_BUILD_COMMAND}\` to produce it.`,
     );
   }
 
-  const metafile = JSON.parse(readFileSync(metafilePath, 'utf8'));
+  let metafile;
+  try {
+    metafile = JSON.parse(readFileSync(metafilePath, 'utf8'));
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Invalid esbuild metafile at ${metafilePath}: ${reason}. ` +
+        `Run \`${METAFILE_BUILD_COMMAND}\` to regenerate it.`,
+    );
+  }
   const offenders = findServeFastPathBundleOffenders(metafile);
   return { ok: offenders.length === 0, offenders };
 }

--- a/scripts/tests/serve-fast-path-bundle-check.test.js
+++ b/scripts/tests/serve-fast-path-bundle-check.test.js
@@ -5,14 +5,36 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   findServeFastPathBundleOffenders,
   formatServeFastPathBundleOffenders,
   normalizeMetafilePath,
 } from '../check-serve-fast-path-bundle.js';
 
+const checkScriptPath = fileURLToPath(
+  new URL('../check-serve-fast-path-bundle.js', import.meta.url),
+);
+
 function makeMetafile(outputs) {
-  return { outputs };
+  return {
+    outputs: {
+      'dist/chunks/fast-path.js': output({
+        inputs: ['packages/cli/src/serve/fast-path.ts'],
+      }),
+      'dist/chunks/fast-path-settings.js': output({
+        inputs: ['packages/cli/src/serve/fast-path-settings.ts'],
+      }),
+      'dist/chunks/run-qwen-serve.js': output({
+        inputs: ['packages/cli/src/serve/run-qwen-serve.ts'],
+      }),
+      ...outputs,
+    },
+  };
 }
 
 function output({ inputs = [], imports = [], bytes = 1 } = {}) {
@@ -70,6 +92,47 @@ describe('serve fast-path bundle check', () => {
     );
   });
 
+  it('reports forbidden built package files reached through static imports', () => {
+    const metafile = makeMetafile({
+      'dist/chunks/run-qwen-serve.js': output({
+        inputs: ['packages/cli/dist/src/serve/run-qwen-serve.js'],
+        imports: [staticImport('dist/chunks/acp-runtime.js')],
+      }),
+      'dist/chunks/acp-runtime.js': output({
+        inputs: ['packages/acp-bridge/dist/bridge.js'],
+      }),
+    });
+
+    expect(findServeFastPathBundleOffenders(metafile)).toEqual([
+      expect.objectContaining({
+        label: 'ACP bridge runtime',
+        matchedInput: 'packages/acp-bridge/dist/bridge.js',
+      }),
+    ]);
+  });
+
+  it('checks fast-path modules that run before runQwenServe listens', () => {
+    const metafile = makeMetafile({
+      'dist/chunks/fast-path.js': output({
+        inputs: ['packages/cli/src/serve/fast-path.ts'],
+        imports: [staticImport('dist/chunks/core-runtime.js')],
+      }),
+      'dist/chunks/core-runtime.js': output({
+        inputs: ['packages/core/dist/src/tools/shell.js'],
+      }),
+    });
+
+    const offenders = findServeFastPathBundleOffenders(metafile);
+
+    expect(offenders).toEqual([
+      expect.objectContaining({
+        label: 'Core shell tool runtime',
+        matchedInput: 'packages/core/dist/src/tools/shell.js',
+        importPath: ['dist/chunks/fast-path.js', 'dist/chunks/core-runtime.js'],
+      }),
+    ]);
+  });
+
   it('allows forbidden runtime files behind dynamic imports', () => {
     const metafile = makeMetafile({
       'dist/chunks/run-qwen-serve.js': output({
@@ -95,7 +158,7 @@ describe('serve fast-path bundle check', () => {
         inputs: [
           'packages/core/src/tools/shell.ts',
           'node_modules/.pnpm/glob@10.5.0/node_modules/glob/dist/esm/index.js',
-          'node_modules/@iarna/toml/toml.js',
+          'node_modules/.pnpm/@iarna+toml@2.2.5/node_modules/@iarna/toml/toml.js',
           'node_modules/chokidar/esm/index.js',
           'node_modules/fzf/dist/fzf.es.js',
         ],
@@ -132,5 +195,52 @@ describe('serve fast-path bundle check', () => {
       'dist/chunks/run-qwen-serve.js',
     );
     expect(findServeFastPathBundleOffenders(metafile)).toEqual([]);
+  });
+
+  it('exits non-zero with CLI diagnostics for bundle offenders', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'serve-fast-path-bundle-'));
+    try {
+      mkdirSync(join(tempDir, 'dist'));
+      writeFileSync(
+        join(tempDir, 'dist', 'esbuild.json'),
+        JSON.stringify(
+          makeMetafile({
+            'dist/chunks/run-qwen-serve.js': output({
+              inputs: ['packages/cli/src/serve/run-qwen-serve.ts'],
+              imports: [staticImport('dist/chunks/acp-runtime.js')],
+            }),
+            'dist/chunks/acp-runtime.js': output({
+              bytes: 179_129,
+              inputs: ['packages/acp-bridge/src/bridge.ts'],
+            }),
+          }),
+        ),
+      );
+
+      expect(() =>
+        execFileSync(process.execPath, [checkScriptPath], {
+          cwd: tempDir,
+          encoding: 'utf8',
+          stdio: 'pipe',
+        }),
+      ).toThrow(/Serve fast-path bundle closure includes pre-listen runtime/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('exits non-zero when the metafile is missing', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'serve-fast-path-bundle-'));
+    try {
+      expect(() =>
+        execFileSync(process.execPath, [checkScriptPath], {
+          cwd: tempDir,
+          encoding: 'utf8',
+          stdio: 'pipe',
+        }),
+      ).toThrow(/Missing esbuild metafile/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/scripts/tests/serve-fast-path-bundle-check.test.js
+++ b/scripts/tests/serve-fast-path-bundle-check.test.js
@@ -237,6 +237,37 @@ describe('serve fast-path bundle check', () => {
     expect(() => findServeFastPathBundleOffenders(metafile)).toThrow(
       /Could not find bundled outputs for serve pre-listen roots/,
     );
+    expect(() => findServeFastPathBundleOffenders(metafile)).toThrow(
+      /npm run build -- --cli-only && npx cross-env DEV=true npm run bundle/,
+    );
+  });
+
+  it('reports each matched input for the same forbidden label and output', () => {
+    const metafile = makeMetafile({
+      'dist/chunks/run-qwen-serve.js': output({
+        inputs: ['packages/cli/src/serve/run-qwen-serve.ts'],
+        imports: [staticImport('dist/chunks/acp-runtime.js')],
+      }),
+      'dist/chunks/acp-runtime.js': output({
+        inputs: [
+          'packages/acp-bridge/src/bridge.ts',
+          'packages/acp-bridge/dist/bridge.js',
+        ],
+      }),
+    });
+
+    const offenders = findServeFastPathBundleOffenders(metafile);
+
+    expect(offenders).toEqual([
+      expect.objectContaining({
+        label: 'ACP bridge runtime',
+        matchedInput: 'packages/acp-bridge/src/bridge.ts',
+      }),
+      expect.objectContaining({
+        label: 'ACP bridge runtime',
+        matchedInput: 'packages/acp-bridge/dist/bridge.js',
+      }),
+    ]);
   });
 
   it('reads a metafile path and returns bundle offenders', () => {
@@ -277,6 +308,31 @@ describe('serve fast-path bundle check', () => {
           metafilePath: join(tempDir, 'dist', 'esbuild.json'),
         }),
       ).toThrow(/Missing esbuild metafile/);
+      expect(() =>
+        checkServeFastPathBundle({
+          metafilePath: join(tempDir, 'dist', 'esbuild.json'),
+        }),
+      ).toThrow(
+        /npm run build -- --cli-only && npx cross-env DEV=true npm run bundle/,
+      );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws with context when the metafile is invalid JSON', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'serve-fast-path-bundle-'));
+    try {
+      mkdirSync(join(tempDir, 'dist'));
+      const metafilePath = join(tempDir, 'dist', 'esbuild.json');
+      writeFileSync(metafilePath, '{');
+
+      expect(() => checkServeFastPathBundle({ metafilePath })).toThrow(
+        /Invalid esbuild metafile at .*dist[/\\]esbuild\.json/,
+      );
+      expect(() => checkServeFastPathBundle({ metafilePath })).toThrow(
+        /Run `npm run build -- --cli-only && npx cross-env DEV=true npm run bundle` to regenerate it/,
+      );
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/scripts/tests/serve-fast-path-bundle-check.test.js
+++ b/scripts/tests/serve-fast-path-bundle-check.test.js
@@ -11,6 +11,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
+  checkServeFastPathBundle,
   findServeFastPathBundleOffenders,
   formatServeFastPathBundleOffenders,
   normalizeMetafilePath,
@@ -45,6 +46,13 @@ function output({ inputs = [], imports = [], bytes = 1 } = {}) {
     ),
     imports,
   };
+}
+
+function writeMetafile(tempDir, metafile) {
+  mkdirSync(join(tempDir, 'dist'));
+  const metafilePath = join(tempDir, 'dist', 'esbuild.json');
+  writeFileSync(metafilePath, JSON.stringify(metafile));
+  return metafilePath;
 }
 
 function staticImport(path) {
@@ -147,6 +155,26 @@ describe('serve fast-path bundle check', () => {
     expect(findServeFastPathBundleOffenders(metafile)).toEqual([]);
   });
 
+  it('ignores external imports in the static closure', () => {
+    const metafile = makeMetafile({
+      'dist/chunks/run-qwen-serve.js': output({
+        inputs: ['packages/cli/src/serve/run-qwen-serve.ts'],
+        imports: [
+          {
+            path: 'dist/chunks/acp-runtime.js',
+            kind: 'import-statement',
+            external: true,
+          },
+        ],
+      }),
+      'dist/chunks/acp-runtime.js': output({
+        inputs: ['packages/acp-bridge/src/bridge.ts'],
+      }),
+    });
+
+    expect(findServeFastPathBundleOffenders(metafile)).toEqual([]);
+  });
+
   it('reports vendor packages reached through the core runtime chunk', () => {
     const metafile = makeMetafile({
       'dist/chunks/run-qwen-serve.js': output({
@@ -197,24 +225,78 @@ describe('serve fast-path bundle check', () => {
     expect(findServeFastPathBundleOffenders(metafile)).toEqual([]);
   });
 
+  it('throws when serve pre-listen roots are missing', () => {
+    const metafile = {
+      outputs: {
+        'dist/chunks/unrelated.js': output({
+          inputs: ['packages/cli/src/unrelated.ts'],
+        }),
+      },
+    };
+
+    expect(() => findServeFastPathBundleOffenders(metafile)).toThrow(
+      /Could not find bundled outputs for serve pre-listen roots/,
+    );
+  });
+
+  it('reads a metafile path and returns bundle offenders', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'serve-fast-path-bundle-'));
+    try {
+      const metafilePath = writeMetafile(
+        tempDir,
+        makeMetafile({
+          'dist/chunks/run-qwen-serve.js': output({
+            inputs: ['packages/cli/src/serve/run-qwen-serve.ts'],
+            imports: [staticImport('dist/chunks/acp-runtime.js')],
+          }),
+          'dist/chunks/acp-runtime.js': output({
+            inputs: ['packages/acp-bridge/src/bridge.ts'],
+          }),
+        }),
+      );
+
+      expect(checkServeFastPathBundle({ metafilePath })).toEqual({
+        ok: false,
+        offenders: [
+          expect.objectContaining({
+            label: 'ACP bridge runtime',
+            matchedInput: 'packages/acp-bridge/src/bridge.ts',
+          }),
+        ],
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws when the checked metafile path is missing', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'serve-fast-path-bundle-'));
+    try {
+      expect(() =>
+        checkServeFastPathBundle({
+          metafilePath: join(tempDir, 'dist', 'esbuild.json'),
+        }),
+      ).toThrow(/Missing esbuild metafile/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('exits non-zero with CLI diagnostics for bundle offenders', () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'serve-fast-path-bundle-'));
     try {
-      mkdirSync(join(tempDir, 'dist'));
-      writeFileSync(
-        join(tempDir, 'dist', 'esbuild.json'),
-        JSON.stringify(
-          makeMetafile({
-            'dist/chunks/run-qwen-serve.js': output({
-              inputs: ['packages/cli/src/serve/run-qwen-serve.ts'],
-              imports: [staticImport('dist/chunks/acp-runtime.js')],
-            }),
-            'dist/chunks/acp-runtime.js': output({
-              bytes: 179_129,
-              inputs: ['packages/acp-bridge/src/bridge.ts'],
-            }),
+      writeMetafile(
+        tempDir,
+        makeMetafile({
+          'dist/chunks/run-qwen-serve.js': output({
+            inputs: ['packages/cli/src/serve/run-qwen-serve.ts'],
+            imports: [staticImport('dist/chunks/acp-runtime.js')],
           }),
-        ),
+          'dist/chunks/acp-runtime.js': output({
+            bytes: 179_129,
+            inputs: ['packages/acp-bridge/src/bridge.ts'],
+          }),
+        }),
       );
 
       expect(() =>

--- a/scripts/tests/serve-fast-path-bundle-check.test.js
+++ b/scripts/tests/serve-fast-path-bundle-check.test.js
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  findServeFastPathBundleOffenders,
+  formatServeFastPathBundleOffenders,
+  normalizeMetafilePath,
+} from '../check-serve-fast-path-bundle.js';
+
+function makeMetafile(outputs) {
+  return { outputs };
+}
+
+function output({ inputs = [], imports = [], bytes = 1 } = {}) {
+  return {
+    bytes,
+    inputs: Object.fromEntries(
+      inputs.map((input) => [input, { bytesInOutput: 1 }]),
+    ),
+    imports,
+  };
+}
+
+function staticImport(path) {
+  return { path, kind: 'import-statement' };
+}
+
+function dynamicImport(path) {
+  return { path, kind: 'dynamic-import' };
+}
+
+describe('serve fast-path bundle check', () => {
+  it('reports forbidden source files reached through static imports', () => {
+    const metafile = makeMetafile({
+      'dist/chunks/run-qwen-serve.js': output({
+        inputs: ['packages/cli/src/serve/run-qwen-serve.ts'],
+        imports: [staticImport('dist/chunks/acp-runtime.js')],
+      }),
+      'dist/chunks/acp-runtime.js': output({
+        bytes: 179_129,
+        inputs: ['packages/acp-bridge/src/bridgeClient.ts'],
+      }),
+    });
+
+    const offenders = findServeFastPathBundleOffenders(metafile);
+    const diagnostic = formatServeFastPathBundleOffenders(offenders);
+
+    expect(offenders).toEqual([
+      expect.objectContaining({
+        label: 'ACP bridge client runtime',
+        matchedInput: 'packages/acp-bridge/src/bridgeClient.ts',
+        outputPath: 'dist/chunks/acp-runtime.js',
+        bytes: 179_129,
+        importPath: [
+          'dist/chunks/run-qwen-serve.js',
+          'dist/chunks/acp-runtime.js',
+        ],
+      }),
+    ]);
+    expect(diagnostic).toContain('- ACP bridge client runtime');
+    expect(diagnostic).toContain(
+      'output: dist/chunks/acp-runtime.js (179129 bytes)',
+    );
+    expect(diagnostic).toContain(
+      'static path: dist/chunks/run-qwen-serve.js -> dist/chunks/acp-runtime.js',
+    );
+  });
+
+  it('allows forbidden runtime files behind dynamic imports', () => {
+    const metafile = makeMetafile({
+      'dist/chunks/run-qwen-serve.js': output({
+        inputs: ['packages/cli/src/serve/run-qwen-serve.ts'],
+        imports: [dynamicImport('dist/chunks/bridge.js')],
+      }),
+      'dist/chunks/bridge.js': output({
+        inputs: ['packages/acp-bridge/src/bridge.ts'],
+      }),
+    });
+
+    expect(findServeFastPathBundleOffenders(metafile)).toEqual([]);
+  });
+
+  it('reports vendor packages reached through the core runtime chunk', () => {
+    const metafile = makeMetafile({
+      'dist/chunks/run-qwen-serve.js': output({
+        inputs: ['packages/cli/src/serve/run-qwen-serve.ts'],
+        imports: [staticImport('dist/chunks/core-runtime.js')],
+      }),
+      'dist/chunks/core-runtime.js': output({
+        bytes: 6_015_919,
+        inputs: [
+          'packages/core/src/tools/shell.ts',
+          'node_modules/.pnpm/glob@10.5.0/node_modules/glob/dist/esm/index.js',
+          'node_modules/@iarna/toml/toml.js',
+          'node_modules/chokidar/esm/index.js',
+          'node_modules/fzf/dist/fzf.es.js',
+        ],
+      }),
+    });
+
+    const offenders = findServeFastPathBundleOffenders(metafile);
+
+    expect(offenders.map((offender) => offender.label)).toEqual([
+      'Core shell tool runtime',
+      'glob vendor package',
+      '@iarna/toml vendor package',
+      'chokidar vendor package',
+      'fzf vendor package',
+    ]);
+    expect(offenders[0].importPath).toEqual([
+      'dist/chunks/run-qwen-serve.js',
+      'dist/chunks/core-runtime.js',
+    ]);
+  });
+
+  it('matches normalized source suffixes without accepting partial names', () => {
+    const metafile = makeMetafile({
+      'dist\\chunks\\run-qwen-serve.js': output({
+        inputs: ['..\\..\\packages\\cli\\src\\serve\\run-qwen-serve.ts'],
+        imports: [staticImport('dist\\chunks\\false-positive.js')],
+      }),
+      'dist\\chunks\\false-positive.js': output({
+        inputs: ['packages/acp-bridge/src/not-bridge.ts'],
+      }),
+    });
+
+    expect(normalizeMetafilePath('dist\\chunks\\run-qwen-serve.js')).toBe(
+      'dist/chunks/run-qwen-serve.js',
+    );
+    expect(findServeFastPathBundleOffenders(metafile)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What this PR does

This PR adds a dedicated bundle-level guard for the `qwen serve` fast path so the pre-listen static bundle closure is checked against ACP bridge runtime modules, core shell runtime, and the heavy vendor packages that previously entered through shared chunks. It also keeps the lightweight source-level guard for the request-helper import boundary and moves the expensive real-bundle assertion out of the CLI unit test path into an explicit CI check.

## Why it's needed

The daemon startup optimization depends on keeping the listener path free of eager ACP runtime and transitive core/vendor imports. Source-level import checks alone can miss esbuild shared chunks and hashed output names, so this adds a metafile-based reachability check that follows static output imports while allowing dynamic imports used by the runtime loader.

## Reviewer Test Plan

### How to verify

Run `npm run test:scripts -- scripts/tests/serve-fast-path-bundle-check.test.js` and confirm the synthetic metafile coverage catches static forbidden runtime imports, allows dynamic imports, reports the vendor package sentinels, and prints the static import path diagnostic. Run `cd packages/cli && npx vitest run src/serve/fast-path.test.ts` and confirm the source fast-path tests pass. Run `npm run check:serve-fast-path-bundle` and confirm the real bundled serve fast-path closure passes. Run `npm run build && npm run typecheck` and confirm the workspace still builds and typechecks.

### Evidence (Before & After)

N/A. This is a non-UI guard and import-boundary hardening change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS local checkout, Node v26.0.0, npm 11.12.1.

## Risk & Scope

- Main risk or tradeoff: The new CI check performs a CLI-only build and bundle on the Ubuntu CI leg, which adds CI time but gives direct coverage for the bundled daemon fast path. It intentionally does not repeat this guard in the macOS/Windows merge-queue jobs because the bundle import graph is platform-independent and the script normalizes paths.
- Not validated / out of scope: This does not change `getCliVersion()` timing, raw HTTP/Express bootstrap behavior, settings async reads, or package `sideEffects` metadata.
- Breaking changes / migration notes: None.

## Linked Issues

Refs #4748

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 为 `qwen serve` fast path 增加了独立的 bundle-level guard，用来检查 pre-listen static bundle closure 是否包含 ACP bridge runtime、core shell runtime，以及此前通过 shared chunks 进入的重 vendor packages。同时保留 request-helper import 边界的轻量源码级 guard，并把真实 bundle 的重断言从 CLI 单测路径移到显式 CI 检查里。

## Why it's needed

daemon 启动优化依赖 listener 路径不 eager 加载 ACP runtime 和 transitive core/vendor imports。单纯的源码 import 检查会漏掉 esbuild shared chunks 和 hash 后的输出文件名，所以这里新增基于 metafile 的 reachability check：跟踪静态 output imports，同时允许 runtime loader 使用的 dynamic imports。

## Reviewer Test Plan

### How to verify

运行 `npm run test:scripts -- scripts/tests/serve-fast-path-bundle-check.test.js`，确认 synthetic metafile 覆盖可以捕获静态 forbidden runtime imports、允许 dynamic imports、报告 vendor package sentinels，并输出 static import path 诊断。运行 `cd packages/cli && npx vitest run src/serve/fast-path.test.ts`，确认源码 fast-path 测试通过。运行 `npm run check:serve-fast-path-bundle`，确认真实 bundled serve fast-path closure 通过。运行 `npm run build && npm run typecheck`，确认 workspace 仍可 build 和 typecheck。

### Evidence (Before & After)

N/A。这是非 UI 的 guard 和 import-boundary hardening 变更。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 本地 checkout，Node v26.0.0，npm 11.12.1。

## Risk & Scope

- Main risk or tradeoff: 新 CI 检查会在 Ubuntu CI leg 上执行 CLI-only build 和 bundle，会增加 CI 时间，但能直接覆盖 bundled daemon fast path。它有意不在 macOS/Windows merge-queue jobs 中重复运行这个 guard，因为 bundle import graph 与平台无关，且脚本已经做了路径归一化。
- Not validated / out of scope: 本 PR 不修改 `getCliVersion()` timing、raw HTTP/Express bootstrap behavior、settings async reads，也不修改 package `sideEffects` metadata。
- Breaking changes / migration notes: 无。

## Linked Issues

Refs #4748

</details>

