### PR TITLE
fix(serve): keep skill slash commands available when the ACP child is unavailable

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -157,6 +157,7 @@ import {
   loadCliConfig,
 } from '../config/config.js';
 import { extractRememberErrorCode } from '../serve/workspace-remember-errors.js';
+import { mapSkillConfigToStatus } from '../serve/workspace-skills-mapping.js';
 import { Session, buildAvailableCommandsSnapshot } from './session/Session.js';
 import { buildSessionTasksStatus } from './session/tasksSnapshot.js';
 import { HistoryReplayer } from './session/HistoryReplayer.js';
@@ -216,7 +217,6 @@ import {
   type ServeWorkspaceProviderModel,
   type ServeWorkspaceProviderStatus,
   type ServeWorkspaceProvidersStatus,
-  type ServeWorkspaceSkillStatus,
   type ServeWorkspaceSkillsStatus,
   type ServeWorkspaceToolStatus,
   type ServeWorkspaceToolsStatus,
@@ -3896,22 +3896,7 @@ class QwenAgent implements Agent {
         v: STATUS_SCHEMA_VERSION,
         workspaceCwd: this.workspaceCwd(config),
         initialized: true,
-        skills: skills.map((skill): ServeWorkspaceSkillStatus => {
-          const modelInvocable = skill.disableModelInvocation !== true;
-          return {
-            kind: 'skill',
-            status: modelInvocable ? 'ok' : 'disabled',
-            name: skill.name,
-            description: skill.description,
-            level: skill.level,
-            modelInvocable,
-            ...(skill.argumentHint ? { argumentHint: skill.argumentHint } : {}),
-            ...(skill.model ? { model: skill.model } : {}),
-            ...(skill.extensionName
-              ? { extensionName: skill.extensionName }
-              : {}),
-          };
-        }),
+        skills: skills.map(mapSkillConfigToStatus),
       };
     } catch (error) {
       return {

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -692,6 +692,7 @@ async function loadServeRuntimeModules() {
     workspaceTypesModule,
     daemonStatusProviderModule,
     workspaceProvidersStatusModule,
+    workspaceSkillsStatusModule,
   ] = await Promise.all([
     import('./server.js'),
     import('@qwen-code/acp-bridge/bridge'),
@@ -700,6 +701,7 @@ async function loadServeRuntimeModules() {
     import('./workspace-service/types.js'),
     import('./daemon-status-provider.js'),
     import('./workspace-providers-status.js'),
+    import('./workspace-skills-status.js'),
   ]);
   return {
     createServeApp: serverModule.createServeApp,
@@ -714,6 +716,8 @@ async function loadServeRuntimeModules() {
       daemonStatusProviderModule.createDaemonStatusProvider,
     createWorkspaceProvidersStatusProvider:
       workspaceProvidersStatusModule.createWorkspaceProvidersStatusProvider,
+    createWorkspaceSkillsStatusProvider:
+      workspaceSkillsStatusModule.createWorkspaceSkillsStatusProvider,
   };
 }
 
@@ -2031,6 +2035,8 @@ export async function runQwenServe(
     const statusProvider = runtime.createDaemonStatusProvider();
     const workspaceProvidersStatusProvider =
       runtime.createWorkspaceProvidersStatusProvider();
+    const workspaceSkillsStatusProvider =
+      runtime.createWorkspaceSkillsStatusProvider();
     // Reverse tool channel (issue #5626, Phase 2). ONE sender registry shared
     // between the bridge (which answers the ACP child's `client_mcp/message`
     // ext-method via `clientMcpSender`) and the WS provider in `createServeApp`
@@ -2161,6 +2167,7 @@ export async function runQwenServe(
       contextFilename: contextFilenameForInit ?? 'QWEN.md',
       statusProvider,
       workspaceProvidersStatusProvider,
+      workspaceSkillsStatusProvider,
       isChannelLive: () => bridge.isChannelLive(),
       persistDisabledTools: persistDisabledToolsFn,
       persistSetting: persistSettingFn,

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -25,6 +25,7 @@ import type { DaemonStatusProvider } from '@qwen-code/acp-bridge';
 import { createBridgeFileSystemAdapter } from './bridge-file-system-adapter.js';
 import { createDaemonStatusProvider } from './daemon-status-provider.js';
 import { createWorkspaceProvidersStatusProvider } from './workspace-providers-status.js';
+import { createWorkspaceSkillsStatusProvider } from './workspace-skills-status.js';
 import { mountAcpHttp, type AcpHttpHandle } from './acp-http/index.js';
 import { createVoiceWsConnectionHandler } from './voice/voice-ws.js';
 import {
@@ -411,6 +412,7 @@ export function createServeApp(
       statusProvider,
       workspaceProvidersStatusProvider:
         createWorkspaceProvidersStatusProvider(),
+      workspaceSkillsStatusProvider: createWorkspaceSkillsStatusProvider(),
       isChannelLive: () => bridge.isChannelLive(),
       persistDisabledTools:
         deps.persistDisabledTools ??

--- a/packages/cli/src/serve/workspace-service/__tests__/facade.test.ts
+++ b/packages/cli/src/serve/workspace-service/__tests__/facade.test.ts
@@ -807,6 +807,57 @@ describe('createDaemonWorkspaceService', () => {
       expect(workspaceSkillsStatusProvider).not.toHaveBeenCalled();
     });
 
+    it('getWorkspaceSkillsStatus replays the cache when the query throws mid-flight', async () => {
+      const liveStatus = {
+        v: 1,
+        workspaceCwd: '/ws',
+        initialized: true,
+        skills: [{ kind: 'skill', status: 'ok', name: 'review' }],
+      };
+      let shouldThrow = false;
+      const queryWorkspaceStatus = vi
+        .fn()
+        .mockImplementation(() =>
+          shouldThrow
+            ? Promise.reject(new Error('channel closed mid-request'))
+            : Promise.resolve(liveStatus),
+        );
+      const svc = createDaemonWorkspaceService(
+        makeDeps({ queryWorkspaceStatus, boundWorkspace: '/ws' }),
+      );
+
+      await svc.getWorkspaceSkillsStatus(makeCtx()); // warms cache (live)
+      shouldThrow = true;
+      const result = await svc.getWorkspaceSkillsStatus(makeCtx());
+
+      // Mid-flight failure resolves to the cached answer, not a rejection.
+      expect(result.skills.map((s) => s.name)).toEqual(['review']);
+    });
+
+    it('getWorkspaceSkillsStatus falls back to daemon-local when the query throws with no cache', async () => {
+      const queryWorkspaceStatus = vi
+        .fn()
+        .mockRejectedValue(new Error('channel closed mid-request'));
+      const workspaceSkillsStatusProvider = vi.fn().mockResolvedValue({
+        v: 1,
+        workspaceCwd: '/ws',
+        initialized: true,
+        skills: [{ kind: 'skill', status: 'ok', name: 'review' }],
+      });
+      const svc = createDaemonWorkspaceService(
+        makeDeps({
+          queryWorkspaceStatus,
+          workspaceSkillsStatusProvider,
+          boundWorkspace: '/ws',
+        }),
+      );
+
+      const result = await svc.getWorkspaceSkillsStatus(makeCtx());
+
+      expect(workspaceSkillsStatusProvider).toHaveBeenCalledWith('/ws');
+      expect(result.skills.map((s) => s.name)).toEqual(['review']);
+    });
+
     it('getWorkspaceProvidersStatus uses daemon-local provider when present', async () => {
       const queryWorkspaceStatus = vi
         .fn()

--- a/packages/cli/src/serve/workspace-service/__tests__/facade.test.ts
+++ b/packages/cli/src/serve/workspace-service/__tests__/facade.test.ts
@@ -642,6 +642,77 @@ describe('createDaemonWorkspaceService', () => {
       expect(result.skills).toEqual([]);
     });
 
+    it('getWorkspaceSkillsStatus replays the last live child status when the channel is idle', async () => {
+      const liveStatus = {
+        v: 1,
+        workspaceCwd: '/ws',
+        initialized: true,
+        skills: [
+          {
+            kind: 'skill',
+            status: 'ok',
+            name: 'review',
+            description: 'Review changed code',
+            level: 'bundled',
+            modelInvocable: true,
+          },
+        ],
+      };
+      let channelLive = true;
+      const queryWorkspaceStatus = vi
+        .fn()
+        .mockImplementation((_m: string, idle: () => unknown) =>
+          Promise.resolve(channelLive ? liveStatus : idle()),
+        );
+      const svc = createDaemonWorkspaceService(
+        makeDeps({ queryWorkspaceStatus, boundWorkspace: '/ws' }),
+      );
+
+      // Channel live: authoritative skills from the ACP child, cached.
+      const first = await svc.getWorkspaceSkillsStatus(makeCtx());
+      expect(first.initialized).toBe(true);
+      expect(first.skills.map((s) => s.name)).toEqual(['review']);
+
+      // Channel reaped: queryWorkspaceStatus falls back to the empty idle
+      // placeholder, but the facade replays the last live status so
+      // skill-backed slash commands (e.g. /review) keep autocompleting.
+      channelLive = false;
+      const second = await svc.getWorkspaceSkillsStatus(makeCtx());
+      expect(second.initialized).toBe(true);
+      expect(second.skills.map((s) => s.name)).toEqual(['review']);
+    });
+
+    it('getWorkspaceSkillsStatus refreshes the cached status on a newer live answer', async () => {
+      const statuses = [
+        {
+          v: 1,
+          workspaceCwd: '/ws',
+          initialized: true,
+          skills: [{ kind: 'skill', status: 'ok', name: 'review' }],
+        },
+        {
+          v: 1,
+          workspaceCwd: '/ws',
+          initialized: true,
+          skills: [
+            { kind: 'skill', status: 'ok', name: 'review' },
+            { kind: 'skill', status: 'ok', name: 'plan' },
+          ],
+        },
+      ];
+      let call = 0;
+      const queryWorkspaceStatus = vi
+        .fn()
+        .mockImplementation(() => Promise.resolve(statuses[call++]));
+      const svc = createDaemonWorkspaceService(
+        makeDeps({ queryWorkspaceStatus, boundWorkspace: '/ws' }),
+      );
+
+      await svc.getWorkspaceSkillsStatus(makeCtx());
+      const refreshed = await svc.getWorkspaceSkillsStatus(makeCtx());
+      expect(refreshed.skills.map((s) => s.name)).toEqual(['review', 'plan']);
+    });
+
     it('getWorkspaceProvidersStatus uses daemon-local provider when present', async () => {
       const queryWorkspaceStatus = vi
         .fn()

--- a/packages/cli/src/serve/workspace-service/__tests__/facade.test.ts
+++ b/packages/cli/src/serve/workspace-service/__tests__/facade.test.ts
@@ -858,6 +858,32 @@ describe('createDaemonWorkspaceService', () => {
       expect(result.skills.map((s) => s.name)).toEqual(['review']);
     });
 
+    it('getWorkspaceSkillsStatus degrades to the idle placeholder when the daemon-local provider throws', async () => {
+      const queryWorkspaceStatus = vi
+        .fn()
+        .mockImplementation((_m: string, idle: () => unknown) =>
+          Promise.resolve(idle()),
+        );
+      const workspaceSkillsStatusProvider = vi
+        .fn()
+        .mockRejectedValue(new Error('local enumeration blew up'));
+      const svc = createDaemonWorkspaceService(
+        makeDeps({
+          queryWorkspaceStatus,
+          workspaceSkillsStatusProvider,
+          boundWorkspace: '/ws',
+        }),
+      );
+
+      // A throwing injected provider must not fail the request.
+      const result = await svc.getWorkspaceSkillsStatus(makeCtx());
+
+      expect(workspaceSkillsStatusProvider).toHaveBeenCalledWith('/ws');
+      expect(result.initialized).toBe(false);
+      expect(result.skills).toEqual([]);
+      expect(mockWriteStderrLine).toHaveBeenCalled();
+    });
+
     it('getWorkspaceProvidersStatus uses daemon-local provider when present', async () => {
       const queryWorkspaceStatus = vi
         .fn()

--- a/packages/cli/src/serve/workspace-service/__tests__/facade.test.ts
+++ b/packages/cli/src/serve/workspace-service/__tests__/facade.test.ts
@@ -713,6 +713,100 @@ describe('createDaemonWorkspaceService', () => {
       expect(refreshed.skills.map((s) => s.name)).toEqual(['review', 'plan']);
     });
 
+    it('getWorkspaceSkillsStatus falls back to the daemon-local provider when the child never answered', async () => {
+      const queryWorkspaceStatus = vi
+        .fn()
+        .mockImplementation((_m: string, idle: () => unknown) =>
+          Promise.resolve(idle()),
+        );
+      const workspaceSkillsStatusProvider = vi.fn().mockResolvedValue({
+        v: 1,
+        workspaceCwd: '/ws',
+        initialized: true,
+        skills: [
+          {
+            kind: 'skill',
+            status: 'ok',
+            name: 'review',
+            description: 'Review changed code',
+            level: 'bundled',
+            modelInvocable: true,
+          },
+        ],
+      });
+      const svc = createDaemonWorkspaceService(
+        makeDeps({
+          queryWorkspaceStatus,
+          workspaceSkillsStatusProvider,
+          boundWorkspace: '/ws',
+        }),
+      );
+
+      const result = await svc.getWorkspaceSkillsStatus(makeCtx());
+
+      expect(workspaceSkillsStatusProvider).toHaveBeenCalledWith('/ws');
+      expect(result.initialized).toBe(true);
+      expect(result.skills.map((s) => s.name)).toEqual(['review']);
+    });
+
+    it('getWorkspaceSkillsStatus prefers the cached child answer over the daemon-local provider', async () => {
+      const liveStatus = {
+        v: 1,
+        workspaceCwd: '/ws',
+        initialized: true,
+        skills: [{ kind: 'skill', status: 'ok', name: 'review' }],
+      };
+      let channelLive = true;
+      const queryWorkspaceStatus = vi
+        .fn()
+        .mockImplementation((_m: string, idle: () => unknown) =>
+          Promise.resolve(channelLive ? liveStatus : idle()),
+        );
+      const workspaceSkillsStatusProvider = vi.fn().mockResolvedValue({
+        v: 1,
+        workspaceCwd: '/ws',
+        initialized: true,
+        skills: [],
+      });
+      const svc = createDaemonWorkspaceService(
+        makeDeps({
+          queryWorkspaceStatus,
+          workspaceSkillsStatusProvider,
+          boundWorkspace: '/ws',
+        }),
+      );
+
+      await svc.getWorkspaceSkillsStatus(makeCtx()); // warms cache (child live)
+      channelLive = false;
+      const result = await svc.getWorkspaceSkillsStatus(makeCtx());
+
+      expect(result.skills.map((s) => s.name)).toEqual(['review']);
+      expect(workspaceSkillsStatusProvider).not.toHaveBeenCalled();
+    });
+
+    it('getWorkspaceSkillsStatus does not use the daemon-local provider while the child answers', async () => {
+      const liveStatus = {
+        v: 1,
+        workspaceCwd: '/ws',
+        initialized: true,
+        skills: [{ kind: 'skill', status: 'ok', name: 'review' }],
+      };
+      const queryWorkspaceStatus = vi.fn().mockResolvedValue(liveStatus);
+      const workspaceSkillsStatusProvider = vi.fn().mockResolvedValue({
+        v: 1,
+        workspaceCwd: '/ws',
+        initialized: true,
+        skills: [],
+      });
+      const svc = createDaemonWorkspaceService(
+        makeDeps({ queryWorkspaceStatus, workspaceSkillsStatusProvider }),
+      );
+
+      await svc.getWorkspaceSkillsStatus(makeCtx());
+
+      expect(workspaceSkillsStatusProvider).not.toHaveBeenCalled();
+    });
+
     it('getWorkspaceProvidersStatus uses daemon-local provider when present', async () => {
       const queryWorkspaceStatus = vi
         .fn()

--- a/packages/cli/src/serve/workspace-service/index.ts
+++ b/packages/cli/src/serve/workspace-service/index.ts
@@ -162,6 +162,7 @@ export function createDaemonWorkspaceService(
     contextFilename,
     statusProvider,
     workspaceProvidersStatusProvider,
+    workspaceSkillsStatusProvider,
     isChannelLive,
     persistDisabledTools,
     persistSetting,
@@ -188,17 +189,16 @@ export function createDaemonWorkspaceService(
     },
 
     async getWorkspaceSkillsStatus(_ctx: WorkspaceRequestContext) {
-      // Skills are enumerated only by the ACP child; the daemon has no local
-      // SkillManager. `queryWorkspaceStatus` therefore returns the idle
-      // placeholder (`initialized: false`, empty `skills`) whenever no child
-      // channel is live — the norm before the first session, and again after
+      // Skills are enumerated by the ACP child, which owns the live
+      // SkillManager (including extension-provided skills). `queryWorkspaceStatus`
+      // returns the idle placeholder (`initialized: false`, empty `skills`)
+      // whenever no child channel is live — before the first session, after
       // the child is reaped on session close (`--channel-idle-timeout-ms`
-      // defaults to an immediate kill). In that window the Web Shell's
+      // defaults to an immediate kill), and when a cold-start preheat times
+      // out before the child ever answers. In those windows the Web Shell's
       // pre-first-prompt slash-command list would otherwise drop every skill,
-      // so `/rev` stops autocompleting `/review`. Serve the last status a live
-      // child produced instead, so skill-backed commands keep autocompleting;
-      // the next live query refreshes it. `initialized` cleanly separates a
-      // real child answer (always `true`) from the idle placeholder (`false`).
+      // so `/rev` stops autocompleting `/review`. `initialized` cleanly
+      // separates a real child answer (always `true`) from the placeholder.
       const status = await queryWorkspaceStatus(
         SERVE_STATUS_EXT_METHODS.workspaceSkills,
         () => createIdleWorkspaceSkillsStatus(boundWorkspace),
@@ -207,7 +207,18 @@ export function createDaemonWorkspaceService(
         lastWorkspaceSkillsStatus = status;
         return status;
       }
-      return lastWorkspaceSkillsStatus ?? status;
+      // Live child unavailable. Prefer the last answer it produced (keeps the
+      // full, extension-aware list available across a reap)...
+      if (lastWorkspaceSkillsStatus) {
+        return lastWorkspaceSkillsStatus;
+      }
+      // ...then fall back to daemon-local enumeration, so a child that has not
+      // answered even once (e.g. a preheat that times out under `npm run dev`)
+      // still yields the on-disk skills — `/review` included.
+      if (workspaceSkillsStatusProvider) {
+        return workspaceSkillsStatusProvider(boundWorkspace);
+      }
+      return status;
     },
 
     async getWorkspaceProvidersStatus(_ctx: WorkspaceRequestContext) {

--- a/packages/cli/src/serve/workspace-service/index.ts
+++ b/packages/cli/src/serve/workspace-service/index.ts
@@ -199,10 +199,23 @@ export function createDaemonWorkspaceService(
       // pre-first-prompt slash-command list would otherwise drop every skill,
       // so `/rev` stops autocompleting `/review`. `initialized` cleanly
       // separates a real child answer (always `true`) from the placeholder.
-      const status = await queryWorkspaceStatus(
-        SERVE_STATUS_EXT_METHODS.workspaceSkills,
-        () => createIdleWorkspaceSkillsStatus(boundWorkspace),
-      );
+      let status: ServeWorkspaceSkillsStatus;
+      try {
+        status = await queryWorkspaceStatus(
+          SERVE_STATUS_EXT_METHODS.workspaceSkills,
+          () => createIdleWorkspaceSkillsStatus(boundWorkspace),
+        );
+      } catch (err) {
+        // The channel can die mid-RPC (`liveChannelInfo()` was valid at the
+        // check but the child exited before the call completed). Treat that
+        // like "no live child" and fall back to the cache / daemon-local
+        // enumeration below instead of failing the request — matching
+        // getWorkspaceEnvStatus / getWorkspacePreflightStatus.
+        writeStderrLine(
+          `qwen serve: getWorkspaceSkillsStatus query failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        status = createIdleWorkspaceSkillsStatus(boundWorkspace);
+      }
       if (status.initialized) {
         lastWorkspaceSkillsStatus = status;
         return status;

--- a/packages/cli/src/serve/workspace-service/index.ts
+++ b/packages/cli/src/serve/workspace-service/index.ts
@@ -227,9 +227,18 @@ export function createDaemonWorkspaceService(
       }
       // ...then fall back to daemon-local enumeration, so a child that has not
       // answered even once (e.g. a preheat that times out under `npm run dev`)
-      // still yields the on-disk skills — `/review` included.
+      // still yields the on-disk skills — `/review` included. The provider
+      // handles its own errors, but it is injected, so guard the call too and
+      // degrade to the idle placeholder rather than failing the request —
+      // matching getWorkspaceEnvStatus / getWorkspacePreflightStatus.
       if (workspaceSkillsStatusProvider) {
-        return workspaceSkillsStatusProvider(boundWorkspace);
+        try {
+          return await workspaceSkillsStatusProvider(boundWorkspace);
+        } catch (err) {
+          writeStderrLine(
+            `qwen serve: getWorkspaceSkillsStatus local provider failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
       }
       return status;
     },

--- a/packages/cli/src/serve/workspace-service/index.ts
+++ b/packages/cli/src/serve/workspace-service/index.ts
@@ -28,6 +28,7 @@ import {
   createIdleEnvStatus,
   createIdleAcpPreflightCells,
   type ServeWorkspacePreflightStatus,
+  type ServeWorkspaceSkillsStatus,
 } from '@qwen-code/acp-bridge/status';
 
 import {
@@ -171,6 +172,11 @@ export function createDaemonWorkspaceService(
     publishWorkspaceEvent,
   } = deps;
 
+  // Last skills status answered by a live ACP child, retained so
+  // skill-backed slash commands (e.g. `/review`) keep autocompleting after
+  // the child channel has been reaped. See `getWorkspaceSkillsStatus`.
+  let lastWorkspaceSkillsStatus: ServeWorkspaceSkillsStatus | undefined;
+
   // -- Facade --
   return {
     // -- Status queries (delegate to ACP child via queryWorkspaceStatus) --
@@ -182,10 +188,26 @@ export function createDaemonWorkspaceService(
     },
 
     async getWorkspaceSkillsStatus(_ctx: WorkspaceRequestContext) {
-      return queryWorkspaceStatus(
+      // Skills are enumerated only by the ACP child; the daemon has no local
+      // SkillManager. `queryWorkspaceStatus` therefore returns the idle
+      // placeholder (`initialized: false`, empty `skills`) whenever no child
+      // channel is live — the norm before the first session, and again after
+      // the child is reaped on session close (`--channel-idle-timeout-ms`
+      // defaults to an immediate kill). In that window the Web Shell's
+      // pre-first-prompt slash-command list would otherwise drop every skill,
+      // so `/rev` stops autocompleting `/review`. Serve the last status a live
+      // child produced instead, so skill-backed commands keep autocompleting;
+      // the next live query refreshes it. `initialized` cleanly separates a
+      // real child answer (always `true`) from the idle placeholder (`false`).
+      const status = await queryWorkspaceStatus(
         SERVE_STATUS_EXT_METHODS.workspaceSkills,
         () => createIdleWorkspaceSkillsStatus(boundWorkspace),
       );
+      if (status.initialized) {
+        lastWorkspaceSkillsStatus = status;
+        return status;
+      }
+      return lastWorkspaceSkillsStatus ?? status;
     },
 
     async getWorkspaceProvidersStatus(_ctx: WorkspaceRequestContext) {

--- a/packages/cli/src/serve/workspace-service/types.ts
+++ b/packages/cli/src/serve/workspace-service/types.ts
@@ -38,6 +38,7 @@ import type {
 import type { WorkspaceVoiceStatus } from '../../services/voice-service.js';
 import type { VoiceMode } from '../../services/voice-settings.js';
 import type { WorkspaceProvidersStatusProvider } from '../workspace-providers-status.js';
+import type { WorkspaceSkillsStatusProvider } from '../workspace-skills-status.js';
 
 // ---------------------------------------------------------------------------
 // WorkspaceRequestContext
@@ -323,6 +324,15 @@ export interface DaemonWorkspaceServiceDeps {
    * instead of querying the ACP child.
    */
   workspaceProvidersStatusProvider?: WorkspaceProvidersStatusProvider;
+
+  /**
+   * Daemon-local skill enumeration. Used as a fallback for
+   * `/workspace/skills` when the ACP child cannot answer (e.g. before the
+   * first prompt on a cold daemon whose preheat has not yet — or cannot —
+   * bring the child up), so skill-backed slash commands autocomplete without
+   * waiting on the child. The live child stays authoritative when present.
+   */
+  workspaceSkillsStatusProvider?: WorkspaceSkillsStatusProvider;
 
   /**
    * Returns whether the ACP channel is currently live. Used by

--- a/packages/cli/src/serve/workspace-skills-mapping.test.ts
+++ b/packages/cli/src/serve/workspace-skills-mapping.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { SkillConfig } from '@qwen-code/qwen-code-core';
+import { mapSkillConfigToStatus } from './workspace-skills-mapping.js';
+
+function makeSkill(overrides: Partial<SkillConfig> = {}): SkillConfig {
+  return {
+    name: 'review',
+    description: 'Review changed code',
+    level: 'bundled',
+    ...overrides,
+  } as SkillConfig;
+}
+
+describe('mapSkillConfigToStatus', () => {
+  it('maps an invocable skill to an ok status with its core fields', () => {
+    const status = mapSkillConfigToStatus(
+      makeSkill({ argumentHint: '[pr-number]' }),
+    );
+
+    expect(status).toEqual({
+      kind: 'skill',
+      status: 'ok',
+      name: 'review',
+      description: 'Review changed code',
+      level: 'bundled',
+      modelInvocable: true,
+      argumentHint: '[pr-number]',
+    });
+  });
+
+  it('marks a disable-model-invocation skill as disabled', () => {
+    const status = mapSkillConfigToStatus(
+      makeSkill({ name: 'internal', disableModelInvocation: true }),
+    );
+
+    expect(status.status).toBe('disabled');
+    expect(status.modelInvocable).toBe(false);
+    expect(status.name).toBe('internal');
+  });
+
+  it('surfaces optional model and extensionName only when present', () => {
+    expect(mapSkillConfigToStatus(makeSkill())).not.toHaveProperty('model');
+    expect(mapSkillConfigToStatus(makeSkill())).not.toHaveProperty(
+      'extensionName',
+    );
+
+    const status = mapSkillConfigToStatus(
+      makeSkill({ model: 'gpt-4o', extensionName: 'acme' }),
+    );
+    expect(status.model).toBe('gpt-4o');
+    expect(status.extensionName).toBe('acme');
+  });
+});

--- a/packages/cli/src/serve/workspace-skills-mapping.ts
+++ b/packages/cli/src/serve/workspace-skills-mapping.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { SkillConfig } from '@qwen-code/qwen-code-core';
+import type { ServeWorkspaceSkillStatus } from '@qwen-code/acp-bridge/status';
+
+/**
+ * Maps a `SkillConfig` (as `SkillManager.listSkills()` returns) to the
+ * `/workspace/skills` wire status. Shared by the ACP child's
+ * `buildWorkspaceSkillsStatus` and the daemon-local
+ * `workspace-skills-status` provider so the two skill listings can never
+ * drift in shape.
+ */
+export function mapSkillConfigToStatus(
+  skill: SkillConfig,
+): ServeWorkspaceSkillStatus {
+  const modelInvocable = skill.disableModelInvocation !== true;
+  return {
+    kind: 'skill',
+    status: modelInvocable ? 'ok' : 'disabled',
+    name: skill.name,
+    description: skill.description,
+    level: skill.level,
+    modelInvocable,
+    ...(skill.argumentHint ? { argumentHint: skill.argumentHint } : {}),
+    ...(skill.model ? { model: skill.model } : {}),
+    ...(skill.extensionName ? { extensionName: skill.extensionName } : {}),
+  };
+}

--- a/packages/cli/src/serve/workspace-skills-status.test.ts
+++ b/packages/cli/src/serve/workspace-skills-status.test.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createWorkspaceSkillsStatusProvider } from './workspace-skills-status.js';
+
+describe('createWorkspaceSkillsStatusProvider', () => {
+  it('enumerates bundled skills (including /review) without an ACP child', async () => {
+    const provider = createWorkspaceSkillsStatusProvider();
+
+    const status = await provider(process.cwd());
+
+    expect(status.initialized).toBe(true);
+    const review = status.skills.find((skill) => skill.name === 'review');
+    expect(review).toBeDefined();
+    expect(review?.kind).toBe('skill');
+    expect(review?.level).toBe('bundled');
+    // Skill-tool listing exposes the model-invocable flag; bundled /review is
+    // invocable, and the argument hint drives the slash-command autocomplete.
+    expect(review?.modelInvocable).toBe(true);
+    expect(review?.argumentHint).toBeTruthy();
+  });
+
+  it('reports the queried workspace path', async () => {
+    const provider = createWorkspaceSkillsStatusProvider();
+
+    const status = await provider('/some/workspace');
+
+    expect(status.workspaceCwd).toBe('/some/workspace');
+  });
+});

--- a/packages/cli/src/serve/workspace-skills-status.test.ts
+++ b/packages/cli/src/serve/workspace-skills-status.test.ts
@@ -4,10 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+const mockWriteStderrLine = vi.hoisted(() => vi.fn());
+vi.mock('../utils/stdioHelpers.js', () => ({
+  writeStderrLine: mockWriteStderrLine,
+}));
+
+import { SkillManager } from '@qwen-code/qwen-code-core';
 import { createWorkspaceSkillsStatusProvider } from './workspace-skills-status.js';
 
 describe('createWorkspaceSkillsStatusProvider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockWriteStderrLine.mockClear();
+  });
+
   it('enumerates bundled skills (including /review) without an ACP child', async () => {
     const provider = createWorkspaceSkillsStatusProvider();
 
@@ -30,5 +42,37 @@ describe('createWorkspaceSkillsStatusProvider', () => {
     const status = await provider('/some/workspace');
 
     expect(status.workspaceCwd).toBe('/some/workspace');
+  });
+
+  it('returns a non-initialized error status (and logs) when enumeration fails', async () => {
+    vi.spyOn(SkillManager.prototype, 'listSkills').mockRejectedValueOnce(
+      new Error('boom'),
+    );
+    const provider = createWorkspaceSkillsStatusProvider();
+
+    const status = await provider('/ws');
+
+    expect(status.initialized).toBe(false);
+    expect(status.skills).toEqual([]);
+    expect(status.workspaceCwd).toBe('/ws');
+    expect(status.errors).toEqual([
+      { kind: 'skills', status: 'error', error: 'boom' },
+    ]);
+    // Non-fatal failures are logged to the daemon's stderr.
+    expect(mockWriteStderrLine).toHaveBeenCalledTimes(1);
+    expect(mockWriteStderrLine.mock.calls[0][0]).toContain('boom');
+  });
+
+  it('reuses one SkillManager per workspace across calls', async () => {
+    const listSpy = vi.spyOn(SkillManager.prototype, 'listSkills');
+    const provider = createWorkspaceSkillsStatusProvider();
+
+    await provider('/ws');
+    await provider('/ws');
+
+    // Memoized: the second query reuses the first SkillManager instance, so
+    // listSkills is invoked on the same object rather than a freshly-scanned one.
+    expect(listSpy).toHaveBeenCalledTimes(2);
+    expect(listSpy.mock.instances[0]).toBe(listSpy.mock.instances[1]);
   });
 });

--- a/packages/cli/src/serve/workspace-skills-status.ts
+++ b/packages/cli/src/serve/workspace-skills-status.ts
@@ -30,13 +30,12 @@
  * outside the child) — those still surface once a session exists.
  */
 
-import { SkillManager } from '@qwen-code/qwen-code-core';
-import type { Config, SkillConfig } from '@qwen-code/qwen-code-core';
-import type {
-  ServeWorkspaceSkillStatus,
-  ServeWorkspaceSkillsStatus,
-} from '@qwen-code/acp-bridge/status';
+import { SkillManager, isSafeModeEnv } from '@qwen-code/qwen-code-core';
+import type { Config } from '@qwen-code/qwen-code-core';
+import type { ServeWorkspaceSkillsStatus } from '@qwen-code/acp-bridge/status';
 import { STATUS_SCHEMA_VERSION } from '@qwen-code/acp-bridge/status';
+import { writeStderrLine } from '../utils/stdioHelpers.js';
+import { mapSkillConfigToStatus } from './workspace-skills-mapping.js';
 
 export type WorkspaceSkillsStatusProvider = (
   workspaceCwd: string,
@@ -57,33 +56,51 @@ type SkillManagerConfigShim = Pick<
 >;
 
 export function createWorkspaceSkillsStatusProvider(): WorkspaceSkillsStatusProvider {
-  return (workspaceCwd) => buildWorkspaceSkillsStatus(workspaceCwd);
+  // Reuse one SkillManager per workspace so repeat queries hit its in-memory
+  // skills cache instead of re-scanning (and re-parsing frontmatter / compiling
+  // globs for) every level on each call. This is a best-effort pre-child
+  // fallback, so the slight staleness — a skill added on disk mid-run is not
+  // picked up until the daemon restarts — is acceptable: the live child
+  // re-lists authoritatively once a session exists.
+  const managers = new Map<string, SkillManager>();
+  return (workspaceCwd) => buildWorkspaceSkillsStatus(workspaceCwd, managers);
 }
 
 async function buildWorkspaceSkillsStatus(
   workspaceCwd: string,
+  managers: Map<string, SkillManager>,
 ): Promise<ServeWorkspaceSkillsStatus> {
   try {
-    const shim: SkillManagerConfigShim = {
-      // The daemon binds to an operator-chosen workspace and only lists skills
-      // for autocomplete (the child gates execution), so enumerate all levels
-      // rather than restricting to bundled-only safe mode.
-      isSafeMode: () => false,
-      getBareMode: () => false,
-      getProjectRoot: () => workspaceCwd,
-      // Extension skills need active-extension context that only the child
-      // has; omit them here and let the session snapshot surface them.
-      getActiveExtensions: () => [],
-    };
-    const skillManager = new SkillManager(shim as Config);
+    let skillManager = managers.get(workspaceCwd);
+    if (!skillManager) {
+      const shim: SkillManagerConfigShim = {
+        // Honor the safe-mode env the same way `Config` does when no explicit
+        // flag is passed, so an operator running in safe mode gets the same
+        // bundled-only listing the child would produce.
+        isSafeMode: () => isSafeModeEnv(),
+        // Bare mode is the interactive `--bare` CLI flag; the daemon never runs
+        // bare, so it is always off here.
+        getBareMode: () => false,
+        getProjectRoot: () => workspaceCwd,
+        // Extension skills need active-extension context that only the child
+        // has; omit them here and let the session snapshot surface them.
+        getActiveExtensions: () => [],
+      };
+      skillManager = new SkillManager(shim as Config);
+      managers.set(workspaceCwd, skillManager);
+    }
     const skills = await skillManager.listSkills();
     return {
       v: STATUS_SCHEMA_VERSION,
       workspaceCwd,
       initialized: true,
-      skills: skills.map(mapSkill),
+      skills: skills.map(mapSkillConfigToStatus),
     };
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    writeStderrLine(
+      `qwen serve: daemon-local skills enumeration failed for ${workspaceCwd}: ${message}`,
+    );
     return {
       v: STATUS_SCHEMA_VERSION,
       workspaceCwd,
@@ -93,24 +110,9 @@ async function buildWorkspaceSkillsStatus(
         {
           kind: 'skills',
           status: 'error',
-          error: error instanceof Error ? error.message : String(error),
+          error: message,
         },
       ],
     };
   }
-}
-
-function mapSkill(skill: SkillConfig): ServeWorkspaceSkillStatus {
-  const modelInvocable = skill.disableModelInvocation !== true;
-  return {
-    kind: 'skill',
-    status: modelInvocable ? 'ok' : 'disabled',
-    name: skill.name,
-    description: skill.description,
-    level: skill.level,
-    modelInvocable,
-    ...(skill.argumentHint ? { argumentHint: skill.argumentHint } : {}),
-    ...(skill.model ? { model: skill.model } : {}),
-    ...(skill.extensionName ? { extensionName: skill.extensionName } : {}),
-  };
 }

--- a/packages/cli/src/serve/workspace-skills-status.ts
+++ b/packages/cli/src/serve/workspace-skills-status.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Daemon-local workspace skills enumeration.
+ *
+ * `/workspace/skills` is normally answered by the ACP child (which owns the
+ * live `SkillManager`). But the child is not always available before the
+ * first prompt: session creation is deferred until then, and the startup
+ * preheat can time out on a slow cold start — most visibly under
+ * `npm run dev`, where the child is transpiled on demand and its
+ * `initialize` handshake routinely exceeds the 10s preheat budget, so no
+ * channel ever comes up. In that window the child cannot list skills, which
+ * drops skill-backed slash commands (e.g. `/review`) from the Web Shell's
+ * pre-first-prompt autocomplete even though the skills exist on disk.
+ *
+ * This provider enumerates skills directly from the filesystem via
+ * `SkillManager`, with no child and no MCP initialization, so the daemon can
+ * answer `/workspace/skills` instantly whenever the child is unavailable.
+ * `SkillManager.listSkills()` only reads a handful of `Config` getters
+ * (safe/bare mode, project root, active extensions), so a lightweight config
+ * shim is sufficient — no full `Config` construction (and no `initialize()`
+ * side effects) required. The live child, when present, stays authoritative:
+ * the facade only falls back here after a real child answer and the cached
+ * last answer are both unavailable, and this daemon-local view intentionally
+ * omits extension-provided skills (there is no active-extension context
+ * outside the child) — those still surface once a session exists.
+ */
+
+import { SkillManager } from '@qwen-code/qwen-code-core';
+import type { Config, SkillConfig } from '@qwen-code/qwen-code-core';
+import type {
+  ServeWorkspaceSkillStatus,
+  ServeWorkspaceSkillsStatus,
+} from '@qwen-code/acp-bridge/status';
+import { STATUS_SCHEMA_VERSION } from '@qwen-code/acp-bridge/status';
+
+export type WorkspaceSkillsStatusProvider = (
+  workspaceCwd: string,
+) => Promise<ServeWorkspaceSkillsStatus>;
+
+/**
+ * The `Config` surface `SkillManager.listSkills()` actually reads. Declaring it
+ * as a `Pick` (rather than casting an inline object literal) type-checks the
+ * shimmed getters against `Config`'s real signatures, so a signature drift is
+ * caught at compile time. Should `SkillManager` grow a dependency on some other
+ * `Config` method, that call would be `undefined` at runtime — which
+ * `buildWorkspaceSkillsStatus`'s try/catch turns into an empty, non-initialized
+ * status (the facade then leaves skills to the live child) rather than a crash.
+ */
+type SkillManagerConfigShim = Pick<
+  Config,
+  'isSafeMode' | 'getBareMode' | 'getProjectRoot' | 'getActiveExtensions'
+>;
+
+export function createWorkspaceSkillsStatusProvider(): WorkspaceSkillsStatusProvider {
+  return (workspaceCwd) => buildWorkspaceSkillsStatus(workspaceCwd);
+}
+
+async function buildWorkspaceSkillsStatus(
+  workspaceCwd: string,
+): Promise<ServeWorkspaceSkillsStatus> {
+  try {
+    const shim: SkillManagerConfigShim = {
+      // The daemon binds to an operator-chosen workspace and only lists skills
+      // for autocomplete (the child gates execution), so enumerate all levels
+      // rather than restricting to bundled-only safe mode.
+      isSafeMode: () => false,
+      getBareMode: () => false,
+      getProjectRoot: () => workspaceCwd,
+      // Extension skills need active-extension context that only the child
+      // has; omit them here and let the session snapshot surface them.
+      getActiveExtensions: () => [],
+    };
+    const skillManager = new SkillManager(shim as Config);
+    const skills = await skillManager.listSkills();
+    return {
+      v: STATUS_SCHEMA_VERSION,
+      workspaceCwd,
+      initialized: true,
+      skills: skills.map(mapSkill),
+    };
+  } catch (error) {
+    return {
+      v: STATUS_SCHEMA_VERSION,
+      workspaceCwd,
+      initialized: false,
+      skills: [],
+      errors: [
+        {
+          kind: 'skills',
+          status: 'error',
+          error: error instanceof Error ? error.message : String(error),
+        },
+      ],
+    };
+  }
+}
+
+function mapSkill(skill: SkillConfig): ServeWorkspaceSkillStatus {
+  const modelInvocable = skill.disableModelInvocation !== true;
+  return {
+    kind: 'skill',
+    status: modelInvocable ? 'ok' : 'disabled',
+    name: skill.name,
+    description: skill.description,
+    level: skill.level,
+    modelInvocable,
+    ...(skill.argumentHint ? { argumentHint: skill.argumentHint } : {}),
+    ...(skill.model ? { model: skill.model } : {}),
+    ...(skill.extensionName ? { extensionName: skill.extensionName } : {}),
+  };
+}


### PR DESCRIPTION
## What this PR does

Makes the Web Shell's pre-first-prompt slash-command list keep skill-backed commands (e.g. `/review`) whenever the ACP child can't answer `/workspace/skills`, via two complementary daemon-side layers:

1. **Cache** the last skills status a live child produced and replay it while no child is live, so a reaped child still yields the full, extension-aware list.
2. **Enumerate skills daemon-locally** (straight from the filesystem via `SkillManager`, no child, no MCP init) as a fallback for when the child has *never* answered — so even a child that never comes up still yields the on-disk skills.

## Why it's needed

`/workspace/skills` is answered only by the ACP child. `requestWorkspaceStatus` checks for an already-live channel (`liveChannelInfo()`, never `ensureChannel()`) and returns the idle placeholder (`initialized: false`, empty `skills`) when there is none. There is no daemon-local fallback like `/workspace/providers` has — so the pre-first-prompt list drops every skill and `/rev` stops autocompleting `/review`. The child is absent in three windows:

- **Before the first session** — session creation is deferred until the first prompt (#6066).
- **After a session closes** — the child is reaped immediately (`--channel-idle-timeout-ms` defaults to `0`).
- **On a cold start, when preheat times out** — most visible under `npm run dev`: the on-demand-transpiled child's `initialize` handshake routinely exceeds the 10s preheat budget (measured ~19s cold, vs a 10s cap), so preheat fails ("`ACP preheat failed, will retry on first session: AcpSessionBridge initialize timed out after 10000ms`") and no channel ever comes up.

The third window is why the reported symptom is *"`/review` is not in the list, but it actually works"*: the skill exists on disk and runs when you submit `/review` in full (which spawns a session), but it never appears in autocomplete because the child hasn't answered `/workspace/skills`. The cache alone can't help there — it never warms without a live child. The daemon-local provider closes it: it reads skills from disk instantly, so `/review` is in the list from the first page load. The live child stays authoritative when present (and keeps extension-provided skills, which the daemon-local view omits).

This completes #6153, which wired the Web Shell to fetch `/workspace/skills` but could not surface skills the daemon was unable to answer without a live child.

## Reviewer Test Plan

### How to verify

Unit: `npx vitest run packages/cli/src/serve/workspace-service/ packages/cli/src/serve/workspace-skills-status.test.ts` — covers cache replay/refresh, the daemon-local fallback ordering (child → cache → local → empty), and that the local provider enumerates bundled `/review` with no child (76 tests). `npx vitest run packages/cli/src/serve/server.test.ts` stays green (574).

End-to-end (`npm run dev:daemon`, where preheat times out so the child is never live pre-prompt):
1. Start it, open the Web Shell, and before sending any message type `/rev`.
2. Press Tab.

Expected (this PR): `/review` is in the slash menu and Tab completes `/rev` → `/review [pr-number|file-path] [--comment]`. Before: `/review` was absent and Tab did nothing.

### Evidence (Before & After)

Real daemon, `GET /workspace/skills` before any session:

| State | Before (main / cache-only) | After (this PR) |
| --- | --- | --- |
| Reaped child, cache warm | `hasReview=true` (replayed) | `hasReview=true` |
| **Cold start, preheat timed out (child never live)** | `initialized=false skillsCount=0` ❌ | `initialized=true skillsCount=25 hasReview=true` ✅ |

Real `npm run dev:daemon` + Playwright (child's preheat still timing out): the browser's `/workspace/skills` returns `initialized=true count=25 hasReview=true` immediately, the slash menu shows `/review`, and `/rev`+Tab → `/review [pr-number|file-path] [--comment]`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local: `node scripts/dev.js serve` / `npm run dev:daemon` (tsx source, loopback), driven with `curl` and Playwright; plus `vitest` unit tests.

## Risk & Scope

- Main risk or tradeoff: the daemon-local view omits extension-provided skills (there is no active-extension context outside the child) and does not apply safe-mode restriction; it is a best-effort fallback for the pre-child window only. The live child stays authoritative when present, and the cache preserves the child's full extension-aware list across a reap, so extension skills are only absent in the never-yet-preheated cold-start window. Skills are listed for autocomplete only — the child still gates execution.
- Not validated / out of scope: not addressing *why* the dev-mode child init exceeds 10s (a separate preheat/timeout concern); this PR makes skills available regardless.
- Breaking changes / migration notes: none. Behavior is unchanged whenever a child answer or a cached answer is available; only the no-child, no-cache path gains the daemon-local fallback.

## Linked Issues

Completes the fix started in #6153.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 Web Shell 首个 prompt 之前的斜杠命令列表在 ACP 子进程无法回答 `/workspace/skills` 时，依然保留技能类命令（如 `/review`），通过两层互补的 daemon 侧机制：

1. **缓存**子进程最近一次答出的技能状态，在无活子进程时回放——这样被回收的子进程仍能给出完整、含扩展的列表。
2. **daemon 本地枚举**技能（直接经 `SkillManager` 读文件系统，不启子进程、不做 MCP 初始化）作为"子进程从未答复"时的兜底——即便子进程一直起不来，也能给出磁盘上的技能。

## 为什么需要

`/workspace/skills` 只由 ACP 子进程回答。`requestWorkspaceStatus` 只被动查已存活通道（`liveChannelInfo()`，从不 `ensureChannel()`），无通道就返回空 idle 占位。它没有 `/workspace/providers` 那样的 daemon 本地兜底——于是首个 prompt 前列表丢光技能、`/rev` 补不出 `/review`。子进程在三个窗口内缺席：

- **首个 session 之前**——session 创建延迟到首个 prompt（#6066）。
- **session 关闭后**——子进程被立即回收（`--channel-idle-timeout-ms` 默认 0）。
- **冷启动 preheat 超时**——`npm run dev` 下最明显：按需 tsx 转译的子进程 `initialize` 握手经常超过 10s 的 preheat 预算（实测冷启动 ~19s，超时上限 10s），preheat 失败（日志 `ACP preheat failed ... initialize timed out after 10000ms`），通道永不就绪。

第三个窗口正是你报的现象——**"`/review` 不在列表里，但真实可用"**：技能在磁盘上、你完整输入 `/review` 提交（会建 session）就能跑，但它从不出现在补全里，因为子进程没答 `/workspace/skills`。仅靠缓存救不了——没有活子进程它永远不被填充。daemon 本地 provider 堵上了这个窗口：直接从磁盘即时读技能，`/review` 从首次打开就在列表里。子进程在线时仍为权威（并保留本地视图省略的扩展技能）。

这补全了 #6153：#6153 让 Web Shell 去拉 `/workspace/skills`，但当 daemon 无活子进程答不出时它无能为力。

## Reviewer Test Plan（评审验证）

### 如何验证

单测：`npx vitest run packages/cli/src/serve/workspace-service/ packages/cli/src/serve/workspace-skills-status.test.ts` —— 覆盖缓存回放/刷新、兜底顺序（子进程→缓存→本地→空）、以及本地 provider 无子进程枚举出 bundled `/review`（76 个测试）。`server.test.ts` 保持全绿（574）。

端到端（`npm run dev:daemon`，其 preheat 超时、首个 prompt 前子进程从不在线）：
1. 启动、打开 Web Shell，发任何消息之前输入 `/rev`。
2. 按 Tab。

预期（本 PR）：`/review` 在斜杠菜单里，Tab 把 `/rev` 补成 `/review [pr-number|file-path] [--comment]`。修复前：`/review` 缺失、Tab 无反应。

### 证据（Before & After）

真实 daemon，建 session 之前 `GET /workspace/skills`：

| 状态 | 修复前（main / 仅缓存） | 修复后（本 PR） |
| --- | --- | --- |
| 子进程被回收、缓存已暖 | `hasReview=true`（回放） | `hasReview=true` |
| **冷启动、preheat 超时（子进程从未在线）** | `initialized=false skillsCount=0` ❌ | `initialized=true skillsCount=25 hasReview=true` ✅ |

真实 `npm run dev:daemon` + Playwright（子进程 preheat 仍在超时）：浏览器 `/workspace/skills` 立即返回 `initialized=true count=25 hasReview=true`，斜杠菜单显示 `/review`，`/rev`+Tab → `/review [pr-number|file-path] [--comment]`。

### 测试平台

仅本地 macOS 验证（单测 + curl + Playwright 真实 UI）；Windows/Linux 未测，交给 CI。

### 运行环境（可选）

本地：`node scripts/dev.js serve` / `npm run dev:daemon`（tsx 源码、loopback），用 curl 和 Playwright 驱动；外加 vitest 单测。

## 风险与范围

- 主要风险／取舍：daemon 本地视图省略扩展提供的技能（子进程外没有活动扩展上下文），也不施加 safe-mode 限制；它只是"子进程就绪前"这个窗口的尽力兜底。子进程在线时仍为权威，缓存又在回收后保留子进程的完整含扩展列表，所以扩展技能只在"从未 preheat 的冷启动窗口"缺席。技能仅用于补全列表——执行仍由子进程把关。
- 未验证／范围之外：不处理 dev 模式子进程 init 为何超过 10s（另一个 preheat/超时议题）；本 PR 让技能无论如何都可用。
- 破坏性变更／迁移：无。有子进程答复或缓存答复时行为完全不变；只有"无子进程且无缓存"这条路径新增了 daemon 本地兜底。

## 关联 Issue

补全 #6153 开始的修复。

</details>
