### PR TITLE
feat(channels): add DingTalk proactive send for channel loops

### DIFF
--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -6344,7 +6344,7 @@ describe('ChannelBase', () => {
       expect(bridge.prompt).toHaveBeenCalledTimes(2);
       expect(bridge.prompt).toHaveBeenLastCalledWith(
         expect.any(String),
-        '[Loop "daily summary" created by Alice]\n\npost summary',
+        '[Loop "daily summary" created by Alice] Scheduled task running unattended: no one is present to answer questions, and your final response is delivered to this chat automatically — do whatever work the task requires, then put the result in your final response instead of trying to deliver it to this chat yourself.\n\npost summary',
         {},
       );
       expect(ch.proactive).toEqual([
@@ -6396,7 +6396,7 @@ describe('ChannelBase', () => {
         [
           'Channel memory for this chat:\nUse staging.',
           'Use repo conventions.',
-          '[Loop "daily summary" created by Alice]\n\npost summary',
+          '[Loop "daily summary" created by Alice] Scheduled task running unattended: no one is present to answer questions, and your final response is delivered to this chat automatically — do whatever work the task requires, then put the result in your final response instead of trying to deliver it to this chat yourself.\n\npost summary',
         ].join('\n\n'),
       );
     });
@@ -6450,14 +6450,14 @@ describe('ChannelBase', () => {
       expect(promptMock.mock.calls[0]![1]).toBe(
         [
           'Use repo conventions.',
-          '[Loop "daily summary" created by Alice]\n\npost summary',
+          '[Loop "daily summary" created by Alice] Scheduled task running unattended: no one is present to answer questions, and your final response is delivered to this chat automatically — do whatever work the task requires, then put the result in your final response instead of trying to deliver it to this chat yourself.\n\npost summary',
         ].join('\n\n'),
       );
       expect(promptMock.mock.calls[1]![1]).toBe(
         [
           'Channel memory for this chat:\nUse staging.',
           'Use repo conventions.',
-          '[Loop "daily summary" created by Alice]\n\npost summary',
+          '[Loop "daily summary" created by Alice] Scheduled task running unattended: no one is present to answer questions, and your final response is delivered to this chat automatically — do whatever work the task requires, then put the result in your final response instead of trying to deliver it to this chat yourself.\n\npost summary',
         ].join('\n\n'),
       );
     });
@@ -6919,7 +6919,7 @@ describe('ChannelBase', () => {
         expect(bridge.newSession).toHaveBeenCalledTimes(1);
         expect(bridge.prompt).toHaveBeenLastCalledWith(
           's-1',
-          '[Loop "daily summary" created by Alice]\n\npost again',
+          '[Loop "daily summary" created by Alice] Scheduled task running unattended: no one is present to answer questions, and your final response is delivered to this chat automatically — do whatever work the task requires, then put the result in your final response instead of trying to deliver it to this chat yourself.\n\npost again',
           {},
         );
         expect(ch.proactive).toEqual([

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -304,7 +304,9 @@ export abstract class ChannelBase {
     );
     const label = sanitizeQuotedText(job.label || job.id, 80);
     const createdBy = sanitizeSenderName(job.createdBy || 'unknown');
-    let promptText = `[Loop "${label}" created by ${createdBy}]\n\n${sanitizePromptText(job.prompt)}`;
+    // Without the delivery-contract sentence the model treats "post X" prompts
+    // as an action it must perform itself and goes hunting for send credentials.
+    let promptText = `[Loop "${label}" created by ${createdBy}] Scheduled task running unattended: no one is present to answer questions, and your final response is delivered to this chat automatically — do whatever work the task requires, then put the result in your final response instead of trying to deliver it to this chat yourself.\n\n${sanitizePromptText(job.prompt)}`;
     const shouldPrependSessionContext = !this.instructedSessions.has(sessionId);
 
     const prev = this.sessionQueues.get(sessionId) ?? Promise.resolve();

--- a/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { DWClientDownStream } from 'dingtalk-stream-sdk-nodejs';
+import type { SessionTarget } from '@qwen-code/channel-base';
 
 const dingtalkSdkMock = vi.hoisted(() => ({
   instances: [] as unknown[],
@@ -545,5 +546,213 @@ describe('DingtalkChannel sender attribution', () => {
         messageId: 'header-m1',
       }),
     );
+  });
+});
+
+describe('DingtalkChannel proactive send', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const groupTarget: SessionTarget = {
+    channelName: 'test-dingtalk',
+    senderId: '443056',
+    chatId: 'cidk4iA51FpTrRlziR0ilUYeg==',
+    isGroup: true,
+  };
+
+  function proactive(channel: DingtalkChannelInstance) {
+    return channel as unknown as {
+      supportsProactiveTarget(target: SessionTarget): boolean;
+      pushProactive(target: SessionTarget, text: string): Promise<void>;
+    };
+  }
+
+  function stubProactiveFetch(
+    sendHandler: (sendCall: number) => Response = () =>
+      new Response('{}', { status: 200 }),
+    tokenHandler: () => Response = () =>
+      new Response(
+        JSON.stringify({
+          errcode: 0,
+          access_token: 'proactive-token',
+          expires_in: 7200,
+        }),
+        { status: 200 },
+      ),
+  ) {
+    let sendCall = 0;
+    const spy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.startsWith('https://oapi.dingtalk.com/gettoken')) {
+          return Promise.resolve(tokenHandler());
+        }
+        return Promise.resolve(sendHandler(sendCall++));
+      });
+    const calls = (prefix: string) =>
+      spy.mock.calls.filter((c) => String(c[0]).startsWith(prefix));
+    return {
+      spy,
+      sendCalls: () =>
+        calls('https://api.dingtalk.com/v1.0/robot/groupMessages/send'),
+      tokenCalls: () => calls('https://oapi.dingtalk.com/gettoken'),
+    };
+  }
+
+  function msgParamOf(call: unknown[]): { title: string; text: string } {
+    const body = JSON.parse(String((call[1] as RequestInit).body));
+    return JSON.parse(body.msgParam);
+  }
+
+  it('opts into proactive send', () => {
+    expect(createChannel().supportsProactiveSend()).toBe(true);
+  });
+
+  it('accepts only group conversation targets', () => {
+    const channel = proactive(createChannel());
+    expect(channel.supportsProactiveTarget(groupTarget)).toBe(true);
+    expect(
+      channel.supportsProactiveTarget({ ...groupTarget, isGroup: false }),
+    ).toBe(false);
+    expect(
+      channel.supportsProactiveTarget({
+        channelName: groupTarget.channelName,
+        senderId: groupTarget.senderId,
+        chatId: groupTarget.chatId,
+      }),
+    ).toBe(false);
+    expect(
+      channel.supportsProactiveTarget({
+        ...groupTarget,
+        chatId: 'https://oapi.dingtalk.com/robot/sendBySession?session=abc',
+      }),
+    ).toBe(false);
+    expect(
+      channel.supportsProactiveTarget({ ...groupTarget, chatId: '' }),
+    ).toBe(false);
+    expect(
+      channel.supportsProactiveTarget({ ...groupTarget, threadId: '7' }),
+    ).toBe(false);
+  });
+
+  it('sends proactive group messages through the robot API', async () => {
+    const channel = proactive(createChannel());
+    const { sendCalls, tokenCalls } = stubProactiveFetch();
+
+    await channel.pushProactive(groupTarget, '# Result\nloop output');
+
+    expect(tokenCalls()).toHaveLength(1);
+    const sends = sendCalls();
+    expect(sends).toHaveLength(1);
+    const init = sends[0]![1] as RequestInit;
+    expect(init.method).toBe('POST');
+    expect(
+      (init.headers as Record<string, string>)['x-acs-dingtalk-access-token'],
+    ).toBe('proactive-token');
+    const body = JSON.parse(String(init.body));
+    expect(body.robotCode).toBe('client-id');
+    expect(body.openConversationId).toBe(groupTarget.chatId);
+    expect(body.msgKey).toBe('sampleMarkdown');
+    expect(msgParamOf(sends[0]!).title).toBe('Result');
+    expect(msgParamOf(sends[0]!).text).toContain('loop output');
+  });
+
+  it('reuses the cached token across sends', async () => {
+    const channel = proactive(createChannel());
+    const { tokenCalls } = stubProactiveFetch();
+
+    await channel.pushProactive(groupTarget, 'first');
+    await channel.pushProactive(groupTarget, 'second');
+
+    expect(tokenCalls()).toHaveLength(1);
+  });
+
+  it('splits long proactive messages into continuation chunks', async () => {
+    const channel = proactive(createChannel());
+    const { sendCalls } = stubProactiveFetch();
+
+    const longLine = 'x'.repeat(100);
+    const longText = Array.from({ length: 50 }, () => longLine).join('\n');
+    await channel.pushProactive(groupTarget, longText);
+
+    const sends = sendCalls();
+    expect(sends).toHaveLength(2);
+    expect(msgParamOf(sends[0]!).title).not.toContain('(cont.)');
+    expect(msgParamOf(sends[1]!).title).toContain('(cont.)');
+  });
+
+  it('stops at the first failed chunk', async () => {
+    const channel = proactive(createChannel());
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const { sendCalls } = stubProactiveFetch(
+      () => new Response('denied', { status: 403 }),
+    );
+
+    const longLine = 'x'.repeat(100);
+    const longText = Array.from({ length: 50 }, () => longLine).join('\n');
+    await expect(channel.pushProactive(groupTarget, longText)).rejects.toThrow(
+      'HTTP 403',
+    );
+
+    expect(sendCalls()).toHaveLength(1);
+  });
+
+  it('surfaces API detail in the error and log on failure', async () => {
+    const channel = proactive(createChannel());
+    const writeSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    stubProactiveFetch(() => new Response('perm denied', { status: 403 }));
+
+    await expect(channel.pushProactive(groupTarget, 'hello')).rejects.toThrow(
+      'DingTalk proactive send failed: HTTP 403 perm denied',
+    );
+
+    const logged = writeSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(logged).toContain(
+      'proactive send failed (chunk 1/1): HTTP 403 perm denied',
+    );
+  });
+
+  it('refreshes the token and retries once on 401', async () => {
+    const channel = proactive(createChannel());
+    const { sendCalls, tokenCalls } = stubProactiveFetch((sendCall) =>
+      sendCall === 0
+        ? new Response('expired', { status: 401 })
+        : new Response('{}', { status: 200 }),
+    );
+
+    await channel.pushProactive(groupTarget, 'hello');
+
+    expect(sendCalls()).toHaveLength(2);
+    expect(tokenCalls()).toHaveLength(2);
+  });
+
+  it('throws when the token endpoint rejects', async () => {
+    const channel = proactive(createChannel());
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    stubProactiveFetch(
+      undefined,
+      () =>
+        new Response(
+          JSON.stringify({ errcode: 40089, errmsg: 'invalid credential' }),
+          { status: 200 },
+        ),
+    );
+
+    await expect(channel.pushProactive(groupTarget, 'hello')).rejects.toThrow(
+      'gettoken errcode=40089',
+    );
+  });
+
+  it('skips blank text without calling the API', async () => {
+    const channel = proactive(createChannel());
+    const { spy } = stubProactiveFetch();
+
+    await channel.pushProactive(groupTarget, '   \n ');
+
+    expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -17,6 +17,7 @@ import type {
   ChannelBaseOptions,
   Envelope,
   ChannelAgentBridge,
+  SessionTarget,
 } from '@qwen-code/channel-base';
 
 /**
@@ -80,6 +81,17 @@ const ACK_REACTION_NAME = '👀';
 const ACK_EMOTION_ID = '2659900';
 const ACK_EMOTION_BG_ID = 'im_bg_1';
 const EMOTION_API = 'https://api.dingtalk.com/v1.0/robot/emotion';
+const GROUP_MSG_API = 'https://api.dingtalk.com/v1.0/robot/groupMessages/send';
+const GROUP_MSG_KEY = 'sampleMarkdown'; // DingTalk's built-in {title, text} markdown template key
+const TOKEN_API = 'https://oapi.dingtalk.com/gettoken';
+const PROACTIVE_FETCH_TIMEOUT_MS = 15_000;
+
+interface DingTalkTokenResponse {
+  errcode?: number;
+  errmsg?: string;
+  access_token?: string;
+  expires_in?: number;
+}
 
 type DingTalkClientInternals = DWClient & {
   debug: boolean;
@@ -95,6 +107,11 @@ export class DingtalkChannel extends ChannelBase {
   private dedupTimer?: ReturnType<typeof setInterval>;
   /** Map conversationId → latest sessionWebhook URL for sending replies. */
   private webhooks: Map<string, string> = new Map();
+  /**
+   * Token cache for proactive sends. The stream SDK only refreshes its token
+   * on (re)connect, so a long-lived socket serves a stale one after ~2h.
+   */
+  private proactiveToken?: { token: string; expiresAt: number };
 
   constructor(
     name: string,
@@ -308,6 +325,137 @@ export class DingtalkChannel extends ChannelBase {
     }
   }
 
+  override supportsProactiveSend(): boolean {
+    return true;
+  }
+
+  /**
+   * The group-message API needs a real openConversationId — reject DMs
+   * (a different API) and webhook-URL fallback chatIds.
+   */
+  protected override supportsProactiveTarget(target: SessionTarget): boolean {
+    return (
+      target.isGroup === true &&
+      target.threadId === undefined &&
+      this.isConversationId(target.chatId)
+    );
+  }
+
+  /**
+   * Single-shot cold send: a failed chunk aborts the remainder (already-sent
+   * chunks are not recalled) and the error surfaces in the loop's lastError.
+   */
+  protected override async pushProactive(
+    target: SessionTarget,
+    text: string,
+  ): Promise<void> {
+    if (!text.trim()) return;
+
+    const chunks = normalizeDingTalkMarkdown(text);
+    const title = extractTitle(text);
+
+    for (let i = 0; i < chunks.length; i++) {
+      await this.sendProactiveChunk(
+        target.chatId,
+        i === 0 ? title : `${title} (cont.)`,
+        chunks[i]!,
+        `chunk ${i + 1}/${chunks.length}`,
+      );
+    }
+  }
+
+  private async getProactiveToken(): Promise<string> {
+    const cached = this.proactiveToken;
+    if (cached && Date.now() < cached.expiresAt) return cached.token;
+
+    const url = `${TOKEN_API}?appkey=${encodeURIComponent(
+      this.config.clientId!,
+    )}&appsecret=${encodeURIComponent(this.config.clientSecret!)}`;
+    let data: DingTalkTokenResponse;
+    try {
+      const resp = await fetch(url, {
+        signal: AbortSignal.timeout(PROACTIVE_FETCH_TIMEOUT_MS),
+      });
+      data = (await resp.json()) as DingTalkTokenResponse;
+    } catch (err) {
+      process.stderr.write(
+        `[DingTalk:${this.name}] proactive send failed: token fetch error ${err}\n`,
+      );
+      throw new Error(
+        'DingTalk proactive send failed: could not fetch access token',
+      );
+    }
+    if (!data.access_token) {
+      const errmsg = sanitizeLogText(String(data.errmsg ?? ''), 200);
+      process.stderr.write(
+        `[DingTalk:${this.name}] proactive send failed: gettoken errcode=${data.errcode} ${errmsg}\n`,
+      );
+      throw new Error(
+        `DingTalk proactive send failed: gettoken errcode=${data.errcode}${errmsg ? ` ${errmsg}` : ''}`,
+      );
+    }
+    this.proactiveToken = {
+      token: data.access_token,
+      // Refresh a minute early so a fire mid-expiry doesn't race the TTL.
+      expiresAt:
+        Date.now() + Math.max(60, (data.expires_in ?? 7200) - 60) * 1000,
+    };
+    return data.access_token;
+  }
+
+  private async sendProactiveChunk(
+    conversationId: string,
+    title: string,
+    text: string,
+    chunkLabel: string,
+  ): Promise<void> {
+    for (let attempt = 0; ; attempt++) {
+      const token = await this.getProactiveToken();
+      let resp: Response;
+      try {
+        resp = await fetch(GROUP_MSG_API, {
+          method: 'POST',
+          headers: {
+            'x-acs-dingtalk-access-token': token,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            robotCode: this.config.clientId!,
+            openConversationId: conversationId,
+            msgKey: GROUP_MSG_KEY,
+            msgParam: JSON.stringify({ title, text }),
+          }),
+          signal: AbortSignal.timeout(PROACTIVE_FETCH_TIMEOUT_MS),
+        });
+      } catch (err) {
+        const cause = (err as { cause?: unknown }).cause;
+        process.stderr.write(
+          `[DingTalk:${this.name}] proactive send error (${chunkLabel}): ${err}${cause ? ` (${cause})` : ''}\n`,
+        );
+        throw new Error(
+          `DingTalk proactive send failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+      if (resp.status === 401 && attempt === 0) {
+        // Stale or revoked token — refresh once and retry this chunk.
+        this.proactiveToken = undefined;
+        await resp.body?.cancel();
+        continue;
+      }
+      if (!resp.ok) {
+        const detail = sanitizeLogText(await resp.text().catch(() => ''), 300);
+        process.stderr.write(
+          `[DingTalk:${this.name}] proactive send failed (${chunkLabel}): HTTP ${resp.status} ${detail}\n`,
+        );
+        throw new Error(
+          `DingTalk proactive send failed: HTTP ${resp.status}${detail ? ` ${detail}` : ''}`,
+        );
+      }
+      await resp.body?.cancel();
+      return;
+    }
+  }
+
   private getAccessToken(): string | undefined {
     return this.client.getConfig().access_token;
   }
@@ -379,8 +527,8 @@ export class DingtalkChannel extends ChannelBase {
 
   /**
    * The chatId passed to onPromptStart/onPromptEnd is `conversationId ||
-   * sessionWebhook` (see message handler below). Reactions require a real
-   * conversation ID — skip the webhook-URL fallback case.
+   * sessionWebhook` (see message handler below). Reactions and proactive
+   * sends require a real conversation ID — skip the webhook-URL fallback case.
    */
   private isConversationId(chatId: string): boolean {
     return !!chatId && !/^https?:\/\//i.test(chatId);


### PR DESCRIPTION
## What this PR does

This teaches the DingTalk channel adapter to send messages proactively, so a channel loop can post its scheduled result into a DingTalk group even when nobody has just spoken. Until now the adapter could only reply through the per-message `sessionWebhook`, which expires and only exists right after an inbound message, so DingTalk rejected `/loop add` outright and could never deliver a scheduled result cold. The adapter now opts into proactive send, delivers through DingTalk's robot group-message API (`robotCode` + `openConversationId` + a self-managed access token), reuses the existing markdown conversion and chunking, and restricts proactive delivery to real group conversation targets — direct messages and webhook-URL fallback targets are rejected before anything is sent.

This PR also adds one line to the prompt that fires a scheduled loop. A loop turn runs unattended and its final response is delivered to the chat automatically, but the model was not told that, so a prompt like "post a summary to the group" was read as an action the model had to carry out itself, and it went looking for a webhook to send through instead of just producing the summary. The new line states the delivery contract explicitly while still allowing the model to run whatever tools the task needs.

## Why it's needed

Channel loops (#6073) gate loop creation on adapter proactive-send support, and #6068 explicitly deferred DingTalk cold-send as a non-goal, so DingTalk users could not use `/loop` at all. Alongside that, the missing delivery-contract line made even a correctly-created loop misbehave: the model treated "send X to the chat" as its own job and asked the user for a webhook URL, which is exactly the confusion this fixes. Together these make channel loops actually usable on DingTalk.

## Reviewer Test Plan

### How to verify

Automated: from `packages/channels/dingtalk` run `npx vitest run` (52 tests) and from `packages/channels/base` run `npx vitest run src/ChannelBase.test.ts src/ChannelLoopScheduler.test.ts src/ChannelLoopStore.test.ts` (272 tests); both suites pass, and `npx tsc --noEmit -p .` is clean in each package. The new DingTalk tests assert the request shape (URL, token header, `robotCode`, `openConversationId`, `msgKey`), token caching and reuse, a single 401 refresh-and-retry, `gettoken` failure surfacing, chunk splitting with continuation titles, fail-fast on the first failed chunk, sanitized error detail, and blank-text skipping. The base tests assert the delivery-contract line is present on every fire, including a second fire on the same session.

Manual (optional, needs a DingTalk app with robot message-send permission granted in the developer console): configure a DingTalk channel, run `npm start -- channel start <name>`, in a group send `/loop add "*/1 * * * *" report the current time`, and confirm the bot posts the result into the group with no prior inbound message; `/loop inspect <id>` shows `lastStatus: ok`; a DM `/loop add` is rejected as an unsupported target.

### Evidence (Before & After)

Before: `/loop add` in a DingTalk group is rejected with "This channel does not support proactive loop messages"; a loop whose prompt asks to post something makes the model reply by asking the user for a webhook URL. After: the loop is created and the scheduled result is delivered into the group directly, containing the requested content.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ unit tests + manual DingTalk group loop |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS, `npm start -- channel start` against a live DingTalk stream bot; unit tests via vitest per package.

## Risk & Scope

- Main risk or tradeoff: proactive send depends on the robot group-message API and the DingTalk app must have message-send permission granted; without it sends fail with a permission error, which now surfaces in the loop's `lastError` rather than failing silently. A failed chunk aborts the remaining chunks (already-sent chunks are not recalled).
- Not validated / out of scope: direct-message proactive send (a different API) is intentionally not implemented and DM targets report unsupported; no chunk-level rate-limit pacing; wiring loops/channel memory into the daemon-managed channel worker (`serve --channel`) is a separate gap not addressed here.
- Breaking changes / migration notes: none. DingTalk proactive send was previously unsupported, so no existing DingTalk loops can exist to migrate; the delivery-contract line only augments the scheduled-loop prompt and does not change the reply path.

## Linked Issues

Closes #6168

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让钉钉渠道适配器支持主动发送消息，这样即使当下没人说话，channel loop 也能把定时任务的结果发进钉钉群。此前适配器只能通过每条消息自带的 `sessionWebhook` 回复，而这个 webhook 会过期、且只在收到消息后短暂存在，所以钉钉会直接拒绝 `/loop add`，也永远无法冷启动地投递定时结果。现在适配器声明支持主动发送，通过钉钉机器人群消息 API（`robotCode` + `openConversationId` + 自管的 access token）投递，复用现有的 markdown 转换与分块，并且只允许推送到真实的群会话目标——私聊和以过期 webhook URL 兜底的目标会在发送前被拒绝。

这个 PR 还给触发定时 loop 的提示词加了一行说明。loop 回合是无人值守运行的，它的最终回复会被自动投递到聊天里，但模型此前并不知道这一点，所以像"把摘要发到群里"这样的提示词会被理解成模型自己要去执行的动作，于是它跑去找 webhook 来发送，而不是直接产出摘要。新加的这行明确声明了投递契约，同时仍然允许模型运行任务所需的各种工具。

## 为什么需要

channel loops（#6073）会以适配器是否支持主动发送作为创建 loop 的前置条件，而 #6068 明确把钉钉冷发送列为暂不实现的 non-goal，所以钉钉用户根本无法使用 `/loop`。与此同时，缺失的投递契约说明会让即便正确创建的 loop 也表现异常：模型把"把 X 发到聊天里"当成自己的活儿，转而向用户索要 webhook URL，这正是本次修复的困惑点。两处改动合在一起，让 channel loops 在钉钉上真正可用。

## Reviewer Test Plan

### 如何验证

自动化：在 `packages/channels/dingtalk` 下运行 `npx vitest run`（52 个测试），在 `packages/channels/base` 下运行 `npx vitest run src/ChannelBase.test.ts src/ChannelLoopScheduler.test.ts src/ChannelLoopStore.test.ts`（272 个测试），两个套件均通过，且每个包的 `npx tsc --noEmit -p .` 都干净。新增的钉钉测试断言了请求形状（URL、token 头、`robotCode`、`openConversationId`、`msgKey`）、token 缓存与复用、一次 401 的刷新重试、`gettoken` 失败的透出、带续块标题的分块、首个 chunk 失败即中止、消毒后的错误详情、以及空白文本跳过。base 测试断言了每次触发都带上投递契约说明，包括同一会话的第二次触发。

手动（可选，需要在钉钉开放平台后台给应用授予机器人消息发送权限）：配置一个钉钉渠道，运行 `npm start -- channel start <name>`，在群里发送 `/loop add "*/1 * * * *" report the current time`，确认机器人在没有前置消息的情况下把结果发进群；`/loop inspect <id>` 显示 `lastStatus: ok`；私聊里的 `/loop add` 会被作为不支持的目标拒绝。

### 证据（Before & After）

之前：在钉钉群里 `/loop add` 会被拒绝，提示 "This channel does not support proactive loop messages"；一个提示词要求发送内容的 loop 会让模型回复向用户索要 webhook URL。之后：loop 被成功创建，定时结果被直接投递进群，内容就是所请求的内容。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 单元测试 + 手动钉钉群 loop |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

macOS，`npm start -- channel start` 连接真实钉钉 stream 机器人；单元测试通过各包的 vitest 运行。

## 风险与范围

- 主要风险/取舍：主动发送依赖机器人群消息 API，钉钉应用必须已授予消息发送权限；未授予时发送会失败并返回权限错误，现在这个错误会体现在 loop 的 `lastError` 里，而不是静默失败。某个 chunk 失败会中止后续 chunk（已发出的 chunk 不会撤回）。
- 未验证/范围外：私聊主动发送（另一个 API）有意不实现，私聊目标会报不支持；没有做 chunk 级别的限流节流；把 loops/channel memory 接线进 daemon 托管的 channel worker（`serve --channel`）是另一个缺口，本 PR 不处理。
- 破坏性变更/迁移说明：无。钉钉主动发送此前不支持，所以不存在需要迁移的既有钉钉 loop；投递契约说明只是增强了定时 loop 的提示词，不改变回复路径。

## 关联 Issue

Closes #6168

</details>
