### PR TITLE
fix(web-shell): improve session restore and loading feedback

### DIFF
--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -2028,14 +2028,11 @@ export function App({
   const loadSidebarSession = useCallback(
     async (sessionId: string) => {
       setSidebarSwitchingSessionId(sessionId);
-      // Close the drawer before awaiting the load so it doesn't linger over the
-      // old transcript while the new session streams in, matching the other
-      // session-switch paths (/resume, ResumeDialog).
+      // Close the drawer before awaiting the load; the transcript clears
+      // immediately and shows its loading skeleton for the selected session.
       closeMobileDrawer();
       try {
-        await sessionActions.loadSession(sessionId, {
-          deferTranscriptReset: true,
-        });
+        await sessionActions.loadSession(sessionId);
       } catch (error) {
         setSidebarSwitchingSessionId((current) =>
           current === sessionId ? null : current,
@@ -2050,11 +2047,17 @@ export function App({
     if (
       sidebarSwitchingSessionId !== null &&
       connection.sessionId === sidebarSwitchingSessionId &&
+      !connection.loadingTranscript &&
       !connection.catchingUp
     ) {
       setSidebarSwitchingSessionId(null);
     }
-  }, [connection.catchingUp, connection.sessionId, sidebarSwitchingSessionId]);
+  }, [
+    connection.catchingUp,
+    connection.loadingTranscript,
+    connection.sessionId,
+    sidebarSwitchingSessionId,
+  ]);
 
   const openTasksPanel = useCallback(() => {
     if (!requireActiveSessionForLocalCommand()) return;
@@ -2200,6 +2203,10 @@ export function App({
 
   const handleSubmit = useCallback(
     (text: string, images?: PromptImage[]) => {
+      if (connectionRef.current.loadingTranscript) {
+        pushToast('warning', t('editor.sessionLoading'));
+        return false;
+      }
       if (
         shouldBlockComposerSubmit({
           connectionStatus: connectionRef.current.status,
@@ -3771,6 +3778,7 @@ export function App({
                         messages={displayMessages}
                         pendingApproval={pendingToolApproval}
                         onShowContextDetail={handleShowContextDetail}
+                        loadingTranscript={connection.loadingTranscript}
                         catchingUp={connection.catchingUp}
                         isResponding={streamingState !== 'idle'}
                         activeTurnStartedAt={activeTurnStartedAt}

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -128,6 +128,7 @@ function mount(
   ref?: RefObject<MessageListHandle | null>,
   opts: {
     hideSessionTimeline?: boolean;
+    loadingTranscript?: boolean;
     catchingUp?: boolean;
     isResponding?: boolean;
     onCanScrollToBottomChange?: (canScrollToBottom: boolean) => void;
@@ -144,6 +145,7 @@ function mount(
           messages={messages}
           pendingApproval={null}
           hideSessionTimeline={opts.hideSessionTimeline}
+          loadingTranscript={opts.loadingTranscript}
           catchingUp={opts.catchingUp}
           isResponding={opts.isResponding}
           shellOutputMaxLines={50}
@@ -161,6 +163,7 @@ function renderInto(
   messages: Message[],
   ref?: RefObject<MessageListHandle | null>,
   opts: {
+    loadingTranscript?: boolean;
     catchingUp?: boolean;
     isResponding?: boolean;
     onCanScrollToBottomChange?: (canScrollToBottom: boolean) => void;
@@ -173,6 +176,7 @@ function renderInto(
           ref={ref}
           messages={messages}
           pendingApproval={null}
+          loadingTranscript={opts.loadingTranscript}
           catchingUp={opts.catchingUp}
           isResponding={opts.isResponding}
           shellOutputMaxLines={50}
@@ -489,6 +493,32 @@ describe('MessageList — turn collapse (DOM)', () => {
     mount([userMsg('u1'), asstMsg('a1')]);
 
     expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('shows a transcript skeleton while loading transcript', () => {
+    const c = mount([], undefined, { loadingTranscript: true });
+
+    expect(
+      c.querySelector('[data-testid="message-list-loading-skeleton"]'),
+    ).not.toBeNull();
+  });
+
+  it('shows the transcript skeleton while loading transcript with existing messages', () => {
+    const c = mount([userMsg('u1')], undefined, {
+      loadingTranscript: true,
+    });
+
+    expect(
+      c.querySelector('[data-testid="message-list-loading-skeleton"]'),
+    ).not.toBeNull();
+  });
+
+  it('does not show the transcript skeleton outside transcript loading', () => {
+    const idle = mount([]);
+
+    expect(
+      idle.querySelector('[data-testid="message-list-loading-skeleton"]'),
+    ).toBeNull();
   });
 
   it('does not smooth-scroll when existing session history loads after an empty render', () => {

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -501,6 +501,9 @@ describe('MessageList — turn collapse (DOM)', () => {
     expect(
       c.querySelector('[data-testid="message-list-loading-skeleton"]'),
     ).not.toBeNull();
+    expect(c.querySelector('[role="status"]')?.textContent).toBe(
+      'Session is still loading. Try again in a moment.',
+    );
   });
 
   it('shows the transcript skeleton while loading transcript with existing messages', () => {
@@ -618,6 +621,40 @@ describe('MessageList — turn collapse (DOM)', () => {
     await nextFrame();
 
     expect(scrollTop).toBe(1200);
+    expect(scrollTo).not.toHaveBeenCalledWith({
+      top: 1200,
+      behavior: 'smooth',
+    });
+  });
+
+  it('does not smooth-scroll when a user prompt is already followed by an assistant row', async () => {
+    const scrollTo = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+      configurable: true,
+      value: scrollTo,
+    });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    renderInto(root, [userMsg('u1'), asstMsg('a1')]);
+    renderInto(root, [
+      userMsg('u1'),
+      asstMsg('a1'),
+      userMsg('u2'),
+      asstMsg('a2'),
+    ]);
+    await nextFrame();
+
     expect(scrollTo).not.toHaveBeenCalledWith({
       top: 1200,
       behavior: 'smooth',

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -584,6 +584,46 @@ describe('MessageList — turn collapse (DOM)', () => {
     });
   });
 
+  it('does not smooth-scroll restored history that ends with a user prompt', async () => {
+    const scrollTo = vi.fn();
+    let scrollTop = 0;
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTop', {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = value;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+      configurable: true,
+      value: scrollTo,
+    });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    renderInto(root, [], undefined, { loadingTranscript: true });
+    renderInto(root, [userMsg('u1')], undefined, {
+      loadingTranscript: false,
+    });
+    await nextFrame();
+
+    expect(scrollTop).toBe(1200);
+    expect(scrollTo).not.toHaveBeenCalledWith({
+      top: 1200,
+      behavior: 'smooth',
+    });
+  });
+
   it('snaps to bottom without smooth scrolling when catch-up completes', () => {
     const scrollTo = vi.fn();
     let scrollTop = 0;

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -128,6 +128,7 @@ function mount(
   ref?: RefObject<MessageListHandle | null>,
   opts: {
     hideSessionTimeline?: boolean;
+    catchingUp?: boolean;
     isResponding?: boolean;
     onCanScrollToBottomChange?: (canScrollToBottom: boolean) => void;
   } = {},
@@ -143,6 +144,7 @@ function mount(
           messages={messages}
           pendingApproval={null}
           hideSessionTimeline={opts.hideSessionTimeline}
+          catchingUp={opts.catchingUp}
           isResponding={opts.isResponding}
           shellOutputMaxLines={50}
           onCanScrollToBottomChange={opts.onCanScrollToBottomChange}
@@ -152,6 +154,33 @@ function mount(
   });
   mounted.push({ root, container });
   return container;
+}
+
+function renderInto(
+  root: Root,
+  messages: Message[],
+  ref?: RefObject<MessageListHandle | null>,
+  opts: {
+    catchingUp?: boolean;
+    isResponding?: boolean;
+    onCanScrollToBottomChange?: (canScrollToBottom: boolean) => void;
+  } = {},
+) {
+  act(() => {
+    root.render(
+      <I18nProvider language="en">
+        <MessageList
+          ref={ref}
+          messages={messages}
+          pendingApproval={null}
+          catchingUp={opts.catchingUp}
+          isResponding={opts.isResponding}
+          shellOutputMaxLines={50}
+          onCanScrollToBottomChange={opts.onCanScrollToBottomChange}
+        />
+      </I18nProvider>,
+    );
+  });
 }
 
 const has = (c: HTMLElement, id: string) =>
@@ -412,7 +441,7 @@ describe('MessageList — turn collapse (DOM)', () => {
     expect(isCollapsed(c, 'g1')).toBe(false);
   });
 
-  it('smooth-scrolls the page when a new chat prompt appears', () => {
+  it('smooth-scrolls the page when a new chat prompt appears', async () => {
     const scrollTo = vi.fn();
     Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
       configurable: true,
@@ -427,12 +456,110 @@ describe('MessageList — turn collapse (DOM)', () => {
       value: scrollTo,
     });
 
-    mount([userMsg('u1')]);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    renderInto(root, [userMsg('u1'), asstMsg('a1')]);
+    renderInto(root, [userMsg('u1'), asstMsg('a1'), userMsg('u2')]);
+    await nextFrame();
 
     expect(scrollTo).toHaveBeenCalledWith({
       top: 1200,
       behavior: 'smooth',
     });
+  });
+
+  it('does not smooth-scroll when initial history already contains a user prompt', () => {
+    const scrollTo = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+      configurable: true,
+      value: scrollTo,
+    });
+
+    mount([userMsg('u1'), asstMsg('a1')]);
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('does not smooth-scroll when existing session history loads after an empty render', () => {
+    const scrollTo = vi.fn();
+    let scrollTop = 0;
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTop', {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = value;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+      configurable: true,
+      value: scrollTo,
+    });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    renderInto(root, []);
+    renderInto(root, [userMsg('u1'), asstMsg('a1')]);
+
+    expect(scrollTop).toBe(1200);
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('snaps to bottom without smooth scrolling when catch-up completes', () => {
+    const scrollTo = vi.fn();
+    let scrollTop = 0;
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTop', {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = value;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+      configurable: true,
+      value: scrollTo,
+    });
+    const messages = [userMsg('u1'), asstMsg('a1')];
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    renderInto(root, messages, undefined, { catchingUp: true });
+    expect(scrollTop).toBe(0);
+
+    renderInto(root, messages, undefined, { catchingUp: false });
+
+    expect(scrollTop).toBe(1200);
+    expect(scrollTo).not.toHaveBeenCalled();
   });
 
   it('does not treat a user_shell row as a new chat prompt', () => {

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -555,6 +555,35 @@ describe('MessageList — turn collapse (DOM)', () => {
     expect(scrollTo).not.toHaveBeenCalled();
   });
 
+  it('smooth-scrolls the first new prompt after an empty render', async () => {
+    const scrollTo = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+      configurable: true,
+      value: scrollTo,
+    });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    renderInto(root, []);
+    renderInto(root, [userMsg('u1')]);
+    await nextFrame();
+
+    expect(scrollTo).toHaveBeenCalledWith({
+      top: 1200,
+      behavior: 'smooth',
+    });
+  });
+
   it('snaps to bottom without smooth scrolling when catch-up completes', () => {
     const scrollTo = vi.fn();
     let scrollTop = 0;

--- a/packages/web-shell/client/components/MessageList.module.css
+++ b/packages/web-shell/client/components/MessageList.module.css
@@ -38,6 +38,18 @@
   pointer-events: none;
 }
 
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .loadingSkeletonUserRow {
   display: flex;
   justify-content: flex-end;

--- a/packages/web-shell/client/components/MessageList.module.css
+++ b/packages/web-shell/client/components/MessageList.module.css
@@ -30,6 +30,92 @@
   transition: width 320ms ease;
 }
 
+.loadingSkeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  padding: 18px 0 36px;
+  pointer-events: none;
+}
+
+.loadingSkeletonUserRow {
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+}
+
+.loadingSkeletonAssistantRow {
+  display: flex;
+  justify-content: flex-start;
+  width: 100%;
+}
+
+.loadingSkeletonUserBubble,
+.loadingSkeletonUserBubbleCompact {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  width: min(62%, 520px);
+  padding: 12px 14px;
+  border-radius: 6px;
+  background: var(--accent);
+}
+
+.loadingSkeletonUserBubbleCompact {
+  width: min(46%, 360px);
+}
+
+.loadingSkeletonAssistantBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: min(72%, 640px);
+  padding: 3px 0;
+}
+
+.loadingSkeletonLineWide,
+.loadingSkeletonLineMedium,
+.loadingSkeletonLineShort,
+.loadingSkeletonLineNarrow {
+  display: block;
+  height: 16px;
+  border-radius: 4px;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--muted-foreground) 10%, transparent) 25%,
+    color-mix(in srgb, var(--muted-foreground) 24%, transparent) 37%,
+    color-mix(in srgb, var(--muted-foreground) 10%, transparent) 63%
+  );
+  background-size: 400% 100%;
+  animation: loadingSkeletonShimmer 1.4s ease infinite;
+}
+
+.loadingSkeletonLineWide {
+  width: 100%;
+}
+
+.loadingSkeletonLineMedium {
+  width: 72%;
+}
+
+.loadingSkeletonLineShort {
+  width: 48%;
+}
+
+.loadingSkeletonLineNarrow {
+  width: 58%;
+}
+
+@keyframes loadingSkeletonShimmer {
+  0% {
+    background-position: 100% 50%;
+  }
+
+  100% {
+    background-position: 0 50%;
+  }
+}
+
 .rowFlash {
   border-radius: 8px;
   animation: row-flash 1.6s ease-out;

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -71,6 +71,10 @@ function getLastUserMessageId(messages: Message[]): string | null {
   return null;
 }
 
+function getLastMessage(messages: Message[]): Message | undefined {
+  return messages[messages.length - 1];
+}
+
 function getLastTurnStartMessageId(messages: Message[]): string | null {
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];
@@ -1805,9 +1809,9 @@ export const MessageList = memo(
     const scrollCooldownCount = useRef(0);
     const sessionTimelineFrame = useRef<number | null>(null);
     const lastReportedCanScrollToBottom = useRef<boolean | null>(null);
-    const didMountRef = useRef(false);
     const didTrackLastUserMsgRef = useRef(false);
     const prevLastUserMsgId = useRef<string | null>(null);
+    const pendingNewUserSmoothScroll = useRef(false);
     const prevActiveExecutionKey = useRef<string | null>(null);
     const prevCatchingUp: MutableRefObject<boolean | undefined> =
       useRef(catchingUp);
@@ -2480,32 +2484,35 @@ export const MessageList = memo(
 
     // Rule 4: new user message → force follow on so the model's reply
     // scrolls into view as it streams in.
-    useEffect(() => {
+    useLayoutEffect(() => {
       const lastId = getLastUserMessageId(messages);
       if (catchingUp) {
         prevLastUserMsgId.current = lastId;
         didTrackLastUserMsgRef.current = true;
+        pendingNewUserSmoothScroll.current = false;
         return;
       }
       if (!didTrackLastUserMsgRef.current) {
         prevLastUserMsgId.current = lastId;
         didTrackLastUserMsgRef.current = true;
+        pendingNewUserSmoothScroll.current = false;
         return;
       }
+      const lastMessage = getLastMessage(messages);
       if (
         lastId &&
-        prevLastUserMsgId.current !== null &&
+        lastMessage?.role === 'user' &&
         lastId !== prevLastUserMsgId.current
       ) {
         setShouldFollow(true);
         // A new prompt supersedes any pending "Show in transcript" scroll.
         pendingScrollRef.current = null;
-        requestAnimationFrame(() => {
-          if (shouldFollow.current) scrollToBottom('smooth');
-        });
+        pendingNewUserSmoothScroll.current = true;
+      } else {
+        pendingNewUserSmoothScroll.current = false;
       }
       prevLastUserMsgId.current = lastId;
-    }, [messages, catchingUp, scrollToBottom, setShouldFollow]);
+    }, [messages, catchingUp, setShouldFollow]);
 
     // Rule 5: session restore — when catchingUp flips from true → falsy,
     // replay just finished. Scroll to bottom once so the user sees the
@@ -2692,19 +2699,13 @@ export const MessageList = memo(
     //         and is a no-op when there's no overflow.
     useLayoutEffect(() => {
       if (catchingUp) return;
-      if (scrollCooldown.current) return;
-      if (pendingFollowRecheck.current) return;
-      if (shouldFollow.current) {
-        const lastId = getLastUserMessageId(messages);
-        const isNewUserMessage =
-          didMountRef.current &&
-          didTrackLastUserMsgRef.current &&
-          lastId !== null &&
-          prevLastUserMsgId.current !== null &&
-          lastId !== prevLastUserMsgId.current;
+      const isNewUserMessage = pendingNewUserSmoothScroll.current;
+      if (scrollCooldown.current && !isNewUserMessage) return;
+      if (pendingFollowRecheck.current && !isNewUserMessage) return;
+      if (shouldFollow.current || isNewUserMessage) {
         scrollToBottom(isNewUserMessage ? 'smooth' : 'auto');
+        pendingNewUserSmoothScroll.current = false;
       }
-      didMountRef.current = true;
     }, [totalVirtualSize, messages, totalCount, catchingUp, scrollToBottom]);
 
     useLayoutEffect(() => {

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -2710,6 +2710,8 @@ export const MessageList = memo(
       if (catchingUp) return;
       const isNewUserMessage = pendingNewUserSmoothScroll.current;
       if (scrollCooldown.current && !isNewUserMessage) return;
+      // Preserve the new-prompt scroll even if a previous disclosure resize is
+      // still settling; it targets the latest virtualizer size from this render.
       if (pendingFollowRecheck.current && !isNewUserMessage) return;
       if (shouldFollow.current || isNewUserMessage) {
         scrollToBottom(isNewUserMessage ? 'smooth' : 'auto');

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -1812,6 +1812,7 @@ export const MessageList = memo(
     const didTrackLastUserMsgRef = useRef(false);
     const prevLastUserMsgId = useRef<string | null>(null);
     const pendingNewUserSmoothScroll = useRef(false);
+    const prevLoadingTranscript = useRef(loadingTranscript);
     const prevActiveExecutionKey = useRef<string | null>(null);
     const prevCatchingUp: MutableRefObject<boolean | undefined> =
       useRef(catchingUp);
@@ -2486,12 +2487,14 @@ export const MessageList = memo(
     // scrolls into view as it streams in.
     useLayoutEffect(() => {
       const lastId = getLastUserMessageId(messages);
-      if (catchingUp) {
+      if (catchingUp || loadingTranscript || prevLoadingTranscript.current) {
         prevLastUserMsgId.current = lastId;
         didTrackLastUserMsgRef.current = true;
         pendingNewUserSmoothScroll.current = false;
+        prevLoadingTranscript.current = loadingTranscript;
         return;
       }
+      prevLoadingTranscript.current = loadingTranscript;
       if (!didTrackLastUserMsgRef.current) {
         prevLastUserMsgId.current = lastId;
         didTrackLastUserMsgRef.current = true;
@@ -2512,7 +2515,7 @@ export const MessageList = memo(
         pendingNewUserSmoothScroll.current = false;
       }
       prevLastUserMsgId.current = lastId;
-    }, [messages, catchingUp, setShouldFollow]);
+    }, [messages, catchingUp, loadingTranscript, setShouldFollow]);
 
     // Rule 5: session restore — when catchingUp flips from true → falsy,
     // replay just finished. Scroll to bottom once so the user sees the

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -1768,6 +1768,8 @@ export const MessageList = memo(
     const scrollCooldownCount = useRef(0);
     const sessionTimelineFrame = useRef<number | null>(null);
     const lastReportedCanScrollToBottom = useRef<boolean | null>(null);
+    const didMountRef = useRef(false);
+    const didTrackLastUserMsgRef = useRef(false);
     const prevLastUserMsgId = useRef<string | null>(null);
     const prevActiveExecutionKey = useRef<string | null>(null);
     const prevCatchingUp: MutableRefObject<boolean | undefined> =
@@ -2444,23 +2446,36 @@ export const MessageList = memo(
       const lastId = getLastUserMessageId(messages);
       if (catchingUp) {
         prevLastUserMsgId.current = lastId;
+        didTrackLastUserMsgRef.current = true;
         return;
       }
-      if (lastId && lastId !== prevLastUserMsgId.current) {
+      if (!didTrackLastUserMsgRef.current) {
+        prevLastUserMsgId.current = lastId;
+        didTrackLastUserMsgRef.current = true;
+        return;
+      }
+      if (
+        lastId &&
+        prevLastUserMsgId.current !== null &&
+        lastId !== prevLastUserMsgId.current
+      ) {
         setShouldFollow(true);
         // A new prompt supersedes any pending "Show in transcript" scroll.
         pendingScrollRef.current = null;
+        requestAnimationFrame(() => {
+          if (shouldFollow.current) scrollToBottom('smooth');
+        });
       }
       prevLastUserMsgId.current = lastId;
-    }, [messages, catchingUp, setShouldFollow]);
+    }, [messages, catchingUp, scrollToBottom, setShouldFollow]);
 
     // Rule 5: session restore — when catchingUp flips from true → falsy,
     // replay just finished. Scroll to bottom once so the user sees the
     // latest content without the viewport fighting the replay.
-    useEffect(() => {
+    useLayoutEffect(() => {
       if (prevCatchingUp.current && !catchingUp) {
         setShouldFollow(true);
-        requestAnimationFrame(() => scrollToBottom());
+        scrollToBottom('auto');
       }
       prevCatchingUp.current = catchingUp;
     }, [catchingUp, scrollToBottom, setShouldFollow]);
@@ -2644,9 +2659,14 @@ export const MessageList = memo(
       if (shouldFollow.current) {
         const lastId = getLastUserMessageId(messages);
         const isNewUserMessage =
-          lastId !== null && lastId !== prevLastUserMsgId.current;
+          didMountRef.current &&
+          didTrackLastUserMsgRef.current &&
+          lastId !== null &&
+          prevLastUserMsgId.current !== null &&
+          lastId !== prevLastUserMsgId.current;
         scrollToBottom(isNewUserMessage ? 'smooth' : 'auto');
       }
+      didMountRef.current = true;
     }, [totalVirtualSize, messages, totalCount, catchingUp, scrollToBottom]);
 
     useLayoutEffect(() => {

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -36,6 +36,7 @@ interface MessageListProps {
   pendingApproval: PermissionRequest | null;
   /** Run /context detail, exactly like typing it (context-usage panels). */
   onShowContextDetail?: () => void;
+  loadingTranscript?: boolean;
   catchingUp?: boolean;
   /**
    * True while the agent is still answering. The newest turn then stays
@@ -1652,12 +1653,48 @@ function joinClassNames(
 
 const EMPTY_SESSION_TIMELINE_ENTRIES: SessionTimelineEntry[] = [];
 
+function LoadingTranscriptSkeleton() {
+  return (
+    <div
+      className={styles.loadingSkeleton}
+      data-testid="message-list-loading-skeleton"
+      aria-hidden="true"
+    >
+      <div className={styles.loadingSkeletonUserRow}>
+        <div className={styles.loadingSkeletonUserBubble}>
+          <span className={styles.loadingSkeletonLineWide} />
+          <span className={styles.loadingSkeletonLineShort} />
+        </div>
+      </div>
+      <div className={styles.loadingSkeletonAssistantRow}>
+        <div className={styles.loadingSkeletonAssistantBlock}>
+          <span className={styles.loadingSkeletonLineMedium} />
+          <span className={styles.loadingSkeletonLineWide} />
+          <span className={styles.loadingSkeletonLineNarrow} />
+        </div>
+      </div>
+      <div className={styles.loadingSkeletonUserRow}>
+        <div className={styles.loadingSkeletonUserBubbleCompact}>
+          <span className={styles.loadingSkeletonLineMedium} />
+        </div>
+      </div>
+      <div className={styles.loadingSkeletonAssistantRow}>
+        <div className={styles.loadingSkeletonAssistantBlock}>
+          <span className={styles.loadingSkeletonLineWide} />
+          <span className={styles.loadingSkeletonLineMedium} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export const MessageList = memo(
   forwardRef<MessageListHandle, MessageListProps>(function MessageList(
     {
       messages,
       pendingApproval,
       onShowContextDetail,
+      loadingTranscript,
       catchingUp,
       isResponding = false,
       activeTurnStartedAt,
@@ -1908,6 +1945,7 @@ export const MessageList = memo(
     // ─────────────────────────────────────────────────────────────────────
 
     const hasTailContent = tailContent !== undefined && tailContent !== null;
+    const showLoadingSkeleton = Boolean(loadingTranscript);
     const hasHeader = !!welcomeHeader;
     const headerOffset = hasHeader ? 1 : 0;
     const tailContentIndex = headerOffset + visibleItems.length;
@@ -2679,6 +2717,7 @@ export const MessageList = memo(
         className={styles.list}
         onClickCapture={handleDisclosureClickCapture}
       >
+        {showLoadingSkeleton && <LoadingTranscriptSkeleton />}
         <SessionTimeline
           entries={sessionTimelineEntries}
           currentTurnId={currentTimelineTurnId}

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -1657,38 +1657,43 @@ function joinClassNames(
 
 const EMPTY_SESSION_TIMELINE_ENTRIES: SessionTimelineEntry[] = [];
 
-function LoadingTranscriptSkeleton() {
+function LoadingTranscriptSkeleton({ label }: { label: string }) {
   return (
-    <div
-      className={styles.loadingSkeleton}
-      data-testid="message-list-loading-skeleton"
-      aria-hidden="true"
-    >
-      <div className={styles.loadingSkeletonUserRow}>
-        <div className={styles.loadingSkeletonUserBubble}>
-          <span className={styles.loadingSkeletonLineWide} />
-          <span className={styles.loadingSkeletonLineShort} />
+    <>
+      <div role="status" aria-live="polite" className={styles.srOnly}>
+        {label}
+      </div>
+      <div
+        className={styles.loadingSkeleton}
+        data-testid="message-list-loading-skeleton"
+        aria-hidden="true"
+      >
+        <div className={styles.loadingSkeletonUserRow}>
+          <div className={styles.loadingSkeletonUserBubble}>
+            <span className={styles.loadingSkeletonLineWide} />
+            <span className={styles.loadingSkeletonLineShort} />
+          </div>
+        </div>
+        <div className={styles.loadingSkeletonAssistantRow}>
+          <div className={styles.loadingSkeletonAssistantBlock}>
+            <span className={styles.loadingSkeletonLineMedium} />
+            <span className={styles.loadingSkeletonLineWide} />
+            <span className={styles.loadingSkeletonLineNarrow} />
+          </div>
+        </div>
+        <div className={styles.loadingSkeletonUserRow}>
+          <div className={styles.loadingSkeletonUserBubbleCompact}>
+            <span className={styles.loadingSkeletonLineMedium} />
+          </div>
+        </div>
+        <div className={styles.loadingSkeletonAssistantRow}>
+          <div className={styles.loadingSkeletonAssistantBlock}>
+            <span className={styles.loadingSkeletonLineWide} />
+            <span className={styles.loadingSkeletonLineMedium} />
+          </div>
         </div>
       </div>
-      <div className={styles.loadingSkeletonAssistantRow}>
-        <div className={styles.loadingSkeletonAssistantBlock}>
-          <span className={styles.loadingSkeletonLineMedium} />
-          <span className={styles.loadingSkeletonLineWide} />
-          <span className={styles.loadingSkeletonLineNarrow} />
-        </div>
-      </div>
-      <div className={styles.loadingSkeletonUserRow}>
-        <div className={styles.loadingSkeletonUserBubbleCompact}>
-          <span className={styles.loadingSkeletonLineMedium} />
-        </div>
-      </div>
-      <div className={styles.loadingSkeletonAssistantRow}>
-        <div className={styles.loadingSkeletonAssistantBlock}>
-          <span className={styles.loadingSkeletonLineWide} />
-          <span className={styles.loadingSkeletonLineMedium} />
-        </div>
-      </div>
-    </div>
+    </>
   );
 }
 
@@ -1717,6 +1722,7 @@ export const MessageList = memo(
     },
     ref,
   ) {
+    const { t } = useI18n();
     const compactMode = useContext(CompactModeContext);
     const mergedMessages = useMemo(
       () =>
@@ -2721,7 +2727,9 @@ export const MessageList = memo(
         className={styles.list}
         onClickCapture={handleDisclosureClickCapture}
       >
-        {showLoadingSkeleton && <LoadingTranscriptSkeleton />}
+        {showLoadingSkeleton && (
+          <LoadingTranscriptSkeleton label={t('editor.sessionLoading')} />
+        )}
         <SessionTimeline
           entries={sessionTimelineEntries}
           currentTurnId={currentTimelineTurnId}

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -384,6 +384,7 @@ const EN: Messages = {
   'editor.send': 'Send message',
   'editor.connectionDisconnected':
     'Connection interrupted. Please try again after it reconnects.',
+  'editor.sessionLoading': 'Session is still loading. Try again in a moment.',
   'editor.processing': 'Processing. New messages will be queued.',
   'editor.searchHint': 'ctrl+r next · tab accept · enter send · esc cancel',
   'editor.searchLabel': 'reverse-i-search:',
@@ -1598,6 +1599,7 @@ const ZH: Messages = {
   'editor.shellPlaceholder': '请输入终端命令',
   'editor.send': '发送消息',
   'editor.connectionDisconnected': '连接已中断，请在恢复后重试。',
+  'editor.sessionLoading': '会话正在加载，请稍后再发送。',
   'editor.processing': '处理中。新消息会进入队列。',
   'editor.searchHint': 'ctrl+r 下一条 · tab 采纳 · enter 发送 · esc 取消',
   'editor.searchLabel': '历史搜索：',

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -4946,7 +4946,7 @@ describe('DaemonSessionProvider', () => {
       await flushPromises();
     });
 
-    expect(connection?.catchingUp).toBe(true);
+    expect(connection?.loadingTranscript).toBe(true);
     expect(blocks).toMatchObject([
       { kind: 'assistant', text: 'old transcript' },
     ]);
@@ -4966,13 +4966,18 @@ describe('DaemonSessionProvider', () => {
   });
 
   it('loads controlled sessionId changes', async () => {
+    const nextSession = createDeferred<MockSession>();
     sdkMocks.sessions.push(
-      createMockSession({ sessionId: 'session-a' }),
-      createMockSession({ sessionId: 'session-b' }),
+      createMockSession({
+        sessionId: 'session-a',
+        replaySnapshot: createTextReplaySnapshot('old transcript'),
+      }),
     );
+    let blocks: readonly DaemonTranscriptBlock[] = [];
     let connection: DaemonConnectionState | undefined;
 
     function Harness() {
+      blocks = useDaemonTranscriptBlocks();
       connection = useDaemonConnection();
       return null;
     }
@@ -4982,7 +4987,13 @@ describe('DaemonSessionProvider', () => {
       sessionId: 'session-a',
     });
     expect(connection).toMatchObject({ sessionId: 'session-a' });
+    expect(blocks).toMatchObject([
+      { kind: 'assistant', text: 'old transcript' },
+    ]);
     sdkMocks.MockDaemonSessionClient.load.mockClear();
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
+      async () => nextSession.promise,
+    );
 
     act(() => {
       root?.render(
@@ -4996,6 +5007,21 @@ describe('DaemonSessionProvider', () => {
       );
     });
     await act(async () => {
+      await flushPromises();
+    });
+
+    expect(connection).toMatchObject({
+      sessionId: 'session-b',
+      loadingTranscript: true,
+    });
+    expect(blocks).toEqual([]);
+    nextSession.resolve(
+      createMockSession({
+        sessionId: 'session-b',
+        replaySnapshot: createTextReplaySnapshot('new transcript'),
+      }),
+    );
+    await act(async () => {
       await wait(5);
       await flushPromises();
     });
@@ -5007,6 +5033,9 @@ describe('DaemonSessionProvider', () => {
       expect.any(String),
     );
     expect(connection).toMatchObject({ sessionId: 'session-b' });
+    expect(blocks).toMatchObject([
+      { kind: 'assistant', text: 'new transcript' },
+    ]);
   });
 
   it('loads controlled sessionId on mount without creating a session', async () => {
@@ -5033,6 +5062,35 @@ describe('DaemonSessionProvider', () => {
       sdkMocks.MockDaemonSessionClient.createOrAttach,
     ).not.toHaveBeenCalled();
     expect(connection).toMatchObject({ sessionId: 'session-a' });
+  });
+
+  it('marks controlled sessionId load as loading transcript before load returns', async () => {
+    const pendingSession = createDeferred<MockSession>();
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
+      async () => pendingSession.promise,
+    );
+    let connection: DaemonConnectionState | undefined;
+
+    function Harness() {
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: 'session-a',
+    });
+
+    expect(connection).toMatchObject({
+      status: 'connecting',
+      sessionId: 'session-a',
+      loadingTranscript: true,
+    });
+
+    pendingSession.resolve(createMockSession({ sessionId: 'session-a' }));
+    await act(async () => {
+      await flushPromises();
+    });
   });
 
   it('does not create a session when sessionId is undefined', async () => {

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -4914,60 +4914,6 @@ describe('DaemonSessionProvider', () => {
     ]);
   });
 
-  it('keeps transcript until replay for deferred session switches', async () => {
-    const nextSession = createDeferred<MockSession>();
-    const currentSession = createMockSession({
-      replaySnapshot: createTextReplaySnapshot('old transcript'),
-    });
-    sdkMocks.sessions.push(currentSession);
-    let actions: DaemonSessionActions | undefined;
-    let blocks: readonly DaemonTranscriptBlock[] = [];
-    let connection: DaemonConnectionState | undefined;
-
-    function Harness() {
-      actions = useDaemonActions();
-      blocks = useDaemonTranscriptBlocks();
-      connection = useDaemonConnection();
-      return null;
-    }
-
-    await renderWithProvider(<Harness />, { autoConnect: true });
-    await act(async () => {
-      await flushPromises();
-    });
-    expect(blocks).toMatchObject([
-      { kind: 'assistant', text: 'old transcript' },
-    ]);
-    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(
-      async () => nextSession.promise,
-    );
-
-    const loadPromise = requireActions(actions)
-      .loadSession('session-b', { deferTranscriptReset: true })
-      .catch(() => undefined);
-    await act(async () => {
-      await flushPromises();
-    });
-
-    expect(connection?.loadingTranscript).toBe(true);
-    expect(blocks).toMatchObject([
-      { kind: 'assistant', text: 'old transcript' },
-    ]);
-    nextSession.resolve(
-      createMockSession({
-        sessionId: 'session-b',
-        replaySnapshot: createTextReplaySnapshot('new transcript'),
-      }),
-    );
-    await act(async () => {
-      await loadPromise;
-      await flushPromises();
-    });
-    expect(blocks).toMatchObject([
-      { kind: 'assistant', text: 'new transcript' },
-    ]);
-  });
-
   it('loads controlled sessionId changes', async () => {
     const nextSession = createDeferred<MockSession>();
     sdkMocks.sessions.push(
@@ -5103,6 +5049,97 @@ describe('DaemonSessionProvider', () => {
     await act(async () => {
       await flushPromises();
     });
+  });
+
+  it('ignores stale metadata after switching to another session', async () => {
+    const providersA = createDeferred<unknown>();
+    const commandsA =
+      createDeferred<Awaited<ReturnType<MockSession['supportedCommands']>>>();
+    const contextA =
+      createDeferred<Awaited<ReturnType<MockSession['context']>>>();
+    sdkMocks.workspaceProviders.mockReturnValueOnce(providersA.promise);
+    sdkMocks.sessions.push(
+      createMockSession({
+        sessionId: 'session-a',
+        replaySnapshot: createTextReplaySnapshot('session a transcript'),
+        supportedCommands: vi.fn(() => commandsA.promise),
+        context: vi.fn(() => contextA.promise),
+      }),
+      createMockSession({
+        sessionId: 'session-b',
+        replaySnapshot: createTextReplaySnapshot('session b transcript'),
+      }),
+    );
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+    let connection: DaemonConnectionState | undefined;
+
+    function Harness() {
+      blocks = useDaemonTranscriptBlocks();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: 'session-a',
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+    expect(connection).toMatchObject({ sessionId: 'session-a' });
+    expect(blocks).toMatchObject([
+      { kind: 'assistant', text: 'session a transcript' },
+    ]);
+
+    act(() => {
+      root?.render(
+        <DaemonSessionProvider
+          baseUrl="http://127.0.0.1:4170"
+          autoConnect={true}
+          sessionId="session-b"
+        >
+          <Harness />
+        </DaemonSessionProvider>,
+      );
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+    expect(connection).toMatchObject({
+      sessionId: 'session-b',
+      loadingTranscript: undefined,
+    });
+    expect(blocks).toMatchObject([
+      { kind: 'assistant', text: 'session b transcript' },
+    ]);
+
+    providersA.resolve({
+      v: 1,
+      workspaceCwd: '/mock-workspace',
+      initialized: true,
+      providers: [],
+    });
+    commandsA.resolve({
+      v: 1,
+      sessionId: 'session-a',
+      availableCommands: [],
+      availableSkills: [],
+    });
+    contextA.resolve({
+      v: 1,
+      sessionId: 'session-a',
+      workspaceCwd: '/mock-workspace',
+      state: { models: { currentModel: 'stale-model' } },
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(connection).toMatchObject({ sessionId: 'session-b' });
+    expect(connection?.currentModel).not.toBe('stale-model');
+    expect(blocks).toMatchObject([
+      { kind: 'assistant', text: 'session b transcript' },
+    ]);
   });
 
   it('loads controlled sessionId on mount without creating a session', async () => {

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -4851,6 +4851,9 @@ describe('DaemonSessionProvider', () => {
     await act(async () => {
       await flushPromises();
     });
+    sdkMocks.MockDaemonSessionClient.load.mockImplementationOnce(async () => {
+      throw createAbortError();
+    });
 
     await act(async () => {
       const loadPromise = requireActions(actions).loadSession('session-b');
@@ -5036,6 +5039,70 @@ describe('DaemonSessionProvider', () => {
     expect(blocks).toMatchObject([
       { kind: 'assistant', text: 'new transcript' },
     ]);
+  });
+
+  it('clears transcript loading after replay before metadata finishes', async () => {
+    const providers = createDeferred<unknown>();
+    const commands =
+      createDeferred<Awaited<ReturnType<MockSession['supportedCommands']>>>();
+    const context =
+      createDeferred<Awaited<ReturnType<MockSession['context']>>>();
+    sdkMocks.workspaceProviders.mockReturnValueOnce(providers.promise);
+    sdkMocks.sessions.push(
+      createMockSession({
+        sessionId: 'session-a',
+        replaySnapshot: createTextReplaySnapshot('restored transcript'),
+        supportedCommands: vi.fn(() => commands.promise),
+        context: vi.fn(() => context.promise),
+      }),
+    );
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+    let connection: DaemonConnectionState | undefined;
+
+    function Harness() {
+      blocks = useDaemonTranscriptBlocks();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: 'session-a',
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(blocks).toMatchObject([
+      { kind: 'assistant', text: 'restored transcript' },
+    ]);
+    expect(connection).toMatchObject({
+      status: 'connected',
+      sessionId: 'session-a',
+      loadingTranscript: undefined,
+    });
+
+    providers.resolve({
+      v: 1,
+      workspaceCwd: '/mock-workspace',
+      initialized: true,
+      providers: [],
+    });
+    commands.resolve({
+      v: 1,
+      sessionId: 'session-a',
+      availableCommands: [],
+      availableSkills: [],
+    });
+    context.resolve({
+      v: 1,
+      sessionId: 'session-a',
+      workspaceCwd: '/mock-workspace',
+      state: {},
+    });
+    await act(async () => {
+      await flushPromises();
+    });
   });
 
   it('loads controlled sessionId on mount without creating a session', async () => {

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -723,6 +723,38 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             }
             setConnection((c) => ({ ...c, catchingUp: undefined }));
           }
+          setConnection((current) => ({
+            ...current,
+            status: 'connected',
+            sessionId: activeSession.sessionId,
+            ...(activeSession.clientId
+              ? { clientId: activeSession.clientId }
+              : {}),
+            workspaceCwd: activeSession.workspaceCwd,
+            displayName:
+              getSessionDisplayName(activeSession.state) ??
+              (current.sessionId === activeSession.sessionId
+                ? current.displayName
+                : undefined),
+            tokenUsage:
+              replayTokenUsage !== undefined
+                ? replayTokenUsage
+                : current.sessionId === activeSession.sessionId
+                  ? current.tokenUsage
+                  : undefined,
+            tokenCount:
+              replayTokenCount !== undefined
+                ? replayTokenCount
+                : current.sessionId === activeSession.sessionId
+                  ? (current.tokenCount ?? 0)
+                  : 0,
+            loadingTranscript: undefined,
+            catchingUp: replayInjected
+              ? current.catchingUp
+              : isSameSessionReconnect ||
+                activeSession.lastEventId != null ||
+                undefined,
+          }));
           if (pendingLoadToResolve) {
             pendingSessionLoadRef.current = undefined;
             clearTimeout(pendingLoadToResolve.timeout);

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -828,59 +828,42 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           const currentMode =
             getCurrentMode(context) ?? providerModelStatus.currentMode;
 
-          setConnection((current) => ({
-            status: 'connected',
-            sessionId: activeSession.sessionId,
-            // Surface the bound client id so consumers can recognize their own
-            // originator-stamped frames (e.g. the web-shell's mid-turn dedupe).
-            ...(activeSession.clientId
-              ? { clientId: activeSession.clientId }
-              : {}),
-            workspaceCwd: activeSession.workspaceCwd,
-            commands: commands.length > 0 ? commands : current.commands,
-            skills: skills.length > 0 ? skills : current.skills,
-            models: sessionModels.length > 0 ? sessionModels : current.models,
-            currentModel: sessionCurrentModel ?? current.currentModel,
-            currentMode: currentMode ?? current.currentMode,
-            displayName:
-              getSessionDisplayName(activeSession.state) ??
-              (current.sessionId === activeSession.sessionId
-                ? current.displayName
-                : undefined),
-            tokenUsage:
-              // Keep token usage in sync with tokenCount: replay usage
-              // supersedes in-memory state, same-session reconnect keeps it,
-              // and a different session without replay usage starts empty.
-              replayTokenUsage !== undefined
-                ? replayTokenUsage
-                : current.sessionId === activeSession.sessionId
-                  ? current.tokenUsage
-                  : undefined,
-            tokenCount:
-              // A freshly loaded snapshot covers everything up to the SSE
-              // resume point, so its usage supersedes the in-memory count;
-              // without one (or with a usage-less replay) keep the
-              // same-session value and start anything else at 0.
-              replayTokenCount !== undefined
-                ? replayTokenCount
-                : current.sessionId === activeSession.sessionId
-                  ? (current.tokenCount ?? 0)
-                  : 0,
-            contextWindow: sessionContextWindow ?? current.contextWindow,
-            providers: providers ?? current.providers,
-            supportedCommands: supportedCommands ?? current.supportedCommands,
-            context: context ?? current.context,
-            capabilities: capabilities ?? current.capabilities,
-            loadingTranscript: undefined,
-            catchingUp:
-              // Replay already injected above — keep the cleared flag rather
-              // than re-arming it (nothing before SSE would clear it again).
-              replayInjected
-                ? current.catchingUp
-                : isSameSessionReconnect ||
-                  activeSession.lastEventId != null ||
-                  undefined,
-          }));
+          setConnection((current) => {
+            if (current.sessionId !== activeSession.sessionId) return current;
+            return {
+              ...current,
+              status: 'connected',
+              sessionId: activeSession.sessionId,
+              // Surface the bound client id so consumers can recognize their own
+              // originator-stamped frames (e.g. the web-shell's mid-turn dedupe).
+              ...(activeSession.clientId
+                ? { clientId: activeSession.clientId }
+                : {}),
+              workspaceCwd: activeSession.workspaceCwd,
+              commands: commands.length > 0 ? commands : current.commands,
+              skills: skills.length > 0 ? skills : current.skills,
+              models: sessionModels.length > 0 ? sessionModels : current.models,
+              currentModel: sessionCurrentModel ?? current.currentModel,
+              currentMode: currentMode ?? current.currentMode,
+              displayName:
+                getSessionDisplayName(activeSession.state) ??
+                current.displayName,
+              contextWindow: sessionContextWindow ?? current.contextWindow,
+              providers: providers ?? current.providers,
+              supportedCommands: supportedCommands ?? current.supportedCommands,
+              context: context ?? current.context,
+              capabilities: capabilities ?? current.capabilities,
+              loadingTranscript: undefined,
+              catchingUp:
+                // Replay already injected above — keep the cleared flag rather
+                // than re-arming it (nothing before SSE would clear it again).
+                replayInjected
+                  ? current.catchingUp
+                  : isSameSessionReconnect ||
+                    activeSession.lastEventId != null ||
+                    undefined,
+            };
+          });
           if (loadWarningTexts.length > 0) {
             store.dispatch(
               loadWarningTexts.map((text) => ({

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -484,6 +484,14 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             const requestClientId = clientId
               ? clientIdRef.current
               : getStableClientId(undefined, targetSessionId);
+            if (targetSessionId) {
+              setConnection((current) => ({
+                ...current,
+                sessionId: targetSessionId,
+                error: undefined,
+                loadingTranscript: true,
+              }));
+            }
             const nextSession = restoreSessionId
               ? await restoreMethod(
                   client,
@@ -831,6 +839,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             supportedCommands: supportedCommands ?? current.supportedCommands,
             context: context ?? current.context,
             capabilities: capabilities ?? current.capabilities,
+            loadingTranscript: undefined,
             catchingUp:
               // Replay already injected above — keep the cleared flag rather
               // than re-arming it (nothing before SSE would clear it again).
@@ -1234,6 +1243,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
               status: 'disconnected',
               sessionId: undefined,
               error: message,
+              loadingTranscript: undefined,
               catchingUp: undefined,
             }));
             return;
@@ -1263,6 +1273,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             ...current,
             status: 'disconnected',
             error: message,
+            loadingTranscript: undefined,
           }));
         }
 
@@ -1271,6 +1282,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           setConnection((current) => ({
             ...current,
             status: 'disconnected',
+            loadingTranscript: undefined,
             catchingUp: undefined,
           }));
           return;
@@ -1470,7 +1482,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     if (sessionId === currentSessionId) return;
 
     const request = sessionId
-      ? actions.loadSession(sessionId, { deferTranscriptReset: true })
+      ? actions.loadSession(sessionId)
       : currentSessionId
         ? actions.clearSession()
         : undefined;

--- a/packages/webui/src/daemon/session/actions.test.ts
+++ b/packages/webui/src/daemon/session/actions.test.ts
@@ -25,6 +25,7 @@ describe('getConnectionAfterSessionClear', () => {
         skills: ['old-skill'],
         supportedCommands: supportedCommandsStatus('session-a'),
         context: contextStatus('session-a'),
+        loadingTranscript: true,
         catchingUp: true,
         error: 'old error',
       } as DaemonConnectionState,
@@ -34,6 +35,7 @@ describe('getConnectionAfterSessionClear', () => {
     expect(next).toMatchObject({
       status: 'connected',
       workspaceCwd: '/workspace',
+      loadingTranscript: undefined,
       catchingUp: undefined,
       error: undefined,
     });
@@ -60,6 +62,7 @@ describe('getConnectionAfterSessionClear', () => {
         skills: ['new-skill'],
         supportedCommands: supportedCommandsStatus('session-b', 'new-command'),
         context: contextStatus('session-b'),
+        loadingTranscript: true,
         catchingUp: true,
         error: 'old error',
       } as DaemonConnectionState,
@@ -77,6 +80,7 @@ describe('getConnectionAfterSessionClear', () => {
       skills: ['new-skill'],
       supportedCommands: supportedCommandsStatus('session-b', 'new-command'),
       context: contextStatus('session-b'),
+      loadingTranscript: undefined,
       catchingUp: undefined,
       error: undefined,
     });

--- a/packages/webui/src/daemon/session/actions.test.ts
+++ b/packages/webui/src/daemon/session/actions.test.ts
@@ -165,6 +165,35 @@ describe('createDaemonSessionActions', () => {
     expect(pendingSessionLoadRef.current?.sessionId).toBe('session-b');
   });
 
+  it('clears transcript loading when a session switch fails', async () => {
+    vi.useFakeTimers();
+    try {
+      const existingSession = createMockSession('session-a');
+      const { actions, getConnection } = createActionsHarness({
+        connection: { status: 'connected', sessionId: 'session-a' },
+        session: existingSession,
+      });
+
+      const loadPromise = actions.loadSession('session-b');
+      expect(getConnection()).toMatchObject({
+        status: 'connecting',
+        sessionId: 'session-b',
+        loadingTranscript: true,
+      });
+
+      vi.advanceTimersByTime(30_000);
+
+      await expect(loadPromise).rejects.toThrow('Session load timed out');
+      expect(getConnection()).toMatchObject({
+        sessionId: 'session-b',
+        loadingTranscript: undefined,
+        catchingUp: undefined,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('creates a detached session when the ref and connection do not match', async () => {
     const existingSession = createMockSession('session-a');
     const nextSession = createMockSession('session-b');

--- a/packages/webui/src/daemon/session/actions.test.ts
+++ b/packages/webui/src/daemon/session/actions.test.ts
@@ -154,6 +154,7 @@ describe('createDaemonSessionActions', () => {
 
     void actions.loadSession('session-b').catch(() => undefined);
 
+    expect(existingSession.detach).toHaveBeenCalledOnce();
     expect(sessionRef.current).toBeUndefined();
     expect(getConnection()).toMatchObject({
       status: 'connecting',

--- a/packages/webui/src/daemon/session/actions.test.ts
+++ b/packages/webui/src/daemon/session/actions.test.ts
@@ -144,6 +144,26 @@ describe('createDaemonSessionActions', () => {
     expect(getConnection()).not.toHaveProperty('sessionId');
   });
 
+  it('clears the active session while a session switch is loading', async () => {
+    const existingSession = createMockSession('session-a');
+    const { actions, getConnection, pendingSessionLoadRef, sessionRef } =
+      createActionsHarness({
+        connection: { status: 'connected', sessionId: 'session-a' },
+        session: existingSession,
+      });
+
+    void actions.loadSession('session-b').catch(() => undefined);
+
+    expect(sessionRef.current).toBeUndefined();
+    expect(getConnection()).toMatchObject({
+      status: 'connecting',
+      sessionId: 'session-b',
+      loadingTranscript: true,
+      catchingUp: undefined,
+    });
+    expect(pendingSessionLoadRef.current?.sessionId).toBe('session-b');
+  });
+
   it('creates a detached session when the ref and connection do not match', async () => {
     const existingSession = createMockSession('session-a');
     const nextSession = createMockSession('session-b');

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -90,6 +90,7 @@ export function getConnectionAfterSessionClear(
   return {
     ...next,
     status: 'connected',
+    loadingTranscript: undefined,
     catchingUp: undefined,
     error: undefined,
   };
@@ -206,9 +207,8 @@ export function createDaemonSessionActions({
     resetCurrentSessionActivePrompt();
     setConnection((current) => ({
       ...current,
-      status: 'connecting',
       error: undefined,
-      catchingUp: true,
+      loadingTranscript: true,
     }));
     setPromptStatus('idle');
     settledPromptsRef.current.clear();
@@ -230,6 +230,7 @@ export function createDaemonSessionActions({
           ...current,
           status: 'disconnected',
           error: message,
+          loadingTranscript: undefined,
           catchingUp: undefined,
         }));
       }

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -205,10 +205,16 @@ export function createDaemonSessionActions({
       activePromptsRef.current.delete(currentSessionId);
     }
     resetCurrentSessionActivePrompt();
+    sessionRef.current = undefined;
     setConnection((current) => ({
       ...current,
+      status: 'connecting',
+      sessionId,
+      clientId: undefined,
+      displayName: undefined,
       error: undefined,
       loadingTranscript: true,
+      catchingUp: undefined,
     }));
     setPromptStatus('idle');
     settledPromptsRef.current.clear();

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -230,7 +230,16 @@ export function createDaemonSessionActions({
     setRestoreMode(mode);
     setRestoreSessionId(sessionId);
     setRestoreSessionNonce((nonce) => nonce + 1);
-    return loadPromise;
+    return loadPromise.catch((error: unknown) => {
+      if (!isAbortError(error)) {
+        setConnection((current) => ({
+          ...current,
+          loadingTranscript: undefined,
+          catchingUp: undefined,
+        }));
+      }
+      throw error;
+    });
   }
 
   return {

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -38,7 +38,6 @@ import type {
   DaemonSessionActions,
   SettledPrompt,
   PendingSessionLoad,
-  SessionSwitchOptions,
 } from './types.js';
 
 interface RefBox<T> {
@@ -190,11 +189,11 @@ export function createDaemonSessionActions({
   function startSessionSwitch(
     sessionId: string,
     mode: 'load' | 'resume',
-    opts?: SessionSwitchOptions,
   ): Promise<void> {
     manualSessionClearRef.current = false;
     const loadPromise = startPendingSessionLoad(sessionId, mode);
-    const currentSessionId = sessionRef.current?.sessionId;
+    const currentSession = sessionRef.current;
+    const currentSessionId = currentSession?.sessionId;
     const activePrompt = currentSessionId
       ? activePromptsRef.current.get(currentSessionId)
       : undefined;
@@ -205,6 +204,14 @@ export function createDaemonSessionActions({
       activePromptsRef.current.delete(currentSessionId);
     }
     resetCurrentSessionActivePrompt();
+    if (currentSession) {
+      void currentSession.detach().catch((error: unknown) => {
+        console.warn(
+          '[DaemonSessionActions] detach before session switch failed:',
+          error,
+        );
+      });
+    }
     sessionRef.current = undefined;
     setConnection((current) => ({
       ...current,
@@ -219,29 +226,11 @@ export function createDaemonSessionActions({
     setPromptStatus('idle');
     settledPromptsRef.current.clear();
     clearPassiveAssistantDoneTimer(passiveAssistantDoneTimerRef);
-    if (!opts?.deferTranscriptReset) {
-      store.reset();
-    }
+    store.reset();
     setRestoreMode(mode);
     setRestoreSessionId(sessionId);
     setRestoreSessionNonce((nonce) => nonce + 1);
-    if (!opts?.deferTranscriptReset) {
-      return loadPromise;
-    }
-    return loadPromise.catch((error: unknown) => {
-      if (!isAbortError(error)) {
-        store.reset();
-        const message = error instanceof Error ? error.message : String(error);
-        setConnection((current) => ({
-          ...current,
-          status: 'disconnected',
-          error: message,
-          loadingTranscript: undefined,
-          catchingUp: undefined,
-        }));
-      }
-      throw error;
-    });
+    return loadPromise;
   }
 
   return {
@@ -555,12 +544,12 @@ export function createDaemonSessionActions({
       }
     },
 
-    async loadSession(sessionId, opts) {
-      return startSessionSwitch(sessionId, 'load', opts);
+    async loadSession(sessionId) {
+      return startSessionSwitch(sessionId, 'load');
     },
 
-    async resumeSession(sessionId, opts) {
-      return startSessionSwitch(sessionId, 'resume', opts);
+    async resumeSession(sessionId) {
+      return startSessionSwitch(sessionId, 'resume');
     },
 
     async createSession() {

--- a/packages/webui/src/daemon/session/types.ts
+++ b/packages/webui/src/daemon/session/types.ts
@@ -72,6 +72,8 @@ export interface DaemonConnectionState {
   supportedCommands?: DaemonSessionSupportedCommandsStatus;
   context?: DaemonSessionContextStatus;
   capabilities?: DaemonCapabilities;
+  /** True while the current session transcript is being loaded. */
+  loadingTranscript?: boolean;
   /** True while replaying buffered events after a reconnect. */
   catchingUp?: boolean;
   error?: string;

--- a/packages/webui/src/daemon/session/types.ts
+++ b/packages/webui/src/daemon/session/types.ts
@@ -310,8 +310,8 @@ export interface DaemonSessionActions {
   listSessions(options?: {
     pageSize?: number;
   }): Promise<DaemonSessionSummary[]>;
-  loadSession(sessionId: string, opts?: SessionSwitchOptions): Promise<void>;
-  resumeSession(sessionId: string, opts?: SessionSwitchOptions): Promise<void>;
+  loadSession(sessionId: string): Promise<void>;
+  resumeSession(sessionId: string): Promise<void>;
   /**
    * Create a daemon session and update local session state. Callers that need
    * transcript/event streaming must follow with `attachSession()`.
@@ -367,10 +367,6 @@ export interface DaemonSessionActions {
     name?: string,
   ): Promise<{ sessionId: string; displayName: string }>;
   forkSession(directive: string): Promise<DaemonForkSessionResult>;
-}
-
-export interface SessionSwitchOptions {
-  deferTranscriptReset?: boolean;
 }
 
 export interface DaemonSessionContextValue {


### PR DESCRIPTION
## What this PR does

This PR improves Web Shell session switching and restore behavior. It prevents existing session history from animating as a new user prompt, adds a transcript loading state with a skeleton while an existing session is loading, and clears the old transcript immediately when switching sessions from the sidebar or through controlled `sessionId`.

It also keeps the composer editable while a session transcript is loading, but blocks submission with a clear toast until the target session has finished loading. This avoids accidentally sending a prompt while the visible transcript belongs to a session that is still being restored.

## Why it's needed

When Web Shell restored an existing session, the message list could smooth-scroll as if restored history were a newly submitted prompt. During slow session loads, the UI also kept showing the previous session transcript until the new one arrived, which made the sidebar selection and main transcript feel out of sync.

The new `loadingTranscript` state separates transcript loading from replay catch-up. That lets the message list show a skeleton for the selected session without reusing `catchingUp`, which still controls replay behavior and composer loading states.

## Reviewer Test Plan

### How to verify

Open Web Shell with existing sessions. Switch from one session to another from the sidebar and confirm the previous transcript clears immediately, an animated skeleton appears, and the target session transcript replaces it when loading completes.

While the skeleton is visible, type in the composer and press Enter. The input should remain editable, but submission should be blocked with a session-loading toast instead of sending to the wrong session or showing a disconnected message.

Reload an existing session with history and confirm the restore lands at the bottom without treating restored history as a newly submitted prompt with smooth-scroll animation.

### Evidence (Before & After)

Before: switching sessions could temporarily show the previous session transcript, and restored history could trigger a smooth scroll intended for new user prompts. Sending while the transcript was still loading could use an unclear disconnected-state toast.

After: switching sessions clears the old transcript and shows a skeleton tied to the selected session. Restored history uses an immediate bottom alignment instead of a new-prompt animation. Sending during transcript loading is blocked with a dedicated session-loading toast.

### Tested on

|     OS     |   Status   |
| :--------: | :--------: |
|  🍏 macOS  | ✅ tested  |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local unit tests from package workspaces.

## Risk & Scope

- Main risk or tradeoff: Session switching now clears the visible transcript immediately instead of keeping the previous session visible until replay arrives. This is intentional for clearer feedback, with the deferred-reset path still available for callers that explicitly request it.
- Not validated / out of scope: Manual browser screenshots and cross-platform visual validation were not run.
- Breaking changes / migration notes: None.

## Linked Issues

<img width="2416" height="1404" alt="image" src="https://github.com/user-attachments/assets/90292a49-0184-43c8-a29f-e1c429346e55" />

N/A

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 优化了 Web Shell 的 session 切换和恢复体验。它避免已有 session 历史在恢复时被当成新用户 prompt 触发平滑滚动，为已有 session 加载过程增加 transcript loading 状态和骨架屏，并且在侧边栏切换或受控 `sessionId` 切换时立即清空旧 transcript。

它也保持 composer 在 session transcript 加载期间可编辑，但在目标 session 加载完成前阻止提交并给出明确 toast。这样可以避免用户在可见 transcript 还在恢复时，把 prompt 误发到错误 session。

## Why it's needed

之前 Web Shell 恢复已有 session 时，消息列表可能像新提交 prompt 一样触发平滑滚动。session load 较慢时，主区域也会继续显示上一个 session 的 transcript，直到新内容回来，导致侧边栏选择和主内容短时间不一致。

新的 `loadingTranscript` 状态把 transcript 加载和 replay catch-up 分开。这样消息列表可以为当前选中的 session 展示骨架屏，而不复用 `catchingUp`；`catchingUp` 继续只控制 replay 行为和 composer loading 状态。

## Reviewer Test Plan

### How to verify

打开有历史 session 的 Web Shell。从侧边栏切换到另一个 session，确认旧 transcript 会立即清空，显示动画骨架屏，并在目标 session 加载完成后展示对应 transcript。

在骨架屏可见时，在 composer 输入并按 Enter。输入框应该保持可编辑，但提交会被阻止，并显示 session 加载中的 toast，而不是发送到错误 session 或显示断连提示。

刷新一个有历史记录的 session，确认恢复后直接定位到底部，不会把恢复出的历史内容当作新用户 prompt 触发平滑滚动动画。

### Evidence (Before & After)

Before：切换 session 时可能短暂显示上一个 session 的 transcript；恢复历史内容时可能触发面向新 prompt 的平滑滚动；transcript 仍在加载时发送可能出现不清晰的断连提示。

After：切换 session 会清空旧 transcript，并显示当前选中 session 的骨架屏。恢复历史内容使用即时底部定位，不再触发新 prompt 的滚动动画。transcript 加载期间发送会被专用 session-loading toast 拦截。

### Tested on

|     OS     |   Status   |
| :--------: | :--------: |
|  🍏 macOS  | ✅ tested  |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

在 package workspace 中运行本地单元测试。

## Risk & Scope

- Main risk or tradeoff: session 切换现在会立即清空可见 transcript，而不是保留上一个 session 到 replay 回来。这是为了让反馈更清晰；显式请求 deferred reset 的调用方仍然可以继续使用原能力。
- Not validated / out of scope: 未运行手动浏览器截图和跨平台视觉验证。
- Breaking changes / migration notes: 无。

## Linked Issues

N/A

</details>
