### PR TITLE
perf(core): Add session start profiler

### DIFF
--- a/.qwen/design/2026-07-06-session-start-profiler.md
+++ b/.qwen/design/2026-07-06-session-start-profiler.md
@@ -10,9 +10,9 @@ It does not change session behavior, public protocol fields, SDK behavior, CLI f
 
 The profiler is enabled only when `QWEN_CODE_PROFILE_SESSION_START=1`.
 
-When enabled, core writes JSONL records under `Storage.getRuntimeBaseDir()/session-start-perf/`. Each record includes a timestamp, `SessionStartSource`, success flag, total duration, bounded stage durations, and small aggregate counts such as history length and rendered snapshot count.
+When enabled, core writes JSONL records under `Storage.getRuntimeBaseDir()/session-start-perf/`. Daily JSONL filenames use the UTC date from the record timestamp. Each record includes a timestamp, `SessionStartSource`, success flag, total duration, bounded stage durations, and small aggregate counts such as history length and rendered snapshot count.
 
-The measured stages follow the existing `startChat()` sequence: tool registry warm, resumed deferred-tool reveal scan, deferred reminder resolution, initial chat history build, reminder dedup seeding, system instruction build, `GeminiChat` construction, orphan tool-use repair, SessionStart hook, optional SessionStart context apply, and `setTools()`.
+The measured stages follow the existing `startChat()` sequence: tool registry warm, resumed deferred-tool reveal scan, deferred reminder setup, initial chat history build, skill reminder dedup seeding, agent reminder dedup seeding, system instruction build, `GeminiChat` construction, orphan tool-use repair, SessionStart hook, optional SessionStart context apply, and `setTools()`.
 
 ## Safety Boundaries
 
@@ -21,6 +21,8 @@ The output intentionally excludes session IDs, prompts, model responses, hook ou
 All profiler writes are best-effort. File-system failures are swallowed so profiling cannot break or slow a session through error handling.
 
 When disabled, the helper performs no file writes and does not read the high-resolution clock.
+
+`failedStage` only records stages that throw through the profiler wrapper. Stages whose underlying helpers catch and suppress their own errors, such as agent reminder dedup seeding and the SessionStart hook, remain successful from the profiler's perspective.
 
 ## Non-Goals
 

--- a/.qwen/design/2026-07-06-session-start-profiler.md
+++ b/.qwen/design/2026-07-06-session-start-profiler.md
@@ -1,0 +1,31 @@
+# Session Start Profiler
+
+## Summary
+
+This change adds an internal, opt-in profiler for `GeminiClient.startChat()` so #6312 follow-up work can identify the remaining per-session initialization hotspot before choosing an optimization.
+
+It does not change session behavior, public protocol fields, SDK behavior, CLI flags, config schema, telemetry schema, or startup profiler semantics.
+
+## Measurement Shape
+
+The profiler is enabled only when `QWEN_CODE_PROFILE_SESSION_START=1`.
+
+When enabled, core writes JSONL records under `Storage.getRuntimeBaseDir()/session-start-perf/`. Each record includes a timestamp, `SessionStartSource`, success flag, total duration, bounded stage durations, and small aggregate counts such as history length and rendered snapshot count.
+
+The measured stages follow the existing `startChat()` sequence: tool registry warm, resumed deferred-tool reveal scan, deferred reminder resolution, initial chat history build, reminder dedup seeding, system instruction build, `GeminiChat` construction, orphan tool-use repair, SessionStart hook, optional SessionStart context apply, and `setTools()`.
+
+## Safety Boundaries
+
+The output intentionally excludes session IDs, prompts, model responses, hook output, tool names, file paths, and working directories. Stage names are static code-owned strings.
+
+All profiler writes are best-effort. File-system failures are swallowed so profiling cannot break or slow a session through error handling.
+
+When disabled, the helper performs no file writes and does not read the high-resolution clock.
+
+## Non-Goals
+
+This change does not optimize `GeminiClient.initialize()` or `startChat()`.
+
+It does not implement Part B extension caching, Part C skill body lazy-loading, command snapshot caching, or any daemon protocol changes.
+
+The next optimization should be chosen only after collecting stage breakdowns from this profiler and comparing them with extension-heavy or skill-heavy fixtures where relevant.

--- a/.qwen/design/2026-07-06-session-start-profiler.md
+++ b/.qwen/design/2026-07-06-session-start-profiler.md
@@ -20,6 +20,8 @@ The output intentionally excludes session IDs, prompts, model responses, hook ou
 
 All profiler writes are best-effort. File-system failures are swallowed so profiling cannot break or slow a session through error handling.
 
+The JSONL writer uses restrictive permissions and `O_NOFOLLOW` on the profile file. Parent-directory replacement remains best-effort because Node does not expose a portable fd-relative append path here; the runtime directory is treated as same-user diagnostic storage, not a boundary against a local same-user attacker.
+
 When disabled, the helper performs no file writes and does not read the high-resolution clock.
 
 `failedStage` only records stages that throw through the profiler wrapper. Stages whose underlying helpers catch and suppress their own errors, such as agent reminder dedup seeding and the SessionStart hook, remain successful from the profiler's perspective.

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -51,6 +51,22 @@ import {
 } from './turn.js';
 import { LoopType } from '../telemetry/types.js';
 
+type MockSessionStartProfiler = {
+  time: Mock;
+  timeSync: Mock;
+  finish: Mock;
+};
+
+const sessionStartProfilerMocks = vi.hoisted(() => ({
+  createSessionStartProfiler: vi.fn(),
+  profilers: [] as MockSessionStartProfiler[],
+}));
+
+vi.mock('./session-start-profiler.js', () => ({
+  createSessionStartProfiler:
+    sessionStartProfilerMocks.createSessionStartProfiler,
+}));
+
 vi.mock('../utils/retry.js', () => ({
   retryWithBackoff: vi.fn(async (fn) => await fn()),
   isUnattendedMode: vi.fn(() => false),
@@ -414,6 +430,20 @@ describe('Gemini Client (client.ts)', () => {
   };
   beforeEach(async () => {
     vi.resetAllMocks();
+    sessionStartProfilerMocks.profilers.length = 0;
+    sessionStartProfilerMocks.createSessionStartProfiler.mockImplementation(
+      () => {
+        const profiler: MockSessionStartProfiler = {
+          time: vi.fn(async (_stage: string, fn: () => Promise<unknown>) =>
+            fn(),
+          ),
+          timeSync: vi.fn((_stage: string, fn: () => unknown) => fn()),
+          finish: vi.fn(),
+        };
+        sessionStartProfilerMocks.profilers.push(profiler);
+        return profiler;
+      },
+    );
     vi.mocked(uiTelemetryService.setLastPromptTokenCount).mockClear();
 
     // Default: createContentGenerator rejects (simulates test env without auth).
@@ -896,6 +926,93 @@ describe('Gemini Client (client.ts)', () => {
       ).resolves.toBeUndefined();
       expect(debugLogger.warn).toHaveBeenCalledWith(
         'SessionStart hook failed: Error: hook failed',
+      );
+    });
+  });
+
+  describe('startChat — session start profiling', () => {
+    beforeEach(() => {
+      sessionStartProfilerMocks.createSessionStartProfiler.mockClear();
+      sessionStartProfilerMocks.profilers.length = 0;
+    });
+
+    it('passes startup, resume, and clear sources to the profiler', async () => {
+      await client.startChat();
+      await client.startChat([{ role: 'user', parts: [{ text: 'hi' }] }]);
+      await client.startChat(undefined, SessionStartSource.Clear);
+
+      expect(
+        sessionStartProfilerMocks.createSessionStartProfiler.mock.calls.map(
+          ([source]) => source,
+        ),
+      ).toEqual([
+        SessionStartSource.Startup,
+        SessionStartSource.Resume,
+        SessionStartSource.Clear,
+      ]);
+    });
+
+    it('finalizes successful startChat profiles with bounded counts', async () => {
+      const hookSystem = {
+        fireSessionStartEvent: vi.fn().mockResolvedValue(
+          createHookOutput('SessionStart', {
+            hookSpecificOutput: {
+              additionalContext: 'hook output',
+            },
+          }),
+        ),
+      };
+      vi.mocked(mockConfig.getDisableAllHooks).mockReturnValue(false);
+      vi.mocked(mockConfig.hasHooksForEvent).mockReturnValue(true);
+      vi.mocked(mockConfig.getHookSystem).mockReturnValue(
+        hookSystem as unknown as ReturnType<Config['getHookSystem']>,
+      );
+
+      await client.startChat(undefined, SessionStartSource.Clear);
+
+      const profiler = sessionStartProfilerMocks.profilers.at(-1)!;
+      expect(profiler.finish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ok: true,
+          extraHistoryLength: 0,
+          historyLength: 1,
+          snapshotEntryCount: 0,
+          deferredReminderCount: 0,
+        }),
+      );
+      expect(profiler.time.mock.calls.map(([stage]) => stage)).toEqual([
+        'tool_registry_warm',
+        'initial_chat_history',
+        'agent_reminder_seed',
+        'session_start_hook',
+        'set_tools',
+      ]);
+      expect(profiler.timeSync.mock.calls.map(([stage]) => stage)).toEqual([
+        'resume_deferred_tool_reveal',
+        'deferred_reminder_resolution',
+        'skill_reminder_seed',
+        'system_instruction',
+        'gemini_chat_construct',
+        'orphan_tool_use_repair',
+        'session_start_context_apply',
+      ]);
+    });
+
+    it('finalizes failed startChat profiles without changing the thrown error', async () => {
+      vi.mocked(getInitialChatHistory).mockRejectedValueOnce(
+        new Error('history failed'),
+      );
+
+      await expect(client.startChat()).rejects.toThrow(
+        'Failed to initialize chat: history failed',
+      );
+
+      const profiler = sessionStartProfilerMocks.profilers.at(-1)!;
+      expect(profiler.finish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ok: false,
+          extraHistoryLength: 0,
+        }),
       );
     });
   });

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -1001,6 +1001,15 @@ describe('Gemini Client (client.ts)', () => {
       ]);
     });
 
+    it('does not record context apply stage without SessionStart context', async () => {
+      await client.startChat();
+
+      const profiler = sessionStartProfilerMocks.profilers.at(-1)!;
+      expect(profiler.timeSync.mock.calls.map(([stage]) => stage)).not.toContain(
+        'session_start_context_apply',
+      );
+    });
+
     it('finalizes failed startChat profiles without changing the thrown error', async () => {
       vi.mocked(getInitialChatHistory).mockRejectedValueOnce(
         new Error('history failed'),

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -950,6 +950,11 @@ describe('Gemini Client (client.ts)', () => {
         SessionStartSource.Resume,
         SessionStartSource.Clear,
       ]);
+      expect(
+        sessionStartProfilerMocks.profilers[1].finish,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ extraHistoryLength: 1 }),
+      );
       for (const profiler of sessionStartProfilerMocks.profilers) {
         expect(profiler.finish).toHaveBeenCalledTimes(1);
       }

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -950,6 +950,9 @@ describe('Gemini Client (client.ts)', () => {
         SessionStartSource.Resume,
         SessionStartSource.Clear,
       ]);
+      for (const profiler of sessionStartProfilerMocks.profilers) {
+        expect(profiler.finish).toHaveBeenCalledTimes(1);
+      }
     });
 
     it('finalizes successful startChat profiles with bounded counts', async () => {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -1001,13 +1001,51 @@ describe('Gemini Client (client.ts)', () => {
       ]);
     });
 
+    it('records non-zero snapshot and deferred reminder counts', async () => {
+      const toolRegistry = vi.mocked(
+        mockConfig.getToolRegistry,
+      )() as unknown as {
+        getDeferredToolSummary: ReturnType<typeof vi.fn>;
+        getTool: ReturnType<typeof vi.fn>;
+      };
+      toolRegistry.getDeferredToolSummary.mockReturnValue([
+        { name: 'cron_create', description: 'schedule' },
+      ]);
+      toolRegistry.getTool.mockImplementation((name: string) =>
+        name === ToolNames.TOOL_SEARCH ? ({} as never) : null,
+      );
+      vi.mocked(getInitialChatHistory).mockResolvedValueOnce([
+        [
+          {
+            role: 'user',
+            parts: [{ text: '<system-reminder>context</system-reminder>' }],
+          },
+        ],
+        [
+          { name: 'skill-one', description: 'first skill' },
+          { name: 'skill-two', description: 'second skill' },
+        ],
+      ]);
+
+      await client.startChat();
+
+      const profiler = sessionStartProfilerMocks.profilers.at(-1)!;
+      expect(profiler.finish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ok: true,
+          snapshotEntryCount: 2,
+          deferredReminderCount: 1,
+        }),
+      );
+    });
+
     it('does not record context apply stage without SessionStart context', async () => {
       await client.startChat();
 
       const profiler = sessionStartProfilerMocks.profilers.at(-1)!;
-      expect(profiler.timeSync.mock.calls.map(([stage]) => stage)).not.toContain(
-        'session_start_context_apply',
-      );
+      expect(
+        profiler.timeSync.mock.calls.map(([stage]) => stage),
+      ).not.toContain('session_start_context_apply');
     });
 
     it('finalizes failed startChat profiles without changing the thrown error', async () => {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -1022,6 +1022,33 @@ describe('Gemini Client (client.ts)', () => {
       );
     });
 
+    it('finalizes failed startChat profiles for first-stage warm errors', async () => {
+      const toolRegistry = vi.mocked(
+        mockConfig.getToolRegistry,
+      )() as unknown as {
+        warmAll: ReturnType<typeof vi.fn>;
+      };
+      toolRegistry.warmAll.mockRejectedValueOnce(new Error('warm failed'));
+
+      await expect(client.startChat()).rejects.toThrow(
+        'Failed to initialize chat: warm failed',
+      );
+
+      const profiler = sessionStartProfilerMocks.profilers.at(-1)!;
+      expect(profiler.time.mock.calls.map(([stage]) => stage)).toContain(
+        'tool_registry_warm',
+      );
+      expect(profiler.finish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ok: false,
+          extraHistoryLength: 0,
+          historyLength: 0,
+          snapshotEntryCount: 0,
+          deferredReminderCount: 0,
+        }),
+      );
+    });
+
     it('finalizes failed startChat profiles for sync stage errors', async () => {
       vi.spyOn(
         client as unknown as { getMainSessionSystemInstruction: () => string },

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -1127,6 +1127,48 @@ describe('Gemini Client (client.ts)', () => {
         }),
       );
     });
+
+    it('finalizes failed startChat profiles with partial counts', async () => {
+      const toolRegistry = vi.mocked(
+        mockConfig.getToolRegistry,
+      )() as unknown as {
+        getDeferredToolSummary: ReturnType<typeof vi.fn>;
+        getTool: ReturnType<typeof vi.fn>;
+      };
+      toolRegistry.getDeferredToolSummary.mockReturnValue([
+        { name: 'cron_create', description: 'schedule' },
+      ]);
+      toolRegistry.getTool.mockImplementation((name: string) =>
+        name === ToolNames.TOOL_SEARCH ? ({} as never) : null,
+      );
+      vi.mocked(getInitialChatHistory).mockResolvedValueOnce([
+        [
+          {
+            role: 'user',
+            parts: [{ text: '<system-reminder>context</system-reminder>' }],
+          },
+        ],
+        [{ name: 'skill-one', description: 'first skill' }],
+      ]);
+      vi.spyOn(client, 'setTools').mockRejectedValueOnce(
+        new Error('set tools failed'),
+      );
+
+      await expect(client.startChat()).rejects.toThrow(
+        'Failed to initialize chat: set tools failed',
+      );
+
+      const profiler = sessionStartProfilerMocks.profilers.at(-1)!;
+      expect(profiler.finish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ok: false,
+          extraHistoryLength: 0,
+          historyLength: 1,
+          snapshotEntryCount: 1,
+          deferredReminderCount: 1,
+        }),
+      );
+    });
   });
 
   describe('startChat — deferred tools', () => {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -992,7 +992,7 @@ describe('Gemini Client (client.ts)', () => {
       ]);
       expect(profiler.timeSync.mock.calls.map(([stage]) => stage)).toEqual([
         'resume_deferred_tool_reveal',
-        'deferred_reminder_resolution',
+        'deferred_reminder_setup',
         'skill_reminder_seed',
         'system_instruction',
         'gemini_chat_construct',

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -1015,6 +1015,36 @@ describe('Gemini Client (client.ts)', () => {
         expect.objectContaining({
           ok: false,
           extraHistoryLength: 0,
+          historyLength: 0,
+          snapshotEntryCount: 0,
+          deferredReminderCount: 0,
+        }),
+      );
+    });
+
+    it('finalizes failed startChat profiles for sync stage errors', async () => {
+      vi.spyOn(
+        client as unknown as { getMainSessionSystemInstruction: () => string },
+        'getMainSessionSystemInstruction',
+      ).mockImplementationOnce(() => {
+        throw new Error('system instruction failed');
+      });
+
+      await expect(client.startChat()).rejects.toThrow(
+        'Failed to initialize chat: system instruction failed',
+      );
+
+      const profiler = sessionStartProfilerMocks.profilers.at(-1)!;
+      expect(profiler.timeSync.mock.calls.map(([stage]) => stage)).toContain(
+        'system_instruction',
+      );
+      expect(profiler.finish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ok: false,
+          extraHistoryLength: 0,
+          historyLength: 1,
+          snapshotEntryCount: 0,
+          deferredReminderCount: 0,
         }),
       );
     });

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -1236,6 +1236,15 @@ export class GeminiClient {
     let history: Content[] = [];
     let snapshotEntries: AvailableSkillEntry[] = [];
     let deferredReminderCount = 0;
+    const finishProfile = (ok: boolean) => {
+      profiler.finish({
+        ok,
+        extraHistoryLength: extraHistory?.length ?? 0,
+        historyLength: history.length,
+        snapshotEntryCount: snapshotEntries.length,
+        deferredReminderCount,
+      });
+    };
 
     try {
       // Warm the tool registry before building startup reminders and tool
@@ -1344,22 +1353,10 @@ export class GeminiClient {
 
       await profiler.time('set_tools', () => this.setTools());
 
-      profiler.finish({
-        ok: true,
-        extraHistoryLength: extraHistory?.length ?? 0,
-        historyLength: history.length,
-        snapshotEntryCount: snapshotEntries.length,
-        deferredReminderCount,
-      });
+      finishProfile(true);
       return this.chat;
     } catch (error) {
-      profiler.finish({
-        ok: false,
-        extraHistoryLength: extraHistory?.length ?? 0,
-        historyLength: history.length,
-        snapshotEntryCount: snapshotEntries.length,
-        deferredReminderCount,
-      });
+      finishProfile(false);
       await reportError(
         error,
         'Error initializing chat session.',

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -1278,14 +1278,11 @@ export class GeminiClient {
           }
         }
       });
-      const deferredTools = profiler.timeSync(
-        'deferred_reminder_resolution',
-        () => {
-          const resolved = this.resolveDeferredToolsForReminder();
-          this.rememberAnnouncedDeferredTools(resolved);
-          return resolved;
-        },
-      );
+      const deferredTools = profiler.timeSync('deferred_reminder_setup', () => {
+        const resolved = this.resolveDeferredToolsForReminder();
+        this.rememberAnnouncedDeferredTools(resolved);
+        return resolved;
+      });
       deferredReminderCount = deferredTools?.length ?? 0;
       [history, snapshotEntries] = await profiler.time(
         'initial_chat_history',

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -1348,6 +1348,8 @@ export class GeminiClient {
         });
       }
 
+      // setTools() intentionally keeps its own warmAll() guard, so this stage
+      // overlaps with tool_registry_warm while preserving the startup path.
       await profiler.time('set_tools', () => this.setTools());
 
       finishProfile(true);

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -39,6 +39,7 @@ import {
   escalatedOutputTokenLimit,
   parsePositiveIntegerEnvValue,
 } from './tokenLimits.js';
+import { createSessionStartProfiler } from './session-start-profiler.js';
 
 const debugLogger = createDebugLogger('CLIENT');
 
@@ -1231,7 +1232,10 @@ export class GeminiClient {
     // Clear stale cache params on session reset to prevent cross-session leakage
     clearCacheSafeParams();
 
+    const profiler = createSessionStartProfiler(sessionStartSource);
     let history: Content[] = [];
+    let snapshotEntries: AvailableSkillEntry[] = [];
+    let deferredReminderCount = 0;
 
     try {
       // Warm the tool registry before building startup reminders and tool
@@ -1240,7 +1244,7 @@ export class GeminiClient {
       // session); `/clear` clears the revealed set via resetChat() before
       // calling us.
       const toolRegistry = this.config.getToolRegistry();
-      await toolRegistry.warmAll();
+      await profiler.time('tool_registry_warm', () => toolRegistry.warmAll());
       // Resume support: when a transcript contains prior calls to a deferred
       // tool, re-reveal that tool so `setTools()` below sends its schema in
       // the declaration list. Without this, the model sees history like
@@ -1248,41 +1252,60 @@ export class GeminiClient {
       // call to foo_tool because the schema is absent. This must happen
       // BEFORE `resolveDeferredToolsForReminder()` runs so the resumed tools
       // are correctly filtered out of the startup reminder built below.
-      if (extraHistory && extraHistory.length > 0) {
-        const deferredNames = new Set(
-          toolRegistry.getDeferredToolSummary().map((t) => t.name),
-        );
-        if (deferredNames.size > 0) {
-          for (const entry of extraHistory) {
-            for (const part of entry.parts ?? []) {
-              const callName = part.functionCall?.name;
-              if (callName && deferredNames.has(callName)) {
-                toolRegistry.revealDeferredTool(callName);
+      profiler.timeSync('resume_deferred_tool_reveal', () => {
+        if (extraHistory && extraHistory.length > 0) {
+          const deferredNames = new Set(
+            toolRegistry.getDeferredToolSummary().map((t) => t.name),
+          );
+          if (deferredNames.size > 0) {
+            for (const entry of extraHistory) {
+              for (const part of entry.parts ?? []) {
+                const callName = part.functionCall?.name;
+                if (callName && deferredNames.has(callName)) {
+                  toolRegistry.revealDeferredTool(callName);
+                }
               }
             }
           }
         }
-      }
-      const deferredTools = this.resolveDeferredToolsForReminder();
-      this.rememberAnnouncedDeferredTools(deferredTools);
-      let snapshotEntries: AvailableSkillEntry[];
-      [history, snapshotEntries] = await getInitialChatHistory(
-        this.config,
-        extraHistory,
-      );
-      this.seedSkillReminderDedupFromSnapshot(snapshotEntries);
-      await this.seedAgentReminderDedupFromCurrent();
-      const systemInstruction = this.getMainSessionSystemInstruction();
-
-      this.chat = new GeminiChat(
-        this.config,
-        {
-          systemInstruction,
+      });
+      const deferredTools = profiler.timeSync(
+        'deferred_reminder_resolution',
+        () => {
+          const resolved = this.resolveDeferredToolsForReminder();
+          this.rememberAnnouncedDeferredTools(resolved);
+          return resolved;
         },
-        history,
-        this.config.getChatRecordingService(),
-        uiTelemetryService,
       );
+      deferredReminderCount = deferredTools?.length ?? 0;
+      [history, snapshotEntries] = await profiler.time(
+        'initial_chat_history',
+        () => getInitialChatHistory(this.config, extraHistory),
+      );
+      profiler.timeSync('skill_reminder_seed', () => {
+        this.seedSkillReminderDedupFromSnapshot(snapshotEntries);
+      });
+      await profiler.time('agent_reminder_seed', () =>
+        this.seedAgentReminderDedupFromCurrent(),
+      );
+      const systemInstruction = profiler.timeSync('system_instruction', () =>
+        this.getMainSessionSystemInstruction(),
+      );
+
+      const chat = profiler.timeSync(
+        'gemini_chat_construct',
+        () =>
+          new GeminiChat(
+            this.config,
+            {
+              systemInstruction,
+            },
+            history,
+            this.config.getChatRecordingService(),
+            uiTelemetryService,
+          ),
+      );
+      this.chat = chat;
 
       // Repair any dangling `model[functionCall]` whose `functionResponse`
       // never made it back into the transcript before we wrote the JSONL.
@@ -1297,26 +1320,46 @@ export class GeminiClient {
       // compaction reordering is also caught — but doing it here keeps
       // any pre-send code reading `chat.history` from seeing a malformed
       // shape.)
-      this.repairOrphanedToolUseTurnsInHistory();
+      profiler.timeSync('orphan_tool_use_repair', () => {
+        this.repairOrphanedToolUseTurnsInHistory();
+      });
 
-      const sessionStartAdditionalContext =
-        await this.fireSessionStartHook(sessionStartSource);
+      const sessionStartAdditionalContext = await profiler.time(
+        'session_start_hook',
+        () => this.fireSessionStartHook(sessionStartSource),
+      );
       this.lastSessionStartContext = sessionStartAdditionalContext;
       this.lastSessionStartSource = sessionStartAdditionalContext
         ? sessionStartSource
         : undefined;
 
       if (sessionStartAdditionalContext) {
-        this.chat.applySessionStartContext(
-          sessionStartAdditionalContext,
-          sessionStartSource,
-        );
+        profiler.timeSync('session_start_context_apply', () => {
+          chat.applySessionStartContext(
+            sessionStartAdditionalContext,
+            sessionStartSource,
+          );
+        });
       }
 
-      await this.setTools();
+      await profiler.time('set_tools', () => this.setTools());
 
+      profiler.finish({
+        ok: true,
+        extraHistoryLength: extraHistory?.length ?? 0,
+        historyLength: history.length,
+        snapshotEntryCount: snapshotEntries.length,
+        deferredReminderCount,
+      });
       return this.chat;
     } catch (error) {
+      profiler.finish({
+        ok: false,
+        extraHistoryLength: extraHistory?.length ?? 0,
+        historyLength: history.length,
+        snapshotEntryCount: snapshotEntries.length,
+        deferredReminderCount,
+      });
       await reportError(
         error,
         'Error initializing chat session.',

--- a/packages/core/src/core/session-start-profiler.test.ts
+++ b/packages/core/src/core/session-start-profiler.test.ts
@@ -120,6 +120,10 @@ describe('session-start-profiler', () => {
         deferredReminderCount: 1,
       },
     ]);
+    expect(debugLoggerMock.debug).toHaveBeenCalledWith(
+      'session-start-profiler enabled',
+      { source: 'resume' },
+    );
   });
 
   it('rounds elapsed durations to two decimal places', async () => {
@@ -294,7 +298,7 @@ describe('session-start-profiler', () => {
     expect(() => profiler.finish({ ok: true })).not.toThrow();
     expect(debugLoggerMock.debug).toHaveBeenCalledWith(
       'session-start-profiler write failed',
-      { name: 'Error', code: 'ENOSPC' },
+      { name: 'Error', message: 'disk full', code: 'ENOSPC' },
     );
   });
 

--- a/packages/core/src/core/session-start-profiler.test.ts
+++ b/packages/core/src/core/session-start-profiler.test.ts
@@ -147,6 +147,38 @@ describe('session-start-profiler', () => {
     });
   });
 
+  it('preserves the first failed stage', async () => {
+    const records: SessionStartProfileRecord[] = [];
+    const profiler = createSessionStartProfiler(SessionStartSource.Startup, {
+      enabled: true,
+      now: clockFrom([100, 110, 115, 120, 130, 140]),
+      writeRecord: (record) => records.push(record),
+      getTimestamp: () => new Date('2026-07-06T00:00:00.000Z'),
+    });
+
+    await expect(
+      profiler.time('stage_a', async () => {
+        throw new Error('stage a failed');
+      }),
+    ).rejects.toThrow('stage a failed');
+    await expect(
+      profiler.time('stage_b', async () => {
+        throw new Error('stage b failed');
+      }),
+    ).rejects.toThrow('stage b failed');
+    profiler.finish({ ok: false });
+
+    expect(records[0]).toMatchObject({
+      ok: false,
+      totalMs: 40,
+      stages: {
+        stage_a: 5,
+        stage_b: 10,
+      },
+      failedStage: 'stage_a',
+    });
+  });
+
   it('rethrows sync stage errors and preserves the failed stage', () => {
     const records: SessionStartProfileRecord[] = [];
     const profiler = createSessionStartProfiler(SessionStartSource.Startup, {

--- a/packages/core/src/core/session-start-profiler.test.ts
+++ b/packages/core/src/core/session-start-profiler.test.ts
@@ -1,0 +1,188 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SessionStartSource } from '../hooks/types.js';
+import {
+  createSessionStartProfiler,
+  type SessionStartProfileRecord,
+} from './session-start-profiler.js';
+
+function clockFrom(values: number[]) {
+  let last = values[values.length - 1] ?? 0;
+  return vi.fn(() => {
+    const next = values.shift();
+    if (next !== undefined) {
+      last = next;
+    }
+    return last;
+  });
+}
+
+describe('session-start-profiler', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('is a no-op when disabled', async () => {
+    const now = vi.fn(() => {
+      throw new Error('disabled profiler should not read time');
+    });
+    const writeRecord = vi.fn();
+    const profiler = createSessionStartProfiler(SessionStartSource.Startup, {
+      enabled: false,
+      now,
+      writeRecord,
+      getTimestamp: () => new Date('2026-07-06T00:00:00.000Z'),
+    });
+
+    await expect(
+      profiler.time('tool_registry_warm', async () => 'ok'),
+    ).resolves.toBe('ok');
+    expect(profiler.timeSync('system_instruction', () => 42)).toBe(42);
+    profiler.finish({ ok: true });
+
+    expect(profiler.enabled).toBe(false);
+    expect(now).not.toHaveBeenCalled();
+    expect(writeRecord).not.toHaveBeenCalled();
+  });
+
+  it('records sync and async stages when enabled', async () => {
+    const records: SessionStartProfileRecord[] = [];
+    const profiler = createSessionStartProfiler(SessionStartSource.Resume, {
+      enabled: true,
+      now: clockFrom([10, 12, 15, 16, 21, 30]),
+      writeRecord: (record) => records.push(record),
+      getTimestamp: () => new Date('2026-07-06T00:00:00.000Z'),
+    });
+
+    await expect(
+      profiler.time('initial_chat_history', async () => 'history'),
+    ).resolves.toBe('history');
+    expect(
+      profiler.timeSync('system_instruction', () => 'system'),
+    ).toBe('system');
+    profiler.finish({
+      ok: true,
+      extraHistoryLength: 3,
+      historyLength: 4,
+      snapshotEntryCount: 2,
+      deferredReminderCount: 1,
+    });
+
+    expect(records).toEqual([
+      {
+        timestamp: '2026-07-06T00:00:00.000Z',
+        source: 'resume',
+        ok: true,
+        totalMs: 20,
+        stages: {
+          initial_chat_history: 3,
+          system_instruction: 5,
+        },
+        extraHistoryLength: 3,
+        historyLength: 4,
+        snapshotEntryCount: 2,
+        deferredReminderCount: 1,
+      },
+    ]);
+  });
+
+  it('rethrows stage errors and preserves the failed stage', async () => {
+    const records: SessionStartProfileRecord[] = [];
+    const profiler = createSessionStartProfiler(SessionStartSource.Startup, {
+      enabled: true,
+      now: clockFrom([100, 110, 125, 130]),
+      writeRecord: (record) => records.push(record),
+      getTimestamp: () => new Date('2026-07-06T00:00:00.000Z'),
+    });
+    const error = new Error('setTools failed');
+
+    await expect(
+      profiler.time('set_tools', async () => {
+        throw error;
+      }),
+    ).rejects.toBe(error);
+    profiler.finish({ ok: false });
+
+    expect(records[0]).toMatchObject({
+      ok: false,
+      totalMs: 30,
+      stages: {
+        set_tools: 15,
+      },
+      failedStage: 'set_tools',
+    });
+  });
+
+  it('does not throw when the output writer fails', () => {
+    const profiler = createSessionStartProfiler(SessionStartSource.Clear, {
+      enabled: true,
+      now: clockFrom([1, 2]),
+      writeRecord: () => {
+        throw new Error('disk full');
+      },
+      getTimestamp: () => new Date('2026-07-06T00:00:00.000Z'),
+    });
+
+    expect(() => profiler.finish({ ok: true })).not.toThrow();
+  });
+
+  it('writes bounded JSONL without sensitive fields', async () => {
+    const runtimeDir = await mkdtemp(
+      join(tmpdir(), 'session-start-profiler-'),
+    );
+    vi.stubEnv('QWEN_RUNTIME_DIR', runtimeDir);
+    vi.stubEnv('QWEN_CODE_PROFILE_SESSION_START', '1');
+
+    try {
+      const profiler = createSessionStartProfiler(SessionStartSource.Clear, {
+        now: clockFrom([10, 15, 20, 30]),
+        getTimestamp: () => new Date('2026-07-06T12:34:56.789Z'),
+      });
+      profiler.timeSync('system_instruction', () => 'system');
+      profiler.finish({
+        ok: true,
+        extraHistoryLength: 0,
+        historyLength: 1,
+        snapshotEntryCount: 0,
+        deferredReminderCount: 0,
+      });
+
+      const files = await readdir(join(runtimeDir, 'session-start-perf'));
+      expect(files).toEqual(['session-start-2026-07-06.jsonl']);
+      const raw = await readFile(
+        join(
+          runtimeDir,
+          'session-start-perf',
+          'session-start-2026-07-06.jsonl',
+        ),
+        'utf8',
+      );
+      const record = JSON.parse(raw.trim()) as SessionStartProfileRecord;
+      const serialized = JSON.stringify(record);
+
+      expect(record).toMatchObject({
+        timestamp: '2026-07-06T12:34:56.789Z',
+        source: 'clear',
+        ok: true,
+        totalMs: 20,
+        stages: { system_instruction: 5 },
+      });
+      expect(record).not.toHaveProperty('sessionId');
+      expect(serialized).not.toContain('prompt');
+      expect(serialized).not.toContain('/test/');
+      expect(serialized).not.toContain('test-session-id');
+      expect(serialized).not.toContain('hook output');
+      expect(serialized).not.toContain('tool name');
+    } finally {
+      await rm(runtimeDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/core/session-start-profiler.test.ts
+++ b/packages/core/src/core/session-start-profiler.test.ts
@@ -362,6 +362,38 @@ describe('session-start-profiler', () => {
     }
   });
 
+  it('appends to an existing JSONL file', async () => {
+    const runtimeDir = await mkdtemp(join(tmpdir(), 'session-start-profiler-'));
+    vi.stubEnv('QWEN_RUNTIME_DIR', runtimeDir);
+    vi.stubEnv(SESSION_START_PROFILE_ENV, '1');
+
+    try {
+      const perfDir = join(runtimeDir, 'session-start-perf');
+      const profilePath = join(perfDir, 'session-start-2026-07-06.jsonl');
+      await mkdir(perfDir);
+      await writeFile(profilePath, '{"existing":true}\n', 'utf8');
+
+      const profiler = createSessionStartProfiler(SessionStartSource.Clear, {
+        now: clockFrom([10, 15, 20]),
+        getTimestamp: () => new Date('2026-07-06T12:34:56.789Z'),
+      });
+      profiler.timeSync('system_instruction', () => undefined);
+      profiler.finish({ ok: true });
+
+      const lines = (await readFile(profilePath, 'utf8')).trim().split('\n');
+      expect(lines).toHaveLength(2);
+      expect(JSON.parse(lines[0]!)).toEqual({ existing: true });
+      expect(JSON.parse(lines[1]!)).toMatchObject({
+        timestamp: '2026-07-06T12:34:56.789Z',
+        source: 'clear',
+        ok: true,
+        stages: { system_instruction: 5 },
+      });
+    } finally {
+      await rm(runtimeDir, { recursive: true, force: true });
+    }
+  });
+
   itNoSymlink('does not write through a symlinked JSONL file', async () => {
     const runtimeDir = await mkdtemp(join(tmpdir(), 'session-start-profiler-'));
     vi.stubEnv('QWEN_RUNTIME_DIR', runtimeDir);

--- a/packages/core/src/core/session-start-profiler.test.ts
+++ b/packages/core/src/core/session-start-profiler.test.ts
@@ -94,6 +94,32 @@ describe('session-start-profiler', () => {
     ]);
   });
 
+  it('accumulates repeated stage durations', () => {
+    const records: SessionStartProfileRecord[] = [];
+    const profiler = createSessionStartProfiler(SessionStartSource.Clear, {
+      enabled: true,
+      now: clockFrom([10, 12, 15, 18, 23, 30]),
+      writeRecord: (record) => records.push(record),
+      getTimestamp: () => new Date('2026-07-06T00:00:00.000Z'),
+    });
+
+    expect(profiler.timeSync('system_instruction', () => 'first')).toBe(
+      'first',
+    );
+    expect(profiler.timeSync('system_instruction', () => 'second')).toBe(
+      'second',
+    );
+    profiler.finish({ ok: true });
+
+    expect(records[0]).toMatchObject({
+      ok: true,
+      totalMs: 20,
+      stages: {
+        system_instruction: 8,
+      },
+    });
+  });
+
   it('rethrows stage errors and preserves the failed stage', async () => {
     const records: SessionStartProfileRecord[] = [];
     const profiler = createSessionStartProfiler(SessionStartSource.Startup, {

--- a/packages/core/src/core/session-start-profiler.test.ts
+++ b/packages/core/src/core/session-start-profiler.test.ts
@@ -91,6 +91,28 @@ describe('session-start-profiler', () => {
     expect(writeRecord).not.toHaveBeenCalled();
   });
 
+  it.each(['true', '0', ''])(
+    'stays disabled when env var is set to %j',
+    (envValue) => {
+      vi.stubEnv(SESSION_START_PROFILE_ENV, envValue);
+      const now = vi.fn(() => {
+        throw new Error('disabled profiler should not read time');
+      });
+      const writeRecord = vi.fn();
+
+      const profiler = createSessionStartProfiler(SessionStartSource.Startup, {
+        now,
+        writeRecord,
+      });
+      profiler.finish({ ok: true });
+
+      expect(profiler.enabled).toBe(false);
+      expect(now).not.toHaveBeenCalled();
+      expect(writeRecord).not.toHaveBeenCalled();
+      expect(debugLoggerMock.debug).not.toHaveBeenCalled();
+    },
+  );
+
   it('records sync and async stages when enabled', async () => {
     const records: SessionStartProfileRecord[] = [];
     const profiler = createSessionStartProfiler(SessionStartSource.Resume, {

--- a/packages/core/src/core/session-start-profiler.test.ts
+++ b/packages/core/src/core/session-start-profiler.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, readdir, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -223,6 +223,11 @@ describe('session-start-profiler', () => {
       ok: true,
       totalMs: 1,
     });
+    expect(records[0]).not.toHaveProperty('extraHistoryLength');
+    expect(records[0]).not.toHaveProperty('historyLength');
+    expect(records[0]).not.toHaveProperty('snapshotEntryCount');
+    expect(records[0]).not.toHaveProperty('deferredReminderCount');
+    expect(records[0]).not.toHaveProperty('failedStage');
   });
 
   it('does not throw when the output writer fails', () => {
@@ -274,16 +279,15 @@ describe('session-start-profiler', () => {
         deferredReminderCount: 0,
       });
 
-      const files = await readdir(join(runtimeDir, 'session-start-perf'));
+      const perfDir = join(runtimeDir, 'session-start-perf');
+      const profilePath = join(perfDir, 'session-start-2026-07-06.jsonl');
+      const files = await readdir(perfDir);
       expect(files).toEqual(['session-start-2026-07-06.jsonl']);
-      const raw = await readFile(
-        join(
-          runtimeDir,
-          'session-start-perf',
-          'session-start-2026-07-06.jsonl',
-        ),
-        'utf8',
-      );
+      if (process.platform !== 'win32') {
+        expect((await stat(perfDir)).mode & 0o777).toBe(0o700);
+        expect((await stat(profilePath)).mode & 0o777).toBe(0o600);
+      }
+      const raw = await readFile(profilePath, 'utf8');
       const record = JSON.parse(raw.trim()) as SessionStartProfileRecord;
       const serialized = JSON.stringify(record);
 

--- a/packages/core/src/core/session-start-profiler.test.ts
+++ b/packages/core/src/core/session-start-profiler.test.ts
@@ -10,6 +10,7 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { SessionStartSource } from '../hooks/types.js';
 import {
+  SESSION_START_PROFILE_ENV,
   createSessionStartProfiler,
   type SessionStartProfileRecord,
 } from './session-start-profiler.js';
@@ -263,7 +264,7 @@ describe('session-start-profiler', () => {
       join(tmpdir(), 'session-start-profiler-'),
     );
     vi.stubEnv('QWEN_RUNTIME_DIR', runtimeDir);
-    vi.stubEnv('QWEN_CODE_PROFILE_SESSION_START', '1');
+    vi.stubEnv(SESSION_START_PROFILE_ENV, '1');
 
     try {
       const profiler = createSessionStartProfiler(SessionStartSource.Clear, {

--- a/packages/core/src/core/session-start-profiler.test.ts
+++ b/packages/core/src/core/session-start-profiler.test.ts
@@ -95,6 +95,29 @@ describe('session-start-profiler', () => {
     ]);
   });
 
+  it('rounds elapsed durations to two decimal places', async () => {
+    const records: SessionStartProfileRecord[] = [];
+    const profiler = createSessionStartProfiler(SessionStartSource.Resume, {
+      enabled: true,
+      now: clockFrom([100.111, 100.222, 100.678, 101.111, 102.345, 102.789]),
+      writeRecord: (record) => records.push(record),
+      getTimestamp: () => new Date('2026-07-06T00:00:00.000Z'),
+    });
+
+    await profiler.time('initial_chat_history', async () => undefined);
+    profiler.timeSync('system_instruction', () => undefined);
+    profiler.finish({ ok: true });
+
+    expect(records[0]).toMatchObject({
+      ok: true,
+      totalMs: 2.68,
+      stages: {
+        initial_chat_history: 0.46,
+        system_instruction: 1.23,
+      },
+    });
+  });
+
   it('accumulates repeated stage durations', () => {
     const records: SessionStartProfileRecord[] = [];
     const profiler = createSessionStartProfiler(SessionStartSource.Clear, {

--- a/packages/core/src/core/session-start-profiler.test.ts
+++ b/packages/core/src/core/session-start-profiler.test.ts
@@ -4,7 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { mkdtemp, readFile, readdir, rm, stat } from 'node:fs/promises';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -39,6 +48,8 @@ function clockFrom(values: number[]) {
 }
 
 describe('session-start-profiler', () => {
+  const itNoSymlink = process.platform === 'win32' ? it.skip : it;
+
   beforeEach(() => {
     debugLoggerMock.debug.mockClear();
   });
@@ -350,4 +361,65 @@ describe('session-start-profiler', () => {
       await rm(runtimeDir, { recursive: true, force: true });
     }
   });
+
+  itNoSymlink('does not write through a symlinked JSONL file', async () => {
+    const runtimeDir = await mkdtemp(join(tmpdir(), 'session-start-profiler-'));
+    vi.stubEnv('QWEN_RUNTIME_DIR', runtimeDir);
+    vi.stubEnv(SESSION_START_PROFILE_ENV, '1');
+
+    try {
+      const perfDir = join(runtimeDir, 'session-start-perf');
+      const targetPath = join(runtimeDir, 'target.jsonl');
+      const profilePath = join(perfDir, 'session-start-2026-07-06.jsonl');
+      await mkdir(perfDir);
+      await writeFile(targetPath, 'sentinel', 'utf8');
+      await symlink(targetPath, profilePath);
+
+      const profiler = createSessionStartProfiler(SessionStartSource.Clear, {
+        now: clockFrom([10, 20]),
+        getTimestamp: () => new Date('2026-07-06T12:34:56.789Z'),
+      });
+      expect(() => profiler.finish({ ok: true })).not.toThrow();
+
+      await expect(readFile(targetPath, 'utf8')).resolves.toBe('sentinel');
+      expect(debugLoggerMock.debug).toHaveBeenCalledWith(
+        'session-start-profiler write failed',
+        expect.objectContaining({ name: 'Error' }),
+      );
+    } finally {
+      await rm(runtimeDir, { recursive: true, force: true });
+    }
+  });
+
+  itNoSymlink(
+    'does not write through a symlinked profile directory',
+    async () => {
+      const runtimeDir = await mkdtemp(
+        join(tmpdir(), 'session-start-profiler-'),
+      );
+      vi.stubEnv('QWEN_RUNTIME_DIR', runtimeDir);
+      vi.stubEnv(SESSION_START_PROFILE_ENV, '1');
+
+      try {
+        const targetDir = join(runtimeDir, 'target-perf');
+        const perfDir = join(runtimeDir, 'session-start-perf');
+        await mkdir(targetDir);
+        await symlink(targetDir, perfDir);
+
+        const profiler = createSessionStartProfiler(SessionStartSource.Clear, {
+          now: clockFrom([10, 20]),
+          getTimestamp: () => new Date('2026-07-06T12:34:56.789Z'),
+        });
+        expect(() => profiler.finish({ ok: true })).not.toThrow();
+
+        await expect(readdir(targetDir)).resolves.toEqual([]);
+        expect(debugLoggerMock.debug).toHaveBeenCalledWith(
+          'session-start-profiler write failed',
+          expect.objectContaining({ name: 'Error' }),
+        );
+      } finally {
+        await rm(runtimeDir, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/packages/core/src/core/session-start-profiler.test.ts
+++ b/packages/core/src/core/session-start-profiler.test.ts
@@ -51,7 +51,7 @@ describe('session-start-profiler', () => {
   const itNoSymlink = process.platform === 'win32' ? it.skip : it;
 
   beforeEach(() => {
-    debugLoggerMock.debug.mockClear();
+    debugLoggerMock.debug.mockReset();
   });
 
   afterEach(() => {
@@ -73,6 +73,16 @@ describe('session-start-profiler', () => {
     await expect(
       profiler.time('tool_registry_warm', async () => 'ok'),
     ).resolves.toBe('ok');
+    const existingPromise = Promise.resolve('same-promise');
+    expect(profiler.time('same_promise', () => existingPromise)).toBe(
+      existingPromise,
+    );
+    const disabledError = new Error('disabled failure');
+    await expect(
+      profiler.time('disabled_error', () => {
+        throw disabledError;
+      }),
+    ).rejects.toBe(disabledError);
     expect(profiler.timeSync('system_instruction', () => 42)).toBe(42);
     profiler.finish({ ok: true });
 
@@ -300,6 +310,39 @@ describe('session-start-profiler', () => {
       'session-start-profiler write failed',
       { name: 'Error', message: 'disk full', code: 'ENOSPC' },
     );
+  });
+
+  it('does not throw when recovery debug logging fails', () => {
+    const profiler = createSessionStartProfiler(SessionStartSource.Clear, {
+      enabled: true,
+      now: clockFrom([1, 2]),
+      writeRecord: () => {
+        throw new Error('disk full');
+      },
+      getTimestamp: () => new Date('2026-07-06T00:00:00.000Z'),
+    });
+    debugLoggerMock.debug.mockImplementation(() => {
+      throw new Error('debug log failed');
+    });
+
+    expect(() => profiler.finish({ ok: true })).not.toThrow();
+  });
+
+  it('does not throw when enabled debug logging fails', () => {
+    debugLoggerMock.debug.mockImplementation(() => {
+      throw new Error('debug log failed');
+    });
+    let profiler: ReturnType<typeof createSessionStartProfiler> | undefined;
+
+    expect(() => {
+      profiler = createSessionStartProfiler(SessionStartSource.Clear, {
+        enabled: true,
+        now: clockFrom([1, 2]),
+        writeRecord: vi.fn(),
+        getTimestamp: () => new Date('2026-07-06T00:00:00.000Z'),
+      });
+    }).not.toThrow();
+    expect(profiler?.enabled).toBe(true);
   });
 
   it('does not throw when finish metadata collection fails', () => {

--- a/packages/core/src/core/session-start-profiler.test.ts
+++ b/packages/core/src/core/session-start-profiler.test.ts
@@ -121,6 +121,52 @@ describe('session-start-profiler', () => {
     });
   });
 
+  it('rethrows sync stage errors and preserves the failed stage', () => {
+    const records: SessionStartProfileRecord[] = [];
+    const profiler = createSessionStartProfiler(SessionStartSource.Startup, {
+      enabled: true,
+      now: clockFrom([100, 110, 120, 130]),
+      writeRecord: (record) => records.push(record),
+      getTimestamp: () => new Date('2026-07-06T00:00:00.000Z'),
+    });
+    const error = new Error('system instruction failed');
+
+    expect(() =>
+      profiler.timeSync('system_instruction', () => {
+        throw error;
+      }),
+    ).toThrow(error);
+    profiler.finish({ ok: false });
+
+    expect(records[0]).toMatchObject({
+      ok: false,
+      totalMs: 30,
+      stages: {
+        system_instruction: 10,
+      },
+      failedStage: 'system_instruction',
+    });
+  });
+
+  it('writes at most one record when finish is called multiple times', () => {
+    const records: SessionStartProfileRecord[] = [];
+    const profiler = createSessionStartProfiler(SessionStartSource.Clear, {
+      enabled: true,
+      now: clockFrom([1, 2, 3]),
+      writeRecord: (record) => records.push(record),
+      getTimestamp: () => new Date('2026-07-06T00:00:00.000Z'),
+    });
+
+    profiler.finish({ ok: true });
+    profiler.finish({ ok: false });
+
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      ok: true,
+      totalMs: 1,
+    });
+  });
+
   it('does not throw when the output writer fails', () => {
     const profiler = createSessionStartProfiler(SessionStartSource.Clear, {
       enabled: true,
@@ -132,6 +178,21 @@ describe('session-start-profiler', () => {
     });
 
     expect(() => profiler.finish({ ok: true })).not.toThrow();
+  });
+
+  it('does not throw when finish metadata collection fails', () => {
+    const writeRecord = vi.fn();
+    const profiler = createSessionStartProfiler(SessionStartSource.Clear, {
+      enabled: true,
+      now: clockFrom([1, 2]),
+      writeRecord,
+      getTimestamp: () => {
+        throw new Error('clock failed');
+      },
+    });
+
+    expect(() => profiler.finish({ ok: false })).not.toThrow();
+    expect(writeRecord).not.toHaveBeenCalled();
   });
 
   it('writes bounded JSONL without sensitive fields', async () => {

--- a/packages/core/src/core/session-start-profiler.test.ts
+++ b/packages/core/src/core/session-start-profiler.test.ts
@@ -7,13 +7,25 @@
 import { mkdtemp, readFile, readdir, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SessionStartSource } from '../hooks/types.js';
 import {
   SESSION_START_PROFILE_ENV,
   createSessionStartProfiler,
   type SessionStartProfileRecord,
 } from './session-start-profiler.js';
+
+const debugLoggerMock = vi.hoisted(() => ({
+  debug: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  isEnabled: vi.fn(() => true),
+  warn: vi.fn(),
+}));
+
+vi.mock('../utils/debugLogger.js', () => ({
+  createDebugLogger: vi.fn(() => debugLoggerMock),
+}));
 
 function clockFrom(values: number[]) {
   let last = values[values.length - 1] ?? 0;
@@ -27,6 +39,10 @@ function clockFrom(values: number[]) {
 }
 
 describe('session-start-profiler', () => {
+  beforeEach(() => {
+    debugLoggerMock.debug.mockClear();
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
   });
@@ -66,9 +82,9 @@ describe('session-start-profiler', () => {
     await expect(
       profiler.time('initial_chat_history', async () => 'history'),
     ).resolves.toBe('history');
-    expect(
-      profiler.timeSync('system_instruction', () => 'system'),
-    ).toBe('system');
+    expect(profiler.timeSync('system_instruction', () => 'system')).toBe(
+      'system',
+    );
     profiler.finish({
       ok: true,
       extraHistoryLength: 3,
@@ -259,12 +275,16 @@ describe('session-start-profiler', () => {
       enabled: true,
       now: clockFrom([1, 2]),
       writeRecord: () => {
-        throw new Error('disk full');
+        throw Object.assign(new Error('disk full'), { code: 'ENOSPC' });
       },
       getTimestamp: () => new Date('2026-07-06T00:00:00.000Z'),
     });
 
     expect(() => profiler.finish({ ok: true })).not.toThrow();
+    expect(debugLoggerMock.debug).toHaveBeenCalledWith(
+      'session-start-profiler write failed',
+      { name: 'Error', code: 'ENOSPC' },
+    );
   });
 
   it('does not throw when finish metadata collection fails', () => {
@@ -283,9 +303,7 @@ describe('session-start-profiler', () => {
   });
 
   it('writes bounded JSONL without sensitive fields', async () => {
-    const runtimeDir = await mkdtemp(
-      join(tmpdir(), 'session-start-profiler-'),
-    );
+    const runtimeDir = await mkdtemp(join(tmpdir(), 'session-start-profiler-'));
     vi.stubEnv('QWEN_RUNTIME_DIR', runtimeDir);
     vi.stubEnv(SESSION_START_PROFILE_ENV, '1');
 

--- a/packages/core/src/core/session-start-profiler.ts
+++ b/packages/core/src/core/session-start-profiler.ts
@@ -127,28 +127,28 @@ class EnabledSessionStartProfiler implements SessionStartProfiler {
     }
     this.finished = true;
 
-    const record: SessionStartProfileRecord = {
-      timestamp: this.getTimestamp().toISOString(),
-      source: this.source,
-      ok: attrs.ok,
-      totalMs: roundMs(this.now() - this.startMs),
-      stages: { ...this.stages },
-      ...(attrs.extraHistoryLength !== undefined
-        ? { extraHistoryLength: attrs.extraHistoryLength }
-        : {}),
-      ...(attrs.historyLength !== undefined
-        ? { historyLength: attrs.historyLength }
-        : {}),
-      ...(attrs.snapshotEntryCount !== undefined
-        ? { snapshotEntryCount: attrs.snapshotEntryCount }
-        : {}),
-      ...(attrs.deferredReminderCount !== undefined
-        ? { deferredReminderCount: attrs.deferredReminderCount }
-        : {}),
-      ...(this.failedStage ? { failedStage: this.failedStage } : {}),
-    };
-
     try {
+      const record: SessionStartProfileRecord = {
+        timestamp: this.getTimestamp().toISOString(),
+        source: this.source,
+        ok: attrs.ok,
+        totalMs: roundMs(this.now() - this.startMs),
+        stages: { ...this.stages },
+        ...(attrs.extraHistoryLength !== undefined
+          ? { extraHistoryLength: attrs.extraHistoryLength }
+          : {}),
+        ...(attrs.historyLength !== undefined
+          ? { historyLength: attrs.historyLength }
+          : {}),
+        ...(attrs.snapshotEntryCount !== undefined
+          ? { snapshotEntryCount: attrs.snapshotEntryCount }
+          : {}),
+        ...(attrs.deferredReminderCount !== undefined
+          ? { deferredReminderCount: attrs.deferredReminderCount }
+          : {}),
+        ...(this.failedStage ? { failedStage: this.failedStage } : {}),
+      };
+
       this.writeRecord(record);
     } catch {
       // Profiling must never affect session creation.

--- a/packages/core/src/core/session-start-profiler.ts
+++ b/packages/core/src/core/session-start-profiler.ts
@@ -21,8 +21,9 @@ export interface SessionStartProfileRecord {
   source: SessionStartSource;
   ok: boolean;
   /**
-   * Wall-clock session start duration. The sum of `stages` can be lower because
-   * only profiled callbacks are included in stage timings.
+   * Wall-clock session start duration. The sum of `stages` can differ from
+   * `totalMs` because some stages overlap and unmeasured code runs between
+   * stages.
    */
   totalMs: number;
   stages: Record<string, number>;
@@ -61,11 +62,15 @@ function roundMs(value: number): number {
 
 function getAppendProfileOpenFlags(): number {
   const constants = fs.constants;
+  const noFollow = constants.O_NOFOLLOW;
+  if (noFollow === undefined) {
+    throw new Error('session-start profiler requires O_NOFOLLOW support');
+  }
   return (
     (constants.O_APPEND ?? 0) |
     (constants.O_CREAT ?? 0) |
     (constants.O_WRONLY ?? 0) |
-    (constants.O_NOFOLLOW ?? 0)
+    noFollow
   );
 }
 
@@ -93,6 +98,8 @@ function assertSafeExistingProfileFile(filePath: string): void {
 function writeProfileRecord(record: SessionStartProfileRecord): void {
   const dir = path.join(Storage.getRuntimeBaseDir(), 'session-start-perf');
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  // Node does not expose a portable fd-relative append here; parent-directory
+  // replacement is best-effort while O_NOFOLLOW protects the JSONL file itself.
   assertSafeProfileDirectory(dir);
   try {
     fs.chmodSync(dir, 0o700);
@@ -122,8 +129,12 @@ function writeProfileRecord(record: SessionStartProfileRecord): void {
 
 const disabledProfiler: SessionStartProfiler = {
   enabled: false,
-  async time<T>(_stage: string, fn: () => T | Promise<T>): Promise<T> {
-    return await fn();
+  time<T>(_stage: string, fn: () => T | Promise<T>): Promise<T> {
+    try {
+      return Promise.resolve(fn());
+    } catch (error) {
+      return Promise.reject(error);
+    }
   },
   timeSync<T>(_stage: string, fn: () => T): T {
     return fn();
@@ -210,11 +221,15 @@ class EnabledSessionStartProfiler implements SessionStartProfiler {
       this.writeRecord(record);
     } catch (error) {
       const code = isNodeError(error) ? error.code : undefined;
-      debugLogger.debug('session-start-profiler write failed', {
-        name: error instanceof Error ? error.name : typeof error,
-        message: error instanceof Error ? error.message : undefined,
-        ...(code ? { code } : {}),
-      });
+      try {
+        debugLogger.debug('session-start-profiler write failed', {
+          name: error instanceof Error ? error.name : typeof error,
+          message: error instanceof Error ? error.message : undefined,
+          ...(code ? { code } : {}),
+        });
+      } catch {
+        // Recovery logging must not propagate into session creation.
+      }
       // Profiling must never affect session creation.
     }
   }
@@ -235,7 +250,11 @@ export function createSessionStartProfiler(
     return disabledProfiler;
   }
 
-  debugLogger.debug('session-start-profiler enabled', { source });
+  try {
+    debugLogger.debug('session-start-profiler enabled', { source });
+  } catch {
+    // Activation logging must not affect session startup.
+  }
 
   return new EnabledSessionStartProfiler(source, {
     now: options.now ?? (() => performance.now()),

--- a/packages/core/src/core/session-start-profiler.ts
+++ b/packages/core/src/core/session-start-profiler.ts
@@ -53,13 +53,27 @@ function roundMs(value: number): number {
 
 function writeProfileRecord(record: SessionStartProfileRecord): void {
   const dir = path.join(Storage.getRuntimeBaseDir(), 'session-start-perf');
-  fs.mkdirSync(dir, { recursive: true });
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  try {
+    fs.chmodSync(dir, 0o700);
+  } catch {
+    // Best-effort hardening on filesystems without POSIX chmod semantics.
+  }
   const filename = `session-start-${record.timestamp.slice(0, 10)}.jsonl`;
-  fs.appendFileSync(
-    path.join(dir, filename),
-    `${JSON.stringify(record)}\n`,
-    'utf8',
-  );
+  const filePath = path.join(dir, filename);
+  const fd = fs.openSync(filePath, 'a', 0o600);
+  try {
+    try {
+      fs.fchmodSync(fd, 0o600);
+    } catch {
+      // Best-effort hardening; profiling output must not block startup.
+    }
+    fs.appendFileSync(fd, `${JSON.stringify(record)}\n`, {
+      encoding: 'utf8',
+    });
+  } finally {
+    fs.closeSync(fd);
+  }
 }
 
 const disabledProfiler: SessionStartProfiler = {

--- a/packages/core/src/core/session-start-profiler.ts
+++ b/packages/core/src/core/session-start-profiler.ts
@@ -1,0 +1,179 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { Storage } from '../config/storage.js';
+import type { SessionStartSource } from '../hooks/types.js';
+
+export const SESSION_START_PROFILE_ENV = 'QWEN_CODE_PROFILE_SESSION_START';
+
+export interface SessionStartProfileRecord {
+  timestamp: string;
+  source: SessionStartSource;
+  ok: boolean;
+  totalMs: number;
+  stages: Record<string, number>;
+  extraHistoryLength?: number;
+  historyLength?: number;
+  snapshotEntryCount?: number;
+  deferredReminderCount?: number;
+  failedStage?: string;
+}
+
+export interface SessionStartProfileFinishAttrs {
+  ok: boolean;
+  extraHistoryLength?: number;
+  historyLength?: number;
+  snapshotEntryCount?: number;
+  deferredReminderCount?: number;
+}
+
+export interface SessionStartProfiler {
+  readonly enabled: boolean;
+  time<T>(stage: string, fn: () => T | Promise<T>): Promise<T>;
+  timeSync<T>(stage: string, fn: () => T): T;
+  finish(attrs: SessionStartProfileFinishAttrs): void;
+}
+
+interface SessionStartProfilerOptions {
+  enabled?: boolean;
+  now?: () => number;
+  getTimestamp?: () => Date;
+  writeRecord?: (record: SessionStartProfileRecord) => void;
+}
+
+function roundMs(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function writeProfileRecord(record: SessionStartProfileRecord): void {
+  const dir = path.join(Storage.getRuntimeBaseDir(), 'session-start-perf');
+  fs.mkdirSync(dir, { recursive: true });
+  const filename = `session-start-${record.timestamp.slice(0, 10)}.jsonl`;
+  fs.appendFileSync(
+    path.join(dir, filename),
+    `${JSON.stringify(record)}\n`,
+    'utf8',
+  );
+}
+
+const disabledProfiler: SessionStartProfiler = {
+  enabled: false,
+  async time<T>(_stage: string, fn: () => T | Promise<T>): Promise<T> {
+    return await fn();
+  },
+  timeSync<T>(_stage: string, fn: () => T): T {
+    return fn();
+  },
+  finish(): void {},
+};
+
+class EnabledSessionStartProfiler implements SessionStartProfiler {
+  readonly enabled = true;
+  private readonly source: SessionStartSource;
+  private readonly now: () => number;
+  private readonly getTimestamp: () => Date;
+  private readonly writeRecord: (record: SessionStartProfileRecord) => void;
+  private readonly startMs: number;
+  private readonly stages: Record<string, number> = {};
+  private failedStage: string | undefined;
+  private finished = false;
+
+  constructor(
+    source: SessionStartSource,
+    options: Required<
+      Pick<SessionStartProfilerOptions, 'now' | 'getTimestamp' | 'writeRecord'>
+    >,
+  ) {
+    this.source = source;
+    this.now = options.now;
+    this.getTimestamp = options.getTimestamp;
+    this.writeRecord = options.writeRecord;
+    this.startMs = this.now();
+  }
+
+  async time<T>(stage: string, fn: () => T | Promise<T>): Promise<T> {
+    const start = this.now();
+    try {
+      return await fn();
+    } catch (error) {
+      this.failedStage ??= stage;
+      throw error;
+    } finally {
+      this.recordStage(stage, start, this.now());
+    }
+  }
+
+  timeSync<T>(stage: string, fn: () => T): T {
+    const start = this.now();
+    try {
+      return fn();
+    } catch (error) {
+      this.failedStage ??= stage;
+      throw error;
+    } finally {
+      this.recordStage(stage, start, this.now());
+    }
+  }
+
+  finish(attrs: SessionStartProfileFinishAttrs): void {
+    if (this.finished) {
+      return;
+    }
+    this.finished = true;
+
+    const record: SessionStartProfileRecord = {
+      timestamp: this.getTimestamp().toISOString(),
+      source: this.source,
+      ok: attrs.ok,
+      totalMs: roundMs(this.now() - this.startMs),
+      stages: { ...this.stages },
+      ...(attrs.extraHistoryLength !== undefined
+        ? { extraHistoryLength: attrs.extraHistoryLength }
+        : {}),
+      ...(attrs.historyLength !== undefined
+        ? { historyLength: attrs.historyLength }
+        : {}),
+      ...(attrs.snapshotEntryCount !== undefined
+        ? { snapshotEntryCount: attrs.snapshotEntryCount }
+        : {}),
+      ...(attrs.deferredReminderCount !== undefined
+        ? { deferredReminderCount: attrs.deferredReminderCount }
+        : {}),
+      ...(this.failedStage ? { failedStage: this.failedStage } : {}),
+    };
+
+    try {
+      this.writeRecord(record);
+    } catch {
+      // Profiling must never affect session creation.
+    }
+  }
+
+  private recordStage(stage: string, start: number, end: number): void {
+    const previous = this.stages[stage] ?? 0;
+    this.stages[stage] = roundMs(previous + end - start);
+  }
+}
+
+export function createSessionStartProfiler(
+  source: SessionStartSource,
+  options: SessionStartProfilerOptions = {},
+): SessionStartProfiler {
+  const enabled =
+    options.enabled ?? process.env[SESSION_START_PROFILE_ENV] === '1';
+  if (!enabled) {
+    return disabledProfiler;
+  }
+
+  return new EnabledSessionStartProfiler(source, {
+    now: options.now ?? (() => performance.now()),
+    getTimestamp: options.getTimestamp ?? (() => new Date()),
+    writeRecord: options.writeRecord ?? writeProfileRecord,
+  });
+}

--- a/packages/core/src/core/session-start-profiler.ts
+++ b/packages/core/src/core/session-start-profiler.ts
@@ -9,8 +9,11 @@ import * as path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { Storage } from '../config/storage.js';
 import type { SessionStartSource } from '../hooks/types.js';
+import { createDebugLogger } from '../utils/debugLogger.js';
 
 export const SESSION_START_PROFILE_ENV = 'QWEN_CODE_PROFILE_SESSION_START';
+
+const debugLogger = createDebugLogger('SESSION_START_PROFILER');
 
 export interface SessionStartProfileRecord {
   timestamp: string;
@@ -164,7 +167,18 @@ class EnabledSessionStartProfiler implements SessionStartProfiler {
       };
 
       this.writeRecord(record);
-    } catch {
+    } catch (error) {
+      const code =
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        typeof error.code === 'string'
+          ? error.code
+          : undefined;
+      debugLogger.debug('session-start-profiler write failed', {
+        name: error instanceof Error ? error.name : typeof error,
+        ...(code ? { code } : {}),
+      });
       // Profiling must never affect session creation.
     }
   }

--- a/packages/core/src/core/session-start-profiler.ts
+++ b/packages/core/src/core/session-start-profiler.ts
@@ -112,8 +112,8 @@ function writeProfileRecord(record: SessionStartProfileRecord): void {
     } catch {
       // Best-effort hardening; profiling output must not block startup.
     }
-    fs.appendFileSync(fd, `${JSON.stringify(record)}\n`, {
-      encoding: 'utf8',
+    fs.appendFileSync(fd, Buffer.from(`${JSON.stringify(record)}\n`, 'utf8'), {
+      flush: true,
     });
   } finally {
     fs.closeSync(fd);
@@ -212,6 +212,7 @@ class EnabledSessionStartProfiler implements SessionStartProfiler {
       const code = isNodeError(error) ? error.code : undefined;
       debugLogger.debug('session-start-profiler write failed', {
         name: error instanceof Error ? error.name : typeof error,
+        message: error instanceof Error ? error.message : undefined,
         ...(code ? { code } : {}),
       });
       // Profiling must never affect session creation.
@@ -233,6 +234,8 @@ export function createSessionStartProfiler(
   if (!enabled) {
     return disabledProfiler;
   }
+
+  debugLogger.debug('session-start-profiler enabled', { source });
 
   return new EnabledSessionStartProfiler(source, {
     now: options.now ?? (() => performance.now()),

--- a/packages/core/src/core/session-start-profiler.ts
+++ b/packages/core/src/core/session-start-profiler.ts
@@ -10,6 +10,7 @@ import { performance } from 'node:perf_hooks';
 import { Storage } from '../config/storage.js';
 import type { SessionStartSource } from '../hooks/types.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import { isNodeError } from '../utils/errors.js';
 
 export const SESSION_START_PROFILE_ENV = 'QWEN_CODE_PROFILE_SESSION_START';
 
@@ -19,6 +20,10 @@ export interface SessionStartProfileRecord {
   timestamp: string;
   source: SessionStartSource;
   ok: boolean;
+  /**
+   * Wall-clock session start duration. The sum of `stages` can be lower because
+   * only profiled callbacks are included in stage timings.
+   */
   totalMs: number;
   stages: Record<string, number>;
   extraHistoryLength?: number;
@@ -78,12 +83,7 @@ function assertSafeExistingProfileFile(filePath: string): void {
       throw new Error('session-start profiler path must be a real file');
     }
   } catch (error) {
-    if (
-      typeof error === 'object' &&
-      error !== null &&
-      'code' in error &&
-      error.code === 'ENOENT'
-    ) {
+    if (isNodeError(error) && error.code === 'ENOENT') {
       return;
     }
     throw error;
@@ -209,13 +209,7 @@ class EnabledSessionStartProfiler implements SessionStartProfiler {
 
       this.writeRecord(record);
     } catch (error) {
-      const code =
-        typeof error === 'object' &&
-        error !== null &&
-        'code' in error &&
-        typeof error.code === 'string'
-          ? error.code
-          : undefined;
+      const code = isNodeError(error) ? error.code : undefined;
       debugLogger.debug('session-start-profiler write failed', {
         name: error instanceof Error ? error.name : typeof error,
         ...(code ? { code } : {}),

--- a/packages/core/src/core/session-start-profiler.ts
+++ b/packages/core/src/core/session-start-profiler.ts
@@ -54,9 +54,46 @@ function roundMs(value: number): number {
   return Math.round(value * 100) / 100;
 }
 
+function getAppendProfileOpenFlags(): number {
+  const constants = fs.constants;
+  return (
+    (constants.O_APPEND ?? 0) |
+    (constants.O_CREAT ?? 0) |
+    (constants.O_WRONLY ?? 0) |
+    (constants.O_NOFOLLOW ?? 0)
+  );
+}
+
+function assertSafeProfileDirectory(dir: string): void {
+  const dirStat = fs.lstatSync(dir);
+  if (!dirStat.isDirectory() || dirStat.isSymbolicLink()) {
+    throw new Error('session-start profiler path must be a real directory');
+  }
+}
+
+function assertSafeExistingProfileFile(filePath: string): void {
+  try {
+    const fileStat = fs.lstatSync(filePath);
+    if (!fileStat.isFile() || fileStat.isSymbolicLink()) {
+      throw new Error('session-start profiler path must be a real file');
+    }
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === 'ENOENT'
+    ) {
+      return;
+    }
+    throw error;
+  }
+}
+
 function writeProfileRecord(record: SessionStartProfileRecord): void {
   const dir = path.join(Storage.getRuntimeBaseDir(), 'session-start-perf');
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  assertSafeProfileDirectory(dir);
   try {
     fs.chmodSync(dir, 0o700);
   } catch {
@@ -64,8 +101,12 @@ function writeProfileRecord(record: SessionStartProfileRecord): void {
   }
   const filename = `session-start-${record.timestamp.slice(0, 10)}.jsonl`;
   const filePath = path.join(dir, filename);
-  const fd = fs.openSync(filePath, 'a', 0o600);
+  assertSafeExistingProfileFile(filePath);
+  const fd = fs.openSync(filePath, getAppendProfileOpenFlags(), 0o600);
   try {
+    if (!fs.fstatSync(fd).isFile()) {
+      throw new Error('session-start profiler path must be a real file');
+    }
     try {
       fs.fchmodSync(fd, 0o600);
     } catch {


### PR DESCRIPTION
## What this PR does

This PR adds an opt-in, core-internal profiler for session startup. When `QWEN_CODE_PROFILE_SESSION_START=1` is set, `GeminiClient.startChat()` records bounded JSONL stage timings under the runtime output directory so session initialization can be broken down without enabling debug logs or changing normal behavior.

The recorded data is intentionally limited to static stage names, source, success state, total and per-stage durations, and small aggregate counts. It avoids prompts, paths, session IDs, model responses, hook output, and tool names.

## Why it's needed

Issue #6312 needs the next optimization to be chosen from measured evidence. Recent measurement showed the remaining light-config cost sits inside `GeminiClient.initialize()`, but it did not identify which `startChat()` stage dominates. This PR adds the measurement hook needed to decide whether to optimize system instruction construction, initial history assembly, tool syncing, hooks, or another stage.

## Reviewer Test Plan

### How to verify

Run the focused core tests and confirm the profiler helper records only when enabled, preserves errors, swallows output-write failures, and that `startChat()` finalizes both success and failure profiles with bounded counts.

Optionally run a local initialization with `QWEN_CODE_PROFILE_SESSION_START=1` and an isolated `QWEN_RUNTIME_DIR`; confirm a `session-start-perf/session-start-YYYY-MM-DD.jsonl` file is produced and contains static stage names plus aggregate counts only.

### Evidence (Before & After)

N/A for UI. Local verification completed with `cd packages/core && npx vitest run src/core/session-start-profiler.test.ts src/core/client.test.ts` passing 236 tests, `npm run build && npm run typecheck` passing, and `npm run lint` passing. A local 12-iteration profiler run was posted to #6312 and showed `system_instruction` as the dominant light-fixture stage.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node v22.22.3, npm 10.9.8. Local verification used built dist output and isolated `QWEN_HOME` / `QWEN_RUNTIME_DIR` for the profiler smoke measurement.

## Risk & Scope

- Main risk or tradeoff: The instrumentation adds wrapper calls inside `startChat()`, but the helper is disabled unless `QWEN_CODE_PROFILE_SESSION_START=1` and performs no file writes or high-resolution clock reads when disabled.
- Not validated / out of scope: This PR does not optimize `GeminiClient.initialize()` or implement Part B extension caching, Part C skill body lazy-loading, daemon protocol changes, or an end-to-end `/session` latency benchmark.
- Breaking changes / migration notes: None; no public API, CLI flag, SDK schema, config schema, protocol, or telemetry schema changes are introduced.

## Linked Issues

Refs #6312

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 增加了一个 core 内部的可选 session startup profiler。设置 `QWEN_CODE_PROFILE_SESSION_START=1` 后，`GeminiClient.startChat()` 会在 runtime output 目录下记录有边界的 JSONL 阶段耗时，这样可以拆解 session 初始化路径，而不需要启用 debug log，也不改变正常行为。

记录的数据有意限制在静态阶段名、来源、成功状态、总耗时/阶段耗时以及少量聚合计数。输出不会包含 prompt、路径、session ID、模型响应、hook 输出或工具名。

## Why it's needed

#6312 的下一步优化需要基于实测证据选择。最近的测量显示轻配置下剩余成本位于 `GeminiClient.initialize()` 内，但还没有定位到 `startChat()` 的具体主耗时阶段。这个 PR 增加所需的测量 hook，用于判断后续应优化 system instruction 构造、initial history assembly、tool syncing、hooks，还是其他阶段。

## Reviewer Test Plan

### How to verify

运行聚焦 core 测试，确认 profiler helper 只在启用时记录、保留原错误、吞掉输出写入失败，并确认 `startChat()` 在成功和失败路径都会用有边界的计数完成 profile。

也可以设置 `QWEN_CODE_PROFILE_SESSION_START=1` 并使用隔离的 `QWEN_RUNTIME_DIR` 跑一次本地初始化；预期会生成 `session-start-perf/session-start-YYYY-MM-DD.jsonl`，且内容只包含静态阶段名和聚合计数。

### Evidence (Before & After)

UI 变化不适用。本地验证已完成：`cd packages/core && npx vitest run src/core/session-start-profiler.test.ts src/core/client.test.ts` 通过 236 个测试，`npm run build && npm run typecheck` 通过，`npm run lint` 通过。一次本地 12 轮 profiler 运行结果已评论到 #6312，显示轻配置 fixture 中 `system_instruction` 是主要阶段。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node v22.22.3，npm 10.9.8。本地验证使用 built dist 输出，并为 profiler smoke measurement 使用隔离的 `QWEN_HOME` / `QWEN_RUNTIME_DIR`。

## Risk & Scope

- Main risk or tradeoff: 这个 instrumentation 在 `startChat()` 内增加了 wrapper 调用，但 helper 只有在 `QWEN_CODE_PROFILE_SESSION_START=1` 时才启用；禁用时不会写文件，也不会读取高精度时钟。
- Not validated / out of scope: 这个 PR 不优化 `GeminiClient.initialize()`，不实现 Part B extension caching、Part C skill body lazy-loading、daemon protocol changes，也不是端到端 `/session` 延迟基准。
- Breaking changes / migration notes: 无；没有引入 public API、CLI flag、SDK schema、config schema、protocol 或 telemetry schema 变更。

## Linked Issues

Refs #6312

</details>
