### PR TITLE
test(core): cover full:false branch of recordAttachedFileRead for truncated @-attachments

### DIFF
--- a/packages/core/src/utils/readManyFiles.test.ts
+++ b/packages/core/src/utils/readManyFiles.test.ts
@@ -522,5 +522,37 @@ describe('readManyFiles', () => {
         expect(status.entry.lastReadCacheable).toBe(false);
       }
     });
+
+    it('records a truncated @-attached file as a partial (full: false) read', async () => {
+      // This attachment exceeds both truncation caps the mock config sets —
+      // the 1000-line `getTruncateToolOutputLines()` limit and the 2500-char
+      // `getTruncateToolOutputThreshold()` — so `processSingleFileContent`
+      // marks it `isTruncated`, which `recordAttachedFileRead` maps to
+      // `full: false`. On a fresh cache a partial read leaves the sticky
+      // `lastReadWasFull` at its `false` default, so this cleanly separates
+      // correct behaviour (false) from the bug it guards against: recording a
+      // truncated attachment as `full: true` would silently clear Edit /
+      // WriteFile prior-read enforcement for a file the model only partly saw.
+      // The file is still cacheable (text with a known `originalLineCount`).
+      const relativePath = 'big.ts';
+      const absolutePath = path.join(tempRootDir, relativePath);
+      const big = Array.from(
+        { length: 1500 },
+        (_, i) => `const x${i} = ${i};`,
+      ).join('\n');
+      await fs.writeFile(absolutePath, big);
+      const cache = new FileReadCache();
+      const mockConfig = createMockConfigWithCache(tempRootDir, cache);
+
+      await readManyFiles(mockConfig, { paths: [relativePath] });
+
+      const stats = nodeFs.statSync(absolutePath);
+      const status = cache.check(stats);
+      expect(status.state).toBe('fresh');
+      if (status.state === 'fresh') {
+        expect(status.entry.lastReadWasFull).toBe(false);
+        expect(status.entry.lastReadCacheable).toBe(true);
+      }
+    });
   });
 });


### PR DESCRIPTION
## What this PR does

Adds a single regression test covering the `full: false` branch of `recordAttachedFileRead` in `packages/core/src/utils/readManyFiles.ts`, introduced by #6295. The test attaches a file large enough to be truncated and asserts it is recorded in the session `FileReadCache` as a partial read (`lastReadWasFull: false`) while remaining cacheable.

## Why it's needed

The maintainer-bot review on #6295 flagged that the `full: false` branch had no coverage. Every existing prior-read enforcement test uses tiny files, so `isTruncated` is always `undefined` and `full` is always `true` — the truncated path was never exercised. Because `full` gates Edit/WriteFile prior-read enforcement, a truncated `@`-attachment mistakenly recorded as `full: true` would silently clear enforcement for a file the model only partly saw. This test locks in the correct behavior so that regression cannot slip back in unnoticed. Test-only; no production code changes.

## Reviewer Test Plan

### How to verify

The new test builds a 1500-line fixture, which exceeds both truncation caps the mock config sets (`getTruncateToolOutputLines() = 1000` and `getTruncateToolOutputThreshold() = 2500`), so `processSingleFileContent` returns `isTruncated: true` and the attachment is recorded with `full: false`. On a fresh cache the sticky `lastReadWasFull` stays at its `false` default for a partial read, so the assertion cleanly separates correct (`false`) from the bug (`true`).

Run:

```
npx vitest run packages/core/src/utils/readManyFiles.test.ts
```

Expected: all tests pass (26 including the new one).

Mutation check confirming the test actually guards the branch: temporarily change `full: !result.isTruncated` to `full: true` in `recordAttachedFileRead` — the new test fails with `expected true to be false`; revert and it passes again.

```
npx vitest run packages/core/src/utils/readManyFiles.test.ts   # 26 passed
npm run typecheck                                              # clean
npx eslint packages/core/src/utils/readManyFiles.test.ts --max-warnings 0   # clean
```

### Evidence (Before & After)

N/A — test-only change, no user-visible behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only (vitest).

## Risk & Scope

- Main risk or tradeoff: None — purely additive test, no production code touched.
- Not validated / out of scope: Only ran the affected package's unit tests locally; relying on CI for Windows/Linux.
- Breaking changes / migration notes: None.

## Linked Issues

Follow-up to #6295 (closes the coverage gap flagged in its maintainer-bot review on `readManyFiles.test.ts`). No closing keyword — the referenced issue #6289 is already resolved by #6295.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

为 #6295 引入的 `packages/core/src/utils/readManyFiles.ts` 中 `recordAttachedFileRead` 的 `full: false` 分支补充了一个回归测试。该测试附加一个足够大、会被截断的文件，并断言它在会话 `FileReadCache` 中被记录为部分读取（`lastReadWasFull: false`），同时仍然是可缓存的。

## 为什么需要它

#6295 的维护者机器人审查指出 `full: false` 分支没有任何测试覆盖。现有的所有 prior-read 强制测试都使用很小的文件，因此 `isTruncated` 始终为 `undefined`、`full` 始终为 `true`，截断路径从未被触发。由于 `full` 控制着 Edit/WriteFile 的 prior-read 强制检查，一个被截断的 `@` 附件若被错误地记录为 `full: true`，会在模型只看到部分内容的情况下悄悄地清除强制检查。此测试锁定正确行为，防止该回归在无人察觉的情况下再次出现。仅为测试，无生产代码改动。

## 审阅者测试计划

新测试构造了一个 1500 行的样例文件，超过了 mock 配置设置的两个截断上限（`getTruncateToolOutputLines() = 1000` 与 `getTruncateToolOutputThreshold() = 2500`），因此 `processSingleFileContent` 返回 `isTruncated: true`，附件以 `full: false` 记录。在全新的缓存上，部分读取会让粘性的 `lastReadWasFull` 保持其 `false` 默认值，从而将正确行为（`false`）与缺陷（`true`）清晰区分开。

运行：

```
npx vitest run packages/core/src/utils/readManyFiles.test.ts
```

预期：全部通过（含新测试共 26 个）。

验证测试确实守护该分支的变异检查：临时将 `recordAttachedFileRead` 中的 `full: !result.isTruncated` 改为 `full: true`，新测试会以 `expected true to be false` 失败；改回后重新通过。

</details>
