### PR TITLE
test(e2e): make fake OpenAI reachable from Docker sandbox

### DIFF
--- a/integration-tests/fake-openai-server.test.ts
+++ b/integration-tests/fake-openai-server.test.ts
@@ -190,6 +190,23 @@ describe('fake OpenAI server', () => {
     expect(response.status).toBe(400);
   });
 
+  it('rejects oversized request bodies', async () => {
+    let handled = false;
+    server = await startFakeOpenAIServer(() => {
+      handled = true;
+      return { content: 'unused' };
+    });
+
+    const response = await fetch(`${server.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: 'x'.repeat(10 * 1024 * 1024 + 1),
+    });
+
+    expect(response.status).toBe(413);
+    expect(handled).toBe(false);
+  });
+
   it('returns 500 without exposing handler error details', async () => {
     server = await startFakeOpenAIServer(() => {
       throw new Error('secret stack detail');

--- a/integration-tests/fake-openai-server.ts
+++ b/integration-tests/fake-openai-server.ts
@@ -45,15 +45,22 @@ export type FakeOpenAIServer = {
   close: () => Promise<void>;
 };
 
-export type FakeOpenAIServerOptions = {
-  listenHost?: string;
-  baseUrlHost?: string;
-};
+export type FakeOpenAIServerOptions =
+  | { listenHost?: undefined; baseUrlHost?: undefined }
+  | { listenHost: string; baseUrlHost: string };
 
 export type FakeOpenAIHandler = (ctx: {
   body: JsonObject;
   requestIndex: number;
 }) => FakeOpenAIResponse | Promise<FakeOpenAIResponse>;
+
+const MAX_REQUEST_BODY_BYTES = 10 * 1024 * 1024;
+
+class RequestBodyTooLargeError extends Error {
+  constructor() {
+    super('fake OpenAI request body too large');
+  }
+}
 
 export function fakeToolCall(
   name: string,
@@ -100,7 +107,13 @@ export async function startFakeOpenAIServer(
       } else {
         writeNonStreamed(res, getModel(body), response);
       }
-    } catch {
+    } catch (error) {
+      if (error instanceof RequestBodyTooLargeError) {
+        res.writeHead(413);
+        res.end('request body too large');
+        return;
+      }
+
       if (res.headersSent) {
         if (!res.writableEnded) {
           res.destroy();
@@ -151,8 +164,21 @@ export async function startFakeOpenAIServer(
 function readRequestBody(req: IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
-    req.on('data', (chunk: Buffer) => chunks.push(chunk));
-    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    let totalLength = 0;
+    let tooLarge = false;
+    req.on('data', (chunk: Buffer) => {
+      if (tooLarge) return;
+      totalLength += chunk.length;
+      if (totalLength > MAX_REQUEST_BODY_BYTES) {
+        tooLarge = true;
+        reject(new RequestBodyTooLargeError());
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => {
+      if (!tooLarge) resolve(Buffer.concat(chunks).toString('utf8'));
+    });
     req.on('error', reject);
   });
 }

--- a/integration-tests/fake-openai-server.ts
+++ b/integration-tests/fake-openai-server.ts
@@ -45,6 +45,11 @@ export type FakeOpenAIServer = {
   close: () => Promise<void>;
 };
 
+export type FakeOpenAIServerOptions = {
+  listenHost?: string;
+  baseUrlHost?: string;
+};
+
 export type FakeOpenAIHandler = (ctx: {
   body: JsonObject;
   requestIndex: number;
@@ -67,6 +72,7 @@ export function fakeToolCall(
 
 export async function startFakeOpenAIServer(
   handler: FakeOpenAIHandler,
+  options: FakeOpenAIServerOptions = {},
 ): Promise<FakeOpenAIServer> {
   const requests: FakeOpenAIRequest[] = [];
   const server = createServer(async (req, res) => {
@@ -125,7 +131,7 @@ export async function startFakeOpenAIServer(
     };
     server.once('error', onError);
     server.once('listening', onListening);
-    server.listen(0, '127.0.0.1');
+    server.listen(0, options.listenHost ?? '127.0.0.1');
   });
 
   const address = server.address();
@@ -134,7 +140,9 @@ export async function startFakeOpenAIServer(
   }
 
   return {
-    baseUrl: `http://127.0.0.1:${(address as AddressInfo).port}/v1`,
+    baseUrl: `http://${options.baseUrlHost ?? '127.0.0.1'}:${
+      (address as AddressInfo).port
+    }/v1`,
     requests,
     close: () => closeServer(server),
   };

--- a/integration-tests/sdk-typescript/tool-control.test.ts
+++ b/integration-tests/sdk-typescript/tool-control.test.ts
@@ -32,6 +32,13 @@ import {
 
 const SHARED_TEST_OPTIONS = createSharedTestOptions();
 const TEST_TIMEOUT = 60000;
+const SANDBOX_MODE = process.env['QWEN_SANDBOX']?.toLowerCase().trim();
+const IS_CONTAINER_SANDBOX = Boolean(
+  SANDBOX_MODE && SANDBOX_MODE !== 'false' && SANDBOX_MODE !== '0',
+);
+const LOCAL_OPENAI_NO_PROXY = IS_CONTAINER_SANDBOX
+  ? '127.0.0.1,localhost,host.docker.internal'
+  : '127.0.0.1,localhost';
 
 describe('Tool Control Parameters (E2E)', () => {
   let helper: SDKTestHelper;
@@ -1031,19 +1038,27 @@ describe('Tool Control Parameters (E2E)', () => {
         await helper.createFile('test.txt', 'original');
 
         const canUseToolCalls: string[] = [];
-        const fakeServer = await startFakeOpenAIServer(({ requestIndex }) => {
-          if (requestIndex === 0) {
-            return {
-              toolCalls: [
-                fakeToolCall('read_file', {
-                  file_path: helper.getPath('test.txt'),
-                }),
-              ],
-            };
-          }
+        const fakeServer = await startFakeOpenAIServer(
+          ({ requestIndex }) => {
+            if (requestIndex === 0) {
+              return {
+                toolCalls: [
+                  fakeToolCall('read_file', {
+                    file_path: helper.getPath('test.txt'),
+                  }),
+                ],
+              };
+            }
 
-          return { content: 'Plan: leave the file unchanged.' };
-        });
+            return { content: 'Plan: leave the file unchanged.' };
+          },
+          IS_CONTAINER_SANDBOX
+            ? {
+                listenHost: '0.0.0.0',
+                baseUrlHost: 'host.docker.internal',
+              }
+            : undefined,
+        );
 
         const q = query({
           prompt: 'Read test.txt and write "modified" to it.',
@@ -1052,8 +1067,8 @@ describe('Tool Control Parameters (E2E)', () => {
             cwd: testDir,
             model: 'fake-model',
             env: {
-              NO_PROXY: '127.0.0.1,localhost',
-              no_proxy: '127.0.0.1,localhost',
+              NO_PROXY: LOCAL_OPENAI_NO_PROXY,
+              no_proxy: LOCAL_OPENAI_NO_PROXY,
               OPENAI_API_KEY: 'fake-key',
               OPENAI_BASE_URL: fakeServer.baseUrl,
               OPENAI_MODEL: 'fake-model',

--- a/integration-tests/sdk-typescript/tool-control.test.ts
+++ b/integration-tests/sdk-typescript/tool-control.test.ts
@@ -33,9 +33,8 @@ import {
 const SHARED_TEST_OPTIONS = createSharedTestOptions();
 const TEST_TIMEOUT = 60000;
 const SANDBOX_MODE = process.env['QWEN_SANDBOX']?.toLowerCase().trim();
-const IS_CONTAINER_SANDBOX = Boolean(
-  SANDBOX_MODE && SANDBOX_MODE !== 'false' && SANDBOX_MODE !== '0',
-);
+const IS_CONTAINER_SANDBOX =
+  SANDBOX_MODE === 'docker' || SANDBOX_MODE === 'podman';
 const LOCAL_OPENAI_NO_PROXY = IS_CONTAINER_SANDBOX
   ? '127.0.0.1,localhost,host.docker.internal'
   : '127.0.0.1,localhost';


### PR DESCRIPTION
## What this PR does

It makes the fake OpenAI endpoint used by SDK E2E tests reachable when the CLI is executed inside a Docker or Podman sandbox. Container sandbox runs now advertise the endpoint through `host.docker.internal` and bypass proxies for that host, while non-sandbox runs keep using loopback.

## Why it's needed

The plan-mode tool-control E2E moved to a host-local fake OpenAI endpoint, but the sandboxed CLI resolved `127.0.0.1` inside the container. The model request never reached the fake endpoint, so the expected read-only tool call was missing and the Docker E2E job failed with `expected [] to include 'read_file'`.

## Reviewer Test Plan

### How to verify

Run the SDK plan-mode tool-control E2E with `QWEN_SANDBOX=docker`; it should complete with the read-only tool call observed instead of timing out or producing an empty tool-call list. Run the same target with `QWEN_SANDBOX=false` to confirm the non-sandbox path still works.

### Evidence (Before & After)

Before: the targeted Docker sandbox run reproduced the CI failure and ended with `expected [] to include 'read_file'`. After: the same targeted Docker sandbox run passed with `1 passed | 29 skipped` in about 8 seconds. This is non-UI behavior; no screenshots.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested through the Docker sandbox image |

### Environment (optional)

macOS host with Docker/Colima, Node v22.22.0, Docker CLI 28.0.0 / daemon 27.4.0, `QWEN_SANDBOX=docker`, sandbox image `ghcr.io/qwenlm/qwen-code:0.19.6`.

## Risk & Scope

- Main risk or tradeoff: the fake endpoint can listen on all interfaces only for tests that explicitly request a container-reachable URL.
- Not validated / out of scope: the full Docker E2E suite did not finish locally because another real-model-driven tool-control scenario hung on the local Docker/Colima setup; GitHub Actions remains the full-suite validation.
- Breaking changes / migration notes: none.

## Linked Issues

References https://github.com/QwenLM/qwen-code/actions/runs/28695587174/job/85104487555.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 让 SDK E2E 测试使用的 fake OpenAI endpoint 在 CLI 进入 Docker 或 Podman sandbox 后仍然可访问。容器 sandbox 场景会通过 `host.docker.internal` 暴露 endpoint，并把该 host 加入代理绕过列表；非 sandbox 场景仍然使用 loopback。

## 为什么需要

plan-mode tool-control E2E 改成了 host 本地 fake OpenAI endpoint，但 sandbox 内的 CLI 会把 `127.0.0.1` 解析到容器自身。模型请求没有到达 fake endpoint，导致预期的只读工具调用缺失，Docker E2E job 报错 `expected [] to include 'read_file'`。

## Reviewer Test Plan

### 如何验证

用 `QWEN_SANDBOX=docker` 运行 SDK plan-mode tool-control E2E；它应该能观察到只读工具调用，而不是超时或得到空工具调用列表。再用 `QWEN_SANDBOX=false` 运行同一个目标，确认非 sandbox 路径仍然正常。

### 证据（修复前后）

修复前：目标 Docker sandbox 运行复现了 CI 失败，最终报 `expected [] to include 'read_file'`。修复后：同一个目标 Docker sandbox 运行通过，结果为 `1 passed | 29 skipped`，耗时约 8 秒。这是非 UI 行为，无截图。

### 测试平台

macOS 已测；Windows 未测；Linux 路径通过 Docker sandbox image 验证。

### 环境

macOS host with Docker/Colima, Node v22.22.0, Docker CLI 28.0.0 / daemon 27.4.0, `QWEN_SANDBOX=docker`, sandbox image `ghcr.io/qwenlm/qwen-code:0.19.6`。

## 风险与范围

- 主要风险或取舍：fake endpoint 只有在测试显式请求容器可访问 URL 时才会监听所有接口。
- 未验证 / 不在范围内：完整 Docker E2E suite 在本地没有跑完，因为另一个依赖真实模型的 tool-control 场景在本地 Docker/Colima 环境中挂住；完整 suite 仍以 GitHub Actions 为准。
- 破坏性变更 / 迁移说明：无。

## 关联问题

参考 https://github.com/QwenLM/qwen-code/actions/runs/28695587174/job/85104487555。

</details>
