### PR TITLE
fix(core): prevent subagent crash when ${hook_context} placeholder has no hook configured

### DIFF
--- a/packages/core/src/agents/background-agent-resume.test.ts
+++ b/packages/core/src/agents/background-agent-resume.test.ts
@@ -44,7 +44,17 @@ describe('BackgroundAgentResumeService', () => {
     });
   });
 
-  function createService(options: { stopHookBlockingCap?: number } = {}) {
+  function createService(
+    options: {
+      stopHookBlockingCap?: number;
+      hookSystem?:
+        | {
+            fireSubagentStartEvent: ReturnType<typeof vi.fn>;
+            fireSubagentStopEvent: ReturnType<typeof vi.fn>;
+          }
+        | undefined;
+    } = {},
+  ) {
     const subagentManager = {
       loadSubagent: vi.fn(async (name: string) =>
         name === 'researcher'
@@ -56,10 +66,13 @@ describe('BackgroundAgentResumeService', () => {
       ),
       createAgentHeadless: vi.fn(),
     };
-    const hookSystem = {
-      fireSubagentStartEvent: vi.fn().mockResolvedValue(undefined),
-      fireSubagentStopEvent: vi.fn().mockResolvedValue(undefined),
-    };
+    const hookSystem =
+      options.hookSystem !== undefined
+        ? options.hookSystem
+        : {
+            fireSubagentStartEvent: vi.fn().mockResolvedValue(undefined),
+            fireSubagentStopEvent: vi.fn().mockResolvedValue(undefined),
+          };
     // Stub registry exposed on both `parent.getToolRegistry()` and the
     // override built by `createApprovalModeOverride` (which now rebuilds
     // the tool registry on the resumed agent's Config so bound tools
@@ -471,6 +484,84 @@ describe('BackgroundAgentResumeService', () => {
     await vi.waitFor(() => {
       expect(registry.get(agentId)?.status).toBe('completed');
     });
+  });
+
+  it('sets hook_context to empty string when no hook system is configured', async () => {
+    const sessionId = 'session-no-hook';
+    const agentId = 'agent-no-hook';
+    const metaPath = getAgentMetaPath(tempDir, sessionId, agentId);
+    const outputFile = getAgentJsonlPath(tempDir, sessionId, agentId);
+
+    writeAgentMeta(metaPath, {
+      agentId,
+      agentType: 'researcher',
+      description: 'Resume without hooks',
+      parentSessionId: sessionId,
+      parentAgentId: null,
+      createdAt: '2026-04-20T00:00:00.000Z',
+      status: 'running',
+      subagentName: 'researcher',
+      resolvedApprovalMode: 'auto-edit',
+    });
+
+    fs.writeFileSync(
+      outputFile,
+      JSON.stringify({
+        uuid: 'u1',
+        parentUuid: null,
+        sessionId,
+        timestamp: '2026-04-20T00:00:00.000Z',
+        type: 'user',
+        message: { role: 'user', parts: [{ text: 'Resume without hooks' }] },
+      }) + '\n',
+      'utf8',
+    );
+
+    registry.register({
+      agentId,
+      description: 'Resume without hooks',
+      subagentType: 'researcher',
+      isBackgrounded: true,
+      status: 'paused',
+      startTime: Date.now(),
+      abortController: new AbortController(),
+      prompt: 'Resume without hooks',
+      outputFile,
+      metaPath,
+    });
+
+    const execute = vi.fn(
+      async (_context: { get: (key: string) => unknown }) => undefined,
+    );
+    const subagent = {
+      execute,
+      setExternalMessageProvider: vi.fn(),
+      getCore: () => ({ getEventEmitter: () => new AgentEventEmitter() }),
+      getExecutionSummary: () => ({
+        totalTokens: 0,
+        outputTokens: 0,
+        totalDurationMs: 0,
+      }),
+      getTerminateMode: () => AgentTerminateMode.GOAL,
+      getFinalText: () => 'done',
+    };
+
+    const { service, subagentManager } = createService({
+      hookSystem: undefined,
+    });
+    subagentManager.createAgentHeadless.mockResolvedValue({
+      subagent,
+      dispose: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const resumed = await service.resumeBackgroundAgent(agentId, 'continue');
+
+    expect(resumed).toBeDefined();
+    expect(execute).toHaveBeenCalledTimes(1);
+    const contextArg = execute.mock.calls[0]![0] as {
+      get: (key: string) => unknown;
+    };
+    expect(contextArg.get('hook_context')).toBe('');
   });
 
   it('returns only model-visible subagent output when resumed background agents complete', async () => {

--- a/packages/core/src/agents/background-agent-resume.ts
+++ b/packages/core/src/agents/background-agent-resume.ts
@@ -1190,6 +1190,9 @@ export class BackgroundAgentResumeService {
     },
   ): Promise<void> {
     const hookSystem = this.config.getHookSystem();
+    // Always set hook_context so ${hook_context} in systemPrompt does not
+    // throw when no hook is configured or the hook returns no additional context.
+    contextState.set('hook_context', '');
     if (!hookSystem) return;
 
     try {
@@ -1262,6 +1265,7 @@ export class BackgroundAgentResumeService {
           'task_prompt',
           typedStopOutput.getEffectiveReason(),
         );
+        continueContext.set('hook_context', '');
         await subagent.execute(continueContext, signal);
 
         if (signal?.aborted) return undefined;

--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -1899,7 +1899,7 @@ describe('AgentTool', () => {
       );
     });
 
-    it('should not inject hook_context when additionalContext is undefined', async () => {
+    it('should inject hook_context as empty string when additionalContext is undefined', async () => {
       const mockStartOutput = {
         getAdditionalContext: vi.fn().mockReturnValue(undefined),
       };
@@ -1918,9 +1918,12 @@ describe('AgentTool', () => {
       ).createInvocation(params);
       await invocation.execute();
 
+      // hook_context is always set (to empty string) so ${hook_context} in
+      // systemPrompt does not throw even when hook returns no additional context.
+      expect(mockContextState.set).toHaveBeenCalledWith('hook_context', '');
       expect(mockContextState.set).not.toHaveBeenCalledWith(
         'hook_context',
-        expect.anything(),
+        expect.stringMatching(/.+/),
       );
     });
 
@@ -1947,7 +1950,7 @@ describe('AgentTool', () => {
       expect(display.status).toBe('completed');
     });
 
-    it('should skip hooks when hookSystem is not available', async () => {
+    it('should set hook_context to empty string even when hookSystem is not available', async () => {
       (config as unknown as Record<string, unknown>)['getHookSystem'] = vi
         .fn()
         .mockReturnValue(undefined);
@@ -1964,6 +1967,8 @@ describe('AgentTool', () => {
       const result = await invocation.execute();
 
       expect(mockHookSystem.fireSubagentStartEvent).not.toHaveBeenCalled();
+      // hook_context is always set so ${hook_context} in systemPrompt does not throw.
+      expect(mockContextState.set).toHaveBeenCalledWith('hook_context', '');
       const llmText = partToString(result.llmContent);
       expect(llmText).toBe('Task completed successfully');
     });

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -1457,6 +1457,7 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
           'task_prompt',
           typedStopOutput.getEffectiveReason(),
         );
+        continueContext.set('hook_context', '');
         await subagent.execute(continueContext, signal);
 
         if (signal?.aborted) return undefined;
@@ -1642,6 +1643,10 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
   ): Promise<string | undefined> {
     const { agentId, agentType, resolvedMode, signal, updateOutput } = opts;
     const hookSystem = this.config.getHookSystem();
+
+    // Always set hook_context so ${hook_context} in systemPrompt does not
+    // throw when no hook is configured or the hook returns no additional context.
+    contextState.set('hook_context', '');
 
     try {
       if (hookSystem) {
@@ -2300,6 +2305,9 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
 
       const contextState = new ContextState();
       contextState.set('task_prompt', taskPrompt);
+      // Always set hook_context so ${hook_context} in systemPrompt does not
+      // throw when no hook is configured or the hook returns no additional context.
+      contextState.set('hook_context', '');
 
       // ── Background (async) execution path ──────────────────────
       if (shouldRunInBackground) {

--- a/packages/core/src/utils/forkedAgent.ts
+++ b/packages/core/src/utils/forkedAgent.ts
@@ -581,6 +581,7 @@ export async function runForkedAgent(
 
     const context = new ContextState();
     context.set('task_prompt', params.taskPrompt);
+    context.set('hook_context', '');
     const execute = () =>
       runWithForkedModelRuntime(modelRuntime, async () => {
         await headless.execute(context, params.abortSignal);


### PR DESCRIPTION
## What this PR does

Fixes a crash when a subagent's `systemPrompt` uses the `${hook_context}` placeholder but no `SubagentStart` hook is configured. Previously the placeholder key was never populated, causing the template engine to throw and the subagent to terminate immediately with an error. Now `hook_context` is always pre-populated with an empty string at the hook injection boundary, so subagents start cleanly regardless of hook configuration. The template engine's strict missing-key validation is preserved for catching genuine typos.

## Why it's needed

Users integrating hook-based context injection commonly include `${hook_context}` in custom subagent prompts. If they don't configure a `SubagentStart` hook — or the hook returns no `additionalContext` — the subagent crashes with a confusing error (`Missing context values for the following keys: hook_context`). The fix makes the placeholder gracefully optional without weakening template validation elsewhere.

## Reviewer Test Plan

### How to verify

1. Define a custom subagent with `${hook_context}` in its `systemPrompt` and no `SubagentStart` hook configured. Launch it and confirm it starts normally instead of crashing.
2. Configure a `SubagentStart` hook that returns `additionalContext` and confirm the subagent receives the context as before (no regression).
3. Run the affected test suites to confirm all pass.

### Evidence (Before & After)

**Before:** Subagent startup threw `Error: Missing context values for the following keys: hook_context` and terminated with `ERROR`.

**After:** Subagent starts normally. `${hook_context}` resolves to `""` when no hook provides context, or to the hook's `additionalContext` when available.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Node 22, vitest unit tests only (no TUI change).

## Risk & Scope

- Main risk or tradeoff: Every subagent `ContextState` now has `hook_context` pre-populated. This is purely additive — existing behavior when hooks provide `additionalContext` is unchanged.
- Not validated / out of scope: Hook configuration UX discoverability.
- Breaking changes / migration notes: None.

## Linked Issues

N/A — identified during internal review.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修复子代理 `systemPrompt` 中使用 `${hook_context}` 占位符但未配置 `SubagentStart` hook 时的启动崩溃问题。现在在 hook 注入边界预先将 `hook_context` 设为空字符串，子代理无论是否配置 hook 都能正常启动。模板引擎对缺失 key 的严格校验保留不变。

## 为什么需要

用户在自定义子代理 prompt 中使用 `${hook_context}` 是常见模式，但未配置 hook 时子代理会立即崩溃并显示令人困惑的错误信息。修复使该占位符优雅降级为空值，同时不影响模板引擎对真正拼写错误的检测能力。

## 验证方式

1. 自定义子代理 `systemPrompt` 包含 `${hook_context}`，不配置 hook，启动应正常。
2. 配置 hook 并返回 `additionalContext`，确认子代理能收到上下文（无回归）。

</details>
