### PR TITLE
fix: resolve macOS seatbelt profile path from bundle dir, not chunks/

### DIFF
--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -4,10 +4,77 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { FatalSandboxError, QWEN_DIR } from '@qwen-code/qwen-code-core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { isContainerPathWithinWorkdir } from './sandbox-path.js';
+import { resolveSeatbeltProfileFile, start_sandbox } from './sandbox.js';
 import { parseSandboxImageName } from './sandboxImageName.js';
 import { parseSandboxMountSpec } from './sandboxMounts.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe('resolveSeatbeltProfileFile', () => {
+  it('strips the chunks segment from bundled seatbelt profile paths', () => {
+    const bundleDir = path.resolve(path.sep, 'tmp', 'qwen', 'lib');
+    const chunkUrl = pathToFileURL(
+      path.join(bundleDir, 'chunks', 'sandbox-AAAA.js'),
+    ).toString();
+
+    expect(resolveSeatbeltProfileFile('permissive-open', chunkUrl)).toBe(
+      path.join(bundleDir, 'sandbox-macos-permissive-open.sb'),
+    );
+  });
+
+  it('keeps source-mode seatbelt profile paths next to the module', () => {
+    const utilsDir = path.resolve(
+      path.sep,
+      'repo',
+      'packages',
+      'cli',
+      'src',
+      'utils',
+    );
+    const sourceUrl = pathToFileURL(
+      path.join(utilsDir, 'sandbox.ts'),
+    ).toString();
+
+    expect(resolveSeatbeltProfileFile('restrictive-closed', sourceUrl)).toBe(
+      path.join(utilsDir, 'sandbox-macos-restrictive-closed.sb'),
+    );
+  });
+
+  it('keeps custom seatbelt profiles under project settings', () => {
+    const bundleDir = path.resolve(path.sep, 'tmp', 'qwen', 'lib');
+    const chunkUrl = pathToFileURL(
+      path.join(bundleDir, 'chunks', 'sandbox-AAAA.js'),
+    ).toString();
+
+    expect(resolveSeatbeltProfileFile('project-profile', chunkUrl)).toBe(
+      path.join(QWEN_DIR, 'sandbox-macos-project-profile.sb'),
+    );
+  });
+
+  it('throws missing file errors with the resolved seatbelt profile path', async () => {
+    vi.stubEnv('SEATBELT_PROFILE', 'permissive-open');
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+    const expectedPath = resolveSeatbeltProfileFile('permissive-open');
+
+    await expect(
+      start_sandbox({ command: 'sandbox-exec', image: '' }),
+    ).rejects.toThrow(
+      new FatalSandboxError(
+        `Missing macos seatbelt profile file '${expectedPath}'`,
+      ),
+    );
+  });
+});
 
 describe('isContainerPathWithinWorkdir', () => {
   it('allows the workdir itself', () => {

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -8,7 +8,6 @@ import { exec, execSync, spawn, type ChildProcess } from 'node:child_process';
 import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import { quote, parse } from 'shell-quote';
 import {
   getUserSettingsDir,
@@ -20,6 +19,7 @@ import {
   FatalSandboxError,
   Storage,
   isSubpath,
+  resolveBundleDir,
 } from '@qwen-code/qwen-code-core';
 import { randomBytes } from 'node:crypto';
 import { writeStderrLine } from './stdioHelpers.js';
@@ -60,6 +60,20 @@ const BUILTIN_SEATBELT_PROFILES = [
   'restrictive-closed',
   'restrictive-proxied',
 ];
+
+export function resolveSeatbeltProfileFile(
+  profile: string,
+  importMetaUrl = import.meta.url,
+): string {
+  if (!BUILTIN_SEATBELT_PROFILES.includes(profile)) {
+    return path.join(SETTINGS_DIRECTORY_NAME, `sandbox-macos-${profile}.sb`);
+  }
+
+  return path.join(
+    resolveBundleDir(importMetaUrl),
+    `sandbox-macos-${profile}.sb`,
+  );
+}
 
 /**
  * Determines whether the sandbox container should be run with the current user's UID and GID.
@@ -189,16 +203,7 @@ export async function start_sandbox(
     }
 
     const profile = (process.env['SEATBELT_PROFILE'] ??= 'permissive-open');
-    let profileFile = fileURLToPath(
-      new URL(`sandbox-macos-${profile}.sb`, import.meta.url),
-    );
-    // if profile name is not recognized, then look for file under project settings directory
-    if (!BUILTIN_SEATBELT_PROFILES.includes(profile)) {
-      profileFile = path.join(
-        SETTINGS_DIRECTORY_NAME,
-        `sandbox-macos-${profile}.sb`,
-      );
-    }
+    const profileFile = resolveSeatbeltProfileFile(profile);
     if (!fs.existsSync(profileFile)) {
       throw new FatalSandboxError(
         `Missing macos seatbelt profile file '${profileFile}'`,


### PR DESCRIPTION
## What this PR does

Resolves the built-in macOS seatbelt (`.sb`) profile path from the bundle directory instead of the `lib/chunks/` directory the bundled entry runs from. Built-in profiles now load correctly from a packaged install, while a user-supplied `SEATBELT_PROFILE` path still resolves under `.qwen` unchanged.

## Why it's needed

On macOS, launching the sandbox from a bundled build failed because the seatbelt profile lookup joined the profile filename onto the chunk directory (`lib/chunks/`) rather than the directory the `.sb` files actually ship in (`lib/`). The built-in profiles came back as missing and the sandbox refused to start. Source and dev runs happened to resolve correctly, so the break only surfaced in packaged installs, as reported in the linked issue.

## Reviewer Test Plan

### How to verify

Run the sandbox unit tests: `cd packages/cli && npx vitest run src/utils/sandbox.test.ts`. The suite covers bundled chunk paths resolving back to `lib/`, source/dev paths, a custom `SEATBELT_PROFILE`, and the missing-file error path. Expected: all tests pass. Before the fix, the bundled-path case resolved to `lib/chunks/<profile>.sb` (missing); after, it resolves to `lib/<profile>.sb`.

### Evidence (Before & After)

Non-UI change (path resolution). Verified via unit tests: `sandbox.test.ts` — 21 tests pass. `prettier --check` clean on both changed files.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Local unit tests via vitest. macOS seatbelt path only; Windows/Linux do not exercise this code path.

## Risk & Scope

- Main risk or tradeoff: changes only the built-in profile path resolution; a regression would surface as a missing-profile error, caught by the added tests.
- Not validated / out of scope: user-supplied `SEATBELT_PROFILE` behavior is unchanged and covered by an existing test.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #6089

<details>
<summary>中文说明</summary>

在 macOS 上，从打包构建启动沙箱时，内置 seatbelt（`.sb`）配置文件的路径被解析到了 `lib/chunks/` 目录，而不是这些文件实际所在的 `lib/` 目录，导致内置配置文件缺失、沙箱无法启动。本 PR 改为从 bundle 目录解析内置 `.sb` 文件，使打包安装能正确加载；用户自定义的 `SEATBELT_PROFILE` 路径仍在 `.qwen` 下解析，行为不变。已通过 `sandbox.test.ts`（21 个测试）验证。

</details>
