### PR TITLE
fix(core): enforce agent concurrency cap on foreground sub-agents

### DIFF
--- a/packages/core/src/agents/background-tasks.test.ts
+++ b/packages/core/src/agents/background-tasks.test.ts
@@ -511,16 +511,24 @@ describe('BackgroundTaskRegistry', () => {
       expect(registry.get('bg-1')?.prompt).toBe('resumed continuation');
     });
 
-    it('does not count foreground, paused, or terminal entries toward the cap', () => {
+    it('counts foreground agents toward the cap but not paused or terminal entries', () => {
       registry = new BackgroundTaskRegistry({
         maxConcurrentBackgroundAgents: 1,
       });
 
+      // A foreground agent occupies a slot.
       registry.register(
         makeRegistration('fg-1', {
           isBackgrounded: false,
         }),
       );
+
+      expect(() => registry.register(makeRegistration('bg-1'))).toThrow(
+        'maximum concurrent background agents (1) reached',
+      );
+
+      // Paused entries do not occupy a slot.
+      registry.unregisterForeground('fg-1');
       registry.register(
         makeRegistration('paused-1', {
           status: 'paused',
@@ -535,7 +543,6 @@ describe('BackgroundTaskRegistry', () => {
       registry.complete('bg-1', 'done');
       registry.register(makeRegistration('bg-2'));
 
-      expect(registry.get('fg-1')).toBeDefined();
       expect(registry.get('paused-1')).toBeDefined();
       expect(registry.get('bg-2')?.status).toBe('running');
     });

--- a/packages/core/src/agents/background-tasks.ts
+++ b/packages/core/src/agents/background-tasks.ts
@@ -428,10 +428,9 @@ export class BackgroundTaskRegistry {
     registration: AgentTaskRegistration,
     options: BackgroundTaskRegisterOptions = {},
   ): AgentTask {
-    if (registration.isBackgrounded && registration.status === 'running') {
+    if (registration.status === 'running') {
       const existing = this.agents.get(registration.agentId);
-      const isReplacingRunning =
-        existing?.isBackgrounded === true && existing.status === 'running';
+      const isReplacingRunning = existing?.status === 'running';
       if (!isReplacingRunning) {
         this.assertCanStartBackgroundAgent();
       }
@@ -852,7 +851,7 @@ export class BackgroundTaskRegistry {
 
   private getRunningBackgroundCount(): number {
     return Array.from(this.agents.values()).filter(
-      (entry) => entry.isBackgrounded && entry.status === 'running',
+      (entry) => entry.status === 'running',
     ).length;
   }
 

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -2135,26 +2135,22 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
       // This is not redundant with registry.register() below — that call
       // remains the authoritative race guard, but by then the launch path
       // has already run hooks and created a child agent.
-      if (shouldRunInBackground) {
-        try {
-          this.config
-            .getBackgroundTaskRegistry()
-            .assertCanStartBackgroundAgent();
-        } catch (error) {
-          const errorMessage =
-            error instanceof Error ? error.message : String(error);
-          this.updateDisplay(
-            {
-              status: 'failed',
-              terminateReason: errorMessage,
-            },
-            updateOutput,
-          );
-          return {
-            llmContent: errorMessage,
-            returnDisplay: this.currentDisplay!,
-          };
-        }
+      try {
+        this.config.getBackgroundTaskRegistry().assertCanStartBackgroundAgent();
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        this.updateDisplay(
+          {
+            status: 'failed',
+            terminateReason: errorMessage,
+          },
+          updateOutput,
+        );
+        return {
+          llmContent: errorMessage,
+          returnDisplay: this.currentDisplay!,
+        };
       }
 
       // ── Optional worktree isolation (Phase 1: provision) ──────────


### PR DESCRIPTION
## What happened?

`QWEN_CODE_MAX_BACKGROUND_AGENTS` only limits agents where `isBackgrounded: true`. Foreground sub-agents (Explorer, general-purpose, statusline-setup) bypass the concurrency cap entirely, allowing the main agent to spawn unlimited foreground sub-agents in parallel.

## What did you expect to happen?

`QWEN_CODE_MAX_BACKGROUND_AGENTS` should limit all concurrent sub-agents regardless of foreground/background mode.

## Changes

Three surgical changes to make the cap apply to all sub-agents:

1. **`background-tasks.ts` — `getRunningBackgroundCount()`**: Count all running agents, not just `isBackgrounded` ones.
2. **`background-tasks.ts` — `register()`**: Remove the `isBackgrounded` guard so the concurrency check applies to all agent registrations.
3. **`agent.ts` — preflight check**: Remove the `shouldRunInBackground` guard so foreground agent launches also hit the cap check before expensive setup.

## Testing

- Updated `background-tasks.test.ts` to verify foreground agents count against the cap
- All tests pass: 89/89 background-tasks, 132/132 agent, 35/35 background-agent-resume (256 total)

## Reviewer Test Plan

### How to verify

```bash
cd packages/core
npx vitest run src/agents/background-tasks.test.ts src/tools/agent/agent.test.ts src/agents/background-agent-resume.test.ts
```

### Environment

Linux x64, Node.js v24

## Notes

- Method/config names (`getRunningBackgroundCount`, `maxConcurrentBackgroundAgents`, `QWEN_CODE_MAX_BACKGROUND_AGENTS`) are preserved to keep the diff minimal and avoid breaking existing configurations. A follow-up could rename these to reflect the broader scope if desired.
- The `isReplacingRunning` check in `register()` is simplified to only check `status === "running"` since the cap now covers all agent types — the `isBackgrounded` qualification on the existing-entry check is no longer needed.

Closes #6290