### PR TITLE
fix(core): add UTF-8 prefix for cmd.exe on Windows

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -1849,6 +1849,25 @@ describe('ShellExecutionService', () => {
       });
     });
 
+    it('should use cmd.exe with chcp 65001 UTF-8 prefix via PTY on Windows', async () => {
+      mockPlatform.mockReturnValue('win32');
+      mockGetShellConfiguration.mockReturnValue({
+        executable: 'cmd.exe',
+        argsPrefix: ['/c'],
+        shell: 'cmd',
+      });
+      await simulateExecution('dir "C:\\Temp\\"', (pty) =>
+        pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null }),
+      );
+
+      // cmd.exe commands on Windows are prefixed with chcp 65001 for UTF-8
+      expect(mockPtySpawn).toHaveBeenCalledWith(
+        'cmd.exe',
+        ['/c', 'chcp 65001 >nul && dir "C:\\Temp\\"'],
+        expect.any(Object),
+      );
+    });
+
     it('should normalize PATH-like env keys on Windows for pty execution', async () => {
       mockPlatform.mockReturnValue('win32');
       vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
@@ -3037,7 +3056,7 @@ describe('ShellExecutionService child_process fallback', () => {
   });
 
   describe('Platform-Specific Behavior', () => {
-    it('should use cmd.exe with windowsVerbatimArguments on Windows', async () => {
+    it('should use cmd.exe with chcp 65001 UTF-8 prefix on Windows', async () => {
       mockPlatform.mockReturnValue('win32');
       mockGetShellConfiguration.mockReturnValue({
         executable: 'cmd.exe',
@@ -3048,9 +3067,10 @@ describe('ShellExecutionService child_process fallback', () => {
         cp.emit('exit', 0, null),
       );
 
+      // cmd.exe commands on Windows are prefixed with chcp 65001 for UTF-8
       expect(mockCpSpawn).toHaveBeenCalledWith(
         'cmd.exe',
-        ['/d', '/s', '/c', 'dir "foo bar"'],
+        ['/d', '/s', '/c', 'chcp 65001 >nul && dir "foo bar"'],
         expect.objectContaining({
           detached: false,
           windowsHide: true,

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -123,6 +123,7 @@ const mockProcessKill = vi
 // to avoid PATH/CWD binary planting. Compute the expected path the same way so
 // assertions stay in sync across platforms (SystemRoot is unset off Windows).
 const TASKKILL = `${process.env['SystemRoot'] || 'C:\\Windows'}\\System32\\taskkill.exe`;
+const CHCP = `${process.env['SystemRoot'] || 'C:\\Windows'}\\System32\\chcp.com`;
 
 const shellExecutionConfig = {
   terminalWidth: 80,
@@ -1811,7 +1812,30 @@ describe('ShellExecutionService', () => {
 
       expect(mockPtySpawn).toHaveBeenCalledWith(
         'cmd.exe',
-        '/d /s /c C:\\Windows\\System32\\chcp.com 65001 >nul 2>nul & dir "foo bar"',
+        `/d /s /c ${CHCP} 65001 >nul 2>nul & dir "foo bar"`,
+        expect.any(Object),
+      );
+      mockGetShellConfiguration.mockReturnValue({
+        executable: 'bash',
+        argsPrefix: ['-c'],
+        shell: 'bash',
+      });
+    });
+
+    it('should not apply UTF-8 prefix for Git Bash on Windows', async () => {
+      mockPlatform.mockReturnValue('win32');
+      mockGetShellConfiguration.mockReturnValue({
+        executable: 'bash.exe',
+        argsPrefix: ['-c'],
+        shell: 'bash',
+      });
+      await simulateExecution('echo hello', (pty) =>
+        pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null }),
+      );
+
+      expect(mockPtySpawn).toHaveBeenCalledWith(
+        'bash.exe',
+        ['-c', 'echo hello'],
         expect.any(Object),
       );
       mockGetShellConfiguration.mockReturnValue({
@@ -3061,17 +3085,33 @@ describe('ShellExecutionService child_process fallback', () => {
       // cmd.exe commands on Windows are prefixed with chcp 65001 for UTF-8
       expect(mockCpSpawn).toHaveBeenCalledWith(
         'cmd.exe',
-        [
-          '/d',
-          '/s',
-          '/c',
-          'C:\\Windows\\System32\\chcp.com 65001 >nul 2>nul & dir "foo bar"',
-        ],
+        ['/d', '/s', '/c', `${CHCP} 65001 >nul 2>nul & dir "foo bar"`],
         expect.objectContaining({
           detached: false,
           windowsHide: true,
           windowsVerbatimArguments: true,
         }),
+      );
+      mockGetShellConfiguration.mockReturnValue({
+        executable: 'bash',
+        argsPrefix: ['-c'],
+        shell: 'bash',
+      });
+    });
+
+    it('should not apply UTF-8 prefix for Git Bash on Windows via child_process', async () => {
+      mockPlatform.mockReturnValue('win32');
+      mockGetShellConfiguration.mockReturnValue({
+        executable: 'bash.exe',
+        argsPrefix: ['-c'],
+        shell: 'bash',
+      });
+      await simulateExecution('echo hello', (cp) => cp.emit('exit', 0, null));
+
+      expect(mockCpSpawn).toHaveBeenCalledWith(
+        'bash.exe',
+        ['-c', 'echo hello'],
+        expect.any(Object),
       );
       mockGetShellConfiguration.mockReturnValue({
         executable: 'bash',

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -1811,7 +1811,7 @@ describe('ShellExecutionService', () => {
 
       expect(mockPtySpawn).toHaveBeenCalledWith(
         'cmd.exe',
-        '/d /s /c %SystemRoot%\\System32\\chcp.com 65001 >nul && dir "foo bar"',
+        '/d /s /c C:\\Windows\\System32\\chcp.com 65001 >nul & dir "foo bar"',
         expect.any(Object),
       );
       mockGetShellConfiguration.mockReturnValue({
@@ -1842,33 +1842,6 @@ describe('ShellExecutionService', () => {
         ],
         expect.any(Object),
       );
-      mockGetShellConfiguration.mockReturnValue({
-        executable: 'bash',
-        argsPrefix: ['-c'],
-        shell: 'bash',
-      });
-    });
-
-    it('should use cmd.exe with chcp 65001 UTF-8 prefix via PTY on Windows', async () => {
-      mockPlatform.mockReturnValue('win32');
-      mockGetShellConfiguration.mockReturnValue({
-        executable: 'cmd.exe',
-        argsPrefix: ['/d', '/s', '/c'],
-        shell: 'cmd',
-      });
-      await simulateExecution('dir "C:\\Temp\\"', (pty) =>
-        pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null }),
-      );
-
-      // cmd.exe commands on Windows are prefixed with chcp 65001 for UTF-8
-      // PTY code joins argsPrefix + command into a single string via .join(' ')
-      expect(mockPtySpawn).toHaveBeenCalledWith(
-        'cmd.exe',
-        '/d /s /c %SystemRoot%\\System32\\chcp.com 65001 >nul && dir "C:\\Temp\\"',
-        expect.any(Object),
-      );
-
-      // Reset shell config to prevent leak into subsequent tests
       mockGetShellConfiguration.mockReturnValue({
         executable: 'bash',
         argsPrefix: ['-c'],

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -1811,7 +1811,7 @@ describe('ShellExecutionService', () => {
 
       expect(mockPtySpawn).toHaveBeenCalledWith(
         'cmd.exe',
-        '/d /s /c dir "foo bar"',
+        '/d /s /c %SystemRoot%\\System32\\chcp.com 65001 >nul && dir "foo bar"',
         expect.any(Object),
       );
       mockGetShellConfiguration.mockReturnValue({
@@ -1853,7 +1853,7 @@ describe('ShellExecutionService', () => {
       mockPlatform.mockReturnValue('win32');
       mockGetShellConfiguration.mockReturnValue({
         executable: 'cmd.exe',
-        argsPrefix: ['/c'],
+        argsPrefix: ['/d', '/s', '/c'],
         shell: 'cmd',
       });
       await simulateExecution('dir "C:\\Temp\\"', (pty) =>
@@ -1861,11 +1861,19 @@ describe('ShellExecutionService', () => {
       );
 
       // cmd.exe commands on Windows are prefixed with chcp 65001 for UTF-8
+      // PTY code joins argsPrefix + command into a single string via .join(' ')
       expect(mockPtySpawn).toHaveBeenCalledWith(
         'cmd.exe',
-        ['/c', 'chcp 65001 >nul && dir "C:\\Temp\\"'],
+        '/d /s /c %SystemRoot%\\System32\\chcp.com 65001 >nul && dir "C:\\Temp\\"',
         expect.any(Object),
       );
+
+      // Reset shell config to prevent leak into subsequent tests
+      mockGetShellConfiguration.mockReturnValue({
+        executable: 'bash',
+        argsPrefix: ['-c'],
+        shell: 'bash',
+      });
     });
 
     it('should normalize PATH-like env keys on Windows for pty execution', async () => {
@@ -3070,7 +3078,12 @@ describe('ShellExecutionService child_process fallback', () => {
       // cmd.exe commands on Windows are prefixed with chcp 65001 for UTF-8
       expect(mockCpSpawn).toHaveBeenCalledWith(
         'cmd.exe',
-        ['/d', '/s', '/c', 'chcp 65001 >nul && dir "foo bar"'],
+        [
+          '/d',
+          '/s',
+          '/c',
+          '%SystemRoot%\\System32\\chcp.com 65001 >nul && dir "foo bar"',
+        ],
         expect.objectContaining({
           detached: false,
           windowsHide: true,

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -1811,7 +1811,7 @@ describe('ShellExecutionService', () => {
 
       expect(mockPtySpawn).toHaveBeenCalledWith(
         'cmd.exe',
-        '/d /s /c C:\\Windows\\System32\\chcp.com 65001 >nul & dir "foo bar"',
+        '/d /s /c C:\\Windows\\System32\\chcp.com 65001 >nul 2>nul & dir "foo bar"',
         expect.any(Object),
       );
       mockGetShellConfiguration.mockReturnValue({
@@ -3064,7 +3064,7 @@ describe('ShellExecutionService child_process fallback', () => {
           '/d',
           '/s',
           '/c',
-          'C:\\Windows\\System32\\chcp.com 65001 >nul & dir "foo bar"',
+          'C:\\Windows\\System32\\chcp.com 65001 >nul 2>nul & dir "foo bar"',
         ],
         expect.objectContaining({
           detached: false,

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -1851,7 +1851,11 @@ describe('ShellExecutionService', () => {
 
     it('should normalize PATH-like env keys on Windows for pty execution', async () => {
       mockPlatform.mockReturnValue('win32');
-      vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+      mockGetShellConfiguration.mockReturnValue({
+        executable: 'cmd.exe',
+        argsPrefix: ['/d', '/s', '/c'],
+        shell: 'cmd',
+      });
       setupConflictingPathEnv();
 
       await simulateExecution('dir', (pty) =>
@@ -1860,6 +1864,11 @@ describe('ShellExecutionService', () => {
 
       const spawnOptions = mockPtySpawn.mock.calls[0][2];
       expectNormalizedWindowsPathEnv(spawnOptions.env);
+      mockGetShellConfiguration.mockReturnValue({
+        executable: 'bash',
+        argsPrefix: ['-c'],
+        shell: 'bash',
+      });
     });
 
     it('should use bash on Linux', async () => {
@@ -3055,7 +3064,7 @@ describe('ShellExecutionService child_process fallback', () => {
           '/d',
           '/s',
           '/c',
-          '%SystemRoot%\\System32\\chcp.com 65001 >nul && dir "foo bar"',
+          'C:\\Windows\\System32\\chcp.com 65001 >nul & dir "foo bar"',
         ],
         expect.objectContaining({
           detached: false,

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -1851,6 +1851,7 @@ describe('ShellExecutionService', () => {
 
     it('should normalize PATH-like env keys on Windows for pty execution', async () => {
       mockPlatform.mockReturnValue('win32');
+      vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
       mockGetShellConfiguration.mockReturnValue({
         executable: 'cmd.exe',
         argsPrefix: ['/d', '/s', '/c'],

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -115,7 +115,7 @@ function applyUtf8Prefix(command: string, shell: string): string {
       );
     }
     if (shell === 'cmd') {
-      return `chcp 65001 >nul && ${command}`;
+      return `%SystemRoot%\\System32\\chcp.com 65001 >nul && ${command}`;
     }
   }
   return command;

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -117,7 +117,7 @@ function applyUtf8Prefix(command: string, shell: string): string {
     if (shell === 'cmd') {
       // Resolve in JS with fallback (defense-in-depth, matches WINDOWS_TASKKILL pattern, see #5873)
       const systemRoot = process.env['SystemRoot'] || 'C:\\Windows';
-      return `${systemRoot}\\System32\\chcp.com 65001 >nul & ${command}`;
+      return `"${systemRoot}\\System32\\chcp.com" 65001 >nul 2>nul & ${command}`;
     }
   }
   return command;

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -105,7 +105,7 @@ export function getShellAbortReasonKind(
  * the system codepage.
  *
  * - PowerShell: uses `[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;`
- * - cmd.exe: uses `chcp 65001 >nul &&`
+ * - cmd.exe: uses `chcp 65001 >nul &`
  */
 function applyUtf8Prefix(command: string, shell: string): string {
   if (os.platform() === 'win32') {

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -115,7 +115,9 @@ function applyUtf8Prefix(command: string, shell: string): string {
       );
     }
     if (shell === 'cmd') {
-      return `%SystemRoot%\\System32\\chcp.com 65001 >nul && ${command}`;
+      // Resolve in JS with fallback (defense-in-depth, matches WINDOWS_TASKKILL pattern, see #5873)
+      const systemRoot = process.env['SystemRoot'] || 'C:\\Windows';
+      return `${systemRoot}\\System32\\chcp.com 65001 >nul & ${command}`;
     }
   }
   return command;

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -13,7 +13,7 @@ import os from 'node:os';
 import type { IPty } from '@lydell/node-pty';
 import { getCachedEncodingForBuffer } from '../utils/systemEncoding.js';
 import { isBinary } from '../utils/textUtils.js';
-import { getShellConfiguration } from '../utils/shell-utils.js';
+import { getShellConfiguration, type ShellType } from '../utils/shell-utils.js';
 import pkg from '@xterm/headless';
 import {
   serializeTerminalToObject,
@@ -105,9 +105,11 @@ export function getShellAbortReasonKind(
  * the system codepage.
  *
  * - PowerShell: uses `[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;`
- * - cmd.exe: uses `chcp 65001 >nul &`
+ * - cmd.exe: uses `{SystemRoot}\System32\chcp.com 65001 >nul 2>nul &`
  */
-function applyUtf8Prefix(command: string, shell: string): string {
+const CHCP = `${process.env['SystemRoot'] || 'C:\\Windows'}\\System32\\chcp.com`;
+
+function applyUtf8Prefix(command: string, shell: ShellType): string {
   if (os.platform() === 'win32') {
     if (shell === 'powershell') {
       return (
@@ -115,9 +117,8 @@ function applyUtf8Prefix(command: string, shell: string): string {
       );
     }
     if (shell === 'cmd') {
-      // Resolve in JS with fallback (defense-in-depth, matches WINDOWS_TASKKILL pattern, see #5873)
-      const systemRoot = process.env['SystemRoot'] || 'C:\\Windows';
-      return `${systemRoot}\\System32\\chcp.com 65001 >nul 2>nul & ${command}`;
+      // Resolved at module-load time (defense-in-depth, matches WINDOWS_TASKKILL pattern, see #5873)
+      return `${CHCP} 65001 >nul 2>nul & ${command}`;
     }
   }
   return command;

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -110,18 +110,22 @@ export function getShellAbortReasonKind(
 const CHCP = `${process.env['SystemRoot'] || 'C:\\Windows'}\\System32\\chcp.com`;
 
 function applyUtf8Prefix(command: string, shell: ShellType): string {
-  if (os.platform() === 'win32') {
-    if (shell === 'powershell') {
+  if (os.platform() !== 'win32') return command;
+  switch (shell) {
+    case 'powershell':
       return (
         '[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;' + command
       );
-    }
-    if (shell === 'cmd') {
+    case 'cmd':
       // Resolved at module-load time (defense-in-depth, matches WINDOWS_TASKKILL pattern, see #5873)
       return `${CHCP} 65001 >nul 2>nul & ${command}`;
+    case 'bash':
+      return command;
+    default: {
+      const _exhaustive: never = shell;
+      return _exhaustive;
     }
   }
-  return command;
 }
 
 /**

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -100,13 +100,23 @@ export function getShellAbortReasonKind(
 }
 
 /**
- * On Windows with PowerShell, prefix the command with a statement that forces
- * UTF-8 output encoding so that CJK and other non-ASCII characters are emitted
- * as UTF-8 regardless of the system codepage.
+ * On Windows, prefix the command with a statement that forces UTF-8 output
+ * encoding so that non-ASCII characters are emitted as UTF-8 regardless of
+ * the system codepage.
+ *
+ * - PowerShell: uses `[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;`
+ * - cmd.exe: uses `chcp 65001 >nul &&`
  */
-function applyPowerShellUtf8Prefix(command: string, shell: string): string {
-  if (os.platform() === 'win32' && shell === 'powershell') {
-    return '[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;' + command;
+function applyUtf8Prefix(command: string, shell: string): string {
+  if (os.platform() === 'win32') {
+    if (shell === 'powershell') {
+      return (
+        '[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;' + command
+      );
+    }
+    if (shell === 'cmd') {
+      return `chcp 65001 >nul && ${command}`;
+    }
   }
   return command;
 }
@@ -682,7 +692,7 @@ export class ShellExecutionService {
     try {
       const isWindows = os.platform() === 'win32';
       const { executable, argsPrefix, shell } = getShellConfiguration();
-      commandToExecute = applyPowerShellUtf8Prefix(commandToExecute, shell);
+      commandToExecute = applyUtf8Prefix(commandToExecute, shell);
       const shellArgs = [...argsPrefix, commandToExecute];
 
       // Note: CodeQL flags this as js/shell-command-injection-from-environment.
@@ -1376,7 +1386,7 @@ export class ShellExecutionService {
       const cols = shellExecutionConfig.terminalWidth ?? 80;
       const rows = shellExecutionConfig.terminalHeight ?? 30;
       const { executable, argsPrefix, shell } = getShellConfiguration();
-      commandToExecute = applyPowerShellUtf8Prefix(commandToExecute, shell);
+      commandToExecute = applyUtf8Prefix(commandToExecute, shell);
 
       // On Windows with cmd.exe, pass args as a single string instead of
       // an array. node-pty's argsToCommandLine re-quotes array elements

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -117,7 +117,7 @@ function applyUtf8Prefix(command: string, shell: string): string {
     if (shell === 'cmd') {
       // Resolve in JS with fallback (defense-in-depth, matches WINDOWS_TASKKILL pattern, see #5873)
       const systemRoot = process.env['SystemRoot'] || 'C:\\Windows';
-      return `"${systemRoot}\\System32\\chcp.com" 65001 >nul 2>nul & ${command}`;
+      return `${systemRoot}\\System32\\chcp.com 65001 >nul 2>nul & ${command}`;
     }
   }
   return command;


### PR DESCRIPTION
## What this PR does

Fixes garbled text output when running shell commands via cmd.exe on Windows with non-UTF-8 console code pages (CP1251, CP936, CP932). The applyUtf8Prefix() function previously only handled PowerShell — cmd.exe output in the system codepage, which Qwen Code decoded as UTF-8, producing corrupted characters.

Extended applyUtf8Prefix() to prepend chcp 65001 for cmd.exe, mirroring the existing PowerShell UTF-8 prefix. The chcp.com path is resolved in JavaScript with a fallback to C:\Windows for defense-in-depth (matching the WINDOWS_TASKKILL pattern). Uses unconditional `&` separator so the user command always runs regardless of chcp outcome.

## Why it's needed

On Windows systems with Cyrillic (CP1251), Chinese (CP936), or Japanese (CP932) console code pages, any non-ASCII output from shell commands through cmd.exe was displayed as garbled text. This affected all Windows users whose system locale is not UTF-8 — a common default for Windows in Russia, China, and Japan. The PowerShell path already worked correctly; only the cmd.exe path was broken.

## Reviewer Test Plan

### How to verify

1. Set Windows console to CP1251: `chcp 1251`
2. Run Qwen Code with a shell command that outputs non-ASCII: `echo Привет мир` via cmd.exe
3. Verify output is readable Cyrillic, not garbled characters.

### Evidence (Before & After)

Before: cmd.exe output in CP1251 decoded as UTF-8 shows ``ÐŸÑ€Ð¸Ð²ÐµÑ‚ Ð¼Ð¸Ñ€``
After: chcp 65001 prefixes the command, output is correct: ``Привет мир``

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🪟 Windows | ✅ tested |
|  🍏 macOS  | N/A |
|  🐧 Linux  | N/A |

Unit tests updated: PTY assertion fixed (string vs array), mock leak prevented, argsPrefix aligned, duplicate test removed.

## Risk & Scope

- Main risk or tradeoff: `chcp.com` is an external binary in System32; using absolute path via JS-resolved `SystemRoot` eliminates PATH traversal risk (defense-in-depth per #5873). Using `&` instead of `&&` means the user command runs even if chcp fails — the worst case is the command runs in the system codepage instead of UTF-8.
- Not validated / out of scope: PowerShell edge cases beyond what existing tests cover.
- Breaking changes / migration notes: None. This is a bugfix with no API changes.

QwenCode QwenLLM
