### PR TITLE
fix(cli): smoother live streaming preview — drop "generating more" cue, hold back partial table rows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,4 +127,6 @@ tmp/
 .venv
 .codegraph
 .qwen/computer-use/installed.json
+# Auto-generated computer-use marker can also appear under nested packages.
+**/.qwen/computer-use/
 .playwright-mcp/

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -371,8 +371,8 @@ const STREAM_PENDING_ITEM_MAX_CHARS = 16_384;
 // Rows kept in reserve below the commit budget so the incremental commit fires
 // BEFORE MarkdownDisplay's safety-net clip (which reserves 2). Keeping the
 // pending item's rendered height under the safety budget stops that clip from
-// engaging and flickering "generating more" / hiding a table in step with the
-// commit cycle.
+// engaging and hiding a table (or slicing the tail) in step with the commit
+// cycle.
 const STREAM_PENDING_COMMIT_RESERVE_ROWS = 5;
 // Conservative estimate of the rows the composer/footer occupy, used to derive
 // a content-area height from terminalHeight before the live value is known.

--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -310,6 +310,63 @@ Some text before.
       expect(lastFrame()).toMatchSnapshot();
     });
 
+    it('holds back an unterminated trailing table row while streaming', () => {
+      const text = `| A | B |
+|---|---|
+| one | two |
+| three | fo`.replace(/\n/g, eol);
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay {...baseProps} text={text} isPending={true} />,
+      );
+      const output = lastFrame() ?? '';
+      // The completed row renders inside the table…
+      expect(output).toContain('one');
+      expect(output).toContain('two');
+      // …but the still-typing frontier row is held back until its closing `|`,
+      // so it never flips between a stray text line and a table row (the source
+      // of per-token footer jitter).
+      expect(output).not.toContain('three');
+      expect(output).toContain('│');
+    });
+
+    it('renders the previously-held frontier row once it terminates', () => {
+      const text = `| A | B |
+|---|---|
+| one | two |
+| three | four |`.replace(/\n/g, eol);
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay {...baseProps} text={text} isPending={true} />,
+      );
+      const output = lastFrame() ?? '';
+      expect(output).toContain('three');
+      expect(output).toContain('four');
+    });
+
+    it('does not hold back a partial row in committed (non-pending) output', () => {
+      const text = `| A | B |
+|---|---|
+| one | two |
+| three | fo`.replace(/\n/g, eol);
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay {...baseProps} text={text} isPending={false} />,
+      );
+      // Committed transcript is final, not a streaming frontier — render as-is.
+      expect(lastFrame() ?? '').toContain('three');
+    });
+
+    it('still closes a streaming table when a non-pipe line follows', () => {
+      const text = `| A | B |
+|---|---|
+| one | two |
+Done.`.replace(/\n/g, eol);
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay {...baseProps} text={text} isPending={true} />,
+      );
+      const output = lastFrame() ?? '';
+      expect(output).toContain('one');
+      expect(output).toContain('Done');
+    });
+
     it('renders a single-column table', () => {
       const text = `
 | Name |

--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -342,6 +342,30 @@ Some text before.
       expect(output).toContain('four');
     });
 
+    it('holds back a partial first row, then pops the table in once it terminates', () => {
+      // Header + separator present but the first data row is still being typed.
+      // The partial row is held back and the table is not drawn yet, so there is
+      // no header+separator with a stray partial line flashing beneath it.
+      const partial = `| A | B |
+|---|---|
+| one | tw`.replace(/\n/g, eol);
+      const { lastFrame: partialFrame } = renderWithProviders(
+        <MarkdownDisplay {...baseProps} text={partial} isPending={true} />,
+      );
+      expect(partialFrame() ?? '').not.toContain('one');
+
+      // Once the row terminates, the table appears complete.
+      const complete = `| A | B |
+|---|---|
+| one | two |`.replace(/\n/g, eol);
+      const { lastFrame: completeFrame } = renderWithProviders(
+        <MarkdownDisplay {...baseProps} text={complete} isPending={true} />,
+      );
+      const out = completeFrame() ?? '';
+      expect(out).toContain('one');
+      expect(out).toContain('two');
+    });
+
     it('does not hold back a partial row in committed (non-pending) output', () => {
       const text = `| A | B |
 |---|---|

--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -101,11 +101,11 @@ describe('<MarkdownDisplay />', () => {
         />,
       );
       const output = lastFrame() ?? '';
-      // Contiguous head + a "generating more" cue — NOT decimated (ink
-      // overflow="hidden" would drop interspersed rows) and NOT blank.
+      // Clipped to budget: head lines present, tail dropped. No "generating more"
+      // cue — incremental scrollback commit (PR #6170) streams content in
+      // real-time, so clipped content is "still streaming" not "delayed output".
       expect(output).toContain('line 1');
       expect(output).toContain('line 2');
-      expect(output).toContain('generating more');
       // The tail is dropped (budget exceeded), so a late line is absent.
       expect(output).not.toContain('line 60');
       const lineCount = output.split('\n').length;
@@ -171,18 +171,14 @@ describe('<MarkdownDisplay />', () => {
       );
       const output = lastFrame() ?? '';
       expect(output.split('\n').length).toBeLessThanOrEqual(10);
-      // The head-slice bounds code content to <= availableTerminalHeight - 2
-      // (= RenderCodeBlock's own inner budget), so the inner "generating more"
-      // never fires inside a slice — there is at most ONE cue, not two stacked.
-      expect(
-        (output.match(/generating more/g) ?? []).length,
-      ).toBeLessThanOrEqual(1);
+      // No "generating more" cue — all cues removed (PR #6170 incremental commit
+      // handles real-time streaming).
+      expect(output.match(/generating more/g) ?? []).toHaveLength(0);
     });
 
     it('does not stack a double cue for a math block near the clip boundary', () => {
-      // RenderMathBlock reserves more rows (RESERVED_LINES=3) than a code block;
-      // the head-slice budget reserves 2 rows so a retained math block never
-      // hits its own inner truncation cue on top of the outer one.
+      // No "generating more" cue — all cues removed (PR #6170 incremental commit
+      // handles real-time streaming).
       const text = [
         '$$',
         ...Array.from({ length: 40 }, (_, i) => `x_{${i}} +`),
@@ -197,9 +193,7 @@ describe('<MarkdownDisplay />', () => {
         />,
       );
       const output = lastFrame() ?? '';
-      expect(
-        (output.match(/generating more/g) ?? []).length,
-      ).toBeLessThanOrEqual(1);
+      expect(output.match(/generating more/g) ?? []).toHaveLength(0);
       expect(output.split('\n').length).toBeLessThanOrEqual(8);
     });
 
@@ -224,7 +218,7 @@ describe('<MarkdownDisplay />', () => {
 
     it('applies the minimum floor at a degenerate budget of 1', () => {
       // Math.max(MIN_PENDING_CONTENT_LINES, 1 - 2) = 1 (floored): keep one
-      // content line + the cue, never 0 or negative.
+      // content line, never 0 or negative. No "generating more" cue.
       const text = Array.from({ length: 60 }, (_, i) => `line ${i + 1}`).join(
         eol,
       );
@@ -239,7 +233,7 @@ describe('<MarkdownDisplay />', () => {
       const output = lastFrame() ?? '';
       expect(output).toContain('line 1');
       expect(output).not.toContain('line 2');
-      expect(output).toContain('generating more');
+      expect(output).not.toContain('generating more');
     });
 
     it('renders unordered lists with different markers', () => {

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -25,6 +25,14 @@ import {
 // coupled to MaxSizedBox's floor).
 const MIN_PENDING_CONTENT_LINES = 1;
 
+// Rows reserved from the viewport when clamping a streaming table's height:
+// marginY 2 + one row of wrapped-cell safety headroom. Tables under-estimate
+// their rendered height the most (a wrapped cell), so they keep one more
+// reserved row than the other blocks. Shared by the render-side clamp
+// (RenderTable's `maxHeight`) and the slice-side estimate (`tableClampRows`)
+// so the two never diverge and let a table overflow the render cap.
+const TABLE_PENDING_RESERVED_ROWS = 3;
+
 interface MarkdownDisplayProps {
   text: string;
   isPending: boolean;
@@ -170,7 +178,7 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
   if (pendingRenderedBudget !== undefined) {
     const tableClampRows =
       availableTerminalHeight !== undefined
-        ? Math.max(2, availableTerminalHeight - 3)
+        ? Math.max(2, availableTerminalHeight - TABLE_PENDING_RESERVED_ROWS)
         : Number.MAX_SAFE_INTEGER;
     const { keptLines } = fitPendingSlice(
       allLines,
@@ -354,18 +362,19 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
       inTable &&
       !tableRowMatch &&
       index === lines.length - 1 &&
-      tableRows.length > 0 &&
+      tableHeaders.length > 0 &&
       /^\s*\|/.test(line)
     ) {
-      // Live streaming frontier: the final line is an unterminated table row
-      // (`| a | b` with no closing `|` yet). Rendering it as a plain text line
-      // below the table — then flipping it into the table once the closing `|`
-      // arrives — makes the frame height and column widths oscillate on every
-      // token, which visibly jitters the footer/composer. Hold the partial row
-      // back instead: skip it so `inTable` stays set and the end-of-content
-      // handler renders the accumulated rows as a live table. The row appears
-      // the moment it terminates. Only when at least one row already exists, so
-      // the header + separator never blank out while the first row is typed.
+      // Live streaming frontier: the final line is an unterminated table row or
+      // separator (`| a | b` with no closing `|` yet). Rendering it as a plain
+      // text line and then flipping it into the table once the closing `|`
+      // arrives makes the frame height and column widths oscillate on every
+      // token, which visibly jitters the footer/composer. Hold it back instead:
+      // skip it so `inTable` stays set and the end-of-content handler renders
+      // only the COMPLETE rows as a live table. A partial row never flips in;
+      // the table appears once its first row terminates and grows one complete
+      // row at a time. Until then the table is simply not drawn (no header +
+      // separator with a stray partial line beneath it).
     } else if (inTable && !tableRowMatch) {
       // End of table — a following line closes it, so this table is COMPLETE
       // and renders in full (the rendered-aware slice guarantees a completed
@@ -894,14 +903,6 @@ interface RenderTableProps {
   isPending?: boolean;
   availableTerminalHeight?: number;
 }
-
-// Backstop only: the pending slice bounds a completed table's height assuming
-// single-line cells, but a cell that WRAPS renders taller and could still
-// overflow. While streaming, cap the table to the viewport (reserve 3 rows:
-// marginY 2 + one row of wrapped-cell safety headroom) so it can never trigger
-// the scroll-to-top lock. Tables under-estimate their rendered height the most
-// (a wrapped cell), so they keep one more reserved row than the other blocks.
-const TABLE_PENDING_RESERVED_ROWS = 3;
 
 const RenderTableInternal: React.FC<RenderTableProps> = ({
   headers,

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -898,7 +898,9 @@ interface RenderTableProps {
 // Backstop only: the pending slice bounds a completed table's height assuming
 // single-line cells, but a cell that WRAPS renders taller and could still
 // overflow. While streaming, cap the table to the viewport (reserve 3 rows:
-// marginY 2 + the outer cue) so it can never trigger the scroll-to-top lock.
+// marginY 2 + one row of wrapped-cell safety headroom) so it can never trigger
+// the scroll-to-top lock. Tables under-estimate their rendered height the most
+// (a wrapped cell), so they keep one more reserved row than the other blocks.
 const TABLE_PENDING_RESERVED_ROWS = 3;
 
 const RenderTableInternal: React.FC<RenderTableProps> = ({

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -21,8 +21,8 @@ import {
   TABLE_SEPARATOR_RE,
   CODE_FENCE_RE,
 } from './pending-rendered-height.js';
-// Minimum content lines to keep in a clipped live preview before the
-// "generating more" cue (own constant — not coupled to MaxSizedBox's floor).
+// Minimum content lines to keep in a clipped live preview (own constant — not
+// coupled to MaxSizedBox's floor).
 const MIN_PENDING_CONTENT_LINES = 1;
 
 interface MarkdownDisplayProps {
@@ -131,12 +131,13 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
   // top lock"). The rendered-height-aware slice below keeps a CONTIGUOUS head of
   // source lines whose RENDERED height fits the budget; a contiguous slice
   // (rather than ink `overflow="hidden"`) avoids decimating interspersed rows
-  // and preserves a code block's own truncation cue. The full message still
+  // and preserves a code block's own truncation. The full message still
   // renders once it commits to `<Static>`. Only while pending and when a budget
   // is known (constrainHeight on — both non-VP and VP pending items pass one).
   //
-  // Reserve 2 rows: 1 for the "generating more" cue, 1 so a retained code/math
-  // block's OWN inner truncation cue can't stack on top of the outer one.
+  // Reserve 2 rows of headroom below the viewport so the live frame stays bound
+  // even when a retained code/math block's own rendered height slightly exceeds
+  // the source-line estimate.
   //
   // This is a SAFETY NET on top of incremental scrollback commit: it guarantees
   // the live frame never exceeds the viewport regardless of how the streaming
@@ -164,23 +165,20 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
   // exceeds the viewport, so ink cannot fall into its from-top full-redraw path
   // (the scroll-to-top lock). Note keptLines can be 0 when even the first
   // line/table alone overflows (e.g. a single very wide/CJK line that wraps past
-  // the budget): render nothing plus the "generating more" cue rather than one
-  // oversized row that would bypass the bound.
+  // the budget): render nothing rather than an oversized row.
   let lines = allLines;
-  let pendingClipped = false;
   if (pendingRenderedBudget !== undefined) {
     const tableClampRows =
       availableTerminalHeight !== undefined
         ? Math.max(2, availableTerminalHeight - 3)
         : Number.MAX_SAFE_INTEGER;
-    const { keptLines, clipped } = fitPendingSlice(
+    const { keptLines } = fitPendingSlice(
       allLines,
       contentWidth,
       pendingRenderedBudget,
       tableClampRows,
     );
-    if (clipped) {
-      pendingClipped = true;
+    if (keptLines < allLines.length) {
       lines = allLines.slice(0, keptLines);
     }
   }
@@ -568,20 +566,12 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
     );
   }
 
-  // When the live message was clipped to a head slice (see pendingLineBudget
-  // above), add a cue that more is streaming. Code blocks retained in the head
-  // still render their own "... generating more ..." truncation.
-  if (pendingClipped) {
-    return (
-      <Box flexDirection="column">
-        {contentBlocks}
-        <Text color={theme.text.secondary} wrap="truncate">
-          ... generating more ...
-        </Text>
-      </Box>
-    );
-  }
-
+  // Safety-net clip: when the pending preview exceeds the rendered-height
+  // budget, slice it to keep the live frame within the viewport. The clipping
+  // still happens (prevents scroll-to-top lock), but we no longer show the
+  // "... generating more ..." cue — incremental scrollback commit (PR #6170)
+  // already streams content to <Static> in real-time, so clipped content is
+  // not "delayed output" but rather "still streaming".
   return <>{contentBlocks}</>;
 };
 
@@ -608,8 +598,13 @@ const RenderCodeBlockInternal: React.FC<RenderCodeBlockProps> = ({
 }) => {
   const settings = useSettings();
   const { renderMode } = useRenderMode();
-  const MIN_LINES_FOR_MESSAGE = 1; // Minimum lines to show before the "generating more" message
-  const RESERVED_LINES = 2; // Lines reserved for the message itself and potential padding
+  // Below this many usable rows there is no room for a meaningful code
+  // preview, so we fall back to the "... code is being written ..." notice.
+  const MIN_PREVIEW_LINES = 1;
+  // One row of headroom below availableTerminalHeight. This used to also hold a
+  // "... generating more ..." cue (removed with PR #6170's incremental commit),
+  // so the reclaimed row now shows an extra code line at the same total height.
+  const RESERVED_LINES = 1;
 
   if (lang?.toLowerCase() === 'mermaid' && renderMode === 'render') {
     if (isPending) {
@@ -642,8 +637,8 @@ const RenderCodeBlockInternal: React.FC<RenderCodeBlockProps> = ({
     );
 
     if (content.length > MAX_CODE_LINES_WHEN_PENDING) {
-      if (MAX_CODE_LINES_WHEN_PENDING < MIN_LINES_FOR_MESSAGE) {
-        // Not enough space to even show the message meaningfully
+      if (MAX_CODE_LINES_WHEN_PENDING < MIN_PREVIEW_LINES) {
+        // Not enough space to even show a truncated preview meaningfully
         return (
           <Box paddingLeft={CODE_BLOCK_PREFIX_PADDING}>
             <Text color={theme.text.secondary}>
@@ -664,7 +659,6 @@ const RenderCodeBlockInternal: React.FC<RenderCodeBlockProps> = ({
       return (
         <Box paddingLeft={CODE_BLOCK_PREFIX_PADDING} flexDirection="column">
           {colorizedTruncatedCode}
-          <Text color={theme.text.secondary}>... generating more ...</Text>
         </Box>
       );
     }
@@ -702,10 +696,13 @@ interface RenderPendingMermaidBlockProps {
 const RenderPendingMermaidBlockInternal: React.FC<
   RenderPendingMermaidBlockProps
 > = ({ content, availableTerminalHeight, contentWidth }) => {
+  // Reserve one row for the "Mermaid diagram is being written..." header. The
+  // second reserved row used to hold a "... generating more ..." cue (removed
+  // with PR #6170); reclaiming it shows an extra preview line at the same height.
   const maxPreviewLines =
     availableTerminalHeight === undefined
       ? 6
-      : Math.max(0, availableTerminalHeight - 2);
+      : Math.max(0, availableTerminalHeight - 1);
   const previewLines = content.slice(0, maxPreviewLines);
   return (
     <Box
@@ -720,9 +717,6 @@ const RenderPendingMermaidBlockInternal: React.FC<
           {line || ' '}
         </Text>
       ))}
-      {content.length > previewLines.length && (
-        <Text color={theme.text.secondary}>... generating more ...</Text>
-      )}
     </Box>
   );
 };
@@ -744,7 +738,10 @@ const RenderMathBlockInternal: React.FC<RenderMathBlockProps> = ({
   isPending,
   availableTerminalHeight,
 }) => {
-  const RESERVED_LINES = 3;
+  // One row for the "LaTeX block · source:" header plus one row of headroom.
+  // The third row used to hold a "... generating more ..." cue (removed with PR
+  // #6170); reclaiming it shows an extra preview line at the same total height.
+  const RESERVED_LINES = 2;
   if (isPending && availableTerminalHeight !== undefined) {
     const maxPreviewLines = Math.max(
       0,
@@ -767,7 +764,6 @@ const RenderMathBlockInternal: React.FC<RenderMathBlockProps> = ({
               {line || ' '}
             </Text>
           ))}
-          <Text color={theme.text.secondary}>... generating more ...</Text>
         </Box>
       );
     }

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -349,6 +349,23 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
         cells.length = tableHeaders.length;
       }
       tableRows.push(cells);
+    } else if (
+      isPending &&
+      inTable &&
+      !tableRowMatch &&
+      index === lines.length - 1 &&
+      tableRows.length > 0 &&
+      /^\s*\|/.test(line)
+    ) {
+      // Live streaming frontier: the final line is an unterminated table row
+      // (`| a | b` with no closing `|` yet). Rendering it as a plain text line
+      // below the table — then flipping it into the table once the closing `|`
+      // arrives — makes the frame height and column widths oscillate on every
+      // token, which visibly jitters the footer/composer. Hold the partial row
+      // back instead: skip it so `inTable` stays set and the end-of-content
+      // handler renders the accumulated rows as a live table. The row appears
+      // the moment it terminates. Only when at least one row already exists, so
+      // the header + separator never blank out while the first row is typed.
     } else if (inTable && !tableRowMatch) {
       // End of table — a following line closes it, so this table is COMPLETE
       // and renders in full (the rendered-aware slice guarantees a completed

--- a/packages/cli/src/ui/utils/pending-rendered-height.ts
+++ b/packages/cli/src/ui/utils/pending-rendered-height.ts
@@ -132,7 +132,7 @@ export interface PendingSliceResult {
   /**
    * Number of leading source lines whose combined RENDERED height fits within
    * `budget`. May be 0 when even the first line/table alone overflows (the
-   * caller then renders nothing plus a "more" cue rather than an oversized row).
+   * caller then renders nothing rather than an oversized row).
    */
   keptLines: number;
   /** True when some trailing source lines were dropped to fit the budget. */


### PR DESCRIPTION
## What this PR does

Two related tidy-ups to the non-VP live streaming markdown preview:

1. **Drop the `... generating more ...` cue.** The preview is clipped to a rendered-height budget so the frame never overflows the viewport (which would trigger ink's scroll-to-top full redraw). It used to append a `... generating more ...` line under the clipped head, in four places: the outer preview clip and the code / mermaid / math blocks. All four are removed and the single row each cue occupied is reclaimed for real content, so the total rendered height is unchanged. The `TableRenderer` `… more rows streaming …` clamp is deliberately kept.

2. **Hold back the unterminated table row while streaming.** While a table streams, the frontier line is often a half-typed row like `| a | b` with no closing `|` yet. Since a table row needs both a leading and trailing pipe, that partial line did not match, so the parser closed the table and rendered the partial as a plain text line below it — then flipped it into the table once the closing `|` arrived. That per-token flip changed the frame height and re-ran column autosizing on every keystroke, jittering the live table. Now the partial row is held back (when at least one complete row already exists) so the table renders steadily and the row appears the moment it terminates.

It also gitignores the nested `.qwen/computer-use/` marker so that auto-generated artifact stops showing up as untracked.

## Why it's needed

The cue existed to tell the user the clipped tail was still coming. Since #6170 landed the incremental scrollback commit, that tail is streamed into `<Static>` in real time — clipped content is "still streaming" and reappears within a commit cycle, not "delayed output". The cue is therefore redundant, and because it is emitted in step with the commit cycle it visibly flickers on and off. The `TableRenderer` clamp is different and kept on purpose: an in-progress oversized table is not yet committed to scrollback, so `… more rows streaming …` still carries information.

The table hold-back removes the most visible source of live-table jitter — the partial-row flip-flop that reflowed the table on every token.

## Reviewer Test Plan

### How to verify

Ask the model for a long markdown table (~60 rows) and watch the stream at two terminal sizes:

- **80×20 (short viewport):** during streaming, no `... generating more ...` appears anywhere; the live table grows one complete row at a time without the per-token flip/reflow; the `… more rows streaming …` clamp still shows on the in-progress oversized table (kept by design); scrolling up mid-stream does NOT jump the viewport to the top and lock it; on completion the full table renders.
- **134×65 (large viewport):** the table fits within the height so nothing is clamped — no cue strings appear at all, the table streams smoothly, and scrolling stays stable.

Also stream a long code block (~80 lines) and confirm no `... generating more ...` at either size.

Unit tests: `npx vitest run packages/cli/src/ui/utils/MarkdownDisplay.test.tsx` → 128 passed (includes four new cases: a partial frontier row is held back, it appears once terminated, a committed/non-pending partial row is not held back, and a non-pipe line still closes the table).

### Evidence (Before & After)

- **Before:** a dim `... generating more ...` line renders under the clipped head and flickers with each scrollback commit; a streaming table flips its frontier row between a stray text line and a table row on every token, reflowing the table.
- **After:** no `... generating more ...` at any viewport size; the streaming table grows one complete row at a time with no per-token reflow. The `… more rows streaming …` table clamp is unchanged.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

Local `npm run dev` on macOS.

## Risk & Scope

- Main risk or tradeoff: presentation-only changes to the non-VP live preview. The rendered-height clip / safety-net still runs unchanged, and the table hold-back only defers an already-incomplete frontier row until it terminates — total rendered height is held constant — so there is no scroll-to-top regression.
- Not addressed here: the fixed bottom controls (loading line / input / footer) still repaint on each streaming tick. That is repaint-frequency flicker, a separate concern from this content-level change, and is the domain of the flicker-reduction work (e.g. #5396).
- Not validated / out of scope: Windows and Linux rendering (macOS only locally; CI covers the rest).
- Breaking changes / migration notes: none.
- Note for rebasing: touches `useGeminiStream.ts` (one comment only), which overlaps the file edited by #5396 — trivial to resolve.

## Linked Issues

Relates to #6170 (incremental scrollback commit that makes the cue redundant) and #5941 (original scroll-to-top lock, already fixed by #6170). No closing keyword.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

针对 non-VP 模式的 live 串流 markdown 预览，做两处相关的整理：

1. **移除 `... generating more ...` 提示。** 预览会被裁切到「算绘高度」预算内，避免画面超出视窗（超出会触发 ink 从顶端整屏重绘）。原本会在裁切后的头部下方附加一行 `... generating more ...`，共四处：外层预览裁切，以及 code / mermaid / math 区块。四处全部移除，且每个提示原本占用的那一行改还给实际内容，因此总算绘高度不变。`TableRenderer` 的 `… more rows streaming …` clamp 刻意保留。

2. **串流中保留还没输入完的表格列。** 表格串流时，最前缘那一行常是还没收尾的 `| a | b`（缺结尾 `|`）。因为表格列需要首尾都有 `|`，这半成品行不符合，于是 parser 会关闭表格、把它画成表格下方的一行纯文字，等结尾 `|` 到了再翻进表格。这个「每个 token 翻牌」会改变画面高度并重算栏宽，让 live 表格抖动。现在改成把半成品行保留（在已有至少一列完整资料时），表格稳定成长，该列一收尾就出现。

另外把巢状的 `.qwen/computer-use/` 标记加入 gitignore，让这个自动产生的档案不再显示为未追踪。

## 为什么需要

提示原本是要告诉使用者被裁掉的尾巴还在后面。但自从 #6170 加入 incremental scrollback commit，那段尾巴会即时串流进 `<Static>`——被裁的内容是「还在串流」、会在一个 commit 周期内重新出现，而非「被延迟的输出」。因此提示多余，且它随 commit 周期出现／消失、会明显闪烁。`TableRenderer` 的 clamp 情况不同、刻意保留：一张还在写入的超高表格尚未提交进 scrollback，所以 `… more rows streaming …` 仍带有资讯。表格保留则移除了 live 表格最明显的抖动来源——每个 token 让表格 reflow 的半成品行翻牌。

## Reviewer 测试计划

请模型产生一个长 markdown 表格（约 60 列），在两种视窗大小下观察串流：

- **80×20（矮视窗）：** 串流中任何位置都不该出现 `... generating more ...`；live 表格每次长一整列、没有逐 token 的翻牌／reflow；`… more rows streaming …` clamp 仍显示在还在写入的超高表格上（刻意保留）；串流中往上滚动不会跳到最顶并锁死；结束后完整表格正常算绘。
- **134×65（大视窗）：** 表格放得下、不会被 clamp——完全不出现任何提示字串，表格串流顺畅，滚动稳定。

另外串流一段长 code 区块（约 80 行），确认两种大小下都不出现 `... generating more ...`。

单元测试：`npx vitest run packages/cli/src/ui/utils/MarkdownDisplay.test.tsx` → 128 passed（含四个新案例：保留半成品前缘行、收尾后出现、非 pending 的半成品行不保留、非管线行仍正常关表）。

## 风险与范围

- 主要风险：仅影响 non-VP live 预览的呈现。算绘高度裁切／安全网仍照常执行；表格保留只是把一条本来就不完整的前缘行延后到收尾，总算绘高度不变——因此不会有 scroll-to-top 回归。
- 本 PR 未处理：下方固定栏（载入行／输入栏／footer）在每次串流 tick 仍会重绘。那是「重绘频率」的闪烁，与本次内容层级的修改是不同问题，属于减少闪烁的工作范畴（例如 #5396）。
- 未验证：Windows 与 Linux 算绘（本机仅 macOS，其余交由 CI）。
- 破坏性变更：无。
- rebase 提醒：改动了 `useGeminiStream.ts`（仅一行注解），与 #5396 编辑同一档案，冲突极易解决。

## 关联 Issue

关联 #6170（让提示变多余的 incremental scrollback commit）与 #5941（原始 scroll-to-top 锁死问题，已由 #6170 修复）。未使用关闭关键字。

</details>
