### PR TITLE
fix(ci): fall back to latest autofix sandbox image

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -517,6 +517,27 @@ jobs:
                 done
           fi
 
+      - name: 'Select issue sandbox image'
+        id: 'issue_sandbox_image'
+        if: |-
+          ${{ steps.decision.outputs.go_issue != '' }}
+        run: |-
+          qwen_version="$(npm view @qwen-code/qwen-code@latest version)"
+          version_image="ghcr.io/qwenlm/qwen-code:${qwen_version}"
+          fallback_image="ghcr.io/qwenlm/qwen-code:latest"
+          sandbox_image="${version_image}"
+          if docker manifest inspect "${version_image}" > /dev/null 2>&1; then
+            echo "Using sandbox image ${sandbox_image}"
+          elif docker manifest inspect "${fallback_image}" > /dev/null 2>&1; then
+            sandbox_image="${fallback_image}"
+            echo "::warning::Sandbox image ${version_image} is not available; falling back to ${fallback_image}."
+          else
+            echo "::error::Neither sandbox image ${version_image} nor ${fallback_image} is available."
+            exit 1
+          fi
+          echo "QWEN_SANDBOX_IMAGE=${sandbox_image}" >> "${GITHUB_ENV}"
+          echo "qwen_version=${qwen_version}" >> "${GITHUB_OUTPUT}"
+
       - name: 'Claim issue'
         id: 'claim'
         if: |-
@@ -552,6 +573,7 @@ jobs:
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
           OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
           OPENAI_MODEL: '${{ vars.QWEN_PR_REVIEW_MODEL }}'
+          version: '${{ steps.issue_sandbox_image.outputs.qwen_version }}'
           settings_json: |-
             {
               "maxSessionTurns": 400,
@@ -1011,6 +1033,25 @@ jobs:
           echo '--- feedback.md ---'
           cat "${WORKDIR}/feedback.md"
 
+      - name: 'Select review sandbox image'
+        id: 'review_sandbox_image'
+        run: |-
+          qwen_version="$(npm view @qwen-code/qwen-code@latest version)"
+          version_image="ghcr.io/qwenlm/qwen-code:${qwen_version}"
+          fallback_image="ghcr.io/qwenlm/qwen-code:latest"
+          sandbox_image="${version_image}"
+          if docker manifest inspect "${version_image}" > /dev/null 2>&1; then
+            echo "Using sandbox image ${sandbox_image}"
+          elif docker manifest inspect "${fallback_image}" > /dev/null 2>&1; then
+            sandbox_image="${fallback_image}"
+            echo "::warning::Sandbox image ${version_image} is not available; falling back to ${fallback_image}."
+          else
+            echo "::error::Neither sandbox image ${version_image} nor ${fallback_image} is available."
+            exit 1
+          fi
+          echo "QWEN_SANDBOX_IMAGE=${sandbox_image}" >> "${GITHUB_ENV}"
+          echo "qwen_version=${qwen_version}" >> "${GITHUB_OUTPUT}"
+
       - name: 'Triage and address'
         id: 'address'
         uses: 'QwenLM/qwen-code-action@5fd6818d04d64e87d255ee4d5f77995e32fbf4c2'
@@ -1021,6 +1062,7 @@ jobs:
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
           OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
           OPENAI_MODEL: '${{ vars.QWEN_PR_REVIEW_MODEL }}'
+          version: '${{ steps.review_sandbox_image.outputs.qwen_version }}'
           settings_json: |-
             {
               "maxSessionTurns": 400,

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -16,6 +16,14 @@ const filterUnattendedCandidates =
   workflow.match(
     /filter_unattended_candidates\(\) \{[\s\S]*?\n[ ]{12}\}/,
   )?.[0] ?? '';
+const issueSandboxImageStep =
+  workflow.match(
+    /- name: 'Select issue sandbox image'[\s\S]*?(?=\n      - name: 'Claim issue')/,
+  )?.[0] ?? '';
+const reviewSandboxImageStep =
+  workflow.match(
+    /- name: 'Select review sandbox image'[\s\S]*?(?=\n      - name: 'Triage and address')/,
+  )?.[0] ?? '';
 
 describe('qwen-autofix workflow', () => {
   it('does not classify tier-2 issues with incomplete fallback comments', () => {
@@ -136,6 +144,33 @@ describe('qwen-autofix workflow', () => {
     expect(filterUnattendedCandidates).toContain('IN($bots[])');
     expect(filterUnattendedCandidates).not.toContain(
       '.author.login] | map(select',
+    );
+  });
+
+  it('falls back to the floating sandbox image only when the matching version image is missing', () => {
+    expect(issueSandboxImageStep.length).toBeGreaterThan(0);
+    expect(reviewSandboxImageStep.length).toBeGreaterThan(0);
+    for (const step of [issueSandboxImageStep, reviewSandboxImageStep]) {
+      expect(step).toContain('npm view @qwen-code/qwen-code@latest version');
+      expect(step).toContain(
+        'version_image="ghcr.io/qwenlm/qwen-code:${qwen_version}"',
+      );
+      expect(step).toContain('fallback_image="ghcr.io/qwenlm/qwen-code:latest"');
+      expect(step).toContain('docker manifest inspect "${version_image}"');
+      expect(step).toContain('docker manifest inspect "${fallback_image}"');
+      expect(step).toContain('QWEN_SANDBOX_IMAGE=${sandbox_image}');
+      expect(step).toContain(
+        'echo "qwen_version=${qwen_version}" >> "${GITHUB_OUTPUT}"',
+      );
+      expect(step).toContain(
+        '::warning::Sandbox image ${version_image} is not available; falling back to ${fallback_image}.',
+      );
+    }
+    expect(workflow).toContain(
+      "version: '${{ steps.issue_sandbox_image.outputs.qwen_version }}'",
+    );
+    expect(workflow).toContain(
+      "version: '${{ steps.review_sandbox_image.outputs.qwen_version }}'",
     );
   });
 });

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -18,11 +18,11 @@ const filterUnattendedCandidates =
   )?.[0] ?? '';
 const issueSandboxImageStep =
   workflow.match(
-    /- name: 'Select issue sandbox image'[\s\S]*?(?=\n      - name: 'Claim issue')/,
+    /- name: 'Select issue sandbox image'[\s\S]*?(?=\n {6}- name: 'Claim issue')/,
   )?.[0] ?? '';
 const reviewSandboxImageStep =
   workflow.match(
-    /- name: 'Select review sandbox image'[\s\S]*?(?=\n      - name: 'Triage and address')/,
+    /- name: 'Select review sandbox image'[\s\S]*?(?=\n {6}- name: 'Triage and address')/,
   )?.[0] ?? '';
 
 describe('qwen-autofix workflow', () => {


### PR DESCRIPTION
## What this PR does

Adds a preflight sandbox image selection step to the scheduled autofix issue and review paths. The workflow now checks the GHCR image that matches the current npm latest Qwen Code version first, then falls back to the floating `latest` image when the versioned image is missing.

## Why it's needed

The scheduled autofix job can run during the short window where npm has published a new Qwen Code version but the matching GHCR sandbox image is not available yet. That release-ordering gap makes the agent fail before it can start, even though this scheduled maintenance task does not require strict sandbox image/package version parity.

## Reviewer Test Plan

### How to verify

Run the workflow script test and confirm it covers both the versioned image probe and the `latest` fallback. Run actionlint and confirm the workflow remains valid. Optionally run the sandbox image probe locally and confirm it selects the matching versioned image when present, or `ghcr.io/qwenlm/qwen-code:latest` when the versioned image is unavailable.

### Evidence (Before & After)

Before: the failing workflow attempted to use `ghcr.io/qwenlm/qwen-code:0.19.4` and failed when that image was not available yet. After: the workflow checks that exact image first and falls back to `ghcr.io/qwenlm/qwen-code:latest` if needed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local verification used the repository script tests, actionlint, and Docker manifest inspection against GHCR. The smoke check selected `ghcr.io/qwenlm/qwen-code:0.19.4` for current npm latest `0.19.4`.

## Risk & Scope

- Main risk or tradeoff: the fallback image may not exactly match the package version when the versioned image is unavailable, but this is acceptable for the scheduled autofix task and avoids failing before the agent starts.
- Not validated / out of scope: changing the package or container image release pipeline.
- Breaking changes / migration notes: none.

## Linked Issues

Resolves #6157

<details>
<summary>中文说明</summary>

## What this PR does

为定时 autofix 的 issue 阶段和 review 阶段增加 sandbox 镜像选择步骤。workflow 会先检查当前 npm latest Qwen Code 版本对应的 GHCR 镜像；如果该版本镜像缺失，则退回使用浮动的 `latest` 镜像。

## Why it's needed

定时 autofix 任务可能会遇到 npm 新版本已经发布、但对应 GHCR sandbox 镜像还没发布完成的短暂窗口。这个发布顺序差会导致 agent 还没启动就失败；而这个定时维护任务并不需要严格保证 sandbox 镜像和 npm 包版本完全一致。

## Reviewer Test Plan

### How to verify

运行 workflow 脚本测试，确认它覆盖了版本镜像探测和 `latest` fallback。运行 actionlint，确认 workflow 仍然合法。也可以本地运行 sandbox 镜像探测，确认版本镜像存在时选择对应版本，版本镜像缺失时选择 `ghcr.io/qwenlm/qwen-code:latest`。

### Evidence (Before & After)

Before：失败的 workflow 尝试使用 `ghcr.io/qwenlm/qwen-code:0.19.4`，在该镜像还不可用时直接失败。After：workflow 会先检查这个精确版本镜像，并在需要时 fallback 到 `ghcr.io/qwenlm/qwen-code:latest`。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地验证使用了仓库脚本测试、actionlint，以及针对 GHCR 的 Docker manifest inspection。smoke check 在当前 npm latest `0.19.4` 下选中了 `ghcr.io/qwenlm/qwen-code:0.19.4`。

## Risk & Scope

- Main risk or tradeoff：fallback 镜像在版本镜像缺失时可能与 package 版本不完全一致，但这对定时 autofix 任务是可接受的，并且可以避免 agent 启动前失败。
- Not validated / out of scope：不修改 package 或 container image 的发布流水线。
- Breaking changes / migration notes：无。

## Linked Issues

Resolves #6157

</details>