### PR TITLE
fix(web-shell): use theme color for @ group titles

### DIFF
--- a/packages/web-shell/client/components/Editor.module.css
+++ b/packages/web-shell/client/components/Editor.module.css
@@ -429,6 +429,7 @@
   margin: 6px 10px 4px;
   padding: 2px 0 4px !important;
   line-height: 1.2;
+  color: var(--muted-foreground, #a1a1aa) !important;
   border-bottom: 1px solid var(--border) !important;
 }
 

--- a/packages/web-shell/client/hooks/useComposerCore.ts
+++ b/packages/web-shell/client/hooks/useComposerCore.ts
@@ -162,6 +162,7 @@ const TOOLTIP_STYLES = `
   margin: 6px 10px 4px;
   padding: 2px 0 4px !important;
   line-height: 1.2;
+  color: var(--muted-foreground, #a1a1aa) !important;
   border-bottom: 1px solid var(--border) !important;
 }
 


### PR DESCRIPTION
## What this PR does

This PR fixes the group-title color used in the web-shell `@` completion menu so the section headers remain readable in dark theme.

Instead of relying on an implicit/default color, the section header now uses the shared muted foreground theme token, which keeps the visual hierarchy while avoiding near-black text on dark backgrounds.

## Why it's needed

In dark theme, the group titles in the web-shell `@` menu could render with a color that was too close to the background, making section headers such as extensions and files difficult to read.

Using an explicit theme variable makes the appearance consistent across themes and avoids accidental regressions from browser or inherited default colors.

## Reviewer Test Plan

### How to verify

1. Open the web-shell in dark theme.
2. Trigger bare `@` completion.
3. Confirm that section headers such as Extensions / Files / MCP Servers are clearly readable against the dark background.
4. Confirm that regular completion rows still render normally and that the dropdown appearance is otherwise unchanged.

### Evidence (Before & After)

Before: group titles in the web-shell `@` completion menu could appear too dark to read comfortably in dark theme.

After: group titles use the muted foreground theme color and remain visible while preserving the intended visual hierarchy.

### Tested on

|     OS     |  Status  |
| :--------: | :------: |
|  🍏 macOS  |    ✅    |
| 🪟 Windows |    ⚠️    |
|  🐧 Linux  |    ⚠️    |

### Environment (optional)

Local web-shell build is currently blocked on the latest `main` by an unrelated `useStatusReport` export mismatch in `DaemonStatusDialog`; this PR only changes the group-title color styling.

## Risk & Scope

- Main risk or tradeoff: Very small UI-only change to section-header color.
- Not validated / out of scope: Cross-platform manual theme verification outside macOS; unrelated upstream web-shell build issue.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 修复了 web-shell 中 `@` 补全菜单分组标题的颜色，使这些 section header 在暗色主题下仍然清晰可读。

这次改动不再依赖隐式/默认颜色，而是显式使用共享的 muted foreground 主题变量，从而在保留层级感的同时，避免暗色背景下出现接近黑色的文字。

## Why it's needed

在暗色主题下，web-shell `@` 菜单中的分组标题颜色可能过于接近背景色，导致像 extensions、files 这样的 section header 难以辨认。

改为使用显式的主题变量后，外观会在不同主题下保持一致，也能避免由于浏览器默认色或继承色导致的意外回归。

## Reviewer Test Plan

### How to verify

1. 在暗色主题下打开 web-shell。
2. 触发 bare `@` 补全。
3. 确认 Extensions / Files / MCP Servers 等分组标题在暗色背景下清晰可读。
4. 确认普通 completion 行的渲染保持正常，下拉整体外观没有其他异常变化。

### Evidence (Before & After)

Before：web-shell `@` 补全菜单中的分组标题在暗色主题下可能过暗，不利于阅读。

After：分组标题改为使用 muted foreground 主题色，在保留视觉层级的同时能清晰显示。

### Tested on

|     OS     |  Status  |
| :--------: | :------: |
|  🍏 macOS  |    ✅    |
| 🪟 Windows |    ⚠️    |
|  🐧 Linux  |    ⚠️    |

### Environment (optional)

本地 web-shell build 目前会被最新 `main` 中与本次改动无关的 `DaemonStatusDialog` / `useStatusReport` 导出不匹配问题阻塞；本 PR 只修改分组标题颜色样式。

## Risk & Scope

- Main risk or tradeoff: 仅为非常小的 UI 颜色调整。
- Not validated / out of scope: 未在 macOS 之外的平台做手工主题验证；也不处理上游无关的 web-shell build 问题。
- Breaking changes / migration notes: 无。

## Linked Issues

N/A

</details>
