### PR TITLE
fix(cli): Avoid blocking WebUI sessions on MCP readiness

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -5887,11 +5887,8 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
 
   it('per-session newSession surfaces MCP failures to stderr (round-7 fix: was silent before)', async () => {
     // Round-7 regression: `QwenAgent.initializeConfig()` (per-session ACP
-    // path) calls `waitForMcpReady()` but the round-4 fix only added the
-    // failure warning to the top-level `runAcpAgent` path. Per-session
-    // configs with failed MCP servers silently fell back to built-in
-    // tools with zero user-visible indication, despite the inline comment
-    // claiming "Same reasoning as the top-level runAcpAgent path."
+    // path) reports MCP failures after readiness settles. Per-session configs
+    // with failed MCP servers must not fall back to built-in tools silently.
     const innerConfig = await setupSessionMocks('session-failed-mcp');
     (
       innerConfig as unknown as { getFailedMcpServerNames: () => string[] }
@@ -5920,16 +5917,46 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     // The warning must list both failed servers and mention "Warning:"
     // exactly like the top-level path and the other non-interactive
     // entry points (`gemini.tsx`, `session.ts`).
-    const matchingWrite = stderrWrite.mock.calls.find(
-      ([msg]) =>
-        typeof msg === 'string' &&
-        msg.includes('Warning: MCP server(s) failed to start') &&
-        msg.includes('broken-server-a') &&
-        msg.includes('broken-server-b'),
-    );
-    expect(matchingWrite).toBeDefined();
+    await vi.waitFor(() => {
+      const matchingWrite = stderrWrite.mock.calls.find(
+        ([msg]) =>
+          typeof msg === 'string' &&
+          msg.includes('Warning: MCP server(s) failed to start') &&
+          msg.includes('broken-server-a') &&
+          msg.includes('broken-server-b'),
+      );
+      expect(matchingWrite).toBeDefined();
+    });
 
     stderrWrite.mockRestore();
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('per-session newSession does not wait for MCP readiness', async () => {
+    const innerConfig = await setupSessionMocks('session-mcp-hangs');
+    innerConfig.waitForMcpReady = vi.fn(
+      () => new Promise<void>(() => {}),
+    ) as typeof innerConfig.waitForMcpReady;
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    await expect(
+      agent.newSession({ cwd: '/tmp', mcpServers: [] }),
+    ).resolves.toMatchObject({ sessionId: 'session-mcp-hangs' });
+    expect(innerConfig.waitForMcpReady).toHaveBeenCalledTimes(1);
+
     mockConnectionState.resolve();
     await agentPromise;
   });

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -7701,16 +7701,23 @@ class QwenAgent implements Agent {
       // (the daemon only adds SDK-type runtime servers for client MCP).
       sendSdkMcpMessage: this.buildClientMcpSender(),
     });
-    // Same reasoning as the top-level runAcpAgent path: ACP feeds session
-    // messages to the model immediately, so we cannot return a Config whose
-    // MCP discovery is still in flight.
-    await config.waitForMcpReady();
-    // Surface MCP failures to stderr — mirrors `runAcpAgent` (lines 95-107)
-    // and the other non-interactive entry points (`gemini.tsx`,
-    // `session.ts`). Without this, per-session ACP configs that lose MCP
-    // servers fall back to built-in-tools-only with no user-visible
-    // indication. Defensive against tests that pass a stubbed Config
-    // without `getFailedMcpServerNames`.
+    // ACP sessions served to WebUI clients are interactive: MCP tools can
+    // arrive progressively, but session creation/loading must not wait for a
+    // slow or wedged server discovery.
+    void this.surfaceMcpFailuresWhenReady(config);
+    return config;
+  }
+
+  private async surfaceMcpFailuresWhenReady(config: Config): Promise<void> {
+    try {
+      await config.waitForMcpReady();
+    } catch (err) {
+      debugLogger.error(
+        `MCP discovery readiness failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return;
+    }
+
     const failedMcpServers =
       typeof config.getFailedMcpServerNames === 'function'
         ? config.getFailedMcpServerNames()
@@ -7721,7 +7728,6 @@ class QwenAgent implements Agent {
           `Continuing with built-in tools and any servers that did connect.\n`,
       );
     }
-    return config;
   }
 
   private async ensureAuthenticated(config: Config): Promise<void> {


### PR DESCRIPTION
## What this PR does

This PR lets WebUI/ACP session creation and session loading return after the per-session configuration is initialized instead of waiting for every MCP server discovery pass to settle. MCP discovery still continues for the same session in the background, and MCP failure warnings are still surfaced after readiness settles.

## Why it's needed

A slow or wedged MCP server can currently block the ACP child inside session creation long enough for the bridge's 10s `newSession` deadline to fire. In `qwen serve --open`, that makes both new conversations and historical conversation loads fail with `BridgeTimeoutError: AcpSessionBridge newSession timed out after 10000ms`. The WebUI is interactive, so the better behavior is to make the session usable immediately and let MCP tools become available progressively.

## Reviewer Test Plan

### How to verify

Configure an MCP server that hangs or takes longer than the bridge session creation timeout to complete discovery, then start `qwen serve --open`. Before this change, creating a new WebUI conversation or loading an existing one fails after about 10 seconds with `BridgeTimeoutError`. After this change, the WebUI session should open normally while MCP discovery continues in the background; later turns can use MCP tools that finish loading, and failed MCP servers still produce the existing warning.

### Evidence (Before & After)

Before: reported WebUI failure when a configured MCP server such as `tete` times out during discovery, with `BridgeTimeoutError: AcpSessionBridge newSession timed out after 10000ms`.

After: added a regression test where per-session `waitForMcpReady()` never resolves and `newSession()` still returns the session id.

Local verification:

```bash
cd packages/cli && npx vitest run src/acp-integration/acpAgent.test.ts
npx prettier --check packages/cli/src/acp-integration/acpAgent.ts packages/cli/src/acp-integration/acpAgent.test.ts
npm run build && npm run typecheck
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Local macOS development checkout using the repository npm scripts listed above.

## Risk & Scope

- Main risk or tradeoff: if a user sends the first prompt before a slow MCP server finishes discovery, that prompt will not see tools from that not-yet-ready server; subsequent prompts in the same session can use tools after discovery refreshes the session tool list.
- Not validated / out of scope: manual `~/.qwen/settings.json` MCP hot-reload for already-created WebUI sessions is unchanged and remains separate from this session-creation timeout fix.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让 WebUI/ACP 的新建会话和加载会话在 per-session 配置初始化完成后就返回，不再等待所有 MCP server discovery 完成。MCP discovery 仍会在同一个 session 后台继续执行，readiness settle 后也仍会输出 MCP 失败告警。

## Why it's needed

当前如果某个 MCP server 很慢或卡住，ACP child 会在 session 创建过程中等待 MCP discovery，直到 bridge 的 10 秒 `newSession` deadline 触发。`qwen serve --open` 下这会导致新建对话和加载历史对话都失败，并显示 `BridgeTimeoutError: AcpSessionBridge newSession timed out after 10000ms`。WebUI 是交互式场景，更合理的行为是先让会话可用，再让 MCP tools 渐进加载。

## Reviewer Test Plan

### How to verify

配置一个 discovery 会挂住或超过 bridge session 创建超时的 MCP server，然后启动 `qwen serve --open`。修改前，新建 WebUI 对话或加载历史对话会在大约 10 秒后因为 `BridgeTimeoutError` 失败。修改后，WebUI session 应正常打开，MCP discovery 在后台继续；后续轮次可以使用加载完成的 MCP tools，失败的 MCP server 仍会输出现有告警。

### Evidence (Before & After)

Before：用户报告当配置了类似 `tete` 这种 discovery 超时的 MCP server 时，WebUI 加载失败，错误为 `BridgeTimeoutError: AcpSessionBridge newSession timed out after 10000ms`。

After：新增回归测试，模拟 per-session `waitForMcpReady()` 永不 resolve，并确认 `newSession()` 仍能返回 session id。

本地验证：

```bash
cd packages/cli && npx vitest run src/acp-integration/acpAgent.test.ts
npx prettier --check packages/cli/src/acp-integration/acpAgent.ts packages/cli/src/acp-integration/acpAgent.test.ts
npm run build && npm run typecheck
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

本地 macOS 开发 checkout，使用上面列出的仓库 npm scripts 验证。

## Risk & Scope

- Main risk or tradeoff: 如果用户在慢 MCP server discovery 完成前就发送第一条 prompt，这一轮不会看到尚未 ready 的 server tools；discovery 刷新当前 session 工具列表后，同一 session 的后续 prompt 可以使用这些 tools。
- Not validated / out of scope: 手动修改 `~/.qwen/settings.json` 后让已创建 WebUI session 热更新 MCP 的行为没有改变，这属于独立问题。
- Breaking changes / migration notes: 无。

## Linked Issues

N/A

</details>