### PR TITLE
fix(web-shell): show skill slash commands (e.g. /review) before first prompt

### DIFF
--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -209,6 +209,7 @@ const sdkMocks = vi.hoisted(() => {
     sessions,
     capabilities,
     workspaceProviders,
+    workspaceSkills,
     MockDaemonClient,
     MockDaemonSessionClient,
     workspaceMcpTools,
@@ -421,6 +422,54 @@ describe('DaemonSessionProvider', () => {
       currentMode: 'yolo',
     });
     expect(connection).not.toHaveProperty('sessionId');
+  });
+
+  it('populates skill slash commands during deferred connect (before first prompt)', async () => {
+    sdkMocks.workspaceProviders.mockResolvedValueOnce({
+      v: 1,
+      workspaceCwd: '/mock-workspace',
+      initialized: true,
+      providers: [],
+    });
+    sdkMocks.workspaceSkills.mockResolvedValueOnce({
+      v: 1,
+      workspaceCwd: '/mock-workspace',
+      initialized: true,
+      skills: [
+        {
+          kind: 'skill',
+          status: 'ok',
+          name: 'review',
+          description: 'Review a GitHub pull request',
+          level: 'bundled',
+          modelInvocable: true,
+        },
+      ],
+    });
+    let connection: DaemonConnectionState | undefined;
+
+    function Harness() {
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: undefined,
+    });
+
+    expect(
+      sdkMocks.MockDaemonSessionClient.createOrAttach,
+    ).not.toHaveBeenCalled();
+    expect(connection?.status).toBe('connected');
+    expect(connection).not.toHaveProperty('sessionId');
+    expect(connection?.skills).toEqual(['review']);
+    expect(connection?.commands).toEqual([
+      expect.objectContaining({
+        name: 'review',
+        description: 'Review a GitHub pull request',
+      }),
+    ]);
   });
 
   it('warns when deferred workspace providers fail', async () => {

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -499,6 +499,35 @@ describe('DaemonSessionProvider', () => {
     );
   });
 
+  it('warns when deferred workspace skills fail', async () => {
+    const error = new Error('skills unavailable');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    sdkMocks.workspaceSkills.mockRejectedValueOnce(error);
+    let connection: DaemonConnectionState | undefined;
+
+    function Harness() {
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: undefined,
+    });
+
+    // Skills failing must not block the deferred connect: providers still
+    // resolve and the connection reports connected, just without skill commands.
+    expect(connection).toMatchObject({
+      status: 'connected',
+      workspaceCwd: '/mock-workspace',
+    });
+    expect(connection).not.toHaveProperty('commands');
+    expect(warn).toHaveBeenCalledWith(
+      '[DaemonSessionProvider] workspaceSkills failed in deferred connect:',
+      error,
+    );
+  });
+
   it('preserves a concurrently created session during deferred connect', async () => {
     const providers = createDeferred<unknown>();
     sdkMocks.workspaceProviders.mockReturnValueOnce(providers.promise);

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -46,6 +46,7 @@ import {
   mapProviderStatus,
   mapSessionContextModels,
   mapSupportedCommands,
+  mapWorkspaceSkills,
   updateConnectionFromDaemonEvent,
 } from './mappers.js';
 import {
@@ -421,20 +422,41 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
               !reconnectSessionId &&
               !shouldCreateFreshSession
             ) {
-              const providerResult = await Promise.allSettled([
+              // Fetch skills alongside providers so skill-backed slash
+              // commands (e.g. /review) can autocomplete before the first
+              // prompt. Both are session-less workspace queries; the
+              // session-scoped supported-commands snapshot (which also carries
+              // custom/MCP/workflow commands) still lands once the first prompt
+              // creates a session.
+              const [providerResult, skillsResult] = await Promise.allSettled([
                 client.workspaceProviders(),
+                client.workspaceSkills(),
               ]);
-              if (providerResult[0].status === 'rejected') {
+              if (providerResult.status === 'rejected') {
                 console.warn(
                   '[DaemonSessionProvider] workspaceProviders failed in deferred connect:',
-                  providerResult[0].reason,
+                  providerResult.reason,
+                );
+              }
+              if (skillsResult.status === 'rejected') {
+                console.warn(
+                  '[DaemonSessionProvider] workspaceSkills failed in deferred connect:',
+                  skillsResult.reason,
                 );
               }
               const providers =
-                providerResult[0].status === 'fulfilled'
-                  ? providerResult[0].value
+                providerResult.status === 'fulfilled'
+                  ? providerResult.value
                   : undefined;
               const providerModelStatus = mapProviderStatus(providers);
+              const {
+                commands: deferredSkillCommands,
+                skills: deferredSkills,
+              } = mapWorkspaceSkills(
+                skillsResult.status === 'fulfilled'
+                  ? skillsResult.value
+                  : undefined,
+              );
               setConnection((current) => ({
                 ...current,
                 status: 'connected',
@@ -445,6 +467,12 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                 contextWindow: providerModelStatus.contextWindow,
                 providers,
                 capabilities: caps,
+                ...(deferredSkillCommands.length > 0
+                  ? { commands: deferredSkillCommands }
+                  : {}),
+                ...(deferredSkills.length > 0
+                  ? { skills: deferredSkills }
+                  : {}),
               }));
               return;
             }

--- a/packages/webui/src/daemon/session/mappers.test.ts
+++ b/packages/webui/src/daemon/session/mappers.test.ts
@@ -5,8 +5,15 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import type { DaemonEvent } from '@qwen-code/sdk/daemon';
-import { getReplayTokenCount, getReplayTokenUsage } from './mappers.js';
+import type {
+  DaemonEvent,
+  DaemonWorkspaceSkillsStatus,
+} from '@qwen-code/sdk/daemon';
+import {
+  getReplayTokenCount,
+  getReplayTokenUsage,
+  mapWorkspaceSkills,
+} from './mappers.js';
 
 function usageEvent(
   id: number,
@@ -140,5 +147,65 @@ describe('getReplayTokenCount', () => {
     expect(
       getReplayTokenCount([usageEvent(1, { inputTokens: 500 }), throwing]),
     ).toBe(500);
+  });
+});
+
+describe('mapWorkspaceSkills', () => {
+  it('returns empty commands and skills for undefined status', () => {
+    expect(mapWorkspaceSkills(undefined)).toEqual({ commands: [], skills: [] });
+  });
+
+  it('maps workspace skills into skill slash commands', () => {
+    const status: DaemonWorkspaceSkillsStatus = {
+      v: 1,
+      workspaceCwd: '/ws',
+      initialized: true,
+      skills: [
+        {
+          kind: 'skill',
+          status: 'ok',
+          name: 'review',
+          description: 'Review a GitHub pull request',
+          level: 'bundled',
+          modelInvocable: true,
+          argumentHint: '<pr-number>',
+        },
+        {
+          kind: 'skill',
+          status: 'ok',
+          name: 'deep-research',
+          description: '',
+          level: 'bundled',
+          modelInvocable: true,
+        },
+      ],
+    };
+
+    const result = mapWorkspaceSkills(status);
+
+    expect(result.skills).toEqual(['review', 'deep-research']);
+    expect(result.commands).toEqual([
+      {
+        name: 'review',
+        description: 'Review a GitHub pull request',
+        argumentHint: '<pr-number>',
+        raw: {
+          name: 'review',
+          description: 'Review a GitHub pull request',
+          input: { hint: '<pr-number>' },
+          _meta: { source: 'skill' },
+        },
+      },
+      {
+        name: 'deep-research',
+        description: '',
+        raw: {
+          name: 'deep-research',
+          description: '',
+          input: null,
+          _meta: { source: 'skill' },
+        },
+      },
+    ]);
   });
 });

--- a/packages/webui/src/daemon/session/mappers.ts
+++ b/packages/webui/src/daemon/session/mappers.ts
@@ -11,6 +11,7 @@ import type {
   DaemonSessionContextStatus,
   DaemonSessionSupportedCommandsStatus,
   DaemonWorkspaceProvidersStatus,
+  DaemonWorkspaceSkillsStatus,
 } from '@qwen-code/sdk/daemon';
 import type {
   DaemonCommandInfo,
@@ -158,6 +159,43 @@ export function mapSupportedCommands(
   return {
     commands: mergeCommands(commands, skillCommands),
     skills: status.availableSkills,
+  };
+}
+
+/**
+ * Maps the session-less `/workspace/skills` status into slash-command entries.
+ *
+ * Session creation is deferred until the first prompt, so before any session
+ * exists the only way to populate skill-backed slash commands (e.g. `/review`)
+ * is this workspace-level status, which the daemon answers from `Config`'s
+ * SkillManager without a live session. The shape mirrors the skills portion of
+ * {@link mapSupportedCommands} so the deferred bootstrap and the post-attach
+ * snapshot stay consistent — except workspace status carries real descriptions
+ * and argument hints, which we surface here.
+ */
+export function mapWorkspaceSkills(
+  status: DaemonWorkspaceSkillsStatus | undefined,
+): {
+  commands: DaemonCommandInfo[];
+  skills: string[];
+} {
+  if (!status) return { commands: [], skills: [] };
+
+  const commands = status.skills.map((skill) => ({
+    name: skill.name,
+    description: skill.description || '',
+    ...(skill.argumentHint ? { argumentHint: skill.argumentHint } : {}),
+    raw: {
+      name: skill.name,
+      description: skill.description || '',
+      input: skill.argumentHint ? { hint: skill.argumentHint } : null,
+      _meta: { source: 'skill' },
+    } satisfies DaemonAvailableCommand,
+  }));
+
+  return {
+    commands,
+    skills: status.skills.map((skill) => skill.name),
   };
 }
 


### PR DESCRIPTION
## What this PR does

Restores skill-backed slash-command autocompletion in the Web Shell composer before the first prompt is sent. Typing `/rev` now suggests `/review` (and every other skill) immediately on a fresh session, instead of only after the first message.

The deferred connect path now fetches the session-less `/workspace/skills` status alongside `/workspace/providers` and seeds `connection.commands` / `connection.skills` from it. The full session-scoped supported-commands snapshot — which additionally carries custom, MCP-prompt and workflow commands — still replaces this list once the first prompt creates a session, so nothing is lost.

## Why it's needed

Since session creation was deferred until the first prompt (#6066), the deferred connect path reports `connected` but only fetches workspace providers; it never populates the slash-command list. Before sending a message the composer therefore falls back to the hardcoded local command list (`getLocalCommands`), which contains only the ~32 built-ins and omits every skill. As a result `/rev` did not autocomplete to `/review` on a freshly opened Web Shell, and no skill was completable until after the first prompt. The completion matching itself was fine (`"review".includes("rev")`); the command list was simply empty of skills.

`/workspace/skills` is answered by the daemon from `Config`'s `SkillManager` without a live session (same class as the `/workspace/providers` call the deferred path already makes) and includes bundled skills such as `review`, so it is the natural session-less source for these commands.

## Reviewer Test Plan

### How to verify

1. Start `qwen serve --web` and open the Web Shell on a fresh session (do not send any message yet).
2. Type `/rev` in the composer.
   - Before: no `/review` suggestion appears (only the hardcoded built-ins complete, e.g. `/hel` → `/help`).
   - After: `/review` (and other skills) appear in the completion menu.
3. Send any prompt, then type `/rev` again — `/review` completes in both builds (the session snapshot path was already working; this PR fixes only the pre-first-prompt state).

Automated coverage:

- `packages/webui/src/daemon/session/mappers.test.ts` — new `mapWorkspaceSkills` unit tests (undefined → empty; skills → skill slash commands with descriptions/argument hints).
- `packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx` — new test asserting the deferred connect path populates `connection.commands`/`skills` with a bundled `review` skill and still creates no session.

```
$ npx vitest run   # in packages/webui
Test Files  17 passed (17)
     Tests  242 passed (242)
```

Lint/format: `eslint` and `prettier --check` clean on all four changed files.

### Evidence (Before & After)

Behavior is exercised by the new provider test: on the deferred (no-session) connect it now yields `connection.commands = [{ name: 'review', … }]` and `connection.skills = ['review']`, whereas before neither was set. No standalone TUI/screenshot capture — this is a data-flow fix verified by unit tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

Unit tests + lint run on macOS. The change is platform-agnostic TypeScript in the webui data layer; CI covers Windows/Linux.

### Environment (optional)

`npx vitest run` in `packages/webui`. A full local `tsc --build` was not run because this checkout has pre-existing dependency staleness unrelated to this change (an older installed `simple-git` lacking the `unsafe.allowUnsafeHooksPath` option used by `packages/core`); a clean `npm ci` build in CI is unaffected.

## Risk & Scope

- Main risk or tradeoff: The pre-first-prompt list now includes skills but still not custom `.qwen/commands`, MCP prompts or saved workflows — those require the session-scoped snapshot and continue to appear after the first prompt. This is a strict improvement over the current behavior, not a full restoration of every command type before first prompt.
- Not validated / out of scope: No real-UI/Playwright capture; verified via unit tests. `/workspace/skills` fetch failures degrade gracefully (warn + no skills), matching the existing `/workspace/providers` handling.
- Breaking changes / migration notes: None. `mapWorkspaceSkills` is additive; the deferred `setConnection` only sets `commands`/`skills` when non-empty and they are overwritten by the session snapshot after the first prompt.

## Linked Issues

<!-- No tracked issue; reported via Web Shell composer behavior. Regression from #6066. -->

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

恢复 Web Shell 输入框在「首次发送消息之前」对技能类斜杠命令的自动补全。现在全新会话下输入 `/rev` 会立即补出 `/review`（以及其它所有技能），而不再是只有发过一条消息之后才行。

延迟连接路径现在会在拉取 `/workspace/providers` 的同时，一并拉取无需 session 的 `/workspace/skills` 状态，并据此填充 `connection.commands` / `connection.skills`。首次 prompt 创建 session 后，完整的、按 session 的 supported-commands 快照（额外包含自定义命令、MCP prompt、工作流命令）仍会替换这份列表，不会丢失任何东西。

## 为什么需要

自从 #6066 把 session 创建推迟到首次 prompt 之后，延迟连接路径虽然会报告 `connected`，但只拉取了 workspace providers，从未填充斜杠命令列表。于是在发消息之前，输入框退回到写死的本地命令列表（`getLocalCommands`），它只含约 32 个内置命令、不含任何技能。结果就是全新打开的 Web Shell 里 `/rev` 补不出 `/review`，且首次 prompt 之前任何技能都补不出来。补全匹配逻辑本身没问题（`"review".includes("rev")`），只是命令列表里根本没有技能。

`/workspace/skills` 由 daemon 从 `Config` 的 `SkillManager` 回答，无需活动 session（与延迟路径已经在调用的 `/workspace/providers` 属于同一类），并且包含 `review` 等 bundled 技能，因此是这些命令天然的、无 session 的数据来源。

## 复核测试计划

### 如何验证

1. 启动 `qwen serve --web`，在全新会话打开 Web Shell（先不要发任何消息）。
2. 在输入框输入 `/rev`。
   - 修复前：不出现 `/review` 建议（只有写死的内置命令能补，如 `/hel` → `/help`）。
   - 修复后：`/review`（及其它技能）出现在补全菜单里。
3. 随便发一条 prompt，再输入 `/rev` —— 两个版本都能补出 `/review`（session 快照路径本来就正常；本 PR 只修首次 prompt 之前的状态）。

自动化覆盖：

- `packages/webui/src/daemon/session/mappers.test.ts` —— 新增 `mapWorkspaceSkills` 单测（undefined → 空；技能 → 带描述/参数提示的技能斜杠命令）。
- `packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx` —— 新增测试：延迟连接路径用 bundled `review` 技能填充 `connection.commands`/`skills`，且依然不创建 session。

```
$ npx vitest run   # 在 packages/webui 下
Test Files  17 passed (17)
     Tests  242 passed (242)
```

Lint/格式：四个改动文件的 `eslint` 与 `prettier --check` 均通过。

### 证据（前后对比）

行为由新增的 provider 测试覆盖：延迟（无 session）连接现在产出 `connection.commands = [{ name: 'review', … }]` 与 `connection.skills = ['review']`，而修复前两者都未设置。没有单独的 TUI/截图 —— 这是数据流层面的修复，用单测验证。

### 测试平台

|    系统    | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

单测 + lint 在 macOS 运行。改动是 webui 数据层的平台无关 TypeScript；Windows/Linux 由 CI 覆盖。

### 运行环境（可选）

在 `packages/webui` 下运行 `npx vitest run`。本地没有跑完整的 `tsc --build`：该 checkout 存在与本改动无关的依赖陈旧问题（本地安装的 `simple-git` 版本偏旧，缺少 `packages/core` 用到的 `unsafe.allowUnsafeHooksPath` 选项）；CI 里干净的 `npm ci` 构建不受影响。

## 风险与范围

- 主要风险/取舍：首次 prompt 之前的列表现在包含技能，但仍不含自定义 `.qwen/commands`、MCP prompt、已保存工作流 —— 这些需要按 session 的快照，会在首次 prompt 之后出现。这是相对当前行为的严格改进，而非在首次 prompt 前完整恢复所有命令类型。
- 未验证 / 范围外：没有真实 UI / Playwright 截图，靠单测验证。`/workspace/skills` 拉取失败时优雅降级（warn + 无技能），与既有 `/workspace/providers` 的处理一致。
- 破坏性变更 / 迁移说明：无。`mapWorkspaceSkills` 是纯新增；延迟连接的 `setConnection` 仅在非空时设置 `commands`/`skills`，且首次 prompt 后会被 session 快照覆盖。

## 关联 Issue

无跟踪 issue；通过 Web Shell 输入框行为反馈发现，是 #6066 引入的回归。

</details>
