### PR TITLE
fix(web-shell): cut mobile session-switch jank (memoized timeline signature, replay-first dispatch)

### DIFF
--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -1836,7 +1836,7 @@ export const MessageList = memo(
       sessionTimelineEntries.length >= SESSION_TIMELINE_MIN_VISIBLE_ENTRIES;
 
     useLayoutEffect(() => {
-      if (hideSessionTimeline || !hasEnoughSessionTimelineEntries) {
+      if (hideSessionTimeline) {
         setIsSessionTimelineVisible((prev) => (prev ? false : prev));
         return;
       }
@@ -1857,7 +1857,7 @@ export const MessageList = memo(
       const observer = new ResizeObserver(updateVisibility);
       observer.observe(el);
       return () => observer.disconnect();
-    }, [hasEnoughSessionTimelineEntries, hideSessionTimeline]);
+    }, [hideSessionTimeline]);
 
     // ── Scroll-follow state ──────────────────────────────────────────────
     //
@@ -2663,7 +2663,7 @@ export const MessageList = memo(
           entries={sessionTimelineEntries}
           currentTurnId={currentTimelineTurnId}
           currentRange={sessionTimelineRange}
-          hidden={!isSessionTimelineVisible}
+          hidden={!isSessionTimelineVisible || !hasEnoughSessionTimelineEntries}
           onSelect={scrollToMessage}
         />
         {useVirtualScroll ? (

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -1576,8 +1576,10 @@ function joinClassNames(
   return result || undefined;
 }
 
-export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
-  function MessageList(
+const EMPTY_SESSION_TIMELINE_ENTRIES: SessionTimelineEntry[] = [];
+
+export const MessageList = memo(
+  forwardRef<MessageListHandle, MessageListProps>(function MessageList(
     {
       messages,
       pendingApproval,
@@ -1611,19 +1613,25 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
       () => groupParallelAgents(mergedMessages),
       [mergedMessages],
     );
-    const sessionTimelineSignature =
-      getSessionTimelineSignature(mergedMessages);
+    const [isSessionTimelineVisible, setIsSessionTimelineVisible] =
+      useState(false);
     const sessionTimelineCache = useRef<{
       signature: string;
       entries: SessionTimelineEntry[];
     } | null>(null);
-    if (sessionTimelineCache.current?.signature !== sessionTimelineSignature) {
-      sessionTimelineCache.current = {
-        signature: sessionTimelineSignature,
-        entries: getSessionTimelineEntries(mergedMessages),
-      };
-    }
-    const sessionTimelineEntries = sessionTimelineCache.current.entries;
+    // Signature + entries are O(transcript text); only pay for them while the
+    // rail can actually show (container >= 1160px — never on mobile).
+    const sessionTimelineEntries = useMemo(() => {
+      if (!isSessionTimelineVisible) return EMPTY_SESSION_TIMELINE_ENTRIES;
+      const signature = getSessionTimelineSignature(mergedMessages);
+      if (sessionTimelineCache.current?.signature !== signature) {
+        sessionTimelineCache.current = {
+          signature,
+          entries: getSessionTimelineEntries(mergedMessages),
+        };
+      }
+      return sessionTimelineCache.current.entries;
+    }, [isSessionTimelineVisible, mergedMessages]);
     const sessionTimelineEntryIndexById = useMemo(
       () =>
         new Map(
@@ -1748,9 +1756,6 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
       () => getTurnIdByDisplayIndex(visibleItems),
       [visibleItems],
     );
-
-    const [isSessionTimelineVisible, setIsSessionTimelineVisible] =
-      useState(false);
 
     useLayoutEffect(() => {
       const el = containerRef.current;
@@ -2624,5 +2629,5 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(
         )}
       </div>
     );
-  },
+  }),
 );

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -2509,10 +2509,11 @@ describe('DaemonSessionProvider', () => {
     });
     sdkMocks.sessions.push(session);
 
-    let connection: DaemonConnectionState | undefined;
+    const states: DaemonConnectionState[] = [];
     let blocks: readonly DaemonTranscriptBlock[] = [];
     function Harness() {
-      connection = useDaemonConnection();
+      const connection = useDaemonConnection();
+      states.push(connection);
       blocks = useDaemonTranscriptBlocks();
       return null;
     }
@@ -2525,7 +2526,8 @@ describe('DaemonSessionProvider', () => {
     expect(blocks).toMatchObject([
       { kind: 'assistant', text: 'replayed transcript' },
     ]);
-    expect(connection).toMatchObject({
+    expect(states.every((s) => !s.catchingUp)).toBe(true);
+    expect(states[states.length - 1]).toMatchObject({
       status: 'connected',
       sessionId: 'session-1',
       catchingUp: undefined,

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -2501,6 +2501,37 @@ describe('DaemonSessionProvider', () => {
     expect(last?.catchingUp).toBeFalsy();
   });
 
+  it('does not re-arm catchingUp after injecting replay for a resumed session', async () => {
+    const session = createMockSession({
+      lastEventId: 5,
+      replaySnapshot: createTextReplaySnapshot('replayed transcript'),
+      events: createIdleEvents(),
+    });
+    sdkMocks.sessions.push(session);
+
+    let connection: DaemonConnectionState | undefined;
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+    function Harness() {
+      connection = useDaemonConnection();
+      blocks = useDaemonTranscriptBlocks();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(blocks).toMatchObject([
+      { kind: 'assistant', text: 'replayed transcript' },
+    ]);
+    expect(connection).toMatchObject({
+      status: 'connected',
+      sessionId: 'session-1',
+      catchingUp: undefined,
+    });
+  });
+
   it('never sets catchingUp on a fresh subscription (no Last-Event-ID)', async () => {
     // A first-time attach has no resume cursor → the daemon emits no
     // replay_complete → arming catchingUp would stick forever. The Provider

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -616,6 +616,117 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           hasCurrentSessionActivePromptRef.current = hasSessionActivePrompt;
           setPromptStatus(hasSessionActivePrompt() ? 'streaming' : 'idle');
 
+          const pendingLoad = pendingSessionLoadRef.current;
+          const pendingLoadToResolve =
+            pendingLoad?.sessionId === activeSession.sessionId
+              ? pendingLoad
+              : undefined;
+
+          // Feed replay snapshot (compacted history + live journal) into
+          // the store before starting the SSE loop. The SSE stream begins
+          // from lastEventId, so only post-snapshot events are delivered.
+          //
+          // This runs before the providers/commands/context fetches below:
+          // the snapshot is already in hand, so the transcript paints one
+          // metadata round-trip earlier (visible on high-latency mobile).
+          //
+          // The deferred store.reset() runs here — in the same synchronous
+          // block as store.dispatch() — so the queueMicrotask notification
+          // only fires once with the fully-populated state.
+          const { compactedReplay, liveJournal } = activeSession.replaySnapshot;
+          const replayEvents = [...compactedReplay, ...liveJournal];
+          const replayInjected =
+            shouldInjectReplaySnapshot && replayEvents.length > 0;
+          if (needsStoreReset && !replayInjected) {
+            // Reset needed but no replay data (e.g. fresh session) — reset
+            // immediately since there is no dispatch to batch with.
+            store.reset();
+          }
+          if (replayInjected) {
+            const replayOpts = {
+              ...eventOptionsRef.current,
+              suppressOwnUserEcho: false,
+            };
+            const allUiEvents: DaemonUiEvent[] = [];
+            for (const replayEvent of replayEvents) {
+              try {
+                const replayUiEvents = normalizeAndFilterEvent(
+                  replayEvent,
+                  activeSession.clientId,
+                  replayOpts,
+                  setConnection,
+                  { updateConnection: false },
+                );
+                allUiEvents.push(
+                  ...filterDaemonUiEventsForTranscript(
+                    replayEvent,
+                    replayUiEvents,
+                    addNotice,
+                  ),
+                );
+                if (replayEvent.type === 'turn_complete') {
+                  const stopReason =
+                    (replayEvent.data as DaemonTurnCompleteData | undefined)
+                      ?.stopReason ?? 'end_turn';
+                  allUiEvents.push(
+                    assistantDoneFromTurnEvent(replayEvent, stopReason),
+                  );
+                } else if (replayEvent.type === 'turn_error') {
+                  allUiEvents.push(
+                    assistantDoneFromTurnEvent(replayEvent, 'error'),
+                  );
+                }
+              } catch (error) {
+                const message =
+                  error instanceof Error ? error.message : String(error);
+                addNotice({
+                  severity: 'warning',
+                  category: 'protocol',
+                  operation: 'normalize_event',
+                  code: 'daemon.replay_event_malformed',
+                  message: 'Skipped malformed replay event',
+                  debugMessage: message,
+                  recoverable: true,
+                });
+                console.warn(
+                  '[DaemonSessionProvider] skipped malformed replay event:',
+                  error,
+                );
+              }
+            }
+            if (needsStoreReset) {
+              store.reset();
+            }
+            if (allUiEvents.length > 0) {
+              store.dispatch(allUiEvents);
+              bumpWorkspaceEventSignals(allUiEvents, setWorkspaceEventSignals);
+            }
+            for (const replayEvent of replayEvents) {
+              settleActivePromptFromTurnEvent(
+                activePromptsRef.current,
+                settledPromptsRef.current,
+                activeSession.sessionId,
+                replayEvent,
+                store,
+                setPromptStatus,
+                passiveAssistantDoneTimerRef,
+                { requireBoundPromptId: true },
+              );
+            }
+            setConnection((c) => ({ ...c, catchingUp: undefined }));
+          }
+          if (pendingLoadToResolve) {
+            pendingSessionLoadRef.current = undefined;
+            clearTimeout(pendingLoadToResolve.timeout);
+            if (
+              skipNextCleanupDetachSessionIdRef.current ===
+              activeSession.sessionId
+            ) {
+              skipNextCleanupDetachSessionIdRef.current = undefined;
+            }
+            pendingLoadToResolve.resolve();
+          }
+
           const canReuseSessionMetadata =
             attachedExistingSession &&
             connectionRef.current.commands !== undefined &&
@@ -721,9 +832,13 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             context: context ?? current.context,
             capabilities: capabilities ?? current.capabilities,
             catchingUp:
-              isSameSessionReconnect ||
-              activeSession.lastEventId != null ||
-              undefined,
+              // Replay already injected above — keep the cleared flag rather
+              // than re-arming it (nothing before SSE would clear it again).
+              replayInjected
+                ? current.catchingUp
+                : isSameSessionReconnect ||
+                  activeSession.lastEventId != null ||
+                  undefined,
           }));
           if (loadWarningTexts.length > 0) {
             store.dispatch(
@@ -732,114 +847,6 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                 text,
               })),
             );
-          }
-
-          const pendingLoad = pendingSessionLoadRef.current;
-          const pendingLoadToResolve =
-            pendingLoad?.sessionId === activeSession.sessionId
-              ? pendingLoad
-              : undefined;
-
-          // Feed replay snapshot (compacted history + live journal) into
-          // the store before starting the SSE loop. The SSE stream begins
-          // from lastEventId, so only post-snapshot events are delivered.
-          //
-          // The deferred store.reset() runs here — in the same synchronous
-          // block as store.dispatch() — so the queueMicrotask notification
-          // only fires once with the fully-populated state.
-          const { compactedReplay, liveJournal } = activeSession.replaySnapshot;
-          const replayEvents = [...compactedReplay, ...liveJournal];
-          if (
-            needsStoreReset &&
-            !(shouldInjectReplaySnapshot && replayEvents.length > 0)
-          ) {
-            // Reset needed but no replay data (e.g. fresh session) — reset
-            // immediately since there is no dispatch to batch with.
-            store.reset();
-          }
-          if (shouldInjectReplaySnapshot && replayEvents.length > 0) {
-            const replayOpts = {
-              ...eventOptionsRef.current,
-              suppressOwnUserEcho: false,
-            };
-            const allUiEvents: DaemonUiEvent[] = [];
-            for (const replayEvent of replayEvents) {
-              try {
-                const replayUiEvents = normalizeAndFilterEvent(
-                  replayEvent,
-                  activeSession.clientId,
-                  replayOpts,
-                  setConnection,
-                  { updateConnection: false },
-                );
-                allUiEvents.push(
-                  ...filterDaemonUiEventsForTranscript(
-                    replayEvent,
-                    replayUiEvents,
-                    addNotice,
-                  ),
-                );
-                if (replayEvent.type === 'turn_complete') {
-                  const stopReason =
-                    (replayEvent.data as DaemonTurnCompleteData | undefined)
-                      ?.stopReason ?? 'end_turn';
-                  allUiEvents.push(
-                    assistantDoneFromTurnEvent(replayEvent, stopReason),
-                  );
-                } else if (replayEvent.type === 'turn_error') {
-                  allUiEvents.push(
-                    assistantDoneFromTurnEvent(replayEvent, 'error'),
-                  );
-                }
-              } catch (error) {
-                const message =
-                  error instanceof Error ? error.message : String(error);
-                addNotice({
-                  severity: 'warning',
-                  category: 'protocol',
-                  operation: 'normalize_event',
-                  code: 'daemon.replay_event_malformed',
-                  message: 'Skipped malformed replay event',
-                  debugMessage: message,
-                  recoverable: true,
-                });
-                console.warn(
-                  '[DaemonSessionProvider] skipped malformed replay event:',
-                  error,
-                );
-              }
-            }
-            if (needsStoreReset) {
-              store.reset();
-            }
-            if (allUiEvents.length > 0) {
-              store.dispatch(allUiEvents);
-              bumpWorkspaceEventSignals(allUiEvents, setWorkspaceEventSignals);
-            }
-            for (const replayEvent of replayEvents) {
-              settleActivePromptFromTurnEvent(
-                activePromptsRef.current,
-                settledPromptsRef.current,
-                activeSession.sessionId,
-                replayEvent,
-                store,
-                setPromptStatus,
-                passiveAssistantDoneTimerRef,
-                { requireBoundPromptId: true },
-              );
-            }
-            setConnection((c) => ({ ...c, catchingUp: undefined }));
-          }
-          if (pendingLoadToResolve) {
-            pendingSessionLoadRef.current = undefined;
-            clearTimeout(pendingLoadToResolve.timeout);
-            if (
-              skipNextCleanupDetachSessionIdRef.current ===
-              activeSession.sessionId
-            ) {
-              skipNextCleanupDetachSessionIdRef.current = undefined;
-            }
-            pendingLoadToResolve.resolve();
           }
           let sawEvent = false;
           let resyncRequested = false;


### PR DESCRIPTION
## What this PR does

Two P0 fixes for the laggy session switch on mobile in the `qwen serve` Web Shell:

1. `MessageList` is now wrapped in `memo`, and the session-timeline signature/entries computation — which concatenates the full text of every message into one giant string — only runs while the timeline rail can actually show (container width >= 1160px, never true on mobile). Previously it ran un-memoized in the render body on every render, including every virtualized scroll frame and every unrelated App re-render.
2. `DaemonSessionProvider` now dispatches the replay snapshot into the transcript store as soon as `/session/:id/load` returns, instead of first awaiting the `workspaceProviders` + `supportedCommands` + `context` round-trip. The snapshot was already fully downloaded at that point; on a high-latency mobile link the old ordering cost a full extra RTT of blank/stale transcript. The `catchingUp` flag in the subsequent `setConnection` no longer re-arms once the replay has been injected (nothing before SSE would clear it again), and the pending-load promise resolves when the transcript is visible rather than after metadata, so the sidebar spinner ends at first paint. A side effect worth noting: load-warning status events were previously dispatched before the deferred `store.reset()` and got wiped on a session switch; they now survive because they are dispatched after replay injection.

## Why it's needed

Switching sessions on a phone visibly freezes the UI and stutters the drawer-close animation (see the full top-to-bottom analysis in #6181). These two changes are the smallest-risk, highest-leverage items from that analysis: the timeline signature is a per-render O(transcript) main-thread tax that mobile pays for a feature it never renders, and the metadata-before-replay ordering delays first paint of the new session by one round-trip for no benefit.

## Reviewer Test Plan

### How to verify

- `npm test` in `packages/webui` (243 tests, includes `DaemonSessionProvider.test.tsx` replay/reconnect/resync coverage) and in `packages/web-shell` (622 tests) — all pass.
- Manual: run `qwen serve` in a workspace with several long sessions, open the Web Shell from a phone (or Chrome DevTools mobile emulation + CPU throttling), switch between sessions from the drawer. Expected: the new transcript paints noticeably sooner (before models/commands metadata resolves) and scrolling a long session no longer rebuilds the timeline signature every frame (verifiable in the Performance panel: no repeated long `getSessionTimelineSignature` frames).
- Regression surface to check: session switch scroll-to-bottom still fires once after replay (the `catchingUp` clear now happens before the `connected` setConnection, which preserves the cleared value), same-session SSE reconnect still shows catching-up until `session.replay_complete`, and the desktop timeline rail (>=1160px container) still renders and tracks scroll.

### Evidence (Before & After)

N/A (perf-ordering change; no visual layout diff. Unit suites above are green; I did not capture phone-side profiling traces.)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only (`vitest` via `npm test` in the two packages), Node 22 / macOS.

## Risk & Scope

- Main risk or tradeoff: the replay dispatch now happens while `connection.status` is still `connecting`, so the transcript renders one metadata round-trip before models/commands/context are populated — consumers that assumed blocks only change after `status === 'connected'` would see the new ordering. The provider test suite (including deferred-reset and resync cases) passes unchanged.
- Not validated / out of scope: real-device profiling numbers; the remaining P1–P3 items in #6181 (virtualization threshold, Shiki visibility gating, gzip on `/load`, sidebar polling, transcript caching, server-side session grace period).
- Breaking changes / migration notes: none. `MessageList` keeps the same props contract (`memo` wraps the existing `forwardRef`).

## Linked Issues

Part of #6181 (P0 items). Not closing — P1–P3 remain.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

针对 `qwen serve` Web Shell 手机端切换 session 卡顿的两项 P0 修复:

1. `MessageList` 现在用 `memo` 包裹,并且 session 时间线 signature/entries 的计算(会把每条消息的完整文本拼成一个巨型字符串)只在时间线导轨真正可见时执行(容器宽度 >= 1160px,手机上永远不成立)。此前它在 render 体内无 memo 地每次执行,包括每个虚拟滚动帧和每次无关的 App 重渲染。
2. `DaemonSessionProvider` 现在在 `/session/:id/load` 返回后立即把 replay 快照 dispatch 进 transcript store,而不是先等 `workspaceProviders` + `supportedCommands` + `context` 三个请求完成。快照此时早已下载完毕;在高延迟的移动网络下,旧顺序白白多付一个 RTT 的白屏/旧画面。后续 `setConnection` 中的 `catchingUp` 在 replay 已注入时不再重新置起(SSE 之前没有任何逻辑会再清除它),pending-load promise 也在 transcript 可见时就 resolve,侧边栏的加载指示在首帧就结束。一个顺带的行为修正:load warning 状态事件此前在延迟的 `store.reset()` 之前 dispatch、切换时会被清掉,现在在 replay 注入之后 dispatch 得以保留。

## 为什么需要

手机上切换 session 会明显冻结 UI 并让抽屉关闭动画掉帧(完整的自上而下分析见 #6181)。这两项是该分析中风险最小、收益最直接的条目:时间线 signature 是每次 render O(全文) 的主线程税,而手机为一个永远不渲染的功能买单;metadata 先于 replay 的顺序则让新会话首帧无谓地晚一个往返。

## 评审验证方式

- 在 `packages/webui`(243 个测试,含 `DaemonSessionProvider.test.tsx` 的 replay/重连/resync 覆盖)和 `packages/web-shell`(622 个测试)分别 `npm test`,全部通过。
- 手动:在有多个长会话的 workspace 里跑 `qwen serve`,用手机(或 Chrome DevTools 移动模拟 + CPU 降速)打开 Web Shell,从抽屉切换会话。预期:新 transcript 明显更早显示(先于 models/commands metadata 返回),长会话滚动不再每帧重建时间线 signature(Performance 面板中不再出现反复的 `getSessionTimelineSignature` 长帧)。
- 回归面:切换后 replay 完成仍触发一次 scroll-to-bottom(`catchingUp` 的清除现在早于 `connected` setConnection,后者会保留已清除的值);同会话 SSE 重连在 `session.replay_complete` 之前仍显示 catching-up;桌面端时间线导轨(容器 >= 1160px)仍正常渲染并跟随滚动。

## 证据(Before & After)

N/A(性能/顺序类改动,无视觉布局差异。上述单测全绿;未采集真机侧的 profiling 记录。)

## 风险与范围

- 主要风险/权衡:replay dispatch 现在发生在 `connection.status` 仍为 `connecting` 时,transcript 会比 models/commands/context 早一个往返渲染——若有消费方假设 blocks 只在 `status === 'connected'` 之后变化,会感知到新顺序。provider 测试套件(含 deferred-reset 与 resync 用例)不改动全部通过。
- 未验证/超出范围:真机 profiling 数据;#6181 中剩余的 P1–P3 条目(虚拟化门槛、Shiki 可见性门控、`/load` gzip、侧边栏轮询、transcript 缓存、服务端 session 宽限期)。
- 破坏性变更/迁移说明:无。`MessageList` 的 props 契约不变(`memo` 包裹原有 `forwardRef`)。

## 关联 Issue

属于 #6181 的 P0 部分。不自动关闭——P1–P3 仍待做。

</details>
