### PR TITLE
docs: document the /config slash command

### DIFF
--- a/docs/users/features/commands.md
+++ b/docs/users/features/commands.md
@@ -326,6 +326,7 @@ Commands for obtaining information and performing system settings.
 | `/stats monthly` | Show monthly token usage statistics                                                                                            | `/stats monthly` (alias `month`), `/stats month [YYYY-MM]`                          |
 | `/stats export`  | Export usage statistics to CSV or JSON                                                                                         | `/stats export <daily\|monthly> [date\|month] [--format csv\|json] [--output path]` |
 | `/settings`      | Open settings editor                                                                                                           | `/settings`                                                                         |
+| `/config`        | Get or set any setting by dot-path key (writes to user settings)                                                              | `/config` (list all), `/config <key>`, `/config <key>=<value>`                      |
 | `/auth`          | Change authentication method                                                                                                   | `/auth`, `/connect`, `/login`                                                       |
 | `/doctor`        | Run installation and environment diagnostics                                                                                   | `/doctor`, `/doctor memory`                                                         |
 | → `memory`       | Show current process memory diagnostics                                                                                        | `/doctor memory [--json] [--sample] [--snapshot]`                                   |
@@ -342,6 +343,10 @@ Commands for obtaining information and performing system settings.
 > [!warning]
 >
 > `/doctor memory --snapshot` writes a V8 heap snapshot that may contain prompts, file contents, API keys, and tool results from the current session. Review the file before sharing it.
+
+> [!note]
+>
+> `/config` reads and writes individual settings by dot-path key (e.g. `general.vimMode`), complementing the interactive `/settings` editor. Running `/config` with no argument (or `--help`) lists every settable key with its type and current value. `/config <key>` prints the current value — except for boolean keys, where it toggles the value. `/config <key>=<value>` sets the value. Changes are written to user settings (`~/.qwen/settings.json`). Only `boolean`, `string`, `number`, and `enum` settings can be changed this way — `array` and `object` settings must be edited in `settings.json` directly. Sensitive values (API keys, tokens, base URLs) are masked in output, and setting `tools.approvalMode` to `yolo` is blocked.
 
 ### 1.10 Common Shortcuts
 


### PR DESCRIPTION
## What this PR does

Documents the `/config` slash command in the user-facing commands reference (`docs/users/features/commands.md`). It adds a row in the "Information, Settings, and Help" section next to `/settings`, plus a note explaining the command's behavior: listing all settable keys, getting a value (with boolean toggling), setting a value via `key=value`, the user-scope write target, the supported setting types, sensitive-value masking, and the `yolo` approval-mode block.

## Why it's needed

The `/config` command is registered as a built-in slash command (`packages/cli/src/services/BuiltinCommandLoader.ts`, implemented in `packages/cli/src/ui/commands/config-command.ts`) and appears in typeahead and `/help`, but it had no entry anywhere under `docs/`. Users had no documented way to discover that they can get or set individual settings by dot-path key from within a session — it was only reachable by stumbling onto it in the command list. This closes a command-documentation gap.

## Reviewer Test Plan

### How to verify

- Confirm the command exists and behaves as documented: `configCommand` in `packages/cli/src/services/BuiltinCommandLoader.ts` and its implementation in `packages/cli/src/ui/commands/config-command.ts` (description "Get or set any setting by dot-path key", user-scope writes, boolean toggle on bare `/config <key>`, `array`/`object` types rejected, sensitive-key masking, `tools.approvalMode=yolo` blocked).
- Render `docs/users/features/commands.md` and confirm the new `/config` table row in section 1.9 and the following note read correctly.
- Docs-only change; no code, tests, or navigation (`_meta.ts`) affected, and no doc pages were added/moved/removed, so the `qc-helper` doc index needs no update.

### Evidence (Before & After)

N/A (documentation-only change)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A

## Risk & Scope

- Main risk or tradeoff: None — documentation-only addition of an existing command.
- Not validated / out of scope: No behavioral changes; only `docs/users/features/commands.md` is touched.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 的作用

在面向用户的命令参考文档（`docs/users/features/commands.md`）中补充了 `/config` 斜杠命令的说明。在“Information, Settings, and Help”一节中于 `/settings` 旁新增一行，并附上一段说明，介绍该命令的行为：列出所有可设置的键、读取某个键的值（布尔类型会切换值）、通过 `key=value` 设置值、写入用户级配置、受支持的设置类型、敏感值的脱敏显示，以及对 `yolo` 审批模式的拦截。

## 为什么需要

`/config` 命令已作为内置斜杠命令注册（`packages/cli/src/services/BuiltinCommandLoader.ts`，实现见 `packages/cli/src/ui/commands/config-command.ts`），并出现在自动补全和 `/help` 中，但此前在 `docs/` 下没有任何文档条目。用户无从得知可以在会话中通过点分路径键读取或设置单个配置项。本 PR 修补了这一命令文档缺口。

## 复查测试计划

- 核对命令行为与文档一致：`BuiltinCommandLoader.ts` 中的 `configCommand` 及 `config-command.ts` 的实现（描述为 “Get or set any setting by dot-path key”，写入用户级配置，`/config <key>` 对布尔类型会切换值，`array`/`object` 类型被拒绝，敏感键脱敏，`tools.approvalMode=yolo` 被拦截）。
- 渲染 `docs/users/features/commands.md`，确认第 1.9 节新增的 `/config` 表格行及随后的说明正确显示。
- 仅文档变更；未涉及代码、测试或导航（`_meta.ts`），也未新增/移动/删除任何文档页面，因此 `qc-helper` 文档索引无需更新。

### 证据（前后对比）

N/A（仅文档变更）

</details>


---
_Generated by [Claude Code](https://claude.ai/code/session_01PuSCk1jj6dEDR3PvpaKaDj)_