### PR TITLE
Restart stalled ACP bridge for channels

### DIFF
--- a/packages/channels/base/src/AcpBridge.test.ts
+++ b/packages/channels/base/src/AcpBridge.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { AcpBridge } from './AcpBridge.js';
+import { ACP_EVENT_LOOP_STALL_RESTART_MS, AcpBridge } from './AcpBridge.js';
 
 const child = vi.hoisted(() => {
   class MockEmitter {
@@ -84,7 +84,7 @@ describe('AcpBridge', () => {
     const proc = child.instances[0]!;
 
     proc.stderr.write(
-      '[perf] acp agent event loop stall: max=917512.388607ms\n',
+      `[perf] acp agent event loop stall: max=${ACP_EVENT_LOOP_STALL_RESTART_MS + 1000}ms\n`,
     );
 
     expect(proc.kill).toHaveBeenCalledTimes(1);
@@ -99,7 +99,9 @@ describe('AcpBridge', () => {
     await bridge.start();
     const proc = child.instances[0]!;
 
-    proc.stderr.write('[perf] acp agent event loop stall: max=2500ms\n');
+    proc.stderr.write(
+      `[perf] acp agent event loop stall: max=${ACP_EVENT_LOOP_STALL_RESTART_MS - 1000}ms\n`,
+    );
 
     expect(proc.kill).not.toHaveBeenCalled();
   });

--- a/packages/channels/base/src/AcpBridge.test.ts
+++ b/packages/channels/base/src/AcpBridge.test.ts
@@ -79,12 +79,38 @@ describe('AcpBridge', () => {
       cliEntryPath: '/tmp/qwen',
       cwd: '/tmp',
     });
+    const disconnected = vi.fn();
+    bridge.on('disconnected', disconnected);
+
+    await bridge.start();
+    const proc = child.instances[0]!;
+    proc.kill.mockImplementation(() => {
+      proc.killed = true;
+      proc.emit('exit', null, 'SIGKILL');
+      return true;
+    });
+
+    proc.stderr.write(
+      `[perf] acp agent event loop stall: max=${ACP_EVENT_LOOP_STALL_RESTART_MS + 1000}ms\n`,
+    );
+
+    expect(proc.kill).toHaveBeenCalledTimes(1);
+    expect(proc.kill).toHaveBeenCalledWith('SIGKILL');
+    expect(bridge.isConnected).toBe(false);
+    expect(disconnected).toHaveBeenCalledWith(null, 'SIGKILL');
+  });
+
+  it('kills the ACP child when a stall line is coalesced with prior stderr', async () => {
+    const bridge = new AcpBridge({
+      cliEntryPath: '/tmp/qwen',
+      cwd: '/tmp',
+    });
 
     await bridge.start();
     const proc = child.instances[0]!;
 
     proc.stderr.write(
-      `[perf] acp agent event loop stall: max=${ACP_EVENT_LOOP_STALL_RESTART_MS + 1000}ms\n`,
+      `debug line\n[perf] acp agent event loop stall: max=${ACP_EVENT_LOOP_STALL_RESTART_MS + 1000}ms\n`,
     );
 
     expect(proc.kill).toHaveBeenCalledTimes(1);

--- a/packages/channels/base/src/AcpBridge.test.ts
+++ b/packages/channels/base/src/AcpBridge.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { AcpBridge } from './AcpBridge.js';
+
+const child = vi.hoisted(() => {
+  class MockEmitter {
+    private listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+
+    on(eventName: string, listener: (...args: unknown[]) => void): this {
+      const listeners = this.listeners.get(eventName) ?? [];
+      listeners.push(listener);
+      this.listeners.set(eventName, listeners);
+      return this;
+    }
+
+    emit(eventName: string, ...args: unknown[]): boolean {
+      const listeners = this.listeners.get(eventName) ?? [];
+      for (const listener of listeners) {
+        listener(...args);
+      }
+      return listeners.length > 0;
+    }
+  }
+
+  class MockStderr extends MockEmitter {
+    write(data: string): void {
+      this.emit('data', Buffer.from(data));
+    }
+  }
+
+  class MockChild extends MockEmitter {
+    stdout = {};
+    stdin = {};
+    stderr = new MockStderr();
+    killed = false;
+    exitCode: number | null = null;
+    kill = vi.fn(() => {
+      this.killed = true;
+      this.exitCode = null;
+      return true;
+    });
+  }
+
+  return {
+    instances: [] as MockChild[],
+    MockChild,
+    spawn: vi.fn(() => {
+      const instance = new MockChild();
+      child.instances.push(instance);
+      return instance;
+    }),
+  };
+});
+
+vi.mock('node:child_process', () => ({
+  spawn: child.spawn,
+}));
+
+vi.mock('node:stream', () => ({
+  Readable: { toWeb: vi.fn(() => ({})) },
+  Writable: { toWeb: vi.fn(() => ({})) },
+}));
+
+vi.mock('@agentclientprotocol/sdk', () => ({
+  PROTOCOL_VERSION: 1,
+  ndJsonStream: vi.fn(() => ({})),
+  ClientSideConnection: vi.fn().mockImplementation(() => ({
+    initialize: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+describe('AcpBridge', () => {
+  beforeEach(() => {
+    child.instances.length = 0;
+    child.spawn.mockClear();
+  });
+
+  it('kills the ACP child when it reports a large event loop stall', async () => {
+    const bridge = new AcpBridge({
+      cliEntryPath: '/tmp/qwen',
+      cwd: '/tmp',
+    });
+
+    await bridge.start();
+    const proc = child.instances[0]!;
+
+    proc.stderr.write(
+      '[perf] acp agent event loop stall: max=917512.388607ms\n',
+    );
+
+    expect(proc.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not kill the ACP child for a small event loop stall warning', async () => {
+    const bridge = new AcpBridge({
+      cliEntryPath: '/tmp/qwen',
+      cwd: '/tmp',
+    });
+
+    await bridge.start();
+    const proc = child.instances[0]!;
+
+    proc.stderr.write('[perf] acp agent event loop stall: max=2500ms\n');
+
+    expect(proc.kill).not.toHaveBeenCalled();
+  });
+});

--- a/packages/channels/base/src/AcpBridge.test.ts
+++ b/packages/channels/base/src/AcpBridge.test.ts
@@ -88,6 +88,7 @@ describe('AcpBridge', () => {
     );
 
     expect(proc.kill).toHaveBeenCalledTimes(1);
+    expect(proc.kill).toHaveBeenCalledWith('SIGKILL');
   });
 
   it('does not kill the ACP child for a small event loop stall warning', async () => {
@@ -101,6 +102,39 @@ describe('AcpBridge', () => {
 
     proc.stderr.write(
       `[perf] acp agent event loop stall: max=${ACP_EVENT_LOOP_STALL_RESTART_MS - 1000}ms\n`,
+    );
+
+    expect(proc.kill).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-perf stderr that mentions an event loop stall', async () => {
+    const bridge = new AcpBridge({
+      cliEntryPath: '/tmp/qwen',
+      cwd: '/tmp',
+    });
+
+    await bridge.start();
+    const proc = child.instances[0]!;
+
+    proc.stderr.write(
+      `debug: acp agent event loop stall: max=${ACP_EVENT_LOOP_STALL_RESTART_MS + 1000}ms\n`,
+    );
+
+    expect(proc.kill).not.toHaveBeenCalled();
+  });
+
+  it('does not kill the ACP child again after it is already killed', async () => {
+    const bridge = new AcpBridge({
+      cliEntryPath: '/tmp/qwen',
+      cwd: '/tmp',
+    });
+
+    await bridge.start();
+    const proc = child.instances[0]!;
+    proc.killed = true;
+
+    proc.stderr.write(
+      `[perf] acp agent event loop stall: max=${ACP_EVENT_LOOP_STALL_RESTART_MS + 1000}ms\n`,
     );
 
     expect(proc.kill).not.toHaveBeenCalled();

--- a/packages/channels/base/src/AcpBridge.ts
+++ b/packages/channels/base/src/AcpBridge.ts
@@ -28,7 +28,7 @@ export interface AcpBridgeOptions {
 
 export const ACP_EVENT_LOOP_STALL_RESTART_MS = 5 * 60 * 1000;
 const ACP_EVENT_LOOP_STALL_RE =
-  /^\[perf\] acp agent event loop stall: max=(\d+(?:\.\d+)?)ms/;
+  /^\[perf\] acp agent event loop stall: max=(\d+(?:\.\d+)?)ms/m;
 
 /**
  * Read a command's aliases off a raw wire `available_commands_update` entry. ACP

--- a/packages/channels/base/src/AcpBridge.ts
+++ b/packages/channels/base/src/AcpBridge.ts
@@ -27,7 +27,8 @@ export interface AcpBridgeOptions {
 }
 
 export const ACP_EVENT_LOOP_STALL_RESTART_MS = 5 * 60 * 1000;
-const ACP_EVENT_LOOP_STALL_RE = /acp agent event loop stall: max=([0-9.]+)ms/;
+const ACP_EVENT_LOOP_STALL_RE =
+  /^\[perf\] acp agent event loop stall: max=(\d+(?:\.\d+)?)ms/;
 
 /**
  * Read a command's aliases off a raw wire `available_commands_update` entry. ACP
@@ -93,7 +94,7 @@ export class AcpBridge extends EventEmitter implements ChannelAgentBridge {
       const msg = data.toString().trim();
       if (msg) {
         process.stderr.write(`[AcpBridge] ${msg}\n`);
-        this.maybeRestartOnEventLoopStall(msg);
+        this.maybeKillOnEventLoopStall(msg);
       }
     });
 
@@ -278,7 +279,7 @@ export class AcpBridge extends EventEmitter implements ChannelAgentBridge {
     return this.connection;
   }
 
-  private maybeRestartOnEventLoopStall(stderr: string): void {
+  private maybeKillOnEventLoopStall(stderr: string): void {
     const match = ACP_EVENT_LOOP_STALL_RE.exec(stderr);
     if (!match) return;
 
@@ -293,8 +294,8 @@ export class AcpBridge extends EventEmitter implements ChannelAgentBridge {
     }
 
     process.stderr.write(
-      `[AcpBridge] ACP agent event loop stalled for ${Math.round(maxMs)}ms; restarting child process\n`,
+      `[AcpBridge] ACP agent event loop stalled for ${Math.round(maxMs)}ms; killing child process to trigger restart\n`,
     );
-    child.kill();
+    child.kill('SIGKILL');
   }
 }

--- a/packages/channels/base/src/AcpBridge.ts
+++ b/packages/channels/base/src/AcpBridge.ts
@@ -26,6 +26,9 @@ export interface AcpBridgeOptions {
   model?: string;
 }
 
+export const ACP_EVENT_LOOP_STALL_RESTART_MS = 5 * 60 * 1000;
+const ACP_EVENT_LOOP_STALL_RE = /acp agent event loop stall: max=([0-9.]+)ms/;
+
 /**
  * Read a command's aliases off a raw wire `available_commands_update` entry. ACP
  * carries them in `_meta` (its only extension point); a top-level `altNames` is
@@ -90,6 +93,7 @@ export class AcpBridge extends EventEmitter implements ChannelAgentBridge {
       const msg = data.toString().trim();
       if (msg) {
         process.stderr.write(`[AcpBridge] ${msg}\n`);
+        this.maybeRestartOnEventLoopStall(msg);
       }
     });
 
@@ -272,5 +276,25 @@ export class AcpBridge extends EventEmitter implements ChannelAgentBridge {
       throw new Error('Not connected to ACP agent');
     }
     return this.connection;
+  }
+
+  private maybeRestartOnEventLoopStall(stderr: string): void {
+    const match = ACP_EVENT_LOOP_STALL_RE.exec(stderr);
+    if (!match) return;
+
+    const maxMs = Number(match[1]);
+    if (!Number.isFinite(maxMs) || maxMs < ACP_EVENT_LOOP_STALL_RESTART_MS) {
+      return;
+    }
+
+    const child = this.child;
+    if (!child || child.killed || child.exitCode !== null) {
+      return;
+    }
+
+    process.stderr.write(
+      `[AcpBridge] ACP agent event loop stalled for ${Math.round(maxMs)}ms; restarting child process\n`,
+    );
+    child.kill();
   }
 }


### PR DESCRIPTION
## What this PR does

Treats a long ACP agent event-loop stall as an unhealthy channel bridge condition. When the standalone channel bridge sees the ACP child report a stall of at least five minutes, it terminates that child process so the existing channel crash-recovery path can restart the bridge and restore sessions.

## Why it's needed

A live DingTalk channel run showed the outer `qwen channel start QwenBot` process staying alive while the ACP agent repeatedly logged event-loop stalls around 15 minutes and new DingTalk messages stopped reaching the Qwen session JSONL. Before this change, `AcpBridge` only forwarded those stall warnings to stderr, so the channel stayed apparently online but unusable. Killing the stalled ACP child converts that silent wedged state into the already-supported `disconnected` recovery flow.

## Reviewer Test Plan

### How to verify

Run a channel bot and force or observe an ACP child log line like `[perf] acp agent event loop stall: max=917512.388607ms`. The channel bridge should log that it is restarting the child process, the ACP process should exit, and the existing channel start recovery should restart the bridge and restore sessions. Small stall warnings should only be logged and should not kill the child.

### Evidence (Before & After)

Before: the parent channel process forwarded large ACP event-loop stall logs but took no recovery action, so the bot could stay alive while no new messages reached the session.

After: focused tests cover both paths: a large stall kills the ACP child, and a small stall does not. Existing channel start tests still pass, covering the restart path that handles child disconnection.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS workspace, Node.js 24.14.1.

## Risk & Scope

- Main risk or tradeoff: a truly long event-loop stall now restarts the ACP child instead of leaving the stalled turn alive. The threshold is five minutes to avoid reacting to short transient pauses.
- Not validated / out of scope: live forced ACP stall in every channel provider; this PR relies on the existing channel bridge crash-recovery path for restart and session restore.
- Breaking changes / migration notes: none expected.

## Linked Issues

Fixes #6329

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把长时间 ACP agent event-loop stall 视为 channel bridge 不健康状态。当 standalone channel bridge 看到 ACP 子进程报告至少 5 分钟的 stall 时，会终止该子进程，让已有的 channel crash-recovery 流程重启 bridge 并恢复 session。

## 为什么需要

一次真实钉钉 channel 运行中，外层 `qwen channel start QwenBot` 进程仍然存活，但 ACP agent 反复打印约 15 分钟的 event-loop stall，新钉钉消息也不再进入 Qwen session JSONL。修改前，`AcpBridge` 只是把这些 stall warning 转发到 stderr，所以 channel 看起来在线但实际不可用。现在杀掉卡住的 ACP 子进程，把静默 wedged 状态转换成已有支持的 `disconnected` 恢复流程。

## Reviewer Test Plan

### 如何验证

运行 channel bot，并强制或观察 ACP 子进程输出类似 `[perf] acp agent event loop stall: max=917512.388607ms` 的日志。channel bridge 应记录正在重启子进程，ACP 进程应退出，然后已有 channel start recovery 会重启 bridge 并恢复 session。较小的 stall warning 只应被记录，不应杀掉子进程。

### 证据（修改前后）

修改前：父 channel 进程只转发大型 ACP event-loop stall 日志，不采取恢复动作，因此 bot 可能仍然存活，但新消息不再进入 session。

修改后：聚焦测试覆盖两个路径：大型 stall 会杀掉 ACP 子进程，小型 stall 不会。现有 channel start 测试仍然通过，覆盖子进程断开后的重启路径。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

macOS 本地工作区，Node.js 24.14.1。

## 风险与范围

- 主要风险或取舍：真正长时间 event-loop stall 现在会重启 ACP 子进程，而不是让 stalled turn 继续存活。阈值设为 5 分钟，避免对短暂暂停误动作。
- 未验证 / 范围外：没有在每个 channel provider 中做真实强制 ACP stall；本 PR 依赖已有 channel bridge crash-recovery 路径完成重启和 session restore。
- 破坏性变更 / 迁移说明：预期没有。

## 关联 Issue

Fixes #6329

</details>