### PR TITLE
test(core): fix MCP idle timeout config stubs

### DIFF
--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -54,6 +54,7 @@ const mockDebugLogger = vi.hoisted(() => ({
   warn: vi.fn(),
 }));
 const ORIGINAL_ENV = process.env;
+const TEST_MCP_TOOL_IDLE_TIMEOUT_MS = 300000;
 
 vi.mock('node:fs', () => ({
   existsSync: mockExistsSync,
@@ -76,6 +77,7 @@ vi.mock('../utils/debugLogger.js', () => ({
  */
 function cfgWithResources(): Config {
   return {
+    getMcpToolIdleTimeoutMs: () => TEST_MCP_TOOL_IDLE_TIMEOUT_MS,
     getResourceRegistry: () => ({
       registerResource: vi.fn(),
       removeResourcesByServer: vi.fn(),
@@ -1277,6 +1279,7 @@ describe('mcp-client', () => {
       const registerResource = vi.fn();
       const removeResourcesByServer = vi.fn();
       const cfg = {
+        getMcpToolIdleTimeoutMs: () => TEST_MCP_TOOL_IDLE_TIMEOUT_MS,
         getResourceRegistry: () => ({
           registerResource,
           removeResourcesByServer,
@@ -1330,6 +1333,7 @@ describe('mcp-client', () => {
       const registerResource = vi.fn();
       const removeResourcesByServer = vi.fn();
       const cfg = {
+        getMcpToolIdleTimeoutMs: () => TEST_MCP_TOOL_IDLE_TIMEOUT_MS,
         getResourceRegistry: () => ({
           registerResource,
           removeResourcesByServer,

--- a/packages/core/src/tools/mcp-transport-pool.test.ts
+++ b/packages/core/src/tools/mcp-transport-pool.test.ts
@@ -149,7 +149,9 @@ function mockMcpSuccess(
 }
 
 describe('McpTransportPool', () => {
-  const cliConfig = {} as Config;
+  const cliConfig = {
+    getMcpToolIdleTimeoutMs: () => 300000,
+  } as Config;
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -471,9 +473,8 @@ describe('McpTransportPool', () => {
       // synchronously when localStatus flips to DISCONNECTED on an
       // active entry (gated by !restartInProgress so intentional
       // restart-mid-disconnect doesn't trip it).
-      const { updateMCPServerStatus, MCPServerStatus } = await import(
-        './mcp-client.js'
-      );
+      const { updateMCPServerStatus, MCPServerStatus } =
+        await import('./mcp-client.js');
       mockMcpSuccess({ toolNames: ['t1'] });
       const pool = new McpTransportPool(cliConfig, mkPoolOptions());
       const cfg = new MCPServerConfig('node');
@@ -545,9 +546,8 @@ describe('McpTransportPool', () => {
       // snapshot — same zombie-attach failure, shifted into drain.
       // Post-W131 the gate extends to ('active' || 'draining') and
       // cancels the drain timer in the same step.
-      const { updateMCPServerStatus, MCPServerStatus } = await import(
-        './mcp-client.js'
-      );
+      const { updateMCPServerStatus, MCPServerStatus } =
+        await import('./mcp-client.js');
       mockMcpSuccess({ toolNames: ['t1'] });
       const pool = new McpTransportPool(
         cliConfig,
@@ -895,9 +895,8 @@ describe('McpTransportPool', () => {
       // `getLastTransportError()` returns undefined → caller falls back
       // to the synthetic-only string. This test pins the behavior
       // existing W120/W131 tests relied on pre-fix.
-      const { updateMCPServerStatus, MCPServerStatus } = await import(
-        './mcp-client.js'
-      );
+      const { updateMCPServerStatus, MCPServerStatus } =
+        await import('./mcp-client.js');
       mockMcpSuccess({ toolNames: ['t1'] });
       const pool = new McpTransportPool(cliConfig, mkPoolOptions());
       const cfg = new MCPServerConfig('node');
@@ -1014,9 +1013,8 @@ describe('McpTransportPool', () => {
       // silent-drop chain compares descendantsSignaled vs
       // descendantsFound and emits the same outer warn even though
       // sweepAndDisconnect itself didn't throw.
-      const { listDescendantPids, sigtermPids } = await import(
-        './pid-descendants.js'
-      );
+      const { listDescendantPids, sigtermPids } =
+        await import('./pid-descendants.js');
       const { createDebugLogger } = await import('../utils/debugLogger.js');
       const debugMock = createDebugLogger('McpPool:Entry');
       // The stub is a singleton across tests; clear prior call history


### PR DESCRIPTION
## What this PR does

Updates the MCP discovery test fixtures so they expose the idle-timeout configuration accessor added by the MCP tool idle-timeout work.

## Why it is needed

The release quality check was failing because the mocked configuration objects used by MCP discovery tests no longer matched the production configuration surface. Tool discovery swallowed the resulting fixture error, returned an empty discovery snapshot, and caused the workspace tests to fail with \"No prompts, tools, or resources found on the server.\"

## Reviewer Test Plan

### How to verify

- Run the MCP discovery and transport-pool unit tests and confirm they pass.

### Evidence (Before & After)

Before: `npx vitest run src/tools/mcp-client.test.ts` failed with 8 MCP discovery failures, including `No prompts, tools, or resources found on the server.`

After: `npx vitest run src/tools/mcp-client.test.ts src/tools/mcp-transport-pool.test.ts` passes with 124 tests.

Additional local checks:

- `npx prettier --check packages/core/src/tools/mcp-client.test.ts packages/core/src/tools/mcp-transport-pool.test.ts` passed.
- `npm run test:ci --workspace=packages/core` still fails locally in unrelated existing areas (`agent-headless`, memory lifecycle, module mock/resolve failures), while the two MCP files touched here pass inside that run.
- `NODE_OPTIONS="--max-old-space-size=8192" npm run typecheck --workspace=packages/core` still fails locally in unrelated existing files (`ide-client`, session service tests, client MCP registrar, and others).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS shell, package-level Vitest and TypeScript checks.

## Risk & Scope

- Main risk or tradeoff: Low; this only keeps test fixtures aligned with the production configuration API.
- Not validated / out of scope: Unrelated local failures in the full core test suite and package typecheck were not fixed here.
- Breaking changes / migration notes: None.

## Linked Issues

Related to #6061.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

更新 MCP discovery 相关测试 fixture，让它们提供 MCP tool idle-timeout 改动新增的配置访问器。

## 为什么需要

Release 的 Quality Checks 失败，是因为 MCP discovery 测试里 mock 的配置对象没有跟上生产配置接口变化。工具发现过程吞掉了 fixture 抛出的错误，返回空 discovery snapshot，最终让 workspace tests 报 `No prompts, tools, or resources found on the server.`

## Reviewer Test Plan

### 如何验证

- 运行 MCP discovery 和 transport-pool 单测，确认通过。

### 前后证据

Before：`npx vitest run src/tools/mcp-client.test.ts` 会出现 8 个 MCP discovery 失败，包括 `No prompts, tools, or resources found on the server.`

After：`npx vitest run src/tools/mcp-client.test.ts src/tools/mcp-transport-pool.test.ts` 通过，共 124 个测试。

额外本地检查：

- `npx prettier --check packages/core/src/tools/mcp-client.test.ts packages/core/src/tools/mcp-transport-pool.test.ts` 通过。
- `npm run test:ci --workspace=packages/core` 本地仍在 unrelated 既有区域失败（`agent-headless`、memory lifecycle、module mock/resolve failures），但本 PR 触及的两个 MCP 文件在该 run 中通过。
- `NODE_OPTIONS="--max-old-space-size=8192" npm run typecheck --workspace=packages/core` 本地仍在 unrelated 既有文件失败（`ide-client`、session service tests、client MCP registrar 等）。

## 风险和范围

- 主要风险或取舍：低；只同步测试 fixture 和生产配置 API。
- 未验证 / 范围外：full core test suite 和 package typecheck 的 unrelated 本地失败未在本 PR 修复。
- Breaking changes / 迁移说明：无。

</details>