### PR TITLE
fix(core): Allow subagents to exit plan mode

### DIFF
--- a/packages/core/src/tools/agent/agent-override.test.ts
+++ b/packages/core/src/tools/agent/agent-override.test.ts
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Config, ApprovalMode } from '../../config/config.js';
+import { isPlanModeBlocked } from '../../core/permissionFlow.js';
+import type { ToolCallConfirmationDetails } from '../tools.js';
 import {
   createApprovalModeOverride,
   hasRebuiltToolRegistry,
@@ -41,6 +43,27 @@ describe('createApprovalModeOverride bound-tool isolation', () => {
     usageStatisticsEnabled: false,
     bareMode: true,
   };
+
+  async function createParentWithRegistry(): Promise<Config> {
+    const parent = new Config(baseParams);
+    const parentRegistry = await parent.createToolRegistry(undefined, {
+      skipDiscovery: true,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (parent as any).toolRegistry = parentRegistry;
+    return parent;
+  }
+
+  function attachFakePermissionManager(parent: Config) {
+    const stripDangerousRulesForAutoMode = vi.fn();
+    const restoreDangerousRules = vi.fn();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (parent as any).permissionManager = {
+      stripDangerousRulesForAutoMode,
+      restoreDangerousRules,
+    };
+    return { stripDangerousRulesForAutoMode, restoreDangerousRules };
+  }
 
   it('returns a Config whose registry is a distinct instance from the parent', async () => {
     const parent = new Config(baseParams);
@@ -150,6 +173,131 @@ describe('createApprovalModeOverride bound-tool isolation', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const boundConfig = (childEdit as any).config as Config;
     expect(boundConfig.getApprovalMode()).toBe(ApprovalMode.YOLO);
+  });
+
+  it('lets a plan-mode override leave plan mode without changing the parent', async () => {
+    const parent = await createParentWithRegistry();
+
+    const { config: child } = await createApprovalModeOverride(
+      parent,
+      ApprovalMode.PLAN,
+    );
+
+    expect(child.getApprovalMode()).toBe(ApprovalMode.PLAN);
+
+    child.setApprovalMode(ApprovalMode.DEFAULT);
+
+    expect(child.getApprovalMode()).toBe(ApprovalMode.DEFAULT);
+    expect(parent.getApprovalMode()).toBe(ApprovalMode.DEFAULT);
+  });
+
+  it('stops plan-mode blocking exec tools after a child override exits plan mode', async () => {
+    const parent = await createParentWithRegistry();
+
+    const { config: child } = await createApprovalModeOverride(
+      parent,
+      ApprovalMode.PLAN,
+    );
+
+    child.setApprovalMode(ApprovalMode.DEFAULT);
+
+    const execDetails = {
+      type: 'exec',
+    } as unknown as ToolCallConfirmationDetails;
+    const isPlanMode = child.getApprovalMode() === ApprovalMode.PLAN;
+
+    expect(isPlanModeBlocked(isPlanMode, false, false, execDetails)).toBe(
+      false,
+    );
+  });
+
+  it('isolates child plan state from a parent that is already in plan mode', async () => {
+    const parent = await createParentWithRegistry();
+    vi.spyOn(parent, 'isTrustedFolder').mockReturnValue(true);
+    parent.setApprovalMode(ApprovalMode.YOLO);
+    parent.setApprovalMode(ApprovalMode.PLAN, { enteredByModel: true });
+
+    const parentGateState = parent.getPlanGateState();
+    expect(parent.getPrePlanMode()).toBe(ApprovalMode.YOLO);
+    expect(parentGateState?.enteredByModel).toBe(true);
+
+    const { config: child } = await createApprovalModeOverride(
+      parent,
+      ApprovalMode.PLAN,
+    );
+
+    expect(child.getPrePlanMode()).toBe(ApprovalMode.YOLO);
+
+    child.setApprovalMode(ApprovalMode.DEFAULT);
+
+    expect(child.getApprovalMode()).toBe(ApprovalMode.DEFAULT);
+    expect(parent.getApprovalMode()).toBe(ApprovalMode.PLAN);
+    expect(parent.getPlanGateState()).toBe(parentGateState);
+  });
+
+  it('uses the parent current mode as pre-plan mode when a non-plan parent creates a plan child', async () => {
+    const parent = await createParentWithRegistry();
+    vi.spyOn(parent, 'isTrustedFolder').mockReturnValue(true);
+    parent.setApprovalMode(ApprovalMode.AUTO_EDIT);
+
+    const { config: child } = await createApprovalModeOverride(
+      parent,
+      ApprovalMode.PLAN,
+    );
+
+    expect(child.getPrePlanMode()).toBe(ApprovalMode.AUTO_EDIT);
+  });
+
+  it('restores AUTO rules when an AUTO child finishes still in AUTO mode', async () => {
+    const parent = await createParentWithRegistry();
+    const { stripDangerousRulesForAutoMode, restoreDangerousRules } =
+      attachFakePermissionManager(parent);
+
+    const { cleanup } = await createApprovalModeOverride(
+      parent,
+      ApprovalMode.AUTO,
+    );
+
+    expect(stripDangerousRulesForAutoMode).toHaveBeenCalledTimes(1);
+
+    cleanup();
+    expect(restoreDangerousRules).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not need cleanup restore after a child leaves AUTO mode itself', async () => {
+    const parent = await createParentWithRegistry();
+    const { stripDangerousRulesForAutoMode, restoreDangerousRules } =
+      attachFakePermissionManager(parent);
+
+    const { config: child, cleanup } = await createApprovalModeOverride(
+      parent,
+      ApprovalMode.AUTO,
+    );
+
+    expect(stripDangerousRulesForAutoMode).toHaveBeenCalledTimes(1);
+
+    child.setApprovalMode(ApprovalMode.DEFAULT);
+    expect(restoreDangerousRules).toHaveBeenCalledTimes(1);
+
+    cleanup();
+    expect(restoreDangerousRules).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores AUTO rules when a non-AUTO child enters AUTO and finishes there', async () => {
+    const parent = await createParentWithRegistry();
+    const { stripDangerousRulesForAutoMode, restoreDangerousRules } =
+      attachFakePermissionManager(parent);
+
+    const { config: child, cleanup } = await createApprovalModeOverride(
+      parent,
+      ApprovalMode.PLAN,
+    );
+
+    child.setApprovalMode(ApprovalMode.AUTO);
+    expect(stripDangerousRulesForAutoMode).toHaveBeenCalledTimes(1);
+
+    cleanup();
+    expect(restoreDangerousRules).toHaveBeenCalledTimes(1);
   });
 
   it('copies discovered tools from the parent registry without re-discovering', async () => {

--- a/packages/core/src/tools/agent/agent-override.test.ts
+++ b/packages/core/src/tools/agent/agent-override.test.ts
@@ -283,6 +283,45 @@ describe('createApprovalModeOverride bound-tool isolation', () => {
     expect(restoreDangerousRules).toHaveBeenCalledTimes(1);
   });
 
+  it('does not restore AUTO rules on cleanup when the parent is already in AUTO mode', async () => {
+    const parent = await createParentWithRegistry();
+    const { stripDangerousRulesForAutoMode, restoreDangerousRules } =
+      attachFakePermissionManager(parent);
+    vi.spyOn(parent, 'isTrustedFolder').mockReturnValue(true);
+    parent.setApprovalMode(ApprovalMode.AUTO);
+
+    const { cleanup } = await createApprovalModeOverride(
+      parent,
+      ApprovalMode.AUTO,
+    );
+
+    expect(stripDangerousRulesForAutoMode).toHaveBeenCalledTimes(1);
+
+    cleanup();
+    expect(restoreDangerousRules).not.toHaveBeenCalled();
+  });
+
+  it('does not restore AUTO rules when a child leaves AUTO while the parent stays in AUTO', async () => {
+    const parent = await createParentWithRegistry();
+    const { stripDangerousRulesForAutoMode, restoreDangerousRules } =
+      attachFakePermissionManager(parent);
+    vi.spyOn(parent, 'isTrustedFolder').mockReturnValue(true);
+    parent.setApprovalMode(ApprovalMode.AUTO);
+
+    const { config: child, cleanup } = await createApprovalModeOverride(
+      parent,
+      ApprovalMode.AUTO,
+    );
+
+    child.setApprovalMode(ApprovalMode.DEFAULT);
+
+    expect(stripDangerousRulesForAutoMode).toHaveBeenCalledTimes(1);
+    expect(restoreDangerousRules).not.toHaveBeenCalled();
+
+    cleanup();
+    expect(restoreDangerousRules).not.toHaveBeenCalled();
+  });
+
   it('restores AUTO rules when a non-AUTO child enters AUTO and finishes there', async () => {
     const parent = await createParentWithRegistry();
     const { stripDangerousRulesForAutoMode, restoreDangerousRules } =

--- a/packages/core/src/tools/agent/agent-override.test.ts
+++ b/packages/core/src/tools/agent/agent-override.test.ts
@@ -18,6 +18,7 @@ import { ToolNames } from '../tool-names.js';
 import { EditTool } from '../edit.js';
 import { WriteFileTool } from '../write-file.js';
 import { ReadFileTool } from '../read-file.js';
+import { recordBlock } from '../../permissions/denialTracking.js';
 
 /**
  * Regression: Object.create(parent) is not enough to isolate a subagent's
@@ -204,6 +205,7 @@ describe('createApprovalModeOverride bound-tool isolation', () => {
     const execDetails = {
       type: 'exec',
     } as unknown as ToolCallConfirmationDetails;
+    expect(child.getApprovalMode()).toBe(ApprovalMode.DEFAULT);
     const isPlanMode = child.getApprovalMode() === ApprovalMode.PLAN;
 
     expect(isPlanModeBlocked(isPlanMode, false, false, execDetails)).toBe(
@@ -227,12 +229,40 @@ describe('createApprovalModeOverride bound-tool isolation', () => {
     );
 
     expect(child.getPrePlanMode()).toBe(ApprovalMode.YOLO);
+    const childGateState = child.getPlanGateState();
+    expect(childGateState).not.toBe(parentGateState);
+    expect(childGateState?.lastFindings).not.toBe(
+      parentGateState?.lastFindings,
+    );
 
     child.setApprovalMode(ApprovalMode.DEFAULT);
+    child.setApprovalMode(ApprovalMode.PLAN);
 
-    expect(child.getApprovalMode()).toBe(ApprovalMode.DEFAULT);
+    expect(child.getApprovalMode()).toBe(ApprovalMode.PLAN);
+    expect(child.getPlanGateState()?.entryId).toBe(
+      (parentGateState?.entryId ?? 0) + 1,
+    );
     expect(parent.getApprovalMode()).toBe(ApprovalMode.PLAN);
     expect(parent.getPlanGateState()).toBe(parentGateState);
+  });
+
+  it('starts child AUTO denial state independent from the parent', async () => {
+    const parent = await createParentWithRegistry();
+    parent.setAutoModeDenialState(recordBlock(parent.getAutoModeDenialState()));
+    const parentDenialState = parent.getAutoModeDenialState();
+
+    const { config: child } = await createApprovalModeOverride(
+      parent,
+      ApprovalMode.DEFAULT,
+    );
+
+    expect(child.getAutoModeDenialState()).toEqual({
+      consecutiveBlock: 0,
+      consecutiveUnavailable: 0,
+      totalBlock: 0,
+      totalUnavailable: 0,
+    });
+    expect(child.getAutoModeDenialState()).not.toBe(parentDenialState);
   });
 
   it('uses the parent current mode as pre-plan mode when a non-plan parent creates a plan child', async () => {
@@ -320,6 +350,29 @@ describe('createApprovalModeOverride bound-tool isolation', () => {
 
     cleanup();
     expect(restoreDangerousRules).not.toHaveBeenCalled();
+  });
+
+  it('restores the inherited permission manager when AUTO-parent mode changes throw', async () => {
+    const parent = await createParentWithRegistry();
+    attachFakePermissionManager(parent);
+    const parentPermissionManager = parent.getPermissionManager();
+    const trustSpy = vi.spyOn(parent, 'isTrustedFolder').mockReturnValue(true);
+    parent.setApprovalMode(ApprovalMode.AUTO);
+
+    const { config: child } = await createApprovalModeOverride(
+      parent,
+      ApprovalMode.AUTO,
+    );
+
+    trustSpy.mockReturnValue(false);
+
+    expect(() => child.setApprovalMode(ApprovalMode.AUTO_EDIT)).toThrow(
+      'Cannot enable privileged approval modes in an untrusted folder.',
+    );
+    expect(child.getPermissionManager()).toBe(parentPermissionManager);
+    expect(
+      Object.prototype.hasOwnProperty.call(child, 'permissionManager'),
+    ).toBe(false);
   });
 
   it('restores AUTO rules when a non-AUTO child enters AUTO and finishes there', async () => {

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -481,6 +481,7 @@ export async function createApprovalModeOverride(
   const override = Object.create(base) as any;
   const baseApprovalMode = base.getApprovalMode();
   override.approvalMode = mode;
+  override.getApprovalMode = Config.prototype.getApprovalMode;
   override.prePlanMode =
     mode === ApprovalMode.PLAN
       ? baseApprovalMode === ApprovalMode.PLAN

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -90,6 +90,7 @@ import {
   formatStopHookBlockingCapWarning,
 } from '../../hooks/stopHookCap.js';
 import { ApprovalMode } from '../../config/config.js';
+import { createDenialState } from '../../permissions/denialTracking.js';
 import { isTeammate } from '../../agents/team/identity.js';
 import {
   getAgentJsonlPath,
@@ -460,17 +461,16 @@ function capturePersistedCliFlags(
  * boundary (see strip lifecycle below).
  *
  * Strip lifecycle for AUTO overrides:
- *   - parent not in AUTO, override in AUTO: this function strips the
- *     PARENT's PM (shared via prototype chain — the override cannot
- *     have its own PM without a much bigger refactor). `cleanup`
- *     restores the strip when the sub-agent finishes, but ONLY if the
- *     parent hasn't itself entered AUTO in the meantime (in which
- *     case restoring would undo the parent's own strip).
- *   - parent already in AUTO, override in AUTO: parent's
- *     `setApprovalMode` already stripped on its own entry. We don't
- *     strip again (would be a no-op anyway via sentinel) and don't
- *     restore on cleanup (lifecycle is parent-owned).
- *   - override not in AUTO: no strip, no restore.
+ *   - parent not in AUTO, override starts in AUTO: this function strips
+ *     the PARENT's PM (shared via prototype chain — the override cannot
+ *     have its own PM without a much bigger refactor).
+ *   - parent already in AUTO, override starts in AUTO: parent's
+ *     `setApprovalMode` already stripped on its own entry, so this
+ *     function does not strip again.
+ *   - override enters/leaves AUTO later: inherited `setApprovalMode`
+ *     performs the normal strip/restore transition against the shared
+ *     PM. `cleanup` only restores if the child finishes still in AUTO
+ *     while the parent is not in AUTO.
  */
 export async function createApprovalModeOverride(
   base: Config,
@@ -479,31 +479,46 @@ export async function createApprovalModeOverride(
 ): Promise<ApprovalModeOverrideHandle> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const override = Object.create(base) as any;
-  override.getApprovalMode = (): ApprovalMode => mode;
+  const baseApprovalMode = base.getApprovalMode();
+  override.approvalMode = mode;
+  override.prePlanMode =
+    mode === ApprovalMode.PLAN
+      ? baseApprovalMode === ApprovalMode.PLAN
+        ? base.getPrePlanMode()
+        : baseApprovalMode
+      : undefined;
+  const basePlanGateState =
+    mode === ApprovalMode.PLAN ? base.getPlanGateState() : undefined;
+  override.planGateState = basePlanGateState
+    ? {
+        ...basePlanGateState,
+        lastFindings: [...basePlanGateState.lastFindings],
+      }
+    : undefined;
+  override.planGateEntryCounter = override.planGateState?.entryId ?? 0;
+  override.autoModeDenialState = createDenialState();
   applyPersistedCliFlagOverrides(override as Config, options.persistedCliFlags);
   await rebuildToolRegistryOnOverride(override as Config, base);
 
-  let cleanup: () => void = () => {};
+  const cleanup = () => {
+    if (
+      (override as Config).getApprovalMode() === ApprovalMode.AUTO &&
+      base.getApprovalMode() !== ApprovalMode.AUTO
+    ) {
+      base.getPermissionManager?.()?.restoreDangerousRules();
+    }
+  };
 
   if (mode === ApprovalMode.AUTO) {
     const baseWasAuto = base.getApprovalMode() === ApprovalMode.AUTO;
     if (!baseWasAuto) {
       // This override is bringing AUTO into a non-AUTO parent. Strip
       // dangerous allow rules so the sub-agent's classifier actually
-      // gates them, then arrange to restore on cleanup.
+      // gates them. Cleanup handles restore if the child finishes in AUTO.
       base.getPermissionManager?.()?.stripDangerousRulesForAutoMode();
-      cleanup = () => {
-        // Defensive: parent could have toggled to AUTO during the sub-
-        // agent's run. In that case parent now owns the strip lifecycle
-        // (its own `setApprovalMode(AUTO)` hook was responsible) and we
-        // must NOT restore — that would un-strip the parent's intent.
-        if (base.getApprovalMode() !== ApprovalMode.AUTO) {
-          base.getPermissionManager?.()?.restoreDangerousRules();
-        }
-      };
     }
     // baseWasAuto: parent's setApprovalMode already stripped; cleanup
-    // stays no-op since lifecycle is parent-owned.
+    // will not restore while the parent remains in AUTO.
   }
 
   return { config: override as Config, cleanup };

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -18,7 +18,6 @@ import type {
   ToolCallConfirmationDetails,
   ToolConfirmationPayload,
 } from '../tools.js';
-import type { Config } from '../../config/config.js';
 import type { PermissionDecision } from '../../permissions/types.js';
 import type { SubagentManager } from '../../subagents/subagent-manager.js';
 import type { SubagentConfig } from '../../subagents/types.js';
@@ -89,7 +88,7 @@ import {
   appendStopHookBlockingCapWarning,
   formatStopHookBlockingCapWarning,
 } from '../../hooks/stopHookCap.js';
-import { ApprovalMode } from '../../config/config.js';
+import { ApprovalMode, Config } from '../../config/config.js';
 import { createDenialState } from '../../permissions/denialTracking.js';
 import { isTeammate } from '../../agents/team/identity.js';
 import {
@@ -467,10 +466,11 @@ function capturePersistedCliFlags(
  *   - parent already in AUTO, override starts in AUTO: parent's
  *     `setApprovalMode` already stripped on its own entry, so this
  *     function does not strip again.
- *   - override enters/leaves AUTO later: inherited `setApprovalMode`
- *     performs the normal strip/restore transition against the shared
- *     PM. `cleanup` only restores if the child finishes still in AUTO
- *     while the parent is not in AUTO.
+ *   - override enters/leaves AUTO later: `setApprovalMode` reuses Config's
+ *     normal state transition, but suppresses AUTO strip/restore while the
+ *     parent is already in AUTO because the parent owns that strip lifecycle.
+ *     `cleanup` only restores if the child finishes still in AUTO while the
+ *     parent is not in AUTO.
  */
 export async function createApprovalModeOverride(
   base: Config,
@@ -497,6 +497,39 @@ export async function createApprovalModeOverride(
     : undefined;
   override.planGateEntryCounter = override.planGateState?.entryId ?? 0;
   override.autoModeDenialState = createDenialState();
+  override.setApprovalMode = (
+    nextMode: ApprovalMode,
+    setOptions?: Parameters<Config['setApprovalMode']>[1],
+  ): void => {
+    if (base.getApprovalMode() !== ApprovalMode.AUTO) {
+      Config.prototype.setApprovalMode.call(
+        override as Config,
+        nextMode,
+        setOptions,
+      );
+      return;
+    }
+
+    const hadOwnPermissionManager = Object.prototype.hasOwnProperty.call(
+      override,
+      'permissionManager',
+    );
+    const ownPermissionManager = override.permissionManager;
+    override.permissionManager = null;
+    try {
+      Config.prototype.setApprovalMode.call(
+        override as Config,
+        nextMode,
+        setOptions,
+      );
+    } finally {
+      if (hadOwnPermissionManager) {
+        override.permissionManager = ownPermissionManager;
+      } else {
+        delete override.permissionManager;
+      }
+    }
+  };
   applyPersistedCliFlagOverrides(override as Config, options.persistedCliFlags);
   await rebuildToolRegistryOnOverride(override as Config, base);
 

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -480,6 +480,8 @@ export async function createApprovalModeOverride(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const override = Object.create(base) as any;
   const baseApprovalMode = base.getApprovalMode();
+  // These own properties intentionally mirror Config's TS-private field names.
+  // Config prototype methods read/write them at runtime on this override object.
   override.approvalMode = mode;
   override.getApprovalMode = Config.prototype.getApprovalMode;
   override.prePlanMode =


### PR DESCRIPTION
## What this PR does

This PR fixes subagent approval-mode overrides so a subagent can actually leave plan mode after `exit_plan_mode` succeeds. The override now owns mutable approval-mode and plan-gate state instead of returning the initial mode from a fixed getter, and it keeps AUTO-mode denial tracking isolated for the child config.

It also tightens the AUTO dangerous-rule cleanup path so a child that starts in AUTO, leaves AUTO, or enters AUTO during execution restores the shared permission manager rules at the right time without relying on the old initial-mode-only cleanup behavior.

## Why it's needed

Subagents launched while the parent is in plan mode inherited `PLAN`, but the child config's `getApprovalMode()` always returned the initial mode captured at creation time. That meant `exit_plan_mode` could report success while the scheduler still believed the child was in plan mode, so exec tools such as shell calls continued to be blocked and the model could loop through repeated plan exits and failed tool calls.

This change makes the child config's approval mode behave like a normal mutable config, which breaks that loop while preserving the existing policy that subagents may inherit plan mode.

## Reviewer Test Plan

### How to verify

Run `cd packages/core && npx vitest run src/tools/agent/agent-override.test.ts` and confirm the new regression cases pass: a plan-mode child exits to default, exec tools are no longer plan-blocked after exit, parent and child plan state remain isolated, and AUTO cleanup handles child entry and exit paths. For broader validation, run `cd packages/core && npx vitest run src/core/permissionFlow.test.ts`, `cd packages/core && npx vitest run src/tools/exitPlanMode.test.ts`, `cd packages/core && npx vitest run src/config/config.test.ts`, `cd packages/core && npm run lint`, and from the repository root run `npm run build && npm run typecheck`.

### Evidence (Before & After)

N/A. This is a non-UI core behavior fix covered by unit tests and build/typecheck validation.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS worktree with Node.js v22.22.3 and npm. Validation used Vitest, ESLint, Prettier checks, repository build, and repository typecheck.

## Risk & Scope

- Main risk or tradeoff: The override now mirrors more of Config's mutable approval-mode state, so the main risk is a mismatch with existing wrapper lifecycle assumptions; regression coverage was added for plan exit, plan state isolation, and AUTO cleanup paths.
- Not validated / out of scope: This does not change the product policy for whether ordinary subagents may use plan tools, and it does not add a generic model loop detector.
- Breaking changes / migration notes: None expected; public APIs, subagent config shape, and tool names are unchanged.

## Linked Issues

Closes #6036

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 修复了子 Agent 的 approval-mode override，使子 Agent 在 `exit_plan_mode` 成功后能够真正退出 plan mode。override 现在拥有可变的 approval-mode 和 plan-gate 状态，不再通过固定 getter 返回创建时的初始 mode，同时也为子 Config 隔离 AUTO-mode denial tracking 状态。

它还收紧了 AUTO dangerous-rule cleanup 路径：无论子 Agent 初始就在 AUTO、运行中离开 AUTO，还是运行中进入 AUTO，都能在正确时机恢复共享 PermissionManager 的规则，不再依赖只看初始 mode 的旧 cleanup 行为。

## Why it's needed

父会话在 plan mode 时启动的子 Agent 会继承 `PLAN`，但子 Config 的 `getApprovalMode()` 一直返回创建时捕获的初始 mode。这会导致 `exit_plan_mode` 看起来成功了，但调度器仍然认为子 Agent 处于 plan mode，于是 shell 等 exec 工具继续被拦截，模型可能进入反复退出 plan 和反复工具失败的循环。

这个改动让子 Config 的 approval mode 像普通 Config 一样可变，从而打断这个循环，同时保留现有的子 Agent 可继承 plan mode 的策略。

## Reviewer Test Plan

### How to verify

运行 `cd packages/core && npx vitest run src/tools/agent/agent-override.test.ts`，确认新增回归用例通过：plan-mode 子 Config 可以退出到 default，退出后 exec 工具不再被 plan block，父子 plan 状态保持隔离，并且 AUTO cleanup 覆盖子 Agent 进入和退出 AUTO 的路径。更完整的验证可以运行 `cd packages/core && npx vitest run src/core/permissionFlow.test.ts`、`cd packages/core && npx vitest run src/tools/exitPlanMode.test.ts`、`cd packages/core && npx vitest run src/config/config.test.ts`、`cd packages/core && npm run lint`，以及在仓库根目录运行 `npm run build && npm run typecheck`。

### Evidence (Before & After)

N/A。这是非 UI 的 core 行为修复，已通过单元测试、构建和类型检查验证。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 macOS worktree，Node.js v22.22.3 和 npm。验证使用了 Vitest、ESLint、Prettier check、仓库构建和仓库类型检查。

## Risk & Scope

- Main risk or tradeoff: override 现在会镜像更多 Config 的可变 approval-mode 状态，主要风险是与既有 wrapper 生命周期假设不一致；本 PR 已为 plan 退出、plan 状态隔离和 AUTO cleanup 路径添加回归覆盖。
- Not validated / out of scope: 本 PR 不改变普通子 Agent 是否可以使用 plan 工具的产品策略，也不新增通用模型循环检测器。
- Breaking changes / migration notes: 预期没有破坏性变更；public API、subagent 配置形态和工具名均未改变。

## Linked Issues

Closes #6036

</details>

