### PR TITLE
feat(acp): Batch session load replay

### DIFF
--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -1289,6 +1289,8 @@ describe('createAcpSessionBridge', () => {
       _meta: { 'qwen.session.loadReplayMode': 'bulk' },
     });
     expect(loaded.state).toEqual({ _meta: { keep: 'state' } });
+    expect(loaded.partial).toBe(true);
+    expect(loaded.replayError).toBe('replay boom');
     expect(loaded.lastEventId).toBe(2);
     expect(loaded.compactedReplay).toEqual([]);
     expect(loaded.liveJournal).toHaveLength(2);
@@ -1305,6 +1307,35 @@ describe('createAcpSessionBridge', () => {
       data: { reason: 'seeded_replay_not_in_ring' },
     });
     await iterator.return?.();
+    await bridge.shutdown();
+  });
+
+  it('rejects oversized response-mode load replay payloads', async () => {
+    const factory: ChannelFactory = async () =>
+      makeChannel({
+        loadSessionImpl: () => ({
+          _meta: {
+            'qwen.session.loadReplay': {
+              v: 1,
+              updates: Array.from({ length: 10_001 }, () => ({
+                sessionUpdate: 'agent_message_chunk',
+              })),
+            },
+          },
+        }),
+      }).channel;
+    const bridge = makeBridge({ channelFactory: factory });
+
+    await expect(
+      bridge.loadSession({
+        sessionId: 'persisted-huge-bulk-history',
+        workspaceCwd: WS_A,
+        historyReplay: 'response',
+      }),
+    ).rejects.toThrow(
+      'qwen.session.loadReplay updates exceed limit (10001 > 10000)',
+    );
+
     await bridge.shutdown();
   });
 

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -44,7 +44,7 @@ import { extractErrorMessage, extractErrorCode } from './bridge.js';
 import type { ChannelFactory } from './channel.js';
 import type { BridgeTelemetry } from './bridgeOptions.js';
 import { createInMemoryChannel } from './inMemoryChannel.js';
-import type { BridgeEvent } from './eventBus.js';
+import { EventBus, type BridgeEvent } from './eventBus.js';
 import { ApprovalMode, ShellExecutionService } from '@qwen-code/qwen-code-core';
 import {
   FakeAgent,
@@ -1337,6 +1337,62 @@ describe('createAcpSessionBridge', () => {
     );
 
     await bridge.shutdown();
+  });
+
+  it('removes a response-mode restore entry if replay seeding throws', async () => {
+    const seedSpy = vi
+      .spyOn(EventBus.prototype, 'seedReplayEvents')
+      .mockImplementationOnce(() => {
+        throw new Error('seed boom');
+      });
+    const handles: ChannelHandle[] = [];
+    const factory: ChannelFactory = async () => {
+      const h = makeChannel({
+        loadSessionImpl: () => ({
+          _meta: {
+            'qwen.session.loadReplay': {
+              v: 1,
+              updates: [{ sessionUpdate: 'agent_message_chunk' }],
+            },
+          },
+        }),
+      });
+      handles.push(h);
+      return h.channel;
+    };
+    const bridge = makeBridge({ channelFactory: factory });
+
+    try {
+      await expect(
+        bridge.loadSession({
+          sessionId: 'persisted-seed-fails',
+          workspaceCwd: WS_A,
+          historyReplay: 'response',
+        }),
+      ).rejects.toThrow('seed boom');
+      expect(bridge.sessionCount).toBe(0);
+      expect(handles[0]?.killed).toBe(true);
+
+      await expect(
+        bridge.loadSession({
+          sessionId: 'persisted-seed-fails',
+          workspaceCwd: WS_A,
+          historyReplay: 'response',
+        }),
+      ).resolves.toMatchObject({
+        sessionId: 'persisted-seed-fails',
+        attached: false,
+      });
+      expect(
+        handles.reduce(
+          (count, handle) => count + handle.agent.loadSessionCalls.length,
+          0,
+        ),
+      ).toBe(2);
+    } finally {
+      seedSpy.mockRestore();
+      await bridge.shutdown();
+    }
   });
 
   it('reports the bad index when response-mode load replay is invalid', async () => {

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -1240,6 +1240,136 @@ describe('createAcpSessionBridge', () => {
     await bridge.shutdown();
   });
 
+  it('loads history replay from response metadata when requested', async () => {
+    const handles: ChannelHandle[] = [];
+    const factory: ChannelFactory = async () => {
+      const h = makeChannel({
+        loadSessionImpl: (p) => {
+          expect(p._meta).toMatchObject({
+            'qwen.session.loadReplayMode': 'bulk',
+          });
+          return {
+            _meta: {
+              keep: 'state',
+              'qwen.session.loadReplay': {
+                v: 1,
+                updates: [
+                  {
+                    sessionUpdate: 'user_message_chunk',
+                    content: { type: 'text', text: 'loaded prompt' },
+                    _meta: { timestamp: 1_700_000_000_000 },
+                  },
+                  {
+                    sessionUpdate: 'agent_message_chunk',
+                    content: { type: 'text', text: 'loaded answer' },
+                  },
+                ],
+              },
+            },
+          };
+        },
+      });
+      handles.push(h);
+      return h.channel;
+    };
+    const bridge = makeBridge({ channelFactory: factory });
+
+    const loaded = await bridge.loadSession({
+      sessionId: 'persisted-bulk-history',
+      workspaceCwd: WS_A,
+      historyReplay: 'response',
+    });
+
+    expect(handles[0]?.agent.loadSessionCalls[0]).toMatchObject({
+      sessionId: 'persisted-bulk-history',
+      cwd: WS_A,
+      mcpServers: [],
+      _meta: { 'qwen.session.loadReplayMode': 'bulk' },
+    });
+    expect(loaded.state).toEqual({ _meta: { keep: 'state' } });
+    expect(loaded.lastEventId).toBe(2);
+    expect(loaded.compactedReplay).toEqual([]);
+    expect(loaded.liveJournal).toHaveLength(2);
+    expect(loaded.liveJournal?.[0]?._meta?.['serverTimestamp']).toBe(
+      1_700_000_000_000,
+    );
+
+    const iterator = bridge
+      .subscribeEvents(loaded.sessionId, { lastEventId: 0 })
+      [Symbol.asyncIterator]();
+    const first = await iterator.next();
+    expect(first.value).toMatchObject({
+      type: 'state_resync_required',
+      data: { reason: 'seeded_replay_not_in_ring' },
+    });
+    await iterator.return?.();
+    await bridge.shutdown();
+  });
+
+  it('orders response-mode replay before restore-time buffered events', async () => {
+    let capturedConn: AgentSideConnection | undefined;
+    const factory: ChannelFactory = async () => {
+      const { clientStream, agentStream } = createInMemoryChannel();
+      const fakeAgent = new FakeAgent({
+        loadSessionImpl: async (p) => {
+          void capturedConn!.extNotification(
+            'qwen/notify/session/mcp-budget-event',
+            {
+              v: 1,
+              sessionId: p.sessionId,
+              kind: 'budget_warning',
+              liveCount: 4,
+              reservedCount: 4,
+              budget: 4,
+              thresholdRatio: 0.75,
+              mode: 'warn',
+            },
+          );
+          await new Promise((r) => setTimeout(r, 20));
+          return {
+            _meta: {
+              'qwen.session.loadReplay': {
+                v: 1,
+                updates: [
+                  {
+                    sessionUpdate: 'agent_message_chunk',
+                    content: { type: 'text', text: 'loaded answer' },
+                  },
+                ],
+              },
+            },
+          };
+        },
+      });
+      capturedConn = new AgentSideConnection(() => fakeAgent, agentStream);
+      return {
+        stream: clientStream,
+        exited: new Promise<
+          | { exitCode: number | null; signalCode: NodeJS.Signals | null }
+          | undefined
+        >(() => {}),
+        kill: async () => {},
+        killSync: () => {},
+      };
+    };
+    const bridge = makeBridge({ channelFactory: factory });
+
+    const loaded = await bridge.loadSession({
+      sessionId: 'bulk-replay-plus-early-event',
+      workspaceCwd: WS_A,
+      historyReplay: 'response',
+    });
+
+    expect(loaded.liveJournal?.map((event) => event.type)).toEqual([
+      'session_update',
+      'mcp_budget_warning',
+    ]);
+    expect(loaded.liveJournal?.[0]?.id).toBe(1);
+    expect(loaded.liveJournal?.[1]?.id).toBe(2);
+
+    await bridge.shutdown();
+  });
+
   it('buffers load replay events until the restored session is registered', async () => {
     let capturedConn: AgentSideConnection | undefined;
     const factory: ChannelFactory = async () => {
@@ -1298,6 +1428,56 @@ describe('createAcpSessionBridge', () => {
     });
 
     await iterator.return?.();
+    await bridge.shutdown();
+  });
+
+  it('keeps streamed load replay if response mode returns no bulk payload', async () => {
+    let capturedConn: AgentSideConnection | undefined;
+    const factory: ChannelFactory = async () => {
+      const { clientStream, agentStream } = createInMemoryChannel();
+      const fakeAgent = new FakeAgent({
+        loadSessionImpl: async (p) => {
+          expect(p._meta).toMatchObject({
+            'qwen.session.loadReplayMode': 'bulk',
+          });
+          await capturedConn!.sessionUpdate({
+            sessionId: p.sessionId,
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: 'legacy-streamed' },
+            },
+          });
+          return {};
+        },
+      });
+      capturedConn = new AgentSideConnection(() => fakeAgent, agentStream);
+      return {
+        stream: clientStream,
+        exited: new Promise<
+          | { exitCode: number | null; signalCode: NodeJS.Signals | null }
+          | undefined
+        >(() => {}),
+        kill: async () => {},
+        killSync: () => {},
+      };
+    };
+    const bridge = makeBridge({ channelFactory: factory });
+
+    const loaded = await bridge.loadSession({
+      sessionId: 'persisted-history-response-fallback',
+      workspaceCwd: WS_A,
+      historyReplay: 'response',
+    });
+
+    expect(loaded.liveJournal).toHaveLength(1);
+    expect(loaded.liveJournal?.[0]?.data).toMatchObject({
+      sessionId: 'persisted-history-response-fallback',
+      update: {
+        sessionUpdate: 'agent_message_chunk',
+        content: { text: 'legacy-streamed' },
+      },
+    });
+
     await bridge.shutdown();
   });
 
@@ -1414,6 +1594,39 @@ describe('createAcpSessionBridge', () => {
     // Coalesced waiter sees the same state, not `{}`.
     expect(r2.state).toEqual({ _meta: { tag: 'restored-baz' } });
 
+    await bridge.shutdown();
+  });
+
+  it('rejects coalescing load requests with incompatible replay modes', async () => {
+    let releaseLoad: ((value: LoadSessionResponse) => void) | undefined;
+    const factory: ChannelFactory = async () =>
+      makeChannel({
+        loadSessionImpl: () =>
+          new Promise<LoadSessionResponse>((resolve) => {
+            releaseLoad = resolve;
+          }),
+      }).channel;
+    const bridge = makeBridge({ channelFactory: factory });
+
+    const first = bridge.loadSession({
+      sessionId: 'coalesce-replay-mode',
+      workspaceCwd: WS_A,
+    });
+    for (let i = 0; i < 50 && !releaseLoad; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(releaseLoad).toBeDefined();
+
+    await expect(
+      bridge.loadSession({
+        sessionId: 'coalesce-replay-mode',
+        workspaceCwd: WS_A,
+        historyReplay: 'response',
+      }),
+    ).rejects.toBeInstanceOf(RestoreInProgressError);
+
+    releaseLoad!({});
+    await first;
     await bridge.shutdown();
   });
 

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -1253,6 +1253,8 @@ describe('createAcpSessionBridge', () => {
               keep: 'state',
               'qwen.session.loadReplay': {
                 v: 1,
+                partial: true,
+                replayError: 'replay boom',
                 updates: [
                   {
                     sessionUpdate: 'user_message_chunk',

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -1306,6 +1306,36 @@ describe('createAcpSessionBridge', () => {
     await bridge.shutdown();
   });
 
+  it('reports the bad index when response-mode load replay is invalid', async () => {
+    const factory: ChannelFactory = async () =>
+      makeChannel({
+        loadSessionImpl: () => ({
+          _meta: {
+            'qwen.session.loadReplay': {
+              v: 1,
+              updates: [
+                { sessionUpdate: 'agent_message_chunk' },
+                { sessionUpdate: 'future_update_type' },
+              ],
+            },
+          },
+        }),
+      }).channel;
+    const bridge = makeBridge({ channelFactory: factory });
+
+    await expect(
+      bridge.loadSession({
+        sessionId: 'persisted-bad-bulk-history',
+        workspaceCwd: WS_A,
+        historyReplay: 'response',
+      }),
+    ).rejects.toThrow(
+      /Invalid qwen\.session\.loadReplay update at index 1 .*count=2.*future_update_type/,
+    );
+
+    await bridge.shutdown();
+  });
+
   it('orders response-mode replay before restore-time buffered events', async () => {
     let capturedConn: AgentSideConnection | undefined;
     const factory: ChannelFactory = async () => {

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -15,6 +15,7 @@ import type {
   PromptRequest,
   SetSessionModelRequest,
   SetSessionModelResponse,
+  SessionUpdate,
 } from '@agentclientprotocol/sdk';
 import type { ApprovalMode } from '@qwen-code/qwen-code-core';
 import {
@@ -71,6 +72,12 @@ import {
   InvalidRewindTargetError,
 } from './bridgeErrors.js';
 import { canonicalizeWorkspace } from './workspacePaths.js';
+import {
+  LOAD_REPLAY_BULK_MODE,
+  LOAD_REPLAY_META_KEY,
+  LOAD_REPLAY_MODE_META_KEY,
+  LOAD_REPLAY_VERSION,
+} from './bridgeTypes.js';
 import type {
   BridgeSession,
   BridgeRestoreSessionRequest,
@@ -139,6 +146,58 @@ const NOOP_BRIDGE_TELEMETRY: BridgeTelemetry = {
     return { ...request, _meta: nextMeta };
   },
 };
+
+const KNOWN_SESSION_UPDATE_TYPES = new Set([
+  'user_message_chunk',
+  'agent_message_chunk',
+  'agent_thought_chunk',
+  'tool_call',
+  'tool_call_update',
+  'plan',
+  'available_commands_update',
+  'current_mode_update',
+  'config_option_update',
+  'session_info_update',
+  'usage_update',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isBulkReplayUpdate(value: unknown): value is SessionUpdate {
+  if (!isRecord(value)) return false;
+  const updateType = value['sessionUpdate'];
+  return (
+    typeof updateType === 'string' && KNOWN_SESSION_UPDATE_TYPES.has(updateType)
+  );
+}
+
+function extractLoadReplayResponse(state: BridgeSessionState): {
+  state: BridgeSessionState;
+  updates: SessionUpdate[];
+} {
+  const meta = isRecord(state._meta) ? state._meta : undefined;
+  const replay = meta?.[LOAD_REPLAY_META_KEY];
+  if (replay === undefined) return { state, updates: [] };
+  if (!isRecord(replay) || replay['v'] !== LOAD_REPLAY_VERSION) {
+    throw new Error('Invalid qwen.session.loadReplay payload');
+  }
+  const rawUpdates = replay['updates'];
+  if (!Array.isArray(rawUpdates) || !rawUpdates.every(isBulkReplayUpdate)) {
+    throw new Error('Invalid qwen.session.loadReplay updates');
+  }
+
+  const nextMeta = { ...(meta ?? {}) };
+  delete nextMeta[LOAD_REPLAY_META_KEY];
+  const cleanState: BridgeSessionState = { ...state };
+  if (Object.keys(nextMeta).length > 0) {
+    cleanState._meta = nextMeta;
+  } else {
+    delete cleanState._meta;
+  }
+  return { state: cleanState, updates: rawUpdates };
+}
 
 /**
  * Stage 1 HTTP->ACP bridge factory + supporting helpers.
@@ -1353,6 +1412,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
 
   interface InFlightRestore {
     action: 'load' | 'resume';
+    historyReplay: 'stream' | 'response';
     promise: Promise<BridgeRestoredSession>;
     /**
      * Synchronous reservation slot for callers that coalesce onto this
@@ -2357,6 +2417,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     sessionId: string,
     workspaceCwd: string,
     events = createSessionEventBus(),
+    options: { drainEarlyEvents?: boolean } = {},
   ): SessionEntry => {
     const entry: SessionEntry = {
       sessionId,
@@ -2386,10 +2447,12 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     byId.set(entry.sessionId, entry);
     touchActivity();
     telemetry.metrics?.sessionLifecycle('spawn');
-    // Drain any guardrail events that fired during this session's
-    // `newSession` handler (before this entry registered) onto the
-    // freshly-created EventBus. Idempotent on unknown sessionIds.
-    ci.client.drainEarlyEvents(entry.sessionId, entry);
+    if (options.drainEarlyEvents !== false) {
+      // Drain any guardrail events that fired during this session's
+      // `newSession` handler (before this entry registered) onto the
+      // freshly-created EventBus. Idempotent on unknown sessionIds.
+      ci.client.drainEarlyEvents(entry.sessionId, entry);
+    }
     return entry;
   };
 
@@ -2524,6 +2587,8 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       throw new Error('AcpSessionBridge is shutting down');
     }
     const workspaceKey = resolveWorkspaceKey(req.workspaceCwd);
+    const historyReplay =
+      action === 'load' ? (req.historyReplay ?? 'stream') : 'stream';
 
     const existing = byId.get(req.sessionId);
     if (existing) {
@@ -2551,7 +2616,10 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       // a watermark — mixing the two on a shared EventBus would give
       // the resume client unexpected replay data or the load client a
       // missing snapshot. Same-action coalescing is unaffected.
-      if (action !== inFlight.action) {
+      if (
+        action !== inFlight.action ||
+        historyReplay !== inFlight.historyReplay
+      ) {
         throw new RestoreInProgressError(
           req.sessionId,
           inFlight.action,
@@ -2644,6 +2712,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       // race-loser case only.
       transportClosed.catch(() => {});
       let state: BridgeSessionState;
+      let replayUpdates: SessionUpdate[] = [];
       try {
         if (action === 'load') {
           state = await Promise.race([
@@ -2657,6 +2726,13 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                 // intentionally has no `mcpServers` field for the
                 // same reason.
                 mcpServers: [],
+                ...(historyReplay === 'response'
+                  ? {
+                      _meta: {
+                        [LOAD_REPLAY_MODE_META_KEY]: LOAD_REPLAY_BULK_MODE,
+                      },
+                    }
+                  : {}),
               }),
               initTimeoutMs,
               'loadSession',
@@ -2676,6 +2752,11 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
             ),
             transportClosed,
           ]);
+        }
+        if (action === 'load' && historyReplay === 'response') {
+          const extracted = extractLoadReplayResponse(state);
+          state = extracted.state;
+          replayUpdates = extracted.updates;
         }
       } catch (err) {
         restoreEvents.close();
@@ -2726,9 +2807,14 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         req.sessionId,
         workspaceKey,
         restoreEvents,
+        { drainEarlyEvents: replayUpdates.length === 0 },
       );
       entry.restoreState = state;
       seedSnapshotCaches(entry, state);
+      if (replayUpdates.length > 0) {
+        await ci.client.seedSessionUpdates(entry, replayUpdates);
+        ci.client.drainEarlyEvents(entry.sessionId, entry);
+      }
       const clientId = registerClient(entry, req.clientId);
       // Fold synchronous coalesce reservations into the new entry's
       // `attachCount`. By this point all coalescers that beat us must
@@ -2777,7 +2863,12 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       }
     });
 
-    inFlightRestores.set(req.sessionId, { action, promise, coalesceState });
+    inFlightRestores.set(req.sessionId, {
+      action,
+      historyReplay,
+      promise,
+      coalesceState,
+    });
     try {
       return await promise;
     } finally {
@@ -3710,6 +3801,12 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       const entry = byId.get(sessionId);
       if (!entry) throw new SessionNotFoundError(sessionId);
       return entry.events.lastEventId;
+    },
+
+    getSessionReplaySnapshot(sessionId) {
+      const entry = byId.get(sessionId);
+      if (!entry) throw new SessionNotFoundError(sessionId);
+      return entry.events.snapshotReplay();
     },
 
     respondToPermission(requestId, response, context) {

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -2937,6 +2937,16 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       pendingRestoreEvents.delete(req.sessionId);
       if (!registeredEntry) {
         restoreEvents.close();
+        let removedRestoreEntry = false;
+        if (byId.get(req.sessionId)?.events === restoreEvents) {
+          byId.delete(req.sessionId);
+          ci?.sessionIds.delete(req.sessionId);
+          removedRestoreEntry = true;
+        }
+        if (removedRestoreEntry && ci && hasNoChannelWork(ci)) {
+          ci.emptyReapPending = true;
+          ci.isDying = true;
+        }
         // On restore failure, purge any guardrail events that the
         // child buffered during this restore window AND re-tombstone
         // the id. Without this, a subsequent successful restore for

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -160,6 +160,7 @@ const KNOWN_SESSION_UPDATE_TYPES = new Set([
   'session_info_update',
   'usage_update',
 ]);
+const MAX_BULK_REPLAY_UPDATES = 10_000;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -182,6 +183,8 @@ function describeLoadReplayValue(value: unknown): string {
 function extractLoadReplayResponse(state: BridgeSessionState): {
   state: BridgeSessionState;
   updates: SessionUpdate[];
+  partial?: true;
+  replayError?: string;
 } {
   const meta = isRecord(state._meta) ? state._meta : undefined;
   const replay = meta?.[LOAD_REPLAY_META_KEY];
@@ -198,6 +201,26 @@ function extractLoadReplayResponse(state: BridgeSessionState): {
     throw new Error(
       `Invalid qwen.session.loadReplay updates ` +
         `(version=${LOAD_REPLAY_VERSION}, count=not-array)`,
+    );
+  }
+  if (rawUpdates.length > MAX_BULK_REPLAY_UPDATES) {
+    throw new Error(
+      `qwen.session.loadReplay updates exceed limit ` +
+        `(${rawUpdates.length} > ${MAX_BULK_REPLAY_UPDATES})`,
+    );
+  }
+  const partial = replay['partial'];
+  if (partial !== undefined && partial !== true) {
+    throw new Error(
+      `Invalid qwen.session.loadReplay partial ` +
+        `(version=${LOAD_REPLAY_VERSION}, partial=${JSON.stringify(partial)})`,
+    );
+  }
+  const replayError = replay['replayError'];
+  if (replayError !== undefined && typeof replayError !== 'string') {
+    throw new Error(
+      `Invalid qwen.session.loadReplay replayError ` +
+        `(version=${LOAD_REPLAY_VERSION}, replayError=${describeLoadReplayValue(replayError)})`,
     );
   }
   const invalidUpdateIndex = rawUpdates.findIndex(
@@ -223,7 +246,12 @@ function extractLoadReplayResponse(state: BridgeSessionState): {
   } else {
     delete cleanState._meta;
   }
-  return { state: cleanState, updates: rawUpdates };
+  return {
+    state: cleanState,
+    updates: rawUpdates,
+    ...(partial === true ? { partial: true as const } : {}),
+    ...(typeof replayError === 'string' ? { replayError } : {}),
+  };
 }
 
 /**
@@ -489,6 +517,9 @@ interface SessionEntry {
    * had an ACP load/resume response, so attaches return `state: {}`.
    */
   restoreState?: BridgeSessionState;
+  /** Response-mode `session/load` can return a partial replay prefix. */
+  restoreReplayPartial?: true;
+  restoreReplayError?: string;
   /**
    * Most recent heartbeat across any client on this session (Date.now()
    * epoch ms). Set on every `recordHeartbeat` call regardless of whether
@@ -2588,22 +2619,41 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
   };
 
   const replayFieldsFor = (
-    entry: { events: EventBus },
+    entry: Pick<
+      SessionEntry,
+      'events' | 'restoreReplayPartial' | 'restoreReplayError'
+    >,
     action: 'load' | 'resume',
   ): Pick<
     BridgeRestoredSession,
-    'compactedReplay' | 'liveJournal' | 'lastEventId'
+    | 'compactedReplay'
+    | 'liveJournal'
+    | 'lastEventId'
+    | 'partial'
+    | 'replayError'
   > => {
+    const replayStatus =
+      action === 'load' && entry.restoreReplayPartial === true
+        ? {
+            partial: true as const,
+            ...(typeof entry.restoreReplayError === 'string'
+              ? { replayError: entry.restoreReplayError }
+              : {}),
+          }
+        : {};
     const snapshot = entry.events.snapshotReplay();
-    if (!snapshot) return { lastEventId: entry.events.lastEventId };
+    if (!snapshot) {
+      return { lastEventId: entry.events.lastEventId, ...replayStatus };
+    }
     if (action === 'load') {
       return {
         compactedReplay: snapshot.compactedTurns,
         liveJournal: snapshot.liveJournal,
         lastEventId: snapshot.lastEventId,
+        ...replayStatus,
       };
     }
-    return { lastEventId: snapshot.lastEventId };
+    return { lastEventId: snapshot.lastEventId, ...replayStatus };
   };
 
   async function restoreSession(
@@ -2740,6 +2790,8 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       transportClosed.catch(() => {});
       let state: BridgeSessionState;
       let replayUpdates: SessionUpdate[] = [];
+      let replayPartial: true | undefined;
+      let replayError: string | undefined;
       try {
         if (action === 'load') {
           state = await Promise.race([
@@ -2784,6 +2836,8 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
           const extracted = extractLoadReplayResponse(state);
           state = extracted.state;
           replayUpdates = extracted.updates;
+          replayPartial = extracted.partial;
+          replayError = extracted.replayError;
         }
       } catch (err) {
         restoreEvents.close();
@@ -2837,6 +2891,12 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         { drainEarlyEvents: replayUpdates.length === 0 },
       );
       entry.restoreState = state;
+      if (replayPartial === true) {
+        entry.restoreReplayPartial = true;
+      }
+      if (replayError !== undefined) {
+        entry.restoreReplayError = replayError;
+      }
       seedSnapshotCaches(entry, state);
       if (replayUpdates.length > 0) {
         await ci.client.seedSessionUpdates(entry, replayUpdates);

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -173,6 +173,12 @@ function isBulkReplayUpdate(value: unknown): value is SessionUpdate {
   );
 }
 
+function describeLoadReplayValue(value: unknown): string {
+  if (Array.isArray(value)) return 'array';
+  if (value === null) return 'null';
+  return typeof value;
+}
+
 function extractLoadReplayResponse(state: BridgeSessionState): {
   state: BridgeSessionState;
   updates: SessionUpdate[];
@@ -181,11 +187,32 @@ function extractLoadReplayResponse(state: BridgeSessionState): {
   const replay = meta?.[LOAD_REPLAY_META_KEY];
   if (replay === undefined) return { state, updates: [] };
   if (!isRecord(replay) || replay['v'] !== LOAD_REPLAY_VERSION) {
-    throw new Error('Invalid qwen.session.loadReplay payload');
+    const version = isRecord(replay) ? replay['v'] : undefined;
+    throw new Error(
+      `Invalid qwen.session.loadReplay payload ` +
+        `(type=${describeLoadReplayValue(replay)}, version=${JSON.stringify(version)})`,
+    );
   }
   const rawUpdates = replay['updates'];
-  if (!Array.isArray(rawUpdates) || !rawUpdates.every(isBulkReplayUpdate)) {
-    throw new Error('Invalid qwen.session.loadReplay updates');
+  if (!Array.isArray(rawUpdates)) {
+    throw new Error(
+      `Invalid qwen.session.loadReplay updates ` +
+        `(version=${LOAD_REPLAY_VERSION}, count=not-array)`,
+    );
+  }
+  const invalidUpdateIndex = rawUpdates.findIndex(
+    (update) => !isBulkReplayUpdate(update),
+  );
+  if (invalidUpdateIndex !== -1) {
+    const invalidUpdate = rawUpdates[invalidUpdateIndex];
+    const discriminator = isRecord(invalidUpdate)
+      ? invalidUpdate['sessionUpdate']
+      : undefined;
+    throw new Error(
+      `Invalid qwen.session.loadReplay update at index ${invalidUpdateIndex} ` +
+        `(version=${LOAD_REPLAY_VERSION}, count=${rawUpdates.length}, ` +
+        `sessionUpdate=${JSON.stringify(discriminator)})`,
+    );
   }
 
   const nextMeta = { ...(meta ?? {}) };

--- a/packages/acp-bridge/src/bridgeClient.ts
+++ b/packages/acp-bridge/src/bridgeClient.ts
@@ -14,6 +14,7 @@ import type {
   RequestPermissionRequest,
   RequestPermissionResponse,
   SessionNotification,
+  SessionUpdate,
   WriteTextFileRequest,
   WriteTextFileResponse,
 } from '@agentclientprotocol/sdk';
@@ -377,6 +378,12 @@ export interface BridgeClientSessionEntry {
   approvalModeRoundtripInFlight?: boolean;
 }
 
+interface PreparedSessionUpdateFrames {
+  frames: Array<Omit<BridgeEvent, 'id' | 'v'>>;
+  artifacts: SessionArtifactInput[];
+  trustedPublisher: boolean;
+}
+
 /**
  * Bridge `Client` implementation — the daemon's response surface for things
  * the agent asks the client (file reads/writes, permission prompts).
@@ -582,9 +589,25 @@ export class BridgeClient implements Client {
     const events =
       entry?.events ?? this.resolvePendingRestoreEvents(params.sessionId);
     if (!events) return;
+    const prepared = this.prepareSessionUpdateFrames(params, entry);
+    for (const frame of prepared.frames) {
+      events.publish(frame);
+    }
+    if (entry && prepared.artifacts.length > 0) {
+      await this.upsertAndPublishArtifacts(entry, prepared.artifacts, {
+        trustedPublisher: prepared.trustedPublisher,
+      });
+    }
+  }
+
+  prepareSessionUpdateFrames(
+    params: SessionNotification,
+    entry?: BridgeClientSessionEntry,
+  ): PreparedSessionUpdateFrames {
     const originator = entry?.activePromptOriginatorClientId
       ? { originatorClientId: entry.activePromptOriginatorClientId }
       : {};
+    const frames: Array<Omit<BridgeEvent, 'id' | 'v'>> = [];
     // A2UI-over-MCP: tool_call_update results from an A2UI UI server carry
     // the A2UI command JSON flattened by core (EmbeddedResource -> text, the
     // application/a2ui+json mime is dropped, so detection keys off the
@@ -596,7 +619,7 @@ export class BridgeClient implements Client {
       // One frame per surface: tool results carrying commands for multiple
       // surfaces are split so every consumer sees a single-surface frame.
       for (const surface of a2ui.surfaces) {
-        events.publish({
+        frames.push({
           type: 'session_update',
           data: {
             sessionId: params.sessionId,
@@ -640,18 +663,46 @@ export class BridgeClient implements Client {
         )
       : [];
     const publishParams = sanitizeSessionUpdateArtifacts(params, updateMeta);
-    events.publish({
+    frames.push({
       type: 'session_update',
       data: publishParams,
       ...originator,
       ...(serverTimestamp !== undefined ? { _meta: { serverTimestamp } } : {}),
     });
-    if (entry) {
-      if (artifacts.length > 0) {
-        await this.upsertAndPublishArtifacts(entry, artifacts, {
-          trustedPublisher: isTrustedArtifactToolUpdate(params, updateMeta),
+    return {
+      frames,
+      artifacts,
+      trustedPublisher: isTrustedArtifactToolUpdate(params, updateMeta),
+    };
+  }
+
+  async seedSessionUpdates(
+    entry: BridgeClientSessionEntry,
+    updates: SessionUpdate[],
+  ): Promise<void> {
+    const frames: Array<Omit<BridgeEvent, 'id' | 'v'>> = [];
+    const artifactBatches: Array<{
+      artifacts: SessionArtifactInput[];
+      trustedPublisher: boolean;
+    }> = [];
+    for (const update of updates) {
+      const prepared = this.prepareSessionUpdateFrames(
+        { sessionId: entry.sessionId, update },
+        entry,
+      );
+      frames.push(...prepared.frames);
+      if (prepared.artifacts.length > 0) {
+        artifactBatches.push({
+          artifacts: prepared.artifacts,
+          trustedPublisher: prepared.trustedPublisher,
         });
       }
+    }
+    entry.events.seedReplayEvents(frames);
+    for (const batch of artifactBatches) {
+      await this.upsertAndPublishArtifacts(entry, batch.artifacts, {
+        trustedPublisher: batch.trustedPublisher,
+      });
     }
   }
 

--- a/packages/acp-bridge/src/bridgeTypes.ts
+++ b/packages/acp-bridge/src/bridgeTypes.ts
@@ -116,6 +116,8 @@ export const LOAD_REPLAY_VERSION = 1 as const;
 export interface BridgeLoadReplayEnvelope {
   v: typeof LOAD_REPLAY_VERSION;
   updates: SessionUpdate[];
+  partial?: true;
+  replayError?: string;
 }
 
 export type BridgeSessionState = LoadSessionResponse | ResumeSessionResponse;

--- a/packages/acp-bridge/src/bridgeTypes.ts
+++ b/packages/acp-bridge/src/bridgeTypes.ts
@@ -14,8 +14,13 @@ import type {
   ResumeSessionResponse,
   SetSessionModelRequest,
   SetSessionModelResponse,
+  SessionUpdate,
 } from '@agentclientprotocol/sdk';
-import type { BridgeEvent, SubscribeOptions } from './eventBus.js';
+import type {
+  BridgeEvent,
+  SessionReplaySnapshot,
+  SubscribeOptions,
+} from './eventBus.js';
 import type { PermissionPolicy } from './permission.js';
 import type {
   SessionArtifactInput,
@@ -99,6 +104,18 @@ export interface BridgeRestoreSessionRequest {
   workspaceCwd: string;
   /** Optional echo of a daemon-issued client id for this session. */
   clientId?: string;
+  /** Internal replay transport for `session/load`; defaults to ACP streaming. */
+  historyReplay?: 'stream' | 'response';
+}
+
+export const LOAD_REPLAY_MODE_META_KEY = 'qwen.session.loadReplayMode';
+export const LOAD_REPLAY_META_KEY = 'qwen.session.loadReplay';
+export const LOAD_REPLAY_BULK_MODE = 'bulk';
+export const LOAD_REPLAY_VERSION = 1 as const;
+
+export interface BridgeLoadReplayEnvelope {
+  v: typeof LOAD_REPLAY_VERSION;
+  updates: SessionUpdate[];
 }
 
 export type BridgeSessionState = LoadSessionResponse | ResumeSessionResponse;
@@ -505,6 +522,14 @@ export interface AcpSessionBridge {
    * start SSE replay so no events are missed.
    */
   getSessionLastEventId(sessionId: string): number;
+
+  /**
+   * Return the current compacted replay snapshot for a loaded session, when
+   * the bridge has a compaction engine configured.
+   */
+  getSessionReplaySnapshot(
+    sessionId: string,
+  ): SessionReplaySnapshot | undefined;
 
   /**
    * Explicitly close a live session. Force-closes even when other clients

--- a/packages/acp-bridge/src/bridgeTypes.ts
+++ b/packages/acp-bridge/src/bridgeTypes.ts
@@ -125,6 +125,10 @@ export type BridgeSessionState = LoadSessionResponse | ResumeSessionResponse;
 export interface BridgeRestoredSession extends BridgeSession {
   /** ACP state returned by `session/load` / `session/resume`. */
   state: BridgeSessionState;
+  /** True when response-mode history replay aborted after emitting a prefix. */
+  partial?: true;
+  /** Agent-provided replay failure detail when `partial` is true. */
+  replayError?: string;
   /** Compacted events for all completed turns (O(turns) size). */
   compactedReplay?: BridgeEvent[];
   /** Raw events since last turn boundary (current incomplete turn). */

--- a/packages/acp-bridge/src/compactionEngine.test.ts
+++ b/packages/acp-bridge/src/compactionEngine.test.ts
@@ -652,6 +652,52 @@ describe('TurnBoundaryCompactionEngine', () => {
 });
 
 describe('EventBus + CompactionEngine integration', () => {
+  it('seedReplayEvents advances replay state without populating the ring', async () => {
+    const engine = new TurnBoundaryCompactionEngine();
+    const bus = new EventBus(100, undefined, engine);
+
+    bus.seedReplayEvents([
+      {
+        type: 'session_update',
+        data: {
+          update: {
+            sessionUpdate: 'user_message_chunk',
+            content: { type: 'text', text: 'loaded' },
+          },
+        },
+        _meta: { serverTimestamp: 1_700_000_000_000 },
+      },
+      {
+        type: 'session_update',
+        data: {
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'history' },
+          },
+        },
+      },
+    ]);
+
+    const snapshot = bus.snapshotReplay()!;
+    expect(snapshot.lastEventId).toBe(2);
+    expect(snapshot.liveJournal).toHaveLength(2);
+    expect(snapshot.liveJournal[0]!._meta?.['serverTimestamp']).toBe(
+      1_700_000_000_000,
+    );
+
+    const iterator = bus.subscribe({ lastEventId: 0 })[Symbol.asyncIterator]();
+    const first = await iterator.next();
+    expect(first.value).toMatchObject({
+      type: 'state_resync_required',
+      data: {
+        reason: 'seeded_replay_not_in_ring',
+        lastDeliveredId: 0,
+        earliestAvailableId: 3,
+      },
+    });
+    await iterator.return?.();
+  });
+
   it('snapshotReplay returns compacted state after publish + turn_complete', () => {
     const engine = new TurnBoundaryCompactionEngine();
     const bus = new EventBus(100, undefined, engine);

--- a/packages/acp-bridge/src/eventBus.ts
+++ b/packages/acp-bridge/src/eventBus.ts
@@ -206,6 +206,41 @@ export class EventBus {
     return this.subs.size;
   }
 
+  seedReplayEvents(
+    inputs: Array<Omit<BridgeEvent, 'id' | 'v'>>,
+  ): BridgeEvent[] {
+    if (this.closed) return [];
+    if (inputs.length === 0) return [];
+
+    const events: BridgeEvent[] = [];
+    for (const input of inputs) {
+      const existingMeta = input._meta;
+      const event: BridgeEvent = {
+        id: this.nextId++,
+        v: EVENT_SCHEMA_VERSION,
+        ...input,
+        _meta: {
+          ...(existingMeta ?? {}),
+          serverTimestamp: getServerTimestamp(existingMeta),
+        },
+      };
+      events.push(event);
+      try {
+        this.compactionEngine?.ingest(event);
+      } catch {
+        // CompactionEngine is best-effort; mirror publish()'s never-throws
+        // contract for bulk replay seeding.
+      }
+    }
+
+    // Seeded replay frames intentionally do not enter the reconnect ring. A
+    // partially retained ring would no longer be a contiguous suffix of all ids
+    // this bus produced, so clear it and let subscribe() surface resync for
+    // stale cursors.
+    this.ring.length = 0;
+    return events;
+  }
+
   /**
    * Publish an event to the bus. Returns the constructed `BridgeEvent`
    * (with `id` + `v` assigned) on success, or `undefined` when the
@@ -454,6 +489,19 @@ export class EventBus {
       } else {
         const earliestInRing = this.ring[0]?.id;
         if (
+          earliestInRing === undefined &&
+          opts.lastEventId < this.nextId - 1
+        ) {
+          queue.forcePush({
+            v: EVENT_SCHEMA_VERSION,
+            type: 'state_resync_required',
+            data: {
+              reason: 'seeded_replay_not_in_ring',
+              lastDeliveredId: opts.lastEventId,
+              earliestAvailableId: this.nextId,
+            },
+          });
+        } else if (
           earliestInRing !== undefined &&
           earliestInRing > opts.lastEventId + 1
         ) {

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -7532,13 +7532,30 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
       async (
         context: {
           config: Config;
-          cumulativeUsage?: unknown;
+          cumulativeUsage?: {
+            promptTokens: number;
+            cachedTokens: number;
+            candidateTokens: number;
+            apiTimeMs: number;
+          };
           sendUpdate: (update: unknown) => Promise<void>;
         },
         history: unknown,
       ) => {
         expect(context.config).toBe(innerConfig);
-        expect(context.cumulativeUsage).toBe(lastSessionMock?.cumulativeUsage);
+        expect(context.cumulativeUsage).not.toBe(
+          lastSessionMock?.cumulativeUsage,
+        );
+        expect(context.cumulativeUsage).toEqual({
+          promptTokens: 0,
+          cachedTokens: 0,
+          candidateTokens: 0,
+          apiTimeMs: 0,
+        });
+        context.cumulativeUsage!.promptTokens = 101;
+        context.cumulativeUsage!.cachedTokens = 17;
+        context.cumulativeUsage!.candidateTokens = 53;
+        context.cumulativeUsage!.apiTimeMs = 0;
         expect(history).toBe(messages);
         await context.sendUpdate(replayUpdate);
       },
@@ -7557,6 +7574,12 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
     expect(response._meta?.['qwen.session.loadReplay']).toEqual({
       v: 1,
       updates: [replayUpdate],
+    });
+    expect(lastSessionMock?.cumulativeUsage).toEqual({
+      promptTokens: 101,
+      cachedTokens: 17,
+      candidateTokens: 53,
+      apiTimeMs: 0,
     });
     expect(lastSessionMock?.replayHistory).not.toHaveBeenCalled();
     expect(lastSessionMock?.primeTurnFromHistory).toHaveBeenCalledWith(
@@ -7589,7 +7612,14 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
       },
     });
     mockHistoryReplay.mockReset();
-    mockHistoryReplay.mockRejectedValueOnce(new Error('replay boom'));
+    mockHistoryReplay.mockImplementationOnce(
+      async (context: { cumulativeUsage?: { promptTokens: number } }) => {
+        if (context.cumulativeUsage) {
+          context.cumulativeUsage.promptTokens = 999;
+        }
+        throw new Error('replay boom');
+      },
+    );
     const { agent, agentPromise } = await spawnAgent();
 
     const response = (await agent.loadSession({
@@ -7616,6 +7646,12 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
       replayError: 'replay boom',
     });
     expect(lastSessionMock?.dispose).not.toHaveBeenCalled();
+    expect(lastSessionMock?.cumulativeUsage).toEqual({
+      promptTokens: 7,
+      cachedTokens: 3,
+      candidateTokens: 5,
+      apiTimeMs: 11,
+    });
     expect(lastSessionMock?.installRewriter).toHaveBeenCalledTimes(1);
     expect(lastSessionMock?.startCronScheduler).toHaveBeenCalledTimes(1);
 

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -7579,6 +7579,52 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
     await agentPromise;
   });
 
+  it('loadSession removes a bulk replay restore if replay throws', async () => {
+    const messages = [{ role: 'user', parts: [{ text: 'hi' }] }];
+    bindRestoreMocks({
+      sessionExists: true,
+      resumedConversation: {
+        messages,
+      },
+    });
+    mockHistoryReplay.mockReset();
+    mockHistoryReplay.mockRejectedValueOnce(new Error('replay boom'));
+    const { agent, agentPromise } = await spawnAgent();
+
+    await expect(
+      agent.loadSession({
+        cwd: '/tmp',
+        sessionId: 'persisted-1',
+        mcpServers: [],
+        _meta: { 'qwen.session.loadReplayMode': 'bulk' },
+      }),
+    ).rejects.toThrow('replay boom');
+
+    const failedSession = lastSessionMock;
+    expect(failedSession?.dispose).toHaveBeenCalledTimes(1);
+    expect(failedSession?.installRewriter).not.toHaveBeenCalled();
+    expect(failedSession?.startCronScheduler).not.toHaveBeenCalled();
+
+    await expect(
+      agent.loadSession({
+        cwd: '/tmp',
+        sessionId: 'persisted-1',
+        mcpServers: [],
+        _meta: { 'qwen.session.loadReplayMode': 'bulk' },
+      }),
+    ).resolves.toMatchObject({
+      modes: expect.anything(),
+      models: expect.anything(),
+      configOptions: expect.anything(),
+    });
+
+    expect(lastSessionMock).not.toBe(failedSession);
+    expect(failedSession?.dispose).toHaveBeenCalledTimes(1);
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it('loadSession skips history replay when getResumedSessionData() returns undefined', async () => {
     // Distinct code path: `createAndStoreSession(config, undefined)`
     // takes the no-conversation branch, so `replayHistory` must

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -7290,6 +7290,13 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
         getConfig: ReturnType<typeof vi.fn>;
         sendAvailableCommandsUpdate: ReturnType<typeof vi.fn>;
         replayHistory: ReturnType<typeof vi.fn>;
+        primeTurnFromHistory: ReturnType<typeof vi.fn>;
+        cumulativeUsage: {
+          promptTokens: number;
+          cachedTokens: number;
+          candidateTokens: number;
+          apiTimeMs: number;
+        };
         installRewriter: ReturnType<typeof vi.fn>;
         startCronScheduler: ReturnType<typeof vi.fn>;
         dispose: ReturnType<typeof vi.fn>;
@@ -7425,6 +7432,13 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
         getConfig: vi.fn().mockReturnValue(innerConfig),
         sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
         replayHistory: vi.fn().mockResolvedValue(undefined),
+        primeTurnFromHistory: vi.fn(),
+        cumulativeUsage: {
+          promptTokens: 7,
+          cachedTokens: 3,
+          candidateTokens: 5,
+          apiTimeMs: 11,
+        },
         installRewriter: vi.fn(),
         startCronScheduler: vi.fn(),
         dispose: vi.fn(),
@@ -7496,6 +7510,70 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
 
     const recording = lastSessionMock?.getConfig().getChatRecordingService();
     expect(recording?.rebuildTurnBoundaries).toHaveBeenCalledWith(messages);
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('loadSession can return bulk replay updates without streaming history', async () => {
+    const messages = [{ role: 'user', parts: [{ text: 'hi' }] }];
+    const innerConfig = bindRestoreMocks({
+      sessionExists: true,
+      resumedConversation: {
+        messages,
+      },
+    });
+    const replayUpdate = {
+      sessionUpdate: 'agent_message_chunk',
+      _meta: { timestamp: 4242 },
+    };
+    mockHistoryReplay.mockImplementation(
+      async (
+        context: {
+          config: Config;
+          cumulativeUsage?: unknown;
+          sendUpdate: (update: unknown) => Promise<void>;
+        },
+        history: unknown,
+      ) => {
+        expect(context.config).toBe(innerConfig);
+        expect(context.cumulativeUsage).toBe(lastSessionMock?.cumulativeUsage);
+        expect(history).toBe(messages);
+        await context.sendUpdate(replayUpdate);
+      },
+    );
+    const { agent, agentPromise } = await spawnAgent();
+
+    const response = (await agent.loadSession({
+      cwd: '/tmp',
+      sessionId: 'persisted-1',
+      mcpServers: [],
+      _meta: { 'qwen.session.loadReplayMode': 'bulk' },
+    })) as {
+      _meta?: Record<string, { v: number; updates: unknown[] }>;
+    };
+
+    expect(response._meta?.['qwen.session.loadReplay']).toEqual({
+      v: 1,
+      updates: [replayUpdate],
+    });
+    expect(lastSessionMock?.replayHistory).not.toHaveBeenCalled();
+    expect(lastSessionMock?.primeTurnFromHistory).toHaveBeenCalledWith(
+      messages,
+    );
+    expect(mockHistoryReplay).toHaveBeenCalledTimes(1);
+
+    expect(
+      lastSessionMock!.primeTurnFromHistory.mock.invocationCallOrder[0],
+    ).toBeLessThan(mockHistoryReplay.mock.invocationCallOrder[0]!);
+    expect(mockHistoryReplay.mock.invocationCallOrder[0]!).toBeLessThan(
+      lastSessionMock!.installRewriter.mock.invocationCallOrder[0]!,
+    );
+    expect(
+      lastSessionMock!.installRewriter.mock.invocationCallOrder[0]!,
+    ).toBeLessThan(
+      lastSessionMock!.startCronScheduler.mock.invocationCallOrder[0]!,
+    );
 
     mockConnectionState.resolve();
     await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -7412,6 +7412,7 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
   function bindRestoreMocks(opts: {
     sessionExists: boolean;
     resumedConversation?: { messages: unknown[] };
+    primeTurnFromHistoryImpl?: (...args: unknown[]) => unknown;
   }) {
     const innerConfig = makeRestoreInnerConfig({
       resumedConversation: opts.resumedConversation,
@@ -7432,7 +7433,7 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
         getConfig: vi.fn().mockReturnValue(innerConfig),
         sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
         replayHistory: vi.fn().mockResolvedValue(undefined),
-        primeTurnFromHistory: vi.fn(),
+        primeTurnFromHistory: vi.fn(opts.primeTurnFromHistoryImpl),
         cumulativeUsage: {
           promptTokens: 7,
           cachedTokens: 3,
@@ -7579,7 +7580,7 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
     await agentPromise;
   });
 
-  it('loadSession removes a bulk replay restore if replay throws', async () => {
+  it('loadSession returns partial bulk replay updates when replay throws', async () => {
     const messages = [{ role: 'user', parts: [{ text: 'hi' }] }];
     bindRestoreMocks({
       sessionExists: true,
@@ -7591,6 +7592,55 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
     mockHistoryReplay.mockRejectedValueOnce(new Error('replay boom'));
     const { agent, agentPromise } = await spawnAgent();
 
+    const response = (await agent.loadSession({
+      cwd: '/tmp',
+      sessionId: 'persisted-1',
+      mcpServers: [],
+      _meta: { 'qwen.session.loadReplayMode': 'bulk' },
+    })) as {
+      _meta?: Record<
+        string,
+        {
+          v: number;
+          updates: unknown[];
+          partial?: boolean;
+          replayError?: string;
+        }
+      >;
+    };
+
+    expect(response._meta?.['qwen.session.loadReplay']).toMatchObject({
+      v: 1,
+      updates: [],
+      partial: true,
+      replayError: 'replay boom',
+    });
+    expect(lastSessionMock?.dispose).not.toHaveBeenCalled();
+    expect(lastSessionMock?.installRewriter).toHaveBeenCalledTimes(1);
+    expect(lastSessionMock?.startCronScheduler).toHaveBeenCalledTimes(1);
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('loadSession removes a bulk replay restore if setup throws', async () => {
+    const messages = [{ role: 'user', parts: [{ text: 'hi' }] }];
+    let primeCalls = 0;
+    bindRestoreMocks({
+      sessionExists: true,
+      resumedConversation: {
+        messages,
+      },
+      primeTurnFromHistoryImpl: () => {
+        primeCalls++;
+        if (primeCalls === 1) {
+          throw new Error('prime boom');
+        }
+      },
+    });
+    mockHistoryReplay.mockReset();
+    const { agent, agentPromise } = await spawnAgent();
+
     await expect(
       agent.loadSession({
         cwd: '/tmp',
@@ -7598,7 +7648,7 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
         mcpServers: [],
         _meta: { 'qwen.session.loadReplayMode': 'bulk' },
       }),
-    ).rejects.toThrow('replay boom');
+    ).rejects.toThrow('prime boom');
 
     const failedSession = lastSessionMock;
     expect(failedSession?.dispose).toHaveBeenCalledTimes(1);

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -7573,7 +7573,7 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
 
     expect(response._meta?.['qwen.session.loadReplay']).toEqual({
       v: 1,
-      updates: [replayUpdate],
+      updates: [{ ...replayUpdate, timestamp: 4242 }],
     });
     expect(lastSessionMock?.cumulativeUsage).toEqual({
       promptTokens: 101,
@@ -7647,10 +7647,10 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
     });
     expect(lastSessionMock?.dispose).not.toHaveBeenCalled();
     expect(lastSessionMock?.cumulativeUsage).toEqual({
-      promptTokens: 7,
-      cachedTokens: 3,
-      candidateTokens: 5,
-      apiTimeMs: 11,
+      promptTokens: 999,
+      cachedTokens: 0,
+      candidateTokens: 0,
+      apiTimeMs: 0,
     });
     expect(lastSessionMock?.installRewriter).toHaveBeenCalledTimes(1);
     expect(lastSessionMock?.startCronScheduler).toHaveBeenCalledTimes(1);

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -85,6 +85,7 @@ import type {
   DiscoveredMCPResource,
   DiscoveredMCPPrompt,
   WorkspaceRememberContextMode,
+  ChatRecord,
 } from '@qwen-code/qwen-code-core';
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 import {
@@ -152,7 +153,11 @@ import {
   type PermissionRuleSet,
 } from '../config/permission-settings.js';
 import { createLoadedSettingsAdapter } from '../config/loadedSettingsAdapter.js';
-import type { ApprovalModeValue, SessionContext } from './session/types.js';
+import type {
+  ApprovalModeValue,
+  CumulativeUsage,
+  SessionContext,
+} from './session/types.js';
 import { z } from 'zod';
 import type { CliArgs } from '../config/config.js';
 import {
@@ -238,7 +243,12 @@ import {
 } from '@qwen-code/acp-bridge/status';
 import {
   CLIENT_MCP_OVER_WS_CONFIG_FLAG,
+  LOAD_REPLAY_BULK_MODE,
+  LOAD_REPLAY_META_KEY,
+  LOAD_REPLAY_MODE_META_KEY,
+  LOAD_REPLAY_VERSION,
   type ClientMcpOverWsRuntimeConfig,
+  type BridgeLoadReplayEnvelope,
 } from '@qwen-code/acp-bridge/bridgeTypes';
 import { isValidServerName } from '../serve/validate-server-name.js';
 import { MAX_REMEMBER_CONTENT_BYTES } from '../serve/workspace-memory-remember-constants.js';
@@ -254,6 +264,70 @@ const debugLogger = createDebugLogger('ACP_AGENT');
 const BTW_CHILD_TIMEOUT_MS = 55_000;
 // Must be less than WORKSPACE_MEMORY_REMEMBER_TIMEOUT_MS (300s) in bridge.ts.
 const WORKSPACE_MEMORY_REMEMBER_CHILD_TIMEOUT_MS = 295_000;
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isBulkLoadReplayRequest(params: LoadSessionRequest): boolean {
+  const meta = isObjectRecord(params._meta) ? params._meta : undefined;
+  return meta?.[LOAD_REPLAY_MODE_META_KEY] === LOAD_REPLAY_BULK_MODE;
+}
+
+async function collectHistoryReplayUpdates({
+  sessionId,
+  config,
+  records,
+  cumulativeUsage,
+  failOnReplayError,
+}: {
+  sessionId: string;
+  config: Config;
+  records: ChatRecord[];
+  cumulativeUsage: CumulativeUsage;
+  failOnReplayError: boolean;
+}): Promise<{ updates: SessionUpdate[]; replayError?: string }> {
+  const updates: SessionUpdate[] = [];
+  const replayContext: SessionContext = {
+    sessionId,
+    config,
+    sendUpdate: async (update) => {
+      updates.push(update);
+    },
+    cumulativeUsage,
+  };
+
+  try {
+    await new HistoryReplayer(replayContext).replay(records);
+  } catch (error) {
+    if (failOnReplayError) {
+      throw error;
+    }
+    const replayError = error instanceof Error ? error.message : String(error);
+    debugLogger.warn(
+      '[loadUpdates] History replay failed for session %s (partial updates: %d):',
+      sessionId,
+      updates.length,
+      error,
+    );
+    return { updates, replayError };
+  }
+
+  return { updates };
+}
+
+function liftSessionUpdateTimestamps(
+  updates: SessionUpdate[],
+): SessionUpdate[] {
+  return updates.map((update) => {
+    const record = update as Record<string, unknown>;
+    const meta = record['_meta'];
+    const timestamp = isObjectRecord(meta) ? meta['timestamp'] : undefined;
+    return typeof timestamp === 'number' || typeof timestamp === 'string'
+      ? ({ ...record, timestamp } as unknown as SessionUpdate)
+      : update;
+  });
+}
 
 function createHiddenWorkspaceMemoryConfig(config: Config): Config {
   return new Proxy(config, {
@@ -2931,11 +3005,37 @@ class QwenAgent implements Agent {
     this.setupFileSystem(config);
 
     const sessionData = config.getResumedSessionData();
+    const bulkReplay = isBulkLoadReplayRequest(params);
     const session = await this.createAndStoreSession(
       config,
       settings,
       sessionData,
+      bulkReplay
+        ? { replayHistory: false, startPostReplayServices: false }
+        : {},
     );
+    let replayEnvelope: BridgeLoadReplayEnvelope | undefined;
+    if (bulkReplay) {
+      const records = sessionData?.conversation.messages;
+      let replayUpdates: SessionUpdate[] = [];
+      if (records) {
+        session.primeTurnFromHistory(records);
+        const replay = await collectHistoryReplayUpdates({
+          sessionId: params.sessionId,
+          config,
+          records,
+          cumulativeUsage: session.cumulativeUsage,
+          failOnReplayError: true,
+        });
+        replayUpdates = replay.updates;
+      }
+      replayEnvelope = {
+        v: LOAD_REPLAY_VERSION,
+        updates: replayUpdates,
+      };
+      session.installRewriter();
+      session.startCronScheduler();
+    }
 
     await this.#restoreWorktreeOnResume(config, session);
 
@@ -2943,10 +3043,19 @@ class QwenAgent implements Agent {
     const availableModels = this.buildAvailableModels(config);
     const configOptions = this.buildConfigOptions(config);
 
-    return {
+    const response: LoadSessionResponse = {
       modes: modesData,
       models: availableModels,
       configOptions,
+    };
+    if (!replayEnvelope) {
+      return response;
+    }
+    return {
+      ...response,
+      _meta: {
+        [LOAD_REPLAY_META_KEY]: replayEnvelope,
+      },
     };
   }
 
@@ -7097,57 +7206,28 @@ class QwenAgent implements Agent {
           return { updates: [] };
         }
 
-        const updates: SessionUpdate[] = [];
-        const replayContext: SessionContext = {
+        const replay = await collectHistoryReplayUpdates({
           sessionId,
           config: this.config,
-          sendUpdate: async (update) => {
-            updates.push(update);
-          },
-          // Fresh accumulator for this replay: MessageEmitter advances it from
-          // replayed usage metadata (tokens only — no per-turn durations) and
-          // PlanEmitter snapshots it onto each todo update, so resumed sessions
-          // recover per-task token spend (API time stays live-only).
+          records: sessionData.conversation.messages,
           cumulativeUsage: {
             promptTokens: 0,
             cachedTokens: 0,
             candidateTokens: 0,
             apiTimeMs: 0,
           },
-        };
-        let replayError: string | undefined;
-        try {
-          await new HistoryReplayer(replayContext).replay(
-            sessionData.conversation.messages,
-          );
-        } catch (error) {
-          replayError = error instanceof Error ? error.message : String(error);
-          debugLogger.warn(
-            '[loadUpdates] History replay failed for session %s (partial updates: %d):',
-            sessionId,
-            updates.length,
-            error,
-          );
-        }
-        const updatesWithTopLevelTimestamps = updates.map((update) => {
-          const record = update as Record<string, unknown>;
-          const meta = record['_meta'];
-          const timestamp =
-            meta && typeof meta === 'object' && !Array.isArray(meta)
-              ? (meta as Record<string, unknown>)['timestamp']
-              : undefined;
-          return typeof timestamp === 'number' || typeof timestamp === 'string'
-            ? { ...record, timestamp }
-            : record;
+          failOnReplayError: false,
         });
 
         return {
-          updates: updatesWithTopLevelTimestamps,
+          updates: liftSessionUpdateTimestamps(replay.updates),
           startTime: sessionData.conversation.startTime,
           lastUpdated: sessionData.conversation.lastUpdated,
           // Signal to the client that replay aborted partway so it doesn't
           // render a truncated replay as the full conversation.
-          ...(replayError !== undefined ? { partial: true, replayError } : {}),
+          ...(replay.replayError !== undefined
+            ? { partial: true, replayError: replay.replayError }
+            : {}),
         };
       }
       case 'restoreSessionHistory': {
@@ -7954,7 +8034,10 @@ class QwenAgent implements Agent {
     config: Config,
     settings: LoadedSettings,
     sessionData?: ResumedSessionData,
-    options: { replayHistory?: boolean } = {},
+    options: {
+      replayHistory?: boolean;
+      startPostReplayServices?: boolean;
+    } = {},
   ): Promise<Session> {
     const sessionId = config.getSessionId();
     const geminiClient = config.getGeminiClient();
@@ -7989,11 +8072,13 @@ class QwenAgent implements Agent {
       await session.replayHistory(sessionData.conversation.messages);
     }
 
-    // Install rewriter AFTER history replay to avoid rewriting historical messages
-    session.installRewriter();
+    if (options.startPostReplayServices !== false) {
+      // Install rewriter AFTER history replay to avoid rewriting historical messages
+      session.installRewriter();
 
-    // After replay so a durable cron fire can't interleave with it.
-    session.startCronScheduler();
+      // After replay so a durable cron fire can't interleave with it.
+      session.startCronScheduler();
+    }
 
     return session;
   }

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -3079,7 +3079,8 @@ class QwenAgent implements Agent {
             records,
             cumulativeUsage: replayUsage,
           });
-          replayUpdates = replay.updates;
+          replayUpdates = liftSessionUpdateTimestamps(replay.updates);
+          copyCumulativeUsage(session.cumulativeUsage, replayUsage);
           if (replay.replayError !== undefined) {
             replayEnvelope = {
               v: LOAD_REPLAY_VERSION,
@@ -3087,8 +3088,6 @@ class QwenAgent implements Agent {
               partial: true,
               replayError: replay.replayError,
             };
-          } else {
-            copyCumulativeUsage(session.cumulativeUsage, replayUsage);
           }
         }
         replayEnvelope ??= {

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -305,7 +305,7 @@ async function collectHistoryReplayUpdates({
     }
     const replayError = error instanceof Error ? error.message : String(error);
     debugLogger.warn(
-      '[loadUpdates] History replay failed for session %s (partial updates: %d):',
+      '[historyReplay] History replay failed for session %s (partial updates: %d):',
       sessionId,
       updates.length,
       error,
@@ -3063,11 +3063,19 @@ class QwenAgent implements Agent {
             config,
             records,
             cumulativeUsage: session.cumulativeUsage,
-            failOnReplayError: true,
+            failOnReplayError: false,
           });
           replayUpdates = replay.updates;
+          if (replay.replayError !== undefined) {
+            replayEnvelope = {
+              v: LOAD_REPLAY_VERSION,
+              updates: replayUpdates,
+              partial: true,
+              replayError: replay.replayError,
+            };
+          }
         }
-        replayEnvelope = {
+        replayEnvelope ??= {
           v: LOAD_REPLAY_VERSION,
           updates: replayUpdates,
         };

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -2792,6 +2792,43 @@ class QwenAgent implements Agent {
     this.sessions.delete(sessionId);
   }
 
+  private discardStoredSessionIfCurrent(
+    sessionId: string,
+    session: Session,
+  ): void {
+    if (this.sessions.get(sessionId) !== session) {
+      return;
+    }
+    const logCleanupFailure = (action: string, err: unknown) => {
+      debugLogger.debug(
+        `Session ${sessionId} ${action} during failed restore cleanup failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    };
+    try {
+      session.dispose();
+    } catch (err) {
+      logCleanupFailure('dispose', err);
+    }
+    try {
+      unregisterGoalHook(session.getConfig(), sessionId);
+    } catch (err) {
+      logCleanupFailure('goal hook unregister', err);
+    }
+    try {
+      this.mcpPool?.releaseSession(sessionId);
+    } catch (err) {
+      logCleanupFailure('MCP pool release', err);
+    }
+    try {
+      uiTelemetryService.removeSession(sessionId);
+    } catch (err) {
+      logCleanupFailure('telemetry removal', err);
+    }
+    this.sessions.delete(sessionId);
+  }
+
   disposeSessions(): void {
     for (const session of this.sessions.values()) {
       session.dispose();
@@ -3016,25 +3053,30 @@ class QwenAgent implements Agent {
     );
     let replayEnvelope: BridgeLoadReplayEnvelope | undefined;
     if (bulkReplay) {
-      const records = sessionData?.conversation.messages;
-      let replayUpdates: SessionUpdate[] = [];
-      if (records) {
-        session.primeTurnFromHistory(records);
-        const replay = await collectHistoryReplayUpdates({
-          sessionId: params.sessionId,
-          config,
-          records,
-          cumulativeUsage: session.cumulativeUsage,
-          failOnReplayError: true,
-        });
-        replayUpdates = replay.updates;
+      try {
+        const records = sessionData?.conversation.messages;
+        let replayUpdates: SessionUpdate[] = [];
+        if (records) {
+          session.primeTurnFromHistory(records);
+          const replay = await collectHistoryReplayUpdates({
+            sessionId: params.sessionId,
+            config,
+            records,
+            cumulativeUsage: session.cumulativeUsage,
+            failOnReplayError: true,
+          });
+          replayUpdates = replay.updates;
+        }
+        replayEnvelope = {
+          v: LOAD_REPLAY_VERSION,
+          updates: replayUpdates,
+        };
+        session.installRewriter();
+        session.startCronScheduler();
+      } catch (err) {
+        this.discardStoredSessionIfCurrent(params.sessionId, session);
+        throw err;
       }
-      replayEnvelope = {
-        v: LOAD_REPLAY_VERSION,
-        updates: replayUpdates,
-      };
-      session.installRewriter();
-      session.startCronScheduler();
     }
 
     await this.#restoreWorktreeOnResume(config, session);

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -274,18 +274,35 @@ function isBulkLoadReplayRequest(params: LoadSessionRequest): boolean {
   return meta?.[LOAD_REPLAY_MODE_META_KEY] === LOAD_REPLAY_BULK_MODE;
 }
 
+function createReplayCumulativeUsage(): CumulativeUsage {
+  return {
+    promptTokens: 0,
+    cachedTokens: 0,
+    candidateTokens: 0,
+    apiTimeMs: 0,
+  };
+}
+
+function copyCumulativeUsage(
+  target: CumulativeUsage,
+  source: CumulativeUsage,
+): void {
+  target.promptTokens = source.promptTokens;
+  target.cachedTokens = source.cachedTokens;
+  target.candidateTokens = source.candidateTokens;
+  target.apiTimeMs = source.apiTimeMs;
+}
+
 async function collectHistoryReplayUpdates({
   sessionId,
   config,
   records,
   cumulativeUsage,
-  failOnReplayError,
 }: {
   sessionId: string;
   config: Config;
   records: ChatRecord[];
   cumulativeUsage: CumulativeUsage;
-  failOnReplayError: boolean;
 }): Promise<{ updates: SessionUpdate[]; replayError?: string }> {
   const updates: SessionUpdate[] = [];
   const replayContext: SessionContext = {
@@ -300,9 +317,6 @@ async function collectHistoryReplayUpdates({
   try {
     await new HistoryReplayer(replayContext).replay(records);
   } catch (error) {
-    if (failOnReplayError) {
-      throw error;
-    }
     const replayError = error instanceof Error ? error.message : String(error);
     debugLogger.warn(
       '[historyReplay] History replay failed for session %s (partial updates: %d):',
@@ -3058,12 +3072,12 @@ class QwenAgent implements Agent {
         let replayUpdates: SessionUpdate[] = [];
         if (records) {
           session.primeTurnFromHistory(records);
+          const replayUsage = createReplayCumulativeUsage();
           const replay = await collectHistoryReplayUpdates({
             sessionId: params.sessionId,
             config,
             records,
-            cumulativeUsage: session.cumulativeUsage,
-            failOnReplayError: false,
+            cumulativeUsage: replayUsage,
           });
           replayUpdates = replay.updates;
           if (replay.replayError !== undefined) {
@@ -3073,6 +3087,8 @@ class QwenAgent implements Agent {
               partial: true,
               replayError: replay.replayError,
             };
+          } else {
+            copyCumulativeUsage(session.cumulativeUsage, replayUsage);
           }
         }
         replayEnvelope ??= {
@@ -7260,13 +7276,7 @@ class QwenAgent implements Agent {
           sessionId,
           config: this.config,
           records: sessionData.conversation.messages,
-          cumulativeUsage: {
-            promptTokens: 0,
-            cachedTokens: 0,
-            candidateTokens: 0,
-            apiTimeMs: 0,
-          },
-          failOnReplayError: false,
+          cumulativeUsage: createReplayCumulativeUsage(),
         });
 
         return {

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -1068,11 +1068,15 @@ export class Session implements SessionContext {
    * Replays conversation history to the client using modular components.
    * Delegates to HistoryReplayer for consistent event emission.
    */
-  async replayHistory(records: ChatRecord[]): Promise<void> {
+  primeTurnFromHistory(records: ChatRecord[]): void {
     this.turn = Math.max(
       this.turn,
       computeInitialTurnFromHistory(records, this.config.getSessionId()),
     );
+  }
+
+  async replayHistory(records: ChatRecord[]): Promise<void> {
+    this.primeTurnFromHistory(records);
     await this.historyReplayer.replay(records);
   }
 

--- a/packages/cli/src/serve/acp-http/connection-registry.ts
+++ b/packages/cli/src/serve/acp-http/connection-registry.ts
@@ -135,6 +135,13 @@ export interface SessionBinding {
    * are unaffected — they're already produced in replay order.
    */
   replayPending?: boolean;
+  /**
+   * Set after ACP `session/load` when the bridge used response-mode history
+   * replay. The first session stream attach rereads the bridge replay snapshot
+   * and emits it; the binding keeps only this lightweight marker, not the
+   * potentially large replay arrays.
+   */
+  initialReplayPending?: boolean;
 }
 
 /** An agent→client request awaiting the client's JSON-RPC response. */
@@ -288,6 +295,19 @@ export class AcpConnection {
       this.sessions.set(sessionId, binding);
     }
     return binding;
+  }
+
+  markInitialReplayPending(sessionId: string): void {
+    this.getOrCreateSession(sessionId).initialReplayPending = true;
+  }
+
+  hasInitialReplayPending(sessionId: string): boolean {
+    return this.sessions.get(sessionId)?.initialReplayPending === true;
+  }
+
+  markInitialReplayComplete(sessionId: string): void {
+    const binding = this.sessions.get(sessionId);
+    if (binding) binding.initialReplayPending = false;
   }
 
   getDiagnostic(): AcpConnectionDiagnostic {
@@ -532,16 +552,16 @@ export class AcpConnection {
     // there's no ring replay, so the buffer is the only delivery path — flush
     // everything now, in order.
     //
-    // RESUME (`resumeFromEventId !== undefined`): the ring replay the event pump
-    // starts at that cursor already redelivers every BUS event (`id !==
-    // undefined`) after the cursor — including frames lost in-flight to the dead
-    // socket — so we do NOT flush id-bearing frames here (flushing would
-    // double-deliver, and advancing a cursor past them to dedupe would silently
-    // drop an in-flight-lost frame whose id sits below the buffer's ids).
+    // REPLAYING ATTACH (Last-Event-ID resume or response-mode load's initial
+    // replay): the event pump redelivers sequenced BUS events (`id !==
+    // undefined`) from the replay source, so we do NOT flush id-bearing frames
+    // here (flushing would double-deliver, and advancing a cursor past them to
+    // dedupe would silently drop an in-flight-lost frame whose id sits below
+    // the buffer's ids).
     //
     // Id-LESS frames are JSON-RPC replies (`replySession`), NOT ring events, so
-    // the ring won't redeliver them. But flushing them HERE — before replay —
-    // would deliver e.g. a `session/prompt` result BEFORE the ring replays the
+    // the replay won't redeliver them. But flushing them HERE — before replay —
+    // would deliver e.g. a `session/prompt` result BEFORE the pump replays the
     // content chunks that preceded it, so the client would see "prompt complete"
     // ahead of the body (the exact truncated-body failure §1.8 fixes). So on
     // resume we DEFER id-less frames: leave them in the buffer for the pump to
@@ -556,7 +576,9 @@ export class AcpConnection {
     // the flush), which would otherwise leave the flag stuck true and buffer
     // every later `sendSessionReply` — including `session/prompt` results —
     // behind a replay boundary this live-only subscription will never emit.
-    binding.replayPending = resumeFromEventId !== undefined;
+    const replayingOnAttach =
+      resumeFromEventId !== undefined || binding.initialReplayPending === true;
+    binding.replayPending = replayingOnAttach;
     if (binding.replayPending) {
       // Breadcrumb: while armed, `sendSessionReply` defers every out-of-band
       // reply (e.g. `session/prompt` results) until the pump delivers
@@ -565,7 +587,7 @@ export class AcpConnection {
       // trace. Logging the arm gives operators a starting point when responses
       // look stuck behind the replay window.
       writeStderrLine(
-        `qwen serve: /acp replay deferral armed (${logSafe(sessionId)}, from id ${resumeFromEventId})`,
+        `qwen serve: /acp replay deferral armed (${logSafe(sessionId)}, from id ${resumeFromEventId ?? 'initial'})`,
       );
     }
     // Drain the gap buffer into a separate array first: on the resume path the
@@ -574,7 +596,7 @@ export class AcpConnection {
     // step; the explicit local makes the copy-semantics invariant visible.
     const gap = binding.buffer.splice(0);
     for (const entry of gap) {
-      if (resumeFromEventId === undefined) {
+      if (!replayingOnAttach) {
         void stream.send(entry.frame, entry.id); // fresh connect: flush all now
       } else if (entry.id !== undefined) {
         // Resume: ring replay owns bus events, so drop the buffered copy to

--- a/packages/cli/src/serve/acp-http/dispatch.ts
+++ b/packages/cli/src/serve/acp-http/dispatch.ts
@@ -1076,6 +1076,7 @@ export class AcpDispatcher {
                     sessionId,
                     workspaceCwd: cwd,
                     clientId: conn.clientId,
+                    historyReplay: 'response',
                   })
                 : await this.bridge.resumeSession({
                     sessionId,
@@ -1121,6 +1122,9 @@ export class AcpDispatcher {
             return;
           }
           conn.getOrCreateSession(sessionId).clientId = restored.clientId;
+          if (method === 'session/load') {
+            conn.markInitialReplayPending(sessionId);
+          }
           conn.ownSession(sessionId);
           // ACP standard: load/resume response includes configOptions + models + modes
           const loadConfigOptions = await this.configOptionsFor(sessionId);
@@ -3700,14 +3704,6 @@ export class AcpDispatcher {
     lastEventId?: number,
   ): Promise<void> {
     try {
-      // `lastEventId` (from the `Last-Event-ID` reconnect header) drives the
-      // EventBus ring replay: events with `id > lastEventId` still buffered
-      // are replayed before live events flow, recovering content frames lost
-      // in a mid-turn proxy gap (§1.8). `undefined` ⇒ live-only, as before.
-      const iterable = this.bridge.subscribeEvents(sessionId, {
-        signal,
-        ...(lastEventId !== undefined ? { lastEventId } : {}),
-      });
       // On resume, `attachSessionStream` defers id-less buffered replies (e.g. a
       // `session/prompt` result produced during the detach gap) so they land
       // AFTER the content chunks that preceded them. Each deferred reply carries
@@ -3735,6 +3731,48 @@ export class AcpDispatcher {
       // deferred replies (anchor guarantee void) instead of stranding them
       // behind an unreachable watermark — the cascading-freeze fix.
       let sawEviction = false;
+      let subscribeFromEventId = lastEventId;
+      if (conn.hasInitialReplayPending(sessionId)) {
+        const snapshot = this.bridge.getSessionReplaySnapshot(sessionId);
+        if (snapshot) {
+          const snapshotEvents = [
+            ...snapshot.compactedTurns,
+            ...snapshot.liveJournal,
+          ].filter((event) => event.type === 'session_update');
+          for (const event of snapshotEvents) {
+            if (signal.aborted) return;
+            if (typeof event.id === 'number' && event.id <= lastDeliveredId) {
+              continue;
+            }
+            conn.touch();
+            this.translateEvent(conn, sessionId, event);
+            if (typeof event.id === 'number') {
+              lastDeliveredId = event.id;
+              conn.releaseDeferredSessionReplies(sessionId, event.id);
+            }
+          }
+          if (signal.aborted) return;
+          lastDeliveredId = Math.max(lastDeliveredId, snapshot.lastEventId);
+          subscribeFromEventId = snapshot.lastEventId;
+        } else {
+          conn.markInitialReplayComplete(sessionId);
+          conn.endReplayDeferral(sessionId, lastDeliveredId, false);
+        }
+      }
+
+      // `lastEventId` (from the `Last-Event-ID` reconnect header) drives the
+      // EventBus ring replay: events with `id > lastEventId` still buffered
+      // are replayed before live events flow, recovering content frames lost
+      // in a mid-turn proxy gap (§1.8). `undefined` ⇒ live-only, as before.
+      // For initial response-mode load replay, snapshot frames are emitted
+      // above and EventBus subscribes from the snapshot high-water mark, so
+      // events published between snapshot read and subscribe are still replayed.
+      const iterable = this.bridge.subscribeEvents(sessionId, {
+        signal,
+        ...(subscribeFromEventId !== undefined
+          ? { lastEventId: subscribeFromEventId }
+          : {}),
+      });
       for await (const event of iterable) {
         if (signal.aborted) break;
         // Count event delivery as connection activity so a long, quiet prompt
@@ -3748,6 +3786,7 @@ export class AcpDispatcher {
         }
         if (event.type === 'replay_complete') {
           conn.endReplayDeferral(sessionId, lastDeliveredId, sawEviction);
+          conn.markInitialReplayComplete(sessionId);
           // Operator breadcrumb for "did resume recover the gap?": one line per
           // resumed stream stating the cursor it resumed from, how far delivery
           // reached, the bus-reported replayed count, and whether the ring had

--- a/packages/cli/src/serve/acp-http/dispatch.ts
+++ b/packages/cli/src/serve/acp-http/dispatch.ts
@@ -3738,7 +3738,7 @@ export class AcpDispatcher {
           const snapshotEvents = [
             ...snapshot.compactedTurns,
             ...snapshot.liveJournal,
-          ].filter((event) => event.type === 'session_update');
+          ];
           for (const event of snapshotEvents) {
             if (signal.aborted) return;
             if (typeof event.id === 'number' && event.id <= lastDeliveredId) {

--- a/packages/cli/src/serve/acp-http/dispatch.ts
+++ b/packages/cli/src/serve/acp-http/dispatch.ts
@@ -3753,7 +3753,10 @@ export class AcpDispatcher {
           }
           if (signal.aborted) return;
           lastDeliveredId = Math.max(lastDeliveredId, snapshot.lastEventId);
-          subscribeFromEventId = snapshot.lastEventId;
+          subscribeFromEventId = Math.max(
+            subscribeFromEventId ?? 0,
+            snapshot.lastEventId,
+          );
         } else {
           conn.markInitialReplayComplete(sessionId);
           conn.endReplayDeferral(sessionId, lastDeliveredId, false);

--- a/packages/cli/src/serve/acp-http/dispatch.ts
+++ b/packages/cli/src/serve/acp-http/dispatch.ts
@@ -3758,6 +3758,9 @@ export class AcpDispatcher {
             snapshot.lastEventId,
           );
         } else {
+          writeStderrLine(
+            `qwen serve: /acp initial replay skipped (no snapshot) session=${logSafe(sessionId)}`,
+          );
           conn.markInitialReplayComplete(sessionId);
           conn.endReplayDeferral(sessionId, lastDeliveredId, false);
         }

--- a/packages/cli/src/serve/acp-http/dispatch.ts
+++ b/packages/cli/src/serve/acp-http/dispatch.ts
@@ -1130,8 +1130,35 @@ export class AcpDispatcher {
           const loadConfigOptions = await this.configOptionsFor(sessionId);
           const loadModels = this.extractModelState(loadConfigOptions);
           const loadModes = this.extractModeState(loadConfigOptions);
+          const loadState = restored.state ?? {};
+          const loadMeta = isObject(loadState._meta)
+            ? loadState._meta
+            : undefined;
+          const loadQwenMeta = isObject(loadMeta?.[QWEN_META_KEY])
+            ? loadMeta[QWEN_META_KEY]
+            : undefined;
+          const replayStatus =
+            method === 'session/load' && restored.partial === true
+              ? {
+                  partial: true as const,
+                  ...(typeof restored.replayError === 'string'
+                    ? { replayError: restored.replayError }
+                    : {}),
+                }
+              : undefined;
           this.replyConn(conn, id, {
-            ...(restored.state ?? {}),
+            ...loadState,
+            ...(replayStatus
+              ? {
+                  _meta: {
+                    ...(loadMeta ?? {}),
+                    [QWEN_META_KEY]: {
+                      ...(loadQwenMeta ?? {}),
+                      sessionLoadReplay: replayStatus,
+                    },
+                  },
+                }
+              : {}),
             ...(loadConfigOptions ? { configOptions: loadConfigOptions } : {}),
             ...(loadModels ? { models: loadModels } : {}),
             ...(loadModes ? { modes: loadModes } : {}),

--- a/packages/cli/src/serve/acp-http/transport.test.ts
+++ b/packages/cli/src/serve/acp-http/transport.test.ts
@@ -16,7 +16,10 @@ import type {
   BridgeSessionSummary,
   HttpAcpBridge,
 } from '@qwen-code/acp-bridge/bridgeTypes';
-import type { BridgeEvent } from '@qwen-code/acp-bridge/eventBus';
+import type {
+  BridgeEvent,
+  SessionReplaySnapshot,
+} from '@qwen-code/acp-bridge/eventBus';
 import { SessionArtifactValidationError } from '@qwen-code/acp-bridge/sessionArtifacts';
 import {
   CancelSentinelCollisionError,
@@ -156,6 +159,12 @@ class FakeBridge {
   /** `attached` value loadSession returns (false = spawned-from-disk). */
   loadAttached = true;
   spawnClientId: string | undefined = 'client-1';
+  loadRequests: Array<{
+    sessionId: string;
+    historyReplay?: string;
+    clientId?: string;
+  }> = [];
+  replaySnapshot: SessionReplaySnapshot | undefined;
 
   closedSessions: string[] = [];
 
@@ -175,7 +184,12 @@ class FakeBridge {
 
   loadShouldThrow = false;
 
-  async loadSession(req: { sessionId: string }) {
+  async loadSession(req: {
+    sessionId: string;
+    historyReplay?: string;
+    clientId?: string;
+  }) {
+    this.loadRequests.push(req);
     if (this.loadShouldThrow) throw new Error('load failed');
     if (this.gate) await this.gate;
     return {
@@ -185,6 +199,10 @@ class FakeBridge {
       clientId: 'client-load',
       state: { replayed: true },
     };
+  }
+
+  getSessionReplaySnapshot(_sessionId: string) {
+    return this.replaySnapshot;
   }
 
   async resumeSession(req: { sessionId: string }) {
@@ -2996,6 +3014,239 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
     const sess = await openStream(connId, 'loaded-1');
     expect(sess.status).toBe(200);
     await sess.body?.cancel(); // release the long-lived SSE socket
+  });
+
+  it('session/load uses response-mode and replays the snapshot on initial session stream attach', async () => {
+    bridge.replaySnapshot = {
+      lastEventId: 2,
+      compactedTurns: [
+        {
+          v: 1,
+          id: 1,
+          type: 'session_update',
+          data: {
+            sessionId: 'loaded-1',
+            update: { sessionUpdate: 'user_message_chunk' },
+          },
+        } as BridgeEvent,
+      ],
+      liveJournal: [
+        {
+          v: 1,
+          id: 2,
+          type: 'session_update',
+          data: {
+            sessionId: 'loaded-1',
+            update: { sessionUpdate: 'agent_message_chunk' },
+          },
+        } as BridgeEvent,
+      ],
+    };
+    const connId = await initialize();
+    const connStream = await openStream(connId);
+    const loadReply = takeFrames(connStream, 1);
+    await new Promise((r) => setTimeout(r, 50));
+    await post(connId, {
+      jsonrpc: '2.0',
+      id: 20,
+      method: 'session/load',
+      params: { sessionId: 'loaded-1' },
+    });
+    const [reply] = (await loadReply) as Array<{
+      id: number;
+      result: { replayed: boolean; compactedReplay?: unknown };
+    }>;
+    expect(reply).toMatchObject({
+      id: 20,
+      result: { replayed: true },
+    });
+    expect(reply.result).not.toHaveProperty('compactedReplay');
+    expect(bridge.loadRequests).toHaveLength(1);
+    expect(bridge.loadRequests[0]).toMatchObject({
+      sessionId: 'loaded-1',
+      clientId: clientIdForConnection(connId),
+      historyReplay: 'response',
+    });
+
+    const sess = await openStream(connId, 'loaded-1');
+    const framesPromise = takeFrames(sess, 3, 1000);
+    await waitUntil(() => bridge.subscribeCalls.length >= 1);
+    expect(bridge.subscribeCalls[0]).toEqual({
+      sessionId: 'loaded-1',
+      lastEventId: 2,
+    });
+    bridge.queues.get('loaded-1')!.push({
+      type: 'replay_complete',
+      data: { replayedCount: 0 },
+    });
+
+    const frames = (await framesPromise) as Array<{
+      method: string;
+      params: {
+        update?: { sessionUpdate?: string };
+        kind?: string;
+      };
+    }>;
+    expect(frames).toHaveLength(3);
+    expect(frames[0]).toMatchObject({
+      method: 'session/update',
+      params: { update: { sessionUpdate: 'user_message_chunk' } },
+    });
+    expect(frames[1]).toMatchObject({
+      method: 'session/update',
+      params: { update: { sessionUpdate: 'agent_message_chunk' } },
+    });
+    expect(frames[2]).toMatchObject({
+      method: '_qwen/notify',
+      params: { kind: 'replay_complete' },
+    });
+  });
+
+  it('defers prompt replies until initial load replay completes', async () => {
+    bridge.replaySnapshot = {
+      lastEventId: 1,
+      compactedTurns: [],
+      liveJournal: [
+        {
+          v: 1,
+          id: 1,
+          type: 'session_update',
+          data: {
+            sessionId: 'loaded-1',
+            update: { sessionUpdate: 'agent_message_chunk' },
+          },
+        } as BridgeEvent,
+      ],
+    };
+    const connId = await initialize();
+    const connStream = await openStream(connId);
+    const loadReply = takeFrames(connStream, 1);
+    await post(connId, {
+      jsonrpc: '2.0',
+      id: 20,
+      method: 'session/load',
+      params: { sessionId: 'loaded-1' },
+    });
+    await loadReply;
+
+    const sess = await openStream(connId, 'loaded-1');
+    const framesPromise = takeFrames(sess, 3, 1000);
+    await waitUntil(() => bridge.subscribeCalls.length >= 1);
+    await post(connId, {
+      jsonrpc: '2.0',
+      id: 21,
+      method: 'session/prompt',
+      params: {
+        sessionId: 'loaded-1',
+        prompt: [{ type: 'text', text: 'hi' }],
+      },
+    });
+    await new Promise((r) => setTimeout(r, 30));
+    bridge.queues.get('loaded-1')!.push({
+      type: 'replay_complete',
+      data: { replayedCount: 0 },
+    });
+
+    const frames = (await framesPromise) as Array<{
+      id?: number;
+      method?: string;
+      params?: { kind?: string; update?: { sessionUpdate?: string } };
+      result?: { stopReason?: string };
+    }>;
+    expect(frames[0]).toMatchObject({
+      method: 'session/update',
+      params: { update: { sessionUpdate: 'agent_message_chunk' } },
+    });
+    expect(frames[1]).toMatchObject({
+      method: '_qwen/notify',
+      params: { kind: 'replay_complete' },
+    });
+    expect(frames[2]).toMatchObject({
+      id: 21,
+      result: { stopReason: 'end_turn' },
+    });
+  });
+
+  it('continues initial load replay from Last-Event-ID after reconnect', async () => {
+    bridge.replaySnapshot = {
+      lastEventId: 2,
+      compactedTurns: [],
+      liveJournal: [
+        {
+          v: 1,
+          id: 1,
+          type: 'session_update',
+          data: {
+            sessionId: 'loaded-1',
+            update: { sessionUpdate: 'user_message_chunk' },
+          },
+        } as BridgeEvent,
+        {
+          v: 1,
+          id: 2,
+          type: 'session_update',
+          data: {
+            sessionId: 'loaded-1',
+            update: { sessionUpdate: 'agent_message_chunk' },
+          },
+        } as BridgeEvent,
+      ],
+    };
+    const connId = await initialize();
+    const connStream = await openStream(connId);
+    const loadReply = takeFrames(connStream, 1);
+    await post(connId, {
+      jsonrpc: '2.0',
+      id: 20,
+      method: 'session/load',
+      params: { sessionId: 'loaded-1' },
+    });
+    await loadReply;
+
+    const firstStream = await openStream(connId, 'loaded-1');
+    const [firstFrame] = (await takeFrames(firstStream, 1, 1000)) as Array<{
+      method: string;
+      params: { update?: { sessionUpdate?: string } };
+    }>;
+    expect(firstFrame).toMatchObject({
+      method: 'session/update',
+      params: { update: { sessionUpdate: 'user_message_chunk' } },
+    });
+    const subscribeCountBeforeReconnect = bridge.subscribeCalls.length;
+
+    const resumed = await fetch(`${base}/acp`, {
+      headers: {
+        accept: 'text/event-stream',
+        'acp-connection-id': connId,
+        'acp-session-id': 'loaded-1',
+        'last-event-id': '1',
+      },
+    });
+    const framesPromise = takeFrames(resumed, 2, 1000);
+    await waitUntil(
+      () => bridge.subscribeCalls.length > subscribeCountBeforeReconnect,
+    );
+    expect(bridge.subscribeCalls.at(-1)).toEqual({
+      sessionId: 'loaded-1',
+      lastEventId: 2,
+    });
+    bridge.queues.get('loaded-1')!.push({
+      type: 'replay_complete',
+      data: { replayedCount: 0 },
+    });
+
+    const frames = (await framesPromise) as Array<{
+      method: string;
+      params: { kind?: string; update?: { sessionUpdate?: string } };
+    }>;
+    expect(frames[0]).toMatchObject({
+      method: 'session/update',
+      params: { update: { sessionUpdate: 'agent_message_chunk' } },
+    });
+    expect(frames[1]).toMatchObject({
+      method: '_qwen/notify',
+      params: { kind: 'replay_complete' },
+    });
   });
 
   it('session/resume owns the session + replies state', async () => {

--- a/packages/cli/src/serve/acp-http/transport.test.ts
+++ b/packages/cli/src/serve/acp-http/transport.test.ts
@@ -165,6 +165,9 @@ class FakeBridge {
     clientId?: string;
   }> = [];
   replaySnapshot: SessionReplaySnapshot | undefined;
+  loadState: Record<string, unknown> = { replayed: true };
+  loadPartial: true | undefined;
+  loadReplayError: string | undefined;
 
   closedSessions: string[] = [];
 
@@ -197,7 +200,9 @@ class FakeBridge {
       workspaceCwd: '/ws',
       attached: this.loadAttached,
       clientId: 'client-load',
-      state: { replayed: true },
+      state: this.loadState,
+      ...(this.loadPartial ? { partial: this.loadPartial } : {}),
+      ...(this.loadReplayError ? { replayError: this.loadReplayError } : {}),
     };
   }
 
@@ -3014,6 +3019,56 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
     const sess = await openStream(connId, 'loaded-1');
     expect(sess.status).toBe(200);
     await sess.body?.cancel(); // release the long-lived SSE socket
+  });
+
+  it('session/load reports partial replay status under qwen _meta', async () => {
+    bridge.loadState = {
+      replayed: true,
+      _meta: { qwen: { existing: 'kept' }, other: { value: 1 } },
+    };
+    bridge.loadPartial = true;
+    bridge.loadReplayError = 'replay boom';
+    const connId = await initialize();
+    const connStream = await openStream(connId);
+    const got = takeFrames(connStream, 1);
+    await new Promise((r) => setTimeout(r, 50));
+    await post(connId, {
+      jsonrpc: '2.0',
+      id: 20,
+      method: 'session/load',
+      params: { sessionId: 'loaded-1' },
+    });
+    const [frame] = (await got) as Array<{
+      id: number;
+      result: {
+        replayed: boolean;
+        partial?: boolean;
+        replayError?: string;
+        _meta?: {
+          qwen?: {
+            existing?: string;
+            sessionLoadReplay?: {
+              partial?: boolean;
+              replayError?: string;
+            };
+          };
+          other?: { value?: number };
+        };
+      };
+    }>;
+    expect(frame.id).toBe(20);
+    expect(frame.result).not.toHaveProperty('partial');
+    expect(frame.result).not.toHaveProperty('replayError');
+    expect(frame.result._meta).toEqual({
+      qwen: {
+        existing: 'kept',
+        sessionLoadReplay: {
+          partial: true,
+          replayError: 'replay boom',
+        },
+      },
+      other: { value: 1 },
+    });
   });
 
   it('session/load uses response-mode and replays the snapshot on initial session stream attach', async () => {

--- a/packages/cli/src/serve/acp-http/transport.test.ts
+++ b/packages/cli/src/serve/acp-http/transport.test.ts
@@ -3249,6 +3249,59 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
     });
   });
 
+  it('does not rewind initial replay subscription behind Last-Event-ID', async () => {
+    bridge.replaySnapshot = {
+      lastEventId: 2,
+      compactedTurns: [],
+      liveJournal: [
+        {
+          v: 1,
+          id: 1,
+          type: 'session_update',
+          data: {
+            sessionId: 'loaded-1',
+            update: { sessionUpdate: 'user_message_chunk' },
+          },
+        } as BridgeEvent,
+        {
+          v: 1,
+          id: 2,
+          type: 'session_update',
+          data: {
+            sessionId: 'loaded-1',
+            update: { sessionUpdate: 'agent_message_chunk' },
+          },
+        } as BridgeEvent,
+      ],
+    };
+    const connId = await initialize();
+    const connStream = await openStream(connId);
+    const loadReply = takeFrames(connStream, 1);
+    await post(connId, {
+      jsonrpc: '2.0',
+      id: 20,
+      method: 'session/load',
+      params: { sessionId: 'loaded-1' },
+    });
+    await loadReply;
+
+    const resumed = await fetch(`${base}/acp`, {
+      headers: {
+        accept: 'text/event-stream',
+        'acp-connection-id': connId,
+        'acp-session-id': 'loaded-1',
+        'last-event-id': '5',
+      },
+    });
+    await waitUntil(() => bridge.subscribeCalls.length >= 1);
+
+    expect(bridge.subscribeCalls.at(-1)).toEqual({
+      sessionId: 'loaded-1',
+      lastEventId: 5,
+    });
+    await resumed.body?.cancel();
+  });
+
   it('session/resume owns the session + replies state', async () => {
     const connId = await initialize();
     const connStream = await openStream(connId);

--- a/packages/cli/src/serve/acp-http/transport.test.ts
+++ b/packages/cli/src/serve/acp-http/transport.test.ts
@@ -3018,7 +3018,7 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
 
   it('session/load uses response-mode and replays the snapshot on initial session stream attach', async () => {
     bridge.replaySnapshot = {
-      lastEventId: 2,
+      lastEventId: 3,
       compactedTurns: [
         {
           v: 1,
@@ -3029,11 +3029,17 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
             update: { sessionUpdate: 'user_message_chunk' },
           },
         } as BridgeEvent,
+        {
+          v: 1,
+          id: 2,
+          type: 'model_switched',
+          data: { modelId: 'qwen3' },
+        } as BridgeEvent,
       ],
       liveJournal: [
         {
           v: 1,
-          id: 2,
+          id: 3,
           type: 'session_update',
           data: {
             sessionId: 'loaded-1',
@@ -3069,11 +3075,11 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
     });
 
     const sess = await openStream(connId, 'loaded-1');
-    const framesPromise = takeFrames(sess, 3, 1000);
+    const framesPromise = takeFrames(sess, 4, 1000);
     await waitUntil(() => bridge.subscribeCalls.length >= 1);
     expect(bridge.subscribeCalls[0]).toEqual({
       sessionId: 'loaded-1',
-      lastEventId: 2,
+      lastEventId: 3,
     });
     bridge.queues.get('loaded-1')!.push({
       type: 'replay_complete',
@@ -3087,16 +3093,20 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
         kind?: string;
       };
     }>;
-    expect(frames).toHaveLength(3);
+    expect(frames).toHaveLength(4);
     expect(frames[0]).toMatchObject({
       method: 'session/update',
       params: { update: { sessionUpdate: 'user_message_chunk' } },
     });
     expect(frames[1]).toMatchObject({
+      method: '_qwen/notify',
+      params: { kind: 'model_switched', data: { modelId: 'qwen3' } },
+    });
+    expect(frames[2]).toMatchObject({
       method: 'session/update',
       params: { update: { sessionUpdate: 'agent_message_chunk' } },
     });
-    expect(frames[2]).toMatchObject({
+    expect(frames[3]).toMatchObject({
       method: '_qwen/notify',
       params: { kind: 'replay_complete' },
     });

--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -267,6 +267,7 @@ export function registerSessionRoutes(
               ? await bridge.loadSession({
                   sessionId,
                   workspaceCwd: cwd,
+                  historyReplay: 'response',
                   ...(clientId !== undefined ? { clientId } : {}),
                 })
               : await bridge.resumeSession({

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -5927,6 +5927,36 @@ describe('createServeApp', () => {
       ]);
     });
 
+    it('surfaces partial response-mode replay details from load', async () => {
+      const bridge = fakeBridge({
+        loadImpl: async (req) => ({
+          sessionId: req.sessionId,
+          workspaceCwd: req.workspaceCwd,
+          attached: false,
+          clientId: 'client-load',
+          state: {},
+          partial: true,
+          replayError: 'replay boom',
+        }),
+      });
+      const app = createServeApp(baseOpts, undefined, { bridge });
+      const res = await request(app)
+        .post('/session/persisted-partial/load')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .send({});
+
+      expect(res.status).toBe(200);
+      expect(res.body.partial).toBe(true);
+      expect(res.body.replayError).toBe('replay boom');
+      expect(bridge.loadCalls).toEqual([
+        {
+          sessionId: 'persisted-partial',
+          workspaceCwd: realpathSync.native(process.cwd()),
+          historyReplay: 'response',
+        },
+      ]);
+    });
+
     it('passes client identity headers through to load/resume bridge calls', async () => {
       for (const action of ['load', 'resume'] as const) {
         const bridge = fakeBridge();

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -5891,7 +5891,11 @@ describe('createServeApp', () => {
         });
         const calls = action === 'load' ? bridge.loadCalls : bridge.resumeCalls;
         expect(calls).toEqual([
-          { sessionId: 'persisted-1', workspaceCwd: WS_BOUND },
+          {
+            sessionId: 'persisted-1',
+            workspaceCwd: WS_BOUND,
+            ...(action === 'load' ? { historyReplay: 'response' } : {}),
+          },
         ]);
       }
     });
@@ -5915,7 +5919,11 @@ describe('createServeApp', () => {
       expect(res.status).toBe(200);
       expect(res.body.state).toEqual({ configOptions: [] });
       expect(bridge.loadCalls).toEqual([
-        { sessionId: 'persisted-2', workspaceCwd: '/work/a' },
+        {
+          sessionId: 'persisted-2',
+          workspaceCwd: '/work/a',
+          historyReplay: 'response',
+        },
       ]);
     });
 
@@ -5934,6 +5942,7 @@ describe('createServeApp', () => {
           {
             sessionId: 'persisted-1',
             workspaceCwd: realpathSync.native(process.cwd()),
+            ...(action === 'load' ? { historyReplay: 'response' } : {}),
             clientId: 'client-1',
           },
         ]);


### PR DESCRIPTION
## What this PR does

This PR adds an opt-in bulk history replay path for daemon `session/load` so the bridge can request replay updates in the ACP response instead of receiving one child-to-daemon notification per historical frame. Default ACP behavior remains streamed replay unless the bridge explicitly requests response-mode replay.

The bridge now parses and strips Qwen-private replay metadata, seeds replay snapshots without notifying subscribers or filling the reconnect ring, and replays initial ACP session streams from the current bridge snapshot while keeping the JSON-RPC load result ACP-standard. REST load now uses response-mode replay and continues returning the existing replay snapshot fields.

## Why it's needed

Large restored sessions previously replayed history through the live event fanout path, which caused event-loop work, ring churn, and interference with subscribers during load. Moving the bridge-owned restore path to a bulk response removes that fanout while preserving compatibility for direct ACP clients and older streamed behavior.

## Reviewer Test Plan

### How to verify

Run the targeted ACP bridge and CLI serve tests and confirm response-mode load returns a replay snapshot without per-frame child-to-daemon replay fanout, default ACP load still streams history, `/acp` load returns a standard result while the session stream receives replayed `session/update` frames, and reconnect with `Last-Event-ID` resumes initial replay deterministically.

### Evidence (Before & After)

N/A; this is a protocol and daemon replay behavior change with no TUI or visual output.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS worktree using Node/npm from the repository environment. Verified with `cd packages/acp-bridge && npx vitest run src/bridge.test.ts src/bridgeClient.test.ts src/compactionEngine.test.ts`, `cd packages/acp-bridge && npx vitest run src/eventBus.test.ts src/compactionEngine.test.ts`, `cd packages/cli && npx vitest run src/acp-integration/acpAgent.test.ts src/serve/acp-http/transport.test.ts`, `git diff --check`, and `npm run build && npm run typecheck`.

## Risk & Scope

- Main risk or tradeoff: The response-mode path still carries replay updates in one ACP response payload, so it removes live notification fanout and ring churn but does not by itself make load payload size O(turns).
- Not validated / out of scope: Windows and Linux local verification were not run; broader end-to-end browser/client flows beyond the ACP HTTP transport tests are out of scope.
- Breaking changes / migration notes: No public REST/SDK response shape changes are intended; the new protocol fields are Qwen-private ACP `_meta` keys and an internal bridge request option.

## Linked Issues

Related: #6263, part of #6312

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 为 daemon `session/load` 增加了可选的批量历史 replay 路径，让 bridge 可以通过 ACP response 获取 replay updates，而不是让 child 对每个历史帧逐条通知 daemon。默认 ACP 行为仍然是 streamed replay，只有 bridge 显式请求 response-mode replay 时才启用新路径。

bridge 现在会解析并剥离 Qwen 私有 replay metadata，以不通知 subscriber、也不填充 reconnect ring 的方式 seed replay snapshot，并在 ACP session stream 初次 attach 时从当前 bridge snapshot 流式补 replay，同时保持 JSON-RPC load result 符合 ACP 标准。REST load 现在使用 response-mode replay，并继续返回现有 replay snapshot 字段。

## Why it's needed

大历史 session restore 之前会通过 live event fanout 路径 replay 历史，导致 load 期间有 event-loop 工作、ring churn，并可能干扰 subscriber。把 bridge 自己使用的 restore 路径改为 bulk response，可以移除这部分 fanout，同时保持 direct ACP client 和旧 streamed 行为兼容。

## Reviewer Test Plan

### How to verify

运行目标 ACP bridge 和 CLI serve 测试，确认 response-mode load 会返回 replay snapshot 且不会通过 child-to-daemon 逐帧 replay 通知扇出，默认 ACP load 仍然流式 replay 历史，`/acp` load 返回标准结果且 session stream 会收到 replayed `session/update` frames，并且带 `Last-Event-ID` 重连时初始 replay 可以确定性续传。

### Evidence (Before & After)

N/A；这是协议和 daemon replay 行为改动，没有 TUI 或视觉输出。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 macOS worktree，使用仓库环境中的 Node/npm。已通过 `cd packages/acp-bridge && npx vitest run src/bridge.test.ts src/bridgeClient.test.ts src/compactionEngine.test.ts`、`cd packages/acp-bridge && npx vitest run src/eventBus.test.ts src/compactionEngine.test.ts`、`cd packages/cli && npx vitest run src/acp-integration/acpAgent.test.ts src/serve/acp-http/transport.test.ts`、`git diff --check` 和 `npm run build && npm run typecheck` 验证。

## Risk & Scope

- Main risk or tradeoff: response-mode 路径仍然会在一个 ACP response payload 中携带 replay updates，因此它移除了 live notification fanout 和 ring churn，但本身不保证 load payload size 变成 O(turns)。
- Not validated / out of scope: 未做 Windows 和 Linux 本地验证；ACP HTTP transport 测试之外的更完整 browser/client 端到端流程不在本 PR 范围内。
- Breaking changes / migration notes: 不预期改变 public REST/SDK response shape；新增协议字段是 Qwen 私有 ACP `_meta` key 和内部 bridge request option。

## Linked Issues

Related: #6263, part of #6312

</details>