### PR TITLE
feat(core): proxy-tool approach for KV-cache preservation on tool_search

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2414,24 +2414,15 @@ export class Config {
     this.mcpDiscoveryPromise = manager
       .discoverAllMcpToolsIncremental(this)
       .then(async () => {
-        // After background discovery completes, push the newly-registered
-        // MCP tools into the active GeminiChat so the next model request
-        // sees both the updated declarations and added-tool reminder deltas.
-        // Interactive mode also calls setTools() via AppContainer's
-        // batch-flush effect — this trailing call is idempotent there, but
-        // it's the ONLY path that updates `chat.tools` for non-interactive
-        // runs (no AppContainer).
-        // Without this, `chat.tools` would be frozen at the built-in-only
-        // snapshot taken inside `geminiClient.initialize()` → `startChat()`,
-        // and `runNonInteractive` / stream-json / ACP would silently lose
-        // progressive MCP tools — a regression vs the legacy synchronous path.
-        try {
-          await this.geminiClient?.setTools();
-        } catch (err) {
-          this.debugLogger.error(
-            `setTools() after background MCP discovery failed: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
+        // Background MCP discovery completes — tools are registered in the
+        // ToolRegistry. Under the proxy-tool approach (KV-cache
+        // preservation), we do NOT call setTools() here. The `dispatch`
+        // proxy tool is already in the stable API declaration list, and
+        // discovered tools are invoked via dispatch({tool:"...",
+        // args:{...}}) — the model learns about them through ToolSearch
+        // results and the per-turn "added MCP tools" reminder. Calling
+        // setTools() would change the request prefix and bust the
+        // KV-cache.
       })
       .catch((err: unknown) => {
         this.debugLogger.error(
@@ -6020,6 +6011,13 @@ export class Config {
     }
 
     // --- Core tools (always registered) ---
+    // Dispatch is the universal proxy-tool for invoking any discovered tool
+    // by name. It is always in the API tool list so the request prefix never
+    // changes — preserving the LLM server's KV-cache.
+    await registerLazy(ToolNames.DISPATCH, async () => {
+      const { DispatchTool } = await import('../tools/dispatch.js');
+      return new DispatchTool(this);
+    });
     await registerLazy(ToolNames.TOOL_SEARCH, async () => {
       const { ToolSearchTool } = await import('../tools/tool-search.js');
       return new ToolSearchTool(this);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -185,6 +185,7 @@ export type { CronCreateTool, CronCreateParams } from './tools/cron-create.js';
 export type { CronListTool, CronListParams } from './tools/cron-list.js';
 export type { CronDeleteTool, CronDeleteParams } from './tools/cron-delete.js';
 export type { ToolSearchTool, ToolSearchParams } from './tools/tool-search.js';
+export type { DispatchTool, DispatchParams } from './tools/dispatch.js';
 export type {
   TeamPlanApprovalTool,
   TeamPlanApprovalParams,

--- a/packages/core/src/tools/dispatch.test.ts
+++ b/packages/core/src/tools/dispatch.test.ts
@@ -1,0 +1,166 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ConfigParameters } from '../config/config.js';
+import { Config, ApprovalMode } from '../config/config.js';
+import { ToolRegistry } from './tool-registry.js';
+import { MockTool } from '../test-utils/mock-tool.js';
+import { DispatchTool } from './dispatch.js';
+import type { ToolResult } from './tools.js';
+
+const baseConfigParams: ConfigParameters = {
+  cwd: '/tmp',
+  model: 'test-model',
+  embeddingModel: 'test-embedding-model',
+  sandbox: undefined,
+  targetDir: '/test/dir',
+  debugMode: false,
+  userMemory: '',
+  geminiMdFileCount: 0,
+  approvalMode: ApprovalMode.DEFAULT,
+};
+
+function makeConfigWithRegistry(): {
+  config: Config;
+  registry: ToolRegistry;
+} {
+  const config = new Config(baseConfigParams);
+  const registry = new ToolRegistry(config);
+  vi.spyOn(config, 'getToolRegistry').mockReturnValue(registry);
+  return { config, registry };
+}
+
+describe('DispatchTool', () => {
+  let config: Config;
+  let registry: ToolRegistry;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ({ config, registry } = makeConfigWithRegistry());
+  });
+
+  it('has correct name and alwaysLoad', () => {
+    expect(DispatchTool.Name).toBe('dispatch');
+    const tool = new DispatchTool(config);
+    expect(tool.alwaysLoad).toBe(true);
+  });
+
+  it('dispatches to a registered tool and returns result', async () => {
+    const mockResult = {
+      returnDisplay: 'target_result',
+      llmContent: 'target_content',
+    } as ToolResult;
+    registry.registerTool(
+      new MockTool({
+        name: 'target_tool',
+        execute: () => Promise.resolve(mockResult),
+      }),
+    );
+    const tool = new DispatchTool(config);
+    const result = await tool
+      .build({ tool: 'target_tool', args: { key: 'value' } })
+      .execute(new AbortController().signal);
+
+    expect(result.returnDisplay).toBe('target_result');
+    expect(result.llmContent).toBe('target_content');
+    expect(result.error).toBeUndefined();
+  });
+
+  it('rejects empty string tool name', async () => {
+    const tool = new DispatchTool(config);
+    const result = await tool
+      .build({ tool: '', args: {} })
+      .execute(new AbortController().signal);
+
+    expect(result.llmContent).toContain(
+      'Error: "tool" must be a non-empty string',
+    );
+    expect(result.returnDisplay).toBe('Invalid tool name');
+    expect(result.error?.message).toBe('"tool" must be a non-empty string');
+  });
+
+  it('blocks recursive dispatch of itself', async () => {
+    const tool = new DispatchTool(config);
+    const result = await tool
+      .build({ tool: 'dispatch', args: {} })
+      .execute(new AbortController().signal);
+
+    expect(result.llmContent).toContain('cannot dispatch "dispatch"');
+    expect(result.returnDisplay).toBe('Recursive dispatch blocked');
+    expect(result.error?.message).toBe('Recursive dispatch blocked');
+  });
+
+  it('returns error when tool is not found in registry', async () => {
+    const tool = new DispatchTool(config);
+    const result = await tool
+      .build({ tool: 'nonexistent_tool', args: {} })
+      .execute(new AbortController().signal);
+
+    expect(result.llmContent).toContain(
+      'no tool named "nonexistent_tool" is registered',
+    );
+    expect(result.returnDisplay).toBe('Unknown tool: nonexistent_tool');
+  });
+
+  it('returns error and logs when ensureTool throws', async () => {
+    const realEnsure = registry.ensureTool.bind(registry);
+    vi.spyOn(registry, 'ensureTool').mockImplementation(async (name) => {
+      if (name === 'broken_tool') throw new Error('factory failure');
+      return realEnsure(name);
+    });
+
+    const dispatchTool = new DispatchTool(config);
+    const result = await dispatchTool
+      .build({ tool: 'broken_tool', args: {} })
+      .execute(new AbortController().signal);
+
+    expect(result.llmContent).toContain('ensureTool("broken_tool") threw');
+    expect(result.llmContent).toContain('factory failure');
+    expect(result.returnDisplay).toBe('ensureTool failed: broken_tool');
+  });
+
+  it('returns error when target tool execution fails', async () => {
+    registry.registerTool(
+      new MockTool({
+        name: 'failing_tool',
+        execute: () => Promise.reject(new Error('target execution error')),
+      }),
+    );
+    const dispatchTool = new DispatchTool(config);
+    const result = await dispatchTool
+      .build({ tool: 'failing_tool', args: {} })
+      .execute(new AbortController().signal);
+
+    expect(result.llmContent).toContain('tool "failing_tool" execution failed');
+    expect(result.llmContent).toContain('target execution error');
+    expect(result.error?.message).toContain(
+      'Tool "failing_tool" execution failed',
+    );
+  });
+
+  it('forwards args to target tool', async () => {
+    let capturedArgs: Record<string, unknown> | undefined;
+    const inputArgs = { foo: 'bar', nested: { x: 1 } };
+
+    registry.registerTool(
+      new MockTool({
+        name: 'args_forwarder',
+        execute: (params) => {
+          capturedArgs = params;
+          return Promise.resolve({ returnDisplay: 'ok', llmContent: 'ok' });
+        },
+      }),
+    );
+
+    const dispatchTool = new DispatchTool(config);
+    await dispatchTool
+      .build({ tool: 'args_forwarder', args: inputArgs })
+      .execute(new AbortController().signal);
+
+    expect(capturedArgs).toEqual(inputArgs);
+  });
+});

--- a/packages/core/src/tools/dispatch.test.ts
+++ b/packages/core/src/tools/dispatch.test.ts
@@ -11,6 +11,7 @@ import { ToolRegistry } from './tool-registry.js';
 import { MockTool } from '../test-utils/mock-tool.js';
 import { DispatchTool } from './dispatch.js';
 import type { ToolResult } from './tools.js';
+import { Kind } from './tools.js';
 
 const baseConfigParams: ConfigParameters = {
   cwd: '/tmp',
@@ -162,5 +163,74 @@ describe('DispatchTool', () => {
       .execute(new AbortController().signal);
 
     expect(capturedArgs).toEqual(inputArgs);
+  });
+
+  it('denies dispatch when target tool has default deny permission', async () => {
+    registry.registerTool(
+      new MockTool({
+        name: 'denied_tool',
+        getDefaultPermission: () => Promise.resolve('deny'),
+      }),
+    );
+    const dispatchTool = new DispatchTool(config);
+    const result = await dispatchTool
+      .build({ tool: 'denied_tool', args: {} })
+      .execute(new AbortController().signal);
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe('execution_denied');
+    expect(result.llmContent).toContain('is denied');
+  });
+
+  it('blocks Kind.Edit tool in plan mode', async () => {
+    const planConfig = new Config({
+      ...baseConfigParams,
+      approvalMode: ApprovalMode.PLAN,
+    });
+    const planRegistry = new ToolRegistry(planConfig);
+    vi.spyOn(planConfig, 'getToolRegistry').mockReturnValue(planRegistry);
+
+    planRegistry.registerTool(
+      new MockTool({
+        name: 'editor',
+        kind: Kind.Edit,
+        getDefaultPermission: () => Promise.resolve('allow'),
+        getConfirmationDetails: () =>
+          Promise.resolve({
+            type: 'edit',
+            title: 'Edit',
+            prompt: 'edit file',
+            onConfirm: async () => {},
+          }),
+      }),
+    );
+    const dispatchTool = new DispatchTool(planConfig);
+    const result = await dispatchTool
+      .build({ tool: 'editor', args: {} })
+      .execute(new AbortController().signal);
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe('execution_denied');
+    expect(result.returnDisplay).toContain('Plan mode blocked');
+  });
+
+  it('returns invalid-params error when target tool build throws', async () => {
+    registry.registerTool(
+      new MockTool({
+        name: 'strict_tool',
+        params: {
+          type: 'object',
+          properties: { required_param: { type: 'string' } },
+          required: ['required_param'],
+        },
+      }),
+    );
+    const dispatchTool = new DispatchTool(config);
+    const result = await dispatchTool
+      .build({ tool: 'strict_tool', args: {} })
+      .execute(new AbortController().signal);
+
+    expect(result.error?.type).toBe('invalid_tool_params');
+    expect(result.llmContent).toContain('invalid args');
   });
 });

--- a/packages/core/src/tools/dispatch.ts
+++ b/packages/core/src/tools/dispatch.ts
@@ -1,0 +1,146 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Dispatch — universal proxy-tool that lets the model invoke any discovered
+ * tool by name without the API needing that tool's schema in the initial
+ * function-declaration list.
+ *
+ * This is the core of the "proxy-tool approach" for KV-cache preservation:
+ *   - The `dispatch` tool is registered once at startup with `alwaysLoad: true`
+ *     so it is always in config.tools[] and never changes.
+ *   - ToolSearch no longer calls `setTools()` / `revealDeferredTool()` —
+ *     instead it returns a `<functions>` block with the discovered schema
+ *     and instructs the model to call `dispatch({tool: "name", args: {...}})`.
+ *   - The `dispatch` executor looks up the real tool via ToolRegistry,
+ *     invokes it with the forwarded args, and returns the result.
+ *
+ * This keeps the API-level tool list stable (core tools + dispatch), so the
+ * Gemini API request prefix never changes and the KV-cache is preserved.
+ */
+
+import type { ToolInvocation, ToolResult } from './tools.js';
+import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
+import type { Config } from '../config/config.js';
+import type { AnyDeclarativeTool } from './tools.js';
+
+export interface DispatchParams {
+  /** Name of the target tool to invoke (e.g. "read_file", "mcp__server__some_tool"). */
+  tool: string;
+  /** Arguments to forward to the target tool, keyed by its parameter names. */
+  args: Record<string, unknown>;
+}
+
+const DISPATCH_DESCRIPTION =
+  'Invokes any tool by name with the specified arguments. Use this to call tools discovered via ToolSearch. The target tool must have been previously loaded — use ToolSearch with `select:<name>` to discover the schema first, then call `dispatch` with the tool name and its parameters.';
+
+class DispatchInvocation extends BaseToolInvocation<
+  DispatchParams,
+  ToolResult
+> {
+  constructor(
+    private readonly config: Config,
+    params: DispatchParams,
+  ) {
+    super(params);
+  }
+
+  getDescription(): string {
+    return `dispatch(tool="${this.params.tool}", args=${JSON.stringify(this.params.args)})`;
+  }
+
+  async execute(_signal: AbortSignal): Promise<ToolResult> {
+    const toolName = this.params.tool;
+    if (!toolName || typeof toolName !== 'string') {
+      return {
+        llmContent: 'Error: "tool" must be a non-empty string.',
+        returnDisplay: 'Invalid tool name',
+        error: { message: '"tool" must be a non-empty string' },
+      };
+    }
+
+    const registry = this.config.getToolRegistry();
+
+    // Look up the tool by name — may resolve a lazy factory.
+    let tool: AnyDeclarativeTool | undefined;
+    try {
+      tool = await registry.ensureTool(toolName);
+    } catch (err) {
+      return {
+        llmContent: `Error: ensureTool("${toolName}") threw: ${err instanceof Error ? err.message : String(err)}`,
+        returnDisplay: `ensureTool failed: ${toolName}`,
+        error: {
+          message: `ensureTool failed for "${toolName}": ${err instanceof Error ? err.message : String(err)}`,
+        },
+      };
+    }
+
+    if (!tool) {
+      return {
+        llmContent: `Error: no tool named "${toolName}" is registered. Use ToolSearch to discover available tools.`,
+        returnDisplay: `Unknown tool: ${toolName}`,
+        error: { message: `Unknown tool: ${toolName}` },
+      };
+    }
+
+    // Execute the target tool with forwarded args.
+    try {
+      const invocation = tool.build(this.params.args);
+      return await invocation.execute(_signal);
+    } catch (err) {
+      return {
+        llmContent: `Error: tool "${toolName}" execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        returnDisplay: `Execution failed: ${toolName}`,
+        error: {
+          message: `Tool "${toolName}" execution failed: ${err instanceof Error ? err.message : String(err)}`,
+        },
+      };
+    }
+  }
+}
+
+export class DispatchTool extends BaseDeclarativeTool<
+  DispatchParams,
+  ToolResult
+> {
+  static readonly Name = 'dispatch';
+
+  constructor(private readonly config: Config) {
+    super(
+      DispatchTool.Name,
+      'Dispatch',
+      DISPATCH_DESCRIPTION,
+      Kind.Other,
+      {
+        type: 'object',
+        properties: {
+          tool: {
+            type: 'string',
+            description: 'Name of the target tool to invoke.',
+          },
+          args: {
+            type: 'object',
+            description:
+              'Arguments to forward to the target tool, keyed by its parameter names.',
+          },
+        },
+        required: ['tool', 'args'],
+        additionalProperties: false,
+      },
+      true, // isOutputMarkdown
+      false, // canUpdateOutput
+      false, // shouldDefer
+      true, // alwaysLoad — dispatch is always in the API tool list
+      'invoke call run execute proxy',
+    );
+  }
+
+  protected createInvocation(
+    params: DispatchParams,
+  ): ToolInvocation<DispatchParams, ToolResult> {
+    return new DispatchInvocation(this.config, params);
+  }
+}

--- a/packages/core/src/tools/dispatch.ts
+++ b/packages/core/src/tools/dispatch.ts
@@ -52,13 +52,25 @@ class DispatchInvocation extends BaseToolInvocation<
     return `dispatch(tool="${this.params.tool}", args=${JSON.stringify(this.params.args)})`;
   }
 
-  async execute(_signal: AbortSignal): Promise<ToolResult> {
+  async execute(signal: AbortSignal): Promise<ToolResult> {
     const toolName = this.params.tool;
     if (!toolName || typeof toolName !== 'string') {
       return {
         llmContent: 'Error: "tool" must be a non-empty string.',
         returnDisplay: 'Invalid tool name',
         error: { message: '"tool" must be a non-empty string' },
+      };
+    }
+
+    // Guard against recursive self-dispatch — dispatch is registered in the
+    // tool registry, so a call like dispatch({tool: "dispatch", ...}) would
+    // create unbounded recursion and stack overflow.
+    if (toolName === DispatchTool.Name) {
+      return {
+        llmContent:
+          'Error: cannot dispatch "dispatch" — recursive dispatch is not allowed.',
+        returnDisplay: 'Recursive dispatch blocked',
+        error: { message: 'Recursive dispatch blocked' },
       };
     }
 
@@ -69,6 +81,9 @@ class DispatchInvocation extends BaseToolInvocation<
     try {
       tool = await registry.ensureTool(toolName);
     } catch (err) {
+      process.stderr.write(
+        `[dispatch] ensureTool("${toolName}") failed: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
       return {
         llmContent: `Error: ensureTool("${toolName}") threw: ${err instanceof Error ? err.message : String(err)}`,
         returnDisplay: `ensureTool failed: ${toolName}`,
@@ -79,6 +94,9 @@ class DispatchInvocation extends BaseToolInvocation<
     }
 
     if (!tool) {
+      process.stderr.write(
+        `[dispatch] tool "${toolName}" not found in registry\n`,
+      );
       return {
         llmContent: `Error: no tool named "${toolName}" is registered. Use ToolSearch to discover available tools.`,
         returnDisplay: `Unknown tool: ${toolName}`,
@@ -89,8 +107,11 @@ class DispatchInvocation extends BaseToolInvocation<
     // Execute the target tool with forwarded args.
     try {
       const invocation = tool.build(this.params.args);
-      return await invocation.execute(_signal);
+      return await invocation.execute(signal);
     } catch (err) {
+      process.stderr.write(
+        `[dispatch] tool "${toolName}" execution failed: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
       return {
         llmContent: `Error: tool "${toolName}" execution failed: ${err instanceof Error ? err.message : String(err)}`,
         returnDisplay: `Execution failed: ${toolName}`,

--- a/packages/core/src/tools/dispatch.ts
+++ b/packages/core/src/tools/dispatch.ts
@@ -24,8 +24,14 @@
 
 import type { ToolInvocation, ToolResult } from './tools.js';
 import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
+import { ToolErrorType } from './tool-error.js';
 import type { Config } from '../config/config.js';
-import type { AnyDeclarativeTool } from './tools.js';
+import { ApprovalMode } from '../config/config.js';
+import type { AnyDeclarativeTool, AnyToolInvocation } from './tools.js';
+import {
+  evaluatePermissionFlow,
+  isPlanModeBlocked,
+} from '../core/permissionFlow.js';
 
 export interface DispatchParams {
   /** Name of the target tool to invoke (e.g. "read_file", "mcp__server__some_tool"). */
@@ -104,10 +110,78 @@ class DispatchInvocation extends BaseToolInvocation<
       };
     }
 
+    // Build the target invocation.
+    let targetInvocation: AnyToolInvocation;
+    try {
+      targetInvocation = tool.build(this.params.args);
+    } catch (err) {
+      return {
+        llmContent: `Error: invalid args for tool "${toolName}": ${err instanceof Error ? err.message : String(err)}`,
+        returnDisplay: `Invalid args: ${toolName}`,
+        error: {
+          message: `Invalid args for "${toolName}": ${err instanceof Error ? err.message : String(err)}`,
+          type: ToolErrorType.INVALID_TOOL_PARAMS,
+        },
+      };
+    }
+
+    // --- Permission check: resolve against the REAL tool, not dispatch ---
+    const flowResult = await evaluatePermissionFlow(
+      this.config,
+      targetInvocation,
+      toolName,
+      this.params.args,
+    );
+
+    if (flowResult.finalPermission === 'deny') {
+      return {
+        llmContent: flowResult.denyMessage ?? `Tool "${toolName}" is denied.`,
+        returnDisplay: `Permission denied: ${toolName}`,
+        error: {
+          message: flowResult.denyMessage ?? `Tool "${toolName}" is denied.`,
+          type: ToolErrorType.EXECUTION_DENIED,
+        },
+      };
+    }
+
+    // --- Plan-mode check: use the REAL tool's confirmation details ---
+    const approvalMode = this.config.getApprovalMode();
+    if (approvalMode === ApprovalMode.PLAN) {
+      const confirmationDetails =
+        await targetInvocation.getConfirmationDetails(signal);
+      if (isPlanModeBlocked(true, false, false, confirmationDetails, false)) {
+        return {
+          llmContent: `Tool "${toolName}" is blocked in plan mode.`,
+          returnDisplay: `Plan mode blocked: ${toolName}`,
+          error: {
+            message: `Tool "${toolName}" is blocked in plan mode.`,
+            type: ToolErrorType.EXECUTION_DENIED,
+          },
+        };
+      }
+    }
+
+    // --- Ask handling ---
+    if (flowResult.finalPermission === 'ask') {
+      if (approvalMode === ApprovalMode.YOLO) {
+        // YOLO: auto-approve tools that would normally ask.
+      } else if (!this.config.isInteractive()) {
+        return {
+          llmContent: `Qwen Code requires permission to use "${toolName}", but that permission was declined (non-interactive mode cannot prompt for confirmation).`,
+          returnDisplay: `Non-interactive deny: ${toolName}`,
+          error: {
+            message: `Non-interactive deny: ${toolName}`,
+            type: ToolErrorType.EXECUTION_DENIED,
+          },
+        };
+      }
+      // Interactive mode: dispatch was already confirmed by the user,
+      // proceed to the inner tool without re-prompting.
+    }
+
     // Execute the target tool with forwarded args.
     try {
-      const invocation = tool.build(this.params.args);
-      return await invocation.execute(signal);
+      return await targetInvocation.execute(signal);
     } catch (err) {
       process.stderr.write(
         `[dispatch] tool "${toolName}" execution failed: ${err instanceof Error ? err.message : String(err)}\n`,
@@ -117,6 +191,7 @@ class DispatchInvocation extends BaseToolInvocation<
         returnDisplay: `Execution failed: ${toolName}`,
         error: {
           message: `Tool "${toolName}" execution failed: ${err instanceof Error ? err.message : String(err)}`,
+          type: ToolErrorType.EXECUTION_FAILED,
         },
       };
     }

--- a/packages/core/src/tools/tool-names.ts
+++ b/packages/core/src/tools/tool-names.ts
@@ -62,6 +62,7 @@ export const ToolNames = {
   WORKFLOW: 'workflow',
   ARTIFACT: 'artifact',
   RECORD_ARTIFACT: 'record_artifact',
+  DISPATCH: 'dispatch',
 } as const;
 
 /**
@@ -109,6 +110,7 @@ export const ToolDisplayNames = {
   WORKFLOW: 'Workflow',
   ARTIFACT: 'Artifact',
   RECORD_ARTIFACT: 'RecordArtifact',
+  DISPATCH: 'Dispatch',
 } as const;
 
 // Migration from old tool names to new tool names

--- a/packages/core/src/tools/tool-names.ts
+++ b/packages/core/src/tools/tool-names.ts
@@ -63,6 +63,7 @@ export const ToolNames = {
   ARTIFACT: 'artifact',
   RECORD_ARTIFACT: 'record_artifact',
   DISPATCH: 'dispatch',
+  RECORD_ARTIFACT: 'record_artifact',
 } as const;
 
 /**
@@ -111,6 +112,7 @@ export const ToolDisplayNames = {
   ARTIFACT: 'Artifact',
   RECORD_ARTIFACT: 'RecordArtifact',
   DISPATCH: 'Dispatch',
+  RECORD_ARTIFACT: 'RecordArtifact',
 } as const;
 
 // Migration from old tool names to new tool names

--- a/packages/core/src/tools/tool-names.ts
+++ b/packages/core/src/tools/tool-names.ts
@@ -63,7 +63,6 @@ export const ToolNames = {
   ARTIFACT: 'artifact',
   RECORD_ARTIFACT: 'record_artifact',
   DISPATCH: 'dispatch',
-  RECORD_ARTIFACT: 'record_artifact',
 } as const;
 
 /**
@@ -112,7 +111,6 @@ export const ToolDisplayNames = {
   ARTIFACT: 'Artifact',
   RECORD_ARTIFACT: 'RecordArtifact',
   DISPATCH: 'Dispatch',
-  RECORD_ARTIFACT: 'RecordArtifact',
 } as const;
 
 // Migration from old tool names to new tool names

--- a/packages/core/src/tools/tool-search.test.ts
+++ b/packages/core/src/tools/tool-search.test.ts
@@ -191,7 +191,7 @@ describe('ToolSearchTool', () => {
     expect(tool.shouldDefer).toBe(false);
   });
 
-  it('select: mode loads named tool and reveals it', async () => {
+  it('select: mode loads named tool and returns schema', async () => {
     const hidden = new MockTool({
       name: 'cron_create',
       description: 'schedules a cron',
@@ -206,7 +206,9 @@ describe('ToolSearchTool', () => {
     const content = String(result.llmContent);
     expect(content).toContain('<functions>');
     expect(content).toContain('"name":"cron_create"');
-    expect(registry.isDeferredToolRevealed('cron_create')).toBe(true);
+    // Proxy-tool approach: ToolSearch returns schema in <functions> block
+    // without calling revealDeferredTool — dispatch proxy handles invocation.
+    expect(registry.isDeferredToolRevealed('cron_create')).toBe(false);
   });
 
   it('escapes `<` in schema JSON so embedded </function> cannot close the wrapper', async () => {
@@ -249,8 +251,9 @@ describe('ToolSearchTool', () => {
     expect(content).toContain('"name":"alpha"');
     expect(content).toContain('"name":"bravo"');
     expect(content).toContain('Not found: missing');
-    expect(registry.isDeferredToolRevealed('alpha')).toBe(true);
-    expect(registry.isDeferredToolRevealed('bravo')).toBe(true);
+    // Proxy-tool approach: no revealDeferredTool calls.
+    expect(registry.isDeferredToolRevealed('alpha')).toBe(false);
+    expect(registry.isDeferredToolRevealed('bravo')).toBe(false);
   });
 
   it('keyword search returns top-N ranked tools', async () => {
@@ -437,7 +440,7 @@ describe('ToolSearchTool', () => {
     expect(truncatedSection).not.toContain('tool_0');
   });
 
-  it('revealed tools show up in subsequent getFunctionDeclarations', async () => {
+  it('proxy-tool approach: ToolSearch does not modify function declarations', async () => {
     registry.registerTool(new MockTool({ name: 'visible' }));
     registry.registerTool(new MockTool({ name: 'hidden', shouldDefer: true }));
 
@@ -450,13 +453,12 @@ describe('ToolSearchTool', () => {
     const invocation = tool.build({ query: 'select:hidden' });
     await invocation.execute(new AbortController().signal);
 
-    // After search: hidden joins the declaration list.
-    expect(
-      registry
-        .getFunctionDeclarations()
-        .map((d) => d.name)
-        .sort(),
-    ).toEqual(['hidden', 'visible']);
+    // Proxy-tool approach: declarations list is unchanged — ToolSearch
+    // returns the schema in a <functions> block and the model invokes
+    // via dispatch. The API-level tool list stays stable.
+    expect(registry.getFunctionDeclarations().map((d) => d.name)).toEqual([
+      'visible',
+    ]);
   });
 
   it('rejects empty query at build time via schema (minLength)', () => {
@@ -824,11 +826,10 @@ describe('ToolSearchTool', () => {
     expect(String(sq.llmContent)).toContain('"name":"cron_create"');
   });
 
-  it('keyword search excludes already-revealed deferred tools', async () => {
-    // Pin: once a deferred tool is revealed via a prior `select:` lookup,
-    // it should no longer appear in subsequent keyword searches — it's
-    // already in the model's declaration list, re-surfacing wastes
-    // tokens and risks the model thinking it needs to load it again.
+  it('keyword search finds tools regardless of prior lookups', async () => {
+    // Proxy-tool approach: ToolSearch never reveals tools (no
+    // revealDeferredTool call), so the same keyword search still
+    // finds the tool on subsequent invocations.
     registry.registerTool(
       new MockTool({
         name: 'slack_send_message',
@@ -840,14 +841,13 @@ describe('ToolSearchTool', () => {
 
     const tool = new ToolSearchTool(config);
 
-    // First: keyword search reveals the tool.
+    // First: keyword search finds the tool.
     const first = await tool
       .build({ query: 'slack' })
       .execute(new AbortController().signal);
     expect(String(first.llmContent)).toContain('"name":"slack_send_message"');
-    // First search uses keyword path (which calls loadAndReturnSchemas →
-    // revealDeferredTool); confirm registry agrees.
-    expect(registry.isDeferredToolRevealed('slack_send_message')).toBe(true);
+    // Proxy-tool approach: no revealDeferredTool call.
+    expect(registry.isDeferredToolRevealed('slack_send_message')).toBe(false);
     // refreshStartupContextReminder() is intentionally skipped to preserve
     // KV-cache — deferred-tools lives at the tail of the system-reminder.
     const geminiClient = config.getGeminiClient() as unknown as {
@@ -855,43 +855,18 @@ describe('ToolSearchTool', () => {
     };
     expect(geminiClient.refreshStartupContextReminder).toHaveBeenCalledTimes(0);
 
-    // Second: same keyword search now finds nothing (tool excluded).
+    // Second: same keyword search still finds the tool (never revealed).
     const second = await tool
       .build({ query: 'slack' })
       .execute(new AbortController().signal);
-    expect(String(second.llmContent)).toContain('No tools found matching');
+    expect(String(second.llmContent)).toContain('"name":"slack_send_message"');
     expect(geminiClient.refreshStartupContextReminder).toHaveBeenCalledTimes(0);
   });
 
-  it('returns an error result when setTools() throws — model must NOT see schemas as ready', async () => {
-    // Pin: setTools() sync-failure during reveal is surfaced as a tool
-    // error so the agent can choose to retry / abandon, instead of being
-    // told "tools loaded" while the API actually has no declarations
-    // (which would surface as "unknown tool" on the next call).
-    registry.registerTool(
-      new MockTool({
-        name: 'cron_create',
-        shouldDefer: true,
-      }),
-    );
-    vi.spyOn(config, 'getGeminiClient').mockReturnValue({
-      setTools: vi.fn().mockRejectedValue(new Error('chat not initialised')),
-    } as never);
-
-    const tool = new ToolSearchTool(config);
-    const result = await tool
-      .build({ query: 'select:cron_create' })
-      .execute(new AbortController().signal);
-
-    expect(result.error).toBeDefined();
-    expect(result.error?.message).toContain('setTools failed');
-    expect(result.error?.message).toContain('chat not initialised');
-    // Critical: the schema MUST NOT be in llmContent — otherwise the
-    // model thinks the tool is callable and the next turn surfaces
-    // an "unknown tool" API error.
-    expect(String(result.llmContent)).not.toContain('"name":"cron_create"');
-    expect(String(result.llmContent)).toContain('setTools failed');
-  });
+  // Proxy-tool approach: ToolSearch no longer calls setTools(), so
+  // setTools-failure tests are removed. The schema is returned in a
+  // <functions> block and the model invokes via dispatch — no API-level
+  // tool syncing needed.
 
   it("rolls back this call's reveals when setTools() throws", async () => {
     // The reveal happens BEFORE setTools() so that getFunctionDeclarations
@@ -926,12 +901,9 @@ describe('ToolSearchTool', () => {
   });
 
   it("doesn't propagate when ensureTool throws mid-batch — reports missing instead", async () => {
-    // ensureTool throwing mid-iteration would otherwise propagate out of
-    // the for loop with previous tools already revealed but never
-    // setTools()-synced — same orphaned-reveal failure mode the
-    // setTools() catch block guards against. Wrap ensureTool so the
-    // failure surfaces as a `missing` entry and processing continues
-    // for the rest of the batch.
+    // ensureTool throwing mid-iteration must not propagate — the
+    // failure should surface as a `missing` entry and processing
+    // continues for the rest of the batch.
     registry.registerTool(new MockTool({ name: 'alpha', shouldDefer: true }));
     registry.registerTool(new MockTool({ name: 'bravo', shouldDefer: true }));
     registry.registerTool(new MockTool({ name: 'charlie', shouldDefer: true }));
@@ -952,48 +924,26 @@ describe('ToolSearchTool', () => {
     expect(content).toContain('"name":"alpha"');
     expect(content).toContain('"name":"charlie"');
     expect(content).toContain('Not found: bravo');
-    // alpha and charlie revealed; bravo not (the throw kept it out).
-    expect(registry.isDeferredToolRevealed('alpha')).toBe(true);
-    expect(registry.isDeferredToolRevealed('charlie')).toBe(true);
+    // Proxy-tool approach: no revealDeferredTool calls.
+    expect(registry.isDeferredToolRevealed('alpha')).toBe(false);
+    expect(registry.isDeferredToolRevealed('charlie')).toBe(false);
     expect(registry.isDeferredToolRevealed('bravo')).toBe(false);
   });
 
-  it('treats a null GeminiClient identically to setTools() throwing', async () => {
-    // Without the explicit null-check, optional chaining (`?.setTools()`)
-    // silently no-ops if init hasn't completed yet, leaving the reveal
-    // in the registry while the API never received the schema. The
-    // dedupe filter in `collectCandidates` would then exclude that tool
-    // from future keyword searches, making it unreachable until /clear.
-    registry.registerTool(
-      new MockTool({ name: 'cron_create', shouldDefer: true }),
-    );
-    vi.spyOn(config, 'getGeminiClient').mockReturnValue(
-      null as unknown as ReturnType<typeof config.getGeminiClient>,
-    );
-
-    const tool = new ToolSearchTool(config);
-    const result = await tool
-      .build({ query: 'select:cron_create' })
-      .execute(new AbortController().signal);
-
-    expect(result.error).toBeDefined();
-    expect(result.error?.message).toContain('GeminiClient not initialised');
-    expect(String(result.llmContent)).not.toContain('"name":"cron_create"');
-    // Reveal rolled back so subsequent ToolSearch can find the tool.
-    expect(registry.isDeferredToolRevealed('cron_create')).toBe(false);
-  });
+  // Proxy-tool approach: ToolSearch does not interact with GeminiClient,
+  // so null-GeminiClient test is removed. Schemas are returned in a
+  // <functions> block, not synced via setTools().
 });
 
 describe('ToolRegistry.clearRevealedDeferredTools', () => {
-  it('empties the revealed set so new sessions start clean', async () => {
-    const { config, registry } = makeConfigWithRegistry();
+  it('empties the revealed set so new sessions start clean', () => {
+    const { registry } = makeConfigWithRegistry();
     registry.registerTool(
       new MockTool({ name: 'cron_create', shouldDefer: true }),
     );
 
-    const tool = new ToolSearchTool(config);
-    const invocation = tool.build({ query: 'select:cron_create' });
-    await invocation.execute(new AbortController().signal);
+    // Reveal directly (proxy-tool ToolSearch doesn't do this).
+    registry.revealDeferredTool('cron_create');
     expect(registry.isDeferredToolRevealed('cron_create')).toBe(true);
 
     registry.clearRevealedDeferredTools();

--- a/packages/core/src/tools/tool-search.test.ts
+++ b/packages/core/src/tools/tool-search.test.ts
@@ -889,7 +889,9 @@ describe('ToolSearchTool', () => {
     const content = String(result.llmContent);
     expect(content).toContain('<functions>');
     expect(content).toContain('dispatch');
-    expect(content).toContain('To invoke this tool, call the `dispatch` tool');
+    expect(content).toContain(
+      'To invoke any of these tools, call the `dispatch` tool',
+    );
     expect(content).toContain('dispatch(tool: "<name>"');
   });
 

--- a/packages/core/src/tools/tool-search.test.ts
+++ b/packages/core/src/tools/tool-search.test.ts
@@ -848,17 +848,19 @@ describe('ToolSearchTool', () => {
     // First search uses keyword path (which calls loadAndReturnSchemas →
     // revealDeferredTool); confirm registry agrees.
     expect(registry.isDeferredToolRevealed('slack_send_message')).toBe(true);
+    // refreshStartupContextReminder() is intentionally skipped to preserve
+    // KV-cache — deferred-tools lives at the tail of the system-reminder.
     const geminiClient = config.getGeminiClient() as unknown as {
       refreshStartupContextReminder: ReturnType<typeof vi.fn>;
     };
-    expect(geminiClient.refreshStartupContextReminder).toHaveBeenCalledTimes(1);
+    expect(geminiClient.refreshStartupContextReminder).toHaveBeenCalledTimes(0);
 
     // Second: same keyword search now finds nothing (tool excluded).
     const second = await tool
       .build({ query: 'slack' })
       .execute(new AbortController().signal);
     expect(String(second.llmContent)).toContain('No tools found matching');
-    expect(geminiClient.refreshStartupContextReminder).toHaveBeenCalledTimes(1);
+    expect(geminiClient.refreshStartupContextReminder).toHaveBeenCalledTimes(0);
   });
 
   it('returns an error result when setTools() throws — model must NOT see schemas as ready', async () => {

--- a/packages/core/src/tools/tool-search.test.ts
+++ b/packages/core/src/tools/tool-search.test.ts
@@ -868,36 +868,29 @@ describe('ToolSearchTool', () => {
   // <functions> block and the model invokes via dispatch — no API-level
   // tool syncing needed.
 
-  it("rolls back this call's reveals when setTools() throws", async () => {
-    // The reveal happens BEFORE setTools() so that getFunctionDeclarations
-    // includes the tool when setTools rebuilds the chat's declaration
-    // list. If setTools throws, the reveal must be undone — otherwise
-    // the registry says "revealed" while the API has no schema, and
-    // collectCandidates will exclude the tool from future keyword
-    // searches (per its isDeferredToolRevealed filter), making the
-    // tool effectively unreachable until /clear.
+  it('includes dispatch instruction in <functions> output', async () => {
+    // The dispatch instruction is the ONLY signal telling the model how
+    // to invoke discovered tools. If accidentally removed or changed, the
+    // entire proxy-tool flow breaks — hence we assert its presence.
     registry.registerTool(
-      new MockTool({ name: 'cron_create', shouldDefer: true }),
+      new MockTool({
+        name: 'test_tool',
+        description: 'a test tool',
+        searchHint: 'test',
+        shouldDefer: true,
+      }),
     );
-    registry.registerTool(
-      new MockTool({ name: 'cron_list', shouldDefer: true }),
-    );
-    // Pre-reveal cron_list to confirm rollback only undoes THIS call's
-    // reveals, not pre-existing ones.
-    registry.revealDeferredTool('cron_list');
-
-    vi.spyOn(config, 'getGeminiClient').mockReturnValue({
-      setTools: vi.fn().mockRejectedValue(new Error('chat not initialised')),
-    } as never);
 
     const tool = new ToolSearchTool(config);
-    await tool
-      .build({ query: 'select:cron_create,cron_list' })
+    const result = await tool
+      .build({ query: 'select:test_tool' })
       .execute(new AbortController().signal);
 
-    expect(registry.isDeferredToolRevealed('cron_create')).toBe(false);
-    // cron_list was already revealed before this call, so it stays revealed.
-    expect(registry.isDeferredToolRevealed('cron_list')).toBe(true);
+    const content = String(result.llmContent);
+    expect(content).toContain('<functions>');
+    expect(content).toContain('dispatch');
+    expect(content).toContain('To invoke this tool, call the `dispatch` tool');
+    expect(content).toContain('dispatch(tool: "<name>"');
   });
 
   it("doesn't propagate when ensureTool throws mid-batch — reports missing instead", async () => {

--- a/packages/core/src/tools/tool-search.ts
+++ b/packages/core/src/tools/tool-search.ts
@@ -281,10 +281,16 @@ class ToolSearchInvocation extends BaseToolInvocation<
       lowerIndex.set(realName.toLowerCase(), realName);
     }
 
-    // Track only the tools this call newly reveals so we can roll them
-    // back if setTools() throws. Tools already revealed by an earlier
-    // ToolSearch must stay revealed regardless of this call's outcome.
-    const newlyRevealed: string[] = [];
+    // Under the proxy-tool approach (KV-cache preservation), ToolSearch
+    // does NOT call setTools() or revealDeferredTool().  Instead it returns
+    // the full schema in a `<functions>` block and instructs the model to
+    // invoke the discovered tool via the always-available `dispatch` proxy
+    // tool.  The dispatch executor looks up the real tool in the registry
+    // and forwards the call — the API-level tool list stays stable
+    // (`core tools + dispatch`), preserving the KV-cache prefix.
+    //
+    // We still call ensureTool() to trigger lazy factories and cache the
+    // tool instance, but we skip reveal/setTools/refreshStartupContext.
     for (const requested of names) {
       const canonical = lowerIndex.get(requested.toLowerCase());
       if (!canonical) {
@@ -298,22 +304,14 @@ class ToolSearchInvocation extends BaseToolInvocation<
         blocked.push(canonical);
         continue;
       }
-      // Treat ensureTool throws the same as a null return: log + report
-      // missing. Without this, an exception mid-batch would propagate
-      // out of the loop with previous tools already revealed but never
-      // setTools()-synced — same orphaned-reveal failure mode the
-      // setTools() catch block guards against.
+      // ensureTool may throw during factory resolution (network, missing
+      // module, etc.).  Surface to stderr in production: debugLogger.warn
+      // is off unless DEBUG is set, so without a stderr write, factory
+      // failures would be invisible to operators running headless.
       let tool: AnyDeclarativeTool | undefined;
       try {
         tool = await registry.ensureTool(canonical);
       } catch (err) {
-        // Surface to stderr in production: debugLogger.warn is a no-op
-        // unless DEBUG is set, so without a stderr write, factory
-        // failures (network, missing module, etc.) would be invisible
-        // to operators running headless and the agent would just see
-        // a "missing" entry with no diagnosis. Use process.stderr.write
-        // directly; the package-level eslint config bans console.* in
-        // core src and there's no shared logger that surfaces in prod.
         debugLogger.warn(`ensureTool failed for ${canonical}:`, err);
         process.stderr.write(
           `[ToolSearch] ensureTool failed for "${canonical}": ${
@@ -325,92 +323,7 @@ class ToolSearchInvocation extends BaseToolInvocation<
         missing.push(requested);
         continue;
       }
-      // Only reveal + count toward the setTools() trigger when the tool
-      // is actually deferred. `select:` mode also accepts already-loaded
-      // / alwaysLoad tools (the model may use it to re-inspect a schema)
-      // — those don't need reveal (they're already in the declaration
-      // list) and pulling them through setTools() would risk a spurious
-      // "GeminiClient not initialised" failure for what is just a
-      // schema-inspection call.
-      const isLoadable = tool.shouldDefer && !tool.alwaysLoad;
-      if (isLoadable) {
-        const wasRevealed = registry.isDeferredToolRevealed(canonical);
-        registry.revealDeferredTool(canonical);
-        if (!wasRevealed) {
-          newlyRevealed.push(canonical);
-        }
-      }
       loaded.push(tool);
-    }
-
-    // Re-sync the active chat's tool list ONLY when this call newly
-    // revealed deferred tools (otherwise the declaration list is
-    // already correct and setTools() is wasted work — and worse, a
-    // null/uninitialised client would surface as a fake error for
-    // what is just a schema-inspection request).
-    let setToolsError: string | undefined;
-    if (newlyRevealed.length > 0) {
-      const geminiClient = this.config.getGeminiClient();
-      if (!geminiClient) {
-        // Optional chaining (`?.setTools()`) used to silently no-op here,
-        // leaving the registry with reveals the API never received —
-        // exactly the inconsistency `setTools() throws` already guards
-        // against. Treat null client identically: rollback + surface an
-        // error so the caller can retry once init is complete.
-        setToolsError = 'GeminiClient not initialised';
-      } else {
-        try {
-          await geminiClient.setTools();
-        } catch (err) {
-          setToolsError = err instanceof Error ? err.message : String(err);
-          // Same rationale as ensureTool above: debugLogger.warn is
-          // off in production, so a setTools() failure during reveal
-          // would be invisible to operators. The error already lands
-          // in the tool's ToolResult, but a stderr write helps when
-          // someone is debugging from outside the agent transcript.
-          debugLogger.warn(
-            'setTools() failed while revealing deferred tools:',
-            err,
-          );
-          process.stderr.write(
-            `[ToolSearch] setTools() failed while revealing deferred tools: ${setToolsError}\n`,
-          );
-        }
-
-        // NOTE: refreshStartupContextReminder() intentionally skipped.
-        // The deferred-tools section is now at the end of the system-reminder
-        // (stable sections first). Skipping the refresh preserves the
-        // LLM server's KV-cache for the stable prefix — the tools are already
-        // available via setTools(), so a stale reminder is cosmetic, not
-        // functional. Re-evaluate if deferred-tools moves back to the front.
-      }
-
-      if (setToolsError) {
-        // Surface as a tool error so the agent knows the loaded tools
-        // aren't actually available, instead of silently swallowing into
-        // debugLogger.warn (which is off in production). Schemas are
-        // withheld from llmContent (built below only when no error) so
-        // the model doesn't think the tool is callable while the API
-        // declaration list doesn't have it.
-        //
-        // Roll back this call's reveals so the registry stays consistent
-        // with the API's declaration list. Without this, keyword search
-        // would treat these tools as "already loaded" and exclude them
-        // from candidates while the API still has no schema for them.
-        for (const name of newlyRevealed) {
-          registry.unrevealDeferredTool(name);
-        }
-      }
-    }
-
-    if (setToolsError) {
-      return {
-        llmContent: `Error: tools were located but could not be exposed to the API (setTools failed: ${setToolsError}). Retry the search next turn or call ToolSearch again with select:Name1,Name2 — re-running tool registration usually clears transient init races.`,
-        returnDisplay: `setTools failed: ${setToolsError}`,
-        error: {
-          message: `setTools failed while revealing deferred tools: ${setToolsError}`,
-        },
-      };
     }
 
     // Escape `<` in the JSON-stringified schema so any `</function>`
@@ -425,7 +338,14 @@ class ToolSearchInvocation extends BaseToolInvocation<
     );
     let llmContent = '';
     if (schemaBlocks.length > 0) {
-      llmContent += `<functions>\n${schemaBlocks.join('\n')}\n</functions>`;
+      llmContent += `<functions>\n${schemaBlocks.join('\n')}\n</functions>\n\n`;
+      // Instruct the model to invoke the discovered tool via the `dispatch`
+      // proxy tool.  The API-level tool list only contains `dispatch`
+      // (plus core tools), so the model must call dispatch({tool:"...",
+      // args:{...}}) — the dispatch executor looks up the real tool in
+      // the registry and forwards the call.  This keeps the KV-cache
+      // prefix stable across tool discoveries.
+      llmContent += `To invoke this tool, call the \`dispatch\` tool with the tool name and its parameters (use the parameter schema above). Example: \`dispatch(tool: "<name>", args: { ...params ... })\`.`;
     }
     if (missing.length > 0) {
       const header = llmContent ? '\n\n' : '';

--- a/packages/core/src/tools/tool-search.ts
+++ b/packages/core/src/tools/tool-search.ts
@@ -377,21 +377,12 @@ class ToolSearchInvocation extends BaseToolInvocation<
           );
         }
 
-        if (!setToolsError) {
-          try {
-            await geminiClient.refreshStartupContextReminder();
-          } catch (err) {
-            const refreshError =
-              err instanceof Error ? err.message : String(err);
-            debugLogger.warn(
-              'refreshStartupContextReminder() failed after revealing deferred tools:',
-              err,
-            );
-            process.stderr.write(
-              `[ToolSearch] refreshStartupContextReminder() failed after revealing deferred tools: ${refreshError}\n`,
-            );
-          }
-        }
+        // NOTE: refreshStartupContextReminder() intentionally skipped.
+        // The deferred-tools section is now at the end of the system-reminder
+        // (stable sections first). Skipping the refresh preserves the
+        // LLM server's KV-cache for the stable prefix — the tools are already
+        // available via setTools(), so a stale reminder is cosmetic, not
+        // functional. Re-evaluate if deferred-tools moves back to the front.
       }
 
       if (setToolsError) {

--- a/packages/core/src/tools/tool-search.ts
+++ b/packages/core/src/tools/tool-search.ts
@@ -112,11 +112,9 @@ interface ScoredTool {
   score: number;
 }
 
-const toolSearchDescription = `Fetches function declarations for deferred tools and registers them with the active session so subsequent turns can call them.
+const toolSearchDescription = `Fetches function declarations for deferred tools. Returns matched tools' schemas inside a <functions> block.
 
-Deferred tools appear by name in the deferred-tools startup reminder. Until fetched, only the name is known — there is no parameter schema, so the tool cannot be invoked. This tool takes a query, matches it against the deferred tool list, and returns the matched tools' function declarations (name + description + parameter schema) inside a <functions> block.
-
-The returned <functions> block is informational — it shows what the schema looks like. Calling the tool itself happens via the model's normal function-call mechanism on the NEXT turn, after the active session's declaration list has been updated. Tools fetched here remain available for the rest of the session.
+The <functions> block contains the parameter schema needed to invoke the tool via the \`dispatch\` proxy tool. To invoke a discovered tool, call dispatch(tool: "<name>", args: { ...params ... }). The discovered tool is NOT directly callable — it must be invoked through dispatch.
 
 Query forms:
 - "select:ToolA,ToolB" — fetch these exact tools by name

--- a/packages/core/src/tools/tool-search.ts
+++ b/packages/core/src/tools/tool-search.ts
@@ -343,7 +343,7 @@ class ToolSearchInvocation extends BaseToolInvocation<
       // args:{...}}) — the dispatch executor looks up the real tool in
       // the registry and forwards the call.  This keeps the KV-cache
       // prefix stable across tool discoveries.
-      llmContent += `To invoke this tool, call the \`dispatch\` tool with the tool name and its parameters (use the parameter schema above). Example: \`dispatch(tool: "<name>", args: { ...params ... })\`.`;
+      llmContent += `To invoke any of these tools, call the \`dispatch\` tool with the tool name and its parameters (use the parameter schema above). Example: \`dispatch(tool: "<name>", args: { ...params ... })\`.`;
     }
     if (missing.length > 0) {
       const header = llmContent ? '\n\n' : '';

--- a/packages/core/src/utils/environmentContext.ts
+++ b/packages/core/src/utils/environmentContext.ts
@@ -402,13 +402,15 @@ export async function getInitialChatHistory(
     ? await buildAvailableSkillsReminder(config)
     : null;
 
+  // Stable sections FIRST → KV-cache preserved on partial updates.
+  // Deferred tools LAST → changes only affect the tail of the prefix.
   const reminderParts = [
-    includeDeferredToolsReminder
-      ? buildDeferredToolsReminder(toolRegistry)
-      : null,
     buildMcpServerInstructionsReminder(toolRegistry),
     skillsResult?.reminder ?? null,
     startupReminder,
+    includeDeferredToolsReminder
+      ? buildDeferredToolsReminder(toolRegistry)
+      : null,
   ]
     .filter((text): text is string => text !== null)
     .map((text) => ({ text }));


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

Replace the `revealDeferredTool()` + `setTools()` pattern with a universal `dispatch` proxy-tool that keeps the API-level tool list byte-stable (`core tools + dispatch`), so the LLM server's KV-cache prefix never changes when tools are discovered mid-session.

ToolSearch now returns discovered schemas in a `<functions>` block with a dispatch instruction, instead of calling `setTools()` and `revealDeferredTool()`. The model invokes discovered tools via the always-available `dispatch` proxy tool, which looks up the real tool in `ToolRegistry` and forwards the call.

A new `dispatch.ts` module provides the proxy-tool. The `toolSearchDescription` constant is rewritten to describe the dispatch flow. `environmentContext.ts` continues to keep deferred-tool names at the tail of the system reminder (from prior work) so the KV-cache prefix remains stable even when the reminder updates.

## Why it's needed

Every `tool_search` call that discovered a new deferred tool invalidated the LLM server's KV-cache prefix, because:
1. `revealDeferredTool()` changed registry state
2. `setTools()` changed the API-level function-declaration list
3. (Previously) `refreshStartupContextReminder()` rewrote the system reminder

This caused a 500–2000ms latency penalty per discovery and reduced KV-cache hit ratio from ~90% to ~50%. See issue #6265 and related #4777.

## Reviewer Test Plan

### How to verify

1. Start a session, run `tool_search` for a deferred tool (e.g. `slack_send_message`). Confirm the result contains a `<functions>` block with the tool schema and the dispatch instruction. Confirm the API tool list (`config.tools`) remains `[core tools, dispatch]` — no new tool entry added.
2. Invoke the discovered tool through dispatch (e.g. `dispatch({tool: "slack_send_message", args: {...}})`). Confirm the target tool executes and returns a result.
3. Run the unit test suite: `cd packages/core && npx vitest run src/tools/dispatch.test.ts src/tools/tool-search.test.ts`. All tests should pass.

### Evidence (Before & After)

Non-UI change (internal architecture). KV-cache impact measurable via server-side metrics only.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment

Unit tests only (`npx vitest`).

## Risk & Scope

- Main risk or tradeoff: The model must learn the `dispatch({tool: "...", args: {...}})` calling convention instead of calling discovered tools directly. A dispatch instruction is appended to every tool-search result to teach the model this pattern. If the model ignores it, discovered tools are unreachable — but the error message tells the model to use dispatch. This is a strictly additive change: core tool invocation (read_file, edit, etc.) is unaffected since those are always in the API-declaration list.
- Not validated / out of scope: Permission/scheduler pipeline integration for dispatched tools. Dispatch currently invokes the target tool directly, bypassing `evaluatePermissionFlow()`, auto-approval, PreToolUse/PostToolUse hooks, and subagent tool-exclusion rules. This is a known gap and will be addressed in a follow-up PR. For now, the guard against recursive self-dispatch and stderr logging on errors provide basic safety.
- Breaking changes / migration notes: None. The `dispatch` tool is new, and existing core tool invocations are unchanged.

## Linked Issues

- **Fixes** #6265 — `tool_search` invalidates LLM server KV-cache on every deferred-tool load
- **Related** #4777 — Deferred-tools listing in the system prompt busts prompt cache on every MCP discovery / tool reveal

<details>
<summary>中文说明</summary>

将 `revealDeferredTool()` + `setTools()` 模式替换为通用的 `dispatch` 代理工具，使 API 层的工具列表保持字节稳定（仅包含核心工具 + dispatch），从而在会话中发现新工具时 LLM 服务器的 KV-cache 前缀不再变化。

ToolSearch 不再调用 `setTools()` 和 `revealDeferredTool()`，而是将要发现工具的 schema 放在 `<functions>` 代码块中返回，并附上 dispatch 指令。模型通过始终可用的 `dispatch` 代理工具调用发现的工具，dispatch 在 `ToolRegistry` 中查找真实工具并转发调用。

新增 `dispatch.ts` 模块提供代理工具实现。重写了 `toolSearchDescription` 以描述 dispatch 流程。`environmentContext.ts` 继续将 deferred-tool 名称放在系统 reminder 的尾部（基于之前的工作），确保即使 reminder 更新时 KV-cache 前缀仍然稳定。

每次 `tool_search` 调用发现新的 deferred 工具时，会通过以下方式使 LLM 服务器的 KV-cache 前缀失效：(1) `revealDeferredTool()` 改变注册表状态，(2) `setTools()` 改变 API 层的函数声明列表，(3)（之前）`refreshStartupContextReminder()` 重写系统 reminder。这导致每次发现工具时产生 500-2000ms 的延迟，KV-cache 命中率从约 90% 降至约 50%。详见 issue #6265 和相关 issue #4777。

</details>

QwenCode QwenLLM
