### PR TITLE
fix(ci): create isolated home before tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,9 @@ jobs:
           QWEN_API_KEY: ''
           GEMINI_API_KEY: ''
           QWEN_DEFAULT_AUTH_TYPE: ''
-        run: 'npm run test:ci'
+        run: |-
+          node -e "const fs = require('node:fs'); for (const key of ['HOME', 'USERPROFILE']) { const dir = process.env[key]; if (dir) fs.mkdirSync(dir, { recursive: true }); }"
+          npm run test:ci
 
       - name: 'Run no-AK integration smoke tests'
         if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && github.event_name == 'pull_request' }}"
@@ -354,7 +356,9 @@ jobs:
           QWEN_API_KEY: ''
           GEMINI_API_KEY: ''
           QWEN_DEFAULT_AUTH_TYPE: ''
-        run: 'npm run test:ci'
+        run: |-
+          node -e "const fs = require('node:fs'); for (const key of ['HOME', 'USERPROFILE']) { const dir = process.env[key]; if (dir) fs.mkdirSync(dir, { recursive: true }); }"
+          npm run test:ci
 
   # Windows counterpart of test_macos (see that job's note). Runner is
   # windows-2022; the check name keeps the windows-latest label so it matches
@@ -407,7 +411,9 @@ jobs:
           QWEN_API_KEY: ''
           GEMINI_API_KEY: ''
           QWEN_DEFAULT_AUTH_TYPE: ''
-        run: 'npm run test:ci'
+        run: |-
+          node -e "const fs = require('node:fs'); for (const key of ['HOME', 'USERPROFILE']) { const dir = process.env[key]; if (dir) fs.mkdirSync(dir, { recursive: true }); }"
+          npm run test:ci
 
   post_coverage_comment:
     name: 'Post Coverage Comment'

--- a/packages/channels/base/src/paths.test.ts
+++ b/packages/channels/base/src/paths.test.ts
@@ -42,7 +42,7 @@ describe('channels/base paths – getGlobalQwenDir', () => {
 
   it('treats bare tilde (~) as home directory', () => {
     process.env['QWEN_HOME'] = '~';
-    expect(getGlobalQwenDir()).toBe(os.homedir());
+    expect(getGlobalQwenDir()).toBe(path.normalize(os.homedir()));
   });
 });
 
@@ -53,7 +53,7 @@ describe('channels/base paths – resolvePath', () => {
   });
 
   it('expands bare tilde (~) to home directory', () => {
-    expect(resolvePath('~')).toBe(os.homedir());
+    expect(resolvePath('~')).toBe(path.normalize(os.homedir()));
   });
 
   it('expands POSIX-style tilde (~/x)', () => {

--- a/packages/cli/src/commands/channel/config-utils.test.ts
+++ b/packages/cli/src/commands/channel/config-utils.test.ts
@@ -176,7 +176,7 @@ describe('parseChannelConfig', () => {
       type: 'bare',
       cwd: '~',
     });
-    expect(result.cwd).toBe(os.homedir());
+    expect(result.cwd).toBe(path.normalize(os.homedir()));
   });
 
   it('resolves relative cwd against process.cwd', async () => {

--- a/packages/core/src/config/storage.test.ts
+++ b/packages/core/src/config/storage.test.ts
@@ -190,7 +190,7 @@ describe('Storage – getRuntimeBaseDir / setRuntimeBaseDir', () => {
 
   it('handles bare tilde (~) as home directory', () => {
     Storage.setRuntimeBaseDir('~');
-    expect(Storage.getRuntimeBaseDir()).toBe(os.homedir());
+    expect(Storage.getRuntimeBaseDir()).toBe(path.normalize(os.homedir()));
   });
 });
 
@@ -578,7 +578,7 @@ describe('Storage – QWEN_HOME env var', () => {
 
   it('handles bare tilde (~) as home directory in QWEN_HOME', () => {
     process.env['QWEN_HOME'] = '~';
-    expect(Storage.getGlobalQwenDir()).toBe(os.homedir());
+    expect(Storage.getGlobalQwenDir()).toBe(path.normalize(os.homedir()));
   });
 
   it('QWEN_HOME and QWEN_RUNTIME_DIR are independent', () => {

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -68,12 +68,18 @@ const UNESCAPE_REGEX = (() => {
  * @returns The tildeified path.
  */
 export function tildeifyPath(filePath: string): string {
-  const homeDir = os.homedir();
-  if (filePath === homeDir) {
+  const rawHomeDir = os.homedir();
+  if (!rawHomeDir) {
+    return filePath;
+  }
+
+  const homeDir = path.normalize(rawHomeDir);
+  const normalizedPath = path.normalize(filePath);
+  if (normalizedPath === homeDir) {
     return '~';
   }
-  if (filePath.startsWith(`${homeDir}${path.sep}`)) {
-    return filePath.replace(homeDir, '~');
+  if (normalizedPath.startsWith(`${homeDir}${path.sep}`)) {
+    return normalizedPath.replace(homeDir, '~');
   }
   return filePath;
 }


### PR DESCRIPTION
## What this PR does

Creates the isolated test home directory before the unit-test step runs on Ubuntu, macOS, and Windows, using Node so Windows drive-letter paths are handled by the platform runtime instead of by bash path conversion.

It also makes home-relative path comparisons tolerant of normalized path separators, so a home value such as a Windows runner temp path is treated consistently when paths are expanded or shortened.

## Why it's needed

A Windows CI run after the isolated test-home change started failing because the workflow pointed HOME and USERPROFILE at `${{ runner.temp }}/qwen-ci-home` without creating that directory first. On Windows this surfaced as filesystem lookups against `D:\a\_temp\qwen-ci-home` returning ENOENT during serve route tests.

The same change also exposed mixed-separator comparisons on Windows: the runner-provided home path and path-normalized results could describe the same directory but compare as different strings. That made bare `~` expectations fail even though the resolved directory was correct.

## Reviewer Test Plan

### How to verify

Re-run the Windows test job that previously failed on the isolated home path. The unit-test step should create its temporary home before starting tests, and the previous ENOENT and mixed-separator `~` failures should not recur.

For local verification, run the CI-equivalent test command with `CI=true`, an empty temporary HOME/USERPROFILE, and empty auth keys. Expected result: all workspaces, script tests, and the serve fast-path bundle check pass.

### Evidence (Before & After)

Before: Windows CI failed after HOME/USERPROFILE were redirected to the runner temp path; the directory did not exist and Windows path separator differences made equivalent home paths compare unequal.

After: local CI-equivalent verification passed with an isolated temporary home created before the test command.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not locally tested; covered by PR CI |
|  🐧 Linux  | ⚠️ not locally tested; covered by PR CI |

### Environment (optional)

macOS local worktree, Node 22/npm workspace install. Verification included `CI=true`, isolated HOME/USERPROFILE, `NO_COLOR=true`, and empty OpenAI/DashScope/Qwen/Gemini auth environment variables.

## Risk & Scope

- Main risk or tradeoff: The workflow now relies on Node for the directory creation immediately before tests; this step already runs after Node setup and dependency installation.
- Not validated / out of scope: I did not restart or change any self-hosted ECS runner state in this PR. This addresses the Windows/macOS/Linux test-home failure path, not the earlier merge-queue runner hang.
- Breaking changes / migration notes: None.

## Linked Issues

Related to the failing Windows CI run: https://github.com/QwenLM/qwen-code/actions/runs/28438297891/job/84269583175

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 Ubuntu、macOS、Windows 的单元测试步骤开始前，先创建隔离的测试 home 目录。这里使用 Node 创建目录，让 Windows drive-letter 路径交给平台运行时处理，避免 bash 对 Windows 路径做不可靠转换。

同时让 home 相关路径比较先做路径规范化，这样 Windows runner 临时目录这种混合 `/` 和 `\` 的路径在展开或缩写时会被当作同一个目录处理。

## 为什么需要

隔离测试 home 的改动合入后，Windows CI 把 HOME 和 USERPROFILE 指到了 `${{ runner.temp }}/qwen-ci-home`，但 workflow 没有提前创建这个目录。Windows 上因此出现对 `D:\a\_temp\qwen-ci-home` 的文件系统访问 ENOENT，导致 serve 路由相关测试失败。

同一次问题还暴露出 Windows 混合路径分隔符比较不稳定：runner 提供的 home 路径和规范化后的结果实际指向同一个目录，但字符串比较不同，导致 bare `~` 相关断言失败。

## Reviewer Test Plan

### How to verify

重新运行之前失败的 Windows test job。单元测试步骤应该会先创建临时 home，再启动测试；之前的 ENOENT 和 `~` 混合分隔符失败不应该再出现。

本地验证方式是使用 `CI=true`、空的临时 HOME/USERPROFILE、空认证 key 运行 CI 等价测试命令。期望结果是所有 workspace、脚本测试以及 serve fast-path bundle 检查通过。

### Evidence (Before & After)

Before：HOME/USERPROFILE 被切到 runner temp 路径后，Windows CI 因目录不存在失败；同时 Windows 路径分隔符差异让等价 home 路径比较失败。

After：本地用隔离临时 home 跑 CI 等价验证已通过，并且测试命令开始前会先创建该目录。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ 本地未测，交给 PR CI 覆盖 |
|  🐧 Linux  | ⚠️ 本地未测，交给 PR CI 覆盖 |

### Environment (optional)

macOS 本地 worktree，Node 22/npm workspace install。验证包含 `CI=true`、隔离 HOME/USERPROFILE、`NO_COLOR=true`，以及空 OpenAI/DashScope/Qwen/Gemini 认证环境变量。

## Risk & Scope

- Main risk or tradeoff：workflow 现在在测试前用 Node 创建目录；这个步骤本来就在 Node setup 和依赖安装之后运行。
- Not validated / out of scope：这个 PR 没有重启或修改任何 ECS self-hosted runner。它解决的是 Windows/macOS/Linux test-home 失败路径，不处理之前 merge queue runner 卡住的问题。
- Breaking changes / migration notes：无。

## Linked Issues

相关 Windows CI 失败 run：https://github.com/QwenLM/qwen-code/actions/runs/28438297891/job/84269583175

</details>
