### PR TITLE
fix(web-shell): improve follow-up suggestion handling

### DIFF
--- a/packages/web-shell/client/hooks/useComposerCore.test.ts
+++ b/packages/web-shell/client/hooks/useComposerCore.test.ts
@@ -6,6 +6,7 @@ import {
   getComposerTagDisplay,
   getComposerTagLabel,
   getComposerTagValue,
+  getFollowupCompletion,
   isLargePaste,
   normalizePastedText,
   prunePendingPastes,
@@ -29,6 +30,22 @@ describe('composer paste helpers', () => {
     expect(isLargePaste(Array.from({ length: 11 }, () => 'x').join('\n'))).toBe(
       true,
     );
+  });
+});
+
+describe('follow-up completion helpers', () => {
+  it('uses the full suggestion when the editor is empty', () => {
+    expect(getFollowupCompletion('', 'show me tests')).toBe('show me tests');
+  });
+
+  it('keeps a suggestion available while the user types a matching prefix', () => {
+    expect(getFollowupCompletion('show', 'show me tests')).toBe(
+      'show me tests',
+    );
+  });
+
+  it('ignores suggestions that no longer match the editor text', () => {
+    expect(getFollowupCompletion('run', 'show me tests')).toBeNull();
   });
 });
 

--- a/packages/web-shell/client/hooks/useComposerCore.ts
+++ b/packages/web-shell/client/hooks/useComposerCore.ts
@@ -660,7 +660,7 @@ export const editableCompartment = new Compartment();
 export const placeholderCompartment = new Compartment();
 export const followupGhostCompartment = new Compartment();
 
-function getFollowupCompletion(
+export function getFollowupCompletion(
   text: string,
   suggestion: string | null | undefined,
 ): string | null {
@@ -1085,11 +1085,23 @@ export function useComposerCore(
   // Update hasContent when tags or images change
   useEffect(() => {
     const view = viewRef.current;
-    const text = view?.state.doc.toString().trim() ?? '';
-    setHasContent(
-      text.length > 0 || composerTags.length > 0 || pastedImages.length > 0,
+    const text = view?.state.doc.toString() ?? '';
+    const followupCompletion = getFollowupCompletion(
+      text,
+      followupState?.isVisible ? followupState.suggestion : null,
     );
-  }, [composerTags, pastedImages]);
+    setHasContent(
+      text.trim().length > 0 ||
+        !!followupCompletion ||
+        composerTags.length > 0 ||
+        pastedImages.length > 0,
+    );
+  }, [
+    composerTags,
+    pastedImages,
+    followupState?.isVisible,
+    followupState?.suggestion,
+  ]);
 
   const promptHistory = useInputHistory();
   const shellHistory = useInputHistory('qwen-web-shell-command-history');
@@ -1278,7 +1290,13 @@ export function useComposerCore(
       textOverride?: string,
       tagsOverride?: readonly WebShellComposerTag[],
     ) => {
-      const rawText = (textOverride ?? view.state.doc.toString()).trim();
+      const editorText = view.state.doc.toString();
+      const followup = followupStateRef.current;
+      const followupCompletion =
+        textOverride === undefined && followup?.isVisible
+          ? getFollowupCompletion(editorText, followup.suggestion)
+          : null;
+      const rawText = (textOverride ?? followupCompletion ?? editorText).trim();
       const tags = tagsOverride ?? composerTagsRef.current;
       if (!rawText && tags.length === 0) return true;
       const text = expandLargePastePlaceholders(
@@ -1294,6 +1312,9 @@ export function useComposerCore(
       );
       if (accepted === false) return true;
       setSlashMenu(null);
+      if (followupCompletion) {
+        onAcceptFollowupRef.current?.('enter', { skipOnAccept: true });
+      }
       onDismissFollowupRef.current?.();
       pendingPastesRef.current.clear();
       nextPasteIdRef.current = 1;
@@ -1753,9 +1774,15 @@ export function useComposerCore(
         // Update hasContent state when document changes
         EditorView.updateListener.of((update) => {
           if (update.docChanged) {
-            const text = update.state.doc.toString().trim();
+            const text = update.state.doc.toString();
+            const followup = followupStateRef.current;
+            const followupCompletion = getFollowupCompletion(
+              text,
+              followup?.isVisible ? followup.suggestion : null,
+            );
             setHasContent(
-              text.length > 0 ||
+              text.trim().length > 0 ||
+                !!followupCompletion ||
                 composerTagsRef.current.length > 0 ||
                 pastedImagesRef.current.length > 0,
             );

--- a/packages/webui/src/daemon/useDaemonFollowupSuggestion.ts
+++ b/packages/webui/src/daemon/useDaemonFollowupSuggestion.ts
@@ -6,7 +6,10 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSyncExternalStore } from 'react';
-import { useDaemonTranscriptStore } from './session/DaemonSessionProvider.js';
+import {
+  useDaemonConnection,
+  useDaemonTranscriptStore,
+} from './session/DaemonSessionProvider.js';
 import {
   clearSidechannelFollowupSuggestion,
   getSidechannelFollowupSuggestion,
@@ -244,6 +247,7 @@ export function useDaemonFollowupSuggestion(
 ): UseDaemonFollowupSuggestionReturn {
   const { enabled = true, onAccept, onOutcome } = opts;
   const store = useDaemonTranscriptStore();
+  const sessionId = useDaemonConnection().sessionId;
   const [state, setState] = useState<FollowupState>(INITIAL_FOLLOWUP_STATE);
   const onAcceptRef = useRef(onAccept);
   onAcceptRef.current = onAccept;
@@ -260,7 +264,9 @@ export function useDaemonFollowupSuggestion(
     getSidechannelFollowupSuggestion,
   );
   const activeFollowupSuggestion =
-    sidechannelFollowupSuggestion ?? lastFollowupSuggestion;
+    sidechannelFollowupSuggestion?.sessionId === sessionId
+      ? sidechannelFollowupSuggestion
+      : lastFollowupSuggestion;
 
   const controller = useMemo(
     () =>
@@ -288,6 +294,24 @@ export function useDaemonFollowupSuggestion(
   // controller's React state, which would otherwise re-trigger this
   // effect on the next render and re-show the suggestion.
   const lastPushedPromptIdRef = useRef<string | undefined>(undefined);
+  const previousSessionIdRef = useRef<string | undefined>(sessionId);
+  useEffect(() => {
+    const previousSessionId = previousSessionIdRef.current;
+    previousSessionIdRef.current = sessionId;
+    const sessionChanged =
+      previousSessionId !== undefined &&
+      sessionId !== undefined &&
+      previousSessionId !== sessionId;
+    if (!sessionChanged) return;
+    // Session switches should drop the old local display and global
+    // sidechannel value, but not the transcript store: the provider resets
+    // that store for the new session, and it may already contain the new
+    // session's own follow-up suggestion.
+    controller.clear();
+    clearSidechannelFollowupSuggestion();
+    lastPushedPromptIdRef.current = undefined;
+  }, [controller, sessionId]);
+
   useEffect(() => {
     const nextPromptId = activeFollowupSuggestion?.promptId;
     if (nextPromptId === lastPushedPromptIdRef.current) return;


### PR DESCRIPTION
## What this PR does

This PR improves web-shell follow-up suggestion handling in two places. First, when a follow-up suggestion is visible, the composer send button now treats the suggestion as sendable content. Clicking send submits the full suggestion when the editor is empty or when the editor text is a matching prefix of that suggestion, matching the existing Enter-key behavior. Second, follow-up suggestions are scoped more carefully across session switches so a suggestion from one session is not carried into another session.

The change also adds focused logic coverage for follow-up completion matching: empty input, matching prefixes, and non-matching text.

## Why it's needed

Before this change, users had to press Tab to materialize a visible follow-up suggestion before the send button became usable. This made the send button appear disabled even though the UI was already showing a valid next prompt. In addition, switching from a session with a follow-up suggestion to another session could leave the previous suggestion visible if the next session did not have one.

The updated behavior lets users send the visible follow-up directly and clears only the local/global suggestion state that can leak between sessions, while preserving the new session's own transcript-store suggestion if it has one.

## Reviewer Test Plan

### How to verify

In web-shell, get a completed response that shows a follow-up suggestion. Confirm the send button is enabled even before pressing Tab, and clicking it sends the full follow-up suggestion. Then type a prefix that matches the suggestion and confirm the send button still submits the full suggestion. Type unrelated text and confirm the suggestion is not used. Switch from a session with a suggestion to a session without one and confirm the old suggestion disappears. Switch from a session without a suggestion to one that has its own follow-up and confirm the new suggestion still appears.

Local verification: `cd packages/web-shell && npx vitest run client/hooks/useComposerCore.test.ts`; `cd packages/webui && npm run typecheck`; `cd packages/web-shell && npx tsc --noEmit -p tsconfig.lib.json`.

### Evidence (Before & After)

Before: the send button stayed disabled for a visible follow-up until the user accepted it with Tab, and session switches could retain a stale suggestion from the previous session.

After: the send button can submit the visible follow-up directly, matching Enter behavior, and session switches clear leaked local/global suggestion state without deleting a new session's own suggestion.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Node 22 workspace, targeted web-shell hook test plus webui and web-shell TypeScript checks.

## Risk & Scope

- Main risk or tradeoff: Follow-up acceptance through the send button is currently reported through the same accept path used by keyboard submission, so telemetry does not distinguish the button source.
- Not validated / out of scope: Full browser visual regression testing and cross-platform CI.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 优化了 web-shell follow-up suggestion 的两个行为。第一，当 follow-up suggestion 可见时，composer 的发送按钮会把它视为可发送内容；如果输入框为空，或者当前输入是 suggestion 的匹配前缀，点击发送会直接提交完整 suggestion，这和已有的 Enter 键行为保持一致。第二，切换 session 时更严格地隔离 follow-up suggestion，避免一个 session 的 suggestion 带到另一个 session。

同时补充了聚焦的逻辑测试，覆盖 follow-up completion 的空输入、前缀匹配和不匹配文本三种情况。

## 为什么需要

修改前，用户必须先按 Tab 将可见的 follow-up suggestion 填入输入框，发送按钮才可用；这会让按钮看起来不可点击，虽然 UI 已经展示了一个有效的下一条 prompt。此外，从有 follow-up 的 session 切到另一个 session 时，如果下一个 session 没有 suggestion，之前的 suggestion 可能残留。

新的行为允许用户直接发送当前可见的 follow-up，并且只清理可能跨 session 泄漏的本地/全局 suggestion 状态，同时保留新 session 自己 transcript store 中的 suggestion。

## Reviewer Test Plan

### 如何验证

在 web-shell 中让一次回复完成并展示 follow-up suggestion。确认不按 Tab 时发送按钮也可用，点击后会发送完整 follow-up suggestion。然后输入 suggestion 的匹配前缀，确认发送按钮仍会提交完整 suggestion。输入不相关文本时，确认不会使用 suggestion。从有 suggestion 的 session 切换到没有 suggestion 的 session，确认旧 suggestion 消失。从没有 suggestion 的 session 切换到一个自身有 follow-up 的 session，确认新 suggestion 仍能展示。

本地验证：`cd packages/web-shell && npx vitest run client/hooks/useComposerCore.test.ts`；`cd packages/webui && npm run typecheck`；`cd packages/web-shell && npx tsc --noEmit -p tsconfig.lib.json`。

### 前后对比证据

Before：可见 follow-up 在用户按 Tab 接受之前，发送按钮仍是 disabled；切换 session 时可能残留上一个 session 的 suggestion。

After：发送按钮可以直接提交可见 follow-up，行为与 Enter 保持一致；session 切换会清理泄漏的本地/全局 suggestion 状态，同时不会删除新 session 自己的 suggestion。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Node 22 workspace，运行了定向 web-shell hook 测试，以及 webui/web-shell TypeScript 检查。

## 风险和范围

- 主要风险或取舍：通过发送按钮接受 follow-up 目前复用键盘提交的接受路径，telemetry 不单独区分按钮来源。
- 未验证 / 不在范围内：完整浏览器视觉回归测试和跨平台 CI。
- Breaking changes / 迁移说明：无。

## Linked Issues

N/A

</details>
