### PR TITLE
feat(web-shell): add onSessionChange and onSubmitBefore callbacks

### DIFF
--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -1,0 +1,563 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+type StreamingState = 'idle' | 'responding';
+
+type MockConnection = {
+  status: 'connected';
+  sessionId: string | undefined;
+  clientId: string;
+  displayName: string | undefined;
+  workspaceCwd: string;
+  currentModel: string;
+  currentMode: string;
+  models: Array<{ id: string; label?: string }>;
+  commands: unknown[];
+  capabilities: { qwenCodeVersion: string; features: string[] };
+  loadingTranscript: boolean;
+  catchingUp: boolean;
+};
+
+type ChatEditorTestProps = {
+  onSubmit: (text: string) => boolean | void;
+  isPreparing?: boolean;
+};
+
+const {
+  mockConnection,
+  mockSessionActions,
+  mockWorkspaceActions,
+  mockStore,
+  mockFollowup,
+  testState,
+  sidebarTokens,
+  rawEnqueuePrompt,
+} = vi.hoisted(() => {
+  const connection: MockConnection = {
+    status: 'connected',
+    sessionId: 'session-1',
+    clientId: 'client-1',
+    displayName: 'Session One',
+    workspaceCwd: '/tmp/project',
+    currentModel: 'qwen',
+    currentMode: 'default',
+    models: [{ id: 'qwen', label: 'Qwen' }],
+    commands: [],
+    capabilities: { qwenCodeVersion: '1.2.3', features: [] },
+    loadingTranscript: false,
+    catchingUp: false,
+  };
+  return {
+    mockConnection: connection,
+    mockSessionActions: {
+      sendPrompt: vi.fn().mockResolvedValue(undefined),
+      createSession: vi.fn().mockResolvedValue({ sessionId: 'session-1' }),
+      refreshCommands: vi.fn().mockResolvedValue(undefined),
+      setModel: vi.fn().mockResolvedValue(undefined),
+      setApprovalMode: vi.fn().mockResolvedValue(undefined),
+      getRewindSnapshots: vi.fn().mockResolvedValue([]),
+      rewindSession: vi.fn().mockResolvedValue(undefined),
+      submitPermission: vi.fn().mockResolvedValue(undefined),
+      clearGoal: vi.fn().mockResolvedValue(undefined),
+      forkSession: vi.fn().mockResolvedValue({ launched: false }),
+      sendShellCommand: vi.fn().mockResolvedValue(undefined),
+      getStats: vi.fn().mockResolvedValue({}),
+    },
+    mockWorkspaceActions: {
+      loadSkillsStatus: vi.fn().mockResolvedValue({ skills: [] }),
+      loadProviders: vi.fn().mockResolvedValue({ current: null }),
+      loadPreflight: vi.fn().mockResolvedValue(null),
+      loadEnv: vi.fn().mockResolvedValue(null),
+      loadMcpStatus: vi.fn().mockResolvedValue({ servers: [] }),
+      loadMcpTools: vi.fn().mockResolvedValue([]),
+      loadMcpResources: vi.fn().mockResolvedValue([]),
+    },
+    mockStore: {
+      dispatch: vi.fn(),
+      appendLocalUserMessage: vi.fn(),
+      appendLocalAssistantMessage: vi.fn(),
+    },
+    mockFollowup: {
+      clear: vi.fn(),
+      onAcceptFollowup: vi.fn(),
+      onDismissFollowup: vi.fn(),
+    },
+    testState: {
+      prompt: 'hello',
+      streamingState: 'idle' as StreamingState,
+      blocks: [] as unknown[],
+      latestChatEditorProps: null as ChatEditorTestProps | null,
+    },
+    sidebarTokens: [] as Array<number | undefined>,
+    rawEnqueuePrompt: vi.fn(() => true),
+  };
+});
+
+vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
+  DAEMON_APPROVAL_MODES: ['default', 'plan', 'auto-edit', 'auto', 'yolo'],
+  useActions: () => mockSessionActions,
+  useConnection: () => mockConnection,
+  useDaemonFollowupSuggestion: () => ({
+    followupState: null,
+    clear: mockFollowup.clear,
+    onAcceptFollowup: mockFollowup.onAcceptFollowup,
+    onDismissFollowup: mockFollowup.onDismissFollowup,
+  }),
+  useSessionNotices: () => ({ notices: [], dismissNotice: vi.fn() }),
+  useSettings: () => ({
+    settings: [],
+    setValue: vi.fn().mockResolvedValue(undefined),
+    reload: vi.fn().mockResolvedValue(undefined),
+    loading: false,
+  }),
+  useStreamingState: () => testState.streamingState,
+  useTranscriptBlocks: () => testState.blocks,
+  useTranscriptStore: () => mockStore,
+  useWorkspaceActions: () => mockWorkspaceActions,
+  useWorkspaceEventSignals: () => ({ extensionsVersion: 0 }),
+}));
+
+vi.mock('@qwen-code/sdk/daemon', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@qwen-code/sdk/daemon')>()),
+  isDaemonTurnError: () => false,
+}));
+
+vi.mock('./hooks/useMessages', () => ({
+  useMessages: () => [],
+}));
+
+vi.mock('./hooks/useBackgroundTasks', () => ({
+  useBackgroundTasks: () => [],
+}));
+
+vi.mock('./hooks/useAnimationFrameValue', () => ({
+  useAnimationFrameValue: (value: unknown) => value,
+}));
+
+vi.mock('./hooks/useQueuedPrompts', () => ({
+  useQueuedPrompts: () => ({
+    queuedPrompts: [],
+    queuedTexts: [],
+    enqueuePrompt: rawEnqueuePrompt,
+    removeQueuedPrompt: vi.fn(),
+    insertQueuedPrompt: vi.fn(),
+    editQueuedPrompt: vi.fn(),
+    editLastQueuedPrompt: vi.fn(() => false),
+    clearQueuedPrompts: vi.fn(() => false),
+  }),
+}));
+
+vi.mock('./components/ChatEditor', async () => {
+  const React = await import('react');
+  return {
+    ChatEditor: React.forwardRef(function ChatEditor(
+      props: ChatEditorTestProps,
+      ref: React.ForwardedRef<{
+        clear: () => void;
+        insertText: (text: string) => void;
+      }>,
+    ) {
+      testState.latestChatEditorProps = props;
+      React.useImperativeHandle(ref, () => ({
+        clear: vi.fn(),
+        insertText: vi.fn(),
+      }));
+      return React.createElement(
+        'button',
+        {
+          'data-testid': 'submit',
+          'data-preparing': props.isPreparing ? 'true' : 'false',
+          onClick: () => props.onSubmit(testState.prompt),
+          type: 'button',
+        },
+        'submit',
+      );
+    }),
+  };
+});
+
+vi.mock('./components/MessageList', async () => {
+  const React = await import('react');
+  return {
+    MessageList: React.forwardRef(function MessageList(
+      props: { showRetryHint?: boolean; onRetryClick?: () => void },
+      ref: React.ForwardedRef<{ scrollToBottom: () => void }>,
+    ) {
+      React.useImperativeHandle(ref, () => ({ scrollToBottom: vi.fn() }));
+      return React.createElement(
+        'div',
+        { 'data-testid': 'messages' },
+        props.showRetryHint
+          ? React.createElement(
+              'button',
+              {
+                'data-testid': 'retry',
+                onClick: props.onRetryClick,
+                type: 'button',
+              },
+              'retry',
+            )
+          : null,
+      );
+    }),
+  };
+});
+
+vi.mock('./components/sidebar/WebShellSidebar', async () => {
+  const React = await import('react');
+  return {
+    WebShellSidebar: (props: { sessionListReloadToken?: number }) => {
+      sidebarTokens.push(props.sessionListReloadToken);
+      return React.createElement('div', { 'data-testid': 'sidebar' });
+    },
+  };
+});
+
+function mockComponent(path: string, exportName: string): void {
+  vi.doMock(path, async () => {
+    const React = await import('react');
+    return {
+      [exportName]: () => React.createElement('div'),
+    };
+  });
+}
+
+mockComponent('./components/StatusBar', 'StatusBar');
+mockComponent('./components/StreamingStatus', 'StreamingStatus');
+mockComponent('./components/ToastHost', 'ToastHost');
+mockComponent('./components/panels/TodoPanel', 'TodoPanel');
+mockComponent('./components/WelcomeHeader', 'WelcomeHeader');
+mockComponent('./components/dialogs/ApprovalModeDialog', 'ApprovalModeDialog');
+mockComponent('./components/dialogs/ResumeDialog', 'ResumeDialog');
+mockComponent('./components/dialogs/DialogShell', 'DialogShell');
+mockComponent('./components/dialogs/ModelDialog', 'ModelDialog');
+mockComponent('./components/dialogs/ToolsDialog', 'ToolsDialog');
+mockComponent('./components/dialogs/DaemonStatusDialog', 'DaemonStatusDialog');
+mockComponent('./components/dialogs/ExtensionsDialog', 'ExtensionsDialog');
+mockComponent('./components/dialogs/ThemeDialog', 'ThemeDialog');
+mockComponent(
+  './components/dialogs/DeleteSessionDialog',
+  'DeleteSessionDialog',
+);
+mockComponent(
+  './components/dialogs/ReleaseSessionDialog',
+  'ReleaseSessionDialog',
+);
+mockComponent('./components/dialogs/RewindDialog', 'RewindDialog');
+mockComponent('./components/dialogs/McpDialog', 'McpDialog');
+mockComponent('./components/messages/AgentsMessage', 'AgentsMessage');
+mockComponent('./components/messages/MemoryMessage', 'MemoryMessage');
+mockComponent('./components/messages/AuthMessage', 'AuthMessage');
+mockComponent('./components/messages/SettingsMessage', 'SettingsMessage');
+mockComponent('./components/messages/ToolApproval', 'ToolApproval');
+mockComponent('./components/messages/AskUserQuestion', 'AskUserQuestion');
+mockComponent('./components/messages/TasksStatusMessage', 'TasksStatusMessage');
+mockComponent('./components/messages/BtwMessage', 'BtwMessage');
+mockComponent('./components/QueuedPromptDisplay', 'QueuedPromptDisplay');
+
+const { App } = await import('./App');
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+function renderApp(props: React.ComponentProps<typeof App> = {}): {
+  container: HTMLElement;
+  rerender: (nextProps?: React.ComponentProps<typeof App>) => void;
+} {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const doRender = (nextProps: React.ComponentProps<typeof App> = props) => {
+    act(() => {
+      root.render(<App sidebar={{ enabled: true }} {...nextProps} />);
+    });
+  };
+  doRender(props);
+  mounted.push({ root, container });
+  return { container, rerender: doRender };
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function clickSubmit(container: HTMLElement): Promise<void> {
+  await act(async () => {
+    container
+      .querySelector<HTMLButtonElement>('[data-testid="submit"]')
+      ?.click();
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    value: vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }),
+  });
+  mockConnection.sessionId = 'session-1';
+  mockConnection.displayName = 'Session One';
+  mockConnection.loadingTranscript = false;
+  mockConnection.catchingUp = false;
+  testState.prompt = 'hello';
+  testState.streamingState = 'idle';
+  testState.blocks = [];
+  testState.latestChatEditorProps = null;
+  sidebarTokens.length = 0;
+  rawEnqueuePrompt.mockClear();
+  mockFollowup.clear.mockClear();
+  for (const value of Object.values(mockSessionActions)) {
+    if (typeof value === 'function' && 'mockClear' in value) value.mockClear();
+  }
+  mockSessionActions.sendPrompt.mockResolvedValue(undefined);
+  mockSessionActions.createSession.mockResolvedValue({
+    sessionId: 'session-1',
+  });
+  mockSessionActions.refreshCommands.mockResolvedValue(undefined);
+  mockSessionActions.setModel.mockResolvedValue(undefined);
+  mockSessionActions.setApprovalMode.mockResolvedValue(undefined);
+  mockSessionActions.getRewindSnapshots.mockResolvedValue([]);
+  mockSessionActions.rewindSession.mockResolvedValue(undefined);
+  mockSessionActions.submitPermission.mockResolvedValue(undefined);
+  mockSessionActions.clearGoal.mockResolvedValue(undefined);
+  mockSessionActions.forkSession.mockResolvedValue({ launched: false });
+  mockSessionActions.sendShellCommand.mockResolvedValue(undefined);
+  mockSessionActions.getStats.mockResolvedValue({});
+  mockWorkspaceActions.loadSkillsStatus.mockResolvedValue({ skills: [] });
+  mockWorkspaceActions.loadProviders.mockResolvedValue({ current: null });
+  mockWorkspaceActions.loadPreflight.mockResolvedValue(null);
+  mockWorkspaceActions.loadEnv.mockResolvedValue(null);
+  mockWorkspaceActions.loadMcpStatus.mockResolvedValue({ servers: [] });
+  mockWorkspaceActions.loadMcpTools.mockResolvedValue([]);
+  mockWorkspaceActions.loadMcpResources.mockResolvedValue([]);
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('App session callbacks', () => {
+  it('gates direct submissions and dispatches submit events with delayed sidebar reload', async () => {
+    vi.useFakeTimers();
+    const onSubmitBefore = vi.fn().mockResolvedValue(undefined);
+    const onSessionChange = vi.fn();
+    const { container } = renderApp({ onSubmitBefore, onSessionChange });
+    await flush();
+
+    await clickSubmit(container);
+    await flush();
+
+    expect(onSubmitBefore).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      prompt: 'hello',
+    });
+    expect(mockFollowup.clear).toHaveBeenCalledTimes(1);
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledWith(
+      'hello',
+      expect.objectContaining({ retry: undefined }),
+    );
+    expect(onSessionChange).toHaveBeenCalledWith({
+      type: 'submit',
+      sessionId: 'session-1',
+      prompt: 'hello',
+      queued: false,
+    });
+
+    const tokenAfterSubmit = sidebarTokens.at(-1);
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(sidebarTokens.at(-1)).not.toBe(tokenAfterSubmit);
+  });
+
+  it('cancels direct submissions when onSubmitBefore rejects and preserves retry state', async () => {
+    const onSubmitBefore = vi.fn((params: { prompt: string }) =>
+      params.prompt === 'blocked'
+        ? Promise.reject(new Error('blocked'))
+        : Promise.resolve(),
+    );
+    const { container, rerender } = renderApp({ onSubmitBefore });
+    await flush();
+
+    testState.prompt = 'first';
+    await clickSubmit(container);
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledWith(
+      'first',
+      expect.objectContaining({ retry: undefined }),
+    );
+
+    act(() => {
+      testState.blocks = [
+        { kind: 'error', source: 'turn_error', id: 'turn-error-1' },
+      ];
+      rerender({ onSubmitBefore });
+    });
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+
+    mockSessionActions.sendPrompt.mockClear();
+    testState.prompt = 'blocked';
+    await clickSubmit(container);
+    await flush();
+
+    expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
+    expect(mockFollowup.clear).toHaveBeenCalledTimes(1);
+    expect(testState.latestChatEditorProps?.isPreparing).toBe(false);
+    expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="retry"]')
+        ?.click();
+      await Promise.resolve();
+    });
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledWith(
+      'first',
+      expect.objectContaining({ retry: true }),
+    );
+  });
+
+  it('gates queued submissions and only enqueues after approval', async () => {
+    let approve: (() => void) | undefined;
+    const onSubmitBefore = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          approve = resolve;
+        }),
+    );
+    const onSessionChange = vi.fn();
+    const { container, rerender } = renderApp({
+      onSubmitBefore,
+      onSessionChange,
+    });
+    await flush();
+
+    act(() => {
+      testState.streamingState = 'responding';
+      rerender({ onSubmitBefore, onSessionChange });
+    });
+    testState.prompt = 'queued';
+    await clickSubmit(container);
+    expect(rawEnqueuePrompt).not.toHaveBeenCalled();
+
+    await act(async () => {
+      approve?.();
+      await Promise.resolve();
+    });
+
+    expect(rawEnqueuePrompt).toHaveBeenCalledWith(
+      'queued',
+      undefined,
+      undefined,
+    );
+    expect(onSessionChange).toHaveBeenCalledWith({
+      type: 'submit',
+      sessionId: 'session-1',
+      prompt: 'queued',
+      queued: true,
+    });
+  });
+
+  it('cancels queued submissions when onSubmitBefore rejects', async () => {
+    const onSubmitBefore = vi.fn().mockRejectedValue(new Error('blocked'));
+    const { container, rerender } = renderApp({ onSubmitBefore });
+    await flush();
+
+    act(() => {
+      testState.streamingState = 'responding';
+      rerender({ onSubmitBefore });
+    });
+    await clickSubmit(container);
+    await flush();
+
+    expect(rawEnqueuePrompt).not.toHaveBeenCalled();
+  });
+
+  it('dispatches turn_complete only for the session that was streaming', async () => {
+    const onSessionChange = vi.fn();
+    const { container, rerender } = renderApp({ onSessionChange });
+    await flush();
+
+    testState.prompt = 'first';
+    await clickSubmit(container);
+    onSessionChange.mockClear();
+
+    act(() => {
+      testState.streamingState = 'responding';
+      rerender({ onSessionChange });
+    });
+    act(() => {
+      testState.blocks = [
+        { kind: 'error', source: 'turn_error', id: 'turn-error-1' },
+      ];
+      testState.streamingState = 'idle';
+      rerender({ onSessionChange });
+    });
+
+    expect(onSessionChange).toHaveBeenCalledWith({
+      type: 'turn_complete',
+      sessionId: 'session-1',
+      error: expect.objectContaining({
+        message: 'Turn error (block turn-error-1)',
+      }),
+    });
+
+    onSessionChange.mockClear();
+    act(() => {
+      testState.streamingState = 'responding';
+      rerender({ onSessionChange });
+    });
+    act(() => {
+      mockConnection.sessionId = 'session-2';
+      testState.streamingState = 'idle';
+      rerender({ onSessionChange });
+    });
+
+    expect(onSessionChange).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'turn_complete' }),
+    );
+  });
+
+  it('dispatches rename only after the current session name changes', async () => {
+    const onSessionChange = vi.fn();
+    const { rerender } = renderApp({ onSessionChange });
+    await flush();
+
+    expect(onSessionChange).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'rename' }),
+    );
+
+    act(() => {
+      mockConnection.displayName = 'Renamed Session';
+      rerender({ onSessionChange });
+    });
+
+    expect(onSessionChange).toHaveBeenCalledWith({
+      type: 'rename',
+      sessionId: 'session-1',
+      newName: 'Renamed Session',
+    });
+
+    onSessionChange.mockClear();
+    act(() => {
+      rerender({ onSessionChange });
+    });
+    expect(onSessionChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -34,6 +34,7 @@ const {
   testState,
   sidebarTokens,
   rawEnqueuePrompt,
+  editorClear,
 } = vi.hoisted(() => {
   const connection: MockConnection = {
     status: 'connected',
@@ -92,6 +93,7 @@ const {
     },
     sidebarTokens: [] as Array<number | undefined>,
     rawEnqueuePrompt: vi.fn(() => true),
+    editorClear: vi.fn(),
   };
 });
 
@@ -161,7 +163,7 @@ vi.mock('./components/ChatEditor', async () => {
     ) {
       testState.latestChatEditorProps = props;
       React.useImperativeHandle(ref, () => ({
-        clear: vi.fn(),
+        clear: editorClear,
         insertText: vi.fn(),
       }));
       return React.createElement(
@@ -316,6 +318,7 @@ beforeEach(() => {
   testState.latestChatEditorProps = null;
   sidebarTokens.length = 0;
   rawEnqueuePrompt.mockClear();
+  editorClear.mockClear();
   mockFollowup.clear.mockClear();
   for (const value of Object.values(mockSessionActions)) {
     if (typeof value === 'function' && 'mockClear' in value) value.mockClear();
@@ -455,6 +458,7 @@ describe('App session callbacks', () => {
     testState.prompt = 'queued';
     await clickSubmit(container);
     expect(rawEnqueuePrompt).not.toHaveBeenCalled();
+    expect(editorClear).not.toHaveBeenCalled();
 
     await act(async () => {
       approve?.();
@@ -472,6 +476,7 @@ describe('App session callbacks', () => {
       prompt: 'queued',
       queued: true,
     });
+    expect(editorClear).toHaveBeenCalledTimes(1);
   });
 
   it('cancels queued submissions when onSubmitBefore rejects', async () => {
@@ -487,6 +492,7 @@ describe('App session callbacks', () => {
     await flush();
 
     expect(rawEnqueuePrompt).not.toHaveBeenCalled();
+    expect(editorClear).not.toHaveBeenCalled();
   });
 
   it('dispatches turn_complete only for the session that was streaming', async () => {

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -376,6 +376,7 @@ describe('App session callbacks', () => {
       'hello',
       expect.objectContaining({ retry: undefined }),
     );
+    expect(editorClear).toHaveBeenCalledTimes(1);
     expect(onSessionChange).toHaveBeenCalledWith({
       type: 'submit',
       sessionId: 'session-1',
@@ -415,12 +416,14 @@ describe('App session callbacks', () => {
     expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
 
     mockSessionActions.sendPrompt.mockClear();
+    editorClear.mockClear();
     testState.prompt = 'blocked';
     await clickSubmit(container);
     await flush();
 
     expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
     expect(mockFollowup.clear).toHaveBeenCalledTimes(1);
+    expect(editorClear).toHaveBeenCalledTimes(0);
     expect(testState.latestChatEditorProps?.isPreparing).toBe(false);
     expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
 

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -2445,7 +2445,9 @@ export function App({
         errorMessage: string,
         opts?: { optimisticUserMessage?: boolean; retry?: boolean },
       ) => {
-        const clearComposerOnPromptStart = !connectionRef.current.sessionId;
+        const clearComposerOnPromptStart =
+          !connectionRef.current.sessionId ||
+          Boolean(onSubmitBeforeRef.current);
         sendPrompt(promptText, promptImages, {
           ...opts,
           clearComposerOnPromptStart,

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -1526,7 +1526,10 @@ export function App({
             prompt: text,
           })
           .then(() => {
-            rawEnqueuePrompt(text, images, onComplete);
+            const result = rawEnqueuePrompt(text, images, onComplete);
+            if (result !== false) {
+              editorRef.current?.clear();
+            }
             const sessionId = connectionRef.current.sessionId;
             if (sessionId && text.trim()) {
               dispatchSessionChangeRef.current?.({
@@ -1543,7 +1546,7 @@ export function App({
               err,
             );
           });
-        return true;
+        return false;
       }
       const result = rawEnqueuePrompt(text, images, onComplete);
       const sessionId = connectionRef.current.sessionId;

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -1359,7 +1359,6 @@ export function App({
         clearComposerOnPromptStart?: boolean;
       },
     ) => {
-      clearFollowup();
       const isUserPrompt = !text.trimStart().startsWith('/');
       const previousLastSubmittedPrompt = lastSubmittedPromptRef.current;
       const previousLastSubmittedImages = lastSubmittedImagesRef.current;
@@ -1386,7 +1385,7 @@ export function App({
           );
           setIsPreparingPrompt(false);
           // Restore retry-critical refs so Ctrl+Y doesn't resend the
-          // cancelled prompt. clearFollowup is not rolled back.
+          // cancelled prompt.
           lastSubmittedPromptRef.current = previousLastSubmittedPrompt;
           lastSubmittedImagesRef.current = previousLastSubmittedImages;
           retriedTurnErrorIdRef.current = previousRetriedTurnErrorId;
@@ -1402,6 +1401,7 @@ export function App({
       if (!onSubmitBeforeRef.current && shouldShowPreparing) {
         setIsPreparingPrompt(true);
       }
+      clearFollowup();
       try {
         await ensureSessionForPrompt();
       } finally {
@@ -1428,7 +1428,9 @@ export function App({
         // Schedule an additional delayed reload to account for daemon-side
         // session registration lag — the immediate reload above may return
         // a list that doesn't yet include the newly created session.
-        clearTimeout(delayedReloadTimerRef.current);
+        if (delayedReloadTimerRef.current !== null) {
+          clearTimeout(delayedReloadTimerRef.current);
+        }
         delayedReloadTimerRef.current = setTimeout(() => {
           setSessionListReloadToken((n) => n + 1);
         }, 2000);

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -1325,8 +1325,17 @@ export function App({
   const onSubmitBeforeRef = useRef(onSubmitBefore);
   onSubmitBeforeRef.current = onSubmitBefore;
   const [sessionListReloadToken, setSessionListReloadToken] = useState(0);
-  const delayedReloadTimerRef = useRef<ReturnType<typeof setTimeout>>();
-  useEffect(() => () => clearTimeout(delayedReloadTimerRef.current), []);
+  const delayedReloadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  useEffect(
+    () => () => {
+      if (delayedReloadTimerRef.current !== null) {
+        clearTimeout(delayedReloadTimerRef.current);
+      }
+    },
+    [],
+  );
   const dispatchSessionChange = useCallback(
     (event: SessionChangeEvent) => {
       onSessionChange?.(event);

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -421,7 +421,7 @@ export interface WebShellProps {
    * Called before a prompt is submitted. Return a Promise — the prompt is held
    * until the Promise resolves. If the Promise rejects, the prompt is cancelled.
    * `sessionId` is `undefined` when the session has not yet been created (deferred).
-   * Not called for queued prompts (submitted while a turn is streaming).
+   * Also called for queued prompts (submitted while a turn is streaming).
    */
   onSubmitBefore?: (params: {
     sessionId: string | undefined;
@@ -1519,9 +1519,32 @@ export function App({
 
   const enqueuePrompt = useCallback(
     (text: string, images?: PromptImage[], onComplete?: () => void) => {
-      // Intentional: onSubmitBefore is not called for queued prompts.
-      // Queued prompts are fire-and-forget while streaming; the pre-submit
-      // hook is designed for synchronous interception of direct submissions.
+      if (onSubmitBeforeRef.current) {
+        onSubmitBeforeRef
+          .current({
+            sessionId: connectionRef.current.sessionId,
+            prompt: text,
+          })
+          .then(() => {
+            rawEnqueuePrompt(text, images, onComplete);
+            const sessionId = connectionRef.current.sessionId;
+            if (sessionId && text.trim()) {
+              dispatchSessionChangeRef.current?.({
+                type: 'submit',
+                sessionId,
+                prompt: text,
+                queued: true,
+              });
+            }
+          })
+          .catch((err: unknown) => {
+            console.warn(
+              '[web-shell] onSubmitBefore rejected queued prompt, cancelled',
+              err,
+            );
+          });
+        return true;
+      }
       const result = rawEnqueuePrompt(text, images, onComplete);
       const sessionId = connectionRef.current.sessionId;
       if (sessionId && text.trim()) {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -329,6 +329,11 @@ export interface WebShellSidebarOptions {
   defaultCollapsed?: boolean;
 }
 
+export type SessionChangeEvent =
+  | { type: 'rename'; sessionId: string; newName: string }
+  | { type: 'submit'; sessionId: string; prompt: string; queued: boolean }
+  | { type: 'turn_complete'; sessionId: string; error?: Error };
+
 export interface WebShellProps {
   /** Called whenever the attached daemon session id changes. */
   onSessionIdChange?: (sessionId: string | undefined) => void;
@@ -410,6 +415,18 @@ export interface WebShellProps {
   composerInput?: WebShellComposerInput;
   /** Replay key for composerInput. */
   composerInputVersion?: number;
+  /** Called when a session-level event occurs (rename, submit, turn complete). */
+  onSessionChange?: (event: SessionChangeEvent) => void;
+  /**
+   * Called before a prompt is submitted. Return a Promise — the prompt is held
+   * until the Promise resolves. If the Promise rejects, the prompt is cancelled.
+   * `sessionId` is `undefined` when the session has not yet been created (deferred).
+   * Not called for queued prompts (submitted while a turn is streaming).
+   */
+  onSubmitBefore?: (params: {
+    sessionId: string | undefined;
+    prompt: string;
+  }) => Promise<void>;
 }
 
 type SessionActionsWithCreate = {
@@ -784,6 +801,8 @@ export function App({
   onComposerReady,
   composerInput,
   composerInputVersion,
+  onSessionChange,
+  onSubmitBefore,
 }: WebShellProps = {}) {
   const [chatWidthMode, setChatWidthMode] =
     useState<ChatWidthMode>(readChatWidthMode);
@@ -1303,6 +1322,24 @@ export function App({
     }
     return createSessionPromiseRef.current;
   }, [sessionActions]);
+  const onSubmitBeforeRef = useRef(onSubmitBefore);
+  onSubmitBeforeRef.current = onSubmitBefore;
+  const [sessionListReloadToken, setSessionListReloadToken] = useState(0);
+  const delayedReloadTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  useEffect(() => () => clearTimeout(delayedReloadTimerRef.current), []);
+  const dispatchSessionChange = useCallback(
+    (event: SessionChangeEvent) => {
+      onSessionChange?.(event);
+      setSessionListReloadToken((n) => n + 1);
+    },
+    [onSessionChange],
+  );
+  // Ref-stable handle so that useCallback hooks (sendPrompt, enqueuePrompt,
+  // turn_complete effect) don't need dispatchSessionChange in their dep arrays.
+  // Without this, an unstable onSessionChange prop would cause those callbacks
+  // to be recreated on every render, cascading into downstream effect chains.
+  const dispatchSessionChangeRef = useRef(dispatchSessionChange);
+  dispatchSessionChangeRef.current = dispatchSessionChange;
   const sendPrompt = useCallback(
     async (
       text: string,
@@ -1315,6 +1352,10 @@ export function App({
     ) => {
       clearFollowup();
       const isUserPrompt = !text.trimStart().startsWith('/');
+      const previousLastSubmittedPrompt = lastSubmittedPromptRef.current;
+      const previousLastSubmittedImages = lastSubmittedImagesRef.current;
+      const previousRetriedTurnErrorId = retriedTurnErrorIdRef.current;
+      const previousShowRetryHint = showRetryHintRef.current;
       if (!opts?.retry && isUserPrompt) {
         lastSubmittedPromptRef.current = text;
         lastSubmittedImagesRef.current = images;
@@ -1322,7 +1363,34 @@ export function App({
       }
       setShowRetryHint(false);
       const shouldShowPreparing = !connectionRef.current.sessionId;
-      if (shouldShowPreparing) {
+      if (onSubmitBeforeRef.current) {
+        setIsPreparingPrompt(true);
+        try {
+          await onSubmitBeforeRef.current({
+            sessionId: connectionRef.current.sessionId,
+            prompt: text,
+          });
+        } catch (err) {
+          console.warn(
+            '[web-shell] onSubmitBefore rejected, prompt cancelled',
+            err,
+          );
+          setIsPreparingPrompt(false);
+          // Restore retry-critical refs so Ctrl+Y doesn't resend the
+          // cancelled prompt. clearFollowup is not rolled back.
+          lastSubmittedPromptRef.current = previousLastSubmittedPrompt;
+          lastSubmittedImagesRef.current = previousLastSubmittedImages;
+          retriedTurnErrorIdRef.current = previousRetriedTurnErrorId;
+          setShowRetryHint(previousShowRetryHint);
+          return;
+        }
+        // Only reset if session already exists; otherwise keep true and let
+        // ensureSessionForPrompt's finally block handle it.
+        if (!shouldShowPreparing) {
+          setIsPreparingPrompt(false);
+        }
+      }
+      if (!onSubmitBeforeRef.current && shouldShowPreparing) {
         setIsPreparingPrompt(true);
       }
       try {
@@ -1339,6 +1407,22 @@ export function App({
       };
       if (opts?.clearComposerOnPromptStart) {
         editorRef.current?.clear();
+      }
+      const sessionIdAfterEnsure = connectionRef.current.sessionId;
+      if (sessionIdAfterEnsure && text.trim()) {
+        dispatchSessionChangeRef.current?.({
+          type: 'submit',
+          sessionId: sessionIdAfterEnsure,
+          prompt: text,
+          queued: false,
+        });
+        // Schedule an additional delayed reload to account for daemon-side
+        // session registration lag — the immediate reload above may return
+        // a list that doesn't yet include the newly created session.
+        clearTimeout(delayedReloadTimerRef.current);
+        delayedReloadTimerRef.current = setTimeout(() => {
+          setSessionListReloadToken((n) => n + 1);
+        }, 2000);
       }
       const result = await (
         sessionActions.sendPrompt as (
@@ -1403,7 +1487,7 @@ export function App({
   const {
     queuedPrompts,
     queuedTexts,
-    enqueuePrompt,
+    enqueuePrompt: rawEnqueuePrompt,
     removeQueuedPrompt,
     insertQueuedPrompt,
     editQueuedPrompt,
@@ -1421,6 +1505,26 @@ export function App({
     notifySuccess,
     t,
   });
+
+  const enqueuePrompt = useCallback(
+    (text: string, images?: PromptImage[], onComplete?: () => void) => {
+      // Intentional: onSubmitBefore is not called for queued prompts.
+      // Queued prompts are fire-and-forget while streaming; the pre-submit
+      // hook is designed for synchronous interception of direct submissions.
+      const result = rawEnqueuePrompt(text, images, onComplete);
+      const sessionId = connectionRef.current.sessionId;
+      if (sessionId && text.trim()) {
+        dispatchSessionChangeRef.current?.({
+          type: 'submit',
+          sessionId,
+          prompt: text,
+          queued: true,
+        });
+      }
+      return result;
+    },
+    [rawEnqueuePrompt],
+  );
 
   useEffect(() => {
     logSessionNoticesHook(notices);
@@ -1730,7 +1834,7 @@ export function App({
         blockLocalCommandDuringTurn();
         return;
       }
-      sendPrompt(command)
+      sendPrompt(command, undefined)
         .then(refreshSettings)
         .catch((error: unknown) => {
           handleLanguageChange(previousLanguage);
@@ -1846,6 +1950,35 @@ export function App({
     onStreamingStateChange?.(streamingState);
   }, [streamingState, onStreamingStateChange]);
 
+  // Reads retryableTurnErrorIdRef which is set by the blocks effect above.
+  // Declaration order matters: this effect must run after the blocks effect
+  // so that within the same render, the ref is already updated before we read it.
+  const prevStreamingForTurnCompleteRef = useRef(streamingState);
+  const streamingSessionIdRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    const prev = prevStreamingForTurnCompleteRef.current;
+    prevStreamingForTurnCompleteRef.current = streamingState;
+    if (streamingState !== 'idle') {
+      streamingSessionIdRef.current = connectionRef.current.sessionId;
+    }
+    if (prev !== 'idle' && streamingState === 'idle') {
+      const sessionId = connectionRef.current.sessionId;
+      // Only fire if the session that was streaming is still the active one.
+      // Session switches reset streamingState to idle, which must not produce
+      // a spurious turn_complete for the new session.
+      if (!sessionId || sessionId !== streamingSessionIdRef.current) return;
+      const turnError =
+        retryableTurnErrorIdRef.current != null
+          ? new Error(`Turn error (block ${retryableTurnErrorIdRef.current})`)
+          : undefined;
+      dispatchSessionChangeRef.current?.({
+        type: 'turn_complete',
+        sessionId,
+        error: turnError,
+      });
+    }
+  }, [streamingState]);
+
   useEffect(() => {
     onConnectionChange?.(connection.status);
   }, [connection.status, onConnectionChange]);
@@ -1877,6 +2010,26 @@ export function App({
     lastNotifiedSessionIdRef.current = connection.sessionId;
     onSessionIdChange?.(connection.sessionId);
   }, [connection.sessionId, onSessionIdChange]);
+
+  const lastRenameSessionRef = useRef<string | undefined>(undefined);
+  const lastRenameNameRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    const sessionId = connection.sessionId;
+    const displayName = connection.displayName;
+    if (!sessionId || !displayName) return;
+    if (sessionId !== lastRenameSessionRef.current) {
+      lastRenameSessionRef.current = sessionId;
+      lastRenameNameRef.current = displayName;
+      return;
+    }
+    if (displayName === lastRenameNameRef.current) return;
+    lastRenameNameRef.current = displayName;
+    dispatchSessionChangeRef.current?.({
+      type: 'rename',
+      sessionId,
+      newName: displayName,
+    });
+  }, [connection.sessionId, connection.displayName]);
 
   useEffect(() => {
     const nextGoal = getLatestActiveGoalFromBlocks(blocks);
@@ -3811,6 +3964,7 @@ export function App({
                   onLoadSession={loadSidebarSession}
                   onError={reportError}
                   mobileOpen={mobileDrawerOpen}
+                  sessionListReloadToken={sessionListReloadToken}
                 />
               </div>
             )}

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.test.tsx
@@ -89,29 +89,33 @@ function renderSidebar(
     onOpenDaemonStatus: () => void;
     onLoadSession: (sessionId: string) => Promise<void> | void;
     onError: (error: unknown, message: string) => void;
+    sessionListReloadToken: number;
   }> = {},
-): HTMLElement {
+): { container: HTMLElement; rerender: (props: typeof overrides) => void } {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
-  act(() => {
-    root.render(
-      <I18nProvider language="en">
-        <WebShellSidebar
-          collapsed={collapsed}
-          onCollapsedChange={noop}
-          onOpenSettings={noop}
-          onOpenDaemonStatus={noop}
-          onNewSession={() => false}
-          onLoadSession={noop}
-          onError={noop}
-          {...overrides}
-        />
-      </I18nProvider>,
-    );
-  });
+  const doRender = (props: typeof overrides) => {
+    act(() => {
+      root.render(
+        <I18nProvider language="en">
+          <WebShellSidebar
+            collapsed={collapsed}
+            onCollapsedChange={noop}
+            onOpenSettings={noop}
+            onOpenDaemonStatus={noop}
+            onNewSession={() => false}
+            onLoadSession={noop}
+            onError={noop}
+            {...props}
+          />
+        </I18nProvider>,
+      );
+    });
+  };
+  doRender(overrides);
   mounted.push({ root, container });
-  return container;
+  return { container, rerender: doRender };
 }
 
 beforeEach(() => {
@@ -150,7 +154,7 @@ afterEach(() => {
 
 describe('WebShellSidebar — version footer', () => {
   it('shows the qwen-code version in the footer when expanded', () => {
-    const container = renderSidebar(false);
+    const { container } = renderSidebar(false);
     const badge = container.querySelector('[title="Qwen Code v1.2.3"]');
     expect(badge).not.toBeNull();
     expect(badge?.textContent).toBe('v1.2.3');
@@ -158,7 +162,7 @@ describe('WebShellSidebar — version footer', () => {
 
   it('renders a non-semver fallback (e.g. "unknown") without a bogus "v" prefix', () => {
     mockConnection.capabilities = { qwenCodeVersion: 'unknown' };
-    const container = renderSidebar(false);
+    const { container } = renderSidebar(false);
     const badge = container.querySelector('[title="Qwen Code unknown"]');
     expect(badge).not.toBeNull();
     expect(badge?.textContent).toBe('unknown');
@@ -166,14 +170,14 @@ describe('WebShellSidebar — version footer', () => {
   });
 
   it('hides the version when the sidebar is collapsed', () => {
-    const container = renderSidebar(true);
+    const { container } = renderSidebar(true);
     expect(container.querySelector('[title="Qwen Code v1.2.3"]')).toBeNull();
     expect(container.textContent ?? '').not.toContain('v1.2.3');
   });
 
   it('renders no version badge when the daemon reports none', () => {
     mockConnection.capabilities = undefined;
-    const container = renderSidebar(false);
+    const { container } = renderSidebar(false);
     expect(container.textContent ?? '').not.toMatch(/v\d/);
   });
 });
@@ -181,7 +185,7 @@ describe('WebShellSidebar — version footer', () => {
 describe('WebShellSidebar — daemon status entry', () => {
   it('invokes onOpenDaemonStatus when the footer button is clicked', () => {
     const onOpenDaemonStatus = vi.fn();
-    const container = renderSidebar(false, { onOpenDaemonStatus });
+    const { container } = renderSidebar(false, { onOpenDaemonStatus });
     const button = container.querySelector<HTMLButtonElement>(
       '[aria-label="Daemon Status"]',
     );
@@ -194,7 +198,7 @@ describe('WebShellSidebar — daemon status entry', () => {
 
   it('still exposes the daemon status button when collapsed', () => {
     const onOpenDaemonStatus = vi.fn();
-    const container = renderSidebar(true, { onOpenDaemonStatus });
+    const { container } = renderSidebar(true, { onOpenDaemonStatus });
     const button = container.querySelector<HTMLButtonElement>(
       '[aria-label="Daemon Status"]',
     );
@@ -225,7 +229,7 @@ async function clickAsync(el: Element | null): Promise<void> {
 describe('WebShellSidebar — session export', () => {
   it('hides export action when daemon does not advertise session_export', () => {
     mockActive.sessions = [makeSession('session-1')];
-    const container = renderSidebar(false);
+    const { container } = renderSidebar(false);
 
     expect(
       container.querySelector('[aria-label="Export conversation record"]'),
@@ -248,7 +252,7 @@ describe('WebShellSidebar — session export', () => {
     const clickSpy = vi
       .spyOn(HTMLAnchorElement.prototype, 'click')
       .mockImplementation(() => {});
-    const container = renderSidebar(false);
+    const { container } = renderSidebar(false);
     const button = container.querySelector<HTMLButtonElement>(
       '[aria-label="Export conversation record"]',
     );
@@ -287,7 +291,7 @@ describe('WebShellSidebar — session export', () => {
     });
     vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
     const onLoadSession = vi.fn();
-    const container = renderSidebar(false, { onLoadSession });
+    const { container } = renderSidebar(false, { onLoadSession });
     const exportButton = container.querySelector<HTMLButtonElement>(
       '[aria-label="Export conversation record"]',
     );
@@ -323,7 +327,7 @@ describe('WebShellSidebar — session export', () => {
     const error = new Error('download failed');
     mockExportSession.mockRejectedValueOnce(error);
     const onError = vi.fn();
-    const container = renderSidebar(false, { onError });
+    const { container } = renderSidebar(false, { onError });
     const button = container.querySelector<HTMLButtonElement>(
       '[aria-label="Export conversation record"]',
     );
@@ -341,7 +345,7 @@ describe('WebShellSidebar — session export', () => {
 describe('WebShellSidebar — archive actions', () => {
   it('archives an active session from the quick action button', async () => {
     mockActive.sessions = [makeSession('aaaaaaaa')];
-    const container = renderSidebar(false);
+    const { container } = renderSidebar(false);
     const archiveBtn = container.querySelector<HTMLButtonElement>(
       '[aria-label="Archive"]',
     );
@@ -355,7 +359,7 @@ describe('WebShellSidebar — archive actions', () => {
   it('disables archiving the current session', () => {
     mockActive.sessions = [makeSession('current1')];
     mockConnection.sessionId = 'current1';
-    const container = renderSidebar(false);
+    const { container } = renderSidebar(false);
     const archiveBtn = container.querySelector<HTMLButtonElement>(
       '[aria-label="Archive"]',
     );
@@ -367,7 +371,7 @@ describe('WebShellSidebar — archive actions', () => {
 
   it('opens the overflow menu with rename, archive, and delete', () => {
     mockActive.sessions = [makeSession('aaaaaaaa')];
-    const container = renderSidebar(false);
+    const { container } = renderSidebar(false);
     click(container.querySelector('[aria-label="More actions"]'));
     const menu = container.querySelector('[role="menu"]');
     expect(menu).not.toBeNull();
@@ -379,7 +383,7 @@ describe('WebShellSidebar — archive actions', () => {
 
   it('archives a non-current session from the overflow menu', async () => {
     mockActive.sessions = [makeSession('aaaaaaaa')];
-    const container = renderSidebar(false);
+    const { container } = renderSidebar(false);
     click(container.querySelector('[aria-label="More actions"]'));
     const archiveItem = Array.from(
       container.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'),
@@ -390,7 +394,7 @@ describe('WebShellSidebar — archive actions', () => {
 
   it('reveals archived sessions on demand and restores them', async () => {
     mockArchived.sessions = [makeSession('bbbbbbbb', { isArchived: true })];
-    const container = renderSidebar(false);
+    const { container } = renderSidebar(false);
     // Collapsed by default: the archived rows (and their Restore button) are
     // not rendered until the section is expanded.
     expect(container.querySelector('[aria-label="Restore"]')).toBeNull();
@@ -404,5 +408,104 @@ describe('WebShellSidebar — archive actions', () => {
     expect(restoreBtn).not.toBeNull();
     await clickAsync(restoreBtn);
     expect(mockArchived.unarchiveSession).toHaveBeenCalledWith('bbbbbbbb');
+  });
+});
+
+describe('WebShellSidebar — sessionListReloadToken effect', () => {
+  it('calls reload when token changes', async () => {
+    mockActive.reload.mockResolvedValue(undefined);
+    const { rerender } = renderSidebar(false, {
+      sessionListReloadToken: 0,
+    });
+    expect(mockActive.reload).not.toHaveBeenCalled();
+
+    rerender({ sessionListReloadToken: 1 });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockActive.reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call reload when token is undefined', async () => {
+    mockActive.reload.mockResolvedValue(undefined);
+    const { rerender } = renderSidebar(false);
+
+    rerender({});
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockActive.reload).not.toHaveBeenCalled();
+  });
+
+  it('does not call reload when token is unchanged', async () => {
+    mockActive.reload.mockResolvedValue(undefined);
+    const { rerender } = renderSidebar(false, {
+      sessionListReloadToken: 1,
+    });
+    mockActive.reload.mockClear();
+
+    rerender({ sessionListReloadToken: 1 });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockActive.reload).not.toHaveBeenCalled();
+  });
+
+  it('skips reload when document is hidden', async () => {
+    mockActive.reload.mockResolvedValue(undefined);
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => true,
+    });
+    const { rerender } = renderSidebar(false, {
+      sessionListReloadToken: 0,
+    });
+
+    rerender({ sessionListReloadToken: 1 });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockActive.reload).not.toHaveBeenCalled();
+
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => false,
+    });
+  });
+
+  it('skips reload when a poll is already in flight', async () => {
+    let resolveFirstPoll: (() => void) | undefined;
+    mockActive.reload.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveFirstPoll = resolve;
+      }),
+    );
+    const { rerender } = renderSidebar(false, {
+      sessionListReloadToken: 0,
+    });
+
+    rerender({ sessionListReloadToken: 1 });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockActive.reload).toHaveBeenCalledTimes(1);
+
+    mockActive.reload.mockResolvedValue(undefined);
+    rerender({ sessionListReloadToken: 2 });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockActive.reload).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFirstPoll?.();
+      await Promise.resolve();
+    });
+
+    rerender({ sessionListReloadToken: 3 });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockActive.reload).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -38,6 +38,7 @@ interface WebShellSidebarProps {
   onLoadSession: (sessionId: string) => Promise<void> | void;
   onError: (error: unknown, fallback: string) => void;
   mobileOpen?: boolean;
+  sessionListReloadToken?: number;
 }
 
 function cx(...classes: Array<string | false | undefined>): string {
@@ -320,6 +321,7 @@ export function WebShellSidebar({
   onLoadSession,
   onError,
   mobileOpen,
+  sessionListReloadToken,
 }: WebShellSidebarProps) {
   const { t } = useI18n();
   const connection = useConnection();
@@ -455,6 +457,22 @@ export function WebShellSidebar({
     }, pollInterval);
     return () => window.clearInterval(intervalId);
   }, [error, hasRunningSession, projectExpanded, reload]);
+
+  const prevReloadTokenRef = useRef(sessionListReloadToken);
+  useEffect(() => {
+    if (
+      sessionListReloadToken !== undefined &&
+      sessionListReloadToken !== prevReloadTokenRef.current &&
+      !document.hidden &&
+      !pollInFlightRef.current
+    ) {
+      prevReloadTokenRef.current = sessionListReloadToken;
+      pollInFlightRef.current = true;
+      void reload().finally(() => {
+        pollInFlightRef.current = false;
+      });
+    }
+  }, [sessionListReloadToken, reload]);
 
   useEffect(() => {
     const runningBySessionId = new Map(

--- a/packages/web-shell/client/index.ts
+++ b/packages/web-shell/client/index.ts
@@ -1,5 +1,5 @@
 export { App as WebShell } from './App';
-export type { WebShellProps, BugReportInfo } from './App';
+export type { WebShellProps, BugReportInfo, SessionChangeEvent } from './App';
 export type { ComposerToolbarAction } from './components/ChatEditor';
 export type { ToastTone } from './components/ToastHost';
 export type { WebShellLanguage } from './i18n';


### PR DESCRIPTION
## What this PR does

Adds two new optional callbacks to `WebShellProps` that let external consumers observe session lifecycle events and intercept prompt submissions before they reach the daemon.

**`onSessionChange`** — fires on three session-level events via a discriminated union:

- `rename` — triggered when `connection.displayName` changes (driven by the SSE `session_metadata_updated` event). Carries `sessionId` and `newName`.
- `submit` — fires after `ensureSessionForPrompt()` resolves (direct submission) or when a prompt is enqueued while streaming (`queued: true`). Carries `sessionId`, `prompt` text, and `queued` flag. All prompts including slash commands go through this path.
- `turn_complete` — fires when `streamingState` transitions from non-idle to idle. Carries `sessionId` and an optional `error` (with block ID for diagnostics). Guarded by `streamingSessionIdRef` to prevent spurious events when the user switches sessions mid-stream.

Each event also bumps a `sessionListReloadToken` that triggers an immediate sidebar session list reload, with `pollInFlightRef` + `document.hidden` guards to prevent concurrent or hidden-tab requests. A delayed 2-second reload is scheduled after `submit` events to account for daemon-side session registration lag (the immediate reload may return a list that doesn't yet include the newly created session).

**`onSubmitBefore`** — an async hook called before every prompt submission (including slash commands like `/language` and `/model`, and also queued prompts). The hook receives `{ sessionId, prompt }` and returns a Promise:

- **Resolve** → submission proceeds normally.
- **Reject** → submission is cancelled. For direct submissions, all retry-critical refs (`lastSubmittedPrompt`, `lastSubmittedImages`, `retriedTurnErrorId`, `showRetryHint`) are restored to pre-hook values so Ctrl+Y retry works correctly. `isPreparingPrompt` is reset. A `console.warn` logs the rejection for diagnostics. For queued prompts, the prompt is simply not added to the queue.

While `onSubmitBefore` is pending for a direct submission, the composer shows a loading state (`isPreparingPrompt = true`) which disables the send button, preventing duplicate submissions. For queued prompts, the hook runs in the background (fire-and-forget) and the prompt is only enqueued if the hook resolves.

## Why it's needed

External consumers that embed the web shell component need two capabilities that were previously missing:

1. **Session lifecycle visibility** — consumers building their own session management UI or analytics need to know when sessions are renamed, prompts are submitted, and turns complete. The existing `onSessionIdChange` only covers session attachment, not these finer-grained events.

2. **Pre-submit gating** — consumers may need to validate, audit, or gate submissions before they reach the daemon (e.g., content policy checks, billing confirmation, rate limiting). Without `onSubmitBefore`, there was no interception point between the user pressing Enter and the prompt being sent.

The sidebar integration (reload token + delayed reload) solves a user-visible issue: after creating a new session, the sidebar would not show the new session until the next poll interval (up to 30 seconds in idle state), because the daemon's session list registration has a lag relative to the client-side session creation.

## Reviewer Test Plan

### How to verify

1. Build and serve: `npm run build && npm run dev` (or `qwen serve --web`).

2. **onSessionChange — rename**: Open the web shell, start a session, rename it via `/rename NewName`. Verify the `onSessionChange` callback fires with `{ type: 'rename', sessionId, newName: 'NewName' }`.

3. **onSessionChange — submit**: Type a prompt and press Enter. Verify the callback fires with `{ type: 'submit', sessionId, prompt, queued: false }`. While a turn is streaming, type another prompt and press Enter — verify the callback fires with `queued: true`.

4. **onSessionChange — turn_complete**: After a turn finishes, verify the callback fires with `{ type: 'turn_complete', sessionId, error: undefined }`. Trigger a turn error and verify `error` is an `Error` with the block ID in the message.

5. **onSubmitBefore — resolve**: Provide an `onSubmitBefore` that resolves. Verify prompts submit normally.

6. **onSubmitBefore — reject**: Provide an `onSubmitBefore` that rejects. Verify the prompt is cancelled, the composer returns to normal (no loading state stuck), and Ctrl+Y still works for the previous turn's retry.

7. **Sidebar reload**: After submitting a prompt in a new session, verify the sidebar shows the new session within ~2 seconds (not after the full poll interval).

8. Run typecheck and tests:
   - `npm run typecheck` — all packages pass.
   - `cd packages/web-shell && npx vitest run` — 972 tests pass.

### Evidence (Before & After)

N/A — the callbacks are additive APIs with no visual change when not provided. The sidebar reload improvement is observable as described in step 7 above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local dev via `npm run dev` with `qwen serve --web`. Unit tests via `vitest` in `packages/web-shell`.

## Risk & Scope

- Main risk or tradeoff: the delayed 2-second reload adds one extra `listSessions` API call per direct submission. This is bounded (the `clearTimeout` on the next submit prevents accumulation) and shares `pollInFlightRef` with the existing poll to prevent concurrent requests.
- Not validated / out of scope: no changes to the daemon, SDK, or session creation flow. The `onSubmitBefore` hook has no timeout — consumers must ensure their Promise settles.
- Breaking changes / migration notes: none — both new props are optional and backward-compatible.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

为 `WebShellProps` 新增两个可选回调，让外部消费者能够观察 session 生命周期事件并在 prompt 到达 daemon 之前拦截提交。

**`onSessionChange`** — 通过 discriminated union 触发三种 session 级事件：

- `rename` — 当 `connection.displayName` 变化时触发（由 SSE `session_metadata_updated` 事件驱动）。携带 `sessionId` 和 `newName`。
- `submit` — 在 `ensureSessionForPrompt()` resolve 后触发（直接提交），或在 streaming 期间入队时触发（`queued: true`）。携带 `sessionId`、`prompt` 文本和 `queued` 标记。所有 prompt（包括斜杠命令）都走这条路径。
- `turn_complete` — 当 `streamingState` 从非 idle 转为 idle 时触发。携带 `sessionId` 和可选的 `error`（含 block ID 用于诊断）。通过 `streamingSessionIdRef` 防止用户切换会话时产生虚假事件。

每个事件还会递增 `sessionListReloadToken`，触发 sidebar session 列表立即刷新，并通过 `pollInFlightRef` + `document.hidden` 守卫防止并发或隐藏标签页下的请求。`submit` 事件后会安排一次 2 秒延迟刷新，以应对 daemon 端 session 注册的延迟。

**`onSubmitBefore`** — 在每次 prompt 提交前调用的异步钩子（包括 `/language`、`/model` 等斜杠命令，也包括排队提交）。钩子接收 `{ sessionId, prompt }` 并返回 Promise：

- **resolve** → 正常继续提交。
- **reject** → 取消提交。对于直接提交，所有重试相关的 ref（`lastSubmittedPrompt`、`lastSubmittedImages`、`retriedTurnErrorId`、`showRetryHint`）恢复到钩子调用前的值，确保 Ctrl+Y 重试正常工作。`isPreparingPrompt` 重置。`console.warn` 记录拒绝原因用于诊断。对于排队提交，prompt 不会被加入队列。

直接提交时，`onSubmitBefore` 执行期间 composer 显示 loading 状态（`isPreparingPrompt = true`），发送按钮被禁用，防止重复提交。排队提交时，钩子在后台执行（fire-and-forget），只有 resolve 后才真正入队。

## 为什么需要

嵌入 web shell 组件的外部消费者需要两个之前缺失的能力：

1. **Session 生命周期可见性** — 构建自己的 session 管理 UI 或分析系统的消费者需要知道 session 何时被重命名、prompt 何时被提交、turn 何时完成。现有的 `onSessionIdChange` 只覆盖 session 挂载，不覆盖这些更细粒度的事件。

2. **提交前拦截** — 消费者可能需要在 prompt 到达 daemon 之前进行验证、审计或门控（如内容策略检查、计费确认、速率限制）。没有 `onSubmitBefore`，在用户按下回车和 prompt 被发送之间没有拦截点。

Sidebar 集成（reload token + 延迟刷新）解决了一个用户可见的问题：创建新 session 后，sidebar 在下一个轮询间隔（空闲状态下最长 30 秒）之前不会显示新 session，因为 daemon 端的 session 列表注册相对于客户端创建有延迟。

## 审阅者测试计划

### 如何验证

1. 构建并启动：`npm run build && npm run dev`（或 `qwen serve --web`）。

2. **onSessionChange — rename**：打开 web shell，启动 session，通过 `/rename NewName` 重命名。验证 `onSessionChange` 回调触发 `{ type: 'rename', sessionId, newName: 'NewName' }`。

3. **onSessionChange — submit**：输入 prompt 并按回车。验证回调触发 `{ type: 'submit', sessionId, prompt, queued: false }`。在 turn streaming 期间，输入另一个 prompt 并按回车——验证回调触发 `queued: true`。

4. **onSessionChange — turn_complete**：turn 完成后，验证回调触发 `{ type: 'turn_complete', sessionId, error: undefined }`。触发 turn 错误并验证 `error` 是一个 `Error`，message 中包含 block ID。

5. **onSubmitBefore — resolve**：提供一个 resolve 的 `onSubmitBefore`。验证 prompt 正常提交。

6. **onSubmitBefore — reject**：提供一个 reject 的 `onSubmitBefore`。验证 prompt 被取消，composer 恢复正常（不卡在 loading 状态），Ctrl+Y 仍能重试上一个 turn。

7. **Sidebar 刷新**：在新 session 中提交 prompt 后，验证 sidebar 在约 2 秒内显示新 session（而非等到完整的轮询间隔）。

8. 运行类型检查和测试：
   - `npm run typecheck` — 所有包通过。
   - `cd packages/web-shell && npx vitest run` — 972 个测试通过。

### 证据（前 / 后）

N/A — 回调是增量 API，不提供时无视觉变化。Sidebar 刷新改善可按上述第 7 步观察。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
| 🐧 Linux   |  ⚠️  |

### 环境（可选）

本地开发通过 `npm run dev` + `qwen serve --web`。单元测试通过 `vitest` 在 `packages/web-shell` 中运行。

## 风险与范围

- 主要风险/取舍：每次直接提交增加一次 2 秒延迟的 `listSessions` API 调用。这是有界的（下次提交时 `clearTimeout` 防止累积），并与现有轮询共享 `pollInFlightRef` 防止并发请求。
- 未验证 / 范围外：不修改 daemon、SDK 或 session 创建流程。`onSubmitBefore` 钩子没有超时——消费者必须确保其 Promise 会 settle。
- 破坏性变更 / 迁移说明：无——两个新 prop 都是可选的且向后兼容。

## 关联 Issue

N/A

</details>

