### PR TITLE
fix(core): treat @-attached files as read for prior-read enforcement

### DIFF
--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -17,6 +17,7 @@ import type { PermissionDecision } from '../permissions/types.js';
 import {
   processSingleFileContent,
   getSpecificMimeType,
+  isCacheableReadResult,
 } from '../utils/fileUtils.js';
 import { parsePDFPageRange } from '../utils/pdf.js';
 import type { Config } from '../config/config.js';
@@ -267,9 +268,7 @@ class ReadFileToolInvocation extends BaseToolInvocation<
     // hash on the read pipeline (deferred follow-up — see Risk
     // section in the PR description).
     if (cacheEnabled && (result.stats ?? stats)) {
-      const cacheable =
-        typeof result.llmContent === 'string' &&
-        result.originalLineCount !== undefined;
+      const cacheable = isCacheableReadResult(result);
       const recordStats: Stats = result.stats ?? stats!;
       cache.recordRead(absPath, recordStats, {
         full: isFullRead && !result.isTruncated,

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -830,6 +830,22 @@ export interface ProcessedFileReadResult {
   stats?: import('node:fs').Stats;
 }
 
+/**
+ * Whether a {@link ProcessedFileReadResult} may be cached for prior-read
+ * enforcement: the payload must be plain text (not an image / PDF `Part`)
+ * and carry a known line count. Shared by `read-file.ts` and
+ * `readManyFiles.ts` so both read paths derive `cacheable` identically and
+ * agree on what Edit / WriteFile may later mutate.
+ */
+export function isCacheableReadResult(
+  result: ProcessedFileReadResult,
+): boolean {
+  return (
+    typeof result.llmContent === 'string' &&
+    result.originalLineCount !== undefined
+  );
+}
+
 export interface ProcessSingleFileContentOptions {
   offset?: number;
   limit?: number;

--- a/packages/core/src/utils/readManyFiles.test.ts
+++ b/packages/core/src/utils/readManyFiles.test.ts
@@ -15,6 +15,8 @@ import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import { StandardFileSystemService } from '../services/fileSystemService.js';
 import type { Config } from '../config/config.js';
 import { createMockWorkspaceContext } from '../test-utils/mockWorkspaceContext.js';
+import { FileReadCache } from '../services/fileReadCache.js';
+import { checkPriorRead } from '../tools/priorReadEnforcement.js';
 
 /** Helper to convert PartListUnion to string for test assertions */
 function contentToString(parts: PartListUnion): string {
@@ -56,6 +58,19 @@ describe('readManyFiles', () => {
       getFileSystemService: () => new StandardFileSystemService(),
       getContentGeneratorConfig: () => ({ modalities: {} }),
       getModel: () => 'text-only-model',
+    }) as unknown as Config;
+
+  // Variant of createMockConfig wired to a live FileReadCache so the
+  // prior-read enforcement path (issue #6289) can be exercised end-to-end.
+  const createMockConfigWithCache = (
+    rootDir: string,
+    cache: FileReadCache,
+    fileReadCacheDisabled = false,
+  ): Config =>
+    ({
+      ...createMockConfig(rootDir),
+      getFileReadCache: () => cache,
+      getFileReadCacheDisabled: () => fileReadCacheDisabled,
     }) as unknown as Config;
 
   async function createTestFile(
@@ -400,6 +415,86 @@ describe('readManyFiles', () => {
       // Downstream callers (e.g. atCommandProcessor) inspect this field to
       // render the read as failed rather than successful.
       expect(result.files[0]!.error).toMatch(/exceeds the 10MB limit/i);
+    });
+  });
+
+  // Issue #6289: files attached via `@path` load their content into context
+  // but were never recorded in the session FileReadCache, so a follow-up
+  // Edit / WriteFile was rejected with EDIT_REQUIRES_PRIOR_READ until the
+  // model redundantly re-read the file with read_file.
+  describe('prior-read enforcement (issue #6289)', () => {
+    it('records an @-attached text file so a later edit passes prior-read enforcement', async () => {
+      const { relativePath, absolutePath } =
+        await createTestFile('attached.ts');
+      const cache = new FileReadCache();
+      const mockConfig = createMockConfigWithCache(tempRootDir, cache);
+
+      // Precondition: the file has never been read this session, so the
+      // enforcement helper rejects an edit.
+      const before = await checkPriorRead(cache, absolutePath, 'editing');
+      expect(before.ok).toBe(false);
+
+      await readManyFiles(mockConfig, { paths: [relativePath] });
+
+      // The @-mention read must now satisfy prior-read enforcement without
+      // a redundant read_file.
+      const after = await checkPriorRead(cache, absolutePath, 'editing');
+      expect(after.ok).toBe(true);
+    });
+
+    it('records the read as fresh and cacheable in the FileReadCache', async () => {
+      const { relativePath, absolutePath } = await createTestFile('notes.md');
+      const cache = new FileReadCache();
+      const mockConfig = createMockConfigWithCache(tempRootDir, cache);
+
+      await readManyFiles(mockConfig, { paths: [relativePath] });
+
+      const stats = nodeFs.statSync(absolutePath);
+      const status = cache.check(stats);
+      expect(status.state).toBe('fresh');
+      if (status.state === 'fresh') {
+        expect(status.entry.lastReadAt).toBeDefined();
+        expect(status.entry.lastReadCacheable).toBe(true);
+      }
+    });
+
+    it('does not record reads when fileReadCacheDisabled is set', async () => {
+      const { relativePath, absolutePath } =
+        await createTestFile('attached.ts');
+      const cache = new FileReadCache();
+      const mockConfig = createMockConfigWithCache(tempRootDir, cache, true);
+
+      await readManyFiles(mockConfig, { paths: [relativePath] });
+
+      expect(cache.size()).toBe(0);
+      const decision = await checkPriorRead(cache, absolutePath, 'editing');
+      expect(decision.ok).toBe(false);
+    });
+
+    it('does not record directories (edit enforcement still rejects them)', async () => {
+      await createTestFile('mydir', 'nested.txt');
+      const cache = new FileReadCache();
+      const mockConfig = createMockConfigWithCache(tempRootDir, cache);
+
+      await readManyFiles(mockConfig, { paths: ['mydir'] });
+
+      expect(cache.size()).toBe(0);
+    });
+
+    it('does not let a binary image attachment satisfy text-edit enforcement', async () => {
+      const relativePath = 'screenshot.png';
+      const absolutePath = path.join(tempRootDir, relativePath);
+      await fs.writeFile(absolutePath, Buffer.from('fake png data'));
+      const cache = new FileReadCache();
+      const mockConfig = createMockConfigWithCache(tempRootDir, cache);
+
+      await readManyFiles(mockConfig, { paths: [relativePath] });
+
+      // A binary payload cannot be mutated as text by Edit / WriteFile, so
+      // enforcement must still reject it rather than being cleared by the
+      // attachment.
+      const decision = await checkPriorRead(cache, absolutePath, 'editing');
+      expect(decision.ok).toBe(false);
     });
   });
 });

--- a/packages/core/src/utils/readManyFiles.test.ts
+++ b/packages/core/src/utils/readManyFiles.test.ts
@@ -496,5 +496,31 @@ describe('readManyFiles', () => {
       const decision = await checkPriorRead(cache, absolutePath, 'editing');
       expect(decision.ok).toBe(false);
     });
+
+    it('records a binary file as a full but non-cacheable read', async () => {
+      // A `.bin` file with a null byte is classified as `binary`: unlike an
+      // image it returns `stats` (so it IS recorded), but it carries no
+      // `originalLineCount`, so `cacheable` must be `false`. This guards the
+      // `originalLineCount !== undefined` clause of the cacheable derivation
+      // — dropping it would wrongly let a non-text payload clear prior-read
+      // enforcement for Edit / WriteFile.
+      const relativePath = 'payload.bin';
+      const absolutePath = path.join(tempRootDir, relativePath);
+      await fs.writeFile(
+        absolutePath,
+        Buffer.from([0x00, 0x01, 0x02, 0x00, 0xff]),
+      );
+      const cache = new FileReadCache();
+      const mockConfig = createMockConfigWithCache(tempRootDir, cache);
+
+      await readManyFiles(mockConfig, { paths: [relativePath] });
+
+      const stats = nodeFs.statSync(absolutePath);
+      const status = cache.check(stats);
+      expect(status.state).toBe('fresh');
+      if (status.state === 'fresh') {
+        expect(status.entry.lastReadCacheable).toBe(false);
+      }
+    });
   });
 });

--- a/packages/core/src/utils/readManyFiles.ts
+++ b/packages/core/src/utils/readManyFiles.ts
@@ -9,6 +9,7 @@ import * as path from 'node:path';
 import type { Part, PartListUnion } from '@google/genai';
 import type { Config } from '../config/config.js';
 import { getErrorMessage } from './errors.js';
+import type { ProcessedFileReadResult } from './fileUtils.js';
 import { processSingleFileContent } from './fileUtils.js';
 import { getFolderStructure } from './getFolderStructure.js';
 
@@ -214,6 +215,11 @@ async function readFileContent(
       };
     }
 
+    // Record the successful read in the session FileReadCache so a later
+    // Edit / WriteFile on an `@`-attached file passes prior-read enforcement
+    // without a redundant read_file (issue #6289).
+    recordAttachedFileRead(config, filePath, fileReadResult);
+
     if (typeof fileReadResult.llmContent === 'string') {
       let fileContentForLlm = '';
       if (
@@ -251,4 +257,45 @@ async function readFileContent(
   } catch {
     return null;
   }
+}
+
+/**
+ * Record an `@`-attached file read in the session {@link FileReadCache} so a
+ * later Edit / WriteFile on the same file passes prior-read enforcement
+ * without the model re-reading it via `read_file` (issue #6289). Without
+ * this, `@`-mentions loaded content into context but never touched the
+ * cache, so `checkPriorRead` saw `unknown` and rejected the edit with
+ * `EDIT_REQUIRES_PRIOR_READ`.
+ *
+ * `@`-mentions are always request-level full reads (no offset / limit /
+ * pages), so `full` hinges only on truncation, and `cacheable` reflects
+ * whether the payload is plain text — mirroring `read-file.ts` so the two
+ * read paths agree on what Edit / WriteFile may mutate. Binary media
+ * (image / audio / native PDF) omit `stats` from the read result and are
+ * skipped here; a later Edit on them is still correctly rejected as a
+ * non-text payload by prior-read enforcement.
+ *
+ * Guards mirror `grepReadTracking.ts`: no-op when the cache is disabled or
+ * unavailable, matching the other utility that records reads outside the
+ * `read_file` tool.
+ */
+function recordAttachedFileRead(
+  config: Config,
+  filePath: string,
+  result: ProcessedFileReadResult,
+): void {
+  if (config.getFileReadCacheDisabled?.()) {
+    return;
+  }
+  const cache = config.getFileReadCache?.();
+  if (!cache || !result.stats) {
+    return;
+  }
+  const cacheable =
+    typeof result.llmContent === 'string' &&
+    result.originalLineCount !== undefined;
+  cache.recordRead(filePath, result.stats, {
+    full: !result.isTruncated,
+    cacheable,
+  });
 }

--- a/packages/core/src/utils/readManyFiles.ts
+++ b/packages/core/src/utils/readManyFiles.ts
@@ -10,7 +10,10 @@ import type { Part, PartListUnion } from '@google/genai';
 import type { Config } from '../config/config.js';
 import { getErrorMessage } from './errors.js';
 import type { ProcessedFileReadResult } from './fileUtils.js';
-import { processSingleFileContent } from './fileUtils.js';
+import {
+  isCacheableReadResult,
+  processSingleFileContent,
+} from './fileUtils.js';
 import { getFolderStructure } from './getFolderStructure.js';
 
 /**
@@ -267,10 +270,11 @@ async function readFileContent(
  * cache, so `checkPriorRead` saw `unknown` and rejected the edit with
  * `EDIT_REQUIRES_PRIOR_READ`.
  *
- * `@`-mentions are always request-level full reads (no offset / limit /
- * pages), so `full` hinges only on truncation, and `cacheable` reflects
- * whether the payload is plain text — mirroring `read-file.ts` so the two
- * read paths agree on what Edit / WriteFile may mutate. Binary media
+ * Although `@`-mentions pass no explicit offset / limit / pages,
+ * `processSingleFileContent` applies `config.getTruncateToolOutputLines()`
+ * as a default cap, so large attachments can still be truncated and
+ * `full` may be `false` — mirroring `read-file.ts` so the two read paths
+ * agree on what Edit / WriteFile may mutate. Binary media
  * (image / audio / native PDF) omit `stats` from the read result and are
  * skipped here; a later Edit on them is still correctly rejected as a
  * non-text payload by prior-read enforcement.
@@ -291,9 +295,7 @@ function recordAttachedFileRead(
   if (!cache || !result.stats) {
     return;
   }
-  const cacheable =
-    typeof result.llmContent === 'string' &&
-    result.originalLineCount !== undefined;
+  const cacheable = isCacheableReadResult(result);
   cache.recordRead(filePath, result.stats, {
     full: !result.isTruncated,
     cacheable,


### PR DESCRIPTION
## What this PR does

Files pulled into the prompt with an `@path` mention are now recorded in the session file-read cache, exactly like a file the model reads with the `read_file` tool. As a result the model can edit or overwrite an attached file straight away, without first being told to re-read it.

## Why it's needed

`@`-mentions load file content through the `readManyFiles` utility, which never told the session read cache that the file had been seen. Only `read_file` and grep-result tracking recorded reads. So when the model tried to edit a file it had just been handed via `@path`, prior-read enforcement found no cache entry, fell through to its "never read this file" branch, and rejected the edit with `EDIT_REQUIRES_PRIOR_READ` — forcing a redundant `read_file` on content that was already in context. This is the behavior reported in #6289.

The fix records the read at the point where the attached content is produced, mirroring `read-file.ts`: an `@`-mention is always a request-level full read (no offset / limit / pages), so `full` depends only on whether the output was truncated, and `cacheable` reflects whether the payload is plain text. Binary media (image / audio / native PDF) do not carry a stat on the read result and are intentionally skipped — a later text edit against them is still correctly rejected as a non-text payload. When the read cache is disabled the recording is a no-op, matching the existing `grepReadTracking` guard.

## Reviewer Test Plan

### How to verify

Reproduction (interactive):
1. Start a session and attach a text file in the prompt, e.g. `@packages/core/src/utils/readManyFiles.ts summarize this file`.
2. In the same turn, ask the model to make a small edit to that same file.
3. Before this change: the edit is rejected with `EDIT_REQUIRES_PRIOR_READ` and the model must call `read_file` first. After this change: the edit proceeds directly.

Automated (added in this PR):
```
npx vitest run packages/core/src/utils/readManyFiles.test.ts
```
New `prior-read enforcement (issue #6289)` cases assert that after `readManyFiles` reads a text file, `checkPriorRead` clears an edit, the cache entry is `fresh` + cacheable, the read is skipped when `fileReadCacheDisabled` is set, directories are not recorded, and a binary image attachment does not satisfy text-edit enforcement.

Expected vs observed: with the fix, an `@`-attached text file passes prior-read enforcement (`ok: true`); the previously-failing assertions now pass.

### Evidence (Before & After)

Non–user-visible behavior change (tool-call enforcement, not TUI). Evidence is the new unit tests:
- Before (source reverted, tests kept): `2 failed | 3 passed` — the two positive assertions fail (`expected 'fresh' to be 'unknown'`, edit `ok` false).
- After: `24 passed` in `readManyFiles.test.ts`; `149 passed` across `readManyFiles` + `read-file` + `grepReadTracking` + `fileReadCache`; typecheck clean; eslint (`--max-warnings 0`) clean; prettier clean.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only (vitest, `packages/core`).

## Risk & Scope

- Main risk or tradeoff: an `@`-attached file's mtime/size is recorded as the read fingerprint; if the file changes between the attachment and a later edit, prior-read enforcement's existing drift check flags it `stale` and asks for a re-read — the same safety net that already applies to `read_file`.
- Not validated / out of scope: the fast-path `file_unchanged` placeholder (not reachable from the `@`-mention path); binary-media attachments are deliberately not recorded.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #6289

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

现在，通过 `@path` 提及方式加入到提示词中的文件，会像使用 `read_file` 工具读取的文件一样，被记录到会话的文件读取缓存中。因此，模型可以立即编辑或覆盖被附加的文件，而不需要先被要求重新读取它。

## 为什么需要它

`@` 提及通过 `readManyFiles` 工具函数加载文件内容，而该函数从未将“文件已被读取”这一事实告知会话读取缓存。只有 `read_file` 和 grep 结果跟踪会记录读取。因此，当模型尝试编辑一个刚刚通过 `@path` 提供给它的文件时，先读检查（prior-read）找不到缓存条目，进入“从未读取过此文件”的分支，并以 `EDIT_REQUIRES_PRIOR_READ` 拒绝编辑——迫使模型对已经存在于上下文中的内容再做一次多余的 `read_file`。这正是 #6289 所报告的行为。

此修复在产生附加内容的位置记录读取，做法与 `read-file.ts` 保持一致：`@` 提及始终是请求级别的完整读取（没有 offset / limit / pages），因此 `full` 仅取决于输出是否被截断，`cacheable` 反映内容是否为纯文本。二进制媒体（图片 / 音频 / 原生 PDF）在读取结果中不带 stat，因此被有意跳过——之后对它们的文本编辑仍会被正确地作为非文本负载而拒绝。当读取缓存被禁用时，记录操作为空操作，与现有的 `grepReadTracking` 保护一致。

## 审阅者测试计划

### 如何验证

交互式复现：
1. 启动会话，并在提示词中附加一个文本文件，例如 `@packages/core/src/utils/readManyFiles.ts summarize this file`。
2. 在同一轮对话中，要求模型对该文件做一处小改动。
3. 修复前：编辑被 `EDIT_REQUIRES_PRIOR_READ` 拒绝，模型必须先调用 `read_file`。修复后：编辑直接进行。

自动化（本 PR 新增）：
```
npx vitest run packages/core/src/utils/readManyFiles.test.ts
```
新增的 `prior-read enforcement (issue #6289)` 用例断言：在 `readManyFiles` 读取文本文件后，`checkPriorRead` 允许编辑、缓存条目为 `fresh` 且可缓存、当设置 `fileReadCacheDisabled` 时跳过记录、目录不被记录、以及二进制图片附件不满足文本编辑的先读要求。

预期与观察：应用修复后，`@` 附加的文本文件通过先读检查（`ok: true`）；此前失败的断言现在全部通过。

### 证据（修复前后）

这是非用户可见的行为变更（工具调用的强制检查，而非 TUI）。证据是新增的单元测试：
- 修复前（还原源码、保留测试）：`2 failed | 3 passed`——两个正向断言失败（`expected 'fresh' to be 'unknown'`，编辑 `ok` 为 false）。
- 修复后：`readManyFiles.test.ts` 中 `24 passed`；`readManyFiles` + `read-file` + `grepReadTracking` + `fileReadCache` 共 `149 passed`；typecheck 通过；eslint（`--max-warnings 0`）通过；prettier 通过。

### 测试平台

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

仅单元测试（vitest，`packages/core`）。

## 风险与范围

- 主要风险 / 取舍：`@` 附加文件的 mtime/size 会被记录为读取指纹；如果文件在附加和之后的编辑之间发生变化，先读检查现有的漂移检测会将其标记为 `stale` 并要求重新读取——这与 `read_file` 已经适用的安全网相同。
- 未验证 / 超出范围：快速路径的 `file_unchanged` 占位（`@` 提及路径无法到达）；二进制媒体附件被有意不记录。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #6289

</details>
