### PR TITLE
fix(web-shell): finalize deferred gated submissions

### DIFF
--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -21,7 +21,11 @@ type MockConnection = {
 };
 
 type ChatEditorTestProps = {
-  onSubmit: (text: string) => boolean | void;
+  onSubmit: (
+    text: string,
+    images?: undefined,
+    commitAccepted?: () => void,
+  ) => boolean | void;
   isPreparing?: boolean;
 };
 
@@ -35,6 +39,7 @@ const {
   sidebarTokens,
   rawEnqueuePrompt,
   editorClear,
+  editorCommit,
 } = vi.hoisted(() => {
   const connection: MockConnection = {
     status: 'connected',
@@ -94,6 +99,7 @@ const {
     sidebarTokens: [] as Array<number | undefined>,
     rawEnqueuePrompt: vi.fn(() => true),
     editorClear: vi.fn(),
+    editorCommit: vi.fn(),
   };
 });
 
@@ -171,7 +177,8 @@ vi.mock('./components/ChatEditor', async () => {
         {
           'data-testid': 'submit',
           'data-preparing': props.isPreparing ? 'true' : 'false',
-          onClick: () => props.onSubmit(testState.prompt),
+          onClick: () =>
+            props.onSubmit(testState.prompt, undefined, editorCommit),
           type: 'button',
         },
         'submit',
@@ -319,6 +326,7 @@ beforeEach(() => {
   sidebarTokens.length = 0;
   rawEnqueuePrompt.mockClear();
   editorClear.mockClear();
+  editorCommit.mockClear();
   mockFollowup.clear.mockClear();
   for (const value of Object.values(mockSessionActions)) {
     if (typeof value === 'function' && 'mockClear' in value) value.mockClear();
@@ -376,7 +384,8 @@ describe('App session callbacks', () => {
       'hello',
       expect.objectContaining({ retry: undefined }),
     );
-    expect(editorClear).toHaveBeenCalledTimes(1);
+    expect(editorCommit).toHaveBeenCalledTimes(1);
+    expect(editorClear).not.toHaveBeenCalled();
     expect(onSessionChange).toHaveBeenCalledWith({
       type: 'submit',
       sessionId: 'session-1',
@@ -417,6 +426,7 @@ describe('App session callbacks', () => {
 
     mockSessionActions.sendPrompt.mockClear();
     editorClear.mockClear();
+    editorCommit.mockClear();
     testState.prompt = 'blocked';
     await clickSubmit(container);
     await flush();
@@ -424,6 +434,7 @@ describe('App session callbacks', () => {
     expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
     expect(mockFollowup.clear).toHaveBeenCalledTimes(1);
     expect(editorClear).toHaveBeenCalledTimes(0);
+    expect(editorCommit).toHaveBeenCalledTimes(0);
     expect(testState.latestChatEditorProps?.isPreparing).toBe(false);
     expect(container.querySelector('[data-testid="retry"]')).not.toBeNull();
 
@@ -462,6 +473,7 @@ describe('App session callbacks', () => {
     await clickSubmit(container);
     expect(rawEnqueuePrompt).not.toHaveBeenCalled();
     expect(editorClear).not.toHaveBeenCalled();
+    expect(editorCommit).not.toHaveBeenCalled();
 
     await act(async () => {
       approve?.();
@@ -479,7 +491,8 @@ describe('App session callbacks', () => {
       prompt: 'queued',
       queued: true,
     });
-    expect(editorClear).toHaveBeenCalledTimes(1);
+    expect(editorCommit).toHaveBeenCalledTimes(1);
+    expect(editorClear).not.toHaveBeenCalled();
   });
 
   it('cancels queued submissions when onSubmitBefore rejects', async () => {
@@ -495,6 +508,25 @@ describe('App session callbacks', () => {
     await flush();
 
     expect(rawEnqueuePrompt).not.toHaveBeenCalled();
+    expect(editorClear).not.toHaveBeenCalled();
+    expect(editorCommit).not.toHaveBeenCalled();
+  });
+
+  it('keeps daemon-bound slash command drafts when onSubmitBefore rejects', async () => {
+    const onSubmitBefore = vi.fn().mockRejectedValue(new Error('blocked'));
+    const { container } = renderApp({ onSubmitBefore });
+    await flush();
+
+    testState.prompt = '/goal ship it';
+    await clickSubmit(container);
+    await flush();
+
+    expect(onSubmitBefore).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      prompt: '/goal ship it',
+    });
+    expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
+    expect(editorCommit).not.toHaveBeenCalled();
     expect(editorClear).not.toHaveBeenCalled();
   });
 

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -36,7 +36,10 @@ import {
   ChatEditor,
   type ComposerToolbarAction,
 } from './components/ChatEditor';
-import type { EditorHandle } from './hooks/useComposerCore';
+import type {
+  ComposerSubmitCommit,
+  EditorHandle,
+} from './hooks/useComposerCore';
 import type { PromptImage } from './adapters/promptTypes';
 import { StatusBar, type StatusBarHandle } from './components/StatusBar';
 import { StreamingStatus } from './components/StreamingStatus';
@@ -273,6 +276,7 @@ interface SendPromptOptionsWithRetry {
   images?: PromptImage[];
   retry?: boolean;
   clearComposerOnPromptStart?: boolean;
+  commitComposerAccepted?: ComposerSubmitCommit;
 }
 
 type GoalStatusTranscriptBlock = DaemonTranscriptBlock & {
@@ -1361,6 +1365,7 @@ export function App({
         optimisticUserMessage?: boolean;
         retry?: boolean;
         clearComposerOnPromptStart?: boolean;
+        commitComposerAccepted?: ComposerSubmitCommit;
       },
     ) => {
       const isUserPrompt = !text.trimStart().startsWith('/');
@@ -1418,7 +1423,9 @@ export function App({
         optimisticUserMessage: opts?.optimisticUserMessage,
         retry: opts?.retry,
       };
-      if (opts?.clearComposerOnPromptStart) {
+      if (opts?.commitComposerAccepted) {
+        opts.commitComposerAccepted();
+      } else if (opts?.clearComposerOnPromptStart) {
         editorRef.current?.clear();
       }
       const sessionIdAfterEnsure = connectionRef.current.sessionId;
@@ -1522,7 +1529,12 @@ export function App({
   });
 
   const enqueuePrompt = useCallback(
-    (text: string, images?: PromptImage[], onComplete?: () => void) => {
+    (
+      text: string,
+      images?: PromptImage[],
+      onComplete?: () => void,
+      commitComposerAccepted?: ComposerSubmitCommit,
+    ) => {
       if (onSubmitBeforeRef.current) {
         onSubmitBeforeRef
           .current({
@@ -1532,7 +1544,11 @@ export function App({
           .then(() => {
             const result = rawEnqueuePrompt(text, images, onComplete);
             if (result !== false) {
-              editorRef.current?.clear();
+              if (commitComposerAccepted) {
+                commitComposerAccepted();
+              } else {
+                editorRef.current?.clear();
+              }
             }
             const sessionId = connectionRef.current.sessionId;
             if (sessionId && text.trim()) {
@@ -2371,15 +2387,23 @@ export function App({
     (
       text: string,
       images?: PromptImage[],
-      opts?: { sendToDaemon?: boolean },
+      opts?: {
+        sendToDaemon?: boolean;
+        commitComposerAccepted?: ComposerSubmitCommit;
+      },
     ) => {
       const goalArg = text.replace(/^\/goal\b/i, '').trim();
       const lowerGoalArg = goalArg.toLowerCase();
       const sendToDaemon = opts?.sendToDaemon ?? true;
       const sendGoalPrompt = () => {
-        const clearComposerOnPromptStart = !connectionRef.current.sessionId;
+        const deferComposerCommit = Boolean(onSubmitBeforeRef.current);
+        const clearComposerOnPromptStart =
+          !connectionRef.current.sessionId || deferComposerCommit;
         sendPrompt(text, images, {
           clearComposerOnPromptStart,
+          commitComposerAccepted: deferComposerCommit
+            ? opts?.commitComposerAccepted
+            : undefined,
         }).catch((error: unknown) => {
           reportError(error, 'Failed to send /goal command');
         });
@@ -2429,7 +2453,11 @@ export function App({
   const hideSettings = hiddenCommands.has('settings');
 
   const handleSubmit = useCallback(
-    (text: string, images?: PromptImage[]) => {
+    (
+      text: string,
+      images?: PromptImage[],
+      commitComposerAccepted?: ComposerSubmitCommit,
+    ) => {
       if (connectionRef.current.loadingTranscript) {
         pushToast('warning', t('editor.sessionLoading'));
         return false;
@@ -2449,12 +2477,15 @@ export function App({
         errorMessage: string,
         opts?: { optimisticUserMessage?: boolean; retry?: boolean },
       ) => {
+        const deferComposerCommit = Boolean(onSubmitBeforeRef.current);
         const clearComposerOnPromptStart =
-          !connectionRef.current.sessionId ||
-          Boolean(onSubmitBeforeRef.current);
+          !connectionRef.current.sessionId || deferComposerCommit;
         sendPrompt(promptText, promptImages, {
           ...opts,
           clearComposerOnPromptStart,
+          commitComposerAccepted: deferComposerCommit
+            ? commitComposerAccepted
+            : undefined,
         }).catch((error: unknown) => reportError(error, errorMessage));
         return clearComposerOnPromptStart ? false : true;
       };
@@ -2463,7 +2494,14 @@ export function App({
         if (match) {
           const cmd = match[1];
           if (hiddenCommands.has(normalizeHiddenCommand(cmd))) {
-            if (promptBlocked) return enqueuePrompt(text, images);
+            if (promptBlocked) {
+              return enqueuePrompt(
+                text,
+                images,
+                undefined,
+                commitComposerAccepted,
+              );
+            }
             return submitPromptFromEditor(
               text,
               images,
@@ -2485,7 +2523,9 @@ export function App({
               }
               return blockLocalCommandDuringTurn();
             }
-            return handleGoalSlashCommand(text, images);
+            return handleGoalSlashCommand(text, images, {
+              commitComposerAccepted,
+            });
           }
           if (cmd === 'theme') {
             const themeArg = text.slice(match[0].length).trim().toLowerCase();
@@ -2547,10 +2587,14 @@ export function App({
               const nextLanguage = normalizeLanguage(languageArg);
               handleLanguageChange(nextLanguage);
               if (!promptBlocked) {
+                const deferComposerCommit = Boolean(onSubmitBeforeRef.current);
                 const clearComposerOnPromptStart =
-                  !connectionRef.current.sessionId;
+                  !connectionRef.current.sessionId || deferComposerCommit;
                 sendPrompt(`/language ui ${nextLanguage}`, undefined, {
                   clearComposerOnPromptStart,
+                  commitComposerAccepted: deferComposerCommit
+                    ? commitComposerAccepted
+                    : undefined,
                 })
                   .then(() => sessionActions.refreshCommands())
                   .catch((error: unknown) => {
@@ -2635,7 +2679,14 @@ export function App({
               return true;
             }
             if (modelArg.startsWith('--fast ')) {
-              if (promptBlocked) return enqueuePrompt(text, images);
+              if (promptBlocked) {
+                return enqueuePrompt(
+                  text,
+                  images,
+                  undefined,
+                  commitComposerAccepted,
+                );
+              }
               return submitPromptFromEditor(
                 text,
                 images,
@@ -2803,7 +2854,14 @@ export function App({
           if (cmd === 'skills') {
             const skillArg = text.slice(match[0].length).trim();
             if (skillArg) {
-              if (promptBlocked) return enqueuePrompt(text, images);
+              if (promptBlocked) {
+                return enqueuePrompt(
+                  text,
+                  images,
+                  undefined,
+                  commitComposerAccepted,
+                );
+              }
               return submitPromptFromEditor(
                 text,
                 images,
@@ -3049,7 +3107,14 @@ export function App({
           if (cmd === 'rename') {
             const renameArg = parseRenameArgument(text.slice(match[0].length));
             if (renameArg.type === 'auto' || renameArg.type === 'delegate') {
-              if (promptBlocked) return enqueuePrompt(text, images);
+              if (promptBlocked) {
+                return enqueuePrompt(
+                  text,
+                  images,
+                  undefined,
+                  commitComposerAccepted,
+                );
+              }
               return submitPromptFromEditor(
                 text,
                 images,
@@ -3238,7 +3303,9 @@ export function App({
           }
         }
         // Forward slash commands as prompts
-        if (promptBlocked) return enqueuePrompt(text, images);
+        if (promptBlocked) {
+          return enqueuePrompt(text, images, undefined, commitComposerAccepted);
+        }
         return submitPromptFromEditor(text, images, 'Failed to send command');
       } else if (text.startsWith('!')) {
         if (promptBlocked) {
@@ -3253,7 +3320,9 @@ export function App({
         });
         return true;
       } else {
-        if (promptBlocked) return enqueuePrompt(text, images);
+        if (promptBlocked) {
+          return enqueuePrompt(text, images, undefined, commitComposerAccepted);
+        }
         return submitPromptFromEditor(text, images, 'Failed to send message');
       }
     },
@@ -3291,8 +3360,12 @@ export function App({
   );
 
   const handleEditorSubmit = useCallback(
-    (text: string, images?: PromptImage[]) => {
-      const accepted = handleSubmit(text, images);
+    (
+      text: string,
+      images?: PromptImage[],
+      commitComposerAccepted?: ComposerSubmitCommit,
+    ) => {
+      const accepted = handleSubmit(text, images, commitComposerAccepted);
       if (accepted !== false) {
         resumeChatBottomFollow('smooth');
       }

--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -62,6 +62,7 @@ interface ChatEditorProps {
   onSubmit: (
     text: string,
     images?: import('../adapters/promptTypes').PromptImage[],
+    commitAccepted?: import('../hooks/useComposerCore').ComposerSubmitCommit,
   ) => boolean | void;
   onCycleMode?: () => void;
   onToggleShortcuts?: () => void;

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.test.tsx
@@ -280,7 +280,7 @@ describe('WebShellSidebar — session organization', () => {
     mockWorkspaceActions.listSessionGroups.mockReturnValue(
       new Promise(() => undefined),
     );
-    const container = renderSidebar(false);
+    const { container } = renderSidebar(false);
     expect(mockUseSessions).toHaveBeenCalledWith({
       autoLoad: true,
       pageSize: 1000,
@@ -484,7 +484,7 @@ describe('WebShellSidebar — session organization', () => {
       }),
     ];
 
-    const container = renderSidebar(false);
+    const { container } = renderSidebar(false);
     await act(async () => {
       await Promise.resolve();
     });
@@ -535,7 +535,7 @@ describe('WebShellSidebar — session organization', () => {
       }),
     ];
 
-    const container = renderSidebar(false);
+    const { container } = renderSidebar(false);
     await act(async () => {
       await Promise.resolve();
     });
@@ -588,7 +588,7 @@ describe('WebShellSidebar — session organization', () => {
       }),
     ];
 
-    const container = renderSidebar(false);
+    const { container } = renderSidebar(false);
     await act(async () => {
       await Promise.resolve();
     });
@@ -630,7 +630,7 @@ describe('WebShellSidebar — session organization', () => {
     );
     mockActive.sessions = [makeSession('session-a'), makeSession('session-b')];
 
-    const container = renderSidebar(false);
+    const { container } = renderSidebar(false);
     await act(async () => {
       await Promise.resolve();
     });
@@ -683,7 +683,7 @@ describe('WebShellSidebar — session organization', () => {
     mockActive.sessions = [makeSession('session-a')];
     const onNewSession = vi.fn();
 
-    const container = renderSidebar(false, { onNewSession });
+    const { container } = renderSidebar(false, { onNewSession });
     await act(async () => {
       await Promise.resolve();
     });
@@ -732,7 +732,7 @@ describe('WebShellSidebar — session organization', () => {
     mockActive.sessions = [makeSession('session-a')];
     const onError = vi.fn();
 
-    const container = renderSidebar(false, { onError });
+    const { container } = renderSidebar(false, { onError });
     await act(async () => {
       await Promise.resolve();
     });

--- a/packages/web-shell/client/hooks/useComposerCore.ts
+++ b/packages/web-shell/client/hooks/useComposerCore.ts
@@ -779,8 +779,14 @@ function createFollowupGhostExtension(suggestion: string | null) {
 
 // ---- Hook options ----
 
+export type ComposerSubmitCommit = () => void;
+
 export interface UseComposerCoreOptions {
-  onSubmit: (text: string, images?: PromptImage[]) => boolean | void;
+  onSubmit: (
+    text: string,
+    images?: PromptImage[],
+    commitAccepted?: ComposerSubmitCommit,
+  ) => boolean | void;
   onCycleMode?: () => void;
   onToggleShortcuts?: () => void;
   disabled?: boolean;
@@ -1395,32 +1401,39 @@ export function useComposerCore(
       const prompt = buildComposerPrompt(text, tags);
       const images = pastedImagesRef.current;
       const isShellMode = shellModeRef.current;
+      let committed = false;
+      const commitAccepted = () => {
+        if (committed) return;
+        committed = true;
+        setSlashMenu(null);
+        if (followupCompletion) {
+          onAcceptFollowupRef.current?.('enter', { skipOnAccept: true });
+        }
+        onDismissFollowupRef.current?.();
+        pendingPastesRef.current.clear();
+        nextPasteIdRef.current = 1;
+        if (isShellMode) {
+          shellHistoryActionsRef.current.push(text);
+          shellHistoryActionsRef.current.reset();
+        } else {
+          historyActionsRef.current.push(text);
+          historyActionsRef.current.reset();
+        }
+        historyBrowseActiveRef.current = false;
+        setComposerTags([]);
+        setPastedImages([]);
+        view.dispatch({
+          changes: { from: 0, to: view.state.doc.length, insert: '' },
+          effects: clearInlineTagsEffect.of(),
+        });
+      };
       const accepted = onSubmitRef.current(
         isShellMode ? `!${prompt}` : prompt,
         images.length > 0 ? [...images] : undefined,
+        commitAccepted,
       );
       if (accepted === false) return true;
-      setSlashMenu(null);
-      if (followupCompletion) {
-        onAcceptFollowupRef.current?.('enter', { skipOnAccept: true });
-      }
-      onDismissFollowupRef.current?.();
-      pendingPastesRef.current.clear();
-      nextPasteIdRef.current = 1;
-      if (isShellMode) {
-        shellHistoryActionsRef.current.push(text);
-        shellHistoryActionsRef.current.reset();
-      } else {
-        historyActionsRef.current.push(text);
-        historyActionsRef.current.reset();
-      }
-      historyBrowseActiveRef.current = false;
-      setComposerTags([]);
-      setPastedImages([]);
-      view.dispatch({
-        changes: { from: 0, to: view.state.doc.length, insert: '' },
-        effects: clearInlineTagsEffect.of(),
-      });
+      commitAccepted();
       return true;
     };
     submitTextRef.current = submitText;


### PR DESCRIPTION
## What this PR does

This PR fixes the remaining `onSubmitBefore` submission-finalization issues found after #6333 was merged. Gated submissions now keep the composer draft visible while the async hook is pending, then run the normal accepted-submit composer finalization only after the hook resolves. The same behavior now applies to direct prompts, queued prompts, and daemon-bound slash submissions such as `/goal ...` and `/language ui ...`.

## Why it's needed

#6333 added the `onSubmitBefore` hook, but the follow-up review found two leftover edge cases: daemon-bound slash commands could still clear accepted composer text before the hook settled, and the temporary `return false` path skipped accepted-submit bookkeeping such as followup dismissal, input history updates, history browse reset, tag/image cleanup, and editor clearing. This follow-up keeps rejection behavior safe without losing the successful-submit cleanup semantics.

## Reviewer Test Plan

### How to verify

Submit a normal prompt, a queued prompt while a turn is streaming, `/goal ...`, and `/language ui ...` with an `onSubmitBefore` hook that first rejects and then resolves. On rejection, the draft should remain in the composer and no prompt should reach the daemon. On resolve, the prompt should proceed and the composer should perform its normal accepted-submit cleanup, including clearing the editor and recording the text in composer history.

### Evidence (Before & After)

Before: #6333 follow-up review showed `/goal ...` and `/language ui ...` still accepted and cleared the composer before `onSubmitBefore` settled, and successful gated submissions that returned `false` skipped accepted-submit composer bookkeeping.

After: `useComposerCore` now passes an idempotent accepted-submit commit callback to the submit handler, and `App` calls it only after `onSubmitBefore` resolves. The targeted unit tests cover direct resolve/reject, queued resolve/reject, and daemon-bound slash command rejection.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Verified locally with `cd packages/web-shell && npx vitest run client/App.test.tsx client/hooks/useComposerCore.test.ts`, `cd packages/web-shell && npx prettier --check client/App.tsx client/App.test.tsx client/components/ChatEditor.tsx client/hooks/useComposerCore.ts`, `cd packages/web-shell && npx eslint --max-warnings 0 client/App.tsx client/App.test.tsx client/components/ChatEditor.tsx client/hooks/useComposerCore.ts`, and `git diff --check`. `cd packages/web-shell && npx tsc -p tsconfig.lib.json` is currently blocked by unrelated existing daemon/sidebar SDK type mismatches on main, for example missing `DaemonSessionGroup` and missing workspace group action typings in `WebShellSidebar.tsx`.

## Risk & Scope

- Main risk or tradeoff: the submit handler now receives an optional commit callback so successful gated submissions can finish composer cleanup asynchronously.
- Not validated / out of scope: full package typecheck, because current main has unrelated web-shell daemon/sidebar type errors.
- Breaking changes / migration notes: none; the external `onSubmitBefore` and `onSessionChange` APIs are unchanged.

## Linked Issues

Follow-up to #6333.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 修复 #6333 合并后剩余的 `onSubmitBefore` 提交收尾问题。现在带 gate 的提交会在异步 hook pending 时保留 composer 草稿，只在 hook resolve 后执行正常的 accepted-submit composer 收尾逻辑。直接提交、queued prompt，以及 `/goal ...`、`/language ui ...` 这类会发给 daemon 的 slash 提交都会使用同一套行为。

## 为什么需要

#6333 新增了 `onSubmitBefore` hook，但后续 review 发现还有两个边界问题：daemon-bound slash command 仍可能在 hook settle 前让 composer 接受并清空文本；同时临时的 `return false` 路径会跳过 accepted-submit bookkeeping，包括 dismiss followup、写入输入历史、重置历史浏览状态、清理 tag/image、清空 editor。这个 follow-up 在保证 reject 不丢草稿的同时，也保留成功提交时原本应该执行的 cleanup 语义。

## Reviewer Test Plan

### 如何验证

用一个先 reject 后 resolve 的 `onSubmitBefore` hook 分别提交普通 prompt、streaming 期间的 queued prompt、`/goal ...` 和 `/language ui ...`。reject 时草稿应该留在 composer，prompt 不应到达 daemon；resolve 时 prompt 应继续发送，并执行正常的 accepted-submit cleanup，包括清空 editor 和写入 composer history。

### 前后证据

Before：#6333 的 follow-up review 指出 `/goal ...` 和 `/language ui ...` 仍会在 `onSubmitBefore` settle 前接受并清空 composer，而且返回 `false` 的成功 gate 提交会跳过 accepted-submit composer bookkeeping。

After：`useComposerCore` 现在把一个幂等的 accepted-submit commit callback 传给 submit handler，`App` 只在 `onSubmitBefore` resolve 后调用它。定向单测覆盖了直接提交 resolve/reject、queued resolve/reject，以及 daemon-bound slash command reject。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### 环境（可选）

本地验证命令包括 `cd packages/web-shell && npx vitest run client/App.test.tsx client/hooks/useComposerCore.test.ts`、`cd packages/web-shell && npx prettier --check client/App.tsx client/App.test.tsx client/components/ChatEditor.tsx client/hooks/useComposerCore.ts`、`cd packages/web-shell && npx eslint --max-warnings 0 client/App.tsx client/App.test.tsx client/components/ChatEditor.tsx client/hooks/useComposerCore.ts` 和 `git diff --check`。`cd packages/web-shell && npx tsc -p tsconfig.lib.json` 当前被 main 上已有的 daemon/sidebar SDK 类型不匹配挡住，例如 `WebShellSidebar.tsx` 缺少 `DaemonSessionGroup` 和 workspace group action typings。

## 风险与范围

- 主要风险或取舍：submit handler 现在会收到一个可选 commit callback，这样成功的 gated submission 可以异步完成 composer cleanup。
- 未验证 / 范围外：完整 package typecheck，因为当前 main 存在无关的 web-shell daemon/sidebar 类型错误。
- 破坏性变更 / 迁移说明：无；外部 `onSubmitBefore` 和 `onSessionChange` API 没有变化。

## 关联问题

#6333 的 follow-up 修复。

</details>
