### PR TITLE
perf(cli): cache LoadedSettings per workspace with stat-based invalidation

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -499,6 +499,14 @@ vi.mock('../config/settings.js', () => ({
   loadSettings: vi.fn(),
   reloadEnvironment: vi.fn(() => ({ updatedKeys: [], removedKeys: [] })),
 }));
+// Passthrough: the real cache would serve the first mockReturnValue to every
+// later same-cwd call, breaking tests that re-point loadSettings per call.
+vi.mock('../config/settings-cache.js', async () => {
+  const settings = await import('../config/settings.js');
+  return {
+    loadSettingsCached: (cwd: string) => settings.loadSettings(cwd),
+  };
+});
 vi.mock('../config/loadedSettingsAdapter.js', () => ({
   createLoadedSettingsAdapter: vi.fn((settings: unknown) => {
     (settings as Record<string, unknown>)['getValue'] = vi.fn();

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -143,6 +143,7 @@ import {
   reloadEnvironment,
   SettingScope,
 } from '../config/settings.js';
+import { loadSettingsCached } from '../config/settings-cache.js';
 import {
   buildPermissionSettings,
   normalizePermissionRules,
@@ -2876,7 +2877,7 @@ class QwenAgent implements Agent {
     // creation from picking up whichever workspace loaded last — Session
     // persists model changes through this instance, so a mix-up writes to
     // another workspace's settings.json.
-    const settings = loadSettings(cwd);
+    const settings = loadSettingsCached(cwd);
     this.settings = settings;
     const config = await this.newSessionConfig(cwd, mcpServers, settings);
     await this.ensureAuthenticated(config);
@@ -2899,7 +2900,7 @@ class QwenAgent implements Agent {
     // Load per-request settings BEFORE the existence check: the check must
     // resolve `advanced.runtimeOutputDir` from THIS request's cwd, not from
     // whichever settings a concurrent handler loaded last.
-    const settings = loadSettings(params.cwd);
+    const settings = loadSettingsCached(params.cwd);
     const exists = await runWithAcpRuntimeOutputDir(
       settings,
       params.cwd,
@@ -2954,7 +2955,7 @@ class QwenAgent implements Agent {
     params: ResumeSessionRequest,
   ): Promise<ResumeSessionResponse> {
     // Same per-request settings discipline as `loadSession`.
-    const settings = loadSettings(params.cwd);
+    const settings = loadSettingsCached(params.cwd);
     const exists = await runWithAcpRuntimeOutputDir(
       settings,
       params.cwd,

--- a/packages/cli/src/acp-integration/acpAgent.worktree.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.worktree.test.ts
@@ -233,6 +233,14 @@ vi.mock('../config/settings.js', () => ({
   SettingScope: {},
   loadSettings: vi.fn(),
 }));
+// Passthrough: the real cache would serve the first mockReturnValue to every
+// later same-cwd call, breaking tests that re-point loadSettings per call.
+vi.mock('../config/settings-cache.js', async () => {
+  const settings = await import('../config/settings.js');
+  return {
+    loadSettingsCached: (cwd: string) => settings.loadSettings(cwd),
+  };
+});
 vi.mock('../config/config.js', () => ({
   loadCliConfig: vi.fn(),
   buildDisabledSkillNamesProvider: vi.fn(() => () => new Set<string>()),

--- a/packages/cli/src/config/environment.ts
+++ b/packages/cli/src/config/environment.ts
@@ -193,8 +193,12 @@ export function getHomeEnvFallbackVars(
  * - ~/.qwen/.env
  * - ~/.env
  * - <QWEN_HOME>/.env (when set)
+ *
+ * Exported so `settings-cache.ts` can re-run the exact same discovery when
+ * validating its fingerprint; keep the discovery semantics in this single
+ * implementation.
  */
-function findEnvFiles(
+export function findEnvFiles(
   settings: Settings,
   startDir: string,
   userLevelPaths: Set<string> = getUserLevelEnvPaths(),

--- a/packages/cli/src/config/settings-cache.test.ts
+++ b/packages/cli/src/config/settings-cache.test.ts
@@ -20,6 +20,7 @@ vi.mock('node:os', async (importOriginal) => {
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { ideContextStore } from '@qwen-code/qwen-code-core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   clearSettingsCacheForTesting,
@@ -66,6 +67,9 @@ describe('loadSettingsCached', () => {
     resetHomeEnvBootstrapForTesting();
     resetEnvironmentTrackingForTesting();
     resetTrustedFoldersForTesting();
+    // IDE trust feeds the ideTrust fingerprint component; clear it so state
+    // never leaks between tests.
+    ideContextStore.clear();
   };
 
   beforeEach(() => {
@@ -204,6 +208,19 @@ describe('loadSettingsCached', () => {
     const otherHome = path.join(tmpRoot, 'home-2');
     fs.mkdirSync(otherHome, { recursive: true });
     mockHome.dir = otherHome;
+
+    const second = loadSettingsCached(workspaceDir);
+    expect(second).not.toBe(first);
+  });
+
+  it('reloads when IDE trust state flips', () => {
+    // The ideTrust fingerprint component guards against a stale trust/merge
+    // result: IDE trust is the one trust input that can change within a live
+    // process (trustedFolders.json is a permanent singleton, folder-trust
+    // toggles live in the settings files themselves).
+    const first = loadSettingsCached(workspaceDir);
+
+    ideContextStore.set({ workspaceState: { isTrusted: true } });
 
     const second = loadSettingsCached(workspaceDir);
     expect(second).not.toBe(first);

--- a/packages/cli/src/config/settings-cache.test.ts
+++ b/packages/cli/src/config/settings-cache.test.ts
@@ -1,0 +1,272 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Mock os.homedir before anything else imports it. The holder is mutable so
+// individual tests can relocate "home" (the homeDir fingerprint component).
+const mockHome = vi.hoisted(() => ({ dir: '/uninitialized-mock-home' }));
+
+vi.mock('os', async (importOriginal) => {
+  const actualOs = await importOriginal<typeof import('node:os')>();
+  return { ...actualOs, homedir: vi.fn(() => mockHome.dir) };
+});
+vi.mock('node:os', async (importOriginal) => {
+  const actualOs = await importOriginal<typeof import('node:os')>();
+  return { ...actualOs, homedir: vi.fn(() => mockHome.dir) };
+});
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearSettingsCacheForTesting,
+  loadSettingsCached,
+} from './settings-cache.js';
+import {
+  resetEnvironmentTrackingForTesting,
+  resetHomeEnvBootstrapForTesting,
+  SettingScope,
+  SETTINGS_VERSION,
+  SETTINGS_VERSION_KEY,
+} from './settings.js';
+import { resetTrustedFoldersForTesting } from './trustedFolders.js';
+
+// Keys written to fixture .env files leak into process.env via
+// loadEnvironment (by design); use a unique prefix and clean them up.
+const TEST_ENV_PREFIX = 'SETTINGS_CACHE_TEST_';
+
+describe('loadSettingsCached', () => {
+  let tmpRoot: string;
+  let homeDir: string;
+  let qwenHome: string;
+  let workspaceDir: string;
+
+  const userSettingsPath = () => path.join(qwenHome, 'settings.json');
+  const workspaceSettingsPath = (ws = workspaceDir) =>
+    path.join(ws, '.qwen', 'settings.json');
+
+  const writeJson = (filePath: string, value: unknown) => {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify(value));
+  };
+
+  // All fixtures carry the current settings version so loadSettings never
+  // rewrites them (a migration self-write would turn the second call into a
+  // legitimate miss and hide what these tests assert).
+  const versioned = (settings: Record<string, unknown>) => ({
+    [SETTINGS_VERSION_KEY]: SETTINGS_VERSION,
+    ...settings,
+  });
+
+  const resetModuleState = () => {
+    clearSettingsCacheForTesting();
+    resetHomeEnvBootstrapForTesting();
+    resetEnvironmentTrackingForTesting();
+    resetTrustedFoldersForTesting();
+  };
+
+  beforeEach(() => {
+    tmpRoot = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'settings-cache-test-')),
+    );
+    homeDir = path.join(tmpRoot, 'home');
+    qwenHome = path.join(tmpRoot, 'qwen-home');
+    workspaceDir = path.join(tmpRoot, 'project', 'app');
+    fs.mkdirSync(homeDir, { recursive: true });
+    fs.mkdirSync(qwenHome, { recursive: true });
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    mockHome.dir = homeDir;
+
+    // Sandbox every settings path inside tmpRoot: user/workspace via
+    // QWEN_HOME + cwd, system/system-defaults via their test overrides.
+    vi.stubEnv('QWEN_HOME', qwenHome);
+    vi.stubEnv(
+      'QWEN_CODE_SYSTEM_SETTINGS_PATH',
+      path.join(tmpRoot, 'system', 'settings.json'),
+    );
+    vi.stubEnv(
+      'QWEN_CODE_SYSTEM_DEFAULTS_PATH',
+      path.join(tmpRoot, 'system', 'system-defaults.json'),
+    );
+    resetModuleState();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith(TEST_ENV_PREFIX)) {
+        delete process.env[key];
+      }
+    }
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('serves the same instance while nothing changed', () => {
+    writeJson(userSettingsPath(), versioned({ model: { name: 'cached' } }));
+
+    const first = loadSettingsCached(workspaceDir);
+    const second = loadSettingsCached(workspaceDir);
+
+    // Identity is the strongest possible assertion: loadSettings() always
+    // constructs a new LoadedSettings, so same instance ⇒ no reload ran.
+    expect(second).toBe(first);
+    expect(second.merged.model?.name).toBe('cached');
+  });
+
+  it('reloads when the user settings file changes', () => {
+    writeJson(userSettingsPath(), versioned({ model: { name: 'before' } }));
+    const first = loadSettingsCached(workspaceDir);
+
+    writeJson(
+      userSettingsPath(),
+      versioned({ model: { name: 'after-edit-longer' } }),
+    );
+    const second = loadSettingsCached(workspaceDir);
+
+    expect(second).not.toBe(first);
+    expect(second.merged.model?.name).toBe('after-edit-longer');
+  });
+
+  it('reloads when a workspace settings file appears and again when it is deleted', () => {
+    const first = loadSettingsCached(workspaceDir);
+
+    writeJson(
+      workspaceSettingsPath(),
+      versioned({ model: { name: 'from-workspace' } }),
+    );
+    const second = loadSettingsCached(workspaceDir);
+    expect(second).not.toBe(first);
+    expect(second.merged.model?.name).toBe('from-workspace');
+
+    fs.rmSync(workspaceSettingsPath());
+    const third = loadSettingsCached(workspaceDir);
+    expect(third).not.toBe(second);
+    expect(third.merged.model?.name).toBeUndefined();
+  });
+
+  it('reloads when a .env file appears closer to the workspace', () => {
+    const first = loadSettingsCached(workspaceDir);
+    expect(process.env[`${TEST_ENV_PREFIX}CLOSER`]).toBeUndefined();
+
+    fs.writeFileSync(
+      path.join(workspaceDir, '.env'),
+      `${TEST_ENV_PREFIX}CLOSER=yes\n`,
+    );
+    const second = loadSettingsCached(workspaceDir);
+
+    expect(second).not.toBe(first);
+    expect(process.env[`${TEST_ENV_PREFIX}CLOSER`]).toBe('yes');
+  });
+
+  it('reloads when a discovered home .env file changes', () => {
+    const homeEnvPath = path.join(qwenHome, '.env');
+    fs.writeFileSync(homeEnvPath, `${TEST_ENV_PREFIX}A=1\n`);
+
+    const first = loadSettingsCached(workspaceDir);
+    expect(process.env[`${TEST_ENV_PREFIX}A`]).toBe('1');
+    expect(loadSettingsCached(workspaceDir)).toBe(first);
+
+    fs.writeFileSync(
+      homeEnvPath,
+      `${TEST_ENV_PREFIX}A=1\n${TEST_ENV_PREFIX}B=2\n`,
+    );
+    const second = loadSettingsCached(workspaceDir);
+
+    expect(second).not.toBe(first);
+    expect(process.env[`${TEST_ENV_PREFIX}B`]).toBe('2');
+  });
+
+  it('reloads when QWEN_HOME points at a different directory', () => {
+    writeJson(userSettingsPath(), versioned({ model: { name: 'home-one' } }));
+    const first = loadSettingsCached(workspaceDir);
+    expect(first.merged.model?.name).toBe('home-one');
+
+    const otherQwenHome = path.join(tmpRoot, 'qwen-home-2');
+    writeJson(
+      path.join(otherQwenHome, 'settings.json'),
+      versioned({ model: { name: 'home-two' } }),
+    );
+    vi.stubEnv('QWEN_HOME', otherQwenHome);
+
+    const second = loadSettingsCached(workspaceDir);
+    expect(second).not.toBe(first);
+    expect(second.merged.model?.name).toBe('home-two');
+  });
+
+  it('reloads when os.homedir() changes even if no settings path moves', () => {
+    // The R2 corner: QWEN_HOME pins the user/system paths and no .env exists
+    // anywhere, so only the homeDir fingerprint component can catch this.
+    const first = loadSettingsCached(workspaceDir);
+
+    const otherHome = path.join(tmpRoot, 'home-2');
+    fs.mkdirSync(otherHome, { recursive: true });
+    mockHome.dir = otherHome;
+
+    const second = loadSettingsCached(workspaceDir);
+    expect(second).not.toBe(first);
+  });
+
+  it('returns a fresh instance after setValue persisted a change', () => {
+    writeJson(userSettingsPath(), versioned({ model: { name: 'initial' } }));
+    const first = loadSettingsCached(workspaceDir);
+
+    first.setValue(SettingScope.User, 'model.name', 'persisted-by-setvalue');
+
+    const second = loadSettingsCached(workspaceDir);
+    expect(second).not.toBe(first);
+    expect(second.merged.model?.name).toBe('persisted-by-setvalue');
+  });
+
+  it('does not cache a load failure and recovers once the file is fixed', () => {
+    // Valid JSON that is not an object bypasses corruption recovery and
+    // makes loadSettings throw FatalConfigError.
+    fs.writeFileSync(userSettingsPath(), '[1]');
+
+    expect(() => loadSettingsCached(workspaceDir)).toThrow(
+      /not a valid JSON object/,
+    );
+
+    writeJson(userSettingsPath(), versioned({ model: { name: 'fixed' } }));
+    const recovered = loadSettingsCached(workspaceDir);
+    expect(recovered.merged.model?.name).toBe('fixed');
+    expect(loadSettingsCached(workspaceDir)).toBe(recovered);
+  });
+
+  it('keeps independent entries per workspace directory', () => {
+    const otherWorkspace = path.join(tmpRoot, 'project', 'other');
+    fs.mkdirSync(otherWorkspace, { recursive: true });
+    writeJson(
+      workspaceSettingsPath(),
+      versioned({ model: { name: 'ws-app' } }),
+    );
+    writeJson(
+      workspaceSettingsPath(otherWorkspace),
+      versioned({ model: { name: 'ws-other' } }),
+    );
+
+    const first = loadSettingsCached(workspaceDir);
+    const other = loadSettingsCached(otherWorkspace);
+
+    expect(other).not.toBe(first);
+    expect(first.merged.model?.name).toBe('ws-app');
+    expect(other.merged.model?.name).toBe('ws-other');
+    expect(loadSettingsCached(workspaceDir)).toBe(first);
+    expect(loadSettingsCached(otherWorkspace)).toBe(other);
+  });
+
+  it('evicts the least recently used entry beyond the cache limit', () => {
+    const first = loadSettingsCached(workspaceDir);
+
+    for (let i = 0; i < 64; i++) {
+      const ws = path.join(tmpRoot, 'fleet', `ws-${i}`);
+      fs.mkdirSync(ws, { recursive: true });
+      loadSettingsCached(ws);
+    }
+
+    // 64 newer entries pushed the first workspace out of the LRU map.
+    expect(loadSettingsCached(workspaceDir)).not.toBe(first);
+  });
+});

--- a/packages/cli/src/config/settings-cache.test.ts
+++ b/packages/cli/src/config/settings-cache.test.ts
@@ -237,6 +237,32 @@ describe('loadSettingsCached', () => {
     expect(second.merged.model?.name).toBe('persisted-by-setvalue');
   });
 
+  it('falls open to a reload when fingerprint validation throws', () => {
+    // Fail-open is a core invariant: an unexpected error while checking the
+    // fingerprint must degrade to a full reload, never surface. isEntryFresh
+    // reads ideContextStore first, so making that throw exercises the
+    // hit-path fail-open (and the caching fail-open, since the rebuilt
+    // fingerprint reads it too). loadSettings itself does not read it here
+    // (the workspace dir is not process.cwd()), so the reload still succeeds.
+    writeJson(userSettingsPath(), versioned({ model: { name: 'ok' } }));
+    const first = loadSettingsCached(workspaceDir);
+
+    const trustSpy = vi.spyOn(ideContextStore, 'get').mockImplementation(() => {
+      throw new Error('boom');
+    });
+    const second = loadSettingsCached(workspaceDir);
+    expect(second).not.toBe(first); // reloaded, not a propagated error
+    expect(second.merged.model?.name).toBe('ok'); // ...and still correct
+
+    // Recovery: the degraded call could not cache (rebuilding the fingerprint
+    // also threw), so this first post-recovery call is itself a miss, then
+    // subsequent calls hit normally.
+    trustSpy.mockRestore();
+    const third = loadSettingsCached(workspaceDir);
+    expect(third.merged.model?.name).toBe('ok');
+    expect(loadSettingsCached(workspaceDir)).toBe(third);
+  });
+
   it('does not cache a load failure and recovers once the file is fixed', () => {
     // Valid JSON that is not an object bypasses corruption recovery and
     // makes loadSettings throw FatalConfigError.

--- a/packages/cli/src/config/settings-cache.ts
+++ b/packages/cli/src/config/settings-cache.ts
@@ -7,7 +7,11 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { ideContextStore, Storage } from '@qwen-code/qwen-code-core';
+import {
+  createDebugLogger,
+  ideContextStore,
+  Storage,
+} from '@qwen-code/qwen-code-core';
 import { findEnvFiles, preResolveHomeEnvOverrides } from './environment.js';
 import {
   getSystemDefaultsPath,
@@ -48,6 +52,11 @@ import type { LoadedSettings } from './settings.js';
 
 const MAX_CACHE_ENTRIES = 64;
 
+// Matches the SETTINGS / SETTINGS_WATCHER / CONFIG loggers used by the
+// neighbouring config modules; enable with the usual DEBUG namespaces to
+// trace hit/miss, fail-open degradation and eviction in production.
+const debugLogger = createDebugLogger('SETTINGS_CACHE');
+
 interface FileSig {
   filePath: string;
   sig: string;
@@ -86,6 +95,13 @@ function realpathOr(p: string): string {
  * Paths are recomputed on every call (not stored once): they depend on
  * QWEN_HOME / HOME and the test-only system-path overrides, so a changed
  * environment shows up as a path mismatch and invalidates the entry.
+ *
+ * IMPORTANT: this list MUST stay in sync with the settings files that
+ * `loadSettings()` reads. Unlike `envFileSigs`, which structurally reuses the
+ * same `findEnvFiles()` that `loadEnvironment()` calls, these four scopes are
+ * enumerated independently. If a future PR adds a new settings scope to
+ * `loadSettings()`, add its path here too — otherwise the cache would serve a
+ * stale `LoadedSettings` with no test or compile-time signal.
  */
 function settingsFileSigs(workspaceDir: string): FileSig[] {
   const filePaths = [
@@ -154,18 +170,24 @@ export function loadSettingsCached(workspaceDir: string): LoadedSettings {
     let isFresh = false;
     try {
       isFresh = isEntryFresh(key, entry);
-    } catch {
+    } catch (error) {
       // Fail open: any unexpected fingerprint error (EACCES, EIO, ...) is
       // treated as a miss so the cache never becomes a new failure source.
+      debugLogger.warn(
+        `fingerprint check failed for ${key}; reloading:`,
+        error,
+      );
     }
     if (isFresh) {
       // Refresh LRU position (Map preserves insertion order).
       cache.delete(key);
       cache.set(key, entry);
+      debugLogger.debug(`hit ${key}`);
       return entry.settings;
     }
     cache.delete(key);
   }
+  debugLogger.debug(`miss ${key}`);
 
   // Sign the settings files BEFORE loading: if one changes while
   // loadSettings() runs, the stored signature is already stale and the next
@@ -174,8 +196,9 @@ export function loadSettingsCached(workspaceDir: string): LoadedSettings {
   let preLoadSigs: FileSig[] | undefined;
   try {
     preLoadSigs = settingsFileSigs(key);
-  } catch {
+  } catch (error) {
     // Fail open: cache nothing this round.
+    debugLogger.warn(`pre-load signing failed for ${key}; not caching:`, error);
   }
 
   // Load errors (FatalConfigError etc.) propagate unchanged and uncached;
@@ -200,11 +223,13 @@ export function loadSettingsCached(workspaceDir: string): LoadedSettings {
         const oldest = cache.keys().next().value;
         if (oldest !== undefined) {
           cache.delete(oldest);
+          debugLogger.debug(`evicted LRU entry ${oldest}`);
         }
       }
-    } catch {
+    } catch (error) {
       // Fail open: serve the freshly loaded settings uncached.
       cache.delete(key);
+      debugLogger.warn(`caching failed for ${key}; serving uncached:`, error);
     }
   }
 

--- a/packages/cli/src/config/settings-cache.ts
+++ b/packages/cli/src/config/settings-cache.ts
@@ -1,0 +1,216 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { ideContextStore, Storage } from '@qwen-code/qwen-code-core';
+import { findEnvFiles, preResolveHomeEnvOverrides } from './environment.js';
+import {
+  getSystemDefaultsPath,
+  getSystemSettingsPath,
+  getUserSettingsPath,
+  loadSettings,
+} from './settings.js';
+import type { LoadedSettings } from './settings.js';
+
+/**
+ * Process-level cache for `loadSettings()`, keyed by workspace directory.
+ *
+ * The ACP child under `qwen serve` is long-lived and serves many sessions
+ * (often for the same cwd). A full `loadSettings()` runs on the shared event
+ * loop for every `session/new` / `session/load`: four settings files read,
+ * parsed, migration-checked and structuredClone'd, the `.env` tree walked,
+ * home `.env` re-read, `${VAR}` references re-resolved, and all scopes merged.
+ * This wrapper serves a previously loaded `LoadedSettings` instance while a
+ * stat-based fingerprint of every filesystem input is unchanged.
+ *
+ * A cache hit still costs ~4 `statSync` + the `.env` discovery walk
+ * (`existsSync` per directory level) + 1-2 `realpathSync` — deliberately so:
+ * invalidation is deterministic (change a file, next call sees it) rather
+ * than time-based. It just skips the much larger read/parse/clone/merge work.
+ *
+ * Known, accepted differences vs. calling `loadSettings()` every time:
+ * 1. Mutating `process.env` directly (no file change) does not re-resolve
+ *    `${VAR}` references baked into cached settings values.
+ * 2. A `.env` file modified *while* the miss-path `loadSettings()` is running
+ *    (and never again afterwards) can be served stale — the microsecond
+ *    TOCTOU window shared by every mtime-based cache.
+ * 3. An in-place overwrite preserving mtime, size *and* inode is invisible.
+ *    Self-writes (`LoadedSettings.setValue`) go through temp-file + rename,
+ *    which changes the inode; on filesystems reporting `ino` as 0 (some
+ *    Windows setups) this degrades to mtime+size detection, same as tsc's
+ *    incremental cache.
+ */
+
+const MAX_CACHE_ENTRIES = 64;
+
+interface FileSig {
+  filePath: string;
+  sig: string;
+}
+
+interface CacheFingerprint {
+  settingsFiles: FileSig[];
+  envFiles: FileSig[];
+  ideTrust: boolean | undefined;
+  realCwd: string;
+  homeDir: string;
+}
+
+interface CacheEntry {
+  settings: LoadedSettings;
+  fingerprint: CacheFingerprint;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+function statSig(filePath: string): string {
+  const st = fs.statSync(filePath, { throwIfNoEntry: false });
+  return st ? `${st.mtimeMs}:${st.size}:${st.ino}` : 'missing';
+}
+
+function realpathOr(p: string): string {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    // Match loadSettings(): fall back to the resolved path.
+    return path.resolve(p);
+  }
+}
+
+/**
+ * Paths are recomputed on every call (not stored once): they depend on
+ * QWEN_HOME / HOME and the test-only system-path overrides, so a changed
+ * environment shows up as a path mismatch and invalidates the entry.
+ */
+function settingsFileSigs(workspaceDir: string): FileSig[] {
+  const filePaths = [
+    getSystemSettingsPath(),
+    getSystemDefaultsPath(),
+    getUserSettingsPath(),
+    new Storage(workspaceDir).getWorkspaceSettingsPath(),
+  ];
+  return filePaths.map((filePath) => ({ filePath, sig: statSig(filePath) }));
+}
+
+/**
+ * Re-runs `.env` discovery and signs the result. Discovery only returns
+ * files that exist, so a new `.env` appearing closer to the workspace (or a
+ * discovered one disappearing) changes the path list itself, while edits to
+ * a discovered file change its signature. Trust changes that would alter
+ * discovery are covered by the settingsFiles / ideTrust components.
+ */
+function envFileSigs(
+  settings: LoadedSettings,
+  workspaceDir: string,
+): FileSig[] {
+  return findEnvFiles(settings.merged, workspaceDir).map((filePath) => ({
+    filePath,
+    sig: statSig(filePath),
+  }));
+}
+
+function sameFileSigs(a: FileSig[], b: FileSig[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return a.every(
+    (sig, i) => sig.filePath === b[i]!.filePath && sig.sig === b[i]!.sig,
+  );
+}
+
+function isEntryFresh(key: string, entry: CacheEntry): boolean {
+  const fp = entry.fingerprint;
+  return (
+    ideContextStore.get()?.workspaceState?.isTrusted === fp.ideTrust &&
+    realpathOr(key) === fp.realCwd &&
+    // homeDir guards the corner where nothing else moves: QWEN_HOME set (so
+    // settings paths don't follow HOME), no .env files anywhere, and the new
+    // home equals the workspace dir — which flips workspaceSettingsActive.
+    realpathOr(os.homedir()) === fp.homeDir &&
+    sameFileSigs(settingsFileSigs(key), fp.settingsFiles) &&
+    sameFileSigs(envFileSigs(entry.settings, key), fp.envFiles)
+  );
+}
+
+/**
+ * Drop-in replacement for `loadSettings(workspaceDir)` on hot paths that use
+ * its default options. Callers needing `LoadSettingsOptions` must keep using
+ * `loadSettings()` directly.
+ */
+export function loadSettingsCached(workspaceDir: string): LoadedSettings {
+  // Idempotent process-level latch (loadSettings runs it internally too);
+  // running it up front makes the QWEN_HOME-derived paths below stable from
+  // the very first call instead of only after the first miss.
+  preResolveHomeEnvOverrides();
+  const key = path.resolve(workspaceDir);
+
+  const entry = cache.get(key);
+  if (entry) {
+    let isFresh = false;
+    try {
+      isFresh = isEntryFresh(key, entry);
+    } catch {
+      // Fail open: any unexpected fingerprint error (EACCES, EIO, ...) is
+      // treated as a miss so the cache never becomes a new failure source.
+    }
+    if (isFresh) {
+      // Refresh LRU position (Map preserves insertion order).
+      cache.delete(key);
+      cache.set(key, entry);
+      return entry.settings;
+    }
+    cache.delete(key);
+  }
+
+  // Sign the settings files BEFORE loading: if one changes while
+  // loadSettings() runs, the stored signature is already stale and the next
+  // call reloads. Conservative — may reload once too often, never serves
+  // stale data.
+  let preLoadSigs: FileSig[] | undefined;
+  try {
+    preLoadSigs = settingsFileSigs(key);
+  } catch {
+    // Fail open: cache nothing this round.
+  }
+
+  // Load errors (FatalConfigError etc.) propagate unchanged and uncached;
+  // the stale entry was already dropped above.
+  const settings = loadSettings(key);
+
+  if (preLoadSigs) {
+    try {
+      cache.set(key, {
+        settings,
+        fingerprint: {
+          settingsFiles: preLoadSigs,
+          // .env discovery needs the merged settings (trust), so it can only
+          // be signed after the load — see difference (2) in the module doc.
+          envFiles: envFileSigs(settings, key),
+          ideTrust: ideContextStore.get()?.workspaceState?.isTrusted,
+          realCwd: realpathOr(key),
+          homeDir: realpathOr(os.homedir()),
+        },
+      });
+      if (cache.size > MAX_CACHE_ENTRIES) {
+        const oldest = cache.keys().next().value;
+        if (oldest !== undefined) {
+          cache.delete(oldest);
+        }
+      }
+    } catch {
+      // Fail open: serve the freshly loaded settings uncached.
+      cache.delete(key);
+    }
+  }
+
+  return settings;
+}
+
+export function clearSettingsCacheForTesting(): void {
+  cache.clear();
+}


### PR DESCRIPTION
## What this PR does

Adds a process-level cache for `LoadedSettings` keyed by the resolved workspace directory (`packages/cli/src/config/settings-cache.ts`), and switches the three ACP session-creation handlers (`newSession`, `loadSession`, `unstable_resumeSession`) to use it. A cache hit revalidates a fingerprint of everything `loadSettings` reads — the four settings file paths and their stat signatures (`mtimeMs:size:ino`), the discovered `.env` file list and signatures, IDE trust state, `realpath(cwd)`, and `realpath(os.homedir())` — and returns the cached instance only when all of it is unchanged. Any settings-file edit (including self-writes via `setValue`), a `.env` file appearing/disappearing/changing at any level of the upward walk, a `QWEN_HOME`/`HOME` switch, or an IDE trust flip invalidates the entry and takes the full `loadSettings` path again. Fingerprint collection is fail-open (any unexpected fs error falls back to a full load, so the cache can never become a new failure source), load failures are never cached, and the cache is LRU-bounded to 64 workspaces.

It also exports `findEnvFiles` from `environment.ts` (one line) so the cache reuses the exact same `.env` discovery semantics (trust filtering, `QWEN_HOME` redirection, home candidates) instead of duplicating them.

## Why it's needed

The `qwen serve` ACP child is a long-lived process that serves many sessions, and every `session/new` / `session/load` / resume currently re-runs a full `loadSettings(cwd)` synchronously on the shared event loop: `existsSync`+`readFileSync`+`JSON.parse` over four settings scopes, migration checks, four `structuredClone` calls, `${VAR}` re-interpolation, a home `.env` re-read, and an upward `.env` directory walk. For serve's typical workload — repeated sessions on the same cwd — this is all repeated work, and it blocks the event loop that all live sessions share. This is part A of the P0-1 "session creation path caching" item from the perf roadmap in #6263 (settings now; extension loading and command/skill snapshots follow as separate PRs).

## Reviewer Test Plan

### How to verify

The new unit suite covers: hit identity (same instance ⇒ no reload ran), each invalidation trigger (user/workspace settings edit, workspace settings appearing and being deleted, a `.env` appearing closer to cwd, home `.env` content change, `QWEN_HOME` switch, `os.homedir()` switch, `setValue` self-write), load-failure non-caching + recovery after the file is fixed, per-cwd entry independence, and LRU eviction.

```bash
cd packages/cli
npx vitest run src/config/settings-cache.test.ts                                                    # 11/11
npx vitest run src/acp-integration/acpAgent.test.ts src/acp-integration/acpAgent.worktree.test.ts   # 184/184 (cache mocked as passthrough so per-call mockReturnValue setups keep working)
npm run typecheck && npm run lint
```

Functional smoke on the real path: build, start `node packages/cli/dist/index.js serve --port <port>` in a sandbox workspace, then POST `/session` with `{"cwd": <ws>, "sessionScope": "thread"}` repeatedly against the same cwd — every request after the first multiplexes onto the live ACP child via `connection.newSession()` and goes through `loadSettingsCached`. Ran 4 rounds of 40+ consecutive creations on the cached binary with zero failures.

### Evidence (Before & After)

Microbenchmark (`loadSettings(ws)` every call vs `loadSettingsCached(ws)` hit; N=200 per variant after 20 warmup iterations; sandboxed tmpdir fixture with user + workspace settings files, an 8-key home `.env`, cwd 3 levels deep; node v24.12.0, macOS with corporate EDR — an environment where syscalls are expensive, i.e. where this matters most).

Typical config (~1.6 KB user settings, 6 MCP servers):

| variant | p50 | p90 | p99 | mean |
| --- | --- | --- | --- | --- |
| `loadSettings` (every call) | 577.8µs | 716.0µs | 3676µs | 659µs |
| `loadSettingsCached` (hit) | 113.7µs | 138.7µs | 219.1µs | 120.1µs |

→ **5.1x at p50** (across 3 runs the p50 speedup ranged 4.9–5.7x), i.e. ~0.5ms of synchronous event-loop time saved per session-create, and the p99 tail drops from ~3.7ms to ~0.2ms.

Large config (~13 KB user settings, 24 MCP servers, 120-entry `tools.exclude`):

| variant | p50 | p90 | p99 | mean |
| --- | --- | --- | --- | --- |
| `loadSettings` (every call) | 1169.7µs | 1614.9µs | 3403.3µs | 1262.8µs |
| `loadSettingsCached` (hit) | 184.0µs | 306.9µs | 1628.1µs | 226.6µs |

→ **6.4x at p50** (8.7x on a second run). The hit cost stays flat regardless of settings size (it is stat-bound: ~4 `statSync` + the `.env` upward walk + 1–2 `realpathSync`), while the full-load cost scales with settings size, so the per-call saving grows to ~1ms for heavyweight configs.

End-to-end (`qwen serve` + 3×40 POST `/session` thread-scope on the same cwd, before vs after): the full-path p50 is ~70–80ms and is dominated by `Config` construction, auth and session setup; round-to-round p50 drift on the *same* binary (±20ms of machine-state noise on this EDR host) is far larger than the ~0.5ms settings segment, so HTTP-level timing cannot resolve this change in either direction — reporting that honestly rather than cherry-picking a favorable round. The e2e runs double as the functional smoke above. The remaining large chunks of the session-create path are exactly what the follow-up PRs (extensions, command/skill snapshot) target.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

node v24.12.0 on macOS; unit tests via vitest plus a local `qwen serve` daemon (`node packages/cli/dist/index.js serve --port <port>`) for the end-to-end smoke.

## Risk & Scope

- Main risk or tradeoff: stat-based invalidation has three narrow, documented gaps (see the module doc in `settings-cache.ts`): (1) mutating `process.env` directly does not re-bake `${VAR}` interpolations on a hit — no file changes are involved, and there is currently no in-repo trigger on the ACP path; (2) a microsecond-scale TOCTOU if a `.env` file changes *during* a miss's load and never changes again afterwards — inherent to all mtime-based caches (same class as the `require` cache or tsc incremental); (3) an in-place overwrite that preserves mtime, size *and* inode is invisible — our own settings writes go through temp+rename (new inode) and are immune, and on filesystems that report inode 0 (some Windows cases) detection degrades to mtime+size. Separately, sessions sharing a cwd now share one `LoadedSettings` instance: this is safe (repo-wide grep shows no in-place writes to `.merged`; `setValue` persists via temp+rename and recomputes merged state) and it actually improves consistency — a `reloadScopeFromDisk` now benefits every session on that cwd instead of only one.
- Not validated / out of scope: only the three ACP session-creation call sites are switched. Every other `loadSettings` caller (settings ext-methods, permission loads, memory get/set, persistence callbacks) keeps its direct load-mutate-adopt semantics. Extension loading (part B) and command/skill snapshot caching (part C) are separate follow-ups per the roadmap.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to the perf roadmap in #6263 (P0-1 "session creation path caching", part A). Related: #6292 (settings concurrency fix that shaped the current call-site structure).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

为 `LoadedSettings` 增加以解析后的 workspace 目录为 key 的进程级缓存（`packages/cli/src/config/settings-cache.ts`），并把 ACP 的三个 session 创建入口（`newSession`、`loadSession`、`unstable_resumeSession`）切换过去。缓存命中时会重新校验一份指纹——四个 settings 文件路径及各自的 stat 签名（`mtimeMs:size:ino`）、`.env` 发现列表及签名、IDE 信任状态、`realpath(cwd)`、`realpath(os.homedir())`——全部一致才返回缓存实例。任何 settings 文件变更（含 `setValue` 自写）、任意层级 `.env` 的出现/删除/修改、`QWEN_HOME`/`HOME` 切换、IDE 信任翻转都会使条目失效并重新走完整 `loadSettings`。指纹采集 fail-open（任何意外的 fs 错误都退回全量加载，缓存层绝不成为新的失败来源），加载失败绝不缓存，缓存按 LRU 上限 64 个 workspace。

同时从 `environment.ts` 导出 `findEnvFiles`（一行改动），让缓存复用完全相同的 `.env` 发现语义（信任过滤、`QWEN_HOME` 重定向、home 候选顺序），而不是复制一份实现。

## 为什么需要

`qwen serve` 的 ACP child 是长驻进程、承载多个 session，而目前每次 `session/new` / `session/load` / resume 都在共享的 event loop 上同步重跑一遍完整 `loadSettings(cwd)`：四个 settings 作用域的 `existsSync`+`readFileSync`+`JSON.parse`、migration 检查、四次 `structuredClone`、`${VAR}` 重新插值、home `.env` 重读、`.env` 目录向上走查。对 serve 的典型负载（同一 cwd 反复建 session）而言这些全是重复劳动，并且阻塞所有活跃 session 共享的 event loop。本 PR 是 #6263 性能路线图中 P0-1「session 创建路径缓存化」的 A 部分（本次只做 settings；extension 加载与命令/skill 快照作为后续独立 PR）。

## 验证方式

新增单测覆盖：命中身份（同一实例 ⇒ 证明未重载）、每一种失效触发（user/workspace settings 编辑、workspace settings 新建与删除、更靠近 cwd 的 `.env` 出现、home `.env` 内容变化、`QWEN_HOME` 切换、`os.homedir()` 切换、`setValue` 自写）、加载失败不缓存 + 文件修复后恢复、不同 cwd 条目相互独立、LRU 淘汰。命令见英文节（`settings-cache.test.ts` 11/11，acpAgent 两个测试文件 184/184——缓存在其中被 mock 成 passthrough，保持按次 `mockReturnValue` 的既有用例语义；`typecheck`/`lint` 通过）。

真实链路 smoke：构建后启动 `node packages/cli/dist/index.js serve --port <port>`，对同一 cwd 反复 POST `/session`（`sessionScope: "thread"`）——首个请求之后都会经 `connection.newSession()` 复用同一个 ACP child，走 `loadSettingsCached`。在缓存版二进制上跑了 4 轮、每轮 40+ 次连续创建，零失败。

## 证据（Before & After）

微基准（每次全量 `loadSettings(ws)` vs 缓存命中 `loadSettingsCached(ws)`；每变体 N=200、预热 20 次；tmpdir 沙箱 fixture：user + workspace settings 文件、8 个 key 的 home `.env`、cwd 深 3 层；node v24.12.0，macOS + 企业 EDR——syscall 昂贵的环境，正是本优化最有价值的场景）。数据见英文节两张表：典型配置（~1.6 KB user settings、6 个 MCP server）**p50 5.1x**（3 轮范围 4.9–5.7x，每次省 ~0.5ms 同步 event-loop 时间，p99 尾部 ~3.7ms → ~0.2ms）；大配置（~13 KB、24 个 MCP server、120 项 `tools.exclude`）**p50 6.4x**（另一轮 8.7x）——命中成本与 settings 体积无关（stat 决定：~4 次 `statSync` + `.env` 向上走查 + 1–2 次 `realpathSync`），全量加载成本随体积增长，重量级配置下每次节省 ~1ms。

端到端（`qwen serve` + 每侧 3×40 次同 cwd thread-scope POST `/session`）：全链路 p50 约 70–80ms，由 `Config` 构建、auth 与 session 装配主导；同一二进制的轮间 p50 漂移（本机 EDR 噪音 ±20ms）远大于 settings 段的 ~0.5ms，HTTP 级计时无法分辨本改动的方向——如实呈现而非挑选有利轮次。e2e 同时充当上述功能 smoke。session 创建路径上剩余的大块开销正是后续 PR（extensions、命令/skill 快照）的目标。

## 风险与范围

- 主要风险/取舍：基于 stat 的失效有三个窄且已在 `settings-cache.ts` 模块注释中记录的缺口：(1) 直接改 `process.env` 不会在命中时重新烘焙 `${VAR}` 插值——不涉及任何文件变化，且 ACP 路径上目前没有仓内触发场景；(2) 若 `.env` 恰在一次 miss 的加载过程中被改且此后不再变化，存在微秒级 TOCTOU——所有 mtime 缓存（`require` 缓存、tsc incremental）的共同窗口；(3) 保持 mtime、size、inode 全不变的原地覆写不可见——自身写盘走 temp+rename（换 inode）天然免疫，inode 恒为 0 的文件系统（部分 Windows 情形）退化为 mtime+size 检测。另外，同 cwd 的 session 现在共享同一个 `LoadedSettings` 实例：这是安全的（全仓 grep 无对 `.merged` 的原地写；`setValue` 走 temp+rename 落盘并重算 merged），且反而改善一致性——`reloadScopeFromDisk` 现在对该 cwd 的所有 session 生效而非只有一个。
- 未验证/超出范围：只切换了 ACP 的三个 session 创建调用点。其余所有 `loadSettings` 调用方（settings ext-methods、权限加载、memory 读写、持久化回调）保持直读的 load-mutate-adopt 语义。extension 加载（B 部分）与命令/skill 快照缓存（C 部分）按路线图作为独立后续 PR。
- 破坏性变更/迁移说明：无。

## 关联

跟进 #6263 中的性能路线图（P0-1「session 创建路径缓存化」A 部分）。相关：#6292（settings 并发修复，塑造了当前调用点结构）。

</details>

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)
