### PR TITLE
fix(core): disable qwen thinking via chat_template_kwargs on non-DashScope servers

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -1112,7 +1112,9 @@ describe('ContentGenerationPipeline', () => {
       // Self-hosted OpenAI-compatible servers render the chat template
       // server-side and read the thinking switch from `chat_template_kwargs`,
       // silently ignoring a top-level `enable_thinking`. A qwen model on such
-      // an endpoint must therefore get the switch nested, not top-level.
+      // an endpoint must therefore get the switch nested, not top-level — and
+      // any top-level `enable_thinking: true` a provider preset injected via
+      // extra_body must be stripped so it can't contradict the opt-out.
       mockContentGeneratorConfig = {
         ...mockContentGeneratorConfig,
         baseUrl: 'https://llm.example.com/v1',
@@ -1124,8 +1126,53 @@ describe('ContentGenerationPipeline', () => {
       };
       pipeline = new ContentGenerationPipeline(mockConfig);
 
+      (mockProvider.buildRequest as Mock).mockImplementation((req) => ({
+        ...req,
+        enable_thinking: true, // Simulates extra_body injection
+      }));
+
       const request: GenerateContentParameters = {
         model: 'Qwen3.6-27B',
+        contents: [{ parts: [{ text: 'Suggest' }], role: 'user' }],
+        config: { thinkingConfig: { includeThoughts: false } },
+      };
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'Suggest' },
+      ]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue({
+        id: 'r',
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      } as OpenAI.Chat.ChatCompletion);
+
+      await pipeline.execute(request, 'forked_query');
+
+      const apiCall = (mockClient.chat.completions.create as Mock).mock
+        .calls[0][0];
+      expect(apiCall.chat_template_kwargs).toEqual({ enable_thinking: false });
+      expect(apiCall.enable_thinking).toBeUndefined();
+    });
+
+    it('disables coder-model thinking via chat_template_kwargs on a non-DashScope endpoint', async () => {
+      // `coder-model` is the QWEN_OAUTH default, but a user can point it at a
+      // self-hosted endpoint. The `model === 'coder-model'` arm must reach the
+      // non-DashScope chat_template_kwargs path just like a `qwen*` model.
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://llm.example.com/v1',
+        model: 'coder-model',
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      const request: GenerateContentParameters = {
+        model: 'coder-model',
         contents: [{ parts: [{ text: 'Suggest' }], role: 'user' }],
         config: { thinkingConfig: { includeThoughts: false } },
       };

--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -1108,6 +1108,47 @@ describe('ContentGenerationPipeline', () => {
       expect(apiCall.enable_thinking).toBeUndefined();
     });
 
+    it('disables qwen thinking via chat_template_kwargs on a non-DashScope endpoint (vLLM/SGLang)', async () => {
+      // Self-hosted OpenAI-compatible servers render the chat template
+      // server-side and read the thinking switch from `chat_template_kwargs`,
+      // silently ignoring a top-level `enable_thinking`. A qwen model on such
+      // an endpoint must therefore get the switch nested, not top-level.
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://llm.example.com/v1',
+        model: 'Qwen3.6-27B',
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      const request: GenerateContentParameters = {
+        model: 'Qwen3.6-27B',
+        contents: [{ parts: [{ text: 'Suggest' }], role: 'user' }],
+        config: { thinkingConfig: { includeThoughts: false } },
+      };
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'Suggest' },
+      ]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue({
+        id: 'r',
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      } as OpenAI.Chat.ChatCompletion);
+
+      await pipeline.execute(request, 'forked_query');
+
+      const apiCall = (mockClient.chat.completions.create as Mock).mock
+        .calls[0][0];
+      expect(apiCall.chat_template_kwargs).toEqual({ enable_thinking: false });
+      expect(apiCall.enable_thinking).toBeUndefined();
+    });
+
     it('does NOT emit enable_thinking on a non-qwen model routed through DashScope', async () => {
       // DashScope's compatible-mode endpoint routes multiple model families
       // (qwen3, GLM, DeepSeek). Hostname alone is not enough — GLM uses

--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -1196,6 +1196,53 @@ describe('ContentGenerationPipeline', () => {
       expect(apiCall.enable_thinking).toBeUndefined();
     });
 
+    it('merges enable_thinking into pre-existing chat_template_kwargs on a non-DashScope endpoint', async () => {
+      // The non-DashScope path spreads any existing `chat_template_kwargs`
+      // before appending `enable_thinking: false`. Guard the merge so a future
+      // refactor can't silently drop user-configured kwargs.
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://llm.example.com/v1',
+        model: 'Qwen3.6-27B',
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      (mockProvider.buildRequest as Mock).mockImplementation((req) => ({
+        ...req,
+        chat_template_kwargs: { apply_chat_template: true },
+      }));
+
+      const request: GenerateContentParameters = {
+        model: 'Qwen3.6-27B',
+        contents: [{ parts: [{ text: 'Suggest' }], role: 'user' }],
+        config: { thinkingConfig: { includeThoughts: false } },
+      };
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'Suggest' },
+      ]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue({
+        id: 'r',
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      } as OpenAI.Chat.ChatCompletion);
+
+      await pipeline.execute(request, 'forked_query');
+
+      const apiCall = (mockClient.chat.completions.create as Mock).mock
+        .calls[0][0];
+      expect(apiCall.chat_template_kwargs).toEqual({
+        apply_chat_template: true,
+        enable_thinking: false,
+      });
+    });
+
     it('does NOT emit enable_thinking on a non-qwen model routed through DashScope', async () => {
       // DashScope's compatible-mode endpoint routes multiple model families
       // (qwen3, GLM, DeepSeek). Hostname alone is not enough — GLM uses

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -599,7 +599,15 @@ export class ContentGenerationPipeline {
           // actually stop emitting <think> when reasoning is disabled — e.g.
           // the auto-mode permission classifier's short structured-output
           // calls, which otherwise spend their small token budget on thinking
-          // and fail closed.
+          // and fail closed. Servers that don't recognise `chat_template_kwargs`
+          // ignore the unknown field, so the switch is a harmless no-op there.
+          //
+          // Drop any top-level `enable_thinking` a provider preset injected via
+          // extra_body (provider-config.ts emits it for models configured with
+          // `enableThinking: true`): leaving it would contradict the
+          // `chat_template_kwargs` opt-out on servers that honour both, and
+          // keeps this path from leaking the qwen-specific field top-level.
+          delete typed['enable_thinking'];
           const existing = (typed['chat_template_kwargs'] ?? {}) as Record<
             string,
             unknown

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -584,13 +584,31 @@ export class ContentGenerationPipeline {
       // start with `qwen` but is the most common hybrid-thinking model
       // for first-time users, so it must be covered.
       const model = (context.model ?? '').toLowerCase();
-      if (
-        DashScopeOpenAICompatibleProvider.isDashScopeProvider(
-          this.contentGeneratorConfig,
-        ) &&
-        (model.startsWith('qwen') || model === 'coder-model')
-      ) {
-        typed['enable_thinking'] = false;
+      if (model.startsWith('qwen') || model === 'coder-model') {
+        if (
+          DashScopeOpenAICompatibleProvider.isDashScopeProvider(
+            this.contentGeneratorConfig,
+          )
+        ) {
+          typed['enable_thinking'] = false;
+        } else {
+          // Non-DashScope OpenAI-compatible servers (vLLM, SGLang, ...) render
+          // the model's chat template server-side and read the thinking switch
+          // from `chat_template_kwargs`, not a top-level `enable_thinking`
+          // (which they silently ignore). Send it there so hybrid qwen models
+          // actually stop emitting <think> when reasoning is disabled — e.g.
+          // the auto-mode permission classifier's short structured-output
+          // calls, which otherwise spend their small token budget on thinking
+          // and fail closed.
+          const existing = (typed['chat_template_kwargs'] ?? {}) as Record<
+            string,
+            unknown
+          >;
+          typed['chat_template_kwargs'] = {
+            ...existing,
+            enable_thinking: false,
+          };
+        }
       }
       // Strip reasoning config — extra_body could inject it, overriding
       // buildReasoningConfig's decision to return {} for disabled thinking.


### PR DESCRIPTION
## What this PR does

For hybrid-thinking qwen models, the "disable thinking" switch is now delivered in a way that self-hosted OpenAI-compatible servers actually honour. When the wire model is a `qwen*` model or `coder-model` and the provider is not DashScope, the pipeline sets `chat_template_kwargs.enable_thinking = false` (merged with any existing `chat_template_kwargs`) instead of the top-level `enable_thinking` field, and strips any top-level `enable_thinking` a provider preset injected via `extra_body` so the two signals cannot contradict. The DashScope path is unchanged.

## Why it's needed

Previously `enable_thinking: false` was only emitted for DashScope providers, and always as a top-level request field. Self-hosted OpenAI-compatible servers (vLLM, SGLang) render the chat template server-side and read the thinking switch from `chat_template_kwargs`; they silently ignore a top-level `enable_thinking`. So on a self-hosted qwen endpoint, thinking is never actually disabled.

The user-facing failure is that auto-approval mode is unusable against such an endpoint. The permission classifier issues short structured-output calls with a small token budget; because thinking stays on, the model spends that budget emitting `<think>`, returns empty or truncated JSON, and every tool call fails closed.

## Reviewer Test Plan

### How to verify

Point qwen-code at a self-hosted vLLM (or SGLang) server serving a hybrid-thinking qwen model such as `Qwen3.6-27B`, configured as an OpenAI-compatible provider (non-DashScope base URL), and enable auto-approval mode.

Before this change: the auto-mode permission classifier calls come back with `content: null` (the model consumes the token budget on `<think>`), and auto mode fails closed on every tool call. After this change: the classifier returns valid JSON and auto mode works, because the server sees `chat_template_kwargs.enable_thinking = false` and stops emitting reasoning.

Unit coverage: `npx vitest run packages/core/src/core/openaiContentGenerator/pipeline.test.ts` (83 passing). New/updated cases assert that a `qwen*` model and a `coder-model` on a non-DashScope endpoint emit `chat_template_kwargs: { enable_thinking: false }` with no top-level `enable_thinking`, and that a top-level `enable_thinking: true` injected via `extra_body` is stripped on this path.

### Evidence (Before & After)

Not a TUI change. Observable request/response difference on a self-hosted vLLM endpoint: before, the classifier response is `content: null`; after, it is valid JSON (e.g. `{"decision":"allow"}`). Behavior is pinned by the unit tests above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS: unit tests + live verification against a vLLM v0.22.1 server. Windows/Linux: not run locally; the change is pure request-shaping logic covered by cross-platform unit tests in CI.

### Environment (optional)

Local unit tests via `npx vitest`; live check against vLLM `v0.22.1` serving `Qwen3.6-27B` NVFP4.

## Risk & Scope

- Main risk or tradeoff: the non-DashScope branch now sends `chat_template_kwargs` on every non-DashScope qwen request. Servers that do not recognise the field ignore it (harmless no-op); this is the same convention vLLM and SGLang already use. It also deletes a top-level `enable_thinking` on this path, which is intentional (the field is qwen-specific and should not leak top-level to non-DashScope servers).
- Not validated / out of scope: live-verified only against vLLM v0.22.1; SGLang, LiteLLM proxies, and Ollama are covered by unit tests but not exercised live. Intentionally not gated on a known-server allowlist: self-hosted endpoint URLs are arbitrary, so an allowlist would be fragile and would exclude legitimate deployments while providing little benefit over relying on unknown-field tolerance.
- Breaking changes / migration notes: none. The DashScope path is byte-for-byte unchanged; the non-DashScope path previously delivered no working thinking-disable at all.

## Linked Issues

Related to #4676 (auto-mode classifier timeouts / stage-2 thinking), which routes through the same DashScope-only path and does not reach self-hosted servers. No closing keyword; this is a distinct fix.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

对于混合思考（hybrid-thinking）的 qwen 模型，现在以自托管的 OpenAI 兼容服务器能真正识别的方式来传递"禁用思考"开关。当线上（wire）模型是 `qwen*` 模型或 `coder-model` 且提供方不是 DashScope 时，pipeline 会设置 `chat_template_kwargs.enable_thinking = false`（与已有的 `chat_template_kwargs` 合并），而不是使用顶层的 `enable_thinking` 字段；同时会移除提供方预设通过 `extra_body` 注入的任何顶层 `enable_thinking`，以免两个信号相互矛盾。DashScope 路径保持不变。

## 为什么需要它

此前 `enable_thinking: false` 只对 DashScope 提供方发送，并且总是作为顶层请求字段。自托管的 OpenAI 兼容服务器（vLLM、SGLang）在服务端渲染聊天模板，并从 `chat_template_kwargs` 读取思考开关；它们会静默忽略顶层的 `enable_thinking`。因此在自托管的 qwen 端点上，思考实际上从未被禁用。

面向用户的故障是：自动批准（auto-approval）模式在这类端点上无法使用。权限分类器（permission classifier）会发出预算很小的短结构化输出请求；由于思考仍然开启，模型把预算花在输出 `<think>` 上，返回空的或被截断的 JSON，导致每次工具调用都失败关闭（fail closed）。

## 审查者测试计划

### 如何验证

将 qwen-code 指向一个自托管的 vLLM（或 SGLang）服务器，服务一个混合思考的 qwen 模型（如 `Qwen3.6-27B`），配置为 OpenAI 兼容提供方（非 DashScope 的 base URL），并启用自动批准模式。

改动之前：自动模式的权限分类器请求返回 `content: null`（模型把 token 预算消耗在 `<think>` 上），每次工具调用都失败关闭。改动之后：分类器返回有效的 JSON，自动模式正常工作，因为服务器看到 `chat_template_kwargs.enable_thinking = false` 并停止输出推理内容。

单元测试覆盖：`npx vitest run packages/core/src/core/openaiContentGenerator/pipeline.test.ts`（83 个通过）。新增/更新的用例断言：非 DashScope 端点上的 `qwen*` 模型和 `coder-model` 会发送 `chat_template_kwargs: { enable_thinking: false }` 且没有顶层 `enable_thinking`；并且通过 `extra_body` 注入的顶层 `enable_thinking: true` 会在该路径上被移除。

### 证据（前后对比）

不是 TUI 改动。在自托管 vLLM 端点上可观察到的请求/响应差异：之前分类器响应为 `content: null`；之后为有效 JSON（例如 `{"decision":"allow"}`）。该行为由上述单元测试固定。

### 测试平台

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS：单元测试 + 针对 vLLM v0.22.1 服务器的实机验证。Windows/Linux：本地未运行；该改动是纯请求构造逻辑，由 CI 中的跨平台单元测试覆盖。

### 环境（可选）

通过 `npx vitest` 运行本地单元测试；针对服务 `Qwen3.6-27B` NVFP4 的 vLLM `v0.22.1` 做了实机检查。

## 风险与范围

- 主要风险或权衡：非 DashScope 分支现在会在每个非 DashScope 的 qwen 请求上发送 `chat_template_kwargs`。不识别该字段的服务器会忽略它（无害的空操作）；这正是 vLLM 和 SGLang 已经采用的约定。它还会在该路径上删除顶层的 `enable_thinking`，这是有意为之（该字段是 qwen 专有的，不应以顶层形式泄漏到非 DashScope 服务器）。
- 未验证 / 超出范围：仅针对 vLLM v0.22.1 做了实机验证；SGLang、LiteLLM 代理和 Ollama 由单元测试覆盖但未做实机验证。有意不基于已知服务器白名单来门控：自托管端点 URL 是任意的，白名单会很脆弱，会把合法部署排除在外，且相比依赖"忽略未知字段"的容错几乎没有额外收益。
- 破坏性变更 / 迁移说明：无。DashScope 路径逐字节保持不变；非 DashScope 路径此前根本没有可用的禁用思考功能。

## 关联 Issue

与 #4676（自动模式分类器超时 / 第二阶段思考）相关，该 issue 走的是同一条仅限 DashScope 的路径，无法到达自托管服务器。不使用关闭关键字；这是一个独立的修复。

</details>
