### PR TITLE
fix(core): keep plan mode and require approval when plan gate is unavailable

### DIFF
--- a/packages/core/src/tools/exitPlanMode.test.ts
+++ b/packages/core/src/tools/exitPlanMode.test.ts
@@ -614,20 +614,66 @@ describe('ExitPlanModeTool', () => {
 
       const result = await tool.build(params).execute(signal);
 
-      // Should return plan_summary (NOT rejected) so user is not trapped
+      // Should return plan_summary (NOT rejected) while staying in plan mode.
       expect(result.returnDisplay).toEqual({
         type: 'plan_summary',
-        message: expect.stringContaining('confirm whether to execute'),
+        message: expect.stringContaining('plan mode remains active'),
         plan: params.plan,
       });
+      expect(result.returnDisplay).not.toEqual(
+        expect.objectContaining({ rejected: true }),
+      );
       expect(result.llmContent).toContain('Ask the user');
       // Should NOT set gate pending flags
       expect(gateState.needsUserPending).toBe(false);
       expect(gateState.capEscalationPending).toBe(false);
-      // Should restore to DEFAULT (not pre-plan YOLO) to force confirmation dialog
-      expect(mockConfig.setApprovalMode).toHaveBeenCalledWith(
+      // Should stay in PLAN mode until the user explicitly approves.
+      expect(mockConfig.setApprovalMode).not.toHaveBeenCalledWith(
         ApprovalMode.DEFAULT,
       );
+      expect(approvalMode).toBe(ApprovalMode.PLAN);
+      expect(mockConfig.savePlan).toHaveBeenCalledWith(params.plan);
+    });
+
+    it('should preserve plan mode when gate is unavailable for a minimal plan', async () => {
+      approvalMode = ApprovalMode.PLAN;
+      const gateState = {
+        entryId: 1,
+        reviewCount: 0,
+        gateMode: 'capped' as const,
+        enteredByModel: true,
+        lastFindings: [],
+        capEscalationPending: false,
+        needsUserPending: false,
+      };
+      (mockConfig.getPrePlanMode as ReturnType<typeof vi.fn>).mockReturnValue(
+        ApprovalMode.YOLO,
+      );
+      (mockConfig.getPlanGateState as ReturnType<typeof vi.fn>).mockReturnValue(
+        gateState,
+      );
+      mockedRunPlanApprovalGate.mockResolvedValue({
+        kind: 'unavailable',
+        reason: 'review model timed out',
+      });
+
+      const params: ExitPlanModeParams = {
+        plan: 'x',
+        originalRequest: 'Test minimal fallback',
+      };
+      const signal = new AbortController().signal;
+
+      const result = await tool.build(params).execute(signal);
+
+      expect(result.returnDisplay).toEqual({
+        type: 'plan_summary',
+        message: expect.stringContaining('plan mode remains active'),
+        plan: params.plan,
+      });
+      expect(mockConfig.setApprovalMode).not.toHaveBeenCalledWith(
+        ApprovalMode.DEFAULT,
+      );
+      expect(approvalMode).toBe(ApprovalMode.PLAN);
       expect(mockConfig.savePlan).toHaveBeenCalledWith(params.plan);
     });
   });

--- a/packages/core/src/tools/exitPlanMode.test.ts
+++ b/packages/core/src/tools/exitPlanMode.test.ts
@@ -627,6 +627,7 @@ describe('ExitPlanModeTool', () => {
       // Should NOT set gate pending flags
       expect(gateState.needsUserPending).toBe(false);
       expect(gateState.capEscalationPending).toBe(false);
+      expect(gateState.gateMode).toBe('user_takeover');
       // Should stay in PLAN mode until the user explicitly approves.
       expect(mockConfig.setApprovalMode).not.toHaveBeenCalledWith(
         ApprovalMode.DEFAULT,
@@ -673,6 +674,7 @@ describe('ExitPlanModeTool', () => {
       expect(mockConfig.setApprovalMode).not.toHaveBeenCalledWith(
         ApprovalMode.DEFAULT,
       );
+      expect(gateState.gateMode).toBe('user_takeover');
       expect(approvalMode).toBe(ApprovalMode.PLAN);
       expect(mockConfig.savePlan).toHaveBeenCalledWith(params.plan);
     });

--- a/packages/core/src/tools/exitPlanMode.ts
+++ b/packages/core/src/tools/exitPlanMode.ts
@@ -302,11 +302,10 @@ class ExitPlanModeToolInvocation extends BaseToolInvocation<
             };
           }
           case 'unavailable': {
-            // Gate is broken — fall back to DEFAULT mode so the user
-            // gets a real confirmation dialog on the next action,
-            // instead of trapping in plan mode with no escape hatch.
+            // Gate is broken — stay in PLAN mode and ask the user for
+            // explicit approval before execution can proceed.
             debugLogger.warn(
-              `Gate unavailable, falling back to DEFAULT mode: ${decision.reason}`,
+              `Gate unavailable, requiring user approval in PLAN mode: ${decision.reason}`,
             );
             return this.fallbackToUserDecision(plan);
           }
@@ -411,15 +410,11 @@ class ExitPlanModeToolInvocation extends BaseToolInvocation<
   }
 
   /**
-   * Gate unavailable fallback — switch to DEFAULT mode so the next
-   * action triggers a real user confirmation dialog. This breaks the
-   * gate trap while forcing the model to present the plan for approval
-   * rather than auto-executing in AUTO/YOLO.
+   * Gate unavailable fallback — fail closed by staying in PLAN mode and
+   * requiring explicit user approval before execution can proceed.
    */
   private fallbackToUserDecision(plan: string): ToolResult {
-    this.setApprovalModeSafely(ApprovalMode.DEFAULT);
-
-    // Save plan so it's on disk even if the model proceeds.
+    // Save plan so it's on disk while the session remains in plan mode.
     try {
       this.config.savePlan(plan);
     } catch (error) {
@@ -434,7 +429,7 @@ class ExitPlanModeToolInvocation extends BaseToolInvocation<
       returnDisplay: {
         type: 'plan_summary',
         message:
-          'Plan gate is unavailable. The plan has been saved — please confirm whether to execute it.',
+          'Plan gate is unavailable. The plan has been saved, and plan mode remains active until the user explicitly approves execution.',
         plan,
       },
     };

--- a/packages/core/src/tools/exitPlanMode.ts
+++ b/packages/core/src/tools/exitPlanMode.ts
@@ -302,8 +302,10 @@ class ExitPlanModeToolInvocation extends BaseToolInvocation<
             };
           }
           case 'unavailable': {
-            // Gate is broken — stay in PLAN mode and ask the user for
-            // explicit approval before execution can proceed.
+            // Gate is broken — stay in PLAN mode but hand control to the user
+            // so the next exit_plan_mode call shows the normal confirmation
+            // dialog and requires explicit approval before execution.
+            gateState.gateMode = 'user_takeover';
             debugLogger.warn(
               `Gate unavailable, requiring user approval in PLAN mode: ${decision.reason}`,
             );
@@ -411,7 +413,9 @@ class ExitPlanModeToolInvocation extends BaseToolInvocation<
 
   /**
    * Gate unavailable fallback — fail closed by staying in PLAN mode and
-   * requiring explicit user approval before execution can proceed.
+   * requiring explicit user approval before execution can proceed. The caller
+   * marks the gate as user_takeover first so the next exit_plan_mode call uses
+   * the normal confirmation dialog instead of re-running the automatic gate.
    */
   private fallbackToUserDecision(plan: string): ToolResult {
     // Save plan so it's on disk while the session remains in plan mode.


### PR DESCRIPTION
## What this PR does

When a model-initiated plan (entered autonomously under AUTO/YOLO) calls `exit_plan_mode` and the plan approval gate returns `unavailable` after its retries, the tool no longer drops the session out of plan mode. Previously this path called `fallbackToUserDecision`, which switched the session to `DEFAULT` mode — silently leaving plan mode so the agent could begin making changes the user never approved. The fallback now fails closed: the session stays in `ApprovalMode.PLAN`, the plan is preserved, and the gate hands control to the user (`gateMode = 'user_takeover'`) so the next `exit_plan_mode` call routes through the normal confirmation dialog instead of re-running the broken gate. The `approved`, `blocked`, `needs_user`, and `cap_escalation` branches are unchanged.

## Why it's needed

The entire purpose of plan mode is to align on the approach before any changes are made. When the gate was unavailable, switching to `DEFAULT` exited plan mode immediately with no approval prompt, silently bypassing that safety gate and risking unintended code modifications. Setting `user_takeover` (rather than just leaving the gate state untouched) is what keeps the user from getting stuck: without it, `getDefaultPermission()` would keep auto-allowing the next `exit_plan_mode` call and re-running the unavailable gate, with no escape path. Now the user always gets an explicit approve/revise decision before execution can begin. Fixes #6034.

## Reviewer Test Plan

### How to verify

This is a non-user-visible logic change in `packages/core`; it is covered by unit tests. Run the targeted suite:

```
cd packages/core && npx vitest run src/tools/exitPlanMode.test.ts
```

Expected: all tests pass (34). The updated `unavailable`-gate tests assert that, on an unavailable gate, `setApprovalMode` is NOT called with `ApprovalMode.DEFAULT`, the session remains in `ApprovalMode.PLAN`, `gateState.gateMode` becomes `'user_takeover'`, the plan is saved, and the result is a non-rejected `plan_summary`. A new test covers the same invariants for a minimal plan.

### Evidence (Before & After)

N/A — non-user-visible change (core logic + unit tests).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A — unit tests only (`vitest`).

## Risk & Scope

- Main risk or tradeoff: behavioral change to the gate-unavailable path — the session now stays in plan mode and requires an explicit user decision instead of falling through to `DEFAULT`. This is the intended fix.
- Not validated / out of scope: the other gate decision branches (`approved`/`blocked`/`needs_user`/`cap_escalation`) are unchanged; the underlying cause of gate unavailability is not addressed here.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #6034

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

当模型在 AUTO/YOLO 模式下自主进入计划模式并调用 `exit_plan_mode`，而计划审批 gate 在重试后返回 `unavailable` 时，本工具不再让会话退出计划模式。此前该分支会调用 `fallbackToUserDecision` 将会话切换到 `DEFAULT` 模式，从而静默地离开计划模式，使 agent 可以开始用户从未批准的修改。现在该回退改为「失败即关闭」：会话保持在 `ApprovalMode.PLAN`，计划被保留，并将控制权交还给用户（`gateMode = 'user_takeover'`），这样下一次 `exit_plan_mode` 调用会走正常的确认对话框，而不是再次运行已损坏的 gate。`approved`、`blocked`、`needs_user`、`cap_escalation` 分支保持不变。

## 为什么需要

计划模式的全部意义在于在做任何修改之前先就方案达成一致。当 gate 不可用时，切换到 `DEFAULT` 会立即退出计划模式且不显示任何审批提示，静默绕过该安全 gate，带来未经批准修改代码的风险。设置 `user_takeover`（而不是仅仅保持 gate 状态不变）是避免用户被卡住的关键：否则 `getDefaultPermission()` 会继续自动允许下一次 `exit_plan_mode` 调用并再次运行不可用的 gate，没有任何退出路径。现在用户在执行开始前总能得到明确的批准/修改决策。Fixes #6034。

</details>
