### PR TITLE
fix(ci): create precheck comments via REST

### DIFF
--- a/.github/workflows/qwen-pr-safety-precheck.yml
+++ b/.github/workflows/qwen-pr-safety-precheck.yml
@@ -89,9 +89,11 @@ jobs:
               -f body="$(cat "$RUNNER_TEMP/pr-precheck-comment.md")" \
               > /dev/null
           else
-            gh pr comment "$PR_NUMBER" \
-              --repo "$GITHUB_REPOSITORY" \
-              --body-file "$RUNNER_TEMP/pr-precheck-comment.md"
+            gh api \
+              --method POST \
+              "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              -f body="$(cat "$RUNNER_TEMP/pr-precheck-comment.md")" \
+              > /dev/null
           fi
 
       - name: 'Clear manual approval comment'


### PR DESCRIPTION
## What this PR does

This PR changes the PR safety precheck's manual-approval comment creation path to use the REST issue comments endpoint instead of `gh pr comment`.

## Why it's needed

After the comment lookup was fixed to stay on GET, fork PR precheck runs can now reach the comment creation path. On PR #6114, run 28561708482 still failed because `gh pr comment` uses GraphQL `addComment`, which was rejected for the workflow token even though the job has `issues: write`. The rest of this workflow already updates and deletes manual-approval comments through the issue comments REST API, so creating the comment through the same API keeps the operation aligned with the granted permission.

## Reviewer Test Plan

### How to verify

Trigger the Qwen Pull Request Review workflow on a fork PR that the safety precheck classifies as requiring manual approval and has no existing manual-approval marker comment. The precheck should create the manual-approval comment through the issue comments API instead of failing with `GraphQL: Resource not accessible by integration (addComment)`.

### Evidence (Before & After)

Before: run 28561708482 on PR #6114 reached the manual-approval comment creation path and failed with `GraphQL: Resource not accessible by integration (addComment)`. After: `actionlint -color=false .github/workflows/qwen-pr-safety-precheck.yml` passes locally.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

Local workflow lint only; no runtime app environment required.

## Risk & Scope

- Main risk or tradeoff: low; the new-comment path now uses the same issue comments REST API family as the existing update and delete paths.
- Not validated / out of scope: a live rerun on a fork PR after merge.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #6114

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 将 PR safety precheck 的人工确认评论创建路径从 `gh pr comment` 改为使用 REST issue comments endpoint。

## Why it's needed

评论查询修复为 GET 之后，fork PR precheck 已经能走到评论创建路径。但 PR #6114 的 run 28561708482 仍然失败，因为 `gh pr comment` 内部使用 GraphQL `addComment`，即使 job 拥有 `issues: write`，该调用仍被 workflow token 拒绝。这个 workflow 里更新和删除人工确认评论本来就走 issue comments REST API，所以创建评论也使用同一组 API，可以与当前授予的权限保持一致。

## Reviewer Test Plan

### How to verify

在一个会被 safety precheck 判定为需要人工确认、且还没有 manual-approval marker 评论的 fork PR 上触发 Qwen Pull Request Review。precheck 应该通过 issue comments API 创建人工确认评论，而不是失败并输出 `GraphQL: Resource not accessible by integration (addComment)`。

### Evidence (Before & After)

Before：PR #6114 的 run 28561708482 走到人工确认评论创建路径后失败，日志包含 `GraphQL: Resource not accessible by integration (addComment)`。After：本地执行 `actionlint -color=false .github/workflows/qwen-pr-safety-precheck.yml` 通过。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

只做了本地 workflow lint；不需要运行时 app 环境。

## Risk & Scope

- Main risk or tradeoff: 风险低；新评论创建路径现在与已有更新、删除路径一样使用 issue comments REST API。
- Not validated / out of scope: merge 后在 fork PR 上真实 rerun。
- Breaking changes / migration notes: 无。

## Linked Issues

Refs #6114

</details>
