### PR TITLE
ci: stabilize actionlint on self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,14 +128,15 @@ jobs:
       # instant the branch is pushed) instead of github.ref. github.ref is the
       # merge ref (refs/pull/N/merge), which GitHub rebuilds asynchronously and
       # can serve stale for minutes after a push, repeatedly flaking this gate.
-      # The merge queue (integration_cli on merge_group) validates the merged
-      # result. Non-PR events keep github.ref.
+      # Merge queue refs are ephemeral; check out the event head SHA directly so
+      # slow hosted runners do not fail after the queue branch is removed.
+      # Non-PR/non-queue events keep github.ref.
       - name: 'Checkout'
         id: 'checkout'
         if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
         uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
         with:
-          ref: "${{ github.event.inputs.branch_ref || (github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number)) || github.ref }}"
+          ref: "${{ github.event.inputs.branch_ref || (github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number)) || (github.event_name == 'merge_group' && github.event.merge_group.head_sha) || github.ref }}"
           # Shallow: nothing here walks git history (the verify guard below checks
           # head.sha == HEAD, schema/tests touch only the working tree). On the
           # in-repo ECS runner a full-history clone is the heaviest transfer and
@@ -318,14 +319,14 @@ jobs:
     permissions:
       contents: 'read'
     steps:
-      # See the Ubuntu gate's checkout: on PRs use the immutable refs/pull/N/head
-      # to avoid merge-ref rebuild lag; other events keep github.ref.
+      # See the Ubuntu gate's checkout: PRs use the immutable refs/pull/N/head
+      # and merge queue uses the event head SHA.
       - name: 'Checkout'
         id: 'checkout'
         if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
         uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
         with:
-          ref: "${{ github.event.inputs.branch_ref || (github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number)) || github.ref }}"
+          ref: "${{ github.event.inputs.branch_ref || (github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number)) || (github.event_name == 'merge_group' && github.event.merge_group.head_sha) || github.ref }}"
 
       - name: 'Set up Node.js 22.x'
         if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
@@ -380,7 +381,7 @@ jobs:
         if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
         uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
         with:
-          ref: "${{ github.event.inputs.branch_ref || (github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number)) || github.ref }}"
+          ref: "${{ github.event.inputs.branch_ref || (github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number)) || (github.event_name == 'merge_group' && github.event.merge_group.head_sha) || github.ref }}"
 
       - name: 'Set up Node.js 22.x'
         if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
@@ -495,6 +496,7 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
         with:
+          ref: "${{ github.event.inputs.branch_ref || (github.event_name == 'merge_group' && github.event.merge_group.head_sha) || github.ref }}"
           # Shallow, mirroring the Ubuntu gate: nothing here walks git history,
           # and a full-history clone is the heaviest transfer on the ECS runner.
           fetch-depth: 1

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -7,6 +7,7 @@
  */
 
 import { execSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -15,7 +16,37 @@ const ACTIONLINT_VERSION = '1.7.12';
 const SHELLCHECK_VERSION = '0.11.0';
 const YAMLLINT_VERSION = '1.35.1';
 
-const TEMP_DIR = join(tmpdir(), 'qwen-code-linters');
+function sanitizePathPart(value) {
+  return value.replace(/[^A-Za-z0-9._-]/g, '_');
+}
+
+export function getLinterTempDir({
+  cwd = process.cwd(),
+  env = process.env,
+} = {}) {
+  const baseDir = env.RUNNER_TEMP || tmpdir();
+  const runId = env.GITHUB_RUN_ID;
+
+  if (runId) {
+    return join(
+      baseDir,
+      'qwen-code-linters',
+      [
+        sanitizePathPart(runId),
+        sanitizePathPart(env.GITHUB_RUN_ATTEMPT || '1'),
+        sanitizePathPart(env.GITHUB_JOB || 'job'),
+      ].join('-'),
+    );
+  }
+
+  const workspaceHash = createHash('sha256')
+    .update(cwd)
+    .digest('hex')
+    .slice(0, 16);
+  return join(baseDir, 'qwen-code-linters', `local-${workspaceHash}`);
+}
+
+const TEMP_DIR = getLinterTempDir();
 
 function getPlatformArch() {
   const platform = process.platform;
@@ -65,6 +96,7 @@ const LINTERS = {
     run: `
       actionlint \
         -color \
+        -shellcheck= \
         -ignore 'SC2002:' \
         -ignore 'SC2016:' \
         -ignore 'SC2129:' \

--- a/scripts/tests/lint.test.js
+++ b/scripts/tests/lint.test.js
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+describe('getLinterTempDir', () => {
+  const originalArgv = process.argv;
+
+  beforeEach(() => {
+    process.argv = ['node', 'scripts/lint.js', '--test-import'];
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+  });
+
+  it('isolates GitHub Actions linter installs by run and job', async () => {
+    const { getLinterTempDir } = await import('../lint.js');
+
+    const first = getLinterTempDir({
+      cwd: '/runner/_work/qwen-code/qwen-code',
+      env: {
+        RUNNER_TEMP: '/runner/_work/_temp',
+        GITHUB_RUN_ID: '28501834362',
+        GITHUB_RUN_ATTEMPT: '1',
+        GITHUB_JOB: 'test',
+      },
+    });
+    const second = getLinterTempDir({
+      cwd: '/runner/_work/qwen-code/qwen-code',
+      env: {
+        RUNNER_TEMP: '/runner/_work/_temp',
+        GITHUB_RUN_ID: '28501834363',
+        GITHUB_RUN_ATTEMPT: '1',
+        GITHUB_JOB: 'integration_cli',
+      },
+    });
+
+    expect(first).toBe(
+      '/runner/_work/_temp/qwen-code-linters/28501834362-1-test',
+    );
+    expect(second).toBe(
+      '/runner/_work/_temp/qwen-code-linters/28501834363-1-integration_cli',
+    );
+    expect(first).not.toBe(second);
+  });
+
+  it('isolates local linter installs by workspace', async () => {
+    const { getLinterTempDir } = await import('../lint.js');
+
+    const first = getLinterTempDir({
+      cwd: '/tmp/qwen-code-a',
+      env: {},
+    });
+    const second = getLinterTempDir({
+      cwd: '/tmp/qwen-code-b',
+      env: {},
+    });
+
+    expect(first).toMatch(/\/qwen-code-linters\/local-[a-f0-9]{16}$/);
+    expect(second).toMatch(/\/qwen-code-linters\/local-[a-f0-9]{16}$/);
+    expect(first).not.toBe(second);
+  });
+});


### PR DESCRIPTION
## What this PR does

This hardens the CI lint path for self-hosted Linux runners. It gives downloaded linter binaries a run/job-scoped temp directory, runs actionlint without its embedded shellcheck integration, keeps the standalone shellcheck step in place, and checks out merge queue jobs by the event head SHA instead of the ephemeral queue branch name.

## Why it's needed

The merge queue has shown multiple CI failures that are runner- or workflow-infrastructure related rather than product test failures. In run `28501834362`, Ubuntu job `84480980355` ran on `ecs-qwen-runner-sg-17`; `Install linters` completed, then `Run actionlint` started at `2026-07-01T07:52:06Z` and hit the 5-minute step timeout. Earlier ECS jobs also showed `actionlint: not found` after `node scripts/lint.js --setup`, which is consistent with several self-hosted runner processes on the same machine sharing and deleting the same `/tmp/qwen-code-linters` directory. Separately, previous merge queue hosted jobs failed checkout with `fatal: couldn't find remote ref refs/heads/gh-readonly-queue/...` after the temporary queue branch disappeared before the runner fetched it.

## Reviewer Test Plan

### How to verify

Confirm the same-repo PR Ubuntu job reaches `Run actionlint` on an ECS runner and finishes that step without timing out. Confirm merge queue checkout logs fetch the merge group head SHA instead of relying on the `gh-readonly-queue/...` branch name. Confirm the separate `Run shellcheck` step still runs after actionlint.

### Evidence (Before & After)

Before: Ubuntu job `84480980355` on `ecs-qwen-runner-sg-17` timed out in `Run actionlint` after 5 minutes; previous ECS job `84317405985` failed with `actionlint: not found` after linter setup; previous hosted merge queue checkout failed with `fatal: couldn't find remote ref refs/heads/gh-readonly-queue/...`.

After: local checks pass for the linter temp directory regression test, formatting, ESLint on the touched script files, and actionlint with the updated flags. Full `scripts/tests` was also attempted, but this fresh worktree has no built `packages/audio-capture/dist`, so an unrelated standalone packaging test failed before a build.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS local worktree, Node.js `v22.23.0`.

## Risk & Scope

- Main risk or tradeoff: actionlint no longer invokes its embedded shellcheck pass for inline workflow `run:` blocks; this avoids the ECS hang path while keeping workflow syntax/expression validation and the dedicated shellcheck step.
- Not validated / out of scope: this PR does not fix the known Windows loop test failures; those are covered by PR #6082 and still fail in merge queue runs that do not include that PR.
- Breaking changes / migration notes: N/A.

## Linked Issues

Related CI evidence: run `28501834362`, job `84480980355`; run `28452226868`, job `84317405985`.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 加固 self-hosted Linux runner 上的 CI lint 路径。下载的 linter 二进制现在会放到按 run/job 隔离的临时目录；actionlint 不再启用内嵌 shellcheck 集成，但独立的 shellcheck 步骤仍保留；merge queue checkout 改为使用事件里的 head SHA，而不是临时的队列分支名。

## 为什么需要

merge queue 最近出现了多次 CI 基建类失败，不是产品测试本身失败。在 run `28501834362` 里，Ubuntu job `84480980355` 跑在 `ecs-qwen-runner-sg-17`；`Install linters` 已完成，但 `Run actionlint` 从 `2026-07-01T07:52:06Z` 开始后触发了 5 分钟单步超时。更早的 ECS job 还出现过 `node scripts/lint.js --setup` 后 `actionlint: not found`，这和同一台机器上多个 self-hosted runner 共用并删除同一个 `/tmp/qwen-code-linters` 目录相符。另一个独立问题是，之前 hosted merge queue job 在 checkout 时遇到 `fatal: couldn't find remote ref refs/heads/gh-readonly-queue/...`，原因是 runner 拉取前临时队列分支已经消失。

## Reviewer Test Plan

### 如何验证

确认同仓 PR 的 Ubuntu job 会跑到 ECS runner，并且 `Run actionlint` 不再超时。确认 merge queue checkout 日志使用 merge group head SHA，而不是依赖 `gh-readonly-queue/...` 分支名。确认独立的 `Run shellcheck` 步骤仍会在 actionlint 后运行。

### 证据（Before & After）

Before：Ubuntu job `84480980355` 在 `ecs-qwen-runner-sg-17` 上的 `Run actionlint` 5 分钟超时；更早的 ECS job `84317405985` 在 linter setup 后失败为 `actionlint: not found`；之前 hosted merge queue checkout 失败为 `fatal: couldn't find remote ref refs/heads/gh-readonly-queue/...`。

After：本地已通过 linter 临时目录回归测试、格式检查、针对改动脚本的 ESLint，以及带新参数的 actionlint。也尝试跑了完整 `scripts/tests`，但这个新 worktree 没有构建出的 `packages/audio-capture/dist`，因此一个无关的 standalone packaging 测试在 build 产物缺失处失败。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境

macOS 本地 worktree，Node.js `v22.23.0`。

## 风险和范围

- 主要风险或取舍：actionlint 不再对 workflow 里的 inline `run:` block 启用内嵌 shellcheck；这样可以绕开 ECS hang 路径，同时保留 workflow 语法/表达式检查和独立 shellcheck 步骤。
- 未验证/不在范围：这个 PR 不修复已知 Windows loop 测试失败；那部分由 PR #6082 覆盖，不包含 #6082 的 merge queue run 仍会失败。
- Breaking changes / migration notes：N/A。

## 关联

相关 CI 证据：run `28501834362` / job `84480980355`；run `28452226868` / job `84317405985`。

</details>
