### PR TITLE
feat(cli): add /reload-plugins command and plugin stale notification

### DIFF
--- a/packages/cli/src/config/hot-reload.test.ts
+++ b/packages/cli/src/config/hot-reload.test.ts
@@ -16,7 +16,11 @@ import {
 import * as os from 'node:os';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
-import type { Config, MCPServerConfig } from '@qwen-code/qwen-code-core';
+import type {
+  Config,
+  Extension,
+  MCPServerConfig,
+} from '@qwen-code/qwen-code-core';
 import type { LoadedSettings, Settings } from './settings.js';
 import type {
   SettingsWatcher,
@@ -26,6 +30,7 @@ import {
   registerMcpHotReload,
   mcpServersEqual,
   mcpGatingEqual,
+  reloadPluginsRuntime,
 } from './hot-reload.js';
 import {
   loadMcpApprovals,
@@ -96,6 +101,108 @@ describe('mcpGatingEqual', () => {
     expect(mcpGatingEqual({ excluded: undefined }, { excluded: [] })).toBe(
       true,
     );
+  });
+});
+
+describe('reloadPluginsRuntime', () => {
+  it('refreshes extension runtime and reloads slash commands', async () => {
+    const refreshCache = vi.fn(async () => {});
+    const refreshTools = vi.fn(async () => {});
+    const reinitializeLsp = vi.fn(async () => {});
+    const reloadCommands = vi.fn(async () => {});
+    const activeExtensions = [
+      {
+        name: 'alpha',
+        commands: ['alpha:run', 'alpha:check'],
+        skills: [{ name: 'skill-a' }],
+        hooks: { PreToolUse: [{ command: 'echo ok' }] },
+        mcpServers: { alpha: { command: 'node' } },
+        path: '/extensions/alpha',
+        config: {
+          name: 'alpha',
+          version: '1.0.0',
+          lspServers: {
+            typescript: {
+              command: 'typescript-language-server',
+              extensionToLanguage: { '.ts': 'typescript' },
+            },
+          },
+        },
+      },
+      {
+        name: 'beta',
+        commands: ['beta:run'],
+        skills: [{ name: 'skill-b' }, { name: 'skill-c' }],
+        hooks: { PostToolUse: [{ command: 'echo done' }] },
+        mcpServers: {
+          beta: { command: 'node' },
+          gamma: { command: 'node' },
+        },
+        path: '/extensions/beta',
+        config: { name: 'beta', version: '1.0.0' },
+      },
+    ] as unknown as Extension[];
+    const config = {
+      getExtensionManager: () => ({
+        refreshCache,
+        refreshTools,
+      }),
+      getActiveExtensions: () => activeExtensions,
+      getTargetDir: () => '/workspace',
+      reinitializeLsp,
+    } as unknown as Config;
+
+    const summary = await reloadPluginsRuntime({ config, reloadCommands });
+
+    expect(refreshCache).toHaveBeenCalledOnce();
+    expect(refreshTools).toHaveBeenCalledOnce();
+    expect(reinitializeLsp).toHaveBeenCalledOnce();
+    expect(reloadCommands).toHaveBeenCalledOnce();
+    expect(refreshCache.mock.invocationCallOrder[0]).toBeLessThan(
+      refreshTools.mock.invocationCallOrder[0],
+    );
+    expect(refreshTools.mock.invocationCallOrder[0]).toBeLessThan(
+      reinitializeLsp.mock.invocationCallOrder[0],
+    );
+    expect(reinitializeLsp.mock.invocationCallOrder[0]).toBeLessThan(
+      reloadCommands.mock.invocationCallOrder[0],
+    );
+    expect(summary).toEqual({
+      extensionCount: 2,
+      commandCount: 3,
+      skillCount: 3,
+      hookCount: 2,
+      mcpServerCount: 3,
+      lspServerCount: 1,
+    });
+  });
+
+  it('does not require an LSP reload hook', async () => {
+    const refreshCache = vi.fn(async () => {});
+    const refreshTools = vi.fn(async () => {});
+    const reloadCommands = vi.fn(async () => {});
+    const config = {
+      getExtensionManager: () => ({
+        refreshCache,
+        refreshTools,
+      }),
+      getActiveExtensions: () => [],
+      getTargetDir: () => '/workspace',
+    } as unknown as Config;
+
+    const summary = await reloadPluginsRuntime({ config, reloadCommands });
+
+    expect(refreshCache).toHaveBeenCalledOnce();
+    expect(refreshTools).toHaveBeenCalledOnce();
+    expect(reloadCommands).toHaveBeenCalledOnce();
+    expect(summary).toEqual({
+      extensionCount: 0,
+      commandCount: 0,
+      skillCount: 0,
+      hookCount: 0,
+      mcpServerCount: 0,
+      lspServerCount: 0,
+    });
   });
 });
 

--- a/packages/cli/src/config/hot-reload.ts
+++ b/packages/cli/src/config/hot-reload.ts
@@ -9,6 +9,7 @@ import {
   createDebugLogger,
   type Config,
   getMCPServerStatus,
+  LspConfigLoader,
   type MCPServerConfig,
 } from '@qwen-code/qwen-code-core';
 import type { LoadedSettings } from './settings.js';
@@ -21,6 +22,91 @@ import {
 import { appEvents, AppEvent } from '../utils/events.js';
 
 const debugLogger = createDebugLogger('MCP_HOT_RELOAD');
+
+type ConfigWithOptionalLspReload = Config & {
+  reinitializeLsp?: () => void | Promise<void>;
+};
+
+/**
+ * Clear the in-memory caches that serve model-visible skills and agents.
+ * Called immediately after every extension mutation so the next model turn
+ * sees the updated active-extension set without waiting for /reload-plugins.
+ * This is the qwen-code equivalent of Claude Code's clearAllCaches() — it
+ * clears memoization so downstream consumers re-read from getActiveExtensions(),
+ * but does NOT restart MCP servers or reload slash commands.
+ */
+export async function clearPluginCaches(config: Config): Promise<void> {
+  // Guard against null/incomplete config (e.g. in tests or non-interactive
+  // contexts where skill/subagent managers were never initialised).
+  if (!config?.getSkillManager && !config?.getSubagentManager) return;
+  const settled = await Promise.allSettled([
+    config.getSkillManager()?.refreshCache(),
+    config.getSubagentManager()?.refreshCache(),
+  ]);
+  for (const result of settled) {
+    if (result.status === 'rejected') {
+      debugLogger.warn(
+        'clearPluginCaches: a refreshCache leg failed:',
+        result.reason,
+      );
+    }
+  }
+}
+
+export interface ReloadPluginsRuntimeOptions {
+  config: Config;
+  reloadCommands?: () => void | Promise<void>;
+}
+
+export interface ReloadPluginsSummary {
+  extensionCount: number;
+  commandCount: number;
+  skillCount: number;
+  hookCount: number;
+  mcpServerCount: number;
+  lspServerCount: number;
+}
+
+export async function reloadPluginsRuntime({
+  config,
+  reloadCommands,
+}: ReloadPluginsRuntimeOptions): Promise<ReloadPluginsSummary> {
+  const extensionManager = config.getExtensionManager();
+  await extensionManager.refreshCache();
+  const activeExtensions = config.getActiveExtensions();
+  const lspConfigs = await new LspConfigLoader(
+    config.getTargetDir(),
+  ).loadExtensionConfigs(activeExtensions);
+  await extensionManager.refreshTools();
+  await (config as ConfigWithOptionalLspReload).reinitializeLsp?.();
+  await reloadCommands?.();
+
+  return {
+    extensionCount: activeExtensions.length,
+    commandCount: activeExtensions.reduce(
+      (sum, extension) => sum + (extension.commands?.length ?? 0),
+      0,
+    ),
+    skillCount: activeExtensions.reduce(
+      (sum, extension) => sum + (extension.skills?.length ?? 0),
+      0,
+    ),
+    hookCount: activeExtensions.reduce(
+      (sum, extension) =>
+        sum +
+        Object.values(extension.hooks ?? {}).reduce(
+          (hookSum, hooks) => hookSum + hooks.length,
+          0,
+        ),
+      0,
+    ),
+    mcpServerCount: activeExtensions.reduce(
+      (sum, extension) => sum + Object.keys(extension.mcpServers ?? {}).length,
+      0,
+    ),
+    lspServerCount: lspConfigs.length,
+  };
+}
 
 /**
  * The three connection-admission lists discovery consults to decide whether a

--- a/packages/cli/src/config/plugin-refresh-state.test.ts
+++ b/packages/cli/src/config/plugin-refresh-state.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearPluginsChanged,
+  markPluginsChanged,
+  needsPluginRefresh,
+  resetPluginRefreshStateForTesting,
+} from './plugin-refresh-state.js';
+import { appEvents, AppEvent } from '../utils/events.js';
+
+describe('plugin refresh state', () => {
+  beforeEach(() => {
+    resetPluginRefreshStateForTesting();
+  });
+
+  it('deduplicates plugin refresh notifications until cleared', () => {
+    const listener = vi.fn();
+    appEvents.on(AppEvent.PluginRefreshNeeded, listener);
+
+    try {
+      expect(markPluginsChanged('extension installed')).toBe(true);
+      expect(needsPluginRefresh()).toBe(true);
+      expect(listener).toHaveBeenCalledWith('extension installed');
+
+      expect(markPluginsChanged('extension updated')).toBe(false);
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      clearPluginsChanged();
+      expect(needsPluginRefresh()).toBe(false);
+
+      expect(markPluginsChanged('extension updated')).toBe(true);
+      expect(listener).toHaveBeenCalledTimes(2);
+      expect(listener).toHaveBeenLastCalledWith('extension updated');
+    } finally {
+      appEvents.off(AppEvent.PluginRefreshNeeded, listener);
+    }
+  });
+});

--- a/packages/cli/src/config/plugin-refresh-state.ts
+++ b/packages/cli/src/config/plugin-refresh-state.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { appEvents, AppEvent } from '../utils/events.js';
+
+let pluginRefreshNeeded = false;
+
+export function markPluginsChanged(reason?: string): boolean {
+  if (pluginRefreshNeeded) {
+    return false;
+  }
+  pluginRefreshNeeded = true;
+  appEvents.emit(AppEvent.PluginRefreshNeeded, reason);
+  return true;
+}
+
+export function clearPluginsChanged(): void {
+  pluginRefreshNeeded = false;
+}
+
+export function needsPluginRefresh(): boolean {
+  return pluginRefreshNeeded;
+}
+
+export function resetPluginRefreshStateForTesting(): void {
+  pluginRefreshNeeded = false;
+}

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -116,6 +116,10 @@ export default {
   'Open homepage': 'Open homepage',
   'Project (Workspace)': 'Project (Workspace)',
   'Refreshed {{count}} extension(s).': 'Refreshed {{count}} extension(s).',
+  'Reload extension runtime changes.': 'Reload extension runtime changes.',
+  'Reload failed.': 'Reload failed.',
+  'Reload failed: {{message}}': 'Reload failed: {{message}}',
+  'Reloaded: {{summary}}': 'Reloaded: {{summary}}',
   'Remove from Favorites': 'Remove from Favorites',
   'Remove marketplace': 'Remove marketplace',
   'Remove marketplace "{{name}}"?': 'Remove marketplace "{{name}}"?',
@@ -957,6 +961,8 @@ export default {
     'No plugins available in this marketplace.',
   'Select a plugin to install from marketplace "{{name}}":':
     'Select a plugin to install from marketplace "{{name}}":',
+  'Plugin changes detected. Run `/reload-plugins` to apply them.':
+    'Plugin changes detected. Run `/reload-plugins` to apply them.',
   'Plugin selection cancelled.': 'Plugin selection cancelled.',
   'Select a plugin from "{{name}}"': 'Select a plugin from "{{name}}"',
   'Use ↑↓ or j/k to navigate, Enter to select, Escape to cancel':

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -111,6 +111,10 @@ export default {
   'Open homepage': '開啟主頁',
   'Project (Workspace)': '專案（工作區）',
   'Refreshed {{count}} extension(s).': '已刷新 {{count}} 個擴充。',
+  'Reload extension runtime changes.': '重新載入擴展執行時變更。',
+  'Reload failed.': '重新載入失敗。',
+  'Reload failed: {{message}}': '重新載入失敗：{{message}}',
+  'Reloaded: {{summary}}': '已重新載入：{{summary}}',
   'Remove from Favorites': '從收藏中移除',
   'Remove marketplace': '移除市場來源',
   'Remove marketplace "{{name}}"?': '移除市場來源 "{{name}}"？',
@@ -887,6 +891,8 @@ export default {
   'No plugins available in this marketplace.': '此市場中沒有可用的插件。',
   'Select a plugin to install from marketplace "{{name}}":':
     '從市場 "{{name}}" 中選擇要安裝的插件：',
+  'Plugin changes detected. Run `/reload-plugins` to apply them.':
+    '偵測到插件變更。執行 `/reload-plugins` 以套用它們。',
   'Plugin selection cancelled.': '插件選擇已取消。',
   'Select a plugin from "{{name}}"': '從 "{{name}}" 中選擇插件',
   'Use ↑↓ or j/k to navigate, Enter to select, Escape to cancel':

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -109,6 +109,10 @@ export default {
   'Open homepage': '打开主页',
   'Project (Workspace)': '项目（工作区）',
   'Refreshed {{count}} extension(s).': '已刷新 {{count}} 个扩展。',
+  'Reload extension runtime changes.': '重新加载扩展运行时变更。',
+  'Reload failed.': '重新加载失败。',
+  'Reload failed: {{message}}': '重新加载失败：{{message}}',
+  'Reloaded: {{summary}}': '已重新加载：{{summary}}',
   'Remove from Favorites': '从收藏中移除',
   'Remove marketplace': '移除市场源',
   'Remove marketplace "{{name}}"?': '移除市场源 "{{name}}"？',
@@ -934,6 +938,8 @@ export default {
   'No plugins available in this marketplace.': '此市场中没有可用的插件。',
   'Select a plugin to install from marketplace "{{name}}":':
     '从市场 "{{name}}" 中选择要安装的插件：',
+  'Plugin changes detected. Run `/reload-plugins` to apply them.':
+    '检测到插件变更。执行 `/reload-plugins` 以应用它们。',
   'Plugin selection cancelled.': '插件选择已取消。',
   'Select a plugin from "{{name}}"': '从 "{{name}}" 中选择插件',
   'Use ↑↓ or j/k to navigate, Enter to select, Escape to cancel':

--- a/packages/cli/src/services/BuiltinCommandLoader.test.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.test.ts
@@ -65,6 +65,17 @@ vi.mock('../ui/commands/permissionsCommand.js', async () => {
   };
 });
 
+vi.mock('../ui/commands/reload-plugins-command.js', async () => {
+  const { CommandKind } = await import('../ui/commands/types.js');
+  return {
+    reloadPluginsCommand: {
+      name: 'reload-plugins',
+      description: 'Reload plugins command',
+      kind: CommandKind.BUILT_IN,
+    },
+  };
+});
+
 vi.mock('../ui/commands/hooksCommand.js', async () => {
   const { CommandKind } = await import('../ui/commands/types.js');
   return {
@@ -201,6 +212,9 @@ describe('BuiltinCommandLoader', () => {
 
     const modelCmd = commands.find((c) => c.name === 'model');
     expect(modelCmd).toBeDefined();
+
+    const reloadPluginsCmd = commands.find((c) => c.name === 'reload-plugins');
+    expect(reloadPluginsCmd).toBeDefined();
   });
 
   it('should include trust command when folder trust is enabled', async () => {

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -54,6 +54,7 @@ import { trustCommand } from '../ui/commands/trustCommand.js';
 import { quitCommand } from '../ui/commands/quitCommand.js';
 import { recapCommand } from '../ui/commands/recapCommand.js';
 import { renameCommand } from '../ui/commands/renameCommand.js';
+import { reloadPluginsCommand } from '../ui/commands/reload-plugins-command.js';
 import { restoreCommand } from '../ui/commands/restoreCommand.js';
 import { resumeCommand } from '../ui/commands/resumeCommand.js';
 import { rewindCommand } from '../ui/commands/rewindCommand.js';
@@ -154,6 +155,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       quitCommand,
       recapCommand,
       renameCommand,
+      reloadPluginsCommand,
       restoreCommand(this.config),
       resumeCommand,
       rewindCommand,

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -87,7 +87,7 @@ import {
   profileCheckpoint,
   finalizeStartupProfile,
 } from '../utils/startupProfiler.js';
-import { appEvents } from '../utils/events.js';
+import { appEvents, AppEvent } from '../utils/events.js';
 import process from 'node:process';
 
 /**
@@ -452,6 +452,7 @@ export const AppContainer = (props: AppContainerProps) => {
     extensionManager,
     historyManager.addItem,
     config.getWorkingDir(),
+    config,
   );
 
   const { providerUpdateRequest, dismissProviderUpdate } = useProviderUpdates(
@@ -887,6 +888,25 @@ export const AppContainer = (props: AppContainerProps) => {
     );
     updateHandlerRef.current = handler;
     return () => handler?.cleanup();
+  }, [historyManager.addItem]);
+
+  useEffect(() => {
+    const addItem = historyManager.addItem;
+    const onPluginRefreshNeeded = () => {
+      addItem(
+        {
+          type: MessageType.INFO,
+          text: t(
+            'Plugin changes detected. Run `/reload-plugins` to apply them.',
+          ),
+        },
+        Date.now(),
+      );
+    };
+    appEvents.on(AppEvent.PluginRefreshNeeded, onPluginRefreshNeeded);
+    return () => {
+      appEvents.off(AppEvent.PluginRefreshNeeded, onPluginRefreshNeeded);
+    };
   }, [historyManager.addItem]);
 
   // Derive widths for InputPrompt using shared helper

--- a/packages/cli/src/ui/commands/extensionsCommand.test.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.test.ts
@@ -9,6 +9,10 @@ import { MessageType } from '../types.js';
 import { extensionsCommand } from './extensionsCommand.js';
 import { type CommandContext } from './types.js';
 import {
+  needsPluginRefresh,
+  resetPluginRefreshStateForTesting,
+} from '../../config/plugin-refresh-state.js';
+import {
   describe,
   it,
   expect,
@@ -49,6 +53,7 @@ describe('extensionsCommand', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    resetPluginRefreshStateForTesting();
     mockOpenBrowserSecurely.mockResolvedValue(undefined);
     mockExtensionManager = createMockExtensionManager();
     mockGetExtensions.mockReturnValue([]);
@@ -236,7 +241,8 @@ describe('extensionsCommand', () => {
         },
         expect.any(Number),
       );
-      expect(mockContext.ui.reloadCommands).toHaveBeenCalled();
+      expect(mockContext.ui.reloadCommands).not.toHaveBeenCalled();
+      expect(needsPluginRefresh()).toBe(true);
     });
 
     it('should redact URL credentials in install progress messages', async () => {

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -251,7 +251,11 @@ async function installAction(context: CommandContext, args: string) {
       Date.now(),
     );
     if (context.services.config) {
-      await clearPluginCaches(context.services.config);
+      try {
+        await clearPluginCaches(context.services.config);
+      } catch {
+        // Cache refresh failure is recoverable via /reload-plugins.
+      }
     }
     markPluginsChanged('extension installed');
   } catch (error) {

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -5,6 +5,8 @@
  */
 
 import { getErrorMessage } from '../../utils/errors.js';
+import { clearPluginCaches } from '../../config/hot-reload.js';
+import { markPluginsChanged } from '../../config/plugin-refresh-state.js';
 import { MessageType } from '../types.js';
 import {
   type CommandContext,
@@ -231,7 +233,14 @@ async function installAction(context: CommandContext, args: string) {
       },
       Date.now(),
     );
-    const extension = await extensionManager.installExtension(installMetadata);
+    const extension = await extensionManager.installExtension(
+      installMetadata,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { refreshTools: false },
+    );
     context.ui.addItem(
       {
         type: MessageType.INFO,
@@ -241,8 +250,10 @@ async function installAction(context: CommandContext, args: string) {
       },
       Date.now(),
     );
-    // FIXME: refresh command controlled by ui for now, cannot be auto refreshed by extensionManager
-    context.ui.reloadCommands();
+    if (context.services.config) {
+      await clearPluginCaches(context.services.config);
+    }
+    markPluginsChanged('extension installed');
   } catch (error) {
     context.ui.addItem(
       {

--- a/packages/cli/src/ui/commands/reload-plugins-command.test.ts
+++ b/packages/cli/src/ui/commands/reload-plugins-command.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Config } from '@qwen-code/qwen-code-core';
+import { reloadPluginsCommand } from './reload-plugins-command.js';
+import type { CommandContext } from './types.js';
+import { reloadPluginsRuntime } from '../../config/hot-reload.js';
+import { clearPluginsChanged } from '../../config/plugin-refresh-state.js';
+
+vi.mock('../../config/hot-reload.js', () => ({
+  reloadPluginsRuntime: vi.fn(async () => ({
+    extensionCount: 1,
+    commandCount: 2,
+    skillCount: 3,
+    hookCount: 4,
+    mcpServerCount: 5,
+    lspServerCount: 6,
+  })),
+}));
+
+vi.mock('../../config/plugin-refresh-state.js', () => ({
+  clearPluginsChanged: vi.fn(),
+}));
+
+const reloadPluginsRuntimeMock = vi.mocked(reloadPluginsRuntime);
+const clearPluginsChangedMock = vi.mocked(clearPluginsChanged);
+
+describe('reloadPluginsCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns an error when config is missing', async () => {
+    const context = {
+      services: { config: null },
+      ui: { reloadCommands: vi.fn() },
+    } as unknown as CommandContext;
+
+    const result = await reloadPluginsCommand.action?.(context, '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Config not loaded.',
+    });
+    expect(reloadPluginsRuntimeMock).not.toHaveBeenCalled();
+    expect(clearPluginsChangedMock).not.toHaveBeenCalled();
+  });
+
+  it('reloads plugin runtime', async () => {
+    const config = {} as Config;
+    const reloadCommands = vi.fn();
+    const context = {
+      services: { config },
+      ui: { reloadCommands },
+    } as unknown as CommandContext;
+
+    const result = await reloadPluginsCommand.action?.(context, '');
+
+    expect(reloadPluginsRuntimeMock).toHaveBeenCalledWith({
+      config,
+      reloadCommands,
+    });
+    expect(clearPluginsChangedMock).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content:
+        'Reloaded: 1 plugin · 2 commands · 3 skills · 4 hooks · 5 plugin MCP servers · 6 plugin LSP servers',
+    });
+  });
+
+  it('surfaces reload failures without clearing the refresh flag', async () => {
+    // A failed reload must not clear the pending-refresh flag — the runtime is
+    // still stale, so the user should be able to retry /reload-plugins.
+    reloadPluginsRuntimeMock.mockRejectedValueOnce(new Error('boom'));
+
+    const config = {} as Config;
+    const reloadCommands = vi.fn();
+    const context = {
+      services: { config },
+      ui: { reloadCommands },
+    } as unknown as CommandContext;
+
+    const result = await reloadPluginsCommand.action?.(context, '');
+
+    expect(reloadPluginsRuntimeMock).toHaveBeenCalledWith({
+      config,
+      reloadCommands,
+    });
+    expect(clearPluginsChangedMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Reload failed: boom',
+    });
+  });
+});

--- a/packages/cli/src/ui/commands/reload-plugins-command.ts
+++ b/packages/cli/src/ui/commands/reload-plugins-command.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  reloadPluginsRuntime,
+  type ReloadPluginsSummary,
+} from '../../config/hot-reload.js';
+import { clearPluginsChanged } from '../../config/plugin-refresh-state.js';
+import { t } from '../../i18n/index.js';
+import {
+  CommandKind,
+  type CommandContext,
+  type MessageActionReturn,
+  type SlashCommand,
+} from './types.js';
+
+function countLabel(count: number, singular: string, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+export function formatReloadPluginsSummary(summary: ReloadPluginsSummary) {
+  return [
+    countLabel(summary.extensionCount, 'plugin'),
+    countLabel(summary.commandCount, 'command'),
+    countLabel(summary.skillCount, 'skill'),
+    countLabel(summary.hookCount, 'hook'),
+    countLabel(summary.mcpServerCount, 'plugin MCP server'),
+    countLabel(summary.lspServerCount, 'plugin LSP server'),
+  ].join(' · ');
+}
+
+export const reloadPluginsCommand: SlashCommand = {
+  name: 'reload-plugins',
+  get description() {
+    return t('Reload extension runtime changes.');
+  },
+  kind: CommandKind.BUILT_IN,
+  supportedModes: ['interactive'] as const,
+  action: async (context: CommandContext): Promise<MessageActionReturn> => {
+    const config = context.services.config;
+    if (!config) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: t('Config not loaded.'),
+      };
+    }
+
+    try {
+      const summary = await reloadPluginsRuntime({
+        config,
+        reloadCommands: context.ui.reloadCommands,
+      });
+      // Only clear the pending-refresh flag on a successful reload — a failed
+      // reload leaves the runtime stale, so the user should be able to retry
+      // /reload-plugins (and still see the "changes detected" notice if they
+      // haven't).
+      clearPluginsChanged();
+
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: t('Reloaded: {{summary}}', {
+          summary: formatReloadPluginsSummary(summary),
+        }),
+      };
+    } catch (error) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content:
+          error instanceof Error
+            ? t('Reload failed: {{message}}', { message: error.message })
+            : t('Reload failed.'),
+      };
+    }
+  },
+};

--- a/packages/cli/src/ui/components/extensions/ExtensionsManagerDialog.test.tsx
+++ b/packages/cli/src/ui/components/extensions/ExtensionsManagerDialog.test.tsx
@@ -16,6 +16,10 @@ import { KeypressProvider } from '../../contexts/KeypressContext.js';
 import { SettingsContext } from '../../contexts/SettingsContext.js';
 import { ShellFocusContext } from '../../contexts/ShellFocusContext.js';
 import { LoadedSettings } from '../../../config/settings.js';
+import {
+  needsPluginRefresh,
+  resetPluginRefreshStateForTesting,
+} from '../../../config/plugin-refresh-state.js';
 import type { UIState } from '../../contexts/UIStateContext.js';
 import type {
   Config,
@@ -98,6 +102,8 @@ const createConfig = (
   ({
     getExtensionManager: () => manager,
     getMcpServers: () => overrides.mcpServers ?? {},
+    getSkillManager: () => undefined,
+    getSubagentManager: () => undefined,
     getToolRegistry: () => undefined,
     getPromptRegistry: () => undefined,
     getResourceRegistry: () => undefined,
@@ -203,6 +209,7 @@ const renderWide = (config: Config, columns: number) => {
 describe('ExtensionsManagerDialog (tabbed)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetPluginRefreshStateForTesting();
   });
 
   it('renders the tab bar with all three tabs', () => {
@@ -421,6 +428,30 @@ describe('ExtensionsManagerDialog (tabbed)', () => {
     expect(frame).toContain('beta');
     // Plugins show their type + version (parallel to "MCP"), not a bare version.
     expect(frame).toContain('Extension v1.0.0');
+  });
+
+  it('marks plugins stale when toggling an installed plugin', async () => {
+    const manager = createManager({
+      extensions: [mockExtension('alpha', true)],
+    });
+    const { stdin, lastFrame } = renderDialog(createConfig(manager), {
+      initialTab: EXTENSIONS_TABS.INSTALLED,
+    });
+
+    await waitFor(() => {
+      expect(lastFrame()).toContain('alpha');
+    });
+    stdin.write(' ');
+
+    await waitFor(() => {
+      expect(manager.disableExtension).toHaveBeenCalledWith(
+        'alpha',
+        expect.any(String),
+        undefined,
+        { refreshTools: false },
+      );
+    });
+    expect(needsPluginRefresh()).toBe(true);
   });
 
   it('nests extension-bundled MCP servers under their extension on the Installed tab', async () => {

--- a/packages/cli/src/ui/components/extensions/tabs/DiscoverTab.tsx
+++ b/packages/cli/src/ui/components/extensions/tabs/DiscoverTab.tsx
@@ -22,6 +22,8 @@ import {
   createDebugLogger,
 } from '@qwen-code/qwen-code-core';
 import { getErrorMessage } from '../../../../utils/errors.js';
+import { clearPluginCaches } from '../../../../config/hot-reload.js';
+import { markPluginsChanged } from '../../../../config/plugin-refresh-state.js';
 import type { StatusMessage } from '../ExtensionsManagerDialog.js';
 
 const debugLogger = createDebugLogger('DISCOVER_TAB');
@@ -219,7 +221,14 @@ export const DiscoverTab = ({
         let ext;
         try {
           const metadata = await parseInstallSource(plugin.installSource);
-          ext = await extensionManager.installExtension(metadata);
+          ext = await extensionManager.installExtension(
+            metadata,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            { refreshTools: false },
+          );
         } catch (error) {
           errors.push(
             `${plugin.name}: ${redactUrlCredentials(getErrorMessage(error))}`,
@@ -238,11 +247,15 @@ export const DiscoverTab = ({
             await extensionManager.disableExtension(
               ext.name,
               SettingScope.User,
+              undefined,
+              { refreshTools: false },
             );
             try {
               await extensionManager.enableExtension(
                 ext.name,
                 SettingScope.Workspace,
+                undefined,
+                { refreshTools: false },
               );
             } catch (enableError) {
               // The User-scope disable already landed; roll it back so a failed
@@ -253,6 +266,8 @@ export const DiscoverTab = ({
                 await extensionManager.enableExtension(
                   ext.name,
                   SettingScope.User,
+                  undefined,
+                  { refreshTools: false },
                 );
               } catch (rollbackError) {
                 // Rollback failed: the extension is now disabled at every scope.
@@ -286,6 +301,15 @@ export const DiscoverTab = ({
       }
       setInstalling(false);
       setSelectedKeys(new Set());
+      if (installed > 0) {
+        try {
+          await clearPluginCaches(config);
+        } catch {
+          // Cache refresh failure is recoverable via /reload-plugins;
+          // don't suppress the install-success UI for a cache error.
+        }
+        markPluginsChanged('extension installed');
+      }
       if (errors.length === 0) {
         onStatus({
           type: 'success',
@@ -320,7 +344,7 @@ export const DiscoverTab = ({
         goToList();
       }
     },
-    [extensionManager, onStatus, load, onInstalled, goToList, onLockChange],
+    [extensionManager, config, onStatus, load, onInstalled, goToList, onLockChange],
   );
 
   const installWithScope = useCallback(

--- a/packages/cli/src/ui/components/extensions/tabs/InstalledTab.tsx
+++ b/packages/cli/src/ui/components/extensions/tabs/InstalledTab.tsx
@@ -33,6 +33,8 @@ import {
   SettingScope as CliSettingScope,
 } from '../../../../config/settings.js';
 import { getErrorMessage } from '../../../../utils/errors.js';
+import { clearPluginCaches } from '../../../../config/hot-reload.js';
+import { markPluginsChanged } from '../../../../config/plugin-refresh-state.js';
 import type {
   InstalledItem,
   InstalledGroup,
@@ -462,10 +464,21 @@ export const InstalledTab = ({
       });
       try {
         if (item.isActive) {
-          await extensionManager.disableExtension(item.name, scope);
+          await extensionManager.disableExtension(item.name, scope, undefined, {
+            refreshTools: false,
+          });
         } else {
-          await extensionManager.enableExtension(item.name, scope);
+          await extensionManager.enableExtension(item.name, scope, undefined, {
+            refreshTools: false,
+          });
         }
+        try {
+          await clearPluginCaches(config);
+        } catch {
+          // Cache refresh failure is recoverable via /reload-plugins;
+          // don't convert a successful toggle into a user-facing error.
+        }
+        markPluginsChanged('extension enablement changed');
         onStatus({
           type: 'success',
           text: t('"{{name}}" {{state}}.', {
@@ -480,7 +493,7 @@ export const InstalledTab = ({
         mutatingRef.current = false;
       }
     },
-    [extensionManager, load, onStatus],
+    [extensionManager, config, load, onStatus],
   );
 
   const toggleMcp = useCallback(

--- a/packages/cli/src/ui/components/extensions/tabs/SourcesTab.tsx
+++ b/packages/cli/src/ui/components/extensions/tabs/SourcesTab.tsx
@@ -216,7 +216,11 @@ export const SourcesTab = ({
         type: 'success',
         text: t('Installed extension "{{name}}".', { name: ext.name }),
       });
-      await clearPluginCaches(config);
+      try {
+        await clearPluginCaches(config);
+      } catch {
+        // Cache refresh failure is recoverable via /reload-plugins.
+      }
       markPluginsChanged('extension installed');
       await load();
       onChanged();

--- a/packages/cli/src/ui/components/extensions/tabs/SourcesTab.tsx
+++ b/packages/cli/src/ui/components/extensions/tabs/SourcesTab.tsx
@@ -22,6 +22,8 @@ import {
   createDebugLogger,
 } from '@qwen-code/qwen-code-core';
 import { getErrorMessage } from '../../../../utils/errors.js';
+import { clearPluginCaches } from '../../../../config/hot-reload.js';
+import { markPluginsChanged } from '../../../../config/plugin-refresh-state.js';
 import { stripUnsafeCharacters } from '../../../utils/textUtils.js';
 import type { StatusMessage } from '../ExtensionsManagerDialog.js';
 
@@ -202,11 +204,20 @@ export const SourcesTab = ({
     setBusy(true);
     try {
       const metadata = await parseInstallSource(input.trim());
-      const ext = await extensionManager.installExtension(metadata);
+      const ext = await extensionManager.installExtension(
+        metadata,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { refreshTools: false },
+      );
       onStatus({
         type: 'success',
         text: t('Installed extension "{{name}}".', { name: ext.name }),
       });
+      await clearPluginCaches(config);
+      markPluginsChanged('extension installed');
       await load();
       onChanged();
       goToList();
@@ -218,7 +229,7 @@ export const SourcesTab = ({
     } finally {
       setBusy(false);
     }
-  }, [extensionManager, input, onStatus, load, onChanged, goToList]);
+  }, [extensionManager, config, input, onStatus, load, onChanged, goToList]);
 
   const openSourceDetail = useCallback(
     async (source: ExtensionSource) => {

--- a/packages/cli/src/ui/components/extensions/views/ExtensionActionsView.tsx
+++ b/packages/cli/src/ui/components/extensions/views/ExtensionActionsView.tsx
@@ -131,7 +131,11 @@ export const ExtensionActionsView = ({
               );
             }
             setEnabled(!enabled);
-            await clearPluginCaches(config);
+            try {
+              await clearPluginCaches(config);
+            } catch {
+              // Cache refresh failure is recoverable via /reload-plugins.
+            }
             markPluginsChanged('extension enablement changed');
             onStatus({
               type: 'success',
@@ -210,7 +214,11 @@ export const ExtensionActionsView = ({
               () => {},
               false,
             );
-            await clearPluginCaches(config);
+            try {
+              await clearPluginCaches(config);
+            } catch {
+              // Cache refresh failure is recoverable via /reload-plugins.
+            }
             markPluginsChanged('extension updated');
             onStatus({
               type: 'success',
@@ -284,7 +292,11 @@ export const ExtensionActionsView = ({
         manager.setExtensionScope(name, newScope);
         setScope(newScope);
         setEnabled(true);
-        await clearPluginCaches(config);
+        try {
+          await clearPluginCaches(config);
+        } catch {
+          // Cache refresh failure is recoverable via /reload-plugins.
+        }
         markPluginsChanged('extension scope changed');
         onStatus({
           type: 'success',
@@ -311,7 +323,11 @@ export const ExtensionActionsView = ({
         await manager.uninstallExtension(ext.name, false, undefined, {
           refreshTools: false,
         });
-        await clearPluginCaches(config);
+        try {
+          await clearPluginCaches(config);
+        } catch {
+          // Cache refresh failure is recoverable via /reload-plugins.
+        }
         markPluginsChanged('extension uninstalled');
         onStatus({
           type: 'success',

--- a/packages/cli/src/ui/components/extensions/views/ExtensionActionsView.tsx
+++ b/packages/cli/src/ui/components/extensions/views/ExtensionActionsView.tsx
@@ -18,6 +18,8 @@ import {
   checkForExtensionUpdate,
 } from '@qwen-code/qwen-code-core';
 import { getErrorMessage } from '../../../../utils/errors.js';
+import { markPluginsChanged } from '../../../../config/plugin-refresh-state.js';
+import { clearPluginCaches } from '../../../../config/hot-reload.js';
 import { ExtensionUpdateState } from '../../../state/extensions.js';
 import {
   PluginDetailView,
@@ -114,11 +116,23 @@ export const ExtensionActionsView = ({
         switch (action) {
           case 'toggle':
             if (enabled) {
-              await manager.disableExtension(name, settingScopeFor(scope));
+              await manager.disableExtension(
+                name,
+                settingScopeFor(scope),
+                undefined,
+                { refreshTools: false },
+              );
             } else {
-              await manager.enableExtension(name, settingScopeFor(scope));
+              await manager.enableExtension(
+                name,
+                settingScopeFor(scope),
+                undefined,
+                { refreshTools: false },
+              );
             }
             setEnabled(!enabled);
+            await clearPluginCaches(config);
+            markPluginsChanged('extension enablement changed');
             onStatus({
               type: 'success',
               text: t('"{{name}}" {{state}}.', {
@@ -194,7 +208,10 @@ export const ExtensionActionsView = ({
               extension,
               ExtensionUpdateState.UPDATE_AVAILABLE,
               () => {},
+              false,
             );
+            await clearPluginCaches(config);
+            markPluginsChanged('extension updated');
             onStatus({
               type: 'success',
               text: t('Updated "{{name}}".', { name }),
@@ -211,7 +228,7 @@ export const ExtensionActionsView = ({
         onStatus({ type: 'error', text: getErrorMessage(error) });
       }
     },
-    [manager, extension, enabled, scope, onStatus, onReload],
+    [manager, config, extension, enabled, scope, onStatus, onReload],
   );
 
   const handleScope = useCallback(
@@ -225,17 +242,31 @@ export const ExtensionActionsView = ({
         // failed enable can't leave the prefs pointing at a scope the extension
         // isn't actually enabled at.
         if (newScope === 'user') {
-          await manager.enableExtension(name, SettingScope.User);
+          await manager.enableExtension(name, SettingScope.User, undefined, {
+            refreshTools: false,
+          });
         } else {
-          await manager.disableExtension(name, SettingScope.User);
+          await manager.disableExtension(name, SettingScope.User, undefined, {
+            refreshTools: false,
+          });
           try {
-            await manager.enableExtension(name, SettingScope.Workspace);
+            await manager.enableExtension(
+              name,
+              SettingScope.Workspace,
+              undefined,
+              { refreshTools: false },
+            );
           } catch (enableError) {
             // The User-scope disable already landed; if the Workspace enable
             // fails the extension would be disabled everywhere. Roll the User
             // enable back so it isn't silently dead.
             try {
-              await manager.enableExtension(name, SettingScope.User);
+              await manager.enableExtension(
+                name,
+                SettingScope.User,
+                undefined,
+                { refreshTools: false },
+              );
             } catch (rollbackError) {
               // Rollback also failed: the extension is now disabled at every
               // scope. Surface that explicitly — the bare enable error wouldn't
@@ -253,6 +284,8 @@ export const ExtensionActionsView = ({
         manager.setExtensionScope(name, newScope);
         setScope(newScope);
         setEnabled(true);
+        await clearPluginCaches(config);
+        markPluginsChanged('extension scope changed');
         onStatus({
           type: 'success',
           text: t('Set "{{name}}" scope to {{scope}}.', {
@@ -267,7 +300,7 @@ export const ExtensionActionsView = ({
       setScopeBusy(false);
       setSub('detail');
     },
-    [manager, extension, onStatus, onReload],
+    [manager, config, extension, onStatus, onReload],
   );
 
   const handleUninstall = useCallback(
@@ -275,7 +308,11 @@ export const ExtensionActionsView = ({
       if (!manager) return;
       setUninstallBusy(true);
       try {
-        await manager.uninstallExtension(ext.name, false);
+        await manager.uninstallExtension(ext.name, false, undefined, {
+          refreshTools: false,
+        });
+        await clearPluginCaches(config);
+        markPluginsChanged('extension uninstalled');
         onStatus({
           type: 'success',
           text: t('Uninstalled "{{name}}".', { name: ext.name }),
@@ -288,7 +325,7 @@ export const ExtensionActionsView = ({
       }
       onExit();
     },
-    [manager, onStatus, onReload, onExit],
+    [manager, config, onStatus, onReload, onExit],
   );
 
   // Escape: from the detail leaves; from a sub-view returns to the detail.

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.test.ts
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.test.ts
@@ -8,6 +8,7 @@ import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { resetPluginRefreshStateForTesting } from '../../config/plugin-refresh-state.js';
 
 import {
   useExtensionUpdates,
@@ -277,6 +278,7 @@ describe('useExtensionUpdates', () => {
   let userExtensionsDir: string;
 
   beforeEach(() => {
+    resetPluginRefreshStateForTesting();
     tempHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'qwen-cli-test-home-'));
     vi.mocked(os.homedir).mockReturnValue(tempHomeDir);
     userExtensionsDir = path.join(tempHomeDir, QWEN_DIR, 'extensions');

--- a/packages/cli/src/ui/hooks/useExtensionUpdates.ts
+++ b/packages/cli/src/ui/hooks/useExtensionUpdates.ts
@@ -5,11 +5,14 @@
  */
 
 import {
+  type Config,
   type ExtensionManager,
   getExtensionDisplayName,
 } from '@qwen-code/qwen-code-core';
 import { getCurrentLanguage } from '../../i18n/index.js';
 import { getErrorMessage } from '../../utils/errors.js';
+import { clearPluginCaches } from '../../config/hot-reload.js';
+import { markPluginsChanged } from '../../config/plugin-refresh-state.js';
 import {
   ExtensionUpdateState,
   extensionUpdatesReducer,
@@ -218,6 +221,7 @@ export const useExtensionUpdates = (
   extensionManager: ExtensionManager,
   addItem: UseHistoryManagerReturn['addItem'],
   cwd: string,
+  config?: Config,
 ) => {
   const [extensionsUpdateState, dispatchExtensionStateUpdate] = useReducer(
     extensionUpdatesReducer,
@@ -250,6 +254,7 @@ export const useExtensionUpdates = (
   }, [
     extensions,
     extensionManager,
+    config,
     extensionsUpdateState.extensionStatuses,
     dispatchExtensionStateUpdate,
   ]);
@@ -289,9 +294,19 @@ export const useExtensionUpdates = (
                 payload: { name: extensionName, state },
               });
             },
+            false,
           )
-          .then((result) => {
+          .then(async (result) => {
             if (!result) return;
+            if (config) {
+              try {
+                await clearPluginCaches(config);
+              } catch {
+                // Cache refresh failure is recoverable via /reload-plugins;
+                // don't convert a successful update into a user-facing error.
+              }
+            }
+            markPluginsChanged('extension updated');
             addItem(
               {
                 type: MessageType.INFO,
@@ -323,7 +338,14 @@ export const useExtensionUpdates = (
         Date.now(),
       );
     }
-  }, [extensions, extensionManager, extensionsUpdateState, addItem, cwd]);
+  }, [
+    extensions,
+    extensionManager,
+    config,
+    extensionsUpdateState,
+    addItem,
+    cwd,
+  ]);
 
   const extensionsUpdateStateComputed = useMemo(() => {
     const result = new Map<string, ExtensionUpdateState>();

--- a/packages/cli/src/utils/events.ts
+++ b/packages/cli/src/utils/events.ts
@@ -9,6 +9,7 @@ import { EventEmitter } from 'node:events';
 export enum AppEvent {
   OpenDebugConsole = 'open-debug-console',
   LogError = 'log-error',
+  PluginRefreshNeeded = 'plugin-refresh-needed',
   OauthDisplayMessage = 'oauth-display-message',
   OauthAuthUrl = 'oauth-auth-url',
   /**

--- a/packages/core/src/extension/extensionManager.test.ts
+++ b/packages/core/src/extension/extensionManager.test.ts
@@ -23,7 +23,11 @@ import {
   hashValue,
   type ExtensionConfig,
 } from './extensionManager.js';
-import type { MCPServerConfig, ExtensionInstallMetadata } from '../index.js';
+import type {
+  Config,
+  MCPServerConfig,
+  ExtensionInstallMetadata,
+} from '../index.js';
 
 const mockGit = {
   clone: vi.fn(),
@@ -786,6 +790,78 @@ describe('extension tests', () => {
 
       await manager.enableExtension('ext1', SettingScope.Workspace);
       expect(manager.isEnabled('ext1', tempWorkspaceDir)).toBe(true);
+    });
+
+    it('should skip tool refresh when requested', async () => {
+      createExtension({
+        extensionsDir: userExtensionsDir,
+        name: 'ext1',
+        version: '1.0.0',
+      });
+      const mockRestartMcpServers = vi.fn();
+      const mockRefreshCache = vi.fn();
+      const mockRefreshHierarchicalMemory = vi.fn();
+      const manager = createExtensionManager();
+      manager.setConfig({
+        getToolRegistry: () => ({
+          restartMcpServers: mockRestartMcpServers,
+        }),
+        getSkillManager: () => ({
+          refreshCache: mockRefreshCache,
+        }),
+        getSubagentManager: () => ({
+          refreshCache: mockRefreshCache,
+        }),
+        refreshHierarchicalMemory: mockRefreshHierarchicalMemory,
+      } as unknown as Config);
+      await manager.refreshCache();
+
+      await manager.disableExtension('ext1', SettingScope.User, undefined, {
+        refreshTools: false,
+      });
+      expect(manager.isEnabled('ext1')).toBe(false);
+      expect(
+        manager.getLoadedExtensions().find((ext) => ext.name === 'ext1')
+          ?.isActive,
+      ).toBe(false);
+
+      await manager.enableExtension('ext1', SettingScope.User, undefined, {
+        refreshTools: false,
+      });
+
+      expect(mockRestartMcpServers).not.toHaveBeenCalled();
+      expect(mockRefreshCache).not.toHaveBeenCalled();
+      expect(mockRefreshHierarchicalMemory).not.toHaveBeenCalled();
+      expect(manager.isEnabled('ext1')).toBe(true);
+      expect(
+        manager.getLoadedExtensions().find((ext) => ext.name === 'ext1')
+          ?.isActive,
+      ).toBe(true);
+    });
+
+    it('should refresh tools by default when disabling (no options)', async () => {
+      createExtension({
+        extensionsDir: userExtensionsDir,
+        name: 'ext2',
+        version: '1.0.0',
+      });
+      const mockRestartMcpServers = vi.fn();
+      const manager = createExtensionManager();
+      manager.setConfig({
+        getToolRegistry: () => ({ restartMcpServers: mockRestartMcpServers }),
+        getSkillManager: () => ({ refreshCache: vi.fn() }),
+        getSubagentManager: () => ({ refreshCache: vi.fn() }),
+      } as unknown as Config);
+      await manager.refreshCache();
+
+      // Disable without passing options — refreshTools should still run.
+      await manager.disableExtension('ext2', SettingScope.User);
+
+      expect(manager.isEnabled('ext2')).toBe(false);
+      // Default refreshTools: true means restartMcpServers IS called (unlike
+      // the explicit { refreshTools: false } test above that asserts the
+      // opposite).
+      expect(mockRestartMcpServers).toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/extension/extensionManager.ts
+++ b/packages/core/src/extension/extensionManager.ts
@@ -112,6 +112,10 @@ export enum SettingScope {
   SystemDefaults = 'SystemDefaults',
 }
 
+interface ExtensionRuntimeRefreshOptions {
+  refreshTools?: boolean;
+}
+
 export interface ExtensionChannelConfig {
   /** Relative path to JS entry point (must export `plugin: ChannelPlugin`) */
   entry: string;
@@ -435,6 +439,7 @@ export class ExtensionManager {
     name: string,
     scope: SettingScope,
     cwd?: string,
+    options?: ExtensionRuntimeRefreshOptions,
   ): Promise<void> {
     const currentDir = cwd ?? this.workspaceDir;
     if (
@@ -455,7 +460,9 @@ export class ExtensionManager {
     const config = getTelemetryConfig(currentDir, this.telemetrySettings);
     logExtensionEnable(config, new ExtensionEnableEvent(name, scope));
     extension.isActive = true;
-    await this.refreshTools();
+    if (options?.refreshTools ?? true) {
+      await this.refreshTools();
+    }
   }
 
   /**
@@ -465,6 +472,7 @@ export class ExtensionManager {
     name: string,
     scope: SettingScope,
     cwd?: string,
+    options?: ExtensionRuntimeRefreshOptions,
   ): Promise<void> {
     const currentDir = cwd ?? this.workspaceDir;
     const config = getTelemetryConfig(currentDir, this.telemetrySettings);
@@ -485,7 +493,9 @@ export class ExtensionManager {
     this.disableByPath(name, true, scopePath);
     logExtensionDisable(config, new ExtensionDisableEvent(name, scope));
     extension.isActive = false;
-    await this.refreshTools();
+    if (options?.refreshTools ?? true) {
+      await this.refreshTools();
+    }
   }
 
   /**
@@ -1018,6 +1028,7 @@ export class ExtensionManager {
     requestSetting?: (setting: ExtensionSetting) => Promise<string>,
     cwd?: string,
     previousExtensionConfig?: ExtensionConfig,
+    options?: ExtensionRuntimeRefreshOptions,
   ): Promise<Extension> {
     const currentDir = cwd ?? this.workspaceDir;
     const telemetryConfig = getTelemetryConfig(
@@ -1287,7 +1298,9 @@ export class ExtensionManager {
               'success',
             ),
           );
-          await this.refreshTools();
+          if (options?.refreshTools ?? true) {
+            await this.refreshTools();
+          }
         } else {
           logExtensionInstallEvent(
             telemetryConfig,
@@ -1301,6 +1314,8 @@ export class ExtensionManager {
           await this.enableExtension(
             newExtensionConfig.name,
             SettingScope.User,
+            undefined,
+            options,
           );
         }
       } finally {
@@ -1385,6 +1400,7 @@ export class ExtensionManager {
     extensionIdentifier: string,
     isUpdate: boolean,
     cwd?: string,
+    options?: ExtensionRuntimeRefreshOptions,
   ): Promise<void> {
     const currentDir = cwd ?? this.workspaceDir;
     const telemetryConfig = getTelemetryConfig(
@@ -1421,7 +1437,9 @@ export class ExtensionManager {
 
     this.removeEnablementConfig(extension.name);
     this.preferencesStore.clear(extension.name);
-    await this.refreshTools();
+    if (options?.refreshTools ?? true) {
+      await this.refreshTools();
+    }
 
     logExtensionUninstall(
       telemetryConfig,
@@ -1512,6 +1530,7 @@ export class ExtensionManager {
           undefined,
           undefined,
           previousExtensionConfig,
+          { refreshTools: enableExtensionReloading },
         );
       } catch (e) {
         callback(extension.name, ExtensionUpdateState.ERROR);

--- a/packages/core/src/extension/extensionManager.ts
+++ b/packages/core/src/extension/extensionManager.ts
@@ -112,7 +112,7 @@ export enum SettingScope {
   SystemDefaults = 'SystemDefaults',
 }
 
-interface ExtensionRuntimeRefreshOptions {
+export interface ExtensionRuntimeRefreshOptions {
   refreshTools?: boolean;
 }
 


### PR DESCRIPTION
## What this PR does

This PR adds a `/reload-plugins` slash command and a lightweight plugin-stale notification flow for Qwen Code extensions, aligning with Claude Code's plugin reload model. When a user installs, uninstalls, updates, enables, disables, or changes the scope of an extension, the runtime no longer rebuilds tool registrations inline on every operation. Instead each mutation marks plugin runtime state as stale and surfaces one deduplicated in-chat notice: `Plugin changes detected. Run /reload-plugins to apply them.` Running `/reload-plugins` performs one coordinated refresh — extension cache, tools, plugin-provided LSP servers, and slash commands — and reports a summary (plugins, commands, skills, hooks, MCP/LSP server counts). A failed reload surfaces a friendly error and keeps the stale flag set so the user can retry.

To let mutations defer the expensive tool refresh, `ExtensionManager.enableExtension` / `disableExtension` / `installExtension` / `uninstallExtension` / `updateExtension` gain an optional `{ refreshTools?: boolean }` option (default `true`, preserving existing behavior). All extension UI entry points pass `refreshTools: false` so the refresh happens once, inside `/reload-plugins`, instead of being interleaved with every mutation.

Model-visible skills and agents are auto-refreshed after every mutation via `clearPluginCaches()`, which rebuilds `SkillManager` and `SubagentManager` caches so the next model turn sees the updated active-extension set — matching Claude Code's `clearAllCaches()` for model-facing memoization.

## Why it's needed

Issue #3696 asks for extension-provided runtime features to be refreshable without a full process restart. The design aligns with Claude Code's plugin reload model: a narrow, manual, plugin-scoped reload command, with automatic hot reload left to the subsystems that already support it. `/reload-plugins` only touches extension runtime state, and only extension management mutations mark plugins stale.

## Development process

This PR delivers the first two slices together, because the manual command is only useful once mutations route through the stale flag.

**Slice 1 — Manual reload command.** Added `reloadPluginsRuntime()` with the runtime sequence: `refreshCache()` → `refreshTools()` → optional LSP reinitialize → optional slash command reload. LSP reinitialize is duck-typed (`config.reinitializeLsp?.()`) because the CLI layer does not yet have a stable LSP service type; this cast can be removed once the LSP API stabilizes. Added `reload-plugins-command.ts` and registered it in `BuiltinCommandLoader`. Added `ReloadPluginsSummary` so the command can report what was reloaded, matching Claude Code's `Reloaded: N plugins · N commands · ...` shape.

**Slice 2 — Plugin stale state and mutation wiring.** Added `plugin-refresh-state.ts` with `markPluginsChanged(reason)`, `clearPluginsChanged()`, `needsPluginRefresh()`. `markPluginsChanged` is idempotent — repeated stale events before reload do not spam notifications. `AppContainer` subscribes to the `PluginRefreshNeeded` event and pushes one in-chat history item. Wired every extension management mutation to `markPluginsChanged`: install (CLI + Discover + Sources), enable/disable (Installed + Actions), update (Actions + `useExtensionUpdates`), scope change (Actions), uninstall (Actions). On the core side, added `{ refreshTools?: boolean }` to the relevant `ExtensionManager` methods so mutations skip the inline tool refresh and defer it to `/reload-plugins`. `clearPluginsChanged()` runs only after a successful reload — a failed reload leaves the flag set.

**Model-visible skills/agents auto-refresh.** Added `clearPluginCaches()` that rebuilds `SkillManager` and `SubagentManager` caches immediately after every mutation, so the next model turn sees the updated active-extension set without waiting for `/reload-plugins`. This matches Claude Code's `clearAllCaches()` memo clearing.

**What's next.** The extension filesystem watcher is out of scope for this PR and will follow. It will detect extension runtime file edits the user did not initiate — `qwen-extension.json` manifest edits, extension command/agent/hook files, and extension storage files — and mark plugins stale instead of auto-refreshing. Existing subsystem-owned hot reload (skills via `SkillManager`, settings-backed MCP, LSP config) is intentionally left untouched and will not be duplicated.

Commands and hooks are not yet covered by the auto-refresh path. Model-visible commands flow through `CommandService`, which has no independent cache-invalidation primitive. Disabled-plugin hook pruning requires a `pruneRemovedPluginHooks` equivalent that qwen-code does not yet have. Both will be addressed in a follow-up PR.

## Reviewer Test Plan

### How to verify

1. Start an interactive session: `node packages/cli/dist/index.js`. Use a clean `QWEN_HOME` (e.g. `QWEN_HOME=/tmp/qwen-plugin-reload-home`) if you want toggle state to actually flip.
2. `/extensions` → **Installed** tab → space to toggle an extension.
3. Exit the dialog. Expected: chat history shows `Plugin changes detected. Run /reload-plugins to apply them.`
4. Run `/reload-plugins`. Expected: `Reloaded: N plugins · N commands · N skills · N hooks · N plugin MCP servers · N plugin LSP servers`.
5. Toggle again without reloading. Expected: no duplicate notification (stale flag dedupes until cleared).
6. (Failure path) Force a reload failure and run `/reload-plugins`. Expected: an `error` message `Reload failed: ...`, and the stale flag is NOT cleared — re-running after the cause is fixed still works.

Unit tests cover: stale flag lifecycle and dedup (`plugin-refresh-state.test.ts`); the `/reload-plugins` command success and failure paths, including "failure does not clear the flag" (`reload-plugins-command.test.ts`); `reloadPluginsRuntime` call ordering and optional LSP (`hot-reload.test.ts`); command registration (`BuiltinCommandLoader.test.ts`); install no longer auto-reloading (`extensionsCommand.test.ts`); toggle marking stale (`ExtensionsManagerDialog.test.tsx`); the core `refreshTools` option (`extensionManager.test.ts`).

### Evidence (Before & After)

N/A — behavior is observable via the in-chat notification and `/reload-plugins` summary; see steps above.

https://github.com/user-attachments/assets/a2e5734a-e3c8-41a6-a56f-c66e5f846589



### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |   ⚠️    |
|  🐧 Linux  |   ⚠️    |

### Environment (optional)

Local macOS development, `node packages/cli/dist/index.js`; unit tests via `npx vitest run` in `packages/cli` and `packages/core`.

## Risk & Scope

- Main risk or tradeoff: extension mutations no longer apply immediately — the user must run `/reload-plugins` to activate changes. This is intentional and matches Claude Code, but anyone relying on the old inline `refreshTools` per operation will see a one-step delay. The `refreshTools` option defaults to `true`, so non-UI callers and programmatic paths are unaffected.
- Not validated / out of scope: the extension filesystem watcher and boundary tests for hooks/channels/context files. Settings.json-driven MCP/skill hot reload, LSP `.lsp.json` hot reload, and `SkillManager` skill content watching remain subsystem-owned and are not touched. A `needsRefresh` flag for non-extension subsystems is intentionally not added. Model-visible command cache invalidation and disabled-plugin hook pruning are tracked for a follow-up PR.
- Breaking changes / migration notes: none. The new `options?` parameter on `ExtensionManager` methods is optional and defaults to current behavior.

## Linked Issues

Progress on https://github.com/QwenLM/qwen-code/issues/3696 (sub-task 5: reload slash command; sub-task 6: needsRefresh notification, scoped to the extension/plugin subsystem).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

本 PR 为 Qwen Code 扩展新增 `/reload-plugins` 斜杠命令和一套轻量的"插件需要重载"通知流程，对齐 Claude Code 的插件重载模型。用户安装、卸载、更新、启用、禁用或修改扩展作用域时，运行时不再在每次操作后内联重建工具注册；改为将插件运行时状态标记为 stale，并在聊天中推送一条去重后的提示：`Plugin changes detected. Run /reload-plugins to apply them.`。执行 `/reload-plugins` 会一次性完成协调刷新——扩展缓存、工具、插件提供的 LSP server、斜杠命令——并报告重载摘要（插件、命令、skill、hook、MCP/LSP server 数量）。重载失败时返回友好错误信息，并保留 stale 标记，用户可重试。

为让变更延迟执行昂贵的 tool 刷新，`ExtensionManager` 的 `enableExtension` / `disableExtension` / `installExtension` / `uninstallExtension` / `updateExtension` 新增可选参数 `{ refreshTools?: boolean }`（默认 `true`，保持现有行为）。所有扩展 UI 入口传 `refreshTools: false`，让刷新集中在 `/reload-plugins` 一次完成，而不是穿插在每次变更中。

模型可见的 skills 和 agents 在每次变更后通过 `clearPluginCaches()` 立即自动刷新——重建 `SkillManager` 和 `SubagentManager` 缓存，模型下一轮就能看到更新后的活跃扩展集合。这对应 Claude Code 的 `clearAllCaches()` 模型层 memo 清理。

## 为什么需要

Issue #3696 要求扩展提供的运行时特性无需重启进程即可刷新。设计对齐 Claude Code 的插件重载模型：一个范围窄、手动触发、只针对插件运行时的重载命令，自动热重载留给已经支持它的子系统。`/reload-plugins` 只动扩展运行时状态，只有扩展管理操作会标记插件为 stale。

## 开发过程

本 PR 一次性交付前两个切片，因为手动命令只有在变更路由到 stale 标记后才有意义。

**切片 1 —— 手动重载命令。** 新增 `reloadPluginsRuntime()`，运行时顺序为：`refreshCache()` → `refreshTools()` → 可选的 LSP 重初始化 → 可选的斜杠命令重载。LSP 重初始化采用 duck typing，因为 CLI 层还没有稳定的 LSP service 类型；等 LSP API 稳定后可移除。新增 `reload-plugins-command.ts` 并在 `BuiltinCommandLoader` 中注册。新增 `ReloadPluginsSummary`，让命令能报告重载了什么，与 Claude Code 的 `Reloaded: N plugins · N commands · ...` 形式一致。

**切片 2 —— 插件 stale 状态与变更接线。** 新增 `plugin-refresh-state.ts`，提供 `markPluginsChanged(reason)`、`clearPluginsChanged()`、`needsPluginRefresh()`。`markPluginsChanged` 是幂等的——重载前的重复 stale 事件不会刷屏。`AppContainer` 订阅 `PluginRefreshNeeded` 事件，向聊天历史推送一条消息。将所有扩展管理操作接线到 `markPluginsChanged`：install、enable/disable、update、scope 变更、uninstall。在 core 层，给相关 `ExtensionManager` 方法新增 `{ refreshTools?: boolean }`，让变更跳过内联 tool 刷新，延迟到 `/reload-plugins`。`clearPluginsChanged()` 只在重载成功后执行——重载失败时保留 stale 标记。

**模型可见 skills/agents 自动刷新。** 新增 `clearPluginCaches()`，在每次扩展变更后立即重建 `SkillManager` 和 `SubagentManager` 缓存，模型下一轮无需等待 `/reload-plugins` 即可看到更新后的活跃扩展集合。对齐 Claude Code 的 `clearAllCaches()` memo 清理。

**后续计划。** 扩展文件系统 watcher 不在本 PR 范围内，后续补上。它将检测用户未主动发起的扩展运行时文件编辑——`qwen-extension.json` manifest 编辑、扩展 command/agent/hook 文件、扩展存储文件——并标记插件为 stale 而非自动刷新。已有子系统级热重载（skills 经 `SkillManager`、settings 支持的 MCP、LSP config）保持不动。

Commands 和 hooks 尚未纳入自动刷新路径。模型可见的 commands 通过 `CommandService` 流转，该服务目前没有独立的缓存失效原语。被禁用插件的 hooks 立即摘除需要 `pruneRemovedPluginHooks` 等价实现，qwen-code 目前缺失。两者将在后续 PR 中处理。

## Reviewer 测试计划

### 如何验证

1. 启动交互 session：`node packages/cli/dist/index.js`。若希望 toggle 状态真正翻转，使用干净的 `QWEN_HOME`（如 `QWEN_HOME=/tmp/qwen-plugin-reload-home`）。
2. `/extensions` → **Installed** 标签页 → 空格 toggle 一个扩展。
3. 退出对话框。预期：聊天历史出现 `Plugin changes detected. Run /reload-plugins to apply them.`
4. 执行 `/reload-plugins`。预期：返回 `Reloaded: N plugins · N commands · N skills · N hooks · N plugin MCP servers · N plugin LSP servers`。
5. 不重载再次 toggle。预期：不重复提示（stale 标记幂等，直到清除）。
6. （失败路径）制造重载失败并执行 `/reload-plugins`。预期：返回 `error` 消息 `Reload failed: ...`，且 stale 标记未清除——修复后重跑仍可生效。

单测覆盖：stale 标记生命周期与去重、`/reload-plugins` 命令成功与失败路径、`reloadPluginsRuntime` 调用顺序与可选 LSP、命令注册、install 不再自动刷新、toggle 设置 stale、core 层 `refreshTools` 选项。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |   ⚠️    |
|  🐧 Linux  |   ⚠️    |

## 风险与范围

- 主要风险/权衡：扩展变更不再立即生效——用户需执行 `/reload-plugins` 激活。这是有意的，与 Claude Code 一致，但依赖旧的内联 `refreshTools` 的路径会有一步延迟。`refreshTools` 选项默认 `true`，非 UI 调用方和编程式路径不受影响。
- 未验证/范围外：扩展文件系统 watcher 以及 hooks/channels/context files 的边界测试。settings.json 驱动的 MCP/skill 热重载、LSP `.lsp.json` 热重载、`SkillManager` 的 skill 内容监听仍由子系统拥有。非扩展子系统的 `needsRefresh` 标记有意不加。模型可见的 command 缓存失效和被禁用插件的 hooks 立即摘除留待后续 PR。
- 破坏性变更/迁移说明：无。`ExtensionManager` 方法新增的 `options?` 参数可选，默认行为不变。

## 关联 Issue

推进 https://github.com/QwenLM/qwen-code/issues/3696（子任务 5：reload 斜杠命令；子任务 6：needsRefresh 通知，范围限定在扩展/插件子系统）。

</details>
