### PR TITLE
feat(cli): support inline one-shot model override in /model (#5967)

### DIFF
--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -1435,6 +1435,10 @@ export default {
     'Switch the model for this session (--fast for suggestion model, --voice for voice transcription model, [model-id] to switch immediately).',
   'Switch the model for this session (--fast for suggestion model, --voice for voice transcription model, --vision for the vision bridge model, [model-id] to switch immediately, or [model-id] [prompt] to run a one-off prompt on another model; the inline prompt is sent verbatim without @file expansion).':
     'Switch the model for this session (--fast for suggestion model, --voice for voice transcription model, --vision for the vision bridge model, [model-id] to switch immediately, or [model-id] [prompt] to run a one-off prompt on another model; the inline prompt is sent verbatim without @file expansion).',
+  "Inline one-shot override isn't supported in this mode — run '/model {{model}}' first, then send your prompt.":
+    "Inline one-shot override isn't supported in this mode — run '/model {{model}}' first, then send your prompt.",
+  "Inline one-shot override can't switch providers. '{{model}}' belongs to a different provider — run '/model {{model}}' first, then send your prompt.":
+    "Inline one-shot override can't switch providers. '{{model}}' belongs to a different provider — run '/model {{model}}' first, then send your prompt.",
   "⚠ '{{model}}' is not a known image-capable model; the vision bridge may fail on images.":
     "⚠ '{{model}}' is not a known image-capable model; the vision bridge may fail on images.",
   'Set a lighter model for prompt suggestions and speculative execution':

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -1433,8 +1433,8 @@ export default {
     'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately).',
   'Switch the model for this session (--fast for suggestion model, --voice for voice transcription model, [model-id] to switch immediately).':
     'Switch the model for this session (--fast for suggestion model, --voice for voice transcription model, [model-id] to switch immediately).',
-  'Switch the model for this session (--fast for suggestion model, --voice for voice transcription model, --vision for the vision bridge model, [model-id] to switch immediately).':
-    'Switch the model for this session (--fast for suggestion model, --voice for voice transcription model, --vision for the vision bridge model, [model-id] to switch immediately).',
+  'Switch the model for this session (--fast for suggestion model, --voice for voice transcription model, --vision for the vision bridge model, [model-id] to switch immediately, or [model-id] [prompt] to run a one-off prompt on another model; the inline prompt is sent verbatim without @file expansion).':
+    'Switch the model for this session (--fast for suggestion model, --voice for voice transcription model, --vision for the vision bridge model, [model-id] to switch immediately, or [model-id] [prompt] to run a one-off prompt on another model; the inline prompt is sent verbatim without @file expansion).',
   "⚠ '{{model}}' is not a known image-capable model; the vision bridge may fail on images.":
     "⚠ '{{model}}' is not a known image-capable model; the vision bridge may fail on images.",
   'Set a lighter model for prompt suggestions and speculative execution':

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -1232,6 +1232,10 @@ export default {
     '切換此會話的模型（--fast 可設置建議模型，--voice 可設置語音轉寫模型，[model-id] 可立即切換）',
   'Switch the model for this session (--fast for suggestion model, --voice for voice transcription model, --vision for the vision bridge model, [model-id] to switch immediately, or [model-id] [prompt] to run a one-off prompt on another model; the inline prompt is sent verbatim without @file expansion).':
     '切換此會話的模型（--fast 可設置建議模型，--voice 可設置語音轉寫模型，--vision 可設置視覺橋接模型，[model-id] 可立即切換，或用 [model-id] [prompt] 在另一個模型上執行一次性提示；內聯提示按原文發送，不展開 @file）',
+  "Inline one-shot override isn't supported in this mode — run '/model {{model}}' first, then send your prompt.":
+    "此模式不支援內聯一次性覆寫——請先執行 '/model {{model}}'，再發送你的提示。",
+  "Inline one-shot override can't switch providers. '{{model}}' belongs to a different provider — run '/model {{model}}' first, then send your prompt.":
+    "內聯一次性覆寫無法切換 provider。'{{model}}' 屬於另一個 provider——請先執行 '/model {{model}}'，再發送你的提示。",
   "⚠ '{{model}}' is not a known image-capable model; the vision bridge may fail on images.":
     "⚠ '{{model}}' 不是已知的圖像能力模型；視覺橋接處理圖片時可能會失敗。",
   'Set a lighter model for prompt suggestions and speculative execution':

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -1230,8 +1230,8 @@ export default {
     '切換此會話的模型（--fast 可設置建議模型）',
   'Switch the model for this session (--fast for suggestion model, --voice for voice transcription model, [model-id] to switch immediately).':
     '切換此會話的模型（--fast 可設置建議模型，--voice 可設置語音轉寫模型，[model-id] 可立即切換）',
-  'Switch the model for this session (--fast for suggestion model, --voice for voice transcription model, --vision for the vision bridge model, [model-id] to switch immediately).':
-    '切換此會話的模型（--fast 可設置建議模型，--voice 可設置語音轉寫模型，--vision 可設置視覺橋接模型，[model-id] 可立即切換）',
+  'Switch the model for this session (--fast for suggestion model, --voice for voice transcription model, --vision for the vision bridge model, [model-id] to switch immediately, or [model-id] [prompt] to run a one-off prompt on another model; the inline prompt is sent verbatim without @file expansion).':
+    '切換此會話的模型（--fast 可設置建議模型，--voice 可設置語音轉寫模型，--vision 可設置視覺橋接模型，[model-id] 可立即切換，或用 [model-id] [prompt] 在另一個模型上執行一次性提示；內聯提示按原文發送，不展開 @file）',
   "⚠ '{{model}}' is not a known image-capable model; the vision bridge may fail on images.":
     "⚠ '{{model}}' 不是已知的圖像能力模型；視覺橋接處理圖片時可能會失敗。",
   'Set a lighter model for prompt suggestions and speculative execution':

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -1344,8 +1344,8 @@ export default {
     '切换此会话的模型（--fast 可设置建议模型）',
   'Switch the model for this session (--fast for suggestion model, --voice for voice transcription model, [model-id] to switch immediately).':
     '切换此会话的模型（--fast 可设置建议模型，--voice 可设置语音转写模型，[model-id] 可立即切换）',
-  'Switch the model for this session (--fast for suggestion model, --voice for voice transcription model, --vision for the vision bridge model, [model-id] to switch immediately).':
-    '切换此会话的模型（--fast 可设置建议模型，--voice 可设置语音转写模型，--vision 可设置视觉桥接模型，[model-id] 可立即切换）',
+  'Switch the model for this session (--fast for suggestion model, --voice for voice transcription model, --vision for the vision bridge model, [model-id] to switch immediately, or [model-id] [prompt] to run a one-off prompt on another model; the inline prompt is sent verbatim without @file expansion).':
+    '切换此会话的模型（--fast 可设置建议模型，--voice 可设置语音转写模型，--vision 可设置视觉桥接模型，[model-id] 可立即切换，或用 [model-id] [prompt] 在另一个模型上运行一次性提示；内联提示按原文发送，不展开 @file）',
   "⚠ '{{model}}' is not a known image-capable model; the vision bridge may fail on images.":
     "⚠ '{{model}}' 不是已知的图像能力模型；视觉桥接处理图片时可能会失败。",
   'Set a lighter model for prompt suggestions and speculative execution':

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -1346,6 +1346,10 @@ export default {
     '切换此会话的模型（--fast 可设置建议模型，--voice 可设置语音转写模型，[model-id] 可立即切换）',
   'Switch the model for this session (--fast for suggestion model, --voice for voice transcription model, --vision for the vision bridge model, [model-id] to switch immediately, or [model-id] [prompt] to run a one-off prompt on another model; the inline prompt is sent verbatim without @file expansion).':
     '切换此会话的模型（--fast 可设置建议模型，--voice 可设置语音转写模型，--vision 可设置视觉桥接模型，[model-id] 可立即切换，或用 [model-id] [prompt] 在另一个模型上运行一次性提示；内联提示按原文发送，不展开 @file）',
+  "Inline one-shot override isn't supported in this mode — run '/model {{model}}' first, then send your prompt.":
+    "此模式不支持内联一次性覆盖——请先运行 '/model {{model}}'，再发送你的提示。",
+  "Inline one-shot override can't switch providers. '{{model}}' belongs to a different provider — run '/model {{model}}' first, then send your prompt.":
+    "内联一次性覆盖无法切换 provider。'{{model}}' 属于另一个 provider——请先运行 '/model {{model}}'，再发送你的提示。",
   "⚠ '{{model}}' is not a known image-capable model; the vision bridge may fail on images.":
     "⚠ '{{model}}' 不是已知的图像能力模型；视觉桥接处理图片时可能会失败。",
   'Set a lighter model for prompt suggestions and speculative execution':

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -562,6 +562,10 @@ export async function runNonInteractive(
       let initialPartList: PartListUnion | null = extractPartsFromUserMessage(
         options.userMessage,
       );
+      // Per-turn model override captured from an inline `/model <id> <prompt>`
+      // slash command; seeds the loop-scoped `modelOverride` below so the
+      // submitted prompt runs on the chosen model without a session switch.
+      let inlineModelOverride: string | undefined;
 
       if (options.continueInterrupted) {
         // Read the full history, not a bounded tail: the Retry send path in
@@ -635,6 +639,7 @@ export async function runNonInteractive(
             case 'submit_prompt':
               // A slash command can replace the prompt entirely; fall back to @-command processing otherwise.
               initialPartList = slashCommandResult.content;
+              inlineModelOverride = slashCommandResult.modelOverride;
               slashHandled = true;
               break;
             case 'message': {
@@ -838,7 +843,7 @@ export async function runNonInteractive(
 
       let isFirstTurn = true;
       let hasUnsentToolResponse = false;
-      let modelOverride: string | undefined;
+      let modelOverride: string | undefined = inlineModelOverride;
       // Session-scoped because the synthetic `structured_output` tool can
       // be invoked from EITHER the main assistant-turn loop or from a
       // drain-turn (queued notification / cron prompt); whichever fires

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -640,6 +640,11 @@ export async function runNonInteractive(
               // A slash command can replace the prompt entirely; fall back to @-command processing otherwise.
               initialPartList = slashCommandResult.content;
               inlineModelOverride = slashCommandResult.modelOverride;
+              if (inlineModelOverride !== undefined) {
+                debugLogger.debug(
+                  `[runNonInteractive] inline model override captured: ${inlineModelOverride}`,
+                );
+              }
               slashHandled = true;
               break;
             case 'message': {
@@ -850,6 +855,11 @@ export async function runNonInteractive(
       // undefined-clears case) are skipped so they cannot silently revert the
       // submitted prompt to the session model mid-turn.
       const inlineModelOverrideActive = inlineModelOverride !== undefined;
+      if (inlineModelOverrideActive) {
+        debugLogger.debug(
+          `[runNonInteractive] inline model override active for turn: ${inlineModelOverride}`,
+        );
+      }
       // Session-scoped because the synthetic `structured_output` tool can
       // be invoked from EITHER the main assistant-turn loop or from a
       // drain-turn (queued notification / cron prompt); whichever fires

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -12,6 +12,7 @@ import type {
   ToolCallRequestInfo,
 } from '@qwen-code/qwen-code-core';
 import { isSlashCommand } from './ui/utils/commandUtils.js';
+import { isInlineModelOverrideAllowed } from './utils/acpModelUtils.js';
 import type { LoadedSettings } from './config/settings.js';
 import {
   executeToolCall,
@@ -639,10 +640,24 @@ export async function runNonInteractive(
             case 'submit_prompt':
               // A slash command can replace the prompt entirely; fall back to @-command processing otherwise.
               initialPartList = slashCommandResult.content;
-              inlineModelOverride = slashCommandResult.modelOverride;
-              if (inlineModelOverride !== undefined) {
+              // Re-validate provider identity rather than trust the producer:
+              // any slash command can set `modelOverride`, so the consumer
+              // enforces that it names a model on the active provider before
+              // redirecting API calls to it.
+              if (
+                slashCommandResult.modelOverride !== undefined &&
+                isInlineModelOverrideAllowed(
+                  config,
+                  slashCommandResult.modelOverride,
+                )
+              ) {
+                inlineModelOverride = slashCommandResult.modelOverride;
                 debugLogger.debug(
                   `[runNonInteractive] inline model override captured: ${inlineModelOverride}`,
+                );
+              } else if (slashCommandResult.modelOverride !== undefined) {
+                debugLogger.warn(
+                  `[runNonInteractive] ignoring model override '${slashCommandResult.modelOverride}': not a model on the active provider`,
                 );
               }
               slashHandled = true;
@@ -850,10 +865,13 @@ export async function runNonInteractive(
       let hasUnsentToolResponse = false;
       let modelOverride: string | undefined = inlineModelOverride;
       // An explicit inline `/model <id> <prompt>` override wins for the whole
-      // turn. Mirrors useGeminiStream's `inlineModelOverrideActiveRef`: while
-      // active, skill-tool `modelOverride` writes (including the
+      // turn: while active, skill-tool `modelOverride` writes (including the
       // undefined-clears case) are skipped so they cannot silently revert the
-      // submitted prompt to the session model mid-turn.
+      // submitted prompt to the session model mid-turn. Unlike useGeminiStream's
+      // ref-based `applyModelOverride`/`clearModelOverride` helpers, this is a
+      // run-scoped const — non-interactive mode is single-turn, so there is no
+      // retry-clearing or skill-tool takeover to guard against, just the
+      // within-turn precedence above.
       const inlineModelOverrideActive = inlineModelOverride !== undefined;
       if (inlineModelOverrideActive) {
         debugLogger.debug(

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -844,6 +844,12 @@ export async function runNonInteractive(
       let isFirstTurn = true;
       let hasUnsentToolResponse = false;
       let modelOverride: string | undefined = inlineModelOverride;
+      // An explicit inline `/model <id> <prompt>` override wins for the whole
+      // turn. Mirrors useGeminiStream's `inlineModelOverrideActiveRef`: while
+      // active, skill-tool `modelOverride` writes (including the
+      // undefined-clears case) are skipped so they cannot silently revert the
+      // submitted prompt to the session model mid-turn.
+      const inlineModelOverrideActive = inlineModelOverride !== undefined;
       // Session-scoped because the synthetic `structured_output` tool can
       // be invoked from EITHER the main assistant-turn loop or from a
       // drain-turn (queued notification / cron prompt); whichever fires
@@ -1389,7 +1395,9 @@ export async function runNonInteractive(
             responseParts: toolResponseParts,
             repeatedDuplicateProviderToolCall,
           } = await processToolCallBatch(toolCallRequests, (override) => {
-            modelOverride = override;
+            if (!inlineModelOverrideActive) {
+              modelOverride = override;
+            }
           });
 
           if (structuredSubmission !== undefined) {

--- a/packages/cli/src/nonInteractiveCliCommands.test.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.test.ts
@@ -376,6 +376,58 @@ describe('handleSlashCommand', () => {
     }
   });
 
+  it('passes a submit_prompt modelOverride through to the result', async () => {
+    const mockCommand = {
+      name: 'custom',
+      description: 'Custom command with a per-turn model override',
+      kind: CommandKind.FILE,
+      action: vi.fn().mockResolvedValue({
+        type: 'submit_prompt',
+        content: [{ text: 'Run on the override model' }],
+        modelOverride: 'glm-5.1',
+      }),
+    };
+    mockGetCommands.mockReturnValue([mockCommand]);
+
+    const result = await handleSlashCommand(
+      '/custom',
+      abortController,
+      mockConfig,
+      mockSettings,
+    );
+
+    expect(result.type).toBe('submit_prompt');
+    if (result.type === 'submit_prompt') {
+      expect(result.content).toEqual([{ text: 'Run on the override model' }]);
+      expect(result.modelOverride).toBe('glm-5.1');
+    }
+  });
+
+  it('omits modelOverride when the command does not set one', async () => {
+    const mockCommand = {
+      name: 'custom',
+      description: 'Custom command without a model override',
+      kind: CommandKind.FILE,
+      action: vi.fn().mockResolvedValue({
+        type: 'submit_prompt',
+        content: [{ text: 'Run on the session model' }],
+      }),
+    };
+    mockGetCommands.mockReturnValue([mockCommand]);
+
+    const result = await handleSlashCommand(
+      '/custom',
+      abortController,
+      mockConfig,
+      mockSettings,
+    );
+
+    expect(result.type).toBe('submit_prompt');
+    if (result.type === 'submit_prompt') {
+      expect(result.modelOverride).toBeUndefined();
+    }
+  });
+
   it('records successful SKILL submit_prompt commands in session metrics', async () => {
     const mockSkillCommand = {
       name: 'review',

--- a/packages/cli/src/nonInteractiveCliCommands.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.ts
@@ -61,6 +61,8 @@ export type NonInteractiveSlashCommandResult =
       type: 'submit_prompt';
       content: PartListUnion;
       outputHistoryItems?: HistoryItemWithoutId[];
+      /** Per-turn model id (e.g. inline `/model <id> <prompt>`); no session change. */
+      modelOverride?: string;
     }
   | {
       type: 'message';
@@ -107,6 +109,9 @@ function handleCommandResult(
       return {
         type: 'submit_prompt',
         content: result.content,
+        ...(result.modelOverride
+          ? { modelOverride: result.modelOverride }
+          : {}),
         ...(outputHistoryItems?.length ? { outputHistoryItems } : {}),
       };
 

--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -198,6 +198,111 @@ describe('modelCommand', () => {
     });
   });
 
+  it('runs a trailing prompt on the given model inline without switching or persisting', async () => {
+    const setValue = vi.fn();
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    mockContext = createMockCommandContext({
+      invocation: {
+        raw: '/model qwen-max explain this code',
+        name: 'model',
+        args: 'qwen-max explain this code',
+      },
+      services: {
+        config: {
+          getContentGeneratorConfig: vi.fn().mockReturnValue({
+            model: 'qwen-plus',
+            authType: AuthType.QWEN_OAUTH,
+          }),
+          getAvailableModelsForAuthType: vi
+            .fn()
+            .mockReturnValue([{ id: 'qwen-max', label: 'Qwen Max' }]),
+          switchModel,
+        },
+        settings: createMockSettings(setValue),
+      },
+    });
+
+    const result = await modelCommand.action!(
+      mockContext,
+      'qwen-max explain this code',
+    );
+
+    // Inline override is per-turn: no session switch, no persistence.
+    expect(switchModel).not.toHaveBeenCalled();
+    expect(setValue).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      type: 'submit_prompt',
+      content: 'explain this code',
+      modelOverride: 'qwen-max',
+    });
+  });
+
+  it('rejects an inline prompt when the model id is not available', async () => {
+    const switchModel = vi.fn();
+    mockContext = createMockCommandContext({
+      invocation: {
+        raw: '/model missing-model hello',
+        name: 'model',
+        args: 'missing-model hello',
+      },
+      services: {
+        config: {
+          getContentGeneratorConfig: vi.fn().mockReturnValue({
+            model: 'qwen-plus',
+            authType: AuthType.QWEN_OAUTH,
+          }),
+          switchModel,
+          getAvailableModelsForAuthType: vi.fn().mockReturnValue([]),
+        },
+        settings: createMockSettings(vi.fn()),
+      },
+    });
+
+    const result = await modelCommand.action!(
+      mockContext,
+      'missing-model hello',
+    );
+
+    expect(switchModel).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ type: 'message', messageType: 'error' });
+  });
+
+  it('rejects an inline prompt that targets a different provider', async () => {
+    const switchModel = vi.fn();
+    mockContext = createMockCommandContext({
+      invocation: {
+        raw: '/model gpt-4(openai) hello',
+        name: 'model',
+        args: 'gpt-4(openai) hello',
+      },
+      services: {
+        config: {
+          getContentGeneratorConfig: vi.fn().mockReturnValue({
+            model: 'qwen-plus',
+            authType: AuthType.QWEN_OAUTH,
+          }),
+          switchModel,
+          getAvailableModelsForAuthType: vi
+            .fn()
+            .mockReturnValue([{ id: 'gpt-4', label: 'GPT-4' }]),
+        },
+        settings: createMockSettings(vi.fn()),
+      },
+    });
+
+    const result = await modelCommand.action!(
+      mockContext,
+      'gpt-4(openai) hello',
+    );
+
+    expect(switchModel).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      type: 'message',
+      messageType: 'error',
+      content: expect.stringContaining('different provider'),
+    });
+  });
+
   it('should not persist the model when direct model validation fails', async () => {
     const setValue = vi.fn();
     const switchModel = vi.fn();

--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -303,6 +303,93 @@ describe('modelCommand', () => {
     });
   });
 
+  it('rejects an inline prompt whose model belongs to a same-auth-type provider with a different endpoint/credentials', async () => {
+    const switchModel = vi.fn();
+    mockContext = createMockCommandContext({
+      invocation: {
+        raw: '/model shared-id hello',
+        name: 'model',
+        args: 'shared-id hello',
+      },
+      services: {
+        config: {
+          // Active provider: one OpenAI-compatible endpoint/credential.
+          getContentGeneratorConfig: vi.fn().mockReturnValue({
+            model: 'shared-id',
+            authType: AuthType.USE_OPENAI,
+            baseUrl: 'https://provider-a.example/v1',
+            apiKeyEnvKey: 'PROVIDER_A_KEY',
+          }),
+          switchModel,
+          // Same id + auth type, but a different provider's endpoint/credential.
+          getAvailableModelsForAuthType: vi.fn().mockReturnValue([
+            {
+              id: 'shared-id',
+              label: 'Shared',
+              authType: AuthType.USE_OPENAI,
+              baseUrl: 'https://provider-b.example/v1',
+              envKey: 'PROVIDER_B_KEY',
+            },
+          ]),
+        },
+        settings: createMockSettings(vi.fn()),
+      },
+    });
+
+    const result = await modelCommand.action!(mockContext, 'shared-id hello');
+
+    expect(switchModel).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      type: 'message',
+      messageType: 'error',
+      content: expect.stringContaining('different provider'),
+    });
+  });
+
+  it('runs an inline prompt when the model matches the active provider endpoint/credentials', async () => {
+    const switchModel = vi.fn();
+    mockContext = createMockCommandContext({
+      invocation: {
+        raw: '/model shared-id hello there',
+        name: 'model',
+        args: 'shared-id hello there',
+      },
+      services: {
+        config: {
+          getContentGeneratorConfig: vi.fn().mockReturnValue({
+            model: 'other',
+            authType: AuthType.USE_OPENAI,
+            baseUrl: 'https://provider-a.example/v1',
+            apiKeyEnvKey: 'PROVIDER_A_KEY',
+          }),
+          switchModel,
+          getAvailableModelsForAuthType: vi.fn().mockReturnValue([
+            {
+              id: 'shared-id',
+              label: 'Shared',
+              authType: AuthType.USE_OPENAI,
+              baseUrl: 'https://provider-a.example/v1',
+              envKey: 'PROVIDER_A_KEY',
+            },
+          ]),
+        },
+        settings: createMockSettings(vi.fn()),
+      },
+    });
+
+    const result = await modelCommand.action!(
+      mockContext,
+      'shared-id hello there',
+    );
+
+    expect(switchModel).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      type: 'submit_prompt',
+      content: 'hello there',
+      modelOverride: 'shared-id',
+    });
+  });
+
   it('rejects an inline prompt in ACP mode (no per-turn override pipeline)', async () => {
     const switchModel = vi.fn();
     mockContext = createMockCommandContext({

--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -45,7 +45,7 @@ describe('modelCommand', () => {
   it('should have the correct name and description', () => {
     expect(modelCommand.name).toBe('model');
     expect(modelCommand.description).toBe(
-      'Switch the model for this session (--fast for suggestion model, --voice for voice transcription model, --vision for the vision bridge model, [model-id] to switch immediately).',
+      'Switch the model for this session (--fast for suggestion model, --voice for voice transcription model, --vision for the vision bridge model, [model-id] to switch immediately, or [model-id] [prompt] to run a one-off prompt on another model; the inline prompt is sent verbatim without @file expansion).',
     );
   });
 
@@ -301,6 +301,39 @@ describe('modelCommand', () => {
       messageType: 'error',
       content: expect.stringContaining('different provider'),
     });
+  });
+
+  it('rejects an inline prompt in ACP mode (no per-turn override pipeline)', async () => {
+    const switchModel = vi.fn();
+    mockContext = createMockCommandContext({
+      executionMode: 'acp',
+      invocation: {
+        raw: '/model qwen-max explain this',
+        name: 'model',
+        args: 'qwen-max explain this',
+      },
+      services: {
+        config: {
+          getContentGeneratorConfig: vi.fn().mockReturnValue({
+            model: 'qwen-plus',
+            authType: AuthType.QWEN_OAUTH,
+          }),
+          switchModel,
+          getAvailableModelsForAuthType: vi
+            .fn()
+            .mockReturnValue([{ id: 'qwen-max', label: 'Qwen Max' }]),
+        },
+        settings: createMockSettings(vi.fn()),
+      },
+    });
+
+    const result = await modelCommand.action!(
+      mockContext,
+      'qwen-max explain this',
+    );
+
+    expect(switchModel).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ type: 'message', messageType: 'error' });
   });
 
   it('should not persist the model when direct model validation fails', async () => {

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -22,7 +22,10 @@ import {
   resolveModelId,
 } from '@qwen-code/qwen-code-core';
 import type { LoadedSettings } from '../../config/settings.js';
-import { parseAcpModelOption } from '../../utils/acpModelUtils.js';
+import {
+  isInlineModelOverrideAllowed,
+  parseAcpModelOption,
+} from '../../utils/acpModelUtils.js';
 import {
   formatUnsupportedVoiceModelMessage,
   isSelectableVoiceModel,
@@ -606,23 +609,17 @@ export const modelCommand: SlashCommand = {
         // baseUrl/envKey for a different provider. So the target must resolve to
         // the SAME provider identity, not merely the same auth type — otherwise
         // a same-id model owned by a different (e.g. OpenAI-compatible) provider
-        // would be sent to the active endpoint/account. Reject a different auth
-        // type outright, then within the active auth type require the provider
-        // identity available here (baseUrl + envKey) to match the active content
-        // generator. Mismatches are pointed at the two-step `/model <id>` flow,
-        // which does switch providers.
+        // would be sent to the active endpoint/account. Reject an explicit
+        // different auth type outright (the `(authType)` suffix), then require
+        // the provider identity (baseUrl + envKey) to match the active content
+        // generator via the shared check that consumers also enforce. Mismatches
+        // are pointed at the two-step `/model <id>` flow, which does switch
+        // providers.
         const sameAuthType = targetAuthType === authType;
-        const activeBaseUrl = contentGeneratorConfig.baseUrl;
-        const activeEnvKey = contentGeneratorConfig.apiKeyEnvKey;
-        const target = sameAuthType
-          ? availableModels.find(
-              (m) =>
-                m.id === parsed.modelId &&
-                (m.baseUrl ?? undefined) === (activeBaseUrl ?? undefined) &&
-                (m.envKey ?? undefined) === (activeEnvKey ?? undefined),
-            )
-          : undefined;
-        if (!target) {
+        if (
+          !sameAuthType ||
+          !isInlineModelOverrideAllowed(config, parsed.modelId)
+        ) {
           return {
             type: 'message',
             messageType: 'error',

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -9,6 +9,7 @@ import type {
   CommandContext,
   OpenDialogActionReturn,
   MessageActionReturn,
+  SubmitPromptActionReturn,
 } from './types.js';
 import { CommandKind } from './types.js';
 import { t } from '../../i18n/index.js';
@@ -212,10 +213,10 @@ export const modelCommand: SlashCommand = {
   completionPriority: 100,
   get description() {
     return t(
-      'Switch the model for this session (--fast for suggestion model, --voice for voice transcription model, --vision for the vision bridge model, [model-id] to switch immediately).',
+      'Switch the model for this session (--fast for suggestion model, --voice for voice transcription model, --vision for the vision bridge model, [model-id] to switch immediately, [model-id] [prompt] to run a one-off prompt on another model).',
     );
   },
-  argumentHint: '[--fast|--voice|--vision] [<model-id>]',
+  argumentHint: '[--fast|--voice|--vision] [<model-id>] [<prompt>]',
   kind: CommandKind.BUILT_IN,
   supportedModes: ['interactive', 'non_interactive', 'acp'] as const,
   completion: async (context, partialArg) => {
@@ -267,7 +268,9 @@ export const modelCommand: SlashCommand = {
   action: async (
     context: CommandContext,
     actionArgs: string,
-  ): Promise<OpenDialogActionReturn | MessageActionReturn> => {
+  ): Promise<
+    OpenDialogActionReturn | MessageActionReturn | SubmitPromptActionReturn
+  > => {
     const { services } = context;
     const { config, settings } = services;
 
@@ -555,7 +558,15 @@ export const modelCommand: SlashCommand = {
       };
     }
 
-    const modelName = args.trim().split(/\s+/)[0] ?? '';
+    // `/model <id>` switches the session model; `/model <id> <prompt>` runs the
+    // prompt on <id> for this turn only (inline one-shot override) without
+    // changing or persisting the session model.
+    const trimmedArgs = args.trim();
+    const firstSpace = trimmedArgs.search(/\s/);
+    const modelName =
+      firstSpace === -1 ? trimmedArgs : trimmedArgs.slice(0, firstSpace);
+    const inlinePrompt =
+      firstSpace === -1 ? '' : trimmedArgs.slice(firstSpace + 1).trim();
     if (modelName) {
       if (!settings) {
         return {
@@ -581,6 +592,29 @@ export const modelCommand: SlashCommand = {
           ),
         };
       }
+
+      if (inlinePrompt) {
+        // The per-turn override only changes the model id sent to the active
+        // provider; it cannot rebuild credentials/endpoint, so a model that
+        // resolves to a different auth type can't be run inline. Point the user
+        // at the two-step `/model <id>` flow, which does switch providers.
+        if (parsed.authType && parsed.authType !== authType) {
+          return {
+            type: 'message',
+            messageType: 'error',
+            content: t(
+              "Inline one-shot override can't switch providers. '{{model}}' belongs to a different provider — run '/model {{model}}' first, then send your prompt.",
+              { model: modelName },
+            ),
+          };
+        }
+        return {
+          type: 'submit_prompt',
+          content: inlinePrompt,
+          modelOverride: parsed.modelId,
+        };
+      }
+
       const effectiveModelName = await switchMainModel(
         config,
         settings,

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -568,13 +568,6 @@ export const modelCommand: SlashCommand = {
     const inlinePrompt =
       firstSpace === -1 ? '' : trimmedArgs.slice(firstSpace + 1).trim();
     if (modelName) {
-      if (!settings) {
-        return {
-          type: 'message',
-          messageType: 'error',
-          content: t('Settings service not available.'),
-        };
-      }
       const parsed = parseAcpModelOption(modelName);
       const targetAuthType = parsed.authType ?? authType;
       const availableModels = config
@@ -608,11 +601,28 @@ export const modelCommand: SlashCommand = {
             ),
           };
         }
-        // The per-turn override only changes the model id sent to the active
-        // provider; it cannot rebuild credentials/endpoint, so a model that
-        // resolves to a different auth type can't be run inline. Point the user
-        // at the two-step `/model <id>` flow, which does switch providers.
-        if (parsed.authType && parsed.authType !== authType) {
+        // The per-turn override reuses the active provider's endpoint and
+        // credentials and only swaps the model id; it cannot rebuild
+        // baseUrl/envKey for a different provider. So the target must resolve to
+        // the SAME provider identity, not merely the same auth type — otherwise
+        // a same-id model owned by a different (e.g. OpenAI-compatible) provider
+        // would be sent to the active endpoint/account. Reject a different auth
+        // type outright, then within the active auth type require the provider
+        // identity available here (baseUrl + envKey) to match the active content
+        // generator. Mismatches are pointed at the two-step `/model <id>` flow,
+        // which does switch providers.
+        const sameAuthType = targetAuthType === authType;
+        const activeBaseUrl = contentGeneratorConfig.baseUrl;
+        const activeEnvKey = contentGeneratorConfig.apiKeyEnvKey;
+        const target = sameAuthType
+          ? availableModels.find(
+              (m) =>
+                m.id === parsed.modelId &&
+                (m.baseUrl ?? undefined) === (activeBaseUrl ?? undefined) &&
+                (m.envKey ?? undefined) === (activeEnvKey ?? undefined),
+            )
+          : undefined;
+        if (!target) {
           return {
             type: 'message',
             messageType: 'error',
@@ -629,6 +639,13 @@ export const modelCommand: SlashCommand = {
         };
       }
 
+      if (!settings) {
+        return {
+          type: 'message',
+          messageType: 'error',
+          content: t('Settings service not available.'),
+        };
+      }
       const effectiveModelName = await switchMainModel(
         config,
         settings,

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -213,10 +213,10 @@ export const modelCommand: SlashCommand = {
   completionPriority: 100,
   get description() {
     return t(
-      'Switch the model for this session (--fast for suggestion model, --voice for voice transcription model, --vision for the vision bridge model, [model-id] to switch immediately, [model-id] [prompt] to run a one-off prompt on another model).',
+      'Switch the model for this session (--fast for suggestion model, --voice for voice transcription model, --vision for the vision bridge model, [model-id] to switch immediately, or [model-id] [prompt] to run a one-off prompt on another model; the inline prompt is sent verbatim without @file expansion).',
     );
   },
-  argumentHint: '[--fast|--voice|--vision] [<model-id>] [<prompt>]',
+  argumentHint: '[--fast|--voice|--vision] [<model-id>] | <model-id> <prompt>',
   kind: CommandKind.BUILT_IN,
   supportedModes: ['interactive', 'non_interactive', 'acp'] as const,
   completion: async (context, partialArg) => {
@@ -594,6 +594,20 @@ export const modelCommand: SlashCommand = {
       }
 
       if (inlinePrompt) {
+        // ACP hosts send the prompt on the session model via a separate
+        // pipeline that doesn't thread a per-turn override, so the inline form
+        // would silently run on the default model. Reject it there rather than
+        // mislead; the two-step `/model <id>` flow still works in ACP.
+        if (context.executionMode === 'acp') {
+          return {
+            type: 'message',
+            messageType: 'error',
+            content: t(
+              "Inline one-shot override isn't supported in this mode — run '/model {{model}}' first, then send your prompt.",
+              { model: modelName },
+            ),
+          };
+        }
         // The per-turn override only changes the model id sent to the active
         // provider; it cannot rebuild credentials/endpoint, so a model that
         // resolves to a different auth type can't be run inline. Point the user

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -217,6 +217,13 @@ export interface SubmitPromptActionReturn {
   content: PartListUnion;
   /** Optional callback invoked after the agent turn completes successfully. */
   onComplete?: () => Promise<void>;
+  /**
+   * Optional per-turn model id. When set, this prompt (and any tool-call
+   * continuations it spawns) runs on the given model without changing the
+   * session's selected model or persisting anything; it auto-reverts on the
+   * next user turn.
+   */
+  modelOverride?: string;
 }
 
 /**

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -963,6 +963,7 @@ export const useSlashCommandProcessor = (
                     type: 'submit_prompt',
                     content,
                     onComplete: result.onComplete,
+                    modelOverride: result.modelOverride,
                   };
                 }
                 case 'confirm_shell_commands': {

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -5277,6 +5277,166 @@ describe('useGeminiStream', () => {
         );
       });
     });
+
+    describe('inline model override', () => {
+      // Make the active provider expose `inline-model` so the consumer-side
+      // provider-identity validation accepts the override.
+      const allowInlineModel = (modelId = 'inline-model') => {
+        mockConfig.getModel = vi.fn(() => 'session-model');
+        mockConfig.getContentGeneratorConfig = vi.fn(
+          () => ({ authType: AuthType.QWEN_OAUTH }) as never,
+        );
+        mockConfig.getAvailableModelsForAuthType = vi.fn(
+          () => [{ id: modelId, authType: AuthType.QWEN_OAUTH }] as never,
+        );
+      };
+
+      it('does not let a skill tool with modelOverride: undefined clobber an active inline override', async () => {
+        allowInlineModel();
+        mockHandleSlashCommand.mockResolvedValue({
+          type: 'submit_prompt',
+          content: 'do the thing',
+          modelOverride: 'inline-model',
+        });
+
+        let capturedOnComplete:
+          | ((completedTools: TrackedToolCall[]) => Promise<void>)
+          | null = null;
+        mockUseReactToolScheduler.mockImplementation((onComplete) => {
+          capturedOnComplete = onComplete;
+          return [
+            [],
+            mockScheduleToolCalls,
+            mockCancelAllToolCalls,
+            mockMarkToolsAsSubmitted,
+          ];
+        });
+
+        const { result } = renderHook(() =>
+          useGeminiStream(
+            new MockedGeminiClientClass(mockConfig),
+            [],
+            mockAddItem,
+            mockConfig,
+            true,
+            mockLoadedSettings,
+            mockOnDebugMessage,
+            mockHandleSlashCommand,
+            false,
+            () => 'vscode' as EditorType,
+            () => {},
+            () => Promise.resolve(),
+            false,
+            () => {},
+            () => {},
+            () => {},
+            () => {},
+            80,
+            24,
+          ),
+        );
+
+        // Turn 1: the inline override is set and used for the first call.
+        await act(async () => {
+          await result.current.submitQuery('/model inline-model do the thing');
+        });
+        await waitFor(() => expect(mockSendMessageStream).toHaveBeenCalled());
+        expect(mockSendMessageStream.mock.calls[0][3]).toMatchObject({
+          modelOverride: 'inline-model',
+        });
+
+        mockSendMessageStream.mockClear();
+
+        // A skill tool completes with `modelOverride: undefined` (an
+        // inherit/no-model skill). The undefined-clears write must be skipped
+        // while the inline override is active, so the continuation still runs
+        // on the inline model rather than reverting to the session model.
+        const completedToolCalls: TrackedToolCall[] = [
+          {
+            request: {
+              callId: 'skill-call',
+              name: 'pdf-skill',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: 'prompt-id-skill',
+            },
+            status: 'success',
+            responseSubmittedToGemini: false,
+            response: {
+              callId: 'skill-call',
+              responseParts: [{ text: 'skill loaded' }],
+              errorType: undefined,
+              modelOverride: undefined,
+            },
+            tool: {
+              name: 'pdf-skill',
+              displayName: 'pdf-skill',
+              description: 'd',
+              build: vi.fn(),
+            } as never,
+            invocation: {
+              getDescription: () => 'desc',
+            } as unknown as AnyToolInvocation,
+            startTime: Date.now(),
+            endTime: Date.now(),
+          } as TrackedCompletedToolCall,
+        ];
+
+        await act(async () => {
+          await capturedOnComplete?.(completedToolCalls);
+        });
+
+        await waitFor(() => expect(mockSendMessageStream).toHaveBeenCalled());
+        expect(mockSendMessageStream.mock.calls[0][3]).toMatchObject({
+          type: SendMessageType.ToolResult,
+          modelOverride: 'inline-model',
+        });
+      });
+
+      it('clears the inline override on retry and reverts to the session model', async () => {
+        allowInlineModel();
+        mockHandleSlashCommand.mockResolvedValue({
+          type: 'submit_prompt',
+          content: 'do the thing',
+          modelOverride: 'inline-model',
+        });
+
+        const { result } = renderTestHook();
+
+        // Turn 1: inline override applied.
+        await act(async () => {
+          await result.current.submitQuery('/model inline-model do the thing');
+        });
+        await waitFor(() => expect(mockSendMessageStream).toHaveBeenCalled());
+        expect(mockSendMessageStream.mock.calls[0][3]).toMatchObject({
+          modelOverride: 'inline-model',
+        });
+
+        mockSendMessageStream.mockClear();
+        mockAddItem.mockClear();
+
+        // Retry re-sends the same prompt; the one-shot override is dropped and
+        // the turn reverts to the session model, with an info item explaining
+        // the switch.
+        await act(async () => {
+          await result.current.submitQuery(
+            'do the thing',
+            SendMessageType.Retry,
+          );
+        });
+        await waitFor(() => expect(mockSendMessageStream).toHaveBeenCalled());
+        expect(
+          mockSendMessageStream.mock.calls[0][3].modelOverride,
+        ).toBeUndefined();
+        expect(mockAddItem).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'info',
+            text: expect.stringContaining('session model'),
+          }),
+          expect.any(Number),
+        );
+      });
+    });
   });
 
   describe('Memory Refresh on save_memory', () => {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -106,6 +106,35 @@ import { recordGoalStatusItem } from '../utils/restoreGoal.js';
 import process from 'node:process';
 
 const debugLogger = createDebugLogger('GEMINI_STREAM');
+
+// The per-turn model override is held in two coupled refs: the model id and a
+// flag marking whether it came from an explicit inline `/model <id> <prompt>`
+// (which must win over skill-tool overrides for the rest of the turn). The two
+// always move together; these helpers are the single place that writes both so
+// the invariant (inline flag true => model id set) can't be broken by editing
+// one ref in isolation, and every set/clear is traceable via debug logs.
+function applyModelOverride(
+  modelOverrideRef: { current: string | undefined },
+  inlineActiveRef: { current: boolean },
+  value: string | undefined,
+  isInline: boolean,
+): void {
+  modelOverrideRef.current = value;
+  inlineActiveRef.current = isInline;
+  debugLogger.debug(
+    `model override ${
+      value === undefined ? 'cleared' : `set to ${value}`
+    } (inline=${isInline})`,
+  );
+}
+
+function clearModelOverride(
+  modelOverrideRef: { current: string | undefined },
+  inlineActiveRef: { current: boolean },
+): void {
+  applyModelOverride(modelOverrideRef, inlineActiveRef, undefined, false);
+}
+
 const MID_TURN_AT_COMMAND_RESOLVE_TIMEOUT_MS = 10_000;
 const MID_TURN_AT_COMMAND_RESOLVE_TIMEOUT_MESSAGE =
   'Mid-turn @ command resolution timed out';
@@ -999,8 +1028,12 @@ export const useGeminiStream = (
               // skipped for ToolResult/Retry — persists across the tool loop,
               // then clears on the next user turn.
               if (slashCommandResult.modelOverride) {
-                modelOverrideRef.current = slashCommandResult.modelOverride;
-                inlineModelOverrideActiveRef.current = true;
+                applyModelOverride(
+                  modelOverrideRef,
+                  inlineModelOverrideActiveRef,
+                  slashCommandResult.modelOverride,
+                  true,
+                );
               }
 
               return {
@@ -2182,12 +2215,26 @@ export const useGeminiStream = (
         // explicit inline `/model <id> <prompt>` override: that is a one-off
         // for the original prompt, so a retry reverts to the session model and
         // lets skill-tool overrides apply again.
+        const droppingInlineOverrideOnRetry =
+          submitType === SendMessageType.Retry &&
+          inlineModelOverrideActiveRef.current;
         if (
           submitType !== SendMessageType.Retry ||
           inlineModelOverrideActiveRef.current
         ) {
-          modelOverrideRef.current = undefined;
-          inlineModelOverrideActiveRef.current = false;
+          // The retry re-sends the same prompt on the session model, which may
+          // differ from the one-shot override. Tell the user so the model
+          // switch isn't silent.
+          if (droppingInlineOverrideOnRetry) {
+            addItem(
+              {
+                type: 'info',
+                text: `Inline model override cleared on retry — retrying on the session model (${config.getModel()}).`,
+              },
+              userMessageTimestamp,
+            );
+          }
+          clearModelOverride(modelOverrideRef, inlineModelOverrideActiveRef);
         }
         // Commit any pending retry error to history (without hint) since the
         // user is starting a new conversation turn.
@@ -2276,6 +2323,7 @@ export const useGeminiStream = (
                 prompt_id,
                 config.getContentGeneratorConfig()?.authType,
                 queryToSend,
+                modelOverrideRef.current ?? config.getModel(),
               ),
             );
           }
@@ -2769,11 +2817,21 @@ export const useGeminiStream = (
       // turn, so skip skill-tool writes (including the undefined-clears case)
       // while it is active.
       for (const toolCall of geminiTools) {
-        if (
-          !inlineModelOverrideActiveRef.current &&
-          'modelOverride' in toolCall.response
-        ) {
-          modelOverrideRef.current = toolCall.response.modelOverride;
+        if ('modelOverride' in toolCall.response) {
+          if (inlineModelOverrideActiveRef.current) {
+            debugLogger.debug(
+              `skill-tool model override (${String(
+                toolCall.response.modelOverride,
+              )}) blocked: inline override active`,
+            );
+          } else {
+            applyModelOverride(
+              modelOverrideRef,
+              inlineModelOverrideActiveRef,
+              toolCall.response.modelOverride,
+              false,
+            );
+          }
         }
       }
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -2176,9 +2176,15 @@ export const useGeminiStream = (
         !allowConcurrentBtwDuringResponse
       ) {
         setModelSwitchedFromQuotaError(false);
-        // Clear model override for new user turns, but preserve it on retry
-        // so the same skill-selected model is used again.
+        // Clear model override for new user turns. On retry, preserve a
+        // skill-selected override so the same model is used again, but drop an
+        // explicit inline `/model <id> <prompt>` override: that is a one-off
+        // for the original prompt, so a retry reverts to the session model and
+        // lets skill-tool overrides apply again.
         if (submitType !== SendMessageType.Retry) {
+          modelOverrideRef.current = undefined;
+          inlineModelOverrideActiveRef.current = false;
+        } else if (inlineModelOverrideActiveRef.current) {
           modelOverrideRef.current = undefined;
           inlineModelOverrideActiveRef.current = false;
         }

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -86,6 +86,7 @@ import {
 import { findLastSafeSplitPoint } from '../utils/markdownUtilities.js';
 import { useStateAndRef } from './useStateAndRef.js';
 import { prefixMidTurnUserMessageParts } from '../../utils/midTurnUserMessage.js';
+import { isInlineModelOverrideAllowed } from '../../utils/acpModelUtils.js';
 import type { UseHistoryManagerReturn } from './useHistoryManager.js';
 import {
   useReactToolScheduler,
@@ -1026,14 +1027,28 @@ export const useGeminiStream = (
               // Runs after the new-user-turn reset above and before the stream
               // is sent, so it applies to this turn and — because the reset is
               // skipped for ToolResult/Retry — persists across the tool loop,
-              // then clears on the next user turn.
+              // then clears on the next user turn. Re-validate provider identity
+              // here rather than trust the producer: any slash command can set
+              // `modelOverride`, so the consumer enforces that it names a model
+              // on the active provider before redirecting API calls to it.
               if (slashCommandResult.modelOverride) {
-                applyModelOverride(
-                  modelOverrideRef,
-                  inlineModelOverrideActiveRef,
-                  slashCommandResult.modelOverride,
-                  true,
-                );
+                if (
+                  isInlineModelOverrideAllowed(
+                    config,
+                    slashCommandResult.modelOverride,
+                  )
+                ) {
+                  applyModelOverride(
+                    modelOverrideRef,
+                    inlineModelOverrideActiveRef,
+                    slashCommandResult.modelOverride,
+                    true,
+                  );
+                } else {
+                  debugLogger.warn(
+                    `ignoring model override '${slashCommandResult.modelOverride}': not a model on the active provider`,
+                  );
+                }
               }
 
               return {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -989,6 +989,14 @@ export const useGeminiStream = (
               localQueryToSendToGemini = slashCommandResult.content;
               submitPromptOnCompleteRef.current =
                 slashCommandResult.onComplete ?? null;
+              // Per-turn model override (e.g. inline `/model <id> <prompt>`).
+              // Runs after the new-user-turn reset above and before the stream
+              // is sent, so it applies to this turn and — because the reset is
+              // skipped for ToolResult/Retry — persists across the tool loop,
+              // then clears on the next user turn.
+              if (slashCommandResult.modelOverride) {
+                modelOverrideRef.current = slashCommandResult.modelOverride;
+              }
 
               return {
                 queryToSend: localQueryToSendToGemini,

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -795,7 +795,7 @@ export const useGeminiStream = (
     // Log API cancellation
     const prompt_id = config.getSessionId() + '########' + getPromptCount();
     const cancellationEvent = new ApiCancelEvent(
-      config.getModel(),
+      modelOverrideRef.current ?? config.getModel(),
       prompt_id,
       config.getContentGeneratorConfig()?.authType,
       loopWakeupsCancelled > 0 ? loopWakeupsCancelled : undefined,
@@ -1534,10 +1534,11 @@ export const useGeminiStream = (
         commitItem(pendingHistoryItemRef.current, userMessageTimestamp);
         setPendingHistoryItem(null);
       }
+      const activeModel = modelOverrideRef.current ?? config.getModel();
       const reasonClause =
         eventValue?.triggerReason === 'image_overflow'
-          ? `accumulated enough tool screenshots to trigger compaction for ${config.getModel()}`
-          : `approached the input token limit for ${config.getModel()}`;
+          ? `accumulated enough tool screenshots to trigger compaction for ${activeModel}`
+          : `approached the input token limit for ${activeModel}`;
       return addItem(
         {
           type: 'info',
@@ -2181,10 +2182,10 @@ export const useGeminiStream = (
         // explicit inline `/model <id> <prompt>` override: that is a one-off
         // for the original prompt, so a retry reverts to the session model and
         // lets skill-tool overrides apply again.
-        if (submitType !== SendMessageType.Retry) {
-          modelOverrideRef.current = undefined;
-          inlineModelOverrideActiveRef.current = false;
-        } else if (inlineModelOverrideActiveRef.current) {
+        if (
+          submitType !== SendMessageType.Retry ||
+          inlineModelOverrideActiveRef.current
+        ) {
           modelOverrideRef.current = undefined;
           inlineModelOverrideActiveRef.current = false;
         }

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -501,6 +501,10 @@ export const useGeminiStream = (
   const processedMemoryToolsRef = useRef<Set<string>>(new Set());
   const submitPromptOnCompleteRef = useRef<(() => Promise<void>) | null>(null);
   const modelOverrideRef = useRef<string | undefined>(undefined);
+  // True when the current turn's model override came from an explicit inline
+  // `/model <id> <prompt>`. Skill-tool overrides must not clobber a user's
+  // explicit choice mid-turn, so this takes precedence until the next user turn.
+  const inlineModelOverrideActiveRef = useRef<boolean>(false);
   const handledProviderToolCallIdsRef = useRef<Set<string>>(new Set());
   // Scoped to a top-level submit and cleared below before a new user prompt.
   // Repeated duplicate provider ids within that submit are terminal/drop-only.
@@ -996,6 +1000,7 @@ export const useGeminiStream = (
               // then clears on the next user turn.
               if (slashCommandResult.modelOverride) {
                 modelOverrideRef.current = slashCommandResult.modelOverride;
+                inlineModelOverrideActiveRef.current = true;
               }
 
               return {
@@ -2175,6 +2180,7 @@ export const useGeminiStream = (
         // so the same skill-selected model is used again.
         if (submitType !== SendMessageType.Retry) {
           modelOverrideRef.current = undefined;
+          inlineModelOverrideActiveRef.current = false;
         }
         // Commit any pending retry error to history (without hint) since the
         // user is starting a new conversation turn.
@@ -2752,8 +2758,14 @@ export const useGeminiStream = (
       // Persist model override from skill tool results (last one wins).
       // Uses `in` so that undefined (from inherit/no-model skills) clears a
       // prior override, while non-skill tools (field absent) leave it intact.
+      // An explicit inline `/model <id> <prompt>` override wins for the whole
+      // turn, so skip skill-tool writes (including the undefined-clears case)
+      // while it is active.
       for (const toolCall of geminiTools) {
-        if ('modelOverride' in toolCall.response) {
+        if (
+          !inlineModelOverrideActiveRef.current &&
+          'modelOverride' in toolCall.response
+        ) {
           modelOverrideRef.current = toolCall.response.modelOverride;
         }
       }

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -782,6 +782,11 @@ export interface SubmitPromptResult {
   content: PartListUnion;
   /** Optional callback invoked after the agent turn completes successfully. */
   onComplete?: () => Promise<void>;
+  /**
+   * Optional per-turn model id. Applies to this submitted prompt (and its
+   * tool-call continuations) only — no session change, no persistence.
+   */
+  modelOverride?: string;
 }
 
 /**

--- a/packages/cli/src/utils/acpModelUtils.test.ts
+++ b/packages/cli/src/utils/acpModelUtils.test.ts
@@ -5,9 +5,10 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { AuthType } from '@qwen-code/qwen-code-core';
+import { AuthType, type Config } from '@qwen-code/qwen-code-core';
 import {
   formatAcpModelId,
+  isInlineModelOverrideAllowed,
   parseAcpBaseModelId,
   parseAcpModelOption,
   sanitizeProviderBaseUrl,
@@ -62,5 +63,101 @@ describe('acpModelUtils', () => {
     ['https://user:secret@api.example', 'https://api.example'],
   ])('sanitizes provider base URL credentials for %s', (input, expected) => {
     expect(sanitizeProviderBaseUrl(input)).toBe(expected);
+  });
+
+  describe('isInlineModelOverrideAllowed', () => {
+    const makeConfig = (
+      contentGeneratorConfig: unknown,
+      available: unknown[],
+    ): Config =>
+      ({
+        getContentGeneratorConfig: () => contentGeneratorConfig,
+        getAvailableModelsForAuthType: () => available,
+      }) as unknown as Config;
+
+    it('allows a model that matches the active provider identity', () => {
+      const config = makeConfig(
+        {
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://provider-a.example/v1',
+          apiKeyEnvKey: 'PROVIDER_A_KEY',
+        },
+        [
+          {
+            id: 'shared-id',
+            authType: AuthType.USE_OPENAI,
+            baseUrl: 'https://provider-a.example/v1',
+            envKey: 'PROVIDER_A_KEY',
+          },
+        ],
+      );
+      expect(isInlineModelOverrideAllowed(config, 'shared-id')).toBe(true);
+    });
+
+    it('allows a model when both sides have no baseUrl/envKey (e.g. qwen-oauth)', () => {
+      const config = makeConfig({ authType: AuthType.QWEN_OAUTH }, [
+        { id: 'qwen-max', authType: AuthType.QWEN_OAUTH },
+      ]);
+      expect(isInlineModelOverrideAllowed(config, 'qwen-max')).toBe(true);
+    });
+
+    it('rejects a same-id model with a different baseUrl', () => {
+      const config = makeConfig(
+        {
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://provider-a.example/v1',
+          apiKeyEnvKey: 'PROVIDER_A_KEY',
+        },
+        [
+          {
+            id: 'shared-id',
+            authType: AuthType.USE_OPENAI,
+            baseUrl: 'https://provider-b.example/v1',
+            envKey: 'PROVIDER_A_KEY',
+          },
+        ],
+      );
+      expect(isInlineModelOverrideAllowed(config, 'shared-id')).toBe(false);
+    });
+
+    it('rejects a same-id model with a different credential env key', () => {
+      const config = makeConfig(
+        {
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://provider-a.example/v1',
+          apiKeyEnvKey: 'PROVIDER_A_KEY',
+        },
+        [
+          {
+            id: 'shared-id',
+            authType: AuthType.USE_OPENAI,
+            baseUrl: 'https://provider-a.example/v1',
+            envKey: 'PROVIDER_B_KEY',
+          },
+        ],
+      );
+      expect(isInlineModelOverrideAllowed(config, 'shared-id')).toBe(false);
+    });
+
+    it('rejects an unknown model id', () => {
+      const config = makeConfig({ authType: AuthType.QWEN_OAUTH }, [
+        { id: 'qwen-max', authType: AuthType.QWEN_OAUTH },
+      ]);
+      expect(isInlineModelOverrideAllowed(config, 'missing')).toBe(false);
+    });
+
+    it('does not match fast-only or voice-only models', () => {
+      const config = makeConfig({ authType: AuthType.QWEN_OAUTH }, [
+        { id: 'qwen-fast', authType: AuthType.QWEN_OAUTH, fastOnly: true },
+        { id: 'qwen-voice', authType: AuthType.QWEN_OAUTH, voiceOnly: true },
+      ]);
+      expect(isInlineModelOverrideAllowed(config, 'qwen-fast')).toBe(false);
+      expect(isInlineModelOverrideAllowed(config, 'qwen-voice')).toBe(false);
+    });
+
+    it('rejects when no active auth type is available', () => {
+      const config = makeConfig(undefined, []);
+      expect(isInlineModelOverrideAllowed(config, 'anything')).toBe(false);
+    });
   });
 });

--- a/packages/cli/src/utils/acpModelUtils.ts
+++ b/packages/cli/src/utils/acpModelUtils.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AuthType } from '@qwen-code/qwen-code-core';
+import { AuthType, type Config } from '@qwen-code/qwen-code-core';
 import { z } from 'zod';
 
 /**
@@ -132,4 +132,39 @@ export function parseAcpModelOption(input: string): {
     }
   }
   return { modelId: trimmed };
+}
+
+/**
+ * Whether a bare `modelId` resolves to the SAME provider identity as the active
+ * content generator — same auth type, base URL, and credential env key.
+ *
+ * A per-turn inline `modelOverride` reuses the active provider's endpoint and
+ * credentials and only swaps the model id; it cannot rebuild baseUrl/envKey for
+ * a different provider. Any consumer that applies a `submit_prompt` result's
+ * `modelOverride` must gate on this so an override naming a same-id model owned
+ * by a different provider (or a different auth type) is never silently sent to
+ * the active endpoint/account — even if a future (or untrusted) slash command
+ * produces the override instead of the validated `/model` command. `modelId` is
+ * the bare id without any `(authType)` suffix.
+ */
+export function isInlineModelOverrideAllowed(
+  config: Config,
+  modelId: string,
+): boolean {
+  const contentGeneratorConfig = config.getContentGeneratorConfig();
+  const authType = contentGeneratorConfig?.authType;
+  if (!authType) {
+    return false;
+  }
+  const activeBaseUrl = contentGeneratorConfig.baseUrl;
+  const activeEnvKey = contentGeneratorConfig.apiKeyEnvKey;
+  return config
+    .getAvailableModelsForAuthType(authType)
+    .filter((m) => !m.fastOnly && !m.voiceOnly)
+    .some(
+      (m) =>
+        m.id === modelId &&
+        (m.baseUrl ?? undefined) === (activeBaseUrl ?? undefined) &&
+        (m.envKey ?? undefined) === (activeEnvKey ?? undefined),
+    );
 }

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -254,6 +254,32 @@ describe('loggers', () => {
       });
     });
 
+    it('should include the model attribute when set (e.g. inline override)', () => {
+      const event = new UserPromptEvent(
+        11,
+        'prompt-id-model',
+        AuthType.USE_OPENAI,
+        'test-prompt',
+        'qwen-max',
+      );
+
+      logUserPrompt(mockConfig, event);
+
+      expect(mockLogger.emit).toHaveBeenCalledWith({
+        body: 'User prompt. Length: 11.',
+        attributes: {
+          'session.id': 'test-session-id',
+          'event.name': EVENT_USER_PROMPT,
+          'event.timestamp': '2025-01-01T00:00:00.000Z',
+          prompt_length: 11,
+          prompt: 'test-prompt',
+          prompt_id: 'prompt-id-model',
+          auth_type: 'openai',
+          model: 'qwen-max',
+        },
+      });
+    });
+
     it('should not log prompt if disabled', () => {
       const mockConfig = {
         getSessionId: () => 'test-session-id',

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -195,6 +195,10 @@ export function logUserPrompt(config: Config, event: UserPromptEvent): void {
     attributes['auth_type'] = event.auth_type;
   }
 
+  if (event.model) {
+    attributes['model'] = event.model;
+  }
+
   if (shouldLogUserPrompts(config)) {
     attributes['prompt'] = event.prompt;
   }

--- a/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
+++ b/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
@@ -487,6 +487,7 @@ export class QwenLogger {
       properties: {
         prompt_id: event.prompt_id,
         prompt_length: event.prompt_length,
+        ...(event.model ? { model: event.model } : {}),
       },
     });
 

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -139,12 +139,15 @@ export class UserPromptEvent implements BaseTelemetryEvent {
   prompt_id: string;
   auth_type?: string;
   prompt?: string;
+  /** Model that actually processed the prompt (e.g. an inline override). */
+  model?: string;
 
   constructor(
     prompt_length: number,
     prompt_Id: string,
     auth_type?: string,
     prompt?: string,
+    model?: string,
   ) {
     this['event.name'] = 'user_prompt';
     this['event.timestamp'] = new Date().toISOString();
@@ -152,6 +155,7 @@ export class UserPromptEvent implements BaseTelemetryEvent {
     this.prompt_id = prompt_Id;
     this.auth_type = auth_type;
     this.prompt = prompt;
+    this.model = model;
   }
 }
 


### PR DESCRIPTION
## What this PR does

Adds an inline one-shot model override to the `/model` command: `/model <model-id> <prompt>` runs the trailing prompt on `<model-id>` for a single turn (including any tool-call continuations it spawns), then automatically reverts to the session's selected model on the next user turn. `/model <model-id>` with no trailing prompt keeps its existing "switch the session model" behavior unchanged. Works in both interactive and non-interactive modes.

## Why it's needed

Resolves #5967. Using a specialist model once currently takes three steps (switch → prompt → switch back). This collapses it into one line and reverts automatically, without touching the session default or persisting anything.

The implementation deliberately avoids a `switchModel()` + revert design. The only post-turn hook (`onComplete`) fires only on clean completion — it is nulled without running on user cancel and on error — so a revert-based approach would leave the session stuck on the temporary model after Ctrl+C or an API error. It would also revert too early for prompts that trigger tool calls, since those span multiple `submitQuery` cycles. Instead the prompt is submitted with a per-turn `modelOverride` (the same primitive skill tools already use): it is preserved across the tool-call loop and cleared on the next genuine user turn, giving correct one-shot semantics with no revert logic and no stuck-model failure modes.

## Reviewer Test Plan

### How to verify

In an interactive session with at least two models configured under the current provider:

1. Note the active model (`/model` shows it).
2. Run `/model <other-model-id> say which model you are` — the prompt runs on `<other-model-id>`; the session model is unchanged and settings are not written.
3. Send any normal prompt next — it runs on the original model (override auto-reverted).
4. `/model <other-model-id>` with no trailing prompt still switches the session model as before.
5. `/model <bogus-id> hi` → error listing available models; no switch.
6. `/model <id-from-another-provider> hi` → error pointing to the two-step `/model <id>` flow; no switch.

Unit tests cover the submit_prompt shape, the no-switch/no-persist guarantee, invalid id, and cross-provider rejection (`packages/cli/src/ui/commands/modelCommand.test.ts`). Existing `nonInteractiveCli` / `nonInteractiveCliCommands` suites pass.

### Evidence (Before & After)

Verified locally in non-interactive mode against a provider with multiple models (session default `qwen3.7-max`), using the OpenAI request logger (`model.enableOpenAILogging`) to capture the actual outgoing request `model`:

| Run | Outgoing request `model` | Persisted default after run |
| --- | --- | --- |
| `qwen -p "/model glm-5.1 reply with exactly: PONG"` (override) | **`glm-5.1`** on the foreground turn; background memory-extractor subagent stayed on `qwen3.7-max` | unchanged (`qwen3.7-max`) |
| `qwen -p "reply with exactly: PONG"` (baseline) | `qwen3.7-max` | unchanged (`qwen3.7-max`) |

So the override applies to the one-shot turn only, does not leak into background subagents, and does not mutate or persist the session model.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local: `npm run bundle` + `node scripts/cli-entry.js` (non-interactive), unit tests (`vitest`), `npm run build`, `npm run typecheck`.

## Risk & Scope

- Main risk or tradeoff: inline override applies only to the current provider; it changes the model id sent to the active content generator but does not rebuild credentials/endpoint.
- Not validated / out of scope: cross-provider inline override (rejected with a clear hint in v1); interactive TUI before/after capture (the non-interactive request-log evidence above exercises the same `submit_prompt` + `modelOverride` path).
- Breaking changes / migration notes: none. No-prompt `/model <id>` behavior is unchanged; the new `modelOverride` field on the submit_prompt result is optional.

## Linked Issues

Closes #5967

> Draft: opening to align with maintainers on the v1 scope decision (same-provider only) before finalizing. See the issue thread for the rationale.
