### PR TITLE
fix(cli): Keep serve health responsive before runtime load

### DIFF
--- a/packages/cli/src/serve/fast-path-open.test.ts
+++ b/packages/cli/src/serve/fast-path-open.test.ts
@@ -104,6 +104,10 @@ describe('serve fast path --open import boundary', () => {
     ]);
 
     await vi.waitFor(() => expect(runQwenServe).toHaveBeenCalledTimes(1));
+    expect(runQwenServe).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ deferRuntimeUntilFirstHealth: false }),
+    );
     await Promise.resolve();
     expect(serveCommandImported).toBe(false);
 
@@ -147,6 +151,10 @@ describe('serve fast path --open import boundary', () => {
     ]);
 
     await vi.waitFor(() => expect(runQwenServe).toHaveBeenCalledTimes(1));
+    expect(runQwenServe).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ deferRuntimeUntilFirstHealth: false }),
+    );
     await Promise.resolve();
     expect(serveCommandImported).toBe(false);
 

--- a/packages/cli/src/serve/fast-path-open.test.ts
+++ b/packages/cli/src/serve/fast-path-open.test.ts
@@ -20,6 +20,25 @@ const originalTrustedFoldersPath =
 describe('serve fast path --open import boundary', () => {
   let tempQwenHome: string | undefined;
 
+  function useTempQwenHome(): void {
+    tempQwenHome = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'qws-fast-path-open-')),
+    );
+    process.env['QWEN_HOME'] = tempQwenHome;
+    process.env['QWEN_CODE_SYSTEM_SETTINGS_PATH'] = path.join(
+      tempQwenHome,
+      'system-settings.json',
+    );
+    process.env['QWEN_CODE_SYSTEM_DEFAULTS_PATH'] = path.join(
+      tempQwenHome,
+      'system-defaults.json',
+    );
+    process.env['QWEN_CODE_TRUSTED_FOLDERS_PATH'] = path.join(
+      tempQwenHome,
+      'trustedFolders.json',
+    );
+  }
+
   afterEach(() => {
     vi.restoreAllMocks();
     vi.doUnmock('./run-qwen-serve.js');
@@ -55,22 +74,7 @@ describe('serve fast path --open import boundary', () => {
   });
 
   it('defers importing the full serve command opener until runtime is ready', async () => {
-    tempQwenHome = fs.realpathSync(
-      fs.mkdtempSync(path.join(os.tmpdir(), 'qws-fast-path-open-')),
-    );
-    process.env['QWEN_HOME'] = tempQwenHome;
-    process.env['QWEN_CODE_SYSTEM_SETTINGS_PATH'] = path.join(
-      tempQwenHome,
-      'system-settings.json',
-    );
-    process.env['QWEN_CODE_SYSTEM_DEFAULTS_PATH'] = path.join(
-      tempQwenHome,
-      'system-defaults.json',
-    );
-    process.env['QWEN_CODE_TRUSTED_FOLDERS_PATH'] = path.join(
-      tempQwenHome,
-      'trustedFolders.json',
-    );
+    useTempQwenHome();
 
     let resolveRuntime: (() => void) | undefined;
     const runtimeReady = new Promise<void>((resolve) => {
@@ -106,5 +110,50 @@ describe('serve fast path --open import boundary', () => {
     resolveRuntime?.();
     await vi.waitFor(() => expect(openBrowser).toHaveBeenCalledTimes(1));
     expect(serveCommandImported).toBe(true);
+  });
+
+  it('skips importing the full serve command opener when runtime startup fails', async () => {
+    useTempQwenHome();
+
+    let rejectRuntime: ((err: Error) => void) | undefined;
+    const runtimeReady = new Promise<void>((_resolve, reject) => {
+      rejectRuntime = reject;
+    });
+    const close = vi.fn().mockResolvedValue(undefined);
+    const runQwenServe = vi.fn(async () => ({
+      runtimeReady,
+      close,
+    }));
+    let serveCommandImported = false;
+    const openBrowser = vi.fn(async () => undefined);
+    vi.doMock('./run-qwen-serve.js', () => ({ runQwenServe }));
+    vi.doMock('../commands/serve.js', () => {
+      serveCommandImported = true;
+      return { maybeOpenWebShellBrowser: openBrowser };
+    });
+    vi.spyOn(process, 'exit').mockImplementation(((code) => {
+      throw new Error(`process.exit ${code}`);
+    }) as typeof process.exit);
+
+    const { tryRunServeFastPath } = await import('./fast-path.js');
+    const fastPathPromise = tryRunServeFastPath([
+      'serve',
+      '--port',
+      '0',
+      '--hostname',
+      '127.0.0.1',
+      '--open',
+      '--no-web',
+    ]);
+
+    await vi.waitFor(() => expect(runQwenServe).toHaveBeenCalledTimes(1));
+    await Promise.resolve();
+    expect(serveCommandImported).toBe(false);
+
+    rejectRuntime?.(new Error('runtime boom'));
+    await expect(fastPathPromise).rejects.toThrow('process.exit 1');
+    expect(openBrowser).not.toHaveBeenCalled();
+    expect(serveCommandImported).toBe(false);
+    expect(close).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cli/src/serve/fast-path-open.test.ts
+++ b/packages/cli/src/serve/fast-path-open.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const originalQwenHome = process.env['QWEN_HOME'];
+const originalSystemSettingsPath =
+  process.env['QWEN_CODE_SYSTEM_SETTINGS_PATH'];
+const originalSystemDefaultsPath =
+  process.env['QWEN_CODE_SYSTEM_DEFAULTS_PATH'];
+const originalTrustedFoldersPath =
+  process.env['QWEN_CODE_TRUSTED_FOLDERS_PATH'];
+
+describe('serve fast path --open import boundary', () => {
+  let tempQwenHome: string | undefined;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.doUnmock('./run-qwen-serve.js');
+    vi.doUnmock('../commands/serve.js');
+    vi.resetModules();
+    if (originalQwenHome === undefined) {
+      delete process.env['QWEN_HOME'];
+    } else {
+      process.env['QWEN_HOME'] = originalQwenHome;
+    }
+    if (originalSystemSettingsPath === undefined) {
+      delete process.env['QWEN_CODE_SYSTEM_SETTINGS_PATH'];
+    } else {
+      process.env['QWEN_CODE_SYSTEM_SETTINGS_PATH'] =
+        originalSystemSettingsPath;
+    }
+    if (originalSystemDefaultsPath === undefined) {
+      delete process.env['QWEN_CODE_SYSTEM_DEFAULTS_PATH'];
+    } else {
+      process.env['QWEN_CODE_SYSTEM_DEFAULTS_PATH'] =
+        originalSystemDefaultsPath;
+    }
+    if (originalTrustedFoldersPath === undefined) {
+      delete process.env['QWEN_CODE_TRUSTED_FOLDERS_PATH'];
+    } else {
+      process.env['QWEN_CODE_TRUSTED_FOLDERS_PATH'] =
+        originalTrustedFoldersPath;
+    }
+    if (tempQwenHome) {
+      fs.rmSync(tempQwenHome, { recursive: true, force: true });
+      tempQwenHome = undefined;
+    }
+  });
+
+  it('defers importing the full serve command opener until runtime is ready', async () => {
+    tempQwenHome = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'qws-fast-path-open-')),
+    );
+    process.env['QWEN_HOME'] = tempQwenHome;
+    process.env['QWEN_CODE_SYSTEM_SETTINGS_PATH'] = path.join(
+      tempQwenHome,
+      'system-settings.json',
+    );
+    process.env['QWEN_CODE_SYSTEM_DEFAULTS_PATH'] = path.join(
+      tempQwenHome,
+      'system-defaults.json',
+    );
+    process.env['QWEN_CODE_TRUSTED_FOLDERS_PATH'] = path.join(
+      tempQwenHome,
+      'trustedFolders.json',
+    );
+
+    let resolveRuntime: (() => void) | undefined;
+    const runtimeReady = new Promise<void>((resolve) => {
+      resolveRuntime = resolve;
+    });
+    const runQwenServe = vi.fn(async () => ({
+      runtimeReady,
+      close: vi.fn().mockResolvedValue(undefined),
+    }));
+    let serveCommandImported = false;
+    const openBrowser = vi.fn(async () => undefined);
+    vi.doMock('./run-qwen-serve.js', () => ({ runQwenServe }));
+    vi.doMock('../commands/serve.js', () => {
+      serveCommandImported = true;
+      return { maybeOpenWebShellBrowser: openBrowser };
+    });
+
+    const { tryRunServeFastPath } = await import('./fast-path.js');
+    void tryRunServeFastPath([
+      'serve',
+      '--port',
+      '0',
+      '--hostname',
+      '127.0.0.1',
+      '--open',
+      '--no-web',
+    ]);
+
+    await vi.waitFor(() => expect(runQwenServe).toHaveBeenCalledTimes(1));
+    await Promise.resolve();
+    expect(serveCommandImported).toBe(false);
+
+    resolveRuntime?.();
+    await vi.waitFor(() => expect(openBrowser).toHaveBeenCalledTimes(1));
+    expect(serveCommandImported).toBe(true);
+  });
+});

--- a/packages/cli/src/serve/fast-path.test.ts
+++ b/packages/cli/src/serve/fast-path.test.ts
@@ -380,7 +380,9 @@ describe('CLI entry import boundary', () => {
     expect(fastPathSource).not.toContain('@qwen-code/qwen-code-core');
     expect(fastPathSource).toContain('bootSettings: settings');
     expect(fastPathSource).toContain('resolveOnListen: true');
-    expect(fastPathSource).toContain('deferRuntimeUntilFirstHealth: true');
+    expect(fastPathSource).toContain(
+      'deferRuntimeUntilFirstHealth: !parsed.open',
+    );
   });
 
   it('uses the shared headless yolo warning helper on the serve fast path', () => {

--- a/packages/cli/src/serve/fast-path.test.ts
+++ b/packages/cli/src/serve/fast-path.test.ts
@@ -383,6 +383,26 @@ describe('CLI entry import boundary', () => {
     expect(fastPathSource).toContain('deferRuntimeUntilFirstHealth: true');
   });
 
+  it('uses the shared headless yolo warning helper on the serve fast path', () => {
+    const fastPathSource = readFileSync('src/serve/fast-path.ts', 'utf8');
+
+    expect(fastPathSource).toContain('getHeadlessYoloSafetyWarning');
+    expect(fastPathSource).not.toContain(
+      "settings.tools?.approvalMode === 'yolo'",
+    );
+  });
+
+  it('keeps headless yolo warning helper free of runtime core imports', () => {
+    const helperSource = readFileSync(
+      'src/utils/headlessSafetyWarnings.ts',
+      'utf8',
+    );
+
+    expect(helperSource).not.toMatch(
+      /import\s+(?!type\b)[^;]*from ['"]@qwen-code\/qwen-code-core['"]/,
+    );
+  });
+
   it('keeps settings free of UI imports used before serve can listen', () => {
     const settingsSource = readFileSync('src/config/settings.ts', 'utf8');
 

--- a/packages/cli/src/serve/fast-path.test.ts
+++ b/packages/cli/src/serve/fast-path.test.ts
@@ -378,6 +378,7 @@ describe('CLI entry import boundary', () => {
     expect(fastPathSource).not.toContain('@qwen-code/qwen-code-core');
     expect(fastPathSource).toContain('bootSettings: settings');
     expect(fastPathSource).toContain('resolveOnListen: true');
+    expect(fastPathSource).toContain('deferRuntimeUntilFirstHealth: true');
   });
 
   it('keeps settings free of UI imports used before serve can listen', () => {

--- a/packages/cli/src/serve/fast-path.test.ts
+++ b/packages/cli/src/serve/fast-path.test.ts
@@ -41,6 +41,7 @@ import {
   resetTrustedFoldersForTesting,
   TrustLevel,
 } from '../config/trustedFolders.js';
+import { HEADLESS_YOLO_NO_SANDBOX_WARNING } from '../utils/headlessSafetyWarnings.js';
 import * as runQwenServeModule from './run-qwen-serve.js';
 import type { ServeFastPathSettings } from './fast-path-settings.js';
 import type { Settings } from '../config/settingsSchema.js';
@@ -873,6 +874,66 @@ describe('serve fast path environment bootstrap', () => {
 
     expect(stderrWrites.join('')).toContain('qwen serve: listen boom');
     expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it('keeps headless yolo warning best-effort after listening', async () => {
+    const originalSandbox = process.env['SANDBOX'];
+    const originalSuppress = process.env['QWEN_CODE_SUPPRESS_YOLO_WARNING'];
+    delete process.env['SANDBOX'];
+    delete process.env['QWEN_CODE_SUPPRESS_YOLO_WARNING'];
+    const qwenHome = useTempQwenHome();
+    writeFileSync(
+      join(qwenHome, 'settings.json'),
+      JSON.stringify({ tools: { approvalMode: 'yolo', sandbox: false } }),
+    );
+    const runtimeReady = Promise.reject(new Error('runtime boom'));
+    void runtimeReady.catch(() => undefined);
+    const close = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(runQwenServeModule, 'runQwenServe').mockResolvedValue({
+      runtimeReady,
+      close,
+    } as unknown as Awaited<
+      ReturnType<typeof runQwenServeModule.runQwenServe>
+    >);
+    const stderrWrites: string[] = [];
+    vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      const text = String(chunk);
+      stderrWrites.push(text);
+      if (text.includes(HEADLESS_YOLO_NO_SANDBOX_WARNING)) {
+        throw new Error('stderr closed');
+      }
+      return true;
+    });
+    vi.spyOn(process, 'exit').mockImplementation(((
+      code?: string | number | null,
+    ) => {
+      throw new Error(`process.exit(${code})`);
+    }) as typeof process.exit);
+
+    try {
+      await expect(
+        tryRunServeFastPath(['serve', '--port', '0', '--no-open', '--no-web']),
+      ).rejects.toThrow('process.exit(1)');
+
+      expect(stderrWrites.join('')).toContain(HEADLESS_YOLO_NO_SANDBOX_WARNING);
+      expect(stderrWrites.join('')).toContain(
+        'qwen serve: runtime startup failed after listener was ready: runtime boom',
+      );
+      expect(stderrWrites.join('')).not.toContain('qwen serve: stderr closed');
+      expect(close).toHaveBeenCalledTimes(1);
+      expect(process.exit).toHaveBeenCalledWith(1);
+    } finally {
+      if (originalSandbox === undefined) {
+        delete process.env['SANDBOX'];
+      } else {
+        process.env['SANDBOX'] = originalSandbox;
+      }
+      if (originalSuppress === undefined) {
+        delete process.env['QWEN_CODE_SUPPRESS_YOLO_WARNING'];
+      } else {
+        process.env['QWEN_CODE_SUPPRESS_YOLO_WARNING'] = originalSuppress;
+      }
+    }
   });
 
   it('rejects malformed user settings so the full settings loader can handle it', async () => {

--- a/packages/cli/src/serve/fast-path.test.ts
+++ b/packages/cli/src/serve/fast-path.test.ts
@@ -37,6 +37,7 @@ import {
   getGlobalQwenDirLite,
   SETTINGS_DIRECTORY_NAME,
 } from '../config/storage-paths-lite.js';
+import { RUNTIME_STARTUP_CANCELLED_MESSAGE } from './runtime-startup-errors.js';
 import {
   resetTrustedFoldersForTesting,
   TrustLevel,
@@ -814,7 +815,7 @@ describe('serve fast path environment bootstrap', () => {
     await expect(
       waitForServeRuntimeOrExit({
         runtimeReady: Promise.reject(
-          new Error('Daemon runtime cancelled: server closed before startup.'),
+          new Error(RUNTIME_STARTUP_CANCELLED_MESSAGE),
         ),
         close,
       }),

--- a/packages/cli/src/serve/fast-path.test.ts
+++ b/packages/cli/src/serve/fast-path.test.ts
@@ -798,6 +798,35 @@ describe('serve fast path environment bootstrap', () => {
     expect(process.exit).toHaveBeenCalledWith(1);
   });
 
+  it('does not report startup failure when runtime startup is cancelled by close', async () => {
+    const stderrWrites: string[] = [];
+    const close = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      stderrWrites.push(String(chunk));
+      return true;
+    });
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((
+      code?: string | number | null,
+    ) => {
+      throw new Error(`process.exit(${code})`);
+    }) as typeof process.exit);
+
+    await expect(
+      waitForServeRuntimeOrExit({
+        runtimeReady: Promise.reject(
+          new Error('Daemon runtime cancelled: server closed before startup.'),
+        ),
+        close,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(close).not.toHaveBeenCalled();
+    expect(stderrWrites.join('')).not.toContain(
+      'runtime startup failed after listener was ready',
+    );
+    expect(exit).not.toHaveBeenCalled();
+  });
+
   it('validates rate limit env after settings bootstrap enables rate limiting', async () => {
     useTempQwenHome();
     tempWorkspace = realpathSync(

--- a/packages/cli/src/serve/fast-path.ts
+++ b/packages/cli/src/serve/fast-path.ts
@@ -7,6 +7,7 @@
 import type { RunHandle } from './run-qwen-serve.js';
 import { normalizeServeFastPathArgv } from './fast-path-argv.js';
 import type { ServeFastPathSettings } from './fast-path-settings.js';
+import { RUNTIME_STARTUP_CANCELLED_MESSAGE } from './runtime-startup-errors.js';
 import type { ServeOptions } from './types.js';
 import { HEADLESS_YOLO_NO_SANDBOX_WARNING } from '../utils/headlessSafetyWarnings.js';
 
@@ -195,9 +196,6 @@ function getServeFastPathValidationError(
 function blockForever(): Promise<never> {
   return new Promise<never>(() => {});
 }
-
-const RUNTIME_STARTUP_CANCELLED_MESSAGE =
-  'Daemon runtime cancelled: server closed before startup.';
 
 export async function waitForServeRuntimeOrExit(
   handle: Pick<RunHandle, 'runtimeReady' | 'close'>,

--- a/packages/cli/src/serve/fast-path.ts
+++ b/packages/cli/src/serve/fast-path.ts
@@ -390,6 +390,11 @@ async function maybeOpenWebShellBrowser(
   open: boolean,
 ): Promise<void> {
   if (!open) return;
+  try {
+    await handle.runtimeReady;
+  } catch {
+    return;
+  }
   const { maybeOpenWebShellBrowser: openBrowser } = await import(
     '../commands/serve.js'
   );

--- a/packages/cli/src/serve/fast-path.ts
+++ b/packages/cli/src/serve/fast-path.ts
@@ -487,7 +487,11 @@ export async function tryRunServeFastPath(
       resolveOnListen: true,
       deferRuntimeUntilFirstHealth: true,
     });
-    emitHeadlessYoloWarning(settings);
+    try {
+      emitHeadlessYoloWarning(settings);
+    } catch {
+      // Keep the warning best-effort, matching the yargs serve handler.
+    }
     await maybeOpenWebShellBrowser(handle, parsed.open);
   } catch (err) {
     writeStderrLine(

--- a/packages/cli/src/serve/fast-path.ts
+++ b/packages/cli/src/serve/fast-path.ts
@@ -196,12 +196,21 @@ function blockForever(): Promise<never> {
   return new Promise<never>(() => {});
 }
 
+const RUNTIME_STARTUP_CANCELLED_MESSAGE =
+  'Daemon runtime cancelled: server closed before startup.';
+
 export async function waitForServeRuntimeOrExit(
   handle: Pick<RunHandle, 'runtimeReady' | 'close'>,
 ): Promise<void> {
   try {
     await handle.runtimeReady;
   } catch (err) {
+    if (
+      err instanceof Error &&
+      err.message === RUNTIME_STARTUP_CANCELLED_MESSAGE
+    ) {
+      return;
+    }
     writeStderrLine(
       `qwen serve: runtime startup failed after listener was ready: ${
         err instanceof Error ? err.message : String(err)

--- a/packages/cli/src/serve/fast-path.ts
+++ b/packages/cli/src/serve/fast-path.ts
@@ -8,6 +8,7 @@ import type { RunHandle } from './run-qwen-serve.js';
 import { normalizeServeFastPathArgv } from './fast-path-argv.js';
 import type { ServeFastPathSettings } from './fast-path-settings.js';
 import type { ServeOptions } from './types.js';
+import { HEADLESS_YOLO_NO_SANDBOX_WARNING } from '../utils/headlessSafetyWarnings.js';
 
 type McpBudgetMode = NonNullable<ServeOptions['mcpBudgetMode']>;
 
@@ -395,25 +396,18 @@ async function maybeOpenWebShellBrowser(
   await openBrowser(handle, true);
 }
 
-async function emitHeadlessYoloWarning(
+function emitHeadlessYoloWarning(
   settings: ServeFastPathSettings | undefined,
-) {
+): void {
   if (!settings) return;
-  try {
-    const { HEADLESS_YOLO_NO_SANDBOX_WARNING } = await import(
-      '../utils/headlessSafetyWarnings.js'
-    );
-    const suppress = process.env['QWEN_CODE_SUPPRESS_YOLO_WARNING'];
-    if (
-      settings.tools?.approvalMode === 'yolo' &&
-      !settings.tools?.sandbox &&
-      !process.env['SANDBOX'] &&
-      !isTruthyEnv(suppress)
-    ) {
-      writeStderrLine(HEADLESS_YOLO_NO_SANDBOX_WARNING);
-    }
-  } catch {
-    // Keep the warning best-effort, matching the yargs serve handler.
+  const suppress = process.env['QWEN_CODE_SUPPRESS_YOLO_WARNING'];
+  if (
+    settings.tools?.approvalMode === 'yolo' &&
+    !settings.tools?.sandbox &&
+    !process.env['SANDBOX'] &&
+    !isTruthyEnv(suppress)
+  ) {
+    writeStderrLine(HEADLESS_YOLO_NO_SANDBOX_WARNING);
   }
 }
 
@@ -491,8 +485,9 @@ export async function tryRunServeFastPath(
     handle = await runQwenServe(parsed.options, {
       ...(settings ? { bootSettings: settings } : {}),
       resolveOnListen: true,
+      deferRuntimeUntilFirstHealth: true,
     });
-    void emitHeadlessYoloWarning(settings);
+    emitHeadlessYoloWarning(settings);
     await maybeOpenWebShellBrowser(handle, parsed.open);
   } catch (err) {
     writeStderrLine(

--- a/packages/cli/src/serve/fast-path.ts
+++ b/packages/cli/src/serve/fast-path.ts
@@ -415,7 +415,7 @@ function emitHeadlessYoloWarning(
   const warning = getHeadlessYoloSafetyWarning({
     getApprovalMode: () => settings.tools?.approvalMode,
     getSandbox: () => settings.tools?.sandbox,
-  } as Parameters<typeof getHeadlessYoloSafetyWarning>[0]);
+  });
   if (warning) {
     writeStderrLine(warning);
   }

--- a/packages/cli/src/serve/fast-path.ts
+++ b/packages/cli/src/serve/fast-path.ts
@@ -495,7 +495,7 @@ export async function tryRunServeFastPath(
     handle = await runQwenServe(parsed.options, {
       ...(settings ? { bootSettings: settings } : {}),
       resolveOnListen: true,
-      deferRuntimeUntilFirstHealth: true,
+      deferRuntimeUntilFirstHealth: !parsed.open,
     });
     try {
       emitHeadlessYoloWarning(settings);

--- a/packages/cli/src/serve/fast-path.ts
+++ b/packages/cli/src/serve/fast-path.ts
@@ -9,7 +9,7 @@ import { normalizeServeFastPathArgv } from './fast-path-argv.js';
 import type { ServeFastPathSettings } from './fast-path-settings.js';
 import { RUNTIME_STARTUP_CANCELLED_MESSAGE } from './runtime-startup-errors.js';
 import type { ServeOptions } from './types.js';
-import { HEADLESS_YOLO_NO_SANDBOX_WARNING } from '../utils/headlessSafetyWarnings.js';
+import { getHeadlessYoloSafetyWarning } from '../utils/headlessSafetyWarnings.js';
 
 type McpBudgetMode = NonNullable<ServeOptions['mcpBudgetMode']>;
 
@@ -412,14 +412,12 @@ function emitHeadlessYoloWarning(
   settings: ServeFastPathSettings | undefined,
 ): void {
   if (!settings) return;
-  const suppress = process.env['QWEN_CODE_SUPPRESS_YOLO_WARNING'];
-  if (
-    settings.tools?.approvalMode === 'yolo' &&
-    !settings.tools?.sandbox &&
-    !process.env['SANDBOX'] &&
-    !isTruthyEnv(suppress)
-  ) {
-    writeStderrLine(HEADLESS_YOLO_NO_SANDBOX_WARNING);
+  const warning = getHeadlessYoloSafetyWarning({
+    getApprovalMode: () => settings.tools?.approvalMode,
+    getSandbox: () => settings.tools?.sandbox,
+  } as Parameters<typeof getHeadlessYoloSafetyWarning>[0]);
+  if (warning) {
+    writeStderrLine(warning);
   }
 }
 

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -987,6 +987,55 @@ describe('runQwenServe runtime startup failures', () => {
     }
   });
 
+  it('allows deferred runtime CORS preflight without auth or runtime startup', async () => {
+    tmpDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'qws-runtime-preflight-')),
+    );
+    const bridge = makeRuntimeBridge();
+    const createBridge = vi
+      .spyOn(acpBridge, 'createAcpSessionBridge')
+      .mockReturnValue(
+        bridge as ReturnType<typeof acpBridge.createAcpSessionBridge>,
+      );
+
+    const handle = await runQwenServe(
+      {
+        port: 0,
+        hostname: '127.0.0.1',
+        mode: 'http-bridge',
+        workspace: tmpDir,
+        maxSessions: 1,
+        serveWebShell: false,
+        token: 'secret-token',
+        allowOrigins: ['http://localhost:5173'],
+      },
+      {
+        resolveOnListen: true,
+        deferRuntimeUntilFirstHealth: true,
+        runtimeStartupTimeoutMs: 0,
+      },
+    );
+
+    try {
+      const res = await fetch(`${handle.url}/session/foo/prompt`, {
+        method: 'OPTIONS',
+        headers: {
+          origin: 'http://localhost:5173',
+          'access-control-request-method': 'POST',
+          'access-control-request-headers': 'authorization,content-type',
+        },
+      });
+      expect(res.status).toBe(204);
+      expect(res.headers.get('access-control-allow-origin')).toBe(
+        'http://localhost:5173',
+      );
+      expect(res.headers.get('access-control-allow-methods')).toContain('POST');
+      expect(createBridge).not.toHaveBeenCalled();
+    } finally {
+      await handle.close();
+    }
+  });
+
   it('does not start deferred runtime for unsupported bootstrap route methods', async () => {
     tmpDir = fs.realpathSync(
       fs.mkdtempSync(path.join(os.tmpdir(), 'qws-bootstrap-method-')),

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -44,6 +44,22 @@ const BASE_BRIDGE_SNAPSHOT: BridgeDaemonStatusSnapshot = {
   sessions: [],
 };
 
+function makeRuntimeBridge(): HttpAcpBridge {
+  return {
+    spawnOrAttach: vi.fn(),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+    killAllSync: vi.fn(),
+    getSession: vi.fn(),
+    getAllSessions: vi.fn().mockReturnValue([]),
+    publishWorkspaceEvent: vi.fn(),
+    getEventRing: vi.fn().mockReturnValue({ getAll: () => [] }),
+    resume: vi.fn(),
+    preheat: vi.fn().mockResolvedValue(undefined),
+    getDaemonStatusSnapshot: vi.fn().mockReturnValue(BASE_BRIDGE_SNAPSHOT),
+    isChannelLive: vi.fn().mockReturnValue(true),
+  } as unknown as HttpAcpBridge;
+}
+
 const mockCreateSpawnChannelFactoryOptions = vi.hoisted(
   () => [] as Array<Record<string, unknown>>,
 );
@@ -708,19 +724,7 @@ describe('runQwenServe runtime startup failures', () => {
     vi.spyOn(qwenCore, 'resolveTelemetrySettings').mockReturnValue(
       telemetryPromise,
     );
-    const bridge = {
-      spawnOrAttach: vi.fn(),
-      shutdown: vi.fn().mockResolvedValue(undefined),
-      killAllSync: vi.fn(),
-      getSession: vi.fn(),
-      getAllSessions: vi.fn().mockReturnValue([]),
-      publishWorkspaceEvent: vi.fn(),
-      getEventRing: vi.fn().mockReturnValue({ getAll: () => [] }),
-      resume: vi.fn(),
-      preheat: vi.fn().mockResolvedValue(undefined),
-      getDaemonStatusSnapshot: vi.fn().mockReturnValue(BASE_BRIDGE_SNAPSHOT),
-      isChannelLive: vi.fn().mockReturnValue(true),
-    } as unknown as HttpAcpBridge;
+    const bridge = makeRuntimeBridge();
     vi.spyOn(acpBridge, 'createAcpSessionBridge').mockReturnValue(
       bridge as ReturnType<typeof acpBridge.createAcpSessionBridge>,
     );
@@ -751,6 +755,127 @@ describe('runQwenServe runtime startup failures', () => {
       });
       await handle.close();
     }
+  });
+
+  it('keeps health responsive before starting deferred runtime work', async () => {
+    tmpDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'qws-health-first-')),
+    );
+    let resolveTelemetry:
+      | ((settings: qwenCore.ResolvedTelemetrySettings) => void)
+      | undefined;
+    const telemetryPromise = new Promise<qwenCore.ResolvedTelemetrySettings>(
+      (resolve) => {
+        resolveTelemetry = resolve;
+      },
+    );
+    vi.spyOn(qwenCore, 'resolveTelemetrySettings').mockReturnValue(
+      telemetryPromise,
+    );
+    const bridge = makeRuntimeBridge();
+    vi.spyOn(acpBridge, 'createAcpSessionBridge').mockReturnValue(
+      bridge as ReturnType<typeof acpBridge.createAcpSessionBridge>,
+    );
+
+    const handle = await runQwenServe(
+      {
+        port: 0,
+        hostname: '127.0.0.1',
+        mode: 'http-bridge',
+        workspace: tmpDir,
+        maxSessions: 1,
+        serveWebShell: false,
+      },
+      {
+        resolveOnListen: true,
+        deferRuntimeUntilFirstHealth: true,
+        runtimeStartupTimeoutMs: 1,
+      },
+    );
+
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      const healthRes = await fetch(`${handle.url}/health`);
+      expect(healthRes.status).toBe(200);
+      expect(await healthRes.json()).toEqual({ status: 'ok' });
+    } finally {
+      resolveTelemetry?.({
+        enabled: false,
+        sensitiveSpanAttributeMaxLength: 1024 * 1024,
+      });
+      await handle.close();
+    }
+  });
+
+  it('starts deferred runtime on fallback when no health probe arrives', async () => {
+    tmpDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'qws-health-fallback-')),
+    );
+    const bridge = makeRuntimeBridge();
+    const createBridge = vi
+      .spyOn(acpBridge, 'createAcpSessionBridge')
+      .mockReturnValue(
+        bridge as ReturnType<typeof acpBridge.createAcpSessionBridge>,
+      );
+
+    const handle = await runQwenServe(
+      {
+        port: 0,
+        hostname: '127.0.0.1',
+        mode: 'http-bridge',
+        workspace: tmpDir,
+        maxSessions: 1,
+        serveWebShell: false,
+      },
+      {
+        resolveOnListen: true,
+        deferRuntimeUntilFirstHealth: true,
+        runtimeStartupTimeoutMs: 0,
+      },
+    );
+
+    try {
+      expect(createBridge).not.toHaveBeenCalled();
+      await vi.waitFor(() => expect(createBridge).toHaveBeenCalledTimes(1), {
+        timeout: 1500,
+      });
+      await expect(handle.runtimeReady).resolves.toBeUndefined();
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('does not start deferred runtime after close before first health', async () => {
+    tmpDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'qws-health-close-')),
+    );
+    const bridge = makeRuntimeBridge();
+    const createBridge = vi
+      .spyOn(acpBridge, 'createAcpSessionBridge')
+      .mockReturnValue(
+        bridge as ReturnType<typeof acpBridge.createAcpSessionBridge>,
+      );
+
+    const handle = await runQwenServe(
+      {
+        port: 0,
+        hostname: '127.0.0.1',
+        mode: 'http-bridge',
+        workspace: tmpDir,
+        maxSessions: 1,
+        serveWebShell: false,
+      },
+      {
+        resolveOnListen: true,
+        deferRuntimeUntilFirstHealth: true,
+        runtimeStartupTimeoutMs: 0,
+      },
+    );
+
+    await handle.close();
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+
+    expect(createBridge).not.toHaveBeenCalled();
   });
 
   it('flushes runtime startup failures to the daemon log when closing', async () => {

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -799,7 +799,7 @@ describe('runQwenServe runtime startup failures', () => {
       expect(await healthRes.json()).toEqual({ status: 'ok' });
 
       await vi.waitFor(() => expect(createBridge).toHaveBeenCalledTimes(1), {
-        timeout: 750,
+        timeout: 500,
       });
       expect(resolveTelemetrySettings).toHaveBeenCalledTimes(1);
       await expect(handle.runtimeReady).resolves.toBeUndefined();
@@ -877,6 +877,53 @@ describe('runQwenServe runtime startup failures', () => {
     await new Promise((resolve) => setTimeout(resolve, 1100));
 
     expect(createBridge).not.toHaveBeenCalled();
+    await expect(handle.runtimeReady).rejects.toThrow(
+      'Server closed before deferred runtime startup began.',
+    );
+  });
+
+  it('does not start deferred runtime after close following first health', async () => {
+    tmpDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'qws-health-close-after-')),
+    );
+    vi.spyOn(qwenCore, 'resolveTelemetrySettings').mockResolvedValue({
+      enabled: false,
+      sensitiveSpanAttributeMaxLength: 1024 * 1024,
+    });
+    const bridge = makeRuntimeBridge();
+    const createBridge = vi
+      .spyOn(acpBridge, 'createAcpSessionBridge')
+      .mockReturnValue(
+        bridge as ReturnType<typeof acpBridge.createAcpSessionBridge>,
+      );
+
+    const handle = await runQwenServe(
+      {
+        port: 0,
+        hostname: '127.0.0.1',
+        mode: 'http-bridge',
+        workspace: tmpDir,
+        maxSessions: 1,
+        serveWebShell: false,
+      },
+      {
+        resolveOnListen: true,
+        deferRuntimeUntilFirstHealth: true,
+        runtimeStartupTimeoutMs: 0,
+      },
+    );
+
+    const healthRes = await fetch(`${handle.url}/health`);
+    expect(healthRes.status).toBe(200);
+    expect(await healthRes.json()).toEqual({ status: 'ok' });
+
+    await handle.close();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(createBridge).not.toHaveBeenCalled();
+    await expect(handle.runtimeReady).rejects.toThrow(
+      'Server closed before deferred runtime startup began.',
+    );
   });
 
   it('flushes runtime startup failures to the daemon log when closing', async () => {

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -930,9 +930,7 @@ describe('runQwenServe runtime startup failures', () => {
     await new Promise((resolve) => setTimeout(resolve, 1100));
 
     expect(createBridge).not.toHaveBeenCalled();
-    await expect(handle.runtimeReady).rejects.toThrow(
-      'Server closed before deferred runtime startup began.',
-    );
+    await expect(handle.runtimeReady).resolves.toBeUndefined();
   });
 
   it('does not start deferred runtime after close following first health', async () => {
@@ -974,8 +972,65 @@ describe('runQwenServe runtime startup failures', () => {
     await new Promise((resolve) => setTimeout(resolve, 100));
 
     expect(createBridge).not.toHaveBeenCalled();
+    await expect(handle.runtimeReady).resolves.toBeUndefined();
+  });
+
+  it('does not cancel deferred runtime once startup is already running', async () => {
+    tmpDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'qws-health-close-running-')),
+    );
+    let resolveTelemetry:
+      | ((settings: qwenCore.ResolvedTelemetrySettings) => void)
+      | undefined;
+    const telemetryPromise = new Promise<qwenCore.ResolvedTelemetrySettings>(
+      (resolve) => {
+        resolveTelemetry = resolve;
+      },
+    );
+    const resolveTelemetrySettings = vi
+      .spyOn(qwenCore, 'resolveTelemetrySettings')
+      .mockReturnValue(telemetryPromise);
+    const bridge = makeRuntimeBridge();
+    const createBridge = vi
+      .spyOn(acpBridge, 'createAcpSessionBridge')
+      .mockReturnValue(
+        bridge as ReturnType<typeof acpBridge.createAcpSessionBridge>,
+      );
+
+    const handle = await runQwenServe(
+      {
+        port: 0,
+        hostname: '127.0.0.1',
+        mode: 'http-bridge',
+        workspace: tmpDir,
+        maxSessions: 1,
+        serveWebShell: false,
+      },
+      {
+        resolveOnListen: true,
+        deferRuntimeUntilFirstHealth: true,
+        runtimeStartupTimeoutMs: 0,
+      },
+    );
+
+    const healthRes = await fetch(`${handle.url}/health`);
+    expect(healthRes.status).toBe(200);
+    expect(await healthRes.json()).toEqual({ status: 'ok' });
+    await vi.waitFor(
+      () => expect(resolveTelemetrySettings).toHaveBeenCalledTimes(1),
+      { timeout: 500 },
+    );
+
+    const closePromise = handle.close();
+    resolveTelemetry?.({
+      enabled: false,
+      sensitiveSpanAttributeMaxLength: 1024 * 1024,
+    });
+    await closePromise;
+
+    expect(createBridge).toHaveBeenCalledTimes(1);
     await expect(handle.runtimeReady).rejects.toThrow(
-      'Server closed before deferred runtime startup began.',
+      'Daemon runtime stopped before mounting.',
     );
   });
 

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -20,6 +20,7 @@ import {
   validatePolicyConfig,
   waitForRuntimeStartingForShutdown,
 } from './run-qwen-serve.js';
+import { RUNTIME_STARTUP_CANCELLED_MESSAGE } from './runtime-startup-errors.js';
 import * as acpBridge from '@qwen-code/acp-bridge/bridge';
 import { canonicalizeWorkspace } from '@qwen-code/acp-bridge/workspacePaths';
 import type {
@@ -951,7 +952,7 @@ describe('runQwenServe runtime startup failures', () => {
 
     expect(createBridge).not.toHaveBeenCalled();
     await expect(handle.runtimeReady).rejects.toThrow(
-      'Daemon runtime cancelled: server closed before startup.',
+      RUNTIME_STARTUP_CANCELLED_MESSAGE,
     );
   });
 
@@ -995,7 +996,7 @@ describe('runQwenServe runtime startup failures', () => {
 
     expect(createBridge).not.toHaveBeenCalled();
     await expect(handle.runtimeReady).rejects.toThrow(
-      'Daemon runtime cancelled: server closed before startup.',
+      RUNTIME_STARTUP_CANCELLED_MESSAGE,
     );
   });
 

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -761,17 +761,12 @@ describe('runQwenServe runtime startup failures', () => {
     tmpDir = fs.realpathSync(
       fs.mkdtempSync(path.join(os.tmpdir(), 'qws-health-first-')),
     );
-    let resolveTelemetry:
-      | ((settings: qwenCore.ResolvedTelemetrySettings) => void)
-      | undefined;
-    const telemetryPromise = new Promise<qwenCore.ResolvedTelemetrySettings>(
-      (resolve) => {
-        resolveTelemetry = resolve;
-      },
-    );
-    vi.spyOn(qwenCore, 'resolveTelemetrySettings').mockReturnValue(
-      telemetryPromise,
-    );
+    const resolveTelemetrySettings = vi
+      .spyOn(qwenCore, 'resolveTelemetrySettings')
+      .mockResolvedValue({
+        enabled: false,
+        sensitiveSpanAttributeMaxLength: 1024 * 1024,
+      });
     const bridge = makeRuntimeBridge();
     const createBridge = vi
       .spyOn(acpBridge, 'createAcpSessionBridge')
@@ -796,25 +791,19 @@ describe('runQwenServe runtime startup failures', () => {
     );
 
     try {
-      await new Promise((resolve) => setTimeout(resolve, 25));
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      expect(resolveTelemetrySettings).not.toHaveBeenCalled();
       expect(createBridge).not.toHaveBeenCalled();
       const healthRes = await fetch(`${handle.url}/health`);
       expect(healthRes.status).toBe(200);
       expect(await healthRes.json()).toEqual({ status: 'ok' });
 
-      resolveTelemetry?.({
-        enabled: false,
-        sensitiveSpanAttributeMaxLength: 1024 * 1024,
-      });
       await vi.waitFor(() => expect(createBridge).toHaveBeenCalledTimes(1), {
-        timeout: 1500,
+        timeout: 750,
       });
+      expect(resolveTelemetrySettings).toHaveBeenCalledTimes(1);
       await expect(handle.runtimeReady).resolves.toBeUndefined();
     } finally {
-      resolveTelemetry?.({
-        enabled: false,
-        sensitiveSpanAttributeMaxLength: 1024 * 1024,
-      });
       await handle.close();
     }
   });

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -1034,6 +1034,56 @@ describe('runQwenServe runtime startup failures', () => {
     );
   });
 
+  it('does not retry deferred runtime after startup failure and later health probe', async () => {
+    tmpDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'qws-health-fail-once-')),
+    );
+    vi.spyOn(qwenCore, 'resolveTelemetrySettings').mockResolvedValue({
+      enabled: false,
+      sensitiveSpanAttributeMaxLength: 1024 * 1024,
+    });
+    const createBridge = vi
+      .spyOn(acpBridge, 'createAcpSessionBridge')
+      .mockImplementation(() => {
+        throw new Error('runtime boom');
+      });
+
+    const handle = await runQwenServe(
+      {
+        port: 0,
+        hostname: '127.0.0.1',
+        mode: 'http-bridge',
+        workspace: tmpDir,
+        maxSessions: 1,
+        serveWebShell: false,
+      },
+      {
+        resolveOnListen: true,
+        deferRuntimeUntilFirstHealth: true,
+        runtimeStartupTimeoutMs: 0,
+      },
+    );
+
+    try {
+      const firstHealthRes = await fetch(`${handle.url}/health`);
+      expect(firstHealthRes.status).toBe(200);
+      expect(await firstHealthRes.json()).toEqual({ status: 'ok' });
+      await expect(handle.runtimeReady).rejects.toThrow('runtime boom');
+      expect(createBridge).toHaveBeenCalledTimes(1);
+
+      const secondHealthRes = await fetch(`${handle.url}/health`);
+      expect(secondHealthRes.status).toBe(503);
+      expect(await secondHealthRes.json()).toMatchObject({
+        status: 'degraded',
+        error: 'runtime boom',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(createBridge).toHaveBeenCalledTimes(1);
+    } finally {
+      await handle.close();
+    }
+  });
+
   it('flushes runtime startup failures to the daemon log when closing', async () => {
     tmpDir = fs.realpathSync(
       fs.mkdtempSync(path.join(os.tmpdir(), 'qws-runtime-fail-log-')),

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -933,6 +933,143 @@ describe('runQwenServe runtime startup failures', () => {
     }
   });
 
+  it('rejects unauthenticated deferred runtime routes before starting runtime', async () => {
+    tmpDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'qws-runtime-route-auth-')),
+    );
+    const bridge = makeRuntimeBridge();
+    const createBridge = vi
+      .spyOn(acpBridge, 'createAcpSessionBridge')
+      .mockReturnValue(
+        bridge as ReturnType<typeof acpBridge.createAcpSessionBridge>,
+      );
+    vi.spyOn(serverModule, 'createServeApp').mockImplementation(() => {
+      const app = express();
+      app.post('/session', (_req, res) => {
+        res.status(201).json({ sessionId: 'session-1' });
+      });
+      return app;
+    });
+
+    const handle = await runQwenServe(
+      {
+        port: 0,
+        hostname: '127.0.0.1',
+        mode: 'http-bridge',
+        workspace: tmpDir,
+        maxSessions: 1,
+        serveWebShell: false,
+        token: 'secret-token',
+      },
+      {
+        resolveOnListen: true,
+        deferRuntimeUntilFirstHealth: true,
+        runtimeStartupTimeoutMs: 0,
+      },
+    );
+
+    try {
+      const res = await fetch(`${handle.url}/session`, { method: 'POST' });
+      expect(res.status).toBe(401);
+      expect(await res.json()).toEqual({ error: 'Unauthorized' });
+      expect(createBridge).not.toHaveBeenCalled();
+
+      const authorizedRes = await fetch(`${handle.url}/session`, {
+        method: 'POST',
+        headers: { authorization: 'Bearer secret-token' },
+      });
+      expect(authorizedRes.status).toBe(201);
+      expect(await authorizedRes.json()).toEqual({ sessionId: 'session-1' });
+      expect(createBridge).toHaveBeenCalledTimes(1);
+      await expect(handle.runtimeReady).resolves.toBeUndefined();
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('does not start deferred runtime for unsupported bootstrap route methods', async () => {
+    tmpDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'qws-bootstrap-method-')),
+    );
+    const bridge = makeRuntimeBridge();
+    const createBridge = vi
+      .spyOn(acpBridge, 'createAcpSessionBridge')
+      .mockReturnValue(
+        bridge as ReturnType<typeof acpBridge.createAcpSessionBridge>,
+      );
+
+    const handle = await runQwenServe(
+      {
+        port: 0,
+        hostname: '127.0.0.1',
+        mode: 'http-bridge',
+        workspace: tmpDir,
+        maxSessions: 1,
+        serveWebShell: false,
+      },
+      {
+        resolveOnListen: true,
+        deferRuntimeUntilFirstHealth: true,
+        runtimeStartupTimeoutMs: 0,
+      },
+    );
+
+    try {
+      const res = await fetch(`${handle.url}/health`, { method: 'POST' });
+      expect(res.status).toBe(503);
+      expect(await res.json()).toMatchObject({
+        code: 'daemon_runtime_starting',
+      });
+      expect(createBridge).not.toHaveBeenCalled();
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('reports deferred runtime startup failure for the triggering runtime route', async () => {
+    tmpDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'qws-runtime-route-fail-')),
+    );
+    vi.spyOn(qwenCore, 'resolveTelemetrySettings').mockResolvedValue({
+      enabled: false,
+      sensitiveSpanAttributeMaxLength: 1024 * 1024,
+    });
+    const createBridge = vi
+      .spyOn(acpBridge, 'createAcpSessionBridge')
+      .mockImplementation(() => {
+        throw new Error('runtime boom');
+      });
+
+    const handle = await runQwenServe(
+      {
+        port: 0,
+        hostname: '127.0.0.1',
+        mode: 'http-bridge',
+        workspace: tmpDir,
+        maxSessions: 1,
+        serveWebShell: false,
+      },
+      {
+        resolveOnListen: true,
+        deferRuntimeUntilFirstHealth: true,
+        runtimeStartupTimeoutMs: 0,
+      },
+    );
+
+    try {
+      const res = await fetch(`${handle.url}/session`, { method: 'POST' });
+      expect(res.status).toBe(503);
+      expect(await res.json()).toEqual({
+        error: 'Daemon runtime failed to start',
+        code: 'daemon_runtime_failed',
+      });
+      expect(createBridge).toHaveBeenCalledTimes(1);
+      await expect(handle.runtimeReady).rejects.toThrow('runtime boom');
+    } finally {
+      await handle.close();
+    }
+  });
+
   it('starts deferred runtime on fallback when no health probe arrives', async () => {
     tmpDir = fs.realpathSync(
       fs.mkdtempSync(path.join(os.tmpdir(), 'qws-health-fallback-')),

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -808,6 +808,59 @@ describe('runQwenServe runtime startup failures', () => {
     }
   });
 
+  it('starts deferred runtime once for duplicate health probes', async () => {
+    tmpDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'qws-health-dedupe-')),
+    );
+    vi.spyOn(qwenCore, 'resolveTelemetrySettings').mockResolvedValue({
+      enabled: false,
+      sensitiveSpanAttributeMaxLength: 1024 * 1024,
+    });
+    const bridge = makeRuntimeBridge();
+    const createBridge = vi
+      .spyOn(acpBridge, 'createAcpSessionBridge')
+      .mockReturnValue(
+        bridge as ReturnType<typeof acpBridge.createAcpSessionBridge>,
+      );
+
+    const handle = await runQwenServe(
+      {
+        port: 0,
+        hostname: '127.0.0.1',
+        mode: 'http-bridge',
+        workspace: tmpDir,
+        maxSessions: 1,
+        serveWebShell: false,
+      },
+      {
+        resolveOnListen: true,
+        deferRuntimeUntilFirstHealth: true,
+        runtimeStartupTimeoutMs: 0,
+      },
+    );
+
+    try {
+      expect(createBridge).not.toHaveBeenCalled();
+      const [firstHealthRes, secondHealthRes] = await Promise.all([
+        fetch(`${handle.url}/health`),
+        fetch(`${handle.url}/health`),
+      ]);
+      expect(firstHealthRes.status).toBe(200);
+      expect(secondHealthRes.status).toBe(200);
+      expect(await firstHealthRes.json()).toEqual({ status: 'ok' });
+      expect(await secondHealthRes.json()).toEqual({ status: 'ok' });
+
+      await vi.waitFor(() => expect(createBridge).toHaveBeenCalledTimes(1), {
+        timeout: 500,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(createBridge).toHaveBeenCalledTimes(1);
+      await expect(handle.runtimeReady).resolves.toBeUndefined();
+    } finally {
+      await handle.close();
+    }
+  });
+
   it('starts deferred runtime on fallback when no health probe arrives', async () => {
     tmpDir = fs.realpathSync(
       fs.mkdtempSync(path.join(os.tmpdir(), 'qws-health-fallback-')),

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -761,6 +761,7 @@ describe('runQwenServe runtime startup failures', () => {
     tmpDir = fs.realpathSync(
       fs.mkdtempSync(path.join(os.tmpdir(), 'qws-health-first-')),
     );
+    const logBaseDir = path.join(tmpDir, 'debug');
     const resolveTelemetrySettings = vi
       .spyOn(qwenCore, 'resolveTelemetrySettings')
       .mockResolvedValue({
@@ -787,9 +788,11 @@ describe('runQwenServe runtime startup failures', () => {
         resolveOnListen: true,
         deferRuntimeUntilFirstHealth: true,
         runtimeStartupTimeoutMs: 0,
+        daemonLogBaseDir: logBaseDir,
       },
     );
 
+    let closed = false;
     try {
       await new Promise((resolve) => setTimeout(resolve, 250));
       expect(resolveTelemetrySettings).not.toHaveBeenCalled();
@@ -803,8 +806,25 @@ describe('runQwenServe runtime startup failures', () => {
       });
       expect(resolveTelemetrySettings).toHaveBeenCalledTimes(1);
       await expect(handle.runtimeReady).resolves.toBeUndefined();
-    } finally {
       await handle.close();
+      closed = true;
+
+      const daemonDir = path.join(logBaseDir, 'daemon');
+      const [logFile] = fs
+        .readdirSync(daemonDir)
+        .filter((fileName) => fileName.endsWith('.log'));
+      expect(logFile).toBeDefined();
+      const logContent = fs.readFileSync(
+        path.join(daemonDir, logFile!),
+        'utf8',
+      );
+      expect(logContent).toContain(
+        'deferred runtime: health timer fired, starting',
+      );
+    } finally {
+      if (!closed) {
+        await handle.close();
+      }
     }
   });
 

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -924,6 +924,7 @@ describe('runQwenServe runtime startup failures', () => {
     tmpDir = fs.realpathSync(
       fs.mkdtempSync(path.join(os.tmpdir(), 'qws-health-close-')),
     );
+    const logBaseDir = path.join(tmpDir, 'debug');
     const bridge = makeRuntimeBridge();
     const createBridge = vi
       .spyOn(acpBridge, 'createAcpSessionBridge')
@@ -944,6 +945,7 @@ describe('runQwenServe runtime startup failures', () => {
         resolveOnListen: true,
         deferRuntimeUntilFirstHealth: true,
         runtimeStartupTimeoutMs: 0,
+        daemonLogBaseDir: logBaseDir,
       },
     );
 
@@ -953,6 +955,15 @@ describe('runQwenServe runtime startup failures', () => {
     expect(createBridge).not.toHaveBeenCalled();
     await expect(handle.runtimeReady).rejects.toThrow(
       RUNTIME_STARTUP_CANCELLED_MESSAGE,
+    );
+    const daemonDir = path.join(logBaseDir, 'daemon');
+    const [logFile] = fs
+      .readdirSync(daemonDir)
+      .filter((fileName) => fileName.endsWith('.log'));
+    expect(logFile).toBeDefined();
+    const logContent = fs.readFileSync(path.join(daemonDir, logFile!), 'utf8');
+    expect(logContent).toContain(
+      'deferred runtime: cancelled, server closed before startup',
     );
   });
 

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -773,9 +773,11 @@ describe('runQwenServe runtime startup failures', () => {
       telemetryPromise,
     );
     const bridge = makeRuntimeBridge();
-    vi.spyOn(acpBridge, 'createAcpSessionBridge').mockReturnValue(
-      bridge as ReturnType<typeof acpBridge.createAcpSessionBridge>,
-    );
+    const createBridge = vi
+      .spyOn(acpBridge, 'createAcpSessionBridge')
+      .mockReturnValue(
+        bridge as ReturnType<typeof acpBridge.createAcpSessionBridge>,
+      );
 
     const handle = await runQwenServe(
       {
@@ -789,15 +791,25 @@ describe('runQwenServe runtime startup failures', () => {
       {
         resolveOnListen: true,
         deferRuntimeUntilFirstHealth: true,
-        runtimeStartupTimeoutMs: 1,
+        runtimeStartupTimeoutMs: 0,
       },
     );
 
     try {
       await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(createBridge).not.toHaveBeenCalled();
       const healthRes = await fetch(`${handle.url}/health`);
       expect(healthRes.status).toBe(200);
       expect(await healthRes.json()).toEqual({ status: 'ok' });
+
+      resolveTelemetry?.({
+        enabled: false,
+        sensitiveSpanAttributeMaxLength: 1024 * 1024,
+      });
+      await vi.waitFor(() => expect(createBridge).toHaveBeenCalledTimes(1), {
+        timeout: 1500,
+      });
+      await expect(handle.runtimeReady).resolves.toBeUndefined();
     } finally {
       resolveTelemetry?.({
         enabled: false,

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -1026,6 +1026,66 @@ describe('runQwenServe runtime startup failures', () => {
     }
   });
 
+  it('serves trailing-slash bootstrap health without waiting for deferred runtime', async () => {
+    tmpDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'qws-bootstrap-trailing-')),
+    );
+    let resolveTelemetry:
+      | ((settings: qwenCore.ResolvedTelemetrySettings) => void)
+      | undefined;
+    const telemetryPromise = new Promise<qwenCore.ResolvedTelemetrySettings>(
+      (resolve) => {
+        resolveTelemetry = resolve;
+      },
+    );
+    vi.spyOn(qwenCore, 'resolveTelemetrySettings').mockReturnValue(
+      telemetryPromise,
+    );
+    const bridge = makeRuntimeBridge();
+    const createBridge = vi
+      .spyOn(acpBridge, 'createAcpSessionBridge')
+      .mockReturnValue(
+        bridge as ReturnType<typeof acpBridge.createAcpSessionBridge>,
+      );
+
+    const handle = await runQwenServe(
+      {
+        port: 0,
+        hostname: '127.0.0.1',
+        mode: 'http-bridge',
+        workspace: tmpDir,
+        maxSessions: 1,
+        serveWebShell: false,
+      },
+      {
+        resolveOnListen: true,
+        deferRuntimeUntilFirstHealth: true,
+        runtimeStartupTimeoutMs: 0,
+      },
+    );
+
+    try {
+      const res = await Promise.race([
+        fetch(`${handle.url}/health/`),
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error('Trailing-slash health timed out')),
+            200,
+          ),
+        ),
+      ]);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ status: 'ok' });
+      expect(createBridge).not.toHaveBeenCalled();
+    } finally {
+      resolveTelemetry?.({
+        enabled: false,
+        sensitiveSpanAttributeMaxLength: 1024 * 1024,
+      });
+      await handle.close();
+    }
+  });
+
   it('reports deferred runtime startup failure for the triggering runtime route', async () => {
     tmpDir = fs.realpathSync(
       fs.mkdtempSync(path.join(os.tmpdir(), 'qws-runtime-route-fail-')),

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -950,7 +950,9 @@ describe('runQwenServe runtime startup failures', () => {
     await new Promise((resolve) => setTimeout(resolve, 1100));
 
     expect(createBridge).not.toHaveBeenCalled();
-    await expect(handle.runtimeReady).resolves.toBeUndefined();
+    await expect(handle.runtimeReady).rejects.toThrow(
+      'Daemon runtime cancelled: server closed before startup.',
+    );
   });
 
   it('does not start deferred runtime after close following first health', async () => {
@@ -992,7 +994,9 @@ describe('runQwenServe runtime startup failures', () => {
     await new Promise((resolve) => setTimeout(resolve, 100));
 
     expect(createBridge).not.toHaveBeenCalled();
-    await expect(handle.runtimeReady).resolves.toBeUndefined();
+    await expect(handle.runtimeReady).rejects.toThrow(
+      'Daemon runtime cancelled: server closed before startup.',
+    );
   });
 
   it('does not cancel deferred runtime once startup is already running', async () => {

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -10,6 +10,7 @@ import * as fs from 'node:fs';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import express from 'express';
 import {
   createLazyBridgeProxy,
   extractContextFilename,
@@ -875,6 +876,56 @@ describe('runQwenServe runtime startup failures', () => {
         timeout: 500,
       });
       await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(createBridge).toHaveBeenCalledTimes(1);
+      await expect(handle.runtimeReady).resolves.toBeUndefined();
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('starts deferred runtime for the first runtime route and serves that request', async () => {
+    tmpDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'qws-runtime-route-start-')),
+    );
+    vi.spyOn(qwenCore, 'resolveTelemetrySettings').mockResolvedValue({
+      enabled: false,
+      sensitiveSpanAttributeMaxLength: 1024 * 1024,
+    });
+    const bridge = makeRuntimeBridge();
+    const createBridge = vi
+      .spyOn(acpBridge, 'createAcpSessionBridge')
+      .mockReturnValue(
+        bridge as ReturnType<typeof acpBridge.createAcpSessionBridge>,
+      );
+    vi.spyOn(serverModule, 'createServeApp').mockImplementation(() => {
+      const app = express();
+      app.post('/session', (_req, res) => {
+        res.status(201).json({ sessionId: 'session-1' });
+      });
+      return app;
+    });
+
+    const handle = await runQwenServe(
+      {
+        port: 0,
+        hostname: '127.0.0.1',
+        mode: 'http-bridge',
+        workspace: tmpDir,
+        maxSessions: 1,
+        serveWebShell: false,
+      },
+      {
+        resolveOnListen: true,
+        deferRuntimeUntilFirstHealth: true,
+        runtimeStartupTimeoutMs: 0,
+      },
+    );
+
+    try {
+      expect(createBridge).not.toHaveBeenCalled();
+      const res = await fetch(`${handle.url}/session`, { method: 'POST' });
+      expect(res.status).toBe(201);
+      expect(await res.json()).toEqual({ sessionId: 'session-1' });
       expect(createBridge).toHaveBeenCalledTimes(1);
       await expect(handle.runtimeReady).resolves.toBeUndefined();
     } finally {

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -94,6 +94,8 @@ const QWEN_SERVE_WRITER_IDLE_TIMEOUT_MS_ENV =
   'QWEN_SERVE_WRITER_IDLE_TIMEOUT_MS';
 const SHUTDOWN_FORCE_CLOSE_MS = 5_000;
 const DEFAULT_RUNTIME_STARTUP_TIMEOUT_MS = 120_000;
+const FAST_PATH_RUNTIME_START_AFTER_HEALTH_MS = 50;
+const FAST_PATH_RUNTIME_START_FALLBACK_MS = 1_000;
 const RUNTIME_STARTUP_TIMEOUT_ENV = 'QWEN_SERVE_RUNTIME_STARTUP_TIMEOUT_MS';
 const MAX_EVENT_RING_SIZE = 1_000_000;
 const DEFAULT_MAX_SESSIONS = 20;
@@ -495,6 +497,12 @@ export interface RunQwenServeDeps {
    */
   resolveOnListen?: boolean;
   /**
+   * Internal serve fast-path mode: keep bootstrap /health responsive before
+   * starting the heavier runtime graph. A fallback timer still starts runtime
+   * when no health probe arrives. Only applies with resolveOnListen.
+   */
+  deferRuntimeUntilFirstHealth?: boolean;
+  /**
    * Bounds background runtime mounting after the listener is ready. Defaults to
    * QWEN_SERVE_RUNTIME_STARTUP_TIMEOUT_MS, then 120s. Use 0 to disable.
    */
@@ -811,6 +819,7 @@ function createBootstrapServeApp(input: {
   sessionShellCommandEnabled: boolean;
   permissionPolicy: PermissionPolicy | undefined;
   getRuntimeError: () => string | undefined;
+  onHealthServed?: () => void;
 }): Application {
   const {
     opts,
@@ -822,6 +831,7 @@ function createBootstrapServeApp(input: {
     sessionShellCommandEnabled,
     permissionPolicy,
     getRuntimeError,
+    onHealthServed,
   } = input;
   const app = express();
 
@@ -843,6 +853,9 @@ function createBootstrapServeApp(input: {
       return;
     }
 
+    if (onHealthServed) {
+      res.once('finish', onHealthServed);
+    }
     res.status(200).json({ status: 'ok' });
   };
   const loopback = isLoopbackBind(opts.hostname);
@@ -1503,6 +1516,9 @@ export async function runQwenServe(
   let markRuntimeReady!: () => void;
   let markRuntimeFailed!: (err: Error) => void;
   let runtimeStartupSettled = false;
+  let startRuntimeAfterHealth: (() => void) | undefined;
+  const deferRuntimeUntilFirstHealth =
+    deps.resolveOnListen === true && deps.deferRuntimeUntilFirstHealth === true;
   const runtimeReady = new Promise<void>((resolve, reject) => {
     markRuntimeReady = resolve;
     markRuntimeFailed = reject;
@@ -1890,6 +1906,9 @@ export async function runQwenServe(
     sessionShellCommandEnabled,
     permissionPolicy,
     getRuntimeError: () => runtimeStartupError,
+    onHealthServed: deferRuntimeUntilFirstHealth
+      ? () => startRuntimeAfterHealth?.()
+      : undefined,
   });
   const app =
     runtimeApp ?? createDelegatingServeApp(bootstrapApp, () => runtimeApp);
@@ -2023,6 +2042,8 @@ export async function runQwenServe(
       let shuttingDown = false;
       let closePromise: Promise<void> | undefined;
       let runtimeStartupTimer: NodeJS.Timeout | undefined;
+      let runtimeStartAfterHealthTimer: NodeJS.Timeout | undefined;
+      let runtimeStartFallbackTimer: NodeJS.Timeout | undefined;
       const runtimeStartupTimeoutMs = resolveRuntimeStartupTimeoutMs(
         deps.runtimeStartupTimeoutMs,
       );
@@ -2030,6 +2051,16 @@ export async function runQwenServe(
         if (!runtimeStartupTimer) return;
         clearTimeout(runtimeStartupTimer);
         runtimeStartupTimer = undefined;
+      };
+      const clearRuntimeStartFallbackTimer = (): void => {
+        if (!runtimeStartFallbackTimer) return;
+        clearTimeout(runtimeStartFallbackTimer);
+        runtimeStartFallbackTimer = undefined;
+      };
+      const clearRuntimeStartAfterHealthTimer = (): void => {
+        if (!runtimeStartAfterHealthTimer) return;
+        clearTimeout(runtimeStartAfterHealthTimer);
+        runtimeStartAfterHealthTimer = undefined;
       };
       const shutdownBridgeAfterFailedStartup = async (
         bridge: AcpSessionBridge | undefined,
@@ -2098,6 +2129,8 @@ export async function runQwenServe(
       };
       const startRuntime = (): void => {
         if (runtimeStarting) return;
+        clearRuntimeStartAfterHealthTimer();
+        clearRuntimeStartFallbackTimer();
         runtimeStarting = buildRuntime()
           .then(async (runtime) => {
             if (runtimeStartupSettled) {
@@ -2136,6 +2169,28 @@ export async function runQwenServe(
           }, runtimeStartupTimeoutMs);
           runtimeStartupTimer.unref();
         }
+      };
+      const scheduleRuntimeStartFallback = (): void => {
+        if (shuttingDown || runtimeStarting || runtimeStartFallbackTimer)
+          return;
+        runtimeStartFallbackTimer = setTimeout(() => {
+          runtimeStartFallbackTimer = undefined;
+          if (shuttingDown) return;
+          startRuntime();
+        }, FAST_PATH_RUNTIME_START_FALLBACK_MS);
+        runtimeStartFallbackTimer.unref();
+      };
+      startRuntimeAfterHealth = (): void => {
+        if (shuttingDown || runtimeStarting || runtimeStartAfterHealthTimer) {
+          return;
+        }
+        clearRuntimeStartFallbackTimer();
+        runtimeStartAfterHealthTimer = setTimeout(() => {
+          runtimeStartAfterHealthTimer = undefined;
+          if (shuttingDown) return;
+          startRuntime();
+        }, FAST_PATH_RUNTIME_START_AFTER_HEALTH_MS);
+        runtimeStartAfterHealthTimer.unref();
       };
 
       // Forward declaration so handle.close can detach the listener after
@@ -2194,6 +2249,8 @@ export async function runQwenServe(
           if (closePromise) return closePromise;
           closePromise = new Promise<void>((res, rej) => {
             shuttingDown = true;
+            clearRuntimeStartAfterHealthTimer();
+            clearRuntimeStartFallbackTimer();
             // NOTE: the SIGINT/SIGTERM handlers stay attached during the
             // drain. Their `if (shuttingDown) return` guard makes a second
             // signal a no-op. Detaching them up front would leave Node's
@@ -2402,6 +2459,8 @@ export async function runQwenServe(
         if (shouldPreheat) {
           startBridgePreheat(bridgeRef);
         }
+      } else if (deferRuntimeUntilFirstHealth) {
+        scheduleRuntimeStartFallback();
       } else {
         startRuntime();
       }

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -2064,6 +2064,20 @@ export async function runQwenServe(
         clearTimeout(runtimeStartAfterHealthTimer);
         runtimeStartAfterHealthTimer = undefined;
       };
+      const stopDeferredRuntimeStartupBeforeStart = (): void => {
+        if (
+          !deferRuntimeUntilFirstHealth ||
+          runtimeStarting ||
+          runtimeStartupSettled
+        )
+          return;
+        runtimeStartupSettled = true;
+        const error = new Error(
+          'Server closed before deferred runtime startup began.',
+        );
+        runtimeStartupError = error.message;
+        markRuntimeFailed(error);
+      };
       const shutdownBridgeAfterFailedStartup = async (
         bridge: AcpSessionBridge | undefined,
       ): Promise<void> => {
@@ -2260,6 +2274,7 @@ export async function runQwenServe(
             shuttingDown = true;
             clearRuntimeStartAfterHealthTimer();
             clearRuntimeStartFallbackTimer();
+            stopDeferredRuntimeStartupBeforeStart();
             // NOTE: the SIGINT/SIGTERM handlers stay attached during the
             // drain. Their `if (shuttingDown) return` guard makes a second
             // signal a no-op. Detaching them up front would leave Node's

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -1049,6 +1049,7 @@ function createDelegatingServeApp(
         !target &&
         options.waitForDeferredRuntimeRoutes === true &&
         !isBootstrapServeRoute(req) &&
+        !isCorsPreflightRequest(req) &&
         options.startRuntime &&
         options.runtimeReady
       ) {
@@ -1089,6 +1090,17 @@ function isBootstrapServeRoute(req: Request): boolean {
       ? req.path.slice(0, -1)
       : req.path;
   return BOOTSTRAP_SERVE_PATHS.has(path);
+}
+
+function isCorsPreflightRequest(req: Request): boolean {
+  return (
+    req.method === 'OPTIONS' &&
+    Boolean(req.headers.origin) &&
+    Boolean(
+      req.headers['access-control-request-method'] ||
+        req.headers['access-control-request-headers'],
+    )
+  );
 }
 
 function runSynchronousRequestGate(

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -94,7 +94,9 @@ const QWEN_SERVE_WRITER_IDLE_TIMEOUT_MS_ENV =
   'QWEN_SERVE_WRITER_IDLE_TIMEOUT_MS';
 const SHUTDOWN_FORCE_CLOSE_MS = 5_000;
 const DEFAULT_RUNTIME_STARTUP_TIMEOUT_MS = 120_000;
+// Let the first /health response flush before evaluating the runtime graph.
 const FAST_PATH_RUNTIME_START_AFTER_HEALTH_MS = 50;
+// Keep manual/non-probed starts moving; health probes cancel this fallback.
 const FAST_PATH_RUNTIME_START_FALLBACK_MS = 1_000;
 const RUNTIME_STARTUP_TIMEOUT_ENV = 'QWEN_SERVE_RUNTIME_STARTUP_TIMEOUT_MS';
 const MAX_EVENT_RING_SIZE = 1_000_000;
@@ -2173,9 +2175,13 @@ export async function runQwenServe(
       const scheduleRuntimeStartFallback = (): void => {
         if (shuttingDown || runtimeStarting || runtimeStartFallbackTimer)
           return;
+        daemonLog.info(
+          `deferred runtime: scheduling fallback start in ${FAST_PATH_RUNTIME_START_FALLBACK_MS}ms`,
+        );
         runtimeStartFallbackTimer = setTimeout(() => {
           runtimeStartFallbackTimer = undefined;
           if (shuttingDown) return;
+          daemonLog.info('deferred runtime: fallback timer fired, starting');
           startRuntime();
         }, FAST_PATH_RUNTIME_START_FALLBACK_MS);
         runtimeStartFallbackTimer.unref();
@@ -2185,6 +2191,9 @@ export async function runQwenServe(
           return;
         }
         clearRuntimeStartFallbackTimer();
+        daemonLog.info(
+          `deferred runtime: health served, scheduling start in ${FAST_PATH_RUNTIME_START_AFTER_HEALTH_MS}ms`,
+        );
         runtimeStartAfterHealthTimer = setTimeout(() => {
           runtimeStartAfterHealthTimer = undefined;
           if (shuttingDown) return;

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -12,6 +12,7 @@ import express, {
   type Application,
   type NextFunction,
   type Request,
+  type RequestHandler,
   type Response,
 } from 'express';
 import { writeStderrLine, writeStdoutLine } from '../utils/stdioHelpers.js';
@@ -812,6 +813,15 @@ export async function waitForRuntimeStartingForShutdown(
   });
 }
 
+const BOOTSTRAP_HEALTH_PATH = '/health';
+const BOOTSTRAP_CAPABILITIES_PATH = '/capabilities';
+const BOOTSTRAP_DAEMON_STATUS_PATH = '/daemon/status';
+const BOOTSTRAP_SERVE_PATHS = new Set([
+  BOOTSTRAP_HEALTH_PATH,
+  BOOTSTRAP_CAPABILITIES_PATH,
+  BOOTSTRAP_DAEMON_STATUS_PATH,
+]);
+
 function createBootstrapServeApp(input: {
   opts: ServeOptions;
   getPort: () => number;
@@ -864,16 +874,16 @@ function createBootstrapServeApp(input: {
   const loopback = isLoopbackBind(opts.hostname);
   const exposeHealthPreAuth = loopback && !opts.requireAuth;
   if (exposeHealthPreAuth) {
-    app.get('/health', healthHandler);
+    app.get(BOOTSTRAP_HEALTH_PATH, healthHandler);
   }
 
   app.use(bearerAuth(opts.token));
 
   if (!exposeHealthPreAuth) {
-    app.get('/health', healthHandler);
+    app.get(BOOTSTRAP_HEALTH_PATH, healthHandler);
   }
 
-  app.get('/capabilities', (_req: Request, res: Response): void => {
+  app.get(BOOTSTRAP_CAPABILITIES_PATH, (_req: Request, res: Response): void => {
     res.status(200).json(
       createBootstrapCapabilities({
         opts,
@@ -885,7 +895,7 @@ function createBootstrapServeApp(input: {
     );
   });
 
-  app.get('/daemon/status', (req: Request, res: Response): void => {
+  app.get(BOOTSTRAP_DAEMON_STATUS_PATH, (req: Request, res: Response): void => {
     const detail = parseDaemonStatusDetail(req.query['detail']);
     if (!detail.ok || !detail.detail) {
       res.status(400).json({
@@ -1028,6 +1038,7 @@ function createDelegatingServeApp(
     waitForDeferredRuntimeRoutes?: boolean;
     startRuntime?: () => void;
     runtimeReady?: Promise<void>;
+    authenticateDeferredRuntimeRequest?: RequestHandler;
   } = {},
 ): Application {
   const app = express();
@@ -1041,6 +1052,17 @@ function createDelegatingServeApp(
         options.startRuntime &&
         options.runtimeReady
       ) {
+        if (
+          options.authenticateDeferredRuntimeRequest &&
+          !runSynchronousRequestGate(
+            options.authenticateDeferredRuntimeRequest,
+            req,
+            res,
+            next,
+          )
+        ) {
+          return;
+        }
         options.startRuntime();
         try {
           await options.runtimeReady;
@@ -1062,14 +1084,24 @@ function createDelegatingServeApp(
 }
 
 function isBootstrapServeRoute(req: Request): boolean {
-  if (req.method !== 'GET' && req.method !== 'HEAD') {
-    return false;
-  }
-  return (
-    req.path === '/health' ||
-    req.path === '/capabilities' ||
-    req.path === '/daemon/status'
-  );
+  return BOOTSTRAP_SERVE_PATHS.has(req.path);
+}
+
+function runSynchronousRequestGate(
+  handler: RequestHandler,
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): boolean {
+  let passed = false;
+  handler(req, res, (err?: unknown) => {
+    if (err) {
+      next(err);
+      return;
+    }
+    passed = true;
+  });
+  return passed;
 }
 
 /**
@@ -1954,6 +1986,7 @@ export async function runQwenServe(
       waitForDeferredRuntimeRoutes: deferRuntimeUntilFirstHealth,
       startRuntime: () => startRuntimeForRequest?.(),
       runtimeReady,
+      authenticateDeferredRuntimeRequest: bearerAuth(opts.token),
     });
 
   // Node's `app.listen()` wants the unbracketed IPv6 literal (`::1`) but

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -2072,7 +2072,11 @@ export async function runQwenServe(
         )
           return;
         runtimeStartupSettled = true;
-        markRuntimeReady();
+        const error = new Error(
+          'Daemon runtime cancelled: server closed before startup.',
+        );
+        runtimeStartupError = error.message;
+        markRuntimeFailed(error);
       };
       const shutdownBridgeAfterFailedStartup = async (
         bridge: AcpSessionBridge | undefined,

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -2207,6 +2207,7 @@ export async function runQwenServe(
         runtimeStartAfterHealthTimer = setTimeout(() => {
           runtimeStartAfterHealthTimer = undefined;
           if (shuttingDown) return;
+          daemonLog.info('deferred runtime: health timer fired, starting');
           startRuntime();
         }, FAST_PATH_RUNTIME_START_AFTER_HEALTH_MS);
         runtimeStartAfterHealthTimer.unref();

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -2072,6 +2072,9 @@ export async function runQwenServe(
           runtimeStartupSettled
         )
           return;
+        daemonLog.info(
+          'deferred runtime: cancelled, server closed before startup',
+        );
         runtimeStartupSettled = true;
         const error = new Error(RUNTIME_STARTUP_CANCELLED_MESSAGE);
         runtimeStartupError = error.message;

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -32,6 +32,7 @@ import type {
 } from '@qwen-code/qwen-code-core';
 import { createBridgeFileSystemAdapter } from './bridge-file-system-adapter.js';
 import { isLoopbackBind } from './loopback-binds.js';
+import { RUNTIME_STARTUP_CANCELLED_MESSAGE } from './runtime-startup-errors.js';
 import { resolveWebShellDir } from './web-shell-resolver.js';
 import {
   allowOriginCors,
@@ -2072,9 +2073,7 @@ export async function runQwenServe(
         )
           return;
         runtimeStartupSettled = true;
-        const error = new Error(
-          'Daemon runtime cancelled: server closed before startup.',
-        );
+        const error = new Error(RUNTIME_STARTUP_CANCELLED_MESSAGE);
         runtimeStartupError = error.message;
         markRuntimeFailed(error);
       };

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -1024,18 +1024,52 @@ function createBootstrapServeApp(input: {
 function createDelegatingServeApp(
   bootstrapApp: Application,
   getRuntimeApp: () => Application | undefined,
+  options: {
+    waitForDeferredRuntimeRoutes?: boolean;
+    startRuntime?: () => void;
+    runtimeReady?: Promise<void>;
+  } = {},
 ): Application {
   const app = express();
   app.use((req: Request, res: Response, next: NextFunction) => {
-    const target = getRuntimeApp() ?? bootstrapApp;
-    const handler = target as unknown as (
-      req: Request,
-      res: Response,
-      next: NextFunction,
-    ) => void;
-    handler(req, res, next);
+    const dispatch = async (): Promise<void> => {
+      let target = getRuntimeApp();
+      if (
+        !target &&
+        options.waitForDeferredRuntimeRoutes === true &&
+        !isBootstrapServeRoute(req) &&
+        options.startRuntime &&
+        options.runtimeReady
+      ) {
+        options.startRuntime();
+        try {
+          await options.runtimeReady;
+        } catch {
+          // Fall through to the bootstrap app so it can report the startup error.
+        }
+        target = getRuntimeApp();
+      }
+      const handler = (target ?? bootstrapApp) as unknown as (
+        req: Request,
+        res: Response,
+        next: NextFunction,
+      ) => void;
+      handler(req, res, next);
+    };
+    void dispatch().catch(next);
   });
   return app;
+}
+
+function isBootstrapServeRoute(req: Request): boolean {
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    return false;
+  }
+  return (
+    req.path === '/health' ||
+    req.path === '/capabilities' ||
+    req.path === '/daemon/status'
+  );
 }
 
 /**
@@ -1520,6 +1554,7 @@ export async function runQwenServe(
   let markRuntimeFailed!: (err: Error) => void;
   let runtimeStartupSettled = false;
   let startRuntimeAfterHealth: (() => void) | undefined;
+  let startRuntimeForRequest: (() => void) | undefined;
   const deferRuntimeUntilFirstHealth =
     deps.resolveOnListen === true && deps.deferRuntimeUntilFirstHealth === true;
   const runtimeReady = new Promise<void>((resolve, reject) => {
@@ -1914,7 +1949,12 @@ export async function runQwenServe(
       : undefined,
   });
   const app =
-    runtimeApp ?? createDelegatingServeApp(bootstrapApp, () => runtimeApp);
+    runtimeApp ??
+    createDelegatingServeApp(bootstrapApp, () => runtimeApp, {
+      waitForDeferredRuntimeRoutes: deferRuntimeUntilFirstHealth,
+      startRuntime: () => startRuntimeForRequest?.(),
+      runtimeReady,
+    });
 
   // Node's `app.listen()` wants the unbracketed IPv6 literal (`::1`) but
   // operators conventionally type `[::1]` (or copy/paste from URLs that
@@ -2188,6 +2228,7 @@ export async function runQwenServe(
           runtimeStartupTimer.unref();
         }
       };
+      startRuntimeForRequest = startRuntime;
       const scheduleRuntimeStartFallback = (): void => {
         if (shuttingDown || runtimeStarting || runtimeStartFallbackTimer)
           return;

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -2064,7 +2064,7 @@ export async function runQwenServe(
         clearTimeout(runtimeStartAfterHealthTimer);
         runtimeStartAfterHealthTimer = undefined;
       };
-      const stopDeferredRuntimeStartupBeforeStart = (): void => {
+      const cancelDeferredRuntimeStartup = (): void => {
         if (
           !deferRuntimeUntilFirstHealth ||
           runtimeStarting ||
@@ -2072,11 +2072,7 @@ export async function runQwenServe(
         )
           return;
         runtimeStartupSettled = true;
-        const error = new Error(
-          'Server closed before deferred runtime startup began.',
-        );
-        runtimeStartupError = error.message;
-        markRuntimeFailed(error);
+        markRuntimeReady();
       };
       const shutdownBridgeAfterFailedStartup = async (
         bridge: AcpSessionBridge | undefined,
@@ -2274,7 +2270,7 @@ export async function runQwenServe(
             shuttingDown = true;
             clearRuntimeStartAfterHealthTimer();
             clearRuntimeStartFallbackTimer();
-            stopDeferredRuntimeStartupBeforeStart();
+            cancelDeferredRuntimeStartup();
             // NOTE: the SIGINT/SIGTERM handlers stay attached during the
             // drain. Their `if (shuttingDown) return` guard makes a second
             // signal a no-op. Detaching them up front would leave Node's

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -1084,7 +1084,11 @@ function createDelegatingServeApp(
 }
 
 function isBootstrapServeRoute(req: Request): boolean {
-  return BOOTSTRAP_SERVE_PATHS.has(req.path);
+  const path =
+    req.path.length > 1 && req.path.endsWith('/')
+      ? req.path.slice(0, -1)
+      : req.path;
+  return BOOTSTRAP_SERVE_PATHS.has(path);
 }
 
 function runSynchronousRequestGate(

--- a/packages/cli/src/serve/runtime-startup-errors.ts
+++ b/packages/cli/src/serve/runtime-startup-errors.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const RUNTIME_STARTUP_CANCELLED_MESSAGE =
+  'Daemon runtime cancelled: server closed before startup.';

--- a/packages/cli/src/utils/headlessSafetyWarnings.test.ts
+++ b/packages/cli/src/utils/headlessSafetyWarnings.test.ts
@@ -5,21 +5,16 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { ApprovalMode, type Config } from '@qwen-code/qwen-code-core';
+import { ApprovalMode } from '@qwen-code/qwen-code-core';
 import {
   HEADLESS_YOLO_NO_SANDBOX_WARNING,
   getHeadlessYoloSafetyWarning,
 } from './headlessSafetyWarnings.js';
 
-function makeConfig(
-  approvalMode: ApprovalMode,
-  sandbox: unknown,
-): Pick<Config, 'getApprovalMode' | 'getSandbox'> {
+function makeConfig(approvalMode: ApprovalMode, sandbox: unknown) {
   return {
     getApprovalMode: () => approvalMode,
-    // Real return type is `SandboxConfig | undefined`; the warning policy
-    // only cares about truthiness so the tests model it as such.
-    getSandbox: () => sandbox as ReturnType<Config['getSandbox']>,
+    getSandbox: () => sandbox,
   };
 }
 

--- a/packages/cli/src/utils/headlessSafetyWarnings.ts
+++ b/packages/cli/src/utils/headlessSafetyWarnings.ts
@@ -29,6 +29,7 @@ export function getHeadlessYoloSafetyWarning(
   config: Pick<Config, 'getApprovalMode' | 'getSandbox'>,
   env: NodeJS.ProcessEnv = process.env,
 ): string | null {
+  // Keep this literal in sync with ApprovalMode.YOLO without importing core at runtime.
   if (config.getApprovalMode() !== 'yolo') return null;
   if (config.getSandbox()) return null;
   // `SANDBOX` is set by the sandbox transport itself: macOS seatbelt sets

--- a/packages/cli/src/utils/headlessSafetyWarnings.ts
+++ b/packages/cli/src/utils/headlessSafetyWarnings.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Config } from '@qwen-code/qwen-code-core';
-
 export const HEADLESS_YOLO_NO_SANDBOX_WARNING =
   'Warning: running headless with --yolo / approval-mode=yolo and no sandbox. ' +
   "All tool calls (shell, write, edit) auto-execute at this process's privilege level. " +
@@ -26,7 +24,10 @@ export const HEADLESS_YOLO_NO_SANDBOX_WARNING =
  * fall through to `process.env`.
  */
 export function getHeadlessYoloSafetyWarning(
-  config: Pick<Config, 'getApprovalMode' | 'getSandbox'>,
+  config: {
+    getApprovalMode(): string | undefined;
+    getSandbox(): unknown;
+  },
   env: NodeJS.ProcessEnv = process.env,
 ): string | null {
   // Keep this literal in sync with ApprovalMode.YOLO without importing core at runtime.

--- a/packages/cli/src/utils/headlessSafetyWarnings.ts
+++ b/packages/cli/src/utils/headlessSafetyWarnings.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ApprovalMode, type Config } from '@qwen-code/qwen-code-core';
+import type { Config } from '@qwen-code/qwen-code-core';
 
 export const HEADLESS_YOLO_NO_SANDBOX_WARNING =
   'Warning: running headless with --yolo / approval-mode=yolo and no sandbox. ' +
@@ -29,7 +29,7 @@ export function getHeadlessYoloSafetyWarning(
   config: Pick<Config, 'getApprovalMode' | 'getSandbox'>,
   env: NodeJS.ProcessEnv = process.env,
 ): string | null {
-  if (config.getApprovalMode() !== ApprovalMode.YOLO) return null;
+  if (config.getApprovalMode() !== 'yolo') return null;
   if (config.getSandbox()) return null;
   // `SANDBOX` is set by the sandbox transport itself: macOS seatbelt sets
   // it to `sandbox-exec`, Docker/Podman to the container name (e.g.


### PR DESCRIPTION
## What this PR does

This PR keeps the serve fast path responsive for the first `/health` probe by deferring the heavier runtime graph until after a successful bootstrap health response has been flushed. It also gives the deferred path a fallback timer so the runtime still starts when no health probe arrives, and keeps the headless YOLO startup warning on the fast path without dynamically importing the core runtime before health can respond.

## Why it's needed

PR #5995 removes accidental pre-listen runtime closure from the serve bundle, but end-to-end `/health` can still be delayed by work that runs immediately after the listener is ready. The runtime import/evaluation path and the headless warning's core import can monopolize the event loop before the first health response is observed, so clients can still wait around the old startup duration even though `processToListenMs` is low.

## Reviewer Test Plan

### How to verify

Start from a build that includes PR #5995 and run `qwen serve --hostname 127.0.0.1 --port <free-port> --workspace /tmp --no-web`, then poll `GET /health` immediately after process start. The first successful response should come from the bootstrap app with `{"status":"ok"}` before runtime routes are mounted, while the runtime should still mount shortly afterward via the health-triggered start or the fallback timer. Reviewers can also confirm that no health probe still starts runtime after the fallback delay, and that closing a handle before the first health response does not start runtime during shutdown.

### Evidence (Before & After)

Before: on the remote Linux verification host, PR #5995 lowered `processToListenMs` to roughly 200-300ms but `/health` still took roughly 1.6s median because post-listen runtime work and the headless warning import could block the event loop before the first health response. After: with this follow-up applied and bundled, the remote benchmark returned first `/health` responses in 220, 244, 266, 282, and 287ms for `node dist/cli.js`; the final local bundled benchmark returned 234, 122, 128, 135, and 126ms with a 128ms median.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

macOS local PR worktree with Node v26.0.0 and npm 11.12.1. Validation included `npm install` (which ran the repository prepare/build/bundle flow), `npm run check:serve-fast-path-bundle`, `npm run typecheck`, `cd packages/cli && npx vitest run src/serve/run-qwen-serve.test.ts -t "runQwenServe runtime startup failures"`, `cd packages/cli && npx vitest run src/serve/fast-path.test.ts src/utils/headlessSafetyWarnings.test.ts`, and a bundled `dist/cli.js` `/health` first-response benchmark. Linux validation was performed on the remote startup-performance host during the investigation using the same bundled benchmark shape on top of PR #5995.

## Risk & Scope

- Main risk or tradeoff: the serve fast path now has a small bootstrap window where `/health` is intentionally available before the full runtime graph is mounted, so clients that immediately call non-health runtime routes can still observe the existing bootstrap "runtime starting" response until runtime mounting completes.
- Not validated / out of scope: this PR does not optimize all runtime module evaluation after health succeeds, does not change non-fast-path embedded startup semantics, and does not retarget away from PR #5995 until that PR merges.
- Breaking changes / migration notes: no user-facing CLI flags or API response schemas change.

## Linked Issues

Follow-up to #5995.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让 serve fast path 在首次 `/health` 探活时保持可响应：成功的 bootstrap health 响应 flush 之后，才启动较重的 runtime graph。它同时保留 fallback timer，确保没有 health 探活时 runtime 仍会启动，并让 headless YOLO 启动警告留在 fast path 上，但不再为了这个警告在 health 可响应前动态导入 core runtime。

## Why it's needed

PR #5995 移除了 serve bundle 中意外的 pre-listen runtime 闭包，但端到端 `/health` 仍可能被 listener ready 之后立即执行的工作拖慢。runtime import/evaluation 路径以及 headless warning 的 core import 都可能在首次 health 响应被客户端观察到前占住事件循环，所以即使 `processToListenMs` 已经很低，客户端仍可能等待接近旧启动耗时。

## Reviewer Test Plan

### How to verify

基于包含 PR #5995 的构建启动 `qwen serve --hostname 127.0.0.1 --port <free-port> --workspace /tmp --no-web`，然后在进程启动后立即轮询 `GET /health`。首次成功响应应来自 bootstrap app，返回 `{"status":"ok"}`，且发生在 runtime routes mount 之前；之后 runtime 应通过 health 触发启动或 fallback timer 正常 mount。Reviewer 也可以确认没有 health 探活时 runtime 会在 fallback 延迟后启动，并确认 handle 在首次 health 前关闭时不会在 shutdown 期间再启动 runtime。

### Evidence (Before & After)

Before：在远程 Linux 验证机器上，PR #5995 将 `processToListenMs` 降到约 200-300ms，但 `/health` median 仍约 1.6s，因为 listen 后的 runtime work 和 headless warning import 仍可能在首次 health 响应前阻塞事件循环。After：叠加这个 follow-up 并打包后，远程 benchmark 中 `node dist/cli.js` 的首次 `/health` 响应为 220、244、266、282、287ms；最终本地 bundled benchmark 的结果为 234、122、128、135、126ms，中位数 128ms。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

macOS 本地 PR worktree，Node v26.0.0，npm 11.12.1。验证包括 `npm install`（触发仓库 prepare/build/bundle 流程）、`npm run check:serve-fast-path-bundle`、`npm run typecheck`、`cd packages/cli && npx vitest run src/serve/run-qwen-serve.test.ts -t "runQwenServe runtime startup failures"`、`cd packages/cli && npx vitest run src/serve/fast-path.test.ts src/utils/headlessSafetyWarnings.test.ts`，以及 bundled `dist/cli.js` 的 `/health` 首响 benchmark。Linux 验证是在远程启动性能机器上，调查过程中基于 PR #5995 用同样的 bundled benchmark 形态完成的。

## Risk & Scope

- Main risk or tradeoff: serve fast path 现在会有一个很短的 bootstrap 窗口，`/health` 会在完整 runtime graph mount 前可用；如果客户端立刻调用非 health runtime 路由，仍会看到现有 bootstrap 的 "runtime starting" 响应，直到 runtime mount 完成。
- Not validated / out of scope: 这个 PR 不继续优化 health 成功后的所有 runtime module evaluation，不改变非 fast-path embedded startup 语义，也不会在 #5995 合并前脱离该 PR 重新 retarget。
- Breaking changes / migration notes: 不改变用户可见 CLI flags 或 API 响应 schema。

## Linked Issues

#5995 的 follow-up。

</details>
