### PR TITLE
fix(cli): smoother streaming table rendering

### DIFF
--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -496,6 +496,19 @@ Done.`.replace(/\n/g, eol);
       expect(output).toContain('500');
     });
 
+    it('releases an options table whose first data cell starts with a dash', () => {
+      // `| --verbose | … |` after a header looks separator-ish to a naive
+      // "starts with a dash" check and would be held all stream. It is not a
+      // real separator (trailing letters), so it must render live.
+      const text = `flags:
+| Flag | Description |
+| --verbose | Enable verbose output |`.replace(/\n/g, eol);
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay {...baseProps} text={text} isPending={true} />,
+      );
+      expect(lastFrame() ?? '').toContain('--verbose');
+    });
+
     it('does not hold back a header with an empty-named column once its separator matches', () => {
       // `| A || B |` is a 3-column table to the renderer (the empty middle cell
       // counts). The hold-back must count columns the same way, or it never

--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -568,6 +568,25 @@ Done.`.replace(/\n/g, eol);
       expect(stripAnsi(lastFrame() ?? '')).toContain('ZZZ');
     });
 
+    it('does not let a backtick fence close an open tilde fence', () => {
+      // An open ~~~ fence must not be closed by an inner ``` (different char), so
+      // the `| … |` line after it stays code content. Guards the fence-char check
+      // for tilde fences (existing tests only cover backticks).
+      const text = `~~~
+| code |
+\`\`\`
+| ZZZ | YYY |`.replace(/\n/g, eol);
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay
+          {...baseProps}
+          text={text}
+          isPending={true}
+          availableTerminalHeight={20}
+        />,
+      );
+      expect(stripAnsi(lastFrame() ?? '')).toContain('ZZZ');
+    });
+
     it('renders the table once the separator matches the header columns', () => {
       const text = `| Alpha | Beta |
 |---|---|
@@ -608,6 +627,30 @@ Done.`.replace(/\n/g, eol);
       const output = lastFrame() ?? '';
       expect(output).toContain('Alpha');
       expect(output).toContain('│');
+    });
+
+    it('uses the final (all-rows) format for a completed mid-content table while streaming', () => {
+      // A table CLOSED by a following line is complete even while the message
+      // streams on, so its format is decided from all rows now — it must not
+      // render horizontal and then flip to vertical at commit. Short first row +
+      // a tall later row → vertical (no box border), not a horizontal grid.
+      const tall = Array.from({ length: 80 }, (_, i) => `w${i}`).join(' ');
+      const text = `| A | B |
+|---|---|
+| x | y |
+| ${tall} | y |
+trailing text`.replace(/\n/g, eol);
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay
+          {...baseProps}
+          text={text}
+          isPending={true}
+          availableTerminalHeight={40}
+        />,
+      );
+      const output = stripAnsi(lastFrame() ?? '');
+      expect(output).toContain('trailing text'); // the table is mid-content
+      expect(output).not.toContain('┌'); // vertical, no horizontal box
     });
 
     it('does not hold back pipe lines inside a pending code block', () => {

--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -587,6 +587,24 @@ Done.`.replace(/\n/g, eol);
       expect(stripAnsi(lastFrame() ?? '')).toContain('ZZZ');
     });
 
+    it('does not hold a pipe line inside an open display-math block', () => {
+      // Inside a `$$ … $$` block the main parser pushes every line verbatim as
+      // math content, never as a table. The hold-back must mirror that: a `| … |`
+      // line (a norm/matrix row) while the math block is still open is NOT a
+      // forming table and must render, not be blanked until the block closes.
+      const text = `$$
+| ZZZ | YYY |`.replace(/\n/g, eol);
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay
+          {...baseProps}
+          text={text}
+          isPending={true}
+          availableTerminalHeight={20}
+        />,
+      );
+      expect(stripAnsi(lastFrame() ?? '')).toContain('ZZZ');
+    });
+
     it('renders the table once the separator matches the header columns', () => {
       const text = `| Alpha | Beta |
 |---|---|

--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -385,11 +385,10 @@ Some text before.
       expect(out).toContain('two');
     });
 
-    it('keeps a streaming frontier table horizontal instead of the vertical list', () => {
-      // A tall cell trips the vertical fallback, which would render the table as
-      // a `label: value` list and then flip to a horizontal table once it
-      // completes (a visible jump). The live streaming frontier table must stay
-      // horizontal; the committed render may fall back to vertical.
+    it('renders a tall-wrapping table the same way streaming and committed (no flip)', () => {
+      // The horizontal-vs-vertical decision is identical while pending and once
+      // committed, so a table never flips format mid-stream (which reads as a
+      // jump). A tall cell trips the vertical fallback in BOTH renders.
       const tallCell = Array.from({ length: 80 }, (_, i) => `w${i}`).join(' ');
       const text = `| Col |
 |---|
@@ -414,7 +413,8 @@ Some text before.
           />,
         ).lastFrame() ?? '';
 
-      expect(stripAnsi(streaming)).toContain('┌');
+      // Both vertical (no box border) — same format, no flip between the two.
+      expect(stripAnsi(streaming)).not.toContain('┌');
       expect(stripAnsi(committed)).not.toContain('┌');
     });
 

--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -480,6 +480,22 @@ Done.`.replace(/\n/g, eol);
       expect(lastFrame() ?? '').toContain('grep foo');
     });
 
+    it('does not hold back a header with an empty-named column once its separator matches', () => {
+      // `| A || B |` is a 3-column table to the renderer (the empty middle cell
+      // counts). The hold-back must count columns the same way, or it never
+      // finds the matching 3-column separator and hides the table all stream.
+      const text = `intro line
+| A || B |
+| - | - | - |
+| x || y |`.replace(/\n/g, eol);
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay {...baseProps} text={text} isPending={true} />,
+      );
+      const output = lastFrame() ?? '';
+      expect(output).toContain('x');
+      expect(output).toContain('y');
+    });
+
     it('keeps holding the header while its separator is still being typed', () => {
       // A partial separator whose column count does not yet match the header is
       // not enough to recognize the table, so the header stays held.

--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -480,6 +480,22 @@ Done.`.replace(/\n/g, eol);
       expect(lastFrame() ?? '').toContain('grep foo');
     });
 
+    it('releases multi-cell non-table pipe content once a non-separator line follows', () => {
+      // A log excerpt / multi-pipe shell output has ≥2 cells per line, so the
+      // header heuristic alone would hold it for the whole stream. But the line
+      // after the "header" is not a separator, so it is not a forming table and
+      // must render live, not vanish until commit.
+      const text = `logs:
+| 200 | OK | GET /a
+| 500 | ERR | GET /b`.replace(/\n/g, eol);
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay {...baseProps} text={text} isPending={true} />,
+      );
+      const output = lastFrame() ?? '';
+      expect(output).toContain('200');
+      expect(output).toContain('500');
+    });
+
     it('does not hold back a header with an empty-named column once its separator matches', () => {
       // `| A || B |` is a 3-column table to the renderer (the empty middle cell
       // counts). The hold-back must count columns the same way, or it never

--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -456,6 +456,19 @@ Done.`.replace(/\n/g, eol);
       expect(output).not.toContain('Alpha');
     });
 
+    it('holds back a multi-column header still being typed (no cell-by-cell flash)', () => {
+      // Incomplete header (no closing `|` yet) but already ≥2 columns: it must
+      // be held, not rendered as raw pipe text, so it does not flash in.
+      const text = `intro line
+| Alpha | Bet`.replace(/\n/g, eol);
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay {...baseProps} text={text} isPending={true} />,
+      );
+      const output = lastFrame() ?? '';
+      expect(output).toContain('intro line');
+      expect(output).not.toContain('Alpha');
+    });
+
     it('does not hold back non-table pipe-leading text', () => {
       // A trailing pipe-line that is not a complete table header (e.g. a shell
       // pipeline or pipe-prefixed log line) must still render, not vanish.

--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -456,6 +456,17 @@ Done.`.replace(/\n/g, eol);
       expect(output).not.toContain('Alpha');
     });
 
+    it('does not hold back non-table pipe-leading text', () => {
+      // A trailing pipe-line that is not a complete table header (e.g. a shell
+      // pipeline or pipe-prefixed log line) must still render, not vanish.
+      const text = `run:
+| grep foo`.replace(/\n/g, eol);
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay {...baseProps} text={text} isPending={true} />,
+      );
+      expect(lastFrame() ?? '').toContain('grep foo');
+    });
+
     it('keeps holding the header while its separator is still being typed', () => {
       // A partial separator whose column count does not yet match the header is
       // not enough to recognize the table, so the header stays held.

--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -5,6 +5,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import stripAnsi from 'strip-ansi';
 import { MarkdownDisplay } from './MarkdownDisplay.js';
 import { LoadedSettings } from '../../config/settings.js';
 import { renderWithProviders } from '../../test-utils/render.js';
@@ -329,6 +330,24 @@ Some text before.
       expect(output).toContain('│');
     });
 
+    it('holds back a frontier row that is closed but missing columns', () => {
+      // `| four | five |` on a 3-column table is an intermediate state of
+      // `| four | five | six |` still being typed: it matches the row regex but
+      // has too few cells, so it must not render (and fill in cell by cell)
+      // until every column has arrived.
+      const text = `| A | B | C |
+|---|---|---|
+| one | two | three |
+| four | five |`.replace(/\n/g, eol);
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay {...baseProps} text={text} isPending={true} />,
+      );
+      const output = lastFrame() ?? '';
+      expect(output).toContain('one');
+      expect(output).toContain('three');
+      expect(output).not.toContain('four');
+    });
+
     it('renders the previously-held frontier row once it terminates', () => {
       const text = `| A | B |
 |---|---|
@@ -366,6 +385,39 @@ Some text before.
       expect(out).toContain('two');
     });
 
+    it('keeps a streaming frontier table horizontal instead of the vertical list', () => {
+      // A tall cell trips the vertical fallback, which would render the table as
+      // a `label: value` list and then flip to a horizontal table once it
+      // completes (a visible jump). The live streaming frontier table must stay
+      // horizontal; the committed render may fall back to vertical.
+      const tallCell = Array.from({ length: 80 }, (_, i) => `w${i}`).join(' ');
+      const text = `| Col |
+|---|
+| ${tallCell} |`.replace(/\n/g, eol);
+
+      const streaming =
+        renderWithProviders(
+          <MarkdownDisplay
+            {...baseProps}
+            text={text}
+            isPending={true}
+            contentWidth={60}
+          />,
+        ).lastFrame() ?? '';
+      const committed =
+        renderWithProviders(
+          <MarkdownDisplay
+            {...baseProps}
+            text={text}
+            isPending={false}
+            contentWidth={60}
+          />,
+        ).lastFrame() ?? '';
+
+      expect(stripAnsi(streaming)).toContain('┌');
+      expect(stripAnsi(committed)).not.toContain('┌');
+    });
+
     it('does not hold back a partial row in committed (non-pending) output', () => {
       const text = `| A | B |
 |---|---|
@@ -389,6 +441,72 @@ Done.`.replace(/\n/g, eol);
       const output = lastFrame() ?? '';
       expect(output).toContain('one');
       expect(output).toContain('Done');
+    });
+
+    it('holds back a forming table header until its separator arrives', () => {
+      // Header present but no separator yet — must not flash as raw `| a | b |`
+      // text (streaming in char by char) before the table box appears.
+      const text = `intro line
+| Alpha | Beta |`.replace(/\n/g, eol);
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay {...baseProps} text={text} isPending={true} />,
+      );
+      const output = lastFrame() ?? '';
+      expect(output).toContain('intro line');
+      expect(output).not.toContain('Alpha');
+    });
+
+    it('keeps holding the header while its separator is still being typed', () => {
+      // A partial separator whose column count does not yet match the header is
+      // not enough to recognize the table, so the header stays held.
+      const text = `intro line
+| Alpha | Beta |
+|--`.replace(/\n/g, eol);
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay {...baseProps} text={text} isPending={true} />,
+      );
+      expect((lastFrame() ?? '').includes('Alpha')).toBe(false);
+    });
+
+    it('renders the table once the separator matches the header columns', () => {
+      const text = `| Alpha | Beta |
+|---|---|
+| 1 | 2 |`.replace(/\n/g, eol);
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay {...baseProps} text={text} isPending={true} />,
+      );
+      const output = lastFrame() ?? '';
+      expect(output).toContain('Alpha');
+      expect(output).toContain('│'); // drawn as a table box, not raw text
+    });
+
+    it('draws the empty table box once recognized, before the first row completes', () => {
+      // Header + separator recognized but the first row is still being typed:
+      // show the header box immediately (empty body) rather than a long blank
+      // while the first row streams (a stall in that window looked like a hang).
+      const text = `| Alpha | Beta |
+|---|---|
+| 1`.replace(/\n/g, eol);
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay {...baseProps} text={text} isPending={true} />,
+      );
+      const output = lastFrame() ?? '';
+      expect(output).toContain('Alpha'); // header box drawn with zero rows
+      expect(output).toContain('│');
+    });
+
+    it('does not hold back pipe lines inside a pending code block', () => {
+      // A `|`-leading line that is fenced code-block content must still render.
+      const text = '```\n| Alpha | Beta |'.replace(/\n/g, eol);
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay
+          {...baseProps}
+          text={text}
+          isPending={true}
+          availableTerminalHeight={20}
+        />,
+      );
+      expect(stripAnsi(lastFrame() ?? '')).toContain('Alpha');
     });
 
     it('renders a single-column table', () => {

--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -537,6 +537,37 @@ Done.`.replace(/\n/g, eol);
       expect((lastFrame() ?? '').includes('Alpha')).toBe(false);
     });
 
+    it('releases a complete separator whose column count differs from the header', () => {
+      // Header has 3 columns, the separator is complete (ends with `|`) but has
+      // only 2 — it can never become a matching separator, and the main parser
+      // treats it as plain text. So it must render, not be held for the stream.
+      const text = `| A | B | C |
+| --- | --- |`.replace(/\n/g, eol);
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay {...baseProps} text={text} isPending={true} />,
+      );
+      expect(lastFrame() ?? '').toContain('A');
+    });
+
+    it('does not hold a pipe line inside a nested (longer) code fence', () => {
+      // A ```` fence is still open; an inner ``` (shorter) does NOT close it, so a
+      // `| … |` line after it is code content and must render. A naive fence
+      // toggle would treat the inner ``` as a close and hold the pipe line back.
+      const text = `\`\`\`\`
+| code example |
+\`\`\`
+| ZZZ | YYY |`.replace(/\n/g, eol);
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay
+          {...baseProps}
+          text={text}
+          isPending={true}
+          availableTerminalHeight={20}
+        />,
+      );
+      expect(stripAnsi(lastFrame() ?? '')).toContain('ZZZ');
+    });
+
     it('renders the table once the separator matches the header columns', () => {
       const text = `| Alpha | Beta |
 |---|---|

--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -549,10 +549,11 @@ Done.`.replace(/\n/g, eol);
       expect(output).toContain('│'); // drawn as a table box, not raw text
     });
 
-    it('draws the empty table box once recognized, before the first row completes', () => {
-      // Header + separator recognized but the first row is still being typed:
-      // show the header box immediately (empty body) rather than a long blank
-      // while the first row streams (a stall in that window looked like a hang).
+    it('defers the table while it has no complete data row (no empty header box)', () => {
+      // Header + separator recognized but the first row is still being typed. A
+      // zero-row table can only render horizontally, so drawing the empty box now
+      // and flipping to vertical once a long first row lands is a visible format
+      // change. Defer instead: nothing is drawn until the first row completes.
       const text = `| Alpha | Beta |
 |---|---|
 | 1`.replace(/\n/g, eol);
@@ -560,7 +561,21 @@ Done.`.replace(/\n/g, eol);
         <MarkdownDisplay {...baseProps} text={text} isPending={true} />,
       );
       const output = lastFrame() ?? '';
-      expect(output).toContain('Alpha'); // header box drawn with zero rows
+      expect(output).not.toContain('Alpha'); // table not drawn yet
+      expect(output).not.toContain('│');
+    });
+
+    it('draws the table once its first row completes', () => {
+      // The deferred table appears — already in its final format — as soon as the
+      // first data row terminates.
+      const text = `| Alpha | Beta |
+|---|---|
+| 1 | 2 |`.replace(/\n/g, eol);
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay {...baseProps} text={text} isPending={true} />,
+      );
+      const output = lastFrame() ?? '';
+      expect(output).toContain('Alpha');
       expect(output).toContain('│');
     });
 

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -494,6 +494,11 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
             aligns={tableAligns}
             enableInlineMath={renderVisualBlocks}
             isPending={isPending}
+            // A following non-table line closed this table: it is COMPLETE and
+            // will gain no more rows, so it is not the streaming frontier. Decide
+            // its format from all rows (not just the first) so it does not flip
+            // horizontal→vertical when the message finally commits.
+            isFrontier={false}
             availableTerminalHeight={availableTerminalHeight}
           />,
         );
@@ -705,6 +710,9 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
         aligns={tableAligns}
         enableInlineMath={renderVisualBlocks}
         isPending={isPending}
+        // End of content: this table is at the streaming frontier and may still
+        // gain rows, so anchor its format to the first row while pending.
+        isFrontier={true}
         availableTerminalHeight={availableTerminalHeight}
       />,
     );
@@ -1018,7 +1026,15 @@ interface RenderTableProps {
   contentWidth: number;
   aligns?: ColumnAlign[];
   enableInlineMath?: boolean;
+  /** True while the whole message is still streaming — drives the height clamp. */
   isPending?: boolean;
+  /**
+   * True only for the table at the streaming frontier (end of content, may still
+   * gain rows). A completed mid-content table passes false so its format is
+   * decided from all rows and does not flip when the message commits. Defaults
+   * true so a bare RenderTable behaves like the frontier.
+   */
+  isFrontier?: boolean;
   availableTerminalHeight?: number;
 }
 
@@ -1029,8 +1045,15 @@ const RenderTableInternal: React.FC<RenderTableProps> = ({
   aligns,
   enableInlineMath = false,
   isPending = false,
+  isFrontier = true,
   availableTerminalHeight,
 }) => {
+  // The height clamp tracks whether the MESSAGE is streaming (overflow can grow
+  // on any tick). The format anchor tracks whether THIS TABLE is still streaming
+  // — only the frontier table anchors its format to the first row; a completed
+  // mid-content table measures all rows. Keeping the clamp on isPending (not
+  // isFrontier) means a mid-content table is still bounded, so the estimator's
+  // clamped cost still matches the render and cannot under-estimate.
   const maxHeight =
     isPending && availableTerminalHeight !== undefined
       ? Math.max(2, availableTerminalHeight - TABLE_PENDING_RESERVED_ROWS)
@@ -1042,7 +1065,7 @@ const RenderTableInternal: React.FC<RenderTableProps> = ({
       contentWidth={contentWidth}
       aligns={aligns}
       enableInlineMath={enableInlineMath}
-      isPending={isPending}
+      isStreaming={isPending && isFrontier}
       maxHeight={maxHeight}
     />
   );

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -643,7 +643,6 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
         aligns={tableAligns}
         enableInlineMath={renderVisualBlocks}
         isPending={isPending}
-        isStreamingFrontier={true}
         availableTerminalHeight={availableTerminalHeight}
       />,
     );
@@ -958,14 +957,6 @@ interface RenderTableProps {
   aligns?: ColumnAlign[];
   enableInlineMath?: boolean;
   isPending?: boolean;
-  /**
-   * True only for the table at the live streaming frontier — the one still
-   * being written at the end of a pending message. A table closed earlier in
-   * the same (still pending) message is already COMPLETE, so it must size its
-   * columns from every row immediately (isStreaming false) instead of staying
-   * frozen to the first row until the whole message finishes.
-   */
-  isStreamingFrontier?: boolean;
   availableTerminalHeight?: number;
 }
 
@@ -976,7 +967,6 @@ const RenderTableInternal: React.FC<RenderTableProps> = ({
   aligns,
   enableInlineMath = false,
   isPending = false,
-  isStreamingFrontier = false,
   availableTerminalHeight,
 }) => {
   const maxHeight =
@@ -991,7 +981,6 @@ const RenderTableInternal: React.FC<RenderTableProps> = ({
       aligns={aligns}
       enableInlineMath={enableInlineMath}
       maxHeight={maxHeight}
-      isStreaming={isPending && isStreamingFrontier}
     />
   );
 };

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -239,18 +239,22 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
           return cols === headerCells;
         });
         // A markdown table's separator is the line IMMEDIATELY after the header.
-        // So once a line follows the header and it does not even begin like a
-        // separator (optional pipe, optional colon, then a dash), this pipe run
-        // is decided: NOT a forming table — a multi-cell shell pipeline
-        // (`| grep foo | wc -l`), a log excerpt (`| 200 | OK | GET /x`) or an
-        // ASCII-art border. Release it rather than hiding it for the whole
-        // stream. While only the header exists (still typing, no line after it
-        // yet) keep holding, so a real multi-column header does not flash in cell
-        // by cell before its separator arrives.
+        // So once a line follows the header and it is not a (possibly still
+        // forming) separator row, this pipe run is decided: NOT a forming table —
+        // a multi-cell shell pipeline (`| grep foo | wc -l`), a log excerpt
+        // (`| 200 | OK | GET /x`), an options table whose first cell starts with
+        // a dash (`| --verbose | … |`), or an ASCII-art border. Release it rather
+        // than hiding it for the whole stream. `tableSeparatorRegex` matches a
+        // partial separator (`|--`) so a real header whose separator is still
+        // being typed stays held; it rejects a dash-led data cell like
+        // `--verbose` (trailing letters), which a looser "starts with a dash"
+        // test would wrongly hold. While only the header exists (no line after it
+        // yet) keep holding so a multi-column header does not flash in cell by
+        // cell before its separator arrives.
         const lineAfterHeader = rest[0];
         const couldStillBeTable =
           lineAfterHeader === undefined ||
-          /^\s*\|?\s*:?-/.test(lineAfterHeader);
+          tableSeparatorRegex.test(lineAfterHeader);
         if (!hasMatchingSeparator && couldStillBeTable) {
           lines = lines.slice(0, start);
         }

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -208,10 +208,17 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
       for (let i = 0; i < start; i++) {
         if (codeFenceRegex.test(lines[i]!)) insideCodeFence = !insideCodeFence;
       }
-      if (!insideCodeFence) {
-        const headerCells = splitMarkdownTableRow(
-          lines[start]!.match(tableRowRegex)?.[1] ?? '',
-        ).filter((c) => c.length > 0).length;
+      // Only hold back when the first pipe-line is a plausible table header (a
+      // complete `| … |` row). Otherwise non-table pipe-leading text — an
+      // un-fenced shell pipeline (`| grep foo`), pipe-prefixed log output — would
+      // vanish from the live preview until the message commits.
+      const headerRowMatch = insideCodeFence
+        ? null
+        : lines[start]!.match(tableRowRegex);
+      if (headerRowMatch) {
+        const headerCells = splitMarkdownTableRow(headerRowMatch[1]).filter(
+          (c) => c.length > 0,
+        ).length;
         const hasMatchingSeparator = lines.slice(start + 1).some((l) => {
           if (!tableSeparatorRegex.test(l)) return false;
           const cols = splitMarkdownTableRow(l).filter(

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -191,6 +191,41 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
     }
   }
 
+  // Hold back a still-forming table at the streaming frontier. A table is only
+  // recognized once its separator line (matching the header's column count) has
+  // arrived; until then the header — and any partial separator — would render as
+  // raw `| a | b |` text and stream in character by character before snapping
+  // into a table box. So while pending, trim a trailing run of pipe-lines that
+  // does not yet contain a matching separator: nothing renders for it until it
+  // can render as a table. (A run that IS a recognizable table is kept — the
+  // per-row hold-back below then handles its unterminated frontier row.)
+  if (isPending && renderVisualBlocks && lines.length > 0) {
+    let start = lines.length;
+    while (start > 0 && /^\s*\|/.test(lines[start - 1]!)) start--;
+    if (start < lines.length) {
+      // Don't touch pipe-lines that are actually fenced code-block content.
+      let insideCodeFence = false;
+      for (let i = 0; i < start; i++) {
+        if (codeFenceRegex.test(lines[i]!)) insideCodeFence = !insideCodeFence;
+      }
+      if (!insideCodeFence) {
+        const headerCells = splitMarkdownTableRow(
+          lines[start]!.match(tableRowRegex)?.[1] ?? '',
+        ).filter((c) => c.length > 0).length;
+        const hasMatchingSeparator = lines.slice(start + 1).some((l) => {
+          if (!tableSeparatorRegex.test(l)) return false;
+          const cols = splitMarkdownTableRow(l).filter(
+            (c) => c.length > 0,
+          ).length;
+          return headerCells > 0 && cols === headerCells;
+        });
+        if (!hasMatchingSeparator) {
+          lines = lines.slice(0, start);
+        }
+      }
+    }
+  }
+
   /** Parse column alignments from a markdown table separator like `|:---|:---:|---:|` */
   const parseTableAligns = (line: string): ColumnAlign[] =>
     splitMarkdownTableRow(line)
@@ -346,6 +381,26 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
     } else if (inTable && tableSeparatorMatch) {
       // Parse alignment from separator line
       tableAligns = parseTableAligns(line);
+    } else if (
+      isPending &&
+      inTable &&
+      index === lines.length - 1 &&
+      tableHeaders.length > 0 &&
+      /^\s*\|/.test(line) &&
+      (!tableRowMatch ||
+        splitMarkdownTableRow(tableRowMatch[1]).length < tableHeaders.length)
+    ) {
+      // Live streaming frontier: the final line is a row still being typed —
+      // either mid-cell (`| a | b` with no closing `|` yet) or closed but with
+      // fewer cells than the header (`| a |` while `| a | b | c |` is coming, an
+      // intermediate that itself matches the row regex). Both would otherwise
+      // render as a padded row that fills in cell by cell and flips as the
+      // closing `|`/columns arrive, jittering the frame. Hold the row back until
+      // it has all its columns: skip it so `inTable` stays set and the
+      // end-of-content handler renders only the COMPLETE rows as a live table.
+      // The whole row (border + all cells) then appears in one step. Guarded on
+      // `tableHeaders.length > 0` so the header + separator never blank out with
+      // a stray partial line beneath them while the first row is typed.
     } else if (inTable && tableRowMatch) {
       // Add table row
       const cells = splitMarkdownTableRow(tableRowMatch[1]);
@@ -357,24 +412,6 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
         cells.length = tableHeaders.length;
       }
       tableRows.push(cells);
-    } else if (
-      isPending &&
-      inTable &&
-      !tableRowMatch &&
-      index === lines.length - 1 &&
-      tableHeaders.length > 0 &&
-      /^\s*\|/.test(line)
-    ) {
-      // Live streaming frontier: the final line is an unterminated table row or
-      // separator (`| a | b` with no closing `|` yet). Rendering it as a plain
-      // text line and then flipping it into the table once the closing `|`
-      // arrives makes the frame height and column widths oscillate on every
-      // token, which visibly jitters the footer/composer. Hold it back instead:
-      // skip it so `inTable` stays set and the end-of-content handler renders
-      // only the COMPLETE rows as a live table. A partial row never flips in;
-      // the table appears once its first row terminates and grows one complete
-      // row at a time. Until then the table is simply not drawn (no header +
-      // separator with a stray partial line beneath it).
     } else if (inTable && !tableRowMatch) {
       // End of table — a following line closes it, so this table is COMPLETE
       // and renders in full (the rendered-aware slice guarantees a completed
@@ -577,7 +614,16 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
   // slice above keeps preceding content within budget, so it can never overflow
   // and lock the terminal. Renders in full once the message commits to <Static>
   // (isPending=false → no clamp).
-  if (inTable && tableHeaders.length > 0 && tableRows.length > 0) {
+  //
+  // No `tableRows.length > 0` guard: once the header + separator are recognized
+  // draw the empty table box right away (its data rows fill in as they complete
+  // via the per-row hold-back). Otherwise the whole table area stays blank from
+  // the moment it is recognized until the first row terminates — if generation
+  // stalls in that window it looks like a hang (no box, no cue). The header does
+  // NOT flash char by char: the pre-loop trim holds it until the separator lands,
+  // so the box appears atomically. Committed (isPending=false) tables always have
+  // rows, so this only affects the live frontier.
+  if (inTable && tableHeaders.length > 0) {
     addContentBlock(
       <RenderTable
         key={`table-${contentBlocks.length}`}
@@ -587,6 +633,7 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
         aligns={tableAligns}
         enableInlineMath={renderVisualBlocks}
         isPending={isPending}
+        isStreamingFrontier={true}
         availableTerminalHeight={availableTerminalHeight}
       />,
     );
@@ -901,6 +948,14 @@ interface RenderTableProps {
   aligns?: ColumnAlign[];
   enableInlineMath?: boolean;
   isPending?: boolean;
+  /**
+   * True only for the table at the live streaming frontier — the one still
+   * being written at the end of a pending message. A table closed earlier in
+   * the same (still pending) message is already COMPLETE, so it must size its
+   * columns from every row immediately (isStreaming false) instead of staying
+   * frozen to the first row until the whole message finishes.
+   */
+  isStreamingFrontier?: boolean;
   availableTerminalHeight?: number;
 }
 
@@ -911,6 +966,7 @@ const RenderTableInternal: React.FC<RenderTableProps> = ({
   aligns,
   enableInlineMath = false,
   isPending = false,
+  isStreamingFrontier = false,
   availableTerminalHeight,
 }) => {
   const maxHeight =
@@ -925,6 +981,7 @@ const RenderTableInternal: React.FC<RenderTableProps> = ({
       aligns={aligns}
       enableInlineMath={enableInlineMath}
       maxHeight={maxHeight}
+      isStreaming={isPending && isStreamingFrontier}
     />
   );
 };

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -217,10 +217,18 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
       // cell — one cell so far — is indistinguishable from a single-pipe line,
       // so it renders briefly until the second column appears; that is the
       // narrowest flash we can allow without hiding real non-table text.)
-      const headerCells = insideCodeFence
-        ? 0
-        : splitMarkdownTableRow(lines[start]!).filter((c) => c.length > 0)
-            .length;
+      // Count header cells the way the main table detector does (strip the
+      // outer pipes, split WITHOUT dropping empty cells) so an empty-named
+      // column like `| A || B |` — which the renderer treats as a real table —
+      // agrees between this hold-back and the renderer, instead of being held
+      // back for the whole stream. The trailing pipe is stripped only when
+      // present, so a still-forming header (`| A | B`) is counted mid-type.
+      let headerCells = 0;
+      if (!insideCodeFence) {
+        let hdr = lines[start]!.replace(/^\s*\|/, '');
+        if (/\|\s*$/.test(hdr)) hdr = hdr.replace(/\|\s*$/, '');
+        headerCells = splitMarkdownTableRow(hdr).length;
+      }
       if (headerCells >= 2) {
         const hasMatchingSeparator = lines.slice(start + 1).some((l) => {
           if (!tableSeparatorRegex.test(l)) return false;

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -203,24 +203,39 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
     let start = lines.length;
     while (start > 0 && /^\s*\|/.test(lines[start - 1]!)) start--;
     if (start < lines.length) {
-      // Don't touch pipe-lines that are actually fenced code-block content.
-      // Track the OPEN fence's delimiter, not a naive toggle: a closing fence
-      // must use the same char and be at least as long (mirrors the main parser),
-      // or a nested fence (```` inside ```` ) mis-toggles and a real code line
-      // like `| A | B |` gets held back as a forming table.
+      // Don't touch pipe-lines that are actually fenced code-block OR display-math
+      // (`$$ … $$`) content: the main parser pushes those verbatim, never as a
+      // table (a `| a | b |` norm/matrix line inside `$$` would otherwise be held
+      // back as a forming table and blank until the block closes). Track the OPEN
+      // code fence's delimiter, not a naive toggle: a closing fence must use the
+      // same char and be at least as long (mirrors the main parser), or a nested
+      // fence (```` inside ```` ) mis-toggles and a real code line like `| A | B |`
+      // gets held back. Mirror the main parser's precedence — a code block wins,
+      // then a math block — so a `$$` inside a code fence does not open math.
       let activeCodeFence = '';
+      let insideMathBlock = false;
       for (let i = 0; i < start; i++) {
-        const fenceMatch = lines[i]!.match(codeFenceRegex);
-        if (!fenceMatch) continue;
+        const line = lines[i]!;
         if (activeCodeFence) {
+          const fenceMatch = line.match(codeFenceRegex);
           if (
+            fenceMatch &&
             fenceMatch[1]!.startsWith(activeCodeFence[0]!) &&
             fenceMatch[1]!.length >= activeCodeFence.length
           ) {
             activeCodeFence = '';
           }
-        } else {
+          continue;
+        }
+        if (insideMathBlock) {
+          if (mathFenceRegex.test(line)) insideMathBlock = false;
+          continue;
+        }
+        const fenceMatch = line.match(codeFenceRegex);
+        if (fenceMatch) {
           activeCodeFence = fenceMatch[1]!;
+        } else if (mathFenceRegex.test(line)) {
+          insideMathBlock = true;
         }
       }
       const insideCodeFence = activeCodeFence !== '';
@@ -240,7 +255,7 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
       // back for the whole stream. The trailing pipe is stripped only when
       // present, so a still-forming header (`| A | B`) is counted mid-type.
       let headerCells = 0;
-      if (!insideCodeFence) {
+      if (!insideCodeFence && !insideMathBlock) {
         let hdr = lines[start]!.replace(/^\s*\|/, '');
         if (/\|\s*$/.test(hdr)) hdr = hdr.replace(/\|\s*$/, '');
         headerCells = splitMarkdownTableRow(hdr).length;

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -651,15 +651,22 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
   // and lock the terminal. Renders in full once the message commits to <Static>
   // (isPending=false → no clamp).
   //
-  // No `tableRows.length > 0` guard: once the header + separator are recognized
-  // draw the empty table box right away (its data rows fill in as they complete
-  // via the per-row hold-back). Otherwise the whole table area stays blank from
-  // the moment it is recognized until the first row terminates — if generation
-  // stalls in that window it looks like a hang (no box, no cue). The header does
-  // NOT flash char by char: the pre-loop trim holds it until the separator lands,
-  // so the box appears atomically. Committed (isPending=false) tables always have
-  // rows, so this only affects the live frontier.
-  if (inTable && tableHeaders.length > 0) {
+  // While PENDING, defer a table that has no COMPLETE data row yet. A zero-row
+  // table can only render horizontally (the vertical fallback needs rows to lay
+  // out), so drawing the empty header box and then flipping to the vertical
+  // `label: value` format once a long first row lands is a visible format change
+  // — and the format genuinely cannot be known from the header alone (column
+  // names are short; the width comes from the values). Waiting for the first
+  // complete row means the table first appears ALREADY in its final format, with
+  // no flip. Cost: the table area stays blank while the header + first row stream
+  // (the pre-loop trim already hid the header text, so this just extends that
+  // blank until the first row terminates). Committed (isPending=false) tables
+  // always have rows, so `!isPending` keeps their behavior unchanged.
+  if (
+    inTable &&
+    tableHeaders.length > 0 &&
+    (tableRows.length > 0 || !isPending)
+  ) {
     addContentBlock(
       <RenderTable
         key={`table-${contentBlocks.length}`}

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -230,14 +230,28 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
         headerCells = splitMarkdownTableRow(hdr).length;
       }
       if (headerCells >= 2) {
-        const hasMatchingSeparator = lines.slice(start + 1).some((l) => {
+        const rest = lines.slice(start + 1);
+        const hasMatchingSeparator = rest.some((l) => {
           if (!tableSeparatorRegex.test(l)) return false;
           const cols = splitMarkdownTableRow(l).filter(
             (c) => c.length > 0,
           ).length;
           return cols === headerCells;
         });
-        if (!hasMatchingSeparator) {
+        // A markdown table's separator is the line IMMEDIATELY after the header.
+        // So once a line follows the header and it does not even begin like a
+        // separator (optional pipe, optional colon, then a dash), this pipe run
+        // is decided: NOT a forming table — a multi-cell shell pipeline
+        // (`| grep foo | wc -l`), a log excerpt (`| 200 | OK | GET /x`) or an
+        // ASCII-art border. Release it rather than hiding it for the whole
+        // stream. While only the header exists (still typing, no line after it
+        // yet) keep holding, so a real multi-column header does not flash in cell
+        // by cell before its separator arrives.
+        const lineAfterHeader = rest[0];
+        const couldStillBeTable =
+          lineAfterHeader === undefined ||
+          /^\s*\|?\s*:?-/.test(lineAfterHeader);
+        if (!hasMatchingSeparator && couldStillBeTable) {
           lines = lines.slice(0, start);
         }
       }

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -208,23 +208,26 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
       for (let i = 0; i < start; i++) {
         if (codeFenceRegex.test(lines[i]!)) insideCodeFence = !insideCodeFence;
       }
-      // Only hold back when the first pipe-line is a plausible table header (a
-      // complete `| … |` row). Otherwise non-table pipe-leading text — an
-      // un-fenced shell pipeline (`| grep foo`), pipe-prefixed log output — would
-      // vanish from the live preview until the message commits.
-      const headerRowMatch = insideCodeFence
-        ? null
-        : lines[start]!.match(tableRowRegex);
-      if (headerRowMatch) {
-        const headerCells = splitMarkdownTableRow(headerRowMatch[1]).filter(
-          (c) => c.length > 0,
-        ).length;
+      // Only hold back a plausible forming TABLE, not arbitrary pipe text. A
+      // table header has ≥2 columns; a single-pipe line (an un-fenced shell
+      // pipeline `| grep foo`, a pipe-prefixed log line) has one cell and must
+      // render. Count cells on the first line whether or not it is closed yet,
+      // so a multi-column header held mid-type does not flash in cell by cell
+      // before its separator arrives. (A header still typing its very first
+      // cell — one cell so far — is indistinguishable from a single-pipe line,
+      // so it renders briefly until the second column appears; that is the
+      // narrowest flash we can allow without hiding real non-table text.)
+      const headerCells = insideCodeFence
+        ? 0
+        : splitMarkdownTableRow(lines[start]!).filter((c) => c.length > 0)
+            .length;
+      if (headerCells >= 2) {
         const hasMatchingSeparator = lines.slice(start + 1).some((l) => {
           if (!tableSeparatorRegex.test(l)) return false;
           const cols = splitMarkdownTableRow(l).filter(
             (c) => c.length > 0,
           ).length;
-          return headerCells > 0 && cols === headerCells;
+          return cols === headerCells;
         });
         if (!hasMatchingSeparator) {
           lines = lines.slice(0, start);

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -204,10 +204,26 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
     while (start > 0 && /^\s*\|/.test(lines[start - 1]!)) start--;
     if (start < lines.length) {
       // Don't touch pipe-lines that are actually fenced code-block content.
-      let insideCodeFence = false;
+      // Track the OPEN fence's delimiter, not a naive toggle: a closing fence
+      // must use the same char and be at least as long (mirrors the main parser),
+      // or a nested fence (```` inside ```` ) mis-toggles and a real code line
+      // like `| A | B |` gets held back as a forming table.
+      let activeCodeFence = '';
       for (let i = 0; i < start; i++) {
-        if (codeFenceRegex.test(lines[i]!)) insideCodeFence = !insideCodeFence;
+        const fenceMatch = lines[i]!.match(codeFenceRegex);
+        if (!fenceMatch) continue;
+        if (activeCodeFence) {
+          if (
+            fenceMatch[1]!.startsWith(activeCodeFence[0]!) &&
+            fenceMatch[1]!.length >= activeCodeFence.length
+          ) {
+            activeCodeFence = '';
+          }
+        } else {
+          activeCodeFence = fenceMatch[1]!;
+        }
       }
+      const insideCodeFence = activeCodeFence !== '';
       // Only hold back a plausible forming TABLE, not arbitrary pipe text. A
       // table header has ≥2 columns; a single-pipe line (an un-fenced shell
       // pipeline `| grep foo`, a pipe-prefixed log line) has one cell and must
@@ -252,9 +268,24 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
         // yet) keep holding so a multi-column header does not flash in cell by
         // cell before its separator arrives.
         const lineAfterHeader = rest[0];
-        const couldStillBeTable =
+        let couldStillBeTable =
           lineAfterHeader === undefined ||
           tableSeparatorRegex.test(lineAfterHeader);
+        // A COMPLETE separator (ends with `|`) whose column count already differs
+        // from the header will never become a valid table — the main parser
+        // treats it as plain text — so release it instead of holding the run for
+        // the rest of the stream. A still-forming separator (no closing `|`) can
+        // still gain columns, so keep holding it.
+        if (
+          couldStillBeTable &&
+          lineAfterHeader !== undefined &&
+          /\|\s*$/.test(lineAfterHeader)
+        ) {
+          const sepCols = splitMarkdownTableRow(lineAfterHeader).filter(
+            (c) => c.length > 0,
+          ).length;
+          if (sepCols !== headerCells) couldStillBeTable = false;
+        }
         if (!hasMatchingSeparator && couldStillBeTable) {
           lines = lines.slice(0, start);
         }
@@ -660,13 +691,11 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
   // complete row means the table first appears ALREADY in its final format, with
   // no flip. Cost: the table area stays blank while the header + first row stream
   // (the pre-loop trim already hid the header text, so this just extends that
-  // blank until the first row terminates). Committed (isPending=false) tables
-  // always have rows, so `!isPending` keeps their behavior unchanged.
-  if (
-    inTable &&
-    tableHeaders.length > 0 &&
-    (tableRows.length > 0 || !isPending)
-  ) {
+  // blank until the first row terminates). The `tableRows.length > 0` guard also
+  // matches the mid-content end-of-table handler above, so a degenerate zero-row
+  // table renders (or not) the same whether it ends the message or is followed by
+  // more text — pending or committed.
+  if (inTable && tableHeaders.length > 0 && tableRows.length > 0) {
     addContentBlock(
       <RenderTable
         key={`table-${contentBlocks.length}`}
@@ -1013,6 +1042,7 @@ const RenderTableInternal: React.FC<RenderTableProps> = ({
       contentWidth={contentWidth}
       aligns={aligns}
       enableInlineMath={enableInlineMath}
+      isPending={isPending}
       maxHeight={maxHeight}
     />
   );

--- a/packages/cli/src/ui/utils/TableRenderer.test.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.test.tsx
@@ -901,6 +901,23 @@ describe('<TableRenderer />', () => {
       expect(clean).toContain('┌');
     });
 
+    it('keeps the zero-row box visible when it exceeds a very narrow terminal', () => {
+      // The maxLineWidth safety check is a second path to the vertical format;
+      // for a zero-row box that would render an empty string (blank). The header
+      // box must stay visible rather than vanish.
+      const output =
+        renderWithProviders(
+          <TableRenderer
+            headers={['C1', 'C2', 'C3', 'C4', 'C5', 'C6']}
+            rows={[]}
+            contentWidth={25}
+          />,
+        ).lastFrame() ?? '';
+      const clean = stripAnsi(output);
+      expect(clean).toContain('┌');
+      expect(clean).toContain('C1');
+    });
+
     const headers = ['A', 'B'];
     const firstRowOnly = [['x', 'y']];
     const withWiderRow = [

--- a/packages/cli/src/ui/utils/TableRenderer.test.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.test.tsx
@@ -931,49 +931,27 @@ describe('<TableRenderer />', () => {
           .find((l) => l.includes('┌')) ?? '';
       return stringWidth(line.trim());
     };
-    const renderStreaming = (rows: string[][]) =>
+    const render = (rows: string[][]) =>
       renderWithProviders(
-        <TableRenderer
-          headers={headers}
-          rows={rows}
-          contentWidth={80}
-          isStreaming
-        />,
+        <TableRenderer headers={headers} rows={rows} contentWidth={80} />,
       ).lastFrame() ?? '';
 
-    it('widens the streaming table when a wider row is appended (redraw on wider)', () => {
+    it('widens the table when a wider row is appended (redraw on wider)', () => {
       // Widths always track the current rows: appending a wider row re-sizes
       // (redraws) the whole table rather than staying frozen to the first row.
-      expect(topBorderWidth(renderStreaming(withWiderRow))).toBeGreaterThan(
-        topBorderWidth(renderStreaming(firstRowOnly)),
+      expect(topBorderWidth(render(withWiderRow))).toBeGreaterThan(
+        topBorderWidth(render(firstRowOnly)),
       );
     });
 
-    it('stays horizontal while streaming even when a row would wrap tall', () => {
-      // A cell tall enough to trip the vertical fallback (maxRowLines) must NOT
-      // flip a streaming table into the vertical `label: value` list — that
-      // brief list-then-table flip is a visible jump. contentWidth stays well
-      // above the narrow-terminal threshold so only the tall-row trigger differs.
+    it('picks the vertical format for a tall-wrapping table (no format flip)', () => {
+      // The horizontal-vs-vertical decision must not depend on a streaming flag,
+      // so a table never flips format mid-stream. A cell tall enough to trip the
+      // vertical fallback renders vertical, identically at every point.
       const tall = [
         [Array.from({ length: 80 }, (_, i) => `w${i}`).join(' '), 'y'],
       ];
-      const streaming =
-        renderWithProviders(
-          <TableRenderer
-            headers={headers}
-            rows={tall}
-            contentWidth={60}
-            isStreaming
-          />,
-        ).lastFrame() ?? '';
-      const completed =
-        renderWithProviders(
-          <TableRenderer headers={headers} rows={tall} contentWidth={60} />,
-        ).lastFrame() ?? '';
-      // Streaming keeps the horizontal box; the completed render may fall back
-      // to the vertical list for the tall cell.
-      expect(stripAnsi(streaming)).toContain('┌');
-      expect(stripAnsi(completed)).not.toContain('┌');
+      expect(stripAnsi(render(tall))).not.toContain('┌'); // vertical list
     });
   });
 });

--- a/packages/cli/src/ui/utils/TableRenderer.test.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.test.tsx
@@ -865,7 +865,7 @@ describe('<TableRenderer />', () => {
     });
   });
 
-  describe('streaming table rendering (isStreaming)', () => {
+  describe('streaming table rendering (format stability)', () => {
     it('renders a header-only box (no divider) when there are no data rows', () => {
       // The live empty box shown while the first row streams: header + borders
       // only. The header/body divider must be skipped so it does not stack on
@@ -931,9 +931,16 @@ describe('<TableRenderer />', () => {
           .find((l) => l.includes('┌')) ?? '';
       return stringWidth(line.trim());
     };
-    const render = (rows: string[][]) =>
+    // Defaults to isPending (this block covers streaming behavior); pass false
+    // to exercise a committed table's all-rows format decision.
+    const render = (rows: string[][], isPending = true) =>
       renderWithProviders(
-        <TableRenderer headers={headers} rows={rows} contentWidth={80} />,
+        <TableRenderer
+          headers={headers}
+          rows={rows}
+          contentWidth={80}
+          isPending={isPending}
+        />,
       ).lastFrame() ?? '';
 
     it('widens the table when a wider row is appended (redraw on wider)', () => {
@@ -944,14 +951,14 @@ describe('<TableRenderer />', () => {
       );
     });
 
-    it('picks the vertical format for a tall-wrapping table (no format flip)', () => {
-      // The horizontal-vs-vertical decision must not depend on a streaming flag,
-      // so a table never flips format mid-stream. A cell tall enough to trip the
-      // vertical fallback renders vertical, identically at every point.
+    it('picks the vertical format for a tall-wrapping first row', () => {
+      // A single row tall enough to trip the vertical fallback renders vertical
+      // — the same whether streaming or committed (its one row IS the first row).
       const tall = [
         [Array.from({ length: 80 }, (_, i) => `w${i}`).join(' '), 'y'],
       ];
       expect(stripAnsi(render(tall))).not.toContain('┌'); // vertical list
+      expect(stripAnsi(render(tall, false))).not.toContain('┌');
     });
 
     it('does not flip to vertical when a tall row is appended after a short first row', () => {
@@ -969,6 +976,25 @@ describe('<TableRenderer />', () => {
         ]),
       );
       expect(output).toContain('┌'); // still horizontal (box drawn)
+    });
+
+    it('DOES use the vertical format for the same table once committed', () => {
+      // A committed (non-pending) table has all rows and no flip concern, so it
+      // measures every row: a short first row + a tall later row goes vertical,
+      // which is more readable than a tall horizontal grid.
+      const tallLaterRow = Array.from({ length: 80 }, (_, i) => `w${i}`).join(
+        ' ',
+      );
+      const output = stripAnsi(
+        render(
+          [
+            ['x', 'y'],
+            [tallLaterRow, 'y'],
+          ],
+          false,
+        ),
+      );
+      expect(output).not.toContain('┌'); // vertical list
     });
   });
 });

--- a/packages/cli/src/ui/utils/TableRenderer.test.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.test.tsx
@@ -864,4 +864,99 @@ describe('<TableRenderer />', () => {
       expect(stripAnsi(output)).toContain('more rows streaming');
     });
   });
+
+  describe('streaming table rendering (isStreaming)', () => {
+    it('renders a header-only box (no divider) when there are no data rows', () => {
+      // The live empty box shown while the first row streams: header + borders
+      // only. The header/body divider must be skipped so it does not stack on
+      // the bottom border and read as an empty second row.
+      const output =
+        renderWithProviders(
+          <TableRenderer
+            headers={['Alpha', 'Beta']}
+            rows={[]}
+            contentWidth={80}
+          />,
+        ).lastFrame() ?? '';
+      const clean = stripAnsi(output);
+      expect(clean).toContain('Alpha');
+      expect(clean).toContain('┌');
+      expect(clean).toContain('└');
+      expect(clean).not.toContain('├');
+    });
+
+    it('keeps the zero-row header box horizontal on a narrow terminal', () => {
+      // The width trigger would otherwise force the vertical format, which with
+      // no rows renders an empty string — a blank box instead of the header.
+      const output =
+        renderWithProviders(
+          <TableRenderer
+            headers={['Alpha', 'Beta']}
+            rows={[]}
+            contentWidth={20}
+          />,
+        ).lastFrame() ?? '';
+      const clean = stripAnsi(output);
+      expect(clean).toContain('Alpha');
+      expect(clean).toContain('┌');
+    });
+
+    const headers = ['A', 'B'];
+    const firstRowOnly = [['x', 'y']];
+    const withWiderRow = [
+      ['x', 'y'],
+      ['x', 'a considerably wider streaming cell'],
+    ];
+    const topBorderWidth = (frame: string) => {
+      const line =
+        stripAnsi(frame)
+          .split('\n')
+          .find((l) => l.includes('┌')) ?? '';
+      return stringWidth(line.trim());
+    };
+    const renderStreaming = (rows: string[][]) =>
+      renderWithProviders(
+        <TableRenderer
+          headers={headers}
+          rows={rows}
+          contentWidth={80}
+          isStreaming
+        />,
+      ).lastFrame() ?? '';
+
+    it('widens the streaming table when a wider row is appended (redraw on wider)', () => {
+      // Widths always track the current rows: appending a wider row re-sizes
+      // (redraws) the whole table rather than staying frozen to the first row.
+      expect(topBorderWidth(renderStreaming(withWiderRow))).toBeGreaterThan(
+        topBorderWidth(renderStreaming(firstRowOnly)),
+      );
+    });
+
+    it('stays horizontal while streaming even when a row would wrap tall', () => {
+      // A cell tall enough to trip the vertical fallback (maxRowLines) must NOT
+      // flip a streaming table into the vertical `label: value` list — that
+      // brief list-then-table flip is a visible jump. contentWidth stays well
+      // above the narrow-terminal threshold so only the tall-row trigger differs.
+      const tall = [
+        [Array.from({ length: 80 }, (_, i) => `w${i}`).join(' '), 'y'],
+      ];
+      const streaming =
+        renderWithProviders(
+          <TableRenderer
+            headers={headers}
+            rows={tall}
+            contentWidth={60}
+            isStreaming
+          />,
+        ).lastFrame() ?? '';
+      const completed =
+        renderWithProviders(
+          <TableRenderer headers={headers} rows={tall} contentWidth={60} />,
+        ).lastFrame() ?? '';
+      // Streaming keeps the horizontal box; the completed render may fall back
+      // to the vertical list for the tall cell.
+      expect(stripAnsi(streaming)).toContain('┌');
+      expect(stripAnsi(completed)).not.toContain('┌');
+    });
+  });
 });

--- a/packages/cli/src/ui/utils/TableRenderer.test.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.test.tsx
@@ -953,5 +953,22 @@ describe('<TableRenderer />', () => {
       ];
       expect(stripAnsi(render(tall))).not.toContain('┌'); // vertical list
     });
+
+    it('does not flip to vertical when a tall row is appended after a short first row', () => {
+      // The vertical decision is anchored to the header + FIRST row. A short
+      // first row renders horizontal; appending a later tall-wrapping row must
+      // NOT flip the whole table to vertical mid-stream — it stays a (taller)
+      // horizontal grid. Guards the no-flip guarantee against later rows.
+      const tallLaterRow = Array.from({ length: 80 }, (_, i) => `w${i}`).join(
+        ' ',
+      );
+      const output = stripAnsi(
+        render([
+          ['x', 'y'],
+          [tallLaterRow, 'y'],
+        ]),
+      );
+      expect(output).toContain('┌'); // still horizontal (box drawn)
+    });
   });
 });

--- a/packages/cli/src/ui/utils/TableRenderer.test.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.test.tsx
@@ -931,15 +931,15 @@ describe('<TableRenderer />', () => {
           .find((l) => l.includes('┌')) ?? '';
       return stringWidth(line.trim());
     };
-    // Defaults to isPending (this block covers streaming behavior); pass false
-    // to exercise a committed table's all-rows format decision.
-    const render = (rows: string[][], isPending = true) =>
+    // Defaults to streaming (this block covers streaming behavior); pass false
+    // to exercise a completed table's all-rows format decision.
+    const render = (rows: string[][], isStreaming = true) =>
       renderWithProviders(
         <TableRenderer
           headers={headers}
           rows={rows}
           contentWidth={80}
-          isPending={isPending}
+          isStreaming={isStreaming}
         />,
       ).lastFrame() ?? '';
 

--- a/packages/cli/src/ui/utils/TableRenderer.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.tsx
@@ -586,6 +586,16 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
   // A zero-row table is the live streaming header box: never vertical — the
   // vertical fallback iterates the rows and with none would render an empty
   // string (a blank box) on a narrow terminal where the width trigger fires.
+  //
+  // KNOWN LIMITATION: `maxRowLines` depends on the column widths, which track
+  // content (a wider row redraws the table). For a table with very long cell
+  // text whose wrapped height sits right at MAX_ROW_LINES, a later row can grow
+  // the columns and nudge the wrap count across the threshold, so the format can
+  // still oscillate vertical↔horizontal WHILE STREAMING. This is an accepted
+  // trade-off of redraw-on-wider column sizing (only extreme wide/long-text
+  // tables hit it; normal tables stay well clear of the threshold). Eliminating
+  // it would require a content-independent decision (which mis-sizes common
+  // key/value tables) or frozen column widths (losing redraw-on-wider).
   const useVerticalFormat =
     rowMetrics.length > 0 &&
     (contentWidth < minHorizontalTableWidth || maxRowLines > MAX_ROW_LINES);

--- a/packages/cli/src/ui/utils/TableRenderer.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.tsx
@@ -64,6 +64,13 @@ interface TableRendererProps {
   aligns?: ColumnAlign[];
   enableInlineMath?: boolean;
   /**
+   * True while the table is still streaming. The horizontal-vs-vertical decision
+   * is then anchored to the first row so the format cannot flip as later rows
+   * arrive; a committed table (false/undefined) measures every row for the most
+   * readable layout.
+   */
+  isPending?: boolean;
+  /**
    * Maximum rendered text lines the table may occupy. When set (streaming
    * preview) and the fully rendered table exceeds it, output is clipped to
    * `maxHeight - 1` lines plus a cue. Backstop against a wrapped-cell table
@@ -435,6 +442,7 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
   contentWidth,
   aligns,
   enableInlineMath = false,
+  isPending = false,
   maxHeight,
 }) => {
   const colCount = headers.length;
@@ -551,16 +559,18 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
   }
 
   // ── Step 4: Check max row lines to decide vertical fallback ──
-  // Measure only the header + the FIRST data row, not every row. Using every row
-  // lets a later, taller row push maxRowLines over the threshold and flip an
-  // already-horizontal table to vertical mid-stream — a visible format change.
-  // The first row is representative for the common case (rows are similar in
-  // size), so freezing the decision to it keeps the format stable as rows stream
-  // in. Column WIDTHS still track all rows (redraw-on-wider is unchanged); only
-  // the horizontal-vs-vertical CHOICE is anchored to the first row.
+  // While STREAMING (isPending), measure only the header + the FIRST data row.
+  // Using every row lets a later, taller row push maxRowLines over the threshold
+  // and flip an already-horizontal table to vertical mid-stream — a visible
+  // format change. The first row is representative for the common case, so
+  // anchoring to it keeps the format stable as rows stream in. A COMMITTED table
+  // has all its rows and no flip concern, so it measures EVERY row for the most
+  // readable layout (a short first row followed by tall rows still goes vertical).
+  // Column WIDTHS always track all rows (redraw-on-wider is unchanged); only the
+  // horizontal-vs-vertical CHOICE is anchored to the first row while streaming.
   function calculateMaxRowLines(): number {
     let maxLines = 1;
-    const firstRow = rowMetrics[0];
+    const rowsToMeasure = isPending ? rowMetrics.slice(0, 1) : rowMetrics;
     for (let i = 0; i < colCount; i++) {
       const headerWrapped = wrapText(
         headerMetrics[i]!.rendered,
@@ -570,8 +580,10 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
         },
       );
       maxLines = Math.max(maxLines, headerWrapped.length);
-      if (firstRow) {
-        const cellWrapped = wrapText(firstRow[i]!.rendered, columnWidths[i]!, {
+    }
+    for (const row of rowsToMeasure) {
+      for (let i = 0; i < colCount; i++) {
+        const cellWrapped = wrapText(row[i]!.rendered, columnWidths[i]!, {
           hard: needsHardWrap,
         });
         maxLines = Math.max(maxLines, cellWrapped.length);

--- a/packages/cli/src/ui/utils/TableRenderer.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.tsx
@@ -551,20 +551,30 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
   }
 
   // ── Step 4: Check max row lines to decide vertical fallback ──
+  // Measure only the header + the FIRST data row, not every row. Using every row
+  // lets a later, taller row push maxRowLines over the threshold and flip an
+  // already-horizontal table to vertical mid-stream — a visible format change.
+  // The first row is representative for the common case (rows are similar in
+  // size), so freezing the decision to it keeps the format stable as rows stream
+  // in. Column WIDTHS still track all rows (redraw-on-wider is unchanged); only
+  // the horizontal-vs-vertical CHOICE is anchored to the first row.
   function calculateMaxRowLines(): number {
     let maxLines = 1;
+    const firstRow = rowMetrics[0];
     for (let i = 0; i < colCount; i++) {
-      const wrapped = wrapText(headerMetrics[i]!.rendered, columnWidths[i]!, {
-        hard: needsHardWrap,
-      });
-      maxLines = Math.max(maxLines, wrapped.length);
-    }
-    for (const row of rowMetrics) {
-      for (let i = 0; i < colCount; i++) {
-        const wrapped = wrapText(row[i]!.rendered, columnWidths[i]!, {
+      const headerWrapped = wrapText(
+        headerMetrics[i]!.rendered,
+        columnWidths[i]!,
+        {
+          hard: needsHardWrap,
+        },
+      );
+      maxLines = Math.max(maxLines, headerWrapped.length);
+      if (firstRow) {
+        const cellWrapped = wrapText(firstRow[i]!.rendered, columnWidths[i]!, {
           hard: needsHardWrap,
         });
-        maxLines = Math.max(maxLines, wrapped.length);
+        maxLines = Math.max(maxLines, cellWrapped.length);
       }
     }
     return maxLines;
@@ -587,15 +597,11 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
   // vertical fallback iterates the rows and with none would render an empty
   // string (a blank box) on a narrow terminal where the width trigger fires.
   //
-  // KNOWN LIMITATION: `maxRowLines` depends on the column widths, which track
-  // content (a wider row redraws the table). For a table with very long cell
-  // text whose wrapped height sits right at MAX_ROW_LINES, a later row can grow
-  // the columns and nudge the wrap count across the threshold, so the format can
-  // still oscillate vertical↔horizontal WHILE STREAMING. This is an accepted
-  // trade-off of redraw-on-wider column sizing (only extreme wide/long-text
-  // tables hit it; normal tables stay well clear of the threshold). Eliminating
-  // it would require a content-independent decision (which mis-sizes common
-  // key/value tables) or frozen column widths (losing redraw-on-wider).
+  // The vertical trigger is anchored to the header + first row (see
+  // calculateMaxRowLines) so appending rows does not flip the format. Residual
+  // corner: a very wide later row can force a proportional column shrink that
+  // re-wraps the first row taller; that is rare and only for genuinely
+  // overflowing tables, where vertical is the right call anyway.
   const useVerticalFormat =
     rowMetrics.length > 0 &&
     (contentWidth < minHorizontalTableWidth || maxRowLines > MAX_ROW_LINES);

--- a/packages/cli/src/ui/utils/TableRenderer.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.tsx
@@ -70,6 +70,16 @@ interface TableRendererProps {
    * overflowing the viewport and triggering the scroll-to-top lock.
    */
   maxHeight?: number;
+  /**
+   * True while the table is still streaming (a pending live preview). Column
+   * widths always track the current rows (a wider row redraws the whole table),
+   * but the format is biased to horizontal: the table only falls back to the
+   * vertical `label: value` list when the terminal is genuinely too narrow, not
+   * because an early row wraps tall. This keeps a streaming table from briefly
+   * rendering as a vertical list and then flipping to a horizontal table (a
+   * visible jump) as more rows arrive.
+   */
+  isStreaming?: boolean;
 }
 
 /** Map Ink-compatible named colors to ANSI foreground codes */
@@ -436,6 +446,7 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
   aligns,
   enableInlineMath = false,
   maxHeight,
+  isStreaming = false,
 }) => {
   const colCount = headers.length;
 
@@ -581,8 +592,18 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
     ABSOLUTE_MIN_HORIZONTAL_TABLE_WIDTH,
     colCount * MIN_COLUMN_WIDTH + borderOverhead + SAFETY_MARGIN,
   );
+  // While the table is still streaming, bias toward the horizontal format: only
+  // fall back to vertical when the terminal is genuinely too narrow for the
+  // columns, NOT because an early row wraps tall. Otherwise a table that will
+  // end up horizontal briefly renders as a vertical `label: value` list and
+  // then flips (a visible jump) once more rows arrive / it completes.
+  // A zero-row table is the live streaming header box: always keep it horizontal
+  // (the header is short enough to fit). The vertical fallback iterates the rows,
+  // so with no rows it would render an empty string — a blank box — on a narrow
+  // terminal where the width trigger fires.
   const useVerticalFormat =
-    contentWidth < minHorizontalTableWidth || maxRowLines > MAX_ROW_LINES;
+    (rowMetrics.length > 0 && contentWidth < minHorizontalTableWidth) ||
+    (!isStreaming && maxRowLines > MAX_ROW_LINES);
 
   // ── Helper: Get alignment for a column ──
   const getAlign = (colIndex: number): ColumnAlign =>
@@ -720,18 +741,23 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
   const tableLines: string[] = [];
   tableLines.push(renderBorderLine('top'));
   tableLines.push(...renderRowLines(headerRendered, true));
-  tableLines.push(renderBorderLine('middle'));
-  rowMetrics.forEach((row, rowIndex) => {
-    tableLines.push(
-      ...renderRowLines(
-        row.map((m) => m.rendered),
-        false,
-      ),
-    );
-    if (rowIndex < rows.length - 1) {
-      tableLines.push(renderBorderLine('middle'));
-    }
-  });
+  // With no data rows yet (a live table whose first row is still streaming),
+  // skip the header/body divider so the box reads as a clean header — otherwise
+  // the divider stacked directly on the bottom border looks like an empty row.
+  if (rowMetrics.length > 0) {
+    tableLines.push(renderBorderLine('middle'));
+    rowMetrics.forEach((row, rowIndex) => {
+      tableLines.push(
+        ...renderRowLines(
+          row.map((m) => m.rendered),
+          false,
+        ),
+      );
+      if (rowIndex < rows.length - 1) {
+        tableLines.push(renderBorderLine('middle'));
+      }
+    });
+  }
   tableLines.push(renderBorderLine('bottom'));
 
   // ── Safety check: verify no line exceeds content width ──

--- a/packages/cli/src/ui/utils/TableRenderer.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.tsx
@@ -64,12 +64,13 @@ interface TableRendererProps {
   aligns?: ColumnAlign[];
   enableInlineMath?: boolean;
   /**
-   * True while the table is still streaming. The horizontal-vs-vertical decision
-   * is then anchored to the first row so the format cannot flip as later rows
-   * arrive; a committed table (false/undefined) measures every row for the most
-   * readable layout.
+   * True while THIS table is still streaming its rows (the frontier). The
+   * horizontal-vs-vertical decision is then anchored to the first row so the
+   * format cannot flip as later rows arrive; a completed table (false/undefined)
+   * — committed, or a mid-content table already closed by following text —
+   * measures every row for the most readable layout.
    */
-  isPending?: boolean;
+  isStreaming?: boolean;
   /**
    * Maximum rendered text lines the table may occupy. When set (streaming
    * preview) and the fully rendered table exceeds it, output is clipped to
@@ -442,7 +443,7 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
   contentWidth,
   aligns,
   enableInlineMath = false,
-  isPending = false,
+  isStreaming = false,
   maxHeight,
 }) => {
   const colCount = headers.length;
@@ -559,18 +560,19 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
   }
 
   // ── Step 4: Check max row lines to decide vertical fallback ──
-  // While STREAMING (isPending), measure only the header + the FIRST data row.
+  // While STREAMING (isStreaming), measure only the header + the FIRST data row.
   // Using every row lets a later, taller row push maxRowLines over the threshold
   // and flip an already-horizontal table to vertical mid-stream — a visible
   // format change. The first row is representative for the common case, so
-  // anchoring to it keeps the format stable as rows stream in. A COMMITTED table
-  // has all its rows and no flip concern, so it measures EVERY row for the most
-  // readable layout (a short first row followed by tall rows still goes vertical).
-  // Column WIDTHS always track all rows (redraw-on-wider is unchanged); only the
+  // anchoring to it keeps the format stable as rows stream in. A COMPLETED table
+  // (committed, or a mid-content table already closed by text) has all its rows
+  // and no flip concern, so it measures EVERY row for the most readable layout (a
+  // short first row followed by tall rows still goes vertical). Column WIDTHS
+  // always track all rows (redraw-on-wider is unchanged); only the
   // horizontal-vs-vertical CHOICE is anchored to the first row while streaming.
   function calculateMaxRowLines(): number {
     let maxLines = 1;
-    const rowsToMeasure = isPending ? rowMetrics.slice(0, 1) : rowMetrics;
+    const rowsToMeasure = isStreaming ? rowMetrics.slice(0, 1) : rowMetrics;
     for (let i = 0; i < colCount; i++) {
       const headerWrapped = wrapText(
         headerMetrics[i]!.rendered,

--- a/packages/cli/src/ui/utils/TableRenderer.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.tsx
@@ -764,8 +764,12 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
   const maxLineWidth = Math.max(
     ...tableLines.map((line) => getCachedStringWidth(stripAnsi(line))),
   );
-  if (maxLineWidth > contentWidth - SAFETY_MARGIN) {
-    // Fallback to vertical format to prevent terminal resize flicker
+  if (rowMetrics.length > 0 && maxLineWidth > contentWidth - SAFETY_MARGIN) {
+    // Fallback to vertical format to prevent terminal resize flicker. Skipped
+    // for a zero-row streaming header box: the vertical format iterates the
+    // rows and would render an empty string (a blank box). Better to keep the
+    // horizontal header — even if it slightly overflows a very narrow terminal
+    // — than to make the box the PR draws immediately vanish.
     return (
       <Box marginY={1}>
         <Text>{clampToMaxHeight(renderVerticalFormat())}</Text>

--- a/packages/cli/src/ui/utils/TableRenderer.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.tsx
@@ -70,16 +70,6 @@ interface TableRendererProps {
    * overflowing the viewport and triggering the scroll-to-top lock.
    */
   maxHeight?: number;
-  /**
-   * True while the table is still streaming (a pending live preview). Column
-   * widths always track the current rows (a wider row redraws the whole table),
-   * but the format is biased to horizontal: the table only falls back to the
-   * vertical `label: value` list when the terminal is genuinely too narrow, not
-   * because an early row wraps tall. This keeps a streaming table from briefly
-   * rendering as a vertical list and then flipping to a horizontal table (a
-   * visible jump) as more rows arrive.
-   */
-  isStreaming?: boolean;
 }
 
 /** Map Ink-compatible named colors to ANSI foreground codes */
@@ -446,7 +436,6 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
   aligns,
   enableInlineMath = false,
   maxHeight,
-  isStreaming = false,
 }) => {
   const colCount = headers.length;
 
@@ -592,18 +581,14 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
     ABSOLUTE_MIN_HORIZONTAL_TABLE_WIDTH,
     colCount * MIN_COLUMN_WIDTH + borderOverhead + SAFETY_MARGIN,
   );
-  // While the table is still streaming, bias toward the horizontal format: only
-  // fall back to vertical when the terminal is genuinely too narrow for the
-  // columns, NOT because an early row wraps tall. Otherwise a table that will
-  // end up horizontal briefly renders as a vertical `label: value` list and
-  // then flips (a visible jump) once more rows arrive / it completes.
-  // A zero-row table is the live streaming header box: always keep it horizontal
-  // (the header is short enough to fit). The vertical fallback iterates the rows,
-  // so with no rows it would render an empty string — a blank box — on a narrow
-  // terminal where the width trigger fires.
+  // The horizontal-vs-vertical decision is the SAME while streaming and once
+  // committed, so a table never flips format mid-stream (which reads as a jump).
+  // A zero-row table is the live streaming header box: never vertical — the
+  // vertical fallback iterates the rows and with none would render an empty
+  // string (a blank box) on a narrow terminal where the width trigger fires.
   const useVerticalFormat =
-    (rowMetrics.length > 0 && contentWidth < minHorizontalTableWidth) ||
-    (!isStreaming && maxRowLines > MAX_ROW_LINES);
+    rowMetrics.length > 0 &&
+    (contentWidth < minHorizontalTableWidth || maxRowLines > MAX_ROW_LINES);
 
   // ── Helper: Get alignment for a column ──
   const getAlign = (colIndex: number): ColumnAlign =>


### PR DESCRIPTION
## What this PR does

Follow-up polish to how a **live (streaming) markdown table** renders in the non-VP TUI, so it streams predictably instead of jittering, flashing, or briefly hanging. All changes are display-only.

- **Atomic rows.** A multi-column row passes through intermediate states that are themselves valid rows with fewer cells (`| a |`, `| a | b |` on the way to `| a | b | c |`), so it used to fill in cell by cell. A frontier row is now held back until it has all its columns and appears in one step. The hold-back keys on column count (a table header has ≥2 columns), so a single-pipe line — a shell pipeline `| grep foo`, a pipe-prefixed log line — still renders and does not vanish.
- **Widths track the current rows.** A wider row redraws the whole table once; a narrower row changes nothing (widths are a max over all rows, so they only grow). No per-token reflow.
- **Consistent horizontal-vs-vertical format.** The decision to render a table as a horizontal box or the vertical `label: value` fallback is the same while streaming and once committed, so a table never flips format mid-stream (which reads as a jump).
- **Hold a forming table until it is recognizable.** A header (and any partial separator) is held while pending until a separator matching the header's column count arrives, so the header no longer streams in char by char as raw `| a | b |` text before snapping into a box. Fenced code-block content is left untouched.
- **Defer until the first complete row (no empty-box flip).** While a table is still forming, its area shows a clean blank — no raw `| a | b |` pipe text, no half-filled rows — until the first row completes, at which point the table appears in one step already in its final horizontal/vertical format. This deliberately avoids drawing an empty header box that would then have to flip to the vertical `label: value` layout once a long first row lands (the format can't be known from the header alone). A clean blank reads better than that flip.

## Why it's needed

Building on #6170 (incremental scrollback commit) and #6340 (drop the redundant cue + hold back partial rows), a streaming table still had visible rough edges: cells trickling in one at a time, the whole table re-widening on a wider cell, and the header streaming in as raw pipe text. Each is a display-side artifact; none changes the model output, the markdown, or the table's data.

## Reviewer Test Plan

### How to verify

Ask the model for a long multi-column markdown table (~60 rows) and watch the live stream at two terminal sizes (e.g. **80×20** and a large window):

- values no longer fill in cell by cell — each row appears whole once its last column arrives;
- column widths track content: a wider row redraws the table once, a narrower row leaves it untouched;
- the header does not stream in char by char as raw `| … |` text — the box appears once the separator lands;
- a non-table pipe line (`| grep foo`) still renders (it is not held back);
- while the first row streams the area shows a clean blank (no raw pipe text, no half-filled rows), then the table appears whole once the first row completes — it does not draw an empty header box that later flips format;
- a table renders the same format (horizontal or the vertical `label: value` list) while streaming and once committed — it does not flip;
- scrolling up mid-stream does not jump to the top and lock (the #6170 guarantee still holds).

Unit tests: `npx vitest run packages/cli/src/ui/utils/TableRenderer.test.tsx packages/cli/src/ui/utils/MarkdownDisplay.test.tsx` → all pass.

### Evidence (Before & After)

- **Before:** a streaming table shows cells filling in one at a time; a wider row re-widens and repaints the whole table; and the header appears as raw `| a | b |` text streaming in.
- **After:** rows appear whole one at a time; widths only grow; the header appears together with its box once the separator lands; while the first row streams the area shows a clean blank (no raw pipe text, no half-filled rows) rather than an empty box, then the table appears whole; and the horizontal/vertical format is stable between streaming and committed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

Local `npm run dev` on macOS, streamed against a live model.

## Risk & Scope

- Main risk or tradeoff: display-only, gated on `isPending` where relevant. The rendered-height clip / safety-net is unchanged, so there is no scroll-to-top regression.
- Known limitation (documented in code): because column widths track content (redraw-on-wider), a table with very long cell text whose wrapped height sits right at the vertical-fallback threshold can still oscillate format while streaming. Only extreme wide/long-text tables hit it; normal tables stay well clear. Eliminating it would need a content-independent format decision (which mis-sizes common key/value tables) or frozen column widths (losing redraw-on-wider) — not worth it for the residual.
- Not addressed here: a table whose separator is invalid markdown (e.g. non-ASCII dashes) is still — correctly — rendered as raw text. The rendered-height estimate for tables with wrapping cells (a separate scroll-to-top edge) is handled in a follow-up.
- Not validated / out of scope: Windows and Linux rendering (macOS only locally; CI covers the rest).
- Breaking changes: none.

## Linked Issues

Relates to #6170 (incremental scrollback commit) and #6340 (cue removal + partial-row hold-back this builds on). No closing keyword.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

延续对 non-VP TUI 中**串流中 markdown 表格**渲染的打磨，让它串流时更稳定，不再抖动、闪烁或短暂空白。全部是显示层改动。

- **整列原子化**：多栏的一列在打字途中会经过「栏数较少但本身合法」的中间态，原本逐格填入；现在整列凑满所有栏才一次出现。以「栏数 ≥2」判别是不是表头，所以单一 pipe 行（shell 管线 `| grep foo`、pipe 开头日志）仍会显示、不会消失。
- **栏宽随当前列**：更宽的列整张重画一次；较窄的列不变（栏宽只增不减）。无逐 token reflow。
- **横式/直式格式一致**：横式方框还是直式 `label: value` 清单的判定，在串流与提交后一致，表格不会中途翻转（翻转看起来像跳）。
- **成形中的表格先不画**：串流中表头（及部分分隔线）会被压住，直到出现「栏数相符的分隔线」才成表格——表头不再以 `| a | b |` 纯文字逐字冒出。Fenced code block 内容不受影响。
- **成形中先留干净空白，等第一列到齐才出现**：表格还在成形时，该区域保持干净空白（没有纯 `| a | b |` pipe 文字、也没有半填的列），直到第一列凑满，表格才一步出现、且已经是最终的横式/直式格式。这是刻意不画空表头框——否则一旦长首列到达就得翻成直式 `label: value`（格式无法只从表头得知），干净空白比那个翻转好读。

## 为什么需要

在 #6170 与 #6340 的基础上，串流表格仍有可见粗糙处：储存格逐格冒、更宽储存格让整张重画、表头以纯文字逐字冒。这些都是显示层现象，不改变模型输出、markdown 或表格资料。

## Reviewer 测试计划

请模型产生长的多栏 markdown 表格（约 60 列），在两种视窗大小观察串流：数值不再逐格冒、栏宽随内容（更宽重画一次、较窄不动）、表头不再纯文字逐字冒、`| grep foo` 类非表格文字仍显示、第一列串流时该区域是干净空白（不画空表头框、不会随后翻转格式）、同一张表串流与提交格式一致（不翻转）、往上滚不跳顶锁死。单元测试：`npx vitest run packages/cli/src/ui/utils/TableRenderer.test.tsx packages/cli/src/ui/utils/MarkdownDisplay.test.tsx` 全通过。

## 风险与范围

- 主要风险：仅显示层。算绘高度裁切／安全网不变，无 scroll-to-top 回归。
- 已知限制（程式码内已注明）：因栏宽随内容（redraw-on-wider），内容极长、换行高度刚好卡在直式门槛的表格，串流中仍可能在直/横间抖动。只有极端宽/长文字表格会踩到；一般表格离门槛很远。要根治需「与内容无关的格式判定」（会误判常见 key/value 表）或「冻结栏宽」（失去 redraw-on-wider），不值得。
- 未处理：分隔线是无效 markdown（如非 ASCII 破折号）的表格仍正确渲染为纯文字；含换行储存格的表格「算绘高度估算」（另一个 scroll-to-top 边界）在后续 PR 处理。
- 未验证：Windows 与 Linux（本机仅 macOS，CI 覆盖）。
- 破坏性变更：无。

## 关联 Issue

关联 #6170 与 #6340。未使用关闭关键字。

</details>

