### PR TITLE
fix(ci): Stop review bots for closed PRs

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -8,6 +8,7 @@ on:
       - 'reopened'
       - 'ready_for_review'
       - 'review_requested'
+      - 'closed'
   issue_comment:
     types: ['created']
   pull_request_review_comment:
@@ -48,18 +49,25 @@ on:
         type: 'boolean'
 
 concurrency:
-  # PR lifecycle events share a PR-scoped group so new pushes restart the delay.
+  # PR lifecycle events share a PR-scoped group so new pushes restart the delay
+  # and closed PRs stop any in-flight lifecycle review.
   # Comment/review events use per-run groups to avoid cancelling active reviews.
   group: >-
     ${{ github.event_name == 'pull_request_target' &&
     format('qwen-pr-review-pr-{0}', github.event.pull_request.number) ||
     format('qwen-pr-review-run-{0}', github.run_id) }}
-  cancel-in-progress: "${{ github.event_name == 'pull_request_target' && github.event.action == 'synchronize' }}"
+  cancel-in-progress: >-
+    ${{
+      github.event_name == 'pull_request_target' &&
+      (github.event.action == 'synchronize' ||
+       github.event.action == 'closed')
+    }}
 
 jobs:
   precheck-pr:
     if: |-
       github.event_name == 'pull_request_target' &&
+      github.event.action != 'closed' &&
       github.event.pull_request.head.repo.full_name != github.repository &&
       (github.event.action != 'review_requested' ||
        github.event.requested_reviewer.login == 'qwen-code-ci-bot')
@@ -207,6 +215,8 @@ jobs:
     # `if`s still do the exact command body match; this prefix is just a filter.
     if: |-
       always() &&
+      (github.event_name != 'pull_request_target' ||
+       github.event.action != 'closed') &&
       (github.event_name != 'pull_request_target' ||
        github.event.pull_request.head.repo.full_name == github.repository ||
        needs.precheck-pr.outputs.decision == 'allow_triage') &&

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -62,6 +62,7 @@ jobs:
        needs.precheck-pr.outputs.decision == 'allow_triage') &&
       (github.event_name == 'pull_request_target' ||
        (github.event_name == 'issue_comment' &&
+        github.event.issue.state == 'open' &&
         (startsWith(github.event.comment.body, '@qwen-code /triage') ||
          github.event.comment.body == '@qwen-code /tmux' ||
          startsWith(github.event.comment.body, '@qwen-code /tmux '))) ||
@@ -160,7 +161,8 @@ jobs:
              (github.event.pull_request.draft == true ||
               needs.authorize.outputs.should_run != 'true')) ||
             (github.event_name == 'issue_comment' &&
-             needs.authorize.outputs.should_run != 'true')
+             (github.event.issue.state != 'open' ||
+              needs.authorize.outputs.should_run != 'true'))
           ) &&
           format('{0}-run-{1}', github.workflow, github.run_id) ||
           format('{0}-{1}', github.workflow, github.event.issue.number || github.event.pull_request.number || github.event.inputs.number)
@@ -172,6 +174,7 @@ jobs:
           (((github.event_name == 'pull_request_target' &&
              github.event.pull_request.draft == false) ||
             (github.event_name == 'issue_comment' &&
+             github.event.issue.state == 'open' &&
              startsWith(github.event.comment.body, '@qwen-code /triage'))) &&
            needs.authorize.outputs.should_run == 'true')
         }}
@@ -197,6 +200,7 @@ jobs:
           ((github.event_name == 'pull_request_target' &&
             github.event.pull_request.draft == false) ||
            (github.event_name == 'issue_comment' &&
+            github.event.issue.state == 'open' &&
             startsWith(github.event.comment.body, '@qwen-code /triage'))) &&
           needs.authorize.outputs.should_run == 'true'
         )
@@ -298,6 +302,7 @@ jobs:
       (
         (github.event_name == 'issue_comment' &&
          github.event.issue.pull_request &&
+         github.event.issue.state == 'open' &&
          (github.event.comment.body == '@qwen-code /tmux' ||
           startsWith(github.event.comment.body, '@qwen-code /tmux ')) &&
          needs.authorize.outputs.should_run == 'true') ||
@@ -316,6 +321,7 @@ jobs:
           (
             ((github.event_name == 'issue_comment' &&
               github.event.issue.pull_request &&
+              github.event.issue.state == 'open' &&
               (github.event.comment.body == '@qwen-code /tmux' ||
                startsWith(github.event.comment.body, '@qwen-code /tmux '))) ||
              (github.event_name == 'workflow_dispatch' &&

--- a/scripts/tests/qwen-resolve-workflow.test.js
+++ b/scripts/tests/qwen-resolve-workflow.test.js
@@ -65,6 +65,14 @@ describe('qwen resolve workflow', () => {
     );
   });
 
+  it('cancels in-flight lifecycle reviews when the PR closes', () => {
+    expect(workflow).toContain("- 'closed'");
+    expect(workflow).toContain("github.event.action == 'closed'");
+    expect(workflow).toContain(
+      "format('qwen-pr-review-pr-{0}', github.event.pull_request.number)",
+    );
+  });
+
   it('listens for /resolve comments', () => {
     expect(workflow).toContain(
       "github.event.comment.body == '@qwen-code /resolve'",

--- a/scripts/tests/qwen-resolve-workflow.test.js
+++ b/scripts/tests/qwen-resolve-workflow.test.js
@@ -66,9 +66,15 @@ describe('qwen resolve workflow', () => {
   });
 
   it('cancels in-flight lifecycle reviews when the PR closes', () => {
+    const concurrencyStart = workflow.indexOf('\nconcurrency:');
+    const concurrency = workflow.slice(
+      concurrencyStart,
+      workflow.indexOf('\njobs:', concurrencyStart),
+    );
+
     expect(workflow).toContain("- 'closed'");
-    expect(workflow).toContain("github.event.action == 'closed'");
-    expect(workflow).toContain(
+    expect(concurrency).toContain("github.event.action == 'closed'");
+    expect(concurrency).toContain(
       "format('qwen-pr-review-pr-{0}', github.event.pull_request.number)",
     );
   });

--- a/scripts/tests/qwen-resolve-workflow.test.js
+++ b/scripts/tests/qwen-resolve-workflow.test.js
@@ -192,6 +192,12 @@ describe('qwen resolve workflow', () => {
       : workflow.slice(resolveJobStart, resolveJobStart + 1 + nextJob);
   const reviewJob = job(workflow, 'review-pr');
   const authorizeJob = job(workflow, 'authorize');
+  const precheckJob = job(workflow, 'precheck-pr');
+
+  it('keeps closed PR events from running precheck or authorize jobs', () => {
+    expect(precheckJob).toContain("github.event.action != 'closed'");
+    expect(authorizeJob).toContain("github.event.action != 'closed'");
+  });
 
   it('does not require fork PR authors to have write permission for automatic review', () => {
     const authorizeStep = step(

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -60,6 +60,16 @@ describe('qwen-triage tmux workflow', () => {
     );
   });
 
+  it('requires open issues or PRs for comment-triggered triage', () => {
+    const authorizeJob = job('authorize');
+    const triageJob = job('triage');
+    const tmuxJob = job('tmux-testing');
+
+    expect(authorizeJob).toContain("github.event.issue.state == 'open'");
+    expect(triageJob).toContain("github.event.issue.state == 'open'");
+    expect(tmuxJob).toContain("github.event.issue.state == 'open'");
+  });
+
   it('escapes embedded tmux artifacts without bash pattern replacement ampersands', () => {
     const postStep = step('Post tmux result comment');
 


### PR DESCRIPTION
## What this PR does

Stops closed PRs from continuing to spend review and triage automation time. PR lifecycle review runs now listen for closed PR events in the same PR-scoped concurrency group, so a close event cancels in-flight automatic review work without running the review itself. Comment-triggered triage and tmux entry points now require the issue or PR to still be open before they can authorize or run agent work.

## Why it's needed

#6299 reports that review automation can keep running after a PR has already been closed, which wastes review tokens and keeps notifying contributors. The previous safeguards checked PR state before starting normal review paths, but they did not create a closed-PR event capable of cancelling an already-running lifecycle review. The triage workflow also accepted command comments on closed issues or PRs, leaving another path where bot work could start after the discussion was already closed.

## Reviewer Test Plan

### How to verify

Start an automatic PR review run, then close the PR before the review finishes. The closed event should enter the same PR-level concurrency group and cancel the in-flight lifecycle review, while the closed event itself should skip the review jobs. On a closed issue or PR, comment `@qwen-code /triage` or `@qwen-code /tmux`; the workflow should not authorize or run the triage/tmux agent path.

Local validation:

- `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-resolve-workflow.test.js scripts/tests/qwen-triage-workflow.test.js` — 27 passed
- `node scripts/lint.js --actionlint` — passed
- `node scripts/lint.js --yamllint` — passed
- `npm run build && npm run typecheck` — passed

### Evidence (Before & After)

N/A — workflow-only change; no user-visible TUI output.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local Node.js workspace; GitHub Actions behavior validated with workflow regression tests plus `actionlint` and `yamllint`.

## Risk & Scope

- Main risk or tradeoff: this cancels PR lifecycle review runs on close, while leaving unrelated comment/review events in their per-run groups so manual requests do not unexpectedly cancel each other.
- Not validated / out of scope: live GitHub Actions cancellation was not exercised against a real in-flight PR review; the behavior is covered structurally by workflow tests and actionlint validation.
- Breaking changes / migration notes: N/A

## Linked Issues

Closes #6299

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

停止已关闭 PR 继续消耗 review 和 triage 自动化资源。PR 生命周期 review 现在会监听 PR closed 事件，并使用同一个 PR 级 concurrency group，因此关闭 PR 的事件会取消正在运行的自动 review，但 closed 事件本身不会继续执行 review。由评论触发的 triage 和 tmux 入口现在也要求 issue 或 PR 仍然是 open 状态，才会进入授权或运行 agent。

## 为什么需要这个改动

#6299 反馈了 PR 已经关闭后 review 自动化仍然可能继续运行的问题，这会浪费 review token，也会持续通知贡献者。之前的保护只是在正常 review 路径启动前检查 PR 状态，但没有一个 closed PR 事件来取消已经运行中的 lifecycle review。triage workflow 也仍然接受 closed issue 或 PR 上的命令评论，留下了另一个在讨论已关闭后仍可能启动 bot 工作的路径。

## Reviewer Test Plan

### 如何验证

启动一次自动 PR review run，然后在 review 完成前关闭 PR。closed 事件应该进入同一个 PR 级 concurrency group 并取消运行中的 lifecycle review，同时 closed 事件本身应该跳过 review jobs。在 closed issue 或 PR 上评论 `@qwen-code /triage` 或 `@qwen-code /tmux`；workflow 不应该授权或运行 triage/tmux agent 路径。

本地验证：

- `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-resolve-workflow.test.js scripts/tests/qwen-triage-workflow.test.js` — 27 passed
- `node scripts/lint.js --actionlint` — passed
- `node scripts/lint.js --yamllint` — passed
- `npm run build && npm run typecheck` — passed

### Evidence (Before & After)

N/A — 仅 workflow 改动，没有用户可见的 TUI 输出。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 Node.js workspace；GitHub Actions 行为通过 workflow 回归测试以及 `actionlint`、`yamllint` 验证。

## Risk & Scope

- Main risk or tradeoff: 这个改动会在 PR 关闭时取消 PR lifecycle review runs，同时保留无关 comment/review 事件的 per-run group，避免手动请求之间意外互相取消。
- Not validated / out of scope: 没有在真实运行中的 PR review 上现场验证 GitHub Actions cancellation；该行为通过 workflow 测试和 actionlint 做了结构性覆盖。
- Breaking changes / migration notes: N/A

## Linked Issues

Closes #6299

</details>
