### PR TITLE
fix(web-shell): only show scroll-to-bottom button when content overflows

### DIFF
--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -1040,12 +1040,12 @@ export function App({
   const editorRef = useRef<EditorHandle | null>(null);
   const notifiedComposerReadyRef = useRef<EditorHandle | null>(null);
   const footerRef = useRef<HTMLDivElement>(null);
-  const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+  const [canScrollMessageListToBottom, setCanScrollMessageListToBottom] =
+    useState(false);
   const previousFooterRectRef = useRef<DOMRect | null>(null);
   const previousEmptyStateRef = useRef(false);
   const resumeChatBottomFollow = useCallback(
     (behavior: ScrollBehavior = 'smooth') => {
-      setShowScrollToBottom(false);
       requestAnimationFrame(() => {
         messageListRef.current?.scrollToBottom(behavior);
         requestAnimationFrame(() => {
@@ -3066,9 +3066,12 @@ export function App({
     }
     editorRef.current?.focus();
   }, []);
-  const handleFollowStateChange = useCallback((isFollowing: boolean) => {
-    setShowScrollToBottom(!isFollowing);
-  }, []);
+  const handleCanScrollToBottomChange = useCallback(
+    (canScrollToBottom: boolean) => {
+      setCanScrollMessageListToBottom(canScrollToBottom);
+    },
+    [],
+  );
 
   const handleRetry = useCallback(() => {
     if (
@@ -3764,7 +3767,9 @@ export function App({
                         }
                         tailContent={undefined}
                         tailKey={undefined}
-                        onFollowStateChange={handleFollowStateChange}
+                        onCanScrollToBottomChange={
+                          handleCanScrollToBottomChange
+                        }
                         virtualScrollThreshold={virtualScrollThreshold}
                       />
                       {btwMessage?.role === 'btw' && (
@@ -3781,7 +3786,7 @@ export function App({
                 </CompactModeContext.Provider>
 
                 <div ref={footerRef} className={styles.footer}>
-                  {showScrollToBottom && (
+                  {canScrollMessageListToBottom && (
                     <div
                       className={
                         showFloatingTodos

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -107,7 +107,10 @@ const planMsg = (id: string): PlanMessage => ({
 function mount(
   messages: Message[],
   ref?: RefObject<MessageListHandle | null>,
-  opts: { isResponding?: boolean } = {},
+  opts: {
+    isResponding?: boolean;
+    onCanScrollToBottomChange?: (canScrollToBottom: boolean) => void;
+  } = {},
 ): HTMLElement {
   const container = document.createElement('div');
   document.body.appendChild(container);
@@ -121,6 +124,7 @@ function mount(
           pendingApproval={null}
           isResponding={opts.isResponding}
           shellOutputMaxLines={50}
+          onCanScrollToBottomChange={opts.onCanScrollToBottomChange}
         />
       </I18nProvider>,
     );
@@ -426,5 +430,81 @@ describe('MessageList — turn collapse (DOM)', () => {
 
     expect(assistantActions(c, 'mid')).toBe('false');
     expect(assistantActions(c, 'a1')).toBe('true');
+  });
+
+  it('reports when the user has scrolled away from the bottom', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTop', {
+      configurable: true,
+      value: 600,
+      writable: true,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    const onCanScrollToBottomChange = vi.fn();
+
+    const container = mount([asstMsg('a1')], undefined, {
+      onCanScrollToBottomChange,
+    });
+    await nextFrame();
+
+    const list = container.firstElementChild as HTMLElement;
+    list.scrollTop = 600;
+    act(() => list.dispatchEvent(new Event('scroll', { bubbles: true })));
+    await nextFrame();
+
+    list.scrollTop = 500;
+    act(() => list.dispatchEvent(new Event('scroll', { bubbles: true })));
+    await nextFrame();
+
+    expect(onCanScrollToBottomChange).toHaveBeenCalledWith(true);
+  });
+
+  it('reports no scroll-to-bottom affordance when the list has no scrollbar', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 600,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const onCanScrollToBottomChange = vi.fn();
+
+    mount([userMsg('u1')], undefined, { onCanScrollToBottomChange });
+    await nextFrame();
+
+    expect(onCanScrollToBottomChange).toHaveBeenCalledWith(false);
+  });
+
+  it('reports no scroll-to-bottom affordance when already at the bottom', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTop', {
+      configurable: true,
+      value: 600,
+      writable: true,
+    });
+    const onCanScrollToBottomChange = vi.fn();
+
+    mount([userMsg('u1')], undefined, { onCanScrollToBottomChange });
+    await nextFrame();
+
+    expect(onCanScrollToBottomChange).toHaveBeenCalledWith(false);
   });
 });

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -603,6 +603,41 @@ describe('MessageList — turn collapse (DOM)', () => {
     expect(onCanScrollToBottomChange).toHaveBeenLastCalledWith(true);
   });
 
+  it('keeps the scroll-to-bottom affordance hidden when disclosure growth stays near bottom', async () => {
+    let scrollHeight = 600;
+    let scrollTop = 0;
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTop', {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = Math.max(0, Math.min(value, scrollHeight - 600));
+      },
+    });
+    const onCanScrollToBottomChange = vi.fn();
+    const c = mount([thinkingMsg('t1'), asstMsg('a1')], undefined, {
+      isResponding: true,
+      onCanScrollToBottomChange,
+    });
+    await nextFrame();
+
+    click(disclosure(c, 't1'));
+
+    scrollHeight = 620;
+    act(() => triggerResizeObservers());
+    await nextFrame();
+    await nextFrame();
+
+    expect(onCanScrollToBottomChange).toHaveBeenLastCalledWith(false);
+  });
+
   it('clears the scroll-to-bottom affordance immediately after scrolling to bottom', async () => {
     let scrollTop = 600;
     Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -21,10 +21,19 @@ vi.mock('./MessageItem', async () => {
       message: Message;
       showAssistantActions?: boolean;
     }) =>
-      React.createElement('div', {
-        'data-testid': `msg-${message.id}`,
-        'data-assistant-actions': String(Boolean(showAssistantActions)),
-      }),
+      React.createElement(
+        'div',
+        {
+          'data-testid': `msg-${message.id}`,
+          'data-assistant-actions': String(Boolean(showAssistantActions)),
+        },
+        message.role === 'thinking'
+          ? React.createElement('button', {
+              'aria-expanded': 'false',
+              'data-testid': `disclosure-${message.id}`,
+            })
+          : null,
+      ),
   };
 });
 vi.mock('./messages/tools/ParallelAgentsGroup', () => ({
@@ -42,8 +51,11 @@ type MessageListHandle = import('./MessageList').MessageListHandle;
 
 // jsdom provides neither ResizeObserver (MessageList's resize guard) nor a real
 // scrollIntoView (the non-virtual scroll path) — stub both.
+const resizeObserverCallbacks: ResizeObserverCallback[] = [];
 class ResizeObserverStub {
-  constructor(private readonly callback: ResizeObserverCallback) {}
+  constructor(private readonly callback: ResizeObserverCallback) {
+    resizeObserverCallbacks.push(callback);
+  }
   observe() {
     this.callback([], this as unknown as ResizeObserver);
   }
@@ -56,12 +68,19 @@ if (!Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = () => {};
 }
 
+function triggerResizeObservers() {
+  for (const callback of resizeObserverCallbacks) {
+    callback([], {} as ResizeObserver);
+  }
+}
+
 const mounted: Array<{ root: Root; container: HTMLElement }> = [];
 afterEach(() => {
   for (const { root, container } of mounted.splice(0)) {
     act(() => root.unmount());
     container.remove();
   }
+  resizeObserverCallbacks.length = 0;
   vi.useRealTimers();
 });
 
@@ -147,6 +166,8 @@ const queryToggle = (c: HTMLElement, turnId: string) =>
   c.querySelector(`[data-testid="toggle-${turnId}"]`) as HTMLElement | null;
 const toggle = (c: HTMLElement, turnId: string) =>
   queryToggle(c, turnId) as HTMLElement;
+const disclosure = (c: HTMLElement, id: string) =>
+  c.querySelector(`[data-testid="disclosure-${id}"]`) as HTMLElement;
 const toggleRow = (c: HTMLElement, turnId: string) =>
   toggle(c, turnId).closest('[role="button"]') as HTMLElement;
 const click = (el: Element) =>
@@ -466,7 +487,13 @@ describe('MessageList — turn collapse (DOM)', () => {
     act(() => list.dispatchEvent(new Event('scroll', { bubbles: true })));
     await nextFrame();
 
-    expect(onCanScrollToBottomChange).toHaveBeenCalledWith(true);
+    expect(onCanScrollToBottomChange).toHaveBeenLastCalledWith(true);
+
+    list.scrollTop = 600;
+    act(() => list.dispatchEvent(new Event('scroll', { bubbles: true })));
+    await nextFrame();
+
+    expect(onCanScrollToBottomChange).toHaveBeenLastCalledWith(false);
   });
 
   it('reports no scroll-to-bottom affordance when the list has no scrollbar', async () => {
@@ -483,7 +510,7 @@ describe('MessageList — turn collapse (DOM)', () => {
     mount([userMsg('u1')], undefined, { onCanScrollToBottomChange });
     await nextFrame();
 
-    expect(onCanScrollToBottomChange).toHaveBeenCalledWith(false);
+    expect(onCanScrollToBottomChange).toHaveBeenLastCalledWith(false);
   });
 
   it('reports no scroll-to-bottom affordance when already at the bottom', async () => {
@@ -505,6 +532,140 @@ describe('MessageList — turn collapse (DOM)', () => {
     mount([userMsg('u1')], undefined, { onCanScrollToBottomChange });
     await nextFrame();
 
-    expect(onCanScrollToBottomChange).toHaveBeenCalledWith(false);
+    expect(onCanScrollToBottomChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('keeps the scroll-to-bottom affordance hidden when followed content grows', async () => {
+    let scrollHeight = 600;
+    let scrollTop = 0;
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTop', {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = Math.max(0, Math.min(value, scrollHeight - 600));
+      },
+    });
+    const onCanScrollToBottomChange = vi.fn();
+
+    mount([asstMsg('a1')], undefined, { onCanScrollToBottomChange });
+    await nextFrame();
+
+    expect(onCanScrollToBottomChange).toHaveBeenLastCalledWith(false);
+
+    scrollHeight = 1200;
+    act(() => triggerResizeObservers());
+    await nextFrame();
+    await nextFrame();
+
+    expect(onCanScrollToBottomChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('reports scroll-to-bottom affordance when a clicked disclosure grows during streaming', async () => {
+    let scrollHeight = 600;
+    let scrollTop = 0;
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTop', {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = Math.max(0, Math.min(value, scrollHeight - 600));
+      },
+    });
+    const onCanScrollToBottomChange = vi.fn();
+    const c = mount([thinkingMsg('t1'), asstMsg('a1')], undefined, {
+      isResponding: true,
+      onCanScrollToBottomChange,
+    });
+    await nextFrame();
+
+    click(disclosure(c, 't1'));
+
+    scrollHeight = 1200;
+    act(() => triggerResizeObservers());
+    await nextFrame();
+    await nextFrame();
+
+    expect(onCanScrollToBottomChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it('clears the scroll-to-bottom affordance immediately after scrolling to bottom', async () => {
+    let scrollTop = 600;
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTop', {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = Math.max(0, Math.min(value, 600));
+      },
+    });
+    const onCanScrollToBottomChange = vi.fn();
+    const ref = createRef<MessageListHandle>();
+    const c = mount([asstMsg('a1')], ref, { onCanScrollToBottomChange });
+    await nextFrame();
+    await nextFrame();
+
+    const list = c.firstElementChild as HTMLElement;
+    scrollTop = 0;
+    act(() => list.dispatchEvent(new Event('scroll', { bubbles: true })));
+    await nextFrame();
+
+    expect(onCanScrollToBottomChange).toHaveBeenLastCalledWith(true);
+
+    act(() => ref.current?.scrollToBottom('auto'));
+
+    expect(onCanScrollToBottomChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('reports scroll-to-bottom affordance when expanding content creates overflow', async () => {
+    let scrollHeight = 600;
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTop', {
+      configurable: true,
+      value: 0,
+      writable: true,
+    });
+    const onCanScrollToBottomChange = vi.fn();
+    const c = mount([userMsg('u1'), toolMsg('g1'), asstMsg('a1')], undefined, {
+      onCanScrollToBottomChange,
+    });
+    await nextFrame();
+
+    click(toggle(c, 'u1'));
+    scrollHeight = 1200;
+    await nextFrame();
+    await nextFrame();
+    await act(() => new Promise<void>((resolve) => setTimeout(resolve, 230)));
+    await nextFrame();
+
+    expect(onCanScrollToBottomChange).toHaveBeenLastCalledWith(true);
   });
 });

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -10,6 +10,7 @@ import {
   useMemo,
   useState,
   type ReactNode,
+  type MouseEvent as ReactMouseEvent,
   type MutableRefObject,
 } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
@@ -1682,7 +1683,6 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
     const scrollCooldown = useRef(false);
     const scrollCooldownCount = useRef(0);
     const sessionTimelineFrame = useRef<number | null>(null);
-    const lastReportedFollow = useRef(true);
     const lastReportedCanScrollToBottom = useRef<boolean | null>(null);
     const prevLastUserMsgId = useRef<string | null>(null);
     const prevActiveExecutionKey = useRef<string | null>(null);
@@ -1696,10 +1696,6 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
     const pendingOverflowFrame = useRef<number | undefined>(undefined);
     catchingUpRef.current = catchingUp;
     const containerRef = useRef<HTMLDivElement>(null);
-
-    const setShouldFollow = useCallback((value: boolean) => {
-      shouldFollow.current = value;
-    }, []);
 
     const reportCanScrollToBottom = useCallback(() => {
       const el = containerRef.current;
@@ -1720,6 +1716,15 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
         reportCanScrollToBottom,
       );
     }, [reportCanScrollToBottom]);
+
+    const setShouldFollow = useCallback(
+      (value: boolean) => {
+        if (shouldFollow.current === value) return;
+        shouldFollow.current = value;
+        scheduleScrollOverflowReport();
+      },
+      [scheduleScrollOverflowReport],
+    );
     const visibleItems = useMemo(
       () =>
         applyTurnCollapse(displayItems, {
@@ -1828,8 +1833,9 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
       if (!el) return;
       const distanceFromBottom =
         el.scrollHeight - el.scrollTop - el.clientHeight;
-      setShouldFollow(distanceFromBottom < 30);
-    }, [setShouldFollow]);
+      setShouldFollow(distanceFromBottom <= 1);
+      scheduleScrollOverflowReport();
+    }, [scheduleScrollOverflowReport, setShouldFollow]);
 
     const scheduleFollowRecheck = useCallback(() => {
       pendingFollowRecheck.current = true;
@@ -1874,19 +1880,29 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
         // follow so streaming output does not yank the viewport back to the
         // tail while the user is inspecting history.
         const el = containerRef.current;
-        if (el && el.scrollHeight <= el.clientHeight + 1) {
-          // If there is no scrollbar yet, there is no meaningful "not at
-          // bottom" state to report. The toggle may create overflow though, so
-          // re-check after the expanded/collapsed rows have been laid out.
-          scheduleFollowRecheck();
-        } else {
+        // If there is no scrollbar yet, there is no meaningful "not at
+        // bottom" state to report. The toggle may create overflow though, so
+        // re-check after the expanded/collapsed rows have been laid out.
+        if (!el || el.scrollHeight > el.clientHeight + 1) {
           setShouldFollow(false);
         }
+        scheduleFollowRecheck();
         setCollapseOverrides((prev) => {
           const next = new Map(prev);
           next.set(turnId, nextExpanded);
           return next;
         });
+      },
+      [scheduleFollowRecheck, setShouldFollow],
+    );
+
+    const handleDisclosureClickCapture = useCallback(
+      (event: ReactMouseEvent<HTMLDivElement>) => {
+        const target = event.target;
+        if (!(target instanceof HTMLElement)) return;
+        if (!target.closest('[aria-expanded]')) return;
+        setShouldFollow(false);
+        scheduleFollowRecheck();
       },
       [scheduleFollowRecheck, setShouldFollow],
     );
@@ -1926,6 +1942,7 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
         }
         scheduleScrollOverflowReport();
         lastScrollTop.current = Math.max(0, el.scrollHeight - el.clientHeight);
+        reportCanScrollToBottom();
         const releaseCooldown = () => {
           if (scrollCooldownCount.current === gen) {
             scrollCooldown.current = false;
@@ -1937,7 +1954,7 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
           requestAnimationFrame(releaseCooldown);
         }
       },
-      [getScrollElement, scheduleScrollOverflowReport],
+      [getScrollElement, reportCanScrollToBottom, scheduleScrollOverflowReport],
     );
 
     const resumeBottomFollow = useCallback(
@@ -2123,6 +2140,7 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
           if (scrollCooldownCount.current === gen) {
             scrollCooldown.current = false;
             scheduleSessionTimelineRangeUpdate();
+            scheduleScrollOverflowReport();
           }
         }, 150);
         const key = getItemKey(rowIndex);
@@ -2135,6 +2153,7 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
         getItemKey,
         setShouldFollow,
         scheduleSessionTimelineRangeUpdate,
+        scheduleScrollOverflowReport,
       ],
     );
 
@@ -2272,20 +2291,30 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
 
     useEffect(() => {
       const el = getScrollElement();
-      if (!el) return;
+      if (!el || typeof ResizeObserver === 'undefined') return;
       const observer = new ResizeObserver(scheduleScrollOverflowReport);
       observer.observe(el);
       for (const child of Array.from(el.children)) {
         observer.observe(child);
       }
+      const mutationObserver = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+          for (const node of Array.from(mutation.addedNodes)) {
+            if (node instanceof HTMLElement) observer.observe(node);
+          }
+          for (const node of Array.from(mutation.removedNodes)) {
+            if (node instanceof HTMLElement) observer.unobserve(node);
+          }
+        }
+        scheduleScrollOverflowReport();
+      });
+      mutationObserver.observe(el, { childList: true });
       scheduleScrollOverflowReport();
-      return () => observer.disconnect();
-    }, [
-      getScrollElement,
-      scheduleScrollOverflowReport,
-      totalCount,
-      totalVirtualSize,
-    ]);
+      return () => {
+        observer.disconnect();
+        mutationObserver.disconnect();
+      };
+    }, [getScrollElement, scheduleScrollOverflowReport]);
 
     // Clear screen (e.g. /clear) → reset to follow mode, drop stale per-turn
     // collapse overrides, and disarm any deferred scroll so it can't fire
@@ -2535,7 +2564,11 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
     }, [messages, scheduleScrollOverflowReport, totalCount, totalVirtualSize]);
 
     return (
-      <div ref={containerRef} className={styles.list}>
+      <div
+        ref={containerRef}
+        className={styles.list}
+        onClickCapture={handleDisclosureClickCapture}
+      >
         <SessionTimeline
           entries={sessionTimelineEntries}
           currentTurnId={currentTimelineTurnId}

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -57,7 +57,7 @@ interface MessageListProps {
   showRetryHint?: boolean;
   onRetryClick?: () => void;
   onBranchSession?: () => void;
-  onFollowStateChange?: (isFollowing: boolean) => void;
+  onCanScrollToBottomChange?: (canScrollToBottom: boolean) => void;
 }
 
 function getLastUserMessageId(messages: Message[]): string | null {
@@ -1593,7 +1593,7 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
       showRetryHint = false,
       onRetryClick,
       onBranchSession,
-      onFollowStateChange,
+      onCanScrollToBottomChange,
     },
     ref,
   ) {
@@ -1683,6 +1683,7 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
     const scrollCooldownCount = useRef(0);
     const sessionTimelineFrame = useRef<number | null>(null);
     const lastReportedFollow = useRef(true);
+    const lastReportedCanScrollToBottom = useRef<boolean | null>(null);
     const prevLastUserMsgId = useRef<string | null>(null);
     const prevActiveExecutionKey = useRef<string | null>(null);
     const prevCatchingUp: MutableRefObject<boolean | undefined> =
@@ -1692,18 +1693,33 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
     const pendingFollowRecheck = useRef(false);
     const pendingFollowRecheckFrame = useRef<number | undefined>(undefined);
     const pendingFollowRecheckTimer = useRef<number | undefined>(undefined);
+    const pendingOverflowFrame = useRef<number | undefined>(undefined);
     catchingUpRef.current = catchingUp;
     const containerRef = useRef<HTMLDivElement>(null);
 
-    const setShouldFollow = useCallback(
-      (value: boolean) => {
-        shouldFollow.current = value;
-        if (lastReportedFollow.current === value) return;
-        lastReportedFollow.current = value;
-        onFollowStateChange?.(value);
-      },
-      [onFollowStateChange],
-    );
+    const setShouldFollow = useCallback((value: boolean) => {
+      shouldFollow.current = value;
+    }, []);
+
+    const reportCanScrollToBottom = useCallback(() => {
+      const el = containerRef.current;
+      const distanceFromBottom = el
+        ? el.scrollHeight - el.scrollTop - el.clientHeight
+        : 0;
+      const canScrollToBottom = !shouldFollow.current && distanceFromBottom > 1;
+      if (lastReportedCanScrollToBottom.current === canScrollToBottom) return;
+      lastReportedCanScrollToBottom.current = canScrollToBottom;
+      onCanScrollToBottomChange?.(canScrollToBottom);
+    }, [onCanScrollToBottomChange]);
+
+    const scheduleScrollOverflowReport = useCallback(() => {
+      if (pendingOverflowFrame.current !== undefined) {
+        window.cancelAnimationFrame(pendingOverflowFrame.current);
+      }
+      pendingOverflowFrame.current = window.requestAnimationFrame(
+        reportCanScrollToBottom,
+      );
+    }, [reportCanScrollToBottom]);
     const visibleItems = useMemo(
       () =>
         applyTurnCollapse(displayItems, {
@@ -1845,6 +1861,9 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
         if (pendingFollowRecheckTimer.current !== undefined) {
           window.clearTimeout(pendingFollowRecheckTimer.current);
         }
+        if (pendingOverflowFrame.current !== undefined) {
+          window.cancelAnimationFrame(pendingOverflowFrame.current);
+        }
       },
       [],
     );
@@ -1905,6 +1924,7 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
         } else {
           el.scrollTop = el.scrollHeight;
         }
+        scheduleScrollOverflowReport();
         lastScrollTop.current = Math.max(0, el.scrollHeight - el.clientHeight);
         const releaseCooldown = () => {
           if (scrollCooldownCount.current === gen) {
@@ -1917,7 +1937,7 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
           requestAnimationFrame(releaseCooldown);
         }
       },
-      [getScrollElement],
+      [getScrollElement, scheduleScrollOverflowReport],
     );
 
     const resumeBottomFollow = useCallback(
@@ -2221,6 +2241,7 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
       const curr = el.scrollTop;
       lastScrollTop.current = curr;
       const distanceFromBottom = el.scrollHeight - curr - el.clientHeight;
+      scheduleScrollOverflowReport();
 
       // Rule 2: scrolling up → pause follow
       if (curr < prev - 1) {
@@ -2235,7 +2256,12 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
       if (distanceFromBottom < 30) {
         setShouldFollow(true);
       }
-    }, [getScrollElement, scheduleSessionTimelineRangeUpdate, setShouldFollow]);
+    }, [
+      getScrollElement,
+      scheduleScrollOverflowReport,
+      scheduleSessionTimelineRangeUpdate,
+      setShouldFollow,
+    ]);
 
     useEffect(() => {
       const el = getScrollElement();
@@ -2243,6 +2269,23 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
       el.addEventListener('scroll', handleScroll, { passive: true });
       return () => el.removeEventListener('scroll', handleScroll);
     }, [getScrollElement, handleScroll]);
+
+    useEffect(() => {
+      const el = getScrollElement();
+      if (!el) return;
+      const observer = new ResizeObserver(scheduleScrollOverflowReport);
+      observer.observe(el);
+      for (const child of Array.from(el.children)) {
+        observer.observe(child);
+      }
+      scheduleScrollOverflowReport();
+      return () => observer.disconnect();
+    }, [
+      getScrollElement,
+      scheduleScrollOverflowReport,
+      totalCount,
+      totalVirtualSize,
+    ]);
 
     // Clear screen (e.g. /clear) → reset to follow mode, drop stale per-turn
     // collapse overrides, and disarm any deferred scroll so it can't fire
@@ -2486,6 +2529,10 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
         scrollToBottom(isNewUserMessage ? 'smooth' : 'auto');
       }
     }, [totalVirtualSize, messages, totalCount, catchingUp, scrollToBottom]);
+
+    useLayoutEffect(() => {
+      scheduleScrollOverflowReport();
+    }, [messages, scheduleScrollOverflowReport, totalCount, totalVirtualSize]);
 
     return (
       <div ref={containerRef} className={styles.list}>

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -1241,6 +1241,7 @@ const ESTIMATE_HEADER = 120;
 const ESTIMATE_MESSAGE = 80;
 const ESTIMATE_TURN_COLLAPSE = 32;
 const ESTIMATE_TAIL = 240;
+const FOLLOW_BOTTOM_THRESHOLD_PX = 30;
 export const VIRTUAL_SCROLL_THRESHOLD = 200;
 
 export function shouldUseVirtualScroll(
@@ -1784,7 +1785,8 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
     //      Even if the model is still streaming, the viewport stays put.
     //
     //   3. Scroll-back-to-bottom resumes — when the user scrolls back
-    //      near the bottom (< 30px from edge), follow mode re-engages
+    //      near the bottom (within FOLLOW_BOTTOM_THRESHOLD_PX), follow mode
+    //      re-engages
     //      and new content resumes sticking.
     //
     //   4. New message resets follow — after the user sends a message,
@@ -1833,7 +1835,7 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
       if (!el) return;
       const distanceFromBottom =
         el.scrollHeight - el.scrollTop - el.clientHeight;
-      setShouldFollow(distanceFromBottom <= 1);
+      setShouldFollow(distanceFromBottom < FOLLOW_BOTTOM_THRESHOLD_PX);
       scheduleScrollOverflowReport();
     }, [scheduleScrollOverflowReport, setShouldFollow]);
 
@@ -2266,13 +2268,13 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
       if (curr < prev - 1) {
         // Container resizes can clamp scrollTop downward while the viewport is
         // still at the tail. Treat that as follow mode, not a manual scroll-up.
-        setShouldFollow(distanceFromBottom < 30);
+        setShouldFollow(distanceFromBottom < FOLLOW_BOTTOM_THRESHOLD_PX);
         return;
       }
       // Rule 3: near bottom → resume follow
       // Run only after non-upward scrolls. Otherwise a tiny wheel-up near the
       // tail would pause follow and immediately re-enable it in the same event.
-      if (distanceFromBottom < 30) {
+      if (distanceFromBottom < FOLLOW_BOTTOM_THRESHOLD_PX) {
         setShouldFollow(true);
       }
     }, [


### PR DESCRIPTION
## What this PR does

Reworks the scroll-to-bottom button visibility logic in the web-shell message list. Previously, the button was tied to the internal "follow" state — it appeared whenever auto-follow was disabled, regardless of whether the content actually overflowed. This change decouples the button from the follow mechanism and instead computes visibility from the actual scroll geometry: the button only appears when the content overflows the viewport **and** the user has scrolled away from the bottom. A `ResizeObserver` and additional `useLayoutEffect` hooks keep the state correct as content grows or the viewport resizes.

The prop is renamed from `onFollowStateChange(isFollowing)` to `onCanScrollToBottomChange(canScrollToBottom)` to reflect the new semantics. Three new unit tests cover: scrolled away from bottom, no overflow (no scrollbar), and already at bottom.

## Why it's needed

The scroll-to-bottom button would flash briefly when new messages arrived even when the message list was short enough to fit entirely in the viewport — there was nothing to scroll to, so the button was meaningless and visually distracting. The root cause was that the old `onFollowStateChange` callback fired on every follow-state transition without checking whether scrolling was even possible. By computing `canScrollToBottom` from `scrollHeight - scrollTop - clientHeight` and guarding with a `ResizeObserver`, the button now only appears when it is actually useful.

## Reviewer Test Plan

### How to verify

1. Open the web-shell and start a chat session with only 1-2 short messages (content fits in the viewport). Confirm the scroll-to-bottom button **never** appears, even briefly when new messages stream in.
2. Add enough messages to overflow the viewport, then scroll up. Confirm the scroll-to-bottom button appears. Click it and confirm the list scrolls to the bottom and the button disappears.
3. While the list is overflowed and auto-following the bottom, confirm the button does **not** appear.
4. Run the new unit tests: `cd packages/web-shell && npx vitest run src/client/components/MessageList.dom.test.tsx`

### Evidence (Before & After)

Before: scroll-to-bottom button flashes on every message when the list is short (no scrollbar).
After: button only appears when content overflows and the user has scrolled away from the bottom.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

npm run dev, web-shell in browser.

## Risk & Scope

- Main risk or tradeoff: The `ResizeObserver` adds one observer per message list mount; cost is negligible but worth noting. The prop rename (`onFollowStateChange` → `onCanScrollToBottomChange`) is a breaking change for any external consumer of `MessageList`, though none are known.
- Not validated / out of scope: Virtual-scroll mode with very large message counts (thousands) was not specifically tested for observer overhead.
- Breaking changes / migration notes: `MessageList` prop renamed — internal only.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

重构了 web-shell 消息列表中"回到底部"按钮的显示逻辑。之前该按钮绑定在内部的"跟随"状态上——只要自动跟随被禁用就会显示，不管内容是否溢出视口。此次修改将按钮与跟随机制解耦，改为根据实际滚动几何计算可见性：只有当内容溢出视口**且**用户已向上滚动离开底部时才显示按钮。新增 `ResizeObserver` 和 `useLayoutEffect` 钩子，确保内容增长或视口缩放时状态保持正确。

Prop 从 `onFollowStateChange(isFollowing)` 重命名为 `onCanScrollToBottomChange(canScrollToBottom)`，以反映新的语义。新增三个单元测试分别覆盖：已滚动离开底部、无溢出（无滚动条）、已在底部。

## 为什么需要这个改动

当消息列表很短（内容完全在视口内）时，"回到底部"按钮会在新消息到达时短暂闪烁——实际上没有内容可滚动，按钮毫无意义且造成视觉干扰。根本原因是旧的 `onFollowStateChange` 回调在每次跟随状态转换时都会触发，而不检查是否真的可以滚动。通过基于 `scrollHeight - scrollTop - clientHeight` 计算 `canScrollToBottom` 并用 `ResizeObserver` 守卫，按钮现在只在真正有用时才出现。

</details>
