### PR TITLE
fix(ci): bypass system proxy for autofix loopback

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -450,6 +450,8 @@ jobs:
             unset QWEN_UPSTREAM_OPENAI_BASE_URL
             export OPENAI_API_KEY=qwen-loopback-proxy
             export OPENAI_BASE_URL="${local_openai_base_url}"
+            export NO_PROXY="127.0.0.1,localhost,::1${NO_PROXY:+,${NO_PROXY}}"
+            export no_proxy="${NO_PROXY}"
             echo "openai_proxy=enabled (${OPENAI_BASE_URL})"
           }
 
@@ -624,8 +626,6 @@ jobs:
             exit without committing. An honest abort is better than a wrong
             fix.
         run: |-
-          BRANCH="autofix/issue-${ISSUE}"
-
           start_openai_proxy() {
             local proxy_info local_openai_base_url
             proxy_info="$(mktemp "${RUNNER_TEMP:-/tmp}/qwen-openai-proxy.XXXXXX")"
@@ -652,6 +652,8 @@ jobs:
             unset QWEN_UPSTREAM_OPENAI_BASE_URL
             export OPENAI_API_KEY=qwen-loopback-proxy
             export OPENAI_BASE_URL="${local_openai_base_url}"
+            export NO_PROXY="127.0.0.1,localhost,::1${NO_PROXY:+,${NO_PROXY}}"
+            export no_proxy="${NO_PROXY}"
             echo "openai_proxy=enabled (${OPENAI_BASE_URL})"
           }
 
@@ -1254,6 +1256,8 @@ jobs:
             unset QWEN_UPSTREAM_OPENAI_BASE_URL
             export OPENAI_API_KEY=qwen-loopback-proxy
             export OPENAI_BASE_URL="${local_openai_base_url}"
+            export NO_PROXY="127.0.0.1,localhost,::1${NO_PROXY:+,${NO_PROXY}}"
+            export no_proxy="${NO_PROXY}"
             echo "openai_proxy=enabled (${OPENAI_BASE_URL})"
           }
 

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -348,6 +348,10 @@ describe('qwen-autofix workflow', () => {
       expect(step).toContain('start_openai_proxy');
       expect(step).toContain('node .github/scripts/openai-proxy.mjs');
       expect(step).toContain('OPENAI_API_KEY=qwen-loopback-proxy');
+      expect(step).toContain(
+        'NO_PROXY="127.0.0.1,localhost,::1${NO_PROXY:+,${NO_PROXY}}"',
+      );
+      expect(step).toContain('no_proxy="${NO_PROXY}"');
       expect(step).toContain('unset QWEN_UPSTREAM_OPENAI_API_KEY');
       expect(step).toContain('unset QWEN_UPSTREAM_OPENAI_BASE_URL');
     }


### PR DESCRIPTION
## What this PR does

Autofix now forces localhost model traffic to bypass runner-level HTTP proxy settings before launching the qwen subprocess. This preserves the local credential-isolating model proxy while preventing the qwen client from sending its 127.0.0.1 endpoint through an external proxy.

## Why it is needed

The post-#6207 ECS autofix runs reached checkout, install, build, and bundle successfully, then failed during candidate assessment with `fetch failed`. Both manually dispatched runs failed at the same step, and the proxy emitted no request logs while qwen printed an Undici environment-proxy warning. That points to runner proxy environment variables intercepting the loopback OpenAI endpoint rather than a bad issue prompt or build failure.

## Reviewer Test Plan

### How to verify

Dispatch Qwen Autofix on main for a forced issue after this change lands. The `Assess candidates` step should log `openai_proxy=enabled (...)` and then either produce a decision artifact or continue to the next phase instead of failing immediately with `fetch failed` before the local proxy sees a request.

### Evidence (Before & After)

Before: workflow_dispatch runs 28648829659 and 28648836208 both failed in `Assess candidates` with `[API Error: Connection error. (cause: fetch failed)]` after the proxy started. After: local workflow tests assert every qwen agent step exports localhost bypass settings, and actionlint accepts the workflow.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local verification commands: `npx vitest run scripts/tests/qwen-autofix-workflow.test.js`, `actionlint .github/workflows/qwen-autofix.yml`, and `npx prettier --check .github/workflows/qwen-autofix.yml scripts/tests/qwen-autofix-workflow.test.js`.

## Risk & Scope

- Main risk or tradeoff: this assumes the runner still needs its normal proxy settings for non-local traffic, so the change only bypasses localhost rather than clearing all proxy variables.
- Not validated / out of scope: a real ECS autofix rerun still needs to happen after the PR lands on main.
- Breaking changes / migration notes: none.

## Linked Issues

References #6207 and the failed autofix runs 28648829659 and 28648836208.

<details>
<summary>中文说明</summary>

## What this PR does

Autofix 在启动 qwen 子进程前，强制让 localhost 模型流量绕过 runner 级别的 HTTP 代理设置。这样保留本地模型凭据隔离 proxy，同时避免 qwen client 把 127.0.0.1 endpoint 发到外部代理。

## Why it is needed

#6207 合入后的 ECS autofix run 已经能通过 checkout、install、build 和 bundle，但在 candidate assessment 阶段失败，错误是 `fetch failed`。两个手动 dispatch 的 run 都在同一步失败，并且本地 proxy 没有任何请求日志，同时 qwen 打出了 Undici environment-proxy warning。这说明问题更像是 runner proxy 环境变量拦截了 loopback OpenAI endpoint，而不是 issue prompt 或 build 本身有问题。

## Reviewer Test Plan

### How to verify

该改动合入 main 后，手动 dispatch 一个指定 issue 的 Qwen Autofix。`Assess candidates` step 应该先打印 `openai_proxy=enabled (...)`，然后生成 decision artifact 或继续进入下一阶段，而不是在本地 proxy 收到请求前立刻以 `fetch failed` 失败。

### Evidence (Before & After)

Before：workflow_dispatch runs 28648829659 和 28648836208 都在 `Assess candidates` 里失败，proxy 启动后 qwen 报 `[API Error: Connection error. (cause: fetch failed)]`。After：本地 workflow 测试断言每个 qwen agent step 都导出 localhost bypass 设置，并且 actionlint 接受 workflow。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地验证命令：`npx vitest run scripts/tests/qwen-autofix-workflow.test.js`、`actionlint .github/workflows/qwen-autofix.yml`、`npx prettier --check .github/workflows/qwen-autofix.yml scripts/tests/qwen-autofix-workflow.test.js`。

## Risk & Scope

- Main risk or tradeoff：假设 runner 对非本地流量仍然需要正常 proxy 设置，所以这里只绕过 localhost，没有清空所有 proxy 环境变量。
- Not validated / out of scope：合入 main 后仍需要真实 ECS autofix rerun 验证。
- Breaking changes / migration notes：无。

## Linked Issues

关联 #6207，以及失败的 autofix runs 28648829659 和 28648836208。

</details>