### PR TITLE
fix(web-shell): keep the user-selectable wrapper out of flex layout

### DIFF
--- a/packages/web-shell/client/components/MessageItem.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageItem.dom.test.tsx
@@ -141,3 +141,26 @@ describe('MessageItem error isolation', () => {
     expect(alert.style.justifyContent).toBe('flex-start');
   });
 });
+
+describe('MessageItem selectable wrapper', () => {
+  it('keeps the user-selectable wrapper out of layout via display: contents', () => {
+    // The wrapper only exists to carry the `data-user-selectable` CSS marker
+    // (standalone.css re-enables text selection through it). It must NOT
+    // generate a layout box: several parents are flex containers whose item
+    // used to be the message body itself — a plain div here becomes the flex
+    // item instead and shrinks to content width, squeezing the user chat
+    // bubble (max-width: 80% of the shrunken wrapper) so even short messages
+    // wrap mid-word.
+    const container = render(
+      <I18nProvider language="en">{item(userMsg('1', 'hello'))}</I18nProvider>,
+    );
+    const wrapper = container.querySelector(
+      '[data-user-selectable]',
+    ) as HTMLElement;
+    expect(wrapper).not.toBeNull();
+    expect(wrapper.style.display).toBe('contents');
+    // The message body renders inside the wrapper, so the CSS descendant
+    // selector `[data-user-selectable] *` still re-enables selection.
+    expect(wrapper.querySelector('[data-testid="user-ok"]')).not.toBeNull();
+  });
+});

--- a/packages/web-shell/client/components/MessageItem.tsx
+++ b/packages/web-shell/client/components/MessageItem.tsx
@@ -154,7 +154,20 @@ export const MessageItem = memo(function MessageItem({
   // standalone.css disables selection on UI chrome (native-app feel); this
   // attribute opts the message subtree back in, including descendants
   // (Markdown body, code blocks, tool panels, sub-messages).
-  const selectableSafeBody = <div data-user-selectable="true">{safeBody}</div>;
+  //
+  // `display: contents` keeps this wrapper out of layout: several parents
+  // (e.g. MessageTimestamp's chat row) are flex containers whose items used
+  // to be the message body itself. A plain div here becomes the flex item
+  // instead and shrinks to its content width, squeezing user chat bubbles
+  // (whose max-width: 80% then resolves against the shrunken wrapper) so
+  // even short messages wrap mid-word. The user-select re-enable rule
+  // matches `[data-user-selectable] *`, so the boxless wrapper does not
+  // affect it.
+  const selectableSafeBody = (
+    <div data-user-selectable="true" style={{ display: 'contents' }}>
+      {safeBody}
+    </div>
+  );
 
   if (message.role === 'assistant') {
     if (showAssistantActions) {


### PR DESCRIPTION
## What this PR does

Restores full-width user chat bubbles in the web shell. The `data-user-selectable` wrapper that #6142 added around every message body now uses `display: contents`, so it keeps carrying the CSS marker that re-enables text selection but no longer generates a layout box. Message bodies go back to being the direct flex items of their row, exactly as before #6142. A regression test locks the wrapper's boxless contract.

## Why it's needed

Since #6142, every user bubble wraps prematurely regardless of viewport width — even a short `/review pr-6220 --comment` breaks onto two lines on a 1440px desktop. The wrapper is a plain div with no width inside a flex row: it shrinks to content width, and the bubble's `max-width: 80%` then resolves against the shrunken wrapper instead of the chat column, mathematically guaranteeing a wrap at ~80% of every message's natural width. `display: contents` removes the wrapper from layout while the `[data-user-selectable] *` re-enable rule (DOM-based selector matching) keeps working, so the mobile text-selection fix from #6142 is fully preserved.

## Reviewer Test Plan

### How to verify

1. `npm run dev:daemon`, open the web shell at any desktop width.
2. Send a short message such as `/review pr-6220 --comment`. Expected: it renders on a single line in a right-aligned bubble. Before this fix it wrapped after `--`.
3. Long-press / drag-select message text (or check `user-select` in devtools): selection still works — the wrapper's attribute still matches the `standalone.css` re-enable rule.
4. Measured on a 1440px viewport: the message row inside `.chatRow` is back to the full 1000px column width (was 205px for the short command), and the bubble's `max-width: 80%` resolves against the column again.

Unit tests: `packages/web-shell` → `npx vitest run` — 699 passed / 55 files, including the new regression test (`MessageItem selectable wrapper`) that fails if the `display: contents` contract is removed.

### Evidence (Before & After)

**Before** (1440px viewport — both the URL message and the short command wrap in squeezed bubbles):

![before](https://raw.githubusercontent.com/carffuca/qwen-code/assets/web-shell-bubble-squeeze/.github-assets/bubble-before.png)

**After** (same viewport — single-line, right-aligned bubbles at natural width):

![after](https://raw.githubusercontent.com/carffuca/qwen-code/assets/web-shell-bubble-squeeze/.github-assets/bubble-after.png)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npm run dev:daemon` (daemon + Vite dev server), Chromium 1440x900, verified live against the running web shell.

## Risk & Scope

- Main risk or tradeoff: `display: contents` historically had accessibility-tree bugs for *semantic* elements in old browsers; this wrapper is a neutral div with no role or event handlers, so it is unaffected, and browser support is universal among supported targets.
- Not validated / out of scope: VoiceOver audio pass (the wrapper carries no semantics); Windows/Linux rendering (CI covers builds; layout math is platform-independent).
- Breaking changes / migration notes: none — one-line style change plus a test.

## Linked Issues

Fixes #6228 (regression introduced by #6142).

<details>
<summary>中文说明</summary>

**本 PR 做了什么**：恢复 web shell 用户聊天气泡的完整宽度。#6142 给每条消息包的 `data-user-selectable` wrapper 现在使用 `display: contents`——它继续携带用于恢复文本选择的 CSS 标记，但不再产生布局盒子。消息体重新直接成为所在行的 flex item，与 #6142 之前完全一致。新增回归测试锁定这个"无盒"契约。

**为什么需要**：#6142 之后，无论视口多宽，每条用户气泡都会提前折行——1440px 桌面上连 `/review pr-6220 --comment` 这样的短命令都折成两行。原因是这个裸 div 在 flex 行里收缩到内容宽度，气泡的 `max-width: 80%` 随之按收缩后的 wrapper 而不是聊天列计算，等于保证每条消息都在自身自然宽度的约 80% 处折行。`display: contents` 把 wrapper 从布局中移除，而 `[data-user-selectable] *` 豁免规则基于 DOM 匹配不受影响，#6142 的移动端文本选择修复完整保留。

**验证方式**：`npm run dev:daemon` 打开 web shell，发送短消息（如 `/review pr-6220 --comment`），应单行显示在右对齐气泡内（修复前在 `--` 后折行）；长按/拖选消息文本仍可选中。1440px 视口实测：消息行恢复 1000px 全列宽（修复前短命令被压到 205px）。单元测试：`packages/web-shell` 全量 699 通过 / 55 文件，含新增回归测试（移除 `display: contents` 契约会失败）。

**风险与范围**：`display: contents` 的历史无障碍树问题只影响老浏览器中的语义元素，此 wrapper 是无 role、无事件的中性 div，不受影响；未验证 VoiceOver 与 Windows/Linux 渲染（布局计算与平台无关）；无破坏性变更。

**关联 Issue**：Fixes #6228（由 #6142 引入的回归）。

</details>
