### PR TITLE
fix(ci): allow prechecked fork PR automation

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -300,9 +300,9 @@ jobs:
 
   review-pr:
     needs: ['review-config', 'delay-automatic-review', 'authorize']
-    # pull_request_target routing (every path additionally gated by the
-    # `authorize` job = the principal has write+ permission):
-    # - review_requested checks the requester and skips delay
+    # pull_request_target routing (all paths additionally pass through
+    # `authorize`; automatic PR events are precheck-gated, while explicit
+    # review_requested events check the requester and skip delay):
     # - opened/synchronize uses delay-automatic-review
     # - reopened/ready_for_review runs immediately
     # KEEP IN SYNC with ack-review-request.if (explicit-trigger branches).

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -197,12 +197,9 @@ jobs:
   authorize:
     needs: ['precheck-pr']
     # Single source of truth for "may this trigger spend Qwen command compute".
-    # The principal whose permission decides eligibility is the PR author
-    # (automatic PR events), the commenter (comment command events), or
-    # the requester (review_requested). They must have write+ permission.
-    # This replaces the per-path author_association checks, which are
-    # unreliable for fork PRs (a write user pushing from a fork is reported as
-    # CONTRIBUTOR, not MEMBER), so fork PRs by trusted authors now qualify.
+    # Automatic PR events are allowed after the fork PR precheck above (or for
+    # same-repo PRs). Manual command events and review_requested are still
+    # gated on the actor/requester having write+ permission.
     # Only run for PR-target events and supported command comments — not every
     # unrelated comment — to avoid spawning a job per comment. The downstream
     # `if`s still do the exact command body match; this prefix is just a filter.
@@ -243,7 +240,6 @@ jobs:
           GH_TOKEN: '${{ secrets.CI_BOT_PAT }}'
           EVENT_NAME: '${{ github.event_name }}'
           PR_ACTION: '${{ github.event.action }}'
-          PR_AUTHOR: '${{ github.event.pull_request.user.login }}'
           COMMENT_USER: '${{ github.event.comment.user.login }}'
           REVIEW_USER: '${{ github.event.review.user.login }}'
           SENDER: '${{ github.event.sender.login }}'
@@ -255,7 +251,9 @@ jobs:
               if [ "$PR_ACTION" = "review_requested" ]; then
                 principal="$SENDER"
               else
-                principal="$PR_AUTHOR"
+                echo "Automatic PR review allowed after precheck." >> "$GITHUB_STEP_SUMMARY"
+                echo "should_review=true" >> "$GITHUB_OUTPUT"
+                exit 0
               fi
               ;;
             issue_comment|pull_request_review_comment)

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -243,6 +243,7 @@ jobs:
           COMMENT_USER: '${{ github.event.comment.user.login }}'
           REVIEW_USER: '${{ github.event.review.user.login }}'
           SENDER: '${{ github.event.sender.login }}'
+          PR_NUMBER: '${{ github.event.pull_request.number }}'
         run: |-
           set -euo pipefail
           # Select the principal whose permission gates this trigger.
@@ -251,7 +252,7 @@ jobs:
               if [ "$PR_ACTION" = "review_requested" ]; then
                 principal="$SENDER"
               else
-                echo "Automatic PR review allowed after precheck." >> "$GITHUB_STEP_SUMMARY"
+                echo "Automatic PR review allowed for PR #${PR_NUMBER} after same-repo/precheck gate." >> "$GITHUB_STEP_SUMMARY"
                 echo "should_review=true" >> "$GITHUB_OUTPUT"
                 exit 0
               fi

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -139,7 +139,7 @@ jobs:
           esac
 
   triage:
-    needs: ['authorize']
+    needs: ['authorize', 'precheck-pr']
     timeout-minutes: 30
     concurrency:
       # GitHub evaluates concurrency before the job `if`, but after `needs`.
@@ -150,7 +150,8 @@ jobs:
           (
             (github.event_name == 'pull_request_target' &&
              (github.event.pull_request.draft == true ||
-              needs.authorize.outputs.should_run != 'true')) ||
+              (needs.authorize.outputs.should_run != 'true' &&
+               needs.precheck-pr.outputs.decision != 'allow_triage'))) ||
             (github.event_name == 'issue_comment' &&
              needs.authorize.outputs.should_run != 'true')
           ) &&
@@ -161,10 +162,12 @@ jobs:
         ${{
           github.event_name == 'issues' ||
           github.event_name == 'workflow_dispatch' ||
-          (((github.event_name == 'pull_request_target' &&
-             github.event.pull_request.draft == false) ||
-            (github.event_name == 'issue_comment' &&
-             startsWith(github.event.comment.body, '@qwen-code /triage'))) &&
+          (github.event_name == 'pull_request_target' &&
+           github.event.pull_request.draft == false &&
+           (needs.authorize.outputs.should_run == 'true' ||
+            needs.precheck-pr.outputs.decision == 'allow_triage')) ||
+          (github.event_name == 'issue_comment' &&
+           startsWith(github.event.comment.body, '@qwen-code /triage') &&
            needs.authorize.outputs.should_run == 'true')
         }}
     # Triage is the read-only analysis agent (same security profile as
@@ -177,21 +180,26 @@ jobs:
     runs-on: "${{ (github.repository == 'QwenLM/qwen-code' && vars.MAINTAINER_ECS_RUNNER_DISABLED != 'true') && fromJSON('[\"self-hosted\", \"linux\", \"x64\", \"ecs-qwen\"]') || fromJSON('[\"ubuntu-latest\"]') }}"
     # startsWith (not contains) prevents false triggers from comments that
     # mention the phrase in quoted text or mid-sentence descriptions.
-    # always() so the job still evaluates when the upstream `authorize` job is
-    # skipped (issues / workflow_dispatch paths, which need no permission gate).
+    # always() so the job still evaluates when the upstream `authorize` or
+    # `precheck-pr` job is skipped (issues / workflow_dispatch paths need no
+    # permission gate; same-repo PRs skip precheck).
+    # For pull_request_target: run if the author has write permission OR the
+    # fork PR passed the safety precheck. Triage is read-only (checks out
+    # trusted base code, reads PR via API), so precheck pass is sufficient.
+    # For /triage comments: still require write permission on the commenter.
     if: >-
       always() && (
         github.event_name == 'issues' ||
         (github.event_name == 'workflow_dispatch' &&
          github.event.inputs.number != '' &&
          github.event.inputs.tmux_pr == '') ||
-        (
-          ((github.event_name == 'pull_request_target' &&
-            github.event.pull_request.draft == false) ||
-           (github.event_name == 'issue_comment' &&
-            startsWith(github.event.comment.body, '@qwen-code /triage'))) &&
-          needs.authorize.outputs.should_run == 'true'
-        )
+        (github.event_name == 'pull_request_target' &&
+         github.event.pull_request.draft == false &&
+         (needs.authorize.outputs.should_run == 'true' ||
+          needs.precheck-pr.outputs.decision == 'allow_triage')) ||
+        (github.event_name == 'issue_comment' &&
+         startsWith(github.event.comment.body, '@qwen-code /triage') &&
+         needs.authorize.outputs.should_run == 'true')
       )
     steps:
       - name: 'Acknowledge triage request'

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -39,14 +39,14 @@ jobs:
 
   authorize:
     needs: ['precheck-pr']
-    # Gate the principal on having write+ permission before any agent runs:
-    #   - pull_request_target / `/triage` comment -> gates triage (read-only),
-    #     keyed on the PR author / the commenter respectively.
+    # Gate manual/high-risk entry points on write+ permission before any agent
+    # runs:
+    #   - automatic pull_request_target triage is allowed after the fork PR
+    #     precheck above (or for same-repo PRs).
+    #   - `/triage` comments are keyed on the commenter.
     #   - `/tmux` comment / `tmux_pr` dispatch -> gates real-user testing, which
     #     EXECUTES the PR author's code, so it is keyed on the PR author (whose
     #     code runs), not the commenter/dispatcher (see principal resolution).
-    # Replaces the old eligibility checks based on same-repo PRs and comment
-    # author_association, so fork PRs by trusted authors are covered.
     # The `issues` and `workflow_dispatch`-with-`number` (triage) triggers need
     # no gate: triage is read-only and dispatch already requires write to
     # invoke. But `tmux_pr` dispatch runs the *PR author's* code, not the
@@ -83,15 +83,18 @@ jobs:
           # content; it only reads event metadata and calls one read API.
           GH_TOKEN: '${{ secrets.CI_BOT_PAT }}'
           EVENT_NAME: '${{ github.event_name }}'
-          PR_AUTHOR: '${{ github.event.pull_request.user.login }}'
           COMMENT_USER: '${{ github.event.comment.user.login }}'
           ISSUE_AUTHOR: '${{ github.event.issue.user.login }}'
           COMMENT_BODY: '${{ github.event.comment.body }}'
           TMUX_PR: '${{ github.event.inputs.tmux_pr }}'
         run: |-
           set -euo pipefail
+          if [ "$EVENT_NAME" = "pull_request_target" ]; then
+            echo "Automatic PR triage allowed after precheck." >> "$GITHUB_STEP_SUMMARY"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           case "$EVENT_NAME" in
-            pull_request_target) principal="$PR_AUTHOR" ;;
             issue_comment)
               # /tmux executes the PR AUTHOR's code, so gate on the author's
               # permission (whose code runs), not the commenter's. /triage only
@@ -139,7 +142,7 @@ jobs:
           esac
 
   triage:
-    needs: ['authorize', 'precheck-pr']
+    needs: ['authorize']
     timeout-minutes: 30
     concurrency:
       # GitHub evaluates concurrency before the job `if`, but after `needs`.
@@ -150,8 +153,7 @@ jobs:
           (
             (github.event_name == 'pull_request_target' &&
              (github.event.pull_request.draft == true ||
-              (needs.authorize.outputs.should_run != 'true' &&
-               needs.precheck-pr.outputs.decision != 'allow_triage'))) ||
+              needs.authorize.outputs.should_run != 'true')) ||
             (github.event_name == 'issue_comment' &&
              needs.authorize.outputs.should_run != 'true')
           ) &&
@@ -162,12 +164,10 @@ jobs:
         ${{
           github.event_name == 'issues' ||
           github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'pull_request_target' &&
-           github.event.pull_request.draft == false &&
-           (needs.authorize.outputs.should_run == 'true' ||
-            needs.precheck-pr.outputs.decision == 'allow_triage')) ||
-          (github.event_name == 'issue_comment' &&
-           startsWith(github.event.comment.body, '@qwen-code /triage') &&
+          (((github.event_name == 'pull_request_target' &&
+             github.event.pull_request.draft == false) ||
+            (github.event_name == 'issue_comment' &&
+             startsWith(github.event.comment.body, '@qwen-code /triage'))) &&
            needs.authorize.outputs.should_run == 'true')
         }}
     # Triage is the read-only analysis agent (same security profile as
@@ -180,26 +180,21 @@ jobs:
     runs-on: "${{ (github.repository == 'QwenLM/qwen-code' && vars.MAINTAINER_ECS_RUNNER_DISABLED != 'true') && fromJSON('[\"self-hosted\", \"linux\", \"x64\", \"ecs-qwen\"]') || fromJSON('[\"ubuntu-latest\"]') }}"
     # startsWith (not contains) prevents false triggers from comments that
     # mention the phrase in quoted text or mid-sentence descriptions.
-    # always() so the job still evaluates when the upstream `authorize` or
-    # `precheck-pr` job is skipped (issues / workflow_dispatch paths need no
-    # permission gate; same-repo PRs skip precheck).
-    # For pull_request_target: run if the author has write permission OR the
-    # fork PR passed the safety precheck. Triage is read-only (checks out
-    # trusted base code, reads PR via API), so precheck pass is sufficient.
-    # For /triage comments: still require write permission on the commenter.
+    # always() so the job still evaluates when the upstream `authorize` job is
+    # skipped (issues / workflow_dispatch paths, which need no permission gate).
     if: >-
       always() && (
         github.event_name == 'issues' ||
         (github.event_name == 'workflow_dispatch' &&
          github.event.inputs.number != '' &&
          github.event.inputs.tmux_pr == '') ||
-        (github.event_name == 'pull_request_target' &&
-         github.event.pull_request.draft == false &&
-         (needs.authorize.outputs.should_run == 'true' ||
-          needs.precheck-pr.outputs.decision == 'allow_triage')) ||
-        (github.event_name == 'issue_comment' &&
-         startsWith(github.event.comment.body, '@qwen-code /triage') &&
-         needs.authorize.outputs.should_run == 'true')
+        (
+          ((github.event_name == 'pull_request_target' &&
+            github.event.pull_request.draft == false) ||
+           (github.event_name == 'issue_comment' &&
+            startsWith(github.event.comment.body, '@qwen-code /triage'))) &&
+          needs.authorize.outputs.should_run == 'true'
+        )
       )
     steps:
       - name: 'Acknowledge triage request'

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -33,6 +33,10 @@ jobs:
     if: |-
       github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name != github.repository
+    permissions:
+      contents: 'read'
+      pull-requests: 'read'
+      issues: 'write'
     uses: './.github/workflows/qwen-pr-safety-precheck.yml'
     secrets:
       CI_BOT_PAT: '${{ secrets.CI_BOT_PAT }}'
@@ -86,11 +90,12 @@ jobs:
           COMMENT_USER: '${{ github.event.comment.user.login }}'
           ISSUE_AUTHOR: '${{ github.event.issue.user.login }}'
           COMMENT_BODY: '${{ github.event.comment.body }}'
+          PR_NUMBER: '${{ github.event.pull_request.number }}'
           TMUX_PR: '${{ github.event.inputs.tmux_pr }}'
         run: |-
           set -euo pipefail
           if [ "$EVENT_NAME" = "pull_request_target" ]; then
-            echo "Automatic PR triage allowed after precheck." >> "$GITHUB_STEP_SUMMARY"
+            echo "Automatic PR triage allowed for PR #${PR_NUMBER} after same-repo/precheck gate." >> "$GITHUB_STEP_SUMMARY"
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/scripts/tests/qwen-resolve-workflow.test.js
+++ b/scripts/tests/qwen-resolve-workflow.test.js
@@ -177,6 +177,20 @@ describe('qwen resolve workflow', () => {
       ? workflow.slice(resolveJobStart)
       : workflow.slice(resolveJobStart, resolveJobStart + 1 + nextJob);
   const reviewJob = job(workflow, 'review-pr');
+  const authorizeJob = job(workflow, 'authorize');
+
+  it('does not require fork PR authors to have write permission for automatic review', () => {
+    const authorizeStep = step(
+      authorizeJob,
+      'Check principal write permission',
+    );
+
+    expect(authorizeStep).toContain('pull_request_target)');
+    expect(authorizeStep).toContain(
+      'echo "should_review=true" >> "$GITHUB_OUTPUT"',
+    );
+    expect(authorizeStep).not.toContain('principal="$PR_AUTHOR"');
+  });
 
   it('keeps the authorization and scope guards on resolve-pr', () => {
     // /resolve must require write+ permission before any credentialed push.

--- a/scripts/tests/qwen-resolve-workflow.test.js
+++ b/scripts/tests/qwen-resolve-workflow.test.js
@@ -188,7 +188,13 @@ describe('qwen resolve workflow', () => {
     expect(authorizeJob).toContain(
       "needs.precheck-pr.outputs.decision == 'allow_triage'",
     );
+    expect(authorizeStep).toMatch(
+      /if \[ "\$PR_ACTION" = "review_requested" \]; then\s+principal="\$SENDER"/,
+    );
     expect(authorizeStep).toContain('pull_request_target)');
+    expect(authorizeStep).toContain(
+      'Automatic PR review allowed for PR #${PR_NUMBER} after same-repo/precheck gate.',
+    );
     expect(authorizeStep).toContain(
       'echo "should_review=true" >> "$GITHUB_OUTPUT"',
     );

--- a/scripts/tests/qwen-resolve-workflow.test.js
+++ b/scripts/tests/qwen-resolve-workflow.test.js
@@ -191,6 +191,15 @@ describe('qwen resolve workflow', () => {
     expect(authorizeStep).toMatch(
       /if \[ "\$PR_ACTION" = "review_requested" \]; then\s+principal="\$SENDER"/,
     );
+    const reviewRequestedBranch = authorizeStep.slice(
+      authorizeStep.indexOf('if [ "$PR_ACTION" = "review_requested" ]; then'),
+      authorizeStep.indexOf('else'),
+    );
+    expect(reviewRequestedBranch).toContain('principal="$SENDER"');
+    expect(reviewRequestedBranch).not.toContain(
+      'echo "should_review=true" >> "$GITHUB_OUTPUT"',
+    );
+    expect(reviewRequestedBranch).not.toContain('exit 0');
     expect(authorizeStep).toContain('pull_request_target)');
     expect(authorizeStep).toContain(
       'Automatic PR review allowed for PR #${PR_NUMBER} after same-repo/precheck gate.',

--- a/scripts/tests/qwen-resolve-workflow.test.js
+++ b/scripts/tests/qwen-resolve-workflow.test.js
@@ -185,6 +185,9 @@ describe('qwen resolve workflow', () => {
       'Check principal write permission',
     );
 
+    expect(authorizeJob).toContain(
+      "needs.precheck-pr.outputs.decision == 'allow_triage'",
+    );
     expect(authorizeStep).toContain('pull_request_target)');
     expect(authorizeStep).toContain(
       'echo "should_review=true" >> "$GITHUB_OUTPUT"',

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -36,9 +36,13 @@ function job(name) {
 
 describe('qwen-triage tmux workflow', () => {
   it('does not require fork PR authors to have write permission for automatic triage', () => {
+    const precheckJob = job('precheck-pr');
     const authorizeJob = job('authorize');
     const authorizeStep = step('Check principal write permission');
 
+    expect(precheckJob).toContain("contents: 'read'");
+    expect(precheckJob).toContain("pull-requests: 'read'");
+    expect(precheckJob).toContain("issues: 'write'");
     expect(authorizeJob).toContain(
       "needs.precheck-pr.outputs.decision == 'allow_triage'",
     );
@@ -47,6 +51,9 @@ describe('qwen-triage tmux workflow', () => {
     );
     expect(authorizeStep).toContain(
       'echo "should_run=true" >> "$GITHUB_OUTPUT"',
+    );
+    expect(authorizeStep).toContain(
+      'Automatic PR triage allowed for PR #${PR_NUMBER} after same-repo/precheck gate.',
     );
     expect(authorizeStep).not.toContain(
       'pull_request_target) principal="$PR_AUTHOR"',

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -23,10 +23,25 @@ function step(name) {
   return match?.[0] ?? '';
 }
 
+function job(name) {
+  const start = workflow.indexOf(`\n  ${name}:`);
+  if (start === -1) {
+    return '';
+  }
+  const nextJob = workflow.slice(start + 1).search(/\n {2}\S/);
+  return nextJob === -1
+    ? workflow.slice(start)
+    : workflow.slice(start, start + 1 + nextJob);
+}
+
 describe('qwen-triage tmux workflow', () => {
   it('does not require fork PR authors to have write permission for automatic triage', () => {
+    const authorizeJob = job('authorize');
     const authorizeStep = step('Check principal write permission');
 
+    expect(authorizeJob).toContain(
+      "needs.precheck-pr.outputs.decision == 'allow_triage'",
+    );
     expect(authorizeStep).toContain(
       'if [ "$EVENT_NAME" = "pull_request_target" ]; then',
     );

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -24,6 +24,20 @@ function step(name) {
 }
 
 describe('qwen-triage tmux workflow', () => {
+  it('does not require fork PR authors to have write permission for automatic triage', () => {
+    const authorizeStep = step('Check principal write permission');
+
+    expect(authorizeStep).toContain(
+      'if [ "$EVENT_NAME" = "pull_request_target" ]; then',
+    );
+    expect(authorizeStep).toContain(
+      'echo "should_run=true" >> "$GITHUB_OUTPUT"',
+    );
+    expect(authorizeStep).not.toContain(
+      'pull_request_target) principal="$PR_AUTHOR"',
+    );
+  });
+
   it('escapes embedded tmux artifacts without bash pattern replacement ampersands', () => {
     const postStep = step('Post tmux result comment');
 


### PR DESCRIPTION
## What this PR does

Allows automatic fork PR triage and PR review to continue after the fork safety precheck returns `allow_triage`, without requiring the PR author to have write permission on `QwenLM/qwen-code`.

Manual command paths remain permission-gated: `@qwen-code /triage`, `@qwen-code /review`, `@qwen-code /resolve`, review-requested events, and `/tmux` still require the relevant actor, requester, or PR author to have write+ where appropriate. The triage path now keeps the precheck decision inside `authorize`, so downstream triage only needs to honor `needs.authorize.outputs.should_run`. Workflow regression tests cover both automatic fork PR triage and automatic fork PR review so they cannot accidentally fall back to checking `PR_AUTHOR` write permission again.

## Why it's needed

The original fork safety precheck made fork PR content safe enough for read-only automation, but the later authorization step still denied non-write PR authors. That meant external fork PRs could pass precheck and still skip triage/review, which defeated the purpose of enabling low-cost automation for external contributors.

This keeps the security boundary where it belongs: automatic read-only triage/review is gated by the trusted precheck, while manual commands and code-executing or code-writing paths remain gated by write+ permissions.

## Reviewer Test Plan

### How to verify

Review the workflow conditions and confirm that automatic `pull_request_target` triage/review for fork PRs can proceed only after the fork precheck has returned `allow_triage`. Confirm that manual slash-command paths and high-risk paths still require write+ permission through `authorize`.

For runtime validation after this lands on `main`, open a safe fork PR from a non-write author, or transition an existing safe fork PR from draft to ready for review, and confirm that automatic triage/review reaches the full agent job after precheck passes. Existing PRs do not retroactively rerun just because this PR merges.

### Evidence (Before & After)

Before: PR #6155 passed the fork safety precheck, but `authorize` resolved the PR author `kagura-agent` and denied the run because that user only had `read` permission. The full `triage` job was skipped.

After: automatic `pull_request_target` triage/review no longer checks `PR_AUTHOR` write permission after the precheck gate. The `authorize` job returns `should_run=true` or `should_review=true` for automatic PR events that reached it, while manual and higher-risk entry points continue to check write+ permission.

Local verification:

```bash
npm run test:scripts -- scripts/tests/qwen-triage-workflow.test.js scripts/tests/qwen-resolve-workflow.test.js
npx prettier --check scripts/tests/qwen-triage-workflow.test.js scripts/tests/qwen-resolve-workflow.test.js
actionlint -ignore 'SC2016' -ignore 'unexpected key "deployment"' .github/workflows/qwen-triage.yml .github/workflows/qwen-code-pr-review.yml
git diff --check
```

All four checks passed locally.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Local workflow/unit validation from the PR worktree. Full `pull_request_target` behavior can only be validated after the workflow change is present on `main`.

## Risk & Scope

- Main risk or tradeoff: automatic read-only triage/review can now spend agent compute for external fork PRs when the deterministic safety precheck allows it.
- Not validated / out of scope: retroactive reruns for existing PRs; existing PRs need a new eligible event or a manual slash command.
- Breaking changes / migration notes: none. `/tmux`, `/resolve`, manual review/triage commands, and review-requested events remain permission-gated.

## Linked Issues

Related to #6155 and the fork PR safety precheck follow-up from #5926.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 fork PR 在安全预检返回 `allow_triage` 后，可以继续自动执行 triage 和 PR review，不再要求 PR 作者在 `QwenLM/qwen-code` 仓库拥有 write 权限。

手动命令路径仍然保留权限门控：`@qwen-code /triage`、`@qwen-code /review`、`@qwen-code /resolve`、review-requested 事件和 `/tmux` 仍会按对应 actor、requester 或 PR author 校验 write+。triage 路径现在把 precheck 决策收敛在 `authorize` 内，下游 triage 只需要看 `needs.authorize.outputs.should_run`。同时新增 workflow 回归测试，避免自动 fork PR triage/review 以后又退回到检查 `PR_AUTHOR` write 权限。

## 为什么需要

原来的 fork 安全预检已经让 fork PR 内容足够安全，可以进入只读自动化；但后续 `authorize` 仍然会因为外部 PR 作者没有 write 权限而拒绝运行。结果就是外部 fork PR 即使通过 precheck，也仍然会跳过 triage/review，这和“给外部贡献者低成本自动化”的目标冲突。

这个改动把安全边界放在正确位置：自动只读 triage/review 由可信 precheck gate；手动命令、执行代码或写代码的高风险路径继续由 write+ 权限 gate。

## Reviewer 测试计划

### 如何验证

检查 workflow 条件，确认 fork PR 的自动 `pull_request_target` triage/review 只有在 fork precheck 返回 `allow_triage` 后才会继续。确认手动 slash-command 路径和高风险路径仍然通过 `authorize` 要求 write+ 权限。

合入 `main` 后，可用一个安全的非 write 作者 fork PR，或把已有安全 fork PR 从 draft 切回 ready for review，确认 precheck 通过后会进入 full agent job。已有 PR 不会因为这个 PR 合入而自动 retroactive rerun。

### 证据（Before & After）

Before：PR #6155 通过 fork safety precheck，但 `authorize` 解析到 PR 作者 `kagura-agent` 后，因为该用户只有 `read` 权限而拒绝运行，最终 full `triage` job 被 skipped。

After：自动 `pull_request_target` triage/review 在 precheck gate 后不再检查 `PR_AUTHOR` write 权限。到达 `authorize` 的自动 PR 事件会输出 `should_run=true` 或 `should_review=true`；手动和更高风险入口仍继续检查 write+ 权限。

本地验证：

```bash
npm run test:scripts -- scripts/tests/qwen-triage-workflow.test.js scripts/tests/qwen-resolve-workflow.test.js
npx prettier --check scripts/tests/qwen-triage-workflow.test.js scripts/tests/qwen-resolve-workflow.test.js
actionlint -ignore 'SC2016' -ignore 'unexpected key "deployment"' .github/workflows/qwen-triage.yml .github/workflows/qwen-code-pr-review.yml
git diff --check
```

四个检查都已在本地通过。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### 环境（可选）

在 PR worktree 中做本地 workflow/unit 验证。完整 `pull_request_target` 行为需要等 workflow 变更进入 `main` 后才能验证。

## 风险与范围

- 主要风险或取舍：当确定性安全预检允许时，外部 fork PR 的只读 triage/review 会开始消耗 agent 算力。
- 未验证 / 不在范围内：已有 PR 的 retroactive rerun；已有 PR 需要新的 eligible event 或手动 slash command。
- 破坏性变更 / 迁移说明：无。`/tmux`、`/resolve`、手动 review/triage 命令和 review-requested 事件仍保留权限门控。

## 关联 Issue

关联 #6155，以及 #5926 fork PR safety precheck 的后续修复。

</details>