### PR TITLE
fix(cua-driver): migrate Windows scripts + add /mcp Approve button

### DIFF
--- a/packages/cua-driver/scripts/_install-rust.sh
+++ b/packages/cua-driver/scripts/_install-rust.sh
@@ -513,7 +513,7 @@ done
 # the baked line hasn't been updated yet (dev / pre-release checkouts).
 #
 # ~~~ BAKED_VERSION: auto-updated by CD workflow after each release — do not edit ~~~
-CUA_DRIVER_RS_BAKED_VERSION="0.6.8"
+CUA_DRIVER_RS_BAKED_VERSION="0.7.0"
 # ~~~ END_BAKED_VERSION ~~~
 
 if [[ -n "${CUA_DRIVER_RS_VERSION:-}" ]]; then


### PR DESCRIPTION
## Summary

Two fixes discovered during Windows cua-driver 0.7.0 testing:

### 1. Windows install/uninstall scripts un-migrated from upstream

`install.ps1` and `uninstall.ps1` were essentially un-migrated — binary name was `cua-driver.exe` (upstream) instead of `qwen-cua-driver.exe`, repo pointed at `trycua/cua`, install paths used upstream vendor names.

- Binary: `cua-driver.exe` → `qwen-cua-driver.exe`
- Repo: `trycua/cua` → `QwenLM/qwen-code`
- Install dir: `Programs\Cua\cua-driver\` → `Programs\Qwen\qwen-cua-driver\`
- Home dir: `.cua-driver` → `.qwen-cua-driver`
- Autostart task: `cua-driver-serve` → `qwen-cua-driver-serve`
- All URLs, process names, user-facing text updated
- `BAKED_VERSION`: `0.6.8` → `0.7.0`
- Added PATH restart hint after install
- Docs URL fixed in `post-install-hints.txt` and `_install-rust.sh` fallback

### 2. `/mcp` UI missing Approve button

Users who missed the startup approval dialog or rejected a workspace MCP server had no way to approve it from the `/mcp` management interface — only `Disable` was shown, creating a dead end.

Added an `Approve` button to `ServerDetailStep` for any server in `awaitingApproval` state (both pending and rejected). The handler persists the approval, un-gates the server, triggers discovery, and refreshes the UI.

## Test plan

- [x] `install.ps1`: verified `$BinaryName = "qwen-cua-driver.exe"`, `$Repo = "QwenLM/qwen-code"`, zero `trycua/cua` references
- [x] `uninstall.ps1`: mirrored all renames
- [x] Typecheck passes (0 errors)
- [x] E2E: tmux test — reject server at startup → enter `/mcp` → Approve button visible → click Approve → status transitions to `disconnected` with Reconnect option