### PR TITLE
feat(web-shell): display nested sub-agents as a tree in the tasks panel

### DIFF
--- a/docs/developers/daemon/08-session-lifecycle.md
+++ b/docs/developers/daemon/08-session-lifecycle.md
@@ -242,7 +242,10 @@ within this session only; it is not a cross-session activity aggregate.
 ### Session Tasks (`session_tasks` capability tag)
 
 `GET /session/:id/tasks` returns a background-task snapshot for agent tasks,
-shell tasks, monitor tasks, and their lifecycle states.
+shell tasks, monitor tasks, and their lifecycle states. Agent entries spawned
+by another sub-agent carry optional lineage fields (`parentAgentId`,
+`parentName`, `depth`) so clients can render nested sub-agents as a tree; see
+the payload example in `qwen-serve-protocol.md`.
 
 ### Session LSP Status (`session_lsp` capability tag)
 

--- a/docs/developers/qwen-serve-protocol.md
+++ b/docs/developers/qwen-serve-protocol.md
@@ -1063,6 +1063,21 @@ names only; clients must not expect skill bodies or paths over this route.
       "outputFile": "/tmp/agent-1.jsonl",
       "isBackgrounded": true,
       "subagentType": "reviewer"
+    },
+    {
+      "kind": "agent",
+      "id": "agent-2",
+      "label": "general-purpose: run the failing test",
+      "description": "run the failing test",
+      "status": "running",
+      "startTime": 1699999999500,
+      "runtimeMs": 500,
+      "outputFile": "/tmp/agent-2.jsonl",
+      "isBackgrounded": false,
+      "subagentType": "general-purpose",
+      "parentAgentId": "agent-1",
+      "parentName": "reviewer",
+      "depth": 1
     }
   ]
 }
@@ -1073,6 +1088,15 @@ prompt and can be queried while the session is streaming. The response only
 contains whitelisted metadata from the agent, shell, and monitor task
 registries; controllers, timers, offsets, pending messages, and raw registry
 objects are never exposed.
+
+Agent tasks spawned by another sub-agent (nested sub-agents, bounded by
+`maxSubagentDepth`) carry three optional lineage fields: `parentAgentId` (the
+spawning agent task's `id`), `parentName` (the spawning agent's
+`subagentType`, captured at registration so it survives the parent's eviction
+from the registry), and `depth` (0-based launch depth; 0 = spawned by the
+top-level session). Agents launched by the top-level session omit
+`parentAgentId` and `parentName`; clients should treat all three fields as
+optional and fall back to a flat list when they are absent.
 
 ### `GET /session/:id/lsp`
 

--- a/packages/acp-bridge/src/status.ts
+++ b/packages/acp-bridge/src/status.ts
@@ -577,6 +577,20 @@ export interface ServeSessionAgentTaskStatus {
   stats?: { totalTokens: number; toolUses: number; durationMs: number };
   recentActivities?: Array<{ name: string; description: string; at: number }>;
   prompt?: string;
+  /**
+   * `id` of the agent task that spawned this one; absent for agents
+   * launched by the top-level session. Mirrors `AgentTask.parentAgentId`
+   * (a `null` there serializes as absent here). Lets clients render the
+   * roster as a tree.
+   */
+  parentAgentId?: string;
+  /**
+   * Display name (`subagentType`) of the spawning agent, captured at
+   * registration time so it survives the parent's eviction. Display-only.
+   */
+  parentName?: string;
+  /** Launch depth (0-based; 0 = spawned by the top-level session). */
+  depth?: number;
 }
 
 export interface ServeSessionShellTaskStatus {

--- a/packages/cli/src/acp-integration/session/tasksSnapshot.test.ts
+++ b/packages/cli/src/acp-integration/session/tasksSnapshot.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { AgentTask, Config } from '@qwen-code/qwen-code-core';
+import { buildSessionTasksStatus } from './tasksSnapshot.js';
+import type { ServeSessionAgentTaskStatus } from '@qwen-code/acp-bridge/status';
+
+function agentTask(overrides: Partial<AgentTask> = {}): AgentTask {
+  return {
+    kind: 'agent',
+    id: 'agent-1',
+    agentId: 'agent-1',
+    description: 'test agent',
+    status: 'running',
+    startTime: 1_000,
+    outputFile: '/tmp/agent-1.jsonl',
+    subagentType: 'general-purpose',
+    isBackgrounded: false,
+    pendingMessages: [],
+    ...overrides,
+  } as AgentTask;
+}
+
+function configWith(agents: AgentTask[]): Config {
+  return {
+    getBackgroundTaskRegistry: () => ({ getAll: () => agents }),
+    getBackgroundShellRegistry: () => ({ getAll: () => [] }),
+    getMonitorRegistry: () => ({ getAll: () => [] }),
+  } as unknown as Config;
+}
+
+function serializedAgents(agents: AgentTask[]): ServeSessionAgentTaskStatus[] {
+  const snapshot = buildSessionTasksStatus(
+    'session-1',
+    configWith(agents),
+    2_000,
+  );
+  return snapshot.tasks.filter(
+    (t): t is ServeSessionAgentTaskStatus => t.kind === 'agent',
+  );
+}
+
+describe('buildSessionTasksStatus agent lineage', () => {
+  it('carries parentAgentId, parentName and depth for a nested agent', () => {
+    const [parent, child] = serializedAgents([
+      agentTask({ id: 'parent-1', agentId: 'parent-1' }),
+      agentTask({
+        id: 'child-1',
+        agentId: 'child-1',
+        parentAgentId: 'parent-1',
+        parentName: 'general-purpose',
+        depth: 1,
+        startTime: 1_500,
+      }),
+    ]);
+    expect(parent.parentAgentId).toBeUndefined();
+    expect(child.parentAgentId).toBe('parent-1');
+    expect(child.parentName).toBe('general-purpose');
+    expect(child.depth).toBe(1);
+  });
+
+  it('normalizes a null parentAgentId (top-level launch) to absent', () => {
+    const [task] = serializedAgents([agentTask({ parentAgentId: null })]);
+    expect('parentAgentId' in task).toBe(false);
+  });
+
+  it('omits all lineage keys for legacy entries without them', () => {
+    const [task] = serializedAgents([agentTask()]);
+    expect('parentAgentId' in task).toBe(false);
+    expect('parentName' in task).toBe(false);
+    expect('depth' in task).toBe(false);
+  });
+
+  it('serializes depth 0 explicitly rather than dropping it', () => {
+    const [task] = serializedAgents([
+      agentTask({ parentAgentId: null, depth: 0 }),
+    ]);
+    expect(task.depth).toBe(0);
+  });
+});

--- a/packages/cli/src/acp-integration/session/tasksSnapshot.ts
+++ b/packages/cli/src/acp-integration/session/tasksSnapshot.ts
@@ -53,6 +53,11 @@ function serializeAgentTask(
     ...optionalField('endTime', entry.endTime),
     ...optionalField('subagentType', entry.subagentType),
     isBackgrounded: entry.isBackgrounded,
+    // Nested-agent lineage for client-side tree rendering. AgentTask uses
+    // `null` parentAgentId for top-level launches — normalize to absent.
+    ...optionalField('parentAgentId', entry.parentAgentId ?? undefined),
+    ...optionalField('parentName', entry.parentName),
+    ...optionalField('depth', entry.depth),
     ...optionalField('error', entry.error),
     ...optionalField('resumeBlockedReason', entry.resumeBlockedReason),
     ...optionalField('stats', entry.stats),

--- a/packages/sdk-typescript/src/daemon/types.ts
+++ b/packages/sdk-typescript/src/daemon/types.ts
@@ -981,6 +981,21 @@ export interface DaemonSessionAgentTaskStatus {
   stats?: { totalTokens: number; toolUses: number; durationMs: number };
   recentActivities?: Array<{ name: string; description: string; at: number }>;
   prompt?: string;
+  /**
+   * `id` of the agent task that spawned this one. Absent for agents
+   * launched by the top-level session. Sub-agents may spawn sub-agents
+   * (bounded by `maxSubagentDepth`); clients render the roster as a tree
+   * by correlating this against sibling `id`s.
+   */
+  parentAgentId?: string;
+  /**
+   * Display name (`subagentType`) of the spawning agent, captured at
+   * registration time so it survives the parent's eviction from the
+   * registry. Display-only.
+   */
+  parentName?: string;
+  /** Launch depth (0-based; 0 = spawned by the top-level session). */
+  depth?: number;
 }
 
 export interface DaemonSessionShellTaskStatus {

--- a/packages/web-shell/client/components/messages/TasksStatusMessage.module.css
+++ b/packages/web-shell/client/components/messages/TasksStatusMessage.module.css
@@ -67,6 +67,14 @@
   white-space: nowrap;
 }
 
+.treeMarker {
+  color: var(--muted-foreground);
+}
+
+.orphanNote {
+  color: var(--muted-foreground);
+}
+
 .status {
   flex: 0 0 auto;
   font-size: 12px;

--- a/packages/web-shell/client/components/messages/TasksStatusMessage.test.tsx
+++ b/packages/web-shell/client/components/messages/TasksStatusMessage.test.tsx
@@ -1,0 +1,214 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type {
+  DaemonSessionAgentTaskStatus,
+  DaemonSessionTasksStatus,
+} from '@qwen-code/sdk/daemon';
+import { I18nProvider } from '../../i18n';
+
+// The panel only needs getTasks/cancelTask from the daemon SDK; mock the
+// hook so the unit test doesn't pull the whole connection graph. Hoisted
+// so tests can assert on / reprogram the mocks across renders.
+const { getTasksMock, cancelTaskMock } = vi.hoisted(() => ({
+  getTasksMock: vi.fn(),
+  cancelTaskMock: vi.fn(),
+}));
+vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
+  useActions: () => ({
+    getTasks: getTasksMock,
+    cancelTask: cancelTaskMock,
+  }),
+}));
+
+const { TasksStatusMessage } = await import('./TasksStatusMessage');
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+afterEach(() => {
+  for (const { root, container } of mounted) {
+    act(() => root.unmount());
+    container.remove();
+  }
+  mounted.length = 0;
+  getTasksMock.mockReset();
+  cancelTaskMock.mockReset();
+});
+
+function agentTask(
+  id: string,
+  overrides: Partial<DaemonSessionAgentTaskStatus> = {},
+): DaemonSessionAgentTaskStatus {
+  return {
+    kind: 'agent',
+    id,
+    label: `label-${id}`,
+    description: `desc-${id}`,
+    status: 'running',
+    startTime: 1_000,
+    runtimeMs: 5_000,
+    isBackgrounded: true,
+    subagentType: 'general-purpose',
+    ...overrides,
+  };
+}
+
+function renderPanel(tasks: DaemonSessionAgentTaskStatus[]): HTMLElement {
+  const snapshot: DaemonSessionTasksStatus = {
+    v: 1,
+    sessionId: 'session-1',
+    now: 10_000,
+    tasks,
+  };
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mounted.push({ root, container });
+  act(() => {
+    root.render(
+      <I18nProvider language="en">
+        <TasksStatusMessage message={{ snapshot }} manageActiveEvent={false} />
+      </I18nProvider>,
+    );
+  });
+  return container;
+}
+
+describe('TasksStatusMessage nested-agent tree', () => {
+  it('groups a child directly beneath its parent across the sort order', () => {
+    // Active sort alone renders newest-first: child(3000), other(2000),
+    // parent(1000). The tree post-pass must pull the child up under its
+    // parent without disturbing the other root's earned position.
+    const container = renderPanel([
+      agentTask('parent', { startTime: 1_000 }),
+      agentTask('other', { startTime: 2_000 }),
+      agentTask('child', {
+        startTime: 3_000,
+        parentAgentId: 'parent',
+        parentName: 'general-purpose',
+        depth: 1,
+      }),
+    ]);
+    const text = container.textContent ?? '';
+    const posOther = text.indexOf('label-other');
+    const posParent = text.indexOf('label-parent');
+    const posChild = text.indexOf('label-child');
+    expect(posOther).toBeGreaterThanOrEqual(0);
+    expect(posParent).toBeGreaterThan(posOther);
+    expect(posChild).toBeGreaterThan(posParent);
+  });
+
+  it('marks nested rows with the ↳ marker and indents by visible depth', () => {
+    const container = renderPanel([
+      agentTask('parent'),
+      agentTask('child', { parentAgentId: 'parent', depth: 1 }),
+    ]);
+    expect(container.textContent).toContain('↳');
+    const indented = container.querySelector(
+      'span[style*="padding-left"]',
+    ) as HTMLElement | null;
+    expect(indented).not.toBeNull();
+    expect(indented!.style.paddingLeft).toBe('16px');
+    expect(indented!.textContent).toContain('label-child');
+  });
+
+  it('annotates an orphaned row with its departed parent instead of indenting', () => {
+    const container = renderPanel([
+      agentTask('orphan', {
+        parentAgentId: 'gone',
+        parentName: 'editor',
+        depth: 2,
+      }),
+    ]);
+    const text = container.textContent ?? '';
+    expect(text).toContain('↳');
+    expect(text).toContain('from editor');
+    expect(container.querySelector('span[style*="padding-left"]')).toBeNull();
+  });
+
+  it('cancels a foreground child of a background parent on the first press', async () => {
+    // The two-step confirm exists to warn "cancelling ends your turn".
+    // A foreground child awaited by a background parent unblocks that
+    // parent, not the user — first press must cancel immediately, same
+    // as the TUI dialog's chain-aware gate.
+    getTasksMock.mockResolvedValue({ tasks: [] });
+    cancelTaskMock.mockResolvedValue({ cancelled: true });
+    renderPanel([
+      agentTask('bg-parent', { isBackgrounded: true, startTime: 2_000 }),
+      agentTask('fg-child', {
+        isBackgrounded: false,
+        parentAgentId: 'bg-parent',
+        depth: 1,
+        startTime: 1_000,
+      }),
+    ]);
+    // The global keydown listener attaches after a 50 ms guard delay.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 80));
+    });
+    const press = (key: string) =>
+      act(async () => {
+        window.dispatchEvent(new KeyboardEvent('keydown', { key }));
+        // Each state change re-arms the delayed listener (50 ms guard);
+        // wait it out so the next press isn't swallowed mid-re-attach.
+        await new Promise((r) => setTimeout(r, 80));
+      });
+    await press('ArrowDown'); // select the child (row 2)
+    await press('x');
+    expect(cancelTaskMock).toHaveBeenCalledTimes(1);
+    expect(cancelTaskMock).toHaveBeenCalledWith('fg-child', 'agent');
+  });
+
+  it('requires a second press to cancel a user-blocking agent', async () => {
+    getTasksMock.mockResolvedValue({ tasks: [] });
+    cancelTaskMock.mockResolvedValue({ cancelled: true });
+    renderPanel([
+      agentTask('fg-root', { isBackgrounded: false, startTime: 2_000 }),
+      agentTask('fg-child', {
+        isBackgrounded: false,
+        parentAgentId: 'fg-root',
+        depth: 1,
+        startTime: 1_000,
+      }),
+    ]);
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 80));
+    });
+    const press = (key: string) =>
+      act(async () => {
+        window.dispatchEvent(new KeyboardEvent('keydown', { key }));
+        // Each state change re-arms the delayed listener (50 ms guard);
+        // wait it out so the next press isn't swallowed mid-re-attach.
+        await new Promise((r) => setTimeout(r, 80));
+      });
+    await press('x'); // fully-foreground chain → arms the confirm instead
+    expect(cancelTaskMock).not.toHaveBeenCalled();
+    await press('x'); // second press confirms
+    expect(cancelTaskMock).toHaveBeenCalledTimes(1);
+    expect(cancelTaskMock).toHaveBeenCalledWith('fg-root', 'agent');
+  });
+
+  it('tags [blocking] only on a fully-foreground chain', () => {
+    const container = renderPanel([
+      agentTask('bg-parent', { isBackgrounded: true }),
+      agentTask('fg-child', {
+        isBackgrounded: false,
+        parentAgentId: 'bg-parent',
+        depth: 1,
+      }),
+      agentTask('fg-root', { isBackgrounded: false }),
+    ]);
+    const text = container.textContent ?? '';
+    // fg-root's whole chain (itself) is foreground → tagged.
+    expect(text).toContain('[blocking] label-fg-root');
+    // fg-child is awaited by a background parent → blocks that parent,
+    // not the user; must NOT be tagged.
+    expect(text).not.toContain('[blocking] label-fg-child');
+    expect(text).not.toContain('[blocking] label-bg-parent');
+  });
+});

--- a/packages/web-shell/client/components/messages/TasksStatusMessage.tsx
+++ b/packages/web-shell/client/components/messages/TasksStatusMessage.tsx
@@ -1,8 +1,15 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type {
   DaemonSessionTasksStatus,
   DaemonSessionTaskStatus,
 } from '@qwen-code/sdk/daemon';
+import {
+  computeAgentTreeInfo,
+  computeUserBlockingIds,
+  reorderChildrenUnderParents,
+  TREE_INDENT_MAX_LEVELS,
+  type AgentTreeInfo,
+} from './agentForest';
 import { useActions } from '@qwen-code/webui/daemon-react-sdk';
 import { useDelayedGlobalKeyDown } from '../../hooks/useDelayedGlobalKeyDown';
 import { useI18n } from '../../i18n';
@@ -60,6 +67,19 @@ function sortTasks(
     if (aActive) return b.startTime - a.startTime;
     return (b.endTime ?? b.startTime) - (a.endTime ?? a.startTime);
   });
+}
+
+/**
+ * Display order for the panel: active-first sort, then each nested agent
+ * grouped under its parent as a tree. The reorder is a post-pass so a tree
+ * spanning the active/terminal buckets stays contiguous at whichever
+ * position its root earned. Every `setTasks` site must use this (not bare
+ * `sortTasks`) — selection is index-based, so list order IS the contract.
+ */
+function arrangeTasks(
+  tasks: DaemonSessionTaskStatus[],
+): DaemonSessionTaskStatus[] {
+  return reorderChildrenUnderParents(sortTasks(tasks));
 }
 
 function formatTokenCount(tokens: number): string {
@@ -139,10 +159,15 @@ function ChevronIcon({ expanded }: { expanded: boolean }) {
   );
 }
 
-function rowLabel(task: DaemonSessionTaskStatus): string {
+function rowLabel(task: DaemonSessionTaskStatus, blocking: boolean): string {
   switch (task.kind) {
     case 'agent':
-      return task.isBackgrounded ? task.label : `[blocking] ${task.label}`;
+      // `blocking` comes from computeUserBlockingIds — an agent is tagged
+      // only when its entire ancestor chain is foreground up to the
+      // top-level session (cancelling it would end the user's turn), not
+      // merely for being a foreground entry (a foreground child awaited by
+      // a background parent blocks that parent, not the user).
+      return blocking ? `[blocking] ${task.label}` : task.label;
     case 'shell':
       return `[shell] ${task.command}`;
     case 'monitor':
@@ -212,7 +237,9 @@ export function TasksStatusMessage({
 }) {
   const { t } = useI18n();
   const actions = useActions();
-  const [tasks, setTasks] = useState(() => sortTasks(message.snapshot.tasks));
+  const [tasks, setTasks] = useState(() =>
+    arrangeTasks(message.snapshot.tasks),
+  );
   const [isOpen, setIsOpen] = useState(true);
   const [step, setStep] = useState<TasksPanelStep>('list');
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -231,6 +258,12 @@ export function TasksStatusMessage({
     tasks.length === 0 ? 0 : Math.min(selectedIndex, tasks.length - 1);
   const selectedTask = tasks[clampedSelectedIndex] ?? null;
 
+  // Tree metadata is computed on the full task list (not the windowed
+  // slice) so a row's indent doesn't shift when the window scrolls past
+  // its parent.
+  const treeInfo = useMemo(() => computeAgentTreeInfo(tasks), [tasks]);
+  const blockingIds = useMemo(() => computeUserBlockingIds(tasks), [tasks]);
+
   useEffect(() => {
     if (!isOpen) return;
     const refresh = () => {
@@ -239,7 +272,7 @@ export function TasksStatusMessage({
       actions
         .getTasks()
         .then((snapshot) => {
-          setTasks(sortTasks(snapshot.tasks));
+          setTasks(arrangeTasks(snapshot.tasks));
           setRefreshError(false);
         })
         .catch((error: unknown) => {
@@ -320,8 +353,14 @@ export function TasksStatusMessage({
       const isRunning = task.status === 'running';
       const isAbandonable = task.kind === 'agent' && task.status === 'paused';
       if (!isRunning && !isAbandonable) return;
-      const isForegroundAgent = task.kind === 'agent' && !task.isBackgrounded;
-      if (isForegroundAgent && pendingCancelId !== task.id) {
+      // Two-step confirm only when cancelling would end the USER's turn —
+      // the same chain-aware verdict as the `[blocking]` row prefix. A
+      // foreground child awaited by a *background* parent unblocks that
+      // parent, not the user, so it cancels on the first press like any
+      // background entry. Mirrors BackgroundTasksDialog's cancel gate.
+      const isUserBlockingAgent =
+        task.kind === 'agent' && blockingIds.has(task.id);
+      if (isUserBlockingAgent && pendingCancelId !== task.id) {
         setPendingCancelId(task.id);
         return;
       }
@@ -334,7 +373,7 @@ export function TasksStatusMessage({
           return;
         }
         const snapshot = await actions.getTasks();
-        setTasks(sortTasks(snapshot.tasks));
+        setTasks(arrangeTasks(snapshot.tasks));
         setActionError(null);
       } catch (error: unknown) {
         console.warn('[web-shell] failed to cancel task:', error);
@@ -343,7 +382,7 @@ export function TasksStatusMessage({
         setBusy(false);
       }
     },
-    [actions, busy, pendingCancelId, t],
+    [actions, busy, blockingIds, pendingCancelId, t],
   );
 
   useDelayedGlobalKeyDown(
@@ -540,6 +579,23 @@ export function TasksStatusMessage({
             const taskStatusLabel = statusLabel(task.status, t);
             const expanded = embedded && selected && step === 'detail';
             const showSelected = embedded ? expanded : selected;
+            const tree: AgentTreeInfo | undefined =
+              task.kind === 'agent' ? treeInfo.get(task.id) : undefined;
+            // Indent clamps so deep trees don't starve the label column;
+            // the detail view's nesting line carries the exact depth.
+            const indentLevels = Math.min(
+              tree?.visibleDepth ?? 0,
+              TREE_INDENT_MAX_LEVELS,
+            );
+            // The ↳ marker is kept even for orphans (parent already gone,
+            // depth back at 0) so "this was a nested agent" stays legible.
+            const nestedMarker =
+              task.kind === 'agent' && task.parentAgentId != null;
+            const orphanNote = tree?.orphaned
+              ? task.kind === 'agent' && task.parentName
+                ? t('tasks.row.from', { parent: task.parentName })
+                : t('tasks.row.nested')
+              : null;
             return (
               <div
                 key={task.id}
@@ -567,7 +623,27 @@ export function TasksStatusMessage({
                   {embedded && (
                     <span className={styles.taskIcon} aria-hidden="true" />
                   )}
-                  <span className={styles.nameCell}>{rowLabel(task)}</span>
+                  <span
+                    className={styles.nameCell}
+                    style={
+                      indentLevels > 0
+                        ? { paddingLeft: `${indentLevels * 16}px` }
+                        : undefined
+                    }
+                  >
+                    {nestedMarker && (
+                      <span className={styles.treeMarker} aria-hidden="true">
+                        {'↳ '}
+                      </span>
+                    )}
+                    {rowLabel(task, blockingIds.has(task.id))}
+                    {orphanNote && (
+                      <span className={styles.orphanNote}>
+                        {' · '}
+                        {orphanNote}
+                      </span>
+                    )}
+                  </span>
                   <span className={`${styles.status} ${stClass}`}>
                     {taskStatusLabel}
                   </span>
@@ -817,6 +893,25 @@ function TaskDetail({
 
       {task.kind === 'agent' && task.subagentType && (
         <DetailField label={t('tasks.detail.type')} value={task.subagentType} />
+      )}
+
+      {task.kind === 'agent' && (task.depth ?? 0) > 0 && (
+        <DetailField
+          label={t('tasks.detail.nesting')}
+          value={
+            // User-facing level = launch depth + 1 (depth 0 = spawned by
+            // the top-level session). Unlike the row indent, this is the
+            // absolute launch level, unaffected by departed ancestors.
+            task.parentName
+              ? t('tasks.detail.nestingValue', {
+                  level: (task.depth ?? 0) + 1,
+                  parent: task.parentName,
+                })
+              : t('tasks.detail.nestingLevel', {
+                  level: (task.depth ?? 0) + 1,
+                })
+          }
+        />
       )}
 
       {task.kind === 'agent' &&

--- a/packages/web-shell/client/components/messages/agentForest.test.ts
+++ b/packages/web-shell/client/components/messages/agentForest.test.ts
@@ -1,0 +1,223 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Fixtures mirror the TUI counterpart's tests
+// (packages/cli/src/ui/components/background-view/agent-forest.test.ts) so
+// the two ports can't silently diverge in semantics.
+
+import { describe, expect, it } from 'vitest';
+import {
+  type AgentForestNode,
+  computeAgentTreeInfo,
+  computeUserBlockingIds,
+  reorderChildrenUnderParents,
+} from './agentForest';
+
+interface TestNode extends AgentForestNode {
+  kind: string;
+  id?: string;
+}
+
+function agent(id: string, overrides: Partial<TestNode> = {}): TestNode {
+  return { kind: 'agent', id, ...overrides };
+}
+
+function idsOf(entries: readonly TestNode[]): Array<string | undefined> {
+  return entries.map((e) => (e.kind === 'agent' ? e.id : e.kind));
+}
+
+describe('reorderChildrenUnderParents', () => {
+  it('keeps a flat roster unchanged', () => {
+    const entries = [agent('a'), agent('b'), agent('c')];
+    expect(idsOf(reorderChildrenUnderParents(entries))).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+  });
+
+  it('pulls a child from behind an interleaving sibling up under its parent', () => {
+    const entries = [
+      agent('p'),
+      agent('q'),
+      agent('p-child', { parentAgentId: 'p' }),
+    ];
+    expect(idsOf(reorderChildrenUnderParents(entries))).toEqual([
+      'p',
+      'p-child',
+      'q',
+    ]);
+  });
+
+  it('orders a multi-level tree depth-first with siblings in input order', () => {
+    const entries = [
+      agent('root'),
+      agent('child-1', { parentAgentId: 'root' }),
+      agent('other-root'),
+      agent('grandchild', { parentAgentId: 'child-1' }),
+      agent('child-2', { parentAgentId: 'root' }),
+    ];
+    expect(idsOf(reorderChildrenUnderParents(entries))).toEqual([
+      'root',
+      'child-1',
+      'grandchild',
+      'child-2',
+      'other-root',
+    ]);
+  });
+
+  it('keeps non-agent entries at their exact positions', () => {
+    const shell: TestNode = { kind: 'shell', id: 'sh-1' };
+    const monitor: TestNode = { kind: 'monitor', id: 'mon-1' };
+    const entries = [
+      agent('p'),
+      shell,
+      agent('q'),
+      agent('p-child', { parentAgentId: 'p' }),
+      monitor,
+    ];
+    const result = reorderChildrenUnderParents(entries);
+    expect(idsOf(result)).toEqual(['p', 'shell', 'p-child', 'q', 'monitor']);
+  });
+
+  it('treats an agent with a departed parent as a root in input order', () => {
+    const entries = [
+      agent('a'),
+      agent('orphan', { parentAgentId: 'gone' }),
+      agent('b'),
+    ];
+    expect(idsOf(reorderChildrenUnderParents(entries))).toEqual([
+      'a',
+      'orphan',
+      'b',
+    ]);
+  });
+
+  it('does not drop members of a parent cycle', () => {
+    const entries = [
+      agent('x', { parentAgentId: 'y' }),
+      agent('y', { parentAgentId: 'x' }),
+      agent('z'),
+    ];
+    const result = reorderChildrenUnderParents(entries);
+    expect(result).toHaveLength(3);
+    expect(new Set(idsOf(result))).toEqual(new Set(['x', 'y', 'z']));
+  });
+
+  it('ignores a self-parent reference', () => {
+    const entries = [agent('a', { parentAgentId: 'a' }), agent('b')];
+    expect(idsOf(reorderChildrenUnderParents(entries))).toEqual(['a', 'b']);
+  });
+
+  it('ignores a shell task whose id collides with a parentAgentId', () => {
+    // Only kind === 'agent' entries participate in the tree; a shell task
+    // with the same id must not adopt the agent as its child.
+    const shell: TestNode = { kind: 'shell', id: 'p' };
+    const entries = [shell, agent('child', { parentAgentId: 'p' }), agent('q')];
+    expect(idsOf(reorderChildrenUnderParents(entries))).toEqual([
+      'shell',
+      'child',
+      'q',
+    ]);
+  });
+});
+
+describe('computeAgentTreeInfo', () => {
+  it('computes visible depth along the present parent chain', () => {
+    const entries = [
+      agent('root'),
+      agent('child', { parentAgentId: 'root' }),
+      agent('grandchild', { parentAgentId: 'child' }),
+    ];
+    const info = computeAgentTreeInfo(entries);
+    expect(info.get('root')).toEqual({ visibleDepth: 0, orphaned: false });
+    expect(info.get('child')).toEqual({ visibleDepth: 1, orphaned: false });
+    expect(info.get('grandchild')).toEqual({
+      visibleDepth: 2,
+      orphaned: false,
+    });
+  });
+
+  it('promotes an agent with a departed parent to visible root and flags it', () => {
+    const entries = [agent('orphan', { parentAgentId: 'gone' })];
+    expect(computeAgentTreeInfo(entries).get('orphan')).toEqual({
+      visibleDepth: 0,
+      orphaned: true,
+    });
+  });
+
+  it('counts depth up to the nearest missing ancestor only', () => {
+    const entries = [
+      agent('parent', { parentAgentId: 'gone' }),
+      agent('child', { parentAgentId: 'parent' }),
+    ];
+    const info = computeAgentTreeInfo(entries);
+    expect(info.get('parent')).toEqual({ visibleDepth: 0, orphaned: true });
+    expect(info.get('child')).toEqual({ visibleDepth: 1, orphaned: false });
+  });
+
+  it('terminates on parent cycles', () => {
+    const entries = [
+      agent('x', { parentAgentId: 'y' }),
+      agent('y', { parentAgentId: 'x' }),
+    ];
+    const info = computeAgentTreeInfo(entries);
+    expect(info.get('x')).toEqual({ visibleDepth: 0, orphaned: false });
+    expect(info.get('y')).toEqual({ visibleDepth: 0, orphaned: false });
+  });
+});
+
+describe('computeUserBlockingIds', () => {
+  it('tags a top-level foreground agent', () => {
+    const entries = [agent('fg', { isBackgrounded: false })];
+    expect(computeUserBlockingIds(entries)).toEqual(new Set(['fg']));
+  });
+
+  it('never tags background agents', () => {
+    const entries = [agent('bg', { isBackgrounded: true })];
+    expect(computeUserBlockingIds(entries).size).toBe(0);
+  });
+
+  it('does not tag a foreground child awaited by a background parent', () => {
+    const entries = [
+      agent('bg-parent', { isBackgrounded: true }),
+      agent('fg-child', { isBackgrounded: false, parentAgentId: 'bg-parent' }),
+    ];
+    expect(computeUserBlockingIds(entries).size).toBe(0);
+  });
+
+  it('tags a fully-foreground chain down from the top-level session', () => {
+    const entries = [
+      agent('fg-parent', { isBackgrounded: false }),
+      agent('fg-child', { isBackgrounded: false, parentAgentId: 'fg-parent' }),
+    ];
+    expect(computeUserBlockingIds(entries)).toEqual(
+      new Set(['fg-parent', 'fg-child']),
+    );
+  });
+
+  it('does not tag when an ancestor is missing from the visible set', () => {
+    const entries = [
+      agent('fg-child', { isBackgrounded: false, parentAgentId: 'gone' }),
+    ];
+    expect(computeUserBlockingIds(entries).size).toBe(0);
+  });
+
+  it('does not tag members of a parent cycle', () => {
+    const entries = [
+      agent('x', { isBackgrounded: false, parentAgentId: 'y' }),
+      agent('y', { isBackgrounded: false, parentAgentId: 'x' }),
+    ];
+    expect(computeUserBlockingIds(entries).size).toBe(0);
+  });
+
+  it('does not tag entries missing the isBackgrounded flag', () => {
+    // The daemon always sends isBackgrounded for agent tasks; a node
+    // without it (defensive) must not be claimed as user-blocking.
+    const entries = [agent('unknown')];
+    expect(computeUserBlockingIds(entries).size).toBe(0);
+  });
+});

--- a/packages/web-shell/client/components/messages/agentForest.ts
+++ b/packages/web-shell/client/components/messages/agentForest.ts
@@ -1,0 +1,206 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * agentForest — pure helpers for rendering nested sub-agents as a tree
+ * in the tasks panel.
+ *
+ * Sub-agents may spawn sub-agents (bounded by `maxSubagentDepth`), and every
+ * agent in the tree appears in the same flat tasks snapshot
+ * (`DaemonSessionTasksStatus`, polled from `GET /session/:id/tasks`). These
+ * helpers turn that flat roster into a parent-grouped display order plus
+ * per-row tree metadata, without assuming the full tree is visible: entries
+ * appear and leave the snapshot independently (foreground agents unregister
+ * on completion, registries cap retained terminal entries), so every function
+ * here treats a missing parent as a normal case, not an error.
+ *
+ * The reorder is a post-pass over an already-sorted list on purpose: the
+ * panel sorts active-then-terminal, and a tree can span those buckets — a
+ * running parent with a just-completed child, or vice versa. Grouping
+ * children under whichever position their parent already earned preserves
+ * the sort semantics for roots while keeping trees contiguous.
+ *
+ * Focused port of the TUI's helpers
+ * (`packages/cli/src/ui/components/background-view/agent-forest.ts`); no
+ * package importable from both surfaces exists, so the two files share
+ * semantics via their collocated tests. Keep behavior changes in sync.
+ */
+
+/**
+ * Minimal structural view of a task entry — satisfied by
+ * `DaemonSessionTaskStatus` union members, so the helpers stay decoupled
+ * from the SDK types. For agent tasks `id` IS the agent id (the daemon
+ * serializer guarantees it), which is what `parentAgentId` references.
+ */
+export interface AgentForestNode {
+  kind: string;
+  id?: string;
+  parentAgentId?: string | null;
+  isBackgrounded?: boolean;
+}
+
+/** Per-agent tree metadata for row rendering. */
+export interface AgentTreeInfo {
+  /**
+   * Structural depth among the *visible* entries (0 = rendered at root
+   * level). An agent whose ancestors left the snapshot renders closer to
+   * the root than its launch depth — the tree indents only what the user
+   * can actually see, so connectors never dangle.
+   */
+  visibleDepth: number;
+  /**
+   * True when the entry claims a parent (`parentAgentId` set) that is not
+   * in the visible set — the row is promoted to root level and annotated
+   * ("from <parent>") instead of indented under nothing.
+   */
+  orphaned: boolean;
+}
+
+// Indent clamp shared with the row renderer: deep trees stop indenting past
+// this level so the label column survives narrow panels; the detail view's
+// level line carries the exact depth beyond the clamp.
+export const TREE_INDENT_MAX_LEVELS = 3;
+
+function isAgentNode<T extends AgentForestNode>(e: T): e is T & { id: string } {
+  return e.kind === 'agent' && typeof e.id === 'string';
+}
+
+/**
+ * Regroups agent entries so each agent renders directly beneath its parent
+ * (depth-first), while every non-agent entry keeps its exact position: the
+ * k-th agent slot in the input is filled by the k-th agent of the grouped
+ * order. Agents whose parent is absent (top-level, departed parent, or a
+ * parent-cycle) keep their original relative order as roots; siblings keep
+ * their original relative order under their parent.
+ */
+export function reorderChildrenUnderParents<T extends AgentForestNode>(
+  entries: readonly T[],
+): T[] {
+  const agents = entries.filter(isAgentNode);
+
+  const byId = new Map<string, T>();
+  for (const agent of agents) byId.set(agent.id, agent);
+
+  const childrenOf = new Map<string, Array<T & { id: string }>>();
+  const roots: Array<T & { id: string }> = [];
+  for (const agent of agents) {
+    const pid = agent.parentAgentId;
+    if (pid != null && pid !== agent.id && byId.has(pid)) {
+      const siblings = childrenOf.get(pid);
+      if (siblings) siblings.push(agent);
+      else childrenOf.set(pid, [agent]);
+    } else {
+      roots.push(agent);
+    }
+  }
+  if (childrenOf.size === 0) return [...entries];
+
+  const ordered: T[] = [];
+  const visited = new Set<string>();
+  const visit = (node: T & { id: string }) => {
+    if (visited.has(node.id)) return;
+    visited.add(node.id);
+    ordered.push(node);
+    for (const child of childrenOf.get(node.id) ?? []) visit(child);
+  };
+  for (const root of roots) visit(root);
+  // Parent-cycles never reach a root; append the members in input order
+  // rather than dropping rows.
+  for (const agent of agents) {
+    if (!visited.has(agent.id)) {
+      visited.add(agent.id);
+      ordered.push(agent);
+    }
+  }
+
+  let next = 0;
+  return entries.map((e) => (isAgentNode(e) ? ordered[next++] : e));
+}
+
+/** How an ancestor walk ended — see {@link ancestorChain}. */
+export type AncestorTermination = 'root' | 'missing' | 'cycle';
+
+/**
+ * Walks `node`'s parent chain through `lookup`, collecting the ancestors
+ * that are actually present (immediate parent first). The walk stops —
+ * without error, per the module contract — at a top-level ancestor
+ * (`'root'`), at a departed/unknown parent id (`'missing'`), or on a
+ * repeated id (`'cycle'`). Single home of the eviction/cycle policy shared
+ * by tree depth and the `[blocking]` verdict.
+ */
+export function ancestorChain<T extends AgentForestNode>(
+  node: AgentForestNode,
+  lookup: (id: string) => T | undefined,
+): { chain: T[]; terminatedBy: AncestorTermination } {
+  const chain: T[] = [];
+  const seen = new Set<string>(node.id != null ? [node.id] : []);
+  let pid = node.parentAgentId;
+  for (;;) {
+    if (pid == null) return { chain, terminatedBy: 'root' };
+    if (seen.has(pid)) return { chain, terminatedBy: 'cycle' };
+    const parent = lookup(pid);
+    if (!parent) return { chain, terminatedBy: 'missing' };
+    seen.add(pid);
+    chain.push(parent);
+    pid = parent.parentAgentId;
+  }
+}
+
+/**
+ * Computes {@link AgentTreeInfo} for every agent entry in the visible set.
+ * Depth is the length of the parent chain that is actually present.
+ */
+export function computeAgentTreeInfo(
+  entries: readonly AgentForestNode[],
+): Map<string, AgentTreeInfo> {
+  const byId = new Map<string, AgentForestNode>();
+  for (const e of entries) if (isAgentNode(e)) byId.set(e.id, e);
+
+  const info = new Map<string, AgentTreeInfo>();
+  for (const e of byId.values()) {
+    const { chain, terminatedBy } = ancestorChain(e, (id) => byId.get(id));
+    info.set(e.id!, {
+      // Cycle members are appended flat at root level by
+      // reorderChildrenUnderParents — mirror that here, otherwise the row
+      // would indent under no rendered parent.
+      visibleDepth: terminatedBy === 'cycle' ? 0 : chain.length,
+      // Orphaned = claims a parent but its IMMEDIATE parent is gone. A
+      // deeper break (grandparent departed) still renders indented under
+      // the present parent, so only a zero-length 'missing' chain counts.
+      orphaned: chain.length === 0 && terminatedBy === 'missing',
+    });
+  }
+  return info;
+}
+
+/**
+ * The agent ids whose cancellation would end the USER's current turn — a
+ * foreground entry whose entire ancestor chain is foreground up to the
+ * top-level session. A foreground child awaited by a *background* parent
+ * blocks that parent, not the user, so it is not tagged; the `[blocking]`
+ * warning exists solely to flag "cancelling this ends your turn". When the
+ * chain cannot be proven (departed ancestor, cycle), the entry is not
+ * tagged — a missing warning is a milder failure than a wrong one.
+ */
+export function computeUserBlockingIds(
+  entries: readonly AgentForestNode[],
+): Set<string> {
+  const byId = new Map<string, AgentForestNode>();
+  for (const e of entries) if (isAgentNode(e)) byId.set(e.id, e);
+
+  const blocking = new Set<string>();
+  for (const e of byId.values()) {
+    if (e.isBackgrounded !== false) continue;
+    const { chain, terminatedBy } = ancestorChain(e, (id) => byId.get(id));
+    if (
+      terminatedBy === 'root' &&
+      chain.every((ancestor) => ancestor.isBackgrounded === false)
+    ) {
+      blocking.add(e.id!);
+    }
+  }
+  return blocking;
+}

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -1145,6 +1145,12 @@ const EN: Messages = {
   'tasks.detail.toolCallCount': 'Tool calls',
   'tasks.detail.tokens': (v) => `${v?.count ?? 0} tokens`,
   'tasks.detail.toolCalls': (v) => `${v?.count ?? 0} tool calls`,
+  'tasks.detail.nesting': 'Nesting',
+  'tasks.detail.nestingValue': (v) =>
+    `Level ${v?.level ?? '?'} · from ${v?.parent ?? '?'}`,
+  'tasks.detail.nestingLevel': (v) => `Level ${v?.level ?? '?'}`,
+  'tasks.row.from': (v) => `from ${v?.parent ?? '?'}`,
+  'tasks.row.nested': 'nested',
   'tips.items':
     'Type / to see all available commands.|Use @ to reference file paths.|Press Esc to cancel an in-flight request.|Use Shift+Enter for a newline.|Press ↑↓ to browse message history.',
   'tools.available': 'Available tools:',
@@ -2316,6 +2322,12 @@ const ZH: Messages = {
   'tasks.detail.toolCallCount': '工具数量',
   'tasks.detail.tokens': (v) => `${v?.count ?? 0} tokens`,
   'tasks.detail.toolCalls': (v) => `${v?.count ?? 0} 次工具调用`,
+  'tasks.detail.nesting': '嵌套',
+  'tasks.detail.nestingValue': (v) =>
+    `第 ${v?.level ?? '?'} 层 · 来自 ${v?.parent ?? '?'}`,
+  'tasks.detail.nestingLevel': (v) => `第 ${v?.level ?? '?'} 层`,
+  'tasks.row.from': (v) => `来自 ${v?.parent ?? '?'}`,
+  'tasks.row.nested': '嵌套',
   'tips.items':
     '输入 / 查看所有可用命令。|使用 @ 引用文件路径。|按 Esc 取消正在进行的请求。|使用 Shift+Enter 换行。|按 ↑↓ 浏览历史消息。',
   'tools.available': '可用工具:',


### PR DESCRIPTION
## What this PR does

With nested sub-agents, an agent can itself spawn agents, but web-shell's background-tasks panel still rendered every agent as an undifferentiated flat row. This PR carries each agent's lineage — who spawned it, that parent's display name, and its launch depth — through the daemon's task snapshot as optional fields, and teaches the panel to render the roster as a tree: children group directly beneath their parent with an `↳` marker and indentation (clamped for deep trees), and a nested agent whose parent has already left the roster is promoted back to root level with a "from &lt;parent&gt;" annotation instead of dangling. The detail view gains a nesting line showing the agent's absolute launch level and parent. The `[blocking]` tag and the two-step stop confirmation also become lineage-aware: they now apply only when cancelling the agent would actually end the user's turn (the whole ancestor chain is foreground), instead of firing for every foreground agent — a nested worker awaited by a background parent now stops on the first press. Public daemon protocol docs are updated with the new payload shape.

This mirrors the tree UX the TUI gained in #6191, sharing its semantics: the ordering pass preserves the panel's existing sort for roots while keeping trees contiguous, missing parents are treated as a normal case rather than an error, and unprovable chains (departed ancestor, cycles) fail toward the milder rendering.

## Why it's needed

The nested sub-agents feature (#6189) makes multi-level agent trees a normal sight in the tasks roster. On the web surface, a user watching such a run today sees several identical-looking rows with no way to tell which agent spawned which, and the blocking tag over-warns — it marks agents whose cancellation would not end the user's turn. The TUI already solved both in #6191; this brings the web surface to parity so the same session reads the same way in both clients.

## Reviewer Test Plan

### How to verify

Start the daemon with the web UI enabled and open web-shell in a browser. In a session, ask the model to spawn a sub-agent whose task is to spawn another sub-agent that runs a long shell command (e.g. `sleep 45`), so a two-level chain is alive for a while. Open the background-tasks panel with `/tasks` while both agents run and confirm: the child row renders directly beneath its parent with an `↳` marker and indentation, while the parent row has neither; opening the child's detail shows a nesting line reading "Level 2 · from &lt;parent type&gt;". For the blocking semantics, note both rows carry `[blocking]` in this foreground chain (correct — cancelling either ends the turn), and pressing `x` on either asks for confirmation; if you instead launch the parent as a background agent, its foreground child shows no `[blocking]` tag and stops on a single press. Older payloads without the new fields (or a daemon predating this change) degrade to the previous flat list. The daemon side can be checked directly: the session tasks endpoint now returns the three optional lineage fields on nested agent entries and omits them on top-level ones.

### Evidence (Before & After)

Before: both agent rows render as an identical flat list (no marker, no indent, no lineage in detail).

After:

| Tasks panel tree | Child detail with nesting line |
| :---: | :---: |
| ![Tasks panel showing the nested agent tree with ↳ marker and indentation](https://raw.githubusercontent.com/QwenLM/qwen-code/d7d556ee6968032f0dd1ec4bb338c44bebb971a0/tasks-panel-tree.png) | ![Child detail view showing Nesting: Level 2 · from general-purpose](https://raw.githubusercontent.com/QwenLM/qwen-code/d7d556ee6968032f0dd1ec4bb338c44bebb971a0/child-detail-nesting.png) |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local bundle (`npm run build && npm run bundle`, `node dist/cli.js serve --web`), real model via DashScope; browser E2E driven with Playwright.

## Risk & Scope

- Main risk or tradeoff: the stop-confirmation gate changes slightly — a foreground agent nested under a background parent no longer requires a second press to stop. This matches the TUI's chain-aware behavior and the tag's documented meaning ("cancelling this ends your turn"), but it is a behavior change from the previous web panel.
- Not validated / out of scope: live activity of depth ≥ 2 agents inside the transcript's inline agent panels (that requires event-emitter bridging in core and is deferred as its own feature); Windows/Linux local verification (CI covers builds).
- Breaking changes / migration notes: none — the three new snapshot fields are optional and additive; old clients ignore them, and the new client falls back to the flat list when they are absent.

## Linked Issues

Builds on the nested sub-agents feature #6189 (merged); web counterpart of the TUI tree in #6191.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

有了嵌套子代理后，代理自身也可以派生代理，但 web-shell 的后台任务面板仍将每个代理渲染为无差别的平铺行。本 PR 将每个代理的谱系信息——由谁派生、父代理的显示名称、启动深度——作为可选字段通过 daemon 的任务快照传递，并让面板以树形渲染任务列表：子代理直接分组在父代理下方，带 `↳` 标记和缩进（深层树会收敛缩进），父代理已离开列表的嵌套代理会被提升回根层级并附加"来自 &lt;父代理&gt;"注释，而不是悬空缩进。详情视图新增嵌套信息行，显示代理的绝对启动层级和父代理。`[blocking]` 标签和两步停止确认也变为谱系感知：仅当取消该代理确实会结束用户当前轮次（整条祖先链均为前台）时才生效，而不是对每个前台代理都触发——由后台父代理等待的嵌套工作代理现在一次按键即可停止。同时更新了公开的 daemon 协议文档。

这与 TUI 在 #6191 中获得的树形 UX 保持一致，共享相同语义：排序后处理在保持面板既有根节点排序的同时让树保持连续，父代理缺失被视为正常情况而非错误，无法证明的链（祖先已离开、循环引用）以更温和的方式渲染。

## 为什么需要

嵌套子代理特性（#6189）使多层代理树成为任务列表中的常见景象。在 web 界面上，用户观察这样的运行时只能看到几行看起来完全相同的条目，无法分辨谁派生了谁，且 blocking 标签过度警告——它标记了那些取消后并不会结束用户轮次的代理。TUI 已在 #6191 中解决了这两个问题；本 PR 让 web 界面达到同等水平，使同一会话在两个客户端中呈现一致。

## 审阅者测试计划

### 如何验证

启动带 web UI 的 daemon 并在浏览器中打开 web-shell。在会话中让模型派生一个子代理，其任务是再派生一个运行长时间 shell 命令（如 `sleep 45`）的子代理，使两层代理链保持存活。在两个代理运行时用 `/tasks` 打开后台任务面板并确认：子代理行直接渲染在父代理下方，带 `↳` 标记和缩进，父代理行则没有；打开子代理详情可见嵌套信息行"第 2 层 · 来自 &lt;父代理类型&gt;"。关于 blocking 语义：在这条前台链中两行都带 `[blocking]`（正确——取消任一都会结束轮次），按 `x` 会要求确认；若改为以后台方式启动父代理，其前台子代理不显示 `[blocking]` 标签，且一次按键即可停止。不含新字段的旧载荷（或早于此变更的 daemon）会退化为之前的平铺列表。daemon 侧可直接检查：会话任务端点现在在嵌套代理条目上返回三个可选谱系字段，顶层代理则省略。

### 证据（前后对比）

之前：两个代理行渲染为完全相同的平铺列表（无标记、无缩进、详情无谱系）。之后：见上方英文部分附图——面板中带 `↳` 标记和缩进的树，以及子代理详情中的"嵌套：第 2 层 · 来自 general-purpose"信息行。

## 风险与范围

- 主要风险或权衡：停止确认门槛略有变化——嵌套在后台父代理下的前台代理不再需要二次按键确认停止。这与 TUI 的链感知行为及标签的文档语义（"取消将结束你的轮次"）一致，但相对之前的 web 面板是行为变化。
- 未验证/超出范围：转录内联代理面板中深度 ≥ 2 代理的实时活动（需要 core 层的事件桥接，作为独立特性延后）；Windows/Linux 本地验证（CI 覆盖构建）。
- 破坏性变更/迁移说明：无——三个新快照字段为可选且增量添加；旧客户端忽略它们，新客户端在字段缺失时回退为平铺列表。

## 关联 Issue

基于已合并的嵌套子代理特性 #6189；是 TUI 树形显示 #6191 的 web 对应实现。

</details>
