### PR TITLE
feat(web-shell): add browser tab favicon

### DIFF
--- a/packages/web-shell/client/index.html
+++ b/packages/web-shell/client/index.html
@@ -4,6 +4,22 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Qwen Code Web chat</title>
+    <!--
+      Favicon is inlined as a data: URI rather than a /favicon.svg file because
+      the daemon's static server only exposes /assets/* and / (see
+      packages/cli/src/serve/web-shell-static.ts) — a file at the dist root
+      would never be reachable. The data: URI is allowed by the shell CSP
+      (img-src 'self' data: blob:). The encodeURIComponent(svg) encoding
+      technique mirrors packages/web-templates/src/export-html/build.mjs;
+      the artwork is from packages/desktop/apps/webui/src/public/favicon.svg
+      (the purple #6D44E8 Qwen mark, legible on both light and dark browser
+      tab bars).
+    -->
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%20141.38%20140%22%3E%0A%20%20%3Cpath%0A%20%20%20%20fill%3D%22%236D44E8%22%0A%20%20%20%20d%3D%22m140.93%2085-16.35-28.33-1.93-3.34%208.66-15a3.323%203.323%200%200%200%200-3.34l-9.62-16.67c-.3-.51-.72-.93-1.22-1.22s-1.07-.45-1.67-.45H82.23l-8.66-15a3.33%203.33%200%200%200-2.89-1.67H51.43c-.59%200-1.17.16-1.66.45-.5.29-.92.71-1.22%201.22L32.19%2029.98l-1.92%203.33H12.96c-.59%200-1.17.16-1.66.45-.5.29-.93.71-1.22%201.22L.45%2051.66a3.323%203.323%200%200%200%200%203.34l18.28%2031.67-8.66%2015a3.32%203.32%200%200%200%200%203.34l9.62%2016.67c.3.51.72.93%201.22%201.22s1.07.45%201.67.45h36.56l8.66%2015a3.35%203.35%200%200%200%202.89%201.67h19.25a3.34%203.34%200%200%200%202.89-1.67l18.28-31.67h17.32c.6%200%201.17-.16%201.67-.45s.92-.71%201.22-1.22l9.62-16.67a3.323%203.323%200%200%200%200-3.34ZM51.44%203.33%2061.07%2020l-9.63%2016.66h76.98l-9.62%2016.66H45.67l-11.54-20zM57.21%20120H22.58l9.63-16.67h19.25l-38.5-66.67h19.25l9.62%2016.67L68.78%20100l-11.55%2020Zm61.59-33.34-9.62-16.67-38.49%2066.67-9.63-16.67%209.63-16.66%2026.94-46.67h23.1l17.32%2030z%22%0A%20%20%2F%3E%0A%3C%2Fsvg%3E"
+    />
   </head>
   <body>
     <!--


### PR DESCRIPTION
## What this PR does

Adds a browser-tab favicon to the Web Shell. The HTML shell (`packages/web-shell/client/index.html`) previously had a `<title>` but no `<link rel="icon">`, so the daemon-served Web Shell tab fell back to the browser's generic page glyph. This inlines the Qwen mark as a `data:` URI so the tab now shows the brand icon.

The icon is inlined rather than shipped as a `/favicon.svg` file on purpose: the daemon's static server (`packages/cli/src/serve/web-shell-static.ts`) only exposes `GET /assets/*` and `GET /`, so a file at the dist root would never be reachable without also adding a new served route. The encoding (`encodeURIComponent(svg)`) and artwork match the existing `packages/web-templates/src/export-html` favicon, and the `data:` URI is already permitted by the shell's CSP (`img-src 'self' data:`). The `#6D44E8` purple brand fill stays legible on both light and dark browser tab bars.

## Why it's needed

A missing favicon makes the Web Shell tab look unfinished and hard to pick out among many open tabs, and because there is no icon link the browser fires a default `GET /favicon.ico` probe that the daemon can only answer with a 404 (that path matches neither `/assets/*` nor the exact `/` route). The repo already carries this exact Qwen mark as the favicon for the desktop webui and the HTML export, so this just brings the Web Shell in line with the rest of the product at near-zero cost.

## Reviewer Test Plan

### How to verify

1. `cd packages/web-shell && npx vite build` — the build succeeds and the inlined `<link rel="icon">` is copied verbatim into `dist/index.html` (Vite leaves `data:` URIs untouched).
2. Decode the `href` and confirm it is the brand mark byte-for-byte:
   ```
   node -e 'const fs=require("fs");const h=fs.readFileSync("packages/web-shell/client/index.html","utf8");const u=h.match(/href="(data:image\/svg\+xml,[^"]*)"/)[1];const d=decodeURIComponent(u.replace(/^data:image\/svg\+xml,/,""));const o=fs.readFileSync("packages/desktop/apps/webui/src/public/favicon.svg","utf8").trim();console.log("round-trips to brand SVG:", d===o)'
   # -> round-trips to brand SVG: true
   ```
3. Run the Web Shell suite: `npx vitest run` → 540/540 pass (incl. `index.test.tsx`).
4. End-to-end: `qwen serve --web`, open the printed URL, and confirm the browser tab shows the purple Qwen mark instead of the generic page glyph.

### Evidence (Before & After)

A browser-tab favicon lives in browser **chrome**, not the page viewport, so it cannot be captured by a headless/terminal screenshot. The verifiable artifact evidence:

**Before** — no icon link in `index.html`:
```html
<title>Qwen Code Web chat</title>
</head>
```
Browser shows the generic page glyph; the default `GET /favicon.ico` probe has no daemon route and 404s.

**After** — inline `data:` URI favicon in the built `dist/index.html`:
```html
<title>Qwen Code Web chat</title>
<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20...fill%3D%22%236D44E8%22...%3C%2Fsvg%3E" />
```
Decodes byte-for-byte to the shipping Qwen mark (`packages/desktop/apps/webui/src/public/favicon.svg`); no extra request, CSP-permitted, no more `/favicon.ico` probe.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

Change is a platform-independent static HTML string served by the same Express handler on every OS, so the macOS verification generalizes; Windows/Linux not run locally.

### Environment (optional)

`npx vite build` + `npx vitest run` in `packages/web-shell` on macOS (Node from the repo toolchain).

## Risk & Scope

- Main risk or tradeoff: none of consequence — adds one static `<link>` to the HTML shell. The ~1.2 KB inline `data:` URI is the same trade-off the HTML export already makes.
- Not validated / out of scope: no real-browser tab screenshot (favicon renders in browser chrome, not capturable headlessly); no change to the daemon static routes or CSP (the `data:` URI already fits `img-src 'self' data:`).
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

给 Web Shell 加上浏览器标签页图标（favicon）。HTML 外壳（`packages/web-shell/client/index.html`）此前只有 `<title>`、没有 `<link rel="icon">`，所以 daemon 提供的 Web Shell 标签页只能显示浏览器默认的通用页面图标。这里把 Qwen logo 以 `data:` URI 内联进去，标签页现在会显示品牌图标。

之所以内联而不是放一个 `/favicon.svg` 文件：daemon 的静态服务器（`packages/cli/src/serve/web-shell-static.ts`）只暴露 `GET /assets/*` 和 `GET /`，放在 dist 根目录的文件不额外加路由根本访问不到。编码方式（`encodeURIComponent(svg)`）和图案与现有的 `packages/web-templates/src/export-html` favicon 一致，而 `data:` URI 已被外壳的 CSP（`img-src 'self' data:`）放行。紫色 `#6D44E8` 品牌填充色在浅色和深色标签栏上都清晰可辨。

## 为什么需要

缺少 favicon 会让 Web Shell 标签页显得没做完，多标签时也不好辨认；而且因为没有 icon link，浏览器会自动发一个默认的 `GET /favicon.ico` 探测请求，daemon 只能回 404（该路径既不匹配 `/assets/*` 也不匹配精确的 `/`）。仓库里 desktop webui 和 HTML 导出已经在用这枚 Qwen logo 作 favicon，这个改动只是让 Web Shell 与产品其余部分对齐，成本几乎为零。

## 评审验证计划

### 如何验证

1. `cd packages/web-shell && npx vite build` —— 构建成功，内联的 `<link rel="icon">` 会被原样拷进 `dist/index.html`（Vite 不会改写 `data:` URI）。
2. 解码 `href`，确认与品牌图标逐字节一致（命令见上方英文）→ 输出 `round-trips to brand SVG: true`。
3. 跑 Web Shell 测试：`npx vitest run` → 540/540 通过（含 `index.test.tsx`）。
4. 端到端：`qwen serve --web`，打开打印出的 URL，确认浏览器标签显示紫色 Qwen logo 而非通用图标。

### 证据（前后对比）

标签页 favicon 显示在浏览器**外框（chrome）**里、不在页面视口内，无法用无头/终端截图捕获。可核验的产物证据：

**Before**：`index.html` 无 icon link，浏览器显示通用图标，默认 `GET /favicon.ico` 探测无路由 → 404。
**After**：构建后的 `dist/index.html` 含内联 `data:` URI favicon，解码后与仓库现有 Qwen logo（`packages/desktop/apps/webui/src/public/favicon.svg`）逐字节一致；不产生额外请求，CSP 已放行，也不再有 `/favicon.ico` 探测。

### 测试平台

仅在 macOS 本地跑了 `vite build` + `vitest`。改动是各平台一致、由同一个 Express handler 以字符串形式返回的静态 HTML，因此 macOS 的验证可推广；Windows/Linux 未本地运行。

## 风险与范围

- 主要风险/取舍：基本没有 —— 只是往 HTML 外壳加一个静态 `<link>`。约 1.2 KB 的内联 `data:` URI 与 HTML 导出已有的取舍相同。
- 未验证/范围外：没有真实浏览器标签截图（favicon 渲染在浏览器外框、无头无法截）；未改 daemon 静态路由或 CSP（`data:` URI 已符合 `img-src 'self' data:`）。
- 破坏性改动/迁移说明：无。

## 关联 Issue

无。

</details>

<img width="618" height="70" alt="image" src="https://github.com/user-attachments/assets/8b7c74e7-c01d-4be7-ab82-ba47b3a7ca15" />
