### PR TITLE
fix(desktop): enforce transform_data isolation

### DIFF
--- a/packages/desktop/packages/session-tools-core/src/handlers/script-sandbox.test.ts
+++ b/packages/desktop/packages/session-tools-core/src/handlers/script-sandbox.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { SessionToolContext } from '../context.ts';
@@ -63,7 +69,9 @@ describe('script_sandbox', () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('inputFile must be within the session directory');
+    expect(result.content[0]?.text).toContain(
+      'inputFile must be within the session directory',
+    );
   });
 
   it('enforces network/filesystem isolation or fails with clear diagnostics', async () => {
@@ -79,11 +87,11 @@ describe('script_sandbox', () => {
       expect(text.length > 0).toBe(true);
       expect(
         text.includes('network isolation') ||
-        text.includes('filesystem isolation') ||
-        text.includes('networkIsolation:') ||
-        text.includes('filesystemIsolation:') ||
-        text.includes('runtime') ||
-        text.includes('Error running sandboxed script')
+          text.includes('filesystem isolation') ||
+          text.includes('networkIsolation:') ||
+          text.includes('filesystemIsolation:') ||
+          text.includes('runtime') ||
+          text.includes('Error running sandboxed script'),
       ).toBe(true);
       return;
     }
@@ -122,7 +130,8 @@ describe('script_sandbox', () => {
   it('passes stdin through when sandbox backend is available', async () => {
     const result = await handleScriptSandbox(ctx(), {
       language: 'node',
-      script: "process.stdin.on('data', d => process.stdout.write(String(d).toUpperCase()));",
+      script:
+        "process.stdin.on('data', d => process.stdout.write(String(d).toUpperCase()));",
       stdin: 'hello stdin',
       timeoutMs: 1500,
     });
@@ -130,12 +139,10 @@ describe('script_sandbox', () => {
     const text = result.content[0]?.text ?? '';
     if (
       result.isError &&
-      (
-        text.includes('filesystem isolation') ||
+      (text.includes('filesystem isolation') ||
         text.includes('network isolation') ||
         text.includes('sandbox_apply') ||
-        text.includes('Operation not permitted')
-      )
+        text.includes('Operation not permitted'))
     ) {
       expect(text.length > 0).toBe(true);
       return;
@@ -155,12 +162,10 @@ describe('script_sandbox', () => {
     const text = result.content[0]?.text ?? '';
     if (
       result.isError &&
-      (
-        text.includes('filesystem isolation') ||
+      (text.includes('filesystem isolation') ||
         text.includes('network isolation') ||
         text.includes('sandbox_apply') ||
-        text.includes('Operation not permitted')
-      )
+        text.includes('Operation not permitted'))
     ) {
       expect(text.length > 0).toBe(true);
       return;

--- a/packages/desktop/packages/session-tools-core/src/handlers/script-sandbox.ts
+++ b/packages/desktop/packages/session-tools-core/src/handlers/script-sandbox.ts
@@ -1,6 +1,8 @@
 import { spawn } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
 import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
+import { randomUUID } from 'node:crypto';
 import type { SessionToolContext } from '../context.ts';
 import { errorResponse, successResponse } from '../response.ts';
 import type { ToolResult } from '../types.ts';
@@ -33,12 +35,31 @@ function truncateOutput(text: string): { text: string; truncated: boolean } {
   };
 }
 
+function killSandboxProcess(child: ChildProcess): void {
+  if (!child.pid) {
+    child.kill('SIGKILL');
+    return;
+  }
+
+  try {
+    if (process.platform === 'win32') {
+      child.kill('SIGKILL');
+    } else {
+      process.kill(-child.pid, 'SIGKILL');
+    }
+  } catch {
+    child.kill('SIGKILL');
+  }
+}
+
 export async function handleScriptSandbox(
   ctx: SessionToolContext,
-  args: ScriptSandboxArgs
+  args: ScriptSandboxArgs,
 ): Promise<ToolResult> {
   if (!ctx.sessionPath || !ctx.dataPath) {
-    return errorResponse('script_sandbox requires sessionPath and dataPath in context.');
+    return errorResponse(
+      'script_sandbox requires sessionPath and dataPath in context.',
+    );
   }
 
   const sessionDir = ctx.sessionPath;
@@ -49,7 +70,9 @@ export async function handleScriptSandbox(
   for (const inputFile of inputFiles) {
     const resolvedInput = resolve(sessionDir, inputFile);
     if (!isPathWithinDirectory(resolvedInput, sessionDir)) {
-      return errorResponse(`inputFile must be within the session directory. Got: ${inputFile}`);
+      return errorResponse(
+        `inputFile must be within the session directory. Got: ${inputFile}`,
+      );
     }
     if (!existsSync(resolvedInput)) {
       return errorResponse(`input file not found: ${inputFile}`);
@@ -61,32 +84,48 @@ export async function handleScriptSandbox(
     mkdirSync(dataDir, { recursive: true });
   }
 
-  const timeoutMs = Math.min(Math.max(args.timeoutMs ?? DEFAULT_TIMEOUT_MS, 1), MAX_TIMEOUT_MS);
+  const timeoutMs = Math.min(
+    Math.max(args.timeoutMs ?? DEFAULT_TIMEOUT_MS, 1),
+    MAX_TIMEOUT_MS,
+  );
   const ext = args.language === 'python3' ? '.py' : '.js';
   const sandboxScriptDir = join(dataDir, '.sandbox-scripts');
   if (!existsSync(sandboxScriptDir)) {
     mkdirSync(sandboxScriptDir, { recursive: true });
   }
-  const tempScript = join(sandboxScriptDir, `craft-sandbox-${ctx.sessionId}-${Date.now()}${ext}`);
+  const tempScript = join(
+    sandboxScriptDir,
+    `craft-sandbox-${randomUUID()}${ext}`,
+  );
 
-  writeFileSync(tempScript, args.script, 'utf-8');
+  writeFileSync(tempScript, args.script, { encoding: 'utf-8', flag: 'wx' });
 
   try {
     const runtime = resolveScriptRuntime(args.language);
     const runtimeArgs = [...runtime.argsPrefix, tempScript, ...resolvedInputs];
 
     let networkIsolation = applyNetworkIsolation(runtime.command, runtimeArgs);
-    let filesystemIsolation = applyFilesystemIsolation(runtime.command, runtimeArgs, sessionDir);
+    let filesystemIsolation = applyFilesystemIsolation(
+      runtime.command,
+      runtimeArgs,
+      sessionDir,
+    );
 
     if (process.platform === 'darwin') {
       // macOS: compose network + filesystem restrictions in a SINGLE sandbox-exec profile
       // to avoid nested sandbox-exec wrapping failures.
-      filesystemIsolation = applyFilesystemIsolation(runtime.command, runtimeArgs, sessionDir, {
-        includeNetworkDeny: true,
-      });
+      filesystemIsolation = applyFilesystemIsolation(
+        runtime.command,
+        runtimeArgs,
+        sessionDir,
+        {
+          includeNetworkDeny: true,
+        },
+      );
       networkIsolation = {
         status: filesystemIsolation.status,
-        backend: filesystemIsolation.status === 'enforced' ? 'sandbox-exec' : 'none',
+        backend:
+          filesystemIsolation.status === 'enforced' ? 'sandbox-exec' : 'none',
         command: runtime.command,
         args: runtimeArgs,
       };
@@ -94,26 +133,26 @@ export async function handleScriptSandbox(
       networkIsolation = applyNetworkIsolation(runtime.command, runtimeArgs);
       if (networkIsolation.status !== 'enforced') {
         return errorResponse(
-          'script_sandbox requires network isolation in all permission modes, but no supported isolation backend is available on this platform/runtime.'
+          'script_sandbox requires network isolation in all permission modes, but no supported isolation backend is available on this platform/runtime.',
         );
       }
 
       filesystemIsolation = applyFilesystemIsolation(
         networkIsolation.command,
         networkIsolation.args,
-        sessionDir
+        sessionDir,
       );
     }
 
     if (networkIsolation.status !== 'enforced') {
       return errorResponse(
-        'script_sandbox requires network isolation in all permission modes, but no supported isolation backend is available on this platform/runtime.'
+        'script_sandbox requires network isolation in all permission modes, but no supported isolation backend is available on this platform/runtime.',
       );
     }
 
     if (filesystemIsolation.status !== 'enforced') {
       return errorResponse(
-        'script_sandbox requires filesystem isolation in all permission modes, but no supported isolation backend is available on this platform/runtime.'
+        'script_sandbox requires filesystem isolation in all permission modes, but no supported isolation backend is available on this platform/runtime.',
       );
     }
 
@@ -123,12 +162,22 @@ export async function handleScriptSandbox(
     });
 
     const startedAt = Date.now();
-    const result = await new Promise<{ stdout: string; stderr: string; code: number | null; timedOut: boolean }>((resolvePromise, reject) => {
-      const child = spawn(filesystemIsolation.command, filesystemIsolation.args, {
-        cwd: dataDir,
-        env,
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
+    const result = await new Promise<{
+      stdout: string;
+      stderr: string;
+      code: number | null;
+      timedOut: boolean;
+    }>((resolvePromise, reject) => {
+      const child = spawn(
+        filesystemIsolation.command,
+        filesystemIsolation.args,
+        {
+          cwd: dataDir,
+          env,
+          stdio: ['pipe', 'pipe', 'pipe'],
+          detached: process.platform !== 'win32',
+        },
+      );
 
       let stdout = '';
       let stderr = '';
@@ -141,7 +190,7 @@ export async function handleScriptSandbox(
 
       const killTimer = setTimeout(() => {
         timedOut = true;
-        child.kill('SIGKILL');
+        killSandboxProcess(child);
       }, timeoutMs);
 
       child.stdout.on('data', (chunk: Buffer) => {

--- a/packages/desktop/packages/session-tools-core/src/handlers/transform-data.test.ts
+++ b/packages/desktop/packages/session-tools-core/src/handlers/transform-data.test.ts
@@ -152,6 +152,8 @@ describe('transform_data path containment', () => {
     expect(existsSync(join(dataDir, 'out.json'))).toBe(true);
     const text = result.content[0]?.text ?? '';
     expect(text).toContain('out.json\nRuntime:');
+    expect(text).toMatch(/Network isolation: \w+ \([\w-]+\)/);
+    expect(text).toMatch(/Filesystem isolation: \w+ \([\w-]+\)/);
     expect(text).toContain('\n\nUse this absolute path as the "src" value');
     expect(text).toContain('\n\nStdout:\nmade output');
   });
@@ -191,6 +193,25 @@ describe('transform_data path containment', () => {
 
     expect(result.isError).toBe(true);
     expect(existsSync(outsidePath)).toBe(false);
+  });
+
+  it('blocks scripts from writing outside the data directory', async () => {
+    const sessionStatePath = join(sessionDir, 'session.jsonl');
+
+    const result = await handleTransformData(ctx(), {
+      language: 'node',
+      script: `const fs=require('node:fs');fs.writeFileSync(${JSON.stringify(sessionStatePath)}, 'nope');fs.writeFileSync(process.argv.at(-1), '{}');`,
+      inputFiles: ['in.txt'],
+      outputFile: 'out.json',
+    });
+
+    if (assertIsolationUnavailable(result)) {
+      expect(existsSync(sessionStatePath)).toBe(false);
+      return;
+    }
+
+    expect(result.isError).toBe(true);
+    expect(existsSync(sessionStatePath)).toBe(false);
   });
 
   it('still rejects input files outside both session and skills directories', async () => {

--- a/packages/desktop/packages/session-tools-core/src/handlers/transform-data.test.ts
+++ b/packages/desktop/packages/session-tools-core/src/handlers/transform-data.test.ts
@@ -1,9 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, symlinkSync } from 'node:fs';
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  existsSync,
+  symlinkSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { SessionToolContext } from '../context.ts';
 import { handleTransformData } from './transform-data.ts';
+import type { ToolResult } from '../types.ts';
 
 describe('transform_data path containment', () => {
   let rootDir: string;
@@ -26,7 +34,10 @@ describe('transform_data path containment', () => {
 
     writeFileSync(join(sessionDir, 'in.txt'), 'hello');
     writeFileSync(join(siblingDir, 'outside.txt'), 'evil');
-    writeFileSync(join(skillsDir, 'branding', 'assets', 'template.pptx'), 'fake-pptx');
+    writeFileSync(
+      join(skillsDir, 'branding', 'assets', 'template.pptx'),
+      'fake-pptx',
+    );
   });
 
   afterEach(() => {
@@ -59,6 +70,21 @@ describe('transform_data path containment', () => {
     };
   }
 
+  function assertIsolationUnavailable(result: ToolResult): boolean {
+    const text = result.content[0]?.text ?? '';
+    const isUnavailable =
+      result.isError === true &&
+      (text.includes('requires network isolation') ||
+        text.includes('requires filesystem isolation'));
+
+    if (isUnavailable) {
+      expect(text).toContain('transform_data requires');
+      expect(text).toContain('but no supported isolation backend is available');
+    }
+
+    return isUnavailable;
+  }
+
   it('rejects output path in sibling directory with shared prefix', async () => {
     const result = await handleTransformData(ctx(), {
       language: 'node',
@@ -68,7 +94,9 @@ describe('transform_data path containment', () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('outputFile must be within the session data directory');
+    expect(result.content[0]?.text).toContain(
+      'outputFile must be within the session data directory',
+    );
   });
 
   it('rejects input path in sibling directory with shared prefix', async () => {
@@ -80,7 +108,9 @@ describe('transform_data path containment', () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('inputFile must be within the session or skills directory');
+    expect(result.content[0]?.text).toContain(
+      'inputFile must be within the session or skills directory',
+    );
   });
 
   it('rejects output path that escapes via symlink', async () => {
@@ -100,16 +130,23 @@ describe('transform_data path containment', () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('outputFile must be within the session data directory');
+    expect(result.content[0]?.text).toContain(
+      'outputFile must be within the session data directory',
+    );
   });
 
   it('allows valid descendant paths and writes output', async () => {
     const result = await handleTransformData(ctx(), {
       language: 'node',
-      script: "const fs=require('node:fs');console.log('made output');fs.writeFileSync(process.argv.at(-1), JSON.stringify({ok:true}));",
+      script:
+        "const fs=require('node:fs');console.log('made output');fs.writeFileSync(process.argv.at(-1), JSON.stringify({ok:true}));",
       inputFiles: ['in.txt'],
       outputFile: 'out.json',
     });
+
+    if (assertIsolationUnavailable(result)) {
+      return;
+    }
 
     expect(result.isError).toBe(false);
     expect(existsSync(join(dataDir, 'out.json'))).toBe(true);
@@ -123,13 +160,37 @@ describe('transform_data path containment', () => {
     const skillAsset = join(skillsDir, 'branding', 'assets', 'template.pptx');
     const result = await handleTransformData(ctx(), {
       language: 'node',
-      script: "const fs=require('node:fs');const data=fs.readFileSync(process.argv.at(-2),'utf-8');fs.writeFileSync(process.argv.at(-1), JSON.stringify({content:data}));",
+      script:
+        "const fs=require('node:fs');const data=fs.readFileSync(process.argv.at(-2),'utf-8');fs.writeFileSync(process.argv.at(-1), JSON.stringify({content:data}));",
       inputFiles: [skillAsset],
       outputFile: 'out.json',
     });
 
+    if (assertIsolationUnavailable(result)) {
+      return;
+    }
+
     expect(result.isError).toBe(false);
     expect(existsSync(join(dataDir, 'out.json'))).toBe(true);
+  });
+
+  it('blocks scripts from writing outside the session directory', async () => {
+    const outsidePath = join(rootDir, 'outside-write.txt');
+
+    const result = await handleTransformData(ctx(), {
+      language: 'node',
+      script: `const fs=require('node:fs');fs.writeFileSync(${JSON.stringify(outsidePath)}, 'nope');fs.writeFileSync(process.argv.at(-1), '{}');`,
+      inputFiles: ['in.txt'],
+      outputFile: 'out.json',
+    });
+
+    if (assertIsolationUnavailable(result)) {
+      expect(existsSync(outsidePath)).toBe(false);
+      return;
+    }
+
+    expect(result.isError).toBe(true);
+    expect(existsSync(outsidePath)).toBe(false);
   });
 
   it('still rejects input files outside both session and skills directories', async () => {
@@ -141,7 +202,9 @@ describe('transform_data path containment', () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('inputFile must be within the session or skills directory');
+    expect(result.content[0]?.text).toContain(
+      'inputFile must be within the session or skills directory',
+    );
   });
 
   it('rejects input path in skills dir that escapes via symlink', async () => {
@@ -162,13 +225,18 @@ describe('transform_data path containment', () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('inputFile must be within the session or skills directory');
+    expect(result.content[0]?.text).toContain(
+      'inputFile must be within the session or skills directory',
+    );
   });
 
   it('rejects skills path when skillsPath is not available in context', async () => {
     // skillsPath is a required getter on SessionToolContext, but at runtime
     // it could theoretically be empty. Verify the handler falls back safely.
-    const ctxNoSkills = { ...ctx(), skillsPath: undefined } as unknown as SessionToolContext;
+    const ctxNoSkills = {
+      ...ctx(),
+      skillsPath: undefined,
+    } as unknown as SessionToolContext;
     const result = await handleTransformData(ctxNoSkills, {
       language: 'node',
       script: "require('node:fs').writeFileSync(process.argv.at(-1), 'ok')",
@@ -177,6 +245,8 @@ describe('transform_data path containment', () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('inputFile must be within the session or skills directory');
+    expect(result.content[0]?.text).toContain(
+      'inputFile must be within the session or skills directory',
+    );
   });
 });

--- a/packages/desktop/packages/session-tools-core/src/handlers/transform-data.ts
+++ b/packages/desktop/packages/session-tools-core/src/handlers/transform-data.ts
@@ -15,7 +15,18 @@ import { join, resolve } from 'node:path';
 import { existsSync, mkdirSync, writeFileSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { createScriptRuntimeEnv } from '../runtime/sandbox-env.ts';
-import { isPathWithinDirectory, isPathWithinDirectoryForCreation } from '../runtime/path-security.ts';
+import {
+  applyFilesystemIsolation,
+  type FilesystemIsolationPlan,
+} from '../runtime/filesystem-isolation.ts';
+import {
+  applyNetworkIsolation,
+  type NetworkIsolationPlan,
+} from '../runtime/network-isolation.ts';
+import {
+  isPathWithinDirectory,
+  isPathWithinDirectoryForCreation,
+} from '../runtime/path-security.ts';
 import { resolveScriptRuntime } from '../runtime/resolve-script-runtime.ts';
 
 export interface TransformDataArgs {
@@ -37,10 +48,12 @@ const TRANSFORM_DATA_TIMEOUT_MS = 30_000;
  */
 export async function handleTransformData(
   ctx: SessionToolContext,
-  args: TransformDataArgs
+  args: TransformDataArgs,
 ): Promise<ToolResult> {
   if (!ctx.sessionPath || !ctx.dataPath) {
-    return errorResponse('transform_data requires sessionPath and dataPath in context.');
+    return errorResponse(
+      'transform_data requires sessionPath and dataPath in context.',
+    );
   }
 
   const sessionDir = ctx.sessionPath;
@@ -50,7 +63,7 @@ export async function handleTransformData(
   const resolvedOutput = resolve(dataDir, args.outputFile);
   if (!isPathWithinDirectoryForCreation(resolvedOutput, dataDir)) {
     return errorResponse(
-      `outputFile must be within the session data directory. Got: ${args.outputFile}`
+      `outputFile must be within the session data directory. Got: ${args.outputFile}`,
     );
   }
 
@@ -65,10 +78,12 @@ export async function handleTransformData(
   for (const inputFile of args.inputFiles) {
     // Try resolving relative to session dir first; if it's absolute, resolve() returns it as-is
     const resolvedInput = resolve(sessionDir, inputFile);
-    const isAllowed = allowedInputDirs.some(dir => isPathWithinDirectory(resolvedInput, dir));
+    const isAllowed = allowedInputDirs.some((dir) =>
+      isPathWithinDirectory(resolvedInput, dir),
+    );
     if (!isAllowed) {
       return errorResponse(
-        `inputFile must be within the session or skills directory. Got: ${inputFile}`
+        `inputFile must be within the session or skills directory. Got: ${inputFile}`,
       );
     }
     if (!existsSync(resolvedInput)) {
@@ -84,14 +99,66 @@ export async function handleTransformData(
 
   // Write script to temp file
   const ext = args.language === 'python3' ? '.py' : '.js';
-  const tempScript = join(tmpdir(), `craft-transform-${ctx.sessionId}-${Date.now()}${ext}`);
+  const tempScript = join(
+    tmpdir(),
+    `craft-transform-${ctx.sessionId}-${Date.now()}${ext}`,
+  );
   writeFileSync(tempScript, args.script, 'utf-8');
 
   try {
-    // Build command from shared runtime resolver
     const runtime = resolveScriptRuntime(args.language);
-    const cmd = runtime.command;
-    const spawnArgs = [...runtime.argsPrefix, tempScript, ...resolvedInputs, resolvedOutput];
+    const runtimeArgs = [
+      ...runtime.argsPrefix,
+      tempScript,
+      ...resolvedInputs,
+      resolvedOutput,
+    ];
+
+    let networkIsolation: NetworkIsolationPlan;
+    let filesystemIsolation: FilesystemIsolationPlan;
+
+    if (process.platform === 'darwin') {
+      filesystemIsolation = applyFilesystemIsolation(
+        runtime.command,
+        runtimeArgs,
+        sessionDir,
+        {
+          includeNetworkDeny: true,
+        },
+      );
+      networkIsolation = {
+        status: filesystemIsolation.status,
+        backend:
+          filesystemIsolation.status === 'enforced' ? 'sandbox-exec' : 'none',
+        command: filesystemIsolation.command,
+        args: filesystemIsolation.args,
+      };
+    } else {
+      networkIsolation = applyNetworkIsolation(runtime.command, runtimeArgs);
+      if (networkIsolation.status !== 'enforced') {
+        return errorResponse(
+          'transform_data requires network isolation in all permission modes, but no supported isolation backend is available on this platform/runtime.',
+        );
+      }
+
+      filesystemIsolation = applyFilesystemIsolation(
+        networkIsolation.command,
+        networkIsolation.args,
+        sessionDir,
+      );
+    }
+
+    if (networkIsolation.status !== 'enforced') {
+      return errorResponse(
+        'transform_data requires network isolation in all permission modes, but no supported isolation backend is available on this platform/runtime.',
+      );
+    }
+
+    if (filesystemIsolation.status !== 'enforced') {
+      return errorResponse(
+        'transform_data requires filesystem isolation in all permission modes, but no supported isolation backend is available on this platform/runtime.',
+      );
+    }
 
     // Strip sensitive env vars + redirect runtime cache/temp paths to session data dir
     const env = createScriptRuntimeEnv({
@@ -102,12 +169,20 @@ export async function handleTransformData(
     // Spawn subprocess with manual timeout that escalates to SIGKILL.
     // We can't rely on spawn()'s built-in `timeout` option because it only sends
     // SIGTERM, which can be caught/ignored — leaving the promise hanging forever.
-    const result = await new Promise<{ stdout: string; stderr: string; code: number | null }>((resolvePromise, reject) => {
-      const child = spawn(cmd, spawnArgs, {
-        cwd: dataDir,
-        env,
-        stdio: ['ignore', 'pipe', 'pipe'],
-      });
+    const result = await new Promise<{
+      stdout: string;
+      stderr: string;
+      code: number | null;
+    }>((resolvePromise, reject) => {
+      const child = spawn(
+        filesystemIsolation.command,
+        filesystemIsolation.args,
+        {
+          cwd: dataDir,
+          env,
+          stdio: ['ignore', 'pipe', 'pipe'],
+        },
+      );
 
       let stdout = '';
       let stderr = '';
@@ -118,13 +193,21 @@ export async function handleTransformData(
         child.kill('SIGKILL');
       }, TRANSFORM_DATA_TIMEOUT_MS);
 
-      child.stdout.on('data', (data: Buffer) => { stdout += data.toString(); });
-      child.stderr.on('data', (data: Buffer) => { stderr += data.toString(); });
+      child.stdout.on('data', (data: Buffer) => {
+        stdout += data.toString();
+      });
+      child.stderr.on('data', (data: Buffer) => {
+        stderr += data.toString();
+      });
 
       child.on('close', (code) => {
         clearTimeout(killTimer);
         if (timedOut) {
-          resolvePromise({ stdout, stderr: `Script timed out after ${TRANSFORM_DATA_TIMEOUT_MS / 1000}s and was killed`, code });
+          resolvePromise({
+            stdout,
+            stderr: `Script timed out after ${TRANSFORM_DATA_TIMEOUT_MS / 1000}s and was killed`,
+            code,
+          });
         } else {
           resolvePromise({ stdout, stderr, code });
         }
@@ -137,24 +220,33 @@ export async function handleTransformData(
     });
 
     if (result.code !== 0) {
-      const errorOutput = result.stderr || result.stdout || 'Script exited with non-zero code';
+      const errorOutput =
+        result.stderr || result.stdout || 'Script exited with non-zero code';
       return errorResponse(
-        `Script failed (exit code ${result.code}):\n${errorOutput.slice(0, 2000)}`
+        `Script failed (exit code ${result.code}):\n${errorOutput.slice(0, 2000)}`,
       );
     }
 
     // Verify output file was created
     if (!existsSync(resolvedOutput)) {
       return errorResponse(
-        `Script completed but output file was not created: ${args.outputFile}\n\nStdout: ${result.stdout.slice(0, 500)}`
+        `Script completed but output file was not created: ${args.outputFile}\n\nStdout: ${result.stdout.slice(0, 500)}`,
       );
     }
 
     // Return the absolute path for use in preview/table block "src" fields
     const lines = [`Output written to: ${resolvedOutput}`];
-    lines.push(`Runtime: ${cmd} (source: ${runtime.source})`);
+    lines.push(`Runtime: ${runtime.command} (source: ${runtime.source})`);
+    lines.push(
+      `Network isolation: ${networkIsolation.status} (${networkIsolation.backend})`,
+    );
+    lines.push(
+      `Filesystem isolation: ${filesystemIsolation.status} (${filesystemIsolation.backend})`,
+    );
     lines.push('');
-    lines.push('Use this absolute path as the "src" value in your datatable, spreadsheet, html-preview, pdf-preview, or image-preview block.');
+    lines.push(
+      'Use this absolute path as the "src" value in your datatable, spreadsheet, html-preview, pdf-preview, or image-preview block.',
+    );
     if (result.stdout.trim()) {
       lines.push('');
       lines.push(`Stdout:\n${result.stdout.slice(0, 500)}`);
@@ -166,6 +258,10 @@ export async function handleTransformData(
     return errorResponse(`Error running script: ${msg}`);
   } finally {
     // Clean up temp script
-    try { unlinkSync(tempScript); } catch { /* ignore */ }
+    try {
+      unlinkSync(tempScript);
+    } catch {
+      /* ignore */
+    }
   }
 }

--- a/packages/desktop/packages/session-tools-core/src/handlers/transform-data.ts
+++ b/packages/desktop/packages/session-tools-core/src/handlers/transform-data.ts
@@ -11,6 +11,7 @@ import type { SessionToolContext } from '../context.ts';
 import type { ToolResult } from '../types.ts';
 import { successResponse, errorResponse } from '../response.ts';
 import { spawn } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
 import { join, resolve } from 'node:path';
 import { existsSync, mkdirSync, writeFileSync, unlinkSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
@@ -19,7 +20,6 @@ import {
   applyFilesystemIsolation,
   type FilesystemIsolationPlan,
 } from '../runtime/filesystem-isolation.ts';
-import type { NetworkIsolationPlan } from '../runtime/network-isolation.ts';
 import {
   isPathWithinDirectory,
   isPathWithinDirectoryForCreation,
@@ -35,9 +35,16 @@ export interface TransformDataArgs {
 
 const TRANSFORM_DATA_TIMEOUT_MS = 30_000;
 
+interface TransformNetworkIsolationPlan {
+  status: FilesystemIsolationPlan['status'];
+  backend: FilesystemIsolationPlan['backend'] | 'none';
+  command: string;
+  args: string[];
+}
+
 function formatIsolationContext(
   filesystemIsolation: FilesystemIsolationPlan,
-  networkIsolation: NetworkIsolationPlan,
+  networkIsolation: TransformNetworkIsolationPlan,
 ): string {
   const commandLine = [
     filesystemIsolation.command,
@@ -48,6 +55,23 @@ function formatIsolationContext(
     `Isolation: filesystem=${filesystemIsolation.status} (${filesystemIsolation.backend}), network=${networkIsolation.status} (${networkIsolation.backend})`,
     `Command: ${commandLine.slice(0, 1000)}`,
   ].join('\n');
+}
+
+function killSandboxProcess(child: ChildProcess): void {
+  if (!child.pid) {
+    child.kill('SIGKILL');
+    return;
+  }
+
+  try {
+    if (process.platform === 'win32') {
+      child.kill('SIGKILL');
+    } else {
+      process.kill(-child.pid, 'SIGKILL');
+    }
+  } catch {
+    child.kill('SIGKILL');
+  }
 }
 
 /**
@@ -112,7 +136,7 @@ export async function handleTransformData(
   // Write script to temp file
   const ext = args.language === 'python3' ? '.py' : '.js';
   const tempScript = join(dataDir, `.craft-transform-${randomUUID()}${ext}`);
-  let networkIsolation: NetworkIsolationPlan | null = null;
+  let networkIsolation: TransformNetworkIsolationPlan | null = null;
   let filesystemIsolation: FilesystemIsolationPlan | null = null;
 
   try {
@@ -132,6 +156,7 @@ export async function handleTransformData(
       dataDir,
       {
         includeNetworkDeny: true,
+        isolateIpc: true,
       },
     );
     networkIsolation = {
@@ -147,12 +172,6 @@ export async function handleTransformData(
     if (filesystemIsolation.status !== 'enforced') {
       return errorResponse(
         'transform_data requires filesystem isolation in all permission modes, but no supported isolation backend is available on this platform/runtime.',
-      );
-    }
-
-    if (networkIsolation.status !== 'enforced') {
-      return errorResponse(
-        'transform_data requires network isolation in all permission modes, but no supported isolation backend is available on this platform/runtime.',
       );
     }
 
@@ -180,6 +199,7 @@ export async function handleTransformData(
           cwd: dataDir,
           env,
           stdio: ['ignore', 'pipe', 'pipe'],
+          detached: process.platform !== 'win32',
         },
       );
 
@@ -189,7 +209,7 @@ export async function handleTransformData(
 
       const killTimer = setTimeout(() => {
         timedOut = true;
-        child.kill('SIGKILL');
+        killSandboxProcess(child);
       }, TRANSFORM_DATA_TIMEOUT_MS);
 
       child.stdout.on('data', (data: Buffer) => {

--- a/packages/desktop/packages/session-tools-core/src/handlers/transform-data.ts
+++ b/packages/desktop/packages/session-tools-core/src/handlers/transform-data.ts
@@ -13,16 +13,13 @@ import { successResponse, errorResponse } from '../response.ts';
 import { spawn } from 'node:child_process';
 import { join, resolve } from 'node:path';
 import { existsSync, mkdirSync, writeFileSync, unlinkSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
 import { createScriptRuntimeEnv } from '../runtime/sandbox-env.ts';
 import {
   applyFilesystemIsolation,
   type FilesystemIsolationPlan,
 } from '../runtime/filesystem-isolation.ts';
-import {
-  applyNetworkIsolation,
-  type NetworkIsolationPlan,
-} from '../runtime/network-isolation.ts';
+import type { NetworkIsolationPlan } from '../runtime/network-isolation.ts';
 import {
   isPathWithinDirectory,
   isPathWithinDirectoryForCreation,
@@ -37,6 +34,21 @@ export interface TransformDataArgs {
 }
 
 const TRANSFORM_DATA_TIMEOUT_MS = 30_000;
+
+function formatIsolationContext(
+  filesystemIsolation: FilesystemIsolationPlan,
+  networkIsolation: NetworkIsolationPlan,
+): string {
+  const commandLine = [
+    filesystemIsolation.command,
+    ...filesystemIsolation.args,
+  ].join(' ');
+  return [
+    '',
+    `Isolation: filesystem=${filesystemIsolation.status} (${filesystemIsolation.backend}), network=${networkIsolation.status} (${networkIsolation.backend})`,
+    `Command: ${commandLine.slice(0, 1000)}`,
+  ].join('\n');
+}
 
 /**
  * Handle the transform_data tool call.
@@ -99,13 +111,13 @@ export async function handleTransformData(
 
   // Write script to temp file
   const ext = args.language === 'python3' ? '.py' : '.js';
-  const tempScript = join(
-    tmpdir(),
-    `craft-transform-${ctx.sessionId}-${Date.now()}${ext}`,
-  );
-  writeFileSync(tempScript, args.script, 'utf-8');
+  const tempScript = join(dataDir, `.craft-transform-${randomUUID()}${ext}`);
+  let networkIsolation: NetworkIsolationPlan | null = null;
+  let filesystemIsolation: FilesystemIsolationPlan | null = null;
 
   try {
+    writeFileSync(tempScript, args.script, { encoding: 'utf-8', flag: 'wx' });
+
     const runtime = resolveScriptRuntime(args.language);
     const runtimeArgs = [
       ...runtime.argsPrefix,
@@ -114,37 +126,27 @@ export async function handleTransformData(
       resolvedOutput,
     ];
 
-    let networkIsolation: NetworkIsolationPlan;
-    let filesystemIsolation: FilesystemIsolationPlan;
+    filesystemIsolation = applyFilesystemIsolation(
+      runtime.command,
+      runtimeArgs,
+      dataDir,
+      {
+        includeNetworkDeny: true,
+      },
+    );
+    networkIsolation = {
+      status: filesystemIsolation.status,
+      backend:
+        filesystemIsolation.status === 'enforced'
+          ? filesystemIsolation.backend
+          : 'none',
+      command: filesystemIsolation.command,
+      args: filesystemIsolation.args,
+    };
 
-    if (process.platform === 'darwin') {
-      filesystemIsolation = applyFilesystemIsolation(
-        runtime.command,
-        runtimeArgs,
-        sessionDir,
-        {
-          includeNetworkDeny: true,
-        },
-      );
-      networkIsolation = {
-        status: filesystemIsolation.status,
-        backend:
-          filesystemIsolation.status === 'enforced' ? 'sandbox-exec' : 'none',
-        command: filesystemIsolation.command,
-        args: filesystemIsolation.args,
-      };
-    } else {
-      networkIsolation = applyNetworkIsolation(runtime.command, runtimeArgs);
-      if (networkIsolation.status !== 'enforced') {
-        return errorResponse(
-          'transform_data requires network isolation in all permission modes, but no supported isolation backend is available on this platform/runtime.',
-        );
-      }
-
-      filesystemIsolation = applyFilesystemIsolation(
-        networkIsolation.command,
-        networkIsolation.args,
-        sessionDir,
+    if (filesystemIsolation.status !== 'enforced') {
+      return errorResponse(
+        'transform_data requires filesystem isolation in all permission modes, but no supported isolation backend is available on this platform/runtime.',
       );
     }
 
@@ -154,11 +156,8 @@ export async function handleTransformData(
       );
     }
 
-    if (filesystemIsolation.status !== 'enforced') {
-      return errorResponse(
-        'transform_data requires filesystem isolation in all permission modes, but no supported isolation backend is available on this platform/runtime.',
-      );
-    }
+    const enforcedFilesystemIsolation = filesystemIsolation;
+    const enforcedNetworkIsolation = networkIsolation;
 
     // Strip sensitive env vars + redirect runtime cache/temp paths to session data dir
     const env = createScriptRuntimeEnv({
@@ -175,8 +174,8 @@ export async function handleTransformData(
       code: number | null;
     }>((resolvePromise, reject) => {
       const child = spawn(
-        filesystemIsolation.command,
-        filesystemIsolation.args,
+        enforcedFilesystemIsolation.command,
+        enforcedFilesystemIsolation.args,
         {
           cwd: dataDir,
           env,
@@ -223,7 +222,7 @@ export async function handleTransformData(
       const errorOutput =
         result.stderr || result.stdout || 'Script exited with non-zero code';
       return errorResponse(
-        `Script failed (exit code ${result.code}):\n${errorOutput.slice(0, 2000)}`,
+        `Script failed (exit code ${result.code}):\n${errorOutput.slice(0, 2000)}${formatIsolationContext(enforcedFilesystemIsolation, enforcedNetworkIsolation)}`,
       );
     }
 
@@ -238,10 +237,10 @@ export async function handleTransformData(
     const lines = [`Output written to: ${resolvedOutput}`];
     lines.push(`Runtime: ${runtime.command} (source: ${runtime.source})`);
     lines.push(
-      `Network isolation: ${networkIsolation.status} (${networkIsolation.backend})`,
+      `Network isolation: ${enforcedNetworkIsolation.status} (${enforcedNetworkIsolation.backend})`,
     );
     lines.push(
-      `Filesystem isolation: ${filesystemIsolation.status} (${filesystemIsolation.backend})`,
+      `Filesystem isolation: ${enforcedFilesystemIsolation.status} (${enforcedFilesystemIsolation.backend})`,
     );
     lines.push('');
     lines.push(
@@ -255,7 +254,11 @@ export async function handleTransformData(
     return successResponse(lines.join('\n'));
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-    return errorResponse(`Error running script: ${msg}`);
+    const isolationContext =
+      filesystemIsolation && networkIsolation
+        ? formatIsolationContext(filesystemIsolation, networkIsolation)
+        : '';
+    return errorResponse(`Error running script: ${msg}${isolationContext}`);
   } finally {
     // Clean up temp script
     try {

--- a/packages/desktop/packages/session-tools-core/src/runtime/filesystem-isolation.test.ts
+++ b/packages/desktop/packages/session-tools-core/src/runtime/filesystem-isolation.test.ts
@@ -1,15 +1,87 @@
 import { describe, it, expect } from 'bun:test';
-import { buildDarwinSandboxProfile } from './filesystem-isolation.ts';
+import {
+  mkdtempSync,
+  mkdirSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import {
+  buildDarwinSandboxProfile,
+  combineFirejailFilesystemIsolation,
+} from './filesystem-isolation.ts';
 
 describe('buildDarwinSandboxProfile', () => {
   it('includes session subpath write allow', () => {
     const profile = buildDarwinSandboxProfile('/tmp/craft-session');
-    expect(profile).toContain('(allow file-write* (subpath "/tmp/craft-session"))');
+    expect(profile).toContain(
+      '(allow file-write* (subpath "/tmp/craft-session"))',
+    );
     expect(profile).not.toContain('(deny network*)');
   });
 
   it('includes deny network when requested', () => {
-    const profile = buildDarwinSandboxProfile('/tmp/craft-session', { includeNetworkDeny: true });
+    const profile = buildDarwinSandboxProfile('/tmp/craft-session', {
+      includeNetworkDeny: true,
+    });
     expect(profile).toContain('(deny network*)');
+  });
+
+  it('includes logical and real write roots when the session path crosses a symlink', () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
+    const root = mkdtempSync(join(tmpdir(), 'sandbox-profile-roots-'));
+    try {
+      const realRoot = join(root, 'real');
+      const linkRoot = join(root, 'link');
+      mkdirSync(realRoot, { recursive: true });
+      symlinkSync(realRoot, linkRoot, 'dir');
+
+      const logicalSession = join(linkRoot, 'session');
+      mkdirSync(logicalSession, { recursive: true });
+      const logicalRoot = resolve(logicalSession);
+      const realSession = realpathSync.native(logicalSession);
+
+      expect(realSession).not.toBe(logicalRoot);
+
+      const profile = buildDarwinSandboxProfile(logicalSession);
+      expect(profile).toContain(
+        `(allow file-write* (subpath "${logicalRoot}"))`,
+      );
+      expect(profile).toContain(
+        `(allow file-write* (subpath "${realSession}"))`,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('combineFirejailFilesystemIsolation', () => {
+  it('adds filesystem flags to an existing firejail network wrapper', () => {
+    expect(
+      combineFirejailFilesystemIsolation(
+        ['--quiet', '--net=none', '--', 'node', 'script.js'],
+        '/tmp/session',
+      ),
+    ).toEqual([
+      '--quiet',
+      '--net=none',
+      '--private=/tmp/session',
+      '--whitelist=/tmp/session',
+      '--',
+      'node',
+      'script.js',
+    ]);
+  });
+
+  it('returns null when firejail args do not contain a command separator', () => {
+    expect(
+      combineFirejailFilesystemIsolation(['--quiet', '--net=none'], '/tmp/x'),
+    ).toBeNull();
   });
 });

--- a/packages/desktop/packages/session-tools-core/src/runtime/filesystem-isolation.test.ts
+++ b/packages/desktop/packages/session-tools-core/src/runtime/filesystem-isolation.test.ts
@@ -8,10 +8,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import {
-  buildDarwinSandboxProfile,
-  combineFirejailFilesystemIsolation,
-} from './filesystem-isolation.ts';
+import { buildDarwinSandboxProfile } from './filesystem-isolation.ts';
 
 describe('buildDarwinSandboxProfile', () => {
   it('includes session subpath write allow', () => {
@@ -29,10 +26,10 @@ describe('buildDarwinSandboxProfile', () => {
     expect(profile).toContain('(deny network*)');
   });
 
-  it('escapes parentheses in session paths', () => {
+  it('keeps parentheses literal inside quoted session paths', () => {
     const profile = buildDarwinSandboxProfile('/tmp/craft-(session)');
     expect(profile).toContain(
-      '(allow file-write* (subpath "/tmp/craft-\\(session\\)"))',
+      '(allow file-write* (subpath "/tmp/craft-(session)"))',
     );
   });
 
@@ -74,30 +71,5 @@ describe('buildDarwinSandboxProfile', () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
-});
-
-describe('combineFirejailFilesystemIsolation', () => {
-  it('adds filesystem flags to an existing firejail network wrapper', () => {
-    expect(
-      combineFirejailFilesystemIsolation(
-        ['--quiet', '--net=none', '--', 'node', 'script.js'],
-        '/tmp/session',
-      ),
-    ).toEqual([
-      '--quiet',
-      '--net=none',
-      '--private=/tmp/session',
-      '--whitelist=/tmp/session',
-      '--',
-      'node',
-      'script.js',
-    ]);
-  });
-
-  it('returns null when firejail args do not contain a command separator', () => {
-    expect(
-      combineFirejailFilesystemIsolation(['--quiet', '--net=none'], '/tmp/x'),
-    ).toBeNull();
   });
 });

--- a/packages/desktop/packages/session-tools-core/src/runtime/filesystem-isolation.test.ts
+++ b/packages/desktop/packages/session-tools-core/src/runtime/filesystem-isolation.test.ts
@@ -29,6 +29,22 @@ describe('buildDarwinSandboxProfile', () => {
     expect(profile).toContain('(deny network*)');
   });
 
+  it('escapes parentheses in session paths', () => {
+    const profile = buildDarwinSandboxProfile('/tmp/craft-(session)');
+    expect(profile).toContain(
+      '(allow file-write* (subpath "/tmp/craft-\\(session\\)"))',
+    );
+  });
+
+  it('falls back to resolved path when realpathSync fails', () => {
+    const missingPath = join(tmpdir(), 'sandbox-profile-missing-session-path');
+    const resolvedPath = resolve(missingPath);
+    const profile = buildDarwinSandboxProfile(missingPath);
+    expect(profile).toContain(
+      `(allow file-write* (subpath "${resolvedPath}"))`,
+    );
+  });
+
   it('includes logical and real write roots when the session path crosses a symlink', () => {
     if (process.platform === 'win32') {
       return;

--- a/packages/desktop/packages/session-tools-core/src/runtime/filesystem-isolation.ts
+++ b/packages/desktop/packages/session-tools-core/src/runtime/filesystem-isolation.ts
@@ -11,6 +11,7 @@ export interface FilesystemIsolationPlan {
 
 export interface FilesystemIsolationOptions {
   includeNetworkDeny?: boolean;
+  isolateIpc?: boolean;
 }
 
 function existsOnPath(binary: string): boolean {
@@ -38,11 +39,7 @@ function canUseSandboxExec(): boolean {
 }
 
 function escapeSandboxPath(path: string): string {
-  return path
-    .replace(/\\/g, '\\\\')
-    .replace(/"/g, '\\"')
-    .replace(/\(/g, '\\(')
-    .replace(/\)/g, '\\)');
+  return path.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
 function sandboxWriteRoots(sessionDir: string): string[] {
@@ -53,26 +50,6 @@ function sandboxWriteRoots(sessionDir: string): string[] {
   } catch {
     return [resolved];
   }
-}
-
-export function combineFirejailFilesystemIsolation(
-  args: string[],
-  sessionRoot: string,
-): string[] | null {
-  const separatorIndex = args.indexOf('--');
-  if (separatorIndex === -1) {
-    return null;
-  }
-
-  const outerArgs = args.slice(0, separatorIndex);
-  const innerArgs = args.slice(separatorIndex + 1);
-  return [
-    ...outerArgs,
-    `--private=${sessionRoot}`,
-    `--whitelist=${sessionRoot}`,
-    '--',
-    ...innerArgs,
-  ];
 }
 
 export function buildDarwinSandboxProfile(
@@ -104,7 +81,7 @@ export function buildDarwinSandboxProfile(
  *
  * Current support:
  * - macOS: sandbox-exec profile
- * - Linux: bubblewrap (preferred) or firejail private/whitelist profile
+ * - Linux: bubblewrap
  * - others: unavailable (fail-safe for script_sandbox)
  */
 export function applyFilesystemIsolation(
@@ -130,7 +107,10 @@ export function applyFilesystemIsolation(
     if (existsOnPath('bwrap')) {
       // Read-only root + writable bind mount for the session subtree.
       // This limits writes to sessionRoot while preserving runtime/library access.
-      const namespaceArgs = ['--unshare-ipc'];
+      const namespaceArgs: string[] = [];
+      if (options?.isolateIpc) {
+        namespaceArgs.push('--unshare-ipc');
+      }
       if (options?.includeNetworkDeny) {
         namespaceArgs.push('--unshare-net');
       }
@@ -159,37 +139,8 @@ export function applyFilesystemIsolation(
       };
     }
 
-    if (existsOnPath('firejail')) {
-      if (command === 'firejail') {
-        const combinedArgs = combineFirejailFilesystemIsolation(
-          args,
-          sessionRoot,
-        );
-        if (combinedArgs) {
-          return {
-            status: 'enforced',
-            backend: 'firejail',
-            command: 'firejail',
-            args: combinedArgs,
-          };
-        }
-      }
-
-      return {
-        status: 'enforced',
-        backend: 'firejail',
-        command: 'firejail',
-        args: [
-          '--quiet',
-          ...(options?.includeNetworkDeny ? ['--net=none'] : []),
-          `--private=${sessionRoot}`,
-          `--whitelist=${sessionRoot}`,
-          '--',
-          command,
-          ...args,
-        ],
-      };
-    }
+    // firejail --private only affects $HOME, so it cannot provide the same
+    // write containment as bwrap's read-only root with one writable bind.
   }
 
   return {

--- a/packages/desktop/packages/session-tools-core/src/runtime/filesystem-isolation.ts
+++ b/packages/desktop/packages/session-tools-core/src/runtime/filesystem-isolation.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 export interface FilesystemIsolationPlan {
@@ -27,7 +28,11 @@ function canUseSandboxExec(): boolean {
     return false;
   }
 
-  const probe = spawnSync('sandbox-exec', ['-p', '(version 1) (allow default)', '/usr/bin/true'], { stdio: 'ignore' });
+  const probe = spawnSync(
+    'sandbox-exec',
+    ['-p', '(version 1) (allow default)', '/usr/bin/true'],
+    { stdio: 'ignore' },
+  );
   sandboxExecUsableCache = probe.status === 0;
   return sandboxExecUsableCache;
 }
@@ -36,11 +41,43 @@ function escapeSandboxPath(path: string): string {
   return path.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
+function sandboxWriteRoots(sessionDir: string): string[] {
+  const resolved = resolve(sessionDir);
+  try {
+    const real = realpathSync.native(resolved);
+    return real === resolved ? [resolved] : [resolved, real];
+  } catch {
+    return [resolved];
+  }
+}
+
+export function combineFirejailFilesystemIsolation(
+  args: string[],
+  sessionRoot: string,
+): string[] | null {
+  const separatorIndex = args.indexOf('--');
+  if (separatorIndex === -1) {
+    return null;
+  }
+
+  const outerArgs = args.slice(0, separatorIndex);
+  const innerArgs = args.slice(separatorIndex + 1);
+  return [
+    ...outerArgs,
+    `--private=${sessionRoot}`,
+    `--whitelist=${sessionRoot}`,
+    '--',
+    ...innerArgs,
+  ];
+}
+
 export function buildDarwinSandboxProfile(
   sessionDir: string,
   options?: FilesystemIsolationOptions,
 ): string {
-  const escapedRoot = escapeSandboxPath(resolve(sessionDir));
+  const writeAllows = sandboxWriteRoots(sessionDir).map(
+    (root) => `(allow file-write* (subpath "${escapeSandboxPath(root)}"))`,
+  );
   const profileParts = [
     '(version 1)',
     '(deny default)',
@@ -48,7 +85,7 @@ export function buildDarwinSandboxProfile(
     '(allow sysctl-read)',
     '(allow file-read*)',
     '(deny file-write*)',
-    `(allow file-write* (subpath "${escapedRoot}"))`,
+    ...writeAllows,
   ];
 
   if (options?.includeNetworkDeny) {
@@ -95,10 +132,16 @@ export function applyFilesystemIsolation(
         command: 'bwrap',
         args: [
           '--die-with-parent',
-          '--ro-bind', '/', '/',
-          '--bind', sessionRoot, sessionRoot,
-          '--proc', '/proc',
-          '--dev', '/dev',
+          '--ro-bind',
+          '/',
+          '/',
+          '--bind',
+          sessionRoot,
+          sessionRoot,
+          '--proc',
+          '/proc',
+          '--dev',
+          '/dev',
           '--',
           command,
           ...args,
@@ -107,11 +150,33 @@ export function applyFilesystemIsolation(
     }
 
     if (existsOnPath('firejail')) {
+      if (command === 'firejail') {
+        const combinedArgs = combineFirejailFilesystemIsolation(
+          args,
+          sessionRoot,
+        );
+        if (combinedArgs) {
+          return {
+            status: 'enforced',
+            backend: 'firejail',
+            command: 'firejail',
+            args: combinedArgs,
+          };
+        }
+      }
+
       return {
         status: 'enforced',
         backend: 'firejail',
         command: 'firejail',
-        args: ['--quiet', `--private=${sessionRoot}`, `--whitelist=${sessionRoot}`, '--', command, ...args],
+        args: [
+          '--quiet',
+          `--private=${sessionRoot}`,
+          `--whitelist=${sessionRoot}`,
+          '--',
+          command,
+          ...args,
+        ],
       };
     }
   }

--- a/packages/desktop/packages/session-tools-core/src/runtime/filesystem-isolation.ts
+++ b/packages/desktop/packages/session-tools-core/src/runtime/filesystem-isolation.ts
@@ -38,7 +38,11 @@ function canUseSandboxExec(): boolean {
 }
 
 function escapeSandboxPath(path: string): string {
-  return path.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return path
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\(/g, '\\(')
+    .replace(/\)/g, '\\)');
 }
 
 function sandboxWriteRoots(sessionDir: string): string[] {
@@ -126,12 +130,18 @@ export function applyFilesystemIsolation(
     if (existsOnPath('bwrap')) {
       // Read-only root + writable bind mount for the session subtree.
       // This limits writes to sessionRoot while preserving runtime/library access.
+      const namespaceArgs = ['--unshare-ipc'];
+      if (options?.includeNetworkDeny) {
+        namespaceArgs.push('--unshare-net');
+      }
+
       return {
         status: 'enforced',
         backend: 'bwrap',
         command: 'bwrap',
         args: [
           '--die-with-parent',
+          ...namespaceArgs,
           '--ro-bind',
           '/',
           '/',
@@ -171,6 +181,7 @@ export function applyFilesystemIsolation(
         command: 'firejail',
         args: [
           '--quiet',
+          ...(options?.includeNetworkDeny ? ['--net=none'] : []),
           `--private=${sessionRoot}`,
           `--whitelist=${sessionRoot}`,
           '--',

--- a/packages/desktop/packages/session-tools-core/src/runtime/network-isolation.ts
+++ b/packages/desktop/packages/session-tools-core/src/runtime/network-isolation.ts
@@ -2,7 +2,7 @@ import { spawnSync } from 'node:child_process';
 
 export interface NetworkIsolationPlan {
   status: 'enforced' | 'unavailable';
-  backend: 'sandbox-exec' | 'bwrap' | 'unshare' | 'firejail' | 'none';
+  backend: 'sandbox-exec' | 'unshare' | 'firejail' | 'none';
   command: string;
   args: string[];
 }

--- a/packages/desktop/packages/session-tools-core/src/runtime/network-isolation.ts
+++ b/packages/desktop/packages/session-tools-core/src/runtime/network-isolation.ts
@@ -2,7 +2,7 @@ import { spawnSync } from 'node:child_process';
 
 export interface NetworkIsolationPlan {
   status: 'enforced' | 'unavailable';
-  backend: 'sandbox-exec' | 'unshare' | 'firejail' | 'none';
+  backend: 'sandbox-exec' | 'bwrap' | 'unshare' | 'firejail' | 'none';
   command: string;
   args: string[];
 }
@@ -22,7 +22,11 @@ function canUseSandboxExec(): boolean {
     return false;
   }
 
-  const probe = spawnSync('sandbox-exec', ['-p', '(version 1) (allow default)', '/usr/bin/true'], { stdio: 'ignore' });
+  const probe = spawnSync(
+    'sandbox-exec',
+    ['-p', '(version 1) (allow default)', '/usr/bin/true'],
+    { stdio: 'ignore' },
+  );
   sandboxExecUsableCache = probe.status === 0;
   return sandboxExecUsableCache;
 }
@@ -41,7 +45,10 @@ function canUseUnshare(): boolean {
  * - Linux: unshare -n (preferred) or firejail --net=none
  * - others: unavailable (fail-safe for script_sandbox)
  */
-export function applyNetworkIsolation(command: string, args: string[]): NetworkIsolationPlan {
+export function applyNetworkIsolation(
+  command: string,
+  args: string[],
+): NetworkIsolationPlan {
   if (process.platform === 'darwin' && canUseSandboxExec()) {
     const profile = '(version 1) (deny network*)';
     return {


### PR DESCRIPTION
## What this PR does

This PR makes `transform_data` run transform scripts through the existing session-tool isolation wrappers instead of launching the runtime directly. It keeps the current input and output path validation, then requires network isolation and filesystem write isolation before executing the script. It also makes the macOS sandbox profile allow the real resolved session path, so valid writes still work when the session directory is reached through a system symlink such as `/var` to `/private/var`.

## Why it's needed

`transform_data` is allowed in safe mode and documented as isolated, but the previous subprocess launch only stripped selected environment variables. A transform script could write outside the intended session directory even when the declared `outputFile` was valid. This fixes that boundary by using the same fail-closed isolation approach already used by the script diagnostic tool.

## Reviewer Test Plan

### How to verify

Run the session-tools-core tests and confirm a normal transform can still write its declared output while a transform script that tries to write outside the session directory fails without creating the outside file.

### Evidence (Before & After)

Before: a locally invoked transform script could write the declared output and also create a second file outside the session tree while the handler returned success. After: the same outside write fails with `EPERM`, the outside file is not created, and a normal declared output write still succeeds under enforced network and filesystem isolation.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local verification used Bun 1.3.14 and Node 25.9.0 on macOS.

## Risk & Scope

- Main risk or tradeoff: hosts without a supported isolation backend now fail closed for `transform_data`, matching the documented safety behavior and the existing script diagnostic tool.
- Not validated / out of scope: Windows and Linux runtime behavior were not exercised locally.
- Breaking changes / migration notes: none expected for environments with supported isolation; unsupported environments will receive an explicit isolation-unavailable error instead of running without isolation.

## Linked Issues

Fixes #6282

<details>
<summary>中文说明</summary>

## What this PR does

此 PR 让 `transform_data` 通过现有的会话工具隔离封装来运行转换脚本，而不是直接启动运行时。它保留当前的输入和输出路径校验，并在执行脚本前要求网络隔离和文件系统写入隔离。同时，它让 macOS sandbox profile 允许真实解析后的会话路径，因此当会话目录经过 `/var` 到 `/private/var` 这类系统符号链接时，合法写入仍然可以正常工作。

## Why it's needed

`transform_data` 在 safe mode 中可用，并且文档说明它是隔离运行的，但之前的子进程启动逻辑只移除了部分环境变量。转换脚本即使声明了合法的 `outputFile`，仍然可以写入会话目录之外的位置。此 PR 使用脚本诊断工具已经采用的 fail-closed 隔离方式来修复这个边界问题。

## Reviewer Test Plan

### How to verify

运行 session-tools-core 测试，并确认普通转换仍然可以写入声明的输出文件，而尝试写入会话目录之外的转换脚本会失败，并且不会创建外部文件。

### Evidence (Before & After)

Before：本地调用的转换脚本可以写入声明的输出文件，同时在会话目录之外创建第二个文件，并且 handler 返回成功。After：同样的外部写入会因 `EPERM` 失败，外部文件不会被创建，普通声明输出写入仍然可以在已强制启用的网络和文件系统隔离下成功。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

本地验证使用 macOS 上的 Bun 1.3.14 和 Node 25.9.0。

## Risk & Scope

- Main risk or tradeoff：没有受支持隔离后端的主机现在会让 `transform_data` fail closed，这与文档中的安全行为以及现有脚本诊断工具保持一致。
- Not validated / out of scope：本地未验证 Windows 和 Linux 运行时行为。
- Breaking changes / migration notes：对具备受支持隔离能力的环境预计没有破坏性变更；不支持隔离的环境会收到明确的 isolation-unavailable 错误，而不是在没有隔离的情况下继续运行。

## Linked Issues

Fixes #6282

</details>
