### PR TITLE
fix: align vscode-ide-companion curly rule with root config

### DIFF
--- a/packages/vscode-ide-companion/eslint.config.mjs
+++ b/packages/vscode-ide-companion/eslint.config.mjs
@@ -66,7 +66,7 @@ export default [
         },
       ],
 
-      curly: 'warn',
+      curly: ['warn', 'multi-line'],
       eqeqeq: ['warn', 'always', { null: 'ignore' }],
       'no-throw-literal': 'warn',
       semi: 'warn',


### PR DESCRIPTION
## What this PR does

Aligns the `curly` ESLint rule in `packages/vscode-ide-companion/eslint.config.mjs` with the root config. The bare `curly: 'warn'` defaults to `'all'`, which flags single-line guard statements like `if (!x) return;`. The root `eslint.config.js` uses `['error', 'multi-line']`, only requiring braces on multi-line bodies. This change sets the package config to `['warn', 'multi-line']` to match.

## Why it's needed

The `issue-autofix` workflow reports 10 warnings across `AuthMessageHandler.ts` (5) and `settingsWriter.ts` (5) for single-line early-return guards that the rest of the codebase allows. These are false positives caused by a config mismatch, not actual code issues. Aligning the rule eliminates noise in CI and keeps lint policy consistent across packages.

## Reviewer Test Plan

### How to verify

Run `npx eslint` on the two affected files from the `packages/vscode-ide-companion` directory:

```bash
cd packages/vscode-ide-companion
npx eslint src/webview/handlers/AuthMessageHandler.ts src/services/settingsWriter.ts
```

Expected: no output (no warnings). On `main`, the same command produces 10 `curly` warnings.

### Evidence (Before & After)

**Before** (on `main`):
```
AuthMessageHandler.ts:181  warning  Expected { after 'if' condition  curly
AuthMessageHandler.ts:214  warning  Expected { after 'if' condition  curly
AuthMessageHandler.ts:264  warning  Expected { after 'if' condition  curly
AuthMessageHandler.ts:283  warning  Expected { after 'if' condition  curly
AuthMessageHandler.ts:303  warning  Expected { after 'if' condition  curly
settingsWriter.ts:155      warning  Expected { after 'while' condition curly
settingsWriter.ts:444      warning  Expected { after 'if' condition  curly
settingsWriter.ts:512      warning  Expected { after 'if' condition  curly
settingsWriter.ts:586      warning  Expected { after 'if' condition  curly
settingsWriter.ts:717      warning  Expected { after 'if' condition  curly
```

**After**: no output, exit code 0.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Node 22, macOS 15.5. Local `npx eslint` only; CI will validate cross-platform.

## Risk & Scope

- Main risk or tradeoff: None. This is a lint config alignment, no runtime code changes.
- Not validated / out of scope: Whether the project should adopt `curly: ['error', 'all']` globally is out of scope for this PR.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

将 `packages/vscode-ide-companion/eslint.config.mjs` 中的 `curly` ESLint 规则与根目录配置对齐。裸写 `curly: 'warn'` 默认等同于 `'all'`，会把 `if (!x) return;` 这类单行 guard 语句全部标红。而根目录的 `eslint.config.js` 用的是 `['error', 'multi-line']`，只对多行 body 强制要求花括号。本 PR 将 package 配置改为 `['warn', 'multi-line']`，与根目录保持一致。

`issue-autofix` workflow 在 `AuthMessageHandler.ts`（5 处）和 `settingsWriter.ts`（5 处）报了 10 条 warning，都是单行 early-return guard，项目其他地方是允许的。这属于配置不一致导致的误报，不是代码问题。对齐规则后可以消除 CI 噪音，保持各 package 间 lint 策略一致。

</details>
