### PR TITLE
fix(cli): error on unknown slash commands in non-interactive mode

### DIFF
--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -1910,38 +1910,23 @@ describe('runNonInteractive', () => {
     );
   });
 
-  it('should treat an unknown slash command as a regular prompt', async () => {
+  it('should return an error for unknown slash commands', async () => {
     setupMetricsMock();
     // No commands are mocked, so any slash command is "unknown"
     mockGetCommands.mockReturnValue([]);
 
-    const events: ServerGeminiStreamEvent[] = [
-      { type: GeminiEventType.Content, value: 'Response to unknown' },
-      {
-        type: GeminiEventType.Finished,
-        value: { reason: undefined, usageMetadata: { totalTokenCount: 5 } },
-      },
-    ];
-    mockGeminiClient.sendMessageStream.mockReturnValue(
-      createStreamFromEvents(events),
-    );
-
-    await runNonInteractive(
+    const exitCode = await runNonInteractive(
       mockConfig,
       mockSettings,
-      '/unknowncommand',
+      '/unknowncommand arg1',
       'prompt-id-unknown',
     );
 
-    // Ensure the raw input is sent to the model
-    expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledWith(
-      [{ text: '/unknowncommand' }],
-      expect.any(AbortSignal),
-      'prompt-id-unknown',
-      { type: SendMessageType.UserQuery },
+    expect(exitCode).toBe(1);
+    expect(mockGeminiClient.sendMessageStream).not.toHaveBeenCalled();
+    expect(processStderrSpy).toHaveBeenCalledWith(
+      'Unknown command: /unknowncommand. Type /help to see available commands.\n',
     );
-
-    expect(processStdoutSpy).toHaveBeenCalledWith('Response to unknown\n');
   });
 
   it('should handle known but unsupported slash commands like /help by returning early', async () => {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -701,8 +701,18 @@ export async function runNonInteractive(
               });
               return 1;
             }
-            case 'no_command':
-              break;
+            case 'no_command': {
+              const typedCommand =
+                input.trim().substring(1).trim().split(/\s+/)[0] ?? '';
+              await emitNonInteractiveFinalMessage({
+                message: `Unknown command: /${typedCommand}. Type /help to see available commands.`,
+                isError: true,
+                adapter,
+                config,
+                startTimeMs: startTime,
+              });
+              return 1;
+            }
             default: {
               const _exhaustive: never = slashCommandResult;
               throw new FatalInputError(

--- a/packages/cli/src/nonInteractiveCliCommands.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.ts
@@ -366,8 +366,7 @@ export const handleSlashCommand = async (
 
   // Load the full command set (unfiltered by the denylist) so that the
   // fallback existence check below can distinguish a disabled command from a
-  // truly unknown one. Without this, a disabled command would fall through to
-  // `no_command` and be forwarded to the model as plain prompt text.
+  // truly unknown one.
   const allCommandService = await CommandService.create(
     allLoaders,
     abortController.signal,


### PR DESCRIPTION
## Summary

Before this change, unknown slash commands (e.g. `/foo`) in non-interactive mode were silently forwarded to the model as regular prompt text. After this change, they produce a clear `Unknown command: /foo. Type /help to see available commands.` error and exit with code 1 — matching the behavior already present in interactive mode.

## What this changes

- `nonInteractiveCli.ts`: the `no_command` case now emits an error via `emitNonInteractiveFinalMessage` and returns exit code 1, instead of silently breaking and letting the input through as a prompt.
- `nonInteractiveCli.test.ts`: updated the existing test to verify the new error behavior (exit 1, no model call, stderr message).
- `nonInteractiveCliCommands.ts`: removed a stale comment that referenced the old forwarding behavior.

## Reviewer Test Plan

1. `npx qwen -p "/nonexistent"` → should print `Unknown command: /nonexistent. Type /help to see available commands.` to stderr and exit 1
2. `npx qwen -p "/nonexistent arg1 arg2"` → same error, only `/nonexistent` shown in message
3. `npx qwen -p "/help"` → still works as before (handled by `unsupported` branch, not `no_command`)
4. `cd packages/cli && npx vitest run src/nonInteractiveCli.test.ts` → all tests pass

Closes #6299