### PR TITLE
test: stabilize plan mode tool-control E2E

### DIFF
--- a/integration-tests/sdk-typescript/tool-control.test.ts
+++ b/integration-tests/sdk-typescript/tool-control.test.ts
@@ -19,6 +19,7 @@ import {
   type SDKMessage,
   type SDKUserMessage,
 } from '@qwen-code/sdk';
+import { fakeToolCall, startFakeOpenAIServer } from '../fake-openai-server.js';
 import {
   SDKTestHelper,
   extractText,
@@ -1030,12 +1031,35 @@ describe('Tool Control Parameters (E2E)', () => {
         await helper.createFile('test.txt', 'original');
 
         const canUseToolCalls: string[] = [];
+        const fakeServer = await startFakeOpenAIServer(({ requestIndex }) => {
+          if (requestIndex === 0) {
+            return {
+              toolCalls: [
+                fakeToolCall('read_file', {
+                  file_path: helper.getPath('test.txt'),
+                }),
+              ],
+            };
+          }
+
+          return { content: 'Plan: leave the file unchanged.' };
+        });
 
         const q = query({
           prompt: 'Read test.txt and write "modified" to it.',
           options: {
             ...SHARED_TEST_OPTIONS,
             cwd: testDir,
+            model: 'fake-model',
+            env: {
+              NO_PROXY: '127.0.0.1,localhost',
+              no_proxy: '127.0.0.1,localhost',
+              OPENAI_API_KEY: 'fake-key',
+              OPENAI_BASE_URL: fakeServer.baseUrl,
+              OPENAI_MODEL: 'fake-model',
+              QWEN_MODEL: 'fake-model',
+            },
+            authType: 'openai',
             permissionMode: 'plan',
             // allowedTools should be overridden by plan mode
             allowedTools: ['write_file'],
@@ -1057,14 +1081,25 @@ describe('Tool Control Parameters (E2E)', () => {
           const toolCalls = findToolCalls(messages);
           const toolNames = toolCalls.map((tc) => tc.toolUse.name);
 
-          // Should be able to read
-          expect(toolNames).toContain('read_file');
+          assertSuccessfulCompletion(messages);
 
-          // write_file should NOT be called in plan mode
-          // (plan mode blocks all write operations)
-          // The AI should respond with a plan instead
+          // read_file should be allowed in plan mode.
+          expect(toolNames).toContain('read_file');
+          const readFileResults = findToolResults(messages, 'read_file');
+          expect(readFileResults.length).toBeGreaterThan(0);
+          for (const result of readFileResults) {
+            expect(result.isError).toBe(false);
+            expect(result.content).toContain('original');
+          }
+
+          // write_file should NOT be called in plan mode.
+          // The fake model responds with a plan after reading the file.
+          expect(toolNames).not.toContain('write_file');
+          expect(canUseToolCalls.length).toBe(0);
+          expect(await helper.readFile('test.txt')).toBe('original');
         } finally {
           await q.close();
+          await fakeServer.close();
         }
       },
       TEST_TIMEOUT,


### PR DESCRIPTION
## What this PR does

This stabilizes the SDK tool-control E2E scenario for plan mode with `allowedTools`. The test now uses a deterministic fake OpenAI server instead of depending on a live model to decide whether and when to call `read_file`.

The scenario still verifies the behavior that matters for the CI failure: plan mode can read the test file, does not call `write_file`, does not invoke the permission callback for a write path, and leaves the file unchanged even though `write_file` is listed in `allowedTools`.

## Why it's needed

The failing E2E CI job reported `expected [] to include 'read_file'`. The old test assumed the model would always call `read_file` before responding, but in plan mode the model can also produce a plan directly. That made the test flaky and caused CI failures unrelated to the code under test.

This PR keeps the `read_file` assertion, but makes it deterministic by driving the model side with the fake OpenAI server. It intentionally does not change core scheduler behavior; this PR is scoped to the E2E CI failure.

## Reviewer Test Plan

### How to verify

Run the SDK tool-control plan-mode scenario and confirm it completes successfully. The collected tool calls should include `read_file`, should not include `write_file`, the permission callback should not be invoked, and the original file content should remain `original`.

### Evidence (Before & After)

N/A for UI evidence. Before this change, CI could fail when no `read_file` call was collected. After this change, the focused SDK E2E scenario uses a fake model response and passes deterministically.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local validation used Node 22, no sandbox, the bundled CLI test entrypoint, and the fake OpenAI server test fixture. Commands run: `npm run build`; `npm run bundle`; `npx prettier --check integration-tests/sdk-typescript/tool-control.test.ts`; `git diff --check`; `QWEN_SANDBOX=false KEEP_OUTPUT=true VERBOSE=true npx vitest run --root ./integration-tests sdk-typescript/tool-control.test.ts -t "permissionMode plan should block all write tools even if allowedTools is set"`.

## Risk & Scope

- Main risk or tradeoff: The E2E now controls the model response for this scenario, so it tests the SDK/tool-control behavior without relying on live model tool selection.
- Not validated / out of scope: This PR does not change or validate core scheduler permission semantics beyond this E2E scenario.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 稳定了 SDK tool-control 里 plan mode + `allowedTools` 的 E2E 场景。测试现在使用确定性的 fake OpenAI server，不再依赖真实模型自行决定是否、以及何时调用 `read_file`。

这个场景仍然验证 CI 失败相关的关键行为：plan mode 可以读取测试文件，不会调用 `write_file`，不会触发写路径的权限回调，并且即使 `write_file` 被列在 `allowedTools` 里，文件内容也保持不变。

## Why it's needed

失败的 E2E CI 报错是 `expected [] to include 'read_file'`。旧测试假设模型一定会先调用 `read_file` 再回答，但在 plan mode 下模型也可能直接输出计划。这让测试变得不稳定，并导致和被测代码无关的 CI 失败。

这个 PR 保留 `read_file` 断言，但通过 fake OpenAI server 驱动模型侧响应，让它变成确定性断言。它有意不修改 core scheduler 行为；这个 PR 的范围只限于修复 E2E CI 异常。

## Reviewer Test Plan

### How to verify

运行 SDK tool-control 的 plan-mode 场景，确认测试成功完成。收集到的工具调用应包含 `read_file`，不应包含 `write_file`；权限回调不应被调用；原始文件内容应保持 `original`。

### Evidence (Before & After)

非 UI 变更，无截图。修改前，当没有收集到 `read_file` 调用时 CI 可能失败。修改后，focused SDK E2E 场景使用 fake model 响应并稳定通过。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地验证使用 Node 22、无 sandbox、bundled CLI 测试入口，以及 fake OpenAI server 测试夹具。已运行命令：`npm run build`；`npm run bundle`；`npx prettier --check integration-tests/sdk-typescript/tool-control.test.ts`；`git diff --check`；`QWEN_SANDBOX=false KEEP_OUTPUT=true VERBOSE=true npx vitest run --root ./integration-tests sdk-typescript/tool-control.test.ts -t "permissionMode plan should block all write tools even if allowedTools is set"`。

## Risk & Scope

- Main risk or tradeoff: 这个 E2E 现在控制了模型响应，因此它测试 SDK/tool-control 行为，不再依赖真实模型的工具选择。
- Not validated / out of scope: 这个 PR 不修改、也不额外验证 core scheduler 的权限语义。
- Breaking changes / migration notes: 无。

## Linked Issues

N/A

</details>