### PR TITLE
fix(ci): add always() to delay-automatic-review and ack-review-request

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -77,6 +77,7 @@ jobs:
     # this `if` only matches the /review command shape.
     needs: ['authorize']
     if: |-
+      always() &&
       needs.authorize.outputs.should_review == 'true' &&
       ((github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
@@ -154,6 +155,7 @@ jobs:
   delay-automatic-review:
     needs: ['authorize']
     if: |-
+      always() &&
       github.event_name == 'pull_request_target' &&
       (github.event.action == 'opened' ||
        github.event.action == 'synchronize') &&


### PR DESCRIPTION
## What this PR does

Add `always()` to the `if` condition of two jobs in the PR review workflow: `delay-automatic-review` and `ack-review-request`. Both jobs transitively depend on `precheck-pr` via `authorize`, and without `always()` they get skipped whenever `precheck-pr` is skipped — even when their direct dependency `authorize` succeeds.

## Why it's needed

Same-repo PRs (non-fork) never trigger the automated Qwen PR review on `opened`/`synchronize` events. The dependency chain is `precheck-pr → authorize → delay-automatic-review → review-pr`. `precheck-pr` is intentionally skipped for same-repo PRs (it only runs for forks). `authorize` has `always()` so it runs and outputs `should_review=true`. But `delay-automatic-review` was missing `always()`, so GitHub Actions' default behavior propagated the skipped transitive dependency, causing the entire review chain to be skipped. PR #5629 is a concrete example — all review jobs were SKIPPED despite `authorize` succeeding.

`ack-review-request` has the same latent bug for comment-triggered `/review` on fork PRs, where `precheck-pr` is skipped because the event type doesn't match `pull_request_target`.

## Reviewer Test Plan

### How to verify

1. Merge this PR into `main`.
2. Push a new commit to any same-repo PR (triggers `pull_request_target` / `synchronize`).
3. Confirm that `delay-automatic-review` runs (after the environment delay) and outputs `should_review=true`, and `review-pr` executes the automated review.
4. Alternatively, check the workflow run for this PR itself — `delay-automatic-review` should no longer show as SKIPPED.

### Evidence (Before & After)

N/A (CI workflow change, no user-visible UI changes)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

N/A — workflow-only change.

## Risk & Scope

- Main risk or tradeoff: None — `always()` is already used by `authorize`, `review-pr`, and `resolve-pr`. This brings the remaining two jobs in line with the established pattern.
- Not validated / out of scope: Fork PR behavior (precheck-pr path) — unchanged by this fix.
- Breaking changes / migration notes: None.

## Linked Issues

Relates to #5629 (PR whose review was not triggered).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

给 PR review workflow 中的两个 job（`delay-automatic-review` 和 `ack-review-request`）的 `if` 条件补上 `always()`。这两个 job 通过 `authorize` 传递依赖 `precheck-pr`，缺少 `always()` 时，即使直接依赖 `authorize` 成功，也会因 `precheck-pr` 被 skip 而被跳过。

## 为什么需要

同仓库 PR（非 fork）在 `opened`/`synchronize` 事件下从未触发自动化 Qwen PR review。依赖链为 `precheck-pr → authorize → delay-automatic-review → review-pr`。`precheck-pr` 仅对 fork PR 运行，同仓库 PR 会被有意 skip。`authorize` 有 `always()` 所以能正常运行并输出 `should_review=true`。但 `delay-automatic-review` 缺少 `always()`，GitHub Actions 的默认行为会将传递依赖的 skip 传播下来，导致整条 review 链路被跳过。PR #5629 就是一个具体案例——所有 review job 都被 SKIPPED，尽管 `authorize` 已成功。

`ack-review-request` 在 fork PR 的评论触发 `/review` 场景下也有同样的潜在 bug，因为 `precheck-pr` 的事件类型不匹配 `pull_request_target` 会被 skip。

## 审查者测试计划

1. 合并本 PR 到 `main`。
2. 向任意同仓库 PR push 一个新 commit（触发 `pull_request_target` / `synchronize`）。
3. 确认 `delay-automatic-review` 正常运行（经过环境延迟后）并输出 `should_review=true`，`review-pr` 执行自动化 review。
4. 或者直接查看本 PR 自身的 workflow run——`delay-automatic-review` 不应再显示为 SKIPPED。

## 风险与范围

- 主要风险：无——`authorize`、`review-pr`、`resolve-pr` 已在使用 `always()`，本修复让剩余两个 job 保持一致。
- 未验证/不在范围内：fork PR 行为（precheck-pr 路径）——本修复不影响。
- 破坏性变更/迁移说明：无。

## 关联 Issue

关联 #5629（review 未被触发的 PR）。

</details>
