### PR TITLE
fix(cli): drop /effort tier autocompletion for an argument-hint placeholder

### DIFF
--- a/packages/cli/src/ui/commands/effort-command.test.ts
+++ b/packages/cli/src/ui/commands/effort-command.test.ts
@@ -106,15 +106,10 @@ describe('effortCommand', () => {
     expect(res).toMatchObject({ messageType: 'error' });
   });
 
-  it('completes tier prefixes', async () => {
-    expect(await effortCommand.completion!(context, 'hi')).toEqual(['high']);
-    expect(await effortCommand.completion!(context, 'x')).toEqual(['xhigh']);
-    expect(await effortCommand.completion!(context, '')).toEqual([
-      'low',
-      'medium',
-      'high',
-      'xhigh',
-      'max',
-    ]);
+  it('does not offer tier autocompletion (tiers are hinted via argumentHint)', () => {
+    // No completion so bare `/effort` opens the picker instead of auto-picking
+    // the first tier; `/effort <tier>` still parses in the action above.
+    expect(effortCommand.completion).toBeUndefined();
+    expect(effortCommand.argumentHint).toBe('[low|medium|high|xhigh|max]');
   });
 });

--- a/packages/cli/src/ui/commands/effort-command.ts
+++ b/packages/cli/src/ui/commands/effort-command.ts
@@ -28,13 +28,14 @@ export const effortCommand: SlashCommand = {
       { tiers: TIER_LIST },
     );
   },
+  // The tiers show up as a placeholder via argumentHint rather than as
+  // autocompletion suggestions: bare `/effort` should open the picker dialog
+  // (no tier auto-selected), while `/effort <tier>` still sets one directly. A
+  // completion function would surface the tiers as submenu-like entries and let
+  // Enter auto-pick the first one, which we don't want here.
   argumentHint: '[low|medium|high|xhigh|max]',
   kind: CommandKind.BUILT_IN,
   supportedModes: ['interactive', 'non_interactive', 'acp'] as const,
-  completion: async (_context, partialArg) => {
-    const prefix = partialArg.trim().toLowerCase();
-    return REASONING_EFFORT_TIERS.filter((tier) => tier.startsWith(prefix));
-  },
   action: async (
     context: CommandContext,
     actionArgs: string,


### PR DESCRIPTION
## What this PR does

Removes the `/effort` command's tier autocompletion so bare `/effort` reliably opens the interactive picker dialog instead of letting Enter auto-select the first completed tier. The five tiers (`low | medium | high | xhigh | max`) are now surfaced as a placeholder via the command's argument hint rather than as submenu-like completion entries. Typing `/effort <tier>` still sets a tier directly, and non-interactive/ACP mode still lists the tiers.

## Why it's needed

With the completion function enabled, typing `/effort` and pressing Enter could auto-pick the first suggested tier (`low`) instead of opening the picker, and the tiers rendered like subcommand entries in the palette. Surfacing them as an argument-hint placeholder is less intrusive, keeps `/effort` alone mapped to "open the picker", and still documents the accepted values inline. This is a small follow-up polish to the unified reasoning-effort feature (#6072).

## Reviewer Test Plan

### How to verify

Unit + types + lint (from repo root):

```
npx vitest run --root packages/cli src/ui/commands/effort-command.test.ts
npm run typecheck --workspace packages/cli
npx eslint packages/cli/src/ui/commands/effort-command.ts
```

Manual (interactive `npm start`):

1. Type `/effort` and press Enter — the tier picker dialog opens (no tier auto-selected).
2. Type `/effort ` (trailing space) — the argument hint `[low|medium|high|xhigh|max]` shows as a placeholder; there is no tier completion popup.
3. Type `/effort high` and press Enter — effort is set to `high` directly.

### Evidence (Before & After)

Text Before/After (TUI capture not run in this headless environment; a reviewer with a terminal should confirm visually):

- Before: `/effort` + Enter could auto-complete to `/effort low` (first suggestion), and the tiers appeared as completion entries.
- After: `/effort` + Enter opens the picker; the tiers appear only as the `[low|medium|high|xhigh|max]` argument-hint placeholder.

Test output (local): `packages/cli` effort-command 7 tests green (including a new assertion that `completion` is undefined and `argumentHint` is set). Typecheck, ESLint, and Prettier clean.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local: `vitest` unit tests + `tsc --noEmit`, no sandbox. Manual TUI steps above were not run in this headless environment.

## Risk & Scope

- Main risk or tradeoff: minimal — this only removes an optional completion callback. The action still parses `/effort <tier>`, so direct-set behavior is unchanged.
- Not validated / out of scope: live multi-OS TUI capture of the placeholder/picker.
- Breaking changes / migration notes: none. `/effort <tier>` and bare `/effort` (picker) are unchanged; only the tier autocompletion suggestions are removed in favor of the argument-hint placeholder.

## Linked Issues

No tracking issue — follow-up polish to the `/effort` feature introduced in #6072.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

移除 `/effort` 命令的档位自动补全，使单独输入 `/effort` 能可靠地打开交互式选择器对话框，而不是让 Enter 自动选中第一个被补全的档位。五个档位（`low | medium | high | xhigh | max`）现在通过命令的 argument hint 以占位符形式提示，而不再作为类似子菜单的补全项出现。`/effort <tier>` 仍可直接设置档位，非交互/ACP 模式仍会列出档位。

## 为什么需要它

启用补全函数后，输入 `/effort` 并回车可能会自动选中第一个建议档位（`low`）而不是打开选择器，并且档位在命令面板里显示得像子命令项。改用 argument-hint 占位符提示更不打扰，让单独的 `/effort` 保持"打开选择器"的语义，同时仍内联说明可选值。这是对统一推理强度功能（#6072）的一处小的后续打磨。

## Reviewer Test Plan

### 如何验证

单元 + 类型 + lint（仓库根目录执行）：

```
npx vitest run --root packages/cli src/ui/commands/effort-command.test.ts
npm run typecheck --workspace packages/cli
npx eslint packages/cli/src/ui/commands/effort-command.ts
```

手动（交互式 `npm start`）：

1. 输入 `/effort` 并回车——档位选择器对话框打开（未自动选中任何档位）。
2. 输入 `/effort `（带尾随空格）——argument hint `[low|medium|high|xhigh|max]` 以占位符形式显示；没有档位补全弹窗。
3. 输入 `/effort high` 并回车——直接把 effort 设为 `high`。

### 证据（Before & After）

文字版 Before/After（本无头环境未做 TUI 录制，建议有终端的 reviewer 视觉确认）：

- Before：`/effort` + 回车可能自动补全成 `/effort low`（第一个建议），且档位以补全项形式出现。
- After：`/effort` + 回车打开选择器；档位只作为 `[low|medium|high|xhigh|max]` 的 argument-hint 占位符出现。

本地测试输出：`packages/cli` effort-command 7 个测试通过（含新增断言：`completion` 为 undefined、`argumentHint` 已设置）。Typecheck、ESLint、Prettier 均干净。

### 测试平台

macOS：✅（单测 + 类型检查 + lint）。Windows / Linux：⚠️ 依赖 CI。

### 环境（可选）

本地：`vitest` 单测 + `tsc --noEmit`，无沙箱。上述手动 TUI 步骤未在本无头环境执行。

## 风险与范围

- 主要风险/取舍：极小——只移除了一个可选的补全回调。action 仍解析 `/effort <tier>`，直接设置行为不变。
- 未验证 / 超出范围：占位符/选择器的多平台 TUI 实机录制。
- 破坏性变更 / 迁移说明：无。`/effort <tier>` 与单独 `/effort`（选择器）行为不变；仅把档位自动补全建议替换为 argument-hint 占位符。

## 关联 Issue

暂无跟踪 issue——对 #6072 引入的 `/effort` 功能的后续打磨。

</details>
