### PR TITLE
ci: Add prepare-pr skill for autofix PR bodies

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -664,13 +664,12 @@ jobs:
             7. **Commit**: a single Conventional Commit on the branch, e.g.
                `fix(core): <summary> (#${{ steps.decision.outputs.go_issue }})`.
             8. **Write outputs**:
-               - /tmp/autofix/pr-title.txt — Conventional Commit style PR title.
-               - /tmp/autofix/pr-body.md — PR description following
-                 .github/pull_request_template.md, with motivation and
-                 changes in prose, a Reviewer Test Plan, and `Fixes #${{ steps.decision.outputs.go_issue }}`.
-                 Do not hard-wrap lines.
                - /tmp/autofix/e2e-report.md — E2E evidence: exact commands,
                  before/after behavior, and test output excerpts.
+               - Use the project skill `prepare-pr`
+                 (.qwen/skills/prepare-pr/SKILL.md) to write
+                 /tmp/autofix/pr-title.txt and /tmp/autofix/pr-body.md for
+                 issue #${{ steps.decision.outputs.go_issue }}.
 
             If at any point you conclude the fix is beyond confident reach,
             STOP: write /tmp/autofix/failure.md with what you learned and

--- a/.qwen/skills/prepare-pr/SKILL.md
+++ b/.qwen/skills/prepare-pr/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: prepare-pr
+description: Prepare GitHub pull request title and body files from the current branch diff, especially for non-interactive CI/autofix flows that must follow the repository PR template without pushing or creating the PR.
+argument-hint: '<output-dir> [issue-number]'
+allowedTools:
+  - read_file
+  - write_file
+  - grep_search
+  - glob
+  - run_shell_command
+---
+
+# Prepare PR
+
+Create PR metadata files only. Do not push, comment, or run `gh pr create`.
+
+## Inputs
+
+- Output directory: default `/tmp/autofix`
+- Issue number: from the argument, `ISSUE`, or the current branch name
+
+## Required Outputs
+
+Write:
+
+- `<output-dir>/pr-title.txt`
+- `<output-dir>/pr-body.md`
+
+## Workflow
+
+1. Inspect the current branch diff with `git diff origin/main...HEAD` and recent commit message with `git log -1 --pretty=%B`.
+2. Read `<output-dir>/e2e-report.md` if it exists.
+3. Read `.github/pull_request_template.md`.
+4. Write a Conventional Commit style title to `pr-title.txt`.
+5. Fill the repository PR template in place and write it to `pr-body.md`.
+
+## PR Body Rules
+
+- Keep every template section heading exactly as written.
+- Do not replace template headings with `Summary`, `Root Cause`, `Fix`, or `Tests`.
+- Use prose for motivation and changes; avoid file-by-file implementation notes unless needed for reviewer clarity.
+- Include a useful Reviewer Test Plan with concrete behavior to verify.
+- Fill `Evidence (Before & After)` with concise before/after behavior or `N/A` for non-UI changes.
+- Mark tested OS rows honestly. For Linux-only CI verification, mark Linux tested and macOS/Windows not tested.
+- Include risk, out-of-scope, and breaking-change notes.
+- Add `Fixes #<issue-number>` under `Linked Issues` when an issue number is known.
+- Keep the `<details><summary>中文说明</summary>` section and translate the English body into Chinese there.
+- Do not hard-wrap paragraphs or list items at a fixed column width.
+
+## Common Mistakes
+
+- Writing a free-form PR body instead of filling the template.
+- Claiming checks passed when they were not run.
+- Omitting the Chinese details section.
+- Using closing keywords for unrelated issues.


### PR DESCRIPTION
## What this PR does

Adds a lightweight project skill, `prepare-pr`, for generating pull request title and body files from the current branch diff in non-interactive CI/autofix flows. Updates the scheduled autofix develop prompt to write the E2E report first, then use that project skill to produce `/tmp/autofix/pr-title.txt` and `/tmp/autofix/pr-body.md`.

## Why it's needed

The autofix workflow previously relied on a short prompt saying the generated PR description should follow `.github/pull_request_template.md`. That was too loose: an autofix PR could publish a free-form body with headings like `Summary`, `Root Cause`, `Fix`, and `Tests` instead of the current repository template. Moving the PR-body rules into a project skill keeps the workflow prompt small while making the template requirement reusable and more explicit.

## Reviewer Test Plan

### How to verify

Review the `prepare-pr` skill and confirm it requires reading `.github/pull_request_template.md`, preserving the template headings, keeping the Chinese details section, writing honest test/risk notes, and avoiding `gh pr create`. Review the `qwen-autofix.yml` prompt and confirm the develop step now asks the agent to write `e2e-report.md` before using `prepare-pr` for the PR title/body files.

### Evidence (Before & After)

Before: the autofix prompt only asked for a PR description "following" the template, so the model could generate a structurally different body. After: the workflow points at a repository skill whose narrow responsibility is to fill the PR template in place and write the expected autofix output files.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   N/A   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Local validation: YAML parse for the workflow and skill frontmatter, `git diff --check`, and `npx prettier --check .github/workflows/qwen-autofix.yml .qwen/skills/prepare-pr/SKILL.md`.

## Risk & Scope

- Main risk or tradeoff: this still relies on the autofix model following the referenced project skill inside the existing develop step; it does not add a slower post-generation template gate.
- Not validated / out of scope: a full scheduled autofix run was not dispatched from this branch.
- Breaking changes / migration notes: none.

## Linked Issues

Related to #6177.

<details>
<summary>中文说明</summary>

## What this PR does

新增一个轻量 project skill：`prepare-pr`，用于在非交互 CI/autofix 流程中基于当前分支 diff 生成 PR title 和 body 文件。同时更新 scheduled autofix 的 develop prompt，让它先写 E2E report，再使用这个 project skill 生成 `/tmp/autofix/pr-title.txt` 和 `/tmp/autofix/pr-body.md`。

## Why it's needed

之前 autofix workflow 只是用一句较宽泛的 prompt 要求 PR description 遵循 `.github/pull_request_template.md`。这个约束不够明确：autofix PR 仍可能生成 `Summary`、`Root Cause`、`Fix`、`Tests` 这类自由格式标题，而不是仓库当前模板。把 PR body 规则沉淀到 project skill 后，workflow prompt 可以保持很小，同时模板要求变得更明确、可复用。

## Reviewer Test Plan

### How to verify

检查 `prepare-pr` skill，确认它要求读取 `.github/pull_request_template.md`、保留模板 headings、保留中文说明区、如实写测试和风险说明，并且禁止执行 `gh pr create`。检查 `qwen-autofix.yml` prompt，确认 develop step 现在要求 agent 先写 `e2e-report.md`，再使用 `prepare-pr` 生成 PR title/body 文件。

### Evidence (Before & After)

Before：autofix prompt 只要求 PR description “following” template，模型仍可能生成结构不同的 body。After：workflow 指向一个仓库内 project skill，该 skill 的职责很窄，只负责原位填充 PR template 并写出 autofix 需要的输出文件。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   N/A   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

本地验证：workflow 和 skill frontmatter 的 YAML parse、`git diff --check`、以及 `npx prettier --check .github/workflows/qwen-autofix.yml .qwen/skills/prepare-pr/SKILL.md`。

## Risk & Scope

- Main risk or tradeoff: 这仍然依赖 autofix 模型在现有 develop step 中遵循被引用的 project skill；没有新增更慢的后置模板校验。
- Not validated / out of scope: 没有从这个分支 dispatch 完整 scheduled autofix run。
- Breaking changes / migration notes: 无。

## Linked Issues

Related to #6177.

</details>
