### PR TITLE
feat(channel): add proactive routines

### DIFF
--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -571,6 +571,7 @@ describe('ChannelBase', () => {
     it('/schedule add rejects a target that already has too many jobs', async () => {
       const existingJobs = Array.from({ length: 10 }, (_, index) => ({
         id: `job-${index}`,
+        enabled: true,
       }));
       const createSchedule = vi.fn();
       const ch = createChannel(
@@ -591,6 +592,40 @@ describe('ChannelBase', () => {
       );
 
       expect(createSchedule).not.toHaveBeenCalled();
+      expect(ch.sent[0]!.text).toContain('Too many scheduled jobs');
+    });
+
+    it('/schedule add uses the atomic target quota when available', async () => {
+      const createForTarget = vi.fn().mockResolvedValue(undefined);
+      const createSchedule = vi.fn();
+      const listForTarget = vi.fn();
+      const ch = createChannel(
+        {},
+        {
+          scheduleController: {
+            create: createSchedule,
+            createForTarget,
+            listForTarget,
+            disable: vi.fn(),
+            validateCron: vi.fn(),
+          },
+        },
+      );
+      ch.proactiveSupported = true;
+
+      await ch.handleInbound(
+        envelope({ text: '/schedule add "0 9 * * *" post summary' }),
+      );
+
+      expect(createForTarget).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channelName: 'test-chan',
+          prompt: 'post summary',
+        }),
+        10,
+      );
+      expect(createSchedule).not.toHaveBeenCalled();
+      expect(listForTarget).not.toHaveBeenCalled();
       expect(ch.sent[0]!.text).toContain('Too many scheduled jobs');
     });
 

--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -4840,6 +4840,48 @@ describe('ChannelBase', () => {
       }
     });
 
+    it('does not push a scheduled response after the session is cancelled', async () => {
+      let resolveScheduledPrompt: (value: string) => void = () => {};
+      (bridge.prompt as ReturnType<typeof vi.fn>).mockImplementationOnce(
+        () =>
+          new Promise<string>((resolve) => {
+            resolveScheduledPrompt = resolve;
+          }),
+      );
+      const ch = createChannel();
+      ch.enableCancelCommand();
+      ch.proactiveSupported = true;
+
+      const scheduled = ch.runScheduledPrompt({
+        id: 'job-1',
+        channelName: 'test-chan',
+        target: {
+          channelName: 'test-chan',
+          senderId: 'alice',
+          chatId: 'chat1',
+          isGroup: false,
+        },
+        cwd: '/tmp',
+        cron: '0 9 * * *',
+        prompt: 'post summary',
+        label: 'daily summary',
+        recurring: true,
+        enabled: true,
+        createdBy: 'Alice',
+        createdAt: '2026-06-30T01:00:00.000Z',
+        consecutiveFailures: 0,
+      });
+      await vi.waitFor(() => {
+        expect(bridge.prompt).toHaveBeenCalledOnce();
+      });
+
+      await ch.handleInbound(envelope({ text: '/cancel', senderId: 'alice' }));
+      resolveScheduledPrompt('late scheduled response');
+      await scheduled;
+
+      expect(ch.proactive).toEqual([]);
+    });
+
     it('disables a stored job when its sender is no longer allowed', async () => {
       const disable = vi.fn().mockResolvedValue(true);
       const ch = createChannel(

--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -4840,6 +4840,87 @@ describe('ChannelBase', () => {
       }
     });
 
+    it('evicts the bridge session after a scheduled timeout', async () => {
+      let rejectLatePrompt: (error: Error) => void = () => {};
+      (bridge.prompt as ReturnType<typeof vi.fn>)
+        .mockImplementationOnce(
+          () =>
+            new Promise<string>((_resolve, reject) => {
+              rejectLatePrompt = reject;
+            }),
+        )
+        .mockResolvedValueOnce('second response');
+      const ch = createChannel();
+      ch.proactiveSupported = true;
+
+      vi.useFakeTimers();
+      try {
+        const scheduled = ch.runScheduledPrompt(
+          {
+            id: 'job-1',
+            channelName: 'test-chan',
+            target: {
+              channelName: 'test-chan',
+              senderId: 'alice',
+              chatId: 'chat1',
+              isGroup: false,
+            },
+            cwd: '/tmp',
+            cron: '0 9 * * *',
+            prompt: 'post summary',
+            label: 'daily summary',
+            recurring: true,
+            enabled: true,
+            createdBy: 'Alice',
+            createdAt: '2026-06-30T01:00:00.000Z',
+            consecutiveFailures: 0,
+          },
+          { timeoutMs: 1000 },
+        );
+        const scheduledResult = scheduled.catch((error: unknown) => error);
+        await vi.waitFor(() => expect(bridge.prompt).toHaveBeenCalledOnce());
+
+        await vi.advanceTimersByTimeAsync(1000);
+        await expect(scheduledResult).resolves.toMatchObject({
+          message: 'scheduled job timed out',
+        });
+        rejectLatePrompt(new Error('late bridge failure'));
+        await Promise.resolve();
+
+        await ch.runScheduledPrompt({
+          id: 'job-2',
+          channelName: 'test-chan',
+          target: {
+            channelName: 'test-chan',
+            senderId: 'alice',
+            chatId: 'chat1',
+            isGroup: false,
+          },
+          cwd: '/tmp',
+          cron: '0 9 * * *',
+          prompt: 'post again',
+          label: 'daily summary',
+          recurring: true,
+          enabled: true,
+          createdBy: 'Alice',
+          createdAt: '2026-06-30T01:00:00.000Z',
+          consecutiveFailures: 0,
+        });
+
+        expect(bridge.newSession).toHaveBeenCalledTimes(2);
+        expect(bridge.prompt).toHaveBeenLastCalledWith(
+          's-2',
+          '[Scheduled task "daily summary" set by Alice]\n\npost again',
+          {},
+        );
+        expect(ch.proactive).toEqual([
+          { chatId: 'chat1', text: 'second response' },
+        ]);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('does not push a scheduled response after the session is cancelled', async () => {
       let resolveScheduledPrompt: (value: string) => void = () => {};
       (bridge.prompt as ReturnType<typeof vi.fn>).mockImplementationOnce(

--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -4,10 +4,16 @@ import type { ChannelConfig, Envelope } from './types.js';
 import type { ChannelAgentBridge } from './ChannelAgentBridge.js';
 import { ChannelBase, CLEAR_CANCEL_TIMEOUT_MS } from './ChannelBase.js';
 import type { ChannelBaseOptions } from './ChannelBase.js';
+import type {
+  ChannelCronJob,
+  ChannelCronJobInput,
+} from './ChannelCronStore.js';
 
 // Concrete test implementation
 class TestChannel extends ChannelBase {
   sent: Array<{ chatId: string; text: string }> = [];
+  proactive: Array<{ chatId: string; text: string }> = [];
+  proactiveSupported = false;
   connected = false;
   toolCalls: Array<{ chatId: string; event: unknown }> = [];
   promptStarts: Array<{
@@ -34,6 +40,17 @@ class TestChannel extends ChannelBase {
 
   override onToolCall(chatId: string, event: unknown): void {
     this.toolCalls.push({ chatId, event });
+  }
+
+  override supportsProactiveSend(): boolean {
+    return this.proactiveSupported;
+  }
+
+  protected override async pushProactive(
+    target: { chatId: string },
+    text: string,
+  ): Promise<void> {
+    this.proactive.push({ chatId: target.chatId, text });
   }
 
   enableCancelCommand(): void {
@@ -438,6 +455,87 @@ describe('ChannelBase', () => {
       expect(ch.sent[0]!.text).toContain('Session: none');
       expect(ch.sent[0]!.text).toContain('Access: open');
       expect(ch.sent[0]!.text).toContain('Channel: test-chan');
+    });
+
+    it('/schedule add stores a job for the current channel target', async () => {
+      const created: ChannelCronJob = {
+        id: 'job-1',
+        channelName: 'test-chan',
+        target: {
+          channelName: 'test-chan',
+          senderId: 'user1',
+          chatId: 'chat1',
+        },
+        cwd: '/tmp',
+        cron: '0 9 * * *',
+        prompt: 'post summary',
+        recurring: true,
+        enabled: true,
+        createdBy: 'User 1',
+        createdAt: '2026-06-30T01:02:03.000Z',
+        consecutiveFailures: 0,
+      };
+      const createSchedule = vi.fn(
+        async (_input: ChannelCronJobInput) => created,
+      );
+      const ch = createChannel(
+        {},
+        {
+          scheduleController: {
+            create: createSchedule,
+            listForTarget: vi.fn(),
+            disable: vi.fn(),
+            validateCron: vi.fn(),
+          },
+        },
+      );
+      ch.proactiveSupported = true;
+
+      await ch.handleInbound(
+        envelope({ text: '/schedule add "0 9 * * *" post summary' }),
+      );
+
+      expect(createSchedule).toHaveBeenCalledWith({
+        channelName: 'test-chan',
+        target: {
+          channelName: 'test-chan',
+          senderId: 'user1',
+          chatId: 'chat1',
+          threadId: undefined,
+        },
+        cwd: '/tmp',
+        cron: '0 9 * * *',
+        prompt: 'post summary',
+        label: 'post summary',
+        recurring: true,
+        createdBy: 'User 1',
+      });
+      expect(ch.sent[0]!.text).toContain('Scheduled job job-1');
+      expect(bridge.prompt).not.toHaveBeenCalled();
+    });
+
+    it('/schedule add rejects adapters that cannot cold send', async () => {
+      const createSchedule = vi.fn();
+      const ch = createChannel(
+        {},
+        {
+          scheduleController: {
+            create: createSchedule,
+            listForTarget: vi.fn(),
+            disable: vi.fn(),
+            validateCron: vi.fn(),
+          },
+        },
+      );
+
+      await ch.handleInbound(
+        envelope({ text: '/schedule add "0 9 * * *" post summary' }),
+      );
+
+      expect(createSchedule).not.toHaveBeenCalled();
+      expect(ch.sent[0]!.text).toContain(
+        'does not support proactive scheduled messages',
+      );
     });
 
     it('/status shows active session', async () => {
@@ -4432,6 +4530,72 @@ describe('ChannelBase', () => {
       expect(slash).toBe(true);
       expect(parsed).not.toBeNull();
       expect(slash).toBe(parsed !== null);
+    });
+  });
+
+  describe('scheduled prompts', () => {
+    it('runs a scheduled prompt as a follow-up and pushes the result proactively', async () => {
+      let resolveFirstPrompt: (value: string) => void = () => {};
+      (bridge.prompt as ReturnType<typeof vi.fn>)
+        .mockImplementationOnce(
+          () =>
+            new Promise<string>((resolve) => {
+              resolveFirstPrompt = resolve;
+            }),
+        )
+        .mockResolvedValueOnce('scheduled response');
+      const ch = createChannel({
+        sessionScope: 'thread',
+        groupPolicy: 'open',
+      });
+      ch.proactiveSupported = true;
+
+      const inbound = ch.handleInbound(
+        envelope({
+          isGroup: true,
+          isMentioned: true,
+          chatId: 'group-1',
+          text: 'first task',
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(bridge.prompt).toHaveBeenCalledTimes(1);
+      });
+
+      const scheduled = ch.runScheduledPrompt({
+        id: 'job-1',
+        channelName: 'test-chan',
+        target: {
+          channelName: 'test-chan',
+          senderId: 'alice',
+          chatId: 'group-1',
+        },
+        cwd: '/tmp',
+        cron: '0 9 * * *',
+        prompt: 'post summary',
+        label: 'daily summary',
+        recurring: true,
+        enabled: true,
+        createdBy: 'Alice',
+        createdAt: '2026-06-30T01:00:00.000Z',
+        consecutiveFailures: 0,
+      });
+      await Promise.resolve();
+      expect(bridge.prompt).toHaveBeenCalledTimes(1);
+
+      resolveFirstPrompt('first response');
+      await inbound;
+      await scheduled;
+
+      expect(bridge.prompt).toHaveBeenCalledTimes(2);
+      expect(bridge.prompt).toHaveBeenLastCalledWith(
+        expect.any(String),
+        '[Scheduled task "daily summary" set by Alice]\n\npost summary',
+        {},
+      );
+      expect(ch.proactive).toEqual([
+        { chatId: 'group-1', text: 'scheduled response' },
+      ]);
     });
   });
 });

--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -641,6 +641,34 @@ describe('ChannelBase', () => {
       );
     });
 
+    it('/schedule add rejects threaded targets unless the adapter supports them', async () => {
+      const createSchedule = vi.fn();
+      const ch = createChannel(
+        {},
+        {
+          scheduleController: {
+            create: createSchedule,
+            listForTarget: vi.fn(),
+            disable: vi.fn(),
+            validateCron: vi.fn(),
+          },
+        },
+      );
+      ch.proactiveSupported = true;
+
+      await ch.handleInbound(
+        envelope({
+          text: '/schedule add "0 9 * * *" post summary',
+          threadId: 'thread-1',
+        }),
+      );
+
+      expect(createSchedule).not.toHaveBeenCalled();
+      expect(ch.sent[0]!.text).toContain(
+        'does not support proactive scheduled messages for this chat target',
+      );
+    });
+
     it('/status shows active session', async () => {
       const ch = createChannel();
       await ch.handleInbound(envelope({ text: 'hi' }));
@@ -4742,6 +4770,37 @@ describe('ChannelBase', () => {
       ).rejects.toThrow('no longer authorized');
 
       expect(disable).toHaveBeenCalledWith('job-1');
+      expect(bridge.prompt).not.toHaveBeenCalled();
+    });
+
+    it('rejects stored threaded jobs unless the adapter supports the target', async () => {
+      const ch = createChannel();
+      ch.proactiveSupported = true;
+
+      await expect(
+        ch.runScheduledPrompt({
+          id: 'job-1',
+          channelName: 'test-chan',
+          target: {
+            channelName: 'test-chan',
+            senderId: 'user1',
+            chatId: 'chat1',
+            threadId: 'thread-1',
+            isGroup: true,
+          },
+          cwd: '/tmp',
+          cron: '0 9 * * *',
+          prompt: 'post summary',
+          recurring: true,
+          enabled: true,
+          createdBy: 'User 1',
+          createdAt: '2026-06-30T01:00:00.000Z',
+          consecutiveFailures: 0,
+        }),
+      ).rejects.toThrow(
+        'does not support proactive scheduled messages for this chat target',
+      );
+
       expect(bridge.prompt).not.toHaveBeenCalled();
     });
 

--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -483,7 +483,7 @@ describe('ChannelBase', () => {
         {
           scheduleController: {
             create: createSchedule,
-            listForTarget: vi.fn(),
+            listForTarget: vi.fn().mockResolvedValue([]),
             disable: vi.fn(),
             validateCron: vi.fn(),
           },
@@ -502,6 +502,7 @@ describe('ChannelBase', () => {
           senderId: 'user1',
           chatId: 'chat1',
           threadId: undefined,
+          isGroup: false,
         },
         cwd: '/tmp',
         cron: '0 9 * * *',
@@ -512,6 +513,108 @@ describe('ChannelBase', () => {
       });
       expect(ch.sent[0]!.text).toContain('Scheduled job job-1');
       expect(bridge.prompt).not.toHaveBeenCalled();
+    });
+
+    it('/schedule commands require shared-session authorization', async () => {
+      const listForTarget = vi.fn().mockResolvedValue([]);
+      const ch = createChannel(
+        {
+          sessionScope: 'single',
+          allowedUsers: ['owner'],
+        },
+        {
+          scheduleController: {
+            create: vi.fn(),
+            listForTarget,
+            disable: vi.fn(),
+            validateCron: vi.fn(),
+          },
+        },
+      );
+
+      await ch.handleInbound(
+        envelope({ senderId: 'stranger', text: '/schedule list' }),
+      );
+
+      expect(listForTarget).not.toHaveBeenCalled();
+      expect(ch.sent[0]!.text).toContain('Only authorized members');
+    });
+
+    it('/schedule cancel only disables jobs owned by the caller target', async () => {
+      const listForTarget = vi.fn().mockResolvedValue([]);
+      const disable = vi.fn().mockResolvedValue(true);
+      const ch = createChannel(
+        {},
+        {
+          scheduleController: {
+            create: vi.fn(),
+            listForTarget,
+            disable,
+            validateCron: vi.fn(),
+          },
+        },
+      );
+
+      await ch.handleInbound(envelope({ text: '/schedule cancel job-1' }));
+
+      expect(listForTarget).toHaveBeenCalledWith('test-chan', {
+        channelName: 'test-chan',
+        senderId: 'user1',
+        chatId: 'chat1',
+        threadId: undefined,
+        isGroup: false,
+      });
+      expect(disable).not.toHaveBeenCalled();
+      expect(ch.sent[0]!.text).toBe('No scheduled job job-1.');
+    });
+
+    it('/schedule add rejects a target that already has too many jobs', async () => {
+      const existingJobs = Array.from({ length: 10 }, (_, index) => ({
+        id: `job-${index}`,
+      }));
+      const createSchedule = vi.fn();
+      const ch = createChannel(
+        {},
+        {
+          scheduleController: {
+            create: createSchedule,
+            listForTarget: vi.fn().mockResolvedValue(existingJobs),
+            disable: vi.fn(),
+            validateCron: vi.fn(),
+          },
+        },
+      );
+      ch.proactiveSupported = true;
+
+      await ch.handleInbound(
+        envelope({ text: '/schedule add "0 9 * * *" post summary' }),
+      );
+
+      expect(createSchedule).not.toHaveBeenCalled();
+      expect(ch.sent[0]!.text).toContain('Too many scheduled jobs');
+    });
+
+    it('/schedule add rejects oversized prompts before persisting', async () => {
+      const createSchedule = vi.fn();
+      const ch = createChannel(
+        {},
+        {
+          scheduleController: {
+            create: createSchedule,
+            listForTarget: vi.fn().mockResolvedValue([]),
+            disable: vi.fn(),
+            validateCron: vi.fn(),
+          },
+        },
+      );
+      ch.proactiveSupported = true;
+
+      await ch.handleInbound(
+        envelope({ text: `/schedule add "0 9 * * *" ${'x'.repeat(4001)}` }),
+      );
+
+      expect(createSchedule).not.toHaveBeenCalled();
+      expect(ch.sent[0]!.text).toContain('Scheduled prompt is too long');
     });
 
     it('/schedule add rejects adapters that cannot cold send', async () => {
@@ -4596,6 +4699,100 @@ describe('ChannelBase', () => {
       expect(ch.proactive).toEqual([
         { chatId: 'group-1', text: 'scheduled response' },
       ]);
+    });
+
+    it('disables a stored job when its sender is no longer allowed', async () => {
+      const disable = vi.fn().mockResolvedValue(true);
+      const ch = createChannel(
+        {
+          senderPolicy: 'allowlist',
+          allowedUsers: ['alice'],
+        },
+        {
+          scheduleController: {
+            create: vi.fn(),
+            listForTarget: vi.fn(),
+            disable,
+            validateCron: vi.fn(),
+          },
+        },
+      );
+      ch.proactiveSupported = true;
+
+      await expect(
+        ch.runScheduledPrompt({
+          id: 'job-1',
+          channelName: 'test-chan',
+          target: {
+            channelName: 'test-chan',
+            senderId: 'bob',
+            chatId: 'chat1',
+            isGroup: false,
+          },
+          cwd: '/tmp',
+          cron: '0 9 * * *',
+          prompt: 'post summary',
+          label: 'daily summary',
+          recurring: true,
+          enabled: true,
+          createdBy: 'Bob',
+          createdAt: '2026-06-30T01:00:00.000Z',
+          consecutiveFailures: 0,
+        }),
+      ).rejects.toThrow('no longer authorized');
+
+      expect(disable).toHaveBeenCalledWith('job-1');
+      expect(bridge.prompt).not.toHaveBeenCalled();
+    });
+
+    it('drains collected messages after a scheduled prompt completes', async () => {
+      let resolveScheduled: (value: string) => void = () => {};
+      (bridge.prompt as ReturnType<typeof vi.fn>)
+        .mockImplementationOnce(
+          () =>
+            new Promise<string>((resolve) => {
+              resolveScheduled = resolve;
+            }),
+        )
+        .mockResolvedValueOnce('follow-up response');
+      const ch = createChannel({ dispatchMode: 'collect' });
+      ch.proactiveSupported = true;
+
+      const scheduled = ch.runScheduledPrompt({
+        id: 'job-1',
+        channelName: 'test-chan',
+        target: {
+          channelName: 'test-chan',
+          senderId: 'user1',
+          chatId: 'chat1',
+          isGroup: false,
+        },
+        cwd: '/tmp',
+        cron: '0 9 * * *',
+        prompt: 'post summary',
+        label: 'daily summary',
+        recurring: true,
+        enabled: true,
+        createdBy: 'User 1',
+        createdAt: '2026-06-30T01:00:00.000Z',
+        consecutiveFailures: 0,
+      });
+      await vi.waitFor(() => {
+        expect(bridge.prompt).toHaveBeenCalledTimes(1);
+      });
+
+      await ch.handleInbound(envelope({ text: 'while scheduled runs' }));
+      resolveScheduled('scheduled response');
+      await scheduled;
+
+      await vi.waitFor(() => {
+        expect(bridge.prompt).toHaveBeenCalledTimes(2);
+      });
+      expect(bridge.prompt).toHaveBeenLastCalledWith(
+        expect.any(String),
+        'while scheduled runs',
+        expect.any(Object),
+      );
     });
   });
 });

--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -4729,6 +4729,82 @@ describe('ChannelBase', () => {
       ]);
     });
 
+    it('starts the scheduled timeout after the queued turn begins', async () => {
+      let resolveFirstPrompt: (value: string) => void = () => {};
+      (bridge.prompt as ReturnType<typeof vi.fn>)
+        .mockImplementationOnce(
+          () =>
+            new Promise<string>((resolve) => {
+              resolveFirstPrompt = resolve;
+            }),
+        )
+        .mockImplementationOnce(() => new Promise<string>(() => undefined));
+      const ch = createChannel({
+        sessionScope: 'thread',
+        groupPolicy: 'open',
+      });
+      ch.proactiveSupported = true;
+
+      vi.useFakeTimers();
+      try {
+        const inbound = ch.handleInbound(
+          envelope({
+            isGroup: true,
+            isMentioned: true,
+            chatId: 'group-1',
+            text: 'first task',
+          }),
+        );
+        await vi.waitFor(() => {
+          expect(bridge.prompt).toHaveBeenCalledTimes(1);
+        });
+
+        const scheduled = ch.runScheduledPrompt(
+          {
+            id: 'job-1',
+            channelName: 'test-chan',
+            target: {
+              channelName: 'test-chan',
+              senderId: 'alice',
+              chatId: 'group-1',
+            },
+            cwd: '/tmp',
+            cron: '0 9 * * *',
+            prompt: 'post summary',
+            label: 'daily summary',
+            recurring: true,
+            enabled: true,
+            createdBy: 'Alice',
+            createdAt: '2026-06-30T01:00:00.000Z',
+            consecutiveFailures: 0,
+          },
+          { timeoutMs: 1000 },
+        );
+        let settled = false;
+        void scheduled.catch(() => {
+          settled = true;
+        });
+
+        await vi.advanceTimersByTimeAsync(5000);
+        await Promise.resolve();
+        expect(settled).toBe(false);
+        expect(bridge.cancelSession).not.toHaveBeenCalled();
+
+        resolveFirstPrompt('first response');
+        await inbound;
+        await vi.waitFor(() => {
+          expect(bridge.prompt).toHaveBeenCalledTimes(2);
+        });
+
+        await vi.advanceTimersByTimeAsync(1000);
+        await expect(scheduled).rejects.toThrow('scheduled job timed out');
+        expect(bridge.cancelSession).toHaveBeenCalledWith(expect.any(String));
+        expect(ch.proactive).toEqual([]);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('disables a stored job when its sender is no longer allowed', async () => {
       const disable = vi.fn().mockResolvedValue(true);
       const ch = createChannel(

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -1,5 +1,10 @@
 import { basename } from 'node:path';
-import type { ChannelConfig, DispatchMode, Envelope } from './types.js';
+import type {
+  ChannelConfig,
+  DispatchMode,
+  Envelope,
+  SessionTarget,
+} from './types.js';
 import { BlockStreamer } from './BlockStreamer.js';
 import { GroupGate } from './GroupGate.js';
 import { SenderGate } from './SenderGate.js';
@@ -18,6 +23,10 @@ import type {
   SessionDiedEvent,
   ToolCallEvent,
 } from './ChannelAgentBridge.js';
+import type {
+  ChannelCronJob,
+  ChannelCronJobInput,
+} from './ChannelCronStore.js';
 
 /**
  * Max time /clear waits for a cancelled in-flight turn to wind down before
@@ -37,6 +46,17 @@ export interface ChannelBaseOptions {
    * events directly.
    */
   registerBridgeEvents?: boolean;
+  scheduleController?: ChannelScheduleController;
+}
+
+export interface ChannelScheduleController {
+  create(input: ChannelCronJobInput): Promise<ChannelCronJob>;
+  listForTarget(
+    channelName: string,
+    target: SessionTarget,
+  ): Promise<ChannelCronJob[]>;
+  disable(id: string): Promise<boolean>;
+  validateCron(cron: string): void;
 }
 
 /** Handler for a slash command. Return true if handled, false to forward to agent. */
@@ -75,6 +95,7 @@ const PARSE_COMMAND_RE = new RegExp(
 );
 /** isSlashCommand: the first whitespace-delimited token alone must be a pure command token. */
 const COMMAND_TOKEN_RE = new RegExp(`^[${COMMAND_TOKEN_CHARS}]+(?:@\\S+)?$`);
+const SCHEDULE_ADD_RE = /^"([^"]+)"\s+(.+)$/su;
 
 /**
  * The command-providing surface of a bridge. AcpBridge runs a single agent and
@@ -89,6 +110,16 @@ interface AgentCommandsProvider {
   availableCommands?: AvailableCommand[];
 }
 
+function parseScheduleAddArgs(
+  args: string,
+): { cron: string; prompt: string } | null {
+  const match = args.trim().match(SCHEDULE_ADD_RE);
+  if (!match) return null;
+  const cron = match[1].trim();
+  const prompt = match[2].trim();
+  return cron && prompt ? { cron, prompt } : null;
+}
+
 export abstract class ChannelBase {
   protected config: ChannelConfig;
   protected bridge: ChannelAgentBridge;
@@ -98,6 +129,7 @@ export abstract class ChannelBase {
   protected name: string;
   /** Resolved proxy URL, available to subclasses for adapter-specific clients. */
   protected proxy?: string;
+  private readonly scheduleController?: ChannelScheduleController;
   private instructedSessions: Set<string> = new Set();
   private commands: Map<string, CommandHandler> = new Map();
   /** Per-session promise chain to serialize prompt + send (followup mode). */
@@ -139,6 +171,7 @@ export abstract class ChannelBase {
     this.config = config;
     this.bridge = bridge;
     this.proxy = options?.proxy;
+    this.scheduleController = options?.scheduleController;
 
     this.groupGate = new GroupGate(config.groupPolicy, config.groups);
 
@@ -168,6 +201,17 @@ export abstract class ChannelBase {
   abstract sendMessage(chatId: string, text: string): Promise<void>;
   abstract disconnect(): void;
 
+  supportsProactiveSend(): boolean {
+    return false;
+  }
+
+  protected async pushProactive(
+    target: SessionTarget,
+    text: string,
+  ): Promise<void> {
+    await this.sendMessage(target.chatId, text);
+  }
+
   /** Replace the bridge instance (used after crash recovery restart). */
   setBridge(bridge: ChannelAgentBridge): void {
     if (this.registerBridgeEvents) {
@@ -178,6 +222,91 @@ export abstract class ChannelBase {
     if (this.registerBridgeEvents) {
       this.attachBridgeEvents(bridge);
     }
+  }
+
+  async runScheduledPrompt(job: ChannelCronJob): Promise<void> {
+    if (!this.supportsProactiveSend()) {
+      throw new Error('Channel does not support proactive scheduled messages.');
+    }
+    if (job.channelName !== this.name) {
+      throw new Error(
+        `Scheduled job ${job.id} belongs to ${job.channelName}, not ${this.name}.`,
+      );
+    }
+
+    const sessionId = await this.router.resolve(
+      this.name,
+      job.target.senderId,
+      job.target.chatId,
+      job.target.threadId,
+      job.cwd,
+    );
+    const label = sanitizeQuotedText(job.label || job.id, 80);
+    const createdBy = sanitizeSenderName(job.createdBy || 'unknown');
+    let promptText = `[Scheduled task "${label}" set by ${createdBy}]\n\n${job.prompt}`;
+    if (this.config.instructions && !this.instructedSessions.has(sessionId)) {
+      promptText = `${this.config.instructions}\n\n${promptText}`;
+      this.instructedSessions.add(sessionId);
+    }
+
+    const prev = this.sessionQueues.get(sessionId) ?? Promise.resolve();
+    const generation = this.sessionGenerations.get(sessionId) ?? 0;
+    const current = prev.then(async () => {
+      if ((this.sessionGenerations.get(sessionId) ?? 0) !== generation) {
+        process.stderr.write(
+          `[${this.name}] dropped scheduled job ${job.id} for session ${sessionId}: session was cleared before it ran\n`,
+        );
+        return;
+      }
+
+      let doneResolve: () => void = () => {};
+      const done = new Promise<void>((resolve) => {
+        doneResolve = resolve;
+      });
+      const promptState: ActivePrompt = {
+        cancelled: false,
+        done,
+        resolve: doneResolve,
+        chatId: job.target.chatId,
+      };
+      this.activePrompts.set(sessionId, promptState);
+      this.onPromptStart(job.target.chatId, sessionId);
+
+      const onChunk = (sid: string, chunk: string) => {
+        if (sid === sessionId && !promptState.cancelled) {
+          this.onResponseChunk(job.target.chatId, chunk, sessionId);
+        }
+      };
+      this.bridge.on('textChunk', onChunk);
+
+      try {
+        const response = await this.bridge.prompt(sessionId, promptText, {});
+        if (!promptState.cancelled && response) {
+          await this.pushProactive(job.target, response);
+        }
+      } finally {
+        this.bridge.off('textChunk', onChunk);
+        const stillCurrent = this.activePrompts.get(sessionId) === promptState;
+        if (!promptState.clearEvicted) {
+          try {
+            this.onPromptEnd(job.target.chatId, sessionId);
+          } catch (err) {
+            process.stderr.write(
+              `[${this.name}] onPromptEnd threw in scheduled job ${job.id} for session ${sessionId}: ${err instanceof Error ? err.message : err}\n`,
+            );
+          }
+        }
+        if (stillCurrent) {
+          this.activePrompts.delete(sessionId);
+        }
+        promptState.resolve();
+      }
+    });
+    this.sessionQueues.set(
+      sessionId,
+      current.catch(() => {}),
+    );
+    await current;
   }
 
   onToolCall(_chatId: string, _event: ToolCallEvent): void {}
@@ -574,6 +703,139 @@ export abstract class ChannelBase {
       await this.sendMessage(envelope.chatId, lines.join('\n'));
       return true;
     });
+
+    this.registerCommand('schedule', async (envelope, args) =>
+      this.handleScheduleCommand(envelope, args),
+    );
+  }
+
+  private async handleScheduleCommand(
+    envelope: Envelope,
+    args: string,
+  ): Promise<boolean> {
+    if (!this.scheduleController) {
+      await this.sendMessage(
+        envelope.chatId,
+        'Scheduled tasks are not available.',
+      );
+      return true;
+    }
+
+    const [subcommand = '', ...rest] = args.trim().split(/\s+/u);
+    switch (subcommand.toLowerCase()) {
+      case 'add':
+        return this.handleScheduleAdd(envelope, rest.join(' '));
+      case 'list':
+        return this.handleScheduleList(envelope);
+      case 'cancel':
+        return this.handleScheduleCancel(envelope, rest[0]);
+      default:
+        await this.sendMessage(
+          envelope.chatId,
+          'Usage: /schedule add "<cron>" <prompt> | /schedule list | /schedule cancel <id>',
+        );
+        return true;
+    }
+  }
+
+  private async handleScheduleAdd(
+    envelope: Envelope,
+    args: string,
+  ): Promise<boolean> {
+    if (!this.scheduleController) return true;
+    if (!this.supportsProactiveSend()) {
+      await this.sendMessage(
+        envelope.chatId,
+        'This channel does not support proactive scheduled messages.',
+      );
+      return true;
+    }
+
+    const parsed = parseScheduleAddArgs(args);
+    if (!parsed) {
+      await this.sendMessage(
+        envelope.chatId,
+        'Usage: /schedule add "<cron>" <prompt>',
+      );
+      return true;
+    }
+
+    try {
+      this.scheduleController.validateCron(parsed.cron);
+    } catch (err) {
+      await this.sendMessage(
+        envelope.chatId,
+        `Invalid cron expression: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return true;
+    }
+
+    const prompt = parsed.prompt.trim();
+    const job = await this.scheduleController.create({
+      channelName: this.name,
+      target: {
+        channelName: this.name,
+        senderId: envelope.senderId,
+        chatId: envelope.chatId,
+        threadId: envelope.threadId,
+      },
+      cwd: this.config.cwd,
+      cron: parsed.cron,
+      prompt,
+      label: prompt.length > 60 ? `${prompt.slice(0, 57)}...` : prompt,
+      recurring: true,
+      createdBy: sanitizeSenderName(
+        envelope.senderName || envelope.senderId || 'unknown',
+      ),
+    });
+
+    await this.sendMessage(
+      envelope.chatId,
+      `Scheduled job ${job.id}: ${job.cron}`,
+    );
+    return true;
+  }
+
+  private async handleScheduleList(envelope: Envelope): Promise<boolean> {
+    if (!this.scheduleController) return true;
+    const jobs = await this.scheduleController.listForTarget(this.name, {
+      channelName: this.name,
+      senderId: envelope.senderId,
+      chatId: envelope.chatId,
+      threadId: envelope.threadId,
+    });
+    if (jobs.length === 0) {
+      await this.sendMessage(envelope.chatId, 'No scheduled jobs.');
+      return true;
+    }
+    await this.sendMessage(
+      envelope.chatId,
+      jobs
+        .map((job) => {
+          const status = job.enabled ? 'enabled' : 'disabled';
+          const label = job.label ? ` ${job.label}` : '';
+          return `${job.id} ${job.cron} ${status}${label}`;
+        })
+        .join('\n'),
+    );
+    return true;
+  }
+
+  private async handleScheduleCancel(
+    envelope: Envelope,
+    id: string | undefined,
+  ): Promise<boolean> {
+    if (!this.scheduleController) return true;
+    if (!id) {
+      await this.sendMessage(envelope.chatId, 'Usage: /schedule cancel <id>');
+      return true;
+    }
+    const disabled = await this.scheduleController.disable(id);
+    await this.sendMessage(
+      envelope.chatId,
+      disabled ? `Cancelled scheduled job ${id}.` : `No scheduled job ${id}.`,
+    );
+    return true;
   }
 
   /** Check if a message text matches a registered local command. */

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -207,13 +207,17 @@ export abstract class ChannelBase {
     return false;
   }
 
+  protected supportsProactiveTarget(target: SessionTarget): boolean {
+    return target.threadId === undefined;
+  }
+
   protected async pushProactive(
     target: SessionTarget,
     text: string,
   ): Promise<void> {
     if (target.threadId) {
-      process.stderr.write(
-        `[${this.name}] scheduled job target includes threadId but this adapter does not override pushProactive; sending to chat ${sanitizeLogText(target.chatId, 64)}\n`,
+      throw new Error(
+        'Channel does not support proactive scheduled messages for threaded targets.',
       );
     }
     await this.sendMessage(target.chatId, text);
@@ -238,6 +242,11 @@ export abstract class ChannelBase {
     if (job.channelName !== this.name) {
       throw new Error(
         `Scheduled job ${job.id} belongs to ${job.channelName}, not ${this.name}.`,
+      );
+    }
+    if (!this.supportsProactiveTarget(job.target)) {
+      throw new Error(
+        'Channel does not support proactive scheduled messages for this chat target.',
       );
     }
     if (!this.isStoredScheduleTargetAuthorized(job.target, job.createdBy)) {
@@ -815,6 +824,13 @@ export abstract class ChannelBase {
     }
 
     const target = this.scheduleTargetFromEnvelope(envelope);
+    if (!this.supportsProactiveTarget(target)) {
+      await this.sendMessage(
+        envelope.chatId,
+        'This channel does not support proactive scheduled messages for this chat target.',
+      );
+      return true;
+    }
     const prompt = sanitizePromptText(parsed.prompt.trim());
     if (Array.from(prompt).length > MAX_SCHEDULE_PROMPT_CHARS) {
       await this.sendMessage(

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -322,6 +322,9 @@ export abstract class ChannelBase {
           job.id,
           options.timeoutMs,
         );
+        if (promptState.cancelRequested && !promptState.cancelled) {
+          promptState.cancelled = await promptState.cancelRequested;
+        }
         if (!promptState.cancelled && response) {
           await this.pushProactive(job.target, response);
         }
@@ -994,7 +997,7 @@ export abstract class ChannelBase {
       senderId: envelope.senderId,
       chatId: envelope.chatId,
       threadId: envelope.threadId,
-      isGroup: envelope.isGroup,
+      isGroup: envelope.isGroup === true,
     };
   }
 

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -385,6 +385,7 @@ export abstract class ChannelBase {
     timeoutMs: number | undefined,
   ): Promise<string> {
     const prompt = promptBridge.prompt(sessionId, promptText, {});
+    prompt.catch(() => {});
     if (timeoutMs === undefined) {
       return prompt;
     }
@@ -403,7 +404,8 @@ export abstract class ChannelBase {
     } catch (err) {
       if (err instanceof Error && err.message === 'scheduled job timed out') {
         promptState.cancelled = true;
-        void promptBridge.cancelSession(sessionId).catch((cancelErr) => {
+        this.onSessionDied(sessionId);
+        await promptBridge.cancelSession(sessionId).catch((cancelErr) => {
           process.stderr.write(
             `[${this.name}] cancelSession failed for timed out scheduled job ${jobId} in session ${sessionId}: ${
               cancelErr instanceof Error ? cancelErr.message : cancelErr

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -96,6 +96,8 @@ const PARSE_COMMAND_RE = new RegExp(
 /** isSlashCommand: the first whitespace-delimited token alone must be a pure command token. */
 const COMMAND_TOKEN_RE = new RegExp(`^[${COMMAND_TOKEN_CHARS}]+(?:@\\S+)?$`);
 const SCHEDULE_ADD_RE = /^"([^"]+)"\s+(.+)$/su;
+const MAX_SCHEDULE_JOBS_PER_TARGET = 10;
+const MAX_SCHEDULE_PROMPT_CHARS = 4000;
 
 /**
  * The command-providing surface of a bridge. AcpBridge runs a single agent and
@@ -209,6 +211,11 @@ export abstract class ChannelBase {
     target: SessionTarget,
     text: string,
   ): Promise<void> {
+    if (target.threadId) {
+      process.stderr.write(
+        `[${this.name}] scheduled job target includes threadId but this adapter does not override pushProactive; sending to chat ${sanitizeLogText(target.chatId, 64)}\n`,
+      );
+    }
     await this.sendMessage(target.chatId, text);
   }
 
@@ -233,6 +240,12 @@ export abstract class ChannelBase {
         `Scheduled job ${job.id} belongs to ${job.channelName}, not ${this.name}.`,
       );
     }
+    if (!this.isStoredScheduleTargetAuthorized(job.target, job.createdBy)) {
+      await this.scheduleController?.disable(job.id);
+      throw new Error(
+        `Scheduled job ${job.id} target is no longer authorized.`,
+      );
+    }
 
     const sessionId = await this.router.resolve(
       this.name,
@@ -243,7 +256,7 @@ export abstract class ChannelBase {
     );
     const label = sanitizeQuotedText(job.label || job.id, 80);
     const createdBy = sanitizeSenderName(job.createdBy || 'unknown');
-    let promptText = `[Scheduled task "${label}" set by ${createdBy}]\n\n${job.prompt}`;
+    let promptText = `[Scheduled task "${label}" set by ${createdBy}]\n\n${sanitizePromptText(job.prompt)}`;
     if (this.config.instructions && !this.instructedSessions.has(sessionId)) {
       promptText = `${this.config.instructions}\n\n${promptText}`;
       this.instructedSessions.add(sessionId);
@@ -277,15 +290,16 @@ export abstract class ChannelBase {
           this.onResponseChunk(job.target.chatId, chunk, sessionId);
         }
       };
-      this.bridge.on('textChunk', onChunk);
+      const promptBridge = this.bridge;
+      promptBridge.on('textChunk', onChunk);
 
       try {
-        const response = await this.bridge.prompt(sessionId, promptText, {});
+        const response = await promptBridge.prompt(sessionId, promptText, {});
         if (!promptState.cancelled && response) {
           await this.pushProactive(job.target, response);
         }
       } finally {
-        this.bridge.off('textChunk', onChunk);
+        promptBridge.off('textChunk', onChunk);
         const stillCurrent = this.activePrompts.get(sessionId) === promptState;
         if (!promptState.clearEvicted) {
           try {
@@ -300,6 +314,29 @@ export abstract class ChannelBase {
           this.activePrompts.delete(sessionId);
         }
         promptState.resolve();
+        const buffer = this.collectBuffers.get(sessionId);
+        if (stillCurrent && buffer && buffer.length > 0) {
+          this.collectBuffers.delete(sessionId);
+          const lost = buffer.length;
+          const coalesced = buffer.map((b) => b.text).join('\n\n');
+          const lastEnvelope = buffer[buffer.length - 1]!.envelope;
+          const syntheticEnvelope: Envelope = {
+            ...lastEnvelope,
+            text: coalesced,
+            alreadyPrefixed: true,
+            referencedText: undefined,
+            attachments: undefined,
+            imageBase64: undefined,
+            imageMimeType: undefined,
+          };
+          this.handleInbound(syntheticEnvelope).catch((err) => {
+            process.stderr.write(
+              `[${this.name}] dropped ${lost} buffered message(s) after scheduled job ${job.id} for session ${sessionId} (last sender ${lastEnvelope.senderId}): ${
+                err instanceof Error ? err.message : String(err)
+              }\n`,
+            );
+          });
+        }
       }
     });
     this.sessionQueues.set(
@@ -720,6 +757,13 @@ export abstract class ChannelBase {
       );
       return true;
     }
+    if (!this.isAuthorizedForSharedSession(envelope)) {
+      await this.sendMessage(
+        envelope.chatId,
+        'Only authorized members can use scheduled tasks in this shared session.',
+      );
+      return true;
+    }
 
     const [subcommand = '', ...rest] = args.trim().split(/\s+/u);
     switch (subcommand.toLowerCase()) {
@@ -770,15 +814,29 @@ export abstract class ChannelBase {
       return true;
     }
 
-    const prompt = parsed.prompt.trim();
+    const target = this.scheduleTargetFromEnvelope(envelope);
+    const prompt = sanitizePromptText(parsed.prompt.trim());
+    if (Array.from(prompt).length > MAX_SCHEDULE_PROMPT_CHARS) {
+      await this.sendMessage(
+        envelope.chatId,
+        `Scheduled prompt is too long; keep it under ${MAX_SCHEDULE_PROMPT_CHARS} characters.`,
+      );
+      return true;
+    }
+    const existingJobs = await this.scheduleController.listForTarget(
+      this.name,
+      target,
+    );
+    if (existingJobs.length >= MAX_SCHEDULE_JOBS_PER_TARGET) {
+      await this.sendMessage(
+        envelope.chatId,
+        `Too many scheduled jobs for this chat. Cancel an existing job before adding another.`,
+      );
+      return true;
+    }
     const job = await this.scheduleController.create({
       channelName: this.name,
-      target: {
-        channelName: this.name,
-        senderId: envelope.senderId,
-        chatId: envelope.chatId,
-        threadId: envelope.threadId,
-      },
+      target,
       cwd: this.config.cwd,
       cron: parsed.cron,
       prompt,
@@ -798,12 +856,10 @@ export abstract class ChannelBase {
 
   private async handleScheduleList(envelope: Envelope): Promise<boolean> {
     if (!this.scheduleController) return true;
-    const jobs = await this.scheduleController.listForTarget(this.name, {
-      channelName: this.name,
-      senderId: envelope.senderId,
-      chatId: envelope.chatId,
-      threadId: envelope.threadId,
-    });
+    const jobs = await this.scheduleController.listForTarget(
+      this.name,
+      this.scheduleTargetFromEnvelope(envelope),
+    );
     if (jobs.length === 0) {
       await this.sendMessage(envelope.chatId, 'No scheduled jobs.');
       return true;
@@ -830,12 +886,49 @@ export abstract class ChannelBase {
       await this.sendMessage(envelope.chatId, 'Usage: /schedule cancel <id>');
       return true;
     }
-    const disabled = await this.scheduleController.disable(id);
+    const jobs = await this.scheduleController.listForTarget(
+      this.name,
+      this.scheduleTargetFromEnvelope(envelope),
+    );
+    const match = jobs.find((job) => job.id === id);
+    const disabled = match ? await this.scheduleController.disable(id) : false;
     await this.sendMessage(
       envelope.chatId,
       disabled ? `Cancelled scheduled job ${id}.` : `No scheduled job ${id}.`,
     );
     return true;
+  }
+
+  private scheduleTargetFromEnvelope(envelope: Envelope): SessionTarget {
+    return {
+      channelName: this.name,
+      senderId: envelope.senderId,
+      chatId: envelope.chatId,
+      threadId: envelope.threadId,
+      isGroup: envelope.isGroup,
+    };
+  }
+
+  private isStoredScheduleTargetAuthorized(
+    target: SessionTarget,
+    senderName: string,
+  ): boolean {
+    const envelope: Envelope = {
+      channelName: this.name,
+      senderId: target.senderId,
+      senderName,
+      chatId: target.chatId,
+      text: '',
+      threadId: target.threadId,
+      isGroup: target.isGroup === true,
+      isMentioned: true,
+      isReplyToBot: true,
+    };
+    return (
+      this.groupGate.check(envelope).allowed &&
+      this.gate.check(target.senderId, senderName).allowed &&
+      this.isAuthorizedForSharedSession(envelope)
+    );
   }
 
   /** Check if a message text matches a registered local command. */

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -51,6 +51,10 @@ export interface ChannelBaseOptions {
 
 export interface ChannelScheduleController {
   create(input: ChannelCronJobInput): Promise<ChannelCronJob>;
+  createForTarget?(
+    input: ChannelCronJobInput,
+    maxEnabledJobs: number,
+  ): Promise<ChannelCronJob | undefined>;
   listForTarget(
     channelName: string,
     target: SessionTarget,
@@ -894,18 +898,7 @@ export abstract class ChannelBase {
       );
       return true;
     }
-    const existingJobs = await this.scheduleController.listForTarget(
-      this.name,
-      target,
-    );
-    if (existingJobs.length >= MAX_SCHEDULE_JOBS_PER_TARGET) {
-      await this.sendMessage(
-        envelope.chatId,
-        `Too many scheduled jobs for this chat. Cancel an existing job before adding another.`,
-      );
-      return true;
-    }
-    const job = await this.scheduleController.create({
+    const input: ChannelCronJobInput = {
       channelName: this.name,
       target,
       cwd: this.config.cwd,
@@ -916,7 +909,32 @@ export abstract class ChannelBase {
       createdBy: sanitizeSenderName(
         envelope.senderName || envelope.senderId || 'unknown',
       ),
-    });
+    };
+    let job: ChannelCronJob | undefined;
+    if (this.scheduleController.createForTarget) {
+      job = await this.scheduleController.createForTarget(
+        input,
+        MAX_SCHEDULE_JOBS_PER_TARGET,
+      );
+    } else {
+      const existingJobs = await this.scheduleController.listForTarget(
+        this.name,
+        target,
+      );
+      if (
+        existingJobs.filter((existingJob) => existingJob.enabled).length <
+        MAX_SCHEDULE_JOBS_PER_TARGET
+      ) {
+        job = await this.scheduleController.create(input);
+      }
+    }
+    if (!job) {
+      await this.sendMessage(
+        envelope.chatId,
+        `Too many scheduled jobs for this chat. Cancel an existing job before adding another.`,
+      );
+      return true;
+    }
 
     await this.sendMessage(
       envelope.chatId,

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -59,6 +59,10 @@ export interface ChannelScheduleController {
   validateCron(cron: string): void;
 }
 
+export interface ChannelScheduledPromptOptions {
+  timeoutMs?: number;
+}
+
 /** Handler for a slash command. Return true if handled, false to forward to agent. */
 type CommandHandler = (envelope: Envelope, args: string) => Promise<boolean>;
 type ActivePrompt = {
@@ -235,7 +239,10 @@ export abstract class ChannelBase {
     }
   }
 
-  async runScheduledPrompt(job: ChannelCronJob): Promise<void> {
+  async runScheduledPrompt(
+    job: ChannelCronJob,
+    options: ChannelScheduledPromptOptions = {},
+  ): Promise<void> {
     if (!this.supportsProactiveSend()) {
       throw new Error('Channel does not support proactive scheduled messages.');
     }
@@ -303,7 +310,14 @@ export abstract class ChannelBase {
       promptBridge.on('textChunk', onChunk);
 
       try {
-        const response = await promptBridge.prompt(sessionId, promptText, {});
+        const response = await this.runScheduledBridgePrompt(
+          promptBridge,
+          sessionId,
+          promptText,
+          promptState,
+          job.id,
+          options.timeoutMs,
+        );
         if (!promptState.cancelled && response) {
           await this.pushProactive(job.target, response);
         }
@@ -353,6 +367,47 @@ export abstract class ChannelBase {
       current.catch(() => {}),
     );
     await current;
+  }
+
+  private async runScheduledBridgePrompt(
+    promptBridge: ChannelAgentBridge,
+    sessionId: string,
+    promptText: string,
+    promptState: ActivePrompt,
+    jobId: string,
+    timeoutMs: number | undefined,
+  ): Promise<string> {
+    const prompt = promptBridge.prompt(sessionId, promptText, {});
+    if (timeoutMs === undefined) {
+      return prompt;
+    }
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        prompt,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => {
+            reject(new Error('scheduled job timed out'));
+          }, timeoutMs);
+          timer.unref?.();
+        }),
+      ]);
+    } catch (err) {
+      if (err instanceof Error && err.message === 'scheduled job timed out') {
+        promptState.cancelled = true;
+        void promptBridge.cancelSession(sessionId).catch((cancelErr) => {
+          process.stderr.write(
+            `[${this.name}] cancelSession failed for timed out scheduled job ${jobId} in session ${sessionId}: ${
+              cancelErr instanceof Error ? cancelErr.message : cancelErr
+            }\n`,
+          );
+        });
+      }
+      throw err;
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   onToolCall(_chatId: string, _event: ToolCallEvent): void {}

--- a/packages/channels/base/src/ChannelCronScheduler.test.ts
+++ b/packages/channels/base/src/ChannelCronScheduler.test.ts
@@ -56,7 +56,9 @@ describe('ChannelCronScheduler', () => {
 
     await scheduler.tick();
 
-    expect(runScheduledPrompt).toHaveBeenCalledWith(baseJob);
+    expect(runScheduledPrompt).toHaveBeenCalledWith(baseJob, {
+      timeoutMs: 300_000,
+    });
     expect(store.update).toHaveBeenCalledWith('job-1', {
       lastFiredAt: '2026-06-30T01:05:30.000Z',
       lastStatus: 'ok',
@@ -94,7 +96,48 @@ describe('ChannelCronScheduler', () => {
 
     await scheduler.tick();
 
-    expect(store.disable).toHaveBeenCalledWith('job-1');
+    expect(store.update).toHaveBeenCalledWith('job-1', {
+      lastFiredAt: '2026-06-30T01:05:30.000Z',
+      lastStatus: 'ok',
+      lastError: undefined,
+      consecutiveFailures: 0,
+      enabled: false,
+    });
+    expect(store.disable).not.toHaveBeenCalled();
+  });
+
+  it('clears abandoned in-flight state when stopped', async () => {
+    runScheduledPrompt.mockImplementation(() => new Promise(() => undefined));
+    const scheduler = new ChannelCronScheduler({
+      store,
+      channels: new Map([['feishu-main', { runScheduledPrompt }]]),
+      now: () => new Date(nowMs),
+      nextFireTime: () => new Date(nowMs - 60_000),
+    });
+
+    void scheduler.tick();
+    await vi.waitFor(() => expect(runScheduledPrompt).toHaveBeenCalledOnce());
+
+    scheduler.stop();
+    void scheduler.tick();
+
+    await vi.waitFor(() => expect(runScheduledPrompt).toHaveBeenCalledTimes(2));
+  });
+
+  it('passes the timeout budget to the channel runner', async () => {
+    const scheduler = new ChannelCronScheduler({
+      store,
+      channels: new Map([['feishu-main', { runScheduledPrompt }]]),
+      now: () => new Date(nowMs),
+      nextFireTime: () => new Date(nowMs - 60_000),
+      jobTimeoutMs: 1234,
+    });
+
+    await scheduler.tick();
+
+    expect(runScheduledPrompt).toHaveBeenCalledWith(baseJob, {
+      timeoutMs: 1234,
+    });
   });
 
   it('records failures and disables a job after repeated errors', async () => {
@@ -151,7 +194,9 @@ describe('ChannelCronScheduler', () => {
 
     void scheduler.tick();
     await vi.waitFor(() => {
-      expect(runScheduledPrompt).toHaveBeenCalledWith(secondJob);
+      expect(runScheduledPrompt).toHaveBeenCalledWith(secondJob, {
+        timeoutMs: 300_000,
+      });
     });
   });
 
@@ -191,6 +236,7 @@ describe('ChannelCronScheduler', () => {
 
     expect(runScheduledPrompt).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'job-2' }),
+      { timeoutMs: 300_000 },
     );
   });
 });

--- a/packages/channels/base/src/ChannelCronScheduler.test.ts
+++ b/packages/channels/base/src/ChannelCronScheduler.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChannelCronScheduler } from './ChannelCronScheduler.js';
+import type { ChannelCronJob, ChannelCronStore } from './ChannelCronStore.js';
+
+describe('ChannelCronScheduler', () => {
+  let jobs: ChannelCronJob[];
+  let store: Pick<ChannelCronStore, 'list' | 'update' | 'disable'>;
+  let runScheduledPrompt: ReturnType<typeof vi.fn>;
+  let nowMs: number;
+
+  const baseJob: ChannelCronJob = {
+    id: 'job-1',
+    channelName: 'feishu-main',
+    target: {
+      channelName: 'feishu-main',
+      senderId: 'alice',
+      chatId: 'chat-1',
+    },
+    cwd: '/repo',
+    cron: '* * * * *',
+    prompt: 'summarize',
+    label: 'summary',
+    recurring: true,
+    enabled: true,
+    createdBy: 'Alice',
+    createdAt: '2026-06-30T01:00:00.000Z',
+    consecutiveFailures: 0,
+  };
+
+  beforeEach(() => {
+    jobs = [{ ...baseJob }];
+    nowMs = Date.parse('2026-06-30T01:05:30.000Z');
+    store = {
+      list: vi.fn(async () => jobs),
+      update: vi.fn(async (id, patch) => {
+        jobs = jobs.map((job) => (job.id === id ? { ...job, ...patch } : job));
+        return true;
+      }),
+      disable: vi.fn(async (id) => {
+        jobs = jobs.map((job) =>
+          job.id === id ? { ...job, enabled: false } : job,
+        );
+        return true;
+      }),
+    };
+    runScheduledPrompt = vi.fn(async () => undefined);
+  });
+
+  it('fires an overdue enabled job through its channel and records success', async () => {
+    const scheduler = new ChannelCronScheduler({
+      store,
+      channels: new Map([['feishu-main', { runScheduledPrompt }]]),
+      now: () => new Date(nowMs),
+      nextFireTime: () => new Date('2026-06-30T01:01:00.000Z'),
+    });
+
+    await scheduler.tick();
+
+    expect(runScheduledPrompt).toHaveBeenCalledWith(baseJob);
+    expect(store.update).toHaveBeenCalledWith('job-1', {
+      lastFiredAt: '2026-06-30T01:05:30.000Z',
+      lastStatus: 'ok',
+      lastError: undefined,
+      consecutiveFailures: 0,
+    });
+  });
+
+  it('does not replay a recurring job again after recording the catch-up fire', async () => {
+    const nextFireTime = vi.fn((_, after: Date) => {
+      if (after.getTime() < nowMs) return new Date(nowMs - 60_000);
+      return new Date(nowMs + 60_000);
+    });
+    const scheduler = new ChannelCronScheduler({
+      store,
+      channels: new Map([['feishu-main', { runScheduledPrompt }]]),
+      now: () => new Date(nowMs),
+      nextFireTime,
+    });
+
+    await scheduler.tick();
+    await scheduler.tick();
+
+    expect(runScheduledPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables a one-shot job after it fires', async () => {
+    jobs = [{ ...baseJob, recurring: false }];
+    const scheduler = new ChannelCronScheduler({
+      store,
+      channels: new Map([['feishu-main', { runScheduledPrompt }]]),
+      now: () => new Date(nowMs),
+      nextFireTime: () => new Date(nowMs - 60_000),
+    });
+
+    await scheduler.tick();
+
+    expect(store.disable).toHaveBeenCalledWith('job-1');
+  });
+
+  it('records failures and disables a job after repeated errors', async () => {
+    jobs = [{ ...baseJob, consecutiveFailures: 4 }];
+    runScheduledPrompt.mockRejectedValue(new Error('cannot cold send'));
+    const scheduler = new ChannelCronScheduler({
+      store,
+      channels: new Map([['feishu-main', { runScheduledPrompt }]]),
+      now: () => new Date(nowMs),
+      nextFireTime: () => new Date(nowMs - 60_000),
+      maxConsecutiveFailures: 5,
+    });
+
+    await scheduler.tick();
+
+    expect(store.update).toHaveBeenCalledWith('job-1', {
+      lastFiredAt: '2026-06-30T01:05:30.000Z',
+      lastStatus: 'error',
+      lastError: 'cannot cold send',
+      consecutiveFailures: 5,
+    });
+    expect(store.disable).toHaveBeenCalledWith('job-1');
+  });
+});

--- a/packages/channels/base/src/ChannelCronScheduler.test.ts
+++ b/packages/channels/base/src/ChannelCronScheduler.test.ts
@@ -118,4 +118,79 @@ describe('ChannelCronScheduler', () => {
     });
     expect(store.disable).toHaveBeenCalledWith('job-1');
   });
+
+  it('skips jobs for channels owned by another process', async () => {
+    jobs = [{ ...baseJob, channelName: 'other-channel' }];
+    const scheduler = new ChannelCronScheduler({
+      store,
+      channels: new Map([['feishu-main', { runScheduledPrompt }]]),
+      now: () => new Date(nowMs),
+      nextFireTime: () => new Date(nowMs - 60_000),
+    });
+
+    await scheduler.tick();
+
+    expect(runScheduledPrompt).not.toHaveBeenCalled();
+    expect(store.update).not.toHaveBeenCalled();
+    expect(store.disable).not.toHaveBeenCalled();
+  });
+
+  it('continues firing other due jobs when one job is still running', async () => {
+    const secondJob = { ...baseJob, id: 'job-2' };
+    jobs = [{ ...baseJob }, secondJob];
+    runScheduledPrompt.mockImplementation((job: ChannelCronJob) => {
+      if (job.id === 'job-1') return new Promise(() => undefined);
+      return Promise.resolve();
+    });
+    const scheduler = new ChannelCronScheduler({
+      store,
+      channels: new Map([['feishu-main', { runScheduledPrompt }]]),
+      now: () => new Date(nowMs),
+      nextFireTime: () => new Date(nowMs - 60_000),
+    });
+
+    void scheduler.tick();
+    await vi.waitFor(() => {
+      expect(runScheduledPrompt).toHaveBeenCalledWith(secondJob);
+    });
+  });
+
+  it('rechecks that a job is still enabled before firing', async () => {
+    store.list = vi
+      .fn()
+      .mockResolvedValueOnce([{ ...baseJob }])
+      .mockResolvedValueOnce([{ ...baseJob, enabled: false }]);
+    const scheduler = new ChannelCronScheduler({
+      store,
+      channels: new Map([['feishu-main', { runScheduledPrompt }]]),
+      now: () => new Date(nowMs),
+      nextFireTime: () => new Date(nowMs - 60_000),
+    });
+
+    await scheduler.tick();
+
+    expect(runScheduledPrompt).not.toHaveBeenCalled();
+  });
+
+  it('ignores a malformed cron job and still fires later due jobs', async () => {
+    const secondJob = { ...baseJob, id: 'job-2' };
+    jobs = [{ ...baseJob }, secondJob];
+    const nextFireTime = vi.fn((cron: string) => {
+      if (cron === baseJob.cron) throw new Error('impossible cron');
+      return new Date(nowMs - 60_000);
+    });
+    jobs[1] = { ...secondJob, cron: '*/5 * * * *' };
+    const scheduler = new ChannelCronScheduler({
+      store,
+      channels: new Map([['feishu-main', { runScheduledPrompt }]]),
+      now: () => new Date(nowMs),
+      nextFireTime,
+    });
+
+    await scheduler.tick();
+
+    expect(runScheduledPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'job-2' }),
+    );
+  });
 });

--- a/packages/channels/base/src/ChannelCronScheduler.test.ts
+++ b/packages/channels/base/src/ChannelCronScheduler.test.ts
@@ -200,6 +200,66 @@ describe('ChannelCronScheduler', () => {
     });
   });
 
+  it('does not block later ticks behind a hung job', async () => {
+    const laterJob = {
+      ...baseJob,
+      id: 'job-2',
+      createdAt: '2026-06-30T01:06:00.000Z',
+    };
+    jobs = [{ ...baseJob }];
+    runScheduledPrompt.mockImplementation((job: ChannelCronJob) => {
+      if (job.id === 'job-1') return new Promise(() => undefined);
+      return Promise.resolve();
+    });
+    const scheduler = new ChannelCronScheduler({
+      store,
+      channels: new Map([['feishu-main', { runScheduledPrompt }]]),
+      now: () => new Date(nowMs),
+      nextFireTime: () => new Date(nowMs - 60_000),
+    });
+
+    void scheduler.tick();
+    await vi.waitFor(() => {
+      expect(runScheduledPrompt).toHaveBeenCalledWith(baseJob, {
+        timeoutMs: 300_000,
+      });
+    });
+    jobs = [jobs[0]!, laterJob];
+    void scheduler.tick();
+
+    await vi.waitFor(() => {
+      expect(runScheduledPrompt).toHaveBeenCalledWith(laterJob, {
+        timeoutMs: 300_000,
+      });
+    });
+  });
+
+  it('logs success persistence failures without recording a job failure', async () => {
+    store.update = vi.fn(async () => {
+      throw new Error('disk full');
+    });
+    const writeSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => {
+        return true;
+      });
+    const scheduler = new ChannelCronScheduler({
+      store,
+      channels: new Map([['feishu-main', { runScheduledPrompt }]]),
+      now: () => new Date(nowMs),
+      nextFireTime: () => new Date(nowMs - 60_000),
+    });
+
+    await scheduler.tick();
+
+    expect(store.update).toHaveBeenCalledTimes(1);
+    expect(store.disable).not.toHaveBeenCalled();
+    expect(writeSpy).toHaveBeenCalledWith(
+      expect.stringContaining('succeeded but status persist failed'),
+    );
+    writeSpy.mockRestore();
+  });
+
   it('rechecks that a job is still enabled before firing', async () => {
     store.list = vi
       .fn()

--- a/packages/channels/base/src/ChannelCronScheduler.ts
+++ b/packages/channels/base/src/ChannelCronScheduler.ts
@@ -31,7 +31,7 @@ export class ChannelCronScheduler {
   private readonly jobTimeoutMs: number;
   private timer: ReturnType<typeof setInterval> | undefined;
   private runningTick: Promise<void> | undefined;
-  private readonly inFlightJobs = new Set<string>();
+  private readonly inFlightJobs = new Map<string, symbol>();
 
   constructor(options: ChannelCronSchedulerOptions) {
     this.store = options.store;
@@ -67,9 +67,12 @@ export class ChannelCronScheduler {
 
   async tick(): Promise<void> {
     if (this.runningTick) return this.runningTick;
-    this.runningTick = this.runTick().finally(() => {
-      this.runningTick = undefined;
+    const tick = this.runTick().finally(() => {
+      if (this.runningTick === tick) {
+        this.runningTick = undefined;
+      }
     });
+    this.runningTick = tick;
     return this.runningTick;
   }
 
@@ -83,7 +86,9 @@ export class ChannelCronScheduler {
         !this.inFlightJobs.has(job.id) &&
         this.isDue(job, now),
     );
-    await Promise.allSettled(dueJobs.map((job) => this.fireOnce(job, now)));
+    for (const job of dueJobs) {
+      void this.fireOnce(job, now);
+    }
   }
 
   private isDue(job: ChannelCronJob, now: Date): boolean {
@@ -99,11 +104,18 @@ export class ChannelCronScheduler {
   }
 
   private async fireOnce(job: ChannelCronJob, now: Date): Promise<void> {
-    this.inFlightJobs.add(job.id);
+    const token = Symbol(job.id);
+    this.inFlightJobs.set(job.id, token);
     try {
       await this.fire(job, now);
+    } catch (err) {
+      process.stderr.write(
+        `[scheduler] unhandled error for job ${job.id}: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
     } finally {
-      this.inFlightJobs.delete(job.id);
+      if (this.inFlightJobs.get(job.id) === token) {
+        this.inFlightJobs.delete(job.id);
+      }
     }
   }
 
@@ -119,21 +131,29 @@ export class ChannelCronScheduler {
       await channel.runScheduledPrompt(latestJob, {
         timeoutMs: this.jobTimeoutMs,
       });
-      const patch: ChannelCronJobPatch = {
-        lastFiredAt: now.toISOString(),
-        lastStatus: 'ok',
-        lastError: undefined,
-        consecutiveFailures: 0,
-      };
-      if (!latestJob.recurring) {
-        patch.enabled = false;
-      }
-      await this.store.update(latestJob.id, patch);
     } catch (err) {
       await this.recordFailure(
         latestJob,
         now,
         err instanceof Error ? err.message : String(err),
+      );
+      return;
+    }
+
+    const patch: ChannelCronJobPatch = {
+      lastFiredAt: now.toISOString(),
+      lastStatus: 'ok',
+      lastError: undefined,
+      consecutiveFailures: 0,
+    };
+    if (!latestJob.recurring) {
+      patch.enabled = false;
+    }
+    try {
+      await this.store.update(latestJob.id, patch);
+    } catch (err) {
+      process.stderr.write(
+        `[scheduler] job ${latestJob.id} succeeded but status persist failed: ${err instanceof Error ? err.message : String(err)}\n`,
       );
     }
   }

--- a/packages/channels/base/src/ChannelCronScheduler.ts
+++ b/packages/channels/base/src/ChannelCronScheduler.ts
@@ -1,0 +1,119 @@
+import type { ChannelCronJob, ChannelCronStore } from './ChannelCronStore.js';
+
+export interface ChannelRoutineRunner {
+  runScheduledPrompt(job: ChannelCronJob): Promise<void>;
+}
+
+export interface ChannelCronSchedulerOptions {
+  store: Pick<ChannelCronStore, 'list' | 'update' | 'disable'>;
+  channels: ReadonlyMap<string, ChannelRoutineRunner>;
+  nextFireTime: (cron: string, after: Date) => Date;
+  now?: () => Date;
+  maxConsecutiveFailures?: number;
+  intervalMs?: number;
+}
+
+export class ChannelCronScheduler {
+  private readonly store: Pick<ChannelCronStore, 'list' | 'update' | 'disable'>;
+  private readonly channels: ReadonlyMap<string, ChannelRoutineRunner>;
+  private readonly nextFireTime: (cron: string, after: Date) => Date;
+  private readonly now: () => Date;
+  private readonly maxConsecutiveFailures: number;
+  private readonly intervalMs: number;
+  private timer: ReturnType<typeof setInterval> | undefined;
+  private runningTick: Promise<void> | undefined;
+
+  constructor(options: ChannelCronSchedulerOptions) {
+    this.store = options.store;
+    this.channels = options.channels;
+    this.nextFireTime = options.nextFireTime;
+    this.now = options.now ?? (() => new Date());
+    this.maxConsecutiveFailures = options.maxConsecutiveFailures ?? 5;
+    this.intervalMs = options.intervalMs ?? 60_000;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    void this.tick();
+    this.timer = setInterval(() => {
+      void this.tick();
+    }, this.intervalMs);
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (!this.timer) return;
+    clearInterval(this.timer);
+    this.timer = undefined;
+  }
+
+  async tick(): Promise<void> {
+    if (this.runningTick) return this.runningTick;
+    this.runningTick = this.runTick().finally(() => {
+      this.runningTick = undefined;
+    });
+    return this.runningTick;
+  }
+
+  private async runTick(): Promise<void> {
+    const now = this.now();
+    const jobs = await this.store.list();
+    for (const job of jobs) {
+      if (!job.enabled || !this.isDue(job, now)) continue;
+      await this.fire(job, now);
+    }
+  }
+
+  private isDue(job: ChannelCronJob, now: Date): boolean {
+    const after = new Date(job.lastFiredAt ?? job.createdAt);
+    return this.nextFireTime(job.cron, after).getTime() <= now.getTime();
+  }
+
+  private async fire(job: ChannelCronJob, now: Date): Promise<void> {
+    const channel = this.channels.get(job.channelName);
+    if (!channel) {
+      await this.recordFailure(
+        job,
+        now,
+        `Channel not running: ${job.channelName}`,
+      );
+      return;
+    }
+
+    try {
+      await channel.runScheduledPrompt(job);
+      await this.store.update(job.id, {
+        lastFiredAt: now.toISOString(),
+        lastStatus: 'ok',
+        lastError: undefined,
+        consecutiveFailures: 0,
+      });
+      if (!job.recurring) {
+        await this.store.disable(job.id);
+      }
+    } catch (err) {
+      await this.recordFailure(
+        job,
+        now,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+
+  private async recordFailure(
+    job: ChannelCronJob,
+    now: Date,
+    message: string,
+  ): Promise<void> {
+    const consecutiveFailures = job.consecutiveFailures + 1;
+    await this.store.update(job.id, {
+      lastFiredAt: now.toISOString(),
+      lastStatus: 'error',
+      lastError: message,
+      consecutiveFailures,
+    });
+    if (consecutiveFailures >= this.maxConsecutiveFailures) {
+      await this.store.disable(job.id);
+    }
+  }
+}

--- a/packages/channels/base/src/ChannelCronScheduler.ts
+++ b/packages/channels/base/src/ChannelCronScheduler.ts
@@ -11,6 +11,7 @@ export interface ChannelCronSchedulerOptions {
   now?: () => Date;
   maxConsecutiveFailures?: number;
   intervalMs?: number;
+  jobTimeoutMs?: number;
 }
 
 export class ChannelCronScheduler {
@@ -20,8 +21,11 @@ export class ChannelCronScheduler {
   private readonly now: () => Date;
   private readonly maxConsecutiveFailures: number;
   private readonly intervalMs: number;
+  private readonly jobTimeoutMs: number;
   private timer: ReturnType<typeof setInterval> | undefined;
   private runningTick: Promise<void> | undefined;
+  private readonly inFlightJobs = new Set<string>();
+  private readonly timedOutJobs = new Set<string>();
 
   constructor(options: ChannelCronSchedulerOptions) {
     this.store = options.store;
@@ -30,13 +34,18 @@ export class ChannelCronScheduler {
     this.now = options.now ?? (() => new Date());
     this.maxConsecutiveFailures = options.maxConsecutiveFailures ?? 5;
     this.intervalMs = options.intervalMs ?? 60_000;
+    this.jobTimeoutMs = options.jobTimeoutMs ?? 5 * 60_000;
   }
 
   start(): void {
     if (this.timer) return;
-    void this.tick();
+    void this.tick().catch((err) => {
+      process.stderr.write(`[scheduler] initial tick failed: ${err}\n`);
+    });
     this.timer = setInterval(() => {
-      void this.tick();
+      void this.tick().catch((err) => {
+        process.stderr.write(`[scheduler] interval tick failed: ${err}\n`);
+      });
     }, this.intervalMs);
     this.timer.unref?.();
   }
@@ -58,45 +67,104 @@ export class ChannelCronScheduler {
   private async runTick(): Promise<void> {
     const now = this.now();
     const jobs = await this.store.list();
-    for (const job of jobs) {
-      if (!job.enabled || !this.isDue(job, now)) continue;
-      await this.fire(job, now);
-    }
+    const dueJobs = jobs.filter(
+      (job) =>
+        job.enabled &&
+        this.channels.has(job.channelName) &&
+        !this.inFlightJobs.has(job.id) &&
+        this.isDue(job, now),
+    );
+    await Promise.allSettled(dueJobs.map((job) => this.fireOnce(job, now)));
   }
 
   private isDue(job: ChannelCronJob, now: Date): boolean {
-    const after = new Date(job.lastFiredAt ?? job.createdAt);
-    return this.nextFireTime(job.cron, after).getTime() <= now.getTime();
+    try {
+      const after = new Date(job.lastFiredAt ?? job.createdAt);
+      return this.nextFireTime(job.cron, after).getTime() <= now.getTime();
+    } catch (err) {
+      process.stderr.write(
+        `[scheduler] invalid cron for job ${job.id}: ${err}\n`,
+      );
+      return false;
+    }
+  }
+
+  private async fireOnce(job: ChannelCronJob, now: Date): Promise<void> {
+    this.inFlightJobs.add(job.id);
+    try {
+      await this.fire(job, now);
+    } finally {
+      if (!this.timedOutJobs.has(job.id)) {
+        this.inFlightJobs.delete(job.id);
+      }
+    }
   }
 
   private async fire(job: ChannelCronJob, now: Date): Promise<void> {
     const channel = this.channels.get(job.channelName);
     if (!channel) {
-      await this.recordFailure(
-        job,
-        now,
-        `Channel not running: ${job.channelName}`,
-      );
       return;
     }
+    const latestJob = await this.findJob(job.id);
+    if (!latestJob?.enabled) return;
 
+    let run: Promise<void> | undefined;
     try {
-      await channel.runScheduledPrompt(job);
-      await this.store.update(job.id, {
+      run = channel.runScheduledPrompt(latestJob);
+      await this.withTimeout(run, latestJob.id);
+      await this.store.update(latestJob.id, {
         lastFiredAt: now.toISOString(),
         lastStatus: 'ok',
         lastError: undefined,
         consecutiveFailures: 0,
       });
-      if (!job.recurring) {
-        await this.store.disable(job.id);
+      if (!latestJob.recurring) {
+        await this.store.disable(latestJob.id);
       }
     } catch (err) {
+      if (
+        run !== undefined &&
+        err instanceof Error &&
+        err.message === 'scheduled job timed out'
+      ) {
+        this.timedOutJobs.add(latestJob.id);
+        run
+          .catch(() => undefined)
+          .finally(() => {
+            this.timedOutJobs.delete(latestJob.id);
+            this.inFlightJobs.delete(latestJob.id);
+          });
+      }
       await this.recordFailure(
-        job,
+        latestJob,
         now,
         err instanceof Error ? err.message : String(err),
       );
+    }
+  }
+
+  private async findJob(id: string): Promise<ChannelCronJob | undefined> {
+    const jobs = await this.store.list();
+    return jobs.find((job) => job.id === id);
+  }
+
+  private async withTimeout(run: Promise<void>, jobId: string): Promise<void> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        run,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => {
+            reject(new Error('scheduled job timed out'));
+          }, this.jobTimeoutMs);
+          timer.unref?.();
+        }),
+      ]);
+    } catch (err) {
+      process.stderr.write(`[scheduler] job ${jobId} failed: ${err}\n`);
+      throw err;
+    } finally {
+      clearTimeout(timer);
     }
   }
 

--- a/packages/channels/base/src/ChannelCronScheduler.ts
+++ b/packages/channels/base/src/ChannelCronScheduler.ts
@@ -1,7 +1,14 @@
-import type { ChannelCronJob, ChannelCronStore } from './ChannelCronStore.js';
+import type {
+  ChannelCronJob,
+  ChannelCronJobPatch,
+  ChannelCronStore,
+} from './ChannelCronStore.js';
 
 export interface ChannelRoutineRunner {
-  runScheduledPrompt(job: ChannelCronJob): Promise<void>;
+  runScheduledPrompt(
+    job: ChannelCronJob,
+    options?: { timeoutMs?: number },
+  ): Promise<void>;
 }
 
 export interface ChannelCronSchedulerOptions {
@@ -25,7 +32,6 @@ export class ChannelCronScheduler {
   private timer: ReturnType<typeof setInterval> | undefined;
   private runningTick: Promise<void> | undefined;
   private readonly inFlightJobs = new Set<string>();
-  private readonly timedOutJobs = new Set<string>();
 
   constructor(options: ChannelCronSchedulerOptions) {
     this.store = options.store;
@@ -51,9 +57,12 @@ export class ChannelCronScheduler {
   }
 
   stop(): void {
-    if (!this.timer) return;
-    clearInterval(this.timer);
+    if (this.timer) {
+      clearInterval(this.timer);
+    }
     this.timer = undefined;
+    this.runningTick = undefined;
+    this.inFlightJobs.clear();
   }
 
   async tick(): Promise<void> {
@@ -94,9 +103,7 @@ export class ChannelCronScheduler {
     try {
       await this.fire(job, now);
     } finally {
-      if (!this.timedOutJobs.has(job.id)) {
-        this.inFlightJobs.delete(job.id);
-      }
+      this.inFlightJobs.delete(job.id);
     }
   }
 
@@ -108,33 +115,21 @@ export class ChannelCronScheduler {
     const latestJob = await this.findJob(job.id);
     if (!latestJob?.enabled) return;
 
-    let run: Promise<void> | undefined;
     try {
-      run = channel.runScheduledPrompt(latestJob);
-      await this.withTimeout(run, latestJob.id);
-      await this.store.update(latestJob.id, {
+      await channel.runScheduledPrompt(latestJob, {
+        timeoutMs: this.jobTimeoutMs,
+      });
+      const patch: ChannelCronJobPatch = {
         lastFiredAt: now.toISOString(),
         lastStatus: 'ok',
         lastError: undefined,
         consecutiveFailures: 0,
-      });
+      };
       if (!latestJob.recurring) {
-        await this.store.disable(latestJob.id);
+        patch.enabled = false;
       }
+      await this.store.update(latestJob.id, patch);
     } catch (err) {
-      if (
-        run !== undefined &&
-        err instanceof Error &&
-        err.message === 'scheduled job timed out'
-      ) {
-        this.timedOutJobs.add(latestJob.id);
-        run
-          .catch(() => undefined)
-          .finally(() => {
-            this.timedOutJobs.delete(latestJob.id);
-            this.inFlightJobs.delete(latestJob.id);
-          });
-      }
       await this.recordFailure(
         latestJob,
         now,
@@ -146,26 +141,6 @@ export class ChannelCronScheduler {
   private async findJob(id: string): Promise<ChannelCronJob | undefined> {
     const jobs = await this.store.list();
     return jobs.find((job) => job.id === id);
-  }
-
-  private async withTimeout(run: Promise<void>, jobId: string): Promise<void> {
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    try {
-      await Promise.race([
-        run,
-        new Promise<never>((_, reject) => {
-          timer = setTimeout(() => {
-            reject(new Error('scheduled job timed out'));
-          }, this.jobTimeoutMs);
-          timer.unref?.();
-        }),
-      ]);
-    } catch (err) {
-      process.stderr.write(`[scheduler] job ${jobId} failed: ${err}\n`);
-      throw err;
-    } finally {
-      clearTimeout(timer);
-    }
   }
 
   private async recordFailure(

--- a/packages/channels/base/src/ChannelCronStore.test.ts
+++ b/packages/channels/base/src/ChannelCronStore.test.ts
@@ -68,6 +68,17 @@ describe('ChannelCronStore', () => {
     ).resolves.toEqual([first]);
   });
 
+  it('does not match targets with different group context', async () => {
+    await store.create(input);
+
+    await expect(
+      store.listForTarget('feishu-main', {
+        ...input.target,
+        isGroup: true,
+      }),
+    ).resolves.toEqual([]);
+  });
+
   it('creates for a target without counting disabled jobs against the cap', async () => {
     const disabled = await store.create(input);
     await store.disable(disabled.id);

--- a/packages/channels/base/src/ChannelCronStore.test.ts
+++ b/packages/channels/base/src/ChannelCronStore.test.ts
@@ -68,6 +68,41 @@ describe('ChannelCronStore', () => {
     ).resolves.toEqual([first]);
   });
 
+  it('creates for a target without counting disabled jobs against the cap', async () => {
+    const disabled = await store.create(input);
+    await store.disable(disabled.id);
+
+    const created = await store.createForTarget(input, 1);
+
+    expect(created).toMatchObject({
+      id: 'job-1',
+      enabled: true,
+      prompt: 'post a daily summary',
+    });
+    await expect(
+      store.listForTarget('feishu-main', input.target),
+    ).resolves.toHaveLength(2);
+  });
+
+  it('enforces the enabled target cap inside the serialized write', async () => {
+    let nextId = 0;
+    const cappedStore = new ChannelCronStore({
+      filePath: path.join(tmpDir, 'channels', 'cron.json'),
+      now: () => new Date('2026-06-30T01:02:03.000Z'),
+      idFactory: () => `job-${++nextId}`,
+    });
+
+    const created = await Promise.all([
+      cappedStore.createForTarget(input, 1),
+      cappedStore.createForTarget(input, 1),
+    ]);
+
+    expect(created.filter(Boolean)).toHaveLength(1);
+    await expect(
+      cappedStore.listForTarget('feishu-main', input.target),
+    ).resolves.toHaveLength(1);
+  });
+
   it('disables a job without deleting its last status', async () => {
     const created = await store.create(input);
     await store.update(created.id, {

--- a/packages/channels/base/src/ChannelCronStore.test.ts
+++ b/packages/channels/base/src/ChannelCronStore.test.ts
@@ -1,0 +1,99 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ChannelCronStore } from './ChannelCronStore.js';
+import type { ChannelCronJobInput } from './ChannelCronStore.js';
+
+describe('ChannelCronStore', () => {
+  let tmpDir: string;
+  let store: ChannelCronStore;
+
+  const input: ChannelCronJobInput = {
+    channelName: 'feishu-main',
+    target: {
+      channelName: 'feishu-main',
+      senderId: 'alice',
+      chatId: 'chat-1',
+      threadId: 'thread-1',
+    },
+    cwd: '/repo',
+    cron: '0 9 * * *',
+    prompt: 'post a daily summary',
+    label: 'daily summary',
+    recurring: true,
+    createdBy: 'Alice',
+  };
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'channel-cron-store-'));
+    store = new ChannelCronStore({
+      filePath: path.join(tmpDir, 'channels', 'cron.json'),
+      now: () => new Date('2026-06-30T01:02:03.000Z'),
+      idFactory: () => 'job-1',
+    });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('creates and persists a channel cron job with default status fields', async () => {
+    const created = await store.create(input);
+
+    expect(created).toEqual({
+      ...input,
+      id: 'job-1',
+      enabled: true,
+      createdAt: '2026-06-30T01:02:03.000Z',
+      consecutiveFailures: 0,
+    });
+
+    const reloaded = new ChannelCronStore({
+      filePath: path.join(tmpDir, 'channels', 'cron.json'),
+    });
+    await expect(reloaded.list()).resolves.toEqual([created]);
+  });
+
+  it('lists only jobs for the current channel target', async () => {
+    const first = await store.create(input);
+    await store.create({
+      ...input,
+      target: { ...input.target, chatId: 'chat-2' },
+      prompt: 'other chat',
+    });
+
+    await expect(
+      store.listForTarget('feishu-main', input.target),
+    ).resolves.toEqual([first]);
+  });
+
+  it('disables a job without deleting its last status', async () => {
+    const created = await store.create(input);
+    await store.update(created.id, {
+      lastStatus: 'error',
+      lastError: 'adapter cannot send proactively',
+      consecutiveFailures: 1,
+    });
+
+    const disabled = await store.disable(created.id);
+
+    expect(disabled).toBe(true);
+    await expect(store.list()).resolves.toEqual([
+      {
+        ...created,
+        enabled: false,
+        lastStatus: 'error',
+        lastError: 'adapter cannot send proactively',
+        consecutiveFailures: 1,
+      },
+    ]);
+  });
+
+  it('refuses to treat corrupt JSON as an empty schedule', async () => {
+    await fs.mkdir(path.join(tmpDir, 'channels'), { recursive: true });
+    await fs.writeFile(path.join(tmpDir, 'channels', 'cron.json'), '{', 'utf8');
+
+    await expect(store.list()).rejects.toThrow(/Malformed JSON/);
+  });
+});

--- a/packages/channels/base/src/ChannelCronStore.ts
+++ b/packages/channels/base/src/ChannelCronStore.ts
@@ -91,6 +91,33 @@ export class ChannelCronStore {
     return job;
   }
 
+  async createForTarget(
+    input: ChannelCronJobInput,
+    maxEnabledJobs: number,
+  ): Promise<ChannelCronJob | undefined> {
+    let created: ChannelCronJob | undefined;
+    await this.updateJobs((jobs) => {
+      const enabledForTarget = jobs.filter(
+        (job) =>
+          job.enabled &&
+          job.channelName === input.channelName &&
+          sameTarget(job.target, input.target),
+      ).length;
+      if (enabledForTarget >= maxEnabledJobs) {
+        return jobs;
+      }
+      created = {
+        ...input,
+        id: this.idFactory(),
+        enabled: true,
+        createdAt: this.now().toISOString(),
+        consecutiveFailures: 0,
+      };
+      return [...jobs, created];
+    });
+    return created;
+  }
+
   async update(id: string, patch: ChannelCronJobPatch): Promise<boolean> {
     let found = false;
     await this.updateJobs((jobs) =>

--- a/packages/channels/base/src/ChannelCronStore.ts
+++ b/packages/channels/base/src/ChannelCronStore.ts
@@ -197,9 +197,7 @@ function sameTarget(a: SessionTarget, b: SessionTarget): boolean {
     a.senderId === b.senderId &&
     a.chatId === b.chatId &&
     a.threadId === b.threadId &&
-    (a.isGroup === undefined ||
-      b.isGroup === undefined ||
-      a.isGroup === b.isGroup)
+    a.isGroup === b.isGroup
   );
 }
 

--- a/packages/channels/base/src/ChannelCronStore.ts
+++ b/packages/channels/base/src/ChannelCronStore.ts
@@ -1,0 +1,210 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import type { SessionTarget } from './types.js';
+
+export type ChannelCronJobStatus = 'ok' | 'error';
+
+export interface ChannelCronJob {
+  id: string;
+  channelName: string;
+  target: SessionTarget;
+  cwd: string;
+  cron: string;
+  prompt: string;
+  label?: string;
+  recurring: boolean;
+  enabled: boolean;
+  createdBy: string;
+  createdAt: string;
+  lastFiredAt?: string;
+  lastStatus?: ChannelCronJobStatus;
+  lastError?: string;
+  consecutiveFailures: number;
+}
+
+export type ChannelCronJobInput = Omit<
+  ChannelCronJob,
+  | 'id'
+  | 'enabled'
+  | 'createdAt'
+  | 'lastFiredAt'
+  | 'lastStatus'
+  | 'lastError'
+  | 'consecutiveFailures'
+>;
+
+export type ChannelCronJobPatch = Partial<
+  Pick<
+    ChannelCronJob,
+    | 'enabled'
+    | 'lastFiredAt'
+    | 'lastStatus'
+    | 'lastError'
+    | 'consecutiveFailures'
+  >
+>;
+
+export interface ChannelCronStoreOptions {
+  filePath: string;
+  now?: () => Date;
+  idFactory?: () => string;
+}
+
+export class ChannelCronStore {
+  private readonly filePath: string;
+  private readonly now: () => Date;
+  private readonly idFactory: () => string;
+  private pendingUpdate: Promise<void> = Promise.resolve();
+
+  constructor(options: ChannelCronStoreOptions) {
+    this.filePath = options.filePath;
+    this.now = options.now ?? (() => new Date());
+    this.idFactory =
+      options.idFactory ?? (() => crypto.randomUUID().slice(0, 8));
+  }
+
+  async list(): Promise<ChannelCronJob[]> {
+    return this.readJobs();
+  }
+
+  async listForTarget(
+    channelName: string,
+    target: SessionTarget,
+  ): Promise<ChannelCronJob[]> {
+    const jobs = await this.readJobs();
+    return jobs.filter(
+      (job) =>
+        job.channelName === channelName && sameTarget(job.target, target),
+    );
+  }
+
+  async create(input: ChannelCronJobInput): Promise<ChannelCronJob> {
+    const job: ChannelCronJob = {
+      ...input,
+      id: this.idFactory(),
+      enabled: true,
+      createdAt: this.now().toISOString(),
+      consecutiveFailures: 0,
+    };
+    await this.updateJobs((jobs) => [...jobs, job]);
+    return job;
+  }
+
+  async update(id: string, patch: ChannelCronJobPatch): Promise<boolean> {
+    let found = false;
+    await this.updateJobs((jobs) =>
+      jobs.map((job) => {
+        if (job.id !== id) return job;
+        found = true;
+        return { ...job, ...patch };
+      }),
+    );
+    return found;
+  }
+
+  async disable(id: string): Promise<boolean> {
+    return this.update(id, { enabled: false });
+  }
+
+  private async updateJobs(
+    mutate: (jobs: ChannelCronJob[]) => ChannelCronJob[],
+  ): Promise<void> {
+    const nextUpdate = this.pendingUpdate.then(async () => {
+      const jobs = await this.readJobs();
+      await this.writeJobs(mutate(jobs));
+    });
+    this.pendingUpdate = nextUpdate.catch(() => {});
+    await nextUpdate;
+  }
+
+  private async readJobs(): Promise<ChannelCronJob[]> {
+    let raw: string;
+    try {
+      raw = await fs.readFile(this.filePath, 'utf8');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw err;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw new Error(
+        `Malformed JSON in ${this.filePath}; fix or delete the file.`,
+      );
+    }
+
+    if (!Array.isArray(parsed)) {
+      throw new Error(
+        `Expected a JSON array in ${this.filePath}; fix or delete the file.`,
+      );
+    }
+    for (const [index, value] of parsed.entries()) {
+      if (!isChannelCronJob(value)) {
+        throw new Error(
+          `Invalid channel cron job at index ${index} in ${this.filePath}.`,
+        );
+      }
+    }
+    return parsed;
+  }
+
+  private async writeJobs(jobs: ChannelCronJob[]): Promise<void> {
+    await fs.mkdir(path.dirname(this.filePath), { recursive: true });
+    const tmpPath = `${this.filePath}.${crypto.randomBytes(6).toString('hex')}.tmp`;
+    try {
+      await fs.writeFile(tmpPath, JSON.stringify(jobs, null, 2), 'utf8');
+      await fs.rename(tmpPath, this.filePath);
+    } catch (err) {
+      await fs.rm(tmpPath, { force: true }).catch(() => {});
+      throw err;
+    }
+  }
+}
+
+function sameTarget(a: SessionTarget, b: SessionTarget): boolean {
+  return (
+    a.channelName === b.channelName &&
+    a.senderId === b.senderId &&
+    a.chatId === b.chatId &&
+    a.threadId === b.threadId
+  );
+}
+
+function isSessionTarget(value: unknown): value is SessionTarget {
+  if (typeof value !== 'object' || value === null) return false;
+  const target = value as Record<string, unknown>;
+  return (
+    typeof target['channelName'] === 'string' &&
+    typeof target['senderId'] === 'string' &&
+    typeof target['chatId'] === 'string' &&
+    (target['threadId'] === undefined || typeof target['threadId'] === 'string')
+  );
+}
+
+function isChannelCronJob(value: unknown): value is ChannelCronJob {
+  if (typeof value !== 'object' || value === null) return false;
+  const job = value as Record<string, unknown>;
+  return (
+    typeof job['id'] === 'string' &&
+    typeof job['channelName'] === 'string' &&
+    isSessionTarget(job['target']) &&
+    typeof job['cwd'] === 'string' &&
+    typeof job['cron'] === 'string' &&
+    typeof job['prompt'] === 'string' &&
+    (job['label'] === undefined || typeof job['label'] === 'string') &&
+    typeof job['recurring'] === 'boolean' &&
+    typeof job['enabled'] === 'boolean' &&
+    typeof job['createdBy'] === 'string' &&
+    typeof job['createdAt'] === 'string' &&
+    (job['lastFiredAt'] === undefined ||
+      typeof job['lastFiredAt'] === 'string') &&
+    (job['lastStatus'] === undefined ||
+      job['lastStatus'] === 'ok' ||
+      job['lastStatus'] === 'error') &&
+    (job['lastError'] === undefined || typeof job['lastError'] === 'string') &&
+    typeof job['consecutiveFailures'] === 'number'
+  );
+}

--- a/packages/channels/base/src/ChannelCronStore.ts
+++ b/packages/channels/base/src/ChannelCronStore.ts
@@ -169,7 +169,10 @@ function sameTarget(a: SessionTarget, b: SessionTarget): boolean {
     a.channelName === b.channelName &&
     a.senderId === b.senderId &&
     a.chatId === b.chatId &&
-    a.threadId === b.threadId
+    a.threadId === b.threadId &&
+    (a.isGroup === undefined ||
+      b.isGroup === undefined ||
+      a.isGroup === b.isGroup)
   );
 }
 
@@ -180,7 +183,9 @@ function isSessionTarget(value: unknown): value is SessionTarget {
     typeof target['channelName'] === 'string' &&
     typeof target['senderId'] === 'string' &&
     typeof target['chatId'] === 'string' &&
-    (target['threadId'] === undefined || typeof target['threadId'] === 'string')
+    (target['threadId'] === undefined ||
+      typeof target['threadId'] === 'string') &&
+    (target['isGroup'] === undefined || typeof target['isGroup'] === 'boolean')
   );
 }
 

--- a/packages/channels/base/src/index.ts
+++ b/packages/channels/base/src/index.ts
@@ -21,7 +21,23 @@ export type {
 export { BlockStreamer } from './BlockStreamer.js';
 export type { BlockStreamerOptions } from './BlockStreamer.js';
 export { ChannelBase } from './ChannelBase.js';
-export type { ChannelBaseOptions } from './ChannelBase.js';
+export type {
+  ChannelBaseOptions,
+  ChannelScheduleController,
+} from './ChannelBase.js';
+export { ChannelCronScheduler } from './ChannelCronScheduler.js';
+export type {
+  ChannelCronSchedulerOptions,
+  ChannelRoutineRunner,
+} from './ChannelCronScheduler.js';
+export { ChannelCronStore } from './ChannelCronStore.js';
+export type {
+  ChannelCronJob,
+  ChannelCronJobInput,
+  ChannelCronJobPatch,
+  ChannelCronJobStatus,
+  ChannelCronStoreOptions,
+} from './ChannelCronStore.js';
 export { PairingStore } from './PairingStore.js';
 export type { PairingRequest } from './PairingStore.js';
 export { GroupGate } from './GroupGate.js';

--- a/packages/channels/base/src/types.ts
+++ b/packages/channels/base/src/types.ts
@@ -100,6 +100,7 @@ export interface SessionTarget {
   senderId: string;
   chatId: string;
   threadId?: string;
+  isGroup?: boolean;
 }
 
 /**

--- a/packages/channels/feishu/src/FeishuAdapter.ts
+++ b/packages/channels/feishu/src/FeishuAdapter.ts
@@ -125,6 +125,10 @@ export class FeishuChannel extends ChannelBase {
       (feishuCfg['collapsibleThreshold'] as number) || 500;
   }
 
+  override supportsProactiveSend(): boolean {
+    return true;
+  }
+
   /** Build the event handler map shared between WebSocket and webhook modes. */
   private buildHandlerMap(): Record<string, (data: unknown) => unknown> {
     return {

--- a/packages/channels/feishu/src/FeishuAdapter.ts
+++ b/packages/channels/feishu/src/FeishuAdapter.ts
@@ -13,6 +13,7 @@ import type {
   ChannelBaseOptions,
   Envelope,
   ChannelAgentBridge,
+  SessionTarget,
 } from '@qwen-code/channel-base';
 
 /** Feishu message event data shape. */
@@ -624,11 +625,29 @@ export class FeishuChannel extends ChannelBase {
   }
 
   async sendMessage(chatId: string, text: string): Promise<void> {
+    await this.sendMessageInternal(chatId, text, false);
+  }
+
+  protected override async pushProactive(
+    target: SessionTarget,
+    text: string,
+  ): Promise<void> {
+    await this.sendMessageInternal(target.chatId, text, true);
+  }
+
+  private async sendMessageInternal(
+    chatId: string,
+    text: string,
+    throwOnFailure: boolean,
+  ): Promise<void> {
     const token = await this.getTenantAccessToken();
     if (!token) {
       process.stderr.write(
         `[Feishu:${this.name}] Cannot send: no access token.\n`,
       );
+      if (throwOnFailure) {
+        throw new Error('Feishu sendMessage failed: no access token');
+      }
       return;
     }
 
@@ -670,11 +689,24 @@ export class FeishuChannel extends ChannelBase {
           process.stderr.write(
             `[Feishu:${this.name}] sendMessage failed: HTTP ${resp.status} ${detail}\n`,
           );
+          if (throwOnFailure) {
+            throw new Error(`Feishu sendMessage failed: HTTP ${resp.status}`);
+          }
         }
       } catch (err) {
+        if (
+          throwOnFailure &&
+          err instanceof Error &&
+          err.message.startsWith('Feishu sendMessage failed:')
+        ) {
+          throw err;
+        }
         process.stderr.write(
           `[Feishu:${this.name}] sendMessage error: ${err}\n`,
         );
+        if (throwOnFailure) {
+          throw err;
+        }
       }
     }
   }

--- a/packages/channels/feishu/src/adapter.test.ts
+++ b/packages/channels/feishu/src/adapter.test.ts
@@ -3,6 +3,7 @@ import { FeishuChannel } from './FeishuAdapter.js';
 import type {
   ChannelAgentBridge,
   ChannelConfig,
+  SessionTarget,
 } from '@qwen-code/channel-base';
 
 function createMockBridge(): ChannelAgentBridge {
@@ -39,6 +40,20 @@ function createChannel(
   const config = createConfig(configOverrides);
   const bridge = createMockBridge();
   return new FeishuChannel('test', config, bridge);
+}
+
+class TestableFeishuChannel extends FeishuChannel {
+  pushScheduled(target: SessionTarget, text: string): Promise<void> {
+    return this.pushProactive(target, text);
+  }
+}
+
+function createTestableChannel(
+  configOverrides?: Partial<ChannelConfig>,
+): TestableFeishuChannel {
+  const config = createConfig(configOverrides);
+  const bridge = createMockBridge();
+  return new TestableFeishuChannel('test', config, bridge);
 }
 
 // Access private methods for unit testing
@@ -789,6 +804,59 @@ describe('FeishuChannel', () => {
 
       expect(stderrSpy).toHaveBeenCalledWith(
         expect.stringContaining('Cannot send: no access token'),
+      );
+      stderrSpy.mockRestore();
+    });
+
+    it('rejects proactive sends when token is unavailable', async () => {
+      const channel = createTestableChannel();
+      const stderrSpy = vi
+        .spyOn(process.stderr, 'write')
+        .mockImplementation(() => true);
+
+      await expect(
+        channel.pushScheduled(
+          {
+            channelName: 'test',
+            senderId: 'ou_user',
+            chatId: 'oc_chat_id',
+          },
+          'hello',
+        ),
+      ).rejects.toThrow('Feishu sendMessage failed: no access token');
+
+      expect(stderrSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Cannot send: no access token'),
+      );
+      stderrSpy.mockRestore();
+    });
+
+    it('rejects proactive sends when Feishu returns an error', async () => {
+      const channel = createTestableChannel();
+      (channel as unknown as Record<string, unknown>)['tokenCache'] = {
+        token: 'tenant-token',
+        expiresAt: Date.now() + 3600_000,
+      };
+      vi.spyOn(global, 'fetch').mockResolvedValue(
+        new Response('server down', { status: 500 }),
+      );
+      const stderrSpy = vi
+        .spyOn(process.stderr, 'write')
+        .mockImplementation(() => true);
+
+      await expect(
+        channel.pushScheduled(
+          {
+            channelName: 'test',
+            senderId: 'ou_user',
+            chatId: 'oc_chat_id',
+          },
+          'hello',
+        ),
+      ).rejects.toThrow('Feishu sendMessage failed: HTTP 500');
+
+      expect(stderrSpy).toHaveBeenCalledWith(
+        expect.stringContaining('sendMessage failed: HTTP 500'),
       );
       stderrSpy.mockRestore();
     });

--- a/packages/channels/feishu/src/adapter.test.ts
+++ b/packages/channels/feishu/src/adapter.test.ts
@@ -59,6 +59,12 @@ describe('FeishuChannel', () => {
         /requires clientId.*clientSecret/,
       );
     });
+
+    it('supports proactive scheduled messages', () => {
+      const channel = createChannel();
+
+      expect(channel.supportsProactiveSend()).toBe(true);
+    });
   });
 
   describe('extractContent', () => {

--- a/packages/channels/telegram/src/TelegramAdapter.test.ts
+++ b/packages/channels/telegram/src/TelegramAdapter.test.ts
@@ -113,6 +113,12 @@ describe('TelegramChannel', () => {
     vi.useRealTimers();
   });
 
+  it('supports proactive scheduled messages', () => {
+    const channel = createChannel();
+
+    expect(channel.supportsProactiveSend()).toBe(true);
+  });
+
   it('clears active typing intervals on disconnect', () => {
     const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
     const channel = createChannel();

--- a/packages/channels/telegram/src/TelegramAdapter.ts
+++ b/packages/channels/telegram/src/TelegramAdapter.ts
@@ -60,6 +60,10 @@ export class TelegramChannel extends ChannelBase {
     this.registerCancelCommand();
   }
 
+  override supportsProactiveSend(): boolean {
+    return true;
+  }
+
   private getFileUrl(filePath: string): string {
     return `https://api.telegram.org/file/bot${this.bot.token}/${filePath}`;
   }

--- a/packages/cli/src/commands/channel/start.test.ts
+++ b/packages/cli/src/commands/channel/start.test.ts
@@ -39,6 +39,24 @@ const mockRouterRemoveSessionId = vi.hoisted(() => vi.fn());
 const mockRouterRestoreSessions = vi.hoisted(() => vi.fn());
 const mockRouterSetBridge = vi.hoisted(() => vi.fn());
 const mockRouterSetChannelScope = vi.hoisted(() => vi.fn());
+const mockChannelCronStoreCreate = vi.hoisted(() => vi.fn());
+const mockChannelCronStoreListForTarget = vi.hoisted(() => vi.fn());
+const mockChannelCronStoreDisable = vi.hoisted(() => vi.fn());
+const mockChannelCronStore = vi.hoisted(() =>
+  vi.fn(() => ({
+    create: mockChannelCronStoreCreate,
+    listForTarget: mockChannelCronStoreListForTarget,
+    disable: mockChannelCronStoreDisable,
+  })),
+);
+const mockChannelCronSchedulerStart = vi.hoisted(() => vi.fn());
+const mockChannelCronSchedulerStop = vi.hoisted(() => vi.fn());
+const mockChannelCronScheduler = vi.hoisted(() =>
+  vi.fn(() => ({
+    start: mockChannelCronSchedulerStart,
+    stop: mockChannelCronSchedulerStop,
+  })),
+);
 const mockSessionRouter = vi.hoisted(() =>
   vi.fn(() => ({
     clearAll: mockRouterClearAll,
@@ -86,6 +104,8 @@ vi.mock('./channel-registry.js', () => ({
 
 vi.mock('@qwen-code/channel-base', () => ({
   AcpBridge: mockAcpBridge,
+  ChannelCronScheduler: mockChannelCronScheduler,
+  ChannelCronStore: mockChannelCronStore,
   SessionRouter: mockSessionRouter,
 }));
 
@@ -135,6 +155,9 @@ beforeEach(() => {
   mockReadServiceInfo.mockReturnValue(null);
   mockRouterGetTarget.mockReturnValue(undefined);
   mockRouterRestoreSessions.mockResolvedValue({ failed: 0, restored: 0 });
+  mockChannelCronStoreCreate.mockResolvedValue({ id: 'job-1' });
+  mockChannelCronStoreListForTarget.mockResolvedValue([]);
+  mockChannelCronStoreDisable.mockResolvedValue(true);
   delete process.env['HTTPS_PROXY'];
   delete process.env['https_proxy'];
   delete process.env['HTTP_PROXY'];
@@ -217,7 +240,15 @@ describe('startCommand.handler', () => {
       'telegram',
       mockParsedChannelConfig,
       expect.any(Object),
-      expect.objectContaining({ proxy: settingsProxy }),
+      expect.objectContaining({
+        proxy: settingsProxy,
+        scheduleController: {
+          create: expect.any(Function),
+          listForTarget: expect.any(Function),
+          disable: expect.any(Function),
+          validateCron: expect.any(Function),
+        },
+      }),
     );
   });
 

--- a/packages/cli/src/commands/channel/start.test.ts
+++ b/packages/cli/src/commands/channel/start.test.ts
@@ -244,6 +244,7 @@ describe('startCommand.handler', () => {
         proxy: settingsProxy,
         scheduleController: {
           create: expect.any(Function),
+          createForTarget: expect.any(Function),
           listForTarget: expect.any(Function),
           disable: expect.any(Function),
           validateCron: expect.any(Function),

--- a/packages/cli/src/commands/channel/start.ts
+++ b/packages/cli/src/commands/channel/start.ts
@@ -340,8 +340,8 @@ async function startSingle(name: string, proxy?: string): Promise<void> {
         registerSessionCleanup(bridge, router, channels);
         attachDisconnectHandler(bridge);
 
-        scheduler.start();
         const result = await router.restoreSessions();
+        scheduler.start();
         writeStdoutLine(
           `[Channel] Bridge restarted. Sessions restored: ${result.restored}, failed: ${result.failed}`,
         );
@@ -527,8 +527,8 @@ async function startAll(proxy?: string): Promise<void> {
         registerSessionCleanup(bridge, router, channels);
         attachDisconnectHandler(bridge);
 
-        scheduler.start();
         const result = await router.restoreSessions();
+        scheduler.start();
         writeStdoutLine(
           `[Channel] Bridge restarted. Sessions restored: ${result.restored}, failed: ${result.failed}`,
         );

--- a/packages/cli/src/commands/channel/start.ts
+++ b/packages/cli/src/commands/channel/start.ts
@@ -84,6 +84,7 @@ function createScheduleController(
     disable: (id) => store.disable(id),
     validateCron: (cron) => {
       parseCron(cron);
+      nextFireTime(cron, new Date());
     },
   };
 }
@@ -338,8 +339,8 @@ async function startSingle(name: string, proxy?: string): Promise<void> {
         registerSessionCleanup(bridge, router, channels);
         attachDisconnectHandler(bridge);
 
-        const result = await router.restoreSessions();
         scheduler.start();
+        const result = await router.restoreSessions();
         writeStdoutLine(
           `[Channel] Bridge restarted. Sessions restored: ${result.restored}, failed: ${result.failed}`,
         );
@@ -525,8 +526,8 @@ async function startAll(proxy?: string): Promise<void> {
         registerSessionCleanup(bridge, router, channels);
         attachDisconnectHandler(bridge);
 
-        const result = await router.restoreSessions();
         scheduler.start();
+        const result = await router.restoreSessions();
         writeStdoutLine(
           `[Channel] Bridge restarted. Sessions restored: ${result.restored}, failed: ${result.failed}`,
         );

--- a/packages/cli/src/commands/channel/start.ts
+++ b/packages/cli/src/commands/channel/start.ts
@@ -2,14 +2,26 @@ import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { CommandModule } from 'yargs';
 import { ProxyAgent, setGlobalDispatcher } from 'undici';
-import { normalizeProxyUrl, Storage } from '@qwen-code/qwen-code-core';
+import {
+  nextFireTime,
+  normalizeProxyUrl,
+  parseCron,
+  Storage,
+} from '@qwen-code/qwen-code-core';
 import { loadSettings } from '../../config/settings.js';
 import { writeStderrLine, writeStdoutLine } from '../../utils/stdioHelpers.js';
-import { AcpBridge, SessionRouter } from '@qwen-code/channel-base';
+import {
+  AcpBridge,
+  ChannelCronScheduler,
+  ChannelCronStore,
+  SessionRouter,
+} from '@qwen-code/channel-base';
 import type {
   ChannelAgentBridge,
   ChannelBase,
+  ChannelBaseOptions,
   ChannelPlugin,
+  ChannelScheduleController,
   ToolCallEvent,
 } from '@qwen-code/channel-base';
 import { getPlugin, registerPlugin } from './channel-registry.js';
@@ -56,6 +68,24 @@ export function resolveProxy(
 
 function sessionsPath(): string {
   return path.join(Storage.getGlobalQwenDir(), 'channels', 'sessions.json');
+}
+
+function channelCronPath(): string {
+  return path.join(Storage.getGlobalQwenDir(), 'channels', 'cron.json');
+}
+
+function createScheduleController(
+  store: ChannelCronStore,
+): ChannelScheduleController {
+  return {
+    create: (input) => store.create(input),
+    listForTarget: (channelName, target) =>
+      store.listForTarget(channelName, target),
+    disable: (id) => store.disable(id),
+    validateCron: (cron) => {
+      parseCron(cron);
+    },
+  };
 }
 
 function loadChannelsConfig(): Record<string, unknown> {
@@ -142,7 +172,7 @@ async function createChannel(
   name: string,
   config: Awaited<ReturnType<typeof parseChannelConfig>>,
   bridge: ChannelAgentBridge,
-  options?: { router?: SessionRouter; proxy?: string },
+  options?: ChannelBaseOptions,
 ): Promise<ChannelBase> {
   const channelPlugin = await getPlugin(config.type);
   if (!channelPlugin) {
@@ -239,10 +269,21 @@ async function startSingle(name: string, proxy?: string): Promise<void> {
     config.sessionScope,
     sessionsPath(),
   );
+  const cronStore = new ChannelCronStore({ filePath: channelCronPath() });
+  const scheduleController = createScheduleController(cronStore);
   const channels: Map<string, ChannelBase> = new Map();
 
-  const channel = await createChannel(name, config, bridge, { router, proxy });
+  const channel = await createChannel(name, config, bridge, {
+    router,
+    proxy,
+    scheduleController,
+  });
   channels.set(name, channel);
+  const scheduler = new ChannelCronScheduler({
+    store: cronStore,
+    channels,
+    nextFireTime,
+  });
   registerToolCallDispatch(bridge, router, channels);
   registerSessionCleanup(bridge, router, channels);
 
@@ -255,6 +296,7 @@ async function startSingle(name: string, proxy?: string): Promise<void> {
     bridge.stop();
     process.exit(1);
   }
+  scheduler.start();
 
   writeServiceInfo([name]);
   writeStdoutLine(`[Channel] "${name}" is running. Press Ctrl+C to stop.`);
@@ -274,6 +316,7 @@ async function startSingle(name: string, proxy?: string): Promise<void> {
         writeStderrLine(
           `[Channel] Bridge crashed ${recentCrashes.length} times in ${CRASH_WINDOW_MS / 1000}s. Giving up.`,
         );
+        scheduler.stop();
         channel.disconnect();
         router.clearAll();
         removeServiceInfo();
@@ -283,6 +326,7 @@ async function startSingle(name: string, proxy?: string): Promise<void> {
       writeStderrLine(
         `[Channel] Bridge crashed (${recentCrashes.length}/${MAX_CRASH_RESTARTS} in window). Restarting in ${RESTART_DELAY_MS / 1000}s...`,
       );
+      scheduler.stop();
       await new Promise((r) => setTimeout(r, RESTART_DELAY_MS));
 
       try {
@@ -295,6 +339,7 @@ async function startSingle(name: string, proxy?: string): Promise<void> {
         attachDisconnectHandler(bridge);
 
         const result = await router.restoreSessions();
+        scheduler.start();
         writeStdoutLine(
           `[Channel] Bridge restarted. Sessions restored: ${result.restored}, failed: ${result.failed}`,
         );
@@ -310,6 +355,7 @@ async function startSingle(name: string, proxy?: string): Promise<void> {
   const shutdown = () => {
     shuttingDown = true;
     writeStdoutLine('\n[Channel] Shutting down...');
+    scheduler.stop();
     channel.disconnect();
     bridge.stop();
     router.clearAll();
@@ -379,6 +425,8 @@ async function startAll(proxy?: string): Promise<void> {
   await bridge.start();
 
   const router = new SessionRouter(bridge, defaultCwd, 'user', sessionsPath());
+  const cronStore = new ChannelCronStore({ filePath: channelCronPath() });
+  const scheduleController = createScheduleController(cronStore);
   // Register per-channel scope overrides so each channel uses its own sessionScope
   for (const { name, config } of parsed) {
     router.setChannelScope(name, config.sessionScope);
@@ -392,9 +440,18 @@ async function startAll(proxy?: string): Promise<void> {
   for (const { name, config } of parsed) {
     channels.set(
       name,
-      await createChannel(name, config, bridge, { router, proxy }),
+      await createChannel(name, config, bridge, {
+        router,
+        proxy,
+        scheduleController,
+      }),
     );
   }
+  const scheduler = new ChannelCronScheduler({
+    store: cronStore,
+    channels,
+    nextFireTime,
+  });
   registerToolCallDispatch(bridge, router, channels);
   registerSessionCleanup(bridge, router, channels);
 
@@ -417,6 +474,7 @@ async function startAll(proxy?: string): Promise<void> {
     bridge.stop();
     process.exit(1);
   }
+  scheduler.start();
 
   writeServiceInfo(parsed.map((p) => p.name));
   writeStdoutLine(
@@ -437,6 +495,7 @@ async function startAll(proxy?: string): Promise<void> {
         writeStderrLine(
           `[Channel] Bridge crashed ${recentCrashes.length} times in ${CRASH_WINDOW_MS / 1000}s. Giving up.`,
         );
+        scheduler.stop();
         for (const channel of channels.values()) {
           try {
             channel.disconnect();
@@ -452,6 +511,7 @@ async function startAll(proxy?: string): Promise<void> {
       writeStderrLine(
         `[Channel] Bridge crashed (${recentCrashes.length}/${MAX_CRASH_RESTARTS} in window). Restarting in ${RESTART_DELAY_MS / 1000}s...`,
       );
+      scheduler.stop();
       await new Promise((r) => setTimeout(r, RESTART_DELAY_MS));
 
       try {
@@ -466,6 +526,7 @@ async function startAll(proxy?: string): Promise<void> {
         attachDisconnectHandler(bridge);
 
         const result = await router.restoreSessions();
+        scheduler.start();
         writeStdoutLine(
           `[Channel] Bridge restarted. Sessions restored: ${result.restored}, failed: ${result.failed}`,
         );
@@ -481,6 +542,7 @@ async function startAll(proxy?: string): Promise<void> {
   const shutdown = () => {
     shuttingDown = true;
     writeStdoutLine('\n[Channel] Shutting down...');
+    scheduler.stop();
     for (const [name, channel] of channels) {
       try {
         channel.disconnect();

--- a/packages/cli/src/commands/channel/start.ts
+++ b/packages/cli/src/commands/channel/start.ts
@@ -79,12 +79,13 @@ function createScheduleController(
 ): ChannelScheduleController {
   return {
     create: (input) => store.create(input),
+    createForTarget: (input, maxEnabledJobs) =>
+      store.createForTarget(input, maxEnabledJobs),
     listForTarget: (channelName, target) =>
       store.listForTarget(channelName, target),
     disable: (id) => store.disable(id),
     validateCron: (cron) => {
       parseCron(cron);
-      nextFireTime(cron, new Date());
     },
   };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -120,6 +120,7 @@ export {
   applySkillAllowedTools,
 } from './tools/skill-utils.js';
 export { atomicWriteFile } from './utils/atomicFileWrite.js';
+export { nextFireTime, parseCron } from './utils/cronParser.js';
 
 // Backward-compatible type re-exports for tool classes removed from eager loading.
 // These preserve TypeScript type compatibility for downstream consumers.


### PR DESCRIPTION
## What this PR does

Adds channel-owned scheduled routines for proactive Qwen Tag workflows. The channel gateway now persists routine definitions, runs a scheduler, and dispatches scheduled prompts through the same session routing and queue as normal channel messages. Feishu and Telegram opt in to proactive scheduled sends because their existing send paths can address a chat directly.

## Why it's needed

Channel users need recurring tasks that survive normal chat inactivity and can report back to an IM thread without requiring a fresh inbound message. Keeping scheduling in the gateway lets routines share channel routing, bridge lifecycle management, and adapter capability checks instead of relying on transient in-session cron loops.

## Reviewer Test Plan

### How to verify

Configure a Feishu or Telegram channel, start the channel service, and send `/schedule add "0 9 * * *" post a daily summary` in a supported chat. Confirm the command returns a scheduled job id, `/schedule list` shows it for that chat target, and `/schedule cancel <id>` disables it. For unsupported adapters such as DingTalk, confirm `/schedule add ...` reports that proactive scheduled messages are not supported.

### Evidence (Before & After)

N/A for UI screenshots. Local unit and build verification passed:
- `cd packages/channels/base && npx vitest run src/ChannelCronStore.test.ts src/ChannelCronScheduler.test.ts src/ChannelBase.test.ts src/SessionRouter.test.ts`
- `cd packages/cli && npx vitest run src/commands/channel/start.test.ts`
- `cd packages/channels/telegram && npx vitest run src/TelegramAdapter.test.ts`
- `cd packages/channels/feishu && npx vitest run src/adapter.test.ts`
- `npm run build`
- `npm run typecheck`
- `git diff --check`

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local Node.js workspace with package-level Vitest commands, repository build, and TypeScript typecheck.

## Risk & Scope

- Main risk or tradeoff: scheduled prompts are gateway-owned and require the channel process to be running; missed recurring ticks are not replayed in bulk.
- Not validated / out of scope: DingTalk true cold-send support, natural-language scheduling, and end-to-end provider API tests.
- Breaking changes / migration notes: none expected; unsupported adapters fail closed for `/schedule add`.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

为 channel 场景增加 gateway 侧的主动例行任务能力。channel gateway 现在会持久化 routine 定义、运行 scheduler，并通过与普通 channel 消息相同的 session routing 和队列派发 scheduled prompt。Feishu 和 Telegram 开启 proactive scheduled send，因为它们现有发送路径可以直接按 chatId 发消息。

## 为什么需要

channel 用户需要能在聊天不活跃时继续运行的周期性任务，并把结果主动回推到 IM thread。把调度放在 gateway 层，可以复用 channel routing、bridge 生命周期管理和 adapter capability check，而不是依赖临时的 session 内 cron loop。

## Reviewer 测试计划

### 如何验证

配置 Feishu 或 Telegram channel，启动 channel service，在支持的聊天里发送 `/schedule add "0 9 * * *" post a daily summary`。确认命令返回 scheduled job id，`/schedule list` 能在当前 chat target 下看到任务，`/schedule cancel <id>` 能禁用任务。对于 DingTalk 等未支持 adapter，确认 `/schedule add ...` 会提示 proactive scheduled messages 不支持。

### 证据（Before & After）

非 UI 改动，无截图。已完成本地单测、构建和类型检查：
- `cd packages/channels/base && npx vitest run src/ChannelCronStore.test.ts src/ChannelCronScheduler.test.ts src/ChannelBase.test.ts src/SessionRouter.test.ts`
- `cd packages/cli && npx vitest run src/commands/channel/start.test.ts`
- `cd packages/channels/telegram && npx vitest run src/TelegramAdapter.test.ts`
- `cd packages/channels/feishu && npx vitest run src/adapter.test.ts`
- `npm run build`
- `npm run typecheck`
- `git diff --check`

### 已测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### 环境（可选）

本地 Node.js workspace，使用 package-level Vitest 命令、仓库 build 和 TypeScript typecheck 验证。

## 风险和范围

- 主要风险或取舍：scheduled prompt 由 gateway 负责，要求 channel 进程持续运行；错过的 recurring tick 不会批量补跑。
- 未验证 / 范围外：DingTalk 真正 cold-send 支持、自然语言调度、provider API 端到端测试。
- 破坏性变更 / 迁移说明：预期无；未支持 adapter 对 `/schedule add` fail closed。

## 关联 Issue

N/A

</details>
