### PR TITLE
ci(audio): clarify macOS prebuild artifact suffix

### DIFF
--- a/.github/workflows/audio-capture-prebuilds.yml
+++ b/.github/workflows/audio-capture-prebuilds.yml
@@ -39,6 +39,7 @@ jobs:
           - os: 'macos-14'
             runner: 'macos-14'
             arch: 'arm64'
+            artifact_suffix: 'arm64+x64'
           - os: 'ubuntu-latest'
             runner: 'ubuntu-latest'
             arch: 'x64'
@@ -69,7 +70,7 @@ jobs:
       - name: 'Upload prebuild'
         uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' # v7.0.1
         with:
-          name: 'prebuilds-${{ matrix.os }}-${{ matrix.arch }}'
+          name: 'prebuilds-${{ matrix.os }}-${{ matrix.artifact_suffix || matrix.arch }}'
           path: 'packages/audio-capture/prebuilds/'
           if-no-files-found: 'error'
 


### PR DESCRIPTION
## What this PR does
- Clarifies the macOS audio prebuild artifact name by using an explicit `arm64+x64` suffix.
- Keeps the existing artifact naming for the other matrix entries unchanged.

AI-assisted: yes
Human reviewed: yes

## Why it's needed
The macOS audio prebuild job now produces a universal archive from the macos-14 runner, but the upload artifact name still advertised only `arm64`. The explicit suffix makes the artifact name match the contents without changing the collect job's `prebuilds-*` download pattern.

## Reviewer Test Plan

### How to verify
- Review `.github/workflows/audio-capture-prebuilds.yml` and confirm only the macOS matrix entry gets `artifact_suffix: 'arm64+x64'`.
- Confirm the upload artifact expression falls back to `matrix.arch` for other platforms.
- Confirm the collect job still downloads `prebuilds-*` artifacts unchanged.

### Evidence (Before & After)
- Before: macOS upload artifact name used `prebuilds-macos-14-arm64` even though the job packages both arm64 and x64 slices.
- After: macOS upload artifact name uses `prebuilds-macos-14-arm64+x64`; all other artifact names are unchanged.

### Tested on
- `actionlint v1.7.7 .github/workflows/audio-capture-prebuilds.yml`
- Node YAML parse for `.github/workflows/audio-capture-prebuilds.yml`
- `git diff --check`

## Risk & Scope
Low risk. This only changes the CI artifact display/upload name for the macOS prebuild matrix entry and leaves artifact collection patterns unchanged.

## Linked Issues
Fixes #5649
