### PR TITLE
fix(cli): allow queued input during compression

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -37,8 +37,10 @@ import {
   AppContainer,
   dedupeNewestFirst,
   getNextRenderMode,
+  isInputActiveForState,
   isRenderModeToggleKey,
   mergeStartupWarnings,
+  shouldDrainMessageQueue,
 } from './AppContainer.js';
 import {
   formatSessionWindowTitle,
@@ -65,6 +67,7 @@ import {
 import {
   type HistoryItem,
   type HistoryItemWithoutId,
+  StreamingState,
   ToolCallStatus,
 } from './types.js';
 import type { RestoreOption } from './components/RewindSelector.js';
@@ -821,6 +824,48 @@ describe('AppContainer State Management', () => {
           />,
         );
       }).not.toThrow();
+    });
+
+    it('keeps input active while compression is processing', () => {
+      expect(
+        isInputActiveForState({
+          initError: null,
+          isProcessing: true,
+          hasPendingCompression: true,
+          streamingState: StreamingState.Idle,
+        }),
+      ).toBe(true);
+
+      expect(
+        isInputActiveForState({
+          initError: null,
+          isProcessing: true,
+          hasPendingCompression: false,
+          streamingState: StreamingState.Idle,
+        }),
+      ).toBe(false);
+    });
+
+    it('does not drain queued messages while compression is processing', () => {
+      expect(
+        shouldDrainMessageQueue({
+          isConfigInitialized: true,
+          streamingState: StreamingState.Idle,
+          isProcessing: true,
+          dialogsVisible: false,
+          messageQueueLength: 1,
+        }),
+      ).toBe(false);
+
+      expect(
+        shouldDrainMessageQueue({
+          isConfigInitialized: true,
+          streamingState: StreamingState.Idle,
+          isProcessing: false,
+          dialogsVisible: false,
+          messageQueueLength: 1,
+        }),
+      ).toBe(true);
     });
 
     it('submits /btw immediately instead of queueing while responding', () => {

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -277,6 +277,54 @@ function isToolExecuting(pendingHistoryItems: HistoryItemWithoutId[]) {
   });
 }
 
+function isCompressionPending(pendingHistoryItems: HistoryItemWithoutId[]) {
+  return pendingHistoryItems.some(
+    (item) =>
+      item.type === MessageType.COMPRESSION && item.compression.isPending,
+  );
+}
+
+export function isInputActiveForState({
+  initError,
+  isProcessing,
+  hasPendingCompression,
+  streamingState,
+}: {
+  initError: unknown;
+  isProcessing: boolean;
+  hasPendingCompression: boolean;
+  streamingState: StreamingState;
+}) {
+  return (
+    !initError &&
+    (!isProcessing || hasPendingCompression) &&
+    (streamingState === StreamingState.Idle ||
+      streamingState === StreamingState.Responding)
+  );
+}
+
+export function shouldDrainMessageQueue({
+  isConfigInitialized,
+  streamingState,
+  isProcessing,
+  dialogsVisible,
+  messageQueueLength,
+}: {
+  isConfigInitialized: boolean;
+  streamingState: StreamingState;
+  isProcessing: boolean;
+  dialogsVisible: boolean;
+  messageQueueLength: number;
+}) {
+  return (
+    isConfigInitialized &&
+    streamingState === StreamingState.Idle &&
+    !isProcessing &&
+    !dialogsVisible &&
+    messageQueueLength > 0
+  );
+}
+
 function getResponseCandidateTokens(
   pendingGeminiHistoryItems: HistoryItemWithoutId[],
 ): number {
@@ -2093,6 +2141,7 @@ export const AppContainer = (props: AppContainerProps) => {
 
       if (
         streamingState === StreamingState.Idle &&
+        !isProcessing &&
         isSlashCommand(submittedValue)
       ) {
         void submitQuery(submittedValue);
@@ -2105,6 +2154,7 @@ export const AppContainer = (props: AppContainerProps) => {
       addMessage,
       agentViewState,
       streamingState,
+      isProcessing,
       submitQuery,
       handleSlashCommand,
       config,
@@ -2142,6 +2192,7 @@ export const AppContainer = (props: AppContainerProps) => {
   );
   const stickyTodos = useStableStickyTodos(rawStickyTodos);
   const hasExecutingTool = isToolExecuting(pendingHistoryItems);
+  const hasPendingCompression = isCompressionPending(pendingHistoryItems);
 
   // Terminal tab progress bar (OSC 9;4) for iTerm2/Ghostty
   useTerminalProgress(streamingState, hasExecutingTool);
@@ -2335,15 +2386,16 @@ export const AppContainer = (props: AppContainerProps) => {
    * Determines if the input prompt should be active and accept user input.
    * Input is disabled during:
    * - Initialization errors
-   * - Slash command processing
+   * - Slash command processing, except pending compression where input can queue
    * - Tool confirmations (WaitingForConfirmation state)
    * - Any future streaming states not explicitly allowed
    */
-  const isInputActive =
-    !initError &&
-    !isProcessing &&
-    (streamingState === StreamingState.Idle ||
-      streamingState === StreamingState.Responding);
+  const isInputActive = isInputActiveForState({
+    initError,
+    isProcessing,
+    hasPendingCompression,
+    streamingState,
+  });
 
   const isFocused = useFocus();
   useBracketedPaste();
@@ -3635,10 +3687,17 @@ export const AppContainer = (props: AppContainerProps) => {
   const [queueDrainNonce, setQueueDrainNonce] = useState(0);
   useEffect(() => {
     if (queueDrainingRef.current) return;
-    if (!isConfigInitialized) return;
-    if (streamingState !== StreamingState.Idle) return;
-    if (dialogsVisible) return;
-    if (messageQueue.length === 0) return;
+    if (
+      !shouldDrainMessageQueue({
+        isConfigInitialized,
+        streamingState,
+        isProcessing,
+        dialogsVisible,
+        messageQueueLength: messageQueue.length,
+      })
+    ) {
+      return;
+    }
 
     // Two-phase: batch plain prompts as one turn, else pop next slash command.
     const plainPrompts = drainQueue();
@@ -3654,6 +3713,7 @@ export const AppContainer = (props: AppContainerProps) => {
   }, [
     isConfigInitialized,
     streamingState,
+    isProcessing,
     dialogsVisible,
     messageQueue,
     drainQueue,


### PR DESCRIPTION
## What this PR does

Keeps the interactive input prompt active while context compression is pending, so users can queue their next message instead of waiting for `/compress` to finish. It also prevents queued messages from draining while slash command processing is still active.

This also keeps idle slash commands from bypassing the queue during processing. Without that guard, commands such as `/model` could still submit immediately because the stream state is idle even though compression is still running.

## Why it's needed

During `/compress`, the stream state can be idle while slash command processing is still active. The previous input-active check hid the prompt whenever `isProcessing` was true, so users could not type the next message during compression.

Simply allowing the prompt to remain visible is not enough: the queue drain effect also needs to respect `isProcessing`, otherwise queued input could be submitted before compression finishes. This PR keeps input available for pending compression while preserving the existing queue ordering.

## Reviewer Test Plan

### How to verify

Run the AppContainer test file and confirm the new compression cases pass. The tests cover both sides of the behavior: input remains active while compression is processing, and queued messages do not drain until processing is no longer active.

    npm run test --workspace=packages/cli -- src/ui/AppContainer.test.tsx
    npm run typecheck --workspace=packages/cli
    npx eslint packages/cli/src/ui/AppContainer.tsx packages/cli/src/ui/AppContainer.test.tsx
    npx prettier --check packages/cli/src/ui/AppContainer.tsx packages/cli/src/ui/AppContainer.test.tsx

Expected output:

    ✓ src/ui/AppContainer.test.tsx (97 tests)

    Test Files  1 passed (1)
    Tests       97 passed (97)

The touched files also pass typecheck, lint, and formatting checks.

### Evidence (Before & After)

N/A

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Tested locally on Windows. Note: the local environment used Node v20.18.1 and emitted engine warnings because the project currently requires Node >=22, but the focused test, typecheck, lint, and format commands above completed successfully.

## Risk & Scope

- Main risk or tradeoff: Low; the change is scoped to AppContainer input activation and queued-message drain timing.
- Not validated / out of scope: Core compression behavior and chat compression internals are unchanged.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #6331

## 中文说明

## 这个 PR 做了什么

当上下文压缩仍在 pending 时，保持交互式输入框可用，让用户可以在 `/compress` 完成前排队下一条消息。同时，在 slash command processing 仍然 active 时，阻止队列里的消息提前 drain。

这个改动也避免 idle 状态下的 slash command 在 processing 期间绕过队列。否则像 `/model` 这样的命令可能会因为 stream state 已经是 idle 而立即提交，即使压缩还在运行。

## 为什么需要

执行 `/compress` 时，stream state 可能已经是 idle，但 slash command processing 仍然 active。此前的 input-active 判断会在 `isProcessing` 为 true 时隐藏输入框，所以用户无法在压缩期间输入下一条消息。

只让输入框显示出来还不够：queue drain effect 也需要尊重 `isProcessing`，否则 queued input 可能在压缩完成前就被提交。这个 PR 在 pending compression 场景下保持输入可用，同时保留现有队列顺序。

## Reviewer Test Plan

### 如何验证

运行 AppContainer 测试文件，确认新增的 compression 用例通过。测试覆盖两个关键行为：压缩 processing 时输入仍保持 active，并且 queued messages 在 processing 结束前不会 drain。

    npm run test --workspace=packages/cli -- src/ui/AppContainer.test.tsx
    npm run typecheck --workspace=packages/cli
    npx eslint packages/cli/src/ui/AppContainer.tsx packages/cli/src/ui/AppContainer.test.tsx
    npx prettier --check packages/cli/src/ui/AppContainer.tsx packages/cli/src/ui/AppContainer.test.tsx

预期输出：

    ✓ src/ui/AppContainer.test.tsx (97 tests)

    Test Files  1 passed (1)
    Tests       97 passed (97)

改动过的文件也已通过 typecheck、lint 和格式检查。

### 证据 Before & After

N/A

### 已测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### 环境

本地在 Windows 上测试。注意：本地环境使用 Node v20.18.1，项目当前要求 Node >=22，所以运行时有 engine warning；但上面列出的 focused test、typecheck、lint 和 format 命令都已成功完成。

## 风险与范围

- 主要风险或权衡：低；改动范围限定在 AppContainer 的输入激活逻辑和 queued-message drain 时机。
- 未验证或不在范围内：没有修改 core compression behavior 或 chat compression 内部逻辑。
- 破坏性变更或迁移说明：无。

## 关联 Issue

Fixes #6331