### PR TITLE
fix(web-shell): improve disconnected composer handling

### DIFF
--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -126,6 +126,11 @@ import {
   createAndAttachSessionForPrompt,
   isDaemonApprovalMode,
 } from './utils/sessionPreparation';
+import {
+  getComposerPlaceholderKey,
+  shouldBlockComposerSubmit,
+  shouldDisableComposerInput,
+} from './utils/composerInputState';
 import type { ACPToolCall, Message, PermissionRequest } from './adapters/types';
 import {
   computeTodoDetails,
@@ -2195,6 +2200,14 @@ export function App({
 
   const handleSubmit = useCallback(
     (text: string, images?: PromptImage[]) => {
+      if (
+        shouldBlockComposerSubmit({
+          connectionStatus: connectionRef.current.status,
+        })
+      ) {
+        pushToast('warning', t('editor.connectionDisconnected'));
+        return false;
+      }
       const promptBlocked = streamingStateRef.current !== 'idle';
       const submitPromptFromEditor = (
         promptText: string,
@@ -3227,7 +3240,11 @@ export function App({
     };
   }, [resetEscapeState]);
 
-  const isDisabled = !connected || connection.catchingUp;
+  const isDisabled = shouldDisableComposerInput({
+    catchingUp: Boolean(connection.catchingUp),
+    pendingApproval: pendingApproval !== null,
+    isPreparingPrompt,
+  });
 
   const handleModelSelect = useCallback(
     (modelId: string) => {
@@ -3857,11 +3874,7 @@ export function App({
                       isRunning={streamingState !== 'idle'}
                       isPreparing={isPreparingPrompt}
                       cancelArmed={cancelArmed}
-                      disabled={
-                        isDisabled ||
-                        pendingApproval !== null ||
-                        isPreparingPrompt
-                      }
+                      disabled={isDisabled}
                       commands={commands}
                       skills={loadedSkills}
                       slashCommandCategoryOrder={slashCommandCategoryOrder}
@@ -3886,13 +3899,14 @@ export function App({
                       onDismissFollowup={onDismissFollowup}
                       composerInput={composerInput}
                       composerInputVersion={composerInputVersion}
-                      placeholderText={
-                        !connected || connection.catchingUp
-                          ? t('common.loading')
-                          : isPreparingPrompt || streamingState !== 'idle'
-                            ? t('editor.processing')
-                            : t('editor.placeholder')
-                      }
+                      placeholderText={t(
+                        getComposerPlaceholderKey({
+                          catchingUp: Boolean(connection.catchingUp),
+                          connectionStatus: connection.status,
+                          isPreparingPrompt,
+                          isStreaming: streamingState !== 'idle',
+                        }),
+                      )}
                     />
                   </div>
                   {CustomFooter ? (

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -3902,7 +3902,6 @@ export function App({
                       placeholderText={t(
                         getComposerPlaceholderKey({
                           catchingUp: Boolean(connection.catchingUp),
-                          connectionStatus: connection.status,
                           isPreparingPrompt,
                           isStreaming: streamingState !== 'idle',
                         }),

--- a/packages/web-shell/client/components/ToastHost.module.css
+++ b/packages/web-shell/client/components/ToastHost.module.css
@@ -57,32 +57,16 @@
 
 .info {
   border-left-color: var(--agent-blue-500);
-  background-image: linear-gradient(
-    color-mix(in srgb, var(--agent-blue-500) 16%, transparent),
-    color-mix(in srgb, var(--agent-blue-500) 16%, transparent)
-  );
 }
 
 .success {
   border-left-color: var(--success-color);
-  background-image: linear-gradient(
-    color-mix(in srgb, var(--success-color) 16%, transparent),
-    color-mix(in srgb, var(--success-color) 16%, transparent)
-  );
 }
 
 .warning {
   border-left-color: var(--warning-color);
-  background-image: linear-gradient(
-    color-mix(in srgb, var(--warning-color) 18%, transparent),
-    color-mix(in srgb, var(--warning-color) 18%, transparent)
-  );
 }
 
 .error {
   border-left-color: var(--error-color);
-  background-image: linear-gradient(
-    color-mix(in srgb, var(--error-color) 18%, transparent),
-    color-mix(in srgb, var(--error-color) 18%, transparent)
-  );
 }

--- a/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.module.css
+++ b/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.module.css
@@ -1,11 +1,10 @@
 .wrap {
-  margin: 8px 0;
+  margin: 0;
 }
 
 .summary {
   width: 100%;
   margin: 0;
-  padding: 2px 0;
   border: none;
   border-radius: 0;
   background: transparent;
@@ -69,7 +68,6 @@
 }
 
 .summaryTextActive {
-  color: var(--muted-foreground);
   background-image: linear-gradient(
     105deg,
     var(--muted-foreground) 0%,

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -382,6 +382,9 @@ const EN: Messages = {
   'editor.placeholder': 'Type a message or @ file path',
   'editor.shellPlaceholder': 'Enter terminal command',
   'editor.send': 'Send message',
+  'editor.connectionDisconnected':
+    'Connection interrupted. Please try again after it reconnects.',
+  'editor.reconnecting': 'Reconnecting. Messages cannot be sent yet.',
   'editor.processing': 'Processing. New messages will be queued.',
   'editor.searchHint': 'ctrl+r next · tab accept · enter send · esc cancel',
   'editor.searchLabel': 'reverse-i-search:',
@@ -1595,6 +1598,8 @@ const ZH: Messages = {
   'editor.placeholder': '输入消息或 @ 文件路径',
   'editor.shellPlaceholder': '请输入终端命令',
   'editor.send': '发送消息',
+  'editor.connectionDisconnected': '连接已中断，请在恢复后重试。',
+  'editor.reconnecting': '正在重新连接，暂时无法发送消息。',
   'editor.processing': '处理中。新消息会进入队列。',
   'editor.searchHint': 'ctrl+r 下一条 · tab 采纳 · enter 发送 · esc 取消',
   'editor.searchLabel': '历史搜索：',

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -384,7 +384,6 @@ const EN: Messages = {
   'editor.send': 'Send message',
   'editor.connectionDisconnected':
     'Connection interrupted. Please try again after it reconnects.',
-  'editor.reconnecting': 'Reconnecting. Messages cannot be sent yet.',
   'editor.processing': 'Processing. New messages will be queued.',
   'editor.searchHint': 'ctrl+r next · tab accept · enter send · esc cancel',
   'editor.searchLabel': 'reverse-i-search:',
@@ -1599,7 +1598,6 @@ const ZH: Messages = {
   'editor.shellPlaceholder': '请输入终端命令',
   'editor.send': '发送消息',
   'editor.connectionDisconnected': '连接已中断，请在恢复后重试。',
-  'editor.reconnecting': '正在重新连接，暂时无法发送消息。',
   'editor.processing': '处理中。新消息会进入队列。',
   'editor.searchHint': 'ctrl+r 下一条 · tab 采纳 · enter 发送 · esc 取消',
   'editor.searchLabel': '历史搜索：',

--- a/packages/web-shell/client/utils/composerInputState.test.ts
+++ b/packages/web-shell/client/utils/composerInputState.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getComposerPlaceholderKey,
+  shouldBlockComposerSubmit,
+  shouldDisableComposerInput,
+} from './composerInputState';
+
+describe('composer input state', () => {
+  it('keeps the composer editable while the SSE connection is disconnected', () => {
+    expect(
+      shouldDisableComposerInput({
+        catchingUp: false,
+        pendingApproval: false,
+        isPreparingPrompt: false,
+      }),
+    ).toBe(false);
+    expect(
+      getComposerPlaceholderKey({
+        catchingUp: false,
+        connectionStatus: 'disconnected',
+        isPreparingPrompt: false,
+        isStreaming: false,
+      }),
+    ).toBe('editor.reconnecting');
+    expect(
+      getComposerPlaceholderKey({
+        catchingUp: false,
+        connectionStatus: 'connected',
+        isPreparingPrompt: false,
+        isStreaming: false,
+      }),
+    ).toBe('editor.placeholder');
+  });
+
+  it('keeps loading state only for catch-up or prompt preparation', () => {
+    expect(
+      shouldDisableComposerInput({
+        catchingUp: true,
+        pendingApproval: false,
+        isPreparingPrompt: false,
+      }),
+    ).toBe(true);
+    expect(
+      getComposerPlaceholderKey({
+        catchingUp: true,
+        connectionStatus: 'connected',
+        isPreparingPrompt: false,
+        isStreaming: false,
+      }),
+    ).toBe('common.loading');
+
+    expect(
+      shouldDisableComposerInput({
+        catchingUp: false,
+        pendingApproval: false,
+        isPreparingPrompt: true,
+      }),
+    ).toBe(true);
+    expect(
+      getComposerPlaceholderKey({
+        catchingUp: false,
+        connectionStatus: 'connected',
+        isPreparingPrompt: true,
+        isStreaming: false,
+      }),
+    ).toBe('editor.processing');
+  });
+
+  it('shows processing placeholder while streaming', () => {
+    expect(
+      getComposerPlaceholderKey({
+        catchingUp: false,
+        connectionStatus: 'connected',
+        isPreparingPrompt: false,
+        isStreaming: true,
+      }),
+    ).toBe('editor.processing');
+  });
+
+  it('still disables editing for pending approvals', () => {
+    expect(
+      shouldDisableComposerInput({
+        catchingUp: false,
+        pendingApproval: true,
+        isPreparingPrompt: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('blocks submit only after the connection reaches a failed state', () => {
+    expect(
+      shouldBlockComposerSubmit({
+        connectionStatus: 'disconnected',
+      }),
+    ).toBe(true);
+    expect(
+      shouldBlockComposerSubmit({
+        connectionStatus: 'error',
+      }),
+    ).toBe(true);
+    expect(
+      shouldBlockComposerSubmit({
+        connectionStatus: 'connecting',
+      }),
+    ).toBe(false);
+    expect(
+      shouldBlockComposerSubmit({
+        connectionStatus: 'connected',
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/web-shell/client/utils/composerInputState.test.ts
+++ b/packages/web-shell/client/utils/composerInputState.test.ts
@@ -17,15 +17,13 @@ describe('composer input state', () => {
     expect(
       getComposerPlaceholderKey({
         catchingUp: false,
-        connectionStatus: 'disconnected',
         isPreparingPrompt: false,
         isStreaming: false,
       }),
-    ).toBe('editor.reconnecting');
+    ).toBe('editor.placeholder');
     expect(
       getComposerPlaceholderKey({
         catchingUp: false,
-        connectionStatus: 'connected',
         isPreparingPrompt: false,
         isStreaming: false,
       }),
@@ -43,7 +41,6 @@ describe('composer input state', () => {
     expect(
       getComposerPlaceholderKey({
         catchingUp: true,
-        connectionStatus: 'connected',
         isPreparingPrompt: false,
         isStreaming: false,
       }),
@@ -59,7 +56,6 @@ describe('composer input state', () => {
     expect(
       getComposerPlaceholderKey({
         catchingUp: false,
-        connectionStatus: 'connected',
         isPreparingPrompt: true,
         isStreaming: false,
       }),
@@ -70,7 +66,6 @@ describe('composer input state', () => {
     expect(
       getComposerPlaceholderKey({
         catchingUp: false,
-        connectionStatus: 'connected',
         isPreparingPrompt: false,
         isStreaming: true,
       }),

--- a/packages/web-shell/client/utils/composerInputState.ts
+++ b/packages/web-shell/client/utils/composerInputState.ts
@@ -19,24 +19,15 @@ export function shouldDisableComposerInput({
 
 export function getComposerPlaceholderKey({
   catchingUp,
-  connectionStatus,
   isPreparingPrompt,
   isStreaming,
 }: {
   catchingUp: boolean;
-  connectionStatus: ComposerConnectionStatus;
   isPreparingPrompt: boolean;
   isStreaming: boolean;
-}):
-  | 'common.loading'
-  | 'editor.processing'
-  | 'editor.reconnecting'
-  | 'editor.placeholder' {
+}): 'common.loading' | 'editor.processing' | 'editor.placeholder' {
   if (catchingUp) return 'common.loading';
   if (isPreparingPrompt || isStreaming) return 'editor.processing';
-  if (connectionStatus === 'disconnected' || connectionStatus === 'error') {
-    return 'editor.reconnecting';
-  }
   return 'editor.placeholder';
 }
 

--- a/packages/web-shell/client/utils/composerInputState.ts
+++ b/packages/web-shell/client/utils/composerInputState.ts
@@ -1,0 +1,49 @@
+type ComposerConnectionStatus =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'disconnected'
+  | 'error';
+
+export function shouldDisableComposerInput({
+  catchingUp,
+  pendingApproval,
+  isPreparingPrompt,
+}: {
+  catchingUp: boolean;
+  pendingApproval: boolean;
+  isPreparingPrompt: boolean;
+}): boolean {
+  return Boolean(catchingUp || pendingApproval || isPreparingPrompt);
+}
+
+export function getComposerPlaceholderKey({
+  catchingUp,
+  connectionStatus,
+  isPreparingPrompt,
+  isStreaming,
+}: {
+  catchingUp: boolean;
+  connectionStatus: ComposerConnectionStatus;
+  isPreparingPrompt: boolean;
+  isStreaming: boolean;
+}):
+  | 'common.loading'
+  | 'editor.processing'
+  | 'editor.reconnecting'
+  | 'editor.placeholder' {
+  if (catchingUp) return 'common.loading';
+  if (isPreparingPrompt || isStreaming) return 'editor.processing';
+  if (connectionStatus === 'disconnected' || connectionStatus === 'error') {
+    return 'editor.reconnecting';
+  }
+  return 'editor.placeholder';
+}
+
+export function shouldBlockComposerSubmit({
+  connectionStatus,
+}: {
+  connectionStatus: ComposerConnectionStatus;
+}): boolean {
+  return connectionStatus === 'disconnected' || connectionStatus === 'error';
+}


### PR DESCRIPTION
## What this PR does

This PR keeps the web shell composer editable when the session event stream disconnects, while preventing disconnected submissions from being treated like normal sends. When the connection reaches a disconnected or error state, the composer now shows a reconnecting placeholder and pressing Enter or clicking send keeps the draft in place while showing a warning toast. It also simplifies toast styling so severity is indicated by the left color rail only, and tightens the parallel agents summary hover treatment so the whole summary text responds consistently without adding a hover background.

## Why it's needed

Frequent SSE disconnects could leave the composer feeling stuck or misleading: the input could be disabled by a transient stream break, or later look normal even though sending would fail. The updated behavior lets users continue drafting through reconnects, gives a clear reconnecting state, and preserves their text if they try to submit too early. The style updates make related web shell feedback less visually heavy and more consistent.

## Reviewer Test Plan

### How to verify

Open the web shell against a daemon session and interrupt the session event stream. The composer should remain editable, the placeholder should indicate that the connection is reconnecting, and pressing Enter or clicking send should show a warning toast while leaving the typed message in the input. After the stream reconnects, normal sends should work again. For the style changes, trigger any toast and confirm only the left rail changes by severity, then hover a parallel agents summary row and confirm the summary text/icon color changes without a background block.

### Evidence (Before & After)

Before: A transient SSE disconnect could make the composer show a loading/disabled state or otherwise appear normal while send failed generically. Toast severity also tinted the full notification background, and the parallel agents summary hover treatment was inconsistent across the row.

After: The composer stays editable during disconnects, disconnected submissions are blocked with a reconnect warning while preserving the draft, toast severity uses only the left color rail, and parallel agents summary hover uses text/icon color only.

Local verification: `cd packages/web-shell && npx vitest run client/utils/composerInputState.test.ts client/components/MessageList.test.ts` passed with 89 tests. `npm run build --workspace @qwen-code/web-shell` passed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local macOS workspace using the web-shell package test/build commands.

## Risk & Scope

- Main risk or tradeoff: Users can still type while disconnected, but submit is intentionally blocked until the session connection is back in a usable state.
- Not validated / out of scope: Manual browser verification on Windows and Linux was not performed locally.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 在会话事件流断开时保持 web shell 输入框可编辑，同时避免断连状态下的发送被当成普通发送处理。当连接进入 disconnected 或 error 状态时，输入框会显示正在重连的占位提示；按 Enter 或点击发送会保留草稿并显示 warning toast。这个 PR 也简化了 toast 样式，让状态只通过左侧色条区分，并收紧了并行智能体摘要行的 hover 效果，使整行文字和图标一致变色但不增加 hover 背景。

## Why it's needed

频繁的 SSE 断连会让输入体验卡住或产生误导：输入框可能因为短暂断流被禁用，或者看起来正常但发送失败。新的行为允许用户在重连期间继续编辑，明确展示重连状态，并在用户过早发送时保留输入内容。样式调整让 web shell 的反馈更轻量，也更一致。

## Reviewer Test Plan

### How to verify

打开 web shell 并连接 daemon session，然后中断 session event stream。输入框应该保持可编辑，占位文案应该提示正在重连；按 Enter 或点击发送应该显示 warning toast，并保留输入框里的内容。事件流恢复后，正常发送应该继续可用。样式方面，触发任意 toast，确认不同状态只改变左侧色条；再 hover 并行智能体摘要行，确认摘要文字和图标变色，但没有背景块。

### Evidence (Before & After)

Before：短暂 SSE 断连可能让输入框显示 loading/disabled 状态，或者看起来正常但发送时只出现通用失败。toast 状态会给整条通知增加背景 tint，并行智能体摘要行的 hover 效果也不够一致。

After：断连期间输入框保持可编辑，断连状态下发送会被拦截并显示重连提示，同时保留草稿；toast 状态只使用左侧色条；并行智能体摘要行 hover 只使用文字和图标变色。

本地验证：`cd packages/web-shell && npx vitest run client/utils/composerInputState.test.ts client/components/MessageList.test.ts` 通过，合计 89 个测试。`npm run build --workspace @qwen-code/web-shell` 通过。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

本地 macOS workspace，使用 web-shell package 的测试和 build 命令验证。

## Risk & Scope

- Main risk or tradeoff：用户在断连时仍然可以输入，但发送会被有意拦截，直到会话连接恢复到可用状态。
- Not validated / out of scope：没有在本地手动验证 Windows 和 Linux 浏览器环境。
- Breaking changes / migration notes：无。

## Linked Issues

N/A

</details>
