### PR TITLE
fix(serve): resolve false auth warning in preflight when API key is set via settings

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -1249,6 +1249,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       getModelsConfig: vi.fn().mockReturnValue({
         getCurrentAuthType: vi.fn().mockReturnValue('api-key'),
         syncAfterAuthRefresh: vi.fn(),
+        getGenerationConfig: vi.fn().mockReturnValue({}),
       }),
       reloadModelProvidersConfig: vi.fn(),
       refreshAuth: vi.fn().mockResolvedValue(undefined),

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -2185,6 +2185,120 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
+  it('extMethod preflight auth cell reports ok when apiKey is in generationConfig but not in env', async () => {
+    const savedEnv = process.env['OPENAI_API_KEY'];
+    delete process.env['OPENAI_API_KEY'];
+    try {
+      mockConfig = {
+        ...mockConfig,
+        getTargetDir: vi.fn().mockReturnValue('/work/status'),
+        getMcpServers: vi.fn().mockReturnValue({}),
+        getAuthType: vi.fn().mockReturnValue('openai'),
+        getModel: vi.fn().mockReturnValue('qwen3.7-max'),
+        getModelsConfig: vi.fn().mockReturnValue({
+          getGenerationConfig: vi
+            .fn()
+            .mockReturnValue({ apiKey: 'sk-settings-key' }),
+          getCurrentAuthType: vi.fn().mockReturnValue('openai'),
+          syncAfterAuthRefresh: vi.fn(),
+        }),
+        getSkillManager: vi.fn().mockReturnValue({
+          listSkills: vi.fn().mockResolvedValue([]),
+        }),
+        getAllConfiguredModels: vi.fn().mockReturnValue([]),
+        getToolRegistry: vi.fn().mockReturnValue({ getAllTools: () => [] }),
+      } as unknown as Config;
+
+      const agentPromise = runAcpAgent(
+        mockConfig,
+        makeSessionSettings(),
+        mockArgv,
+      );
+      await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+      const agent = capturedAgentFactory!({
+        get closed() {
+          return mockConnectionState.promise;
+        },
+      }) as AgentLike;
+
+      const preflight = (await agent.extMethod(
+        SERVE_STATUS_EXT_METHODS.workspacePreflight,
+        {},
+      )) as {
+        cells: Array<{
+          kind: string;
+          status: string;
+          detail?: { hasToken: boolean };
+        }>;
+      };
+
+      const authCell = preflight.cells.find((c) => c.kind === 'auth');
+      expect(authCell?.status).toBe('ok');
+      expect(authCell?.detail?.hasToken).toBe(true);
+
+      mockConnectionState.resolve();
+      await agentPromise;
+    } finally {
+      if (savedEnv !== undefined) {
+        process.env['OPENAI_API_KEY'] = savedEnv;
+      }
+    }
+  });
+
+  it('extMethod preflight auth cell reports warning when no apiKey in env or generationConfig', async () => {
+    const savedEnv = process.env['OPENAI_API_KEY'];
+    delete process.env['OPENAI_API_KEY'];
+    try {
+      mockConfig = {
+        ...mockConfig,
+        getTargetDir: vi.fn().mockReturnValue('/work/status'),
+        getMcpServers: vi.fn().mockReturnValue({}),
+        getAuthType: vi.fn().mockReturnValue('openai'),
+        getModel: vi.fn().mockReturnValue('qwen3.7-max'),
+        getModelsConfig: vi.fn().mockReturnValue({
+          getGenerationConfig: vi.fn().mockReturnValue({}),
+          getCurrentAuthType: vi.fn().mockReturnValue('openai'),
+          syncAfterAuthRefresh: vi.fn(),
+        }),
+        getSkillManager: vi.fn().mockReturnValue({
+          listSkills: vi.fn().mockResolvedValue([]),
+        }),
+        getAllConfiguredModels: vi.fn().mockReturnValue([]),
+        getToolRegistry: vi.fn().mockReturnValue({ getAllTools: () => [] }),
+      } as unknown as Config;
+
+      const agentPromise = runAcpAgent(
+        mockConfig,
+        makeSessionSettings(),
+        mockArgv,
+      );
+      await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+      const agent = capturedAgentFactory!({
+        get closed() {
+          return mockConnectionState.promise;
+        },
+      }) as AgentLike;
+
+      const preflight = (await agent.extMethod(
+        SERVE_STATUS_EXT_METHODS.workspacePreflight,
+        {},
+      )) as {
+        cells: Array<{ kind: string; status: string; error?: string }>;
+      };
+
+      const authCell = preflight.cells.find((c) => c.kind === 'auth');
+      expect(authCell?.status).toBe('warning');
+      expect(authCell?.error).toContain('OPENAI_API_KEY');
+
+      mockConnectionState.resolve();
+      await agentPromise;
+    } finally {
+      if (savedEnv !== undefined) {
+        process.env['OPENAI_API_KEY'] = savedEnv;
+      }
+    }
+  });
+
   it('provider status marks current only for matching models', async () => {
     mockConfig = {
       ...mockConfig,

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -2309,13 +2309,13 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       ...mockConfig,
       getTargetDir: vi.fn().mockReturnValue('/work/status'),
       getMcpServers: vi.fn().mockReturnValue({}),
-      getAuthType: vi.fn().mockReturnValue('qwen'),
-      getModel: vi.fn().mockReturnValue('qwen-plus'),
+      getAuthType: vi.fn().mockReturnValue('custom-provider'),
+      getModel: vi.fn().mockReturnValue('custom-model'),
       getModelsConfig: vi.fn().mockReturnValue({
         getGenerationConfig: vi
           .fn()
           .mockReturnValue({ apiKey: 'sk-from-settings' }),
-        getCurrentAuthType: vi.fn().mockReturnValue('qwen'),
+        getCurrentAuthType: vi.fn().mockReturnValue('custom-provider'),
         syncAfterAuthRefresh: vi.fn(),
       }),
       getSkillManager: vi.fn().mockReturnValue({
@@ -2362,11 +2362,11 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       ...mockConfig,
       getTargetDir: vi.fn().mockReturnValue('/work/status'),
       getMcpServers: vi.fn().mockReturnValue({}),
-      getAuthType: vi.fn().mockReturnValue('qwen'),
-      getModel: vi.fn().mockReturnValue('qwen-plus'),
+      getAuthType: vi.fn().mockReturnValue('custom-provider'),
+      getModel: vi.fn().mockReturnValue('custom-model'),
       getModelsConfig: vi.fn().mockReturnValue({
         getGenerationConfig: vi.fn().mockReturnValue({}),
-        getCurrentAuthType: vi.fn().mockReturnValue('qwen'),
+        getCurrentAuthType: vi.fn().mockReturnValue('custom-provider'),
         syncAfterAuthRefresh: vi.fn(),
       }),
       getSkillManager: vi.fn().mockReturnValue({
@@ -2403,6 +2403,58 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     expect(authCell?.status).toBe('unknown');
     expect(authCell?.detail?.hasToken).toBe('unknown');
     expect(authCell?.detail?.envVarCandidates).toEqual([]);
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('extMethod preflight auth cell reports unknown for qwen-oauth even with placeholder apiKey', async () => {
+    mockConfig = {
+      ...mockConfig,
+      getTargetDir: vi.fn().mockReturnValue('/work/status'),
+      getMcpServers: vi.fn().mockReturnValue({}),
+      getAuthType: vi.fn().mockReturnValue('qwen-oauth'),
+      getModel: vi.fn().mockReturnValue('qwen-plus'),
+      getModelsConfig: vi.fn().mockReturnValue({
+        getGenerationConfig: vi
+          .fn()
+          .mockReturnValue({ apiKey: 'QWEN_OAUTH_DYNAMIC_TOKEN' }),
+        getCurrentAuthType: vi.fn().mockReturnValue('qwen-oauth'),
+        syncAfterAuthRefresh: vi.fn(),
+      }),
+      getSkillManager: vi.fn().mockReturnValue({
+        listSkills: vi.fn().mockResolvedValue([]),
+      }),
+      getAllConfiguredModels: vi.fn().mockReturnValue([]),
+      getToolRegistry: vi.fn().mockReturnValue({ getAllTools: () => [] }),
+    } as unknown as Config;
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    const preflight = (await agent.extMethod(
+      SERVE_STATUS_EXT_METHODS.workspacePreflight,
+      {},
+    )) as {
+      cells: Array<{
+        kind: string;
+        status: string;
+        detail?: { hasToken: boolean | 'unknown'; envVarCandidates: string[] };
+      }>;
+    };
+
+    const authCell = preflight.cells.find((c) => c.kind === 'auth');
+    expect(authCell?.status).toBe('unknown');
+    expect(authCell?.detail?.hasToken).toBe('unknown');
 
     mockConnectionState.resolve();
     await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -2027,6 +2027,11 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       getAuthType: vi.fn().mockReturnValue('qwen'),
       getActiveRuntimeModelSnapshot: vi.fn().mockReturnValue(undefined),
       getModel: vi.fn().mockReturnValue('qwen-plus'),
+      getModelsConfig: vi.fn().mockReturnValue({
+        getGenerationConfig: vi.fn().mockReturnValue({}),
+        getCurrentAuthType: vi.fn().mockReturnValue('qwen'),
+        syncAfterAuthRefresh: vi.fn(),
+      }),
       getSkillManager: vi.fn().mockReturnValue({
         listSkills: vi.fn().mockResolvedValue([]),
       }),
@@ -2297,6 +2302,110 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         process.env['OPENAI_API_KEY'] = savedEnv;
       }
     }
+  });
+
+  it('extMethod preflight auth cell reports ok for non-env-keyed auth when apiKey is in generationConfig', async () => {
+    mockConfig = {
+      ...mockConfig,
+      getTargetDir: vi.fn().mockReturnValue('/work/status'),
+      getMcpServers: vi.fn().mockReturnValue({}),
+      getAuthType: vi.fn().mockReturnValue('qwen'),
+      getModel: vi.fn().mockReturnValue('qwen-plus'),
+      getModelsConfig: vi.fn().mockReturnValue({
+        getGenerationConfig: vi
+          .fn()
+          .mockReturnValue({ apiKey: 'sk-from-settings' }),
+        getCurrentAuthType: vi.fn().mockReturnValue('qwen'),
+        syncAfterAuthRefresh: vi.fn(),
+      }),
+      getSkillManager: vi.fn().mockReturnValue({
+        listSkills: vi.fn().mockResolvedValue([]),
+      }),
+      getAllConfiguredModels: vi.fn().mockReturnValue([]),
+      getToolRegistry: vi.fn().mockReturnValue({ getAllTools: () => [] }),
+    } as unknown as Config;
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    const preflight = (await agent.extMethod(
+      SERVE_STATUS_EXT_METHODS.workspacePreflight,
+      {},
+    )) as {
+      cells: Array<{
+        kind: string;
+        status: string;
+        detail?: { hasToken: boolean | 'unknown'; envVarCandidates: string[] };
+      }>;
+    };
+
+    const authCell = preflight.cells.find((c) => c.kind === 'auth');
+    expect(authCell?.status).toBe('ok');
+    expect(authCell?.detail?.hasToken).toBe(true);
+    expect(authCell?.detail?.envVarCandidates).toEqual([]);
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('extMethod preflight auth cell reports unknown for non-env-keyed auth when no apiKey anywhere', async () => {
+    mockConfig = {
+      ...mockConfig,
+      getTargetDir: vi.fn().mockReturnValue('/work/status'),
+      getMcpServers: vi.fn().mockReturnValue({}),
+      getAuthType: vi.fn().mockReturnValue('qwen'),
+      getModel: vi.fn().mockReturnValue('qwen-plus'),
+      getModelsConfig: vi.fn().mockReturnValue({
+        getGenerationConfig: vi.fn().mockReturnValue({}),
+        getCurrentAuthType: vi.fn().mockReturnValue('qwen'),
+        syncAfterAuthRefresh: vi.fn(),
+      }),
+      getSkillManager: vi.fn().mockReturnValue({
+        listSkills: vi.fn().mockResolvedValue([]),
+      }),
+      getAllConfiguredModels: vi.fn().mockReturnValue([]),
+      getToolRegistry: vi.fn().mockReturnValue({ getAllTools: () => [] }),
+    } as unknown as Config;
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    const preflight = (await agent.extMethod(
+      SERVE_STATUS_EXT_METHODS.workspacePreflight,
+      {},
+    )) as {
+      cells: Array<{
+        kind: string;
+        status: string;
+        detail?: { hasToken: boolean | 'unknown'; envVarCandidates: string[] };
+      }>;
+    };
+
+    const authCell = preflight.cells.find((c) => c.kind === 'auth');
+    expect(authCell?.status).toBe('unknown');
+    expect(authCell?.detail?.hasToken).toBe('unknown');
+    expect(authCell?.detail?.envVarCandidates).toEqual([]);
+
+    mockConnectionState.resolve();
+    await agentPromise;
   });
 
   it('provider status marks current only for matching models', async () => {

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -2150,6 +2150,11 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       getMcpServers: vi.fn().mockReturnValue({}),
       getAuthType: vi.fn().mockReturnValue('qwen'),
       getModel: vi.fn().mockReturnValue('qwen-plus'),
+      getModelsConfig: vi.fn().mockReturnValue({
+        getGenerationConfig: vi.fn().mockReturnValue({}),
+        getCurrentAuthType: vi.fn().mockReturnValue('qwen'),
+        syncAfterAuthRefresh: vi.fn(),
+      }),
       getSkillManager: vi.fn(() => {
         throw new Error('config getter exploded mid-eval');
       }),

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -4120,7 +4120,10 @@ class QwenAgent implements Agent {
         Boolean(process.env[name]),
       );
       let hasToken = Boolean(presentVar);
-      if (!hasToken && String(authType) !== AuthType.QWEN_OAUTH) {
+      if (
+        !hasToken &&
+        !AUTH_PREFLIGHT_WAIVED_AUTH_TYPES.has(String(authType))
+      ) {
         const resolvedApiKey = config
           .getModelsConfig()
           .getGenerationConfig()?.apiKey;

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -4091,9 +4091,10 @@ class QwenAgent implements Agent {
   }
 
   /**
-   * Pure auth preflight check. Looks up the well-known env var keys for the
-   * configured auth method (via `AUTH_ENV_MAPPINGS`) and reports whether at
-   * least one is present.
+   * Pure auth preflight check. First looks up the well-known env var keys
+   * for the configured auth method, then falls back to the API key already
+   * resolved into the generation config (which folds settings.security.auth.apiKey,
+   * provider envKey from settings.env, and CLI flags into a single value).
    *
    * Deliberately does NOT call `validateAuthMethod` from `cli/config/auth.ts`:
    * that helper has side effects (reloads `.env` from disk via
@@ -4118,19 +4119,31 @@ class QwenAgent implements Agent {
       const presentVar = apiKeyVars.find((name: string) =>
         Boolean(process.env[name]),
       );
-      const hasToken = Boolean(presentVar);
+      let hasToken = Boolean(presentVar);
+      if (!hasToken) {
+        const resolvedApiKey = config
+          .getModelsConfig()
+          .getGenerationConfig()?.apiKey;
+        if (resolvedApiKey) {
+          hasToken = true;
+        }
+      }
       // No env-var registration → either OAuth-style auth (qwen-oauth) or
       // a custom provider whose key is sourced from settings rather than
-      // env. Surface as `unknown` (the SDK consumer can defer to the
-      // `/session` boot for definitive validation) rather than a false
-      // negative.
+      // env. If the resolved generation config already contains an apiKey
+      // we can report 'ok'; otherwise surface 'unknown' so the SDK
+      // consumer defers to the `/session` boot for definitive validation.
       if (apiKeyVars.length === 0) {
         return this.acpCell('auth', {
-          status: 'unknown',
-          hint: 'Auth credentials for this provider are not env-keyed; full validation runs at session start.',
+          status: hasToken ? 'ok' : 'unknown',
+          ...(hasToken
+            ? {}
+            : {
+                hint: 'Auth credentials for this provider are not env-keyed; full validation runs at session start.',
+              }),
           detail: {
             source: String(authType),
-            hasToken: 'unknown',
+            hasToken: hasToken || ('unknown' as const),
             envVarCandidates: [],
           },
         });

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -4120,7 +4120,7 @@ class QwenAgent implements Agent {
         Boolean(process.env[name]),
       );
       let hasToken = Boolean(presentVar);
-      if (!hasToken) {
+      if (!hasToken && String(authType) !== AuthType.QWEN_OAUTH) {
         const resolvedApiKey = config
           .getModelsConfig()
           .getGenerationConfig()?.apiKey;


### PR DESCRIPTION
## What this PR does

Fixes a false-positive auth warning on the daemon status dashboard preflight check. When the API key is not set via process environment variables but is configured through `settings.security.auth.apiKey` or a provider-specific `envKey` in `settings.env`, the preflight cell now correctly reports `ok` instead of a misleading warning.

The fix adds a fallback that checks the already-resolved `generationConfig.apiKey` from the live `Config` object — this value folds all credential sources (env vars, settings apiKey, provider envKey, CLI flags) into a single resolved key, consistent with `auth.ts`'s `hasApiKeyForAuth` logic. Also fixes the `apiKeyVars.length === 0` branch (non-env-keyed auth types) to report `ok` when the resolved key is present, instead of unconditionally returning `unknown`.

## Why it's needed

Users who configure their API key through `settings.security.auth.apiKey` (e.g. DashScope key) or provider `envKey` in `settings.env` (e.g. `DASHSCOPE_API_KEY`, `IDEALAB_TEAM_KEY`) see a spurious warning "None of the env vars [OPENAI_API_KEY] is set for authType 'openai'" on the Dashboard → preflight section, even though their credentials work correctly at session start. This erodes trust in the dashboard's diagnostic value.

## Reviewer Test Plan

### How to verify

1. Configure `settings.json` with `security.auth.apiKey` set and no `OPENAI_API_KEY` env var
2. Start daemon: `qwen serve --open`
3. Open Dashboard → click the Dashboard button in the bottom bar
4. Verify the **preflight → auth** cell shows `正常` (ok) instead of `警告` (warning)

### Evidence (Before & After)

**Before:** preflight auth cell shows warning "None of the env vars [OPENAI_API_KEY] is set for authType 'openai'" even when `settings.security.auth.apiKey` is configured.

**After:** preflight auth cell shows `ok` when the API key is resolvable from any source (env var, settings apiKey, provider envKey, CLI flags).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  ⚠️   |
|  🐧 Linux  |  ⚠️   |

### Environment (optional)

Local `npm start -- serve --open`, daemon status dashboard.

## Risk & Scope

- Main risk or tradeoff: `config.getModelsConfig().getGenerationConfig()?.apiKey` is a pure getter with no side effects — safe for the read-only preflight path. The existing env-var check is tried first, so this is strictly additive.
- Not validated / out of scope: OAuth-based auth types (qwen-oauth) — these already return `unknown` status via the `apiKeyVars.length === 0` branch, unchanged behavior when no resolved key exists.
- Breaking changes / migration notes: None.

<details>
<summary>中文说明</summary>

## 改动内容

修复 daemon 状态面板 preflight 检查中的 auth 误报。当 API key 不是通过环境变量设置，而是通过 `settings.security.auth.apiKey` 或 provider 的 `envKey`（在 `settings.env` 中）配置时，preflight auth cell 现在正确显示 `ok` 而不是误导性的 warning。

修复方案：在环境变量检查失败后，fallback 到 `Config` 对象中已解析的 `generationConfig.apiKey`——该值汇聚了所有凭据来源（环境变量、settings apiKey、provider envKey、CLI 参数），与 `auth.ts` 中 `hasApiKeyForAuth` 的逻辑一致。同时修复了 `apiKeyVars.length === 0` 分支（非 env-keyed 的 auth 类型），当已解析的 key 存在时返回 `ok` 而非无条件返回 `unknown`。

## 为什么需要

通过 `settings.security.auth.apiKey`（如 DashScope key）或 provider `envKey`（如 `DASHSCOPE_API_KEY`、`IDEALAB_TEAM_KEY`）配置凭据的用户，在 Dashboard → preflight 区域会看到虚假警告 "None of the env vars [OPENAI_API_KEY] is set for authType 'openai'"，尽管凭据在 session 启动时工作正常。这降低了 dashboard 诊断信息的可信度。

## 验证方式

1. 在 `settings.json` 中配置 `security.auth.apiKey`，不设 `OPENAI_API_KEY` 环境变量
2. 启动 daemon：`qwen serve --open`
3. 打开 Dashboard，点击底部的 Dashboard 按钮
4. 验证 **preflight → auth** cell 显示 `正常`（ok）而非 `警告`（warning）

## 风险与范围

- 主要风险：`config.getModelsConfig().getGenerationConfig()?.apiKey` 是纯 getter，无副作用，对只读的 preflight 路径安全。现有的环境变量检查优先执行，此修改是严格的增量补充。
- 未验证/不在范围：OAuth 类型认证（qwen-oauth）—— 这些仍通过 `apiKeyVars.length === 0` 分支返回 `unknown`，无 key 时行为不变。
- 破坏性变更/迁移说明：无。

</details>

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)