### PR TITLE
fix(ci): list workflow comments with GET

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -115,7 +115,9 @@ jobs:
           fi
           ACK_BODY="<!-- qwen-review-ack -->_Qwen Code review request accepted. Review is queued in [workflow run](${RUN_URL})._"
           EXISTING_ACK_ID="$(
+            # -F would otherwise make gh api default to POST.
             gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              --method GET \
               --paginate \
               -F per_page=100 \
               | jq -sr '[.[][] | select(.body | contains("<!-- qwen-review-ack -->")) | select(.user.login == "github-actions[bot]")] | last | .id // empty'

--- a/.github/workflows/qwen-pr-safety-precheck.yml
+++ b/.github/workflows/qwen-pr-safety-precheck.yml
@@ -75,7 +75,9 @@ jobs:
         run: |-
           set -euo pipefail
           existing_id="$(
+            # -F would otherwise make gh api default to POST.
             gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              --method GET \
               --paginate \
               -F per_page=100 \
               | jq -sr '[.[][] | select(.body | contains("<!-- qwen-pr-precheck:manual-required -->")) | select(.user.login == "github-actions[bot]")] | last | .id // empty'
@@ -100,7 +102,9 @@ jobs:
         run: |-
           set -euo pipefail
           existing_id="$(
+            # -F would otherwise make gh api default to POST.
             gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              --method GET \
               --paginate \
               -F per_page=100 \
               | jq -sr '[.[][] | select(.body | contains("<!-- qwen-pr-precheck:manual-required -->")) | select(.user.login == "github-actions[bot]")] | last | .id // empty'

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -960,7 +960,11 @@ jobs:
 
           # Dedup: update an existing tmux comment if one is already present.
           if ! EXISTING="$(
-            gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --paginate -F per_page=100 \
+            # -F would otherwise make gh api default to POST.
+            gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+              --method GET \
+              --paginate \
+              -F per_page=100 \
               | jq -sr '[.[][] | select(.body | contains("<!-- qwen-triage:tmux -->"))] | last | .id // empty'
           )"; then
             echo "::warning::Failed to look up existing tmux comments; will create a new one."


### PR DESCRIPTION
## What this PR does

This PR makes the workflow steps that deduplicate existing PR comments use explicit GET requests before updating, clearing, or creating follow-up comments.

## Why it's needed

Those lookups pass `per_page` through `gh api -F`, which makes `gh` default the request to POST unless the method is overridden. On comment-list endpoints this can fail with `Resource not accessible by integration` and then cascade into jq parsing errors. The explicit method keeps these calls as reads while preserving the existing pagination and filtering behavior.

## Reviewer Test Plan

### How to verify

Trigger the affected review, precheck, or triage comment paths on a PR where an existing bot comment may be updated. The lookup should list existing comments with GET and then update or create the intended comment instead of failing in the lookup pipeline.

### Evidence (Before & After)

Before: run 28558349368 on PR #6114 failed in the manual-approval comment path with `gh: Resource not accessible by integration (HTTP 403)` followed by a jq parse error. After: `actionlint -color=false .github/workflows/qwen-pr-safety-precheck.yml .github/workflows/qwen-code-pr-review.yml` passes locally, and `actionlint -color=false -ignore 'SC2016' .github/workflows/qwen-triage.yml` passes locally. The ignored SC2016 finding is pre-existing and unrelated to this change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

Local workflow lint only; no runtime app environment required.

## Risk & Scope

- Main risk or tradeoff: low; the change only preserves the intended list-comments API method while keeping pagination and filtering unchanged.
- Not validated / out of scope: a live rerun on a fork PR after merge.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #6114

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让几个用于去重 PR 评论的 workflow 步骤，在更新、清理或创建后续评论前，明确用 GET 请求读取已有评论。

## Why it's needed

这些查询通过 `gh api -F` 传入 `per_page`，而 `gh` 在带 field 参数时会默认把请求切成 POST，除非显式指定 method。对于列出评论的 endpoint，这会触发 `Resource not accessible by integration`，然后继续引发 jq 解析错误。显式 method 可以保持这些调用为只读请求，同时保留现有分页和过滤行为。

## Reviewer Test Plan

### How to verify

在可能需要更新已有 bot 评论的 PR 上触发相关 review、precheck 或 triage 评论路径。查询应该用 GET 读取已有评论，然后更新或创建目标评论，而不是在评论查询管道里失败。

### Evidence (Before & After)

Before：PR #6114 的 run 28558349368 在人工确认评论路径失败，日志包含 `gh: Resource not accessible by integration (HTTP 403)` 和后续 jq 解析错误。After：本地执行 `actionlint -color=false .github/workflows/qwen-pr-safety-precheck.yml .github/workflows/qwen-code-pr-review.yml` 通过，且 `actionlint -color=false -ignore 'SC2016' .github/workflows/qwen-triage.yml` 通过。被忽略的 SC2016 是既有问题，与本次改动无关。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

只做了本地 workflow lint；不需要运行时 app 环境。

## Risk & Scope

- Main risk or tradeoff: 风险低；这个改动只保持原本 intended 的评论列表 API 请求方法，分页和过滤逻辑不变。
- Not validated / out of scope: merge 后在 fork PR 上真实 rerun。
- Breaking changes / migration notes: 无。

## Linked Issues

Refs #6114

</details>
