### PR TITLE
fix(ci): diagnose autofix publish credentials

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -216,6 +216,21 @@ jobs:
           npm run build
           npm run bundle
 
+      - name: 'Check bot credentials'
+        env:
+          GITHUB_TOKEN: '${{ secrets.CI_DEV_BOT_PAT }}'
+        run: |-
+          if [[ -z "${GITHUB_TOKEN}" ]]; then
+            echo '::error::CI_DEV_BOT_PAT is required to run the issue autofix job.'
+            exit 1
+          fi
+          bot_actor="$(GH_TOKEN="${GITHUB_TOKEN}" gh api user --jq '.login')"
+          echo "CI_DEV_BOT_PAT authenticates as ${bot_actor}"
+          if [[ "${bot_actor}" != "${AUTOFIX_BOT}" ]]; then
+            echo "::error::CI_DEV_BOT_PAT authenticates as ${bot_actor}; expected ${AUTOFIX_BOT}."
+            exit 1
+          fi
+
       - name: 'Find candidate issues'
         id: 'scan'
         env:
@@ -729,7 +744,14 @@ jobs:
             echo '::error::CI_DEV_BOT_PAT is required to publish the PR as qwen-code-dev-bot.'
             exit 1
           fi
+          publish_actor="$(GH_TOKEN="${GITHUB_TOKEN}" gh api user --jq '.login')"
+          echo "CI_DEV_BOT_PAT authenticates as ${publish_actor}"
+          if [[ "${publish_actor}" != "${AUTOFIX_BOT}" ]]; then
+            echo "::error::CI_DEV_BOT_PAT authenticates as ${publish_actor}; expected ${AUTOFIX_BOT}."
+            exit 1
+          fi
           BRANCH="autofix/issue-${ISSUE}"
+          git config --local --unset-all http.https://github.com/.extraheader || true
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git"
           git push --force-with-lease origin "${BRANCH}"
 
@@ -749,11 +771,16 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.CI_DEV_BOT_PAT }}'
           ISSUE: '${{ steps.decision.outputs.go_issue }}'
           COMMENT_ID: '${{ steps.claim.outputs.comment_id }}'
+          PUBLISH_OUTCOME: '${{ steps.publish.outcome }}'
         run: |-
           if [[ -f "${WORKDIR}/failure.md" ]]; then
             REASON='no further automated attempts will be made on this issue.'
             DETAIL="$(head -c 1500 "${WORKDIR}/failure.md")"
             LABEL_ARGS=(--remove-label 'autofix/in-progress' --add-label 'autofix/skip')
+          elif [[ "${PUBLISH_OUTCOME}" == 'failure' ]]; then
+            REASON='the issue will be eligible for a future automated attempt.'
+            DETAIL='The agent produced and verified a fix, but publishing the PR failed. Check the Publish PR step logs for the CI_DEV_BOT_PAT actor and git push error.'
+            LABEL_ARGS=(--remove-label 'autofix/in-progress')
           else
             REASON='the issue will be eligible for a future automated attempt.'
             DETAIL='The run failed before producing a verified fix.'

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -198,6 +198,28 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: 'Check bot credentials'
+        env:
+          GITHUB_TOKEN: '${{ secrets.CI_DEV_BOT_PAT }}'
+        run: |-
+          if [[ -z "${GITHUB_TOKEN}" ]]; then
+            echo '::error::CI_DEV_BOT_PAT is required to run the issue autofix job.'
+            exit 1
+          fi
+          api_error_file="$(mktemp)"
+          if ! bot_actor="$(GH_TOKEN="${GITHUB_TOKEN}" gh api user --jq '.login' 2>"${api_error_file}")"; then
+            api_error="$(tr '\r\n' ' ' < "${api_error_file}")"
+            rm -f "${api_error_file}"
+            echo "::error::Failed to verify CI_DEV_BOT_PAT identity with gh api user: ${api_error:-unknown error}."
+            exit 1
+          fi
+          rm -f "${api_error_file}"
+          echo "CI_DEV_BOT_PAT authenticates as ${bot_actor}"
+          if [[ "${bot_actor}" != "${AUTOFIX_BOT}" ]]; then
+            echo "::error::CI_DEV_BOT_PAT authenticates as ${bot_actor}; expected ${AUTOFIX_BOT}."
+            exit 1
+          fi
+
       - name: 'Set up Node.js'
         uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # v6.4.0
         with:
@@ -215,21 +237,6 @@ jobs:
           npm ci --prefer-offline --no-audit --progress=false
           npm run build
           npm run bundle
-
-      - name: 'Check bot credentials'
-        env:
-          GITHUB_TOKEN: '${{ secrets.CI_DEV_BOT_PAT }}'
-        run: |-
-          if [[ -z "${GITHUB_TOKEN}" ]]; then
-            echo '::error::CI_DEV_BOT_PAT is required to run the issue autofix job.'
-            exit 1
-          fi
-          bot_actor="$(GH_TOKEN="${GITHUB_TOKEN}" gh api user --jq '.login')"
-          echo "CI_DEV_BOT_PAT authenticates as ${bot_actor}"
-          if [[ "${bot_actor}" != "${AUTOFIX_BOT}" ]]; then
-            echo "::error::CI_DEV_BOT_PAT authenticates as ${bot_actor}; expected ${AUTOFIX_BOT}."
-            exit 1
-          fi
 
       - name: 'Find candidate issues'
         id: 'scan'
@@ -744,7 +751,14 @@ jobs:
             echo '::error::CI_DEV_BOT_PAT is required to publish the PR as qwen-code-dev-bot.'
             exit 1
           fi
-          publish_actor="$(GH_TOKEN="${GITHUB_TOKEN}" gh api user --jq '.login')"
+          api_error_file="$(mktemp)"
+          if ! publish_actor="$(GH_TOKEN="${GITHUB_TOKEN}" gh api user --jq '.login' 2>"${api_error_file}")"; then
+            api_error="$(tr '\r\n' ' ' < "${api_error_file}")"
+            rm -f "${api_error_file}"
+            echo "::error::Failed to verify CI_DEV_BOT_PAT identity with gh api user: ${api_error:-unknown error}."
+            exit 1
+          fi
+          rm -f "${api_error_file}"
           echo "CI_DEV_BOT_PAT authenticates as ${publish_actor}"
           if [[ "${publish_actor}" != "${AUTOFIX_BOT}" ]]; then
             echo "::error::CI_DEV_BOT_PAT authenticates as ${publish_actor}; expected ${AUTOFIX_BOT}."
@@ -779,7 +793,7 @@ jobs:
             LABEL_ARGS=(--remove-label 'autofix/in-progress' --add-label 'autofix/skip')
           elif [[ "${PUBLISH_OUTCOME}" == 'failure' ]]; then
             REASON='the issue will be eligible for a future automated attempt.'
-            DETAIL='The agent produced and verified a fix, but publishing the PR failed. Check the Publish PR step logs for the CI_DEV_BOT_PAT actor and git push error.'
+            DETAIL='The agent produced and verified a fix, but publishing the PR failed. Check the Publish PR step logs for the CI_DEV_BOT_PAT actor, git push, PR creation, or PR comment error.'
             LABEL_ARGS=(--remove-label 'autofix/in-progress')
           else
             REASON='the issue will be eligible for a future automated attempt.'
@@ -1241,9 +1255,23 @@ jobs:
             echo '::error::CI_DEV_BOT_PAT is required to push and report as qwen-code-dev-bot.'
             exit 1
           fi
+          api_error_file="$(mktemp)"
+          if ! bot_actor="$(GH_TOKEN="${GITHUB_TOKEN}" gh api user --jq '.login' 2>"${api_error_file}")"; then
+            api_error="$(tr '\r\n' ' ' < "${api_error_file}")"
+            rm -f "${api_error_file}"
+            echo "::error::Failed to verify CI_DEV_BOT_PAT identity with gh api user: ${api_error:-unknown error}."
+            exit 1
+          fi
+          rm -f "${api_error_file}"
+          echo "CI_DEV_BOT_PAT authenticates as ${bot_actor}"
+          if [[ "${bot_actor}" != "${AUTOFIX_BOT}" ]]; then
+            echo "::error::CI_DEV_BOT_PAT authenticates as ${bot_actor}; expected ${AUTOFIX_BOT}."
+            exit 1
+          fi
 
           if [[ "${OUTCOME}" == "fixed" ]]; then
             NEXT_ROUND="$(( ROUND + 1 ))"
+            git config --local --unset-all http.https://github.com/.extraheader || true
             git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git"
             git push --force-with-lease origin "${BRANCH}"
             {

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -16,6 +16,18 @@ const filterUnattendedCandidates =
   workflow.match(
     /filter_unattended_candidates\(\) \{[\s\S]*?\n[ ]{12}\}/,
   )?.[0] ?? '';
+const checkBotCredentialsStep =
+  workflow.match(
+    /- name: 'Check bot credentials'[\s\S]*?(?=\n[ ]{6}- name: 'Find candidate issues')/,
+  )?.[0] ?? '';
+const publishPrStep =
+  workflow.match(
+    /- name: 'Publish PR'[\s\S]*?(?=\n[ ]{6}- name: 'Withdraw claim on failure')/,
+  )?.[0] ?? '';
+const withdrawClaimStep =
+  workflow.match(
+    /- name: 'Withdraw claim on failure'[\s\S]*?(?=\n[ ]{2}# ==========)/,
+  )?.[0] ?? '';
 
 describe('qwen-autofix workflow', () => {
   it('does not classify tier-2 issues with incomplete fallback comments', () => {
@@ -136,6 +148,33 @@ describe('qwen-autofix workflow', () => {
     expect(filterUnattendedCandidates).toContain('IN($bots[])');
     expect(filterUnattendedCandidates).not.toContain(
       '.author.login] | map(select',
+    );
+  });
+
+  it('keeps publish credential failures diagnosable', () => {
+    expect(checkBotCredentialsStep.length).toBeGreaterThan(0);
+    expect(publishPrStep.length).toBeGreaterThan(0);
+    expect(withdrawClaimStep.length).toBeGreaterThan(0);
+    expect(checkBotCredentialsStep).toContain(
+      'GH_TOKEN="${GITHUB_TOKEN}" gh api user --jq \'.login\'',
+    );
+    expect(checkBotCredentialsStep).toContain(
+      'CI_DEV_BOT_PAT authenticates as ${bot_actor}',
+    );
+    expect(publishPrStep).toContain(
+      'GH_TOKEN="${GITHUB_TOKEN}" gh api user --jq \'.login\'',
+    );
+    expect(publishPrStep).toContain(
+      'CI_DEV_BOT_PAT authenticates as ${publish_actor}',
+    );
+    expect(publishPrStep).toContain(
+      'git config --local --unset-all http.https://github.com/.extraheader || true',
+    );
+    expect(withdrawClaimStep).toContain(
+      "PUBLISH_OUTCOME: '${{ steps.publish.outcome }}'",
+    );
+    expect(withdrawClaimStep).toContain(
+      'The agent produced and verified a fix, but publishing the PR failed.',
     );
   });
 });

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -18,11 +18,15 @@ const filterUnattendedCandidates =
   )?.[0] ?? '';
 const checkBotCredentialsStep =
   workflow.match(
-    /- name: 'Check bot credentials'[\s\S]*?(?=\n[ ]{6}- name: 'Find candidate issues')/,
+    /- name: 'Check bot credentials'[\s\S]*?(?=\n[ ]{6}- name: 'Set up Node.js')/,
   )?.[0] ?? '';
 const publishPrStep =
   workflow.match(
     /- name: 'Publish PR'[\s\S]*?(?=\n[ ]{6}- name: 'Withdraw claim on failure')/,
+  )?.[0] ?? '';
+const pushAndReportStep =
+  workflow.match(
+    /- name: 'Push and report'[\s\S]*?(?=\n[ ]{6}- name: 'Report dry-run \/ failure')/,
   )?.[0] ?? '';
 const withdrawClaimStep =
   workflow.match(
@@ -154,9 +158,16 @@ describe('qwen-autofix workflow', () => {
   it('keeps publish credential failures diagnosable', () => {
     expect(checkBotCredentialsStep.length).toBeGreaterThan(0);
     expect(publishPrStep.length).toBeGreaterThan(0);
+    expect(pushAndReportStep.length).toBeGreaterThan(0);
     expect(withdrawClaimStep.length).toBeGreaterThan(0);
+    expect(workflow.indexOf("- name: 'Check bot credentials'")).toBeLessThan(
+      workflow.indexOf("- name: 'Set up Node.js'"),
+    );
     expect(checkBotCredentialsStep).toContain(
       'GH_TOKEN="${GITHUB_TOKEN}" gh api user --jq \'.login\'',
+    );
+    expect(checkBotCredentialsStep).toContain(
+      'Failed to verify CI_DEV_BOT_PAT identity with gh api user',
     );
     expect(checkBotCredentialsStep).toContain(
       'CI_DEV_BOT_PAT authenticates as ${bot_actor}',
@@ -168,6 +179,18 @@ describe('qwen-autofix workflow', () => {
       'CI_DEV_BOT_PAT authenticates as ${publish_actor}',
     );
     expect(publishPrStep).toContain(
+      'Failed to verify CI_DEV_BOT_PAT identity with gh api user',
+    );
+    expect(publishPrStep).toContain(
+      'git config --local --unset-all http.https://github.com/.extraheader || true',
+    );
+    expect(pushAndReportStep).toContain(
+      'GH_TOKEN="${GITHUB_TOKEN}" gh api user --jq \'.login\'',
+    );
+    expect(pushAndReportStep).toContain(
+      'CI_DEV_BOT_PAT authenticates as ${bot_actor}',
+    );
+    expect(pushAndReportStep).toContain(
       'git config --local --unset-all http.https://github.com/.extraheader || true',
     );
     expect(withdrawClaimStep).toContain(
@@ -175,6 +198,9 @@ describe('qwen-autofix workflow', () => {
     );
     expect(withdrawClaimStep).toContain(
       'The agent produced and verified a fix, but publishing the PR failed.',
+    );
+    expect(withdrawClaimStep).toContain(
+      'git push, PR creation, or PR comment error',
     );
   });
 });


### PR DESCRIPTION
## What this PR does

Adds a publish-time credential identity check to the scheduled autofix issue flow before it pushes the generated branch and opens a pull request. It also clears any local GitHub extraheader before setting the PAT-backed remote URL, and makes the claim-withdrawal comment distinguish PR publication failures from agent or verification failures.

## Why it's needed

A recent autofix run for #5979 generated and verified a fix, but failed in the final publish step with GitHub reporting the actor as `github-actions[bot]`. The workflow expected `CI_DEV_BOT_PAT` to authenticate as `qwen-code-dev-bot`, so the current logs made it hard to tell whether the secret value was wrong or Git credentials were being overridden.

## Reviewer Test Plan

### How to verify

Run the qwen-autofix workflow script test and confirm the publish credential contract is covered. Run actionlint and confirm the workflow remains valid. For live verification, dispatch this workflow from the PR branch and inspect the `Publish PR` logs for `CI_DEV_BOT_PAT authenticates as ...` before any push attempt.

### Evidence (Before & After)

Before: the workflow failed at `git push --force-with-lease` with `Permission to QwenLM/qwen-code.git denied to github-actions[bot]`, while the issue comment said the run failed before producing a verified fix. After: the publish step logs the authenticated actor up front and the withdrawal comment reports PR publication failure when the agent already produced and verified a fix.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local verification used repository script tests and actionlint.

## Risk & Scope

- Main risk or tradeoff: this intentionally fails earlier when `CI_DEV_BOT_PAT` authenticates as an unexpected actor, so credential misconfiguration becomes explicit instead of failing later during push.
- Not validated / out of scope: changing or rotating the repository secret itself.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #5979

<details>
<summary>中文说明</summary>

## What this PR does

在定时 autofix 的 issue 发布链路里，push 生成分支并创建 PR 之前，增加凭据身份检查。它还会在设置 PAT remote URL 前清理本地 GitHub extraheader，并让撤回 claim 的评论区分 PR 发布失败和 agent / verification 失败。

## Why it's needed

#5979 的一次 autofix run 已经生成并验证了修复，但最后发布步骤失败，GitHub 报告 actor 是 `github-actions[bot]`。workflow 预期 `CI_DEV_BOT_PAT` 应该认证为 `qwen-code-dev-bot`，所以之前日志很难直接判断是 secret 值不对，还是 Git 凭据被覆盖。

## Reviewer Test Plan

### How to verify

运行 qwen-autofix workflow 脚本测试，确认 publish credential 契约被覆盖。运行 actionlint，确认 workflow 仍然合法。线上验证时，从这个 PR 分支 dispatch workflow，并在 `Publish PR` 日志里检查 push 前的 `CI_DEV_BOT_PAT authenticates as ...` 输出。

### Evidence (Before & After)

Before：workflow 在 `git push --force-with-lease` 失败，报 `Permission to QwenLM/qwen-code.git denied to github-actions[bot]`，但 issue 评论却说 run 在产出 verified fix 前失败。After：publish 步骤会先打印认证 actor；如果 agent 已经产出并验证修复但 PR 发布失败，撤回评论会明确说明是 PR publication failure。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地验证使用了仓库脚本测试和 actionlint。

## Risk & Scope

- Main risk or tradeoff：如果 `CI_DEV_BOT_PAT` 认证成非预期 actor，这个改动会更早失败，让凭据误配置变得明确，而不是等到 push 时失败。
- Not validated / out of scope：不修改或轮换 repository secret 本身。
- Breaking changes / migration notes：无。

## Linked Issues

Refs #5979

</details>