### PR TITLE
fix(cli): yield to React after addItem to reduce input lag

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -4035,6 +4035,9 @@ describe('useGeminiStream', () => {
       await act(async () => {
         await Promise.resolve();
         await Promise.resolve();
+        // Flush the macrotask yield (setImmediate) added after addItem()
+        // so that sendMessageStream is actually invoked.
+        await vi.advanceTimersByTimeAsync(0);
       });
 
       expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
@@ -4163,6 +4166,8 @@ describe('useGeminiStream', () => {
       await act(async () => {
         await Promise.resolve();
         await Promise.resolve();
+        // Flush the macrotask yield (setImmediate) added after addItem()
+        await vi.advanceTimersByTimeAsync(0);
       });
 
       expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
@@ -4223,6 +4228,8 @@ describe('useGeminiStream', () => {
       await act(async () => {
         await Promise.resolve();
         await Promise.resolve();
+        // Flush the macrotask yield (setImmediate) added after addItem()
+        await vi.advanceTimersByTimeAsync(0);
       });
 
       await act(async () => {
@@ -4361,6 +4368,8 @@ describe('useGeminiStream', () => {
       await act(async () => {
         await Promise.resolve();
         await Promise.resolve();
+        // Flush the macrotask yield (setImmediate) added after addItem()
+        await vi.advanceTimersByTimeAsync(0);
       });
 
       expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
@@ -4711,6 +4720,8 @@ describe('useGeminiStream', () => {
       await act(async () => {
         await Promise.resolve();
         await Promise.resolve();
+        // Flush the macrotask yield (setImmediate) added after addItem()
+        await vi.advanceTimersByTimeAsync(0);
       });
 
       // Cancel without advancing the throttle timer; the cancel-time
@@ -4828,6 +4839,8 @@ describe('useGeminiStream', () => {
       await act(async () => {
         await Promise.resolve();
         await Promise.resolve();
+        // Flush the macrotask yield (setImmediate) added after addItem()
+        await vi.advanceTimersByTimeAsync(0);
       });
 
       // Sanity: the throttle has not fired yet.
@@ -6743,6 +6756,8 @@ describe('useGeminiStream', () => {
           void result.current.submitQuery('think then retry');
           await Promise.resolve();
           await Promise.resolve();
+          // Flush the macrotask yield (setImmediate) added after addItem()
+          await vi.advanceTimersByTimeAsync(0);
         });
 
         // Advance past STREAM_UPDATE_THROTTLE_MS (60ms) so the thought
@@ -6840,6 +6855,8 @@ describe('useGeminiStream', () => {
 
         await act(async () => {
           await Promise.resolve();
+          // Flush the macrotask yield (setImmediate) added after addItem()
+          await vi.advanceTimersByTimeAsync(0);
         });
 
         const findErrorItem = () =>
@@ -6953,6 +6970,12 @@ describe('useGeminiStream', () => {
 
         act(() => {
           void result.current.submitQuery('Trigger retry after countdown');
+        });
+
+        await act(async () => {
+          await Promise.resolve();
+          // Flush the macrotask yield (setImmediate) added after addItem()
+          await vi.advanceTimersByTimeAsync(0);
         });
 
         let errorItem = result.current.pendingHistoryItems.find(

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1038,6 +1038,11 @@ export const useGeminiStream = (
           };
         }
 
+        // Yield to let React render the user message before continuing
+        // with @-command processing and API call. Reduces the visual lag
+        // between input-box clear and the message appearing in history.
+        await Promise.resolve();
+
         // Handle @-commands (which might involve tool calls)
         if (isAtCommand(trimmedQuery)) {
           const atCommandResult = await handleAtCommand({

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1038,10 +1038,16 @@ export const useGeminiStream = (
           };
         }
 
-        // Yield to let React render the user message before continuing
-        // with @-command processing and API call. Reduces the visual lag
-        // between input-box clear and the message appearing in history.
-        await Promise.resolve();
+        // Yield via macrotask to let Ink/React flush the user message render
+        // before continuing with @-command processing and API call.
+        // React 19.2.4 (Ink 7.0.3) schedules renders via
+        // MessageChannel.postMessage (a macrotask), so a microtask yield
+        // (await Promise.resolve()) does NOT give React a chance to render —
+        // the continuation runs first. setImmediate fires in the check phase
+        // after I/O events (where MessageChannel delivers its postMessage),
+        // guaranteeing React renders first without the ~1ms timer overhead
+        // of setTimeout(0).
+        await new Promise((r) => setImmediate(r));
 
         // Handle @-commands (which might involve tool calls)
         if (isAtCommand(trimmedQuery)) {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1036,18 +1036,19 @@ export const useGeminiStream = (
             id: insertedId,
             text: trimmedQuery,
           };
-        }
 
-        // Yield via macrotask to let Ink/React flush the user message render
-        // before continuing with @-command processing and API call.
-        // React 19.2.4 (Ink 7.0.3) schedules renders via
-        // MessageChannel.postMessage (a macrotask), so a microtask yield
-        // (await Promise.resolve()) does NOT give React a chance to render —
-        // the continuation runs first. setImmediate fires in the check phase
-        // after I/O events (where MessageChannel delivers its postMessage),
-        // guaranteeing React renders first without the ~1ms timer overhead
-        // of setTimeout(0).
-        await new Promise((r) => setImmediate(r));
+          // Yield via macrotask to let Ink/React flush the user message
+          // render before continuing with @-command processing and API
+          // call. React 19.2.4 (Ink 7.0.3) schedules renders via
+          // MessageChannel.postMessage (a macrotask), so a microtask yield
+          // (await Promise.resolve()) does NOT give React a chance to
+          // render — the continuation runs first. setImmediate fires in
+          // the check phase after I/O events (where MessageChannel
+          // delivers its postMessage), guaranteeing React renders first
+          // without the ~1ms timer overhead of setTimeout(0).
+          // Only needed for non-Cron submissions since Cron skips addItem().
+          await new Promise((r) => setImmediate(r));
+        }
 
         // Handle @-commands (which might involve tool calls)
         if (isAtCommand(trimmedQuery)) {


### PR DESCRIPTION
## What this PR does

Adds a macrotask yield point (`await new Promise(r => setImmediate(r))`) after `addItem()` in the `prepareQueryForGemini` function. This gives React a rendering window immediately after the user message state update, before continuing with background operations like @-command processing and API call.

## Why it's needed

User messages appeared in the chat history with a noticeable delay (200-500ms) after the input box was cleared. The root cause was that `addItem()` triggered a React state update via `setHistory()`, but subsequent synchronous operations in the same async function blocked React from rendering until the next `await` in the call chain (typically `sendMessageStream()` or `processGeminiStreamEvents()`).

React 19.2.4 (Ink 7.0.3) schedules renders via `MessageChannel.postMessage`, which is a macrotask. A microtask yield (`await Promise.resolve()`) would NOT work because the event loop drains all microtasks before any macrotask fires. By inserting a macrotask yield (`setImmediate`), we yield control to the event loop's check phase (after I/O events where MessageChannel delivers), allowing React to render the user message immediately while background processing continues in parallel.

## Reviewer Test Plan

### How to verify

1. Run `npm run dev` to start the CLI in development mode
2. Type any message in the input box and press Enter
3. Observe that the input box clears and the message appears in the chat history nearly simultaneously (no visible lag gap)
4. Test with @-commands (e.g., `@file.ts`) to confirm file reading and context injection still work correctly
5. Test with slash commands (e.g., `/help`) to confirm command processing is unaffected

### Evidence (Before & After)

**Before**: Input box clears → 200-500ms blank period → message suddenly appears in history

**After**: Input box clears → message appears in history within ~50-100ms (feels instantaneous)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

## Risk & Scope

- Main risk or tradeoff: Adds one extra macrotask cycle (`setImmediate`) to the prompt submission path. The performance impact is negligible (<1ms) and only affects the rendering timing, not the actual message processing logic.
- Not validated / out of scope: Daemon/web-shell mode (this fix targets the TUI code path in `useGeminiStream.ts`)
- Breaking changes / migration notes: None

## Linked Issues

No existing issue filed for this.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 `prepareQueryForGemini` 函数的 `addItem()` 调用后添加了一个宏任务让权点（`await new Promise(r => setImmediate(r))`）。这使得 React 在用户消息状态更新后立即获得渲染窗口，然后再继续后台操作（如 @-command 处理和 vision bridge 转换）。

## 为什么需要

用户消息在输入框清空后，要延迟 200-500ms 才出现在聊天记录中。根本原因是 `addItem()` 通过 `setHistory()` 触发了 React state 更新，但同一 async 函数中的后续同步操作阻塞了 React 的渲染，直到调用链中的下一个 `await`（通常是 `sendMessageStream()` 或 `processGeminiStreamEvents()`）。

React 19.2.4 (Ink 7.0.3) 使用 `MessageChannel.postMessage` 调度渲染，这是一个宏任务。微任务让权（`await Promise.resolve()`）无效，因为事件循环会先清空所有微任务才执行宏任务。通过插入宏任务让权（`setImmediate`），我们让出执行权给事件循环的 check 阶段（在 I/O 事件之后，MessageChannel 在此投递），使 React 能立即渲染用户消息，而后台处理继续并行进行。

## 验证方式

1. 运行 `npm run dev` 启动 CLI 开发模式
2. 在输入框中输入任意消息并按回车
3. 观察输入框清空和消息出现在聊天记录中几乎同时发生（无明显 lag）
4. 测试 @-command（如 `@file.ts`）确认文件读取和上下文注入正常
5. 测试 slash command（如 `/help`）确认命令处理不受影响

**修复前**：输入框清空 → 200-500ms 空白期 → 消息突然出现

**修复后**：输入框清空 → 消息在 ~50-100ms 内出现（感觉是即时的）

</details>