### PR TITLE
fix(web-shell): keep skill slash commands after starting a new session

### DIFF
--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -4355,6 +4355,63 @@ describe('DaemonSessionProvider', () => {
     ).not.toHaveBeenCalled();
   });
 
+  it('keeps workspace skill slash commands after clearing so /review still autocompletes', async () => {
+    const firstSession = createMockSession({
+      sessionId: 'session-a',
+      supportedCommands: vi.fn(async () => ({
+        v: 1 as const,
+        sessionId: 'session-a',
+        availableCommands: [],
+        availableSkills: ['review'],
+      })),
+    });
+    sdkMocks.sessions.push(firstSession);
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: 'session-a',
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+    expect(connection?.commands?.map((command) => command.name)).toContain(
+      'review',
+    );
+    expect(connection?.skills).toContain('review');
+
+    await act(async () => {
+      await actions?.clearSession();
+    });
+    for (let i = 0; i < 10 && connection?.sessionId !== undefined; i++) {
+      await act(async () => {
+        await wait(5);
+        await flushPromises();
+      });
+    }
+
+    // Clearing returns to the deferred pre-first-prompt state (no sessionId),
+    // but the workspace-scoped skill command must survive so '/rev' + Tab keeps
+    // completing '/review' in the new session before its first prompt creates a
+    // session (matches the initial deferred-connect guarantee from #6153).
+    expect(connection).not.toHaveProperty('sessionId');
+    expect(connection?.commands?.map((command) => command.name)).toContain(
+      'review',
+    );
+    expect(connection?.skills).toContain('review');
+    // The session-scoped raw snapshots are still dropped so the next session
+    // refetches instead of reusing stale metadata.
+    expect(connection).not.toHaveProperty('supportedCommands');
+    expect(connection).not.toHaveProperty('context');
+  });
+
   it('ignores streamed events from a session after it is cleared', async () => {
     const streamStarted = createDeferred<void>();
     const releaseOldEvent = createDeferred<void>();

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -4486,6 +4486,73 @@ describe('DaemonSessionProvider', () => {
     expect(connection?.skills).toEqual([]);
   });
 
+  it('keeps preserved commands when the next supported-commands fetch fails', async () => {
+    const firstSession = createMockSession({
+      sessionId: 'session-a',
+      supportedCommands: vi.fn(async () => ({
+        v: 1 as const,
+        sessionId: 'session-a',
+        availableCommands: [
+          { name: 'cmd-a', description: 'Command A', input: null },
+        ],
+        availableSkills: ['review'],
+      })),
+    });
+    const failingSession = createMockSession({
+      sessionId: 'session-b',
+      supportedCommands: vi.fn(async () => {
+        throw new Error('supported-commands unavailable');
+      }),
+    });
+    sdkMocks.sessions.push(firstSession, failingSession);
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: 'session-a',
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+    expect(connection?.commands?.map((command) => command.name)).toContain(
+      'cmd-a',
+    );
+
+    await act(async () => {
+      await actions?.clearSession();
+    });
+
+    // A skipped or failed fetch is not authoritative — unlike a fulfilled empty
+    // snapshot it must not clobber the preserved list. supportedCommands()
+    // rejecting here leaves supportedCommands === undefined, so the commands
+    // survive rather than being wiped.
+    const providerActions = requireActions(actions);
+    await act(async () => {
+      await providerActions.createSession();
+    });
+    let attach: Promise<void> | undefined;
+    act(() => {
+      attach = providerActions.attachSession();
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+    await attach;
+
+    expect(connection).toMatchObject({ sessionId: 'session-b' });
+    expect(connection?.commands?.map((command) => command.name)).toContain(
+      'cmd-a',
+    );
+    expect(connection?.skills).toContain('review');
+  });
+
   it('ignores streamed events from a session after it is cleared', async () => {
     const streamStarted = createDeferred<void>();
     const releaseOldEvent = createDeferred<void>();

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -4412,6 +4412,80 @@ describe('DaemonSessionProvider', () => {
     expect(connection).not.toHaveProperty('context');
   });
 
+  it('drops preserved commands when the next session reports an empty list', async () => {
+    const firstSession = createMockSession({
+      sessionId: 'session-a',
+      supportedCommands: vi.fn(async () => ({
+        v: 1 as const,
+        sessionId: 'session-a',
+        availableCommands: [
+          { name: 'cmd-a', description: 'Command A', input: null },
+        ],
+        availableSkills: ['review'],
+      })),
+    });
+    const emptySession = createMockSession({
+      sessionId: 'session-b',
+      supportedCommands: vi.fn(async () => ({
+        v: 1 as const,
+        sessionId: 'session-b',
+        availableCommands: [],
+        availableSkills: [],
+      })),
+    });
+    // session-a loads on mount; the detached session created after the clear
+    // pops session-b next.
+    sdkMocks.sessions.push(firstSession, emptySession);
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: 'session-a',
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+    expect(connection?.commands?.map((command) => command.name)).toContain(
+      'cmd-a',
+    );
+
+    await act(async () => {
+      await actions?.clearSession();
+    });
+    // The preserved list keeps autocompleting through the clear (commands is
+    // still present here)...
+    expect(connection?.commands?.map((command) => command.name)).toContain(
+      'cmd-a',
+    );
+
+    // ...but once the next session's supported-commands fetch comes back empty,
+    // that fulfilled snapshot is authoritative — the stale commands must not
+    // survive it.
+    const providerActions = requireActions(actions);
+    await act(async () => {
+      await providerActions.createSession();
+    });
+    let attach: Promise<void> | undefined;
+    act(() => {
+      attach = providerActions.attachSession();
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+    await attach;
+
+    expect(connection).toMatchObject({ sessionId: 'session-b' });
+    expect(connection?.commands).toEqual([]);
+    expect(connection?.skills).toEqual([]);
+  });
+
   it('ignores streamed events from a session after it is cleared', async () => {
     const streamStarted = createDeferred<void>();
     const releaseOldEvent = createDeferred<void>();

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -840,8 +840,16 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                 ? { clientId: activeSession.clientId }
                 : {}),
               workspaceCwd: activeSession.workspaceCwd,
-              commands: commands.length > 0 ? commands : current.commands,
-              skills: skills.length > 0 ? skills : current.skills,
+              // A fulfilled supported-commands fetch is authoritative even when
+              // it returns an empty list: fall back to the preserved
+              // `current.commands` only when the fetch was skipped or failed
+              // (supportedCommands === undefined). Keying on length instead
+              // would let a genuinely-empty snapshot leave a stale command list
+              // in place (see getConnectionAfterSessionClear, which now
+              // preserves commands across a clear).
+              commands:
+                supportedCommands !== undefined ? commands : current.commands,
+              skills: supportedCommands !== undefined ? skills : current.skills,
               models: sessionModels.length > 0 ? sessionModels : current.models,
               currentModel: sessionCurrentModel ?? current.currentModel,
               currentMode: currentMode ?? current.currentMode,

--- a/packages/webui/src/daemon/session/actions.test.ts
+++ b/packages/webui/src/daemon/session/actions.test.ts
@@ -43,10 +43,13 @@ describe('getConnectionAfterSessionClear', () => {
     expect(next).not.toHaveProperty('clientId');
     expect(next).not.toHaveProperty('displayName');
     expect(next).not.toHaveProperty('tokenCount');
-    expect(next).not.toHaveProperty('commands');
-    expect(next).not.toHaveProperty('skills');
     expect(next).not.toHaveProperty('supportedCommands');
     expect(next).not.toHaveProperty('context');
+    // Workspace-scoped slash commands and skills survive a clear so skill-backed
+    // commands (e.g. /review) keep autocompleting in the fresh deferred session
+    // before its first prompt creates a session (mirrors #6153 / #6066).
+    expect(next.commands).toEqual([commandInfo('old-command')]);
+    expect(next.skills).toEqual(['old-skill']);
   });
 
   it('preserves a concurrently loaded session', () => {

--- a/packages/webui/src/daemon/session/actions.test.ts
+++ b/packages/webui/src/daemon/session/actions.test.ts
@@ -52,6 +52,33 @@ describe('getConnectionAfterSessionClear', () => {
     expect(next.skills).toEqual(['old-skill']);
   });
 
+  it('handles commands and skills being undefined before clear', () => {
+    // Optional fields: clearing before the first available_commands_update
+    // (open the app, immediately start a new chat) leaves them absent. The
+    // delete calls are harmless no-ops and nothing is fabricated.
+    const next = getConnectionAfterSessionClear(
+      {
+        status: 'disconnected',
+        workspaceCwd: '/workspace',
+        sessionId: 'session-a',
+        clientId: 'client-a',
+        supportedCommands: supportedCommandsStatus('session-a'),
+        context: contextStatus('session-a'),
+      } as DaemonConnectionState,
+      'session-a',
+    );
+
+    expect(next).toMatchObject({
+      status: 'connected',
+      workspaceCwd: '/workspace',
+    });
+    expect(next).not.toHaveProperty('sessionId');
+    expect(next).not.toHaveProperty('commands');
+    expect(next).not.toHaveProperty('skills');
+    expect(next).not.toHaveProperty('supportedCommands');
+    expect(next).not.toHaveProperty('context');
+  });
+
   it('preserves a concurrently loaded session', () => {
     const next = getConnectionAfterSessionClear(
       {

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -81,10 +81,19 @@ export function getConnectionAfterSessionClear(
     delete next.displayName;
     delete next.tokenUsage;
     delete next.tokenCount;
-    delete next.commands;
-    delete next.skills;
+    // Drop the session-scoped raw snapshots (both carry the cleared
+    // sessionId), which also makes the effect's canReuseSessionMetadata
+    // check refetch fresh data for the next session.
     delete next.supportedCommands;
     delete next.context;
+    // Keep `commands`/`skills`: they are workspace-scoped (skills, custom,
+    // MCP-prompt and workflow slash commands all live at the workspace/config
+    // level, not the session), so they stay valid after the session is
+    // cleared. Clearing starts a fresh deferred session that is not created
+    // until the first prompt (#6066); preserving these keeps skill-backed
+    // slash commands like /review autocompleting in that window — the same
+    // guarantee #6153 added for the initial deferred connect. The next
+    // session's available_commands_update refreshes them once it lands.
   }
   return {
     ...next,

--- a/packages/webui/src/daemon/session/mappers.test.ts
+++ b/packages/webui/src/daemon/session/mappers.test.ts
@@ -13,7 +13,38 @@ import {
   getReplayTokenCount,
   getReplayTokenUsage,
   mapWorkspaceSkills,
+  updateConnectionFromDaemonEvent,
 } from './mappers.js';
+import type { DaemonConnectionState } from './types.js';
+
+function availableCommandsEvent(
+  availableCommands: Array<Record<string, unknown>>,
+  availableSkills: string[],
+): DaemonEvent {
+  return {
+    id: 1,
+    v: 1,
+    type: 'session_update',
+    data: {
+      update: {
+        sessionUpdate: 'available_commands_update',
+        availableCommands,
+        availableSkills,
+      },
+    },
+  } as DaemonEvent;
+}
+
+function applyEvent(
+  current: DaemonConnectionState,
+  event: DaemonEvent,
+): DaemonConnectionState {
+  let next = current;
+  updateConnectionFromDaemonEvent(event, (update) => {
+    next = typeof update === 'function' ? update(next) : update;
+  });
+  return next;
+}
 
 function usageEvent(
   id: number,
@@ -215,5 +246,44 @@ describe('mapWorkspaceSkills', () => {
         },
       },
     ]);
+  });
+});
+
+describe('updateConnectionFromDaemonEvent', () => {
+  it('replaces commands and skills from an available_commands_update', () => {
+    const next = applyEvent(
+      { status: 'connected', workspaceCwd: '/workspace' },
+      availableCommandsEvent(
+        [{ name: 'review', description: 'Review a PR', input: null }],
+        ['review'],
+      ),
+    );
+
+    expect(next.commands?.map((command) => command.name)).toEqual(['review']);
+    expect(next.skills).toEqual(['review']);
+  });
+
+  it('clears stale commands when the update reports an empty list', () => {
+    // The daemon snapshot is authoritative: a list that shrank to empty must
+    // not leave the previous commands autocompleting. Keying on length would
+    // preserve the stale entries.
+    const next = applyEvent(
+      {
+        status: 'connected',
+        workspaceCwd: '/workspace',
+        commands: [
+          {
+            name: 'review',
+            description: '',
+            raw: { name: 'review', description: '', input: null },
+          },
+        ],
+        skills: ['review'],
+      },
+      availableCommandsEvent([], []),
+    );
+
+    expect(next.commands).toEqual([]);
+    expect(next.skills).toEqual([]);
   });
 });

--- a/packages/webui/src/daemon/session/mappers.ts
+++ b/packages/webui/src/daemon/session/mappers.ts
@@ -242,9 +242,14 @@ export function updateConnectionFromDaemonEvent(
     }
     if (getString(update, 'sessionUpdate') === 'available_commands_update') {
       const { commands, skills } = mapAvailableCommandsUpdate(update);
+      // An available_commands_update is the daemon's authoritative snapshot of
+      // the current slash commands, so assign it directly (matching `skills`)
+      // rather than keeping the previous list when it is empty — otherwise a
+      // command list that shrank to empty would leave stale entries
+      // autocompleting.
       setConnection((current) => ({
         ...current,
-        commands: commands.length > 0 ? commands : current.commands,
+        commands,
         skills,
       }));
     }


### PR DESCRIPTION
## What this PR does

Preserves the workspace-scoped slash-command list when the user starts a new chat, so skill-backed commands keep autocompleting in the new session before its first prompt. Starting a new session now only discards the session-scoped snapshots (the supported-commands and context payloads that carry the cleared session id), while keeping the derived `commands`/`skills` that the composer's slash menu reads.

## Why it's needed

Every "new session" entry point in the web shell — the sidebar button, the composer quick action, and the `/new`, `/reset` and `/clear` commands — routes through `clearSession()`, which calls `getConnectionAfterSessionClear`. That helper deleted `connection.commands` and `connection.skills`. Nothing repopulated them: after the old session's SSE stream closes the connection loop returns early on `manualSessionClear`, and the deferred skill-fetch path never re-runs. So in the newly created (second) session, before the first prompt, the composer fell back to the hardcoded local command list, which omits skills. Typing `/rev` and pressing Tab therefore would not complete `/review`.

This is the same class of gap that #6153 fixed for the initial deferred connect (before the very first prompt), except it was triggered on the clear path and left unfixed. Skills, custom commands, MCP-prompt commands and workflow commands are all workspace/config level, not session level, so they stay valid across a clear within the same workspace and should not be dropped.

## Reviewer Test Plan

### How to verify

1. `qwen serve --web`, open the web shell, and let the workspace expose a bundled skill such as `/review`.
2. In the first session, type `/rev` and press Tab — it completes `/review`.
3. Start a new chat (sidebar "New Session", or run `/new`).
4. In the new session, before sending any prompt, type `/rev` and press Tab.
   - Before: nothing happens — the slash menu has no `/review`, so Tab can't complete it.
   - After: it completes to `/review`, same as the first session.

Automated coverage:

- `packages/webui` → `npx vitest run src/daemon/session/` — 177 tests pass, including:
  - `actions.test.ts` › `getConnectionAfterSessionClear` › `clears session fields …` (asserts `commands`/`skills` survive, session-scoped fields are dropped).
  - `DaemonSessionProvider.test.tsx` › `keeps workspace skill slash commands after clearing so /review still autocompletes` — drives the real `clearSession` through the provider and asserts `connection.commands` still contains `review`.
- Mutation check: restoring the old `delete next.commands` / `delete next.skills` makes both new tests fail, confirming they lock the behavior.
- `npx tsc --noEmit`, `eslint` and `prettier --check` on the changed files all pass.

### Evidence (Before & After)

The user-visible effect is the slash-menu / Tab completion described above. It is captured behaviorally by the provider-level integration test (real `clearSession`): before the change the assertion `connection.commands` contains `review` fails after a clear; after the change it passes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local unit/integration tests via `vitest` in `packages/webui`.

## Risk & Scope

- Main risk or tradeoff: after a clear, the preserved command list could briefly be stale if the workspace's available commands changed mid-session (e.g. an MCP server disconnected). It is refreshed by the next session's `available_commands_update`, and the session-scoped `supportedCommands`/`context` are still dropped so metadata is refetched (no stale reuse).
- Not validated / out of scope: no change to how commands are fetched or to the daemon; only the clear-time state reduction changed.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在用户新建会话时，保留工作区级的斜杠命令列表，使得技能类命令在新会话首条 prompt 之前仍能自动补全。新建会话现在只丢弃 session 级的快照（带着被清理 sessionId 的 supported-commands 和 context），而保留输入框斜杠面板读取的 `commands`/`skills`。

## 为什么需要

Web Shell 里所有"新建会话"入口——侧边栏按钮、输入框快捷动作，以及 `/new`、`/reset`、`/clear` 命令——都汇入 `clearSession()`，它会调用 `getConnectionAfterSessionClear`。该函数删除了 `connection.commands` 和 `connection.skills`，而且没人回填：旧会话 SSE 流关闭后，连接循环在 `manualSessionClear` 处提前返回，抓取技能的 deferred 分支也不会再跑。于是在新建的（第 2 个）会话里、首条 prompt 之前，输入框退化成写死的本地命令列表（不含技能）。此时输入 `/rev` 按 Tab 补不出 `/review`。

这与 #6153 修复的"初始 deferred 连接（首条 prompt 之前）丢技能命令"是同一类问题，只是触发点在 clear 路径上，之前没修到。技能、自定义命令、MCP prompt、工作流命令都是工作区/配置级、而非会话级，在同一工作区里跨会话依然有效，因此不应被删除。

## 审阅者测试计划

### 如何验证

1. `qwen serve --web` 打开 web shell，工作区暴露一个内置技能如 `/review`。
2. 在第 1 个会话输入 `/rev` 按 Tab —— 补全为 `/review`。
3. 新建会话（侧边栏 "New Session" 或执行 `/new`）。
4. 在新会话里，不发任何 prompt，输入 `/rev` 按 Tab。
   - 修复前：无反应——斜杠面板里没有 `/review`，Tab 补不出。
   - 修复后：补全为 `/review`，与第 1 个会话一致。

自动化覆盖：

- `packages/webui` → `npx vitest run src/daemon/session/` —— 177 测试通过，含：
  - `actions.test.ts` › `getConnectionAfterSessionClear` › `clears session fields …`（断言 `commands`/`skills` 保留、session 级字段被删）。
  - `DaemonSessionProvider.test.tsx` › `keeps workspace skill slash commands after clearing so /review still autocompletes` —— 通过 provider 驱动真实 `clearSession`，断言清理后 `connection.commands` 仍含 `review`。
- 变异验证：把旧的 `delete next.commands` / `delete next.skills` 加回去，两个新测试都变红，确认测试锁住了行为。
- 对改动文件的 `npx tsc --noEmit`、`eslint`、`prettier --check` 全部通过。

### 证据（前 / 后）

用户可见效果即上文的斜杠面板 / Tab 补全，由 provider 级集成测试（真实 `clearSession`）行为化地捕获：修复前"清理后 `connection.commands` 含 `review`"断言失败，修复后通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

在 `packages/webui` 用 `vitest` 跑本地单测/集成测试。

## 风险与范围

- 主要风险/取舍：清理后保留的命令列表，若工作区可用命令在会话中途变化（如某 MCP server 断开）可能短暂陈旧。它会被下个会话的 `available_commands_update` 刷新，且 session 级的 `supportedCommands`/`context` 仍被丢弃以强制重取（不会复用陈旧数据）。
- 未验证 / 范围外：不改命令抓取方式、不改 daemon；仅改动清理时的状态裁剪。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

N/A

</details>
