### PR TITLE
ci(workflows): remind authors not to force-push active PRs

### DIFF
--- a/.github/workflows/pr-force-push-reminder.yml
+++ b/.github/workflows/pr-force-push-reminder.yml
@@ -7,13 +7,17 @@ on:
 
 permissions:
   contents: 'read'
+  issues: 'write'
   pull-requests: 'write'
 
-# One in-flight check per PR; a newer push supersedes the previous one so we
-# never post the reminder twice for a rapid burst of force-pushes.
+# Serialize runs per PR without cancelling: a run that already detected a
+# force-push must be allowed to finish and post, while later pushes queue
+# behind it and then no-op via the once-per-PR marker. Cancelling in-progress
+# runs could silently drop a reminder when a force-push is immediately
+# followed by a normal push (the cancelling run sees 'ahead' and exits).
 concurrency:
   group: 'pr-force-push-reminder-${{ github.event.pull_request.number }}'
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   remind-on-force-push:

--- a/.github/workflows/pr-force-push-reminder.yml
+++ b/.github/workflows/pr-force-push-reminder.yml
@@ -43,10 +43,22 @@ jobs:
               return;
             }
 
-            // Skip automation-driven updates (e.g. integration/autofix bots).
-            // Only humans rebasing/force-pushing should get the reminder.
-            if (context.payload.sender?.type === 'Bot') {
-              console.log(`Push made by bot "${context.payload.sender.login}"; skipping.`);
+            // Skip automation-driven updates. A GitHub App push has
+            // sender.type === 'Bot', but the repo's own autofix bot pushes
+            // (including force-pushes) via a PAT as the user account
+            // qwen-code-dev-bot, which arrives with sender.type === 'User' — so
+            // also skip known automation logins (mirrors qwen-autofix.yml's
+            // KNOWN_BOTS). Only human contributors should be reminded.
+            const sender = context.payload.sender;
+            const KNOWN_AUTOMATION = new Set([
+              'qwen-code-ci-bot',
+              'qwen-code-dev-bot',
+              'github-actions',
+              'github-actions[bot]',
+              'gemini-cli-robot',
+            ]);
+            if (sender?.type === 'Bot' || KNOWN_AUTOMATION.has(sender?.login)) {
+              console.log(`Push made by automation "${sender?.login}" (${sender?.type}); skipping.`);
               return;
             }
 
@@ -64,11 +76,16 @@ jobs:
               });
               status = cmp.data.status;
             } catch (err) {
-              // The compare can 404 if the old tip is no longer reachable.
-              // Stay conservative and skip rather than risk a false accusation.
-              const reason = err.status || err.message;
-              console.log(`Could not compare ${before}...${after}: ${reason}. Skipping.`);
-              return;
+              // A 404 means the old tip (`before`) is no longer reachable — it
+              // was orphaned by the force-push and already GC'd. Skip
+              // conservatively rather than risk a false accusation. Any other
+              // error (403/429/5xx) is a real failure: rethrow so the run goes
+              // red and the outage is visible instead of a silent no-op.
+              if (err.status === 404) {
+                console.log(`Old tip ${before} no longer reachable (404); skipping.`);
+                return;
+              }
+              throw err;
             }
 
             console.log(`Compare ${before.slice(0, 7)}...${after.slice(0, 7)} => ${status}`);
@@ -86,8 +103,18 @@ jobs:
               issue_number: pr.number,
               per_page: 100,
             });
-            if (comments.some((c) => c.body && c.body.includes(MARKER))) {
-              console.log('Reminder already posted on this PR; skipping.');
+            // Only trust the marker on our own bot's comment — otherwise anyone
+            // could permanently suppress reminders by pasting the marker string.
+            if (
+              comments.some(
+                (c) =>
+                  c.user?.type === 'Bot' &&
+                  c.user?.login === 'github-actions[bot]' &&
+                  c.body &&
+                  c.body.includes(MARKER),
+              )
+            ) {
+              console.log('Reminder already posted by the bot on this PR; skipping.');
               return;
             }
 
@@ -113,10 +140,17 @@ jobs:
               '</details>',
             ].join('\n');
 
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number,
-              body,
-            });
-            console.log(`Posted force-push reminder on PR #${pr.number}.`);
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body,
+              });
+              console.log(`Posted force-push reminder on PR #${pr.number}.`);
+            } catch (err) {
+              // Surface auth/rate-limit/transient failures with context and let
+              // the run go red instead of failing silently.
+              core.error(`Failed to comment on PR #${pr.number}: ${err.status} ${err.message}`);
+              throw err;
+            }

--- a/.github/workflows/pr-force-push-reminder.yml
+++ b/.github/workflows/pr-force-push-reminder.yml
@@ -1,0 +1,118 @@
+name: 'PR Force-Push Reminder'
+
+on:
+  pull_request_target:
+    types:
+      - 'synchronize'
+
+permissions:
+  contents: 'read'
+  pull-requests: 'write'
+
+# One in-flight check per PR; a newer push supersedes the previous one so we
+# never post the reminder twice for a rapid burst of force-pushes.
+concurrency:
+  group: 'pr-force-push-reminder-${{ github.event.pull_request.number }}'
+  cancel-in-progress: true
+
+jobs:
+  remind-on-force-push:
+    name: 'Remind on force-push'
+    timeout-minutes: 5
+    if: |-
+      ${{ github.repository == 'QwenLM/qwen-code' }}
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Detect force-push and post reminder'
+        uses: 'actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3'  # v9.0.0
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          script: |
+            const pr = context.payload.pull_request;
+            const before = context.payload.before;
+            const after = context.payload.after;
+
+            // A `synchronize` event should always carry both SHAs; bail out if
+            // either is missing or `before` is the all-zero (no parent) SHA.
+            if (!before || !after || /^0+$/.test(before)) {
+              console.log('No usable before/after SHA; nothing to do.');
+              return;
+            }
+
+            // Skip automation-driven updates (e.g. integration/autofix bots).
+            // Only humans rebasing/force-pushing should get the reminder.
+            if (context.payload.sender?.type === 'Bot') {
+              console.log(`Push made by bot "${context.payload.sender.login}"; skipping.`);
+              return;
+            }
+
+            // Compare the old tip (`before`) with the new tip (`after`):
+            //   ahead     -> new commits added on top of the old tip (normal push)
+            //   identical -> no change
+            //   behind    -> reset to an older commit (force-push)
+            //   diverged  -> history rewritten, e.g. rebase/amend (force-push)
+            let status;
+            try {
+              const cmp = await github.rest.repos.compareCommitsWithBasehead({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                basehead: `${before}...${after}`,
+              });
+              status = cmp.data.status;
+            } catch (err) {
+              // The compare can 404 if the old tip is no longer reachable.
+              // Stay conservative and skip rather than risk a false accusation.
+              const reason = err.status || err.message;
+              console.log(`Could not compare ${before}...${after}: ${reason}. Skipping.`);
+              return;
+            }
+
+            console.log(`Compare ${before.slice(0, 7)}...${after.slice(0, 7)} => ${status}`);
+            if (status === 'ahead' || status === 'identical') {
+              console.log('Fast-forward push (not a force-push); nothing to do.');
+              return;
+            }
+
+            // Force-push confirmed. Post the reminder at most once per PR; the
+            // hidden marker lets us detect a reminder we already left.
+            const MARKER = '<!-- pr-force-push-reminder -->';
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              per_page: 100,
+            });
+            if (comments.some((c) => c.body && c.body.includes(MARKER))) {
+              console.log('Reminder already posted on this PR; skipping.');
+              return;
+            }
+
+            const english =
+              'Please do not rebase or force-push to an active PR as it invalidates ' +
+              'existing review comments. Note for future reference, the bots always ' +
+              'squash all changes into a single commit automatically as part of the ' +
+              'integration.';
+            const chinese =
+              '请勿对活跃的 PR 执行 rebase 或 force-push，因为这会使已有的评审评论失效。' +
+              '另外，供日后参考：作为集成流程的一部分，机器人始终会自动将所有改动' +
+              '压缩（squash）为单个提交。';
+            const body = [
+              MARKER,
+              '',
+              english,
+              '',
+              '<details>',
+              '<summary>中文</summary>',
+              '',
+              chinese,
+              '',
+              '</details>',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body,
+            });
+            console.log(`Posted force-push reminder on PR #${pr.number}.`);

--- a/.github/workflows/pr-force-push-reminder.yml
+++ b/.github/workflows/pr-force-push-reminder.yml
@@ -50,6 +50,7 @@ jobs:
             // also skip known automation logins (mirrors qwen-autofix.yml's
             // KNOWN_BOTS). Only human contributors should be reminded.
             const sender = context.payload.sender;
+            // KEEP IN SYNC with KNOWN_BOTS in .github/workflows/qwen-autofix.yml.
             const KNOWN_AUTOMATION = new Set([
               'qwen-code-ci-bot',
               'qwen-code-dev-bot',
@@ -97,12 +98,18 @@ jobs:
             // Force-push confirmed. Post the reminder at most once per PR; the
             // hidden marker lets us detect a reminder we already left.
             const MARKER = '<!-- pr-force-push-reminder -->';
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number,
-              per_page: 100,
-            });
+            let comments;
+            try {
+              comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 100,
+              });
+            } catch (err) {
+              core.error(`Failed to list comments on PR #${pr.number}: ${err.status} ${err.message}`);
+              throw err;
+            }
             // Only trust the marker on our own bot's comment — otherwise anyone
             // could permanently suppress reminders by pasting the marker string.
             if (

--- a/.github/workflows/pr-force-push-reminder.yml
+++ b/.github/workflows/pr-force-push-reminder.yml
@@ -10,14 +10,13 @@ permissions:
   issues: 'write'
   pull-requests: 'write'
 
-# Serialize runs per PR without cancelling: a run that already detected a
-# force-push must be allowed to finish and post, while later pushes queue
-# behind it and then no-op via the once-per-PR marker. Cancelling in-progress
-# runs could silently drop a reminder when a force-push is immediately
-# followed by a normal push (the cancelling run sees 'ahead' and exits).
-concurrency:
-  group: 'pr-force-push-reminder-${{ github.event.pull_request.number }}'
-  cancel-in-progress: false
+# No concurrency group on purpose. GitHub keeps at most one pending run per
+# group, so a burst of pushes can cancel a still-pending run that was about to
+# post — dropping the very reminder this workflow exists to deliver. Letting
+# every synchronize event run independently guarantees each force-push is
+# evaluated; idempotency comes from the once-per-PR marker checked in the script
+# (not from serializing runs). A rare double-post on two near-simultaneous
+# first force-pushes is the acceptable cost of never silently missing one.
 
 jobs:
   remind-on-force-push:

--- a/scripts/tests/pr-force-push-reminder-workflow.test.js
+++ b/scripts/tests/pr-force-push-reminder-workflow.test.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2025 Qwen Team
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -106,6 +106,10 @@ describe('pr force-push reminder workflow', () => {
     expect(workflow).toContain('<!-- pr-force-push-reminder -->');
     expect(workflow).toContain("c.user?.type === 'Bot'");
     expect(workflow).toContain("c.user?.login === 'github-actions[bot]'");
+    // Assert the skip path itself, so deleting the guard fails a test.
+    expect(workflow).toContain(
+      'Reminder already posted by the bot on this PR; skipping.',
+    );
   });
 
   it('wraps every GitHub write/read in error logging that rethrows', () => {

--- a/scripts/tests/pr-force-push-reminder-workflow.test.js
+++ b/scripts/tests/pr-force-push-reminder-workflow.test.js
@@ -38,14 +38,12 @@ describe('pr force-push reminder workflow', () => {
     expect(workflow).toContain("pull-requests: 'write'");
   });
 
-  it('serializes per-PR runs without cancelling in-flight reminders', () => {
-    expect(workflow).toContain(
-      "group: 'pr-force-push-reminder-${{ github.event.pull_request.number }}'",
-    );
-    // cancel-in-progress: true would let a normal push cancel an in-flight run
-    // that already detected a force-push, silently dropping the reminder.
-    expect(workflow).toContain('cancel-in-progress: false');
-    expect(workflow).not.toContain('cancel-in-progress: true');
+  it('uses no concurrency group so no push event is ever dropped', () => {
+    // GitHub keeps at most one pending run per concurrency group, so a group
+    // could cancel a still-pending force-push run before it posts. Idempotency
+    // comes from the marker instead, so there must be no concurrency block.
+    expect(workflow).not.toContain('concurrency:');
+    expect(workflow).not.toContain('cancel-in-progress');
   });
 
   it('bounds the job and pins the github-script action by SHA', () => {

--- a/scripts/tests/pr-force-push-reminder-workflow.test.js
+++ b/scripts/tests/pr-force-push-reminder-workflow.test.js
@@ -63,20 +63,21 @@ describe('pr force-push reminder workflow', () => {
     expect(workflow).toContain(
       "sender?.type === 'Bot' || KNOWN_AUTOMATION.has(sender?.login)",
     );
-    for (const login of [
-      'qwen-code-ci-bot',
-      'qwen-code-dev-bot',
-      'github-actions',
-      'github-actions[bot]',
-      'gemini-cli-robot',
-    ]) {
-      expect(workflow).toContain(`'${login}'`);
-    }
-    // The KNOWN_AUTOMATION list mirrors qwen-autofix.yml — drift would let an
-    // automation account get reminded, so the sync is asserted here.
     expect(workflow).toContain(
       'KEEP IN SYNC with KNOWN_BOTS in .github/workflows/qwen-autofix.yml',
     );
+    // Mechanically enforce the sync: read qwen-autofix.yml's KNOWN_BOTS and
+    // assert every login is also skipped here, so adding a bot there without
+    // updating this list fails the test rather than silently drifting.
+    const autofix = readFileSync(
+      path.join(repoRoot, '.github/workflows/qwen-autofix.yml'),
+      'utf8',
+    );
+    const match = autofix.match(/KNOWN_BOTS:\s*'(\[.*\])'/);
+    expect(match, 'KNOWN_BOTS not found in qwen-autofix.yml').not.toBeNull();
+    for (const login of JSON.parse(match[1])) {
+      expect(workflow).toContain(`'${login}'`);
+    }
   });
 
   it('detects force-pushes with a 3-dot compare on the base repo', () => {

--- a/scripts/tests/pr-force-push-reminder-workflow.test.js
+++ b/scripts/tests/pr-force-push-reminder-workflow.test.js
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..',
+);
+
+describe('pr force-push reminder workflow', () => {
+  const workflow = readFileSync(
+    path.join(repoRoot, '.github/workflows/pr-force-push-reminder.yml'),
+    'utf8',
+  );
+
+  it('triggers only on pull_request_target synchronize', () => {
+    expect(workflow).toContain('pull_request_target:');
+    expect(workflow).toContain("- 'synchronize'");
+    // Must not check out or run PR code: a github-script-only job needs no
+    // checkout, which is what keeps pull_request_target safe from pwn-requests.
+    expect(workflow).not.toContain('actions/checkout');
+  });
+
+  it('only runs on the upstream repo', () => {
+    expect(workflow).toContain("github.repository == 'QwenLM/qwen-code'");
+  });
+
+  it('grants the permissions the comment endpoints need', () => {
+    expect(workflow).toContain("contents: 'read'");
+    expect(workflow).toContain("issues: 'write'");
+    expect(workflow).toContain("pull-requests: 'write'");
+  });
+
+  it('serializes per-PR runs without cancelling in-flight reminders', () => {
+    expect(workflow).toContain(
+      "group: 'pr-force-push-reminder-${{ github.event.pull_request.number }}'",
+    );
+    // cancel-in-progress: true would let a normal push cancel an in-flight run
+    // that already detected a force-push, silently dropping the reminder.
+    expect(workflow).toContain('cancel-in-progress: false');
+    expect(workflow).not.toContain('cancel-in-progress: true');
+  });
+
+  it('bounds the job and pins the github-script action by SHA', () => {
+    expect(workflow).toContain('timeout-minutes: 5');
+    expect(workflow).toContain(
+      'actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3',
+    );
+  });
+
+  it('guards against missing or zero before/after SHAs', () => {
+    expect(workflow).toContain('!before || !after || /^0+$/.test(before)');
+  });
+
+  it('skips bot and known-automation pushes', () => {
+    // GitHub Apps arrive as sender.type Bot; the autofix bot force-pushes via a
+    // PAT as a User account, so its login must be skipped explicitly.
+    expect(workflow).toContain(
+      "sender?.type === 'Bot' || KNOWN_AUTOMATION.has(sender?.login)",
+    );
+    for (const login of [
+      'qwen-code-ci-bot',
+      'qwen-code-dev-bot',
+      'github-actions',
+      'github-actions[bot]',
+      'gemini-cli-robot',
+    ]) {
+      expect(workflow).toContain(`'${login}'`);
+    }
+    // The KNOWN_AUTOMATION list mirrors qwen-autofix.yml — drift would let an
+    // automation account get reminded, so the sync is asserted here.
+    expect(workflow).toContain(
+      'KEEP IN SYNC with KNOWN_BOTS in .github/workflows/qwen-autofix.yml',
+    );
+  });
+
+  it('detects force-pushes with a 3-dot compare on the base repo', () => {
+    // Verified against the live REST API: 3-dot returns diverged/behind for
+    // force-pushes and resolves fork-PR commits, while 2-dot 404s. Do not
+    // "simplify" this to two dots.
+    expect(workflow).toContain('basehead: `${before}...${after}`');
+    expect(workflow).not.toContain('basehead: `${before}..${after}`');
+    // The base repo resolves fork-PR commits via refs/pull/N/head, so the
+    // compare targets context.repo, not the (possibly deleted) head repo.
+    expect(workflow).not.toContain('pr.head.repo');
+    // Only ahead/identical is a normal push; behind/diverged is a force-push.
+    expect(workflow).toContain("status === 'ahead' || status === 'identical'");
+  });
+
+  it('skips on a 404 compare but surfaces other errors', () => {
+    // A 404 means the old tip was orphaned by the force-push; anything else
+    // (403/429/5xx) must fail the run loudly instead of a silent green no-op.
+    expect(workflow).toContain('if (err.status === 404)');
+    expect(workflow).toContain('throw err;');
+    expect(workflow).not.toContain('Could not compare');
+  });
+
+  it('only trusts the dedup marker on its own bot comment', () => {
+    // Otherwise any user could suppress all future reminders by pasting the
+    // marker string into a comment.
+    expect(workflow).toContain('<!-- pr-force-push-reminder -->');
+    expect(workflow).toContain("c.user?.type === 'Bot'");
+    expect(workflow).toContain("c.user?.login === 'github-actions[bot]'");
+  });
+
+  it('wraps every GitHub write/read in error logging that rethrows', () => {
+    // listComments, compare (via the 404 branch), and createComment must all
+    // surface failures rather than swallowing them.
+    expect(workflow).toContain('Failed to list comments on PR #${pr.number}');
+    expect(workflow).toContain('Failed to comment on PR #${pr.number}');
+    expect(workflow).toContain('core.error(');
+  });
+
+  it('posts a bilingual reminder', () => {
+    expect(workflow).toContain('Please do not rebase or force-push');
+    expect(workflow).toContain('squash all changes into a single commit');
+    expect(workflow).toContain('<summary>中文</summary>');
+    expect(workflow).toContain('请勿对活跃的 PR 执行 rebase 或 force-push');
+  });
+});


### PR DESCRIPTION
## What this PR does

Adds a lightweight GitHub Actions workflow that watches open pull requests and, when a contributor rebases or force-pushes the PR branch, posts a one-time reminder comment asking them not to force-push (because it invalidates existing inline review comments) and noting that the integration bots squash all changes into a single commit automatically on merge. The reminder is bilingual — English with a collapsed Chinese translation.

It distinguishes a force-push from a normal push by comparing the `before` and `after` SHAs carried on the `pull_request_target` `synchronize` event: a `behind` or `diverged` compare status means history was rewritten (force-push), while `ahead`/`identical` is a normal push and is ignored. The comment is posted at most once per PR (guarded by a hidden HTML marker and full comment-list pagination), pushes initiated by bots are skipped, and a failed comparison is treated conservatively (no comment) so the bot never makes a false accusation.

## Why it's needed

Contributors frequently rebase or force-push their PR branches, which silently invalidates existing inline review comments and makes re-review harder. Since the integration bots squash everything into a single commit on merge anyway, force-pushing to "clean up" history is unnecessary. An automatic, friendly, once-per-PR reminder reduces this churn without a maintainer having to leave the same comment by hand each time.

## Reviewer Test Plan

### How to verify

This is a CI-only change (a single new workflow file). It cannot execute until it lands on the base branch, because `pull_request_target` always runs the workflow definition from the target branch — so a reviewer confirms it via static validation plus a post-merge smoke test. Static validation performed locally (macOS):

- `actionlint .github/workflows/pr-force-push-reminder.yml` → passes.
- `yamllint --format github` with the repo's `.yamllint` config → passes (same result as the existing workflows).
- The embedded `github-script` body, wrapped in an async function exactly as `github-script` runs it, passes `node --check`.

After merge, behavior can be confirmed on a throwaway PR: pushing additional commits produces no comment (compare status `ahead`); `git commit --amend && git push --force` or a rebase produces exactly one reminder comment; a second force-push produces no duplicate (the marker is detected).

### Evidence (Before & After)

N/A — non–user-visible CI workflow; its only output is a PR comment posted after the workflow is on the base branch.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ (actionlint + yamllint + `node --check`)   |
| 🪟 Windows |   N/A   |
|  🐧 Linux  |   N/A (workflow executes only on GitHub-hosted `ubuntu-latest`)   |

### Environment (optional)

N/A — static lint validation only; the workflow itself has no local runtime.

## Risk & Scope

- Main risk or tradeoff: it posts a comment on force-push. Mitigated by the once-per-PR marker, skipping bot senders, and the conservative skip-on-compare-failure. It uses `pull_request_target` but never checks out or executes PR code (it only calls the GitHub REST API), so there is no pwn-request exposure. Permissions are minimal: `contents: read`, `pull-requests: write`.
- Not validated / out of scope: end-to-end behavior on a live PR (cannot run until the workflow is on the base branch).
- Breaking changes / migration notes: none. Additive workflow only.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

新增一个轻量的 GitHub Actions workflow，监听处于打开状态的 PR；当贡献者对 PR 分支执行 rebase 或 force-push 时，自动发一条一次性提醒评论，请其不要 force-push（因为会使已有的行内评审评论失效），并说明集成机器人在合并时本就会自动把所有改动压缩（squash）成单个提交。提醒为双语——英文正文 + 折叠的中文翻译。

它通过比较 `pull_request_target` 的 `synchronize` 事件所携带的 `before` 与 `after` 两个 SHA 来区分 force-push 与普通推送：compare 状态为 `behind` 或 `diverged` 表示历史被改写（force-push），而 `ahead`/`identical` 是普通推送、直接忽略。评论每个 PR 最多发一次（用隐藏 HTML 标记 + 全量评论分页去重）、跳过由机器人发起的推送、比较失败时保守处理（不发评论），以确保不会误伤。

## 为什么需要

贡献者经常 rebase 或 force-push 自己的 PR 分支，这会悄无声息地使已有的行内评审评论失效、增加重新评审的成本。既然集成机器人在合并时本就会把所有改动 squash 成单个提交，为"整理"历史而 force-push 是没必要的。一条自动、友好、每个 PR 仅一次的提醒可以减少这类来回，而不需要维护者每次手动留同样的评论。

## 评审验证计划

### 如何验证

这是一个纯 CI 改动（仅新增一个 workflow 文件）。在它进入基准分支之前无法运行，因为 `pull_request_target` 始终使用目标分支上的 workflow 定义——因此评审者通过静态校验 + 合并后冒烟测试来确认。本地（macOS）已做的静态校验：

- `actionlint .github/workflows/pr-force-push-reminder.yml` → 通过。
- 用仓库 `.yamllint` 配置跑 `yamllint --format github` → 通过（与现有 workflow 结果一致）。
- 将内嵌的 `github-script` 脚本体按 `github-script` 实际运行方式用 async 函数包裹后，`node --check` → 通过。

合并后可在一个临时 PR 上确认：追加普通提交不会产生评论（compare 状态 `ahead`）；执行 `git commit --amend && git push --force` 或 rebase 会产生恰好一条提醒评论；再次 force-push 不会重复发（标记被检测到）。

### 证据（前/后对比）

N/A — 非用户可见的 CI workflow；其唯一输出是在 workflow 进入基准分支后于 PR 上发的评论。

### 测试平台

见上方表格：macOS 已做静态 lint 校验；workflow 本身只在 GitHub 托管的 `ubuntu-latest` 上运行。

### 运行环境（可选）

N/A — 仅静态 lint 校验，workflow 本身没有本地运行时。

## 风险与范围

- 主要风险/权衡：会在 force-push 时发评论。已通过"每 PR 一次"标记、跳过机器人发起者、比较失败保守跳过来缓解。使用了 `pull_request_target`，但从不 checkout 或执行 PR 代码（只调用 GitHub REST API），因此不存在 pwn-request 风险。权限最小化：`contents: read`、`pull-requests: write`。
- 未验证 / 范围外：在真实 PR 上的端到端行为（在 workflow 进入基准分支前无法运行）。
- 破坏性变更 / 迁移说明：无。仅新增 workflow。

## 关联 Issue

N/A

</details>
