### PR TITLE
fix(cli): make the non-VP transcript scrollable during multi-agent runs

### DIFF
--- a/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
@@ -29,6 +29,8 @@ vi.mock('../hooks/useMouseEvents.js', () => ({
   useMouseEvents: vi.fn(),
 }));
 
+import { useMouseEvents } from '../hooks/useMouseEvents.js';
+
 import { toggleKeyHint } from './messages/ConversationMessages.js';
 
 describe('<HistoryItemDisplay />', () => {
@@ -537,6 +539,42 @@ describe('<HistoryItemDisplay />', () => {
         { settings: makeTimestampSettings() },
       );
       expect(lastFrame()).not.toMatch(/\[\d{2}:\d{2}:\d{2}\]/);
+    });
+  });
+
+  describe('thinking-block mouse tracking is VP-gated (non-VP scroll fix)', () => {
+    // A collapsed thinking block arms a click-to-expand mouse handler. The
+    // VP-gating itself lives in useMouseEvents (covered by its own test); here
+    // we pin the contract that the thinking block subscribes WITHOUT
+    // `bypassVpGate`, i.e. it is subject to the gate — so in non-VP it never
+    // turns on SGR mouse tracking and native terminal scrollback survives.
+    // (Alt+T still expands the block in non-VP.)
+    const thoughtItem: HistoryItem = {
+      id: 1,
+      type: 'gemini_thought',
+      text: 'Inspecting the repository',
+      durationMs: 1200,
+    };
+
+    it('subscribes the click handler without bypassVpGate (stays VP-gated)', () => {
+      vi.mocked(useMouseEvents).mockClear();
+      renderWithProviders(
+        <CompactModeProvider
+          value={{ compactMode: false, compactInline: false }}
+        >
+          <HistoryItemDisplay
+            item={thoughtItem}
+            terminalWidth={100}
+            isPending={false}
+          />
+        </CompactModeProvider>,
+      );
+      expect(vi.mocked(useMouseEvents)).toHaveBeenCalled();
+      const opts = vi.mocked(useMouseEvents).mock.calls.at(-1)?.[1];
+      // Collapsed thought → the handler is "active", but it must NOT bypass the
+      // VP gate, so useMouseEvents only arms it in VP mode.
+      expect(opts?.isActive).toBe(true);
+      expect(opts?.bypassVpGate ?? false).toBe(false);
     });
   });
 });

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -108,6 +108,10 @@ const ClickableThinkMessage: React.FC<{
 }) => {
   const ref = useRef<DOMElement>(null);
   const { openThinkingViewer } = useThinkingViewer();
+  // Click-to-expand needs SGR mouse tracking. We do NOT pass `bypassVpGate`, so
+  // useMouseEvents enables it only in VP mode; in non-VP the click handler
+  // stays dormant and native terminal scrollback is preserved (the block still
+  // expands via Alt+T — the "option+t to expand" affordance it already shows).
   const isActive = !isPending && !expanded;
   const sanitizedViewerText = useMemo(
     () => escapeAnsiCtrlCodes(viewerText),

--- a/packages/cli/src/ui/components/ThinkingViewer.test.tsx
+++ b/packages/cli/src/ui/components/ThinkingViewer.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from 'ink-testing-library';
+import { ThinkingViewer } from './ThinkingViewer.js';
+import { useMouseEvents } from './../hooks/useMouseEvents.js';
+
+// The modal viewer owns the wheel for its own scrolling and renders on the
+// alternate screen in non-VP mode (no native scrollback to protect), so it must
+// subscribe WITH `bypassVpGate: true`. Mirror of the HistoryItemDisplay test
+// that pins the OPPOSITE contract for the click-to-expand handler. The gating
+// logic itself lives in useMouseEvents (covered by its own test); here we only
+// pin the option ThinkingViewer passes.
+vi.mock('./../hooks/useMouseEvents.js', () => ({
+  useMouseEvents: vi.fn(),
+}));
+
+// Avoid the real terminal-size / keypress / frame-flush wiring — they are not
+// part of the contract under test and would otherwise require a TTY + context.
+vi.mock('./../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => ({ rows: 24, columns: 80 }),
+}));
+vi.mock('./../hooks/useKeypress.js', () => ({
+  useKeypress: vi.fn(),
+}));
+vi.mock('./../hooks/use-frame-coalesced-flush.js', () => ({
+  useFrameCoalescedFlush: () => ({ schedule: vi.fn(), cancel: vi.fn() }),
+}));
+
+describe('ThinkingViewer mouse tracking', () => {
+  beforeEach(() => {
+    vi.mocked(useMouseEvents).mockClear();
+  });
+
+  it('subscribes the wheel handler WITH bypassVpGate (works in non-VP)', () => {
+    render(
+      <ThinkingViewer
+        data={{ text: 'Inspecting the repository', durationMs: 1200 }}
+        onClose={() => {}}
+        useAlternateScreen={false}
+      />,
+    );
+    expect(vi.mocked(useMouseEvents)).toHaveBeenCalled();
+    const opts = vi.mocked(useMouseEvents).mock.calls.at(-1)?.[1];
+    expect(opts?.isActive).toBe(true);
+    // Must bypass the VP gate, or wheel scrolling in the modal silently breaks
+    // in non-VP mode.
+    expect(opts?.bypassVpGate).toBe(true);
+  });
+});

--- a/packages/cli/src/ui/components/ThinkingViewer.tsx
+++ b/packages/cli/src/ui/components/ThinkingViewer.tsx
@@ -118,7 +118,10 @@ export const ThinkingViewer: FC<ThinkingViewerProps> = ({
       },
       [scheduleWheelFlush],
     ),
-    { isActive: true },
+    // Modal viewer renders on the alternate screen in non-VP mode (no native
+    // scrollback to protect), and owns the wheel for its own scrolling — opt
+    // out of the VP gate so it works in both VP and non-VP.
+    { isActive: true, bypassVpGate: true },
   );
 
   const title =

--- a/packages/cli/src/ui/components/messages/InlineParallelAgentsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/messages/InlineParallelAgentsDisplay.test.tsx
@@ -260,4 +260,55 @@ describe('<InlineParallelAgentsDisplay />', () => {
     // Tally counts only the agent.
     expect(frame).toContain('0/1 done');
   });
+
+  describe('height backstop (availableTerminalHeight)', () => {
+    const manyAgents = (n: number): IndividualToolCallDisplay[] =>
+      Array.from({ length: n }, (_, i) =>
+        agentToolCall({
+          callId: `cap-${i}`,
+          subagentName: 'general-purpose',
+          taskDescription: `CapAgent ${i}`,
+          status: 'completed',
+        }),
+      );
+
+    const renderCapped = (
+      toolCalls: IndividualToolCallDisplay[],
+      availableTerminalHeight?: number,
+    ) =>
+      render(
+        <ConfigContext.Provider value={undefined}>
+          <InlineParallelAgentsDisplay
+            toolCalls={toolCalls}
+            contentWidth={120}
+            availableTerminalHeight={availableTerminalHeight}
+          />
+        </ConfigContext.Provider>,
+      );
+
+    it('without a budget, renders every agent (no cap)', () => {
+      const { lastFrame } = renderCapped(manyAgents(10));
+      const frame = lastFrame() ?? '';
+      // header + 10 rows, no overflow indicator.
+      expect(frame.split('\n').length).toBe(11);
+      expect(frame).not.toContain('more agent');
+    });
+
+    it('with a budget, windows to the most recent rows + "+N more" and never exceeds the budget', () => {
+      const budget = 6;
+      const { lastFrame } = renderCapped(manyAgents(10), budget);
+      const frame = lastFrame() ?? '';
+      // The whole non-Static frame must fit the budget, else ink clears the
+      // terminal every repaint (the scroll snap-back this guards against).
+      expect(frame.split('\n').length).toBeLessThanOrEqual(budget);
+      // rowBudget = budget - 2 = 4 visible rows → 6 hidden.
+      expect(frame).toContain('+6 more agents');
+      // Windows from the END (most recent), so the last agent shows and the
+      // first does not.
+      expect(frame).toContain('CapAgent 9');
+      expect(frame).not.toContain('CapAgent 0');
+      // Header tally still reflects the full count.
+      expect(frame).toContain('10/10 done');
+    });
+  });
 });

--- a/packages/cli/src/ui/components/messages/InlineParallelAgentsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/messages/InlineParallelAgentsDisplay.test.tsx
@@ -322,6 +322,21 @@ describe('<InlineParallelAgentsDisplay />', () => {
       expect(frame).toContain('10/10 done');
     });
 
+    it('at a budget of 3, shows exactly one (most-recent) row + indicator', () => {
+      // The transition point: budget 2 shows zero data rows, budget 3 shows the
+      // first one (rowsFit = budget - 2 = 1). Pins the off-by-one in
+      // `rowsFit = availableTerminalHeight - 2` and in `rows.slice(...)`.
+      const budget = 3;
+      const { lastFrame } = renderCapped(manyAgents(10), budget);
+      const frame = lastFrame() ?? '';
+      expect(frame.split('\n').length).toBe(budget);
+      expect(frame).toContain('+9 more agents');
+      // The single visible row is the most recent agent, not an older one.
+      expect(frame).toContain('CapAgent 9');
+      expect(frame).not.toContain('CapAgent 0');
+      expect(frame).toContain('10/10 done');
+    });
+
     it('at a budget of 2, keeps the header + indicator only (drops every row)', () => {
       const budget = 2;
       const { lastFrame } = renderCapped(manyAgents(10), budget);

--- a/packages/cli/src/ui/components/messages/InlineParallelAgentsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/messages/InlineParallelAgentsDisplay.test.tsx
@@ -294,6 +294,17 @@ describe('<InlineParallelAgentsDisplay />', () => {
       expect(frame).not.toContain('more agent');
     });
 
+    it('with a generous budget, renders every agent (backstop is a no-op)', () => {
+      // 10 agents + header = 11 rows < budget 20, so the `rows.length + 1 >
+      // budget` guard is false and windowing must NOT kick in. Pins the `>`
+      // boundary: a regression to `>=` (or an off-by-one) would truncate here
+      // even though there is room.
+      const { lastFrame } = renderCapped(manyAgents(10), 20);
+      const frame = lastFrame() ?? '';
+      expect(frame.split('\n').length).toBe(11);
+      expect(frame).not.toContain('more agent');
+    });
+
     it('with a budget, windows to the most recent rows + "+N more" and never exceeds the budget', () => {
       const budget = 6;
       const { lastFrame } = renderCapped(manyAgents(10), budget);

--- a/packages/cli/src/ui/components/messages/InlineParallelAgentsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/messages/InlineParallelAgentsDisplay.test.tsx
@@ -310,5 +310,29 @@ describe('<InlineParallelAgentsDisplay />', () => {
       // Header tally still reflects the full count.
       expect(frame).toContain('10/10 done');
     });
+
+    it('at a budget of 2, keeps the header + indicator only (drops every row)', () => {
+      const budget = 2;
+      const { lastFrame } = renderCapped(manyAgents(10), budget);
+      const frame = lastFrame() ?? '';
+      // header (1) + "+N more" indicator (1) = 2 rows, exactly the budget — no
+      // data row may slip in, or the frame overflows and snaps back.
+      expect(frame.split('\n').length).toBeLessThanOrEqual(budget);
+      expect(frame).toContain('+10 more agents');
+      expect(frame).not.toContain('CapAgent');
+      expect(frame).toContain('10/10 done');
+    });
+
+    it('at a budget of 1, keeps only the header (drops rows and the indicator)', () => {
+      const budget = 1;
+      const { lastFrame } = renderCapped(manyAgents(10), budget);
+      const frame = lastFrame() ?? '';
+      // Only the header fits; even the overflow indicator would overflow.
+      expect(frame.split('\n').length).toBeLessThanOrEqual(budget);
+      expect(frame).not.toContain('more agent');
+      expect(frame).not.toContain('CapAgent');
+      // The header label still carries the full tally.
+      expect(frame).toContain('10/10 done');
+    });
   });
 });

--- a/packages/cli/src/ui/components/messages/InlineParallelAgentsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/messages/InlineParallelAgentsDisplay.test.tsx
@@ -294,12 +294,14 @@ describe('<InlineParallelAgentsDisplay />', () => {
       expect(frame).not.toContain('more agent');
     });
 
-    it('with a generous budget, renders every agent (backstop is a no-op)', () => {
-      // 10 agents + header = 11 rows < budget 20, so the `rows.length + 1 >
-      // budget` guard is false and windowing must NOT kick in. Pins the `>`
-      // boundary: a regression to `>=` (or an off-by-one) would truncate here
-      // even though there is room.
-      const { lastFrame } = renderCapped(manyAgents(10), 20);
+    it('at the exact-fit budget, renders every agent (backstop is a no-op)', () => {
+      // Budget = rows.length + 1 = 11 pins the `>` boundary precisely:
+      //   11 > 11  = false → correct, no windowing (renders all 10 + header)
+      //   11 >= 11 = true  → a regression to `>=` would fire windowing and emit
+      //                      a "+1 more" indicator even though everything fits.
+      // The `not.toContain('more agent')` assertion is what catches that flip
+      // (the line count alone coincides at 11 in both branches).
+      const { lastFrame } = renderCapped(manyAgents(10), 11);
       const frame = lastFrame() ?? '';
       expect(frame.split('\n').length).toBe(11);
       expect(frame).not.toContain('more agent');

--- a/packages/cli/src/ui/components/messages/InlineParallelAgentsDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/InlineParallelAgentsDisplay.tsx
@@ -321,6 +321,11 @@ export const InlineParallelAgentsDisplay: React.FC<
           </Text>
         </Box>
       )}
+      {/* INVARIANT: each AgentRow must render exactly 1 terminal line. The
+          height backstop above (rowsFit = budget - 2) counts one line per row;
+          if AgentRow ever grows to multiple lines the frame would exceed the
+          budget and re-trigger the shouldClearTerminalForFrame snap-back this
+          guards against. Enforced by the wrap="truncate-end" Texts in AgentRow. */}
       {visibleRows.map((row) => (
         <AgentRow key={row.agentId} row={row} now={now} />
       ))}
@@ -328,6 +333,10 @@ export const InlineParallelAgentsDisplay: React.FC<
   );
 };
 
+// INVARIANT: must render exactly ONE terminal line. The parent's height
+// backstop (rowsFit = availableTerminalHeight - 2) assumes one line per row;
+// all Text elements below use wrap="truncate-end" to hold that. Do not add
+// wrapping/multi-line content here without revisiting that windowing math.
 const AgentRow: React.FC<{ row: RowData; now: number }> = ({ row, now }) => {
   const { glyph, color } = statusGlyph(row.status);
   const safeName = escapeAnsiCtrlCodes(row.name);

--- a/packages/cli/src/ui/components/messages/InlineParallelAgentsDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/InlineParallelAgentsDisplay.tsx
@@ -12,11 +12,17 @@
  * progress information into a count.
  *
  * Each row shows: status glyph · agent name · elapsed · tokens.
- * Rendered in the committed phase only; during the live phase
- * `LiveAgentPanel` below the composer owns the per-agent roster.
- * Elapsed and token data fall back to
- * `AgentResultDisplay.executionSummary` when the registry entry has
- * been unregistered.
+ * Rendered in BOTH phases via `ToolGroupMessage`'s `inlineToolCalls`
+ * hand-off. During the live phase only terminal (completed / failed /
+ * cancelled) agents render here — running / background ones are owned by
+ * `LiveAgentPanel` below the composer — and an `availableTerminalHeight`
+ * windowing backstop caps the panel height so the non-`<Static>` live
+ * frame can't overflow and trigger ink's scroll snap-back. In the
+ * committed phase the full roster renders with no cap, as the persistent
+ * scrollback record. `totalAgentCount` keeps the header tally honest when
+ * the rendered rows are a live-phase subset. Elapsed and token data fall
+ * back to `AgentResultDisplay.executionSummary` when the registry entry
+ * has been unregistered.
  */
 
 import type React from 'react';

--- a/packages/cli/src/ui/components/messages/InlineParallelAgentsDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/InlineParallelAgentsDisplay.tsx
@@ -316,22 +316,26 @@ export const InlineParallelAgentsDisplay: React.FC<
   return (
     <Box flexDirection="column" width={contentWidth} paddingX={1}>
       <Box>
-        <Text bold color={theme.text.accent}>
+        {/* truncate-end keeps the header to 1 line — the backstop budgets it as
+            one row; without it a narrow terminal would wrap it and overflow. */}
+        <Text bold color={theme.text.accent} wrap="truncate-end">
           {headerLabel}
         </Text>
       </Box>
       {overflowCount > 0 && (
         <Box>
-          <Text color={theme.text.secondary}>
+          {/* Likewise 1 line: the backstop reserves a single row for this. */}
+          <Text color={theme.text.secondary} wrap="truncate-end">
             … +{overflowCount} more {overflowCount === 1 ? 'agent' : 'agents'}
           </Text>
         </Box>
       )}
-      {/* INVARIANT: each AgentRow must render exactly 1 terminal line. The
-          height backstop above (rowsFit = budget - 2) counts one line per row;
-          if AgentRow ever grows to multiple lines the frame would exceed the
-          budget and re-trigger the shouldClearTerminalForFrame snap-back this
-          guards against. Enforced by the wrap="truncate-end" Texts in AgentRow. */}
+      {/* INVARIANT: header (1) + optional overflow indicator (1) + each AgentRow
+          (1) must each render exactly 1 terminal line. The height backstop above
+          (rowsFit = budget - 2) counts one line apiece; if any grows to multiple
+          lines the frame would exceed the budget and re-trigger the
+          shouldClearTerminalForFrame snap-back this guards against. Enforced by
+          wrap="truncate-end" on every Text here and in AgentRow. */}
       {visibleRows.map((row) => (
         <AgentRow key={row.agentId} row={row} now={now} />
       ))}
@@ -367,7 +371,9 @@ const AgentRow: React.FC<{ row: RowData; now: number }> = ({ row, now }) => {
   return (
     <Box flexDirection="row">
       <Box flexShrink={0} marginRight={1}>
-        <Text color={color}>{glyph}</Text>
+        <Text color={color} wrap="truncate-end">
+          {glyph}
+        </Text>
       </Box>
       <Box flexShrink={0} marginRight={1} width={NAME_COL_WIDTH}>
         <Text wrap="truncate-end">{displayName}</Text>
@@ -378,7 +384,9 @@ const AgentRow: React.FC<{ row: RowData; now: number }> = ({ row, now }) => {
         </Text>
       </Box>
       <Box flexShrink={0}>
-        <Text color={theme.text.secondary}>{trailing}</Text>
+        <Text color={theme.text.secondary} wrap="truncate-end">
+          {trailing}
+        </Text>
       </Box>
     </Box>
   );

--- a/packages/cli/src/ui/components/messages/InlineParallelAgentsDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/InlineParallelAgentsDisplay.tsx
@@ -43,6 +43,16 @@ interface InlineParallelAgentsDisplayProps {
    * defaults to the number of agent entries in `toolCalls`.
    */
   totalAgentCount?: number;
+  /**
+   * Hard cap on the panel's rendered height (rows). The panel renders
+   * inside the non-`<Static>` live frame; if that frame exceeds the
+   * terminal height, ink clears the whole screen on every repaint
+   * (scroll snap-back / flicker — see ink `shouldClearTerminalForFrame`).
+   * When set, the agent list windows to the most recent rows that fit,
+   * leaving a "+N more" indicator. Omitted → no cap (committed phase,
+   * where the row already lives in `<Static>`).
+   */
+  availableTerminalHeight?: number;
 }
 
 /**
@@ -173,7 +183,12 @@ function truncateMiddle(input: string, max: number): string {
 
 export const InlineParallelAgentsDisplay: React.FC<
   InlineParallelAgentsDisplayProps
-> = ({ toolCalls, contentWidth, totalAgentCount }) => {
+> = ({
+  toolCalls,
+  contentWidth,
+  totalAgentCount,
+  availableTerminalHeight,
+}) => {
   const config = useContext(ConfigContext);
 
   // Static slice of agent calls for this group. The caller already
@@ -263,6 +278,18 @@ export const InlineParallelAgentsDisplay: React.FC<
   const total = totalAgentCount ?? rows.length;
   const headerLabel = `Parallel agents · ${total} · ${doneCount}/${total} done`;
 
+  // Height backstop: the panel lives in the non-`<Static>` live frame, so its
+  // height must stay within budget or ink clears the whole terminal on every
+  // repaint (scroll snap-back). Reserve 1 row for the header and 1 for the
+  // overflow indicator, then window to the most recent rows that fit. A budget
+  // ≤ 0 / undefined means "no cap" (committed phase — already in `<Static>`).
+  const rowBudget =
+    availableTerminalHeight && availableTerminalHeight > 0
+      ? Math.max(1, availableTerminalHeight - 2)
+      : rows.length;
+  const overflowCount = Math.max(0, rows.length - rowBudget);
+  const visibleRows = overflowCount > 0 ? rows.slice(rows.length - rowBudget) : rows;
+
   return (
     <Box flexDirection="column" width={contentWidth} paddingX={1}>
       <Box>
@@ -270,7 +297,14 @@ export const InlineParallelAgentsDisplay: React.FC<
           {headerLabel}
         </Text>
       </Box>
-      {rows.map((row) => (
+      {overflowCount > 0 && (
+        <Box>
+          <Text color={theme.text.secondary}>
+            … +{overflowCount} more {overflowCount === 1 ? 'agent' : 'agents'}
+          </Text>
+        </Box>
+      )}
+      {visibleRows.map((row) => (
         <AgentRow key={row.agentId} row={row} now={now} />
       ))}
     </Box>

--- a/packages/cli/src/ui/components/messages/InlineParallelAgentsDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/InlineParallelAgentsDisplay.tsx
@@ -279,16 +279,33 @@ export const InlineParallelAgentsDisplay: React.FC<
   const headerLabel = `Parallel agents · ${total} · ${doneCount}/${total} done`;
 
   // Height backstop: the panel lives in the non-`<Static>` live frame, so its
-  // height must stay within budget or ink clears the whole terminal on every
-  // repaint (scroll snap-back). Reserve 1 row for the header and 1 for the
-  // overflow indicator, then window to the most recent rows that fit. A budget
-  // ≤ 0 / undefined means "no cap" (committed phase — already in `<Static>`).
-  const rowBudget =
-    availableTerminalHeight && availableTerminalHeight > 0
-      ? Math.max(1, availableTerminalHeight - 2)
-      : rows.length;
-  const overflowCount = Math.max(0, rows.length - rowBudget);
-  const visibleRows = overflowCount > 0 ? rows.slice(rows.length - rowBudget) : rows;
+  // total height must stay within budget or ink clears the whole terminal on
+  // every repaint (scroll snap-back). The header always costs 1 row; when rows
+  // overflow, the "+N more" indicator costs another. Window to the most recent
+  // rows that still fit AFTER reserving those lines, so the rendered height
+  // (header + optional indicator + visibleRows) never exceeds the budget — even
+  // at degenerate budgets ≤ 2, where we drop all rows (and at a budget of 1 the
+  // indicator too, leaving just the header whose label still states the total).
+  // A budget ≤ 0 / undefined means "no cap" (committed phase — already in
+  // `<Static>`).
+  const hasBudget =
+    availableTerminalHeight != null && availableTerminalHeight > 0;
+  let overflowCount = 0;
+  let visibleRows = rows;
+  if (hasBudget && rows.length + 1 > availableTerminalHeight) {
+    // header (1) + all rows would exceed the budget → window.
+    if (availableTerminalHeight >= 2) {
+      // Reserve 1 row for the header and 1 for the "+N more" indicator; the
+      // remainder is for rows.
+      const rowsFit = availableTerminalHeight - 2;
+      overflowCount = rows.length - rowsFit;
+      visibleRows = rowsFit > 0 ? rows.slice(rows.length - rowsFit) : [];
+    } else {
+      // Budget of 1: only the header fits — drop every row and the indicator
+      // too. The header label still states the total agent count.
+      visibleRows = [];
+    }
+  }
 
   return (
     <Box flexDirection="column" width={contentWidth} paddingX={1}>

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -1247,5 +1247,46 @@ describe('<ToolGroupMessage />', () => {
       expect(frame).toContain('COMMITB');
       expect(frame).toContain('2/2 done');
     });
+
+    it('forwards the height cap only in the live phase (committed phase = no cap)', () => {
+      // The InlineParallelAgentsDisplay height backstop guards ONLY the live,
+      // non-`<Static>` frame. ToolGroupMessage forwards
+      // `isPending ? availableTerminalHeight : undefined`, so a tight budget
+      // windows the live phase but never the committed scrollback record (where
+      // MainContent passes staticAreaMaxItemHeight >= 100). Without the
+      // conditional, completed agents would be permanently hidden behind a
+      // static "+N more" in scrollback. The contrast pins that load-bearing
+      // conditional — a regression that always forwards (or always drops) the
+      // budget breaks exactly one of these two assertions.
+      const manyCompleted = Array.from({ length: 8 }, (_, i) =>
+        parallelAgent(`cap-${i}`, `CAPAGENT${i}`, 'completed'),
+      );
+
+      // Live phase + tight budget → windowing kicks in, overflow indicator shows.
+      const live = renderParallel(
+        <ToolGroupMessage
+          {...baseProps}
+          isPending={true}
+          availableTerminalHeight={5}
+          toolCalls={manyCompleted}
+        />,
+      );
+      expect(live.lastFrame() ?? '').toContain('more agent');
+
+      // Committed phase, SAME tight budget → cap suppressed, every agent renders.
+      const committed = renderParallel(
+        <ToolGroupMessage
+          {...baseProps}
+          isPending={false}
+          availableTerminalHeight={5}
+          toolCalls={manyCompleted}
+        />,
+      );
+      const committedFrame = committed.lastFrame() ?? '';
+      expect(committedFrame).not.toContain('more agent');
+      expect(committedFrame).toContain('CAPAGENT0');
+      expect(committedFrame).toContain('CAPAGENT7');
+      expect(committedFrame).toContain('8/8 done');
+    });
   });
 });

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -1143,4 +1143,109 @@ describe('<ToolGroupMessage />', () => {
       expect(frame).not.toContain('Delegate task to subagent');
     });
   });
+
+  describe('Pure parallel agent group: LiveAgentPanel hand-off (dedup)', () => {
+    // Regression for the non-VP scroll snap-back (#5798): during the live
+    // phase the pure-parallel inline panel used the UNFILTERED toolCalls,
+    // so running subagents were rendered inline AND in LiveAgentPanel below
+    // the composer. Two full rosters inflate the non-`<Static>` live frame
+    // past the terminal height, at which point ink clears the whole screen
+    // (incl. scrollback) on every repaint. The branch now routes through the
+    // same `inlineToolCalls` hand-off as every other group.
+    // InlineParallelAgentsDisplay reads the registry off config; give it a
+    // real stub (the bare `{}` mockConfig would make `getBackgroundTaskRegistry`
+    // throw). Empty registry → rows fall back to the tool-result data.
+    const registryConfig = {
+      getBackgroundTaskRegistry: () => ({ get: () => undefined }),
+    } as unknown as Config;
+    const renderParallel = (component: React.ReactElement) =>
+      render(
+        <ConfigContext.Provider value={registryConfig}>
+          {component}
+        </ConfigContext.Provider>,
+      );
+
+    const parallelAgent = (
+      callId: string,
+      taskDescription: string,
+      status: AgentResultDisplay['status'],
+    ): IndividualToolCallDisplay =>
+      createToolCall({
+        callId,
+        name: 'task',
+        description: taskDescription,
+        status:
+          status === 'running'
+            ? ToolCallStatus.Executing
+            : status === 'completed'
+              ? ToolCallStatus.Success
+              : ToolCallStatus.Error,
+        resultDisplay: {
+          type: 'task_execution',
+          subagentName: 'reviewer',
+          taskDescription,
+          taskPrompt: 'review',
+          status,
+        } as AgentResultDisplay,
+      });
+
+    it('live phase: an all-running parallel group renders nothing inline (panel owns the roster)', () => {
+      const { lastFrame } = renderParallel(
+        <ToolGroupMessage
+          {...baseProps}
+          isPending={true}
+          toolCalls={[
+            parallelAgent('a1', 'RUNALPHA', 'running'),
+            parallelAgent('a2', 'RUNBETA', 'running'),
+          ]}
+        />,
+      );
+      const frame = lastFrame() ?? '';
+      // No duplicate inline roster: header absent, neither running agent shown.
+      expect(frame).not.toContain('Parallel agents');
+      expect(frame).not.toContain('RUNALPHA');
+      expect(frame).not.toContain('RUNBETA');
+    });
+
+    it('live phase: a mixed group shows only terminal agents inline, hides panel-owned running ones, keeps the full total', () => {
+      const { lastFrame } = renderParallel(
+        <ToolGroupMessage
+          {...baseProps}
+          isPending={true}
+          toolCalls={[
+            parallelAgent('a1', 'DONEONE', 'completed'),
+            parallelAgent('a2', 'RUNTWO', 'running'),
+            parallelAgent('a3', 'RUNTHREE', 'running'),
+          ]}
+        />,
+      );
+      const frame = lastFrame() ?? '';
+      expect(frame).toContain('Parallel agents');
+      // The completed agent surfaces inline (en route to scrollback).
+      expect(frame).toContain('DONEONE');
+      // Running agents are owned by the panel — NOT duplicated inline.
+      expect(frame).not.toContain('RUNTWO');
+      expect(frame).not.toContain('RUNTHREE');
+      // Header total stays honest (3 agents, 1 done) even though 1 row renders.
+      expect(frame).toContain('1/3 done');
+    });
+
+    it('committed phase: renders every agent inline (the persistent record)', () => {
+      const { lastFrame } = renderParallel(
+        <ToolGroupMessage
+          {...baseProps}
+          isPending={false}
+          toolCalls={[
+            parallelAgent('a1', 'COMMITA', 'completed'),
+            parallelAgent('a2', 'COMMITB', 'completed'),
+          ]}
+        />,
+      );
+      const frame = lastFrame() ?? '';
+      expect(frame).toContain('Parallel agents');
+      expect(frame).toContain('COMMITA');
+      expect(frame).toContain('COMMITB');
+      expect(frame).toContain('2/2 done');
+    });
+  });
 });

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -283,7 +283,13 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
         toolCalls={inlineToolCalls}
         contentWidth={contentWidth}
         totalAgentCount={toolCalls.length}
-        availableTerminalHeight={availableTerminalHeight}
+        // The height backstop guards only the live, non-`<Static>` frame. Once
+        // committed (`isPending=false`) the rows live in `<Static>` with no
+        // snap-back risk, and MainContent passes `staticAreaMaxItemHeight`
+        // (>=100) here — forwarding that would let the cap fire on scrollback
+        // and permanently hide completed agents behind "+N more". Pass
+        // undefined (no cap) when committed, per the component's contract.
+        availableTerminalHeight={isPending ? availableTerminalHeight : undefined}
       />
     );
   }

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -272,15 +272,17 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   // header's "N · done/N" honest, and `availableTerminalHeight` is a hard cap
   // backstop for degenerate cases (many agents finishing at once).
   if (isPureParallelAgentGroup(toolCalls) && !hasSubagentPendingConfirmation) {
-    const inlineAgentToolCalls = inlineToolCalls.filter(isSubagentToolEntry);
-    if (inlineAgentToolCalls.length === 0) {
+    // `isPureParallelAgentGroup` already guarantees every entry is a subagent,
+    // so `inlineToolCalls` (a subset) and `toolCalls.length` need no further
+    // `isSubagentToolEntry` filtering here.
+    if (inlineToolCalls.length === 0) {
       return null;
     }
     return (
       <InlineParallelAgentsDisplay
-        toolCalls={inlineAgentToolCalls}
+        toolCalls={inlineToolCalls}
         contentWidth={contentWidth}
-        totalAgentCount={toolCalls.filter(isSubagentToolEntry).length}
+        totalAgentCount={toolCalls.length}
         availableTerminalHeight={availableTerminalHeight}
       />
     );

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -258,14 +258,30 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   const hasSubagentPendingConfirmation = subagentsAwaitingApproval.length > 0;
 
   // Pure parallel agent group (≥2 agents, nothing else).
-  // Dense panel in both phases with all agents. During live phase
-  // LiveAgentPanel below also shows running agents (brief overlap
-  // that resolves as agents complete and expire from the panel).
+  //
+  // Render through the SAME `inlineToolCalls` hand-off as every other group:
+  // during the live phase, running / background subagents are owned by
+  // LiveAgentPanel below the composer, so rendering them here too duplicated a
+  // full agent roster inside the non-`<Static>` live frame. Once that frame
+  // exceeds the terminal height, ink clears the whole screen (incl. scrollback)
+  // on every repaint — the per-second elapsed/token ticks then make it fire
+  // continuously, so scroll-up snaps straight back to the bottom (#5798, the
+  // `shouldClearTerminalForFrame` path in ink). Showing only the agents the
+  // panel is NOT displaying (terminal rows en route to `<Static>`) halves the
+  // live frame and keeps it under the viewport. `totalAgentCount` keeps the
+  // header's "N · done/N" honest, and `availableTerminalHeight` is a hard cap
+  // backstop for degenerate cases (many agents finishing at once).
   if (isPureParallelAgentGroup(toolCalls) && !hasSubagentPendingConfirmation) {
+    const inlineAgentToolCalls = inlineToolCalls.filter(isSubagentToolEntry);
+    if (inlineAgentToolCalls.length === 0) {
+      return null;
+    }
     return (
       <InlineParallelAgentsDisplay
-        toolCalls={toolCalls}
+        toolCalls={inlineAgentToolCalls}
         contentWidth={contentWidth}
+        totalAgentCount={toolCalls.filter(isSubagentToolEntry).length}
+        availableTerminalHeight={availableTerminalHeight}
       />
     );
   }

--- a/packages/cli/src/ui/components/shared/ScrollableList.tsx
+++ b/packages/cli/src/ui/components/shared/ScrollableList.tsx
@@ -180,7 +180,9 @@ function ScrollableList<T>(
     [scheduleScrollFlush, cancelPendingScroll],
   );
 
-  useMouseEvents(handleMouseEvent, { isActive: hasFocus });
+  // The VP viewport owns the wheel (this IS the in-app scroller), so opt out
+  // of the VP gate — though in practice ScrollableList only mounts in VP mode.
+  useMouseEvents(handleMouseEvent, { isActive: hasFocus, bypassVpGate: true });
 
   // ScrollableList is a thin keyboard / mouse wrapper around VirtualizedList.
   // The previous outer <Box flexGrow={1}> wrapper carried a never-read

--- a/packages/cli/src/ui/hooks/useMouseEvents.test.tsx
+++ b/packages/cli/src/ui/hooks/useMouseEvents.test.tsx
@@ -10,6 +10,8 @@ import { renderHook } from '@testing-library/react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { useStdin, useStdout } from 'ink';
 import { KeypressProvider } from '../contexts/KeypressContext.js';
+import { SettingsContext } from '../contexts/SettingsContext.js';
+import type { LoadedSettings } from '../../config/settings.js';
 import { useMouseEvents } from './useMouseEvents.js';
 
 vi.mock('ink', async (importOriginal) => {
@@ -31,9 +33,26 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
   <KeypressProvider kittyProtocolEnabled={false}>{children}</KeypressProvider>
 );
 
+const vpWrapper = (useTerminalBuffer: boolean) => {
+  const VpWrapper = ({ children }: { children: React.ReactNode }) => (
+    <SettingsContext.Provider
+      value={
+        { merged: { ui: { useTerminalBuffer } } } as unknown as LoadedSettings
+      }
+    >
+      <KeypressProvider kittyProtocolEnabled={false}>
+        {children}
+      </KeypressProvider>
+    </SettingsContext.Provider>
+  );
+  return VpWrapper;
+};
+
+// Mechanism tests exercise enable/disable/ref-counting independent of the VP
+// gate, so they opt out via bypassVpGate.
 function useTwoMouseSubscribers(firstActive: boolean, secondActive: boolean) {
-  useMouseEvents(() => {}, { isActive: firstActive });
-  useMouseEvents(() => {}, { isActive: secondActive });
+  useMouseEvents(() => {}, { isActive: firstActive, bypassVpGate: true });
+  useMouseEvents(() => {}, { isActive: secondActive, bypassVpGate: true });
 }
 
 describe('useMouseEvents', () => {
@@ -92,5 +111,29 @@ describe('useMouseEvents', () => {
     stdout.write.mockClear();
     unmount();
     expect(stdout.write).not.toHaveBeenCalled();
+  });
+
+  describe('VP gate', () => {
+    it('non-VP without bypass: does NOT enable mouse mode (native scrollback preserved)', () => {
+      renderHook(() => useMouseEvents(() => {}, { isActive: true }), {
+        wrapper: vpWrapper(false),
+      });
+      expect(stdout.write).not.toHaveBeenCalledWith(ENABLE_MOUSE);
+    });
+
+    it('VP without bypass: enables mouse mode', () => {
+      renderHook(() => useMouseEvents(() => {}, { isActive: true }), {
+        wrapper: vpWrapper(true),
+      });
+      expect(stdout.write).toHaveBeenCalledWith(ENABLE_MOUSE);
+    });
+
+    it('bypassVpGate: enables mouse mode even in non-VP (modal / VP viewport)', () => {
+      renderHook(
+        () => useMouseEvents(() => {}, { isActive: true, bypassVpGate: true }),
+        { wrapper: vpWrapper(false) },
+      );
+      expect(stdout.write).toHaveBeenCalledWith(ENABLE_MOUSE);
+    });
   });
 });

--- a/packages/cli/src/ui/hooks/useMouseEvents.ts
+++ b/packages/cli/src/ui/hooks/useMouseEvents.ts
@@ -8,7 +8,7 @@
  * out of the KeypressContext pipeline, call each handler, restore on cleanup.
  */
 
-import { useEffect, useRef, useCallback } from 'react';
+import { useContext, useEffect, useRef, useCallback } from 'react';
 import { useStdin, useStdout } from 'ink';
 import {
   enableMouseEvents,
@@ -16,8 +16,22 @@ import {
   type MouseEvent,
 } from '../utils/mouse.js';
 import { useKeypressContext } from '../contexts/KeypressContext.js';
+import { SettingsContext } from '../contexts/SettingsContext.js';
 
 export type MouseHandler = (event: MouseEvent) => void;
+
+export interface MouseEventsOptions {
+  /** Subscribe + enable SGR mouse mode only while this is true. */
+  isActive: boolean;
+  /**
+   * Opt out of the VP gate. By default mouse tracking is enabled only in VP
+   * mode (`ui.useTerminalBuffer`), so non-VP keeps native terminal scrollback.
+   * Set true for surfaces that own the wheel regardless — the VP viewport
+   * (ScrollableList) and alternate-screen modals (ThinkingViewer) — where
+   * there is no main-screen native scrollback to protect.
+   */
+  bypassVpGate?: boolean;
+}
 
 type MouseModeEntry = {
   refs: number;
@@ -80,16 +94,29 @@ function releaseMouseMode(stdout: NodeJS.WriteStream): void {
  */
 export function useMouseEvents(
   handler: MouseHandler,
-  { isActive }: { isActive: boolean },
+  { isActive, bypassVpGate = false }: MouseEventsOptions,
 ): void {
   const { isRawModeSupported } = useStdin();
   const { stdout } = useStdout();
   const { subscribeMouse, unsubscribeMouse } = useKeypressContext();
 
+  // VP gate: enabling SGR mouse tracking (?1002h) makes the host terminal stop
+  // doing native scrollback on the wheel. That is only acceptable when the app
+  // itself owns the wheel — i.e. in VP mode (ScrollableList) or on an
+  // alternate-screen surface (a modal) that has no native scrollback to begin
+  // with. On the non-VP main screen, holding mouse tracking just hijacks the
+  // wheel (Terminal.app diverts it away from scrollback), so by DEFAULT mouse
+  // tracking is denied outside VP. Surfaces that legitimately consume the wheel
+  // pass `bypassVpGate` to opt in. This keeps the non-VP transcript scrollable
+  // no matter how many click/hover subscribers are added later.
+  const settings = useContext(SettingsContext);
+  const isVpMode = settings?.merged.ui?.useTerminalBuffer ?? false;
+  const vpGateOpen = isVpMode || bypassVpGate;
+
   const handlerRef = useRef(handler);
   handlerRef.current = handler;
 
-  const enabled = isActive && isRawModeSupported;
+  const enabled = isActive && isRawModeSupported && vpGateOpen;
 
   useEffect(() => {
     if (!enabled) return;


### PR DESCRIPTION
## What this PR does

Fixes two independent root causes that make the **non-VP** (default) transcript impossible to scroll up during rich runs (e.g. `/review`'s multi-agent fan-out). The view either snaps straight back to the bottom, or the wheel recalls composer history / drives the background-agent panel instead of scrolling.

Two focused commits:

1. **Stop scroll snap-back during parallel-agent runs.** Ink clears the whole terminal (incl. scrollback) on every repaint once the non-`<Static>` live frame exceeds the terminal height (`shouldClearTerminalForFrame`). The pure-parallel inline panel rendered the *unfiltered* tool calls, so running subagents were shown inline **and** in `LiveAgentPanel` below the composer — two full rosters that push the live frame past the viewport; the per-second elapsed/token ticks then fire the clear continuously. The branch now routes through the same `inlineToolCalls` hand-off as every other group (running subagents are owned by the panel), with an `availableTerminalHeight` windowing backstop on `InlineParallelAgentsDisplay`.

2. **Keep native scrollback usable in non-VP mode.** Enabling SGR mouse tracking (`?1002h`) makes the host terminal stop doing native scrollback on the wheel (Terminal.app even diverts the wheel to arrow keys, which then drive composer input history and the panel). A collapsed thinking block armed mouse tracking just for click-to-expand, unconditionally — so any non-VP session with thinking blocks could no longer scroll. `useMouseEvents` now gates on VP mode by default (`ui.useTerminalBuffer`); surfaces that genuinely own the wheel opt out via a new `bypassVpGate` (`ScrollableList`, the alternate-screen `ThinkingViewer`). The thinking-block click handler does not, so in non-VP it stays dormant and native scrollback is preserved (the block still expands via Alt+T). Single chokepoint → future non-VP mouse subscribers can't reintroduce the regression.

## Why it's needed

PR #5799 only corrected the footer-height accounting; it neither de-duplicated the parallel-agent rosters nor stopped mouse tracking from hijacking the wheel, so non-VP scrolling stayed broken during `/review`-style runs. Root cause was confirmed against the real (forked) ink renderer: a non-`<Static>` frame taller than the terminal triggers `clearTerminal` on every render; below it, ink does an in-place `log-update` and native scrollback survives.

## Reviewer Test Plan

### How to verify

Automated — from the repo root:

```
npx vitest run \
  packages/cli/src/ui/components/messages/InlineParallelAgentsDisplay.test.tsx \
  packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx \
  packages/cli/src/ui/hooks/useMouseEvents.test.tsx \
  packages/cli/src/ui/components/HistoryItemDisplay.test.tsx \
  packages/cli/src/ui/components/shared/ScrollableList.test.tsx
# Tests  97 passed
```

Added regression tests: pure-parallel live-phase dedup + header total honesty + windowing backstop; `useMouseEvents` VP-gate (off in non-VP, on in VP, `bypassVpGate` overrides); thinking-block subscribes without `bypassVpGate`.

Manual (the live symptom), short terminal, non-VP: run `/review` on a PR. Before: scroll-up snaps back / wheel recalls history. After: the transcript scrolls.

### Evidence (Before & After)

The before/after is encoded programmatically (the live TUI symptom needs a real TTY + API key, which CI lacks):

- **Snap-back**: the dedup test asserts that during the live phase a pure-parallel group renders **no** running-agent rows inline (panel owns them) — before, the unfiltered branch rendered a second full roster, inflating the non-`<Static>` frame past the viewport and triggering `clearTerminal` every repaint. The windowing test asserts the inline frame height never exceeds its `availableTerminalHeight` budget.
- **Wheel hijack**: the `useMouseEvents` VP-gate test asserts mouse tracking is **not** enabled in non-VP without `bypassVpGate` (native scrollback preserved), **is** enabled in VP, and that `bypassVpGate` overrides. The thinking-block test pins that it subscribes without the bypass, i.e. stays gated.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

Verified locally on macOS (the 5 suites above, plus tsc-diff = zero new type errors and eslint clean on the changed files). Windows/Linux not run locally — covered by CI.

## Risk & Scope

- Non-VP loses **mouse click-to-expand** on thinking blocks (Alt+T keyboard expand, already advertised on the block, is unchanged). VP is unaffected.
- Parallel-agent inline panel no longer duplicates running agents during the live phase; terminal (completed/failed/cancelled) rows still render inline as the scrollback summary, header keeps the full `done/total`.
- No settings/API changes.

## Linked Issues

Refs #5798

<details>
<summary>中文说明</summary>

修复非 VP（默认）模式下 transcript 无法上滚的两个独立根因（`/review` 多 agent 场景必现）：

1. **上滚被弹回**：Ink 在「非 `<Static>` 动态帧 > 终端行数」时每帧 `clearTerminal`（连 scrollback 一起清）。并行 agent 组的 inline 面板用了未过滤的 toolCalls，导致 running 子 agent 在顶部 inline 和底部 `LiveAgentPanel` **重复渲染**两份名册，把动态帧撑过视口；每秒 tick 持续触发清屏。改为走与其它组相同的 `inlineToolCalls` 交接（running 由面板独占），并给 `InlineParallelAgentsDisplay` 加 `availableTerminalHeight` 窗口化兜底。

2. **滚轮被劫持**：开启 SGR 鼠标追踪（`?1002h`）会让终端不再对滚轮做原生 scrollback（Terminal.app 还把滚轮转成方向键 → 回放 composer 历史 / 操作面板）。collapsed thinking 块为了点击展开无条件开了鼠标追踪，于是非 VP 下只要有 thinking 块就滚不动。`useMouseEvents` 改为默认仅在 VP（`ui.useTerminalBuffer`）下启用；真正需要滚轮的面板（`ScrollableList`、alt-screen 的 `ThinkingViewer`）用新增的 `bypassVpGate` 显式豁免。thinking 块点击不豁免 → 非 VP 休眠、原生 scrollback 保住（仍可 Alt+T 展开）。单点收口，杜绝未来回归。

PR #5799 只修了 footer 高度核算，未消除重复名册、也未阻止鼠标追踪劫持滚轮，故问题仍在。根因已对真实（fork 版）ink 渲染器实证。

</details>

🤖 Generated with [Qwen Code](https://qwen.ai/qwencode)
