### PR TITLE
fix(core): skip no-op max_tokens escalation

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -7317,7 +7317,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chat.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         {
           message: [
             { text: 'describe this image' },

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -7275,7 +7275,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chat.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         { message: 'write a long essay' },
         'prompt-recovery',
       );
@@ -7338,6 +7338,48 @@ describe('GeminiChat', async () => {
       expect(serialized).toContain('"data":"current-shot"');
     });
 
+    it('should skip no-op escalation and recover directly for high-output models', async () => {
+      const streams = [
+        makeStream([makeChunk([{ text: 'Hello' }], 'MAX_TOKENS')]),
+        makeStream([makeChunk([{ text: ' ending.' }], 'STOP')]),
+      ];
+      let callIndex = 0;
+      vi.mocked(mockContentGenerator.generateContentStream).mockImplementation(
+        async () => streams[callIndex++]!,
+      );
+
+      const stream = await chat.sendMessageStream(
+        'gemini-3-pro',
+        { message: 'write a long essay' },
+        'prompt-direct-recovery',
+      );
+
+      const events: StreamEvent[] = [];
+      for await (const event of stream) {
+        events.push(event);
+      }
+
+      const retries = events.filter((e) => e.type === StreamEventType.RETRY);
+      expect(retries.length).toBe(1);
+      expect((retries[0] as { isContinuation?: boolean }).isContinuation).toBe(
+        true,
+      );
+      expect(
+        (retries[0] as { maxOutputTokensEscalated?: number })
+          .maxOutputTokensEscalated,
+      ).toBeUndefined();
+      expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
+        2,
+      );
+
+      const history = chat.getHistory();
+      const lastEntry = history[history.length - 1]!;
+      const text = lastEntry.parts
+        ?.map((part) => ('text' in part ? part.text : ''))
+        .join('');
+      expect(text).toBe('Hello ending.');
+    });
+
     it('should coalesce overlapping recovery continuation text', async () => {
       const streams = [
         makeStream([makeChunk([{ text: 'discarded initial' }], 'MAX_TOKENS')]),
@@ -7357,7 +7399,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chat.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         { message: 'write a long essay' },
         'prompt-recovery-overlap',
       );
@@ -7415,7 +7457,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chat.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         { message: 'write a long mermaid answer' },
         'prompt-recovery-contained-replay',
       );
@@ -7463,7 +7505,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chat.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         { message: 'write something' },
         'prompt-recovery-prose-opener',
       );
@@ -7500,7 +7542,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chat.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         { message: 'write something' },
         'prompt-recovery-far-prose',
       );
@@ -7541,7 +7583,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chat.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         { message: 'write something with a heading' },
         'prompt-recovery-line-boundary-reject',
       );
@@ -7591,7 +7633,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chat.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         { message: 'continue the derivation' },
         'prompt-recovery-single-cell-pipe-prose',
       );
@@ -7638,7 +7680,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chat.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         { message: 'write a structured answer' },
         'prompt-recovery-newline-normalization',
       );
@@ -7674,7 +7716,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chat.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         { message: 'write something' },
         'prompt-recovery-full-overlap',
       );
@@ -7727,7 +7769,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chat.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         { message: 'write something' },
         'prompt-recovery-thought-only',
       );
@@ -7782,7 +7824,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chat.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         { message: 'write a long essay' },
         'prompt-recovery-thinking-continuation',
       );
@@ -7830,7 +7872,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chat.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         { message: 'write a long essay' },
         'prompt-recovery-thinking-continuation-order',
       );
@@ -7879,7 +7921,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chat.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         { message: '帮我分析数据' },
         'prompt-recovery-cjk-floor',
       );
@@ -7919,7 +7961,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chat.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         { message: 'write a long markdown answer' },
         'prompt-recovery-leading-whitespace',
       );
@@ -7973,7 +8015,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chat.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         { message: 'write a very long answer' },
         'prompt-recovery-tail-truncation',
       );
@@ -8033,7 +8075,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chat.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         { message: 'write a response that contains my delimiter' },
         'prompt-recovery-delimiter-collision',
       );
@@ -8100,7 +8142,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chat.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         { message: 'write a response that contains my opening delimiter' },
         'prompt-recovery-delimiter-collision-open',
       );
@@ -8168,7 +8210,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chat.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         { message: 'write a file' },
         'prompt-recovery-skip',
       );
@@ -8208,7 +8250,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chat.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         { message: 'infinite loop test' },
         'prompt-recovery-cap',
       );
@@ -8240,7 +8282,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chat.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         { message: 'recovery fails' },
         'prompt-recovery-fail',
       );
@@ -8323,7 +8365,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chat.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         { message: 'recovery throws after functionCall' },
         'prompt-recovery-fc-throw',
       );
@@ -8398,7 +8440,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chat.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         { message: 'mixed recovery' },
         'prompt-recovery-mixed',
       );
@@ -8440,7 +8482,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chat.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         { message: 'essay' },
         'prompt-recovery-coalesce',
       );
@@ -8532,7 +8574,7 @@ describe('GeminiChat', async () => {
       );
 
       const stream = await chatWithRecording.sendMessageStream(
-        'gemini-3-pro',
+        'gemini-pro',
         { message: 'kick off' },
         'prompt-escalation-flush',
       );

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -1791,10 +1791,10 @@ export class GeminiChat {
     // closure can also access it.
     //
     // The subagent path sets params.config.maxOutputTokens explicitly; the
-    // interactive path leaves it undefined but will escalate to
-    // max(ESCALATED_MAX_TOKENS, tokenLimit(model, 'output')) on MAX_TOKENS.
-    // Pre-reserving that space prevents the dead zone between the adjusted
-    // auto threshold and an unadjusted hard threshold (issue #5950).
+    // interactive path leaves it undefined but may still use up to
+    // max(ESCALATED_MAX_TOKENS, tokenLimit(model, 'output')) across MAX_TOKENS
+    // handling. Pre-reserving that space prevents the dead zone between the
+    // adjusted auto threshold and an unadjusted hard threshold (issue #5950).
     const cgConfigForThresholds = this.config.getContentGeneratorConfig();
     const parsedEnvMaxTokensForThreshold = parsePositiveIntegerEnvValue(
       process.env['QWEN_CODE_MAX_OUTPUT_TOKENS'],
@@ -2454,78 +2454,92 @@ export class GeminiChat {
           }
         }
 
-        // Max output tokens escalation: if the retry loop succeeded but hit
-        // MAX_TOKENS, retry once at the model's full output limit. This ensures
-        // models with large output limits (e.g., 128K for Claude Opus, GPT-5)
-        // are fully utilized, while using ESCALATED_MAX_TOKENS (64K) as a floor
-        // for unknown models.
+        // Max output tokens handling: if the retry loop succeeded but hit
+        // MAX_TOKENS, retry once at an escalated output limit only when that
+        // would raise the effective initial limit. When the initial limit is
+        // already at or above the escalation floor (for example 64K+ output
+        // models), skip the no-op escalation call but still run continuation
+        // recovery on the partial response.
         // Placed outside the retry loop so that any errors from the
-        // escalated stream propagate directly (not caught by retry logic).
+        // escalated/recovery streams propagate directly (not caught by retry
+        // logic).
         const requestedMaxOutputTokens = params.config?.maxOutputTokens;
+        const effectiveInitialMaxOutputTokens =
+          requestedMaxOutputTokens ?? tokenLimit(model, 'output');
         const escalatedLimit = Math.max(
           ESCALATED_MAX_TOKENS,
           tokenLimit(model, 'output'),
         );
         const shouldEscalateMaxOutputTokens =
-          requestedMaxOutputTokens === undefined ||
-          requestedMaxOutputTokens < escalatedLimit;
+          effectiveInitialMaxOutputTokens < escalatedLimit;
 
         if (
           lastError === null &&
           lastFinishReason === FinishReason.MAX_TOKENS &&
           !maxTokensEscalated &&
-          !hasUserMaxTokensOverride &&
-          shouldEscalateMaxOutputTokens
+          !hasUserMaxTokensOverride
         ) {
           maxTokensEscalated = true;
-          const startingLimitLabel =
-            requestedMaxOutputTokens === undefined
-              ? 'default max_tokens'
-              : `${requestedMaxOutputTokens} tokens`;
-          debugLogger.info(
-            `Output truncated at ${startingLimitLabel}. Escalating to ${escalatedLimit} tokens.`,
-          );
-          // Remove partial model response from history
-          // (processStreamResponse already pushed it)
-          if (
-            self.history.length > 0 &&
-            self.history[self.history.length - 1].role === 'model'
-          ) {
-            self.history.pop();
-          }
-          // Signal UI to discard partial output
-          yield {
-            type: StreamEventType.RETRY,
-            maxOutputTokensEscalated: escalatedLimit,
-          };
-          // Retry with escalated max_tokens
-          const escalatedParams: SendMessageParameters = {
-            ...params,
-            config: {
-              ...params.config,
-              maxOutputTokens: escalatedLimit,
-            },
-          };
-          let escalatedFinishReason: string | undefined;
-          const escalatedStream = await self.makeApiCallAndProcessStream(
-            model,
-            requestContents,
-            escalatedParams,
-            prompt_id,
-          );
-          for await (const chunk of escalatedStream) {
-            const fr = chunk.candidates?.[0]?.finishReason;
-            if (fr) escalatedFinishReason = fr;
-            yield { type: StreamEventType.CHUNK, value: chunk };
+          let recoveryFinishReason: string | undefined = lastFinishReason;
+          let recoveryParams: SendMessageParameters = params;
+
+          if (shouldEscalateMaxOutputTokens) {
+            const startingLimitLabel =
+              requestedMaxOutputTokens === undefined
+                ? 'default max_tokens'
+                : `${requestedMaxOutputTokens} tokens`;
+            debugLogger.info(
+              `Output truncated at ${startingLimitLabel}. Escalating to ${escalatedLimit} tokens.`,
+            );
+            // Remove partial model response from history
+            // (processStreamResponse already pushed it)
+            if (
+              self.history.length > 0 &&
+              self.history[self.history.length - 1].role === 'model'
+            ) {
+              self.history.pop();
+            }
+            // Signal UI to discard partial output
+            yield {
+              type: StreamEventType.RETRY,
+              maxOutputTokensEscalated: escalatedLimit,
+            };
+            // Retry with escalated max_tokens
+            const escalatedParams: SendMessageParameters = {
+              ...params,
+              config: {
+                ...params.config,
+                maxOutputTokens: escalatedLimit,
+              },
+            };
+            recoveryParams = escalatedParams;
+            recoveryFinishReason = undefined;
+            const escalatedStream = await self.makeApiCallAndProcessStream(
+              model,
+              requestContents,
+              escalatedParams,
+              prompt_id,
+            );
+            for await (const chunk of escalatedStream) {
+              const fr = chunk.candidates?.[0]?.finishReason;
+              if (fr) recoveryFinishReason = fr;
+              yield { type: StreamEventType.CHUNK, value: chunk };
+            }
+          } else {
+            debugLogger.info(
+              `Output truncated at ${effectiveInitialMaxOutputTokens} tokens; ` +
+                `skipping no-op escalation to ${escalatedLimit} tokens and running recovery.`,
+            );
           }
 
-          // Recovery: if the escalated response is also truncated, keep the
-          // partial response in history and inject a recovery message so the
-          // model can continue from where it left off.
+          // Recovery: if the escalated response (or, when escalation is a
+          // no-op, the initial response) is still truncated, keep the partial
+          // response in history and inject a recovery message so the model can
+          // continue from where it left off.
           let recoveryCount = 0;
           let successfulRecoveries = 0;
           while (
-            escalatedFinishReason === FinishReason.MAX_TOKENS &&
+            recoveryFinishReason === FinishReason.MAX_TOKENS &&
             recoveryCount < MAX_OUTPUT_RECOVERY_ATTEMPTS
           ) {
             // Skip recovery when the truncated turn already contains a
@@ -2547,7 +2561,7 @@ export class GeminiChat {
 
             recoveryCount++;
             debugLogger.info(
-              `Output still truncated after escalation. ` +
+              `Output still truncated after max_tokens handling. ` +
                 `Recovery attempt ${recoveryCount}/${MAX_OUTPUT_RECOVERY_ATTEMPTS}.`,
             );
             // The partial model response is already in history
@@ -2564,17 +2578,17 @@ export class GeminiChat {
             yield { type: StreamEventType.RETRY, isContinuation: true };
             // Re-send with the updated history (includes partial + recovery)
             const recoveryContents = self.getRequestHistory(currentUserContent);
-            escalatedFinishReason = undefined;
+            recoveryFinishReason = undefined;
             try {
               const recoveryStream = await self.makeApiCallAndProcessStream(
                 model,
                 recoveryContents,
-                escalatedParams,
+                recoveryParams,
                 prompt_id,
               );
               for await (const chunk of recoveryStream) {
                 const fr = chunk.candidates?.[0]?.finishReason;
-                if (fr) escalatedFinishReason = fr;
+                if (fr) recoveryFinishReason = fr;
                 yield { type: StreamEventType.CHUNK, value: chunk };
               }
               // Iteration fully succeeded: both the user recovery turn and


### PR DESCRIPTION
## What this PR does

This PR skips the max_tokens escalation retry when the model's effective initial output limit is already at or above the escalated limit. In that case, MAX_TOKENS now goes directly into output recovery instead of making a no-op retry with the same max output token limit.

## Why it's needed

After the default output max_tokens behavior started using the model-declared output limit, high-output models can already begin at or above the escalation floor. For those models, the escalation retry does not increase the limit, so it adds an unnecessary API call before recovery. The recovery path still needs to run, though, because simply guarding the old escalation block would also skip continuation recovery.

## Reviewer Test Plan

### How to verify

For low-output models, MAX_TOKENS should still trigger the existing escalation retry first, and then enter recovery if the escalated response is also truncated. For high-output models, MAX_TOKENS should skip the no-op escalation retry and enter continuation recovery directly. I verified this with the focused output-token recovery tests, the full `geminiChat.test.ts` suite, and Prettier on the touched files.

```text
npx vitest run src/core/geminiChat.test.ts -t "output token recovery"
✓ src/core/geminiChat.test.ts (200 tests | 174 skipped)
Tests 26 passed | 174 skipped

npx vitest run src/core/geminiChat.test.ts
✓ src/core/geminiChat.test.ts (200 tests)
Tests 200 passed

npx prettier --check packages/core/src/core/geminiChat.ts packages/core/src/core/geminiChat.test.ts
All matched files use Prettier code style!
```

`npm run typecheck --workspace=packages/core` currently fails locally in existing provider test/dist type mismatches unrelated to this change, such as `src/providers/__tests__/provider-config.test.ts` and `src/providers/__tests__/presets/custom-provider.test.ts`.

### Evidence (Before & After)

N/A

### Tested on

|     OS     |     Status     |
| :--------: | :------------: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows |   ✅ tested    |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Windows local checkout, package test run from `packages/core`.

## Risk & Scope

- Main risk or tradeoff: The MAX_TOKENS handling branch is now split between real escalation and direct recovery, so the main risk is accidentally changing retry event ordering. The added regression test covers the high-output direct recovery path, and the existing recovery tests continue to cover the escalation path.
- Not validated / out of scope: Full workspace typecheck is not clean locally due to existing provider test/dist type mismatches outside this PR.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #5939

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 会在模型的实际初始输出上限已经大于或等于 escalation 上限时，跳过 max_tokens escalation retry。也就是说，这种情况下遇到 MAX_TOKENS 会直接进入输出恢复流程，而不是用相同的 max output token limit 再发起一次没有实际效果的重试。

## Why it's needed

默认输出 max_tokens 行为改成使用模型声明的输出上限之后，高输出模型一开始就可能已经达到或超过 escalation floor。对这些模型来说，escalation retry 并不会提高上限，只会在 recovery 之前多产生一次不必要的 API 调用。不过 recovery 路径仍然需要继续执行，因为如果只是简单跳过旧的 escalation block，也会把 continuation recovery 一起跳过。

## Reviewer Test Plan

### How to verify

对于低输出模型，MAX_TOKENS 仍然应该先触发已有的 escalation retry，如果 escalated response 仍然被截断，再进入 recovery。对于高输出模型，MAX_TOKENS 应该跳过无实际效果的 escalation retry，并直接进入 continuation recovery。我用 output-token recovery 的聚焦测试、完整的 `geminiChat.test.ts` 测试套件，以及针对本次修改文件的 Prettier 检查验证了这一点。

```text
npx vitest run src/core/geminiChat.test.ts -t "output token recovery"
✓ src/core/geminiChat.test.ts (200 tests | 174 skipped)
Tests 26 passed | 174 skipped

npx vitest run src/core/geminiChat.test.ts
✓ src/core/geminiChat.test.ts (200 tests)
Tests 200 passed

npx prettier --check packages/core/src/core/geminiChat.ts packages/core/src/core/geminiChat.test.ts
All matched files use Prettier code style!
```

`npm run typecheck --workspace=packages/core` 当前在本地仍然失败，但失败点是已有的 provider test/dist 类型不一致问题，和本次改动无关，例如 `src/providers/__tests__/provider-config.test.ts` 和 `src/providers/__tests__/presets/custom-provider.test.ts`。

### Evidence (Before & After)

N/A

### Tested on

|     OS     |     Status     |
| :--------: | :------------: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows |   ✅ tested    |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Windows 本地 checkout，测试命令在 `packages/core` 下运行。

## Risk & Scope

- Main risk or tradeoff: MAX_TOKENS 处理分支现在区分真实 escalation 和直接 recovery，主要风险是意外改变 retry event 顺序。新增回归测试覆盖了高输出模型直接 recovery 路径，已有 recovery 测试继续覆盖 escalation 路径。
- Not validated / out of scope: 本地完整 workspace typecheck 由于本 PR 之外已有的 provider test/dist 类型不一致问题无法通过。
- Breaking changes / migration notes: 无。

## Linked Issues

Fixes #5939

</details>
