### PR TITLE
fix(ci): grant PR review precheck permissions

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -63,6 +63,10 @@ jobs:
       github.event.pull_request.head.repo.full_name != github.repository &&
       (github.event.action != 'review_requested' ||
        github.event.requested_reviewer.login == 'qwen-code-ci-bot')
+    permissions:
+      contents: 'read'
+      pull-requests: 'read'
+      issues: 'write'
     uses: './.github/workflows/qwen-pr-safety-precheck.yml'
 
   ack-review-request:


### PR DESCRIPTION
## What this PR does

This PR grants the pull request review precheck job the token permissions its reusable safety workflow requests. The change is intentionally scoped to the precheck job only, so the rest of the review workflow keeps its existing permission boundaries.

## Why it's needed

Qwen Pull Request Review is currently triggering but failing before any jobs start. GitHub reports the reusable precheck workflow asks for `issues: write` and `pull-requests: read`, while the caller allows those scopes as `none`. As a result, automatic and comment-triggered review runs end with `startup_failure` instead of queueing the review.

## Reviewer Test Plan

### How to verify

Trigger the Qwen Pull Request Review workflow on a PR or rerun a recent failed review workflow run. The workflow should pass startup validation and create the precheck/authorization jobs instead of failing with the reusable workflow permission error.

### Evidence (Before & After)

Before: recent Qwen Pull Request Review runs failed at startup with an invalid workflow error on the reusable precheck call. After: `actionlint -color=false .github/workflows/qwen-code-pr-review.yml` passes locally.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

Local workflow lint only; no runtime app environment required.

## Risk & Scope

- Main risk or tradeoff: the precheck job receives the minimum permissions already requested by the called reusable workflow.
- Not validated / out of scope: a live GitHub Actions rerun after merge.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 给 PR review 的 precheck job 补上它调用的 reusable safety workflow 所需的 token 权限。改动只限制在 precheck job 本身，不改变 review workflow 其它 job 的权限边界。

## Why it's needed

Qwen Pull Request Review 目前有触发，但在任何 job 启动前失败。GitHub 报错显示 reusable precheck workflow 需要 `issues: write` 和 `pull-requests: read`，但调用方给这两个 scope 的有效权限是 `none`，导致自动 review 和评论触发的 review 都变成 `startup_failure`，不会真正排队执行 review。

## Reviewer Test Plan

### How to verify

在一个 PR 上触发 Qwen Pull Request Review，或者 rerun 最近失败的 review workflow。workflow 应该通过启动阶段校验，并创建 precheck/authorization jobs，而不是因为 reusable workflow 权限错误直接 startup failure。

### Evidence (Before & After)

Before：最近的 Qwen Pull Request Review runs 在 reusable precheck 调用处因为 invalid workflow 启动失败。After：本地执行 `actionlint -color=false .github/workflows/qwen-code-pr-review.yml` 通过。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

只做了本地 workflow lint；不需要运行时 app 环境。

## Risk & Scope

- Main risk or tradeoff: precheck job 获得被调用 reusable workflow 已声明需要的最小权限。
- Not validated / out of scope: merge 后真实 GitHub Actions rerun。
- Breaking changes / migration notes: 无。

## Linked Issues

N/A

</details>
