### PR TITLE
feat(web-shell): show the qwen-code version in the sidebar footer

### DIFF
--- a/packages/cli/src/ui/components/Header.test.tsx
+++ b/packages/cli/src/ui/components/Header.test.tsx
@@ -52,6 +52,15 @@ describe('<Header />', () => {
     expect(lastFrame()).toContain('v1.0.0');
   });
 
+  it('shows a non-semver fallback like "unknown" without a bogus "v" prefix', () => {
+    const { lastFrame } = render(
+      <Header {...defaultProps} version="unknown" />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('(unknown)');
+    expect(frame).not.toContain('vunknown');
+  });
+
   it('displays auth type and model', () => {
     const { lastFrame } = render(<Header {...defaultProps} />);
     expect(lastFrame()).toContain('Qwen OAuth');

--- a/packages/cli/src/ui/components/Header.tsx
+++ b/packages/cli/src/ui/components/Header.tsx
@@ -49,6 +49,16 @@ function formatAuthDisplayType(
   }
 }
 
+/**
+ * Format the version for display. Real semver releases get a "v" prefix
+ * ("v0.19.4"); a non-semver fallback such as "unknown" (from getCliVersion when
+ * the package version can't be resolved) is shown as-is so we never render a
+ * bogus "vunknown".
+ */
+function formatVersionLabel(version: string): string {
+  return /^\d/.test(version) ? `v${version}` : version;
+}
+
 interface HeaderProps {
   /**
    * Width-aware override for the logo column. Each tier is a sanitized
@@ -88,6 +98,7 @@ export const Header: React.FC<HeaderProps> = ({
   const { columns: terminalWidth } = useTerminalSize();
 
   const formattedAuthType = formatAuthDisplayType(authDisplayType);
+  const versionLabel = formatVersionLabel(version);
 
   // Calculate available space properly:
   // First determine if logo can be shown, then use remaining space for path
@@ -209,7 +220,7 @@ export const Header: React.FC<HeaderProps> = ({
           <Text bold color={theme.text.accent}>
             {customBannerTitle ? customBannerTitle : '>_ Qwen Code'}
           </Text>
-          <Text color={theme.text.secondary}> (v{version})</Text>
+          <Text color={theme.text.secondary}> ({versionLabel})</Text>
         </Text>
         {/* Subtitle (when set) replaces the blank spacer row. We always
             emit a row here so the auth/model line stays at the same

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.module.css
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.module.css
@@ -578,6 +578,16 @@
   flex: 0 0 auto;
 }
 
+.version {
+  flex: 0 0 auto;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  line-height: 1;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  user-select: text;
+}
+
 .collapsed .newChatButton,
 .collapsed .footerButton,
 .collapsed .projectRow {

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+const { mockConnection } = vi.hoisted(() => ({
+  mockConnection: {
+    status: 'connected',
+    sessionId: null as string | null,
+    workspaceCwd: '/tmp/project',
+    capabilities: { qwenCodeVersion: '1.2.3' } as
+      | { qwenCodeVersion?: string }
+      | undefined,
+  },
+}));
+
+vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
+  useConnection: () => mockConnection,
+  useActions: () => ({ renameSession: vi.fn() }),
+  useSessions: () => ({
+    sessions: [],
+    loading: false,
+    error: null,
+    reload: vi.fn(),
+    deleteSession: vi.fn(),
+  }),
+}));
+
+const { I18nProvider } = await import('../../i18n');
+const { WebShellSidebar } = await import('./WebShellSidebar');
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+const noop = () => {};
+
+function renderSidebar(collapsed: boolean): HTMLElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <I18nProvider language="en">
+        <WebShellSidebar
+          collapsed={collapsed}
+          onCollapsedChange={noop}
+          onOpenSettings={noop}
+          onNewSession={() => false}
+          onLoadSession={noop}
+          onError={noop}
+        />
+      </I18nProvider>,
+    );
+  });
+  mounted.push({ root, container });
+  return container;
+}
+
+beforeEach(() => {
+  mockConnection.capabilities = { qwenCodeVersion: '1.2.3' };
+});
+
+afterEach(() => {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+});
+
+describe('WebShellSidebar — version footer', () => {
+  it('shows the qwen-code version in the footer when expanded', () => {
+    const container = renderSidebar(false);
+    const badge = container.querySelector('[title="Qwen Code v1.2.3"]');
+    expect(badge).not.toBeNull();
+    expect(badge?.textContent).toBe('v1.2.3');
+  });
+
+  it('renders a non-semver fallback (e.g. "unknown") without a bogus "v" prefix', () => {
+    mockConnection.capabilities = { qwenCodeVersion: 'unknown' };
+    const container = renderSidebar(false);
+    const badge = container.querySelector('[title="Qwen Code unknown"]');
+    expect(badge).not.toBeNull();
+    expect(badge?.textContent).toBe('unknown');
+    expect(container.textContent ?? '').not.toContain('vunknown');
+  });
+
+  it('hides the version when the sidebar is collapsed', () => {
+    const container = renderSidebar(true);
+    expect(container.querySelector('[title="Qwen Code v1.2.3"]')).toBeNull();
+    expect(container.textContent ?? '').not.toContain('v1.2.3');
+  });
+
+  it('renders no version badge when the daemon reports none', () => {
+    mockConnection.capabilities = undefined;
+    const container = renderSidebar(false);
+    expect(container.textContent ?? '').not.toMatch(/v\d/);
+  });
+});

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -214,6 +214,14 @@ export function WebShellSidebar({
   const currentSessionId = connection.sessionId;
   const projectName =
     getWorkspaceName(connection.workspaceCwd) || t('sidebar.projectFallback');
+  const qwenCodeVersion = connection.capabilities?.qwenCodeVersion || '';
+  // Numeric releases render as "v1.2.3"; a non-semver fallback such as
+  // "unknown" is shown as-is so we never produce a bogus "vunknown".
+  const versionLabel = qwenCodeVersion
+    ? /^\d/.test(qwenCodeVersion)
+      ? `v${qwenCodeVersion}`
+      : qwenCodeVersion
+    : '';
   const sidebarStyle = {
     '--web-shell-sidebar-width': `${sidebarWidth}px`,
   } as CSSProperties;
@@ -940,6 +948,11 @@ export function WebShellSidebar({
           </span>
           {!collapsed && <span>{t('sidebar.settings')}</span>}
         </button>
+        {!collapsed && versionLabel && (
+          <span className={styles.version} title={`Qwen Code ${versionLabel}`}>
+            {versionLabel}
+          </span>
+        )}
         {!mobileOpen && (
           <button
             className={styles.collapseButton}

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -24,12 +24,14 @@ import {
   existsSync,
   symlinkSync,
   mkdirSync,
+  readFileSync,
 } from 'node:fs';
 import { tmpdir, platform } from 'node:os';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, '..');
 const cliPackageDir = join(root, 'packages', 'cli');
+const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8'));
 
 // Ensure qc-helper bundled skill can find user docs in dev mode.
 // In dev, import.meta.url resolves to the source tree, so the bundled skill
@@ -102,7 +104,10 @@ const importFlag = `--import ${pathToFileURL(registerPath).href}`;
 const env = {
   ...process.env,
   DEV: 'true',
-  CLI_VERSION: 'dev',
+  // Report the real package version (like scripts/start.js) so the UI shows
+  // e.g. "v0.19.4" instead of "dev". DEV=true / NODE_ENV=development remain the
+  // signals that distinguish a dev build.
+  CLI_VERSION: pkg.version,
   NODE_ENV: 'development',
   NODE_OPTIONS: `${existingNodeOptions} --expose-gc ${importFlag}`.trim(),
 };

--- a/scripts/tests/dev.test.js
+++ b/scripts/tests/dev.test.js
@@ -32,6 +32,7 @@ vi.mock('node:fs', () => ({
   existsSync: existsSyncMock,
   symlinkSync: vi.fn(),
   mkdirSync: vi.fn(),
+  readFileSync: vi.fn(() => JSON.stringify({ version: '0.0.0-test' })),
 }));
 
 const normalizePath = (path) => String(path).replaceAll('\\', '/');


### PR DESCRIPTION
## What this PR does

Surfaces the running qwen-code version in the Web Shell, which previously showed no version anywhere on the page. The version now appears in the sidebar footer, inline on the same row as the Settings button (right-aligned, just before the collapse control) so it stays visible without taking its own row.

It also makes the version render sensibly wherever it is shown: the string only gets a leading `v` when it is a real semver release (e.g. `v0.19.4`); a non-semver fallback such as `unknown` is shown as-is, so the UI never renders a bogus `vunknown`. The same formatting is applied to the TUI header.

Finally, it fixes dev builds so they report the real package version instead of a placeholder. `scripts/dev.js` previously injected `CLI_VERSION=dev`, so `npm run dev` (and the web-shell daemon it starts) showed `dev` — rendered as `vdev` before the formatting fix. It now uses the package version, matching `scripts/start.js`. `DEV=true` / `NODE_ENV=development` remain the signals that mark a dev build.

## Why it's needed

Users had no way to see which qwen-code version the Web Shell was running: the page showed no version at all and there was no passive indicator during a session. Putting it in the always-visible sidebar footer closes that gap. The dev-build fix ensures the version shown is the real one (e.g. `v0.19.4`) rather than the confusing `dev` / `vdev` placeholder.

## Reviewer Test Plan

### How to verify

Web Shell: build (`npm run build`) or use a released build, start `qwen serve`, and open the Web Shell. The sidebar footer shows the version inline with Settings, e.g. `⚙ Settings   v0.19.4  ‹`. Collapsing the sidebar hides it (like the Settings label); expanding brings it back.

TUI: start the CLI; the header reads `>_ Qwen Code (v0.19.4)`.

Dev build: `node scripts/dev.js --version` prints the real version (e.g. `0.19.4`), not `dev`; `node scripts/dev.js serve` → `GET /capabilities` returns `"qwenCodeVersion":"0.19.4"` and the Web Shell footer shows `v0.19.4`.

Unit tests: `npm test` in `packages/web-shell` and the `Header.test.tsx` suite in `packages/cli` cover the version formatting (semver → `v…`, non-semver fallback shown as-is) plus the collapsed / absent cases.

### Evidence (Before & After)

TUI header (real tmux capture of a dev build):

- Before: `>_ Qwen Code (vdev)`
- After: `>_ Qwen Code (v0.19.4)`

Web Shell sidebar footer:

- Before: no version anywhere on the page.
- After: `⚙ Settings   v0.19.4  ‹` on one row (browser-verified: shared row, correct left-to-right order, version right-aligned before the collapse chevron).

Dev daemon `GET /capabilities`:

- Before: `"qwenCodeVersion":"dev"`
- After: `"qwenCodeVersion":"0.19.4"`

Local screenshots of the welcome screen and footer were captured during verification and can be attached on request.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

Platform-agnostic change (version-string formatting, a CSS flex row, and reading `package.json`); verified end-to-end on macOS via a real `qwen serve` + Chromium and a real tmux TUI.

### Environment (optional)

`node scripts/dev.js serve` and a built `qwen serve`, driven with Playwright/Chromium and tmux.

## Risk & Scope

- Main risk or tradeoff: `scripts/dev.js` now reports the real package version in dev, so dev-mode user-agent/telemetry strings read e.g. `0.19.4` instead of `dev` — already the behavior of `scripts/start.js`. `DEV=true` still distinguishes dev builds, and update checks are gated on `DEV` (not the version), so no update prompts appear in dev.
- Not validated / out of scope: Windows and Linux (platform-agnostic; not run there). The collapsed 56px rail intentionally hides the version, and the mobile drawer footer is unchanged.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 Web Shell 中展示当前运行的 qwen-code 版本号——此前页面上任何地方都看不到版本。现在版本号显示在侧边栏底部，和 Settings 按钮同一行（靠右，紧挨折叠按钮左侧），因此始终可见且不占用单独一行。

同时让版本号在所有展示处都能正确渲染：只有真正的语义化版本（如 `v0.19.4`）才加 `v` 前缀；诸如 `unknown` 这类非语义化的兜底值原样显示，绝不会出现 `vunknown` 之类的错误串。TUI 头部套用同样的格式化。

最后，修复了开发构建显示占位符的问题。`scripts/dev.js` 原先注入 `CLI_VERSION=dev`，导致 `npm run dev`（及其启动的 web-shell daemon）显示 `dev`——在格式化修复前渲染成 `vdev`。现在改用真实包版本，和 `scripts/start.js` 保持一致。`DEV=true` / `NODE_ENV=development` 仍是标识开发构建的信号。

## 为什么需要

用户此前无法得知 Web Shell 运行的是哪个 qwen-code 版本：页面完全不显示版本，会话过程中也没有常驻指示。把它放到始终可见的侧边栏底部即可弥补。开发构建的修复确保显示的是真实版本（如 `v0.19.4`），而非令人困惑的 `dev` / `vdev` 占位符。

## 评审验证方案

### 如何验证

Web Shell：构建（`npm run build`）或使用发布版，启动 `qwen serve` 打开 Web Shell。侧边栏底部与 Settings 同行显示版本，例如 `⚙ Settings   v0.19.4  ‹`。折叠侧边栏后版本隐藏（与 Settings 文字一致），展开后恢复。

TUI：启动 CLI，头部显示 `>_ Qwen Code (v0.19.4)`。

开发构建：`node scripts/dev.js --version` 打印真实版本（如 `0.19.4`）而非 `dev`；`node scripts/dev.js serve` → `GET /capabilities` 返回 `"qwenCodeVersion":"0.19.4"`，Web Shell 底部显示 `v0.19.4`。

单元测试：`packages/web-shell` 的 `npm test` 与 `packages/cli` 的 `Header.test.tsx` 覆盖了版本格式化（语义化 → `v…`、非语义化兜底原样显示）以及折叠 / 缺省场景。

### 证据（前后对比）

TUI 头部（开发构建的真实 tmux 抓取）：

- 之前：`>_ Qwen Code (vdev)`
- 之后：`>_ Qwen Code (v0.19.4)`

Web Shell 侧边栏底部：

- 之前：页面无任何版本。
- 之后：`⚙ Settings   v0.19.4  ‹` 同一行（浏览器实测：同行、左到右顺序正确、版本靠右位于折叠箭头左侧）。

开发 daemon 的 `GET /capabilities`：

- 之前：`"qwenCodeVersion":"dev"`
- 之后：`"qwenCodeVersion":"0.19.4"`

验证过程中已截取欢迎页与底部的本地截图，可按需附上。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

平台无关改动（版本字符串格式化、CSS flex 行布局、读取 `package.json`）；已在 macOS 通过真实 `qwen serve` + Chromium 与真实 tmux TUI 端到端验证。

### 运行环境（可选）

`node scripts/dev.js serve` 及构建后的 `qwen serve`，用 Playwright/Chromium 与 tmux 驱动。

## 风险与范围

- 主要风险 / 取舍：`scripts/dev.js` 现在在开发模式下上报真实包版本，因此开发模式的 user-agent/telemetry 字符串会是 `0.19.4` 而非 `dev`——这已经是 `scripts/start.js` 的行为。`DEV=true` 仍可区分开发构建，且更新检查是按 `DEV`（而非版本号）门控，所以开发模式不会弹出更新提示。
- 未验证 / 范围外：Windows 与 Linux（平台无关，未在其上运行）。折叠的 56px 窄栏有意隐藏版本，移动端抽屉底部保持不变。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

N/A

</details>
