### PR TITLE
fix(core): add UTF-8 prefix for cmd.exe on Windows

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -1849,6 +1849,25 @@ describe('ShellExecutionService', () => {
       });
     });
 
+    it('should use cmd.exe with chcp 65001 UTF-8 prefix via PTY on Windows', async () => {
+      mockPlatform.mockReturnValue('win32');
+      mockGetShellConfiguration.mockReturnValue({
+        executable: 'cmd.exe',
+        argsPrefix: ['/c'],
+        shell: 'cmd',
+      });
+      await simulateExecution('dir "C:\\Temp\\"', (pty) =>
+        pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null }),
+      );
+
+      // cmd.exe commands on Windows are prefixed with chcp 65001 for UTF-8
+      expect(mockPtySpawn).toHaveBeenCalledWith(
+        'cmd.exe',
+        ['/c', 'chcp 65001 >nul && dir "C:\\Temp\\"'],
+        expect.any(Object),
+      );
+    });
+
     it('should normalize PATH-like env keys on Windows for pty execution', async () => {
       mockPlatform.mockReturnValue('win32');
       vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
@@ -3037,7 +3056,7 @@ describe('ShellExecutionService child_process fallback', () => {
   });
 
   describe('Platform-Specific Behavior', () => {
-    it('should use cmd.exe with windowsVerbatimArguments on Windows', async () => {
+    it('should use cmd.exe with chcp 65001 UTF-8 prefix on Windows', async () => {
       mockPlatform.mockReturnValue('win32');
       mockGetShellConfiguration.mockReturnValue({
         executable: 'cmd.exe',
@@ -3048,9 +3067,10 @@ describe('ShellExecutionService child_process fallback', () => {
         cp.emit('exit', 0, null),
       );
 
+      // cmd.exe commands on Windows are prefixed with chcp 65001 for UTF-8
       expect(mockCpSpawn).toHaveBeenCalledWith(
         'cmd.exe',
-        ['/d', '/s', '/c', 'dir "foo bar"'],
+        ['/d', '/s', '/c', 'chcp 65001 >nul && dir "foo bar"'],
         expect.objectContaining({
           detached: false,
           windowsHide: true,

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -100,13 +100,23 @@ export function getShellAbortReasonKind(
 }
 
 /**
- * On Windows with PowerShell, prefix the command with a statement that forces
- * UTF-8 output encoding so that CJK and other non-ASCII characters are emitted
- * as UTF-8 regardless of the system codepage.
+ * On Windows, prefix the command with a statement that forces UTF-8 output
+ * encoding so that non-ASCII characters are emitted as UTF-8 regardless of
+ * the system codepage.
+ *
+ * - PowerShell: uses `[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;`
+ * - cmd.exe: uses `chcp 65001 >nul &&`
  */
-function applyPowerShellUtf8Prefix(command: string, shell: string): string {
-  if (os.platform() === 'win32' && shell === 'powershell') {
-    return '[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;' + command;
+function applyUtf8Prefix(command: string, shell: string): string {
+  if (os.platform() === 'win32') {
+    if (shell === 'powershell') {
+      return (
+        '[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;' + command
+      );
+    }
+    if (shell === 'cmd') {
+      return `chcp 65001 >nul && ${command}`;
+    }
   }
   return command;
 }
@@ -682,7 +692,7 @@ export class ShellExecutionService {
     try {
       const isWindows = os.platform() === 'win32';
       const { executable, argsPrefix, shell } = getShellConfiguration();
-      commandToExecute = applyPowerShellUtf8Prefix(commandToExecute, shell);
+      commandToExecute = applyUtf8Prefix(commandToExecute, shell);
       const shellArgs = [...argsPrefix, commandToExecute];
 
       // Note: CodeQL flags this as js/shell-command-injection-from-environment.
@@ -1376,7 +1386,7 @@ export class ShellExecutionService {
       const cols = shellExecutionConfig.terminalWidth ?? 80;
       const rows = shellExecutionConfig.terminalHeight ?? 30;
       const { executable, argsPrefix, shell } = getShellConfiguration();
-      commandToExecute = applyPowerShellUtf8Prefix(commandToExecute, shell);
+      commandToExecute = applyUtf8Prefix(commandToExecute, shell);
 
       // On Windows with cmd.exe, pass args as a single string instead of
       // an array. node-pty's argsToCommandLine re-quotes array elements


### PR DESCRIPTION
## Description

Fixes garbled text output when `run_shell_command` executes commands via `cmd.exe` on Windows with non-UTF-8 console code pages (e.g., CP1251, CP936, CP932).

## Root Cause

`applyPowerShellUtf8Prefix()` only handled PowerShell — `cmd.exe` received no UTF-8 prefix and output in the system code page, which Qwen Code decoded as UTF-8, causing garbled text.

## Fix

Extended `applyUtf8Prefix()` to prepend `chcp 65001 >nul &&` for `cmd.exe`, similar to the existing PowerShell UTF-8 prefix.

**Changed:** `packages/core/src/services/shellExecutionService.ts`
**Added:** PTY test for cmd.exe UTF-8 prefix

**Refs:** #6214
