### PR TITLE
fix(mobile-mcp): align CD workflow npm auth with release.yml

### DIFF
--- a/.github/workflows/cd-mobile-mcp.yml
+++ b/.github/workflows/cd-mobile-mcp.yml
@@ -14,20 +14,21 @@ on:
         type: 'boolean'
         default: true
 
-permissions:
-  contents: 'read'
-  id-token: 'write'
-
 jobs:
   build-and-publish:
     runs-on: 'ubuntu-latest'
+    permissions:
+      contents: 'read'
     steps:
       - uses: 'actions/checkout@v4'
 
       - uses: 'actions/setup-node@v5'
         with:
-          node-version: '22'
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: 'package-lock.json'
           registry-url: 'https://registry.npmjs.org'
+          scope: '@qwen-code'
 
       - name: 'Determine version'
         id: 'version'
@@ -58,6 +59,6 @@ jobs:
       - name: 'Publish'
         if: '${{ !inputs.dry_run }}'
         working-directory: 'packages/mobile-mcp'
-        run: 'npm publish --access public --provenance'
+        run: 'npm publish --access public'
         env:
           NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}'


### PR DESCRIPTION
## Summary

Fix `npm publish` ENEEDAUTH failure in cd-mobile-mcp.yml by aligning with the working release.yml configuration:

1. Add `scope: '@qwen-code'` to setup-node (was missing → npm couldn't auth for scoped package)
2. Remove `--provenance` from publish (release.yml doesn't use it, and it requires `id-token: write` permissions)
3. Move permissions to job level with `contents: 'read'` only (matching release.yml)
4. Use `.nvmrc` for node version + npm cache (matching release.yml)

## Test plan

- [x] yamllint + actionlint pass
- [x] Trigger dry-run after merge to verify Install → Build → Test pass
- [x] Trigger publish to verify npm auth works