### PR TITLE
fix(ci): use CI_BOT_PAT for precheck comment on fork PRs

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -68,7 +68,8 @@ jobs:
       pull-requests: 'read'
       issues: 'write'
     uses: './.github/workflows/qwen-pr-safety-precheck.yml'
-    secrets: inherit
+    secrets:
+      CI_BOT_PAT: '${{ secrets.CI_BOT_PAT }}'
 
   ack-review-request:
     # KEEP IN SYNC with review-pr.if (explicit-trigger branches).

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -68,6 +68,7 @@ jobs:
       pull-requests: 'read'
       issues: 'write'
     uses: './.github/workflows/qwen-pr-safety-precheck.yml'
+    secrets: inherit
 
   ack-review-request:
     # KEEP IN SYNC with review-pr.if (explicit-trigger branches).

--- a/.github/workflows/qwen-pr-safety-precheck.yml
+++ b/.github/workflows/qwen-pr-safety-precheck.yml
@@ -2,6 +2,9 @@ name: 'Qwen PR Safety Precheck'
 
 on:
   workflow_call:
+    secrets:
+      CI_BOT_PAT:
+        required: false
     outputs:
       decision:
         description: 'allow_triage or manual_required'

--- a/.github/workflows/qwen-pr-safety-precheck.yml
+++ b/.github/workflows/qwen-pr-safety-precheck.yml
@@ -80,7 +80,7 @@ jobs:
               --method GET \
               --paginate \
               -F per_page=100 \
-              | jq -sr '[.[][] | select(.body | contains("<!-- qwen-pr-precheck:manual-required -->"))] | last | .id // empty'
+              | jq -sr '[.[][] | select(.body | contains("<!-- qwen-pr-precheck:manual-required -->")) | select(.user.login == "github-actions[bot]" or .user.login == "qwen-code-ci-bot" or (.user.type == "Bot"))] | last | .id // empty'
           )"
           if [ -n "$existing_id" ]; then
             gh api \
@@ -107,7 +107,7 @@ jobs:
               --method GET \
               --paginate \
               -F per_page=100 \
-              | jq -sr '[.[][] | select(.body | contains("<!-- qwen-pr-precheck:manual-required -->"))] | last | .id // empty'
+              | jq -sr '[.[][] | select(.body | contains("<!-- qwen-pr-precheck:manual-required -->")) | select(.user.login == "github-actions[bot]" or .user.login == "qwen-code-ci-bot" or (.user.type == "Bot"))] | last | .id // empty'
           )"
           if [ -n "$existing_id" ]; then
             gh api \

--- a/.github/workflows/qwen-pr-safety-precheck.yml
+++ b/.github/workflows/qwen-pr-safety-precheck.yml
@@ -70,7 +70,7 @@ jobs:
       - name: 'Upsert manual approval comment'
         if: "steps.assess.outputs.decision == 'manual_required'"
         env:
-          GH_TOKEN: '${{ github.token }}'
+          GH_TOKEN: '${{ secrets.CI_BOT_PAT || github.token }}'
           PR_NUMBER: '${{ github.event.pull_request.number }}'
         run: |-
           set -euo pipefail
@@ -80,7 +80,7 @@ jobs:
               --method GET \
               --paginate \
               -F per_page=100 \
-              | jq -sr '[.[][] | select(.body | contains("<!-- qwen-pr-precheck:manual-required -->")) | select(.user.login == "github-actions[bot]")] | last | .id // empty'
+              | jq -sr '[.[][] | select(.body | contains("<!-- qwen-pr-precheck:manual-required -->"))] | last | .id // empty'
           )"
           if [ -n "$existing_id" ]; then
             gh api \
@@ -97,7 +97,7 @@ jobs:
       - name: 'Clear manual approval comment'
         if: "steps.assess.outputs.decision == 'allow_triage'"
         env:
-          GH_TOKEN: '${{ github.token }}'
+          GH_TOKEN: '${{ secrets.CI_BOT_PAT || github.token }}'
           PR_NUMBER: '${{ github.event.pull_request.number }}'
         run: |-
           set -euo pipefail
@@ -107,7 +107,7 @@ jobs:
               --method GET \
               --paginate \
               -F per_page=100 \
-              | jq -sr '[.[][] | select(.body | contains("<!-- qwen-pr-precheck:manual-required -->")) | select(.user.login == "github-actions[bot]")] | last | .id // empty'
+              | jq -sr '[.[][] | select(.body | contains("<!-- qwen-pr-precheck:manual-required -->"))] | last | .id // empty'
           )"
           if [ -n "$existing_id" ]; then
             gh api \

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -34,6 +34,7 @@ jobs:
       github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name != github.repository
     uses: './.github/workflows/qwen-pr-safety-precheck.yml'
+    secrets: inherit
 
   authorize:
     needs: ['precheck-pr']

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -34,7 +34,8 @@ jobs:
       github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name != github.repository
     uses: './.github/workflows/qwen-pr-safety-precheck.yml'
-    secrets: inherit
+    secrets:
+      CI_BOT_PAT: '${{ secrets.CI_BOT_PAT }}'
 
   authorize:
     needs: ['precheck-pr']


### PR DESCRIPTION
## What this PR does

This PR switches the precheck comment steps from `github.token` to `secrets.CI_BOT_PAT` (with `github.token` fallback) and passes `secrets: inherit` from both caller workflows so the reusable precheck workflow can access the PAT.

Also drops the hardcoded `.user.login == "github-actions[bot]"` jq filter from the comment dedup query — the HTML marker `<!-- qwen-pr-precheck:manual-required -->` is sufficient and the posting user may differ depending on which token is used.

## Why it's needed

The precheck workflow's "Upsert manual approval comment" step fails on fork PRs with:

```
GraphQL: Resource not accessible by integration (addComment)
```

The `github.token` granted to a reusable workflow called via `workflow_call` under `pull_request_target` does not have sufficient permissions to write PR comments for fork PRs, even with `issues: write` declared. The recently merged GET fix (#6148) resolved the read side (listing comments), but the write side (`gh pr comment` → GraphQL `addComment`) still fails.

Using `CI_BOT_PAT` is consistent with how `authorize` and other secret-bearing jobs already handle this.

## Reviewer Test Plan

### How to verify

Re-run the precheck on an existing fork PR (e.g. #6133 or #6150). The manual approval comment should be posted successfully instead of failing with 403/GraphQL errors.

### Evidence (Before & After)

Before: fork PR precheck runs fail — [#6133 run](https://github.com/QwenLM/qwen-code/actions/runs/28560535578/job/84677122569), [#6150 run](https://github.com/QwenLM/qwen-code/actions/runs/28560419973/job/84676772038), [#6151 run](https://github.com/QwenLM/qwen-code/actions/runs/28561076030/job/84678685776). After: `actionlint` passes locally; runtime validation requires merge + a fork PR push.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

Local workflow lint only; runtime validation requires merge.

## Risk & Scope

- Main risk or tradeoff: exposes `CI_BOT_PAT` to the precheck job. Acceptable because this job runs on `ubuntu-latest`, checks out only trusted code from the default branch, and never executes fork PR code.
- Not validated / out of scope: live rerun on a fork PR after merge.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #5926, #6148

<details>
<summary>中文说明</summary>

## What this PR does

将 precheck 评论步骤的 token 从 `github.token` 切换为 `secrets.CI_BOT_PAT`（保留 `github.token` 兜底），并在两个调用方 workflow 中添加 `secrets: inherit` 以便 reusable workflow 可以访问 PAT。

同时移除了 jq 查询中硬编码的 `.user.login == "github-actions[bot]"` 过滤条件——HTML marker 已足够唯一，且发布评论的用户可能因 token 不同而变化。

## Why it's needed

precheck workflow 的 "Upsert manual approval comment" 步骤在 fork PR 上失败：

```
GraphQL: Resource not accessible by integration (addComment)
```

通过 `workflow_call` 在 `pull_request_target` 下调用 reusable workflow 时，`github.token` 即使声明了 `issues: write`，也没有足够权限在 fork PR 上写评论。最近合并的 GET fix（#6148）解决了读取端（列出评论），但写入端（`gh pr comment` → GraphQL `addComment`）仍然失败。

使用 `CI_BOT_PAT` 与 `authorize` 等其他需要 secret 的 job 保持一致。

## Reviewer Test Plan

### How to verify

在已有的 fork PR（如 #6133 或 #6150）上重新运行 precheck。manual approval 评论应该成功发布，而不是报 403/GraphQL 错误。

### Evidence (Before & After)

Before: fork PR 的 precheck 运行失败 — [#6133 run](https://github.com/QwenLM/qwen-code/actions/runs/28560535578/job/84677122569), [#6150 run](https://github.com/QwenLM/qwen-code/actions/runs/28560419973/job/84676772038), [#6151 run](https://github.com/QwenLM/qwen-code/actions/runs/28561076030/job/84678685776)。After: 本地 `actionlint` 通过；运行时验证需要合并后 + fork PR 推送。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

仅本地 workflow lint；运行时验证需要合并。

## Risk & Scope

- Main risk or tradeoff: 将 `CI_BOT_PAT` 暴露给 precheck job。可接受，因为此 job 运行在 `ubuntu-latest` 上，只 checkout 默认分支的可信代码，不执行 fork PR 代码。
- Not validated / out of scope: 合并后在 fork PR 上实际 rerun。
- Breaking changes / migration notes: 无。

## Linked Issues

Follow-up to #5926, #6148

</details>