### PR TITLE
fix(web-shell): suppress stale pending prompt refresh errors

### DIFF
--- a/packages/web-shell/client/hooks/useQueuedPrompts.ts
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.ts
@@ -52,6 +52,12 @@ interface UseQueuedPromptsArgs {
 
 const MAX_COMPLETED_PROMPT_IDS = 100;
 
+type RefreshPendingPromptsResult =
+  | 'refreshed'
+  | 'skipped'
+  | 'superseded'
+  | 'failed';
+
 function areQueuedPromptsEqual(
   left: readonly QueuedPrompt[],
   right: readonly QueuedPrompt[],
@@ -221,26 +227,28 @@ export function useQueuedPrompts({
   );
 
   const refreshPendingPrompts = useCallback(
-    async (targetSessionId = sessionId): Promise<boolean> => {
-      if (!connected || !targetSessionId) return false;
-      if (latestSessionIdRef.current !== targetSessionId) return false;
+    async (
+      targetSessionId = sessionId,
+    ): Promise<RefreshPendingPromptsResult> => {
+      if (!connected || !targetSessionId) return 'skipped';
+      if (latestSessionIdRef.current !== targetSessionId) return 'skipped';
       const requestSeq = ++refreshRequestSeqRef.current;
       try {
         const result = await sessionActions.getPendingPrompts({
           sessionId: targetSessionId,
         });
-        if (requestSeq !== refreshRequestSeqRef.current) return false;
-        if (latestSessionIdRef.current !== targetSessionId) return false;
+        if (requestSeq !== refreshRequestSeqRef.current) return 'superseded';
+        if (latestSessionIdRef.current !== targetSessionId) return 'skipped';
         syncServerQueuedPrompts(
           result.pendingPrompts.filter(
             (p) => p.state === 'queued' || p.state === 'running',
           ),
           targetSessionId,
         );
-        return true;
+        return 'refreshed';
       } catch (error) {
         console.warn('Failed to refresh pending prompts', error);
-        return false;
+        return 'failed';
       }
     },
     [connected, sessionActions, sessionId, syncServerQueuedPrompts],
@@ -595,7 +603,7 @@ export function useQueuedPrompts({
           return false;
         }
         completionCallbacksRef.current.delete(target.serverPromptId);
-        if (!(await refreshPendingPrompts(targetSessionId))) {
+        if ((await refreshPendingPrompts(targetSessionId)) === 'failed') {
           setQueuedPromptFlags(target.id, {
             isEditing: false,
             isRemoving: false,
@@ -612,7 +620,7 @@ export function useQueuedPrompts({
           isEditing: false,
           isRemoving: false,
         });
-        if (!(await refreshPendingPrompts(targetSessionId))) {
+        if ((await refreshPendingPrompts(targetSessionId)) !== 'refreshed') {
           restoreQueuedPrompts([target]);
         }
         reportError(error, fallback);


### PR DESCRIPTION
## What this PR does

This PR makes pending prompt refresh results explicit so the web shell can distinguish a real refresh failure from a refresh that was skipped or superseded by a newer request. Queue insert, edit, and delete flows now only show the pending prompt refresh error when the refresh request itself fails.

## Why it's needed

When a queued prompt is inserted, edited, or removed, the web shell removes the server-side pending prompt and then refreshes the pending prompt list. The refresh helper previously returned `false` for several different outcomes, including normal races where a later refresh superseded the current one. Those benign races were treated as user-visible failures, which could show misleading messages such as “Queue changed but pending prompts could not refresh” even though the queue mutation had already succeeded.

## Reviewer Test Plan

### How to verify

Review the queue insert/edit/delete path and confirm that a superseded or skipped pending prompt refresh no longer reports a user-visible error after `removePendingPrompt` succeeds. A reviewer can also trigger rapid queued prompt changes while a turn is active and confirm that stale refreshes do not surface the “pending prompts could not refresh” error unless the pending prompt fetch actually fails.

### Evidence (Before & After)

Before: a stale pending prompt refresh could return the same failure value as an actual request error, causing a misleading user-visible queue error after a successful queue mutation.

After: refresh results distinguish `refreshed`, `skipped`, `superseded`, and `failed`; only `failed` reports the pending prompt refresh error after a successful queue mutation.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Local validation: `npx prettier --check packages/web-shell/client/hooks/useQueuedPrompts.ts`; `npm run build --workspace=packages/webui`; `npm run build --workspace=packages/sdk-typescript`; `npm run build --workspace=packages/web-shell`.

## Risk & Scope

- Main risk or tradeoff: The queue UI still relies on the follow-up refresh to reconcile the visible queue after a successful server-side removal, so this PR intentionally changes error reporting semantics without changing queue reconciliation behavior.
- Not validated / out of scope: Full end-to-end browser reproduction across all operating systems was not run locally.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让 pending prompt 的刷新结果变得更明确，因此 web shell 可以区分真正的刷新失败，以及刷新被跳过或被更新请求覆盖的正常情况。队列插入、编辑、删除流程现在只会在刷新请求本身失败时显示 pending prompt 刷新错误。

## Why it's needed

当用户插入、编辑或移除一个排队 prompt 时，web shell 会先移除服务端的 pending prompt，然后刷新 pending prompt 列表。之前刷新辅助函数对多种结果都返回 `false`，其中包括后续刷新覆盖当前刷新这种正常竞态。这类正常竞态会被当成用户可见失败，导致即使队列变更已经成功，也可能显示 “Queue changed but pending prompts could not refresh” 这类误导提示。

## Reviewer Test Plan

### How to verify

检查队列插入、编辑、删除路径，确认 `removePendingPrompt` 成功后，如果 pending prompt 刷新被覆盖或跳过，不再报告用户可见错误。审核者也可以在一个 turn 正在运行时快速变更多个队列 prompt，确认过期刷新不会弹出 “pending prompts could not refresh” 错误，除非 pending prompt 获取请求本身确实失败。

### Evidence (Before & After)

Before：过期的 pending prompt 刷新会返回和真实请求错误相同的失败值，导致成功变更队列后仍可能出现误导性的用户可见队列错误。

After：刷新结果区分为 `refreshed`、`skipped`、`superseded` 和 `failed`；成功变更队列后，只有 `failed` 会报告 pending prompt 刷新错误。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

本地验证：`npx prettier --check packages/web-shell/client/hooks/useQueuedPrompts.ts`；`npm run build --workspace=packages/webui`；`npm run build --workspace=packages/sdk-typescript`；`npm run build --workspace=packages/web-shell`。

## Risk & Scope

- Main risk or tradeoff：队列 UI 在服务端移除成功后仍依赖后续刷新来校准可见队列，所以这个 PR 只调整错误报告语义，不改变队列校准行为。
- Not validated / out of scope：本地没有在所有操作系统上跑完整浏览器端到端复现。
- Breaking changes / migration notes：无。

## Linked Issues

N/A

</details>
