### PR TITLE
feat(web-shell): improve slash command discovery (taller menu, group counts, fuzzy search)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27343,6 +27343,7 @@
         "@codemirror/view": "^6.35.0",
         "@tanstack/react-virtual": "^3.13.26",
         "codemirror": "^6.0.0",
+        "fzf": "^0.5.2",
         "katex": "^0.16.47",
         "mermaid": "^11.15.0",
         "react-markdown": "^9.0.0",

--- a/packages/web-shell/client/completions/slashCompletion.test.ts
+++ b/packages/web-shell/client/completions/slashCompletion.test.ts
@@ -178,6 +178,82 @@ describe('getSlashCommandCompletionResult', () => {
     ]);
   });
 
+  it('fuzzy-ranks top-level commands for an abbreviated query', () => {
+    const commands: CommandInfo[] = [
+      { name: 'model', description: 'Switch model', source: 'builtin-command' },
+      {
+        name: 'memory',
+        description: 'Manage memory',
+        source: 'builtin-command',
+      },
+      {
+        name: 'agent-reproduce-feature',
+        description: 'Reproduce a feature',
+        source: 'skill-dir-command',
+      },
+    ];
+
+    const mdl = getSlashCommandCompletionResult(
+      '/mdl',
+      4,
+      commands,
+      [],
+      'en',
+      getTranslator('en'),
+    );
+    expect(mdl?.items[0]?.label).toBe('/model');
+
+    const arf = getSlashCommandCompletionResult(
+      '/arf',
+      4,
+      commands,
+      [],
+      'en',
+      getTranslator('en'),
+    );
+    expect(arf?.items.map((item) => item.label)).toContain(
+      '/agent-reproduce-feature',
+    );
+  });
+
+  it('drops section headers while searching but keeps them while browsing', () => {
+    const commands: CommandInfo[] = [
+      {
+        name: 'clear',
+        description: 'Clear the screen',
+        source: 'builtin-command',
+      },
+      {
+        name: 'demo:ping',
+        description: 'Project command',
+        source: 'skill-dir-command',
+      },
+    ];
+
+    const browsing = getSlashCommandCompletionResult(
+      '/',
+      1,
+      commands,
+      [],
+      'en',
+      getTranslator('en'),
+    );
+    expect(browsing?.items.every((item) => Boolean(item.section))).toBe(true);
+
+    const searching = getSlashCommandCompletionResult(
+      '/c',
+      2,
+      commands,
+      [],
+      'en',
+      getTranslator('en'),
+    );
+    expect(searching?.items.map((item) => item.label)).toEqual(['/clear']);
+    expect(searching?.items.every((item) => item.section === undefined)).toBe(
+      true,
+    );
+  });
+
   it('honors panel category order and filtered commands', () => {
     const commands: CommandInfo[] = [
       {

--- a/packages/web-shell/client/completions/slashCompletion.test.ts
+++ b/packages/web-shell/client/completions/slashCompletion.test.ts
@@ -254,6 +254,21 @@ describe('getSlashCommandCompletionResult', () => {
     );
   });
 
+  it('returns null when fuzzy search matches nothing', () => {
+    const commands: CommandInfo[] = [
+      { name: 'clear', description: 'Clear', source: 'builtin-command' },
+    ];
+    const result = getSlashCommandCompletionResult(
+      '/zzzzzzz',
+      8,
+      commands,
+      [],
+      'en',
+      getTranslator('en'),
+    );
+    expect(result).toBeNull();
+  });
+
   it('honors panel category order and filtered commands', () => {
     const commands: CommandInfo[] = [
       {

--- a/packages/web-shell/client/completions/slashCompletion.ts
+++ b/packages/web-shell/client/completions/slashCompletion.ts
@@ -4,6 +4,7 @@ import type {
   CompletionResult,
   CompletionSection,
 } from '@codemirror/autocomplete';
+import { Fzf } from 'fzf';
 import type { CommandInfo } from '../adapters/types';
 import type { WebShellLanguage } from '../i18n';
 import {
@@ -332,6 +333,58 @@ function getLineBounds(text: string, cursor: number) {
   };
 }
 
+// The visible slash menu (React SlashCommandPanel) drives its top-level command
+// list through getSlashCommandCompletionResult. For a non-empty query we rank
+// with fzf — the same fuzzy engine the TUI uses — so abbreviated input like
+// "mdl" surfaces "model" and "arf" surfaces "agent-reproduce-feature". Building
+// the index is keyed on the commands array identity, so it happens once per
+// command set rather than on every keystroke. (slashCompletionSource, the
+// CodeMirror source below, is not wired into the live editor and still does
+// substring filtering.)
+const commandFzfCache = new WeakMap<
+  readonly CommandInfo[],
+  { fzf: Fzf<readonly string[]>; byName: Map<string, CommandInfo> }
+>();
+
+function getCommandFzf(commands: CommandInfo[]) {
+  let entry = commandFzfCache.get(commands);
+  if (!entry) {
+    const names: string[] = [];
+    const byName = new Map<string, CommandInfo>();
+    for (const command of commands) {
+      if (byName.has(command.name)) continue;
+      names.push(command.name);
+      byName.set(command.name, command);
+    }
+    entry = {
+      fzf: new Fzf(names, { fuzzy: 'v2', casing: 'case-insensitive' }),
+      byName,
+    };
+    commandFzfCache.set(commands, entry);
+  }
+  return entry;
+}
+
+function fuzzyRankCommands(
+  commands: CommandInfo[],
+  query: string,
+): CommandInfo[] {
+  try {
+    const { fzf, byName } = getCommandFzf(commands);
+    const matches: CommandInfo[] = [];
+    for (const result of fzf.find(query)) {
+      const command = byName.get(result.item);
+      if (command) matches.push(command);
+    }
+    return matches;
+  } catch {
+    const lp = query.toLowerCase();
+    return commands.filter((command) =>
+      command.name.toLowerCase().includes(lp),
+    );
+  }
+}
+
 export function getSlashCommandCompletionResult(
   text: string,
   cursor: number,
@@ -423,13 +476,15 @@ export function getSlashCommandCompletionResult(
   if (!match) return null;
 
   const prefix = match[1];
-  const lp = prefix.toLowerCase();
-  const filteredCommands = commands
-    .filter((command) => {
-      if (!prefix) return true;
-      return command.name.toLowerCase().includes(lp);
-    })
-    .sort((a, b) => compareSlashCommands(a, b, lp, categoryOrder));
+  // Empty query: browse the full list grouped and ordered by category.
+  // Non-empty query: fuzzy-rank by relevance (best match first), matching the
+  // TUI, so partial or abbreviated input surfaces the command the user means.
+  const isBrowsing = prefix.length === 0;
+  const filteredCommands = isBrowsing
+    ? [...commands].sort((a, b) =>
+        compareSlashCommands(a, b, '', categoryOrder),
+      )
+    : fuzzyRankCommands(commands, prefix);
 
   const items = filteredCommands.map((command): SlashCommandCompletionItem => {
     const apply = `/${command.name} `;
@@ -441,7 +496,12 @@ export function getSlashCommandCompletionResult(
       detail: command.description || undefined,
       apply,
       category,
-      section: translate(COMMAND_SECTION_KEYS[category]),
+      // Section headers only make sense while browsing the category-ordered
+      // list; a relevance-ranked result set interleaves categories, so headers
+      // would appear before nearly every row. Drop them during search.
+      ...(isBrowsing
+        ? { section: translate(COMMAND_SECTION_KEYS[category]) }
+        : {}),
       ...(showCommandInfo && command.description
         ? { type: 'command-info' as const }
         : {}),

--- a/packages/web-shell/client/completions/slashCompletion.ts
+++ b/packages/web-shell/client/completions/slashCompletion.ts
@@ -377,7 +377,11 @@ function fuzzyRankCommands(
       if (command) matches.push(command);
     }
     return matches;
-  } catch {
+  } catch (error) {
+    console.warn(
+      '[web-shell] slash fuzzy search failed, falling back to substring match:',
+      error,
+    );
     const lp = query.toLowerCase();
     return commands.filter((command) =>
       command.name.toLowerCase().includes(lp),

--- a/packages/web-shell/client/components/ChatEditor.module.css
+++ b/packages/web-shell/client/components/ChatEditor.module.css
@@ -181,7 +181,9 @@
 .slashPanel {
   position: fixed;
   z-index: var(--web-shell-popover-z-index, 1000);
-  --slash-panel-max-height: min(calc(12 * (22px + 10px) + 6px + 12px), 40vh);
+  /* Round cap sized for ~12 command rows plus their section headers/dividers,
+     bounded by 45vh so it stays proportional on short viewports. */
+  --slash-panel-max-height: min(460px, 45vh);
   --slash-anchor-width: 620px;
   --slash-command-col: 20ch;
   --slash-desc-col: 32ch;

--- a/packages/web-shell/client/components/ChatEditor.module.css
+++ b/packages/web-shell/client/components/ChatEditor.module.css
@@ -258,12 +258,24 @@
 }
 
 .slashSectionHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
   padding: 4px 8px 2px;
   color: var(--muted-foreground);
   font-size: 11px;
   font-weight: 500;
   letter-spacing: 0.02em;
   user-select: none;
+}
+
+.slashSectionCount {
+  flex: 0 0 auto;
+  color: var(--muted-foreground);
+  font-weight: 400;
+  font-variant-numeric: tabular-nums;
+  opacity: 0.7;
 }
 
 .slashItem {

--- a/packages/web-shell/client/components/ChatEditor.module.css
+++ b/packages/web-shell/client/components/ChatEditor.module.css
@@ -181,12 +181,7 @@
 .slashPanel {
   position: fixed;
   z-index: var(--web-shell-popover-z-index, 1000);
-  --slash-panel-max-height: min(
-    calc(
-      (22px + 10px) + (22px + 10px) + (22px + 10px) + (22px + 10px) + 6px + 12px
-    ),
-    50vh
-  );
+  --slash-panel-max-height: min(calc(12 * (22px + 10px) + 6px + 12px), 40vh);
   --slash-anchor-width: 620px;
   --slash-command-col: 20ch;
   --slash-desc-col: 32ch;
@@ -260,6 +255,15 @@
   height: 1px;
   margin: 5px 8px;
   background: var(--chat-editor-border-color);
+}
+
+.slashSectionHeader {
+  padding: 4px 8px 2px;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  user-select: none;
 }
 
 .slashItem {

--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -31,6 +31,7 @@ import {
   getComposerTagValue,
 } from '../hooks/useComposerCore';
 import { ModeIcon } from './ModeIcon';
+import { planSlashSectionRows } from '../utils/slashSectionPlan';
 import { getModelDisplayName } from '../utils/modelDisplay';
 import { VoiceButton } from '../voice/VoiceButton';
 import styles from './ChatEditor.module.css';
@@ -682,20 +683,9 @@ function SlashCommandPanel({
     '--slash-column-gap': hasDetailColumn ? '2ch' : '0px',
   } as CSSProperties;
 
-  let lastSection: string | undefined;
-  const sectionCounts = new Map<string, number>();
-  if (menu.kind === 'command') {
-    for (const item of menu.items) {
-      if (item.section) {
-        sectionCounts.set(
-          item.section,
-          (sectionCounts.get(item.section) ?? 0) + 1,
-        );
-      }
-    }
-  }
-
   if (!anchorRect) return null;
+
+  const rowPlans = planSlashSectionRows(menu.items, menu.kind);
 
   const positionedPanelStyle = {
     ...panelStyle,
@@ -729,22 +719,19 @@ function SlashCommandPanel({
             onScroll={() => setHoverDetail(null)}
           >
             {menu.items.map((item, index) => {
-              const section = item.section;
-              const showSection =
-                menu.kind === 'command' &&
-                section !== undefined &&
-                section !== lastSection;
-              lastSection = section ?? lastSection;
+              const plan = rowPlans[index];
               return (
                 <div key={`${item.id}:${index}`} className={styles.slashEntry}>
-                  {showSection && (
+                  {plan.showHeader && (
                     <>
-                      {index > 0 && <div className={styles.slashSection} />}
+                      {plan.showDivider && (
+                        <div className={styles.slashSection} />
+                      )}
                       <div className={styles.slashSectionHeader}>
-                        <span>{section}</span>
-                        {section && sectionCounts.get(section) ? (
+                        <span>{item.section}</span>
+                        {plan.count > 0 ? (
                           <span className={styles.slashSectionCount}>
-                            {sectionCounts.get(section)}
+                            {plan.count}
                           </span>
                         ) : null}
                       </div>

--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -683,6 +683,17 @@ function SlashCommandPanel({
   } as CSSProperties;
 
   let lastSection: string | undefined;
+  const sectionCounts = new Map<string, number>();
+  if (menu.kind === 'command') {
+    for (const item of menu.items) {
+      if (item.section) {
+        sectionCounts.set(
+          item.section,
+          (sectionCounts.get(item.section) ?? 0) + 1,
+        );
+      }
+    }
+  }
 
   if (!anchorRect) return null;
 
@@ -729,7 +740,14 @@ function SlashCommandPanel({
                   {showSection && (
                     <>
                       {index > 0 && <div className={styles.slashSection} />}
-                      <div className={styles.slashSectionHeader}>{section}</div>
+                      <div className={styles.slashSectionHeader}>
+                        <span>{section}</span>
+                        {section && sectionCounts.get(section) ? (
+                          <span className={styles.slashSectionCount}>
+                            {sectionCounts.get(section)}
+                          </span>
+                        ) : null}
+                      </div>
                     </>
                   )}
                   <button

--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -721,13 +721,17 @@ function SlashCommandPanel({
               const section = item.section;
               const showSection =
                 menu.kind === 'command' &&
-                index > 0 &&
                 section !== undefined &&
                 section !== lastSection;
               lastSection = section ?? lastSection;
               return (
                 <div key={`${item.id}:${index}`} className={styles.slashEntry}>
-                  {showSection && <div className={styles.slashSection} />}
+                  {showSection && (
+                    <>
+                      {index > 0 && <div className={styles.slashSection} />}
+                      <div className={styles.slashSectionHeader}>{section}</div>
+                    </>
+                  )}
                   <button
                     ref={(node) => {
                       itemRefs.current[index] = node;

--- a/packages/web-shell/client/utils/slashSectionPlan.test.ts
+++ b/packages/web-shell/client/utils/slashSectionPlan.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { planSlashSectionRows } from './slashSectionPlan';
+
+describe('planSlashSectionRows', () => {
+  it('shows a header at each group boundary', () => {
+    const plans = planSlashSectionRows(
+      [
+        { section: 'Custom commands' },
+        { section: 'Custom commands' },
+        { section: 'Skill commands' },
+        { section: 'System commands' },
+      ],
+      'command',
+    );
+    expect(plans.map((p) => p.showHeader)).toEqual([true, false, true, true]);
+  });
+
+  it('shows a header but no divider on the first row', () => {
+    const plans = planSlashSectionRows(
+      [{ section: 'Skill commands' }, { section: 'System commands' }],
+      'command',
+    );
+    expect(plans[0]).toMatchObject({ showHeader: true, showDivider: false });
+    expect(plans[1]).toMatchObject({ showHeader: true, showDivider: true });
+  });
+
+  it('does not repeat headers for adjacent duplicate sections', () => {
+    const plans = planSlashSectionRows(
+      [
+        { section: 'System commands' },
+        { section: 'System commands' },
+        { section: 'System commands' },
+      ],
+      'command',
+    );
+    expect(plans.filter((p) => p.showHeader)).toHaveLength(1);
+  });
+
+  it('reports the number of rows in each section on the header row', () => {
+    const plans = planSlashSectionRows(
+      [
+        { section: 'Skill commands' },
+        { section: 'Skill commands' },
+        { section: 'System commands' },
+      ],
+      'command',
+    );
+    expect(plans[0].count).toBe(2);
+    expect(plans[1].count).toBe(0);
+    expect(plans[2].count).toBe(1);
+  });
+
+  it('never groups subcommand menus', () => {
+    const plans = planSlashSectionRows(
+      [{ section: 'Skill commands' }, { section: 'System commands' }],
+      'subcommand',
+    );
+    expect(plans.every((p) => !p.showHeader && p.count === 0)).toBe(true);
+  });
+
+  it('shows no headers when items carry no section (search results)', () => {
+    const plans = planSlashSectionRows(
+      [{ section: undefined }, { section: undefined }],
+      'command',
+    );
+    expect(plans.every((p) => !p.showHeader)).toBe(true);
+  });
+});

--- a/packages/web-shell/client/utils/slashSectionPlan.ts
+++ b/packages/web-shell/client/utils/slashSectionPlan.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** Per-row rendering plan for the slash command panel's section grouping. */
+export interface SlashSectionRowPlan {
+  /** Render the category header above this row (group boundary). */
+  showHeader: boolean;
+  /** Render the divider above the header (every boundary except the first row). */
+  showDivider: boolean;
+  /** Number of rows in this row's section; 0 when no header is shown. */
+  count: number;
+}
+
+/**
+ * Decide, for each item, whether it starts a new section (and so needs a header,
+ * a divider, and the group count). Extracted as a pure function so the section
+ * boundary logic — headers at group boundaries, a header but no divider on the
+ * first row, and no redundant headers for adjacent duplicate sections — is unit
+ * testable without rendering the panel.
+ *
+ * Only 'command' menus are grouped; subcommand menus render flat (no headers).
+ */
+export function planSlashSectionRows(
+  items: ReadonlyArray<{ section?: string }>,
+  kind: 'command' | 'subcommand',
+): SlashSectionRowPlan[] {
+  const counts = new Map<string, number>();
+  if (kind === 'command') {
+    for (const item of items) {
+      if (item.section) {
+        counts.set(item.section, (counts.get(item.section) ?? 0) + 1);
+      }
+    }
+  }
+
+  let lastSection: string | undefined;
+  return items.map((item, index) => {
+    const section = item.section;
+    const showHeader =
+      kind === 'command' && section !== undefined && section !== lastSection;
+    const showDivider = showHeader && index > 0;
+    lastSection = section ?? lastSection;
+    return {
+      showHeader,
+      showDivider,
+      count: showHeader && section ? (counts.get(section) ?? 0) : 0,
+    };
+  });
+}

--- a/packages/web-shell/package.json
+++ b/packages/web-shell/package.json
@@ -29,6 +29,7 @@
     "@codemirror/view": "^6.35.0",
     "@tanstack/react-virtual": "^3.13.26",
     "codemirror": "^6.0.0",
+    "fzf": "^0.5.2",
     "katex": "^0.16.47",
     "mermaid": "^11.15.0",
     "react-markdown": "^9.0.0",


### PR DESCRIPTION
## What this PR does

Makes the web-shell slash-command menu easy to search and browse when there are many commands. Four changes:

1. **Taller menu** — the popup was capped at exactly four rows; it now shows up to twelve (bounded by 40vh).
2. **Category headers** — the existing custom/skill/system grouping was only a faint 1px divider; each group boundary now renders its category name.
3. **Per-group counts** — each header shows how many commands the group holds (e.g. `Skill commands  28`), so the volume hidden below the fold is visible at a glance.
4. **Fuzzy search** — typing now fuzzy-ranks commands with the same `fzf` engine the TUI already uses, so abbreviated input like `mdl` finds `/model` and `arf` finds `/agent-reproduce-feature`. An empty query keeps the grouped browse list; a non-empty query switches to a flat relevance-ranked list.

## Why it's needed

With built-in commands, project commands, and skills merged together the menu holds 40+ entries (60 in this repo). Only four were ever visible, the grouping was invisible, and matching was plain substring — so `mdl` matched nothing and users had to know a command's exact spelling or scroll a thin list. Fuzzy ranking plus a taller, labeled, counted menu makes commands far easier to find. Fuzzy search also brings the web shell to parity with the TUI, which already uses `fzf` for the same commands.

## Reviewer Test Plan

### How to verify

1. `npm run build --workspace=@qwen-code/qwen-code-core`, then from the repo root: `node packages/cli/dist/index.js serve --web --port 18811` (cwd determines which project/skill commands load).
2. Open the web UI, click the composer, type `/`.
   - Expected: ~9–12 rows depending on window height (was 4), with **Custom / Skill / System commands** headers, each showing its command count.
3. Type an abbreviation that is **not** a substring, e.g. `/mdl`, `/arf`, `/thm`.
   - Expected: `/model`, `/agent-reproduce-feature`, `/theme` respectively surface — plain substring matching returns nothing for these.

Verified locally against a real `qwen serve --web` binary with Playwright: browse shows 60 commands grouped as `Skill commands 28` / `System commands 32`; `/mdl`→`/model`, `/thm`→`/theme`, `/arf` includes `/agent-reproduce-feature` — all fuzzy-only matches with no console errors. Unit tests (`slashCompletion.test.ts` +2 fuzzy cases, 21 total; full web-shell suite 739 passed), prettier, eslint, and `tsc -p tsconfig.lib.json` (0 errors) all pass. The fzf index is built once per command set and falls back to substring filtering on error.

### Evidence (Before & After)

**Before** — capped at 4 rows, no labels, substring-only:

![before](https://raw.githubusercontent.com/wenshao/qwen-code/pr-assets/slash-menu/docs/assets/slash-before.png)

**After — browse** — up to 12 rows, category headers with counts:

![browse](https://raw.githubusercontent.com/wenshao/qwen-code/pr-assets/slash-menu/docs/assets/slash-browse-tall.png)

**After — fuzzy `/mdl`** — abbreviation (not a substring) finds `/model`:

![fuzzy-mdl](https://raw.githubusercontent.com/wenshao/qwen-code/pr-assets/slash-menu/docs/assets/slash-fuzzy-mdl.png)

**After — fuzzy `/arf`** — finds `/agent-reproduce-feature`:

![fuzzy-arf](https://raw.githubusercontent.com/wenshao/qwen-code/pr-assets/slash-menu/docs/assets/slash-fuzzy-arf.png)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS, `qwen serve --web` with an isolated HOME; Playwright (headless Chromium) for screenshots and DOM assertions.

## Risk & Scope

- Main risk or tradeoff: adds `fzf` (^0.5.2, already a `packages/cli` dependency, pure-JS, browser-safe) to `packages/web-shell`. Fuzzy ranking changes result ordering for non-empty queries from category-first to relevance-first — intentional and matching the TUI.
- Not validated / out of scope: Windows/Linux rendering (CSS is platform-independent). The dead `slashCompletionSource` CodeMirror source (not wired into the live editor) still does substring filtering; only the live `getSlashCommandCompletionResult` path gained fuzzy — noted in a code comment.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 web-shell 的斜杠命令菜单在命令很多时更好搜索和浏览。四项改动:

1. **加高菜单** —— 弹层原本封顶 4 行,现在最多 12 行(上限 40vh)。
2. **分类标题** —— 已有的自定义/Skill/系统分组此前只是一条 1px 分隔线,现在每个分组边界渲染分类名。
3. **分组计数** —— 每个标题显示该组命令数(如 `Skill commands  28`),一眼看出折叠线下藏了多少。
4. **模糊搜索** —— 输入时用 TUI 已在用的 `fzf` 引擎做模糊排序,所以缩写 `mdl` 能找到 `/model`、`arf` 能找到 `/agent-reproduce-feature`。空查询保持分组浏览列表,非空查询切换为按相关度排序的扁平列表。

## 为什么需要

内置命令、项目命令、skill 合并后菜单有 40+ 条(本仓库 60 条)。此前只露 4 条、分组不可见、匹配是纯子串——`mdl` 匹配不到任何东西,用户得知道命令确切拼写或滚动细列表。模糊排序 + 更高/带标题/带计数的菜单让命令好找得多。模糊搜索也让 Web Shell 与 TUI 对齐(TUI 对同一批命令早已用 `fzf`)。

## 复现与验证

1. `npm run build --workspace=@qwen-code/qwen-code-core`,然后仓库根目录:`node packages/cli/dist/index.js serve --web --port 18811`(cwd 决定加载哪些项目命令/skill)。
2. 打开 Web UI,点输入框,输入 `/`:预期随窗口高度显示约 9–12 行(原 4 行),带 **自定义 / Skill / 系统** 标题,每个标题显示命令数。
3. 输入**非子串**的缩写,如 `/mdl`、`/arf`、`/thm`:预期分别浮现 `/model`、`/agent-reproduce-feature`、`/theme`——纯子串匹配对这些返回空。

已用真实 `qwen serve --web` 二进制 + Playwright 本地验证:浏览显示 60 条命令,分组为 `Skill commands 28` / `System commands 32`;`/mdl`→`/model`、`/thm`→`/theme`、`/arf` 含 `/agent-reproduce-feature`——全是纯模糊命中且无 console 报错。单测(`slashCompletion.test.ts` 新增 2 个模糊用例、共 21;完整 web-shell 套件 739 通过)、prettier、eslint、`tsc -p tsconfig.lib.json`(0 错误)全过。fzf 索引按命令集构建一次,失败时回退子串过滤。

## 风险与范围

- 主要风险/取舍:给 `packages/web-shell` 增加 `fzf`(^0.5.2,已是 `packages/cli` 依赖,纯 JS、浏览器安全)。模糊排序把非空查询的结果顺序从"分类优先"改为"相关度优先"——有意为之,且与 TUI 一致。
- 未验证/超范围:Windows/Linux 渲染(CSS 与平台无关)。死代码 `slashCompletionSource`(CodeMirror 源,未接入实际编辑器)仍用子串;只有活路径 `getSlashCommandCompletionResult` 加了模糊——已在代码注释中说明。
- 破坏性变更/迁移说明:无。

</details>

