### PR TITLE
feat(channels): add listSessions to ChannelAgentBridge

### DIFF
--- a/packages/channels/base/src/ChannelAgentBridge.ts
+++ b/packages/channels/base/src/ChannelAgentBridge.ts
@@ -29,6 +29,12 @@ interface ChannelAgentBridgeEventMap {
   toolCall: [ToolCallEvent];
 }
 
+export interface BridgeSessionInfo {
+  sessionId: string;
+  workspaceCwd: string;
+  hasActivePrompt: boolean;
+}
+
 export interface ChannelAgentBridge {
   readonly availableCommands: AvailableCommand[];
   getAvailableCommands?(sessionId: string): AvailableCommand[];
@@ -53,4 +59,5 @@ export interface ChannelAgentBridge {
     command: string,
     signal?: AbortSignal,
   ): Promise<{ exitCode: number | null; output: string; aborted: boolean }>;
+  listSessions?(): BridgeSessionInfo[];
 }

--- a/packages/channels/base/src/DaemonChannelBridge.test.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.test.ts
@@ -1275,4 +1275,192 @@ describe('DaemonChannelBridge', () => {
     events.close();
     bridge.stop();
   });
+
+  it('listSessions returns empty array when no sessions are attached', async () => {
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn(),
+    });
+    await bridge.start();
+
+    expect(bridge.listSessions()).toEqual([]);
+
+    bridge.stop();
+  });
+
+  it('listSessions returns attached sessions with hasActivePrompt status', async () => {
+    const firstEvents = new EventQueue();
+    const secondEvents = new EventQueue();
+    const firstSession = createFakeSession(firstEvents, 'session-1');
+    const secondSession = createFakeSession(secondEvents, 'session-2');
+    let resolvePrompt: () => void = () => {};
+    firstSession.prompt.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvePrompt = () => resolve({ stopReason: 'end_turn' });
+        }),
+    );
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi
+        .fn()
+        .mockResolvedValueOnce(firstSession)
+        .mockResolvedValueOnce(secondSession),
+    });
+    await bridge.start();
+
+    await bridge.newSession('/repo');
+    await bridge.newSession('/repo');
+
+    const sessions = bridge.listSessions();
+    expect(sessions).toHaveLength(2);
+    expect(sessions).toEqual(
+      expect.arrayContaining([
+        {
+          sessionId: 'session-1',
+          workspaceCwd: '/repo',
+          hasActivePrompt: false,
+        },
+        {
+          sessionId: 'session-2',
+          workspaceCwd: '/repo',
+          hasActivePrompt: false,
+        },
+      ]),
+    );
+
+    const promptPromise = bridge.prompt('session-1', 'hello');
+    await waitFor(() => expect(firstSession.prompt).toHaveBeenCalledOnce());
+
+    const during = bridge.listSessions();
+    expect(
+      during.find((s) => s.sessionId === 'session-1')?.hasActivePrompt,
+    ).toBe(true);
+    expect(
+      during.find((s) => s.sessionId === 'session-2')?.hasActivePrompt,
+    ).toBe(false);
+
+    resolvePrompt();
+    await promptPromise;
+
+    expect(
+      bridge.listSessions().find((s) => s.sessionId === 'session-1')
+        ?.hasActivePrompt,
+    ).toBe(false);
+
+    firstEvents.close();
+    secondEvents.close();
+    bridge.stop();
+  });
+
+  it('listSessions excludes dropped sessions', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+    await bridge.start();
+
+    await bridge.newSession('/repo');
+    expect(bridge.listSessions()).toHaveLength(1);
+
+    events.push({
+      id: 1,
+      v: 1,
+      type: 'session_died',
+      data: { reason: 'gone' },
+    });
+    await waitFor(() => expect(bridge.listSessions()).toEqual([]));
+
+    events.close();
+    bridge.stop();
+  });
+
+  it('listSessions shows hasActivePrompt false after cancelSession', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    let resolvePrompt: () => void = () => {};
+    session.prompt.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvePrompt = () => resolve({ stopReason: 'cancelled' });
+        }),
+    );
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+    await bridge.start();
+    await bridge.newSession('/repo');
+
+    const promptPromise = bridge.prompt('session-1', 'hello');
+    await waitFor(() => expect(session.prompt).toHaveBeenCalledOnce());
+    expect(
+      bridge.listSessions().find((s) => s.sessionId === 'session-1')
+        ?.hasActivePrompt,
+    ).toBe(true);
+
+    await bridge.cancelSession('session-1');
+    resolvePrompt();
+    await promptPromise;
+
+    expect(
+      bridge.listSessions().find((s) => s.sessionId === 'session-1')
+        ?.hasActivePrompt,
+    ).toBe(false);
+
+    events.close();
+    bridge.stop();
+  });
+
+  it('listSessions returns empty after bridge stop', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+    await bridge.start();
+    await bridge.newSession('/repo');
+    expect(bridge.listSessions()).toHaveLength(1);
+
+    bridge.stop();
+
+    expect(bridge.listSessions()).toEqual([]);
+    events.close();
+  });
+
+  it('listSessions reflects session replacement with same ID', async () => {
+    const firstEvents = new EventQueue();
+    const secondEvents = new EventQueue();
+    const firstSession = createFakeSession(firstEvents, 'session-1');
+    const secondSession = createFakeSession(secondEvents, 'session-1');
+    (secondSession as { workspaceCwd: string }).workspaceCwd = '/other';
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi
+        .fn()
+        .mockResolvedValueOnce(firstSession)
+        .mockResolvedValueOnce(secondSession),
+    });
+    await bridge.start();
+    await bridge.newSession('/repo');
+    expect(bridge.listSessions()).toEqual([
+      { sessionId: 'session-1', workspaceCwd: '/repo', hasActivePrompt: false },
+    ]);
+
+    await bridge.newSession('/other');
+    const sessions = bridge.listSessions();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toEqual({
+      sessionId: 'session-1',
+      workspaceCwd: '/other',
+      hasActivePrompt: false,
+    });
+
+    firstEvents.close();
+    secondEvents.close();
+    bridge.stop();
+  });
 });

--- a/packages/channels/base/src/DaemonChannelBridge.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.ts
@@ -5,6 +5,7 @@ import type {
 } from '@agentclientprotocol/sdk';
 import type {
   AvailableCommand,
+  BridgeSessionInfo,
   ChannelAgentBridge,
   ToolCallEvent,
 } from './ChannelAgentBridge.js';
@@ -233,6 +234,18 @@ export class DaemonChannelBridge
 
   getAvailableCommands(sessionId: string): AvailableCommand[] {
     return this.availableCommandsBySession.get(sessionId) ?? [];
+  }
+
+  listSessions(): BridgeSessionInfo[] {
+    const result: BridgeSessionInfo[] = [];
+    for (const session of this.sessions.values()) {
+      result.push({
+        sessionId: session.sessionId,
+        workspaceCwd: session.workspaceCwd,
+        hasActivePrompt: this.activePrompts.has(session.sessionId),
+      });
+    }
+    return result;
   }
 
   async start(): Promise<void> {

--- a/packages/channels/base/src/index.ts
+++ b/packages/channels/base/src/index.ts
@@ -2,6 +2,7 @@ export { getGlobalQwenDir, resolvePath } from './paths.js';
 export { AcpBridge } from './AcpBridge.js';
 export type {
   AvailableCommand,
+  BridgeSessionInfo,
   ChannelAgentBridge,
   SessionDiedEvent,
   ToolCallEvent,

--- a/packages/cli/src/commands/channel/daemon-worker.test.ts
+++ b/packages/cli/src/commands/channel/daemon-worker.test.ts
@@ -368,6 +368,57 @@ describe('createDaemonChannelBridgeFacade', () => {
     ]);
     expect(getAvailableCommands).toHaveBeenCalledWith('session-1');
   });
+
+  it('forwards listSessions when present on bridge', () => {
+    const listSessions = vi.fn(() => [
+      {
+        sessionId: 'sess-1',
+        workspaceCwd: '/repo',
+        hasActivePrompt: false,
+      },
+    ]);
+    const bridge = {
+      availableCommands: [],
+      on: mockBridgeOn,
+      off: mockBridgeOff,
+      newSession: mockBridgeNewSession,
+      loadSession: mockBridgeLoadSession,
+      prompt: mockBridgePrompt,
+      cancelSession: mockBridgeCancelSession,
+      listSessions,
+    };
+
+    const facade = createDaemonChannelBridgeFacade(bridge, {
+      exposeShellCommand: false,
+    });
+
+    expect(facade.listSessions?.()).toEqual([
+      {
+        sessionId: 'sess-1',
+        workspaceCwd: '/repo',
+        hasActivePrompt: false,
+      },
+    ]);
+    expect(listSessions).toHaveBeenCalled();
+  });
+
+  it('omits listSessions when absent on bridge', () => {
+    const bridge = {
+      availableCommands: [],
+      on: mockBridgeOn,
+      off: mockBridgeOff,
+      newSession: mockBridgeNewSession,
+      loadSession: mockBridgeLoadSession,
+      prompt: mockBridgePrompt,
+      cancelSession: mockBridgeCancelSession,
+    };
+
+    const facade = createDaemonChannelBridgeFacade(bridge, {
+      exposeShellCommand: false,
+    });
+
+    expect('listSessions' in facade).toBe(false);
+  });
 });
 
 describe('runChannelDaemonWorker', () => {

--- a/packages/cli/src/commands/channel/daemon-worker.ts
+++ b/packages/cli/src/commands/channel/daemon-worker.ts
@@ -159,6 +159,10 @@ export function createDaemonChannelBridgeFacade(
     facade.shellCommand = bridge.shellCommand.bind(bridge);
   }
 
+  if (bridge.listSessions) {
+    facade.listSessions = bridge.listSessions.bind(bridge);
+  }
+
   return facade;
 }
 


### PR DESCRIPTION
## What this PR does

Adds an optional `listSessions()` method to the `ChannelAgentBridge` interface, allowing channel consumers to enumerate sessions currently attached to a bridge instance. Only `DaemonChannelBridge` implements it — it reads from the internal `sessions` Map and `activePrompts` Set to return a point-in-time snapshot of `BridgeSessionInfo[]`. The daemon-worker facade unconditionally forwards the method when present, matching the existing `getAvailableCommands` pattern.

## Why it's needed

The daemon channel link path had no way to list active sessions. Channel adapters and diagnostic tools need session enumeration for observability and session management scenarios.

## Reviewer Test Plan

### How to verify

Run the unit tests:

```bash
npx vitest run packages/channels/base/src/DaemonChannelBridge.test.ts
npx tsc --noEmit -p packages/channels/base/tsconfig.json
```

The 6 new test cases cover: empty bridge, multi-session listing with `hasActivePrompt` lifecycle, session drop exclusion, cancel cleanup, bridge stop cleanup, and same-ID session replacement. Facade forwarding is tested in `daemon-worker.test.ts` (present + absent cases).

### Evidence (Before & After)

N/A — non-UI change. New interface method + implementation + tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  ⚠️   |
|  🐧 Linux  |  ⚠️   |

### Environment (optional)

N/A — unit tests only.

## Risk & Scope

- Main risk or tradeoff: Purely additive — new optional method on existing interface; no existing behavior changed.
- Not validated / out of scope: `AcpBridge` does not implement `listSessions` (optional method, by design).
- Breaking changes / migration notes: None.

<details>
<summary>中文说明</summary>

## 做了什么

在 `ChannelAgentBridge` 接口上新增可选方法 `listSessions()`，返回当前 bridge 实例已 attach 的活跃 session 快照（`BridgeSessionInfo[]`）。仅 `DaemonChannelBridge` 实现——从内部 `sessions` Map 和 `activePrompts` Set 读取。daemon-worker facade 在方法存在时无条件转发，与 `getAvailableCommands` 模式一致。

## 为什么需要

daemon channel 链路此前无法列举活跃 session，channel 适配器和诊断工具需要 session 枚举能力。

## 风险与范围

- 纯增量改动，不修改已有行为
- `AcpBridge` 不实现该方法（可选方法，设计如此）
- 无破坏性变更

</details>

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)