### PR TITLE
fix(acp): pass per-session settings explicitly instead of racing on this.settings

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -1377,6 +1377,88 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
+  it('passes each concurrent newSession its own workspace settings instance', async () => {
+    const settingsA = makeSessionSettings();
+    const settingsB = makeSessionSettings();
+    vi.mocked(loadSettings).mockImplementation(
+      (cwd) =>
+        (cwd === '/workspace-a' ? settingsA : settingsB) as LoadedSettings,
+    );
+
+    const innerConfigA = {
+      ...makeInnerConfig(),
+      getSessionId: vi.fn().mockReturnValue('session-a'),
+    };
+    const innerConfigB = {
+      ...makeInnerConfig(),
+      getSessionId: vi.fn().mockReturnValue('session-b'),
+    };
+    // Session A stalls inside loadCliConfig (its real-world analogue: config
+    // load + MCP discovery + auth refresh) while session B starts and
+    // finishes; the gate then lets A complete.
+    let releaseSessionA!: () => void;
+    const sessionAGate = new Promise<void>((resolve) => {
+      releaseSessionA = resolve;
+    });
+    vi.mocked(loadCliConfig)
+      .mockImplementationOnce(async () => {
+        await sessionAGate;
+        return innerConfigA as unknown as Config;
+      })
+      .mockImplementationOnce(async () => innerConfigB as unknown as Config);
+    vi.mocked(Session).mockImplementation(
+      (sessionId: string) =>
+        ({
+          getId: vi.fn().mockReturnValue(sessionId),
+          sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
+          replayHistory: vi.fn().mockResolvedValue(undefined),
+          installRewriter: vi.fn(),
+          startCronScheduler: vi.fn(),
+          dispose: vi.fn(),
+        }) as unknown as InstanceType<typeof Session>,
+    );
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const fakeConn = {
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    } as AgentSideConnectionLike;
+    const agent = capturedAgentFactory!(fakeConn) as AgentLike;
+
+    const sessionAPromise = agent.newSession({
+      cwd: '/workspace-a',
+      mcpServers: [],
+    });
+    await vi.waitFor(() =>
+      expect(vi.mocked(loadCliConfig)).toHaveBeenCalledTimes(1),
+    );
+    await agent.newSession({ cwd: '/workspace-b', mcpServers: [] });
+    releaseSessionA();
+    await sessionAPromise;
+
+    expect(vi.mocked(loadSettings)).toHaveBeenCalledWith('/workspace-a');
+    expect(vi.mocked(loadSettings)).toHaveBeenCalledWith('/workspace-b');
+
+    const sessionCalls = vi.mocked(Session).mock.calls;
+    expect(sessionCalls).toHaveLength(2);
+    // Session B finished first while A was still mid-creation.
+    expect(sessionCalls[0]![0]).toBe('session-b');
+    expect(sessionCalls[0]![3]).toBe(settingsB);
+    // Session A must still be constructed with workspace A's settings, not
+    // with the instance session B loaded in the meantime.
+    expect(sessionCalls[1]![0]).toBe('session-a');
+    expect(sessionCalls[1]![3]).toBe(settingsA);
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it('does not return discontinued qwen-oauth as the only ACP auth option', async () => {
     vi.mocked(buildAuthMethods).mockReturnValue([
       {

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -2900,7 +2900,6 @@ class QwenAgent implements Agent {
     // resolve `advanced.runtimeOutputDir` from THIS request's cwd, not from
     // whichever settings a concurrent handler loaded last.
     const settings = loadSettings(params.cwd);
-    this.settings = settings;
     const exists = await runWithAcpRuntimeOutputDir(
       settings,
       params.cwd,
@@ -2912,6 +2911,10 @@ class QwenAgent implements Agent {
     if (!exists) {
       throw RequestError.resourceNotFound(`session:${params.sessionId}`);
     }
+    // Adopt into the "latest loaded" cache only once the session is
+    // confirmed — a failed probe for a stale id must not repoint
+    // agent-level readers at this request's workspace.
+    this.settings = settings;
 
     const config = await this.newSessionConfig(
       params.cwd,
@@ -2952,7 +2955,6 @@ class QwenAgent implements Agent {
   ): Promise<ResumeSessionResponse> {
     // Same per-request settings discipline as `loadSession`.
     const settings = loadSettings(params.cwd);
-    this.settings = settings;
     const exists = await runWithAcpRuntimeOutputDir(
       settings,
       params.cwd,
@@ -2964,6 +2966,7 @@ class QwenAgent implements Agent {
     if (!exists) {
       throw RequestError.resourceNotFound(`session:${params.sessionId}`);
     }
+    this.settings = settings;
 
     const config = await this.newSessionConfig(
       params.cwd,

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -2870,11 +2870,19 @@ class QwenAgent implements Agent {
     cwd,
     mcpServers,
   }: NewSessionRequest): Promise<NewSessionResponse> {
-    const config = await this.newSessionConfig(cwd, mcpServers);
+    // Per-request settings: session handlers run concurrently, and
+    // `this.settings` is only a "latest loaded" cache for agent-level
+    // readers. Threading the instance explicitly keeps a slow session
+    // creation from picking up whichever workspace loaded last — Session
+    // persists model changes through this instance, so a mix-up writes to
+    // another workspace's settings.json.
+    const settings = loadSettings(cwd);
+    this.settings = settings;
+    const config = await this.newSessionConfig(cwd, mcpServers, settings);
     await this.ensureAuthenticated(config);
     this.setupFileSystem(config);
 
-    const session = await this.createAndStoreSession(config);
+    const session = await this.createAndStoreSession(config, settings);
     const availableModels = this.buildAvailableModels(config);
     const modesData = this.buildModesData(config);
     const configOptions = this.buildConfigOptions(config);
@@ -2888,8 +2896,13 @@ class QwenAgent implements Agent {
   }
 
   async loadSession(params: LoadSessionRequest): Promise<LoadSessionResponse> {
+    // Load per-request settings BEFORE the existence check: the check must
+    // resolve `advanced.runtimeOutputDir` from THIS request's cwd, not from
+    // whichever settings a concurrent handler loaded last.
+    const settings = loadSettings(params.cwd);
+    this.settings = settings;
     const exists = await runWithAcpRuntimeOutputDir(
-      this.settings,
+      settings,
       params.cwd,
       async () => {
         const sessionService = new SessionService(params.cwd);
@@ -2907,6 +2920,7 @@ class QwenAgent implements Agent {
       // future loosening — `newSessionConfig` iterates the list, so
       // a `null`/`undefined` would otherwise throw `TypeError`.
       params.mcpServers ?? [],
+      settings,
       params.sessionId,
       true,
     );
@@ -2914,7 +2928,11 @@ class QwenAgent implements Agent {
     this.setupFileSystem(config);
 
     const sessionData = config.getResumedSessionData();
-    const session = await this.createAndStoreSession(config, sessionData);
+    const session = await this.createAndStoreSession(
+      config,
+      settings,
+      sessionData,
+    );
 
     await this.#restoreWorktreeOnResume(config, session);
 
@@ -2932,8 +2950,11 @@ class QwenAgent implements Agent {
   async unstable_resumeSession(
     params: ResumeSessionRequest,
   ): Promise<ResumeSessionResponse> {
+    // Same per-request settings discipline as `loadSession`.
+    const settings = loadSettings(params.cwd);
+    this.settings = settings;
     const exists = await runWithAcpRuntimeOutputDir(
-      this.settings,
+      settings,
       params.cwd,
       async () => {
         const sessionService = new SessionService(params.cwd);
@@ -2947,6 +2968,7 @@ class QwenAgent implements Agent {
     const config = await this.newSessionConfig(
       params.cwd,
       params.mcpServers ?? [],
+      settings,
       params.sessionId,
       true,
     );
@@ -2955,6 +2977,7 @@ class QwenAgent implements Agent {
 
     const session = await this.createAndStoreSession(
       config,
+      settings,
       config.getResumedSessionData(),
       { replayHistory: false },
     );
@@ -7674,10 +7697,10 @@ class QwenAgent implements Agent {
   private async newSessionConfig(
     cwd: string,
     mcpServers: McpServer[],
+    settings: LoadedSettings,
     sessionId?: string,
     resume?: boolean,
   ): Promise<Config> {
-    this.settings = loadSettings(cwd);
     // ACP/IDE-injected servers are session-level: they must outrank a project
     // `.mcp.json` and stay un-gated. Collect them separately and pass them as
     // `sessionMcpServers` (top precedence tier) rather than merging into
@@ -7738,7 +7761,7 @@ class QwenAgent implements Agent {
       }
     }
 
-    const settings = this.settings.merged;
+    const mergedSettings = settings.merged;
 
     const argvForSession = {
       ...this.argv,
@@ -7747,7 +7770,7 @@ class QwenAgent implements Agent {
     };
 
     const config = await loadCliConfig(
-      settings,
+      mergedSettings,
       argvForSession,
       cwd,
       // ACP sessions do not provide an extension override. Passing [] is a
@@ -7756,16 +7779,16 @@ class QwenAgent implements Agent {
       undefined,
       // Pass separated hooks for proper source attribution
       {
-        userHooks: this.settings.getUserHooks(),
-        projectHooks: this.settings.getProjectHooks(),
+        userHooks: settings.getUserHooks(),
+        projectHooks: settings.getProjectHooks(),
       },
-      // CRITICAL: close over `this.settings` (LoadedSettings instance), NOT
-      // over the local `settings` snapshot built above. `LoadedSettings.
-      // setValue` replaces `_merged`, so a closure over the snapshot would
-      // never see workspace toggles applied during the session. ACP/Zed
-      // sessions otherwise leak persisted disabled skills into the first
-      // <available_skills> at cold start.
-      buildDisabledSkillNamesProvider(this.settings),
+      // CRITICAL: close over the per-request `settings` (LoadedSettings
+      // instance), NOT over the `mergedSettings` snapshot built above.
+      // `LoadedSettings.setValue` replaces `_merged`, so a closure over the
+      // snapshot would never see workspace toggles applied during the
+      // session. ACP/Zed sessions otherwise leak persisted disabled skills
+      // into the first <available_skills> at cold start.
+      buildDisabledSkillNamesProvider(settings),
       sessionMcpServers,
     );
     // ACP sessions run with piped stdio (non-TTY), so the default
@@ -7926,6 +7949,7 @@ class QwenAgent implements Agent {
 
   private async createAndStoreSession(
     config: Config,
+    settings: LoadedSettings,
     sessionData?: ResumedSessionData,
     options: { replayHistory?: boolean } = {},
   ): Promise<Session> {
@@ -7939,12 +7963,7 @@ class QwenAgent implements Agent {
 
     this.sessions.get(sessionId)?.dispose();
 
-    const session = new Session(
-      sessionId,
-      config,
-      this.connection,
-      this.settings,
-    );
+    const session = new Session(sessionId, config, this.connection, settings);
     this.sessions.set(sessionId, session);
 
     setTimeout(async () => {


### PR DESCRIPTION
## What this PR does

Makes each ACP session entry point (`newSession`, `loadSession`, `unstable_resumeSession`) load its workspace's `LoadedSettings` once at the top of the handler and thread that same instance explicitly through `newSessionConfig` and `createAndStoreSession`, instead of re-reading the shared mutable `this.settings` field after long awaits. `this.settings` stays in place as a "latest loaded" cache for agent-level readers (auth persistence, fastModel, folder trust, language, settings ext-methods), which keeps their behavior unchanged.

Concretely:

- `newSession` / `loadSession` / `unstable_resumeSession` start with `const settings = loadSettings(cwd); this.settings = settings;` and pass `settings` down.
- `newSessionConfig(cwd, mcpServers, settings, sessionId?, resume?)` takes the instance as a required parameter and no longer calls `loadSettings` itself; its merged snapshot, hook accessors, and the disabled-skills provider all use the passed instance.
- `createAndStoreSession(config, settings, sessionData?, options?)` constructs `Session` with the passed instance instead of `this.settings`.
- `loadSession` / `unstable_resumeSession` run their session-existence check (`runWithAcpRuntimeOutputDir`) with the settings just loaded for the request's `cwd`, not with whatever a previous handler left behind.

## Why it's needed

ACP JSON-RPC handlers run concurrently, and session creation awaits config load, MCP discovery, and an auth refresh between "load settings" and "construct Session" — a window of hundreds of ms to seconds. Two reads of `this.settings` race across that window:

1. **`createAndStoreSession` → `new Session(..., this.settings)`**: if session B starts while session A is mid-creation, A's `Session` is constructed with B's `LoadedSettings`. `Session` persists model changes through that instance (`setValue(persistScope, 'model.name' / 'model.baseUrl', ...)`), so with multi-workspace clients a model switch in workspace A **writes into workspace B's settings.json**. It also breaks the instance-identity contract documented at the `buildDisabledSkillNamesProvider` call site (the provider must close over the same instance later reloaded via `reloadScopeFromDisk`).
2. **`loadSession`/`unstable_resumeSession` existence check**: it ran under `runWithAcpRuntimeOutputDir(this.settings, ...)` *before* this request's settings were loaded, i.e. with the previous handler's instance. With per-workspace `advanced.runtimeOutputDir` values, the check looks in the wrong directory and returns a spurious "session not found".

Semantic notes:

- The `this.settings` cache keeps its pre-fix update timing: `newSession` adopts the freshly loaded instance immediately, and `loadSession`/`unstable_resumeSession` adopt it only after the session-existence check passes — a failed (404) probe leaves the cache untouched, exactly as before this PR. The existence check itself uses the local per-request instance.
- **Known limitation (pre-existing, unchanged)**: with multiple live sessions, the skills ext-method's `reloadScopeFromDisk` still only affects the settings instance of the session(s) that share it; sessions bound to other instances don't see the reload. That is exactly the single-cache behavior before this PR — this change neither widens nor narrows it.

## Reviewer Test Plan

**How to verify**

1. Read the new regression test `passes each concurrent newSession its own workspace settings instance` in `packages/cli/src/acp-integration/acpAgent.test.ts`. It interleaves two `newSession` calls (workspace A stalls in `loadCliConfig` while workspace B completes) and asserts each `Session` is constructed with its own workspace's `LoadedSettings` instance.
2. `cd packages/cli && npx vitest run src/acp-integration/acpAgent.test.ts` — passes on this branch.
3. Revert the `acpAgent.ts` hunks (keep the test) and re-run: the test fails with session A receiving workspace B's settings instance, reproducing the race.

**Evidence Before & After**

Before (fix reverted via `git stash push -- packages/cli/src/acp-integration/acpAgent.ts`, test kept):

```
FAIL  src/acp-integration/acpAgent.test.ts > QwenAgent MCP SSE/HTTP support > passes each concurrent newSession its own workspace settings instance
AssertionError: expected { merged: { mcpServers: {} }, …(3) } to be { merged: { mcpServers: {} }, …(3) } // Object.is equality

Compared values have no visual difference.

 ❯ src/acp-integration/acpAgent.test.ts:1382:33
    1380|     // with the instance session B loaded in the meantime.
    1381|     expect(sessionCalls[1]![0]).toBe('session-a');
    1382|     expect(sessionCalls[1]![3]).toBe(settingsA);
```

("no visual difference" is the point: the two fixture instances are structurally identical, and session A was constructed with workspace B's *instance* — an identity mix-up, which is exactly what makes `setValue` persist into the wrong workspace file in production.)

After (this branch, full file suite):

```
Test Files  1 passed (1)
     Tests  181 passed (181)
```

`tsc --noEmit` and `eslint` on the two changed files are clean.

**Tested on**

| 🍏 macOS | 🪟 Windows | 🐧 Linux |
| --- | --- | --- |
| ✅ | ➖ | ➖ |

**Environment**

- Node v24.12.0, macOS (darwin 25.4.0)

## Risk & Scope

- **Main risk**: a missed `this.settings` reader inside the session-creation path that should now use the per-request instance. Mitigated by auditing every `this.settings` use in `acpAgent.ts`: remaining reads are agent-level by design (authenticate persistence, `loadPermissionSettings`, fastModel/folderTrust/language, settings ext-methods) and keep the existing "latest loaded" cache semantics.
- **Not validated**: multi-workspace end-to-end run against a real ACP client issuing concurrent `session/new` for different cwds (covered by the unit-level interleaving test instead).
- **Breaking changes**: none. `newSessionConfig`/`createAndStoreSession` are private methods; ACP protocol surface is unchanged.

## Linked Issues

Related: #6263 (daemon multi-session performance; this PR fixes the correctness half of the shared-agent-state findings from the same investigation).

<details><summary>中文说明</summary>

## 本 PR 做了什么

让三个 ACP 会话入口(`newSession`、`loadSession`、`unstable_resumeSession`)在 handler 开头各自加载一次工作区的 `LoadedSettings`,并把同一个实例显式传递给 `newSessionConfig` 和 `createAndStoreSession`,不再在长 await 之后重新读取共享可变字段 `this.settings`。`this.settings` 保留为"最近一次加载"的缓存,供 agent 级读者(认证持久化、fastModel、目录信任、语言、settings 扩展方法)使用,其行为不变。

具体改动:

- 三个 handler 开头 `const settings = loadSettings(cwd); this.settings = settings;`,后续显式传递 `settings`;
- `newSessionConfig(cwd, mcpServers, settings, sessionId?, resume?)` 增加必选参数,不再自己调用 `loadSettings`;merged 快照、hooks 读取、disabled-skills provider 全部改用传入实例;
- `createAndStoreSession(config, settings, sessionData?, options?)` 用传入实例构造 `Session`;
- `loadSession`/`unstable_resumeSession` 的会话存在性检查(`runWithAcpRuntimeOutputDir`)使用本次请求刚加载的 settings,而不是上一个 handler 留下的实例。

## 为什么需要

ACP JSON-RPC handler 是并发执行的,而会话创建在"加载 settings"与"构造 Session"之间要经过配置加载、MCP 发现、认证刷新等多段 await,窗口达数百毫秒到秒级。这个窗口内有两处 `this.settings` 读取会发生竞争:

1. **`createAndStoreSession` 里 `new Session(..., this.settings)`**:会话 A 创建过程中会话 B 开始,A 的 `Session` 会拿到 B 的 `LoadedSettings`。`Session` 通过该实例持久化模型切换(`setValue(persistScope, 'model.name' / 'model.baseUrl', ...)`),多工作区客户端下,A 工作区的模型切换会**写进 B 工作区的 settings.json**;同时破坏 `buildDisabledSkillNamesProvider` 调用点注释所要求的实例一致性约定。
2. **`loadSession`/`unstable_resumeSession` 的存在性检查**:原先在本次 `loadSettings` 之前执行,用的是上一个 handler 的实例;各工作区 `advanced.runtimeOutputDir` 不同时会在错误目录找会话文件,误报"会话不存在"(404)。

语义说明:

- `this.settings` 缓存保持修复前的更新时点:`newSession` 立即采纳新加载的实例;`loadSession`/`unstable_resumeSession` 仅在存在性检查通过后才更新缓存——失败(404)的探测不触碰缓存,与修复前完全一致。存在性检查本身使用请求级局部实例。
- **既有限制(本 PR 不改变)**:多会话并存时,skills 扩展方法的 `reloadScopeFromDisk` 仍只作用于与之共享实例的会话;绑定其他实例的会话感知不到。这与修复前单缓存的行为一致,本 PR 既不扩大也不缩小该限制。

## 评审验证建议

1. 阅读新增回归测试 `passes each concurrent newSession its own workspace settings instance`:两个 `newSession` 交错执行(A 在 `loadCliConfig` 挂起、B 先完成),断言每个 `Session` 拿到各自工作区的 `LoadedSettings` 实例。
2. `cd packages/cli && npx vitest run src/acp-integration/acpAgent.test.ts` 在本分支通过(181/181)。
3. 保留测试、回退 `acpAgent.ts` 改动后重跑,测试失败(A 拿到 B 的实例),即复现竞争;失败信息中 "Compared values have no visual difference" 恰好说明这是**实例身份**错配而非内容差异。

## 风险与范围

- **主要风险**:会话创建路径上遗漏某个本应改用请求级实例的 `this.settings` 读点。已逐一审计 `acpAgent.ts` 中全部 `this.settings` 使用:剩余读点均为设计上的 agent 级语义(认证持久化、`loadPermissionSettings`、fastModel/目录信任/语言、settings 扩展方法),保持既有缓存语义。
- **未验证**:真实 ACP 客户端对不同 cwd 并发发起 `session/new` 的端到端场景(以单测层面的交错测试覆盖)。
- **破坏性变更**:无。两个方法均为私有方法,ACP 协议面不变。

</details>

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)
