### PR TITLE
refactor(core): centralize extension runtime refresh

### DIFF
--- a/docs/plans/2026-07-01-extension-runtime-refresh-implementation.md
+++ b/docs/plans/2026-07-01-extension-runtime-refresh-implementation.md
@@ -1,0 +1,320 @@
+# Extension Runtime Refresh Implementation Plan
+
+Tracking issue: https://github.com/QwenLM/qwen-code/issues/3696
+
+Working branch: `feat/extension-runtime-refresh`
+
+## Summary
+
+Qwen Code should keep the existing user experience where extension UI
+mutations take effect automatically. Installing, updating, enabling, disabling,
+or uninstalling an extension should continue to refresh runtime state without
+requiring the user to run a manual command.
+
+The remaining work is to make that automatic path complete, cheaper, and more
+visible to the model. A separate `/reload-plugins` path should be added later
+for external file changes that Qwen Code did not initiate, such as editing
+installed extension files by hand.
+
+## Current Behavior
+
+`ExtensionManager` already refreshes part of the runtime after extension
+mutations:
+
+```text
+enable/disable/install/update/uninstall
+  -> ExtensionManager.refreshTools()
+  -> refreshMemory()
+      -> ToolRegistry.restartMcpServers()
+      -> SkillManager.refreshCache()
+      -> SubagentManager.refreshCache()
+      -> refreshHierarchicalMemory()
+```
+
+This is useful but incomplete:
+
+- MCP refresh is currently too expensive because it restarts all MCP servers.
+- Commands are rebuilt indirectly through UI-layer command reload behavior.
+- Hooks are not part of the extension runtime refresh orchestration.
+- LSP server configuration from extensions is not reinitialized at runtime.
+- Model-facing availability notices are asymmetric:
+  - skills and model-invocable commands announce additions, but not removals;
+  - MCP tools announce additions, but not removals;
+  - agents update the Agent tool schema/description, but do not send an
+    explicit added/removed agent reminder.
+
+## Design Direction
+
+### Keep Automatic Mutation Refresh
+
+Extension UI mutations should remain automatic. This differs from Claude Code's
+plugin flow, where plugin mutations primarily set a stale flag and ask the user
+to run `/reload-plugins`.
+
+For Qwen Code, automatic mutation refresh is the better default because it
+preserves the current UX: when a user toggles an extension, the extension should
+actually become usable or unusable in the running session.
+
+### Add Manual Reload Only for External Changes
+
+`/reload-plugins` should be a repair/resync path for file changes outside Qwen
+Code's mutation APIs:
+
+- a user edits files under an installed extension directory;
+- an external process updates extension contents;
+- a marketplace/local extension source changes on disk;
+- a watcher sees a change but should not auto-refresh during noisy file writes.
+
+This command should reuse the same runtime refresh orchestration as automatic
+mutations.
+
+### Separate Runtime Refresh from Model Notification
+
+Refreshing runtime state is not enough. The model also needs an accurate view of
+which capabilities are available.
+
+Runtime refresh updates what can actually execute. Model notification updates
+what the model believes it can call. These are related but separate concerns.
+
+## Subsystem Behavior
+
+### Skills
+
+Extension skills are loaded by `SkillManager.refreshCache()` from active
+extensions. `SkillTool.refreshSkills()` updates the in-memory runtime sets.
+
+Problem: the model-facing `<available_skills>` path is currently add-only after
+startup. Disabling an extension removes the skill from runtime state, but the
+old listing may remain in conversation history.
+
+Planned behavior:
+
+- keep runtime refresh through `SkillManager.refreshCache()`;
+- after extension runtime refresh, provide a way to send the current complete
+  available skills/commands list, or an equivalent clear delta;
+- avoid relying only on "new skills became available" reminders for extension
+  mutation changes.
+
+### Commands
+
+Extension commands are user-visible slash commands by default. Some are also
+model-visible when `modelInvocable === true`; those enter the Skill tool's
+available-skill list and can be invoked by name through `SkillTool`.
+
+Problem: there is no core command manager. Command reload is a CLI/UI-layer
+operation, and extension mutations do not have a clear command refresh contract.
+
+Planned behavior:
+
+- make command reload an explicit part of extension runtime refresh where the
+  CLI/TUI layer is available;
+- ensure model-invocable extension commands update the Skill tool provider
+  before model-facing skill reminders are emitted;
+- keep this minimal and avoid moving the entire command system into core.
+
+### MCP
+
+Extension MCP server config is merged through `Config.getMergedMcpServers()`.
+
+Problem: extension mutations currently call `restartMcpServers()`, which
+restarts and rediscovers all MCP servers.
+
+Planned behavior:
+
+- reuse or extend the existing incremental MCP reconcile path;
+- after extension cache state is updated, reconcile against the latest merged
+  MCP map;
+- connect added servers, disconnect removed servers, and restart only changed
+  servers;
+- keep existing added MCP tool reminders;
+- add a removed MCP tool reminder so disabling an extension does not leave the
+  model relying on stale tool availability context.
+
+### Agents
+
+Extension agents are loaded by `SubagentManager.refreshCache()`. `AgentTool`
+listens for subagent changes and updates its description and `subagent_type`
+schema enum, then calls `geminiClient.setTools()`.
+
+Problem: this updates runtime/tool schema, but there is no explicit
+conversation reminder for added or removed agent types. In practice, the model
+may not notice new extension agents unless prompted.
+
+Planned behavior:
+
+- keep `SubagentManager.refreshCache()` and `AgentTool` schema refresh;
+- add a model-facing added/removed agent-type reminder, similar in intent to
+  Claude Code's `agent_listing_delta`;
+- do not make each agent a separate tool. Agents remain selected through the
+  `Agent` tool's `subagent_type` parameter.
+
+### LSP
+
+Extension `lspServers` can be read by the LSP config loader.
+
+Problem: LSP startup currently initializes the native LSP service once. Runtime
+extension changes do not reinitialize LSP server configuration.
+
+Planned behavior:
+
+- add an optional LSP reinitialization hook to extension runtime refresh;
+- call it when LSP is enabled and the API is available;
+- do not add a model-facing reminder for LSP initially, because LSP is exposed
+  as a fixed `lsp` tool and server state is better surfaced through status and
+  tool results.
+
+### Hooks
+
+Extension hooks should be treated as runtime extension components.
+
+Problem: extension mutation refresh does not currently have a clear hook reload
+step.
+
+Planned behavior:
+
+- add hook reload to the extension runtime refresh orchestration;
+- disabling/uninstalling an extension should remove its hooks;
+- enabling/installing/updating an extension should register its current hooks.
+
+## Proposed PR Sequence
+
+### PR 1: Shared Extension Runtime Refresh Orchestrator
+
+Create a small shared orchestration function used by extension mutations.
+
+Scope:
+
+- preserve current behavior;
+- keep automatic extension mutation refresh;
+- move the current refresh sequence behind one function;
+- do not add watcher support;
+- do not add `/reload-plugins`;
+- do not change model reminders;
+- MCP may still use the existing full restart in this PR.
+
+Expected value:
+
+- gives later PRs one place to attach commands, hooks, LSP, MCP reconcile, and
+  model notifications;
+- keeps review focused on structure, not behavior changes.
+
+### PR 2: Complete Automatic Mutation Refresh
+
+Extend the orchestrator to refresh all runtime components that should update
+after extension UI mutations.
+
+Scope:
+
+- commands reload when the CLI/TUI command service is available;
+- hooks reload;
+- optional LSP reinitialization;
+- keep skills, agents, and memory refresh;
+- keep MCP behavior unchanged unless a minimal no-risk integration is already
+  available.
+
+Expected value:
+
+- extension enable/disable/install/update/uninstall becomes more complete
+  without changing the user-facing automatic-refresh model.
+
+### PR 3: Incremental MCP Refresh for Extension Mutations
+
+Replace full MCP restart with incremental reconcile for extension-driven
+changes.
+
+Scope:
+
+- reconcile against the latest merged MCP config after extension cache changes;
+- avoid restarting unrelated MCP servers;
+- keep existing event/update behavior so `setTools()` still runs through the
+  MCP update path.
+
+Expected value:
+
+- reduces side effects and latency when toggling extensions.
+
+### PR 4: Model-Facing Availability Notifications
+
+Fix stale model-visible capability lists.
+
+Scope:
+
+- send a current complete skills/model-invocable commands listing, or equivalent
+  clear delta, after extension refresh changes that affect skills/commands;
+- add removed MCP tool reminders;
+- add agent added/removed reminders;
+- avoid adding an LSP reminder initially.
+
+Expected value:
+
+- the model's conversation context matches runtime availability after extension
+  changes.
+
+### PR 5: `/reload-plugins`
+
+Add a manual reload command for external extension file changes.
+
+Scope:
+
+- reuse the shared extension runtime refresh orchestrator;
+- report a concise refresh summary;
+- do not replace automatic mutation refresh;
+- clear any stale state introduced by the later watcher PR.
+
+Expected value:
+
+- users have a manual repair path when file watching detects changes or when
+  auto-detection misses a change.
+
+### PR 6: Extension File Watcher and Stale Notification
+
+Detect external extension file changes and notify the user.
+
+Scope:
+
+- watch a conservative allowlist of extension-related files:
+  - `qwen-extension.json`;
+  - `.qwen-extension-install.json`;
+  - extension enablement, preferences, and source metadata;
+  - `commands/**`;
+  - `skills/**`;
+  - `agents/**`;
+  - `hooks/**`;
+  - referenced LSP config files;
+  - extension context files such as `GEMINI.md`;
+- mark extension runtime as stale;
+- show a UI notification suggesting `/reload-plugins`;
+- do not automatically reload on every file event.
+
+Expected value:
+
+- external file changes are discoverable without making runtime refresh noisy or
+  fragile.
+
+## Non-Goals
+
+- Do not replace Qwen Code's automatic extension mutation behavior with a
+  mandatory manual reload flow.
+- Do not introduce a broad generic refresh framework before concrete call sites
+  need it.
+- Do not make each agent type a separate model tool.
+- Do not make LSP availability reminders part of the first implementation.
+- Do not automatically reload every extension file watcher event.
+
+## Open Questions
+
+- What is the smallest stable API for command reload from extension runtime
+  refresh without over-coupling core and CLI?
+- Should skills/commands use a full current listing after extension refresh, or
+  an added/removed delta? Full listing is simpler and closer to the current
+  `<available_skills>` model.
+- Should removed MCP tool reminders include all removed tools, or group by
+  extension/server to reduce noise?
+- Which existing hook reload function should become the public orchestration
+  point?
+- How should `/reload-plugins` behave in non-interactive mode, if at all?
+
+## Tracking Notes
+
+Use this document to keep PR scope narrow. Each PR should update this file when
+its part of the plan is completed or intentionally changed.

--- a/packages/core/src/extension/extension-runtime-refresh.test.ts
+++ b/packages/core/src/extension/extension-runtime-refresh.test.ts
@@ -77,4 +77,27 @@ describe('refreshExtensionRuntime', () => {
     expect(refreshSkills).toHaveBeenCalledOnce();
     expect(refreshSubagents).toHaveBeenCalledOnce();
   });
+
+  it('rejects when restartMcpServers fails', async () => {
+    const restartMcpServers = vi
+      .fn()
+      .mockRejectedValue(new Error('mcp failed'));
+    const refreshSkills = vi.fn();
+    const refreshSubagents = vi.fn();
+    const refreshHierarchicalMemory = vi.fn();
+
+    const config = {
+      getToolRegistry: () => ({ restartMcpServers }),
+      getSkillManager: () => ({ refreshCache: refreshSkills }),
+      getSubagentManager: () => ({ refreshCache: refreshSubagents }),
+      refreshHierarchicalMemory,
+    } as unknown as ExtensionRuntimeRefreshConfig;
+
+    await expect(refreshExtensionRuntime(config)).rejects.toThrow('mcp failed');
+
+    expect(restartMcpServers).toHaveBeenCalledOnce();
+    expect(refreshSkills).not.toHaveBeenCalled();
+    expect(refreshSubagents).not.toHaveBeenCalled();
+    expect(refreshHierarchicalMemory).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/extension/extension-runtime-refresh.test.ts
+++ b/packages/core/src/extension/extension-runtime-refresh.test.ts
@@ -35,4 +35,46 @@ describe('refreshExtensionRuntime', () => {
     expect(refreshSubagents).toHaveBeenCalledOnce();
     expect(refreshHierarchicalMemory).toHaveBeenCalledOnce();
   });
+
+  it('continues when a refreshCache leg rejects', async () => {
+    const restartMcpServers = vi.fn();
+    const refreshSkills = vi.fn().mockRejectedValue(new Error('skills failed'));
+    const refreshSubagents = vi.fn();
+    const refreshHierarchicalMemory = vi.fn();
+
+    const config = {
+      getToolRegistry: () => ({ restartMcpServers }),
+      getSkillManager: () => ({ refreshCache: refreshSkills }),
+      getSubagentManager: () => ({ refreshCache: refreshSubagents }),
+      refreshHierarchicalMemory,
+    } as unknown as ExtensionRuntimeRefreshConfig;
+
+    await expect(refreshExtensionRuntime(config)).resolves.toBeUndefined();
+
+    expect(restartMcpServers).toHaveBeenCalledOnce();
+    expect(refreshSkills).toHaveBeenCalledOnce();
+    expect(refreshSubagents).toHaveBeenCalledOnce();
+    expect(refreshHierarchicalMemory).toHaveBeenCalledOnce();
+  });
+
+  it('resolves when refreshHierarchicalMemory throws', async () => {
+    const restartMcpServers = vi.fn();
+    const refreshSkills = vi.fn();
+    const refreshSubagents = vi.fn();
+
+    const config = {
+      getToolRegistry: () => ({ restartMcpServers }),
+      getSkillManager: () => ({ refreshCache: refreshSkills }),
+      getSubagentManager: () => ({ refreshCache: refreshSubagents }),
+      refreshHierarchicalMemory: vi
+        .fn()
+        .mockRejectedValue(new Error('memory failed')),
+    } as unknown as ExtensionRuntimeRefreshConfig;
+
+    await expect(refreshExtensionRuntime(config)).resolves.toBeUndefined();
+
+    expect(restartMcpServers).toHaveBeenCalledOnce();
+    expect(refreshSkills).toHaveBeenCalledOnce();
+    expect(refreshSubagents).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/core/src/extension/extension-runtime-refresh.test.ts
+++ b/packages/core/src/extension/extension-runtime-refresh.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  refreshExtensionRuntime,
+  type ExtensionRuntimeRefreshConfig,
+} from './extension-runtime-refresh.js';
+
+describe('refreshExtensionRuntime', () => {
+  it('returns early without config', async () => {
+    await expect(refreshExtensionRuntime(undefined)).resolves.not.toThrow();
+  });
+
+  it('refreshes existing extension runtime components', async () => {
+    const restartMcpServers = vi.fn();
+    const refreshSkills = vi.fn();
+    const refreshSubagents = vi.fn();
+    const refreshHierarchicalMemory = vi.fn();
+
+    const config = {
+      getToolRegistry: () => ({ restartMcpServers }),
+      getSkillManager: () => ({ refreshCache: refreshSkills }),
+      getSubagentManager: () => ({ refreshCache: refreshSubagents }),
+      refreshHierarchicalMemory,
+    } as unknown as ExtensionRuntimeRefreshConfig;
+
+    await refreshExtensionRuntime(config);
+
+    expect(restartMcpServers).toHaveBeenCalledOnce();
+    expect(refreshSkills).toHaveBeenCalledOnce();
+    expect(refreshSubagents).toHaveBeenCalledOnce();
+    expect(refreshHierarchicalMemory).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/src/extension/extension-runtime-refresh.ts
+++ b/packages/core/src/extension/extension-runtime-refresh.ts
@@ -22,6 +22,15 @@ export async function refreshExtensionRuntime(
 ): Promise<void> {
   if (!config) return;
 
+  // Error-handling contract:
+  //   Tier 1 (fatal)   — restartMcpServers failure propagates. MCP is a
+  //                       prerequisite for tool discovery; callers must know
+  //                       if it failed so they can surface the error.
+  //   Tier 2 (swallow)  — refreshCache failures (skills, subagents) are
+  //                       logged via warn but swallowed by allSettled.
+  //   Tier 3 (swallow)  — refreshHierarchicalMemory failure is logged via
+  //                       error but swallowed by try/catch.
+  // When adding new refresh steps, decide explicitly which tier applies.
   await config.getToolRegistry().restartMcpServers();
 
   // Refresh skills + subagents in parallel. Both `refreshCache` calls now

--- a/packages/core/src/extension/extension-runtime-refresh.ts
+++ b/packages/core/src/extension/extension-runtime-refresh.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createDebugLogger } from '../utils/debugLogger.js';
+import type { Config } from '../config/config.js';
+
+const debugLogger = createDebugLogger('EXTENSION_RUNTIME_REFRESH');
+
+export type ExtensionRuntimeRefreshConfig = Pick<
+  Config,
+  | 'getToolRegistry'
+  | 'getSkillManager'
+  | 'getSubagentManager'
+  | 'refreshHierarchicalMemory'
+>;
+
+export async function refreshExtensionRuntime(
+  config: ExtensionRuntimeRefreshConfig | undefined,
+): Promise<void> {
+  if (!config) return;
+
+  await config.getToolRegistry().restartMcpServers();
+
+  // Use allSettled so a rejection from one refresh leg does not prevent the
+  // other leg from applying or stop the memory refresh below.
+  const skillManager = config.getSkillManager();
+  const settled = await Promise.allSettled([
+    skillManager?.refreshCache(),
+    config.getSubagentManager().refreshCache(),
+  ]);
+
+  for (const result of settled) {
+    if (result.status === 'rejected') {
+      debugLogger.warn(
+        'refreshExtensionRuntime: a refreshCache leg failed:',
+        result.reason,
+      );
+    }
+  }
+
+  // Await hierarchical memory refresh so callers only continue after the
+  // extension refresh has settled, but do not unwind an already-applied
+  // extension mutation if memory refresh fails.
+  try {
+    await config.refreshHierarchicalMemory();
+  } catch (err) {
+    debugLogger.error(
+      'refreshExtensionRuntime: refreshHierarchicalMemory failed:',
+      err,
+    );
+  }
+}

--- a/packages/core/src/extension/extension-runtime-refresh.ts
+++ b/packages/core/src/extension/extension-runtime-refresh.ts
@@ -24,8 +24,14 @@ export async function refreshExtensionRuntime(
 
   await config.getToolRegistry().restartMcpServers();
 
-  // Use allSettled so a rejection from one refresh leg does not prevent the
-  // other leg from applying or stop the memory refresh below.
+  // Refresh skills + subagents in parallel. Both `refreshCache` calls now
+  // resolve only after their async change-listener chain settles — for skills,
+  // that includes `SkillTool.refreshSkills()` rebuilding the model-facing tool
+  // description and updating `geminiClient`'s tool list. Use allSettled (rather
+  // than Promise.all) so a rejection from one leg does not cascade — the other
+  // leg's result is still applied, refreshHierarchicalMemory below still runs,
+  // and callers (`enableExtension`, etc.) don't unwind because of an unrelated
+  // transient failure.
   const skillManager = config.getSkillManager();
   const settled = await Promise.allSettled([
     skillManager?.refreshCache(),
@@ -42,8 +48,11 @@ export async function refreshExtensionRuntime(
   }
 
   // Await hierarchical memory refresh so callers only continue after the
-  // extension refresh has settled, but do not unwind an already-applied
-  // extension mutation if memory refresh fails.
+  // extension refresh has settled. Wrap in try/catch so a transient failure
+  // doesn't propagate up to `enableExtension` / `installExtension` callers,
+  // which have already mutated their `isActive`/`installed` flags by the time
+  // this function is invoked — a failed memory refresh leaves stale memory
+  // but should not back out the surrounding extension transition.
   try {
     await config.refreshHierarchicalMemory();
   } catch (err) {

--- a/packages/core/src/extension/extensionManager.ts
+++ b/packages/core/src/extension/extensionManager.ts
@@ -98,6 +98,7 @@ import {
 import { loadSkillsFromDir } from '../skills/skill-load.js';
 import { loadSubagentFromDir } from '../subagents/subagent-manager.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import { refreshExtensionRuntime } from './extension-runtime-refresh.js';
 
 const debugLogger = createDebugLogger('EXTENSIONS');
 
@@ -1570,47 +1571,7 @@ export class ExtensionManager {
   }
 
   async refreshMemory(): Promise<void> {
-    if (!this.config) return;
-    // refresh mcp servers
-    await this.config.getToolRegistry().restartMcpServers();
-    // Refresh skills + subagents in parallel. Both `refreshCache` calls
-    // now resolve only after their async change-listener chain settles
-    // — for skills, that includes `SkillTool.refreshSkills()` rebuilding
-    // the model-facing tool description and updating `geminiClient`'s
-    // tool list. allSettled (rather than Promise.all) so a rejection
-    // from one leg does not cascade — the other leg's result is still
-    // applied, refreshHierarchicalMemory below still runs, and the
-    // `refreshTools` callers (`enableExtension`, etc.) don't unwind
-    // because of an unrelated transient failure.
-    const skillManager = this.config.getSkillManager();
-    const settled = await Promise.allSettled([
-      skillManager?.refreshCache(),
-      this.config.getSubagentManager().refreshCache(),
-    ]);
-    for (const result of settled) {
-      if (result.status === 'rejected') {
-        debugLogger.warn(
-          'refreshMemory: a refreshCache leg failed:',
-          result.reason,
-        );
-      }
-    }
-    // Hierarchical memory refresh is now awaited too — the previous
-    // fire-and-forget defeated the rest of the function's "wait until
-    // refresh is done" contract. Wrap in try/catch so a transient
-    // failure doesn't propagate up to `enableExtension` /
-    // `installExtension` callers, which have already mutated their
-    // `isActive`/`installed` flags by the time refreshMemory is
-    // invoked. A failed memory refresh leaves stale memory but should
-    // not back out the surrounding extension transition.
-    try {
-      await this.config.refreshHierarchicalMemory();
-    } catch (err) {
-      debugLogger.error(
-        'refreshMemory: refreshHierarchicalMemory failed:',
-        err,
-      );
-    }
+    await refreshExtensionRuntime(this.config);
   }
 
   async refreshTools(): Promise<void> {


### PR DESCRIPTION
## What this PR does

Extracts the body of `ExtensionManager.refreshMemory()` into a standalone, exported `refreshExtensionRuntime()` function in a new `packages/core/src/extension/extension-runtime-refresh.ts` module. The function takes `ExtensionRuntimeRefreshConfig`, a `Pick<Config, 'getToolRegistry' | 'getSkillManager' | 'getSubagentManager' | 'refreshHierarchicalMemory'>` view of `Config`, so it can run without an `ExtensionManager` instance. `ExtensionManager.refreshMemory()` now just delegates to it. This is a pure extraction: the restart-MCP-servers step, the `Promise.allSettled` refresh of skills/subagents, and the awaited try/catch around hierarchical memory refresh are all preserved exactly as before, with no behavior change.

## Why it's needed

Part of #3696 (comprehensive hot-reload system), specifically the sub-task for a single orchestrator that refreshes subsystem caches and runtime state in a predictable order. Today that refresh logic is inlined inside `ExtensionManager`, which makes it unreachable for planned future call sites: a manual `/reload-plugins` command for external file changes, and additional refresh steps for commands, hooks, and LSP servers. This PR is step 1 of the sequenced plan in `docs/plans/2026-07-01-extension-runtime-refresh-implementation.md` ("Shared Extension Runtime Refresh Orchestrator"): move the current refresh sequence behind one function with no behavior change, so later PRs have a single place to attach the additional refresh steps and model-facing notifications.

## Reviewer Test Plan

### How to verify

Run the existing extension manager suite plus the new orchestrator test, and confirm the project still typechecks cleanly:

```bash
npx vitest run packages/core/src/extension/extensionManager.test.ts packages/core/src/extension/extension-runtime-refresh.test.ts
npm run typecheck
```

Both suites pass (59 tests). Manually, toggling an extension (enable/disable/install/update/uninstall) should still refresh MCP servers, skills, subagents, and hierarchical memory exactly as before — there is no observable behavior change, since `refreshMemory()` now only delegates to the extracted function.

### Evidence (Before & After)

N/A — internal refactor, no user-visible or TUI change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local: `npm run dev` on macOS, Node 22.

## Risk & Scope

- Main risk or tradeoff: none functionally — verified the extraction is behaviorally identical to the original `refreshMemory()` body (same `Promise.allSettled` semantics, same try/catch around `refreshHierarchicalMemory`, same `restartMcpServers` ordering).
- Not validated / out of scope: this PR doesn't change MCP restart cost, and doesn't add command/hook/LSP refresh or model-facing availability notifications — those are the follow-up PRs in the linked plan doc.
- Breaking changes / migration notes: none. `refreshExtensionRuntime` and `ExtensionRuntimeRefreshConfig` are new exports from `extension-runtime-refresh.ts`; they are not yet re-exported from the package barrel, since no consumer outside `packages/core/src/extension/` needs them yet.

## Linked Issues

Part of #3696

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 `ExtensionManager.refreshMemory()` 的方法体抽取成一个独立导出的 `refreshExtensionRuntime()` 函数，放进新文件 `packages/core/src/extension/extension-runtime-refresh.ts`。该函数接收 `ExtensionRuntimeRefreshConfig`，即 `Pick<Config, 'getToolRegistry' | 'getSkillManager' | 'getSubagentManager' | 'refreshHierarchicalMemory'>`，因此可以在没有 `ExtensionManager` 实例的情况下运行。`ExtensionManager.refreshMemory()` 现在只是委托给它。这是一次纯粹的抽取：重启 MCP 服务器的步骤、通过 `Promise.allSettled` 刷新 skills/subagents、以及对 hierarchical memory 刷新的 await + try/catch，行为都与之前完全一致，没有任何变化。

## 为什么需要

属于 #3696（全面的热重载系统）的一部分，具体是其中"统一的缓存/运行时状态刷新编排器"子任务。目前这部分刷新逻辑写死在 `ExtensionManager` 内部，导致未来的调用点（比如面向外部文件变更的手动 `/reload-plugins` 命令，以及 commands/hooks/LSP 的额外刷新步骤）无法复用它。这个 PR 是 `docs/plans/2026-07-01-extension-runtime-refresh-implementation.md` 中规划的第一步（"共享的 Extension Runtime 刷新编排器"）：把现有的刷新流程收进一个函数、不改变任何行为，这样后续 PR 就有了一个统一的地方去挂接更多刷新步骤和面向模型的通知。

## Reviewer Test Plan

（测试步骤同上，此处省略以保持可读性。）

## 风险与范围

- 主要风险与权衡：功能上没有风险——已验证这次抽取与原始 `refreshMemory()` 方法体在行为上完全一致（相同的 `Promise.allSettled` 语义、相同的 `refreshHierarchicalMemory` try/catch、相同的 `restartMcpServers` 执行顺序）。
- 未验证/超出范围：这个 PR 不涉及 MCP 重启开销的优化，也没有加入 commands/hooks/LSP 刷新或面向模型的可用性变更通知——这些都是关联计划文档中后续 PR 的工作。
- Breaking changes / 迁移说明：无。`refreshExtensionRuntime` 和 `ExtensionRuntimeRefreshConfig` 是 `extension-runtime-refresh.ts` 新增的导出，目前还没有从包的 barrel 文件中重新导出，因为暂时没有 `packages/core/src/extension/` 之外的调用方需要它们。

## 关联 Issues

属于 #3696 的一部分

</details>
