### PR TITLE
ci: persist npm cache on self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,15 @@ jobs:
             echo "::warning::Expected Node 22.x but found $(node -v); tests will run against the runner's Node."
           fi
 
+      - name: 'Configure persistent npm cache (self-hosted)'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && runner.environment == 'self-hosted' }}"
+        run: |-
+          cache_dir="${HOME}/.cache/qwen-code/npm"
+          mkdir -p "${cache_dir}"
+          echo "NPM_CONFIG_CACHE=${cache_dir}" >> "${GITHUB_ENV}"
+          echo "Using persistent npm cache at ${cache_dir}"
+          du -sh "${cache_dir}" 2>/dev/null || true
+
       - name: 'Configure npm for rate limiting'
         if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
         run: |-
@@ -192,6 +201,13 @@ jobs:
         if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
         run: |-
           npm ci --prefer-offline --no-audit --progress=false
+
+      - name: 'Report npm cache usage (self-hosted)'
+        if: "${{ always() && needs.classify_pr.outputs.skip_ci != 'true' && runner.environment == 'self-hosted' }}"
+        run: |-
+          cache_dir="${NPM_CONFIG_CACHE:-$(npm config get cache)}"
+          echo "npm cache: ${cache_dir}"
+          du -sh "${cache_dir}" 2>/dev/null || true
 
       - name: 'Audit critical runtime dependencies'
         if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
@@ -536,11 +552,27 @@ jobs:
             echo "::warning::Expected Node 22.x but found $(node -v); integration tests will run against the runner's Node."
           fi
 
+      - name: 'Configure persistent npm cache (self-hosted)'
+        if: "${{ runner.environment == 'self-hosted' }}"
+        run: |-
+          cache_dir="${HOME}/.cache/qwen-code/npm"
+          mkdir -p "${cache_dir}"
+          echo "NPM_CONFIG_CACHE=${cache_dir}" >> "${GITHUB_ENV}"
+          echo "Using persistent npm cache at ${cache_dir}"
+          du -sh "${cache_dir}" 2>/dev/null || true
+
       - name: 'Install Dependencies'
         env:
           NPM_CONFIG_PREFER_OFFLINE: 'true'
         run: |-
           npm ci --no-audit --progress=false
+
+      - name: 'Report npm cache usage (self-hosted)'
+        if: "${{ always() && runner.environment == 'self-hosted' }}"
+        run: |-
+          cache_dir="${NPM_CONFIG_CACHE:-$(npm config get cache)}"
+          echo "npm cache: ${cache_dir}"
+          du -sh "${cache_dir}" 2>/dev/null || true
 
       - name: 'Run CLI Integration Tests'
         run: |-


### PR DESCRIPTION
## What this PR does

This PR makes the self-hosted Linux CI jobs use an explicit persistent npm cache directory under the runner user's home directory. The regular Ubuntu test job and the merge-queue CLI integration job now set `NPM_CONFIG_CACHE` to a stable path outside the workspace and `RUNNER_TEMP`, then print the cache size before and after dependency installation.

## Why it's needed

Hosted jobs already use `setup-node`'s npm cache, but the self-hosted ECS path only reused the machine's default npm behavior implicitly. Making the cache path explicit gives the runner a stable place to keep npm's content-addressed package cache across jobs while still letting `npm ci` rebuild `node_modules` from the current lockfile. The diagnostic output also makes it possible to confirm whether the runner cleanup policy is preserving or deleting that cache between runs.

## Reviewer Test Plan

### How to verify

Review the next self-hosted Linux CI logs and confirm the npm install path prints `Using persistent npm cache at .../.cache/qwen-code/npm` before install and `npm cache: .../.cache/qwen-code/npm` after install. On a subsequent run on a reused self-hosted runner, the pre-install cache size should be non-zero if the runner home directory is preserved. Dependency correctness still comes from `npm ci` and the committed lockfile integrity data; this PR does not cache `node_modules`.

### Evidence (Before & After)

N/A. This is a CI configuration change with local workflow validation only.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested locally; intended for self-hosted CI   |

### Environment (optional)

Validated locally with `node scripts/lint.js --setup`, `node scripts/lint.js --actionlint`, `node scripts/lint.js --yamllint`, and `npx prettier --check .github/workflows/ci.yml`.

## Risk & Scope

- Main risk or tradeoff: npm's package cache can grow on long-lived self-hosted runners and may need host-level retention cleanup if disk pressure appears.
- Not validated / out of scope: actual cache reuse on ECS is confirmed only by follow-up CI logs because it depends on the runner host cleanup policy.
- Breaking changes / migration notes: none; hosted runner caching is unchanged, and self-hosted jobs still run `npm ci` from the lockfile.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让 self-hosted Linux CI job 使用 runner 用户 home 目录下的显式持久 npm cache。常规 Ubuntu 测试 job 和 merge queue 的 CLI integration job 都会把 `NPM_CONFIG_CACHE` 设置到 workspace 和 `RUNNER_TEMP` 之外的稳定路径，并在依赖安装前后打印 cache 体积。

## Why it's needed

hosted job 已经通过 `setup-node` 使用 npm cache，但 self-hosted ECS 路径之前只隐式依赖机器默认 npm 行为。显式 cache 路径可以让 runner 在多次 job 之间稳定保留 npm 的 content-addressed package cache，同时仍然由 `npm ci` 根据当前 lockfile 重建 `node_modules`。诊断输出也能帮助确认 runner 的清理策略到底有没有保留这个 cache。

## Reviewer Test Plan

### How to verify

查看下一次 self-hosted Linux CI 日志，确认 npm install 前打印 `Using persistent npm cache at .../.cache/qwen-code/npm`，install 后打印 `npm cache: .../.cache/qwen-code/npm`。如果后续 run 复用了同一台 self-hosted runner 且 home 目录被保留，那么 install 前的 cache 体积应该不是空的。依赖正确性仍由 `npm ci` 和已提交 lockfile 里的 integrity 数据保证；这个 PR 不缓存 `node_modules`。

### Evidence (Before & After)

N/A。这是 CI 配置变更，本地只做 workflow 校验。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested locally; intended for self-hosted CI   |

### Environment (optional)

本地验证命令：`node scripts/lint.js --setup`、`node scripts/lint.js --actionlint`、`node scripts/lint.js --yamllint`、`npx prettier --check .github/workflows/ci.yml`。

## Risk & Scope

- Main risk or tradeoff: 长期运行的 self-hosted runner 上 npm package cache 可能增长；如果出现磁盘压力，需要宿主机层面的保留/清理策略。
- Not validated / out of scope: ECS 上是否真实跨 run 复用 cache 需要通过后续 CI 日志确认，因为这取决于 runner 宿主机的清理策略。
- Breaking changes / migration notes: 无；hosted runner cache 不变，self-hosted job 仍然通过 `npm ci` 从 lockfile 安装。

## Linked Issues

N/A

</details>
