### PR TITLE
fix(vscode): keep auth quick inputs open on focus loss

### DIFF
--- a/packages/vscode-ide-companion/src/webview/handlers/AuthMessageHandler.test.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/AuthMessageHandler.test.ts
@@ -41,6 +41,10 @@ describe('AuthMessageHandler', () => {
 
     await handler.handle({ type: 'auth' });
 
+    expect(mockShowQuickPick).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ ignoreFocusOut: true }),
+    );
     expect(sendToWebView).toHaveBeenCalledWith({ type: 'authCancelled' });
   });
 
@@ -65,6 +69,9 @@ describe('AuthMessageHandler', () => {
 
     await handler.handle({ type: 'auth' });
 
+    expect(mockShowInputBox).toHaveBeenCalledWith(
+      expect.objectContaining({ ignoreFocusOut: true }),
+    );
     expect(sendToWebView).toHaveBeenCalledWith({ type: 'authCancelled' });
   });
 

--- a/packages/vscode-ide-companion/src/webview/handlers/AuthMessageHandler.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/AuthMessageHandler.ts
@@ -120,6 +120,7 @@ export class AuthMessageHandler extends BaseMessageHandler {
     const choice = await vscode.window.showQuickPick(items, {
       title,
       placeHolder,
+      ignoreFocusOut: true,
     });
     if (!choice || choice.kind === vscode.QuickPickItemKind.Separator) {
       this.notifyAuthCancelled();
@@ -145,6 +146,7 @@ export class AuthMessageHandler extends BaseMessageHandler {
       placeHolder: opts.placeHolder,
       value: opts.value,
       password: opts.password ?? false,
+      ignoreFocusOut: true,
       validateInput: opts.required
         ? (v) => (!v?.trim() ? 'This field is required' : null)
         : undefined,


### PR DESCRIPTION
## Summary

- keep the VS Code auth provider QuickPick open when focus moves away
- keep auth InputBox prompts open across focus changes
- add regression coverage for both quick input option objects

Fixes #6230.

## Testing

- `npm test --workspace=packages/vscode-ide-companion -- src/webview/handlers/AuthMessageHandler.test.ts`
- `npm run check-types --workspace=packages/vscode-ide-companion`
- `npm run lint --workspace=packages/vscode-ide-companion`
- `npm run build --workspace=packages/vscode-ide-companion`
- `git diff --check`

## Notes

AI-assisted: yes. I manually reviewed the diff and test output before opening this PR.

I did not manually exercise the VS Code QuickPick/InputBox UI because the regression is covered through the mocked VS Code API options in `AuthMessageHandler.test.ts`.
