### PR TITLE
fix(cache): preserve tools prefix in side-query for Anthropic prompt-cache hits

### DIFF
--- a/packages/core/src/followup/speculation.test.ts
+++ b/packages/core/src/followup/speculation.test.ts
@@ -153,6 +153,56 @@ describe('generatePipelinedSuggestion preserveTools', () => {
   });
 });
 
+describe('generatePipelinedSuggestion preserveTools conditional', () => {
+  it('passes preserveTools: false when fast model differs from cache-safe model', async () => {
+    const config = {
+      getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
+      getCwd: vi.fn().mockReturnValue(process.cwd()),
+      getFastModel: vi.fn().mockReturnValue('different-fast-model'),
+      getToolRegistry: vi.fn().mockReturnValue({
+        ensureTool: vi.fn().mockResolvedValue({
+          build: vi.fn().mockReturnValue({
+            execute: vi.fn().mockResolvedValue({
+              llmContent: '',
+              returnDisplay: '',
+            }),
+          }),
+        }),
+      }),
+    } as unknown as Config;
+
+    forkedAgentMocks.runForkedAgent.mockResolvedValue({
+      jsonResult: { suggestion: 'next step' },
+    });
+
+    forkedAgentMocks.sendMessageStream.mockImplementation(async function* () {
+      yield {
+        type: 'chunk',
+        value: {
+          candidates: [
+            {
+              content: {
+                parts: [{ text: 'done' }],
+              },
+            },
+          ],
+        },
+      };
+    });
+
+    const state = await startSpeculation(config, 'do something');
+    await vi.waitFor(() => {
+      expect(state.status).toBe('completed');
+    });
+
+    expect(forkedAgentMocks.runForkedAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ preserveTools: false }),
+    );
+
+    await abortSpeculation(state);
+  });
+});
+
 describe('ensureToolResultPairing', () => {
   it('returns empty array unchanged', () => {
     expect(ensureToolResultPairing([])).toEqual([]);

--- a/packages/core/src/followup/speculation.test.ts
+++ b/packages/core/src/followup/speculation.test.ts
@@ -101,107 +101,69 @@ describe('startSpeculation', () => {
   });
 });
 
-describe('generatePipelinedSuggestion preserveTools', () => {
-  it('passes preserveTools: true to runForkedAgent', async () => {
-    const config = {
-      getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
-      getCwd: vi.fn().mockReturnValue(process.cwd()),
-      getFastModel: vi.fn().mockReturnValue(undefined),
-      getToolRegistry: vi.fn().mockReturnValue({
-        ensureTool: vi.fn().mockResolvedValue({
-          build: vi.fn().mockReturnValue({
-            execute: vi.fn().mockResolvedValue({
-              llmContent: '',
-              returnDisplay: '',
+describe.each([
+  {
+    scenario: 'same model (undefined)',
+    fastModel: undefined,
+    expectedPreserveTools: true,
+  },
+  {
+    scenario: 'different model',
+    fastModel: 'different-fast-model',
+    expectedPreserveTools: false,
+  },
+])(
+  'generatePipelinedSuggestion preserveTools — $scenario',
+  ({ fastModel, expectedPreserveTools }) => {
+    it(`passes preserveTools: ${String(expectedPreserveTools)} to runForkedAgent`, async () => {
+      const config = {
+        getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
+        getCwd: vi.fn().mockReturnValue(process.cwd()),
+        getFastModel: vi.fn().mockReturnValue(fastModel),
+        getToolRegistry: vi.fn().mockReturnValue({
+          ensureTool: vi.fn().mockResolvedValue({
+            build: vi.fn().mockReturnValue({
+              execute: vi.fn().mockResolvedValue({
+                llmContent: '',
+                returnDisplay: '',
+              }),
             }),
           }),
         }),
-      }),
-    } as unknown as Config;
+      } as unknown as Config;
 
-    forkedAgentMocks.runForkedAgent.mockResolvedValue({
-      jsonResult: { suggestion: 'next step' },
-    });
+      forkedAgentMocks.runForkedAgent.mockResolvedValue({
+        jsonResult: { suggestion: 'next step' },
+      });
 
-    // Model returns text-only — no tool calls — so speculation completes
-    // and triggers generatePipelinedSuggestion.
-    forkedAgentMocks.sendMessageStream.mockImplementation(async function* () {
-      yield {
-        type: 'chunk',
-        value: {
-          candidates: [
-            {
-              content: {
-                parts: [{ text: 'done' }],
+      forkedAgentMocks.sendMessageStream.mockImplementation(async function* () {
+        yield {
+          type: 'chunk',
+          value: {
+            candidates: [
+              {
+                content: {
+                  parts: [{ text: 'done' }],
+                },
               },
-            },
-          ],
-        },
-      };
+            ],
+          },
+        };
+      });
+
+      const state = await startSpeculation(config, 'do something');
+      await vi.waitFor(() => {
+        expect(state.status).toBe('completed');
+      });
+
+      expect(forkedAgentMocks.runForkedAgent).toHaveBeenCalledWith(
+        expect.objectContaining({ preserveTools: expectedPreserveTools }),
+      );
+
+      await abortSpeculation(state);
     });
-
-    const state = await startSpeculation(config, 'do something');
-    await vi.waitFor(() => {
-      expect(state.status).toBe('completed');
-    });
-
-    expect(forkedAgentMocks.runForkedAgent).toHaveBeenCalledWith(
-      expect.objectContaining({ preserveTools: true }),
-    );
-
-    await abortSpeculation(state);
-  });
-});
-
-describe('generatePipelinedSuggestion preserveTools conditional', () => {
-  it('passes preserveTools: false when fast model differs from cache-safe model', async () => {
-    const config = {
-      getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
-      getCwd: vi.fn().mockReturnValue(process.cwd()),
-      getFastModel: vi.fn().mockReturnValue('different-fast-model'),
-      getToolRegistry: vi.fn().mockReturnValue({
-        ensureTool: vi.fn().mockResolvedValue({
-          build: vi.fn().mockReturnValue({
-            execute: vi.fn().mockResolvedValue({
-              llmContent: '',
-              returnDisplay: '',
-            }),
-          }),
-        }),
-      }),
-    } as unknown as Config;
-
-    forkedAgentMocks.runForkedAgent.mockResolvedValue({
-      jsonResult: { suggestion: 'next step' },
-    });
-
-    forkedAgentMocks.sendMessageStream.mockImplementation(async function* () {
-      yield {
-        type: 'chunk',
-        value: {
-          candidates: [
-            {
-              content: {
-                parts: [{ text: 'done' }],
-              },
-            },
-          ],
-        },
-      };
-    });
-
-    const state = await startSpeculation(config, 'do something');
-    await vi.waitFor(() => {
-      expect(state.status).toBe('completed');
-    });
-
-    expect(forkedAgentMocks.runForkedAgent).toHaveBeenCalledWith(
-      expect.objectContaining({ preserveTools: false }),
-    );
-
-    await abortSpeculation(state);
-  });
-});
+  },
+);
 
 describe('ensureToolResultPairing', () => {
   it('returns empty array unchanged', () => {

--- a/packages/core/src/followup/speculation.test.ts
+++ b/packages/core/src/followup/speculation.test.ts
@@ -101,6 +101,58 @@ describe('startSpeculation', () => {
   });
 });
 
+describe('generatePipelinedSuggestion preserveTools', () => {
+  it('passes preserveTools: true to runForkedAgent', async () => {
+    const config = {
+      getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
+      getCwd: vi.fn().mockReturnValue(process.cwd()),
+      getFastModel: vi.fn().mockReturnValue(undefined),
+      getToolRegistry: vi.fn().mockReturnValue({
+        ensureTool: vi.fn().mockResolvedValue({
+          build: vi.fn().mockReturnValue({
+            execute: vi.fn().mockResolvedValue({
+              llmContent: '',
+              returnDisplay: '',
+            }),
+          }),
+        }),
+      }),
+    } as unknown as Config;
+
+    forkedAgentMocks.runForkedAgent.mockResolvedValue({
+      jsonResult: { suggestion: 'next step' },
+    });
+
+    // Model returns text-only — no tool calls — so speculation completes
+    // and triggers generatePipelinedSuggestion.
+    forkedAgentMocks.sendMessageStream.mockImplementation(async function* () {
+      yield {
+        type: 'chunk',
+        value: {
+          candidates: [
+            {
+              content: {
+                parts: [{ text: 'done' }],
+              },
+            },
+          ],
+        },
+      };
+    });
+
+    const state = await startSpeculation(config, 'do something');
+    await vi.waitFor(() => {
+      expect(state.status).toBe('completed');
+    });
+
+    expect(forkedAgentMocks.runForkedAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ preserveTools: true }),
+    );
+
+    await abortSpeculation(state);
+  });
+});
+
 describe('ensureToolResultPairing', () => {
   it('returns empty array unchanged', () => {
     expect(ensureToolResultPairing([])).toEqual([]);

--- a/packages/core/src/followup/speculation.ts
+++ b/packages/core/src/followup/speculation.ts
@@ -554,6 +554,7 @@ ${SUGGESTION_PROMPT}`;
     const cacheSafeParams = getCacheSafeParams();
     if (!cacheSafeParams) return null;
     const model = modelOverride ?? config.getFastModel();
+    const resolvedModel = model ?? cacheSafeParams.model;
     const result = await runForkedAgent({
       config,
       userMessage: augmentedPrompt,
@@ -561,7 +562,7 @@ ${SUGGESTION_PROMPT}`;
       jsonSchema: PIPELINED_SCHEMA,
       ...(model !== undefined ? { model } : {}),
       abortSignal,
-      preserveTools: true,
+      preserveTools: resolvedModel === cacheSafeParams.model,
     });
 
     if (abortSignal.aborted) return null;

--- a/packages/core/src/followup/speculation.ts
+++ b/packages/core/src/followup/speculation.ts
@@ -561,6 +561,7 @@ ${SUGGESTION_PROMPT}`;
       jsonSchema: PIPELINED_SCHEMA,
       ...(model !== undefined ? { model } : {}),
       abortSignal,
+      preserveTools: true,
     });
 
     if (abortSignal.aborted) return null;

--- a/packages/core/src/followup/suggestionGenerator.test.ts
+++ b/packages/core/src/followup/suggestionGenerator.test.ts
@@ -99,6 +99,34 @@ describe('generatePromptSuggestion', () => {
       expect.objectContaining({ model: 'openai:fast-model' }),
     );
   });
+  it('passes preserveTools: true for Anthropic prompt-cache sharing', async () => {
+    mockGetCacheSafeParams.mockReturnValue({
+      generationConfig: {},
+      history: conversationHistory,
+      model: 'main-model',
+      version: 1,
+    });
+    mockRunForkedAgent.mockResolvedValue({
+      text: null,
+      jsonResult: { suggestion: 'run tests' },
+      usage: { inputTokens: 10, outputTokens: 3, cacheHitTokens: 5 },
+    });
+    const config = {
+      getFastModel: vi.fn(() => undefined),
+      getModel: vi.fn(() => 'main-model'),
+    } as unknown as Config;
+
+    await generatePromptSuggestion(
+      config,
+      conversationHistory,
+      new AbortController().signal,
+      { enableCacheSharing: true },
+    );
+
+    expect(mockRunForkedAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ preserveTools: true }),
+    );
+  });
 });
 
 describe('shouldFilterSuggestion', () => {

--- a/packages/core/src/followup/suggestionGenerator.test.ts
+++ b/packages/core/src/followup/suggestionGenerator.test.ts
@@ -127,6 +127,35 @@ describe('generatePromptSuggestion', () => {
       expect.objectContaining({ preserveTools: true }),
     );
   });
+
+  it('passes preserveTools: false when fast model differs from cache-safe model', async () => {
+    mockGetCacheSafeParams.mockReturnValue({
+      generationConfig: {},
+      history: conversationHistory,
+      model: 'main-model',
+      version: 1,
+    });
+    mockRunForkedAgent.mockResolvedValue({
+      text: null,
+      jsonResult: { suggestion: 'run tests' },
+      usage: { inputTokens: 10, outputTokens: 3, cacheHitTokens: 5 },
+    });
+    const config = {
+      getFastModel: vi.fn(() => 'different-fast-model'),
+      getModel: vi.fn(() => 'main-model'),
+    } as unknown as Config;
+
+    await generatePromptSuggestion(
+      config,
+      conversationHistory,
+      new AbortController().signal,
+      { enableCacheSharing: true },
+    );
+
+    expect(mockRunForkedAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ preserveTools: false }),
+    );
+  });
 });
 
 describe('shouldFilterSuggestion', () => {

--- a/packages/core/src/followup/suggestionGenerator.ts
+++ b/packages/core/src/followup/suggestionGenerator.ts
@@ -156,6 +156,7 @@ async function generateViaForkedQuery(
     cacheSafeParams,
     jsonSchema: SUGGESTION_SCHEMA,
     model,
+    preserveTools: true,
   });
 
   if (result.jsonResult) {

--- a/packages/core/src/followup/suggestionGenerator.ts
+++ b/packages/core/src/followup/suggestionGenerator.ts
@@ -156,7 +156,7 @@ async function generateViaForkedQuery(
     cacheSafeParams,
     jsonSchema: SUGGESTION_SCHEMA,
     model,
-    preserveTools: true,
+    preserveTools: model === cacheSafeParams.model,
   });
 
   if (result.jsonResult) {

--- a/packages/core/src/utils/forkedAgent.cache.test.ts
+++ b/packages/core/src/utils/forkedAgent.cache.test.ts
@@ -677,64 +677,6 @@ describe('runForkedAgent (cache path)', () => {
     expect(sendParams.config!.tools).toBeUndefined();
   });
 
-  it('strips tools by default when preserveTools is omitted', async () => {
-    saveCacheSafeParams(
-      {
-        tools: [
-          {
-            functionDeclarations: [
-              { name: 'edit', description: 'Edit a file' },
-            ],
-          },
-        ],
-      },
-      [],
-      'test-model',
-    );
-
-    let capturedParams: unknown = null;
-
-    const mockSendMessageStream = vi.fn(
-      (_model: string, params: unknown, _promptId: string) => {
-        capturedParams = params;
-        async function* generate() {
-          yield {
-            type: StreamEventType.CHUNK,
-            value: {
-              candidates: [
-                {
-                  content: {
-                    role: 'model',
-                    parts: [{ text: 'ok' }],
-                  },
-                },
-              ],
-            },
-          };
-        }
-        return Promise.resolve(generate());
-      },
-    );
-
-    vi.mocked(GeminiChat).mockImplementation(
-      () =>
-        ({
-          sendMessageStream: mockSendMessageStream,
-        }) as unknown as GeminiChat,
-    );
-
-    await runForkedAgent({
-      config: {} as Config,
-      userMessage: 'suggest something',
-      cacheSafeParams: getCacheSafeParams()!,
-    });
-
-    const sendParams = capturedParams as {
-      config?: { tools?: unknown };
-    };
-    expect(sendParams.config!.tools).toEqual([]);
-  });
-
   it('strips tools when preserveTools is explicitly false', async () => {
     saveCacheSafeParams(
       {
@@ -859,6 +801,72 @@ describe('runForkedAgent (cache path)', () => {
     });
 
     expect(result.text).toBe('some text');
+  });
+
+  it('returns null text when response contains only functionCall parts', async () => {
+    saveCacheSafeParams(
+      {
+        systemInstruction: 'You are helpful',
+        tools: [
+          {
+            functionDeclarations: [
+              { name: 'edit', description: 'Edit a file' },
+            ],
+          },
+        ],
+      },
+      [],
+      'test-model',
+    );
+
+    const mockSendMessageStream = vi.fn(
+      (_model: string, _params: unknown, _promptId: string) => {
+        async function* generate() {
+          yield {
+            type: StreamEventType.CHUNK,
+            value: {
+              candidates: [
+                {
+                  content: {
+                    role: 'model',
+                    parts: [
+                      {
+                        functionCall: {
+                          name: 'edit',
+                          args: { file: 'a.ts' },
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+              usageMetadata: {
+                promptTokenCount: 10,
+                candidatesTokenCount: 5,
+                totalTokenCount: 15,
+              },
+            },
+          };
+        }
+        return Promise.resolve(generate());
+      },
+    );
+
+    vi.mocked(GeminiChat).mockImplementation(
+      () =>
+        ({
+          sendMessageStream: mockSendMessageStream,
+        }) as unknown as GeminiChat,
+    );
+
+    const result = await runForkedAgent({
+      config: {} as Config,
+      userMessage: 'suggest something',
+      cacheSafeParams: getCacheSafeParams()!,
+      preserveTools: true,
+    });
+
+    expect(result.text).toBeNull();
   });
 
   it('throws when CacheSafeParams are not available', async () => {

--- a/packages/core/src/utils/forkedAgent.cache.test.ts
+++ b/packages/core/src/utils/forkedAgent.cache.test.ts
@@ -612,6 +612,188 @@ describe('runForkedAgent (cache path)', () => {
     expect(createRuntimeContentGeneratorView).not.toHaveBeenCalled();
   });
 
+  it('does not strip tools when preserveTools is true', async () => {
+    saveCacheSafeParams(
+      {
+        systemInstruction: 'You are helpful',
+        tools: [
+          {
+            functionDeclarations: [
+              { name: 'edit', description: 'Edit a file' },
+              { name: 'shell', description: 'Run a command' },
+            ],
+          },
+        ],
+      },
+      [{ role: 'user', parts: [{ text: 'hello' }] }],
+      'test-model',
+    );
+
+    let capturedParams: unknown = null;
+
+    const mockSendMessageStream = vi.fn(
+      (_model: string, params: unknown, _promptId: string) => {
+        capturedParams = params;
+        async function* generate() {
+          yield {
+            type: StreamEventType.CHUNK,
+            value: {
+              candidates: [
+                {
+                  content: {
+                    role: 'model',
+                    parts: [{ text: '{"suggestion":"run tests"}' }],
+                  },
+                },
+              ],
+              usageMetadata: {
+                promptTokenCount: 10,
+                candidatesTokenCount: 5,
+              },
+            },
+          };
+        }
+        return Promise.resolve(generate());
+      },
+    );
+
+    vi.mocked(GeminiChat).mockImplementation(
+      () =>
+        ({
+          sendMessageStream: mockSendMessageStream,
+        }) as unknown as GeminiChat,
+    );
+
+    await runForkedAgent({
+      config: {} as Config,
+      userMessage: 'suggest something',
+      cacheSafeParams: getCacheSafeParams()!,
+      preserveTools: true,
+    });
+
+    const sendParams = capturedParams as {
+      config?: { tools?: unknown };
+    };
+    expect(sendParams.config!.tools).toBeUndefined();
+  });
+
+  it('strips tools by default when preserveTools is omitted', async () => {
+    saveCacheSafeParams(
+      {
+        tools: [
+          {
+            functionDeclarations: [
+              { name: 'edit', description: 'Edit a file' },
+            ],
+          },
+        ],
+      },
+      [],
+      'test-model',
+    );
+
+    let capturedParams: unknown = null;
+
+    const mockSendMessageStream = vi.fn(
+      (_model: string, params: unknown, _promptId: string) => {
+        capturedParams = params;
+        async function* generate() {
+          yield {
+            type: StreamEventType.CHUNK,
+            value: {
+              candidates: [
+                {
+                  content: {
+                    role: 'model',
+                    parts: [{ text: 'ok' }],
+                  },
+                },
+              ],
+            },
+          };
+        }
+        return Promise.resolve(generate());
+      },
+    );
+
+    vi.mocked(GeminiChat).mockImplementation(
+      () =>
+        ({
+          sendMessageStream: mockSendMessageStream,
+        }) as unknown as GeminiChat,
+    );
+
+    await runForkedAgent({
+      config: {} as Config,
+      userMessage: 'suggest something',
+      cacheSafeParams: getCacheSafeParams()!,
+    });
+
+    const sendParams = capturedParams as {
+      config?: { tools?: unknown };
+    };
+    expect(sendParams.config!.tools).toEqual([]);
+  });
+
+  it('strips tools when preserveTools is explicitly false', async () => {
+    saveCacheSafeParams(
+      {
+        tools: [
+          {
+            functionDeclarations: [
+              { name: 'edit', description: 'Edit a file' },
+            ],
+          },
+        ],
+      },
+      [],
+      'test-model',
+    );
+
+    let capturedParams: unknown = null;
+
+    const mockSendMessageStream = vi.fn(
+      (_model: string, params: unknown, _promptId: string) => {
+        capturedParams = params;
+        async function* generate() {
+          yield {
+            type: StreamEventType.CHUNK,
+            value: {
+              candidates: [
+                {
+                  content: {
+                    role: 'model',
+                    parts: [{ text: 'ok' }],
+                  },
+                },
+              ],
+            },
+          };
+        }
+        return Promise.resolve(generate());
+      },
+    );
+
+    vi.mocked(GeminiChat).mockImplementation(
+      () =>
+        ({
+          sendMessageStream: mockSendMessageStream,
+        }) as unknown as GeminiChat,
+    );
+
+    await runForkedAgent({
+      config: {} as Config,
+      userMessage: 'suggest something',
+      cacheSafeParams: getCacheSafeParams()!,
+      preserveTools: false,
+    });
+
+    const sendParams = capturedParams as {
+      config?: { tools?: unknown };
+    };
+    expect(sendParams.config!.tools).toEqual([]);
+  });
+
   it('throws when CacheSafeParams are not available', async () => {
     const mockConfig = {} as unknown as Config;
 

--- a/packages/core/src/utils/forkedAgent.cache.test.ts
+++ b/packages/core/src/utils/forkedAgent.cache.test.ts
@@ -794,6 +794,73 @@ describe('runForkedAgent (cache path)', () => {
     expect(sendParams.config!.tools).toEqual([]);
   });
 
+  it('filters out functionCall parts when preserveTools is true', async () => {
+    saveCacheSafeParams(
+      {
+        systemInstruction: 'You are helpful',
+        tools: [
+          {
+            functionDeclarations: [
+              { name: 'edit', description: 'Edit a file' },
+            ],
+          },
+        ],
+      },
+      [],
+      'test-model',
+    );
+
+    const mockSendMessageStream = vi.fn(
+      (_model: string, _params: unknown, _promptId: string) => {
+        async function* generate() {
+          yield {
+            type: StreamEventType.CHUNK,
+            value: {
+              candidates: [
+                {
+                  content: {
+                    role: 'model',
+                    parts: [
+                      { text: 'some text' },
+                      {
+                        functionCall: {
+                          name: 'edit',
+                          args: { file: 'a.ts' },
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+              usageMetadata: {
+                promptTokenCount: 10,
+                candidatesTokenCount: 5,
+                totalTokenCount: 15,
+              },
+            },
+          };
+        }
+        return Promise.resolve(generate());
+      },
+    );
+
+    vi.mocked(GeminiChat).mockImplementation(
+      () =>
+        ({
+          sendMessageStream: mockSendMessageStream,
+        }) as unknown as GeminiChat,
+    );
+
+    const result = await runForkedAgent({
+      config: {} as Config,
+      userMessage: 'suggest something',
+      cacheSafeParams: getCacheSafeParams()!,
+      preserveTools: true,
+    });
+
+    expect(result.text).toBe('some text');
+  });
+
   it('throws when CacheSafeParams are not available', async () => {
     const mockConfig = {} as unknown as Config;
 

--- a/packages/core/src/utils/forkedAgent.cache.test.ts
+++ b/packages/core/src/utils/forkedAgent.cache.test.ts
@@ -869,6 +869,83 @@ describe('runForkedAgent (cache path)', () => {
     expect(result.text).toBeNull();
   });
 
+  it('preserves tools and includes jsonSchema fields when both preserveTools and jsonSchema are set', async () => {
+    saveCacheSafeParams(
+      {
+        systemInstruction: 'You are helpful',
+        tools: [
+          {
+            functionDeclarations: [
+              { name: 'edit', description: 'Edit a file' },
+              { name: 'shell', description: 'Run a command' },
+            ],
+          },
+        ],
+      },
+      [],
+      'test-model',
+    );
+
+    let capturedParams: unknown = null;
+
+    const mockSendMessageStream = vi.fn(
+      (_model: string, params: unknown, _promptId: string) => {
+        capturedParams = params;
+        async function* generate() {
+          yield {
+            type: StreamEventType.CHUNK,
+            value: {
+              candidates: [
+                {
+                  content: {
+                    role: 'model',
+                    parts: [{ text: '{"suggestion":"run tests"}' }],
+                  },
+                },
+              ],
+              usageMetadata: {
+                promptTokenCount: 10,
+                candidatesTokenCount: 5,
+              },
+            },
+          };
+        }
+        return Promise.resolve(generate());
+      },
+    );
+
+    vi.mocked(GeminiChat).mockImplementation(
+      () =>
+        ({
+          sendMessageStream: mockSendMessageStream,
+        }) as unknown as GeminiChat,
+    );
+
+    const schema = {
+      type: 'object',
+      properties: { suggestion: { type: 'string' } },
+    };
+
+    await runForkedAgent({
+      config: {} as Config,
+      userMessage: 'suggest something',
+      cacheSafeParams: getCacheSafeParams()!,
+      preserveTools: true,
+      jsonSchema: schema,
+    });
+
+    const sendParams = capturedParams as {
+      config?: {
+        tools?: unknown;
+        responseMimeType?: string;
+        responseJsonSchema?: unknown;
+      };
+    };
+    expect(sendParams.config!.tools).toBeUndefined();
+    expect(sendParams.config!.responseMimeType).toBe('application/json');
+    expect(sendParams.config!.responseJsonSchema).toBe(schema);
+  });
+
   it('throws when CacheSafeParams are not available', async () => {
     const mockConfig = {} as unknown as Config;
 

--- a/packages/core/src/utils/forkedAgent.ts
+++ b/packages/core/src/utils/forkedAgent.ts
@@ -42,6 +42,7 @@ import { ApprovalMode, type Config } from '../config/config.js';
 import { GeminiChat, StreamEventType } from '../core/geminiChat.js';
 import { createRuntimeContentGeneratorView } from '../models/content-generator-config.js';
 import { createApprovalModeOverride } from '../tools/agent/agent.js';
+import { createDebugLogger } from './debugLogger.js';
 import {
   AgentHeadless,
   AgentEventEmitter,
@@ -61,6 +62,8 @@ import {
 } from './modelId.js';
 import { ToolNames } from '../tools/tool-names.js';
 import { runWithChatRecordingSuppressed } from './chat-recording-suppression-context.js';
+
+const debugLogger = createDebugLogger('FORKED_AGENT');
 
 // ---------------------------------------------------------------------------
 // CacheSafeParams — shared prompt-cache slot
@@ -276,7 +279,8 @@ export async function runWithForkedChatModel<T>(
 
 /**
  * Result from a cache-path runForkedAgent (with cacheSafeParams).
- * Single-turn, text-only — tools are denied.
+ * Single-turn, text-only. Tools stripped by default; pass preserveTools
+ * to keep the parent's tools for cache-prefix matching.
  */
 export interface ForkedQueryResult {
   /** Extracted text response, or null if no text */
@@ -496,8 +500,22 @@ export async function runForkedAgent(
       for await (const event of stream) {
         if (event.type !== StreamEventType.CHUNK) continue;
         const response = event.value;
-        const text = response.candidates?.[0]?.content?.parts
-          ?.filter((p) => !(p as Record<string, unknown>)['thought'])
+        const parts = response.candidates?.[0]?.content?.parts ?? [];
+
+        // Defensive: when preserveTools is true the model could produce
+        // functionCall parts instead of text. Log and discard them.
+        if (
+          preserveTools &&
+          parts.some((p) => (p as Record<string, unknown>).functionCall)
+        ) {
+          debugLogger.warn(
+            'Cache-path forked query received functionCall with preserveTools; discarding.',
+          );
+        }
+
+        const text = parts
+          .filter((p) => !(p as Record<string, unknown>)['thought'])
+          .filter((p) => !(p as Record<string, unknown>).functionCall)
           .map((p) => p.text ?? '')
           .join('');
         if (text) fullText += text;

--- a/packages/core/src/utils/forkedAgent.ts
+++ b/packages/core/src/utils/forkedAgent.ts
@@ -506,7 +506,7 @@ export async function runForkedAgent(
         // functionCall parts instead of text. Log and discard them.
         if (
           preserveTools &&
-          parts.some((p) => (p as Record<string, unknown>).functionCall)
+          parts.some((p) => (p as Record<string, unknown>)['functionCall'])
         ) {
           debugLogger.warn(
             'Cache-path forked query received functionCall with preserveTools; discarding.',
@@ -515,7 +515,7 @@ export async function runForkedAgent(
 
         const text = parts
           .filter((p) => !(p as Record<string, unknown>)['thought'])
-          .filter((p) => !(p as Record<string, unknown>).functionCall)
+          .filter((p) => !(p as Record<string, unknown>)['functionCall'])
           .map((p) => p.text ?? '')
           .join('');
         if (text) fullText += text;

--- a/packages/core/src/utils/forkedAgent.ts
+++ b/packages/core/src/utils/forkedAgent.ts
@@ -9,15 +9,20 @@
  *
  * The two execution paths are selected by whether cacheSafeParams is supplied:
  *
- *   WITH cacheSafeParams  → GeminiChat single-turn, NO tools, shares parent
- *                            prompt cache (systemInstruction + history).
+ *   WITH cacheSafeParams  → GeminiChat single-turn, shares parent prompt
+ *                            cache (systemInstruction + history). Tools are
+ *                            stripped by default (NO_TOOLS) to prevent
+ *                            function calls; pass preserveTools: true to
+ *                            keep the parent's tools prefix for Anthropic
+ *                            prompt-cache hits.
  *                            Use for: /btw, suggestions, pipelined suggestions.
  *
  *   WITHOUT cacheSafeParams → AgentHeadless multi-turn, full tool access,
  *                              isolated session (no shared history).
  *                              Use for: memory extract, dream consolidation.
  *
- * Tool-deny for forked queries is enforced at the per-request level (NO_TOOLS).
+ * Tool-deny for forked queries is enforced at the per-request level (NO_TOOLS)
+ * unless the caller opts out via preserveTools to share the cache prefix.
  *
  * Callers (extractScheduler, dreamScheduler) own concurrency control.
  * runSideQuery() remains a separate primitive for structured-JSON calls that
@@ -145,7 +150,11 @@ export function clearCacheSafeParams(): void {
 // Forked chat — shared by runForkedAgent (cache path) and speculation
 // ---------------------------------------------------------------------------
 
-/** Per-request config that strips tools so the model never produces function calls. */
+/**
+ * Per-request config that strips tools so the model never produces function
+ * calls. Applied by default in the cache path; skipped when preserveTools
+ * is true (to share the Anthropic prompt-cache prefix).
+ */
 const NO_TOOLS = Object.freeze({ tools: [] as const }) as Pick<
   GenerateContentConfig,
   'tools'
@@ -305,7 +314,7 @@ function extractQueryUsage(
  */
 export type ForkedAgentParams = CachePathParams | AgentPathParams;
 
-/** Cache path: single-turn, tool-free, shares parent prompt cache. */
+/** Cache path: single-turn, shares parent prompt cache. */
 export interface CachePathParams {
   /** Runtime config. */
   config: Config;
@@ -319,6 +328,13 @@ export interface CachePathParams {
   model?: string;
   /** External cancellation signal. */
   abortSignal?: AbortSignal;
+  /**
+   * When true, keep the parent's tools in the per-request config so the
+   * Anthropic prompt-cache key (system + tools) matches the main agent's.
+   * Default (false/omitted): strip tools via NO_TOOLS to prevent function
+   * calls — appropriate for most forked queries.
+   */
+  preserveTools?: boolean;
 }
 
 /** AgentHeadless path: multi-turn, full tool access, isolated session. */
@@ -418,7 +434,8 @@ function isMutatingFileTool(toolName: string): boolean {
  * Two overloads selected by the shape of `params`:
  *
  *   params.cacheSafeParams present  → cache path (ForkedQueryResult)
- *     Single-turn, NO tools, shares parent prompt cache.
+ *     Single-turn, tools stripped by default (preserveTools overrides),
+ *     shares parent prompt cache.
  *     Use for: /btw, suggestions, pipelined suggestions.
  *
  *   params.taskPrompt present        → agent path (ForkedAgentResult)
@@ -436,8 +453,14 @@ export async function runForkedAgent(
 ): Promise<ForkedQueryResult | ForkedAgentResult> {
   // ── Cache path ────────────────────────────────────────────────────────────
   if ('cacheSafeParams' in params) {
-    const { config, userMessage, cacheSafeParams, jsonSchema, abortSignal } =
-      params;
+    const {
+      config,
+      userMessage,
+      cacheSafeParams,
+      jsonSchema,
+      abortSignal,
+      preserveTools,
+    } = params;
     const modelSelector = params.model ?? cacheSafeParams.model;
     const modelRuntime = await buildForkedModelRuntime(
       config,
@@ -448,7 +471,9 @@ export async function runForkedAgent(
     return runWithForkedModelRuntime(modelRuntime, async (model) => {
       const chat = createForkedChat(config, cacheSafeParams);
 
-      const requestConfig: GenerateContentConfig = { ...NO_TOOLS };
+      const requestConfig: GenerateContentConfig = preserveTools
+        ? {}
+        : { ...NO_TOOLS };
       if (abortSignal) requestConfig.abortSignal = abortSignal;
       if (jsonSchema) {
         requestConfig.responseMimeType = 'application/json';


### PR DESCRIPTION
## What this PR does

Preserves the parent conversation's `tools` array in side-queries (suggestion mode, pipelined suggestions) so the Anthropic prompt-cache key (`system + tools`) stays identical to the main conversation, eliminating guaranteed cache misses and preventing cache eviction cascading.

Adds a `preserveTools?: boolean` option to `CachePathParams` and enables it for suggestion generation and pipelined speculation. Other forked-query callers (e.g., `/btw`, memory extract) keep the default tool-stripping behavior for backward compatibility.

## Why it's needed

As reported in #5942 (Defect 1), `runForkedAgent` applies `NO_TOOLS = { tools: [] }` to every per-request config. For Anthropic providers, the cache key includes both `system` and `tools` — so even though the forked query shares the parent's `systemInstruction`, the different `tools` value (empty vs. full) causes a cache prefix mismatch. Each side-query becomes a guaranteed full-price request (~17% of requests in measured sessions) and can evict the main conversation's cached prefix, forcing the next main-thread request to also fully miss.

Claude Code, on the same Anthropic backend, runs side-queries with the **same** `system + tools` prefix (appending the suggestion instruction as a trailing message) and achieves ~100% cache hit rates — confirming the fix direction.

## Reviewer Test Plan

### How to verify

1. **Unit tests** — run the test suite to confirm cache-path behavior:
   ```bash
   npx vitest run packages/core/src/utils/forkedAgent.cache.test.ts
   npx vitest run packages/core/src/followup/suggestionGenerator.test.ts
   npx vitest run packages/core/src/followup/speculation.test.ts
   ```
2. **Cache behavior verification** — to observe the actual cache improvement, run qwen-code with an Anthropic provider and a proxy that logs request bodies (e.g., mitmproxy). Compare side-query requests before and after:
   - **Before**: side-query `tools` field is `[]`, different from main conversation → cache miss
   - **After**: side-query `tools` field matches main conversation → cache hit (look for `cache_read_input_tokens` > 0 in the API response)
3. **Backward compatibility** — forked-query callers that don't pass `preserveTools: true` (e.g., `/btw` command, memory extract) should continue to strip tools as before.

### Evidence (Before & After)

Non-UI change (internal cache optimization). All test results:

- `forkedAgent.cache.test.ts`: 16 tests ✅
- `forkedAgent.agent.test.ts`: 13 tests ✅
- `suggestionGenerator.test.ts`: 20 tests ✅
- `speculation.test.ts`: 8 tests ✅
- Full `followup/` directory: 112 tests ✅

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Local dev environment with `npm run dev`. Unit tests only — cache behavior is backend-specific and verified via test assertions on the config object passed to the provider.

## Risk & Scope

- Main risk or tradeoff: The model now sees tool definitions in side-queries and could theoretically attempt function calls in a single-turn suggestion context. Mitigated by the fact that side-queries use a constrained prompt that doesn't request tool use, and the suggestion consumer ignores tool-call responses.
- Not validated / out of scope: Defect 2 from #5942 (conversation breakpoint placement for optimal cache boundaries) is not included.
- Breaking changes / migration notes: None. Default behavior unchanged — tools are still stripped unless `preserveTools: true` is explicitly passed.

## Linked Issues

Fixes #5942 (Defect 1)

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在 side-query（建议模式、流水线建议）中保留父对话的 `tools` 数组，使 Anthropic 的 prompt-cache 键（`system + tools`）与主对话保持一致，消除必然的缓存未命中并防止缓存驱逐级联。

在 `CachePathParams` 中添加 `preserveTools?: boolean` 选项，并在建议生成和流水线推测中启用。其他 forked-query 调用方（如 `/btw`、记忆提取）保持默认的工具剥离行为以保证向后兼容。

## 为什么需要

如 #5942（缺陷 1）所报告，`runForkedAgent` 对每个请求配置应用 `NO_TOOLS = { tools: [] }`。对于 Anthropic 提供商，缓存键包含 `system` 和 `tools` —— 即使 forked query 共享父级的 `systemInstruction`，不同的 `tools` 值（空 vs. 完整）也会导致缓存前缀不匹配。每次 side-query 都会成为全价请求（测量会话中约 17% 的请求），并可能驱逐主对话的缓存前缀，迫使下一次主线程请求也完全未命中。

Claude Code 在同一 Anthropic 后端上，side-query 使用**相同的** `system + tools` 前缀（将建议指令作为尾部消息追加），实现了约 100% 的缓存命中率 —— 这验证了修复方向。

## 审阅测试计划

### 如何验证

1. **单元测试** — 运行测试套件确认缓存路径行为：
   ```bash
   npx vitest run packages/core/src/utils/forkedAgent.cache.test.ts
   npx vitest run packages/core/src/followup/suggestionGenerator.test.ts
   npx vitest run packages/core/src/followup/speculation.test.ts
   ```
2. **缓存行为验证** — 使用 Anthropic 提供商和记录请求体的代理（如 mitmproxy）运行 qwen-code。对比 side-query 请求的前后变化：
   - **之前**：side-query 的 `tools` 字段为 `[]`，与主对话不同 → 缓存未命中
   - **之后**：side-query 的 `tools` 字段与主对话匹配 → 缓存命中（查看 API 响应中 `cache_read_input_tokens` > 0）
3. **向后兼容** — 未传 `preserveTools: true` 的 forked-query 调用方（如 `/btw` 命令、记忆提取）应继续像之前一样剥离工具。

### 证据（前后对比）

非 UI 变更（内部缓存优化）。所有测试结果：

- `forkedAgent.cache.test.ts`: 16 tests ✅
- `forkedAgent.agent.test.ts`: 13 tests ✅
- `suggestionGenerator.test.ts`: 20 tests ✅
- `speculation.test.ts`: 8 tests ✅
- 完整 `followup/` 目录: 112 tests ✅

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | N/A  |
| 🪟 Windows | N/A  |
|  🐧 Linux  |  ✅  |

## 风险与范围

- 主要风险或权衡：模型现在在 side-query 中能看到工具定义，理论上可能在单轮建议上下文中尝试函数调用。但 side-query 使用的受限提示不请求工具使用，且建议消费者会忽略工具调用响应，因此风险已缓解。
- 未验证 / 超出范围：#5942 的缺陷 2（对话断点放置以优化缓存边界）未包含在内。
- 破坏性变更 / 迁移说明：无。默认行为不变 —— 除非显式传递 `preserveTools: true`，否则工具仍会被剥离。

## 关联 Issue

修复 #5942（缺陷 1）

</details>
