### PR TITLE
fix(cli): validate ask_user_question TUI option input

### DIFF
--- a/packages/cli/src/ui/components/messages/AskUserQuestionDialog.test.tsx
+++ b/packages/cli/src/ui/components/messages/AskUserQuestionDialog.test.tsx
@@ -221,6 +221,25 @@ describe('<AskUserQuestionDialog />', () => {
       unmount();
     });
 
+    it('does not auto-submit pasted numeric prefixes as option numbers', async () => {
+      const onConfirm = vi.fn();
+      const details = createConfirmationDetails();
+
+      const { stdin, unmount } = renderWithProviders(
+        <AskUserQuestionDialog
+          confirmationDetails={details}
+          onConfirm={onConfirm}
+        />,
+      );
+      await wait();
+
+      stdin.write('\u001B[200~2x\u001B[201~');
+      await wait();
+
+      expect(onConfirm).not.toHaveBeenCalled();
+      unmount();
+    });
+
     it('does not auto-submit when pressing number key for "Other" custom input', async () => {
       const onConfirm = vi.fn();
       const details = createConfirmationDetails();

--- a/packages/cli/src/ui/components/messages/AskUserQuestionDialog.tsx
+++ b/packages/cli/src/ui/components/messages/AskUserQuestionDialog.tsx
@@ -206,8 +206,8 @@ export const AskUserQuestionDialog: React.FC<AskUserQuestionDialogProps> = ({
       }
 
       // Number key selection
-      const numKey = parseInt(input || '', 10);
-      if (!isNaN(numKey) && numKey >= 1 && numKey <= totalOptions) {
+      const numKey = input && /^[1-9]\d*$/.test(input) ? Number(input) : NaN;
+      if (Number.isSafeInteger(numKey) && numKey <= totalOptions) {
         const targetIndex = numKey - 1;
         setSelectedIndex(targetIndex);
 


### PR DESCRIPTION
## What this PR does

Tightens number-key selection in `AskUserQuestionDialog` so pasted numeric-prefix sequences are not accepted as option selections.

Previously the dialog used `parseInt(input || '', 10)` for numbered option shortcuts. That meant a bracketed paste sequence such as `2x` was parsed as `2`; in single-select mode, selecting a predefined option by number auto-submits immediately, so the malformed paste could submit the second option.

This PR changes the dialog to accept only whole-token, canonical positive integer input before converting it to a number. Valid numbered shortcuts such as `2` still work, and multi-digit shortcuts such as `10` continue to work when that option exists. Non-canonical inputs such as `2x`, `02`, and `2.5` are ignored.

## Why it's needed

`ask_user_question` can collect answers through multiple paths. #5622 already tightened malformed answer indexes in the core confirmation payload path. This PR closes the same numeric-prefix class of issue in the interactive TUI dialog path.

The issue is easiest to trigger through bracketed paste, which can deliver multiple characters as one `key.sequence`. Because the dialog auto-submits single-select predefined options, accepting `parseInt()` prefixes can turn malformed pasted input into an unintended answer.

## Reviewer Test Plan

### How to verify

Run the focused dialog tests from the repo root:

```bash
npm exec vitest -- run packages/cli/src/ui/components/messages/AskUserQuestionDialog.test.tsx --coverage.enabled=false
```

Reviewer checks:

- Pressing `2` still selects/submits the second predefined option.
- Pasting `2x` through bracketed paste does not submit option 2.
- Existing single-select, multi-select, custom input, and multiple-question behavior remains unchanged.

### Evidence (Before & After)

Before this change, the new regression test failed:

```ts
stdin.write('\u001B[200~2x\u001B[201~');

// Unexpectedly submitted:
{ answers: { 0: 'Blue' } }
```

After this change, the pasted malformed numeric-prefix sequence is ignored and the focused test file passes locally:

```text
✓ |@qwen-code/qwen-code| src/ui/components/messages/AskUserQuestionDialog.test.tsx (22 tests | 1 skipped)
Test Files  1 passed (1)
Tests  21 passed | 1 skipped (22)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS     | tested |
|  Windows   | not tested |
|  Linux     | not tested |

### Environment (optional)

Local Node.js workspace tests on macOS. Windows/Linux left to CI.

## Risk & Scope

- Main risk or tradeoff: low. The change only tightens the numbered shortcut parser from `parseInt()` prefix parsing to whole-token canonical positive integer parsing.
- Not validated / out of scope: full repository preflight was not run locally. The focused TUI dialog test and formatting checks for the touched files were run.
- Breaking changes / migration notes: none for valid option number input. Malformed numeric-prefix paste sequences are no longer accepted as valid selections.

## Linked Issues

Fixes #6041
Related: #5621
Related: #5622
Related: #5791

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

收紧 `AskUserQuestionDialog` 中数字选项快捷键的解析逻辑，避免 pasted numeric-prefix sequence 被当作合法选项号。

此前对话框使用 `parseInt(input || '', 10)`。因此 bracketed paste 传入 `2x` 时会被解析成 `2`；在单选题中，数字选择预定义选项会立即提交，所以 malformed paste 可能误提交第 2 个选项。

本 PR 改为只接受完整、规范的正整数输入。`2` 仍可选择第 2 项；存在第 10 项时，`10` 仍可选择第 10 项；`2x`、`02`、`2.5` 等非规范输入会被忽略。

## 为什么需要

`ask_user_question` 有多个答案输入路径。#5622 已经修复了 core confirmation payload 中 malformed answer index 被 `parseInt()` 部分接受的问题。本 PR 修复同一类 numeric-prefix 问题在交互式 TUI dialog 路径中的表现。

该问题最容易通过 bracketed paste 触发，因为 paste 可以把多个字符作为同一个 `key.sequence` 传入。由于单选题中的数字选项会自动提交，接受 `parseInt()` 数字前缀可能把 malformed pasted input 变成非预期答案。

## Reviewer Test Plan

### How to verify

从仓库根目录运行 focused dialog tests：

```bash
npm exec vitest -- run packages/cli/src/ui/components/messages/AskUserQuestionDialog.test.tsx --coverage.enabled=false
```

审查者应确认：按 `2` 仍会选择/提交第 2 个预定义选项；通过 bracketed paste 粘贴 `2x` 不会提交第 2 个选项；既有单选、多选、自定义输入、多问题行为不变。

### Evidence (Before & After)

修复前，新增回归测试失败：粘贴 `2x` 会误提交 `{ answers: { 0: 'Blue' } }`。修复后，该 malformed numeric-prefix paste 被忽略，focused test 文件本地通过：21 passed，1 skipped。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS     | tested |
|  Windows   | not tested |
|  Linux     | not tested |

## Risk & Scope

- 主要风险：低。改动只把数字快捷键解析从 `parseInt()` 前缀解析收紧为完整 token 的 canonical 正整数解析。
- 未验证 / 范围外：本地未跑完整 preflight；已运行 touched TUI dialog test 和 touched files formatting checks。
- 破坏性变更：合法数字选项输入无破坏性变化。malformed numeric-prefix paste sequence 不再被当作合法选择。

## 关联 Issue

Fixes #6041
Related: #5621
Related: #5622
Related: #5791

</details>