### PR TITLE
fix(cli): prevent transcript re-scroll on tab-switch in terminal multiplexers

### DIFF
--- a/patches/ink+7.0.3.patch
+++ b/patches/ink+7.0.3.patch
@@ -1,3 +1,51 @@
+diff --git a/node_modules/ink/build/ink.js b/node_modules/ink/build/ink.js
+index ef659f3..14d0aba 100644
+--- a/node_modules/ink/build/ink.js
++++ b/node_modules/ink/build/ink.js
+@@ -145,6 +145,7 @@ export default class Ink {
+     lastOutputToRender;
+     lastOutputHeight;
+     lastTerminalWidth;
++    lastTerminalHeight;
+     container;
+     rootNode;
+     // This variable is used only in debug mode to store full static output
+@@ -227,6 +228,7 @@ export default class Ink {
+         this.lastOutputToRender = '';
+         this.lastOutputHeight = 0;
+         this.lastTerminalWidth = getWindowSize(this.options.stdout).columns;
++        this.lastTerminalHeight = getWindowSize(this.options.stdout).rows;
+         // This variable is used only in debug mode to store full static output
+         // so that it's rerendered every time, not just new static parts, like in non-debug mode
+         this.fullStaticOutput = '';
+@@ -260,7 +262,18 @@ export default class Ink {
+         void this.exitPromise.catch(noop);
+     }
+     resized = () => {
+-        const currentWidth = getWindowSize(this.options.stdout).columns;
++        const { columns: currentWidth, rows: currentHeight } = getWindowSize(this.options.stdout);
++        // A resize event whose dimensions are unchanged carries no layout work.
++        // Terminal multiplexers (tmux/cmux/screen) routinely re-send SIGWINCH
++        // with identical dimensions when a pane regains focus; re-rendering here
++        // pushes renderInteractiveFrame down its overflow path, which writes
++        // `clearTerminal + fullStaticOutput + output` and re-streams the ENTIRE
++        // scrollback — visibly scrolling the transcript from top to bottom every
++        // time you switch back to the tab. Nothing changed, so do nothing.
++        if (currentWidth === this.lastTerminalWidth &&
++            currentHeight === this.lastTerminalHeight) {
++            return;
++        }
+         if (currentWidth < this.lastTerminalWidth) {
+             // We clear the screen when decreasing terminal width to prevent duplicate overlapping re-renders.
+             this.log.clear();
+@@ -270,6 +283,7 @@ export default class Ink {
+         this.calculateLayout();
+         this.onRender();
+         this.lastTerminalWidth = currentWidth;
++        this.lastTerminalHeight = currentHeight;
+     };
+     resolveExitPromise = () => { };
+     rejectExitPromise = () => { };
 diff --git a/node_modules/ink/package.json b/node_modules/ink/package.json
 --- a/node_modules/ink/package.json
 +++ b/node_modules/ink/package.json


### PR DESCRIPTION
## What this PR does

Stops the whole transcript from re-scrolling top→bottom when you switch back to a tab running a long task in terminal multiplexers (tmux/cmux/screen).

Patches upstream ink 7.0.3 (via `patch-package`) so `Ink.resized()` returns early when the terminal dimensions are unchanged, and tracks `lastTerminalHeight` alongside the existing `lastTerminalWidth`.

## Why it's needed

In non-VP (default) mode the whole history lives in Ink's `<Static>` region, accumulated in `this.fullStaticOutput`. When the dynamic (non-`<Static>`) frame is taller than the viewport, `renderInteractiveFrame` takes its overflow path and writes `clearTerminal + this.fullStaticOutput + output` — i.e. it clears the screen+scrollback and re-prints the entire session transcript, which visibly scrolls from top to bottom (and takes a while on long sessions).

`resized()` unconditionally calls `onRender()` on every `resize`/`SIGWINCH`, even when dimensions didn't change. Terminal multiplexers routinely re-send SIGWINCH with identical dimensions when a pane regains focus, so each switch-back into a running task triggered this full replay. A same-dimension resize has no layout work to do, and multiplexers preserve pane content across focus, so the correct behavior is to do nothing.

This is not caused by #6015 (the non-VP scroll-snapback / wheel PR) — that PR never touched `resized()` / `fullStaticOutput` / `shouldClearTerminalForFrame`; it shares only the same overflow mechanism. This is stock upstream ink behavior.

## Reviewer Test Plan

### How to verify

Fake-TTY harness (viewport 10 rows, dynamic frame 14 rows → overflow), emit a `resize` with unchanged dimensions:

| | `clearTerminal` emitted | history lines re-emitted |
| --- | :---: | :---: |
| **before** | ✅ | 12 / 12 (full replay) |
| **after** | ❌ | 0 / 12 (no-op) |

A genuine dimension change still relayouts + renders (the early-return only fires when both `columns` and `rows` are unchanged). Existing rendering suites pass (`InlineParallelAgentsDisplay`, `ScrollableList`, `VirtualizedList` incl. auto-scroll = 46 tests). Patch applies cleanly from pristine (`patch-package` → `ink@7.0.3 ✔`); the existing `package.json` exports hunk is preserved.

Manual: in tmux/cmux, non-VP mode, run a long task, scroll to the bottom, switch to another tab and back. **Before:** the transcript replays from the top and scrolls for a while before reaching the bottom. **After:** the view stays put.

### Evidence (Before & After)

N/A — non-UI code change in vendored ink; behavior confirmed via fake-TTY harness output above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ |
| 🪟 Windows | ⚠️ |
|  🐧 Linux  | ⚠️ |

### Environment

Local runtime: `npm run dev`; fake-TTY harness for automated verification. No sandbox involved — patch-only change to vendored ink.

## Risk & Scope

- **Main risk:** behavior changes only for resize events with byte-identical dimensions (previously a full re-render, now a no-op — correct, since there is no layout change and multiplexers retain pane content). Real resizes are unaffected.
- **Not validated / out of scope:** verified the mechanism (same-dimension resize ⇒ full `fullStaticOutput` replay) and that this fix makes that case a no-op, with a fake-TTY harness. Could not run real cmux locally to confirm its tab-switch emits a same-dimension SIGWINCH (the common case for tmux/screen). If cmux instead emits a changed-dimension resize on switch, a deeper follow-up is needed (avoid re-emitting the full `fullStaticOutput` on the overflow-clear path). Please sanity-check on the original cmux setup.
- **Breaking changes:** none — patch-only change to vendored ink; no app/API/settings changes.

## Linked Issues

Ref #6015 (related non-VP scroll-snapback fix; different root cause — see "Why it's needed" above).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修复了在终端复用器（tmux/cmux/screen）中切换回正在运行长任务的标签页时，整个会话记录从上到下重新滚动的问题。

通过 `patch-package` 修补上游 ink 7.0.3，使 `Ink.resized()` 在终端尺寸未变时提前返回，并新增 `lastTerminalHeight` 与已有的 `lastTerminalWidth` 配套跟踪。

## 为什么需要修复

在非 VP（默认）模式下，完整历史记录存储在 Ink 的 `<Static>` 区域（`this.fullStaticOutput`）。当动态帧（非 `<Static>` 部分）高度超过视口时，`renderInteractiveFrame` 走溢出路径，写入 `clearTerminal + this.fullStaticOutput + output`——即清屏+清滚动缓冲并重新打印整个会话记录，导致可见的从上到下滚动（长会话时耗时明显）。

`resized()` 在每次 `resize`/`SIGWINCH` 时无条件调用 `onRender()`，即使尺寸没变。终端复用器在面板重新获得焦点时常会发送尺寸完全相同的 SIGWINCH，因此每次切回运行中的任务标签页都会触发完整重放。尺寸未变的 resize 不需要做任何布局工作，且复用器在焦点切换时保留面板内容，所以正确行为是什么都不做。

此问题不是 #6015（非 VP 滚动回弹/滚轮 PR）导致的——那个 PR 从未修改 `resized()` / `fullStaticOutput` / `shouldClearTerminalForFrame`，仅共享了相同的溢出机制。这是上游 ink 的原生行为。

## 审阅者测试计划

### 如何验证

Fake-TTY 测试工具（视口 10 行，动态帧 14 行 → 溢出），发送尺寸不变的 `resize`：

| | 触发 `clearTerminal` | 重新输出的历史行 |
| --- | :---: | :---: |
| **修复前** | ✅ | 12 / 12（完整重放） |
| **修复后** | ❌ | 0 / 12（无操作） |

真正的尺寸变化仍会重新布局和渲染（提前返回仅在 `columns` 和 `rows` 均未变时触发）。现有渲染测试套件全部通过（`InlineParallelAgentsDisplay`、`ScrollableList`、`VirtualizedList` 含自动滚动 = 46 个测试）。补丁从干净状态应用成功（`patch-package` → `ink@7.0.3 ✔`）；保留了现有的 `package.json` exports hunk。

手动验证：在 tmux/cmux 非VP 模式下，运行长任务，滚动到底部，切换到另一个标签页再切回。**修复前：** 会话记录从顶部重放并滚动一段时间才到达底部。**修复后：** 视图保持不动。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ |
| 🪟 Windows | ⚠️ |
|  🐧 Linux  | ⚠️ |

### 运行环境

本地运行：`npm run dev`；使用 fake-TTY 工具进行自动化验证。无沙箱——仅修改 vendored ink 补丁。

## 风险与范围

- **主要风险：** 仅对尺寸完全相同的 resize 事件改变行为（之前是完整重渲染，现在是无操作——正确，因为没有布局变化且复用器保留面板内容）。真正的 resize 不受影响。
- **未验证/超出范围：** 已验证机制（同尺寸 resize ⇒ 完整 `fullStaticOutput` 重放）及此修复使该情况变为无操作，使用 fake-TTY 工具。无法在本地运行真正的 cmux 来确认其标签切换是否发送同尺寸 SIGWINCH（tmux/screen 的常见情况）。如果 cmux 在切换时发送的是尺寸变化的 resize，则需要更深入的后续修复（避免在溢出清屏路径上重新输出完整 `fullStaticOutput`）。请在原始 cmux 环境上验证。
- **破坏性变更：** 无——仅修改 vendored ink 补丁，无应用/API/设置变更。

## 关联 Issue

参考 #6015（相关的非 VP 滚动回弹修复；根因不同——见上方"为什么需要修复"）。

</details>
