### PR TITLE
fix(cli): preserve partial remote input JSONL records

### DIFF
--- a/packages/cli/src/remoteInput/RemoteInputWatcher.test.ts
+++ b/packages/cli/src/remoteInput/RemoteInputWatcher.test.ts
@@ -131,6 +131,26 @@ describe('RemoteInputWatcher', () => {
     expect(submitted).toEqual(['split']);
   });
 
+  it('consumes complete records but defers a trailing partial in the same poll', async () => {
+    watcher = new RemoteInputWatcher(inputFile);
+    const submitted: string[] = [];
+    watcher.setSubmitFn((text) => {
+      submitted.push(text);
+    });
+
+    fs.appendFileSync(
+      inputFile,
+      '{"type":"submit","text":"first"}\n{"type":"submit","text":"sec',
+    );
+    await watcher.checkForNewInput();
+    expect(submitted).toEqual(['first']);
+
+    fs.appendFileSync(inputFile, 'ond"}\n');
+    await watcher.checkForNewInput();
+
+    expect(submitted).toEqual(['first', 'second']);
+  });
+
   it('does not consume a trailing partial confirmation before newline', async () => {
     watcher = new RemoteInputWatcher(inputFile);
     const handler = vi.fn();

--- a/packages/cli/src/remoteInput/RemoteInputWatcher.test.ts
+++ b/packages/cli/src/remoteInput/RemoteInputWatcher.test.ts
@@ -114,6 +114,41 @@ describe('RemoteInputWatcher', () => {
     expect(submitted).toEqual(['after-bad-line']);
   });
 
+  it('does not consume a trailing partial submit command before newline', async () => {
+    watcher = new RemoteInputWatcher(inputFile);
+    const submitted: string[] = [];
+    watcher.setSubmitFn((text) => {
+      submitted.push(text);
+    });
+
+    fs.appendFileSync(inputFile, '{"type":"submit","text":"spl');
+    await watcher.checkForNewInput();
+    expect(submitted).toEqual([]);
+
+    fs.appendFileSync(inputFile, 'it"}\n');
+    await watcher.checkForNewInput();
+
+    expect(submitted).toEqual(['split']);
+  });
+
+  it('does not consume a trailing partial confirmation before newline', async () => {
+    watcher = new RemoteInputWatcher(inputFile);
+    const handler = vi.fn();
+    watcher.setConfirmationHandler(handler);
+
+    fs.appendFileSync(
+      inputFile,
+      '{"type":"confirmation_response","request_id":"req-7"',
+    );
+    await watcher.checkForNewInput();
+    expect(handler).not.toHaveBeenCalled();
+
+    fs.appendFileSync(inputFile, ',"allowed":true}\n');
+    await watcher.checkForNewInput();
+
+    expect(handler).toHaveBeenCalledWith('req-7', true);
+  });
+
   it('reads commands written after the input file is truncated', async () => {
     watcher = new RemoteInputWatcher(inputFile);
     const submitted: string[] = [];

--- a/packages/cli/src/remoteInput/RemoteInputWatcher.ts
+++ b/packages/cli/src/remoteInput/RemoteInputWatcher.ts
@@ -158,10 +158,19 @@ export class RemoteInputWatcher {
 
     if (currentSize <= this.bytesRead) return Promise.resolve();
 
-    const nextConsumedPrefixHash = this.hashFilePrefix(currentSize);
+    const consumeUntil = this.findLastCompleteRecordEnd(
+      this.bytesRead,
+      currentSize,
+    );
+    if (consumeUntil === null) {
+      return Promise.resolve();
+    }
+
+    const nextConsumedPrefixHash = this.hashFilePrefix(consumeUntil);
     this.reading = true;
     const stream = createReadStream(this.filePath, {
       start: this.bytesRead,
+      end: consumeUntil - 1,
       encoding: 'utf-8',
     });
     const rl = createInterface({ input: stream, crlfDelay: Infinity });
@@ -207,7 +216,7 @@ export class RemoteInputWatcher {
 
     return new Promise<void>((resolve) => {
       rl.on('close', () => {
-        this.bytesRead = currentSize;
+        this.bytesRead = consumeUntil;
         if (nextConsumedPrefixHash !== null) {
           this.consumedPrefixHash = nextConsumedPrefixHash;
         }
@@ -216,6 +225,41 @@ export class RemoteInputWatcher {
         resolve();
       });
     });
+  }
+
+  private findLastCompleteRecordEnd(start: number, end: number): number | null {
+    if (end <= start) return null;
+
+    let fd: number | null = null;
+    try {
+      fd = openSync(this.filePath, 'r');
+      const buffer = Buffer.allocUnsafe(Math.min(64 * 1024, end - start));
+      let remaining = end - start;
+      let position = start;
+      let lastLineBreak = -1;
+
+      while (remaining > 0) {
+        const bytesToRead = Math.min(buffer.length, remaining);
+        const bytesRead = readSync(fd, buffer, 0, bytesToRead, position);
+        if (bytesRead <= 0) break;
+        for (let i = 0; i < bytesRead; i++) {
+          if (buffer[i] === 0x0a) {
+            lastLineBreak = position + i;
+          }
+        }
+        remaining -= bytesRead;
+        position += bytesRead;
+      }
+
+      return lastLineBreak >= start ? lastLineBreak + 1 : null;
+    } catch (err) {
+      debugLogger.warn('RemoteInput: failed to scan complete records:', err);
+      return null;
+    } finally {
+      if (fd !== null) {
+        closeSync(fd);
+      }
+    }
   }
 
   private hasConsumedPrefixChanged(): boolean {


### PR DESCRIPTION
## What this PR does

Prevents remote input from consuming a trailing incomplete JSONL record before it has been terminated by a newline. Once the writer finishes the record, the watcher processes the submit or confirmation command normally.

## Why it's needed

### What Problem This Solves

Remote input is consumed as a newline-delimited JSONL command stream: a command should only be read once its record has been terminated by `\n`. That matters because external writers can append one JSONL record in multiple filesystem writes, leaving the file temporarily ending with a valid prefix of a command rather than a complete JSONL line.

For example, a sidecar or integration can split one `submit` command across two appends:

```ts
fs.appendFileSync(inputFile, '{"type":"submit","text":"spl');
await watcher.checkForNewInput(); // no complete JSONL record yet

fs.appendFileSync(inputFile, 'it"}\n');
await watcher.checkForNewInput(); // now parses {"type":"submit","text":"split"}
```

Before this change, `readNewLines()` read through the current file size. If the file ended with an unterminated fragment, the watcher could pass that fragment to `JSON.parse`, treat it as a malformed line, and advance `bytesRead` past it. When the writer later appended the remaining bytes, the watcher resumed after the skipped fragment, so the completed command could no longer be reconstructed by the watcher.

The practical impact is limited but real: incrementally written `submit` commands or `confirmation_response` approvals could be missed when the final newline arrived after a polling cycle. This PR keeps trailing unterminated bytes pending until the newline completes the JSONL record, while preserving the existing behavior for complete malformed lines.

### Changes

The watcher now finds the last complete newline-terminated record in the newly appended byte range before creating the read stream. It reads only through that complete boundary and advances `bytesRead` to the consumed boundary instead of the current file size.

Bytes after the last newline remain pending for the next poll. The command schema, polling model, submit queue, confirmation dispatch path, truncate/rewrite detection, and complete-malformed-line handling are intentionally unchanged.

### Evidence

The new split-submit test writes `{"type":"submit","text":"spl`, confirms that no submit is queued yet, then appends `it"}\n` and confirms that `split` is submitted.

The new split-confirmation test covers the same trailing-partial-record behavior for `confirmation_response`: the handler is not called while the record is unterminated, then receives `('req-7', true)` after the remaining bytes and newline are appended. The mixed-record test covers the reviewer-requested path where one poll contains a complete `submit` record followed by a trailing partial record; the complete command is consumed immediately and the partial command is deferred until its newline arrives.

Focused validation:

```text
Windows, Node.js v24.15.0:
npm --workspace packages/cli run test -- src/remoteInput/RemoteInputWatcher.test.ts

Test Files  1 passed (1)
Tests       10 passed (10)
```

```text
Ubuntu 22.04.5 LTS on WSL2, isolated /tmp clone, Linux Node.js v22.17.0:
npm --workspace packages/cli run test -- src/remoteInput/RemoteInputWatcher.test.ts

Test Files  1 passed (1)
Tests       10 passed (10)
```

The Linux run used a temporary clone under `/tmp` with a Linux Node.js tarball, so it did not reuse or rewrite the Windows checkout's `node_modules`. The suite includes the three split-record tests plus the existing malformed-line, queued-submit, shutdown, and truncate/rewrite coverage.

### Possible call chain / impact

```text
external writer / sidecar / integration
  -> appends JSONL command to --input-file or configured remote input path
  -> interactive startup creates RemoteInputWatcher
  -> checkForNewInput()
  -> readNewLines()
  -> parsed command dispatches to submit queue or confirmation handler
```

This PR only changes how the watcher decides the readable boundary for appended input. Incremental writers no longer miss a trailing partial command when a poll happens before the newline is appended.

Nearby behavior remains unchanged: complete malformed lines are still skipped, submits can still queue while the TUI is busy, confirmations still dispatch immediately once parsed, shutdown behavior is unchanged, and truncate/rewrite handling keeps its existing coverage.

## Reviewer Test Plan

### How to verify

Run `npm --workspace packages/cli run test -- src/remoteInput/RemoteInputWatcher.test.ts` and confirm the split submit and split confirmation cases are both processed only after the newline completes the JSONL record. The existing malformed-line, queued-submit, shutdown, and truncate/rewrite cases should continue to pass.

### Evidence (Before & After)

Before: a trailing partial submit or confirmation record could be consumed as a malformed line before the writer finished it, causing the completed command to be missed by the watcher. After: the watcher leaves the partial record unread, then processes it successfully after the remaining bytes and newline arrive.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍎 macOS  | ⚠️ not tested locally |
| 🪟 Windows | ✅ tested locally |
|  🐧 Linux  | ✅ tested via isolated Ubuntu-22.04 WSL2 clone |

### Environment (optional)

Windows local validation used Node.js v24.15.0. Linux validation used an isolated `/tmp` clone on Ubuntu-22.04 WSL2 with Linux Node.js v22.17.0, avoiding the Windows checkout and its `node_modules`.

## Risk & Scope

- Main risk or tradeoff: a trailing unterminated record is now deferred instead of consumed immediately, so command processing waits until the writer appends the final newline.
- Not validated / out of scope: changing the remote input file format, polling model, or writer-side behavior.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #6316

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 防止 remote input 在 JSONL 记录还没有以换行符结束前，就提前消费文件尾部的不完整记录。写入方补完整条记录并追加换行后，watcher 会正常处理 `submit` 或 `confirmation_response` 命令。

## Why it's needed

### What Problem This Solves

Remote input 是一条以换行符分隔的 JSONL 命令流：一条命令只有在记录以 `\n` 结束后，才应该被当作完整命令读取。关键点是，外部写入器不一定一次性写完整条 JSONL 记录；它可能把同一条命令拆成多次文件 append，所以文件尾部会短暂出现“只写了一半”的命令片段。

例如，边车进程或集成方可能把一条 `submit` 命令拆成两次写入：

```ts
fs.appendFileSync(inputFile, '{"type":"submit","text":"spl');
await watcher.checkForNewInput(); // 此时还没有完整 JSONL 记录

fs.appendFileSync(inputFile, 'it"}\n');
await watcher.checkForNewInput(); // 此时才解析为 {"type":"submit","text":"split"}
```

修复前，`readNewLines()` 会直接读到当前文件大小。如果文件尾部正好是不完整 JSON 片段，watcher 可能会把这段片段交给 `JSON.parse`，随后按 malformed line 跳过，并把 `bytesRead` 推进到这段字节之后。等写入方再追加剩余字节时，watcher 已经从后面的位置继续读取，无法再把前半段和后半段拼回原始命令。

实际影响是窄范围但真实的：增量写入的 `submit` 命令或 `confirmation_response` 确认响应，可能在最终换行到达后仍被 watcher 漏掉。这个 PR 会把尚未以换行结束的尾部字节保留到下一轮轮询，直到换行补齐 JSONL 记录；完整但格式错误的行仍按原有逻辑跳过。

### Changes

现在 watcher 会在新增字节范围内先找到最后一条完整的、以换行结束的记录。随后它只读取到这个完整边界，并把 `bytesRead` 推进到实际已消费的位置，而不是直接推进到当前文件大小。

最后一个换行符之后的尾部字节会留到下一轮轮询继续等待。命令 schema、轮询模型、submit 队列、confirmation 分发路径、truncate/rewrite 检测，以及完整 malformed line 的处理逻辑都保持不变。

### Evidence

新增的 split-submit 测试会先写入半条 `{"type":"submit","text":"spl`，确认此时不会提交任何内容；再追加 `it"}\n`，确认最终提交的是 `split`。

新增的 split-confirmation 测试对 `confirmation_response` 做同样覆盖：记录尚未以换行结束时 handler 不会触发；追加剩余字节和换行后，handler 会收到 `('req-7', true)`。新增的 mixed-record 测试覆盖 reviewer 指出的路径：同一次 poll 中同时包含一条完整的 `submit` 记录和一条尾部 partial 记录；完整命令会立即消费，partial 命令会等换行到达后再处理。

聚焦验证：

```text
Windows, Node.js v24.15.0:
npm --workspace packages/cli run test -- src/remoteInput/RemoteInputWatcher.test.ts

Test Files  1 passed (1)
Tests       10 passed (10)
```

```text
Ubuntu 22.04.5 LTS on WSL2, isolated /tmp clone, Linux Node.js v22.17.0:
npm --workspace packages/cli run test -- src/remoteInput/RemoteInputWatcher.test.ts

Test Files  1 passed (1)
Tests       10 passed (10)
```

Linux 侧验证使用 `/tmp` 下的临时 clone 和 Linux Node.js tarball，没有复用或改写 Windows checkout 的 `node_modules`。这 10 个测试包括三个 split-record 场景，以及已有 malformed line、queued submit、shutdown、truncate/rewrite 等回归覆盖。

### Possible call chain / impact

```text
外部写入器 / 边车进程 / 集成方
  -> 向 --input-file 或配置的 remote input 路径追加 JSONL 命令
  -> 交互式启动阶段创建 RemoteInputWatcher
  -> checkForNewInput()
  -> readNewLines()
  -> 解析后的命令进入 submit 队列或 confirmation handler
```

这个 PR 只改变 watcher 对“新增输入可读取边界”的判断。对于增量写入器来说，poll 发生在最终换行到达之前时，尾部 partial command 不会再被提前跳过。

相邻行为保持不变：完整但格式错误的行仍会跳过；TUI 忙碌时 submit 仍可排队；confirmation 解析后仍立即分发；shutdown 行为不变；truncate/rewrite 处理继续由现有测试覆盖。

## Reviewer Test Plan

### How to verify

运行 `npm --workspace packages/cli run test -- src/remoteInput/RemoteInputWatcher.test.ts`，确认 split submit 和 split confirmation 都只会在换行补齐 JSONL 记录后被处理。同时，已有 malformed line、queued submit、shutdown、truncate/rewrite 场景应继续通过。

### Evidence (Before & After)

修复前：尾部不完整的 submit 或 confirmation 记录可能在写入方完成前被 watcher 当作 malformed line 消费，导致补齐后的命令被 watcher 漏掉。

修复后：watcher 会保留未完成记录，等剩余字节和换行到达后再成功处理。

### Tested on

本地 Windows 已验证；Linux 已通过 Ubuntu-22.04 WSL2 隔离临时 clone 验证；macOS 未在本地验证，留给项目 CI 覆盖。

### Environment (optional)

Windows 本地验证使用 Node.js v24.15.0。Linux 验证使用 Ubuntu-22.04 WSL2 + Linux Node.js v22.17.0，并在 `/tmp` 临时 clone 内安装依赖，避免污染 Windows checkout。

## Risk & Scope

主要风险或权衡是：watcher 现在会把尚未以换行结束的尾部记录延后处理，所以命令处理会等到写入方追加最终换行符之后再发生。

不改变 remote input 文件格式、轮询模型、写入方行为、命令 schema、submit 队列或 confirmation 分发语义。

没有破坏性变更或迁移要求。

## Linked Issues

Fixes #6316

</details>